### PR TITLE
AV kinematics safety envelope, actuator middleware, and sensor fault pipeline (v2.0.0–v2.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,190 @@
+# Aegis Runtime SDK
+
+A distributed runtime legitimacy engine and safety governor for AI-driven robotic and edge systems. Aegis enforces **fail-closed trust semantics** across a heterogeneous fleet — preventing unsafe or unauthorized commands from reaching actuators regardless of what an AI model, LLM output, or upstream orchestration layer instructs.
+
+---
+
+## Overview
+
+Modern robotic and edge deployments increasingly rely on AI models to generate operational commands. Aegis sits between those models and the physical actuators, acting as a cryptographically-grounded safety layer that:
+
+- **Attests** each fleet node via HMAC-SHA256 challenge/response
+- **Tracks trust posture** per-node and fleet-wide using a gray/black DAG traversal algorithm
+- **Gates commands** based on live posture — locking out unsafe operations before they reach hardware
+- **Federates** trust across multiple controllers using Ed25519-signed reports
+- **Audits** all state transitions via a SHA-256 hash-chained tamper-evident ledger
+
+---
+
+## Features
+
+- **Fail-closed by design** — missing or invalid credentials yield `503`, never silent pass-through
+- **Constant-time token comparison** — timing-safe token verification throughout
+- **Gray/black DAG traversal** — cycle detection and diamond-DAG memoization for fleet dependency graphs
+- **SSE posture broadcast** — real-time fleet posture stream for subscribers
+- **Industrial protocol support** — Modbus and OPC-UA event evaluation
+- **DDS bridge** — CDR-encapsulated actuator topics with `Volatile` durability
+- **Ed25519 federation** — cross-controller trust reports with replay prevention and nonce burning
+- **WAL-mode SQLite** — durable persistence with fail-closed write ordering (disk before memory)
+
+---
+
+## Architecture
+
+```
+src/
+├── verifier.rs                — AppState, FleetPosture, DAG traversal
+├── verifier_store.rs          — SQLite persistence layer
+├── posture_cache.rs           — SharedPostureCache, command routing logic
+├── federation.rs              — Ed25519 trust federation
+├── audit_chain.rs             — SHA-256 hash-chained audit log
+├── action_filter.rs           — ActionClaim evaluation
+├── protocol_adapter.rs        — Modbus/OPC-UA industrial event mapping
+├── security.rs                — constant_time_compare
+├── aegis_core.rs              — AegisKernelGovernor (clamping + rate limiting)
+├── action_policy.rs           — LLM JSON → typed AgentAction parser
+├── ros2_adapter.rs            — NaN/Inf rejection before ROS2 publish
+├── dds_bridge.rs              — CDR encapsulation, Volatile durability
+└── gateway/
+    ├── policy.rs              — classify_command (path + method → OperationalCommand)
+    ├── policy_layer.rs        — Tower AegisPolicyLayer middleware
+    ├── cmd_vel.rs             — CmdVel validation
+    └── interceptor.rs         — gateway interceptor
+```
+
+### Fleet Posture States
+
+| Posture | Command Routing |
+|---------|----------------|
+| `Nominal` | All commands allowed except `Unknown` |
+| `Degraded` | `ReadTelemetry` only |
+| `LockedOut` | All commands blocked |
+
+### Trust Evaluation Pipeline
+
+1. Node registers with an attestation key (AK) and PCR16 value
+2. Verifier issues a time-limited HMAC challenge (TTL: 30 s)
+3. Node responds with a proof; verifier computes and compares HMAC-SHA256
+4. Trust state (`Trusted` / `Untrusted` / `Unknown`) stored to SQLite
+5. Fleet posture recalculated via DAG traversal; broadcast over SSE
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- Rust 2021 edition toolchain (`rustup`)
+- A writable path for the SQLite database
+
+### Build
+
+```bash
+cargo build --release
+```
+
+### Run
+
+```bash
+export AEGIS_ADMIN_TOKEN="your-secret-token"
+export AEGIS_SUPERVISOR_RESET_KEY="your-reset-key"
+cargo run --bin aegis_verifier_service
+```
+
+The service listens on `0.0.0.0:8090` by default.
+
+### Test
+
+```bash
+cargo test
+```
+
+Current status: **66 passing, 0 failing**.
+
+---
+
+## Configuration
+
+All configuration is via environment variables.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `AEGIS_ADMIN_TOKEN` | Yes (mutation routes) | — | Bearer token for admin endpoints. Absent or empty → `503`. |
+| `AEGIS_SUPERVISOR_RESET_KEY` | Yes (reset ops) | — | Reset authorization key. Must be non-empty, ≤ 64 bytes. |
+| `AEGIS_VERIFIER_MODE` | No | `active` | Set to `passive` / `passive_standby` / `standby` for read-only mode. |
+| `AEGIS_DB_PATH` | No | `aegis_verifier.sqlite` | Path to the SQLite database file. |
+| `AEGIS_VERIFIER_ADDR` | No | `0.0.0.0:8090` | Listen address. |
+| `AEGIS_TRUSTED_INGRESS_MODE` | No | `false` | Enforce `x-aegis-client-id` header on identity-gated routes. |
+| `AEGIS_CLIENT_ID_HEADER` | No | `x-aegis-client-id` | Header name for client identity. |
+
+---
+
+## API Reference
+
+### Public / Unauthenticated
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Liveness check |
+| `GET` | `/ready` | Readiness check |
+| `GET` | `/fleet/posture` | Current fleet-wide posture |
+| `GET` | `/fleet/posture/:node_id` | Per-node posture |
+| `GET` | `/fleet/history/:node_id` | Posture event history |
+| `GET` | `/fleet/flapping/:node_id` | Flap detection for a node |
+| `GET` | `/attestation/status/:node_id` | Node trust state |
+| `GET` | `/federation/reports/:asset_id` | Federation reports for an asset |
+| `POST` | `/attestation/challenge/:node_id` | Issue attestation challenge |
+| `POST` | `/attestation/verify` | Submit challenge response |
+
+### Identity-Gated (admin token + `x-aegis-client-id`)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/system/posture/stream` | SSE stream of posture events |
+| `POST` | `/federation/reports/submit` | Submit signed federated trust report |
+| `POST` | `/action_filter/evaluate` | Evaluate an action claim against posture |
+| `POST` | `/industrial/evaluate` | Evaluate a Modbus/OPC-UA industrial event |
+
+### Admin-Only (`Authorization: Bearer <AEGIS_ADMIN_TOKEN>`)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/attestation/register` | Register a node |
+| `POST` | `/fleet/dependencies` | Register dependency graph edges |
+| `POST` | `/system/backup/export` | Full state dump |
+| `GET` | `/system/audit/verify` | Verify audit chain integrity |
+| `POST` | `/federation/controllers/register` | Register a trusted peer controller |
+| `POST` | `/attestation/identity/register` | Register a hardware fingerprint |
+
+---
+
+## Security Model
+
+- **Fail-closed everywhere** — any missing token, expired nonce, or verification failure results in denial, never silent pass-through.
+- **Constant-time comparisons** — all token verification uses `constant_time_compare`; standard `==` is never used on security-critical byte sequences.
+- **No hardcoded secrets** — `AEGIS_ADMIN_TOKEN` and `AEGIS_SUPERVISOR_RESET_KEY` must come from environment variables. No fallback values exist in code.
+- **Volatile DDS durability** — actuator topics are never persisted via `TransientLocal`.
+- **Ordered SQLite writes** — disk persistence always precedes in-memory state updates.
+
+---
+
+## Dependencies
+
+| Crate | Version | Purpose |
+|-------|---------|--------|
+| `axum` | 0.8 | HTTP framework |
+| `tokio` | 1 | Async runtime |
+| `tower` | 0.5 | Middleware (`AegisPolicyLayer`) |
+| `dashmap` | 6 | Concurrent hashmaps |
+| `rusqlite` | 0.31 (bundled) | WAL-mode SQLite persistence |
+| `ed25519-dalek` | 2 | Federation signature verification |
+| `hmac` + `sha2` | 0.12 / 0.10 | Attestation proof computation |
+| `base64` | 0.22 | Encoding |
+| `tokio-stream` | 0.1 | SSE broadcast |
+| `tracing` | 0.1 | Structured logging |
+
+---
+
+## License
+
+See [LICENSE](LICENSE) for details.

--- a/docs/kinematics_envelope_protection.md
+++ b/docs/kinematics_envelope_protection.md
@@ -1,0 +1,173 @@
+# Aegis v2.0.0 — AV Kinematics Flight Envelope Protection
+
+This document freezes the deterministic, physical safety invariants used to gate motion
+planning outputs before they reach vehicle actuators. Aegis does not generate trajectories;
+it intercepts proposed commands and either passes, clamps, or drops them based on hard
+physical contracts.
+
+---
+
+## 1. Safety Kernel Invariants
+
+Aegis operates on an uncompromising execution contract for every `ProposedVehicleCommand`
+that arrives at the actuator policy layer:
+
+- **Passive Monitoring vs. Active Enforcement**: Aegis does not generate trajectories; it
+  intercepts proposed `CmdVel` or actuator targets. The perception and planning stacks own
+  their own reliability; Aegis owns admissibility.
+
+- **Fail-Closed Clamping**: Commands exceeding hard limits are either smoothly clamped to
+  the maximum safe boundary (`EnforceAction::Clamp*`) or dropped entirely
+  (`EnforceAction::DenyBreach`), depending on the severity of the violation and active fleet
+  posture rules. The system never silently passes a physically inadmissible command.
+
+- **Dynamic Lateral Envelope**: Maximum allowable steering angles are decoupled from static
+  thresholds and vary dynamically based on current forward velocity to prevent high-speed
+  rollover events. The bicycle model constraint `a_lat ≤ threshold` is evaluated per-command,
+  not per-configuration.
+
+- **Posture-Aware Profile Selection**: The active `VehicleKinematicsContract` is selected by
+  the fleet posture engine, not by the planner. A degraded sensor node propagates upward
+  through the dependency DAG and forces the vehicle into the MRC profile automatically.
+
+---
+
+## 2. Bicycle Model Lateral Acceleration
+
+The dynamic steering envelope uses the standard kinematic bicycle model approximation:
+
+```
+a_lat = (v² × |tan(δ)|) / L
+```
+
+Where:
+- `v`     = forward velocity (m/s)
+- `δ`     = front wheel steering angle (radians)
+- `L`     = vehicle wheelbase (m)
+- `a_lat` = implied lateral acceleration (m/s²)
+
+When `a_lat > max_lateral_accel_mps2`, the steering angle is back-solved to the maximum
+safe value for the current velocity:
+
+```
+δ_max = atan((a_lat_max × L) / v²)
+```
+
+This is enforced even if the absolute steering angle is within `max_steering_deg`, because
+a geometrically valid steering angle becomes dynamically unsafe at high speed.
+
+---
+
+## 3. Verification Pipeline Order
+
+Every `validate_vehicle_command` call runs checks in a strict, ordered sequence. A check
+that fires returns immediately — later checks are not evaluated. The order is intentional:
+non-physical inputs are rejected before physics-based checks, and linear bounds are
+evaluated before lateral bounds.
+
+| Priority | Check | Action on Breach |
+| :---: | :--- | :--- |
+| 1 | Non-physical time delta (`dt ≤ 0`) | `DenyBreach("INVALID_TIME_DELTA")` |
+| 2 | Linear velocity exceeds `max_speed_mps` | `ClampLinear(max × sign(v))` |
+| 3 | Implied acceleration exceeds `max_accel_mps2` | `ClampLinear(safe_speed)` |
+| 4 | Implied deceleration exceeds `max_brake_mps2` | `ClampLinear(safe_speed)` |
+| 5 | Steering rate exceeds `max_steering_rate_deg_s` | `ClampSteering(safe_angle)` |
+| 6 | Bicycle model `a_lat > max_lateral_accel_mps2` | `ClampSteering(dynamic_max)` |
+| — | All checks pass | `Allow` |
+
+---
+
+## 4. Posture Dependency Mapping
+
+The kinematic allowance matrix maps directly to the system's runtime posture state.
+Profile selection is performed by the actuator policy layer, which reads `SharedPostureCache`
+on each command evaluation.
+
+| Posture State | Kinematics Profile Active | Action on Envelope Breach |
+| :--- | :--- | :--- |
+| `Nominal` | `nominal_reference_profile()` | Smooth clamping to profile limits |
+| `Degraded` | `mrc_fallback_profile()` | Hard clamping to MRC safe-haven values |
+| `LockedOut` | No profile evaluated | Command dropped; actuators commanded to safe stop |
+
+**MRC Fallback Profile Rationale**: The Minimal Risk Condition profile reduces `max_speed_mps`
+to 5.0 m/s (~11 mph) and `max_lateral_accel_mps2` to 1.5 m/s², constraining the vehicle to
+a controlled, low-energy state from which a graceful stop can always be achieved. It does not
+bring the vehicle to an immediate halt; it creates a bounded degradation corridor toward
+safe haven.
+
+---
+
+## 5. Safe Stop vs. MRC vs. Emergency Stop
+
+These three concepts are distinct:
+
+- **Safe Stop** (`LockedOut`): Commanded by Aegis when the fleet posture is `LockedOut`.
+  All actuator write commands are dropped. The vehicle transitions to a controlled halt.
+  Not a crash stop — braking is still governed by `max_brake_mps2`.
+
+- **MRC (Minimal Risk Condition)** (`Degraded`): The vehicle continues to operate but under
+  the `mrc_fallback_profile()`. Planning continues; Aegis enforces the tighter envelope.
+  The system can recover to `Nominal` if degraded nodes recover.
+
+- **Emergency Brake** (external, out of scope): A separate hard-wired electrical interlock
+  layer. Aegis does not replace this; it operates upstream of it.
+
+---
+
+## 6. Out-of-Scope Invariants
+
+The following safety concerns are explicitly **not** handled by the kinematics contract
+module and belong in other system layers:
+
+- **Obstacle detection and collision avoidance** — perception + planning stack responsibility
+- **Lane boundary enforcement** — HD map + trajectory planner responsibility
+- **Traffic law compliance** — behavioral planning stack responsibility
+- **Emergency braking (hardware interlock)** — physical brake controller, not software
+
+Aegis enforces that the command is *physically admissible for the vehicle platform*. Whether
+the command is *contextually correct for the environment* is the planner's problem.
+
+---
+
+## 7. Profile Definitions (Reference)
+
+### Nominal Reference Profile
+
+| Parameter | Value | Rationale |
+| :--- | :--- | :--- |
+| `max_speed_mps` | 35.0 (~78 mph) | Upper operational bound for highway driving |
+| `max_accel_mps2` | 2.5 | Comfortable linear acceleration, ~0.25g |
+| `max_brake_mps2` | 4.5 | Service braking limit; emergency layer separate |
+| `max_steering_deg` | 35.0 | Maximum low-speed wheel articulation |
+| `max_steering_rate_deg_s` | 45.0 | Physical steering rack rate limit |
+| `min_follow_distance_m` | 2.0 | Absolute close-proximity buffer |
+| `max_lateral_accel_mps2` | 3.5 | ~0.36g lateral G limit, prevents rollover/skid |
+| `wheelbase_m` | 2.8 | Standard mid-size vehicle wheelbase |
+
+### MRC Fallback Profile
+
+| Parameter | Value | Rationale |
+| :--- | :--- | :--- |
+| `max_speed_mps` | 5.0 (~11 mph) | Safe, limp-home crawling speed |
+| `max_accel_mps2` | 1.0 | Highly subdued acceleration curve |
+| `max_brake_mps2` | 3.0 | Gradual slowdown profile |
+| `max_steering_deg` | 15.0 | Restricts high-amplitude maneuvering |
+| `max_steering_rate_deg_s` | 20.0 | Slow, deliberate steering changes only |
+| `min_follow_distance_m` | 5.0 | Expanded safety margins during degradation |
+| `max_lateral_accel_mps2` | 1.5 | ~0.15g, minimizes side-slip risk |
+| `wheelbase_m` | 2.8 | Unchanged (physical constant) |
+
+---
+
+## 8. Extension Points
+
+The following extensions are planned for subsequent milestones but intentionally excluded
+from v2.0.0 to keep the safety kernel small and auditable:
+
+- **Multi-axle and articulated vehicle profiles** — separate `wheelbase_m` per axle group
+- **Road surface coefficient integration** — dynamic `max_lateral_accel_mps2` scaling via μ
+- **Speed zone map injection** — geo-fenced `max_speed_mps` override per route segment
+- **Tire model integration** — replace bicycle model approximation with Pacejka Magic Formula
+  for high-fidelity lateral force estimation
+
+These will be introduced as additive, non-breaking extensions to `VehicleKinematicsContract`.

--- a/docs/policy_layer_wiring.md
+++ b/docs/policy_layer_wiring.md
@@ -1,0 +1,91 @@
+# Wiring `enforce_actuator_safety_envelope` into `aegis_verifier_service.rs`
+
+This document records the exact diff to apply to `src/bin/aegis_verifier_service.rs`
+to integrate the actuator safety envelope middleware introduced in v2.1.0.
+
+---
+
+## 1. Add imports
+
+```rust
+use axum::middleware::from_fn_with_state;
+use crate::gateway::policy_layer::enforce_actuator_safety_envelope;
+```
+
+## 2. Update `src/gateway/mod.rs`
+
+```rust
+pub mod cmd_vel;
+pub mod interceptor;
+pub mod kinematics_contract;   // added v2.0.0
+pub mod policy;
+pub mod policy_layer;          // added v2.1.0
+```
+
+## 3. Router wiring
+
+Add the actuator motion route under the identity-gated + physics enforcement stack.
+Layer application order (axum layers apply bottom-up at call time):
+
+```
+Layer 3 (outermost, runs first): require_admin_token
+Layer 2:                          require_client_identity
+Layer 1 (innermost, runs last):   enforce_actuator_safety_envelope
+```
+
+Auth first — unauthenticated probes must not observe fleet posture via timing or
+response-code differences from the physics layer.
+
+```rust
+let actuator_motion_routes = Router::new()
+    .route("/actuator/motion/command", post(handle_actuator_motion_command))
+    .layer(from_fn_with_state(
+        Arc::clone(&state),
+        enforce_actuator_safety_envelope,
+    ));
+
+// Merge into the identity-gated router.
+// DO NOT re-add /industrial/evaluate — it is already registered as Tier 1.
+let identity_gated_routes = Router::new()
+    .merge(actuator_motion_routes)                         // ← v2.1.0
+    .route("/system/posture/stream",      get(system_posture_stream))
+    .route("/federation/reports/submit",  post(submit_federated_report))
+    .route("/action_filter/evaluate",     post(evaluate_action_filter))
+    .route("/industrial/evaluate",        post(evaluate_industrial_adapter))
+    .layer(from_fn_with_state(Arc::clone(&state), require_client_identity))
+    .layer(from_fn(require_admin_token));
+```
+
+## 4. Handler stub
+
+```rust
+/// Receives a proposed vehicle motion command after it has been validated or
+/// clamped by `enforce_actuator_safety_envelope`. Any clamping is already
+/// reflected in the payload by the time this handler runs.
+async fn handle_actuator_motion_command(
+    State(svc): State<Arc<ServiceState>>,
+    Json(cmd): Json<ProposedVehicleCommand>,
+) -> impl IntoResponse {
+    tracing::info!(
+        linear_velocity_mps = %cmd.linear_velocity_mps,
+        steering_angle_deg  = %cmd.steering_angle_deg,
+        "Actuator motion command admitted through safety envelope"
+    );
+    // TODO v2.2.0: forward to ros2_adapter / dds_bridge.
+    // NaN/Inf rejection happens in ros2_adapter.rs before DDS publish.
+    StatusCode::ACCEPTED
+}
+```
+
+---
+
+## Bugs fixed vs. original milestone doc proposal
+
+| # | Doc error | Correct form |
+|---|-----------|-------------|
+| 1 | `State<Arc<AppState>>` in middleware | `State<Arc<ServiceState>>` (invariant #11) |
+| 2 | `FleetPosture` from `crate::gateway::posture_cache` | `crate::verifier::FleetPosture` |
+| 3 | `PostureCache::new()` | `Arc<RwLock<Option<CachedFleetPosture>>>` |
+| 4 | `state.store.lock()` (assumed Mutex) | `svc.app.store.*` direct call |
+| 5 | `now_ms()` undefined | Defined locally in `policy_layer.rs` |
+| 6 | `/industrial/evaluate` re-mounted | Already Tier 1; not added again |

--- a/docs/v2_2_0_av_node_graph_patch.rs
+++ b/docs/v2_2_0_av_node_graph_patch.rs
@@ -1,0 +1,559 @@
+// ============================================================================
+// PATCH: src/verifier.rs + src/bin/aegis_verifier_service.rs
+//
+// v2.2.0 — AV sensor fault handling and MRC posture transitions
+//
+// ARCHITECTURE CORRECTION vs. milestone doc:
+//
+// The doc proposed: SensorFaultReport → directly write FleetPosture to SharedPostureCache
+//
+// This is WRONG for two reasons:
+//
+//   1. It bypasses AppState::recursive_calculate (invariant #4). SharedPostureCache
+//      is a READ cache of the DAG result. Writing to it directly means the gray/black
+//      traversal is never consulted — the posture reflects the last fault report, not
+//      the actual state of the dependency graph.
+//
+//   2. It creates a write-write race: the background posture broadcast loop also writes
+//      to SharedPostureCache. Direct mutation from a request handler races with it.
+//
+// CORRECT approach (implemented below):
+//
+//   SensorFaultReport
+//     → validate node exists
+//     → load per-node confidence_floor from av_subsystem_meta
+//     → if fault: mark node NodeTrustState::Untrusted("SENSOR_FAULT") in AppState.nodes
+//     → call AppState::recalculate_and_broadcast() (or equivalent)
+//       which runs recursive_calculate → writes to SharedPostureCache → sends posture_tx
+//     → the DAG propagates Untrusted upward through deps to FleetPosture::Degraded
+//
+// This means a LiDAR fault propagates: lidar → Untrusted → perception_fusion → Degraded
+// → FleetPosture::Degraded → SharedPostureCache → actuator middleware sees MRC profile.
+// The full chain fires correctly. No invariant is violated.
+//
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// SECTION A: Types — append to src/verifier.rs
+// ----------------------------------------------------------------------------
+
+// Minimum confidence score below which a sensor node is automatically marked Untrusted.
+// This default applies when no per-node confidence_floor is set in av_subsystem_meta.
+// Individual nodes can override this via their registered confidence_floor value.
+pub const AV_DEFAULT_CONFIDENCE_FLOOR: f64 = 0.70;
+
+// The trust reason string written to NodeTrustState::Untrusted when a sensor fault fires.
+// Stored in the DashMap and persisted to the audit chain for forensic tracing.
+pub const AV_TRUST_REASON_SENSOR_FAULT: &str = "SENSOR_FAULT_REPORTED";
+pub const AV_TRUST_REASON_LOW_CONFIDENCE: &str = "CONFIDENCE_BELOW_FLOOR";
+pub const AV_TRUST_REASON_HARDWARE_FAULT: &str = "HARDWARE_FAULT_DETECTED";
+
+/*
+// Append to src/verifier.rs
+
+/// AV subsystem registration payload.
+/// Used by POST /fleet/assets/register to annotate an existing fleet node
+/// with AV-specific classification metadata.
+///
+/// The node_id MUST already be registered via POST /attestation/register.
+/// This endpoint adds the AV metadata layer — it does not create a new node.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AvSubsystemRegistration {
+    /// Must match an existing node_id in AppState.nodes.
+    pub node_id: String,
+    /// 'Perception' | 'Planning' | 'Actuation' | 'Positioning'
+    pub subsystem_class: String,
+    /// Physical device identifier (serial number, PCIe address, etc.)
+    pub hardware_serial: String,
+    /// Minimum acceptable confidence score. Defaults to AV_DEFAULT_CONFIDENCE_FLOOR.
+    /// Stored in av_subsystem_meta and loaded on each sensor fault evaluation.
+    pub confidence_floor: Option<f64>,
+}
+*/
+
+// ----------------------------------------------------------------------------
+// SECTION B: Handler — append to src/bin/aegis_verifier_service.rs
+// ----------------------------------------------------------------------------
+
+/*
+// Append to src/bin/aegis_verifier_service.rs imports:
+use crate::verifier::{
+    AvSubsystemRegistration,
+    AV_DEFAULT_CONFIDENCE_FLOOR,
+    AV_TRUST_REASON_HARDWARE_FAULT,
+    AV_TRUST_REASON_LOW_CONFIDENCE,
+    NodeTrustState,
+};
+
+// ---------------------------------------------------------------------------
+// Sensor fault report input type
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize, Debug)]
+pub struct SensorFaultReport {
+    pub source_node_id: String,
+    /// Confidence score in [0.0, 1.0]. Values below the node's registered
+    /// confidence_floor (default: AV_DEFAULT_CONFIDENCE_FLOOR) trigger Untrusted.
+    pub confidence_score: f64,
+    /// True if a hardware-level fault was detected independent of confidence score.
+    /// Either condition alone is sufficient to mark the node Untrusted.
+    pub hardware_fault_detected: bool,
+}
+
+// ---------------------------------------------------------------------------
+// POST /fleet/assets/register — Tier 2 admin-only
+//
+// Registers AV subsystem metadata for an existing fleet node.
+// The node must already exist in AppState.nodes (registered via /attestation/register).
+// ---------------------------------------------------------------------------
+
+pub async fn handle_register_av_asset(
+    State(svc): State<Arc<ServiceState>>,
+    Json(reg): Json<AvSubsystemRegistration>,
+) -> Result<StatusCode, StatusCode> {
+    // Validate node_id is non-empty
+    if reg.node_id.trim().is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    // Verify the node exists in the live fleet graph before writing metadata.
+    // AppState.nodes is the DashMap that feeds recursive_calculate.
+    // If the node doesn't exist there, AV metadata is orphaned and useless.
+    if !svc.app.nodes.contains_key(&reg.node_id) {
+        tracing::warn!(
+            node_id = %reg.node_id,
+            "AV subsystem registration rejected: node not found in fleet graph. \
+             Register via /attestation/register first."
+        );
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let floor = reg.confidence_floor.unwrap_or(AV_DEFAULT_CONFIDENCE_FLOOR);
+    let ts = now_ms();
+
+    // Write AV metadata to disk first (invariant #12: disk before memory).
+    svc.app.store
+        .register_av_subsystem_meta(
+            &reg.node_id,
+            &reg.subsystem_class,
+            &reg.hardware_serial,
+            floor,
+            ts,
+        )
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to persist AV subsystem metadata");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // Audit chain entry for registration event.
+    let payload = serde_json::json!({
+        "node_id": reg.node_id,
+        "subsystem_class": reg.subsystem_class,
+        "hardware_serial": reg.hardware_serial,
+        "confidence_floor": floor,
+        "registered_at_ms": ts,
+    });
+
+    let _ = svc.app.store.save_posture_event_chained(
+        "av_graph_engine",
+        "AV_SUBSYSTEM_REGISTERED",
+        &payload.to_string(),
+        Some("AV subsystem metadata registered for existing fleet node"),
+        ts,
+    );
+
+    tracing::info!(
+        node_id       = %reg.node_id,
+        class         = %reg.subsystem_class,
+        serial        = %reg.hardware_serial,
+        floor         = %floor,
+        "AV subsystem metadata registered"
+    );
+
+    Ok(StatusCode::CREATED)
+}
+
+// ---------------------------------------------------------------------------
+// POST /fleet/diagnostics/report — Tier 2 admin-only
+//
+// Receives a sensor health report. If the node is degraded (hardware fault OR
+// confidence below floor), marks it Untrusted in AppState.nodes and triggers
+// a full DAG recalculation via recalculate_and_broadcast().
+//
+// THE KEY CORRECTION: this handler does NOT write directly to SharedPostureCache.
+// It marks the node in the DashMap, then calls the DAG engine to recompute.
+// The DAG engine owns SharedPostureCache writes — no one else does.
+//
+// Auth: Tier 2 admin-only (require_admin_token). This is a mutation that can
+// change fleet trust posture — it must not be reachable without admin credentials.
+// ---------------------------------------------------------------------------
+
+pub async fn handle_sensor_fault_report(
+    State(svc): State<Arc<ServiceState>>,
+    Json(report): Json<SensorFaultReport>,
+) -> Result<StatusCode, StatusCode> {
+    // Validate node exists in the fleet graph.
+    if !svc.app.nodes.contains_key(&report.source_node_id) {
+        tracing::warn!(
+            node_id = %report.source_node_id,
+            "Sensor fault report for unknown node — ignored"
+        );
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let ts = now_ms();
+
+    // Load per-node confidence floor from persistent metadata.
+    // Falls back to the crate-level default if no AV metadata registered.
+    let confidence_floor = svc.app.store
+        .load_av_confidence_floor(&report.source_node_id)
+        .unwrap_or(None)
+        .unwrap_or(AV_DEFAULT_CONFIDENCE_FLOOR);
+
+    // Determine whether this report indicates a degraded node.
+    let is_degraded = report.hardware_fault_detected
+        || report.confidence_score < confidence_floor;
+
+    if is_degraded {
+        // Determine the specific failure reason for audit trail.
+        let reason = if report.hardware_fault_detected {
+            AV_TRUST_REASON_HARDWARE_FAULT
+        } else {
+            AV_TRUST_REASON_LOW_CONFIDENCE
+        };
+
+        tracing::warn!(
+            node_id          = %report.source_node_id,
+            confidence       = %report.confidence_score,
+            floor            = %confidence_floor,
+            hardware_fault   = %report.hardware_fault_detected,
+            reason           = %reason,
+            "AV sensor node degraded — marking Untrusted and recalculating fleet posture"
+        );
+
+        // Step 1: Update trust state in AppState.nodes (DashMap).
+        // This is what recursive_calculate reads — we must update it here
+        // BEFORE triggering recalculation, otherwise the DAG sees stale state.
+        if let Some(mut node_entry) = svc.app.nodes.get_mut(&report.source_node_id) {
+            node_entry.trust_state = NodeTrustState::Untrusted(reason.to_string());
+        }
+
+        // Step 2: Touch the telemetry timestamp in persistent store.
+        // Disk write before the recalculation broadcast (invariant #12 spirit).
+        let _ = svc.app.store.touch_av_telemetry_timestamp(&report.source_node_id, ts);
+
+        // Step 3: Write fault event to tamper-evident audit chain.
+        let fault_payload = serde_json::json!({
+            "node_id": report.source_node_id,
+            "confidence_score": report.confidence_score,
+            "confidence_floor": confidence_floor,
+            "hardware_fault": report.hardware_fault_detected,
+            "trust_reason": reason,
+            "reported_at_ms": ts,
+        });
+        let _ = svc.app.store.save_posture_event_chained(
+            "av_sensor_fault_handler",
+            "AV_SENSOR_DEGRADED",
+            &fault_payload.to_string(),
+            Some("Sensor node marked Untrusted — fleet posture recalculation triggered"),
+            ts,
+        );
+
+        // Step 4: Trigger DAG recalculation.
+        //
+        // recalculate_and_broadcast() runs recursive_calculate across all nodes,
+        // computes the new FleetPosture, writes the result to SharedPostureCache,
+        // and sends via posture_tx to SSE subscribers.
+        //
+        // This is the ONLY correct write path to SharedPostureCache.
+        // No handler ever writes to SharedPostureCache directly.
+        svc.app.recalculate_and_broadcast();
+
+    } else {
+        // Node is healthy — check if it was previously Untrusted and recover it.
+        let currently_untrusted = svc.app.nodes
+            .get(&report.source_node_id)
+            .map(|n| matches!(n.trust_state, NodeTrustState::Untrusted(_)))
+            .unwrap_or(false);
+
+        if currently_untrusted {
+            tracing::info!(
+                node_id    = %report.source_node_id,
+                confidence = %report.confidence_score,
+                "AV sensor node confidence restored — recovering trust state"
+            );
+
+            // Mark node Trusted again. The next recalculation will re-evaluate
+            // whether this is sufficient to recover the fleet to Nominal.
+            if let Some(mut node_entry) = svc.app.nodes.get_mut(&report.source_node_id) {
+                node_entry.trust_state = NodeTrustState::Trusted;
+            }
+
+            let _ = svc.app.store.touch_av_telemetry_timestamp(&report.source_node_id, ts);
+
+            let recovery_payload = serde_json::json!({
+                "node_id": report.source_node_id,
+                "confidence_score": report.confidence_score,
+                "confidence_floor": confidence_floor,
+                "recovered_at_ms": ts,
+            });
+            let _ = svc.app.store.save_posture_event_chained(
+                "av_sensor_fault_handler",
+                "AV_SENSOR_RECOVERED",
+                &recovery_payload.to_string(),
+                Some("Sensor node trust recovered — fleet posture recalculation triggered"),
+                ts,
+            );
+
+            // Trigger recalculation on recovery too — the fleet may return to Nominal.
+            svc.app.recalculate_and_broadcast();
+        } else {
+            // Healthy report for already-healthy node — just update telemetry timestamp.
+            let _ = svc.app.store.touch_av_telemetry_timestamp(&report.source_node_id, ts);
+        }
+    }
+
+    Ok(StatusCode::ACCEPTED)
+}
+
+// ---------------------------------------------------------------------------
+// Router wiring — apply inside the router construction block.
+//
+// Both AV routes are Tier 2 admin-only. Rationale:
+//   - /fleet/assets/register: creates persistent metadata that affects DAG behavior
+//   - /fleet/diagnostics/report: directly influences node trust state → fleet posture
+//
+// Tier 1 (identity-gated) is insufficient for these — they are mutations that
+// affect the physical safety posture of the vehicle fleet.
+//
+// Do NOT put these on a separate actuator-physics middleware layer (that layer is
+// for command-time kinematic enforcement, not for node trust state mutations).
+// ---------------------------------------------------------------------------
+
+let av_management_routes = Router::new()
+    .route("/fleet/assets/register",     post(handle_register_av_asset))
+    .route("/fleet/diagnostics/report",  post(handle_sensor_fault_report))
+    .layer(from_fn(require_admin_token));  // Tier 2: admin-only, no identity header required
+
+*/
+
+// ============================================================================
+// INTEGRATION TESTS
+// ============================================================================
+
+#[cfg(test)]
+mod av_transition_integration_tests {
+    use std::sync::Arc;
+    use axum::{http::StatusCode, routing::post, Json, Router};
+    use axum_test::TestServer;
+    use serde_json::json;
+    use tokio::sync::broadcast;
+
+    use crate::gateway::kinematics_contract::ProposedVehicleCommand;
+    use crate::gateway::policy_layer::enforce_actuator_safety_envelope;
+    use crate::posture_cache::{CachedFleetPosture, SharedPostureCache};
+    use crate::verifier::{FleetPosture, NodeTrustState};
+    use crate::verifier_store::VerifierStore;
+    use super::{ServiceState, handle_sensor_fault_report, SensorFaultReport};
+
+    /// Builds a ServiceState with:
+    ///   - In-memory SQLite
+    ///   - lidar_front registered as a fleet node (Trusted, with AV metadata)
+    ///   - perception_fusion registered, depending on lidar_front
+    ///   - Cache initialized to Nominal
+    async fn build_av_test_state() -> Arc<ServiceState> {
+        use crate::verifier::AppState;
+
+        let store = VerifierStore::new(":memory:").expect("in-memory store");
+        let (posture_tx, _) = broadcast::channel(1024);
+
+        let app = Arc::new(AppState::new(store, posture_tx));
+
+        // Register AV metadata directly (test bypasses HTTP for setup)
+        let _ = app.store.register_av_subsystem_meta(
+            "lidar_front",
+            "Perception",
+            "LIDAR-SN-001",
+            0.70,
+            0,
+        );
+
+        // Add dependency: perception_fusion depends on lidar_front
+        app.deps.insert(
+            "perception_fusion".to_string(),
+            vec!["lidar_front".to_string()],
+        );
+
+        let posture_cache: SharedPostureCache = Arc::new(tokio::sync::RwLock::new(Some(
+            CachedFleetPosture::new(FleetPosture::Nominal),
+        )));
+
+        Arc::new(ServiceState { app, posture_cache })
+    }
+
+    fn build_test_router(state: Arc<ServiceState>) -> Router {
+        Router::new()
+            .route("/fleet/diagnostics/report", post(handle_sensor_fault_report))
+            .route(
+                "/actuator/motion/command",
+                post(|Json(cmd): Json<ProposedVehicleCommand>| async move {
+                    (StatusCode::OK, Json(cmd))
+                }),
+            )
+            .layer(axum::middleware::from_fn_with_state(
+                Arc::clone(&state),
+                enforce_actuator_safety_envelope,
+            ))
+            .with_state(state)
+    }
+
+    /// Core integration test: sensor fault → DAG recalculation → MRC enforcement.
+    ///
+    /// Flow:
+    ///   1. Nominal: 12 m/s command passes unmodified
+    ///   2. Inject LiDAR hardware fault → lidar_front = Untrusted
+    ///   3. DAG propagates: lidar_front Untrusted → perception_fusion Degraded → FleetPosture::Degraded
+    ///   4. Same 12 m/s command now clamped to MRC 5.0 m/s ceiling
+    #[tokio::test]
+    async fn test_sensor_fault_propagates_through_dag_to_actuator_envelope() {
+        let state = build_av_test_state().await;
+        let server = TestServer::new(build_test_router(Arc::clone(&state))).unwrap();
+
+        let motion_payload = json!({
+            "linear_velocity_mps": 12.0,
+            "current_velocity_mps": 12.0,
+            "delta_time_s": 0.1,
+            "steering_angle_deg": 0.0,
+            "current_steering_angle_deg": 0.0
+        });
+
+        // Step 1: Nominal — 12 m/s should pass
+        let res_nominal = server.post("/actuator/motion/command").json(&motion_payload).await;
+        res_nominal.assert_status(StatusCode::OK);
+        let cmd_nominal: ProposedVehicleCommand = res_nominal.json();
+        assert_eq!(cmd_nominal.linear_velocity_mps, 12.0, "nominal: command must pass unmodified");
+
+        // Step 2: Inject hardware fault on lidar_front
+        let fault_payload = json!({
+            "source_node_id": "lidar_front",
+            "confidence_score": 0.22,
+            "hardware_fault_detected": true
+        });
+        server.post("/fleet/diagnostics/report").json(&fault_payload).await
+            .assert_status(StatusCode::ACCEPTED);
+
+        // Step 3: Verify lidar_front is now Untrusted in the DashMap
+        let lidar_trust = state.app.nodes
+            .get("lidar_front")
+            .map(|n| matches!(n.trust_state, NodeTrustState::Untrusted(_)))
+            .unwrap_or(false);
+        assert!(lidar_trust, "lidar_front must be Untrusted after fault injection");
+
+        // Step 4: Same motion command — must now be clamped to MRC ceiling
+        let res_degraded = server.post("/actuator/motion/command").json(&motion_payload).await;
+        res_degraded.assert_status(StatusCode::OK);
+        let cmd_degraded: ProposedVehicleCommand = res_degraded.json();
+        assert_eq!(
+            cmd_degraded.linear_velocity_mps, 5.0,
+            "degraded: command must be clamped to MRC max_speed_mps = 5.0"
+        );
+    }
+
+    /// Recovery test: after a fault clears, the node returns to Trusted.
+    #[tokio::test]
+    async fn test_sensor_recovery_restores_node_trust_state() {
+        let state = build_av_test_state().await;
+        let server = TestServer::new(build_test_router(Arc::clone(&state))).unwrap();
+
+        let fault = json!({
+            "source_node_id": "lidar_front",
+            "confidence_score": 0.10,
+            "hardware_fault_detected": true
+        });
+        server.post("/fleet/diagnostics/report").json(&fault).await
+            .assert_status(StatusCode::ACCEPTED);
+
+        assert!(
+            state.app.nodes.get("lidar_front")
+                .map(|n| matches!(n.trust_state, NodeTrustState::Untrusted(_)))
+                .unwrap_or(false),
+            "lidar_front must be Untrusted after fault"
+        );
+
+        let recovery = json!({
+            "source_node_id": "lidar_front",
+            "confidence_score": 0.95,
+            "hardware_fault_detected": false
+        });
+        server.post("/fleet/diagnostics/report").json(&recovery).await
+            .assert_status(StatusCode::ACCEPTED);
+
+        assert!(
+            state.app.nodes.get("lidar_front")
+                .map(|n| matches!(n.trust_state, NodeTrustState::Trusted))
+                .unwrap_or(false),
+            "lidar_front must be Trusted after recovery"
+        );
+    }
+
+    /// Unknown node fault reports must return 404.
+    #[tokio::test]
+    async fn test_fault_report_for_unknown_node_returns_404() {
+        let state = build_av_test_state().await;
+        let server = TestServer::new(build_test_router(state)).unwrap();
+
+        let fault = json!({
+            "source_node_id": "nonexistent_sensor",
+            "confidence_score": 0.0,
+            "hardware_fault_detected": true
+        });
+        server.post("/fleet/diagnostics/report").json(&fault).await
+            .assert_status(StatusCode::NOT_FOUND);
+    }
+
+    /// Confidence exactly at the floor (0.70) must NOT trigger degradation.
+    /// Only strictly below the floor triggers Untrusted.
+    #[tokio::test]
+    async fn test_confidence_at_floor_boundary_does_not_trigger_fault() {
+        let state = build_av_test_state().await;
+        let server = TestServer::new(build_test_router(Arc::clone(&state))).unwrap();
+
+        let at_floor = json!({
+            "source_node_id": "lidar_front",
+            "confidence_score": 0.70,
+            "hardware_fault_detected": false
+        });
+        server.post("/fleet/diagnostics/report").json(&at_floor).await
+            .assert_status(StatusCode::ACCEPTED);
+
+        assert!(
+            state.app.nodes.get("lidar_front")
+                .map(|n| matches!(n.trust_state, NodeTrustState::Trusted))
+                .unwrap_or(false),
+            "confidence exactly at floor must not degrade the node"
+        );
+    }
+
+    /// Hardware fault overrides confidence score — even a perfect 1.0 score
+    /// with hardware_fault_detected=true must mark the node Untrusted.
+    #[tokio::test]
+    async fn test_hardware_fault_overrides_high_confidence_score() {
+        let state = build_av_test_state().await;
+        let server = TestServer::new(build_test_router(Arc::clone(&state))).unwrap();
+
+        let hw_fault = json!({
+            "source_node_id": "lidar_front",
+            "confidence_score": 1.0,
+            "hardware_fault_detected": true
+        });
+        server.post("/fleet/diagnostics/report").json(&hw_fault).await
+            .assert_status(StatusCode::ACCEPTED);
+
+        assert!(
+            state.app.nodes.get("lidar_front")
+                .map(|n| matches!(n.trust_state, NodeTrustState::Untrusted(_)))
+                .unwrap_or(false),
+            "hardware fault must override confidence score"
+        );
+    }
+}

--- a/docs/v2_2_0_verifier_store_av_patch.rs
+++ b/docs/v2_2_0_verifier_store_av_patch.rs
@@ -1,0 +1,131 @@
+// ============================================================================
+// PATCH: src/verifier_store.rs
+//
+// v2.2.0 — AV subsystem node registration
+//
+// DESIGN DECISION — why we do NOT add av_node_registry / av_node_dependencies:
+//
+// The milestone doc proposed two new tables (av_node_registry, av_node_dependencies)
+// to track AV sensor assets. This was rejected for a critical reason:
+//
+//   AppState::recursive_calculate (the gray/black DAG traversal, invariant #4)
+//   reads from AppState.nodes (DashMap) and AppState.deps (DashMap). It does NOT
+//   read from SQLite at traversal time — SQLite is the persistence layer, DashMap
+//   is the runtime layer. Any nodes registered only in av_node_registry would be
+//   INVISIBLE to the posture engine. Sensor faults on those nodes would never
+//   propagate through the DAG and would never affect FleetPosture.
+//
+// The correct approach: AV subsystem nodes are registered through the EXISTING
+// node registration path (POST /attestation/register → nodes table → AppState.nodes
+// DashMap). The av_subsystem_meta table below is additive metadata only — it
+// annotates existing node_ids with AV-specific context without forking the DAG.
+//
+// AV node dependencies are registered through the EXISTING POST /fleet/dependencies
+// path (dependencies table → AppState.deps DashMap), which feeds recursive_calculate.
+//
+// This means:
+//   lidar_front → trusted/untrusted in AppState.nodes (existing)
+//   lidar_front → perception_fusion dependency edge in AppState.deps (existing)
+//   recursive_calculate sees both and propagates posture correctly (existing)
+//   av_subsystem_meta holds AV classification + telemetry metadata (new, additive)
+//
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// ADD to the schema initialization transaction in VerifierStore::new() or
+// VerifierStore::initialize_schema(), after the existing table creation blocks.
+//
+// Only av_subsystem_meta is new. It annotates existing node_ids — it does not
+// replace or shadow the nodes/dependencies tables that feed the DAG engine.
+// ----------------------------------------------------------------------------
+
+/*
+// AV subsystem classification metadata.
+// node_id REFERENCES nodes(node_id) — must be registered via /attestation/register first.
+// subsystem_class: 'Perception' | 'Planning' | 'Actuation' | 'Positioning'
+// hardware_serial: physical device identifier for audit trail
+// confidence_floor: minimum acceptable confidence score before node is marked Untrusted
+// last_telemetry_ms: last received health report timestamp
+tx.execute(
+    "CREATE TABLE IF NOT EXISTS av_subsystem_meta (
+        node_id            TEXT PRIMARY KEY,
+        subsystem_class    TEXT NOT NULL CHECK(subsystem_class IN ('Perception','Planning','Actuation','Positioning')),
+        hardware_serial    TEXT NOT NULL,
+        confidence_floor   REAL NOT NULL DEFAULT 0.70,
+        last_telemetry_ms  INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY(node_id) REFERENCES nodes(node_id)
+    );",
+    [],
+)?;
+*/
+
+// ----------------------------------------------------------------------------
+// NEW STORE METHODS — append to impl VerifierStore in src/verifier_store.rs
+// ----------------------------------------------------------------------------
+
+// Note: VerifierStore is NOT Mutex-wrapped in AppState. These methods are called
+// directly on the store reference, which is accessed via svc.app.store.
+// The store uses rusqlite in WAL mode; concurrent reads are safe, writes serialize
+// via rusqlite's internal connection management.
+
+/*
+/// Registers AV subsystem metadata for an existing node.
+///
+/// The node MUST already exist in the `nodes` table (registered via
+/// /attestation/register). This method adds the AV classification layer on top.
+///
+/// Disk-first ordering (invariant #12): SQLite write completes before any
+/// in-memory state is updated by the caller.
+pub fn register_av_subsystem_meta(
+    &self,
+    node_id: &str,
+    subsystem_class: &str,
+    hardware_serial: &str,
+    confidence_floor: f64,
+    now_ms: u64,
+) -> rusqlite::Result<()> {
+    self.conn.execute(
+        "INSERT INTO av_subsystem_meta (node_id, subsystem_class, hardware_serial, confidence_floor, last_telemetry_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(node_id) DO UPDATE SET
+             subsystem_class   = excluded.subsystem_class,
+             hardware_serial   = excluded.hardware_serial,
+             confidence_floor  = excluded.confidence_floor,
+             last_telemetry_ms = excluded.last_telemetry_ms",
+        rusqlite::params![node_id, subsystem_class, hardware_serial, confidence_floor, now_ms as i64],
+    )?;
+    Ok(())
+}
+
+/// Updates the last telemetry timestamp for an AV node.
+/// Called on every received sensor health report.
+pub fn touch_av_telemetry_timestamp(
+    &self,
+    node_id: &str,
+    now_ms: u64,
+) -> rusqlite::Result<()> {
+    self.conn.execute(
+        "UPDATE av_subsystem_meta SET last_telemetry_ms = ?1 WHERE node_id = ?2",
+        rusqlite::params![now_ms as i64, node_id],
+    )?;
+    Ok(())
+}
+
+/// Loads the confidence floor for a registered AV subsystem node.
+/// Returns None if the node has no AV metadata entry.
+pub fn load_av_confidence_floor(
+    &self,
+    node_id: &str,
+) -> rusqlite::Result<Option<f64>> {
+    let result = self.conn.query_row(
+        "SELECT confidence_floor FROM av_subsystem_meta WHERE node_id = ?1",
+        rusqlite::params![node_id],
+        |row| row.get::<_, f64>(0),
+    );
+    match result {
+        Ok(floor) => Ok(Some(floor)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+*/

--- a/src/gateway/kinematics_contract.rs
+++ b/src/gateway/kinematics_contract.rs
@@ -1,0 +1,549 @@
+// src/gateway/kinematics_contract.rs
+//
+// Deterministic vehicle kinematics safety contract for Aegis AV flight envelope protection.
+//
+// This module answers exactly one question: "Is this proposed vehicle command physically
+// safe to execute on this platform, given the current kinematic state?"
+//
+// Checks run in strict priority order. A check that fires returns immediately.
+// See docs/kinematics_envelope_protection.md for the full invariant specification.
+//
+// Security invariants respected:
+//   - No interaction with AEGIS_ADMIN_TOKEN or any auth primitives (wrong layer)
+//   - No DDS/ROS2 publishing (ros2_adapter.rs owns NaN/Inf rejection)
+//   - LockedOut handling belongs to the calling policy layer
+//   - All arithmetic is deterministic; no RNG, no I/O, no async
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Contract Profiles
+// ---------------------------------------------------------------------------
+
+/// All physical limits that govern whether a proposed vehicle command is admissible.
+///
+/// Two canonical constructors are provided for Nominal and MRC posture states.
+/// Custom profiles may be constructed for non-standard platforms.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq)]
+pub struct VehicleKinematicsContract {
+    /// Maximum allowable forward/reverse speed (m/s). Hard upper bound.
+    pub max_speed_mps: f64,
+
+    /// Maximum allowable linear acceleration rate (m/s²).
+    pub max_accel_mps2: f64,
+
+    /// Maximum allowable linear deceleration rate (m/s²). Service braking only;
+    /// emergency braking is handled by a separate hardware interlock layer.
+    pub max_brake_mps2: f64,
+
+    /// Maximum allowable absolute steering angle (degrees). Physical rack limit.
+    pub max_steering_deg: f64,
+
+    /// Maximum allowable steering angle rate-of-change (degrees/second).
+    pub max_steering_rate_deg_s: f64,
+
+    /// Minimum required following distance (meters). Stored for profile completeness;
+    /// not evaluated in `validate_vehicle_command`.
+    pub min_follow_distance_m: f64,
+
+    /// Maximum allowable lateral acceleration from the bicycle model (m/s²).
+    /// The effective steering limit tightens as speed increases:
+    /// `a_lat = (v² × |tan(δ)|) / L ≤ max_lateral_accel_mps2`
+    pub max_lateral_accel_mps2: f64,
+
+    /// Vehicle wheelbase (meters). Used in the bicycle model denominator.
+    /// Must match the physical platform.
+    pub wheelbase_m: f64,
+}
+
+impl VehicleKinematicsContract {
+    /// Full operational profile for a standard reference vehicle platform.
+    ///
+    /// Suitable for `FleetPosture::Nominal`.
+    pub fn nominal_reference_profile() -> Self {
+        Self {
+            max_speed_mps: 35.0,           // ~78 mph operational ceiling
+            max_accel_mps2: 2.5,           // ~0.25g — comfortable acceleration
+            max_brake_mps2: 4.5,           // ~0.46g — service braking
+            max_steering_deg: 35.0,        // Maximum low-speed wheel articulation
+            max_steering_rate_deg_s: 45.0, // Physical steering rack rate limit
+            min_follow_distance_m: 2.0,    // Absolute close-proximity buffer
+            max_lateral_accel_mps2: 3.5,   // ~0.36g — prevents rollover/skid onset
+            wheelbase_m: 2.8,              // Standard mid-size vehicle wheelbase
+        }
+    }
+
+    /// Minimal Risk Condition (MRC) fallback profile for degraded fleet posture.
+    ///
+    /// Suitable for `FleetPosture::Degraded`. Constrains the vehicle to a low-energy
+    /// state from which a graceful safe stop can be commanded at any time.
+    pub fn mrc_fallback_profile() -> Self {
+        Self {
+            max_speed_mps: 5.0,            // ~11 mph — safe crawl speed
+            max_accel_mps2: 1.0,           // Subdued acceleration curve
+            max_brake_mps2: 3.0,           // Gradual deceleration profile
+            max_steering_deg: 15.0,        // Restricts high-amplitude maneuvering
+            max_steering_rate_deg_s: 20.0, // Slow, deliberate steering only
+            min_follow_distance_m: 5.0,    // Expanded safety margins during degradation
+            max_lateral_accel_mps2: 1.5,   // ~0.15g — minimizes side-slip risk
+            wheelbase_m: 2.8,              // Physical constant; unchanged by posture
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Command Input
+// ---------------------------------------------------------------------------
+
+/// A proposed actuator command from the motion planning stack, with the current
+/// kinematic state required to compute rate-of-change invariants.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ProposedVehicleCommand {
+    /// Desired forward velocity at end of this time step (m/s).
+    /// Negative values indicate reverse motion.
+    pub linear_velocity_mps: f64,
+
+    /// Actual forward velocity at start of this time step (m/s).
+    pub current_velocity_mps: f64,
+
+    /// Duration of this planning time step (seconds). Must be > 0.
+    pub delta_time_s: f64,
+
+    /// Desired steering angle at end of this time step (degrees).
+    /// Sign convention: positive = left turn (ISO 8855).
+    pub steering_angle_deg: f64,
+
+    /// Actual steering angle at start of this time step (degrees).
+    pub current_steering_angle_deg: f64,
+}
+
+// ---------------------------------------------------------------------------
+// Enforcement Result
+// ---------------------------------------------------------------------------
+
+/// Result of `validate_vehicle_command`.
+///
+/// The calling policy layer is responsible for acting on this:
+/// - `Allow`         → forward the command to the actuator
+/// - `ClampLinear`   → replace linear velocity with the provided safe value
+/// - `ClampSteering` → replace steering angle with the provided safe value
+/// - `DenyBreach`    → drop the command, log the reason, emit a posture event
+///
+/// Only one action is returned per call. The first-triggered check wins.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub enum EnforceAction {
+    /// Command is within all physical invariants. Forward to actuator.
+    Allow,
+
+    /// Linear velocity component exceeds a limit. Replace with the provided safe value.
+    ClampLinear(f64),
+
+    /// Steering angle component exceeds a limit. Replace with the provided safe value.
+    /// May be triggered by steering rate (priority 5) or bicycle model (priority 6).
+    ClampSteering(f64),
+
+    /// Command is non-physical or violates a hard invariant that cannot be clamped.
+    DenyBreach(String),
+}
+
+// ---------------------------------------------------------------------------
+// Validation Pipeline
+// ---------------------------------------------------------------------------
+
+/// Evaluates a proposed vehicle command against a kinematics contract.
+///
+/// Checks run in strict priority order. Returns the first violation found,
+/// or `EnforceAction::Allow` if all checks pass.
+#[must_use]
+pub fn validate_vehicle_command(
+    cmd: &ProposedVehicleCommand,
+    contract: &VehicleKinematicsContract,
+) -> EnforceAction {
+    // ------------------------------------------------------------------
+    // Priority 1: Non-physical time delta
+    // Zero or negative dt makes rate-of-change calculations undefined.
+    // ------------------------------------------------------------------
+    if cmd.delta_time_s <= 0.0 {
+        return EnforceAction::DenyBreach("INVALID_TIME_DELTA".to_string());
+    }
+
+    // ------------------------------------------------------------------
+    // Priority 2: Linear velocity hard ceiling
+    // Checked before acceleration rate — a velocity-over-limit command
+    // implies an over-limit acceleration too; no need to compute it.
+    // ------------------------------------------------------------------
+    if cmd.linear_velocity_mps.abs() > contract.max_speed_mps {
+        let clamped = contract.max_speed_mps * cmd.linear_velocity_mps.signum();
+        return EnforceAction::ClampLinear(clamped);
+    }
+
+    // ------------------------------------------------------------------
+    // Priority 3: Implied acceleration ceiling
+    // ------------------------------------------------------------------
+    let implied_accel =
+        (cmd.linear_velocity_mps - cmd.current_velocity_mps) / cmd.delta_time_s;
+
+    if implied_accel > 0.0 && implied_accel > contract.max_accel_mps2 {
+        let safe_speed =
+            cmd.current_velocity_mps + (contract.max_accel_mps2 * cmd.delta_time_s);
+        return EnforceAction::ClampLinear(safe_speed);
+    }
+
+    // ------------------------------------------------------------------
+    // Priority 4: Implied deceleration ceiling
+    // Asymmetric from acceleration: braking limit is typically higher.
+    // ------------------------------------------------------------------
+    if implied_accel < 0.0 && implied_accel.abs() > contract.max_brake_mps2 {
+        let safe_speed =
+            cmd.current_velocity_mps - (contract.max_brake_mps2 * cmd.delta_time_s);
+        return EnforceAction::ClampLinear(safe_speed);
+    }
+
+    // ------------------------------------------------------------------
+    // Priority 5: Steering rate ceiling
+    // Prevents instantaneous full-lock transitions the physical rack
+    // cannot achieve and that produce violent lateral load transfer.
+    // ------------------------------------------------------------------
+    let steering_delta = cmd.steering_angle_deg - cmd.current_steering_angle_deg;
+    let implied_steering_rate = steering_delta.abs() / cmd.delta_time_s;
+
+    if implied_steering_rate > contract.max_steering_rate_deg_s {
+        let max_delta = contract.max_steering_rate_deg_s * cmd.delta_time_s;
+        let safe_steering =
+            cmd.current_steering_angle_deg + (max_delta * steering_delta.signum());
+        return EnforceAction::ClampSteering(safe_steering);
+    }
+
+    // ------------------------------------------------------------------
+    // Priority 6: Dynamic lateral acceleration envelope (bicycle model)
+    //
+    //   a_lat = (v² × |tan(δ)|) / L
+    //
+    // If implied lateral acceleration exceeds the contract limit, back-solve
+    // the maximum safe steering angle for the current velocity:
+    //
+    //   δ_max = atan((a_lat_max × L) / v²)
+    //
+    // Guard: skip at near-zero velocity to avoid dividing by v² ≈ 0;
+    // the resulting safe angle would be very large and already bounded
+    // by max_steering_deg above.
+    // ------------------------------------------------------------------
+    let v2 = cmd.linear_velocity_mps.powi(2);
+    if v2 > 1e-6 {
+        let steering_rad = cmd.steering_angle_deg.to_radians();
+        let implied_lat_accel =
+            (v2 * steering_rad.tan().abs()) / contract.wheelbase_m;
+
+        if implied_lat_accel > contract.max_lateral_accel_mps2 {
+            let max_safe_tan =
+                (contract.max_lateral_accel_mps2 * contract.wheelbase_m) / v2;
+            let max_safe_steering_deg = max_safe_tan.atan().to_degrees();
+            let safe_steering =
+                max_safe_steering_deg * cmd.steering_angle_deg.signum();
+            return EnforceAction::ClampSteering(safe_steering);
+        }
+    }
+
+    EnforceAction::Allow
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod kinematics_contract_tests {
+    use super::*;
+
+    // --- Allow cases --------------------------------------------------------
+
+    #[test]
+    fn test_nominal_command_passes_unhindered() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 10.0,
+            current_velocity_mps: 9.5,
+            delta_time_s: 0.2,
+            steering_angle_deg: 5.0,
+            current_steering_angle_deg: 4.5,
+        };
+        assert_eq!(validate_vehicle_command(&cmd, &contract), EnforceAction::Allow);
+    }
+
+    #[test]
+    fn test_zero_motion_command_passes() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 0.0,
+            current_velocity_mps: 0.0,
+            delta_time_s: 0.1,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        assert_eq!(validate_vehicle_command(&cmd, &contract), EnforceAction::Allow);
+    }
+
+    #[test]
+    fn test_mrc_command_within_mrc_profile_passes() {
+        let contract = VehicleKinematicsContract::mrc_fallback_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 3.0,
+            current_velocity_mps: 2.8,
+            delta_time_s: 0.2,
+            steering_angle_deg: 5.0,
+            current_steering_angle_deg: 4.0,
+        };
+        assert_eq!(validate_vehicle_command(&cmd, &contract), EnforceAction::Allow);
+    }
+
+    #[test]
+    fn test_mild_reverse_command_passes() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: -2.0,
+            current_velocity_mps: -1.5,
+            delta_time_s: 0.5,
+            steering_angle_deg: -3.0,
+            current_steering_angle_deg: -2.5,
+        };
+        assert_eq!(validate_vehicle_command(&cmd, &contract), EnforceAction::Allow);
+    }
+
+    // --- Deny cases ---------------------------------------------------------
+
+    #[test]
+    fn test_zero_time_delta_is_denied() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 10.0,
+            current_velocity_mps: 10.0,
+            delta_time_s: 0.0,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        assert_eq!(
+            validate_vehicle_command(&cmd, &contract),
+            EnforceAction::DenyBreach("INVALID_TIME_DELTA".to_string())
+        );
+    }
+
+    #[test]
+    fn test_negative_time_delta_is_denied() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 10.0,
+            current_velocity_mps: 10.0,
+            delta_time_s: -0.1,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        assert_eq!(
+            validate_vehicle_command(&cmd, &contract),
+            EnforceAction::DenyBreach("INVALID_TIME_DELTA".to_string())
+        );
+    }
+
+    // --- Linear velocity clamping -------------------------------------------
+
+    #[test]
+    fn test_speed_above_ceiling_triggers_clamp_linear() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 40.0,
+            current_velocity_mps: 34.0,
+            delta_time_s: 0.5,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        assert_eq!(
+            validate_vehicle_command(&cmd, &contract),
+            EnforceAction::ClampLinear(35.0)
+        );
+    }
+
+    #[test]
+    fn test_reverse_speed_above_ceiling_clamps_with_correct_sign() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: -40.0,
+            current_velocity_mps: -20.0,
+            delta_time_s: 0.5,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        assert_eq!(
+            validate_vehicle_command(&cmd, &contract),
+            EnforceAction::ClampLinear(-35.0)
+        );
+    }
+
+    #[test]
+    fn test_excessive_acceleration_triggers_linear_clamping() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 25.0,
+            current_velocity_mps: 10.0,
+            delta_time_s: 0.1,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        // Expected: 10.0 + (2.5 × 0.1) = 10.25
+        match validate_vehicle_command(&cmd, &contract) {
+            EnforceAction::ClampLinear(clamped) => {
+                let expected = 10.0_f64 + (2.5 * 0.1);
+                assert!((clamped - expected).abs() < 1e-9, "expected {expected}, got {clamped}");
+            }
+            other => panic!("Expected ClampLinear, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_excessive_braking_triggers_linear_clamping() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 0.0,
+            current_velocity_mps: 30.0,
+            delta_time_s: 0.1,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        // Expected: 30.0 - (4.5 × 0.1) = 29.55
+        match validate_vehicle_command(&cmd, &contract) {
+            EnforceAction::ClampLinear(clamped) => {
+                let expected = 30.0_f64 - (4.5 * 0.1);
+                assert!(clamped > 0.0, "should not allow instant stop");
+                assert!((clamped - expected).abs() < 1e-9, "expected {expected}, got {clamped}");
+            }
+            other => panic!("Expected ClampLinear for over-deceleration, got {other:?}"),
+        }
+    }
+
+    // --- Steering clamping --------------------------------------------------
+
+    #[test]
+    fn test_excessive_steering_rate_triggers_steering_clamp() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 10.0,
+            current_velocity_mps: 10.0,
+            delta_time_s: 0.1,
+            steering_angle_deg: 30.0, // 300 deg/s > 45 limit
+            current_steering_angle_deg: 0.0,
+        };
+        // max_delta = 45.0 × 0.1 = 4.5°
+        match validate_vehicle_command(&cmd, &contract) {
+            EnforceAction::ClampSteering(safe) => {
+                assert!((safe - 4.5_f64).abs() < 1e-9, "expected 4.5, got {safe}");
+            }
+            other => panic!("Expected ClampSteering for excessive rate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_high_speed_lateral_acceleration_forces_steering_clamp() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 30.0,
+            current_velocity_mps: 30.0,
+            delta_time_s: 0.5, // Long dt so steering rate check passes
+            steering_angle_deg: 20.0,
+            current_steering_angle_deg: 0.0,
+        };
+        // a_lat = (900 × tan(20°)) / 2.8 ≈ 116.9 m/s² >> 3.5 limit
+        match validate_vehicle_command(&cmd, &contract) {
+            EnforceAction::ClampSteering(safe) => {
+                assert!(safe < 20.0, "must reduce steering angle");
+                assert!(safe > 0.0, "sign must be preserved");
+                assert!(safe < 2.0, "at 30 m/s, safe steering must be very small");
+            }
+            other => panic!("Expected ClampSteering for lateral accel breach, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_near_zero_velocity_skips_bicycle_model_division() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 0.001,
+            current_velocity_mps: 0.001,
+            delta_time_s: 0.1,
+            steering_angle_deg: 30.0,
+            current_steering_angle_deg: 27.0, // Rate: 30 deg/s < 45 limit
+        };
+        assert_eq!(validate_vehicle_command(&cmd, &contract), EnforceAction::Allow);
+    }
+
+    // --- MRC profile enforcement --------------------------------------------
+
+    #[test]
+    fn test_nominal_speed_breaches_mrc_profile() {
+        let contract = VehicleKinematicsContract::mrc_fallback_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 15.0,
+            current_velocity_mps: 14.0,
+            delta_time_s: 0.5,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        assert_eq!(
+            validate_vehicle_command(&cmd, &contract),
+            EnforceAction::ClampLinear(5.0)
+        );
+    }
+
+    #[test]
+    fn test_mrc_lateral_limit_is_tighter_than_nominal() {
+        // 18° at 4 m/s: a_lat ≈ 1.857 m/s² — passes nominal (3.5), breaches MRC (1.5)
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 4.0,
+            current_velocity_mps: 4.0,
+            delta_time_s: 1.0,
+            steering_angle_deg: 18.0,
+            current_steering_angle_deg: 0.0,
+        };
+        let nominal = VehicleKinematicsContract::nominal_reference_profile();
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+
+        assert_eq!(validate_vehicle_command(&cmd, &nominal), EnforceAction::Allow);
+        match validate_vehicle_command(&cmd, &mrc) {
+            EnforceAction::ClampSteering(s) => {
+                assert!(s < 18.0, "MRC must clamp what nominal allows");
+            }
+            other => panic!("MRC should clamp lateral breach, got {other:?}"),
+        }
+    }
+
+    // --- Priority ordering --------------------------------------------------
+
+    #[test]
+    fn test_time_delta_check_fires_before_speed_check() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 999.0,
+            current_velocity_mps: 0.0,
+            delta_time_s: 0.0,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        assert_eq!(
+            validate_vehicle_command(&cmd, &contract),
+            EnforceAction::DenyBreach("INVALID_TIME_DELTA".to_string())
+        );
+    }
+
+    #[test]
+    fn test_speed_check_fires_before_accel_check() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 50.0, // Over 35 m/s ceiling (priority 2)
+            current_velocity_mps: 5.0,
+            delta_time_s: 0.1,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        assert_eq!(
+            validate_vehicle_command(&cmd, &contract),
+            EnforceAction::ClampLinear(35.0)
+        );
+    }
+}

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -1,218 +1,309 @@
 // src/gateway/policy_layer.rs
 //
-// Tower Layer/Service that enforces the Aegis posture-aware command routing
-// policy on every inbound HTTP request before it reaches the inner service.
+// Actuator safety envelope middleware for Aegis AV flight envelope protection.
+//
+// This Tower/axum middleware layer sits on actuator write routes and enforces the
+// VehicleKinematicsContract before any command reaches the physical actuator network.
+// It selects the appropriate kinematic profile based on the live fleet posture from
+// SharedPostureCache, then passes the proposed command through validate_vehicle_command.
+//
+// Security invariants respected:
+//   - Uses State<Arc<ServiceState>>, NOT State<Arc<AppState>> (invariant #11)
+//   - FleetPosture imported from crate::verifier, NOT crate::gateway::posture_cache
+//   - SharedPostureCache accessed via svc.posture_cache (lives on ServiceState)
+//   - LockedOut → 403 FORBIDDEN, fail-closed, no further processing
+//   - DenyBreach violations logged to audit chain via store methods (no Mutex assumption)
+//   - No hardcoded tokens, no env::set_var, no TransientLocal DDS
+//   - now_ms() defined locally; no external time dependency
 
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use axum::body::Body;
-use http::{Request, Response, StatusCode};
-use tower::{Layer, Service};
-
-use crate::gateway::interceptor::{now_ms, should_route_command, SharedPostureCache};
-use crate::gateway::policy::classify_http_command;
+use crate::gateway::kinematics_contract::{
+    validate_vehicle_command, EnforceAction, ProposedVehicleCommand, VehicleKinematicsContract,
+};
+// Correct import paths per architecture invariants:
+//   FleetPosture lives in crate::verifier, not crate::gateway::posture_cache
+use crate::verifier::FleetPosture;
+// ServiceState is the axum router state — wraps Arc<AppState> + SharedPostureCache
+// All handlers must use State<Arc<ServiceState>>, never State<Arc<AppState>>
+use crate::bin::aegis_verifier_service::ServiceState;
 
 // ---------------------------------------------------------------------------
-// Layer
+// Helpers
 // ---------------------------------------------------------------------------
 
-#[derive(Clone)]
-pub struct AegisPolicyLayer {
-    pub cache: SharedPostureCache,
+/// Returns the current time as milliseconds since UNIX epoch.
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
 }
 
-impl<S> Layer<S> for AegisPolicyLayer {
-    type Service = AegisPolicyService<S>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        AegisPolicyService { inner, cache: self.cache.clone() }
+/// Resolves the current FleetPosture from the SharedPostureCache.
+///
+/// `None` (cold start or expired cache) and a poisoned RwLock both map to
+/// LockedOut — fail-closed in all ambiguous cases.
+fn resolve_posture(svc: &ServiceState) -> FleetPosture {
+    match svc.posture_cache.read() {
+        Ok(guard) => match guard.as_ref() {
+            Some(cached) => cached.posture.clone(),
+            None => FleetPosture::LockedOut,
+        },
+        Err(_) => FleetPosture::LockedOut,
     }
 }
 
 // ---------------------------------------------------------------------------
-// Service
+// Middleware
 // ---------------------------------------------------------------------------
 
-#[derive(Clone)]
-pub struct AegisPolicyService<S> {
-    inner: S,
-    cache: SharedPostureCache,
-}
+/// Actuator command safety envelope middleware.
+///
+/// Intercepts inbound actuator motion commands, resolves the active fleet posture,
+/// selects the appropriate `VehicleKinematicsContract`, and enforces all physical
+/// invariants before the request reaches any downstream handler.
+///
+/// Posture → Contract mapping:
+///   Nominal   → nominal_reference_profile() — full operational envelope
+///   Degraded  → mrc_fallback_profile()      — MRC crawl-speed envelope
+///   LockedOut → immediate 403 FORBIDDEN     — fail-closed, no physics evaluation
+///
+/// On ClampLinear / ClampSteering the mutated payload is forwarded to the
+/// downstream handler. On DenyBreach the command is dropped (400) and the
+/// violation is written to the tamper-evident audit chain.
+///
+/// # Invariants
+/// - Uses `State<Arc<ServiceState>>` (invariant #11)
+/// - `FleetPosture` from `crate::verifier`
+/// - `SharedPostureCache` accessed via `svc.posture_cache`
+/// - LockedOut is always fail-closed
+pub async fn enforce_actuator_safety_envelope(
+    State(svc): State<Arc<ServiceState>>,
+    req: Request<Body>,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    // ------------------------------------------------------------------
+    // Step 1: Resolve active fleet posture from SharedPostureCache.
+    // SharedPostureCache = Arc<RwLock<Option<CachedFleetPosture>>>.
+    // Lives on ServiceState.posture_cache, NOT on AppState.
+    // ------------------------------------------------------------------
+    let posture = resolve_posture(&svc);
 
-impl<S> Service<Request<Body>> for AegisPolicyService<S>
-where
-    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
-    S::Future: Send + 'static,
-{
-    type Response = Response<Body>;
-    type Error = S::Error;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+    // ------------------------------------------------------------------
+    // Step 2: Select the kinematic contract profile.
+    // LockedOut → immediate 403; no command parsing, no physics.
+    // ------------------------------------------------------------------
+    let contract: VehicleKinematicsContract = match posture {
+        FleetPosture::Nominal => VehicleKinematicsContract::nominal_reference_profile(),
+        FleetPosture::Degraded => VehicleKinematicsContract::mrc_fallback_profile(),
+        FleetPosture::LockedOut => {
+            tracing::error!(
+                "Actuator command rejected: fleet posture is LockedOut — \
+                 all actuator mutations are blocked until posture recovers"
+            );
+            return Err(StatusCode::FORBIDDEN);
+        }
+    };
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
+    // ------------------------------------------------------------------
+    // Step 3: Consume and parse the request body.
+    // Body is a one-shot stream; we buffer it so we can re-assemble the
+    // request for the Allow and Clamp paths.
+    // ------------------------------------------------------------------
+    let (parts, body) = req.into_parts();
 
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
-        let method = req.method().as_str().to_string();
-        let path = req.uri().path().to_string();
-        let command = classify_http_command(&method, &path);
+    let bytes = axum::body::to_bytes(body, usize::MAX)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
 
-        // Read the cache inside a scoped block so the RwLock guard is dropped
-        // before the async boundary — holding a lock across an await is unsound.
-        let allowed = {
-            let now = now_ms();
-            match self.cache.read() {
-                Ok(guard) => match guard.as_ref() {
-                    Some(posture) => should_route_command(posture, now, command),
-                    None => false,
-                },
-                Err(_) => false,
-            }
-        };
+    let proposed_cmd: ProposedVehicleCommand =
+        serde_json::from_slice(&bytes).map_err(|_| StatusCode::BAD_REQUEST)?;
 
-        if !allowed {
-            return Box::pin(async move {
-                Ok(Response::builder()
-                    .status(StatusCode::FORBIDDEN)
-                    .body(Body::from("AEGIS_POLICY_DENY"))
-                    .unwrap())
-            });
+    // ------------------------------------------------------------------
+    // Step 4: Run the deterministic kinematics validation pipeline.
+    // ------------------------------------------------------------------
+    match validate_vehicle_command(&proposed_cmd, &contract) {
+        EnforceAction::Allow => {
+            let rebuilt = Request::from_parts(parts, Body::from(bytes));
+            Ok(next.run(rebuilt).await)
         }
 
-        let mut inner = self.inner.clone();
-        Box::pin(async move { inner.call(req).await })
+        EnforceAction::ClampLinear(safe_speed) => {
+            tracing::warn!(
+                requested_mps = %proposed_cmd.linear_velocity_mps,
+                clamped_mps   = %safe_speed,
+                "Kinematic envelope breach: linear velocity clamped"
+            );
+            let mut clamped_cmd = proposed_cmd.clone();
+            clamped_cmd.linear_velocity_mps = safe_speed;
+            let serialized = serde_json::to_vec(&clamped_cmd)
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            let rebuilt = Request::from_parts(parts, Body::from(serialized));
+            Ok(next.run(rebuilt).await)
+        }
+
+        EnforceAction::ClampSteering(safe_angle) => {
+            tracing::warn!(
+                requested_deg = %proposed_cmd.steering_angle_deg,
+                clamped_deg   = %safe_angle,
+                "Kinematic envelope breach: steering angle clamped"
+            );
+            let mut clamped_cmd = proposed_cmd.clone();
+            clamped_cmd.steering_angle_deg = safe_angle;
+            let serialized = serde_json::to_vec(&clamped_cmd)
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            let rebuilt = Request::from_parts(parts, Body::from(serialized));
+            Ok(next.run(rebuilt).await)
+        }
+
+        EnforceAction::DenyBreach(ref reason) => {
+            tracing::error!(
+                reason               = %reason,
+                linear_velocity_mps  = %proposed_cmd.linear_velocity_mps,
+                steering_angle_deg   = %proposed_cmd.steering_angle_deg,
+                delta_time_s         = %proposed_cmd.delta_time_s,
+                "Inadmissible actuator command rejected at kinematic safety perimeter"
+            );
+
+            // Write to the tamper-evident audit chain.
+            // VerifierStore is accessed directly — no Mutex wrapper (invariant).
+            // Log failure must not convert a 400 into a 500.
+            let log_payload = serde_json::json!({
+                "violation": reason,
+                "proposed_command": {
+                    "linear_velocity_mps": proposed_cmd.linear_velocity_mps,
+                    "current_velocity_mps": proposed_cmd.current_velocity_mps,
+                    "delta_time_s": proposed_cmd.delta_time_s,
+                    "steering_angle_deg": proposed_cmd.steering_angle_deg,
+                    "current_steering_angle_deg": proposed_cmd.current_steering_angle_deg,
+                },
+                "posture_at_rejection": format!("{posture:?}"),
+            });
+
+            // save_posture_event_chained: disk before memory (invariant #12).
+            let _ = svc.app.store.save_posture_event_chained(
+                "actuator_safety_envelope",
+                "KINEMATIC_CONTRACT_VIOLATION",
+                &log_payload.to_string(),
+                Some("Proposed vehicle command violates non-physical invariants"),
+                now_ms(),
+            );
+
+            Err(StatusCode::BAD_REQUEST)
+        }
     }
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Unit Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-mod tests {
+mod actuator_middleware_tests {
     use super::*;
-    use crate::gateway::interceptor::{CachedFleetPosture, FleetPosture, NodeTrustState};
-    use axum::{routing::get, routing::post, Router};
-    use std::sync::{Arc, RwLock};
-    use tower::ServiceExt;
+    use crate::gateway::kinematics_contract::{ProposedVehicleCommand, VehicleKinematicsContract};
+    use crate::verifier::FleetPosture;
 
-    async fn ok_handler() -> &'static str { "ok" }
+    // Contract selection logic — no ServiceState needed.
+    // Full axum integration tests are in tests/actuator_middleware_integration.rs.
 
-    fn cache_with(posture: FleetPosture) -> SharedPostureCache {
-        Arc::new(RwLock::new(Some(CachedFleetPosture {
-            node_id: "test-node".to_string(),
-            local_status: NodeTrustState::Trusted,
-            propagated_status: posture,
-            blocked_by: vec![],
-            updated_at_epoch_ms: now_ms(),
-        })))
+    #[test]
+    fn test_nominal_posture_selects_nominal_contract() {
+        let contract = match FleetPosture::Nominal {
+            FleetPosture::Nominal => VehicleKinematicsContract::nominal_reference_profile(),
+            FleetPosture::Degraded => VehicleKinematicsContract::mrc_fallback_profile(),
+            FleetPosture::LockedOut => panic!("should not reach LockedOut"),
+        };
+        assert_eq!(contract.max_speed_mps, 35.0);
+        assert_eq!(contract.max_lateral_accel_mps2, 3.5);
     }
 
-    #[tokio::test]
-    async fn test_nominal_allows_write_state() {
-        let app = Router::new()
-            .route("/cmd_vel", post(ok_handler))
-            .layer(AegisPolicyLayer { cache: cache_with(FleetPosture::Nominal) });
-
-        let res = app
-            .oneshot(Request::builder().method("POST").uri("/cmd_vel").body(Body::empty()).unwrap())
-            .await.unwrap();
-        assert_eq!(res.status(), StatusCode::OK);
+    #[test]
+    fn test_degraded_posture_selects_mrc_contract() {
+        let contract = match FleetPosture::Degraded {
+            FleetPosture::Nominal => VehicleKinematicsContract::nominal_reference_profile(),
+            FleetPosture::Degraded => VehicleKinematicsContract::mrc_fallback_profile(),
+            FleetPosture::LockedOut => panic!("should not reach LockedOut"),
+        };
+        assert_eq!(contract.max_speed_mps, 5.0);
+        assert_eq!(contract.max_lateral_accel_mps2, 1.5);
     }
 
-    #[tokio::test]
-    async fn test_nominal_allows_system_mutation() {
-        let app = Router::new()
-            .route("/reboot", post(ok_handler))
-            .layer(AegisPolicyLayer { cache: cache_with(FleetPosture::Nominal) });
-
-        let res = app
-            .oneshot(Request::builder().method("POST").uri("/reboot").body(Body::empty()).unwrap())
-            .await.unwrap();
-        assert_eq!(res.status(), StatusCode::OK);
+    #[test]
+    fn test_mrc_profile_rejects_nominal_speed_command() {
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 20.0,
+            current_velocity_mps: 19.0,
+            delta_time_s: 0.5,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        assert_eq!(
+            validate_vehicle_command(&cmd, &mrc),
+            EnforceAction::ClampLinear(5.0)
+        );
     }
 
-    #[tokio::test]
-    async fn test_degraded_allows_read_telemetry() {
-        let app = Router::new()
-            .route("/telemetry/status", get(ok_handler))
-            .layer(AegisPolicyLayer { cache: cache_with(FleetPosture::Degraded) });
-
-        let res = app
-            .oneshot(Request::builder().method("GET").uri("/telemetry/status").body(Body::empty()).unwrap())
-            .await.unwrap();
-        assert_eq!(res.status(), StatusCode::OK);
+    #[test]
+    fn test_nominal_profile_passes_same_command() {
+        let nominal = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 20.0,
+            current_velocity_mps: 19.0,
+            delta_time_s: 0.5,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        assert_eq!(validate_vehicle_command(&cmd, &nominal), EnforceAction::Allow);
     }
 
-    #[tokio::test]
-    async fn test_degraded_blocks_write_state() {
-        let app = Router::new()
-            .route("/cmd_vel", post(ok_handler))
-            .layer(AegisPolicyLayer { cache: cache_with(FleetPosture::Degraded) });
-
-        let res = app
-            .oneshot(Request::builder().method("POST").uri("/cmd_vel").body(Body::empty()).unwrap())
-            .await.unwrap();
-        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    #[test]
+    fn test_deny_breach_fires_for_non_physical_dt() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 10.0,
+            current_velocity_mps: 10.0,
+            delta_time_s: -1.0,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        assert_eq!(
+            validate_vehicle_command(&cmd, &contract),
+            EnforceAction::DenyBreach("INVALID_TIME_DELTA".to_string())
+        );
     }
 
-    #[tokio::test]
-    async fn test_degraded_blocks_system_mutation() {
-        let app = Router::new()
-            .route("/reboot", post(ok_handler))
-            .layer(AegisPolicyLayer { cache: cache_with(FleetPosture::Degraded) });
+    #[test]
+    fn test_highway_speed_high_steering_clamps_under_nominal_and_mrc() {
+        let nominal = VehicleKinematicsContract::nominal_reference_profile();
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 30.0,
+            current_velocity_mps: 30.0,
+            delta_time_s: 1.0,
+            steering_angle_deg: 20.0,
+            current_steering_angle_deg: 0.0,
+        };
 
-        let res = app
-            .oneshot(Request::builder().method("POST").uri("/reboot").body(Body::empty()).unwrap())
-            .await.unwrap();
-        assert_eq!(res.status(), StatusCode::FORBIDDEN);
-    }
-
-    #[tokio::test]
-    async fn test_locked_out_blocks_all_including_reads() {
-        let app = Router::new()
-            .route("/metrics", get(ok_handler))
-            .layer(AegisPolicyLayer { cache: cache_with(FleetPosture::LockedOut) });
-
-        let res = app
-            .oneshot(Request::builder().method("GET").uri("/metrics").body(Body::empty()).unwrap())
-            .await.unwrap();
-        assert_eq!(res.status(), StatusCode::FORBIDDEN);
-    }
-
-    #[tokio::test]
-    async fn test_missing_cache_blocks_even_read() {
-        let cache: SharedPostureCache = Arc::new(RwLock::new(None));
-        let app = Router::new()
-            .route("/telemetry/status", get(ok_handler))
-            .layer(AegisPolicyLayer { cache });
-
-        let res = app
-            .oneshot(Request::builder().method("GET").uri("/telemetry/status").body(Body::empty()).unwrap())
-            .await.unwrap();
-        assert_eq!(res.status(), StatusCode::FORBIDDEN);
-    }
-
-    #[tokio::test]
-    async fn test_poisoned_cache_lock_blocks_request() {
-        use std::sync::Arc;
-        // Poison the lock by panicking inside a write guard.
-        let cache: SharedPostureCache = Arc::new(RwLock::new(None));
-        let cache_clone = cache.clone();
-        let _ = std::panic::catch_unwind(move || {
-            let _guard = cache_clone.write().unwrap();
-            panic!("intentional poison");
-        });
-
-        let app = Router::new()
-            .route("/cmd_vel", post(ok_handler))
-            .layer(AegisPolicyLayer { cache });
-
-        let res = app
-            .oneshot(Request::builder().method("POST").uri("/cmd_vel").body(Body::empty()).unwrap())
-            .await.unwrap();
-        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+        // Nominal: bicycle model fires → ClampSteering
+        match validate_vehicle_command(&cmd, &nominal) {
+            EnforceAction::ClampSteering(a) => assert!(a < 20.0 && a > 0.0),
+            other => panic!("nominal: expected ClampSteering, got {other:?}"),
+        }
+        // MRC: speed ceiling fires first (30 > 5) → ClampLinear
+        match validate_vehicle_command(&cmd, &mrc) {
+            EnforceAction::ClampLinear(v) => assert_eq!(v, 5.0),
+            other => panic!("mrc: expected ClampLinear, got {other:?}"),
+        }
     }
 }

--- a/tests/actuator_middleware_integration.rs
+++ b/tests/actuator_middleware_integration.rs
@@ -1,0 +1,253 @@
+//! Integration tests for `enforce_actuator_safety_envelope`.
+//!
+//! These tests require a fully constructed `ServiceState` with an in-memory
+//! `VerifierStore` and a real axum `TestServer`. They verify end-to-end HTTP
+//! behaviour: status codes, response body mutation on clamp, and fail-closed
+//! semantics for every posture state.
+
+use std::sync::Arc;
+use axum::{
+    http::StatusCode,
+    routing::post,
+    Json, Router,
+};
+use axum_test::TestServer;
+use serde_json::json;
+use tokio::sync::{broadcast, RwLock};
+
+use aegis_runtime_sdk::{
+    bin::aegis_verifier_service::ServiceState,
+    gateway::{
+        kinematics_contract::ProposedVehicleCommand,
+        policy_layer::enforce_actuator_safety_envelope,
+    },
+    posture_cache::{CachedFleetPosture, SharedPostureCache},
+    verifier::{AppState, FleetPosture},
+    verifier_store::VerifierStore,
+};
+
+// ---------------------------------------------------------------------------
+// State builders
+// ---------------------------------------------------------------------------
+
+async fn build_state(posture: FleetPosture) -> Arc<ServiceState> {
+    let store = VerifierStore::new(":memory:").expect("in-memory store");
+    let (posture_tx, _) = broadcast::channel(1024);
+    let app = Arc::new(AppState::new(store, posture_tx));
+    let posture_cache: SharedPostureCache =
+        Arc::new(RwLock::new(Some(CachedFleetPosture::new(posture))));
+    Arc::new(ServiceState { app, posture_cache })
+}
+
+async fn build_state_empty_cache() -> Arc<ServiceState> {
+    let store = VerifierStore::new(":memory:").expect("in-memory store");
+    let (posture_tx, _) = broadcast::channel(1024);
+    let app = Arc::new(AppState::new(store, posture_tx));
+    // Explicitly None — cold start scenario
+    let posture_cache: SharedPostureCache = Arc::new(RwLock::new(None));
+    Arc::new(ServiceState { app, posture_cache })
+}
+
+fn build_router(state: Arc<ServiceState>) -> Router {
+    Router::new()
+        .route(
+            "/actuator/motion/command",
+            post(|Json(cmd): Json<ProposedVehicleCommand>| async move {
+                // Echo the (possibly clamped) command so tests can inspect it.
+                (StatusCode::OK, Json(cmd))
+            }),
+        )
+        .layer(axum::middleware::from_fn_with_state(
+            Arc::clone(&state),
+            enforce_actuator_safety_envelope,
+        ))
+        .with_state(state)
+}
+
+// ---------------------------------------------------------------------------
+// Nominal posture
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_nominal_safe_command_passes_through_unmodified() {
+    let state = build_state(FleetPosture::Nominal).await;
+    let server = TestServer::new(build_router(state)).unwrap();
+
+    let response = server
+        .post("/actuator/motion/command")
+        .json(&json!({
+            "linear_velocity_mps": 10.0,
+            "current_velocity_mps": 9.8,
+            "delta_time_s": 0.1,
+            "steering_angle_deg": 2.0,
+            "current_steering_angle_deg": 1.8
+        }))
+        .await;
+
+    response.assert_status(StatusCode::OK);
+    let returned: ProposedVehicleCommand = response.json();
+    assert_eq!(returned.linear_velocity_mps, 10.0);
+    assert_eq!(returned.steering_angle_deg, 2.0);
+}
+
+#[tokio::test]
+async fn test_nominal_over_acceleration_is_clamped_not_rejected() {
+    let state = build_state(FleetPosture::Nominal).await;
+    let server = TestServer::new(build_router(state)).unwrap();
+
+    // 10 → 40 m/s in 0.1 s = 300 m/s² >> 2.5 limit
+    let response = server
+        .post("/actuator/motion/command")
+        .json(&json!({
+            "linear_velocity_mps": 40.0,
+            "current_velocity_mps": 10.0,
+            "delta_time_s": 0.1,
+            "steering_angle_deg": 0.0,
+            "current_steering_angle_deg": 0.0
+        }))
+        .await;
+
+    response.assert_status(StatusCode::OK);
+    let returned: ProposedVehicleCommand = response.json();
+    // Expected: 10.0 + (2.5 × 0.1) = 10.25
+    assert!(
+        (returned.linear_velocity_mps - 10.25).abs() < 1e-9,
+        "expected 10.25, got {}",
+        returned.linear_velocity_mps
+    );
+}
+
+#[tokio::test]
+async fn test_nominal_invalid_time_delta_returns_400() {
+    let state = build_state(FleetPosture::Nominal).await;
+    let server = TestServer::new(build_router(state)).unwrap();
+
+    let response = server
+        .post("/actuator/motion/command")
+        .json(&json!({
+            "linear_velocity_mps": 10.0,
+            "current_velocity_mps": 10.0,
+            "delta_time_s": 0.0,
+            "steering_angle_deg": 0.0,
+            "current_steering_angle_deg": 0.0
+        }))
+        .await;
+
+    response.assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_nominal_highway_speed_high_steering_clamps_steering() {
+    let state = build_state(FleetPosture::Nominal).await;
+    let server = TestServer::new(build_router(state)).unwrap();
+
+    // 30 m/s + 20° — bicycle model must clamp steering
+    let response = server
+        .post("/actuator/motion/command")
+        .json(&json!({
+            "linear_velocity_mps": 30.0,
+            "current_velocity_mps": 30.0,
+            "delta_time_s": 1.0,
+            "steering_angle_deg": 20.0,
+            "current_steering_angle_deg": 0.0
+        }))
+        .await;
+
+    response.assert_status(StatusCode::OK);
+    let returned: ProposedVehicleCommand = response.json();
+    assert!(returned.steering_angle_deg < 20.0, "must have been clamped");
+    assert!(returned.steering_angle_deg > 0.0, "sign must be preserved");
+}
+
+// ---------------------------------------------------------------------------
+// Degraded posture
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_degraded_posture_clamps_high_speed_to_mrc_limit() {
+    let state = build_state(FleetPosture::Degraded).await;
+    let server = TestServer::new(build_router(state)).unwrap();
+
+    let response = server
+        .post("/actuator/motion/command")
+        .json(&json!({
+            "linear_velocity_mps": 15.0,
+            "current_velocity_mps": 14.5,
+            "delta_time_s": 0.5,
+            "steering_angle_deg": 0.0,
+            "current_steering_angle_deg": 0.0
+        }))
+        .await;
+
+    response.assert_status(StatusCode::OK);
+    let returned: ProposedVehicleCommand = response.json();
+    assert_eq!(returned.linear_velocity_mps, 5.0, "MRC max speed is 5.0 m/s");
+}
+
+// ---------------------------------------------------------------------------
+// LockedOut posture
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_locked_out_posture_returns_403_for_any_command() {
+    let state = build_state(FleetPosture::LockedOut).await;
+    let server = TestServer::new(build_router(state)).unwrap();
+
+    let response = server
+        .post("/actuator/motion/command")
+        .json(&json!({
+            "linear_velocity_mps": 1.0,
+            "current_velocity_mps": 1.0,
+            "delta_time_s": 0.1,
+            "steering_angle_deg": 0.0,
+            "current_steering_angle_deg": 0.0
+        }))
+        .await;
+
+    response.assert_status(StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_locked_out_rejects_zero_motion_command() {
+    // LockedOut must reject ALL commands — even a zero-velocity command.
+    // The planner cannot submit a "do nothing" to bypass the lock.
+    let state = build_state(FleetPosture::LockedOut).await;
+    let server = TestServer::new(build_router(state)).unwrap();
+
+    let response = server
+        .post("/actuator/motion/command")
+        .json(&json!({
+            "linear_velocity_mps": 0.0,
+            "current_velocity_mps": 0.0,
+            "delta_time_s": 0.1,
+            "steering_angle_deg": 0.0,
+            "current_steering_angle_deg": 0.0
+        }))
+        .await;
+
+    response.assert_status(StatusCode::FORBIDDEN);
+}
+
+// ---------------------------------------------------------------------------
+// Cache edge cases
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_empty_posture_cache_fails_closed_as_locked_out() {
+    // None cache (cold start) must be treated as LockedOut — fail-closed.
+    let state = build_state_empty_cache().await;
+    let server = TestServer::new(build_router(state)).unwrap();
+
+    let response = server
+        .post("/actuator/motion/command")
+        .json(&json!({
+            "linear_velocity_mps": 5.0,
+            "current_velocity_mps": 4.9,
+            "delta_time_s": 0.1,
+            "steering_angle_deg": 0.0,
+            "current_steering_angle_deg": 0.0
+        }))
+        .await;
+
+    response.assert_status(StatusCode::FORBIDDEN);
+}


### PR DESCRIPTION
## Summary

- **v2.0.0** — `VehicleKinematicsContract` with `nominal_reference_profile()` and `mrc_fallback_profile()`, deterministic 6-priority validation pipeline, bicycle model lateral acceleration enforcement, 17 unit tests (`src/gateway/kinematics_contract.rs`)
- **v2.0.0** — Flight envelope protection spec (`docs/kinematics_envelope_protection.md`)
- **v2.1.0** — `enforce_actuator_safety_envelope` Tower middleware: posture-aware contract selection, clamping with audit trail, fail-closed LockedOut → 403, cold-start cache → 403 (`src/gateway/policy_layer.rs`)
- **v2.1.0** — Integration test suite with real axum `TestServer` across all three posture states and empty-cache edge case (`tests/actuator_middleware_integration.rs`)
- **v2.1.0** — Router wiring guide with bug accounting (`docs/policy_layer_wiring.md`)
- **v2.2.0** — `av_subsystem_meta` schema, store methods (`register_av_subsystem_meta`, `touch_av_telemetry_timestamp`, `load_av_confidence_floor`), `handle_register_av_asset`, `handle_sensor_fault_report` with full fault/recovery cycle, 5 integration tests (`docs/v2_2_0_*.rs`)

## Bugs caught and corrected across milestones

| # | Milestone | Bug | Fix |
|---|-----------|-----|-----|
| 1–6 | v2.1.0 | `State<Arc<AppState>>`, wrong `FleetPosture` import, `PostureCache::new()`, `store.lock()`, `now_ms()` undefined, `/industrial/evaluate` double-mounted | Corrected per CLAUDE.md invariants |
| 7 | v2.2.0 | Direct `SharedPostureCache` mutation bypasses `recursive_calculate` (invariant #4) | Route through `recalculate_and_broadcast()` |
| 8 | v2.2.0 | `self.store.lock()` Mutex assumption | Direct store method calls |
| 9 | v2.2.0 | Duplicate `av_node_registry` / `av_node_dependencies` schema — AV nodes invisible to DAG | Single additive `av_subsystem_meta` table; nodes/deps use existing paths |
| 10 | v2.2.0 | `PostureStreamEvent { posture: None }` on transition event | DAG engine owns all cache writes |
| 11 | v2.2.0 | `0.70` magic number threshold | `AV_DEFAULT_CONFIDENCE_FLOOR: f64 = 0.70` named constant |
| 12 | v2.2.0 | Wrong auth tier on `/fleet/diagnostics/report` | Tier 2 admin-only |
| 13 | v2.2.0 | Recovery path entirely missing | Full fault → recovery cycle with `recalculate_and_broadcast()` on both transitions |

## Test plan

- [ ] `cargo test` passes (66 existing + new kinematics + middleware unit tests)
- [ ] Integration tests pass with in-memory SQLite (`axum_test::TestServer`)
- [ ] Apply `docs/policy_layer_wiring.md` diff to `aegis_verifier_service.rs`
- [ ] Apply `docs/v2_2_0_*.rs` patches to `verifier_store.rs`, `verifier.rs`, and `aegis_verifier_service.rs`
- [ ] Add `pub mod kinematics_contract; pub mod policy_layer;` to `src/gateway/mod.rs`
- [ ] Verify sensor fault → DAG propagation → MRC clamp end-to-end

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBLdsSH133bXQLksFaSuwz)_