### PR TITLE
feat(dev-tools): shared wire-client mirror + UDP proposal bench for governor-service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service"]
+members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench"]
 resolver = "2"
 
 [package]

--- a/crates/kirra-proposal-bench/Cargo.toml
+++ b/crates/kirra-proposal-bench/Cargo.toml
@@ -1,0 +1,19 @@
+# crates/kirra-proposal-bench/Cargo.toml
+#
+# DEV/TEST ONLY — a UDP bench tool that exercises a running
+# kirra-governor-service across a sweep of proposals and prints the verdicts.
+# NOT a shipped or safety artifact. Depends only on the shared wire mirror
+# (kirra-wire-client) → serde + bincode + std; no kirra-runtime-sdk, no ROS/async.
+[package]
+name = "kirra-proposal-bench"
+version = "0.1.0"
+edition = "2021"
+description = "DEV/TEST UDP bench for kirra-governor-service — sends a proposal sweep and prints the verdict table. Not a safety artifact."
+license = "Apache-2.0"
+
+[[bin]]
+name = "kirra-proposal-bench"
+path = "src/main.rs"
+
+[dependencies]
+kirra-wire-client = { path = "../kirra-wire-client" }

--- a/crates/kirra-proposal-bench/src/main.rs
+++ b/crates/kirra-proposal-bench/src/main.rs
@@ -1,0 +1,119 @@
+// crates/kirra-proposal-bench/src/main.rs
+//
+// kirra-proposal-bench — DEV/TEST tool. Sends a sweep of proposals to a running
+// `kirra-governor-service` over UDP, decodes each verdict via the shared
+// `kirra-wire-client` mirror, and prints a CASE / REASON / VERDICT table.
+//
+// NOT a shipped or safety artifact: it neither contains nor re-implements any
+// verdict logic — it just talks to the governor and reports what comes back.
+//
+//   cargo run -p kirra-proposal-bench
+//   KIRRA_GOVERNOR_ADDR=192.168.1.50:9760 cargo run -p kirra-proposal-bench
+
+use kirra_wire_client::{
+    decode_verdict, encode_proposal, ClientEnforceAction, Proposal, ProposedCommand,
+};
+use std::net::UdpSocket;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const DEFAULT_ADDR: &str = "127.0.0.1:9760";
+const RECV_TIMEOUT: Duration = Duration::from_millis(1000);
+
+/// One sweep case: a human-readable intent plus the command to send. The intent
+/// is what we EXPECT to provoke; the printed verdict is whatever the governor
+/// actually returns (the bench reports, it does not predict).
+struct Case {
+    name: &'static str,
+    cmd: ProposedCommand,
+}
+
+fn cmd(linear: f64, current: f64, dt: f64, steer: f64, cur_steer: f64) -> ProposedCommand {
+    ProposedCommand {
+        linear_velocity_mps: linear,
+        current_velocity_mps: current,
+        delta_time_s: dt,
+        steering_angle_deg: steer,
+        current_steering_angle_deg: cur_steer,
+    }
+}
+
+fn now_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}
+
+/// (REASON token, VERDICT rendering) for the table.
+fn render(action: &ClientEnforceAction, reason_code: u32) -> (String, String) {
+    match action {
+        ClientEnforceAction::Allow => ("ACCEPT".into(), "Allow".into()),
+        ClientEnforceAction::ClampLinear(v) => {
+            ("CLAMP_LINEAR".into(), format!("ClampLinear({v:.3} m/s)"))
+        }
+        ClientEnforceAction::ClampSteering(v) => {
+            ("CLAMP_STEER".into(), format!("ClampSteering({v:.3} deg)"))
+        }
+        ClientEnforceAction::DenyBreach(code) => {
+            (format!("{code:?}"), format!("DenyBreach (reason_code={reason_code})"))
+        }
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    let addr = std::env::var("KIRRA_GOVERNOR_ADDR").unwrap_or_else(|_| DEFAULT_ADDR.to_string());
+
+    let sock = UdpSocket::bind("0.0.0.0:0")?;
+    sock.connect(&addr)?;
+    sock.set_read_timeout(Some(RECV_TIMEOUT))?;
+
+    let cases = [
+        Case { name: "nominal accept",      cmd: cmd(1.0, 1.0, 0.1, 0.0, 0.0) },
+        Case { name: "over-speed clamp",    cmd: cmd(50.0, 50.0, 1.0, 0.0, 0.0) },
+        Case { name: "reverse over-speed",  cmd: cmd(-50.0, -50.0, 1.0, 0.0, 0.0) },
+        Case { name: "hard steering step",  cmd: cmd(2.0, 2.0, 0.1, 40.0, 0.0) },
+        Case { name: "NaN deny",            cmd: cmd(f64::NAN, 1.0, 0.1, 0.0, 0.0) },
+        Case { name: "zero-dt deny",        cmd: cmd(1.0, 1.0, 0.0, 0.0, 0.0) },
+    ];
+
+    eprintln!("kirra-proposal-bench → {addr} ({} cases)\n", cases.len());
+    println!("{:<20} | {:<26} | {}", "CASE", "REASON", "VERDICT");
+    println!("{}", "-".repeat(78));
+
+    let mut buf = [0u8; 4096];
+    let mut sent = 0usize;
+    let mut answered = 0usize;
+
+    for (i, c) in cases.iter().enumerate() {
+        let proposal = Proposal {
+            seq: i as u64 + 1,
+            ts_nanos: now_nanos(),
+            command: c.cmd.clone(),
+        };
+        let bytes = encode_proposal(&proposal).expect("encode proposal");
+        sock.send(&bytes)?;
+        sent += 1;
+
+        match sock.recv(&mut buf) {
+            Ok(n) => match decode_verdict(&buf[..n]) {
+                Ok(v) => {
+                    answered += 1;
+                    let (reason, verdict) = render(&v.action, v.reason_code);
+                    println!("{:<20} | {:<26} | {}", c.name, reason, verdict);
+                }
+                Err(e) => println!("{:<20} | {:<26} | DECODE ERROR: {e}", c.name, "ERR"),
+            },
+            Err(e) => println!("{:<20} | {:<26} | NO REPLY ({e})", c.name, "TIMEOUT"),
+        }
+    }
+
+    println!("\n{answered}/{sent} proposals answered by {addr}");
+    if answered == 0 {
+        eprintln!(
+            "no verdicts received — is kirra-governor-service running? \
+             (cargo run -p kirra-governor-service)"
+        );
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/crates/kirra-wire-client/Cargo.toml
+++ b/crates/kirra-wire-client/Cargo.toml
@@ -1,0 +1,19 @@
+# crates/kirra-wire-client/Cargo.toml
+#
+# DEV/TEST ONLY — the single shared CLIENT-SIDE mirror of the
+# kirra-governor-service UDP wire schema. NOT a shipped or safety artifact; the
+# governor's own verdict core (src/gateway/kinematics_contract.rs) remains the
+# sole source of truth. This crate exists so the dev bench and the (future) car
+# bridge node share ONE definition of the wire types instead of each re-rolling
+# them. Pure serde + bincode + std; it deliberately does NOT depend on
+# kirra-runtime-sdk.
+[package]
+name = "kirra-wire-client"
+version = "0.1.0"
+edition = "2021"
+description = "DEV/TEST client-side mirror of the kirra-governor-service UDP wire schema (serde + bincode). Not a safety artifact."
+license = "Apache-2.0"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+bincode = "1.3"

--- a/crates/kirra-wire-client/src/lib.rs
+++ b/crates/kirra-wire-client/src/lib.rs
@@ -1,0 +1,212 @@
+// crates/kirra-wire-client/src/lib.rs
+//
+// kirra-wire-client — the SINGLE shared client-side mirror of the
+// `kirra-governor-service` UDP wire schema. Pure serde + bincode + std; it does
+// NOT depend on `kirra-runtime-sdk` / the verdict core. Both the dev bench
+// (`kirra-proposal-bench`) and the future car bridge node reuse THIS crate so
+// the wire types are defined exactly once on the client side.
+//
+// DEV/TEST ONLY — not a shipped or safety artifact. The governor's verdict core
+// (`src/gateway/kinematics_contract.rs`) is the sole source of truth; this is a
+// convenience mirror for talking to it over the wire.
+//
+// ┌───────────────────────────────────────────────────────────────────────────┐
+// │ WIRE-FORMAT INVARIANT — READ BEFORE EDITING                                 │
+// │                                                                             │
+// │ bincode puts NO field/variant NAMES on the wire: it encodes enums by their  │
+// │ POSITIONAL VARIANT INDEX (a u32 tag) and structs by FIELD ORDER. Therefore  │
+// │ the variant order of `ClientEnforceAction` / `ClientDenyCode` and the field │
+// │ order of `ProposedCommand` / `Proposal` / `Verdict` MUST EXACTLY MIRROR:    │
+// │                                                                             │
+// │   • src/gateway/kinematics_contract.rs  →  EnforceAction, DenyCode,         │
+// │                                            ProposedVehicleCommand           │
+// │   • crates/kirra-governor-service/src/main.rs  →  Proposal, Verdict         │
+// │                                                                             │
+// │ Reordering or inserting a variant/field on EITHER side silently corrupts    │
+// │ every decode (a deny would read as a different deny; a clamp as garbage).   │
+// │ The `wire_layout` tests below pin the byte layout and fail on drift.        │
+// └───────────────────────────────────────────────────────────────────────────┘
+
+use serde::{Deserialize, Serialize};
+
+/// Mirror of core `ProposedVehicleCommand` — fields in the SAME ORDER.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposedCommand {
+    /// Desired forward velocity at end of step (m/s); negative = reverse.
+    pub linear_velocity_mps: f64,
+    /// Actual forward velocity at start of step (m/s).
+    pub current_velocity_mps: f64,
+    /// Planning step duration (s); must be > 0.
+    pub delta_time_s: f64,
+    /// Desired steering angle at end of step (deg); +left (ISO 8855).
+    pub steering_angle_deg: f64,
+    /// Actual steering angle at start of step (deg).
+    pub current_steering_angle_deg: f64,
+}
+
+/// Mirror of the governor's `Proposal` (car → governor). Field order MUST match.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Proposal {
+    pub seq: u64,
+    pub ts_nanos: u128,
+    pub command: ProposedCommand,
+}
+
+/// Mirror of core `DenyCode` — variants in the SAME ORDER (the index IS the
+/// wire tag). The trailing `// N` is the bincode variant index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClientDenyCode {
+    NanInfLinearVelocity,        // 0
+    NanInfCurrentVelocity,       // 1
+    NanInfSteeringAngle,         // 2
+    NanInfCurrentSteering,       // 3
+    NanInfDeltaTime,             // 4
+    InvalidTimeDelta,            // 5
+    AssetLockedOut,              // 6
+    DrivableSpaceDeparture,      // 7
+    DegradedReinitiationDenied,  // 8
+    DegradedSpeedIncreaseDenied, // 9
+}
+
+/// Mirror of core `EnforceAction` — variants in the SAME ORDER.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ClientEnforceAction {
+    Allow,                      // 0
+    ClampLinear(f64),           // 1
+    ClampSteering(f64),         // 2
+    DenyBreach(ClientDenyCode), // 3
+}
+
+/// Mirror of the governor's `Verdict` (governor → car). The governor's
+/// `Verdict.action` is `Serialize`-only; here `ClientEnforceAction` is fully
+/// (de)serializable so the client can DECODE the reply. `Serialize` is derived
+/// too only so the drift tests can re-encode and byte-compare.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Verdict {
+    pub seq: u64,
+    pub action: ClientEnforceAction,
+    pub reason_code: u32,
+}
+
+/// Encode a `Proposal` for the wire (matches the governor's `bincode::serialize`).
+pub fn encode_proposal(p: &Proposal) -> bincode::Result<Vec<u8>> {
+    bincode::serialize(p)
+}
+
+/// Decode a `Verdict` from the wire (matches the governor's `bincode::serialize`).
+pub fn decode_verdict(bytes: &[u8]) -> bincode::Result<Verdict> {
+    bincode::deserialize(bytes)
+}
+
+#[cfg(test)]
+mod wire_layout {
+    use super::*;
+
+    // bincode free-function config is fixint + little-endian. These literal
+    // byte sequences are computed by hand from that layout, so they pin the wire
+    // format independently of this crate's own code — if anyone reorders a
+    // variant/field, decode lands on the wrong variant and these fail.
+
+    /// A `DenyBreach(NanInfDeltaTime)` verdict, seq=7, reason_code=5.
+    /// Layout: seq u64 LE | action: enum-index 3 (DenyBreach) u32 LE,
+    ///                       inner DenyCode index 4 (NanInfDeltaTime) u32 LE
+    ///       | reason_code u32 LE
+    const DENY_VERDICT_BYTES: [u8; 20] = [
+        7, 0, 0, 0, 0, 0, 0, 0, // seq = 7
+        3, 0, 0, 0, // EnforceAction::DenyBreach (index 3)
+        4, 0, 0, 0, // DenyCode::NanInfDeltaTime (index 4)
+        5, 0, 0, 0, // reason_code = 5
+    ];
+
+    #[test]
+    fn known_bytes_deny_verdict_decodes_and_reencodes() {
+        let v = decode_verdict(&DENY_VERDICT_BYTES).expect("decode known bytes");
+        assert_eq!(
+            v,
+            Verdict {
+                seq: 7,
+                action: ClientEnforceAction::DenyBreach(ClientDenyCode::NanInfDeltaTime),
+                reason_code: 5,
+            },
+            "known deny verdict must decode to the mirrored variant — if this fails, \
+             the enum order drifted from the core"
+        );
+        // Re-encode must reproduce the exact bytes (round-trip closes the loop).
+        assert_eq!(bincode::serialize(&v).unwrap(), DENY_VERDICT_BYTES);
+    }
+
+    #[test]
+    fn known_bytes_allow_verdict() {
+        // seq=0, Allow (index 0, no payload), reason_code=0 → 16 zero bytes.
+        let bytes = [0u8; 16];
+        let v = decode_verdict(&bytes).expect("decode");
+        assert_eq!(v.action, ClientEnforceAction::Allow, "index 0 must be Allow");
+        assert_eq!(v.seq, 0);
+        assert_eq!(v.reason_code, 0);
+        assert_eq!(bincode::serialize(&v).unwrap(), bytes);
+    }
+
+    #[test]
+    fn all_ten_deny_codes_pin_their_index() {
+        // Each DenyCode must encode at its declared position. The DenyBreach
+        // inner index sits at byte offset 12 (seq[0..8] + DenyBreach-tag[8..12]).
+        let codes = [
+            ClientDenyCode::NanInfLinearVelocity,
+            ClientDenyCode::NanInfCurrentVelocity,
+            ClientDenyCode::NanInfSteeringAngle,
+            ClientDenyCode::NanInfCurrentSteering,
+            ClientDenyCode::NanInfDeltaTime,
+            ClientDenyCode::InvalidTimeDelta,
+            ClientDenyCode::AssetLockedOut,
+            ClientDenyCode::DrivableSpaceDeparture,
+            ClientDenyCode::DegradedReinitiationDenied,
+            ClientDenyCode::DegradedSpeedIncreaseDenied,
+        ];
+        for (i, code) in codes.iter().enumerate() {
+            let v = Verdict {
+                seq: 0,
+                action: ClientEnforceAction::DenyBreach(*code),
+                reason_code: 0,
+            };
+            let bytes = bincode::serialize(&v).unwrap();
+            assert_eq!(bytes[8], 3, "DenyBreach must be EnforceAction index 3");
+            assert_eq!(
+                bytes[12], i as u8,
+                "{code:?} must encode at DenyCode index {i} (wire-order drift!)"
+            );
+        }
+    }
+
+    #[test]
+    fn clamp_payload_round_trips() {
+        // Exercises the f64 payload on ClampLinear/ClampSteering (indices 1/2).
+        for action in [
+            ClientEnforceAction::ClampLinear(22.35),
+            ClientEnforceAction::ClampSteering(-12.5),
+        ] {
+            let v = Verdict { seq: 99, action: action.clone(), reason_code: 0 };
+            let bytes = bincode::serialize(&v).unwrap();
+            assert_eq!(decode_verdict(&bytes).unwrap(), v);
+        }
+    }
+
+    #[test]
+    fn proposal_encodes_with_expected_prefix() {
+        // seq=1 (u64), ts_nanos=0 (u128 = 16 bytes), then the 5 f64 command
+        // fields → 8 + 16 + 40 = 64 bytes total; seq prefix is 01 00..00.
+        let p = Proposal {
+            seq: 1,
+            ts_nanos: 0,
+            command: ProposedCommand {
+                linear_velocity_mps: 1.0,
+                current_velocity_mps: 1.0,
+                delta_time_s: 0.1,
+                steering_angle_deg: 0.0,
+                current_steering_angle_deg: 0.0,
+            },
+        };
+        let bytes = encode_proposal(&p).unwrap();
+        assert_eq!(bytes.len(), 8 + 16 + 5 * 8, "fixed-schema proposal size");
+        assert_eq!(&bytes[0..8], &[1, 0, 0, 0, 0, 0, 0, 0], "seq u64 LE prefix");
+    }
+}


### PR DESCRIPTION
## Summary

DEV/TEST tooling for the two-box prototype (not a shipped or safety artifact). Two new crates, **serde + bincode + std only**.

### `crates/kirra-wire-client` — the single shared wire mirror
Client-side mirror of `kirra-governor-service`'s UDP schema, reused by the bench now and the future car bridge node (so the wire types are defined once on the client side; no `kirra-runtime-sdk` dependency).
- `Proposal { seq, ts_nanos, ProposedCommand }` (Serialize) and `Verdict { seq, ClientEnforceAction, reason_code }` (Deserialize; `ClientEnforceAction { Allow, ClampLinear, ClampSteering, DenyBreach(ClientDenyCode) }`, `ClientDenyCode` with the 10 variants).
- **Wire-format invariant**: bincode puts no names on the wire — enums encode by positional variant index, structs by field order — so variant/field order here MUST mirror `src/gateway/kinematics_contract.rs` (`EnforceAction`/`DenyCode`/`ProposedVehicleCommand`) and the governor's `Proposal`/`Verdict`. A prominent boxed comment states this, and **`wire_layout` drift tests pin the byte layout**: a known-bytes deny verdict decodes+re-encodes, the Allow case, **all 10 deny indices**, the clamp `f64` payload, and the proposal prefix/size.

### `crates/kirra-proposal-bench` — UDP bench
Sends a sweep to `KIRRA_GOVERNOR_ADDR` (default `127.0.0.1:9760`), decodes each verdict via the mirror, prints a CASE/REASON/VERDICT table. Depends only on `kirra-wire-client`.

## Verification

`cargo tree` (both crates) → **bincode + serde only** (no tokio/r2r/ROS/axum/rusqlite/reqwest/hyper/parent-crate). `cargo build`/`cargo test` clean — wire-client drift tests: **5 passed**.

End-to-end against a live `kirra-governor-service` (`6/6` answered) — the observed table:

```
CASE                 | REASON                     | VERDICT
------------------------------------------------------------------------------
nominal accept       | ACCEPT                     | Allow
over-speed clamp     | CLAMP_LINEAR               | ClampLinear(35.000 m/s)
reverse over-speed   | CLAMP_LINEAR               | ClampLinear(-35.000 m/s)
hard steering step   | CLAMP_STEER                | ClampSteering(4.500 deg)
NaN deny             | NanInfLinearVelocity       | DenyBreach (reason_code=1)
zero-dt deny         | InvalidTimeDelta           | DenyBreach (reason_code=6)
```

The deny rows decoded to the **correct mirror variants** (`NanInfLinearVelocity`→1, `InvalidTimeDelta`→6) over the real wire — i.e. the governor encoded with the *core* types and the client mirror decoded the right semantics, which is the actual cross-crate drift check.

## Guardrails
- `src/gateway/kinematics_contract.rs` **unchanged** — not edited, not in the diff. Blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b` verified start and end.
- No `git add -A`; staged only `Cargo.toml` (workspace members) + the two new crates.

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_