### PR TITLE
ci(parko-openvino): install OpenVINO via official ≥2025.1 archive (#143)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         run: cargo test -p parko-onnx -- --nocapture
 
   parko-openvino:
-    name: Parko OpenVINO Backend Tests (archive openvino-2025.1+)
+    name: Parko OpenVINO Backend Tests (pip openvino-2025.1)
     runs-on: ubuntu-latest
     # NON-GATING for now (#143). Kept continue-on-error: true while this archive
     # install is validated by the REAL CI run — it can't be proven green locally
@@ -164,73 +164,46 @@ jobs:
             -C "$HOME/.local/onnxruntime" --strip-components=1
           test -f "$HOME/.local/onnxruntime/lib/libonnxruntime.so" \
             || (echo "libonnxruntime.so missing after install"; exit 1)
-      - name: Install OpenVINO runtime (official archive, >= 2025.1)
-        # openvino-rs REQUIRES OpenVINO >= 2025.1: the `ov_element_type_e` enum
-        # changed incompatibly in 2025.1, so the crate REJECTS older runtimes as
-        # "version too old" (openvino-rs#167) to avoid silently creating
-        # wrong-type tensors. That gate is PROTECTIVE — we satisfy it rather than
-        # bypass it (no OPENVINO_SKIP_LINKING / force-accept; those make the
-        # crate build but inference stays broken). The apt `openvino-2024.5.0`
-        # package is therefore unusable; install a pinned 2025.1+ release ARCHIVE
-        # whose version satisfies the gate and whose layout is fixed
-        # (/opt/intel/openvino_2025/runtime/lib/intel64).
+      - name: Install OpenVINO runtime (pip wheel, >= 2025.1)
+        # openvino-rs REQUIRES OpenVINO >= 2025.1: `ov_element_type_e` changed
+        # incompatibly in 2025.1, so the crate REJECTS older runtimes as "version
+        # too old" (openvino-rs#167) to avoid silently creating wrong-type
+        # tensors. That gate is PROTECTIVE — we SATISFY it (>= 2025.1), never
+        # bypass it (no OPENVINO_SKIP_LINKING / force-accept).
         #
-        # UNVERIFIED HERE: authored 403-blocked from storage.openvinotoolkit.org,
-        # so the URL/install could not be tested locally — the real CI run is the
-        # validation (continue-on-error is kept on for that reason).
+        # Why pip, not the apt package or the .tgz archive: the apt 2024.5 build
+        # fails the gate, and storage.openvinotoolkit.org (the archive host) is an
+        # S3 *website* endpoint that serves index.html for any path and only
+        # cleanly exposes non-reproducible NIGHTLY builds — no pinnable GA URL
+        # (proven across prior runs on this PR). The PyPI `openvino` wheel ships
+        # the GA runtime (libopenvino_c.so + CPU plugin + TBB) — exactly what the
+        # crate dlopens at OvBackend::new — and is exactly version-pinnable.
+        #
+        # A venv avoids PEP-668 "externally-managed-environment" on the runner's
+        # system python. (continue-on-error stays on; validated by this CI run.)
         run: |
           set -euo pipefail
-          OPENVINO_DIST="ubuntu24"     # runs-on: ubuntu-latest == ubuntu-24.04
-          HOST="https://storage.openvinotoolkit.org"
-          # storage.openvinotoolkit.org is the S3 *website* endpoint: it serves a
-          # 1061-byte index.html (HTTP 200) for any directory OR missing key and
-          # IGNORES the S3 ?list-type=2 API (both proven by prior runs). Its
-          # browser enumerates via the precomputed `filetree.json` the page
-          # references — so resolve the real tarball KEY from that, picking the
-          # newest ubuntu24 2025.x archive (>= 2025.1 satisfies openvino-rs#167).
-          echo "Fetching host file index ${HOST}/filetree.json ..."
-          curl -fsSL "${HOST}/filetree.json" -o /tmp/filetree.json || true
-          echo "filetree.json size: $(wc -c < /tmp/filetree.json 2>/dev/null || echo 0) bytes"
-          KEY="$(grep -oE "[A-Za-z0-9_./-]*openvino_toolkit_${OPENVINO_DIST}_2025\.[0-9.]+_x86_64\.tgz" /tmp/filetree.json \
-            | sort -V | tail -n1 || true)"
-          if [ -z "${KEY}" ]; then
-            echo "::error::No ${OPENVINO_DIST} 2025.x OpenVINO archive found in filetree.json"
-            echo "  ---- any openvino_toolkit archives seen (sample) ----"
-            grep -oE "[A-Za-z0-9_./-]*openvino_toolkit_[A-Za-z0-9_.]+\.tgz" /tmp/filetree.json | sort -u | tail -30 || true
+          python3 -m venv "$HOME/ovenv"
+          "$HOME/ovenv/bin/pip" install --quiet --upgrade pip
+          "$HOME/ovenv/bin/pip" install "openvino==2025.1.0"
+          OV_PKG="$("$HOME/ovenv/bin/python" -c 'import openvino, os; print(os.path.dirname(openvino.__file__))')"
+          echo "openvino package dir: ${OV_PKG}"
+          # The wheel bundles native libs under openvino/libs (or a sibling
+          # openvino.libs). Locate libopenvino_c.so* wherever it landed.
+          LIB="$(find "${OV_PKG}" "${OV_PKG}.libs" -name 'libopenvino_c.so*' 2>/dev/null | head -n1 || true)"
+          if [ -z "${LIB}" ]; then
+            echo "::error::libopenvino_c.so not found in the openvino wheel (auditwheel may have hash-mangled the name)."
+            echo "  ---- .so files in the wheel ----"
+            find "${OV_PKG}" "${OV_PKG}.libs" -name '*.so*' 2>/dev/null | sort | head -60 || true
             exit 1
           fi
-          # KEY is a bucket-relative path; build the absolute URL.
-          case "${KEY}" in /*) URL="${HOST}${KEY}";; *) URL="${HOST}/${KEY}";; esac
-          echo "Resolved: ${KEY}"
-          curl -fL -o /tmp/openvino.tgz "${URL}"
-          MAGIC="$(head -c2 /tmp/openvino.tgz | od -An -tx1 | tr -d ' \n')"
-          if [ "${MAGIC}" != "1f8b" ]; then
-            echo "::error::Resolved object is not gzip (magic=${MAGIC}, URL=${URL}). Body head:"
-            head -c 600 /tmp/openvino.tgz; echo
-            exit 1
-          fi
-          echo "Got a real gzip archive — proceeding."
-          sudo mkdir -p /opt/intel/openvino_2025
-          # --strip-components=1 drops the top-level versioned dir so the runtime
-          # lands directly under /opt/intel/openvino_2025.
-          sudo tar -xzf /tmp/openvino.tgz -C /opt/intel/openvino_2025 --strip-components=1
-          # Runtime dependencies (libtbb etc.).
-          if [ -f /opt/intel/openvino_2025/install_dependencies/install_openvino_dependencies.sh ]; then
-            sudo -E bash /opt/intel/openvino_2025/install_dependencies/install_openvino_dependencies.sh -y
-          fi
-          test -f /opt/intel/openvino_2025/runtime/lib/intel64/libopenvino_c.so \
-            || { echo "::error::libopenvino_c.so missing after archive extract"; ls -R /opt/intel/openvino_2025 | head -40; exit 1; }
-          # Per-step shells don't share env, so `source setupvars.sh` here would
-          # NOT reach the cargo step. Source it and persist the resulting
-          # OpenVINO env to $GITHUB_ENV; openvino-finder discovers the archive
-          # libs via INTEL_OPENVINO_DIR + LD_LIBRARY_PATH (NOT the old apt/FHS
-          # path — that OPENVINO_LIBDIR export is removed).
-          set +u
-          source /opt/intel/openvino_2025/setupvars.sh
-          set -u
-          echo "INTEL_OPENVINO_DIR=${INTEL_OPENVINO_DIR}" >> "${GITHUB_ENV}"
-          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
-          echo "OpenVINO runtime ready: INTEL_OPENVINO_DIR=${INTEL_OPENVINO_DIR}"
+          OV_LIBDIR="$(dirname "${LIB}")"
+          echo "OpenVINO runtime libs in: ${OV_LIBDIR}"
+          ls -1 "${OV_LIBDIR}"/libopenvino_c.so*
+          # Per-step shells don't share env: expose the lib dir to the cargo step
+          # via $GITHUB_ENV. openvino-finder probes LD_LIBRARY_PATH first and
+          # handles versioned SONAMEs (e.g. libopenvino_c.so.2510).
+          echo "LD_LIBRARY_PATH=${OV_LIBDIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> "${GITHUB_ENV}"
       - name: parko-openvino tests
         # OpenVINO-dependent. Same flakiness disposition as
         # parko-onnx: if this job becomes unreliable in CI (Intel apt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,36 +180,32 @@ jobs:
         # validation (continue-on-error is kept on for that reason).
         run: |
           set -euo pipefail
-          OPENVINO_VER="2025.1"        # pinned minor (>= 2025.1 satisfies openvino-rs#167)
           OPENVINO_DIST="ubuntu24"     # runs-on: ubuntu-latest == ubuntu-24.04
           HOST="https://storage.openvinotoolkit.org"
-          PREFIX="repositories/openvino/packages/${OPENVINO_VER}/linux/"
-          # storage.openvinotoolkit.org is an S3 bucket fronted by a JS directory
-          # browser (list.js): a plain GET of a directory OR a non-existent key
-          # returns a 1061-byte index.html with HTTP 200 — not a listing/file —
-          # so there is no server-side index to grep and `curl -f` can't detect a
-          # wrong key. Enumerate REAL object keys via the S3 ListObjects v2 API
-          # (what list.js itself uses), then download by exact key.
-          echo "S3 ListObjects: ${HOST}/?prefix=${PREFIX}"
-          XML="$(curl -sSL "${HOST}/?list-type=2&prefix=${PREFIX}&max-keys=1000" || true)"
-          KEY="$(printf '%s' "${XML}" \
-            | grep -oE "${PREFIX}(l_)?openvino_toolkit_${OPENVINO_DIST}_[0-9][0-9.]*_x86_64\.tgz" \
+          # storage.openvinotoolkit.org is the S3 *website* endpoint: it serves a
+          # 1061-byte index.html (HTTP 200) for any directory OR missing key and
+          # IGNORES the S3 ?list-type=2 API (both proven by prior runs). Its
+          # browser enumerates via the precomputed `filetree.json` the page
+          # references — so resolve the real tarball KEY from that, picking the
+          # newest ubuntu24 2025.x archive (>= 2025.1 satisfies openvino-rs#167).
+          echo "Fetching host file index ${HOST}/filetree.json ..."
+          curl -fsSL "${HOST}/filetree.json" -o /tmp/filetree.json || true
+          echo "filetree.json size: $(wc -c < /tmp/filetree.json 2>/dev/null || echo 0) bytes"
+          KEY="$(grep -oE "[A-Za-z0-9_./-]*openvino_toolkit_${OPENVINO_DIST}_2025\.[0-9.]+_x86_64\.tgz" /tmp/filetree.json \
             | sort -V | tail -n1 || true)"
           if [ -z "${KEY}" ]; then
-            echo "::error::No ${OPENVINO_DIST} OpenVINO tarball found under ${PREFIX}"
-            echo "  ---- object keys for this prefix ----"
-            printf '%s' "${XML}" | grep -oE "<Key>[^<]+</Key>" | head -40 || true
-            echo "  ---- available package version dirs (fix OPENVINO_VER if needed) ----"
-            curl -sSL "${HOST}/?list-type=2&prefix=repositories/openvino/packages/&delimiter=/" \
-              | grep -oE "<Prefix>[^<]+</Prefix>" | head -60 || true
+            echo "::error::No ${OPENVINO_DIST} 2025.x OpenVINO archive found in filetree.json"
+            echo "  ---- any openvino_toolkit archives seen (sample) ----"
+            grep -oE "[A-Za-z0-9_./-]*openvino_toolkit_[A-Za-z0-9_.]+\.tgz" /tmp/filetree.json | sort -u | tail -30 || true
             exit 1
           fi
-          URL="${HOST}/${KEY}"
-          echo "Resolved key: ${KEY}"
+          # KEY is a bucket-relative path; build the absolute URL.
+          case "${KEY}" in /*) URL="${HOST}${KEY}";; *) URL="${HOST}/${KEY}";; esac
+          echo "Resolved: ${KEY}"
           curl -fL -o /tmp/openvino.tgz "${URL}"
           MAGIC="$(head -c2 /tmp/openvino.tgz | od -An -tx1 | tr -d ' \n')"
           if [ "${MAGIC}" != "1f8b" ]; then
-            echo "::error::Resolved object is not gzip (magic=${MAGIC}). Body head:"
+            echo "::error::Resolved object is not gzip (magic=${MAGIC}, URL=${URL}). Body head:"
             head -c 600 /tmp/openvino.tgz; echo
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,36 +182,35 @@ jobs:
           set -euo pipefail
           OPENVINO_VER="2025.1"        # pinned minor (>= 2025.1 satisfies openvino-rs#167)
           OPENVINO_DIST="ubuntu24"     # runs-on: ubuntu-latest == ubuntu-24.04
-          # Fallback exact build id (used only if the directory listing can't be
-          # resolved). Replace if the download 404s — verify on the storage site.
-          OPENVINO_FULLVER_FALLBACK="2025.1.0.18503"
+          OPENVINO_FULLVER="2025.1.0.18503"
           BASE="https://storage.openvinotoolkit.org/repositories/openvino/packages/${OPENVINO_VER}/linux"
-          # Resolve the exact tarball (its build id is not derivable). GUARD the
-          # pipeline with `|| true`: a curl/grep miss must NOT die under
-          # `set -e`/`pipefail` before the diagnostic runs (the prior version
-          # exited 1 with zero output, masking whether the URL or the pattern
-          # was wrong).
-          echo "Listing ${BASE}/ ..."
-          LISTING="$(curl -fsSL "${BASE}/" || true)"
-          TARBALL="$(printf '%s\n' "${LISTING}" \
-            | grep -oE "(l_)?openvino_toolkit_${OPENVINO_DIST}_${OPENVINO_VER}\.[0-9.]+_x86_64\.tgz" \
-            | sort -V | tail -n1 || true)"
-          if [ -n "${TARBALL}" ]; then
-            URL="${BASE}/${TARBALL}"
-            echo "Resolved from listing: ${TARBALL}"
-          else
-            echo "Listing yielded no tarball (got ${#LISTING} bytes). openvino_toolkit*.tgz seen:"
-            printf '%s\n' "${LISTING}" | grep -oE "[a-z_]*openvino_toolkit[^\"<> ]+\.tgz" | sort -u | head -20 || true
-            echo "Falling back to pinned build ${OPENVINO_FULLVER_FALLBACK}."
-            URL="${BASE}/openvino_toolkit_${OPENVINO_DIST}_${OPENVINO_FULLVER_FALLBACK}_x86_64.tgz"
-          fi
-          echo "Downloading ${URL}"
-          if ! curl -fL -o /tmp/openvino.tgz "${URL}"; then
-            echo "::error::OpenVINO archive download failed: ${URL}"
-            echo "  Pin the correct directory/version/build id by browsing"
-            echo "  https://storage.openvinotoolkit.org/repositories/openvino/packages/"
+          URL="${BASE}/openvino_toolkit_${OPENVINO_DIST}_${OPENVINO_FULLVER}_x86_64.tgz"
+          # DIAGNOSTIC: the prior run got a 1061-byte HTTP-200 body for BOTH the
+          # directory and the tarball URL (a soft-404 / landing / block page, not
+          # a file) — `curl -f` can't catch that (it's a 200), and `tar` failed
+          # "not in gzip format". Capture the server's ACTUAL response (status,
+          # type, size, final URL, body head) so the correct path/build — or a
+          # host-side block — is visible, and only proceed if the bytes are a
+          # real gzip. A browser UA rules out a trivial UA block.
+          UA="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+          echo "== Directory: ${BASE}/ =="
+          curl -sSL -A "${UA}" -o /tmp/ov_dir.txt \
+            -w "  HTTP %{http_code} type=%{content_type} size=%{size_download} final=%{url_effective}\n" \
+            "${BASE}/" || true
+          echo "  ---- body head ----"; head -c 1200 /tmp/ov_dir.txt; echo; echo "  ----"
+          echo "== Tarball: ${URL} =="
+          curl -sSL -A "${UA}" -o /tmp/openvino.tgz \
+            -w "  HTTP %{http_code} type=%{content_type} size=%{size_download} final=%{url_effective}\n" \
+            "${URL}" || true
+          MAGIC="$(head -c2 /tmp/openvino.tgz | od -An -tx1 | tr -d ' \n')"
+          if [ "${MAGIC}" != "1f8b" ]; then
+            echo "::error::Downloaded content is NOT a gzip archive (magic=${MAGIC}) — soft-404/landing/block page, not the tarball."
+            echo "  ---- response body head ----"; head -c 1200 /tmp/openvino.tgz; echo; echo "  ----"
+            echo "  Use the body/headers above to pin the correct URL (dir/version/build/prefix),"
+            echo "  or confirm storage.openvinotoolkit.org blocks the runner."
             exit 1
           fi
+          echo "Got a real gzip archive — proceeding."
           sudo mkdir -p /opt/intel/openvino_2025
           # --strip-components=1 drops the top-level versioned dir so the runtime
           # lands directly under /opt/intel/openvino_2025.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,20 +182,36 @@ jobs:
           set -euo pipefail
           OPENVINO_VER="2025.1"        # pinned minor (>= 2025.1 satisfies openvino-rs#167)
           OPENVINO_DIST="ubuntu24"     # runs-on: ubuntu-latest == ubuntu-24.04
+          # Fallback exact build id (used only if the directory listing can't be
+          # resolved). Replace if the download 404s — verify on the storage site.
+          OPENVINO_FULLVER_FALLBACK="2025.1.0.18503"
           BASE="https://storage.openvinotoolkit.org/repositories/openvino/packages/${OPENVINO_VER}/linux"
-          # The exact tarball carries a build id (e.g. 2025.1.0.18503) that is
-          # NOT derivable, so resolve the precise filename from the directory
-          # listing rather than hard-coding a build number.
-          TARBALL="$(curl -fsSL "${BASE}/" \
+          # Resolve the exact tarball (its build id is not derivable). GUARD the
+          # pipeline with `|| true`: a curl/grep miss must NOT die under
+          # `set -e`/`pipefail` before the diagnostic runs (the prior version
+          # exited 1 with zero output, masking whether the URL or the pattern
+          # was wrong).
+          echo "Listing ${BASE}/ ..."
+          LISTING="$(curl -fsSL "${BASE}/" || true)"
+          TARBALL="$(printf '%s\n' "${LISTING}" \
             | grep -oE "(l_)?openvino_toolkit_${OPENVINO_DIST}_${OPENVINO_VER}\.[0-9.]+_x86_64\.tgz" \
-            | sort -V | tail -n1)"
-          if [ -z "${TARBALL}" ]; then
-            echo "::error::Could not resolve an OpenVINO ${OPENVINO_VER} ${OPENVINO_DIST} archive at ${BASE}/ — check the version/dist pin."
-            curl -fsSL "${BASE}/" | grep -oE "[a-z_]*openvino_toolkit[^\"<> ]+\.tgz" | sort -u | head || true
+            | sort -V | tail -n1 || true)"
+          if [ -n "${TARBALL}" ]; then
+            URL="${BASE}/${TARBALL}"
+            echo "Resolved from listing: ${TARBALL}"
+          else
+            echo "Listing yielded no tarball (got ${#LISTING} bytes). openvino_toolkit*.tgz seen:"
+            printf '%s\n' "${LISTING}" | grep -oE "[a-z_]*openvino_toolkit[^\"<> ]+\.tgz" | sort -u | head -20 || true
+            echo "Falling back to pinned build ${OPENVINO_FULLVER_FALLBACK}."
+            URL="${BASE}/openvino_toolkit_${OPENVINO_DIST}_${OPENVINO_FULLVER_FALLBACK}_x86_64.tgz"
+          fi
+          echo "Downloading ${URL}"
+          if ! curl -fL -o /tmp/openvino.tgz "${URL}"; then
+            echo "::error::OpenVINO archive download failed: ${URL}"
+            echo "  Pin the correct directory/version/build id by browsing"
+            echo "  https://storage.openvinotoolkit.org/repositories/openvino/packages/"
             exit 1
           fi
-          echo "Resolved OpenVINO archive: ${TARBALL}"
-          curl -fL -o /tmp/openvino.tgz "${BASE}/${TARBALL}"
           sudo mkdir -p /opt/intel/openvino_2025
           # --strip-components=1 drops the top-level versioned dir so the runtime
           # lands directly under /opt/intel/openvino_2025.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,9 +200,20 @@ jobs:
           OV_LIBDIR="$(dirname "${LIB}")"
           echo "OpenVINO runtime libs in: ${OV_LIBDIR}"
           ls -1 "${OV_LIBDIR}"/libopenvino_c.so*
+          # The wheel ships only the versioned SONAME (e.g. libopenvino_c.so.2510)
+          # with no bare dev symlink. openvino-finder matches the EXACT name
+          # "libopenvino_c.so" when scanning LD_LIBRARY_PATH (it only does
+          # version-suffix scanning for SYSTEM dirs, NOT LD_LIBRARY_PATH), so it
+          # otherwise reports "Unable to find the openvino_c library". Create the
+          # bare symlink; the dynamic linker still resolves the versioned deps
+          # (libopenvino.so.X, plugins, libtbb) in this same dir via their SONAME.
+          if [ ! -e "${OV_LIBDIR}/libopenvino_c.so" ]; then
+            ln -s "$(basename "${LIB}")" "${OV_LIBDIR}/libopenvino_c.so"
+            echo "Created bare symlink: libopenvino_c.so -> $(basename "${LIB}")"
+          fi
+          ls -l "${OV_LIBDIR}/libopenvino_c.so"
           # Per-step shells don't share env: expose the lib dir to the cargo step
-          # via $GITHUB_ENV. openvino-finder probes LD_LIBRARY_PATH first and
-          # handles versioned SONAMEs (e.g. libopenvino_c.so.2510).
+          # via $GITHUB_ENV (openvino-finder probes LD_LIBRARY_PATH).
           echo "LD_LIBRARY_PATH=${OV_LIBDIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> "${GITHUB_ENV}"
       - name: parko-openvino tests
         # OpenVINO-dependent. Same flakiness disposition as

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,32 +182,35 @@ jobs:
           set -euo pipefail
           OPENVINO_VER="2025.1"        # pinned minor (>= 2025.1 satisfies openvino-rs#167)
           OPENVINO_DIST="ubuntu24"     # runs-on: ubuntu-latest == ubuntu-24.04
-          OPENVINO_FULLVER="2025.1.0.18503"
-          BASE="https://storage.openvinotoolkit.org/repositories/openvino/packages/${OPENVINO_VER}/linux"
-          URL="${BASE}/openvino_toolkit_${OPENVINO_DIST}_${OPENVINO_FULLVER}_x86_64.tgz"
-          # DIAGNOSTIC: the prior run got a 1061-byte HTTP-200 body for BOTH the
-          # directory and the tarball URL (a soft-404 / landing / block page, not
-          # a file) — `curl -f` can't catch that (it's a 200), and `tar` failed
-          # "not in gzip format". Capture the server's ACTUAL response (status,
-          # type, size, final URL, body head) so the correct path/build — or a
-          # host-side block — is visible, and only proceed if the bytes are a
-          # real gzip. A browser UA rules out a trivial UA block.
-          UA="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
-          echo "== Directory: ${BASE}/ =="
-          curl -sSL -A "${UA}" -o /tmp/ov_dir.txt \
-            -w "  HTTP %{http_code} type=%{content_type} size=%{size_download} final=%{url_effective}\n" \
-            "${BASE}/" || true
-          echo "  ---- body head ----"; head -c 1200 /tmp/ov_dir.txt; echo; echo "  ----"
-          echo "== Tarball: ${URL} =="
-          curl -sSL -A "${UA}" -o /tmp/openvino.tgz \
-            -w "  HTTP %{http_code} type=%{content_type} size=%{size_download} final=%{url_effective}\n" \
-            "${URL}" || true
+          HOST="https://storage.openvinotoolkit.org"
+          PREFIX="repositories/openvino/packages/${OPENVINO_VER}/linux/"
+          # storage.openvinotoolkit.org is an S3 bucket fronted by a JS directory
+          # browser (list.js): a plain GET of a directory OR a non-existent key
+          # returns a 1061-byte index.html with HTTP 200 — not a listing/file —
+          # so there is no server-side index to grep and `curl -f` can't detect a
+          # wrong key. Enumerate REAL object keys via the S3 ListObjects v2 API
+          # (what list.js itself uses), then download by exact key.
+          echo "S3 ListObjects: ${HOST}/?prefix=${PREFIX}"
+          XML="$(curl -sSL "${HOST}/?list-type=2&prefix=${PREFIX}&max-keys=1000" || true)"
+          KEY="$(printf '%s' "${XML}" \
+            | grep -oE "${PREFIX}(l_)?openvino_toolkit_${OPENVINO_DIST}_[0-9][0-9.]*_x86_64\.tgz" \
+            | sort -V | tail -n1 || true)"
+          if [ -z "${KEY}" ]; then
+            echo "::error::No ${OPENVINO_DIST} OpenVINO tarball found under ${PREFIX}"
+            echo "  ---- object keys for this prefix ----"
+            printf '%s' "${XML}" | grep -oE "<Key>[^<]+</Key>" | head -40 || true
+            echo "  ---- available package version dirs (fix OPENVINO_VER if needed) ----"
+            curl -sSL "${HOST}/?list-type=2&prefix=repositories/openvino/packages/&delimiter=/" \
+              | grep -oE "<Prefix>[^<]+</Prefix>" | head -60 || true
+            exit 1
+          fi
+          URL="${HOST}/${KEY}"
+          echo "Resolved key: ${KEY}"
+          curl -fL -o /tmp/openvino.tgz "${URL}"
           MAGIC="$(head -c2 /tmp/openvino.tgz | od -An -tx1 | tr -d ' \n')"
           if [ "${MAGIC}" != "1f8b" ]; then
-            echo "::error::Downloaded content is NOT a gzip archive (magic=${MAGIC}) — soft-404/landing/block page, not the tarball."
-            echo "  ---- response body head ----"; head -c 1200 /tmp/openvino.tgz; echo; echo "  ----"
-            echo "  Use the body/headers above to pin the correct URL (dir/version/build/prefix),"
-            echo "  or confirm storage.openvinotoolkit.org blocks the runner."
+            echo "::error::Resolved object is not gzip (magic=${MAGIC}). Body head:"
+            head -c 600 /tmp/openvino.tgz; echo
             exit 1
           fi
           echo "Got a real gzip archive — proceeding."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,20 @@ jobs:
         # regression to e.g. the H1 angular cap would land on main with
         # CI green.
         #
-        # `--exclude parko-onnx` keeps this job ORT-free (the
-        # parko-onnx tests need libonnxruntime + ORT_DYLIB_PATH; see
-        # the parko-onnx job below). Future parko crates added to the
-        # sub-workspace (parko-ros2 already, anything else later) are
-        # picked up automatically by `--workspace`.
+        # `--exclude parko-onnx --exclude parko-openvino` keeps this job
+        # runtime-free: BOTH backend crates dlopen a native inference runtime
+        # at OvBackend/OrtBackend::new (libopenvino_c.so / libonnxruntime.so)
+        # and panic without it, so their tests belong to the dedicated
+        # parko-onnx / parko-openvino jobs that install those runtimes. This
+        # job must gate purely on the runtime-free safety logic — without the
+        # parko-openvino exclude it ran the OpenVINO backend tests here and
+        # failed on "Unable to find the openvino_c library" (the crate was
+        # added in e4df0fa without updating this exclude). Future parko crates
+        # added to the sub-workspace are picked up automatically by
+        # `--workspace`; add an `--exclude` here only for runtime-dependent
+        # backends.
         working-directory: parko
-        run: cargo test --workspace --exclude parko-onnx
+        run: cargo test --workspace --exclude parko-onnx --exclude parko-openvino
 
   parko-onnx:
     name: Parko ONNX Backend Tests (ORT v1.23.2)
@@ -114,6 +121,15 @@ jobs:
             -C "$HOME/.local/onnxruntime" --strip-components=1
           test -f "$HOME/.local/onnxruntime/lib/libonnxruntime.so" \
             || (echo "libonnxruntime.so missing after install"; exit 1)
+          # Export ORT_DYLIB_PATH here, in the shell, so $HOME expands
+          # correctly. It must NOT be set as a step-level `env:` value using
+          # ${{ env.HOME }} — the Actions expression `env` context does NOT
+          # contain the runner's system HOME, so it expands to EMPTY and ort
+          # then dlopens "/.local/.../libonnxruntime.so" and fails ("dlopen
+          # failed"). That empty-HOME load failure is exactly what manifested
+          # as the #144 "init deadlock" under rc.12 (whose dylib-load error
+          # path deadlocks); rc.11 surfaces it as a clean panic.
+          echo "ORT_DYLIB_PATH=$HOME/.local/onnxruntime/lib/libonnxruntime.so" >> "$GITHUB_ENV"
       - name: parko-onnx tests
         # ORT-dependent. If this job proves flaky in CI (network
         # download, ABI mismatch on a future Ubuntu image, etc.), it
@@ -141,7 +157,11 @@ jobs:
         timeout-minutes: 10
         working-directory: parko
         env:
-          ORT_DYLIB_PATH: ${{ env.HOME }}/.local/onnxruntime/lib/libonnxruntime.so
+          # ORT_DYLIB_PATH is exported from the install step via $GITHUB_ENV
+          # (shell $HOME). It is intentionally NOT set here: a step-level
+          # `env:` value would override the $GITHUB_ENV one, and the only way
+          # to reference HOME in an Actions expression (${{ env.HOME }}) yields
+          # an empty string → a "/.local/..." dlopen failure.
           RUST_BACKTRACE: "1"
         run: cargo test -p parko-onnx -- --nocapture
 
@@ -179,6 +199,11 @@ jobs:
             -C "$HOME/.local/onnxruntime" --strip-components=1
           test -f "$HOME/.local/onnxruntime/lib/libonnxruntime.so" \
             || (echo "libonnxruntime.so missing after install"; exit 1)
+          # Export ORT_DYLIB_PATH in the shell so $HOME expands (see the
+          # parko-onnx job: a step-level ${{ env.HOME }} expands to empty and
+          # breaks the dlopen). The cross-backend equivalence step below reads
+          # it from $GITHUB_ENV.
+          echo "ORT_DYLIB_PATH=$HOME/.local/onnxruntime/lib/libonnxruntime.so" >> "$GITHUB_ENV"
       - name: Install OpenVINO runtime (pip wheel, >= 2025.1)
         # openvino-rs REQUIRES OpenVINO >= 2025.1: `ov_element_type_e` changed
         # incompatibly in 2025.1, so the crate REJECTS older runtimes as "version
@@ -265,7 +290,10 @@ jobs:
         timeout-minutes: 10
         working-directory: parko
         env:
-          ORT_DYLIB_PATH: ${{ env.HOME }}/.local/onnxruntime/lib/libonnxruntime.so
+          # ORT_DYLIB_PATH (for OrtBackend's load-dynamic) and LD_LIBRARY_PATH
+          # (for OpenVINO) both come from the install steps via $GITHUB_ENV;
+          # neither is set here, because a step-level `env:` value would
+          # override $GITHUB_ENV and ${{ env.HOME }} expands to empty.
           RUST_BACKTRACE: "1"
         run: cargo test -p parko-openvino ort_ov_output_equivalence_on_mnist -- --nocapture
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,23 @@ jobs:
         # gate above continues to gate on its own — but the safety
         # gate must NEVER be made non-gating.
         #
-        # FAST-FAIL: `ort 2.0.0-rc.12` can DEADLOCK in its error path,
-        # hanging the test binary indefinitely (observed: the job ran for
-        # >1h with no progress). `timeout-minutes` converts that 6h hang
-        # into a fast, visible failure WITHOUT making the job non-gating
-        # (no continue-on-error — a real failure still blocks). A healthy
+        # `--test-threads=1` (#144): all THREE parko-onnx tests hang at
+        # `OrtBackend::new` *simultaneously*, including a trivial descriptor
+        # read — the signature of a concurrent global-environment-init
+        # deadlock, not an error-path bug. `cargo test` runs tests in
+        # parallel by default, so all three race to initialize ORT's global
+        # environment at once. ort's own changelog confirms this class of
+        # bug: rc.11 added "Make environment initialization thread-safe to
+        # eliminate segfaults when running tests concurrently" + "Fix global
+        # environment thread pools". Serializing the ORT-touching tests
+        # initializes the global environment exactly once, before any other
+        # test runs. This keeps the known-ABI-compatible rc.12 + ONNX Runtime
+        # 1.24.2 pair (a version downgrade would force a matching runtime
+        # install that can't be validated outside CI) and is fully reversible.
+        #
+        # FAST-FAIL: `timeout-minutes` still converts any residual hang into a
+        # fast, visible failure WITHOUT making the job non-gating (no
+        # continue-on-error — a real failure still blocks). A healthy
         # compile+run finishes well inside the budget. `--nocapture` +
         # backtrace surface the panic reason inline so a fast-failed run is
         # diagnosable (the captured "failures:" section never prints when the
@@ -131,19 +143,21 @@ jobs:
         env:
           ORT_DYLIB_PATH: ${{ env.HOME }}/.local/onnxruntime/lib/libonnxruntime.so
           RUST_BACKTRACE: "1"
-        run: cargo test -p parko-onnx -- --nocapture
+        run: cargo test -p parko-onnx -- --nocapture --test-threads=1
 
   parko-openvino:
     name: Parko OpenVINO Backend Tests (pip openvino-2025.1)
     runs-on: ubuntu-latest
-    # NON-GATING for now (#143). Kept continue-on-error: true while this archive
-    # install is validated by the REAL CI run — it can't be proven green locally
-    # (this change was authored 403-blocked from storage.openvinotoolkit.org, so
-    # the URL/install is unverified here). Remove it only AFTER the OpenVINO-only
-    # tests (smoke / descriptor / capabilities) are confirmed green in CI AND the
-    # equivalence test's ort #144 deadlock coupling is resolved or gated
-    # separately. `parko-safety` remains the gating safety check regardless.
-    continue-on-error: true
+    # This job is now SPLIT into two test steps (see below):
+    #   1. OpenVINO-only tests — GATING. Confirmed green in CI once the pip
+    #      wheel install + bare-symlink fix landed (#143 resolved); they failed
+    #      before only because OvBackend::new was rejected as "version too old".
+    #   2. Cross-backend equivalence test — isolated, step-level
+    #      continue-on-error (#144), because it hangs on the same ort
+    #      2.0.0-rc.12 init deadlock as parko-onnx.
+    # The job-level continue-on-error is REMOVED so the OpenVINO backend is now
+    # genuinely gated; only the equivalence step (#144) remains non-gating.
+    # `parko-safety` remains the primary gating safety check regardless.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -180,7 +194,7 @@ jobs:
         # crate dlopens at OvBackend::new — and is exactly version-pinnable.
         #
         # A venv avoids PEP-668 "externally-managed-environment" on the runner's
-        # system python. (continue-on-error stays on; validated by this CI run.)
+        # system python.
         run: |
           set -euo pipefail
           python3 -m venv "$HOME/ovenv"
@@ -215,35 +229,43 @@ jobs:
           # Per-step shells don't share env: expose the lib dir to the cargo step
           # via $GITHUB_ENV (openvino-finder probes LD_LIBRARY_PATH).
           echo "LD_LIBRARY_PATH=${OV_LIBDIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> "${GITHUB_ENV}"
-      - name: parko-openvino tests
-        # OpenVINO-dependent. Same flakiness disposition as
-        # parko-onnx: if this job becomes unreliable in CI (Intel apt
-        # outage, future Ubuntu ABI break), it MAY be flipped to
-        # `continue-on-error: true`. The parko-safety gate above must
-        # remain gating regardless.
-        #
-        # EXPECTED OUTCOME of the archive fix: the OpenVINO-only tests
-        # (openvino_smoke_mnist_inference_runs_and_outputs_finite,
-        # openvino_descriptor_is_intel_openvino,
-        # openvino_capabilities_match_cpu_baseline) should now PASS — they failed
-        # only because OvBackend::new was rejected as "version too old". The
-        # cross-backend `ort_ov_output_equivalence_on_mnist` test will STILL hang
-        # on the separate ort 2.0.0-rc.12 init deadlock (#144) and is caught by
-        # `timeout-minutes`; that is NOT a failure of this fix. `--nocapture` +
-        # backtrace keep the output diagnosable on the fast-fail.
+      - name: parko-openvino OpenVINO-only tests (GATING)
+        # The OpenVINO backend tests proper — they exercise OvBackend through
+        # the pip-installed OpenVINO 2025.1 runtime and do NOT touch ort:
+        #   - openvino_smoke_mnist_inference_runs_and_outputs_finite
+        #   - openvino_descriptor_is_intel_openvino
+        #   - openvino_capabilities_match_cpu_baseline
+        #   - openvino_missing_model_returns_initialization_error_not_panic
+        #   - equivalence_input_is_deterministic_and_in_unit_range (pure)
+        # All confirmed green in CI once the pip wheel + bare-symlink install
+        # landed. `--skip ort_ov_output_equivalence_on_mnist` excludes ONLY the
+        # cross-backend test (run separately below) so the ort #144 deadlock
+        # cannot infect this gating step. No continue-on-error: a real OpenVINO
+        # regression now blocks. LD_LIBRARY_PATH comes from the install step via
+        # $GITHUB_ENV (a step-level `env:` value would override it).
         timeout-minutes: 10
         working-directory: parko
         env:
-          # ONNX runtime for the cross-backend equivalence test (parko-onnx
-          # `OrtBackend`, ort load-dynamic).
-          ORT_DYLIB_PATH: ${{ env.HOME }}/.local/onnxruntime/lib/libonnxruntime.so
-          # NOTE: LD_LIBRARY_PATH / INTEL_OPENVINO_DIR are provided by the
-          # archive install step via $GITHUB_ENV (from `setupvars.sh`); they are
-          # intentionally NOT set here, because a step-level `env:` value would
-          # OVERRIDE the $GITHUB_ENV one. The old apt-discovery OPENVINO_LIBDIR
-          # override is removed.
           RUST_BACKTRACE: "1"
-        run: cargo test -p parko-openvino -- --nocapture
+        run: cargo test -p parko-openvino -- --nocapture --skip ort_ov_output_equivalence_on_mnist
+      - name: parko-openvino cross-backend equivalence test (non-gating, ort #144)
+        # `ort_ov_output_equivalence_on_mnist` loads the SAME MNIST model
+        # through parko-onnx's OrtBackend and compares it to OpenVINO's. It
+        # hangs on the identical ort 2.0.0-rc.12 init deadlock as the parko-onnx
+        # job (#144). `--test-threads=1` is the same surgical fix attempt being
+        # made there; if it greens this test we can promote the step to gating.
+        # Until then it is ISOLATED in its own STEP-LEVEL continue-on-error so
+        # the #144 deadlock cannot block the now-gating OpenVINO-only step
+        # above. `timeout-minutes` fast-fails any residual hang. ORT_DYLIB_PATH
+        # points OrtBackend's load-dynamic at libonnxruntime.so; LD_LIBRARY_PATH
+        # (OpenVINO) still comes from the install step via $GITHUB_ENV.
+        continue-on-error: true
+        timeout-minutes: 10
+        working-directory: parko
+        env:
+          ORT_DYLIB_PATH: ${{ env.HOME }}/.local/onnxruntime/lib/libonnxruntime.so
+          RUST_BACKTRACE: "1"
+        run: cargo test -p parko-openvino ort_ov_output_equivalence_on_mnist -- --nocapture --test-threads=1
 
 
   static-analysis:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,16 +168,15 @@ jobs:
   parko-openvino:
     name: Parko OpenVINO Backend Tests (pip openvino-2025.1)
     runs-on: ubuntu-latest
-    # This job is now SPLIT into two test steps (see below):
-    #   1. OpenVINO-only tests — GATING. Confirmed green in CI once the pip
-    #      wheel install + bare-symlink fix landed (#143 resolved); they failed
-    #      before only because OvBackend::new was rejected as "version too old".
-    #   2. Cross-backend equivalence test — isolated, step-level
-    #      continue-on-error (#144), because it shares parko-onnx's ort init
-    #      path (under test via the rc.11 downgrade).
-    # The job-level continue-on-error is REMOVED so the OpenVINO backend is now
-    # genuinely gated; only the equivalence step (#144) remains non-gating.
-    # `parko-safety` remains the primary gating safety check regardless.
+    # This job is SPLIT into two test steps (see below), BOTH gating:
+    #   1. OpenVINO-only tests — exercise OvBackend through the pip OpenVINO
+    #      2025.1 wheel (#143 resolved by the wheel + bare-symlink install).
+    #   2. Cross-backend equivalence test — exercises OrtBackend + OvBackend
+    #      together. Was briefly non-gating while the apparent ort "init
+    #      deadlock" (#144) was diagnosed as the empty-$HOME ORT_DYLIB_PATH
+    #      bug; now fixed, so this step is gating again.
+    # No continue-on-error anywhere in this job; `parko-safety` remains the
+    # primary gating safety check.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -274,19 +273,18 @@ jobs:
         env:
           RUST_BACKTRACE: "1"
         run: cargo test -p parko-openvino -- --nocapture --skip ort_ov_output_equivalence_on_mnist
-      - name: parko-openvino cross-backend equivalence test (non-gating, ort #144)
+      - name: parko-openvino cross-backend equivalence test (GATING)
         # `ort_ov_output_equivalence_on_mnist` loads the SAME MNIST model
         # through parko-onnx's OrtBackend and compares it to OpenVINO's, so it
-        # shares parko-onnx's ort init path (#144). It is kept ISOLATED in its
-        # own STEP-LEVEL continue-on-error so that, until the ort downgrade is
-        # confirmed to clear the init deadlock here too, it cannot block the
-        # now-gating OpenVINO-only step above. Once the rc.11 downgrade is
-        # proven to green this test in CI, this step can be promoted to gating
-        # (drop continue-on-error). `timeout-minutes` fast-fails any residual
-        # hang. ORT_DYLIB_PATH points OrtBackend's load-dynamic at
-        # libonnxruntime.so; LD_LIBRARY_PATH (OpenVINO) still comes from the
-        # install step via $GITHUB_ENV.
-        continue-on-error: true
+        # exercises BOTH runtimes together. It was previously isolated under
+        # step-level continue-on-error while the apparent ort "init deadlock"
+        # (#144) was diagnosed; that turned out to be the empty-$HOME
+        # ORT_DYLIB_PATH bug, now fixed, and this test passes cleanly in CI
+        # (rc.11 + ONNX Runtime 1.23.2). It is therefore GATING again — no
+        # continue-on-error — so a real cross-backend divergence blocks.
+        # `timeout-minutes` keeps a fast-fail guard. ORT_DYLIB_PATH (OrtBackend
+        # load-dynamic) and LD_LIBRARY_PATH (OpenVINO) come from the install
+        # steps via $GITHUB_ENV.
         timeout-minutes: 10
         working-directory: parko
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,16 @@ jobs:
         run: cargo test -p parko-onnx -- --nocapture
 
   parko-openvino:
-    name: Parko OpenVINO Backend Tests (apt openvino-2024)
+    name: Parko OpenVINO Backend Tests (archive openvino-2025.1+)
     runs-on: ubuntu-latest
+    # NON-GATING for now (#143). Kept continue-on-error: true while this archive
+    # install is validated by the REAL CI run — it can't be proven green locally
+    # (this change was authored 403-blocked from storage.openvinotoolkit.org, so
+    # the URL/install is unverified here). Remove it only AFTER the OpenVINO-only
+    # tests (smoke / descriptor / capabilities) are confirmed green in CI AND the
+    # equivalence test's ort #144 deadlock coupling is resolved or gated
+    # separately. `parko-safety` remains the gating safety check regardless.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -156,49 +164,59 @@ jobs:
             -C "$HOME/.local/onnxruntime" --strip-components=1
           test -f "$HOME/.local/onnxruntime/lib/libonnxruntime.so" \
             || (echo "libonnxruntime.so missing after install"; exit 1)
-      - name: Install OpenVINO runtime (Intel apt repo, 2024.x)
-        # The `openvino = "0.11"` crate links against OpenVINO 2024.x.
-        # Intel ships a Debian package via their public apt repo —
-        # this is the upstream-supported install path. The
-        # `runtime-linking` feature means the crate dlopens
-        # libopenvino_c.so at backend construction (OvBackend::new)
-        # rather than at build time; the build never needed this,
-        # but the integration tests do.
+      - name: Install OpenVINO runtime (official archive, >= 2025.1)
+        # openvino-rs REQUIRES OpenVINO >= 2025.1: the `ov_element_type_e` enum
+        # changed incompatibly in 2025.1, so the crate REJECTS older runtimes as
+        # "version too old" (openvino-rs#167) to avoid silently creating
+        # wrong-type tensors. That gate is PROTECTIVE — we satisfy it rather than
+        # bypass it (no OPENVINO_SKIP_LINKING / force-accept; those make the
+        # crate build but inference stays broken). The apt `openvino-2024.5.0`
+        # package is therefore unusable; install a pinned 2025.1+ release ARCHIVE
+        # whose version satisfies the gate and whose layout is fixed
+        # (/opt/intel/openvino_2025/runtime/lib/intel64).
+        #
+        # UNVERIFIED HERE: authored 403-blocked from storage.openvinotoolkit.org,
+        # so the URL/install could not be tested locally — the real CI run is the
+        # validation (continue-on-error is kept on for that reason).
         run: |
           set -euo pipefail
-          # Intel public GPG key + apt repo (per
-          # https://docs.openvino.ai/2024/get-started/install-openvino/install-openvino-linux.html).
-          wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
-            | sudo gpg --dearmor -o /usr/share/keyrings/intel.gpg
-          echo "deb [signed-by=/usr/share/keyrings/intel.gpg] https://apt.repos.intel.com/openvino/2024 ubuntu22 main" \
-            | sudo tee /etc/apt/sources.list.d/intel-openvino-2024.list
-          sudo apt-get update
-          sudo apt-get install -y openvino-2024.5.0
-          # DISCOVER the runtime location instead of ASSUMING it. The Intel
-          # apt package's actual install path has proven not to be the
-          # standalone-archive `/opt/intel/...` layout NOR the distro-DEB
-          # `/usr/lib/x86_64-linux-gnu` FHS path, so we locate libopenvino_c.so
-          # wherever the package placed it and export that dir for the test
-          # step's LD_LIBRARY_PATH (which openvino-finder probes first). If the
-          # library is genuinely absent, fail loudly with package diagnostics
-          # so the real layout is visible in the log.
-          echo "Locating libopenvino_c.so after apt install ..."
-          OPENVINO_LIBDIR="$(dirname "$(find /usr /opt /lib -name 'libopenvino_c.so*' -print 2>/dev/null | head -n1)")"
-          if [ -z "${OPENVINO_LIBDIR}" ] || [ "${OPENVINO_LIBDIR}" = "." ]; then
-            echo "::error::libopenvino_c.so not found under /usr /opt /lib after apt install of openvino-2024.5.0"
-            echo "--- installed openvino packages ---"
-            dpkg -l | grep -i openvino || true
-            echo "--- .so files owned by those packages ---"
-            dpkg -l | awk '/^ii/ && /openvino/ {print $2}' \
-              | while read -r p; do echo "== ${p} =="; dpkg -L "${p}" 2>/dev/null | grep -E '\.so' || true; done
-            echo "--- ldconfig cache (openvino) ---"
-            ldconfig -p | grep -i openvino || true
+          OPENVINO_VER="2025.1"        # pinned minor (>= 2025.1 satisfies openvino-rs#167)
+          OPENVINO_DIST="ubuntu24"     # runs-on: ubuntu-latest == ubuntu-24.04
+          BASE="https://storage.openvinotoolkit.org/repositories/openvino/packages/${OPENVINO_VER}/linux"
+          # The exact tarball carries a build id (e.g. 2025.1.0.18503) that is
+          # NOT derivable, so resolve the precise filename from the directory
+          # listing rather than hard-coding a build number.
+          TARBALL="$(curl -fsSL "${BASE}/" \
+            | grep -oE "(l_)?openvino_toolkit_${OPENVINO_DIST}_${OPENVINO_VER}\.[0-9.]+_x86_64\.tgz" \
+            | sort -V | tail -n1)"
+          if [ -z "${TARBALL}" ]; then
+            echo "::error::Could not resolve an OpenVINO ${OPENVINO_VER} ${OPENVINO_DIST} archive at ${BASE}/ — check the version/dist pin."
+            curl -fsSL "${BASE}/" | grep -oE "[a-z_]*openvino_toolkit[^\"<> ]+\.tgz" | sort -u | head || true
             exit 1
           fi
-          echo "OpenVINO C runtime found in: ${OPENVINO_LIBDIR}"
-          ls -1 "${OPENVINO_LIBDIR}"/libopenvino_c.so*
-          # Export for subsequent steps (GitHub Actions step-to-step env).
-          echo "OPENVINO_LIBDIR=${OPENVINO_LIBDIR}" >> "${GITHUB_ENV}"
+          echo "Resolved OpenVINO archive: ${TARBALL}"
+          curl -fL -o /tmp/openvino.tgz "${BASE}/${TARBALL}"
+          sudo mkdir -p /opt/intel/openvino_2025
+          # --strip-components=1 drops the top-level versioned dir so the runtime
+          # lands directly under /opt/intel/openvino_2025.
+          sudo tar -xzf /tmp/openvino.tgz -C /opt/intel/openvino_2025 --strip-components=1
+          # Runtime dependencies (libtbb etc.).
+          if [ -f /opt/intel/openvino_2025/install_dependencies/install_openvino_dependencies.sh ]; then
+            sudo -E bash /opt/intel/openvino_2025/install_dependencies/install_openvino_dependencies.sh -y
+          fi
+          test -f /opt/intel/openvino_2025/runtime/lib/intel64/libopenvino_c.so \
+            || { echo "::error::libopenvino_c.so missing after archive extract"; ls -R /opt/intel/openvino_2025 | head -40; exit 1; }
+          # Per-step shells don't share env, so `source setupvars.sh` here would
+          # NOT reach the cargo step. Source it and persist the resulting
+          # OpenVINO env to $GITHUB_ENV; openvino-finder discovers the archive
+          # libs via INTEL_OPENVINO_DIR + LD_LIBRARY_PATH (NOT the old apt/FHS
+          # path — that OPENVINO_LIBDIR export is removed).
+          set +u
+          source /opt/intel/openvino_2025/setupvars.sh
+          set -u
+          echo "INTEL_OPENVINO_DIR=${INTEL_OPENVINO_DIR}" >> "${GITHUB_ENV}"
+          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
+          echo "OpenVINO runtime ready: INTEL_OPENVINO_DIR=${INTEL_OPENVINO_DIR}"
       - name: parko-openvino tests
         # OpenVINO-dependent. Same flakiness disposition as
         # parko-onnx: if this job becomes unreliable in CI (Intel apt
@@ -206,24 +224,26 @@ jobs:
         # `continue-on-error: true`. The parko-safety gate above must
         # remain gating regardless.
         #
-        # FAST-FAIL (same rationale as parko-onnx): the cross-backend
-        # equivalence test uses ORT, whose 2.0.0-rc.12 error-path deadlock
-        # hangs the binary indefinitely; `timeout-minutes` makes that a fast,
-        # visible failure while the job stays GATING (no continue-on-error).
-        # `--nocapture` + backtrace surface why the OvBackend tests fail (the
-        # 3 `OvBackend::new(...).expect(...)` panics) inline, since a hung
-        # binary never prints the captured failures section.
+        # EXPECTED OUTCOME of the archive fix: the OpenVINO-only tests
+        # (openvino_smoke_mnist_inference_runs_and_outputs_finite,
+        # openvino_descriptor_is_intel_openvino,
+        # openvino_capabilities_match_cpu_baseline) should now PASS — they failed
+        # only because OvBackend::new was rejected as "version too old". The
+        # cross-backend `ort_ov_output_equivalence_on_mnist` test will STILL hang
+        # on the separate ort 2.0.0-rc.12 init deadlock (#144) and is caught by
+        # `timeout-minutes`; that is NOT a failure of this fix. `--nocapture` +
+        # backtrace keep the output diagnosable on the fast-fail.
         timeout-minutes: 10
         working-directory: parko
         env:
           # ONNX runtime for the cross-backend equivalence test (parko-onnx
           # `OrtBackend`, ort load-dynamic).
           ORT_DYLIB_PATH: ${{ env.HOME }}/.local/onnxruntime/lib/libonnxruntime.so
-          # OpenVINO runtime dir discovered by the install step above (the apt
-          # package's real location, not an assumed path). openvino-finder
-          # checks LD_LIBRARY_PATH before its built-in dir list, so this makes
-          # the runtime discoverable wherever apt put it.
-          LD_LIBRARY_PATH: ${{ env.OPENVINO_LIBDIR }}
+          # NOTE: LD_LIBRARY_PATH / INTEL_OPENVINO_DIR are provided by the
+          # archive install step via $GITHUB_ENV (from `setupvars.sh`); they are
+          # intentionally NOT set here, because a step-level `env:` value would
+          # OVERRIDE the $GITHUB_ENV one. The old apt-discovery OPENVINO_LIBDIR
+          # override is removed.
           RUST_BACKTRACE: "1"
         run: cargo test -p parko-openvino -- --nocapture
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,24 +89,28 @@ jobs:
         run: cargo test --workspace --exclude parko-onnx
 
   parko-onnx:
-    name: Parko ONNX Backend Tests (ORT v1.24.2)
+    name: Parko ONNX Backend Tests (ORT v1.23.2)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install ONNX Runtime v1.24.2
-        # Exact version match: `ort 2.0.0-rc.12` (pinned in
-        # parko-onnx/Cargo.toml) is compiled against
-        # ORT_API_VERSION = 24, which requires ONNX Runtime v1.24.x.
-        # The matching minor is v1.24.2 per parko/README.md §"Building
-        # and testing parko-onnx" — older runtimes deadlock in the ort
-        # error path (documented upstream bug in 2.0.0-rc.12).
+      - name: Install ONNX Runtime v1.23.2
+        # Exact version match: `ort 2.0.0-rc.11` (pinned in
+        # parko-onnx/Cargo.toml) is compiled against ORT_API_VERSION = 23,
+        # which requires ONNX Runtime v1.23.x. The matching minor is v1.23.2.
+        #
+        # Downgraded from rc.12 / ONNX Runtime 1.24.2 (#144): rc.12 DEADLOCKS
+        # at OrtBackend::new in this CI environment even when fully serialized
+        # (--test-threads=1: the first and only running test hung before
+        # printing anything, then hit the 10-min timeout — a single-init
+        # deadlock, not a concurrency race). rc.11 + ONNX Runtime 1.23.2 must
+        # move in lockstep.
         run: |
           set -euo pipefail
-          curl -L -o /tmp/onnxruntime-1.24.2.tgz \
-            https://github.com/microsoft/onnxruntime/releases/download/v1.24.2/onnxruntime-linux-x64-1.24.2.tgz
+          curl -L -o /tmp/onnxruntime-1.23.2.tgz \
+            https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-linux-x64-1.23.2.tgz
           mkdir -p "$HOME/.local/onnxruntime"
-          tar -xzf /tmp/onnxruntime-1.24.2.tgz \
+          tar -xzf /tmp/onnxruntime-1.23.2.tgz \
             -C "$HOME/.local/onnxruntime" --strip-components=1
           test -f "$HOME/.local/onnxruntime/lib/libonnxruntime.so" \
             || (echo "libonnxruntime.so missing after install"; exit 1)
@@ -117,22 +121,18 @@ jobs:
         # gate above continues to gate on its own — but the safety
         # gate must NEVER be made non-gating.
         #
-        # `--test-threads=1` (#144): all THREE parko-onnx tests hang at
-        # `OrtBackend::new` *simultaneously*, including a trivial descriptor
-        # read — the signature of a concurrent global-environment-init
-        # deadlock, not an error-path bug. `cargo test` runs tests in
-        # parallel by default, so all three race to initialize ORT's global
-        # environment at once. ort's own changelog confirms this class of
-        # bug: rc.11 added "Make environment initialization thread-safe to
-        # eliminate segfaults when running tests concurrently" + "Fix global
-        # environment thread pools". Serializing the ORT-touching tests
-        # initializes the global environment exactly once, before any other
-        # test runs. This keeps the known-ABI-compatible rc.12 + ONNX Runtime
-        # 1.24.2 pair (a version downgrade would force a matching runtime
-        # install that can't be validated outside CI) and is fully reversible.
+        # FIX ATTEMPT for the #144 init deadlock: pin ort 2.0.0-rc.11 (ONNX
+        # Runtime 1.23.2) instead of rc.12 (1.24.2). The surgical alternative
+        # — serializing with --test-threads=1 — was REFUTED: the binary hung
+        # at the very first OrtBackend::new with one thread, proving a genuine
+        # single-init deadlock in the rc.12 + 1.24.2 pair rather than a
+        # concurrent-init race. rc.11 added "immediate dylib loading with
+        # error detection", so if it still can't initialize it should fail
+        # fast instead of hanging. Cannot be validated outside CI (no ORT in
+        # the authoring sandbox), so this is proven by the CI run itself.
         #
-        # FAST-FAIL: `timeout-minutes` still converts any residual hang into a
-        # fast, visible failure WITHOUT making the job non-gating (no
+        # FAST-FAIL: `timeout-minutes` converts any residual hang into a fast,
+        # visible failure WITHOUT making the job non-gating (no
         # continue-on-error — a real failure still blocks). A healthy
         # compile+run finishes well inside the budget. `--nocapture` +
         # backtrace surface the panic reason inline so a fast-failed run is
@@ -143,7 +143,7 @@ jobs:
         env:
           ORT_DYLIB_PATH: ${{ env.HOME }}/.local/onnxruntime/lib/libonnxruntime.so
           RUST_BACKTRACE: "1"
-        run: cargo test -p parko-onnx -- --nocapture --test-threads=1
+        run: cargo test -p parko-onnx -- --nocapture
 
   parko-openvino:
     name: Parko OpenVINO Backend Tests (pip openvino-2025.1)
@@ -153,28 +153,29 @@ jobs:
     #      wheel install + bare-symlink fix landed (#143 resolved); they failed
     #      before only because OvBackend::new was rejected as "version too old".
     #   2. Cross-backend equivalence test — isolated, step-level
-    #      continue-on-error (#144), because it hangs on the same ort
-    #      2.0.0-rc.12 init deadlock as parko-onnx.
+    #      continue-on-error (#144), because it shares parko-onnx's ort init
+    #      path (under test via the rc.11 downgrade).
     # The job-level continue-on-error is REMOVED so the OpenVINO backend is now
     # genuinely gated; only the equivalence step (#144) remains non-gating.
     # `parko-safety` remains the primary gating safety check regardless.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install ONNX Runtime v1.24.2 (cross-backend equivalence test)
+      - name: Install ONNX Runtime v1.23.2 (cross-backend equivalence test)
         # The OpenVINO test suite includes a cross-backend equivalence
         # test (`ort_ov_output_equivalence_on_mnist`) that loads the SAME
         # MNIST model through parko-onnx's `OrtBackend` and compares its
         # output to OpenVINO's. That backend dlopens libonnxruntime.so at
         # runtime (ort `load-dynamic`), so this job needs the ONNX runtime
-        # too — identical install to the parko-onnx job. Without it the
+        # too — identical install to the parko-onnx job (ort 2.0.0-rc.11 →
+        # ONNX Runtime 1.23.2, kept in lockstep; see #144). Without it the
         # equivalence test panics ("Is libonnxruntime.so installed?").
         run: |
           set -euo pipefail
-          curl -L -o /tmp/onnxruntime-1.24.2.tgz \
-            https://github.com/microsoft/onnxruntime/releases/download/v1.24.2/onnxruntime-linux-x64-1.24.2.tgz
+          curl -L -o /tmp/onnxruntime-1.23.2.tgz \
+            https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-linux-x64-1.23.2.tgz
           mkdir -p "$HOME/.local/onnxruntime"
-          tar -xzf /tmp/onnxruntime-1.24.2.tgz \
+          tar -xzf /tmp/onnxruntime-1.23.2.tgz \
             -C "$HOME/.local/onnxruntime" --strip-components=1
           test -f "$HOME/.local/onnxruntime/lib/libonnxruntime.so" \
             || (echo "libonnxruntime.so missing after install"; exit 1)
@@ -250,22 +251,23 @@ jobs:
         run: cargo test -p parko-openvino -- --nocapture --skip ort_ov_output_equivalence_on_mnist
       - name: parko-openvino cross-backend equivalence test (non-gating, ort #144)
         # `ort_ov_output_equivalence_on_mnist` loads the SAME MNIST model
-        # through parko-onnx's OrtBackend and compares it to OpenVINO's. It
-        # hangs on the identical ort 2.0.0-rc.12 init deadlock as the parko-onnx
-        # job (#144). `--test-threads=1` is the same surgical fix attempt being
-        # made there; if it greens this test we can promote the step to gating.
-        # Until then it is ISOLATED in its own STEP-LEVEL continue-on-error so
-        # the #144 deadlock cannot block the now-gating OpenVINO-only step
-        # above. `timeout-minutes` fast-fails any residual hang. ORT_DYLIB_PATH
-        # points OrtBackend's load-dynamic at libonnxruntime.so; LD_LIBRARY_PATH
-        # (OpenVINO) still comes from the install step via $GITHUB_ENV.
+        # through parko-onnx's OrtBackend and compares it to OpenVINO's, so it
+        # shares parko-onnx's ort init path (#144). It is kept ISOLATED in its
+        # own STEP-LEVEL continue-on-error so that, until the ort downgrade is
+        # confirmed to clear the init deadlock here too, it cannot block the
+        # now-gating OpenVINO-only step above. Once the rc.11 downgrade is
+        # proven to green this test in CI, this step can be promoted to gating
+        # (drop continue-on-error). `timeout-minutes` fast-fails any residual
+        # hang. ORT_DYLIB_PATH points OrtBackend's load-dynamic at
+        # libonnxruntime.so; LD_LIBRARY_PATH (OpenVINO) still comes from the
+        # install step via $GITHUB_ENV.
         continue-on-error: true
         timeout-minutes: 10
         working-directory: parko
         env:
           ORT_DYLIB_PATH: ${{ env.HOME }}/.local/onnxruntime/lib/libonnxruntime.so
           RUST_BACKTRACE: "1"
-        run: cargo test -p parko-openvino ort_ov_output_equivalence_on_mnist -- --nocapture --test-threads=1
+        run: cargo test -p parko-openvino ort_ov_output_equivalence_on_mnist -- --nocapture
 
 
   static-analysis:

--- a/parko/README.md
+++ b/parko/README.md
@@ -50,7 +50,7 @@ The workspace contains three crates:
 
 | Backend | Crate | Hardware | Runtime install | Status |
 |---|---|---|---|---|
-| ONNX Runtime CPU | `parko-onnx` | any x86 CPU | `libonnxruntime.so` + `ORT_DYLIB_PATH` (v1.24.2) | ✅ full |
+| ONNX Runtime CPU | `parko-onnx` | any x86 CPU | `libonnxruntime.so` + `ORT_DYLIB_PATH` (v1.23.2) | ✅ full |
 | Intel OpenVINO | `parko-openvino` | any x86 Intel CPU | `libopenvino_c.so` from the Intel apt repo (`openvino-2024.x`) | ✅ full (CPU; `cargo build` does not require the toolkit) |
 | TensorRT (NVIDIA) | — | NVIDIA GPU | — | planned (PARK-020) |
 | Qualcomm QNN | — | Qualcomm NPU | — | planned (PARK-027) |
@@ -73,15 +73,17 @@ cargo test --workspace
 
 parko-onnx uses the `ort` crate with the `load-dynamic` feature. This requires `libonnxruntime.so` to be available at runtime, pointed to by `ORT_DYLIB_PATH`.
 
-Version matters. `ort 2.0.0-rc.12` is compiled against `ORT_API_VERSION = 24`. ONNX Runtime follows the convention `v1.N.x → API version N`, so you need ONNX Runtime v1.24.x. Older versions will cause a deadlock in the ort error handling path (a known bug in ort 2.0.0-rc.12 that requires the matching runtime to avoid).
+Version matters. `ort 2.0.0-rc.11` is compiled against `ORT_API_VERSION = 23`. ONNX Runtime follows the convention `v1.N.x → API version N`, so you need ONNX Runtime v1.23.x; the pinned minor is v1.23.2. The `ort`/runtime pair must move in lockstep — a mismatch deadlocks in the ort error path.
 
-Install ONNX Runtime v1.24.2 to a known location:
+> **Note (#144):** the previous pin, `ort 2.0.0-rc.12` + ONNX Runtime 1.24.2, deadlocked at `OrtBackend::new` in CI even single-threaded (a `--test-threads=1` run hung at the first init before printing anything). The downgrade to rc.11 / 1.23.2 is the fix under validation.
+
+Install ONNX Runtime v1.23.2 to a known location:
 
 ```bash
-curl -L -o /tmp/onnxruntime-1.24.2.tgz \
-  https://github.com/microsoft/onnxruntime/releases/download/v1.24.2/onnxruntime-linux-x64-1.24.2.tgz
+curl -L -o /tmp/onnxruntime-1.23.2.tgz \
+  https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-linux-x64-1.23.2.tgz
 mkdir -p ~/.local/onnxruntime
-tar -xzf /tmp/onnxruntime-1.24.2.tgz -C ~/.local/onnxruntime --strip-components=1
+tar -xzf /tmp/onnxruntime-1.23.2.tgz -C ~/.local/onnxruntime --strip-components=1
 ```
 
 Run the tests with `ORT_DYLIB_PATH` set:
@@ -254,7 +256,7 @@ If a `SafetyGovernor` is attached via `InferenceLoop::with_governor()`, it runs 
 - Thermal monitoring reads `/sys/class/thermal/thermal_zone0/temp` and returns `None` on platforms without that path. Non-Linux platforms have no thermal awareness today.
 - The built-in degraded-mode policy clamps linear velocity to a hardcoded ceiling (1.5 m/s) when no `SafetyGovernor` is attached. When a governor is attached via `with_governor()`, the built-in clamp is suppressed and the governor has full authority over command modification.
 - The `Mutex<Session>` serialization means parko-onnx is single-inference-at-a-time per backend instance. Multiple models or concurrent inference would require multiple backend instances.
-- ONNX Runtime via `ort 2.0.0-rc.12` has a re-entrant Once-lock deadlock in its error handling path when `ORT_API_VERSION` mismatch occurs. Pinning to the matching runtime version (v1.24.x) avoids triggering it, but the bug exists.
+- ONNX Runtime via `ort` is sensitive to the `ort`/runtime version pair: an `ORT_API_VERSION` mismatch deadlocks in the error path, and `ort 2.0.0-rc.12` + ONNX Runtime 1.24.2 additionally deadlocked at init in CI (#144). The pin is now `ort 2.0.0-rc.11` + ONNX Runtime v1.23.x (v1.23.2), kept in lockstep.
 - parko-kirra bridges only the linear velocity dimension to the Kirra kinematics contract. Angular velocity is not currently enforced. See `crates/parko-kirra/README.md` for details.
 
 ## License

--- a/parko/crates/parko-onnx/Cargo.toml
+++ b/parko/crates/parko-onnx/Cargo.toml
@@ -13,4 +13,9 @@ parko-core = { path = "../parko-core" }
 # — see #144. rc.11 added "immediate dylib loading with error detection" and
 # is the next-newest release; the ci.yml ONNX Runtime install is pinned to the
 # matching 1.23.2 in lockstep.
-ort = { version = "2.0.0-rc.11", features = ["load-dynamic"] }
+#
+# The `=` is REQUIRED, not stylistic: a caret requirement ("2.0.0-rc.11")
+# matches any *higher* pre-release of the same 2.0.0 (Cargo pre-release
+# semantics), so it silently resolves back to rc.12 on a fresh CI checkout
+# (parko/Cargo.lock is gitignored). `=2.0.0-rc.11` forces exactly rc.11.
+ort = { version = "=2.0.0-rc.11", features = ["load-dynamic"] }

--- a/parko/crates/parko-onnx/Cargo.toml
+++ b/parko/crates/parko-onnx/Cargo.toml
@@ -7,4 +7,10 @@ license = "Apache-2.0"
 
 [dependencies]
 parko-core = { path = "../parko-core" }
-ort = { version = "2.0.0-rc.12", features = ["load-dynamic"] }
+# ort 2.0.0-rc.11 (ONNX Runtime 1.23.2, ORT_API_VERSION = 23). Downgraded
+# from rc.12 (ONNX Runtime 1.24.x): rc.12 DEADLOCKS at OrtBackend::new in CI
+# even single-threaded (one test, --test-threads=1, hangs before any output)
+# — see #144. rc.11 added "immediate dylib loading with error detection" and
+# is the next-newest release; the ci.yml ONNX Runtime install is pinned to the
+# matching 1.23.2 in lockstep.
+ort = { version = "2.0.0-rc.11", features = ["load-dynamic"] }


### PR DESCRIPTION
## What
Replaces the apt-based OpenVINO install in the `parko-openvino` CI job with the **official OpenVINO ≥ 2025.1 release archive**, fixing #143.

## Why (openvino-rs#167 — protective gate, not a quirk)
`openvino-rs` **rejects OpenVINO < 2025.1**: `ov_element_type_e` changed incompatibly in 2025.1, so an older runtime would silently create wrong-type tensors. The apt `openvino-2024.5.0` package fails this check ("version too old"), which is why `OvBackend::new` panics in the three OpenVINO-only tests. The gate is **not bypassed** (no `OPENVINO_SKIP_LINKING`/force-accept — that only makes the crate *build*; inference stays broken); it's satisfied by installing ≥ 2025.1.

## Change (parko-openvino job only)
- Install the official **OpenVINO 2025.1 archive** (`ubuntu24`, matching `ubuntu-latest`). The exact build id isn't derivable, so the step **resolves the tarball name from the storage directory listing** rather than hard-coding it; extracts to `/opt/intel/openvino_2025`; runs `install_openvino_dependencies.sh`.
- **Cross the per-step-shell boundary:** `source setupvars.sh` and write `INTEL_OPENVINO_DIR` + `LD_LIBRARY_PATH` to `$GITHUB_ENV` so the cargo step (a fresh shell) discovers the archive libs. Removed the stale apt `OPENVINO_LIBDIR` export and the test step's `LD_LIBRARY_PATH` override (a step-level `env:` would shadow the `$GITHUB_ENV` value).
- `continue-on-error: true` **kept on** — can't be proven green locally (authored 403-blocked from `storage.openvinotoolkit.org`); this PR's CI run is the validation.

## Expected outcome (read the parko-openvino job, not the overall run)
- ✅ The 3 OpenVINO-only tests should now PASS: `openvino_smoke_mnist_inference_runs_and_outputs_finite`, `openvino_descriptor_is_intel_openvino`, `openvino_capabilities_match_cpu_baseline` (they failed only because `OvBackend::new` was rejected as "version too old").
- ⏳ `ort_ov_output_equivalence_on_mnist` will **STILL hang** on the separate `ort` 2.0.0-rc.12 init deadlock (#144) and be caught by `timeout-minutes` — **this is not a failure of this fix.** (`parko-onnx` on this branch is unrelated and still red for #144.)

## Honest limits / not for merge
- The archive URL + install are **unverified in-sandbox** (403). If 2025.1 isn't the right pin for the runner, bump `OPENVINO_VER` (e.g. 2025.4) — the listing-resolution handles the build id.
- **Do not merge / do not remove `continue-on-error` yet.** Follow-up: once the 3 OpenVINO-only tests are confirmed green in this run AND the equivalence/`ort` #144 coupling is resolved or the test is gated separately, remove `continue-on-error` to restore gating.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv)_