### PR TITLE
fix(governor): Degraded posture is decel-to-stop-and-HOLD, not an MRC…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,25 @@ PROMOTION_TIMEOUT_MS         = 10_000     // standby promotes if primary silent 
 - `Degraded` → allows `ReadTelemetry` only
 - `Nominal` → allows all except `Unknown`
 
+**Degraded = Controlled Decel-to-Stop-and-HOLD** (`enforce_degraded_decel_to_stop`, issue #70):
+- Degraded is NOT a sustained reduced-speed crawl. The kinematic Governor admits a
+  command in Degraded ONLY if all hold: (a) within the MRC envelope (the
+  *decel-trajectory bound*, via `validate_vehicle_command` against the MRC contract);
+  (b) non-increasing speed `|proposed| <= |current|` → else `DenyCode::DegradedSpeedIncreaseDenied`;
+  (c) no re-initiation — if `|current| <= STOP_EPSILON_MPS` (0.05), any `|proposed| > STOP_EPSILON_MPS`
+  → `DenyCode::DegradedReinitiationDenied` (HOLD at zero); a reversal through a stop is also re-initiation.
+- A denied command → MRC controlled stop; the Governor never authors re-acceleration.
+- Wired at ALL four enforcement points: gateway `enforce_actuator_safety_envelope`,
+  fabric `AssetGovernor::evaluate_command`, ros2-adapter `validate_trajectory_slow`,
+  parko-kirra `KirraGovernor::apply_mrc_profile` (the last also gates an independent
+  angular-velocity channel via `STOP_EPSILON_RAD_S` for differential drive).
+- The Nominal WCET-critical `validate_vehicle_command` path is UNCHANGED.
+- "MRC" disambiguation: Degraded MRC = decel-to-stop *envelope* (bounds a converging
+  command); LockedOut MRC fallback = safe-stop *maneuver* (all commands denied).
+- Motivation: Cruise SF Oct-2023 post-stop pullover-drag (~3 m/s, under a 5 m/s crawl
+  ceiling). Recovery is AUTOMATIC on return to Nominal (contrast LockedOut human-reset).
+  See `docs/safety/SAFE_STATE_SPECIFICATION.md` SS-002.
+
 **AV Recovery Hysteresis** (`evaluate_recovery_report`):
 - Node is `Untrusted` after a fault (hw_fault or confidence < floor)
 - Recovery requires `AV_RECOVERY_STREAK_THRESHOLD` (5) consecutive healthy reports

--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -21,7 +21,7 @@ use kirra_runtime_sdk::gateway::containment::{
     Point as KernelPoint,
 };
 use kirra_runtime_sdk::gateway::kinematics_contract::{
-    validate_vehicle_command, EnforceAction, ProposedVehicleCommand,
+    enforce_degraded_decel_to_stop, validate_vehicle_command, EnforceAction, ProposedVehicleCommand,
 };
 use kirra_runtime_sdk::verifier::FleetPosture;
 use parko_core::rss::{
@@ -152,9 +152,12 @@ pub fn validate_trajectory_slow(
     // Posture-driven kinematics contract:
     //   - Nominal  → integrator's full envelope (`to_kinematics_contract`)
     //   - Degraded → MRC-derated dynamic limits, same integrator geometry
-    //                (`to_mrc_kinematics_contract`)
+    //                (`to_mrc_kinematics_contract`), used as the
+    //                decel-trajectory bound for the Issue #70 stop-and-hold
+    //                gate below.
     // LockedOut was short-circuited above; this match is exhaustive on
     // the remaining variants.
+    let degraded = posture == FleetPosture::Degraded;
     let kinematics = match posture {
         FleetPosture::Nominal  => config.to_kinematics_contract(),
         FleetPosture::Degraded => config.to_mrc_kinematics_contract(),
@@ -173,7 +176,17 @@ pub fn validate_trajectory_slow(
         // Carry the segment's commanded steering forward so the next
         // segment's "current" steering = this segment's commanded steering.
         prev_steering_deg = cmd.steering_angle_deg;
-        match validate_vehicle_command(&cmd, &kinematics) {
+        // Issue #70: in Degraded the trajectory must be a controlled
+        // decel-to-stop — each segment non-increasing in speed and never
+        // re-initiating motion from a stop. A planned re-acceleration or
+        // pullover-from-stop segment → DenyBreach → MRCFallback (the
+        // controlled stop). Nominal uses the full per-pose envelope.
+        let verdict = if degraded {
+            enforce_degraded_decel_to_stop(&cmd, &kinematics)
+        } else {
+            validate_vehicle_command(&cmd, &kinematics)
+        };
+        match verdict {
             EnforceAction::Allow => {}
             EnforceAction::ClampLinear(_) | EnforceAction::ClampSteering(_) => {
                 clamp_seen = true;

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -240,6 +240,76 @@ fn degraded_posture_caps_kinematics_to_mrc() {
 }
 
 #[test]
+fn degraded_reaccel_from_stop_mrcs() {
+    // Issue #70 (Cruise Oct-2023 SF lesson): under Degraded the trajectory
+    // must be a controlled decel-to-stop. A trajectory that starts stopped
+    // and re-accelerates (a planned pullover-from-stop) must NOT be
+    // admitted under Degraded — the re-initiation segment trips DenyBreach
+    // and the aggregate verdict is MRCFallback (the controlled stop).
+    // Under Nominal the same trajectory is a normal launch and is accepted.
+    let dt = 0.1;
+    let speeds = [0.0_f64, 0.5, 1.2, 2.0, 2.8, 3.5];
+    let mut x = 5.0;
+    let trajectory: Vec<TrajectoryPoint> = speeds
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| {
+            let p = TrajectoryPoint {
+                pose: Pose { x_m: x, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: v,
+                time_from_start_s: (i as f64) * dt,
+            };
+            x += v * dt;
+            p
+        })
+        .collect();
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let objects: Vec<PerceivedObject> = Vec::new();
+    let cfg = VehicleConfig::default_urban();
+
+    let degraded_verdict = validate_trajectory_slow(
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Degraded,
+    );
+    assert_eq!(degraded_verdict, TrajectoryVerdict::MRCFallback,
+        "Degraded must refuse a re-acceleration-from-stop trajectory (no autonomous \
+         re-initiation of motion); got {degraded_verdict:?}");
+}
+
+#[test]
+fn degraded_decel_to_stop_trajectory_is_admitted() {
+    // The complement of the Cruise lesson: a Degraded trajectory that bleeds
+    // speed down toward a stop (monotonically non-increasing, within the MRC
+    // envelope) is admitted — Accept or Clamp, never MRCFallback.
+    let dt = 0.2;
+    let speeds = [4.0_f64, 3.2, 2.4, 1.6, 0.8, 0.0];
+    let mut x = 5.0;
+    let trajectory: Vec<TrajectoryPoint> = speeds
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| {
+            let p = TrajectoryPoint {
+                pose: Pose { x_m: x, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: v,
+                time_from_start_s: (i as f64) * dt,
+            };
+            x += v * dt;
+            p
+        })
+        .collect();
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let objects: Vec<PerceivedObject> = Vec::new();
+    let cfg = VehicleConfig::default_urban();
+
+    let verdict = validate_trajectory_slow(
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Degraded,
+    );
+    assert!(
+        matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "Degraded decel-to-stop trajectory must be admitted (not MRCFallback); got {verdict:?}"
+    );
+}
+
+#[test]
 fn locked_out_short_circuits_to_mrcfallback() {
     // Even a perfectly clean trajectory must produce MRCFallback under
     // LockedOut. The geometry checks are not required to run — the

--- a/docs/kinematics_envelope_protection.md
+++ b/docs/kinematics_envelope_protection.md
@@ -146,9 +146,18 @@ the command is *contextually correct for the environment* is the planner's probl
 
 ### MRC Fallback Profile
 
+> **Issue #70 — Degraded is decel-to-stop-and-HOLD, not a crawl.** Under the
+> Degraded posture this profile is the **decel-trajectory bound** — the upper
+> bound on a command that is already *converging toward zero* — NOT a crawl
+> set-point the vehicle is driven up to. The Degraded enforcement
+> (`enforce_degraded_decel_to_stop`) additionally requires non-increasing
+> speed and forbids re-initiation of motion from a stop. The values below are
+> the envelope ceilings for a permitted (decelerating) command; see
+> `docs/safety/SAFE_STATE_SPECIFICATION.md` SS-002.
+
 | Parameter | Value | Rationale |
 | :--- | :--- | :--- |
-| `max_speed_mps` | 5.0 (~11 mph) | Safe, limp-home crawling speed |
+| `max_speed_mps` | 5.0 (~11 mph) | Ceiling for a decelerating command (decel-trajectory bound); never a sustained crawl set-point (issue #70) |
 | `max_accel_mps2` | 1.0 | Highly subdued acceleration curve |
 | `max_brake_mps2` | 3.0 | Gradual slowdown profile |
 | `max_steering_deg` | 15.0 | Restricts high-amplitude maneuvering |

--- a/docs/safety/SAFE_STATE_SPECIFICATION.md
+++ b/docs/safety/SAFE_STATE_SPECIFICATION.md
@@ -1,10 +1,18 @@
 # Kirra Safe State Specification
 
 Document ID: KIRRA-SSS-001
-Version: 1.0
+Version: 1.1
 Status: Active
 Standard: ISO 26262 ASIL-D
-Date: 2026-05-29
+Date: 2026-06-03
+
+Change log:
+  - v1.1 (2026-06-03, Issue #70): SS-002 Degraded redefined from "MRC
+    reduced-speed crawl" to "controlled decel-to-stop-and-HOLD with no
+    autonomous re-initiation of motion"; added the Cruise Oct-2023
+    pullover-drag rationale; disambiguated Degraded MRC envelope vs LockedOut
+    MRC fallback; folded in the Issue #49 closeout (§7). Behavior change, not
+    docs-only — enforced by `enforce_degraded_decel_to_stop`.
 
 ## 1. Overview
 
@@ -40,12 +48,55 @@ Safety goals covered: SG-001, SG-002, SG-004, SG-005, SG-011
 
 ---
 
-### SS-002: Minimum Risk Condition (PostureState::Degraded)
+### SS-002: Minimum Risk Condition — Controlled Decel-to-Stop and Hold (PostureState::Degraded)
 
-Behavior:
-  `MRC_VELOCITY_CEILING_MPS` (5.0 m/s) cap applied by `KirraGovernor`
-  `apply_mrc_profile()`. System continues operating in reduced-capability
-  mode. Commands forwarded but velocity capped at 5.0 m/s.
+Behavior (Issue #70):
+  Degraded is a **controlled decel-to-stop-and-HOLD**, NOT a sustained
+  reduced-speed crawl. The Governor permits a command in Degraded **only if
+  all** of the following hold; otherwise it is denied and the actuator falls
+  to the MRC controlled stop:
+
+  - **(a) within the MRC kinematic envelope** — the MRC profile
+    (`MRC_VELOCITY_CEILING_MPS` = 5.0 m/s speed cap, plus the MRC
+    accel/brake/steering/lateral limits) acts as the **decel-trajectory
+    bound** for a *still-moving, decelerating* command — it is the upper
+    bound on a command that is already converging toward zero, NOT a crawl
+    set-point the vehicle is driven up to;
+  - **(b) non-increasing speed** — `|proposed| ≤ |current|`. Any speed
+    increase is denied (`DenyCode::DegradedSpeedIncreaseDenied`);
+  - **(c) no autonomous re-initiation of motion** — if the vehicle is
+    stopped (`|current| ≤ STOP_EPSILON_MPS`, 0.05 m/s), any command above
+    the stop floor is denied (`DenyCode::DegradedReinitiationDenied`); the
+    vehicle HOLDS at zero. A direction reversal through a stop is likewise
+    treated as re-initiation and denied.
+
+  Enforced by `enforce_degraded_decel_to_stop` at every Degraded enforcement
+  point (gateway `enforce_actuator_safety_envelope`, fabric
+  `AssetGovernor::evaluate_command`, ros2-adapter `validate_trajectory_slow`,
+  and parko-kirra `KirraGovernor::apply_mrc_profile` — the last also gates an
+  *independent angular-velocity* channel for differential-drive platforms).
+  The net effect: a vehicle that enters Degraded while moving bleeds speed to
+  a standstill under the MRC bound and then holds; a stopped vehicle stays
+  stopped. **The Governor never authors re-acceleration.**
+
+Rationale — **Cruise, San Francisco, October 2023.** After an initial
+  collision, a robotaxi executed an automated pullover **from a stop** and
+  dragged a pedestrian who was pinned under the vehicle roughly 20 ft at
+  ~3 m/s. A 3 m/s pullover-from-stop sits *below* a 5 m/s reduced-speed crawl
+  ceiling — so the prior "Degraded = MRC crawl" behavior would have
+  **permitted** exactly that maneuver. SS-002 is therefore defined as
+  decel-to-stop-and-HOLD with no autonomous re-initiation: under a degraded
+  safety posture the safe action is to stop and stay stopped, not to perform
+  a discretionary low-speed maneuver. (A *legitimate* pullover requires full
+  situational competence and belongs to SS-001 Nominal — by design it is out
+  of scope for Degraded.)
+
+"MRC" disambiguation: the **Degraded MRC** here is the decel-to-stop
+  *envelope* (the bound on a converging command). It is distinct from the
+  **LockedOut MRC fallback** (SS-003), which is the safe-stop *maneuver* the
+  actuator performs when every command is denied. Both drive toward a
+  standstill; Degraded additionally permits a cooperative decelerating
+  command, LockedOut permits none.
 
 Entry conditions (any of):
   - SG-003: Sensor telemetry timeout (`AV_TELEMETRY_TIMEOUT_MS` exceeded)
@@ -54,13 +105,20 @@ Entry conditions (any of):
   - Node trust state `Untrusted` with non-critical dependency impact
   - `Degraded` posture propagated from dependency graph
 
-Recovery:
+Recovery (AUTOMATIC):
   `AV_RECOVERY_STREAK_THRESHOLD` (5) consecutive clean ticks within
-  `AV_RECOVERY_WINDOW_MS` (10,000 ms) → transitions to SS-001 Nominal.
-  A single unhealthy report or gap in the window resets streak to 0.
-  (SG-013)
+  `AV_RECOVERY_WINDOW_MS` (10,000 ms) → transitions to SS-001 Nominal, and
+  only then may motion be (re-)initiated. A single unhealthy report or gap in
+  the window resets streak to 0. (SG-013) This is the key contrast with
+  SS-003: Degraded recovery is automatic on return to Nominal, whereas
+  LockedOut requires an explicit human reset.
 
 Implements: ISO 26262 safe state for recoverable faults.
+
+Issue-#49 closeout: #49 ("Degraded must converge to 0") is realized by this
+  decel-to-stop-and-HOLD behavior — convergence to zero is the (b)+(c)
+  invariant, and "hold at zero" is the no-re-initiation rule. See the
+  loose-ends note in §7.
 
 Safety goals covered: SG-003, SG-005, SG-013
 
@@ -70,8 +128,15 @@ Safety goals covered: SG-003, SG-005, SG-013
 
 Behavior:
   0.0 m/s hard stop. No commands forwarded to actuators under any
-  circumstance. Human intervention required to clear.
+  circumstance — every command is denied and the actuator performs its
+  **MRC fallback** safe-stop maneuver. Human intervention required to clear.
   `LockedOut` dominates all other posture states.
+
+  "MRC" note: the LockedOut **MRC fallback** is the safe-stop *maneuver*
+  executed when all commands are denied (e.g. `mrc_command` / MRC fallback
+  profile → zero velocity, max-decel brake ramp). It is distinct from the
+  SS-002 Degraded MRC *envelope*, which still admits a cooperative
+  decelerating command. LockedOut admits none.
 
 Entry conditions (any of):
   - DAG cycle detected in dependency graph
@@ -149,9 +214,15 @@ The following invariants are enforced in code and must never be
 violated regardless of what upstream AI systems instruct:
 
 1.  `LockedOut` can only be cleared by human reset — never automatic
-2.  `Degraded` recovery requires N consecutive clean ticks — not immediate
+2.  `Degraded` recovery requires N consecutive clean ticks — not immediate;
+    recovery is AUTOMATIC on return to Nominal (contrast invariant 1)
 3.  Governor unreachable → `Degraded` semantics (NOT `LockedOut`)
 4.  RSS unsafe → `Degraded` semantics (NOT `LockedOut`)
+4a. `Degraded` is decel-to-stop-and-HOLD: a command is admitted only if it is
+    non-increasing in speed AND does not re-initiate motion from a stop
+    (`enforce_degraded_decel_to_stop`); a stopped vehicle HOLDS, and the
+    Governor never authors re-acceleration. Motion may be (re-)initiated only
+    after recovery to SS-001 Nominal. (Issue #70 — Cruise 2023 pullover-drag)
 5.  NaN / Inf model output → safe floor applied before governor runs
 6.  DAG `LockedOut` propagates upward — never downgraded by RSS recovery
 7.  `LockedOut` dominates `Degraded` — if both conditions present,
@@ -190,9 +261,56 @@ This section shrinks as CERT-004 implements each test.
 
 ---
 
-## 6. Implementation References
+## 6. Issue #49 Closeout and Loose Ends
+
+Issue #49 (PARK-037) — "Integrate Parko + KirraGovernor with ROS2 cmd_vel
+topics; Governor clamps observable on `filtered_cmd_vel`; closed-loop on
+Hiwonder" — has a **safety-behavior** portion and a **wiring/hardware**
+portion. This change (Issue #70) closes the former; the latter remains.
+
+CLOSED by this change (the Degraded-converge-to-zero safety semantics):
+  - The Degraded posture now provably converges the vehicle to a standstill
+    and holds it there (the SS-002 (b)+(c) invariant), realized uniformly at
+    all four enforcement points via `enforce_degraded_decel_to_stop`. The
+    "Degraded → 0" intent #49 carried is now a tested, fail-closed behavior
+    (decel-to-stop-and-HOLD, no autonomous re-initiation).
+
+LOOSE ENDS — NOT closed here (tracked separately, do not auto-close #49 on
+this change alone):
+  1. **ROS2 topic naming / observability.** The roadmap (PARK-037,
+     `work/roadmap.md`) expects governor clamps to be observable on a
+     dedicated `filtered_cmd_vel` topic. The adapter currently publishes the
+     single gated output to the configurable `~/output/cmd_vel`
+     (`parko/crates/parko-ros2/src/config.rs`,
+     `crates/kirra-ros2-adapter`), not a separate `filtered_cmd_vel`. Whether
+     to add a distinct filtered-output topic (raw vs gated, for observability)
+     vs keep the single gated topic is an integration decision, not a safety
+     one — out of scope for #70.
+  2. **Hiwonder closed-loop hardware verification.** #49's acceptance includes
+     on-hardware closed-loop validation on the Hiwonder platform. This change
+     is verified in-process (unit + the `governor_closes_loop_proof` axis);
+     hardware bring-up is separate.
+  3. **#49 ↔ #92 scope overlap.** Triage (`docs/ISSUE_TRIAGE_2026-06-01.md`)
+     flags overlap between #49 (ROS2 cmd_vel wiring) and #92 (Occy Governor
+     trajectory check). The overlap is unaffected by — and orthogonal to —
+     the Degraded behavior change here.
+
+Recommendation: close the Degraded-converge-to-0 sub-goal of #49 against this
+change and re-scope the remaining #49 work (topic naming, Hiwonder bring-up)
+to its own follow-up issue, rather than auto-closing #49 in full.
+
+---
+
+## 7. Implementation References
 
 - `PostureState` enum: `src/posture_engine.rs` (or `src/verifier.rs`)
+- Degraded decel-to-stop-and-hold gate (Issue #70):
+  `enforce_degraded_decel_to_stop` + `STOP_EPSILON_MPS` in
+  `src/gateway/kinematics_contract.rs`; wired at
+  `src/gateway/policy_layer.rs`, `src/fabric/governor.rs`,
+  `crates/kirra-ros2-adapter/src/validation.rs`, and
+  `parko/crates/parko-kirra/src/lib.rs` (`apply_mrc_profile`,
+  + `STOP_EPSILON_RAD_S` angular gate)
 - `KirraGovernor` authority model: `parko/parko-kirra/src/lib.rs`
 - `startup_sentinel`: `src/bin/kirra_verifier_service.rs`
 - `should_route_command`: `src/posture_cache.rs`

--- a/parko/INTEGRATION.md
+++ b/parko/INTEGRATION.md
@@ -225,7 +225,7 @@ response per state:
 | Posture | Governor behaviour |
 |---|---|
 | `Nominal` | Full envelope: Kirra kinematics contract on linear, SOTIF bound on angular |
-| `Degraded` | MRC profile: linear clamped to `MRC_VELOCITY_CEILING_MPS = 5.0`, angular derated by `mrc_posture_factor` |
+| `Degraded` | **Controlled decel-to-stop-and-HOLD (issue #70)** — NOT a sustained crawl. A command is admitted only if it is non-increasing in speed AND does not re-initiate motion from a stop (per channel: linear floor `STOP_EPSILON_MPS = 0.05`, angular floor `STOP_EPSILON_RAD_S = 0.02`); a *permitted* (decelerating) command is then clamped to the MRC envelope (linear ≤ `MRC_VELOCITY_CEILING_MPS = 5.0`, angular derated by `mrc_posture_factor`). A speed increase or re-initiation from rest returns `Deny { reason: "DEGRADED_SPEED_INCREASE_DENIED" / "DEGRADED_REINITIATION_DENIED" }` → MRC controlled stop. `previous` (last commanded) supplies the current velocity; `None` ⇒ treated as stopped (fail-closed). |
 | `LockedOut` | Hard stop — every command returns `Deny { reason: "LockedOut: hard stop" }` |
 
 ### 3.5 GovernorComparator (dual-governor lockstep)
@@ -563,7 +563,10 @@ code at branch `feat/parko-integration-spec`, off main `8eadf83`.
 | `ComparatorAsGovernor` newtype | `parko/crates/parko-ros2/src/comparator_adapter.rs` |
 | `PlatformParams` + `conservative_default()` + `urban_service_robot_reference()` + `AngularVelocityBound` | `parko/crates/parko-kirra/src/angular_bound.rs:50`, `:191` |
 | `URBAN_ODD_SPEED_CAP_MPS = 22.35` | `src/gateway/kinematics_contract.rs:43` |
-| `MRC_VELOCITY_CEILING_MPS = 5.0` | `parko/crates/parko-kirra/src/lib.rs:54` |
+| `MRC_VELOCITY_CEILING_MPS = 5.0` (decel-trajectory bound, not a crawl set-point — issue #70) | `parko/crates/parko-kirra/src/lib.rs` |
+| `STOP_EPSILON_MPS = 0.05` (linear stop floor, Degraded no-re-initiation) | `src/gateway/kinematics_contract.rs` |
+| `STOP_EPSILON_RAD_S = 0.02` (angular stop floor, Degraded no-re-initiation) | `parko/crates/parko-kirra/src/lib.rs` |
+| `enforce_degraded_decel_to_stop` (Degraded decel-to-stop-and-hold gate, issue #70) | `src/gateway/kinematics_contract.rs` |
 | `VehicleKinematicsContract` field set (max_speed_mps / odd_speed_cap_mps / max_accel_mps2 / max_brake_mps2 / max_steering_deg / max_steering_rate_deg_s / min_follow_distance_m / max_lateral_accel_mps2 / wheelbase_m / width_m / length_m / overhang_front_m / overhang_rear_m) | `src/gateway/kinematics_contract.rs:54` |
 | `VehicleConfig::default_urban`, `warn_if_missing_odd_cap` | `crates/kirra-ros2-adapter/src/config.rs` |
 | `PostureTracker`, `POSTURE_STALENESS_TIMEOUT_MS = 6_000` | `src/posture_tracker.rs:57` |

--- a/parko/crates/parko-core/tests/posture_divergence_proptest.rs
+++ b/parko/crates/parko-core/tests/posture_divergence_proptest.rs
@@ -4,14 +4,19 @@
 // within the Kirra profile velocity ceiling for each SafetyPosture. This is
 // the core correctness invariant for the governor integration.
 //
-// KirraGovernor posture authority model:
+// KirraGovernor posture authority model (Issue #70):
 //   Nominal   → validate_vehicle_command (nominal profile, 35.0 m/s ceiling + rate limits)
-//   Degraded  → direct cap at MRC fallback ceiling (5.0 m/s), no rate limits
+//   Degraded  → controlled DECEL-TO-STOP-and-HOLD: a command is permitted only
+//               if it is non-increasing in speed and does not re-initiate motion
+//               from a stop; a permitted (decelerating) command is then capped
+//               at the MRC fallback ceiling (5.0 m/s). A speed increase or a
+//               re-initiation from rest is DENIED (→ 0.0, MRC controlled stop).
 //   LockedOut → hard stop (Deny → 0.0 m/s), regardless of proposed velocity
 //
-// The nominal profile also applies rate-of-change limits; with previous=None
-// the effective output is bounded by both the speed cap and the acceleration
-// limit over one tick period.
+// Because the Degraded gate is relative to the CURRENT velocity, these
+// properties pass a `previous` (last commanded) velocity: a moving,
+// non-increasing history isolates the MRC-cap property from the gate; a
+// `None`/zero history exercises the no-re-initiation property.
 //
 // Run with: cargo test -p parko-core
 
@@ -36,15 +41,27 @@ fn effective_linear_velocity(action: EnforcementAction, proposed: f64) -> f64 {
     }
 }
 
-fn evaluate_governor(proposed: f64, posture: SafetyPosture) -> f64 {
+/// Evaluate with an explicit previous (current) velocity. `None` ⇒ no history
+/// (treated as stopped by the Degraded gate).
+fn evaluate_governor_with(proposed: f64, previous: Option<f64>, posture: SafetyPosture) -> f64 {
     let governor = KirraGovernor::new();
     let cmd = ControlCommand {
         linear_velocity: proposed,
         angular_velocity: 0.0,
         timestamp_ms: 0,
     };
-    let action = governor.evaluate(&cmd, None, 0.05, posture);
+    let prev = previous.map(|v| ControlCommand {
+        linear_velocity: v,
+        angular_velocity: 0.0,
+        timestamp_ms: 0,
+    });
+    let action = governor.evaluate(&cmd, prev.as_ref(), 0.05, posture);
     effective_linear_velocity(action, proposed)
+}
+
+/// Backward-compatible helper: no history (`previous = None`).
+fn evaluate_governor(proposed: f64, posture: SafetyPosture) -> f64 {
+    evaluate_governor_with(proposed, None, posture)
 }
 
 proptest! {
@@ -68,19 +85,42 @@ proptest! {
         );
     }
 
-    /// Degraded posture: output must equal exactly proposed.min(MRC_VELOCITY_CEILING_MPS).
-    /// A ceiling check (<=) is insufficient — the exact contract must hold.
+    /// Degraded posture, DECELERATING command (Issue #70): a non-increasing
+    /// command (previous == proposed) passes the decel-to-stop gate and is
+    /// capped at the MRC ceiling — output must equal exactly
+    /// proposed.min(MRC_VELOCITY_CEILING_MPS). A ceiling check (<=) is
+    /// insufficient — the exact MRC-cap contract must hold for a permitted
+    /// command.
     #[test]
     fn governor_degraded_applies_exact_mrc_contract(
         proposed in 0.0f64..=1000.0f64
     ) {
         prop_assume!(proposed.is_finite());
-        let output = evaluate_governor(proposed, SafetyPosture::Degraded);
+        // previous == proposed ⇒ non-increasing (decel/hold), passes the gate.
+        let output = evaluate_governor_with(proposed, Some(proposed), SafetyPosture::Degraded);
         prop_assert_eq!(
             output,
             proposed.min(MRC_VELOCITY_CEILING_MPS),
-            "Degraded: expected min({}, {}), got {}",
+            "Degraded (decelerating): expected min({}, {}), got {}",
             proposed, MRC_VELOCITY_CEILING_MPS, output
+        );
+    }
+
+    /// Degraded posture, RE-INITIATION from rest (Issue #70 — Cruise lesson):
+    /// with no motion history (previous = None ⇒ stopped), any command above
+    /// the stop floor must be DENIED → 0.0. The governor never autonomously
+    /// re-initiates motion under Degraded.
+    #[test]
+    fn governor_degraded_denies_reinitiation_from_rest(
+        proposed in 0.1f64..=1000.0f64
+    ) {
+        prop_assume!(proposed.is_finite());
+        let output = evaluate_governor(proposed, SafetyPosture::Degraded);
+        prop_assert_eq!(
+            output,
+            0.0,
+            "Degraded must deny re-initiation from rest (got {} for proposed {})",
+            output, proposed
         );
     }
 
@@ -102,19 +142,24 @@ proptest! {
         );
     }
 
-    /// LockedOut is strictly more restrictive than Degraded: for any positive
-    /// proposed velocity, the LockedOut output (0.0) must be less than the
-    /// Degraded output (capped at MRC ceiling, > 0 when proposed > 0).
+    /// LockedOut is at least as restrictive as Degraded, and strictly more so
+    /// when Degraded admits motion. For a DECELERATING command (previous ==
+    /// proposed, so the decel-to-stop gate passes), Degraded keeps the vehicle
+    /// moving (capped at the MRC ceiling, > 0 for proposed > 0) while LockedOut
+    /// is a hard stop (0.0). (Issue #70: for a re-initiation-from-rest command
+    /// the two coincide at 0.0 — both refuse to start motion — so the strict
+    /// inequality is asserted on the case where Degraded is permitted to move.)
     #[test]
     fn locked_out_is_more_restrictive_than_degraded(
         proposed in 0.001f64..=1000.0f64
     ) {
         prop_assume!(proposed.is_finite());
-        let degraded_out = evaluate_governor(proposed, SafetyPosture::Degraded);
+        let degraded_out =
+            evaluate_governor_with(proposed, Some(proposed), SafetyPosture::Degraded);
         let locked_out = evaluate_governor(proposed, SafetyPosture::LockedOut);
         prop_assert!(
             locked_out < degraded_out,
-            "LockedOut ({}) must be < Degraded ({}) for proposed {}",
+            "LockedOut ({}) must be < Degraded ({}) for a decelerating proposed {}",
             locked_out, degraded_out, proposed
         );
     }

--- a/parko/crates/parko-core/tests/rss_governor_proptest.rs
+++ b/parko/crates/parko-core/tests/rss_governor_proptest.rs
@@ -3,11 +3,17 @@
 // Property-based tests for the RSS pre-actuator gate in KirraGovernor.
 // Three posture variants × 10,000 cases each.
 //
-// Authority model (ADL-001, commits 9943aa9/e1ba1a2/21c3a35):
+// Authority model (ADL-001; Issue #70 decel-to-stop-and-hold):
 //   LockedOut → 0.0                             (hard stop)
-//   Degraded  → min(proposed, MRC_VELOCITY_CEILING_MPS)
+//   Degraded  → decel-to-stop-and-HOLD: a non-increasing / non-re-initiating
+//               command is permitted then capped at MRC_VELOCITY_CEILING_MPS;
+//               a speed increase or re-initiation from rest is denied (→ 0.0).
 //   Nominal   → nominal profile
-//   RSS unsafe → Degraded semantics (MRC cap)   (NOT a hard stop)
+//   RSS unsafe → Degraded semantics                (NOT a hard stop)
+//
+// The MRC-cap blocks below pass a non-increasing `previous` (== commanded) so
+// the Issue #70 gate is satisfied and the exact MRC-cap contract is what the
+// property exercises.
 //
 // Input strategy: bounded ranges matching plausible vehicle operating
 // parameters, not arbitrary f64. Avoids NaN/Inf edge cases and focuses
@@ -63,7 +69,10 @@ proptest! {
             lateral_margin: f64::MAX,
         });
 
-        let action  = gov.evaluate(&make_cmd(commanded), None, 0.05, SafetyPosture::Nominal);
+        // Issue #70: non-increasing history so the RSS-unsafe MRC path's
+        // decel-to-stop gate passes and the MRC-cap property is exercised.
+        let prev = make_cmd(commanded);
+        let action  = gov.evaluate(&make_cmd(commanded), Some(&prev), 0.05, SafetyPosture::Nominal);
         let out_vel = effective_linear_velocity(action, commanded);
 
         if !rss_safe {
@@ -103,7 +112,10 @@ proptest! {
             lateral_margin: f64::MAX,
         });
 
-        let action  = gov.evaluate(&make_cmd(commanded), None, 0.05, SafetyPosture::Degraded);
+        // Issue #70: non-increasing history so the Degraded decel-to-stop gate
+        // passes and the MRC-cap property is exercised.
+        let prev = make_cmd(commanded);
+        let action  = gov.evaluate(&make_cmd(commanded), Some(&prev), 0.05, SafetyPosture::Degraded);
         let out_vel = effective_linear_velocity(action, commanded);
         let expected = commanded.min(MRC_VELOCITY_CEILING_MPS);
 

--- a/parko/crates/parko-kirra/src/diverse.rs
+++ b/parko/crates/parko-kirra/src/diverse.rs
@@ -76,7 +76,8 @@ use parko_core::RssState;
 
 use crate::angular_bound::{AngularVelocityBound, PlatformParams};
 use crate::comparator::RssAwareGovernor;
-use crate::MRC_VELOCITY_CEILING_MPS;
+use crate::{degraded_channel_violation, MRC_VELOCITY_CEILING_MPS, STOP_EPSILON_RAD_S};
+use kirra_runtime_sdk::gateway::kinematics_contract::STOP_EPSILON_MPS;
 
 /// Acceleration-space tolerance used by the primary's rate checks
 /// (`max_accel_mps2 + 1e-9`). Mirrored here so the diverse interval test
@@ -210,13 +211,29 @@ impl DiverseKirraGovernor {
         }
     }
 
-    /// Minimum-risk envelope (Degraded / RSS-unsafe). Mirrors the primary's
-    /// `apply_mrc_profile` effect — linear capped at the MRC ceiling, angular
-    /// capped at the MRC ω_max evaluated at the post-cap linear speed — but
+    /// Minimum-risk enforcement (Degraded / RSS-unsafe). Mirrors the primary's
+    /// `apply_mrc_profile`: first the Issue #70 decel-to-stop-and-HOLD gate
+    /// (deny any speed increase / re-initiation on either channel relative to
+    /// `previous`), then — for a converging command — the MRC envelope clamp,
     /// expressed with an explicit over-ceiling guard and `copysign`.
-    fn enforce_minimum_risk(&self, proposed: &ControlCommand) -> EnforcementAction {
+    fn enforce_minimum_risk(
+        &self,
+        proposed: &ControlCommand,
+        previous: Option<&ControlCommand>,
+    ) -> EnforcementAction {
         let v = proposed.linear_velocity;
         let w = proposed.angular_velocity;
+
+        // Issue #70 stop-and-hold gate (both channels) — identical thresholds
+        // and reason tokens as the primary, so the two governors agree.
+        let cur_lin = previous.map(|p| p.linear_velocity).unwrap_or(0.0);
+        let cur_ang = previous.map(|p| p.angular_velocity).unwrap_or(0.0);
+        if let Some(reason) = degraded_channel_violation(cur_lin, v, STOP_EPSILON_MPS) {
+            return EnforcementAction::Deny { reason: reason.to_string() };
+        }
+        if let Some(reason) = degraded_channel_violation(cur_ang, w, STOP_EPSILON_RAD_S) {
+            return EnforcementAction::Deny { reason: reason.to_string() };
+        }
 
         // DIFFERENCE #4 — over-ceiling guard instead of `v.min(MRC)`.
         let capped_linear = if v > MRC_VELOCITY_CEILING_MPS {
@@ -354,7 +371,7 @@ impl SafetyGovernor for DiverseKirraGovernor {
             Regime::HardStop => EnforcementAction::Deny {
                 reason: "DiverseKirraGovernor: locked-out hard stop".to_string(),
             },
-            Regime::MinimumRisk => self.enforce_minimum_risk(proposed),
+            Regime::MinimumRisk => self.enforce_minimum_risk(proposed, previous),
             Regime::Nominal => self.enforce_nominal(proposed, previous, delta_time_s),
         }
     }
@@ -608,9 +625,12 @@ mod tests {
         use crate::comparator::RssAwareGovernor;
         let mut gov = DiverseKirraGovernor::new();
         RssAwareGovernor::set_rss_state(&mut gov, unsafe_rss());
-        // RSS unsafe ⇒ MRC path ⇒ 20 m/s clamped to the MRC ceiling (5.0),
-        // not the ~35 m/s Nominal envelope.
-        let out = gov.evaluate(&twist(20.0, 0.0), None, 0.05, SafetyPosture::Nominal);
+        // RSS unsafe ⇒ MRC path ⇒ a 20 m/s DECELERATING command clamped to the
+        // MRC ceiling (5.0), not the ~35 m/s Nominal envelope. (Issue #70: a
+        // moving `previous` so the decel-to-stop gate passes and the MRC clamp
+        // is what this exercises — a re-initiation from rest would Deny.)
+        let prev = twist(20.0, 0.0);
+        let out = gov.evaluate(&twist(20.0, 0.0), Some(&prev), 0.05, SafetyPosture::Nominal);
         let v = effective_lin(&out, 20.0);
         assert!((v - MRC_VELOCITY_CEILING_MPS).abs() < 1e-9,
             "set_rss_state(unsafe) must route to MRC ceiling {MRC_VELOCITY_CEILING_MPS}, got {v}");

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -34,6 +34,7 @@
 
 use kirra_runtime_sdk::gateway::kinematics_contract::{
     validate_vehicle_command, EnforceAction, ProposedVehicleCommand, VehicleKinematicsContract,
+    STOP_EPSILON_MPS,
 };
 // `DenyCode` is reached via `EnforceAction::DenyBreach` — see the Nominal branch below.
 use kirra_runtime_sdk::verifier::FleetPosture;
@@ -49,11 +50,56 @@ pub use angular_bound::{AngularVelocityBound, PlatformParams, ROLLOVER_MIN_LINEA
 pub use comparator::{GovernorComparator, RssAwareGovernor};
 pub use diverse::DiverseKirraGovernor;
 
-/// MRC (Minimum Risk Condition) velocity ceiling.
-/// Applied when posture is Degraded or RSS state is unsafe.
-/// NOT applied to LockedOut — LockedOut is a hard stop (0.0).
+/// MRC (Minimum Risk Condition) velocity ceiling — the decel-trajectory
+/// bound applied to a *decelerating* command under Degraded / RSS-unsafe.
+/// NOT a crawl set-point: as of Issue #70, Degraded is decel-to-stop-and-HOLD
+/// (see `apply_mrc_profile`), so this ceiling bounds how fast a still-moving,
+/// converging-to-zero command may be — it never licenses re-initiation or a
+/// speed increase. NOT applied to LockedOut — LockedOut is a hard stop (0.0).
 /// Single source of truth. Per ADL-001.
 pub const MRC_VELOCITY_CEILING_MPS: f64 = 5.0;
+
+/// Angular-velocity magnitude (rad/s) at or below which the platform is
+/// treated as **not rotating** for the Issue #70 Degraded no-re-initiation
+/// invariant on the angular channel (≈ 1.1 deg/s — above gyro noise, below
+/// any deliberate turn). The angular analogue of `STOP_EPSILON_MPS`.
+///
+/// JUDGMENT-CALL (Issue #70 FLAG #2): differential-drive platforms have an
+/// independent angular-velocity actuator, so the converge-to-zero /
+/// no-re-initiation rule is applied to the angular channel natively here
+/// (unlike the Ackermann bicycle model, where yaw rate `ω = v·tan δ/L`
+/// vanishes with linear speed and needs no separate angular gate).
+pub const STOP_EPSILON_RAD_S: f64 = 0.02;
+
+/// Issue #70 Degraded single-channel gate: returns `Some(reason)` when a
+/// proposed value on one motion channel (linear or angular) violates the
+/// decel-to-stop-and-HOLD invariant relative to the current value, else
+/// `None`. The `reason` tokens match the Kirra-SDK `DenyCode` audit strings
+/// (`DEGRADED_REINITIATION_DENIED` / `DEGRADED_SPEED_INCREASE_DENIED`) so the
+/// cross-crate deny vocabulary stays identical.
+///
+/// `current`/`proposed` are signed; `eps` is the channel's stop floor.
+/// Fails closed on non-finite input.
+fn degraded_channel_violation(current: f64, proposed: f64, eps: f64) -> Option<&'static str> {
+    if !proposed.is_finite() || !current.is_finite() {
+        return Some("DEGRADED_REINITIATION_DENIED");
+    }
+    let cur_mag = current.abs();
+    let prop_mag = proposed.abs();
+    // (c) no re-initiation from a stop / hold.
+    if cur_mag <= eps && prop_mag > eps {
+        return Some("DEGRADED_REINITIATION_DENIED");
+    }
+    // (c') no direction reversal through a stop while moving.
+    if proposed.signum() != current.signum() && cur_mag > eps && prop_mag > eps {
+        return Some("DEGRADED_REINITIATION_DENIED");
+    }
+    // (b) non-increasing magnitude.
+    if prop_mag > cur_mag + 1e-9 {
+        return Some("DEGRADED_SPEED_INCREASE_DENIED");
+    }
+    None
+}
 
 /// **Angular-velocity bound — SOTIF-derived (issue #136).**
 ///
@@ -212,19 +258,50 @@ impl KirraGovernor {
 }
 
 impl KirraGovernor {
-    /// Applies the MRC envelope on BOTH axes — Degraded semantics. Used
-    /// by both the Degraded posture branch and the RSS unsafe gate. NOT
-    /// used for LockedOut (which is a hard stop returning 0.0).
+    /// Applies the Degraded / RSS-unsafe enforcement: **controlled
+    /// decel-to-stop-and-HOLD** (Issue #70) on BOTH axes, with the MRC
+    /// envelope as the decel-trajectory bound. Used by both the Degraded
+    /// posture branch and the RSS unsafe gate. NOT used for LockedOut (which
+    /// is a hard stop returning 0.0).
     ///
-    /// Most-restrictive-wins across the two axes:
-    ///   - linear within cap + angular within cap  → Allow
-    ///   - linear over cap   + angular within cap  → ClampLinearVelocity
-    ///   - linear within cap + angular over cap    → ClampAngularVelocity
-    ///   - both over cap                            → ClampMotion { Some, Some }
-    // SAFETY: SG8 | REQ: mrc-envelope-multiaxis-clamp | TEST: degraded_above_cap_clamps_to_mrc_ceiling,rss_unsafe_above_ceiling_clamps_to_mrc,degraded_angular_above_bound_clamps_to_mrc_angular_ceiling,degraded_both_axes_above_bound_returns_clampmotion
-    // (MRC envelope contraction on Degraded posture — clamps both linear
-    //  and angular axes rather than denying outright. H1 closeout.)
-    fn apply_mrc_profile(&self, proposed: &ControlCommand) -> EnforcementAction {
+    /// Two stages, gate then clamp:
+    ///   1. **Stop-and-hold gate** — per channel (linear and angular,
+    ///      `degraded_channel_violation`): deny any speed increase or
+    ///      re-initiation from a stop. `current` is taken from `previous`
+    ///      (the last commanded value; `None` ⇒ treated as stopped, so a
+    ///      first-cycle motion command fails closed). A violation on either
+    ///      channel → `Deny` (the actuator falls to the controlled stop);
+    ///      the Governor does not author a replacement command.
+    ///   2. **MRC envelope clamp** (unchanged) — for a command that passed
+    ///      the gate (converging toward zero), most-restrictive-wins:
+    ///        - linear within cap + angular within cap  → Allow
+    ///        - linear over cap   + angular within cap  → ClampLinearVelocity
+    ///        - linear within cap + angular over cap    → ClampAngularVelocity
+    ///        - both over cap                            → ClampMotion { Some, Some }
+    // SAFETY: SG8 | REQ: degraded-decel-to-stop-and-hold-multiaxis | TEST: degraded_above_cap_clamps_to_mrc_ceiling,rss_unsafe_above_ceiling_clamps_to_mrc,degraded_angular_above_bound_clamps_to_mrc_angular_ceiling,degraded_both_axes_above_bound_returns_clampmotion,degraded_reinitiation_from_stop_is_denied,degraded_angular_reinitiation_from_stop_is_denied
+    // (Issue #70: Degraded is decel-to-stop-and-HOLD, not an MRC crawl —
+    //  no autonomous re-initiation on either axis; clamps a converging
+    //  command to the MRC envelope.)
+    fn apply_mrc_profile(
+        &self,
+        proposed: &ControlCommand,
+        previous: Option<&ControlCommand>,
+    ) -> EnforcementAction {
+        // Stage 1 — Issue #70 stop-and-hold gate (both channels).
+        let cur_lin = previous.map(|p| p.linear_velocity).unwrap_or(0.0);
+        let cur_ang = previous.map(|p| p.angular_velocity).unwrap_or(0.0);
+        if let Some(reason) =
+            degraded_channel_violation(cur_lin, proposed.linear_velocity, STOP_EPSILON_MPS)
+        {
+            return EnforcementAction::Deny { reason: reason.to_string() };
+        }
+        if let Some(reason) =
+            degraded_channel_violation(cur_ang, proposed.angular_velocity, STOP_EPSILON_RAD_S)
+        {
+            return EnforcementAction::Deny { reason: reason.to_string() };
+        }
+
+        // Stage 2 — MRC envelope clamp (unchanged).
         let safe_linear = proposed.linear_velocity.min(MRC_VELOCITY_CEILING_MPS);
         let linear_clamped = safe_linear < proposed.linear_velocity;
         // SOTIF-derived: ω_max evaluated at the COMMAND's linear
@@ -283,15 +360,16 @@ impl SafetyGovernor for KirraGovernor {
             };
         }
 
-        // RSS gate second — unsafe state applies Degraded semantics (MRC cap).
-        // Per ADL-001: a sensor gap is recoverable; hard stop (0.0) is not.
+        // RSS gate second — unsafe state applies Degraded semantics
+        // (decel-to-stop-and-HOLD, Issue #70). Per ADL-001: a sensor gap is
+        // recoverable; hard stop (0.0) is not.
         if !self.rss_state.safe {
-            return self.apply_mrc_profile(proposed);
+            return self.apply_mrc_profile(proposed, previous);
         }
 
         match posture {
             SafetyPosture::LockedOut => unreachable!("handled above"),
-            SafetyPosture::Degraded => self.apply_mrc_profile(proposed),
+            SafetyPosture::Degraded => self.apply_mrc_profile(proposed, previous),
             SafetyPosture::Nominal => {
                 let current_velocity = previous.map(|p| p.linear_velocity).unwrap_or(0.0);
                 let kirra_input = ProposedVehicleCommand {
@@ -379,26 +457,31 @@ mod tests {
         }
     }
 
-    // Test 2 — Degraded applies the MRC cap.
+    // Test 2 — Degraded applies the MRC cap to a DECELERATING command.
+    // (Issue #70: `previous` is a moving vehicle bleeding speed toward the
+    //  command; without a moving history the gate would deny re-initiation —
+    //  see `degraded_reinitiation_from_stop_is_denied`.)
     #[test]
     fn degraded_above_cap_clamps_to_mrc_ceiling() {
         let gov = KirraGovernor::new();
-        let action = gov.evaluate(&cmd(10.0), None, 0.05, SafetyPosture::Degraded);
+        let prev = cmd(10.0);
+        let action = gov.evaluate(&cmd(10.0), Some(&prev), 0.05, SafetyPosture::Degraded);
         assert_eq!(
             effective_velocity(action, 10.0),
             MRC_VELOCITY_CEILING_MPS,
-            "Degraded: input above MRC ceiling must be capped"
+            "Degraded: a decelerating command above the MRC ceiling must be capped"
         );
     }
 
     #[test]
     fn degraded_below_cap_allows_through() {
         let gov = KirraGovernor::new();
-        let action = gov.evaluate(&cmd(3.0), None, 0.05, SafetyPosture::Degraded);
+        let prev = cmd(3.0);
+        let action = gov.evaluate(&cmd(3.0), Some(&prev), 0.05, SafetyPosture::Degraded);
         assert_eq!(
             effective_velocity(action, 3.0),
             3.0,
-            "Degraded: input below MRC ceiling must pass through"
+            "Degraded: a non-increasing command below the MRC ceiling must pass through"
         );
     }
 
@@ -406,12 +489,13 @@ mod tests {
     #[test]
     fn locked_out_and_degraded_produce_different_outputs() {
         let gov = KirraGovernor::new();
+        let prev = cmd(3.0);
         let locked_out = effective_velocity(
-            gov.evaluate(&cmd(3.0), None, 0.05, SafetyPosture::LockedOut),
+            gov.evaluate(&cmd(3.0), Some(&prev), 0.05, SafetyPosture::LockedOut),
             3.0,
         );
         let degraded = effective_velocity(
-            gov.evaluate(&cmd(3.0), None, 0.05, SafetyPosture::Degraded),
+            gov.evaluate(&cmd(3.0), Some(&prev), 0.05, SafetyPosture::Degraded),
             3.0,
         );
         assert_ne!(
@@ -453,7 +537,8 @@ mod tests {
         let mut gov = KirraGovernor::new();
         gov.update_rss_state(unsafe_rss());
         let commanded = MRC_VELOCITY_CEILING_MPS + 5.0;
-        let action = gov.evaluate(&cmd(commanded), None, 0.05, SafetyPosture::Nominal);
+        let prev = cmd(commanded);
+        let action = gov.evaluate(&cmd(commanded), Some(&prev), 0.05, SafetyPosture::Nominal);
         assert_eq!(
             effective_velocity(action, commanded),
             commanded.min(MRC_VELOCITY_CEILING_MPS),
@@ -481,7 +566,8 @@ mod tests {
         let mut gov = KirraGovernor::new();
         gov.update_rss_state(unsafe_rss());
         let commanded = MRC_VELOCITY_CEILING_MPS - 1.0;
-        let action = gov.evaluate(&cmd(commanded), None, 0.05, SafetyPosture::Nominal);
+        let prev = cmd(commanded);
+        let action = gov.evaluate(&cmd(commanded), Some(&prev), 0.05, SafetyPosture::Nominal);
         assert_eq!(
             effective_velocity(action, commanded),
             commanded,
@@ -493,18 +579,19 @@ mod tests {
     #[test]
     fn rss_unsafe_and_degraded_share_mrc_code_path() {
         let mut gov = KirraGovernor::new();
+        let prev = cmd(10.0);
 
         // Degraded with RSS safe
         gov.update_rss_state(safe_rss());
         let output_degraded = effective_velocity(
-            gov.evaluate(&cmd(10.0), None, 0.05, SafetyPosture::Degraded),
+            gov.evaluate(&cmd(10.0), Some(&prev), 0.05, SafetyPosture::Degraded),
             10.0,
         );
 
         // Nominal with RSS unsafe
         gov.update_rss_state(unsafe_rss());
         let output_rss_unsafe = effective_velocity(
-            gov.evaluate(&cmd(10.0), None, 0.05, SafetyPosture::Nominal),
+            gov.evaluate(&cmd(10.0), Some(&prev), 0.05, SafetyPosture::Nominal),
             10.0,
         );
 
@@ -690,7 +777,10 @@ mod tests {
             MRC_VELOCITY_CEILING_MPS - 0.5,
             H1_MRC_RAD_S + 0.3,
         );
-        let action = gov.evaluate(&proposed, None, 0.05, SafetyPosture::Degraded);
+        // Issue #70: a moving, non-increasing `previous` so the decel-to-stop
+        // gate passes and the angular MRC clamp is what the test exercises.
+        let prev = proposed.clone();
+        let action = gov.evaluate(&proposed, Some(&prev), 0.05, SafetyPosture::Degraded);
         match action {
             EnforcementAction::ClampAngularVelocity(a) => {
                 assert!(
@@ -711,7 +801,10 @@ mod tests {
             MRC_VELOCITY_CEILING_MPS + 2.0,
             H1_MRC_RAD_S + 0.4,
         );
-        let action = gov.evaluate(&proposed, None, 0.05, SafetyPosture::Degraded);
+        // Issue #70: moving, non-increasing `previous` so the gate passes and
+        // the dual-axis MRC clamp is what the test exercises.
+        let prev = proposed.clone();
+        let action = gov.evaluate(&proposed, Some(&prev), 0.05, SafetyPosture::Degraded);
         match action {
             EnforcementAction::ClampMotion { linear, angular } => {
                 assert_eq!(linear, Some(MRC_VELOCITY_CEILING_MPS));
@@ -822,7 +915,12 @@ mod tests {
         let gov = KirraGovernor::new()
             .with_platform_params(PlatformParams::urban_service_robot_reference());
         let proposed = cmd_twist(0.0, 1.0);
-        let action = gov.evaluate(&proposed, None, 0.05, SafetyPosture::Degraded);
+        // Issue #70: already rotating at the commanded rate (non-increasing),
+        // so the angular decel-to-stop gate passes and the MRC sweep clamp is
+        // what this test exercises. Re-initiating rotation from a standstill
+        // under Degraded is denied — see `degraded_angular_reinitiation_from_stop_is_denied`.
+        let prev = proposed.clone();
+        let action = gov.evaluate(&proposed, Some(&prev), 0.05, SafetyPosture::Degraded);
         match action {
             EnforcementAction::ClampAngularVelocity(a) => {
                 assert!((a - 0.4167_f64).abs() < 1e-2,
@@ -848,5 +946,87 @@ mod tests {
                 other => panic!("v={v}: expected ClampAngularVelocity, got {other:?}"),
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #70 — Degraded decel-to-stop-and-HOLD (Cruise Oct-2023 SF lesson)
+    // -----------------------------------------------------------------------
+
+    /// A STOPPED platform must not re-initiate LINEAR motion under Degraded.
+    #[test]
+    fn degraded_reinitiation_from_stop_is_denied() {
+        let gov = KirraGovernor::new();
+        let prev = cmd(0.0); // stopped
+        let action = gov.evaluate(&cmd(3.0), Some(&prev), 0.05, SafetyPosture::Degraded);
+        assert!(
+            matches!(action, EnforcementAction::Deny { .. }),
+            "Degraded must deny linear re-initiation from a stop; got {action:?}"
+        );
+    }
+
+    /// `previous = None` (no history / cold start) is treated as stopped —
+    /// a first-cycle Degraded motion command fails closed.
+    #[test]
+    fn degraded_no_history_treated_as_stopped() {
+        let gov = KirraGovernor::new();
+        let action = gov.evaluate(&cmd(3.0), None, 0.05, SafetyPosture::Degraded);
+        assert!(
+            matches!(action, EnforcementAction::Deny { .. }),
+            "Degraded with no history must fail closed (hold); got {action:?}"
+        );
+    }
+
+    /// A LINEAR speed increase while moving is denied under Degraded.
+    #[test]
+    fn degraded_speed_increase_is_denied() {
+        let gov = KirraGovernor::new();
+        let prev = cmd(2.0);
+        let action = gov.evaluate(&cmd(4.0), Some(&prev), 0.05, SafetyPosture::Degraded);
+        assert!(
+            matches!(action, EnforcementAction::Deny { .. }),
+            "Degraded must deny a linear speed increase; got {action:?}"
+        );
+    }
+
+    /// A STOPPED platform must not re-initiate ANGULAR motion under Degraded
+    /// (Issue #70 FLAG #2 — angular channel gated natively for diff-drive).
+    #[test]
+    fn degraded_angular_reinitiation_from_stop_is_denied() {
+        let gov = legacy_scalar_gov();
+        let prev = cmd_twist(0.0, 0.0); // stopped, not rotating
+        let proposed = cmd_twist(0.0, 0.3); // re-initiate in-place rotation
+        let action = gov.evaluate(&proposed, Some(&prev), 0.05, SafetyPosture::Degraded);
+        assert!(
+            matches!(action, EnforcementAction::Deny { .. }),
+            "Degraded must deny angular re-initiation from a standstill; got {action:?}"
+        );
+    }
+
+    /// A decelerating (non-increasing) LINEAR command is admitted under
+    /// Degraded — the vehicle is permitted to bleed speed to a stop.
+    #[test]
+    fn degraded_decel_toward_zero_is_admitted() {
+        let gov = KirraGovernor::new();
+        let prev = cmd(4.0);
+        let action = gov.evaluate(&cmd(2.0), Some(&prev), 0.05, SafetyPosture::Degraded);
+        assert!(
+            !matches!(action, EnforcementAction::Deny { .. }),
+            "Degraded must admit a decelerating command; got {action:?}"
+        );
+        assert_eq!(effective_velocity(action, 2.0), 2.0,
+            "a within-MRC decelerating command passes through unchanged");
+    }
+
+    /// Holding at a standstill (0 → 0) on both channels is admitted — the
+    /// safe state itself.
+    #[test]
+    fn degraded_hold_at_stop_is_admitted() {
+        let gov = KirraGovernor::new();
+        let prev = cmd_twist(0.0, 0.0);
+        let action = gov.evaluate(&cmd_twist(0.0, 0.0), Some(&prev), 0.05, SafetyPosture::Degraded);
+        assert!(
+            matches!(action, EnforcementAction::Allow),
+            "Degraded must admit holding at a standstill; got {action:?}"
+        );
     }
 }

--- a/src/fabric/governor.rs
+++ b/src/fabric/governor.rs
@@ -1,7 +1,7 @@
 use crate::fabric::asset::KinematicProfileType;
 use crate::gateway::kinematics_contract::{
-    validate_vehicle_command, DenyCode, EnforceAction, ProposedVehicleCommand,
-    VehicleKinematicsContract,
+    enforce_degraded_decel_to_stop, validate_vehicle_command, DenyCode, EnforceAction,
+    ProposedVehicleCommand, VehicleKinematicsContract,
 };
 use crate::verifier::FleetPosture;
 
@@ -95,9 +95,10 @@ impl AssetGovernor {
         Self { asset_id, profile }
     }
 
-    // SAFETY: SG8 | REQ: fabric-posture-gated-mrc-or-deny | TEST: test_locked_out_denies_all_commands,test_mrc_profile_selected_on_degraded_posture
+    // SAFETY: SG8 | REQ: fabric-posture-gated-mrc-or-deny | TEST: test_locked_out_denies_all_commands,test_mrc_profile_selected_on_degraded_posture,test_degraded_reinitiation_from_stop_is_denied
     // (≅ AEGIS SG-007. LockedOut → DenyCode::AssetLockedOut; Degraded →
-    //  MRC contract; Nominal → full envelope. Posture-driven MRC selection.)
+    //  controlled decel-to-stop-and-HOLD under the MRC envelope (Issue #70);
+    //  Nominal → full envelope.)
     pub fn evaluate_command(
         &self,
         cmd: &ProposedVehicleCommand,
@@ -107,9 +108,12 @@ impl AssetGovernor {
             FleetPosture::LockedOut => {
                 EnforceAction::DenyBreach(DenyCode::AssetLockedOut)
             }
+            // Issue #70: Degraded is decel-to-stop-and-HOLD, not an MRC crawl.
+            // The command must be converging toward zero within the MRC
+            // envelope and must never re-initiate motion from a stop.
             FleetPosture::Degraded => {
                 let contract = self.profile.mrc_contract();
-                validate_vehicle_command(cmd, &contract)
+                enforce_degraded_decel_to_stop(cmd, &contract)
             }
             FleetPosture::Nominal => {
                 let contract = self.profile.nominal_contract();
@@ -149,30 +153,52 @@ mod tests {
         assert_eq!(contract.max_steering_deg, 180.0);
     }
 
+    // Issue #70: Degraded is decel-to-stop-and-HOLD. A re-initiation from a
+    // stop that Nominal would (rate-clamp and) admit is DENIED under Degraded.
     #[test]
     fn test_mrc_profile_selected_on_degraded_posture() {
         let g = AssetGovernor::new("av01".to_string(), KinematicProfileType::AutomotiveNominal);
-        // At nominal profile, max speed is 35 m/s; MRC is much lower.
-        // A 10 m/s command should pass Nominal but be clamped under Degraded.
-        let fast_cmd = ProposedVehicleCommand {
+        // Stopped, commanded to accelerate to 10 m/s.
+        let reinit_cmd = ProposedVehicleCommand {
             linear_velocity_mps: 10.0,
             current_velocity_mps: 0.0,
             delta_time_s: 0.1,
             steering_angle_deg: 0.0,
             current_steering_angle_deg: 0.0,
         };
-        let nominal_result = g.evaluate_command(&fast_cmd, &FleetPosture::Nominal);
-        // Should be clamped due to acceleration, but not outright denied
-        let degraded_result = g.evaluate_command(&fast_cmd, &FleetPosture::Degraded);
-        // MRC max speed is 35*0.3 = 10.5 m/s; clamp may or may not fire on speed alone
-        // The key invariant: degraded result must NOT be Allow if command exceeds MRC
+        let nominal_result = g.evaluate_command(&reinit_cmd, &FleetPosture::Nominal);
+        let degraded_result = g.evaluate_command(&reinit_cmd, &FleetPosture::Degraded);
+        // Nominal admits the motion (clamped by accel limits, never denied).
         assert!(
             matches!(nominal_result, EnforceAction::ClampLinear(_) | EnforceAction::Allow),
             "nominal: {nominal_result:?}"
         );
-        assert!(
-            matches!(degraded_result, EnforceAction::ClampLinear(_) | EnforceAction::Allow),
+        // Degraded refuses to re-initiate motion from a stop — fail-closed.
+        assert_eq!(
+            degraded_result,
+            EnforceAction::DenyBreach(DenyCode::DegradedReinitiationDenied),
             "degraded: {degraded_result:?}"
+        );
+    }
+
+    // Issue #70: under Degraded, a decelerating-toward-zero command from a
+    // moving state is admitted (clamped to the MRC envelope as needed), not
+    // denied — the vehicle is permitted to bleed speed to a controlled stop.
+    #[test]
+    fn test_degraded_reinitiation_from_stop_is_denied() {
+        let g = AssetGovernor::new("av01".to_string(), KinematicProfileType::AutomotiveNominal);
+        // Moving at 8 m/s, commanded down to 4 m/s — decelerating.
+        let decel_cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 4.0,
+            current_velocity_mps: 8.0,
+            delta_time_s: 1.0,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        let degraded_result = g.evaluate_command(&decel_cmd, &FleetPosture::Degraded);
+        assert!(
+            !matches!(degraded_result, EnforceAction::DenyBreach(_)),
+            "decelerating command must be admitted under Degraded: {degraded_result:?}"
         );
     }
 

--- a/src/fabric/router.rs
+++ b/src/fabric/router.rs
@@ -426,24 +426,41 @@ mod tests {
         assert!(posture.blocked_by.iter().any(|s| s == "UNVERIFIED_PENDING_FIRST_POSTURE"),
             "blocked_by must surface the unverified state, got {:?}", posture.blocked_by);
 
-        // A command that fits the per-profile MRC envelope is allowed.
-        // Robot MRC max_speed = 1.8 * 0.3 = 0.54 m/s, so 0.1 m/s passes.
-        let result = router.route_command("r01", &safe_cmd())
-            .expect("route_command should not error");
-        assert!(matches!(result, EnforceAction::Allow | EnforceAction::ClampLinear { .. } | EnforceAction::ClampSteering { .. }),
-            "MRC-envelope command must not DenyBreach on a freshly registered asset, got {result:?}");
-
-        // A command outside the MRC envelope (full nominal speed) must NOT pass.
-        let over_mrc = ProposedVehicleCommand {
-            linear_velocity_mps: 1.5,
+        // Issue #70: a freshly-registered asset is seeded Degraded =
+        // decel-to-stop-and-HOLD. Holding at a standstill is allowed; the
+        // governor will NOT autonomously re-initiate motion from rest.
+        let hold = ProposedVehicleCommand {
+            linear_velocity_mps: 0.0,
             current_velocity_mps: 0.0,
             delta_time_s: 0.1,
             steering_angle_deg: 0.0,
             current_steering_angle_deg: 0.0,
         };
-        let result = router.route_command("r01", &over_mrc).expect("route_command should not error");
-        assert!(!matches!(result, EnforceAction::Allow),
-            "command above MRC envelope must be clamped or denied on a freshly registered asset, got {result:?}");
+        let result = router.route_command("r01", &hold)
+            .expect("route_command should not error");
+        assert!(matches!(result, EnforceAction::Allow),
+            "holding at a standstill must be allowed on a freshly registered (Degraded) asset, got {result:?}");
+
+        // A re-initiation command from rest (the `safe_cmd` 0.1 m/s crawl that
+        // the old MRC-crawl behavior admitted) must now be DENIED — no
+        // autonomous re-initiation of motion under Degraded.
+        let result = router.route_command("r01", &safe_cmd())
+            .expect("route_command should not error");
+        assert!(matches!(result, EnforceAction::DenyBreach(_)),
+            "re-initiation from a stop must be denied on a Degraded asset, got {result:?}");
+
+        // A decelerating command (moving → slower, within the MRC envelope)
+        // IS admitted — the asset may bleed speed to a controlled stop.
+        let decel = ProposedVehicleCommand {
+            linear_velocity_mps: 0.2,
+            current_velocity_mps: 0.4,
+            delta_time_s: 0.1,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        let result = router.route_command("r01", &decel).expect("route_command should not error");
+        assert!(!matches!(result, EnforceAction::DenyBreach(_)),
+            "a decelerating within-MRC command must be admitted on a Degraded asset, got {result:?}");
     }
 
     // FIX 2 — auto-propagation.

--- a/src/gateway/kinematics_contract.rs
+++ b/src/gateway/kinematics_contract.rs
@@ -240,6 +240,23 @@ pub enum DenyCode {
     /// OCCY_FAULT_MODEL §3 sensor-availability rule). Issued by
     /// `gateway::containment::validate_trajectory_containment`.
     DrivableSpaceDeparture,
+    /// Safety: SG-007 ≅ SG8. Degraded posture: a stopped vehicle
+    /// (`|current_velocity_mps| <= STOP_EPSILON_MPS`) was commanded to
+    /// re-initiate motion (`|linear_velocity_mps| > STOP_EPSILON_MPS`), or
+    /// to reverse direction through a stop. In Degraded the safe state is
+    /// **decel-to-stop-and-HOLD**: the Governor never authorizes autonomous
+    /// re-initiation of motion from a standstill. Issued by
+    /// `enforce_degraded_decel_to_stop`. (Issue #70 — Cruise Oct-2023 SF
+    /// post-stop pullover-drag lesson: a stopped AV must not re-initiate
+    /// motion under a degraded safety posture.)
+    DegradedReinitiationDenied,
+    /// Safety: SG-007 ≅ SG8. Degraded posture: the proposed speed magnitude
+    /// exceeds the current speed magnitude (`|linear_velocity_mps| >
+    /// |current_velocity_mps|`). Degraded permits only a **non-increasing**
+    /// (decelerating-toward-zero) speed profile; any acceleration is denied
+    /// and the actuator falls to the MRC controlled-stop. Issued by
+    /// `enforce_degraded_decel_to_stop`. (Issue #70.)
+    DegradedSpeedIncreaseDenied,
 }
 
 impl DenyCode {
@@ -257,6 +274,8 @@ impl DenyCode {
             Self::InvalidTimeDelta      => "INVALID_TIME_DELTA",
             Self::AssetLockedOut        => "ASSET_LOCKED_OUT",
             Self::DrivableSpaceDeparture => "DRIVABLE_SPACE_DEPARTURE",
+            Self::DegradedReinitiationDenied  => "DEGRADED_REINITIATION_DENIED",
+            Self::DegradedSpeedIncreaseDenied => "DEGRADED_SPEED_INCREASE_DENIED",
         }
     }
 }
@@ -265,6 +284,114 @@ impl std::fmt::Display for DenyCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.reason())
     }
+}
+
+// ---------------------------------------------------------------------------
+// Degraded-posture stop-and-hold gate (Issue #70)
+// ---------------------------------------------------------------------------
+
+/// Speed magnitude (m/s) at or below which the vehicle is treated as
+/// **stopped** for the Degraded decel-to-stop-and-HOLD invariant.
+///
+/// At a standstill, wheel-odometry / GNSS-velocity estimates carry a few
+/// cm/s of noise; this floor (5 cm/s) sits above that noise band yet far
+/// below any meaningful crawl, so it denies any *commanded* re-initiation of
+/// motion from a stop while not flapping on standstill sensor jitter.
+///
+/// JUDGMENT-CALL (Issue #70 FLAG #1): 0.05 m/s is the recommended value.
+/// Integrators with a noisier velocity estimate may raise it; it must stay
+/// well below the slowest deliberate maneuver speed so a genuine creep is
+/// never silently admitted.
+pub const STOP_EPSILON_MPS: f64 = 0.05;
+
+/// Degraded-posture enforcement: **controlled decel-to-stop-and-HOLD** with
+/// NO autonomous re-initiation of motion.
+///
+/// This is the Issue #70 Degraded behavior. It is a *narrower* allow than the
+/// Nominal envelope and a *wider* allow than LockedOut (which denies
+/// everything): in Degraded the vehicle is permitted to keep moving only so
+/// long as it is converging toward a standstill under the MRC kinematic
+/// envelope, and once stopped it must HOLD. It must never be commanded to
+/// speed up or to re-initiate motion from a stop.
+///
+/// A proposed command is permitted **only if ALL** hold:
+///
+/// - **(a) within the MRC kinematic envelope** — delegated to
+///   [`validate_vehicle_command`] against `mrc_contract`, which is the
+///   decel-trajectory bound (speed ceiling, brake/accel rate, steering,
+///   lateral-accel). A clamp from the envelope is still a permitted
+///   (decelerating) command, returned as `ClampLinear`/`ClampSteering`.
+/// - **(b) non-increasing speed magnitude** — `|proposed| <= |current|`. Any
+///   speed increase → [`DenyCode::DegradedSpeedIncreaseDenied`].
+/// - **(c) no re-initiation from a stop** — if `|current| <= STOP_EPSILON_MPS`,
+///   any `|proposed| > STOP_EPSILON_MPS` → [`DenyCode::DegradedReinitiationDenied`]
+///   (hold at zero). A direction reversal through a stop (sign flip while both
+///   magnitudes exceed the stop floor) is likewise treated as re-initiation of
+///   opposite-direction motion → [`DenyCode::DegradedReinitiationDenied`]
+///   (Issue #70 FLAG #3: converge-toward-zero by magnitude, no reverse
+///   re-initiation).
+///
+/// On a (b)/(c) violation the function returns `DenyBreach(..)`; the caller
+/// drops the command and the actuator falls to the MRC controlled-stop — the
+/// Governor does **not** author a replacement decel command (parallel to the
+/// LockedOut deny→MRC fallback, but with the narrower Degraded allow above).
+///
+/// The angular channel is intentionally NOT gated here for the Ackermann
+/// bicycle model: a vehicle's yaw rate is `ω = v·tan(δ)/L`, so the linear
+/// no-re-initiation / non-increasing invariant already forces `ω → 0` as
+/// `v → 0`. Steering *geometry* at a standstill is not motion and is left to
+/// the envelope's steering-rate/angle clamps. Platforms with an *independent*
+/// angular-velocity actuator (e.g. differential drive in `parko-kirra`) apply
+/// the same converge-to-zero / no-re-initiation rule to the angular channel
+/// natively (Issue #70 FLAG #2).
+///
+/// WCET (Issue #70 STEP 5 / S3): the gate adds only a fixed, branch-bounded
+/// set of finite-checks, `abs`, sign and magnitude comparisons before
+/// delegating to the already-characterized [`validate_vehicle_command`]. It is
+/// O(1), allocation-free, and only on the Degraded path — the Nominal verdict
+/// path is unchanged.
+// SAFETY: SG8 | REQ: degraded-decel-to-stop-and-hold | TEST: test_degraded_reinitiation_from_stop_is_denied,test_degraded_speed_increase_is_denied,test_degraded_decel_toward_zero_is_allowed,test_degraded_hold_at_stop_is_allowed,test_degraded_reverse_through_stop_is_denied
+#[must_use]
+pub fn enforce_degraded_decel_to_stop(
+    cmd: &ProposedVehicleCommand,
+    mrc_contract: &VehicleKinematicsContract,
+) -> EnforceAction {
+    // Priority 0: fail closed on non-finite linear/current velocity before any
+    // magnitude comparison. NaN compares false against every threshold, which
+    // would silently mask a re-initiation; reject explicitly. (The full
+    // NaN/Inf + dt guard is re-run inside validate_vehicle_command for the
+    // envelope check; these two are the fields the gate itself reads.)
+    if !cmd.linear_velocity_mps.is_finite() {
+        return EnforceAction::DenyBreach(DenyCode::NanInfLinearVelocity);
+    }
+    if !cmd.current_velocity_mps.is_finite() {
+        return EnforceAction::DenyBreach(DenyCode::NanInfCurrentVelocity);
+    }
+
+    let proposed = cmd.linear_velocity_mps.abs();
+    let current = cmd.current_velocity_mps.abs();
+
+    // (c) No autonomous re-initiation from a stop — HOLD at zero.
+    if current <= STOP_EPSILON_MPS && proposed > STOP_EPSILON_MPS {
+        return EnforceAction::DenyBreach(DenyCode::DegradedReinitiationDenied);
+    }
+
+    // (c') No direction reversal through a stop while moving — commanding the
+    // opposite sign at a non-trivial magnitude re-initiates motion in reverse.
+    let reversing = cmd.linear_velocity_mps.signum() != cmd.current_velocity_mps.signum();
+    if reversing && current > STOP_EPSILON_MPS && proposed > STOP_EPSILON_MPS {
+        return EnforceAction::DenyBreach(DenyCode::DegradedReinitiationDenied);
+    }
+
+    // (b) Non-increasing speed magnitude (decelerating-toward-zero only).
+    // A tiny tolerance absorbs float jitter on a steady-state hold; anything
+    // meaningfully above the current magnitude is a speed increase → deny.
+    if proposed > current + 1e-9 {
+        return EnforceAction::DenyBreach(DenyCode::DegradedSpeedIncreaseDenied);
+    }
+
+    // (a) Within the MRC kinematic envelope — the decel-trajectory bound.
+    validate_vehicle_command(cmd, mrc_contract)
 }
 
 // ---------------------------------------------------------------------------
@@ -1087,6 +1214,9 @@ mod kinematics_contract_tests {
             // SG2 + GAP 8 means the corridor-departure variant must also
             // pin its Display token for audit-hash stability.
             DenyCode::DrivableSpaceDeparture,
+            // Issue #70 — Degraded decel-to-stop-and-hold reason codes.
+            DenyCode::DegradedReinitiationDenied,
+            DenyCode::DegradedSpeedIncreaseDenied,
         ];
         for code in all {
             assert_eq!(
@@ -1095,5 +1225,102 @@ mod kinematics_contract_tests {
                 "Display for {code:?} must equal reason() token"
             );
         }
+    }
+
+    // --- Issue #70: Degraded decel-to-stop-and-hold gate -------------------
+
+    fn degraded_cmd(current: f64, proposed: f64) -> ProposedVehicleCommand {
+        ProposedVehicleCommand {
+            linear_velocity_mps: proposed,
+            current_velocity_mps: current,
+            delta_time_s: 0.1,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        }
+    }
+
+    /// Cruise lesson (Cruise Oct-2023 SF): a STOPPED vehicle must not
+    /// re-initiate motion under Degraded posture.
+    #[test]
+    fn test_degraded_reinitiation_from_stop_is_denied() {
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+        // Stopped (0.0), commanded to crawl forward at 3 m/s — the exact
+        // class of maneuver the Cruise pullover-drag executed from a stop.
+        let cmd = degraded_cmd(0.0, 3.0);
+        assert_eq!(
+            enforce_degraded_decel_to_stop(&cmd, &mrc),
+            EnforceAction::DenyBreach(DenyCode::DegradedReinitiationDenied)
+        );
+    }
+
+    /// A speed INCREASE while moving is denied (only decel-toward-zero allowed).
+    #[test]
+    fn test_degraded_speed_increase_is_denied() {
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+        let cmd = degraded_cmd(2.0, 4.0); // 2 → 4 m/s, accelerating
+        assert_eq!(
+            enforce_degraded_decel_to_stop(&cmd, &mrc),
+            EnforceAction::DenyBreach(DenyCode::DegradedSpeedIncreaseDenied)
+        );
+    }
+
+    /// A decelerating-toward-zero command within the MRC envelope is ALLOWED.
+    #[test]
+    fn test_degraded_decel_toward_zero_is_allowed() {
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+        // 3 → 2.9 m/s over 0.1 s: decel of 1 m/s², within MRC max_brake (3.0).
+        let cmd = degraded_cmd(3.0, 2.9);
+        assert_eq!(
+            enforce_degraded_decel_to_stop(&cmd, &mrc),
+            EnforceAction::Allow
+        );
+    }
+
+    /// Holding at a standstill (0 → 0) is ALLOWED — that IS the safe state.
+    #[test]
+    fn test_degraded_hold_at_stop_is_allowed() {
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+        let cmd = degraded_cmd(0.0, 0.0);
+        assert_eq!(
+            enforce_degraded_decel_to_stop(&cmd, &mrc),
+            EnforceAction::Allow
+        );
+    }
+
+    /// A direction reversal through a stop (forward → reverse) is treated as
+    /// re-initiation of opposite-direction motion and denied.
+    #[test]
+    fn test_degraded_reverse_through_stop_is_denied() {
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+        let cmd = degraded_cmd(2.0, -1.0); // moving forward, commanded reverse
+        assert_eq!(
+            enforce_degraded_decel_to_stop(&cmd, &mrc),
+            EnforceAction::DenyBreach(DenyCode::DegradedReinitiationDenied)
+        );
+    }
+
+    /// An over-MRC-ceiling but still-decelerating command is clamped by the
+    /// envelope (NOT denied) — the gate defers (a) to validate_vehicle_command.
+    #[test]
+    fn test_degraded_overspeed_but_decelerating_is_clamped_by_envelope() {
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+        // Current 20, proposed 8: decelerating (non-increasing) but 8 > 5.0
+        // MRC ceiling → envelope clamps to 5.0.
+        let cmd = degraded_cmd(20.0, 8.0);
+        assert_eq!(
+            enforce_degraded_decel_to_stop(&cmd, &mrc),
+            EnforceAction::ClampLinear(5.0)
+        );
+    }
+
+    /// Non-finite inputs fail closed even on the Degraded gate.
+    #[test]
+    fn test_degraded_gate_rejects_nan_linear() {
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+        let cmd = degraded_cmd(2.0, f64::NAN);
+        assert_eq!(
+            enforce_degraded_decel_to_stop(&cmd, &mrc),
+            EnforceAction::DenyBreach(DenyCode::NanInfLinearVelocity)
+        );
     }
 }

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -16,7 +16,8 @@ use crate::audit_writer::{
     fleet_posture_str, AuditWriteJob, KinematicViolationPayload, ProposedCommandPayload,
 };
 use crate::gateway::kinematics_contract::{
-    validate_vehicle_command, EnforceAction, ProposedVehicleCommand, VehicleKinematicsContract,
+    enforce_degraded_decel_to_stop, validate_vehicle_command, EnforceAction,
+    ProposedVehicleCommand, VehicleKinematicsContract,
 };
 use crate::gateway::policy::{classify_http_command, OperationalCommand};
 use crate::posture_cache::{
@@ -164,9 +165,14 @@ impl EnforcementOutcome {
 /// selects the appropriate VehicleKinematicsContract, and enforces all physical
 /// invariants before the request reaches any downstream handler.
 ///
-/// Posture → Contract mapping:
+/// Posture → enforcement mapping:
 ///   Nominal   → nominal_reference_profile() — full operational envelope
-///   Degraded  → mrc_fallback_profile()      — MRC crawl-speed envelope
+///   Degraded  → controlled decel-to-stop-and-HOLD (Issue #70): the MRC
+///               envelope as the decel-trajectory bound, PLUS a
+///               non-increasing-speed + no-re-initiation gate
+///               (`enforce_degraded_decel_to_stop`). A stopped vehicle is
+///               held at rest; a moving vehicle may only bleed speed toward
+///               zero. Speed increase / re-initiation → DenyBreach → MRC stop.
 ///   LockedOut → immediate 403 FORBIDDEN     — fail-closed, no physics evaluation
 ///
 /// # Invariants
@@ -182,19 +188,17 @@ pub async fn enforce_actuator_safety_envelope(
     let posture = resolve_posture(&svc);
 
     // SAFETY: SG8 | REQ: posture-to-contract-mrc-selection | TEST: test_degraded_posture_selects_mrc_contract,test_degraded_posture_clamps_high_speed_to_mrc_limit,test_locked_out_posture_has_no_contract,test_locked_out_rejects_zero_motion_command
-    // (Nominal → nominal envelope; Degraded → MRC fallback envelope;
-    //  LockedOut → fail-closed 403 with no contract evaluated.)
-    let contract: VehicleKinematicsContract = match posture {
-        FleetPosture::Nominal => VehicleKinematicsContract::nominal_reference_profile(),
-        FleetPosture::Degraded => VehicleKinematicsContract::mrc_fallback_profile(),
-        FleetPosture::LockedOut => {
-            tracing::error!(
-                "Actuator command rejected: fleet posture is LockedOut — \
-                 all actuator mutations are blocked until posture recovers"
-            );
-            return Err(StatusCode::FORBIDDEN);
-        }
-    };
+    // (Nominal → nominal envelope; Degraded → decel-to-stop-and-HOLD gate
+    //  over the MRC envelope (Issue #70); LockedOut → fail-closed 403 with no
+    //  command body even parsed.) LockedOut short-circuits here so the
+    //  fail-closed path never touches the request body.
+    if posture == FleetPosture::LockedOut {
+        tracing::error!(
+            "Actuator command rejected: fleet posture is LockedOut — \
+             all actuator mutations are blocked until posture recovers"
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
 
     let (mut parts, body) = req.into_parts();
 
@@ -211,7 +215,22 @@ pub async fn enforce_actuator_safety_envelope(
     let proposed_cmd: ProposedVehicleCommand =
         serde_json::from_slice(&bytes).map_err(|_| StatusCode::BAD_REQUEST)?;
 
-    match validate_vehicle_command(&proposed_cmd, &contract) {
+    // Issue #70: Nominal runs the full envelope; Degraded runs the
+    // decel-to-stop-and-HOLD gate (non-increasing speed + no re-initiation)
+    // over the MRC envelope. LockedOut was already short-circuited above.
+    let verdict = match posture {
+        FleetPosture::Nominal => validate_vehicle_command(
+            &proposed_cmd,
+            &VehicleKinematicsContract::nominal_reference_profile(),
+        ),
+        FleetPosture::Degraded => enforce_degraded_decel_to_stop(
+            &proposed_cmd,
+            &VehicleKinematicsContract::mrc_fallback_profile(),
+        ),
+        FleetPosture::LockedOut => unreachable!("LockedOut short-circuited above"),
+    };
+
+    match verdict {
         EnforceAction::Allow => {
             // Thread the verdict to the handler so the response reports it.
             parts.extensions.insert(EnforcementOutcome::allow(&proposed_cmd));

--- a/src/wcet_gate.rs
+++ b/src/wcet_gate.rs
@@ -169,7 +169,8 @@ fn measure_stats<F: FnMut()>(iterations: u32, mut f: F) -> (u128, u128) {
 mod ci_gate_tests {
     use super::*;
     use crate::gateway::kinematics_contract::{
-        validate_vehicle_command, ProposedVehicleCommand, VehicleKinematicsContract,
+        enforce_degraded_decel_to_stop, validate_vehicle_command, ProposedVehicleCommand,
+        VehicleKinematicsContract,
     };
     use crate::gateway::policy::OperationalCommand;
     use crate::posture_cache::{should_route_command, CachedFleetPosture};
@@ -290,6 +291,33 @@ mod ci_gate_tests {
             ));
         });
         assert_under_budget("validate_vehicle_command::P6_ClampSteering", max_ns, p999_ns);
+    }
+
+    #[test]
+    fn wcet_enforce_degraded_decel_to_stop_worst_case() {
+        // Issue #70 (STEP 5): the Degraded gate adds only a fixed set of
+        // finite-checks + magnitude/sign comparisons before delegating to the
+        // already-budgeted validate_vehicle_command. Worst case is the
+        // PASS-the-gate path (a decelerating command), which runs the gate's
+        // O(1) checks AND the full P0..P6 envelope pipeline — strictly more
+        // work than a denied command (which returns at the gate). The Nominal
+        // path is unchanged and benched separately above; this confirms the
+        // Degraded path stays under the same per-verdict budget.
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 4.0,   // decelerating from 4.5 → passes gate
+            current_velocity_mps: 4.5,
+            delta_time_s: 0.05,
+            steering_angle_deg: 5.0,
+            current_steering_angle_deg: 0.0,
+        };
+        let (max_ns, p999_ns) = measure_stats(ITERS, || {
+            let _ = std::hint::black_box(enforce_degraded_decel_to_stop(
+                std::hint::black_box(&cmd),
+                std::hint::black_box(&mrc),
+            ));
+        });
+        assert_under_budget("enforce_degraded_decel_to_stop::pass_then_envelope", max_ns, p999_ns);
     }
 
     #[test]

--- a/tests/actuator_envelope_integration.rs
+++ b/tests/actuator_envelope_integration.rs
@@ -361,9 +361,13 @@ async fn test_capstone_degraded_overspeed_clamps_and_hides_original() {
     let ceiling = VehicleKinematicsContract::mrc_fallback_profile().effective_max_speed_mps();
     let original = 100.0;
 
+    // Issue #70: the command must be DECELERATING (current 120 → proposed 100)
+    // to exercise the envelope clamp — a speed *increase* under Degraded is
+    // denied, not clamped (see the decel-to-stop-and-hold gate). 100 m/s is
+    // still far over the 5 m/s MRC ceiling, so the envelope clamps it.
     let (status, v) =
-        send_json(build_schema_app(svc), Body::from(cmd_json(original, 4.0, 0.1, 0.0, 0.0))).await;
-    assert_eq!(status, StatusCode::OK, "over-speed is clamped, not denied");
+        send_json(build_schema_app(svc), Body::from(cmd_json(original, 120.0, 0.1, 0.0, 0.0))).await;
+    assert_eq!(status, StatusCode::OK, "over-speed (decelerating) is clamped, not denied");
 
     // Clamp is reported (not a hardcoded "Allow") under both key families.
     assert_eq!(v["action"], "ClampLinear");

--- a/tests/governor_closes_loop_proof.rs
+++ b/tests/governor_closes_loop_proof.rs
@@ -134,6 +134,9 @@ struct Trajectory {
     deny_count: usize,
     max_enforced_speed: f64,
     max_enforced_steer: f64,
+    /// Speed at the end of the run — distinguishes "held at stop" (Issue #70
+    /// Degraded) from "re-accelerated" (Nominal) when peak speed alone cannot.
+    final_speed: f64,
 }
 
 /// GOVERNED run: each command goes through the REAL gateway; the enforced result
@@ -143,8 +146,20 @@ async fn governed_run(
     wb: f64,
     commands: &[ProposedVehicleCommand],
 ) -> Trajectory {
+    governed_run_seeded(svc, wb, VehicleState::at_rest(), commands).await
+}
+
+/// As `governed_run`, but the vehicle starts from `initial` rather than rest.
+/// Used by the Issue #70 decel-to-stop-and-hold axis, where the safe behavior
+/// (bleed speed to zero, then HOLD) only manifests from a moving start.
+async fn governed_run_seeded(
+    svc: Arc<ServiceState>,
+    wb: f64,
+    initial: VehicleState,
+    commands: &[ProposedVehicleCommand],
+) -> Trajectory {
     let router = gateway_router(svc);
-    let mut state = VehicleState::at_rest();
+    let mut state = initial;
     let mut tr = Trajectory::default();
     for cmd in commands {
         let c = ProposedVehicleCommand {
@@ -172,6 +187,7 @@ async fn governed_run(
         tr.peak_speed = tr.peak_speed.max(state.velocity_mps.abs());
         tr.peak_lateral = tr.peak_lateral.max(state.lateral_accel_mps2(wb));
     }
+    tr.final_speed = state.velocity_mps.abs();
     tr
 }
 
@@ -359,37 +375,111 @@ async fn axis2a_rss_fault_drives_posture_to_degraded() {
         .await;
 }
 
-/// 2b — Degraded posture (the RSS fault's result) makes the gateway clamp the
-///      vehicle to the MRC crawl envelope; Nominal (no fault) does not. The
-///      delta is the fault-driven safe response.
+/// 2b — Degraded posture (the RSS fault's result) makes the gateway drive the
+///      vehicle to a CONTROLLED DECEL-TO-STOP and then HOLD — it does not
+///      sustain a crawl, and it does not re-initiate motion. (Issue #70 —
+///      retires the old "Degraded = 5 m/s MRC crawl" behavior in favor of
+///      decel-to-stop-and-hold; the Cruise Oct-2023 SF pullover-drag is the
+///      motivating incident.) Nominal (no fault) keeps cruising as the
+///      negative control.
 #[tokio::test]
-async fn axis2b_degraded_posture_holds_vehicle_to_mrc_vs_nominal() {
+async fn axis2b_degraded_posture_decels_to_stop_and_holds_vs_nominal() {
     let wb = VehicleKinematicsContract::mrc_fallback_profile().wheelbase_m;
-    let mrc_ceiling = VehicleKinematicsContract::mrc_fallback_profile().effective_max_speed_mps();
-    // Enough steps for the Nominal accel-limiter to ramp the 10 m/s cruise well
-    // past the 5 m/s MRC crawl. Degraded clamps to 5 immediately (P2 ceiling), so
-    // the two plateau apart — the fault-driven delta.
-    let cruise = cruise_commands(10.0, 200);
 
-    // Fault-driven (Degraded): MRC clamp holds the vehicle to the crawl ceiling.
-    let degraded = governed_run(service_state(FleetPosture::Degraded), wb, &cruise).await;
-    assert!(
-        degraded.peak_speed <= mrc_ceiling + TOL,
-        "Degraded must hold the vehicle to the MRC crawl ({} <= {})", degraded.peak_speed, mrc_ceiling
-    );
-    assert!(degraded.clamp_count > 0, "Degraded cruise above MRC must be clamped");
+    // The vehicle is already moving at 1 m/s when the fault drives it Degraded.
+    // The planner cooperatively commands a stop, the vehicle bleeds speed to
+    // zero under the MRC decel bound and HOLDS; then the planner tries to
+    // re-accelerate (the unsafe pullover-from-stop the Cruise incident teaches
+    // us to refuse).
+    let initial = VehicleState::new(0.0, 0.0, 0.0, 1.0);
+    let mut commands: Vec<ProposedVehicleCommand> = Vec::new();
+    for _ in 0..20 {
+        commands.push(cmd(0.0, 0.0));          // cooperative decel + hold at stop
+    }
+    for _ in 0..20 {
+        commands.push(cmd(3.0, 0.0));          // attempt to re-initiate motion
+    }
 
-    // Negative control (Nominal, no fault): the SAME cruise runs at full 10 m/s.
-    let nominal = governed_run(service_state(FleetPosture::Nominal), wb, &cruise).await;
+    // Fault-driven (Degraded): bleeds speed to 0, HOLDS, and DENIES every
+    // re-initiation attempt.
+    let degraded =
+        governed_run_seeded(service_state(FleetPosture::Degraded), wb, initial.clone(), &commands).await;
     assert!(
-        nominal.peak_speed > mrc_ceiling + TOL,
-        "Nominal cruise should exceed the MRC ceiling ({} > {})", nominal.peak_speed, mrc_ceiling
+        degraded.peak_speed <= 1.0 + TOL,
+        "Degraded must never increase speed beyond the initial 1 m/s (got peak {})",
+        degraded.peak_speed
     );
-    // The fault-driven posture is what produced the safe behavior.
     assert!(
-        nominal.peak_speed > degraded.peak_speed + TOL,
-        "the fault-driven Degraded posture must reduce vehicle speed ({} nominal vs {} degraded)",
-        nominal.peak_speed, degraded.peak_speed
+        degraded.final_speed <= TOL,
+        "Degraded must come to rest and HOLD (final speed {})", degraded.final_speed
+    );
+    assert_eq!(
+        degraded.deny_count, 20,
+        "Degraded must DENY all 20 re-initiation-from-stop attempts (Cruise lesson)"
+    );
+
+    // Negative control (Nominal, no fault): the re-acceleration tail is honored
+    // — the vehicle is moving again by the end of the run, and nothing is denied.
+    let nominal =
+        governed_run_seeded(service_state(FleetPosture::Nominal), wb, initial, &commands).await;
+    assert_eq!(nominal.deny_count, 0, "Nominal must not deny any of these commands");
+    assert!(
+        nominal.final_speed > degraded.final_speed + TOL,
+        "the fault-driven Degraded posture must keep the vehicle stopped while \
+         Nominal re-accelerates (nominal final {} vs degraded final {})",
+        nominal.final_speed, degraded.final_speed
+    );
+}
+
+/// 2b″ — THE CRUISE LESSON, per-command. Under Degraded:
+///   - a re-initiation command from a stop is DENIED (the post-stop pullover);
+///   - a speed-increase command while moving is DENIED;
+///   - a decelerating-toward-zero command within the MRC envelope is ALLOWED.
+/// This is the narrow Degraded allow that the old MRC-crawl ceiling would have
+/// wrongly permitted (a 3 m/s pullover from a stop sits *under* the 5 m/s
+/// crawl ceiling, so the old behavior would have let it through).
+#[tokio::test]
+async fn axis2b_degraded_denies_reinitiation_and_speed_increase() {
+    let router = gateway_router(service_state(FleetPosture::Degraded));
+
+    // (1) Re-initiation from a stop — the Cruise pullover. DENIED.
+    let from_stop = ProposedVehicleCommand {
+        linear_velocity_mps: 3.0,
+        current_velocity_mps: 0.0,
+        delta_time_s: DT_S,
+        steering_angle_deg: 0.0,
+        current_steering_angle_deg: 0.0,
+    };
+    assert!(
+        enforce_once(&router, &from_stop).await.denied,
+        "Degraded must deny re-initiation of motion from a stop"
+    );
+
+    // (2) Speed increase while moving — DENIED.
+    let speed_up = ProposedVehicleCommand {
+        linear_velocity_mps: 4.0,
+        current_velocity_mps: 2.0,
+        delta_time_s: DT_S,
+        steering_angle_deg: 0.0,
+        current_steering_angle_deg: 0.0,
+    };
+    assert!(
+        enforce_once(&router, &speed_up).await.denied,
+        "Degraded must deny a speed increase while moving"
+    );
+
+    // (3) Decelerating toward zero within the MRC envelope — ALLOWED.
+    let decel = ProposedVehicleCommand {
+        linear_velocity_mps: 2.0,
+        current_velocity_mps: 3.0,
+        delta_time_s: DT_S,
+        steering_angle_deg: 0.0,
+        current_steering_angle_deg: 0.0,
+    };
+    let e = enforce_once(&router, &decel).await;
+    assert!(
+        !e.denied,
+        "Degraded must ALLOW a decelerating-toward-zero command within the MRC envelope"
     );
 }
 


### PR DESCRIPTION
… crawl

Redefine the Degraded fleet posture from a sustained 5 m/s MRC crawl to a CONTROLLED decel-to-stop-and-HOLD with NO autonomous re-initiation of motion.

Motivation: Cruise, San Francisco, October 2023. After an initial collision a robotaxi executed an automated pullover from a stop and dragged a pinned pedestrian ~20 ft at ~3 m/s. A 3 m/s pullover-from-stop sits BELOW a 5 m/s crawl ceiling, so the prior "Degraded = MRC crawl" behavior would have permitted exactly that maneuver. Under a degraded safety posture the correct action is to stop and stay stopped, never to perform a discretionary low-speed maneuver.

Behavior (new shared gate `enforce_degraded_decel_to_stop`): in Degraded a command is admitted ONLY if (a) within the MRC kinematic envelope (the decel-trajectory bound), (b) non-increasing speed |proposed| <= |current|, and (c) no re-initiation from a stop (|current| <= STOP_EPSILON_MPS => deny any |proposed| > STOP_EPSILON_MPS; reversal-through-stop is re-initiation too). Violations of (b)/(c) => DenyBreach(DegradedSpeedIncreaseDenied / DegradedReinitiationDenied) => actuator falls to the MRC controlled stop. The Governor never authors re-acceleration.

Wired identically at all four enforcement points:
- gateway  `enforce_actuator_safety_envelope` (policy_layer.rs)
- fabric    `AssetGovernor::evaluate_command`
- ros2      `validate_trajectory_slow` (per-pose, Degraded)
- parko     `KirraGovernor::apply_mrc_profile` + diverse shadow
            (also gates an independent angular channel via STOP_EPSILON_RAD_S
             for differential drive; the Ackermann bicycle model needs no
             separate angular gate since omega = v*tan(d)/L -> 0 as v -> 0)

The Nominal WCET-critical `validate_vehicle_command` path is unchanged; the gate adds only O(1) deterministic comparisons on the Degraded path (new WCET gate test added). LockedOut is unchanged (hard stop, human reset only); Degraded recovery remains automatic on return to Nominal.

Docs: SAFE_STATE_SPECIFICATION.md SS-002 rewritten (decel-to-stop-and-hold, Cruise rationale, MRC envelope vs LockedOut MRC-fallback disambiguation, automatic-vs-human-reset contrast); kinematics_envelope_protection.md, CLAUDE.md, parko/INTEGRATION.md updated to retire the crawl framing.

Tests: governor_closes_loop_proof Degraded axis rewritten to decel-to-stop + new re-initiation/speed-increase negative test (Cruise lesson); unit + proptest coverage across both workspaces updated for the new gate.

Realizes the Degraded-converge-to-zero scope of #49 (decel-to-stop-and-hold); the ROS2 filtered_cmd_vel topic-wiring and Hiwonder hardware portions of #49 remain open (see SAFE_STATE_SPECIFICATION.md sec 6 loose-ends note).

Refs #70. Addresses #49 (Degraded-converge-to-0 scope; loose ends documented).

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv