### PR TITLE
ci: auto-cancel superseded runs + job timeouts (stop orphaned-run pileups)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,23 @@ on:
 permissions:
   contents: read
 
+# Auto-cancel superseded runs. Without this, every push to a PR (or main)
+# leaves the prior run churning — they don't share a concurrency group, so
+# nothing cancels them and they pile up holding runners until they finally
+# time out. Group per workflow + ref so each PR/branch keeps only its newest
+# run; `cancel-in-progress` reaps the rest the moment a new commit lands.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # Job-level fast-fail guard so a hung run can't linger for hours holding
+    # runners (the parko-onnx/openvino test STEPS already have their own
+    # timeout-minutes; these are the previously-unbounded jobs).
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -24,6 +37,7 @@ jobs:
   coverage:
     name: Branch Coverage (MC/DC pending — issue #65)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -55,6 +69,7 @@ jobs:
   wcet-gate:
     name: WCET Gate (non-instrumented timing)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -67,6 +82,7 @@ jobs:
   parko-safety:
     name: Parko Safety Tests (no ROS, no ORT)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -299,6 +315,7 @@ jobs:
   static-analysis:
     name: Static Analysis (ISO 26262)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Why
PR #145 left **9 workflow runs (#84–#92) stuck "in progress"** on one branch. Root cause: `ci.yml` has no `concurrency` group, so each push to the PR never cancelled the prior run — they piled up and held runners (and several jobs have no `timeout-minutes`, so a stuck run can linger for hours rather than fast-failing).

This is purely run-lifecycle hygiene — **no change to what any job does or gates.**

## Changes
- **`concurrency` group** (`${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`): a new commit on a PR/branch now reaps that ref's older in-progress runs automatically.
- **Job-level `timeout-minutes`** on the previously-unbounded jobs: `test` 20, `coverage` 30, `wcet-gate` 15, `parko-safety` 15, `static-analysis` 20. `parko-onnx` / `parko-openvino` already bound their long test steps at the step level.

## Note
This addresses the `parko-safety` "hang guard" half of the tech-debt recorded in #146 (the allowlist half is separate). It does **not** retroactively cancel the existing 9 orphaned runs on the merged `ci/openvino-archive-install` branch — those need the branch deleted (which cancels them) or a manual cancel, since the automation here lacks `actions: write`.

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv)_