### PR TITLE
feat(impact): derive vanished_object from AgentScene frame diff — SG6 (#102 follow-up)

### DIFF
--- a/parko/crates/parko-core/src/impact.rs
+++ b/parko/crates/parko-core/src/impact.rs
@@ -11,6 +11,8 @@
 // `control_loop`'s `EmergencyStop`: once in the safe state, clean evidence does
 // not pull it back out) and is cleared ONLY by an explicit clearance signal.
 
+use crate::rss::AgentScene;
+
 /// One tick of impact evidence. Synthetic in tests; real sensor / agent-diff
 /// ingestion is DEFERRED (see the PR notes).
 #[derive(Debug, Clone, Copy)]
@@ -22,9 +24,10 @@ pub struct ImpactEvidence {
     pub imu_accel_spike_mps2: f64,
     /// A physical contact sensor fired — a definitive impact.
     pub contact_sensor: bool,
-    /// A close-range tracked agent vanished between frames (the
-    /// person-under-vehicle case). Supplied as a flag here; the stateful
-    /// `AgentScene`-diff that derives it is DEFERRED. Latches ALONE, per SG6.
+    /// A close-range agent vanished between frames (the person-under-vehicle
+    /// case). DERIVED from the `AgentScene` frame diff by
+    /// [`VanishedObjectDetector`] (the caller runs it and feeds the flag here).
+    /// Latches ALONE, per SG6.
     pub vanished_object: bool,
 }
 
@@ -302,6 +305,182 @@ impl ClearanceLoop {
     }
 }
 
+/// Config for [`VanishedObjectDetector`]. All three are VALIDATION-PENDING
+/// conservative placeholders — NOT certified values.
+#[derive(Debug, Clone, Copy)]
+pub struct VanishedCfg {
+    /// Close-range radius (m): a finite longitudinal gap `<= r_close_m` makes an
+    /// agent a "close agent" whose later disappearance is the person-under-
+    /// vehicle concern. VALIDATION-PENDING.
+    pub r_close_m: f64,
+    /// Worst-case agent escape speed (m/s) used to grow the reachable band. Cf.
+    /// the occlusion primitive's `v_emerge_max` worst-case-agent modelling
+    /// (`crate::rss` occlusion cap): the same "bound the actor, don't track it"
+    /// philosophy. A *lower* value makes the band tighter → latches more readily
+    /// on a departure (the immobilize-safe nuisance direction). VALIDATION-PENDING.
+    pub v_agent_max_mps: f64,
+    /// Band slack (m) added to absorb measurement noise at the band edge.
+    /// VALIDATION-PENDING.
+    pub slack_m: f64,
+}
+
+impl Default for VanishedCfg {
+    fn default() -> Self {
+        // VALIDATION-PENDING placeholders (not certified values):
+        Self {
+            r_close_m: 2.0,        // person-near-vehicle close range
+            v_agent_max_mps: 3.0,  // brisk human gait — conservative (tight band)
+            slack_m: 0.5,          // band edge noise
+        }
+    }
+}
+
+/// A pending close-agent obligation: a close agent was observed and has not yet
+/// been shown to have departed trackably.
+#[derive(Debug, Clone, Copy)]
+struct PendingClose {
+    /// First tick (ms) the close agent was observed (diagnostic; not used in the
+    /// band, which grows from `last_valid_frame_ms`).
+    first_seen_ms: u64,
+    /// The most recent VALID frame (ms) at which the obligation was set/refreshed.
+    /// The reachable band grows from here, so a gap (Absent / empty-vec) that does
+    /// NOT refresh it lets the band keep growing with elapsed time.
+    last_valid_frame_ms: u64,
+}
+
+/// SG6 — derive [`ImpactEvidence::vanished_object`] from the [`AgentScene`] frame
+/// diff (the #102-deferred follow-up). The latch's strongest trigger (the
+/// person-under-vehicle case, which latches ALONE) is converted from a SUPPLIED
+/// boolean to a COMPUTED one.
+///
+/// SET-LEVEL semantics (forced by grounding): `RssAgent` has **no identity**, so
+/// this cannot track a specific agent across frames. It maintains a single
+/// pending close-agent obligation and decides, on each VALID frame, whether the
+/// close agent could have legitimately departed — by a **kinematic-reachability
+/// band**, not per-agent association.
+///
+/// A VALID frame is `KnownEmpty` or `Agents(non-empty)`. `Absent` and
+/// `Agents(vec![])` are GAPS (empty-vec is ambiguous per the established
+/// fail-closed rule — it must NOT count as evidence of departure). The
+/// obligation is **sticky-toward-safe**: it PERSISTS across gaps and the band
+/// keeps growing, so the verdict is decided at the gap's END (the next valid
+/// frame). During a gap the existing `AgentScene::Absent → UNSAFE` evaluation
+/// already vetoes motion, so the vehicle is held regardless.
+///
+/// Verdict (on a valid frame with a pending obligation): compute
+/// `R_band = r_close_m + v_agent_max_mps · Δt + slack_m` (Δt = seconds since
+/// `last_valid_frame_ms`). If ANY agent has a finite gap `<= R_band`, the close
+/// agent plausibly moved / is still tracked → refresh (still within `r_close`) or
+/// release (within band but no longer within `r_close` — it departed trackably).
+///
+/// If NO agent is within the band, the verdict turns on the **plausibility
+/// horizon** (a decided reading of the spec's "band grown past plausibility",
+/// derived from the three cfg params — there is no fourth knob): absence is
+/// conclusive evidence of a vanish ONLY while the band's GROWTH term
+/// `v_agent_max_mps · Δt <= r_close_m` (the departing agent would still be in the
+/// near-field and detectable). Within that window, nothing-detected ⇒
+/// `vanished_object = true` THIS tick — `KnownEmpty` with a small band is the
+/// strongest vanish evidence (perception asserts NOTHING anywhere). Once growth
+/// exceeds `r_close_m` (a long gap ⇒ a huge band), a legitimately-departing agent
+/// could be beyond the near-field, so absence is UNINFORMATIVE → release, no
+/// latch. The obligation is consumed either way.
+///
+/// NUISANCE TRADE (decided, per SG6's err direction): a close encounter + a brief
+/// sensor blip + an agent that genuinely walked away fast CAN latch → operator
+/// clearance. That is the stated direction: immobilize when a person MIGHT be
+/// under the vehicle. NaN discipline: a non-finite gap can never prove presence
+/// in the band (non-finite agents are IGNORED for band membership), which errs
+/// toward latching — never let NaN satisfy the band.
+// SAFETY: SG6 | REQ: vanished-object-derivation | TEST: test_vanished_close_then_empty_small_band,test_not_vanished_departed_within_band,test_vanished_short_gap_not_long_gap,test_never_close_never_vanishes,test_empty_vec_is_gap_not_departure,test_nan_gap_current_no_band_prior_no_obligation,test_band_boundary_inclusive,test_refresh_close_across_ticks
+#[derive(Debug, Clone, Default)]
+pub struct VanishedObjectDetector {
+    pending: Option<PendingClose>,
+}
+
+impl VanishedObjectDetector {
+    pub fn new() -> Self {
+        Self { pending: None }
+    }
+
+    /// The `vanished_object` flag for THIS tick. The caller feeds it into
+    /// [`ImpactEvidence`] BEFORE the latch / [`ClearanceLoop`] observes — the
+    /// same caller-supplies-`now_ms` convention as `ClearanceLoop`.
+    pub fn observe(&mut self, scene: &AgentScene, now_ms: u64, cfg: &VanishedCfg) -> bool {
+        // VALID frame? Absent / empty-vec are GAPS: the obligation persists, the
+        // band keeps growing, and no vanish verdict is computed (perception is
+        // not asserting anything this tick).
+        let agents: &[crate::rss::RssAgent] = match scene {
+            AgentScene::KnownEmpty => &[],
+            AgentScene::Agents(v) if !v.is_empty() => v.as_slice(),
+            _ => return false, // Absent OR Agents(vec![]) — gap
+        };
+
+        // A finite gap within the close radius makes an agent a "close agent".
+        // NaN never qualifies (errs toward latching).
+        let close_present = agents
+            .iter()
+            .any(|a| a.actual_longitudinal_gap_m.is_finite() && a.actual_longitudinal_gap_m <= cfg.r_close_m);
+
+        let pending = match self.pending {
+            None => {
+                // No prior obligation → nothing could have vanished. Open one iff
+                // a close agent is present now.
+                if close_present {
+                    self.pending = Some(PendingClose { first_seen_ms: now_ms, last_valid_frame_ms: now_ms });
+                }
+                return false;
+            }
+            Some(p) => p,
+        };
+
+        // Reachable band from the last valid (refreshing) frame. saturating_sub
+        // guards a non-monotonic clock (Δt floored at 0).
+        let dt_s = now_ms.saturating_sub(pending.last_valid_frame_ms) as f64 / 1000.0;
+        let r_band = cfg.r_close_m + cfg.v_agent_max_mps * dt_s + cfg.slack_m;
+
+        // Any agent within the band? Inclusive (`<=`): an agent OBSERVED exactly
+        // at the band edge counts as PRESENT — ties go to "still tracked". The
+        // fail-closed latch direction is preserved because what latches is the
+        // ABSENCE of any agent within the band, not a boundary tie. NaN ignored.
+        let within_band = agents
+            .iter()
+            .any(|a| a.actual_longitudinal_gap_m.is_finite() && a.actual_longitudinal_gap_m <= r_band);
+
+        if within_band {
+            if close_present {
+                // Still close → refresh the obligation (reset the band origin).
+                self.pending = Some(PendingClose {
+                    first_seen_ms: pending.first_seen_ms,
+                    last_valid_frame_ms: now_ms,
+                });
+            } else {
+                // Within band but no longer within r_close → departed trackably.
+                self.pending = None;
+            }
+            return false;
+        }
+
+        // No agent within the band. Whether absence proves a VANISH depends on
+        // the PLAUSIBILITY HORIZON (a decided interpretation of the spec's "band
+        // grown past plausibility", derived from the three cfg params — no fourth
+        // knob): absence is conclusive ONLY while the band's GROWTH term
+        // `v_agent_max_mps · Δt` has not exceeded one close radius. Within that
+        // window a present-but-departing agent would still be in the near-field
+        // and detectable, so "nothing here" means it vanished (under-vehicle).
+        // Once growth exceeds `r_close_m` (a long gap ⇒ a huge band), a
+        // legitimately-departing agent could be beyond the near-field / out of
+        // range, so absence is UNINFORMATIVE — release the obligation, no latch.
+        let growth_m = cfg.v_agent_max_mps * dt_s;
+        self.pending = None;
+        growth_m <= cfg.r_close_m
+    }
+
+    /// Whether a close-agent obligation is currently pending (diagnostic).
+    pub fn has_pending(&self) -> bool {
+        self.pending.is_some()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -562,5 +741,135 @@ mod tests {
         let mut l = escalated();
         assert_eq!(l.try_clear(&future, now, MAX_AGE), Err(ClearanceRejection::MalformedGrant));
         assert!(l.is_immobilized());
+    }
+
+    // ───────────────────── #102 vanished-object derivation ──────────────────
+
+    use crate::rss::RssAgent;
+
+    fn vcfg() -> VanishedCfg {
+        VanishedCfg::default() // r_close=2.0, v_max=3.0, slack=0.5
+    }
+    /// An agent at the given longitudinal gap (other RSS fields irrelevant here).
+    fn agent(gap_m: f64) -> RssAgent {
+        RssAgent {
+            ego_vel: 0.0,
+            lead_vel: 0.0,
+            actual_longitudinal_gap_m: gap_m,
+            ego_lat_vel: 0.0,
+            obj_lat_vel: 0.0,
+            actual_lateral_separation_m: 100.0,
+        }
+    }
+    fn agents(gaps: &[f64]) -> AgentScene {
+        AgentScene::Agents(gaps.iter().map(|&g| agent(g)).collect())
+    }
+
+    /// Close agent, then a small-band KnownEmpty next tick → vanished.
+    #[test]
+    fn test_vanished_close_then_empty_small_band() {
+        let mut d = VanishedObjectDetector::new();
+        assert!(!d.observe(&agents(&[1.0]), 0, &vcfg())); // close → obligation, no verdict
+        assert!(d.has_pending());
+        // dt=0.1s → band=2.0+0.3+0.5=2.8; growth=0.3 <= r_close=2.0 → conclusive.
+        assert!(d.observe(&AgentScene::KnownEmpty, 100, &vcfg()), "small-band KnownEmpty must vanish");
+        assert!(!d.has_pending(), "obligation consumed by the vanish");
+    }
+
+    /// Close agent, then an agent within the band but beyond r_close → departed
+    /// trackably (NOT vanished); the obligation is released once nothing is within
+    /// r_close.
+    #[test]
+    fn test_not_vanished_departed_within_band() {
+        let mut d = VanishedObjectDetector::new();
+        assert!(!d.observe(&agents(&[1.0]), 0, &vcfg()));
+        // dt=0.1s → band=2.8; agent at 2.0+ε (within band, beyond r_close).
+        assert!(!d.observe(&agents(&[2.0 + 1e-6]), 100, &vcfg()), "departed-within-band must not vanish");
+        assert!(!d.has_pending(), "obligation released — departed trackably");
+    }
+
+    /// Absent gap then KnownEmpty: a SHORT gap vanishes; a LONG gap (band grown
+    /// past the plausibility horizon) does not. Both band values hand-checked.
+    #[test]
+    fn test_vanished_short_gap_not_long_gap() {
+        // SHORT: close@0, Absent@50 (gap, persists), KnownEmpty@200.
+        let mut d = VanishedObjectDetector::new();
+        assert!(!d.observe(&agents(&[1.0]), 0, &vcfg()));
+        assert!(!d.observe(&AgentScene::Absent, 50, &vcfg()), "gap tick yields no verdict");
+        assert!(d.has_pending(), "obligation persists across the gap");
+        // dt from last_valid(0) = 0.2s → growth=0.6 <= 2.0 → conclusive; band=3.1.
+        assert!(d.observe(&AgentScene::KnownEmpty, 200, &vcfg()), "short gap then empty → vanish");
+
+        // LONG: close@0, Absent@5000 (gap), KnownEmpty@10000.
+        let mut d = VanishedObjectDetector::new();
+        assert!(!d.observe(&agents(&[1.0]), 0, &vcfg()));
+        assert!(!d.observe(&AgentScene::Absent, 5_000, &vcfg()));
+        // dt=10s → growth=30.0 > r_close=2.0 → past plausibility; band=32.5.
+        assert!(!d.observe(&AgentScene::KnownEmpty, 10_000, &vcfg()), "long gap → not vanished");
+        assert!(!d.has_pending());
+    }
+
+    /// An agent never within r_close → never an obligation → never vanishes.
+    #[test]
+    fn test_never_close_never_vanishes() {
+        let mut d = VanishedObjectDetector::new();
+        for t in (0..500).step_by(100) {
+            assert!(!d.observe(&agents(&[5.0]), t, &vcfg()), "far agent never vanishes");
+            assert!(!d.observe(&AgentScene::KnownEmpty, t + 50, &vcfg()), "no obligation → no vanish");
+            assert!(!d.has_pending());
+        }
+    }
+
+    /// `Agents(vec![])` is a GAP (ambiguous), not departure evidence: it yields no
+    /// verdict and does NOT release a pending obligation.
+    #[test]
+    fn test_empty_vec_is_gap_not_departure() {
+        let mut d = VanishedObjectDetector::new();
+        assert!(!d.observe(&agents(&[1.0]), 0, &vcfg())); // obligation
+        assert!(!d.observe(&AgentScene::Agents(vec![]), 100, &vcfg()), "empty-vec is a gap → no verdict");
+        assert!(d.has_pending(), "empty-vec must not release the obligation");
+        // The obligation survives to vanish on the next valid (small-band) frame.
+        assert!(d.observe(&AgentScene::KnownEmpty, 200, &vcfg()));
+    }
+
+    /// NaN gap in the current frame does not satisfy the band (so a NaN-only frame
+    /// vanishes — the immobilize-safe direction); a NaN gap in the prior frame
+    /// does not create an obligation.
+    #[test]
+    fn test_nan_gap_current_no_band_prior_no_obligation() {
+        // Current-frame NaN ignored for band membership → vanish.
+        let mut d = VanishedObjectDetector::new();
+        assert!(!d.observe(&agents(&[1.0]), 0, &vcfg()));
+        // dt=0.1 small band; the only agent has a NaN gap → not within band → vanish.
+        assert!(d.observe(&agents(&[f64::NAN]), 100, &vcfg()), "NaN agent cannot satisfy the band");
+
+        // Prior-frame NaN does not create an obligation.
+        let mut d = VanishedObjectDetector::new();
+        assert!(!d.observe(&agents(&[f64::NAN]), 0, &vcfg()), "NaN gap is not a close agent");
+        assert!(!d.has_pending(), "no obligation from a NaN-only frame");
+        assert!(!d.observe(&AgentScene::KnownEmpty, 100, &vcfg()), "no obligation → no vanish");
+    }
+
+    /// Band boundary is INCLUSIVE: an agent observed exactly at R_band counts as
+    /// present (ties → still tracked) → not vanished.
+    #[test]
+    fn test_band_boundary_inclusive() {
+        let mut d = VanishedObjectDetector::new();
+        assert!(!d.observe(&agents(&[1.0]), 0, &vcfg()));
+        // dt=0.1s → R_band = 2.0 + 3.0*0.1 + 0.5 = 2.8 exactly.
+        let r_band = 2.0 + 3.0 * 0.1 + 0.5;
+        assert!(!d.observe(&agents(&[r_band]), 100, &vcfg()), "agent exactly at R_band is present (inclusive)");
+        assert!(!d.has_pending(), "released — within band, beyond r_close");
+    }
+
+    /// An agent staying within r_close across many ticks refreshes the obligation
+    /// and never latches.
+    #[test]
+    fn test_refresh_close_across_ticks() {
+        let mut d = VanishedObjectDetector::new();
+        for t in (0..1_000).step_by(100) {
+            assert!(!d.observe(&agents(&[1.0]), t, &vcfg()), "still-close never vanishes");
+            assert!(d.has_pending(), "obligation refreshed while close");
+        }
     }
 }

--- a/parko/crates/parko-core/src/impact.rs
+++ b/parko/crates/parko-core/src/impact.rs
@@ -385,6 +385,17 @@ struct PendingClose {
 /// could be beyond the near-field, so absence is UNINFORMATIVE → release, no
 /// latch. The obligation is consumed either way.
 ///
+/// RESIDUAL (explicit). After the horizon, *departed* and *under-vehicle* are
+/// perceptually INDISTINGUISHABLE — both present as an empty scene. This detector
+/// chooses NOT-latch there; the alternative would latch on every close-encounter
+/// followed by a perception outage. Compensating controls bound the residual:
+/// (1) motion was vetoed THROUGHOUT the gap (the existing `AgentScene::Absent →
+/// UNSAFE` evaluation), so the vehicle did not move while the scene was unknown;
+/// and (2) resumption from an extended gap goes through the existing
+/// recovery-confirm discipline, not a bare resume. This detector covers the
+/// ≤ 1-cycle SG6 window (an object that vanishes BETWEEN adjacent frames), not
+/// long-gap epistemics.
+///
 /// NUISANCE TRADE (decided, per SG6's err direction): a close encounter + a brief
 /// sensor blip + an agent that genuinely walked away fast CAN latch → operator
 /// clearance. That is the stated direction: immobilize when a person MIGHT be

--- a/parko/crates/parko-core/src/lib.rs
+++ b/parko/crates/parko-core/src/lib.rs
@@ -67,7 +67,8 @@ pub use commit_zone::{
 };
 pub use impact::{
     is_impact, ClearanceLoop, ClearanceRejection, ClearanceState, ImpactCfg, ImpactEvidence,
-    ImpactLatch, OperatorClearanceGrant, DEFAULT_MAX_GRANT_AGE_MS,
+    ImpactLatch, OperatorClearanceGrant, VanishedCfg, VanishedObjectDetector,
+    DEFAULT_MAX_GRANT_AGE_MS,
 };
 pub use localization::{
     gate_commit_zone_scene, gate_water_scene, localization_trusted, LocalizationCfg,

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -50,8 +50,8 @@ use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
 use parko_core::{
     commit_zone_blocked, gate_commit_zone_scene, gate_water_scene, localization_trusted,
     water_untraversable_veto, AgentScene, ClearanceLoop, CommitZoneCfg, CommitZoneScene,
-    ImpactLatch, LocalizationCfg, LocalizationIntegrity, OcclusionScene, RssParams, RssState,
-    WaterScene, WaterVetoConfig, MAX_RSS_AGENTS,
+    ImpactEvidence, ImpactLatch, LocalizationCfg, LocalizationIntegrity, OcclusionScene, RssParams,
+    RssState, VanishedCfg, VanishedObjectDetector, WaterScene, WaterVetoConfig, MAX_RSS_AGENTS,
 };
 
 pub mod angular_bound;
@@ -862,6 +862,31 @@ impl KirraGovernor {
     }
 }
 
+/// SG6 — derive `vanished_object` from the agent scene and fold it into this
+/// tick's [`ImpactEvidence`], BEFORE the existing [`ImpactLatch`] /
+/// [`ClearanceLoop`] consumes it (#102 follow-up). Thin by design: it only runs
+/// the [`VanishedObjectDetector`] and sets the flag — the latch, the clearance
+/// loop, and the `is_impact` fusion are UNCHANGED (they already handle the flag,
+/// which latches ALONE per SG6). `imu_accel_spike_mps2` and `contact_sensor` are
+/// the caller's other evidence for the tick; `now_ms` follows the same
+/// caller-supplied-clock convention as the detector and the clearance loop.
+#[allow(clippy::too_many_arguments)]
+pub fn impact_evidence_with_vanished(
+    detector: &mut VanishedObjectDetector,
+    scene: &AgentScene,
+    now_ms: u64,
+    vanished_cfg: &VanishedCfg,
+    imu_accel_spike_mps2: f64,
+    contact_sensor: bool,
+) -> ImpactEvidence {
+    let vanished_object = detector.observe(scene, now_ms, vanished_cfg);
+    ImpactEvidence {
+        imu_accel_spike_mps2,
+        contact_sensor,
+        vanished_object,
+    }
+}
+
 impl SafetyGovernor for KirraGovernor {
     fn evaluate(
         &self,
@@ -1492,15 +1517,15 @@ mod tests {
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 mod scene_rss_tests {
-    use super::{compute_occlusion_cap, compute_scene_rss, KirraGovernor};
+    use super::{compute_occlusion_cap, compute_scene_rss, impact_evidence_with_vanished, KirraGovernor};
     use parko_core::commands::ControlCommand;
     use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
     use parko_core::{
         non_yielding_clearance, AgentScene, ClearanceLoop, ClearanceState, CommitZoneCfg,
         CommitZoneMap, CommitZoneScene, ImpactCfg, ImpactEvidence, ImpactLatch, LocalizationCfg,
         LocalizationIntegrity, NonYieldingAgent, NonYieldingScene, OcclusionScene,
-        OperatorClearanceGrant, RssAgent, RssParams, RssState, TraversalEvidence, WaterScene,
-        WaterVetoConfig, MAX_RSS_AGENTS,
+        OperatorClearanceGrant, RssAgent, RssParams, RssState, TraversalEvidence, VanishedCfg,
+        VanishedObjectDetector, WaterScene, WaterVetoConfig, MAX_RSS_AGENTS,
     };
 
     fn params() -> RssParams {
@@ -1919,6 +1944,41 @@ mod scene_rss_tests {
         l.try_clear(&grant, now, 60_000).expect("well-formed grant clears");
         let resumed = gov.evaluate_with_clearance_loop(&cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal, &l);
         assert!(matches!(resumed, EnforcementAction::Allow), "after the grant, motion resumes, got {resumed:?}");
+    }
+
+    /// SG6 end-to-end (#102 follow-up): a close agent, then a next valid frame
+    /// empty within the band → DERIVED `vanished_object` → the impact latch fires
+    /// ALONE (no IMU spike, no contact) → the motion veto immobilizes.
+    #[test]
+    fn vanished_object_derivation_latches_alone_and_vetoes() {
+        let gov = KirraGovernor::new();
+        let mut detector = VanishedObjectDetector::new();
+        let vcfg = VanishedCfg::default();
+        let mut latch = ImpactLatch::new();
+
+        let close = AgentScene::Agents(vec![RssAgent {
+            ego_vel: 0.0, lead_vel: 0.0, actual_longitudinal_gap_m: 1.0,
+            ego_lat_vel: 0.0, obj_lat_vel: 0.0, actual_lateral_separation_m: 100.0,
+        }]);
+
+        // Tick 1 — close agent: derives vanished=false (obligation opens), no latch.
+        let ev1 = impact_evidence_with_vanished(&mut detector, &close, 0, &vcfg, 0.0, false);
+        assert!(!ev1.vanished_object);
+        latch.observe(&ev1, &ImpactCfg::default());
+        assert!(!latch.is_latched());
+
+        // Tick 2 — KnownEmpty within the band: derives vanished=true with NO IMU
+        // spike and NO contact → the latch fires on the vanished flag ALONE.
+        let ev2 = impact_evidence_with_vanished(&mut detector, &AgentScene::KnownEmpty, 100, &vcfg, 0.0, false);
+        assert!(ev2.vanished_object, "small-band empty after a close agent must derive vanished");
+        assert!(!ev2.contact_sensor && ev2.imu_accel_spike_mps2 == 0.0, "latches on vanished ALONE");
+        latch.observe(&ev2, &ImpactCfg::default());
+        assert!(latch.is_latched(), "vanished_object latches alone per SG6");
+
+        // The motion veto immobilizes a pushed-safe command.
+        let action = gov.evaluate_with_impact_latch(&cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal, &latch);
+        assert!(matches!(action, EnforcementAction::Deny { .. }),
+            "a derived vanished-object latch must immobilize, got {action:?}");
     }
 
     // --- SG5 commit-zone veto (issue #106) ---


### PR DESCRIPTION
## Derive `vanished_object` from the AgentScene frame diff — SG6 (#102 follow-up)

Converts the impact latch's **strongest trigger** — the person-under-vehicle `vanished_object` flag, which **latches ALONE** per SG6 — from a **supplied** boolean to a **derived** one. parko-only; the latch / `ClearanceLoop` / `is_impact` fusion are **unchanged** (they already handle the flag).

### Set-level semantics (forced by grounding)
`RssAgent` has **no identity field**, so this is **set-level with a kinematic-reachability band**, not per-agent tracking. `VanishedObjectDetector` (parko-core, alongside `ImpactLatch`) keeps a single pending close-agent obligation and decides per valid frame.

- **`VanishedCfg`** `{ r_close_m=2.0, v_agent_max_mps=3.0, slack_m=0.5 }` — all **VALIDATION-PENDING**; `v_agent_max` cites the occlusion `v_emerge_max` worst-case-agent philosophy.
- **Valid vs gap:** a valid frame is `KnownEmpty` or `Agents(non-empty)`; `Absent` and `Agents(vec[])` are **GAPS** (empty-vec is ambiguous — never departure evidence). The obligation is **sticky-toward-safe**: it persists across gaps and the band keeps growing, so the verdict is decided at the gap's *end* (the existing `Absent → UNSAFE` veto holds the vehicle during the gap).
- **Band** `R_band = r_close + v_agent_max·Δt + slack`. Any agent within band → **refresh** (still close) or **release** (departed trackably). No agent within band → the **plausibility horizon** decides.

### The plausibility horizon (a decided interpretation — flagged)
The spec's literal "no agent in band ⇒ vanish" would latch on *any* `KnownEmpty`, which contradicts its own "long gap → not vanished" test. The grounded resolution, **derived from the three cfg params (no fourth knob)**: absence is conclusive evidence of a vanish **only while the band's growth `v_agent_max·Δt ≤ r_close`** (the departing agent would still be near-field and detectable). A long gap grows the band past that → absence is uninformative → release, no latch. Both hand-checked band values are in the tests.

- Band membership is **inclusive** (ties → still tracked).
- **NaN discipline:** non-finite gaps are ignored for band membership (errs toward latching — the immobilize-safe direction) and never create an obligation.
- **Nuisance trade (per SG6's err direction):** a close encounter + a brief sensor blip + an agent that genuinely walked away fast *can* latch → operator clearance. Documented as intended.

### parko-kirra
A thin `impact_evidence_with_vanished()` helper runs the detector and populates `ImpactEvidence.vanished_object` before the latch/loop consumes it — fusion untouched. **End-to-end test:** close agent → empty-within-band → derived vanished → latch fires *alone* (no IMU, no contact) → `evaluate_with_impact_latch` immobilizes.

### Tests
small-band empty → vanished; departed-within-band → not (released); short gap → vanished / long gap → not (both bands hand-checked); never-close → never; empty-vec is a gap not departure; NaN current-frame doesn't satisfy band & NaN prior-frame no obligation; band boundary inclusive; refresh across many close ticks (no latch). `cargo test -p parko-core -p parko-kirra` green (parko-core 171, parko-kirra 136 — all #102/#103/#263 suites intact); clippy clean.

### Scope / safety
parko-core + parko-kirra only (3 files). `r_close` / `v_agent_max` VALIDATION-PENDING. Talisman `997fb7ae…` byte-identical.

References #102, #103. Converts the latch's strongest trigger from supplied to derived.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_