### PR TITLE
feat(parko-onnx): fail-closed CUDA execution provider (CPU | CUDA selectable)

### DIFF
--- a/parko/crates/parko-core/src/backend.rs
+++ b/parko/crates/parko-core/src/backend.rs
@@ -89,6 +89,9 @@ pub struct TensorBatch<'a> {
 #[derive(Debug, Clone, PartialEq)]
 pub enum BackendDescriptor {
     Cpu,
+    /// NVIDIA GPU via the ONNX Runtime **CUDA** execution provider
+    /// (parko-onnx `OrtBackend::new_cuda`, behind the `cuda` feature).
+    Cuda,
     TensorRT,
     QualcommQnn,
     TiTidl,

--- a/parko/crates/parko-core/src/scheduler.rs
+++ b/parko/crates/parko-core/src/scheduler.rs
@@ -65,6 +65,7 @@ fn capabilities_precision(caps: &BackendCapabilities) -> PrecisionMode {
 fn descriptor_vendor(d: &BackendDescriptor) -> &'static str {
     match d {
         BackendDescriptor::Cpu => "ort-cpu",
+        BackendDescriptor::Cuda => "cuda",
         BackendDescriptor::TensorRT => "tensorrt",
         BackendDescriptor::QualcommQnn => "qnn",
         BackendDescriptor::TiTidl => "ti-tidl",

--- a/parko/crates/parko-onnx/Cargo.toml
+++ b/parko/crates/parko-onnx/Cargo.toml
@@ -5,6 +5,16 @@ edition = "2021"
 description = "ONNX Runtime backend for parko-core via ort"
 license = "Apache-2.0"
 
+[features]
+# CUDA execution provider (NVIDIA GPU). Enables ort's `cuda` feature, which
+# compiles in the CUDA EP bindings. The DEFAULT build is CPU-only and pulls NO
+# CUDA libraries: `ort/cuda` -> `ort-sys/cuda` is an empty marker feature, and
+# `load-dynamic` (always on) sets `ort-sys/disable-linking`, so nothing CUDA is
+# LINKED at build time — `cargo build --features cuda` compiles with no CUDA/GPU
+# present. Real CUDA inference needs a CUDA-enabled ONNX Runtime + GPU at RUNTIME
+# (the gated tests run only in a dedicated GPU CI job — see tests/, #144 pattern).
+cuda = ["ort/cuda"]
+
 [dependencies]
 parko-core = { path = "../parko-core" }
 # ort 2.0.0-rc.11 (ONNX Runtime 1.23.2, ORT_API_VERSION = 23). Downgraded

--- a/parko/crates/parko-onnx/src/lib.rs
+++ b/parko/crates/parko-onnx/src/lib.rs
@@ -4,8 +4,8 @@ use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
 
 use parko_core::backend::{
-    BackendCapabilities, BackendError, InferenceBackend, InferenceThreads, ModelHandle,
-    TensorBatch,
+    BackendCapabilities, BackendDescriptor, BackendError, InferenceBackend, InferenceThreads,
+    ModelHandle, TensorBatch,
 };
 
 pub mod session_core;
@@ -13,6 +13,11 @@ use session_core::OrtRunCore;
 
 pub struct OrtBackend {
     core: OrtRunCore,
+    /// Which execution provider this instance actually runs on. Set per
+    /// constructor: `Cpu` for `new`/`with_threads`, `Cuda` for a successful
+    /// `new_cuda`/`with_cuda_config`, and honestly back to `Cpu` for the opt-in
+    /// CUDA→CPU degraded fallback. Returned by [`InferenceBackend::descriptor`].
+    descriptor: BackendDescriptor,
 }
 
 impl OrtBackend {
@@ -54,6 +59,7 @@ impl OrtBackend {
         // shared core single-sources the load_model/run logic.
         Ok(Self {
             core: OrtRunCore::new(session, "ort_native_cpu"),
+            descriptor: BackendDescriptor::Cpu,
         })
     }
 }
@@ -69,12 +75,147 @@ impl InferenceBackend for OrtBackend {
         self.core.run(model, inputs)
     }
 
+    fn descriptor(&self) -> BackendDescriptor {
+        self.descriptor.clone()
+    }
+
     fn capabilities(&self) -> BackendCapabilities {
-        // CPU ONNX Runtime baseline — update when quantized models are tested (PARK-009, ADL-007)
+        // CPU ONNX Runtime baseline — update when quantized models are tested (PARK-009, ADL-007).
+        // TODO(cuda): the CUDA EP enables FP16/INT8 inference; revisit
+        // supports_fp16 / supports_int8 for the `new_cuda` path once measured on
+        // GPU hardware. Conservatively reported false (full-precision posture)
+        // until validated, so this stays correct for both EPs today.
         BackendCapabilities {
             supports_int8: false,
             supports_fp16: false,
             max_batch_size: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CUDA execution provider (NVIDIA GPU) — behind the `cuda` feature
+// ---------------------------------------------------------------------------
+//
+// Mirrors the CPU constructor but builds the session on ort's CUDA EP, then
+// hands it to the SAME `OrtRunCore` (load_model/run is single-sourced — no
+// duplication). The CPU constructor and its "ort_native_cpu" identity are
+// untouched.
+//
+// FAIL-CLOSED (the load-bearing safety property): the CUDA EP is registered with
+// `.error_on_failure()`. ort's default is to SILENTLY fall back to CPU when an
+// EP can't register — exactly the silent-degradation hazard a safety path must
+// reject. With `error_on_failure`, a missing GPU/driver/CUDA-provider lib makes
+// construction return `BackendError::InitializationError` — never a quiet CPU
+// run. An explicit, WARN-logged CPU fallback is available only by opt-in
+// (`CudaConfig::allow_cpu_fallback`, default false).
+//
+// DETERMINISM HONESTY: GPU CUDA is not bitwise-reproducible the way single-thread
+// CPU is, so this path does NOT read `InferenceThreads` (a CPU concept).
+
+#[cfg(feature = "cuda")]
+use ort::ep::CUDA;
+
+/// Configuration for [`OrtBackend::with_cuda_config`].
+#[cfg(feature = "cuda")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CudaConfig {
+    /// CUDA device ordinal (0 = first GPU).
+    pub device_id: i32,
+    /// EP-init-failure policy. **Fail-closed by default (`false`)**: a CUDA-EP
+    /// registration failure returns `Err` with no CPU fallback. Set `true` to
+    /// opt into an explicit, `tracing::WARN`-logged degrade-to-CPU.
+    pub allow_cpu_fallback: bool,
+}
+
+#[cfg(feature = "cuda")]
+impl Default for CudaConfig {
+    fn default() -> Self {
+        // Device 0, FAIL-CLOSED (no silent CPU fallback).
+        Self { device_id: 0, allow_cpu_fallback: false }
+    }
+}
+
+/// Build a session on the CUDA EP, registered `error_on_failure` (fail-closed).
+/// Returns `Err` if the EP cannot register against the dlopened ORT runtime
+/// (no GPU / driver / CUDA provider) — never a silent CPU run.
+#[cfg(feature = "cuda")]
+fn build_cuda_session(model_path: &str, cfg: &CudaConfig) -> Result<Session, BackendError> {
+    let cuda_ep = CUDA::default()
+        .with_device_id(cfg.device_id)
+        .build()
+        .error_on_failure();
+
+    Session::builder()
+        .map_err(|e| BackendError::InitializationError(format!("ort builder error: {e:?}")))?
+        .with_execution_providers([cuda_ep])
+        .map_err(|e| BackendError::InitializationError(format!(
+            "CUDA EP registration failed (fail-closed; no silent CPU fallback). The dlopened \
+             ONNX Runtime lacks a usable CUDA provider, or no GPU/driver is present: {e:?}"
+        )))?
+        .commit_from_file(model_path)
+        .map_err(|e| BackendError::InitializationError(format!("ort session init error: {e:?}")))
+}
+
+#[cfg(feature = "cuda")]
+impl OrtBackend {
+    /// Construct a CUDA (NVIDIA GPU) backend with the default config — device 0,
+    /// **fail-closed** (no CPU fallback). Mirrors [`OrtBackend::new`] for the
+    /// CPU path. Requires a CUDA-enabled ONNX Runtime + GPU at runtime.
+    pub fn new_cuda(model_path: &str) -> Result<Self, BackendError> {
+        Self::with_cuda_config(model_path, &CudaConfig::default())
+    }
+
+    /// Construct a CUDA backend with an explicit [`CudaConfig`]. On a successful
+    /// CUDA-EP registration: descriptor `Cuda`, model_id prefix `"ort_cuda"`. On
+    /// failure: fail-closed `Err` by default, or — if `cfg.allow_cpu_fallback` —
+    /// a `tracing::WARN` "CUDA EP unavailable, degraded to CPU" and a plain CPU
+    /// session (descriptor honestly `Cpu`, model_id `"ort_cuda_degraded_cpu"` so
+    /// audit distinguishes a degraded run from the real CPU backend).
+    pub fn with_cuda_config(model_path: &str, cfg: &CudaConfig) -> Result<Self, BackendError> {
+        match build_cuda_session(model_path, cfg) {
+            Ok(session) => {
+                tracing::info!(
+                    backend = "ort_cuda",
+                    device_id = cfg.device_id,
+                    execution_provider = "CUDA",
+                    bitwise_reproducible = false,
+                    "OrtBackend CUDA execution posture (NVIDIA GPU EP; not bitwise-reproducible)"
+                );
+                Ok(Self {
+                    core: OrtRunCore::new(session, "ort_cuda"),
+                    descriptor: BackendDescriptor::Cuda,
+                })
+            }
+            Err(e) => {
+                if !cfg.allow_cpu_fallback {
+                    // Default, safety posture: fail-closed.
+                    return Err(e);
+                }
+                // Opt-in degraded path. Surfaced loudly; honestly reports CPU.
+                tracing::warn!(
+                    backend = "ort_cuda",
+                    device_id = cfg.device_id,
+                    cause = %format!("{e:?}"),
+                    "CUDA EP unavailable, degraded to CPU"
+                );
+                // A plain CPU session (mirrors the CPU constructor's build; the
+                // CPU constructor itself is left untouched). Distinct model_id so
+                // a degraded-CUDA run is never mistaken for the native CPU backend.
+                let threads = InferenceThreads::default();
+                let session = Session::builder()
+                    .map_err(|e| BackendError::InitializationError(format!("ort builder error: {e:?}")))?
+                    .with_intra_threads(threads.num_threads)
+                    .map_err(|e| BackendError::InitializationError(format!("ort intra_threads error: {e:?}")))?
+                    .with_optimization_level(GraphOptimizationLevel::Disable)
+                    .map_err(|e| BackendError::InitializationError(format!("ort opt_level error: {e:?}")))?
+                    .commit_from_file(model_path)
+                    .map_err(|e| BackendError::InitializationError(format!("ort session init error: {e:?}")))?;
+                Ok(Self {
+                    core: OrtRunCore::new(session, "ort_cuda_degraded_cpu"),
+                    descriptor: BackendDescriptor::Cpu,
+                })
+            }
         }
     }
 }

--- a/parko/crates/parko-onnx/tests/test_onnx_backend.rs
+++ b/parko/crates/parko-onnx/tests/test_onnx_backend.rs
@@ -83,3 +83,86 @@ fn test_ort_backend_capabilities() {
         "capabilities must match documented CPU ONNX baseline"
     );
 }
+
+// ---------------------------------------------------------------------------
+// CUDA execution provider tests — behind the `cuda` feature
+// ---------------------------------------------------------------------------
+//
+// These are NOT run by the default CI (it does not pass `--features cuda`). They
+// run in a dedicated GPU CI job (`cargo test -p parko-onnx --features cuda` on
+// NVIDIA silicon with a CUDA-enabled ONNX Runtime) — same gating spirit as the
+// ORT-dylib / TensorRT GPU gating (#144). The cross-check self-skips (does not
+// fail) when no CUDA provider/GPU is present, so `--features cuda` on a non-GPU
+// box is clean.
+
+#[cfg(feature = "cuda")]
+mod cuda_ep {
+    use super::*;
+    use parko_onnx::CudaConfig;
+
+    /// GPU-FREE: the default CUDA config is fail-closed (no silent CPU fallback),
+    /// device 0. Runs anywhere `--features cuda` builds — constructs no session.
+    #[test]
+    fn cuda_config_default_is_fail_closed() {
+        let cfg = CudaConfig::default();
+        assert!(!cfg.allow_cpu_fallback,
+            "CUDA must default to fail-closed — no silent CPU fallback");
+        assert_eq!(cfg.device_id, 0, "default CUDA device is 0");
+    }
+
+    /// GPU-GATED: a constructed CUDA backend reports the `Cuda` descriptor and
+    /// its MNIST output matches the CPU backend within tolerance. Self-skips
+    /// (no failure) when CUDA is unavailable — `new_cuda` fail-closes there.
+    #[test]
+    fn cuda_descriptor_and_mnist_matches_cpu() {
+        let model_path = "tests/data/mnist-12.onnx";
+
+        // Construct the CUDA backend fail-closed. If CUDA isn't available
+        // (no GPU / driver / CUDA-enabled ORT lib) this returns Err — skip.
+        let cuda = match OrtBackend::new_cuda(model_path) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("SKIP: CUDA EP unavailable (no GPU / CUDA ORT provider) — {e:?}. \
+                           This test runs only in the GPU CI job.");
+                return;
+            }
+        };
+        assert_eq!(cuda.descriptor(), BackendDescriptor::Cuda,
+            "the CUDA backend must report the Cuda descriptor");
+
+        let cpu = OrtBackend::new(model_path).expect("CPU backend");
+
+        // Same MNIST input through both EPs.
+        let model_cpu = cpu.load_model(model_path).expect("cpu load");
+        let model_cuda = cuda.load_model(model_path).expect("cuda load");
+
+        let input_name = "Input3";
+        let output_name = "Plus214_Output_0";
+        let total: usize = model_cpu.input_shapes.get(input_name).unwrap().iter().product();
+        let img = vec![0.0f32; total];
+
+        let batch = |img: &'static [f32]| {
+            let mut m = HashMap::new();
+            m.insert(input_name.to_string(), TensorStorage::Borrowed(img));
+            TensorBatch { named_tensors: m, metadata: HashMap::new() }
+        };
+        // Leak a stable slice for the 'static Borrowed lifetime (test-only).
+        let img: &'static [f32] = Box::leak(img.into_boxed_slice());
+
+        let out_cpu = cpu.run(&model_cpu, &batch(img)).expect("cpu run");
+        let out_cuda = cuda.run(&model_cuda, &batch(img)).expect("cuda run");
+
+        let a = out_cpu.named_tensors.get(output_name).unwrap().as_slice();
+        let b = out_cuda.named_tensors.get(output_name).unwrap().as_slice();
+        assert_eq!(a.len(), b.len(), "output length must match across EPs");
+
+        // GPU vs CPU is NOT bitwise identical — compare within tolerance.
+        const TOL: f32 = 1e-3;
+        for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+            assert!(y.is_finite(), "non-finite CUDA score at {i}: {y}");
+            assert!((x - y).abs() <= TOL,
+                "CUDA vs CPU mismatch at class {i}: cpu={x}, cuda={y}, |Δ|>{TOL}");
+        }
+        println!("CUDA matches CPU within {TOL}. cpu={a:?} cuda={b:?}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **CUDA execution provider** to `parko-onnx` so the ONNX Runtime backend runs on **CPU (existing) or NVIDIA GPU via CUDA, selectable and fail-closed**. Reuses `OrtRunCore` verbatim — no load/run duplication. parko-side only; the main-crate verdict path is untouched.

## Feature & dep (Step 1)
- New `cuda` feature on `parko-onnx` → `["ort/cuda"]`. `ort` stays pinned at **`=2.0.0-rc.11`** (the rc.12 deadlock note still applies).
- **Default build is CPU-only and links no CUDA**: `ort/cuda → ort-sys/cuda` is an empty marker feature, and `load-dynamic` (always on) sets `ort-sys/disable-linking`, so `cargo build --features cuda` compiles with **no GPU/CUDA libs present**. Verified.

## CUDA path (Step 2) — mirrors the CPU path, reuses `OrtRunCore`
- `OrtBackend::new_cuda(model_path)` / `with_cuda_config(model_path, &CudaConfig{ device_id, allow_cpu_fallback })` build the session on `ort::ep::CUDA` and hand it to the same `OrtRunCore` with model_id prefix **`"ort_cuda"`**.
- **Fail-closed by default**: the CUDA EP is registered `.error_on_failure()` — a missing GPU/driver/provider returns `BackendError::InitializationError` (no silent CPU fallback), exactly like `parko-tensorrt`.
- **Opt-in fallback** (`allow_cpu_fallback`, default `false`): on EP failure, logs `tracing::WARN "CUDA EP unavailable, degraded to CPU"` and builds a plain CPU session — distinct model_id `"ort_cuda_degraded_cpu"`, descriptor honestly `Cpu`.
- **CPU constructor + `"ort_native_cpu"` identity untouched.**
- `BackendDescriptor` gains a `Cuda` variant (parko-core; `#[non_exhaustive]` → non-breaking; the `descriptor_vendor` match arm added). `descriptor()` now returns the per-instance EP. `capabilities()` left at the conservative baseline with a `TODO(cuda)` to revisit fp16/int8 once GPU-measured.

## Tests (Step 3)
- **GPU-free** `cuda_config_default_is_fail_closed` — runs in any `--features cuda` build (constructs no session). **Passes.**
- **GPU-gated** `cuda_descriptor_and_mnist_matches_cpu` — descriptor reports `Cuda`, MNIST CUDA output matches CPU within `1e-3`. Self-skips (no failure) when no GPU/CUDA-ORT is present; runs only in the dedicated GPU CI job (`--features cuda` on NVIDIA silicon) — same gating spirit as #144. Compiles cleanly.

## Verification (Step 4)
- `cargo build -p parko-onnx` (default) and `--features cuda` both compile — no CUDA libs needed.
- Root `kirra-runtime-sdk` builds (parko-core variant addition is non-breaking).
- Tests compile default + cuda; the GPU-free config test is green.
- `cargo tree`: ort's `cuda` feature appears **only** under `--features cuda`.

**Descriptor output:** CPU path → `BackendDescriptor::Cpu` (model_id `ort_native_cpu`); CUDA path → `BackendDescriptor::Cuda` (model_id `ort_cuda`); opt-in degraded → `BackendDescriptor::Cpu` (model_id `ort_cuda_degraded_cpu`).

> Note: the default `cargo test -p parko-onnx` (CPU) and the GPU-gated test need the ONNX Runtime dylib (and a GPU for CUDA) at runtime — absent in this sandbox, so they're verified by compilation here and run in the ORT/GPU CI jobs. Same constraint as #144.

## Guardrails
- `src/gateway/kinematics_contract.rs` unchanged — blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b` (verified start and end), not in the diff.
- No `git add -A`; staged only the 5 parko-side files.

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_