### PR TITLE
chore(safety): canonical safety-goal ID scheme + reverse KIRRA-SG-001 drift (#160)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 
 | Document | Doc ID | Status |
 |----------|--------|--------|
 | Hazard Analysis and Risk Assessment (HARA) | KIRRA-HARA-001 | Draft |
-| Safety Goals | KIRRA-SG-001 | Draft |
+| Safety Goals | AEGIS-SG-001 | Draft |
 | Safety Architecture | KIRRA-SA-001 | Draft |
 | Requirements Traceability Matrix | KIRRA-RTM-001 | Draft |
 | Coding Guidelines | KIRRA-CG-001 | Draft |

--- a/docs/safety/ASTM_F3269_MAPPING.md
+++ b/docs/safety/ASTM_F3269_MAPPING.md
@@ -141,8 +141,8 @@ These invariants are verified by proptest properties in `src/gateway/kinematics_
 | RTA.2: The RTA monitor shall switch to the backup control law within the fault tolerant time interval | Posture transition to Degraded applies MRC profile to next command (synchronous, per-command FTTI) | FTTI for kinematic enforcement: per-command (< 1ms); FTTI for posture: AV_TELEMETRY_TIMEOUT_MS = 2000ms |
 | RTA.3: The backup control law shall keep the system within the recovery region | MRC Fallback Profile max_speed = 5.0 m/s is within the proven-safe region for all vehicle types | VehicleKinematicsContract::mrc_fallback_profile() |
 | RTA.4: The RTA monitor shall be independent of the primary function | Kirra is a separate process; primary function has no write access to Kirra state; admin token required for all mutations | Architectural separation; require_admin_token on all mutation routes |
-| RTA.5: The RTA monitor shall fail to a safe state | Stale posture cache → LockedOut (all commands denied). Absent env token → 503 fail-closed. Empty posture cache → LockedOut. Poisoned RwLock → LockedOut. | src/posture_cache.rs:should_route_command, AEGIS-SG-005 |
-| RTA.6: The RTA monitor shall record evidence of monitoring decisions | Every command evaluation generates an audit entry in the SHA-256 hash-chained audit log with Ed25519 signature | src/audit_chain.rs, AEGIS-SG-010 |
+| RTA.5: The RTA monitor shall fail to a safe state | Stale posture cache → LockedOut (all commands denied). Absent env token → 503 fail-closed. Empty posture cache → LockedOut. Poisoned RwLock → LockedOut. | src/posture_cache.rs:should_route_command, SG-005 |
+| RTA.6: The RTA monitor shall record evidence of monitoring decisions | Every command evaluation generates an audit entry in the SHA-256 hash-chained audit log with Ed25519 signature | src/audit_chain.rs, SG-010 |
 
 ---
 

--- a/docs/safety/SAFETY_GOALS.md
+++ b/docs/safety/SAFETY_GOALS.md
@@ -8,6 +8,20 @@ Date: 2026-05-23
 
 ---
 
+## Canonical Identifier Scheme
+
+- **`AEGIS-SG-001`** is the document ID of this document (immutable
+  cert-configuration lineage; retained across the Aegis→Kirra product
+  rename). It is a *document* identifier, never a goal identifier.
+- **Kernel/governor safety goals** are `SG-001`…`SG-016`, defined herein.
+- **Occy planner safety goals** are `SG1`…`SG9`, defined in
+  `OCCY_SAFETY_GOALS.md` (document ID `KIRRA-OCCY-SG-001`); the kernel↔Occy
+  cross-mapping is authoritative in `OCCY_SAFETY_GOALS.md` §6.2.
+- **Rule:** reference a goal as `SG-NNN` (kernel) or `SGN` (Occy). Do not
+  write `AEGIS-SG-NNN` for a goal; that prefix denotes the document only.
+
+---
+
 ## 1. Overview
 
 This document defines the Safety Goals (SG) derived from the Hazard Analysis and Risk Assessment (AEGIS-HARA-001). Each safety goal is assigned an ASIL level, a precise and testable goal statement, a safe state, a Fault Tolerant Time Interval (FTTI), and a verification method.

--- a/project-board/templates.md
+++ b/project-board/templates.md
@@ -116,7 +116,7 @@
 ### Traceability
 | Requirement | Source | Test |
 |-------------|--------|------|
-| <!-- KIRRA-SG-001 §X --> | <!-- src/kirra_core.rs:NN --> | <!-- test_rss_property --> |
+| <!-- AEGIS-SG-001 §X --> | <!-- src/kirra_core.rs:NN --> | <!-- test_rss_property --> |
 
 ### Notes
 <!-- Reference IEEE 2846 sections, ISO 26262 clauses, or HARA entries. -->


### PR DESCRIPTION
Closes #160.

**Documentation-only** consistency fix — no source-code logic change, behavior-preserving.

## Canonical scheme (now documented)
- **`AEGIS-SG-001`** is the immutable **document ID** of `docs/safety/SAFETY_GOALS.md` (cert-configuration lineage retained across the Aegis→Kirra rename) — a *document* identifier, **never** a goal identifier.
- **Kernel/governor** goals are `SG-001`…`SG-016`; **Occy planner** goals are `SG1`…`SG9` (`KIRRA-OCCY-SG-001`, cross-mapped in OCCY §6.2).
- **Rule:** reference a goal as `SG-NNN` (kernel) or `SGN` (Occy); `AEGIS-SG-NNN` must never denote a goal.

## Changes (exactly 4 files)
1. `README.md` — `KIRRA-SG-001` → `AEGIS-SG-001` (doc-ID drift).
2. `project-board/templates.md` — `KIRRA-SG-001` → `AEGIS-SG-001` (doc-ID drift).
3. `docs/safety/ASTM_F3269_MAPPING.md` — goal refs `AEGIS-SG-005` → `SG-005`, `AEGIS-SG-010` → `SG-010`.
4. `docs/safety/SAFETY_GOALS.md` — new **“Canonical Identifier Scheme”** section near the top.

Per-string edits, **not** a global replace — the legitimate `AEGIS-SG-001` doc-ID used correctly elsewhere (`SAFETY_CASE_INDEX`, `REQUIREMENTS_TRACEABILITY`, `HARA`, `IEC_61508_MAPPING`, …) and `KIRRA-OCCY-SG-001` are untouched.

## Verification
- `git diff --stat` → only the 4 files above; **`kinematics_contract.rs` not in the diff**.
- Talisman `src/gateway/kinematics_contract.rs` byte-identical at blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b`.
- `git grep 'KIRRA-SG-001'` → none; `git grep -E 'AEGIS-SG-(005|010)'` → none; the only `AEGIS-SG-NNN` in README/docs/project-board is `AEGIS-SG-001` (the doc-ID).

Diff: 4 files, +18/−4. Staged explicitly (no `git add -A`).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_