### PR TITLE
feat(collector): Phase 2 manifest + lineage (missed by #195)

### DIFF
--- a/crates/kirra-collector/Cargo.toml
+++ b/crates/kirra-collector/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 arrow = "58"
 parquet = "58"
+sha2 = "0.10"
 
 [[bin]]
 name = "kirra-collector"

--- a/crates/kirra-collector/build.rs
+++ b/crates/kirra-collector/build.rs
@@ -1,0 +1,54 @@
+// crates/kirra-collector/build.rs
+//
+// Records provenance into compile-time env vars for the dataset manifest [M3]:
+//   - KIRRA_GIT_COMMIT    : `git rev-parse --short HEAD`, or "unknown"
+//   - KIRRA_SCHEMA_VERSION: the kirra-capture-schema crate version, read from the
+//     sibling Cargo.toml (the schema crate is off-limits to edit, so we parse its
+//     manifest), or "unknown" if the sibling can't be found (standalone/packaged
+//     build outside the workspace) — mirrors the git-hash fallback so the build
+//     never fails just because a path moved.
+
+use std::process::Command;
+
+fn main() {
+    let git = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=KIRRA_GIT_COMMIT={git}");
+
+    let schema_version = std::fs::read_to_string("../kirra-capture-schema/Cargo.toml")
+        .ok()
+        .and_then(|toml| parse_package_version(&toml))
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=KIRRA_SCHEMA_VERSION={schema_version}");
+
+    // Re-run when provenance sources change.
+    println!("cargo:rerun-if-changed=../kirra-capture-schema/Cargo.toml");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+/// Extract `version = "..."` from the `[package]` section of a Cargo.toml.
+fn parse_package_version(toml: &str) -> Option<String> {
+    let mut in_package = false;
+    for line in toml.lines() {
+        let t = line.trim();
+        if t.starts_with('[') {
+            in_package = t == "[package]";
+            continue;
+        }
+        if in_package {
+            if let Some(rest) = t.strip_prefix("version") {
+                let val = rest.trim_start().strip_prefix('=')?.trim();
+                return Some(val.trim_matches('"').to_string());
+            }
+        }
+    }
+    None
+}

--- a/crates/kirra-collector/src/dataset.rs
+++ b/crates/kirra-collector/src/dataset.rs
@@ -24,9 +24,22 @@ use kirra_capture_schema::CaptureRecord;
 use crate::bag::BusMatch;
 use crate::{outcome_token, source_token, CollectorError};
 
+/// Provenance for one written partition (recorded in the dataset manifest).
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct PartitionInfo {
+    pub doer_version: String,
+    pub source: String,
+    pub row_count: usize,
+    /// Parquet path RELATIVE to the dataset root (e.g.
+    /// `doer_version=v1/source=COMMAND_GATEWAY/part-000.parquet`).
+    pub relative_path: String,
+}
+
 /// One row of the training dataset — the joined summary. Flat (one nullable
 /// column per source-specific field) so it maps directly onto an Arrow batch.
-#[derive(Debug, Clone, PartialEq)]
+/// `Serialize` is used only for the canonical content digest (Phase 2), never on
+/// the verdict/wire path.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct DatasetRow {
     // --- common (every record) ---
     pub decision_seq: u64,
@@ -217,9 +230,13 @@ fn sanitize(value: &str) -> String {
 }
 
 /// Write the rows as Parquet, partitioned `doer_version=<v>/source=<s>/`. Returns
-/// the list of part files written. Heavy frames are never materialized — only the
-/// summary columns + `bulk_ref` are.
-pub fn write_dataset(rows: &[DatasetRow], out_dir: &Path) -> Result<Vec<PathBuf>, CollectorError> {
+/// one `PartitionInfo` per partition written (deterministic order). Heavy frames
+/// are never materialized — only the summary columns + `bulk_ref` are.
+///
+/// Rows within each partition are sorted by `(source, decision_seq)` so the
+/// output is reproducible regardless of the caller's input order — the basis for
+/// the manifest's stable `content_digest` [M2].
+pub fn write_dataset(rows: &[DatasetRow], out_dir: &Path) -> Result<Vec<PartitionInfo>, CollectorError> {
     let schema = dataset_schema();
     // Group by (doer_version, source); BTreeMap → deterministic partition order.
     let mut groups: BTreeMap<(String, String), Vec<&DatasetRow>> = BTreeMap::new();
@@ -227,16 +244,20 @@ pub fn write_dataset(rows: &[DatasetRow], out_dir: &Path) -> Result<Vec<PathBuf>
         groups.entry((r.doer_version.clone(), r.source.clone())).or_default().push(r);
     }
     let mut written = Vec::new();
-    for ((doer_version, source), group) in &groups {
-        let dir = out_dir
-            .join(format!("doer_version={}", sanitize(doer_version)))
-            .join(format!("source={}", sanitize(source)));
-        fs::create_dir_all(&dir).map_err(CollectorError::Io)?;
-        let path = dir.join("part-000.parquet");
-        let batch = build_batch(&schema, group)?;
+    for ((doer_version, source), mut group) in groups {
+        group.sort_by(|a, b| (a.source.as_str(), a.decision_seq).cmp(&(b.source.as_str(), b.decision_seq)));
+        let rel = format!(
+            "doer_version={}/source={}/part-000.parquet",
+            sanitize(&doer_version),
+            sanitize(&source)
+        );
+        let path = out_dir.join(&rel);
+        fs::create_dir_all(path.parent().expect("partition path has a parent"))
+            .map_err(CollectorError::Io)?;
+        let batch = build_batch(&schema, &group)?;
         let file = fs::File::create(&path).map_err(CollectorError::Io)?;
-        // UNCOMPRESSED keeps Phase 1 codec-independent + byte-deterministic;
-        // compression is a Phase-2 tuning knob.
+        // UNCOMPRESSED keeps the output codec-independent + byte-deterministic;
+        // compression is a later tuning knob.
         let props = WriterProperties::builder()
             .set_compression(Compression::UNCOMPRESSED)
             .build();
@@ -244,7 +265,12 @@ pub fn write_dataset(rows: &[DatasetRow], out_dir: &Path) -> Result<Vec<PathBuf>
             ArrowWriter::try_new(file, Arc::clone(&schema), Some(props)).map_err(CollectorError::Parquet)?;
         writer.write(&batch).map_err(CollectorError::Parquet)?;
         writer.close().map_err(CollectorError::Parquet)?;
-        written.push(path);
+        written.push(PartitionInfo {
+            doer_version,
+            source,
+            row_count: group.len(),
+            relative_path: rel,
+        });
     }
     Ok(written)
 }

--- a/crates/kirra-collector/src/lib.rs
+++ b/crates/kirra-collector/src/lib.rs
@@ -3,30 +3,35 @@
 // kirra-collector — the OFFLINE learning-loop collector (docs/COLLECTOR_DESIGN.md).
 // It reads the two dark capture JSONL streams, keeps every intervention while
 // sampling passes [D5], joins each kept record to a bus recording [D2], attaches
-// the doer's model version [D3], and writes a training-ready Parquet dataset [D4]
-// with a reconciliation report.
+// the doer's model version [D3], writes a training-ready Parquet dataset [D4],
+// and (Phase 2) emits a `manifest.json` with lineage + a reproducible
+// `dataset_id` so a model trained on it can point back at exactly this data.
 //
 // §0 SAFETY BOUNDARY: this crate depends on `kirra-capture-schema` ONLY (plus
-// serde / arrow / parquet) — NEVER on `kirra-runtime-sdk`. It is offline,
-// out-of-vehicle, produces only a dataset, and is mechanically incapable of
-// linking or reaching the verdict path. `cargo tree -p kirra-collector` is the
-// enforced check.
+// serde / serde_json / arrow / parquet / sha2) — NEVER on `kirra-runtime-sdk`.
+// It is offline, out-of-vehicle, produces only a dataset, and is mechanically
+// incapable of linking or reaching the verdict path. `cargo tree -p
+// kirra-collector` is the enforced check.
 
 use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::fmt::Write as _;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use kirra_capture_schema::{CaptureOutcome, CaptureRecord, CaptureSource};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 pub mod bag;
 pub mod dataset;
 pub mod join;
+pub mod manifest;
 pub mod reconcile;
 pub mod sample;
 
 use bag::BagReader;
 use join::JoinOutcome;
+use manifest::Manifest;
 use reconcile::Reconciliation;
 
 /// Stable string token for a capture source — the partition value and join key.
@@ -50,7 +55,47 @@ pub fn outcome_token(o: CaptureOutcome) -> &'static str {
     }
 }
 
-/// Collector run configuration (the CLI flags, or a test's choices).
+/// Lowercase hex of a byte slice.
+#[must_use]
+pub(crate) fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+/// SHA-256 of a byte slice, lowercase hex.
+#[must_use]
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    hex(&h.finalize())
+}
+
+/// Per-input-file provenance (manifest `inputs[]`). The `sha256` is over the raw
+/// file bytes; `record_count` and the per-source counts are this file's
+/// contribution.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct InputDigest {
+    pub name: String,
+    pub sha256: String,
+    pub record_count: usize,
+    pub command_gateway: usize,
+    pub slow_loop_trajectory: usize,
+}
+
+/// Provenance fed into `run` alongside the records — kept separate from
+/// `CollectorConfig` (which is pure algorithm params).
+#[derive(Debug, Clone)]
+pub struct Lineage {
+    /// Per-capture-file digests (sha256 + counts).
+    pub inputs: Vec<InputDigest>,
+    /// Which bag backend produced the join (`bag-json`, `db3`, `mcap`).
+    pub bag_backend: String,
+}
+
+/// Collector run configuration (the algorithm/run params — NOT provenance).
 #[derive(Debug, Clone)]
 pub struct CollectorConfig {
     /// Pass-sampling rate in [0, 1]; 1.0 keeps every pass [D5].
@@ -59,7 +104,7 @@ pub struct CollectorConfig {
     pub window_ms: u64,
     /// Fail the run if the orphan rate exceeds this (data-quality gate).
     pub max_orphan_rate: f64,
-    /// Output dataset root; partitions are written beneath it.
+    /// Output dataset root; partitions + `manifest.json` are written beneath it.
     pub out_dir: PathBuf,
 }
 
@@ -69,9 +114,10 @@ pub enum CollectorError {
     Io(std::io::Error),
     Arrow(arrow::error::ArrowError),
     Parquet(parquet::errors::ParquetError),
-    /// The orphan rate exceeded `max_orphan_rate`. The dataset was still written;
-    /// the reconciliation is carried so the caller can report it.
-    OrphanRateExceeded { recon: Box<Reconciliation>, max: f64 },
+    /// The orphan rate exceeded `max_orphan_rate`. The dataset + manifest were
+    /// still written; the manifest is carried so the caller can report the
+    /// `dataset_id` + quality of the flagged dataset.
+    OrphanRateExceeded { manifest: Box<Manifest>, max: f64 },
 }
 
 impl std::fmt::Display for CollectorError {
@@ -80,10 +126,13 @@ impl std::fmt::Display for CollectorError {
             CollectorError::Io(e) => write!(f, "io error: {e}"),
             CollectorError::Arrow(e) => write!(f, "arrow error: {e}"),
             CollectorError::Parquet(e) => write!(f, "parquet error: {e}"),
-            CollectorError::OrphanRateExceeded { recon, max } => write!(
+            CollectorError::OrphanRateExceeded { manifest, max } => write!(
                 f,
                 "orphan rate {:.3} exceeds ceiling {:.3} ({} of {} kept records unjoined)",
-                recon.orphan_rate, max, recon.orphans, recon.kept_after_sampling
+                manifest.quality.orphan_rate,
+                max,
+                manifest.quality.orphans,
+                manifest.quality.kept_after_sampling
             ),
         }
     }
@@ -91,29 +140,58 @@ impl std::fmt::Display for CollectorError {
 
 impl std::error::Error for CollectorError {}
 
-/// Read capture records from one or more JSONL files. Blank lines are skipped;
-/// malformed lines are logged to stderr and skipped (a single bad line never
-/// aborts a whole session's ingest).
-pub fn read_jsonl(paths: &[PathBuf]) -> std::io::Result<Vec<CaptureRecord>> {
-    let mut out = Vec::new();
+/// Read capture records from one or more JSONL files AND compute per-file
+/// provenance (sha256 over the raw bytes + record / per-source counts). Blank
+/// lines are skipped; malformed lines are logged to stderr and skipped (a single
+/// bad line never aborts a session's ingest).
+pub fn read_jsonl_with_digests(
+    paths: &[PathBuf],
+) -> std::io::Result<(Vec<CaptureRecord>, Vec<InputDigest>)> {
+    let mut all = Vec::new();
+    let mut digests = Vec::new();
     for path in paths {
-        let file = File::open(path)?;
-        for (lineno, line) in BufReader::new(file).lines().enumerate() {
-            let line = line?;
-            if line.trim().is_empty() {
+        let bytes = fs::read(path)?;
+        let sha256 = sha256_hex(&bytes);
+        let (mut record_count, mut command_gateway, mut slow_loop_trajectory) = (0, 0, 0);
+        for (idx, raw) in bytes.split(|b| *b == b'\n').enumerate() {
+            let line = std::str::from_utf8(raw).unwrap_or("").trim();
+            if line.is_empty() {
                 continue;
             }
-            match serde_json::from_str::<CaptureRecord>(&line) {
-                Ok(rec) => out.push(rec),
+            match serde_json::from_str::<CaptureRecord>(line) {
+                Ok(rec) => {
+                    record_count += 1;
+                    match rec.source {
+                        CaptureSource::CommandGateway => command_gateway += 1,
+                        CaptureSource::SlowLoopTrajectory => slow_loop_trajectory += 1,
+                    }
+                    all.push(rec);
+                }
                 Err(e) => eprintln!(
                     "warn: skipping malformed capture line {}:{}: {e}",
                     path.display(),
-                    lineno + 1
+                    idx + 1
                 ),
             }
         }
+        digests.push(InputDigest {
+            name: path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.display().to_string()),
+            sha256,
+            record_count,
+            command_gateway,
+            slow_loop_trajectory,
+        });
     }
-    Ok(out)
+    Ok((all, digests))
+}
+
+/// Read capture records only (provenance discarded). Thin wrapper over
+/// `read_jsonl_with_digests` so existing callers are unchanged.
+pub fn read_jsonl(paths: &[PathBuf]) -> std::io::Result<Vec<CaptureRecord>> {
+    Ok(read_jsonl_with_digests(paths)?.0)
 }
 
 /// Deduplicate by `(source, decision_seq)` (the primary key [D2]) and return a
@@ -135,14 +213,17 @@ pub fn index_dedup(records: Vec<CaptureRecord>) -> (Vec<CaptureRecord>, usize) {
     (map.into_values().collect(), duplicates)
 }
 
-/// The whole pipeline: dedup → stratified sample → join → write Parquet →
-/// reconcile. Writes the dataset under `cfg.out_dir` and returns the
-/// reconciliation. Fails (after writing) if the orphan rate exceeds the ceiling.
+/// The whole pipeline: dedup → stratified sample → join → write Parquet → write
+/// manifest → reconcile. Writes the dataset + `manifest.json` under
+/// `cfg.out_dir` and returns the `Manifest` (which embeds the `Reconciliation` as
+/// `quality` and the reproducible `dataset_id`). Fails (after writing both) if
+/// the orphan rate exceeds the ceiling — the error still carries the manifest.
 pub fn run(
     records: Vec<CaptureRecord>,
     bag: &dyn BagReader,
+    lineage: &Lineage,
     cfg: &CollectorConfig,
-) -> Result<Reconciliation, CollectorError> {
+) -> Result<Manifest, CollectorError> {
     let (deduped, duplicates_dropped) = index_dedup(records);
 
     let mut recon = Reconciliation {
@@ -193,16 +274,23 @@ pub fn run(
         }
     }
 
-    dataset::write_dataset(&rows, &cfg.out_dir)?;
+    // Canonical order for a reproducible content digest [M2] (already the
+    // dedup order; explicit for robustness).
+    rows.sort_by(|a, b| (a.source.as_str(), a.decision_seq).cmp(&(b.source.as_str(), b.decision_seq)));
+
+    let partitions = dataset::write_dataset(&rows, &cfg.out_dir)?;
     recon.orphan_rate = recon.orphan_rate();
+
+    let manifest = manifest::build_manifest(lineage, bag.bag_uri(), cfg, &recon, &rows, &partitions);
+    manifest::write_manifest(&manifest, &cfg.out_dir)?;
 
     if recon.orphan_rate > cfg.max_orphan_rate {
         return Err(CollectorError::OrphanRateExceeded {
-            recon: Box::new(recon),
+            manifest: Box::new(manifest),
             max: cfg.max_orphan_rate,
         });
     }
-    Ok(recon)
+    Ok(manifest)
 }
 
 /// Convenience: list the part files under a dataset root (sorted), for callers

--- a/crates/kirra-collector/src/main.rs
+++ b/crates/kirra-collector/src/main.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use kirra_collector::bag::InMemoryBag;
-use kirra_collector::{read_jsonl, run, CollectorConfig, CollectorError};
+use kirra_collector::{read_jsonl_with_digests, run, CollectorConfig, CollectorError, Lineage};
 
 struct Args {
     captures: Vec<PathBuf>,
@@ -121,7 +121,7 @@ fn main() -> ExitCode {
         }
     };
 
-    let records = match read_jsonl(&args.captures) {
+    let (records, input_digests) = match read_jsonl_with_digests(&args.captures) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("error: reading capture JSONL: {e}");
@@ -129,6 +129,10 @@ fn main() -> ExitCode {
         }
     };
 
+    let lineage = Lineage {
+        inputs: input_digests,
+        bag_backend: "bag-json".to_string(),
+    };
     let cfg = CollectorConfig {
         pass_rate: args.pass_rate,
         window_ms: args.window_ms,
@@ -136,18 +140,19 @@ fn main() -> ExitCode {
         out_dir: args.out.unwrap(),
     };
 
-    match run(records, &bag, &cfg) {
-        Ok(recon) => {
-            println!("{}", recon.summary());
-            println!("{}", serde_json::to_string(&recon).unwrap());
+    match run(records, &bag, &lineage, &cfg) {
+        Ok(manifest) => {
+            println!("{}", manifest.quality.summary());
+            println!("dataset_id = {}", manifest.dataset_id);
             ExitCode::SUCCESS
         }
-        Err(CollectorError::OrphanRateExceeded { recon, max }) => {
-            println!("{}", recon.summary());
+        Err(CollectorError::OrphanRateExceeded { manifest, max }) => {
+            println!("{}", manifest.quality.summary());
+            println!("dataset_id = {}", manifest.dataset_id);
             eprintln!(
-                "error: orphan rate {:.3} exceeds --max-orphan-rate {:.3} — dataset written but \
-                 flagged for review",
-                recon.orphan_rate, max
+                "error: orphan rate {:.3} exceeds --max-orphan-rate {:.3} — dataset + manifest \
+                 written but flagged for review",
+                manifest.quality.orphan_rate, max
             );
             ExitCode::FAILURE
         }

--- a/crates/kirra-collector/src/manifest.rs
+++ b/crates/kirra-collector/src/manifest.rs
@@ -1,0 +1,273 @@
+// crates/kirra-collector/src/manifest.rs
+//
+// Dataset manifest + lineage (docs/COLLECTOR_DESIGN.md Phase 2). Every dataset
+// gets a `manifest.json` at its root recording WHAT produced it (collector +
+// schema versions, git commit), WHAT went in (per-input sha256 + counts, the bag
+// reference), HOW (the run params), the quality `Reconciliation`, the partitions
+// written, and a reproducible `dataset_id` — so a model trained on this dataset
+// can point back at exactly the data + provenance behind it.
+//
+// [M1] `dataset_id` is a sha256 over the LOGICAL content + lineage:
+//   { sorted input sha256s, schema version, collector version, params,
+//     content_digest }. It EXCLUDES `created_at` and the PHYSICAL Parquet bytes
+//   (arrow/parquet encoding + metadata timestamps are nondeterministic) — so the
+//   same inputs + params + collector build always reproduce the same id.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::dataset::{DatasetRow, PartitionInfo};
+use crate::reconcile::Reconciliation;
+use crate::{hex, CollectorConfig, CollectorError, InputDigest, Lineage};
+
+const COLLECTOR_VERSION: &str = env!("CARGO_PKG_VERSION");
+const GIT_COMMIT: &str = env!("KIRRA_GIT_COMMIT");
+const SCHEMA_VERSION: &str = env!("KIRRA_SCHEMA_VERSION");
+
+/// The sampling scheme recorded in the manifest params.
+pub const SAMPLING_KIND: &str = "fnv-keyed, deterministic";
+
+/// `dataset_id` algorithm tag — bump if the canonical id construction changes
+/// (so ids are never silently comparable across algorithm versions).
+const DATASET_ID_ALGO: &str = "kirra-collector-dataset-id-v1";
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CollectorInfo {
+    pub version: String,
+    pub git_commit: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SchemaInfo {
+    pub crate_name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct BagRef {
+    pub backend: String,
+    pub uri: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ManifestParams {
+    pub pass_rate: f64,
+    pub window_ms: u64,
+    pub max_orphan_rate: f64,
+    pub sampling: String,
+}
+
+/// The full dataset manifest, written to `<out>/manifest.json`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Manifest {
+    /// Reproducible logical id [M1] — excludes `created_at` + physical bytes.
+    pub dataset_id: String,
+    /// Wall-clock build time (ISO-8601 UTC). Provenance only; NOT in the id.
+    pub created_at: String,
+    pub collector: CollectorInfo,
+    pub schema: SchemaInfo,
+    pub inputs: Vec<InputDigest>,
+    pub bag: BagRef,
+    pub params: ManifestParams,
+    /// The run's quality accounting — the single source of truth (serialized as-is).
+    pub quality: Reconciliation,
+    pub partitions: Vec<PartitionInfo>,
+    pub doer_versions: Vec<String>,
+    pub decision_t_wall_ms_min: Option<u64>,
+    pub decision_t_wall_ms_max: Option<u64>,
+    /// sha256 over the canonical logical rows (partition-layout independent).
+    pub content_digest: String,
+}
+
+/// sha256 over the canonical logical rows — sorted by `(source, decision_seq)`
+/// (unique per run after dedup), each serialized to canonical JSON. Independent
+/// of partition layout + physical Parquet encoding.
+#[must_use]
+pub fn content_digest(rows: &[DatasetRow]) -> String {
+    let mut sorted: Vec<&DatasetRow> = rows.iter().collect();
+    sorted.sort_by(|a, b| (a.source.as_str(), a.decision_seq).cmp(&(b.source.as_str(), b.decision_seq)));
+    let mut h = Sha256::new();
+    for row in sorted {
+        let line = serde_json::to_string(row).expect("DatasetRow serializes infallibly");
+        h.update(line.as_bytes());
+        h.update(b"\n");
+    }
+    hex(&h.finalize())
+}
+
+/// Compute the reproducible `dataset_id` [M1]. Deliberately takes NO `created_at`
+/// and NO physical Parquet bytes — only the logical content + lineage — so the
+/// same inputs/params/build always yield the same id (INV-4).
+#[must_use]
+pub fn compute_dataset_id(
+    input_sha256s: &[String],
+    schema_version: &str,
+    collector_version: &str,
+    params: &ManifestParams,
+    content_digest: &str,
+) -> String {
+    let mut inputs = input_sha256s.to_vec();
+    inputs.sort();
+    let mut h = Sha256::new();
+    h.update(DATASET_ID_ALGO.as_bytes());
+    h.update(b"\n");
+    for s in &inputs {
+        h.update(s.as_bytes());
+        h.update(b"\n");
+    }
+    h.update(format!("schema={schema_version}\n").as_bytes());
+    h.update(format!("collector={collector_version}\n").as_bytes());
+    h.update(
+        format!(
+            "pass_rate={}\nwindow_ms={}\nmax_orphan_rate={}\nsampling={}\n",
+            params.pass_rate, params.window_ms, params.max_orphan_rate, params.sampling
+        )
+        .as_bytes(),
+    );
+    h.update(format!("content={content_digest}\n").as_bytes());
+    hex(&h.finalize())
+}
+
+/// Build the manifest after the dataset is written.
+#[must_use]
+pub fn build_manifest(
+    lineage: &Lineage,
+    bag_uri: &str,
+    cfg: &CollectorConfig,
+    quality: &Reconciliation,
+    rows: &[DatasetRow],
+    partitions: &[PartitionInfo],
+) -> Manifest {
+    let params = ManifestParams {
+        pass_rate: cfg.pass_rate,
+        window_ms: cfg.window_ms,
+        max_orphan_rate: cfg.max_orphan_rate,
+        sampling: SAMPLING_KIND.to_string(),
+    };
+    let content_digest = content_digest(rows);
+    let input_sha256s: Vec<String> = lineage.inputs.iter().map(|i| i.sha256.clone()).collect();
+    let dataset_id =
+        compute_dataset_id(&input_sha256s, SCHEMA_VERSION, COLLECTOR_VERSION, &params, &content_digest);
+
+    let mut doer_versions: Vec<String> = partitions.iter().map(|p| p.doer_version.clone()).collect();
+    doer_versions.sort();
+    doer_versions.dedup();
+
+    let mut min = None;
+    let mut max = None;
+    for r in rows {
+        min = Some(min.map_or(r.t_wall_ms, |m: u64| m.min(r.t_wall_ms)));
+        max = Some(max.map_or(r.t_wall_ms, |m: u64| m.max(r.t_wall_ms)));
+    }
+
+    Manifest {
+        dataset_id,
+        created_at: now_iso8601_utc(),
+        collector: CollectorInfo {
+            version: COLLECTOR_VERSION.to_string(),
+            git_commit: GIT_COMMIT.to_string(),
+        },
+        schema: SchemaInfo {
+            crate_name: "kirra-capture-schema".to_string(),
+            version: SCHEMA_VERSION.to_string(),
+        },
+        inputs: lineage.inputs.clone(),
+        bag: BagRef {
+            backend: lineage.bag_backend.clone(),
+            uri: bag_uri.to_string(),
+        },
+        params,
+        quality: quality.clone(),
+        partitions: partitions.to_vec(),
+        doer_versions,
+        decision_t_wall_ms_min: min,
+        decision_t_wall_ms_max: max,
+        content_digest,
+    }
+}
+
+/// Write the manifest to `<out_dir>/manifest.json` (pretty JSON).
+pub fn write_manifest(manifest: &Manifest, out_dir: &Path) -> Result<PathBuf, CollectorError> {
+    std::fs::create_dir_all(out_dir).map_err(CollectorError::Io)?;
+    let path = out_dir.join("manifest.json");
+    let json = serde_json::to_string_pretty(manifest)
+        .map_err(|e| CollectorError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)))?;
+    std::fs::write(&path, json).map_err(CollectorError::Io)?;
+    Ok(path)
+}
+
+/// Current UTC time as `YYYY-MM-DDTHH:MM:SSZ`. Self-contained (no chrono dep);
+/// uses Howard Hinnant's civil-from-days. Provenance only — excluded from the id.
+fn now_iso8601_utc() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0) as i64;
+    let days = secs.div_euclid(86_400);
+    let rem = secs.rem_euclid(86_400);
+    let (y, m, d) = civil_from_days(days);
+    let (hh, mm, ss) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+    format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}Z")
+}
+
+/// (year, month, day) from days since the Unix epoch (1970-01-01).
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32; // [1, 12]
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params() -> ManifestParams {
+        ManifestParams {
+            pass_rate: 1.0,
+            window_ms: 100,
+            max_orphan_rate: 0.05,
+            sampling: SAMPLING_KIND.to_string(),
+        }
+    }
+
+    #[test]
+    fn dataset_id_is_stable_and_input_sensitive() {
+        let base = compute_dataset_id(&["aaa".into(), "bbb".into()], "0.1.0", "0.1.0", &params(), "cd");
+        // Same inputs → same id (order-independent on the input list).
+        assert_eq!(
+            base,
+            compute_dataset_id(&["bbb".into(), "aaa".into()], "0.1.0", "0.1.0", &params(), "cd")
+        );
+        // A different input hash → different id.
+        assert_ne!(
+            base,
+            compute_dataset_id(&["aaa".into(), "ccc".into()], "0.1.0", "0.1.0", &params(), "cd")
+        );
+        // A different param → different id.
+        let mut p2 = params();
+        p2.pass_rate = 0.5;
+        assert_ne!(base, compute_dataset_id(&["aaa".into(), "bbb".into()], "0.1.0", "0.1.0", &p2, "cd"));
+        // A different content digest → different id.
+        assert_ne!(
+            base,
+            compute_dataset_id(&["aaa".into(), "bbb".into()], "0.1.0", "0.1.0", &params(), "cd2")
+        );
+    }
+
+    #[test]
+    fn civil_from_days_known_dates() {
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+        assert_eq!(civil_from_days(18_993), (2022, 1, 1));
+        // 2000-01-01 is 10957 days after the epoch.
+        assert_eq!(civil_from_days(10_957), (2000, 1, 1));
+    }
+}

--- a/crates/kirra-collector/tests/pipeline.rs
+++ b/crates/kirra-collector/tests/pipeline.rs
@@ -1,13 +1,12 @@
 // crates/kirra-collector/tests/pipeline.rs
 //
-// STEP B2 — drive the WHOLE collector pipeline (ingest → stratified sampling →
-// join → Parquet → reconciliation) against SYNTHETIC fixtures: hand-built
-// capture records for both sources + an in-memory bag. No real rosbag needed
-// (C2/C4 deferred until the GPU bench is up).
+// End-to-end pipeline tests against SYNTHETIC fixtures: hand-built capture
+// records for both sources + an in-memory bag. No real rosbag needed (C2/C4
+// deferred until the GPU bench is up).
 //
-// Asserts: join hit/orphan counts; stratified sampling keeps every intervention
-// and samples passes; Parquet partitions by doer_version/source; bulk_ref present
-// and heavy frames absent; the orphan-rate gate fails loud.
+// Covers: join hit/orphan counts; stratified sampling; Parquet partitioning;
+// bulk_ref present + heavy frames absent; the orphan-rate gate; and (Phase 2)
+// the dataset manifest — reproducible dataset_id, lineage, and quality.
 
 use std::path::{Path, PathBuf};
 
@@ -17,7 +16,9 @@ use kirra_capture_schema::{
 };
 use kirra_collector::bag::{BusMessage, InMemoryBag};
 use kirra_collector::dataset::read_part_columns_and_rows;
-use kirra_collector::{list_parquet_parts, run, CollectorConfig, CollectorError};
+use kirra_collector::{
+    list_parquet_parts, read_jsonl_with_digests, run, CollectorConfig, CollectorError, Lineage,
+};
 
 // ---- fixtures --------------------------------------------------------------
 
@@ -81,12 +82,24 @@ fn bus_msg(t_wall_ms: u64, ver: &str, traj_id: Option<u64>, reff: &str) -> BusMe
     }
 }
 
+fn lineage() -> Lineage {
+    Lineage { inputs: vec![], bag_backend: "test".to_string() }
+}
+
 fn unique_out(tag: &str) -> PathBuf {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    std::env::temp_dir().join(format!("kirra-collector-test-{tag}-{nanos}"))
+    std::env::temp_dir().join(format!("kirra-collector-test-{tag}-{nanos}-{n}"))
+}
+
+fn write_jsonl(path: &Path, recs: &[CaptureRecord]) {
+    let body: String =
+        recs.iter().map(|r| serde_json::to_string(r).unwrap() + "\n").collect();
+    std::fs::write(path, body).unwrap();
 }
 
 /// The dataset's full column set — pinning this proves NO raw frame/point/object
@@ -101,7 +114,7 @@ const EXPECTED_COLUMNS: &[&str] = &[
     "target_speed_mps", "bulk_ref",
 ];
 
-// ---- tests -----------------------------------------------------------------
+// ---- pipeline tests --------------------------------------------------------
 
 #[test]
 fn happy_path_joins_both_sources_and_partitions() {
@@ -121,14 +134,10 @@ fn happy_path_joins_both_sources_and_partitions() {
             bus_msg(2105, "model_v1", Some(43), "bag#tj1"),
         ],
     );
-    let cfg = CollectorConfig {
-        pass_rate: 1.0,
-        window_ms: 100,
-        max_orphan_rate: 0.0,
-        out_dir: out.clone(),
-    };
+    let cfg = CollectorConfig { pass_rate: 1.0, window_ms: 100, max_orphan_rate: 0.0, out_dir: out.clone() };
 
-    let recon = run(records, &bag, &cfg).expect("run should succeed");
+    let m = run(records, &bag, &lineage(), &cfg).expect("run should succeed");
+    let recon = &m.quality;
     assert_eq!(recon.records_in, 4);
     assert_eq!(recon.records_in_command_gateway, 2);
     assert_eq!(recon.records_in_slow_loop_trajectory, 2);
@@ -139,7 +148,8 @@ fn happy_path_joins_both_sources_and_partitions() {
     assert_eq!(recon.orphans, 0);
     assert_eq!(recon.orphan_rate, 0.0);
 
-    // Two partitions: one per source, both under doer_version=model_v1.
+    // INV-3: manifest is ADDED at the dataset root; partitions unchanged.
+    assert!(out.join("manifest.json").exists(), "manifest.json at dataset root");
     let gw_part = out.join("doer_version=model_v1/source=COMMAND_GATEWAY/part-000.parquet");
     let tj_part = out.join("doer_version=model_v1/source=SLOW_LOOP_TRAJECTORY/part-000.parquet");
     assert!(gw_part.exists(), "gateway partition must exist at {gw_part:?}");
@@ -148,15 +158,11 @@ fn happy_path_joins_both_sources_and_partitions() {
     let (cols, rows) = read_part_columns_and_rows(&gw_part).unwrap();
     assert_eq!(rows, 2, "two gateway rows");
     assert_eq!(cols, EXPECTED_COLUMNS, "schema must be exactly the summary columns");
-    assert!(cols.contains(&"bulk_ref".to_string()), "bulk_ref present");
-    // Heavy frames absent: no raw payload columns, only counts + endpoints.
     for forbidden in ["points", "objects", "object_list", "frame", "frames", "trajectory_points"] {
         assert!(!cols.iter().any(|c| c == forbidden), "no raw `{forbidden}` column");
     }
-
-    let (_cols, tj_rows) = read_part_columns_and_rows(&tj_part).unwrap();
+    let (_c, tj_rows) = read_part_columns_and_rows(&tj_part).unwrap();
     assert_eq!(tj_rows, 2, "two trajectory rows");
-
     cleanup(&out);
 }
 
@@ -164,10 +170,10 @@ fn happy_path_joins_both_sources_and_partitions() {
 fn stratified_sampling_keeps_interventions_drops_passes_at_zero_rate() {
     let out = unique_out("sample0");
     let records = vec![
-        gateway(0, 1000, CaptureOutcome::Allow),       // pass → dropped at 0.0
-        gateway(1, 1100, CaptureOutcome::ClampLinear), // intervention → kept
-        trajectory(0, 2000, 42, CaptureOutcome::Allow), // pass → dropped
-        trajectory(1, 2100, 43, CaptureOutcome::Deny),  // intervention → kept
+        gateway(0, 1000, CaptureOutcome::Allow),
+        gateway(1, 1100, CaptureOutcome::ClampLinear),
+        trajectory(0, 2000, 42, CaptureOutcome::Allow),
+        trajectory(1, 2100, 43, CaptureOutcome::Deny),
     ];
     let bag = InMemoryBag::new(
         "synthetic",
@@ -178,7 +184,8 @@ fn stratified_sampling_keeps_interventions_drops_passes_at_zero_rate() {
     );
     let cfg = CollectorConfig { pass_rate: 0.0, window_ms: 100, max_orphan_rate: 0.0, out_dir: out.clone() };
 
-    let recon = run(records, &bag, &cfg).expect("run should succeed");
+    let m = run(records, &bag, &lineage(), &cfg).expect("run should succeed");
+    let recon = &m.quality;
     assert_eq!(recon.passes_in, 2);
     assert_eq!(recon.interventions_in, 2);
     assert_eq!(recon.passes_kept, 0, "pass_rate 0.0 drops every pass");
@@ -192,18 +199,19 @@ fn stratified_sampling_keeps_interventions_drops_passes_at_zero_rate() {
 #[test]
 fn orphan_rate_gate_fails_loud_when_exceeded() {
     let out = unique_out("orphan");
-    // One gateway record with NO bus message in the window → orphan.
     let records = vec![gateway(0, 1000, CaptureOutcome::ClampLinear)];
     let bag = InMemoryBag::new("synthetic", vec![bus_msg(99_000, "model_v1", None, "far")]);
-
-    // Ceiling 0.0 → the single orphan (rate 1.0) must fail loud.
     let cfg = CollectorConfig { pass_rate: 1.0, window_ms: 100, max_orphan_rate: 0.0, out_dir: out.clone() };
-    match run(records, &bag, &cfg) {
-        Err(CollectorError::OrphanRateExceeded { recon, max }) => {
-            assert_eq!(recon.orphans, 1);
-            assert_eq!(recon.joined, 0);
-            assert_eq!(recon.orphan_rate, 1.0);
+
+    match run(records, &bag, &lineage(), &cfg) {
+        Err(CollectorError::OrphanRateExceeded { manifest, max }) => {
+            assert_eq!(manifest.quality.orphans, 1);
+            assert_eq!(manifest.quality.joined, 0);
+            assert_eq!(manifest.quality.orphan_rate, 1.0);
             assert_eq!(max, 0.0);
+            // The flagged dataset is still identifiable: a manifest was written.
+            assert!(out.join("manifest.json").exists());
+            assert!(!manifest.dataset_id.is_empty());
         }
         other => panic!("expected OrphanRateExceeded, got {other:?}"),
     }
@@ -213,7 +221,6 @@ fn orphan_rate_gate_fails_loud_when_exceeded() {
 #[test]
 fn orphan_under_ceiling_succeeds() {
     let out = unique_out("orphan_ok");
-    // 1 joined + 1 orphan → orphan_rate 0.5, under a 0.75 ceiling.
     let records = vec![
         gateway(0, 1000, CaptureOutcome::ClampLinear),
         gateway(1, 5000, CaptureOutcome::Deny),
@@ -221,10 +228,10 @@ fn orphan_under_ceiling_succeeds() {
     let bag = InMemoryBag::new("synthetic", vec![bus_msg(1005, "model_v1", None, "bag#gw0")]);
     let cfg = CollectorConfig { pass_rate: 1.0, window_ms: 100, max_orphan_rate: 0.75, out_dir: out.clone() };
 
-    let recon = run(records, &bag, &cfg).expect("under ceiling → ok");
-    assert_eq!(recon.joined, 1);
-    assert_eq!(recon.orphans, 1);
-    assert_eq!(recon.orphan_rate, 0.5);
+    let m = run(records, &bag, &lineage(), &cfg).expect("under ceiling → ok");
+    assert_eq!(m.quality.joined, 1);
+    assert_eq!(m.quality.orphans, 1);
+    assert_eq!(m.quality.orphan_rate, 0.5);
     cleanup(&out);
 }
 
@@ -235,7 +242,6 @@ fn distinct_doer_versions_produce_distinct_partitions() {
         gateway(0, 1000, CaptureOutcome::ClampLinear),
         gateway(1, 2000, CaptureOutcome::ClampLinear),
     ];
-    // Same source, two different doer versions on the bus side.
     let bag = InMemoryBag::new(
         "synthetic",
         vec![
@@ -245,12 +251,11 @@ fn distinct_doer_versions_produce_distinct_partitions() {
     );
     let cfg = CollectorConfig { pass_rate: 1.0, window_ms: 100, max_orphan_rate: 0.0, out_dir: out.clone() };
 
-    let recon = run(records, &bag, &cfg).expect("run ok");
-    assert_eq!(recon.joined, 2);
+    let m = run(records, &bag, &lineage(), &cfg).expect("run ok");
+    assert_eq!(m.quality.joined, 2);
+    assert_eq!(m.doer_versions, vec!["model_v1".to_string(), "model_v2".to_string()]);
     let parts = list_parquet_parts(&out).unwrap();
     assert_eq!(parts.len(), 2, "one partition per doer_version");
-    assert!(out.join("doer_version=model_v1/source=COMMAND_GATEWAY/part-000.parquet").exists());
-    assert!(out.join("doer_version=model_v2/source=COMMAND_GATEWAY/part-000.parquet").exists());
     cleanup(&out);
 }
 
@@ -261,20 +266,16 @@ fn read_jsonl_and_dedup_round_trips_through_the_pipeline() {
     std::fs::create_dir_all(&dir).unwrap();
     let capture_path = dir.join("capture.jsonl");
 
-    // Two lines, the SECOND a duplicate (source, decision_seq) of the first.
     let r0 = gateway(0, 1000, CaptureOutcome::ClampLinear);
     let dup = gateway(0, 1000, CaptureOutcome::Allow); // same key → dropped
     let r1 = trajectory(0, 2000, 42, CaptureOutcome::Deny);
-    let body = format!(
-        "{}\n{}\n\n{}\n", // blank line tolerated
-        serde_json::to_string(&r0).unwrap(),
-        serde_json::to_string(&dup).unwrap(),
-        serde_json::to_string(&r1).unwrap(),
-    );
-    std::fs::write(&capture_path, body).unwrap();
+    write_jsonl(&capture_path, &[r0, dup, r1]);
 
-    let records = kirra_collector::read_jsonl(&[capture_path]).unwrap();
-    assert_eq!(records.len(), 3, "read_jsonl reads every non-blank line incl. the dup");
+    let (records, inputs) = read_jsonl_with_digests(&[capture_path]).unwrap();
+    assert_eq!(records.len(), 3, "reads every non-blank line incl. the dup");
+    assert_eq!(inputs[0].record_count, 3);
+    assert_eq!(inputs[0].command_gateway, 2);
+    assert_eq!(inputs[0].slow_loop_trajectory, 1);
 
     let bag = InMemoryBag::new(
         "synthetic",
@@ -283,11 +284,122 @@ fn read_jsonl_and_dedup_round_trips_through_the_pipeline() {
             bus_msg(2005, "model_v1", Some(42), "bag#tj0"),
         ],
     );
+    let lin = Lineage { inputs, bag_backend: "bag-json".to_string() };
     let cfg = CollectorConfig { pass_rate: 1.0, window_ms: 100, max_orphan_rate: 0.0, out_dir: out.clone() };
-    let recon = run(records, &bag, &cfg).expect("run ok");
-    assert_eq!(recon.duplicates_dropped, 1, "the duplicate (source, decision_seq) is dropped");
-    assert_eq!(recon.records_in, 2, "two distinct records survive dedup");
-    assert_eq!(recon.joined, 2);
+    let m = run(records, &bag, &lin, &cfg).expect("run ok");
+    assert_eq!(m.quality.duplicates_dropped, 1, "the duplicate (source, decision_seq) is dropped");
+    assert_eq!(m.quality.records_in, 2, "two distinct records survive dedup");
+    assert_eq!(m.quality.joined, 2);
+    cleanup(&out);
+    cleanup(&dir);
+}
+
+// ---- Phase 2: manifest + lineage + reproducibility -------------------------
+
+/// Run the same capture file + bag twice → identical `dataset_id`; a perturbed
+/// input or a changed param → a different id. (`created_at` is excluded from the
+/// id by construction — `compute_dataset_id` takes no such argument; see the
+/// unit test in manifest.rs.)
+#[test]
+fn dataset_id_is_reproducible_and_input_sensitive() {
+    let dir = unique_out("detin");
+    std::fs::create_dir_all(&dir).unwrap();
+    let cap = dir.join("cap.jsonl");
+    write_jsonl(&cap, &[gateway(0, 1000, CaptureOutcome::ClampLinear), trajectory(0, 2000, 42, CaptureOutcome::Deny)]);
+    let bag = InMemoryBag::new(
+        "synthetic",
+        vec![bus_msg(1005, "model_v1", None, "a"), bus_msg(2005, "model_v1", Some(42), "b")],
+    );
+
+    let run_id = |cap_path: &Path, pass_rate: f64| -> String {
+        let (records, inputs) = read_jsonl_with_digests(&[cap_path.to_path_buf()]).unwrap();
+        let lin = Lineage { inputs, bag_backend: "bag-json".to_string() };
+        let cfg = CollectorConfig { pass_rate, window_ms: 100, max_orphan_rate: 1.0, out_dir: unique_out("idrun") };
+        let m = run(records, &bag, &lin, &cfg).expect("run ok");
+        cleanup(&cfg.out_dir);
+        m.dataset_id
+    };
+
+    let id1 = run_id(&cap, 1.0);
+    let id2 = run_id(&cap, 1.0);
+    assert_eq!(id1, id2, "same inputs + params + build → identical dataset_id");
+
+    let id_rate = run_id(&cap, 0.5);
+    assert_ne!(id1, id_rate, "different pass_rate → different dataset_id");
+
+    // Perturb one input record (different decision_seq → different bytes + content).
+    let cap2 = dir.join("cap2.jsonl");
+    write_jsonl(&cap2, &[gateway(0, 1000, CaptureOutcome::ClampLinear), trajectory(9, 2000, 42, CaptureOutcome::Deny)]);
+    let id_perturbed = run_id(&cap2, 1.0);
+    assert_ne!(id1, id_perturbed, "a perturbed input record → different dataset_id");
+
+    cleanup(&dir);
+}
+
+/// The manifest records full lineage + the run's quality verbatim, and is written
+/// as valid JSON at the dataset root.
+#[test]
+fn manifest_records_lineage_quality_and_partitions() {
+    let dir = unique_out("manin");
+    std::fs::create_dir_all(&dir).unwrap();
+    let cap = dir.join("cap.jsonl");
+    write_jsonl(
+        &cap,
+        &[
+            gateway(0, 1000, CaptureOutcome::Allow),
+            gateway(1, 1100, CaptureOutcome::ClampLinear),
+            trajectory(0, 2000, 42, CaptureOutcome::Deny),
+        ],
+    );
+    let (records, inputs) = read_jsonl_with_digests(&[cap.clone()]).unwrap();
+    let lin = Lineage { inputs, bag_backend: "bag-json".to_string() };
+    let out = unique_out("manout");
+    let cfg = CollectorConfig { pass_rate: 1.0, window_ms: 100, max_orphan_rate: 1.0, out_dir: out.clone() };
+    let bag = InMemoryBag::new(
+        "synthetic.json",
+        vec![
+            bus_msg(1005, "v1", None, "a"),
+            bus_msg(1105, "v1", None, "b"),
+            bus_msg(2005, "v1", Some(42), "c"),
+        ],
+    );
+
+    let m = run(records, &bag, &lin, &cfg).expect("run ok");
+
+    // Inputs lineage.
+    assert_eq!(m.inputs.len(), 1);
+    assert_eq!(m.inputs[0].record_count, 3);
+    assert_eq!(m.inputs[0].command_gateway, 2);
+    assert_eq!(m.inputs[0].slow_loop_trajectory, 1);
+    assert_eq!(m.inputs[0].sha256.len(), 64, "sha256 hex is 64 chars");
+
+    // Quality == the run reconciliation.
+    assert_eq!(m.quality.records_in, 3);
+    assert_eq!(m.quality.joined, 3);
+    assert_eq!(m.quality.orphans, 0);
+
+    // Partitions (gateway + trajectory, single doer_version) with row counts.
+    assert_eq!(m.partitions.len(), 2);
+    assert_eq!(m.partitions.iter().map(|p| p.row_count).sum::<usize>(), 3);
+    assert!(m.partitions.iter().all(|p| p.relative_path.ends_with("part-000.parquet")));
+
+    // Provenance present.
+    assert!(!m.collector.version.is_empty());
+    assert!(!m.schema.version.is_empty());
+    assert_eq!(m.schema.crate_name, "kirra-capture-schema");
+    assert_eq!(m.bag.backend, "bag-json");
+    assert!(m.bag.uri.contains("synthetic"));
+    assert_eq!(m.doer_versions, vec!["v1".to_string()]);
+    assert_eq!(m.decision_t_wall_ms_min, Some(1000));
+    assert_eq!(m.decision_t_wall_ms_max, Some(2000));
+
+    // manifest.json written + valid JSON carrying the same id.
+    let mf = out.join("manifest.json");
+    assert!(mf.exists());
+    let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&mf).unwrap()).unwrap();
+    assert_eq!(v["dataset_id"].as_str().unwrap(), m.dataset_id);
+    assert_eq!(v["quality"]["joined"].as_u64().unwrap(), 3);
+
     cleanup(&out);
     cleanup(&dir);
 }


### PR DESCRIPTION
#195 merged only Stage A + B; this brings the Phase 2 manifest/lineage commit to main.

- Adds `crates/kirra-collector/src/manifest.rs` + `build.rs`: a `manifest.json` at each dataset root with full lineage (collector + schema versions, git commit, per-input sha256 + counts, bag reference), the quality `Reconciliation` verbatim, the partitions written, and a **reproducible `dataset_id`** (sha256 over the logical content + lineage; excludes `created_at` and the physical Parquet bytes).
- Single commit, **collector-crate-only** (manifest.rs, build.rs, Cargo.toml +sha2, dataset.rs, lib.rs, main.rs, tests/pipeline.rs).
- Verdict-path blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b` held; `cargo tree -p kirra-collector` has no `kirra-runtime-sdk` (sha2 is the only new dep); 16 collector tests + 509 SDK lib tests green; whole workspace builds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv)_