### PR TITLE
ci: split WCET gate from instrumented coverage run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,15 +35,34 @@ jobs:
         # TODO: restore `--mcdc` once cargo-llvm-cov and rustc nightly realign on
         # the coverage-options value. Current nightly accepts only block|branch|
         # condition; --branch is the closest substitute that compiles today.
+        #
+        # `--skip wcet_gate` excludes WCET timing assertions from the
+        # instrumented run. llvm-cov instrumentation adds 20–50% overhead on
+        # O(n) scans, which invalidates wall-clock budgets. The authoritative
+        # WCET measurement runs in the dedicated `wcet-gate` job below on a
+        # clean stable toolchain.
         run: |
           cargo llvm-cov --workspace --branch \
             --ignore-filename-regex='/.cargo/registry' \
-            --lcov --output-path lcov.info
+            --lcov --output-path lcov.info \
+            -- --skip wcet_gate
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           files: lcov.info
           fail_ci_if_error: false
+
+  wcet-gate:
+    name: WCET Gate (non-instrumented timing)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run WCET gate tests
+        # Authoritative WCET measurement. Runs on stable, non-instrumented,
+        # without llvm-cov. The coverage job above skips these tests because
+        # instrumentation overhead invalidates wall-clock thresholds.
+        run: cargo test -p kirra-runtime-sdk --lib wcet_gate::ci_gate_tests
 
   static-analysis:
     name: Static Analysis (ISO 26262)


### PR DESCRIPTION
Root cause: wcet_gate::ci_gate_tests::wcet_validate_trajectory_containment_worst_case fails under `cargo llvm-cov` because instrumentation adds 20–50% overhead on the O(n) corridor scan, which invalidates the 10ms SG2-CI threshold. The slow-loop safety budget is 100ms — the test is well within the real budget; the failure is a measurement artifact of the instrumented build, not a geometry/correctness regression.

Two-part fix:

Part A — coverage job: append `-- --skip wcet_gate` to the llvm-cov test filter so the instrumented run no longer attempts to enforce wall-clock budgets. Coverage of wcet_gate logic is not meaningful under instrumentation anyway (the assertions are timing-based).

Part B — new dedicated `wcet-gate` job: runs on stable, non-instrumented, without llvm-cov. This is the authoritative WCET measurement. Verified locally: 7/7 wcet_gate tests pass on clean stable in 1.43s.

Verified locally:
  - cargo test -p kirra-runtime-sdk --lib wcet_gate::ci_gate_tests → 7 passed; 0 failed (including wcet_validate_trajectory_containment_worst_case)
  - cargo test -p kirra-runtime-sdk --lib -- --skip wcet_gate → 392 passed; 0 failed; 7 filtered out (filter syntax confirmed)
  - cargo test --workspace → 562 passed; 0 failed; 0 ignored