### PR TITLE
feat(capture): learning-loop Phase 1.5 — slow-loop trajectory emit point

### DIFF
--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -40,7 +40,8 @@ use tokio::sync::mpsc;
 
 use crate::corridor::CorridorSource;
 use crate::state::{
-    AdaptorState, EgoOdom, TrajectoryPoint, SUBSCRIPTION_STALENESS_TIMEOUT_MS,
+    AdaptorState, EgoOdom, TrajectoryPoint, TrajectoryVerdict,
+    SUBSCRIPTION_STALENESS_TIMEOUT_MS,
 };
 use crate::validation::{
     check_command_conforms, validate_trajectory_slow_capped, ConformanceVerdict, IncomingControl,
@@ -51,6 +52,14 @@ use crate::perception_ingest::{perception_derate_enabled, publish_perception_tic
 use kirra_runtime_sdk::gateway::perception_monitor::{
     empty_perception_cap, resolve_perception_cap, KinematicPlausibilityContract,
     PerceptionCapPublisher,
+};
+// Learning-loop capture (Phase 1.5, docs/CAPTURE_PIPELINE_SPEC.md §3) — the
+// slow-loop trajectory emit point. Reuses the SDK's Phase-1 machinery
+// (bounded mpsc + spawn_blocking JSONL drain); DEFAULT OFF via
+// `KIRRA_CAPTURE_ENABLED`. Additive only — never on / altering the verdict.
+use kirra_runtime_sdk::capture::{
+    capture_enabled, spawn_capture_writer, CaptureRecord, PoseSnapshot,
+    TrajectoryCaptureExt, TrajectoryDecision,
 };
 
 /// Read the subscription staleness timeout (ms) from
@@ -348,6 +357,16 @@ pub async fn run_adapter(
         KinematicPlausibilityContract::urban_reference(),
         subscription_staleness_timeout_ms(), // ttl reuses the subscription staleness budget
     );
+    // Learning-loop capture — the slow-loop trajectory emit point (Phase 1.5).
+    // DEFAULT OFF: only when `KIRRA_CAPTURE_ENABLED` is truthy do we spawn the
+    // SDK's bounded JSONL writer; otherwise `capture_tx` is `None` and the emit
+    // below is a pure no-op. The writer takes no state (the SDK refactored the
+    // unused `Arc<AppState>` out), so the adapter spawns its own. The seq is an
+    // adapter-local monotonic decision counter (the slow loop's analogue of the
+    // gateway's `capture_decision_seq`).
+    let capture_tx: Option<mpsc::Sender<CaptureRecord>> =
+        capture_enabled().then(spawn_capture_writer);
+    let capture_seq = Arc::new(std::sync::atomic::AtomicU64::new(0));
     tokio::spawn(async move {
         let mut rx = trajectory_rx;
         while let Some(traj) = rx.recv().await {
@@ -411,6 +430,56 @@ pub async fn run_adapter(
                     elapsed_us = elapsed_us,
                     "trajectory_validation_wcet_exceeded"
                 );
+            }
+
+            // Learning-loop capture (Phase 1.5) — emit the slow-loop verdict as
+            // a BOUNDED record AFTER the WCET measurement (so it never counts
+            // against the slow-loop budget) and beside update_trajectory. The
+            // record is O(1): counts + endpoint poses + join keys, NEVER a fresh
+            // clone of the full points/objects vectors. Wait-free try_send;
+            // drop-on-full/closed with a loud log — capture never blocks or
+            // alters the verdict. No-op when capture is disabled (capture_tx None).
+            if let Some(tx) = capture_tx.as_ref() {
+                let decision = match verdict {
+                    TrajectoryVerdict::Accept => TrajectoryDecision::Accept,
+                    TrajectoryVerdict::Clamp => TrajectoryDecision::Clamp,
+                    TrajectoryVerdict::MRCFallback | TrajectoryVerdict::Pending => {
+                        TrajectoryDecision::MrcFallback
+                    }
+                };
+                let pose_snap = |p: &TrajectoryPoint| PoseSnapshot {
+                    x_m: p.pose.x_m,
+                    y_m: p.pose.y_m,
+                    heading_rad: p.pose.heading_rad,
+                };
+                let ext = TrajectoryCaptureExt {
+                    asset_id: traj.asset_id.clone(),
+                    trajectory_id: traj.trajectory_id,
+                    objects_ms,
+                    point_count: traj.points.len(),
+                    object_count: objects.len(),
+                    first_pose: traj.points.first().map(pose_snap),
+                    last_pose: traj.points.last().map(pose_snap),
+                    target_speed_mps: traj.points.last().map(|p| p.velocity_mps),
+                };
+                let rec = CaptureRecord::from_trajectory_verdict(
+                    capture_seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+                    now_ms,
+                    decision,
+                    posture,
+                    ext,
+                    perception_derate_enabled(),
+                );
+                match tx.try_send(rec) {
+                    Ok(()) => {}
+                    Err(mpsc::error::TrySendError::Full(_)) => tracing::warn!(
+                        asset_id = %traj.asset_id,
+                        "capture channel FULL — dropping slow-loop record (off the verdict path)"
+                    ),
+                    Err(mpsc::error::TrySendError::Closed(_)) => tracing::warn!(
+                        "capture channel CLOSED — capture writer gone; slow-loop record dropped"
+                    ),
+                }
             }
         }
     });

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -1622,8 +1622,7 @@ async fn main() {
     // gateway emit is a pure no-op (capture_writer_tx stays None). Non-safety
     // side channel; mirrors the audit writer wiring above.
     if kirra_runtime_sdk::capture::capture_enabled() {
-        let capture_tx =
-            kirra_runtime_sdk::capture::spawn_capture_writer(Arc::clone(&app_state));
+        let capture_tx = kirra_runtime_sdk::capture::spawn_capture_writer();
         app_state.install_capture_writer(capture_tx);
         tracing::info!("learning-loop capture ENABLED (KIRRA_CAPTURE_ENABLED) — verdict records → JSONL sink");
     }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -26,7 +26,6 @@
 // the audit SQLite hash-chain). A DDS telemetry topic is a later phase.
 
 use std::io::Write;
-use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Instant;
 
@@ -34,7 +33,7 @@ use serde::Serialize;
 use tokio::sync::mpsc;
 
 use crate::gateway::kinematics_contract::{EnforceAction, ProposedVehicleCommand};
-use crate::verifier::{AppState, FleetPosture};
+use crate::verifier::FleetPosture;
 
 /// Bounded capture queue depth — mirrors `AUDIT_QUEUE_BOUND`.
 pub const CAPTURE_QUEUE_BOUND: usize = 2048;
@@ -76,6 +75,35 @@ pub enum CaptureOutcome {
     Deny,
 }
 
+/// Which enforcement point emitted the record. Phase 1 had one emit (the
+/// command gateway, fast loop); Phase 1.5 (docs/CAPTURE_PIPELINE_SPEC.md §3)
+/// adds the slow-loop trajectory verdict in the ROS 2 adapter. The Linux
+/// collector keys on this to bucket fast- vs slow-loop corrections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CaptureSource {
+    /// The actuator command gateway (`policy_layer`), per-command fast loop.
+    CommandGateway,
+    /// The ROS 2 adapter's slow-loop trajectory validator.
+    SlowLoopTrajectory,
+}
+
+/// SDK-side mirror of the adapter's slow-loop `TrajectoryVerdict`. The real
+/// type lives DOWNSTREAM in `kirra-ros2-adapter` and cannot be referenced
+/// here without a dependency cycle (the adapter depends on this crate, not
+/// the reverse). The adapter maps its `TrajectoryVerdict` onto this at the
+/// emit site; keeping the enum here lets the verdict→outcome mapping below
+/// be unit-tested in the crate that owns `CaptureOutcome`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrajectoryDecision {
+    /// Promoted as-is.
+    Accept,
+    /// Promoted as a speed-derated variant (per-pose Clamp).
+    Clamp,
+    /// Refused / collapsed to MRC (also covers the adapter's `Pending`).
+    MrcFallback,
+}
+
 /// A snapshot of the doer's proposal (correlation context; the Linux collector
 /// joins this with the bus-observed perception/ego/model-version).
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -99,6 +127,46 @@ impl From<&ProposedVehicleCommand> for ProposedCommandSnapshot {
     }
 }
 
+/// A single world-frame pose, the BOUNDED endpoints of a trajectory summary.
+/// We record only the first + last pose, never the full point sequence — the
+/// summary must stay O(1) so the slow-loop emit never regresses WCET.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct PoseSnapshot {
+    pub x_m: f64,
+    pub y_m: f64,
+    pub heading_rad: f64,
+}
+
+/// BOUNDED slow-loop trajectory summary + join keys. This is the trajectory
+/// analogue of `ProposedCommandSnapshot`: it carries just enough to JOIN the
+/// record Linux-side (asset/trajectory ids + the objects-snapshot freshness
+/// stamp) plus a fixed-size shape summary (counts + endpoint poses + the
+/// planner's target speed). It deliberately does NOT clone the full point or
+/// object vectors — only their lengths and endpoints — so building it is O(1)
+/// and stays off the slow loop's measured WCET.
+#[derive(Debug, Clone, Serialize)]
+pub struct TrajectoryCaptureExt {
+    /// Join key — the per-asset id ("ego" in single-asset deployments).
+    pub asset_id: String,
+    /// Join key — the planner/adapter-assigned monotonic trajectory id.
+    pub trajectory_id: u64,
+    /// Join key — wall-clock ms of the objects snapshot the verdict used
+    /// (the same freshness stamp the perception tick is keyed on); lets the
+    /// collector line the record up with the bus-observed perception frame.
+    pub objects_ms: u64,
+    /// Number of points in the candidate trajectory (shape, not the points).
+    pub point_count: usize,
+    /// Number of perceived objects the verdict saw (shape, not the objects).
+    pub object_count: usize,
+    /// First pose of the candidate (None for an empty trajectory).
+    pub first_pose: Option<PoseSnapshot>,
+    /// Last pose of the candidate (None for an empty trajectory).
+    pub last_pose: Option<PoseSnapshot>,
+    /// The planner's commanded speed at the last point (m/s) — the "target"
+    /// the slow loop validated against. None for an empty trajectory.
+    pub target_speed_mps: Option<f64>,
+}
+
 /// The small, fixed-shape capture record. Carries the correction Kirra imposed +
 /// the proposal context + join keys. Deliberately does NOT carry the doer's model
 /// version — Kirra doesn't know it; it is joined Linux-side.
@@ -110,8 +178,18 @@ pub struct CaptureRecord {
     pub t_mono_ns: u128,
     /// Wall-clock ms (bus join).
     pub t_wall_ms: u64,
-    /// The doer's proposal (correlation + context).
-    pub proposed: ProposedCommandSnapshot,
+    /// Which enforcement point emitted this record (fast loop vs slow loop).
+    pub source: CaptureSource,
+    /// The doer's proposal (correlation + context). Present for the command
+    /// gateway (`CommandGateway`); absent for the slow-loop trajectory record,
+    /// which carries its context in `traj` instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposed: Option<ProposedCommandSnapshot>,
+    /// Bounded slow-loop trajectory summary + join keys. Present only for
+    /// `SlowLoopTrajectory` records; `None` (and omitted from JSON) for the
+    /// command-gateway record.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub traj: Option<TrajectoryCaptureExt>,
     /// What Kirra decided.
     pub outcome: CaptureOutcome,
     /// Which check fired, if a deny (the `DenyCode` token); `None` otherwise.
@@ -149,13 +227,63 @@ impl CaptureRecord {
             decision_seq,
             t_mono_ns: mono_ns(),
             t_wall_ms,
-            proposed: proposed.into(),
+            source: CaptureSource::CommandGateway,
+            proposed: Some(proposed.into()),
+            traj: None,
             outcome,
             deny_code,
             safe_value,
             // Degraded posture admits commands only through the decel-to-stop-and-HOLD
             // (MRC) envelope; LockedOut is short-circuited before the gateway verdict.
             mrc: matches!(posture, FleetPosture::Degraded),
+            posture: posture_token(posture),
+            derate_enabled,
+        }
+    }
+
+    /// Build a record from the adapter's already-computed slow-loop
+    /// trajectory verdict + a BOUNDED trajectory summary. Pure; performs no
+    /// I/O. Called at the adapter's slow-loop emit site, OFF the verdict path
+    /// (after `validate_trajectory_slow_capped` has already returned).
+    ///
+    /// Verdict → outcome mapping (the slow-loop analogue of `from_verdict`):
+    ///   - `Accept`      → `Allow`        (promoted as-is)
+    ///   - `Clamp`       → `ClampLinear`  (promoted speed-derated)
+    ///   - `MrcFallback` → `Deny` (`mrc = true`, `deny_code = TRAJECTORY_MRC_FALLBACK`)
+    ///
+    /// `mrc` is also set whenever the posture is `Degraded` (decel-to-stop
+    /// envelope), matching the gateway record's semantics.
+    #[must_use]
+    pub fn from_trajectory_verdict(
+        decision_seq: u64,
+        t_wall_ms: u64,
+        decision: TrajectoryDecision,
+        posture: FleetPosture,
+        traj: TrajectoryCaptureExt,
+        derate_enabled: bool,
+    ) -> Self {
+        let (outcome, deny_code) = match decision {
+            TrajectoryDecision::Accept => (CaptureOutcome::Allow, None),
+            TrajectoryDecision::Clamp => (CaptureOutcome::ClampLinear, None),
+            TrajectoryDecision::MrcFallback => {
+                (CaptureOutcome::Deny, Some("TRAJECTORY_MRC_FALLBACK"))
+            }
+        };
+        Self {
+            decision_seq,
+            t_mono_ns: mono_ns(),
+            t_wall_ms,
+            source: CaptureSource::SlowLoopTrajectory,
+            proposed: None,
+            traj: Some(traj),
+            outcome,
+            deny_code,
+            // The slow loop has no single substituted scalar (the correction
+            // is a whole-trajectory derate/refusal); the target speed lives in
+            // the bounded summary instead.
+            safe_value: None,
+            mrc: matches!(decision, TrajectoryDecision::MrcFallback)
+                || matches!(posture, FleetPosture::Degraded),
             posture: posture_token(posture),
             derate_enabled,
         }
@@ -172,10 +300,12 @@ fn posture_token(p: FleetPosture) -> &'static str {
 }
 
 /// Spawns the single capture-writer task on the blocking pool and returns the
-/// bounded mpsc Sender the gateway `try_send`s into. Exactly mirrors
+/// bounded mpsc Sender producers `try_send` into. Mirrors
 /// `audit_writer::spawn_audit_writer`: `blocking_recv` drains serially; the task
-/// exits when the last Sender drops.
-pub fn spawn_capture_writer(_app: Arc<AppState>) -> mpsc::Sender<CaptureRecord> {
+/// exits when the last Sender drops. Both emit points (the verifier's command
+/// gateway and the ROS 2 adapter's slow loop) call this — it takes no state, so
+/// the adapter, which has no `AppState`, can spawn its own writer too.
+pub fn spawn_capture_writer() -> mpsc::Sender<CaptureRecord> {
     let (tx, mut rx) = mpsc::channel::<CaptureRecord>(CAPTURE_QUEUE_BOUND);
     let sink_path = std::env::var(CAPTURE_SINK_PATH_ENV)
         .unwrap_or_else(|_| "kirra_capture.jsonl".to_string());
@@ -263,6 +393,70 @@ mod tests {
         assert_eq!(dn.outcome, CaptureOutcome::Deny);
         assert_eq!(dn.deny_code, Some("NAN_INF_LINEAR_VELOCITY"));
         assert_eq!(dn.safe_value, None);
+    }
+
+    fn traj_ext() -> TrajectoryCaptureExt {
+        TrajectoryCaptureExt {
+            asset_id: "ego".to_string(),
+            trajectory_id: 7,
+            objects_ms: 123_456,
+            point_count: 12,
+            object_count: 3,
+            first_pose: Some(PoseSnapshot { x_m: 0.0, y_m: 0.0, heading_rad: 0.0 }),
+            last_pose: Some(PoseSnapshot { x_m: 5.0, y_m: 1.0, heading_rad: 0.1 }),
+            target_speed_mps: Some(8.0),
+        }
+    }
+
+    #[test]
+    fn from_trajectory_verdict_maps_each_decision() {
+        let accept = CaptureRecord::from_trajectory_verdict(
+            0, 1000, TrajectoryDecision::Accept, FleetPosture::Nominal, traj_ext(), false);
+        assert_eq!(accept.outcome, CaptureOutcome::Allow);
+        assert_eq!(accept.deny_code, None);
+        assert!(!accept.mrc);
+        assert_eq!(accept.source, CaptureSource::SlowLoopTrajectory);
+        assert!(accept.proposed.is_none(), "trajectory record carries no command proposal");
+        assert_eq!(accept.traj.as_ref().unwrap().trajectory_id, 7);
+        assert_eq!(accept.traj.as_ref().unwrap().objects_ms, 123_456);
+
+        let clamp = CaptureRecord::from_trajectory_verdict(
+            1, 1000, TrajectoryDecision::Clamp, FleetPosture::Nominal, traj_ext(), true);
+        assert_eq!(clamp.outcome, CaptureOutcome::ClampLinear);
+        assert_eq!(clamp.deny_code, None);
+        assert!(clamp.derate_enabled);
+
+        let mrc = CaptureRecord::from_trajectory_verdict(
+            2, 1000, TrajectoryDecision::MrcFallback, FleetPosture::Nominal, traj_ext(), false);
+        assert_eq!(mrc.outcome, CaptureOutcome::Deny);
+        assert_eq!(mrc.deny_code, Some("TRAJECTORY_MRC_FALLBACK"));
+        assert!(mrc.mrc, "MRCFallback → controlled stop");
+
+        // Degraded posture forces mrc even on an Accept decision.
+        let degraded = CaptureRecord::from_trajectory_verdict(
+            3, 1000, TrajectoryDecision::Accept, FleetPosture::Degraded, traj_ext(), false);
+        assert!(degraded.mrc, "Degraded posture → MRC envelope");
+        assert_eq!(degraded.posture, "DEGRADED");
+    }
+
+    #[test]
+    fn gateway_record_omits_traj_and_keeps_proposed_in_json() {
+        // The command-gateway record must serialize WITH `proposed` and
+        // WITHOUT `traj` (skip_serializing_if). The trajectory record is the
+        // mirror image.
+        let gw = CaptureRecord::from_verdict(
+            0, 1, &EnforceAction::Allow, FleetPosture::Nominal, &cmd(), false);
+        let gw_json = serde_json::to_string(&gw).unwrap();
+        assert!(gw_json.contains("\"source\":\"COMMAND_GATEWAY\""));
+        assert!(gw_json.contains("\"proposed\""));
+        assert!(!gw_json.contains("\"traj\""), "gateway record omits traj");
+
+        let tj = CaptureRecord::from_trajectory_verdict(
+            0, 1, TrajectoryDecision::Accept, FleetPosture::Nominal, traj_ext(), false);
+        let tj_json = serde_json::to_string(&tj).unwrap();
+        assert!(tj_json.contains("\"source\":\"SLOW_LOOP_TRAJECTORY\""));
+        assert!(tj_json.contains("\"traj\""));
+        assert!(!tj_json.contains("\"proposed\""), "trajectory record omits proposed");
     }
 
     #[test]


### PR DESCRIPTION
Add the second capture emit point — the ROS 2 adapter's slow-loop TRAJECTORY verdict — reusing the Phase-1 machinery (docs/CAPTURE_PIPELINE_SPEC.md §3).

src/capture.rs (additive):
  - `CaptureSource { CommandGateway, SlowLoopTrajectory }` + a `source` field on `CaptureRecord` (from_verdict tags CommandGateway).
  - `TrajectoryDecision` — SDK-side mirror of the adapter's TrajectoryVerdict (the real type lives downstream; referencing it here would be a dep cycle).
  - `TrajectoryCaptureExt` — a BOUNDED summary + join keys (asset/trajectory ids, objects_ms freshness stamp, point/object counts, first/last pose, target speed). Never clones the full points/objects vectors → O(1).
  - `CaptureRecord::from_trajectory_verdict` — Accept→Allow, Clamp→ClampLinear, MrcFallback→Deny(mrc, TRAJECTORY_MRC_FALLBACK); Degraded posture forces mrc.
  - `proposed` is now Option (omitted for trajectory records); `traj` is Option (omitted for gateway records) — both skip_serializing_if.
  - spawn_capture_writer drops the unused Arc<AppState> arg so the adapter, which has no AppState, can spawn its own writer. Caller updated.

crates/kirra-ros2-adapter/src/node.rs:
  - Spawn the SDK capture writer at slow-loop startup, DEFAULT OFF (KIRRA_CAPTURE_ENABLED); adapter-local AtomicU64 decision seq.
  - Emit a bounded record AFTER the WCET measurement and beside update_trajectory — additive, wait-free try_send, drop-on-full/closed.

Invariants: verdict-path blob 997fb7ae… unchanged; validate_trajectory_slow_capped and TrajectoryVerdict type/semantics untouched; default OFF; slow-loop WCET not regressed (capture runs after the measured window).