### PR TITLE
fix(canopen): map NMT node-id → fleet node so offline recalc is effectful (#84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,7 @@ proptest = "1"  # dev-dependency
 | `KIRRA_HEARTBEAT_INTERVAL` | No | `2000` | HA heartbeat write interval (ms) |
 | `KIRRA_PROMOTION_TIMEOUT` | No | `10000` | Standby promotes if primary silent this long (ms) |
 | `KIRRA_SUPERVISOR_RESET_KEY` | Yes (reset ops) | — | Must be non-empty, ≤ 64 bytes |
+| `KIRRA_CANOPEN_NODE_MAP` | No | — | CANopen node-id → fleet-node-id map (#84), `canid:fleet_node` comma-separated (e.g. `5:robot-01,6:robot-02`). Unset → every NMT-offline is unattributed (fail-closed) |
 
 ---
 

--- a/src/adapters/canopen.rs
+++ b/src/adapters/canopen.rs
@@ -1,5 +1,8 @@
 // src/adapters/canopen.rs
 
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
 use serde::{Deserialize, Serialize};
 use crate::gateway::policy::OperationalCommand;
 
@@ -79,6 +82,131 @@ impl CanOpenAdapter {
             emergency_code,
             triggers_recalculation,
         }
+    }
+}
+
+/// Env var carrying the CANopen-node-id → fleet-node-id map (#84).
+/// Format: comma-separated `canid:fleet_node_id` pairs, e.g.
+/// `5:robot-01,6:robot-02`. The map is CONFIG-sourced — there is no
+/// hardcoded table; an unset/empty var yields an empty map (every offline
+/// is then unattributed, handled fail-closed by the caller).
+pub const CANOPEN_NODE_MAP_ENV: &str = "KIRRA_CANOPEN_NODE_MAP";
+
+/// CANopen bus-address (`u8` node-id) → fleet-node-id (`String`) resolver.
+///
+/// The fleet-node-id is the key into the verifier's node registry
+/// (`AppState::nodes`) and DAG — resolving it is what lets an NMT-offline
+/// event mark the CORRECT asset so the posture recalc is effectful.
+#[derive(Debug, Clone, Default)]
+pub struct CanOpenNodeMap {
+    map: HashMap<u8, String>,
+}
+
+impl CanOpenNodeMap {
+    /// Parse the `canid:fleet_node` comma-separated config spec. Malformed
+    /// or out-of-range entries are skipped with a warning (never panic);
+    /// a later duplicate canid overrides an earlier one.
+    pub fn from_spec(spec: &str) -> Self {
+        let mut map = HashMap::new();
+        for raw in spec.split(',') {
+            let entry = raw.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            let Some((id_str, node)) = entry.split_once(':') else {
+                tracing::warn!(entry, "CANopen node-map: skipping malformed entry (expected `canid:fleet_node`)");
+                continue;
+            };
+            let node = node.trim();
+            match id_str.trim().parse::<u8>() {
+                Ok(id) if !node.is_empty() => {
+                    map.insert(id, node.to_string());
+                }
+                _ => {
+                    tracing::warn!(entry, "CANopen node-map: skipping entry with invalid node-id (0-255) or empty fleet-node");
+                }
+            }
+        }
+        Self { map }
+    }
+
+    /// Resolve a CANopen node-id to its fleet-node-id, if mapped.
+    pub fn resolve(&self, node_id: u8) -> Option<&str> {
+        self.map.get(&node_id).map(String::as_str)
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+}
+
+/// Process-wide CANopen node map, initialized once at startup from the
+/// environment. Kept out of `ServiceState`/`AppState` so this adapter-layer
+/// fix needs no change to their (many) construction sites.
+static GLOBAL_NODE_MAP: OnceLock<CanOpenNodeMap> = OnceLock::new();
+
+/// Initialize the global CANopen node map from `KIRRA_CANOPEN_NODE_MAP`.
+/// Idempotent — a second call is a no-op. Call once during startup.
+pub fn init_node_map_from_env() {
+    let spec = std::env::var(CANOPEN_NODE_MAP_ENV).unwrap_or_default();
+    let map = CanOpenNodeMap::from_spec(&spec);
+    let count = map.len();
+    if GLOBAL_NODE_MAP.set(map).is_ok() {
+        tracing::info!(entries = count, "CANopen node map initialized from env");
+    }
+}
+
+/// Resolve a CANopen node-id against the global map. Returns `None` when the
+/// map is uninitialized or has no entry for the id (fail-closed: the caller
+/// treats `None` as an unattributed offline, never a silent no-op).
+pub fn global_resolve(node_id: u8) -> Option<String> {
+    GLOBAL_NODE_MAP
+        .get()
+        .and_then(|m| m.resolve(node_id))
+        .map(str::to_string)
+}
+
+/// Why an NMT-offline could not be attributed to a fleet node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnattributedReason {
+    /// No CANopen→fleet mapping exists for this bus node-id.
+    NoMapping,
+    /// The mapping exists but names a node not in the verifier registry.
+    NodeNotRegistered,
+}
+
+/// Disposition of an NMT node-offline event after fleet-node resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NmtOfflineOutcome {
+    /// Resolved to a registered fleet node — mark it offline (effectful recalc).
+    Attributed { fleet_node_id: String },
+    /// Could not be attributed — handle fail-closed (surface, never drop).
+    Unattributed { canopen_node_id: u8, reason: UnattributedReason },
+}
+
+/// Classify an NMT-offline event given the resolved fleet node (if any) and
+/// whether that node is registered in the verifier. Pure + total: a node-id
+/// that resolves to a registered node is `Attributed`; everything else is
+/// `Unattributed` with a reason — there is no silent-drop path.
+pub fn classify_nmt_offline(
+    canopen_node_id: u8,
+    resolved: Option<String>,
+    node_registered: bool,
+) -> NmtOfflineOutcome {
+    match resolved {
+        Some(fleet_node_id) if node_registered => NmtOfflineOutcome::Attributed { fleet_node_id },
+        Some(_) => NmtOfflineOutcome::Unattributed {
+            canopen_node_id,
+            reason: UnattributedReason::NodeNotRegistered,
+        },
+        None => NmtOfflineOutcome::Unattributed {
+            canopen_node_id,
+            reason: UnattributedReason::NoMapping,
+        },
     }
 }
 
@@ -196,5 +324,59 @@ mod tests {
         let m = CanOpenMessage { node_id: 127, function_code: 0xE, data: vec![], source_node: "n".to_string() };
         let e = CanOpenAdapter::evaluate(&m);
         assert_eq!(e.node_id, 127);
+    }
+
+    // --- #84: CANopen-node-id → fleet-node mapping + fail-closed classification ---
+
+    #[test]
+    fn test_node_map_parses_spec_and_resolves() {
+        let m = CanOpenNodeMap::from_spec("5:robot-01, 6 : robot-02 ,127:drone-09");
+        assert_eq!(m.len(), 3);
+        assert_eq!(m.resolve(5), Some("robot-01"));
+        assert_eq!(m.resolve(6), Some("robot-02"));
+        assert_eq!(m.resolve(127), Some("drone-09"));
+        assert_eq!(m.resolve(9), None, "unmapped id resolves to None");
+    }
+
+    #[test]
+    fn test_node_map_skips_malformed_entries_without_panicking() {
+        // missing colon, non-numeric id, out-of-range id, empty node, blanks
+        let m = CanOpenNodeMap::from_spec("garbage,xx:n,300:n,7:,, 8:robot-08 ,");
+        assert_eq!(m.resolve(8), Some("robot-08"));
+        assert_eq!(m.len(), 1, "only the one well-formed entry survives");
+    }
+
+    #[test]
+    fn test_empty_spec_is_empty_map() {
+        assert!(CanOpenNodeMap::from_spec("").is_empty());
+        assert!(CanOpenNodeMap::from_spec("   ").is_empty());
+    }
+
+    #[test]
+    fn test_classify_mapped_registered_is_attributed() {
+        let out = classify_nmt_offline(5, Some("robot-01".to_string()), true);
+        assert_eq!(out, NmtOfflineOutcome::Attributed { fleet_node_id: "robot-01".to_string() });
+    }
+
+    #[test]
+    fn test_classify_unmapped_is_unattributed_no_mapping() {
+        // FAIL-CLOSED: an unmapped offline is never dropped — it is classified
+        // Unattributed(NoMapping) for the caller to surface.
+        let out = classify_nmt_offline(99, None, false);
+        assert_eq!(
+            out,
+            NmtOfflineOutcome::Unattributed { canopen_node_id: 99, reason: UnattributedReason::NoMapping }
+        );
+    }
+
+    #[test]
+    fn test_classify_mapped_but_unregistered_is_unattributed() {
+        // A mapping that points at a node the verifier doesn't know is also
+        // fail-closed — we cannot attribute the offline to a real asset.
+        let out = classify_nmt_offline(5, Some("ghost".to_string()), false);
+        assert_eq!(
+            out,
+            NmtOfflineOutcome::Unattributed { canopen_node_id: 5, reason: UnattributedReason::NodeNotRegistered }
+        );
     }
 }

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -926,11 +926,82 @@ async fn evaluate_canopen_adapter(
     let (allowed, denial_reason) = kirra_runtime_sdk::protocol_adapter::command_allowed_for_posture_pub(&eval.command, &posture);
     let audit_ref = now_ms().to_string();
 
+    // #84: resolve the CANopen bus node-id to a FLEET node so an NMT-offline
+    // event marks the correct asset and the recalc is EFFECTFUL. Unmapped or
+    // unregistered ids are FAIL-CLOSED — surfaced as an unattributed offline
+    // (distinct audit event + warning + response flag), never a silent no-op.
+    let offline_outcome = if eval.triggers_recalculation {
+        use kirra_runtime_sdk::adapters::canopen::{classify_nmt_offline, global_resolve};
+        let resolved = global_resolve(eval.node_id);
+        let registered = resolved
+            .as_deref()
+            .map(|n| svc.app.nodes.contains_key(n))
+            .unwrap_or(false);
+        Some(classify_nmt_offline(eval.node_id, resolved, registered))
+    } else {
+        None
+    };
+
+    // Apply the offline effect (mark the node + drive a recalc). The fleet node
+    // actually marked offline (if any) is recorded for the audit + response.
+    let mut attributed_fleet_node: Option<String> = None;
+    if let Some(outcome) = &offline_outcome {
+        use kirra_runtime_sdk::adapters::canopen::{NmtOfflineOutcome, UnattributedReason};
+        use kirra_runtime_sdk::posture_engine_v2::PostureRecalcTrigger;
+        match outcome {
+            NmtOfflineOutcome::Attributed { fleet_node_id } => {
+                match svc.app.mark_node_untrusted(fleet_node_id, "CANOPEN_NMT_OFFLINE", now_ms()) {
+                    Ok(true) => {
+                        attributed_fleet_node = Some(fleet_node_id.clone());
+                        tracing::warn!(
+                            canopen_node_id = eval.node_id,
+                            fleet_node_id = %fleet_node_id,
+                            "CANopen NMT node-offline → fleet node marked Untrusted; effectful recalc enqueued"
+                        );
+                        enqueue_recalc(&svc, PostureRecalcTrigger::NodeTrustChanged {
+                            node_id: fleet_node_id.clone(),
+                            reason: "CANOPEN_NMT_OFFLINE".to_string(),
+                        });
+                    }
+                    // Mapping raced a deregistration, or the store write failed:
+                    // fail-closed exactly like an unattributed offline.
+                    Ok(false) | Err(()) => {
+                        tracing::error!(
+                            canopen_node_id = eval.node_id,
+                            fleet_node_id = %fleet_node_id,
+                            "CANopen NMT node-offline: mapped node missing or store write failed — \
+                             treating as UNATTRIBUTED (fail-closed)"
+                        );
+                        enqueue_recalc(&svc, PostureRecalcTrigger::DependencyGraphChanged);
+                    }
+                }
+            }
+            NmtOfflineOutcome::Unattributed { canopen_node_id, reason } => {
+                let reason_str = match reason {
+                    UnattributedReason::NoMapping => "NO_MAPPING",
+                    UnattributedReason::NodeNotRegistered => "NODE_NOT_REGISTERED",
+                };
+                tracing::warn!(
+                    canopen_node_id = *canopen_node_id,
+                    source_node = %msg.source_node,
+                    reason = reason_str,
+                    "CANopen NMT node-offline UNATTRIBUTED — recorded as unattributed offline; \
+                     recalc enqueued (fail-closed, never silently dropped)"
+                );
+                enqueue_recalc(&svc, PostureRecalcTrigger::DependencyGraphChanged);
+            }
+        }
+    }
+
     if !allowed || eval.triggers_recalculation {
         match svc.app.store.lock() {
             Ok(mut store) => {
                 let event_type = if eval.triggers_recalculation {
-                    "CANOPEN_NMT_NODE_OFFLINE"
+                    if attributed_fleet_node.is_some() {
+                        "CANOPEN_NMT_NODE_OFFLINE"
+                    } else {
+                        "CANOPEN_NMT_OFFLINE_UNATTRIBUTED"
+                    }
                 } else {
                     "INDUSTRIAL_ACTION_DENIED"
                 };
@@ -938,6 +1009,8 @@ async fn evaluate_canopen_adapter(
                     "canopen_adapter", event_type,
                     &json!({
                         "node_id": eval.node_id,
+                        "fleet_node_id": attributed_fleet_node.clone(),
+                        "node_offline_attributed": attributed_fleet_node.is_some(),
                         "message_type": format!("{:?}", eval.message_type),
                         "is_emergency": eval.is_emergency,
                         "triggers_recalculation": eval.triggers_recalculation,
@@ -958,32 +1031,17 @@ async fn evaluate_canopen_adapter(
         }
     }
 
-    // CANopen NMT node-offline / reset surfaces an underlying-fleet change,
-    // but there is no production CANopen-bus-address → fleet-node-id
-    // mapping in this repo today. The honest minimal wiring is to enqueue
-    // a `DependencyGraphChanged` so the freshness pipeline runs — but
-    // because no underlying state changed, the resulting recalc recomputes
-    // the SAME posture. This is a partial fix; tracked as follow-up so the
-    // recalc becomes effectful once the mapping exists.
-    if eval.triggers_recalculation {
-        tracing::warn!(
-            canopen_node_id = eval.node_id,
-            source_node     = %msg.source_node,
-            "CANopen NMT node-offline triggers recalc, but no CANopen→fleet-node \
-             mapping exists yet — recalc is a no-op until that mapping is defined"
-        );
-        enqueue_recalc(
-            &svc,
-            kirra_runtime_sdk::posture_engine_v2::PostureRecalcTrigger::DependencyGraphChanged,
-        );
-    }
-
     Json(json!({
         "protocol": "canopen",
         "command": format!("{:?}", eval.command),
         "allowed": allowed,
         "denial_reason": denial_reason,
         "posture_at_evaluation": posture_str,
+        // #84: whether the NMT-offline was attributed to a fleet node (and which).
+        // `false` on an offline event means the id was unmapped/unregistered and
+        // handled fail-closed — surfaced here so callers never read silence as success.
+        "node_offline_attributed": attributed_fleet_node.is_some(),
+        "fleet_node_id": attributed_fleet_node,
         "adapter_details": {
             "message_type": format!("{:?}", eval.message_type),
             "node_id": eval.node_id,
@@ -1669,6 +1727,12 @@ async fn main() {
 
     let mode = VerifierOperationMode::from_env();
     println!("Kirra Verifier starting in {mode:?} mode (db: {db_path})");
+
+    // #84: load the CANopen-node-id → fleet-node-id map from config so an NMT
+    // node-offline event marks the correct asset (effectful recalc). Sourced
+    // from KIRRA_CANOPEN_NODE_MAP; unset → empty map (every offline is then
+    // unattributed, handled fail-closed in evaluate_canopen_adapter).
+    kirra_runtime_sdk::adapters::canopen::init_node_map_from_env();
 
     let audit_signing_key: Option<ed25519_dalek::SigningKey> =
         std::env::var("KIRRA_LOG_SIGNING_KEY").ok()

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -310,6 +310,31 @@ impl AppState {
         Ok(())
     }
 
+    /// Mark a registered node `Untrusted` (e.g. a CANopen NMT node-offline,
+    /// #84) so the next DAG recalc reflects it. Disk-first (invariant #12):
+    /// re-persists via `persist_and_insert_node`.
+    ///
+    /// Returns `Ok(true)` if the node existed and was updated, `Ok(false)` if
+    /// no such node is registered (the caller fail-closes on this), `Err(())`
+    /// on a store failure.
+    pub fn mark_node_untrusted(
+        &self,
+        node_id: &str,
+        reason: &str,
+        now_ms: u64,
+    ) -> Result<bool, ()> {
+        let Some(existing) = self.nodes.get(node_id).map(|n| n.clone()) else {
+            return Ok(false);
+        };
+        let updated = RegisteredNode {
+            status: NodeTrustState::Untrusted(reason.to_string()),
+            last_trust_update_ms: now_ms,
+            ..existing
+        };
+        self.persist_and_insert_node(updated)?;
+        Ok(true)
+    }
+
     /// Persist dependency list to SQLite then update in-memory graph (fail-closed).
     pub fn persist_and_insert_deps(&self, node_id: &str, deps: Vec<String>) -> Result<(), ()> {
         self.store.lock()
@@ -456,5 +481,61 @@ mod transport_identity_tests {
         headers.insert("x-custom-identity", HeaderValue::from_static("fleet-controller"));
         assert!(validate_client_identity_headers(true, "x-custom-identity", &headers));
         assert!(!validate_client_identity_headers(true, "x-kirra-client-id", &headers));
+    }
+}
+
+#[cfg(test)]
+mod mark_node_untrusted_tests {
+    use super::*;
+    use crate::verifier_store::VerifierStore;
+
+    fn app() -> AppState {
+        let store = VerifierStore::new(":memory:").expect("in-memory store");
+        AppState::new(store, VerifierOperationMode::Active)
+    }
+
+    fn trusted_node(id: &str) -> RegisteredNode {
+        RegisteredNode {
+            node_id: id.to_string(),
+            status: NodeTrustState::Trusted,
+            registered_at_ms: 1,
+            last_trust_update_ms: 1,
+            ak_public_pem: None,
+            expected_pcr16_digest_hex: None,
+        }
+    }
+
+    // #84: marking the resolved fleet node offline must be EFFECTFUL — the DAG
+    // recalc flips the node's posture from Nominal to LockedOut.
+    #[test]
+    fn marking_registered_node_untrusted_is_effectful() {
+        let app = app();
+        app.persist_and_insert_node(trusted_node("robot-01")).unwrap();
+        assert_eq!(
+            app.calculate_posture("robot-01").propagated_status,
+            FleetPosture::Nominal,
+            "a Trusted node is Nominal before the offline"
+        );
+
+        let updated = app.mark_node_untrusted("robot-01", "CANOPEN_NMT_OFFLINE", 1_000).unwrap();
+        assert!(updated, "an existing node is updated");
+
+        assert!(matches!(
+            app.nodes.get("robot-01").unwrap().status,
+            NodeTrustState::Untrusted(_)
+        ));
+        assert_eq!(
+            app.calculate_posture("robot-01").propagated_status,
+            FleetPosture::LockedOut,
+            "marking the node offline must change the recalculated posture (effectful)"
+        );
+    }
+
+    // Marking a node the verifier doesn't know returns Ok(false) so the caller
+    // can fail-closed (treat as an unattributed offline) rather than no-op.
+    #[test]
+    fn marking_unknown_node_returns_false() {
+        let app = app();
+        assert!(!app.mark_node_untrusted("ghost", "CANOPEN_NMT_OFFLINE", 1).unwrap());
     }
 }


### PR DESCRIPTION
Closes #84.

## Problem
`CanOpenAdapter::evaluate()` set `triggers_recalculation` on an NMT node-offline, but nothing resolved the raw CAN bus node-id (`u8`) to a **fleet** node. The handler enqueued a `DependencyGraphChanged` recalc that recomputed the *same* posture because no underlying state changed — effectively a **no-op**. (Acknowledged in-code and tracked in `docs/safety/REVIEW_WRAPUP_2026-05-30.md`.)

## Fix
- **Adapter-layer, config-sourced map** (`KIRRA_CANOPEN_NODE_MAP`, `canid:fleet_node` comma-separated — no hardcoded table). New pure, testable types in `src/adapters/canopen.rs`: `CanOpenNodeMap` (`from_spec`/`resolve`) and `classify_nmt_offline`. Loaded once at startup via `init_node_map_from_env()`.
- **Effectful path**: an NMT-offline whose node-id maps to a **registered** fleet node now marks that node `Untrusted` via the new `AppState::mark_node_untrusted` (disk-first, invariant #12) and enqueues `NodeTrustChanged` — so the DAG recalc flips the **correct asset's** posture (Nominal → LockedOut). Proven by `marking_registered_node_untrusted_is_effectful`.
- **Fail-closed on unmapped/unregistered ids** (see decision below).

## Unmapped-id decision (fail-closed handling)
An NMT-offline that cannot be attributed to a registered fleet node is **never silently dropped**. It is:
1. classified `Unattributed { NoMapping | NodeNotRegistered }`,
2. written to the tamper-evident log as a **distinct** `CANOPEN_NMT_OFFLINE_UNATTRIBUTED` event,
3. logged at `warn`, and surfaced in the response as `node_offline_attributed: false`, and
4. still enqueues a recalc so the freshness pipeline runs.

I deliberately chose **loud surfacing + safe default** over escalating to a fleet-wide `Degraded` on any unattributed offline. The endpoint (`/industrial/canopen/evaluate`) is admin-token + client-identity gated, but a global-degrade-on-unknown-id would still be an over-trigger / DoS surface and would mask *which* node went offline. Surfacing the unattributable offline tamper-evidently makes it operator-actionable without that hazard.

## Tests
`src/adapters/canopen.rs`: parse/resolve, malformed-entry skip (no panic), empty spec, classification (mapped+registered → Attributed; unmapped → NoMapping; mapped-but-unregistered → NodeNotRegistered). `src/verifier.rs`: effectful mark (Nominal→LockedOut) + unknown-node → `Ok(false)`. Existing canopen/protocol-adapter tests unchanged.

- `cargo test --lib`: 549 passed, 0 failed
- `cargo test --bin kirra_verifier_service`: 12 passed, 0 failed
- existing `adapters::canopen` + `protocol_adapter` regression: green

No talisman/secret artifacts in the diff; staged explicitly (no `git add -A`).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_