### PR TITLE
fix(ros2-adapter): clone posture for slow-loop capture (E0382)

### DIFF
--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -402,7 +402,7 @@ pub async fn run_adapter(
                 &objects,
                 &slow_state.config,
                 odom.as_ref(),
-                posture,
+                posture.clone(),
                 effective_perception_cap,
             );
             let now_ms = std::time::SystemTime::now()


### PR DESCRIPTION
## Summary
One-line, ros2-feature-only build fix. `FleetPosture` is moved into `validate_trajectory_slow_capped`, then used again by `record_from_trajectory_verdict` in the Phase-1.5 capture block (`crates/kirra-ros2-adapter/src/node.rs`). `FleetPosture` isn't `Copy`, so the second use fails to borrow-check (E0382). Clone at the validate call site (fieldless enum, negligible cost) so the original survives to the capture record.

## Why CI didn't catch it
The break is only reachable under `--features ros2`; there is no ros2 build job in CI.

## Verification
- `cargo build -p kirra-ros2-adapter --features ros2` compiles + links cleanly (curated `ros2_ws/install` msgs sourced).
- Verdict path `src/gateway/kinematics_contract.rs` unchanged (blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b`).
- Diff is exactly one line: `posture,` → `posture.clone(),`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)