### PR TITLE
feat(collector): real rosbag2 .db3 BagReader (C2)

### DIFF
--- a/crates/kirra-collector/Cargo.toml
+++ b/crates/kirra-collector/Cargo.toml
@@ -14,6 +14,8 @@ serde_json = "1.0"
 arrow = "58"
 parquet = "58"
 sha2 = "0.10"
+# [C2] real rosbag2 db3 backend (Db3BagReader). bundled = vendored SQLite (no system dep).
+rusqlite = { version = "0.31", features = ["bundled"] }
 
 [[bin]]
 name = "kirra-collector"

--- a/crates/kirra-collector/src/bag.rs
+++ b/crates/kirra-collector/src/bag.rs
@@ -96,3 +96,254 @@ impl BagReader for InMemoryBag {
             .collect()
     }
 }
+
+/// Errors from opening a real rosbag2 bag.
+#[derive(Debug)]
+pub enum BagError {
+    /// Failed to open the sqlite file or run the topic-resolution query.
+    Open(rusqlite::Error),
+    /// The requested join topic is not present in the bag's `topics` table.
+    TopicNotFound(String),
+}
+
+impl std::fmt::Display for BagError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BagError::Open(e) => write!(f, "opening rosbag2 db3: {e}"),
+            BagError::TopicNotFound(t) => write!(f, "join topic not found in bag: {t}"),
+        }
+    }
+}
+
+impl std::error::Error for BagError {}
+
+/// Real rosbag2 sqlite3 (`.db3`) backend [C2].
+///
+/// This reads the bag's `topics`/`messages` tables and indexes the join topic
+/// by message timestamp — it does NOT deserialize the CDR payloads
+/// (docs/COLLECTOR_DESIGN.md [D4]: reference the heavy frames, never copy or
+/// decode them). Consequently it populates `t_wall_ms`, the run's `doer_version`
+/// [D3], and a `bulk_ref` (`uri#topic@stamp_ns`); the [D2] cross-check keys
+/// (`asset_id`/`trajectory_id`/`objects_ms`) are left `None`, which the join
+/// treats as "not asserted" (it never vetoes — see `join::keys_agree`). Richer
+/// cross-check stamping requires the doer to emit a structured bus-index topic,
+/// deferred to [C2b]. MCAP is a separate follow-up.
+pub struct Db3BagReader {
+    uri: String,
+    topic: String,
+    conn: rusqlite::Connection,
+    topic_id: i64,
+    doer_version: String,
+}
+
+impl Db3BagReader {
+    /// Open a rosbag2 `.db3` read-only and resolve the join `topic` to its id.
+    /// `doer_version` is supplied out-of-band (one recording == one doer build);
+    /// it can't be read without decoding the payload, which we deliberately don't.
+    pub fn open(
+        path: &std::path::Path,
+        topic: &str,
+        doer_version: impl Into<String>,
+    ) -> Result<Self, BagError> {
+        let conn = rusqlite::Connection::open_with_flags(
+            path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )
+        .map_err(BagError::Open)?;
+        let topic_id: i64 = conn
+            .query_row("SELECT id FROM topics WHERE name = ?1", [topic], |r| r.get(0))
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => BagError::TopicNotFound(topic.to_string()),
+                other => BagError::Open(other),
+            })?;
+        Ok(Self {
+            uri: path.display().to_string(),
+            topic: topic.to_string(),
+            conn,
+            topic_id,
+            doer_version: doer_version.into(),
+        })
+    }
+}
+
+impl BagReader for Db3BagReader {
+    fn bag_uri(&self) -> &str {
+        &self.uri
+    }
+
+    fn messages_in_window(&self, t_wall_ms: u64, window_ms: u64) -> Vec<BusMessage> {
+        // rosbag2 stamps are nanoseconds; the join window is milliseconds. Mirror
+        // InMemoryBag's inclusive [t-window, t+window] ms window (the +999_999
+        // covers the whole upper millisecond).
+        let lo_ns = t_wall_ms.saturating_sub(window_ms).saturating_mul(1_000_000);
+        let hi_ns = t_wall_ms
+            .saturating_add(window_ms)
+            .saturating_mul(1_000_000)
+            .saturating_add(999_999);
+        let mut stmt = match self.conn.prepare(
+            "SELECT timestamp FROM messages WHERE topic_id = ?1 AND timestamp BETWEEN ?2 AND ?3",
+        ) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        // The trait signature is infallible (Vec); a query error degrades to an
+        // empty window -> the record becomes an ORPHAN, surfaced by reconciliation
+        // rather than silently lost. `open()` already validated topic + handle.
+        let rows = stmt.query_map(
+            rusqlite::params![self.topic_id, lo_ns as i64, hi_ns as i64],
+            |r| r.get::<_, i64>(0),
+        );
+        let Ok(rows) = rows else { return Vec::new() };
+        rows.flatten()
+            .map(|ts| {
+                let ts_ns = ts as u64;
+                BusMessage {
+                    t_wall_ms: ts_ns / 1_000_000,
+                    doer_version: self.doer_version.clone(),
+                    asset_id: None,
+                    trajectory_id: None,
+                    objects_ms: None,
+                    bulk_ref: format!("{}#{}@{}", self.uri, self.topic, ts_ns),
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod db3_tests {
+    use super::*;
+
+    // Build a faithful synthetic rosbag2 db3 (core schema + the extra Jazzy
+    // `type_description_hash` column, to prove the reader doesn't depend on it).
+    fn make_bag(path: &std::path::Path) {
+        let _ = std::fs::remove_file(path);
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE topics(
+                id INTEGER PRIMARY KEY, name TEXT NOT NULL, type TEXT NOT NULL,
+                serialization_format TEXT NOT NULL, offered_qos_profiles TEXT NOT NULL,
+                type_description_hash TEXT NOT NULL);
+             CREATE TABLE messages(
+                id INTEGER PRIMARY KEY, topic_id INTEGER NOT NULL,
+                timestamp INTEGER NOT NULL, data BLOB NOT NULL);
+             CREATE INDEX timestamp_idx ON messages(timestamp ASC);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO topics VALUES (1,'/planning/trajectory','autoware_planning_msgs/msg/Trajectory','cdr','','h1')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO topics VALUES (2,'/perception/objects','autoware_perception_msgs/msg/PredictedObjects','cdr','','h2')",
+            [],
+        ).unwrap();
+        let payload: &[u8] = &[0xAA, 0xBB]; // opaque CDR — the reader must never decode it
+        for (id, ts) in [(1i64, 1_000_000_000i64), (2, 1_010_000_000), (3, 1_050_000_000), (4, 2_000_000_000)] {
+            conn.execute(
+                "INSERT INTO messages (id, topic_id, timestamp, data) VALUES (?1, 1, ?2, ?3)",
+                rusqlite::params![id, ts, payload],
+            ).unwrap();
+        }
+        // a message on the OTHER topic must never leak into the trajectory query
+        conn.execute(
+            "INSERT INTO messages (id, topic_id, timestamp, data) VALUES (99, 2, 1005000000, ?1)",
+            rusqlite::params![payload],
+        ).unwrap();
+    }
+
+    fn tmp_db() -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("kirra_db3_{}_{}.db3", std::process::id(), nanos))
+    }
+
+    #[test]
+    fn window_math_matches_inmemory_semantics() {
+        let db = tmp_db();
+        make_bag(&db);
+        let r = Db3BagReader::open(&db, "/planning/trajectory", "doer-v1.2.3").unwrap();
+
+        // ±100ms around 1000ms == [900,1100] -> 1000,1010,1050 (NOT 2000)
+        let mut ms: Vec<u64> = r.messages_in_window(1000, 100).iter().map(|m| m.t_wall_ms).collect();
+        ms.sort_unstable();
+        assert_eq!(ms, vec![1000, 1010, 1050]);
+
+        // ±30ms around 1050 -> just 1050
+        let ms2: Vec<u64> = r.messages_in_window(1050, 30).iter().map(|m| m.t_wall_ms).collect();
+        assert_eq!(ms2, vec![1050]);
+
+        let _ = std::fs::remove_file(&db);
+    }
+
+    #[test]
+    fn stamps_version_refs_topic_and_isolates_topic() {
+        let db = tmp_db();
+        make_bag(&db);
+        let r = Db3BagReader::open(&db, "/planning/trajectory", "doer-v1.2.3").unwrap();
+
+        let all = r.messages_in_window(1005, 1000); // huge window
+        assert_eq!(all.len(), 4, "only the 4 trajectory msgs; the perception topic is excluded");
+        assert!(all.iter().all(|m| m.doer_version == "doer-v1.2.3"), "doer_version stamped [D3]");
+        assert!(
+            all.iter().all(|m| m.asset_id.is_none() && m.trajectory_id.is_none() && m.objects_ms.is_none()),
+            "cross-check keys left None (no CDR decode); join treats None as not-asserted [D2]/[D4]"
+        );
+        assert!(all.iter().all(|m| m.bulk_ref.contains("#/planning/trajectory@")));
+
+        let exact = r.messages_in_window(1000, 5);
+        assert_eq!(exact.len(), 1);
+        assert_eq!(exact[0].bulk_ref, format!("{}#/planning/trajectory@1000000000", db.display()));
+        assert_eq!(r.bag_uri(), db.display().to_string());
+
+        let _ = std::fs::remove_file(&db);
+    }
+
+    #[test]
+    fn topic_not_found_is_a_clean_error() {
+        let db = tmp_db();
+        make_bag(&db);
+        assert!(matches!(
+            Db3BagReader::open(&db, "/does/not/exist", "v"),
+            Err(BagError::TopicNotFound(_))
+        ));
+        let _ = std::fs::remove_file(&db);
+    }
+
+    // The real reason this backend is valid as a first cut: a record joins
+    // against it through the same join path, using time + version + bulk_ref.
+    #[test]
+    fn joins_through_the_real_join_path() {
+        use crate::join::{join_record, JoinOutcome};
+        use kirra_capture_schema::{CaptureOutcome, CaptureRecord, CaptureSource};
+
+        let db = tmp_db();
+        make_bag(&db);
+        let r = Db3BagReader::open(&db, "/planning/trajectory", "doer-v1.2.3").unwrap();
+
+        let rec = CaptureRecord {
+            decision_seq: 0,
+            t_mono_ns: 0,
+            t_wall_ms: 1008, // within ±100ms of the 1000/1010 stamps
+            source: CaptureSource::CommandGateway,
+            proposed: None,
+            traj: None,
+            outcome: CaptureOutcome::Allow,
+            deny_code: None,
+            safe_value: None,
+            mrc: false,
+            posture: "NOMINAL".to_string(),
+            derate_enabled: false,
+        };
+        let JoinOutcome::Joined(m) = join_record(&rec, &r, 100) else {
+            panic!("expected a join against the db3 bag");
+        };
+        assert_eq!(m.doer_version, "doer-v1.2.3");
+        assert_eq!(m.matched_t_wall_ms, 1010, "nearest-in-time to 1008 is the 1010 stamp");
+        assert!(m.bulk_ref.ends_with("@1010000000"));
+
+        let _ = std::fs::remove_file(&db);
+    }
+}

--- a/crates/kirra-collector/src/main.rs
+++ b/crates/kirra-collector/src/main.rs
@@ -16,13 +16,15 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use kirra_collector::bag::InMemoryBag;
+use kirra_collector::bag::{BagReader, Db3BagReader, InMemoryBag};
 use kirra_collector::{read_jsonl_with_digests, run, CollectorConfig, CollectorError, Lineage};
 
 struct Args {
     captures: Vec<PathBuf>,
     bag_json: Option<PathBuf>,
     bag_real: Option<PathBuf>,
+    bag_topic: Option<String>,
+    doer_version: Option<String>,
     out: Option<PathBuf>,
     pass_rate: f64,
     window_ms: u64,
@@ -35,6 +37,8 @@ impl Default for Args {
             captures: Vec::new(),
             bag_json: None,
             bag_real: None,
+            bag_topic: None,
+            doer_version: None,
             out: None,
             pass_rate: 1.0,
             window_ms: 100,
@@ -48,7 +52,9 @@ kirra-collector — offline learning-loop collector
 
   --capture <path>          capture JSONL (repeatable; at least one required)
   --bag-json <path>         synthetic bus recording (JSON array of bus messages)
-  --bag <path>              real rosbag2 db3/MCAP backend (NOT yet wired — C2)
+  --bag <path>              real rosbag2 .db3 backend (C2). Requires --bag-topic + --doer-version
+  --bag-topic <topic>       doer trajectory/proposal topic to index in the .db3
+  --doer-version <ver>      doer build stamped on joined rows (can't be read from CDR)
   --out <dir>               output dataset root (required)
   --pass-rate <f64>         ALLOW sampling rate, default 1.0 (keep all)
   --window-ms <u64>         join window ± ms, default 100
@@ -64,6 +70,8 @@ fn parse_args() -> Result<Args, String> {
             "--capture" => args.captures.push(PathBuf::from(next("--capture")?)),
             "--bag-json" => args.bag_json = Some(PathBuf::from(next("--bag-json")?)),
             "--bag" => args.bag_real = Some(PathBuf::from(next("--bag")?)),
+            "--bag-topic" => args.bag_topic = Some(next("--bag-topic")?),
+            "--doer-version" => args.doer_version = Some(next("--doer-version")?),
             "--out" => args.out = Some(PathBuf::from(next("--out")?)),
             "--pass-rate" => {
                 args.pass_rate = next("--pass-rate")?.parse().map_err(|e| format!("--pass-rate: {e}"))?
@@ -103,21 +111,51 @@ fn main() -> ExitCode {
         }
     };
 
-    // [C2] real bag backend deferred until the bench records its first session.
-    if let Some(p) = &args.bag_real {
-        eprintln!(
-            "error: --bag {} — the rosbag2 db3/MCAP backend is not wired yet (C2, \
-             bench not up). Use --bag-json for offline runs.",
-            p.display()
-        );
-        return ExitCode::FAILURE;
-    }
-
-    let bag = match InMemoryBag::from_json_file(args.bag_json.as_ref().unwrap()) {
-        Ok(b) => b,
-        Err(e) => {
-            eprintln!("error: reading --bag-json: {e}");
-            return ExitCode::FAILURE;
+    let (bag, bag_backend): (Box<dyn BagReader>, &str) = if let Some(p) = &args.bag_real {
+        match p.extension().and_then(|e| e.to_str()) {
+            Some("db3") => {
+                let Some(topic) = args.bag_topic.as_deref() else {
+                    eprintln!("error: --bag <db3> requires --bag-topic <doer trajectory topic>");
+                    return ExitCode::FAILURE;
+                };
+                let Some(ver) = args.doer_version.as_deref() else {
+                    eprintln!(
+                        "error: --bag <db3> requires --doer-version <run's doer build> \
+                         (it can't be read without decoding payloads)"
+                    );
+                    return ExitCode::FAILURE;
+                };
+                match Db3BagReader::open(p, topic, ver) {
+                    Ok(r) => (Box::new(r), "db3"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        return ExitCode::FAILURE;
+                    }
+                }
+            }
+            Some("mcap") => {
+                eprintln!(
+                    "error: --bag {} — the MCAP backend is deferred (C2b). \
+                     Use a .db3 bag or --bag-json.",
+                    p.display()
+                );
+                return ExitCode::FAILURE;
+            }
+            _ => {
+                eprintln!(
+                    "error: --bag {} — unrecognized bag extension (expected .db3).",
+                    p.display()
+                );
+                return ExitCode::FAILURE;
+            }
+        }
+    } else {
+        match InMemoryBag::from_json_file(args.bag_json.as_ref().unwrap()) {
+            Ok(b) => (Box::new(b), "bag-json"),
+            Err(e) => {
+                eprintln!("error: reading --bag-json: {e}");
+                return ExitCode::FAILURE;
+            }
         }
     };
 
@@ -131,7 +169,7 @@ fn main() -> ExitCode {
 
     let lineage = Lineage {
         inputs: input_digests,
-        bag_backend: "bag-json".to_string(),
+        bag_backend: bag_backend.to_string(),
     };
     let cfg = CollectorConfig {
         pass_rate: args.pass_rate,
@@ -140,7 +178,7 @@ fn main() -> ExitCode {
         out_dir: args.out.unwrap(),
     };
 
-    match run(records, &bag, &lineage, &cfg) {
+    match run(records, bag.as_ref(), &lineage, &cfg) {
         Ok(manifest) => {
             println!("{}", manifest.quality.summary());
             println!("dataset_id = {}", manifest.dataset_id);


### PR DESCRIPTION
Db3BagReader reads rosbag2 topics/messages and indexes the join topic by timestamp, referencing frames via bulk_ref without decoding CDR ([D4]). Populates t_wall_ms + doer_version + bulk_ref; [D2] cross-check keys left None (join treats None as not-asserted). Wires --bag/--bag-topic/--doer-version. rusqlite (bundled). MCAP + structured cross-check index deferred (C2b). Verdict path unchanged; §0 boundary intact (no kirra-runtime-sdk dep).

## Verification (run in-sandbox on modern Rust)
- `cargo test -p kirra-collector` → **green**: lib 12 passed (incl. the 4 new `db3_tests`: window math, version/ref/topic-isolation, topic-not-found error, join through the real `join_record` path) + pipeline 8 passed.
- `cargo build -p kirra-collector` → the `--bag`/`--bag-topic`/`--doer-version` CLI wiring compiles clean.
- §0 safety boundary: `cargo tree -p kirra-collector` shows no `kirra-runtime-sdk` dep (only `kirra-capture-schema` + serde/serde_json/arrow/parquet/sha2/rusqlite).
- Verdict blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b` unchanged.
- Rebased onto current `main` (post-#196): exactly one signed commit; diff is exactly the 3 collector files.

https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDQqeLoq55WnmAQ445YyGv)_