### PR TITLE
feat(collector): kirra-collector binary — JSONL→join→Parquet (Stage B)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema"]
+members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector"]
 resolver = "2"
 
 [package]

--- a/crates/kirra-collector/Cargo.toml
+++ b/crates/kirra-collector/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "kirra-collector"
+version = "0.1.0"
+edition = "2021"
+description = "Offline learning-loop collector: joins Kirra capture JSONL to a bus recording and writes a training-ready Parquet dataset. Depends on kirra-capture-schema ONLY — never the governor (docs/COLLECTOR_DESIGN.md §0)."
+repository = "https://github.com/justinlooney/kirra-runtime-sdk"
+authors = ["Justin Looney <justin@kirrasystems.io>"]
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+kirra-capture-schema = { path = "../kirra-capture-schema" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+arrow = "58"
+parquet = "58"
+
+[[bin]]
+name = "kirra-collector"
+path = "src/main.rs"

--- a/crates/kirra-collector/src/bag.rs
+++ b/crates/kirra-collector/src/bag.rs
@@ -1,0 +1,98 @@
+// crates/kirra-collector/src/bag.rs
+//
+// The bus side of the join. The collector matches each capture record to a bus
+// message (the doer's proposal/trajectory + perception + a doer-version stamp)
+// recorded during the same bench run, then references the heavy frames by
+// `bulk_ref` rather than copying them (docs/COLLECTOR_DESIGN.md [D2]/[D4]).
+//
+// [C2] The real bag backend (rosbag2 sqlite3 `.db3` vs MCAP) is DEFERRED until
+// the first AWSIM/Autoware session is recorded — the GPU bench isn't up. So bag
+// access sits behind the `BagReader` trait; Phase 1 ships an in-memory /
+// JSON-backed synthetic impl that exercises the whole join → Parquet →
+// reconciliation pipeline with no real bag. A `Db3BagReader` / `McapBagReader`
+// slots in later without touching the join or dataset code.
+
+use serde::{Deserialize, Serialize};
+
+/// One bus message the collector can join against. The heavy payload (full
+/// trajectory points, object lists, sensor frames) is NOT here — it stays in the
+/// bag and is referenced by `bulk_ref`. These are the fields the join needs:
+/// the time stamp, the doer version [D3], the cross-check keys [D2], and the
+/// reference back into the bag.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusMessage {
+    /// Wall-clock ms of the bus message (the join axis against `t_wall_ms`).
+    pub t_wall_ms: u64,
+    /// The doer's model/config version, stamped on the bus side [D3]. Kirra is
+    /// ignorant of this; the collector attaches it here.
+    pub doer_version: String,
+    /// Cross-check key [D2] — the asset id, where the bus message carries one.
+    #[serde(default)]
+    pub asset_id: Option<String>,
+    /// Cross-check key [D2] — the trajectory id, where present.
+    #[serde(default)]
+    pub trajectory_id: Option<u64>,
+    /// Cross-check key [D2] — the objects-snapshot freshness stamp, where present.
+    #[serde(default)]
+    pub objects_ms: Option<u64>,
+    /// Reference into the bag for the heavy frames (uri#offset / topic@stamp).
+    /// This is the `bulk_ref` written into the Parquet row — never the frames.
+    pub bulk_ref: String,
+}
+
+/// The result of a successful join: what the collector attaches to the record.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BusMatch {
+    pub doer_version: String,
+    pub bulk_ref: String,
+    pub matched_t_wall_ms: u64,
+}
+
+/// The bus-recording abstraction. The real implementations (db3/MCAP) are a
+/// Phase-1 follow-up [C2]; everything upstream depends only on this trait.
+pub trait BagReader {
+    /// Provenance — the bag's uri (recorded into `bulk_ref` provenance / logs).
+    fn bag_uri(&self) -> &str;
+    /// All bus messages whose stamp falls within `±window_ms` of `t_wall_ms`.
+    /// Order is not guaranteed; the join picks the best candidate.
+    fn messages_in_window(&self, t_wall_ms: u64, window_ms: u64) -> Vec<BusMessage>;
+}
+
+/// In-memory synthetic bag — Phase 1 tests + offline runs. Loadable from a JSON
+/// array of `BusMessage` (the `--bag-json` path) so the binary is runnable
+/// end-to-end with no real recording.
+pub struct InMemoryBag {
+    uri: String,
+    messages: Vec<BusMessage>,
+}
+
+impl InMemoryBag {
+    #[must_use]
+    pub fn new(uri: impl Into<String>, messages: Vec<BusMessage>) -> Self {
+        Self { uri: uri.into(), messages }
+    }
+
+    /// Load from a JSON file containing an array of `BusMessage`.
+    pub fn from_json_file(path: &std::path::Path) -> std::io::Result<Self> {
+        let bytes = std::fs::read(path)?;
+        let messages: Vec<BusMessage> = serde_json::from_slice(&bytes)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        Ok(Self::new(path.display().to_string(), messages))
+    }
+}
+
+impl BagReader for InMemoryBag {
+    fn bag_uri(&self) -> &str {
+        &self.uri
+    }
+
+    fn messages_in_window(&self, t_wall_ms: u64, window_ms: u64) -> Vec<BusMessage> {
+        let lo = t_wall_ms.saturating_sub(window_ms);
+        let hi = t_wall_ms.saturating_add(window_ms);
+        self.messages
+            .iter()
+            .filter(|m| m.t_wall_ms >= lo && m.t_wall_ms <= hi)
+            .cloned()
+            .collect()
+    }
+}

--- a/crates/kirra-collector/src/dataset.rs
+++ b/crates/kirra-collector/src/dataset.rs
@@ -1,0 +1,250 @@
+// crates/kirra-collector/src/dataset.rs
+//
+// The dataset writer (docs/COLLECTOR_DESIGN.md [D4]). One flat row per kept,
+// joined decision, written as Parquet partitioned `doer_version=<v>/source=<s>/`.
+// The row holds the triple SUMMARY (the proposal/trajectory summary + outcome
+// label + posture + join keys) plus `bulk_ref` — a reference into the bag for the
+// heavy frames. It deliberately has NO column for raw points / object lists /
+// sensor frames: those live in the bag and are NEVER copied into Parquet.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, BooleanArray, Float64Array, StringArray, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
+use parquet::basic::Compression;
+use parquet::file::properties::WriterProperties;
+
+use kirra_capture_schema::CaptureRecord;
+
+use crate::bag::BusMatch;
+use crate::{outcome_token, source_token, CollectorError};
+
+/// One row of the training dataset — the joined summary. Flat (one nullable
+/// column per source-specific field) so it maps directly onto an Arrow batch.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DatasetRow {
+    // --- common (every record) ---
+    pub decision_seq: u64,
+    pub source: String,
+    pub t_wall_ms: u64,
+    /// u128 has no Arrow type; carried as a decimal string (it is an ordering
+    /// key, never arithmetic in the dataset).
+    pub t_mono_ns: String,
+    pub doer_version: String,
+    pub outcome: String,
+    pub deny_code: Option<String>,
+    pub safe_value: Option<f64>,
+    pub mrc: bool,
+    pub posture: String,
+    pub derate_enabled: bool,
+    // --- gateway-only (None on trajectory rows) ---
+    pub proposed_linear_velocity_mps: Option<f64>,
+    pub proposed_current_velocity_mps: Option<f64>,
+    pub proposed_steering_angle_deg: Option<f64>,
+    pub proposed_current_steering_angle_deg: Option<f64>,
+    pub proposed_delta_time_s: Option<f64>,
+    // --- trajectory-only (None on gateway rows) ---
+    pub asset_id: Option<String>,
+    pub trajectory_id: Option<u64>,
+    pub objects_ms: Option<u64>,
+    pub point_count: Option<u64>,
+    pub object_count: Option<u64>,
+    pub first_pose_x_m: Option<f64>,
+    pub first_pose_y_m: Option<f64>,
+    pub first_pose_heading_rad: Option<f64>,
+    pub last_pose_x_m: Option<f64>,
+    pub last_pose_y_m: Option<f64>,
+    pub last_pose_heading_rad: Option<f64>,
+    pub target_speed_mps: Option<f64>,
+    // --- join ---
+    /// Reference into the bag for the heavy frames — NOT the frames themselves.
+    pub bulk_ref: String,
+}
+
+/// Build a dataset row from a record + its bus match. The `doer_version` and
+/// `bulk_ref` come from the bus side [D3]; the rest is the record's own summary.
+#[must_use]
+pub fn build_row(rec: &CaptureRecord, m: &BusMatch) -> DatasetRow {
+    let p = rec.proposed.as_ref();
+    let t = rec.traj.as_ref();
+    DatasetRow {
+        decision_seq: rec.decision_seq,
+        source: source_token(rec.source).to_string(),
+        t_wall_ms: rec.t_wall_ms,
+        t_mono_ns: rec.t_mono_ns.to_string(),
+        doer_version: m.doer_version.clone(),
+        outcome: outcome_token(rec.outcome).to_string(),
+        deny_code: rec.deny_code.clone(),
+        safe_value: rec.safe_value,
+        mrc: rec.mrc,
+        posture: rec.posture.clone(),
+        derate_enabled: rec.derate_enabled,
+        proposed_linear_velocity_mps: p.map(|x| x.linear_velocity_mps),
+        proposed_current_velocity_mps: p.map(|x| x.current_velocity_mps),
+        proposed_steering_angle_deg: p.map(|x| x.steering_angle_deg),
+        proposed_current_steering_angle_deg: p.map(|x| x.current_steering_angle_deg),
+        proposed_delta_time_s: p.map(|x| x.delta_time_s),
+        asset_id: t.map(|x| x.asset_id.clone()),
+        trajectory_id: t.map(|x| x.trajectory_id),
+        objects_ms: t.map(|x| x.objects_ms),
+        point_count: t.map(|x| x.point_count as u64),
+        object_count: t.map(|x| x.object_count as u64),
+        first_pose_x_m: t.and_then(|x| x.first_pose.map(|p| p.x_m)),
+        first_pose_y_m: t.and_then(|x| x.first_pose.map(|p| p.y_m)),
+        first_pose_heading_rad: t.and_then(|x| x.first_pose.map(|p| p.heading_rad)),
+        last_pose_x_m: t.and_then(|x| x.last_pose.map(|p| p.x_m)),
+        last_pose_y_m: t.and_then(|x| x.last_pose.map(|p| p.y_m)),
+        last_pose_heading_rad: t.and_then(|x| x.last_pose.map(|p| p.heading_rad)),
+        target_speed_mps: t.and_then(|x| x.target_speed_mps),
+        bulk_ref: m.bulk_ref.clone(),
+    }
+}
+
+/// The Arrow schema for the dataset. Field order MUST match `build_batch` below.
+#[must_use]
+pub fn dataset_schema() -> SchemaRef {
+    let f = |name: &str, dt: DataType, nullable: bool| Field::new(name, dt, nullable);
+    Arc::new(Schema::new(vec![
+        f("decision_seq", DataType::UInt64, false),
+        f("source", DataType::Utf8, false),
+        f("t_wall_ms", DataType::UInt64, false),
+        f("t_mono_ns", DataType::Utf8, false),
+        f("doer_version", DataType::Utf8, false),
+        f("outcome", DataType::Utf8, false),
+        f("deny_code", DataType::Utf8, true),
+        f("safe_value", DataType::Float64, true),
+        f("mrc", DataType::Boolean, false),
+        f("posture", DataType::Utf8, false),
+        f("derate_enabled", DataType::Boolean, false),
+        f("proposed_linear_velocity_mps", DataType::Float64, true),
+        f("proposed_current_velocity_mps", DataType::Float64, true),
+        f("proposed_steering_angle_deg", DataType::Float64, true),
+        f("proposed_current_steering_angle_deg", DataType::Float64, true),
+        f("proposed_delta_time_s", DataType::Float64, true),
+        f("asset_id", DataType::Utf8, true),
+        f("trajectory_id", DataType::UInt64, true),
+        f("objects_ms", DataType::UInt64, true),
+        f("point_count", DataType::UInt64, true),
+        f("object_count", DataType::UInt64, true),
+        f("first_pose_x_m", DataType::Float64, true),
+        f("first_pose_y_m", DataType::Float64, true),
+        f("first_pose_heading_rad", DataType::Float64, true),
+        f("last_pose_x_m", DataType::Float64, true),
+        f("last_pose_y_m", DataType::Float64, true),
+        f("last_pose_heading_rad", DataType::Float64, true),
+        f("target_speed_mps", DataType::Float64, true),
+        f("bulk_ref", DataType::Utf8, false),
+    ]))
+}
+
+fn build_batch(schema: &SchemaRef, rows: &[&DatasetRow]) -> Result<RecordBatch, CollectorError> {
+    macro_rules! f64_opt {
+        ($field:ident) => {
+            Arc::new(Float64Array::from_iter(rows.iter().map(|r| r.$field))) as ArrayRef
+        };
+    }
+    macro_rules! u64_opt {
+        ($field:ident) => {
+            Arc::new(UInt64Array::from_iter(rows.iter().map(|r| r.$field))) as ArrayRef
+        };
+    }
+    macro_rules! str_opt {
+        ($field:ident) => {
+            Arc::new(StringArray::from_iter(rows.iter().map(|r| r.$field.clone()))) as ArrayRef
+        };
+    }
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(UInt64Array::from_iter_values(rows.iter().map(|r| r.decision_seq))),
+        Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.source.as_str()))),
+        Arc::new(UInt64Array::from_iter_values(rows.iter().map(|r| r.t_wall_ms))),
+        Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.t_mono_ns.as_str()))),
+        Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.doer_version.as_str()))),
+        Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.outcome.as_str()))),
+        str_opt!(deny_code),
+        f64_opt!(safe_value),
+        Arc::new(BooleanArray::from_iter(rows.iter().map(|r| Some(r.mrc)))),
+        Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.posture.as_str()))),
+        Arc::new(BooleanArray::from_iter(rows.iter().map(|r| Some(r.derate_enabled)))),
+        f64_opt!(proposed_linear_velocity_mps),
+        f64_opt!(proposed_current_velocity_mps),
+        f64_opt!(proposed_steering_angle_deg),
+        f64_opt!(proposed_current_steering_angle_deg),
+        f64_opt!(proposed_delta_time_s),
+        str_opt!(asset_id),
+        u64_opt!(trajectory_id),
+        u64_opt!(objects_ms),
+        u64_opt!(point_count),
+        u64_opt!(object_count),
+        f64_opt!(first_pose_x_m),
+        f64_opt!(first_pose_y_m),
+        f64_opt!(first_pose_heading_rad),
+        f64_opt!(last_pose_x_m),
+        f64_opt!(last_pose_y_m),
+        f64_opt!(last_pose_heading_rad),
+        f64_opt!(target_speed_mps),
+        Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.bulk_ref.as_str()))),
+    ];
+    RecordBatch::try_new(Arc::clone(schema), columns).map_err(CollectorError::Arrow)
+}
+
+/// Read back a written Parquet part's column names + total row count. Used by
+/// tests and (Phase 2) join-quality metrics — lets callers verify a dataset
+/// without taking a direct arrow/parquet dependency.
+pub fn read_part_columns_and_rows(path: &Path) -> Result<(Vec<String>, usize), CollectorError> {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    let file = fs::File::open(path).map_err(CollectorError::Io)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(CollectorError::Parquet)?;
+    let columns: Vec<String> = builder.schema().fields().iter().map(|f| f.name().clone()).collect();
+    let reader = builder.build().map_err(CollectorError::Parquet)?;
+    let mut rows = 0usize;
+    for batch in reader {
+        rows += batch.map_err(CollectorError::Arrow)?.num_rows();
+    }
+    Ok((columns, rows))
+}
+
+/// Replace any path-unsafe characters in a partition value with `_`.
+fn sanitize(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') { c } else { '_' })
+        .collect()
+}
+
+/// Write the rows as Parquet, partitioned `doer_version=<v>/source=<s>/`. Returns
+/// the list of part files written. Heavy frames are never materialized — only the
+/// summary columns + `bulk_ref` are.
+pub fn write_dataset(rows: &[DatasetRow], out_dir: &Path) -> Result<Vec<PathBuf>, CollectorError> {
+    let schema = dataset_schema();
+    // Group by (doer_version, source); BTreeMap → deterministic partition order.
+    let mut groups: BTreeMap<(String, String), Vec<&DatasetRow>> = BTreeMap::new();
+    for r in rows {
+        groups.entry((r.doer_version.clone(), r.source.clone())).or_default().push(r);
+    }
+    let mut written = Vec::new();
+    for ((doer_version, source), group) in &groups {
+        let dir = out_dir
+            .join(format!("doer_version={}", sanitize(doer_version)))
+            .join(format!("source={}", sanitize(source)));
+        fs::create_dir_all(&dir).map_err(CollectorError::Io)?;
+        let path = dir.join("part-000.parquet");
+        let batch = build_batch(&schema, group)?;
+        let file = fs::File::create(&path).map_err(CollectorError::Io)?;
+        // UNCOMPRESSED keeps Phase 1 codec-independent + byte-deterministic;
+        // compression is a Phase-2 tuning knob.
+        let props = WriterProperties::builder()
+            .set_compression(Compression::UNCOMPRESSED)
+            .build();
+        let mut writer =
+            ArrowWriter::try_new(file, Arc::clone(&schema), Some(props)).map_err(CollectorError::Parquet)?;
+        writer.write(&batch).map_err(CollectorError::Parquet)?;
+        writer.close().map_err(CollectorError::Parquet)?;
+        written.push(path);
+    }
+    Ok(written)
+}

--- a/crates/kirra-collector/src/join.rs
+++ b/crates/kirra-collector/src/join.rs
@@ -1,0 +1,160 @@
+// crates/kirra-collector/src/join.rs
+//
+// The join (docs/COLLECTOR_DESIGN.md [D2]). For each kept capture record, find
+// the bus message that recorded the same decision: within a `±window_ms`
+// wall-clock window, cross-checked on `asset_id` / `trajectory_id` / `objects_ms`
+// where the record carries them (trajectory records do; gateway records don't).
+// A record with no bus match in the window is an ORPHAN — surfaced by the
+// reconciliation report, never silently dropped.
+
+use kirra_capture_schema::CaptureRecord;
+
+use crate::bag::{BagReader, BusMatch, BusMessage};
+
+/// Outcome of joining one record against the bag.
+#[derive(Debug, Clone, PartialEq)]
+pub enum JoinOutcome {
+    Joined(BusMatch),
+    Orphan,
+}
+
+#[inline]
+fn time_dist(msg: &BusMessage, rec: &CaptureRecord) -> u64 {
+    msg.t_wall_ms.abs_diff(rec.t_wall_ms)
+}
+
+/// Do a candidate bus message's cross-check keys agree with this record's
+/// trajectory summary? A `None` on the bus side is treated as "not asserted"
+/// (does not veto); only a present-and-DIFFERENT key disqualifies. This keeps
+/// the join robust to partial bus stamping while still rejecting mismatches.
+fn keys_agree(msg: &BusMessage, rec: &CaptureRecord) -> bool {
+    let Some(t) = rec.traj.as_ref() else {
+        return true; // gateway records have no cross-check keys
+    };
+    let asset_ok = msg.asset_id.as_deref().map_or(true, |a| a == t.asset_id);
+    let traj_ok = msg.trajectory_id.map_or(true, |id| id == t.trajectory_id);
+    let objs_ok = msg.objects_ms.map_or(true, |o| o == t.objects_ms);
+    asset_ok && traj_ok && objs_ok
+}
+
+/// Join one record. Prefers candidates whose cross-check keys agree; among
+/// those, the nearest in time. Falls back to nearest-in-time only if NO
+/// key-agreeing candidate exists (so a stray bus message with a wrong id never
+/// wins over a correct one, but the join still lands when keys are unstamped).
+#[must_use]
+pub fn join_record(rec: &CaptureRecord, bag: &dyn BagReader, window_ms: u64) -> JoinOutcome {
+    let candidates = bag.messages_in_window(rec.t_wall_ms, window_ms);
+    if candidates.is_empty() {
+        return JoinOutcome::Orphan;
+    }
+    let best = candidates
+        .iter()
+        .filter(|m| keys_agree(m, rec))
+        .min_by_key(|m| time_dist(m, rec))
+        .or_else(|| candidates.iter().min_by_key(|m| time_dist(m, rec)));
+    match best {
+        Some(m) => JoinOutcome::Joined(BusMatch {
+            doer_version: m.doer_version.clone(),
+            bulk_ref: m.bulk_ref.clone(),
+            matched_t_wall_ms: m.t_wall_ms,
+        }),
+        None => JoinOutcome::Orphan,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bag::InMemoryBag;
+    use kirra_capture_schema::{CaptureOutcome, CaptureRecord, CaptureSource, TrajectoryCaptureExt};
+
+    fn gw(seq: u64, t_wall_ms: u64) -> CaptureRecord {
+        CaptureRecord {
+            decision_seq: seq,
+            t_mono_ns: 0,
+            t_wall_ms,
+            source: CaptureSource::CommandGateway,
+            proposed: None,
+            traj: None,
+            outcome: CaptureOutcome::Allow,
+            deny_code: None,
+            safe_value: None,
+            mrc: false,
+            posture: "NOMINAL".to_string(),
+            derate_enabled: false,
+        }
+    }
+
+    fn traj_rec(seq: u64, t_wall_ms: u64, traj_id: u64) -> CaptureRecord {
+        CaptureRecord {
+            decision_seq: seq,
+            t_mono_ns: 0,
+            t_wall_ms,
+            source: CaptureSource::SlowLoopTrajectory,
+            proposed: None,
+            traj: Some(TrajectoryCaptureExt {
+                asset_id: "ego".to_string(),
+                trajectory_id: traj_id,
+                objects_ms: 500,
+                point_count: 3,
+                object_count: 1,
+                first_pose: None,
+                last_pose: None,
+                target_speed_mps: Some(8.0),
+            }),
+            outcome: CaptureOutcome::Allow,
+            deny_code: None,
+            safe_value: None,
+            mrc: false,
+            posture: "NOMINAL".to_string(),
+            derate_enabled: false,
+        }
+    }
+
+    fn msg(t: u64, ver: &str, traj_id: Option<u64>, reff: &str) -> BusMessage {
+        BusMessage {
+            t_wall_ms: t,
+            doer_version: ver.to_string(),
+            asset_id: traj_id.map(|_| "ego".to_string()),
+            trajectory_id: traj_id,
+            objects_ms: traj_id.map(|_| 500),
+            bulk_ref: reff.to_string(),
+        }
+    }
+
+    #[test]
+    fn orphan_when_no_message_in_window() {
+        let bag = InMemoryBag::new("test", vec![msg(10_000, "v1", None, "a")]);
+        assert_eq!(join_record(&gw(0, 1000), &bag, 100), JoinOutcome::Orphan);
+    }
+
+    #[test]
+    fn nearest_in_time_wins_for_gateway() {
+        let bag = InMemoryBag::new(
+            "test",
+            vec![msg(1050, "v1", None, "far"), msg(1010, "v2", None, "near")],
+        );
+        let JoinOutcome::Joined(m) = join_record(&gw(0, 1000), &bag, 100) else {
+            panic!("expected join");
+        };
+        assert_eq!(m.bulk_ref, "near");
+        assert_eq!(m.doer_version, "v2");
+    }
+
+    #[test]
+    fn key_agreeing_candidate_beats_a_closer_mismatch() {
+        // A closer message with the WRONG trajectory id must lose to a slightly
+        // farther one whose keys agree.
+        let bag = InMemoryBag::new(
+            "test",
+            vec![
+                msg(1005, "wrong", Some(999), "wrong_keys"),
+                msg(1020, "right", Some(42), "right_keys"),
+            ],
+        );
+        let JoinOutcome::Joined(m) = join_record(&traj_rec(0, 1000, 42), &bag, 100) else {
+            panic!("expected join");
+        };
+        assert_eq!(m.bulk_ref, "right_keys", "key agreement must outrank time proximity");
+    }
+}

--- a/crates/kirra-collector/src/lib.rs
+++ b/crates/kirra-collector/src/lib.rs
@@ -1,0 +1,229 @@
+// crates/kirra-collector/src/lib.rs
+//
+// kirra-collector — the OFFLINE learning-loop collector (docs/COLLECTOR_DESIGN.md).
+// It reads the two dark capture JSONL streams, keeps every intervention while
+// sampling passes [D5], joins each kept record to a bus recording [D2], attaches
+// the doer's model version [D3], and writes a training-ready Parquet dataset [D4]
+// with a reconciliation report.
+//
+// §0 SAFETY BOUNDARY: this crate depends on `kirra-capture-schema` ONLY (plus
+// serde / arrow / parquet) — NEVER on `kirra-runtime-sdk`. It is offline,
+// out-of-vehicle, produces only a dataset, and is mechanically incapable of
+// linking or reaching the verdict path. `cargo tree -p kirra-collector` is the
+// enforced check.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+use kirra_capture_schema::{CaptureOutcome, CaptureRecord, CaptureSource};
+
+pub mod bag;
+pub mod dataset;
+pub mod join;
+pub mod reconcile;
+pub mod sample;
+
+use bag::BagReader;
+use join::JoinOutcome;
+use reconcile::Reconciliation;
+
+/// Stable string token for a capture source — the partition value and join key.
+#[must_use]
+pub fn source_token(s: CaptureSource) -> &'static str {
+    match s {
+        CaptureSource::CommandGateway => "COMMAND_GATEWAY",
+        CaptureSource::SlowLoopTrajectory => "SLOW_LOOP_TRAJECTORY",
+    }
+}
+
+/// Stable string token for an outcome — the dataset's training label. Matches the
+/// schema crate's SCREAMING_SNAKE serde rename so labels are consistent on disk.
+#[must_use]
+pub fn outcome_token(o: CaptureOutcome) -> &'static str {
+    match o {
+        CaptureOutcome::Allow => "ALLOW",
+        CaptureOutcome::ClampLinear => "CLAMP_LINEAR",
+        CaptureOutcome::ClampSteering => "CLAMP_STEERING",
+        CaptureOutcome::Deny => "DENY",
+    }
+}
+
+/// Collector run configuration (the CLI flags, or a test's choices).
+#[derive(Debug, Clone)]
+pub struct CollectorConfig {
+    /// Pass-sampling rate in [0, 1]; 1.0 keeps every pass [D5].
+    pub pass_rate: f64,
+    /// Join window (± ms) around each record's `t_wall_ms` [D2].
+    pub window_ms: u64,
+    /// Fail the run if the orphan rate exceeds this (data-quality gate).
+    pub max_orphan_rate: f64,
+    /// Output dataset root; partitions are written beneath it.
+    pub out_dir: PathBuf,
+}
+
+/// Errors the collector can fail with.
+#[derive(Debug)]
+pub enum CollectorError {
+    Io(std::io::Error),
+    Arrow(arrow::error::ArrowError),
+    Parquet(parquet::errors::ParquetError),
+    /// The orphan rate exceeded `max_orphan_rate`. The dataset was still written;
+    /// the reconciliation is carried so the caller can report it.
+    OrphanRateExceeded { recon: Box<Reconciliation>, max: f64 },
+}
+
+impl std::fmt::Display for CollectorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CollectorError::Io(e) => write!(f, "io error: {e}"),
+            CollectorError::Arrow(e) => write!(f, "arrow error: {e}"),
+            CollectorError::Parquet(e) => write!(f, "parquet error: {e}"),
+            CollectorError::OrphanRateExceeded { recon, max } => write!(
+                f,
+                "orphan rate {:.3} exceeds ceiling {:.3} ({} of {} kept records unjoined)",
+                recon.orphan_rate, max, recon.orphans, recon.kept_after_sampling
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CollectorError {}
+
+/// Read capture records from one or more JSONL files. Blank lines are skipped;
+/// malformed lines are logged to stderr and skipped (a single bad line never
+/// aborts a whole session's ingest).
+pub fn read_jsonl(paths: &[PathBuf]) -> std::io::Result<Vec<CaptureRecord>> {
+    let mut out = Vec::new();
+    for path in paths {
+        let file = File::open(path)?;
+        for (lineno, line) in BufReader::new(file).lines().enumerate() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<CaptureRecord>(&line) {
+                Ok(rec) => out.push(rec),
+                Err(e) => eprintln!(
+                    "warn: skipping malformed capture line {}:{}: {e}",
+                    path.display(),
+                    lineno + 1
+                ),
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Deduplicate by `(source, decision_seq)` (the primary key [D2]) and return a
+/// stably-ordered vec plus the count of duplicates dropped. First occurrence
+/// wins; BTreeMap gives a deterministic `(source, decision_seq)` ordering so the
+/// dataset is reproducible.
+#[must_use]
+pub fn index_dedup(records: Vec<CaptureRecord>) -> (Vec<CaptureRecord>, usize) {
+    let mut map: BTreeMap<(&'static str, u64), CaptureRecord> = BTreeMap::new();
+    let mut duplicates = 0usize;
+    for rec in records {
+        let key = (source_token(rec.source), rec.decision_seq);
+        if map.contains_key(&key) {
+            duplicates += 1;
+            continue;
+        }
+        map.insert(key, rec);
+    }
+    (map.into_values().collect(), duplicates)
+}
+
+/// The whole pipeline: dedup → stratified sample → join → write Parquet →
+/// reconcile. Writes the dataset under `cfg.out_dir` and returns the
+/// reconciliation. Fails (after writing) if the orphan rate exceeds the ceiling.
+pub fn run(
+    records: Vec<CaptureRecord>,
+    bag: &dyn BagReader,
+    cfg: &CollectorConfig,
+) -> Result<Reconciliation, CollectorError> {
+    let (deduped, duplicates_dropped) = index_dedup(records);
+
+    let mut recon = Reconciliation {
+        records_in: deduped.len(),
+        duplicates_dropped,
+        records_in_command_gateway: 0,
+        records_in_slow_loop_trajectory: 0,
+        interventions_in: 0,
+        passes_in: 0,
+        kept_after_sampling: 0,
+        interventions_kept: 0,
+        passes_kept: 0,
+        joined: 0,
+        orphans: 0,
+        applied_pass_rate: cfg.pass_rate,
+        orphan_rate: 0.0,
+    };
+
+    let mut rows = Vec::new();
+    for rec in &deduped {
+        match rec.source {
+            CaptureSource::CommandGateway => recon.records_in_command_gateway += 1,
+            CaptureSource::SlowLoopTrajectory => recon.records_in_slow_loop_trajectory += 1,
+        }
+        let intervention = sample::is_intervention(rec);
+        if intervention {
+            recon.interventions_in += 1;
+        } else {
+            recon.passes_in += 1;
+        }
+
+        if !sample::keep(rec, cfg.pass_rate) {
+            continue;
+        }
+        recon.kept_after_sampling += 1;
+        if intervention {
+            recon.interventions_kept += 1;
+        } else {
+            recon.passes_kept += 1;
+        }
+
+        match join::join_record(rec, bag, cfg.window_ms) {
+            JoinOutcome::Joined(m) => {
+                recon.joined += 1;
+                rows.push(dataset::build_row(rec, &m));
+            }
+            JoinOutcome::Orphan => recon.orphans += 1,
+        }
+    }
+
+    dataset::write_dataset(&rows, &cfg.out_dir)?;
+    recon.orphan_rate = recon.orphan_rate();
+
+    if recon.orphan_rate > cfg.max_orphan_rate {
+        return Err(CollectorError::OrphanRateExceeded {
+            recon: Box::new(recon),
+            max: cfg.max_orphan_rate,
+        });
+    }
+    Ok(recon)
+}
+
+/// Convenience: list the part files under a dataset root (sorted), for callers
+/// that want to enumerate what was written.
+pub fn list_parquet_parts(out_dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut parts = Vec::new();
+    fn walk(dir: &Path, parts: &mut Vec<PathBuf>) -> std::io::Result<()> {
+        if !dir.is_dir() {
+            return Ok(());
+        }
+        for entry in std::fs::read_dir(dir)? {
+            let path = entry?.path();
+            if path.is_dir() {
+                walk(&path, parts)?;
+            } else if path.extension().is_some_and(|e| e == "parquet") {
+                parts.push(path);
+            }
+        }
+        Ok(())
+    }
+    walk(out_dir, &mut parts)?;
+    parts.sort();
+    Ok(parts)
+}

--- a/crates/kirra-collector/src/main.rs
+++ b/crates/kirra-collector/src/main.rs
@@ -1,0 +1,159 @@
+// crates/kirra-collector/src/main.rs
+//
+// CLI entry for the offline learning-loop collector. Thin wrapper over the
+// library pipeline (`kirra_collector::run`).
+//
+// Usage:
+//   kirra-collector --capture <a.jsonl> [--capture <b.jsonl> ...] \
+//                   (--bag-json <bus.json> | --bag <bag.db3|.mcap>) \
+//                   --out <dataset_dir> \
+//                   [--pass-rate 1.0] [--window-ms 100] [--max-orphan-rate 0.05]
+//
+// [C2] The real `--bag` backend (rosbag2 db3 / MCAP) is not wired yet (the bench
+// isn't up); `--bag-json` reads a JSON array of bus messages so the tool runs
+// end-to-end offline today.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use kirra_collector::bag::InMemoryBag;
+use kirra_collector::{read_jsonl, run, CollectorConfig, CollectorError};
+
+struct Args {
+    captures: Vec<PathBuf>,
+    bag_json: Option<PathBuf>,
+    bag_real: Option<PathBuf>,
+    out: Option<PathBuf>,
+    pass_rate: f64,
+    window_ms: u64,
+    max_orphan_rate: f64,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            captures: Vec::new(),
+            bag_json: None,
+            bag_real: None,
+            out: None,
+            pass_rate: 1.0,
+            window_ms: 100,
+            max_orphan_rate: 0.05,
+        }
+    }
+}
+
+const USAGE: &str = "\
+kirra-collector — offline learning-loop collector
+
+  --capture <path>          capture JSONL (repeatable; at least one required)
+  --bag-json <path>         synthetic bus recording (JSON array of bus messages)
+  --bag <path>              real rosbag2 db3/MCAP backend (NOT yet wired — C2)
+  --out <dir>               output dataset root (required)
+  --pass-rate <f64>         ALLOW sampling rate, default 1.0 (keep all)
+  --window-ms <u64>         join window ± ms, default 100
+  --max-orphan-rate <f64>   fail if exceeded, default 0.05
+  -h, --help                this help";
+
+fn parse_args() -> Result<Args, String> {
+    let mut args = Args::default();
+    let mut it = std::env::args().skip(1);
+    while let Some(flag) = it.next() {
+        let mut next = |name: &str| it.next().ok_or_else(|| format!("{name} needs a value"));
+        match flag.as_str() {
+            "--capture" => args.captures.push(PathBuf::from(next("--capture")?)),
+            "--bag-json" => args.bag_json = Some(PathBuf::from(next("--bag-json")?)),
+            "--bag" => args.bag_real = Some(PathBuf::from(next("--bag")?)),
+            "--out" => args.out = Some(PathBuf::from(next("--out")?)),
+            "--pass-rate" => {
+                args.pass_rate = next("--pass-rate")?.parse().map_err(|e| format!("--pass-rate: {e}"))?
+            }
+            "--window-ms" => {
+                args.window_ms = next("--window-ms")?.parse().map_err(|e| format!("--window-ms: {e}"))?
+            }
+            "--max-orphan-rate" => {
+                args.max_orphan_rate =
+                    next("--max-orphan-rate")?.parse().map_err(|e| format!("--max-orphan-rate: {e}"))?
+            }
+            "-h" | "--help" => {
+                println!("{USAGE}");
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+    if args.captures.is_empty() {
+        return Err("at least one --capture is required".to_string());
+    }
+    if args.out.is_none() {
+        return Err("--out is required".to_string());
+    }
+    if args.bag_json.is_none() && args.bag_real.is_none() {
+        return Err("one of --bag-json or --bag is required".to_string());
+    }
+    Ok(args)
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {e}\n\n{USAGE}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // [C2] real bag backend deferred until the bench records its first session.
+    if let Some(p) = &args.bag_real {
+        eprintln!(
+            "error: --bag {} — the rosbag2 db3/MCAP backend is not wired yet (C2, \
+             bench not up). Use --bag-json for offline runs.",
+            p.display()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let bag = match InMemoryBag::from_json_file(args.bag_json.as_ref().unwrap()) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("error: reading --bag-json: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let records = match read_jsonl(&args.captures) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: reading capture JSONL: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let cfg = CollectorConfig {
+        pass_rate: args.pass_rate,
+        window_ms: args.window_ms,
+        max_orphan_rate: args.max_orphan_rate,
+        out_dir: args.out.unwrap(),
+    };
+
+    match run(records, &bag, &cfg) {
+        Ok(recon) => {
+            println!("{}", recon.summary());
+            println!("{}", serde_json::to_string(&recon).unwrap());
+            ExitCode::SUCCESS
+        }
+        Err(CollectorError::OrphanRateExceeded { recon, max }) => {
+            println!("{}", recon.summary());
+            eprintln!(
+                "error: orphan rate {:.3} exceeds --max-orphan-rate {:.3} — dataset written but \
+                 flagged for review",
+                recon.orphan_rate, max
+            );
+            ExitCode::FAILURE
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/kirra-collector/src/reconcile.rs
+++ b/crates/kirra-collector/src/reconcile.rs
@@ -1,0 +1,74 @@
+// crates/kirra-collector/src/reconcile.rs
+//
+// The reconciliation report (docs/COLLECTOR_DESIGN.md §4): the audit that the
+// dataset faithfully represents the run. It accounts for every record — in,
+// kept after sampling, joined, orphaned — and the applied pass rate, so a bench
+// session can be validated ("every clamp/deny/MRC present; pass count matches
+// the sampling rate; join hit-rate reported; orphans flagged"). If the orphan
+// rate exceeds the configured ceiling, the run fails loud rather than silently
+// emitting a half-joined dataset.
+
+use serde::Serialize;
+
+/// A full accounting of one collector run.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Reconciliation {
+    /// Total deduplicated capture records read.
+    pub records_in: usize,
+    /// Duplicate `(source, decision_seq)` lines dropped at ingest.
+    pub duplicates_dropped: usize,
+    pub records_in_command_gateway: usize,
+    pub records_in_slow_loop_trajectory: usize,
+    /// Records that are interventions (outcome != ALLOW) — never sampled out.
+    pub interventions_in: usize,
+    /// Records that are passes (outcome == ALLOW) — subject to sampling.
+    pub passes_in: usize,
+    /// Records kept after stratified sampling (interventions + sampled passes).
+    pub kept_after_sampling: usize,
+    pub interventions_kept: usize,
+    pub passes_kept: usize,
+    /// Kept records that joined to a bus message.
+    pub joined: usize,
+    /// Kept records with no bus match in the window.
+    pub orphans: usize,
+    /// The pass rate actually applied.
+    pub applied_pass_rate: f64,
+    /// `orphans / kept_after_sampling` (0.0 when nothing was kept).
+    pub orphan_rate: f64,
+}
+
+impl Reconciliation {
+    #[must_use]
+    pub fn orphan_rate(&self) -> f64 {
+        if self.kept_after_sampling == 0 {
+            0.0
+        } else {
+            self.orphans as f64 / self.kept_after_sampling as f64
+        }
+    }
+
+    /// Human-readable one-block summary for the CLI.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        format!(
+            "reconciliation:\n  \
+             records_in            = {} (gateway {}, trajectory {}; {} duplicate(s) dropped)\n  \
+             interventions / passes= {} / {}\n  \
+             kept_after_sampling   = {} (interventions {}, passes {}; pass_rate {:.3})\n  \
+             joined / orphans      = {} / {} (orphan_rate {:.3})",
+            self.records_in,
+            self.records_in_command_gateway,
+            self.records_in_slow_loop_trajectory,
+            self.duplicates_dropped,
+            self.interventions_in,
+            self.passes_in,
+            self.kept_after_sampling,
+            self.interventions_kept,
+            self.passes_kept,
+            self.applied_pass_rate,
+            self.joined,
+            self.orphans,
+            self.orphan_rate,
+        )
+    }
+}

--- a/crates/kirra-collector/src/sample.rs
+++ b/crates/kirra-collector/src/sample.rs
@@ -1,0 +1,101 @@
+// crates/kirra-collector/src/sample.rs
+//
+// Stratified pass-sampling (docs/COLLECTOR_DESIGN.md [D5]). Selection bias is the
+// trap: training only on corrections teaches the wrong thing. So the collector
+// keeps EVERY intervention (clamp / steering-clamp / deny / MRC) unconditionally,
+// and samples the abundant ALLOW ("pass") records at a configurable `pass_rate`
+// (bench default 1.0 = keep everything).
+//
+// The sampling is DETERMINISTIC — a stable hash of `(source, decision_seq)` maps
+// each record to a fixed value in [0, 1), kept iff that value < `pass_rate`. This
+// makes a dataset reproducible (same inputs + rate → same rows) and lets the
+// reconciliation counts be asserted exactly in tests, rather than relying on a
+// random seed.
+
+use kirra_capture_schema::{CaptureOutcome, CaptureRecord};
+
+use crate::source_token;
+
+/// A record is an "intervention" iff Kirra did anything other than allow it.
+/// These are NEVER sampled out — they are the rare, valuable corrective signal.
+#[must_use]
+pub fn is_intervention(rec: &CaptureRecord) -> bool {
+    rec.outcome != CaptureOutcome::Allow
+}
+
+/// Deterministic per-record sample value in `[0, 1)`. FNV-1a over the join key
+/// `(source, decision_seq)`, folded to a 53-bit mantissa for a uniform double.
+#[must_use]
+pub fn sample_value(rec: &CaptureRecord) -> f64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut h = FNV_OFFSET;
+    for b in source_token(rec.source).as_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    for b in rec.decision_seq.to_le_bytes() {
+        h ^= u64::from(b);
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    // Top 53 bits → uniform in [0, 1). Strictly < 1.0, so pass_rate = 1.0 keeps
+    // every pass and pass_rate = 0.0 keeps none.
+    ((h >> 11) as f64) / ((1u64 << 53) as f64)
+}
+
+/// The stratified keep decision: all interventions, plus passes whose
+/// deterministic sample value is below `pass_rate`.
+#[must_use]
+pub fn keep(rec: &CaptureRecord, pass_rate: f64) -> bool {
+    is_intervention(rec) || sample_value(rec) < pass_rate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kirra_capture_schema::{CaptureRecord, CaptureSource};
+
+    fn rec(seq: u64, outcome: CaptureOutcome) -> CaptureRecord {
+        CaptureRecord {
+            decision_seq: seq,
+            t_mono_ns: 0,
+            t_wall_ms: 0,
+            source: CaptureSource::CommandGateway,
+            proposed: None,
+            traj: None,
+            outcome,
+            deny_code: None,
+            safe_value: None,
+            mrc: false,
+            posture: "NOMINAL".to_string(),
+            derate_enabled: false,
+        }
+    }
+
+    #[test]
+    fn sample_value_is_in_unit_interval_and_deterministic() {
+        for seq in 0..1000 {
+            let v = sample_value(&rec(seq, CaptureOutcome::Allow));
+            assert!((0.0..1.0).contains(&v), "value {v} out of [0,1)");
+            // stable across calls
+            assert_eq!(v, sample_value(&rec(seq, CaptureOutcome::Allow)));
+        }
+    }
+
+    #[test]
+    fn rate_one_keeps_all_passes_rate_zero_keeps_none() {
+        for seq in 0..1000 {
+            let r = rec(seq, CaptureOutcome::Allow);
+            assert!(keep(&r, 1.0), "pass_rate 1.0 must keep every pass");
+            assert!(!keep(&r, 0.0), "pass_rate 0.0 must drop every pass");
+        }
+    }
+
+    #[test]
+    fn interventions_are_never_sampled_out() {
+        for outcome in [CaptureOutcome::ClampLinear, CaptureOutcome::ClampSteering, CaptureOutcome::Deny] {
+            let r = rec(7, outcome);
+            assert!(keep(&r, 0.0), "intervention must survive even at pass_rate 0.0");
+        }
+    }
+}

--- a/crates/kirra-collector/tests/pipeline.rs
+++ b/crates/kirra-collector/tests/pipeline.rs
@@ -1,0 +1,297 @@
+// crates/kirra-collector/tests/pipeline.rs
+//
+// STEP B2 — drive the WHOLE collector pipeline (ingest → stratified sampling →
+// join → Parquet → reconciliation) against SYNTHETIC fixtures: hand-built
+// capture records for both sources + an in-memory bag. No real rosbag needed
+// (C2/C4 deferred until the GPU bench is up).
+//
+// Asserts: join hit/orphan counts; stratified sampling keeps every intervention
+// and samples passes; Parquet partitions by doer_version/source; bulk_ref present
+// and heavy frames absent; the orphan-rate gate fails loud.
+
+use std::path::{Path, PathBuf};
+
+use kirra_capture_schema::{
+    CaptureOutcome, CaptureRecord, CaptureSource, PoseSnapshot, ProposedCommandSnapshot,
+    TrajectoryCaptureExt,
+};
+use kirra_collector::bag::{BusMessage, InMemoryBag};
+use kirra_collector::dataset::read_part_columns_and_rows;
+use kirra_collector::{list_parquet_parts, run, CollectorConfig, CollectorError};
+
+// ---- fixtures --------------------------------------------------------------
+
+fn gateway(seq: u64, t_wall_ms: u64, outcome: CaptureOutcome) -> CaptureRecord {
+    CaptureRecord {
+        decision_seq: seq,
+        t_mono_ns: u128::from(seq) * 1000,
+        t_wall_ms,
+        source: CaptureSource::CommandGateway,
+        proposed: Some(ProposedCommandSnapshot {
+            linear_velocity_mps: 40.0,
+            current_velocity_mps: 40.0,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+            delta_time_s: 0.1,
+        }),
+        traj: None,
+        outcome,
+        deny_code: matches!(outcome, CaptureOutcome::Deny).then(|| "NAN_INF_LINEAR_VELOCITY".to_string()),
+        safe_value: matches!(outcome, CaptureOutcome::ClampLinear).then_some(35.0),
+        mrc: false,
+        posture: "NOMINAL".to_string(),
+        derate_enabled: false,
+    }
+}
+
+fn trajectory(seq: u64, t_wall_ms: u64, traj_id: u64, outcome: CaptureOutcome) -> CaptureRecord {
+    CaptureRecord {
+        decision_seq: seq,
+        t_mono_ns: u128::from(seq) * 1000,
+        t_wall_ms,
+        source: CaptureSource::SlowLoopTrajectory,
+        proposed: None,
+        traj: Some(TrajectoryCaptureExt {
+            asset_id: "ego".to_string(),
+            trajectory_id: traj_id,
+            objects_ms: 500,
+            point_count: 12,
+            object_count: 3,
+            first_pose: Some(PoseSnapshot { x_m: 0.0, y_m: 0.0, heading_rad: 0.0 }),
+            last_pose: Some(PoseSnapshot { x_m: 5.0, y_m: 1.0, heading_rad: 0.1 }),
+            target_speed_mps: Some(8.0),
+        }),
+        outcome,
+        deny_code: matches!(outcome, CaptureOutcome::Deny).then(|| "TRAJECTORY_MRC_FALLBACK".to_string()),
+        safe_value: None,
+        mrc: matches!(outcome, CaptureOutcome::Deny),
+        posture: "NOMINAL".to_string(),
+        derate_enabled: false,
+    }
+}
+
+fn bus_msg(t_wall_ms: u64, ver: &str, traj_id: Option<u64>, reff: &str) -> BusMessage {
+    BusMessage {
+        t_wall_ms,
+        doer_version: ver.to_string(),
+        asset_id: traj_id.map(|_| "ego".to_string()),
+        trajectory_id: traj_id,
+        objects_ms: traj_id.map(|_| 500),
+        bulk_ref: reff.to_string(),
+    }
+}
+
+fn unique_out(tag: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("kirra-collector-test-{tag}-{nanos}"))
+}
+
+/// The dataset's full column set — pinning this proves NO raw frame/point/object
+/// payload column exists (only counts + endpoint poses + bulk_ref).
+const EXPECTED_COLUMNS: &[&str] = &[
+    "decision_seq", "source", "t_wall_ms", "t_mono_ns", "doer_version", "outcome", "deny_code",
+    "safe_value", "mrc", "posture", "derate_enabled", "proposed_linear_velocity_mps",
+    "proposed_current_velocity_mps", "proposed_steering_angle_deg",
+    "proposed_current_steering_angle_deg", "proposed_delta_time_s", "asset_id", "trajectory_id",
+    "objects_ms", "point_count", "object_count", "first_pose_x_m", "first_pose_y_m",
+    "first_pose_heading_rad", "last_pose_x_m", "last_pose_y_m", "last_pose_heading_rad",
+    "target_speed_mps", "bulk_ref",
+];
+
+// ---- tests -----------------------------------------------------------------
+
+#[test]
+fn happy_path_joins_both_sources_and_partitions() {
+    let out = unique_out("happy");
+    let records = vec![
+        gateway(0, 1000, CaptureOutcome::Allow),
+        gateway(1, 1100, CaptureOutcome::ClampLinear),
+        trajectory(0, 2000, 42, CaptureOutcome::Allow),
+        trajectory(1, 2100, 43, CaptureOutcome::Deny),
+    ];
+    let bag = InMemoryBag::new(
+        "synthetic",
+        vec![
+            bus_msg(1005, "model_v1", None, "bag#gw0"),
+            bus_msg(1105, "model_v1", None, "bag#gw1"),
+            bus_msg(2005, "model_v1", Some(42), "bag#tj0"),
+            bus_msg(2105, "model_v1", Some(43), "bag#tj1"),
+        ],
+    );
+    let cfg = CollectorConfig {
+        pass_rate: 1.0,
+        window_ms: 100,
+        max_orphan_rate: 0.0,
+        out_dir: out.clone(),
+    };
+
+    let recon = run(records, &bag, &cfg).expect("run should succeed");
+    assert_eq!(recon.records_in, 4);
+    assert_eq!(recon.records_in_command_gateway, 2);
+    assert_eq!(recon.records_in_slow_loop_trajectory, 2);
+    assert_eq!(recon.interventions_in, 2, "clamp + deny");
+    assert_eq!(recon.passes_in, 2, "allow + accept");
+    assert_eq!(recon.kept_after_sampling, 4, "pass_rate 1.0 keeps all");
+    assert_eq!(recon.joined, 4);
+    assert_eq!(recon.orphans, 0);
+    assert_eq!(recon.orphan_rate, 0.0);
+
+    // Two partitions: one per source, both under doer_version=model_v1.
+    let gw_part = out.join("doer_version=model_v1/source=COMMAND_GATEWAY/part-000.parquet");
+    let tj_part = out.join("doer_version=model_v1/source=SLOW_LOOP_TRAJECTORY/part-000.parquet");
+    assert!(gw_part.exists(), "gateway partition must exist at {gw_part:?}");
+    assert!(tj_part.exists(), "trajectory partition must exist at {tj_part:?}");
+
+    let (cols, rows) = read_part_columns_and_rows(&gw_part).unwrap();
+    assert_eq!(rows, 2, "two gateway rows");
+    assert_eq!(cols, EXPECTED_COLUMNS, "schema must be exactly the summary columns");
+    assert!(cols.contains(&"bulk_ref".to_string()), "bulk_ref present");
+    // Heavy frames absent: no raw payload columns, only counts + endpoints.
+    for forbidden in ["points", "objects", "object_list", "frame", "frames", "trajectory_points"] {
+        assert!(!cols.iter().any(|c| c == forbidden), "no raw `{forbidden}` column");
+    }
+
+    let (_cols, tj_rows) = read_part_columns_and_rows(&tj_part).unwrap();
+    assert_eq!(tj_rows, 2, "two trajectory rows");
+
+    cleanup(&out);
+}
+
+#[test]
+fn stratified_sampling_keeps_interventions_drops_passes_at_zero_rate() {
+    let out = unique_out("sample0");
+    let records = vec![
+        gateway(0, 1000, CaptureOutcome::Allow),       // pass → dropped at 0.0
+        gateway(1, 1100, CaptureOutcome::ClampLinear), // intervention → kept
+        trajectory(0, 2000, 42, CaptureOutcome::Allow), // pass → dropped
+        trajectory(1, 2100, 43, CaptureOutcome::Deny),  // intervention → kept
+    ];
+    let bag = InMemoryBag::new(
+        "synthetic",
+        vec![
+            bus_msg(1105, "model_v1", None, "bag#gw1"),
+            bus_msg(2105, "model_v1", Some(43), "bag#tj1"),
+        ],
+    );
+    let cfg = CollectorConfig { pass_rate: 0.0, window_ms: 100, max_orphan_rate: 0.0, out_dir: out.clone() };
+
+    let recon = run(records, &bag, &cfg).expect("run should succeed");
+    assert_eq!(recon.passes_in, 2);
+    assert_eq!(recon.interventions_in, 2);
+    assert_eq!(recon.passes_kept, 0, "pass_rate 0.0 drops every pass");
+    assert_eq!(recon.interventions_kept, 2, "every intervention survives");
+    assert_eq!(recon.kept_after_sampling, 2);
+    assert_eq!(recon.joined, 2);
+    assert_eq!(recon.orphans, 0);
+    cleanup(&out);
+}
+
+#[test]
+fn orphan_rate_gate_fails_loud_when_exceeded() {
+    let out = unique_out("orphan");
+    // One gateway record with NO bus message in the window → orphan.
+    let records = vec![gateway(0, 1000, CaptureOutcome::ClampLinear)];
+    let bag = InMemoryBag::new("synthetic", vec![bus_msg(99_000, "model_v1", None, "far")]);
+
+    // Ceiling 0.0 → the single orphan (rate 1.0) must fail loud.
+    let cfg = CollectorConfig { pass_rate: 1.0, window_ms: 100, max_orphan_rate: 0.0, out_dir: out.clone() };
+    match run(records, &bag, &cfg) {
+        Err(CollectorError::OrphanRateExceeded { recon, max }) => {
+            assert_eq!(recon.orphans, 1);
+            assert_eq!(recon.joined, 0);
+            assert_eq!(recon.orphan_rate, 1.0);
+            assert_eq!(max, 0.0);
+        }
+        other => panic!("expected OrphanRateExceeded, got {other:?}"),
+    }
+    cleanup(&out);
+}
+
+#[test]
+fn orphan_under_ceiling_succeeds() {
+    let out = unique_out("orphan_ok");
+    // 1 joined + 1 orphan → orphan_rate 0.5, under a 0.75 ceiling.
+    let records = vec![
+        gateway(0, 1000, CaptureOutcome::ClampLinear),
+        gateway(1, 5000, CaptureOutcome::Deny),
+    ];
+    let bag = InMemoryBag::new("synthetic", vec![bus_msg(1005, "model_v1", None, "bag#gw0")]);
+    let cfg = CollectorConfig { pass_rate: 1.0, window_ms: 100, max_orphan_rate: 0.75, out_dir: out.clone() };
+
+    let recon = run(records, &bag, &cfg).expect("under ceiling → ok");
+    assert_eq!(recon.joined, 1);
+    assert_eq!(recon.orphans, 1);
+    assert_eq!(recon.orphan_rate, 0.5);
+    cleanup(&out);
+}
+
+#[test]
+fn distinct_doer_versions_produce_distinct_partitions() {
+    let out = unique_out("multiver");
+    let records = vec![
+        gateway(0, 1000, CaptureOutcome::ClampLinear),
+        gateway(1, 2000, CaptureOutcome::ClampLinear),
+    ];
+    // Same source, two different doer versions on the bus side.
+    let bag = InMemoryBag::new(
+        "synthetic",
+        vec![
+            bus_msg(1005, "model_v1", None, "bag#a"),
+            bus_msg(2005, "model_v2", None, "bag#b"),
+        ],
+    );
+    let cfg = CollectorConfig { pass_rate: 1.0, window_ms: 100, max_orphan_rate: 0.0, out_dir: out.clone() };
+
+    let recon = run(records, &bag, &cfg).expect("run ok");
+    assert_eq!(recon.joined, 2);
+    let parts = list_parquet_parts(&out).unwrap();
+    assert_eq!(parts.len(), 2, "one partition per doer_version");
+    assert!(out.join("doer_version=model_v1/source=COMMAND_GATEWAY/part-000.parquet").exists());
+    assert!(out.join("doer_version=model_v2/source=COMMAND_GATEWAY/part-000.parquet").exists());
+    cleanup(&out);
+}
+
+#[test]
+fn read_jsonl_and_dedup_round_trips_through_the_pipeline() {
+    let out = unique_out("jsonl");
+    let dir = unique_out("jsonl_in");
+    std::fs::create_dir_all(&dir).unwrap();
+    let capture_path = dir.join("capture.jsonl");
+
+    // Two lines, the SECOND a duplicate (source, decision_seq) of the first.
+    let r0 = gateway(0, 1000, CaptureOutcome::ClampLinear);
+    let dup = gateway(0, 1000, CaptureOutcome::Allow); // same key → dropped
+    let r1 = trajectory(0, 2000, 42, CaptureOutcome::Deny);
+    let body = format!(
+        "{}\n{}\n\n{}\n", // blank line tolerated
+        serde_json::to_string(&r0).unwrap(),
+        serde_json::to_string(&dup).unwrap(),
+        serde_json::to_string(&r1).unwrap(),
+    );
+    std::fs::write(&capture_path, body).unwrap();
+
+    let records = kirra_collector::read_jsonl(&[capture_path]).unwrap();
+    assert_eq!(records.len(), 3, "read_jsonl reads every non-blank line incl. the dup");
+
+    let bag = InMemoryBag::new(
+        "synthetic",
+        vec![
+            bus_msg(1005, "model_v1", None, "bag#gw0"),
+            bus_msg(2005, "model_v1", Some(42), "bag#tj0"),
+        ],
+    );
+    let cfg = CollectorConfig { pass_rate: 1.0, window_ms: 100, max_orphan_rate: 0.0, out_dir: out.clone() };
+    let recon = run(records, &bag, &cfg).expect("run ok");
+    assert_eq!(recon.duplicates_dropped, 1, "the duplicate (source, decision_seq) is dropped");
+    assert_eq!(recon.records_in, 2, "two distinct records survive dedup");
+    assert_eq!(recon.joined, 2);
+    cleanup(&out);
+    cleanup(&dir);
+}
+
+fn cleanup(path: &Path) {
+    let _ = std::fs::remove_dir_all(path);
+}


### PR DESCRIPTION
Stage B of the learning-loop collector (docs/COLLECTOR_DESIGN.md). The OFFLINE tool that turns the two dark capture streams + a bus recording into a versioned training dataset. Depends on kirra-capture-schema ONLY (arrow/parquet/serde) — never kirra-runtime-sdk, so §0 doer/checker isolation is a dependency-graph fact.

Pipeline (crates/kirra-collector):
  - ingest: read both JSONL streams via the schema types; dedup + index by (source, decision_seq) [D2], stable ordering.
  - sample: stratified pass-sampling [D5] — keep EVERY intervention, sample ALLOW at a deterministic rate (FNV of the join key; reproducible). Default 1.0.
  - join: match each kept record to a bus message within ±window_ms [D2], cross-checked on asset_id/trajectory_id/objects_ms where present; no match → orphan (never silently dropped). Bag access is behind a BagReader trait so the real rosbag2 db3/MCAP backend [C2] slots in later; Phase 1 ships an in-memory / --bag-json synthetic impl.
  - dataset: Parquet partitioned doer_version=<v>/source=<s>/ [D4]; one flat row per kept decision (the triple summary + outcome label + posture + join keys + doer_version [D3]) with bulk_ref into the bag. NO raw points/objects/frame columns — heavy frames stay in the bag, referenced not copied.
  - reconcile: full accounting (in / kept / joined / orphans / pass_rate); fails loud if orphan_rate exceeds the ceiling.
  - CLI: --capture (repeatable) --bag-json|--bag --out --pass-rate --window-ms --max-orphan-rate. The real --bag backend errors clearly (C2 deferred).

Tests (synthetic fixtures, no real bag — C4 follow-up gated on the GPU bench):
  6 unit + 6 end-to-end — join hit/orphan counts, stratified sampling, multi-
  doer_version partitioning, pinned column set (proves frames absent), JSONL
  ingest + dedup, orphan-rate gate.

Verification: blob 997fb7ae… unchanged; cargo tree -p kirra-collector has NO kirra-runtime-sdk (INV-4); SDK 509 lib tests still green; whole workspace builds.