### PR TITLE
chore(clippy): resolve all outstanding clippy warnings (both workspaces)

### DIFF
--- a/parko/crates/parko-core/src/scheduler.rs
+++ b/parko/crates/parko-core/src/scheduler.rs
@@ -140,7 +140,7 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
             .payload
             .named_tensors
             .values()
-            .map(|s| s.as_slice().len() * std::mem::size_of::<f32>())
+            .map(|s| std::mem::size_of_val(s.as_slice()))
             .sum();
 
         let backend_ref = Arc::clone(&self.backend);

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -11,6 +11,11 @@
 // (linear_velocity_mps, steering_angle_deg) — semantically different
 // control representations.
 //
+// (clippy doc-list lints are allowed below: `angular_bound.rs` carries
+// column-aligned ASCII parameter-derivation tables in its doc-comments that the
+// markdown-nesting lints would misalign.)
+#![allow(clippy::doc_lazy_continuation, clippy::doc_overindented_list_items)]
+//
 //   - Linear axis is bridged through Kirra's vehicle kinematics contract
 //     (acceleration, deceleration, lateral-accel; see
 //     `validate_vehicle_command`).
@@ -109,25 +114,24 @@ fn degraded_channel_violation(current: f64, proposed: f64, eps: f64) -> Option<&
     None
 }
 
-/// **Angular-velocity bound — SOTIF-derived (issue #136).**
-///
-/// The H1 placeholder constants (`MAX_ANGULAR_VELOCITY_RAD_S_PLACEHOLDER
-/// = 1.5`, `MRC_ANGULAR_VELOCITY_CEILING_RAD_S = 0.5`) are removed.
-/// The bound is now computed by
-/// `crate::angular_bound::AngularVelocityBound::omega_max(v)` from
-/// platform parameters (`PlatformParams`):
-///
-///   ω_max(v) = min(rollover(v), sweep, ftti)
-///
-/// with rollover masked below `ROLLOVER_MIN_LINEAR_VELOCITY_MPS` to
-/// handle the v=0 singularity. See `crate::angular_bound` and
-/// `docs/safety/ANGULAR_VELOCITY_SOTIF.md` for the derivation,
-/// assumptions, and worked reference numbers.
-///
-/// **Status:** DRAFT — pending formal safety-engineer review. The
-/// improvement over the H1 placeholders is real (reasoning + defensible
-/// values where there were none), but treating these numbers as a
-/// validated safety claim requires sign-off.
+// Angular-velocity bound — SOTIF-derived (issue #136).
+//
+// The H1 placeholder constants (`MAX_ANGULAR_VELOCITY_RAD_S_PLACEHOLDER = 1.5`,
+// `MRC_ANGULAR_VELOCITY_CEILING_RAD_S = 0.5`) are removed. The bound is now
+// computed by `crate::angular_bound::AngularVelocityBound::omega_max(v)` from
+// platform parameters (`PlatformParams`):
+//
+//   ω_max(v) = min(rollover(v), sweep, ftti)
+//
+// with rollover masked below `ROLLOVER_MIN_LINEAR_VELOCITY_MPS` to handle the
+// v=0 singularity. See `crate::angular_bound` and
+// `docs/safety/ANGULAR_VELOCITY_SOTIF.md` for the derivation, assumptions, and
+// worked reference numbers.
+//
+// Status: DRAFT — pending formal safety-engineer review. The improvement over
+// the H1 placeholders is real (reasoning + defensible values where there were
+// none), but treating these numbers as a validated safety claim requires
+// sign-off.
 
 /// CHECKER-OVER-DOER pairwise RSS evaluation (issue #92).
 ///
@@ -282,6 +286,12 @@ pub struct KirraGovernor {
     mrc_angular_bound: AngularVelocityBound,
 }
 
+impl Default for KirraGovernor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KirraGovernor {
     /// Construct a governor that holds both nominal and MRC fallback
     /// contract profiles and selects between them per-call based on
@@ -379,7 +389,7 @@ impl KirraGovernor {
     pub fn nominal() -> Self {
         let profile = VehicleKinematicsContract::nominal_reference_profile();
         Self {
-            nominal_contract: profile.clone(),
+            nominal_contract: profile,
             fallback_contract: profile,
             rss_state: RssState { safe: true, longitudinal_margin: f64::MAX, lateral_margin: f64::MAX },
             nominal_angular_bound: AngularVelocityBound::nominal(PlatformParams::conservative_default()),
@@ -393,7 +403,7 @@ impl KirraGovernor {
     pub fn mrc_fallback() -> Self {
         let profile = VehicleKinematicsContract::mrc_fallback_profile();
         Self {
-            nominal_contract: profile.clone(),
+            nominal_contract: profile,
             fallback_contract: profile,
             rss_state: RssState { safe: true, longitudinal_margin: f64::MAX, lateral_margin: f64::MAX },
             nominal_angular_bound: AngularVelocityBound::nominal(PlatformParams::conservative_default()),

--- a/parko/crates/parko-ros2/src/lib.rs
+++ b/parko/crates/parko-ros2/src/lib.rs
@@ -20,6 +20,10 @@
 // (KIRRA-OCCY-TOPOLOGY-001) — the parallel-paths L1 decision Parko +
 // Occy run side by side, sharing safety primitives, never chained.
 
+// clippy doc-list lints allowed: `command_mapping.rs` documents the Twist 2D
+// subset as an aligned list the markdown-nesting lint would reformat.
+#![allow(clippy::doc_lazy_continuation, clippy::doc_overindented_list_items)]
+
 pub mod command_mapping;
 pub mod comparator_adapter;
 pub mod config;

--- a/parko/crates/parko-ros2/src/sensor_mapping.rs
+++ b/parko/crates/parko-ros2/src/sensor_mapping.rs
@@ -1898,7 +1898,7 @@ mod camera_tests {
         let bytes = [10u8, 20, 30, 40]; // 2×2 mono
         let cfg = cfg_2x2_unit01_nchw(CameraEncoding::Mono8);
         let out = CameraMapping::new(cfg).to_tensor(&CameraSample { bytes: &bytes, src_width: 2, src_height: 2 }).expect("mono");
-        assert_eq!(get(&out).len(), 2 * 2 * 1, "mono8 produces H*W*1 floats");
+        assert_eq!(get(&out).len(), (2 * 2), "mono8 produces H*W*1 floats");
     }
 
     /// Resize nearest-neighbour to a larger target.
@@ -2879,7 +2879,7 @@ mod radar_tests {
         let r = t(&out);
         assert_eq!(r.len(), 5 * 2);
         assert_eq!(r[0 * 2], 10.0); // range
-        assert_eq!(r[1 * 2], 0.2);  // az
+        assert_eq!(r[2], 0.2);  // az
         assert_eq!(r[3 * 2], 4.0);  // velocity (Doppler)
         // detection-1 slots (odd indices) are padding.
         assert!((0..5).all(|f| r[f * 2 + 1] == 0.0));
@@ -3065,8 +3065,8 @@ mod radar_tests {
                 prop_assert_eq!(grid[base + 4], d.rcs);
             }
             // Remaining rows are zero padding — no phantom detections.
-            for slot in (k * RADAR_FEATURES)..(8 * RADAR_FEATURES) {
-                prop_assert_eq!(grid[slot], 0.0);
+            for &cell in &grid[(k * RADAR_FEATURES)..(8 * RADAR_FEATURES)] {
+                prop_assert_eq!(cell, 0.0);
             }
         }
     }

--- a/src/gateway/kinematics_proptest.rs
+++ b/src/gateway/kinematics_proptest.rs
@@ -212,18 +212,15 @@ proptest! {
     #[test]
     fn prop_clamp_linear_value_within_speed_contract(cmd in valid_dt_command()) {
         let contract = VehicleKinematicsContract::nominal_reference_profile();
-        match validate_vehicle_command(&cmd, &contract) {
-            EnforceAction::ClampLinear(v) => {
-                prop_assert!(
-                    v.is_finite(),
-                    "ClampLinear value must be finite, got {v}"
-                );
-                prop_assert!(
-                    v.abs() <= contract.max_speed_mps + 1e-9,
-                    "ClampLinear value {v} must be <= max_speed {}", contract.max_speed_mps
-                );
-            }
-            _ => {}
+        if let EnforceAction::ClampLinear(v) = validate_vehicle_command(&cmd, &contract) {
+            prop_assert!(
+                v.is_finite(),
+                "ClampLinear value must be finite, got {v}"
+            );
+            prop_assert!(
+                v.abs() <= contract.max_speed_mps + 1e-9,
+                "ClampLinear value {v} must be <= max_speed {}", contract.max_speed_mps
+            );
         }
     }
 }
@@ -232,19 +229,16 @@ proptest! {
     #[test]
     fn prop_clamp_steering_value_is_finite(cmd in valid_dt_command()) {
         let contract = VehicleKinematicsContract::nominal_reference_profile();
-        match validate_vehicle_command(&cmd, &contract) {
-            EnforceAction::ClampSteering(delta) => {
-                prop_assert!(
-                    delta.is_finite(),
-                    "ClampSteering value must be finite, got {delta}"
-                );
-                prop_assert!(
-                    delta.abs() <= contract.max_steering_deg + 1e-9,
-                    "ClampSteering value {delta} must be <= max_steering_deg {}",
-                    contract.max_steering_deg
-                );
-            }
-            _ => {}
+        if let EnforceAction::ClampSteering(delta) = validate_vehicle_command(&cmd, &contract) {
+            prop_assert!(
+                delta.is_finite(),
+                "ClampSteering value must be finite, got {delta}"
+            );
+            prop_assert!(
+                delta.abs() <= contract.max_steering_deg + 1e-9,
+                "ClampSteering value {delta} must be <= max_steering_deg {}",
+                contract.max_steering_deg
+            );
         }
     }
 }

--- a/src/gateway/perception_monitor.rs
+++ b/src/gateway/perception_monitor.rs
@@ -635,7 +635,7 @@ pub fn apply_perception_cap(
     contract: &VehicleKinematicsContract,
     effective_cap: Option<f64>,
 ) -> VehicleKinematicsContract {
-    let mut out = contract.clone();
+    let mut out = *contract;
     if let Some(cap) = effective_cap {
         let existing = out.effective_max_speed_mps();
         out.odd_speed_cap_mps = Some(existing.min(cap));

--- a/src/kinematics_sim.rs
+++ b/src/kinematics_sim.rs
@@ -639,7 +639,7 @@ mod kinematics_sim_tests {
             let target = (i as f64 * 0.5).min(30.0);
             ProposedVehicleCommand {
                 linear_velocity_mps: target,
-                current_velocity_mps: ((i as f64 - 1.0) * 0.5).max(0.0).min(30.0),
+                current_velocity_mps: ((i as f64 - 1.0) * 0.5).clamp(0.0, 30.0),
                 delta_time_s: DT,
                 steering_angle_deg: 0.0,
                 current_steering_angle_deg: 0.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,13 @@
 // src/lib.rs
 
+// These two doc lints fire on intentionally column-aligned ASCII derivation
+// tables in safety doc-comments (e.g. the SG2 lateral-margin budget in
+// `gateway/containment.rs`, the perception kinematic-ceiling budget in
+// `gateway/perception_monitor.rs`). Satisfying them would misalign those tables,
+// which are read as evidence — so the alignment wins over the markdown-nesting
+// pedantry.
+#![allow(clippy::doc_lazy_continuation, clippy::doc_overindented_list_items)]
+
 pub mod kirra_core;
 pub mod modbus_adapter;
 pub mod config;

--- a/src/posture_cache.rs
+++ b/src/posture_cache.rs
@@ -110,9 +110,9 @@ impl CachedFleetPosture {
     /// Uses generation=0 (sentinel for "no engine recalculation has landed
     /// yet") and the current system time. `next_generation()` always returns
     /// >= 1, so a generation=0 seed is guaranteed to be superseded by the
-    /// first real engine write — required for the monotonic-replace check
-    /// in `replace_cache_if_newer` to accept the first recalc result.
-    /// For production engine writes, use `new_with_generation` instead.
+    /// > first real engine write — required for the monotonic-replace check
+    /// > in `replace_cache_if_newer` to accept the first recalc result.
+    /// > For production engine writes, use `new_with_generation` instead.
     pub fn new(posture: FleetPosture) -> Self {
         use std::time::{SystemTime, UNIX_EPOCH};
         let now = SystemTime::now()

--- a/src/recovery_hysteresis.rs
+++ b/src/recovery_hysteresis.rs
@@ -381,6 +381,9 @@ pub async fn handle_sensor_fault_report(
 
 #[cfg(test)]
 mod hysteresis_tests {
+    // These tests assert COMPILE-TIME-CONSTANT invariants between config
+    // constants (e.g. TIMEOUT > WARN) — that they are constant is the point.
+    #![allow(clippy::assertions_on_constants)]
     use super::*;
 
     #[test]

--- a/src/standby_monitor.rs
+++ b/src/standby_monitor.rs
@@ -641,6 +641,9 @@ async fn perform_promotion(
 
 #[cfg(test)]
 mod standby_monitor_tests {
+    // These tests assert COMPILE-TIME-CONSTANT invariants between config
+    // constants (e.g. TIMEOUT > WARN) — that they are constant is the point.
+    #![allow(clippy::assertions_on_constants)]
     use super::*;
 
     // NOTE (#80): the former wall-clock-age arithmetic tests

--- a/src/telemetry_watchdog.rs
+++ b/src/telemetry_watchdog.rs
@@ -319,6 +319,9 @@ pub(crate) fn watchdog_sweep_once(
 
 #[cfg(test)]
 mod watchdog_tests {
+    // These tests assert COMPILE-TIME-CONSTANT invariants between config
+    // constants (e.g. TIMEOUT > WARN) — that they are constant is the point.
+    #![allow(clippy::assertions_on_constants)]
     use super::*;
 
     #[test]

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -316,6 +316,9 @@ impl AppState {
     }
 
     /// Persist node to SQLite then update in-memory map (fail-closed: disk before memory).
+    // `Result<_, ()>` is intentional: the caller fail-closes on ANY error without
+    // needing a typed reason (the detail is logged at the store layer).
+    #[allow(clippy::result_unit_err)]
     pub fn persist_and_insert_node(&self, node: RegisteredNode) -> Result<(), ()> {
         self.store.lock()
             .map_err(|_| ())?
@@ -332,6 +335,7 @@ impl AppState {
     /// Returns `Ok(true)` if the node existed and was updated, `Ok(false)` if
     /// no such node is registered (the caller fail-closes on this), `Err(())`
     /// on a store failure.
+    #[allow(clippy::result_unit_err)] // intentional fail-closed `()` error; see persist_and_insert_node.
     pub fn mark_node_untrusted(
         &self,
         node_id: &str,
@@ -351,6 +355,7 @@ impl AppState {
     }
 
     /// Persist dependency list to SQLite then update in-memory graph (fail-closed).
+    #[allow(clippy::result_unit_err)] // intentional fail-closed `()` error; see persist_and_insert_node.
     pub fn persist_and_insert_deps(&self, node_id: &str, deps: Vec<String>) -> Result<(), ()> {
         self.store.lock()
             .map_err(|_| ())?

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -4240,7 +4240,7 @@ mod audit_anchor_head_77_tests {
     use super::*;
     use rusqlite::params;
     use ed25519_dalek::SigningKey;
-    use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
+    use base64::engine::general_purpose::STANDARD as b64e;
 
     fn signed_store() -> (VerifierStore, ed25519_dalek::VerifyingKey) {
         let mut s = VerifierStore::new(":memory:").expect("store");
@@ -4459,7 +4459,7 @@ mod causal_chain_87_tests {
         }, sk.as_ref()).unwrap();
         s.append_causal_event(&CausalEventInput {
             entry_id: "entry-2", asset_id: "follower", event_type: "DEGRADE", payload: "{}",
-            caused_by: &[id1.clone()], affects_assets: &[],
+            caused_by: std::slice::from_ref(&id1), affects_assets: &[],
             fabric_generation: 1, timestamp_ms: 200,
         }, sk.as_ref()).unwrap();
         s.append_causal_event(&CausalEventInput {
@@ -4577,7 +4577,7 @@ mod causal_chain_87_tests {
             entry_id = e.entry_id.clone();
             s.append_causal_event(&CausalEventInput {
                 entry_id: "persist-2", asset_id: "b", event_type: "EVT2", payload: "{}",
-                caused_by: &[entry_id.clone()], affects_assets: &[],
+                caused_by: std::slice::from_ref(&entry_id), affects_assets: &[],
                 fabric_generation: 3, timestamp_ms: 2000,
             }, None).unwrap();
         } // drop closes the connection


### PR DESCRIPTION
Both workspaces — the root `kirra-runtime-sdk` crate and the `parko/` sub-workspace — are now **clippy-clean (0 warnings, `--all-targets`)**. The frozen talisman `src/gateway/kinematics_contract.rs` is **byte-identical and not in the diff**, and there are no verdict-path changes.

49 pre-existing warnings → 0, handled in three tiers (not blanket-silenced):

### Genuinely fixed (behaviour-preserving)
- `manual_slice_size_calculation` → `size_of_val`; `single_match` → `if let`; `manual_clamp` → `.clamp()`; `needless_range_loop` → slice iteration; `cloned_ref_to_slice_refs` → `std::slice::from_ref`; unused `base64::Engine` import (re-imported locally in the helpers); `empty_line_after_doc_comments` (an orphaned angular-bound narrative converted to a `//` comment); `new_without_default` → `impl Default for KirraGovernor`.
- Most applied via `cargo clippy --fix`; the rest by hand.

### Intentional-by-design → `#[allow]` with rationale (not silenced blindly)
- **`result_unit_err`** on `persist_and_insert_node` / `mark_node_untrusted` / `persist_and_insert_deps`: the `Result<_, ()>` is deliberate — the caller fail-closes on *any* store error without needing a typed reason (INV-12, disk-before-memory).
- **`assertions_on_constants`** in the `recovery_hysteresis` / `telemetry_watchdog` / `standby_monitor` test modules: these tests assert **compile-time-constant relationships** between config constants (`TIMEOUT > WARN`, `SWEEP < WARN`, …) — that they're constant is the whole point of the checks.
- **`doc_lazy_continuation` / `doc_overindented_list_items`**: scoped crate-level `#[allow]` in the 3 affected crates — they fire on **intentionally column-aligned ASCII derivation tables** in safety doc-comments (the SG2 lateral-margin budget, the perception kinematic-ceiling budget, the angular-bound parameter table) that the markdown-nesting lints would misalign. The alignment is read as evidence, so it wins.

### Verify
- `cargo clippy --all-targets` → **0 warnings** in both workspaces.
- No behaviour change: root `cargo test --lib` green (**588**); parko `cargo test -p parko-core -p parko-kirra -p parko-ros2` green (**142** in parko-kirra incl. the full RSS/water/impact/occlusion set).
- Talisman `997fb7ae15ce3e11adec9218044c7c84b049ad3b` byte-identical; **no `src/gateway/kinematics_contract.rs` in the diff**.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_