### PR TITLE
test(cert): close ASIL-D zero-coverage goals SG-003 / SG-007 / SG-008 (CERT-003)

### DIFF
--- a/docs/safety/RTM_GAP_REPORT.md
+++ b/docs/safety/RTM_GAP_REPORT.md
@@ -30,6 +30,33 @@ The RTM's own self-reported coverage (`All 16 safety goals are covered`, `Total 
 
 ---
 
+## Update — CERT-003 ASIL-D increment (2026-06-07)
+
+The three remaining **ASIL-D** zero-coverage goals now have real, deterministic
+test evidence:
+
+| Goal | ASIL | Status after this increment | Tests (actual fn names / locations) |
+|---|---|---|---|
+| SG-003 | D | **CLOSED** | `src/telemetry_watchdog.rs` mod `sg_003_cert_tests`: `test_watchdog_marks_node_untrusted_after_timeout`, `test_watchdog_detection_latency_within_bound`, `test_watchdog_triggers_posture_recalculation` (RTM-named; in-crate because `watchdog_sweep_once` is `pub(crate)`) |
+| SG-007 | D | **propagation CLOSED**; causal-log sub-gap OPEN | `tests/fault_injection.rs::test_safety_goal_sg_007_cross_asset_lockout_propagation` (leader LockedOut → followers Degraded in one synchronous fabric pass, + precondition cross-check). The RTM-named `test_causal_log_records_propagation_event` remains OPEN: `FabricRouter::propagate_cross_asset_trust` does not record to any causal log — closing it needs propagation→causal-log wiring (a mechanism change), kept as an explicit stub. |
+| SG-008 | D | **CLOSED** | `src/bin/kirra_verifier_service.rs`: pure `check_startup_invariants` predicate + mod `sg_008_cert_tests` (admin-token / WAL / watchdog / posture-engine violations, all-present Ok, Active-vs-PassiveStandby distinction, check-order stability). `main` evaluates it immediately before `TcpListener::bind` and aborts on `Err` (fail-closed; bind never reached on violation). |
+
+Resulting goal-level coverage: **11 / 16 (68.75%)**. Every **ASIL-D** goal
+(SG-001, SG-002, SG-003, SG-005, SG-006, SG-007, SG-008) now has at least one
+real test. The remaining zero-coverage goals are all ASIL-B/C — **SG-009,
+SG-010, SG-012, SG-013, SG-015** — plus the SG-007 causal-log sub-gap noted above.
+
+Code-side traceability: `grep -rn "SG-0" src/` now returns **68** hits
+(mechanisms carry `// Verifies: SG-NNN` tags), up from ~0 in the canonical form.
+
+**Test-count reconciliation:** the long-stale "Total Test Suite Size: 306
+passing" figure is superseded — the core crate (`src/` + `tests/`) currently
+defines **582** `#[test]`/`#[tokio::test]` functions. (The 306 figure predates
+substantial test growth and should be treated as historical; downstream docs
+still quoting it — REQUIREMENTS_TRACEABILITY.md, SAFETY_CASE_INDEX.md,
+ROADMAP_TO_ASIL_D.md, IEC_61508_MAPPING.md, ASTM_F3269_MAPPING.md — are a
+separate reconciliation pass.)
+
 ## Gaps — goals without any test coverage
 
 After CERT-004 these **8** safety goals (down from 11) still have no real test in the codebase. SG-006, SG-014, and SG-016 were closed and now live in `tests/fault_injection.rs`. The remaining 8 stubs are in `tests/cert_003_rtm_gap_stubs.rs`, with infrastructure-required notes added for SG-010, SG-013, and SG-015.

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -79,6 +79,81 @@ async fn require_admin_token(request: Request, next: Next) -> Result<Response, S
     Ok(next.run(request).await)
 }
 
+// --- SG-008: process fail-closed startup sentinel ---------------------------
+//
+// Verifies: SG-008 (ASIL D) — Process Fail-Closed on Startup. The service must
+// refuse to bind its listener unless the safety-critical startup invariants
+// hold. The checks are factored into a pure predicate so they are
+// deterministically testable without `process::exit` (see sg_008_cert_tests):
+// `main` builds a `StartupContext` from the real boot facts, and aborts BEFORE
+// `TcpListener::bind` on any `Err` — so "the listener never binds before
+// invariants pass" holds by construction (bind is strictly after the check).
+
+/// The boot facts the startup sentinel evaluates. Built once in `main` from the
+/// real environment/store/wiring; consumed by `check_startup_invariants`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StartupContext {
+    /// `KIRRA_ADMIN_TOKEN` is present and non-empty (CRITICAL INVARIANT #6).
+    pub admin_token_present: bool,
+    /// The SQLite store reports `journal_mode = wal` (CRITICAL INVARIANT #12
+    /// ordering depends on the WAL-mode durable seam).
+    pub sqlite_wal: bool,
+    /// True on the Active path. PassiveStandby is read-only and intentionally
+    /// runs neither the watchdog nor the posture engine, so those two
+    /// invariants are evaluated ONLY when this is true.
+    pub mode_active: bool,
+    /// The telemetry watchdog task was spawned (Active path; SG-003 / SG9).
+    pub watchdog_spawned: bool,
+    /// The serialized posture-engine worker is running (`posture_engine_tx` set).
+    pub posture_engine_running: bool,
+}
+
+/// The first violated startup invariant, if any.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StartupInvariant {
+    AdminTokenMissing,
+    SqliteNotWal,
+    WatchdogNotSpawned,
+    PostureEngineDown,
+}
+
+impl std::fmt::Display for StartupInvariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::AdminTokenMissing => "KIRRA_ADMIN_TOKEN absent or empty",
+            Self::SqliteNotWal => "SQLite store is not in WAL journal mode",
+            Self::WatchdogNotSpawned => "telemetry watchdog not spawned (Active path)",
+            Self::PostureEngineDown => "posture-engine worker not running (Active path)",
+        };
+        write!(f, "{s}")
+    }
+}
+
+/// SG-008 (ASIL D) — pure startup-invariant predicate. Returns the first
+/// violated invariant, or `Ok(())` when all hold. Fail-closed and order-stable.
+/// The watchdog / posture-engine invariants apply only to the Active path
+/// (`mode_active`); PassiveStandby is read-only and runs neither, so requiring
+/// them there would wrongly abort a valid standby.
+//
+// Verifies: SG-008
+pub(crate) fn check_startup_invariants(ctx: &StartupContext) -> Result<(), StartupInvariant> {
+    if !ctx.admin_token_present {
+        return Err(StartupInvariant::AdminTokenMissing);
+    }
+    if !ctx.sqlite_wal {
+        return Err(StartupInvariant::SqliteNotWal);
+    }
+    if ctx.mode_active {
+        if !ctx.watchdog_spawned {
+            return Err(StartupInvariant::WatchdogNotSpawned);
+        }
+        if !ctx.posture_engine_running {
+            return Err(StartupInvariant::PostureEngineDown);
+        }
+    }
+    Ok(())
+}
+
 async fn require_client_identity(
     State(svc): State<Arc<ServiceState>>,
     request: Request,
@@ -1856,6 +1931,10 @@ async fn main() {
     // PassiveStandby does not run this — its promotion path already calls
     // recalculate_and_broadcast once on transition to Active. Ongoing
     // freshness on the freshly-promoted node is filed as a C2 follow-up.
+    // SG-008 startup-invariant fact: set true once the watchdog is spawned on
+    // the Active path (PassiveStandby leaves it false — and the sentinel does
+    // not require it there).
+    let mut watchdog_spawned = false;
     if svc_state.app.is_active() {
         kirra_runtime_sdk::posture_engine::recalculate_and_broadcast(
             &svc_state.app,
@@ -1888,6 +1967,7 @@ async fn main() {
             Arc::clone(&svc_state.app),
             posture_tx.clone(),
         );
+        watchdog_spawned = true;
         tracing::info!(
             timeout_ms = kirra_runtime_sdk::telemetry_watchdog::AV_TELEMETRY_TIMEOUT_MS,
             "telemetry watchdog spawned (SG9 sensor-liveness)"
@@ -2006,6 +2086,29 @@ async fn main() {
             enforce_posture_routing,
         ));
 
+    // SG-008 (ASIL D): fail closed BEFORE binding the listener. Build the boot
+    // facts and evaluate the startup-invariant predicate; on any violation, log
+    // and abort so no request can reach a half-initialized service. Bind is
+    // strictly AFTER this check, so "the listener never binds before invariants
+    // pass" holds by construction.
+    let startup_ctx = StartupContext {
+        admin_token_present: std::env::var("KIRRA_ADMIN_TOKEN")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false),
+        sqlite_wal: svc_state.app.store.lock().unwrap().is_wal_mode(),
+        mode_active: svc_state.app.is_active(),
+        watchdog_spawned,
+        posture_engine_running: svc_state.posture_engine_tx.get().is_some(),
+    };
+    if let Err(violation) = check_startup_invariants(&startup_ctx) {
+        tracing::error!(
+            invariant = %violation,
+            "SG-008: startup invariant violated — aborting before listener bind (fail-closed)"
+        );
+        std::process::exit(1);
+    }
+    tracing::info!("SG-008: startup invariants satisfied; binding listener");
+
     println!("Kirra Verifier Service listening on {listen_addr} (db: {db_path})");
     let listener = tokio::net::TcpListener::bind(&listen_addr).await
         .expect("failed to bind listener");
@@ -2049,5 +2152,142 @@ async fn shutdown_signal() {
     tokio::select! {
         _ = ctrl_c => {},
         _ = terminate => {},
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CERT-003 — SG-008 RTM coverage (ASIL D): Process Fail-Closed on Startup
+//
+// Verifies: SG-008 — the startup sentinel refuses to bind unless every
+// safety-critical startup invariant holds. We test the PURE predicate
+// (`check_startup_invariants`) for each individual violation, the all-present
+// Ok case, and the mode distinction (watchdog/posture-engine are required only
+// on the Active path). The abort + bind ordering is structural: `main` calls
+// this predicate immediately before `TcpListener::bind` and `process::exit(1)`s
+// on Err, so a failing predicate means the listener is never reached. These
+// live in the bin (the predicate is `pub(crate)` and not visible to an external
+// integration test).
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod sg_008_cert_tests {
+    use super::{check_startup_invariants, StartupContext, StartupInvariant};
+
+    /// All invariants satisfied on the Active path.
+    fn all_ok_active() -> StartupContext {
+        StartupContext {
+            admin_token_present: true,
+            sqlite_wal: true,
+            mode_active: true,
+            watchdog_spawned: true,
+            posture_engine_running: true,
+        }
+    }
+
+    #[test]
+    fn test_startup_ok_when_all_invariants_hold() {
+        assert_eq!(
+            check_startup_invariants(&all_ok_active()),
+            Ok(()),
+            "SG-008: startup must succeed when all invariants hold"
+        );
+    }
+
+    #[test]
+    fn test_startup_aborts_without_admin_token() {
+        let ctx = StartupContext { admin_token_present: false, ..all_ok_active() };
+        assert_eq!(
+            check_startup_invariants(&ctx),
+            Err(StartupInvariant::AdminTokenMissing),
+            "SG-008: startup must fail closed when KIRRA_ADMIN_TOKEN is absent/empty"
+        );
+    }
+
+    #[test]
+    fn test_startup_aborts_when_sqlite_not_wal() {
+        let ctx = StartupContext { sqlite_wal: false, ..all_ok_active() };
+        assert_eq!(
+            check_startup_invariants(&ctx),
+            Err(StartupInvariant::SqliteNotWal),
+            "SG-008: startup must fail closed when the store is not in WAL mode"
+        );
+    }
+
+    #[test]
+    fn test_startup_aborts_when_watchdog_not_spawned_on_active() {
+        let ctx = StartupContext { watchdog_spawned: false, ..all_ok_active() };
+        assert_eq!(
+            check_startup_invariants(&ctx),
+            Err(StartupInvariant::WatchdogNotSpawned),
+            "SG-008: an Active node must fail closed if the telemetry watchdog is not spawned"
+        );
+    }
+
+    #[test]
+    fn test_startup_aborts_when_posture_engine_down_on_active() {
+        let ctx = StartupContext { posture_engine_running: false, ..all_ok_active() };
+        assert_eq!(
+            check_startup_invariants(&ctx),
+            Err(StartupInvariant::PostureEngineDown),
+            "SG-008: an Active node must fail closed if the posture-engine worker is not running"
+        );
+    }
+
+    /// PassiveStandby is read-only and runs neither the watchdog nor the
+    /// posture engine — so their absence must NOT abort a standby, but the
+    /// admin-token and WAL invariants still apply.
+    #[test]
+    fn test_standby_ok_without_watchdog_or_posture_engine() {
+        let ctx = StartupContext {
+            admin_token_present: true,
+            sqlite_wal: true,
+            mode_active: false,
+            watchdog_spawned: false,
+            posture_engine_running: false,
+        };
+        assert_eq!(
+            check_startup_invariants(&ctx),
+            Ok(()),
+            "SG-008: PassiveStandby must boot without watchdog/posture-engine (not required in read-only mode)"
+        );
+    }
+
+    #[test]
+    fn test_standby_still_requires_admin_token_and_wal() {
+        let no_token = StartupContext {
+            admin_token_present: false,
+            sqlite_wal: true,
+            mode_active: false,
+            watchdog_spawned: false,
+            posture_engine_running: false,
+        };
+        assert_eq!(
+            check_startup_invariants(&no_token),
+            Err(StartupInvariant::AdminTokenMissing),
+            "SG-008: admin token is required in every mode"
+        );
+        let no_wal = StartupContext { admin_token_present: true, sqlite_wal: false, ..no_token };
+        assert_eq!(
+            check_startup_invariants(&no_wal),
+            Err(StartupInvariant::SqliteNotWal),
+            "SG-008: WAL mode is required in every mode"
+        );
+    }
+
+    /// Order stability: when multiple invariants are violated, the admin-token
+    /// check (first/highest-priority) wins — deterministic diagnosis.
+    #[test]
+    fn test_invariant_check_order_is_stable() {
+        let ctx = StartupContext {
+            admin_token_present: false,
+            sqlite_wal: false,
+            mode_active: true,
+            watchdog_spawned: false,
+            posture_engine_running: false,
+        };
+        assert_eq!(
+            check_startup_invariants(&ctx),
+            Err(StartupInvariant::AdminTokenMissing),
+            "SG-008: the admin-token invariant must be reported first when several are violated"
+        );
     }
 }

--- a/src/fabric/router.rs
+++ b/src/fabric/router.rs
@@ -176,6 +176,10 @@ impl FabricRouter {
 
     /// Cross-asset trust propagation rules.
     /// Returns a list of (asset_id, forced_posture) pairs to apply.
+    ///
+    // Verifies: SG-007 — a LockedOut leader degrades dependent followers within
+    // one synchronous fabric pass (tests/fault_injection.rs
+    // test_safety_goal_sg_007_cross_asset_lockout_propagation).
     pub fn propagate_cross_asset_trust(&self) -> Vec<(String, FleetPosture)> {
         let mut changes: Vec<(String, FleetPosture)> = Vec::new();
 

--- a/src/telemetry_watchdog.rs
+++ b/src/telemetry_watchdog.rs
@@ -166,6 +166,11 @@ pub fn spawn_telemetry_watchdog_with_clock(
 /// `spawn_telemetry_watchdog_with_clock` calls this once per
 /// `sweep_interval.tick()` — production behavior is byte-for-byte the
 /// same as the previous in-loop body.
+///
+// Verifies: SG-003 — Sensor Timeout Fault Detection. A node silent for
+// ≥ AV_TELEMETRY_TIMEOUT_MS is marked Untrusted(TELEMETRY_TIMEOUT) and a
+// PostureRecalcTrigger::WatchdogTimeout is sent within one sweep
+// (sg_003_cert_tests + watchdog_di_tests).
 pub(crate) fn watchdog_sweep_once(
     app: &Arc<AppState>,
     posture_engine_tx: &PostureEngineSender,
@@ -628,5 +633,146 @@ mod watchdog_di_tests {
         // (3) refresh stamp advanced to `now`.
         assert_eq!(observed_last_refresh, now,
             "*last_node_refresh_ms must be set to clock.now_ms() after a refresh");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CERT-003 — SG-003 RTM-named coverage (ASIL D)
+//
+// Verifies: SG-003 — Sensor Timeout Fault Detection. The behaviour is also
+// exercised by `watchdog_di_tests` (the dead-man's switch); these tests carry
+// the RTM-named function names so `docs/safety/REQUIREMENTS_TRACEABILITY.md`
+// reconciles against the source tree and `grep -rn "SG-0"` returns real hits
+// (closes the SG-003 zero-coverage finding in RTM_GAP_REPORT.md B1). They drive
+// the deterministic `watchdog_sweep_once` (pub(crate)) under a VirtualClock —
+// no real time, no spawned-task timing.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod sg_003_cert_tests {
+    use super::*;
+    use crate::clock::VirtualClock;
+    use crate::posture_engine_v2::PostureRecalcTrigger;
+    use crate::verifier::{AppState, RegisteredNode, VerifierOperationMode};
+    use crate::verifier_store::VerifierStore;
+    use tokio::sync::mpsc;
+
+    fn app_with_trusted_node(node_id: &str, last_seen_ms: u64) -> Arc<AppState> {
+        let store = VerifierStore::new(":memory:").expect("memory store");
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+        app.nodes.insert(
+            node_id.to_string(),
+            RegisteredNode {
+                node_id: node_id.to_string(),
+                status: NodeTrustState::Trusted,
+                registered_at_ms: last_seen_ms,
+                last_trust_update_ms: last_seen_ms,
+                ak_public_pem: None,
+                expected_pcr16_digest_hex: None,
+            },
+        );
+        app
+    }
+
+    fn health(node_id: &str, last_seen_ms: u64) -> HashMap<String, WatchdogNodeEntry> {
+        let mut m = HashMap::new();
+        m.insert(
+            node_id.to_string(),
+            WatchdogNodeEntry {
+                node_id: node_id.to_string(),
+                last_seen_ms,
+                warn_logged: false,
+            },
+        );
+        m
+    }
+
+    /// Verifies: SG-003 — a node silent for ≥ `AV_TELEMETRY_TIMEOUT_MS` is
+    /// marked `Untrusted("TELEMETRY_TIMEOUT")` on the sweep that observes it.
+    #[test]
+    fn test_watchdog_marks_node_untrusted_after_timeout() {
+        let anchor: u64 = 1_000_000;
+        // Exactly at the timeout boundary (silence == AV_TELEMETRY_TIMEOUT_MS).
+        let now = anchor + AV_TELEMETRY_TIMEOUT_MS;
+        let clock = VirtualClock::starting_at(now);
+        let app = app_with_trusted_node("lidar_front", anchor);
+        let (tx, _rx) = mpsc::channel::<PostureRecalcTrigger>(128);
+        let mut nh = health("lidar_front", anchor);
+        let mut last_refresh = now; // bypass the SQLite refresh arm
+
+        watchdog_sweep_once(&app, &tx, clock.as_ref(), &mut nh, &mut last_refresh);
+
+        assert_eq!(
+            app.nodes.get("lidar_front").unwrap().status.clone(),
+            NodeTrustState::Untrusted("TELEMETRY_TIMEOUT".to_string()),
+            "SG-003: a node silent ≥ AV_TELEMETRY_TIMEOUT_MS must be marked Untrusted(TELEMETRY_TIMEOUT)"
+        );
+    }
+
+    /// Verifies: SG-003 — detection happens within `AV_TELEMETRY_TIMEOUT_MS +
+    /// AV_WATCHDOG_SWEEP_MS`: nothing fires just below the timeout, and the
+    /// first sweep at/after the boundary fires.
+    #[test]
+    fn test_watchdog_detection_latency_within_bound() {
+        let anchor: u64 = 2_000_000;
+        let app = app_with_trusted_node("imu_main", anchor);
+        let (tx, mut rx) = mpsc::channel::<PostureRecalcTrigger>(128);
+        let mut nh = health("imu_main", anchor);
+        // Keep a recent (non-zero) refresh stamp so the SQLite refresh arm is
+        // skipped on both sweeps below.
+        let mut last_refresh = anchor + AV_TELEMETRY_TIMEOUT_MS;
+
+        // Just below the timeout → no detection.
+        let below = VirtualClock::starting_at(anchor + AV_TELEMETRY_TIMEOUT_MS - 1);
+        watchdog_sweep_once(&app, &tx, below.as_ref(), &mut nh, &mut last_refresh);
+        assert!(
+            matches!(
+                app.nodes.get("imu_main").map(|n| n.status.clone()),
+                Some(NodeTrustState::Trusted)
+            ),
+            "SG-003: must NOT detect a timeout before AV_TELEMETRY_TIMEOUT_MS of silence"
+        );
+        assert!(rx.try_recv().is_err(), "SG-003: no trigger may fire before the timeout");
+
+        // Within one sweep after the boundary → detected.
+        let detect_now = anchor + AV_TELEMETRY_TIMEOUT_MS + AV_WATCHDOG_SWEEP_MS;
+        let at = VirtualClock::starting_at(detect_now);
+        watchdog_sweep_once(&app, &tx, at.as_ref(), &mut nh, &mut last_refresh);
+
+        let detection_latency_ms = detect_now - anchor;
+        assert!(
+            detection_latency_ms <= AV_TELEMETRY_TIMEOUT_MS + AV_WATCHDOG_SWEEP_MS,
+            "SG-003: worst-case detection latency must be ≤ TIMEOUT + one SWEEP"
+        );
+        assert_eq!(
+            app.nodes.get("imu_main").unwrap().status.clone(),
+            NodeTrustState::Untrusted("TELEMETRY_TIMEOUT".to_string()),
+            "SG-003: node must be detected within TIMEOUT + one sweep"
+        );
+    }
+
+    /// Verifies: SG-003 — a detected timeout sends a
+    /// `PostureRecalcTrigger::WatchdogTimeout` on the engine channel (so the
+    /// loss of a sensor drives a posture recalculation).
+    #[test]
+    fn test_watchdog_triggers_posture_recalculation() {
+        let anchor: u64 = 3_000_000;
+        let now = anchor + AV_TELEMETRY_TIMEOUT_MS + 250;
+        let clock = VirtualClock::starting_at(now);
+        let app = app_with_trusted_node("radar_left", anchor);
+        let (tx, mut rx) = mpsc::channel::<PostureRecalcTrigger>(128);
+        let mut nh = health("radar_left", anchor);
+        let mut last_refresh = now;
+
+        watchdog_sweep_once(&app, &tx, clock.as_ref(), &mut nh, &mut last_refresh);
+
+        match rx
+            .try_recv()
+            .expect("SG-003: watchdog must send PostureRecalcTrigger::WatchdogTimeout")
+        {
+            PostureRecalcTrigger::WatchdogTimeout { node_id, .. } => {
+                assert_eq!(node_id, "radar_left", "SG-003: trigger must name the silent node");
+            }
+            other => panic!("SG-003: expected WatchdogTimeout, got {other:?}"),
+        }
     }
 }

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -897,6 +897,18 @@ impl VerifierStore {
         self.conn.query_row("SELECT 1", [], |_| Ok(()))
     }
 
+    /// SG-008 startup-invariant support: true when the hot connection reports
+    /// `journal_mode = wal`. `new()` sets `PRAGMA journal_mode=WAL`, so a
+    /// file-backed store reports "wal"; a `:memory:` store reports "memory"
+    /// (WAL is unavailable for in-memory DBs). The startup sentinel reads this
+    /// to fail closed before binding the listener if the DB is not in WAL mode.
+    pub fn is_wal_mode(&self) -> bool {
+        self.conn
+            .query_row("PRAGMA journal_mode;", [], |r| r.get::<_, String>(0))
+            .map(|m| m.eq_ignore_ascii_case("wal"))
+            .unwrap_or(false)
+    }
+
     pub fn load_all_posture_events(&self) -> Result<Vec<serde_json::Value>> {
         let mut stmt = self.conn.prepare(
             "SELECT node_id, event_type, posture_json, reason, created_at_ms

--- a/tests/cert_003_rtm_gap_stubs.rs
+++ b/tests/cert_003_rtm_gap_stubs.rs
@@ -14,17 +14,13 @@
 // Traceability matrix:    docs/safety/REQUIREMENTS_TRACEABILITY.md
 // Gap report:             docs/safety/RTM_GAP_REPORT.md
 
-#[test]
-#[ignore = "TODO(CERT-003): implement test for SG-003"]
-fn test_safety_goal_sg_003_sensor_timeout_fault_detection() {
-    // Safety Goal: SG-003 — Sensor Timeout Fault Detection (ASIL D)
-    // This test must verify: spawn_telemetry_watchdog marks any sensor
-    // node Untrusted within AV_TELEMETRY_TIMEOUT_MS (2000 ms) +
-    // AV_WATCHDOG_SWEEP_MS (100 ms) of last telemetry, and sends a
-    // PostureRecalcTrigger within the same sweep cycle.
-    // Currently unimplemented — tracked in CERT-003
-    todo!("implement SG-003 verification")
-}
+// SG-003 — Sensor Timeout Fault Detection (ASIL D): IMPLEMENTED (CERT-003).
+// The RTM-named tests live in `src/telemetry_watchdog.rs` mod `sg_003_cert_tests`
+// (test_watchdog_marks_node_untrusted_after_timeout,
+//  test_watchdog_detection_latency_within_bound,
+//  test_watchdog_triggers_posture_recalculation). They drive `watchdog_sweep_once`,
+// which is `pub(crate)`, so they must be in-crate unit tests — not this external
+// integration file. The mechanism carries a `// Verifies: SG-003` tag.
 
 #[test]
 #[ignore = "Implemented in tests/fault_injection.rs — test_safety_goal_sg_006_unknown_command_denial"]
@@ -32,16 +28,22 @@ fn test_safety_goal_sg_006_unknown_command_denial() {
     // See tests/fault_injection.rs for full implementation (CERT-004).
 }
 
+// SG-007 — Cross-Asset Fleet Lockout Propagation (ASIL D): the propagation
+// SAFETY PROPERTY (leader LockedOut → all Nominal followers Degraded within one
+// synchronous fabric pass) is IMPLEMENTED in tests/fault_injection.rs
+// (test_safety_goal_sg_007_cross_asset_lockout_propagation); the mechanism
+// (FabricRouter::propagate_cross_asset_trust) carries a `// Verifies: SG-007` tag.
+//
+// REMAINING SUB-GAP — the RTM also names a causal-log assertion, but
+// propagate_cross_asset_trust does NOT record propagation events to any causal
+// log (FabricCausalLog lives on ServiceState and is not wired into the router).
+// Satisfying it requires adding audit/causal-log wiring to the propagation
+// mechanism (a code change, not just a test). Kept as an explicit ignored stub
+// so the gap stays visible and honest.
 #[test]
-#[ignore = "TODO(CERT-003): implement test for SG-007"]
-fn test_safety_goal_sg_007_cross_asset_lockout_propagation() {
-    // Safety Goal: SG-007 — Cross-Asset Fleet Lockout Propagation (ASIL D)
-    // This test must verify: when a leader asset transitions to LockedOut,
-    // propagate_cross_asset_trust degrades all follower assets within one
-    // fabric governor tick (target <= 500 ms), and the propagation event
-    // is recorded in the fabric causal log.
-    // Currently unimplemented — tracked in CERT-003
-    todo!("implement SG-007 verification")
+#[ignore = "TODO(CERT-003): SG-007 propagation→causal-log recording not yet wired (see note above)"]
+fn test_safety_goal_sg_007_causal_log_records_propagation_event() {
+    todo!("wire propagate_cross_asset_trust to FabricCausalLog, then assert the leader→follower event")
 }
 
 #[test]

--- a/tests/cert_003_rtm_gap_stubs.rs
+++ b/tests/cert_003_rtm_gap_stubs.rs
@@ -46,17 +46,16 @@ fn test_safety_goal_sg_007_causal_log_records_propagation_event() {
     todo!("wire propagate_cross_asset_trust to FabricCausalLog, then assert the leader→follower event")
 }
 
-#[test]
-#[ignore = "TODO(CERT-003): implement test for SG-008"]
-fn test_safety_goal_sg_008_process_fail_closed_on_crash() {
-    // Safety Goal: SG-008 — Process Fail-Closed on Crash (ASIL D)
-    // This test must verify: startup_sentinel aborts the process if any
-    // safety invariant fails (admin token missing, watchdog not spawned,
-    // posture engine not running, SQLite not in WAL mode), and the TCP
-    // listener never binds before all invariants pass.
-    // Currently unimplemented — tracked in CERT-003
-    todo!("implement SG-008 verification")
-}
+// SG-008 — Process Fail-Closed on Startup (ASIL D): IMPLEMENTED (CERT-003).
+// The startup-invariant predicate `check_startup_invariants` + its
+// `StartupContext` / `StartupInvariant` live in
+// `src/bin/kirra_verifier_service.rs` and are tested by mod `sg_008_cert_tests`
+// there (admin-token / WAL / watchdog / posture-engine violations, the
+// all-present Ok case, the Active-vs-PassiveStandby distinction, and check-order
+// stability). They are `pub(crate)` in the binary, so the tests must be in-bin —
+// not in this external integration file. `main` evaluates the predicate
+// immediately before `TcpListener::bind` and aborts on Err, so the listener
+// never binds before invariants pass. The predicate carries `// Verifies: SG-008`.
 
 #[test]
 #[ignore = "TODO(CERT-003): implement test for SG-009"]

--- a/tests/fault_injection.rs
+++ b/tests/fault_injection.rs
@@ -209,3 +209,111 @@ fn test_safety_goal_sg_016_dds_actuator_volatile_durability() {
          was intentionally removed, update this test."
     );
 }
+
+// ============================================================================
+// SG-007 (ASIL D) — Cross-asset fleet lockout propagation
+//
+// Property: when a convoy LEADER transitions to LockedOut, every Nominal
+// convoy FOLLOWER is degraded within a single synchronous fabric pass
+// (`FabricRouter::update_asset_posture_and_propagate`). The "≤ 500 ms one
+// fabric tick" budget holds BY CONSTRUCTION — propagation runs inline within
+// the call, with no async hop to time — so the bound is argued structurally
+// rather than by sleeping.
+//
+// Mechanism: src/fabric/router.rs — register_asset / update_asset_posture /
+// update_asset_posture_and_propagate / fabric_state, driven by
+// propagate_cross_asset_trust Rule 2 (the `convoy_role` metadata key).
+// Safe state: dependent assets fail toward Degraded when a depended-upon
+// asset is lost.
+//
+// SCOPE NOTE (honest gap): the RTM also names
+// `test_causal_log_records_propagation_event`, but the current FabricRouter
+// does NOT record propagation events to any causal log — the FabricCausalLog
+// lives on ServiceState and is not wired into propagate_cross_asset_trust.
+// That assertion is therefore intentionally NOT made here (a green test must
+// reflect the mechanism as it exists); it remains an explicit stub in
+// tests/cert_003_rtm_gap_stubs.rs pending propagation→causal-log wiring.
+// ============================================================================
+
+#[test]
+fn test_safety_goal_sg_007_cross_asset_lockout_propagation() {
+    use std::collections::HashMap;
+    use kirra_runtime_sdk::fabric::asset::{
+        AssetPosture, AssetType, FabricAsset, KinematicProfileType,
+    };
+    use kirra_runtime_sdk::fabric::router::FabricRouter;
+
+    fn convoy_asset(id: &str, role: &str) -> FabricAsset {
+        let mut metadata = HashMap::new();
+        metadata.insert("convoy_role".to_string(), role.to_string());
+        FabricAsset {
+            asset_id: id.to_string(),
+            asset_type: AssetType::AutonomousVehicle,
+            display_name: id.to_string(),
+            kinematic_profile: KinematicProfileType::AutomotiveNominal,
+            registered_at_ms: 1_000,
+            last_seen_ms: 1_000,
+            metadata,
+        }
+    }
+    fn posture_at(id: &str, p: FleetPosture, generation: u64) -> AssetPosture {
+        AssetPosture {
+            asset_id: id.to_string(),
+            posture: p,
+            generation,
+            computed_at_ms: 2_000,
+            contributing_nodes: vec![],
+            blocked_by: vec![],
+        }
+    }
+
+    let router = FabricRouter::new();
+    router.register_asset(&convoy_asset("leader01", "leader"));
+    router.register_asset(&convoy_asset("follower01", "follower"));
+    router.register_asset(&convoy_asset("follower02", "follower"));
+
+    // register_asset seeds Degraded; force every asset Nominal so the
+    // degrade TRANSITION produced by propagation is observable.
+    for id in ["leader01", "follower01", "follower02"] {
+        router.update_asset_posture(id, posture_at(id, FleetPosture::Nominal, 1));
+    }
+
+    // Precondition cross-check: a non-LockedOut (Nominal) leader must NOT
+    // propagate — Rule 2 fires ONLY from a LockedOut leader.
+    router.update_asset_posture_and_propagate(
+        "leader01",
+        posture_at("leader01", FleetPosture::Nominal, 2),
+    );
+    for a in router.fabric_state().assets {
+        if a.asset_id.starts_with("follower") {
+            assert_eq!(
+                a.posture, FleetPosture::Nominal,
+                "SG-007 precondition: follower {} must stay Nominal while the leader is not LockedOut",
+                a.asset_id
+            );
+        }
+    }
+
+    // Leader → LockedOut: one synchronous propagation pass must degrade every
+    // Nominal follower (the safety property).
+    router.update_asset_posture_and_propagate(
+        "leader01",
+        posture_at("leader01", FleetPosture::LockedOut, 3),
+    );
+
+    let followers: Vec<(String, FleetPosture)> = router
+        .fabric_state()
+        .assets
+        .into_iter()
+        .filter(|a| a.asset_id.starts_with("follower"))
+        .map(|a| (a.asset_id, a.posture))
+        .collect();
+    assert_eq!(followers.len(), 2, "SG-007: both followers must be present");
+    for (id, posture) in followers {
+        assert_eq!(
+            posture,
+            FleetPosture::Degraded,
+            "SG-007: convoy follower {id} must degrade when the leader is LockedOut"
+        );
+    }
+}


### PR DESCRIPTION
Closes the top of the `RTM_GAP_REPORT.md` B1 punch-list: the **ASIL-D** safety goals that had no real test. SG-006 was already done (CERT-004), so this lands the remaining ASIL-D set — **SG-003, SG-007, SG-008** — with deterministic, runnable evidence. **Every ASIL-D safety goal now has at least one real test.**

All tests were compiled and run locally (`cargo test -p kirra-runtime-sdk`): **512 lib + 8 bin (SG-008) + fault_injection (incl. SG-007), 0 failures.** Verdict path (`kinematics_contract.rs`) untouched.

## SG-003 (ASIL D) — Sensor timeout fault detection
`src/telemetry_watchdog.rs` mod `sg_003_cert_tests` (in-crate: `watchdog_sweep_once` is `pub(crate)`), driven by the existing `VirtualClock` seam — no real time:
- `test_watchdog_marks_node_untrusted_after_timeout` — silence ≥ `AV_TELEMETRY_TIMEOUT_MS` → `Untrusted("TELEMETRY_TIMEOUT")`.
- `test_watchdog_detection_latency_within_bound` — no detection just below the timeout; detected within one sweep after → latency ≤ `TIMEOUT + SWEEP`.
- `test_watchdog_triggers_posture_recalculation` — a `PostureRecalcTrigger::WatchdogTimeout` is sent.

These carry the RTM-named function names so the RTM reconciles against the tree; `// Verifies: SG-003` added to the mechanism.

## SG-007 (ASIL D) — Cross-asset fleet lockout propagation
`tests/fault_injection.rs::test_safety_goal_sg_007_cross_asset_lockout_propagation`: a LockedOut convoy leader degrades all Nominal followers within one **synchronous** fabric pass (`update_asset_posture_and_propagate`), plus a precondition cross-check that a non-LockedOut leader does **not** propagate. The "≤ 500 ms one tick" bound holds by construction (synchronous, no async hop). `// Verifies: SG-007` added to `propagate_cross_asset_trust`.

> **Honest scope note:** the RTM also names a causal-log assertion, but `FabricRouter::propagate_cross_asset_trust` does **not** record propagation events to any causal log (the `FabricCausalLog` lives on `ServiceState` and isn't wired into the router). Satisfying it requires adding audit wiring to the propagation mechanism — a code change, not an observation test — so it is intentionally **not** faked here and remains an explicit ignored stub (`test_safety_goal_sg_007_causal_log_records_propagation_event`). Happy to do that wiring as a follow-up if you want SG-007 fully closed.

## SG-008 (ASIL D) — Process fail-closed on startup
`src/bin/kirra_verifier_service.rs`:
- New pure predicate `check_startup_invariants(&StartupContext) -> Result<(), StartupInvariant>` (admin-token / SQLite-WAL always; watchdog-spawned / posture-engine-running **Active-path only** — PassiveStandby is read-only and runs neither, so requiring them there would wrongly abort a valid standby). `// Verifies: SG-008`.
- `main` builds the context from real boot facts and aborts (`process::exit(1)`) **before** `TcpListener::bind` on any violation — so "the listener never binds before invariants pass" holds by construction.
- mod `sg_008_cert_tests`: 8 tests (each invariant, all-present Ok, Active-vs-standby distinction, check-order stability). In-bin because the predicate is `pub(crate)`.
- `src/verifier_store.rs::is_wal_mode()` backs the WAL invariant.

> **Design note:** the plan described SG-008 as "factor out existing checks," but the bin had **no** startup-invariant gate (only a runtime `require_admin_token` middleware; `startup_sentinel.rs` is hardware-attestation). So this **introduces** the gate. It is a real behavior change to the security-critical startup path: a node now refuses to boot (rather than booting and serving 503) if `KIRRA_ADMIN_TOKEN` is absent, the DB isn't WAL, or — on the Active path — the watchdog/posture-engine didn't start. Flagging explicitly for review.

## Docs / stubs
- `RTM_GAP_REPORT.md`: CERT-003 increment — goal-level coverage **11/16**, all ASIL-D covered; SG-007 causal-log noted as the one remaining sub-gap; reconciled the stale "306 passing" claim (core crate now defines **582** test fns); code-side `SG-0` tags now **68**.
- `cert_003_rtm_gap_stubs.rs`: SG-003 + SG-008 stubs retired; SG-007 narrowed to the causal-log sub-gap.

This flips the headline cert finding from "not defensible for an ASIL-D assessment" to "all ASIL-D safety goals have real, deterministic test evidence."

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_