### PR TITLE
docs: learning-loop architecture — fixed checker (Kirra) + adaptive doer

### DIFF
--- a/docs/CAPTURE_PIPELINE_SPEC.md
+++ b/docs/CAPTURE_PIPELINE_SPEC.md
@@ -1,0 +1,137 @@
+# Capture Pipeline Spec — corrective-supervision dataset for the learning loop
+
+Status: SPEC (2026-06-05). Builds on `LEARNING_LOOP_ARCHITECTURE.md`. Assumes the
+**hybrid** capture choice (§3 there): Kirra emits a small non-blocking verdict record; a
+Linux collector joins it with bus telemetry into the full triple.
+
+> **Recorded status.** Companion spec to `LEARNING_LOOP_ARCHITECTURE.md`. **The §3
+> capture-location decision in the architecture doc is OPEN** (owner, 2026-06-05); this spec
+> is the *hybrid-(3) elaboration*, conditional on that confirmation. Its own §6 decisions
+> (sink, correlation key, model-version attribution, dataset format, pass-sampling) are
+> likewise **open**. **As-built note:** the §1 hook seam exists on `main` today —
+> `crates/kirra-ros2-adapter/src/node.rs` binds `objects`, `effective_perception_cap`, then
+> `verdict = validate_trajectory_slow_capped(...)` in the slow loop; the capture call goes
+> immediately after `verdict`. The §0 verdict-path anchor `997fb7ae…` is current on `main`.
+
+## 0. The non-negotiable constraint
+The verdict path stays byte-identical: **`src/gateway/kinematics_contract.rs` =
+`997fb7ae15ce3e11adec9218044c7c84b049ad3b`** (`validate_vehicle_command`,
+`enforce_degraded_decel_to_stop`, `DenyCode`, `effective_max_speed_mps`, …). Capture is
+**purely additive at the call site** and must never:
+- change the verdict, its inputs, or its timing/WCET;
+- block, allocate, or do I/O on the verdict path;
+- be required for the safety domain to function (it fails closed identically with capture on
+  or off).
+
+Capture is **off by default** behind a flag (`KIRRA_CAPTURE_ENABLED`); enabling it changes
+no verdict.
+
+## 1. Where it hooks (the seam — NOT the verdict path)
+The slow-loop tick in `crates/kirra-ros2-adapter/src/node.rs` already computes everything
+the safety side of the triple needs, right after:
+
+```
+let verdict = validate_trajectory_slow_capped(&traj.points, slow_corridor, &objects,
+                                              &slow_state.config, odom, …);
+```
+
+At that point the tick holds: `traj` (the doer's PROPOSAL), `objects` (perception),
+`odom` (ego), `posture`, `effective_perception_cap`, and `verdict` (the DECISION +
+correction). The capture call goes **immediately after `verdict` is bound** — in `node.rs`,
+not in `kinematics_contract.rs`. (Optionally a second, lighter record at the fast-loop
+`check_command_conforms` conformance site.)
+
+## 2. What Kirra emits — the verdict record (small, safety-side)
+Keep the on-tick record tiny and fixed-shape; the bulky inputs are pulled from the bus by
+the collector (§3). Fields:
+
+| field | source | why |
+|---|---|---|
+| `decision_seq` | node-assigned monotonic counter | join key + ordering |
+| `t_mono`, `t_wall` | clock | ordering / bus join |
+| `corr_objects_ms` | `objects_ms` freshness stamp | join to the perception frame |
+| `corr_traj_stamp` | the proposal trajectory's stamp | join to the proposal |
+| `outcome` | from `verdict` | accept / clamp / MRC / reject |
+| `deny_code` | `DenyCode` | which check fired (kinematic / corridor / RSS / staleness / perception-derate) |
+| `applied_cap_mps` | `effective_max_speed_mps()` / `effective_perception_cap` | the CORRECTION Kirra imposed |
+| `mrc` | bool | controlled-stop substitution |
+| `posture` | `posture` | nominal / degraded / locked-out context |
+| `derate_enabled` | `perception_derate_enabled()` | so passes are attributable |
+
+This is the authoritative "what Kirra decided and did" — the **correction** half of the
+triple — and only Kirra knows it. Note it does NOT carry the doer's model version (Kirra
+doesn't know it); that's joined on the Linux side (§3).
+
+## 3. Emission mechanism (WCET-safe, fire-and-forget)
+- The call-site pushes the fixed record into a **bounded lock-free SPSC ring** (pre-
+  allocated, no alloc, no lock, no syscall on the tick). If full → **drop/overwrite oldest**
+  (capture is best-effort; safety never waits).
+- A **separate low-priority drain task/thread** empties the ring and ships records to the
+  sink. On QNX this is a low-priority thread; on Linux (bench) the same — OS-agnostic.
+- **Sink [DECISION]:** (a) append to a local log file, or (b) publish on a dedicated
+  **non-safety DDS telemetry topic** (`~/telemetry/verdict_record`). Recommend (b) so the
+  Linux collector subscribes uniformly alongside the bus tap; (a) is the simplest bring-up.
+
+## 4. The Linux collector — assembling the triple
+A Linux-only service (never in the safety domain). It:
+1. **Subscribes to the bus** and buffers, by correlation key (stamp/seq): the PROPOSAL
+   (`traj` / pre-governed command), the PERCEPTION (`objects` → `PredictedObjects`), the
+   EGO state (`odom`), and the **doer model version** (stamped by the doer on its
+   telemetry — see decision below).
+2. **Ingests verdict records** (from the sink).
+3. **Joins** record ↔ bus telemetry on `decision_seq` (+ `corr_objects_ms` /
+   `corr_traj_stamp` as cross-checks) → one **corrective-supervision sample**.
+4. **Writes** the sample to the versioned dataset store (§5).
+
+The collector is where all heavy data engineering lives — the certified checker stays tiny.
+
+## 5. Dataset schema + versioning
+One sample = the triple + provenance:
+
+```
+sample {
+  sample_id, t_mono, t_wall,
+  model_version,                 # doer's version (join), partition key
+  scenario_tags[],               # optional labels (sim/real, scenario id)
+  is_intervention,               # outcome != accept
+  inputs   { perception: PredictedObjects, ego: Odometry, trajectory_in: Trajectory },
+  proposal { command_or_trajectory },         # what the doer wanted
+  verdict  { outcome, deny_code, applied_cap_mps, mrc, posture, derate_enabled }  # what Kirra did
+}
+```
+- **Format [DECISION]:** Parquet/Arrow (columnar, ML-friendly) recommended; rosbag + a
+  sidecar index is the lower-friction bench option.
+- **Versioning:** partition by `(model_version, date)`; append-only; rotate/bound on the
+  bench (it generates a lot). Each training run slices "samples generated by model vN."
+- **Selection-bias note (from the architecture doc §5):** the dataset must include
+  `is_intervention == false` samples (normal driving), not just corrections — the collector
+  records every decision, with optional pass-sampling to control volume.
+
+## 6. Decisions to confirm
+1. **Sink:** DDS telemetry topic (recommended) vs local log file (simplest bring-up).
+2. **Correlation key:** node-assigned `decision_seq` (recommended) + stamps as cross-check.
+3. **Model-version attribution:** doer stamps its proposal/telemetry with its version, joined
+   by the collector (recommended — keeps Kirra ignorant of the model). Confirm the doer can
+   stamp it.
+4. **Dataset format:** Parquet/Arrow vs rosbag+sidecar.
+5. **Pass-sampling rate** (1.0 = log every decision) — start at 1.0 on the bench, tune later.
+
+## 7. Build phases
+1. **Verdict record + ring + drain + call-site hook** (Rust, in `node.rs`/adapter — NOT
+   `kinematics_contract.rs`). Tests: capture never blocks; **verdict path blob still
+   `997fb7ae…`**; verdicts identical with capture on vs off.
+2. **Sink** (telemetry topic or file) + a tiny reader.
+3. **Linux collector** (bus tap + record ingest + join → sample).
+4. **Dataset store + schema + versioning.**
+5. (Downstream) training/validation consumers read the dataset.
+
+Phase 1 is the buildable-today piece and the only one that touches the repo's safety-
+adjacent code — everything after is Linux-side tooling.
+
+> **Build-time guardrails (restating §0 against the merged code):** Phase 1 lives in
+> `crates/kirra-ros2-adapter/` (and a small `kirra-runtime-sdk` record type), gated behind
+> `KIRRA_CAPTURE_ENABLED` (default OFF), mirroring the existing fire-and-forget emit
+> discipline (`audit_writer_tx.try_send` — wait-free, drop-on-full) and the
+> `KIRRA_PERCEPTION_DERATE_ENABLED` default-off precedent. `src/gateway/kinematics_contract.rs`
+> stays byte-identical (`997fb7ae…`); the on-tick push is a bounded, droppable enqueue that
+> the verdict never waits on.

--- a/docs/LEARNING_LOOP_ARCHITECTURE.md
+++ b/docs/LEARNING_LOOP_ARCHITECTURE.md
@@ -1,0 +1,175 @@
+# Learning-Loop Architecture — fixed checker (Kirra) + adaptive doer (Linux)
+
+Status: DESIGN (2026-06-05). Owner: Justin. Scope: how Kirra's interventions feed a
+continuous-improvement loop for the planner/perception **without** Kirra ever learning.
+
+> **Repo placement / status.** Design record. Cross-refs: ADR-0004 (independent safety
+> channel — the doer/checker boundary this loop is built on), the fixed verdict path
+> (`src/gateway/kinematics_contract.rs`, blob `997fb7ae…`), KIRRA-OCCY-DEPLOY-001 (bench →
+> vehicle topology), and #189 (QNX 8.0 / nto80, see §6). Open decisions are tracked in §8;
+> **§3 capture location is NOT yet confirmed** (recommended-but-open). See the as-built
+> grounding appendix (§9) for the existing repo mechanisms this design builds on.
+
+## 0. The one principle everything follows
+- **Checker (Kirra)** — fixed, certified, has final authority on the command path,
+  and *produces the training data*. **Never learns. Never co-adapts.**
+- **Doer (Occy / Autoware perception + prediction + planning)** — adaptive. *Proposes*
+  commands; never has final authority. This is what improves.
+- **Parko** — the governed inference runtime that *serves* the doer's learnable models
+  deterministically. Doesn't train.
+
+The fixed checker is precisely what makes letting the doer learn *safe*: the doer can be
+imperfect and still never execute a catastrophic command, because Kirra bounds the
+consequences. The governor is the seatbelt that lets the doer experiment.
+
+## 1. Two domains, one minimal interface
+
+```
+   SAFETY DOMAIN  (certified, fixed)              AUTONOMY + LEARNING DOMAIN  (Linux)
+   ┌─────────────────────────────┐                ┌──────────────────────────────────────┐
+   │ Kirra governor (fixed)      │◄── proposal ───│ Occy / Autoware  (DOER — learns)       │
+   │  verdict path 997fb7ae…     │                │   perception → prediction → planning   │
+   │  pass / clamp / MRC / veto  │── governed ───►│   models served by Parko (TensorRT)    │
+   │        │  verdict record     │   command      │   → actuator iface / Dataspeed bridge  │
+   └────────┼────────────────────┘ (non-blocking) └───────────────┬────────────────────────┘
+            │                                                      │ telemetry (bus tap)
+            └──────────────► Linux collector ◄─────────────────────┘
+                                   │
+                                   ▼
+                    corrective-supervision dataset (versioned)
+                                   │ train (GPU box / cloud)
+                                   ▼
+                    candidate model ── validate in AWSIM vs FIXED Kirra
+                                   │
+                                   ▼  human release gate (per-model safety case)
+                    deploy new model → Parko ─────────────► (back to "drive")
+```
+
+The interface is deliberately thin: the doer **proposes**, Kirra **disposes**, and Kirra
+**emits a small verdict record**. The safety domain's correctness does NOT depend on the
+learning domain — Kirra fails closed on silence/garbage. That independence is exactly what
+licenses the Linux side to be experimental.
+
+## 2. The data: the corrective-supervision triple
+Every Kirra decision is captured as:
+1. **State / inputs** — what the doer saw at decision time (perception output, ego state,
+   relevant context).
+2. **Proposal** — the command/trajectory the doer wanted to execute.
+3. **Verdict + correction** — Kirra's decision (pass / clamp / MRC / veto), the deny
+   code/reason, and the *safe command Kirra substituted*.
+
+Plus metadata: timestamp, **doer model version**, scenario tags, pass-vs-intervention flag.
+
+This is richer than negative examples: a clamp gives you *(state, bad proposal, safe
+correction)* — the same shape as learning from an expert who only steps in when you're
+about to err. High-quality supervision, and you already generate it for free.
+
+## 3. Capture — where it happens  [DECISION TO CONFIRM — OPEN]
+The certified checker must NOT take on heavy logging/IO that could touch its determinism or
+WCET. Three options:
+
+- **(1) Kirra logs the full triple.** Authoritative, but loads the certified checker with a
+  non-safety responsibility. Risky for the verdict path's timing budget.
+- **(2) Linux observer reconstructs from the bus.** Keeps the checker minimal, but if
+  Kirra's deny-code/reason isn't on the wire, you lose the richest part of the signal.
+- **(3) HYBRID — recommended.** Kirra emits a *small, fixed-size, fire-and-forget* verdict
+  record (deny code + the substitute it applied) on a **non-safety telemetry path** that the
+  verdict path never waits on (ring buffer / shared mem). A **Linux-side collector** joins
+  that with bus-observed proposal + perception to assemble the full triple and store it.
+  → certified checker's extra job stays tiny and non-blocking; all heavy data engineering
+  lives on Linux.
+
+Recommendation: **(3)**. **Status: OPEN — not yet confirmed (owner, 2026-06-05).** Confirm
+before we build the capture pipeline. (§9 notes that the repo already has the off-hot-path
+emit primitive option (3) would generalize.)
+
+## 4. The closed loop (with the human gate)
+1. **Drive** — doer proposes → Kirra governs → governed command executes; Kirra emits
+   verdict records.
+2. **Capture** — Linux collector joins verdict records + bus telemetry → versioned dataset.
+3. **Mine** — pull corrections (clamp/MRC/veto) **plus** normal-driving samples **plus**
+   sim data. (Never clamp-only — see §5.)
+4. **Train** — improve the Autoware perception/prediction/planning model(s) offline on the
+   GPU box / cloud.
+5. **Validate** — run the candidate in AWSIM **against the FIXED Kirra**; measure driving
+   quality, intervention rate, and absence of new unsafe behaviors, plus existing gates.
+6. **Gate (human)** — deliberate release decision; candidate must pass sim + against-fixed-
+   governor first. Tag the model with its dataset + validation lineage.
+7. **Deploy** — new model artifact → Parko. Kirra **unchanged**.
+8. **Repeat** — new model generates fresh verdict records → step 1.
+
+"Continuous improvement" = a steady cadence of **validated releases**, NOT live weight
+updates on a moving vehicle.
+
+## 5. Safety invariants (architectural constraints, not nice-to-haves)
+1. **Kirra never trains / never co-adapts.** It's the fixed reference the doer is validated
+   against. Enforced by: separate, hash-pinned, certified binary; the training pipeline has
+   no write path to it.
+2. **Safety-domain independence.** Kirra's correctness can't depend on the learning domain;
+   it fails closed on silence/garbage. The interface is one-way-authority.
+3. **Objective ≠ "minimize clamps."** Optimize *good and safe driving*; clamp-rate is a
+   diagnostic, not the loss. (Goodhart: minimizing clamps alone teaches timid or
+   governor-gaming behavior.)
+4. **Never train on clamps alone.** Mix corrections + normal driving + sim. (Selection
+   bias: corrections are *safe*, not *optimal*.)
+5. **Human-gated, sim-validated deploys.** No online learning on the live vehicle; every
+   model proves itself in sim against the fixed governor.
+6. **Versioned lineage.** Every deployed model ties to its dataset + validation evidence —
+   a per-model mini safety case, consistent with the existing safety-case discipline.
+
+## 6. Where each piece runs — and the bench-vs-production reality
+| Component | Bench (now) | Production vehicle (later) |
+|---|---|---|
+| Kirra (checker, fixed) | **Linux** (Orin/JetPack) | **QNX** (certified RTOS, dedicated/partitioned) |
+| Occy / Autoware (doer) | Linux | Linux compute node |
+| Parko (serves models) | Linux (Orin, TensorRT) | Linux / DRIVE OS |
+| Collector + training + AWSIM + gate | Linux (GPU box / cloud) | Linux (offline) |
+
+Key honest point: **the learning loop is OS-agnostic for Kirra.** The checker's job —
+propose → govern → emit verdict record — is identical whether it runs on Linux (bench) or
+QNX (production). So you build and run the *entire* loop on Linux now; Kirra later moves to
+QNX for the certified vehicle with **zero change to the loop**. (QNX 8.0 is currently
+blocked on upstream libc `nto80`; tracked separately in **#189**. Bench Kirra stays Linux
+regardless.)
+
+## 7. Staged build plan
+1. **Capture pipeline** (next; buildable pre-hardware) — Kirra emits the non-blocking
+   verdict record; Linux collector assembles the versioned corrective-supervision dataset.
+2. **Sim validation harness** — candidate model in AWSIM vs fixed Kirra (uses the GPU box).
+3. **Training loop** — dataset → offline model improvement.
+4. **Release gate + lineage** — human-gated deploy with per-model safety case.
+5. **(Later) QNX production deployment** of the unchanged checker.
+
+## 8. Open decisions to confirm
+- §3 capture location: **hybrid (3)** recommended — **OPEN** (left open per owner, 2026-06-05).
+- Which model(s) learn first (perception/prediction vs planning) — pick the one whose
+  failures dominate Kirra's interventions once the capture data exists.
+- Dataset schema + storage (drives the capture-pipeline spec).
+
+## 9. As-built grounding (repo, verified 2026-06-05)
+Editorial appendix (not part of the original design; records how the design lands on the
+current codebase so a future implementer starts from what exists):
+
+- **The "fixed checker" anchor is real.** `src/gateway/kinematics_contract.rs`
+  (`validate_vehicle_command`, the verdict path) is the hash-pinned reference; its blob is
+  `997fb7ae15ce3e11adec9218044c7c84b049ad3b` on `main` and has been held byte-identical
+  across every change this cycle. §5 invariant #1 ("hash-pinned, no write path") is the
+  discipline already enforced.
+- **§3(3) "fire-and-forget verdict record" is a generalization of an existing primitive.**
+  The Deny arm of `enforce_actuator_safety_envelope` (`src/gateway/policy_layer.rs`) already
+  emits a structured `KinematicViolationPayload` (deny code + values) via
+  `audit_writer_tx.try_send(...)` — wait-free, drop-on-full, **off the verdict path** (the
+  WCET-gate boundedness argument depends on that try_send never blocking). And
+  `EnforcementOutcome { action: Allow | ClampLinear | ClampSteering | Deny, + enforced
+  values + ProposedCommandPayload }` is already produced for **every** arm (threaded as a
+  request extension today). So §3(3) ≈ "extend that emit from Deny-only to all verdicts,
+  onto a telemetry path a Linux collector reads" — not new machinery on the certified path.
+- **Non-safety telemetry-path precedent exists.** `PostureStreamEvent` is broadcast over a
+  bounded ring buffer (`broadcast::channel(POSTURE_BROADCAST_CAPACITY)`, SSE) — the same
+  "publish, never block the verdict" shape §3 calls for.
+- **Load-bearing constraint for whoever builds §7.1:** the verdict-record emit must stay a
+  bounded, droppable enqueue (try_send "Full = Err, never block"), and
+  `kinematics_contract.rs` must remain byte-identical. The capture pipeline adds a
+  *non-safety* emit + a Linux collector; it must not become a verdict-path dependency.
+- **QNX move is tracked.** §6's "Kirra later moves to QNX, zero loop change" depends on the
+  QNX-8.0 toolchain, blocked on upstream libc `nto80` — issue **#189**.


### PR DESCRIPTION
Records the learning-loop architecture design (owner Justin, 2026-06-05) in the repo: how Kirra's interventions feed a continuous-improvement loop for the Autoware perception/prediction/planning **doer** WITHOUT Kirra ever learning. The doer/checker boundary (ADR-0004) is exactly what makes letting the doer learn safe — the fixed, certified checker bounds the consequences so the doer can experiment.

**Doc-only** — no source/feature/default changes (`git diff --stat`: 1 file).

Preserves the owner's design (§0 principle, §1 two-domain interface, §2 corrective-supervision triple, §4 closed loop + human gate, §5 safety invariants, §6 bench-vs-production OS-agnosticism, §7 staged build plan). **§3 capture location is kept OPEN** (hybrid (3) recommended, NOT confirmed — per owner decision today).

Adds a clearly-marked **as-built grounding appendix (§9)** so a future implementer starts from what exists:
- the verdict-path anchor (`kinematics_contract.rs`, blob `997fb7ae…`) is the hash-pinned fixed checker §5 invariant #1 describes;
- §3(3)'s "fire-and-forget verdict record" is a **generalization of an existing primitive** — the Deny arm already emits a structured payload via `audit_writer_tx.try_send(...)` (wait-free, drop-on-full, off the verdict path), and `EnforcementOutcome` is already produced for every arm;
- `PostureStreamEvent` broadcast is the existing non-safety telemetry-path precedent;
- load-bearing constraint: the emit must stay a bounded droppable enqueue and `kinematics_contract.rs` must remain byte-identical.

Cross-refs ADR-0004, the fixed verdict path, KIRRA-OCCY-DEPLOY-001, and #189 (QNX 8.0 / nto80, §6).

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv)_