### PR TITLE
feat(governor-service): minimal UDP governor wrapping the verdict core (two-box prototype)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector"]
+members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service"]
 resolver = "2"
 
 [package]

--- a/crates/kirra-governor-service/Cargo.toml
+++ b/crates/kirra-governor-service/Cargo.toml
@@ -1,0 +1,25 @@
+# crates/kirra-governor-service/Cargo.toml
+#
+# Minimal over-the-wire (UDP) KIRRA governor for the two-box governed-car
+# prototype (docs/adr/KIRRA_BRINGUP_RUNBOOK.md, Prompt A).
+#
+# DEPENDENCY DISCIPLINE (ADR-0001): this target depends ONLY on serde + bincode
+# + std. It deliberately does NOT depend on the parent `kirra-runtime-sdk` crate
+# (which pulls tokio/axum/rusqlite/reqwest) — instead it compiles the EXISTING
+# verdict core (src/gateway/kinematics_contract.rs) in verbatim via `#[path]`
+# (see src/main.rs), so the verdict logic is the real, unmodified one while the
+# dependency tree stays minimal and ROS/async-free for the QNX cert target.
+[package]
+name = "kirra-governor-service"
+version = "0.1.0"
+edition = "2021"
+description = "Minimal UDP KIRRA governor (two-box prototype); wraps the verdict core verbatim. serde + bincode + std only — no ROS/async."
+license = "Apache-2.0"
+
+[[bin]]
+name = "kirra-governor-service"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+bincode = "1.3"

--- a/crates/kirra-governor-service/README.md
+++ b/crates/kirra-governor-service/README.md
@@ -1,0 +1,94 @@
+# kirra-governor-service
+
+Minimal over-the-wire (UDP) KIRRA governor for the two-box governed-car
+prototype — see `docs/adr/KIRRA_BRINGUP_RUNBOOK.md` (Prompt A), `ADR-0001`, and
+`KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md`.
+
+It wraps the **existing** verdict core (`src/gateway/kinematics_contract.rs`),
+compiled in **verbatim** via `#[path]` — not forked, not moved (the talisman
+file stays byte-identical, blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b`).
+Because that file imports only `serde` + `std`, this binary's whole dependency
+tree is **serde + bincode + std** — no `tokio`, ROS 2, `r2r`, or DDS, matching
+the minimal-governor thesis of ADR-0001 (and the QNX cert target has none of
+those anyway).
+
+## Wire contract (single source of truth)
+
+Two fixed-schema `bincode` structs over UDP, 1:1 request/response:
+
+- **Proposal** (car → governor): `{ seq: u64, ts_nanos: u128, command: ProposedVehicleCommand }`
+- **Verdict** (governor → car): `{ seq: u64, action: EnforceAction, reason_code: u32 }`
+
+`command` is the verdict core's real input type (`ProposedVehicleCommand`); no
+kinematic fields are invented. The safety envelope
+(`VehicleKinematicsContract`) is the **governor's** policy
+(`nominal_reference_profile()`) and is *not* carried in the proposal — the doer
+proposes a command; it does not choose its own limits.
+
+`reason_code`: `0` = no breach (Accept / Clamp); `1..=10` map 1:1 to `DenyCode`
+(`NanInfLinearVelocity`=1 … `DegradedSpeedIncreaseDenied`=10), so a car can
+branch on a stable numeric without deserializing `EnforceAction` (which is
+`Serialize`-only in the core).
+
+## Run (host / prototype)
+
+```sh
+cargo run -p kirra-governor-service
+# listens on 0.0.0.0:9760 — override with KIRRA_GOVERNOR_ADDR=host:port
+```
+
+## Host build & test (CI / dev — pure Rust, builds anywhere)
+
+```sh
+cargo build -p kirra-governor-service
+cargo test  -p kirra-governor-service     # service logic + the verdict core's own unit tests
+```
+
+## QNX x86-64 cross-compile (dev host only — NOT run in CI)
+
+The cert target is QNX Neutrino; this build runs on the QNX SDP dev host, not in
+CI (no QNX SDP toolchain there). The **prototype** uses standard Rust for the
+QNX target — the Ferrocene / `no_std` / ASIL-D factoring is a later stage per
+ADR-0001 and does not block the demo.
+
+1. Install QNX SDP 8.0 and source its environment (puts `qcc`/`q++` and the
+   target sysroot on `PATH` / `QNX_TARGET`):
+
+   ```sh
+   source ~/qnx800/qnxsdp-env.sh
+   ```
+
+2. Provide a Rust QNX target — either rustup's QNX target or the **Ferrocene**
+   toolchain, whose qualified targets include QNX Neutrino 7.1.0 (x86-64 +
+   Armv8-A):
+
+   ```sh
+   rustup target add x86_64-pc-nto-qnx710        # rustup's QNX Neutrino 7.1 target
+   ```
+
+3. Point Cargo's linker at the QNX compiler driver and build **only this crate**
+   (its dep tree is serde + bincode, so nothing ROS/async obstructs the QNX
+   build):
+
+   ```sh
+   export CARGO_TARGET_X86_64_PC_NTO_QNX710_LINKER=qcc
+   export CARGO_TARGET_X86_64_PC_NTO_QNX710_RUSTFLAGS="-Clink-arg=-Vgcc_ntox86_64"
+   cargo build -p kirra-governor-service --target x86_64-pc-nto-qnx710 --release
+   ```
+
+4. Copy the binary to the QNX target and run it; point the car's bridge node
+   (runbook Prompt B) at `host:port`.
+
+> The exact target triple and `qcc -V<variant>` argument depend on the installed
+> QNX SDP and Rust/Ferrocene release — confirm against the QNX SDP and Ferrocene
+> QNX-target docs at build time. What this crate **guarantees** is the part that
+> matters for portability: its dependency tree is serde + bincode only, so there
+> is nothing ROS/async to stand in the way of the QNX build.
+
+## What this is not
+
+A prototype over UDP — not the certified build and not a tight real-time control
+transport. Stale/missing verdicts are handled by safe-stating (governor watchdog
+M6 + car-side deadline), which is the correct fail direction. The cert target
+(single-SoC QNX Hypervisor, shared-memory mailbox, Ferrocene `no_std` core)
+follows once the logic is proven — see ADR-0001.

--- a/crates/kirra-governor-service/src/main.rs
+++ b/crates/kirra-governor-service/src/main.rs
@@ -1,0 +1,256 @@
+// crates/kirra-governor-service/src/main.rs
+//
+// kirra-governor-service — minimal over-the-wire (UDP) KIRRA governor for the
+// two-box governed-car prototype (docs/adr/KIRRA_BRINGUP_RUNBOOK.md, Prompt A).
+//
+// It wraps the EXISTING verdict core — `src/gateway/kinematics_contract.rs` —
+// compiled in VERBATIM via `#[path]`. The file is NOT forked and NOT moved: it
+// stays byte-identical at its canonical location (talisman blob
+// 997fb7ae15ce3e11adec9218044c7c84b049ad3b). Because that file imports only
+// `serde` + `std`, including it here pulls in nothing heavy: this binary's
+// entire dependency tree is serde + bincode + std — NO tokio, ROS 2, r2r, or
+// DDS, per ADR-0001 (the governor is the minimal, async/ROS-free checker; the
+// QNX cert target has none of those anyway).
+//
+// PROTOTYPE STAGE (QM, not the cert build): regular Rust over UDP. The
+// Ferrocene / `no_std` / ASIL-D factoring and the shared-memory mailbox are a
+// later stage and do not block the demo — see ADR-0001 and the bring-up runbook.
+
+// Compile the real verdict core in verbatim. Path is relative to THIS file:
+// crates/kirra-governor-service/src/ -> ../../../ = repo root -> src/gateway/...
+// `allow(dead_code)`: the core exposes the full contract API (e.g.
+// `enforce_degraded_decel_to_stop`, `mrc_fallback_profile`) that the parent
+// crate uses; this minimal binary only calls `validate_vehicle_command`, so the
+// rest is legitimately unused HERE — not dead. We do not edit the file to
+// silence this (talisman); we scope the allow to the include site.
+#[allow(dead_code)]
+#[path = "../../../src/gateway/kinematics_contract.rs"]
+mod kinematics_contract;
+
+use kinematics_contract::{
+    validate_vehicle_command, DenyCode, EnforceAction, ProposedVehicleCommand,
+    VehicleKinematicsContract,
+};
+use serde::{Deserialize, Serialize};
+use std::net::UdpSocket;
+
+/// Default listen address (override with `KIRRA_GOVERNOR_ADDR`).
+const DEFAULT_ADDR: &str = "0.0.0.0:9760";
+
+/// Wire request, car -> governor. Carries ONLY the proposed command: the safety
+/// envelope (`VehicleKinematicsContract`) is the GOVERNOR's policy, never the
+/// doer's to choose. `ProposedVehicleCommand` is the verdict core's real input
+/// type (serde-(de)serializable in the core) — no kinematic fields are invented
+/// here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Proposal {
+    /// Monotonic request sequence (echoed in the verdict; basis for the M6 watchdog).
+    pub seq: u64,
+    /// Car-side send timestamp (nanoseconds). Used for staleness once the M6
+    /// watchdog is wired; carried now so the schema is stable.
+    pub ts_nanos: u128,
+    /// The proposed command — the verdict core's real input type, verbatim.
+    pub command: ProposedVehicleCommand,
+}
+
+/// Wire response, governor -> car. `action` is the verdict core's own output
+/// (`EnforceAction`, Serialize-only in the core, which is all a one-way encode
+/// needs). `reason_code` is a stable numeric a car can branch on WITHOUT
+/// deserializing `EnforceAction`.
+#[derive(Debug, Clone, Serialize)]
+pub struct Verdict {
+    pub seq: u64,
+    pub action: EnforceAction,
+    pub reason_code: u32,
+}
+
+/// Stable numeric reason code: `0` = no breach (Accept / Clamp); `1..=10` map
+/// 1:1 to `DenyCode`. Kept as an explicit match so adding a `DenyCode` variant
+/// upstream forces a compile error here (no silent gap).
+fn reason_code(action: &EnforceAction) -> u32 {
+    match action {
+        EnforceAction::Allow
+        | EnforceAction::ClampLinear(_)
+        | EnforceAction::ClampSteering(_) => 0,
+        EnforceAction::DenyBreach(code) => deny_code_num(*code),
+    }
+}
+
+fn deny_code_num(code: DenyCode) -> u32 {
+    match code {
+        DenyCode::NanInfLinearVelocity => 1,
+        DenyCode::NanInfCurrentVelocity => 2,
+        DenyCode::NanInfSteeringAngle => 3,
+        DenyCode::NanInfCurrentSteering => 4,
+        DenyCode::NanInfDeltaTime => 5,
+        DenyCode::InvalidTimeDelta => 6,
+        DenyCode::AssetLockedOut => 7,
+        DenyCode::DrivableSpaceDeparture => 8,
+        DenyCode::DegradedReinitiationDenied => 9,
+        DenyCode::DegradedSpeedIncreaseDenied => 10,
+    }
+}
+
+/// The decision: run the verdict core VERBATIM against the governor's contract.
+/// Pure (no I/O) so it is unit-testable without a socket.
+fn decide(proposal: &Proposal, contract: &VehicleKinematicsContract) -> Verdict {
+    let action = validate_vehicle_command(&proposal.command, contract);
+    let reason_code = reason_code(&action);
+    Verdict {
+        seq: proposal.seq,
+        action,
+        reason_code,
+    }
+}
+
+/// Minimal M6 watchdog state (staleness check stubbed for the prototype; the
+/// safe-state wiring comes later per the runbook). For now it only flags a
+/// non-monotonic sequence, which would indicate a reordered/replayed proposal.
+#[derive(Default)]
+struct WatchdogState {
+    last_seq: Option<u64>,
+    last_ts_nanos: Option<u128>,
+}
+
+impl WatchdogState {
+    /// Records the proposal and returns `false` if the sequence did not advance
+    /// (the caller logs it). Staleness-vs-deadline and the safe-state emission
+    /// are deliberately NOT implemented yet (M6).
+    fn observe(&mut self, proposal: &Proposal) -> bool {
+        let monotonic = self.last_seq.map(|p| proposal.seq > p).unwrap_or(true);
+        self.last_seq = Some(proposal.seq);
+        self.last_ts_nanos = Some(proposal.ts_nanos);
+        monotonic
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    let addr = std::env::var("KIRRA_GOVERNOR_ADDR").unwrap_or_else(|_| DEFAULT_ADDR.to_string());
+
+    // The governor enforces its OWN envelope. Nominal reference profile for the
+    // prototype; the MRC fallback profile is available for a degraded mode.
+    let contract = VehicleKinematicsContract::nominal_reference_profile();
+
+    let socket = UdpSocket::bind(&addr)?;
+    eprintln!(
+        "kirra-governor-service: listening on {addr} (UDP), \
+         contract = nominal_reference_profile, effective_max_speed = {:.2} m/s",
+        contract.effective_max_speed_mps()
+    );
+
+    let mut watchdog = WatchdogState::default();
+    // One UDP datagram per proposal; 64 KiB is far above the fixed-schema size.
+    let mut buf = vec![0u8; 64 * 1024];
+
+    loop {
+        let (n, peer) = socket.recv_from(&mut buf)?;
+
+        let proposal: Proposal = match bincode::deserialize(&buf[..n]) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("decode error from {peer}: {e}");
+                continue;
+            }
+        };
+
+        if !watchdog.observe(&proposal) {
+            eprintln!(
+                "watchdog: non-monotonic seq {} from {peer} (staleness/safe-state is M6, stubbed)",
+                proposal.seq
+            );
+        }
+
+        let verdict = decide(&proposal, &contract);
+
+        match bincode::serialize(&verdict) {
+            Ok(bytes) => {
+                if let Err(e) = socket.send_to(&bytes, peer) {
+                    eprintln!("send error to {peer}: {e}");
+                }
+            }
+            Err(e) => eprintln!("encode error for seq {}: {e}", verdict.seq),
+        }
+    }
+}
+
+#[cfg(test)]
+mod service_tests {
+    use super::*;
+
+    fn steady(linear: f64, steering: f64) -> Proposal {
+        Proposal {
+            seq: 1,
+            ts_nanos: 0,
+            command: ProposedVehicleCommand {
+                linear_velocity_mps: linear,
+                current_velocity_mps: linear,
+                delta_time_s: 0.1,
+                steering_angle_deg: steering,
+                current_steering_angle_deg: steering,
+            },
+        }
+    }
+
+    #[test]
+    fn steady_low_speed_command_is_accepted() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let v = decide(&steady(1.0, 0.0), &contract);
+        assert_eq!(v.action, EnforceAction::Allow, "a steady 1 m/s straight command must pass");
+        assert_eq!(v.reason_code, 0);
+        assert_eq!(v.seq, 1);
+    }
+
+    #[test]
+    fn nan_linear_velocity_is_denied_with_code_1() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let v = decide(&steady(f64::NAN, 0.0), &contract);
+        assert_eq!(
+            v.action,
+            EnforceAction::DenyBreach(DenyCode::NanInfLinearVelocity),
+            "NaN linear velocity must be denied by the verdict core verbatim"
+        );
+        assert_eq!(v.reason_code, 1, "NaN-linear maps to reason_code 1");
+    }
+
+    #[test]
+    fn verdict_echoes_request_seq() {
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let mut p = steady(1.0, 0.0);
+        p.seq = 42;
+        assert_eq!(decide(&p, &contract).seq, 42);
+    }
+
+    #[test]
+    fn proposal_round_trips_over_bincode() {
+        // The decode side of the wire (Proposal: Deserialize) must round-trip.
+        let p = steady(2.5, 3.0);
+        let bytes = bincode::serialize(&p).expect("encode");
+        let back: Proposal = bincode::deserialize(&bytes).expect("decode");
+        assert_eq!(back.seq, p.seq);
+        assert_eq!(back.command.linear_velocity_mps, p.command.linear_velocity_mps);
+        assert_eq!(back.command.steering_angle_deg, p.command.steering_angle_deg);
+    }
+
+    #[test]
+    fn verdict_serializes_for_the_wire() {
+        // The encode side of the wire (Verdict: Serialize) must succeed for both
+        // an accept and a deny.
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let accept = decide(&steady(1.0, 0.0), &contract);
+        let deny = decide(&steady(f64::INFINITY, 0.0), &contract);
+        assert!(bincode::serialize(&accept).is_ok());
+        assert!(bincode::serialize(&deny).is_ok());
+    }
+
+    #[test]
+    fn watchdog_flags_non_monotonic_seq() {
+        let mut wd = WatchdogState::default();
+        let mut p = steady(1.0, 0.0);
+        p.seq = 5;
+        assert!(wd.observe(&p), "first observation is always monotonic");
+        p.seq = 4;
+        assert!(!wd.observe(&p), "a lower seq must be flagged as non-monotonic");
+        p.seq = 6;
+        assert!(wd.observe(&p), "an advancing seq is monotonic again");
+    }
+}


### PR DESCRIPTION
## Summary

Prompt A from the two-box bring-up runbook. New minimal binary crate **`kirra-governor-service`**: an over-the-wire (UDP) governor that wraps the **existing** verdict core for the prototype demonstrator.

- Blocking `std::net::UdpSocket` loop: bincode-decode `Proposal` → run the verdict core **verbatim** → bincode-encode `Verdict` → reply to sender.
- **Wire schema bound to the real types** (no invented fields):
  - `Proposal { seq: u64, ts_nanos: u128, command: ProposedVehicleCommand }`
  - `Verdict  { seq: u64, action: EnforceAction, reason_code: u32 }`
- The safety envelope (`VehicleKinematicsContract::nominal_reference_profile()`) is the **governor's** policy — *not* carried in the proposal. The doer proposes a command; it never picks its own limits.
- `reason_code`: `0` = no breach (Accept/Clamp); `1..=10` map 1:1 to `DenyCode` (so a car can branch on a numeric without deserializing `EnforceAction`, which is `Serialize`-only in the core).
- M6 watchdog state is **stubbed** (monotonic-seq flag only); staleness→safe-state is wired later, per the runbook.

## Dependency discipline (ADR-0001) — the key constraint

The crate depends on **serde + bincode + std only** — it does **not** depend on the heavy parent crate (`kirra-runtime-sdk`, which pulls tokio/axum/rusqlite/reqwest). Instead it compiles `src/gateway/kinematics_contract.rs` **in verbatim via `#[path]`**, so the verdict logic is the real, unmodified core while the dep tree stays ROS/async-free for the QNX cert target.

```
$ cargo tree -p kirra-governor-service
kirra-governor-service v0.1.0
├── bincode v1.3.3
│   └── serde v1.0.228
│       ├── serde_core v1.0.228
│       └── serde_derive v1.0.228 (proc-macro) → proc-macro2 / quote / syn / unicode-ident
└── serde v1.0.228 (*)
```
Explicit scan: **no** tokio / r2r / ROS / axum / rusqlite / reqwest / DDS / hyper.

## Verification
- `cargo build -p kirra-governor-service` → clean (0 warnings; dead-code from the verbatim core's unused-here API is scoped-`allow`ed at the include site, not by editing the file).
- `cargo test -p kirra-governor-service` → **48 passed** (6 service tests: accept, NaN-deny→code 1, seq echo, bincode round-trip, verdict-serialize, watchdog monotonicity — plus the ~42 verdict-core unit tests that ride along via the `#[path]` include).
- **QNX x86-64 cross-compile documented** in `crates/kirra-governor-service/README.md` (dev-host only; explicitly NOT in CI — no QNX SDP there).

## Guardrails
- `src/gateway/kinematics_contract.rs` **unchanged** — not edited, not moved. Blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b` verified start and end; `git status` confirms it's not in the diff.
- No `git add -A`; staged only `Cargo.toml` (workspace member add) + the new crate.

Prototype/QM stage — regular Rust over UDP. The Ferrocene / `no_std` / ASIL-D factoring and the shared-memory mailbox follow once the logic is proven (ADR-0001).

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_