### PR TITLE
feat(impact): SG6 clearance-confirmation + operator-escalation loop (#103)

### DIFF
--- a/parko/crates/parko-core/src/impact.rs
+++ b/parko/crates/parko-core/src/impact.rs
@@ -95,12 +95,210 @@ impl ImpactLatch {
     }
 
     /// Clear the latch ONLY on an explicit clearance signal (`true`). A `false`
-    /// is a no-op (it never re-asserts motion). Wiring this to the #103
-    /// authenticated-clearance mechanism is a DEFERRED follow-up.
+    /// is a no-op (it never re-asserts motion).
+    ///
+    /// LOW-LEVEL PRIMITIVE — do not call this for production clearance. This is
+    /// the inner mechanism; `true` here trusts the caller unconditionally, which
+    /// is exactly the gap SS-003 forbids. Production clearance MUST go through
+    /// [`ClearanceLoop::try_clear`] (#103), which admits ONLY a well-formed
+    /// [`OperatorClearanceGrant`]. `ClearanceLoop` (and #263's
+    /// `RecordedImpactLatch`) own an `ImpactLatch` and call this internally; the
+    /// method stays public so those wrappers — and the existing #102/#263 APIs —
+    /// keep working.
     pub fn clear(&mut self, clearance: bool) {
         if clearance {
             self.latched = false;
         }
+    }
+}
+
+/// Default ceiling on how old a clearance grant may be (ms) before it is stale.
+/// VALIDATION-PENDING conservative placeholder — a grant is a fresh, deliberate
+/// operator act, so the window is short; tune on integration.
+pub const DEFAULT_MAX_GRANT_AGE_MS: u64 = 60_000;
+
+/// An operator's clearance authorization for a post-collision latch (SG6 / #103).
+///
+/// LAYERING (the named boundary): parko CANNOT authenticate an operator —
+/// authentication lives in the verifier / `kirra_core` reset mechanism (#255,
+/// `KIRRA_SUPERVISOR_RESET_KEY`). This type enforces the STRUCTURE only: clearance
+/// is admissible ONLY via a well-formed grant, no other path. The integrator /
+/// verifier is responsible for issuing a grant ONLY after it has authenticated
+/// the operator — that obligation is an assumption of use, not enforced here.
+#[derive(Debug, Clone)]
+pub struct OperatorClearanceGrant {
+    /// The clearing operator's identifier (audit subject). Must be non-empty.
+    pub operator_id: String,
+    /// Wall-clock time (ms) the grant was issued. Checked against `now_ms`:
+    /// must be `<= now` (no future-dating) and within `max_grant_age_ms`.
+    pub granted_at_ms: u64,
+}
+
+impl OperatorClearanceGrant {
+    /// Structural validity (NOT authentication). `true` iff: `operator_id` is
+    /// non-empty; `granted_at_ms <= now_ms` (a FUTURE-dated grant is malformed);
+    /// and the grant is not older than `max_grant_age_ms` (age boundary is
+    /// INCLUSIVE — a grant exactly `max_grant_age_ms` old is still well-formed).
+    /// `now_ms` is supplied (no `SystemTime::now()` here — testability).
+    pub fn is_well_formed(&self, now_ms: u64, max_grant_age_ms: u64) -> bool {
+        if self.operator_id.is_empty() {
+            return false;
+        }
+        if self.granted_at_ms > now_ms {
+            return false; // future-dated → malformed
+        }
+        // u64 subtraction is safe: granted_at_ms <= now_ms here.
+        let age_ms = now_ms - self.granted_at_ms;
+        age_ms <= max_grant_age_ms // inclusive boundary
+    }
+}
+
+/// Why a [`ClearanceLoop::try_clear`] attempt was rejected. The state is left
+/// UNCHANGED on every rejection (still immobilized).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClearanceRejection {
+    /// The grant was not well-formed (empty id / future-dated / stale).
+    MalformedGrant,
+    /// There was nothing to clear — the loop is in `Normal` (not immobilized).
+    /// A clear attempt on `Normal` is a no-op recorded as a rejection, never a
+    /// silent success (it would otherwise mask a logic error upstream).
+    NotImmobilized,
+}
+
+impl ClearanceRejection {
+    /// A short, stable reason code for audit bodies.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            ClearanceRejection::MalformedGrant => "malformed_grant",
+            ClearanceRejection::NotImmobilized => "not_immobilized",
+        }
+    }
+}
+
+/// The lifecycle state of the SG6 clearance loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClearanceState {
+    /// No active impact — motion permitted (by this check).
+    Normal,
+    /// Impact fused this tick but the once-per-incident escalation edge has not
+    /// yet been raised. Transient: the next `observe` raises escalation.
+    /// Immobilized.
+    Latched,
+    /// The operator-escalation signal has been raised for this incident.
+    /// Immobilized; awaiting a well-formed grant.
+    EscalationRaised,
+}
+
+/// SG6 — the clearance-confirmation + operator-escalation state machine (#103).
+///
+/// Wraps an [`ImpactLatch`] and enforces the SS-003 "human intervention required"
+/// STRUCTURE that the bare latch cannot: once immobilized, the ONLY transition
+/// back to `Normal` is [`try_clear`](Self::try_clear) with a well-formed
+/// [`OperatorClearanceGrant`]. Clean evidence never clears (the inner latch
+/// guarantees this; the wrapper preserves it).
+///
+/// Lifecycle: `Normal` --impact--> `Latched` --next observe--> `EscalationRaised`
+/// --well-formed grant--> `Normal`. The `Latched → EscalationRaised` edge is the
+/// distinct, once-per-incident RAISED signal ([`escalation_pending`]).
+///
+/// THE INVARIANT: there is NO method, evidence pattern, or path that leaves
+/// `Latched` / `EscalationRaised` for `Normal` except `try_clear` with a
+/// well-formed grant.
+// SAFETY: SG6 | REQ: clearance-confirmation-loop | TEST: test_clean_evidence_never_clears_loop,test_malformed_grants_rejected_still_immobilized,test_well_formed_grant_clears,test_escalation_raised_once_per_incident,test_reimpact_during_escalation_no_second_raise,test_cleared_then_new_impact_raises_again,test_grant_on_normal_rejected,test_veto_active_in_both_latched_states,test_grant_age_boundary_inclusive,test_future_dated_grant_malformed
+#[derive(Debug, Clone)]
+pub struct ClearanceLoop {
+    latch: ImpactLatch,
+    state: ClearanceState,
+    /// Whether the once-per-incident escalation edge has been emitted, so a
+    /// re-impact while `EscalationRaised` does not double-raise.
+    escalation_emitted: bool,
+}
+
+impl Default for ClearanceLoop {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClearanceLoop {
+    pub fn new() -> Self {
+        Self {
+            latch: ImpactLatch::new(),
+            state: ClearanceState::Normal,
+            escalation_emitted: false,
+        }
+    }
+
+    /// The current lifecycle state.
+    pub fn state(&self) -> ClearanceState {
+        self.state
+    }
+
+    /// True while the vehicle must be immobilized — `Latched` OR
+    /// `EscalationRaised`. Feeds the existing motion veto unchanged.
+    pub fn is_immobilized(&self) -> bool {
+        matches!(
+            self.state,
+            ClearanceState::Latched | ClearanceState::EscalationRaised
+        )
+    }
+
+    /// True once the operator-escalation has been raised for the active incident
+    /// (the operator-UI signal). False in `Normal` and `Latched`.
+    pub fn escalation_pending(&self) -> bool {
+        matches!(self.state, ClearanceState::EscalationRaised)
+    }
+
+    /// Observe one tick. Delegates fusion to the inner [`ImpactLatch`]:
+    /// * `Normal` + fused impact → `Latched` (a new incident).
+    /// * `Latched` → `EscalationRaised` (raise the once-per-incident edge),
+    ///   whether or not this tick also fused (the latch stays latched regardless).
+    /// * `EscalationRaised` → stays (no double-raise on re-impact).
+    ///
+    /// `now_ms` is accepted for signature symmetry / future use; fusion itself is
+    /// time-independent.
+    pub fn observe(&mut self, evidence: &ImpactEvidence, cfg: &ImpactCfg, _now_ms: u64) {
+        self.latch.observe(evidence, cfg);
+        match self.state {
+            ClearanceState::Normal => {
+                if self.latch.is_latched() {
+                    self.state = ClearanceState::Latched;
+                    self.escalation_emitted = false;
+                }
+            }
+            ClearanceState::Latched => {
+                // The transient Latched state escalates on the next observation.
+                self.state = ClearanceState::EscalationRaised;
+                self.escalation_emitted = true;
+            }
+            ClearanceState::EscalationRaised => {
+                // Re-impact stays escalated — no second raise.
+            }
+        }
+    }
+
+    /// The ONLY path back to `Normal`. Admits clearance iff the loop is currently
+    /// immobilized AND `grant` is well-formed; otherwise returns a
+    /// [`ClearanceRejection`] and leaves the state UNCHANGED.
+    ///
+    /// On success it clears the inner latch via the low-level primitive and
+    /// returns to `Normal` (the incident is over; a future impact starts fresh).
+    pub fn try_clear(
+        &mut self,
+        grant: &OperatorClearanceGrant,
+        now_ms: u64,
+        max_grant_age_ms: u64,
+    ) -> Result<(), ClearanceRejection> {
+        if !self.is_immobilized() {
+            return Err(ClearanceRejection::NotImmobilized);
+        }
+        if !grant.is_well_formed(now_ms, max_grant_age_ms) {
+            return Err(ClearanceRejection::MalformedGrant);
+        }
+        self.latch.clear(true);
+        self.state = ClearanceState::Normal;
+        self.escalation_emitted = false;
+        Ok(())
     }
 }
 
@@ -210,5 +408,159 @@ mod tests {
         assert!(!is_impact(&at, &cfg()), "spike exactly at threshold must NOT latch (strict >)");
         let above = ImpactEvidence { imu_accel_spike_mps2: 30.0 + 1e-6, ..clean() };
         assert!(is_impact(&above, &cfg()), "spike just above threshold latches");
+    }
+
+    // ───────────────────── #103 clearance-confirmation loop ─────────────────
+
+    const MAX_AGE: u64 = DEFAULT_MAX_GRANT_AGE_MS; // 60_000
+
+    fn contact() -> ImpactEvidence {
+        ImpactEvidence { contact_sensor: true, ..clean() }
+    }
+    /// A well-formed grant issued `age_ms` before `now`.
+    fn grant(now: u64, age_ms: u64) -> OperatorClearanceGrant {
+        OperatorClearanceGrant { operator_id: "op-7".into(), granted_at_ms: now - age_ms }
+    }
+    /// Drive a fresh loop into EscalationRaised (impact, then one more tick).
+    fn escalated() -> ClearanceLoop {
+        let mut l = ClearanceLoop::new();
+        l.observe(&contact(), &cfg(), 1_000); // Normal → Latched
+        l.observe(&clean(), &cfg(), 1_001); // Latched → EscalationRaised
+        assert_eq!(l.state(), ClearanceState::EscalationRaised);
+        l
+    }
+
+    /// THE INVARIANT (part 1): clean evidence over many ticks never clears the
+    /// loop — it stays immobilized.
+    #[test]
+    fn test_clean_evidence_never_clears_loop() {
+        let mut l = escalated();
+        for t in 0..50 {
+            l.observe(&clean(), &cfg(), 2_000 + t);
+            assert!(l.is_immobilized(), "clean evidence must never release the loop");
+        }
+    }
+
+    /// THE INVARIANT (part 2): every malformed grant is rejected and leaves the
+    /// state unchanged (still immobilized).
+    #[test]
+    fn test_malformed_grants_rejected_still_immobilized() {
+        let now = 100_000u64;
+        let bad = [
+            OperatorClearanceGrant { operator_id: String::new(), granted_at_ms: now }, // empty id
+            OperatorClearanceGrant { operator_id: "op".into(), granted_at_ms: now + 5 }, // future
+            OperatorClearanceGrant { operator_id: "op".into(), granted_at_ms: now - (MAX_AGE + 1) }, // stale
+        ];
+        for g in bad {
+            let mut l = escalated();
+            let r = l.try_clear(&g, now, MAX_AGE);
+            assert_eq!(r, Err(ClearanceRejection::MalformedGrant), "malformed grant must be rejected: {g:?}");
+            assert!(l.is_immobilized(), "state must be unchanged after a rejected grant");
+            assert_eq!(l.state(), ClearanceState::EscalationRaised);
+        }
+    }
+
+    /// ONLY a well-formed grant transitions back to Normal.
+    #[test]
+    fn test_well_formed_grant_clears() {
+        let now = 100_000u64;
+        let mut l = escalated();
+        assert!(l.try_clear(&grant(now, 10), now, MAX_AGE).is_ok());
+        assert_eq!(l.state(), ClearanceState::Normal);
+        assert!(!l.is_immobilized(), "a well-formed grant releases the loop");
+        assert!(!l.escalation_pending());
+    }
+
+    /// Escalation is a once-per-incident rising edge: it raises exactly once,
+    /// then stays pending across many immobilized ticks.
+    #[test]
+    fn test_escalation_raised_once_per_incident() {
+        let mut l = ClearanceLoop::new();
+        assert!(!l.escalation_pending());
+        l.observe(&contact(), &cfg(), 1_000);
+        assert_eq!(l.state(), ClearanceState::Latched);
+        assert!(!l.escalation_pending(), "not yet raised in the transient Latched tick");
+        l.observe(&clean(), &cfg(), 1_001);
+        assert!(l.escalation_pending(), "raised on the next observation");
+        // stays pending, no oscillation
+        for t in 0..10 {
+            l.observe(&clean(), &cfg(), 1_100 + t);
+            assert!(l.escalation_pending());
+        }
+    }
+
+    /// Re-impact while EscalationRaised does not raise a second time.
+    #[test]
+    fn test_reimpact_during_escalation_no_second_raise() {
+        let mut l = escalated();
+        l.observe(&contact(), &cfg(), 3_000); // re-impact
+        assert_eq!(l.state(), ClearanceState::EscalationRaised, "re-impact stays escalated");
+        assert!(l.escalation_pending());
+    }
+
+    /// Cleared, then a new impact, raises a NEW escalation (a distinct incident).
+    #[test]
+    fn test_cleared_then_new_impact_raises_again() {
+        let now = 100_000u64;
+        let mut l = escalated();
+        l.try_clear(&grant(now, 10), now, MAX_AGE).unwrap();
+        assert_eq!(l.state(), ClearanceState::Normal);
+        // New incident.
+        l.observe(&contact(), &cfg(), now + 1_000);
+        assert_eq!(l.state(), ClearanceState::Latched);
+        l.observe(&clean(), &cfg(), now + 1_001);
+        assert!(l.escalation_pending(), "a new impact after clearance raises a fresh escalation");
+    }
+
+    /// A clear attempt on Normal is rejected (NotImmobilized), not silently
+    /// absorbed.
+    #[test]
+    fn test_grant_on_normal_rejected() {
+        let now = 100_000u64;
+        let mut l = ClearanceLoop::new();
+        assert_eq!(l.state(), ClearanceState::Normal);
+        let r = l.try_clear(&grant(now, 10), now, MAX_AGE);
+        assert_eq!(r, Err(ClearanceRejection::NotImmobilized), "clearing Normal must be a recorded rejection");
+        assert_eq!(l.state(), ClearanceState::Normal);
+    }
+
+    /// The veto (is_immobilized) is active in BOTH Latched and EscalationRaised,
+    /// and released only after a grant.
+    #[test]
+    fn test_veto_active_in_both_latched_states() {
+        let mut l = ClearanceLoop::new();
+        assert!(!l.is_immobilized()); // Normal
+        l.observe(&contact(), &cfg(), 1_000);
+        assert_eq!(l.state(), ClearanceState::Latched);
+        assert!(l.is_immobilized(), "veto active in Latched");
+        l.observe(&clean(), &cfg(), 1_001);
+        assert_eq!(l.state(), ClearanceState::EscalationRaised);
+        assert!(l.is_immobilized(), "veto active in EscalationRaised");
+        let now = 2_000u64;
+        l.try_clear(&grant(now, 10), now, MAX_AGE).unwrap();
+        assert!(!l.is_immobilized(), "released only after the grant");
+    }
+
+    /// Age boundary is INCLUSIVE: a grant exactly max_grant_age_ms old is
+    /// well-formed; one ms older is not.
+    #[test]
+    fn test_grant_age_boundary_inclusive() {
+        let now = 100_000u64;
+        let exactly = OperatorClearanceGrant { operator_id: "op".into(), granted_at_ms: now - MAX_AGE };
+        assert!(exactly.is_well_formed(now, MAX_AGE), "exactly max age is well-formed (inclusive)");
+        let older = OperatorClearanceGrant { operator_id: "op".into(), granted_at_ms: now - (MAX_AGE + 1) };
+        assert!(!older.is_well_formed(now, MAX_AGE), "one ms older is stale");
+    }
+
+    /// A future-dated grant is malformed (granted_at_ms > now).
+    #[test]
+    fn test_future_dated_grant_malformed() {
+        let now = 100_000u64;
+        let future = OperatorClearanceGrant { operator_id: "op".into(), granted_at_ms: now + 1 };
+        assert!(!future.is_well_formed(now, MAX_AGE), "a future-dated grant must be malformed");
+        // and is rejected by try_clear
+        let mut l = escalated();
+        assert_eq!(l.try_clear(&future, now, MAX_AGE), Err(ClearanceRejection::MalformedGrant));
+        assert!(l.is_immobilized());
     }
 }

--- a/parko/crates/parko-core/src/lib.rs
+++ b/parko/crates/parko-core/src/lib.rs
@@ -65,7 +65,10 @@ pub use commit_zone::{
     commit_zone_blocked, exit_clearance_verified, CommitZoneCfg, CommitZoneMap, CommitZoneScene,
     ExitClearanceEvidence,
 };
-pub use impact::{is_impact, ImpactCfg, ImpactEvidence, ImpactLatch};
+pub use impact::{
+    is_impact, ClearanceLoop, ClearanceRejection, ClearanceState, ImpactCfg, ImpactEvidence,
+    ImpactLatch, OperatorClearanceGrant, DEFAULT_MAX_GRANT_AGE_MS,
+};
 pub use localization::{
     gate_commit_zone_scene, gate_water_scene, localization_trusted, LocalizationCfg,
     LocalizationIntegrity,

--- a/parko/crates/parko-kirra/src/audit_sink.rs
+++ b/parko/crates/parko-kirra/src/audit_sink.rs
@@ -22,7 +22,10 @@ use std::sync::{Arc, Mutex};
 use base64::Engine as _;
 use ed25519_dalek::SigningKey;
 use kirra_runtime_sdk::verifier_store::VerifierStore;
-use parko_core::{ImpactCfg, ImpactEvidence, ImpactLatch};
+use parko_core::{
+    ClearanceLoop, ClearanceRejection, ClearanceState, ImpactCfg, ImpactEvidence, ImpactLatch,
+    OperatorClearanceGrant,
+};
 
 use crate::comparator::{DivergenceEvent, DivergenceEventSink, InMemoryDivergenceSink};
 
@@ -264,6 +267,12 @@ pub fn select_divergence_sink(
 pub const IMPACT_DETECTED_EVENT_TYPE: &str = "ImpactDetected";
 /// The audit-log event type for an impact-latch CLEARANCE (true→false).
 pub const IMPACT_CLEARED_EVENT_TYPE: &str = "ImpactCleared";
+/// The audit-log event type for the once-per-incident operator-escalation edge
+/// (#103). PascalCase, same table/convention.
+pub const IMPACT_ESCALATION_RAISED_EVENT_TYPE: &str = "ImpactEscalationRaised";
+/// The audit-log event type for a REJECTED clearance attempt (#103) — a
+/// malformed grant, or a clear attempt with nothing to clear.
+pub const IMPACT_CLEARANCE_REJECTED_EVENT_TYPE: &str = "ImpactClearanceRejected";
 
 /// Audit source tag for SG6 impact events (the `governor_comparator` analogue).
 const IMPACT_AUDIT_SOURCE: &str = "governor_impact_latch";
@@ -303,23 +312,48 @@ impl ImpactDetectedPayload {
     }
 }
 
-/// The note recorded with an `ImpactCleared` event — the clearance source.
+/// The note recorded with an `ImpactCleared` event — the clearance source. On the
+/// #103 clearance loop this carries the clearing operator's id (an audit subject).
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ImpactClearedPayload {
-    /// A short note on WHAT cleared the latch. The authenticated-clearance
-    /// mechanism (#103) is a deferred follow-up; this records whatever clearance
-    /// source the caller asserts.
+    /// A short note on WHAT cleared the latch. For the #103 loop this is the
+    /// clearing operator's id. The authenticated-clearance mechanism itself is a
+    /// named-boundary deferral — parko records the asserted source, it does not
+    /// authenticate it (auth lives in the verifier / #255 reset key).
     pub clearance_source: String,
+}
+
+/// The context recorded with an `ImpactEscalationRaised` event (#103) — the
+/// once-per-incident operator-intervention-required signal.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ImpactEscalationPayload {
+    /// A short, fixed description of why the escalation was raised.
+    pub detail: String,
+}
+
+/// The context recorded with an `ImpactClearanceRejected` event (#103). Carries
+/// the rejection reason and the operator id (an audit SUBJECT — id is fine to
+/// record; there is no operator token at this layer to leak).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ImpactClearanceRejectedPayload {
+    /// The clearing operator's id from the rejected grant (audit subject).
+    pub operator_id: String,
+    /// The stable rejection reason code (`malformed_grant` / `not_immobilized`).
+    pub reason: String,
 }
 
 /// Infallible sink for SG6 impact-latch transitions. `record_*` NEVER returns an
 /// error and NEVER blocks the latch — a failed audit write is the sink's problem,
-/// not the motion veto's (see [`RecordedImpactLatch`]).
+/// not the motion veto's (see [`RecordedImpactLatch`] / [`RecordedClearanceLoop`]).
 pub trait ImpactEventSink: Send + Sync {
     /// Record a false→true latch transition (exactly once per rising edge).
     fn record_detected(&self, payload: &ImpactDetectedPayload);
     /// Record a true→false clearance (exactly once per falling edge).
     fn record_cleared(&self, payload: &ImpactClearedPayload);
+    /// Record the once-per-incident operator-escalation edge (#103).
+    fn record_escalation_raised(&self, payload: &ImpactEscalationPayload);
+    /// Record a rejected clearance attempt (#103).
+    fn record_clearance_rejected(&self, payload: &ImpactClearanceRejectedPayload);
 }
 
 /// Durable, signed [`ImpactEventSink`] — the SG6 analogue of
@@ -373,6 +407,12 @@ impl ImpactEventSink for ImpactAuditSink {
     fn record_cleared(&self, payload: &ImpactClearedPayload) {
         self.record_event(IMPACT_CLEARED_EVENT_TYPE, payload);
     }
+    fn record_escalation_raised(&self, payload: &ImpactEscalationPayload) {
+        self.record_event(IMPACT_ESCALATION_RAISED_EVENT_TYPE, payload);
+    }
+    fn record_clearance_rejected(&self, payload: &ImpactClearanceRejectedPayload) {
+        self.record_event(IMPACT_CLEARANCE_REJECTED_EVENT_TYPE, payload);
+    }
 }
 
 /// Ephemeral, in-memory [`ImpactEventSink`] for dev / test / the no-durable-audit
@@ -406,6 +446,12 @@ impl ImpactEventSink for InMemoryImpactSink {
     }
     fn record_cleared(&self, payload: &ImpactClearedPayload) {
         self.push(IMPACT_CLEARED_EVENT_TYPE, payload);
+    }
+    fn record_escalation_raised(&self, payload: &ImpactEscalationPayload) {
+        self.push(IMPACT_ESCALATION_RAISED_EVENT_TYPE, payload);
+    }
+    fn record_clearance_rejected(&self, payload: &ImpactClearanceRejectedPayload) {
+        self.push(IMPACT_CLEARANCE_REJECTED_EVENT_TYPE, payload);
     }
 }
 
@@ -484,6 +530,109 @@ impl RecordedImpactLatch {
             });
         }
         self.last_latched = now;
+    }
+}
+
+/// SG6 — a [`ClearanceLoop`] (#103) wrapped with the rising-edge audit recorder,
+/// emitting through the same [`ImpactEventSink`] family #263 established.
+///
+/// Audit sequence per incident: `ImpactDetected` on the Normal→Latched edge
+/// (incident open, with the trigger breakdown), then `ImpactEscalationRaised`
+/// ONCE on the Latched→EscalationRaised edge (operator-intervention signal), then
+/// either `ImpactCleared` (a well-formed grant) or `ImpactClearanceRejected` (a
+/// rejected attempt, with the reason). No per-tick spam; re-impact while
+/// escalated raises nothing new.
+///
+/// INFALLIBLE toward the control path: the state machine is mutated FIRST, then
+/// the best-effort audit write — so [`is_immobilized`](Self::is_immobilized) (the
+/// motion veto) is BIT-IDENTICAL with or without a sink, and a failed write only
+/// increments the durable sink's `write_failures` counter.
+// SAFETY: SG6 | REQ: clearance-confirmation-loop | TEST: test_loop_escalation_raised_once,test_loop_clear_emits_impact_cleared,test_loop_rejection_recorded_state_unchanged,test_loop_sink_failure_state_unaffected,test_loop_veto_unchanged_without_sink
+pub struct RecordedClearanceLoop {
+    clearance: ClearanceLoop,
+    sink: Arc<dyn ImpactEventSink>,
+    last_escalation_pending: bool,
+}
+
+impl RecordedClearanceLoop {
+    /// Wrap a fresh clearance loop with a recorder over `sink`.
+    pub fn new(sink: Arc<dyn ImpactEventSink>) -> Self {
+        Self {
+            clearance: ClearanceLoop::new(),
+            sink,
+            last_escalation_pending: false,
+        }
+    }
+
+    /// The current lifecycle state.
+    pub fn state(&self) -> ClearanceState {
+        self.clearance.state()
+    }
+
+    /// True while immobilized (Latched OR EscalationRaised) — feeds the motion
+    /// veto. Identical to [`ClearanceLoop::is_immobilized`].
+    pub fn is_immobilized(&self) -> bool {
+        self.clearance.is_immobilized()
+    }
+
+    /// True once the operator-escalation has been raised for the active incident.
+    pub fn escalation_pending(&self) -> bool {
+        self.clearance.escalation_pending()
+    }
+
+    /// Observe one tick. Delegates to [`ClearanceLoop::observe`] (state FIRST),
+    /// then emits `ImpactDetected` on the incident-open edge and exactly ONE
+    /// `ImpactEscalationRaised` on the false→true escalation edge.
+    pub fn observe(&mut self, evidence: &ImpactEvidence, cfg: &ImpactCfg, now_ms: u64) {
+        let before = self.clearance.state();
+        self.clearance.observe(evidence, cfg, now_ms);
+        let after = self.clearance.state();
+
+        // Incident open (Normal → Latched): record the trigger breakdown.
+        if before == ClearanceState::Normal && after == ClearanceState::Latched {
+            self.sink
+                .record_detected(&ImpactDetectedPayload::from_evidence(evidence, cfg));
+        }
+        // Operator-escalation rising edge (once per incident).
+        let pending = self.clearance.escalation_pending();
+        if pending && !self.last_escalation_pending {
+            self.sink.record_escalation_raised(&ImpactEscalationPayload {
+                detail: "post-collision immobilization — operator clearance required".to_string(),
+            });
+        }
+        self.last_escalation_pending = pending;
+    }
+
+    /// The ONLY clearance path. Delegates to [`ClearanceLoop::try_clear`] (state
+    /// FIRST), then records the outcome: `ImpactCleared` on success (with the
+    /// operator id as the clearance source — not duplicated elsewhere), or
+    /// `ImpactClearanceRejected` (with the reason) on rejection. Returns the
+    /// loop's `Result` unchanged.
+    pub fn try_clear(
+        &mut self,
+        grant: &OperatorClearanceGrant,
+        now_ms: u64,
+        max_grant_age_ms: u64,
+    ) -> Result<(), ClearanceRejection> {
+        let outcome = self
+            .clearance
+            .try_clear(grant, now_ms, max_grant_age_ms);
+        match &outcome {
+            Ok(()) => {
+                self.last_escalation_pending = false;
+                self.sink.record_cleared(&ImpactClearedPayload {
+                    clearance_source: grant.operator_id.clone(),
+                });
+            }
+            Err(rej) => {
+                self.sink
+                    .record_clearance_rejected(&ImpactClearanceRejectedPayload {
+                        operator_id: grant.operator_id.clone(),
+                        reason: rej.reason_code().to_string(),
+                    });
+            }
+        }
+        outcome
     }
 }
 
@@ -839,5 +988,127 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&body).expect("json");
         assert_eq!(json["contact_sensor"], true);
         assert_eq!(json["spike_over_threshold"], false, "a non-finite spike never reads as fired");
+    }
+
+    // ─────────────── #103 clearance-loop audit integration ──────────────────
+
+    const LOOP_MAX_AGE: u64 = 60_000;
+
+    fn good_grant(now: u64) -> OperatorClearanceGrant {
+        OperatorClearanceGrant { operator_id: "op-7".to_string(), granted_at_ms: now - 100 }
+    }
+    /// Drive a recorded loop into EscalationRaised.
+    fn escalate(loop_: &mut RecordedClearanceLoop) {
+        loop_.observe(&contact_ev(), &icfg(), 1_000); // Normal → Latched (Detected)
+        loop_.observe(&clean_ev(), &icfg(), 1_001); // Latched → EscalationRaised (Raised)
+        assert_eq!(loop_.state(), ClearanceState::EscalationRaised);
+    }
+
+    /// Escalation is recorded exactly ONCE per incident — re-impact while
+    /// escalated raises nothing new.
+    #[test]
+    fn test_loop_escalation_raised_once() {
+        let sink = Arc::new(InMemoryImpactSink::new());
+        let mut loop_ = RecordedClearanceLoop::new(sink.clone());
+        escalate(&mut loop_);
+        // many more ticks, including a re-impact
+        for t in 0..5 {
+            loop_.observe(&clean_ev(), &icfg(), 2_000 + t);
+        }
+        loop_.observe(&contact_ev(), &icfg(), 3_000); // re-impact while escalated
+        assert_eq!(count_type(&sink, IMPACT_ESCALATION_RAISED_EVENT_TYPE), 1,
+            "exactly one ImpactEscalationRaised per incident");
+        assert_eq!(count_type(&sink, IMPACT_DETECTED_EVENT_TYPE), 1,
+            "exactly one ImpactDetected on the incident-open edge");
+    }
+
+    /// A well-formed grant emits ONE `ImpactCleared` (operator id as source) and
+    /// no rejection.
+    #[test]
+    fn test_loop_clear_emits_impact_cleared() {
+        let sink = Arc::new(InMemoryImpactSink::new());
+        let mut loop_ = RecordedClearanceLoop::new(sink.clone());
+        escalate(&mut loop_);
+        let now = 5_000u64;
+        assert!(loop_.try_clear(&good_grant(now), now, LOOP_MAX_AGE).is_ok());
+        assert_eq!(loop_.state(), ClearanceState::Normal);
+        assert_eq!(count_type(&sink, IMPACT_CLEARED_EVENT_TYPE), 1, "one ImpactCleared on success");
+        assert_eq!(count_type(&sink, IMPACT_CLEARANCE_REJECTED_EVENT_TYPE), 0, "no rejection on success");
+        let (_, body) = sink.events().into_iter().find(|(t, _)| t == IMPACT_CLEARED_EVENT_TYPE).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["clearance_source"], "op-7", "the clearing operator id is the source");
+    }
+
+    /// A rejected clearance is RECORDED (reason + operator id) and leaves the
+    /// state unchanged (still immobilized) — never silently absorbed.
+    #[test]
+    fn test_loop_rejection_recorded_state_unchanged() {
+        let sink = Arc::new(InMemoryImpactSink::new());
+        let mut loop_ = RecordedClearanceLoop::new(sink.clone());
+        escalate(&mut loop_);
+        let now = 5_000u64;
+        let malformed = OperatorClearanceGrant { operator_id: "op-9".to_string(), granted_at_ms: now + 10 }; // future
+        let r = loop_.try_clear(&malformed, now, LOOP_MAX_AGE);
+        assert_eq!(r, Err(ClearanceRejection::MalformedGrant));
+        assert!(loop_.is_immobilized(), "state must be unchanged after a rejected grant");
+        assert_eq!(count_type(&sink, IMPACT_CLEARANCE_REJECTED_EVENT_TYPE), 1);
+        assert_eq!(count_type(&sink, IMPACT_CLEARED_EVENT_TYPE), 0, "no ImpactCleared on rejection");
+        let (_, body) = sink.events().into_iter().find(|(t, _)| t == IMPACT_CLEARANCE_REJECTED_EVENT_TYPE).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["reason"], "malformed_grant");
+        assert_eq!(json["operator_id"], "op-9", "the operator id (audit subject) is recorded");
+    }
+
+    /// Sink failure (poisoned store) does NOT affect the state machine or the
+    /// motion veto — the #263 infallibility proof, extended to the loop.
+    #[test]
+    fn test_loop_sink_failure_state_unaffected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("impact_audit.sqlite");
+        let store = Arc::new(Mutex::new(VerifierStore::new(db.to_str().unwrap()).expect("store")));
+        // Poison the store mutex.
+        let s = Arc::clone(&store);
+        let _ = std::thread::spawn(move || {
+            let _g = s.lock().unwrap();
+            panic!("poison the audit store for the failure test");
+        })
+        .join();
+
+        let sink = Arc::new(ImpactAuditSink::new(Arc::clone(&store)));
+        let mut loop_ = RecordedClearanceLoop::new(sink.clone());
+        loop_.observe(&contact_ev(), &icfg(), 1_000);
+        loop_.observe(&clean_ev(), &icfg(), 1_001);
+        assert!(loop_.is_immobilized(), "veto unaffected by sink failure");
+        assert!(loop_.escalation_pending(), "escalation state unaffected by sink failure");
+        assert!(sink.write_failures() >= 1, "the failed writes must be counted");
+        // A good grant still clears the state machine regardless of audit outcome.
+        let now = 5_000u64;
+        assert!(loop_.try_clear(&good_grant(now), now, LOOP_MAX_AGE).is_ok());
+        assert!(!loop_.is_immobilized(), "clearance state machine unaffected by sink failure");
+    }
+
+    /// The wrapped loop's veto tracks a bare `ClearanceLoop` bit-for-bit over a
+    /// sequence + a clear (no-durable in-memory sink).
+    #[test]
+    fn test_loop_veto_unchanged_without_sink() {
+        use parko_core::ClearanceLoop as BareLoop;
+        let sink = Arc::new(InMemoryImpactSink::new());
+        let mut recorded = RecordedClearanceLoop::new(sink);
+        let mut bare = BareLoop::new();
+
+        let seq = [clean_ev(), contact_ev(), clean_ev(), clean_ev()];
+        for (i, ev) in seq.iter().enumerate() {
+            let now = 1_000 + i as u64;
+            recorded.observe(ev, &icfg(), now);
+            bare.observe(ev, &icfg(), now);
+            assert_eq!(recorded.is_immobilized(), bare.is_immobilized(),
+                "wrapped loop veto must track the bare loop");
+        }
+        let now = 9_000u64;
+        let g = OperatorClearanceGrant { operator_id: "op".to_string(), granted_at_ms: now - 10 };
+        let _ = recorded.try_clear(&g, now, LOOP_MAX_AGE);
+        let _ = bare.try_clear(&g, now, LOOP_MAX_AGE);
+        assert_eq!(recorded.is_immobilized(), bare.is_immobilized());
+        assert!(!recorded.is_immobilized());
     }
 }

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -49,9 +49,9 @@ use parko_core::rss::{lateral_safe_distance, longitudinal_safe_distance, occlusi
 use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
 use parko_core::{
     commit_zone_blocked, gate_commit_zone_scene, gate_water_scene, localization_trusted,
-    water_untraversable_veto, AgentScene, CommitZoneCfg, CommitZoneScene, ImpactLatch,
-    LocalizationCfg, LocalizationIntegrity, OcclusionScene, RssParams, RssState, WaterScene,
-    WaterVetoConfig, MAX_RSS_AGENTS,
+    water_untraversable_veto, AgentScene, ClearanceLoop, CommitZoneCfg, CommitZoneScene,
+    ImpactLatch, LocalizationCfg, LocalizationIntegrity, OcclusionScene, RssParams, RssState,
+    WaterScene, WaterVetoConfig, MAX_RSS_AGENTS,
 };
 
 pub mod angular_bound;
@@ -61,8 +61,10 @@ pub mod diverse;
 pub use angular_bound::{AngularVelocityBound, PlatformParams, ROLLOVER_MIN_LINEAR_VELOCITY_MPS};
 pub use audit_sink::{
     select_divergence_sink, select_impact_sink, AuditChainLinkerDivergenceSink, FatalAuditConfig,
-    ImpactAuditSink, ImpactClearedPayload, ImpactDetectedPayload, ImpactEventSink,
-    InMemoryImpactSink, RecordedImpactLatch, IMPACT_CLEARED_EVENT_TYPE, IMPACT_DETECTED_EVENT_TYPE,
+    ImpactAuditSink, ImpactClearanceRejectedPayload, ImpactClearedPayload, ImpactDetectedPayload,
+    ImpactEscalationPayload, ImpactEventSink, InMemoryImpactSink, RecordedClearanceLoop,
+    RecordedImpactLatch, IMPACT_CLEARANCE_REJECTED_EVENT_TYPE, IMPACT_CLEARED_EVENT_TYPE,
+    IMPACT_DETECTED_EVENT_TYPE, IMPACT_ESCALATION_RAISED_EVENT_TYPE,
 };
 pub use comparator::{GovernorComparator, RssAwareGovernor};
 pub use diverse::DiverseKirraGovernor;
@@ -833,6 +835,31 @@ impl KirraGovernor {
         }
         self.evaluate(proposed, previous, delta_time_s, posture)
     }
+
+    /// AUTHORITATIVE post-collision path through the SG6 CLEARANCE LOOP (#103).
+    ///
+    /// While the [`ClearanceLoop`] is immobilized — in EITHER `Latched` OR
+    /// `EscalationRaised` — OVERRIDE any proposed motion → immobilize, exactly as
+    /// [`evaluate_with_impact_latch`](Self::evaluate_with_impact_latch) does for
+    /// the bare latch. The difference is the EXIT: the loop returns to `Normal`
+    /// only via `ClearanceLoop::try_clear` with a well-formed operator grant (the
+    /// SS-003 structural no-resume), never on clean evidence.
+    pub fn evaluate_with_clearance_loop(
+        &self,
+        proposed: &ControlCommand,
+        previous: Option<&ControlCommand>,
+        delta_time_s: f64,
+        posture: SafetyPosture,
+        clearance: &ClearanceLoop,
+    ) -> EnforcementAction {
+        if clearance.is_immobilized() {
+            return EnforcementAction::Deny {
+                reason: "SG6: post-collision clearance loop — immobilize until operator clearance"
+                    .to_string(),
+            };
+        }
+        self.evaluate(proposed, previous, delta_time_s, posture)
+    }
 }
 
 impl SafetyGovernor for KirraGovernor {
@@ -1469,9 +1496,10 @@ mod scene_rss_tests {
     use parko_core::commands::ControlCommand;
     use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
     use parko_core::{
-        AgentScene, CommitZoneCfg, CommitZoneMap, CommitZoneScene, ImpactCfg, ImpactEvidence,
-        ImpactLatch, LocalizationCfg, LocalizationIntegrity, OcclusionScene, RssAgent, RssParams,
-        RssState, TraversalEvidence, WaterScene, WaterVetoConfig, MAX_RSS_AGENTS,
+        AgentScene, ClearanceLoop, ClearanceState, CommitZoneCfg, CommitZoneMap, CommitZoneScene,
+        ImpactCfg, ImpactEvidence, ImpactLatch, LocalizationCfg, LocalizationIntegrity,
+        OcclusionScene, OperatorClearanceGrant, RssAgent, RssParams, RssState, TraversalEvidence,
+        WaterScene, WaterVetoConfig, MAX_RSS_AGENTS,
     };
 
     fn params() -> RssParams {
@@ -1858,6 +1886,38 @@ mod scene_rss_tests {
             &cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal, &l);
         assert!(matches!(resumed, EnforcementAction::Allow),
             "after explicit clearance, motion resumes, got {resumed:?}");
+    }
+
+    // --- SG6 clearance loop (issue #103) ---
+
+    /// The clearance-loop motion veto immobilizes in BOTH Latched and
+    /// EscalationRaised, and releases ONLY after a well-formed operator grant —
+    /// the SS-003 structural no-resume at the governor boundary.
+    #[test]
+    fn clearance_loop_vetoes_in_both_states_and_releases_only_on_grant() {
+        let gov = KirraGovernor::new();
+        let mut l = ClearanceLoop::new();
+        let contact = ImpactEvidence { imu_accel_spike_mps2: 0.5, contact_sensor: true, vanished_object: false };
+        let clean = ImpactEvidence { imu_accel_spike_mps2: 0.5, contact_sensor: false, vanished_object: false };
+
+        // Latched → Deny.
+        l.observe(&contact, &ImpactCfg::default(), 1_000);
+        assert_eq!(l.state(), ClearanceState::Latched);
+        let d1 = gov.evaluate_with_clearance_loop(&cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal, &l);
+        assert!(matches!(d1, EnforcementAction::Deny { .. }), "Latched must immobilize, got {d1:?}");
+
+        // EscalationRaised → still Deny; clean evidence never resumes.
+        l.observe(&clean, &ImpactCfg::default(), 1_001);
+        assert_eq!(l.state(), ClearanceState::EscalationRaised);
+        let d2 = gov.evaluate_with_clearance_loop(&cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal, &l);
+        assert!(matches!(d2, EnforcementAction::Deny { .. }), "EscalationRaised must immobilize, got {d2:?}");
+
+        // A well-formed grant — and ONLY that — releases motion.
+        let now = 5_000u64;
+        let grant = OperatorClearanceGrant { operator_id: "op-1".to_string(), granted_at_ms: now - 100 };
+        l.try_clear(&grant, now, 60_000).expect("well-formed grant clears");
+        let resumed = gov.evaluate_with_clearance_loop(&cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal, &l);
+        assert!(matches!(resumed, EnforcementAction::Allow), "after the grant, motion resumes, got {resumed:?}");
     }
 
     // --- SG5 commit-zone veto (issue #106) ---


### PR DESCRIPTION
## SG6 clearance loop — structural no-resume (#103)

Closes the clearance loop that **#102** (`ImpactLatch`) and **#263** (audit bridge) set up. Today `ImpactLatch::clear(bool)` lets **any** caller un-latch by passing `true` — SS-003's *"human intervention required"* has no structural enforcement at this layer. This adds that structure: once immobilized, the **only** path back to `Normal` is a well-formed operator grant.

### Named boundary (stated up front)
parko **cannot authenticate** an operator — authentication lives in the verifier / `kirra_core` reset mechanism (**#255**, `KIRRA_SUPERVISOR_RESET_KEY`). This loop enforces the **structure** only (clearance via a well-formed grant, no other path); the integrator/verifier is responsible for issuing a grant **only after** it authenticates the operator. That obligation is an **assumption of use**, documented in the type's doc-comments (`OperatorClearanceGrant`), not enforced here. Operator-notification **transport** (how `escalation_pending` reaches a human) is likewise deferred — integrator/UI territory.

### parko-core (`impact.rs`)
- **`OperatorClearanceGrant { operator_id, granted_at_ms }`** + `is_well_formed(now_ms, max_grant_age_ms)`: non-empty id, **not future-dated**, not older than max age (**inclusive** boundary). `now_ms` supplied (testability). `DEFAULT_MAX_GRANT_AGE_MS` is a conservative VALIDATION-PENDING default.
- **`ClearanceLoop`** state machine: `Normal → Latched → EscalationRaised → Normal`. `Latched` is the transient post-impact tick; the next `observe` raises the **once-per-incident** escalation edge (a distinct, observable signal). API: `observe` / `is_immobilized` (Latched **or** EscalationRaised — feeds the veto) / `escalation_pending` / `try_clear(grant) -> Result<(), ClearanceRejection>` (the **only** clear path).
- **The invariant:** nothing transitions out of `Latched`/`EscalationRaised` except `try_clear` with a well-formed grant; clean evidence never clears; re-impact while escalated does **not** double-raise.
- The bare `ImpactLatch::clear(bool)` **stays** (the low-level primitive #263 uses) with a doc-comment directing production clearance through `ClearanceLoop`. **No #102/#263 API broken.**

### parko-kirra
- **`RecordedClearanceLoop`** emits through the existing `ImpactEventSink` family with rising-edge semantics: `ImpactDetected` (incident open) → `ImpactEscalationRaised` (once per incident) → on `try_clear` either `ImpactCleared` (operator id as source — not duplicated) or `ImpactClearanceRejected` (reason + operator id; id is an audit **subject**, there is no token at this layer to leak). New payloads + two trait methods (`record_escalation_raised` / `record_clearance_rejected`) implemented for both the durable and in-memory sinks. **Infallible toward the veto** — state mutated first, audit best-effort, `write_failures` counter (the #263 proof, extended).
- **`evaluate_with_clearance_loop`** — motion-veto sibling of `evaluate_with_impact_latch` that vetoes in **both** `Latched` and `EscalationRaised`.

### Tests
The invariant (clean evidence never clears; malformed grants — empty id / future / stale — rejected and still immobilized; only a well-formed grant clears); escalation rising edge (once per incident; re-impact no second raise; cleared-then-new-impact raises again); grant-on-`Normal` rejected (recorded, not absorbed); veto active in both states; grant age boundary inclusive; audit integration (escalation once, cleared on success, rejection recorded with reason + id, sink-failure leaves the state machine unaffected, no-sink veto tracks a bare loop). `cargo test -p parko-core -p parko-kirra` green (all #102/#263 suites intact); clippy clean.

### Scope / safety
- **parko-core + parko-kirra only.** No `src/`. Grant **authentication** and notification **transport** are named-boundary deferrals. Gateway kinematics contract byte-identical — talisman blob `997fb7ae…` unchanged.

Completes the **runtime side of #103** (the reset hardening was #255). References #103, #102, SS-003.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_