### PR TITLE
docs(readme): refresh root + parko READMEs to current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 
 | ADR-0003 | Two-tier KIRRA architecture — base + optional D1 | Accepted |
 | ADR-0004 | Independent Safety Channel — D1–D3 settlement | Superseded by ADR-0003 |
 
+The **cert-target platform** decision and its prototype bring-up plan live under
+[`docs/adr/`](docs/adr/): `ADR-0001-governor-deployment-platform.md` (KIRRA
+governor on QNX Hypervisor 8.0 for Safety; the Autoware/ROS 2 doer as an isolated
+guest VM; a Ferrocene `no_std` verdict core as the certified artifact), with
+companions `KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md`, `KIRRA_BRINGUP_RUNBOOK.md`,
+and `KIRRA_QNX_CROSSCOMPILE.md`. (That file's `ADR-0001` prefix is independent of
+the numbered ODD-cap ADRs in the table above — a known naming overlap.)
+
 See [docs/safety/](docs/safety/) for the complete safety case foundation,
 [docs/safety/SAFETY_CASE_INDEX.md](docs/safety/SAFETY_CASE_INDEX.md) for the
 full document registry, and [docs/safety/ROADMAP_TO_ASIL_D.md](docs/safety/ROADMAP_TO_ASIL_D.md)
@@ -226,6 +234,7 @@ Modern robotic and autonomous deployments increasingly rely on AI models to gene
 - **Deterministic test harness** — `ScenarioRunner` with virtual clock injection for temporal integration tests
 - **MC/DC pair-completing tests** — coverage evidence per KIRRA-OCCY-MCDC-001
 - **CARLA integration** — `kirra_carla_client` binary for AV simulator connectivity
+- **Two-box prototype tools** — `kirra-governor-service` (UDP governor wrapping the verdict core), `kirra-proposal-bench` (proposal-sweep harness), and the shared `kirra-wire-client` mirror; pure-Rust, runs the governed-car demo before the QNX cert factoring (ADR-0001, `docs/adr/KIRRA_BRINGUP_RUNBOOK.md`)
 - **Auto-generated traceability matrix** — `// SAFETY:` tag scanner produces `docs/safety/TRACEABILITY_MATRIX.md`
 
 ---
@@ -271,7 +280,7 @@ src/
     └── kirra_carla_client.rs     — CARLA AV simulator integration
 
 crates/
-└── kirra-ros2-adapter/           — Occy #131 Option-B per-trajectory wiring
+├── kirra-ros2-adapter/           — Occy #131 Option-B per-trajectory wiring (ros2 feature)
     ├── src/
     │   ├── lib.rs                — public surface + re-exports
     │   ├── config.rs             — VehicleConfig (envelope params, FTTI budgets)
@@ -290,6 +299,18 @@ crates/
     │   │                           subscription-staleness watchdog (ros2 feature)
     │   └── bin/                  — verifier service binary (ros2 feature)
     └── tests/                    — slow / fast loop unit + integration tests
+├── kirra-governor-service/       — minimal over-the-wire (UDP) governor wrapping the
+│                                   EXISTING verdict core verbatim (serde + bincode + std
+│                                   only — no ROS/async); two-box prototype demonstrator,
+│                                   QNX cert-target path per ADR-0001
+├── kirra-wire-client/            — single shared client-side mirror of the governor's UDP
+│                                   wire schema (dev/test; reused by the bench + future car
+│                                   bridge so the wire types are defined once)
+├── kirra-proposal-bench/         — dev/test UDP bench: sweeps proposals at a running
+│                                   kirra-governor-service and prints a CASE/REASON/VERDICT table
+├── kirra-capture-schema/         — governor-free capture-record wire schema, shared verbatim
+│                                   with the offline collector
+└── kirra-collector/              — offline capture / replay collector (db3 + mcap readers)
 ```
 
 The `kirra-ros2-adapter` crate is feature-gated on `ros2` (default build
@@ -314,7 +335,9 @@ Layout mirrors `kirra-ros2-adapter`:
   unit tests).
 - `ros2` feature → r2r 0.9.5 + the node binary.
 - `onnx-backend` feature → parko-onnx OrtBackend (production inference;
-  requires `ORT_DYLIB_PATH`).
+  requires `ORT_DYLIB_PATH`). CPU by default; parko-onnx's `cuda` feature
+  selects the NVIDIA CUDA execution provider (fail-closed — a missing
+  GPU/driver/provider errors out, never a silent CPU fallback).
 
 Fail-closed paths: sensor staleness → stopped twist (MRC);
 `InferenceLoop::tick` error → stopped twist; comparator divergence

--- a/parko/README.md
+++ b/parko/README.md
@@ -23,7 +23,7 @@ The intended use case is robotics and edge systems where ML perception drives ac
 
 ## Current capabilities
 
-The workspace contains three crates:
+The workspace contains six crates (`parko-core`, `parko-onnx`, `parko-openvino`, `parko-tensorrt`, `parko-kirra`, `parko-ros2`):
 
 **`parko-core`** — Core types and traits. No backends.
 - `InferenceBackend` trait
@@ -33,11 +33,11 @@ The workspace contains three crates:
 - `InferenceLoop` with one-tick-delayed actuator publication, degraded-mode detection, and optional `SafetyGovernor`
 - `ControlLoop` with a clock-driven state machine
 - `SafetyGovernor` trait for pluggable command envelope enforcement
-- 33 unit and integration tests
+- extensive unit + integration tests (RSS and posture-divergence proptests, the `ControlLoop` state machine incl. recovery hysteresis)
 
 **`parko-onnx`** — ONNX Runtime backend, using the `ort` crate.
-- One backend implementation: `OrtBackend` (CPU only)
-- Integration test passing against MNIST-12
+- `OrtBackend`: CPU by default; the **`cuda`** feature adds a **fail-closed** NVIDIA CUDA execution provider (`new_cuda` / `with_cuda_config`) — a missing GPU/driver/provider errors out, never a silent CPU fallback
+- Integration test passing against MNIST-12 (the CUDA-vs-CPU cross-check is GPU-CI-gated)
 
 **`parko-openvino`** — OpenVINO backend, using the `openvino` crate.
 - One backend implementation: `OvBackend` (CPU device, ingests ONNX directly)
@@ -51,8 +51,9 @@ The workspace contains three crates:
 | Backend | Crate | Hardware | Runtime install | Status |
 |---|---|---|---|---|
 | ONNX Runtime CPU | `parko-onnx` | any x86 CPU | `libonnxruntime.so` + `ORT_DYLIB_PATH` (v1.23.2) | ✅ full |
+| ONNX Runtime CUDA | `parko-onnx` (`cuda` feature) | NVIDIA GPU | CUDA-enabled `libonnxruntime.so` + GPU | ✅ code (fail-closed); runtime test GPU-CI-gated |
 | Intel OpenVINO | `parko-openvino` | any x86 Intel CPU | `libopenvino_c.so` from the Intel apt repo (`openvino-2024.x`) | ✅ full (CPU; `cargo build` does not require the toolkit) |
-| TensorRT (NVIDIA) | — | NVIDIA GPU | — | planned (PARK-020) |
+| TensorRT (NVIDIA) | `parko-tensorrt` | NVIDIA GPU / Jetson | TensorRT-enabled ORT runtime | CI-buildable skeleton; real inference Jetson-gated (PARK-021) |
 | Qualcomm QNN | — | Qualcomm NPU | — | planned (PARK-027) |
 | TI TIDL | — | TI hardware | — | planned (PARK-028) |
 | AMD Vitis | — | AMD hardware | — | planned (PARK-030) |


### PR DESCRIPTION
## Summary

Docs-only. Refreshes the root and parko READMEs to reflect the current state after this session's merges (new crates, the parko-onnx CUDA EP, the platform ADR set). No source changes.

### Root `README.md`
- **`crates/` layout** now lists **all 6 workspace members** — added `kirra-governor-service`, `kirra-wire-client`, `kirra-proposal-bench`, `kirra-capture-schema`, `kirra-collector` alongside the (previously sole-listed) `kirra-ros2-adapter`.
- **Test / Tooling**: added the two-box prototype tools (`kirra-governor-service` + `kirra-proposal-bench` + the shared `kirra-wire-client` mirror).
- **parko `onnx-backend` bullet**: CPU by default; parko-onnx's `cuda` feature selects the fail-closed NVIDIA CUDA EP.
- **ADR section**: points to the `docs/adr/` governor-deployment-platform ADR set (strategy / bring-up runbook / QNX recipe), explicitly flagging the `ADR-0001` naming overlap with the numbered ODD-cap ADRs (honest, not silently renumbered).

### `parko/README.md`
- "three crates" → **six** (`parko-core`, `parko-onnx`, `parko-openvino`, `parko-tensorrt`, `parko-kirra`, `parko-ros2`).
- `parko-onnx` `OrtBackend`: **CPU + optional fail-closed CUDA EP** (was "CPU only").
- **Backend-status table**: added the ONNX-Runtime-CUDA row; updated TensorRT from "planned" to the actual `parko-tensorrt` CI-buildable / Jetson-gated skeleton (PARK-021).
- Refreshed the egregiously-stale parko-core "33 tests" line to a non-brittle description (avoids re-staling on a hard count).

## Guardrails
- Docs-only — only `README.md` and `parko/README.md` changed.
- `src/gateway/kinematics_contract.rs` unchanged (blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b`), not in the diff.
- No `git add -A`.

https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyMV3dHqjV2gryfBL8HFoV)_