### PR TITLE
feat(commit-zone): non-yielding-agent clearance — SG5 brick 3 (#108)

### DIFF
--- a/parko/crates/parko-core/src/commit_zone.rs
+++ b/parko/crates/parko-core/src/commit_zone.rs
@@ -106,6 +106,12 @@ pub struct CommitZoneCfg {
     /// Extra receiving-space margin (m) required beyond the vehicle length for a
     /// downstream exit to count as verified. VALIDATION-PENDING.
     pub exit_margin_m: f64,
+    /// Temporal safety margin (s) the ego must FULLY clear a conflict zone ahead
+    /// of a non-yielding crosser's arrival (the train / fast non-yielding-agent
+    /// model). VALIDATION-PENDING — the margin also absorbs MODERATE agent
+    /// acceleration (the model itself is constant-speed; a worst-case
+    /// ACCELERATING agent is explicitly out of scope here).
+    pub clearance_time_margin_s: f64,
 }
 
 impl Default for CommitZoneCfg {
@@ -115,6 +121,7 @@ impl Default for CommitZoneCfg {
             look_ahead_m: 94.0,    // SG5 / SG4 ≈ 94 m look-ahead basis
             vehicle_length_m: 4.5, // a passenger-vehicle-class default
             exit_margin_m: 1.0,    // a small standoff beyond the vehicle length
+            clearance_time_margin_s: 2.0, // conservative temporal standoff
         }
     }
 }
@@ -140,6 +147,118 @@ pub struct ExitClearanceEvidence {
 pub fn exit_clearance_verified(evidence: &ExitClearanceEvidence, cfg: &CommitZoneCfg) -> bool {
     evidence.downstream_clear_m.is_finite()
         && evidence.downstream_clear_m >= cfg.vehicle_length_m + cfg.exit_margin_m
+}
+
+/// A non-yielding crosser converging on the commit zone — a train, or a fast
+/// agent that will NOT brake for the ego (the no-yield assumption). Synthetic in
+/// tests; detection / ingestion is DEFERRED (as with the agent-set / water /
+/// occlusion ingestion).
+///
+/// WHY THIS ISN'T RSS: `longitudinal_safe_distance` assumes the other agent
+/// BRAKES at `brake_max` (the yielding assumption). A train does not yield. This
+/// model assumes the agent MAINTAINS speed (never brakes) and asks whether it
+/// will occupy the conflict zone while the ego is still inside it.
+#[derive(Debug, Clone, Copy)]
+pub struct NonYieldingAgent {
+    /// The agent's converging speed (m/s) toward the conflict zone. Assumed
+    /// CONSTANT (no braking). `<= 0` (stationary / receding), finite → the agent
+    /// never arrives (clear w.r.t. it). Non-finite → fail-closed NOT clear.
+    pub approach_velocity_mps: f64,
+    /// Distance along the AGENT's path to the conflict zone (m). Non-finite →
+    /// fail-closed NOT clear.
+    pub distance_to_conflict_m: f64,
+}
+
+/// The non-yielding-crosser scene this tick. Mirrors `AgentScene`'s three-way
+/// ABSENT-vs-KNOWN discipline EXACTLY (cf. parko-kirra empty-agents rule, #92):
+/// an absent detector is NOT "no train", and an EMPTY agent vector is ambiguous
+/// vs a positive "none detected" — both fail closed.
+#[derive(Debug, Clone)]
+pub enum NonYieldingScene {
+    /// No detection ran this tick → fail-closed NOT clear (absent ≠ none).
+    Absent,
+    /// Detection ran and positively reported NO non-yielding agent → clear by
+    /// this check.
+    KnownNone,
+    /// Detected non-yielding agents — ALL must clear. An EMPTY vec is ambiguous
+    /// vs `KnownNone` and is treated as NOT clear (the #92 empty-agents rule).
+    Agents(Vec<NonYieldingAgent>),
+}
+
+/// SG5 — derive `clearance_confirmed` against the NON-YIELDING model: is entry
+/// clear of EVERY converging non-yielding crosser?
+///
+/// `true` iff the ego FULLY exits the conflict zone (its whole length past the
+/// far edge) before each agent arrives, with `clearance_time_margin_s` to spare:
+///
+/// * `ego_full_clear_time = (map.distance_to_zone_m + zone_length_m +
+///   cfg.vehicle_length_m) / ego_speed_mps` — constant-speed ego (conservative).
+/// * `agent_arrival_time = distance_to_conflict_m / approach_velocity_mps` —
+///   constant speed, NO braking assumed.
+/// * an agent is clear iff `agent_arrival_time > ego_full_clear_time +
+///   cfg.clearance_time_margin_s` (STRICT). ALL agents must clear.
+///
+/// FAIL-CLOSED arithmetic:
+/// * `ego_speed_mps <= 0` or non-finite → NOT clear (an ego that cannot traverse
+///   cannot claim clearance).
+/// * any non-finite agent field → NOT clear (NaN must not ride the `<= 0` branch).
+/// * `approach_velocity_mps <= 0` (stationary / receding), FINITE → that agent
+///   never arrives → clear w.r.t. that agent.
+/// * `Absent` / empty `Agents` vec → NOT clear; `KnownNone` → clear.
+///
+/// Callers POPULATE `ZoneAhead.clearance_confirmed` with this — the same pattern
+/// as [`exit_clearance_verified`]. NOTE: "confirmed clearance" for SG5 now means
+/// CONFIRMED AGAINST THE NON-YIELDING MODEL, not perception's optimistic guess.
+// SAFETY: SG5 | REQ: non-yielding-agent-clearance | TEST: test_nonyield_train_beats_ego_not_clear,test_nonyield_ego_clears_with_margin,test_nonyield_margin_boundary_strict,test_nonyield_all_rule_one_not_clear,test_nonyield_absent_not_clear,test_nonyield_known_none_clear,test_nonyield_empty_vec_not_clear,test_nonyield_ego_speed_nonpositive_or_nan_not_clear,test_nonyield_agent_receding_clear_nan_velocity_not_clear,test_nonyield_nonfinite_distance_not_clear
+pub fn non_yielding_clearance(
+    scene: &NonYieldingScene,
+    map: &CommitZoneMap,
+    zone_length_m: f64,
+    ego_speed_mps: f64,
+    cfg: &CommitZoneCfg,
+) -> bool {
+    let agents = match scene {
+        // Absent detector ≠ "no train"; empty vec is ambiguous vs KnownNone.
+        NonYieldingScene::Absent => return false,
+        NonYieldingScene::KnownNone => return true,
+        NonYieldingScene::Agents(a) if a.is_empty() => return false,
+        NonYieldingScene::Agents(a) => a,
+    };
+
+    // An ego that cannot traverse cannot claim clearance.
+    if !ego_speed_mps.is_finite() || ego_speed_mps <= 0.0 {
+        return false;
+    }
+    if !map.distance_to_zone_m.is_finite() || !zone_length_m.is_finite() {
+        return false;
+    }
+    let ego_full_clear_time =
+        (map.distance_to_zone_m + zone_length_m + cfg.vehicle_length_m) / ego_speed_mps;
+    if !ego_full_clear_time.is_finite() {
+        return false;
+    }
+
+    for agent in agents {
+        // NaN discipline FIRST so a non-finite value can never ride the <= 0
+        // (receding) branch.
+        if !agent.approach_velocity_mps.is_finite() || !agent.distance_to_conflict_m.is_finite() {
+            return false;
+        }
+        // Stationary / receding (finite) → never arrives → clear w.r.t. this one.
+        if agent.approach_velocity_mps <= 0.0 {
+            continue;
+        }
+        let agent_arrival_time = agent.distance_to_conflict_m / agent.approach_velocity_mps;
+        if !agent_arrival_time.is_finite() {
+            return false;
+        }
+        // Clear ONLY if the agent arrives strictly AFTER the ego has fully
+        // cleared, plus the temporal margin. Equality (or earlier) → NOT clear.
+        if agent_arrival_time <= ego_full_clear_time + cfg.clearance_time_margin_s {
+            return false;
+        }
+    }
+    true
 }
 
 /// SG5 — must the governor BLOCK entry to this commit zone (stop short)?
@@ -502,5 +621,126 @@ mod tests {
         };
         assert!(commit_zone_blocked(&s, &c),
             "a derived unverified exit must veto entry");
+    }
+
+    // ───────────────────── #108 non-yielding-agent clearance ───────────────
+
+    /// Reference geometry: zone at 50 m, length 30 m, ego 10 m/s. The ego must
+    /// clear `50 + 30 + 4.5 = 84.5 m` → `ego_full_clear_time = 8.45 s`. With the
+    /// default 2.0 s margin the agent must arrive AFTER 10.45 s.
+    fn agents(v: Vec<NonYieldingAgent>) -> NonYieldingScene {
+        NonYieldingScene::Agents(v)
+    }
+
+    /// Headline case: a train arrives BEFORE the ego has cleared → not clear.
+    #[test]
+    fn test_nonyield_train_beats_ego_not_clear() {
+        // arrival = 60 / 10 = 6.0 s  <  8.45 s clear time → not clear.
+        let s = agents(vec![NonYieldingAgent {
+            approach_velocity_mps: 10.0, distance_to_conflict_m: 60.0,
+        }]);
+        assert!(!non_yielding_clearance(&s, &healthy_map(50.0), 30.0, 10.0, &cfg()),
+            "a train that arrives before the ego clears must NOT be clear");
+    }
+
+    /// Ego clears with margin to spare → clear.
+    #[test]
+    fn test_nonyield_ego_clears_with_margin() {
+        // arrival = 200 / 10 = 20.0 s  >  8.45 + 2.0 = 10.45 s → clear.
+        let s = agents(vec![NonYieldingAgent {
+            approach_velocity_mps: 10.0, distance_to_conflict_m: 200.0,
+        }]);
+        assert!(non_yielding_clearance(&s, &healthy_map(50.0), 30.0, 10.0, &cfg()),
+            "an agent arriving well after the ego clears must be clear");
+    }
+
+    /// Hand-checked margin boundary: arrival EXACTLY at clear + margin → NOT clear
+    /// (strict `>`). clear+margin = 8.45 + 2.0 = 10.45 s; at v=10, that's d=104.5.
+    #[test]
+    fn test_nonyield_margin_boundary_strict() {
+        let at = agents(vec![NonYieldingAgent {
+            approach_velocity_mps: 10.0, distance_to_conflict_m: 104.5,
+        }]);
+        assert!(!non_yielding_clearance(&at, &healthy_map(50.0), 30.0, 10.0, &cfg()),
+            "arrival exactly at clear+margin must NOT be clear (strict >)");
+        // just past the boundary → clear.
+        let past = agents(vec![NonYieldingAgent {
+            approach_velocity_mps: 10.0, distance_to_conflict_m: 104.5 + 1e-3,
+        }]);
+        assert!(non_yielding_clearance(&past, &healthy_map(50.0), 30.0, 10.0, &cfg()),
+            "arrival just past clear+margin must be clear");
+    }
+
+    /// ALL rule: one clear agent + one not-clear agent → NOT clear.
+    #[test]
+    fn test_nonyield_all_rule_one_not_clear() {
+        let s = agents(vec![
+            NonYieldingAgent { approach_velocity_mps: 10.0, distance_to_conflict_m: 200.0 }, // clear
+            NonYieldingAgent { approach_velocity_mps: 10.0, distance_to_conflict_m: 60.0 },  // not clear
+        ]);
+        assert!(!non_yielding_clearance(&s, &healthy_map(50.0), 30.0, 10.0, &cfg()),
+            "one non-clear agent among many must make the scene NOT clear");
+    }
+
+    /// Absent detector → NOT clear (absent ≠ none).
+    #[test]
+    fn test_nonyield_absent_not_clear() {
+        assert!(!non_yielding_clearance(&NonYieldingScene::Absent, &healthy_map(50.0), 30.0, 10.0, &cfg()),
+            "an absent detector must NOT be clear (fail-closed)");
+    }
+
+    /// KnownNone → clear.
+    #[test]
+    fn test_nonyield_known_none_clear() {
+        assert!(non_yielding_clearance(&NonYieldingScene::KnownNone, &healthy_map(50.0), 30.0, 10.0, &cfg()),
+            "a positive 'none detected' must be clear");
+    }
+
+    /// EMPTY Agents vec is ambiguous vs KnownNone → NOT clear (#92 rule).
+    #[test]
+    fn test_nonyield_empty_vec_not_clear() {
+        assert!(!non_yielding_clearance(&agents(vec![]), &healthy_map(50.0), 30.0, 10.0, &cfg()),
+            "an empty agents vec must NOT be clear (distinct from KnownNone)");
+    }
+
+    /// An ego that cannot traverse cannot claim clearance: speed 0 / negative /
+    /// NaN → NOT clear, even against an agent that would otherwise be clear.
+    #[test]
+    fn test_nonyield_ego_speed_nonpositive_or_nan_not_clear() {
+        let far = agents(vec![NonYieldingAgent {
+            approach_velocity_mps: 10.0, distance_to_conflict_m: 1.0e6,
+        }]);
+        for bad in [0.0, -5.0, f64::NAN] {
+            assert!(!non_yielding_clearance(&far, &healthy_map(50.0), 30.0, bad, &cfg()),
+                "ego speed {bad} must make the scene NOT clear");
+        }
+    }
+
+    /// A finite RECEDING agent (negative velocity) never arrives → clear w.r.t.
+    /// it; a NaN velocity must NOT ride the `<= 0` receding branch → NOT clear.
+    #[test]
+    fn test_nonyield_agent_receding_clear_nan_velocity_not_clear() {
+        let receding = agents(vec![NonYieldingAgent {
+            approach_velocity_mps: -3.0, distance_to_conflict_m: 5.0,
+        }]);
+        assert!(non_yielding_clearance(&receding, &healthy_map(50.0), 30.0, 10.0, &cfg()),
+            "a finite receding agent never arrives → clear w.r.t. it");
+        let nan_v = agents(vec![NonYieldingAgent {
+            approach_velocity_mps: f64::NAN, distance_to_conflict_m: 5.0,
+        }]);
+        assert!(!non_yielding_clearance(&nan_v, &healthy_map(50.0), 30.0, 10.0, &cfg()),
+            "a NaN velocity must NOT slip through the receding branch (NOT clear)");
+    }
+
+    /// Non-finite distance_to_conflict → NOT clear.
+    #[test]
+    fn test_nonyield_nonfinite_distance_not_clear() {
+        for bad in [f64::NAN, f64::INFINITY] {
+            let s = agents(vec![NonYieldingAgent {
+                approach_velocity_mps: 10.0, distance_to_conflict_m: bad,
+            }]);
+            assert!(!non_yielding_clearance(&s, &healthy_map(50.0), 30.0, 10.0, &cfg()),
+                "non-finite distance_to_conflict must be NOT clear ({bad})");
+        }
     }
 }

--- a/parko/crates/parko-core/src/lib.rs
+++ b/parko/crates/parko-core/src/lib.rs
@@ -60,8 +60,8 @@ pub use rss::{
     OcclusionScene, RssAgent, RssParams, RssState, MAX_RSS_AGENTS,
 };
 pub use commit_zone::{
-    commit_zone_blocked, exit_clearance_verified, CommitZoneCfg, CommitZoneMap, CommitZoneScene,
-    ExitClearanceEvidence,
+    commit_zone_blocked, exit_clearance_verified, non_yielding_clearance, CommitZoneCfg,
+    CommitZoneMap, CommitZoneScene, ExitClearanceEvidence, NonYieldingAgent, NonYieldingScene,
 };
 pub use impact::{is_impact, ImpactCfg, ImpactEvidence, ImpactLatch};
 pub use safety::{EnforcementAction, SafetyGovernor, SafetyPosture};

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -1408,9 +1408,10 @@ mod scene_rss_tests {
     use parko_core::commands::ControlCommand;
     use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
     use parko_core::{
-        AgentScene, CommitZoneCfg, CommitZoneMap, CommitZoneScene, ImpactCfg, ImpactEvidence,
-        ImpactLatch, OcclusionScene, RssAgent, RssParams, RssState, TraversalEvidence, WaterScene,
-        WaterVetoConfig, MAX_RSS_AGENTS,
+        non_yielding_clearance, AgentScene, CommitZoneCfg, CommitZoneMap, CommitZoneScene,
+        ImpactCfg, ImpactEvidence, ImpactLatch, NonYieldingAgent, NonYieldingScene, OcclusionScene,
+        RssAgent, RssParams, RssState, TraversalEvidence, WaterScene, WaterVetoConfig,
+        MAX_RSS_AGENTS,
     };
 
     fn params() -> RssParams {
@@ -1881,5 +1882,56 @@ mod scene_rss_tests {
             &AgentScene::KnownEmpty, &CommitZoneScene::Unknown, &CommitZoneCfg::default(), &params());
         assert!(!matches!(action, EnforcementAction::Allow),
             "an absent/unhealthy map must override pushed safe:true (Reject from map alone), got {action:?}");
+    }
+
+    /// SG5 trio end-to-end (#260 map-anchored block + #107 exit-clearance + #108
+    /// non-yielding clearance): a train that arrives before the ego clears →
+    /// DERIVED clearance_confirmed=false → blocked → overrides pushed safe:true.
+    #[test]
+    fn commit_zone_non_yielding_train_overrides_pushed_safe() {
+        let mut gov = KirraGovernor::new();
+        gov.update_rss_state(RssState { safe: true, longitudinal_margin: f64::MAX, lateral_margin: f64::MAX });
+        let cfg = CommitZoneCfg::default();
+        let map = healthy_zone_map(50.0);
+        // train: arrival 60/10 = 6.0 s < ego clear (8.45 s) → NOT clear.
+        let scene = NonYieldingScene::Agents(vec![NonYieldingAgent {
+            approach_velocity_mps: 10.0, distance_to_conflict_m: 60.0,
+        }]);
+        let clearance = non_yielding_clearance(&scene, &map, 30.0, 10.0, &cfg);
+        assert!(!clearance, "the train must defeat clearance (derived false)");
+        // exit verified independently, but clearance is false → blocked.
+        let zone = CommitZoneScene::ZoneAhead {
+            map, clearance_confirmed: clearance, exit_verified: true,
+            zone_length_m: 30.0, proposed_stop_distance_m: None,
+        };
+        let action = gov.evaluate_scene_with_commit_zone(
+            &cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal,
+            &AgentScene::KnownEmpty, &zone, &cfg, &params());
+        assert!(!matches!(action, EnforcementAction::Allow),
+            "a non-yielding train must override safe:true → MRC (stop short), got {action:?}");
+    }
+
+    /// Inverse: train arrives well AFTER the ego clears + exit verified → DERIVED
+    /// clearance_confirmed=true → permitted (no over-block).
+    #[test]
+    fn commit_zone_non_yielding_clear_passes_through() {
+        let gov = KirraGovernor::new();
+        let cfg = CommitZoneCfg::default();
+        let map = healthy_zone_map(50.0);
+        // train: arrival 200/10 = 20.0 s > 8.45 + 2.0 = 10.45 s → clear.
+        let scene = NonYieldingScene::Agents(vec![NonYieldingAgent {
+            approach_velocity_mps: 10.0, distance_to_conflict_m: 200.0,
+        }]);
+        let clearance = non_yielding_clearance(&scene, &map, 30.0, 10.0, &cfg);
+        assert!(clearance, "an agent arriving well after the ego clears must be clear");
+        let zone = CommitZoneScene::ZoneAhead {
+            map, clearance_confirmed: clearance, exit_verified: true,
+            zone_length_m: 30.0, proposed_stop_distance_m: None,
+        };
+        let action = gov.evaluate_scene_with_commit_zone(
+            &cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal,
+            &AgentScene::KnownEmpty, &zone, &cfg, &params());
+        assert!(matches!(action, EnforcementAction::Allow),
+            "a non-yielding-clear, exit-verified zone must permit entry, got {action:?}");
     }
 }


### PR DESCRIPTION
## SG5 brick 3 of 3 — non-yielding-agent clearance (#108)

Completes the SG5 commit-zone trio under EPIC #106:
- **#260** map-anchored `COMMIT_ZONE_BLOCKED` foundation
- **#107** computed exit-clearance + stop-inside
- **#108** (this) non-yielding-agent clearance — DERIVES `clearance_confirmed` exactly the way #107 derived `exit_verified`.

> **Stacked on #261.** #261 (the #107 brick) is not yet merged, so this PR is based on `feat/sg5-exit-clearance-stop-inside-107` and the diff shows **only #108's changes**. Merge #261 first; GitHub will retarget this PR's base to `main` automatically.

### Why this isn't RSS
`longitudinal_safe_distance` assumes the other agent **brakes** at `brake_max` — the *yielding* assumption. A train does not yield. The non-yielding model assumes the agent **maintains speed** (never brakes) and asks: will it occupy the conflict zone while the ego is still inside it? Entry is clear **only** if the ego *fully* exits before the agent arrives, with margin. Uncertainty → blocked.

### parko-core (`commit_zone.rs`)
- **`NonYieldingAgent { approach_velocity_mps, distance_to_conflict_m }`** — supplied input; detection/ingestion deferred (as with the agent-set / water / occlusion modules).
- **`NonYieldingScene`** mirrors `AgentScene`'s three-way discipline exactly: `Absent` (no detection → fail-closed NOT clear), `KnownNone` (clear by this check), `Agents(Vec)` (**ALL** must clear; an **empty** vec is ambiguous vs `KnownNone` → NOT clear — the #92 empty-agents rule).
- **`CommitZoneCfg`** gains `clearance_time_margin_s` (2.0, VALIDATION-PENDING).
- **`non_yielding_clearance(scene, map, zone_length_m, ego_speed_mps, cfg)`**:
  - `ego_full_clear_time = (distance_to_zone + zone_length + vehicle_length) / ego_speed` (constant-speed ego, conservative — clears its full length past the far edge).
  - `agent_arrival_time = distance_to_conflict / approach_velocity` (constant speed, no braking).
  - clear for an agent iff `arrival > clear + margin` (**strict**); **ALL** agents must clear.
  - **Fail-closed arithmetic:** `ego_speed <= 0` / non-finite → NOT clear; any non-finite agent field → NOT clear (NaN cannot ride the `<= 0` branch); a finite **receding** agent (`v <= 0`) never arrives → clear w.r.t. it.
  - Callers populate `ZoneAhead.clearance_confirmed` with this — **"confirmed clearance" for SG5 now means confirmed against the non-yielding model**, not perception's optimistic guess.

### parko-kirra
- Trio end-to-end integration: a train arriving before the ego clears derives `clearance_confirmed=false` → `commit_zone_blocked` → overrides a pushed `safe:true` → MRC (stop short); the inverse (arrives well after + exit verified) → permitted (no over-block).

### Tests
10 new parko-core unit tests (train-beats-ego, ego-clears-with-margin, strict margin boundary, ALL-rule with one not-clear, Absent/KnownNone/empty-vec discipline, ego-speed 0/neg/NaN, receding-clear vs NaN-velocity-not-clear, non-finite distance) + the 2 parko-kirra integration tests. `cargo test -p parko-core -p parko-kirra` green (140 + 119 lib tests); clippy clean.

### Scope / safety
- **parko-core + parko-kirra only.** No `src/` changes; the gateway kinematics contract is untouched — talisman blob `997fb7ae…` unchanged.
- **Out of scope:** a worst-case **accelerating** agent — the model is constant-speed + margin (the margin absorbs moderate acceleration); thresholds are VALIDATION-PENDING. Detection/ingestion of the crosser is deferred.

Closes #108. References #107. Part of EPIC #106.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_