### PR TITLE
fix(wcet-gate): restore test-scoped Instant import — repairs broken workspace test build

### DIFF
--- a/src/wcet_gate.rs
+++ b/src/wcet_gate.rs
@@ -153,6 +153,11 @@ pub const GOVERNOR_PERCEPTION_GUARD_WCET_CI_THRESHOLD_MICROS: u64 = 10_000;
 /// code-path regression).
 #[cfg(test)]
 fn measure_stats<F: FnMut()>(iterations: u32, mut f: F) -> (u128, u128) {
+    // Imported here (function-local, test-only) rather than at module scope:
+    // `measure_stats` is the sole user and is itself `#[cfg(test)]`, so a
+    // module-level `use std::time::Instant;` is flagged unused by non-test
+    // `cargo build` (which is what previously prompted its erroneous removal).
+    use std::time::Instant;
     let mut samples: Vec<u128> = Vec::with_capacity(iterations as usize);
     for _ in 0..iterations {
         let t0 = Instant::now();


### PR DESCRIPTION
## Fixes broken `main` test build (regression from #212)

`cargo test --workspace` on `main` fails to compile:
```
error[E0433]: cannot find type `Instant` in this scope
  --> src/wcet_gate.rs:158:18
158 |         let t0 = Instant::now();
```

### Root cause
PR #212 removed `use std::time::Instant;` because a plain `cargo build -p kirra-runtime-sdk` flagged it unused. But it was **not** unused — its only consumer is the `#[cfg(test)] fn measure_stats` (`Instant::now()` at line 158), which a non-test build doesn't compile. So the import looked dead to `cargo build` but is required by `cargo test`. (#212's verification only ran the non-test build, which is why this slipped through — a `cargo test`/`--tests` check would have caught it. My mistake on that PR.)

### Fix
Re-add the import **function-locally inside `measure_stats`** (its sole, test-only user) rather than at module scope. This compiles the test build **and** keeps the non-test build warning-free — resolving the original tension that prompted the erroneous removal.

### Verification
- `cargo build -p kirra-runtime-sdk` → no `Instant`/unused-import warning.
- `cargo test -p kirra-runtime-sdk --lib wcet_gate::` → **10 passed, 0 failed** (the gate the workspace build choked on now compiles and runs).
- Remaining 2 lib-test warnings (`audit_chain.rs` unused `Signer`/`VerifyingKey`, `scenario_runner.rs` unused `Arc`) are pre-existing, unrelated to this change.

`src/gateway/kinematics_contract.rs` blob unchanged: `997fb7ae15ce3e11adec9218044c7c84b049ad3b`. Only `src/wcet_gate.rs` touched.

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_