### PR TITLE
docs(safety): reconcile liveness exemption with LockedOut invariant (#70)

### DIFF
--- a/docs/safety/SAFE_STATE_SPECIFICATION.md
+++ b/docs/safety/SAFE_STATE_SPECIFICATION.md
@@ -152,6 +152,35 @@ Recovery:
   under any circumstances. Human must verify system state before
   issuing reset.
 
+Liveness/observability exemption (path-class distinction):
+  "LockedOut admits no commands" (and fail-closed posture gating generally)
+  governs the **command** and **mutation** path classes — actuator/control
+  routes and state-mutating routes. It does NOT govern read-only
+  liveness/observability probes, which carry NO command, mutation, or actuator
+  authority. The two statements describe **different path classes** and are not
+  in tension.
+
+  The following read-only paths are DELIBERATELY exempt from posture gating
+  AND from the HA epoch fence, and remain reachable under `LockedOut` and on a
+  self-demoted / fenced node — exactly the set enforced by `is_posture_exempt`
+  (`src/gateway/policy_layer.rs`):
+
+      "/health" | "/health/live" | "/ready" | "/metrics"
+
+  Rationale — keeping liveness reachable under `LockedOut` is itself a safety
+  property: an operator / orchestrator MUST be able to observe that a node is
+  `LockedOut`. A node that goes dark is indistinguishable from a crash and can
+  trigger incorrect failover (e.g. a standby promoting against a node that is
+  in fact alive and correctly `LockedOut`).
+
+  Source of truth + enforcing test: the authoritative allowlist is
+  `is_posture_exempt` in `src/gateway/policy_layer.rs`; the real-router test
+  `health_exempt_under_lockedout_on_real_router`
+  (`src/bin/kirra_verifier_service.rs`, issue #72 / PR #226) proves `/health`
+  stays HTTP 200 under `LockedOut` on the assembled production router. This doc
+  list and `is_posture_exempt` MUST be kept in sync — a change to one requires
+  updating the other.
+
 Implements: ISO 26262 safe state for non-recoverable faults.
 
 Safety goals covered: SG-007, SG-011 (partial)
@@ -236,6 +265,17 @@ violated regardless of what upstream AI systems instruct:
     calls `save_node` then `nodes.insert`, never reversed
 12. `KIRRA_ADMIN_TOKEN` compared with `constant_time_compare` only —
     standard `==` forbidden on security-critical byte sequences
+13. Liveness/observability probes are EXEMPT from posture gating and the HA
+    epoch fence, and stay reachable under `LockedOut` and on a fenced /
+    self-demoted node — `is_posture_exempt` allowlists exactly
+    `/health`, `/health/live`, `/ready`, `/metrics`. This does NOT contradict
+    invariants 7–9: "`LockedOut` admits no commands" governs the COMMAND and
+    MUTATION path classes; read-only liveness probes carry no command or
+    actuator authority and are a different path class. Keeping liveness
+    observable under `LockedOut` is itself a safety property (a dark node is
+    indistinguishable from a crash and can trigger incorrect failover). The
+    doc list (SS-003) and `is_posture_exempt`
+    (`src/gateway/policy_layer.rs`) must be kept in sync. (Issue #70)
 
 ---
 


### PR DESCRIPTION
Closes #70.

## Problem

The §4 "Safe State Transition Invariants" list in `docs/safety/SAFE_STATE_SPECIFICATION.md` read as self-contradictory: "`LockedOut` admits no commands" / fail-closed sat alongside a posture gate (`enforce_posture_routing`) that *deliberately* keeps liveness/observability probes reachable under `LockedOut`. The reconciliation makes the path-class distinction explicit so the two statements are no longer in apparent tension.

## Change (doc-only)

- **SS-003 (Lockout / Hard Stop)** — new "Liveness/observability exemption (path-class distinction)" subsection:
  - "LockedOut admits no commands" governs the **command** and **mutation** path classes; it does **not** govern read-only liveness/observability probes, which carry no command, mutation, or actuator authority — a different path class, not a contradiction.
  - The exempt allowlist is quoted **verbatim** from the source of truth `is_posture_exempt` (`src/gateway/policy_layer.rs`): `"/health" | "/health/live" | "/ready" | "/metrics"`.
  - Rationale: keeping liveness reachable under `LockedOut` is itself a safety property — a dark node is indistinguishable from a crash and can trigger incorrect failover (e.g. a standby promoting against a node that is alive and correctly `LockedOut`).
  - Anchored to `is_posture_exempt` as the authoritative allowlist and the #226 real-router test `health_exempt_under_lockedout_on_real_router` as the enforcing check; notes the doc list and `is_posture_exempt` must be kept in sync.
- **§4 invariants** — added invariant 13 restating the exemption and explicitly noting it does **not** contradict invariants 7–9 (different path class).

## Verification

- `git diff --stat`: **only** `docs/safety/SAFE_STATE_SPECIFICATION.md` changed (+40). Verdict path `src/gateway/kinematics_contract.rs` **absent** from the diff.
- Allowlist parity: the SS-003 block reproduces the exact `matches!` pattern at `policy_layer.rs:419`, and invariant 13 lists the same four entries — no drift.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_