### PR TITLE
feat(fabric): record cross-asset trust propagation to causal log (SG-007)

### DIFF
--- a/docs/safety/REQUIREMENTS_TRACEABILITY.md
+++ b/docs/safety/REQUIREMENTS_TRACEABILITY.md
@@ -86,7 +86,7 @@ Traceability flows in both directions:
 |-------|-----------------------|----------------|---------|
 | TR-007 | `propagate_cross_asset_trust` shall set the posture of all follower assets registered to a leader asset to `Degraded` when the leader asset's posture is `LockedOut` | `src/fabric/router.rs:propagate_cross_asset_trust` (Rule 1) | `test_convoy_leader_lockout_degrades_followers` ✗ |
 | TR-007a | `propagate_cross_asset_trust` shall set follower asset postures to `Degraded` when the leader asset posture is `Degraded` and all followers are currently `Nominal` | `src/fabric/router.rs:propagate_cross_asset_trust` (Rule 2) | `test_convoy_leader_degraded_degrades_nominal_followers` ✗ |
-| TR-007b | The fabric causal log (`src/fabric/causal_log.rs`) shall record every cross-asset trust propagation event with a causal timestamp | `src/fabric/causal_log.rs` | `test_causal_log_records_propagation_event` ✗ |
+| TR-007b | The fabric causal log (`src/fabric/causal_log.rs`) shall record every cross-asset trust propagation event with a causal timestamp | `src/fabric/router.rs::propagate_and_record` → `src/fabric/causal_log.rs::record` | `tests/cert_003_rtm_gap_stubs.rs::test_safety_goal_sg_007_causal_log_records_propagation_event` ✓. *Conscious deferral:* fan-in rules record a single deterministic representative trigger (lexicographically-smallest LockedOut source) — the degrade decision is unchanged; multi-trigger fan-out (one event per trigger→follower, or all sources in `caused_by`) is the eventual refinement for multi-source-lockout forensic completeness. |
 
 ---
 

--- a/docs/safety/RTM_GAP_REPORT.md
+++ b/docs/safety/RTM_GAP_REPORT.md
@@ -38,13 +38,14 @@ test evidence:
 | Goal | ASIL | Status after this increment | Tests (actual fn names / locations) |
 |---|---|---|---|
 | SG-003 | D | **CLOSED** | `src/telemetry_watchdog.rs` mod `sg_003_cert_tests`: `test_watchdog_marks_node_untrusted_after_timeout`, `test_watchdog_detection_latency_within_bound`, `test_watchdog_triggers_posture_recalculation` (RTM-named; in-crate because `watchdog_sweep_once` is `pub(crate)`) |
-| SG-007 | D | **propagation CLOSED**; causal-log sub-gap OPEN | `tests/fault_injection.rs::test_safety_goal_sg_007_cross_asset_lockout_propagation` (leader LockedOut → followers Degraded in one synchronous fabric pass, + precondition cross-check). The RTM-named `test_causal_log_records_propagation_event` remains OPEN: `FabricRouter::propagate_cross_asset_trust` does not record to any causal log — closing it needs propagation→causal-log wiring (a mechanism change), kept as an explicit stub. |
+| SG-007 | D | **CLOSED** (propagation + causal-log) | `tests/fault_injection.rs::test_safety_goal_sg_007_cross_asset_lockout_propagation` (leader LockedOut → followers Degraded in one synchronous fabric pass, + precondition cross-check) AND `tests/cert_003_rtm_gap_stubs.rs::test_safety_goal_sg_007_causal_log_records_propagation_event` (the causal-log sub-gap, now closed): `FabricRouter::propagate_and_record` records a `cross_asset_trust_degrade` event per rule-firing to the `FabricCausalLog` while the propagation decisions stay byte-identical to `propagate_cross_asset_trust`. **Conscious deferral:** fan-in rules (an "any LockedOut source of type X degrades dependents" rule — drone↔ground-station, infrastructure) record a single *deterministic representative* trigger (the lexicographically-smallest LockedOut source); the degrade *decision* is unchanged. Multi-trigger fan-out (one event per trigger→follower, or all sources in `caused_by`) is the eventual refinement for forensic completeness on multi-source lockouts — not yet required. The convoy and warehouse rules already attribute the exact trigger. |
 | SG-008 | D | **CLOSED** | `src/bin/kirra_verifier_service.rs`: pure `check_startup_invariants` predicate + mod `sg_008_cert_tests` (admin-token / WAL / watchdog / posture-engine violations, all-present Ok, Active-vs-PassiveStandby distinction, check-order stability). `main` evaluates it immediately before `TcpListener::bind` and aborts on `Err` (fail-closed; bind never reached on violation). |
 
 Resulting goal-level coverage: **11 / 16 (68.75%)**. Every **ASIL-D** goal
 (SG-001, SG-002, SG-003, SG-005, SG-006, SG-007, SG-008) now has at least one
 real test. The remaining zero-coverage goals are all ASIL-B/C — **SG-009,
-SG-010, SG-012, SG-013, SG-015** — plus the SG-007 causal-log sub-gap noted above.
+SG-010, SG-012, SG-013, SG-015**. (The SG-007 causal-log sub-gap noted above is
+now CLOSED — see the SG-007 row.)
 
 Code-side traceability: `grep -rn "SG-0" src/` now returns **68** hits
 (mechanisms carry `// Verifies: SG-NNN` tags), up from ~0 in the canonical form.

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -1489,7 +1489,10 @@ async fn handle_list_fabric_assets(
 async fn handle_fabric_state(
     State(svc): State<Arc<ServiceState>>,
 ) -> impl IntoResponse {
-    let changes = svc.fabric_router.propagate_cross_asset_trust();
+    // SG-007: propagate AND record each rule-firing to the causal log (decisions
+    // unchanged). Use the current fabric generation for the recorded events.
+    let fabric_generation = svc.fabric_router.fabric_state().fabric_generation;
+    let changes = svc.fabric_router.propagate_and_record(&svc.fabric_causal_log, fabric_generation);
     for (asset_id, new_posture) in changes {
         let gen = svc.fabric_router.fabric_state().fabric_generation + 1;
         svc.fabric_router.update_asset_posture(&asset_id, AssetPosture {

--- a/src/fabric/router.rs
+++ b/src/fabric/router.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use dashmap::DashMap;
 use crate::fabric::asset::{AssetPosture, AssetType, FabricAsset, FabricState};
 use crate::fabric::governor::AssetGovernor;
+use crate::fabric::causal_log::FabricCausalLog;
 use crate::gateway::kinematics_contract::{EnforceAction, ProposedVehicleCommand};
 use crate::verifier::FleetPosture;
 use crate::posture_cache::now_ms;
@@ -19,6 +20,28 @@ impl std::fmt::Display for FabricError {
             Self::AssetNotFound(id) => write!(f, "Asset not found: {id}"),
             Self::GovernorError(msg) => write!(f, "Governor error: {msg}"),
             Self::PostureUnavailable(id) => write!(f, "Posture unavailable for: {id}"),
+        }
+    }
+}
+
+/// One trigger-tagged cross-asset trust propagation (SG-007): the LockedOut
+/// `trigger_asset` degraded `follower` to `new_posture`. Internal — the public
+/// `propagate_cross_asset_trust` exposes only `(follower, new_posture)`; the
+/// trigger tag is what lets `propagate_and_record` attribute the causal event.
+struct TrustPropagation {
+    trigger_asset: String,
+    follower: String,
+    new_posture: FleetPosture,
+}
+
+impl TrustPropagation {
+    /// A follower degraded to `Degraded` by a LockedOut trigger (the only
+    /// transition the propagation rules produce).
+    fn degrade(trigger: &str, follower: &str) -> Self {
+        Self {
+            trigger_asset: trigger.to_string(),
+            follower: follower.to_string(),
+            new_posture: FleetPosture::Degraded,
         }
     }
 }
@@ -177,11 +200,82 @@ impl FabricRouter {
     /// Cross-asset trust propagation rules.
     /// Returns a list of (asset_id, forced_posture) pairs to apply.
     ///
+    /// Thin map over [`FabricRouter::evaluate_cross_asset_trust`] — the returned
+    /// `(follower, posture)` pairs (and their order) are byte-identical to the
+    /// pre-SG-007-recording behavior. The richer trigger-tagged result is used
+    /// only by [`FabricRouter::propagate_and_record`] for causal-log recording.
+    ///
     // Verifies: SG-007 — a LockedOut leader degrades dependent followers within
     // one synchronous fabric pass (tests/fault_injection.rs
     // test_safety_goal_sg_007_cross_asset_lockout_propagation).
     pub fn propagate_cross_asset_trust(&self) -> Vec<(String, FleetPosture)> {
-        let mut changes: Vec<(String, FleetPosture)> = Vec::new();
+        self.evaluate_cross_asset_trust()
+            .into_iter()
+            .map(|p| (p.follower, p.new_posture))
+            .collect()
+    }
+
+    /// Cross-asset trust propagation + causal-log recording (SG-007).
+    ///
+    /// Runs the SAME evaluation as [`FabricRouter::propagate_cross_asset_trust`]
+    /// (the propagation DECISIONS are unchanged) and additionally records one
+    /// causal event per rule-firing (per LockedOut trigger asset) into `log`,
+    /// tagging the followers it degraded as `affects_assets`. Returns the same
+    /// flat `(follower, posture)` Vec the public fn returns.
+    ///
+    // Verifies: SG-007 (causal-log sub-gap) — propagation events are recorded to
+    // the FabricCausalLog, not just applied.
+    pub fn propagate_and_record(
+        &self,
+        log: &FabricCausalLog,
+        fabric_generation: u64,
+    ) -> Vec<(String, FleetPosture)> {
+        let propagations = self.evaluate_cross_asset_trust();
+
+        // Group followers by their triggering LockedOut asset, preserving
+        // first-seen trigger order (one causal event per rule-firing/trigger).
+        let mut grouped: Vec<(String, Vec<String>)> = Vec::new();
+        for p in &propagations {
+            if let Some(entry) = grouped.iter_mut().find(|(t, _)| *t == p.trigger_asset) {
+                entry.1.push(p.follower.clone());
+            } else {
+                grouped.push((p.trigger_asset.clone(), vec![p.follower.clone()]));
+            }
+        }
+        for (trigger, followers) in &grouped {
+            let payload = format!(
+                "LockedOut asset '{trigger}' degraded {} dependent follower(s) to Degraded \
+                 (SG-007 cross-asset trust propagation)",
+                followers.len()
+            );
+            // caused_by empty (the lockout is the root cause); affects_assets =
+            // the followers this trigger degraded. Mirrors the record(...) usage
+            // in kirra_verifier_service.rs.
+            log.record(
+                trigger,
+                "cross_asset_trust_degrade",
+                &payload,
+                vec![],
+                followers.clone(),
+                fabric_generation,
+            );
+        }
+
+        propagations
+            .into_iter()
+            .map(|p| (p.follower, p.new_posture))
+            .collect()
+    }
+
+    /// Internal: evaluate the 4 cross-asset trust rules into trigger-tagged
+    /// propagations (one entry per degraded follower, tagged with the LockedOut
+    /// asset that triggered it). Single source of truth for both
+    /// `propagate_cross_asset_trust` (decision only) and `propagate_and_record`
+    /// (decision + causal-log recording). The rule conditions and the set/order
+    /// of degraded followers are identical to the original inline logic; the
+    /// only addition is capturing the trigger asset id per firing.
+    fn evaluate_cross_asset_trust(&self) -> Vec<TrustPropagation> {
+        let mut out: Vec<TrustPropagation> = Vec::new();
 
         // Collect current postures and asset metadata
         let all_assets: Vec<(String, AssetType, AssetPosture, std::collections::HashMap<String, String>)> =
@@ -195,48 +289,55 @@ impl FabricRouter {
                 ))
             }).collect();
 
-        // Rule 1: Drone depends on ground control station (IndustrialController)
-        let ground_stations_locked: bool = all_assets.iter().any(|(_, at, ap, _)|
-            *at == AssetType::IndustrialController && ap.posture == FleetPosture::LockedOut
-        );
-        if ground_stations_locked {
+        // Rule 1: Drone depends on ground control station (IndustrialController).
+        // Trigger = a LockedOut ground station (deterministic representative: the
+        // lexicographically-smallest locked id). `Some` iff the original `any`.
+        let locked_ground = all_assets.iter()
+            .filter(|(_, at, ap, _)| *at == AssetType::IndustrialController && ap.posture == FleetPosture::LockedOut)
+            .map(|(id, _, _, _)| id.clone())
+            .min();
+        if let Some(trigger) = locked_ground {
             for (id, at, ap, _) in &all_assets {
                 if *at == AssetType::Drone && ap.posture == FleetPosture::Nominal {
-                    changes.push((id.clone(), FleetPosture::Degraded));
+                    out.push(TrustPropagation::degrade(&trigger, id));
                 }
             }
         }
 
-        // Rule 2: Convoy follower degrades when leader is LockedOut
-        let leader_locked: bool = all_assets.iter().any(|(_, _, ap, meta)|
-            meta.get("convoy_role").map(|r| r == "leader").unwrap_or(false)
-                && ap.posture == FleetPosture::LockedOut
-        );
-        if leader_locked {
+        // Rule 2: Convoy follower degrades when leader is LockedOut.
+        let locked_leader = all_assets.iter()
+            .filter(|(_, _, ap, meta)|
+                meta.get("convoy_role").map(|r| r == "leader").unwrap_or(false)
+                    && ap.posture == FleetPosture::LockedOut)
+            .map(|(id, _, _, _)| id.clone())
+            .min();
+        if let Some(trigger) = locked_leader {
             for (id, _, ap, meta) in &all_assets {
                 if meta.get("convoy_role").map(|r| r == "follower").unwrap_or(false)
                     && ap.posture == FleetPosture::Nominal
                 {
-                    changes.push((id.clone(), FleetPosture::Degraded));
+                    out.push(TrustPropagation::degrade(&trigger, id));
                 }
             }
         }
 
-        // Rule 3: Infrastructure lockout degrades dependents
-        let infra_locked: bool = all_assets.iter().any(|(_, at, ap, _)|
-            *at == AssetType::Infrastructure && ap.posture == FleetPosture::LockedOut
-        );
-        if infra_locked {
+        // Rule 3: Infrastructure lockout degrades dependents.
+        let locked_infra = all_assets.iter()
+            .filter(|(_, at, ap, _)| *at == AssetType::Infrastructure && ap.posture == FleetPosture::LockedOut)
+            .map(|(id, _, _, _)| id.clone())
+            .min();
+        if let Some(trigger) = locked_infra {
             for (id, _, ap, meta) in &all_assets {
                 if meta.get("depends_on_infrastructure").map(|v| v == "true").unwrap_or(false)
                     && ap.posture == FleetPosture::Nominal
                 {
-                    changes.push((id.clone(), FleetPosture::Degraded));
+                    out.push(TrustPropagation::degrade(&trigger, id));
                 }
             }
         }
 
-        // Rule 4: Warehouse lockout degrades all registered robots
+        // Rule 4: Warehouse lockout degrades registered robots in that warehouse.
+        // Trigger is per-follower (the robot's own locked warehouse).
         let locked_warehouses: Vec<String> = all_assets.iter()
             .filter(|(_, at, ap, _)| *at == AssetType::Warehouse && ap.posture == FleetPosture::LockedOut)
             .map(|(id, _, _, _)| id.clone())
@@ -245,14 +346,14 @@ impl FabricRouter {
             for (id, at, ap, meta) in &all_assets {
                 if *at == AssetType::Robot && ap.posture == FleetPosture::Nominal {
                     let robot_warehouse = meta.get("warehouse_id").map(|s| s.as_str()).unwrap_or("");
-                    if locked_warehouses.iter().any(|w| w == robot_warehouse) {
-                        changes.push((id.clone(), FleetPosture::Degraded));
+                    if let Some(w) = locked_warehouses.iter().find(|w| w.as_str() == robot_warehouse) {
+                        out.push(TrustPropagation::degrade(w, id));
                     }
                 }
             }
         }
 
-        changes
+        out
     }
 
     pub fn asset_count(&self) -> usize {

--- a/tests/cert_003_rtm_gap_stubs.rs
+++ b/tests/cert_003_rtm_gap_stubs.rs
@@ -28,22 +28,77 @@ fn test_safety_goal_sg_006_unknown_command_denial() {
     // See tests/fault_injection.rs for full implementation (CERT-004).
 }
 
-// SG-007 — Cross-Asset Fleet Lockout Propagation (ASIL D): the propagation
-// SAFETY PROPERTY (leader LockedOut → all Nominal followers Degraded within one
-// synchronous fabric pass) is IMPLEMENTED in tests/fault_injection.rs
-// (test_safety_goal_sg_007_cross_asset_lockout_propagation); the mechanism
-// (FabricRouter::propagate_cross_asset_trust) carries a `// Verifies: SG-007` tag.
-//
-// REMAINING SUB-GAP — the RTM also names a causal-log assertion, but
-// propagate_cross_asset_trust does NOT record propagation events to any causal
-// log (FabricCausalLog lives on ServiceState and is not wired into the router).
-// Satisfying it requires adding audit/causal-log wiring to the propagation
-// mechanism (a code change, not just a test). Kept as an explicit ignored stub
-// so the gap stays visible and honest.
+// SG-007 — Cross-Asset Fleet Lockout Propagation (ASIL D): CLOSED.
+// The propagation SAFETY PROPERTY (leader LockedOut → all Nominal followers
+// Degraded within one synchronous fabric pass) is in tests/fault_injection.rs
+// (test_safety_goal_sg_007_cross_asset_lockout_propagation). The previously-open
+// causal-log sub-gap is now closed: FabricRouter::propagate_and_record records a
+// `cross_asset_trust_degrade` event per rule-firing into the FabricCausalLog
+// (the propagation DECISIONS are byte-identical to propagate_cross_asset_trust).
+// The test below asserts BOTH the decision and the recorded causal event.
 #[test]
-#[ignore = "TODO(CERT-003): SG-007 propagation→causal-log recording not yet wired (see note above)"]
 fn test_safety_goal_sg_007_causal_log_records_propagation_event() {
-    todo!("wire propagate_cross_asset_trust to FabricCausalLog, then assert the leader→follower event")
+    use std::collections::HashMap;
+    use kirra_runtime_sdk::fabric::router::FabricRouter;
+    use kirra_runtime_sdk::fabric::causal_log::FabricCausalLog;
+    use kirra_runtime_sdk::fabric::asset::{AssetPosture, AssetType, FabricAsset, KinematicProfileType};
+    use kirra_runtime_sdk::verifier::FleetPosture;
+
+    fn convoy_av(id: &str, role: &str) -> FabricAsset {
+        let mut metadata = HashMap::new();
+        metadata.insert("convoy_role".to_string(), role.to_string());
+        FabricAsset {
+            asset_id: id.to_string(),
+            asset_type: AssetType::AutonomousVehicle,
+            display_name: id.to_string(),
+            kinematic_profile: KinematicProfileType::AutomotiveNominal,
+            registered_at_ms: 1000,
+            last_seen_ms: 1000,
+            metadata,
+        }
+    }
+    fn posture(id: &str, p: FleetPosture, gen: u64) -> AssetPosture {
+        AssetPosture {
+            asset_id: id.to_string(),
+            posture: p,
+            generation: gen,
+            computed_at_ms: 1000,
+            contributing_nodes: vec![],
+            blocked_by: vec![],
+        }
+    }
+
+    let router = FabricRouter::new();
+    router.register_asset(&convoy_av("leader01", "leader"));
+    router.register_asset(&convoy_av("follower01", "follower"));
+    // Registration seeds Degraded; lift the follower to Nominal so the rule has
+    // a transition to make, then lock out the leader.
+    router.update_asset_posture("follower01", posture("follower01", FleetPosture::Nominal, 1));
+    router.update_asset_posture("leader01", posture("leader01", FleetPosture::LockedOut, 2));
+
+    let log = FabricCausalLog::new(None);
+    let fabric_generation = router.fabric_state().fabric_generation;
+    let changes = router.propagate_and_record(&log, fabric_generation);
+
+    // (a) decision unchanged: the LockedOut leader degrades the Nominal follower.
+    assert!(
+        changes.iter().any(|(id, p)| id == "follower01" && *p == FleetPosture::Degraded),
+        "leader LockedOut must degrade the Nominal follower (propagation decision); changes={changes:?}"
+    );
+
+    // (b) the causal log recorded the propagation: asset_id = the LockedOut
+    // leader, affects_assets containing the degraded follower.
+    let entries = log.export(0, u64::MAX);
+    assert!(
+        entries.iter().any(|e|
+            e.asset_id == "leader01"
+            && e.event_type == "cross_asset_trust_degrade"
+            && e.affects_assets.iter().any(|a| a == "follower01")
+            && e.fabric_generation == fabric_generation
+        ),
+        "FabricCausalLog must record the leader→follower propagation event \
+         (asset_id=leader01, affects=follower01); entries={entries:?}"
+    );
 }
 
 // SG-008 — Process Fail-Closed on Startup (ASIL D): IMPLEMENTED (CERT-003).


### PR DESCRIPTION
## Summary

Closes the **SG-007 causal-log sub-gap**: cross-asset trust propagation now records to the `FabricCausalLog`, and the stub test is replaced with a real one. The propagation **decisions are byte-identical** — this only *adds* recording. Not the verdict path.

## Changes
**`src/fabric/router.rs`** (Step 1 + 2)
- Extracted the 4-rule evaluation into `evaluate_cross_asset_trust()` returning trigger-tagged `TrustPropagation { trigger_asset, follower, new_posture }` (one per degraded follower, tagged with the LockedOut asset that triggered it). For rules 1–3 the trigger is a deterministic representative (lexicographically-smallest locked source); rule 4 is per-follower (the robot's own locked warehouse). Rule conditions and the set/order of degraded followers are unchanged.
- `propagate_cross_asset_trust()` is now a **thin map** over it → identical `(follower, posture)` output/order (existing SG-007 + router tests pass unchanged).
- New `propagate_and_record(&self, log, fabric_generation)` runs the same evaluation, records **one `cross_asset_trust_degrade` causal event per rule-firing** (`asset_id` = trigger, `affects_assets` = the followers it degraded, `caused_by = []`), then returns the same flat Vec. Mirrors the `record(...)` usage in `kirra_verifier_service.rs`.

**`src/bin/kirra_verifier_service.rs`** (Step 2)
- `handle_fabric_state` now calls `propagate_and_record(&svc.fabric_causal_log, <current fabric_generation>)` so production actually records (apply-loop behavior unchanged).

**`tests/cert_003_rtm_gap_stubs.rs`** (Step 3)
- Un-ignored the SG-007 test (removed `#[ignore]` + `todo!()`) and implemented it: LockedOut convoy leader + Nominal follower + a `FabricCausalLog`; asserts **(a)** the follower is degraded (decision unchanged) **and (b)** the log (`export`) contains the event with `asset_id = leader` and `affects_assets` containing the follower. **SG-012 stub left ignored.**

## Verification (Step 4)
- Router unit tests **10/10** (behavior preserved — including the convoy/warehouse/drone propagation tests, unchanged).
- Un-ignored SG-007 test **passes**; existing `fault_injection::test_safety_goal_sg_007_cross_asset_lockout_propagation` **passes**.
- Full lib suite **524 passed / 0 failed**; bin **8 passed** (call-site edit compiles).
- `cert_003_rtm_gap_stubs`: now **2 passed / 7 ignored** (SG-007 moved ignored→passing); SG-012 still `ignored` with its mechanism-gap note.
- `src/gateway/kinematics_contract.rs` **unchanged** (blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b`, not in the diff). No `git add -A`.

**Diff stat:** `router.rs +132/-17`, `kirra_verifier_service.rs +4/-1`, `cert_003_rtm_gap_stubs.rs +71/-12` (3 files, +198 / −39).

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_