### PR TITLE
feat(ros2-adapter): Phase I integration-harness observability + clean-accept probe

### DIFF
--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -266,6 +266,14 @@ pub async fn run_adapter(
         let mut traj_seq: u64 = 0;
         while let Some(msg) = s.next().await {
             let now = now_ms_wall();
+            // Phase I observability (integration-harness §I.1a): a per-callback
+            // entry event PROVES delivery (vs staleness) for the A-vs-B split.
+            tracing::info!(
+                target: "kirra::ingress",
+                topic = "trajectory",
+                stamp_ms = now,
+                "subscription_callback"
+            );
             traj_state.touch_trajectory(now);
             tracing::debug!(points = msg.points.len(), "trajectory_msg_received");
             let parsed = crate::parsing::parse_trajectory(&msg, now);
@@ -303,7 +311,14 @@ pub async fn run_adapter(
     tokio::spawn(async move {
         let mut s = obj_stream;
         while let Some(msg) = s.next().await {
-            obj_state.touch_objects(now_ms_wall());
+            let now = now_ms_wall();
+            tracing::info!(
+                target: "kirra::ingress",
+                topic = "objects",
+                stamp_ms = now,
+                "subscription_callback"
+            );
+            obj_state.touch_objects(now);
             let parsed = crate::parsing::parse_predicted_objects(&msg);
             obj_state.update_objects(parsed);
         }
@@ -314,7 +329,14 @@ pub async fn run_adapter(
     tokio::spawn(async move {
         let mut s = odom_stream;
         while let Some(msg) = s.next().await {
-            odom_state.touch_odom(now_ms_wall());
+            let now = now_ms_wall();
+            tracing::info!(
+                target: "kirra::ingress",
+                topic = "odometry",
+                stamp_ms = now,
+                "subscription_callback"
+            );
+            odom_state.touch_odom(now);
             let parsed = crate::parsing::parse_odom(&msg);
             odom_state.update_odom(parsed);
         }
@@ -418,10 +440,28 @@ pub async fn run_adapter(
                 now_ms,
             );
             let elapsed_us = start.elapsed().as_micros();
+            // Phase I observability (integration-harness §I.1b): carry posture +
+            // per-input freshness ages on the verdict span so a derate caused by
+            // stale inputs (Branch B) is distinguishable from non-delivery
+            // (Branch A) directly from the logs. A never-seen slot (last_*_ms == 0)
+            // reports u64::MAX rather than a misleadingly-huge "age since epoch".
+            let now_fresh = now_ms_wall();
+            let age_of =
+                |t: u64| if t == 0 { u64::MAX } else { now_fresh.saturating_sub(t) };
+            let traj_age_ms =
+                age_of(slow_state.last_trajectory_ms.load(std::sync::atomic::Ordering::Relaxed));
+            let objects_age_ms =
+                age_of(slow_state.last_objects_ms.load(std::sync::atomic::Ordering::Relaxed));
+            let odom_age_ms =
+                age_of(slow_state.last_odom_ms.load(std::sync::atomic::Ordering::Relaxed));
             tracing::info!(
                 asset_id = %traj.asset_id,
                 trajectory_id = traj.trajectory_id,
                 verdict = ?verdict,
+                posture = ?posture,
+                traj_age_ms,
+                objects_age_ms,
+                odom_age_ms,
                 elapsed_us = elapsed_us,
                 "trajectory_verdict"
             );

--- a/crates/kirra-ros2-adapter/tests/perception_mechanism_gate_ros2.rs
+++ b/crates/kirra-ros2-adapter/tests/perception_mechanism_gate_ros2.rs
@@ -151,6 +151,7 @@ use kirra_ros2_adapter::corridor::{CorridorSource, MockCorridorSource};
 use kirra_ros2_adapter::node::run_adapter;
 use kirra_ros2_adapter::perception_ingest::perception_derate_enabled;
 use kirra_ros2_adapter::state::{AdaptorState, TrajectoryVerdict};
+use kirra_runtime_sdk::verifier::FleetPosture;
 
 /// Adapter node name + namespace the harness publishes INTO. `run_adapter`
 /// creates the node in namespace `"kirra"`; the harness picks the name, so the
@@ -174,6 +175,23 @@ fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+/// Phase I observability (integration-harness §I.1). Install a tracing subscriber
+/// so the node's `kirra::ingress` `subscription_callback` events and the slow-loop
+/// `trajectory_verdict` spans (now carrying posture + per-input freshness ages) are
+/// visible under `--nocapture`. This is the harness's core defect fix: without a
+/// subscriber the existing PMON-004 test could not tell delivery (Branch A) from
+/// staleness (Branch B). Idempotent (`try_init`) so every `#[ignore]` test in this
+/// binary may call it; filter with `RUST_LOG` (defaults to `info`).
+fn init_tracing() {
+    use tracing_subscriber::{fmt, EnvFilter};
+    let _ = fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_test_writer()
+        .try_init();
 }
 
 /// A 3-pose straight trajectory at x = 60, 62, 64 (inside the 0..100 × ±5 m mock
@@ -384,5 +402,102 @@ async fn run_full_node_integration_async() {
     // no shutdown channel yet, Phase 4 — so abort is the clean exit), then drop
     // the harness node.
     adapter.abort();
+}
+
+// --- Phase I clean-accept delivery probe (integration-harness §I.2) ---
+
+/// The canonical A-vs-B discriminator. A plausible straight trajectory inside the
+/// mock corridor + BENIGN objects (scenario_b — all plausible, so the perception
+/// cap is nominal) + fresh odom must reach `Accept` at **Nominal** posture over
+/// real DDS. Holds in BOTH derate modes, because benign objects never trigger a
+/// cap — so this isolates *delivery + the clean verdict* from the derate matrix.
+///
+/// With `init_tracing` installed, read the `kirra::ingress` `subscription_callback`
+/// events while this runs:
+///   - reaches `Accept` + callbacks seen  → delivery works; the original
+///     scenario-b `MRCFallback` was a fixture artifact, not a product bug.
+///   - `MRCFallback` + NO callbacks       → Branch A (wiring): a topic / namespace
+///     / QoS / typesupport mismatch; the per-topic callback events pinpoint which
+///     subscription never fired.
+///   - `MRCFallback` + callbacks fire     → Branch B (staleness/stamping): inspect
+///     the `*_age_ms` fields on the `trajectory_verdict` span.
+///
+/// Live ROS 2 graph; run on a ROS-sourced dev box:
+///   source /opt/ros/${ROS_DISTRO}/setup.bash
+///   cargo test -p kirra-ros2-adapter --features ros2 \
+///       --test perception_mechanism_gate_ros2 clean_accept_delivery_probe \
+///       -- --ignored --nocapture
+#[test]
+#[ignore = "live ROS 2 node graph over real DDS; run via `-- --ignored` on a ROS-sourced dev box (see doc comment)"]
+fn clean_accept_delivery_probe() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(clean_accept_delivery_probe_async());
+}
+
+async fn clean_accept_delivery_probe_async() {
+    init_tracing();
+
+    // Distinct node name so this probe's topics don't collide with
+    // run_full_node_integration when both run in the same binary.
+    const PROBE_NODE: &str = "pmon004_clean_accept";
+    let probe_topic = |leaf: &str| format!("/{NS}/{PROBE_NODE}/input/{leaf}");
+
+    // Spawn the adapter sharing AdaptorState (the verdict observation point — the
+    // node publishes no output topic yet, Phase 4).
+    let state = AdaptorState::new();
+    let corridor: Arc<dyn CorridorSource> =
+        Arc::new(MockCorridorSource::straight_5m_half_width(100.0));
+    let adapter_state = Arc::clone(&state);
+    let adapter = tokio::spawn(async move {
+        let _ = run_adapter(adapter_state, corridor, PROBE_NODE).await;
+    });
+
+    // Harness publisher node (its own r2r context → real DDS to the adapter).
+    let ctx = r2r::Context::create().expect("harness r2r context");
+    let mut node =
+        r2r::Node::create(ctx, "pmon004_clean_accept_harness", NS).expect("harness node");
+    let traj_pub = node
+        .create_publisher::<r2r::autoware_planning_msgs::msg::Trajectory>(
+            &probe_topic("trajectory"),
+            r2r::QosProfile::default(),
+        )
+        .expect("trajectory publisher");
+    let obj_pub = node
+        .create_publisher::<r2r::autoware_perception_msgs::msg::PredictedObjects>(
+            &probe_topic("objects"),
+            r2r::QosProfile::default(),
+        )
+        .expect("objects publisher");
+    let odom_pub = node
+        .create_publisher::<r2r::nav_msgs::msg::Odometry>(
+            &probe_topic("odometry"),
+            r2r::QosProfile::default(),
+        )
+        .expect("odometry publisher");
+
+    // Benign, all-plausible objects → nominal cap → Accept regardless of derate.
+    let benign = fixture_to_predicted_objects(&scenario_b());
+    drive_until(
+        &state,
+        &traj_pub,
+        &odom_pub,
+        &obj_pub,
+        Some(&benign),
+        TrajectoryVerdict::Accept,
+        0,
+        "clean-accept delivery probe",
+    )
+    .await;
+
+    // Posture must be Nominal: no posture source is configured, so the
+    // PostureTracker stays in `nominal_default_no_source` mode.
+    assert_eq!(
+        state.current_posture(),
+        FleetPosture::Nominal,
+        "clean-accept must observe Nominal posture (no posture source configured)"
+    );
+
+    adapter.abort();
+    let _ = adapter.await;
 }
 


### PR DESCRIPTION
Phase I of the KIRRA Integration Harness (#205). Makes the live-DDS online path **observable** so the deferred PMON-004 sub-gate-1 **A-vs-B** question (non-delivery/wiring vs staleness) is answerable from the logs, and adds the canonical **clean-accept** delivery probe.

> ⚠️ **Draft — bench build/run required.** This is `ros2`-gated code (r2r). It does **not** compile in CI or the authoring sandbox (no ROS). It was authored against current `main` (`node.rs`, `perception_mechanism_gate_ros2.rs`) but has **not** been compiled — please build/run on a ROS 2 Jazzy box. The default-feature build of the crate is unaffected (verified).

## Changes

**`src/node.rs`** (observation only — verdict path untouched):
- Per-callback-entry `tracing` event (`target: "kirra::ingress"`, `topic`, `stamp_ms`) on each of the trajectory / objects / odometry drain tasks → **proves delivery** independent of staleness.
- Enriched the slow-loop `trajectory_verdict` span with `posture` + per-input freshness ages (`traj_age_ms` / `objects_age_ms` / `odom_age_ms`) → a stale-input derate (**Branch B**) is now distinguishable from non-delivery (**Branch A**) directly from the logs. A never-seen slot (`last_*_ms == 0`) reports `u64::MAX` rather than a misleading age-since-epoch.

**`tests/perception_mechanism_gate_ros2.rs`:**
- `init_tracing()` — installs a `RUST_LOG`-filtered subscriber with a test writer (the existing test installed **none**, which was the core observability defect). Idempotent `try_init`; called by both `#[ignore]` tests. Reuses the already-present optional `tracing-subscriber` dep (gated on `ros2`).
- `clean_accept_delivery_probe` — a plausible straight trajectory inside the mock corridor + **benign** objects (`scenario_b`, all plausible → nominal cap) + fresh odom must reach `Accept` at **Nominal** posture over real DDS. Holds in **both** derate modes (benign objects never trigger a cap), so it isolates *delivery + the clean verdict* from the derate matrix.

## How to run (bench)
```
source /opt/ros/${ROS_DISTRO}/setup.bash   # Jazzy
# clean-accept delivery probe (A-vs-B):
cargo test -p kirra-ros2-adapter --features ros2 \
    --test perception_mechanism_gate_ros2 clean_accept_delivery_probe \
    -- --ignored --nocapture
# full derate matrix, now observable (derate ON):
KIRRA_PERCEPTION_DERATE_ENABLED=1 cargo test -p kirra-ros2-adapter --features ros2 \
    --test perception_mechanism_gate_ros2 -- --ignored --nocapture
```

## A-vs-B reading (from the new spans)
| `clean-accept` over real DDS | `kirra::ingress` callbacks seen? | conclusion |
|---|---|---|
| `Accept` / Nominal | yes | **Delivery works** — the original scenario-b `MRCFallback` was a fixture artifact, not a product bug. |
| `MRCFallback` | **no** callbacks | **Branch A — wiring** (topic/namespace/QoS/typesupport). The per-topic callback events pinpoint which subscription never fired. |
| `MRCFallback` | yes, callbacks fire | **Branch B — staleness/stamping**: inspect the `*_age_ms` fields on the `trajectory_verdict` span. |

The existing scenario `(d)` (silent → stale → Clamp) already exercises Branch B and is now observable too.

## Scope / notes
- **Verdict path untouched** — no changes to `kinematics_contract.rs` / the verifier / the governor decision logic; purely spans + a test scenario.
- Phase II (standalone scenario player + collector capture-readback demo artifact, AWSIM/Orin on-ramps, the pure-Rust verdict-trace asserter) remains tracked in #205.

Closes part of #205 (Phase I).

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
**Build verified (June 2026):** `kirra-ros2-adapter` builds warning-free on Ubuntu 24.04 Jazzy fresh install with Autoware message workspace sourced. Unused `EgoOdom` import removed (chore PR above). QNX cross-compile config added to `.cargo/config.toml` for both x86_64 and aarch64le targets — see ADL-014 in `work/decisions.md` for full toolchain findings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_