### PR TITLE
feat(parko-tensorrt): PARK-021 TensorRT backend scaffold (A1, CI-buildable)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,21 @@ jobs:
           RUST_BACKTRACE: "1"
         run: cargo test -p parko-onnx -- --nocapture
 
+      - name: parko-tensorrt fail-closed test (PARK-021, GATING)
+        # Reuses the CPU-only ONNX Runtime installed above (ORT_DYLIB_PATH from
+        # $GITHUB_ENV). This build of ORT has NO TensorRT execution provider, so
+        # registering the TRT EP (with `.error_on_failure()`) must make
+        # TrtBackend::with_config return Err — proving the safety-critical
+        # "no silent CPU fallback" on the very environment that lacks TensorRT.
+        # The test self-skips only when the ORT lib FILE is absent (it is present
+        # here), so it asserts in this job. Real TRT inference is Jetson-gated and
+        # not run on CI; the TensorRTStubBackend remains the CI runtime fallback.
+        timeout-minutes: 10
+        working-directory: parko
+        env:
+          RUST_BACKTRACE: "1"
+        run: cargo test -p parko-tensorrt --test fail_closed -- --nocapture
+
   parko-openvino:
     name: Parko OpenVINO Backend Tests (pip openvino-2025.1)
     runs-on: ubuntu-latest

--- a/parko/Cargo.toml
+++ b/parko/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/parko-core", "crates/parko-onnx", "crates/parko-kirra", "crates/parko-ros2", "crates/parko-openvino"]
+members = ["crates/parko-core", "crates/parko-onnx", "crates/parko-kirra", "crates/parko-ros2", "crates/parko-openvino", "crates/parko-tensorrt"]
 resolver = "2"
 
 [profile.release]

--- a/parko/crates/parko-onnx/src/lib.rs
+++ b/parko/crates/parko-onnx/src/lib.rs
@@ -1,20 +1,18 @@
 // crates/parko-onnx/src/lib.rs
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-
-use ort::{
-    session::{builder::GraphOptimizationLevel, Session},
-    value::{Tensor, ValueType},
-};
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
 
 use parko_core::backend::{
     BackendCapabilities, BackendError, InferenceBackend, InferenceThreads, ModelHandle,
-    PrecisionMode, TensorBatch, TensorStorage,
+    TensorBatch,
 };
 
+pub mod session_core;
+use session_core::OrtRunCore;
+
 pub struct OrtBackend {
-    session: Arc<Mutex<Session>>,
+    core: OrtRunCore,
 }
 
 impl OrtBackend {
@@ -52,106 +50,23 @@ impl OrtBackend {
             "OrtBackend execution posture"
         );
 
+        // The CPU backend keeps its model_id identity ("ort_native_cpu"); the
+        // shared core single-sources the load_model/run logic.
         Ok(Self {
-            session: Arc::new(Mutex::new(session)),
+            core: OrtRunCore::new(session, "ort_native_cpu"),
         })
     }
 }
 
 impl InferenceBackend for OrtBackend {
     fn load_model(&self, path: &str) -> Result<ModelHandle, BackendError> {
-        let session = self.session.lock()
-            .map_err(|e| BackendError::InitializationError(format!("session lock poisoned: {}", e)))?;
-
-        let mut input_shapes = HashMap::new();
-        let mut output_shapes = HashMap::new();
-
-        for input in session.inputs() {
-            let shape: Vec<usize> = if let ValueType::Tensor { shape, .. } = input.dtype() {
-                shape.iter().map(|&d| d.max(1) as usize).collect()
-            } else {
-                vec![]
-            };
-            input_shapes.insert(input.name().to_string(), shape);
-        }
-
-        for output in session.outputs() {
-            let shape: Vec<usize> = if let ValueType::Tensor { shape, .. } = output.dtype() {
-                shape.iter().map(|&d| d.max(1) as usize).collect()
-            } else {
-                vec![]
-            };
-            output_shapes.insert(output.name().to_string(), shape);
-        }
-
-        Ok(ModelHandle {
-            model_id: format!("ort_native_cpu_session_from_{}", path),
-            input_shapes,
-            output_shapes,
-            expected_precision: PrecisionMode::FP32,
-        })
+        self.core.load_model(path)
     }
 
     fn run(&self, model: &ModelHandle, inputs: &TensorBatch)
         -> Result<TensorBatch<'static>, BackendError>
     {
-        let mut ort_inputs: Vec<(String, Tensor<f32>)> = Vec::new();
-
-        for (name, expected_shape) in &model.input_shapes {
-            let Some(storage) = inputs.named_tensors.get(name) else {
-                return Err(BackendError::ExecutionFailure(format!(
-                    "Missing input tensor '{}'", name
-                )));
-            };
-
-            let raw_slice = storage.as_slice();
-            let expected_len: usize = expected_shape.iter().product();
-
-            if raw_slice.len() != expected_len {
-                return Err(BackendError::DimensionMismatch {
-                    expected: expected_shape.clone(),
-                    actual: vec![raw_slice.len()],
-                });
-            }
-
-            let tensor = Tensor::from_array((expected_shape.clone(), raw_slice.to_vec()))
-                .map_err(|e| BackendError::ExecutionFailure(format!("ort tensor error: {:?}", e)))?;
-
-            ort_inputs.push((name.clone(), tensor));
-        }
-
-        let mut session = self.session.lock()
-            .map_err(|e| BackendError::ExecutionFailure(format!("session lock poisoned: {}", e)))?;
-
-        // Collect output names before run() borrows session mutably.
-        let output_names: Vec<String> = session.outputs().iter()
-            .map(|o| o.name().to_string())
-            .collect();
-
-        let outputs = session.run(ort_inputs)
-            .map_err(|e| BackendError::ExecutionFailure(format!("ort execution error: {:?}", e)))?;
-
-        let mut output_named_tensors = HashMap::new();
-
-        for name in &output_names {
-            let ort_value = outputs.get(name.as_str())
-                .ok_or_else(|| BackendError::ExecutionFailure(format!(
-                    "Missing output node '{}'", name
-                )))?;
-
-            let (_, raw_slice) = ort_value.try_extract_tensor::<f32>()
-                .map_err(|e| BackendError::ExecutionFailure(format!("tensor extract error: {:?}", e)))?;
-
-            output_named_tensors.insert(
-                name.clone(),
-                TensorStorage::Owned(raw_slice.to_vec()),
-            );
-        }
-
-        Ok(TensorBatch {
-            named_tensors: output_named_tensors,
-            metadata: HashMap::new(),
-        })
+        self.core.run(model, inputs)
     }
 
     fn capabilities(&self) -> BackendCapabilities {

--- a/parko/crates/parko-onnx/src/session_core.rs
+++ b/parko/crates/parko-onnx/src/session_core.rs
@@ -1,0 +1,146 @@
+// crates/parko-onnx/src/session_core.rs
+//
+// Shared ORT inference core (PARK-021, A1). The `load_model` + `run` logic is
+// IDENTICAL for every ort-backed backend — it operates on a committed
+// `ort::Session` regardless of whether that session runs on the CPU provider
+// (parko-onnx `OrtBackend`) or the TensorRT execution provider (parko-tensorrt
+// `TrtBackend`). The ONLY difference between those backends is how the session is
+// BUILT (thread/precision/EP config + which posture is logged), which stays in
+// each backend's constructor. This module holds the part they share.
+//
+// EXTRACTION IS PURE: the bodies below are relocated verbatim from `OrtBackend`;
+// the `model_id` prefix is parameterized so each backend keeps its own model_id
+// string while the inference logic is single-sourced. parko-onnx behavior is
+// unchanged (`OrtBackend` passes the original "ort_native_cpu" prefix).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use ort::{
+    session::Session,
+    value::{Tensor, ValueType},
+};
+
+use parko_core::backend::{
+    BackendError, ModelHandle, PrecisionMode, TensorBatch, TensorStorage,
+};
+
+/// Owns a committed `ort::Session` and runs the shared `load_model` / `run`
+/// inference path. Each backend builds its own session (CPU vs TRT EP) and hands
+/// it here; the inference logic below is single-sourced.
+pub struct OrtRunCore {
+    session: Arc<Mutex<Session>>,
+    /// Backend-specific model_id prefix (e.g. "ort_native_cpu" for the CPU
+    /// backend, "ort_trt" for the TensorRT backend) so each keeps its identity
+    /// while sharing the logic.
+    model_id_prefix: String,
+}
+
+impl OrtRunCore {
+    /// Wrap a committed session. `model_id_prefix` is the backend's identity tag
+    /// used in `load_model`'s `model_id`.
+    pub fn new(session: Session, model_id_prefix: impl Into<String>) -> Self {
+        Self {
+            session: Arc::new(Mutex::new(session)),
+            model_id_prefix: model_id_prefix.into(),
+        }
+    }
+
+    /// Read input/output shapes off the session into a `ModelHandle`. Relocated
+    /// verbatim from `OrtBackend::load_model`.
+    pub fn load_model(&self, path: &str) -> Result<ModelHandle, BackendError> {
+        let session = self.session.lock()
+            .map_err(|e| BackendError::InitializationError(format!("session lock poisoned: {}", e)))?;
+
+        let mut input_shapes = HashMap::new();
+        let mut output_shapes = HashMap::new();
+
+        for input in session.inputs() {
+            let shape: Vec<usize> = if let ValueType::Tensor { shape, .. } = input.dtype() {
+                shape.iter().map(|&d| d.max(1) as usize).collect()
+            } else {
+                vec![]
+            };
+            input_shapes.insert(input.name().to_string(), shape);
+        }
+
+        for output in session.outputs() {
+            let shape: Vec<usize> = if let ValueType::Tensor { shape, .. } = output.dtype() {
+                shape.iter().map(|&d| d.max(1) as usize).collect()
+            } else {
+                vec![]
+            };
+            output_shapes.insert(output.name().to_string(), shape);
+        }
+
+        Ok(ModelHandle {
+            model_id: format!("{}_session_from_{}", self.model_id_prefix, path),
+            input_shapes,
+            output_shapes,
+            expected_precision: PrecisionMode::FP32,
+        })
+    }
+
+    /// Run inference. Relocated verbatim from `OrtBackend::run`.
+    pub fn run(&self, model: &ModelHandle, inputs: &TensorBatch)
+        -> Result<TensorBatch<'static>, BackendError>
+    {
+        let mut ort_inputs: Vec<(String, Tensor<f32>)> = Vec::new();
+
+        for (name, expected_shape) in &model.input_shapes {
+            let Some(storage) = inputs.named_tensors.get(name) else {
+                return Err(BackendError::ExecutionFailure(format!(
+                    "Missing input tensor '{}'", name
+                )));
+            };
+
+            let raw_slice = storage.as_slice();
+            let expected_len: usize = expected_shape.iter().product();
+
+            if raw_slice.len() != expected_len {
+                return Err(BackendError::DimensionMismatch {
+                    expected: expected_shape.clone(),
+                    actual: vec![raw_slice.len()],
+                });
+            }
+
+            let tensor = Tensor::from_array((expected_shape.clone(), raw_slice.to_vec()))
+                .map_err(|e| BackendError::ExecutionFailure(format!("ort tensor error: {:?}", e)))?;
+
+            ort_inputs.push((name.clone(), tensor));
+        }
+
+        let mut session = self.session.lock()
+            .map_err(|e| BackendError::ExecutionFailure(format!("session lock poisoned: {}", e)))?;
+
+        // Collect output names before run() borrows session mutably.
+        let output_names: Vec<String> = session.outputs().iter()
+            .map(|o| o.name().to_string())
+            .collect();
+
+        let outputs = session.run(ort_inputs)
+            .map_err(|e| BackendError::ExecutionFailure(format!("ort execution error: {:?}", e)))?;
+
+        let mut output_named_tensors = HashMap::new();
+
+        for name in &output_names {
+            let ort_value = outputs.get(name.as_str())
+                .ok_or_else(|| BackendError::ExecutionFailure(format!(
+                    "Missing output node '{}'", name
+                )))?;
+
+            let (_, raw_slice) = ort_value.try_extract_tensor::<f32>()
+                .map_err(|e| BackendError::ExecutionFailure(format!("tensor extract error: {:?}", e)))?;
+
+            output_named_tensors.insert(
+                name.clone(),
+                TensorStorage::Owned(raw_slice.to_vec()),
+            );
+        }
+
+        Ok(TensorBatch {
+            named_tensors: output_named_tensors,
+            metadata: HashMap::new(),
+        })
+    }
+}

--- a/parko/crates/parko-tensorrt/Cargo.toml
+++ b/parko/crates/parko-tensorrt/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "parko-tensorrt"
+version = "0.1.0"
+edition = "2021"
+description = "TensorRT (NVIDIA Jetson) backend for parko-core via ort's TensorRT execution provider"
+license = "Apache-2.0"
+
+[dependencies]
+parko-core = { path = "../parko-core" }
+# Shared ORT session + load_model/run core, extracted from parko-onnx (PARK-021,
+# A1). parko-tensorrt differs from parko-onnx ONLY in the EP/precision config; the
+# inference path is identical, so it is reused, not duplicated.
+parko-onnx = { path = "../parko-onnx" }
+# Same ort + load-dynamic as parko-onnx. load-dynamic pulls ort-sys/disable-linking,
+# so this compiles with NO CUDA/TensorRT libraries present (CI has no GPU). The TRT
+# execution provider is registered at runtime against the dlopened libonnxruntime.so;
+# on a CPU-only ORT lib that registration FAILS (fail-closed), and on the Jetson's
+# TensorRT-enabled ORT it succeeds.
+ort = { version = "=2.0.0-rc.11", features = ["load-dynamic"] }
+tracing = "0.1"

--- a/parko/crates/parko-tensorrt/src/lib.rs
+++ b/parko/crates/parko-tensorrt/src/lib.rs
@@ -1,0 +1,316 @@
+// crates/parko-tensorrt/src/lib.rs
+//
+// PARK-021 — TensorRT backend (A1: distinct crate using ort's TensorRT execution
+// provider). Runs Parko accelerated on the ROSOrin's Jetson. CI-BUILDABLE ONLY:
+// it compiles with no GPU/CUDA/TRT libraries present (ort's `load-dynamic` pulls
+// `ort-sys/disable-linking`), but real inference requires a TensorRT-enabled ORT
+// runtime on NVIDIA silicon — see the PARK-021 Jetson-gated list at the bottom.
+//
+// REUSE: the load_model/run inference path is IDENTICAL to parko-onnx and is
+// single-sourced via `parko_onnx::session_core::OrtRunCore`. This crate differs
+// ONLY in how the session is built (the TRT execution provider + precision
+// config) and which posture is logged.
+//
+// FAIL-CLOSED (the load-bearing safety property): the TRT EP is registered with
+// `.error_on_failure()`. ort's default is to SILENTLY fall back to CPU when an EP
+// fails to register (confirmed in ort rc.11 `apply_execution_providers`); that is
+// exactly the silent-degradation hazard a safety path must reject. With
+// `error_on_failure`, a TRT-unavailable runtime (e.g. CI's CPU-only ORT lib)
+// makes `with_config` return `Err` — never a quiet CPU run.
+//
+// DETERMINISM HONESTY: GPU TensorRT is NOT bitwise-reproducible the way
+// single-thread CPU is, so this backend does NOT read `InferenceThreads`
+// (num_threads is a CPU concept). Its config anchor is `TrtPosture`. The safety
+// posture is "fixed engine + fixed precision + decision-agreement bound
+// (hardware-measured)", logged — not a bitwise-determinism claim.
+
+use ort::ep::TensorRT;
+use ort::session::Session;
+
+use parko_core::backend::{
+    BackendCapabilities, BackendDescriptor, BackendError, InferenceBackend, ModelHandle,
+    TensorBatch,
+};
+use parko_onnx::session_core::OrtRunCore;
+
+/// TF32 control state. Ampere+ GPUs (the Orin) may use TF32 for fp32 matmuls,
+/// silently dropping mantissa bits. ort's TensorRT EP exposes NO TF32 knob
+/// (confirmed in ort rc.11 source — `with_fp16`/`with_int8` exist, no TF32), so
+/// this backend CANNOT enforce TF32-off from Rust. This is an honest,
+/// not-yet-resolved precision gap, surfaced rather than hidden.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tf32Control {
+    /// TF32 is NOT enforced off here. Resolution is Jetson-gated (e.g. the
+    /// `NVIDIA_TF32_OVERRIDE=0` env override, measured against tolerance) or, if
+    /// it cannot be controlled, the A2 (native nvinfer) escalation trigger.
+    /// MUST NOT be read as "TF32 off / full precision guaranteed".
+    UnenforcedPendingJetsonResolution,
+}
+
+impl Tf32Control {
+    /// Honest one-line status for the init log. Deliberately does NOT say "off".
+    #[must_use]
+    pub fn status_str(self) -> &'static str {
+        match self {
+            Tf32Control::UnenforcedPendingJetsonResolution => "UNENFORCED (pending Jetson resolution; no TF32 knob in ort TRT EP)",
+        }
+    }
+}
+
+/// The TensorRT backend's execution posture — its config anchor and the audit
+/// record logged at init. Replaces the CPU/OpenVINO `bitwise_reproducible`
+/// claim, which does not hold on GPU.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrtPosture {
+    /// FP16 inference. FIXED false — full precision for the safety path.
+    pub fp16: bool,
+    /// INT8 inference. FIXED false — no silent quantization.
+    pub int8: bool,
+    /// TF32 control — see [`Tf32Control`]. NOT enforceable from ort's TRT EP.
+    pub tf32: Tf32Control,
+    /// Where the serialized TRT engine is cached (per model/shape/version/GPU).
+    pub engine_cache_path: String,
+    /// SHA of the built engine. `None` until an engine is actually built on
+    /// hardware (Jetson-gated); it cannot be known on a GPU-less CI build.
+    pub engine_sha: Option<String>,
+}
+
+impl TrtPosture {
+    /// The fixed safety defaults for a given engine-cache path: full precision
+    /// (no fp16/int8), TF32 unenforced-pending, no engine SHA yet.
+    #[must_use]
+    pub fn full_precision(engine_cache_path: impl Into<String>) -> Self {
+        Self {
+            fp16: false,
+            int8: false,
+            tf32: Tf32Control::UnenforcedPendingJetsonResolution,
+            engine_cache_path: engine_cache_path.into(),
+            engine_sha: None,
+        }
+    }
+
+    /// True only if precision is *fully* guaranteed end to end. It is NOT, while
+    /// TF32 is unenforceable from the EP — so this is honestly `false`. The init
+    /// log surfaces this rather than implying full-precision determinism.
+    #[must_use]
+    pub fn full_precision_guaranteed(&self) -> bool {
+        // Even with fp16/int8 off, full precision is NOT guaranteed while TF32 is
+        // unenforceable from ort's TRT EP. Honestly `false` until TF32 is
+        // resolved on the Jetson (env override measured vs tolerance, or A2).
+        if self.fp16 || self.int8 {
+            return false;
+        }
+        match self.tf32 {
+            Tf32Control::UnenforcedPendingJetsonResolution => false,
+        }
+    }
+}
+
+/// Configuration for [`TrtBackend::with_config`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrtConfig {
+    /// Engine-cache directory. See [`resolve_engine_cache_path`].
+    pub engine_cache_path: String,
+}
+
+impl Default for TrtConfig {
+    fn default() -> Self {
+        Self { engine_cache_path: resolve_engine_cache_path(None) }
+    }
+}
+
+/// Default engine-cache directory when none is configured. The fixed input
+/// shapes Parko's sensor mappings emit mean one engine per model and clean cache
+/// reuse, so a stable on-disk path is the intended setup.
+pub const DEFAULT_ENGINE_CACHE_PATH: &str = "./parko_trt_engine_cache";
+
+/// Resolve the engine-cache path: explicit wins, else `PARKO_TRT_ENGINE_CACHE`
+/// env, else the default. Pure + GPU-free (unit-tested on CI).
+#[must_use]
+pub fn resolve_engine_cache_path(explicit: Option<&str>) -> String {
+    if let Some(p) = explicit {
+        return p.to_string();
+    }
+    std::env::var("PARKO_TRT_ENGINE_CACHE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_ENGINE_CACHE_PATH.to_string())
+}
+
+/// TensorRT inference backend. Construct with [`TrtBackend::with_config`] (or
+/// [`TrtBackend::new`] for defaults). Real inference is Jetson-gated.
+pub struct TrtBackend {
+    core: OrtRunCore,
+    posture: TrtPosture,
+}
+
+impl TrtBackend {
+    /// Construct with the default config (resolved engine-cache path, full
+    /// precision). Jetson-gated at runtime: needs a TensorRT-enabled ORT lib.
+    pub fn new(model_path: &str) -> Result<Self, BackendError> {
+        Self::with_config(model_path, &TrtConfig::default())
+    }
+
+    /// Build a session that runs on the TensorRT EP ONLY (no CUDA/CPU EP entries
+    /// — fail-closed is the posture), with full precision (fp16/int8 off) and
+    /// engine caching enabled. Returns `Err` if the TRT EP cannot register
+    /// against the dlopened ORT runtime (`error_on_failure`) — never a silent
+    /// CPU run.
+    pub fn with_config(model_path: &str, cfg: &TrtConfig) -> Result<Self, BackendError> {
+        let posture = TrtPosture::full_precision(cfg.engine_cache_path.clone());
+
+        // TRT EP only. fp16=false, int8=false (full precision); engine cache on.
+        // `.error_on_failure()` makes a failed registration fatal (fail-closed).
+        let trt_ep = TensorRT::default()
+            .with_fp16(posture.fp16)
+            .with_int8(posture.int8)
+            .with_engine_cache(true)
+            .with_engine_cache_path(&posture.engine_cache_path)
+            .build()
+            .error_on_failure();
+
+        let session: Session = Session::builder()
+            .map_err(|e| BackendError::InitializationError(format!("ort builder error: {e:?}")))?
+            .with_execution_providers([trt_ep])
+            .map_err(|e| BackendError::InitializationError(format!(
+                "TensorRT EP registration failed — refusing to run (fail-closed; no CPU fallback). \
+                 The dlopened ONNX Runtime lacks a usable TensorRT provider \
+                 (expected on a CPU-only ORT build / CI): {e:?}"
+            )))?
+            .commit_from_file(model_path)
+            .map_err(|e| BackendError::InitializationError(format!("ort session init error: {e:?}")))?;
+
+        // Audit-relevant posture log. HONEST: full_precision_guaranteed is false
+        // while TF32 is unenforceable, and GPU TRT is not bitwise-reproducible.
+        tracing::info!(
+            backend = "tensorrt",
+            fp16 = posture.fp16,
+            int8 = posture.int8,
+            tf32 = %posture.tf32.status_str(),
+            engine_cache_path = %posture.engine_cache_path,
+            engine_sha = ?posture.engine_sha,
+            full_precision_guaranteed = posture.full_precision_guaranteed(),
+            "TrtBackend execution posture (TensorRT EP; not bitwise-reproducible — \
+             fixed-engine + fixed-precision + hardware-measured decision-agreement posture)"
+        );
+
+        Ok(Self {
+            core: OrtRunCore::new(session, "ort_trt"),
+            posture,
+        })
+    }
+
+    /// The logged execution posture (audit / introspection).
+    #[must_use]
+    pub fn posture(&self) -> &TrtPosture {
+        &self.posture
+    }
+}
+
+impl InferenceBackend for TrtBackend {
+    fn load_model(&self, path: &str) -> Result<ModelHandle, BackendError> {
+        self.core.load_model(path)
+    }
+
+    fn run(&self, model: &ModelHandle, inputs: &TensorBatch)
+        -> Result<TensorBatch<'static>, BackendError>
+    {
+        self.core.run(model, inputs)
+    }
+
+    fn descriptor(&self) -> BackendDescriptor {
+        BackendDescriptor::TensorRT
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        // Jetson-gated: the real fp16/int8/batch capabilities are measured on
+        // hardware (PARK-021). The CI-buildable skeleton reports the conservative
+        // full-precision posture it actually configures.
+        BackendCapabilities {
+            supports_int8: false,
+            supports_fp16: false,
+            max_batch_size: None,
+        }
+    }
+}
+
+/// PARK-021 JETSON-GATED FOLLOW-UPS — cannot be implemented/validated on CI (no
+/// GPU). Each is a tracked next step with its resolution path; this crate is the
+/// CI-buildable skeleton only.
+///
+/// 1. **Real `load_model`/`run` output** — needs a TensorRT-enabled ORT runtime
+///    on NVIDIA silicon. The inference path itself is already shared
+///    (`OrtRunCore`); only on-hardware validation remains.
+/// 2. **Engine build / cache + warm-up** — TRT builds a per-model/shape engine
+///    (slow first run), cached at `engine_cache_path`. Parko's sensor mappings
+///    emit FIXED shapes → one engine per model, clean cache reuse. Needs a
+///    startup warm-up so the multi-second build never lands on the first real
+///    command. Populate `TrtPosture.engine_sha` once an engine exists.
+/// 3. **Precision validation** — confirm fp32 is actually used, and resolve TF32:
+///    test `NVIDIA_TF32_OVERRIDE=0` and measure its impact vs the decision
+///    tolerance. If TF32 can't be controlled out-of-band, this is the **A2
+///    (native nvinfer FFI) escalation trigger** (the ort TRT EP has no TF32 knob).
+/// 4. **Cross-backend equivalence** — extend the #152 ORT-vs-OV harness to
+///    TRT-vs-ORT-CPU. TRT-vs-CPU drift exceeds CPU-vs-CPU drift, so the bound is a
+///    SEPARATE, hardware-measured **decision-agreement** tolerance on the governed
+///    command (not bitwise logits). Anchor the harness on `TrtPosture`, NOT
+///    `InferenceThreads` (a CPU concept).
+/// 5. **Perf / latency** — engine-build time, warm vs cold, throughput.
+/// 6. **Runtime confirmation** — verify the JetPack ORT build on the ROSOrin
+///    image actually carries the TensorRT EP (so `with_config` succeeds there,
+///    rather than fail-closing as it correctly does on CI's CPU-only build).
+pub mod park021_jetson_gated {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // GPU-FREE — these RUN on CI (no ORT runtime, no Session construction).
+
+    #[test]
+    fn trt_posture_defaults_are_full_precision() {
+        let p = TrtPosture::full_precision("/tmp/cache");
+        assert!(!p.fp16, "fp16 must default off (full precision)");
+        assert!(!p.int8, "int8 must default off (no silent quantization)");
+        assert_eq!(p.tf32, Tf32Control::UnenforcedPendingJetsonResolution);
+        assert_eq!(p.engine_sha, None, "no engine SHA until built on hardware");
+    }
+
+    #[test]
+    fn full_precision_is_not_guaranteed_while_tf32_unenforced() {
+        // Honesty guard: even with fp16/int8 off, precision is NOT fully
+        // guaranteed because TF32 is unenforceable from the EP. The flag — and
+        // therefore the init log — must say false.
+        let p = TrtPosture::full_precision("/tmp/cache");
+        assert!(!p.full_precision_guaranteed(),
+            "must not claim full precision while TF32 is unenforced");
+    }
+
+    #[test]
+    fn tf32_status_is_honest_not_off() {
+        let s = Tf32Control::UnenforcedPendingJetsonResolution.status_str();
+        assert!(s.contains("UNENFORCED"), "status must surface that TF32 is unenforced");
+        assert!(!s.to_lowercase().contains("off"),
+            "status must NOT read as 'TF32 off'");
+    }
+
+    #[test]
+    fn engine_cache_path_explicit_wins() {
+        assert_eq!(resolve_engine_cache_path(Some("/var/parko/trt")), "/var/parko/trt");
+    }
+
+    #[test]
+    fn engine_cache_path_falls_back_to_default() {
+        // With no explicit path and (assuming) no env, the default is used.
+        // Not asserting under a set env to keep this hermetic.
+        if std::env::var("PARKO_TRT_ENGINE_CACHE").is_err() {
+            assert_eq!(resolve_engine_cache_path(None), DEFAULT_ENGINE_CACHE_PATH);
+        }
+    }
+
+    #[test]
+    fn config_default_uses_resolved_path() {
+        let c = TrtConfig::default();
+        assert!(!c.engine_cache_path.is_empty());
+    }
+}

--- a/parko/crates/parko-tensorrt/tests/fail_closed.rs
+++ b/parko/crates/parko-tensorrt/tests/fail_closed.rs
@@ -1,0 +1,52 @@
+//! FAIL-CLOSED — the safety-relevant test, and the reason parko-tensorrt has a
+//! dedicated CI job. It REQUIRES an ONNX Runtime shared lib (ORT_DYLIB_PATH set,
+//! same as the parko-onnx job). CI installs the Microsoft CPU-only build, which
+//! has NO usable TensorRT provider. So registering the TRT EP (with
+//! `error_on_failure`) must make `TrtBackend::with_config` return `Err` — proving
+//! "no silent CPU fallback" on the very environment that lacks TensorRT.
+//!
+//! It does NOT run in the default workspace test job (that job excludes
+//! parko-tensorrt because no ORT lib is installed there); it does NOT run in the
+//! GPU-less sandbox. It runs in the parko-tensorrt CI job that installs the CPU
+//! ORT runtime. See ci.yml.
+
+use parko_core::backend::BackendError;
+use parko_tensorrt::{TrtBackend, TrtConfig};
+
+/// On a CPU-only ORT runtime, constructing the TRT backend must FAIL (the TRT EP
+/// can't register and `error_on_failure` propagates it) — never a silent CPU run.
+#[test]
+fn trt_backend_fails_closed_when_tensorrt_ep_unavailable() {
+    // Skip cleanly unless a loadable ORT runtime is actually present — the
+    // assertion is meaningful only where libonnxruntime.so can be dlopened (ort
+    // PANICS on a missing dylib, which is "no runtime", not the fail-closed
+    // signal). NOTE: `.cargo/config.toml` sets ORT_DYLIB_PATH unconditionally, so
+    // the env var alone is not a reliable signal — the FILE must exist. The CI
+    // parko-tensorrt job installs the CPU-only ORT lib at this path, so it runs
+    // the assertion; the GPU-less sandbox lacks the file and skips.
+    let dylib = std::env::var("ORT_DYLIB_PATH").unwrap_or_default();
+    if dylib.is_empty() || !std::path::Path::new(&dylib).exists() {
+        eprintln!("SKIP: ORT runtime lib not present ({dylib:?}) — fail-closed test needs a loadable ORT lib (CI parko-tensorrt job only)");
+        return;
+    }
+
+    // Any path: construction must fail at EP registration, before model load.
+    let cfg = TrtConfig { engine_cache_path: "/tmp/parko_trt_cache".to_string() };
+    let result = TrtBackend::with_config("tests/data/any_model.onnx", &cfg);
+
+    let err = result.err().expect(
+        "TrtBackend::with_config MUST fail on a CPU-only ORT runtime — \
+         the TensorRT EP is unavailable and fail-closed must reject, never silently run CPU",
+    );
+
+    // Mapped to an InitializationError; the message names the fail-closed reason.
+    match err {
+        BackendError::InitializationError(msg) => {
+            assert!(
+                msg.contains("TensorRT") || msg.contains("fail-closed") || msg.contains("registration"),
+                "error must identify the TensorRT EP fail-closed cause, got: {msg}"
+            );
+        }
+        other => panic!("expected InitializationError (fail-closed), got: {other:?}"),
+    }
+}


### PR DESCRIPTION
Distinct `parko-tensorrt` crate running Parko on NVIDIA Jetson via `ort`'s TensorRT execution provider (the **A1** design from the PARK-020/PARK-021 investigation). **CI-buildable with no GPU**; real inference is Jetson-gated and stubbed/flagged.

## What's in
- **Shared core (pure extraction):** `parko_onnx::session_core::OrtRunCore` holds the `load_model`/`run` logic, single-sourced between `parko-onnx` and `parko-tensorrt` (relocated verbatim; `OrtBackend` behavior unchanged).
- **`TrtBackend`** via the shared core; `descriptor() = BackendDescriptor::TensorRT`. `with_config` registers the TRT EP **only** (no CUDA/CPU fallback entries), `fp16=false`, `int8=false`, engine cache on.
- **Fail-closed registration:** the EP is built with `.error_on_failure()` — ort's default silently falls back to CPU (confirmed in rc.11 source), which is rejected. A TRT-unavailable runtime makes `with_config` return `Err`, never a silent CPU run.
- **`TrtPosture`** is the config anchor (not `InferenceThreads` — GPU TRT isn't bitwise-reproducible like single-thread CPU). **TF32 honesty:** ort's TRT EP has no TF32 knob, so TF32 is carried as `Tf32Control::UnenforcedPendingJetsonResolution` and the init log reports `full_precision_guaranteed=false` — it does not claim "TF32 off".

## CI
Compiles with no GPU/CUDA/TRT libs (`ort` `load-dynamic` → `ort-sys/disable-linking`). The **fail-closed test runs on CPU-only CI** (the `parko-onnx` job's ORT lib): the TRT EP is absent there, so `TrtBackend::with_config` must `Err` — proving "no silent CPU fallback" on the very environment that lacks TensorRT. GPU-free `TrtPosture` unit tests run anywhere.

## Jetson-gated (documented in `park021_jetson_gated`, NOT in this PR)
Real `load_model`/`run` output; engine build/cache + warm-up; precision/TF32 resolution (`NVIDIA_TF32_OVERRIDE=0` measured vs tolerance, or A2 native-nvinfer escalation); TRT-vs-CPU decision-agreement tolerance; perf; JetPack ORT TRT-EP confirmation.

## Issue wiring (conservative — Jetson remainder ≠ done)
Refs #32 (PARK-020 spike: binding decision A1 made; `.trt` on-device verification still Jetson-gated), Refs #33 (PARK-021: the `TrtBackend` struct + EP path are scaffolded; real inference Jetson-gated), Refs #34 (PARK-022: backend + descriptor in place; runtime stub-vs-real *selection* wiring still pending), Refs #35 (PARK-023: fail-closed path present; CPU-vs-TRT comparison is hardware-measured, Jetson-gated). Deliberately **no `Closes`** — the closing condition for each is on-Jetson validation.

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv)_