### PR TITLE
deploy(parko): ort-cpu production backend image (ROS 2 Jazzy + ONNX Runtime 1.23.2) (#44)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -424,7 +424,8 @@ Every target has a real, ready-to-run procedure — not a "requires-SDK" refusal
 - **Container vs host.** Target-parameterized installer driving both, with
   per-target **base images** (CPU / Intel / L4T-Jetson / vendor) for the
   reproducible/pilot path. The gateway `Dockerfile`/`docker-compose.yml` are
-  **not forked**.
+  **not forked**. The ort-cpu (CPU) per-target image is
+  `deploy/docker/Dockerfile.parko-ort-cpu` (ROS 2 Jazzy + ONNX Runtime 1.23.2).
 
 ### Common safety gates (chipset-independent, NON-skippable)
 

--- a/deploy/docker/Dockerfile.parko-ort-cpu
+++ b/deploy/docker/Dockerfile.parko-ort-cpu
@@ -1,0 +1,112 @@
+# deploy/docker/Dockerfile.parko-ort-cpu
+#
+# #44 (PARK-032) — Parko inference runtime as a PER-TARGET backend image.
+# Scope = ort-cpu PRODUCTION (the only ready-now target). This is a NEW
+# per-target base image; the gateway `Dockerfile` / `docker-compose.yml` are
+# NOT forked (see INSTALL.md "Container vs host"). TensorRT (L4T/Jetson) and
+# OpenVINO (Intel) are per-target follow-ons.
+#
+# Base: ros:jazzy-ros-base (Ubuntu 24.04, glibc) — matches the ONNX Runtime
+# glibc .so and the project's ROS 2 distro (Jazzy). The node is built with
+# `--features ros2,onnx-backend` (ros2 → r2r, required by the [[bin]];
+# onnx-backend → the real OrtBackend instead of MockBackend).
+#
+# POSTURE: the ort-cpu posture (single-thread + GraphOptimizationLevel::Disable,
+# bitwise-reproducible) is parko-onnx's CODE DEFAULT — there is nothing to
+# configure and no posture config file is added.
+
+# =============================== BUILD STAGE ===============================
+FROM ros:jazzy-ros-base AS build
+SHELL ["/bin/bash", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+# 1. Build toolchain + native deps. clang/libclang → r2r bindgen; cmake → msg
+#    build; colcon + rosidl generators → build the curated autoware_*_msgs
+#    overlay so r2r_msg_gen can generate bindings against them.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates build-essential pkg-config \
+      clang libclang-dev cmake git \
+      python3-colcon-common-extensions \
+      ros-jazzy-rosidl-default-generators \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rust toolchain. No in-repo rust-toolchain.toml → stable (the crates are
+# edition 2021); honor a rust-toolchain.toml automatically if one is added.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --profile minimal --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# 2. ONNX Runtime CPU = EXACTLY v1.23.2 (linux-x64). NOT 1.24.x: rc.12 / ORT
+#    1.24.2 DEADLOCKS at OrtBackend::new (#144). v1.23.2 matches the pinned
+#    `ort = "=2.0.0-rc.11"` (ORT_API_VERSION 23). Installed at the exact path
+#    parko/.cargo/config.toml expects so cargo resolves ORT_DYLIB_PATH without
+#    an override. (Reuses the .github/workflows/ci.yml install step.)
+RUN set -euo pipefail; \
+    curl -L -o /tmp/onnxruntime-1.23.2.tgz \
+      https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-linux-x64-1.23.2.tgz; \
+    mkdir -p /root/.local/onnxruntime; \
+    tar -xzf /tmp/onnxruntime-1.23.2.tgz -C /root/.local/onnxruntime --strip-components=1; \
+    test -f /root/.local/onnxruntime/lib/libonnxruntime.so
+ENV ORT_DYLIB_PATH=/root/.local/onnxruntime/lib/libonnxruntime.so
+
+# 3. Repo.
+WORKDIR /build
+COPY . .
+
+# 4. Build the curated ROS 2 msgs overlay (autoware_*_msgs + kirra_safety),
+#    source it so AMENT_PREFIX_PATH exposes the curated msgs to r2r_msg_gen,
+#    then 5. cargo build the node + the fail-closed probe with the real ORT
+#    backend.
+#
+#    §7 note: a FRESH docker build has no stale r2r_msg_gen, so the usual
+#    `cargo clean -p r2r -p r2r_msg_gen` is NOT needed here — BUT if the build
+#    fails with `undefined symbol: ...autoware_*_msgs...` (MapProjectorInfo /
+#    AreaInfo / ControlHorizon / ... — types removed when the msgs were
+#    trimmed), that IS the §7 stale-codegen signature: uncomment the
+#    `cargo clean` below (fall back to a full `cargo clean`) and rebuild.
+RUN set -euo pipefail; \
+    source /opt/ros/jazzy/setup.bash; \
+    cd /build/ros2_ws && colcon build --merge-install && cd /build; \
+    source /build/ros2_ws/install/setup.bash; \
+    cd /build/parko; \
+    # cargo clean -p r2r -p r2r_msg_gen   # §7: enable only on the undefined-symbol signature above \
+    cargo build --release -p parko-ros2 --bin parko_ros2_node --features ros2,onnx-backend; \
+    cargo build --release -p parko-onnx --example backend_load_probe
+
+# ============================== RUNTIME STAGE ==============================
+# ros:jazzy-ros-base again — r2r needs rcl/rmw/typesupport at runtime.
+FROM ros:jazzy-ros-base AS runtime
+SHELL ["/bin/bash", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Artifacts: the v1.23.2 ORT .so, the node, the fail-closed probe, the curated
+# msgs overlay (for r2r typesupport at runtime), and a known-good sample model
+# the probe loads by default.
+COPY --from=build /root/.local/onnxruntime/lib/libonnxruntime.so /opt/parko/onnxruntime/lib/libonnxruntime.so
+COPY --from=build /build/parko/target/release/parko_ros2_node            /opt/parko/bin/parko_ros2_node
+COPY --from=build /build/parko/target/release/examples/backend_load_probe /opt/parko/bin/backend_load_probe
+COPY --from=build /build/ros2_ws/install                                  /opt/parko/ros2_ws/install
+COPY --from=build /build/parko/crates/parko-onnx/tests/data/mnist-12.onnx /opt/parko/models/mnist-12.onnx
+COPY --from=build /build/deploy/docker/parko-ort-cpu-entrypoint.sh        /usr/local/bin/parko-ort-cpu-entrypoint.sh
+
+# ORT_DYLIB_PATH ends in .../onnxruntime/lib/libonnxruntime.so — the layout
+# parko/.cargo/config.toml expects (the runtime user is non-root, so the .so
+# lives under /opt rather than the build stage's /root/.local). PARKO_MODEL_PATH
+# defaults to the baked sample so the fail-closed probe always has a model;
+# operators override it (volume/env) for real models. PARKO_OCCY_TOPOLOGY
+# selects the parallel-paths topology — see docs/safety/PARKO_OCCY_TOPOLOGY.md
+# (KIRRA-OCCY-TOPOLOGY-001).
+ENV ORT_DYLIB_PATH=/opt/parko/onnxruntime/lib/libonnxruntime.so \
+    PARKO_MODEL_PATH=/opt/parko/models/mnist-12.onnx \
+    PARKO_OCCY_TOPOLOGY=parallel
+
+# Non-root runtime user.
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin parko \
+    && chown -R parko:parko /opt/parko
+USER parko
+WORKDIR /opt/parko
+
+# The entrypoint sources ROS + the overlay, runs the FAIL-CLOSED backend-load
+# probe (refuses to start if the ORT CPU runtime didn't load), then execs the
+# node.
+ENTRYPOINT ["/usr/local/bin/parko-ort-cpu-entrypoint.sh"]

--- a/deploy/docker/parko-ort-cpu-entrypoint.sh
+++ b/deploy/docker/parko-ort-cpu-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# #44 ort-cpu PRODUCTION entrypoint.
+#
+# Sources the ROS 2 Jazzy environment + the curated msgs overlay, runs the
+# FAIL-CLOSED backend-load probe, and only then execs the node. If the ORT CPU
+# runtime does not actually load the model, the probe exits non-zero and this
+# script REFUSES to start the node — there is NO MockBackend fallback in the
+# production image.
+set -euo pipefail
+
+# ROS setup scripts reference unbound vars under `set -u`; relax around sourcing.
+set +u
+source /opt/ros/jazzy/setup.bash
+source /opt/parko/ros2_ws/install/setup.bash
+set -u
+
+# PARKO_BACKEND_PROBE gate: exits 0 ONLY if ORT CPU actually loaded the model.
+echo "PARKO_BACKEND_PROBE: validating ORT CPU backend load (${PARKO_MODEL_PATH})..."
+/opt/parko/bin/backend_load_probe "${PARKO_MODEL_PATH}"
+
+exec /opt/parko/bin/parko_ros2_node "$@"

--- a/parko/crates/parko-onnx/examples/backend_load_probe.rs
+++ b/parko/crates/parko-onnx/examples/backend_load_probe.rs
@@ -1,0 +1,54 @@
+//! #44 — fail-closed ORT-CPU backend-load probe for the production image.
+//!
+//! FLAGGED FOR REVIEW: this is the one small code addition the #44 task allows
+//! ("No src/ changes except (if unavoidable) a tiny load-probe; flag it"). A
+//! slim runtime image carries no `cargo`/source, so the existing
+//! `tests/test_onnx_backend.rs` cannot run there; this example reuses the SAME
+//! load path (`OrtBackend::new` + `load_model`) as a standalone probe binary the
+//! container entrypoint runs before exec'ing the node.
+//!
+//! Contract: exit 0 ONLY if the ORT CPU runtime actually loaded the model; any
+//! failure exits non-zero so the production entrypoint REFUSES to start (no
+//! MockBackend fallback in the production image). This generalizes the
+//! installer's `PARKO_BACKEND_PROBE` gate.
+//!
+//! Model path: `argv[1]` or `$PARKO_MODEL_PATH` (the image bakes a known-good
+//! mnist sample as the default so the probe always has a model to load).
+
+use parko_core::backend::InferenceBackend;
+use parko_onnx::OrtBackend;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let model_path = std::env::args()
+        .nth(1)
+        .or_else(|| std::env::var("PARKO_MODEL_PATH").ok())
+        .unwrap_or_default();
+    if model_path.is_empty() {
+        eprintln!("PARKO_BACKEND_PROBE: FAIL — no model path (argv[1] or PARKO_MODEL_PATH)");
+        return ExitCode::FAILURE;
+    }
+
+    // OrtBackend::new dlopens libonnxruntime.so via ORT_DYLIB_PATH — this is the
+    // load that fails closed if the ORT CPU runtime is missing/mismatched.
+    let backend = match OrtBackend::new(model_path.as_str()) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("PARKO_BACKEND_PROBE: FAIL — OrtBackend::new('{model_path}'): {e:?}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match backend.load_model(model_path.as_str()) {
+        Ok(_) => {
+            println!(
+                "PARKO_BACKEND_PROBE: OK — ORT CPU runtime loaded and model introspected ({model_path})"
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("PARKO_BACKEND_PROBE: FAIL — load_model('{model_path}'): {e:?}");
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
Refs #44 (PARK-032) — see the closure note below.

Packages the Parko inference runtime as a **per-target backend image**, scope = **ort-cpu production** (the only ready-now target). New artifact only — the gateway `Dockerfile` / `docker-compose.yml` are **not forked** (per INSTALL.md "Container vs host"). TensorRT (L4T/Jetson) and OpenVINO (Intel) are per-target follow-ons.

## Deliverable
`deploy/docker/Dockerfile.parko-ort-cpu` — multi-stage on **`ros:jazzy-ros-base`** (Ubuntu 24.04, glibc; the project's ROS 2 distro):
- **Build stage:** Rust (stable; no in-repo `rust-toolchain.toml`) + `clang`/`libclang`/`cmake`/`colcon` + rosidl generators → installs **ONNX Runtime CPU v1.23.2** (linux-x64) at the path `parko/.cargo/config.toml` expects → `colcon build` the curated `autoware_*_msgs` + `kirra_safety` overlay (so `r2r_msg_gen` binds against it via `AMENT_PREFIX_PATH`) → `cargo build --release -p parko-ros2 --bin parko_ros2_node --features ros2,onnx-backend` (real `OrtBackend`, not `MockBackend`) + the probe.
- **Runtime stage:** `ros:jazzy-ros-base` (rcl/rmw/typesupport for r2r); copies the `libonnxruntime.so`, node, probe, the overlay `install/`, and a baked sample model; non-root user; entrypoint runs the fail-closed probe then execs the node.

## Key decisions
- **ONNX Runtime pinned EXACTLY v1.23.2** (matches `ort = "=2.0.0-rc.11"`, `ORT_API_VERSION 23`). `1.24.x` (rc.12) **deadlocks at `OrtBackend::new`** (#144) — the only `1.24` strings in the Dockerfile are that rejected-version rationale; the install is 1.23.2. Reuses the CI install step.
- **Fail-closed load probe (`PARKO_BACKEND_PROBE`):** ⚠️ **the one code addition** the task permits and I'm flagging — a small `parko-onnx` example (`examples/backend_load_probe.rs`) reusing `OrtBackend::new` + `load_model` on the bundled `mnist-12.onnx`. A slim runtime image can't run `cargo test`, so this standalone probe binary is built in the build stage and the entrypoint **refuses to start if ORT didn't load** (no MockBackend fallback in production).
- **Posture:** ort-cpu single-thread + `GraphOptimizationLevel::Disable` (bitwise-reproducible) is parko-onnx's **code default** — nothing configured, no posture file (documented in a Dockerfile comment).
- `INSTALL.md`: one-line pointer to the per-target image (no restructure).

## Verified (statically; the docker build itself is Jazzy-bench-gated)
- Probe example **compiles** (`cargo build -p parko-onnx --example backend_load_probe`).
- Dockerfile install version = `1.23.2`; features `ros2,onnx-backend`; `ORT_DYLIB_PATH` matches the `parko/.cargo/config.toml` layout (`.../onnxruntime/lib/libonnxruntime.so`).
- Entrypoint git mode `100755`, `bash -n` clean.
- Diff is 4 files; **no** gateway `Dockerfile`/`docker-compose.yml`/`Dockerfile.native` or `src/gateway`; talisman `src/gateway/kinematics_contract.rs` byte-identical (blob `997fb7ae…`).

## Closure
**Refs**, not Closes — #44 should close only once the image **builds and the probe passes on the Jazzy bench** (can't run a glibc/ROS docker build or load real ORT in the authoring sandbox).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_