### PR TITLE
docs(adr): ADR-0001 governor deployment platform + strategy companion

### DIFF
--- a/docs/adr/ADR-0001-governor-deployment-platform.md
+++ b/docs/adr/ADR-0001-governor-deployment-platform.md
@@ -1,0 +1,117 @@
+# ADR-0001 — Governor Deployment Platform
+
+**Status:** Accepted
+**Date:** 2026-06-08
+**Owner:** Justin Looney
+**Scope:** Certification-target platform and deployment topology for the KIRRA runtime safety governor. This is a decision of record for the *cert target*, not a statement of achieved certification.
+
+---
+
+## Decision
+
+The KIRRA governor runs as the **safety-domain payload directly on QNX Hypervisor 8.0 for Safety**. The Autoware / ROS 2 Jazzy / Occy planning stack (the *doer*) runs **unmodified as an isolated Ubuntu guest VM** on the same SoC. The certified virtual machine manager provides the ASIL-D freedom-from-interference boundary between them.
+
+The governor is implemented in **Rust, built with the Ferrocene qualified toolchain** targeting QNX Neutrino. The **certified artifact is the minimal `no_std` verdict core** (the kinematic contract and its gates), not the full governor process.
+
+PikeOS and INTEGRITY are **not** build targets. They remain roadmap-only, activated solely by a named customer whose platform is already certified on them (aerospace / defense / space / rail).
+
+---
+
+## Context
+
+KIRRA's thesis is runtime assurance: a small, certified **checker** sits above a large, uncertified **doer** and gates every actuator command. That decomposition is only creditable for a top-level ASIL-D claim if the isolation between checker and doer is itself a *certified* freedom-from-interference boundary — engineering isolation is not sufficient. The platform decision therefore turns on three requirements:
+
+1. A certified separation kernel / hypervisor that can host an uncertified Linux workload next to an ASIL-D component with certified FFI.
+2. A qualified path for the governor's implementation language (Rust) at ASIL-D.
+3. Minimal cert scope — only the verdict logic and its I/O boundary should fall inside the certified envelope.
+
+All three resolve cleanly on QNX. The dev environment (Ubuntu / Jazzy laptop) is the *doer-side* environment and is unchanged by this decision.
+
+---
+
+## Platform stack (grounded, with certifying body)
+
+| Layer | Product | Certification | Notes |
+|---|---|---|---|
+| Hypervisor / VMM | **QNX Hypervisor 8.0 for Safety** (GA 2026-03-10) | TÜV Rheinland — ISO 26262 **ASIL D**, IEC 61508 SIL 4, IEC 62304 Class C | Certified VMM; hosts **unmodified** Linux/Android guests; SMMU manager contains guest DMA; guarantees safe transitions to a Design Safe State; ARMv8 + x86-64. |
+| Safety OS | **QNX OS for Safety 8.0** | TÜV Rheinland — ISO 26262 **ASIL D**, IEC 61508 SIL 3, IEC 62304 Class C, ISO/SAE 21434 | "Certify only the parts you build, not the OS or toolchains." Qualified C/C++ toolchain (TCL3). POSIX. FFI built in. |
+| Rust toolchain | **Ferrocene** (QNX Neutrino target) | TÜV SÜD — ISO 26262 **ASIL D** (TCL3) compiler | Qualified targets include QNX Neutrino 7.1.0 (x86-64 + Armv8-A). **Compiler** is ASIL-D; **certified library** is currently a `core` subset at ASIL-B / SIL2 and growing. → governor core must be `no_std` / core-subset; anything outside the certified subset is qualified by the team. |
+
+---
+
+## Domain layout (single SoC)
+
+```
++-----------------------------------------------------------------+
+|              QNX Hypervisor 8.0 for Safety  (ASIL D)            |
+|                  certified freedom-from-interference            |
+|                                                                 |
+|  SAFETY DOMAIN (on hypervisor)        NON-SAFETY DOMAIN (VM)     |
+|  +-----------------------------+      +----------------------+   |
+|  |  KIRRA GOVERNOR (checker)   |      |  Ubuntu guest (doer) |   |
+|  |  - no_std verdict core      |      |  - ROS 2 Jazzy       |   |
+|  |    (kinematic contract)     |      |  - Autoware          |   |
+|  |  - own clock + watchdog     |      |  - Occy planner      |   |
+|  |  - owns actuator output     |      |  - perception / ML   |   |
+|  |  - Ferrocene / Rust         |      |  - DDS / r2r (here)  |   |
+|  +--------------+--------------+      +----------+-----------+   |
+|                 ^   verdict / clamp             | proposal       |
+|                 |  (narrow shared-mem mailbox)  v                |
+|                 +-------------------------------+                |
+|                                                                 |
+|   actuator bus (CAN/etc.) terminates in the SAFETY domain only  |
++-----------------------------------------------------------------+
+        GPU (if present) ── passthrough to Ubuntu VM, SMMU-contained
+```
+
+- **Safety domain (runs directly on the hypervisor):** the governor — minimal `no_std` Rust verdict core, its watchdog, and the actuator output path.
+- **Non-safety domain (isolated VM):** the entire Ubuntu/Autoware/Jazzy/Occy stack, unmodified, plus all DDS/r2r/ROS plumbing.
+- **Boundary:** certified FFI — spatial (MMU + SMMU DMA containment) and temporal (CPU partitioning, vCPUs pinned to physical cores).
+
+---
+
+## Binding invariants (the design rules that make it safe)
+
+1. **Propose vs. dispose.** The doer only *proposes* — it writes a trajectory/command into the inter-VM channel. It never touches actuators.
+2. **Governor owns the actuator path.** The physical actuator bus terminates in the safety domain. The Ubuntu VM is *physically incapable* of driving actuators directly. The governor is the last gate.
+3. **Narrow, analyzable channel.** The doer↔governor interface is a fixed-schema shared-memory mailbox. DDS / r2r / ROS stay entirely inside the Ubuntu VM. No ROS reaches into the safety domain.
+4. **Governor has its own clock and watchdog,** driven by the certified scheduler. "No fresh valid proposal by deadline" = fault → Design Safe State (the hypervisor guarantees the safe-state transition).
+5. **All doer output is untrusted input.** The governor's safety function (detect → safe-state) must not depend on the doer behaving. Validity is established by the verdict core, never assumed.
+
+---
+
+## Cert-scope boundary
+
+**Inside the ASIL-D envelope (small, qualifiable):**
+- the `no_std` verdict core (kinematic contract + gates)
+- inter-VM channel read
+- actuator write
+- the governor's clock + watchdog
+
+**Outside the ASIL-D envelope (in the guest, or in a lower-ASIL QNX process):**
+- Autoware, the Occy planner, perception, all ML
+- the GPU path
+- DDS / r2r / ROS / `tokio` / `std`
+- federation, attestation, telemetry, and audit machinery (anything that pulls in `std` / async)
+
+This mirrors the existing "protect the verdict path as the fixed core" discipline; this ADR makes that the formal certification rationale — the verdict core is the qualifiable kernel, everything else is plumbing held outside the boundary.
+
+---
+
+## Open items / integration work (the part we actually build)
+
+- **Inter-VM channel contract.** Define the fixed-schema shared-memory mailbox (proposal in, verdict/clamp out). This is the primary new engineering surface.
+- **Actuator-ownership wiring.** Route the physical command path through the safety domain.
+- **Ferrocene library coverage check.** Confirm the governor core stays within (or qualifies beyond) the certified `core` subset; track subset growth across Ferrocene releases.
+- **Safe-state mapping.** Wire the governor's safe-state output to the hypervisor's Design Safe State transition.
+- **GPU.** If perception needs it, pass the GPU through to the Ubuntu VM with SMMU containment; the governor requires no accelerator by design.
+
+---
+
+## Consequences
+
+- **Dev workflow unchanged.** The Ubuntu / Jazzy laptop remains the doer-side development environment. This ADR concerns the cert *target*, not day-to-day development.
+- **Rust is retained at ASIL-D** via Ferrocene's qualified QNX target — the reason QNX was chosen over PikeOS/INTEGRITY, which are not Ferrocene-qualified targets today.
+- **The talisman discipline gains a formal basis.** Keeping the verdict path minimal and fixed is now the certification kernel strategy, not just hygiene.
+- **Vendor-neutrality is preserved as an architecture property,** not a free-deployment claim. Each additional kernel (PikeOS/INTEGRITY) is a separate per-platform qualification campaign, triggered only by a named customer in that domain.
+- **"Ubuntu isolated as a VM on a certified OS, governor on QNX" is now a supported product configuration,** not a bespoke design — QNX Hypervisor 8.0 for Safety (GA 2026-03-10) is the certified VMM that provides it.

--- a/docs/adr/KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md
+++ b/docs/adr/KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md
@@ -1,0 +1,183 @@
+# KIRRA Platform & Deployment Strategy
+
+**Date:** 2026-06-08
+**Status:** Decision captured (see ADR-0001)
+**Purpose:** Full technical and strategic rationale behind the governor's platform and deployment decision. The concise decision of record lives in `ADR-0001-governor-deployment-platform.md`; this document is the supporting analysis, the comparative reasoning, and the cited evidence.
+
+---
+
+## Executive summary
+
+The KIRRA governor will run as the safety-domain payload **directly on QNX Hypervisor 8.0 for Safety**, with the Autoware / ROS 2 Jazzy / Occy stack (the *doer*) running **unmodified as an isolated Ubuntu guest VM** on the same SoC. The certified VMM supplies the ASIL-D freedom-from-interference boundary that makes the runtime-assurance decomposition creditable. The governor is written in **Rust, compiled with Ferrocene** (qualified for QNX Neutrino), and the **certified artifact is the minimal `no_std` verdict core**, not the whole process.
+
+QNX is chosen over PikeOS and INTEGRITY for one decisive reason on top of parity: it is the only one of the three with a qualified ASIL-D Rust toolchain target, so the governor stays in Rust without a bespoke toolchain qualification. PikeOS and INTEGRITY remain roadmap-only, activated by a named customer already certified on them.
+
+---
+
+## 1. The architectural distinction everything rests on
+
+A separation-kernel hypervisor runs two fundamentally different kinds of partition:
+
+- **Native certified partition** — code running in (or directly on) the certified RTOS/hypervisor, inside the safety envelope.
+- **Linux guest VM** — a full general-purpose OS hosted as an isolated virtual machine.
+
+These have completely different certification implications, and conflating them is the most common mistake in this space. The governor belongs in the certified domain; the planner belongs in a Linux guest. The hypervisor enforces the boundary between them.
+
+---
+
+## 2. Why the doer stack is Linux-guest-grade
+
+Autoware + ROS 2 Jazzy + the Rust/r2r planning code is a heavyweight Linux workload (Ubuntu base, large dependency tree, frequently GPU/CUDA). It does not run natively on a microkernel. The realistic — and correct — home for it is an **unmodified Linux guest VM**, where it behaves exactly as it does on bare Ubuntu because, inside the guest, it *is* Ubuntu.
+
+This is a feature, not a compromise: the doer ports to the target platform "for free" (it's just a VM), and the entire uncertified stack is quarantined behind the hypervisor boundary. The doer is the *uncertified* partition by design.
+
+---
+
+## 3. Substrate comparison — QNX vs PikeOS vs INTEGRITY
+
+All three are credible certified separation kernels and all three are supported targets for Apex.Grace (the certified ROS 2 fork), per Apex.AI's own statements. The decision criteria that matter to KIRRA:
+
+| Criterion | QNX | PikeOS | INTEGRITY |
+|---|---|---|---|
+| ISO 26262 ASIL-D certified kernel | Yes (TÜV Rheinland) | Yes | Yes |
+| Certified hypervisor for mixed-criticality | **Yes — Hypervisor for Safety 8.0** | Yes (separation kernel) | Yes |
+| Built-in freedom-from-interference | Yes | Yes | Yes |
+| Qualified ASIL-D **Rust** toolchain target | **Yes (Ferrocene / QNX Neutrino)** | Not today | Not today |
+| Qualified C/C++ toolchain | Yes (TCL3) | Yes | Yes |
+| POSIX compliance (eases porting) | **Strong** | Partial (personalities) | Partial |
+| Primary domain | **Automotive / industrial / robotics** | European avionics / space / rail (ITAR-free) | Aerospace / defense (DO-178C DAL A) |
+| Automotive incumbency | **Highest** (hundreds of millions of vehicles) | Moderate | Moderate |
+
+QNX wins on parity plus three KIRRA-specific advantages: the qualified Rust path (Section 4), strong POSIX compliance (cheaper porting), and automotive incumbency (credibility with the OEM/Tier-1 buyers a safety governor must persuade). A near-exact customer analog already exists publicly: **FERNRIDE selected QNX OS for Safety for autonomous terminal tractors**, citing POSIX compliance and the goal of shortening the timeline to certify the *entire* stack — the same off-highway/bounded-ODD profile KIRRA should target for a first pilot.
+
+---
+
+## 4. The Rust-at-ASIL-D path (Ferrocene) — and why QNX is uniquely good for it
+
+KIRRA's governor is Rust. Using Rust in an ASIL-D component requires a *qualified* Rust toolchain, which is **Ferrocene** — the first qualified Rust compiler, TÜV SÜD-qualified to ISO 26262 ASIL-D (TCL3), IEC 61508, and IEC 62304.
+
+The decisive fact: **Ferrocene's qualified targets include QNX Neutrino 7.1.0 on x86-64 and Armv8-A** (alongside x86-64 Linux and bare-metal Arm). They do **not** currently include PikeOS or INTEGRITY native — those would be "additional RTOSes on request," i.e., a fresh target qualification effort. So QNX is the one substrate where "Rust governor + RTOS + ASIL-D" is an off-the-shelf, already-qualified path.
+
+**The nuance to engineer around — compiler vs. library coverage:**
+- The Ferrocene **compiler** is ASIL-D.
+- The Ferrocene **certified library** is currently a subset of `core` at ASIL-B / SIL2 (expanded again at embedded world 2026, and growing).
+- `std`, `tokio`, and `r2r` are far outside that certified subset.
+
+**Implication:** the ASIL-D-qualified artifact must be the **minimal `no_std` verdict core** — the kinematic contract and its gates — compiled with Ferrocene against the certified `core` subset, with any code outside the subset qualified by the team. The `std`/async/ROS machinery stays *outside* the ASIL-D boundary. This is not a constraint imposed by the platform so much as the same cert-scope discipline the architecture already depends on; the platform just makes it explicit.
+
+*(Fallback if the Rust-at-ASIL-D path ever proves impractical for a given assessor: QNX's qualified path is C/C++ TCL3, with a C++ library pre-certified — ASIL-B headers/templates, ASIL-D runtime binaries. That would mean reimplementing the certified verdict core in C/C++. It is a known, supported escape hatch, not the plan.)*
+
+---
+
+## 5. Deployment architecture — QNX Hypervisor 8.0 for Safety
+
+As of **GA 2026-03-10**, this is a purchasable, certified product configuration — not a bespoke design. QNX Hypervisor 8.0 for Safety is a TÜV-Rheinland-certified VMM (ISO 26262 ASIL D, IEC 61508 SIL 4, IEC 62304 Class C) that hosts **unmodified Linux and Android guests** and is explicitly positioned for "Physical AI" — autonomous and intelligent software-defined systems across automotive, robotics, medical, and industrial — which is precisely KIRRA's space.
+
+### Topology (single SoC)
+
+```
++-----------------------------------------------------------------+
+|              QNX Hypervisor 8.0 for Safety  (ASIL D)            |
+|                  certified freedom-from-interference            |
+|                                                                 |
+|  SAFETY DOMAIN (on hypervisor)        NON-SAFETY DOMAIN (VM)     |
+|  +-----------------------------+      +----------------------+   |
+|  |  KIRRA GOVERNOR (checker)   |      |  Ubuntu guest (doer) |   |
+|  |  - no_std verdict core      |      |  - ROS 2 Jazzy       |   |
+|  |    (kinematic contract)     |      |  - Autoware          |   |
+|  |  - own clock + watchdog     |      |  - Occy planner      |   |
+|  |  - owns actuator output     |      |  - perception / ML   |   |
+|  |  - Ferrocene / Rust         |      |  - DDS / r2r (here)  |   |
+|  +--------------+--------------+      +----------+-----------+   |
+|                 ^   verdict / clamp             | proposal       |
+|                 |  (narrow shared-mem mailbox)  v                |
+|                 +-------------------------------+                |
+|                                                                 |
+|   actuator bus (CAN/etc.) terminates in the SAFETY domain only  |
++-----------------------------------------------------------------+
+        GPU (if present) -- passthrough to Ubuntu VM, SMMU-contained
+```
+
+The recommended configuration is one QNX documents directly: the guest runs in a VM while the safety-critical application runs directly on the hypervisor.
+
+### Data flow and binding invariants
+
+1. **Propose vs. dispose.** The doer only *proposes* — it writes a trajectory/command into the inter-VM channel. It never touches actuators.
+2. **Governor owns the actuator path.** The physical actuator bus terminates in the safety domain; the Ubuntu VM is physically incapable of driving actuators directly. The governor is the last gate.
+3. **Narrow, analyzable channel.** A fixed-schema shared-memory mailbox. DDS / r2r / ROS stay entirely inside the Ubuntu VM; no ROS reaches into the safety domain.
+4. **Governor has its own clock and watchdog,** off the certified scheduler. "No fresh valid proposal by deadline" = fault → Design Safe State (the hypervisor guarantees safe-state transitions).
+5. **All doer output is untrusted input.** The governor's detect→safe-state function must never depend on the doer behaving.
+
+### Why it is creditable
+
+The ASIL decomposition — uncertified QM-level Ubuntu beside an ASIL-D governor, still supporting a top-level safety claim — only holds if the isolation boundary is itself certified. It is: the hypervisor carries the ASIL-D freedom-from-interference, with spatial isolation (MMU plus an SMMU manager that contains guest DMA) and temporal isolation (CPU partitioning, vCPUs pinnable to physical cores). A fault, hang, flood, or compromise in the Ubuntu guest cannot prevent the governor from detecting and safe-stating. The runtime-assurance bet rests on a certified foundation rather than on Linux behaving.
+
+### Cert-scope boundary
+
+**Inside the ASIL-D envelope:** the `no_std` verdict core, the inter-VM channel read, the actuator write, and the governor's clock/watchdog.
+**Outside:** Autoware, the Occy planner, perception, ML, the GPU path, DDS/r2r/ROS/`tokio`/`std`, and the federation/attestation/telemetry/audit machinery.
+
+---
+
+## 6. Integration work — the part we actually build
+
+The isolation is *bought*; the integration is built. The real new engineering surface is small and well-defined:
+
+- **Inter-VM channel contract** — the fixed-schema shared-memory mailbox (proposal in, verdict/clamp out). Primary new surface.
+- **Actuator-ownership wiring** — route the physical command path through the safety domain.
+- **Ferrocene library coverage check** — keep the governor core within (or qualify beyond) the certified `core` subset; track subset growth across releases.
+- **Safe-state mapping** — wire the governor's safe-state output to the hypervisor's Design Safe State transition.
+- **GPU** — if perception needs it, pass it through to the Ubuntu VM with SMMU containment; the governor needs no accelerator by design.
+
+---
+
+## 7. PikeOS and INTEGRITY — roadmap positioning
+
+For the first certified target (automotive AV, Rust governor), PikeOS and INTEGRITY do **not** come into play; selecting them would forfeit the off-the-shelf Ferrocene Rust path. They enter the picture only later, and only as **customer environments**, driven by KIRRA's vendor-neutral positioning:
+
+- **INTEGRITY** — aerospace/defense incumbent (DO-178C DAL A, EAL 6+, 80-plus airborne systems), with automotive presence. The target if a pilot originates in defense robotics.
+- **PikeOS** — European avionics/space/rail (DO-178C, ECSS, EN 50128), fully European and ITAR-free — a sovereignty selling point. The target for European or ITAR-sensitive opportunities.
+
+A customer already certified on one of these will not switch to QNX to adopt the governor; KIRRA ports *to them*.
+
+**Honest cost framing:** vendor-neutrality is an *architecture property*, not a free-deployment claim. Each additional kernel is a separate per-platform qualification campaign — a qualified Rust toolchain on that kernel (Ferrocene "on request"), plus re-doing the inter-partition channel and integration evidence. The verdict *logic* ports cheaply because it is minimal `no_std`; the *certification evidence* is per-platform and is where the cost lives. The only thing required now to keep the option open is to hold the verdict core free of QNX-specific syscalls and `std` — which the cert-scope discipline already does.
+
+---
+
+## 8. Market and relationship context
+
+- **Apex.AI is a category neighbor, not a competitor.** Apex.Grace is an ASIL-D-certified ROS 2 runtime (the *doer* layer); KIRRA is a runtime-assurance governor that sits *above* a planner. KIRRA could even run over Apex.Grace. Apex.Grace is supported on QNX, INTEGRITY, PikeOS, and Linux-PREEMPT_RT — so leaning on it would inherit multi-kernel portability, though KIRRA's own cert evidence remains per-kernel. The natural relationship is complementary, with acquisition a plausible outcome.
+- **The #1 value multiplier remains a named pilot.** The platform decision is now settled; the gating item for credibility and for any acquisition conversation is a real deployment. The kernel choice should follow the pilot customer's existing substrate — which, for the most likely (automotive/industrial/off-highway) customers, is QNX anyway.
+
+---
+
+## 9. What does NOT change
+
+- **Dev workflow** — the Ubuntu / Jazzy laptop stays the doer-side development environment. This is a cert-*target* decision, not a day-to-day one.
+- **Rust** — retained at ASIL-D via Ferrocene's qualified QNX target.
+- **The talisman discipline** — keeping `kinematics_contract.rs` minimal and fixed is now the formal certification-kernel strategy, not just hygiene. That file is the thing that becomes the qualified `no_std` core.
+
+---
+
+## Sources
+
+- Apex.OS support across QNX / INTEGRITY / Cisco / PikeOS / Linux-PREEMPT_RT — Electronic Design: https://www.electronicdesign.com/markets/automotive/video/21240334/making-ros-2-automotive-ready
+- INTEGRITY ASIL-D, Apex companion, Tier IV/Autoware partnership — Embedded.com: https://www.embedded.com/av-developers-build-on-ros-framework/
+- INTEGRITY DO-178C DAL A / EAL 6+ / architecture — ArchiveOS: https://archiveos.org/integrity/
+- PikeOS certifications, architectures, ITAR-free — MathWorks: https://www.mathworks.com/products/connections/product_detail/pikeos.html
+- micro-ROS supported RTOSes (FreeRTOS/Zephyr/NuttX) — micro.ros.org: https://micro.ros.org/docs/overview/rtos/
+- QNX OS for Safety 8.0 — ASIL D / SIL3 / Class C / ISO-SAE 21434 — QNX: https://qnx.software/en/software/products-and-solutions/qnx-os-and-os-for-safety
+- QNX OS for Safety — "certify only what you build," TCL3 toolchain — Automate.org: https://www.automate.org/products/blackberry-qnx/qnx-operating-system-for-safety
+- QNX OS for Safety — C++ library pre-cert (ASIL-B headers / ASIL-D runtime) — AWS Marketplace: https://aws.amazon.com/marketplace/pp/prodview-26pvihq76slfa
+- FERNRIDE selects QNX OS for Safety (autonomous terminal tractors) — Stock Titan: https://www.stocktitan.net/news/BB/fernride-selects-qnx-for-safety-certified-autonomous-terminal-aswl1mle15q3.html
+- Ferrocene ASIL-D + qualified QNX Neutrino target — BusinessWire: https://www.businesswire.com/news/home/20250114192138/en/
+- Ferrocene 24.11 (QNX toolchains qualified) — Ferrous Systems: https://ferrous-systems.com/blog/ferrocene-24-11-0/
+- Ferrocene 26.02 (certified core subset ASIL-B) — Ferrous Systems: https://ferrous-systems.com/blog/ferrocene-26-02-0/
+- Ferrocene targets (Linux, QNX, bare-metal Arm; additional RTOSes on request) — Ferrocene: https://ferrocene.dev/
+- QNX Hypervisor 8.0 for Safety GA (2026-03-10), certified VMM, unmodified Linux/Android guests — Newswire: https://www.newswire.com/news/qnx-hypervisor-8-0-for-safety-powers-the-industry-shift-toward-physical-ai
+- QNX Hypervisor for Safety — certified VM isolation, focus cert on your components — SoftwareOne: https://platform.softwareone.com/product/qnx-hypervisor-for-safety/PCP-9229-3037
+- QNX Hypervisor — SMMU DMA containment, Design Safe State, mixed criticality — QNX: https://qnx.software/en/software/products-and-solutions/qnx-hypervisor-and-hypervisor-for-safety
+
+---
+
+*Companion document: `ADR-0001-governor-deployment-platform.md` (the decision of record).*

--- a/docs/adr/KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md
+++ b/docs/adr/KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md
@@ -151,7 +151,39 @@ A customer already certified on one of these will not switch to QNX to adopt the
 
 ---
 
-## 9. What does NOT change
+## 9. Strategic acquirers & partnership path
+
+KIRRA is open to an acquisition outcome. The platform decision shapes both *who* the credible acquirers are and *how* to reach them. The governing principle: **architecture makes KIRRA acquirable; traction makes it worth acquiring.**
+
+### The two named candidates
+
+**QNX / BlackBerry**
+- *Fit.* BlackBerry has refocused around QNX after divesting the Cylance endpoint-security business to Arctic Wolf (closed Feb 2025). QNX is now a profitable "Rule of 40" segment — ~$268M revenue, 14% YoY growth, 83% gross margin, embedded in 275M-plus vehicles — and is explicitly chasing "growing momentum in robotics, physical AI, and other adjacent markets." KIRRA *is* a physical-AI safety-governance layer, so it is adjacent to exactly the expansion QNX is publicly pursuing. Selling KIRRA-on-QNX sells more QNX, moves QNX up-stack, and plays to BlackBerry's surviving safety-plus-security positioning (secure-comms / sovereign DNA + ISO 21434 / UNECE WP.29 relevance). KIRRA's attestation / federated-trust layer is a security story as much as a safety one.
+- *Means.* Profitable, ~$432M cash, capital-disciplined (notable share buybacks). Able to do tuck-ins, but value-conscious.
+- *How they actually grow — the key insight.* QNX expands through **pre-integrated partnerships**, not an acquisition spree: QNX + Vector + TTTech Auto (pre-integrated vehicle software platform), QNX + AMD (robotics), QNX + Microsoft (SDP 8.0 on Azure), plus the General Embedded Development Platform. So the front door is the **QNX partner ecosystem**, not an M&A cold-pitch.
+- *Structural factor.* A QNX/IoT spin-off and public listing is targeted for roughly the first half of FY2027. The eventual acquirer may therefore be a soon-to-be-standalone QNX entity. Spin-preparation cuts both ways on near-term M&A appetite (caution vs. tuck-ins to strengthen the equity story).
+
+**Apex.AI**
+- *Fit.* A category neighbor, not a competitor. Apex.Grace is the certified ROS 2 *doer*-layer runtime; KIRRA sits *above* it as the governor, so the relationship is complementary, and Apex.Grace runs on QNX / INTEGRITY / PikeOS / Linux-RT — making "KIRRA over Apex.Grace" coherent. Apex is already ASIL-D, capitalized, and has customers/partners (Tier IV / Autoware, Toyota Woven, Green Hills, Infineon). KIRRA fills the runtime-assurance / attestation gap sitting above their runtime.
+
+### The sequence: partner, then acquire
+
+1. **Stand up on QNX SDP 8.0** (the Azure eval is low-lift) — establish a "running / validated on QNX" footing. This advances the cert-target work and the relationship simultaneously.
+2. **Enter the QNX partner ecosystem** as a pre-integrated runtime-safety-governance layer for QNX's robotics / physical-AI push — mirroring how Vector, TTTech, and AMD plugged in.
+3. **Land a QNX-based pilot** — the #1 value multiplier.
+4. **Let the acquisition conversation flow** from partnership + traction + defensible IP, rather than pitching it cold.
+
+### The optionality guardrail
+
+Deep QNX integration helps the BlackBerry thesis but risks a single-bidder corner. The **kernel-agnostic verdict core mandated by ADR-0001** is precisely what preserves Apex, the Tier-1s, and AV companies as *alternative* acquirers — and alternatives are what create pricing tension. Build on QNX as the reference target; keep the core portable so QNX is not the only buyer who can use KIRRA.
+
+### Valuation reality
+
+At the pre-pilot, pre-revenue stage, even a perfect-fit buyer values architecture as an acqui-hire or tech tuck-in, and a value-disciplined buyer (BlackBerry) will not pay up for architecture alone. What moves the number: a **named pilot** (ideally on QNX), **defensible IP** in the attestation / two-set DAG / federation design, and **relevance to the ISO 21434 / UNECE WP.29** cybersecurity tightening now hitting automotive.
+
+---
+
+## 10. What does NOT change
 
 - **Dev workflow** — the Ubuntu / Jazzy laptop stays the doer-side development environment. This is a cert-*target* decision, not a day-to-day one.
 - **Rust** — retained at ASIL-D via Ferrocene's qualified QNX target.
@@ -177,6 +209,10 @@ A customer already certified on one of these will not switch to QNX to adopt the
 - QNX Hypervisor 8.0 for Safety GA (2026-03-10), certified VMM, unmodified Linux/Android guests — Newswire: https://www.newswire.com/news/qnx-hypervisor-8-0-for-safety-powers-the-industry-shift-toward-physical-ai
 - QNX Hypervisor for Safety — certified VM isolation, focus cert on your components — SoftwareOne: https://platform.softwareone.com/product/qnx-hypervisor-for-safety/PCP-9229-3037
 - QNX Hypervisor — SMMU DMA containment, Design Safe State, mixed criticality — QNX: https://qnx.software/en/software/products-and-solutions/qnx-hypervisor-and-hypervisor-for-safety
+- BlackBerry FY2026 results — QNX $268M / 14% growth / Rule of 40 / robotics & physical AI momentum — SEC 8-K: https://www.sec.gov/Archives/edgar/data/1070235/000107023526000029/q4fy26ex-991.htm
+- BlackBerry sells Cylance to Arctic Wolf (closed Feb 2025) — SEC 8-K: https://www.sec.gov/Archives/edgar/data/0001070235/000107023525000041/a2025-02x03xarcticwolfandb.htm
+- QNX partnerships (Vector/TTTech, AMD, Microsoft Azure, GEDP), 275M+ vehicles — SEC 8-K: https://www.sec.gov/Archives/edgar/data/0001070235/000107023525000065/q4fy25ex-991.htm
+- BlackBerry IoT/QNX spin-off targeted ~1H FY2027 — Finimize: https://finimize.com/content/bb-asset-snapshot
 
 ---
 


### PR DESCRIPTION
## Summary

Docs-only. Lands **ADR-0001 — Governor Deployment Platform** (the decision of record: KIRRA governor as the safety-domain payload on **QNX Hypervisor 8.0 for Safety**; the Autoware/ROS 2 Jazzy/Occy *doer* as an unmodified isolated Ubuntu guest VM; **Ferrocene `no_std` verdict core** as the certified artifact; PikeOS/INTEGRITY roadmap-only) plus its supporting analysis companion **KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md**.

## Files (both new, verbatim, byte-identical to source)
- `docs/adr/ADR-0001-governor-deployment-platform.md`
- `docs/adr/KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md`

## Placement & naming notes
- Placed in **`docs/adr/`** (it already exists, per the "if docs/adr/ exists, use it" rule — the `docs/safety/` heredoc target was only the fallback).
- Co-located so the strategy doc's cross-reference (`Companion document: ADR-0001-governor-deployment-platform.md`, bare filename) **resolves** — verified.
- **Filename kept as the verbatim `ADR-0001-…`** even though `docs/adr/` already contains `0001-occy-odd-speed-cap.md` (the existing `####-kebab` series 0001–0004). The two are **distinct files on disk** (`ADR-0001-…` vs `0001-…`), so there's no collision; and renaming to `0005-…` would have broken the companion's verbatim cross-references. Flagging it so you can decide if you'd prefer a renumber later — trivial to change.

## Guardrails honored
- **Docs-only** — no source modified. `git status` showed exactly the two new untracked docs before staging.
- Verdict path `src/gateway/kinematics_contract.rs` blob unchanged: `997fb7ae15ce3e11adec9218044c7c84b049ad3b` (verified start and end).
- No `git add -A`; staged only the two doc paths.

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_