### PR TITLE
feat(parko-kirra): diverse second governor for the comparator — CERT-006

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # Required
-AEGIS_ADMIN_TOKEN=change-me-to-a-long-random-secret
+KIRRA_ADMIN_TOKEN=change-me-to-a-long-random-secret
 
 # Optional — defaults shown
-# AEGIS_VERIFIER_ADDR=0.0.0.0:8090
-# AEGIS_DB_PATH=/var/lib/aegis/aegis.db
-# AEGIS_VERIFIER_MODE=active
-# AEGIS_TRUSTED_INGRESS_MODE=false
+# KIRRA_VERIFIER_ADDR=0.0.0.0:8090
+# KIRRA_DB_PATH=/var/lib/kirra/kirra.db
+# KIRRA_VERIFIER_MODE=active
+# KIRRA_TRUSTED_INGRESS_MODE=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install ONNX Runtime v1.24.2 (cross-backend equivalence test)
+        # The OpenVINO test suite includes a cross-backend equivalence
+        # test (`ort_ov_output_equivalence_on_mnist`) that loads the SAME
+        # MNIST model through parko-onnx's `OrtBackend` and compares its
+        # output to OpenVINO's. That backend dlopens libonnxruntime.so at
+        # runtime (ort `load-dynamic`), so this job needs the ONNX runtime
+        # too — identical install to the parko-onnx job. Without it the
+        # equivalence test panics ("Is libonnxruntime.so installed?").
+        run: |
+          set -euo pipefail
+          curl -L -o /tmp/onnxruntime-1.24.2.tgz \
+            https://github.com/microsoft/onnxruntime/releases/download/v1.24.2/onnxruntime-linux-x64-1.24.2.tgz
+          mkdir -p "$HOME/.local/onnxruntime"
+          tar -xzf /tmp/onnxruntime-1.24.2.tgz \
+            -C "$HOME/.local/onnxruntime" --strip-components=1
+          test -f "$HOME/.local/onnxruntime/lib/libonnxruntime.so" \
+            || (echo "libonnxruntime.so missing after install"; exit 1)
       - name: Install OpenVINO runtime (Intel apt repo, 2024.x)
         # The `openvino = "0.11"` crate links against OpenVINO 2024.x.
         # Intel ships a Debian package via their public apt repo —
@@ -145,11 +162,23 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/intel-openvino-2024.list
           sudo apt-get update
           sudo apt-get install -y openvino-2024.5.0
-          # Find the C library — the openvino-finder probes the
-          # standard install paths automatically, but we sanity-check
-          # before running the tests so a missing lib produces a
-          # clear CI failure rather than a panic deep in a test.
-          find /opt/intel -name "libopenvino_c.so*" -print | head -5
+          # Sanity-check the C runtime BEFORE running the tests so a
+          # missing lib is a clear failure here rather than a panic deep
+          # in a test. The apt/DEB package installs to the system FHS
+          # location /usr/lib/x86_64-linux-gnu — NOT /opt/intel, which is
+          # only created by the standalone OpenVINO archive installer.
+          # /usr/lib/x86_64-linux-gnu is exactly what openvino-finder
+          # (SYSTEM_INSTALLATION_DIRECTORIES, OpenVINO >= 2022.3) probes by
+          # default, so no LD_LIBRARY_PATH / OPENVINO_* env var is needed
+          # at test time.
+          if ! ls /usr/lib/x86_64-linux-gnu/libopenvino_c.so* >/dev/null 2>&1; then
+            echo "::error::libopenvino_c.so not found in /usr/lib/x86_64-linux-gnu after apt install"
+            echo "Installed openvino shared objects (for diagnosis):"
+            dpkg -L openvino-2024.5.0 | grep -E 'libopenvino.*\.so' || true
+            exit 1
+          fi
+          echo "OpenVINO C runtime present:"
+          ls -1 /usr/lib/x86_64-linux-gnu/libopenvino_c.so*
       - name: parko-openvino tests
         # OpenVINO-dependent. Same flakiness disposition as
         # parko-onnx: if this job becomes unreliable in CI (Intel apt
@@ -158,12 +187,16 @@ jobs:
         # remain gating regardless.
         working-directory: parko
         env:
-          # The openvino-finder crate uses LD_LIBRARY_PATH /
-          # OPENVINO_LIB_PATH when set; the apt install lands the
-          # library at /opt/intel/openvino/runtime/lib/intel64/.
-          LD_LIBRARY_PATH: /opt/intel/openvino/runtime/lib/intel64
-          OPENVINO_LIB_PATH: /opt/intel/openvino/runtime/lib/intel64
+          # ONNX runtime for the cross-backend equivalence test (parko-onnx
+          # `OrtBackend`, ort load-dynamic). OpenVINO itself needs NO env
+          # var: the apt/DEB package lands libopenvino_c.so in
+          # /usr/lib/x86_64-linux-gnu, which openvino-finder probes by
+          # default. (The previous /opt/intel paths were the archive
+          # installer's layout, which apt never creates — that stale
+          # assumption is what broke this job.)
+          ORT_DYLIB_PATH: ${{ env.HOME }}/.local/onnxruntime/lib/libonnxruntime.so
         run: cargo test -p parko-openvino
+
 
   static-analysis:
     name: Static Analysis (ISO 26262)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
-# Aegis Safety Kernel — Installation Guide
+# Kirra Safety Kernel — Installation Guide
 
-Aegis is a deterministic safety enforcement kernel for autonomous systems.
+Kirra is a deterministic safety enforcement kernel for autonomous systems.
 It intercepts motion commands from AI planners and enforces hard physical
 limits before they reach actuators — preventing unsafe commands from reaching
 robots, vehicles, drones, or industrial equipment regardless of what the AI
@@ -31,7 +31,7 @@ instructs.
 ## Quick Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/justinlooney/aegis/master/install.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/justinlooney/kirra-runtime-sdk/master/install.sh | sudo bash
 ```
 
 The installer will:
@@ -51,24 +51,24 @@ The installer will:
 ### Admin Token
 The admin token is a secret password required for all management operations —
 registering devices, viewing fleet posture, submitting safety reports. Think of
-it like a root password for the Aegis API.
+it like a root password for the Kirra API.
 
 - **Leave blank** to have the installer generate a secure random token
 - **Enter your own** if you want a specific value (minimum 16 characters recommended)
-- The token is stored in `/etc/aegis/aegis.env`, readable only by root and the
-  `aegis` system user
+- The token is stored in `/etc/kirra/kirra.env`, readable only by root and the
+  `kirra` system user
 - **Write it down or store it in a password manager** — you'll need it for API calls
 
 ### Port
-The TCP port Aegis listens on. Default is **8090**.
+The TCP port Kirra listens on. Default is **8090**.
 
 Change this if:
 - Another service already uses 8090
 - Your firewall requires a specific port
-- You're running multiple Aegis instances on the same machine
+- You're running multiple Kirra instances on the same machine
 
 ### Database Location
-Where Aegis stores its SQLite database. Default is `/var/lib/aegis/aegis.db`.
+Where Kirra stores its SQLite database. Default is `/var/lib/kirra/kirra.db`.
 
 Change this if:
 - You want the database on a separate volume
@@ -82,13 +82,13 @@ Change this if:
 ### Check the Service is Running
 
 ```bash
-sudo systemctl status aegis-verifier
+sudo systemctl status kirra-verifier
 ```
 
 You should see `active (running)`. If not, check the logs:
 
 ```bash
-sudo journalctl -u aegis-verifier -n 50
+sudo journalctl -u kirra-verifier -n 50
 ```
 
 ### Test the API
@@ -103,19 +103,19 @@ curl -H "Authorization: Bearer YOUR_TOKEN" \
 ```
 
 Replace `YOUR_TOKEN` with the token shown at the end of installation,
-or find it in `/etc/aegis/aegis.env`.
+or find it in `/etc/kirra/kirra.env`.
 
 ### View Logs
 
 ```bash
 # Live log stream
-sudo journalctl -u aegis-verifier -f
+sudo journalctl -u kirra-verifier -f
 
 # Last 100 lines
-sudo journalctl -u aegis-verifier -n 100
+sudo journalctl -u kirra-verifier -n 100
 
 # Logs from the last hour
-sudo journalctl -u aegis-verifier --since "1 hour ago"
+sudo journalctl -u kirra-verifier --since "1 hour ago"
 ```
 
 ---
@@ -124,38 +124,38 @@ sudo journalctl -u aegis-verifier --since "1 hour ago"
 
 | Action | Command |
 |--------|---------|
-| Check status | `sudo systemctl status aegis-verifier` |
-| Start | `sudo systemctl start aegis-verifier` |
-| Stop | `sudo systemctl stop aegis-verifier` |
-| Restart | `sudo systemctl restart aegis-verifier` |
-| View logs | `sudo journalctl -u aegis-verifier -f` |
-| Disable autostart | `sudo systemctl disable aegis-verifier` |
+| Check status | `sudo systemctl status kirra-verifier` |
+| Start | `sudo systemctl start kirra-verifier` |
+| Stop | `sudo systemctl stop kirra-verifier` |
+| Restart | `sudo systemctl restart kirra-verifier` |
+| View logs | `sudo journalctl -u kirra-verifier -f` |
+| Disable autostart | `sudo systemctl disable kirra-verifier` |
 
 ---
 
 ## Configuration
 
-Configuration lives in `/etc/aegis/aegis.env`. Edit this file to change
+Configuration lives in `/etc/kirra/kirra.env`. Edit this file to change
 any setting, then restart the service.
 
 ```bash
-sudo nano /etc/aegis/aegis.env
-sudo systemctl restart aegis-verifier
+sudo nano /etc/kirra/kirra.env
+sudo systemctl restart kirra-verifier
 ```
 
 ### Configuration Reference
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `AEGIS_ADMIN_TOKEN` | **Yes** | — | Bearer token for admin API calls |
-| `AEGIS_VERIFIER_ADDR` | No | `0.0.0.0:8090` | Listen address and port |
-| `AEGIS_DB_PATH` | No | `/var/lib/aegis/aegis.db` | SQLite database path |
-| `AEGIS_VERIFIER_MODE` | No | `active` | `active` or `passive_standby` |
-| `AEGIS_TRUSTED_INGRESS_MODE` | No | `false` | Require client ID headers |
-| `AEGIS_INSTANCE_ID` | No | hostname | Unique ID for HA deployments |
-| `AEGIS_HEARTBEAT_INTERVAL` | No | `2000` | HA heartbeat interval (ms) |
-| `AEGIS_PROMOTION_TIMEOUT` | No | `10000` | HA promotion timeout (ms) |
-| `AEGIS_SUPERVISOR_RESET_KEY` | No | — | Supervisor reset operations |
+| `KIRRA_ADMIN_TOKEN` | **Yes** | — | Bearer token for admin API calls |
+| `KIRRA_VERIFIER_ADDR` | No | `0.0.0.0:8090` | Listen address and port |
+| `KIRRA_DB_PATH` | No | `/var/lib/kirra/kirra.db` | SQLite database path |
+| `KIRRA_VERIFIER_MODE` | No | `active` | `active` or `passive_standby` |
+| `KIRRA_TRUSTED_INGRESS_MODE` | No | `false` | Require client ID headers |
+| `KIRRA_INSTANCE_ID` | No | hostname | Unique ID for HA deployments |
+| `KIRRA_HEARTBEAT_INTERVAL` | No | `2000` | HA heartbeat interval (ms) |
+| `KIRRA_PROMOTION_TIMEOUT` | No | `10000` | HA promotion timeout (ms) |
+| `KIRRA_SUPERVISOR_RESET_KEY` | No | — | Supervisor reset operations |
 
 ### Rotating the Admin Token
 
@@ -164,11 +164,11 @@ sudo systemctl restart aegis-verifier
 NEW_TOKEN=$(openssl rand -hex 32)
 
 # Update the config file
-sudo sed -i "s/^AEGIS_ADMIN_TOKEN=.*/AEGIS_ADMIN_TOKEN=${NEW_TOKEN}/" \
-    /etc/aegis/aegis.env
+sudo sed -i "s/^KIRRA_ADMIN_TOKEN=.*/KIRRA_ADMIN_TOKEN=${NEW_TOKEN}/" \
+    /etc/kirra/kirra.env
 
 # Restart to apply
-sudo systemctl restart aegis-verifier
+sudo systemctl restart kirra-verifier
 
 echo "New token: ${NEW_TOKEN}"
 ```
@@ -180,19 +180,19 @@ Update all clients and integrations with the new token before restarting.
 ## Upgrading
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/justinlooney/aegis/master/install.sh \
+curl -fsSL https://raw.githubusercontent.com/justinlooney/kirra-runtime-sdk/master/install.sh \
     | sudo bash -s -- --force
 ```
 
 The `--force` flag reinstalls over the existing installation. Your configuration
-(`/etc/aegis/aegis.env`) and database (`/var/lib/aegis/aegis.db`) are preserved.
+(`/etc/kirra/kirra.env`) and database (`/var/lib/kirra/kirra.db`) are preserved.
 
 ---
 
 ## Uninstalling
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/justinlooney/aegis/master/install.sh \
+curl -fsSL https://raw.githubusercontent.com/justinlooney/kirra-runtime-sdk/master/install.sh \
     | sudo bash -s -- --uninstall
 ```
 
@@ -200,45 +200,45 @@ This removes the binary and service but **preserves** your configuration and
 database. To remove everything:
 
 ```bash
-sudo rm -rf /etc/aegis /var/lib/aegis /var/log/aegis
-sudo userdel -r aegis 2>/dev/null || true
+sudo rm -rf /etc/kirra /var/lib/kirra /var/log/kirra
+sudo userdel -r kirra 2>/dev/null || true
 ```
 
 ---
 
 ## High Availability (Two-Instance Setup)
 
-For production deployments where Aegis must remain running even if one
+For production deployments where Kirra must remain running even if one
 machine fails, deploy two instances: one `active` (primary) and one
 `passive_standby` (standby). Both must share the same SQLite database
 (via NFS, shared block storage, or database replication).
 
-**Primary instance** (`/etc/aegis/aegis.env`):
+**Primary instance** (`/etc/kirra/kirra.env`):
 ```
-AEGIS_VERIFIER_MODE=active
-AEGIS_INSTANCE_ID=aegis-primary
+KIRRA_VERIFIER_MODE=active
+KIRRA_INSTANCE_ID=kirra-primary
 ```
 
-**Standby instance** (`/etc/aegis/aegis.env`):
+**Standby instance** (`/etc/kirra/kirra.env`):
 ```
-AEGIS_VERIFIER_MODE=passive_standby
-AEGIS_INSTANCE_ID=aegis-standby
-AEGIS_DB_PATH=/mnt/shared/aegis.db
+KIRRA_VERIFIER_MODE=passive_standby
+KIRRA_INSTANCE_ID=kirra-standby
+KIRRA_DB_PATH=/mnt/shared/kirra.db
 ```
 
 The standby monitors the primary's heartbeat. If the primary is silent for
-10 seconds (configurable via `AEGIS_PROMOTION_TIMEOUT`), the standby
+10 seconds (configurable via `KIRRA_PROMOTION_TIMEOUT`), the standby
 automatically promotes itself to active and begins enforcing posture.
 
 ---
 
 ## Firewall Configuration
 
-If you have a firewall (ufw, iptables, firewalld), allow the Aegis port:
+If you have a firewall (ufw, iptables, firewalld), allow the Kirra port:
 
 ```bash
 # ufw
-sudo ufw allow 8090/tcp comment "Aegis Safety Kernel"
+sudo ufw allow 8090/tcp comment "Kirra Safety Kernel"
 
 # firewalld
 sudo firewall-cmd --permanent --add-port=8090/tcp
@@ -258,12 +258,12 @@ sudo ufw allow from 10.0.1.0/24 to any port 8090
 Set environment variables before running the installer to skip all prompts:
 
 ```bash
-export AEGIS_ADMIN_TOKEN="your-secret-token-here"
-export AEGIS_PORT="8090"
-export AEGIS_DB_PATH="/var/lib/aegis/aegis.db"
-export AEGIS_VERIFIER_MODE="active"
+export KIRRA_ADMIN_TOKEN="your-secret-token-here"
+export KIRRA_PORT="8090"
+export KIRRA_DB_PATH="/var/lib/kirra/kirra.db"
+export KIRRA_VERIFIER_MODE="active"
 
-curl -fsSL https://raw.githubusercontent.com/justinlooney/aegis/master/install.sh \
+curl -fsSL https://raw.githubusercontent.com/justinlooney/kirra-runtime-sdk/master/install.sh \
     | sudo -E bash -s -- --non-interactive
 ```
 
@@ -276,72 +276,72 @@ The `-E` flag passes your environment variables through sudo.
 ### Service Won't Start
 
 ```bash
-sudo journalctl -u aegis-verifier -n 100
+sudo journalctl -u kirra-verifier -n 100
 ```
 
 Common causes:
-- **Port already in use**: Change `AEGIS_VERIFIER_ADDR` in `/etc/aegis/aegis.env`
-- **Database directory not writable**: `sudo chown aegis:aegis /var/lib/aegis`
-- **Missing admin token**: Ensure `AEGIS_ADMIN_TOKEN` is set in `/etc/aegis/aegis.env`
+- **Port already in use**: Change `KIRRA_VERIFIER_ADDR` in `/etc/kirra/kirra.env`
+- **Database directory not writable**: `sudo chown kirra:kirra /var/lib/kirra`
+- **Missing admin token**: Ensure `KIRRA_ADMIN_TOKEN` is set in `/etc/kirra/kirra.env`
 
 ### API Returns 401 Unauthorized
 
 Your admin token is wrong or missing. Check:
 ```bash
 # View the configured token (requires root)
-sudo grep AEGIS_ADMIN_TOKEN /etc/aegis/aegis.env
+sudo grep KIRRA_ADMIN_TOKEN /etc/kirra/kirra.env
 ```
 
 Use it in requests:
 ```bash
-curl -H "Authorization: Bearer $(sudo grep AEGIS_ADMIN_TOKEN /etc/aegis/aegis.env | cut -d= -f2)" \
+curl -H "Authorization: Bearer $(sudo grep KIRRA_ADMIN_TOKEN /etc/kirra/kirra.env | cut -d= -f2)" \
      http://localhost:8090/fleet/posture
 ```
 
 ### API Returns 503 Service Unavailable
 
 The admin token environment variable is empty or missing. Restart the service
-after ensuring `AEGIS_ADMIN_TOKEN` is set in `/etc/aegis/aegis.env`.
+after ensuring `KIRRA_ADMIN_TOKEN` is set in `/etc/kirra/kirra.env`.
 
 ### Database Errors
 
 ```bash
 # Check disk space
-df -h /var/lib/aegis
+df -h /var/lib/kirra
 
 # Check file ownership
-ls -la /var/lib/aegis/
+ls -la /var/lib/kirra/
 
 # Fix ownership if wrong
-sudo chown -R aegis:aegis /var/lib/aegis
+sudo chown -R kirra:kirra /var/lib/kirra
 ```
 
 ### Architecture Mismatch
 
 If you see `Exec format error`, the binary architecture doesn't match your
 system. The installer detects architecture automatically — if it downloaded
-the wrong binary, open an issue at https://github.com/justinlooney/aegis/issues
+the wrong binary, open an issue at https://github.com/justinlooney/kirra-runtime-sdk/issues
 with the output of `uname -m`.
 
 ---
 
 ## Security Notes
 
-- The admin token is equivalent to root access to the Aegis API. Treat it
+- The admin token is equivalent to root access to the Kirra API. Treat it
   like a password.
-- `/etc/aegis/aegis.env` is readable by root and the `aegis` group only
+- `/etc/kirra/kirra.env` is readable by root and the `kirra` group only
   (mode 640). Do not change this permission.
-- The `aegis` system user has no login shell and no home directory outside
-  `/var/lib/aegis`. It cannot be used to log in.
+- The `kirra` system user has no login shell and no home directory outside
+  `/var/lib/kirra`. It cannot be used to log in.
 - All administrative API calls are logged to the tamper-evident audit chain
   stored in the database.
-- For production deployments, place Aegis behind a TLS-terminating reverse
+- For production deployments, place Kirra behind a TLS-terminating reverse
   proxy (nginx, Caddy) and restrict direct port access.
 
 ---
 
 ## Getting Help
 
-- **Documentation**: https://github.com/justinlooney/aegis
-- **Issues**: https://github.com/justinlooney/aegis/issues
-- **Logs**: `sudo journalctl -u aegis-verifier -f`
+- **Documentation**: https://github.com/justinlooney/kirra-runtime-sdk
+- **Issues**: https://github.com/justinlooney/kirra-runtime-sdk/issues
+- **Logs**: `sudo journalctl -u kirra-verifier -f`

--- a/config/asset_profile.json
+++ b/config/asset_profile.json
@@ -7,7 +7,7 @@
     "max_concurrent_connections": 32
   },
   "telemetry": {
-    "log_directory": "/var/log/aegis"
+    "log_directory": "/var/log/kirra"
   },
   "contract": {
     "asset_register_offset": 10,

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Aegis Safety Kernel</title>
+    <title>Kirra Safety Kernel</title>
   </head>
   <body>
     <div id="root"></div>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "aegis-dashboard",
+  "name": "kirra-dashboard",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "aegis-dashboard",
+      "name": "kirra-dashboard",
       "version": "1.0.0",
       "dependencies": {
         "react": "^18.2.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aegis-dashboard",
+  "name": "kirra-dashboard",
   "version": "1.0.0",
   "type": "module",
   "scripts": {

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -391,7 +391,7 @@ function fmtTime(ms) {
 }
 
 // ─── Main App ─────────────────────────────────────────────────────────────────
-export default function AegisDashboard() {
+export default function KirraDashboard() {
   const [config, setConfig]       = useState({ url: "http://localhost:8090", token: "" });
   const [connected, setConnected] = useState(false);
   const [page, setPage]           = useState("overview");
@@ -465,7 +465,7 @@ export default function AegisDashboard() {
     return () => clearInterval(interval);
   }, [connected, loadFabricState]);
 
-  // SSE posture stream (best-effort; requires x-aegis-client-id header via server config)
+  // SSE posture stream (best-effort; requires x-kirra-client-id header via server config)
   useEffect(() => {
     if (!connected) return;
     const url = `${config.url.replace(/\/$/, "")}/system/posture/stream`;
@@ -496,7 +496,7 @@ export default function AegisDashboard() {
           </div>
           <div className="connect-screen">
             <div className="connect-card">
-              <div className="connect-title">Connect to Aegis</div>
+              <div className="connect-title">Connect to Kirra</div>
               <div className="connect-sub">Enter your verifier URL and admin token to get started.</div>
               {error && <div className="alert error">{error}</div>}
               <div className="field">
@@ -508,7 +508,7 @@ export default function AegisDashboard() {
                 <label>Admin Token</label>
                 <input type="password" value={config.token}
                   onChange={e => setConfig(c => ({ ...c, token: e.target.value }))}
-                  placeholder="Bearer token from /etc/aegis/aegis.env"
+                  placeholder="Bearer token from /etc/kirra/kirra.env"
                   onKeyDown={e => e.key === "Enter" && connect()} />
               </div>
               <button className="btn btn-primary btn-full" onClick={connect} disabled={loading}>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 services:
-  aegis-verifier:
+  kirra-verifier:
     build: .
-    container_name: aegis-verifier
+    container_name: kirra-verifier
     ports:
-      - "${AEGIS_PORT:-8090}:8090"
+      - "${KIRRA_PORT:-8090}:8090"
     env_file:
       - .env
     environment:
-      AEGIS_VERIFIER_ADDR: "0.0.0.0:8090"
-      AEGIS_DB_PATH: "/var/lib/aegis/aegis.db"
-      AEGIS_VERIFIER_MODE: "${AEGIS_VERIFIER_MODE:-active}"
+      KIRRA_VERIFIER_ADDR: "0.0.0.0:8090"
+      KIRRA_DB_PATH: "/var/lib/kirra/kirra.db"
+      KIRRA_VERIFIER_MODE: "${KIRRA_VERIFIER_MODE:-active}"
     volumes:
-      - aegis-data:/var/lib/aegis
+      - kirra-data:/var/lib/kirra
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-fsSL", "http://localhost:8090/health"]
@@ -20,33 +20,33 @@ services:
       start_period: 5s
       retries: 3
 
-  aegis-dashboard:
+  kirra-dashboard:
     build:
       context: dashboard
       dockerfile: Dockerfile
-    container_name: aegis-dashboard
+    container_name: kirra-dashboard
     ports:
       - "${DASHBOARD_PORT:-8091}:80"
     restart: unless-stopped
     depends_on:
-      aegis-verifier:
+      kirra-verifier:
         condition: service_healthy
 
   # Optional HA standby — enable with: docker compose --profile ha up
-  aegis-standby:
+  kirra-standby:
     profiles: [ha]
     build: .
-    container_name: aegis-standby
+    container_name: kirra-standby
     ports:
-      - "${AEGIS_STANDBY_PORT:-8092}:8090"
+      - "${KIRRA_STANDBY_PORT:-8092}:8090"
     env_file:
       - .env
     environment:
-      AEGIS_VERIFIER_ADDR: "0.0.0.0:8090"
-      AEGIS_DB_PATH: "/var/lib/aegis/aegis.db"
-      AEGIS_VERIFIER_MODE: "passive_standby"
+      KIRRA_VERIFIER_ADDR: "0.0.0.0:8090"
+      KIRRA_DB_PATH: "/var/lib/kirra/kirra.db"
+      KIRRA_VERIFIER_MODE: "passive_standby"
     volumes:
-      - aegis-data-standby:/var/lib/aegis
+      - kirra-data-standby:/var/lib/kirra
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-fsSL", "http://localhost:8090/health"]
@@ -56,5 +56,5 @@ services:
       retries: 3
 
 volumes:
-  aegis-data:
-  aegis-data-standby:
+  kirra-data:
+  kirra-data-standby:

--- a/docs/ISSUE_TRIAGE_2026-06-01.md
+++ b/docs/ISSUE_TRIAGE_2026-06-01.md
@@ -60,7 +60,7 @@ spot checks vs `git log --oneline main -50`,
 
 | # | Title | Conf | Evidence | Why P0 |
 |---|---|---|---|---|
-| **43** | PARK-031 normalize Kirra naming | HIGH | `scripts/build_release.sh:17-92` + `scripts/setup_ros2_fleet.sh:6-97` pervasively `aegis-*` / `AEGIS_*` | Pilot integrator first-build hits these scripts and gets confusing artifacts. |
+| **43** | PARK-031 normalize Kirra naming | HIGH | `scripts/build_release.sh:17-92` + `scripts/setup_ros2_fleet.sh:6-97` pervasively `kirra-*` / `KIRRA_*` | Pilot integrator first-build hits these scripts and gets confusing artifacts. |
 | **69** | fix(gateway): unknown POST/PUT → WriteState | HIGH | `src/gateway/policy.rs:38-41` falls through to `WriteState` (comment: "All other POST/PUT: treat as WriteState") | SG-006 invariant: Unknown commands must DENY before posture check. This silently widens the WriteState surface. |
 | **73** | fix(verifier): attestation HMAC | HIGH | `src/bin/kirra_verifier_service.rs:299-360` still HMAC(`KIRRA_ADMIN_TOKEN`, nonce); `ak_public_pem` + PCR16 unread | Documented impersonation gap. |
 | **89** | [Occy 0.A] Scaffold kirra-planner crate | HIGH | no `kirra-planner` workspace member in `/Cargo.toml` or `parko/Cargo.toml`; `crates/` has only `kirra-ros2-adapter` | Blocks all Occy Phase 1 work (#90–#93). |
@@ -135,7 +135,7 @@ No issue was bucketed `NEEDS-TRIAGE` — all 77 had enough evidence to place. **
 
 **P0 (pilot-blocking) — 4**:
 1. **#89** Scaffold `kirra-planner` crate — blocks Occy Phase 1 entirely.
-2. **#43** Normalize aegis-* → kirra-* across `scripts/` + Docker — blocks integrator first-build.
+2. **#43** Normalize kirra-* → kirra-* across `scripts/` + Docker — blocks integrator first-build.
 3. **#69** Gateway POST/PUT classification — SG-006 invariant gap (unknown commands silently classified as WriteState).
 4. **#73** Per-node attestation key (not shared HMAC) — documented impersonation gap.
 

--- a/docs/MIGRATION_AEGIS_TO_KIRRA.md
+++ b/docs/MIGRATION_AEGIS_TO_KIRRA.md
@@ -1,0 +1,90 @@
+# Migration: Aegis → Kirra (Issue #43)
+
+This project was formerly named **Aegis** and is now **Kirra**. The code,
+crate, primary binary, and runtime environment variables had already moved to
+the `kirra` / `KIRRA_*` namespace, but a set of **build, deploy, and
+documentation artifacts still referenced the old `aegis` names**. Because the
+running service reads only `KIRRA_*`, those stale references were
+non-functional — e.g. an `.env`/compose file setting `AEGIS_ADMIN_TOKEN` left
+the service with no token (HTTP 503), and build/install scripts pointed at
+binaries, a link name, and unit files that no longer exist. Issue #43 tracked
+this integrator-build blocker. This change completes the rename.
+
+## Decision: hard rename, no aliases
+
+These are **breaking** renames with **no backward-compatible aliases**, which
+is the correct choice here: this is a pre-release SDK with no production
+deployment, and the old `AEGIS_*` names were already inert (the binary never
+read them after the code-side rename). Keeping aliases would preserve names
+that did not actually work. Update any pinned references as below.
+
+## Public renames (old → new)
+
+### Environment variables (set by integrators / deploy)
+The service has read `KIRRA_*` for some time; only the deploy artifacts were
+stale. Any integrator still exporting `AEGIS_*` must switch:
+
+| Old | New |
+|-----|-----|
+| `AEGIS_ADMIN_TOKEN` | `KIRRA_ADMIN_TOKEN` |
+| `AEGIS_VERIFIER_ADDR` | `KIRRA_VERIFIER_ADDR` |
+| `AEGIS_DB_PATH` | `KIRRA_DB_PATH` |
+| `AEGIS_VERIFIER_MODE` | `KIRRA_VERIFIER_MODE` |
+| `AEGIS_TRUSTED_INGRESS_MODE` | `KIRRA_TRUSTED_INGRESS_MODE` |
+| `AEGIS_CLIENT_ID_HEADER` | `KIRRA_CLIENT_ID_HEADER` |
+| `AEGIS_LOG_SIGNING_KEY` | `KIRRA_LOG_SIGNING_KEY` |
+| `AEGIS_INSTANCE_ID` / `AEGIS_HEARTBEAT_INTERVAL` / `AEGIS_PROMOTION_TIMEOUT` | `KIRRA_INSTANCE_ID` / `KIRRA_HEARTBEAT_INTERVAL` / `KIRRA_PROMOTION_TIMEOUT` |
+| `AEGIS_SUPERVISOR_RESET_KEY` | `KIRRA_SUPERVISOR_RESET_KEY` |
+| `AEGIS_PORT` / `AEGIS_STANDBY_PORT` (compose/install helpers) | `KIRRA_PORT` / `KIRRA_STANDBY_PORT` |
+
+### Build / link artifacts
+| Old | New |
+|-----|-----|
+| binary `aegis_verifier_service` | `kirra_verifier_service` |
+| binary `aegis_carla_client` | `kirra_carla_client` |
+| link flag `-laegis_runtime_sdk` | `-lkirra_runtime_sdk` (lib `kirra_runtime_sdk`) |
+| release archive `aegis-<ver>-<target>.tar.gz` | `kirra-<ver>-<target>.tar.gz` |
+
+### Deploy / runtime layout
+| Old | New |
+|-----|-----|
+| HTTP identity header `x-aegis-client-id` | `x-kirra-client-id` |
+| systemd unit `aegis-verifier.service` | `kirra-verifier.service` |
+| systemd unit `aegis-dashboard.service` | `kirra-dashboard.service` |
+| config dir `/etc/aegis`, env file `/etc/aegis/aegis.env` | `/etc/kirra`, `/etc/kirra/kirra.env` |
+| data dir `/var/lib/aegis`, db `aegis.db` | `/var/lib/kirra`, `kirra.db` |
+| log dir `/var/log/aegis` | `/var/log/kirra` |
+| system user/group `aegis` | `kirra` |
+| docker-compose services/volumes `aegis-verifier`, `aegis-data` | `kirra-verifier`, `kirra-data` |
+| npm package `aegis-dashboard` | `kirra-dashboard` |
+| GitHub repo `justinlooney/aegis` | `justinlooney/kirra-runtime-sdk` |
+| ROS 2 package refs `aegis_safety` (scripts) | `kirra_safety` |
+
+## Deliberately NOT renamed (kept on purpose)
+
+To avoid corrupting history and the formal traceability namespace, the
+following `Aegis`/`AEGIS` references are **intentional** and were left intact:
+
+1. **The `AEGIS-*` safety-case document-ID scheme** — `AEGIS-SC-000`,
+   `AEGIS-HARA-001`, `AEGIS-SG-001`, `AEGIS-CG-001`, `AEGIS-ROAD-001`,
+   `AEGIS-RTM-001`, `AEGIS-SA-001`, `AEGIS-F3269-001`, `AEGIS-61508-001`,
+   `AEGIS-STD-001`, etc. — and the `≅ AEGIS SG-xxx` cross-map comments in the
+   code. These are a controlled predecessor-framework identifier namespace
+   that the current `KIRRA-*` / `OCCY-*` documents deliberately cross-reference;
+   `docs/releases/v1.5.0.md` records that this scheme's rename is tracked
+   separately. They are not build-affecting.
+2. **Historical artifacts** — the `docs/releases/v1.5.0.md` release note
+   ("published under the previous Aegis branding"), the README v1.1.1
+   changelog entry, the `### Foundation (Kirra / Aegis line)` doc-table
+   heading, and the `work/` planning/decision/done logs (which deliberately
+   reference the old names — e.g. grep patterns hunting for `AegisGovernor` to
+   confirm its absence, and the #43 task definition itself). Renaming history
+   corrupts it.
+3. **`CLAUDE.md`** path-avoidance note (`not /home/user/aegis`) — it
+   deliberately names the old path to warn against using it.
+
+> Note for reviewers: `work/github-projects.md` still contains a stale
+> `parko-aegis` crate reference and an `aegis-integration` GitHub label name.
+> These live in a project-tracking doc (kept verbatim as planning history) and
+> are not build-affecting; rename them in a separate project-board pass if the
+> label is to be renamed in GitHub itself.

--- a/docs/action_filter.md
+++ b/docs/action_filter.md
@@ -1,10 +1,10 @@
-# Aegis Action Filter — LLM to Actuator Safety Enforcement
+# Kirra Action Filter — LLM to Actuator Safety Enforcement
 
 ## What It Is
 
-The Aegis Action Filter is the enforcement layer between AI model output and physical actuators. When a large language model generates a command — whether via OpenAI function calling, a LangChain tool invocation, or raw JSON output from a custom agent — the Action Filter intercepts that command before it reaches any hardware and evaluates it against the live fleet posture.
+The Kirra Action Filter is the enforcement layer between AI model output and physical actuators. When a large language model generates a command — whether via OpenAI function calling, a LangChain tool invocation, or raw JSON output from a custom agent — the Action Filter intercepts that command before it reaches any hardware and evaluates it against the live fleet posture.
 
-The filter operates on the principle that AI models are not trusted to make physical safety decisions. They can reason about goals, choose strategies, and select appropriate actions — but the final determination of whether an action is physically safe to execute at this exact moment, given the current state of the fleet, belongs to Aegis. This separation of concerns is not optional. A model that hallucinates a velocity of 999 m/s must be stopped at the software layer with the same certainty that a hardware interlock would stop it.
+The filter operates on the principle that AI models are not trusted to make physical safety decisions. They can reason about goals, choose strategies, and select appropriate actions — but the final determination of whether an action is physically safe to execute at this exact moment, given the current state of the fleet, belongs to Kirra. This separation of concerns is not optional. A model that hallucinates a velocity of 999 m/s must be stopped at the software layer with the same certainty that a hardware interlock would stop it.
 
 The Action Filter combines three independent enforcement mechanisms: posture-aware policy (what is permitted in the current system state), kinematic contract validation (are the physical parameters within the safe operating envelope), and action-type whitelisting (is this a recognized, permitted action at all). All three must pass for a command to be allowed. Any single failure results in an unambiguous denial with a structured reason code that is logged to the SHA-256 hash-chained audit ledger.
 
@@ -21,7 +21,7 @@ The Action Filter combines three independent enforcement mechanisms: posture-awa
                           ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │              POST /action_filter/evaluate                           │
-│         (Bearer token + x-aegis-client-id required)                │
+│         (Bearer token + x-kirra-client-id required)                │
 │                                                                     │
 │  Stage 1: JSON Schema Validation                                    │
 │    Malformed JSON → 400 BAD_REQUEST (logged, never 422 or 500)      │
@@ -68,9 +68,9 @@ Each stage is independent and runs in sequence. A failure at any stage short-cir
 
 **The Hallucination Problem.** Language models generate text that is statistically plausible, not physically safe. A model instructed to "move the robot forward as fast as possible" may output a velocity command that exceeds the physical design limits of the platform. A model that has seen robotics tutorials in its training data may confidently emit a `deploy_payload_at_max_velocity` command that does not correspond to any registered action type on the actual fleet. Without a hard enforcement layer, these hallucinations become actuator commands.
 
-Aegis eliminates this failure mode at the transport layer. The model's output is treated as an *intent claim* — a request to perform an action — rather than an authorized instruction. The claim is evaluated against ground truth (live fleet posture, kinematic contracts, registered action whitelist) and either approved or denied. The model never touches hardware directly.
+Kirra eliminates this failure mode at the transport layer. The model's output is treated as an *intent claim* — a request to perform an action — rather than an authorized instruction. The claim is evaluated against ground truth (live fleet posture, kinematic contracts, registered action whitelist) and either approved or denied. The model never touches hardware directly.
 
-**Posture-Aware Restriction.** An action that would be safe under nominal conditions may be catastrophic when the fleet is in a degraded state. If a sensor fusion node has reported a hardware fault, the fleet posture transitions to `Degraded`. In Degraded posture, all kinetic writes are denied regardless of the model's confidence in its command. The model does not know — and cannot be expected to know — the real-time health state of every fleet component. Aegis enforces posture-appropriate restrictions automatically and transparently.
+**Posture-Aware Restriction.** An action that would be safe under nominal conditions may be catastrophic when the fleet is in a degraded state. If a sensor fusion node has reported a hardware fault, the fleet posture transitions to `Degraded`. In Degraded posture, all kinetic writes are denied regardless of the model's confidence in its command. The model does not know — and cannot be expected to know — the real-time health state of every fleet component. Kirra enforces posture-appropriate restrictions automatically and transparently.
 
 **The Audit Trail.** Every action evaluated by the filter is logged to a SHA-256 hash-chained audit ledger. The chain links each record to its predecessor via a cryptographic hash, making retroactive modification detectable. This means that every command an AI model attempted — whether allowed or denied — is permanently recorded with the fleet posture at evaluation time, the request identifier, and the reason for the decision. For regulated deployments (aerospace, medical robotics, autonomous vehicles), this ledger provides the evidence trail required for incident investigation and certification.
 
@@ -97,7 +97,7 @@ The design principle is explicit: anything not on the whitelist is denied. There
 
 ### POST /action_filter/evaluate
 
-**Authentication:** `Authorization: Bearer <AEGIS_ADMIN_TOKEN>` and `x-aegis-client-id: <client-id>` headers required.
+**Authentication:** `Authorization: Bearer <KIRRA_ADMIN_TOKEN>` and `x-kirra-client-id: <client-id>` headers required.
 
 **Request Schema:**
 
@@ -154,7 +154,7 @@ Allow (nominal, valid kinematics):
 ```bash
 curl -s -X POST http://localhost:8090/action_filter/evaluate \
   -H "Authorization: Bearer your-admin-token" \
-  -H "x-aegis-client-id: my-agent" \
+  -H "x-kirra-client-id: my-agent" \
   -H "Content-Type: application/json" \
   -d '{
     "action_type": "cmd_vel",
@@ -170,7 +170,7 @@ Deny (hallucinated velocity):
 ```bash
 curl -s -X POST http://localhost:8090/action_filter/evaluate \
   -H "Authorization: Bearer your-admin-token" \
-  -H "x-aegis-client-id: my-agent" \
+  -H "x-kirra-client-id: my-agent" \
   -H "Content-Type: application/json" \
   -d '{
     "action_type": "cmd_vel",
@@ -186,7 +186,7 @@ Deny (degraded posture):
 ```bash
 curl -s -X POST http://localhost:8090/action_filter/evaluate \
   -H "Authorization: Bearer your-admin-token" \
-  -H "x-aegis-client-id: my-agent" \
+  -H "x-kirra-client-id: my-agent" \
   -H "Content-Type: application/json" \
   -d '{
     "action_type": "cmd_vel",
@@ -202,7 +202,7 @@ Deny (malformed JSON):
 ```bash
 curl -s -X POST http://localhost:8090/action_filter/evaluate \
   -H "Authorization: Bearer your-admin-token" \
-  -H "x-aegis-client-id: my-agent" \
+  -H "x-kirra-client-id: my-agent" \
   -H "Content-Type: application/json" \
   -d 'not valid json'
 # Response: {"error":"MALFORMED_REQUEST","detail":"...","allowed":false}  HTTP 400
@@ -229,8 +229,8 @@ The Action Filter is specifically designed to contain three categories of AI mod
 ```python
 # Define the action as an OpenAI function
 check_action = {
-    "name": "check_action_with_aegis",
-    "description": "Validate a robot action through Aegis safety filter before execution",
+    "name": "check_action_with_kirra",
+    "description": "Validate a robot action through Kirra safety filter before execution",
     "parameters": {
         "type": "object",
         "properties": {
@@ -246,8 +246,8 @@ check_action = {
 # In the agent loop: always check before executing
 def execute_if_safe(action_type, target_node, risk_class, payload):
     result = requests.post(
-        "http://aegis:8090/action_filter/evaluate",
-        headers={"Authorization": "Bearer $TOKEN", "x-aegis-client-id": "gpt-agent"},
+        "http://kirra:8090/action_filter/evaluate",
+        headers={"Authorization": "Bearer $TOKEN", "x-kirra-client-id": "gpt-agent"},
         json={"action_type": action_type, "target_node": target_node,
               "risk_class": risk_class, "payload": payload}
     ).json()
@@ -267,8 +267,8 @@ from langchain.tools import tool
 
 @tool
 def move_robot(target_node: str, linear_x: float, angular_z: float) -> str:
-    """Move a robot at the specified velocity. Always filtered by Aegis."""
-    result = aegis_check("cmd_vel", target_node, "kinetic_write",
+    """Move a robot at the specified velocity. Always filtered by Kirra."""
+    result = kirra_check("cmd_vel", target_node, "kinetic_write",
                          {"linear_x": linear_x, "linear_y": 0.0, "linear_z": 0.0,
                           "angular_x": 0.0, "angular_y": 0.0, "angular_z": angular_z})
     if result["allowed"]:
@@ -281,16 +281,16 @@ def move_robot(target_node: str, linear_x: float, angular_z: float) -> str:
 **Direct JSON (any agent framework):**
 
 ```python
-# Universal pattern: every AI-generated action becomes an HTTP call to Aegis
+# Universal pattern: every AI-generated action becomes an HTTP call to Kirra
 # before touching any hardware interface.
 action = ai_model.generate_action(current_state)  # returns dict
-aegis_result = requests.post("http://aegis:8090/action_filter/evaluate",
+kirra_result = requests.post("http://kirra:8090/action_filter/evaluate",
                              headers=auth_headers, json=action).json()
-if aegis_result["allowed"]:
+if kirra_result["allowed"]:
     robot_interface.execute(action)
 ```
 
-The integration pattern is identical across frameworks: the AI model decides *what* to do; Aegis decides *whether* it is safe to do it right now.
+The integration pattern is identical across frameworks: the AI model decides *what* to do; Kirra decides *whether* it is safe to do it right now.
 
 ---
 

--- a/docs/kinematics_envelope_protection.md
+++ b/docs/kinematics_envelope_protection.md
@@ -1,7 +1,7 @@
-# Aegis v2.0.0 — AV Kinematics Flight Envelope Protection
+# Kirra v2.0.0 — AV Kinematics Flight Envelope Protection
 
 This document freezes the deterministic, physical safety invariants used to gate motion
-planning outputs before they reach vehicle actuators. Aegis does not generate trajectories;
+planning outputs before they reach vehicle actuators. Kirra does not generate trajectories;
 it intercepts proposed commands and either passes, clamps, or drops them based on hard
 physical contracts.
 
@@ -9,12 +9,12 @@ physical contracts.
 
 ## 1. Safety Kernel Invariants
 
-Aegis operates on an uncompromising execution contract for every `ProposedVehicleCommand`
+Kirra operates on an uncompromising execution contract for every `ProposedVehicleCommand`
 that arrives at the actuator policy layer:
 
-- **Passive Monitoring vs. Active Enforcement**: Aegis does not generate trajectories; it
+- **Passive Monitoring vs. Active Enforcement**: Kirra does not generate trajectories; it
   intercepts proposed `CmdVel` or actuator targets. The perception and planning stacks own
-  their own reliability; Aegis owns admissibility.
+  their own reliability; Kirra owns admissibility.
 
 - **Fail-Closed Clamping**: Commands exceeding hard limits are either smoothly clamped to
   the maximum safe boundary (`EnforceAction::Clamp*`) or dropped entirely
@@ -101,16 +101,16 @@ safe haven.
 
 These three concepts are distinct:
 
-- **Safe Stop** (`LockedOut`): Commanded by Aegis when the fleet posture is `LockedOut`.
+- **Safe Stop** (`LockedOut`): Commanded by Kirra when the fleet posture is `LockedOut`.
   All actuator write commands are dropped. The vehicle transitions to a controlled halt.
   Not a crash stop — braking is still governed by `max_brake_mps2`.
 
 - **MRC (Minimal Risk Condition)** (`Degraded`): The vehicle continues to operate but under
-  the `mrc_fallback_profile()`. Planning continues; Aegis enforces the tighter envelope.
+  the `mrc_fallback_profile()`. Planning continues; Kirra enforces the tighter envelope.
   The system can recover to `Nominal` if degraded nodes recover.
 
 - **Emergency Brake** (external, out of scope): A separate hard-wired electrical interlock
-  layer. Aegis does not replace this; it operates upstream of it.
+  layer. Kirra does not replace this; it operates upstream of it.
 
 ---
 
@@ -124,7 +124,7 @@ module and belong in other system layers:
 - **Traffic law compliance** — behavioral planning stack responsibility
 - **Emergency braking (hardware interlock)** — physical brake controller, not software
 
-Aegis enforces that the command is *physically admissible for the vehicle platform*. Whether
+Kirra enforces that the command is *physically admissible for the vehicle platform*. Whether
 the command is *contextually correct for the environment* is the planner's problem.
 
 ---

--- a/docs/llm_integration_guide.md
+++ b/docs/llm_integration_guide.md
@@ -1,6 +1,6 @@
-# Aegis LLM Integration Guide
+# Kirra LLM Integration Guide
 
-Practical guide for connecting AI agents and language model pipelines to the Aegis Action Filter safety enforcement layer.
+Practical guide for connecting AI agents and language model pipelines to the Kirra Action Filter safety enforcement layer.
 
 ---
 
@@ -8,11 +8,11 @@ Practical guide for connecting AI agents and language model pipelines to the Aeg
 
 The fastest path to LLM-safe actuator control: intercept every AI-generated action with a single HTTP call before sending it to hardware.
 
-**Step 1.** Start Aegis with an admin token:
+**Step 1.** Start Kirra with an admin token:
 ```bash
-export AEGIS_ADMIN_TOKEN="your-secret-token"
-export AEGIS_SUPERVISOR_RESET_KEY="your-reset-key"
-./aegis_verifier_service
+export KIRRA_ADMIN_TOKEN="your-secret-token"
+export KIRRA_SUPERVISOR_RESET_KEY="your-reset-key"
+./kirra_verifier_service
 # Listening on 0.0.0.0:8090
 ```
 
@@ -20,7 +20,7 @@ export AEGIS_SUPERVISOR_RESET_KEY="your-reset-key"
 ```bash
 curl -s -X POST http://localhost:8090/action_filter/evaluate \
   -H "Authorization: Bearer your-secret-token" \
-  -H "x-aegis-client-id: my-llm-agent" \
+  -H "x-kirra-client-id: my-llm-agent" \
   -H "Content-Type: application/json" \
   -d '{
     "action_type": "cmd_vel",
@@ -55,17 +55,17 @@ That's the entire integration. The rest of this guide covers authentication, han
 
 ## Authentication
 
-Aegis uses two authentication mechanisms for the action filter endpoint:
+Kirra uses two authentication mechanisms for the action filter endpoint:
 
 ### Bearer Token (Required on all protected routes)
 
 All calls to `/action_filter/evaluate` require an `Authorization` header with the admin bearer token:
 
 ```
-Authorization: Bearer <AEGIS_ADMIN_TOKEN>
+Authorization: Bearer <KIRRA_ADMIN_TOKEN>
 ```
 
-The token is read from the `AEGIS_ADMIN_TOKEN` environment variable at startup. If the variable is absent or empty, the service returns `503 Service Unavailable` on all protected routes (fail-closed, not fail-open). There are no hardcoded fallback tokens.
+The token is read from the `KIRRA_ADMIN_TOKEN` environment variable at startup. If the variable is absent or empty, the service returns `503 Service Unavailable` on all protected routes (fail-closed, not fail-open). There are no hardcoded fallback tokens.
 
 Token comparison uses constant-time comparison to prevent timing attacks. Never use standard string equality for token comparison in your own code that wraps this API.
 
@@ -74,23 +74,23 @@ Token comparison uses constant-time comparison to prevent timing attacks. Never 
 The `/action_filter/evaluate` endpoint is in the identity-gated tier, which requires a client identity header in addition to the bearer token:
 
 ```
-x-aegis-client-id: <your-agent-identifier>
+x-kirra-client-id: <your-agent-identifier>
 ```
 
-The header name defaults to `x-aegis-client-id` and can be configured via the `AEGIS_CLIENT_ID_HEADER` environment variable. The value is a free-form string identifying the AI agent or orchestration system making the request (e.g., `"openai-agent-001"`, `"langchain-robot-controller"`, `"my-custom-planner"`).
+The header name defaults to `x-kirra-client-id` and can be configured via the `KIRRA_CLIENT_ID_HEADER` environment variable. The value is a free-form string identifying the AI agent or orchestration system making the request (e.g., `"openai-agent-001"`, `"langchain-robot-controller"`, `"my-custom-planner"`).
 
-This header is required when `AEGIS_TRUSTED_INGRESS_MODE=true`. In default configuration (`AEGIS_TRUSTED_INGRESS_MODE=false`), the header is accepted but not strictly required. For production deployments, enable trusted ingress mode to enforce strict client identity.
+This header is required when `KIRRA_TRUSTED_INGRESS_MODE=true`. In default configuration (`KIRRA_TRUSTED_INGRESS_MODE=false`), the header is accepted but not strictly required. For production deployments, enable trusted ingress mode to enforce strict client identity.
 
 **Complete authenticated request headers:**
 ```
-Authorization: Bearer <AEGIS_ADMIN_TOKEN>
-x-aegis-client-id: <client-identifier>
+Authorization: Bearer <KIRRA_ADMIN_TOKEN>
+x-kirra-client-id: <client-identifier>
 Content-Type: application/json
 ```
 
 ### Token Security Recommendations
 
-- Store `AEGIS_ADMIN_TOKEN` in a secrets manager (AWS Secrets Manager, HashiCorp Vault, Kubernetes Secrets). Never put it in code or version control.
+- Store `KIRRA_ADMIN_TOKEN` in a secrets manager (AWS Secrets Manager, HashiCorp Vault, Kubernetes Secrets). Never put it in code or version control.
 - Rotate tokens regularly. The `/system/audit/rotate-signing-key` endpoint supports key rotation for the audit chain signing key.
 - Use separate client IDs per agent or deployment (e.g., `"gpt4-prod-001"`, `"claude-staging-002"`). This allows per-agent audit filtering.
 - In Kubernetes deployments, inject the token as an environment variable from a Secret, not a ConfigMap.
@@ -190,7 +190,7 @@ The action filter returns one of three effective outcomes:
 The action is approved. Your agent loop should proceed with hardware execution.
 
 ```python
-result = check_with_aegis(action)
+result = check_with_kirra(action)
 if result["allowed"]:
     hardware_client.execute(action)
     log.info(f"Executed: {action['action_type']} on {action['target_node']}")
@@ -223,7 +223,7 @@ The action itself is invalid, regardless of posture. The model generated an out-
         # Model hallucinated an unsafe velocity — inform and retry with clamped value
         log.error(f"Kinematic envelope breach: {action['payload']}")
         clamped = clamp_to_safe_envelope(action["payload"])
-        retry_with_aegis(action["action_type"], action["target_node"], clamped)
+        retry_with_kirra(action["action_type"], action["target_node"], clamped)
         
     elif reason == "UNKNOWN_ACTION_TYPE":
         # Model invented a non-existent action — this is a hallucination
@@ -236,13 +236,13 @@ The action itself is invalid, regardless of posture. The model generated an out-
         # Add retry with forced JSON schema validation at the model layer
 ```
 
-The key principle: `allowed: false` means **stop**. Do not retry with the same parameters without understanding and addressing the reason code. Do not try to route around Aegis. The audit trail records every attempt.
+The key principle: `allowed: false` means **stop**. Do not retry with the same parameters without understanding and addressing the reason code. Do not try to route around Kirra. The audit trail records every attempt.
 
 ---
 
 ## Registering the AI Model as a Fleet Node
 
-An AI model or agent can be registered as a fleet node. This allows Aegis to track its trust state and, critically, mark it `Untrusted` if it begins exhibiting anomalous behavior (repeated hallucinated commands, out-of-envelope requests, unexpected action types).
+An AI model or agent can be registered as a fleet node. This allows Kirra to track its trust state and, critically, mark it `Untrusted` if it begins exhibiting anomalous behavior (repeated hallucinated commands, out-of-envelope requests, unexpected action types).
 
 **Step 1. Register the model as a node:**
 
@@ -289,7 +289,7 @@ The posture stream lets your agent proactively know when the fleet state changes
 ```bash
 curl -N http://localhost:8090/system/posture/stream \
   -H "Authorization: Bearer your-admin-token" \
-  -H "x-aegis-client-id: my-llm-agent" \
+  -H "x-kirra-client-id: my-llm-agent" \
   -H "Accept: text/event-stream"
 ```
 
@@ -305,12 +305,12 @@ data: {"event_type":"NODE_STATUS_CHANGED","node_id":"sensor_01","emitted_at_ms":
 import sseclient
 import requests
 
-def subscribe_posture_stream(aegis_url, token, client_id):
+def subscribe_posture_stream(kirra_url, token, client_id):
     resp = requests.get(
-        f"{aegis_url}/system/posture/stream",
+        f"{kirra_url}/system/posture/stream",
         headers={
             "Authorization": f"Bearer {token}",
-            "x-aegis-client-id": client_id,
+            "x-kirra-client-id": client_id,
             "Accept": "text/event-stream",
         },
         stream=True,
@@ -342,7 +342,7 @@ Subscribe to the posture stream in a background thread at agent startup. This el
 
 **1. Subscribe to the SSE stream at startup.** Don't wait for a denied action to discover that the fleet is degraded. A background thread subscribed to `/system/posture/stream` gives you real-time visibility into fleet health changes and lets your agent switch modes proactively.
 
-**2. Always check `allowed` before any hardware call.** There should be no code path in your agent loop that sends a command to hardware without first receiving `allowed: true` from Aegis. Treat the Aegis response as a gate, not a suggestion.
+**2. Always check `allowed` before any hardware call.** There should be no code path in your agent loop that sends a command to hardware without first receiving `allowed: true` from Kirra. Treat the Kirra response as a gate, not a suggestion.
 
 **3. Use structured reason codes for agent behavior.** The `reason` field is a stable, machine-readable code. Build your agent loop to branch on reason codes rather than parsing free-text messages. `KINEMATIC_ENVELOPE_BREACH` should trigger a different response than `UNKNOWN_ACTION_TYPE` — the first suggests a clamp-and-retry, the second suggests a hallucination that needs to be logged for model evaluation.
 
@@ -350,9 +350,9 @@ Subscribe to the posture stream in a background thread at agent startup. This el
 
 **5. Register your AI model as a fleet node.** This enables the dependency graph to propagate trust state from the model to its downstream actuators. A hallucinating model can be marked `Untrusted`, which cascades to `Degraded` posture for any actuator that depends on it for commands.
 
-**6. Enable trusted ingress mode in production.** Set `AEGIS_TRUSTED_INGRESS_MODE=true` and ensure every client sends a unique `x-aegis-client-id`. This enables per-agent audit filtering and prevents unauthenticated clients from reaching the action filter.
+**6. Enable trusted ingress mode in production.** Set `KIRRA_TRUSTED_INGRESS_MODE=true` and ensure every client sends a unique `x-kirra-client-id`. This enables per-agent audit filtering and prevents unauthenticated clients from reaching the action filter.
 
-**7. Set connection timeouts.** Aegis is a synchronous HTTP endpoint. Set a 5-second timeout on your HTTP client. If Aegis is unreachable, treat the failure as a deny and halt the action. Never default to executing hardware commands when the safety filter is unavailable.
+**7. Set connection timeouts.** Kirra is a synchronous HTTP endpoint. Set a 5-second timeout on your HTTP client. If Kirra is unreachable, treat the failure as a deny and halt the action. Never default to executing hardware commands when the safety filter is unavailable.
 
 **8. Use the audit export for compliance.** The `/system/audit/export` endpoint provides a paginated, hash-chained export of all action filter decisions. Export and archive this log periodically for incident investigation, regulatory compliance, and model evaluation data.
 

--- a/docs/multi_asset_fabric.md
+++ b/docs/multi_asset_fabric.md
@@ -4,7 +4,7 @@
 
 ### The Problem
 
-The original Aegis runtime was designed around a single-fleet model: one DAG of trust nodes, one posture state, one set of kinematic limits. This works well when all devices operate under a unified trust boundary, but modern deployments involve heterogeneous physical systems — autonomous vehicles, warehouse robots, drones, industrial controllers, and infrastructure nodes — each with radically different safety envelopes, operational roles, and failure modes.
+The original Kirra runtime was designed around a single-fleet model: one DAG of trust nodes, one posture state, one set of kinematic limits. This works well when all devices operate under a unified trust boundary, but modern deployments involve heterogeneous physical systems — autonomous vehicles, warehouse robots, drones, industrial controllers, and infrastructure nodes — each with radically different safety envelopes, operational roles, and failure modes.
 
 A single `FleetPosture` cannot meaningfully distinguish between a 35 m/s autonomous highway vehicle and a 0.5 m/s warehouse robot. Applying the same lockout or degraded state to both simultaneously ignores the operational reality that a slow-moving robot has very different consequences from a high-speed AV going LockedOut.
 
@@ -185,7 +185,7 @@ The log is append-only and all entries are kept in memory during runtime. For du
 
 ## API Reference
 
-All fabric endpoints require Bearer token authentication (`AEGIS_ADMIN_TOKEN`).
+All fabric endpoints require Bearer token authentication (`KIRRA_ADMIN_TOKEN`).
 
 ### POST /fabric/assets/register
 

--- a/docs/policy_layer_wiring.md
+++ b/docs/policy_layer_wiring.md
@@ -1,6 +1,6 @@
-# Wiring `enforce_actuator_safety_envelope` into `aegis_verifier_service.rs`
+# Wiring `enforce_actuator_safety_envelope` into `kirra_verifier_service.rs`
 
-This document records the exact diff to apply to `src/bin/aegis_verifier_service.rs`
+This document records the exact diff to apply to `src/bin/kirra_verifier_service.rs`
 to integrate the actuator safety envelope middleware introduced in v2.1.0.
 
 ---

--- a/docs/protocol_adapters.md
+++ b/docs/protocol_adapters.md
@@ -1,8 +1,8 @@
-# Aegis Protocol Adapters — Industrial Safety Integration
+# Kirra Protocol Adapters — Industrial Safety Integration
 
 ## Overview
 
-Aegis functions as a universal safety kernel across the industrial automation stack. Protocol adapters translate protocol-specific messages into Aegis `OperationalCommand` types, which are then evaluated against the current fleet posture to determine whether a command is safe to execute.
+Kirra functions as a universal safety kernel across the industrial automation stack. Protocol adapters translate protocol-specific messages into Kirra `OperationalCommand` types, which are then evaluated against the current fleet posture to determine whether a command is safe to execute.
 
 The adapter layer is intentionally thin — no external protocol libraries are required. Each adapter implements the message classification logic directly in pure Rust, keeping the safety-critical path free of third-party dependencies.
 
@@ -56,8 +56,8 @@ Modbus is the oldest and most widely deployed industrial protocol. It uses a sim
 
 ```bash
 curl -X POST http://localhost:8090/industrial/evaluate \
-  -H "Authorization: Bearer $AEGIS_ADMIN_TOKEN" \
-  -H "x-aegis-client-id: modbus-gateway-01" \
+  -H "Authorization: Bearer $KIRRA_ADMIN_TOKEN" \
+  -H "x-kirra-client-id: modbus-gateway-01" \
   -H "Content-Type: application/json" \
   -d '{
     "protocol": "modbus",
@@ -122,8 +122,8 @@ The following CIP classes are flagged as `safety_relevant=true` and receive elev
 **Read a tag (allowed in any posture):**
 ```bash
 curl -X POST http://localhost:8090/industrial/ethernet-ip/evaluate \
-  -H "Authorization: Bearer $AEGIS_ADMIN_TOKEN" \
-  -H "x-aegis-client-id: eip-gateway-01" \
+  -H "Authorization: Bearer $KIRRA_ADMIN_TOKEN" \
+  -H "x-kirra-client-id: eip-gateway-01" \
   -H "Content-Type: application/json" \
   -d '{
     "command_code": 101,
@@ -159,8 +159,8 @@ curl -X POST http://localhost:8090/industrial/ethernet-ip/evaluate \
 **Unified endpoint:**
 ```bash
 curl -X POST http://localhost:8090/industrial/evaluate \
-  -H "Authorization: Bearer $AEGIS_ADMIN_TOKEN" \
-  -H "x-aegis-client-id: eip-gateway-01" \
+  -H "Authorization: Bearer $KIRRA_ADMIN_TOKEN" \
+  -H "x-kirra-client-id: eip-gateway-01" \
   -d '{
     "protocol": "ethernet_ip",
     "message": {
@@ -227,8 +227,8 @@ NMT commands that take a node offline set `triggers_recalculation=true`, signali
 
 ```bash
 curl -X POST http://localhost:8090/industrial/canopen/evaluate \
-  -H "Authorization: Bearer $AEGIS_ADMIN_TOKEN" \
-  -H "x-aegis-client-id: can-gateway-01" \
+  -H "Authorization: Bearer $KIRRA_ADMIN_TOKEN" \
+  -H "x-kirra-client-id: can-gateway-01" \
   -d '{
     "node_id": 5,
     "function_code": 3,
@@ -264,7 +264,7 @@ curl -X POST http://localhost:8090/industrial/canopen/evaluate \
 
 DNP3 (Distributed Network Protocol 3) is the dominant protocol for SCADA systems controlling critical infrastructure. It was designed for high-reliability, low-bandwidth environments with inherent support for data integrity and time synchronization.
 
-**Security Note:** DNP3 was designed before cybersecurity was a concern. Broadcast commands (destination address `0xFFFF`) are a significant attack vector — a single malicious packet can command every device on the network simultaneously. Aegis always creates an audit entry for broadcast commands regardless of posture.
+**Security Note:** DNP3 was designed before cybersecurity was a concern. Broadcast commands (destination address `0xFFFF`) are a significant attack vector — a single malicious packet can command every device on the network simultaneously. Kirra always creates an audit entry for broadcast commands regardless of posture.
 
 ### Function Code Mapping
 
@@ -292,15 +292,15 @@ DNP3 (Distributed Network Protocol 3) is the dominant protocol for SCADA systems
 
 ### Broadcast Detection
 
-Any message with `dest_address == 0xFFFF` is flagged as a broadcast. Aegis always creates an audit chain entry for broadcast commands with event type `DNP3_BROADCAST_COMMAND`, regardless of whether the command is allowed.
+Any message with `dest_address == 0xFFFF` is flagged as a broadcast. Kirra always creates an audit chain entry for broadcast commands with event type `DNP3_BROADCAST_COMMAND`, regardless of whether the command is allowed.
 
 ### Example Requests
 
 **Read (allowed in any posture):**
 ```bash
 curl -X POST http://localhost:8090/industrial/dnp3/evaluate \
-  -H "Authorization: Bearer $AEGIS_ADMIN_TOKEN" \
-  -H "x-aegis-client-id: dnp3-gateway-01" \
+  -H "Authorization: Bearer $KIRRA_ADMIN_TOKEN" \
+  -H "x-kirra-client-id: dnp3-gateway-01" \
   -d '{
     "source_address": 1,
     "dest_address": 10,
@@ -337,8 +337,8 @@ All five protocols can be evaluated through a single endpoint using the `protoco
 
 ```
 POST /industrial/evaluate
-Authorization: Bearer <AEGIS_ADMIN_TOKEN>
-x-aegis-client-id: <client-id>
+Authorization: Bearer <KIRRA_ADMIN_TOKEN>
+x-kirra-client-id: <client-id>
 Content-Type: application/json
 
 {
@@ -366,11 +366,11 @@ The `message` field schema varies by protocol. See the per-protocol sections abo
 
 ## Audit Trail
 
-Every industrial evaluation is subject to the Aegis audit chain:
+Every industrial evaluation is subject to the Kirra audit chain:
 
 - **Denials** always create an `INDUSTRIAL_ACTION_DENIED` entry
 - **DNP3 broadcast commands** always create a `DNP3_BROADCAST_COMMAND` entry
 - **CANOpen NMT node-offline transitions** create a `CANOPEN_NMT_NODE_OFFLINE` entry
 - **EtherNet/IP allowed broadcasts** on safety-relevant classes create an `INDUSTRIAL_ACTION_ALLOWED_BROADCAST` entry
 
-All entries are SHA-256 hash-chained and optionally Ed25519-signed (when `AEGIS_LOG_SIGNING_KEY` is set).
+All entries are SHA-256 hash-chained and optionally Ed25519-signed (when `KIRRA_LOG_SIGNING_KEY` is set).

--- a/docs/ros2_interlock.md
+++ b/docs/ros2_interlock.md
@@ -1,8 +1,8 @@
-# Aegis ROS2 Safety Interlock
+# Kirra ROS2 Safety Interlock
 
 ## Architecture
 
-The Aegis ROS2 safety interlock sits between your navigation stack (Nav2, AI planners, or any autonomous path-following system) and your physical motor controllers. Every velocity command is submitted to the Aegis verifier for kinematic enforcement and fleet posture checking before it reaches hardware. The package provides three ROS2 nodes that work together:
+The Kirra ROS2 safety interlock sits between your navigation stack (Nav2, AI planners, or any autonomous path-following system) and your physical motor controllers. Every velocity command is submitted to the Kirra verifier for kinematic enforcement and fleet posture checking before it reaches hardware. The package provides three ROS2 nodes that work together:
 
 ```
 Nav2 / AI Planner
@@ -26,24 +26,24 @@ Nav2 / AI Planner
 Additional nodes run in parallel:
 
 ```
-sensor_monitor ---- POST /fleet/diagnostics/report ---> Aegis
+sensor_monitor ---- POST /fleet/diagnostics/report ---> Kirra
                  ^
     /scan, /imu/data, /odom, /camera/depth/image_raw
 
-posture_subscriber <- SSE /system/posture/stream <- Aegis
+posture_subscriber <- SSE /system/posture/stream <- Kirra
                  |
-                 +-> /aegis/fleet_posture  (String)
-                 +-> /aegis/posture_events (String)
+                 +-> /kirra/fleet_posture  (String)
+                 +-> /kirra/posture_events (String)
                  +-> /cmd_vel  ZERO (on LockedOut transition)
 ```
 
 ### Node Responsibilities
 
-**cmd_vel_interceptor** — The critical path node. It intercepts every `geometry_msgs/Twist` on its input topic, converts it to an Aegis `ProposedVehicleCommand` using a bicycle-model approximation for the mecanum drive geometry, and POSTs it to `/actuator/motion/command`. Aegis returns an `EnforceAction` (`Allow`, `Clamp`, or `DenyBreach`) with optionally clamped velocity and steering values. The interceptor reconstructs a safe Twist preserving the original lateral motion ratios and publishes it to the output topic. On any failure (timeout, connection error, denied, unexpected HTTP status), it publishes a zero-velocity Twist and logs the action — fail-closed by default.
+**cmd_vel_interceptor** — The critical path node. It intercepts every `geometry_msgs/Twist` on its input topic, converts it to an Kirra `ProposedVehicleCommand` using a bicycle-model approximation for the mecanum drive geometry, and POSTs it to `/actuator/motion/command`. Kirra returns an `EnforceAction` (`Allow`, `Clamp`, or `DenyBreach`) with optionally clamped velocity and steering values. The interceptor reconstructs a safe Twist preserving the original lateral motion ratios and publishes it to the output topic. On any failure (timeout, connection error, denied, unexpected HTTP status), it publishes a zero-velocity Twist and logs the action — fail-closed by default.
 
-**sensor_monitor** — Monitors ROS2 sensor topics and continuously reports confidence scores to Aegis via `/fleet/diagnostics/report`. It tracks message freshness, frequency (Hz), and quality metrics (IMU covariance) for four sensors: lidar_front, depth_camera, imu_primary, and wheel_encoders. Aegis uses these reports to compute per-node trust states and fleet-wide posture via its DAG traversal algorithm. When sensors degrade or go silent, posture transitions propagate through the dependency graph and the interceptor starts receiving denials or restricted commands.
+**sensor_monitor** — Monitors ROS2 sensor topics and continuously reports confidence scores to Kirra via `/fleet/diagnostics/report`. It tracks message freshness, frequency (Hz), and quality metrics (IMU covariance) for four sensors: lidar_front, depth_camera, imu_primary, and wheel_encoders. Kirra uses these reports to compute per-node trust states and fleet-wide posture via its DAG traversal algorithm. When sensors degrade or go silent, posture transitions propagate through the dependency graph and the interceptor starts receiving denials or restricted commands.
 
-**posture_subscriber** — Maintains a live SSE (Server-Sent Events) connection to Aegis and republishes posture transitions as ROS2 topics. When posture transitions to `LockedOut`, it immediately publishes a zero-velocity emergency stop to the safe velocity topic. It reconnects automatically if the Aegis connection drops.
+**posture_subscriber** — Maintains a live SSE (Server-Sent Events) connection to Kirra and republishes posture transitions as ROS2 topics. When posture transitions to `LockedOut`, it immediately publishes a zero-velocity emergency stop to the safe velocity topic. It reconnects automatically if the Kirra connection drops.
 
 ---
 
@@ -54,39 +54,39 @@ posture_subscriber <- SSE /system/posture/stream <- Aegis
 - ROS2 Humble or Iron (tested on Humble)
 - Python 3.10+
 - `python3-requests` (`pip3 install requests` or `sudo apt install python3-requests`)
-- Aegis verifier service running and accessible
+- Kirra verifier service running and accessible
 
 ### Build
 
 ```bash
 cd ~/ros2_ws
-colcon build --packages-select aegis_safety
+colcon build --packages-select kirra_safety
 source install/setup.bash
 ```
 
 If you want to also build the C++ bridge package alongside:
 
 ```bash
-colcon build --packages-select aegis_safety aegis_bridge_cpp
+colcon build --packages-select kirra_safety kirra_bridge_cpp
 source install/setup.bash
 ```
 
 ### Environment Variables
 
-The Aegis token should be set in the environment rather than hardcoded in config files:
+The Kirra token should be set in the environment rather than hardcoded in config files:
 
 ```bash
-export AEGIS_ADMIN_TOKEN="your-admin-token-here"
-export AEGIS_URL="http://localhost:8090"   # optional, default is localhost:8090
+export KIRRA_ADMIN_TOKEN="your-admin-token-here"
+export KIRRA_URL="http://localhost:8090"   # optional, default is localhost:8090
 ```
 
 ---
 
 ## Topic Remapping for Nav2 Integration
 
-Nav2's `controller_server` publishes velocity commands to `/cmd_vel` by default. To insert the Aegis interlock, you remap Nav2's output to a raw topic and configure the interceptor to consume from that raw topic and publish to `/cmd_vel` (which your motor drivers subscribe to).
+Nav2's `controller_server` publishes velocity commands to `/cmd_vel` by default. To insert the Kirra interlock, you remap Nav2's output to a raw topic and configure the interceptor to consume from that raw topic and publish to `/cmd_vel` (which your motor drivers subscribe to).
 
-The `aegis_with_robot.launch.py` file does this automatically:
+The `kirra_with_robot.launch.py` file does this automatically:
 
 ```
 nav2_bringup publishes to  /cmd_vel_raw   (configure via cmd_vel_topic launch arg)
@@ -114,18 +114,18 @@ ros2 launch nav2_bringup navigation_launch.py cmd_vel_topic:=/cmd_vel_raw
 
 ## Fleet Node Registration
 
-Before starting the robot, register the sensor dependency graph with Aegis. This tells Aegis which nodes exist, how they depend on each other, and what constitutes a healthy fleet.
+Before starting the robot, register the sensor dependency graph with Kirra. This tells Kirra which nodes exist, how they depend on each other, and what constitutes a healthy fleet.
 
-Run the registration script once (after Aegis is running):
+Run the registration script once (after Kirra is running):
 
 ```bash
-AEGIS_ADMIN_TOKEN=your-token bash scripts/setup_ros2_fleet.sh
+KIRRA_ADMIN_TOKEN=your-token bash scripts/setup_ros2_fleet.sh
 ```
 
-Or with a custom Aegis URL:
+Or with a custom Kirra URL:
 
 ```bash
-AEGIS_URL=http://192.168.1.100:8090 AEGIS_ADMIN_TOKEN=your-token bash scripts/setup_ros2_fleet.sh
+KIRRA_URL=http://192.168.1.100:8090 KIRRA_ADMIN_TOKEN=your-token bash scripts/setup_ros2_fleet.sh
 ```
 
 The script registers the following dependency graph:
@@ -158,28 +158,28 @@ After registration, replace the placeholder TPM keys with real AK public keys if
 
 The ROSOrin is a mecanum-wheeled robot with a wheelbase of 0.2 m and a max speed of 1.8 m/s. All three motion axes are active (linear.x forward, linear.y lateral strafing, angular.z rotation).
 
-### Step 1: Start Aegis
+### Step 1: Start Kirra
 
 ```bash
-AEGIS_ADMIN_TOKEN=your-token ./target/release/aegis_verifier_service
+KIRRA_ADMIN_TOKEN=your-token ./target/release/kirra_verifier_service
 ```
 
 ### Step 2: Register the fleet graph
 
 ```bash
-AEGIS_ADMIN_TOKEN=your-token bash scripts/setup_ros2_fleet.sh
+KIRRA_ADMIN_TOKEN=your-token bash scripts/setup_ros2_fleet.sh
 ```
 
 ### Step 3: Build and launch the interlock
 
 ```bash
 cd ~/ros2_ws
-colcon build --packages-select aegis_safety
+colcon build --packages-select kirra_safety
 source install/setup.bash
 
-ros2 launch aegis_safety aegis_with_robot.launch.py \
-  aegis_url:=http://localhost:8090 \
-  aegis_token:=$AEGIS_ADMIN_TOKEN
+ros2 launch kirra_safety kirra_with_robot.launch.py \
+  kirra_url:=http://localhost:8090 \
+  kirra_token:=$KIRRA_ADMIN_TOKEN
 ```
 
 ### Step 4: Verify operation
@@ -188,13 +188,13 @@ ros2 launch aegis_safety aegis_with_robot.launch.py \
 # Monitor the safe velocity output
 ros2 topic echo /cmd_vel
 
-# Monitor Aegis enforcement decisions
-ros2 topic echo /aegis/enforcement_action
+# Monitor Kirra enforcement decisions
+ros2 topic echo /kirra/enforcement_action
 
 # Monitor fleet posture
-ros2 topic echo /aegis/fleet_posture
+ros2 topic echo /kirra/fleet_posture
 
-# Publish a test velocity (should appear on /cmd_vel after Aegis approval)
+# Publish a test velocity (should appear on /cmd_vel after Kirra approval)
 ros2 topic pub /cmd_vel_raw geometry_msgs/msg/Twist \
   "{linear: {x: 0.3, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}"
 ```
@@ -208,26 +208,26 @@ ros2 topic pub /cmd_vel_raw geometry_msgs/msg/Twist \
   "{linear: {x: 3.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}"
 ```
 
-The interceptor should clamp the output to 1.8 m/s and log a warning. The `/aegis/enforcement_action` topic will show `Clamp:v=1.80`.
+The interceptor should clamp the output to 1.8 m/s and log a warning. The `/kirra/enforcement_action` topic will show `Clamp:v=1.80`.
 
 ---
 
 ## Tuning Parameters for Different Robots
 
-All parameters are configured in `config/aegis_params.yaml` or overridden via launch arguments.
+All parameters are configured in `config/kirra_params.yaml` or overridden via launch arguments.
 
 ### cmd_vel_interceptor parameters
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `aegis_url` | `http://localhost:8090` | Aegis verifier base URL |
-| `aegis_token` | `""` | Bearer token (set via env or launch arg) |
-| `aegis_client_id` | `ros2-interceptor-01` | Client ID for identity-gated routes |
+| `kirra_url` | `http://localhost:8090` | Kirra verifier base URL |
+| `kirra_token` | `""` | Bearer token (set via env or launch arg) |
+| `kirra_client_id` | `ros2-interceptor-01` | Client ID for identity-gated routes |
 | `wheelbase_m` | `0.2` | Robot wheelbase for bicycle model (ROSOrin: 0.2 m) |
 | `max_speed_mps` | `1.8` | Maximum speed (ROSOrin: 1.8 m/s) |
 | `input_topic` | `/cmd_vel` | Velocity input from planner |
 | `output_topic` | `/cmd_vel_safe` | Enforced velocity to motors |
-| `timeout_ms` | `50` | Aegis API call timeout in ms |
+| `timeout_ms` | `50` | Kirra API call timeout in ms |
 | `fallback_on_timeout` | `stop` | `stop` (fail-closed) or `passthrough` |
 
 For slower robots (e.g., warehouse AMRs at 0.5 m/s):
@@ -247,7 +247,7 @@ cmd_vel_interceptor:
   ros__parameters:
     max_speed_mps: 5.0
     timeout_ms: 30
-    fallback_on_timeout: "passthrough"  # Allow if Aegis unreachable
+    fallback_on_timeout: "passthrough"  # Allow if Kirra unreachable
 ```
 
 ### sensor_monitor parameters
@@ -273,11 +273,11 @@ sensor_monitor:
 
 ## Troubleshooting
 
-### Aegis is unreachable
+### Kirra is unreachable
 
-By default the interceptor is fail-closed: if it cannot reach Aegis (connection refused, timeout), it publishes a zero-velocity stop and logs `CONNECTION_ERROR:STOP`. The robot will stop until Aegis becomes reachable again.
+By default the interceptor is fail-closed: if it cannot reach Kirra (connection refused, timeout), it publishes a zero-velocity stop and logs `CONNECTION_ERROR:STOP`. The robot will stop until Kirra becomes reachable again.
 
-To change this behavior to allow passthrough when Aegis is unreachable:
+To change this behavior to allow passthrough when Kirra is unreachable:
 
 ```yaml
 cmd_vel_interceptor:
@@ -289,14 +289,14 @@ Use passthrough only in controlled environments where stopping the robot is more
 
 ### Fleet posture is Degraded
 
-When posture is `Degraded`, Aegis allows `ReadTelemetry` operations but restricts `WriteState` mutations. The interceptor will receive HTTP 403 or a `DenyBreach` action for motion commands. Check which sensors are reporting low confidence:
+When posture is `Degraded`, Kirra allows `ReadTelemetry` operations but restricts `WriteState` mutations. The interceptor will receive HTTP 403 or a `DenyBreach` action for motion commands. Check which sensors are reporting low confidence:
 
 ```bash
 # Check the posture event stream
-ros2 topic echo /aegis/posture_events
+ros2 topic echo /kirra/posture_events
 
-# Or query Aegis directly
-curl -H "Authorization: Bearer $AEGIS_ADMIN_TOKEN" http://localhost:8090/fleet/posture
+# Or query Kirra directly
+curl -H "Authorization: Bearer $KIRRA_ADMIN_TOKEN" http://localhost:8090/fleet/posture
 ```
 
 ### Fleet posture is LockedOut — Emergency Stop
@@ -306,22 +306,22 @@ When posture is `LockedOut`:
 2. `cmd_vel_interceptor` will receive HTTP 503 on all subsequent commands and continue publishing zeros.
 3. The robot remains stopped until posture recovers to `Nominal`.
 
-Recovery requires a consecutive streak of healthy sensor reports (5 reports within a 10-second window per the Aegis recovery hysteresis algorithm). Once sensors recover, posture will transition back to `Degraded` and then `Nominal` automatically.
+Recovery requires a consecutive streak of healthy sensor reports (5 reports within a 10-second window per the Kirra recovery hysteresis algorithm). Once sensors recover, posture will transition back to `Degraded` and then `Nominal` automatically.
 
 ### High enforcement latency
 
-The interceptor has a 50ms timeout by default. If your Aegis instance is on a remote host, you may see increased latency. Options:
+The interceptor has a 50ms timeout by default. If your Kirra instance is on a remote host, you may see increased latency. Options:
 
 1. Increase `timeout_ms` to 100-200ms (and accept slower response to commands).
-2. Run Aegis on the robot's onboard computer (`localhost`) to minimize round-trip time.
+2. Run Kirra on the robot's onboard computer (`localhost`) to minimize round-trip time.
 3. Pre-authorize a velocity range and use the posture subscriber only to gate emergency stops, reducing per-command HTTP calls.
 
 ### posture_subscriber cannot connect to SSE stream
 
-The SSE stream (`GET /system/posture/stream`) is identity-gated: it requires both a Bearer token and the `x-aegis-client-id` header. Verify:
+The SSE stream (`GET /system/posture/stream`) is identity-gated: it requires both a Bearer token and the `x-kirra-client-id` header. Verify:
 
-1. `AEGIS_TRUSTED_INGRESS_MODE=true` is set in the Aegis environment if identity gating is enabled.
-2. The `aegis_token` and `aegis_client_id` parameters are correctly set.
+1. `KIRRA_TRUSTED_INGRESS_MODE=true` is set in the Kirra environment if identity gating is enabled.
+2. The `kirra_token` and `kirra_client_id` parameters are correctly set.
 
 The bridge reconnects automatically every 5 seconds on failure and logs the reconnection attempts.
 
@@ -337,21 +337,21 @@ This scenario demonstrates the end-to-end safety response to sensor occlusion:
 
 3. **Sensor monitor detects staleness**: After 2 seconds of silence, `_lidar_confidence()` returns 0.0. The monitor posts a report: `{"node_id": "lidar_front", "confidence_score": 0.0, "hardware_fault": false}`.
 
-4. **Aegis processes the report**: Aegis marks `lidar_front` as Untrusted. The DAG traversal propagates: `perception_fusion` becomes Degraded, `navigation_stack` becomes Degraded, `motor_controller` becomes Degraded. Fleet posture transitions to `Degraded`.
+4. **Kirra processes the report**: Kirra marks `lidar_front` as Untrusted. The DAG traversal propagates: `perception_fusion` becomes Degraded, `navigation_stack` becomes Degraded, `motor_controller` becomes Degraded. Fleet posture transitions to `Degraded`.
 
-5. **Posture subscriber receives the event**: The SSE stream delivers a `{"posture": "Degraded", "reason": "..."}` event. The subscriber publishes `"Degraded"` on `/aegis/fleet_posture`.
+5. **Posture subscriber receives the event**: The SSE stream delivers a `{"posture": "Degraded", "reason": "..."}` event. The subscriber publishes `"Degraded"` on `/kirra/fleet_posture`.
 
-6. **Interceptor receives HTTP 403**: The next cmd_vel command to Aegis returns a denial. The interceptor publishes a zero-velocity stop and logs `BLOCKED:HTTP_403`.
+6. **Interceptor receives HTTP 403**: The next cmd_vel command to Kirra returns a denial. The interceptor publishes a zero-velocity stop and logs `BLOCKED:HTTP_403`.
 
 7. **Robot slows and stops**: The motor controllers receive zero velocity. The robot stops.
 
 8. **Uncover the LiDAR**: The `/scan` topic resumes. The sensor monitor starts receiving messages and rebuilds the Hz estimate.
 
-9. **Recovery hysteresis**: After 5 consecutive healthy reports within 10 seconds, Aegis marks `lidar_front` Trusted again. The DAG traversal clears the cascade. Fleet posture transitions back to `Nominal`.
+9. **Recovery hysteresis**: After 5 consecutive healthy reports within 10 seconds, Kirra marks `lidar_front` Trusted again. The DAG traversal clears the cascade. Fleet posture transitions back to `Nominal`.
 
 10. **Commands resume**: The interceptor receives `Allow` responses again. The robot can resume autonomous motion.
 
-The full transition takes approximately 10-15 seconds from sensor recovery to posture restoration, governed by the Aegis `AV_RECOVERY_STREAK_THRESHOLD` (5 reports) and `AV_RECOVERY_WINDOW_MS` (10 seconds) constants.
+The full transition takes approximately 10-15 seconds from sensor recovery to posture restoration, governed by the Kirra `AV_RECOVERY_STREAK_THRESHOLD` (5 reports) and `AV_RECOVERY_WINDOW_MS` (10 seconds) constants.
 
 ---
 
@@ -359,21 +359,21 @@ The full transition takes approximately 10-15 seconds from sensor recovery to po
 
 The package defines two custom ROS2 message types in the `msg/` directory:
 
-**AegisPosture.msg** — Carries a posture snapshot with the list of blocked nodes, a Unix timestamp, and the monotonic generation counter from Aegis. Subscribe to `/aegis/fleet_posture` using this message type when you need structured posture data (the simple String publisher uses the posture label only).
+**KirraPosture.msg** — Carries a posture snapshot with the list of blocked nodes, a Unix timestamp, and the monotonic generation counter from Kirra. Subscribe to `/kirra/fleet_posture` using this message type when you need structured posture data (the simple String publisher uses the posture label only).
 
-**SensorHealth.msg** — Mirrors the Aegis `/fleet/diagnostics/report` payload as a ROS2 message. Can be used to republish sensor health data on the ROS2 graph for visualization in tools like rqt.
+**SensorHealth.msg** — Mirrors the Kirra `/fleet/diagnostics/report` payload as a ROS2 message. Can be used to republish sensor health data on the ROS2 graph for visualization in tools like rqt.
 
 To use these in other packages after building:
 
 ```python
-from aegis_safety.msg import AegisPosture, SensorHealth
+from kirra_safety.msg import KirraPosture, SensorHealth
 ```
 
 ---
 
 ## Security Considerations
 
-- Never hardcode the `AEGIS_ADMIN_TOKEN` in config files or launch files. Use environment variables.
+- Never hardcode the `KIRRA_ADMIN_TOKEN` in config files or launch files. Use environment variables.
 - The interceptor includes the admin token in every HTTP request. Use TLS (`https://`) in production to prevent token interception.
-- The `fallback_on_timeout: passthrough` mode bypasses Aegis enforcement when the service is unreachable. Use it only in environments where stopping is more dangerous than operating without enforcement, and ensure Aegis is deployed with high availability.
+- The `fallback_on_timeout: passthrough` mode bypasses Kirra enforcement when the service is unreachable. Use it only in environments where stopping is more dangerous than operating without enforcement, and ensure Kirra is deployed with high availability.
 - The posture subscriber SSE thread runs as a daemon thread. If the main ROS2 node shuts down, the thread exits cleanly because `_running` is set to `False` in `destroy_node()`.

--- a/docs/safety/ASTM_F3269_MAPPING.md
+++ b/docs/safety/ASTM_F3269_MAPPING.md
@@ -1,4 +1,4 @@
-# Aegis — ASTM F3269 Run Time Assurance Mapping
+# Kirra — ASTM F3269 Run Time Assurance Mapping
 
 Document ID: AEGIS-F3269-001
 Version: 1.0.0
@@ -12,15 +12,15 @@ Date: 2026-05-23
 
 ASTM F3269-21 defines a methodology for Run Time Assurance (RTA) monitoring of autonomous and semi-autonomous systems. RTA provides a runtime safety monitor that bounds the behavior of a primary autonomous function (e.g., an AI navigation stack) and reverts to a safe backup control law when the primary function operates outside proven-safe bounds.
 
-Aegis is architecturally an RTA monitor. This document maps each F3269 concept to the corresponding Aegis component, confirming that Aegis satisfies the intent of the standard.
+Kirra is architecturally an RTA monitor. This document maps each F3269 concept to the corresponding Kirra component, confirming that Kirra satisfies the intent of the standard.
 
 ---
 
 ## 2. Terminology Mapping
 
-| ASTM F3269 Term | Aegis Implementation | Notes |
+| ASTM F3269 Term | Kirra Implementation | Notes |
 |-----------------|---------------------|-------|
-| RTA Monitor | Aegis Safety Kernel (`aegis_verifier_service` binary + `validate_vehicle_command()` + `should_route_command()`) | The Aegis process is the monitor — it intercepts every proposed command and gates it |
+| RTA Monitor | Kirra Safety Kernel (`kirra_verifier_service` binary + `validate_vehicle_command()` + `should_route_command()`) | The Kirra process is the monitor — it intercepts every proposed command and gates it |
 | Primary Function (PF) | AI Planner / Autonomous Navigation Stack (e.g., Nav2, LLM-based controller, CARLA autopilot) | The upstream system generating ProposedVehicleCommand JSON payloads |
 | Backup Control Law (BCL) | MRC Fallback Profile (`VehicleKinematicsContract::mrc_fallback_profile()`) | Applied automatically when FleetPosture transitions to Degraded |
 | Safe Set / Safe Region | FleetPosture::Nominal with Nominal Reference Profile active | The region of operation where the primary function is within verified bounds |
@@ -51,7 +51,7 @@ Aegis is architecturally an RTA monitor. This document maps each F3269 concept t
                              │ POST /actuator/motion/command
                              ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                   RTA MONITOR (Aegis)                        │
+│                   RTA MONITOR (Kirra)                        │
 │                                                              │
 │  1. Posture Gate (should_route_command)                      │
 │     LockedOut → DenyAll                                      │
@@ -135,12 +135,12 @@ These invariants are verified by proptest properties in `src/gateway/kinematics_
 
 ## 6. Claim Against F3269 Requirements
 
-| F3269 Requirement | Aegis Claim | Evidence |
+| F3269 Requirement | Kirra Claim | Evidence |
 |-------------------|-------------|----------|
 | RTA.1: The RTA monitor shall detect when the primary function exceeds the safe set | validate_vehicle_command() detects speed, acceleration, steering, and NaN/Inf exceedances synchronously on every command | src/gateway/kinematics_contract.rs, 306 passing tests |
 | RTA.2: The RTA monitor shall switch to the backup control law within the fault tolerant time interval | Posture transition to Degraded applies MRC profile to next command (synchronous, per-command FTTI) | FTTI for kinematic enforcement: per-command (< 1ms); FTTI for posture: AV_TELEMETRY_TIMEOUT_MS = 2000ms |
 | RTA.3: The backup control law shall keep the system within the recovery region | MRC Fallback Profile max_speed = 5.0 m/s is within the proven-safe region for all vehicle types | VehicleKinematicsContract::mrc_fallback_profile() |
-| RTA.4: The RTA monitor shall be independent of the primary function | Aegis is a separate process; primary function has no write access to Aegis state; admin token required for all mutations | Architectural separation; require_admin_token on all mutation routes |
+| RTA.4: The RTA monitor shall be independent of the primary function | Kirra is a separate process; primary function has no write access to Kirra state; admin token required for all mutations | Architectural separation; require_admin_token on all mutation routes |
 | RTA.5: The RTA monitor shall fail to a safe state | Stale posture cache → LockedOut (all commands denied). Absent env token → 503 fail-closed. Empty posture cache → LockedOut. Poisoned RwLock → LockedOut. | src/posture_cache.rs:should_route_command, AEGIS-SG-005 |
 | RTA.6: The RTA monitor shall record evidence of monitoring decisions | Every command evaluation generates an audit entry in the SHA-256 hash-chained audit log with Ed25519 signature | src/audit_chain.rs, AEGIS-SG-010 |
 
@@ -160,6 +160,6 @@ These invariants are verified by proptest properties in `src/gateway/kinematics_
 
 | Field | Value |
 |-------|-------|
-| Prepared by | Aegis Engineering |
+| Prepared by | Kirra Engineering |
 | Next review | 2026-11-23 |
 | Supersedes | None |

--- a/docs/safety/ASTM_F3269_RTA_MAPPING.md
+++ b/docs/safety/ASTM_F3269_RTA_MAPPING.md
@@ -32,7 +32,7 @@ an ASTM-recognized body has not yet been performed.
 Relationship to the existing preliminary mapping in
 `docs/safety/ASTM_F3269_MAPPING.md` (AEGIS-F3269-001 v1.0.0): that
 earlier document established the initial claim shape under the prior
-Aegis branding; this document (KIRRA-RTA-001) is the up-to-date
+Kirra branding; this document (KIRRA-RTA-001) is the up-to-date
 working mapping aligned with the current Kirra architecture, the
 ODD specification, and CERT-track artifacts. The earlier document
 remains in the safety case index for historical traceability.

--- a/docs/safety/CODING_GUIDELINES.md
+++ b/docs/safety/CODING_GUIDELINES.md
@@ -1,4 +1,4 @@
-# Aegis Safety Kernel — Rust Safety Coding Guidelines
+# Kirra Safety Kernel — Rust Safety Coding Guidelines
 
 Document ID: AEGIS-CG-001
 Version: 1.0.0
@@ -12,9 +12,9 @@ Date: 2026-05-23
 
 ### 1.1 Purpose
 
-These guidelines define the Rust coding standard for safety-critical code paths in the `aegis-runtime-sdk` crate. They are derived from MISRA C:2012 principles adapted for the Rust programming language and aligned with the Ferrocene Language Specification (FLS), which defines the safe subset of Rust suitable for use in safety-critical systems under IEC 61508 and ISO 26262.
+These guidelines define the Rust coding standard for safety-critical code paths in the `kirra-runtime-sdk` crate. They are derived from MISRA C:2012 principles adapted for the Rust programming language and aligned with the Ferrocene Language Specification (FLS), which defines the safe subset of Rust suitable for use in safety-critical systems under IEC 61508 and ISO 26262.
 
-The guidelines are binding for all code in the `aegis-runtime-sdk` crate that implements or supports a safety goal in AEGIS-SG-001. They are advisory for non-safety-critical code (e.g., CARLA integration, dashboard tooling).
+The guidelines are binding for all code in the `kirra-runtime-sdk` crate that implements or supports a safety goal in AEGIS-SG-001. They are advisory for non-safety-critical code (e.g., CARLA integration, dashboard tooling).
 
 ### 1.2 Safety-Critical Paths
 
@@ -40,7 +40,7 @@ The following modules and files are classified as safety-critical and are subjec
 | `src/adapters/dnp3.rs` | SG-012 | ASIL B |
 | `src/federation_reconciliation.rs` | SG-014 | ASIL B |
 
-Non-safety-critical files (e.g., `src/bin/aegis_carla_client.rs`, `src/metrics.rs`, `examples/`) are subject to guidelines at the discretion of the code reviewer and are not held to ASIL compliance.
+Non-safety-critical files (e.g., `src/bin/kirra_carla_client.rs`, `src/metrics.rs`, `examples/`) are subject to guidelines at the discretion of the code reviewer and are not held to ASIL compliance.
 
 ### 1.3 Relationship to Standards
 
@@ -143,7 +143,7 @@ Casts that may silently truncate or lose precision (e.g., `f64 as f32`, `u64 as 
 
 ### Rule CONC-001: Lock Ordering Must Be Documented and Enforced (Mandatory)
 
-Any code that acquires multiple locks simultaneously shall document the lock acquisition order and shall always acquire locks in the documented order to prevent deadlock. In the Aegis codebase, the established lock ordering is:
+Any code that acquires multiple locks simultaneously shall document the lock acquisition order and shall always acquire locks in the documented order to prevent deadlock. In the Kirra codebase, the established lock ordering is:
 
 1. `AppState.store` (`Arc<Mutex<VerifierStore>>`) — innermost
 2. `SharedPostureCache` (`Arc<RwLock<...>>`) — outer
@@ -269,11 +269,11 @@ Even in these permitted uses, the RNG shall be seeded from `OsRng` and shall not
 
 ## 7. Security Invariants
 
-The following 13 security invariants, as defined in `CLAUDE.md`, are binding for all code in the `aegis-runtime-sdk` crate. Any pull request that violates these invariants shall be rejected without exception, regardless of other justifications.
+The following 13 security invariants, as defined in `CLAUDE.md`, are binding for all code in the `kirra-runtime-sdk` crate. Any pull request that violates these invariants shall be rejected without exception, regardless of other justifications.
 
 ### INV-01: require_admin_token Must Never Be Bypassed (Mandatory, ASIL B)
 
-`require_admin_token` must never be commented out, bypassed, or removed from any mutation route. It reads `AEGIS_ADMIN_TOKEN` from the environment; if absent or empty, it returns HTTP 503 (fail-closed), never fail-open. This implements SG-015 (TR-015, TR-015a).
+`require_admin_token` must never be commented out, bypassed, or removed from any mutation route. It reads `KIRRA_ADMIN_TOKEN` from the environment; if absent or empty, it returns HTTP 503 (fail-closed), never fail-open. This implements SG-015 (TR-015, TR-015a).
 
 ### INV-02: constant_time_compare for All Token Comparisons (Mandatory, ASIL B)
 
@@ -291,17 +291,17 @@ The following 13 security invariants, as defined in `CLAUDE.md`, are binding for
 
 `pending_challenges: DashMap<String, ChallengeEntry>` must never be removed. Nonces are volatile, in-memory only, and expire after `CHALLENGE_TTL_MS = 30000` ms. Persisting nonces to SQLite would allow replay attacks after process restart.
 
-### INV-06: AEGIS_ADMIN_TOKEN From Environment Only (Mandatory, ASIL B)
+### INV-06: KIRRA_ADMIN_TOKEN From Environment Only (Mandatory, ASIL B)
 
-`AEGIS_ADMIN_TOKEN` must come from `std::env::var("AEGIS_ADMIN_TOKEN")` only. No hardcoded fallback values, default strings, or configuration-file overrides for this variable are permitted. Absent or empty resolves to HTTP 503.
+`KIRRA_ADMIN_TOKEN` must come from `std::env::var("KIRRA_ADMIN_TOKEN")` only. No hardcoded fallback values, default strings, or configuration-file overrides for this variable are permitted. Absent or empty resolves to HTTP 503.
 
-### INV-07: AEGIS_SUPERVISOR_RESET_KEY From Environment Only (Mandatory, ASIL B)
+### INV-07: KIRRA_SUPERVISOR_RESET_KEY From Environment Only (Mandatory, ASIL B)
 
-`AEGIS_SUPERVISOR_RESET_KEY` must come from the environment variable only, with no hardcoded fallbacks. The value must be present, non-empty, and at most 64 bytes. Any value failing these constraints results in startup abort via `startup_sentinel`.
+`KIRRA_SUPERVISOR_RESET_KEY` must come from the environment variable only, with no hardcoded fallbacks. The value must be present, non-empty, and at most 64 bytes. Any value failing these constraints results in startup abort via `startup_sentinel`.
 
 ### INV-08: Hard Boundary Clamp Before Rate-of-Change Limiter (Mandatory, ASIL D)
 
-The velocity envelope cap (Priority 2 in `validate_vehicle_command`) must always be applied before the rate-of-change limiter in `AegisKernelGovernor`. The hard clamp to `max_speed_mps` takes absolute priority. No ordering inversion is permitted. This implements SG-001 and addresses H-015.
+The velocity envelope cap (Priority 2 in `validate_vehicle_command`) must always be applied before the rate-of-change limiter in `KirraKernelGovernor`. The hard clamp to `max_speed_mps` takes absolute priority. No ordering inversion is permitted. This implements SG-001 and addresses H-015.
 
 ### INV-09: OperationalCommand::Unknown Denied Before Posture Check (Mandatory, ASIL D)
 
@@ -355,7 +355,7 @@ The following function bodies are Protected Code Regions. Any modification requi
 | `src/posture_cache.rs:should_route_command` | SG-005, SG-006 | INV-09 |
 | `src/gateway/kinematics_contract.rs:validate_vehicle_command` | SG-001, SG-002, SG-004 | INV-08 |
 | `src/verifier.rs:AppState::recursive_calculate` | SG-003, SG-007 | INV-04 |
-| `src/bin/aegis_verifier_service.rs:require_admin_token` | SG-015 | INV-01, INV-02, INV-06 |
+| `src/bin/kirra_verifier_service.rs:require_admin_token` | SG-015 | INV-01, INV-02, INV-06 |
 | `src/recovery_hysteresis.rs:evaluate_recovery_report` | SG-013 | — |
 | `src/posture_engine_v2.rs:resolve_posture_with_reason` | SG-005 | — |
 | `src/standby_monitor.rs:spawn_promotion_monitor` | SG-009 | — |
@@ -413,7 +413,7 @@ The following static analysis tools shall be run as part of the CI pipeline for 
 
 | Field | Value |
 |-------|-------|
-| Prepared by | Aegis Engineering |
+| Prepared by | Kirra Engineering |
 | Review status | Pending TUV pre-assessment |
 | Next review | 2026-11-23 |
 | Supersedes | None |

--- a/docs/safety/COMPARATOR_DIVERSITY.md
+++ b/docs/safety/COMPARATOR_DIVERSITY.md
@@ -1,0 +1,191 @@
+# Governor Comparator — Diversity Argument
+
+**Doc ID:** KIRRA-CERT006-DIVERSITY-001
+**Tracker:** CERT-006 (comparator diversity)
+**Implements:** `parko/crates/parko-kirra/src/diverse.rs`,
+`parko/crates/parko-kirra/src/comparator.rs`
+**Relates to:** CERT-006 (software lockstep comparator),
+`docs/safety/ANGULAR_VELOCITY_SOTIF.md` (#136, the shared angular spec),
+`docs/safety/IEC_61508_SIL3_MAPPING.md` §FM-002
+**Date:** 2026-06-01
+
+---
+
+> # ⚠️ DRAFT — pending formal safety-engineer review
+>
+> This is a **first** diverse implementation plus a **draft** diversity
+> argument. A diversity claim is a safety argument that a real assessor
+> will scrutinise; it has **not** yet been reviewed or signed off by a
+> safety engineer. The same human-review bar that applies to the SOTIF
+> angular-bound work (#136) applies here.
+>
+> What is engineering fact (testable, and tested) vs what is a reasoned
+> argument (not testable) is called out explicitly below. Do not cite the
+> argument sections as validated coverage.
+
+---
+
+## 1. Background and problem statement
+
+The `GovernorComparator` is Kirra's software lockstep: it runs two safety
+governors on the same input each tick and compares their outputs. On a
+persistent divergence (and once the vehicle is at a safe speed) it escalates
+to a fail-closed `Deny` (LockedOut). The escalation, leaky-bucket
+accumulator, speed gate and audit sink are unchanged by this work — see the
+`comparator.rs` module documentation.
+
+Until CERT-006-diversity, the comparator ran **two identical
+`KirraGovernor` instances**. Identical redundancy detects:
+
+- **random / transient faults** — bit flips, single-event upsets, memory
+  corruption, a transient error in one instance;
+- **state divergence** — the two copies fed inconsistent RSS / posture
+  updates.
+
+It is, by construction, **blind to systematic faults**. A logic or numerical
+bug in the shared code path (a wrong comparison operator, an off-by-`dt`
+error, a mis-signed clamp) computes the *same* wrong answer in *both* copies.
+They agree, the comparator sees no divergence, and the wrong command reaches
+the actuator. This is the gap CERT-006-diversity closes.
+
+## 2. Decision — diversity kind (Approach A)
+
+Two options were considered:
+
+| | Approach A — structural / algorithmic diversity | Approach B — full N-version |
+|---|---|---|
+| What | A second governor enforcing the **same** properties via deliberately **different computation** (different control flow, different algebra, different decomposition). | A clean-room reimplementation from the **spec only**, not the primary's code. |
+| Catches | Implementation-level systematic faults (the most common class). | Maximal implementation diversity. |
+| Shares | The specification **and** the config/contract. | The specification only. |
+| Effort | Tractable now. | Substantially more; independent team, independent spec interpretation. |
+| Decision | **IMPLEMENTED (this deliverable).** | Noted as the stronger-but-later step (§6). Not built now. |
+
+**Approach A is implemented** as `DiverseKirraGovernor`. It is the right
+first step: it removes the largest and most likely fault class
+(implementation bugs) at tractable cost, and it is honest about what it does
+not cover (§5).
+
+## 3. The two properties, and which are testable
+
+| Property | Kind | Where demonstrated |
+|---|---|---|
+| **CORRECTNESS** — the diverse governor produces the **same physical verdict** as the primary on valid inputs (no false divergence). | Testable; critical. | `diverse::tests::agreement_*` (hand-built set spanning Allow / each Clamp / Deny across every posture + both RSS states + multiple configs) and `diverse::tests::proptest_diverse_agrees_with_primary` (10 000 bounded cases). |
+| **DIVERSITY** — the two are structurally different enough that a systematic implementation bug would not appear identically in both. | An **argument**, not a test. You cannot test "would a hypothetical bug be caught." | §4 (documented structural differences) + the fault-class reasoning in §4.2. |
+| **DETECTION** — injecting a fault into one path makes the comparator diverge → escalate → fail-closed. | Demonstrable. | `comparator::tests::test_injected_fault_is_detected_and_escalates` (+ the in-envelope control case). |
+
+A false divergence on a valid input would itself be a safety-relevant
+regression (the comparator would clamp/stop a *good* command), which is why
+CORRECTNESS is the property guarded most heavily.
+
+## 4. The structural differences (the reviewable core)
+
+`DiverseKirraGovernor` enforces every property `KirraGovernor` does — the ODD
+speed ceiling, the acceleration / braking rate envelope, the SOTIF
+angular-velocity bound `ω_max(v)`, the MRC contraction, and the LockedOut
+hard stop — but reaches the verdict through different computation. It does
+**not** call `validate_vehicle_command` and does **not** call any
+`KirraGovernor` method; it only reads the shared *config* (the kinematics
+contract's limit fields and the `AngularVelocityBound`).
+
+### 4.1 Concrete differences
+
+1. **Regime selection.**
+   *Primary:* checks `LockedOut`, then a **separate** RSS early-return, then
+   `match posture` (`KirraGovernor::evaluate`).
+   *Diverse:* a single `classify` step folds "Degraded posture **OR**
+   RSS-unsafe" into one `MinimumRisk` predicate and treats `LockedOut` as the
+   dominating hard stop, then dispatches once. The primary reaches the MRC
+   code from two different branches; the diverse governor reaches it from
+   one. (Algebraically equivalent — verified by the agreement tests.)
+
+2. **Linear rate envelope — the most error-prone arithmetic.**
+   *Primary:* computes a scalar implied acceleration `(v − c)/dt` and
+   **sign-splits** into two magnitude comparisons against the accel and brake
+   limits (`apply ...` then return the first triggered clamp).
+   *Diverse:* builds the **admissible-velocity interval**
+   `[c − brake·dt, c + accel·dt]`, clipped to `±ceiling`, and does interval
+   containment. The primary's `+1e-9` tolerance lives in *acceleration*
+   space; it is mapped into *velocity* space (`1e-9·dt`) here. Different
+   decomposition, identical result. A bug like "forgot to multiply the brake
+   limit by `dt`" in one formulation would not reproduce in the other.
+
+3. **Effective ceiling.**
+   *Primary:* calls `contract.effective_max_speed_mps()`.
+   *Diverse:* re-derives `min(max_speed, odd_cap)` inline, so it does not
+   share that accessor.
+
+4. **Clamp reconstruction.**
+   *Primary:* `value * x.signum()` and `f64::clamp`.
+   *Diverse:* `f64::copysign` and an explicit `.max(..).min(..)` fold.
+
+5. **No shared enforcement code.** The diverse path shares *config*, not
+   *computation*. This is the "same limits, computed differently" the safety
+   case requires; reusing the primary's functions would defeat the diversity
+   and is deliberately avoided (and flagged in the module docs if ever
+   introduced).
+
+### 4.2 Fault class covered
+
+Approach A covers **implementation-level systematic faults**: bugs in *how*
+one governor computes a verdict from the (correct) limits — wrong operator,
+wrong sign, off-by-`dt`, wrong rounding/tolerance handling, a mis-ordered
+clamp, a transposed branch. Because the two governors decompose the same
+computation differently, such a bug in one path is unlikely to produce a
+byte-for-byte identical wrong output in the other, so the comparator's
+divergence detection fires. This is the most common and most likely class of
+systematic fault in hand-written safety code, which is why it is the right
+first target.
+
+## 5. What this diversity does **NOT** cover (the honest limit)
+
+- **Shared-specification faults.** Both governors are derived from the same
+  spec. If the *spec* is wrong — a wrong limit value, a wrong safety goal, a
+  flaw in the `ω_max(v)` derivation itself (`ANGULAR_VELOCITY_SOTIF.md`,
+  still DRAFT) — **both** implement the same wrong behaviour, they agree, and
+  the comparator stays silent. Diversity of implementation cannot catch a
+  fault of specification.
+- **Shared-config faults.** The two governors consume the same kinematics
+  contract and the same `AngularVelocityBound`. A mis-configured limit is
+  applied identically by both. (Diversity is in the *enforcement*, not in
+  the *limit values*.)
+- **The shared angular derivation.** `ω_max(v)` is computed by the shared
+  `AngularVelocityBound::omega_max`. The diverse governor re-implements the
+  *enforcement* around it (the clamp decision), but **not** the SOTIF
+  derivation. A fault inside `omega_max` is shared.
+- **Common-cause faults below the software layer** — compiler bugs, the Rust
+  core/std, the host CPU/FPU. Out of scope for a same-binary software
+  comparator; these belong to the hardware/diverse-toolchain story.
+
+These are not defects in this deliverable — they are the inherent boundary of
+implementation diversity, stated so the safety case does not overclaim.
+
+## 6. What a full N-version step (Approach B) would add later
+
+A clean-room reimplementation from the spec — ideally by an independent
+person interpreting the requirements without reading the primary's code —
+would add resilience to **spec-interpretation** faults: two engineers are
+less likely to misread the same requirement in the same way than one
+engineer is to write two structurally different encodings of their own
+(possibly mistaken) understanding. It still shares the written specification,
+so a genuine spec error survives even Approach B; that residual is addressed
+by **diverse review of the spec itself**, not by code diversity. Approach B
+is materially more effort and is **not** built in this deliverable.
+
+## 7. Verification summary
+
+- `cargo test -p parko-kirra` — green, including the agreement set, the
+  10 000-case agreement proptest, and the injected-fault detection test.
+- `cargo test --workspace --exclude parko-onnx --exclude parko-openvino`
+  (in `parko/`) — green.
+- Root `cargo test --workspace` — unchanged.
+- The comparator's escalation / accumulator / speed-gate / audit logic is
+  **unchanged**; only the shadow governor's implementation differs and the
+  comparator is now generic over the shadow type (default
+  `DiverseKirraGovernor`; a second `KirraGovernor` still constructs the
+  legacy identical-redundancy comparator for tests).
+
+## 8. Status
+
+**Derived / implemented — pending safety-engineer review.** Not closed. The
+diversity argument in §4–§6 requires the same human review as the #136 SOTIF
+work before it can be cited as validated coverage in any assessment.

--- a/docs/safety/HARA.md
+++ b/docs/safety/HARA.md
@@ -1,4 +1,4 @@
-# Aegis Safety Kernel — Hazard Analysis and Risk Assessment (HARA)
+# Kirra Safety Kernel — Hazard Analysis and Risk Assessment (HARA)
 
 Document ID: AEGIS-HARA-001
 Version: 1.0.0
@@ -10,11 +10,11 @@ Date: 2026-05-23
 
 ## 1. Item Definition
 
-**Item name:** Aegis Runtime Safety Kernel
+**Item name:** Kirra Runtime Safety Kernel
 **Item version:** 1.5.0
-**Item description:** Aegis is a runtime safety enforcement layer that intercepts proposed actuator commands from AI planners, autonomous navigation stacks, and LLM-based controllers, and enforces hard physical constraints before commands reach vehicle actuators, robot motors, drone flight controllers, or industrial machinery. Aegis operates as a fail-closed middleware process between the AI planning layer and the physical actuator interface.
+**Item description:** Kirra is a runtime safety enforcement layer that intercepts proposed actuator commands from AI planners, autonomous navigation stacks, and LLM-based controllers, and enforces hard physical constraints before commands reach vehicle actuators, robot motors, drone flight controllers, or industrial machinery. Kirra operates as a fail-closed middleware process between the AI planning layer and the physical actuator interface.
 
-**Scope:** This HARA covers the Aegis software item deployed as:
+**Scope:** This HARA covers the Kirra software item deployed as:
 - An autonomous vehicle motion command governor (AV/UGV)
 - A robot kinematic safety enforcer (ROS2/mecanum platforms)
 - A drone command gating layer
@@ -22,7 +22,7 @@ Date: 2026-05-23
 - A multi-asset fleet safety fabric
 
 **Item boundary:**
-- In scope: All software within the `aegis-runtime-sdk` crate, the `aegis_verifier_service` binary, the ROS2 safety interlock nodes, the industrial protocol adapters, and the multi-asset safety fabric
+- In scope: All software within the `kirra-runtime-sdk` crate, the `kirra_verifier_service` binary, the ROS2 safety interlock nodes, the industrial protocol adapters, and the multi-asset safety fabric
 - Out of scope: The AI planner generating commands, the physical actuator hardware, the vehicle chassis, sensor hardware
 
 ---
@@ -35,8 +35,8 @@ Date: 2026-05-23
 | OS2 | Degraded sensor operation — one or more sensors faulted, fleet posture Degraded |
 | OS3 | Multiple sensor failure — two or more sensors faulted simultaneously |
 | OS4 | AI planner producing out-of-envelope commands (overspeed, excessive steering, NaN/Inf) |
-| OS5 | Communication loss between AI planner and Aegis |
-| OS6 | Aegis process failure or crash (primary instance) |
+| OS5 | Communication loss between AI planner and Kirra |
+| OS6 | Kirra process failure or crash (primary instance) |
 | OS7 | Database corruption or audit chain failure |
 | OS8 | Network partition in HA deployment (primary-standby) |
 | OS9 | Clock skew in distributed deployment |
@@ -78,22 +78,22 @@ Severity, Exposure, and Controllability are rated per ISO 26262-3:
 
 | Hazard ID | Description | Operational Situation | Potential Harm | S | E | C | ASIL | Safety Goal |
 |-----------|-------------|----------------------|----------------|---|---|---|------|-------------|
-| H-001 | Aegis passes a motion command with linear_velocity_mps exceeding the active contract's max_speed_mps | OS1, OS4 | Vehicle exceeds safe speed; collision with pedestrians, infrastructure, or other vehicles | S3 | E4 | C3 | D | SG-001 |
-| H-002 | Aegis passes a command implying lateral acceleration exceeding max_lateral_accel_mps2, computed by bicycle model | OS1, OS4 | Vehicle rollover or loss of traction causing collision | S3 | E4 | C2 | D | SG-002 |
-| H-003 | Aegis fails to detect sensor node trust state transition within AV_TELEMETRY_TIMEOUT_MS; fleet posture remains Nominal when it should be Degraded | OS2, OS3 | AI planner operates at full speed/maneuverability with degraded sensor input; collision risk | S3 | E3 | C3 | D | SG-003 |
+| H-001 | Kirra passes a motion command with linear_velocity_mps exceeding the active contract's max_speed_mps | OS1, OS4 | Vehicle exceeds safe speed; collision with pedestrians, infrastructure, or other vehicles | S3 | E4 | C3 | D | SG-001 |
+| H-002 | Kirra passes a command implying lateral acceleration exceeding max_lateral_accel_mps2, computed by bicycle model | OS1, OS4 | Vehicle rollover or loss of traction causing collision | S3 | E4 | C2 | D | SG-002 |
+| H-003 | Kirra fails to detect sensor node trust state transition within AV_TELEMETRY_TIMEOUT_MS; fleet posture remains Nominal when it should be Degraded | OS2, OS3 | AI planner operates at full speed/maneuverability with degraded sensor input; collision risk | S3 | E3 | C3 | D | SG-003 |
 | H-004 | Stale posture cache (age >= POSTURE_CACHE_TTL_MS) causes MRC profile not applied during sensor degradation | OS2, OS9 | Commands evaluated against Nominal contract when Degraded contract should be active | S2 | E4 | C3 | D | SG-005 |
 | H-005 | NaN or Inf in motion command field passes through enforcement without detection | OS4, OS10 | Undefined arithmetic behavior in downstream actuator; uncontrolled motion | S3 | E2 | C3 | C | SG-004 |
-| H-006 | Aegis process crashes; no command gating occurs and commands pass directly to actuator | OS6 | Unfiltered AI planner commands reach actuators without kinematic enforcement | S3 | E3 | C2 | D | SG-008 |
+| H-006 | Kirra process crashes; no command gating occurs and commands pass directly to actuator | OS6 | Unfiltered AI planner commands reach actuators without kinematic enforcement | S3 | E3 | C2 | D | SG-008 |
 | H-007 | PassiveStandby instance fails to promote when primary crashes within PROMOTION_TIMEOUT_MS | OS6, OS8 | Gap in enforcement coverage during failover window | S2 | E2 | C3 | B | SG-009 |
 | H-008 | SHA-256 audit chain tampered; safety violations undetected in post-incident analysis | OS7, OS10 | Inability to reconstruct events leading to incident; regulatory and legal exposure | S1 | E4 | C3 | B | SG-010 |
 | H-009 | LLM hallucination produces action with OperationalCommand::Unknown; Action Filter does not deny | OS4, OS10 | Unclassified command reaches actuator; undefined physical behavior | S3 | E3 | C3 | D | SG-006 |
-| H-010 | CANOpen NMT stop/pre-op/reset command not triggering posture recalculation | OS13 | Industrial controller enters stop state; Aegis posture remains Nominal; unsynchronized state | S2 | E3 | C3 | C | SG-011 |
+| H-010 | CANOpen NMT stop/pre-op/reset command not triggering posture recalculation | OS13 | Industrial controller enters stop state; Kirra posture remains Nominal; unsynchronized state | S2 | E3 | C3 | C | SG-011 |
 | H-011 | DNP3 broadcast control command executed without being audited in chain | OS13, OS10 | Critical infrastructure control without tamper-evident record | S2 | E2 | C2 | B | SG-012 |
 | H-012 | Cross-asset trust propagation failure in fabric — leader asset LockedOut, follower assets unaware and continuing motion | OS12 | Convoy vehicles or linked robots continue at Nominal speed without awareness of fleet lockout | S3 | E3 | C3 | D | SG-007 |
 | H-013 | Recovery hysteresis bypassed by sensor replay attack; faulty sensor promoted to Trusted prematurely | OS11, OS10 | Flapping sensor with manipulated telemetry triggers early Nominal posture restoration | S2 | E2 | C3 | B | SG-013 |
 | H-014 | Federation report with forged or replayed generation counter accepted by reconciliation engine | OS10 | Peer controller posture downgraded or upgraded via adversarial input | S2 | E2 | C3 | B | SG-014 |
 | H-015 | Rate-of-change limiter applied before hard boundary clamp; velocity spike slips through in single cycle | OS1, OS4 | Transient over-speed command reaches actuator before next enforcement cycle | S2 | E3 | C3 | C | SG-001 |
-| H-016 | AEGIS_ADMIN_TOKEN absent or empty; mutation route returns 503 but system misconfigured as fail-open | OS1, OS10 | Unauthorized node registration or trust manipulation | S2 | E2 | C3 | B | SG-015 |
+| H-016 | KIRRA_ADMIN_TOKEN absent or empty; mutation route returns 503 but system misconfigured as fail-open | OS1, OS10 | Unauthorized node registration or trust manipulation | S2 | E2 | C3 | B | SG-015 |
 | H-017 | DDS actuator topic configured with TransientLocal durability; stale command delivered to reconnecting actuator | OS5 | Actuator receives outdated command from DDS history cache after reconnect | S2 | E3 | C3 | C | SG-016 |
 
 ---
@@ -108,7 +108,7 @@ See AEGIS-SG-001 for full safety goal definitions.
 
 | Field | Value |
 |-------|-------|
-| Prepared by | Aegis Engineering |
+| Prepared by | Kirra Engineering |
 | Review status | Pending TUV pre-assessment |
 | Next review | 2026-11-23 |
 | Supersedes | None |

--- a/docs/safety/IEC_61508_MAPPING.md
+++ b/docs/safety/IEC_61508_MAPPING.md
@@ -1,4 +1,4 @@
-# Aegis — IEC 61508 SIL 3 Preliminary Claim Mapping
+# Kirra — IEC 61508 SIL 3 Preliminary Claim Mapping
 
 Document ID: AEGIS-61508-001
 Version: 1.0.0
@@ -10,12 +10,12 @@ Date: 2026-05-23
 
 ## 1. Purpose
 
-This document provides a preliminary mapping of Aegis safety functions to IEC 61508 requirements for a Safety Integrity Level 3 (SIL 3) claim using the Safety Element out of Context (SEooC) model defined in IEC 61508-2 Annex B.
+This document provides a preliminary mapping of Kirra safety functions to IEC 61508 requirements for a Safety Integrity Level 3 (SIL 3) claim using the Safety Element out of Context (SEooC) model defined in IEC 61508-2 Annex B.
 
 This is a pre-assessment document intended to support:
 1. Scoping discussions with a Functional Safety assessment body (Exida, TUV SUD, SGS)
 2. Gap identification before committing to formal certification
-3. Evidence that the Aegis development approach is aligned with IEC 61508
+3. Evidence that the Kirra development approach is aligned with IEC 61508
 
 This document does not constitute a formal SIL claim. A formal claim requires an independent assessment body to verify compliance.
 
@@ -23,19 +23,19 @@ This document does not constitute a formal SIL claim. A formal claim requires an
 
 ## 2. Item Definition and Scope
 
-**E/E/PE Safety-related System:** Aegis Runtime Safety Kernel (`aegis-runtime-sdk` v1.5.0)
+**E/E/PE Safety-related System:** Kirra Runtime Safety Kernel (`kirra-runtime-sdk` v1.5.0)
 
 **Type of system:** Software SEooC — Safety Element out of Context
 
-Under the SEooC model, Aegis is certified as a software component with assumed safety requirements (ASRs). Integrators perform in-context verification to confirm ASRs are satisfied in their specific deployment.
+Under the SEooC model, Kirra is certified as a software component with assumed safety requirements (ASRs). Integrators perform in-context verification to confirm ASRs are satisfied in their specific deployment.
 
 **System boundary:**
-- In scope: All safety functions implemented in `aegis-runtime-sdk`, specifically the enforcement pipeline, posture derivation, and trust graph layer
+- In scope: All safety functions implemented in `kirra-runtime-sdk`, specifically the enforcement pipeline, posture derivation, and trust graph layer
 - Out of scope: Hardware platform, operating system, upstream AI planner, physical actuators
 
 **Claimed SIL:** SIL 3
 
-**Justification for SIL 3:** Based on the risk assessment in AEGIS-HARA-001, the highest-ASIL hazards (H-001, H-002, H-003, H-006, H-009, H-012) are rated ASIL-D under ISO 26262. The IEC 61508 equivalent is SIL 3. A SIL 4 claim would require continuous mode operation with a PFH < 10^-8/h; the command-on-demand nature of Aegis enforcement places it in high-demand mode with PFH requirements, where SIL 3 (PFH < 10^-7/h) is the appropriate target.
+**Justification for SIL 3:** Based on the risk assessment in AEGIS-HARA-001, the highest-ASIL hazards (H-001, H-002, H-003, H-006, H-009, H-012) are rated ASIL-D under ISO 26262. The IEC 61508 equivalent is SIL 3. A SIL 4 claim would require continuous mode operation with a PFH < 10^-8/h; the command-on-demand nature of Kirra enforcement places it in high-demand mode with PFH requirements, where SIL 3 (PFH < 10^-7/h) is the appropriate target.
 
 ---
 
@@ -43,7 +43,7 @@ Under the SEooC model, Aegis is certified as a software component with assumed s
 
 ### SF-001: Motion Command Velocity Clamping [SIL 3]
 
-**Description:** Aegis shall clamp the linear velocity of any motion command to the active kinematic contract's max_speed_mps before forwarding to the actuator.
+**Description:** Kirra shall clamp the linear velocity of any motion command to the active kinematic contract's max_speed_mps before forwarding to the actuator.
 
 **Implementation:** `validate_vehicle_command()` Priority 2 check in `src/gateway/kinematics_contract.rs`
 
@@ -59,7 +59,7 @@ Under the SEooC model, Aegis is certified as a software component with assumed s
 
 ### SF-002: Lateral Acceleration Constraint [SIL 3]
 
-**Description:** Aegis shall compute bicycle model lateral acceleration for every steering command and clamp steering angle when lateral acceleration would exceed max_lateral_accel_mps2.
+**Description:** Kirra shall compute bicycle model lateral acceleration for every steering command and clamp steering angle when lateral acceleration would exceed max_lateral_accel_mps2.
 
 **Implementation:** `validate_vehicle_command()` Priority 6 check — `lateral_accel = velocity^2 * tan(steering_deg.to_radians()) / wheelbase_m`
 
@@ -73,7 +73,7 @@ Under the SEooC model, Aegis is certified as a software component with assumed s
 
 ### SF-003: Posture-Gated Command Routing [SIL 3]
 
-**Description:** Aegis shall deny all WriteState and SystemMutation commands when fleet posture is Degraded, and deny all commands when fleet posture is LockedOut or the posture cache is stale.
+**Description:** Kirra shall deny all WriteState and SystemMutation commands when fleet posture is Degraded, and deny all commands when fleet posture is LockedOut or the posture cache is stale.
 
 **Implementation:** `should_route_command()` in `src/posture_cache.rs`
 
@@ -90,7 +90,7 @@ Under the SEooC model, Aegis is certified as a software component with assumed s
 
 ### SF-004: NaN/Inf Rejection [SIL 2]
 
-**Description:** Aegis shall reject any motion command containing NaN or infinite values before any arithmetic evaluation.
+**Description:** Kirra shall reject any motion command containing NaN or infinite values before any arithmetic evaluation.
 
 **Implementation:** `validate_vehicle_command()` Priority 0 check — `!field.is_finite()` for all f64 fields
 
@@ -102,7 +102,7 @@ Under the SEooC model, Aegis is certified as a software component with assumed s
 
 ### SF-005: Unknown Command Denial [SIL 3]
 
-**Description:** Aegis shall deny any action classified as OperationalCommand::Unknown in all fleet posture states, before posture evaluation.
+**Description:** Kirra shall deny any action classified as OperationalCommand::Unknown in all fleet posture states, before posture evaluation.
 
 **Implementation:** `should_route_command()` early return — `if command == OperationalCommand::Unknown { return false; }` in `src/posture_cache.rs`
 
@@ -114,7 +114,7 @@ Under the SEooC model, Aegis is certified as a software component with assumed s
 
 ### SF-006: Cross-Asset Trust Propagation [SIL 3]
 
-**Description:** In a Multi-Asset Fabric deployment, when a leader asset transitions to LockedOut, Aegis shall propagate Degraded posture to all follower assets within one fabric recalculation cycle.
+**Description:** In a Multi-Asset Fabric deployment, when a leader asset transitions to LockedOut, Kirra shall propagate Degraded posture to all follower assets within one fabric recalculation cycle.
 
 **Implementation:** `FabricRouter::propagate_cross_asset_trust()` in `src/fabric/router.rs` — 4 propagation rules (convoy, drone-controller, infrastructure, warehouse-robot)
 
@@ -128,7 +128,7 @@ IEC 61508-2 Table 2 and 3 define architectural constraints for SIL claims based 
 
 ### Software Architecture (IEC 61508-3 Clause 7.4)
 
-| Requirement | Aegis Implementation | Compliance |
+| Requirement | Kirra Implementation | Compliance |
 |-------------|---------------------|------------|
 | Modular design | Functions decomposed into layers (Trust Graph, Posture Derivation, Enforcement) | Compliant |
 | Structured programming | Rust ownership model enforces structured control flow; no goto, no unsafe on critical paths | Compliant |
@@ -139,7 +139,7 @@ IEC 61508-2 Table 2 and 3 define architectural constraints for SIL claims based 
 
 ### Avoidance of Systematic Failures (IEC 61508-3 Clause 7.4.4)
 
-| Technique | Aegis Implementation |
+| Technique | Kirra Implementation |
 |-----------|---------------------|
 | Defensive programming (B.2.2) | Fail-closed on every error path; LockedOut as default unknown posture |
 | Modular approach (B.2.4) | Three-layer architecture; each layer independently testable |
@@ -153,7 +153,7 @@ IEC 61508-2 Table 2 and 3 define architectural constraints for SIL claims based 
 
 ## 5. Software Development Process (IEC 61508-3 Part 6)
 
-| Phase | IEC 61508-3 Requirement | Aegis Status |
+| Phase | IEC 61508-3 Requirement | Kirra Status |
 |-------|------------------------|--------------|
 | Software requirements specification | Safety goals (AEGIS-SG-001) + technical requirements (AEGIS-RTM-001) | Complete (Draft) |
 | Software architecture design | Three-layer safety architecture (AEGIS-SA-001) | Complete (Draft) |
@@ -168,17 +168,17 @@ IEC 61508-2 Table 2 and 3 define architectural constraints for SIL claims based 
 
 ## 6. Assumed Safety Requirements (SEooC)
 
-For the SEooC model, Aegis declares the following Assumed Safety Requirements (ASRs) that integrators must verify in-context:
+For the SEooC model, Kirra declares the following Assumed Safety Requirements (ASRs) that integrators must verify in-context:
 
 | ASR ID | Assumption | Integrator Verification Required |
 |--------|------------|----------------------------------|
-| ASR-001 | The upstream AI planner sends commands in the ProposedVehicleCommand JSON schema via HTTP POST to the Aegis enforcement endpoint | Integrator documents the interface contract between planner and Aegis |
-| ASR-002 | AEGIS_ADMIN_TOKEN and AEGIS_SUPERVISOR_RESET_KEY are provisioned as non-empty environment variables before startup | Integrator documents key provisioning procedure |
+| ASR-001 | The upstream AI planner sends commands in the ProposedVehicleCommand JSON schema via HTTP POST to the Kirra enforcement endpoint | Integrator documents the interface contract between planner and Kirra |
+| ASR-002 | KIRRA_ADMIN_TOKEN and KIRRA_SUPERVISOR_RESET_KEY are provisioned as non-empty environment variables before startup | Integrator documents key provisioning procedure |
 | ASR-003 | The kinematic contract parameters (max_speed_mps, max_lateral_accel_mps2, wheelbase_m) are correctly configured for the specific platform | Integrator provides vehicle/robot specification and confirms parameters |
 | ASR-004 | The deployment platform provides a monotonic clock with resolution sufficient for AV_WATCHDOG_SWEEP_MS (100ms) operation | Integrator confirms platform clock specification |
 | ASR-005 | The SQLite database is on durable storage; filesystem failure is covered by the integrator's platform FMEA | Integrator documents storage reliability |
-| ASR-006 | Network latency between the AI planner and Aegis is < 50ms under normal operation | Integrator measures and documents network latency |
-| ASR-007 | The Aegis process is supervised by a process monitor (systemd, QNX resource manager, or equivalent) that restarts it on crash | Integrator documents process supervision configuration |
+| ASR-006 | Network latency between the AI planner and Kirra is < 50ms under normal operation | Integrator measures and documents network latency |
+| ASR-007 | The Kirra process is supervised by a process monitor (systemd, QNX resource manager, or equivalent) that restarts it on crash | Integrator documents process supervision configuration |
 
 ---
 
@@ -209,7 +209,7 @@ For the SEooC model, Aegis declares the following Assumed Safety Requirements (A
 
 | Field | Value |
 |-------|-------|
-| Prepared by | Aegis Engineering |
+| Prepared by | Kirra Engineering |
 | Review status | Pre-assessment (not yet reviewed by assessment body) |
 | Next review | 2026-11-23 |
 | Supersedes | None |

--- a/docs/safety/IEC_61508_SIL3_MAPPING.md
+++ b/docs/safety/IEC_61508_SIL3_MAPPING.md
@@ -86,12 +86,23 @@ Kirra implementation:
 Source: `src/posture_cache.rs`, `src/verifier.rs`
 
 #### FM-002: Redundant Safety Enforcement (Software Lockstep)
-IEC 61508 reference: §7.4.5 — Redundancy
+IEC 61508 reference: §7.4.5 — Redundancy; §7.4.4 — diverse (N-version) software
 Kirra implementation:
-- `GovernorComparator` runs two independent `KirraGovernor` instances
-- Divergence beyond `COMPARATOR_TOLERANCE = 1e-9` → `EnforcementAction::Deny` (LockedOut semantics)
-- Software equivalent of hardware dual-core lockstep (NVIDIA DRIVE AGX / NXP S32)
-Source: `parko/crates/parko-kirra/src/comparator.rs` (CERT-006)
+- `GovernorComparator` runs a primary `KirraGovernor` against a **diverse**
+  shadow `DiverseKirraGovernor` (CERT-006 diversity). The two enforce the same
+  safety properties via structurally different computation, so a systematic
+  *implementation* fault is unlikely to manifest identically in both. The
+  comparator is generic over the shadow; a second `KirraGovernor` still yields
+  the legacy identical-redundancy pairing (random-fault detection only).
+- Divergence beyond `COMPARATOR_TOLERANCE = 1e-9` → posture-aware, speed-gated
+  escalation to `EnforcementAction::Deny` (LockedOut semantics)
+- Software equivalent of hardware dual-core lockstep (NVIDIA DRIVE AGX / NXP S32),
+  now with implementation diversity layered on top
+- **Honest limit:** diversity is at the implementation layer only; primary and
+  shadow share the specification and config, so spec-level faults are NOT
+  covered. See `docs/safety/COMPARATOR_DIVERSITY.md` (DRAFT — pending review).
+Source: `parko/crates/parko-kirra/src/comparator.rs`,
+`parko/crates/parko-kirra/src/diverse.rs` (CERT-006)
 
 #### FM-003: Watchdog and Telemetry Timeout Detection
 IEC 61508 reference: §7.4.2.5 — Watchdog

--- a/docs/safety/IEC_61508_SIL3_MAPPING.md
+++ b/docs/safety/IEC_61508_SIL3_MAPPING.md
@@ -27,7 +27,7 @@ a notified body has not yet been performed.
 Relationship to the existing preliminary mapping in
 `docs/safety/IEC_61508_MAPPING.md` (AEGIS-61508-001 v1.0.0): that
 earlier document established the initial claim shape under the prior
-Aegis branding; this document (KIRRA-SIL3-001) is the up-to-date
+Kirra branding; this document (KIRRA-SIL3-001) is the up-to-date
 working mapping aligned with the current Kirra architecture and the
 CERT-track artifacts. The earlier document remains in the safety
 case index for historical traceability.

--- a/docs/safety/OCCY_SAFETY_GOALS.md
+++ b/docs/safety/OCCY_SAFETY_GOALS.md
@@ -9,7 +9,7 @@ with an *explicit, traceable* derivation.
 
 **Relationship to AEGIS-SG-001.** This document does NOT supersede
 `docs/safety/SAFETY_GOALS.md` (AEGIS-SG-001), which defines the broader
-16-goal scheme covering the full Aegis kernel scope (AV + UGV + robot + drone +
+16-goal scheme covering the full Kirra kernel scope (AV + UGV + robot + drone +
 industrial protocols + fabric). This document is the planner-focused Occy
 derivation; the two coexist. See §6.2 for the cross-mapping.
 
@@ -228,7 +228,7 @@ action).**
 ### 6.2 Mapping to AEGIS-SG-001 (preexisting kernel safety goals)
 
 The preexisting `docs/safety/SAFETY_GOALS.md` (AEGIS-SG-001 v1.0.0) defines a
-broader 16-goal scheme covering the full Aegis kernel scope. The Occy
+broader 16-goal scheme covering the full Kirra kernel scope. The Occy
 derivation here is a planner-focused subset with different numbering. Both
 schemes coexist; this table shows the correspondence so an assessor (or a code
 reviewer reading a `Safety:` traceability tag) can navigate either way.

--- a/docs/safety/REQUIREMENTS_TRACEABILITY.md
+++ b/docs/safety/REQUIREMENTS_TRACEABILITY.md
@@ -1,4 +1,4 @@
-# Aegis Safety Kernel — Requirements Traceability Matrix
+# Kirra Safety Kernel — Requirements Traceability Matrix
 
 Document ID: AEGIS-RTM-001
 Version: 1.0.0
@@ -10,7 +10,7 @@ Date: 2026-05-23
 
 ## 1. Overview
 
-This Requirements Traceability Matrix (RTM) links each Safety Goal (AEGIS-SG-001) to one or more Technical Requirements (TR), the precise implementation location within the `aegis-runtime-sdk` crate, and the test(s) that demonstrate compliance. All 16 safety goals are covered.
+This Requirements Traceability Matrix (RTM) links each Safety Goal (AEGIS-SG-001) to one or more Technical Requirements (TR), the precise implementation location within the `kirra-runtime-sdk` crate, and the test(s) that demonstrate compliance. All 16 safety goals are covered.
 
 Traceability flows in both directions:
 - **Forward:** Safety Goal -> Technical Requirement -> Implementation -> Test
@@ -25,7 +25,7 @@ Traceability flows in both directions:
 | TR ID | Technical Requirement | Implementation | Test(s) |
 |-------|-----------------------|----------------|---------|
 | TR-001 | `validate_vehicle_command` shall return `ClampLinear(max_speed_mps)` when `linear_velocity_mps.abs() > max_speed_mps` for the active kinematic contract | `src/gateway/kinematics_contract.rs:validate_vehicle_command` (Priority 2) | `test_speed_above_ceiling_triggers_clamp_linear` ✓ |
-| TR-001a | The hard velocity clamp (Priority 2) shall execute before the rate-of-change limiter in `AegisKernelGovernor`; no ordering inversion shall be permitted | `src/gateway/kinematics_contract.rs` Priority 2 precedes `src/aegis_core.rs` rate limiter | Code inspection + proptest kinematics suite |
+| TR-001a | The hard velocity clamp (Priority 2) shall execute before the rate-of-change limiter in `KirraKernelGovernor`; no ordering inversion shall be permitted | `src/gateway/kinematics_contract.rs` Priority 2 precedes `src/kirra_core.rs` rate limiter | Code inspection + proptest kinematics suite |
 | TR-001b | `validate_vehicle_command` shall return `ClampLinear(0.0)` when the kinematic contract requires a stopped state (zero-velocity fence, Priority 1) | `src/gateway/kinematics_contract.rs:validate_vehicle_command` (Priority 1) | `test_zero_velocity_fence_enforced` ✗ |
 
 ---
@@ -75,7 +75,7 @@ Traceability flows in both directions:
 | TR ID | Technical Requirement | Implementation | Test(s) |
 |-------|-----------------------|----------------|---------|
 | TR-006 | `should_route_command` shall return `false` for `OperationalCommand::Unknown` as an unconditional early return before any posture evaluation | `src/posture_cache.rs:should_route_command` (Unknown early return, step 1) | `test_unknown_command_denied_in_all_posture_states` ✗ |
-| TR-006a | The `AegisPolicyLayer` Tower middleware shall map any HTTP request that does not match a known path+method combination to `OperationalCommand::Unknown` via `classify_command` | `src/gateway/policy.rs:classify_command`, `src/gateway/policy_layer.rs:AegisPolicyLayer` | `test_unrecognized_path_classified_as_unknown` ✗ |
+| TR-006a | The `KirraPolicyLayer` Tower middleware shall map any HTTP request that does not match a known path+method combination to `OperationalCommand::Unknown` via `classify_command` | `src/gateway/policy.rs:classify_command`, `src/gateway/policy_layer.rs:KirraPolicyLayer` | `test_unrecognized_path_classified_as_unknown` ✗ |
 | TR-006b | The `ActionFilter` shall deny any `ActionClaim` that maps to `OperationalCommand::Unknown` regardless of the current fleet posture | `src/action_filter.rs:ActionFilter` | `test_action_filter_denies_unknown_action_type` ✗ |
 
 ---
@@ -94,9 +94,9 @@ Traceability flows in both directions:
 
 | TR ID | Technical Requirement | Implementation | Test(s) |
 |-------|-----------------------|----------------|---------|
-| TR-008 | `startup_sentinel` shall verify all safety invariants (admin token present, watchdog spawned, posture engine running, SQLite WAL mode active) before the TCP listener binds; on any invariant failure, the process shall abort | `src/startup_sentinel.rs`, `src/bin/aegis_verifier_service.rs` | Integration smoke test, `test_startup_aborts_without_admin_token` ✗ |
-| TR-008a | The `aegis_verifier_service` binary shall bind the TCP listener only after `startup_sentinel` succeeds; no route shall be served before all invariants pass | `src/bin/aegis_verifier_service.rs` — listener bind ordering | Integration test confirming no response before startup_sentinel completes |
-| TR-008b | The `AegisPolicyLayer` Tower middleware shall be applied to the router at construction time; there shall be no code path that serves a request without passing through the middleware | `src/gateway/policy_layer.rs:AegisPolicyLayer`, `src/bin/aegis_verifier_service.rs` | Integration test confirming all routes pass through middleware |
+| TR-008 | `startup_sentinel` shall verify all safety invariants (admin token present, watchdog spawned, posture engine running, SQLite WAL mode active) before the TCP listener binds; on any invariant failure, the process shall abort | `src/startup_sentinel.rs`, `src/bin/kirra_verifier_service.rs` | Integration smoke test, `test_startup_aborts_without_admin_token` ✗ |
+| TR-008a | The `kirra_verifier_service` binary shall bind the TCP listener only after `startup_sentinel` succeeds; no route shall be served before all invariants pass | `src/bin/kirra_verifier_service.rs` — listener bind ordering | Integration test confirming no response before startup_sentinel completes |
+| TR-008b | The `KirraPolicyLayer` Tower middleware shall be applied to the router at construction time; there shall be no code path that serves a request without passing through the middleware | `src/gateway/policy_layer.rs:KirraPolicyLayer`, `src/bin/kirra_verifier_service.rs` | Integration test confirming all routes pass through middleware |
 
 ---
 
@@ -115,8 +115,8 @@ Traceability flows in both directions:
 | TR ID | Technical Requirement | Implementation | Test(s) |
 |-------|-----------------------|----------------|---------|
 | TR-010 | `AuditChainLinker` shall reject (detect as tampered) any entry where `SHA-256(serialized(previous_entry))` does not equal the `prev_hash` field of the current entry | `src/audit_chain.rs:AuditChainLinker` | `test_audit_chain_tamper_detection` ✗ |
-| TR-010a | The `/system/audit/verify` endpoint shall perform a full chain verification and return a structured result indicating the first tampered entry index and its computed vs. expected hash | `src/bin/aegis_verifier_service.rs` — audit verify route handler | `test_audit_verify_endpoint_detects_corruption` ✗ |
-| TR-010b | Audit chain verification shall be performed automatically on service startup before the TCP listener binds | `src/startup_sentinel.rs` or `src/bin/aegis_verifier_service.rs` startup sequence | Integration test confirming startup verification |
+| TR-010a | The `/system/audit/verify` endpoint shall perform a full chain verification and return a structured result indicating the first tampered entry index and its computed vs. expected hash | `src/bin/kirra_verifier_service.rs` — audit verify route handler | `test_audit_verify_endpoint_detects_corruption` ✗ |
+| TR-010b | Audit chain verification shall be performed automatically on service startup before the TCP listener binds | `src/startup_sentinel.rs` or `src/bin/kirra_verifier_service.rs` startup sequence | Integration test confirming startup verification |
 
 ---
 
@@ -134,8 +134,8 @@ Traceability flows in both directions:
 
 | TR ID | Technical Requirement | Implementation | Test(s) |
 |-------|-----------------------|----------------|---------|
-| TR-012 | The DNP3 protocol adapter and verifier service shall write an audit chain entry for every DNP3 message with `dest_address == DNP3_BROADCAST_ADDRESS` before applying any control output | `src/adapters/dnp3.rs`, `src/bin/aegis_verifier_service.rs:evaluate_dnp3_adapter` | `test_dnp3_broadcast_always_audited` ✗ |
-| TR-012a | If the audit chain write fails for a DNP3 broadcast command, the control output shall be blocked and an error shall be returned to the caller | `src/adapters/dnp3.rs` or `src/bin/aegis_verifier_service.rs` audit-before-action ordering | `test_dnp3_broadcast_blocked_on_audit_write_failure` ✗ |
+| TR-012 | The DNP3 protocol adapter and verifier service shall write an audit chain entry for every DNP3 message with `dest_address == DNP3_BROADCAST_ADDRESS` before applying any control output | `src/adapters/dnp3.rs`, `src/bin/kirra_verifier_service.rs:evaluate_dnp3_adapter` | `test_dnp3_broadcast_always_audited` ✗ |
+| TR-012a | If the audit chain write fails for a DNP3 broadcast command, the control output shall be blocked and an error shall be returned to the caller | `src/adapters/dnp3.rs` or `src/bin/kirra_verifier_service.rs` audit-before-action ordering | `test_dnp3_broadcast_blocked_on_audit_write_failure` ✗ |
 | TR-012b | Non-broadcast DNP3 commands (unicast) shall also be audited, but an audit write failure for a non-broadcast command shall not block the control output | `src/adapters/dnp3.rs` | `test_dnp3_unicast_audit_failure_non_fatal` ✗ |
 
 ---
@@ -164,9 +164,9 @@ Traceability flows in both directions:
 
 | TR ID | Technical Requirement | Implementation | Test(s) |
 |-------|-----------------------|----------------|---------|
-| TR-015 | `require_admin_token` shall return HTTP 503 when `std::env::var("AEGIS_ADMIN_TOKEN")` returns `Err` or an empty string; it shall never return a 200-series or 400-series response in this condition | `src/bin/aegis_verifier_service.rs:require_admin_token` | `test_admin_token_absent_returns_503` ✗ |
-| TR-015a | `require_admin_token` shall be called on every mutation route handler; no mutation route shall be reachable without passing through `require_admin_token` | `src/bin/aegis_verifier_service.rs` — all admin route handlers | Code inspection + integration test matrix covering all mutation routes |
-| TR-015b | Token comparison in `require_admin_token` shall use `constant_time_compare` from `src/security.rs`; standard `==` operator shall not be used on the token bytes | `src/security.rs:constant_time_compare`, `src/bin/aegis_verifier_service.rs:require_admin_token` | Code inspection |
+| TR-015 | `require_admin_token` shall return HTTP 503 when `std::env::var("KIRRA_ADMIN_TOKEN")` returns `Err` or an empty string; it shall never return a 200-series or 400-series response in this condition | `src/bin/kirra_verifier_service.rs:require_admin_token` | `test_admin_token_absent_returns_503` ✗ |
+| TR-015a | `require_admin_token` shall be called on every mutation route handler; no mutation route shall be reachable without passing through `require_admin_token` | `src/bin/kirra_verifier_service.rs` — all admin route handlers | Code inspection + integration test matrix covering all mutation routes |
+| TR-015b | Token comparison in `require_admin_token` shall use `constant_time_compare` from `src/security.rs`; standard `==` operator shall not be used on the token bytes | `src/security.rs:constant_time_compare`, `src/bin/kirra_verifier_service.rs:require_admin_token` | Code inspection |
 
 ---
 
@@ -184,21 +184,21 @@ Traceability flows in both directions:
 
 | Safety Goal | ASIL | TR Count | Implementation Files | Test Count |
 |-------------|------|----------|----------------------|------------|
-| SG-001 | D | 3 (TR-001, TR-001a, TR-001b) | src/gateway/kinematics_contract.rs, src/aegis_core.rs | 3+ |
+| SG-001 | D | 3 (TR-001, TR-001a, TR-001b) | src/gateway/kinematics_contract.rs, src/kirra_core.rs | 3+ |
 | SG-002 | D | 3 (TR-002, TR-002a, TR-002b) | src/gateway/kinematics_contract.rs, src/kinematics_sim.rs | 3+ |
 | SG-003 | D | 3 (TR-003, TR-003a, TR-003b) | src/telemetry_watchdog.rs | 3+ |
 | SG-004 | C | 3 (TR-004, TR-004a, TR-004b) | src/gateway/kinematics_contract.rs, src/ros2_adapter.rs | 3+ |
 | SG-005 | D | 3 (TR-005, TR-005a, TR-005b) | src/posture_engine_v2.rs, src/posture_cache.rs | 2+ |
 | SG-006 | D | 3 (TR-006, TR-006a, TR-006b) | src/posture_cache.rs, src/gateway/policy.rs, src/action_filter.rs | 3+ |
 | SG-007 | D | 3 (TR-007, TR-007a, TR-007b) | src/fabric/router.rs, src/fabric/causal_log.rs | 2+ |
-| SG-008 | D | 3 (TR-008, TR-008a, TR-008b) | src/startup_sentinel.rs, src/bin/aegis_verifier_service.rs | 3+ |
+| SG-008 | D | 3 (TR-008, TR-008a, TR-008b) | src/startup_sentinel.rs, src/bin/kirra_verifier_service.rs | 3+ |
 | SG-009 | B | 3 (TR-009, TR-009a, TR-009b) | src/standby_monitor.rs | 3+ |
-| SG-010 | B | 3 (TR-010, TR-010a, TR-010b) | src/audit_chain.rs, src/bin/aegis_verifier_service.rs | 2+ |
+| SG-010 | B | 3 (TR-010, TR-010a, TR-010b) | src/audit_chain.rs, src/bin/kirra_verifier_service.rs | 2+ |
 | SG-011 | C | 3 (TR-011, TR-011a, TR-011b) | src/adapters/canopen.rs | 3+ |
-| SG-012 | B | 3 (TR-012, TR-012a, TR-012b) | src/adapters/dnp3.rs, src/bin/aegis_verifier_service.rs | 3+ |
+| SG-012 | B | 3 (TR-012, TR-012a, TR-012b) | src/adapters/dnp3.rs, src/bin/kirra_verifier_service.rs | 3+ |
 | SG-013 | B | 3 (TR-013, TR-013a, TR-013b) | src/recovery_hysteresis.rs | 3+ |
 | SG-014 | B | 3 (TR-014, TR-014a, TR-014b) | src/federation_reconciliation.rs, src/federation.rs | 3+ |
-| SG-015 | B | 3 (TR-015, TR-015a, TR-015b) | src/bin/aegis_verifier_service.rs, src/security.rs | 2+ |
+| SG-015 | B | 3 (TR-015, TR-015a, TR-015b) | src/bin/kirra_verifier_service.rs, src/security.rs | 2+ |
 | SG-016 | C | 3 (TR-016, TR-016a, TR-016b) | src/dds_bridge.rs, src/startup_sentinel.rs | 1+ |
 
 **Total Technical Requirements:** 48
@@ -210,10 +210,10 @@ Traceability flows in both directions:
 
 The following items require additional traceability work before ASIL-D certification submission:
 
-1. ROS2 interlock node behavior (ros2_ws/src/aegis_safety/) — functional requirements exist but TR linkage to safety goals is pending.
+1. ROS2 interlock node behavior (ros2_ws/src/kirra_safety/) — functional requirements exist but TR linkage to safety goals is pending.
 2. EtherNet/IP adapter (src/adapters/ethernet_ip.rs) — safety-relevant behavior not yet assessed in HARA; addendum HARA update planned.
 3. Modbus and OPC-UA adapters (src/protocol_adapter.rs) — partial coverage; audit requirements to be confirmed.
-4. CARLA integration (src/bin/aegis_carla_client.rs) — not in scope for vehicle safety case; separate assessment for simulation environment.
+4. CARLA integration (src/bin/kirra_carla_client.rs) — not in scope for vehicle safety case; separate assessment for simulation environment.
 
 ---
 
@@ -221,7 +221,7 @@ The following items require additional traceability work before ASIL-D certifica
 
 | Field | Value |
 |-------|-------|
-| Prepared by | Aegis Engineering |
+| Prepared by | Kirra Engineering |
 | Review status | Pending TUV pre-assessment |
 | Next review | 2026-11-23 |
 | Supersedes | None |

--- a/docs/safety/ROADMAP_TO_ASIL_D.md
+++ b/docs/safety/ROADMAP_TO_ASIL_D.md
@@ -1,4 +1,4 @@
-# Aegis Safety Kernel — ASIL-D Certification Roadmap
+# Kirra Safety Kernel — ASIL-D Certification Roadmap
 
 Document ID: AEGIS-ROAD-001
 Version: 1.0.0
@@ -10,10 +10,10 @@ Date: 2026-05-23
 
 ## 1. Overview
 
-This document defines the roadmap for achieving ISO 26262 ASIL-D certification for the Aegis Runtime Safety Kernel (`aegis-runtime-sdk` v1.5.0 and subsequent versions). The roadmap is organized into five phases, each with defined entry criteria, deliverables, exit criteria, and estimated duration.
+This document defines the roadmap for achieving ISO 26262 ASIL-D certification for the Kirra Runtime Safety Kernel (`kirra-runtime-sdk` v1.5.0 and subsequent versions). The roadmap is organized into five phases, each with defined entry criteria, deliverables, exit criteria, and estimated duration.
 
 The target certification scope is:
-- Item: Aegis Runtime Safety Kernel (software element)
+- Item: Kirra Runtime Safety Kernel (software element)
 - ASIL: ASIL D (highest integrity level, per AEGIS-HARA-001)
 - Standard: ISO 26262:2018 (second edition), Parts 1-9
 - Supplementary: IEC 62443 (industrial cybersecurity), ROS 2 Safety WG recommendations
@@ -181,7 +181,7 @@ Address open issues from AEGIS-SC-000 Section 4:
 
 ### 5.1 Objectives
 
-Qualify the target execution platform to a level commensurate with ASIL D requirements for the Aegis safety kernel deployment. The primary target platform is QNX Neutrino RTOS for automotive-grade deployments.
+Qualify the target execution platform to a level commensurate with ASIL D requirements for the Kirra safety kernel deployment. The primary target platform is QNX Neutrino RTOS for automotive-grade deployments.
 
 ### 5.2 Background
 
@@ -189,7 +189,7 @@ ISO 26262-6:2018 §5.4.3 requires that the operating environment (OS, RTOS, hard
 - Qualified as a Safety Element out of Context (SEooC) to the required ASIL, or
 - Assessed as a pre-existing element with sufficient evidence of fitness for purpose
 
-QNX Neutrino RTOS 7.1 is commercially available with TUV Rheinland ASIL D certification under ISO 26262. Aegis deployed on QNX can reference this existing certification.
+QNX Neutrino RTOS 7.1 is commercially available with TUV Rheinland ASIL D certification under ISO 26262. Kirra deployed on QNX can reference this existing certification.
 
 Linux-based deployments require a separate assessment. A Linux real-time kernel with PREEMPT_RT patch and appropriate hardening may achieve ASIL B; ASIL D on Linux requires additional mitigations (partitioning, hypervisor).
 
@@ -197,14 +197,14 @@ Linux-based deployments require a separate assessment. A Linux real-time kernel 
 
 | Deliverable | Description | Target |
 |-------------|-------------|--------|
-| Platform Assessment Report | Assessment of QNX 7.1 for Aegis deployment | Q3 2026 |
+| Platform Assessment Report | Assessment of QNX 7.1 for Kirra deployment | Q3 2026 |
 | Hardware Qualification Plan | Assessment of target ECU hardware | Q3 2026 |
 | Timing Analysis | WCET analysis for enforce path on target hardware | Q4 2026 |
 | Memory Footprint Analysis | Stack and heap usage for safety-critical tasks | Q4 2026 |
 
 ### 5.4 QNX-Specific Integration Requirements
 
-- Aegis posture engine worker shall be a dedicated QNX pulse-based thread at a fixed RT priority above the command handler threads
+- Kirra posture engine worker shall be a dedicated QNX pulse-based thread at a fixed RT priority above the command handler threads
 - The telemetry watchdog shall use QNX timer_create with CLOCK_MONOTONIC to guarantee sweep interval accuracy
 - Stack allocation for safety-critical threads shall be pre-allocated and guarded with stack canaries
 - The DDS bridge shall use the QNX DDS (OMG DDS for Embedded, or a QNX-certified DDS implementation)
@@ -225,7 +225,7 @@ Linux-based deployments require a separate assessment. A Linux real-time kernel 
 |-----------|-------------|
 | Target hardware selected | 2026-07-01 |
 | QNX platform assessment initiated | 2026-07-15 |
-| Aegis ported to QNX and building cleanly | 2026-08-15 |
+| Kirra ported to QNX and building cleanly | 2026-08-15 |
 | WCET measurement infrastructure deployed | 2026-09-01 |
 | WCET measurements complete and within bounds | 2026-10-15 |
 | Platform Assessment Report issued | 2026-11-01 |
@@ -314,7 +314,7 @@ The pre-assessment shall cover:
 
 ### 7.1 Objectives
 
-Achieve ISO 26262 ASIL D certification for the Aegis Runtime Safety Kernel from a recognized accreditation body. The certification covers the software item as defined in AEGIS-HARA-001 deployed on the qualified QNX platform.
+Achieve ISO 26262 ASIL D certification for the Kirra Runtime Safety Kernel from a recognized accreditation body. The certification covers the software item as defined in AEGIS-HARA-001 deployed on the qualified QNX platform.
 
 ### 7.2 Certification Process
 
@@ -324,7 +324,7 @@ Achieve ISO 26262 ASIL D certification for the Aegis Runtime Safety Kernel from 
 4. **Test Witness:** Assessor witnesses execution of the complete test suite (306+ tests) on target hardware; reviews MC/DC coverage reports.
 5. **Process Audit:** Assessor audits software development process artifacts: configuration management records, change requests, review records, defect tracking.
 6. **Assessment Report:** Assessor issues assessment report with findings.
-7. **Certificate Issuance:** Following resolution of assessment findings, certificate of conformance to ISO 26262 ASIL D is issued for aegis-runtime-sdk.
+7. **Certificate Issuance:** Following resolution of assessment findings, certificate of conformance to ISO 26262 ASIL D is issued for kirra-runtime-sdk.
 
 ### 7.3 Certification Maintenance
 
@@ -349,7 +349,7 @@ After initial certification, the following activities maintain certification val
 
 ### 7.5 Exit Criteria
 
-- Certificate of conformance to ISO 26262 ASIL D issued by accredited body for `aegis-runtime-sdk` as deployed on qualified QNX platform
+- Certificate of conformance to ISO 26262 ASIL D issued by accredited body for `kirra-runtime-sdk` as deployed on qualified QNX platform
 - No open blocking or major findings from assessment
 - Certification maintenance plan established and approved
 
@@ -404,7 +404,7 @@ Phase 1 (Foundation)
 
 | Field | Value |
 |-------|-------|
-| Prepared by | Aegis Engineering |
+| Prepared by | Kirra Engineering |
 | Review status | Pending TUV pre-assessment |
 | Next review | 2026-11-23 |
 | Supersedes | None |

--- a/docs/safety/SAFETY_ARCHITECTURE.md
+++ b/docs/safety/SAFETY_ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Aegis Safety Kernel — Safety Architecture
+# Kirra Safety Kernel — Safety Architecture
 
 Document ID: AEGIS-SA-001
 Version: 1.0.0
@@ -10,9 +10,9 @@ Date: 2026-05-23
 
 ## 1. Overview
 
-The Aegis safety architecture is organized as three independent, sequentially ordered enforcement layers. A vehicle command must pass through all three layers before it can reach a downstream actuator. Each layer independently implements one or more safety goals and has its own failure mode and mitigation strategy. In addition, supplementary safety mechanisms provide cross-cutting protections that apply to multiple layers and safety goals.
+The Kirra safety architecture is organized as three independent, sequentially ordered enforcement layers. A vehicle command must pass through all three layers before it can reach a downstream actuator. Each layer independently implements one or more safety goals and has its own failure mode and mitigation strategy. In addition, supplementary safety mechanisms provide cross-cutting protections that apply to multiple layers and safety goals.
 
-This document references source file paths within the `aegis-runtime-sdk` crate (v1.5.0). All paths are relative to the crate root at `src/`.
+This document references source file paths within the `kirra-runtime-sdk` crate (v1.5.0). All paths are relative to the crate root at `src/`.
 
 ---
 
@@ -184,7 +184,7 @@ Layer 3 applies posture-aware command routing and hard kinematic envelope enforc
 | 6 | Bicycle model lateral acceleration: compute `v^2 / R` and clamp steering if result exceeds `max_lateral_accel_mps2` | SG-002 |
 | 7 | Kinematics forward simulation validation | SG-001, SG-002 |
 
-The hard velocity clamp (Priority 2) always executes before the rate-of-change limiter (implemented in `src/aegis_core.rs`), satisfying the invariant that the envelope cap always wins over rate priority.
+The hard velocity clamp (Priority 2) always executes before the rate-of-change limiter (implemented in `src/kirra_core.rs`), satisfying the invariant that the envelope cap always wins over rate priority.
 
 **Test coverage:** Unit test suite including `test_speed_above_ceiling_triggers_clamp_linear`, `test_nominal_highway_speed_high_steering_clamps_steering`, `test_nan_linear_velocity_is_denied`, `test_inf_linear_velocity_is_denied`, plus the full proptest suite in `src/gateway/kinematics_proptest.rs`.
 **Failure mode:** Incorrect contract loaded for current posture (e.g., Nominal contract applied during Degraded posture).
@@ -214,9 +214,9 @@ The `OperationalCommand::Unknown` early return (step 1) is a protected invariant
 
 **Mechanism ID:** M-007
 **Safety Goals implemented:** SG-006, SG-008
-**Implementation location:** `src/gateway/policy_layer.rs` — `AegisPolicyLayer`
+**Implementation location:** `src/gateway/policy_layer.rs` — `KirraPolicyLayer`
 
-`AegisPolicyLayer` is a Tower middleware that wraps the axum HTTP service. For each incoming request, it:
+`KirraPolicyLayer` is a Tower middleware that wraps the axum HTTP service. For each incoming request, it:
 
 1. Calls `classify_command()` (`src/gateway/policy.rs`) to map the HTTP path and method to an `OperationalCommand`.
 2. Calls `should_route_command()` with the classified command and the current posture cache.
@@ -370,7 +370,7 @@ Time-dependent functions (`resolve_posture_with_reason`, `should_route_command`,
 
 | Field | Value |
 |-------|-------|
-| Prepared by | Aegis Engineering |
+| Prepared by | Kirra Engineering |
 | Review status | Pending TUV pre-assessment |
 | Next review | 2026-11-23 |
 | Supersedes | None |

--- a/docs/safety/SAFETY_CASE_INDEX.md
+++ b/docs/safety/SAFETY_CASE_INDEX.md
@@ -25,6 +25,7 @@ Date: 2026-05-23
 | AEGIS-61508-001 | IEC 61508 SIL 3 Preliminary Claim Mapping | 1.0.0 | Draft | docs/safety/IEC_61508_MAPPING.md | 2026-05-23 |
 | KIRRA-SIL3-001 | IEC 61508 SIL 3 Requirements Mapping (current) | 1.0 | Draft | docs/safety/IEC_61508_SIL3_MAPPING.md | 2026-05-29 |
 | KIRRA-REV-001 | External Security/Safety Review Wrap-Up | 1.0 | Final | docs/safety/REVIEW_WRAPUP_2026-05-30.md | 2026-05-30 |
+| KIRRA-CERT006-DIVERSITY-001 | Governor Comparator Diversity Argument (CERT-006; structural/algorithmic diverse shadow + honest limits) | 0.1 | Draft — pending review | docs/safety/COMPARATOR_DIVERSITY.md | 2026-06-01 |
 | KIRRA-OCCY-SG-001 | Occy Safety Goals (HARA + STPA derivation for Occy planner item; complements AEGIS-SG-001) | 0.1 | Draft | docs/safety/OCCY_SAFETY_GOALS.md | 2026-05-30 |
 | KIRRA-OCCY-ODD-001 | Occy ODD + SOTIF triggering-condition catalog (ISO 21448) | 0.1 | Draft | docs/safety/OCCY_SOTIF.md | 2026-05-31 |
 | KIRRA-OCCY-SPEED-001 | Occy speed-envelope analysis (SSD / breaking-point / derate) | 0.1 | Draft | docs/safety/SPEED_ENVELOPE.md | 2026-05-31 |

--- a/docs/safety/SAFETY_CASE_INDEX.md
+++ b/docs/safety/SAFETY_CASE_INDEX.md
@@ -1,4 +1,4 @@
-# Aegis Safety Kernel — Safety Case Index
+# Kirra Safety Kernel — Safety Case Index
 
 Document ID: AEGIS-SC-000
 Version: 1.0.0
@@ -53,15 +53,15 @@ Date: 2026-05-23
 
 ## 2. Safety Case Argument Structure
 
-The Aegis safety case is structured using the Goal Structuring Notation (GSN) as defined in GSN Community Standard v3 and as recommended by ISO 26262-2:2018 Annex B. The top-level safety claim and supporting argument are described below.
+The Kirra safety case is structured using the Goal Structuring Notation (GSN) as defined in GSN Community Standard v3 and as recommended by ISO 26262-2:2018 Annex B. The top-level safety claim and supporting argument are described below.
 
 ### 2.1 Top-Level Safety Claim
 
-**G-TOP:** The Aegis Runtime Safety Kernel (aegis-runtime-sdk v1.5.0) is sufficiently safe for use as a real-time command enforcement layer in autonomous vehicle, robot, drone, and industrial control deployments operating under ISO 26262 Part 3 item definition AEGIS-HARA-001.
+**G-TOP:** The Kirra Runtime Safety Kernel (kirra-runtime-sdk v1.5.0) is sufficiently safe for use as a real-time command enforcement layer in autonomous vehicle, robot, drone, and industrial control deployments operating under ISO 26262 Part 3 item definition AEGIS-HARA-001.
 
 ### 2.2 Context
 
-**C-01:** The Aegis item is as defined in AEGIS-HARA-001 Section 1 (Item Definition): the `aegis-runtime-sdk` crate, the `aegis_verifier_service` binary, the ROS2 safety interlock nodes, the industrial protocol adapters, and the multi-asset safety fabric.
+**C-01:** The Kirra item is as defined in AEGIS-HARA-001 Section 1 (Item Definition): the `kirra-runtime-sdk` crate, the `kirra_verifier_service` binary, the ROS2 safety interlock nodes, the industrial protocol adapters, and the multi-asset safety fabric.
 
 **C-02:** "Sufficiently safe" means that all 17 hazards identified in AEGIS-HARA-001 Section 3 are mitigated to their required ASIL level through the implementation of safety goals SG-001 through SG-016 in AEGIS-SG-001.
 
@@ -118,11 +118,11 @@ Supporting evidence:
 
 The following claims are identified but not yet fully supported by evidence. They represent gaps to be addressed in the certification roadmap (AEGIS-ROAD-001):
 
-**G-PROCESS:** The Aegis software was developed in accordance with a qualified ISO 26262-compliant process, including: qualified tools, configuration management, change management, and systematic verification.
+**G-PROCESS:** The Kirra software was developed in accordance with a qualified ISO 26262-compliant process, including: qualified tools, configuration management, change management, and systematic verification.
 
 Status: Process documentation in progress. See AEGIS-ROAD-001 Phase 2.
 
-**G-PLATFORM:** The platform on which Aegis executes (OS, hardware, compiler) is qualified to a level commensurate with ASIL D.
+**G-PLATFORM:** The platform on which Kirra executes (OS, hardware, compiler) is qualified to a level commensurate with ASIL D.
 
 Status: Ferrocene compiler qualification in progress. QNX platform assessment pending. See AEGIS-ROAD-001 Phase 3.
 
@@ -172,7 +172,7 @@ AEGIS-SG-001 (Safety Goals)
 
 | Field | Value |
 |-------|-------|
-| Prepared by | Aegis Engineering |
+| Prepared by | Kirra Engineering |
 | Review status | Pending TUV pre-assessment |
 | Next review | 2026-11-23 |
 | Supersedes | None |

--- a/docs/safety/SAFETY_GOALS.md
+++ b/docs/safety/SAFETY_GOALS.md
@@ -1,4 +1,4 @@
-# Aegis Safety Kernel — Safety Goals
+# Kirra Safety Kernel — Safety Goals
 
 Document ID: AEGIS-SG-001
 Version: 1.0.0
@@ -12,7 +12,7 @@ Date: 2026-05-23
 
 This document defines the Safety Goals (SG) derived from the Hazard Analysis and Risk Assessment (AEGIS-HARA-001). Each safety goal is assigned an ASIL level, a precise and testable goal statement, a safe state, a Fault Tolerant Time Interval (FTTI), and a verification method.
 
-Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and are the primary input to safety requirements decomposition.
+Safety goals are allocated to the `kirra-runtime-sdk` v1.5.0 software item and are the primary input to safety requirements decomposition.
 
 ---
 
@@ -24,7 +24,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** D
 **Derived from:** H-001, H-015
-**Goal statement:** The Aegis safety kernel shall prevent any command with an absolute linear velocity (linear_velocity_mps) exceeding the active kinematic contract's max_speed_mps from being delivered to a downstream actuator. The hard envelope cap shall be applied before any rate-of-change limiter, such that no transient overspeed command can pass through in any enforcement cycle.
+**Goal statement:** The Kirra safety kernel shall prevent any command with an absolute linear velocity (linear_velocity_mps) exceeding the active kinematic contract's max_speed_mps from being delivered to a downstream actuator. The hard envelope cap shall be applied before any rate-of-change limiter, such that no transient overspeed command can pass through in any enforcement cycle.
 **Safe state:** The commanded velocity is clamped to max_speed_mps; the enforcement decision is logged to the audit chain; the original command is not forwarded.
 **FTTI:** 50 ms (one enforcement cycle; must be enforced on the command as received, not deferred)
 **Verification method:** Unit test (test_speed_above_ceiling_triggers_clamp_linear), property-based test (proptest kinematics suite), integration test with CARLA simulator, code inspection of priority ordering in validate_vehicle_command
@@ -35,7 +35,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** D
 **Derived from:** H-002
-**Goal statement:** The Aegis safety kernel shall compute the implied lateral acceleration for every vehicle command using the bicycle kinematic model and shall prevent delivery of any command that would cause lateral acceleration exceeding the active contract's max_lateral_accel_mps2.
+**Goal statement:** The Kirra safety kernel shall compute the implied lateral acceleration for every vehicle command using the bicycle kinematic model and shall prevent delivery of any command that would cause lateral acceleration exceeding the active contract's max_lateral_accel_mps2.
 **Safe state:** Steering angle is clamped such that the resulting lateral acceleration is at or below max_lateral_accel_mps2; the enforcement decision is logged; the original command is not forwarded.
 **FTTI:** 50 ms
 **Verification method:** Unit test (test_nominal_highway_speed_high_steering_clamps_steering), property-based test (kinematics_proptest.rs), forward simulator validation (kinematics_sim.rs)
@@ -46,7 +46,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** D
 **Derived from:** H-003
-**Goal statement:** The Aegis telemetry watchdog shall detect the absence of telemetry from any registered AV sensor node within AV_TELEMETRY_TIMEOUT_MS (2000 ms) and shall transition that node to the Untrusted trust state, triggering fleet posture recalculation, within one watchdog sweep interval (AV_WATCHDOG_SWEEP_MS = 100 ms) after the timeout expires.
+**Goal statement:** The Kirra telemetry watchdog shall detect the absence of telemetry from any registered AV sensor node within AV_TELEMETRY_TIMEOUT_MS (2000 ms) and shall transition that node to the Untrusted trust state, triggering fleet posture recalculation, within one watchdog sweep interval (AV_WATCHDOG_SWEEP_MS = 100 ms) after the timeout expires.
 **Safe state:** The sensor node is marked Untrusted; fleet posture is recalculated; if posture transitions to Degraded or LockedOut, the posture cache is updated and all subsequent commands are evaluated under the new posture.
 **FTTI:** AV_TELEMETRY_TIMEOUT_MS + AV_WATCHDOG_SWEEP_MS = 2100 ms
 **Verification method:** Unit test (test_watchdog_marks_node_untrusted_after_timeout), temporal integration test via ScenarioRunner with VirtualClock injection, inspection of spawn_telemetry_watchdog loop interval
@@ -57,7 +57,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** C
 **Derived from:** H-005
-**Goal statement:** The Aegis gateway shall reject any vehicle command containing a non-finite (NaN or Inf) value in any f64 field before performing any arithmetic on that command. The rejection shall occur as the first check (Priority 0) in validate_vehicle_command, prior to all other enforcement logic.
+**Goal statement:** The Kirra gateway shall reject any vehicle command containing a non-finite (NaN or Inf) value in any f64 field before performing any arithmetic on that command. The rejection shall occur as the first check (Priority 0) in validate_vehicle_command, prior to all other enforcement logic.
 **Safe state:** The command is rejected with an appropriate error variant; no arithmetic is performed on the non-finite value; the rejection is logged to the audit chain.
 **FTTI:** 50 ms
 **Verification method:** Unit tests (test_nan_linear_velocity_is_denied, test_inf_linear_velocity_is_denied), property-based test generating arbitrary f64 combinations including NaN/Inf
@@ -68,7 +68,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** D
 **Derived from:** H-004
-**Goal statement:** The Aegis posture resolution function shall return a LockedOut result with reason PostureCacheStale when the cached fleet posture age meets or exceeds POSTURE_CACHE_TTL_MS (5000 ms). The system shall never evaluate a vehicle command against a stale posture cache.
+**Goal statement:** The Kirra posture resolution function shall return a LockedOut result with reason PostureCacheStale when the cached fleet posture age meets or exceeds POSTURE_CACHE_TTL_MS (5000 ms). The system shall never evaluate a vehicle command against a stale posture cache.
 **Safe state:** Commands are blocked (fail-closed) until the posture cache is refreshed with a valid recalculation result; the stale-cache lockout reason is logged.
 **FTTI:** POSTURE_CACHE_TTL_MS = 5000 ms (cache staleness is the bound; lockout is immediate upon detection)
 **Verification method:** Unit test (test_stale_cache_fails_closed_after_virtual_clock_advance) using VirtualClock injection, integration test confirming no command passes during stale window
@@ -79,7 +79,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** D
 **Derived from:** H-009
-**Goal statement:** The Aegis command router shall deny OperationalCommand::Unknown before performing any posture evaluation, in all posture states including Nominal. The early return on Unknown shall be the first check in should_route_command and shall never be conditioned on posture state.
+**Goal statement:** The Kirra command router shall deny OperationalCommand::Unknown before performing any posture evaluation, in all posture states including Nominal. The early return on Unknown shall be the first check in should_route_command and shall never be conditioned on posture state.
 **Safe state:** The command is denied; the denial is logged; the fleet posture is unaffected.
 **FTTI:** Synchronous; enforced within the request handling cycle (< 10 ms)
 **Verification method:** Unit test (test_unknown_command_denied_in_all_posture_states), code inspection of should_route_command to verify unconditional early return, mutation testing to confirm the check cannot be removed without test failure
@@ -90,7 +90,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** D
 **Derived from:** H-012
-**Goal statement:** When a leader asset in a multi-asset fabric transitions to LockedOut posture, the Aegis fabric router shall propagate a Degraded posture state to all follower assets registered in the cross-asset dependency group within one propagation cycle (defined by the fabric governor tick interval).
+**Goal statement:** When a leader asset in a multi-asset fabric transitions to LockedOut posture, the Kirra fabric router shall propagate a Degraded posture state to all follower assets registered in the cross-asset dependency group within one propagation cycle (defined by the fabric governor tick interval).
 **Safe state:** Follower assets receive Degraded posture; their command enforcement applies the Degraded contract (ReadTelemetry only); motion commands are blocked on all followers until the leader recovers.
 **FTTI:** One fabric governor tick interval (implementation-defined; target <= 500 ms)
 **Verification method:** Integration test (test_convoy_leader_lockout_degrades_followers), fabric unit tests in src/fabric/router.rs
@@ -101,10 +101,10 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** D
 **Derived from:** H-006
-**Goal statement:** The Aegis verifier service shall perform a startup invariant check via startup_sentinel before accepting any command traffic. If any invariant check fails, the process shall abort rather than enter a fail-open state. The service architecture shall not permit command forwarding to bypass the posture enforcement layer.
+**Goal statement:** The Kirra verifier service shall perform a startup invariant check via startup_sentinel before accepting any command traffic. If any invariant check fails, the process shall abort rather than enter a fail-open state. The service architecture shall not permit command forwarding to bypass the posture enforcement layer.
 **Safe state:** Process aborts cleanly; no commands are forwarded; the upstream AI planner receives connection-refused or timeout errors and must handle the absence of the enforcement layer.
 **FTTI:** Startup check must complete before the TCP listener binds; no commands accepted until all invariants pass.
-**Verification method:** Integration smoke test confirming service startup with valid configuration, negative test confirming abort on missing AEGIS_ADMIN_TOKEN, code inspection of startup_sentinel invariant list
+**Verification method:** Integration smoke test confirming service startup with valid configuration, negative test confirming abort on missing KIRRA_ADMIN_TOKEN, code inspection of startup_sentinel invariant list
 
 ---
 
@@ -123,7 +123,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** B
 **Derived from:** H-008
-**Goal statement:** The Aegis audit chain linker shall detect any modification to a previously written audit entry by verifying that the prev_hash field of each entry matches SHA-256(previous_entry_serialized). Verification shall be available on demand via the /system/audit/verify endpoint and shall be performed automatically on startup.
+**Goal statement:** The Kirra audit chain linker shall detect any modification to a previously written audit entry by verifying that the prev_hash field of each entry matches SHA-256(previous_entry_serialized). Verification shall be available on demand via the /system/audit/verify endpoint and shall be performed automatically on startup.
 **Safe state:** Tampered entries are detected and reported; the verification result is logged; the system continues operating but flags the chain integrity failure for operator review.
 **FTTI:** Verification is on-demand; tamper detection latency is bounded by the time between audit operations.
 **Verification method:** Unit test (test_audit_chain_tamper_detection), code inspection of AuditChainLinker hash verification logic, fuzz test injecting corrupted bytes at random entry positions
@@ -134,7 +134,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** C
 **Derived from:** H-010
-**Goal statement:** The Aegis CANOpen protocol adapter shall interpret NMT commands with data[0] values of 0x02 (Stop), 0x80 (Pre-Operational), 0x81 (Reset Node), or 0x82 (Reset Communication) as posture-affecting events and shall set triggers_recalculation=true, causing the posture engine to recalculate fleet posture within one engine cycle.
+**Goal statement:** The Kirra CANOpen protocol adapter shall interpret NMT commands with data[0] values of 0x02 (Stop), 0x80 (Pre-Operational), 0x81 (Reset Node), or 0x82 (Reset Communication) as posture-affecting events and shall set triggers_recalculation=true, causing the posture engine to recalculate fleet posture within one engine cycle.
 **Safe state:** The posture engine recalculates posture reflecting the NMT state change; if posture degrades, subsequent commands are evaluated under the updated posture.
 **FTTI:** One posture engine cycle (coalescing mpsc channel, target <= 200 ms)
 **Verification method:** Unit test (test_canopen_nmt_stop_triggers_posture_recalculation), adapter integration test with synthetic CANOpen frames
@@ -145,7 +145,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** B
 **Derived from:** H-011
-**Goal statement:** The Aegis DNP3 protocol adapter and verifier service shall write an audit chain entry for every DNP3 message with a destination address equal to DNP3_BROADCAST_ADDRESS before any control output is applied. The audit entry shall be written atomically before the control effect is permitted.
+**Goal statement:** The Kirra DNP3 protocol adapter and verifier service shall write an audit chain entry for every DNP3 message with a destination address equal to DNP3_BROADCAST_ADDRESS before any control output is applied. The audit entry shall be written atomically before the control effect is permitted.
 **Safe state:** The audit entry is written before the control output; if the audit write fails, the control output is blocked (fail-closed audit ordering).
 **FTTI:** Synchronous; audit write precedes control output within the same request handling cycle.
 **Verification method:** Unit test (test_dnp3_broadcast_always_audited), code inspection confirming audit-before-action ordering in evaluate_dnp3_adapter
@@ -156,7 +156,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** B
 **Derived from:** H-013
-**Goal statement:** The Aegis recovery hysteresis evaluator shall require exactly AV_RECOVERY_STREAK_THRESHOLD (5) consecutive healthy sensor reports, all arriving within a single AV_RECOVERY_WINDOW_MS (10000 ms) window, before transitioning a node from Untrusted to Trusted. Any gap between consecutive reports that exceeds AV_RECOVERY_WINDOW_MS shall reset the streak counter to zero. Any single unhealthy report during recovery shall reset the streak counter to zero.
+**Goal statement:** The Kirra recovery hysteresis evaluator shall require exactly AV_RECOVERY_STREAK_THRESHOLD (5) consecutive healthy sensor reports, all arriving within a single AV_RECOVERY_WINDOW_MS (10000 ms) window, before transitioning a node from Untrusted to Trusted. Any gap between consecutive reports that exceeds AV_RECOVERY_WINDOW_MS shall reset the streak counter to zero. Any single unhealthy report during recovery shall reset the streak counter to zero.
 **Safe state:** The node remains Untrusted until the full streak is satisfied; the fleet posture remains at the degraded level appropriate for the Untrusted node count.
 **FTTI:** Recovery is bounded by AV_RECOVERY_STREAK_THRESHOLD * (inter-report interval) + AV_RECOVERY_WINDOW_MS; no premature recovery can occur before this bound.
 **Verification method:** Unit tests (test_recovery_requires_full_streak, test_streak_resets_on_gap), temporal integration test with VirtualClock injection simulating various report patterns
@@ -167,7 +167,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** B
 **Derived from:** H-014
-**Goal statement:** The Aegis federation reconciliation engine shall reject any FederatedTrustReportV2 with a generation counter less than or equal to the last accepted generation counter from the same peer controller. Nonces from accepted reports shall be burned in the federation_report_nonces table to prevent replay within the FEDERATION_REPLAY_WINDOW_MS (5000 ms) window.
+**Goal statement:** The Kirra federation reconciliation engine shall reject any FederatedTrustReportV2 with a generation counter less than or equal to the last accepted generation counter from the same peer controller. Nonces from accepted reports shall be burned in the federation_report_nonces table to prevent replay within the FEDERATION_REPLAY_WINDOW_MS (5000 ms) window.
 **Safe state:** The replayed or outdated report is rejected; the current posture state is unchanged; the rejection is logged to the audit chain.
 **FTTI:** Synchronous; rejection occurs within the federation report evaluation pipeline.
 **Verification method:** Unit test (test_federation_replay_rejected), code inspection of reconcile_reports generation comparison logic, nonce burning verification test
@@ -178,10 +178,10 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** B
 **Derived from:** H-016
-**Goal statement:** The Aegis verifier service shall return HTTP 503 (Service Unavailable) for all mutation routes when the AEGIS_ADMIN_TOKEN environment variable is absent or resolves to an empty string. The require_admin_token function shall never be bypassed, commented out, or conditioned on a feature flag on any mutation route.
+**Goal statement:** The Kirra verifier service shall return HTTP 503 (Service Unavailable) for all mutation routes when the KIRRA_ADMIN_TOKEN environment variable is absent or resolves to an empty string. The require_admin_token function shall never be bypassed, commented out, or conditioned on a feature flag on any mutation route.
 **Safe state:** All mutation operations are blocked; read-only and public routes remain available; the 503 response does not include any information about the token configuration.
 **FTTI:** Synchronous; enforced at request ingress before any state mutation.
-**Verification method:** Unit test (test_admin_token_absent_returns_503), integration test confirming all admin routes return 503 when AEGIS_ADMIN_TOKEN is unset, code inspection of require_admin_token usage on all mutation routes
+**Verification method:** Unit test (test_admin_token_absent_returns_503), integration test confirming all admin routes return 503 when KIRRA_ADMIN_TOKEN is unset, code inspection of require_admin_token usage on all mutation routes
 
 ---
 
@@ -189,7 +189,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 **ASIL:** C
 **Derived from:** H-017
-**Goal statement:** All DDS actuator topics created by the Aegis DDS bridge shall be configured with DurabilityPolicy::Volatile. No actuator topic shall use DurabilityPolicy::TransientLocal or any other durability policy that would cause historical commands to be delivered to reconnecting subscribers.
+**Goal statement:** All DDS actuator topics created by the Kirra DDS bridge shall be configured with DurabilityPolicy::Volatile. No actuator topic shall use DurabilityPolicy::TransientLocal or any other durability policy that would cause historical commands to be delivered to reconnecting subscribers.
 **Safe state:** Reconnecting actuator subscribers receive only fresh commands; historical commands from before the reconnect are not delivered; the actuator starts from a stopped or hold state until the next fresh command arrives.
 **FTTI:** This is a static configuration invariant; there is no runtime FTTI. The property must be verified at startup and on each topic creation.
 **Verification method:** Code inspection of src/dds_bridge.rs confirming DurabilityPolicy::Volatile in all topic creation calls, static analysis, startup assertion (if configurable topic durability is supported)
@@ -223,7 +223,7 @@ Safety goals are allocated to the `aegis-runtime-sdk` v1.5.0 software item and a
 
 | Field | Value |
 |-------|-------|
-| Prepared by | Aegis Engineering |
+| Prepared by | Kirra Engineering |
 | Review status | Pending TUV pre-assessment |
 | Next review | 2026-11-23 |
 | Supersedes | None |

--- a/docs/safety/STANDARDS_MATRIX.md
+++ b/docs/safety/STANDARDS_MATRIX.md
@@ -1,4 +1,4 @@
-# Aegis Safety Standards Matrix
+# Kirra Safety Standards Matrix
 
 Document ID: AEGIS-STD-001
 Version: 1.0.0
@@ -9,7 +9,7 @@ Date: 2026-05-23
 
 ## 1. Purpose
 
-This matrix identifies 23 safety and security standards relevant to Aegis deployments across five industry verticals. For each standard, it documents Aegis applicability, current compliance status, the SEooC (Safety Element out of Context) model applicability, and the certification priority.
+This matrix identifies 23 safety and security standards relevant to Kirra deployments across five industry verticals. For each standard, it documents Kirra applicability, current compliance status, the SEooC (Safety Element out of Context) model applicability, and the certification priority.
 
 Priority levels:
 - P0: Must have — gates primary commercial targets
@@ -20,59 +20,59 @@ Priority levels:
 
 ## 2. Automotive Vertical
 
-| # | Standard | Title | Priority | Aegis Scope | Current Status | Path |
+| # | Standard | Title | Priority | Kirra Scope | Current Status | Path |
 |---|----------|-------|----------|-------------|----------------|------|
-| 1 | ISO 26262 ASIL-D | Functional Safety — Road Vehicles | P0 | Aegis as SEooC safety governor for AV motion commands. validate_vehicle_command(), posture-gated routing, and fail-closed cache semantics map directly to ISO 26262-6 software requirements. | Safety case foundation complete (HARA, SGs, RTM, Architecture). Tool qualification and process compliance pending. | SEooC via TUV SUD. Estimated EUR 150K–250K. |
-| 2 | ISO/PAS 21448 SOTIF | Safety of the Intended Functionality | P1 | SOTIF covers hazards from insufficiency of the AI planner's intended behavior (not failures). Aegis addresses SOTIF by bounding all planner outputs to the kinematic contract, converting SOTIF behavioral uncertainty into a hard enforcement boundary. | Gap analysis pending. SOTIF does not replace ISO 26262 for Aegis; it applies to the upstream AI planner. | Document Aegis as a SOTIF mitigation measure for the AI planner's triggering conditions. |
-| 3 | ISO/SAE 21434 | Road Vehicles — Cybersecurity Engineering | P1 | Aegis directly implements several 21434 security controls: constant-time token comparison, HMAC-SHA256 attestation, Ed25519-signed audit chain, nonce-based replay prevention, admin token enforcement, and adversarial input detection in the Action Filter. | Informal compliance. No formal TARA (Threat Analysis and Risk Assessment) yet. | Map existing security invariants to 21434 TARA outputs. Estimated 2–4 months. |
-| 4 | UN ECE WP.29 R155/R156 | Cybersecurity Management System / Software Update Management | P2 | R155 requires a CSMS covering the vehicle's supply chain. Aegis as a software component must be covered under the OEM's CSMS. R156 requires secure OTA update procedures for software on the vehicle. | Not yet addressed. Applies when Aegis is deployed on a type-approved vehicle. | Address during OEM integration. No standalone Aegis action required; document supply chain security claims. |
-| 5 | AUTOSAR Adaptive | AUTOSAR Adaptive Platform (AP) — ARA Safety | P2 | AUTOSAR AP defines the execution environment for ASIL-D software on modern E/E architectures. Aegis would run as an Adaptive Application (AA) in a future automotive integration. The posture engine worker and axum HTTP interface would need to be replaced or wrapped by AUTOSAR communication middleware. | Not applicable until automotive OEM integration. | Track. No action until OEM engagement. |
+| 1 | ISO 26262 ASIL-D | Functional Safety — Road Vehicles | P0 | Kirra as SEooC safety governor for AV motion commands. validate_vehicle_command(), posture-gated routing, and fail-closed cache semantics map directly to ISO 26262-6 software requirements. | Safety case foundation complete (HARA, SGs, RTM, Architecture). Tool qualification and process compliance pending. | SEooC via TUV SUD. Estimated EUR 150K–250K. |
+| 2 | ISO/PAS 21448 SOTIF | Safety of the Intended Functionality | P1 | SOTIF covers hazards from insufficiency of the AI planner's intended behavior (not failures). Kirra addresses SOTIF by bounding all planner outputs to the kinematic contract, converting SOTIF behavioral uncertainty into a hard enforcement boundary. | Gap analysis pending. SOTIF does not replace ISO 26262 for Kirra; it applies to the upstream AI planner. | Document Kirra as a SOTIF mitigation measure for the AI planner's triggering conditions. |
+| 3 | ISO/SAE 21434 | Road Vehicles — Cybersecurity Engineering | P1 | Kirra directly implements several 21434 security controls: constant-time token comparison, HMAC-SHA256 attestation, Ed25519-signed audit chain, nonce-based replay prevention, admin token enforcement, and adversarial input detection in the Action Filter. | Informal compliance. No formal TARA (Threat Analysis and Risk Assessment) yet. | Map existing security invariants to 21434 TARA outputs. Estimated 2–4 months. |
+| 4 | UN ECE WP.29 R155/R156 | Cybersecurity Management System / Software Update Management | P2 | R155 requires a CSMS covering the vehicle's supply chain. Kirra as a software component must be covered under the OEM's CSMS. R156 requires secure OTA update procedures for software on the vehicle. | Not yet addressed. Applies when Kirra is deployed on a type-approved vehicle. | Address during OEM integration. No standalone Kirra action required; document supply chain security claims. |
+| 5 | AUTOSAR Adaptive | AUTOSAR Adaptive Platform (AP) — ARA Safety | P2 | AUTOSAR AP defines the execution environment for ASIL-D software on modern E/E architectures. Kirra would run as an Adaptive Application (AA) in a future automotive integration. The posture engine worker and axum HTTP interface would need to be replaced or wrapped by AUTOSAR communication middleware. | Not applicable until automotive OEM integration. | Track. No action until OEM engagement. |
 
 ---
 
 ## 3. Drones / UAS Vertical
 
-| # | Standard | Title | Priority | Aegis Scope | Current Status | Path |
+| # | Standard | Title | Priority | Kirra Scope | Current Status | Path |
 |---|----------|-------|----------|-------------|----------------|------|
-| 6 | ASTM F3269 | Standard Methods for Run Time Assurance (RTA) of Autonomous and Semi-Autonomous Systems | P0 | Aegis is architecturally a Run Time Assurance monitor. The RTA Monitor = Aegis Safety Kernel; Primary Function = AI Navigation Stack; Backup Control Law = MRC Fallback Profile; Recovery Region = Degraded posture; Safe Region = Nominal posture. This standard directly describes what Aegis does. See AEGIS-F3269-001 for full mapping. | Self-mapping in progress. No test lab required — self-declaration. | Purchase standard (~$80 USD from ASTM). Complete mapping (AEGIS-F3269-001). Estimated 2 weeks. |
-| 7 | DO-178C / EUROCAE ED-12C | Software Considerations in Airborne Systems and Equipment Certification | P1 | For drone deployments requiring FAA/EASA airworthiness approval. Aegis as a DAL-B or DAL-C software component would require a DO-178C-compliant development process: requirements traceability (partially done), structural coverage (MC/DC), qualified tools (Rust/Ferrocene), and independence in testing. | Partial — RTM (AEGIS-RTM-001), coding guidelines (AEGIS-CG-001), and property-based tests are DO-178C-compatible artifacts. MC/DC coverage not yet measured. | Establish structural coverage with cargo-tarpaulin or llvm-cov. Ferrocene compiler qualification applies. |
+| 6 | ASTM F3269 | Standard Methods for Run Time Assurance (RTA) of Autonomous and Semi-Autonomous Systems | P0 | Kirra is architecturally a Run Time Assurance monitor. The RTA Monitor = Kirra Safety Kernel; Primary Function = AI Navigation Stack; Backup Control Law = MRC Fallback Profile; Recovery Region = Degraded posture; Safe Region = Nominal posture. This standard directly describes what Kirra does. See AEGIS-F3269-001 for full mapping. | Self-mapping in progress. No test lab required — self-declaration. | Purchase standard (~$80 USD from ASTM). Complete mapping (AEGIS-F3269-001). Estimated 2 weeks. |
+| 7 | DO-178C / EUROCAE ED-12C | Software Considerations in Airborne Systems and Equipment Certification | P1 | For drone deployments requiring FAA/EASA airworthiness approval. Kirra as a DAL-B or DAL-C software component would require a DO-178C-compliant development process: requirements traceability (partially done), structural coverage (MC/DC), qualified tools (Rust/Ferrocene), and independence in testing. | Partial — RTM (AEGIS-RTM-001), coding guidelines (AEGIS-CG-001), and property-based tests are DO-178C-compatible artifacts. MC/DC coverage not yet measured. | Establish structural coverage with cargo-tarpaulin or llvm-cov. Ferrocene compiler qualification applies. |
 | 8 | DO-333 | Formal Methods Supplement to DO-178C | P2 | DO-333 permits formal verification as a substitute for some structural coverage requirements. The deterministic nature of validate_vehicle_command() and should_route_command() makes them amenable to formal verification. | Not started. | Evaluate post-DO-178C. Proptest property-based tests are a step toward formal argument. |
-| 9 | FAA AC 21-49 / BVLOS Operations | FAA Advisory Circular for UAS Beyond Visual Line of Sight | P2 | BVLOS approvals require demonstrated system reliability and safety case evidence. Aegis's HARA, safety goals, and audit chain are directly relevant evidence artifacts. | Not started. Applicable when Aegis-governed drones seek BVLOS approval. | Provide safety case evidence package (HARA + RTM + test results) to BVLOS applicant. |
+| 9 | FAA AC 21-49 / BVLOS Operations | FAA Advisory Circular for UAS Beyond Visual Line of Sight | P2 | BVLOS approvals require demonstrated system reliability and safety case evidence. Kirra's HARA, safety goals, and audit chain are directly relevant evidence artifacts. | Not started. Applicable when Kirra-governed drones seek BVLOS approval. | Provide safety case evidence package (HARA + RTM + test results) to BVLOS applicant. |
 
 ---
 
 ## 4. Robotics Vertical
 
-| # | Standard | Title | Priority | Aegis Scope | Current Status | Path |
+| # | Standard | Title | Priority | Kirra Scope | Current Status | Path |
 |---|----------|-------|----------|-------------|----------------|------|
-| 10 | ISO 10218-1/2 | Robots and Robotic Devices — Safety Requirements for Industrial Robots | P1 | Aegis governs motion commands to robot actuators and enforces the kinematic contract (max speed, steering rate). The MRC fallback profile and fail-closed posture semantics align with ISO 10218 protective stop and speed/separation monitoring requirements. The ROS2 interlock (ros2_ws/src/aegis_safety/) is the integration point. | Informal compliance. ROS2 interlock correctly implements emergency stop on LockedOut transition. | Map Aegis safety functions to ISO 10218 risk assessment outcomes. 1–2 months. |
-| 11 | ISO/TS 15066 | Robots and Robotic Devices — Collaborative Robots | P1 | For collaborative robot deployments where Aegis governs a robot operating near humans. ISO/TS 15066 defines four collaboration modes (safety-rated monitoring stop, hand-guiding, speed/separation, power/force limiting). Aegis Degraded posture maps to speed/separation mode speed limits. | Speed limit in MRC profile (5.0 m/s, robot: 1.8 * 0.3 = 0.54 m/s) is conservative but needs human proximity context. | Document Aegis MRC profile as speed/separation monitoring speed limit. |
-| 12 | IEC 62061 | Safety of Machinery — Functional Safety of Safety-related Control Systems | P1 | IEC 62061 applies to safety-related electrical control systems on machinery. SIL requirements under IEC 62061 are derivative of IEC 61508 and directly applicable to Aegis. An Aegis-governed industrial robot's safety functions (motion stop, speed limiting) are SIL-claimable under 62061. | IEC 61508 mapping (AEGIS-61508-001) provides the foundation. | Apply IEC 61508 SIL 3 claim to 62061 derivatively. |
+| 10 | ISO 10218-1/2 | Robots and Robotic Devices — Safety Requirements for Industrial Robots | P1 | Kirra governs motion commands to robot actuators and enforces the kinematic contract (max speed, steering rate). The MRC fallback profile and fail-closed posture semantics align with ISO 10218 protective stop and speed/separation monitoring requirements. The ROS2 interlock (ros2_ws/src/kirra_safety/) is the integration point. | Informal compliance. ROS2 interlock correctly implements emergency stop on LockedOut transition. | Map Kirra safety functions to ISO 10218 risk assessment outcomes. 1–2 months. |
+| 11 | ISO/TS 15066 | Robots and Robotic Devices — Collaborative Robots | P1 | For collaborative robot deployments where Kirra governs a robot operating near humans. ISO/TS 15066 defines four collaboration modes (safety-rated monitoring stop, hand-guiding, speed/separation, power/force limiting). Kirra Degraded posture maps to speed/separation mode speed limits. | Speed limit in MRC profile (5.0 m/s, robot: 1.8 * 0.3 = 0.54 m/s) is conservative but needs human proximity context. | Document Kirra MRC profile as speed/separation monitoring speed limit. |
+| 12 | IEC 62061 | Safety of Machinery — Functional Safety of Safety-related Control Systems | P1 | IEC 62061 applies to safety-related electrical control systems on machinery. SIL requirements under IEC 62061 are derivative of IEC 61508 and directly applicable to Kirra. An Kirra-governed industrial robot's safety functions (motion stop, speed limiting) are SIL-claimable under 62061. | IEC 61508 mapping (AEGIS-61508-001) provides the foundation. | Apply IEC 61508 SIL 3 claim to 62061 derivatively. |
 | 13 | EN ISO 13849-1 | Safety of Machinery — Safety-Related Parts of Control Systems | P2 | Alternative to IEC 62061 for machinery safety. Uses Performance Level (PL a–e) rather than SIL. PLe maps approximately to SIL 3. Applicable for European CE marking. | Not started. Lower priority than IEC 61508 path. | Address post-IEC 61508 via derivative mapping. |
 
 ---
 
 ## 5. Industrial Infrastructure Vertical
 
-| # | Standard | Title | Priority | Aegis Scope | Current Status | Path |
+| # | Standard | Title | Priority | Kirra Scope | Current Status | Path |
 |---|----------|-------|----------|-------------|----------------|------|
-| 14 | IEC 61508 SIL 3 | Functional Safety of Electrical / Electronic / Programmable Electronic Safety-related Systems | P0 | Broadest leverage standard — ISO 26262, IEC 61511, IEC 62061, and IEC 62443 all derive from or reference 61508. A SIL 3 SEooC certificate from Exida or TUV makes Aegis applicable across all industrial verticals simultaneously. The three core safety functions (velocity clamping, posture-gated routing, unknown command denial) are SIL 3 candidates. See AEGIS-61508-001 for preliminary mapping. | Preliminary mapping complete (AEGIS-61508-001). No formal assessment yet. | Exida scoping call for SIL 3 SEooC. Estimated EUR 50K–150K depending on scope. |
-| 15 | IEC 61511 | Functional Safety — Safety Instrumented Systems for the Process Industry Sector | P1 | IEC 61511 governs Safety Instrumented Functions (SIFs) in process plants (oil/gas, chemical, water). Aegis governing industrial controllers via the DNP3/EtherNet/IP/CANOpen adapters is a SIF boundary enforcement layer. IEC 61511 is derivative of IEC 61508 — the SIL 3 claim covers it. | The DNP3 adapter (src/adapters/dnp3.rs) audits broadcast commands and detects critical infrastructure groups. | Document after IEC 61508 SIL 3 is achieved. |
-| 16 | IEC 62443 | Industrial Automation and Control Systems (IACS) Security | P1 | IEC 62443 defines security levels (SL 1–4) for industrial systems. Aegis's security model (constant-time token comparison, HMAC attestation, Ed25519 signing, nonce-based replay prevention, admin token enforcement) maps to SL 2–3 requirements. | Informal compliance with multiple 62443 controls. No formal assessment. | Document Aegis security invariants against 62443-3-3 system requirements. 1–2 months. |
-| 17 | IEC 61131-3 | Programmable Controllers — Programming Languages | P2 | IEC 61131-3 defines PLC programming languages. Relevant only if Aegis is deployed as a software component within a PLC runtime. Not currently applicable. | Not applicable. | Track for future PLC integration scenarios. |
-| 18 | NERC CIP | Critical Infrastructure Protection Standards | P2 | NERC CIP applies to bulk electric systems. If Aegis governs systems connected to grid infrastructure (substations, generation control), NERC CIP requirements apply to the asset owner, not to Aegis as a software component. | Not applicable directly. | Provide NERC CIP compliance documentation to integrators on request. |
+| 14 | IEC 61508 SIL 3 | Functional Safety of Electrical / Electronic / Programmable Electronic Safety-related Systems | P0 | Broadest leverage standard — ISO 26262, IEC 61511, IEC 62061, and IEC 62443 all derive from or reference 61508. A SIL 3 SEooC certificate from Exida or TUV makes Kirra applicable across all industrial verticals simultaneously. The three core safety functions (velocity clamping, posture-gated routing, unknown command denial) are SIL 3 candidates. See AEGIS-61508-001 for preliminary mapping. | Preliminary mapping complete (AEGIS-61508-001). No formal assessment yet. | Exida scoping call for SIL 3 SEooC. Estimated EUR 50K–150K depending on scope. |
+| 15 | IEC 61511 | Functional Safety — Safety Instrumented Systems for the Process Industry Sector | P1 | IEC 61511 governs Safety Instrumented Functions (SIFs) in process plants (oil/gas, chemical, water). Kirra governing industrial controllers via the DNP3/EtherNet/IP/CANOpen adapters is a SIF boundary enforcement layer. IEC 61511 is derivative of IEC 61508 — the SIL 3 claim covers it. | The DNP3 adapter (src/adapters/dnp3.rs) audits broadcast commands and detects critical infrastructure groups. | Document after IEC 61508 SIL 3 is achieved. |
+| 16 | IEC 62443 | Industrial Automation and Control Systems (IACS) Security | P1 | IEC 62443 defines security levels (SL 1–4) for industrial systems. Kirra's security model (constant-time token comparison, HMAC attestation, Ed25519 signing, nonce-based replay prevention, admin token enforcement) maps to SL 2–3 requirements. | Informal compliance with multiple 62443 controls. No formal assessment. | Document Kirra security invariants against 62443-3-3 system requirements. 1–2 months. |
+| 17 | IEC 61131-3 | Programmable Controllers — Programming Languages | P2 | IEC 61131-3 defines PLC programming languages. Relevant only if Kirra is deployed as a software component within a PLC runtime. Not currently applicable. | Not applicable. | Track for future PLC integration scenarios. |
+| 18 | NERC CIP | Critical Infrastructure Protection Standards | P2 | NERC CIP applies to bulk electric systems. If Kirra governs systems connected to grid infrastructure (substations, generation control), NERC CIP requirements apply to the asset owner, not to Kirra as a software component. | Not applicable directly. | Provide NERC CIP compliance documentation to integrators on request. |
 
 ---
 
 ## 6. Cross-Cutting Standards
 
-| # | Standard | Title | Priority | Aegis Scope | Current Status | Path |
+| # | Standard | Title | Priority | Kirra Scope | Current Status | Path |
 |---|----------|-------|----------|-------------|----------------|------|
-| 19 | IEC 62304 | Medical Device Software — Software Life Cycle Processes | P2 | IEC 62304 defines software development processes for medical devices. Methodology (SOUP management, unit testing, traceability, configuration management) is directly applicable to Aegis as a model for process compliance regardless of medical deployment. | Not targeted. Referenced for process methodology. | Use IEC 62304 Class C (safety-critical software) as process model for Phase 2 compliance. |
+| 19 | IEC 62304 | Medical Device Software — Software Life Cycle Processes | P2 | IEC 62304 defines software development processes for medical devices. Methodology (SOUP management, unit testing, traceability, configuration management) is directly applicable to Kirra as a model for process compliance regardless of medical deployment. | Not targeted. Referenced for process methodology. | Use IEC 62304 Class C (safety-critical software) as process model for Phase 2 compliance. |
 | 20 | MISRA C:2012 / Ferrocene LS | MISRA C Guidelines adapted for Rust via Ferrocene Language Specification | P1 | AEGIS-CG-001 (Rust Safety Coding Guidelines) is explicitly based on MISRA C:2012 principles adapted for Rust and the Ferrocene Language Specification. Ferrocene is the ISO 26262-qualified Rust compiler toolchain. | Coding guidelines adopted (AEGIS-CG-001). Ferrocene compiler not yet in use — currently using standard rustc. | Switch to Ferrocene compiler for ASIL-D builds. Required for ISO 26262 tool qualification. |
-| 21 | ISO/IEC 25010 | Systems and Software Quality Models | P2 | Defines software quality characteristics: functional suitability, reliability, security, maintainability, safety. Useful as a quality framework for Aegis but not a certification target. | Not targeted. | Reference for quality attribute definitions. |
-| 22 | NIST SP 800-82 Rev 3 | Guide to Operational Technology Security | P2 | NIST 800-82 provides security guidance for industrial control systems. Relevant when Aegis is deployed in OT environments (power, water, manufacturing). The admin token enforcement, attestation, and audit chain directly implement 800-82 access control and audit requirements. | Informal compliance with relevant controls. | Document alignment with NIST 800-82 controls for US government and critical infrastructure customers. |
-| 23 | ISO/IEC 27001 | Information Security Management Systems | P2 | ISO 27001 ISMS is a process standard for managing information security. Relevant at the organizational level, not the software component level. Applicable when Aegis is commercialized and requires supply chain security attestation. | Not targeted. | Address at commercial entity formation stage. |
+| 21 | ISO/IEC 25010 | Systems and Software Quality Models | P2 | Defines software quality characteristics: functional suitability, reliability, security, maintainability, safety. Useful as a quality framework for Kirra but not a certification target. | Not targeted. | Reference for quality attribute definitions. |
+| 22 | NIST SP 800-82 Rev 3 | Guide to Operational Technology Security | P2 | NIST 800-82 provides security guidance for industrial control systems. Relevant when Kirra is deployed in OT environments (power, water, manufacturing). The admin token enforcement, attestation, and audit chain directly implement 800-82 access control and audit requirements. | Informal compliance with relevant controls. | Document alignment with NIST 800-82 controls for US government and critical infrastructure customers. |
+| 23 | ISO/IEC 27001 | Information Security Management Systems | P2 | ISO 27001 ISMS is a process standard for managing information security. Relevant at the organizational level, not the software component level. Applicable when Kirra is commercialized and requires supply chain security attestation. | Not targeted. | Address at commercial entity formation stage. |
 
 ---
 
@@ -88,15 +88,15 @@ Priority levels:
 
 ## 8. SEooC Architecture Summary
 
-The Safety Element out of Context (SEooC) model allows Aegis to be certified once and deployed into many different vehicles, robots, and industrial systems. Under the SEooC model:
+The Safety Element out of Context (SEooC) model allows Kirra to be certified once and deployed into many different vehicles, robots, and industrial systems. Under the SEooC model:
 
-1. **Aegis Engineering** certifies the Aegis software component to the required ASIL/SIL level with assumed safety requirements (ASRs) documented in the safety case.
+1. **Kirra Engineering** certifies the Kirra software component to the required ASIL/SIL level with assumed safety requirements (ASRs) documented in the safety case.
 2. **Integrators** perform in-context verification: they confirm that the ASRs are satisfied in their specific deployment (vehicle type, sensor configuration, network topology, failure mode analysis).
 3. **Per-deployment cost** is substantially lower than certifying the full item each time.
 
-The SEooC assumption set for Aegis includes:
+The SEooC assumption set for Kirra includes:
 - The upstream AI planner or navigation stack sends commands in the ProposedVehicleCommand JSON schema
-- The deployment provides AEGIS_ADMIN_TOKEN and AEGIS_SUPERVISOR_RESET_KEY as non-empty env vars
+- The deployment provides KIRRA_ADMIN_TOKEN and KIRRA_SUPERVISOR_RESET_KEY as non-empty env vars
 - The kinematic contract parameters (max_speed_mps, max_lateral_accel_mps2, wheelbase_m) are correctly configured for the specific vehicle or robot platform
 - The deployment platform provides monotonic clock access
 - The SQLite database path is on durable storage with adequate write throughput
@@ -107,6 +107,6 @@ The SEooC assumption set for Aegis includes:
 
 | Field | Value |
 |-------|-------|
-| Prepared by | Aegis Engineering |
+| Prepared by | Kirra Engineering |
 | Next review | 2026-11-23 |
 | Supersedes | None |

--- a/docs/v1_active_passive_runbook.md
+++ b/docs/v1_active_passive_runbook.md
@@ -1,12 +1,12 @@
-# Aegis v1.0.0 — Active / PassiveStandby Operations Runbook
+# Kirra v1.0.0 — Active / PassiveStandby Operations Runbook
 
-This document serves as the formal engineering handbook for running, promoting, and maintaining high-availability Aegis verifier node cluster infrastructure under standard and incident-response operational parameters.
+This document serves as the formal engineering handbook for running, promoting, and maintaining high-availability Kirra verifier node cluster infrastructure under standard and incident-response operational parameters.
 
 ---
 
 ## 1. Runtime Modes
 
-The verifier cluster utilizes the configuration environment flag `AEGIS_VERIFIER_MODE` to designate cluster topology and prevent data corruption.
+The verifier cluster utilizes the configuration environment flag `KIRRA_VERIFIER_MODE` to designate cluster topology and prevent data corruption.
 
 ### Capability Behavior Matrix
 
@@ -29,14 +29,14 @@ The verifier cluster utilizes the configuration environment flag `AEGIS_VERIFIER
 To stand up a node as the primary read-write control authority, instantiate the runtime environment as follows:
 
 ```bash
-export AEGIS_VERIFIER_MODE=active
-export AEGIS_ADMIN_TOKEN="your-secure-token-hash"
-cargo run --bin aegis_verifier_service
+export KIRRA_VERIFIER_MODE=active
+export KIRRA_ADMIN_TOKEN="your-secure-token-hash"
+cargo run --bin kirra_verifier_service
 ```
 
 #### Expected Log Signature:
 ```text
-[AEGIS VERIFIER] mode=Active
+[KIRRA VERIFIER] mode=Active
 ```
 
 ### Passive Standby Node Initialization
@@ -44,14 +44,14 @@ cargo run --bin aegis_verifier_service
 To stand up a node as a secure, high-performance read-only mirror capable of taking offloaded analytic queries, instantiate the runtime environment as follows:
 
 ```bash
-export AEGIS_VERIFIER_MODE=passive_standby
-export AEGIS_ADMIN_TOKEN="your-secure-token-hash"
-cargo run --bin aegis_verifier_service
+export KIRRA_VERIFIER_MODE=passive_standby
+export KIRRA_ADMIN_TOKEN="your-secure-token-hash"
+cargo run --bin kirra_verifier_service
 ```
 
 #### Expected Log Signature:
 ```text
-[AEGIS VERIFIER] mode=PassiveStandby
+[KIRRA VERIFIER] mode=PassiveStandby
 ```
 
 ---
@@ -74,7 +74,7 @@ To promote a running PassiveStandby instance into a fully mutable Active primary
 
  1. **Lift the Mutation Shield**: Update the running host process environment configurations to toggle the mode boundary:
     ```bash
-    export AEGIS_VERIFIER_MODE=active
+    export KIRRA_VERIFIER_MODE=active
     ```
  2. **Force Process Re-Initialization**: Restart or signal the service binary to boot under the `Active` context flag.
  3. **Validate Liveness & Connectivity**: Verify the node rehydrated its stored cache and can communicate with its underlying database by dispatching an unauthenticated local check:
@@ -100,7 +100,7 @@ Pipes the extracted JSON backup archive directly into the newly promoted control
 
 ```bash
 curl -i -X POST http://127.0.0.1:8089/system/backup/import \
-  -H "X-Aegis-Admin-Token: [REDACTED]" \
+  -H "X-Kirra-Admin-Token: [REDACTED]" \
   -H "Content-Type: application/json" \
   --data-binary @backup.json
 ```

--- a/docs/v1_dag_cycle_depth_report.md
+++ b/docs/v1_dag_cycle_depth_report.md
@@ -1,14 +1,14 @@
-# Aegis v1.0.0 — Dependency DAG Cycle and Depth Protection Report
+# Kirra v1.0.0 — Dependency DAG Cycle and Depth Protection Report
 
-This document establishes the definitive mathematical, algorithmic, and defensive specification for the Aegis v1.0.0 Directed Acyclic Graph (DAG) topology evaluation engine. It formally proves how the control plane shields itself against recursive processing exploitation, stack-exhaustion denial of service (DoS), graph poisoning, and adversarial topology manipulation.
+This document establishes the definitive mathematical, algorithmic, and defensive specification for the Kirra v1.0.0 Directed Acyclic Graph (DAG) topology evaluation engine. It formally proves how the control plane shields itself against recursive processing exploitation, stack-exhaustion denial of service (DoS), graph poisoning, and adversarial topology manipulation.
 
 ---
 
 ## 1. DAG Security Model
 
-The structural stability of the Aegis trust propagation engine depends on deterministic execution boundaries. Because trust states are inherited recursively through an asset dependency tree, the evaluation surface represents a high-leverage target for malicious inputs.
+The structural stability of the Kirra trust propagation engine depends on deterministic execution boundaries. Because trust states are inherited recursively through an asset dependency tree, the evaluation surface represents a high-leverage target for malicious inputs.
 
-> **Core Performance Invariant**: Aegis topology evaluation must always terminate in bounded time.
+> **Core Performance Invariant**: Kirra topology evaluation must always terminate in bounded time.
 
 ### Threat Modeling & Mitigation Target Matrix
 

--- a/docs/v1_dr_drill_transcript.md
+++ b/docs/v1_dr_drill_transcript.md
@@ -1,6 +1,6 @@
-# Aegis v1.0.0 — Disaster Recovery Drill Transcript
+# Kirra v1.0.0 — Disaster Recovery Drill Transcript
 
-This transcript serves as the official cryptographic and operational validation record for the Aegis v1.0.0 Disaster Recovery (DR) pipeline. The operations recorded herein confirm that the system can survive an abrupt primary control plane failure, maintain zero-leak security invariants, and restore topological consistency onto a blank-slate instance without state drift.
+This transcript serves as the official cryptographic and operational validation record for the Kirra v1.0.0 Disaster Recovery (DR) pipeline. The operations recorded herein confirm that the system can survive an abrupt primary control plane failure, maintain zero-leak security invariants, and restore topological consistency onto a blank-slate instance without state drift.
 
 ---
 
@@ -32,7 +32,7 @@ With the primary verifier in a state of terminal stability, an administrative sn
 
 ```bash
 curl -i -X POST http://127.0.0.1:8088/system/backup/export \
-  -H "X-Aegis-Admin-Token: [REDACTED]" \
+  -H "X-Kirra-Admin-Token: [REDACTED]" \
   -o backup.json
 ```
 
@@ -50,7 +50,7 @@ A catastrophic local control plane disruption was induced by hard-terminating th
 ### Operational Sequence:
  1. **Primary Terminated**: `kill -9` sent directly to the process listening on port 8088.
  2. **Standby Promoted**: The orchestration controller intercepted the primary dropout signal.
- 3. **Runtime Reconfiguration**: The environment profile on the target secondary environment was updated to `AEGIS_VERIFIER_MODE=active`. The application reactor on port 8089 hot-reloaded the variable, lifting the passive-mode mutation shield.
+ 3. **Runtime Reconfiguration**: The environment profile on the target secondary environment was updated to `KIRRA_VERIFIER_MODE=active`. The application reactor on port 8089 hot-reloaded the variable, lifting the passive-mode mutation shield.
 
 ---
 
@@ -61,7 +61,7 @@ The serialized JSON state snapshot captured from the dead primary node was piped
 ```bash
 curl -i -X POST http://127.0.0.1:8089/system/backup/import \
   -H "Content-Type: application/json" \
-  -H "X-Aegis-Admin-Token: [REDACTED]" \
+  -H "X-Kirra-Admin-Token: [REDACTED]" \
   --data-binary @backup.json
 ```
 

--- a/docs/v1_gateway_policy_matrix.md
+++ b/docs/v1_gateway_policy_matrix.md
@@ -1,6 +1,6 @@
-# Aegis v1.0.0 — Gateway Policy Matrix
+# Kirra v1.0.0 — Gateway Policy Matrix
 
-This document defines the formal behavioral specifications and security invariants for the Aegis v1.0.0 edge gateway proxy interceptor. It serves as the definitive reference for proving how and why network payloads are validated, classified, and either routed or dropped at the cluster boundary.
+This document defines the formal behavioral specifications and security invariants for the Kirra v1.0.0 edge gateway proxy interceptor. It serves as the definitive reference for proving how and why network payloads are validated, classified, and either routed or dropped at the cluster boundary.
 
 ---
 
@@ -61,7 +61,7 @@ now_ms() - updated_at_epoch_ms > ttl_ms
   ```text
   HTTP/1.1 403 Forbidden
   Content-Type: text/plain
-  Body: AEGIS_POLICY_DENY
+  Body: KIRRA_POLICY_DENY
   ```
 
 ---

--- a/docs/v1_release_notes_and_architecture.md
+++ b/docs/v1_release_notes_and_architecture.md
@@ -1,12 +1,12 @@
-# Aegis v1.0.0 — Release Notes and Architecture Specification
+# Kirra v1.0.0 — Release Notes and Architecture Specification
 
-This document serves as the definitive release announcement and architectural specification for the Aegis v1.0.0 Stable Control Plane baseline. It establishes the programmatic lineage, structural topology mappings, and core engineering philosophy behind the production-hardened legitimacy platform.
+This document serves as the definitive release announcement and architectural specification for the Kirra v1.0.0 Stable Control Plane baseline. It establishes the programmatic lineage, structural topology mappings, and core engineering philosophy behind the production-hardened legitimacy platform.
 
 ---
 
 ## 1. Release Declaration
 
-Aegis v1.0.0 establishes a production-grade distributed legitimacy control plane combining:
+Kirra v1.0.0 establishes a production-grade distributed legitimacy control plane combining:
 - TPM-backed cryptographic attestation
 - Recursive DAG trust propagation
 - Fail-closed gateway enforcement
@@ -15,13 +15,13 @@ Aegis v1.0.0 establishes a production-grade distributed legitimacy control plane
 - Active/passive operational redundancy
 - Atomic disaster recovery restoration
 
-> **The Aegis Thesis**: The system does not assume trust. The system continuously proves trust.
+> **The Kirra Thesis**: The system does not assume trust. The system continuously proves trust.
 
 ---
 
 ## 2. Milestone Lineage
 
-The evolution of the Aegis codebase through its iterative milestones tracks a deliberate, uncompromising path toward architectural hardening. Every milestone preserved fail-closed semantics as a non-negotiable invariant.
+The evolution of the Kirra codebase through its iterative milestones tracks a deliberate, uncompromising path toward architectural hardening. Every milestone preserved fail-closed semantics as a non-negotiable invariant.
 
 | Version | Capability Introduced |
 | :--- | :--- |
@@ -64,7 +64,7 @@ The topology below describes the exact, unidirectional cryptographic validation 
            │
            ▼
 ┌──────────────────────────┐
-│      Aegis Verifier      │
+│      Kirra Verifier      │
 ├──────────────────────────┤
 │  Nonce Validation        │
 │  Signature Verification  │
@@ -120,9 +120,9 @@ The topology below describes the exact, unidirectional cryptographic validation 
 
 ## 6. Failure Philosophy
 
-Aegis is explicitly engineered to prioritize platform legitimacy above all else. When an anomaly occurs, the control-plane platform defaults to a defensive posture.
+Kirra is explicitly engineered to prioritize platform legitimacy above all else. When an anomaly occurs, the control-plane platform defaults to a defensive posture.
 
-Aegis is engineered to fail closed. When uncertainty exists:
+Kirra is engineered to fail closed. When uncertainty exists:
  * Permissions collapse
  * Mutations halt
  * Topology propagation stops
@@ -160,7 +160,7 @@ To ensure strict engineering discipline and keep code complexities tightly bound
  * **Self-healing topology rewriting**: Topology modifications require administrative token authentication.
  * **Distributed write replication**: State synchronization is managed via JSON data transfers.
 
-> *Aegis v1.0.0 prioritizes deterministic control, auditability, and fail-closed operation over autonomous coordination complexity.*
+> *Kirra v1.0.0 prioritizes deterministic control, auditability, and fail-closed operation over autonomous coordination complexity.*
 
 ---
 
@@ -179,4 +179,4 @@ The architectural groundwork laid in v1.0.0 allows a clear path forward for subs
 
 ## 10. Final Release Statement
 
-Aegis v1.0.0 establishes a deterministic, cryptographically anchored legitimacy fabric for distributed operational systems. Trust is continuously measured. Authorization is continuously re-evaluated. Failure collapses safely.
+Kirra v1.0.0 establishes a deterministic, cryptographically anchored legitimacy fabric for distributed operational systems. Trust is continuously measured. Authorization is continuously re-evaluated. Failure collapses safely.

--- a/docs/v1_route_authorization_matrix.md
+++ b/docs/v1_route_authorization_matrix.md
@@ -1,6 +1,6 @@
-# Aegis v1.0.0 — Route Authorization Matrix
+# Kirra v1.0.0 — Route Authorization Matrix
 
-This document defines the authoritative access control matrix and operational boundary mappings for the Aegis v1.0.0 Stable Control Plane interface surface.
+This document defines the authoritative access control matrix and operational boundary mappings for the Kirra v1.0.0 Stable Control Plane interface surface.
 
 | Route | Method | Handler | Auth | Mode | Mutation? | Security Notes |
 |---|---|---|---|---|---|---|

--- a/docs/v1_security_invariants.md
+++ b/docs/v1_security_invariants.md
@@ -1,6 +1,6 @@
-# Aegis v1.0.0 — Full Security Invariant Audit Specification
+# Kirra v1.0.0 — Full Security Invariant Audit Specification
 
-This document establishes the absolute security invariants of the Aegis distributed legitimacy engine. Every operational pathway, optimization, and recovery procedure must satisfy these ten structural properties. Any deviation or shortcut constitutes a fatal security failure.
+This document establishes the absolute security invariants of the Kirra distributed legitimacy engine. Every operational pathway, optimization, and recovery procedure must satisfy these ten structural properties. Any deviation or shortcut constitutes a fatal security failure.
 
 ---
 
@@ -27,7 +27,7 @@ This document establishes the absolute security invariants of the Aegis distribu
 ## 4. PassiveStandby Read-Only Enforcement
 * **Invariant**: Nodes configured as replicas must be structurally incapable of introducing state mutations or data divergence.
 * **Specification**:
-  * On service initialization, if `AEGIS_VERIFIER_MODE` resolves to `PassiveStandby`, the gatekeeper helper `require_active_mode` must evaluate to a hard error boundary.
+  * On service initialization, if `KIRRA_VERIFIER_MODE` resolves to `PassiveStandby`, the gatekeeper helper `require_active_mode` must evaluate to a hard error boundary.
   * Any request attempting to hit `register_node`, `issue_challenge`, `verify_attestation`, or `register_dependencies` on a standby node must fail immediately, returning `503 Service Unavailable` without allocating internal query or execution resources.
 
 ## 5. Write-Through Persistence Ordering

--- a/docs/v1_tpm_attestation_proof.md
+++ b/docs/v1_tpm_attestation_proof.md
@@ -1,14 +1,14 @@
-# Aegis v1.0.0 — TPM Attestation Verification Specification
+# Kirra v1.0.0 — TPM Attestation Verification Specification
 
-This document provides the definitive mathematical and structural specification for the Aegis v1.0.0 Trusted Platform Module (TPM) remote attestation architecture. It details the precise tracking mechanics that ensure the control plane relies exclusively on unmockable, cryptographically validated platform state assertions rather than transient network configurations.
+This document provides the definitive mathematical and structural specification for the Kirra v1.0.0 Trusted Platform Module (TPM) remote attestation architecture. It details the precise tracking mechanics that ensure the control plane relies exclusively on unmockable, cryptographically validated platform state assertions rather than transient network configurations.
 
 ---
 
 ## 1. Attestation Trust Model
 
-The Aegis security model operates on a zero-trust network posture. Network layer identifiers (such as IP addresses, MAC coordinates, or transport-layer sessions) are treated as hostile, modifiable vectors.
+The Kirra security model operates on a zero-trust network posture. Network layer identifiers (such as IP addresses, MAC coordinates, or transport-layer sessions) are treated as hostile, modifiable vectors.
 
-> **Root Security Invariant**: Aegis does not trust network identity. Aegis trusts measured platform state.
+> **Root Security Invariant**: Kirra does not trust network identity. Kirra trusts measured platform state.
 
 Trust is established by building a rigid cryptographic chain of custody from physical silicon registers up to cluster-wide policy enforcement:
 

--- a/docs/v2_2_0_av_node_graph_patch.rs
+++ b/docs/v2_2_0_av_node_graph_patch.rs
@@ -1,5 +1,5 @@
 // ============================================================================
-// PATCH: src/verifier.rs + src/bin/aegis_verifier_service.rs
+// PATCH: src/verifier.rs + src/bin/kirra_verifier_service.rs
 //
 // v2.2.0 — AV sensor fault handling and MRC posture transitions
 //
@@ -72,11 +72,11 @@ pub struct AvSubsystemRegistration {
 */
 
 // ----------------------------------------------------------------------------
-// SECTION B: Handler — append to src/bin/aegis_verifier_service.rs
+// SECTION B: Handler — append to src/bin/kirra_verifier_service.rs
 // ----------------------------------------------------------------------------
 
 /*
-// Append to src/bin/aegis_verifier_service.rs imports:
+// Append to src/bin/kirra_verifier_service.rs imports:
 use crate::verifier::{
     AvSubsystemRegistration,
     AV_DEFAULT_CONFIDENCE_FLOOR,

--- a/examples/langchain_action_filter.py
+++ b/examples/langchain_action_filter.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Aegis + LangChain: Safety-filtered robot control via LangChain tools.
-The AI decides what to do. Aegis decides if it's physically safe to do it.
+Kirra + LangChain: Safety-filtered robot control via LangChain tools.
+The AI decides what to do. Kirra decides if it's physically safe to do it.
 
 This example demonstrates:
-  - Wrapping robot actions as LangChain tools with Aegis safety filtering
+  - Wrapping robot actions as LangChain tools with Kirra safety filtering
   - Handling Allow, Deny (posture), and Deny (kinematic breach) responses
   - Mocked agent output to demonstrate the safety filter without LangChain/OpenAI
 
@@ -12,7 +12,7 @@ Dependencies:
   pip install requests
   pip install langchain langchain-openai  # optional — for real agent
 
-The key architectural point: the @tool function body calls Aegis BEFORE
+The key architectural point: the @tool function body calls Kirra BEFORE
 sending any command to hardware. The LangChain agent sees only the tool's
 return value — it never has direct hardware access.
 """
@@ -20,31 +20,31 @@ return value — it never has direct hardware access.
 import json
 import requests
 
-AEGIS_URL = "http://localhost:8090"
-AEGIS_TOKEN = "your-admin-token"
-AEGIS_CLIENT_ID = "langchain-agent-001"
+KIRRA_URL = "http://localhost:8090"
+KIRRA_TOKEN = "your-admin-token"
+KIRRA_CLIENT_ID = "langchain-agent-001"
 
 # ---------------------------------------------------------------------------
-# Aegis client helper
+# Kirra client helper
 # ---------------------------------------------------------------------------
 
-def _aegis_evaluate(
+def _kirra_evaluate(
     action_type: str,
     target_node: str,
     risk_class: str,
     payload: dict,
 ) -> dict:
-    """Send an action claim to Aegis for posture-aware safety evaluation.
+    """Send an action claim to Kirra for posture-aware safety evaluation.
 
-    Returns the Aegis decision dict. Raises requests.HTTPError on HTTP errors.
+    Returns the Kirra decision dict. Raises requests.HTTPError on HTTP errors.
     Raises requests.ConnectionError / requests.Timeout on network failures.
     Callers must treat any exception from this function as a DENY.
     """
     resp = requests.post(
-        f"{AEGIS_URL}/action_filter/evaluate",
+        f"{KIRRA_URL}/action_filter/evaluate",
         headers={
-            "Authorization": f"Bearer {AEGIS_TOKEN}",
-            "x-aegis-client-id": AEGIS_CLIENT_ID,
+            "Authorization": f"Bearer {KIRRA_TOKEN}",
+            "x-kirra-client-id": KIRRA_CLIENT_ID,
             "Content-Type": "application/json",
         },
         json={
@@ -60,10 +60,10 @@ def _aegis_evaluate(
 
 
 # ---------------------------------------------------------------------------
-# LangChain tool definitions with Aegis safety filtering
+# LangChain tool definitions with Kirra safety filtering
 #
 # Each @tool function:
-#   1. Calls Aegis to get a safety decision
+#   1. Calls Kirra to get a safety decision
 #   2. Only proceeds with hardware interaction if allowed=True
 #   3. Returns a human-readable result (which the agent sees as tool output)
 #
@@ -109,20 +109,20 @@ def move_robot(target_node: str, linear_x: float, angular_z: float) -> str:
           f"linear_x={linear_x}, angular_z={angular_z}")
 
     try:
-        decision = _aegis_evaluate(
+        decision = _kirra_evaluate(
             action_type="cmd_vel",
             target_node=target_node,
             risk_class="kinetic_write",
             payload=payload,
         )
     except requests.exceptions.RequestException as exc:
-        print(f"  [AEGIS] Unreachable: {exc}. Halting action.")
+        print(f"  [KIRRA] Unreachable: {exc}. Halting action.")
         return (
-            "Motion command denied: Aegis safety filter is unreachable. "
+            "Motion command denied: Kirra safety filter is unreachable. "
             "No hardware command was sent."
         )
 
-    print(f"  [AEGIS] allowed={decision['allowed']}, "
+    print(f"  [KIRRA] allowed={decision['allowed']}, "
           f"reason={decision['reason']}, "
           f"posture={decision['posture_at_evaluation']}, "
           f"request_id={decision['request_id']}")
@@ -159,7 +159,7 @@ def move_robot(target_node: str, linear_x: float, angular_z: float) -> str:
         )
     else:
         return (
-            f"Motion denied by Aegis safety filter. "
+            f"Motion denied by Kirra safety filter. "
             f"Reason: {reason}. Fleet posture: {posture}."
         )
 
@@ -181,17 +181,17 @@ def read_sensor(target_node: str) -> str:
     print(f"\n[TOOL] read_sensor called: target={target_node}")
 
     try:
-        decision = _aegis_evaluate(
+        decision = _kirra_evaluate(
             action_type="read_telemetry",
             target_node=target_node,
             risk_class="read",
             payload={},
         )
     except requests.exceptions.RequestException as exc:
-        print(f"  [AEGIS] Unreachable: {exc}. Halting read.")
-        return "Telemetry read denied: Aegis safety filter is unreachable."
+        print(f"  [KIRRA] Unreachable: {exc}. Halting read.")
+        return "Telemetry read denied: Kirra safety filter is unreachable."
 
-    print(f"  [AEGIS] allowed={decision['allowed']}, "
+    print(f"  [KIRRA] allowed={decision['allowed']}, "
           f"reason={decision['reason']}, "
           f"posture={decision['posture_at_evaluation']}")
 
@@ -208,14 +208,14 @@ def read_sensor(target_node: str) -> str:
 @langchain_tool
 def get_fleet_health() -> str:
     """
-    Query the current fleet posture from Aegis (public, unauthenticated endpoint).
+    Query the current fleet posture from Kirra (public, unauthenticated endpoint).
 
     Returns a summary of the current fleet-wide posture state.
     This does not go through the action filter — it reads public posture state.
     """
     print("\n[TOOL] get_fleet_health called")
     try:
-        resp = requests.get(f"{AEGIS_URL}/fleet/posture", timeout=5)
+        resp = requests.get(f"{KIRRA_URL}/fleet/posture", timeout=5)
         resp.raise_for_status()
         data = resp.json()
         fleet = data.get("fleet", [])
@@ -257,7 +257,7 @@ def _read_hardware_telemetry(target_node: str) -> dict:
 
 def run_langchain_agent(user_prompt: str) -> None:
     """
-    Run a LangChain ReAct agent with Aegis-filtered robot tools.
+    Run a LangChain ReAct agent with Kirra-filtered robot tools.
     Requires: pip install langchain langchain-openai, and OPENAI_API_KEY env var.
     """
     if not LANGCHAIN_AVAILABLE:
@@ -311,7 +311,7 @@ Question: {input}
 
 def demo_mocked_agent_output():
     """
-    Demonstrates Aegis safety filtering with mocked agent tool invocations.
+    Demonstrates Kirra safety filtering with mocked agent tool invocations.
 
     Simulates four scenarios that a LangChain agent might generate:
       1. Valid motion command in nominal posture
@@ -319,13 +319,13 @@ def demo_mocked_agent_output():
       3. Read telemetry (allowed even in degraded posture)
       4. A scenario where the agent checks fleet health before moving
 
-    NOTE: This demo connects to a live Aegis instance at AEGIS_URL.
-    If Aegis is not running, each call will raise a connection error
+    NOTE: This demo connects to a live Kirra instance at KIRRA_URL.
+    If Kirra is not running, each call will raise a connection error
     which is caught and printed as a graceful denial.
     """
     print("=" * 60)
-    print("Aegis Action Filter Demo — LangChain-style Tool Invocations")
-    print(f"Aegis URL: {AEGIS_URL}")
+    print("Kirra Action Filter Demo — LangChain-style Tool Invocations")
+    print(f"Kirra URL: {KIRRA_URL}")
     print("=" * 60)
 
     scenarios = [
@@ -375,7 +375,7 @@ def demo_mocked_agent_output():
     print("\n" + "=" * 60)
     print("Demo complete.")
     print("In a real LangChain agent, these tool calls are generated by the LLM.")
-    print("Aegis evaluates each one against live fleet posture before any")
+    print("Kirra evaluates each one against live fleet posture before any")
     print("hardware interaction occurs. The agent only sees the tool's return value.")
     print("=" * 60)
 

--- a/examples/openai_action_filter.py
+++ b/examples/openai_action_filter.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Aegis + OpenAI: Safety-filtered robot control via GPT function calling.
-The AI decides what to do. Aegis decides if it's physically safe to do it.
+Kirra + OpenAI: Safety-filtered robot control via GPT function calling.
+The AI decides what to do. Kirra decides if it's physically safe to do it.
 
 This example demonstrates:
-  - Sending AI-generated actions through Aegis before hardware execution
+  - Sending AI-generated actions through Kirra before hardware execution
   - Handling Allow, Deny (posture), and Deny (kinematic breach) responses
   - Subscribing to the SSE posture stream for proactive posture awareness
   - Mocked LLM output to demonstrate the safety filter without OpenAI credentials
@@ -21,26 +21,26 @@ import requests
 
 # import openai  # pip install openai
 
-AEGIS_URL = "http://localhost:8090"
-AEGIS_TOKEN = "your-admin-token"
-AEGIS_CLIENT_ID = "openai-agent-001"
+KIRRA_URL = "http://localhost:8090"
+KIRRA_TOKEN = "your-admin-token"
+KIRRA_CLIENT_ID = "openai-agent-001"
 
 # Set to True and provide OPENAI_API_KEY to use real GPT function calling.
 USE_REAL_OPENAI = False
 
 # ---------------------------------------------------------------------------
-# Aegis Action Filter client
+# Kirra Action Filter client
 # ---------------------------------------------------------------------------
 
-def check_action_with_aegis(
+def check_action_with_kirra(
     action_type: str,
     target_node: str,
     risk_class: str,
     payload: dict,
 ) -> dict:
-    """Send any AI-generated action through Aegis before executing it on hardware.
+    """Send any AI-generated action through Kirra before executing it on hardware.
 
-    Returns the Aegis decision dict:
+    Returns the Kirra decision dict:
       {
         "allowed": bool,
         "reason": str,
@@ -48,14 +48,14 @@ def check_action_with_aegis(
         "request_id": str,
       }
 
-    Raises requests.HTTPError if Aegis returns a non-2xx status (e.g. 401, 503).
+    Raises requests.HTTPError if Kirra returns a non-2xx status (e.g. 401, 503).
     Always raises on network failure — treat that as a deny in the caller.
     """
     resp = requests.post(
-        f"{AEGIS_URL}/action_filter/evaluate",
+        f"{KIRRA_URL}/action_filter/evaluate",
         headers={
-            "Authorization": f"Bearer {AEGIS_TOKEN}",
-            "x-aegis-client-id": AEGIS_CLIENT_ID,
+            "Authorization": f"Bearer {KIRRA_TOKEN}",
+            "x-kirra-client-id": KIRRA_CLIENT_ID,
             "Content-Type": "application/json",
         },
         json={
@@ -93,7 +93,7 @@ OPENAI_FUNCTIONS = [
         "name": "move_robot",
         "description": (
             "Move a robot at the specified linear and angular velocity. "
-            "This command is subject to Aegis safety filtering."
+            "This command is subject to Kirra safety filtering."
         ),
         "parameters": {
             "type": "object",
@@ -137,10 +137,10 @@ OPENAI_FUNCTIONS = [
 
 def execute_function_call(function_name: str, arguments: dict) -> str:
     """
-    Execute an LLM-generated function call through Aegis safety filtering.
+    Execute an LLM-generated function call through Kirra safety filtering.
 
     This is the core integration point: every function call the model requests
-    goes through check_action_with_aegis() before any hardware interaction.
+    goes through check_action_with_kirra() before any hardware interaction.
     Returns a string result to feed back to the model.
     """
     print(f"\n[AGENT] Model requested: {function_name}({arguments})")
@@ -160,17 +160,17 @@ def execute_function_call(function_name: str, arguments: dict) -> str:
         }
 
         try:
-            decision = check_action_with_aegis(
+            decision = check_action_with_kirra(
                 action_type="cmd_vel",
                 target_node=target_node,
                 risk_class="kinetic_write",
                 payload=payload,
             )
         except requests.exceptions.RequestException as exc:
-            print(f"  [AEGIS] Unreachable: {exc}. Treating as DENY.")
-            return "Action denied: Aegis safety filter unavailable."
+            print(f"  [KIRRA] Unreachable: {exc}. Treating as DENY.")
+            return "Action denied: Kirra safety filter unavailable."
 
-        print(f"  [AEGIS] Decision: allowed={decision['allowed']}, "
+        print(f"  [KIRRA] Decision: allowed={decision['allowed']}, "
               f"reason={decision['reason']}, "
               f"posture={decision['posture_at_evaluation']}, "
               f"request_id={decision['request_id']}")
@@ -204,17 +204,17 @@ def execute_function_call(function_name: str, arguments: dict) -> str:
         target_node = arguments.get("target_node", "sensor_01")
 
         try:
-            decision = check_action_with_aegis(
+            decision = check_action_with_kirra(
                 action_type="read_telemetry",
                 target_node=target_node,
                 risk_class="read",
                 payload={},
             )
         except requests.exceptions.RequestException as exc:
-            print(f"  [AEGIS] Unreachable: {exc}. Treating as DENY.")
-            return "Telemetry read denied: Aegis safety filter unavailable."
+            print(f"  [KIRRA] Unreachable: {exc}. Treating as DENY.")
+            return "Telemetry read denied: Kirra safety filter unavailable."
 
-        print(f"  [AEGIS] Decision: allowed={decision['allowed']}, "
+        print(f"  [KIRRA] Decision: allowed={decision['allowed']}, "
               f"reason={decision['reason']}, "
               f"posture={decision['posture_at_evaluation']}")
 
@@ -288,7 +288,7 @@ def run_agent_loop_with_real_openai(user_prompt: str) -> None:
 # ---------------------------------------------------------------------------
 
 class PostureStreamSubscriber:
-    """Background thread that subscribes to the Aegis SSE posture stream."""
+    """Background thread that subscribes to the Kirra SSE posture stream."""
 
     def __init__(self):
         self.current_posture = "Unknown"
@@ -305,10 +305,10 @@ class PostureStreamSubscriber:
     def _run(self):
         try:
             resp = requests.get(
-                f"{AEGIS_URL}/system/posture/stream",
+                f"{KIRRA_URL}/system/posture/stream",
                 headers={
-                    "Authorization": f"Bearer {AEGIS_TOKEN}",
-                    "x-aegis-client-id": AEGIS_CLIENT_ID,
+                    "Authorization": f"Bearer {KIRRA_TOKEN}",
+                    "x-kirra-client-id": KIRRA_CLIENT_ID,
                     "Accept": "text/event-stream",
                 },
                 stream=True,
@@ -340,20 +340,20 @@ class PostureStreamSubscriber:
 
 def demo_mocked_llm_output():
     """
-    Demonstrates the Aegis safety filter without requiring OpenAI credentials.
+    Demonstrates the Kirra safety filter without requiring OpenAI credentials.
 
     Simulates three scenarios that an LLM agent might generate:
       1. A valid motion command (should be allowed in Nominal posture)
       2. A hallucinated extreme velocity (should be denied: KINEMATIC_ENVELOPE_BREACH)
       3. A hallucinated unknown action type (should be denied: UNKNOWN_ACTION_TYPE)
 
-    NOTE: This demo connects to a live Aegis instance at AEGIS_URL.
-    If Aegis is not running, each check_action_with_aegis() call will raise
+    NOTE: This demo connects to a live Kirra instance at KIRRA_URL.
+    If Kirra is not running, each check_action_with_kirra() call will raise
     a connection error, which is caught and printed gracefully.
     """
     print("=" * 60)
-    print("Aegis Action Filter Demo (Mocked LLM Output)")
-    print(f"Aegis URL: {AEGIS_URL}")
+    print("Kirra Action Filter Demo (Mocked LLM Output)")
+    print(f"Kirra URL: {KIRRA_URL}")
     print("=" * 60)
 
     # Mocked LLM function calls — simulating what GPT-4o might generate
@@ -401,7 +401,7 @@ def demo_mocked_llm_output():
 
     print("\n" + "=" * 60)
     print("Demo complete.")
-    print("Check /system/audit/export on your Aegis instance to see")
+    print("Check /system/audit/export on your Kirra instance to see")
     print("all decisions logged to the SHA-256 hash-chained audit ledger.")
     print("=" * 60)
 
@@ -409,7 +409,7 @@ def demo_mocked_llm_output():
 if __name__ == "__main__":
     if USE_REAL_OPENAI:
         # Real OpenAI mode: uses GPT function calling, requires OPENAI_API_KEY
-        print("Starting Aegis-filtered robot agent with real OpenAI...")
+        print("Starting Kirra-filtered robot agent with real OpenAI...")
 
         # Subscribe to posture stream in background for proactive posture awareness
         posture_stream = PostureStreamSubscriber()

--- a/install.sh
+++ b/install.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
-# install.sh — Aegis Safety Kernel Installer
+# install.sh — Kirra Safety Kernel Installer
 #
-# Installs the Aegis Safety Kernel Verifier Service on Debian/Ubuntu systems.
+# Installs the Kirra Safety Kernel Verifier Service on Debian/Ubuntu systems.
 # Supports x86_64, aarch64 (NVIDIA Jetson, Raspberry Pi), and armv7.
 #
 # Usage (recommended — pulls latest release from GitHub):
-#   curl -fsSL https://raw.githubusercontent.com/justinlooney/aegis/master/install.sh | sudo bash
+#   curl -fsSL https://raw.githubusercontent.com/justinlooney/kirra-runtime-sdk/master/install.sh | sudo bash
 #
 # Usage (from downloaded release archive):
 #   sudo bash install.sh
 #
 # Usage (non-interactive with environment variables pre-set):
-#   AEGIS_ADMIN_TOKEN=mytoken AEGIS_PORT=8090 sudo bash install.sh --non-interactive
+#   KIRRA_ADMIN_TOKEN=mytoken KIRRA_PORT=8090 sudo bash install.sh --non-interactive
 #
 # What this script does:
 #   1. Detects system architecture
-#   2. Downloads the correct Aegis binary (or uses bundled binary if present)
-#   3. Creates a dedicated 'aegis' system user and required directories
+#   2. Downloads the correct Kirra binary (or uses bundled binary if present)
+#   3. Creates a dedicated 'kirra' system user and required directories
 #   4. Prompts for configuration (port, token, database location)
-#   5. Writes /etc/aegis/aegis.env with your configuration
+#   5. Writes /etc/kirra/kirra.env with your configuration
 #   6. Installs and starts the systemd service
 #   7. Verifies the service is running correctly
 #
@@ -28,7 +28,7 @@
 #   - sudo / root access
 #   - Internet access (if downloading binary from GitHub)
 #
-# Support: https://github.com/justinlooney/aegis/issues
+# Support: https://github.com/justinlooney/kirra-runtime-sdk/issues
 
 set -euo pipefail
 
@@ -36,17 +36,17 @@ set -euo pipefail
 # Constants
 # ---------------------------------------------------------------------------
 
-AEGIS_USER="aegis"
-AEGIS_GROUP="aegis"
+KIRRA_USER="kirra"
+KIRRA_GROUP="kirra"
 INSTALL_DIR="/usr/local/bin"
-CONFIG_DIR="/etc/aegis"
-DATA_DIR="/var/lib/aegis"
-LOG_DIR="/var/log/aegis"
-SERVICE_NAME="aegis-verifier"
+CONFIG_DIR="/etc/kirra"
+DATA_DIR="/var/lib/kirra"
+LOG_DIR="/var/log/kirra"
+SERVICE_NAME="kirra-verifier"
 SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
-ENV_FILE="${CONFIG_DIR}/aegis.env"
-BINARY_NAME="aegis_verifier_service"
-GITHUB_REPO="justinlooney/aegis"
+ENV_FILE="${CONFIG_DIR}/kirra.env"
+BINARY_NAME="kirra_verifier_service"
+GITHUB_REPO="justinlooney/kirra-runtime-sdk"
 GITHUB_API="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
 
 # Minimum supported OS versions
@@ -116,15 +116,15 @@ for arg in "$@"; do
             echo "Options:"
             echo "  --non-interactive  Skip prompts, use env vars or defaults"
             echo "  --force            Reinstall even if already installed"
-            echo "  --uninstall        Remove Aegis and all its files"
+            echo "  --uninstall        Remove Kirra and all its files"
             echo "  --no-start         Install but don't start the service"
             echo "  --help             Show this help"
             echo ""
             echo "Environment variables (for --non-interactive):"
-            echo "  AEGIS_ADMIN_TOKEN  Admin bearer token (required)"
-            echo "  AEGIS_PORT         Listen port (default: 8090)"
-            echo "  AEGIS_DB_PATH      Database path (default: /var/lib/aegis/aegis.db)"
-            echo "  AEGIS_VERIFIER_MODE active or passive_standby (default: active)"
+            echo "  KIRRA_ADMIN_TOKEN  Admin bearer token (required)"
+            echo "  KIRRA_PORT         Listen port (default: 8090)"
+            echo "  KIRRA_DB_PATH      Database path (default: /var/lib/kirra/kirra.db)"
+            echo "  KIRRA_VERIFIER_MODE active or passive_standby (default: active)"
             exit 0
             ;;
         *)
@@ -138,7 +138,7 @@ done
 # ---------------------------------------------------------------------------
 
 do_uninstall() {
-    section "Uninstalling Aegis"
+    section "Uninstalling Kirra"
 
     if systemctl is-active --quiet "${SERVICE_NAME}" 2>/dev/null; then
         info "Stopping service..."
@@ -163,9 +163,9 @@ do_uninstall() {
     echo ""
     echo "To remove everything including data:"
     echo "  sudo rm -rf ${CONFIG_DIR} ${DATA_DIR} ${LOG_DIR}"
-    echo "  sudo userdel -r ${AEGIS_USER} 2>/dev/null || true"
+    echo "  sudo userdel -r ${KIRRA_USER} 2>/dev/null || true"
     echo ""
-    success "Aegis service uninstalled."
+    success "Kirra service uninstalled."
     exit 0
 }
 
@@ -198,7 +198,7 @@ fi
 
 # systemd check
 if ! command -v systemctl &>/dev/null; then
-    fatal "systemd is required but not found. Aegis uses systemd for service management."
+    fatal "systemd is required but not found. Kirra uses systemd for service management."
 fi
 success "systemd detected"
 
@@ -210,7 +210,7 @@ case "${ARCH}" in
     armv7l|armv7)        BINARY_ARCH="armv7-linux"    ;;
     *)
         fatal "Unsupported architecture: ${ARCH}
-Aegis supports: x86_64 (Intel/AMD), aarch64 (Jetson/Pi/Graviton), armv7 (embedded ARM)
+Kirra supports: x86_64 (Intel/AMD), aarch64 (Jetson/Pi/Graviton), armv7 (embedded ARM)
 Please open an issue at https://github.com/${GITHUB_REPO}/issues"
         ;;
 esac
@@ -219,7 +219,7 @@ success "Architecture: ${ARCH} → using ${BINARY_ARCH} binary"
 # Check for existing installation
 if [ -f "${INSTALL_DIR}/${BINARY_NAME}" ] && [ "${FORCE_REINSTALL}" = false ]; then
     EXISTING_VERSION=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>/dev/null || echo "unknown")
-    warn "Aegis is already installed (${EXISTING_VERSION})"
+    warn "Kirra is already installed (${EXISTING_VERSION})"
     warn "Run with --force to reinstall, or --uninstall to remove"
     echo ""
     echo "Current service status:"
@@ -237,11 +237,11 @@ success "Required tools available"
 # Binary acquisition
 # ---------------------------------------------------------------------------
 
-section "Installing Aegis Binary"
+section "Installing Kirra Binary"
 
 # Check if binary is bundled (running from release archive)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BUNDLED_BINARY="${SCRIPT_DIR}/aegis/${BINARY_NAME}"
+BUNDLED_BINARY="${SCRIPT_DIR}/kirra/${BINARY_NAME}"
 
 if [ -f "${BUNDLED_BINARY}" ]; then
     info "Using bundled binary"
@@ -250,7 +250,7 @@ else
     info "Downloading from GitHub releases..."
 
     if ! command -v curl &>/dev/null; then
-        fatal "curl is required to download Aegis. Run: sudo apt-get install -y curl"
+        fatal "curl is required to download Kirra. Run: sudo apt-get install -y curl"
     fi
 
     # Get latest release URL
@@ -282,7 +282,7 @@ else
     TMPDIR=$(mktemp -d)
     trap 'rm -rf "${TMPDIR}"' EXIT
 
-    ARCHIVE="${TMPDIR}/aegis.tar.gz"
+    ARCHIVE="${TMPDIR}/kirra.tar.gz"
     curl -fsSL --progress-bar "${DOWNLOAD_URL}" -o "${ARCHIVE}" || \
         fatal "Download failed. URL: ${DOWNLOAD_URL}"
 
@@ -298,7 +298,7 @@ else
             if grep -q "${ARCHIVE_NAME}" "${CHECKSUMS}"; then
                 (cd "${TMPDIR}" && \
                     grep "${ARCHIVE_NAME}" SHA256SUMS | \
-                    sed "s|${ARCHIVE_NAME}|aegis.tar.gz|" | \
+                    sed "s|${ARCHIVE_NAME}|kirra.tar.gz|" | \
                     sha256sum -c --quiet) || \
                     fatal "Checksum verification FAILED — download may be corrupt or tampered"
                 success "Checksum verified"
@@ -309,7 +309,7 @@ else
     # Extract
     info "Extracting..."
     tar -xzf "${ARCHIVE}" -C "${TMPDIR}"
-    BINARY_PATH="${TMPDIR}/aegis/${BINARY_NAME}"
+    BINARY_PATH="${TMPDIR}/kirra/${BINARY_NAME}"
 
     if [ ! -f "${BINARY_PATH}" ]; then
         fatal "Binary not found in archive. Archive contents:"
@@ -333,17 +333,17 @@ success "Binary installed to ${INSTALL_DIR}/${BINARY_NAME}"
 section "Creating System User and Directories"
 
 # Create system user (no login shell, no home directory in /home)
-if ! id "${AEGIS_USER}" &>/dev/null; then
+if ! id "${KIRRA_USER}" &>/dev/null; then
     useradd \
         --system \
         --no-create-home \
         --home-dir "${DATA_DIR}" \
         --shell /usr/sbin/nologin \
-        --comment "Aegis Safety Kernel Service" \
-        "${AEGIS_USER}"
-    success "Created system user: ${AEGIS_USER}"
+        --comment "Kirra Safety Kernel Service" \
+        "${KIRRA_USER}"
+    success "Created system user: ${KIRRA_USER}"
 else
-    info "System user ${AEGIS_USER} already exists"
+    info "System user ${KIRRA_USER} already exists"
 fi
 
 # Create directories with correct ownership
@@ -351,16 +351,16 @@ for dir in "${CONFIG_DIR}" "${DATA_DIR}" "${LOG_DIR}"; do
     mkdir -p "${dir}"
 done
 
-# Config: root-owned, aegis-readable (contains admin token)
-chown root:${AEGIS_GROUP} "${CONFIG_DIR}"
+# Config: root-owned, kirra-readable (contains admin token)
+chown root:${KIRRA_GROUP} "${CONFIG_DIR}"
 chmod 750 "${CONFIG_DIR}"
 
-# Data: aegis-owned (database writes)
-chown ${AEGIS_USER}:${AEGIS_GROUP} "${DATA_DIR}"
+# Data: kirra-owned (database writes)
+chown ${KIRRA_USER}:${KIRRA_GROUP} "${DATA_DIR}"
 chmod 750 "${DATA_DIR}"
 
-# Logs: aegis-owned
-chown ${AEGIS_USER}:${AEGIS_GROUP} "${LOG_DIR}"
+# Logs: kirra-owned
+chown ${KIRRA_USER}:${KIRRA_GROUP} "${LOG_DIR}"
 chmod 750 "${LOG_DIR}"
 
 success "Directories created"
@@ -375,7 +375,7 @@ info "  Logs:     ${LOG_DIR}"
 section "Configuration"
 
 echo ""
-echo "Aegis requires a few configuration values."
+echo "Kirra requires a few configuration values."
 echo "Press Enter to accept the default shown in [brackets]."
 echo ""
 
@@ -387,15 +387,15 @@ echo "  submitting federation reports). Keep this secure."
 echo "  It must be provided in API calls as: Authorization: Bearer <token>"
 echo ""
 
-if [ -n "${AEGIS_ADMIN_TOKEN:-}" ]; then
-    ADMIN_TOKEN="${AEGIS_ADMIN_TOKEN}"
-    info "Using AEGIS_ADMIN_TOKEN from environment"
+if [ -n "${KIRRA_ADMIN_TOKEN:-}" ]; then
+    ADMIN_TOKEN="${KIRRA_ADMIN_TOKEN}"
+    info "Using KIRRA_ADMIN_TOKEN from environment"
 elif [ "${NON_INTERACTIVE}" = true ]; then
-    fatal "AEGIS_ADMIN_TOKEN must be set in non-interactive mode"
+    fatal "KIRRA_ADMIN_TOKEN must be set in non-interactive mode"
 else
     # Check if upgrading and token already exists
-    if [ -f "${ENV_FILE}" ] && grep -q "^AEGIS_ADMIN_TOKEN=" "${ENV_FILE}"; then
-        EXISTING_TOKEN=$(grep "^AEGIS_ADMIN_TOKEN=" "${ENV_FILE}" | cut -d= -f2-)
+    if [ -f "${ENV_FILE}" ] && grep -q "^KIRRA_ADMIN_TOKEN=" "${ENV_FILE}"; then
+        EXISTING_TOKEN=$(grep "^KIRRA_ADMIN_TOKEN=" "${ENV_FILE}" | cut -d= -f2-)
         echo -n "  Keep existing token? [Y/n]: "
         read -r KEEP_TOKEN
         if [[ "${KEEP_TOKEN:-Y}" =~ ^[Yy]$ ]]; then
@@ -426,13 +426,13 @@ fi
 # --- Port ---
 echo ""
 echo -e "${BOLD}Listen Port${NC}"
-echo "  The port Aegis listens on for HTTP API requests."
+echo "  The port Kirra listens on for HTTP API requests."
 echo "  Default 8090 is recommended unless it conflicts with other services."
 echo ""
 
 DEFAULT_PORT="8090"
 if [ "${NON_INTERACTIVE}" = true ]; then
-    PORT="${AEGIS_PORT:-${DEFAULT_PORT}}"
+    PORT="${KIRRA_PORT:-${DEFAULT_PORT}}"
 else
     echo -n "  Port [${DEFAULT_PORT}]: "
     read -r PORT
@@ -449,14 +449,14 @@ info "Listen address: 0.0.0.0:${PORT}"
 # --- Database path ---
 echo ""
 echo -e "${BOLD}Database Location${NC}"
-echo "  Aegis stores its fleet registry, audit chain, and posture history"
+echo "  Kirra stores its fleet registry, audit chain, and posture history"
 echo "  in a SQLite database. This file should be on a persistent volume."
 echo "  For production deployments, consider a dedicated disk or volume."
 echo ""
 
-DEFAULT_DB="${DATA_DIR}/aegis.db"
+DEFAULT_DB="${DATA_DIR}/kirra.db"
 if [ "${NON_INTERACTIVE}" = true ]; then
-    DB_PATH="${AEGIS_DB_PATH:-${DEFAULT_DB}}"
+    DB_PATH="${KIRRA_DB_PATH:-${DEFAULT_DB}}"
 else
     echo -n "  Database path [${DEFAULT_DB}]: "
     read -r DB_PATH
@@ -464,15 +464,15 @@ else
 fi
 info "Database: ${DB_PATH}"
 
-# Ensure database directory exists and is writable by aegis user
+# Ensure database directory exists and is writable by kirra user
 DB_DIR=$(dirname "${DB_PATH}")
 mkdir -p "${DB_DIR}"
-chown ${AEGIS_USER}:${AEGIS_GROUP} "${DB_DIR}"
+chown ${KIRRA_USER}:${KIRRA_GROUP} "${DB_DIR}"
 
 # --- Verifier mode ---
 echo ""
 echo -e "${BOLD}Verifier Mode${NC}"
-echo "  active          — This is the primary Aegis instance. It enforces"
+echo "  active          — This is the primary Kirra instance. It enforces"
 echo "                    posture and writes to the cache. Use this for"
 echo "                    single-instance or primary HA deployments."
 echo ""
@@ -483,7 +483,7 @@ echo ""
 
 DEFAULT_MODE="active"
 if [ "${NON_INTERACTIVE}" = true ]; then
-    VERIFIER_MODE="${AEGIS_VERIFIER_MODE:-${DEFAULT_MODE}}"
+    VERIFIER_MODE="${KIRRA_VERIFIER_MODE:-${DEFAULT_MODE}}"
 else
     echo -n "  Mode - active or passive_standby [${DEFAULT_MODE}]: "
     read -r VERIFIER_MODE
@@ -513,67 +513,67 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 
 cat > "${ENV_FILE}" << EOF
-# Aegis Safety Kernel — Environment Configuration
+# Kirra Safety Kernel — Environment Configuration
 # Generated by installer on $(date -u '+%Y-%m-%dT%H:%M:%SZ')
 # Edit this file to change configuration, then run:
-#   sudo systemctl restart aegis-verifier
+#   sudo systemctl restart kirra-verifier
 
 # ── Security ──────────────────────────────────────────────────────────────
 # Admin bearer token — required for all administrative API calls.
 # Keep this secret. Rotate by editing this file and restarting the service.
 # API usage: Authorization: Bearer <value>
-AEGIS_ADMIN_TOKEN=${ADMIN_TOKEN}
+KIRRA_ADMIN_TOKEN=${ADMIN_TOKEN}
 
 # Log signing key — Ed25519 private key (base64). Leave blank to disable signing.
 # Generate: openssl genpkey -algorithm ed25519 2>/dev/null | openssl pkey -outform DER 2>/dev/null | tail -c 32 | base64
-# AEGIS_LOG_SIGNING_KEY=
+# KIRRA_LOG_SIGNING_KEY=
 
 # ── Network ───────────────────────────────────────────────────────────────
 # Address and port to listen on.
 # Use 127.0.0.1:${PORT} to restrict to localhost (if behind a reverse proxy).
 # Use 0.0.0.0:${PORT} to listen on all interfaces (default).
-AEGIS_VERIFIER_ADDR=0.0.0.0:${PORT}
+KIRRA_VERIFIER_ADDR=0.0.0.0:${PORT}
 
 # ── Storage ───────────────────────────────────────────────────────────────
 # Path to the SQLite database file.
 # This file contains the fleet registry, audit chain, and posture history.
 # Back this up regularly in production deployments.
-AEGIS_DB_PATH=${DB_PATH}
+KIRRA_DB_PATH=${DB_PATH}
 
 # ── Operation Mode ────────────────────────────────────────────────────────
 # active          = Primary instance. Enforces posture. Writes to cache.
 # passive_standby = HA standby. Observes only. Auto-promotes if primary fails.
-AEGIS_VERIFIER_MODE=${VERIFIER_MODE}
+KIRRA_VERIFIER_MODE=${VERIFIER_MODE}
 
 # ── Identity and Ingress (advanced) ───────────────────────────────────────
-# Set to true to require x-aegis-client-id header on identity-gated routes.
+# Set to true to require x-kirra-client-id header on identity-gated routes.
 # Leave false for standard deployments.
-AEGIS_TRUSTED_INGRESS_MODE=false
+KIRRA_TRUSTED_INGRESS_MODE=false
 
-# Header name used for client identity (when AEGIS_TRUSTED_INGRESS_MODE=true)
-AEGIS_CLIENT_ID_HEADER=x-aegis-client-id
+# Header name used for client identity (when KIRRA_TRUSTED_INGRESS_MODE=true)
+KIRRA_CLIENT_ID_HEADER=x-kirra-client-id
 
 # ── High Availability (optional) ──────────────────────────────────────────
-# Unique identifier for this Aegis instance (used in HA deployments).
+# Unique identifier for this Kirra instance (used in HA deployments).
 # Leave blank to use hostname automatically.
-# AEGIS_INSTANCE_ID=
+# KIRRA_INSTANCE_ID=
 
 # Heartbeat interval for primary → standby signaling (milliseconds).
 # Default: 2000 (2 seconds)
-# AEGIS_HEARTBEAT_INTERVAL=2000
+# KIRRA_HEARTBEAT_INTERVAL=2000
 
 # Promotion timeout — standby promotes if primary silent for this long (ms).
 # Default: 10000 (10 seconds)
-# AEGIS_PROMOTION_TIMEOUT=10000
+# KIRRA_PROMOTION_TIMEOUT=10000
 
 # ── Supervisor Reset Key (optional) ───────────────────────────────────────
 # Required only if using supervisor reset operations.
 # Must be non-empty and ≤ 64 bytes if set.
-# AEGIS_SUPERVISOR_RESET_KEY=
+# KIRRA_SUPERVISOR_RESET_KEY=
 EOF
 
 # Secure the config file — contains the admin token
-chown root:${AEGIS_GROUP} "${ENV_FILE}"
+chown root:${KIRRA_GROUP} "${ENV_FILE}"
 chmod 640 "${ENV_FILE}"
 
 success "Configuration written to ${ENV_FILE}"
@@ -585,21 +585,21 @@ success "Configuration written to ${ENV_FILE}"
 section "Installing systemd Service"
 
 # Write service file (use bundled version or generate inline)
-BUNDLED_SERVICE="${SCRIPT_DIR}/systemd/aegis-verifier.service"
+BUNDLED_SERVICE="${SCRIPT_DIR}/systemd/kirra-verifier.service"
 
 if [ -f "${BUNDLED_SERVICE}" ]; then
     cp "${BUNDLED_SERVICE}" "${SERVICE_FILE}"
 else
     cat > "${SERVICE_FILE}" << EOF
 [Unit]
-Description=Aegis Safety Kernel Verifier Service
+Description=Kirra Safety Kernel Verifier Service
 Documentation=https://github.com/${GITHUB_REPO}
 After=network.target
 Wants=network.target
 
 [Service]
-User=${AEGIS_USER}
-Group=${AEGIS_GROUP}
+User=${KIRRA_USER}
+Group=${KIRRA_GROUP}
 ExecStart=${INSTALL_DIR}/${BINARY_NAME}
 WorkingDirectory=${DATA_DIR}
 EnvironmentFile=${ENV_FILE}
@@ -614,7 +614,7 @@ ProtectHome=true
 ReadWritePaths=${DATA_DIR} ${LOG_DIR}
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=aegis-verifier
+SyslogIdentifier=kirra-verifier
 MemoryMax=512M
 TasksMax=64
 
@@ -637,13 +637,13 @@ if [ "${SKIP_SERVICE_START}" = false ]; then
 
     # Validate token is present before starting — empty token causes 503 fail-closed
     if [ -z "${ADMIN_TOKEN:-}" ]; then
-        fatal "AEGIS_ADMIN_TOKEN is empty — cannot start service (service would return 503 on all requests)"
+        fatal "KIRRA_ADMIN_TOKEN is empty — cannot start service (service would return 503 on all requests)"
     fi
 
     systemctl start "${SERVICE_NAME}"
 
     # Wait for service to become healthy
-    info "Waiting for Aegis to start..."
+    info "Waiting for Kirra to start..."
     MAX_WAIT=30
     WAITED=0
     while [ ${WAITED} -lt ${MAX_WAIT} ]; do
@@ -659,7 +659,7 @@ if [ "${SKIP_SERVICE_START}" = false ]; then
 
     if curl -fsSL --max-time 2 \
         "http://127.0.0.1:${PORT}/health" &>/dev/null; then
-        success "Aegis is running and healthy"
+        success "Kirra is running and healthy"
     else
         warn "Service started but health check did not respond within ${MAX_WAIT}s"
         warn "Check logs: sudo journalctl -u ${SERVICE_NAME} -n 50"
@@ -677,39 +677,39 @@ DASHBOARD_PORT=8091
 if [ -d "${BUNDLED_DASHBOARD}" ]; then
     section "Web Dashboard"
     echo ""
-    echo "  A web dashboard is included for monitoring the Aegis fleet."
+    echo "  A web dashboard is included for monitoring the Kirra fleet."
     echo "  It will be served on port ${DASHBOARD_PORT} using Python's built-in HTTP server."
     echo ""
 
     if [ "${NON_INTERACTIVE}" = true ]; then
-        _install_dash="${AEGIS_INSTALL_DASHBOARD:-Y}"
+        _install_dash="${KIRRA_INSTALL_DASHBOARD:-Y}"
     else
         echo -n "  Install web dashboard? [Y/n]: "
         read -r _install_dash
     fi
 
     if [[ "${_install_dash:-Y}" =~ ^[Yy]$ ]]; then
-        DASHBOARD_SHARE_DIR="/usr/local/share/aegis/dashboard"
+        DASHBOARD_SHARE_DIR="/usr/local/share/kirra/dashboard"
         mkdir -p "${DASHBOARD_SHARE_DIR}"
         cp -r "${BUNDLED_DASHBOARD}/." "${DASHBOARD_SHARE_DIR}/"
-        chown -R root:${AEGIS_GROUP} "${DASHBOARD_SHARE_DIR}"
+        chown -R root:${KIRRA_GROUP} "${DASHBOARD_SHARE_DIR}"
         chmod -R 755 "${DASHBOARD_SHARE_DIR}"
 
-        DASHBOARD_SERVICE_FILE="/etc/systemd/system/aegis-dashboard.service"
-        BUNDLED_DASH_SVC="${SCRIPT_DIR}/systemd/aegis-dashboard.service"
+        DASHBOARD_SERVICE_FILE="/etc/systemd/system/kirra-dashboard.service"
+        BUNDLED_DASH_SVC="${SCRIPT_DIR}/systemd/kirra-dashboard.service"
 
         if [ -f "${BUNDLED_DASH_SVC}" ]; then
             cp "${BUNDLED_DASH_SVC}" "${DASHBOARD_SERVICE_FILE}"
         else
             cat > "${DASHBOARD_SERVICE_FILE}" << EOF
 [Unit]
-Description=Aegis Safety Kernel Web Dashboard
-After=network.target aegis-verifier.service
-Wants=aegis-verifier.service
+Description=Kirra Safety Kernel Web Dashboard
+After=network.target kirra-verifier.service
+Wants=kirra-verifier.service
 
 [Service]
-User=${AEGIS_USER}
-Group=${AEGIS_GROUP}
+User=${KIRRA_USER}
+Group=${KIRRA_GROUP}
 ExecStart=/usr/bin/python3 -m http.server ${DASHBOARD_PORT} --directory ${DASHBOARD_SHARE_DIR}
 WorkingDirectory=${DASHBOARD_SHARE_DIR}
 Restart=on-failure
@@ -724,10 +724,10 @@ EOF
 
         chmod 644 "${DASHBOARD_SERVICE_FILE}"
         systemctl daemon-reload
-        systemctl enable aegis-dashboard
+        systemctl enable kirra-dashboard
 
         if [ "${SKIP_SERVICE_START}" = false ]; then
-            systemctl start aegis-dashboard
+            systemctl start kirra-dashboard
             success "Dashboard installed and running on port ${DASHBOARD_PORT}"
         else
             success "Dashboard installed (not started)"
@@ -744,7 +744,7 @@ fi
 section "Installation Complete"
 
 echo ""
-success "Aegis Safety Kernel installed successfully"
+success "Kirra Safety Kernel installed successfully"
 echo ""
 bold "Service Management:"
 echo "  Status:   sudo systemctl status ${SERVICE_NAME}"
@@ -776,14 +776,14 @@ if [ "${GENERATED_TOKEN}" = true ]; then
     echo -e "  Admin Token: ${BOLD}${ADMIN_TOKEN}${NC}"
     echo ""
     echo "  This token is also stored in ${ENV_FILE}"
-    echo "  (readable by root and the aegis group only)"
+    echo "  (readable by root and the kirra group only)"
     echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 fi
 
 echo ""
 bold "Quick API Test:"
 echo "  curl http://localhost:${PORT}/health"
-echo "  curl -H 'Authorization: Bearer \${AEGIS_ADMIN_TOKEN}' \\"
+echo "  curl -H 'Authorization: Bearer \${KIRRA_ADMIN_TOKEN}' \\"
 echo "       http://localhost:${PORT}/fleet/posture"
 echo ""
 bold "Documentation:"

--- a/parko/crates/parko-core/src/safety.rs
+++ b/parko/crates/parko-core/src/safety.rs
@@ -4,7 +4,7 @@ use crate::commands::ControlCommand;
 
 /// Operational posture passed to safety governors. Parallel to but
 /// independent of any specific safety system's posture vocabulary.
-/// parko-core owns this type; adapter crates (e.g., parko-aegis) map
+/// parko-core owns this type; adapter crates (e.g., parko-kirra) map
 /// it to their respective external types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SafetyPosture {

--- a/parko/crates/parko-kirra/Cargo.toml
+++ b/parko/crates/parko-kirra/Cargo.toml
@@ -8,3 +8,6 @@ license = "Apache-2.0"
 [dependencies]
 parko-core = { path = "../parko-core" }
 kirra-runtime-sdk = { path = "../../.." }
+
+[dev-dependencies]
+proptest = "1"

--- a/parko/crates/parko-kirra/src/comparator.rs
+++ b/parko/crates/parko-kirra/src/comparator.rs
@@ -12,6 +12,7 @@
 // (fallback). Read the module carefully before modifying — the
 // complexity below exists specifically to prevent a hard stop at speed.
 
+use crate::diverse::DiverseKirraGovernor;
 use crate::{KirraGovernor, MRC_VELOCITY_CEILING_MPS};
 use parko_core::commands::ControlCommand;
 use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
@@ -19,6 +20,30 @@ use parko_core::RssState;
 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+// ---------------------------------------------------------------------------
+// RSS-aware governor capability
+// ---------------------------------------------------------------------------
+
+/// A [`SafetyGovernor`] whose RSS safe-distance state can be updated.
+///
+/// `SafetyGovernor::evaluate` is stateless w.r.t. RSS, but the Kirra
+/// governors hold an RSS gate that the control loop refreshes each cycle.
+/// The comparator is generic over the shadow governor (CERT-006 diversity),
+/// so it needs a trait to push RSS state into whatever shadow is wired —
+/// the primary `KirraGovernor` or the `DiverseKirraGovernor`.
+///
+/// The method is named `set_rss_state` (not `update_rss_state`) to avoid
+/// shadowing the governors' existing inherent `update_rss_state` methods.
+pub trait RssAwareGovernor: SafetyGovernor {
+    fn set_rss_state(&mut self, state: RssState);
+}
+
+impl RssAwareGovernor for KirraGovernor {
+    fn set_rss_state(&mut self, state: RssState) {
+        self.update_rss_state(state);
+    }
+}
 
 /// Tolerance for floating-point comparison between primary and shadow.
 /// 1e-9 is effectively exact equality for f64 safety computations.
@@ -193,44 +218,36 @@ struct DivState {
 /// to LockedOut **only** when the divergence is persistent **AND** the
 /// vehicle is already at a safe speed — never as a hard stop at speed.
 ///
-/// # FOLLOW-UP (true diverse redundancy)
+/// # Redundancy Model (CERT-006)
 ///
-/// `GovernorComparator` is hard-wired to two `KirraGovernor` instances, so
-/// primary and shadow run identical code and only catch RANDOM faults.
-/// Making the comparator generic over `SafetyGovernor` would (a) allow an
-/// independent second implementation as the shadow — the implementation
-/// diversity the safety case says automotive requires — and (b) make
-/// angular-divergence reachable in integration tests via a mock governor.
-/// Tracked separately.
+/// The comparator is generic over the shadow governor `S`. The default,
+/// and the production wiring, pairs the primary `KirraGovernor` with the
+/// structurally diverse `DiverseKirraGovernor` (`S = DiverseKirraGovernor`).
 ///
-/// # Redundancy Model
+/// - **Diverse redundancy (default).** Primary and shadow enforce the SAME
+///   safety properties via DIFFERENT computation (see
+///   `crate::diverse::DiverseKirraGovernor`). This catches RANDOM faults AND
+///   the most common class of SYSTEMATIC faults: implementation-level logic
+///   / numerical bugs, which are unlikely to manifest identically in two
+///   structurally different code paths.
+/// - **Identical redundancy (`S = KirraGovernor`).** Still constructible
+///   (e.g. for tests). Catches RANDOM faults only — a logic bug in the
+///   shared code path produces the same wrong output in both copies and the
+///   comparator stays silent.
 ///
-/// Primary and shadow currently run IDENTICAL code. This catches
-/// RANDOM faults (memory corruption, bit flips, transient errors) and
-/// state divergence from differing inputs / updates. It does NOT catch
-/// systematic faults — a logic bug in the shared code path produces
-/// the same wrong output in both instances and the comparator stays
-/// silent.
+/// ## Honest limit (do not overstate in any safety case)
 ///
-/// ## Diversity roadmap (do not overstate in any safety case)
-///
-/// - Parameterized diversity (different rate-limit / recovery params
-///   per instance) catches ONLY state-/config-DEPENDENT systematic
-///   faults. Shared-code-path logic faults (e.g. a wrong comparison
-///   operator in the clamp) survive it. It is a weak mitigation.
-/// - Independent implementation (two codebases) is the gold standard
-///   for systematic faults, but a common SPECIFICATION fault still
-///   defeats it — diverse review of the spec is part of the story.
-///
-/// **Current:** identical redundancy + posture-aware, speed-gated
-/// divergence handling. Adequate for stationary / slow robots and
-/// industrial systems. **High-speed automotive deployment REQUIRES
-/// implementation diversity in addition to this fix.**
+/// The diverse shadow shares the SPECIFICATION and the config/contract with
+/// the primary. A SPEC-level fault (a wrong limit value, or a flaw in the
+/// shared ω_max derivation) appears identically in both and is NOT caught.
+/// Closing that requires diverse spec review and ultimately an N-version
+/// clean-room reimplementation. See `docs/safety/COMPARATOR_DIVERSITY.md`
+/// (DRAFT — pending safety-engineer review).
 ///
 /// Per CERT-006 — ISO 26262 ASIL-D decomposition argument.
-pub struct GovernorComparator {
+pub struct GovernorComparator<S: SafetyGovernor = DiverseKirraGovernor> {
     primary: KirraGovernor,
-    shadow: KirraGovernor,
+    shadow: S,
     state: Mutex<DivState>,
     sink: Arc<dyn DivergenceEventSink>,
 }
@@ -305,10 +322,14 @@ pub(crate) fn actions_diverge(
     (p_lin - s_lin).abs() > tol || (p_ang - s_ang).abs() > tol
 }
 
-impl GovernorComparator {
-    /// Create a comparator with two independent governor instances and the
-    /// default in-memory divergence sink.
-    pub fn new(primary: KirraGovernor, shadow: KirraGovernor) -> Self {
+impl<S: SafetyGovernor> GovernorComparator<S> {
+    /// Create a comparator with a primary `KirraGovernor` and a shadow
+    /// governor `S`, and the default in-memory divergence sink.
+    ///
+    /// Production wiring passes a `DiverseKirraGovernor` shadow (CERT-006
+    /// implementation diversity); passing a second `KirraGovernor` yields the
+    /// legacy identical-redundancy comparator.
+    pub fn new(primary: KirraGovernor, shadow: S) -> Self {
         Self::with_sink(primary, shadow, Arc::new(InMemoryDivergenceSink::new()))
     }
 
@@ -317,7 +338,7 @@ impl GovernorComparator {
     /// in `kirra-runtime-sdk`.
     pub fn with_sink(
         primary: KirraGovernor,
-        shadow: KirraGovernor,
+        shadow: S,
         sink: Arc<dyn DivergenceEventSink>,
     ) -> Self {
         Self {
@@ -465,12 +486,15 @@ impl GovernorComparator {
         action
     }
 
+}
+
+impl<S: RssAwareGovernor> GovernorComparator<S> {
     /// Update RSS state on both governors. Must be called via this method
     /// (not on either inner governor directly) to maintain identical state
     /// between primary and shadow.
     pub fn update_rss_state(&mut self, state: RssState) {
         self.primary.update_rss_state(state.clone());
-        self.shadow.update_rss_state(state);
+        self.shadow.set_rss_state(state);
     }
 }
 
@@ -874,6 +898,102 @@ mod tests {
             !actions_diverge(&p, &s, &proposed, COMPARATOR_TOLERANCE),
             "Same physical effect via different variants must not be flagged \
              (compare effect, not variant)"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // CERT-006 — DETECTION: a seeded systematic fault in ONE governor
+    // path must make the comparator diverge and escalate (fail-closed).
+    //
+    // This is the demonstrable half of the diversity argument: we inject a
+    // fault into the shadow and prove the comparator catches the resulting
+    // disagreement. (The CORRECTNESS / no-false-divergence half — that the
+    // real DiverseKirraGovernor AGREES with the primary on valid inputs —
+    // lives in `crate::diverse::tests`.)
+    // -----------------------------------------------------------------
+
+    /// A deliberately-broken shadow governor: it omits the linear
+    /// ODD-ceiling / rate clamp entirely (always `Allow` outside LockedOut).
+    /// This models a SYSTEMATIC implementation fault localized to the linear
+    /// envelope — exactly the class identical redundancy cannot see but
+    /// diverse redundancy can.
+    struct CeilingBlindShadow;
+
+    impl SafetyGovernor for CeilingBlindShadow {
+        fn evaluate(
+            &self,
+            _proposed: &ControlCommand,
+            _previous: Option<&ControlCommand>,
+            _delta_time_s: f64,
+            posture: SafetyPosture,
+        ) -> EnforcementAction {
+            match posture {
+                // LockedOut still hard-stops (so the bug is narrow: it agrees
+                // with the primary everywhere except the linear envelope).
+                SafetyPosture::LockedOut => EnforcementAction::Deny {
+                    reason: "CeilingBlindShadow: locked out".to_string(),
+                },
+                // BUG: never clamps the linear axis.
+                _ => EnforcementAction::Allow,
+            }
+        }
+    }
+
+    /// An over-ceiling command makes the correct primary clamp while the
+    /// fault-injected shadow passes it through — the comparator must diverge,
+    /// and at a safe speed escalate to a fail-closed Deny (LockedOut).
+    #[test]
+    fn test_injected_fault_is_detected_and_escalates() {
+        let comparator =
+            GovernorComparator::new(KirraGovernor::new(), CeilingBlindShadow);
+
+        // 40 m/s is above the 35 m/s ODD ceiling: primary → ClampLinear(35),
+        // shadow → Allow(40). Previous = 3 m/s is below SAFE_LOCKOUT_SPEED.
+        let commanded = cmd(40.0);
+        let slow_prev = cmd(3.0);
+
+        // First tick already diverges and reconciles (no hard stop at speed).
+        let first =
+            comparator.evaluate(&commanded, Some(&slow_prev), 0.05, SafetyPosture::Nominal);
+        assert!(
+            matches!(first, EnforcementAction::ClampMotion { .. }),
+            "First divergent tick must reconcile (ClampMotion), not hard stop. Got {first:?}"
+        );
+
+        // Sustained divergence at a safe speed escalates to LockedOut.
+        let mut last = first;
+        for _ in 0..10 {
+            last = comparator.evaluate(&commanded, Some(&slow_prev), 0.05, SafetyPosture::Nominal);
+        }
+        assert!(
+            matches!(last, EnforcementAction::Deny { .. }),
+            "Persistent injected-fault divergence at safe speed must escalate \
+             to a fail-closed Deny. Got {last:?}"
+        );
+        if let EnforcementAction::Deny { reason } = last {
+            assert!(
+                reason.contains("divergence"),
+                "Escalation Deny must reference divergence; got {reason:?}"
+            );
+        }
+    }
+
+    /// Control case: with the SAME fault-injected shadow but an in-envelope
+    /// command (both governors return the same physical effect), the
+    /// comparator must NOT diverge — proving the detection above is caused by
+    /// the fault, not by the pairing itself.
+    #[test]
+    fn test_injected_fault_silent_when_command_in_envelope() {
+        let comparator =
+            GovernorComparator::new(KirraGovernor::new(), CeilingBlindShadow);
+        let in_env = cmd(3.0);
+        let prev = cmd(3.0);
+        let out = comparator.evaluate(&in_env, Some(&prev), 0.05, SafetyPosture::Nominal);
+        // Primary Allows (3 m/s steady state), shadow Allows → agreement →
+        // primary output, never a divergence Deny.
+        assert!(
+            !matches!(out, EnforcementAction::Deny { .. }),
+            "In-envelope command must not trigger divergence. Got {out:?}"
         );
     }
 }

--- a/parko/crates/parko-kirra/src/diverse.rs
+++ b/parko/crates/parko-kirra/src/diverse.rs
@@ -1,0 +1,595 @@
+// crates/parko-kirra/src/diverse.rs
+//
+// CERT-006 — DIVERSE second safety governor (structural / algorithmic
+// diversity, "Approach A").
+//
+// WHY THIS EXISTS
+// ---------------
+// `GovernorComparator` historically ran two *identical* `KirraGovernor`
+// instances. Identical redundancy catches RANDOM / transient faults (bit
+// flips, memory corruption, state divergence) but is BLIND to a SYSTEMATIC
+// fault: a logic or numerical bug in the shared code path computes the same
+// wrong answer in both copies, they agree, and the comparator stays silent.
+//
+// `DiverseKirraGovernor` enforces the SAME safety properties as the primary
+// `KirraGovernor` — the same ODD speed cap, the same acceleration / braking
+// rate envelope, the same SOTIF angular-velocity bound, the same MRC
+// contraction, the same LockedOut hard-stop — but it computes them through a
+// deliberately DIFFERENT control-flow and DIFFERENT algebra. A systematic
+// *implementation* bug in one is therefore unlikely to manifest identically
+// in the other, so the comparator's existing divergence/escalation machinery
+// can finally catch it.
+//
+// HONEST LIMIT (state it, don't oversell — see docs/safety/COMPARATOR_DIVERSITY.md):
+//   This is *implementation* diversity. Both governors are derived from the
+//   SAME specification and consume the SAME config/contract (the kinematics
+//   contract limits and the `AngularVelocityBound` ω_max(v) derivation are
+//   shared). A fault in that shared SPEC — e.g. a wrong limit value, or a
+//   flaw in the ω_max derivation itself — would appear identically in both
+//   and is NOT caught by this. Closing that requires diverse review of the
+//   spec and, ultimately, an N-version clean-room reimplementation (the
+//   stronger-but-later "Approach B").
+//
+// DIVERSITY IS NOT A LICENCE TO DIVERGE ON VALID INPUTS
+// -----------------------------------------------------
+// The critical, testable correctness property is AGREEMENT: on every valid
+// input the diverse governor must produce the SAME physical verdict as the
+// primary (a false divergence would be a safety-relevant regression — it
+// would trip the comparator on a good command). The differences below are
+// purely structural; they are algebraically equivalent to the primary and
+// the broad agreement test (`tests` module + the proptest) guards that.
+//
+// CONCRETE STRUCTURAL DIFFERENCES vs `KirraGovernor` (the reviewable core):
+//
+//   1. REGIME SELECTION. Primary: check LockedOut, then a *separate* RSS
+//      early-return, then `match posture`. Diverse: a single `classify`
+//      step folds "Degraded posture OR RSS-unsafe" into one MinimumRisk
+//      predicate and treats LockedOut as the dominating hard-stop, then
+//      dispatches once.
+//
+//   2. LINEAR RATE ENVELOPE. Primary: computes a scalar implied
+//      acceleration `(v - c)/dt` and sign-splits into two magnitude
+//      comparisons against the accel / brake limits. Diverse: builds the
+//      admissible-velocity INTERVAL `[c - brake·dt, c + accel·dt]` and does
+//      interval containment. (The +1e-9 tolerance lives in acceleration
+//      space in the primary; it is mapped into velocity space — `1e-9·dt` —
+//      here. Algebraically identical, different code path.)
+//
+//   3. CEILING. Primary uses `effective_max_speed_mps()`; diverse re-derives
+//      `min(max_speed, odd_cap)` inline so it does not share that accessor.
+//
+//   4. CLAMP RECONSTRUCTION. Primary clamps via `value * x.signum()` and
+//      `f64::clamp`; diverse uses `f64::copysign` and an explicit
+//      `.max(..).min(..)` fold.
+//
+//   5. NO SHARED ENFORCEMENT CODE. Diverse does NOT call
+//      `validate_vehicle_command`, nor any `KirraGovernor` method. It only
+//      reads the shared *config* (contract limit fields + the
+//      `AngularVelocityBound`), which is the "same limits, computed
+//      differently" the safety case requires.
+
+use kirra_runtime_sdk::gateway::kinematics_contract::VehicleKinematicsContract;
+
+use parko_core::commands::ControlCommand;
+use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
+use parko_core::RssState;
+
+use crate::angular_bound::{AngularVelocityBound, PlatformParams};
+use crate::comparator::RssAwareGovernor;
+use crate::MRC_VELOCITY_CEILING_MPS;
+
+/// Acceleration-space tolerance used by the primary's rate checks
+/// (`max_accel_mps2 + 1e-9`). Mirrored here so the diverse interval test
+/// fires on exactly the same boundary as the primary's magnitude test.
+const ACCEL_EPSILON: f64 = 1e-9;
+
+/// Which enforcement envelope applies on this tick. Computed up front by
+/// `classify`, replacing the primary's interleaved LockedOut / RSS-gate /
+/// posture-match control flow with a single dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Regime {
+    /// LockedOut — hard stop, dominates everything (incl. RSS).
+    HardStop,
+    /// Degraded posture OR RSS-unsafe — minimum-risk (MRC) contraction.
+    MinimumRisk,
+    /// Nominal posture with a safe RSS state — full kinematic envelope.
+    Nominal,
+}
+
+/// A diverse second implementation of the Kirra safety governor.
+///
+/// Implements the same [`SafetyGovernor`] contract as [`crate::KirraGovernor`]
+/// and consumes the same configuration (kinematics contract + angular
+/// bounds), but reaches its verdict through structurally different
+/// computation. See the module documentation for the diversity argument and
+/// `docs/safety/COMPARATOR_DIVERSITY.md` (DRAFT) for the safety case.
+pub struct DiverseKirraGovernor {
+    /// Same nominal kinematics contract the primary holds. Only its limit
+    /// FIELDS are read (`max_speed_mps`, `max_accel_mps2`, `max_brake_mps2`,
+    /// `odd_speed_cap_mps`) — the diverse path does NOT call
+    /// `validate_vehicle_command`.
+    nominal_contract: VehicleKinematicsContract,
+    rss_state: RssState,
+    /// SOTIF-derived angular bound for the Nominal posture — same config
+    /// object the primary uses. The ω_max(v) derivation is shared SPEC
+    /// (see the honest-limit note); the ENFORCEMENT decision around it is
+    /// re-implemented here.
+    nominal_angular_bound: AngularVelocityBound,
+    /// SOTIF-derived angular bound for the MRC (Degraded / RSS-unsafe) posture.
+    mrc_angular_bound: AngularVelocityBound,
+}
+
+impl Default for DiverseKirraGovernor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DiverseKirraGovernor {
+    /// Construct a diverse governor with defaults identical to
+    /// [`crate::KirraGovernor::new`] so the two agree by construction on a
+    /// shared config. Mirroring the primary's defaults is what makes the
+    /// comparator's agreement property meaningful.
+    pub fn new() -> Self {
+        Self {
+            nominal_contract: VehicleKinematicsContract::nominal_reference_profile(),
+            rss_state: RssState {
+                safe: true,
+                longitudinal_margin: f64::MAX,
+                lateral_margin: f64::MAX,
+            },
+            nominal_angular_bound: AngularVelocityBound::nominal(
+                PlatformParams::conservative_default(),
+            ),
+            mrc_angular_bound: AngularVelocityBound::mrc(PlatformParams::conservative_default()),
+        }
+    }
+
+    /// Override the angular bounds with v-independent scalar values. Mirrors
+    /// [`crate::KirraGovernor::with_angular_bounds`] so a comparator can pair
+    /// a primary and a diverse governor on the same scalar config.
+    ///
+    /// Panics if either bound is non-finite or non-positive.
+    pub fn with_angular_bounds(mut self, nominal_rad_s: f64, mrc_rad_s: f64) -> Self {
+        assert!(
+            nominal_rad_s.is_finite() && nominal_rad_s > 0.0,
+            "nominal angular bound must be a finite positive value, got {}",
+            nominal_rad_s
+        );
+        assert!(
+            mrc_rad_s.is_finite() && mrc_rad_s > 0.0,
+            "MRC angular bound must be a finite positive value, got {}",
+            mrc_rad_s
+        );
+        self.nominal_angular_bound = AngularVelocityBound::Scalar(nominal_rad_s);
+        self.mrc_angular_bound = AngularVelocityBound::Scalar(mrc_rad_s);
+        self
+    }
+
+    /// Override the angular bounds with platform-parameter-driven SOTIF
+    /// derivations. Mirrors [`crate::KirraGovernor::with_platform_params`].
+    pub fn with_platform_params(mut self, params: PlatformParams) -> Self {
+        params.validate().expect(
+            "PlatformParams failed validation; check geometry > 0 and \
+             mrc_posture_factor in (0, 1]",
+        );
+        self.nominal_angular_bound = AngularVelocityBound::nominal(params.clone());
+        self.mrc_angular_bound = AngularVelocityBound::mrc(params);
+        self
+    }
+
+    /// Update the RSS safe-distance state. Same semantics as the primary's
+    /// `update_rss_state`; the comparator keeps both governors in lockstep
+    /// by calling this through its own `update_rss_state`.
+    pub fn update_rss_state(&mut self, state: RssState) {
+        self.rss_state = state;
+    }
+
+    /// DIFFERENCE #1 — single regime classifier. Folds the primary's
+    /// LockedOut-then-RSS-gate-then-posture-match control flow into one
+    /// dispatch. LockedOut dominates (matches the primary returning Deny
+    /// before its RSS gate); otherwise "Degraded OR RSS-unsafe" both route
+    /// to the minimum-risk envelope (the primary reaches the same MRC code
+    /// from two different branches).
+    fn classify(&self, posture: SafetyPosture) -> Regime {
+        if posture == SafetyPosture::LockedOut {
+            Regime::HardStop
+        } else if posture == SafetyPosture::Degraded || !self.rss_state.safe {
+            Regime::MinimumRisk
+        } else {
+            Regime::Nominal
+        }
+    }
+
+    /// DIFFERENCE #3 — re-derive the effective ceiling inline rather than
+    /// calling `contract.effective_max_speed_mps()`.
+    fn effective_ceiling(&self) -> f64 {
+        match self.nominal_contract.odd_speed_cap_mps {
+            Some(cap) if cap < self.nominal_contract.max_speed_mps => cap,
+            _ => self.nominal_contract.max_speed_mps,
+        }
+    }
+
+    /// Minimum-risk envelope (Degraded / RSS-unsafe). Mirrors the primary's
+    /// `apply_mrc_profile` effect — linear capped at the MRC ceiling, angular
+    /// capped at the MRC ω_max evaluated at the post-cap linear speed — but
+    /// expressed with an explicit over-ceiling guard and `copysign`.
+    fn enforce_minimum_risk(&self, proposed: &ControlCommand) -> EnforcementAction {
+        let v = proposed.linear_velocity;
+        let w = proposed.angular_velocity;
+
+        // DIFFERENCE #4 — over-ceiling guard instead of `v.min(MRC)`.
+        let capped_linear = if v > MRC_VELOCITY_CEILING_MPS {
+            MRC_VELOCITY_CEILING_MPS
+        } else {
+            v
+        };
+        let linear_clamped = capped_linear != v;
+
+        // Angular bound is evaluated at the (post-cap) linear speed — same
+        // as the primary's `v_for_bound = safe_linear.abs()`.
+        let omega_ceiling = self.mrc_angular_bound.omega_max(capped_linear.abs());
+        let angular = clamp_angular(w, omega_ceiling);
+
+        build_action(capped_linear, linear_clamped, angular)
+    }
+
+    /// Nominal envelope. Re-implements the primary's linear pipeline
+    /// (finiteness + dt guards, ODD ceiling, accel/brake rate limit) via the
+    /// interval formulation (DIFFERENCE #2) and re-implements the angular
+    /// clamp, then folds the two axes most-restrictively.
+    fn enforce_nominal(
+        &self,
+        proposed: &ControlCommand,
+        previous: Option<&ControlCommand>,
+        delta_time_s: f64,
+    ) -> EnforcementAction {
+        let v = proposed.linear_velocity;
+        let w = proposed.angular_velocity;
+        let current = previous.map(|p| p.linear_velocity).unwrap_or(0.0);
+
+        // Fail-closed guards. The primary emits a distinct DenyCode per
+        // offending field; the comparator compares physical EFFECT (a hard
+        // stop is a hard stop), so a single combined guard with a generic
+        // reason is the diverse — and equivalent — form.
+        if !v.is_finite() || !current.is_finite() || !delta_time_s.is_finite() {
+            return EnforcementAction::Deny {
+                reason: "DiverseKirraGovernor: non-finite command input — hard stop".to_string(),
+            };
+        }
+        if delta_time_s <= 0.0 {
+            return EnforcementAction::Deny {
+                reason: "DiverseKirraGovernor: non-physical time delta — hard stop".to_string(),
+            };
+        }
+
+        let (safe_linear, linear_clamped) =
+            self.diverse_linear_envelope(v, current, delta_time_s);
+
+        // DIFFERENCE — angular bound evaluated at the ORIGINAL commanded
+        // linear speed (matching the primary's `nominal_angular_clamp`,
+        // which uses `proposed.linear_velocity` regardless of any linear
+        // clamp that fired).
+        let omega_ceiling = self.nominal_angular_bound.omega_max(v.abs());
+        let angular = clamp_angular(w, omega_ceiling);
+
+        build_action(safe_linear, linear_clamped, angular)
+    }
+
+    /// DIFFERENCE #2 — the linear envelope as an admissible-velocity interval.
+    ///
+    /// Returns `(safe_linear, clamped)`. Priority, matching the primary:
+    ///   1. the absolute ODD ceiling dominates the rate limit (the primary
+    ///      early-returns on it before computing acceleration);
+    ///   2. otherwise clamp into `[current - brake·dt, current + accel·dt]`,
+    ///      itself clipped to `±ceiling`.
+    fn diverse_linear_envelope(&self, v: f64, current: f64, dt: f64) -> (f64, bool) {
+        let ceiling = self.effective_ceiling();
+
+        // Priority 1: absolute ceiling. Same comparison form as the primary
+        // so the boundary decision is identical.
+        if v.abs() > ceiling {
+            return (f64::copysign(ceiling, v), true);
+        }
+
+        // Priority 2: rate envelope as an interval.
+        let max_up = current + self.nominal_contract.max_accel_mps2 * dt;
+        let max_down = current - self.nominal_contract.max_brake_mps2 * dt;
+        // The primary's tolerance is `+1e-9` in acceleration space; in
+        // velocity space (over one tick) that is `1e-9 · dt`.
+        let band = ACCEL_EPSILON * dt;
+        let clip = |x: f64| x.max(-ceiling).min(ceiling);
+
+        if v - max_up > band {
+            (clip(max_up), true)
+        } else if max_down - v > band {
+            (clip(max_down), true)
+        } else {
+            (v, false)
+        }
+    }
+}
+
+/// DIFFERENCE #4 — angular clamp via `copysign`. `Some(clamped)` when the
+/// magnitude exceeds the ceiling, else `None` (axis passes through). The
+/// magnitude test is exceeded ⇒ `w != 0`, so `copysign` reconstructs the
+/// commanded direction exactly as the primary's `omega * w.signum()` does.
+fn clamp_angular(w: f64, omega_ceiling: f64) -> Option<f64> {
+    if w.abs() > omega_ceiling {
+        Some(f64::copysign(omega_ceiling, w))
+    } else {
+        None
+    }
+}
+
+/// Fold the two per-axis verdicts into a single [`EnforcementAction`],
+/// most-restrictive-wins. Produces the same variant the primary does for a
+/// given `(linear_clamped, angular_clamped)` pair so the physical effect —
+/// and the action shape — match.
+fn build_action(
+    safe_linear: f64,
+    linear_clamped: bool,
+    angular: Option<f64>,
+) -> EnforcementAction {
+    match (linear_clamped, angular) {
+        (false, None) => EnforcementAction::Allow,
+        (true, None) => EnforcementAction::ClampLinearVelocity(safe_linear),
+        (false, Some(safe_angular)) => EnforcementAction::ClampAngularVelocity(safe_angular),
+        (true, Some(safe_angular)) => EnforcementAction::ClampMotion {
+            linear: Some(safe_linear),
+            angular: Some(safe_angular),
+        },
+    }
+}
+
+impl SafetyGovernor for DiverseKirraGovernor {
+    fn evaluate(
+        &self,
+        proposed: &ControlCommand,
+        previous: Option<&ControlCommand>,
+        delta_time_s: f64,
+        posture: SafetyPosture,
+    ) -> EnforcementAction {
+        match self.classify(posture) {
+            Regime::HardStop => EnforcementAction::Deny {
+                reason: "DiverseKirraGovernor: locked-out hard stop".to_string(),
+            },
+            Regime::MinimumRisk => self.enforce_minimum_risk(proposed),
+            Regime::Nominal => self.enforce_nominal(proposed, previous, delta_time_s),
+        }
+    }
+}
+
+impl RssAwareGovernor for DiverseKirraGovernor {
+    fn set_rss_state(&mut self, state: RssState) {
+        self.update_rss_state(state);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+//
+// The CORRECTNESS property (agreement) is the critical one and lives here:
+//   - `agreement_*` hand-built cases span Allow / each Clamp / Deny across
+//     every posture and both RSS states and several configs;
+//   - `proptest_*` fuzzes the same property across 10k bounded inputs.
+//
+// Both assert the comparator's OWN predicate (`actions_diverge`) sees no
+// divergence between primary and diverse — i.e. the diverse governor never
+// introduces a false divergence on a valid input.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::comparator::actions_diverge;
+    use crate::KirraGovernor;
+    use proptest::prelude::*;
+
+    const TOL: f64 = 1e-9;
+
+    fn twist(linear: f64, angular: f64) -> ControlCommand {
+        ControlCommand {
+            linear_velocity: linear,
+            angular_velocity: angular,
+            timestamp_ms: 0,
+        }
+    }
+
+    fn safe_rss() -> RssState {
+        RssState {
+            safe: true,
+            longitudinal_margin: 12.0,
+            lateral_margin: 5.0,
+        }
+    }
+
+    fn unsafe_rss() -> RssState {
+        RssState {
+            safe: false,
+            longitudinal_margin: 1.0,
+            lateral_margin: 0.3,
+        }
+    }
+
+    /// Assert primary and diverse agree (no divergence) on one input under a
+    /// shared default config + given RSS state.
+    fn assert_agrees(
+        rss: RssState,
+        proposed: &ControlCommand,
+        previous: Option<&ControlCommand>,
+        dt: f64,
+        posture: SafetyPosture,
+    ) {
+        let mut primary = KirraGovernor::new();
+        let mut diverse = DiverseKirraGovernor::new();
+        primary.update_rss_state(rss.clone());
+        diverse.update_rss_state(rss);
+
+        let p = primary.evaluate(proposed, previous, dt, posture);
+        let d = diverse.evaluate(proposed, previous, dt, posture);
+        assert!(
+            !actions_diverge(&p, &d, proposed, TOL),
+            "false divergence: posture={posture:?} cmd=({},{}) prev={:?} dt={dt}\n  primary={p:?}\n  diverse={d:?}",
+            proposed.linear_velocity,
+            proposed.angular_velocity,
+            previous.map(|c| c.linear_velocity),
+        );
+    }
+
+    // -- Hand-built broad agreement set ----------------------------------
+
+    /// Nominal: in-envelope Allow, ceiling clamp, accel clamp, brake clamp,
+    /// angular clamp, both-axes clamp, in-place rotation.
+    #[test]
+    fn agreement_nominal_spans_allow_and_each_clamp() {
+        let prev = twist(3.0, 0.0);
+        // Allow — steady state in envelope.
+        assert_agrees(safe_rss(), &twist(3.0, 0.0), Some(&prev), 0.05, SafetyPosture::Nominal);
+        // Linear ceiling clamp (|v| > 35).
+        assert_agrees(safe_rss(), &twist(40.0, 0.0), Some(&prev), 0.05, SafetyPosture::Nominal);
+        assert_agrees(safe_rss(), &twist(-50.0, 0.0), Some(&prev), 0.05, SafetyPosture::Nominal);
+        // Acceleration rate clamp.
+        assert_agrees(safe_rss(), &twist(20.0, 0.0), Some(&twist(0.0, 0.0)), 0.05, SafetyPosture::Nominal);
+        // Brake rate clamp.
+        assert_agrees(safe_rss(), &twist(-20.0, 0.0), Some(&twist(10.0, 0.0)), 0.05, SafetyPosture::Nominal);
+        // Angular-only clamp (linear in envelope, big yaw).
+        assert_agrees(safe_rss(), &twist(2.0, 5.0), Some(&twist(2.0, 0.0)), 0.05, SafetyPosture::Nominal);
+        // Both axes clamp (over ceiling + big yaw).
+        assert_agrees(safe_rss(), &twist(60.0, 5.0), Some(&twist(30.0, 0.0)), 0.05, SafetyPosture::Nominal);
+        // In-place rotation (v=0, big yaw).
+        assert_agrees(safe_rss(), &twist(0.0, 3.0), Some(&twist(0.0, 0.0)), 0.05, SafetyPosture::Nominal);
+    }
+
+    /// Nominal fail-closed Deny paths (non-finite / non-physical dt).
+    #[test]
+    fn agreement_nominal_deny_paths() {
+        let prev = twist(3.0, 0.0);
+        assert_agrees(safe_rss(), &twist(f64::NAN, 0.0), Some(&prev), 0.05, SafetyPosture::Nominal);
+        assert_agrees(safe_rss(), &twist(3.0, 0.0), Some(&prev), 0.0, SafetyPosture::Nominal);
+        assert_agrees(safe_rss(), &twist(3.0, 0.0), Some(&prev), -0.1, SafetyPosture::Nominal);
+    }
+
+    /// Degraded posture — MRC contraction on both axes.
+    #[test]
+    fn agreement_degraded_spans_mrc_envelope() {
+        // Below MRC cap → pass.
+        assert_agrees(safe_rss(), &twist(3.0, 0.1), None, 0.05, SafetyPosture::Degraded);
+        // Above MRC linear cap → clamp to 5.0.
+        assert_agrees(safe_rss(), &twist(10.0, 0.0), None, 0.05, SafetyPosture::Degraded);
+        // Above MRC angular cap.
+        assert_agrees(safe_rss(), &twist(2.0, 4.0), None, 0.05, SafetyPosture::Degraded);
+        // Both axes over MRC caps.
+        assert_agrees(safe_rss(), &twist(12.0, 4.0), None, 0.05, SafetyPosture::Degraded);
+        // Reverse below cap (negative not clamped by min()).
+        assert_agrees(safe_rss(), &twist(-3.0, 0.0), None, 0.05, SafetyPosture::Degraded);
+    }
+
+    /// RSS-unsafe in Nominal posture must take the same MRC path.
+    #[test]
+    fn agreement_rss_unsafe_takes_mrc_path() {
+        assert_agrees(unsafe_rss(), &twist(10.0, 0.0), None, 0.05, SafetyPosture::Nominal);
+        assert_agrees(unsafe_rss(), &twist(2.0, 4.0), None, 0.05, SafetyPosture::Nominal);
+        assert_agrees(unsafe_rss(), &twist(3.0, 0.1), None, 0.05, SafetyPosture::Nominal);
+    }
+
+    /// LockedOut dominates everything (incl. RSS-unsafe).
+    #[test]
+    fn agreement_locked_out_hard_stop() {
+        for &v in &[0.0_f64, 3.0, 35.0, 100.0, -20.0] {
+            assert_agrees(safe_rss(), &twist(v, 2.0), None, 0.05, SafetyPosture::LockedOut);
+            assert_agrees(unsafe_rss(), &twist(v, 2.0), None, 0.05, SafetyPosture::LockedOut);
+        }
+    }
+
+    /// Diversity must hold across config too: same platform params on both
+    /// → still agree. Uses the urban reference platform (different ω_max).
+    #[test]
+    fn agreement_with_shared_platform_params() {
+        let p = PlatformParams::urban_service_robot_reference();
+        let mut primary = KirraGovernor::new().with_platform_params(p.clone());
+        let mut diverse = DiverseKirraGovernor::new().with_platform_params(p);
+        primary.update_rss_state(safe_rss());
+        diverse.update_rss_state(safe_rss());
+
+        for (v, w, posture) in [
+            (1.0, 0.5, SafetyPosture::Nominal),
+            (0.0, 1.0, SafetyPosture::Nominal),
+            (4.0, 0.9, SafetyPosture::Degraded),
+            (10.0, 2.0, SafetyPosture::Nominal),
+        ] {
+            let cmd = twist(v, w);
+            let prev = twist(v, 0.0);
+            let pa = primary.evaluate(&cmd, Some(&prev), 0.05, posture);
+            let da = diverse.evaluate(&cmd, Some(&prev), 0.05, posture);
+            assert!(
+                !actions_diverge(&pa, &da, &cmd, TOL),
+                "platform-params divergence at ({v},{w},{posture:?}): {pa:?} vs {da:?}"
+            );
+        }
+    }
+
+    /// Same with scalar angular-bound overrides.
+    #[test]
+    fn agreement_with_shared_scalar_bounds() {
+        let mut primary = KirraGovernor::new().with_angular_bounds(0.7, 0.3);
+        let mut diverse = DiverseKirraGovernor::new().with_angular_bounds(0.7, 0.3);
+        primary.update_rss_state(safe_rss());
+        diverse.update_rss_state(safe_rss());
+        for (v, w, posture) in [
+            (2.0, 0.8, SafetyPosture::Nominal),
+            (2.0, 0.4, SafetyPosture::Degraded),
+        ] {
+            let cmd = twist(v, w);
+            let prev = twist(v, 0.0);
+            let pa = primary.evaluate(&cmd, Some(&prev), 0.05, posture);
+            let da = diverse.evaluate(&cmd, Some(&prev), 0.05, posture);
+            assert!(!actions_diverge(&pa, &da, &cmd, TOL), "{pa:?} vs {da:?}");
+        }
+    }
+
+    // -- Property-based broad agreement ----------------------------------
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+        /// CORRECTNESS / no-false-divergence: across a broad bounded input
+        /// space and every posture + RSS state, primary and diverse must
+        /// never diverge. A regression here means the diverse governor would
+        /// trip the comparator on a VALID command.
+        #[test]
+        fn proptest_diverse_agrees_with_primary(
+            v in -60.0_f64..60.0,
+            w in -12.0_f64..12.0,
+            c in -60.0_f64..60.0,
+            dt in 0.005_f64..0.5,
+            posture_idx in 0usize..3,
+            rss_safe in proptest::bool::ANY,
+            has_prev in proptest::bool::ANY,
+        ) {
+            let posture = [
+                SafetyPosture::Nominal,
+                SafetyPosture::Degraded,
+                SafetyPosture::LockedOut,
+            ][posture_idx];
+            let rss = if rss_safe { safe_rss() } else { unsafe_rss() };
+
+            let mut primary = KirraGovernor::new();
+            let mut diverse = DiverseKirraGovernor::new();
+            primary.update_rss_state(rss.clone());
+            diverse.update_rss_state(rss);
+
+            let cmd = twist(v, w);
+            let prev = twist(c, 0.0);
+            let previous = if has_prev { Some(&prev) } else { None };
+
+            let p = primary.evaluate(&cmd, previous, dt, posture);
+            let d = diverse.evaluate(&cmd, previous, dt, posture);
+            prop_assert!(
+                !actions_diverge(&p, &d, &cmd, TOL),
+                "divergence: posture={:?} v={} w={} c={} dt={} prev={}\n  primary={:?}\n  diverse={:?}",
+                posture, v, w, c, dt, has_prev, p, d,
+            );
+        }
+    }
+}

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -44,8 +44,10 @@ use parko_core::RssState;
 
 pub mod angular_bound;
 pub mod comparator;
+pub mod diverse;
 pub use angular_bound::{AngularVelocityBound, PlatformParams, ROLLOVER_MIN_LINEAR_VELOCITY_MPS};
-pub use comparator::GovernorComparator;
+pub use comparator::{GovernorComparator, RssAwareGovernor};
+pub use diverse::DiverseKirraGovernor;
 
 /// MRC (Minimum Risk Condition) velocity ceiling.
 /// Applied when posture is Degraded or RSS state is unsafe.

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -28,7 +28,7 @@ use parko_core::backends::mock::MockBackend;
 use parko_core::commands::ControlCommand;
 use parko_core::safety::SafetyPosture;
 use parko_core::scheduler::InferenceLoop;
-use parko_kirra::{GovernorComparator, KirraGovernor};
+use parko_kirra::{DiverseKirraGovernor, GovernorComparator, KirraGovernor};
 use parko_ros2::{
     comparator_adapter::ComparatorAsGovernor,
     config::ParkoNodeConfig,
@@ -91,7 +91,10 @@ where
         }
     });
 
-    let comparator = GovernorComparator::new(KirraGovernor::new(), KirraGovernor::new());
+    // CERT-006: diverse redundancy — primary KirraGovernor paired with a
+    // structurally diverse DiverseKirraGovernor shadow, so the comparator can
+    // catch implementation-level systematic faults, not just random ones.
+    let comparator = GovernorComparator::new(KirraGovernor::new(), DiverseKirraGovernor::new());
     let infer = InferenceLoop::new(backend, model, actuator_tx)
         .with_governor(ComparatorAsGovernor(comparator))
         .with_tick_period(tick_period_s);

--- a/parko/crates/parko-ros2/src/comparator_adapter.rs
+++ b/parko/crates/parko-ros2/src/comparator_adapter.rs
@@ -14,13 +14,18 @@
 
 use parko_core::commands::ControlCommand;
 use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
-use parko_kirra::GovernorComparator;
+use parko_kirra::{DiverseKirraGovernor, GovernorComparator};
 
 /// Newtype wrapper that exposes a `GovernorComparator` as a
 /// `SafetyGovernor`. Delegation is one-line; no logic.
-pub struct ComparatorAsGovernor(pub GovernorComparator);
+///
+/// Generic over the comparator's shadow governor `S`; defaults to the
+/// CERT-006 `DiverseKirraGovernor` so the stock wiring is diverse-redundant.
+pub struct ComparatorAsGovernor<S: SafetyGovernor = DiverseKirraGovernor>(
+    pub GovernorComparator<S>,
+);
 
-impl SafetyGovernor for ComparatorAsGovernor {
+impl<S: SafetyGovernor> SafetyGovernor for ComparatorAsGovernor<S> {
     fn evaluate(
         &self,
         proposed: &ControlCommand,

--- a/project-board/columns.yaml
+++ b/project-board/columns.yaml
@@ -2,7 +2,7 @@ board:
   name: "Kirra Safety Runtime"
   description: >
     Solo lean-agile board for a hardware-neutral, safety-critical autonomy
-    runtime targeting ASIL-D. Tracks parko-core, parko-onnx, parko-aegis,
+    runtime targeting ASIL-D. Tracks parko-core, parko-onnx, parko-kirra,
     and kirra-runtime-sdk from deterministic tick grid through
     certification-ready packaging.
 
@@ -158,7 +158,7 @@ labels:
   - name: "backend-openvino"  ; color: "cfd3d7"
   - name: "backend-rocm"      ; color: "fef2c0"
   - name: "behavioral-safety" ; color: "d93f0b"
-  - name: "aegis-integration" ; color: "b60205"
+  - name: "kirra-integration" ; color: "b60205"
   - name: "posture-engine"    ; color: "e99695"
   - name: "packaging"         ; color: "c2e0c6"
   - name: "simulation"        ; color: "fbca04"

--- a/project-board/templates.md
+++ b/project-board/templates.md
@@ -169,7 +169,7 @@ Apply exactly one type label + one or more domain labels + one status label.
 **Type:** `feat` `fix` `test` `docs` `chore` `safety`
 
 **Domain:** `control-loop` `backend-qnn` `backend-tidl` `backend-openvino`
-`backend-rocm` `behavioral-safety` `aegis-integration` `posture-engine`
+`backend-rocm` `behavioral-safety` `kirra-integration` `posture-engine`
 `packaging` `simulation` `certification`
 
 **Status:** `backlog` → `ready` → `in-progress` → `done`

--- a/ros2_ws/src/kirra_safety/msg/SensorHealth.msg
+++ b/ros2_ws/src/kirra_safety/msg/SensorHealth.msg
@@ -1,4 +1,4 @@
-string node_id            # Aegis node identifier (e.g. lidar_front)
+string node_id            # Kirra node identifier (e.g. lidar_front)
 float64 confidence_score  # 0.0 (fault) to 1.0 (healthy)
 bool hardware_fault       # True if hardware error detected
 int64 timestamp_ms        # Unix timestamp (milliseconds)

--- a/scripts/build_native_test.sh
+++ b/scripts/build_native_test.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
-# Build and run the Aegis native C++ FFI integration test.
+# Build and run the Kirra native C++ FFI integration test.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-AEGIS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+KIRRA_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-echo "Building Aegis shared library..."
-cargo build --release --manifest-path "${AEGIS_DIR}/Cargo.toml"
+echo "Building Kirra shared library..."
+cargo build --release --manifest-path "${KIRRA_DIR}/Cargo.toml"
 
-LIB_PATH="${AEGIS_DIR}/target/release"
-INCLUDE_PATH="${AEGIS_DIR}/include"
-TEST_SRC="${AEGIS_DIR}/tests/native_test.cpp"
-TEST_BIN="${AEGIS_DIR}/target/native_test"
+LIB_PATH="${KIRRA_DIR}/target/release"
+INCLUDE_PATH="${KIRRA_DIR}/include"
+TEST_SRC="${KIRRA_DIR}/tests/native_test.cpp"
+TEST_BIN="${KIRRA_DIR}/target/native_test"
 
 echo "Compiling native test..."
 g++ -std=c++17 -o "${TEST_BIN}" "${TEST_SRC}" \
     -I "${INCLUDE_PATH}" \
     -L "${LIB_PATH}" \
-    -laegis_runtime_sdk \
+    -lkirra_runtime_sdk \
     -Wl,-rpath,"${LIB_PATH}"
 
 echo "Running native test..."

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/build_release.sh
 #
-# Builds Aegis release binaries for all supported targets.
+# Builds Kirra release binaries for all supported targets.
 # Run this on your development machine before a GitHub release.
 #
 # Prerequisites (install once):
@@ -14,17 +14,17 @@
 #
 # Output:
 #   dist/
-#     aegis-v1.0.0-x86_64-linux.tar.gz
-#     aegis-v1.0.0-aarch64-linux.tar.gz
-#     aegis-v1.0.0-armv7-linux.tar.gz
+#     kirra-v1.0.0-x86_64-linux.tar.gz
+#     kirra-v1.0.0-aarch64-linux.tar.gz
+#     kirra-v1.0.0-armv7-linux.tar.gz
 #     SHA256SUMS
 
 set -euo pipefail
 
 VERSION="${1:-$(git describe --tags --exact-match 2>/dev/null || echo "dev")}"
 DIST_DIR="dist"
-BINARY="aegis_verifier_service"
-CARLA_BINARY="aegis_carla_client"
+BINARY="kirra_verifier_service"
+CARLA_BINARY="kirra_carla_client"
 
 TARGETS=(
     "x86_64-unknown-linux-musl"
@@ -38,7 +38,7 @@ TARGET_NAMES=(
     "armv7-linux"
 )
 
-echo "Building Aegis ${VERSION}"
+echo "Building Kirra ${VERSION}"
 echo "Targets: ${TARGETS[*]}"
 echo ""
 
@@ -56,7 +56,7 @@ fi
 for i in "${!TARGETS[@]}"; do
     TARGET="${TARGETS[$i]}"
     TARGET_NAME="${TARGET_NAMES[$i]}"
-    ARCHIVE_NAME="aegis-${VERSION}-${TARGET_NAME}.tar.gz"
+    ARCHIVE_NAME="kirra-${VERSION}-${TARGET_NAME}.tar.gz"
 
     echo "Building ${TARGET_NAME}..."
 
@@ -74,7 +74,7 @@ for i in "${!TARGETS[@]}"; do
 
     # Create staging directory
     STAGING="$(mktemp -d)"
-    STAGING_BIN="${STAGING}/aegis"
+    STAGING_BIN="${STAGING}/kirra"
     mkdir -p "${STAGING_BIN}"
 
     # Copy binaries
@@ -89,7 +89,7 @@ for i in "${!TARGETS[@]}"; do
 
     # Copy systemd unit template
     mkdir -p "${STAGING}/systemd"
-    cp scripts/aegis-verifier.service "${STAGING}/systemd/"
+    cp scripts/kirra-verifier.service "${STAGING}/systemd/"
 
     # Write version file
     echo "${VERSION}" > "${STAGING}/VERSION"
@@ -113,6 +113,6 @@ echo "Files in ${DIST_DIR}/:"
 ls -lh "${DIST_DIR}/"
 echo ""
 echo "Next steps:"
-echo "  1. Test an archive: tar -xzf ${DIST_DIR}/aegis-${VERSION}-x86_64-linux.tar.gz"
+echo "  1. Test an archive: tar -xzf ${DIST_DIR}/kirra-${VERSION}-x86_64-linux.tar.gz"
 echo "  2. Create GitHub release and upload contents of ${DIST_DIR}/"
 echo "  3. Or push a git tag to trigger automated release via GitHub Actions"

--- a/scripts/setup_ros2_fleet.sh
+++ b/scripts/setup_ros2_fleet.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
-# Register the Hiwonder ROSOrin fleet node graph in Aegis.
+# Register the Hiwonder ROSOrin fleet node graph in Kirra.
 # Run once before starting the robot.
 #
 # Usage:
-#   AEGIS_ADMIN_TOKEN=your-token bash scripts/setup_ros2_fleet.sh
+#   KIRRA_ADMIN_TOKEN=your-token bash scripts/setup_ros2_fleet.sh
 #   or:
-#   AEGIS_URL=http://192.168.1.100:8090 AEGIS_ADMIN_TOKEN=your-token bash scripts/setup_ros2_fleet.sh
+#   KIRRA_URL=http://192.168.1.100:8090 KIRRA_ADMIN_TOKEN=your-token bash scripts/setup_ros2_fleet.sh
 
 set -e
 
-AEGIS_URL="${AEGIS_URL:-http://localhost:8090}"
-AEGIS_TOKEN="${AEGIS_ADMIN_TOKEN}"
+KIRRA_URL="${KIRRA_URL:-http://localhost:8090}"
+KIRRA_TOKEN="${KIRRA_ADMIN_TOKEN}"
 
-if [ -z "$AEGIS_TOKEN" ]; then
-    echo "ERROR: AEGIS_ADMIN_TOKEN environment variable is not set." >&2
+if [ -z "$KIRRA_TOKEN" ]; then
+    echo "ERROR: KIRRA_ADMIN_TOKEN environment variable is not set." >&2
     exit 1
 fi
 
-AUTH_HEADER="Authorization: Bearer $AEGIS_TOKEN"
+AUTH_HEADER="Authorization: Bearer $KIRRA_TOKEN"
 CONTENT_TYPE="Content-Type: application/json"
 
-echo "Registering Hiwonder ROSOrin fleet nodes in Aegis at $AEGIS_URL"
+echo "Registering Hiwonder ROSOrin fleet nodes in Kirra at $KIRRA_URL"
 
 register_node() {
     local node_id="$1"
     local description="$2"
     echo "  Registering node: $node_id"
-    curl -sf -X POST "$AEGIS_URL/attestation/register" \
+    curl -sf -X POST "$KIRRA_URL/attestation/register" \
         -H "$AUTH_HEADER" \
         -H "$CONTENT_TYPE" \
         -d "{
@@ -41,7 +41,7 @@ register_dependency() {
     local from="$1"
     local to="$2"
     echo "  Dependency: $from -> $to"
-    curl -sf -X POST "$AEGIS_URL/fleet/dependencies" \
+    curl -sf -X POST "$KIRRA_URL/fleet/dependencies" \
         -H "$AUTH_HEADER" \
         -H "$CONTENT_TYPE" \
         -d "{\"node_id\": \"$to\", \"depends_on\": [\"$from\"]}" > /dev/null
@@ -92,6 +92,6 @@ echo ""
 echo "Next steps:"
 echo "  1. Replace PLACEHOLDER_PEM_REPLACE_WITH_REAL_KEY with actual TPM AK public keys"
 echo "  2. Build and launch the interlock:"
-echo "     cd ros2_ws && colcon build --packages-select aegis_safety"
+echo "     cd ros2_ws && colcon build --packages-select kirra_safety"
 echo "     source install/setup.bash"
-echo "     ros2 launch aegis_safety aegis_with_robot.launch.py aegis_token:=\$AEGIS_ADMIN_TOKEN"
+echo "     ros2 launch kirra_safety kirra_with_robot.launch.py kirra_token:=\$KIRRA_ADMIN_TOKEN"

--- a/tests/hil_replay_proof.py
+++ b/tests/hil_replay_proof.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Hardware-in-loop replay proof: validates Aegis proxy behaviour against reference vectors.
+"""Hardware-in-loop replay proof: validates Kirra proxy behaviour against reference vectors.
 
-Three phases are tested in sequence against a running Aegis gateway on localhost:5502.
+Three phases are tested in sequence against a running Kirra gateway on localhost:5502.
 Each phase sends a single Modbus TCP FC06 frame and checks the exact byte response.
 
 PHASE_1: 1201.8 GPM — within envelope, passes through unchanged.
@@ -9,7 +9,7 @@ PHASE_2: 4593.6 GPM — exceeds 3000.0 GPM ceiling, clamped and forwarded as 300
 PHASE_3: register 11 (0x000B) — not the monitored asset_identifier 10, triggers exception 0x02.
 
 Usage:
-    AEGIS_SUPERVISOR_RESET_KEY=<key> cargo run -- config/asset_profile.json &
+    KIRRA_SUPERVISOR_RESET_KEY=<key> cargo run -- config/asset_profile.json &
     python3 tests/hil_replay_proof.py
 """
 

--- a/tests/native_test.cpp
+++ b/tests/native_test.cpp
@@ -1,42 +1,42 @@
 // tests/native_test.cpp
-// Native C++ integration test for the Aegis FFI layer.
+// Native C++ integration test for the Kirra FFI layer.
 
 #include <cassert>
 #include <cstdio>
 #include <cstring>
-#include "../include/aegis.h"
+#include "../include/kirra.h"
 
 int main() {
-    printf("=== Aegis Native FFI Integration Test ===\n\n");
+    printf("=== Kirra Native FFI Integration Test ===\n\n");
 
     // Velocity within envelope — expect passthrough
-    double safe_result = aegis_filter_move_velocity(1.0, 0.1);
+    double safe_result = kirra_filter_move_velocity(1.0, 0.1);
     printf("Safe velocity 1.0 -> %.4f\n", safe_result);
     assert(safe_result >= 0.9 && safe_result <= 1.1);
 
     // Velocity beyond envelope — expect clamping to max_linear_velocity (2.0)
-    double clamped_result = aegis_filter_move_velocity(10.0, 0.1);
+    double clamped_result = kirra_filter_move_velocity(10.0, 0.1);
     printf("Over-limit velocity 10.0 -> %.4f (clamped)\n", clamped_result);
     assert(clamped_result <= 2.0);
 
     // Angular velocity within limit (1.5) — expect passthrough
-    double safe_angular = aegis_filter_rotate_velocity(1.0, 0.1);
+    double safe_angular = kirra_filter_rotate_velocity(1.0, 0.1);
     printf("Safe angular 1.0 -> %.4f\n", safe_angular);
     assert(safe_angular >= 0.9 && safe_angular <= 1.1);
 
     // Angular velocity over limit — expect clamping
-    double clamped_angular = aegis_filter_rotate_velocity(5.0, 0.1);
+    double clamped_angular = kirra_filter_rotate_velocity(5.0, 0.1);
     printf("Over-limit angular 5.0 -> %.4f (clamped)\n", clamped_angular);
     assert(clamped_angular <= 1.5);
 
     // Trust score should be available
-    uint32_t score = aegis_get_trust_score();
+    uint32_t score = kirra_get_trust_score();
     printf("Trust score: %u\n", score);
     assert(score <= 100);
 
     // Reset without env key — must return 0 (fail-closed)
     const uint8_t token[] = "test_token";
-    int reset_result = aegis_reset_state(token, strlen((const char*)token));
+    int reset_result = kirra_reset_state(token, strlen((const char*)token));
     printf("Reset without env key: %d (expected 0)\n", reset_result);
     assert(reset_result == 0);
 

--- a/work/backlog.md
+++ b/work/backlog.md
@@ -1892,6 +1892,21 @@ a follow-up issue.
 
 ## CERT-006 `kirra-governor` `safety-case` `certification`
 
+> **Status: derived / implemented — pending safety-engineer review (NOT closed).**
+> - v1–v3: software lockstep comparator with posture-aware, speed-gated,
+>   two-axis divergence escalation + audit sink (`comparator.rs`).
+> - **Diversity (2026-06-01):** the identical-redundancy instantiation is
+>   replaced by structural/algorithmic diversity (Approach A) —
+>   `DiverseKirraGovernor` (`parko/crates/parko-kirra/src/diverse.rs`) is a
+>   second governor enforcing the same properties via different computation;
+>   the comparator is now generic over the shadow (default = diverse). This
+>   catches implementation-level systematic faults; it does NOT catch
+>   spec-level faults shared by both (honest limit). Full N-version
+>   (Approach B) is the stronger-but-later step.
+> - Diversity argument: `docs/safety/COMPARATOR_DIVERSITY.md`
+>   (KIRRA-CERT006-DIVERSITY-001, DRAFT). Needs the same human review as #136
+>   before it can be cited as validated coverage.
+
 **Primary + Shadow Governor Comparator**
 
 NVIDIA DRIVE AGX uses hardware lockstep — two cores run the same


### PR DESCRIPTION
Replace the comparator's identical KirraGovernor redundancy with structural/algorithmic diversity (Approach A). Identical redundancy catches only random faults; a systematic implementation bug computes the same wrong answer in both copies and the comparator stays silent.

- Add DiverseKirraGovernor (diverse.rs): enforces the same properties (ODD ceiling, accel/brake rate envelope, SOTIF angular bound, MRC contraction, LockedOut) as the primary, but via different control flow and algebra (single regime classifier; rate limit as admissible-velocity interval vs scalar-acceleration sign-split; inline ceiling; copysign). It shares only config/contract, never the primary's enforcement code.
- Make GovernorComparator generic over the shadow (default DiverseKirraGovernor) via a new RssAwareGovernor trait; escalation / accumulator / speed-gate / audit logic unchanged. A second KirraGovernor still constructs the legacy identical-redundancy pairing.
- Wire the production parko_ros2_node and ComparatorAsGovernor to the diverse shadow.
- Tests: broad agreement set + 10k-case proptest (CORRECTNESS — diverse never falsely diverges from primary on valid inputs); injected-fault detection test (DETECTION — a seeded systematic fault diverges and escalates fail-closed). Existing comparator tests unchanged.
- Docs: docs/safety/COMPARATOR_DIVERSITY.md (DRAFT) documenting the structural differences, the fault class covered, and the honest limit (shared spec -> spec-level faults NOT covered). Update IEC FM-002, the safety-case index, and the CERT-006 tracker status to implemented-pending-review (not closed).

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv