### PR TITLE
feat(impact): signed audit bridge for the SG6 impact latch (#102 → #104)

### DIFF
--- a/parko/crates/parko-kirra/src/audit_sink.rs
+++ b/parko/crates/parko-kirra/src/audit_sink.rs
@@ -22,6 +22,7 @@ use std::sync::{Arc, Mutex};
 use base64::Engine as _;
 use ed25519_dalek::SigningKey;
 use kirra_runtime_sdk::verifier_store::VerifierStore;
+use parko_core::{ImpactCfg, ImpactEvidence, ImpactLatch};
 
 use crate::comparator::{DivergenceEvent, DivergenceEventSink, InMemoryDivergenceSink};
 
@@ -85,36 +86,30 @@ fn parse_signing_key(key_b64: &str) -> Result<SigningKey, FatalAuditConfig> {
     Ok(SigningKey::from_bytes(&bytes))
 }
 
-/// Durable, signed [`DivergenceEventSink`] (CERT-006).
-///
-/// Persists every divergence to the SDK's hash-chained, Ed25519-signed audit
-/// ledger. `record` is infallible by the trait contract — but a divergence that
-/// is *detected yet not durably recorded* is itself safety-relevant, so a
-/// persistence failure is never silently swallowed: it increments the
-/// operator-observable [`write_failures`](Self::write_failures) counter and logs
-/// loudly to stderr (matching the in-crate sink convention).
-pub struct AuditChainLinkerDivergenceSink {
+/// Shared, fail-closed writer over the SDK's hash-chained, Ed25519-signed audit
+/// ledger. Both the CERT-006 comparator-divergence sink and the SG6 impact-audit
+/// sink record through this ONE struct (REUSE — a single write path and a single
+/// `write_failures` accounting): it owns the [`VerifierStore`] handle (which owns
+/// `audit_log_chain` + the signing key) and a detected-but-unrecorded counter,
+/// and appends every event via [`VerifierStore::save_posture_event_chained`]
+/// (which goes through `AuditChainLinker::append_audit_event_tx`).
+struct ChainedAuditWriter {
     store: Arc<Mutex<VerifierStore>>,
     write_failures: AtomicU64,
 }
 
-impl AuditChainLinkerDivergenceSink {
-    /// Build a sink over an SDK store. The store MUST own the audit chain (it
-    /// does — `VerifierStore::new` creates `audit_log_chain`) and a signing key
-    /// (set via `VerifierStore::set_signing_key` / `admit_signing_key`) for the
-    /// entries to be signed.
-    pub fn new(store: Arc<Mutex<VerifierStore>>) -> Self {
+impl ChainedAuditWriter {
+    fn new(store: Arc<Mutex<VerifierStore>>) -> Self {
         Self {
             store,
             write_failures: AtomicU64::new(0),
         }
     }
 
-    /// Open a durable, *signed* divergence sink from a DB path and a base64
-    /// Ed25519 signing key. Fail-closed: a store that cannot be opened, or a key
-    /// that cannot be decoded, is a [`FatalAuditConfig`] — never a silent
+    /// Open a store from a path + base64 Ed25519 key. Fail-closed: an unopenable
+    /// store or an undecodable key is a [`FatalAuditConfig`] — never a silent
     /// fallback to an unsigned or ephemeral sink.
-    pub fn open(db_path: &str, key_b64: &str) -> Result<Self, FatalAuditConfig> {
+    fn open(db_path: &str, key_b64: &str) -> Result<Self, FatalAuditConfig> {
         let key = parse_signing_key(key_b64)?;
         let mut store = VerifierStore::new(db_path)
             .map_err(|e| FatalAuditConfig::StoreOpenFailed(e.to_string()))?;
@@ -122,10 +117,7 @@ impl AuditChainLinkerDivergenceSink {
         Ok(Self::new(Arc::new(Mutex::new(store))))
     }
 
-    /// Number of divergences that were DETECTED but could NOT be durably +
-    /// signed. MUST be `0` in a healthy deployment; a non-zero value means the
-    /// tamper-evident record is MISSING for that many divergences — observe it.
-    pub fn write_failures(&self) -> u64 {
+    fn write_failures(&self) -> u64 {
         self.write_failures.load(Ordering::SeqCst)
     }
 
@@ -139,6 +131,73 @@ impl AuditChainLinkerDivergenceSink {
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0)
     }
+
+    /// Append one already-serialised event body under `(source, event_type)`.
+    /// Infallible toward the caller: a lock-poison or write error increments
+    /// `write_failures` and logs loudly — never propagated, never panics.
+    fn record(&self, source: &str, event_type: &str, body: &str) {
+        let outcome = match self.store.lock() {
+            Ok(mut store) => {
+                store.save_posture_event_chained(source, event_type, body, None, Self::now_ms())
+            }
+            Err(_) => {
+                self.note_failure();
+                eprintln!(
+                    "[audit] {event_type} NOT recorded — audit store mutex poisoned \
+                     (event is UNAUDITED)"
+                );
+                return;
+            }
+        };
+        if let Err(e) = outcome {
+            self.note_failure();
+            eprintln!(
+                "[audit] AUDIT-CHAIN WRITE FAILED for {event_type}: {e} — \
+                 event detected but NOT in the tamper-evident log"
+            );
+        }
+    }
+}
+
+/// Durable, signed [`DivergenceEventSink`] (CERT-006).
+///
+/// Persists every divergence to the SDK's hash-chained, Ed25519-signed audit
+/// ledger via the shared [`ChainedAuditWriter`]. `record` is infallible by the
+/// trait contract — but a divergence that is *detected yet not durably recorded*
+/// is itself safety-relevant, so a persistence failure is never silently
+/// swallowed: it increments the operator-observable
+/// [`write_failures`](Self::write_failures) counter and logs loudly to stderr.
+pub struct AuditChainLinkerDivergenceSink {
+    writer: ChainedAuditWriter,
+}
+
+impl AuditChainLinkerDivergenceSink {
+    /// Build a sink over an SDK store. The store MUST own the audit chain (it
+    /// does — `VerifierStore::new` creates `audit_log_chain`) and a signing key
+    /// (set via `VerifierStore::set_signing_key` / `admit_signing_key`) for the
+    /// entries to be signed.
+    pub fn new(store: Arc<Mutex<VerifierStore>>) -> Self {
+        Self {
+            writer: ChainedAuditWriter::new(store),
+        }
+    }
+
+    /// Open a durable, *signed* divergence sink from a DB path and a base64
+    /// Ed25519 signing key. Fail-closed: a store that cannot be opened, or a key
+    /// that cannot be decoded, is a [`FatalAuditConfig`] — never a silent
+    /// fallback to an unsigned or ephemeral sink.
+    pub fn open(db_path: &str, key_b64: &str) -> Result<Self, FatalAuditConfig> {
+        Ok(Self {
+            writer: ChainedAuditWriter::open(db_path, key_b64)?,
+        })
+    }
+
+    /// Number of divergences that were DETECTED but could NOT be durably +
+    /// signed. MUST be `0` in a healthy deployment; a non-zero value means the
+    /// tamper-evident record is MISSING for that many divergences — observe it.
+    pub fn write_failures(&self) -> u64 {
+        self.writer.write_failures()
+    }
 }
 
 impl DivergenceEventSink for AuditChainLinkerDivergenceSink {
@@ -146,7 +205,7 @@ impl DivergenceEventSink for AuditChainLinkerDivergenceSink {
         let body = match serde_json::to_string(&event) {
             Ok(s) => s,
             Err(e) => {
-                self.note_failure();
+                self.writer.note_failure();
                 eprintln!(
                     "[CERT-006] ComparatorDivergence NOT recorded — JSON serialization failed: \
                      {e} (divergence is UNAUDITED)"
@@ -154,32 +213,8 @@ impl DivergenceEventSink for AuditChainLinkerDivergenceSink {
                 return;
             }
         };
-
-        let outcome = match self.store.lock() {
-            Ok(mut store) => store.save_posture_event_chained(
-                "governor_comparator",
-                COMPARATOR_DIVERGENCE_EVENT_TYPE,
-                &body,
-                None,
-                Self::now_ms(),
-            ),
-            Err(_) => {
-                self.note_failure();
-                eprintln!(
-                    "[CERT-006] ComparatorDivergence NOT recorded — audit store mutex poisoned \
-                     (divergence is UNAUDITED)"
-                );
-                return;
-            }
-        };
-
-        if let Err(e) = outcome {
-            self.note_failure();
-            eprintln!(
-                "[CERT-006] AUDIT-CHAIN WRITE FAILED for ComparatorDivergence: {e} — \
-                 divergence detected but NOT in the tamper-evident log"
-            );
-        }
+        self.writer
+            .record("governor_comparator", COMPARATOR_DIVERGENCE_EVENT_TYPE, &body);
     }
 }
 
@@ -211,6 +246,244 @@ pub fn select_divergence_sink(
                 db_path, key_b64,
             )?)),
         },
+    }
+}
+
+// ───────────────────── SG6 impact-audit bridge (#102 → #104) ────────────────
+//
+// Record `ImpactLatch` transitions as signed, hash-chained audit events through
+// the SAME #247 sink crossing (parko-kirra → VerifierStore → the
+// `append_audit_event_tx` ledger). The impact rows land in the SAME ledger the
+// #104 post-incident sequence writes to (forensic adjacency) — no cross-subsystem
+// plumbing: the latch already drives deny/posture, and the incident opens via the
+// existing posture path. parko-kirra ONLY; node wiring is a deferred deploy step.
+
+/// The audit-log event type for a post-collision impact LATCH (false→true).
+/// PascalCase, matching the #247 `"ComparatorDivergence"` convention in the same
+/// table.
+pub const IMPACT_DETECTED_EVENT_TYPE: &str = "ImpactDetected";
+/// The audit-log event type for an impact-latch CLEARANCE (true→false).
+pub const IMPACT_CLEARED_EVENT_TYPE: &str = "ImpactCleared";
+
+/// Audit source tag for SG6 impact events (the `governor_comparator` analogue).
+const IMPACT_AUDIT_SOURCE: &str = "governor_impact_latch";
+
+/// The trigger breakdown recorded with an `ImpactDetected` event: WHICH fusion
+/// signals fired — NEVER raw sensor streams. The IMU magnitude is included ONLY
+/// when finite (a non-finite reading never latches on its own and is not a
+/// trustworthy datum to retain).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ImpactDetectedPayload {
+    /// The physical contact sensor fired (a definitive impact).
+    pub contact_sensor: bool,
+    /// A FINITE IMU spike above the threshold fired (the `is_impact` IMU term).
+    pub spike_over_threshold: bool,
+    /// A close-range tracked agent vanished (person-under-vehicle).
+    pub vanished_object: bool,
+    /// The IMU spike magnitude (m/s²) — present ONLY if finite; omitted entirely
+    /// on a non-finite reading.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spike_magnitude_mps2: Option<f64>,
+}
+
+impl ImpactDetectedPayload {
+    /// Derive the trigger breakdown from the latching evidence + fusion config.
+    /// Mirrors the `is_impact` IMU term exactly (finite AND above threshold).
+    fn from_evidence(evidence: &ImpactEvidence, cfg: &ImpactCfg) -> Self {
+        let finite = evidence.imu_accel_spike_mps2.is_finite();
+        Self {
+            contact_sensor: evidence.contact_sensor,
+            spike_over_threshold: finite
+                && evidence.imu_accel_spike_mps2 > cfg.spike_threshold_mps2,
+            vanished_object: evidence.vanished_object,
+            // Retain the magnitude ONLY when finite — a non-finite reading
+            // serialises to NO field (see `skip_serializing_if`).
+            spike_magnitude_mps2: finite.then_some(evidence.imu_accel_spike_mps2),
+        }
+    }
+}
+
+/// The note recorded with an `ImpactCleared` event — the clearance source.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ImpactClearedPayload {
+    /// A short note on WHAT cleared the latch. The authenticated-clearance
+    /// mechanism (#103) is a deferred follow-up; this records whatever clearance
+    /// source the caller asserts.
+    pub clearance_source: String,
+}
+
+/// Infallible sink for SG6 impact-latch transitions. `record_*` NEVER returns an
+/// error and NEVER blocks the latch — a failed audit write is the sink's problem,
+/// not the motion veto's (see [`RecordedImpactLatch`]).
+pub trait ImpactEventSink: Send + Sync {
+    /// Record a false→true latch transition (exactly once per rising edge).
+    fn record_detected(&self, payload: &ImpactDetectedPayload);
+    /// Record a true→false clearance (exactly once per falling edge).
+    fn record_cleared(&self, payload: &ImpactClearedPayload);
+}
+
+/// Durable, signed [`ImpactEventSink`] — the SG6 analogue of
+/// [`AuditChainLinkerDivergenceSink`], sharing the same [`ChainedAuditWriter`]
+/// write path so impact rows land in the SAME signed ledger the #104
+/// post-incident sequence writes to (forensic adjacency).
+pub struct ImpactAuditSink {
+    writer: ChainedAuditWriter,
+}
+
+impl ImpactAuditSink {
+    /// Build a sink over an SDK store (must own the audit chain + a signing key).
+    pub fn new(store: Arc<Mutex<VerifierStore>>) -> Self {
+        Self {
+            writer: ChainedAuditWriter::new(store),
+        }
+    }
+
+    /// Open a durable, *signed* impact sink from a DB path + base64 Ed25519 key.
+    /// Same fail-closed contract as [`AuditChainLinkerDivergenceSink::open`].
+    pub fn open(db_path: &str, key_b64: &str) -> Result<Self, FatalAuditConfig> {
+        Ok(Self {
+            writer: ChainedAuditWriter::open(db_path, key_b64)?,
+        })
+    }
+
+    /// Impact transitions that were DETECTED but could NOT be durably + signed.
+    /// MUST be `0` in a healthy deployment (mirrors the divergence counter).
+    pub fn write_failures(&self) -> u64 {
+        self.writer.write_failures()
+    }
+
+    fn record_event<P: serde::Serialize>(&self, event_type: &str, payload: &P) {
+        match serde_json::to_string(payload) {
+            Ok(body) => self.writer.record(IMPACT_AUDIT_SOURCE, event_type, &body),
+            Err(e) => {
+                self.writer.note_failure();
+                eprintln!(
+                    "[SG6] {event_type} NOT recorded — JSON serialization failed: {e} \
+                     (impact transition is UNAUDITED)"
+                );
+            }
+        }
+    }
+}
+
+impl ImpactEventSink for ImpactAuditSink {
+    fn record_detected(&self, payload: &ImpactDetectedPayload) {
+        self.record_event(IMPACT_DETECTED_EVENT_TYPE, payload);
+    }
+    fn record_cleared(&self, payload: &ImpactClearedPayload) {
+        self.record_event(IMPACT_CLEARED_EVENT_TYPE, payload);
+    }
+}
+
+/// Ephemeral, in-memory [`ImpactEventSink`] for dev / test / the no-durable-audit
+/// fallback. Buffers `(event_type, json_body)` pairs; never persists, never signs.
+#[derive(Default)]
+pub struct InMemoryImpactSink {
+    events: Mutex<Vec<(String, String)>>,
+}
+
+impl InMemoryImpactSink {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot of the buffered `(event_type, json_body)` pairs.
+    pub fn events(&self) -> Vec<(String, String)> {
+        self.events.lock().map(|v| v.clone()).unwrap_or_default()
+    }
+
+    fn push<P: serde::Serialize>(&self, event_type: &str, payload: &P) {
+        let body = serde_json::to_string(payload).unwrap_or_else(|_| "<unserializable>".into());
+        if let Ok(mut v) = self.events.lock() {
+            v.push((event_type.to_string(), body));
+        }
+    }
+}
+
+impl ImpactEventSink for InMemoryImpactSink {
+    fn record_detected(&self, payload: &ImpactDetectedPayload) {
+        self.push(IMPACT_DETECTED_EVENT_TYPE, payload);
+    }
+    fn record_cleared(&self, payload: &ImpactClearedPayload) {
+        self.push(IMPACT_CLEARED_EVENT_TYPE, payload);
+    }
+}
+
+/// Select the impact-audit sink from the same two env inputs as
+/// [`select_divergence_sink`], applying the identical CERT-006 fail-closed
+/// contract (durable+signed when both set; in-memory when no DB; FATAL when a DB
+/// is requested but cannot be made tamper-evident).
+pub fn select_impact_sink(
+    db: Option<String>,
+    key: Option<String>,
+) -> Result<Arc<dyn ImpactEventSink>, FatalAuditConfig> {
+    match db.as_deref() {
+        None | Some("") => Ok(Arc::new(InMemoryImpactSink::new())),
+        Some(db_path) => match key.as_deref() {
+            None | Some("") => Err(FatalAuditConfig::MissingSigningKey),
+            Some(key_b64) => Ok(Arc::new(ImpactAuditSink::open(db_path, key_b64)?)),
+        },
+    }
+}
+
+/// SG6 — an [`ImpactLatch`] wrapped with a RISING-EDGE audit recorder. Delegates
+/// `observe` / `clear` to the inner latch and emits EXACTLY ONE audit event per
+/// transition: `ImpactDetected` on false→true, `ImpactCleared` on true→false. No
+/// per-tick spam while latched; a cleared latch that latches AGAIN emits a second
+/// `ImpactDetected`.
+///
+/// INFALLIBLE toward the control path: the latch is mutated FIRST, then the
+/// (best-effort) audit write happens — so the latch's safety behavior (the motion
+/// veto) is BIT-IDENTICAL with or without a sink, and a failed write only
+/// increments the sink's `write_failures` counter.
+// SAFETY: SG6 | REQ: impact-audit-bridge | TEST: test_rising_edge_emits_one_detected,test_clear_emits_one_cleared_relatch_emits_second_detected,test_impact_durably_recorded_signed_and_chained,test_sink_failure_counts_latch_and_veto_unchanged,test_no_sink_latch_behavior_identical,test_detected_payload_has_trigger_booleans,test_nonfinite_spike_magnitude_omitted
+pub struct RecordedImpactLatch {
+    latch: ImpactLatch,
+    sink: Arc<dyn ImpactEventSink>,
+    last_latched: bool,
+}
+
+impl RecordedImpactLatch {
+    /// Wrap a fresh latch with a recorder over `sink`.
+    pub fn new(sink: Arc<dyn ImpactEventSink>) -> Self {
+        Self {
+            latch: ImpactLatch::new(),
+            sink,
+            last_latched: false,
+        }
+    }
+
+    /// True while latched — the governor immobilizes. Identical to the inner
+    /// [`ImpactLatch::is_latched`].
+    pub fn is_latched(&self) -> bool {
+        self.latch.is_latched()
+    }
+
+    /// Observe one tick. Delegates to [`ImpactLatch::observe`], then emits ONE
+    /// `ImpactDetected` iff THIS tick caused a false→true transition (compared via
+    /// the last-known state — no per-tick spam while latched).
+    pub fn observe(&mut self, evidence: &ImpactEvidence, cfg: &ImpactCfg) {
+        self.latch.observe(evidence, cfg);
+        let now = self.latch.is_latched();
+        if now && !self.last_latched {
+            self.sink
+                .record_detected(&ImpactDetectedPayload::from_evidence(evidence, cfg));
+        }
+        self.last_latched = now;
+    }
+
+    /// Clear on an explicit clearance signal. Delegates to [`ImpactLatch::clear`],
+    /// then emits ONE `ImpactCleared` iff THIS caused a true→false transition.
+    /// `source` is the clearance note recorded in the audit row.
+    pub fn clear(&mut self, clearance: bool, source: &str) {
+        self.latch.clear(clearance);
+        let now = self.latch.is_latched();
+        if !now && self.last_latched {
+            self.sink.record_cleared(&ImpactClearedPayload {
+                clearance_source: source.to_string(),
+            });
+        }
+        self.last_latched = now;
     }
 }
 
@@ -402,5 +675,169 @@ mod tests {
                 .any(|e| e["event_type"] == COMPARATOR_DIVERGENCE_EVENT_TYPE),
             "a ComparatorDivergence audit entry must be persisted"
         );
+    }
+
+    // ───────────── SG6 impact-audit bridge (#102 → #104) tests ──────────────
+
+    fn icfg() -> ImpactCfg {
+        ImpactCfg::default() // spike_threshold = 30.0
+    }
+    fn clean_ev() -> ImpactEvidence {
+        ImpactEvidence { imu_accel_spike_mps2: 0.5, contact_sensor: false, vanished_object: false }
+    }
+    fn contact_ev() -> ImpactEvidence {
+        ImpactEvidence { contact_sensor: true, ..clean_ev() }
+    }
+    fn count_type(sink: &InMemoryImpactSink, ty: &str) -> usize {
+        sink.events().iter().filter(|(t, _)| t == ty).count()
+    }
+
+    /// Rising edge: 3 latched ticks emit EXACTLY ONE `ImpactDetected` (no
+    /// per-tick spam while latched stays true).
+    #[test]
+    fn test_rising_edge_emits_one_detected() {
+        let sink = Arc::new(InMemoryImpactSink::new());
+        let mut latch = RecordedImpactLatch::new(sink.clone());
+        for _ in 0..3 {
+            latch.observe(&contact_ev(), &icfg());
+        }
+        assert!(latch.is_latched());
+        assert_eq!(
+            count_type(&sink, IMPACT_DETECTED_EVENT_TYPE),
+            1,
+            "3 latched ticks must emit exactly ONE ImpactDetected"
+        );
+    }
+
+    /// Clear emits exactly one `ImpactCleared`; a re-latch afterward emits a
+    /// SECOND `ImpactDetected`.
+    #[test]
+    fn test_clear_emits_one_cleared_relatch_emits_second_detected() {
+        let sink = Arc::new(InMemoryImpactSink::new());
+        let mut latch = RecordedImpactLatch::new(sink.clone());
+
+        latch.observe(&contact_ev(), &icfg()); // detect #1
+        latch.clear(false, "noop"); // no-op → no event
+        latch.clear(true, "supervisor_reset"); // clear #1
+        assert!(!latch.is_latched());
+        latch.observe(&contact_ev(), &icfg()); // detect #2 (re-latch)
+
+        assert_eq!(count_type(&sink, IMPACT_DETECTED_EVENT_TYPE), 2, "re-latch must emit a second ImpactDetected");
+        assert_eq!(count_type(&sink, IMPACT_CLEARED_EVENT_TYPE), 1, "exactly one ImpactCleared on the single falling edge");
+    }
+
+    /// File-backed durability + signing (mirrors the divergence sink's test): the
+    /// impact transitions are durable, hash-linked, and verify under the key.
+    #[test]
+    fn test_impact_durably_recorded_signed_and_chained() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("impact_audit.sqlite");
+        let key = SigningKey::from_bytes(&[11u8; 32]);
+        let vk = key.verifying_key();
+
+        let mut store = VerifierStore::new(db.to_str().unwrap()).expect("store");
+        store.set_signing_key(key);
+        let sink = Arc::new(ImpactAuditSink::new(Arc::new(Mutex::new(store))));
+        // keep a separate handle to read back after.
+        // (Re-open below to verify durability across a fresh store handle.)
+        let db_path = db.to_str().unwrap().to_string();
+
+        let mut latch = RecordedImpactLatch::new(sink.clone());
+        latch.observe(&contact_ev(), &icfg());
+        latch.clear(true, "supervisor_reset");
+        assert_eq!(sink.write_failures(), 0, "both transitions must be durably recorded");
+
+        let verifier = VerifierStore::new(&db_path).expect("re-open store");
+        let v = verifier.verify_audit_chain_full(Some(&vk)).expect("verify");
+        assert!(v.chain_intact, "audit chain must be hash-intact");
+        assert!(v.signature_valid, "signatures must verify under the key");
+        assert!(v.signed_entries >= 2, "both impact entries must be signed, got {}", v.signed_entries);
+
+        let events = verifier.load_all_posture_events().expect("load events");
+        let detected = events.iter().find(|e| e["event_type"] == IMPACT_DETECTED_EVENT_TYPE)
+            .expect("an ImpactDetected entry must exist");
+        assert_eq!(detected["posture"]["contact_sensor"], true);
+        assert!(events.iter().any(|e| e["event_type"] == IMPACT_CLEARED_EVENT_TYPE),
+            "an ImpactCleared entry must exist");
+    }
+
+    /// Sink failure (poisoned store) → `write_failures` increments, but the latch
+    /// state and the motion veto are UNCHANGED (the infallibility proof).
+    #[test]
+    fn test_sink_failure_counts_latch_and_veto_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("impact_audit.sqlite");
+        let store = Arc::new(Mutex::new(VerifierStore::new(db.to_str().unwrap()).expect("store")));
+
+        // Poison the store mutex so the audit write cannot land.
+        let s = Arc::clone(&store);
+        let _ = std::thread::spawn(move || {
+            let _g = s.lock().unwrap();
+            panic!("poison the audit store for the failure test");
+        })
+        .join();
+
+        let sink = Arc::new(ImpactAuditSink::new(Arc::clone(&store)));
+        let mut latch = RecordedImpactLatch::new(sink.clone());
+        latch.observe(&contact_ev(), &icfg());
+
+        assert_eq!(sink.write_failures(), 1, "a transition that could not be recorded MUST be counted");
+        assert!(latch.is_latched(), "the latch (motion veto) must be UNCHANGED by a sink failure");
+    }
+
+    /// No durable sink (in-memory fallback) → the wrapped latch behaves IDENTICALLY
+    /// to a bare `ImpactLatch` over the same evidence sequence.
+    #[test]
+    fn test_no_sink_latch_behavior_identical() {
+        let sink = Arc::new(InMemoryImpactSink::new());
+        let mut recorded = RecordedImpactLatch::new(sink);
+        let mut bare = ImpactLatch::new();
+
+        let seq = [clean_ev(), contact_ev(), clean_ev(), clean_ev()];
+        for ev in &seq {
+            recorded.observe(ev, &icfg());
+            bare.observe(ev, &icfg());
+            assert_eq!(recorded.is_latched(), bare.is_latched(),
+                "wrapped latch must track the bare latch bit-for-bit");
+        }
+        // and on clear
+        recorded.clear(true, "reset");
+        bare.clear(true);
+        assert_eq!(recorded.is_latched(), bare.is_latched());
+    }
+
+    /// The detected payload carries the trigger booleans (which signals fired).
+    #[test]
+    fn test_detected_payload_has_trigger_booleans() {
+        let sink = Arc::new(InMemoryImpactSink::new());
+        let mut latch = RecordedImpactLatch::new(sink.clone());
+        // contact + vanished fire; spike below threshold does not.
+        let ev = ImpactEvidence { imu_accel_spike_mps2: 1.0, contact_sensor: true, vanished_object: true };
+        latch.observe(&ev, &icfg());
+
+        let (_, body) = sink.events().into_iter().find(|(t, _)| t == IMPACT_DETECTED_EVENT_TYPE).expect("detected");
+        let json: serde_json::Value = serde_json::from_str(&body).expect("json");
+        assert_eq!(json["contact_sensor"], true);
+        assert_eq!(json["vanished_object"], true);
+        assert_eq!(json["spike_over_threshold"], false, "a sub-threshold spike must not read as fired");
+        assert_eq!(json["spike_magnitude_mps2"], 1.0, "a finite magnitude is retained");
+    }
+
+    /// A non-finite spike magnitude is OMITTED from the payload entirely (it never
+    /// latches on its own and is not a trustworthy datum). The latch here fires on
+    /// the contact signal; the NaN IMU contributes no magnitude field.
+    #[test]
+    fn test_nonfinite_spike_magnitude_omitted() {
+        let sink = Arc::new(InMemoryImpactSink::new());
+        let mut latch = RecordedImpactLatch::new(sink.clone());
+        let ev = ImpactEvidence { imu_accel_spike_mps2: f64::NAN, contact_sensor: true, vanished_object: false };
+        latch.observe(&ev, &icfg());
+
+        let (_, body) = sink.events().into_iter().find(|(t, _)| t == IMPACT_DETECTED_EVENT_TYPE).expect("detected");
+        assert!(!body.contains("spike_magnitude_mps2"),
+            "a non-finite spike magnitude must be omitted from the payload, got {body}");
+        let json: serde_json::Value = serde_json::from_str(&body).expect("json");
+        assert_eq!(json["contact_sensor"], true);
+        assert_eq!(json["spike_over_threshold"], false, "a non-finite spike never reads as fired");
     }
 }

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -58,7 +58,9 @@ pub mod comparator;
 pub mod diverse;
 pub use angular_bound::{AngularVelocityBound, PlatformParams, ROLLOVER_MIN_LINEAR_VELOCITY_MPS};
 pub use audit_sink::{
-    select_divergence_sink, AuditChainLinkerDivergenceSink, FatalAuditConfig,
+    select_divergence_sink, select_impact_sink, AuditChainLinkerDivergenceSink, FatalAuditConfig,
+    ImpactAuditSink, ImpactClearedPayload, ImpactDetectedPayload, ImpactEventSink,
+    InMemoryImpactSink, RecordedImpactLatch, IMPACT_CLEARED_EVENT_TYPE, IMPACT_DETECTED_EVENT_TYPE,
 };
 pub use comparator::{GovernorComparator, RssAwareGovernor};
 pub use diverse::DiverseKirraGovernor;


### PR DESCRIPTION
## The #102 → #104 bridge — sign the SG6 impact latch's transitions

Records `ImpactLatch` (SG6, #102) transitions as **signed, hash-chained audit events** via the established **#247** sink crossing (parko-kirra → `VerifierStore` → `append_audit_event_tx`). The latch's transitions now land in the **same signed ledger the #104 post-incident sequence writes to** — forensic adjacency, with **no cross-subsystem plumbing**: the latch already drives deny/posture and the incident opens via the existing posture path, so the #104 machinery (`post_incident.rs`) needs no modification.

### `audit_sink.rs`
- **`ChainedAuditWriter`** — the #247 divergence sink refactored to expose **one** fail-closed write path (the store handle + `write_failures` counter + the `save_posture_event_chained` append). `AuditChainLinkerDivergenceSink` now **delegates** to it; **its public surface and CERT-006 tests are untouched** (reuse, not a copy).
- **`ImpactAuditSink`** (durable, signed) + **`InMemoryImpactSink`** (fallback) implement a new **`ImpactEventSink`** trait. Event types match the #247 PascalCase convention in the same table: **`"ImpactDetected"` / `"ImpactCleared"`**. **`select_impact_sink`** mirrors `select_divergence_sink`'s fail-closed env contract (both vars → durable + signed; neither → in-memory + caller-warns; DB-set + key-invalid → hard `FatalAuditConfig`).
- **`ImpactDetectedPayload`** records the **trigger breakdown** — `contact_sensor` / `spike_over_threshold` / `vanished_object` booleans, **never raw sensor streams** — plus the IMU spike magnitude **only when finite** (omitted on a non-finite reading). **`ImpactClearedPayload`** records the clearance-source note.
- **`RecordedImpactLatch`** wraps `ImpactLatch` with **rising-edge semantics**: it compares the last-known latched state before/after each `observe`/`clear` and emits **exactly one** `ImpactDetected` per false→true and **one** `ImpactCleared` per true→false — no per-tick spam while latched; a re-latch after clearance emits a second `ImpactDetected`.
- **Infallible toward the control path:** the latch is mutated **first**, then the best-effort audit write happens — a write failure only increments `write_failures` and **never** alters the latch or the motion veto. The latch's safety behavior is **bit-identical with or without a sink**.

### Tests (parko-kirra)
Rising-edge dedupe (3 latched ticks → one `ImpactDetected`); clear-then-relatch (one `ImpactCleared`, second `ImpactDetected`); file-backed **durable + signed + hash-chained** (mirrors the #247 sink test); **sink-failure counts while latch/veto unchanged** (the infallibility proof); no-sink fallback tracks a bare `ImpactLatch` bit-for-bit; payload carries the trigger booleans; **non-finite spike magnitude omitted**. `cargo test -p parko-kirra` green (all existing audit_sink/divergence tests still pass); clippy clean.

### #103 note
Partially covers the **#103-deferred clearance audit**: SG6 **clearance is now recorded**; the authenticated-clearance *mechanism* itself remains a #103 follow-up.

### Scope / safety
- **parko-kirra only** (`audit_sink.rs` + `lib.rs` registration). **No `src/` changes**, no `post_incident.rs`, **no parko-ros2 node wiring** (the deploy-time hookup is deferred, as the #247 node config was a separate step).
- Gateway kinematics contract byte-identical — talisman blob `997fb7ae…` unchanged.

References #102, #104, #103.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_