### PR TITLE
ci(parko): runtime-isolation guard + exclude parko-tensorrt from no-runtime lane (#146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Runtime-isolation guard (#146)
+        working-directory: parko
+        run: ci/check-runtime-isolation.sh
       - name: parko safety-critical tests
         # `parko/` is a separate workspace and the root `cargo test
         # --workspace` does NOT descend into it. Without this job the
@@ -96,20 +99,25 @@ jobs:
         # regression to e.g. the H1 angular cap would land on main with
         # CI green.
         #
-        # `--exclude parko-onnx --exclude parko-openvino` keeps this job
-        # runtime-free: BOTH backend crates dlopen a native inference runtime
-        # at OvBackend/OrtBackend::new (libopenvino_c.so / libonnxruntime.so)
-        # and panic without it, so their tests belong to the dedicated
-        # parko-onnx / parko-openvino jobs that install those runtimes. This
-        # job must gate purely on the runtime-free safety logic — without the
-        # parko-openvino exclude it ran the OpenVINO backend tests here and
-        # failed on "Unable to find the openvino_c library" (the crate was
-        # added in e4df0fa without updating this exclude). Future parko crates
-        # added to the sub-workspace are picked up automatically by
-        # `--workspace`; add an `--exclude` here only for runtime-dependent
-        # backends.
+        # This lane stays runtime-free by EXCLUDING every crate that dlopens a
+        # native inference runtime at backend `::new` (libopenvino_c.so /
+        # libonnxruntime.so) and panics without it — those tests belong to the
+        # dedicated parko-onnx / parko-openvino jobs that install the runtimes.
+        # The runtime-dependent backends are enumerated ONCE in
+        # `ci/runtime-dependent-crates.txt` (the single source of truth) and the
+        # `--exclude` flags below are derived from it. The preceding
+        # "Runtime-isolation guard" step (#146, `ci/check-runtime-isolation.sh`)
+        # FAILS this lane if a new ort/openvino/r2r-linked crate is added
+        # without being listed — closing the drift hole that previously let
+        # parko-openvino (added in e4df0fa) and parko-tensorrt run here
+        # runtime-free without an exclude. Future runtime-FREE parko crates are
+        # still picked up automatically by `--workspace`.
         working-directory: parko
-        run: cargo test --workspace --exclude parko-onnx --exclude parko-openvino
+        run: |
+          EXCLUDES=$(grep -vE '^[[:space:]]*(#|$)' ci/runtime-dependent-crates.txt \
+            | sed 's/^/--exclude /' | tr '\n' ' ')
+          echo "Excluding runtime-dependent backends: $EXCLUDES"
+          cargo test --workspace $EXCLUDES
 
   parko-onnx:
     name: Parko ONNX Backend Tests (ORT v1.23.2)

--- a/parko/ci/check-runtime-isolation.sh
+++ b/parko/ci/check-runtime-isolation.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# #146 guard: every parko member with a NON-OPTIONAL normal dep on a native
+# runtime crate (ort/ort-sys/openvino/r2r) MUST be listed in
+# ci/runtime-dependent-crates.txt, which the no-runtime gating lane excludes.
+# Exact-match (also catches stale list entries). Fails loudly on drift.
+set -euo pipefail
+cd "$(dirname "$0")/.."   # -> parko/
+LIST="ci/runtime-dependent-crates.txt"
+MARKERS="ort|ort-sys|openvino|r2r"
+declared=$(grep -vE '^[[:space:]]*(#|$)' "$LIST" | sort -u)
+detected=$(cargo metadata --no-deps --format-version 1 \
+  | jq -r --arg m "$MARKERS" '
+      .packages[] as $p
+      | $p.dependencies[]
+      | select(.kind == null)          # normal deps
+      | select(.optional == false)
+      | select(.name | test("^(" + $m + ")$"))
+      | $p.name' \
+  | sort -u)
+if [ "$declared" != "$detected" ]; then
+  echo "ERROR (#146 runtime-isolation guard): list vs reality mismatch."
+  echo "--- declared (ci/runtime-dependent-crates.txt) ---"; echo "$declared"
+  echo "--- detected (crates with a non-optional native-runtime dep) ---"; echo "$detected"
+  echo "Every crate that links a native inference/ROS runtime must be listed so"
+  echo "the no-runtime gating lane excludes it; remove stale entries that no longer apply."
+  exit 1
+fi
+echo "OK (#146): gating-lane exclude list matches runtime-dependent crates:"
+echo "$detected"

--- a/parko/ci/runtime-dependent-crates.txt
+++ b/parko/ci/runtime-dependent-crates.txt
@@ -1,0 +1,3 @@
+parko-onnx
+parko-openvino
+parko-tensorrt


### PR DESCRIPTION
Refs #146 (CI-guard half only — see scope note below).

## Problem
The **"Parko Safety Tests (no ROS, no ORT)"** gating lane hardcoded `--exclude parko-onnx --exclude parko-openvino`. But `parko-tensorrt` also has a **non-optional** normal dep on `ort` (load-dynamic), so it was **silently running in the runtime-free lane** — live drift that the hardcoded list let rot.

## Fix — make the exclude list un-rot-able
- **`parko/ci/runtime-dependent-crates.txt`** — single source of truth: the parko members that link a native inference/ROS runtime — `parko-onnx`, `parko-openvino`, `parko-tensorrt`. (`parko-ros2`'s `r2r` is `optional = true` → runtime-free by default, correctly **not** listed.)
- **`parko/ci/check-runtime-isolation.sh`** (mode `100755`) — derives the real set from `cargo metadata` (non-optional normal deps matching `ort|ort-sys|openvino|r2r`) and **fails the lane on any mismatch** vs the list — a newly-linked crate that isn't listed, or a stale entry that no longer links a runtime. Exact-match both directions.
- **`ci.yml`** — a guard step runs the check **before** the tests; the test command now **derives its `--exclude` flags from the list** (so the lane now also excludes `parko-tensorrt` — the fix). The job comment is updated to point at the list + guard instead of the old "add an `--exclude` here" guidance.

## Verified
- `ci/check-runtime-isolation.sh` → `OK` with the 3 crates (it **detects** `parko-tensorrt`, proving the drift).
- Removing `parko-tensorrt` from the list → guard exits **1** with the mismatch report; restored → `OK`.
- Derived flags: `--exclude parko-onnx --exclude parko-openvino --exclude parko-tensorrt`.
- `ci.yml` is valid YAML; the script is git-tracked at mode `100755`.
- Diff is **only** `.github/workflows/ci.yml` + the two new `parko/ci/` files — **no `src/`**; talisman `src/gateway/kinematics_contract.rs` byte-identical (blob `997fb7ae…`).

## Scope note
The **`ort` rc→GA version bump is out of scope** — there is no `ort 2.0.0` GA (latest is rc.12); that's tracked separately. This PR is the CI-guard half of #146 only, hence **Refs** (not Closes) #146.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_