### PR TITLE
fix(verifier-store): durable epoch fence + nonce at power-loss (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Modern robotic and autonomous deployments increasingly rely on AI models to gene
 - **Ed25519 federation** — cross-controller trust reports with replay prevention and nonce burning
 - **Federation reconciliation** — generation-ordered conflict resolution for multi-controller deployments
 - **HA standby/promotion** — heartbeat-based automatic promotion from passive standby to active
-- **WAL-mode SQLite** — durable persistence with fail-closed write ordering (disk before memory)
+- **WAL-mode SQLite** — fail-closed write **ordering** (disk before memory, INV-12); power-loss **durability** is precise: `synchronous=FULL` for the HA epoch fence and federation nonce burn (survive a hard cut), audit ledger durable to the last checkpoint (see `docs/safety/CODING_GUIDELINES.md` INV-12)
 - **SHA-256 hash-chained audit ledger** — tamper-evident record of all state transitions
 
 ### Test / Tooling

--- a/docs/safety/CODING_GUIDELINES.md
+++ b/docs/safety/CODING_GUIDELINES.md
@@ -319,6 +319,13 @@ All axum route handlers must use `State<Arc<ServiceState>>` as the state extract
 
 In `persist_and_insert_node` and all equivalent persistence-then-memory operations, the SQLite write (`save_node`) must occur before the in-memory insert (`nodes.insert`). Reversing this order would allow in-memory state to diverge from persisted state on crash, creating an inconsistent trust state on restart.
 
+**Ordering vs durability — keep these distinct (#74).** INV-12 is a write-**ordering** invariant (disk row before in-memory mutation); it is unchanged. **Durability** — surviving an OS crash / power loss at commit time — is a separate property with a precise, deliberate boundary:
+
+- **HA epoch claim** (`try_claim_epoch`) and **federation nonce burn** (`save_federated_report_chained`) commit on a dedicated `synchronous=FULL` connection → **fsync-durable**, so they survive a hard power-loss. This closes the split-brain window (a claimed epoch cannot regress on recovery) and the anti-replay gap.
+- **Audit-chain rows** are **durable to the last checkpoint**: the per-command path stays `synchronous=NORMAL` (no per-row fsync — throughput-safe), and `durable_checkpoint()` fsyncs the WAL on graceful safe-stop / shutdown (SIGINT/SIGTERM), in addition to SQLite's auto-checkpoint. The **final pre-power-loss audit rows MAY be lost on an *ungraceful* cut** (no SIGTERM runs the checkpoint). This is the accepted loss window — chosen over a 20 Hz per-row fsync.
+- **Verdict path** is store-free → nothing to lose; WCET unaffected.
+- A periodic fsync'd audit checkpoint is an available future tightening (off by default) if tighter audit durability is later required.
+
 ### INV-13: No std::env::set_var in Multithreaded Context (Mandatory)
 
 `std::env::set_var()` is not thread-safe on POSIX systems and shall never be called after the tokio runtime starts. All environment variable reads shall occur at startup via `std::env::var()` and be stored in the application state. See Rule CONC-002.

--- a/docs/safety/OCCY_FAULT_MODEL.md
+++ b/docs/safety/OCCY_FAULT_MODEL.md
@@ -19,6 +19,20 @@ on a fault, not after recovery. The design prioritizes safety over availability,
 and this document characterizes the availability cost so it is understood rather
 than surprising.
 
+**HA durability boundary (#74).** The HA **epoch fence** — the mechanism behind
+"at most one effective writer across partition / skew / restart" — is now backed
+against hard power-loss: the epoch claim (`try_claim_epoch`) commits on a
+`synchronous=FULL` connection (fsync per commit), so a claimed epoch cannot
+regress on recovery and the split-brain window is closed even across an OS crash.
+(Before #74 the claim was persisted but only `synchronous=NORMAL`-durable, so a
+power-loss at commit time could drop it — the "across restart" property had a
+power-loss hole, now closed.) The federation **nonce burn** (anti-replay) is
+likewise `synchronous=FULL`. The **audit ledger** tail is durable to the last
+checkpoint (fsync'd on graceful safe-stop/shutdown + SQLite auto-checkpoint); the
+final rows before an *ungraceful* power cut may be lost — a forensic gap, not a
+safety-state gap (the verdict path is store-free). See
+`docs/safety/CODING_GUIDELINES.md` INV-12 for the precise statement.
+
 ---
 
 ## 2. Governor fault model

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -1940,6 +1940,45 @@ async fn main() {
     println!("Kirra Verifier Service listening on {listen_addr} (db: {db_path})");
     let listener = tokio::net::TcpListener::bind(&listen_addr).await
         .expect("failed to bind listener");
-    axum::serve(listener, app).await
+
+    // #74: on safe-stop / shutdown, force a durable checkpoint so the audit chain
+    // (and any NORMAL-connection writes) are fsync'd to disk — durable at the
+    // moment that matters most (the incident preceding the stop). The HA epoch
+    // and federation nonce burns are already FULL-synced per-commit.
+    let shutdown_state = Arc::clone(&svc_state.app);
+    let shutdown = async move {
+        shutdown_signal().await;
+        match shutdown_state.store.lock() {
+            Ok(store) => match store.durable_checkpoint() {
+                Ok(()) => tracing::info!("audit: durable checkpoint flushed on shutdown"),
+                Err(e) => tracing::error!(error = %e, "audit: durable checkpoint FAILED on shutdown"),
+            },
+            Err(_) => tracing::error!("audit: durable checkpoint skipped — store lock poisoned at shutdown"),
+        }
+    };
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await
         .expect("server error");
+}
+
+/// Resolves on SIGINT (Ctrl-C) or SIGTERM — the safe-stop / shutdown signals.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        if let Ok(mut sig) = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            sig.recv().await;
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
 }

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -41,7 +41,18 @@ pub struct AuditExportPage {
 }
 
 pub struct VerifierStore {
+    /// Hot/read connection — `synchronous=NORMAL`. Carries the verdict-adjacent
+    /// per-command audit (no fsync; throughput-safe at 20 Hz+).
     conn: Connection,
+    /// Durable connection — `synchronous=FULL` (fsync per commit). Carries
+    /// durability-critical writes whose loss is a CORRECTNESS or anti-replay
+    /// bug (#74): the HA epoch CAS and the federation nonce burn. `synchronous`
+    /// is per-connection, so this second handle to the SAME WAL DB force-syncs
+    /// while the hot path stays NORMAL. `None` for in-memory stores (no
+    /// power-loss semantics, and a 2nd `:memory:` open is a DISTINCT db) — there
+    /// durability-critical writes fall back to `conn`. This is the reusable
+    /// durable-write seam #165 (active-key + genesis persistence) extends.
+    durable_conn: Option<Connection>,
     pub signing_key: Option<ed25519_dalek::SigningKey>,
 }
 
@@ -215,7 +226,48 @@ impl VerifierStore {
                 ON fabric_causal_log(timestamp_ms);"
         )?;
 
-        Ok(Self { conn, signing_key: None })
+        // Durable (force-synced) connection for the fence-correctness + anti-
+        // replay writes (#74). Same WAL DB file; `synchronous=FULL` fsyncs every
+        // commit. In-memory stores have no power-loss semantics and a second
+        // `:memory:` open would be a separate database, so we skip it there and
+        // fall back to `conn` for those writes (a no-op durability-wise).
+        let durable_conn = if path == ":memory:" {
+            None
+        } else {
+            let dc = Connection::open(path)?;
+            dc.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;")?;
+            Some(dc)
+        };
+
+        Ok(Self { conn, durable_conn, signing_key: None })
+    }
+
+    /// Durability-critical read/single-write connection: the FULL handle when
+    /// present (file-backed), else the main connection (in-memory fallback).
+    fn durable_ref(&self) -> &Connection {
+        self.durable_conn.as_ref().unwrap_or(&self.conn)
+    }
+
+    /// Durability-critical transaction connection (mutable): FULL handle when
+    /// present, else the main connection.
+    fn durable_mut(&mut self) -> &mut Connection {
+        match self.durable_conn {
+            Some(ref mut c) => c,
+            None => &mut self.conn,
+        }
+    }
+
+    /// Force a durable checkpoint: `wal_checkpoint(TRUNCATE)` on the FULL
+    /// connection fsyncs the shared WAL into the main DB file, making ALL
+    /// committed data durable — including the per-command audit rows written on
+    /// the NORMAL connection. Call on safe-stop / shutdown (and optionally
+    /// periodically) to bound the audit loss window WITHOUT per-row fsync. No-op
+    /// for in-memory stores. Idempotent and cheap when the WAL is already small.
+    pub fn durable_checkpoint(&self) -> Result<()> {
+        if let Some(dc) = &self.durable_conn {
+            dc.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+        }
+        Ok(())
     }
 
     pub fn set_signing_key(&mut self, key: ed25519_dalek::SigningKey) {
@@ -523,7 +575,13 @@ impl VerifierStore {
         report: &FederatedTrustReport,
         received_at_ms: u64,
     ) -> Result<()> {
-        let tx = self.conn.transaction()?;
+        // #74: route the whole federation commit — report + NONCE BURN + audit —
+        // through the FULL (force-synced) connection. A burned nonce must survive
+        // power-loss or anti-replay is defeated (the 5 s freshness window only
+        // partially bounds replay). Federation reports are rare, so the per-commit
+        // fsync is off the hot path and inconsequential to throughput.
+        let signing_key = self.signing_key.clone(); // durable_mut() borrows self
+        let tx = self.durable_mut().transaction()?;
 
         let posture_json = serde_json::to_string(&report.posture)
             .map_err(|_| rusqlite::Error::InvalidQuery)?;
@@ -558,7 +616,7 @@ impl VerifierStore {
             "FEDERATED_TRUST_REPORT_ACCEPTED",
             &audit.to_string(),
             received_at_ms as i64,
-            self.signing_key.as_ref(),
+            signing_key.as_ref(),
         )?;
 
         tx.commit()
@@ -1336,7 +1394,12 @@ impl VerifierStore {
         instance_id: &str,
         now_ms: u64,
     ) -> Result<Option<u64>> {
-        let n = self.conn.execute(
+        // #74 CORRECTNESS FIX: the epoch CAS goes through the FULL (force-synced)
+        // connection, so the claim is DURABLE (fsync'd) before this returns —
+        // and the caller (standby_monitor) only sets the in-memory held_epoch /
+        // acts as Active AFTER this returns. A claimed epoch can no longer
+        // regress on power-loss recovery, closing the split-brain window.
+        let n = self.durable_ref().execute(
             "UPDATE ha_state SET epoch = epoch + 1, active_instance_id = ?2, updated_at_ms = ?3 \
              WHERE id = 1 AND epoch = ?1",
             params![observed as i64, instance_id, now_ms as i64],
@@ -2048,5 +2111,133 @@ mod audit_key_rotation_tests {
         let r = s.verify_audit_chain_full(Some(&a.verifying_key())).unwrap();
         assert!(!r.signature_valid, "unknown key_id must fail closed, not skip");
         assert_eq!(r.first_invalid_signature_index, Some(0));
+    }
+}
+
+/// Issue #74 — SQLite durability at power-loss: durable (FULL) connection
+/// routing, epoch non-regression (the fence-correctness proof), nonce
+/// durability, the in-memory fallback, and the shutdown checkpoint.
+#[cfg(test)]
+mod durability_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static CTR: AtomicU64 = AtomicU64::new(0);
+
+    /// Temp DB file (+ -wal/-shm) cleaned up on drop.
+    struct TmpDb(String);
+    impl TmpDb {
+        fn new(tag: &str) -> Self {
+            let n = CTR.fetch_add(1, Ordering::SeqCst);
+            let p = std::env::temp_dir()
+                .join(format!("kirra74_{tag}_{}_{n}.db", std::process::id()));
+            TmpDb(p.to_string_lossy().into_owned())
+        }
+        fn path(&self) -> &str { &self.0 }
+    }
+    impl Drop for TmpDb {
+        fn drop(&mut self) {
+            for ext in ["", "-wal", "-shm"] {
+                let _ = std::fs::remove_file(format!("{}{}", self.0, ext));
+            }
+        }
+    }
+
+    fn pragma_synchronous(c: &Connection) -> i64 {
+        c.query_row("PRAGMA synchronous", [], |r| r.get(0)).unwrap()
+    }
+
+    fn report(nonce: &str) -> crate::federation::FederatedTrustReport {
+        crate::federation::FederatedTrustReport {
+            source_controller_id: "ctrl-A".to_string(),
+            asset_id: "asset-1".to_string(),
+            posture: crate::verifier::FleetPosture::Nominal,
+            issued_at_ms: 1_000,
+            expires_at_ms: 9_000,
+            nonce_hex: nonce.to_string(),
+            signature_b64: "sig".to_string(),
+        }
+    }
+
+    /// DURABLE ROUTING + config: a file-backed store has a FULL durable
+    /// connection distinct from the NORMAL main connection.
+    #[test]
+    fn durable_connection_is_full_main_is_normal() {
+        let db = TmpDb::new("routing");
+        let s = VerifierStore::new(db.path()).unwrap();
+        assert_eq!(pragma_synchronous(&s.conn), 1, "main conn is NORMAL (1)");
+        let dc = s.durable_conn.as_ref().expect("file store must have a durable connection");
+        assert_eq!(pragma_synchronous(dc), 2, "durable conn is FULL (2)");
+    }
+
+    /// IN-MEMORY FALLBACK: no separate durable conn (a 2nd :memory: open would be
+    /// a distinct db), and epoch/nonce still work via the main connection.
+    #[test]
+    fn memory_store_has_no_durable_conn_but_works() {
+        let mut s = VerifierStore::new(":memory:").unwrap();
+        assert!(s.durable_conn.is_none(), ":memory: must fall back to the main conn");
+        assert_eq!(s.try_claim_epoch(0, "A", 1).unwrap(), Some(1));
+        s.save_federated_report_chained(&report("aa"), 2_000).unwrap();
+        assert!(s.has_seen_federation_nonce("aa").unwrap());
+    }
+
+    /// EPOCH NON-REGRESSION (the fence-correctness core of #74): a claim
+    /// committed via the FULL path survives a store reopen ("recovery") and does
+    /// NOT regress — a stale-observed re-claim then fails (no double-claim).
+    #[test]
+    fn epoch_claim_durable_across_reopen_and_fence_holds() {
+        let db = TmpDb::new("epoch");
+        {
+            let mut s = VerifierStore::new(db.path()).unwrap();
+            assert_eq!(s.try_claim_epoch(0, "primary", 100).unwrap(), Some(1),
+                "primary claims epoch 1 (FULL-synced)");
+        } // drop → simulate process loss; the claim was fsync'd on its FULL commit.
+
+        // Recover: reopen the SAME file.
+        let mut s2 = VerifierStore::new(db.path()).unwrap();
+        assert_eq!(s2.try_claim_epoch(0, "ghost", 200).unwrap(), None,
+            "a stale-observed (epoch 0) re-claim MUST fail — the epoch did not regress to 0");
+        assert_eq!(s2.try_claim_epoch(1, "standby", 300).unwrap(), Some(2),
+            "the durable epoch is 1; the legitimate next claim advances to 2 (fence intact)");
+    }
+
+    /// NONCE DURABILITY: a burned federation nonce survives reopen → no replay.
+    #[test]
+    fn nonce_burn_durable_across_reopen() {
+        let db = TmpDb::new("nonce");
+        {
+            let mut s = VerifierStore::new(db.path()).unwrap();
+            s.save_federated_report_chained(&report("deadbeef"), 2_000).unwrap();
+            assert!(s.has_seen_federation_nonce("deadbeef").unwrap(), "burned before reopen");
+        } // drop → simulate process loss.
+        let s2 = VerifierStore::new(db.path()).unwrap();
+        assert!(s2.has_seen_federation_nonce("deadbeef").unwrap(),
+            "burned nonce must survive recovery — no replay window");
+    }
+
+    /// AUDIT-CHAIN INTEGRITY + shutdown checkpoint: appends stay sequenced and
+    /// hash-linked under the dual-connection setup; durable_checkpoint() flushes
+    /// without breaking verification.
+    #[test]
+    fn audit_chain_intact_after_checkpoint() {
+        use ed25519_dalek::SigningKey;
+        let db = TmpDb::new("audit");
+        let key = SigningKey::from_bytes(&[7; 32]);
+        let mut s = VerifierStore::new(db.path()).unwrap();
+        s.set_signing_key(key.clone());
+        // Append a few chained rows via a real store write path.
+        for i in 0..3 {
+            s.save_posture_event_chained("n", "EVT", "{}", None, 100 + i).unwrap();
+        }
+        // Force the shutdown-style durable checkpoint.
+        s.durable_checkpoint().unwrap();
+        let r = s.verify_audit_chain_full(Some(&key.verifying_key())).unwrap();
+        assert!(r.chain_intact, "hash chain intact across the dual-conn + checkpoint");
+        assert!(r.signature_valid, "signatures verify");
+        // Reopen and re-verify — checkpointed rows are durable.
+        drop(s);
+        let s2 = VerifierStore::new(db.path()).unwrap();
+        let r2 = s2.verify_audit_chain_full(Some(&key.verifying_key())).unwrap();
+        assert!(r2.chain_intact && r2.signed_entries >= 3, "rows durable + intact after reopen");
     }
 }

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -263,6 +263,18 @@ impl VerifierStore {
     /// the NORMAL connection. Call on safe-stop / shutdown (and optionally
     /// periodically) to bound the audit loss window WITHOUT per-row fsync. No-op
     /// for in-memory stores. Idempotent and cheap when the WAL is already small.
+    ///
+    /// DURABILITY BOUNDARY (#74) — by design, NOT a bug: the audit-chain tail is
+    /// durable only to the LAST checkpoint. The HA epoch claim and federation
+    /// nonce burn are `synchronous=FULL` (fsync per commit, survive a hard power
+    /// loss); the audit chain stays `synchronous=NORMAL` (no per-row fsync —
+    /// throughput-safe at 20 Hz+) and relies on this checkpoint (graceful
+    /// safe-stop/shutdown + SQLite auto-checkpoint). So the final audit rows
+    /// before an UNGRACEFUL power cut may be lost — a forensic gap, never a
+    /// safety-state gap (the verdict path is store-free). Do NOT assume the audit
+    /// tail is hard-power-loss-durable. Tighter durability (a periodic fsync'd
+    /// checkpoint) is an available future knob, off by default. See
+    /// docs/safety/CODING_GUIDELINES.md INV-12.
     pub fn durable_checkpoint(&self) -> Result<()> {
         if let Some(dc) = &self.durable_conn {
             dc.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;


### PR DESCRIPTION
Closes #74. Adds a separate `synchronous=FULL` durable connection (same WAL DB; `:memory:` falls back). The HA epoch CAS (`try_claim_epoch`) and the federation nonce burn now run force-synced on the FULL connection — durable BEFORE the in-memory epoch update — closing the power-loss split-brain window (the correctness fix) and the anti-replay gap. Per-command audit stays on the async writer; `durable_checkpoint()` fsyncs the shared WAL on graceful safe-stop/shutdown. The verdict path is untouched (store-free → WCET unchanged).

Accept-and-document boundary included: epoch + nonce survive a hard power-loss; the audit chain is durable to the last checkpoint, so the final pre-power-loss audit rows may be lost on an UNGRACEFUL cut (README:222 qualified; boundary stated near CODING_GUIDELINES INV-12; OCCY_FAULT_MODEL "durable epoch fence" claim now backed). Sibling follow-ups #164 (HMAC salt rotation) and #165 (rotated key/genesis durable across restart, to build on this FULL connection) remain OPEN by design.

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv