### PR TITLE
refactor(capture): extract kirra-capture-schema crate (collector Stag…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-ros2-adapter"]
+members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema"]
 resolver = "2"
 
 [package]
@@ -48,6 +48,9 @@ tpm = ["dep:tss-esapi"]
 
 [dependencies]
 parko-core = { path = "parko/crates/parko-core" }
+# Governor-free wire schema for capture records, shared verbatim with the offline
+# collector (docs/COLLECTOR_DESIGN.md [C1]). Re-exported by `crate::capture`.
+kirra-capture-schema = { path = "crates/kirra-capture-schema" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hmac = "0.12"

--- a/crates/kirra-capture-schema/Cargo.toml
+++ b/crates/kirra-capture-schema/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "kirra-capture-schema"
+version = "0.1.0"
+edition = "2021"
+description = "Wire schema for Kirra's learning-loop capture records — the single authoritative, governor-free type set shared by the SDK emitters and the offline collector."
+repository = "https://github.com/justinlooney/kirra-runtime-sdk"
+authors = ["Justin Looney <justin@kirrasystems.io>"]
+license = "MIT OR Apache-2.0"
+
+# §0 SAFETY BOUNDARY: this crate depends on `serde` ONLY. It carries no governor
+# types and no logic — just the leaf record shapes. The offline collector depends
+# on THIS crate (never on `kirra-runtime-sdk`), which is what mechanically
+# guarantees the collector cannot link or reach the verdict path.
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/crates/kirra-capture-schema/src/lib.rs
+++ b/crates/kirra-capture-schema/src/lib.rs
@@ -1,0 +1,260 @@
+// crates/kirra-capture-schema/src/lib.rs
+//
+// Wire schema for Kirra's learning-loop capture records (docs/COLLECTOR_DESIGN.md
+// [D6 / C1]). This is the SINGLE authoritative definition of the on-disk capture
+// JSONL shape, shared by two sides:
+//   - the SDK emitters (`kirra_runtime_sdk::capture`), which BUILD records via
+//     constructors that touch governor types and SERIALIZE them, and
+//   - the offline `kirra-collector`, which DESERIALIZES them to assemble the
+//     training dataset.
+//
+// §0 SAFETY BOUNDARY (enforced by the dependency graph, not a comment): this
+// crate depends on `serde` ONLY. It holds no governor types and no logic — only
+// leaf data. Because the collector depends on THIS crate and never on
+// `kirra-runtime-sdk`, it is mechanically incapable of linking or reaching the
+// verdict path. The SDK depends on this crate and re-exports the types
+// (`pub use kirra_capture_schema::*;`) so every existing `crate::capture::*` path
+// keeps resolving unchanged.
+//
+// Owned strings (NOT `&'static str`): `posture` and `deny_code` are `String` /
+// `Option<String>` here, not the SDK's internal `&'static str` tokens — serde
+// cannot `Deserialize` a `&'static str`, and the collector must read these back.
+// The on-disk JSON is byte-for-byte identical (a JSON string is a string either
+// way); only the in-memory backing differs. The SDK constructors `.to_string()`
+// their static tokens into these fields.
+//
+// Note on what is NOT here:
+//   - `TrajectoryDecision` stays in the SDK — it is a constructor INPUT (the
+//     SDK-side mirror of the adapter's `TrajectoryVerdict`), never a serialized
+//     field, so it has no place in the wire schema.
+//   - `From<&ProposedVehicleCommand> for ProposedCommandSnapshot` stays in the
+//     SDK (inlined into the constructor) — it references a governor type and so
+//     cannot live in this serde-only crate.
+
+use serde::{Deserialize, Serialize};
+
+/// The decision Kirra reached, as a stable token (the "correction" kind).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CaptureOutcome {
+    Allow,
+    ClampLinear,
+    ClampSteering,
+    Deny,
+}
+
+/// Which enforcement point emitted the record. Phase 1 had one emit (the
+/// command gateway, fast loop); Phase 1.5 (docs/CAPTURE_PIPELINE_SPEC.md §3)
+/// adds the slow-loop trajectory verdict in the ROS 2 adapter. The Linux
+/// collector keys on this to bucket fast- vs slow-loop corrections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CaptureSource {
+    /// The actuator command gateway (`policy_layer`), per-command fast loop.
+    CommandGateway,
+    /// The ROS 2 adapter's slow-loop trajectory validator.
+    SlowLoopTrajectory,
+}
+
+/// A snapshot of the doer's proposal (correlation context; the Linux collector
+/// joins this with the bus-observed perception/ego/model-version). The SDK
+/// builds this from the governor's `ProposedVehicleCommand` at the emit site.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ProposedCommandSnapshot {
+    pub linear_velocity_mps: f64,
+    pub current_velocity_mps: f64,
+    pub steering_angle_deg: f64,
+    pub current_steering_angle_deg: f64,
+    pub delta_time_s: f64,
+}
+
+/// A single world-frame pose, the BOUNDED endpoints of a trajectory summary.
+/// Only the first + last pose are recorded, never the full point sequence — the
+/// summary must stay O(1) so the slow-loop emit never regresses WCET.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PoseSnapshot {
+    pub x_m: f64,
+    pub y_m: f64,
+    pub heading_rad: f64,
+}
+
+/// BOUNDED slow-loop trajectory summary + join keys. The trajectory analogue of
+/// `ProposedCommandSnapshot`: just enough to JOIN the record Linux-side
+/// (asset/trajectory ids + the objects-snapshot freshness stamp) plus a
+/// fixed-size shape summary (counts + endpoint poses + the planner's target
+/// speed). It deliberately does NOT clone the full point or object vectors —
+/// only their lengths and endpoints.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TrajectoryCaptureExt {
+    /// Join key — the per-asset id ("ego" in single-asset deployments).
+    pub asset_id: String,
+    /// Join key — the planner/adapter-assigned monotonic trajectory id.
+    pub trajectory_id: u64,
+    /// Join key — wall-clock ms of the objects snapshot the verdict used
+    /// (the same freshness stamp the perception tick is keyed on); lets the
+    /// collector line the record up with the bus-observed perception frame.
+    pub objects_ms: u64,
+    /// Number of points in the candidate trajectory (shape, not the points).
+    pub point_count: usize,
+    /// Number of perceived objects the verdict saw (shape, not the objects).
+    pub object_count: usize,
+    /// First pose of the candidate (None for an empty trajectory).
+    pub first_pose: Option<PoseSnapshot>,
+    /// Last pose of the candidate (None for an empty trajectory).
+    pub last_pose: Option<PoseSnapshot>,
+    /// The planner's commanded speed at the last point (m/s) — the "target"
+    /// the slow loop validated against. None for an empty trajectory.
+    pub target_speed_mps: Option<f64>,
+}
+
+/// The small, fixed-shape capture record. Carries the correction Kirra imposed +
+/// the proposal/trajectory context + join keys. Deliberately does NOT carry the
+/// doer's model version — Kirra doesn't know it; it is joined Linux-side.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CaptureRecord {
+    /// Monotonic per-decision sequence (the join/order key).
+    pub decision_seq: u64,
+    /// Monotonic ns since process start (ordering, skew-free).
+    pub t_mono_ns: u128,
+    /// Wall-clock ms (bus join).
+    pub t_wall_ms: u64,
+    /// Which enforcement point emitted this record (fast loop vs slow loop).
+    pub source: CaptureSource,
+    /// The doer's proposal (correlation + context). Present for the command
+    /// gateway (`CommandGateway`); absent for the slow-loop trajectory record,
+    /// which carries its context in `traj` instead.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub proposed: Option<ProposedCommandSnapshot>,
+    /// Bounded slow-loop trajectory summary + join keys. Present only for
+    /// `SlowLoopTrajectory` records; `None` (and omitted from JSON) for the
+    /// command-gateway record.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub traj: Option<TrajectoryCaptureExt>,
+    /// What Kirra decided.
+    pub outcome: CaptureOutcome,
+    /// Which check fired, if a deny (the `DenyCode` token); `None` otherwise.
+    /// Owned `String` (not `&'static str`) so the collector can deserialize it.
+    pub deny_code: Option<String>,
+    /// The safe value Kirra substituted on a clamp (m/s for linear, deg for
+    /// steering); `None` for Allow/Deny.
+    pub safe_value: Option<f64>,
+    /// Controlled-stop substitution (Degraded → decel-to-stop-and-HOLD envelope).
+    pub mrc: bool,
+    /// Posture context. Owned `String` (not `&'static str`) for deserialization;
+    /// the SDK writes one of `NOMINAL` / `DEGRADED` / `LOCKED_OUT`.
+    pub posture: String,
+    /// Whether the perception derate was enabled (so passes are attributable).
+    pub derate_enabled: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gateway_clamp_record() -> CaptureRecord {
+        CaptureRecord {
+            decision_seq: 0,
+            t_mono_ns: 0,
+            t_wall_ms: 1000,
+            source: CaptureSource::CommandGateway,
+            proposed: Some(ProposedCommandSnapshot {
+                linear_velocity_mps: 40.0,
+                current_velocity_mps: 40.0,
+                steering_angle_deg: 0.0,
+                current_steering_angle_deg: 0.0,
+                delta_time_s: 0.1,
+            }),
+            traj: None,
+            outcome: CaptureOutcome::ClampLinear,
+            deny_code: None,
+            safe_value: Some(35.0),
+            mrc: false,
+            posture: "NOMINAL".to_string(),
+            derate_enabled: false,
+        }
+    }
+
+    fn trajectory_mrc_record() -> CaptureRecord {
+        CaptureRecord {
+            decision_seq: 3,
+            t_mono_ns: 0,
+            t_wall_ms: 2000,
+            source: CaptureSource::SlowLoopTrajectory,
+            proposed: None,
+            traj: Some(TrajectoryCaptureExt {
+                asset_id: "ego".to_string(),
+                trajectory_id: 7,
+                objects_ms: 123_456,
+                point_count: 12,
+                object_count: 3,
+                first_pose: Some(PoseSnapshot { x_m: 0.0, y_m: 0.0, heading_rad: 0.0 }),
+                last_pose: Some(PoseSnapshot { x_m: 5.0, y_m: 1.0, heading_rad: 0.1 }),
+                target_speed_mps: Some(8.0),
+            }),
+            outcome: CaptureOutcome::Deny,
+            deny_code: Some("TRAJECTORY_MRC_FALLBACK".to_string()),
+            safe_value: None,
+            mrc: true,
+            posture: "DEGRADED".to_string(),
+            derate_enabled: false,
+        }
+    }
+
+    /// The on-disk wire shape, pinned. These exact strings are the
+    /// pre-extraction shape (declared-field order; SCREAMING_SNAKE enums;
+    /// skip_serializing_if on proposed/traj only; deny_code/posture as JSON
+    /// strings/null). If any of these change, the collector's deserialize and
+    /// every prior captured file break — so they are pinned, not asserted loosely.
+    #[test]
+    fn gateway_record_wire_shape_is_pinned() {
+        let s = serde_json::to_string(&gateway_clamp_record()).unwrap();
+        assert_eq!(
+            s,
+            r#"{"decision_seq":0,"t_mono_ns":0,"t_wall_ms":1000,"source":"COMMAND_GATEWAY","proposed":{"linear_velocity_mps":40.0,"current_velocity_mps":40.0,"steering_angle_deg":0.0,"current_steering_angle_deg":0.0,"delta_time_s":0.1},"outcome":"CLAMP_LINEAR","deny_code":null,"safe_value":35.0,"mrc":false,"posture":"NOMINAL","derate_enabled":false}"#
+        );
+    }
+
+    #[test]
+    fn trajectory_record_wire_shape_is_pinned() {
+        let s = serde_json::to_string(&trajectory_mrc_record()).unwrap();
+        assert_eq!(
+            s,
+            r#"{"decision_seq":3,"t_mono_ns":0,"t_wall_ms":2000,"source":"SLOW_LOOP_TRAJECTORY","traj":{"asset_id":"ego","trajectory_id":7,"objects_ms":123456,"point_count":12,"object_count":3,"first_pose":{"x_m":0.0,"y_m":0.0,"heading_rad":0.0},"last_pose":{"x_m":5.0,"y_m":1.0,"heading_rad":0.1},"target_speed_mps":8.0},"outcome":"DENY","deny_code":"TRAJECTORY_MRC_FALLBACK","safe_value":null,"mrc":true,"posture":"DEGRADED","derate_enabled":false}"#
+        );
+    }
+
+    /// Full round-trip: serialize → deserialize → re-serialize must equal the
+    /// original JSON, for both sources. This is what proves the owned-`String`
+    /// switch (vs the SDK's `&'static str`) did not move the wire format and that
+    /// the collector reads exactly what the SDK writes.
+    #[test]
+    fn round_trip_is_lossless_for_each_source() {
+        for original in [gateway_clamp_record(), trajectory_mrc_record()] {
+            let s1 = serde_json::to_string(&original).unwrap();
+            let back: CaptureRecord = serde_json::from_str(&s1).unwrap();
+            assert_eq!(back, original, "deserialized record must equal the original");
+            let s2 = serde_json::to_string(&back).unwrap();
+            assert_eq!(s1, s2, "re-serialized JSON must be byte-identical");
+        }
+    }
+
+    /// The collector can deserialize a gateway line that OMITS `traj` and a
+    /// trajectory line that OMITS `proposed` — the `#[serde(default)]` on both
+    /// optional join blocks makes the skip-serialized shape readable.
+    #[test]
+    fn deserialize_tolerates_omitted_optional_blocks() {
+        let gw: CaptureRecord = serde_json::from_str(
+            &serde_json::to_string(&gateway_clamp_record()).unwrap(),
+        )
+        .unwrap();
+        assert!(gw.traj.is_none());
+        assert!(gw.proposed.is_some());
+
+        let tj: CaptureRecord = serde_json::from_str(
+            &serde_json::to_string(&trajectory_mrc_record()).unwrap(),
+        )
+        .unwrap();
+        assert!(tj.proposed.is_none());
+        assert!(tj.traj.is_some());
+    }
+}

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -58,8 +58,8 @@ use kirra_runtime_sdk::gateway::perception_monitor::{
 // (bounded mpsc + spawn_blocking JSONL drain); DEFAULT OFF via
 // `KIRRA_CAPTURE_ENABLED`. Additive only — never on / altering the verdict.
 use kirra_runtime_sdk::capture::{
-    capture_enabled, spawn_capture_writer, CaptureRecord, PoseSnapshot,
-    TrajectoryCaptureExt, TrajectoryDecision,
+    capture_enabled, record_from_trajectory_verdict, spawn_capture_writer, CaptureRecord,
+    PoseSnapshot, TrajectoryCaptureExt, TrajectoryDecision,
 };
 
 /// Read the subscription staleness timeout (ms) from
@@ -462,7 +462,7 @@ pub async fn run_adapter(
                     last_pose: traj.points.last().map(pose_snap),
                     target_speed_mps: traj.points.last().map(|p| p.velocity_mps),
                 };
-                let rec = CaptureRecord::from_trajectory_verdict(
+                let rec = record_from_trajectory_verdict(
                     capture_seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
                     now_ms,
                     decision,

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,21 +1,31 @@
 // src/capture.rs
 //
-// Learning-loop capture channel — Phase 1 (docs/CAPTURE_PIPELINE_SPEC.md, #190).
+// Learning-loop capture channel — Phase 1 (docs/CAPTURE_PIPELINE_SPEC.md, #190);
+// Phase 1.5 slow-loop emit (#192); Stage A schema extraction
+// (docs/COLLECTOR_DESIGN.md [C1]).
 //
 // Records the "correction" half of the corrective-supervision triple — what Kirra
 // DECIDED and the safe value it imposed — as a NON-BLOCKING side channel, so a
 // Linux-side collector can later join it with bus telemetry. This is a SIBLING of
 // `src/audit_writer.rs`, mirroring it one-for-one:
 //   - a bounded mpsc channel + a single spawn_blocking drain task,
-//   - the producer (the actuator gateway) only `try_send`s a small fixed-shape
-//     record — wait-free, drop-on-full, NEVER blocking the verdict path,
+//   - the producer (the actuator gateway / the adapter slow loop) only
+//     `try_send`s a small fixed-shape record — wait-free, drop-on-full, NEVER
+//     blocking the verdict path,
 //   - default OFF behind `KIRRA_CAPTURE_ENABLED` (mirrors the perception-derate
 //     default-off env gate).
 //
-// HARD INVARIANTS (this module + its call site uphold):
+// SCHEMA LOCATION (Stage A): the on-disk record TYPES live in the governor-free
+// `kirra-capture-schema` crate and are re-exported below (`pub use
+// kirra_capture_schema::*;`) so every `crate::capture::*` path keeps resolving.
+// This module keeps the BUILDERS (which touch governor types) and the writer.
+// The split is what lets the offline collector reuse the exact schema without
+// linking the verdict path (§0).
+//
+// HARD INVARIANTS (this module + its call sites uphold):
 //   * Verdict path byte-identical — capture is additive; it reads the
-//     already-computed `EnforceAction` and emits. It never lives in, or alters,
-//     `src/gateway/kinematics_contract.rs`.
+//     already-computed `EnforceAction` / `TrajectoryDecision` and emits. It never
+//     lives in, or alters, `src/gateway/kinematics_contract.rs`.
 //   * Verdicts/responses identical capture-on vs -off — the emit changes only the
 //     side channel; it never gates/delays/alters the verdict, EnforcementOutcome,
 //     or the HTTP response.
@@ -29,11 +39,17 @@ use std::io::Write;
 use std::sync::OnceLock;
 use std::time::Instant;
 
-use serde::Serialize;
 use tokio::sync::mpsc;
 
 use crate::gateway::kinematics_contract::{EnforceAction, ProposedVehicleCommand};
 use crate::verifier::FleetPosture;
+
+// The capture record wire schema lives in the governor-free
+// `kirra-capture-schema` crate (docs/COLLECTOR_DESIGN.md [C1]); re-export it so
+// every existing `crate::capture::{CaptureRecord, ...}` /
+// `kirra_runtime_sdk::capture::*` path keeps resolving, and so the SDK and the
+// offline collector share ONE authoritative definition with no drift.
+pub use kirra_capture_schema::*;
 
 /// Bounded capture queue depth — mirrors `AUDIT_QUEUE_BOUND`.
 pub const CAPTURE_QUEUE_BOUND: usize = 2048;
@@ -65,35 +81,13 @@ fn mono_ns() -> u128 {
     START.get_or_init(Instant::now).elapsed().as_nanos()
 }
 
-/// The decision Kirra reached, as a stable token (the "correction" kind).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum CaptureOutcome {
-    Allow,
-    ClampLinear,
-    ClampSteering,
-    Deny,
-}
-
-/// Which enforcement point emitted the record. Phase 1 had one emit (the
-/// command gateway, fast loop); Phase 1.5 (docs/CAPTURE_PIPELINE_SPEC.md §3)
-/// adds the slow-loop trajectory verdict in the ROS 2 adapter. The Linux
-/// collector keys on this to bucket fast- vs slow-loop corrections.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum CaptureSource {
-    /// The actuator command gateway (`policy_layer`), per-command fast loop.
-    CommandGateway,
-    /// The ROS 2 adapter's slow-loop trajectory validator.
-    SlowLoopTrajectory,
-}
-
 /// SDK-side mirror of the adapter's slow-loop `TrajectoryVerdict`. The real
 /// type lives DOWNSTREAM in `kirra-ros2-adapter` and cannot be referenced
 /// here without a dependency cycle (the adapter depends on this crate, not
 /// the reverse). The adapter maps its `TrajectoryVerdict` onto this at the
-/// emit site; keeping the enum here lets the verdict→outcome mapping below
-/// be unit-tested in the crate that owns `CaptureOutcome`.
+/// emit site; keeping the enum here (NOT in the wire-schema crate) lets the
+/// verdict→outcome mapping below be unit-tested where the builders live — it is
+/// a constructor INPUT, never a serialized field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrajectoryDecision {
     /// Promoted as-is.
@@ -104,189 +98,102 @@ pub enum TrajectoryDecision {
     MrcFallback,
 }
 
-/// A snapshot of the doer's proposal (correlation context; the Linux collector
-/// joins this with the bus-observed perception/ego/model-version).
-#[derive(Debug, Clone, Copy, Serialize)]
-pub struct ProposedCommandSnapshot {
-    pub linear_velocity_mps: f64,
-    pub current_velocity_mps: f64,
-    pub steering_angle_deg: f64,
-    pub current_steering_angle_deg: f64,
-    pub delta_time_s: f64,
-}
-
-impl From<&ProposedVehicleCommand> for ProposedCommandSnapshot {
-    fn from(c: &ProposedVehicleCommand) -> Self {
-        Self {
-            linear_velocity_mps: c.linear_velocity_mps,
-            current_velocity_mps: c.current_velocity_mps,
-            steering_angle_deg: c.steering_angle_deg,
-            current_steering_angle_deg: c.current_steering_angle_deg,
-            delta_time_s: c.delta_time_s,
+/// Build a record from the already-computed gateway verdict + context. Pure;
+/// performs no I/O. Called at the gateway emit site (off the verdict path).
+///
+/// Free function (not an inherent method) because `CaptureRecord` now lives in
+/// `kirra-capture-schema` — the orphan rule forbids an inherent impl here. The
+/// `ProposedVehicleCommand → ProposedCommandSnapshot` mapping is inlined for the
+/// same reason (a `From` impl would have to live in one crate or the other and
+/// can do neither without dragging the governor into the schema crate).
+#[must_use]
+pub fn record_from_verdict(
+    decision_seq: u64,
+    t_wall_ms: u64,
+    verdict: &EnforceAction,
+    posture: FleetPosture,
+    proposed: &ProposedVehicleCommand,
+    derate_enabled: bool,
+) -> CaptureRecord {
+    let (outcome, deny_code, safe_value) = match verdict {
+        EnforceAction::Allow => (CaptureOutcome::Allow, None, None),
+        EnforceAction::ClampLinear(v) => (CaptureOutcome::ClampLinear, None, Some(*v)),
+        EnforceAction::ClampSteering(d) => (CaptureOutcome::ClampSteering, None, Some(*d)),
+        EnforceAction::DenyBreach(code) => {
+            (CaptureOutcome::Deny, Some(code.reason().to_string()), None)
         }
+    };
+    CaptureRecord {
+        decision_seq,
+        t_mono_ns: mono_ns(),
+        t_wall_ms,
+        source: CaptureSource::CommandGateway,
+        // Inlined ProposedVehicleCommand → ProposedCommandSnapshot mapping
+        // (the former `From` impl — see doc comment above).
+        proposed: Some(ProposedCommandSnapshot {
+            linear_velocity_mps: proposed.linear_velocity_mps,
+            current_velocity_mps: proposed.current_velocity_mps,
+            steering_angle_deg: proposed.steering_angle_deg,
+            current_steering_angle_deg: proposed.current_steering_angle_deg,
+            delta_time_s: proposed.delta_time_s,
+        }),
+        traj: None,
+        outcome,
+        deny_code,
+        safe_value,
+        // Degraded posture admits commands only through the decel-to-stop-and-HOLD
+        // (MRC) envelope; LockedOut is short-circuited before the gateway verdict.
+        mrc: matches!(posture, FleetPosture::Degraded),
+        posture: posture_token(posture).to_string(),
+        derate_enabled,
     }
 }
 
-/// A single world-frame pose, the BOUNDED endpoints of a trajectory summary.
-/// We record only the first + last pose, never the full point sequence — the
-/// summary must stay O(1) so the slow-loop emit never regresses WCET.
-#[derive(Debug, Clone, Copy, Serialize)]
-pub struct PoseSnapshot {
-    pub x_m: f64,
-    pub y_m: f64,
-    pub heading_rad: f64,
-}
-
-/// BOUNDED slow-loop trajectory summary + join keys. This is the trajectory
-/// analogue of `ProposedCommandSnapshot`: it carries just enough to JOIN the
-/// record Linux-side (asset/trajectory ids + the objects-snapshot freshness
-/// stamp) plus a fixed-size shape summary (counts + endpoint poses + the
-/// planner's target speed). It deliberately does NOT clone the full point or
-/// object vectors — only their lengths and endpoints — so building it is O(1)
-/// and stays off the slow loop's measured WCET.
-#[derive(Debug, Clone, Serialize)]
-pub struct TrajectoryCaptureExt {
-    /// Join key — the per-asset id ("ego" in single-asset deployments).
-    pub asset_id: String,
-    /// Join key — the planner/adapter-assigned monotonic trajectory id.
-    pub trajectory_id: u64,
-    /// Join key — wall-clock ms of the objects snapshot the verdict used
-    /// (the same freshness stamp the perception tick is keyed on); lets the
-    /// collector line the record up with the bus-observed perception frame.
-    pub objects_ms: u64,
-    /// Number of points in the candidate trajectory (shape, not the points).
-    pub point_count: usize,
-    /// Number of perceived objects the verdict saw (shape, not the objects).
-    pub object_count: usize,
-    /// First pose of the candidate (None for an empty trajectory).
-    pub first_pose: Option<PoseSnapshot>,
-    /// Last pose of the candidate (None for an empty trajectory).
-    pub last_pose: Option<PoseSnapshot>,
-    /// The planner's commanded speed at the last point (m/s) — the "target"
-    /// the slow loop validated against. None for an empty trajectory.
-    pub target_speed_mps: Option<f64>,
-}
-
-/// The small, fixed-shape capture record. Carries the correction Kirra imposed +
-/// the proposal context + join keys. Deliberately does NOT carry the doer's model
-/// version — Kirra doesn't know it; it is joined Linux-side.
-#[derive(Debug, Clone, Serialize)]
-pub struct CaptureRecord {
-    /// Monotonic per-decision sequence (the join/order key).
-    pub decision_seq: u64,
-    /// Monotonic ns since process start (ordering, skew-free).
-    pub t_mono_ns: u128,
-    /// Wall-clock ms (bus join).
-    pub t_wall_ms: u64,
-    /// Which enforcement point emitted this record (fast loop vs slow loop).
-    pub source: CaptureSource,
-    /// The doer's proposal (correlation + context). Present for the command
-    /// gateway (`CommandGateway`); absent for the slow-loop trajectory record,
-    /// which carries its context in `traj` instead.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub proposed: Option<ProposedCommandSnapshot>,
-    /// Bounded slow-loop trajectory summary + join keys. Present only for
-    /// `SlowLoopTrajectory` records; `None` (and omitted from JSON) for the
-    /// command-gateway record.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub traj: Option<TrajectoryCaptureExt>,
-    /// What Kirra decided.
-    pub outcome: CaptureOutcome,
-    /// Which check fired, if a deny (the `DenyCode` token); `None` otherwise.
-    pub deny_code: Option<&'static str>,
-    /// The safe value Kirra substituted on a clamp (m/s for linear, deg for
-    /// steering); `None` for Allow/Deny.
-    pub safe_value: Option<f64>,
-    /// Controlled-stop substitution (Degraded → decel-to-stop-and-HOLD envelope).
-    pub mrc: bool,
-    /// Posture context.
-    pub posture: &'static str,
-    /// Whether the perception derate was enabled (so passes are attributable).
-    pub derate_enabled: bool,
-}
-
-impl CaptureRecord {
-    /// Build a record from the already-computed verdict + context. Pure; performs
-    /// no I/O. Called at the gateway emit site (off the verdict path).
-    #[must_use]
-    pub fn from_verdict(
-        decision_seq: u64,
-        t_wall_ms: u64,
-        verdict: &EnforceAction,
-        posture: FleetPosture,
-        proposed: &ProposedVehicleCommand,
-        derate_enabled: bool,
-    ) -> Self {
-        let (outcome, deny_code, safe_value) = match verdict {
-            EnforceAction::Allow => (CaptureOutcome::Allow, None, None),
-            EnforceAction::ClampLinear(v) => (CaptureOutcome::ClampLinear, None, Some(*v)),
-            EnforceAction::ClampSteering(d) => (CaptureOutcome::ClampSteering, None, Some(*d)),
-            EnforceAction::DenyBreach(code) => (CaptureOutcome::Deny, Some(code.reason()), None),
-        };
-        Self {
-            decision_seq,
-            t_mono_ns: mono_ns(),
-            t_wall_ms,
-            source: CaptureSource::CommandGateway,
-            proposed: Some(proposed.into()),
-            traj: None,
-            outcome,
-            deny_code,
-            safe_value,
-            // Degraded posture admits commands only through the decel-to-stop-and-HOLD
-            // (MRC) envelope; LockedOut is short-circuited before the gateway verdict.
-            mrc: matches!(posture, FleetPosture::Degraded),
-            posture: posture_token(posture),
-            derate_enabled,
+/// Build a record from the adapter's already-computed slow-loop trajectory
+/// verdict + a BOUNDED trajectory summary. Pure; performs no I/O. Called at the
+/// adapter's slow-loop emit site, OFF the verdict path (after
+/// `validate_trajectory_slow_capped` has already returned).
+///
+/// Verdict → outcome mapping (the slow-loop analogue of `record_from_verdict`):
+///   - `Accept`      → `Allow`        (promoted as-is)
+///   - `Clamp`       → `ClampLinear`  (promoted speed-derated)
+///   - `MrcFallback` → `Deny` (`mrc = true`, `deny_code = TRAJECTORY_MRC_FALLBACK`)
+///
+/// `mrc` is also set whenever the posture is `Degraded` (decel-to-stop
+/// envelope), matching the gateway record's semantics.
+#[must_use]
+pub fn record_from_trajectory_verdict(
+    decision_seq: u64,
+    t_wall_ms: u64,
+    decision: TrajectoryDecision,
+    posture: FleetPosture,
+    traj: TrajectoryCaptureExt,
+    derate_enabled: bool,
+) -> CaptureRecord {
+    let (outcome, deny_code) = match decision {
+        TrajectoryDecision::Accept => (CaptureOutcome::Allow, None),
+        TrajectoryDecision::Clamp => (CaptureOutcome::ClampLinear, None),
+        TrajectoryDecision::MrcFallback => {
+            (CaptureOutcome::Deny, Some("TRAJECTORY_MRC_FALLBACK".to_string()))
         }
-    }
-
-    /// Build a record from the adapter's already-computed slow-loop
-    /// trajectory verdict + a BOUNDED trajectory summary. Pure; performs no
-    /// I/O. Called at the adapter's slow-loop emit site, OFF the verdict path
-    /// (after `validate_trajectory_slow_capped` has already returned).
-    ///
-    /// Verdict → outcome mapping (the slow-loop analogue of `from_verdict`):
-    ///   - `Accept`      → `Allow`        (promoted as-is)
-    ///   - `Clamp`       → `ClampLinear`  (promoted speed-derated)
-    ///   - `MrcFallback` → `Deny` (`mrc = true`, `deny_code = TRAJECTORY_MRC_FALLBACK`)
-    ///
-    /// `mrc` is also set whenever the posture is `Degraded` (decel-to-stop
-    /// envelope), matching the gateway record's semantics.
-    #[must_use]
-    pub fn from_trajectory_verdict(
-        decision_seq: u64,
-        t_wall_ms: u64,
-        decision: TrajectoryDecision,
-        posture: FleetPosture,
-        traj: TrajectoryCaptureExt,
-        derate_enabled: bool,
-    ) -> Self {
-        let (outcome, deny_code) = match decision {
-            TrajectoryDecision::Accept => (CaptureOutcome::Allow, None),
-            TrajectoryDecision::Clamp => (CaptureOutcome::ClampLinear, None),
-            TrajectoryDecision::MrcFallback => {
-                (CaptureOutcome::Deny, Some("TRAJECTORY_MRC_FALLBACK"))
-            }
-        };
-        Self {
-            decision_seq,
-            t_mono_ns: mono_ns(),
-            t_wall_ms,
-            source: CaptureSource::SlowLoopTrajectory,
-            proposed: None,
-            traj: Some(traj),
-            outcome,
-            deny_code,
-            // The slow loop has no single substituted scalar (the correction
-            // is a whole-trajectory derate/refusal); the target speed lives in
-            // the bounded summary instead.
-            safe_value: None,
-            mrc: matches!(decision, TrajectoryDecision::MrcFallback)
-                || matches!(posture, FleetPosture::Degraded),
-            posture: posture_token(posture),
-            derate_enabled,
-        }
+    };
+    CaptureRecord {
+        decision_seq,
+        t_mono_ns: mono_ns(),
+        t_wall_ms,
+        source: CaptureSource::SlowLoopTrajectory,
+        proposed: None,
+        traj: Some(traj),
+        outcome,
+        deny_code,
+        // The slow loop has no single substituted scalar (the correction is a
+        // whole-trajectory derate/refusal); the target speed lives in the
+        // bounded summary instead.
+        safe_value: None,
+        mrc: matches!(decision, TrajectoryDecision::MrcFallback)
+            || matches!(posture, FleetPosture::Degraded),
+        posture: posture_token(posture).to_string(),
+        derate_enabled,
     }
 }
 
@@ -369,29 +276,29 @@ mod tests {
     }
 
     #[test]
-    fn from_verdict_maps_each_arm() {
+    fn record_from_verdict_maps_each_arm() {
         let c = cmd();
-        let allow = CaptureRecord::from_verdict(0, 1000, &EnforceAction::Allow, FleetPosture::Nominal, &c, false);
+        let allow = record_from_verdict(0, 1000, &EnforceAction::Allow, FleetPosture::Nominal, &c, false);
         assert_eq!(allow.outcome, CaptureOutcome::Allow);
         assert_eq!(allow.deny_code, None);
         assert_eq!(allow.safe_value, None);
         assert!(!allow.mrc);
         assert_eq!(allow.posture, "NOMINAL");
 
-        let cl = CaptureRecord::from_verdict(1, 1000, &EnforceAction::ClampLinear(5.0), FleetPosture::Nominal, &c, true);
+        let cl = record_from_verdict(1, 1000, &EnforceAction::ClampLinear(5.0), FleetPosture::Nominal, &c, true);
         assert_eq!(cl.outcome, CaptureOutcome::ClampLinear);
         assert_eq!(cl.safe_value, Some(5.0));
         assert!(cl.derate_enabled);
 
-        let cs = CaptureRecord::from_verdict(2, 1000, &EnforceAction::ClampSteering(3.0), FleetPosture::Degraded, &c, false);
+        let cs = record_from_verdict(2, 1000, &EnforceAction::ClampSteering(3.0), FleetPosture::Degraded, &c, false);
         assert_eq!(cs.outcome, CaptureOutcome::ClampSteering);
         assert_eq!(cs.safe_value, Some(3.0));
         assert!(cs.mrc, "Degraded → MRC envelope");
         assert_eq!(cs.posture, "DEGRADED");
 
-        let dn = CaptureRecord::from_verdict(3, 1000, &EnforceAction::DenyBreach(DenyCode::NanInfLinearVelocity), FleetPosture::Nominal, &c, false);
+        let dn = record_from_verdict(3, 1000, &EnforceAction::DenyBreach(DenyCode::NanInfLinearVelocity), FleetPosture::Nominal, &c, false);
         assert_eq!(dn.outcome, CaptureOutcome::Deny);
-        assert_eq!(dn.deny_code, Some("NAN_INF_LINEAR_VELOCITY"));
+        assert_eq!(dn.deny_code.as_deref(), Some("NAN_INF_LINEAR_VELOCITY"));
         assert_eq!(dn.safe_value, None);
     }
 
@@ -409,8 +316,8 @@ mod tests {
     }
 
     #[test]
-    fn from_trajectory_verdict_maps_each_decision() {
-        let accept = CaptureRecord::from_trajectory_verdict(
+    fn record_from_trajectory_verdict_maps_each_decision() {
+        let accept = record_from_trajectory_verdict(
             0, 1000, TrajectoryDecision::Accept, FleetPosture::Nominal, traj_ext(), false);
         assert_eq!(accept.outcome, CaptureOutcome::Allow);
         assert_eq!(accept.deny_code, None);
@@ -420,20 +327,20 @@ mod tests {
         assert_eq!(accept.traj.as_ref().unwrap().trajectory_id, 7);
         assert_eq!(accept.traj.as_ref().unwrap().objects_ms, 123_456);
 
-        let clamp = CaptureRecord::from_trajectory_verdict(
+        let clamp = record_from_trajectory_verdict(
             1, 1000, TrajectoryDecision::Clamp, FleetPosture::Nominal, traj_ext(), true);
         assert_eq!(clamp.outcome, CaptureOutcome::ClampLinear);
         assert_eq!(clamp.deny_code, None);
         assert!(clamp.derate_enabled);
 
-        let mrc = CaptureRecord::from_trajectory_verdict(
+        let mrc = record_from_trajectory_verdict(
             2, 1000, TrajectoryDecision::MrcFallback, FleetPosture::Nominal, traj_ext(), false);
         assert_eq!(mrc.outcome, CaptureOutcome::Deny);
-        assert_eq!(mrc.deny_code, Some("TRAJECTORY_MRC_FALLBACK"));
+        assert_eq!(mrc.deny_code.as_deref(), Some("TRAJECTORY_MRC_FALLBACK"));
         assert!(mrc.mrc, "MRCFallback → controlled stop");
 
         // Degraded posture forces mrc even on an Accept decision.
-        let degraded = CaptureRecord::from_trajectory_verdict(
+        let degraded = record_from_trajectory_verdict(
             3, 1000, TrajectoryDecision::Accept, FleetPosture::Degraded, traj_ext(), false);
         assert!(degraded.mrc, "Degraded posture → MRC envelope");
         assert_eq!(degraded.posture, "DEGRADED");
@@ -443,15 +350,15 @@ mod tests {
     fn gateway_record_omits_traj_and_keeps_proposed_in_json() {
         // The command-gateway record must serialize WITH `proposed` and
         // WITHOUT `traj` (skip_serializing_if). The trajectory record is the
-        // mirror image.
-        let gw = CaptureRecord::from_verdict(
+        // mirror image. (The wire shape itself is pinned in the schema crate.)
+        let gw = record_from_verdict(
             0, 1, &EnforceAction::Allow, FleetPosture::Nominal, &cmd(), false);
         let gw_json = serde_json::to_string(&gw).unwrap();
         assert!(gw_json.contains("\"source\":\"COMMAND_GATEWAY\""));
         assert!(gw_json.contains("\"proposed\""));
         assert!(!gw_json.contains("\"traj\""), "gateway record omits traj");
 
-        let tj = CaptureRecord::from_trajectory_verdict(
+        let tj = record_from_trajectory_verdict(
             0, 1, TrajectoryDecision::Accept, FleetPosture::Nominal, traj_ext(), false);
         let tj_json = serde_json::to_string(&tj).unwrap();
         assert!(tj_json.contains("\"source\":\"SLOW_LOOP_TRAJECTORY\""));
@@ -474,7 +381,7 @@ mod tests {
         // returns Full; the producer never blocks. Use a 1-slot channel with no
         // drain so it fills immediately.
         let (tx, _rx) = mpsc::channel::<CaptureRecord>(1);
-        let rec = CaptureRecord::from_verdict(0, 1, &EnforceAction::Allow, FleetPosture::Nominal, &cmd(), false);
+        let rec = record_from_verdict(0, 1, &EnforceAction::Allow, FleetPosture::Nominal, &cmd(), false);
         assert!(tx.try_send(rec.clone()).is_ok());
         match tx.try_send(rec) {
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -258,7 +258,7 @@ pub async fn enforce_actuator_safety_envelope(
     // emit): the `KIRRA_CAPTURE_ENABLED` env decides INSTALLATION at startup, so
     // default-off / tests → `get()` is `None` → pure no-op (INV-3).
     if let Some(tx) = svc.app.capture_writer_tx.get() {
-        let rec = crate::capture::CaptureRecord::from_verdict(
+        let rec = crate::capture::record_from_verdict(
             svc.app
                 .capture_decision_seq
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed),


### PR DESCRIPTION
…e A)

Stage A of the learning-loop collector work (docs/COLLECTOR_DESIGN.md [C1]): extract the capture record wire schema into a governor-free crate so the offline collector can reuse the EXACT types without linking the verdict path. Behavior-preserving relocation + re-export; no functional change.

New crate crates/kirra-capture-schema (serde-only dep):
  - The 6 serialized leaf types (CaptureOutcome, CaptureSource, ProposedCommandSnapshot, PoseSnapshot, TrajectoryCaptureExt, CaptureRecord), now deriving Serialize + Deserialize (collector must read them).
  - deny_code: Option<String> and posture: String (were &'static str in the SDK — serde cannot Deserialize &'static str). On-disk JSON is byte-identical; pinned wire-shape + lossless round-trip tests prove it.

src/capture.rs:
  - pub use kirra_capture_schema::*; (every crate::capture::* path still resolves).
  - TrajectoryDecision stays here — it is a constructor INPUT, never serialized.
  - from_verdict / from_trajectory_verdict become free functions record_from_verdict / record_from_trajectory_verdict (orphan rule: the type now lives in another crate). The From<&ProposedVehicleCommand> mapping is inlined into record_from_verdict (same reason) and the impl dropped.

Call sites updated: src/gateway/policy_layer.rs, crates/kirra-ros2-adapter/src/node.rs.
Root Cargo.toml: new workspace member + path dep.

Invariants: verdict-path blob 997fb7ae… unchanged; 509 lib tests + 17 integration tests green; adapter builds; schema crate dep tree is serde-only (no kirra-runtime-sdk) — §0 collector isolation guaranteed by the dependency graph.

Stage B (the kirra-collector binary) follows on this branch.