### PR TITLE
feat(parko-kirra): durable signed ComparatorDivergence audit sink (CERT-006)

### DIFF
--- a/docs/safety/COMPARATOR_DIVERSITY.md
+++ b/docs/safety/COMPARATOR_DIVERSITY.md
@@ -31,8 +31,11 @@ The `GovernorComparator` is Kirra's software lockstep: it runs two safety
 governors on the same input each tick and compares their outputs. On a
 persistent divergence (and once the vehicle is at a safe speed) it escalates
 to a fail-closed `Deny` (LockedOut). The escalation, leaky-bucket
-accumulator, speed gate and audit sink are unchanged by this work — see the
-`comparator.rs` module documentation.
+accumulator and speed gate are unchanged by this work — see the
+`comparator.rs` module documentation. The **divergence sink** (where each
+detected divergence is recorded) is now selectable per deployment: an
+ephemeral in-memory buffer (dev/test) or a durable, Ed25519-signed,
+hash-chained audit ledger (production). See §7a.
 
 Until CERT-006-diversity, the comparator ran **two identical
 `KirraGovernor` instances**. Identical redundancy detects:
@@ -183,6 +186,40 @@ is materially more effort and is **not** built in this deliverable.
   comparator is now generic over the shadow type (default
   `DiverseKirraGovernor`; a second `KirraGovernor` still constructs the
   legacy identical-redundancy comparator for tests).
+
+## 7a. Durable divergence audit sink (CERT-006 follow-up)
+
+A divergence the comparator *detects but does not durably record* is itself
+safety-relevant: a post-incident investigation needs a tamper-evident trail of
+every time the primary and shadow governors disagreed. The reference node
+(`parko-ros2`) therefore wires the comparator to a sink selected fail-closed
+from two environment variables:
+
+| `PARKO_DIVERGENCE_AUDIT_DB` | `KIRRA_LOG_SIGNING_KEY` | Sink selected | Notes |
+|---|---|---|---|
+| unset / empty | unset | in-memory (ephemeral) | node emits a loud `WARN`; **not** certification-grade — divergences are lost on restart |
+| unset / empty | set | in-memory (ephemeral) | a signing key with no DB is inert; same `WARN` |
+| set | set (valid) + store opens | **durable + signed** | divergences appended to the SDK's hash-chained `audit_log_chain`, Ed25519-signed with the supplied key |
+| set | unset | **FATAL — node exits non-zero** | a durable audit was requested but would be unsigned (not tamper-evident); no silent fallback |
+| set | set but invalid, OR store will not open | **FATAL — node exits non-zero** | no silent fallback to an ephemeral/unsigned sink |
+
+The selection logic is `parko_kirra::select_divergence_sink`; the durable sink
+is `AuditChainLinkerDivergenceSink`, which records each divergence through the
+SDK's `VerifierStore::save_posture_event_chained` with event type
+`"ComparatorDivergence"` and the JSON-serialised `DivergenceEvent` as the body.
+A persistence failure is never swallowed: it increments an operator-observable
+`write_failures` counter and logs loudly.
+
+**Scope of the durability claim (honest limits):**
+
+- The chain is **node-local**. Each `parko-ros2` node signs its own divergence
+  ledger with `KIRRA_LOG_SIGNING_KEY`. It is hash-linked and signature-verifiable
+  (`verify_audit_chain_full`), but it does **not** yet participate in the
+  verifier's `#165` key-adoption / lineage trust map, and divergences are **not**
+  forwarded to the central verifier audit chain. Cross-node correlation and
+  fleet-level key trust are a tracked follow-up, not part of this deliverable.
+- The signing key is supplied via env (`KIRRA_LOG_SIGNING_KEY`); key custody,
+  rotation and HSM-backing are deployment concerns outside this document.
 
 ## 8. Status
 

--- a/parko/crates/parko-kirra/Cargo.toml
+++ b/parko/crates/parko-kirra/Cargo.toml
@@ -12,10 +12,13 @@ kirra-runtime-sdk = { path = "../../.." }
 # it through the SDK's hash-chained, signed audit log (VerifierStore).
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# `AuditChainLinkerDivergenceSink::open` parses a base64-encoded Ed25519 signing
+# key (KIRRA_LOG_SIGNING_KEY) in non-test code, so these are regular deps.
+ed25519-dalek = { version = "2" }
+base64 = "0.22"
 
 [dev-dependencies]
 proptest = "1"
-# Durability + signing test for AuditChainLinkerDivergenceSink: a real signing
-# key + a file-backed SQLite audit chain.
-ed25519-dalek = { version = "2" }
+# Durability + signing test for AuditChainLinkerDivergenceSink: a file-backed
+# SQLite audit chain.
 tempfile = "3"

--- a/parko/crates/parko-kirra/Cargo.toml
+++ b/parko/crates/parko-kirra/Cargo.toml
@@ -8,6 +8,14 @@ license = "Apache-2.0"
 [dependencies]
 parko-core = { path = "../parko-core" }
 kirra-runtime-sdk = { path = "../../.." }
+# CERT-006 durable divergence sink: serialise DivergenceEvent → JSON and persist
+# it through the SDK's hash-chained, signed audit log (VerifierStore).
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 proptest = "1"
+# Durability + signing test for AuditChainLinkerDivergenceSink: a real signing
+# key + a file-backed SQLite audit chain.
+ed25519-dalek = { version = "2" }
+tempfile = "3"

--- a/parko/crates/parko-kirra/src/audit_sink.rs
+++ b/parko/crates/parko-kirra/src/audit_sink.rs
@@ -19,12 +19,71 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
+use base64::Engine as _;
+use ed25519_dalek::SigningKey;
 use kirra_runtime_sdk::verifier_store::VerifierStore;
 
-use crate::comparator::{DivergenceEvent, DivergenceEventSink};
+use crate::comparator::{DivergenceEvent, DivergenceEventSink, InMemoryDivergenceSink};
 
 /// The audit-log event type for a comparator divergence (the doc-spec name).
 pub const COMPARATOR_DIVERGENCE_EVENT_TYPE: &str = "ComparatorDivergence";
+
+/// A fail-closed misconfiguration of the durable divergence sink (CERT-006).
+///
+/// The reference node treats every variant as FATAL: a deployment that asked
+/// for a durable audit (`PARKO_DIVERGENCE_AUDIT_DB` set) but cannot produce a
+/// *signed, persisted* record must NOT silently fall back to the ephemeral
+/// in-memory sink — that would leave comparator divergences unaudited while the
+/// operator believes they are captured.
+#[derive(Debug)]
+pub enum FatalAuditConfig {
+    /// A durable DB was requested but no signing key was supplied. The audit
+    /// chain would be persisted but UNSIGNED — not tamper-evident — so reject.
+    MissingSigningKey,
+    /// The supplied signing key could not be decoded into an Ed25519 key
+    /// (bad base64, or not 32 bytes).
+    InvalidSigningKey(String),
+    /// The SQLite audit store at the requested path could not be opened.
+    StoreOpenFailed(String),
+}
+
+impl std::fmt::Display for FatalAuditConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FatalAuditConfig::MissingSigningKey => write!(
+                f,
+                "PARKO_DIVERGENCE_AUDIT_DB is set but KIRRA_LOG_SIGNING_KEY is unset — \
+                 a durable divergence audit must be signed (tamper-evident); refusing to \
+                 persist an unsigned chain"
+            ),
+            FatalAuditConfig::InvalidSigningKey(why) => write!(
+                f,
+                "KIRRA_LOG_SIGNING_KEY is not a valid base64 Ed25519 signing key: {why}"
+            ),
+            FatalAuditConfig::StoreOpenFailed(why) => write!(
+                f,
+                "could not open the divergence audit store (PARKO_DIVERGENCE_AUDIT_DB): {why}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FatalAuditConfig {}
+
+/// Decode a base64-encoded 32-byte Ed25519 signing key (the same encoding the
+/// verifier service accepts for `KIRRA_LOG_SIGNING_KEY`).
+fn parse_signing_key(key_b64: &str) -> Result<SigningKey, FatalAuditConfig> {
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(key_b64.trim())
+        .map_err(|e| FatalAuditConfig::InvalidSigningKey(e.to_string()))?;
+    let bytes: [u8; 32] = raw.as_slice().try_into().map_err(|_| {
+        FatalAuditConfig::InvalidSigningKey(format!(
+            "expected 32 key bytes, got {}",
+            raw.len()
+        ))
+    })?;
+    Ok(SigningKey::from_bytes(&bytes))
+}
 
 /// Durable, signed [`DivergenceEventSink`] (CERT-006).
 ///
@@ -49,6 +108,18 @@ impl AuditChainLinkerDivergenceSink {
             store,
             write_failures: AtomicU64::new(0),
         }
+    }
+
+    /// Open a durable, *signed* divergence sink from a DB path and a base64
+    /// Ed25519 signing key. Fail-closed: a store that cannot be opened, or a key
+    /// that cannot be decoded, is a [`FatalAuditConfig`] — never a silent
+    /// fallback to an unsigned or ephemeral sink.
+    pub fn open(db_path: &str, key_b64: &str) -> Result<Self, FatalAuditConfig> {
+        let key = parse_signing_key(key_b64)?;
+        let mut store = VerifierStore::new(db_path)
+            .map_err(|e| FatalAuditConfig::StoreOpenFailed(e.to_string()))?;
+        store.set_signing_key(key);
+        Ok(Self::new(Arc::new(Mutex::new(store))))
     }
 
     /// Number of divergences that were DETECTED but could NOT be durably +
@@ -109,6 +180,37 @@ impl DivergenceEventSink for AuditChainLinkerDivergenceSink {
                  divergence detected but NOT in the tamper-evident log"
             );
         }
+    }
+}
+
+/// Select the divergence sink for a deployment from its two environment
+/// inputs, applying the CERT-006 fail-closed contract:
+///
+/// | `db` (`PARKO_DIVERGENCE_AUDIT_DB`) | `key` (`KIRRA_LOG_SIGNING_KEY`) | result |
+/// |---|---|---|
+/// | unset | unset | `Ok` ephemeral in-memory sink — caller MUST warn (non-cert) |
+/// | unset | set   | `Ok` ephemeral in-memory sink — caller MUST warn (non-cert) |
+/// | set   | set, valid, store opens | `Ok` durable + signed sink |
+/// | set   | unset | `Err(MissingSigningKey)` — would be unsigned |
+/// | set   | invalid key OR store unopenable | `Err(...)` — no silent fallback |
+///
+/// The key insight: a durable audit was *requested* (db set) but cannot be made
+/// tamper-evident → FATAL. The caller (the reference node) exits non-zero.
+pub fn select_divergence_sink(
+    db: Option<String>,
+    key: Option<String>,
+) -> Result<Arc<dyn DivergenceEventSink>, FatalAuditConfig> {
+    match db.as_deref() {
+        // No durable DB requested → ephemeral sink (the caller warns it is
+        // non-cert / divergences are not persisted). A stray signing key with
+        // no DB is harmless: nothing to sign.
+        None | Some("") => Ok(Arc::new(InMemoryDivergenceSink::new())),
+        Some(db_path) => match key.as_deref() {
+            None | Some("") => Err(FatalAuditConfig::MissingSigningKey),
+            Some(key_b64) => Ok(Arc::new(AuditChainLinkerDivergenceSink::open(
+                db_path, key_b64,
+            )?)),
+        },
     }
 }
 
@@ -192,6 +294,113 @@ mod tests {
             sink.write_failures(),
             1,
             "a divergence that could not be durably recorded MUST be counted, not swallowed"
+        );
+    }
+
+    /// Base64-encode a 32-byte key the way `KIRRA_LOG_SIGNING_KEY` is supplied.
+    fn key_b64(seed: u8) -> String {
+        base64::engine::general_purpose::STANDARD.encode([seed; 32])
+    }
+
+    // --- TASK 3a: `select_divergence_sink` fail-closed contract -------------
+
+    /// db unset + key unset → ephemeral in-memory sink (caller warns).
+    #[test]
+    fn select_neither_set_yields_in_memory_sink() {
+        let sink = select_divergence_sink(None, None).expect("in-memory is Ok");
+        // It records without panicking and is NOT durable (nothing to assert on
+        // disk) — exercising it proves the trait object is usable.
+        sink.record(sample_event());
+    }
+
+    /// db unset + key set → still ephemeral (a key with no DB is harmless).
+    #[test]
+    fn select_key_without_db_yields_in_memory_sink() {
+        let sink =
+            select_divergence_sink(None, Some(key_b64(9))).expect("in-memory is Ok");
+        sink.record(sample_event());
+    }
+
+    /// An empty DB string is treated as unset (env vars are often set to "").
+    #[test]
+    fn select_empty_db_string_is_treated_as_unset() {
+        let sink = select_divergence_sink(Some(String::new()), Some(key_b64(9)))
+            .expect("empty db == unset → in-memory Ok");
+        sink.record(sample_event());
+    }
+
+    /// db set + key UNSET → fatal: a durable audit was requested but would be
+    /// unsigned. No silent fallback.
+    #[test]
+    fn select_db_without_key_is_fatal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("audit.sqlite");
+        let res = select_divergence_sink(Some(db.to_str().unwrap().to_string()), None);
+        assert!(
+            matches!(res, Err(FatalAuditConfig::MissingSigningKey)),
+            "durable audit with no signing key must be fatal"
+        );
+    }
+
+    /// db set + key set but UNDECODABLE → fatal, not a fallback.
+    #[test]
+    fn select_db_with_invalid_key_is_fatal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("audit.sqlite");
+        let res = select_divergence_sink(
+            Some(db.to_str().unwrap().to_string()),
+            Some("not-valid-base64-!!!".to_string()),
+        );
+        assert!(
+            matches!(res, Err(FatalAuditConfig::InvalidSigningKey(_))),
+            "an undecodable signing key must be fatal"
+        );
+    }
+
+    /// A well-formed base64 string of the wrong length is also fatal.
+    #[test]
+    fn select_db_with_wrong_length_key_is_fatal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("audit.sqlite");
+        let short = base64::engine::general_purpose::STANDARD.encode([1u8; 16]);
+        let res = select_divergence_sink(Some(db.to_str().unwrap().to_string()), Some(short));
+        assert!(
+            matches!(res, Err(FatalAuditConfig::InvalidSigningKey(_))),
+            "a 16-byte key must be fatal"
+        );
+    }
+
+    /// db set + valid key + openable store → durable, SIGNED sink, end-to-end:
+    /// a recorded divergence verifies under the supplied key's public half.
+    #[test]
+    fn select_db_and_valid_key_yields_durable_signed_sink() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("audit.sqlite");
+        let db_path = db.to_str().unwrap().to_string();
+
+        let key = SigningKey::from_bytes(&[5u8; 32]);
+        let vk = key.verifying_key();
+        let b64 = base64::engine::general_purpose::STANDARD.encode(key.to_bytes());
+
+        let sink = select_divergence_sink(Some(db_path.clone()), Some(b64))
+            .expect("durable sink with a valid key is Ok");
+        sink.record(sample_event());
+
+        // Re-open the same DB and prove the entry is durable + signed.
+        let verifier = VerifierStore::new(&db_path).expect("re-open store");
+        let v = verifier
+            .verify_audit_chain_full(Some(&vk))
+            .expect("verify chain");
+        assert!(v.chain_intact, "chain must be hash-intact");
+        assert!(v.signature_valid, "signature must verify under the key");
+        assert!(v.signed_entries >= 1, "the divergence entry must be signed");
+
+        let events = verifier.load_all_posture_events().expect("load events");
+        assert!(
+            events
+                .iter()
+                .any(|e| e["event_type"] == COMPARATOR_DIVERGENCE_EVENT_TYPE),
+            "a ComparatorDivergence audit entry must be persisted"
         );
     }
 }

--- a/parko/crates/parko-kirra/src/audit_sink.rs
+++ b/parko/crates/parko-kirra/src/audit_sink.rs
@@ -1,0 +1,197 @@
+//! CERT-006 — durable, signed production sink for `ComparatorDivergence` events.
+//!
+//! [`crate::comparator::InMemoryDivergenceSink`] is ephemeral + unsigned (dev /
+//! test only). A production deployment MUST wire a sink that persists every
+//! divergence to a tamper-evident record — this module provides it.
+//!
+//! [`AuditChainLinkerDivergenceSink`] holds the SDK's [`VerifierStore`] (the
+//! handle that owns the hash-chained `audit_log_chain` ledger + the Ed25519
+//! signing key) and records each divergence via
+//! [`VerifierStore::save_posture_event_chained`], which appends through
+//! `AuditChainLinker::append_audit_event_tx` — the same signed, hash-linked
+//! ledger the verifier service writes — with event type `"ComparatorDivergence"`
+//! and the JSON-serialised [`DivergenceEvent`] as the body.
+//!
+//! NOTE: `save_posture_event_chained` also writes a `posture_events` row in the
+//! same transaction; that row is incidental — the authoritative, contract-
+//! specified artifact is the signed `audit_log_chain` entry.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use kirra_runtime_sdk::verifier_store::VerifierStore;
+
+use crate::comparator::{DivergenceEvent, DivergenceEventSink};
+
+/// The audit-log event type for a comparator divergence (the doc-spec name).
+pub const COMPARATOR_DIVERGENCE_EVENT_TYPE: &str = "ComparatorDivergence";
+
+/// Durable, signed [`DivergenceEventSink`] (CERT-006).
+///
+/// Persists every divergence to the SDK's hash-chained, Ed25519-signed audit
+/// ledger. `record` is infallible by the trait contract — but a divergence that
+/// is *detected yet not durably recorded* is itself safety-relevant, so a
+/// persistence failure is never silently swallowed: it increments the
+/// operator-observable [`write_failures`](Self::write_failures) counter and logs
+/// loudly to stderr (matching the in-crate sink convention).
+pub struct AuditChainLinkerDivergenceSink {
+    store: Arc<Mutex<VerifierStore>>,
+    write_failures: AtomicU64,
+}
+
+impl AuditChainLinkerDivergenceSink {
+    /// Build a sink over an SDK store. The store MUST own the audit chain (it
+    /// does — `VerifierStore::new` creates `audit_log_chain`) and a signing key
+    /// (set via `VerifierStore::set_signing_key` / `admit_signing_key`) for the
+    /// entries to be signed.
+    pub fn new(store: Arc<Mutex<VerifierStore>>) -> Self {
+        Self {
+            store,
+            write_failures: AtomicU64::new(0),
+        }
+    }
+
+    /// Number of divergences that were DETECTED but could NOT be durably +
+    /// signed. MUST be `0` in a healthy deployment; a non-zero value means the
+    /// tamper-evident record is MISSING for that many divergences — observe it.
+    pub fn write_failures(&self) -> u64 {
+        self.write_failures.load(Ordering::SeqCst)
+    }
+
+    fn note_failure(&self) {
+        self.write_failures.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0)
+    }
+}
+
+impl DivergenceEventSink for AuditChainLinkerDivergenceSink {
+    fn record(&self, event: DivergenceEvent) {
+        let body = match serde_json::to_string(&event) {
+            Ok(s) => s,
+            Err(e) => {
+                self.note_failure();
+                eprintln!(
+                    "[CERT-006] ComparatorDivergence NOT recorded — JSON serialization failed: \
+                     {e} (divergence is UNAUDITED)"
+                );
+                return;
+            }
+        };
+
+        let outcome = match self.store.lock() {
+            Ok(mut store) => store.save_posture_event_chained(
+                "governor_comparator",
+                COMPARATOR_DIVERGENCE_EVENT_TYPE,
+                &body,
+                None,
+                Self::now_ms(),
+            ),
+            Err(_) => {
+                self.note_failure();
+                eprintln!(
+                    "[CERT-006] ComparatorDivergence NOT recorded — audit store mutex poisoned \
+                     (divergence is UNAUDITED)"
+                );
+                return;
+            }
+        };
+
+        if let Err(e) = outcome {
+            self.note_failure();
+            eprintln!(
+                "[CERT-006] AUDIT-CHAIN WRITE FAILED for ComparatorDivergence: {e} — \
+                 divergence detected but NOT in the tamper-evident log"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn sample_event() -> DivergenceEvent {
+        DivergenceEvent {
+            primary_lin: 3.0,
+            shadow_lin: 0.0,
+            delta_lin: 3.0,
+            primary_ang: 0.1,
+            shadow_ang: 0.0,
+            delta_ang: 0.1,
+            accumulator: 7,
+            current_speed_mps: Some(2.5),
+            reconciled_lin: 0.0,
+            reconciled_ang: 0.0,
+            escalated_to_lockout: true,
+        }
+    }
+
+    /// TASK 2 — a real signing key + file-backed audit chain: the recorded
+    /// divergence is DURABLE, hash-linked, and its signature VERIFIES (distinct
+    /// from the in-memory emission test, which only proves buffering).
+    #[test]
+    fn divergence_is_durably_recorded_signed_and_hash_linked() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("divergence_audit.sqlite");
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let vk = key.verifying_key();
+
+        let mut store = VerifierStore::new(db.to_str().unwrap()).expect("store");
+        store.set_signing_key(key);
+        let store = Arc::new(Mutex::new(store));
+
+        let sink = AuditChainLinkerDivergenceSink::new(Arc::clone(&store));
+        sink.record(sample_event());
+        assert_eq!(sink.write_failures(), 0, "the divergence must have been durably recorded");
+
+        let guard = store.lock().unwrap();
+
+        // Durable + hash-linked + SIGNED (verifies under the real key).
+        let v = guard.verify_audit_chain_full(Some(&vk)).expect("verify");
+        assert!(v.chain_intact, "audit chain must be hash-intact");
+        assert!(v.signature_valid, "the signature must verify under the signing key");
+        assert!(v.signed_entries >= 1, "the divergence entry must be signed, got {}", v.signed_entries);
+
+        // The entry is a `ComparatorDivergence` carrying the event body.
+        let events = guard.load_all_posture_events().expect("load events");
+        let div = events
+            .iter()
+            .find(|e| e["event_type"] == COMPARATOR_DIVERGENCE_EVENT_TYPE)
+            .expect("a ComparatorDivergence audit entry must exist");
+        assert_eq!(div["posture"]["escalated_to_lockout"], true);
+        assert_eq!(div["posture"]["accumulator"], 7);
+    }
+
+    /// A persistence failure (poisoned store) is surfaced via `write_failures`,
+    /// never silently swallowed — a detected-but-unaudited divergence is itself
+    /// safety-relevant.
+    #[test]
+    fn persistence_failure_is_surfaced_not_swallowed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("divergence_audit.sqlite");
+        let store = Arc::new(Mutex::new(VerifierStore::new(db.to_str().unwrap()).expect("store")));
+
+        // Poison the store mutex so the audit write cannot land.
+        let s = Arc::clone(&store);
+        let _ = std::thread::spawn(move || {
+            let _g = s.lock().unwrap();
+            panic!("poison the audit store for the failure test");
+        })
+        .join();
+
+        let sink = AuditChainLinkerDivergenceSink::new(Arc::clone(&store));
+        sink.record(sample_event());
+        assert_eq!(
+            sink.write_failures(),
+            1,
+            "a divergence that could not be durably recorded MUST be counted, not swallowed"
+        );
+    }
+}

--- a/parko/crates/parko-kirra/src/comparator.rs
+++ b/parko/crates/parko-kirra/src/comparator.rs
@@ -105,7 +105,7 @@ const DIVERGENCE_LOCKOUT_MIN_DURATION_MS: u64 = 2_000;
 /// CERT-006 v3 added the four `*_ang` fields so the audit record captures
 /// angular-axis divergence (previously invisible to the comparator). The
 /// `*_lin` fields are the prior `*_vel` fields renamed for clarity.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct DivergenceEvent {
     pub primary_lin: f64,
     pub shadow_lin: f64,

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -49,7 +49,9 @@ pub mod audit_sink;
 pub mod comparator;
 pub mod diverse;
 pub use angular_bound::{AngularVelocityBound, PlatformParams, ROLLOVER_MIN_LINEAR_VELOCITY_MPS};
-pub use audit_sink::AuditChainLinkerDivergenceSink;
+pub use audit_sink::{
+    select_divergence_sink, AuditChainLinkerDivergenceSink, FatalAuditConfig,
+};
 pub use comparator::{GovernorComparator, RssAwareGovernor};
 pub use diverse::DiverseKirraGovernor;
 

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -45,9 +45,11 @@ use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
 use parko_core::{AgentScene, RssParams, RssState, MAX_RSS_AGENTS};
 
 pub mod angular_bound;
+pub mod audit_sink;
 pub mod comparator;
 pub mod diverse;
 pub use angular_bound::{AngularVelocityBound, PlatformParams, ROLLOVER_MIN_LINEAR_VELOCITY_MPS};
+pub use audit_sink::AuditChainLinkerDivergenceSink;
 pub use comparator::{GovernorComparator, RssAwareGovernor};
 pub use diverse::DiverseKirraGovernor;
 

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -28,7 +28,9 @@ use parko_core::backends::mock::MockBackend;
 use parko_core::commands::ControlCommand;
 use parko_core::safety::SafetyPosture;
 use parko_core::scheduler::InferenceLoop;
-use parko_kirra::{DiverseKirraGovernor, GovernorComparator, KirraGovernor};
+use parko_kirra::{
+    select_divergence_sink, DiverseKirraGovernor, GovernorComparator, KirraGovernor,
+};
 use parko_ros2::{
     comparator_adapter::ComparatorAsGovernor,
     config::ParkoNodeConfig,
@@ -57,6 +59,53 @@ fn build_dev_backend() -> Arc<MockBackend> {
     outputs.insert("cmd_vel_linear".to_string(),  vec![0.0]);
     outputs.insert("cmd_vel_angular".to_string(), vec![0.0]);
     Arc::new(MockBackend::new(outputs, BackendDescriptor::Cpu))
+}
+
+/// CERT-006: resolve the comparator divergence sink from the environment,
+/// fail-closed.
+///
+///   - `PARKO_DIVERGENCE_AUDIT_DB` — SQLite path for the durable, hash-chained
+///     audit ledger. Unset → divergences are buffered in memory only
+///     (ephemeral; NOT certification-grade) and a loud WARN is emitted.
+///   - `KIRRA_LOG_SIGNING_KEY` — base64 Ed25519 signing key. REQUIRED when the
+///     audit DB is set; the durable chain must be signed to be tamper-evident.
+///
+/// If a durable audit was requested but cannot be made signed + persistent
+/// (missing/invalid key, or the store will not open), that is a FATAL
+/// misconfiguration: the node exits non-zero rather than run with divergences
+/// going unaudited while the operator believes they are captured.
+fn build_divergence_sink() -> Arc<dyn parko_kirra::comparator::DivergenceEventSink> {
+    let db = std::env::var("PARKO_DIVERGENCE_AUDIT_DB").ok();
+    let key = std::env::var("KIRRA_LOG_SIGNING_KEY").ok();
+
+    let durable_requested = db.as_deref().is_some_and(|s| !s.is_empty());
+
+    match select_divergence_sink(db, key) {
+        Ok(sink) => {
+            if durable_requested {
+                tracing::info!(
+                    "parko-ros2: CERT-006 comparator divergences → durable, signed audit chain \
+                     (PARKO_DIVERGENCE_AUDIT_DB)"
+                );
+            } else {
+                tracing::warn!(
+                    "parko-ros2: PARKO_DIVERGENCE_AUDIT_DB is unset — comparator divergences are \
+                     buffered IN MEMORY ONLY and are LOST on restart. This is NOT a \
+                     certification-grade configuration; set PARKO_DIVERGENCE_AUDIT_DB and \
+                     KIRRA_LOG_SIGNING_KEY for a durable, signed divergence record."
+                );
+            }
+            sink
+        }
+        Err(e) => {
+            tracing::error!(
+                "parko-ros2: FATAL — cannot configure the CERT-006 divergence audit sink: {e}. \
+                 A durable audit was requested but cannot be made signed + persistent. Refusing \
+                 to start with divergences unaudited."
+            );
+            std::process::exit(1);
+        }
+    }
 }
 
 fn build_loop<B>(
@@ -93,8 +142,13 @@ where
 
     // CERT-006: diverse redundancy — primary KirraGovernor paired with a
     // structurally diverse DiverseKirraGovernor shadow, so the comparator can
-    // catch implementation-level systematic faults, not just random ones.
-    let comparator = GovernorComparator::new(KirraGovernor::new(), DiverseKirraGovernor::new());
+    // catch implementation-level systematic faults, not just random ones. Every
+    // divergence is routed to the selected sink (durable+signed if configured).
+    let comparator = GovernorComparator::with_sink(
+        KirraGovernor::new(),
+        DiverseKirraGovernor::new(),
+        build_divergence_sink(),
+    );
     let infer = InferenceLoop::new(backend, model, actuator_tx)
         .with_governor(ComparatorAsGovernor(comparator))
         .with_tick_period(tick_period_s);


### PR DESCRIPTION
CERT-006 follow-up — the durable, signed production sink for `ComparatorDivergence`, plus a fail-closed selector and the reference-node wiring. Divergence events defaulted to `InMemoryDivergenceSink` (ephemeral, unsigned); this provides the persistent, hash-chained, signed sink the design specifies and wires it in.

> ⚠️ **DRAFT — the `COMPARATOR_DIVERSITY.md` diversity argument remains pending formal safety-engineer review.** This PR adds the durable audit-sink plumbing; it does not change the diversity claim's review status.

## TASK 1 — production sink (`parko-kirra/src/audit_sink.rs`)
`AuditChainLinkerDivergenceSink` holds the SDK `VerifierStore` (the handle that owns the hash-chained `audit_log_chain` + the Ed25519 signing key). `record()` serialises the `DivergenceEvent` to JSON (it now derives `Serialize`) and persists it via `save_posture_event_chained` → `AuditChainLinker::append_audit_event_tx`, event type `&#34;ComparatorDivergence&#34;` — the same signed, tamper-evident ledger the verifier service writes.

`record()` is infallible per the trait, but a divergence **detected-but-not-durably-recorded is itself safety-relevant**, so a failure is **never swallowed**: it increments an operator-observable `write_failures()` counter **and** logs loudly to stderr.

## TASK 2 — durability + signing test
A **real** `SigningKey` + a **file-backed** SQLite audit chain: record a divergence, then `verify_audit_chain_full(Some(&amp;vk))` asserts `chain_intact` + `signature_valid` + a signed entry, and `load_all_posture_events` confirms a `&#34;ComparatorDivergence&#34;` entry carrying the event body. A second test poisons the store mutex and asserts the failure is surfaced via `write_failures` (not swallowed).

## TASK 3 — fail-closed selection + node wiring ✅
**Locked decisions implemented:** node-local durable chain, **signed-only**, signing key reused from `KIRRA_LOG_SIGNING_KEY`, durable sink gated by `PARKO_DIVERGENCE_AUDIT_DB`.

**`parko-kirra`:**
- `AuditChainLinkerDivergenceSink::open(db_path, key_b64)` — open a durable, Ed25519-signed store from a base64 signing key.
- `FatalAuditConfig` (`MissingSigningKey` / `InvalidSigningKey` / `StoreOpenFailed`) — misconfiguration that must **never** silently fall back to an ephemeral or unsigned sink.
- `select_divergence_sink(db, key)` implementing the contract:

  | `PARKO_DIVERGENCE_AUDIT_DB` | `KIRRA_LOG_SIGNING_KEY` | result |
  |---|---|---|
  | unset / empty | unset | `Ok` ephemeral in-memory (caller warns — not cert-grade) |
  | unset / empty | set | `Ok` ephemeral in-memory (key inert; caller warns) |
  | set | set, valid, store opens | `Ok` **durable + signed** |
  | set | unset | `Err(MissingSigningKey)` — would be unsigned |
  | set | invalid key **or** unopenable store | `Err(...)` — no silent fallback |

  Contract unit tests cover every cell, including an end-to-end durable+signed case re-opened and verified via `verify_audit_chain_full`.
- `ed25519-dalek` + `base64` promoted to regular deps (`open()` parses the key in non-test code).

**`parko-ros2`** (bench-gated, `feature = ros2` — not built in CI):
- `build_divergence_sink()` reads the two env vars, selects the sink fail-closed, **exits non-zero** on a fatal misconfiguration, and **warns loudly** when running ephemeral (in-memory, lost on restart).
- comparator now constructed via `GovernorComparator::with_sink(...)` at `parko_ros2_node.rs`.

**`docs/safety/COMPARATOR_DIVERSITY.md`:** new §7a documents the durable sink and the env-contract table, with **honest limits** — the chain is **node-local**; it does **not** yet join the verifier's `#165` key-adoption/lineage trust map and divergences are not forwarded to the central verifier chain (tracked follow-up). DRAFT / safety-engineer-review banner retained.

`cargo test -p parko-kirra` — 101 + 3 green, including the new contract tests; `clippy` clean on the new code. Scope is **parko-kirra + parko-ros2 + `COMPARATOR_DIVERSITY.md`** only; no SDK `src/` change; talisman `src/gateway/kinematics_contract.rs` byte-identical (`997fb7ae…`).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_