### PR TITLE
spike(transport): iceoryx2 host-side feature-subset + fault-matrix (#273)

### DIFF
--- a/tools/iceoryx2-spike/Cargo.toml
+++ b/tools/iceoryx2-spike/Cargo.toml
@@ -1,0 +1,31 @@
+# Standalone spike crate — NOT a member of the kirra-runtime-sdk workspace.
+# The empty [workspace] table below makes this its own workspace root, so it
+# carries its own Cargo.lock and iceoryx2 never enters any SDK/parko crate's
+# dependency tree (this is a spike, not an adoption — adoption is the #275 ADR's
+# decision). See README.md.
+[workspace]
+
+[package]
+name = "iceoryx2-spike"
+version = "0.0.0"
+edition = "2021"
+publish = false
+description = "Host-side iceoryx2 feature-subset + fault-matrix spike (#273)"
+
+# PINNED — host-side feature-subset spike (#273). Version recorded in README.
+# `default-features = false` so THIS crate's features (below) drive iceoryx2's,
+# letting us reproduce the QNX 8.0 `--no-default-features` constraint on host:
+#   cargo test                       -> "full"    config (iceoryx2 std + console)
+#   cargo test --no-default-features -> "minimal" config (iceoryx2 NO features)
+[dependencies]
+iceoryx2 = { version = "=0.9.1", default-features = false }
+
+[features]
+# DEFAULT (host full): mirror iceoryx2's own default feature set (std + console).
+default = ["ix-full"]
+ix-full = ["iceoryx2/std", "iceoryx2/console"]
+# MINIMAL (QNX 8.0 `--no-default-features` mirror): iceoryx2 with NO features.
+# Empirically sufficient for pub/sub + subscriber lifecycle + the judge — the
+# minimal subset is EMPTY (the #273 deliverable; see README). Reached via
+# `--no-default-features` (leaves iceoryx2 at default-features = false with
+# nothing added back).

--- a/tools/iceoryx2-spike/README.md
+++ b/tools/iceoryx2-spike/README.md
@@ -1,0 +1,152 @@
+# iceoryx2 host-side feature-subset + fault-matrix spike (#273)
+
+Part of EPIC #270 (iceoryx2 transport adoption for the QNX governor lane).
+**This is a spike, not an adoption** — adoption is the #275 ADR's decision. It
+produces the evidence that informs **#274** (QNX 8.0 feature-subset check) and
+**#275** (the transport ADR).
+
+## Isolation (hard rule)
+
+A **standalone crate** with its own `[workspace]` table (→ its own `Cargo.lock`).
+It is **NOT** a member of the `kirra-runtime-sdk` / `parko` workspace, and
+**iceoryx2 never enters any existing crate's dependency tree.** The certified
+kinematic envelope lives in the untouched talisman
+`src/gateway/kinematics_contract.rs`; this spike imports **nothing** from it and
+labels its own envelope numbers as **PROXIES**.
+
+## Pinned version
+
+```
+iceoryx2 = "=0.9.1"
+```
+
+> The host spike pins **0.9.1** (latest at authoring; host Linux is iceoryx2
+> tier-1). The EPIC notes QNX 7.1 landed as tier-3 in v0.7.0. **#274 must
+> re-confirm the feature subset against whatever version targets QNX 8.0** — the
+> methodology transfers even if exact flags shift between versions.
+
+## How to run
+
+```sh
+cd tools/iceoryx2-spike
+
+# FULL config (iceoryx2 default features: std + console)
+cargo test                          # asserted fault matrix over real iceoryx2
+cargo run                           # print the matrix + per-class timing
+
+# MINIMAL config (iceoryx2 --no-default-features → NO features; QNX-8.0 mirror)
+cargo test --no-default-features
+cargo run  --no-default-features
+
+# Production-shape demo: subscriber + publisher as two OS processes
+cargo run -- --two-process
+```
+
+The asserted matrix (`cargo test`) runs publisher + subscriber in one process
+over the `ipc` service — **genuine zero-copy shared memory**, just deterministic
+for assertion. The `--two-process` mode exercises the *same* channel across two
+OS processes (the production shape).
+
+## THE FEATURE-SUBSET RESULT (the deliverable for #274)
+
+| Config | iceoryx2 features | Builds | Runs | Matrix |
+|--------|-------------------|--------|------|--------|
+| **full** (default) | `std`, `console` | ✅ | ✅ | PASS |
+| **minimal** (`--no-default-features`) | **(none)** | ✅ | ✅ | PASS |
+
+**The minimal feature subset for KIRRA's governor edge (pub/sub + subscriber
+lifecycle + judge) is EMPTY.** On host, iceoryx2 0.9.1 compiles **and** runs the
+zero-copy publish/subscribe path with `default-features = false` and nothing
+added back — both `std` and `console` are droppable.
+
+* `console` = iceoryx2-bb-loggers console output — pure convenience, droppable.
+* `std` = std support across the `iceoryx2-bb-*` crates. **Not required** for the
+  pub/sub + subscriber-lifecycle API this spike uses on host. (The spike's own
+  binary still links `std`; the QNX-8.0 `--no-default-features` constraint is
+  about *iceoryx2's* `std` feature, not the application's.)
+* No feature had to be re-added. **Input to #274:** start from
+  `--no-default-features` on the QNX 8.0 target and verify this empty set
+  survives the 8.0 build + runtime (the host cannot prove the *target* runtime —
+  that is #274's job).
+
+> Note on `cargo build --no-default-features`: the CLI flag gates **this crate's**
+> features, not the dependency's. The two configs are therefore driven through
+> this crate's `[features]` (`ix-full = ["iceoryx2/std", "iceoryx2/console"]`,
+> default-off), with iceoryx2 declared `default-features = false`.
+
+## Fault matrix (verdict-correctness gate)
+
+Eight harness fault classes + an `IntegrityFlag` class, each injected
+publisher-side, detected subscriber-side, verdict asserted. **PASS gate =
+verdict correctness only.** Both feature configs are all-PASS.
+
+```
+fault class            samples     ok    p50(us)    p99(us)    max(us)
+----------------------------------------------------------------------
+Valid                     2000   PASS      6.821     16.642     40.570
+BadMagic/StaleHeader      2000   PASS      6.667     15.229     91.615
+SequenceRegress           2000   PASS      6.671     21.574     99.067
+Replay (equal seq)        2000   PASS      6.678     15.588     39.458
+DeadlineMissed            2000   PASS      6.671     21.596     54.754
+IntegrityFlag             2000   PASS      6.655     16.230     43.433
+PayloadCorrupt (CRC)      2000   PASS      6.666     15.563     55.823
+PayloadOversize           2000   PASS      5.713     13.626     43.062
+KinematicLimit            2000   PASS      6.801     15.319     56.222
+```
+
+(Above: full config. The minimal config produces the same all-PASS matrix; both
+are reproduced by the commands above.)
+
+### Subscriber-edge defense-in-depth → judge
+
+Each received frame passes the subscriber **edge** (bounds/oversize, then payload
+CRC) **before** the judge runs the contract checks (magic → sequence → deadline →
+integrity flag → kinematic envelope).
+
+### The Replay row (corrected `<=`)
+
+The judge's sequence rule is **`sequence <= last_accepted ⇒ reject`** — an *equal*
+sequence is a replay and rejects; only a *strictly newer* sequence passes. The
+strict-`<` form was a known replay hole and is **not** reintroduced. Proven
+red/green by `replay_equal_sequence_rejects` (equal → `Reject(Replay)`, newer →
+`Accept`) and the `Replay (equal seq)` matrix row.
+
+## TornHeader — ELIMINATED BY TRANSPORT (a finding, not a skipped test)
+
+iceoryx2's managed sample lifecycle prevents a torn read **by construction**: the
+publisher writes into an **exclusively-loaned** slot, and `send()` publishes an
+**immutable** sample; the subscriber's `receive()` returns an **owned `Sample`**
+over a stable slot that is **not recycled while held**. The application never
+double-reads a live, concurrently-mutating buffer — so a torn header is not
+reachable without `unsafe` raw-memory access, which this spike forbids.
+**`transport-eliminates-X` is first-class ADR evidence for #275.** (A variable-
+length `[u8]` service would additionally bound the received slice length; the
+fixed `#[repr(C)]` frame here makes the application-level `declared_len` bound
+the explicit oversize check.)
+
+## FFI-elimination (the architectural point)
+
+In the classic-iceoryx **C++** shim the judge was reached across an `extern "C"`
+boundary — a raw pointer dereference inside `unsafe`. Over a **Rust iceoryx2**
+subscriber edge the judge is an **ordinary function call** on a typed
+`&CommandFrame`: **no `extern "C"`, no `unsafe`, no FFI on the command path**
+(`grep -rn 'unsafe\|extern "C"\|no_mangle' src/` finds only doc-comments). The
+governor hot path can be Rust end-to-end — coherent with the QNX + Ferrocene
+certification stack. **This is the input to the #275 ADR** ("FFI demoted to the
+documented C/C++ integration boundary").
+
+## Honesty banner
+
+The PASS gate is **verdict correctness**. The host timing above is **indicative
+only** — warmup-primed p50/p99/max over the full
+publish→zero-copy→validate→judge path on a shared dev host. **Certified WCET
+comes from the QNX 8.0 target under FIFO scheduling (#274).** Host numbers are
+never presented as WCET.
+
+## Informs
+
+* **#274** — QNX 8.0 `--no-default-features` build + feature-subset verification +
+  target-measured FDIT/WCET. This spike's empty minimal feature list is its input.
+* **#275** — the transport ADR (iceoryx2 over classic; Rust end-to-end; FFI
+  demoted). This spike supplies the no-FFI demonstration and the
+  transport-eliminates-TornHeader finding.

--- a/tools/iceoryx2-spike/src/harness.rs
+++ b/tools/iceoryx2-spike/src/harness.rs
@@ -1,0 +1,279 @@
+// harness.rs — drive the fault classes through a REAL iceoryx2 zero-copy
+// pub/sub channel and assert the subscriber-side outcome per class.
+//
+// Flow per injected frame: publisher.loan → write → send  ⇒  zero-copy shared
+// memory  ⇒  subscriber.receive  ⇒  edge_validate (bounds/oversize, CRC)  ⇒
+// judge. The verdict is asserted on the RECEIVED frame, proving the data made it
+// across the transport intact. PASS/FAIL is on VERDICT CORRECTNESS ONLY; the
+// timing is indicative (see the honesty banner in main.rs).
+
+use core::time::Duration;
+use std::time::Instant;
+
+use iceoryx2::port::publisher::Publisher;
+use iceoryx2::port::subscriber::Subscriber;
+use iceoryx2::prelude::*;
+
+use crate::judge::{JudgeState, RejectReason, Verdict};
+use crate::wire::{edge_validate, CommandFrame, EdgeReject, MAX_PAYLOAD_LEN};
+
+/// Logical "now" handed to the judge (monotonic-domain nanoseconds). Fixed so
+/// the deadline verdict is deterministic; the real path TIMING is measured
+/// separately with `Instant` and never feeds a verdict.
+const LOGICAL_NOW_NANOS: u64 = 1_000_000_000;
+const FUTURE_DEADLINE_NANOS: u64 = u64::MAX / 2;
+const PAST_DEADLINE_NANOS: u64 = 0;
+/// Seed sequence for the classes that need a prior accepted command.
+const SEED_SEQUENCE: u64 = 1_000;
+
+/// The combined subscriber-side outcome: rejected at the edge, or judged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Outcome {
+    EdgeReject(EdgeReject),
+    Judged(Verdict),
+}
+
+/// Subscriber-side processing: edge defense-in-depth THEN the judge.
+pub fn process(frame: &CommandFrame, state: &mut JudgeState, now_nanos: u64) -> Outcome {
+    match edge_validate(frame) {
+        Err(e) => Outcome::EdgeReject(e),
+        Ok(()) => Outcome::Judged(state.judge(frame, now_nanos)),
+    }
+}
+
+/// The fault classes injected through the channel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FaultClass {
+    Valid,
+    BadMagicStaleHeader,
+    SequenceRegress,
+    Replay,
+    DeadlineMissed,
+    IntegrityFlag,
+    PayloadCorrupt,
+    PayloadOversize,
+    KinematicLimit,
+}
+
+impl FaultClass {
+    pub const ALL: [FaultClass; 9] = [
+        FaultClass::Valid,
+        FaultClass::BadMagicStaleHeader,
+        FaultClass::SequenceRegress,
+        FaultClass::Replay,
+        FaultClass::DeadlineMissed,
+        FaultClass::IntegrityFlag,
+        FaultClass::PayloadCorrupt,
+        FaultClass::PayloadOversize,
+        FaultClass::KinematicLimit,
+    ];
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            FaultClass::Valid => "Valid",
+            FaultClass::BadMagicStaleHeader => "BadMagic/StaleHeader",
+            FaultClass::SequenceRegress => "SequenceRegress",
+            FaultClass::Replay => "Replay (equal seq)",
+            FaultClass::DeadlineMissed => "DeadlineMissed",
+            FaultClass::IntegrityFlag => "IntegrityFlag",
+            FaultClass::PayloadCorrupt => "PayloadCorrupt (CRC)",
+            FaultClass::PayloadOversize => "PayloadOversize",
+            FaultClass::KinematicLimit => "KinematicLimit",
+        }
+    }
+
+    /// The outcome a correct subscriber MUST produce for this class.
+    pub fn expected(&self) -> Outcome {
+        match self {
+            FaultClass::Valid => Outcome::Judged(Verdict::Accept),
+            FaultClass::BadMagicStaleHeader => Outcome::Judged(Verdict::Reject(RejectReason::BadMagic)),
+            FaultClass::SequenceRegress => Outcome::Judged(Verdict::Reject(RejectReason::SequenceRegress)),
+            FaultClass::Replay => Outcome::Judged(Verdict::Reject(RejectReason::Replay)),
+            FaultClass::DeadlineMissed => Outcome::Judged(Verdict::Reject(RejectReason::DeadlineMissed)),
+            FaultClass::IntegrityFlag => Outcome::Judged(Verdict::Reject(RejectReason::IntegrityFlag)),
+            FaultClass::PayloadCorrupt => Outcome::EdgeReject(EdgeReject::CrcMismatch),
+            FaultClass::PayloadOversize => Outcome::EdgeReject(EdgeReject::Oversize),
+            FaultClass::KinematicLimit => Outcome::Judged(Verdict::Reject(RejectReason::KinematicLimit)),
+        }
+    }
+
+    /// Fresh judge state appropriate for this class. Replay/Regress need a prior
+    /// accepted command, so their state is pre-seeded; the rest start empty.
+    fn initial_state(&self) -> JudgeState {
+        match self {
+            FaultClass::SequenceRegress | FaultClass::Replay => JudgeState {
+                last_accepted: SEED_SEQUENCE,
+                have_accepted: true,
+            },
+            _ => JudgeState::new(),
+        }
+    }
+
+    /// Build the (faulted) frame for iteration `i` of this class. `i` lets the
+    /// Valid stream advance monotonically; reject classes keep a constant
+    /// sequence (rejections never advance the gate).
+    fn build_frame(&self, i: u64) -> CommandFrame {
+        match self {
+            FaultClass::Valid => {
+                // Strictly-increasing sequence so each is newer than the last.
+                CommandFrame::well_formed(SEED_SEQUENCE + 1 + i, FUTURE_DEADLINE_NANOS, 5.0, 0.2)
+            }
+            FaultClass::BadMagicStaleHeader => {
+                let mut f = CommandFrame::well_formed(1, FUTURE_DEADLINE_NANOS, 5.0, 0.2);
+                f.magic = 0xDEAD_BEEF;
+                f
+            }
+            FaultClass::SequenceRegress => {
+                // Below the seeded last_accepted ⇒ regress.
+                CommandFrame::well_formed(SEED_SEQUENCE - 500, FUTURE_DEADLINE_NANOS, 5.0, 0.2)
+            }
+            FaultClass::Replay => {
+                // Exactly the seeded last_accepted ⇒ replay (the corrected `<=`).
+                CommandFrame::well_formed(SEED_SEQUENCE, FUTURE_DEADLINE_NANOS, 5.0, 0.2)
+            }
+            FaultClass::DeadlineMissed => {
+                CommandFrame::well_formed(1, PAST_DEADLINE_NANOS, 5.0, 0.2)
+            }
+            FaultClass::IntegrityFlag => {
+                let mut f = CommandFrame::well_formed(1, FUTURE_DEADLINE_NANOS, 5.0, 0.2);
+                f.integrity_flag = 0;
+                f
+            }
+            FaultClass::PayloadCorrupt => {
+                let mut f = CommandFrame::well_formed(1, FUTURE_DEADLINE_NANOS, 5.0, 0.2);
+                f.payload[0] ^= 0xFF; // mutate bytes WITHOUT recomputing the CRC
+                f
+            }
+            FaultClass::PayloadOversize => {
+                let mut f = CommandFrame::well_formed(1, FUTURE_DEADLINE_NANOS, 5.0, 0.2);
+                f.declared_len = (MAX_PAYLOAD_LEN + 1) as u16;
+                f
+            }
+            FaultClass::KinematicLimit => {
+                // Linear speed far beyond the PROXY envelope.
+                CommandFrame::well_formed(1, FUTURE_DEADLINE_NANOS, 999.0, 0.0)
+            }
+        }
+    }
+}
+
+/// One row of the fault matrix.
+#[derive(Clone, Debug)]
+pub struct RowResult {
+    pub class: FaultClass,
+    pub samples: usize,
+    pub all_correct: bool,
+    pub expected: Outcome,
+    pub observed: Outcome,
+    pub p50: Duration,
+    pub p99: Duration,
+    pub max: Duration,
+}
+
+impl RowResult {
+    pub fn pass(&self) -> bool {
+        self.all_correct
+    }
+}
+
+fn percentile(sorted: &[Duration], pct: f64) -> Duration {
+    if sorted.is_empty() {
+        return Duration::ZERO;
+    }
+    let idx = ((pct / 100.0) * (sorted.len() as f64 - 1.0)).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+/// A live iceoryx2 publish/subscribe channel for `CommandFrame`, used by the
+/// matrix. The publisher and subscriber are real iceoryx2 endpoints over the
+/// `ipc` service (genuine zero-copy shared memory); the harness creates them in
+/// one process for a deterministic matrix, while the binary's `--two-process`
+/// mode demonstrates the production shape.
+pub struct Channel {
+    publisher: Publisher<ipc::Service, CommandFrame, ()>,
+    subscriber: Subscriber<ipc::Service, CommandFrame, ()>,
+}
+
+impl Channel {
+    pub fn create(service_name: &str) -> Result<Self, Box<dyn core::error::Error>> {
+        let node = NodeBuilder::new().create::<ipc::Service>()?;
+        let service = node
+            .service_builder(&service_name.try_into()?)
+            .publish_subscribe::<CommandFrame>()
+            .open_or_create()?;
+        let publisher = service.publisher_builder().create()?;
+        let subscriber = service.subscriber_builder().create()?;
+        Ok(Self { publisher, subscriber })
+    }
+
+    /// Publish one frame and return the RECEIVED copy (proves the round-trip).
+    fn round_trip(&self, frame: CommandFrame) -> Result<CommandFrame, Box<dyn core::error::Error>> {
+        let sample = self.publisher.loan_uninit()?;
+        let sample = sample.write_payload(frame);
+        sample.send()?;
+        // Drain to the most recent sample for this 1:1 exchange.
+        let mut received = None;
+        while let Some(sample) = self.subscriber.receive()? {
+            received = Some(*sample);
+        }
+        received.ok_or_else(|| "no sample received over iceoryx2".into())
+    }
+
+    /// Run one fault class `samples` times through the channel, timing the
+    /// publish→zero-copy→validate→judge path and asserting verdict correctness.
+    pub fn run_class(
+        &self,
+        class: FaultClass,
+        samples: usize,
+    ) -> Result<RowResult, Box<dyn core::error::Error>> {
+        let mut state = class.initial_state();
+        let expected = class.expected();
+        let mut all_correct = true;
+        let mut observed = expected; // overwritten by the first real outcome
+        let mut durations: Vec<Duration> = Vec::with_capacity(samples);
+
+        for i in 0..samples as u64 {
+            let frame = class.build_frame(i);
+            let start = Instant::now();
+            let received = self.round_trip(frame)?;
+            let out = process(&received, &mut state, LOGICAL_NOW_NANOS);
+            durations.push(start.elapsed());
+            observed = out;
+            if out != expected {
+                all_correct = false;
+            }
+        }
+
+        durations.sort_unstable();
+        Ok(RowResult {
+            class,
+            samples,
+            all_correct,
+            expected,
+            observed,
+            p50: percentile(&durations, 50.0),
+            p99: percentile(&durations, 99.0),
+            max: durations.last().copied().unwrap_or(Duration::ZERO),
+        })
+    }
+}
+
+/// Run the full fault matrix over a fresh iceoryx2 channel. `warmup` valid
+/// round-trips prime the path before the timed `samples` per class.
+pub fn run_matrix(
+    service_name: &str,
+    warmup: usize,
+    samples: usize,
+) -> Result<Vec<RowResult>, Box<dyn core::error::Error>> {
+    let channel = Channel::create(service_name)?;
+
+    // Warmup (not timed, not asserted) — first-touch shared-memory + cache.
+    let warm = FaultClass::Valid;
+    let _ = channel.run_class(warm, warmup.max(1))?;
+
+    let mut rows = Vec::new();
+    for class in FaultClass::ALL {
+        rows.push(channel.run_class(class, samples)?);
+    }
+    Ok(rows)
+}

--- a/tools/iceoryx2-spike/src/judge.rs
+++ b/tools/iceoryx2-spike/src/judge.rs
@@ -1,0 +1,119 @@
+// judge.rs — the runtime command judge (contract checks), as PLAIN SAFE RUST.
+//
+// FFI-ELIMINATION DEMONSTRATION: in the C/C++ classic-iceoryx shim the judge was
+// reached across an `extern "C"` boundary (raw pointer + `unsafe`). Over a Rust
+// iceoryx2 subscriber edge the judge is just an ORDINARY FUNCTION CALL on a typed
+// `&CommandFrame` — no `extern "C"`, no `unsafe`, no FFI on the command path.
+// That is the architectural point of this spike (see README).
+//
+// PROXY CONSTANTS: the envelope numbers below are clearly-labelled PROXIES for
+// the spike. The CERTIFIED kinematic envelope lives in the untouched talisman
+// `src/gateway/kinematics_contract.rs` (`VehicleKinematicsContract`); this spike
+// imports NOTHING from it and must never be read as the certified bound.
+
+use crate::wire::{CommandFrame, FRAME_MAGIC};
+
+/// PROXY nominal linear-speed ceiling (m/s). NOT certified — see module note.
+/// (Cf. the talisman `VehicleKinematicsContract::max_speed_mps`.)
+pub const PROXY_MAX_LINEAR_MPS: f64 = 22.35;
+/// PROXY angular-rate ceiling (rad/s). NOT certified — see module note.
+/// (Cf. the talisman / parko angular-bound work, KIRRA-OCCY-ANGULAR-SOTIF-001.)
+pub const PROXY_MAX_ANGULAR_RADPS: f64 = 1.5;
+
+/// The judge's verdict for a single frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Verdict {
+    /// All contract checks passed — the command is admissible.
+    Accept,
+    /// Rejected, with the reason.
+    Reject(RejectReason),
+}
+
+/// Why the judge rejected a frame. Distinct codes so the fault matrix can assert
+/// exactly what each injected fault produces (e.g. Replay vs SequenceRegress).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RejectReason {
+    /// Header magic mismatch (BadMagic / StaleHeader).
+    BadMagic,
+    /// `sequence < last_accepted` — an out-of-order / regressed command.
+    SequenceRegress,
+    /// `sequence == last_accepted` — a REPLAYED command. (The corrected check:
+    /// equal sequence rejects. The strict-`<` form was a known replay hole and
+    /// is NOT reintroduced here.)
+    Replay,
+    /// `now > deadline` — the command arrived too late to be actuated.
+    DeadlineMissed,
+    /// The upstream integrity assertion was not set.
+    IntegrityFlag,
+    /// The decoded command exceeds the (PROXY) kinematic envelope, or is
+    /// non-finite.
+    KinematicLimit,
+}
+
+/// Per-stream judge state. `last_accepted` is the highest accepted sequence; it
+/// gates monotonicity and replay. The `Default` (no command accepted yet) is the
+/// correct fresh state.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct JudgeState {
+    pub last_accepted: u64,
+    pub have_accepted: bool,
+}
+
+impl JudgeState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Judge one frame at time `now_nanos` (monotonic domain). On `Accept`,
+    /// advances `last_accepted`. Pure aside from that state update; no unsafe.
+    ///
+    /// Check order: magic → sequence (monotonic, replay-rejecting) → deadline →
+    /// integrity flag → kinematic envelope. (The subscriber EDGE has already done
+    /// bounds/oversize + CRC; see `wire::edge_validate`.)
+    pub fn judge(&mut self, frame: &CommandFrame, now_nanos: u64) -> Verdict {
+        // 1. Header magic.
+        if frame.magic != FRAME_MAGIC {
+            return Verdict::Reject(RejectReason::BadMagic);
+        }
+
+        // 2. Sequence monotonicity + replay. The corrected rule: reject when
+        //    `sequence <= last_accepted`. Equal == replay, lower == regress.
+        if self.have_accepted && frame.sequence <= self.last_accepted {
+            let reason = if frame.sequence == self.last_accepted {
+                RejectReason::Replay
+            } else {
+                RejectReason::SequenceRegress
+            };
+            return Verdict::Reject(reason);
+        }
+
+        // 3. Deadline freshness.
+        if now_nanos > frame.deadline_nanos {
+            return Verdict::Reject(RejectReason::DeadlineMissed);
+        }
+
+        // 4. Upstream integrity assertion.
+        if frame.integrity_flag != 1 {
+            return Verdict::Reject(RejectReason::IntegrityFlag);
+        }
+
+        // 5. Kinematic envelope (PROXY bounds; NaN/Inf fail closed).
+        match frame.decode_command() {
+            Some((lin, ang)) => {
+                if !lin.is_finite()
+                    || !ang.is_finite()
+                    || lin.abs() > PROXY_MAX_LINEAR_MPS
+                    || ang.abs() > PROXY_MAX_ANGULAR_RADPS
+                {
+                    return Verdict::Reject(RejectReason::KinematicLimit);
+                }
+            }
+            None => return Verdict::Reject(RejectReason::KinematicLimit),
+        }
+
+        // All checks passed — accept and advance the sequence gate.
+        self.last_accepted = frame.sequence;
+        self.have_accepted = true;
+        Verdict::Accept
+    }
+}

--- a/tools/iceoryx2-spike/src/lib.rs
+++ b/tools/iceoryx2-spike/src/lib.rs
@@ -1,0 +1,16 @@
+// iceoryx2-spike — host-side feature-subset + fault-matrix spike (#273).
+//
+// A STANDALONE crate (its own workspace + lockfile) that proves the iceoryx2
+// feature subset KIRRA's governor edge needs and runs the QNX-harness fault
+// matrix over a real Rust zero-copy pub/sub channel — no C++ shim, no FFI, no
+// unsafe on the command path. Informs #274 (QNX 8.0 feature check) and #275
+// (the transport ADR). It is a SPIKE, not an adoption: iceoryx2 must never enter
+// any SDK/parko crate's dependency tree.
+//
+// The certified kinematic envelope lives in the untouched talisman
+// `src/gateway/kinematics_contract.rs`; this crate imports NOTHING from it and
+// labels its own envelope numbers as PROXIES.
+
+pub mod harness;
+pub mod judge;
+pub mod wire;

--- a/tools/iceoryx2-spike/src/main.rs
+++ b/tools/iceoryx2-spike/src/main.rs
@@ -1,0 +1,205 @@
+// iceoryx2-spike binary — runs the fault matrix over a real iceoryx2 channel and
+// prints it with per-fault-class timing.
+//
+// Modes:
+//   (default)        run the matrix in-process over the `ipc` service (real
+//                    zero-copy shared memory) — deterministic, the asserted run.
+//   --two-process    spawn a child `subscribe` process and a child `publish`
+//                    process so the SAME channel is exercised as two OS
+//                    processes — the production shape.
+//   subscribe N      (internal) receive N frames and judge them.
+//   publish   N      (internal) publish N valid frames.
+//
+// HONESTY BANNER: the PASS gate is VERDICT CORRECTNESS. Host timing is
+// INDICATIVE ONLY. Certified WCET comes from the QNX 8.0 target under FIFO
+// scheduling (#274) — host numbers are never presented as WCET.
+
+use std::env;
+use std::process::Command;
+
+use iceoryx2::prelude::*;
+use iceoryx2_spike::harness::{process, run_matrix, Outcome, RowResult};
+use iceoryx2_spike::judge::{JudgeState, Verdict};
+use iceoryx2_spike::wire::{CommandFrame, FRAME_MAGIC};
+
+const SERVICE: &str = "kirra/iceoryx2-spike/cmd";
+const WARMUP: usize = 200;
+const SAMPLES: usize = 2_000;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let mode = args.get(1).map(String::as_str).unwrap_or("matrix");
+
+    let result = match mode {
+        "matrix" => run_and_print_matrix(),
+        "--two-process" => run_two_process(&args[0]),
+        "subscribe" => run_subscriber(parse_count(&args, 2)),
+        "publish" => run_publisher(parse_count(&args, 2)),
+        other => {
+            eprintln!("unknown mode: {other} (use: matrix | --two-process | subscribe N | publish N)");
+            std::process::exit(2);
+        }
+    };
+
+    if let Err(e) = result {
+        eprintln!("ERROR: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn parse_count(args: &[String], idx: usize) -> usize {
+    args.get(idx).and_then(|s| s.parse().ok()).unwrap_or(100)
+}
+
+fn run_and_print_matrix() -> Result<(), Box<dyn core::error::Error>> {
+    let rows = run_matrix(SERVICE, WARMUP, SAMPLES)?;
+    print_banner();
+    print_matrix(&rows);
+    print_torn_header_finding();
+
+    let all_pass = rows.iter().all(RowResult::pass);
+    println!(
+        "\nGATE (verdict correctness): {}",
+        if all_pass { "PASS" } else { "FAIL" }
+    );
+    if !all_pass {
+        return Err("one or more fault classes produced an incorrect verdict".into());
+    }
+    Ok(())
+}
+
+fn print_banner() {
+    println!("============================================================================");
+    println!(" iceoryx2 host-side fault matrix (#273) — Rust end-to-end, no FFI, no unsafe");
+    println!(" transport: iceoryx2 v0.9.1  |  service type: ipc (zero-copy shared memory)");
+    println!(" PASS GATE = VERDICT CORRECTNESS.  Timing is INDICATIVE (host, not WCET).");
+    println!(" Certified WCET comes from the QNX 8.0 target under FIFO scheduling (#274).");
+    println!("============================================================================");
+}
+
+fn print_matrix(rows: &[RowResult]) {
+    println!(
+        "\n{:<22} {:>7} {:>6} {:>10} {:>10} {:>10}",
+        "fault class", "samples", "ok", "p50(us)", "p99(us)", "max(us)"
+    );
+    println!("{}", "-".repeat(70));
+    for r in rows {
+        println!(
+            "{:<22} {:>7} {:>6} {:>10.3} {:>10.3} {:>10.3}",
+            r.class.name(),
+            r.samples,
+            if r.pass() { "PASS" } else { "FAIL" },
+            r.p50.as_secs_f64() * 1e6,
+            r.p99.as_secs_f64() * 1e6,
+            r.max.as_secs_f64() * 1e6,
+        );
+        if !r.pass() {
+            println!("    expected {:?}, observed {:?}", r.expected, r.observed);
+        }
+    }
+}
+
+fn print_torn_header_finding() {
+    println!("\nTornHeader: ELIMINATED BY TRANSPORT (finding, not a skipped test).");
+    println!("  iceoryx2's sample lifecycle prevents a torn read BY CONSTRUCTION: the");
+    println!("  publisher writes into an exclusively-loaned slot and `send()` publishes an");
+    println!("  immutable sample; the subscriber's `receive()` returns an owned `Sample`");
+    println!("  over a stable slot that is not recycled while held. The application never");
+    println!("  double-reads a live, concurrently-mutating buffer — so a torn header is not");
+    println!("  reachable without `unsafe` raw-memory access, which this spike forbids.");
+    println!("  transport-eliminates-X is first-class ADR evidence for #275.");
+}
+
+// --- two-process production-shape demo -------------------------------------
+
+fn run_two_process(exe: &str) -> Result<(), Box<dyn core::error::Error>> {
+    const N: usize = 500;
+    println!("[two-process] spawning subscriber + publisher as separate OS processes...");
+    let mut sub = Command::new(exe).arg("subscribe").arg(N.to_string()).spawn()?;
+    // Give the subscriber a moment to create the service/endpoint.
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    let mut pubp = Command::new(exe).arg("publish").arg(N.to_string()).spawn()?;
+    let pub_status = pubp.wait()?;
+    let sub_status = sub.wait()?;
+    println!(
+        "[two-process] publisher exit={:?}, subscriber exit={:?}",
+        pub_status.code(),
+        sub_status.code()
+    );
+    if pub_status.success() && sub_status.success() {
+        println!("[two-process] PASS — real two-process zero-copy exchange over iceoryx2.");
+        Ok(())
+    } else {
+        Err("two-process exchange failed".into())
+    }
+}
+
+fn run_subscriber(n: usize) -> Result<(), Box<dyn core::error::Error>> {
+    let node = NodeBuilder::new().create::<ipc::Service>()?;
+    let service = node
+        .service_builder(&SERVICE.try_into()?)
+        .publish_subscribe::<CommandFrame>()
+        .open_or_create()?;
+    let subscriber = service.subscriber_builder().create()?;
+
+    let mut received = 0usize;
+    let mut accepted = 0usize;
+    let mut state = JudgeState::new();
+    // Bounded zero-copy queues may DROP under burst when the consumer lags — that
+    // is expected pub/sub backpressure, not a correctness failure. So complete on
+    // a quiet period (no new frame for a grace window) rather than a fixed count,
+    // and gate success on CORRECTNESS: every frame that arrived was accepted, and
+    // the sequence stream stayed monotonic (no reorder over the transport).
+    let overall_deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let mut last_rx = std::time::Instant::now();
+    loop {
+        let mut got_any = false;
+        while let Some(sample) = subscriber.receive()? {
+            received += 1;
+            got_any = true;
+            let frame: CommandFrame = *sample;
+            if let Outcome::Judged(Verdict::Accept) = process(&frame, &mut state, 1_000_000_000) {
+                accepted += 1;
+            }
+        }
+        if got_any {
+            last_rx = std::time::Instant::now();
+        }
+        if received >= 1 && last_rx.elapsed() > std::time::Duration::from_millis(800) {
+            break;
+        }
+        if std::time::Instant::now() > overall_deadline {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+    println!(
+        "[subscribe] received={received}/{n} accepted={accepted} \
+         (pub/sub may drop under burst; correctness = all received accepted, monotonic)"
+    );
+    if received >= 1 && accepted == received {
+        Ok(())
+    } else {
+        Err(format!("subscriber correctness failed: accepted {accepted}/{received}").into())
+    }
+}
+
+fn run_publisher(n: usize) -> Result<(), Box<dyn core::error::Error>> {
+    let node = NodeBuilder::new().create::<ipc::Service>()?;
+    let service = node
+        .service_builder(&SERVICE.try_into()?)
+        .publish_subscribe::<CommandFrame>()
+        .open_or_create()?;
+    let publisher = service.publisher_builder().create()?;
+
+    for i in 0..n as u64 {
+        let frame = CommandFrame::well_formed(i + 1, u64::MAX / 2, 5.0, 0.2);
+        debug_assert_eq!(frame.magic, FRAME_MAGIC);
+        let sample = publisher.loan_uninit()?;
+        let sample = sample.write_payload(frame);
+        sample.send()?;
+        std::thread::sleep(std::time::Duration::from_micros(200));
+    }
+    println!("[publish] sent {n} valid frames");
+    Ok(())
+}

--- a/tools/iceoryx2-spike/src/wire.rs
+++ b/tools/iceoryx2-spike/src/wire.rs
@@ -1,0 +1,124 @@
+// wire.rs — the on-the-wire command frame + the subscriber-EDGE validations.
+//
+// The frame is a fixed-size `#[repr(C)]` POD so it rides iceoryx2's zero-copy
+// publish/subscribe directly (no serialization on the hot path). The subscriber
+// edge keeps two defense-in-depth checks BEFORE the judge runs: a bounds /
+// oversize check and a payload CRC verify (harness design carried over from the
+// QNX FFI harness). The judge (see judge.rs) runs only on a frame that has
+// passed these.
+
+use iceoryx2::prelude::ZeroCopySend;
+
+/// Maximum valid application payload length (bytes) inside the fixed frame.
+/// A `declared_len` above this is the OVERSIZE fault — rejected at the edge.
+pub const MAX_PAYLOAD_LEN: usize = 32;
+
+/// Fixed payload capacity carried by every frame. The iceoryx2 message size is
+/// therefore constant (`size_of::<CommandFrame>()`); "oversize" is modelled as a
+/// *declared* length beyond `MAX_PAYLOAD_LEN` (an application-level bound), since
+/// a fixed type cannot transport a larger-than-capacity buffer. A variable-length
+/// `[u8]` service would additionally check the received slice length; noted in
+/// the README.
+pub const PAYLOAD_CAPACITY: usize = 64;
+
+/// The expected header magic. A frame whose magic differs is rejected
+/// (BadMagic / StaleHeader class).
+pub const FRAME_MAGIC: u32 = 0x4B49_5252; // "KIRR"
+
+/// One command frame. `#[repr(C)]`, all-POD, naturally aligned — nothing is
+/// packed; the layout is stable for zero-copy transfer.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, ZeroCopySend)]
+pub struct CommandFrame {
+    /// Header magic — must equal [`FRAME_MAGIC`].
+    pub magic: u32,
+    /// Monotonic command sequence number. The judge rejects `seq <= last`
+    /// (equal = replay, lower = regress); strictly-newer passes.
+    pub sequence: u64,
+    /// Absolute deadline (nanoseconds, monotonic domain) by which the command
+    /// must be consumed. The judge rejects `now > deadline`.
+    pub deadline_nanos: u64,
+    /// Upstream integrity assertion. `1` = integrity asserted; anything else is
+    /// rejected (IntegrityFlag class).
+    pub integrity_flag: u8,
+    /// Number of valid payload bytes. `> MAX_PAYLOAD_LEN` ⇒ OVERSIZE.
+    pub declared_len: u16,
+    /// CRC-32 (IEEE) over `payload[..declared_len]`. Verified at the edge.
+    pub crc32: u32,
+    /// Fixed-capacity payload buffer; the command occupies the first
+    /// `declared_len` bytes (here: two little-endian `f64`s — linear m/s,
+    /// angular rad/s).
+    pub payload: [u8; PAYLOAD_CAPACITY],
+}
+
+impl CommandFrame {
+    /// Build a well-formed frame carrying `(linear_mps, angular_radps)`, with a
+    /// correct CRC and `declared_len = 16`. Callers mutate fields afterward to
+    /// inject faults.
+    pub fn well_formed(sequence: u64, deadline_nanos: u64, linear_mps: f64, angular_radps: f64) -> Self {
+        let mut payload = [0u8; PAYLOAD_CAPACITY];
+        payload[0..8].copy_from_slice(&linear_mps.to_le_bytes());
+        payload[8..16].copy_from_slice(&angular_radps.to_le_bytes());
+        let declared_len: u16 = 16;
+        let crc32 = crc32_ieee(&payload[..declared_len as usize]);
+        Self {
+            magic: FRAME_MAGIC,
+            sequence,
+            deadline_nanos,
+            integrity_flag: 1,
+            declared_len,
+            crc32,
+            payload,
+        }
+    }
+
+    /// Decode the kinematic command `(linear_mps, angular_radps)` from the
+    /// payload. Returns `None` if there are not enough valid bytes.
+    pub fn decode_command(&self) -> Option<(f64, f64)> {
+        let n = self.declared_len as usize;
+        if !(16..=PAYLOAD_CAPACITY).contains(&n) {
+            return None;
+        }
+        let lin = f64::from_le_bytes(self.payload[0..8].try_into().ok()?);
+        let ang = f64::from_le_bytes(self.payload[8..16].try_into().ok()?);
+        Some((lin, ang))
+    }
+}
+
+/// Why the subscriber EDGE rejected a frame (before the judge ran).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EdgeReject {
+    /// `declared_len` exceeds `MAX_PAYLOAD_LEN` (or the frame capacity).
+    Oversize,
+    /// CRC over the declared payload bytes did not match the header CRC.
+    CrcMismatch,
+}
+
+/// The subscriber-edge defense-in-depth: bounds/oversize THEN CRC. Returns
+/// `Ok(())` only if the frame is safe to hand to the judge. Pure, no unsafe.
+pub fn edge_validate(frame: &CommandFrame) -> Result<(), EdgeReject> {
+    let n = frame.declared_len as usize;
+    // 1. bounds / oversize — never index past the buffer, never trust a length.
+    if n > MAX_PAYLOAD_LEN || n > PAYLOAD_CAPACITY {
+        return Err(EdgeReject::Oversize);
+    }
+    // 2. payload CRC — integrity of the bytes the judge will read.
+    if crc32_ieee(&frame.payload[..n]) != frame.crc32 {
+        return Err(EdgeReject::CrcMismatch);
+    }
+    Ok(())
+}
+
+/// CRC-32 (IEEE 802.3, reflected, poly 0xEDB88320), table-less. Kept in-crate so
+/// the spike's only dependency is iceoryx2 (clean feature-subset story).
+pub fn crc32_ieee(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}

--- a/tools/iceoryx2-spike/tests/fault_matrix.rs
+++ b/tools/iceoryx2-spike/tests/fault_matrix.rs
@@ -1,0 +1,114 @@
+// Integration test — the fault matrix over a REAL iceoryx2 channel, asserted.
+// Runs identically in both feature configs:
+//   cargo test                        (full:    iceoryx2 std + console)
+//   cargo test --no-default-features  (minimal: iceoryx2 no features)
+//
+// Gate = verdict correctness only.
+
+use iceoryx2_spike::harness::{run_matrix, FaultClass, Outcome};
+use iceoryx2_spike::judge::{JudgeState, RejectReason, Verdict};
+use iceoryx2_spike::wire::{edge_validate, CommandFrame, EdgeReject, FRAME_MAGIC, MAX_PAYLOAD_LEN};
+
+/// Every fault class produces its expected verdict across many samples over the
+/// real transport.
+#[test]
+fn fault_matrix_all_classes_correct() {
+    let rows = run_matrix("kirra/spike/test-matrix", 50, 200).expect("matrix run");
+    assert_eq!(rows.len(), FaultClass::ALL.len());
+    for r in &rows {
+        assert!(
+            r.all_correct,
+            "class {} wrong: expected {:?}, observed {:?}",
+            r.class.name(),
+            r.expected,
+            r.observed
+        );
+    }
+}
+
+/// The Replay row specifically: an EQUAL sequence must reject (the corrected
+/// `<=` rule). This is the red/green proof that the strict-`<` replay hole is
+/// not present.
+#[test]
+fn replay_equal_sequence_rejects() {
+    let mut state = JudgeState { last_accepted: 7, have_accepted: true };
+    // Equal sequence ⇒ Replay.
+    let equal = CommandFrame::well_formed(7, u64::MAX / 2, 1.0, 0.0);
+    assert_eq!(
+        state.judge(&equal, 1_000),
+        Verdict::Reject(RejectReason::Replay),
+        "equal sequence must be rejected as Replay (the corrected <= check)"
+    );
+    // Strictly-newer ⇒ accepted (the legitimate path still works).
+    let newer = CommandFrame::well_formed(8, u64::MAX / 2, 1.0, 0.0);
+    assert_eq!(state.judge(&newer, 1_000), Verdict::Accept);
+}
+
+/// Lower sequence is a regress (distinct from replay).
+#[test]
+fn lower_sequence_is_regress() {
+    let mut state = JudgeState { last_accepted: 7, have_accepted: true };
+    let lower = CommandFrame::well_formed(6, u64::MAX / 2, 1.0, 0.0);
+    assert_eq!(state.judge(&lower, 1_000), Verdict::Reject(RejectReason::SequenceRegress));
+}
+
+/// The subscriber edge rejects oversize before the judge sees the frame.
+#[test]
+fn edge_rejects_oversize() {
+    let mut f = CommandFrame::well_formed(1, u64::MAX / 2, 1.0, 0.0);
+    f.declared_len = (MAX_PAYLOAD_LEN + 1) as u16;
+    assert_eq!(edge_validate(&f), Err(EdgeReject::Oversize));
+}
+
+/// The subscriber edge rejects a CRC mismatch.
+#[test]
+fn edge_rejects_crc_mismatch() {
+    let mut f = CommandFrame::well_formed(1, u64::MAX / 2, 1.0, 0.0);
+    f.payload[0] ^= 0xFF; // corrupt without recomputing CRC
+    assert_eq!(edge_validate(&f), Err(EdgeReject::CrcMismatch));
+}
+
+/// Bad magic, missed deadline, integrity flag, and the kinematic envelope all
+/// reject through the judge; a clean frame accepts.
+#[test]
+fn judge_contract_checks() {
+    // Clean accept.
+    let mut s = JudgeState::new();
+    let ok = CommandFrame::well_formed(1, u64::MAX / 2, 5.0, 0.2);
+    assert_eq!(s.judge(&ok, 1_000), Verdict::Accept);
+
+    // Bad magic.
+    let mut s = JudgeState::new();
+    let mut bad = CommandFrame::well_formed(1, u64::MAX / 2, 5.0, 0.2);
+    bad.magic = !FRAME_MAGIC;
+    assert_eq!(s.judge(&bad, 1_000), Verdict::Reject(RejectReason::BadMagic));
+
+    // Missed deadline (now > deadline).
+    let mut s = JudgeState::new();
+    let stale = CommandFrame::well_formed(1, 100, 5.0, 0.2);
+    assert_eq!(s.judge(&stale, 1_000), Verdict::Reject(RejectReason::DeadlineMissed));
+
+    // Integrity flag not set.
+    let mut s = JudgeState::new();
+    let mut noint = CommandFrame::well_formed(1, u64::MAX / 2, 5.0, 0.2);
+    noint.integrity_flag = 0;
+    assert_eq!(s.judge(&noint, 1_000), Verdict::Reject(RejectReason::IntegrityFlag));
+
+    // Kinematic envelope (over the PROXY limit) and NaN both reject.
+    let mut s = JudgeState::new();
+    let fast = CommandFrame::well_formed(1, u64::MAX / 2, 999.0, 0.0);
+    assert_eq!(s.judge(&fast, 1_000), Verdict::Reject(RejectReason::KinematicLimit));
+    let mut s = JudgeState::new();
+    let nan = CommandFrame::well_formed(1, u64::MAX / 2, f64::NAN, 0.0);
+    assert_eq!(s.judge(&nan, 1_000), Verdict::Reject(RejectReason::KinematicLimit));
+}
+
+/// Sanity: a valid frame survives the zero-copy round-trip and is accepted
+/// (a single-class smoke over the transport).
+#[test]
+fn valid_round_trips_and_accepts() {
+    let rows = run_matrix("kirra/spike/test-valid", 10, 20).expect("matrix run");
+    let valid = rows.iter().find(|r| r.class == FaultClass::Valid).unwrap();
+    assert!(valid.all_correct);
+    assert_eq!(valid.observed, Outcome::Judged(Verdict::Accept));
+}


### PR DESCRIPTION
## iceoryx2 host-side feature-subset + fault-matrix spike (#273)

A **standalone** crate at `tools/iceoryx2-spike/` that proves the iceoryx2 feature subset KIRRA's governor edge needs and runs the QNX-harness fault matrix over a **real Rust zero-copy pub/sub channel** — no C++ shim, no FFI, no `unsafe` on the command path. Part of EPIC #270; informs **#274** and **#275**.

### Isolation (hard rule honored)
Own `[workspace]` table → own `Cargo.lock`; **iceoryx2 is pinned `=0.9.1` and never enters any SDK/parko crate's dependency tree** (spike, not adoption — adoption is #275's decision). The certified envelope stays in the untouched talisman; the spike imports nothing from it and labels its own numbers as **PROXIES**.

### THE FEATURE-SUBSET RESULT (deliverable for #274)
| Config | iceoryx2 features | Builds | Runs | Matrix |
|---|---|---|---|---|
| **full** (default) | `std`, `console` | ✅ | ✅ | PASS |
| **minimal** (`--no-default-features`) | **(none)** | ✅ | ✅ | PASS |

**The minimal subset is EMPTY** — on host, iceoryx2 0.9.1 compiles *and* runs the zero-copy pub/sub path with `default-features = false` and nothing added back (both `std` and `console` droppable). That's the input to #274 (which must re-confirm on the QNX 8.0 *target* — the host can't prove target runtime). *(Caveat in the README: the CLI `--no-default-features` gates the spike crate, so the two configs are driven via this crate's `[features]` with iceoryx2 declared `default-features = false`.)*

### Fault matrix (both configs all-PASS; gate = verdict correctness only)
```
fault class            samples     ok    p50(us)    p99(us)    max(us)
Valid                     2000   PASS      6.821     16.642     40.570
BadMagic/StaleHeader      2000   PASS      6.667     15.229     91.615
SequenceRegress           2000   PASS      6.671     21.574     99.067
Replay (equal seq)        2000   PASS      6.678     15.588     39.458
DeadlineMissed            2000   PASS      6.671     21.596     54.754
IntegrityFlag             2000   PASS      6.655     16.230     43.433
PayloadCorrupt (CRC)      2000   PASS      6.666     15.563     55.823
PayloadOversize           2000   PASS      5.713     13.626     43.062
KinematicLimit            2000   PASS      6.801     15.319     56.222
```
Subscriber **edge** (bounds/oversize → CRC) runs before the **judge** (magic → sequence → deadline → integrity → kinematic). The **Replay** row proves the corrected `sequence <= last_accepted ⇒ reject` (equal = replay; strictly-newer passes) — the strict-`<` hole is **not** reintroduced (red/green in `replay_equal_sequence_rejects`).

### TornHeader — ELIMINATED BY TRANSPORT (a finding, not a skipped test)
iceoryx2's sample lifecycle prevents a torn read **by construction**: the publisher writes into an exclusively-loaned slot, `send()` publishes an immutable sample, and the subscriber's `receive()` returns an owned `Sample` over a stable slot not recycled while held — the application never double-reads a live, mutating buffer. Not reachable without `unsafe` raw-memory access (which the spike forbids). `transport-eliminates-X` is first-class ADR evidence for #275.

### FFI-elimination (the architectural point for #275)
In the classic C++ shim the judge was reached across `extern "C"` (raw pointer + `unsafe`). Over the Rust iceoryx2 edge the judge is an **ordinary function call** on a typed `&CommandFrame` — `grep -rn 'unsafe\|extern "C"\|no_mangle' src/` finds only doc-comments.

### Verification
- `cargo test` **and** `cargo test --no-default-features` green (7 tests each, the matrix over real iceoryx2).
- `cargo run [--no-default-features]` prints both all-PASS matrices; `cargo run -- --two-process` exercises the production two-process shape (stable 3/3).
- clippy clean both configs; no `unsafe`/`extern "C"`.
- `git diff --name-only origin/main...HEAD` → **only `tools/iceoryx2-spike/**`** (no workspace `Cargo.toml` edits, no `src/`, no `parko/`).
- Talisman `997fb7ae…` byte-identical.

### Honesty banner
PASS gate = verdict correctness. Host timing is **indicative only**; certified WCET comes from the QNX 8.0 target under FIFO scheduling (**#274**). Host numbers are never presented as WCET.

References #273, EPIC #270; informs #274 and #275.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_