### PR TITLE
feat(audit): command-source handoff provenance (#112, #111)

### DIFF
--- a/src/command_source.rs
+++ b/src/command_source.rs
@@ -1,0 +1,215 @@
+// src/command_source.rs
+//
+// #111 (CommandSource definition) + #112 (command_source handoff provenance).
+//
+// SG7 — READ THIS. This is the AUDIT / INGRESS layer. The Governor verdict
+// (`validate_vehicle_command` / `classify_http_command`) is and stays
+// SOURCE-BLIND: it takes no source parameter (SG7 "doer-agnostic verdict",
+// guarded by `sg7_doer_agnostic_verdict_byte_identical_across_ingress_paths` in
+// `gateway/policy_layer.rs`). Command source is recorded HERE — where it is
+// already known at ingress — and is NEVER threaded into the verdict. Nothing in
+// this module is reachable from the verdict path.
+//
+// OBSERVABILITY ONLY. A handoff event is forensic: it emits into the EXISTING
+// signed, hash-chained verifier audit log via
+// `VerifierStore::save_posture_event_chained` → `audit_chain::append_audit_event_tx`
+// (the same ledger as posture transitions / the #247 divergence sink — no new
+// sink; #165 key-trust applies). A failed write bumps the operator-observable
+// `command_source_write_failures` counter (#245/#247 pattern) and is dropped —
+// it never blocks or alters the control path.
+
+use std::sync::atomic::Ordering;
+
+use crate::verifier::AppState;
+
+/// Audit event type for a control-authority transition (SCREAMING_SNAKE,
+/// matching the existing vocabulary; no collision with existing strings).
+pub const COMMAND_SOURCE_HANDOFF: &str = "COMMAND_SOURCE_HANDOFF";
+
+/// `node_id` column value for command-source rows.
+const COMMAND_SOURCE_NODE_ID: &str = "command_source";
+
+/// #111 — who authored a command, recorded at the ingress/audit layer (NEVER in
+/// the verdict). The `Unattributed` variant mirrors the existing
+/// `CANOPEN_NMT_OFFLINE_UNATTRIBUTED` honesty: a handoff whose source cannot be
+/// attributed is recorded AS unattributed, never dropped or guessed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandSource {
+    /// The autonomous planner / AI stack.
+    AutonomousPlanner,
+    /// A human teleoperator.
+    Teleoperator,
+    /// An HA standby controller that took over command authority.
+    StandbyController,
+    /// The minimum-risk-condition safe-stop authority (decel-to-stop / hold).
+    MrcSafeStop,
+    /// Fail-closed: the source could not be attributed. Recorded explicitly,
+    /// never silently dropped (cf. `CANOPEN_NMT_OFFLINE_UNATTRIBUTED`).
+    Unattributed,
+}
+
+impl CommandSource {
+    /// Stable audit-payload rendering (do not change without an audit-format
+    /// migration — the string is bound into the chain hash).
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            CommandSource::AutonomousPlanner => "AutonomousPlanner",
+            CommandSource::Teleoperator => "Teleoperator",
+            CommandSource::StandbyController => "StandbyController",
+            CommandSource::MrcSafeStop => "MrcSafeStop",
+            CommandSource::Unattributed => "Unattributed",
+        }
+    }
+}
+
+fn note_failure(app: &AppState, why: &str) {
+    app.command_source_write_failures.fetch_add(1, Ordering::SeqCst);
+    tracing::error!(
+        error = %why,
+        "COMMAND_SOURCE_HANDOFF audit write failed — provenance event missing from \
+         the chain (observability only; the safety verdict path is unaffected)"
+    );
+}
+
+/// #112 — emit a `COMMAND_SOURCE_HANDOFF` audit event recording a
+/// control-authority transition (`from_source` → `to_source`, `reason`,
+/// `timestamp`) into the existing signed, hash-chained verifier log.
+///
+/// OBSERVABILITY ONLY — never blocks or alters the verdict; a failed write only
+/// bumps `command_source_write_failures`.
+///
+/// COMPLEMENTS (does not replace) the specific `STANDBY_PROMOTED_TO_ACTIVE`
+/// event: a standby promotion emits BOTH — the promotion record AND this
+/// generalized provenance record (`AutonomousPlanner` → `StandbyController`) —
+/// so the provenance series is uniform across all handoff kinds without a
+/// redundant second promotion event.
+pub fn record_handoff(
+    app: &AppState,
+    from_source: CommandSource,
+    to_source: CommandSource,
+    reason: &str,
+    ts: u64,
+) {
+    let body = serde_json::json!({
+        "from_source": from_source.as_str(),
+        "to_source":   to_source.as_str(),
+        "reason":      reason,
+        "timestamp":   ts,
+    });
+    let outcome = match app.store.lock() {
+        Ok(mut store) => store.save_posture_event_chained(
+            COMMAND_SOURCE_NODE_ID,
+            COMMAND_SOURCE_HANDOFF,
+            &body.to_string(),
+            Some(reason),
+            ts,
+        ),
+        Err(_) => {
+            note_failure(app, "store mutex poisoned");
+            return;
+        }
+    };
+    if let Err(e) = outcome {
+        note_failure(app, &e.to_string());
+    }
+}
+
+/// Operator-observable count of handoff audit writes that were DETECTED but
+/// could NOT be durably recorded (#245/#247 convention). MUST be `0` in a
+/// healthy deployment; a non-zero value means that many provenance events are
+/// MISSING from the tamper-evident log.
+pub fn write_failures(app: &AppState) -> u64 {
+    app.command_source_write_failures.load(Ordering::SeqCst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::verifier::{AppState, VerifierOperationMode};
+    use crate::verifier_store::VerifierStore;
+    use ed25519_dalek::SigningKey;
+
+    fn app_with_key() -> (AppState, ed25519_dalek::VerifyingKey) {
+        let key = SigningKey::from_bytes(&[5u8; 32]);
+        let vk = key.verifying_key();
+        let mut store = VerifierStore::new(":memory:").expect("store");
+        store.set_signing_key(key);
+        (AppState::new(store, VerifierOperationMode::Active), vk)
+    }
+
+    /// The required test: a handoff emits a `COMMAND_SOURCE_HANDOFF` that is
+    /// signed + hash-chained and carries BOTH sources + the reason.
+    #[test]
+    fn handoff_emits_signed_chained_event_with_both_sources() {
+        let (app, vk) = app_with_key();
+
+        record_handoff(
+            &app,
+            CommandSource::AutonomousPlanner,
+            CommandSource::Teleoperator,
+            "operator takeover requested",
+            1_000,
+        );
+        assert_eq!(write_failures(&app), 0, "the handoff must have been durably recorded");
+
+        let store = app.store.lock().unwrap();
+        let v = store.verify_audit_chain_full(Some(&vk)).expect("verify");
+        assert!(v.chain_intact, "handoff event must be hash-chained");
+        assert!(v.signature_valid, "handoff event must verify under the signing key");
+        assert!(v.signed_entries >= 1, "the handoff event must be signed, got {}", v.signed_entries);
+
+        let events = store.load_all_posture_events().expect("load");
+        let h = &events
+            .iter()
+            .find(|e| e["event_type"] == COMMAND_SOURCE_HANDOFF)
+            .expect("a COMMAND_SOURCE_HANDOFF event must exist")["posture"];
+        assert_eq!(h["from_source"], "AutonomousPlanner");
+        assert_eq!(h["to_source"], "Teleoperator");
+        assert_eq!(h["reason"], "operator takeover requested");
+        assert_eq!(h["timestamp"], 1_000);
+    }
+
+    /// An unattributed handoff is recorded AS unattributed, not dropped (mirrors
+    /// the CANOPEN_NMT_OFFLINE_UNATTRIBUTED honesty).
+    #[test]
+    fn unattributed_handoff_is_recorded_not_dropped() {
+        let (app, _vk) = app_with_key();
+        record_handoff(
+            &app,
+            CommandSource::Unattributed,
+            CommandSource::MrcSafeStop,
+            "source unattributable -> MRC safe-stop",
+            2_000,
+        );
+        let store = app.store.lock().unwrap();
+        let events = store.load_all_posture_events().expect("load");
+        let h = &events
+            .iter()
+            .find(|e| e["event_type"] == COMMAND_SOURCE_HANDOFF)
+            .expect("unattributed handoff must still be recorded")["posture"];
+        assert_eq!(h["from_source"], "Unattributed");
+        assert_eq!(h["to_source"], "MrcSafeStop");
+    }
+
+    /// Each variant renders a stable, distinct audit string (planner↔teleop,
+    /// primary→standby, planner→MRC all representable).
+    #[test]
+    fn variants_render_stable_distinct_strings() {
+        let all = [
+            CommandSource::AutonomousPlanner,
+            CommandSource::Teleoperator,
+            CommandSource::StandbyController,
+            CommandSource::MrcSafeStop,
+            CommandSource::Unattributed,
+        ];
+        let rendered: Vec<&str> = all.iter().map(|s| s.as_str()).collect();
+        // distinct
+        for i in 0..rendered.len() {
+            for j in (i + 1)..rendered.len() {
+                assert_ne!(rendered[i], rendered[j], "variant strings must be distinct");
+            }
+        }
+        assert_eq!(CommandSource::StandbyController.as_str(), "StandbyController");
+        assert_eq!(CommandSource::MrcSafeStop.as_str(), "MrcSafeStop");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@ pub mod audit_writer;
 // #104 — post-incident forensic sequence instrumentation (observability-only;
 // emits a correlation-id'd, signed, hash-chained sequence into the audit log).
 pub mod post_incident;
+// #111/#112 — command-source provenance (audit/ingress layer; the verdict stays
+// source-blind per SG7). Emits COMMAND_SOURCE_HANDOFF into the signed chain.
+pub mod command_source;
 // Learning-loop capture channel (Phase 1, #190) — sibling of audit_writer;
 // non-blocking, default-OFF side channel recording the verdict/correction.
 pub mod capture;

--- a/src/standby_monitor.rs
+++ b/src/standby_monitor.rs
@@ -593,6 +593,18 @@ async fn perform_promotion(
         );
     }
 
+    // #112: record the control-authority handoff provenance ALONGSIDE the
+    // promotion event (complement, not a duplicate). A primary failure transfers
+    // autonomous command authority to this standby controller. Observability
+    // only — never blocks promotion (its own store lock + failure counter).
+    crate::command_source::record_handoff(
+        app,
+        crate::command_source::CommandSource::AutonomousPlanner,
+        crate::command_source::CommandSource::StandbyController,
+        reason,
+        ts,
+    );
+
     // Step 5: Initial recalculation as Active instance.
     // is_active() now returns true, so recalculate_and_broadcast will write
     // to the cache and emit broadcasts instead of returning early.

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -237,6 +237,10 @@ pub struct AppState {
     /// detected but could not be durably recorded (#245/#247 pattern). MUST be 0
     /// in a healthy deployment; never gates the verdict path.
     pub post_incident_write_failures: Arc<AtomicU64>,
+    /// #112 — operator-observable count of command-source handoff audit writes
+    /// that were detected but could not be durably recorded (#245/#247 pattern).
+    /// MUST be 0 in a healthy deployment; never gates the verdict path.
+    pub command_source_write_failures: Arc<AtomicU64>,
 }
 
 impl AppState {
@@ -263,6 +267,7 @@ impl AppState {
             rss_recovery_streak: Arc::new(Mutex::new(RssRecoveryStreak { count: 0, start_ms: 0 })),
             current_incident: Arc::new(Mutex::new(None)),
             post_incident_write_failures: Arc::new(AtomicU64::new(0)),
+            command_source_write_failures: Arc::new(AtomicU64::new(0)),
         }
     }
 


### PR DESCRIPTION
Audit-only forensic provenance for control-authority transitions (#112), with the `CommandSource` definition (#111), emitted into the **existing** signed, hash-chained verifier log. **Observability only.**

## SG7 preserved (the hard constraint)
The Governor verdict stays **source-blind**: `validate_vehicle_command` and `classify_http_command` are **unchanged** — they take no source parameter — and the parity test passes **unchanged**:
```
test gateway::policy_layer::actuator_middleware_tests::sg7_doer_agnostic_verdict_byte_identical_across_ingress_paths ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 581 filtered out
```
Command source is recorded **only at the audit/ingress layer** where it's already known; it is never threaded into the verdict. **No `src/gateway/` changes.**

## What's in it (`src/command_source.rs`, new)
- **#111 `CommandSource`** enum at the audit layer: `AutonomousPlanner`, `Teleoperator`, `StandbyController`, `MrcSafeStop`, and **`Unattributed`** — the fail-closed variant: an unattributable handoff is recorded *as* unattributed (mirroring the existing `CANOPEN_NMT_OFFLINE_UNATTRIBUTED` honesty), never dropped.
- **#112 `record_handoff(app, from, to, reason, ts)`** — emits `COMMAND_SOURCE_HANDOFF` (`from_source`, `to_source`, `reason`, `timestamp`) via `save_posture_event_chained` → `append_audit_event_tx`: signed + hash-chained, **same ledger as posture transitions / the #247 sink — no new sink; #165 key-trust applies**. A failed write bumps `command_source_write_failures` and is dropped — never blocks.

## Wiring — complement, not duplicate
`standby_monitor::perform_promotion` records an `AutonomousPlanner → StandbyController` handoff **alongside** the existing `STANDBY_PROMOTED_TO_ACTIVE` event (the one concrete control-authority transition in the verifier today) — generalizing the provenance record without a redundant second promotion event. The `planner↔teleoperator` and `planner→MRC` transitions have **no distinct ingress code paths yet**; `record_handoff` is the primitive those sites call once wired (deferred, like #92/#122 ingestion). `AppState` gains the `command_source_write_failures` counter.

## SPI effect (#117) — GAP → EMITTED
Upgrades the **command_source SPI** in `UL4600_SAFETY_CASE.md` §5.3 from **GAP → EMITTED**. **The UL4600 relabel doc edit is a deferred follow-up, intentionally NOT in this PR.**

## Verify
- `cargo test --lib` green — **582 passed** (+3 new), incl. a test asserting a handoff emits `COMMAND_SOURCE_HANDOFF` signed + hash-chained carrying both sources (`verify_audit_chain_full`), **and the SG7 parity test unchanged** (line above). Clippy clean.
- Diff = 4 src files (`command_source.rs`, `lib.rs`, `verifier.rs`, `standby_monitor.rs`); **no `src/gateway/*`**; talisman `997fb7ae15ce3e11adec9218044c7c84b049ad3b` byte-identical.

Refs #112, #111.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_