### PR TITLE
chore(wcet-gate): drop unused import(s)

### DIFF
--- a/src/wcet_gate.rs
+++ b/src/wcet_gate.rs
@@ -22,8 +22,6 @@
 // latency), a sub-100µs verdict WCET fits with multiple orders of magnitude
 // of headroom.
 
-use std::time::Instant;
-
 // ---------------------------------------------------------------------------
 // Structural boundedness argument (Pass A + B1 + B2 + B3 evidence)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Removes the compiler-flagged unused import in `src/wcet_gate.rs` (`use std::time::Instant;`, line 25) — the only warning in that file. No behavior change; docs/logic untouched.

## Change
- Deleted `use std::time::Instant;` (and its now-redundant trailing blank line). One line of code removed.

## Verification
- Before: `cargo build -p kirra-runtime-sdk` → `warning: unused import: std::time::Instant` at `src/wcet_gate.rs:25`.
- After: clean build, **0 errors / warning gone**; no `cannot find … Instant` (confirming it was genuinely unused).
- No blanket `cargo fix` — only `src/wcet_gate.rs` was touched and staged.
- `src/gateway/kinematics_contract.rs` blob unchanged: `997fb7ae15ce3e11adec9218044c7c84b049ad3b`.

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_