### PR TITLE
test: quality-hardening pass — property + fault-injection tests, muta…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ __pycache__/
 *.profdata
 coverage-report/
 lcov.info
+
+# cargo-mutants output (quality-hardening pass)
+mutants.out/

--- a/parko/crates/parko-kirra/src/angular_bound.rs
+++ b/parko/crates/parko-kirra/src/angular_bound.rs
@@ -427,4 +427,140 @@ mod tests {
         assert!((omega - 0.4167_f64).abs() < 1e-3,
             "MRC at v=0: expected ~0.4167 rad/s (sweep with halved v_edge_safe), got {omega}");
     }
+
+    // -----------------------------------------------------------------------
+    // PROPERTY TESTS — invariants of ω_max(v) = min(rollover(v), sweep, ftti),
+    // derived from docs/safety/ANGULAR_VELOCITY_SOTIF.md §2-§3 and the
+    // rollover physics a_lat = v·|ω| ≤ g·t/(2·h). These assert the SAFETY
+    // SHAPE of the bound, not specific numbers; a good property kills a class
+    // of mutants (sign flips, min→max, dropped terms).
+    // -----------------------------------------------------------------------
+
+    use proptest::prelude::*;
+
+    /// Strategy: physically-plausible platform params (all geometry > 0,
+    /// posture factor in (0, 1]). Mirrors `PlatformParams::validate`'s domain.
+    fn plausible_params() -> impl Strategy<Value = PlatformParams> {
+        (
+            0.05_f64..2.0,   // track_width_m
+            0.05_f64..2.0,   // cog_height_m
+            0.05_f64..2.0,   // robot_extent_m
+            0.01_f64..2.0,   // v_edge_safe_mps
+            0.005_f64..1.5,  // theta_max_rad
+            0.01_f64..1.0,   // ftti_s
+            0.05_f64..1.0,   // mrc_posture_factor (in (0,1])
+        )
+            .prop_map(|(t, h, r, ve, th, ftti, pf)| PlatformParams {
+                track_width_m: t,
+                cog_height_m: h,
+                robot_extent_m: r,
+                v_edge_safe_mps: ve,
+                theta_max_rad: th,
+                ftti_s: ftti,
+                mrc_posture_factor: pf,
+            })
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2000))]
+
+        /// INVARIANT: ω_max(v) is always finite and ≥ 0 (it is a bound on a
+        /// non-negative magnitude |ω|). Source: SOTIF §2 — every term is a
+        /// ratio of positive quantities; the v→0 singularity is masked.
+        #[test]
+        fn prop_omega_max_is_finite_and_nonnegative(
+            p in plausible_params(),
+            v in -50.0_f64..50.0,
+        ) {
+            let nom = AngularVelocityBound::nominal(p.clone());
+            let mrc = AngularVelocityBound::mrc(p);
+            for w in [nom.omega_max(v), mrc.omega_max(v)] {
+                prop_assert!(w.is_finite(), "ω_max must be finite, got {w}");
+                prop_assert!(w >= 0.0, "ω_max must be ≥ 0, got {w}");
+            }
+        }
+
+        /// INVARIANT: ω_max(v) ≤ the v-independent ceiling min(sweep, ftti) for
+        /// EVERY v — the rollover term can only tighten the bound, never loosen
+        /// it. Source: SOTIF §2 — ω_max = min(rollover, sweep, ftti) ≤ sweep,
+        /// ≤ ftti. This is the "≤ configured Nominal cap" invariant.
+        #[test]
+        fn prop_omega_max_never_exceeds_sweep_ftti_ceiling(
+            p in plausible_params(),
+            v in -50.0_f64..50.0,
+        ) {
+            let sweep = p.v_edge_safe_mps / p.robot_extent_m;
+            let ftti  = p.theta_max_rad / p.ftti_s;
+            let ceiling = sweep.min(ftti);
+            let w = AngularVelocityBound::nominal(p).omega_max(v);
+            prop_assert!(w <= ceiling + 1e-9,
+                "ω_max({v})={w} exceeded the sweep/ftti ceiling {ceiling}");
+        }
+
+        /// INVARIANT: ω_max is NON-INCREASING in |v| — faster forward speed can
+        /// only tighten the rollover constraint (ω_rollover(v) = g·t/(2·h·v) is
+        /// strictly decreasing in v), never loosen it. Source: rollover physics
+        /// a_lat = v·|ω|; SOTIF §2(a). Kills a min→max / sign-flip mutant.
+        #[test]
+        fn prop_omega_max_is_non_increasing_in_speed(
+            p in plausible_params(),
+            v1 in 0.0_f64..50.0,
+            dv in 0.0_f64..50.0,
+        ) {
+            let bound = AngularVelocityBound::nominal(p);
+            let v2 = v1 + dv; // v2 >= v1
+            prop_assert!(
+                bound.omega_max(v1) + 1e-9 >= bound.omega_max(v2),
+                "ω_max must not increase with speed: ω({v1})={} < ω({v2})={}",
+                bound.omega_max(v1), bound.omega_max(v2)
+            );
+        }
+
+        /// INVARIANT: below the rollover floor (|v| < ROLLOVER_MIN_LINEAR_
+        /// VELOCITY_MPS = 0.05) the rollover term is masked and ω_max equals
+        /// the constant min(sweep, ftti) — finite, no divide-by-zero. Source:
+        /// SOTIF §3.4 (v→0 singularity handling).
+        #[test]
+        fn prop_below_rollover_floor_returns_constant_ceiling(
+            p in plausible_params(),
+            v in 0.0_f64..ROLLOVER_MIN_LINEAR_VELOCITY_MPS,
+        ) {
+            let sweep = p.v_edge_safe_mps / p.robot_extent_m;
+            let ftti  = p.theta_max_rad / p.ftti_s;
+            let ceiling = sweep.min(ftti);
+            let w = AngularVelocityBound::nominal(p).omega_max(v);
+            prop_assert!(w.is_finite());
+            prop_assert!((w - ceiling).abs() < 1e-9,
+                "below the rollover floor ω_max must equal the constant ceiling {ceiling}, got {w}");
+        }
+
+        /// INVARIANT: the MRC bound is never looser than the Nominal bound at
+        /// the same v (posture_factor ≤ 1 derates sweep + ftti; rollover is
+        /// unchanged). Source: SOTIF §2 (MRC derate). The envelope contracts
+        /// in Degraded — it must never expand.
+        #[test]
+        fn prop_mrc_bound_is_at_or_below_nominal(
+            p in plausible_params(),
+            v in 0.0_f64..50.0,
+        ) {
+            let nom = AngularVelocityBound::nominal(p.clone());
+            let mrc = AngularVelocityBound::mrc(p);
+            prop_assert!(mrc.omega_max(v) <= nom.omega_max(v) + 1e-9,
+                "MRC bound must be ≤ Nominal at v={v}");
+        }
+
+        /// INVARIANT: the conservative default is always tighter than the old
+        /// H1 placeholder (1.5 rad/s nominal) it replaced — an uncharacterised
+        /// platform fails toward safe. Source: lib.rs #136 note + SOTIF §3.1.
+        #[test]
+        fn prop_conservative_default_is_below_old_placeholder(
+            v in -50.0_f64..50.0,
+        ) {
+            const OLD_PLACEHOLDER_RAD_S: f64 = 1.5;
+            let w = AngularVelocityBound::nominal(PlatformParams::conservative_default())
+                .omega_max(v);
+            prop_assert!(w <= OLD_PLACEHOLDER_RAD_S,
+                "conservative default ω_max({v})={w} must be ≤ old placeholder 1.5");
+        }
+    }
 }

--- a/parko/crates/parko-kirra/src/diverse.rs
+++ b/parko/crates/parko-kirra/src/diverse.rs
@@ -548,6 +548,74 @@ mod tests {
         }
     }
 
+    // -- Gap-closing tests driven by mutation survivors (PART 1 triage) ---
+
+    fn effective_lin(action: &EnforcementAction, proposed: f64) -> f64 {
+        match action {
+            EnforcementAction::Allow => proposed,
+            EnforcementAction::ClampLinearVelocity(v) => *v,
+            EnforcementAction::ClampAngularVelocity(_) => proposed,
+            EnforcementAction::ClampMotion { linear, .. } => linear.unwrap_or(proposed),
+            EnforcementAction::Deny { .. } => 0.0,
+        }
+    }
+
+    /// FAIL-CLOSED finiteness: a non-finite linear velocity, current velocity,
+    /// time delta, OR a non-physical dt must Deny in the Nominal path — even
+    /// when the OTHER inputs are finite. Guards the per-field OR in the
+    /// finiteness check (kills the `||`→`&&` survivors at enforce_nominal):
+    /// with `&&` a single NaN would slip through to an unbounded command.
+    #[test]
+    fn diverse_denies_each_nonfinite_input_in_nominal() {
+        let gov = DiverseKirraGovernor::new();
+        let fin = twist(1.0, 0.0);
+        // Non-finite linear (current + dt finite).
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let out = gov.evaluate(&twist(bad, 0.0), Some(&fin), 0.05, SafetyPosture::Nominal);
+            assert!(matches!(out, EnforcementAction::Deny { .. }),
+                "non-finite linear {bad} must fail-closed; got {out:?}");
+        }
+        // Non-finite current velocity (proposed + dt finite).
+        let out = gov.evaluate(&fin, Some(&twist(f64::NAN, 0.0)), 0.05, SafetyPosture::Nominal);
+        assert!(matches!(out, EnforcementAction::Deny { .. }), "non-finite current must Deny");
+        // Non-finite dt, and non-physical dt <= 0.
+        assert!(matches!(gov.evaluate(&fin, Some(&fin), f64::NAN, SafetyPosture::Nominal),
+            EnforcementAction::Deny { .. }), "non-finite dt must Deny");
+        assert!(matches!(gov.evaluate(&fin, Some(&fin), 0.0, SafetyPosture::Nominal),
+            EnforcementAction::Deny { .. }), "dt=0 must Deny");
+    }
+
+    /// The Nominal accel-rate clamp produces the SPEC value
+    /// `current + max_accel·dt` (2.5 m/s² · 0.05 s = 0.125 m/s from rest),
+    /// not the raw command and not a mis-scaled value. Pins the rate-envelope
+    /// arithmetic to the kinematics contract.
+    #[test]
+    fn diverse_accel_clamp_equals_spec_value() {
+        let gov = DiverseKirraGovernor::new();
+        let out = gov.evaluate(&twist(20.0, 0.0), Some(&twist(0.0, 0.0)), 0.05, SafetyPosture::Nominal);
+        let v = effective_lin(&out, 20.0);
+        assert!((v - 0.125).abs() < 1e-6,
+            "accel clamp must be current + max_accel*dt = 0.125 m/s, got {v}");
+    }
+
+    /// The `RssAwareGovernor::set_rss_state` TRAIT impl must actually update
+    /// the RSS gate — the comparator drives the shadow through this method, so
+    /// a no-op here would let the diverse shadow ignore RSS-unsafe and diverge
+    /// from the primary. (The agreement proptest uses the inherent
+    /// `update_rss_state`, leaving the trait path untested — this closes it.)
+    #[test]
+    fn diverse_set_rss_state_trait_takes_effect() {
+        use crate::comparator::RssAwareGovernor;
+        let mut gov = DiverseKirraGovernor::new();
+        RssAwareGovernor::set_rss_state(&mut gov, unsafe_rss());
+        // RSS unsafe ⇒ MRC path ⇒ 20 m/s clamped to the MRC ceiling (5.0),
+        // not the ~35 m/s Nominal envelope.
+        let out = gov.evaluate(&twist(20.0, 0.0), None, 0.05, SafetyPosture::Nominal);
+        let v = effective_lin(&out, 20.0);
+        assert!((v - MRC_VELOCITY_CEILING_MPS).abs() < 1e-9,
+            "set_rss_state(unsafe) must route to MRC ceiling {MRC_VELOCITY_CEILING_MPS}, got {v}");
+    }
+
     // -- Property-based broad agreement ----------------------------------
 
     proptest! {

--- a/parko/crates/parko-ros2/Cargo.toml
+++ b/parko/crates/parko-ros2/Cargo.toml
@@ -72,6 +72,8 @@ parko-onnx = { path = "../parko-onnx", optional = true }
 [dev-dependencies]
 # State-machine tests use parko-core's MockBackend (no ORT, no ROS).
 tokio = { version = "1", features = ["full", "test-util", "macros"] }
+# Property tests for the pure sensor mappings (quality-hardening pass).
+proptest = "1"
 
 # The node binary is feature-gated to `ros2`; the default cargo build
 # does not see this entry.

--- a/parko/crates/parko-ros2/src/sensor_mapping.rs
+++ b/parko/crates/parko-ros2/src/sensor_mapping.rs
@@ -937,3 +937,171 @@ mod odom_tests {
         assert_eq!(v, &[0.1_f32, 0.2, 0.3, 0.4]);
     }
 }
+
+// ===========================================================================
+// PROPERTY TESTS — sensor mapping invariants (quality-hardening pass)
+//
+// Each property states the invariant + its source. The mappings are the
+// untrusted-input boundary (raw sensor bytes → model tensor); a violated
+// range/shape invariant is a real safety risk (an out-of-contract tensor fed
+// to the policy). These are written to assert REAL behavior, not to chase a
+// mutation score.
+// ===========================================================================
+#[cfg(test)]
+mod property_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn encoding_strategy() -> impl Strategy<Value = CameraEncoding> {
+        prop_oneof![
+            Just(CameraEncoding::Rgb8),
+            Just(CameraEncoding::Bgr8),
+            Just(CameraEncoding::Mono8),
+        ]
+    }
+
+    /// Build a config + a correctly-sized random byte buffer for the chosen
+    /// encoding and source dims. Keeps dims small so the property runs fast.
+    fn camera_case() -> impl Strategy<Value = (CameraConfig, Vec<u8>, u32, u32)> {
+        (encoding_strategy(), 1u32..6, 1u32..6, 1u32..6, 1u32..6).prop_flat_map(
+            |(enc, sw, sh, tw, th)| {
+                let ch = enc.channels();
+                let nbytes = (sw as usize) * (sh as usize) * ch;
+                proptest::collection::vec(any::<u8>(), nbytes).prop_map(move |bytes| {
+                    let cfg = CameraConfig {
+                        encoding: enc,
+                        target_height: th,
+                        target_width: tw,
+                        resize: CameraResize::Nearest,
+                        normalization: CameraNormalization::Unit01,
+                        layout: CameraLayout::Nchw,
+                        tensor_name: "image".to_string(),
+                    };
+                    (cfg, bytes, sw, sh)
+                })
+            },
+        )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1500))]
+
+        /// INVARIANT: Unit01 normalization output is ALWAYS in [0, 1].
+        /// SOURCE: sensor_mapping.rs — `raw / 255.0`, raw ∈ [0, 255].
+        #[test]
+        fn prop_unit01_output_in_0_1((cfg, bytes, sw, sh) in camera_case()) {
+            let cfg = CameraConfig { normalization: CameraNormalization::Unit01, ..cfg };
+            let out = CameraMapping::new(cfg)
+                .to_tensor(&CameraSample { bytes: &bytes, src_width: sw, src_height: sh })
+                .expect("valid sized input must map");
+            for &x in out.named_tensors.get("image").unwrap().as_slice() {
+                prop_assert!((0.0..=1.0).contains(&x), "Unit01 out-of-range: {x}");
+            }
+        }
+
+        /// INVARIANT: SignedUnit normalization output is ALWAYS in [-1, 1].
+        /// SOURCE: `raw / 127.5 - 1.0`; raw ∈ [0,255] ⇒ [-1.0, 1.0].
+        #[test]
+        fn prop_signedunit_output_in_pm1((cfg, bytes, sw, sh) in camera_case()) {
+            let cfg = CameraConfig { normalization: CameraNormalization::SignedUnit, ..cfg };
+            let out = CameraMapping::new(cfg)
+                .to_tensor(&CameraSample { bytes: &bytes, src_width: sw, src_height: sh })
+                .expect("valid sized input must map");
+            for &x in out.named_tensors.get("image").unwrap().as_slice() {
+                prop_assert!((-1.0..=1.0).contains(&x), "SignedUnit out-of-range: {x}");
+            }
+        }
+
+        /// INVARIANT: MeanStd output is finite for finite mean and std > 0.
+        /// SOURCE: `(raw/255 - mean)/std`; finite ÷ nonzero-finite is finite.
+        /// (std = 0 is an integrator misconfiguration — see the finding note
+        /// in the hardening report; this property is the valid-domain claim.)
+        #[test]
+        fn prop_meanstd_output_finite_for_positive_std(
+            (cfg, bytes, sw, sh) in camera_case(),
+            mean in -5.0_f32..5.0,
+            std in 0.05_f32..5.0,
+        ) {
+            let ch = cfg.encoding.channels();
+            let cfg = CameraConfig {
+                normalization: CameraNormalization::MeanStd {
+                    mean: vec![mean; ch], std: vec![std; ch],
+                },
+                ..cfg
+            };
+            let out = CameraMapping::new(cfg)
+                .to_tensor(&CameraSample { bytes: &bytes, src_width: sw, src_height: sh })
+                .expect("valid sized input must map");
+            for &x in out.named_tensors.get("image").unwrap().as_slice() {
+                prop_assert!(x.is_finite(), "MeanStd produced non-finite {x} (mean={mean}, std={std})");
+            }
+        }
+
+        /// INVARIANT: resize yields EXACTLY target_height × target_width ×
+        /// channels elements. SOURCE: `out = vec![0.0; dst_h*dst_w*channels]`.
+        /// A wrong-length tensor breaks the model input contract.
+        #[test]
+        fn prop_output_length_matches_target_dims((cfg, bytes, sw, sh) in camera_case()) {
+            let expect = (cfg.target_height as usize)
+                * (cfg.target_width as usize)
+                * cfg.encoding.channels();
+            let out = CameraMapping::new(cfg)
+                .to_tensor(&CameraSample { bytes: &bytes, src_width: sw, src_height: sh })
+                .expect("valid sized input must map");
+            prop_assert_eq!(out.named_tensors.get("image").unwrap().as_slice().len(), expect);
+        }
+
+        /// INVARIANT: the rgb8↔bgr8 reorder is a TRUE PERMUTATION — the same
+        /// physical pixel (R,G,B) maps to the SAME RGB-ordered output whether
+        /// the source is declared Rgb8 (bytes R,G,B) or Bgr8 (bytes B,G,R).
+        /// No channel is lost or duplicated. SOURCE: `dst_c = channels-1-c`
+        /// for Bgr8 is the reverse permutation on 3 channels.
+        #[test]
+        fn prop_rgb8_bgr8_is_permutation(r in any::<u8>(), g in any::<u8>(), b in any::<u8>()) {
+            let base = CameraConfig {
+                encoding: CameraEncoding::Rgb8,
+                target_height: 1, target_width: 1,
+                resize: CameraResize::Nearest,
+                normalization: CameraNormalization::Unit01,
+                layout: CameraLayout::Nchw,
+                tensor_name: "image".to_string(),
+            };
+            let rgb = CameraMapping::new(base.clone())
+                .to_tensor(&CameraSample { bytes: &[r, g, b], src_width: 1, src_height: 1 })
+                .unwrap();
+            let bgr = CameraMapping::new(CameraConfig { encoding: CameraEncoding::Bgr8, ..base })
+                .to_tensor(&CameraSample { bytes: &[b, g, r], src_width: 1, src_height: 1 })
+                .unwrap();
+            // Same RGB-ordered output for both source orderings.
+            prop_assert_eq!(
+                rgb.named_tensors.get("image").unwrap().as_slice(),
+                bgr.named_tensors.get("image").unwrap().as_slice()
+            );
+            // And it is exactly [R,G,B]/255 — no channel dropped/duplicated.
+            let got = rgb.named_tensors.get("image").unwrap().as_slice();
+            prop_assert_eq!(got, &[r as f32/255.0, g as f32/255.0, b as f32/255.0]);
+        }
+
+        /// INVARIANT: quaternion→yaw is finite and within atan2's range
+        /// [-π, π]. SOURCE: `yaw = siny_cosp.atan2(cosy_cosp)` (Tait–Bryan ZYX).
+        /// NOTE: atan2's range is [-π, π]; the spec's "(-π, π]" is the typical
+        /// non-boundary case — the boundary value -π is a legal atan2 output,
+        /// so the asserted invariant is the mathematically-exact closed range.
+        #[test]
+        fn prop_quat_to_yaw_in_range(
+            qx in -1.0_f64..1.0, qy in -1.0_f64..1.0,
+            qz in -1.0_f64..1.0, qw in -1.0_f64..1.0,
+        ) {
+            // Skip the degenerate zero quaternion (not a rotation).
+            let norm = (qx*qx + qy*qy + qz*qz + qw*qw).sqrt();
+            prop_assume!(norm > 1e-6);
+            let (nx, ny, nz, nw) = (qx/norm, qy/norm, qz/norm, qw/norm);
+            let (_roll, _pitch, yaw) = quat_to_euler(nx, ny, nz, nw);
+            prop_assert!(yaw.is_finite(), "yaw must be finite, got {yaw}");
+            prop_assert!(
+                (-std::f64::consts::PI..=std::f64::consts::PI).contains(&yaw),
+                "yaw {yaw} outside [-π, π]"
+            );
+        }
+    }
+}

--- a/parko/crates/parko-ros2/src/tick_pipeline.rs
+++ b/parko/crates/parko-ros2/src/tick_pipeline.rs
@@ -376,6 +376,123 @@ mod tick_pipeline_tests {
         assert_eq!(twist, OutgoingTwist::stopped(100));
     }
 
+    // =======================================================================
+    // PART 3 — fault injection across the parko pipeline stage
+    //   sensor → inference → ControlCommand → governor → gated cmd_vel.
+    //
+    // Each test injects a fault and asserts an EXPLICIT fail-closed outcome
+    // (safe-stop / bounded / InferenceError), not merely "no panic". Mirrors
+    // the comparator's injected-fault style. The stale-sensor, locked-out,
+    // degraded-MRC, and posture-unfed→Degraded faults are covered by the
+    // tests above and in the M2b section below; these add the inference-output
+    // and backend-failure faults that were previously untested end-to-end.
+    // =======================================================================
+
+    /// A backend whose `run()` always fails — models an inference-engine error
+    /// (ORT/OpenVINO dlopen/exec failure) at the pipeline's inference stage.
+    #[derive(Debug)]
+    struct FailingBackend;
+    impl parko_core::backend::InferenceBackend for FailingBackend {
+        fn load_model(
+            &self,
+            path: &str,
+        ) -> Result<parko_core::backend::ModelHandle, parko_core::backend::BackendError> {
+            Ok(parko_core::backend::ModelHandle {
+                model_id: format!("failing::{path}"),
+                input_shapes: HashMap::new(),
+                output_shapes: HashMap::new(),
+                expected_precision: parko_core::backend::PrecisionMode::FP32,
+            })
+        }
+        fn run(
+            &self,
+            _model: &parko_core::backend::ModelHandle,
+            _inputs: &TensorBatch,
+        ) -> Result<TensorBatch<'static>, parko_core::backend::BackendError> {
+            Err(parko_core::backend::BackendError::ExecutionFailure(
+                "injected backend failure".to_string(),
+            ))
+        }
+        fn descriptor(&self) -> BackendDescriptor {
+            BackendDescriptor::Cpu
+        }
+    }
+
+    fn build_loop_with_backend<B: parko_core::backend::InferenceBackend + 'static>(
+        backend: Arc<B>,
+    ) -> Arc<Mutex<InferenceLoop<B>>> {
+        let model = backend.load_model("test.onnx").expect("mock model loads");
+        let (tx, _rx) = mpsc::channel::<ControlCommand>(8);
+        let comparator = GovernorComparator::new(KirraGovernor::new(), KirraGovernor::new());
+        let infer = InferenceLoop::new(backend, model, tx)
+            .with_governor(ComparatorAsGovernor(comparator))
+            .with_tick_period(0.05);
+        Arc::new(Mutex::new(infer))
+    }
+
+    /// FAULT: inference emits NaN linear velocity. ASSERT fail-closed — the
+    /// gated cmd_vel is a safe stop; the NaN command never reaches the
+    /// actuator. (Scheduler scrubs non-finite output; `enforce_outgoing_twist`
+    /// is the defence-in-depth backstop.)
+    #[tokio::test(start_paused = true)]
+    async fn fault_nan_inference_output_publishes_stopped_twist() {
+        let (infer, _rx) = build_loop(f32::NAN, 0.5);
+        let frame = make_frame(101, 0);
+        let outcome = run_pipeline_tick(&default_config(), infer, frame, SafetyPosture::Nominal).await;
+        assert_eq!(outcome.twist.linear_x_mps, 0.0,
+            "NaN inference must safe-stop (linear=0), got {}", outcome.twist.linear_x_mps);
+        assert_eq!(outcome.twist.angular_z_rads, 0.0,
+            "NaN inference must safe-stop (angular=0), got {}", outcome.twist.angular_z_rads);
+        assert!(outcome.twist.linear_x_mps.is_finite() && outcome.twist.angular_z_rads.is_finite(),
+            "the published command must be finite (no NaN leak to cmd_vel)");
+    }
+
+    /// FAULT: inference emits +∞ linear velocity. ASSERT fail-closed safe stop.
+    #[tokio::test(start_paused = true)]
+    async fn fault_inf_inference_output_publishes_stopped_twist() {
+        let (infer, _rx) = build_loop(f32::INFINITY, 0.0);
+        let frame = make_frame(102, 0);
+        let outcome = run_pipeline_tick(&default_config(), infer, frame, SafetyPosture::Nominal).await;
+        assert_eq!(outcome.twist.linear_x_mps, 0.0,
+            "inf inference must safe-stop, got {}", outcome.twist.linear_x_mps);
+        assert!(outcome.twist.linear_x_mps.is_finite(),
+            "no inf leak to cmd_vel");
+    }
+
+    /// FAULT: inference emits a wildly out-of-range (but finite) 1000 m/s.
+    /// ASSERT the governor BOUNDS it — a wrong-but-in-bounds command is never
+    /// admitted as-is. The published value is the safe-envelope clamp, far
+    /// below the requested 1000 m/s, finite and non-negative.
+    #[tokio::test(start_paused = true)]
+    async fn fault_out_of_range_inference_is_bounded_not_admitted() {
+        let (infer, _rx) = build_loop(1000.0, 0.0);
+        let frame = make_frame(103, 0);
+        let outcome = run_pipeline_tick(&default_config(), infer, frame, SafetyPosture::Nominal).await;
+        let v = outcome.twist.linear_x_mps;
+        assert!(v.is_finite(), "published velocity must be finite, got {v}");
+        assert!(v >= 0.0, "must not flip sign, got {v}");
+        assert!(v < 1000.0,
+            "1000 m/s must be CLAMPED by the governor envelope, never admitted as-is; got {v}");
+    }
+
+    /// FAULT: the inference backend itself errors. ASSERT fail-closed — the
+    /// pipeline emits a stopped twist AND surfaces a structured InferenceError,
+    /// never a fail-OPEN pass-through.
+    #[tokio::test(start_paused = true)]
+    async fn fault_backend_failure_fails_closed() {
+        let infer = build_loop_with_backend(Arc::new(FailingBackend));
+        let frame = make_frame(104, 0);
+        let outcome = run_pipeline_tick(&default_config(), infer, frame, SafetyPosture::Nominal).await;
+        assert_eq!(outcome.twist.linear_x_mps, 0.0,
+            "backend failure must safe-stop (linear=0)");
+        assert_eq!(outcome.twist.angular_z_rads, 0.0,
+            "backend failure must safe-stop (angular=0)");
+        match outcome.error {
+            Some(TickError::InferenceError(_)) => {}
+            other => panic!("backend failure must surface InferenceError (fail-closed), got {other:?}"),
+        }
+    }
+
     // -----------------------------------------------------------------------
     // M2b — `run_pipeline_tick_with_posture_state` exercises the shared
     // `PostureTracker` inside the tick. These tests mirror M1b's

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -374,4 +374,57 @@ mod tests {
             attestation_signing_payload("a", 1)
         );
     }
+
+    // -----------------------------------------------------------------------
+    // PROPERTY: the signing payload is INJECTIVE over (node_id, nonce).
+    //
+    // INVARIANT: distinct (node_id, nonce) pairs NEVER produce the same signing
+    // payload. SOURCE: the construction is a domain tag, then the node_id
+    // LENGTH (u64 LE), then the node_id bytes, then the nonce (u64 LE). The
+    // length prefix makes the (node_id || nonce) boundary unambiguous, so the
+    // map is injective. Why it matters: if two different (node_id, nonce) pairs
+    // shared a payload, a signature issued for one could be replayed for the
+    // other — a cross-node / cross-nonce attestation forgery. This property is
+    // the cryptographic justification for the length-prefix.
+    // -----------------------------------------------------------------------
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(4000))]
+
+        /// Different inputs ⇒ different payloads (injectivity / no collisions).
+        #[test]
+        fn prop_signing_payload_is_injective(
+            id_a in "[ -~]{0,40}",
+            n_a in any::<u64>(),
+            id_b in "[ -~]{0,40}",
+            n_b in any::<u64>(),
+        ) {
+            let same_input = id_a == id_b && n_a == n_b;
+            let same_payload = attestation_signing_payload(&id_a, n_a)
+                == attestation_signing_payload(&id_b, n_b);
+            // Equal payloads are permitted ONLY when the inputs are equal.
+            prop_assert_eq!(
+                same_payload, same_input,
+                "payload collision across distinct inputs: ({:?},{}) vs ({:?},{})",
+                id_a, n_a, id_b, n_b
+            );
+        }
+
+        /// A specific stress on the boundary-shift class: moving a byte across
+        /// the node_id/nonce seam must change the payload (length-prefix guard).
+        #[test]
+        fn prop_no_boundary_shift_collision(
+            head in "[ -~]{1,20}",
+            tail in "[ -~]{1,20}",
+            nonce in any::<u64>(),
+        ) {
+            let combined = format!("{head}{tail}");
+            // Same concatenated id-bytes split at two different points must
+            // still yield distinct payloads unless they are literally equal.
+            let p1 = attestation_signing_payload(&combined, nonce);
+            let p2 = attestation_signing_payload(&head, nonce);
+            prop_assert_ne!(p1, p2);
+        }
+    }
 }


### PR DESCRIPTION
…tion triage

Confidence pass on safety-critical code (no safety logic changed; additive tests only). Mutation testing (cargo-mutants v27) scoped to the safety modules drove the gaps.

PART 2 — property tests (invariant + source documented on each):
- angular_bound (#136 ω_max): finite & ≥0; ≤ sweep/ftti ceiling; non-increasing in speed; below-floor masking returns the constant ceiling; MRC ≤ Nominal; conservative_default ≤ old 1.5 placeholder. (6)
- sensor_mapping: Unit01∈[0,1]; SignedUnit∈[-1,1]; MeanStd finite for std>0; output length == target dims; rgb8↔bgr8 is a true permutation; quat→yaw finite & within atan2 range. (6, + proptest dev-dep on parko-ros2)
- attestation payload: injective over (node_id, nonce) — the length-prefix anti-replay guarantee, as a property. (2)

PART 3 — fault injection across sensor→inference→governor→cmd_vel:
- NaN / inf inference output → safe-stop (no leak to cmd_vel)
- out-of-range (1000 m/s) inference → governor BOUNDS it (never admitted as-is)
- backend failure → fail-closed (stopped + InferenceError) Each asserts an explicit fail-CLOSED outcome, not just "no panic".

PART 1 — mutation testing + triage (parko via --in-place: cargo-mutants' subtree copy breaks parko-kirra's `path=../../..` dep to the root crate):
- attestation+policy: 17/18 viable caught (94%); sole survivor `as_str→""` is a diagnostic string, not safety-relevant.
- angular_bound: 33/33 viable caught (100%).
- diverse governor: 49→52 caught after 3 gap-closing tests (finiteness OR-guard ×2; set_rss_state trait no-op ×1 — the agreement proptest used the inherent update_rss_state, leaving the trait path untested). Remaining 11 survivors triaged: 5 dead (ODD-cap arm unreachable — see finding) + 6 equivalent (boundary >/>= and the band-tolerance magnitude, all within the comparator's 1e-9 tolerance).

FINDINGS (flagged, NOT fixed here — separate decision/branch):
- CameraNormalization::MeanStd divides by std with no std!=0 guard; std=0 yields non-finite tensor values (caught downstream by the governor's non-finite guard, but the mapping violates its finite-output invariant).
- DiverseKirraGovernor hardcodes nominal_reference_profile (odd_speed_cap_mps = None), so effective_ceiling's ODD-cap arm is unreachable; a primary configured with an ODD cap could not be matched by the diverse shadow (would diverge → comparator fail-closes, but config is incomplete).

Root + parko safety lane green incl. all new tests; traceability gate green.