### PR TITLE
feat(posture): flood-condition → FleetPosture Degraded escalation (#99)

### DIFF
--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -84,11 +84,17 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     // Step 2: Derive aggregate posture — pure function, no I/O.
     let dag_posture = derive_fleet_posture(&node_postures);
 
-    // RSS escalation: active violation elevates Nominal to Degraded.
-    // LockedOut (from DAG) is never downgraded by this check.
-    let new_posture = if app.rss_active_violation.load(std::sync::atomic::Ordering::SeqCst)
-        && dag_posture == FleetPosture::Nominal
-    {
+    // RSS / flood escalation: an active RSS violation OR active flood condition
+    // elevates Nominal to Degraded. The Nominal-only guard means LockedOut /
+    // Degraded (from the DAG) are NEVER downgraded by this check; the two
+    // conditions compose (either → Degraded); and recovery is automatic — when
+    // both flags clear and the DAG is Nominal, posture returns to Nominal via
+    // this same path (no separate recovery logic).
+    // SAFETY: SG4 | REQ: flood-posture-coupling | TEST: test_flood_active_nominal_escalates_to_degraded,test_flood_active_locked_out_stays_locked_out,test_flood_active_degraded_stays_degraded,test_flood_and_rss_compose,test_flood_clears_auto_recovers_to_nominal,test_flood_default_false_is_inert
+    let escalate = (app.rss_active_violation.load(std::sync::atomic::Ordering::SeqCst)
+        || app.flood_condition_active.load(std::sync::atomic::Ordering::SeqCst))
+        && dag_posture == FleetPosture::Nominal;
+    let new_posture = if escalate {
         FleetPosture::Degraded
     } else {
         dag_posture
@@ -460,5 +466,132 @@ mod posture_engine_tests {
             "generation > 0 must populate an empty cache");
         let snap_gen = cache.read().unwrap().as_ref().unwrap().generation;
         assert_eq!(snap_gen, 1);
+    }
+
+    // ── #99 flood-condition → FleetPosture coupling ──────────────────────────
+    // Driven through the real authoritative write path (`recalculate_and_broadcast`,
+    // audit-commit-gated), reading the resulting cache posture. DAG postures are
+    // forced by inserting nodes: Untrusted → LockedOut, Unknown → Degraded,
+    // empty/Trusted → Nominal (per `recursive_calculate`).
+
+    fn active_app() -> std::sync::Arc<AppState> {
+        use crate::verifier::VerifierOperationMode;
+        use crate::verifier_store::VerifierStore;
+        let store = VerifierStore::new(":memory:").unwrap();
+        std::sync::Arc::new(AppState::new(store, VerifierOperationMode::Active))
+    }
+
+    fn insert_node(app: &AppState, id: &str, status: NodeTrustState) {
+        use crate::verifier::RegisteredNode;
+        app.nodes.insert(
+            id.to_string(),
+            RegisteredNode {
+                node_id: id.to_string(),
+                status,
+                registered_at_ms: 0,
+                last_trust_update_ms: 0,
+                ak_public_pem: None,
+                expected_pcr16_digest_hex: None,
+            },
+        );
+    }
+
+    fn cache_posture(cache: &SharedPostureCache) -> Option<FleetPosture> {
+        cache.read().ok().and_then(|g| g.as_ref().map(|c| c.posture.clone()))
+    }
+
+    fn empty_cache() -> SharedPostureCache {
+        std::sync::Arc::new(std::sync::RwLock::new(None))
+    }
+
+    #[test]
+    fn test_flood_active_nominal_escalates_to_degraded() {
+        let app = active_app();
+        let cache = empty_cache();
+        app.flood_condition_active.store(true, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded),
+            "flood + DAG Nominal must escalate to Degraded");
+    }
+
+    /// THE KEY SAFETY ASSERTION: flood never downgrades a DAG LockedOut.
+    #[test]
+    fn test_flood_active_locked_out_stays_locked_out() {
+        let app = active_app();
+        let cache = empty_cache();
+        insert_node(&app, "n", NodeTrustState::Untrusted("test".to_string())); // DAG → LockedOut
+        app.flood_condition_active.store(true, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::LockedOut),
+            "flood must NEVER downgrade a DAG LockedOut");
+    }
+
+    #[test]
+    fn test_flood_active_degraded_stays_degraded() {
+        let app = active_app();
+        let cache = empty_cache();
+        insert_node(&app, "n", NodeTrustState::Unknown); // DAG → Degraded
+        app.flood_condition_active.store(true, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded),
+            "flood does not alter an already-Degraded DAG posture");
+    }
+
+    /// flood and RSS compose: either active (with Nominal DAG) → Degraded.
+    #[test]
+    fn test_flood_and_rss_compose() {
+        let app = active_app();
+        let cache = empty_cache();
+        app.flood_condition_active.store(true, Ordering::SeqCst);
+        app.rss_active_violation.store(true, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded),
+            "flood OR rss escalates Nominal → Degraded");
+    }
+
+    /// Clearing the flag auto-recovers to Nominal via the existing path — no new
+    /// recovery logic.
+    #[test]
+    fn test_flood_clears_auto_recovers_to_nominal() {
+        let app = active_app();
+        let cache = empty_cache();
+        app.flood_condition_active.store(true, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded));
+
+        app.flood_condition_active.store(false, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::Nominal),
+            "clearing the flood flag returns posture to Nominal (auto-recovery)");
+    }
+
+    /// Default-false flag is inert (no setter exists in this PR).
+    #[test]
+    fn test_flood_default_false_is_inert() {
+        let app = active_app();
+        let cache = empty_cache();
+        assert!(!app.flood_condition_active.load(Ordering::SeqCst), "the flag defaults false");
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::Nominal),
+            "no flood (default) → no escalation");
+    }
+
+    /// The flood escalation flows through the EXISTING audit-commit-gated path:
+    /// the cache being written to Degraded proves the audit committed, and the
+    /// existing posture-transition event is emitted (no new audit plumbing).
+    #[test]
+    fn test_flood_transition_flows_through_audit_gated_path() {
+        let app = active_app();
+        let cache = empty_cache();
+        app.flood_condition_active.store(true, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded));
+
+        let store = app.store.lock().unwrap();
+        let events = store.load_all_posture_events().expect("load events");
+        assert!(
+            events.iter().any(|e| e["event_type"] == "SYSTEM_POSTURE_TRANSITION"),
+            "the flood escalation must emit the existing posture-transition audit event"
+        );
     }
 }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -227,6 +227,12 @@ pub struct AppState {
     pub transport_identity: TransportIdentityConfig,
     /// True while an RSS safe-distance violation is active (recalculate elevates to Degraded).
     pub rss_active_violation: Arc<AtomicBool>,
+    /// #99 — true while flood conditions are present. Read by the posture engine
+    /// to escalate Nominal → Degraded (SG4 operational layer), exactly like
+    /// `rss_active_violation`. The SETTER (a flood detector, or a bridge from
+    /// sustained #98 WATER_UNTRAVERSABLE vetoes) is a deferred cross-subsystem
+    /// follow-up; this flag is read-only in the current code (defaults false).
+    pub flood_condition_active: Arc<AtomicBool>,
     /// Recovery streak for clearing an active RSS violation.
     pub rss_recovery_streak: Arc<Mutex<RssRecoveryStreak>>,
     /// #104 — the currently-open post-incident forensic sequence (correlation id
@@ -264,6 +270,7 @@ impl AppState {
             posture_tx,
             transport_identity: TransportIdentityConfig::from_env(),
             rss_active_violation: Arc::new(AtomicBool::new(false)),
+            flood_condition_active: Arc::new(AtomicBool::new(false)),
             rss_recovery_streak: Arc::new(Mutex::new(RssRecoveryStreak { count: 0, start_ms: 0 })),
             current_incident: Arc::new(Mutex::new(None)),
             post_incident_write_failures: Arc::new(AtomicU64::new(0)),


### PR DESCRIPTION
The **operational** SG4 complement to #98. Where #98 is the tactical per-trajectory water veto (→ MRC stop-short), #99 degrades **fleet posture** when flood conditions are present. It mirrors the existing RSS escalation exactly — the posture engine reads an atomic flag (it does **not** call into parko), the same decoupling that sidesteps any cross-subsystem reach.

## TASK 1 — the flag
`AppState` gains `flood_condition_active: Arc<AtomicBool>` alongside `rss_active_violation` (default `false`). **Read-only in this PR** — no setter (see scope).

## TASK 2 — the coupling
Applied in `posture_engine::recalculate_and_broadcast` — confirmed the **single authoritative write path** (`posture_engine_v2::recalculate_and_broadcast_with_context` just delegates to it; v2 only *sets* the RSS flag via recovery hysteresis). The existing RSS escalation becomes additive with flood under the **same Nominal-only guard**:
```rust
let escalate = (app.rss_active_violation.load(SeqCst)
    || app.flood_condition_active.load(SeqCst))
    && dag_posture == FleetPosture::Nominal;
let new_posture = if escalate { FleetPosture::Degraded } else { dag_posture };
```
**Semantics held + tested:** flood elevates Nominal→Degraded **only**; it **never downgrades a DAG LockedOut** (the Nominal-only guard); it **composes** with RSS (either → Degraded); and it **auto-recovers** — when the flag clears and the DAG is Nominal, posture returns to Nominal via the existing path (no new recovery logic). The escalated posture is computed **before** persist, so it flows through the existing audit-commit-gated `persist→cache→broadcast` and emits the existing `SYSTEM_POSTURE_TRANSITION` event — **no new audit plumbing**.

## Tests (7, through the real `recalculate_and_broadcast`)
DAG postures forced by node insertion (Untrusted→LockedOut, Unknown→Degraded, empty→Nominal): nominal→degraded; **locked-out stays locked-out** (the key safety assertion); degraded stays degraded; flood+rss compose; flag-clears→auto-recovery; default-false inert; and the transition flows through the audit-gated path (posture-transition event emitted).

## Scope — setter deferred (named follow-up)
The flag **setter** — a flood detector, or a bridge from sustained #98 `WATER_UNTRAVERSABLE` vetoes (parko → src/, cross-subsystem) — is a **deferred follow-up with its own scoping** (like the #103 audit-route deferral). Named here, not built. The flag is inert until then.

## Verify
- `cargo test --lib` green — **595 passed** (+7), incl. the no-downgrade, composition, and auto-recovery tests. Clippy clean.
- Diff = only `src/verifier.rs` + `src/posture_engine.rs`; **no `parko/**`, no `src/gateway/**`**; talisman `997fb7ae15ce3e11adec9218044c7c84b049ad3b` byte-identical.

Refs #99.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_