### PR TITLE
feat(capture): learning-loop capture channel — Phase 1 (gated, mirror…

### DIFF
--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -1617,6 +1617,17 @@ async fn main() {
         kirra_runtime_sdk::audit_writer::spawn_audit_writer(Arc::clone(&app_state));
     app_state.install_audit_writer(audit_tx);
 
+    // Learning-loop capture writer (Phase 1, #190) — DEFAULT OFF. Only spawned +
+    // installed when KIRRA_CAPTURE_ENABLED is set; unset → no writer, and the
+    // gateway emit is a pure no-op (capture_writer_tx stays None). Non-safety
+    // side channel; mirrors the audit writer wiring above.
+    if kirra_runtime_sdk::capture::capture_enabled() {
+        let capture_tx =
+            kirra_runtime_sdk::capture::spawn_capture_writer(Arc::clone(&app_state));
+        app_state.install_capture_writer(capture_tx);
+        tracing::info!("learning-loop capture ENABLED (KIRRA_CAPTURE_ENABLED) — verdict records → JSONL sink");
+    }
+
     {
         let guard = app_state.store.lock()
             .expect("verifier store lock poisoned during boot hydration");

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,0 +1,290 @@
+// src/capture.rs
+//
+// Learning-loop capture channel — Phase 1 (docs/CAPTURE_PIPELINE_SPEC.md, #190).
+//
+// Records the "correction" half of the corrective-supervision triple — what Kirra
+// DECIDED and the safe value it imposed — as a NON-BLOCKING side channel, so a
+// Linux-side collector can later join it with bus telemetry. This is a SIBLING of
+// `src/audit_writer.rs`, mirroring it one-for-one:
+//   - a bounded mpsc channel + a single spawn_blocking drain task,
+//   - the producer (the actuator gateway) only `try_send`s a small fixed-shape
+//     record — wait-free, drop-on-full, NEVER blocking the verdict path,
+//   - default OFF behind `KIRRA_CAPTURE_ENABLED` (mirrors the perception-derate
+//     default-off env gate).
+//
+// HARD INVARIANTS (this module + its call site uphold):
+//   * Verdict path byte-identical — capture is additive; it reads the
+//     already-computed `EnforceAction` and emits. It never lives in, or alters,
+//     `src/gateway/kinematics_contract.rs`.
+//   * Verdicts/responses identical capture-on vs -off — the emit changes only the
+//     side channel; it never gates/delays/alters the verdict, EnforcementOutcome,
+//     or the HTTP response.
+//   * Wait-free — `try_send`; Full/Closed → drop + LOUD log; safety never waits.
+//
+// Sink (Phase-1 DECISION): a plain JSONL append file (no tamper-evidence needed —
+// this is training data, not the audit chain, so it deliberately does NOT reuse
+// the audit SQLite hash-chain). A DDS telemetry topic is a later phase.
+
+use std::io::Write;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use serde::Serialize;
+use tokio::sync::mpsc;
+
+use crate::gateway::kinematics_contract::{EnforceAction, ProposedVehicleCommand};
+use crate::verifier::{AppState, FleetPosture};
+
+/// Bounded capture queue depth — mirrors `AUDIT_QUEUE_BOUND`.
+pub const CAPTURE_QUEUE_BOUND: usize = 2048;
+
+/// Env gate (default OFF). Mirrors `KIRRA_PERCEPTION_DERATE_ENABLED`.
+pub const CAPTURE_ENABLED_ENV: &str = "KIRRA_CAPTURE_ENABLED";
+
+/// Optional override for the JSONL sink path. Default: `kirra_capture.jsonl`
+/// in the process CWD.
+pub const CAPTURE_SINK_PATH_ENV: &str = "KIRRA_CAPTURE_SINK_PATH";
+
+/// True iff capture is enabled. Default OFF — unset / falsey → no records.
+/// Truthy = `1` / `true` / `yes` (case-insensitive), matching
+/// `perception_derate_enabled`.
+#[must_use]
+pub fn capture_enabled() -> bool {
+    std::env::var(CAPTURE_ENABLED_ENV)
+        .map(|v| {
+            let t = v.trim();
+            t == "1" || t.eq_ignore_ascii_case("true") || t.eq_ignore_ascii_case("yes")
+        })
+        .unwrap_or(false)
+}
+
+/// Monotonic nanoseconds since first call (process-stable ordering source for
+/// `t_mono_ns`, independent of wall-clock adjustments).
+fn mono_ns() -> u128 {
+    static START: OnceLock<Instant> = OnceLock::new();
+    START.get_or_init(Instant::now).elapsed().as_nanos()
+}
+
+/// The decision Kirra reached, as a stable token (the "correction" kind).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CaptureOutcome {
+    Allow,
+    ClampLinear,
+    ClampSteering,
+    Deny,
+}
+
+/// A snapshot of the doer's proposal (correlation context; the Linux collector
+/// joins this with the bus-observed perception/ego/model-version).
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct ProposedCommandSnapshot {
+    pub linear_velocity_mps: f64,
+    pub current_velocity_mps: f64,
+    pub steering_angle_deg: f64,
+    pub current_steering_angle_deg: f64,
+    pub delta_time_s: f64,
+}
+
+impl From<&ProposedVehicleCommand> for ProposedCommandSnapshot {
+    fn from(c: &ProposedVehicleCommand) -> Self {
+        Self {
+            linear_velocity_mps: c.linear_velocity_mps,
+            current_velocity_mps: c.current_velocity_mps,
+            steering_angle_deg: c.steering_angle_deg,
+            current_steering_angle_deg: c.current_steering_angle_deg,
+            delta_time_s: c.delta_time_s,
+        }
+    }
+}
+
+/// The small, fixed-shape capture record. Carries the correction Kirra imposed +
+/// the proposal context + join keys. Deliberately does NOT carry the doer's model
+/// version — Kirra doesn't know it; it is joined Linux-side.
+#[derive(Debug, Clone, Serialize)]
+pub struct CaptureRecord {
+    /// Monotonic per-decision sequence (the join/order key).
+    pub decision_seq: u64,
+    /// Monotonic ns since process start (ordering, skew-free).
+    pub t_mono_ns: u128,
+    /// Wall-clock ms (bus join).
+    pub t_wall_ms: u64,
+    /// The doer's proposal (correlation + context).
+    pub proposed: ProposedCommandSnapshot,
+    /// What Kirra decided.
+    pub outcome: CaptureOutcome,
+    /// Which check fired, if a deny (the `DenyCode` token); `None` otherwise.
+    pub deny_code: Option<&'static str>,
+    /// The safe value Kirra substituted on a clamp (m/s for linear, deg for
+    /// steering); `None` for Allow/Deny.
+    pub safe_value: Option<f64>,
+    /// Controlled-stop substitution (Degraded → decel-to-stop-and-HOLD envelope).
+    pub mrc: bool,
+    /// Posture context.
+    pub posture: &'static str,
+    /// Whether the perception derate was enabled (so passes are attributable).
+    pub derate_enabled: bool,
+}
+
+impl CaptureRecord {
+    /// Build a record from the already-computed verdict + context. Pure; performs
+    /// no I/O. Called at the gateway emit site (off the verdict path).
+    #[must_use]
+    pub fn from_verdict(
+        decision_seq: u64,
+        t_wall_ms: u64,
+        verdict: &EnforceAction,
+        posture: FleetPosture,
+        proposed: &ProposedVehicleCommand,
+        derate_enabled: bool,
+    ) -> Self {
+        let (outcome, deny_code, safe_value) = match verdict {
+            EnforceAction::Allow => (CaptureOutcome::Allow, None, None),
+            EnforceAction::ClampLinear(v) => (CaptureOutcome::ClampLinear, None, Some(*v)),
+            EnforceAction::ClampSteering(d) => (CaptureOutcome::ClampSteering, None, Some(*d)),
+            EnforceAction::DenyBreach(code) => (CaptureOutcome::Deny, Some(code.reason()), None),
+        };
+        Self {
+            decision_seq,
+            t_mono_ns: mono_ns(),
+            t_wall_ms,
+            proposed: proposed.into(),
+            outcome,
+            deny_code,
+            safe_value,
+            // Degraded posture admits commands only through the decel-to-stop-and-HOLD
+            // (MRC) envelope; LockedOut is short-circuited before the gateway verdict.
+            mrc: matches!(posture, FleetPosture::Degraded),
+            posture: posture_token(posture),
+            derate_enabled,
+        }
+    }
+}
+
+#[inline]
+fn posture_token(p: FleetPosture) -> &'static str {
+    match p {
+        FleetPosture::Nominal => "NOMINAL",
+        FleetPosture::Degraded => "DEGRADED",
+        FleetPosture::LockedOut => "LOCKED_OUT",
+    }
+}
+
+/// Spawns the single capture-writer task on the blocking pool and returns the
+/// bounded mpsc Sender the gateway `try_send`s into. Exactly mirrors
+/// `audit_writer::spawn_audit_writer`: `blocking_recv` drains serially; the task
+/// exits when the last Sender drops.
+pub fn spawn_capture_writer(_app: Arc<AppState>) -> mpsc::Sender<CaptureRecord> {
+    let (tx, mut rx) = mpsc::channel::<CaptureRecord>(CAPTURE_QUEUE_BOUND);
+    let sink_path = std::env::var(CAPTURE_SINK_PATH_ENV)
+        .unwrap_or_else(|_| "kirra_capture.jsonl".to_string());
+    tokio::task::spawn_blocking(move || {
+        let mut sink = match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&sink_path)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::error!(
+                    error = %e, path = %sink_path,
+                    "capture writer: could not open JSONL sink; capture records will be dropped"
+                );
+                // Drain and discard so producers' try_send never wedges on Full.
+                while rx.blocking_recv().is_some() {}
+                return;
+            }
+        };
+        tracing::info!(
+            queue_bound = CAPTURE_QUEUE_BOUND, path = %sink_path,
+            "capture writer task started"
+        );
+        while let Some(rec) = rx.blocking_recv() {
+            write_one_capture(&mut sink, &rec);
+        }
+        tracing::info!("capture writer task exiting (channel closed)");
+    });
+    tx
+}
+
+/// Single-record write — JSONL line append. The only place serialization + I/O
+/// for capture run (off the verdict path).
+fn write_one_capture(sink: &mut std::fs::File, rec: &CaptureRecord) {
+    match serde_json::to_string(rec) {
+        Ok(line) => {
+            if let Err(e) = writeln!(sink, "{line}") {
+                tracing::error!(error = %e, "capture writer: JSONL append failed; record dropped");
+            }
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "capture writer: record serialize failed; dropped");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gateway::kinematics_contract::DenyCode;
+
+    fn cmd() -> ProposedVehicleCommand {
+        ProposedVehicleCommand {
+            linear_velocity_mps: 10.0,
+            current_velocity_mps: 9.0,
+            delta_time_s: 0.1,
+            steering_angle_deg: 2.0,
+            current_steering_angle_deg: 1.0,
+        }
+    }
+
+    #[test]
+    fn from_verdict_maps_each_arm() {
+        let c = cmd();
+        let allow = CaptureRecord::from_verdict(0, 1000, &EnforceAction::Allow, FleetPosture::Nominal, &c, false);
+        assert_eq!(allow.outcome, CaptureOutcome::Allow);
+        assert_eq!(allow.deny_code, None);
+        assert_eq!(allow.safe_value, None);
+        assert!(!allow.mrc);
+        assert_eq!(allow.posture, "NOMINAL");
+
+        let cl = CaptureRecord::from_verdict(1, 1000, &EnforceAction::ClampLinear(5.0), FleetPosture::Nominal, &c, true);
+        assert_eq!(cl.outcome, CaptureOutcome::ClampLinear);
+        assert_eq!(cl.safe_value, Some(5.0));
+        assert!(cl.derate_enabled);
+
+        let cs = CaptureRecord::from_verdict(2, 1000, &EnforceAction::ClampSteering(3.0), FleetPosture::Degraded, &c, false);
+        assert_eq!(cs.outcome, CaptureOutcome::ClampSteering);
+        assert_eq!(cs.safe_value, Some(3.0));
+        assert!(cs.mrc, "Degraded → MRC envelope");
+        assert_eq!(cs.posture, "DEGRADED");
+
+        let dn = CaptureRecord::from_verdict(3, 1000, &EnforceAction::DenyBreach(DenyCode::NanInfLinearVelocity), FleetPosture::Nominal, &c, false);
+        assert_eq!(dn.outcome, CaptureOutcome::Deny);
+        assert_eq!(dn.deny_code, Some("NAN_INF_LINEAR_VELOCITY"));
+        assert_eq!(dn.safe_value, None);
+    }
+
+    #[test]
+    fn capture_enabled_defaults_off_when_unset() {
+        // INV-13: no set_var in a multithreaded test runner; assert the unset
+        // default contract (CI has it unset).
+        if std::env::var(CAPTURE_ENABLED_ENV).is_err() {
+            assert!(!capture_enabled(), "unset env must be disabled");
+        }
+    }
+
+    #[tokio::test]
+    async fn try_send_full_drops_without_blocking() {
+        // INV-4: mirror audit_writer's full-drop test — at capacity, try_send
+        // returns Full; the producer never blocks. Use a 1-slot channel with no
+        // drain so it fills immediately.
+        let (tx, _rx) = mpsc::channel::<CaptureRecord>(1);
+        let rec = CaptureRecord::from_verdict(0, 1, &EnforceAction::Allow, FleetPosture::Nominal, &cmd(), false);
+        assert!(tx.try_send(rec.clone()).is_ok());
+        match tx.try_send(rec) {
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}
+            other => panic!("expected Full at capacity, got {other:?}"),
+        }
+    }
+}

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -245,6 +245,42 @@ pub async fn enforce_actuator_safety_envelope(
         FleetPosture::LockedOut => unreachable!("LockedOut short-circuited above"),
     };
 
+    // Learning-loop capture (Phase 1, #190) — ADDITIVE, gated, wait-free.
+    // Reads the already-computed `verdict` and records the correction half of
+    // the corrective-supervision triple on a non-safety side channel. It NEVER
+    // gates/delays/alters the verdict, the EnforcementOutcome, or the response
+    // (INV-2) — note it sits BEFORE the response dispatch and only borrows the
+    // outcome. Default OFF (INV-3): with no writer installed this is a no-op.
+    // `try_send` drops on Full/Closed with a loud log (INV-4) — safety never
+    // waits. A single site here captures EVERY arm (passes included, to avoid
+    // downstream selection bias); it sits beside the Deny-arm audit `try_send`,
+    // not replacing it. Gated SOLELY by writer presence (mirrors the audit
+    // emit): the `KIRRA_CAPTURE_ENABLED` env decides INSTALLATION at startup, so
+    // default-off / tests → `get()` is `None` → pure no-op (INV-3).
+    if let Some(tx) = svc.app.capture_writer_tx.get() {
+        let rec = crate::capture::CaptureRecord::from_verdict(
+            svc.app
+                .capture_decision_seq
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            now_ms(),
+            &verdict,
+            posture.clone(),
+            &proposed_cmd,
+            svc.perception_monitor_enabled,
+        );
+        match tx.try_send(rec) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                tracing::warn!(
+                    "capture queue FULL — dropping verdict record (best-effort; safety never waits)"
+                );
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                tracing::warn!("capture writer task GONE — verdict record dropped");
+            }
+        }
+    }
+
     match verdict {
         EnforceAction::Allow => {
             // Thread the verdict to the handler so the response reports it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ pub mod clock;
 pub mod scenario_runner;
 pub mod audit_chain;
 pub mod audit_writer;
+// Learning-loop capture channel (Phase 1, #190) — sibling of audit_writer;
+// non-blocking, default-OFF side channel recording the verdict/correction.
+pub mod capture;
 pub mod wcet_gate;
 pub mod traceability_gate;
 pub mod federation;

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -210,6 +210,17 @@ pub struct AppState {
     /// `install_audit_writer` once to install.
     pub audit_writer_tx:
         std::sync::OnceLock<tokio::sync::mpsc::Sender<crate::audit_writer::AuditWriteJob>>,
+    /// Learning-loop capture channel (Phase 1, #190) — sibling of
+    /// `audit_writer_tx`. The actuator gateway `try_send`s a small
+    /// `CaptureRecord` here off the verdict path. `None` (writer not installed,
+    /// e.g. capture disabled or tests) → the gateway emit is a pure no-op.
+    /// Installed once via `install_capture_writer` at startup, only when
+    /// `capture::capture_enabled()`.
+    pub capture_writer_tx:
+        std::sync::OnceLock<tokio::sync::mpsc::Sender<crate::capture::CaptureRecord>>,
+    /// Monotonic per-decision sequence for the capture join key. Incremented at
+    /// the gateway emit; non-safety (capture only).
+    pub capture_decision_seq: Arc<AtomicU64>,
     /// Bounded broadcast channel for real-time posture stream subscribers.
     pub posture_tx: broadcast::Sender<PostureStreamEvent>,
     /// Transport identity enforcement config — reads from env at startup.
@@ -236,6 +247,8 @@ impl AppState {
             held_epoch: Arc::new(AtomicU64::new(0)),
             cached_db_epoch: Arc::new(AtomicU64::new(initial_db_epoch)),
             audit_writer_tx: std::sync::OnceLock::new(),
+            capture_writer_tx: std::sync::OnceLock::new(),
+            capture_decision_seq: Arc::new(AtomicU64::new(0)),
             posture_tx,
             transport_identity: TransportIdentityConfig::from_env(),
             rss_active_violation: Arc::new(AtomicBool::new(false)),
@@ -260,6 +273,20 @@ impl AppState {
         if self.audit_writer_tx.set(tx).is_err() {
             tracing::warn!(
                 "audit writer Sender already installed — ignoring duplicate install"
+            );
+        }
+    }
+
+    /// Install the capture-writer mpsc Sender (learning-loop Phase 1, #190).
+    /// Called once at startup, after `capture::spawn_capture_writer`, and only
+    /// when `capture::capture_enabled()`. Mirrors `install_audit_writer`.
+    pub fn install_capture_writer(
+        &self,
+        tx: tokio::sync::mpsc::Sender<crate::capture::CaptureRecord>,
+    ) {
+        if self.capture_writer_tx.set(tx).is_err() {
+            tracing::warn!(
+                "capture writer Sender already installed — ignoring duplicate install"
             );
         }
     }

--- a/tests/actuator_envelope_integration.rs
+++ b/tests/actuator_envelope_integration.rs
@@ -546,3 +546,85 @@ async fn test_capstone_missing_enforcement_outcome_extension_fails_closed_500() 
     assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR,
         "missing EnforcementOutcome extension must fail closed 500, never a defaulted Allow");
 }
+
+// ---------------------------------------------------------------------------
+// Learning-loop capture (Phase 1, #190): INV-2 on-vs-off equivalence +
+// per-arm record emission. Capture is installed by handing AppState a writer
+// Sender (no env mutation); default-off elsewhere keeps the verdict path inert.
+// ---------------------------------------------------------------------------
+
+/// Build a Nominal state with a capture writer installed; return (svc, rx) so the
+/// test can both drive the gateway and observe the emitted records.
+fn build_state_with_capture()
+    -> (Arc<ServiceState>, tokio::sync::mpsc::Receiver<kirra_runtime_sdk::capture::CaptureRecord>)
+{
+    use kirra_runtime_sdk::verifier::{AppState, VerifierOperationMode};
+    use kirra_runtime_sdk::verifier_store::VerifierStore;
+    let store = VerifierStore::new(":memory:").expect("in-memory store");
+    let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+    let (tx, rx) = tokio::sync::mpsc::channel(16);
+    app.install_capture_writer(tx);
+    let posture_cache: SharedPostureCache =
+        Arc::new(std::sync::RwLock::new(Some(CachedFleetPosture::new(FleetPosture::Nominal))));
+    let svc = Arc::new(ServiceState {
+        app,
+        posture_cache,
+        audit_verifying_key: None,
+        fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
+        fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
+        fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new(None)),
+        posture_engine_tx: std::sync::OnceLock::new(),
+        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_monitor_enabled: false,
+    });
+    (svc, rx)
+}
+
+/// INV-2: with capture ON (writer installed), the verdict/response for a set of
+/// commands is byte-identical to capture OFF. Capture changes only the side channel.
+#[tokio::test]
+async fn test_capture_on_vs_off_responses_identical() {
+    let cases = [
+        cmd_json(20.0, 20.0, 0.1, 0.0, 0.0), // Allow (steady, under the 35 vehicle max)
+        cmd_json(40.0, 40.0, 0.1, 0.0, 0.0), // ClampLinear (40 > 35)
+    ];
+    for body in cases {
+        let off = build_state_with_posture(FleetPosture::Nominal);
+        let (off_status, off_v) = send_json(build_schema_app(off), Body::from(body.clone())).await;
+
+        let (on_svc, _rx) = build_state_with_capture();
+        let (on_status, on_v) = send_json(build_schema_app(on_svc), Body::from(body)).await;
+
+        assert_eq!(on_status, off_status, "capture must not change the status");
+        assert_eq!(on_v, off_v, "capture must not change the response body");
+    }
+}
+
+/// A capture record is emitted for EVERY arm (Allow + Clamp), with the correct
+/// outcome + the substituted safe value — passes included (selection-bias).
+#[tokio::test]
+async fn test_capture_emits_a_record_per_arm() {
+    use kirra_runtime_sdk::capture::CaptureOutcome;
+
+    // Allow.
+    let (svc, mut rx) = build_state_with_capture();
+    let (status, _v) =
+        send_json(build_schema_app(svc), Body::from(cmd_json(20.0, 20.0, 0.1, 0.0, 0.0))).await;
+    assert_eq!(status, StatusCode::OK);
+    let rec = rx.try_recv().expect("a capture record for the Allow");
+    assert_eq!(rec.outcome, CaptureOutcome::Allow);
+    assert_eq!(rec.safe_value, None);
+    assert_eq!(rec.posture, "NOMINAL");
+    assert_eq!(rec.decision_seq, 0);
+    assert!(rx.try_recv().is_err(), "exactly one record per request");
+
+    // ClampLinear → records the substituted safe value (the correction).
+    let (svc2, mut rx2) = build_state_with_capture();
+    let (status2, _v2) =
+        send_json(build_schema_app(svc2), Body::from(cmd_json(40.0, 40.0, 0.1, 0.0, 0.0))).await;
+    assert_eq!(status2, StatusCode::OK);
+    let rec2 = rx2.try_recv().expect("a capture record for the ClampLinear");
+    assert_eq!(rec2.outcome, CaptureOutcome::ClampLinear);
+    assert_eq!(rec2.safe_value, Some(35.0), "the correction Kirra imposed");
+}
+


### PR DESCRIPTION
…s audit_writer)

First buildable piece of the learning-loop capture pipeline (docs/CAPTURE_PIPELINE_SPEC.md, #190): records the "correction" half of the corrective-supervision triple — what Kirra decided + the safe value it imposed — on a NON-BLOCKING side channel, so a Linux collector can later join it with bus telemetry. A sibling of the audit path, mirrored one-for-one.

INVARIANTS (verified): src/gateway/kinematics_contract.rs BYTE-IDENTICAL (997fb7ae…), NOT in the diff. Capture is purely additive: it reads the already-computed EnforceAction and try_sends a record; it never gates/delays/ alters the verdict, EnforcementOutcome, or the HTTP response (INV-2 on==off test). Default OFF: the writer is only installed when KIRRA_CAPTURE_ENABLED is set, so default/tests → capture_writer_tx None → pure no-op (INV-3). Wait-free: try_send, drop-on-full + loud log (INV-4 test).

- NEW src/capture.rs (sibling of audit_writer.rs): CaptureRecord (decision_seq, t_mono_ns, t_wall_ms, proposed snapshot, outcome, deny_code, safe_value, mrc, posture, derate_enabled — NO doer model_version, joined Linux-side); CAPTURE_QUEUE_BOUND=2048; spawn_capture_writer (bounded mpsc + spawn_blocking drain → write_one_capture); capture_enabled()/CAPTURE_ENABLED_ENV. Sink = plain JSONL append file (KIRRA_CAPTURE_SINK_PATH, default kirra_capture.jsonl) — deliberately NOT the audit SQLite hash-chain (training data, no tamper- evidence needed). DDS topic is a later phase.
- AppState: capture_writer_tx OnceLock + capture_decision_seq AtomicU64 (new — no gateway counter existed) + install_capture_writer, mirroring the audit OnceLock.
- policy_layer.rs: a single additive emit right AFTER the verdict is bound and BEFORE the response dispatch — captures EVERY arm (Allow/Clamp/Clamp/Deny, passes included to avoid downstream selection bias), gated solely by writer presence (mirrors the audit emit), beside the Deny-arm audit try_send.
- startup: spawn+install the capture writer only when capture_enabled() (default OFF), mirroring the audit-writer wiring.

Tests: capture unit (from_verdict per-arm map, default-off, full-drop) + gateway integration (on==off response equivalence, a record per arm with the substituted safe value). lib 507, actuator integration 17, all green.

Flagged: emit at the command-gateway (all arms) per the spec — the node.rs slow-loop trajectory record (with objects_ms/traj_stamp join keys) is Phase 1.5. Sink = JSONL (Phase 1); DDS topic later. Correlation key = decision_seq + t_wall + proposed snapshot.

Refs #190, docs/CAPTURE_PIPELINE_SPEC.md, docs/LEARNING_LOOP_ARCHITECTURE.md.

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv