### PR TITLE
feat(gateway): gated perception-derate verdict-path composition (KIRRA-OCCY-PMON-002)

### DIFF
--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -1451,7 +1451,15 @@ async fn handle_fabric_command(
         Err(e) => return (StatusCode::BAD_REQUEST, Json(json!({"error": e.body_text()}))).into_response(),
     };
 
-    match svc.fabric_router.route_command(&asset_id, &cmd) {
+    // KIRRA-OCCY-PMON-002: resolve the perception-derate cap O(1) here (the
+    // handler holds `svc`/`ServiceState`) and thread it through to the fabric
+    // governor's Nominal arm. `None` while the monitor is disabled (default).
+    let perception_cap = kirra_runtime_sdk::gateway::perception_monitor::resolve_perception_cap(
+        svc.perception_monitor_enabled,
+        &svc.perception_cap,
+        now_ms(),
+    );
+    match svc.fabric_router.route_command(&asset_id, &cmd, perception_cap) {
         Ok(action) => {
             let action_str = format!("{:?}", action);
             let allowed = !matches!(action, kirra_runtime_sdk::gateway::kinematics_contract::EnforceAction::DenyBreach(_));
@@ -1632,6 +1640,11 @@ async fn main() {
         fabric_telemetry: Arc::new(FabricTelemetry::new()),
         fabric_causal_log: Arc::new(FabricCausalLog::new(signing_key)),
         posture_engine_tx: std::sync::OnceLock::new(),
+        // KIRRA-OCCY-PMON-002: perception-derate composition. DEFAULT OFF —
+        // pure no-op (state 1) until #126 wires a real perception ingest and a
+        // deployment enables the monitor + starts the publisher worker.
+        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_monitor_enabled: false,
     });
 
     {

--- a/src/fabric/governor.rs
+++ b/src/fabric/governor.rs
@@ -99,10 +99,17 @@ impl AssetGovernor {
     // (≅ AEGIS SG-007. LockedOut → DenyCode::AssetLockedOut; Degraded →
     //  controlled decel-to-stop-and-HOLD under the MRC envelope (Issue #70);
     //  Nominal → full envelope.)
+    // `effective_perception_cap` (KIRRA-OCCY-PMON-002): the perception-derate
+    // cap resolved by the caller (`Option<f64>` — `None` when the monitor is
+    // disabled; `Some(0.0)` MRC floor when an enabled monitor is stale). It is
+    // composed into the Nominal-arm contract via `apply_perception_cap` (a pure
+    // `min` into `odd_speed_cap_mps`), so `validate_vehicle_command` stays
+    // byte-identical. No-op on Degraded/LockedOut (already at/below MRC).
     pub fn evaluate_command(
         &self,
         cmd: &ProposedVehicleCommand,
         current_posture: &FleetPosture,
+        effective_perception_cap: Option<f64>,
     ) -> EnforceAction {
         match current_posture {
             FleetPosture::LockedOut => {
@@ -116,7 +123,10 @@ impl AssetGovernor {
                 enforce_degraded_decel_to_stop(cmd, &contract)
             }
             FleetPosture::Nominal => {
-                let contract = self.profile.nominal_contract();
+                let contract = crate::gateway::perception_monitor::apply_perception_cap(
+                    &self.profile.nominal_contract(),
+                    effective_perception_cap,
+                );
                 validate_vehicle_command(cmd, &contract)
             }
         }
@@ -166,8 +176,8 @@ mod tests {
             steering_angle_deg: 0.0,
             current_steering_angle_deg: 0.0,
         };
-        let nominal_result = g.evaluate_command(&reinit_cmd, &FleetPosture::Nominal);
-        let degraded_result = g.evaluate_command(&reinit_cmd, &FleetPosture::Degraded);
+        let nominal_result = g.evaluate_command(&reinit_cmd, &FleetPosture::Nominal, None);
+        let degraded_result = g.evaluate_command(&reinit_cmd, &FleetPosture::Degraded, None);
         // Nominal admits the motion (clamped by accel limits, never denied).
         assert!(
             matches!(nominal_result, EnforceAction::ClampLinear(_) | EnforceAction::Allow),
@@ -195,7 +205,7 @@ mod tests {
             steering_angle_deg: 0.0,
             current_steering_angle_deg: 0.0,
         };
-        let degraded_result = g.evaluate_command(&decel_cmd, &FleetPosture::Degraded);
+        let degraded_result = g.evaluate_command(&decel_cmd, &FleetPosture::Degraded, None);
         assert!(
             !matches!(degraded_result, EnforceAction::DenyBreach(_)),
             "decelerating command must be admitted under Degraded: {degraded_result:?}"
@@ -205,7 +215,7 @@ mod tests {
     #[test]
     fn test_locked_out_denies_all_commands() {
         let g = AssetGovernor::new("av01".to_string(), KinematicProfileType::AutomotiveNominal);
-        let result = g.evaluate_command(&nominal_cmd(), &FleetPosture::LockedOut);
+        let result = g.evaluate_command(&nominal_cmd(), &FleetPosture::LockedOut, None);
         assert_eq!(result, EnforceAction::DenyBreach(DenyCode::AssetLockedOut));
     }
 
@@ -215,7 +225,7 @@ mod tests {
         // 0.5 m/s with zero current velocity over 0.1s dt: accel = 5 m/s²
         // Robot MRC max_accel is 1.5*0.4 = 0.6 m/s², nominal is 1.5 m/s²
         // This will be clamped but not denied
-        let result = g.evaluate_command(&nominal_cmd(), &FleetPosture::Nominal);
+        let result = g.evaluate_command(&nominal_cmd(), &FleetPosture::Nominal, None);
         // Either Allow or ClampLinear is acceptable (depends on accel)
         assert!(!matches!(result, EnforceAction::DenyBreach(_)));
     }
@@ -230,7 +240,7 @@ mod tests {
             steering_angle_deg: 0.0,
             current_steering_angle_deg: 0.0,
         };
-        let result = g.evaluate_command(&fast, &FleetPosture::Nominal);
+        let result = g.evaluate_command(&fast, &FleetPosture::Nominal, None);
         assert_eq!(result, EnforceAction::ClampLinear(0.5));
     }
 }

--- a/src/fabric/router.rs
+++ b/src/fabric/router.rs
@@ -80,10 +80,15 @@ impl FabricRouter {
         self.asset_postures.entry(asset.asset_id.clone()).or_insert(initial_posture);
     }
 
+    // `effective_perception_cap` (KIRRA-OCCY-PMON-002): the perception-derate
+    // cap the caller resolved from the `SharedPerceptionCap` (the caller holds
+    // `ServiceState`; the router just threads the scalar through to the
+    // governor's Nominal arm). `None` when the monitor is disabled.
     pub fn route_command(
         &self,
         asset_id: &str,
         cmd: &ProposedVehicleCommand,
+        effective_perception_cap: Option<f64>,
     ) -> Result<EnforceAction, FabricError> {
         let governor = self.governors.get(asset_id)
             .ok_or_else(|| FabricError::AssetNotFound(asset_id.to_string()))?;
@@ -92,7 +97,7 @@ impl FabricRouter {
             .map(|p| p.posture.clone())
             .unwrap_or(FleetPosture::LockedOut);  // fail-closed if posture unknown
 
-        Ok(governor.evaluate_command(cmd, &posture))
+        Ok(governor.evaluate_command(cmd, &posture, effective_perception_cap))
     }
 
     /// Low-level posture write. Used by:
@@ -302,14 +307,14 @@ mod tests {
     fn test_route_command_to_correct_asset_governor() {
         let router = FabricRouter::new();
         router.register_asset(&make_asset("r01", AssetType::Robot, KinematicProfileType::RobotNominal));
-        let result = router.route_command("r01", &safe_cmd());
+        let result = router.route_command("r01", &safe_cmd(), None);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_unknown_asset_returns_error() {
         let router = FabricRouter::new();
-        let result = router.route_command("nonexistent", &safe_cmd());
+        let result = router.route_command("nonexistent", &safe_cmd(), None);
         assert!(matches!(result, Err(FabricError::AssetNotFound(_))));
     }
 
@@ -436,7 +441,7 @@ mod tests {
             steering_angle_deg: 0.0,
             current_steering_angle_deg: 0.0,
         };
-        let result = router.route_command("r01", &hold)
+        let result = router.route_command("r01", &hold, None)
             .expect("route_command should not error");
         assert!(matches!(result, EnforceAction::Allow),
             "holding at a standstill must be allowed on a freshly registered (Degraded) asset, got {result:?}");
@@ -444,7 +449,7 @@ mod tests {
         // A re-initiation command from rest (the `safe_cmd` 0.1 m/s crawl that
         // the old MRC-crawl behavior admitted) must now be DENIED — no
         // autonomous re-initiation of motion under Degraded.
-        let result = router.route_command("r01", &safe_cmd())
+        let result = router.route_command("r01", &safe_cmd(), None)
             .expect("route_command should not error");
         assert!(matches!(result, EnforceAction::DenyBreach(_)),
             "re-initiation from a stop must be denied on a Degraded asset, got {result:?}");
@@ -458,7 +463,7 @@ mod tests {
             steering_angle_deg: 0.0,
             current_steering_angle_deg: 0.0,
         };
-        let result = router.route_command("r01", &decel).expect("route_command should not error");
+        let result = router.route_command("r01", &decel, None).expect("route_command should not error");
         assert!(!matches!(result, EnforceAction::DenyBreach(_)),
             "a decelerating within-MRC command must be admitted on a Degraded asset, got {result:?}");
     }
@@ -544,7 +549,7 @@ mod tests {
                         delta_time_s: 0.1,
                         steering_angle_deg: 0.0,
                         current_steering_angle_deg: 0.0,
-                    });
+                    }, None);
                 }
             })
         }).collect();

--- a/src/gateway/perception_monitor.rs
+++ b/src/gateway/perception_monitor.rs
@@ -517,6 +517,186 @@ pub fn range_supported_speed_mps(range_m: f64, t_react_s: f64, a_brake_mps2: f64
     }
 }
 
+// ===========================================================================
+// Verdict-path composition (KIRRA-OCCY-PMON-002).
+//
+// Makes the guards ENFORCE without touching the byte-stable verdict path.
+// Option B: a perception-monitor worker evaluates the guards at perception-tick
+// rate and PUBLISHES a cap to `SharedPerceptionCap`; the verdict surfaces read
+// that cap O(1), resolve the 3-state lifecycle, and TIGHTEN the contract they
+// pass to `validate_vehicle_command` via `apply_perception_cap` — so
+// `validate_vehicle_command` and `effective_max_speed_mps` stay byte-identical.
+// Derate-only: never touches `DenyCode` or the deny path.
+// ===========================================================================
+
+use std::sync::{Arc, RwLock};
+use crate::gateway::kinematics_contract::VehicleKinematicsContract;
+
+/// The MRC-floor cap (m/s). A published cap of `0.0` composes into
+/// `effective_max_speed = min(…, 0.0) = 0.0` and surfaces as the EXISTING
+/// `ClampLinear(0.0)` → controlled stop. No new code path.
+pub const MRC_FLOOR_CAP_MPS: f64 = 0.0;
+
+/// Atomic published snapshot of the perception-derived speed cap. Mirrors
+/// `CachedFleetPosture`: the worker owns `generated_at_ms`/`ttl_ms`; the
+/// verdict-path resolver reads them to evaluate staleness.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CachedPerceptionCap {
+    /// Published permitted-speed cap (m/s). `0.0` = controlled stop.
+    pub cap_mps: f64,
+    /// Absolute timestamp (ms since UNIX epoch) when the worker published this.
+    pub generated_at_ms: u64,
+    /// Staleness TTL (ms). After `generated_at_ms + ttl_ms < now`, the resolver
+    /// treats this entry as stale and fails closed to the MRC floor.
+    pub ttl_ms: u64,
+    /// The `DerateCode` that produced this cap (audit/diagnostics).
+    pub reason: DerateCode,
+}
+
+impl CachedPerceptionCap {
+    /// Returns true if this entry has exceeded its TTL relative to `now_ms`.
+    /// Saturating subtraction tolerates clock skew without panic — identical
+    /// to `CachedFleetPosture::is_stale`.
+    #[must_use]
+    pub fn is_stale(&self, now_ms: u64) -> bool {
+        now_ms.saturating_sub(self.generated_at_ms) >= self.ttl_ms
+    }
+}
+
+/// Shared perception-cap cache. `Arc<RwLock<Option<CachedPerceptionCap>>>` —
+/// the same shape as `SharedPostureCache`. `None` = the enabled worker has not
+/// published yet (cold start) → the resolver fails closed.
+pub type SharedPerceptionCap = Arc<RwLock<Option<CachedPerceptionCap>>>;
+
+/// Constructs an empty (cold-start) shared perception cap.
+#[must_use]
+pub fn empty_perception_cap() -> SharedPerceptionCap {
+    Arc::new(RwLock::new(None))
+}
+
+/// The 3-state cap resolver (KIRRA-OCCY-PMON-002 §4) — the enabled-gate.
+///
+/// Pure function of `(enabled, cache, now_ms)` → the effective perception cap to
+/// compose, or `None` for "no cap, no derate":
+///
+/// - **State 1 — NOT enabled** → `None`. The monitor is an *optional* layer;
+///   its absence is NOT a fault and must not derate. This is what lets the
+///   mechanism land as a pure no-op on main before any ingest exists.
+/// - **State 2 — enabled + FRESH** (`now − generated_at ≤ ttl`) → `Some(cap_mps)`.
+/// - **State 3 — enabled + STALE / `None` / poisoned RwLock** → `Some(MRC_FLOOR_CAP_MPS)`.
+///   A configured monitor going silent IS a fault → controlled stop. Mirrors
+///   `resolve_posture → LockedOut` exactly.
+#[must_use]
+pub fn resolve_perception_cap(
+    enabled: bool,
+    cache: &SharedPerceptionCap,
+    now_ms: u64,
+) -> Option<f64> {
+    // State 1 — layer not deployed/enabled. No-op (NOT a fault).
+    if !enabled {
+        return None;
+    }
+    // Enabled: read O(1). Poison → fail closed (state 3).
+    match cache.read() {
+        Ok(guard) => match guard.as_ref() {
+            // State 2 — fresh.
+            Some(entry) if !entry.is_stale(now_ms) => Some(entry.cap_mps),
+            // State 3 — stale or never-published.
+            _ => Some(MRC_FLOOR_CAP_MPS),
+        },
+        // State 3 — poisoned lock.
+        Err(_) => Some(MRC_FLOOR_CAP_MPS),
+    }
+}
+
+/// Composition via call-site contract tightening (KIRRA-OCCY-PMON-002 §1, §6).
+///
+/// Returns a copy of `contract` whose `odd_speed_cap_mps` is tightened to
+/// `min(existing_effective_cap, cap)` when `effective_cap` is `Some`; returns
+/// the contract unchanged when `None`. Because
+/// `effective_max_speed_mps() = min(max_speed_mps, odd_speed_cap_mps)`, the
+/// result yields `min(max_speed, odd_cap, perception_cap)` — the ADR-0002
+/// most-conservative-wins multi-input `min` — **without** touching
+/// `validate_vehicle_command` or `effective_max_speed_mps`. The verdict fn
+/// stays byte-identical; the only per-command cost is the O(1) resolver read at
+/// the call site.
+///
+/// WHY call-site tightening (not threading an `Option<f64>` through
+/// `validate_vehicle_command`): keeping the verdict fn + `effective_max_speed_mps`
+/// byte-identical preserves their verified-unchanged status (WCET, MC/DC, the
+/// whole P0..P6 pipeline) and confines this change to the composition layer.
+#[must_use]
+pub fn apply_perception_cap(
+    contract: &VehicleKinematicsContract,
+    effective_cap: Option<f64>,
+) -> VehicleKinematicsContract {
+    let mut out = contract.clone();
+    if let Some(cap) = effective_cap {
+        let existing = out.effective_max_speed_mps();
+        out.odd_speed_cap_mps = Some(existing.min(cap));
+    }
+    out
+}
+
+/// Publishes perception-derate caps into a `SharedPerceptionCap` at tick rate.
+/// Stateless w.r.t. its own history; mirrors the posture-engine worker's
+/// "compute then atomically replace the cache" shape.
+///
+/// First cut is KINEMATIC-ONLY (`range_supported_derate` is STAGED — no `R_obs`
+/// producer exists, #120 Item B). When the range guard lands, `on_tick` composes
+/// `min(kinematic_cap, range_cap)` here before publishing.
+pub struct PerceptionCapPublisher {
+    cache: SharedPerceptionCap,
+    contract: KinematicPlausibilityContract,
+    ttl_ms: u64,
+}
+
+impl PerceptionCapPublisher {
+    #[must_use]
+    pub fn new(
+        cache: SharedPerceptionCap,
+        contract: KinematicPlausibilityContract,
+        ttl_ms: u64,
+    ) -> Self {
+        Self { cache, contract, ttl_ms }
+    }
+
+    /// Run the kinematic guard over a fresh perception snapshot and publish the
+    /// resulting cap. Called once per perception tick.
+    pub fn on_tick(&self, perception: &PerceptionOutput, now_ms: u64) {
+        let decision = kinematic_plausibility_derate(perception, &self.contract);
+        self.publish(decision.cap_mps, decision.reason, now_ms);
+    }
+
+    /// Staleness sweep: if no fresh cap exists within the TTL, publish the
+    /// MRC-floor cap (a configured monitor going silent IS a fault). Mirrors
+    /// the telemetry watchdog's timeout sweep.
+    pub fn sweep_staleness(&self, now_ms: u64) {
+        let stale = match self.cache.read() {
+            Ok(guard) => guard.as_ref().map(|e| e.is_stale(now_ms)).unwrap_or(true),
+            Err(_) => true,
+        };
+        if stale {
+            self.publish(MRC_FLOOR_CAP_MPS, DerateCode::PerceptionSnapshotUnhealthy, now_ms);
+        }
+    }
+
+    fn publish(&self, cap_mps: f64, reason: DerateCode, now_ms: u64) {
+        let entry = CachedPerceptionCap {
+            cap_mps,
+            generated_at_ms: now_ms,
+            ttl_ms: self.ttl_ms,
+            reason,
+        };
+        // Poison-tolerant write: if the lock is poisoned we still replace the
+        // entry (the resolver fails closed on poison regardless).
+        match self.cache.write() {
+            Ok(mut guard) => *guard = Some(entry),
+            Err(poisoned) => *poisoned.into_inner() = Some(entry),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -811,5 +991,245 @@ mod tests {
             let json = serde_json::to_string(&code).expect("serialize");
             assert_eq!(json, format!("\"{token}\""));
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Composition (KIRRA-OCCY-PMON-002): resolver, apply_perception_cap,
+    // end-to-end resolve→apply→validate, and the publisher worker.
+    // -----------------------------------------------------------------------
+
+    use crate::gateway::kinematics_contract::{
+        validate_vehicle_command, EnforceAction, ProposedVehicleCommand, VehicleKinematicsContract,
+        URBAN_ODD_SPEED_CAP_MPS,
+    };
+
+    fn fresh_cap(cache: &SharedPerceptionCap, cap_mps: f64, now_ms: u64, ttl_ms: u64) {
+        *cache.write().unwrap() = Some(CachedPerceptionCap {
+            cap_mps,
+            generated_at_ms: now_ms,
+            ttl_ms,
+            reason: DerateCode::ObjectVelocityImplausible,
+        });
+    }
+
+    /// A steady-state command at `v` m/s (no accel/steering corrections), so the
+    /// only thing that can act is the P2 velocity ceiling.
+    fn cmd_at(v: f64) -> ProposedVehicleCommand {
+        ProposedVehicleCommand {
+            linear_velocity_mps: v,
+            current_velocity_mps: v,
+            delta_time_s: 0.1,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        }
+    }
+
+    // ---- 3-state resolver ----
+
+    #[test]
+    fn resolver_state1_not_enabled_is_none() {
+        let cache = empty_perception_cap();
+        fresh_cap(&cache, 5.0, 1000, 500); // even with a fresh cap present…
+        assert_eq!(resolve_perception_cap(false, &cache, 1100), None, "disabled → no cap");
+    }
+
+    #[test]
+    fn resolver_state2_enabled_fresh_returns_cap() {
+        let cache = empty_perception_cap();
+        fresh_cap(&cache, 7.5, 1000, 500);
+        assert_eq!(resolve_perception_cap(true, &cache, 1200), Some(7.5));
+    }
+
+    #[test]
+    fn resolver_state3_enabled_stale_is_mrc_floor() {
+        let cache = empty_perception_cap();
+        fresh_cap(&cache, 7.5, 1000, 500);
+        // now - generated = 600 > ttl 500 → stale → MRC floor.
+        assert_eq!(resolve_perception_cap(true, &cache, 1600), Some(MRC_FLOOR_CAP_MPS));
+    }
+
+    #[test]
+    fn resolver_state3_enabled_none_is_mrc_floor() {
+        let cache = empty_perception_cap(); // never published
+        assert_eq!(resolve_perception_cap(true, &cache, 1000), Some(MRC_FLOOR_CAP_MPS));
+    }
+
+    // ---- apply_perception_cap ----
+
+    #[test]
+    fn apply_none_returns_unchanged_contract() {
+        let base = VehicleKinematicsContract::nominal_reference_profile();
+        let out = apply_perception_cap(&base, None);
+        assert_eq!(out.effective_max_speed_mps(), base.effective_max_speed_mps());
+        assert_eq!(out.odd_speed_cap_mps, base.odd_speed_cap_mps);
+    }
+
+    #[test]
+    fn apply_some_tightens_to_min() {
+        let base = VehicleKinematicsContract::nominal_reference_profile(); // max 35, no odd cap
+        // Perception cap 12 < 35 → effective becomes 12.
+        let out = apply_perception_cap(&base, Some(12.0));
+        assert_eq!(out.effective_max_speed_mps(), 12.0);
+        // A looser perception cap never raises the ceiling.
+        let out2 = apply_perception_cap(&base, Some(100.0));
+        assert_eq!(out2.effective_max_speed_mps(), base.max_speed_mps);
+    }
+
+    #[test]
+    fn apply_composes_with_existing_odd_cap_most_conservative_wins() {
+        let mut base = VehicleKinematicsContract::nominal_reference_profile();
+        base.odd_speed_cap_mps = Some(URBAN_ODD_SPEED_CAP_MPS); // 22.35
+        // Perception cap 10 < 22.35 → 10 wins.
+        assert_eq!(apply_perception_cap(&base, Some(10.0)).effective_max_speed_mps(), 10.0);
+        // Perception cap 30 > 22.35 → existing odd cap still wins.
+        assert!(
+            (apply_perception_cap(&base, Some(30.0)).effective_max_speed_mps() - URBAN_ODD_SPEED_CAP_MPS).abs() < 1e-9
+        );
+    }
+
+    #[test]
+    fn apply_zero_floor_stops() {
+        let base = VehicleKinematicsContract::nominal_reference_profile();
+        let out = apply_perception_cap(&base, Some(MRC_FLOOR_CAP_MPS));
+        assert_eq!(out.effective_max_speed_mps(), 0.0);
+    }
+
+    // ---- end-to-end: resolve → apply → validate (the composition outcome) ----
+
+    #[test]
+    fn compose_state1_identical_to_baseline() {
+        let cache = empty_perception_cap();
+        let base = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = cmd_at(20.0); // under the 35 m/s vehicle max → baseline Allow
+        let baseline = validate_vehicle_command(&cmd, &base);
+
+        let eff = resolve_perception_cap(false, &cache, 1000); // disabled
+        let composed = validate_vehicle_command(&cmd, &apply_perception_cap(&base, eff));
+        assert_eq!(composed, baseline);
+        assert_eq!(composed, EnforceAction::Allow);
+    }
+
+    #[test]
+    fn compose_state2_cap_below_command_clamps() {
+        let cache = empty_perception_cap();
+        fresh_cap(&cache, 8.0, 1000, 500);
+        let base = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = cmd_at(20.0); // 20 > published cap 8 → clamp to 8
+
+        let eff = resolve_perception_cap(true, &cache, 1200);
+        let composed = validate_vehicle_command(&cmd, &apply_perception_cap(&base, eff));
+        assert_eq!(composed, EnforceAction::ClampLinear(8.0));
+    }
+
+    #[test]
+    fn compose_state2_cap_above_command_allows() {
+        let cache = empty_perception_cap();
+        fresh_cap(&cache, 25.0, 1000, 500);
+        let base = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = cmd_at(20.0); // 20 < published cap 25 → Allow
+
+        let eff = resolve_perception_cap(true, &cache, 1200);
+        let composed = validate_vehicle_command(&cmd, &apply_perception_cap(&base, eff));
+        assert_eq!(composed, EnforceAction::Allow);
+    }
+
+    #[test]
+    fn compose_state3_stale_is_controlled_stop() {
+        let cache = empty_perception_cap();
+        fresh_cap(&cache, 25.0, 1000, 500);
+        let base = VehicleKinematicsContract::nominal_reference_profile();
+        let cmd = cmd_at(20.0);
+
+        // Stale (now - gen = 600 > ttl 500) → MRC floor → ClampLinear(0.0).
+        let eff = resolve_perception_cap(true, &cache, 1600);
+        let composed = validate_vehicle_command(&cmd, &apply_perception_cap(&base, eff));
+        assert_eq!(composed, EnforceAction::ClampLinear(0.0));
+    }
+
+    // ---- publisher worker (synthetic TrackedObjects → published cap) ----
+
+    fn ok_obj(id: u64) -> TrackedObject {
+        TrackedObject {
+            id,
+            pos_m: Vec2 { x: 10.0, y: 0.0 },
+            vel_mps: Vec2 { x: 5.0, y: 0.0 },
+            prev_pos_m: Vec2 { x: 9.5, y: 0.0 },
+            dt_s: 0.1,
+        }
+    }
+
+    #[test]
+    fn worker_on_tick_publishes_nominal_cap_for_clean_snapshot() {
+        let cache = empty_perception_cap();
+        let pubr = PerceptionCapPublisher::new(
+            cache.clone(),
+            KinematicPlausibilityContract::urban_reference(),
+            500,
+        );
+        let objs = [ok_obj(1), ok_obj(2)];
+        let p = PerceptionOutput {
+            objects: &objs,
+            confidence: 0.95,
+            age_ms: 10,
+            min_confidence: 0.5,
+            max_age_ms: 500,
+        };
+        pubr.on_tick(&p, 1000);
+        // Enabled+fresh read returns the nominal cap (no implausible objects).
+        assert_eq!(
+            resolve_perception_cap(true, &cache, 1100),
+            Some(URBAN_ODD_SPEED_CAP_MPS)
+        );
+    }
+
+    #[test]
+    fn worker_on_tick_publishes_mrc_floor_for_implausible_snapshot() {
+        let cache = empty_perception_cap();
+        let pubr = PerceptionCapPublisher::new(
+            cache.clone(),
+            KinematicPlausibilityContract::urban_reference(),
+            500,
+        );
+        // A non-finite object → structural failure → MRC floor (0.0).
+        let mut bad = ok_obj(1);
+        bad.vel_mps = Vec2 { x: f64::NAN, y: 0.0 };
+        let objs = [bad];
+        let p = PerceptionOutput {
+            objects: &objs,
+            confidence: 0.95,
+            age_ms: 10,
+            min_confidence: 0.5,
+            max_age_ms: 500,
+        };
+        pubr.on_tick(&p, 1000);
+        assert_eq!(resolve_perception_cap(true, &cache, 1100), Some(0.0));
+    }
+
+    #[test]
+    fn worker_sweep_publishes_mrc_floor_when_no_tick() {
+        let cache = empty_perception_cap(); // never ticked
+        let pubr = PerceptionCapPublisher::new(
+            cache.clone(),
+            KinematicPlausibilityContract::urban_reference(),
+            500,
+        );
+        pubr.sweep_staleness(2000);
+        // Sweep published an MRC-floor cap; a fresh read now sees 0.0.
+        let entry = cache.read().unwrap().unwrap();
+        assert_eq!(entry.cap_mps, 0.0);
+        assert_eq!(resolve_perception_cap(true, &cache, 2050), Some(0.0));
+    }
+
+    #[test]
+    fn worker_sweep_leaves_fresh_cap_untouched() {
+        let cache = empty_perception_cap();
+        fresh_cap(&cache, 9.0, 2000, 500);
+        let pubr = PerceptionCapPublisher::new(
+            cache.clone(),
+            KinematicPlausibilityContract::urban_reference(),
+            500,
+        );
+        pubr.sweep_staleness(2100); // within TTL → no-op
+        assert_eq!(resolve_perception_cap(true, &cache, 2100), Some(9.0));
     }
 }

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -19,6 +19,7 @@ use crate::gateway::kinematics_contract::{
     enforce_degraded_decel_to_stop, validate_vehicle_command, EnforceAction,
     ProposedVehicleCommand, VehicleKinematicsContract,
 };
+use crate::gateway::perception_monitor::{apply_perception_cap, resolve_perception_cap};
 use crate::gateway::policy::{classify_http_command, OperationalCommand};
 use crate::posture_cache::{
     now_ms as posture_now_ms, should_route_command, CachedFleetPosture, ServiceState,
@@ -219,10 +220,24 @@ pub async fn enforce_actuator_safety_envelope(
     // decel-to-stop-and-HOLD gate (non-increasing speed + no re-initiation)
     // over the MRC envelope. LockedOut was already short-circuited above.
     let verdict = match posture {
-        FleetPosture::Nominal => validate_vehicle_command(
-            &proposed_cmd,
-            &VehicleKinematicsContract::nominal_reference_profile(),
-        ),
+        FleetPosture::Nominal => {
+            // KIRRA-OCCY-PMON-002 composition: read the perception-derate cap
+            // O(1) (3-state resolver — None when the monitor is disabled, MRC
+            // floor when an enabled monitor is stale/silent) and tighten the
+            // Nominal contract via `apply_perception_cap` BEFORE the verdict
+            // call. `validate_vehicle_command`/`effective_max_speed_mps` are
+            // unchanged; the only added per-command cost is this O(1) read.
+            let eff_cap = resolve_perception_cap(
+                svc.perception_monitor_enabled,
+                &svc.perception_cap,
+                now_ms(),
+            );
+            let contract = apply_perception_cap(
+                &VehicleKinematicsContract::nominal_reference_profile(),
+                eff_cap,
+            );
+            validate_vehicle_command(&proposed_cmd, &contract)
+        }
         FleetPosture::Degraded => enforce_degraded_decel_to_stop(
             &proposed_cmd,
             &VehicleKinematicsContract::mrc_fallback_profile(),

--- a/src/posture_cache.rs
+++ b/src/posture_cache.rs
@@ -165,6 +165,20 @@ pub struct ServiceState {
     /// channel is full; the gate fail-closes on the resulting stale cache.
     pub posture_engine_tx:
         std::sync::OnceLock<crate::posture_engine_v2::PostureEngineSender>,
+
+    /// Track-C perception-derate cap cache (KIRRA-OCCY-PMON-002). The
+    /// perception-monitor worker publishes a speed cap here at perception-tick
+    /// rate; the actuator verdict surfaces read it O(1) and compose it into the
+    /// Nominal-arm contract via `apply_perception_cap`. Present even when the
+    /// monitor is disabled (the enabled flag gates use, not allocation).
+    pub perception_cap: crate::gateway::perception_monitor::SharedPerceptionCap,
+
+    /// Whether the perception monitor is deployed/enabled. **Defaults false** —
+    /// when false, `resolve_perception_cap` returns `None` (state 1: no-op), so
+    /// the composition is a pure no-op until a real perception ingest (#126)
+    /// wires and enables the monitor. A disabled monitor's absence is NOT a
+    /// fault; only a *configured* monitor going silent fails closed (state 3).
+    pub perception_monitor_enabled: bool,
 }
 
 /// Returns current time as milliseconds since UNIX epoch.

--- a/src/wcet_gate.rs
+++ b/src/wcet_gate.rs
@@ -122,6 +122,24 @@ pub const GOVERNOR_VERDICT_WCET_CI_THRESHOLD_MICROS: u64 = 1000;
 /// fail-closed timeout setting.
 pub const GOVERNOR_CONTAINMENT_WCET_CI_THRESHOLD_MICROS: u64 = 10_000;
 
+/// CI regression-gate threshold for the Track-C perception kinematic-plausibility
+/// guard (microseconds), evaluated at PERCEPTION-TICK rate — NOT per command
+/// (KIRRA-OCCY-PMON-002, Option B).
+///
+/// Like the SG2 containment check, this guard is structurally heavier than the
+/// O(1) per-command kernel: it is `O(MAX_TRACKED_OBJECTS)` (a finite/structural
+/// check + a velocity-magnitude + a teleport implied-speed test per object,
+/// `MAX_TRACKED_OBJECTS = 256`). It does NOT fold into the per-command budget —
+/// under Option B it runs once per perception frame and publishes a cap; the
+/// verdict path only does an O(1) cap read (gated separately by the per-command
+/// threshold, see `wcet_perception_cap_read_is_o1`).
+///
+/// 10 000 µs is generous for debug-mode CI (same caveat / separate-budget
+/// rationale as `GOVERNOR_CONTAINMENT_WCET_CI_THRESHOLD_MICROS`); S8 (#120)
+/// re-measures on the target SoC. The exact value is provisional — confirmed
+/// alongside the tick-rate worker's real cadence at deployment time.
+pub const GOVERNOR_PERCEPTION_GUARD_WCET_CI_THRESHOLD_MICROS: u64 = 10_000;
+
 // ---------------------------------------------------------------------------
 // Measurement helpers
 // ---------------------------------------------------------------------------
@@ -408,6 +426,99 @@ mod ci_gate_tests {
              on top of its expected O(poses × vertices × 4) edge work.",
             GOVERNOR_CONTAINMENT_WCET_CI_THRESHOLD_MICROS,
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // KIRRA-OCCY-PMON-002 — perception-derate composition WCET coverage.
+    //
+    // Two separate budgets, mirroring the containment precedent:
+    //   (1) the tick-rate kinematic guard (O(MAX_TRACKED_OBJECTS)) — its OWN
+    //       budget, NOT the per-command one;
+    //   (2) the per-command cap read+compose (resolve_perception_cap +
+    //       apply_perception_cap) — must stay O(1), under the per-command budget
+    //       (no per-command budget revision).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn wcet_perception_kinematic_guard_worst_case() {
+        use crate::gateway::perception_monitor::{
+            kinematic_plausibility_derate, KinematicPlausibilityContract, PerceptionOutput,
+            TrackedObject, Vec2, MAX_TRACKED_OBJECTS,
+        };
+        // Worst case: a full MAX_TRACKED_OBJECTS slice of valid, plausible
+        // objects (every object runs the finite + velocity + teleport checks to
+        // completion — no early structural-failure return).
+        let objs: Vec<TrackedObject> = (0..MAX_TRACKED_OBJECTS as u64)
+            .map(|id| TrackedObject {
+                id,
+                pos_m: Vec2 { x: 10.0, y: 0.0 },
+                vel_mps: Vec2 { x: 5.0, y: 0.0 },
+                prev_pos_m: Vec2 { x: 9.5, y: 0.0 },
+                dt_s: 0.1,
+            })
+            .collect();
+        let perception = PerceptionOutput {
+            objects: &objs,
+            confidence: 0.95,
+            age_ms: 10,
+            min_confidence: 0.5,
+            max_age_ms: 500,
+        };
+        let contract = KinematicPlausibilityContract::urban_reference();
+
+        const GUARD_ITERS: u32 = 2_000;
+        let (max_ns, p999_ns) = measure_stats(GUARD_ITERS, || {
+            let _ = std::hint::black_box(kinematic_plausibility_derate(
+                std::hint::black_box(&perception),
+                std::hint::black_box(&contract),
+            ));
+        });
+        let (max_us, p999_us) = (max_ns / 1000, p999_ns / 1000);
+        println!(
+            "WCET-GATE perception_kinematic_guard::worst_case ({MAX_TRACKED_OBJECTS} objects): \
+             max={max_ns}ns ({max_us}us)  p99.9={p999_ns}ns ({p999_us}us)  \
+             vs PMON-guard CI-threshold {}us (TICK-rate, not per-command — see \
+             GOVERNOR_PERCEPTION_GUARD_WCET_CI_THRESHOLD_MICROS)",
+            GOVERNOR_PERCEPTION_GUARD_WCET_CI_THRESHOLD_MICROS,
+        );
+        assert!(
+            p999_us < GOVERNOR_PERCEPTION_GUARD_WCET_CI_THRESHOLD_MICROS as u128,
+            "WCET REGRESSION on perception_kinematic_guard::worst_case: p99.9 {p999_us}us \
+             exceeds the PMON-guard CI threshold {}us — the O(MAX_TRACKED_OBJECTS) guard \
+             has acquired a heap alloc / lock / I/O on top of its per-object scalar work.",
+            GOVERNOR_PERCEPTION_GUARD_WCET_CI_THRESHOLD_MICROS,
+        );
+    }
+
+    #[test]
+    fn wcet_perception_cap_read_is_o1() {
+        use crate::gateway::kinematics_contract::VehicleKinematicsContract;
+        use crate::gateway::perception_monitor::{
+            apply_perception_cap, empty_perception_cap, resolve_perception_cap, CachedPerceptionCap,
+            DerateCode,
+        };
+        // The per-command hot-path addition: resolve (one RwLock read + staleness
+        // compare) + apply (clone + one min). Must stay under the PER-COMMAND
+        // budget — this is the cost the verdict path actually pays per command.
+        let cache = empty_perception_cap();
+        let now = crate::posture_cache::now_ms();
+        *cache.write().unwrap() = Some(CachedPerceptionCap {
+            cap_mps: 12.0,
+            generated_at_ms: now,
+            ttl_ms: 5_000,
+            reason: DerateCode::ObjectVelocityImplausible,
+        });
+        let base = VehicleKinematicsContract::nominal_reference_profile();
+
+        let (max_ns, p999_ns) = measure_stats(ITERS, || {
+            let eff = std::hint::black_box(resolve_perception_cap(
+                std::hint::black_box(true),
+                std::hint::black_box(&cache),
+                std::hint::black_box(now),
+            ));
+            let _ = std::hint::black_box(apply_perception_cap(std::hint::black_box(&base), eff));
+        });
+        assert_under_budget("perception_cap_read+compose::per_command", max_ns, p999_ns);
     }
 
     #[test]

--- a/tests/actuator_envelope_integration.rs
+++ b/tests/actuator_envelope_integration.rs
@@ -47,6 +47,8 @@ fn build_state_with_posture(posture: FleetPosture) -> Arc<ServiceState> {
         fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
         fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
+        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_monitor_enabled: false,
     })
 }
 
@@ -427,6 +429,106 @@ async fn test_capstone_degraded_in_envelope_passes_through_unclamped() {
     assert_eq!(v["linear_velocity_mps"], 3.0);
     assert_eq!(v["enforced_steering_angle_deg"], 1.0);
     assert_eq!(v["steering_angle_deg"], 1.0);
+}
+
+// ---------------------------------------------------------------------------
+// KIRRA-OCCY-PMON-002: perception-derate composition wired into the HTTP
+// actuator middleware (the call-site tightening at the Nominal arm).
+// ---------------------------------------------------------------------------
+
+/// PMON-002 state 2 (enabled + fresh, cap below command): the middleware reads
+/// the published cap and clamps the forwarded command to it. A steady-state
+/// command (current == linear, no accel/steer correction) isolates the cap as
+/// the only acting constraint.
+#[tokio::test]
+async fn test_perception_cap_enabled_fresh_clamps_to_published_cap() {
+    // enabled=true is set on the ServiceState below; cap 3.0 m/s, command 10 m/s.
+    let store = VerifierStore::new(":memory:").expect("in-memory store");
+    let app_state = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+    let posture_cache: SharedPostureCache =
+        Arc::new(std::sync::RwLock::new(Some(CachedFleetPosture::new(FleetPosture::Nominal))));
+    let perception_cap = kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap();
+    {
+        use kirra_runtime_sdk::gateway::perception_monitor::{CachedPerceptionCap, DerateCode};
+        let now = kirra_runtime_sdk::posture_cache::now_ms();
+        *perception_cap.write().unwrap() = Some(CachedPerceptionCap {
+            cap_mps: 3.0,
+            generated_at_ms: now,
+            ttl_ms: 5_000,
+            reason: DerateCode::ObjectVelocityImplausible,
+        });
+    }
+    let svc = Arc::new(ServiceState {
+        app: app_state,
+        posture_cache,
+        audit_verifying_key: None,
+        fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
+        fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
+        fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new(None)),
+        posture_engine_tx: std::sync::OnceLock::new(),
+        perception_cap,
+        perception_monitor_enabled: true,
+    });
+
+    // 10 m/s steady (current==linear so no accel/steer clamp) → clamp to cap 3.0.
+    let (status, v) =
+        send_json(build_schema_app(svc), Body::from(cmd_json(10.0, 10.0, 0.1, 0.0, 0.0))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(v["action"], "ClampLinear");
+    assert_eq!(v["enforced_linear_velocity_mps"], 3.0,
+        "enabled+fresh perception cap must clamp the forwarded command to 3.0");
+}
+
+/// PMON-002 state 1 (disabled): identical to the no-perception baseline — a
+/// command under the vehicle max is Allowed unchanged. (Default ServiceState
+/// has `perception_monitor_enabled = false`.)
+#[tokio::test]
+async fn test_perception_cap_disabled_is_noop() {
+    let svc = build_state_with_posture(FleetPosture::Nominal); // enabled = false
+    let (status, v) =
+        send_json(build_schema_app(svc), Body::from(cmd_json(10.0, 10.0, 0.1, 0.0, 0.0))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(v["action"], "Allow", "disabled monitor must be a pure no-op");
+    assert_eq!(v["enforced_linear_velocity_mps"], 10.0);
+}
+
+/// PMON-002 state 3 (enabled + STALE): a configured monitor whose cap has aged
+/// past its TTL fails closed to the MRC floor → ClampLinear(0.0) controlled stop.
+#[tokio::test]
+async fn test_perception_cap_enabled_stale_controlled_stop() {
+    let store = VerifierStore::new(":memory:").expect("in-memory store");
+    let app_state = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+    let posture_cache: SharedPostureCache =
+        Arc::new(std::sync::RwLock::new(Some(CachedFleetPosture::new(FleetPosture::Nominal))));
+    let perception_cap = kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap();
+    {
+        use kirra_runtime_sdk::gateway::perception_monitor::{CachedPerceptionCap, DerateCode};
+        // generated far in the past relative to a tiny TTL → stale on read.
+        *perception_cap.write().unwrap() = Some(CachedPerceptionCap {
+            cap_mps: 9.0,
+            generated_at_ms: 1, // epoch-ancient
+            ttl_ms: 1,
+            reason: DerateCode::ObjectVelocityImplausible,
+        });
+    }
+    let svc = Arc::new(ServiceState {
+        app: app_state,
+        posture_cache,
+        audit_verifying_key: None,
+        fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
+        fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
+        fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new(None)),
+        posture_engine_tx: std::sync::OnceLock::new(),
+        perception_cap,
+        perception_monitor_enabled: true,
+    });
+
+    let (status, v) =
+        send_json(build_schema_app(svc), Body::from(cmd_json(10.0, 10.0, 0.1, 0.0, 0.0))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(v["action"], "ClampLinear");
+    assert_eq!(v["enforced_linear_velocity_mps"], 0.0,
+        "enabled+stale monitor must fail closed to a controlled stop (cap 0.0)");
 }
 
 /// FAIL-CLOSED: the handler's signature declares `Extension<EnforcementOutcome>`

--- a/tests/actuator_middleware_integration.rs
+++ b/tests/actuator_middleware_integration.rs
@@ -31,6 +31,8 @@ fn build_state(posture: FleetPosture) -> Arc<ServiceState> {
         fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
         fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
+        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_monitor_enabled: false,
     })
 }
 
@@ -46,6 +48,8 @@ fn build_state_empty_cache() -> Arc<ServiceState> {
         fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
         fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
+        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_monitor_enabled: false,
     })
 }
 

--- a/tests/governor_closes_loop_proof.rs
+++ b/tests/governor_closes_loop_proof.rs
@@ -79,6 +79,8 @@ fn service_state_from(app: Arc<AppState>, cache: SharedPostureCache) -> Arc<Serv
         fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
         fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
+        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_monitor_enabled: false,
     })
 }
 

--- a/tests/posture_gate_integration.rs
+++ b/tests/posture_gate_integration.rs
@@ -61,6 +61,8 @@ fn build_state(initial: Option<CachedFleetPosture>) -> Arc<ServiceState> {
         fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
         fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
+        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_monitor_enabled: false,
     })
 }
 


### PR DESCRIPTION
Realizes the PMON-002 composition mechanism (Option B). Adds `SharedPerceptionCap` (mirror of `SharedPostureCache`), a 3-state resolver (not-enabled → no-op / enabled+fresh → derate / enabled+stale|None|poisoned → MRC floor), and `apply_perception_cap` call-site tightening that composes the perception cap into the Nominal-arm contract's `odd_speed_cap_mps` — yielding `min(max_speed, odd_cap, perception_cap)` WITHOUT touching the verdict fn. Wired at the HTTP middleware + fabric surfaces; parko-kirra staged (matched primary+diverse-shadow pair). A `PerceptionCapPublisher` worker + staleness sweep, and a separate tick-rate WCET budget (containment precedent).

**INVARIANTS:** `kinematics_contract.rs` byte-identical to main (`validate_vehicle_command` / `effective_max_speed_mps` / `DenyCode` untouched); derate-only, deny path untouched.

**SAFE BY DEFAULT:** `perception_monitor_enabled` defaults FALSE, so this is a pure NO-OP on main — it enforces NOTHING until #126 wires a real TrackedObject source and the worker is enabled.

**Scope:** kinematic guard only. Staged follow-ups: #126 (TrackedObject ingest), #120 Item B (R_obs producer + range guard), parko-kirra matched-pair wiring.

Refs KIRRA-OCCY-PMON-002, KIRRA-OCCY-PMON-001, ADR-0002, ADR-0004.

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv)_