### PR TITLE
chore(collector): drop unused PathBuf import in dataset.rs

### DIFF
--- a/crates/kirra-collector/src/dataset.rs
+++ b/crates/kirra-collector/src/dataset.rs
@@ -9,7 +9,7 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, BooleanArray, Float64Array, StringArray, UInt64Array};


### PR DESCRIPTION
## What

`crates/kirra-collector/src/dataset.rs` imported `use std::path::{Path, PathBuf};` but only `Path` is used (the `read_part_columns_and_rows` / `write_dataset` signatures). Trim the unused `PathBuf`:

```rust
-use std::path::{Path, PathBuf};
+use std::path::Path;
```

## Scope

- Pure cleanup, 1 line. No behavior change.
- Build-safe by construction: if `PathBuf` were actually used, compilation would already fail — it isn't. Confirmed `PathBuf` occurred exactly once (the import) on `main`; after this change there are zero `PathBuf` references and `Path` is still imported.

_Note: a full `cargo build -p kirra-collector` wasn't run in the authoring sandbox (the collector needs Rust 1.85+ for parquet/edition2024 and the sandbox is older), but an unused-import removal can't change build outcome._

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_