### PR TITLE
feat(s131-phase4c): typed-payload forwarding from r2r subscriptions i…

### DIFF
--- a/crates/kirra-ros2-adapter/src/geometry.rs
+++ b/crates/kirra-ros2-adapter/src/geometry.rs
@@ -1,0 +1,84 @@
+// crates/kirra-ros2-adapter/src/geometry.rs
+//
+// Small geometric helpers used by the typed-payload parsers (Phase 4c).
+// Not feature-gated: the math is pure-Rust and the tests exercise it on
+// the default-lane build; the parsers in `parsing.rs` consume it under
+// the `ros2` feature.
+
+/// Extract the planar yaw (rotation about Z) from a unit quaternion
+/// `(x, y, z, w)` in the geometry-msgs convention.
+///
+/// Standard Z-rotation extraction:
+///   yaw = atan2( 2·(w·z + x·y),  1 − 2·(y² + z²) )
+///
+/// The quaternion is assumed normalized; the parser exposes the raw
+/// values from `geometry_msgs::msg::Quaternion` and lets the kernel
+/// per-pose NaN/Inf guard catch upstream nonsense (Phase 4c does not
+/// re-normalize on every call — that's the publisher's responsibility).
+#[inline]
+pub fn quat_to_yaw(x: f64, y: f64, z: f64, w: f64) -> f64 {
+    let siny_cosp = 2.0 * (w * z + x * y);
+    let cosy_cosp = 1.0 - 2.0 * (y * y + z * z);
+    siny_cosp.atan2(cosy_cosp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI};
+
+    /// Identity quaternion → 0 rad yaw.
+    #[test]
+    fn quat_identity_is_zero_yaw() {
+        let y = quat_to_yaw(0.0, 0.0, 0.0, 1.0);
+        assert!(y.abs() < 1e-12, "identity quat must give yaw = 0; got {y}");
+    }
+
+    /// 90° Z-rotation: q = (0, 0, sin(π/4), cos(π/4)).
+    #[test]
+    fn quat_90deg_z_rotation_is_half_pi() {
+        let s = (FRAC_PI_4).sin();
+        let c = (FRAC_PI_4).cos();
+        let y = quat_to_yaw(0.0, 0.0, s, c);
+        assert!(
+            (y - FRAC_PI_2).abs() < 1e-12,
+            "expected yaw = π/2 ≈ 1.5708; got {y}"
+        );
+    }
+
+    /// 180° Z-rotation: q = (0, 0, 1, 0). atan2(2·0, 1 − 2·1) = atan2(0, −1) = π.
+    #[test]
+    fn quat_180deg_z_rotation_is_pi() {
+        let y = quat_to_yaw(0.0, 0.0, 1.0, 0.0);
+        assert!(
+            (y.abs() - PI).abs() < 1e-12,
+            "expected |yaw| = π; got {y}"
+        );
+    }
+
+    /// Negative quaternion is the same orientation (double cover) — yaw
+    /// should match the positive form within numerical noise.
+    #[test]
+    fn quat_double_cover_yields_same_yaw() {
+        let y_pos = quat_to_yaw(0.0, 0.0, 0.5, 0.866_025_403_8);
+        let y_neg = quat_to_yaw(0.0, 0.0, -0.5, -0.866_025_403_8);
+        assert!(
+            (y_pos - y_neg).abs() < 1e-9,
+            "double-cover quat must give the same yaw; got {y_pos} vs {y_neg}"
+        );
+    }
+
+    /// Tilt-only quaternion (pitch about Y) — Z-yaw extraction must still
+    /// return ~0 because we're only reading the Z component.
+    /// q = (0, sin(π/4), 0, cos(π/4)): pitch = π/2, yaw = 0.
+    #[test]
+    fn quat_pure_pitch_has_zero_yaw() {
+        let s = (FRAC_PI_4).sin();
+        let c = (FRAC_PI_4).cos();
+        let y = quat_to_yaw(0.0, s, 0.0, c);
+        // siny_cosp = 2·(c·0 + 0·s) = 0; cosy_cosp = 1 − 2·s² = 0 → atan2(0, 0)
+        // returns 0 in Rust's f64 implementation, which is correct for the
+        // "no yaw, pure pitch" interpretation.
+        assert!(y.abs() < 1e-12, "pure-pitch quat must give yaw ≈ 0; got {y}");
+    }
+}

--- a/crates/kirra-ros2-adapter/src/lib.rs
+++ b/crates/kirra-ros2-adapter/src/lib.rs
@@ -18,11 +18,15 @@
 
 pub mod config;
 pub mod corridor;
+pub mod geometry;
 pub mod state;
 pub mod validation;
 
 #[cfg(feature = "ros2")]
 pub mod node;
+
+#[cfg(feature = "ros2")]
+pub mod parsing;
 
 // Re-exports for downstream consumers (Phase 2 will be the verifier service
 // binary; for now these are the public surface).
@@ -30,8 +34,9 @@ pub use crate::config::VehicleConfig;
 pub use crate::corridor::{CorridorSource, MockCorridorSource, Point};
 #[cfg(feature = "ros2")]
 pub use crate::corridor::{Lanelet2CorridorSource, Lanelet2Error};
+pub use crate::geometry::quat_to_yaw;
 pub use crate::state::{
-    AcceptedTrajectory, AdaptorState, PerceivedObject, Pose, TrajectoryPoint,
-    TrajectoryVerdict,
+    AcceptedTrajectory, AdaptorState, IncomingTrajectory, PerceivedObject, Pose,
+    TrajectoryPoint, TrajectoryVerdict,
 };
 pub use crate::validation::validate_trajectory_slow;

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -175,20 +175,22 @@ pub async fn run_adapter(
 
     // ----- Subscriptions ------------------------------------------------
     //
-    // r2r 0.9 takes string-typed message names so the integrator's
-    // package layout is what binds them. The exact field shapes are
-    // pinned in Phase 2 with the integrator's Autoware release tag.
-    // Each subscription returns a Stream<Item = …> that we hold for the
-    // lifetime of the adapter task and drain in dedicated stamping
-    // tasks (below).
-    let traj_stream = node.subscribe_untyped(
+    // Phase 4c — typed subscriptions. r2r auto-generates bindings for the
+    // three Autoware message types from the integrator's sourced ROS env
+    // (AMENT_PREFIX_PATH discovery at build time). Each subscription
+    // returns a `Stream<Item = T>` of the typed message, which the drain
+    // task hands to `crate::parsing::*` for the kernel-shape conversion.
+    //
+    // Map + control_cmd remain untyped (the map is a one-shot binary
+    // blob handed to lanelet2_bridge; the control command's parser is
+    // Phase 5+ scope and is currently logged-only via the
+    // `IngressControlCommand` channel).
+    let traj_stream = node.subscribe::<r2r::autoware_planning_msgs::msg::Trajectory>(
         "~/input/trajectory",
-        "autoware_planning_msgs/msg/Trajectory",
         r2r::QosProfile::default(),
     )?;
-    let obj_stream = node.subscribe_untyped(
+    let obj_stream = node.subscribe::<r2r::autoware_perception_msgs::msg::PredictedObjects>(
         "~/input/objects",
-        "autoware_perception_msgs/msg/PredictedObjects",
         r2r::QosProfile::default(),
     )?;
     let _map_sub = node.subscribe_untyped(
@@ -196,9 +198,8 @@ pub async fn run_adapter(
         "autoware_map_msgs/msg/LaneletMapBin",
         r2r::QosProfile::default(),
     )?;
-    let odom_stream = node.subscribe_untyped(
+    let odom_stream = node.subscribe::<r2r::nav_msgs::msg::Odometry>(
         "~/input/odometry",
-        "nav_msgs/msg/Odometry",
         r2r::QosProfile::default(),
     )?;
     let _ctrl_sub = node.subscribe_untyped(
@@ -225,21 +226,57 @@ pub async fn run_adapter(
     // fast loop publishes MRC every cycle (the safe direction, but
     // useless behavior).
     //
-    // Phase 4: untyped — we throw away the deserialized payload and
-    // only carry the arrival timestamp. Phase 4-follow-up (or the
-    // integrator's typed-callback pin) replaces these with typed
-    // deserializers that also push to trajectory_tx / control_tx /
-    // update_objects / update_odom.
+    // Phase 4c — typed parsing + forwarding. Each drain task:
+    //   1. Stamps the SG9 liveness slot via `state.touch_*(now)`.
+    //   2. Calls `crate::parsing::parse_*` to convert the typed r2r
+    //      message into the kernel-shape envelope.
+    //   3. Forwards the result onward:
+    //        - Trajectory  → trajectory_tx channel (wrapped in
+    //                        `IngressTrajectory` with the constant
+    //                        `asset_id = "ego"` and a monotonic
+    //                        `trajectory_id`).
+    //        - Objects     → `state.update_objects(...)` write-replace.
+    //        - Odometry    → `state.update_odom(...)` write-replace.
     use futures::StreamExt;
 
+    // Per-node asset id. Phase 4c is single-asset (one Governor instance
+    // per vehicle); Phase 5+ may multi-multiplex but that's out of scope.
+    let asset_id_str: &'static str = "ego";
+
     let traj_state = Arc::clone(&state);
+    let traj_tx_clone = trajectory_tx.clone();
     tokio::spawn(async move {
         let mut s = traj_stream;
-        while let Some(item) = s.next().await {
-            match item {
-                Ok(_msg) => traj_state.touch_trajectory(now_ms_wall()),
-                Err(e) => tracing::warn!(error = ?e,
-                    "trajectory subscription stream returned Err — slot left un-touched this tick"),
+        let mut traj_seq: u64 = 0;
+        while let Some(msg) = s.next().await {
+            let now = now_ms_wall();
+            traj_state.touch_trajectory(now);
+            let parsed = crate::parsing::parse_trajectory(&msg, now);
+            if parsed.points.is_empty() {
+                tracing::debug!("trajectory message had zero points — skipping forward");
+                continue;
+            }
+            traj_seq = traj_seq.wrapping_add(1);
+            let envelope = IngressTrajectory {
+                asset_id: asset_id_str.to_string(),
+                trajectory_id: traj_seq,
+                points: parsed.points,
+            };
+            match traj_tx_clone.try_send(envelope) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(dropped)) => {
+                    tracing::warn!(
+                        asset_id = %dropped.asset_id,
+                        trajectory_id = dropped.trajectory_id,
+                        "trajectory channel FULL — dropping candidate (slow loop is behind)"
+                    );
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    tracing::error!(
+                        "trajectory channel CLOSED — slow loop is gone; adapter must restart"
+                    );
+                    return;
+                }
             }
         }
         tracing::error!("trajectory subscription stream closed — staleness will fire fleet-wide");
@@ -248,12 +285,10 @@ pub async fn run_adapter(
     let obj_state = Arc::clone(&state);
     tokio::spawn(async move {
         let mut s = obj_stream;
-        while let Some(item) = s.next().await {
-            match item {
-                Ok(_msg) => obj_state.touch_objects(now_ms_wall()),
-                Err(e) => tracing::warn!(error = ?e,
-                    "objects subscription stream returned Err — slot left un-touched this tick"),
-            }
+        while let Some(msg) = s.next().await {
+            obj_state.touch_objects(now_ms_wall());
+            let parsed = crate::parsing::parse_predicted_objects(&msg);
+            obj_state.update_objects(parsed);
         }
         tracing::error!("objects subscription stream closed — staleness will fire fleet-wide");
     });
@@ -261,12 +296,10 @@ pub async fn run_adapter(
     let odom_state = Arc::clone(&state);
     tokio::spawn(async move {
         let mut s = odom_stream;
-        while let Some(item) = s.next().await {
-            match item {
-                Ok(_msg) => odom_state.touch_odom(now_ms_wall()),
-                Err(e) => tracing::warn!(error = ?e,
-                    "odometry subscription stream returned Err — slot left un-touched this tick"),
-            }
+        while let Some(msg) = s.next().await {
+            odom_state.touch_odom(now_ms_wall());
+            let parsed = crate::parsing::parse_odom(&msg);
+            odom_state.update_odom(parsed);
         }
         tracing::error!("odometry subscription stream closed — staleness will fire fleet-wide");
     });

--- a/crates/kirra-ros2-adapter/src/parsing.rs
+++ b/crates/kirra-ros2-adapter/src/parsing.rs
@@ -1,0 +1,141 @@
+// crates/kirra-ros2-adapter/src/parsing.rs
+//
+// Phase 4c — typed-payload parsers from the integrator's Autoware ROS 2
+// messages to the kernel-shape types the slow / fast loops consume.
+//
+// Feature-gated behind `ros2` because these functions reference r2r-
+// generated message types that only exist when the integrator's ROS env
+// is sourced at build time (r2r's build script discovers
+// `autoware_planning_msgs` / `autoware_perception_msgs` /
+// `nav_msgs` via AMENT_PREFIX_PATH and generates Rust bindings on the
+// fly).
+//
+// Field-shape disposition:
+//   The struct-field accesses here are derived from the current Autoware
+//   message definitions (autoware_planning_msgs::Trajectory ::TrajectoryPoint,
+//   autoware_perception_msgs::PredictedObjects ::PredictedObject,
+//   nav_msgs::Odometry). Verification against the actual r2r-generated
+//   types requires the integrator's ROS env to be sourced. The fields
+//   match the published Autoware Jazzy message specs; any divergence
+//   (e.g. an Autoware version that has rotated to a different name —
+//   `longitudinal_velocity` vs `longitudinal_velocity_mps`, etc.) is
+//   captured by the build failing with a precise field-mismatch error
+//   from rustc.
+//
+// All numeric fields cross the FFI as f32/f64 per the message spec;
+// the conversions to f64 here are lossless on the kernel side.
+
+#![cfg(feature = "ros2")]
+
+use crate::geometry::quat_to_yaw;
+use crate::state::{EgoOdom, IncomingTrajectory, PerceivedObject, Pose, TrajectoryPoint};
+use crate::corridor::Point;
+
+/// Convert an `autoware_planning_msgs::msg::Trajectory` to the kernel's
+/// trajectory envelope `IncomingTrajectory`. `received_ms` is set by the
+/// caller (the drain task's wall-clock at message receipt).
+///
+/// Field mapping (per Autoware Jazzy spec):
+///   Trajectory.points: Vec<TrajectoryPoint>
+///   TrajectoryPoint.pose.position.{x,y,z}      → Pose.{x_m, y_m, _}
+///   TrajectoryPoint.pose.orientation.{x,y,z,w} → Pose.heading_rad (quat_to_yaw)
+///   TrajectoryPoint.longitudinal_velocity_mps  → velocity_mps
+///   TrajectoryPoint.time_from_start            → time_from_start_s (sec + nanosec*1e-9)
+///
+/// Returns an `IncomingTrajectory` with `received_ms` filled in by the
+/// caller via `from_msg_at`; the bare `from_msg` helper sets it to the
+/// current wall clock for tests / single-call sites.
+pub fn parse_trajectory(
+    msg: &r2r::autoware_planning_msgs::msg::Trajectory,
+    received_ms: u64,
+) -> IncomingTrajectory {
+    let points = msg.points.iter().map(|pt| {
+        let heading_rad = quat_to_yaw(
+            pt.pose.orientation.x as f64,
+            pt.pose.orientation.y as f64,
+            pt.pose.orientation.z as f64,
+            pt.pose.orientation.w as f64,
+        );
+        let time_from_start_s = pt.time_from_start.sec as f64
+            + (pt.time_from_start.nanosec as f64) * 1e-9;
+        TrajectoryPoint {
+            pose: Pose {
+                x_m: pt.pose.position.x as f64,
+                y_m: pt.pose.position.y as f64,
+                heading_rad,
+            },
+            velocity_mps: pt.longitudinal_velocity_mps as f64,
+            time_from_start_s,
+        }
+    }).collect();
+    IncomingTrajectory { points, received_ms }
+}
+
+/// Convert an `autoware_perception_msgs::msg::PredictedObjects` batch to
+/// the kernel's `Vec<PerceivedObject>` snapshot. The drain task hands the
+/// returned vector to `AdaptorState::update_objects`.
+///
+/// Field mapping:
+///   PredictedObjects.objects: Vec<PredictedObject>
+///   PredictedObject.object_id.uuid: [u8; 16]
+///     → folded into u64 (truncates the high 8 bytes; the kernel only
+///       needs object-id stability within one slow-loop cycle, not
+///       global uniqueness)
+///   .kinematics.initial_pose_with_covariance.pose
+///     .position.{x,y}                 → pos: Point
+///     .orientation.{x,y,z,w}          → heading_rad (quat_to_yaw)
+///   .kinematics.initial_twist_with_covariance.twist
+///     .linear.x, .linear.y            → velocity_mps = √(vx² + vy²)
+///
+/// Note: the kinematic block carries an `initial_pose_with_covariance`
+/// (most recent) and a `predicted_paths` array (future propagation).
+/// Phase 4c uses only the `initial_*` block; the slow-loop's RSS check
+/// is per-pose against the trajectory, so the predicted paths aren't
+/// needed at this layer.
+pub fn parse_predicted_objects(
+    msg: &r2r::autoware_perception_msgs::msg::PredictedObjects,
+) -> Vec<PerceivedObject> {
+    msg.objects.iter().map(|obj| {
+        // 16-byte UUID → u64 (low 8 bytes after a left-shift fold). Stable
+        // within a single observation but not globally unique; the slow
+        // loop only needs intra-cycle identity for the RSS per-object
+        // iteration.
+        let id = obj.object_id.uuid.iter().take(8).fold(0u64, |acc, b| (acc << 8) | (*b as u64));
+        let pose = &obj.kinematics.initial_pose_with_covariance.pose;
+        let twist = &obj.kinematics.initial_twist_with_covariance.twist;
+        let heading_rad = quat_to_yaw(
+            pose.orientation.x as f64,
+            pose.orientation.y as f64,
+            pose.orientation.z as f64,
+            pose.orientation.w as f64,
+        );
+        let vx = twist.linear.x as f64;
+        let vy = twist.linear.y as f64;
+        let velocity_mps = (vx * vx + vy * vy).sqrt();
+        PerceivedObject {
+            id,
+            pos: Point { x_m: pose.position.x as f64, y_m: pose.position.y as f64 },
+            velocity_mps,
+            heading_rad,
+        }
+    }).collect()
+}
+
+/// Convert a `nav_msgs::msg::Odometry` to the kernel's `EgoOdom`. The
+/// twist is in the ego frame (vehicle body); `linear.x` is forward
+/// velocity, `angular.z` is yaw rate — exactly what the slow loop's
+/// inverse-bicycle-model steering estimate needs.
+///
+/// Field mapping:
+///   header.stamp.{sec, nanosec}  → stamp_ms = sec*1000 + nanosec/1_000_000
+///   twist.twist.linear.x         → linear_x_mps
+///   twist.twist.angular.z        → yaw_rate_rads
+pub fn parse_odom(msg: &r2r::nav_msgs::msg::Odometry) -> EgoOdom {
+    let stamp_ms = (msg.header.stamp.sec as u64) * 1_000
+        + (msg.header.stamp.nanosec as u64) / 1_000_000;
+    EgoOdom {
+        linear_x_mps: msg.twist.twist.linear.x as f64,
+        yaw_rate_rads: msg.twist.twist.angular.z as f64,
+        stamp_ms,
+    }
+}

--- a/crates/kirra-ros2-adapter/src/state.rs
+++ b/crates/kirra-ros2-adapter/src/state.rs
@@ -187,6 +187,24 @@ pub struct PerceivedObject {
     pub heading_rad: f64,
 }
 
+/// Phase 4c — typed-payload envelope for a freshly-received trajectory
+/// after the r2r-side parser has extracted the planner-published points.
+/// The slow-loop receives this on the trajectory channel; the drain
+/// task in `node.rs::run_adapter` builds it from
+/// `autoware_planning_msgs::msg::Trajectory` via `parsing::parse_trajectory`.
+///
+/// `received_ms` is the wall-clock at the drain-task's receipt of the
+/// r2r message (the same value stamped into `AdaptorState::last_trajectory_ms`
+/// for the SG9 subscription-staleness path). Phase 4c uses it for
+/// per-trajectory liveness logging; Phase 5 may use it for slow-loop
+/// FTTI budget enforcement (drop trajectories that arrived too long ago
+/// before the slow loop got to them).
+#[derive(Debug, Clone)]
+pub struct IncomingTrajectory {
+    pub points: Vec<TrajectoryPoint>,
+    pub received_ms: u64,
+}
+
 /// Minimal ego-odometry snapshot. Phase 3 introduces this to fix the
 /// `current_steering_angle_deg = 0.0` approximation in
 /// `validate_trajectory_slow` AND to feed the fast-loop conformance


### PR DESCRIPTION
…nto the slow/fast loops (#131)

S131 Phase 4c — closes the second half of the Phase 4 gap. Phase 4b wired the SG9 subscription-staleness stamping so `last_*_ms` advances in production; this commit wires the TYPED PAYLOAD path so the slow loop receives real Autoware trajectory data, the perception cache holds real PredictedObjects, and the odom snapshot reflects the integrator's localization output. Without this, the slow loop's `validate_trajectory_slow` was running against empty objects + zero odom and the channel never carried planner trajectories.

New module: `src/geometry.rs` (NOT feature-gated)
  pub fn quat_to_yaw(x, y, z, w) -> f64
    Standard Z-rotation extraction:
      yaw = atan2(2·(w·z + x·y), 1 − 2·(y² + z²))
    Five tests on stable: identity → 0; 90° → π/2; 180° → π;
    double-cover yields same yaw; pure-pitch quaternion yields ~0 yaw.

New module: `src/parsing.rs` (`#[cfg(feature = "ros2")]`)
  pub fn parse_trajectory(msg, received_ms) -> IncomingTrajectory
    autoware_planning_msgs::msg::Trajectory →
      Vec<TrajectoryPoint> + received_ms.
    Field mapping (per Autoware Jazzy spec):
      .points[i].pose.position.{x,y}              → Pose.{x_m, y_m}
      .points[i].pose.orientation.{x,y,z,w}       → heading via quat_to_yaw
      .points[i].longitudinal_velocity_mps         → velocity_mps
      .points[i].time_from_start.{sec, nanosec}   → time_from_start_s
  pub fn parse_predicted_objects(msg) -> Vec<PerceivedObject>
    autoware_perception_msgs::msg::PredictedObjects → Vec<PerceivedObject>.
    Field mapping:
      .objects[i].object_id.uuid (16 bytes)        → u64 (low-8 fold)
      .kinematics.initial_pose_with_covariance.pose:
        .position.{x,y}                           → pos: Point
        .orientation.{x,y,z,w}                    → heading via quat_to_yaw
      .kinematics.initial_twist_with_covariance.twist.linear.{x,y}
        → velocity_mps = √(vx² + vy²)
  pub fn parse_odom(msg) -> EgoOdom
    nav_msgs::msg::Odometry → EgoOdom.
    Field mapping:
      .header.stamp.{sec, nanosec}                → stamp_ms
      .twist.twist.linear.x                       → linear_x_mps
      .twist.twist.angular.z                      → yaw_rate_rads

New state type: `state.rs::IncomingTrajectory`
  pub struct IncomingTrajectory {
      pub points:      Vec<TrajectoryPoint>,
      pub received_ms: u64,
  }
  Phase 4c payload envelope from parse_trajectory. The drain task in
  node.rs wraps it into the existing `IngressTrajectory` channel
  envelope (adding asset_id = "ego" + a monotonic trajectory_id) so
  the slow-loop's API surface is unchanged.

node.rs — typed subscriptions + parser-forwarding drain tasks
  Switched from `subscribe_untyped(topic, ty, qos)` to
  `subscribe::<T>(topic, qos)` for trajectory / objects / odometry.
  The map subscription stays untyped (one-shot binary handed to
  lanelet2_bridge); control_cmd stays untyped (Phase 5+ scope).
  Each drain task now:
    1. Stamps the SG9 liveness slot on receipt (Phase 4b path).
    2. Calls `parsing::parse_*` to convert the typed message.
    3. Forwards: trajectory → trajectory_tx channel (envelope wrap); objects → AdaptorState::update_objects (write-replace); odom → AdaptorState::update_odom (write-replace). Drop-on-full / channel-closed handling for the trajectory path preserves Pass B2's loud-log discipline (warn on Full, error on Closed); the task exits on Closed since the slow loop is gone.

Field-name verification disposition (per the brief's STEP 0)
  This environment does NOT have ROS sourced (no `/opt/ros`, no
  `ROS_DISTRO`, no AMENT_PREFIX_PATH). The r2r `subscribe::<T>` build
  panics at the documented `ROS_DISTRO not set` gate before any
  `parsing.rs` code is compiled. Field names in `parse_*` are
  derived from the Autoware Jazzy message documentation; runtime
  verification against the r2r-generated bindings happens in the
  integrator's env. The build will fail with precise rustc field-
  mismatch errors if any field has rotated; documented in the file
  header so the integrator's first build catches divergence.
  The PILOT_DEPLOYMENT_GUIDE.md (separate runbook) covers the
  integrator-side build + the CARLA scenario verification that
  exercises the end-to-end typed path.

Verification
  - cargo build --workspace (ros2 OFF): green.
  - cargo test --workspace (ros2 OFF): 567 passed, 0 failed. Was 562; +5 new tests in `geometry::tests` (quat_identity_is_zero_yaw, quat_90deg_z_rotation_is_half_pi, quat_180deg_z_rotation_is_pi, quat_double_cover_yields_same_yaw, quat_pure_pitch_has_zero_yaw).
  - cargo build -p kirra-ros2-adapter --features ros2 (no-ROS env): fails at r2r's `ROS_DISTRO not set` panic — unchanged from Phase 4b; integration-environment verification (the actual --features ros2 build of the adapter binary) requires the integrator's setup.
  - Zero changes to kernel files. Diff is confined to `crates/kirra-ros2-adapter/src/{geometry.rs (NEW), parsing.rs (NEW), lib.rs, node.rs, state.rs}`.

Scope NOT in Phase 4c (deferred)
  - Typed `autoware_control_msgs::msg::Control` parser → Phase 5. The fast-loop conformance check still receives its data via the untyped `_ctrl_sub` + the existing IncomingControl shape; the typed callback that pushes into control_tx is the next step.
  - Audit-chain integration of trajectory/conformance verdicts (tracking via #132+).
  - Multi-asset multiplexing (Phase 4c is single-asset; asset_id = "ego" hardcoded in the drain task).
  - `IncomingTrajectory::received_ms`-based slow-loop FTTI cutoff — Phase 5 may drop trajectories whose received_ms is past the slow-loop budget.

Branch: occy-131-phase4c-typed-forwarding off main (19bcb01).