### PR TITLE
docs(safety): reconcile ROS2 safe-output topic naming — retire phantom filtered_cmd_vel (#171)

### DIFF
--- a/docs/releases/v1.5.0.md
+++ b/docs/releases/v1.5.0.md
@@ -22,7 +22,9 @@ v1.5.0 is the first release to include a multi-asset safety fabric, industrial p
 ## ROS2 Safety Interlock
 
 - `kirra_safety` ROS2 package (`cmd_vel_interceptor`, sensor monitor, posture subscriber)
-- `cmd_vel` → governor → `filtered_cmd_vel` pipeline wired to fleet posture
+- `cmd_vel` → governor → `cmd_vel_safe` pipeline wired to fleet posture
+  <!-- Corrected 2026-06 (#171): the as-shipped topic is `/cmd_vel_safe`; the
+       original note named `/filtered_cmd_vel`, which was never implemented. -->
 - Sensor telemetry timeout detection (SG-003)
 - Deploys on Ubuntu 24.04 + ROS2 Jazzy
 

--- a/docs/safety/SAFE_STATE_SPECIFICATION.md
+++ b/docs/safety/SAFE_STATE_SPECIFICATION.md
@@ -275,29 +275,43 @@ CLOSED by this change (the Degraded-converge-to-zero safety semantics):
     "Degraded → 0" intent #49 carried is now a tested, fail-closed behavior
     (decel-to-stop-and-HOLD, no autonomous re-initiation).
 
-LOOSE ENDS — NOT closed here (tracked separately, do not auto-close #49 on
-this change alone):
-  1. **ROS2 topic naming / observability.** The roadmap (PARK-037,
-     `work/roadmap.md`) expects governor clamps to be observable on a
-     dedicated `filtered_cmd_vel` topic. The adapter currently publishes the
-     single gated output to the configurable `~/output/cmd_vel`
-     (`parko/crates/parko-ros2/src/config.rs`,
-     `crates/kirra-ros2-adapter`), not a separate `filtered_cmd_vel`. Whether
-     to add a distinct filtered-output topic (raw vs gated, for observability)
-     vs keep the single gated topic is an integration decision, not a safety
-     one — out of scope for #70.
-  2. **Hiwonder closed-loop hardware verification.** #49's acceptance includes
-     on-hardware closed-loop validation on the Hiwonder platform. This change
-     is verified in-process (unit + the `governor_closes_loop_proof` axis);
-     hardware bring-up is separate.
+LOOSE ENDS — split to the follow-up issue #171; the topic-naming half is now
+RESOLVED (below), the Hiwonder half remains open:
+  1. **ROS2 topic naming / observability — RESOLVED (#171).** The phantom
+     `/filtered_cmd_vel` from the original PARK-037 planning text was **never
+     implemented** in either component; it existed only in planning docs. The
+     canonical, implemented safe-output topics are:
+       - **`/cmd_vel_safe`** — the robotics stack (`kirra_safety`
+         `cmd_vel_interceptor` → enforced command; `posture_subscriber` zero-Twist
+         on LockedOut; the C++ bridge `/kirra/cmd_vel_safe`; `kirra_params.yaml`);
+       - **`~/output/cmd_vel`** — the AV adapter
+         (`crates/kirra-ros2-adapter`, `parko/crates/parko-ros2/src/config.rs`),
+         which has published on it all along.
+     The dedicated-filtered-topic question is resolved as **no new topic**: the
+     raw-vs-gated observability a `/filtered_cmd_vel` would have provided already
+     exists via the **input/output split** — raw = the input topic (`/cmd_vel`),
+     gated = the output topic (`/cmd_vel_safe` / `~/output/cmd_vel`) — and the
+     governor's clamp is independently observable on the enforcement/action topic
+     and the Ed25519 audit chain. A dedicated topic would be redundant. The stale
+     `/filtered_cmd_vel` references in the planning docs are retired in favor of
+     these real names; do not rename working code to match a stale spec.
+     OPTIONAL consistency follow-up (flagged, NOT done here): unify the AV
+     adapter's `~/output/cmd_vel` to `/cmd_vel_safe` for one cross-component name
+     — an integration nicety, not a safety change.
+  2. **Hiwonder closed-loop hardware verification — OPEN (#171).** #49's
+     acceptance includes on-hardware closed-loop validation on the Hiwonder
+     platform. This is verified in-process today (unit + the
+     `governor_closes_loop_proof` axis); hardware bring-up is separate and
+     remains blocked on the hardware.
   3. **#49 ↔ #92 scope overlap.** Triage (`docs/ISSUE_TRIAGE_2026-06-01.md`)
      flags overlap between #49 (ROS2 cmd_vel wiring) and #92 (Occy Governor
      trajectory check). The overlap is unaffected by — and orthogonal to —
      the Degraded behavior change here.
 
-Recommendation: close the Degraded-converge-to-0 sub-goal of #49 against this
-change and re-scope the remaining #49 work (topic naming, Hiwonder bring-up)
-to its own follow-up issue, rather than auto-closing #49 in full.
+Status: the Degraded-converge-to-0 sub-goal of #49 closed against the Issue #70
+change, and the remainder was re-homed to follow-up issue **#171**. Of that
+remainder, the **topic-naming half is now resolved** (loose-end 1 above);
+**only the Hiwonder closed-loop hardware validation remains open** under #171.
 
 ---
 

--- a/work/backlog.md
+++ b/work/backlog.md
@@ -1270,8 +1270,9 @@ alternative simulation environment.
 **Integrate Parko + KirraGovernor with ROS2 cmd_vel topics**
 
 Wire the Parko control loop and KirraGovernor into ROS2 cmd_vel topics:
-`cmd_vel` → governor → `filtered_cmd_vel`. The governor's hard-veto on
-Degraded/LockedOut must be observable on the filtered topic. Depends on PARK-036.
+`cmd_vel` → governor → `cmd_vel_safe` (gated output; `/filtered_cmd_vel` was
+never implemented — retired per #171). The governor's hard-veto on
+Degraded/LockedOut must be observable on the gated output topic. Depends on PARK-036.
 KirraGovernor authority model: hard-veto on Degraded/LockedOut, clamp on Nominal,
 conservative fallback if unreachable.
 
@@ -1306,7 +1307,7 @@ REQUIREMENTS:
    a. Query FleetPosture from kirra-runtime-sdk (KIRRA_VERIFIER_ADDR).
    b. Map to PostureState: Nominal/Degraded/LockedOut.
    c. Call <actual governor struct>.enforce(commanded_vel, posture).
-   d. Publish result directly to /filtered_cmd_vel. No post-processing.
+   d. Publish result directly to /cmd_vel_safe. No post-processing.
       Comment: "Output is governor output — governor is single source of truth"
 3. Unreachable: drop to Degraded, call enforce(vel, Degraded), log
    "governor_unreachable — applying local Degraded posture".

--- a/work/pending_prompts.md
+++ b/work/pending_prompts.md
@@ -634,9 +634,9 @@ Requirements:
 2. For each message:
    a. Query current FleetPosture from kirra-runtime-sdk.
    b. Call KirraGovernor.enforce(commanded_vel, posture).
-   c. Publish result to /filtered_cmd_vel.
+   c. Publish result to /cmd_vel_safe.
 3. If posture is Degraded or LockedOut: output velocity == 0.0 (hard veto).
 4. If posture is Nominal: apply kinematic clamp; publish clamped value.
-5. Test: inject Degraded posture via set_state_for_test; assert /filtered_cmd_vel == 0.
+5. Test: inject Degraded posture via set_state_for_test; assert /cmd_vel_safe == 0.
 6. Use Kirra naming in all comments and docs.
 ```

--- a/work/roadmap.md
+++ b/work/roadmap.md
@@ -183,7 +183,7 @@ TIME-SENSITIVE (30-day license in progress).
 | Task | What | Done When |
 |------|------|-----------|
 | PARK-036 (GitHub Issue #48) | Bring up ROS2 Jazzy on Ubuntu 24.04. Configure colcon workspace; verify basic pub/sub. | `ros2 topic echo` works; workspace builds cleanly. |
-| PARK-037 (GitHub Issue #49) | Integrate Parko + KirraGovernor with ROS2 cmd_vel topics. Governor clamps observable on `filtered_cmd_vel`. | Closed-loop behavior on Hiwonder; governor clamps verified on filtered topic. |
+| PARK-037 (GitHub Issue #49 → follow-up #171) | Integrate Parko + KirraGovernor with ROS2 cmd_vel topics. Governor clamps observable on the gated output topic — `/cmd_vel_safe` (robotics) / `~/output/cmd_vel` (AV adapter); `/filtered_cmd_vel` was never implemented and is retired. | Topic naming RESOLVED (#171); closed-loop behavior on Hiwonder remains open; governor clamps verified on the gated output topic + Ed25519 audit chain. |
 | PARK-038 (GitHub Issue #50) | Build full reference robot stack: Parko + KirraGovernor + ROS2 + kirra_safety interlock + CARLA alternative. | BLOCKED: depends on Hiwonder hardware + ROS2 Jazzy setup. |
 
 ### Safety Case (all NEW WORK)


### PR DESCRIPTION
Refs #171 (topic-naming half of #49 / PARK-037 loose-end 1). **Does NOT close #171** — the Hiwonder closed-loop hardware half remains blocked/open.

Reconciles the docs to the **implemented** ROS2 gated safe-output topics: `/cmd_vel_safe` (robotics `kirra_safety`) and `~/output/cmd_vel` (AV adapter `crates/kirra-ros2-adapter` / `parko-ros2`). `/filtered_cmd_vel` was **never implemented** in either component — it existed only in planning docs — and is retired.

`docs/safety/SAFE_STATE_SPECIFICATION.md` §6 marks loose-end 1 **RESOLVED**: the dedicated-filtered-topic question is resolved as **no new topic** — raw is the input topic (`/cmd_vel`), gated is the output topic (`/cmd_vel_safe` / `~/output/cmd_vel`), and the governor's clamp is independently observable on the enforcement/action topic + the Ed25519 audit chain, so a dedicated topic would be redundant.

Docs-only (5 `.md` files: `SAFE_STATE_SPECIFICATION.md`, `work/roadmap.md`, `docs/releases/v1.5.0.md`, `work/backlog.md`, `work/pending_prompts.md`); **no code/config touched** — the AV adapter's working `~/output/cmd_vel` is untouched. The `docs/releases/v1.5.0.md` line that named the non-existent `/filtered_cmd_vel` is corrected with a dated historical annotation. The optional cross-component rename of the adapter's `~/output/cmd_vel` → `/cmd_vel_safe` is noted as a separate follow-up, not done here.

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv)_