### PR TITLE
chore: drop genuinely-unused test-build imports (lints only)

### DIFF
--- a/src/audit_chain.rs
+++ b/src/audit_chain.rs
@@ -246,7 +246,7 @@ impl AuditChainLinker {
 mod audit_signing_tests {
     use super::*;
     use rusqlite::Connection;
-    use ed25519_dalek::{SigningKey, VerifyingKey, Signer, Verifier, Signature};
+    use ed25519_dalek::{SigningKey, Verifier, Signature};
 
     fn setup_db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();

--- a/src/scenario_runner.rs
+++ b/src/scenario_runner.rs
@@ -518,7 +518,6 @@ async fn evaluate_assertion(
 #[cfg(test)]
 mod scenario_runner_tests {
     use super::*;
-    use std::sync::Arc;
     use crate::posture_cache::CachedFleetPosture;
     use crate::verifier::FleetPosture;
     use crate::clock::VirtualClock;


### PR DESCRIPTION
## Summary

Trivial lint cleanup — removes two genuinely-unused imports flagged only in test builds (`cargo build --tests`). **No logic changes.**

## Changes (each verified per the wcet_gate lesson — grepped every symbol's whole-file usage under all cfgs before removing)

**`src/scenario_runner.rs:521`** — `use std::sync::Arc;` *inside* `#[cfg(test)] mod scenario_runner_tests` was redundant with the mod's `use super::*;` (line 520), which already re-exports the parent module's `Arc` (the real `use std::sync::Arc;` at line 51). Removed the duplicate; the test code resolves `Arc` via `super::*`.

**`src/audit_chain.rs:249`** — removed only the unused `Signer` and `VerifyingKey` from the `audit_signing_tests` import list; **`SigningKey`, `Verifier`, `Signature` are still used and kept**. (`Signer` appears elsewhere only as a separate local `use` at line 203; `VerifyingKey` only fully-qualified at line 73 — neither is referenced in the test mod body.)

## Verification
- `cargo build --tests` → **0 warnings** (these two were the only ones).
- Full lib suite **524 passed / 0 failed** (covers all `scenario_runner` and `audit_chain` tests).
- `src/gateway/kinematics_contract.rs` unchanged (blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b`), not in the diff.
- No `git add -A`; only the two files staged.

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_