### PR TITLE
feat(adapter): perception-ingest slice-1 — kinematic guard enforcing at adapter surface, default OFF (KIRRA-OCCY-PMON-003)

### DIFF
--- a/crates/kirra-ros2-adapter/src/lib.rs
+++ b/crates/kirra-ros2-adapter/src/lib.rs
@@ -21,6 +21,9 @@ pub mod corridor;
 pub mod geometry;
 pub mod state;
 pub mod validation;
+// KIRRA-OCCY-PMON-003 slice-1 — pure perception-ingest shim/orchestration
+// (non-ros2-gated; safety logic tested under default features).
+pub mod perception_ingest;
 
 // `posture_tracker` was relocated to the kernel
 // (`kirra_runtime_sdk::posture_tracker`) by M2b so the parko-ros2 node

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -43,7 +43,14 @@ use crate::state::{
     AdaptorState, EgoOdom, TrajectoryPoint, SUBSCRIPTION_STALENESS_TIMEOUT_MS,
 };
 use crate::validation::{
-    check_command_conforms, validate_trajectory_slow, ConformanceVerdict, IncomingControl,
+    check_command_conforms, validate_trajectory_slow_capped, ConformanceVerdict, IncomingControl,
+};
+// KIRRA-OCCY-PMON-003 slice-1: pure ingest orchestration (safety logic lives
+// in `perception_ingest` + the kernel; this node only forwards to them).
+use crate::perception_ingest::{perception_derate_enabled, publish_perception_tick};
+use kirra_runtime_sdk::gateway::perception_monitor::{
+    empty_perception_cap, resolve_perception_cap, KinematicPlausibilityContract,
+    PerceptionCapPublisher,
 };
 
 /// Read the subscription staleness timeout (ms) from
@@ -330,6 +337,17 @@ pub async fn run_adapter(
     // the M1-era behaviour for verifier-less deployments.
     let slow_state = Arc::clone(&state);
     let slow_corridor = Arc::clone(&corridor);
+    // KIRRA-OCCY-PMON-003 slice-1 (D3a): adapter-local perception-derate cap.
+    // The publisher runs the Track-C kinematic guard at perception-tick rate
+    // and publishes a speed cap; the slow loop reads it O(1) and composes it
+    // into the per-pose verdict. DEFAULT OFF via `KIRRA_PERCEPTION_DERATE_ENABLED`
+    // — `resolve_perception_cap(false, ..)` returns `None` → pure no-op.
+    let perception_cache = empty_perception_cap();
+    let perception_publisher = PerceptionCapPublisher::new(
+        perception_cache.clone(),
+        KinematicPlausibilityContract::urban_reference(),
+        subscription_staleness_timeout_ms(), // ttl reuses the subscription staleness budget
+    );
     tokio::spawn(async move {
         let mut rx = trajectory_rx;
         while let Some(traj) = rx.recv().await {
@@ -337,13 +355,36 @@ pub async fn run_adapter(
             let objects = slow_state.snapshot_objects();
             let odom = slow_state.snapshot_odom();
             let posture = slow_state.current_posture();
-            let verdict = validate_trajectory_slow(
+
+            // Track-C ingest tick (pure orchestration in `perception_ingest`):
+            // publish the cap stamped with the OBJECTS' freshness timestamp, so
+            // the cap ages with the object stream and `resolve_perception_cap`
+            // fails closed (state-3 MRC) when objects go silent. If objects are
+            // stale/never-seen, sweep an MRC-floor cap proactively.
+            let now_wall = now_ms_wall();
+            let objects_ms =
+                slow_state.last_objects_ms.load(std::sync::atomic::Ordering::Relaxed);
+            let objects_fresh = objects_ms != 0
+                && now_wall.saturating_sub(objects_ms) <= subscription_staleness_timeout_ms();
+            if objects_fresh {
+                publish_perception_tick(&perception_publisher, &objects, objects_ms);
+            } else {
+                perception_publisher.sweep_staleness(now_wall);
+            }
+            let effective_perception_cap = resolve_perception_cap(
+                perception_derate_enabled(),
+                &perception_cache,
+                now_wall,
+            );
+
+            let verdict = validate_trajectory_slow_capped(
                 &traj.points,
                 slow_corridor.as_ref(),
                 &objects,
                 &slow_state.config,
                 odom.as_ref(),
                 posture,
+                effective_perception_cap,
             );
             let now_ms = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)

--- a/crates/kirra-ros2-adapter/src/parsing.rs
+++ b/crates/kirra-ros2-adapter/src/parsing.rs
@@ -117,6 +117,10 @@ pub fn parse_predicted_objects(
             pos: Point { x_m: pose.position.x as f64, y_m: pose.position.y as f64 },
             velocity_mps,
             heading_rad,
+            // KIRRA-OCCY-PMON-003 §5 (PRESERVE): carry the twist VECTOR through
+            // (previously discarded after the magnitude collapse) so the
+            // Track-C kinematic ceiling sees the reported map-frame velocity.
+            vel: Point { x_m: vx, y_m: vy },
         }
     }).collect()
 }

--- a/crates/kirra-ros2-adapter/src/perception_ingest.rs
+++ b/crates/kirra-ros2-adapter/src/perception_ingest.rs
@@ -1,0 +1,247 @@
+// crates/kirra-ros2-adapter/src/perception_ingest.rs
+//
+// KIRRA-OCCY-PMON-003 slice-1 — the perception ingest that flips the Track-C
+// kinematic guard from dormant to ENFORCING at the adapter surface (D3a).
+//
+// THIS MODULE IS NOT ros2-gated. It holds the *safety-relevant* ingest
+// transforms as PURE functions over kernel types + the adapter's plain
+// `PerceivedObject` (itself non-gated), so they compile and are unit-tested
+// under DEFAULT features (CI `Test`). The ROS2 wiring in `node.rs`
+// (`ros2`-gated) is a thin extractor that snapshots `PerceivedObject`s and
+// calls these — it makes no safety decision.
+//
+// Pipeline (all pure here):
+//   PerceivedObject[]  --perceived_to_tracked-->  TrackedObject[]
+//                      --ingest_perception_output--> PerceptionOutput
+//                      --PerceptionCapPublisher::on_tick--> SharedPerceptionCap
+//   then the slow loop: resolve_perception_cap(enabled, cache, now) -> Option<f64>
+//        -> validate_trajectory_slow_capped(.., eff_cap) -> apply_perception_cap
+//
+// Scope: kinematic reported-velocity CEILING only (D2a; teleport D2b deferred).
+// Range guard, parko-kirra, and the verifier HTTP/fabric path (D3b) are staged.
+
+use kirra_runtime_sdk::gateway::perception_monitor::{
+    ingest_perception_output, tracked_object_from_parts, PerceptionCapPublisher, TrackedObject, Vec2,
+};
+
+use crate::state::PerceivedObject;
+
+/// Env var that enables the Track-C perception derate on the adapter surface.
+/// **Default OFF** (mirrors the `KIRRA_POSTURE_STREAM_URL` presence-gating in
+/// `node.rs`): unset / falsey → disabled → `resolve_perception_cap` returns
+/// state-1 `None` → pure no-op. Enabling on a real vehicle is additionally
+/// gated on the D4 frame-confirm + a sim/bench validation gate (NOT in this
+/// slice).
+pub const PERCEPTION_DERATE_ENABLED_ENV: &str = "KIRRA_PERCEPTION_DERATE_ENABLED";
+
+/// Read the enable gate from the environment. Truthy = `1`/`true`/`yes`
+/// (case-insensitive); anything else (including unset) = disabled.
+#[must_use]
+pub fn perception_derate_enabled() -> bool {
+    std::env::var(PERCEPTION_DERATE_ENABLED_ENV)
+        .map(|v| {
+            let t = v.trim();
+            t == "1" || t.eq_ignore_ascii_case("true") || t.eq_ignore_ascii_case("yes")
+        })
+        .unwrap_or(false)
+}
+
+/// Pure shim: map the adapter's `PerceivedObject`s to kernel `TrackedObject`s
+/// (KIRRA-OCCY-PMON-003 §3). Reported-velocity vector is carried through;
+/// `prev_pos_m`/`dt_s` are set so the teleport check is inert (D2a). No
+/// tracking or association happens here — IDs + velocity come from upstream
+/// (ADR-0004).
+#[must_use]
+pub fn perceived_to_tracked(objects: &[PerceivedObject]) -> Vec<TrackedObject> {
+    objects
+        .iter()
+        .map(|o| {
+            tracked_object_from_parts(
+                o.id,
+                Vec2 { x: o.pos.x_m, y: o.pos.y_m },
+                Vec2 { x: o.vel.x_m, y: o.vel.y_m },
+            )
+        })
+        .collect()
+}
+
+/// Run one perception tick: remap → assemble → publish the kinematic-guard cap
+/// into the publisher's `SharedPerceptionCap`. `tick_ms` should be the
+/// **objects' freshness timestamp** (so the cap ages with the object stream and
+/// `resolve_perception_cap` fails closed when objects go silent), not a
+/// trajectory-cycle clock.
+pub fn publish_perception_tick(
+    publisher: &PerceptionCapPublisher,
+    objects: &[PerceivedObject],
+    tick_ms: u64,
+) {
+    let tracked = perceived_to_tracked(objects);
+    let perception = ingest_perception_output(&tracked);
+    publisher.on_tick(&perception, tick_ms);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::corridor::Point;
+    use kirra_runtime_sdk::gateway::kinematics_contract::{
+        validate_vehicle_command, EnforceAction, ProposedVehicleCommand, VehicleKinematicsContract,
+    };
+    use kirra_runtime_sdk::gateway::perception_monitor::{
+        apply_perception_cap, empty_perception_cap, resolve_perception_cap, DerateCode,
+        KinematicPlausibilityContract,
+    };
+
+    fn obj(id: u64, vx: f64, vy: f64) -> PerceivedObject {
+        PerceivedObject {
+            id,
+            pos: Point { x_m: 0.0, y_m: 0.0 },
+            velocity_mps: (vx * vx + vy * vy).sqrt(),
+            heading_rad: 0.0,
+            vel: Point { x_m: vx, y_m: vy },
+        }
+    }
+
+    fn publisher(cache: &kirra_runtime_sdk::gateway::perception_monitor::SharedPerceptionCap) -> PerceptionCapPublisher {
+        PerceptionCapPublisher::new(cache.clone(), KinematicPlausibilityContract::urban_reference(), 500)
+    }
+
+    // ---- shim ----
+
+    #[test]
+    fn shim_carries_velocity_vector_and_neutralizes_teleport() {
+        let tracked = perceived_to_tracked(&[obj(1, 3.0, 4.0)]);
+        assert_eq!(tracked.len(), 1);
+        assert_eq!(tracked[0].id, 1);
+        assert_eq!(tracked[0].vel_mps, Vec2 { x: 3.0, y: 4.0 });
+        assert_eq!(tracked[0].prev_pos_m, tracked[0].pos_m); // teleport no-op
+        assert!(tracked[0].dt_s > 0.0);
+    }
+
+    // ---- publisher tick over synthetic objects ----
+
+    #[test]
+    fn tick_publishes_nominal_cap_for_plausible_objects() {
+        let cache = empty_perception_cap();
+        let p = publisher(&cache);
+        publish_perception_tick(&p, &[obj(1, 5.0, 0.0), obj(2, 3.0, 4.0)], 1000);
+        // No object over the 60 m/s ceiling → nominal cap published.
+        let cap = resolve_perception_cap(true, &cache, 1100);
+        assert_eq!(
+            cap,
+            Some(kirra_runtime_sdk::gateway::kinematics_contract::URBAN_ODD_SPEED_CAP_MPS)
+        );
+    }
+
+    #[test]
+    fn tick_publishes_mrc_floor_for_implausible_object() {
+        let cache = empty_perception_cap();
+        let p = publisher(&cache);
+        // |vel| = 70 > 60 → implausible; single object → fraction 1.0 → MRC floor.
+        publish_perception_tick(&p, &[obj(1, 70.0, 0.0)], 1000);
+        assert_eq!(resolve_perception_cap(true, &cache, 1100), Some(0.0));
+    }
+
+    // ---- 3-state resolve (delegated to the kernel resolver, asserted here) ----
+
+    #[test]
+    fn resolve_three_states() {
+        let cache = empty_perception_cap();
+        let p = publisher(&cache);
+        publish_perception_tick(&p, &[obj(1, 5.0, 0.0)], 1000);
+
+        // state 1 — disabled → no-op
+        assert_eq!(resolve_perception_cap(false, &cache, 1100), None);
+        // state 2 — enabled + fresh → the published cap
+        assert!(resolve_perception_cap(true, &cache, 1100).is_some());
+        assert!(resolve_perception_cap(true, &cache, 1100).unwrap() > 0.0);
+        // state 3 — enabled + stale (now - gen = 600 > ttl 500) → MRC floor
+        assert_eq!(resolve_perception_cap(true, &cache, 1600), Some(0.0));
+    }
+
+    #[test]
+    fn resolve_state3_when_never_published() {
+        let cache = empty_perception_cap();
+        assert_eq!(resolve_perception_cap(true, &cache, 1000), Some(0.0));
+    }
+
+    // ---- sweep on a silent stream ----
+
+    #[test]
+    fn sweep_publishes_mrc_on_silent_stream() {
+        let cache = empty_perception_cap();
+        let p = publisher(&cache);
+        p.sweep_staleness(2000);
+        assert_eq!(cache.read().unwrap().unwrap().cap_mps, 0.0);
+    }
+
+    // ---- compose: resolve → apply → per-pose verdict ----
+
+    fn cmd_at(v: f64) -> ProposedVehicleCommand {
+        ProposedVehicleCommand {
+            linear_velocity_mps: v,
+            current_velocity_mps: v,
+            delta_time_s: 0.1,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        }
+    }
+
+    #[test]
+    fn compose_state2_clamps_to_cap() {
+        let cache = empty_perception_cap();
+        // Publish an implausible snapshot → cap = MRC floor 0.0… instead test a
+        // mid cap by writing directly is covered in the kernel; here exercise the
+        // adapter path end-to-end with a plausible cap by using a contract whose
+        // nominal cap is the published value.
+        let p = publisher(&cache);
+        publish_perception_tick(&p, &[obj(1, 5.0, 0.0)], 1000); // nominal cap (22.35)
+        let eff = resolve_perception_cap(true, &cache, 1100);
+
+        let base = VehicleKinematicsContract::nominal_reference_profile(); // max 35
+        let tightened = apply_perception_cap(&base, eff);
+        // Command at 30 m/s > 22.35 perception cap → clamp to 22.35.
+        let verdict = validate_vehicle_command(&cmd_at(30.0), &tightened);
+        assert_eq!(
+            verdict,
+            EnforceAction::ClampLinear(
+                kirra_runtime_sdk::gateway::kinematics_contract::URBAN_ODD_SPEED_CAP_MPS
+            )
+        );
+    }
+
+    #[test]
+    fn compose_state3_is_controlled_stop() {
+        let cache = empty_perception_cap(); // never published → state 3
+        let eff = resolve_perception_cap(true, &cache, 1000);
+        assert_eq!(eff, Some(0.0));
+        let base = VehicleKinematicsContract::nominal_reference_profile();
+        let tightened = apply_perception_cap(&base, eff);
+        let verdict = validate_vehicle_command(&cmd_at(20.0), &tightened);
+        assert_eq!(verdict, EnforceAction::ClampLinear(0.0)); // controlled stop
+    }
+
+    #[test]
+    fn compose_state1_is_noop() {
+        let cache = empty_perception_cap();
+        let eff = resolve_perception_cap(false, &cache, 1000); // disabled
+        assert_eq!(eff, None);
+        let base = VehicleKinematicsContract::nominal_reference_profile();
+        let tightened = apply_perception_cap(&base, eff);
+        // Identical to baseline: 20 m/s under the 35 m/s vehicle max → Allow.
+        assert_eq!(validate_vehicle_command(&cmd_at(20.0), &tightened), EnforceAction::Allow);
+        assert_eq!(tightened.effective_max_speed_mps(), base.effective_max_speed_mps());
+    }
+
+    // ---- env gate default off ----
+
+    #[test]
+    fn env_gate_defaults_off_when_unset() {
+        // Do not mutate process env in a multithreaded test runner (INV-13);
+        // assert the default-off contract by reading the current value, which
+        // is unset in CI → false.
+        if std::env::var(PERCEPTION_DERATE_ENABLED_ENV).is_err() {
+            assert!(!perception_derate_enabled(), "unset env must be disabled");
+        }
+    }
+}

--- a/crates/kirra-ros2-adapter/src/state.rs
+++ b/crates/kirra-ros2-adapter/src/state.rs
@@ -188,6 +188,13 @@ pub struct PerceivedObject {
     pub pos: Point,
     pub velocity_mps: f64,
     pub heading_rad: f64,
+    /// Reported map-frame ground-velocity **vector** `{x_m, y_m}` (m/s),
+    /// preserved from the upstream Autoware twist (KIRRA-OCCY-PMON-003 §5
+    /// sub-decision = PRESERVE). `velocity_mps` stays the magnitude RSS uses;
+    /// `vel` feeds the Track-C kinematic-plausibility ceiling (a vector-
+    /// magnitude check). Frame note: rests on the upstream message contract
+    /// being map/world-frame absolute — see PMON-003 §4 / D4.
+    pub vel: Point,
 }
 
 /// Phase 4c — typed-payload envelope for a freshly-received trajectory

--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -91,6 +91,35 @@ pub fn validate_trajectory_slow(
     latest_odom: Option<&EgoOdom>,
     posture: FleetPosture,
 ) -> TrajectoryVerdict {
+    // Back-compat delegate: no perception-derate cap (the M1 behaviour). The
+    // ROS2 slow loop calls `validate_trajectory_slow_capped` with the
+    // resolved Track-C cap (KIRRA-OCCY-PMON-003 slice-1).
+    validate_trajectory_slow_capped(
+        trajectory, corridor, objects, config, latest_odom, posture, None,
+    )
+}
+
+/// As [`validate_trajectory_slow`], plus the Track-C perception-derate cap
+/// (KIRRA-OCCY-PMON-003 D3a). `effective_perception_cap` is the value resolved
+/// by [`resolve_perception_cap`] at the call site (the adapter slow loop):
+/// `None` when the monitor is disabled/absent (state 1 → no-op), `Some(0.0)`
+/// MRC floor when an enabled monitor is stale/silent (state 3).
+///
+/// The cap is composed into the per-pose kinematics contract via the kernel's
+/// `apply_perception_cap` (a `min` into `odd_speed_cap_mps`) — so
+/// `validate_vehicle_command` stays byte-identical; this only tightens the
+/// contract handed to it. Derate-only: `DenyCode` / the deny path are
+/// untouched, and an MRC-floor (0.0) cap surfaces as the existing
+/// `ClampLinear(0.0)` controlled stop.
+pub fn validate_trajectory_slow_capped(
+    trajectory: &[TrajectoryPoint],
+    corridor: &dyn CorridorSource,
+    objects: &[PerceivedObject],
+    config: &VehicleConfig,
+    latest_odom: Option<&EgoOdom>,
+    posture: FleetPosture,
+    effective_perception_cap: Option<f64>,
+) -> TrajectoryVerdict {
     // ----- Posture short-circuit (M1) ----------------------------------
     //
     // A LockedOut fleet must not be commanded — the safe response is to
@@ -158,11 +187,21 @@ pub fn validate_trajectory_slow(
     // LockedOut was short-circuited above; this match is exhaustive on
     // the remaining variants.
     let degraded = posture == FleetPosture::Degraded;
-    let kinematics = match posture {
+    let base_kinematics = match posture {
         FleetPosture::Nominal  => config.to_kinematics_contract(),
         FleetPosture::Degraded => config.to_mrc_kinematics_contract(),
         FleetPosture::LockedOut => unreachable!("handled by the posture short-circuit above"),
     };
+    // KIRRA-OCCY-PMON-003: compose the Track-C perception-derate cap (most-
+    // conservative-wins `min` into `odd_speed_cap_mps`). Applied uniformly —
+    // a no-op when `None` (state 1) or when the cap is above the posture
+    // ceiling; an MRC-floor (0.0) cap tightens the ceiling to 0 → controlled
+    // stop via the existing per-pose `ClampLinear`. `validate_vehicle_command`
+    // is unchanged.
+    let kinematics = kirra_runtime_sdk::gateway::perception_monitor::apply_perception_cap(
+        &base_kinematics,
+        effective_perception_cap,
+    );
     let initial_steering_deg = current_steering_deg_from_odom(latest_odom, config);
     let mut clamp_seen = false;
     let mut prev_steering_deg = initial_steering_deg;

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -102,6 +102,7 @@ fn test_rss_violation_rejects() {
         pos: Point { x_m: 9.0, y_m: 0.0 },
         velocity_mps: 0.0,
         heading_rad: 0.0,
+        vel: Point { x_m: 0.0, y_m: 0.0 },
     }];
     let cfg = VehicleConfig::default_urban();
 

--- a/src/gateway/perception_monitor.rs
+++ b/src/gateway/perception_monitor.rs
@@ -41,11 +41,16 @@ pub const MAX_TRACKED_OBJECTS: usize = 256;
 
 /// Maximum credible object ground speed (m/s), GROUND/MAP-FRAME.
 ///
-/// **Derived value — KIRRA-OCCY-PMON-KIN-MARGIN-001.** The contract reports
-/// each object's own **map-frame** velocity (confirmed against the Autoware
-/// adapter — this is the object's absolute ground speed, NOT an ego-relative
-/// / closing speed), so the ceiling is a single absolute bound, not a sum of
-/// ego + object speeds.
+/// **Derived value — KIRRA-OCCY-PMON-KIN-MARGIN-001.** The ceiling is checked
+/// against each object's own **map-frame absolute ground speed** (not an
+/// ego-relative / closing speed), so it is a single absolute bound, not a sum
+/// of ego + object speeds. **This map/world-frame assumption rests on the
+/// upstream Autoware message contract** (`PredictedObjects` twist), NOT on any
+/// transform inside the KIRRA adapter — the adapter performs no frame
+/// conversion on object twist (see KIRRA-OCCY-PMON-003 §4 / D4). **Confirm per
+/// deployment** that the target Autoware version emits object twist as
+/// map/world-frame absolute velocity before enabling the derate on a vehicle;
+/// if it does not, the ingest shim must transform to map frame first.
 ///
 /// `60.0 m/s` (216 km/h) is the rounded value of:
 ///   - max credible object-class ground speed near the deployment ODD road
@@ -697,6 +702,64 @@ impl PerceptionCapPublisher {
     }
 }
 
+// ===========================================================================
+// Ingest helpers (KIRRA-OCCY-PMON-003 slice-1) — PURE, default-features-tested.
+//
+// These are the *safety-relevant* transforms of the perception ingest. They
+// operate on KERNEL types + plain scalars only (NOT on any ROS / r2r /
+// adapter type), so they compile and are unit-tested under default features
+// (CI `Test`). The ROS2 adapter's `ros2`-gated wiring is a thin extractor that
+// pulls `(id, pos, vel)` out of its message type and calls these — it holds no
+// safety decision logic.
+// ===========================================================================
+
+/// Sentinel inter-frame Δt (seconds) used by [`tracked_object_from_parts`] so
+/// the teleport (implied-speed) check is a **no-op** in slice-1 (D2a): with
+/// `prev_pos_m == pos_m`, the implied speed `|pos − prev_pos| / dt = 0` for any
+/// positive `dt`, so only the reported-velocity ceiling can fire. The real
+/// inter-frame Δt arrives with the teleport check itself (D2b, deferred).
+pub const TELEPORT_NOOP_DT_S: f64 = 1.0;
+
+/// Build a kernel [`TrackedObject`] from ingest parts (KIRRA-OCCY-PMON-003 §3).
+///
+/// `vel_mps` is the object's **reported map-frame ground velocity vector**
+/// (D2a: reported-velocity ceiling). `prev_pos_m` is set to `pos_m` and `dt_s`
+/// to [`TELEPORT_NOOP_DT_S`], making the teleport check inert for slice-1.
+///
+/// Pure; no allocation; the caller (the ROS2 adapter shim) supplies already-
+/// extracted scalars — no tracking/association happens here (ADR-0004).
+#[must_use]
+pub fn tracked_object_from_parts(id: u64, pos_m: Vec2, vel_mps: Vec2) -> TrackedObject {
+    TrackedObject {
+        id,
+        pos_m,
+        vel_mps,
+        prev_pos_m: pos_m,
+        dt_s: TELEPORT_NOOP_DT_S,
+    }
+}
+
+/// Assemble a [`PerceptionOutput`] for the ingest path from a bounded slice of
+/// shimmed objects (KIRRA-OCCY-PMON-003 §3).
+///
+/// Upstream-tracked objects are treated as trusted-present (`confidence = 1.0`,
+/// `min_confidence = 0.0`), so the snapshot-confidence gate does not itself
+/// derate; **object-stream staleness is enforced one layer up** by the cap's
+/// `generated_at_ms`/`ttl_ms` + `resolve_perception_cap` (the freshness
+/// authority for the ingest). The structural fail-closed gates that DO remain
+/// active here are the per-object finite/`dt>0` checks inside the guard and the
+/// `objects.len() <= MAX_TRACKED_OBJECTS` bound (over-cap → MRC floor).
+#[must_use]
+pub fn ingest_perception_output(objects: &[TrackedObject]) -> PerceptionOutput<'_> {
+    PerceptionOutput {
+        objects,
+        confidence: 1.0,
+        age_ms: 0,
+        min_confidence: 0.0,
+        max_age_ms: u64::MAX,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -1231,5 +1294,53 @@ mod tests {
         );
         pubr.sweep_staleness(2100); // within TTL → no-op
         assert_eq!(resolve_perception_cap(true, &cache, 2100), Some(9.0));
+    }
+
+    // -----------------------------------------------------------------------
+    // Ingest helpers (KIRRA-OCCY-PMON-003 slice-1): tracked_object_from_parts
+    // + ingest_perception_output. Pure, default-features (CI `Test`).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn shim_from_parts_carries_vector_and_neutralizes_teleport() {
+        let obj = tracked_object_from_parts(7, Vec2 { x: 10.0, y: 2.0 }, Vec2 { x: 3.0, y: 4.0 });
+        assert_eq!(obj.id, 7);
+        assert_eq!(obj.pos_m, Vec2 { x: 10.0, y: 2.0 });
+        assert_eq!(obj.vel_mps, Vec2 { x: 3.0, y: 4.0 }); // vector preserved
+        // D2a: prev == pos and dt > 0 → implied speed is exactly 0 (teleport no-op).
+        assert_eq!(obj.prev_pos_m, obj.pos_m);
+        assert_eq!(obj.dt_s, TELEPORT_NOOP_DT_S);
+        assert!(obj.dt_s > 0.0);
+        let implied = obj.pos_m.dist_to(&obj.prev_pos_m) / obj.dt_s;
+        assert_eq!(implied, 0.0, "teleport implied-speed must be 0 in slice-1");
+    }
+
+    #[test]
+    fn shim_object_only_velocity_ceiling_can_fire() {
+        // |vel| = 5 (3,4) < 60 → plausible; the teleport check is inert.
+        let ok = tracked_object_from_parts(1, Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 3.0, y: 4.0 });
+        // |vel| = 65 > 60 → velocity ceiling trips (teleport still inert).
+        let bad = tracked_object_from_parts(2, Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 65.0, y: 0.0 });
+        let objs = [ok, bad];
+        let p = ingest_perception_output(&objs);
+        let d = kinematic_plausibility_derate(&p, &KinematicPlausibilityContract::urban_reference());
+        assert_eq!(d.reason, DerateCode::ObjectVelocityImplausible);
+    }
+
+    #[test]
+    fn ingest_output_passes_health_gate_and_keeps_count_bound() {
+        let objs: Vec<TrackedObject> = (0..3)
+            .map(|i| tracked_object_from_parts(i, Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 1.0, y: 0.0 }))
+            .collect();
+        assert!(ingest_perception_output(&objs).is_healthy());
+        // Over MAX_TRACKED_OBJECTS → unhealthy → guard returns MRC floor.
+        let too_many: Vec<TrackedObject> = (0..(MAX_TRACKED_OBJECTS as u64 + 1))
+            .map(|i| tracked_object_from_parts(i, Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 1.0, y: 0.0 }))
+            .collect();
+        let p = ingest_perception_output(&too_many);
+        assert!(!p.is_healthy());
+        let d = kinematic_plausibility_derate(&p, &KinematicPlausibilityContract::urban_reference());
+        assert_eq!(d.reason, DerateCode::PerceptionSnapshotUnhealthy);
+        assert_eq!(d.cap_mps, 0.0);
     }
 }


### PR DESCRIPTION
The milestone slice — the kinematic guard (PMON-001) is wired to ENFORCE at the adapter verdict surface (D3a) by composing the resolved perception cap into the adapter's `validate_vehicle_command` via the same `pub` `apply_perception_cap`.

**Lands DARK:** `KIRRA_PERCEPTION_DERATE_ENABLED` defaults OFF → pure no-op on main.

**STRUCTURE:** all safety decisions live in PURE, non-ros2-gated, CI-`Test`-covered functions (`perceived_to_tracked`, `publish_perception_tick`, `tracked_object_from_parts`, `ingest_perception_output`, the capped validator); the ros2-gated code (parse vector-preserve, slow-loop tick) is thin forwarding with no safety logic and — by repo structure — no automated coverage (no ros2 job), so its end-to-end correctness is gated to the pre-enable validation step.

**INVARIANTS:** `src/gateway/kinematics_contract.rs` byte-identical (verdict fn untouched); `DenyCode`/deny path untouched; derate-only; MRC-floor 0.0 → existing `ClampLinear` → controlled stop.

**ENABLING on a vehicle is gated on (NOT in this slice):** D4 frame-confirm (Autoware emits map-frame ABSOLUTE object twist), end-to-end freshness verification, and a sim/bench validation gate. Also corrects the overstated PMON-001 map-frame comment.

Staged: D2b teleport, range guard (#120 Item B), parko-kirra matched pair, D3b verifier path.

Refs #126, KIRRA-OCCY-PMON-001/002/003, ADR-0002, ADR-0004.

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv)_