### PR TITLE
feat(parko-ros2): Odom/IMU/Radar scalar extraction shims (pure cores …

### DIFF
--- a/parko/crates/parko-ros2/src/imu_shim.rs
+++ b/parko/crates/parko-ros2/src/imu_shim.rs
@@ -1,0 +1,148 @@
+// parko/crates/parko-ros2/src/imu_shim.rs
+//
+// sensor_msgs/Imu → ImuSample extraction shim — the deferred ROS half of the IMU
+// mapping. PURE field-copy CORE (no r2r, always compiled, unit-tested) + a THIN
+// r2r ADAPTER (`#[cfg(feature = "ros2")]`, extraction only).
+//
+// SAFETY FRAMING. Upstream of the IMU transform → model → governor. The
+// transform already fail-closes on non-finite values, so this shim stays thin.
+// The two things it MUST get right are MEANING-preserving:
+//   1. ORIENTATION AVAILABILITY — `sensor_msgs/Imu` signals "orientation not
+//      provided" via `orientation_covariance[0] == -1.0`. In that case the shim
+//      emits `None`. It NEVER fabricates an identity quaternion: identity would
+//      assert "level + facing forward", a false attitude — exactly the hazard
+//      the IMU transform's fail-closed path guards. This is the load-bearing
+//      shim behavior; both branches are tested.
+//   2. QUATERNION ORDER — `{x,y,z,w}` → `Quaternion{x,y,z,w}` verbatim (pinned).
+//
+// f64→f32 NARROWING (FLAGGED — narrow-and-pass): the ROS message is f64, the
+// transform input is f32. The shim narrows and passes; it does NOT add a second
+// non-finite gate. A huge finite f64 narrows to f32 `Inf`, which the IMU
+// transform's EXISTING non-finite check rejects — so a second gate here would be
+// redundant. Keeping the shim thin is deliberate.
+//
+// MIRROR / MERGE NOTE: `ImuSample` + `Quaternion` live on the (unmerged)
+// feat/parko-imu-mapping branch, so they are MIRRORED here (byte-identical) so
+// this shim compiles standalone off `main`. When the IMU mapping lands, delete
+// these mirrors and `use crate::sensor_mapping::{ImuSample, Quaternion};`.
+
+/// MIRROR of feat/parko-imu-mapping's `Quaternion` (ROS order x,y,z,w, f32).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Quaternion {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
+}
+
+/// MIRROR of feat/parko-imu-mapping's `ImuSample` (the transform input).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ImuSample {
+    pub linear_acceleration: [f32; 3],
+    pub angular_velocity: [f32; 3],
+    /// `None` when the sensor reports orientation unavailable — never fabricated.
+    pub orientation: Option<Quaternion>,
+}
+
+/// Plain mirror of the `sensor_msgs/Imu` fields the shim reads — r2r-free.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ImuRawFields {
+    /// `linear_acceleration` {x, y, z} (m/s²).
+    pub linear_acceleration: [f64; 3],
+    /// `angular_velocity` {x, y, z} (rad/s).
+    pub angular_velocity: [f64; 3],
+    /// `orientation` in `[x, y, z, w]` order.
+    pub orientation_xyzw: [f64; 4],
+    /// `orientation_covariance[0]`. `-1.0` = orientation not provided (ROS
+    /// convention).
+    pub orientation_covariance0: f64,
+}
+
+fn narrow3(v: [f64; 3]) -> [f32; 3] {
+    // narrow-and-pass: out-of-f32-range values become ±Inf and are rejected by
+    // the transform's non-finite check (no second gate here — see module docs).
+    [v[0] as f32, v[1] as f32, v[2] as f32]
+}
+
+/// Pure field copy + orientation-availability decision into the transform's
+/// `ImuSample`. No value validation beyond the availability convention.
+#[must_use]
+pub fn imu_to_sample(raw: &ImuRawFields) -> ImuSample {
+    let orientation = if raw.orientation_covariance0 == -1.0 {
+        // Orientation not provided — NEVER fabricate identity.
+        None
+    } else {
+        Some(Quaternion {
+            x: raw.orientation_xyzw[0] as f32,
+            y: raw.orientation_xyzw[1] as f32,
+            z: raw.orientation_xyzw[2] as f32,
+            w: raw.orientation_xyzw[3] as f32,
+        })
+    };
+    ImuSample {
+        linear_acceleration: narrow3(raw.linear_acceleration),
+        angular_velocity: narrow3(raw.angular_velocity),
+        orientation,
+    }
+}
+
+/// THIN r2r ADAPTER — extraction only. Compiles only under `--features ros2`.
+#[cfg(feature = "ros2")]
+pub fn imu_msg_to_sample(msg: &r2r::sensor_msgs::msg::Imu) -> ImuSample {
+    let a = &msg.linear_acceleration;
+    let g = &msg.angular_velocity;
+    let o = &msg.orientation;
+    imu_to_sample(&ImuRawFields {
+        linear_acceleration: [a.x, a.y, a.z],
+        angular_velocity: [g.x, g.y, g.z],
+        orientation_xyzw: [o.x, o.y, o.z, o.w],
+        orientation_covariance0: msg.orientation_covariance[0],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(cov0: f64) -> ImuRawFields {
+        ImuRawFields {
+            linear_acceleration: [1.5, -2.5, 9.81],
+            angular_velocity: [0.1, -0.2, 0.3],
+            orientation_xyzw: [0.11, 0.22, 0.33, 0.44], // asymmetric → order pinned
+            orientation_covariance0: cov0,
+        }
+    }
+
+    #[test]
+    fn covariance_minus_one_yields_no_orientation() {
+        // ROS "orientation not provided" — must be None, never identity.
+        let s = imu_to_sample(&raw(-1.0));
+        assert_eq!(s.orientation, None);
+    }
+
+    #[test]
+    fn orientation_present_lands_in_xyzw_order() {
+        let s = imu_to_sample(&raw(0.0)); // cov0 != -1 → orientation present
+        assert_eq!(
+            s.orientation,
+            Some(Quaternion { x: 0.11, y: 0.22, z: 0.33, w: 0.44 })
+        );
+    }
+
+    #[test]
+    fn accel_and_gyro_narrow_f64_to_f32() {
+        let s = imu_to_sample(&raw(0.0));
+        assert_eq!(s.linear_acceleration, [1.5_f32, -2.5, 9.81]);
+        assert_eq!(s.angular_velocity, [0.1_f32, -0.2, 0.3]);
+    }
+
+    #[test]
+    fn out_of_f32_range_narrows_to_inf_for_the_transform_to_reject() {
+        // narrow-and-pass: 1e300 (finite f64) → f32 Inf; the shim does NOT gate
+        // it — the transform's non-finite check does.
+        let mut r = raw(0.0);
+        r.linear_acceleration = [1e300, 0.0, 0.0];
+        let s = imu_to_sample(&r);
+        assert!(s.linear_acceleration[0].is_infinite());
+    }
+}

--- a/parko/crates/parko-ros2/src/lib.rs
+++ b/parko/crates/parko-ros2/src/lib.rs
@@ -23,7 +23,10 @@
 pub mod command_mapping;
 pub mod comparator_adapter;
 pub mod config;
+pub mod imu_shim;
+pub mod odometry_shim;
 pub mod posture_state;
+pub mod radar_shim;
 pub mod sensor_mapping;
 pub mod tick_pipeline;
 

--- a/parko/crates/parko-ros2/src/odometry_shim.rs
+++ b/parko/crates/parko-ros2/src/odometry_shim.rs
@@ -1,0 +1,97 @@
+// parko/crates/parko-ros2/src/odometry_shim.rs
+//
+// nav_msgs/Odometry → OdomSample extraction shim — the deferred ROS half of the
+// odometry mapping. PURE field-copy CORE (no r2r, always compiled, unit-tested)
+// + a THIN r2r ADAPTER (`#[cfg(feature = "ros2")]`, extraction only).
+//
+// SAFETY FRAMING. The shim is upstream of the odom transform → model → governor.
+// The transform already fail-closes on non-finite values, so this shim stays
+// thin (no value validation here). What it must get right is MEANING: the
+// quaternion component order. The r2r `geometry_msgs/Quaternion` is `{x,y,z,w}`
+// and `OdomSample.orientation_xyzw` is `[x, y, z, w]` — a direct order copy, but
+// a silent reorder would scramble every orientation, so the order is pinned by
+// test.
+//
+// FRAME NOTE (FLAGGED): a `nav_msgs/Odometry` carries pose in the odom/world
+// frame and twist in the child (body) frame. This shim copies BOTH VERBATIM —
+// it does NOT transform frames. The transform / model owns frame expectations;
+// the shim only moves fields.
+//
+// OdomSample is IN MAIN, so this references `crate::sensor_mapping::OdomSample`
+// directly — no mirror, no collapse-at-merge.
+
+use crate::sensor_mapping::OdomSample;
+
+/// Plain mirror of the `nav_msgs/Odometry` fields `OdomSample` needs — r2r-free,
+/// so the field mapping is unit-testable without a ROS environment.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OdometryRawFields {
+    /// `pose.pose.position` {x, y, z}.
+    pub position: [f64; 3],
+    /// `pose.pose.orientation` in `[x, y, z, w]` order.
+    pub orientation_xyzw: [f64; 4],
+    /// `twist.twist.linear` {x, y, z}.
+    pub linear_velocity: [f64; 3],
+    /// `twist.twist.angular` {x, y, z}.
+    pub angular_velocity: [f64; 3],
+}
+
+/// Pure field copy into the transform's `OdomSample`. No narrowing (both f64),
+/// no frame transform, no value validation (the transform owns that).
+#[must_use]
+pub fn odometry_to_sample(raw: &OdometryRawFields) -> OdomSample {
+    OdomSample {
+        position: raw.position,
+        // [x, y, z, w] verbatim — DO NOT reorder (pinned by test).
+        orientation_xyzw: raw.orientation_xyzw,
+        linear_velocity: raw.linear_velocity,
+        angular_velocity: raw.angular_velocity,
+    }
+}
+
+/// THIN r2r ADAPTER — extraction only. Pulls the raw fields off the r2r message
+/// and calls the pure fn. Compiles only under `--features ros2` in a ROS env.
+#[cfg(feature = "ros2")]
+pub fn odometry_msg_to_sample(msg: &r2r::nav_msgs::msg::Odometry) -> OdomSample {
+    let p = &msg.pose.pose.position;
+    let o = &msg.pose.pose.orientation;
+    let l = &msg.twist.twist.linear;
+    let a = &msg.twist.twist.angular;
+    odometry_to_sample(&OdometryRawFields {
+        position: [p.x, p.y, p.z],
+        orientation_xyzw: [o.x, o.y, o.z, o.w],
+        linear_velocity: [l.x, l.y, l.z],
+        angular_velocity: [a.x, a.y, a.z],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Asymmetric input so any field swap or quaternion reorder is visible.
+    fn raw() -> OdometryRawFields {
+        OdometryRawFields {
+            position: [1.0, 2.0, 3.0],
+            orientation_xyzw: [0.1, 0.2, 0.3, 0.4], // x,y,z,w — all distinct
+            linear_velocity: [4.0, 5.0, 6.0],
+            angular_velocity: [7.0, 8.0, 9.0],
+        }
+    }
+
+    #[test]
+    fn quaternion_lands_in_xyzw_order() {
+        let s = odometry_to_sample(&raw());
+        // A reorder (e.g. w,x,y,z) would make this fail.
+        assert_eq!(s.orientation_xyzw, [0.1, 0.2, 0.3, 0.4]);
+    }
+
+    #[test]
+    fn fields_copied_to_correct_slots() {
+        let s = odometry_to_sample(&raw());
+        assert_eq!(s.position, [1.0, 2.0, 3.0]);
+        assert_eq!(s.linear_velocity, [4.0, 5.0, 6.0]);
+        assert_eq!(s.angular_velocity, [7.0, 8.0, 9.0]);
+        // Distinct blocks → a position/linear/angular swap would be caught above.
+    }
+}

--- a/parko/crates/parko-ros2/src/radar_shim.rs
+++ b/parko/crates/parko-ros2/src/radar_shim.rs
@@ -1,0 +1,133 @@
+// parko/crates/parko-ros2/src/radar_shim.rs
+//
+// radar_msgs/RadarScan → Vec<RadarDetection> extraction shim — the deferred ROS
+// half of the radar mapping. PURE field-copy CORE (no r2r, always compiled,
+// unit-tested) + a THIN r2r ADAPTER (`#[cfg(feature = "ros2")]`, extraction
+// only).
+//
+// SAFETY FRAMING. Upstream of the radar transform → model → governor. The
+// transform already fail-closes on non-finite values, so this shim stays thin.
+// What it must get right is the FIELD MAPPING — a wrong column feeds the model
+// the wrong quantity (a confidently-wrong, in-bounds corruption). Two names
+// change and are flagged:
+//   - `doppler_velocity` → `velocity` (the Doppler radial velocity, radar's key
+//     signal — must not be dropped or swapped).
+//   - `amplitude` → `rcs` (amplitude is the return-strength proxy for radar
+//     cross-section; the name change is intentional, documented here).
+//
+// MESSAGE CHOICE (FLAGGED): target `radar_msgs/RadarScan` — the DETECTION list,
+// which matches the radar transform's detection-list input. `radar_msgs/
+// RadarTracks` is the object-level alternative and maps differently (tracked
+// objects, not raw detections); it is a SEPARATE future shim, not handled here.
+//
+// 2D RADAR: `RadarScan` always carries an `elevation` field, so the shim passes
+// `Some(elevation)`. It does NOT decide 2D-ness — the transform's
+// `ElevationPolicy` owns that interpretation; the shim only moves the field.
+//
+// MIRROR / MERGE NOTE: `RadarDetection` lives on the (unmerged)
+// feat/parko-radar-mapping branch, so it is MIRRORED here (byte-identical) so
+// this shim compiles standalone off `main`. When the radar mapping lands, delete
+// the mirror and `use crate::sensor_mapping::RadarDetection;`.
+
+/// MIRROR of feat/parko-radar-mapping's `RadarDetection` (the transform input).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RadarDetection {
+    pub range: f32,
+    pub azimuth: f32,
+    pub elevation: Option<f32>,
+    pub velocity: f32,
+    pub rcs: f32,
+}
+
+/// Plain mirror of one `radar_msgs/RadarReturn`'s relevant fields — r2r-free.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RadarReturnRaw {
+    pub range: f32,
+    pub azimuth: f32,
+    pub elevation: f32,
+    pub doppler_velocity: f32,
+    pub amplitude: f32,
+}
+
+/// Pure field copy of one return into the transform's `RadarDetection`. The two
+/// renamed fields (Doppler→velocity, amplitude→rcs) are the mapping that must
+/// not be mis-wired.
+#[must_use]
+pub fn radar_return_to_detection(r: &RadarReturnRaw) -> RadarDetection {
+    RadarDetection {
+        range: r.range,
+        azimuth: r.azimuth,
+        // RadarScan always carries elevation; the transform's ElevationPolicy
+        // decides 2D interpretation — the shim just passes Some, never decides.
+        elevation: Some(r.elevation),
+        velocity: r.doppler_velocity, // Doppler radial velocity
+        rcs: r.amplitude,             // amplitude = RCS proxy
+    }
+}
+
+/// Pure scan → detection list. Preserves COUNT and ORDER (none lost, duplicated,
+/// or reordered).
+#[must_use]
+pub fn radar_scan_to_detections(returns: &[RadarReturnRaw]) -> Vec<RadarDetection> {
+    returns.iter().map(radar_return_to_detection).collect()
+}
+
+/// THIN r2r ADAPTER — extraction only. Compiles only under `--features ros2`.
+#[cfg(feature = "ros2")]
+pub fn radar_scan_msg_to_detections(
+    msg: &r2r::radar_msgs::msg::RadarScan,
+) -> Vec<RadarDetection> {
+    let raws: Vec<RadarReturnRaw> = msg
+        .returns
+        .iter()
+        .map(|r| RadarReturnRaw {
+            range: r.range,
+            azimuth: r.azimuth,
+            elevation: r.elevation,
+            doppler_velocity: r.doppler_velocity,
+            amplitude: r.amplitude,
+        })
+        .collect();
+    radar_scan_to_detections(&raws)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Distinct values per field so a mis-map (esp. doppler→velocity,
+    /// amplitude→rcs) is visible.
+    fn ret(range: f32, az: f32, el: f32, dop: f32, amp: f32) -> RadarReturnRaw {
+        RadarReturnRaw { range, azimuth: az, elevation: el, doppler_velocity: dop, amplitude: amp }
+    }
+
+    #[test]
+    fn return_maps_to_correct_detection_fields() {
+        let d = radar_return_to_detection(&ret(10.0, 0.5, 0.25, -3.0, 42.0));
+        assert_eq!(d.range, 10.0);
+        assert_eq!(d.azimuth, 0.5);
+        assert_eq!(d.elevation, Some(0.25));
+        assert_eq!(d.velocity, -3.0, "doppler_velocity must map to velocity");
+        assert_eq!(d.rcs, 42.0, "amplitude must map to rcs");
+    }
+
+    #[test]
+    fn multi_return_scan_preserves_count_and_order() {
+        let scan = vec![
+            ret(1.0, 0.1, 0.0, 1.0, 11.0),
+            ret(2.0, 0.2, 0.0, 2.0, 22.0),
+            ret(3.0, 0.3, 0.0, 3.0, 33.0),
+        ];
+        let out = radar_scan_to_detections(&scan);
+        assert_eq!(out.len(), 3, "no return lost or duplicated");
+        // same order: range 1,2,3 with the matching velocity/rcs.
+        assert_eq!(out[0].range, 1.0);
+        assert_eq!(out[1].velocity, 2.0);
+        assert_eq!(out[2].rcs, 33.0);
+    }
+
+    #[test]
+    fn empty_scan_yields_empty_list() {
+        assert!(radar_scan_to_detections(&[]).is_empty());
+    }
+}


### PR DESCRIPTION
…+ r2r adapters)

The deferred ROS halves of the odom, IMU, and radar mappings, batched. Same template as the PointCloud2/Image shims: each is a PURE field-copy CORE (no r2r, always compiled, unit-tested) + a THIN r2r ADAPTER (ros2-gated, extraction only). These are field copies (no binary parsing), so they stay thin and do NOT duplicate the transforms' non-finite validation — they copy/narrow and let the transform validate. What they get right is meaning-preservation.

ODOM (references in-main OdomSample, no mirror; f64→f64):
- position ← pose.pose.position; orientation_xyzw ← pose.pose.orientation in [x,y,z,w] order (verbatim — pinned by test); linear/angular ← twist.twist.*.
- FLAGGED: pose is odom/world frame, twist is body frame; the shim copies verbatim and does NOT transform frames (transform owns frame expectations).

IMU (MIRRORS ImuSample + Quaternion; f64→f32):
- accel/gyro ← msg fields as f32; orientation: cov[0]==-1.0 → None (ROS "not provided") else Some(Quaternion{x,y,z,w}). NEVER fabricates identity — that asserts a false attitude (the load-bearing behavior; both branches tested).
- FLAGGED narrow-and-pass: f64→f32 narrowing only; a huge finite f64 → f32 Inf, which the IMU transform's existing non-finite check rejects. No second gate.

RADAR (MIRRORS RadarDetection; f32→f32):
- targets radar_msgs/RadarScan (detection list); RadarTracks is a separate future shim (FLAGGED). Per return: range/azimuth ← same; elevation ← Some(elevation) (shim passes; transform's ElevationPolicy decides 2D); velocity ← doppler_velocity; rcs ← amplitude (amplitude = RCS proxy, FLAGGED name change). Scan → same-length, same-order Vec.

Fail-closed: shims keep no value validation; the transforms own it (incl. quaternion-norm — a non-unit/all-zero quaternion is passed through, the transform validates norm). No shim-level error types added.

Tests (pure, no ROS; 9): odom quaternion-order + field-slot copies (asymmetric input so a swap/reorder fails); IMU None-vs-Some + xyzw order + f64→f32 narrow + out-of-range→Inf; radar field-map (doppler→velocity, amplitude→rcs, distinct values) + elevation→Some + multi-return count/order. parko-ros2 78 green; default build clean (r2r adapters compile only under --features ros2 in a ROS env, not run here).

Additive — three independent modules with their own raw-fields structs. Odom is clean (in-main OdomSample); IMU/Radar mirror their on-branch input types and collapse after those mappings land (delete mirror, use crate::sensor_mapping::*).

Not merged.

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv