### PR TITLE
refactor: bundle high-arity params into structs to clear too_many_arguments (#68)

### DIFF
--- a/src/audit_chain.rs
+++ b/src/audit_chain.rs
@@ -90,43 +90,46 @@ pub fn canonical_anchor_head_payload(sequence: u64, record_hash: &str) -> String
 /// `fabric_generation`, `sequence`) are appended as LE bytes. Length-prefixing
 /// closes field-splicing ambiguities (`"AB"+"C"` vs `"A"+"BC"`) so neither a
 /// scalar nor an edge element can be silently relabeled or moved between fields.
-#[allow(clippy::too_many_arguments)]
-pub fn compute_causal_record_hash(
-    previous_hash: &str,
-    entry_id: &str,
-    asset_id: &str,
-    event_type: &str,
-    payload: &str,
-    caused_by: &[String],
-    affects_assets: &[String],
-    timestamp_ms: u64,
-    fabric_generation: u64,
-    sequence: u64,
-) -> String {
+/// Bundled inputs for [`compute_causal_record_hash`].
+#[derive(Debug, Clone)]
+pub struct CausalRecordHashInput<'a> {
+    pub previous_hash: &'a str,
+    pub entry_id: &'a str,
+    pub asset_id: &'a str,
+    pub event_type: &'a str,
+    pub payload: &'a str,
+    pub caused_by: &'a [String],
+    pub affects_assets: &'a [String],
+    pub timestamp_ms: u64,
+    pub fabric_generation: u64,
+    pub sequence: u64,
+}
+
+pub fn compute_causal_record_hash(input: &CausalRecordHashInput<'_>) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"KIRRA-CAUSAL-V1");
     for field in [
-        previous_hash.as_bytes(),
-        entry_id.as_bytes(),
-        asset_id.as_bytes(),
-        event_type.as_bytes(),
-        payload.as_bytes(),
+        input.previous_hash.as_bytes(),
+        input.entry_id.as_bytes(),
+        input.asset_id.as_bytes(),
+        input.event_type.as_bytes(),
+        input.payload.as_bytes(),
     ] {
         hasher.update((field.len() as u64).to_le_bytes());
         hasher.update(field);
     }
     // Edge vectors: count-prefixed, each element length-prefixed. This is what
     // binds the causality edges into the record hash.
-    for vec in [caused_by, affects_assets] {
+    for vec in [input.caused_by, input.affects_assets] {
         hasher.update((vec.len() as u64).to_le_bytes());
         for elem in vec {
             hasher.update((elem.len() as u64).to_le_bytes());
             hasher.update(elem.as_bytes());
         }
     }
-    hasher.update(timestamp_ms.to_le_bytes());
-    hasher.update(fabric_generation.to_le_bytes());
-    hasher.update(sequence.to_le_bytes());
+    hasher.update(input.timestamp_ms.to_le_bytes());
+    hasher.update(input.fabric_generation.to_le_bytes());
+    hasher.update(input.sequence.to_le_bytes());
     hex::encode(hasher.finalize())
 }
 
@@ -634,65 +637,85 @@ mod audit_signing_tests {
 
     #[test]
     fn test_causal_record_hash_is_deterministic() {
-        let h1 = compute_causal_record_hash(
-            &"0".repeat(64), "entry1", "asset1", "FAULT", "{}",
-            &["c1".to_string()], &["a1".to_string()], 1000, 5, 0,
-        );
-        let h2 = compute_causal_record_hash(
-            &"0".repeat(64), "entry1", "asset1", "FAULT", "{}",
-            &["c1".to_string()], &["a1".to_string()], 1000, 5, 0,
-        );
+        let h1 = compute_causal_record_hash(&CausalRecordHashInput {
+            previous_hash: &"0".repeat(64), entry_id: "entry1", asset_id: "asset1",
+            event_type: "FAULT", payload: "{}",
+            caused_by: &["c1".to_string()], affects_assets: &["a1".to_string()],
+            timestamp_ms: 1000, fabric_generation: 5, sequence: 0,
+        });
+        let h2 = compute_causal_record_hash(&CausalRecordHashInput {
+            previous_hash: &"0".repeat(64), entry_id: "entry1", asset_id: "asset1",
+            event_type: "FAULT", payload: "{}",
+            caused_by: &["c1".to_string()], affects_assets: &["a1".to_string()],
+            timestamp_ms: 1000, fabric_generation: 5, sequence: 0,
+        });
         assert_eq!(h1, h2, "causal record hash must be deterministic");
     }
 
     #[test]
     fn test_causal_record_hash_binds_caused_by_edge() {
-        let base = compute_causal_record_hash(
-            &"0".repeat(64), "e", "a", "T", "{}",
-            &["c1".to_string()], &["x".to_string()], 1, 1, 0,
-        );
-        let tampered = compute_causal_record_hash(
-            &"0".repeat(64), "e", "a", "T", "{}",
-            &["c2".to_string()], &["x".to_string()], 1, 1, 0,
-        );
+        let base = compute_causal_record_hash(&CausalRecordHashInput {
+            previous_hash: &"0".repeat(64), entry_id: "e", asset_id: "a",
+            event_type: "T", payload: "{}",
+            caused_by: &["c1".to_string()], affects_assets: &["x".to_string()],
+            timestamp_ms: 1, fabric_generation: 1, sequence: 0,
+        });
+        let tampered = compute_causal_record_hash(&CausalRecordHashInput {
+            previous_hash: &"0".repeat(64), entry_id: "e", asset_id: "a",
+            event_type: "T", payload: "{}",
+            caused_by: &["c2".to_string()], affects_assets: &["x".to_string()],
+            timestamp_ms: 1, fabric_generation: 1, sequence: 0,
+        });
         assert_ne!(base, tampered, "changing caused_by MUST change the record hash");
     }
 
     #[test]
     fn test_causal_record_hash_binds_affects_assets_edge() {
-        let base = compute_causal_record_hash(
-            &"0".repeat(64), "e", "a", "T", "{}",
-            &[], &["x".to_string()], 1, 1, 0,
-        );
-        let tampered = compute_causal_record_hash(
-            &"0".repeat(64), "e", "a", "T", "{}",
-            &[], &["y".to_string()], 1, 1, 0,
-        );
+        let base = compute_causal_record_hash(&CausalRecordHashInput {
+            previous_hash: &"0".repeat(64), entry_id: "e", asset_id: "a",
+            event_type: "T", payload: "{}",
+            caused_by: &[], affects_assets: &["x".to_string()],
+            timestamp_ms: 1, fabric_generation: 1, sequence: 0,
+        });
+        let tampered = compute_causal_record_hash(&CausalRecordHashInput {
+            previous_hash: &"0".repeat(64), entry_id: "e", asset_id: "a",
+            event_type: "T", payload: "{}",
+            caused_by: &[], affects_assets: &["y".to_string()],
+            timestamp_ms: 1, fabric_generation: 1, sequence: 0,
+        });
         assert_ne!(base, tampered, "changing affects_assets MUST change the record hash");
     }
 
     #[test]
     fn test_causal_record_hash_binds_fabric_generation_edge() {
-        let base = compute_causal_record_hash(
-            &"0".repeat(64), "e", "a", "T", "{}", &[], &[], 1, 5, 0,
-        );
-        let tampered = compute_causal_record_hash(
-            &"0".repeat(64), "e", "a", "T", "{}", &[], &[], 1, 6, 0,
-        );
+        let base = compute_causal_record_hash(&CausalRecordHashInput {
+            previous_hash: &"0".repeat(64), entry_id: "e", asset_id: "a",
+            event_type: "T", payload: "{}", caused_by: &[], affects_assets: &[],
+            timestamp_ms: 1, fabric_generation: 5, sequence: 0,
+        });
+        let tampered = compute_causal_record_hash(&CausalRecordHashInput {
+            previous_hash: &"0".repeat(64), entry_id: "e", asset_id: "a",
+            event_type: "T", payload: "{}", caused_by: &[], affects_assets: &[],
+            timestamp_ms: 1, fabric_generation: 6, sequence: 0,
+        });
         assert_ne!(base, tampered, "changing fabric_generation MUST change the record hash");
     }
 
     #[test]
     fn test_causal_record_hash_length_prefix_prevents_splicing() {
         // ("AB","C") vs ("A","BC") in the edge vectors must differ.
-        let a = compute_causal_record_hash(
-            &"0".repeat(64), "e", "a", "T", "{}",
-            &["AB".to_string(), "C".to_string()], &[], 1, 1, 0,
-        );
-        let b = compute_causal_record_hash(
-            &"0".repeat(64), "e", "a", "T", "{}",
-            &["A".to_string(), "BC".to_string()], &[], 1, 1, 0,
-        );
+        let a = compute_causal_record_hash(&CausalRecordHashInput {
+            previous_hash: &"0".repeat(64), entry_id: "e", asset_id: "a",
+            event_type: "T", payload: "{}",
+            caused_by: &["AB".to_string(), "C".to_string()], affects_assets: &[],
+            timestamp_ms: 1, fabric_generation: 1, sequence: 0,
+        });
+        let b = compute_causal_record_hash(&CausalRecordHashInput {
+            previous_hash: &"0".repeat(64), entry_id: "e", asset_id: "a",
+            event_type: "T", payload: "{}",
+            caused_by: &["A".to_string(), "BC".to_string()], affects_assets: &[],
+            timestamp_ms: 1, fabric_generation: 1, sequence: 0,
+        });
         assert_ne!(a, b, "length-prefixing must defeat edge field-splicing");
     }
 

--- a/src/fabric/causal_log.rs
+++ b/src/fabric/causal_log.rs
@@ -92,14 +92,16 @@ impl FabricCausalLog {
         match self.store.lock() {
             Ok(mut store) => {
                 if let Err(e) = store.append_causal_event(
-                    &entry_id,
-                    asset_id,
-                    event_type,
-                    payload,
-                    &caused_by,
-                    &affects_assets,
-                    fabric_generation,
-                    timestamp_ms,
+                    &crate::verifier_store::CausalEventInput {
+                        entry_id: &entry_id,
+                        asset_id,
+                        event_type,
+                        payload,
+                        caused_by: &caused_by,
+                        affects_assets: &affects_assets,
+                        fabric_generation,
+                        timestamp_ms,
+                    },
                     self.signing_key.as_ref(),
                 ) {
                     tracing::error!(

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -45,9 +45,22 @@ pub struct KirraLiveGateway {
     pub max_allowed_workers: u32, pub log_directory: String, pub io_writer_lock: Arc<Mutex<()>>,
 }
 
+/// Bundled construction parameters for [`KirraLiveGateway::new`].
+#[derive(Debug, Clone)]
+pub struct GatewayConfig {
+    pub proxy_port: u16,
+    pub plc_target_port: u16,
+    pub admin_port: u16,
+    pub metrics_port: u16,
+    pub config: ContractProfile,
+    pub auth_key: Vec<u8>,
+    pub max_threads: u32,
+    pub log_dir: String,
+}
+
 impl KirraLiveGateway {
-    pub fn new(proxy_port: u16, plc_target_port: u16, admin_port: u16, metrics_port: u16, config: ContractProfile, auth_key: Vec<u8>, max_threads: u32, log_dir: String) -> Self {
-        Self { proxy_port, plc_target_port, admin_reset_port: admin_port, metrics_port, runtime_config: config, system_auth_key: auth_key, max_allowed_workers: max_threads.max(1), log_directory: log_dir, io_writer_lock: Arc::new(Mutex::new(())) }
+    pub fn new(cfg: GatewayConfig) -> Self {
+        Self { proxy_port: cfg.proxy_port, plc_target_port: cfg.plc_target_port, admin_reset_port: cfg.admin_port, metrics_port: cfg.metrics_port, runtime_config: cfg.config, system_auth_key: cfg.auth_key, max_allowed_workers: cfg.max_threads.max(1), log_directory: cfg.log_dir, io_writer_lock: Arc::new(Mutex::new(())) }
     }
 
     fn read_exact_frame<R: Read>(stream: &mut R, expected_len: usize, buffer: &mut [u8]) -> Result<usize, std::io::Error> {
@@ -245,7 +258,17 @@ impl KirraLiveGateway {
                                     _ => GlobalSystemState::Degraded,
                                 };
 
-                                rec.log(now_ms, "NETWORK_PROXY", "SESSION_TOKEN", "MODBUS_WRITE", dynamic_resolution_text, system_state_enum, gov.trust_mode(), gov.trust_engine.current_score, intercept.mitigation_narrative.clone());
+                                rec.log(crate::kirra_core::JournalLogEntry {
+                                    ts: now_ms,
+                                    actor: "NETWORK_PROXY",
+                                    token: "SESSION_TOKEN",
+                                    action: "MODBUS_WRITE",
+                                    res: dynamic_resolution_text,
+                                    state: system_state_enum,
+                                    mode: gov.trust_mode(),
+                                    score: gov.trust_engine.current_score,
+                                    narrative: intercept.mitigation_narrative.clone(),
+                                });
                                 flush_payload = Some(rec.clone());
                             }
                             adapter_clone.encode_response(intercept.sanitized_scalar, raw_frame)

--- a/src/industrial_proxy.rs
+++ b/src/industrial_proxy.rs
@@ -125,17 +125,17 @@ impl LiveProtocolSimulator {
             crate::kirra_core::TrustMode::LockedOut => GlobalSystemState::Failsafe,
         };
 
-        self.recorder.log(
-            sim_time_ms,
-            "INDUSTRIAL_MASTER",
-            &format!("TX_{}", packet.extract_transaction_id()),
-            &format!("WRITE_REG_{}", packet.extract_target_register()),
-            if was_mitigated { "MUTATED_CLAMP" } else { "TRANSPARENT" },
-            system_state,
-            active_trust,
-            self.unified_governor.trust_evaluator.current_score,
-            result.mitigation_narrative.clone(),
-        );
+        self.recorder.log(crate::kirra_core::JournalLogEntry {
+            ts: sim_time_ms,
+            actor: "INDUSTRIAL_MASTER",
+            token: &format!("TX_{}", packet.extract_transaction_id()),
+            action: &format!("WRITE_REG_{}", packet.extract_target_register()),
+            res: if was_mitigated { "MUTATED_CLAMP" } else { "TRANSPARENT" },
+            state: system_state,
+            mode: active_trust,
+            score: self.unified_governor.trust_evaluator.current_score,
+            narrative: result.mitigation_narrative.clone(),
+        });
 
         ProxyResolutionSummary {
             outbound_bytes,

--- a/src/kirra_core.rs
+++ b/src/kirra_core.rs
@@ -238,12 +238,26 @@ impl Default for CausalFlightRecorder {
     }
 }
 
+/// Bundled parameters for [`CausalFlightRecorder::log`].
+#[derive(Debug, Clone)]
+pub struct JournalLogEntry<'a> {
+    pub ts: u64,
+    pub actor: &'a str,
+    pub token: &'a str,
+    pub action: &'a str,
+    pub res: &'a str,
+    pub state: GlobalSystemState,
+    pub mode: TrustMode,
+    pub score: u32,
+    pub narrative: String,
+}
+
 impl CausalFlightRecorder {
     pub fn new() -> Self { Self { journal: std::collections::VecDeque::new() } }
-    pub fn log(&mut self, ts: u64, actor: &str, token: &str, action: &str, res: &str, state: GlobalSystemState, mode: TrustMode, score: u32, narrative: String) {
+    pub fn log(&mut self, entry: JournalLogEntry<'_>) {
         self.journal.push_back(JournalEntry {
-            timestamp_ms: ts, actor: actor.to_string(), token: token.to_string(), action: action.to_string(), resolution: res.to_string(),
-            score, system_state: state, trust_mode: mode, operator_narrative: narrative,
+            timestamp_ms: entry.ts, actor: entry.actor.to_string(), token: entry.token.to_string(), action: entry.action.to_string(), resolution: entry.res.to_string(),
+            score: entry.score, system_state: entry.state, trust_mode: entry.mode, operator_narrative: entry.narrative,
         });
         if self.journal.len() > 100 { self.journal.pop_front(); }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 use std::env;
 use std::sync::mpsc::channel;
 use kirra_runtime_sdk::config::KirraRuntimeConfig;
-use kirra_runtime_sdk::gateway::KirraLiveGateway;
+use kirra_runtime_sdk::gateway::{KirraLiveGateway, GatewayConfig};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -33,16 +33,16 @@ fn main() {
 
     let secure_key = raw_key_string.into_bytes();
 
-    let interposer = KirraLiveGateway::new(
-        runtime_config.network.proxy_listen_port,
-        runtime_config.network.plc_target_port,
-        runtime_config.network.admin_reset_port,
-        runtime_config.network.metrics_http_port,
-        runtime_config.contract,
-        secure_key,
-        runtime_config.network.max_concurrent_connections,
-        runtime_config.telemetry.log_directory,
-    );
+    let interposer = KirraLiveGateway::new(GatewayConfig {
+        proxy_port: runtime_config.network.proxy_listen_port,
+        plc_target_port: runtime_config.network.plc_target_port,
+        admin_port: runtime_config.network.admin_reset_port,
+        metrics_port: runtime_config.network.metrics_http_port,
+        config: runtime_config.contract,
+        auth_key: secure_key,
+        max_threads: runtime_config.network.max_concurrent_connections,
+        log_dir: runtime_config.telemetry.log_directory,
+    });
 
     let (tx, rx) = channel();
     interposer.spawn_mock_plc_target(tx);

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -20,6 +20,19 @@ pub struct StructuredLogEvent {
     pub event_narrative: String,
 }
 
+/// Bundled parameters for [`EnterpriseTelemetryGateway::emit_structured_event`].
+#[derive(Debug, Clone)]
+pub struct StructuredEventInput<'a> {
+    pub severity: &'a str,
+    pub tx_id: u16,
+    pub offset: u16,
+    pub raw: f64,
+    pub sanitized: f64,
+    pub score: u32,
+    pub mode: &'a str,
+    pub narrative: &'a str,
+}
+
 pub struct EnterpriseTelemetryGateway { node_identifier: String }
 
 impl EnterpriseTelemetryGateway {
@@ -31,13 +44,13 @@ impl EnterpriseTelemetryGateway {
         format!("KIRRA-NODE-{}-{:04X}-SEQ-{}", self.node_identifier, tx_id, seq)
     }
 
-    pub fn emit_structured_event(&self, severity: &str, tx_id: u16, offset: u16, raw: f64, sanitized: f64, score: u32, mode: &str, narrative: &str) -> String {
+    pub fn emit_structured_event(&self, input: &StructuredEventInput<'_>) -> String {
         let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs();
         let event = StructuredLogEvent {
-            timestamp_epoch_secs: now, severity: severity.to_string(), node_id: self.node_identifier.clone(),
-            correlation_id: self.generate_correlation_id(tx_id), transaction_id: tx_id, register_offset: offset,
-            raw_demand: raw, sanitized_output: sanitized, trust_score: score, trust_mode: mode.to_string(),
-            event_narrative: narrative.to_string(),
+            timestamp_epoch_secs: now, severity: input.severity.to_string(), node_id: self.node_identifier.clone(),
+            correlation_id: self.generate_correlation_id(input.tx_id), transaction_id: input.tx_id, register_offset: input.offset,
+            raw_demand: input.raw, sanitized_output: input.sanitized, trust_score: input.score, trust_mode: input.mode.to_string(),
+            event_narrative: input.narrative.to_string(),
         };
         serde_json::to_string(&event).unwrap_or_else(|_| r#"{"error":"TELEMETRY_SERIALIZATION_FAILED"}"#.to_string())
     }

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -292,6 +292,24 @@ fn ledger_row_is_self_attested(r: &LedgerRow) -> bool {
     audit_verify_sig(&vk, &payload, &r.signature_b64)
 }
 
+/// Bundled event-data inputs for [`VerifierStore::append_causal_event`].
+///
+/// Groups the causal-event payload fields (everything that describes the event
+/// being appended). The `signing_key` is intentionally kept as a separate
+/// parameter on the method, since it is a distinct concern (signing identity,
+/// not event data).
+#[derive(Debug, Clone)]
+pub struct CausalEventInput<'a> {
+    pub entry_id: &'a str,
+    pub asset_id: &'a str,
+    pub event_type: &'a str,
+    pub payload: &'a str,
+    pub caused_by: &'a [String],
+    pub affects_assets: &'a [String],
+    pub fabric_generation: u64,
+    pub timestamp_ms: u64,
+}
+
 impl VerifierStore {
     pub fn new(path: &str) -> Result<Self> {
         let conn = Connection::open(path)?;
@@ -2291,19 +2309,21 @@ impl VerifierStore {
     /// the content-addressed `key_id`, INSERTs the row, and advances the signed
     /// causal anchor-head in the SAME transaction. Returns the fully-populated
     /// `CausalLogEntry`.
-    #[allow(clippy::too_many_arguments)]
     pub fn append_causal_event(
         &mut self,
-        entry_id: &str,
-        asset_id: &str,
-        event_type: &str,
-        payload: &str,
-        caused_by: &[String],
-        affects_assets: &[String],
-        fabric_generation: u64,
-        timestamp_ms: u64,
+        event: &CausalEventInput<'_>,
         signing_key: Option<&ed25519_dalek::SigningKey>,
     ) -> Result<crate::fabric::causal_log::CausalLogEntry> {
+        let CausalEventInput {
+            entry_id,
+            asset_id,
+            event_type,
+            payload,
+            caused_by,
+            affects_assets,
+            fabric_generation,
+            timestamp_ms,
+        } = *event;
         use crate::audit_chain::{
             canonical_causal_anchor_head_payload, canonical_causal_signing_payload,
             compute_causal_record_hash, verifying_key_id,
@@ -2327,18 +2347,19 @@ impl VerifierStore {
         };
         let sequence: u64 = (prev_seq + 1) as u64;
 
-        let record_hash = compute_causal_record_hash(
-            &previous_hash,
-            entry_id,
-            asset_id,
-            event_type,
-            payload,
-            caused_by,
-            affects_assets,
-            timestamp_ms,
-            fabric_generation,
-            sequence,
-        );
+        let record_hash =
+            compute_causal_record_hash(&crate::audit_chain::CausalRecordHashInput {
+                previous_hash: &previous_hash,
+                entry_id,
+                asset_id,
+                event_type,
+                payload,
+                caused_by,
+                affects_assets,
+                timestamp_ms,
+                fabric_generation,
+                sequence,
+            });
 
         let signature_b64: Option<String> = signing_key.map(|k| {
             let payload_str = canonical_causal_signing_payload(
@@ -2583,18 +2604,18 @@ impl VerifierStore {
             let caused_by: Vec<String> = serde_json::from_str(&caused_by_json).unwrap_or_default();
             let affects_assets: Vec<String> =
                 serde_json::from_str(&affects_json).unwrap_or_default();
-            let recalc = compute_causal_record_hash(
-                &previous_hash_hex,
-                &entry_id,
-                &asset_id,
-                &event_type,
-                &payload,
-                &caused_by,
-                &affects_assets,
-                timestamp_ms.max(0) as u64,
-                fabric_generation.max(0) as u64,
-                sequence.max(0) as u64,
-            );
+            let recalc = compute_causal_record_hash(&crate::audit_chain::CausalRecordHashInput {
+                previous_hash: &previous_hash_hex,
+                entry_id: &entry_id,
+                asset_id: &asset_id,
+                event_type: &event_type,
+                payload: &payload,
+                caused_by: &caused_by,
+                affects_assets: &affects_assets,
+                timestamp_ms: timestamp_ms.max(0) as u64,
+                fabric_generation: fabric_generation.max(0) as u64,
+                sequence: sequence.max(0) as u64,
+            });
             if recalc != record_hash_hex {
                 chain_intact = false;
             }
@@ -4431,12 +4452,21 @@ mod causal_chain_87_tests {
     fn append3_causal(s: &mut VerifierStore) {
         let sk = s.signing_key.clone();
         let id1 = "entry-1".to_string();
-        s.append_causal_event("entry-1", "leader", "FAULT", "{}",
-            &[], &["follower".to_string()], 1, 100, sk.as_ref()).unwrap();
-        s.append_causal_event("entry-2", "follower", "DEGRADE", "{}",
-            &[id1.clone()], &[], 1, 200, sk.as_ref()).unwrap();
-        s.append_causal_event("entry-3", "follower", "STOP", "{}",
-            &[id1], &["leader".to_string()], 2, 300, sk.as_ref()).unwrap();
+        s.append_causal_event(&CausalEventInput {
+            entry_id: "entry-1", asset_id: "leader", event_type: "FAULT", payload: "{}",
+            caused_by: &[], affects_assets: &["follower".to_string()],
+            fabric_generation: 1, timestamp_ms: 100,
+        }, sk.as_ref()).unwrap();
+        s.append_causal_event(&CausalEventInput {
+            entry_id: "entry-2", asset_id: "follower", event_type: "DEGRADE", payload: "{}",
+            caused_by: &[id1.clone()], affects_assets: &[],
+            fabric_generation: 1, timestamp_ms: 200,
+        }, sk.as_ref()).unwrap();
+        s.append_causal_event(&CausalEventInput {
+            entry_id: "entry-3", asset_id: "follower", event_type: "STOP", payload: "{}",
+            caused_by: &[id1], affects_assets: &["leader".to_string()],
+            fabric_generation: 2, timestamp_ms: 300,
+        }, sk.as_ref()).unwrap();
     }
 
     #[test]
@@ -4539,11 +4569,17 @@ mod causal_chain_87_tests {
         let entry_id;
         {
             let mut s = VerifierStore::new(&path_str).expect("file store");
-            let e = s.append_causal_event("persist-1", "a", "EVT", "{}",
-                &[], &["x".to_string()], 3, 1000, None).unwrap();
+            let e = s.append_causal_event(&CausalEventInput {
+                entry_id: "persist-1", asset_id: "a", event_type: "EVT", payload: "{}",
+                caused_by: &[], affects_assets: &["x".to_string()],
+                fabric_generation: 3, timestamp_ms: 1000,
+            }, None).unwrap();
             entry_id = e.entry_id.clone();
-            s.append_causal_event("persist-2", "b", "EVT2", "{}",
-                &[entry_id.clone()], &[], 3, 2000, None).unwrap();
+            s.append_causal_event(&CausalEventInput {
+                entry_id: "persist-2", asset_id: "b", event_type: "EVT2", payload: "{}",
+                caused_by: &[entry_id.clone()], affects_assets: &[],
+                fabric_generation: 3, timestamp_ms: 2000,
+            }, None).unwrap();
         } // drop closes the connection
 
         {


### PR DESCRIPTION
Closes #68.

Pure **behavior-preserving** refactor — no logic change. Resolves every `clippy::too_many_arguments` (threshold 7) by grouping each function's related parameters into a cohesive named struct, and removes the two now-unnecessary `#[allow(clippy::too_many_arguments)]` suppressions.

## Functions refactored (the complete set — 3 live + 2 previously suppressed)
| Function | File | Args | New param struct |
|---|---|---|---|
| `AuditJournal::log` | `kirra_core.rs` | 10 | `JournalLogEntry<'a>` |
| `emit_structured_event` | `telemetry.rs` | 9 | `StructuredEventInput<'a>` |
| `KirraLiveGateway::new` | `gateway/mod.rs` | 8 | `GatewayConfig` |
| `compute_causal_record_hash` | `audit_chain.rs` *(was suppressed)* | 10 | `CausalRecordHashInput<'a>` |
| `VerifierStore::append_causal_event` | `verifier_store.rs` *(was suppressed)* | 10 | `CausalEventInput<'a>` (+ `signing_key` kept separate) |

Every call site (~21 across `gateway/mod.rs`, `industrial_proxy.rs`, `main.rs`, `fabric/causal_log.rs`, `verifier_store.rs`, and the `audit_chain.rs` tests) was updated with an **identical field mapping** — no value dropped, added, defaulted, or reordered; the function bodies read the same fields in the same order (only the access path changed, e.g. `previous_hash` → `input.previous_hash`).

## Why this is safe
The `compute_causal_record_hash` body hashes its fields in the exact same domain-tagged, length-prefixed order — so the **hash-determinism + edge-tamper tests** in `audit_chain.rs` and the **persistence / SG-007** tests for `append_causal_event` pass **unchanged**. A dropped or reordered field would change the hash and fail those tests. That's the proof.

## Verification (independently re-run)
- `cargo clippy --all-targets` → **0** `too_many_arguments`, no new lints/errors.
- `cargo build` + `cargo test` → green: lib **579**, audit_chain **21**, verifier_store **64**, bins **21**, SG-007 propagation, parko-core/parko-kirra **92**.
- `grep -rn 'allow(clippy::too_many_arguments)' src/` → **empty**.
- `src/gateway/kinematics_contract.rs` (talisman) untouched and **not in the diff**.

Diff: 8 files, +255/−144. Staged explicitly (no `git add -A`).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_