### PR TITLE
docs(safety): add ISO/IEC TR 5469 + ISO/PAS 8800 AI-functional-safety…

### DIFF
--- a/docs/safety/ISO_IEC_TR_5469_MAPPING.md
+++ b/docs/safety/ISO_IEC_TR_5469_MAPPING.md
@@ -1,0 +1,132 @@
+# Kirra — ISO/IEC TR 5469 AI-Functional-Safety Alignment Mapping
+
+Document ID: KIRRA-TR5469-001
+Version: 0.1
+Status: Draft — alignment statement (NOT a certification claim)
+References: ISO/IEC TR 5469:2024 (Artificial intelligence — Functional safety and AI systems); IEC 61508:2010; ISO 26262:2018; ISO/PAS 21448 (SOTIF); ISO/PAS 8800
+Date: 2026-06-03
+
+---
+
+## 0. Honest framing — this is alignment, not certification
+
+ISO/IEC TR 5469 is a **Technical Report**: informative **guidance**, not a
+certifiable normative standard. Kirra therefore **aligns with and cites** TR 5469
+as its AI-functional-safety *methodology and identity* — it is **not a
+certification target**, and nothing in this document should be read as a
+conformance or certification claim against TR 5469. The certifiable claims live
+against the normative standards already in the matrix (IEC 61508 SIL 3 →
+KIRRA-61508-001 / AEGIS-61508-001; ISO 26262 ASIL-D; ASTM F3269 → AEGIS-F3269-001).
+
+What TR 5469 gives Kirra is the **conceptual anchor**: it is the standard that
+describes Kirra's exact pattern, and it ties the cross-domain story together.
+
+---
+
+## 1. What TR 5469 is, and why it sits above the matrix
+
+TR 5469 is **industry-agnostic**, with terminology anchored to **IEC 61508**. It
+explicitly references IEC 61508, ISO 26262, IEC 62061, ISO 13849, and IEC 61511 —
+i.e. it sits **above** the whole existing standards matrix (`STANDARDS_MATRIX.md`,
+AEGIS-STD-001) and connects the per-vertical functional-safety entries into one
+AI-safety narrative.
+
+TR 5469 addresses several usage situations for AI in relation to safety functions,
+including:
+
+1. **AI used inside a safety function.**
+2. **Non-AI safety-related functions used to ensure the safety of AI-controlled
+   equipment.**
+3. **AI used to develop safety functions.**
+
+It classifies AI usage by levels/classes and discusses architectural measures to
+mitigate AI insufficiency and how AI elements relate to IEC 61508 concepts.
+
+---
+
+## 2. The core mapping — Kirra is usage class 2
+
+**Kirra is squarely usage situation (2): a deterministic, non-AI, independently
+developed safety function that ensures the safety of AI-controlled equipment.**
+The AI-controlled equipment is the Occy / Parko AI planner-controller; Kirra is
+the safety function that **does not trust it** and enforces a hard envelope on its
+outputs.
+
+This is the architecturally **preferred** pattern TR 5469 endorses for AI in
+safety-critical control. TR 5469 treats certifying a neural network to high
+integrity as hard and limited; the recommended alternative is to **bound the AI's
+outputs with a deterministic, certifiable safety channel**. Kirra IS that channel:
+
+| TR 5469 concept | Kirra realization | Evidence |
+|---|---|---|
+| The "AI element" (insufficiency to be mitigated) | Occy / Parko AI planner + ML inference backends | (the governed item) |
+| Non-AI safety function over AI-controlled equipment | The Kirra Governor — deterministic, independently developed | ADR-0003 (KIRRA-OCCY-ADR-003), Safety Architecture (AEGIS-SA-001) |
+| Deterministic, bounded enforcement | `validate_vehicle_command()` — scalar kinematic-contract clamp, **WCET-bounded** verdict, no heap on the verdict path | SG-001 (velocity envelope), SG-002 (lateral accel), SG-004 (finiteness); `wcet_gate` |
+| Fail-closed safe state on any insufficiency | Fail-closed → MRC (Minimal Risk Condition); unknown-command denial in all postures | SG-006, SG-008; OCCY SG4 (MRC publication), SG5 (liveness) |
+| Architectural diversity measure | Comparator diversity — structurally/algorithmically diverse shadow | CERT-006 (KIRRA-CERT006-DIVERSITY-001) |
+| Independence between AI element and safety function | Independent safety channel; integrity burden on the deterministic channel, not the AI | ADR-0003 two-tier; OCCY_DFA (KIRRA-OCCY-DFA-001) |
+
+**The argument in one sentence:** the integrity burden sits on the certifiable
+deterministic channel (Kirra), not on the AI — which is exactly the AI-safety
+posture TR 5469 describes for usage class 2, and is Kirra's strongest AI-safety
+claim.
+
+---
+
+## 3. Connection to the existing decomposition + architecture
+
+TR 5469's usage-class-2 pattern is the conceptual umbrella over work Kirra already
+has:
+
+- **ASIL/integrity decomposition (OCCY_DFA, KIRRA-OCCY-DFA-001):** the deterministic
+  Governor carries the high-integrity requirement; the AI planner is decomposed to
+  a lower-integrity element whose insufficiency is mitigated by the Governor's hard
+  envelope. TR 5469 is the AI-specific justification for *why* that decomposition
+  is sound for an AI element.
+- **Two-tier architecture (ADR-0003, KIRRA-OCCY-ARCH-001):** the base Governor is
+  the non-AI safety function; the optional D1 add-on is an independent detection
+  channel. TR 5469 frames both as architectural measures against AI insufficiency.
+- **Comparator diversity (CERT-006, KIRRA-CERT006-DIVERSITY-001):** a diversity
+  measure with honestly-stated limits — the kind of architectural mitigation TR
+  5469 discusses, applied to the Governor itself.
+- **IEC 61508 anchor (AEGIS-61508-001):** because TR 5469's terminology is anchored
+  to 61508, Kirra's 61508 SIL-3 mapping is the normative spine; TR 5469 is the
+  AI-context layer on top.
+- **SOTIF (ISO 21448) / OCCY_SOTIF (KIRRA-OCCY-ODD-001):** SOTIF covers the AI
+  planner's behavioral insufficiency (triggering conditions); TR 5469 + Kirra's
+  enforcement convert that uncertainty into a bounded enforcement boundary. ISO/PAS
+  8800 (matrix #25) is the automotive-specific tailoring of this same idea.
+
+---
+
+## 4. Relationship to ISO/PAS 8800 (automotive)
+
+For the AV path, **ISO/PAS 8800** is the AI-safety layer *on top of* the existing
+ISO 26262 (matrix #1) + SOTIF (matrix #2) entries — it tailors ISO 26262 for AI
+and extends SOTIF for AI/ML non-determinism, and references TR 5469. TR 5469 is the
+industry-agnostic methodology; ISO/PAS 8800 is its automotive specialization,
+relevant when an AV stack is the certification target. The Kirra usage-class-2
+argument above is identical in both; 8800 just maps it into 26262 process terms.
+
+---
+
+## 5. What this buys, and what it does not
+
+- **Does buy:** the AI-safety *identity* — Kirra is the textbook TR 5469
+  usage-class-2 safety function — and a single cross-domain narrative tying the
+  61508 / 26262 / SOTIF / machinery entries into one AI-safety story.
+- **Does not buy:** any certificate. TR 5469 is guidance; the certifiable claims
+  remain IEC 61508 SIL 3 / ISO 26262 ASIL-D / ASTM F3269. This document is a
+  reference mapping, not a conformance argument.
+
+---
+
+## 6. Document control
+
+| Field | Value |
+|---|---|
+| Doc ID | KIRRA-TR5469-001 |
+| Supersedes | — |
+| Registered in | SAFETY_CASE_INDEX.md (AEGIS-SC-000) |
+| Matrix entry | STANDARDS_MATRIX.md (AEGIS-STD-001) #24 |
+| Cross-refs | ADR-0003, OCCY_DFA (KIRRA-OCCY-DFA-001), COMPARATOR_DIVERSITY (CERT-006), IEC_61508_MAPPING (AEGIS-61508-001), OCCY_SOTIF (KIRRA-OCCY-ODD-001) |

--- a/docs/safety/SAFETY_CASE_INDEX.md
+++ b/docs/safety/SAFETY_CASE_INDEX.md
@@ -48,6 +48,7 @@ Date: 2026-05-23
 | KIRRA-OCCY-SPEED-VAL-001 | Occy speed-cap validation matrix (S8 #120 Item C; PROVEN/OK-ANALYTICAL/AoU-GAP dispositions for each ADR-0001 assumption; cap unchanged at 50 mph) | 0.1 | Draft | docs/safety/OCCY_SPEED_CAP_VALIDATION.md | 2026-05-31 |
 | KIRRA-OCCY-IDC-RANGES-001 | Occy D1 IDC detection-range specification (S8 #120 Item B; per-sensor spec table + SSD-derate cap-impact + vendor-RFP requirements; closes Item C AoU rows 1+4 in the D1 tier) | 0.1 | Draft | docs/safety/OCCY_IDC_DETECTION_RANGES.md | 2026-05-31 |
 | KIRRA-OCCY-QUANT-001 | Occy quantitative HW safety metrics (S8 #120 Item D; SPFM/LFM/PMHF target-vs-claimed across 5 sub-elements; single-supply PMHF 17.7 FIT FAIL, dual-supply 8.7 FIT PASS; deployment requirement: ASIL-D-class redundant supply) | 0.1 | Draft | docs/safety/OCCY_QUANTITATIVE_METRICS.md | 2026-05-31 |
+| KIRRA-TR5469-001 | ISO/IEC TR 5469 AI-functional-safety alignment (Kirra as the usage-class-2 non-AI safety function over AI-controlled equipment; align/cite — NOT a certification target, TR = guidance) | 0.1 | Draft | docs/safety/ISO_IEC_TR_5469_MAPPING.md | 2026-06-03 |
 
 ---
 

--- a/docs/safety/STANDARDS_MATRIX.md
+++ b/docs/safety/STANDARDS_MATRIX.md
@@ -9,7 +9,7 @@ Date: 2026-05-23
 
 ## 1. Purpose
 
-This matrix identifies 23 safety and security standards relevant to Kirra deployments across five industry verticals. For each standard, it documents Kirra applicability, current compliance status, the SEooC (Safety Element out of Context) model applicability, and the certification priority.
+This matrix identifies 25 safety and security standards relevant to Kirra deployments across five industry verticals plus the cross-cutting layer. For each standard, it documents Kirra applicability, current compliance status, the SEooC (Safety Element out of Context) model applicability, and the certification priority.
 
 Priority levels:
 - P0: Must have — gates primary commercial targets
@@ -27,6 +27,7 @@ Priority levels:
 | 3 | ISO/SAE 21434 | Road Vehicles — Cybersecurity Engineering | P1 | Kirra directly implements several 21434 security controls: constant-time token comparison, HMAC-SHA256 attestation, Ed25519-signed audit chain, nonce-based replay prevention, admin token enforcement, and adversarial input detection in the Action Filter. | Informal compliance. No formal TARA (Threat Analysis and Risk Assessment) yet. | Map existing security invariants to 21434 TARA outputs. Estimated 2–4 months. |
 | 4 | UN ECE WP.29 R155/R156 | Cybersecurity Management System / Software Update Management | P2 | R155 requires a CSMS covering the vehicle's supply chain. Kirra as a software component must be covered under the OEM's CSMS. R156 requires secure OTA update procedures for software on the vehicle. | Not yet addressed. Applies when Kirra is deployed on a type-approved vehicle. | Address during OEM integration. No standalone Kirra action required; document supply chain security claims. |
 | 5 | AUTOSAR Adaptive | AUTOSAR Adaptive Platform (AP) — ARA Safety | P2 | AUTOSAR AP defines the execution environment for ASIL-D software on modern E/E architectures. Kirra would run as an Adaptive Application (AA) in a future automotive integration. The posture engine worker and axum HTTP interface would need to be replaced or wrapped by AUTOSAR communication middleware. | Not applicable until automotive OEM integration. | Track. No action until OEM engagement. |
+| 25 | ISO/PAS 8800 | Road Vehicles — Safety and Artificial Intelligence | P1 | The AI-safety layer ON TOP of the existing ISO 26262 (#1) + SOTIF (#2) entries for the AV path. ISO/PAS 8800 does not replace ISO 26262 — it tailors 26262's methods for AI/ML and extends SOTIF (ISO 21448) to address AI/ML non-determinism, and references ISO/IEC TR 5469 (#24). For Kirra's Occy line, it is the AI-functional-safety tailoring relevant when an AV stack is the certification target; KIRRA itself remains the deterministic non-AI safety function bounding the AI planner (the TR 5469 usage-class-2 pattern — see #24 / KIRRA-TR5469-001). | Gap. PAS (pre-standard; more normative than a TR, not yet a full IS). Relevant once the ISO 26262 (#1) + SOTIF (#2) work matures. | Matrix row now; full mapping deferred — map alongside/after the 26262 + SOTIF work. |
 
 ---
 
@@ -73,6 +74,7 @@ Priority levels:
 | 21 | ISO/IEC 25010 | Systems and Software Quality Models | P2 | Defines software quality characteristics: functional suitability, reliability, security, maintainability, safety. Useful as a quality framework for Kirra but not a certification target. | Not targeted. | Reference for quality attribute definitions. |
 | 22 | NIST SP 800-82 Rev 3 | Guide to Operational Technology Security | P2 | NIST 800-82 provides security guidance for industrial control systems. Relevant when Kirra is deployed in OT environments (power, water, manufacturing). The admin token enforcement, attestation, and audit chain directly implement 800-82 access control and audit requirements. | Informal compliance with relevant controls. | Document alignment with NIST 800-82 controls for US government and critical infrastructure customers. |
 | 23 | ISO/IEC 27001 | Information Security Management Systems | P2 | ISO 27001 ISMS is a process standard for managing information security. Relevant at the organizational level, not the software component level. Applicable when Kirra is commercialized and requires supply chain security attestation. | Not targeted. | Address at commercial entity formation stage. |
+| 24 | ISO/IEC TR 5469 | Artificial Intelligence — Functional Safety and AI Systems | P1 | **The AI-functional-safety methodology + identity anchor.** Industry-agnostic, terminology anchored to IEC 61508; sits ABOVE the whole matrix and references IEC 61508 / ISO 26262 / IEC 62061 / ISO 13849 / IEC 61511. KIRRA is squarely **usage class 2** — a deterministic, non-AI, independently developed safety function that ensures the safety of AI-controlled equipment (the Occy/Parko AI planner/controller). This is the architecturally preferred TR 5469 pattern for AI in safety-critical control: rather than certify a neural net to high integrity (which TR 5469 treats as hard/limited), bound the AI's outputs with a deterministic certifiable safety channel — exactly KIRRA's independent channel (ADR-0003), the WCET-bounded `validate_vehicle_command` kinematic-contract enforcement, fail-closed MRC, and comparator diversity (CERT-006). The integrity burden sits on the certifiable deterministic channel, not the AI. | Gap (alignment). **NOT a certification target** — TR 5469 is a Technical Report (informative guidance), so KIRRA *aligns with and cites* it, it cannot be certified against it. | Alignment + reference mapping (KIRRA-TR5469-001). Connects the cross-domain story to OCCY_DFA (decomposition) + ADR-0003 (two-tier). |
 
 ---
 
@@ -81,7 +83,7 @@ Priority levels:
 | Priority | Standards | Count | Action |
 |----------|-----------|-------|--------|
 | P0 | ISO 26262 ASIL-D (#1), ASTM F3269 (#6), IEC 61508 SIL 3 (#14) | 3 | Active certification tracks |
-| P1 | ISO/SAE 21434 (#3), DO-178C/ED-12C (#7), ISO 10218-1/2 (#10), ISO/TS 15066 (#11), IEC 62061 (#12), IEC 61511 (#15), IEC 62443 (#16), MISRA C/Ferrocene (#20) | 8 | Derivative from P0 or vertical-specific |
+| P1 | ISO/SAE 21434 (#3), DO-178C/ED-12C (#7), ISO 10218-1/2 (#10), ISO/TS 15066 (#11), IEC 62061 (#12), IEC 61511 (#15), IEC 62443 (#16), MISRA C/Ferrocene (#20), ISO/IEC TR 5469 (#24, AI-safety identity anchor — align/cite, not a cert target), ISO/PAS 8800 (#25, AV AI-safety layer) | 10 | Derivative from P0 or vertical-specific |
 | P2 | UN ECE WP.29 (#4), AUTOSAR AP (#5), DO-333 (#8), FAA BVLOS (#9), EN ISO 13849 (#13), IEC 61131-3 (#17), NERC CIP (#18), IEC 62304 (#19), ISO/IEC 25010 (#21), NIST 800-82 (#22), ISO 27001 (#23) | 12 | Track; address when needed |
 
 ---


### PR DESCRIPTION
… anchor

The two AI-functional-safety standards had zero references in the repo; TR 5469 is the standard that describes KIRRA's exact pattern (the identity-critical gap). Doc-only — alignment/citation, not a certification claim.

- STANDARDS_MATRIX.md (AEGIS-STD-001): +ISO/IEC TR 5469 (#24, Cross-Cutting, P1 — AI-functional-safety methodology + identity anchor; KIRRA = usage-class-2 non-AI safety function over AI-controlled equipment; align/cite, NOT a cert target since TR = guidance); +ISO/PAS 8800 (#25, Automotive, P1 — AI-safety layer on 26262+SOTIF for the AV path, matrix row now / full mapping deferred). Count 23→25; Priority Matrix P1 8→10.
- New docs/safety/ISO_IEC_TR_5469_MAPPING.md (KIRRA-TR5469-001): the usage-class-2 argument (bound the AI's outputs with a deterministic certifiable channel rather than certify the net), the decomposition/independent-channel argument, cross-refs to ADR-0003, OCCY_DFA, COMPARATOR_DIVERSITY (CERT-006), IEC_61508_MAPPING, and the SOTIF docs. TR-is-guidance framing kept front and center.
- SAFETY_CASE_INDEX.md (AEGIS-SC-000): registered KIRRA-TR5469-001.

Prefix convention: new doc uses KIRRA-* (the post-2026-05-29 convention; the 2026-05-23 foundation docs remain AEGIS-*). SG IDs cited unchanged.

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv