### PR TITLE
feat(rss): occlusion / limited-sightline speed bound — RSS rule iv (#122)

### DIFF
--- a/parko/crates/parko-core/src/lib.rs
+++ b/parko/crates/parko-core/src/lib.rs
@@ -50,8 +50,8 @@ pub use commands::ControlCommand;
 pub use control_loop::ControlLoop;
 pub use runtime::{RuntimeClock, RuntimeState, TickStatus};
 pub use rss::{
-    lateral_safe_distance, longitudinal_safe_distance, AgentScene, RssAgent, RssParams, RssState,
-    MAX_RSS_AGENTS,
+    lateral_safe_distance, longitudinal_safe_distance, occlusion_limited_speed, AgentScene,
+    OcclusionScene, RssAgent, RssParams, RssState, MAX_RSS_AGENTS,
 };
 pub use safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
 pub use scheduler::{DegradationThresholds, InferenceLoop};

--- a/parko/crates/parko-core/src/rss.rs
+++ b/parko/crates/parko-core/src/rss.rs
@@ -140,6 +140,102 @@ pub fn longitudinal_safe_distance(
     raw.max(0.0)
 }
 
+/// Search ceiling for the rule-iv closing-speed inversion (m/s). Far above any
+/// ground-vehicle + emerging-actor closing speed; a sightline that admits a
+/// closing speed at or beyond this does not bind the ego below the ceiling, so
+/// the returned cap is `ceiling - v_emerge_max` — still finite, never `Inf`.
+const OCCLUSION_SEARCH_CEILING_MPS: f64 = 150.0;
+
+/// Maximum safe ego speed under RSS rule iv — occlusion / limited sightline
+/// (IEEE 2846-2022 §5, occlusion handling).
+///
+/// Returns the largest ego speed (m/s) at which the ego can still maintain RSS
+/// longitudinal safe distance against a worst-case actor that could emerge from
+/// the occluded region at the sightline boundary `d_sight`.
+///
+/// Worst-case-emergence model — a safety-modelling CHOICE; reviewer, read this:
+///   * A hidden actor may exist just beyond the visible range and move toward
+///     the ego's conflict point at up to `v_emerge_max`. The encounter is
+///     modelled as CLOSING: the ego (at `v_ego`) and the actor (at
+///     `v_emerge_max`) approach a fixed conflict point at the sightline
+///     boundary, so the effective approach speed is `v_ego + v_emerge_max`.
+///   * The ego must keep its required longitudinal safe distance against a
+///     stationary conflict point (`lead_vel = 0`) at that closing speed within
+///     `d_sight`: `longitudinal_safe_distance(v_ego + v_emerge_max, 0, ..) <= d_sight`.
+///   * Both knobs move the bound conservatively: a SHORTER sightline or a FASTER
+///     possible emerger lowers the permitted ego speed.
+///   * `v_emerge_max = 0` reduces this to the classic "stop within the available
+///     sightline" (SSD) rule. A caller that cannot bound the emerging speed
+///     should pass the largest credible value; the parko-kirra `Absent` path
+///     takes this to its fail-closed limit (a full stop).
+///
+/// Method: `longitudinal_safe_distance(., 0, ..)` is continuous and monotonically
+/// increasing in the closing speed, so the largest admissible closing speed is
+/// found by bounded bisection and the ego cap is that minus `v_emerge_max`
+/// (clamped >= 0).
+///
+/// FAIL-CLOSED: any invalid input (non-finite; `d_sight <= 0`; negative
+/// `v_emerge_max`; or the non-finite / non-positive brake/accel conditions the
+/// longitudinal primitive guards) returns `0.0` — the ego must stop. `0.0` is
+/// the speed-cap analogue of `RSS_FAILSAFE_DISTANCE_M` (defence in depth, SG9).
+// SAFETY: SG1 SG9 | REQ: rss-occlusion-sightline-failsafe | TEST: test_occlusion_nonpositive_dsight_is_stop,test_occlusion_nonfinite_input_is_stop,test_occlusion_invalid_brake_is_stop,test_occlusion_monotonic_in_sightline,test_occlusion_roundtrips_longitudinal,test_occlusion_faster_emerger_lowers_cap
+// (≅ Occy SG1 RSS rule iv / occlusion; H9 occlusion trigger -> SG9 fail-closed
+//  to a stop. Any invalid input returns 0.0 — a fail-closed speed cap.)
+pub fn occlusion_limited_speed(
+    d_sight: f64,
+    v_emerge_max: f64,
+    reaction_time: f64,
+    accel_max: f64,
+    brake_min: f64,
+    brake_max: f64,
+) -> f64 {
+    // See lateral/longitudinal note: no debug_assert! — the runtime guard is the
+    // safety contract, and the fail-closed tests drive these invalid inputs.
+    if !(finite_positive(d_sight)
+        && v_emerge_max.is_finite()
+        && v_emerge_max >= 0.0
+        && finite_positive(brake_min)
+        && finite_positive(brake_max)
+        && reaction_time.is_finite()
+        && accel_max.is_finite())
+    {
+        return 0.0;
+    }
+
+    // required(v_close): the gap the ego needs to stop short of a fixed conflict
+    // point at worst-case closing speed `v_close`. Monotone increasing in v_close
+    // (lead_vel = 0, so the lead-braking term is absent).
+    let required = |v_close: f64| -> f64 {
+        longitudinal_safe_distance(v_close, 0.0, reaction_time, accel_max, brake_min, brake_max)
+    };
+
+    // Even a zero closing speed needs the reaction-phase creep gap; a sightline
+    // below that admits no motion → stop.
+    if required(0.0) > d_sight {
+        return 0.0;
+    }
+
+    // Largest admissible closing speed, via monotone bisection.
+    let mut lo = 0.0_f64;
+    let mut hi = OCCLUSION_SEARCH_CEILING_MPS;
+    if required(hi) <= d_sight {
+        // Sightline does not bind below the search ceiling.
+        lo = hi;
+    } else {
+        // ~60 iterations drives the interval far below f64 speed resolution.
+        for _ in 0..60 {
+            let mid = 0.5 * (lo + hi);
+            if required(mid) <= d_sight {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+    }
+
+    (lo - v_emerge_max).max(0.0)
+}
+
 // ---------------------------------------------------------------------------
 // Agent-set input model for pairwise RSS (issue #92)
 // ---------------------------------------------------------------------------
@@ -207,6 +303,25 @@ pub enum AgentScene {
     /// One or more agents to check pairwise. An empty vector here is treated
     /// fail-closed (callers must use `KnownEmpty` for a verified-clear scene).
     Agents(Vec<RssAgent>),
+}
+
+/// The occlusion / sightline descriptor the governor sees this tick, for RSS
+/// rule iv (issue #122). Mirrors [`AgentScene`]'s ABSENT vs KNOWN distinction,
+/// which is safety-critical here too: a MISSING sightline assessment must NOT be
+/// read as "the road is clear".
+#[derive(Debug, Clone, Copy)]
+pub enum OcclusionScene {
+    /// No occlusion / sightline assessment this tick (perception gap) →
+    /// fail-closed: treat as worst-case occlusion (zero sightline → the ego must
+    /// stop). ABSENT is NOT `KnownClear`.
+    Absent,
+    /// Perception ran and the relevant sightline is verified clear → RSS rule iv
+    /// imposes no speed bound.
+    KnownClear,
+    /// A limited sightline: the nearest occluded-region boundary is `d_sight_m`
+    /// along the ego path, and an actor could emerge from it at up to
+    /// `v_emerge_max_mps`.
+    Limited { d_sight_m: f64, v_emerge_max_mps: f64 },
 }
 
 #[cfg(test)]
@@ -527,5 +642,65 @@ mod tests {
         let r2 = longitudinal_safe_distance(0.0, 0.0, 0.0, 0.0, -f64::MIN_POSITIVE, 1.0);
         assert!(r1 < RSS_FAILSAFE_DISTANCE_M, "tiny positive brake_min passes the guard, got {r1}");
         assert!(r2 >= RSS_FAILSAFE_DISTANCE_M, "tiny negative brake_min must fail safe, got {r2}");
+    }
+
+    // ── occlusion_limited_speed (RSS rule iv, issue #122) ────────────────────
+    // Shared ego params for the occlusion tests: rt=0.5, accel=2.0, brakes=6.0.
+
+    /// d_sight <= 0 → ego must stop (0.0). Zero and negative sightlines.
+    #[test]
+    fn test_occlusion_nonpositive_dsight_is_stop() {
+        assert_eq!(occlusion_limited_speed(0.0, 0.0, 0.5, 2.0, 6.0, 6.0), 0.0,
+            "zero sightline must fail closed to a stop");
+        assert_eq!(occlusion_limited_speed(-5.0, 0.0, 0.5, 2.0, 6.0, 6.0), 0.0,
+            "negative sightline must fail closed to a stop");
+    }
+
+    /// Non-finite inputs (incl. negative emerge velocity) → 0.0.
+    #[test]
+    fn test_occlusion_nonfinite_input_is_stop() {
+        assert_eq!(occlusion_limited_speed(f64::NAN, 0.0, 0.5, 2.0, 6.0, 6.0), 0.0, "NaN d_sight → stop");
+        assert_eq!(occlusion_limited_speed(50.0, f64::INFINITY, 0.5, 2.0, 6.0, 6.0), 0.0, "Inf v_emerge → stop");
+        assert_eq!(occlusion_limited_speed(50.0, -1.0, 0.5, 2.0, 6.0, 6.0), 0.0, "negative v_emerge is invalid → stop");
+        assert_eq!(occlusion_limited_speed(50.0, 0.0, f64::NAN, 2.0, 6.0, 6.0), 0.0, "NaN reaction_time → stop");
+    }
+
+    /// The same non-positive/non-finite brake/accel guard as the primitives.
+    #[test]
+    fn test_occlusion_invalid_brake_is_stop() {
+        assert_eq!(occlusion_limited_speed(50.0, 0.0, 0.5, 2.0, 0.0, 6.0), 0.0, "zero brake_min → stop");
+        assert_eq!(occlusion_limited_speed(50.0, 0.0, 0.5, 2.0, 6.0, -1.0), 0.0, "negative brake_max → stop");
+    }
+
+    /// Monotonicity: a longer sightline allows a greater-or-equal speed, and a
+    /// much longer one strictly more.
+    #[test]
+    fn test_occlusion_monotonic_in_sightline() {
+        let cap = |d: f64| occlusion_limited_speed(d, 0.0, 0.5, 2.0, 6.0, 6.0);
+        let (a, b, c) = (cap(10.0), cap(40.0), cap(120.0));
+        assert!(a <= b && b <= c, "more sightline must allow >= speed: {a}, {b}, {c}");
+        assert!(c > a, "a much longer sightline must allow a strictly higher speed: {a} vs {c}");
+    }
+
+    /// Hand-anchored via the longitudinal primitive as the ORACLE: take a closing
+    /// speed, compute the sightline it requires, and confirm the inverse recovers
+    /// it (v_emerge_max = 0, so the ego cap equals the closing speed).
+    #[test]
+    fn test_occlusion_roundtrips_longitudinal() {
+        let (rt, acc, bmin, bmax) = (0.5, 2.0, 6.0, 6.0);
+        let v = 12.0_f64;
+        let d = longitudinal_safe_distance(v, 0.0, rt, acc, bmin, bmax);
+        let cap = occlusion_limited_speed(d, 0.0, rt, acc, bmin, bmax);
+        assert!((cap - v).abs() < 1e-3,
+            "the inverse of longitudinal_safe_distance must recover {v}, got {cap}");
+    }
+
+    /// A faster possible emerger lowers the cap (the conservative direction).
+    #[test]
+    fn test_occlusion_faster_emerger_lowers_cap() {
+        let slow = occlusion_limited_speed(60.0, 0.0, 0.5, 2.0, 6.0, 6.0);
+        let fast = occlusion_limited_speed(60.0, 5.0, 0.5, 2.0, 6.0, 6.0);
+        assert!(fast < slow, "a faster possible emerger must lower the cap: slow={slow}, fast={fast}");
+        assert!(fast >= 0.0, "the cap is never negative, got {fast}");
     }
 }

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -40,9 +40,9 @@ use kirra_runtime_sdk::gateway::kinematics_contract::{
 use kirra_runtime_sdk::verifier::FleetPosture;
 
 use parko_core::commands::ControlCommand;
-use parko_core::rss::{lateral_safe_distance, longitudinal_safe_distance};
+use parko_core::rss::{lateral_safe_distance, longitudinal_safe_distance, occlusion_limited_speed};
 use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
-use parko_core::{AgentScene, RssParams, RssState, MAX_RSS_AGENTS};
+use parko_core::{AgentScene, OcclusionScene, RssParams, RssState, MAX_RSS_AGENTS};
 
 pub mod angular_bound;
 pub mod audit_sink;
@@ -220,6 +220,41 @@ pub fn compute_scene_rss(scene: &AgentScene, params: &RssParams) -> RssState {
         safe: all_safe,
         longitudinal_margin: min_long_margin,
         lateral_margin: min_lat_margin,
+    }
+}
+
+/// CHECKER-OVER-DOER occlusion speed cap — RSS rule iv (issue #122).
+///
+/// The trusted checker computes the maximum admissible ego speed from the
+/// sightline scene ITSELF, via the vetted parko-core primitive
+/// [`occlusion_limited_speed`] — it never trusts a caller-pushed verdict.
+///
+/// Fail-closed scene handling mirrors [`compute_scene_rss`]'s ABSENT-vs-KNOWN
+/// distinction on the occlusion axis:
+///   - `Absent` (no sightline assessment) → `0.0`: worst-case occlusion, the ego
+///     must stop. ABSENT is NOT `KnownClear`.
+///   - `KnownClear` (sightline verified clear) → `f64::INFINITY`: rule iv does
+///     not bind.
+///   - `Limited { d_sight_m, v_emerge_max_mps }` → `occlusion_limited_speed`,
+///     which itself fails closed to `0.0` on any invalid input.
+///
+/// The returned value is a MAX EGO SPEED (m/s); the governor treats a proposed
+/// speed above it as RSS-unsafe (override → MRC profile).
+pub fn compute_occlusion_cap(occlusion: &OcclusionScene, params: &RssParams) -> f64 {
+    match *occlusion {
+        OcclusionScene::Absent => 0.0,
+        OcclusionScene::KnownClear => f64::INFINITY,
+        OcclusionScene::Limited {
+            d_sight_m,
+            v_emerge_max_mps,
+        } => occlusion_limited_speed(
+            d_sight_m,
+            v_emerge_max_mps,
+            params.reaction_time,
+            params.accel_max,
+            params.brake_min,
+            params.brake_max,
+        ),
     }
 }
 
@@ -564,6 +599,49 @@ impl KirraGovernor {
     ) -> EnforcementAction {
         let computed = compute_scene_rss(scene, params);
         self.gate(proposed, previous, delta_time_s, posture, computed.safe)
+    }
+
+    /// AUTHORITATIVE pairwise RSS + occlusion path (issues #92 + #122).
+    ///
+    /// Extends [`evaluate_scene`] with RSS rule iv: alongside the pairwise agent
+    /// verdict, the governor computes the occlusion speed cap from the sightline
+    /// scene it sees ([`compute_occlusion_cap`]) and OVERRIDES the verdict to
+    /// unsafe when the proposed ego speed exceeds that cap. Checker-over-doer: a
+    /// caller-pushed `safe: true` that violates the occlusion bound is overridden
+    /// (→ MRC profile), never trusted.
+    ///
+    /// Fail-closed: an `Absent` occlusion scene caps at `0.0` (any motion is
+    /// unsafe) — DISTINCT from `KnownClear`, where rule iv does not bind. A
+    /// non-finite proposed speed fails the `<=` comparison (NaN) → unsafe.
+    ///
+    /// NOTE: producing the [`OcclusionScene`] from perception (sightline ranging
+    /// / occluded-region extraction) is OUT OF SCOPE here, exactly as the agent
+    /// set's perception ingestion is for `evaluate_scene` — the scene is a check
+    /// INPUT supplied by the caller.
+    #[allow(clippy::too_many_arguments)]
+    pub fn evaluate_scene_with_occlusion(
+        &self,
+        proposed: &ControlCommand,
+        previous: Option<&ControlCommand>,
+        delta_time_s: f64,
+        posture: SafetyPosture,
+        scene: &AgentScene,
+        occlusion: &OcclusionScene,
+        params: &RssParams,
+    ) -> EnforcementAction {
+        let pairwise_safe = compute_scene_rss(scene, params).safe;
+        let cap = compute_occlusion_cap(occlusion, params);
+        // The occlusion bound is on SPEED magnitude. `<=` is NaN-safe: a
+        // non-finite proposed speed makes it false → unsafe; an `Absent` cap of
+        // 0.0 makes any |v| > 0 unsafe; a `KnownClear` cap of +inf never binds.
+        let occlusion_ok = proposed.linear_velocity.abs() <= cap;
+        self.gate(
+            proposed,
+            previous,
+            delta_time_s,
+            posture,
+            pairwise_safe && occlusion_ok,
+        )
     }
 }
 
@@ -1197,10 +1275,12 @@ mod tests {
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 mod scene_rss_tests {
-    use super::{compute_scene_rss, KirraGovernor};
+    use super::{compute_occlusion_cap, compute_scene_rss, KirraGovernor};
     use parko_core::commands::ControlCommand;
     use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
-    use parko_core::{AgentScene, RssAgent, RssParams, RssState, MAX_RSS_AGENTS};
+    use parko_core::{
+        AgentScene, OcclusionScene, RssAgent, RssParams, RssState, MAX_RSS_AGENTS,
+    };
 
     fn params() -> RssParams {
         RssParams {
@@ -1347,5 +1427,89 @@ mod scene_rss_tests {
         assert!(!matches!(computed_unsafe, EnforcementAction::Allow),
             "the governor's OWN pairwise computation must override the doer's safe:true \
              and apply the RSS-unsafe MRC profile, got {computed_unsafe:?}");
+    }
+
+    // --- RSS rule iv: occlusion speed bound (issue #122) ---
+
+    /// ABSENT occlusion data must fail closed — DISTINCT from KnownClear. Even a
+    /// clear agent scene and a pushed safe:true cannot make it Allow.
+    #[test]
+    fn occlusion_absent_is_fail_closed_unsafe() {
+        let mut gov = KirraGovernor::new();
+        gov.update_rss_state(RssState { safe: true, longitudinal_margin: f64::MAX, lateral_margin: f64::MAX });
+        let proposed = cmd(8.0);
+        let prev = cmd(8.0);
+        let action = gov.evaluate_scene_with_occlusion(
+            &proposed, Some(&prev), 0.05, SafetyPosture::Nominal,
+            &AgentScene::KnownEmpty, &OcclusionScene::Absent, &params());
+        assert!(!matches!(action, EnforcementAction::Allow),
+            "absent occlusion data must fail closed (not Allow), got {action:?}");
+    }
+
+    /// KNOWN-CLEAR sightline imposes no rule-iv bound: with a clear agent scene
+    /// the Nominal verdict is Allow (the absent-vs-known distinction matters).
+    #[test]
+    fn occlusion_known_clear_does_not_bind() {
+        let gov = KirraGovernor::new();
+        let proposed = cmd(8.0);
+        let prev = cmd(8.0);
+        let action = gov.evaluate_scene_with_occlusion(
+            &proposed, Some(&prev), 0.05, SafetyPosture::Nominal,
+            &AgentScene::KnownEmpty, &OcclusionScene::KnownClear, &params());
+        assert!(matches!(action, EnforcementAction::Allow),
+            "a verified-clear sightline must not bind rule iv, got {action:?}");
+    }
+
+    /// THE KEY TEST (rule-iv analogue of the pairwise checker-over-doer): a tight
+    /// sightline whose cap is below the proposed speed OVERRIDES a pushed
+    /// safe:true → MRC profile (not Allow).
+    #[test]
+    fn checker_over_doer_occlusion_overrides_pushed_safe_bool() {
+        let mut gov = KirraGovernor::new();
+        gov.update_rss_state(RssState { safe: true, longitudinal_margin: f64::MAX, lateral_margin: f64::MAX });
+        let proposed = cmd(8.0);
+        let prev = cmd(8.0);
+        let p = params();
+        // 5 m of sightline → cap well below 8 m/s (fixture self-check).
+        let tight = OcclusionScene::Limited { d_sight_m: 5.0, v_emerge_max_mps: 0.0 };
+        assert!(compute_occlusion_cap(&tight, &p) < 8.0,
+            "fixture: the occlusion cap must bind below the proposed 8 m/s");
+
+        let action = gov.evaluate_scene_with_occlusion(
+            &proposed, Some(&prev), 0.05, SafetyPosture::Nominal,
+            &AgentScene::KnownEmpty, &tight, &p);
+        assert!(!matches!(action, EnforcementAction::Allow),
+            "a proposed speed above the occlusion cap must override pushed safe:true → MRC, got {action:?}");
+    }
+
+    /// The override is CONDITIONAL, not blanket: a sightline long enough that the
+    /// cap exceeds the proposed speed does not bind → Allow.
+    #[test]
+    fn occlusion_generous_sightline_allows() {
+        let gov = KirraGovernor::new();
+        let proposed = cmd(8.0);
+        let prev = cmd(8.0);
+        let p = params();
+        let clear_enough = OcclusionScene::Limited { d_sight_m: 500.0, v_emerge_max_mps: 0.0 };
+        assert!(compute_occlusion_cap(&clear_enough, &p) > 8.0,
+            "fixture: a 500 m sightline cap must exceed 8 m/s");
+        let action = gov.evaluate_scene_with_occlusion(
+            &proposed, Some(&prev), 0.05, SafetyPosture::Nominal,
+            &AgentScene::KnownEmpty, &clear_enough, &p);
+        assert!(matches!(action, EnforcementAction::Allow),
+            "a sightline long enough must not bind rule iv, got {action:?}");
+    }
+
+    /// The bound is never larger than the no-occlusion (KnownClear) case — for
+    /// any limited sightline, the cap is <= the unbounded cap.
+    #[test]
+    fn occlusion_cap_never_exceeds_no_occlusion() {
+        let p = params();
+        let no_occ = compute_occlusion_cap(&OcclusionScene::KnownClear, &p);
+        for d in [5.0_f64, 20.0, 100.0, 1000.0] {
+            let lim = compute_occlusion_cap(
+                &OcclusionScene::Limited { d_sight_m: d, v_emerge_max_mps: 0.0 }, &p);
+            assert!(lim <= no_occ, "limited cap {lim} (d={d}) must be <= no-occlusion {no_occ}");
+        }
     }
 }


### PR DESCRIPTION
Completes the RSS rule set — longitudinal + lateral landed with #92; this adds the **occlusion / limited-sightline** bound (RSS rule iv) for TC-05 (occluded VRU). Pure-Rust, **parko-only**, CI-testable in the no-ROS/no-ORT lane. Mirrors the #92 checker-over-doer pattern.

## TASK 1 — `parko-core/rss.rs`: `occlusion_limited_speed(...)`
Returns the max safe ego speed under rule iv: the largest `v_ego` for which the ego still maintains RSS longitudinal safe distance against a worst-case actor emerging at the sightline boundary `d_sight`.
- **Reuses `longitudinal_safe_distance` as the oracle** — `required(v_close)` is monotone in the closing speed, inverted by bounded bisection, then the ego cap is that minus `v_emerge_max`.
- **Worst-case-emergence model documented for the reviewer**: a CLOSING encounter, effective approach speed `v_ego + v_emerge_max` against a fixed conflict point at `d_sight`; shorter sightline *or* faster possible emerger ⇒ lower permitted speed; `v_emerge_max = 0` reduces to "stop within sightline" (SSD).
- **FAIL-CLOSED to `0.0`** (speed-cap analogue of `RSS_FAILSAFE_DISTANCE_M`) on any invalid input; reuses the `finite_positive` helper.
- Tagged `// SAFETY: SG1 SG9` (confirmed against `OCCY_SAFETY_GOALS.md`; H9 lists occlusion → SG9).
- New `OcclusionScene` enum (`Absent` / `KnownClear` / `Limited`) mirroring `AgentScene`.
- Tests: `d_sight ≤ 0` → 0; non-finite → 0; invalid brake → 0; monotonicity; round-trip vs the longitudinal primitive; faster emerger lowers the cap.

## TASK 2 — `parko-kirra/lib.rs`: authoritative-path integration
- `compute_occlusion_cap(occlusion, params)`: `Absent` → `0.0` (stop), `KnownClear` → `+∞` (no bind), `Limited` → `occlusion_limited_speed`.
- `evaluate_scene_with_occlusion(...)`: overrides to unsafe (→ MRC profile) when the proposed ego speed exceeds the occlusion cap — checker-over-doer, a pushed `safe: true` is overridden. `evaluate_scene` left intact for #92.
- **Fail-closed on ABSENT occlusion** (worst-case → stop), DISTINCT from `KnownClear` — the absent-vs-known analogue of #238.
- Tests: absent → fail-closed; known-clear → unbounded; checker-over-doer override; generous-sightline allows; cap never exceeds the no-occlusion case.

## Scope
- **IN:** the rule-iv occlusion speed-bound CHECK over an occlusion INPUT.
- **OUT (deferred):** perception → occlusion ingestion, exactly as #92 deferred agent-set ingestion. Not built here.

## Verify
- `cargo test -p parko-core -p parko-kirra` green (incl. new fail-closed / checker-over-doer / absent-vs-known tests). Clippy clean.
- No SDK `src/` in the diff; talisman byte-identical (`997fb7ae15ce3e11adec9218044c7c84b049ad3b`).

Refs #122.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_