### PR TITLE
fix(bridge): correct CMakeLists relative-path overshoot in kirra_bridge_cpp

### DIFF
--- a/ros2_ws/src/kirra_bridge_cpp/CMakeLists.txt
+++ b/ros2_ws/src/kirra_bridge_cpp/CMakeLists.txt
@@ -12,13 +12,13 @@ find_package(std_msgs REQUIRED)
 
 add_executable(kirra_bridge_node src/kirra_bridge_node.cpp)
 
-target_include_directories(kirra_bridge_node PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../../../include")
-target_link_directories(kirra_bridge_node PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../../../target/release")
+target_include_directories(kirra_bridge_node PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../../include")
+target_link_directories(kirra_bridge_node PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../../target/release")
 
 ament_target_dependencies(kirra_bridge_node rclcpp geometry_msgs std_msgs)
 target_link_libraries(kirra_bridge_node kirra_runtime_sdk)
 
-set_target_properties(kirra_bridge_node PROPERTIES INSTALL_RPATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../target/release")
+set_target_properties(kirra_bridge_node PROPERTIES INSTALL_RPATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../target/release")
 
 install(TARGETS kirra_bridge_node DESTINATION lib/${PROJECT_NAME})
 ament_package()


### PR DESCRIPTION
## What

Corrects a relative-path overshoot in `ros2_ws/src/kirra_bridge_cpp/CMakeLists.txt`. The package sits **three** levels below the repo root, but the include dir, link dir, and `INSTALL_RPATH` used `../../../../` (**four** levels), resolving *above* the repo:

```
<repo>/ros2_ws/src/kirra_bridge_cpp/CMakeLists.txt
../        -> ros2_ws/src
../../     -> ros2_ws
../../../  -> <repo>              <-- correct: include/ and target/release/ live here
../../../../ -> <parent of repo>  <-- WRONG (what was committed)
```

So `kirra_bridge_cpp` could never find `include/kirra.h` (`fatal error: kirra.h: No such file or directory`). Fix = drop one `../` from each of the three occurrences (include dir, link dir, rpath).

## Scope

- **CMake-only**, 3 lines changed. No Rust changes; the verdict path (`src/gateway/kinematics_contract.rs`) is untouched.
- Deliberately **separate from #201** (the adapter `--features ros2` CI gate, which is correctly green by *skipping* the C++ bridge). Actually gating the bridge build in CI — which additionally needs a prebuilt cdylib (`cargo build --release`) — is a heavier, separate job for later.
- `include/kirra.h` is already committed; the cdylib comes from the root crate (`crate-type = ["rlib","cdylib"]`), so no header-generation step is needed for that future bridge gate.

## Verification

- Path fix is arithmetic and correct by construction: with `../../../`, `${CMAKE_CURRENT_SOURCE_DIR}/../../../include` resolves to `<repo>/include`, where `kirra.h` lives (confirmed).
- A full colcon build of the bridge needs ROS + the prebuilt cdylib and is not exercised here (no bridge-in-CI gate yet).

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_