### PR TITLE
feat(tools): trace RTM harness rows to real SG/TR identifiers (#272)

### DIFF
--- a/tools/qnx-rtm-harness/QNX_MAPPING.md
+++ b/tools/qnx-rtm-harness/QNX_MAPPING.md
@@ -87,7 +87,14 @@ TR covers the transport-contract instantiation** the harness exercises.
 
 - **SG-07 replay → `NO-RTM-ID`.** Replay (`sequence == last_accepted`) is the equal
   case of the same SG-014 anti-replay principle as SG-02; same finding — federation
-  TR-014 is not the message bus. Candidate new TR alongside SG-02.
+  TR-014 is not the message bus. The nearest *existing command-path* replay
+  requirement is **TR-016b** (REQUIREMENTS_TRACEABILITY.md:179 — the DDS bridge
+  shall hold no sequence/history cache that would let stale commands replay to
+  reconnecting subscribers). SG-07 still does not trace to it: TR-016b verifies the
+  **absence** of a replay-enabling cache in the bridge (code inspection), whereas
+  SG-07 verifies **active rejection** of a replayed frame at the judge — they are
+  **complementary barriers** (don't-cache vs do-reject), and neither substitutes for
+  the other. Candidate new TR (alongside SG-02) remains needed.
 
 ---
 

--- a/tools/qnx-rtm-harness/QNX_MAPPING.md
+++ b/tools/qnx-rtm-harness/QNX_MAPPING.md
@@ -1,29 +1,145 @@
-# QNX_MAPPING — RTM-ID mapping & QNX cross-compile notes (#271 → #272 / #274)
+# QNX_MAPPING — RTM tracing & QNX cross-compile notes (#271 → #272 / #274)
 
-## 1. SG-row → real RTM ID — PLACEHOLDER (tracked by #272)
+This document **grounds** each harness fault row against the kernel's real safety
+artifacts — `docs/safety/SAFETY_GOALS.md` (AEGIS-SG-001, the `SG-001…SG-016`
+definitions) and `docs/safety/REQUIREMENTS_TRACEABILITY.md` (AEGIS-RTM-001, the
+`TR-NNN` rows). Those docs are read as **ground truth and are NOT modified** by
+this change (#272 touches only `tools/qnx-rtm-harness/**`).
 
-The harness rows are labelled `SG-00 … SG-07`. **These are PLACEHOLDER IDs.**
-Mapping them to the kernel's real Requirements Traceability IDs
-(`docs/safety/REQUIREMENTS_TRACEABILITY.md`, the `SG-001 … SG-016` namespace) and
-emitting the CSV in the column order `docs/safety/RTM_GAP_REPORT.md` expects is
-the dedicated follow-up **issue #272** — not done here.
+> **The local `SG-0N` is the HARNESS ROW INDEX, not a kernel RTM id.** The
+> `rtm_id`/`tr_id` columns are the bridge. The mapping is honest: only **one** row
+> has a genuine kernel TR home; **six** are real coverage gaps; one is a control.
+> A shoehorned mapping would be worse than a named gap — the gap IS the evidence
+> (it is exactly what `RTM_GAP_REPORT.md` exists to capture).
 
-| Harness row | Injects | Verdict | Real RTM ID |
+---
+
+## 1. The grounded mapping table
+
+| Harness row | Injects | Verdict | `rtm_id` | `tr_id` | Disposition |
+|---|---|---|---|---|---|
+| SG-00 | valid command (no fault) | `Ok` | `CONTROL` | `NONE` | clean-accept control |
+| SG-01 | bad header magic | `StaleHeader` | `NO-RTM-ID` | `CANDIDATE` | **gap** |
+| SG-02 | sequence strictly-lower | `SequenceRegress` | `NO-RTM-ID` | `CANDIDATE` | **gap** |
+| SG-03 | deadline elapsed | `DeadlineMissed` | `NO-RTM-ID` | `CANDIDATE` | **gap** |
+| SG-04 | payload CRC mismatch | `PayloadCorrupt` | `NO-RTM-ID` | `CANDIDATE` | **gap** |
+| SG-05 | payload oversize (bounds) | `PayloadOversize` | `NO-RTM-ID` | `CANDIDATE` | **gap** |
+| SG-06 | over-envelope velocity | `KinematicLimit` | `SG-001` | `TR-001` | **genuine hit (proxy)** |
+| SG-07 | replay (`seq == last`) | `SequenceRegress` | `NO-RTM-ID` | `CANDIDATE` | **gap** |
+
+---
+
+## 2. Per-row justification (one line each, citing the SG/TR text)
+
+- **SG-00 valid → `CONTROL`.** No fault is injected; this is the negative control
+  that proves the accept path. It exercises the *accept side* of SG-001's velocity
+  envelope (an in-envelope command must pass) but evidences no fault-detection TR,
+  so it carries `CONTROL`/`NONE` rather than a forced mapping.
+
+- **SG-06 over-envelope → `SG-001 / TR-001` (the only genuine hit).** SG-001
+  ("Velocity Envelope Enforcement") requires that no command with
+  `linear_velocity.abs() > max_speed` reach an actuator; TR-001 is the
+  `validate_vehicle_command` magnitude check. The judge's
+  `|commanded_velocity| > PROXY_MAX_COMMANDED_VELOCITY` rejection is the **same
+  safety property**. **Qualified as proxy:** the bound is the harness PROXY
+  (`22_350` mm/s), *not* the certified `VehicleKinematicsContract`, and the judge
+  **rejects** (`KinematicLimit`) where TR-001 specifies **clamp** (`ClampLinear`).
+  So this is *proxy/partial* evidence for SG-001 — it does **not** discharge or
+  substitute for TR-001's certified `test_speed_above_ceiling_triggers_clamp_linear`.
+
+The six **`NO-RTM-ID`** rows below are honest gaps: each names the **principle
+precedent** SG (the safety principle that already exists in the kernel for a
+*different* artifact) under which a candidate new TR would live, but **no current
+TR covers the transport-contract instantiation** the harness exercises.
+
+- **SG-01 bad-magic → `NO-RTM-ID`.** Rejecting a frame whose header magic/version
+  is invalid is a transport-framing validity property. **No kernel SG covers frame
+  header validity** (verified: `grep` for magic/frame-header in the SG/RTM docs
+  returns nothing). Candidate new TR under a *new* EPIC-#270 transport-contract
+  safety goal.
+
+- **SG-02 sequence-regress → `NO-RTM-ID`.** Anti-rollback on a per-message
+  monotonic counter. The *principle* exists as **SG-014** ("Federation Report
+  Replay Prevention": reject `generation <= last accepted`), but TR-014 is
+  `reconcile_reports` on `FederatedTrustReportV2` — federation reports, **not** the
+  message bus. Candidate new TR extending the SG-014 anti-rollback principle to the
+  transport contract.
+
+- **SG-03 deadline-missed → `NO-RTM-ID`.** Per-message freshness/deadline. The
+  *principle* is the staleness-fail-closed family — **SG-003** (sensor timeout) and
+  **SG-005** (posture-cache staleness: "never evaluate a command against a stale
+  cache"). But TR-003 is the telemetry watchdog and TR-005 is the posture-cache
+  TTL; **neither is a per-message frame deadline**. Candidate new TR under the
+  SG-003/SG-005 staleness family.
+
+- **SG-04 payload-corrupt → `NO-RTM-ID`.** Payload integrity via CRC. The
+  *principle* is integrity/tamper detection — **SG-010** ("Audit Chain Tamper
+  Detection", SHA-256 `prev_hash`). But TR-010 is the *audit-log chain*, a
+  different artifact from an in-transit message payload. Candidate new TR under the
+  SG-010 integrity principle for message-payload integrity.
+
+- **SG-05 payload-oversize → `NO-RTM-ID`.** Bounds rejection at the FFI boundary —
+  a memory-safety/robustness property of the shim (it short-circuits and never
+  crosses into the judge). The evidence home for FFI-boundary isolation is
+  `docs/safety/OCCY_FFI_EVIDENCE.md` (Freedom-From-Interference, communication
+  isolation) and `OCCY_DFA.md`, **not a kernel SG/TR**. Candidate new TR under an
+  FFI-robustness / freedom-from-interference goal.
+
+- **SG-07 replay → `NO-RTM-ID`.** Replay (`sequence == last_accepted`) is the equal
+  case of the same SG-014 anti-replay principle as SG-02; same finding — federation
+  TR-014 is not the message bus. Candidate new TR alongside SG-02.
+
+---
+
+## 3. Coverage gaps surfaced (the held line)
+
+The harness traces **8 transport-contract fault classes**; against the **current**
+kernel RTM, exactly **one** (over-envelope → SG-001/TR-001, proxy) has a real TR
+home. The other **six** are genuine **`NO-RTM-ID`** gaps:
+
+| Gap | Fault class | Principle precedent | Candidate new TR home |
 |---|---|---|---|
-| SG-00 | valid command | `Ok` | _TBD (#272)_ |
-| SG-01 | bad magic | `StaleHeader` | _TBD (#272)_ |
-| SG-02 | sequence regress (strictly lower) | `SequenceRegress` | _TBD (#272)_ |
-| SG-03 | deadline missed | `DeadlineMissed` | _TBD (#272)_ |
-| SG-04 | corrupt payload (CRC) | `PayloadCorrupt` | _TBD (#272)_ |
-| SG-05 | oversize payload | `PayloadOversize` (shim short-circuit) | _TBD (#272)_ |
-| SG-06 | over-envelope command | `KinematicLimit` | _TBD (#272)_ |
-| SG-07 | replay (sequence == last_accepted) | `SequenceRegress` | _TBD (#272)_ |
+| 1 | frame header validity (bad magic) | — (none) | new transport-contract SG (EPIC #270) |
+| 2 | message sequence monotonicity | SG-014 (federation anti-rollback) | transport anti-rollback TR |
+| 3 | message deadline freshness | SG-003 / SG-005 (staleness family) | per-message deadline TR |
+| 4 | message payload integrity (CRC) | SG-010 (audit-chain integrity) | payload-integrity TR |
+| 5 | FFI payload bounds (oversize) | OCCY_FFI_EVIDENCE / OCCY_DFA (FFI) | FFI-robustness TR |
+| 6 | message replay (`seq == last`) | SG-014 (federation replay) | transport replay TR |
 
-The harness already emits a machine-readable CSV (`id,fault_class,result,
-expected_verdict,observed_verdict,p50_ns,p99_ns,max_ns`); #272 remaps `id` to the
-real RTM IDs and reorders to the gap-report's expected columns.
+This is the finding, not a defect of the harness: the EPIC #270 iceoryx2/QNX
+**transport-contract** surface (framing, ordering, freshness, integrity, bounds)
+is **not yet represented in the kernel RTM**, which was authored for the HTTP
+verifier + governor + protocol adapters. Surfacing these six gaps is the point.
 
-## 2. The concern split (recap)
+> **Adding these candidate TRs to the RTM itself is a follow-up `docs/safety/**`
+> change requiring its own safety review — it is explicitly NOT part of this PR.**
+> #272 only traces the harness to the RTM as it stands today; it does not modify
+> the RTM or the gap report.
+
+---
+
+## 4. CSV format — PROPOSED (no per-test table in the gap report to match)
+
+`docs/safety/RTM_GAP_REPORT.md` has **no per-test CSV evidence table** to conform
+to — its tables are markdown (`goal | ASIL | description | tests`) with **no timing
+columns**. Per #272's instruction, the harness therefore emits a **proposed**
+format (and labels it "proposed" in the output):
+
+```
+harness_row,rtm_id,tr_id,fault_class,verdict_expected,verdict_observed,pass,p50_ns,p99_ns,max_ns,wcet_status
+```
+
+- `harness_row` — the **local** index (`SG-0N`), never presented as an RTM id.
+- `rtm_id` / `tr_id` — the kernel-RTM bridge (`SG-001`/`TR-001`, or
+  `NO-RTM-ID`/`CANDIDATE`, or `CONTROL`/`NONE`).
+- `wcet_status` — constant **`TBD-QNX-TARGET`**: host timing is never WCET (§6).
+
+If a per-test CSV schema is later defined in the gap report, the column order here
+should be re-aligned to it (a one-line `printf` change).
+
+---
+
+## 5. The concern split (recap)
 
 - **C++ shim = driver** — memory/transport safety: double-read tear detection,
   bounds (oversize short-circuits, never crosses the FFI), CRC over the payload.
@@ -31,9 +147,12 @@ real RTM IDs and reorders to the gap-report's expected columns.
   integrity → kinematic) on the shim's stabilized snapshot.
 
 This is **ADR-0006 Clause 3**'s documented C/C++ integration boundary — no longer
-the governor hot path.
+the governor hot path. (The mapping in §1 reflects it: the two shim-side rows
+SG-04/SG-05 never reach the judge — visible as the fast p50 on SG-05.)
 
-## 3. QNX cross-compile (real work = #274)
+---
+
+## 6. QNX cross-compile (real work = #274)
 
 The host build uses native `g++` + `rustc`. For a QNX 8.0 target:
 
@@ -42,18 +161,15 @@ The host build uses native `g++` + `rustc`. For a QNX 8.0 target:
   freestanding-friendly build.
 - **Rust judge**: build the `no_std` staticlib for the QNX target tuple, e.g.
   `--target x86_64-pc-nto-qnx8_0_0` or `aarch64-unknown-nto-qnx8_0_0`, keeping
-  `-C panic=abort`. The judge is already `no_std` + zero-alloc + integer-only, so
-  it carries no std/edition-2024 transitive surface of its own (contrast the
-  iceoryx2 dependency tree — see EPIC #270 / #274).
+  `-C panic=abort`. The judge is already `no_std` + zero-alloc + integer-only.
 - **FDIT/WCET**: re-run the harness on the target under **FIFO scheduling** and
   replace the indicative host p50/p99/max with **target-measured** percentiles —
   the numbers that actually back the FTTI claim. This is **#274**.
 
-See `docs/adr/KIRRA_QNX_CROSSCOMPILE.md` for the existing cross-compile recipe
-context.
+See `docs/adr/KIRRA_QNX_CROSSCOMPILE.md` for the existing cross-compile recipe.
 
-## 4. WCET-TBD
+## 7. WCET-TBD
 
-Host timing in the harness output is **indicative only**. Certified WCET is
-**TBD on the QNX target (#274)**; the harness banner states this and the PASS gate
-is **verdict correctness**, never timing.
+Host timing in the harness output is **indicative only** (`wcet_status` is the
+constant `TBD-QNX-TARGET`). Certified WCET is **TBD on the QNX target (#274)**; the
+PASS gate is **verdict correctness**, never timing.

--- a/tools/qnx-rtm-harness/README.md
+++ b/tools/qnx-rtm-harness/README.md
@@ -3,7 +3,9 @@
 C++ **shim** (driver) → Rust **judge** (checker) over a frozen `extern "C"`
 contract ABI, with an automated **FDIT / RTM fault-injection** matrix that proves
 **verdict correctness** across eight fault classes. Part of **EPIC #270**
-(iceoryx2 transport / QNX governor lane). RTM-ID tracing is the follow-up **#272**.
+(iceoryx2 transport / QNX governor lane). Each row is **traced to the kernel RTM**
+(**#272** — see `QNX_MAPPING.md`): one genuine hit (SG-001/TR-001, proxy), six
+honest `NO-RTM-ID` transport-contract gaps, one control.
 
 > Built with **g++ + rustc directly (no cargo)**. The Rust judge is a `no_std`
 > `staticlib` — dependency-free, mirroring the QNX cross-compile shape.
@@ -44,22 +46,31 @@ built `--crate-type staticlib -C panic=abort` and linked into the C++ executable
 
 ## The fault matrix (gate = verdict correctness only)
 
-Eight rows, each named for **exactly** what it injects. Host run:
+Eight rows, each named for **exactly** what it injects, each carrying its grounded
+**RTM** mapping (the `row` column is the LOCAL harness index, **not** an RTM id —
+the `rtm` column is the bridge). Host run:
 
 ```
-id     fault class            ok     verdict             p50(ns)    p99(ns)    max(ns)
-----------------------------------------------------------------------------------
-SG-00  valid                  PASS   Ok                      501        520      20784
-SG-01  bad-magic              PASS   StaleHeader             500        517      22050
-SG-02  sequence-regress       PASS   SequenceRegress         503        529      34489
-SG-03  deadline-missed        PASS   DeadlineMissed          500        517      23915
-SG-04  payload-corrupt (CRC)  PASS   PayloadCorrupt          503        524      19721
-SG-05  payload-oversize       PASS   PayloadOversize          39         55      17133
-SG-06  over-envelope          PASS   KinematicLimit          504        525      17045
-SG-07  replay (seq==last)     PASS   SequenceRegress         500        519      29045
+row    fault class            rtm            ok     verdict             p50(ns)    p99(ns)    max(ns)
+-------------------------------------------------------------------------------------------------
+SG-00  valid                  CONTROL        PASS   Ok                      500        645      19318
+SG-01  bad-magic              NO-RTM-ID      PASS   StaleHeader             500        692     141615
+SG-02  sequence-regress       NO-RTM-ID      PASS   SequenceRegress         500        522      58236
+SG-03  deadline-missed        NO-RTM-ID      PASS   DeadlineMissed          501        524      23158
+SG-04  payload-corrupt (CRC)  NO-RTM-ID      PASS   PayloadCorrupt          499        647      64000
+SG-05  payload-oversize       NO-RTM-ID      PASS   PayloadOversize          38         61       4815
+SG-06  over-envelope          SG-001/TR-001  PASS   KinematicLimit          500        635      69192
+SG-07  replay (seq==last)     NO-RTM-ID      PASS   SequenceRegress         500        531      40385
 
 GATE (verdict correctness): PASS
 ```
+
+The RTM mapping is **grounded** in `docs/safety/{SAFETY_GOALS,REQUIREMENTS_TRACEABILITY}.md`
+(read-only). Only **over-envelope** has a genuine kernel TR home — **SG-001/TR-001**,
+qualified as PROXY (proxy bound, reject-not-clamp). The other six transport-contract
+fault classes are honest **`NO-RTM-ID`** gaps (candidate new TRs for the EPIC #270
+lane), and the valid row is the clean-accept **`CONTROL`**. Full per-row
+justification + the surfaced coverage gaps: **`QNX_MAPPING.md`**.
 
 - **SG-07 Replay** (`sequence == last_accepted`) is its **own row** and PASSes
   with `SequenceRegress`. The judge's rule is the corrected
@@ -99,5 +110,7 @@ imports it, and its number must never be read as a certified bound.
 ## QNX
 
 `CMakeLists.txt` notes the QNX cross-compile hook as a comment; the real
-cross-compile + on-target FDIT/WCET work is **#274**. The SG-0N → real-RTM-ID
-mapping is **#272** — see `QNX_MAPPING.md`.
+cross-compile + on-target FDIT/WCET work is **#274**. The harness→kernel-RTM
+tracing (**#272**, done) is in `QNX_MAPPING.md`; **adding the candidate `NO-RTM-ID`
+TRs to the RTM itself is a separate `docs/safety/**` change with its own review —
+not part of #272**, which only traces against the RTM as it stands.

--- a/tools/qnx-rtm-harness/rtm_harness.cpp
+++ b/tools/qnx-rtm-harness/rtm_harness.cpp
@@ -9,8 +9,16 @@
 // certified WCET. Certified WCET must be measured on the QNX target under FIFO
 // scheduling (#274). Host numbers are never presented as WCET.
 //
-// The SG-0N row IDs are PLACEHOLDERS; mapping them to the real kernel RTM IDs
-// (REQUIREMENTS_TRACEABILITY.md SG-001..SG-016) is issue #272.
+// RTM TRACING (#272, this change): the local `SG-0N` is the HARNESS ROW INDEX —
+// NOT a kernel RTM identifier. The `rtm_id`/`tr_id` fields are the bridge to the
+// real kernel RTM (docs/safety/REQUIREMENTS_TRACEABILITY.md, AEGIS-RTM-001). The
+// honest grounded result (per-row JUSTIFICATION in QNX_MAPPING.md): only the
+// over-envelope row has a genuine RTM home — SG-001/TR-001 (PROXY bound,
+// reject-not-clamp). The other six transport-contract fault classes (frame magic,
+// sequence monotonicity, message deadline, payload CRC, payload bounds, replay)
+// have NO matching kernel TR — they are honest NO-RTM-ID gaps, candidate new TRs
+// for the EPIC #270 transport-contract lane. The valid row is the clean-accept
+// CONTROL. The gaps ARE evidence (they feed the RTM gap report); never force-fit.
 
 #include <algorithm>
 #include <cstdint>
@@ -71,8 +79,15 @@ struct Baseline {
 
 // Mutator: takes the baseline view + payload + crc by value, injects a fault.
 struct Row {
-    const char *id;
-    const char *name;
+    const char *id;   // LOCAL harness row index (SG-0N) — NOT a kernel RTM id.
+    const char *name; // exactly what this row injects (honest fault name).
+    // RTM bridge (#272). `rtm_display` is the human column; `rtm_id`/`tr_id` are
+    // the CSV cells. A genuine hit carries SG-NNN/TR-NNN; an honest gap carries
+    // "NO-RTM-ID"/"CANDIDATE"; the no-fault control carries "CONTROL"/"NONE".
+    // See QNX_MAPPING.md for the per-row justification.
+    const char *rtm_display;
+    const char *rtm_id;
+    const char *tr_id;
     std::uint8_t expected;
     // Whether the Rust JUDGE is invoked. FALSE for the rows the SHIM driver
     // rejects on its own (oversize bounds AND CRC corruption) — they never cross
@@ -105,15 +120,19 @@ void inj_replay(KirraContractView &v, std::uint8_t *, std::uint32_t &) {
     v.sequence = 1000; // EQUAL to last_accepted ⇒ replay ⇒ SequenceRegress
 }
 
+// Verdicts + injection unchanged from #284; only the RTM-mapping cells are added.
+// Mapping is GROUNDED in REQUIREMENTS_TRACEABILITY.md / SAFETY_GOALS.md — only the
+// over-envelope row evidences a real kernel TR (SG-001/TR-001, proxy); the rest
+// are honest NO-RTM-ID transport-contract gaps (QNX_MAPPING.md justifies each).
 const Row kRows[] = {
-    {"SG-00", "valid",                  KIRRA_VERDICT_OK,               true,  inj_valid},
-    {"SG-01", "bad-magic",              KIRRA_VERDICT_STALE_HEADER,     true,  inj_bad_magic},
-    {"SG-02", "sequence-regress",       KIRRA_VERDICT_SEQUENCE_REGRESS, true,  inj_seq_regress},
-    {"SG-03", "deadline-missed",        KIRRA_VERDICT_DEADLINE_MISSED,  true,  inj_deadline},
-    {"SG-04", "payload-corrupt (CRC)",  KIRRA_VERDICT_PAYLOAD_CORRUPT,  false, inj_payload_corrupt},
-    {"SG-05", "payload-oversize",       KIRRA_VERDICT_PAYLOAD_OVERSIZE, false, inj_oversize},
-    {"SG-06", "over-envelope",          KIRRA_VERDICT_KINEMATIC_LIMIT,  true,  inj_kinematic},
-    {"SG-07", "replay (seq==last)",     KIRRA_VERDICT_SEQUENCE_REGRESS, true,  inj_replay},
+    {"SG-00", "valid",                 "CONTROL",       "CONTROL",   "NONE",      KIRRA_VERDICT_OK,               true,  inj_valid},
+    {"SG-01", "bad-magic",             "NO-RTM-ID",     "NO-RTM-ID", "CANDIDATE", KIRRA_VERDICT_STALE_HEADER,     true,  inj_bad_magic},
+    {"SG-02", "sequence-regress",      "NO-RTM-ID",     "NO-RTM-ID", "CANDIDATE", KIRRA_VERDICT_SEQUENCE_REGRESS, true,  inj_seq_regress},
+    {"SG-03", "deadline-missed",       "NO-RTM-ID",     "NO-RTM-ID", "CANDIDATE", KIRRA_VERDICT_DEADLINE_MISSED,  true,  inj_deadline},
+    {"SG-04", "payload-corrupt (CRC)", "NO-RTM-ID",     "NO-RTM-ID", "CANDIDATE", KIRRA_VERDICT_PAYLOAD_CORRUPT,  false, inj_payload_corrupt},
+    {"SG-05", "payload-oversize",      "NO-RTM-ID",     "NO-RTM-ID", "CANDIDATE", KIRRA_VERDICT_PAYLOAD_OVERSIZE, false, inj_oversize},
+    {"SG-06", "over-envelope",         "SG-001/TR-001", "SG-001",    "TR-001",    KIRRA_VERDICT_KINEMATIC_LIMIT,  true,  inj_kinematic},
+    {"SG-07", "replay (seq==last)",    "NO-RTM-ID",     "NO-RTM-ID", "CANDIDATE", KIRRA_VERDICT_SEQUENCE_REGRESS, true,  inj_replay},
 };
 
 struct RowResult {
@@ -169,8 +188,10 @@ void print_banner() {
     std::printf(" KIRRA QNX RTM harness (#271) — C++ shim (driver) -> Rust judge (checker)\n");
     std::printf(" PASS GATE = VERDICT CORRECTNESS ONLY.  Timing is INDICATIVE (host FDIT).\n");
     std::printf(" Certified WCET must be measured on the QNX target under FIFO scheduling\n");
-    std::printf(" (#274) — host numbers are NEVER presented as WCET.  SG-0N IDs are\n");
-    std::printf(" placeholders; real-RTM-ID mapping is #272.\n");
+    std::printf(" (#274) — host numbers are NEVER presented as WCET.  The RTM column maps\n");
+    std::printf(" each row to the kernel RTM (#272); SG-0N is the LOCAL row index, not an\n");
+    std::printf(" RTM id.  Only over-envelope hits a real TR (SG-001, proxy); the rest are\n");
+    std::printf(" honest NO-RTM-ID transport-contract gaps (see QNX_MAPPING.md).\n");
     std::printf("============================================================================\n");
 }
 
@@ -182,17 +203,18 @@ int main() {
     RowResult results[sizeof(kRows) / sizeof(kRows[0])];
     bool all_pass = true;
 
-    std::printf("\n%-6s %-22s %-6s %-16s %10s %10s %10s\n",
-                "id", "fault class", "ok", "verdict", "p50(ns)", "p99(ns)", "max(ns)");
-    std::printf("----------------------------------------------------------------------------------\n");
+    std::printf("\n%-6s %-22s %-14s %-6s %-16s %10s %10s %10s\n",
+                "row", "fault class", "rtm", "ok", "verdict", "p50(ns)", "p99(ns)", "max(ns)");
+    std::printf("-------------------------------------------------------------------------------------------------\n");
 
     for (std::size_t i = 0; i < sizeof(kRows) / sizeof(kRows[0]); ++i) {
         results[i] = run_row(kRows[i]);
         const RowResult &r = results[i];
         const bool row_ok = r.pass && r.short_circuit_ok;
         if (!row_ok) all_pass = false;
-        std::printf("%-6s %-22s %-6s %-16s %10llu %10llu %10llu\n",
-                    kRows[i].id, kRows[i].name, row_ok ? "PASS" : "FAIL",
+        std::printf("%-6s %-22s %-14s %-6s %-16s %10llu %10llu %10llu\n",
+                    kRows[i].id, kRows[i].name, kRows[i].rtm_display,
+                    row_ok ? "PASS" : "FAIL",
                     verdict_name(r.observed),
                     static_cast<unsigned long long>(r.p50),
                     static_cast<unsigned long long>(r.p99),
@@ -206,19 +228,26 @@ int main() {
         }
     }
 
-    // Machine-readable CSV (placeholder IDs; #272 remaps). Column order:
-    // id,fault_class,result,expected_verdict,observed_verdict,p50_ns,p99_ns,max_ns
-    std::printf("\nCSV:\n");
-    std::printf("id,fault_class,result,expected_verdict,observed_verdict,p50_ns,p99_ns,max_ns\n");
+    // Machine-readable CSV. The RTM gap report (RTM_GAP_REPORT.md) has NO per-test
+    // CSV evidence-table format to match — its tables are markdown (goal | ASIL |
+    // description | tests), no timing columns — so this is the PROPOSED grounded
+    // format (flagged proposed in QNX_MAPPING.md), per #272's instruction. Columns:
+    // harness_row is the LOCAL index; rtm_id/tr_id are the kernel-RTM bridge;
+    // wcet_status is constant TBD-QNX-TARGET (host timing is never WCET, #274).
+    std::printf("\nCSV (proposed format — RTM_GAP_REPORT.md has no per-test CSV table to match):\n");
+    std::printf("harness_row,rtm_id,tr_id,fault_class,verdict_expected,verdict_observed,"
+                "pass,p50_ns,p99_ns,max_ns,wcet_status\n");
     for (std::size_t i = 0; i < sizeof(kRows) / sizeof(kRows[0]); ++i) {
         const RowResult &r = results[i];
         const bool row_ok = r.pass && r.short_circuit_ok;
-        std::printf("%s,%s,%s,%s,%s,%llu,%llu,%llu\n",
-                    kRows[i].id, kRows[i].name, row_ok ? "PASS" : "FAIL",
+        std::printf("%s,%s,%s,%s,%s,%s,%s,%llu,%llu,%llu,%s\n",
+                    kRows[i].id, kRows[i].rtm_id, kRows[i].tr_id, kRows[i].name,
                     verdict_name(kRows[i].expected), verdict_name(r.observed),
+                    row_ok ? "PASS" : "FAIL",
                     static_cast<unsigned long long>(r.p50),
                     static_cast<unsigned long long>(r.p99),
-                    static_cast<unsigned long long>(r.max));
+                    static_cast<unsigned long long>(r.max),
+                    "TBD-QNX-TARGET");
     }
 
     std::printf("\nGATE (verdict correctness): %s\n", all_pass ? "PASS" : "FAIL");


### PR DESCRIPTION
## Trace the FDIT harness rows to the real kernel RTM (#272)

Follow-up to **#271** (EPIC #270). Traces each harness fault row to the kernel RTM, **grounded** in `docs/safety/SAFETY_GOALS.md` (AEGIS-SG-001) and `docs/safety/REQUIREMENTS_TRACEABILITY.md` (AEGIS-RTM-001) — both **read as ground truth, NOT modified**. Diff is exactly `tools/qnx-rtm-harness/**` (row mapping fields, CSV emission, `QNX_MAPPING.md`, `README.md`).

### The held line — honest mapping, no force-fit

Of the 8 transport-contract fault classes, **exactly one** has a genuine kernel TR home:

| Harness row | Injects | Verdict | `rtm_id` / `tr_id` |
|---|---|---|---|
| SG-00 | valid (no fault) | `Ok` | `CONTROL` / `NONE` |
| SG-01 | bad header magic | `StaleHeader` | **`NO-RTM-ID`** / `CANDIDATE` |
| SG-02 | sequence regress | `SequenceRegress` | **`NO-RTM-ID`** / `CANDIDATE` |
| SG-03 | deadline missed | `DeadlineMissed` | **`NO-RTM-ID`** / `CANDIDATE` |
| SG-04 | payload CRC | `PayloadCorrupt` | **`NO-RTM-ID`** / `CANDIDATE` |
| SG-05 | payload oversize | `PayloadOversize` | **`NO-RTM-ID`** / `CANDIDATE` |
| SG-06 | over-envelope | `KinematicLimit` | **`SG-001` / `TR-001`** (proxy) |
| SG-07 | replay (`seq==last`) | `SequenceRegress` | **`NO-RTM-ID`** / `CANDIDATE` |

**SG-06 → SG-001/TR-001** is the only hit, and it is **qualified as PROXY**: the judge checks the harness proxy bound (not the certified `VehicleKinematicsContract`) and **rejects** where TR-001 specifies **clamp** — proxy/partial evidence, *not* a substitute for TR-001's certified test.

### NO-RTM-ID gaps called out prominently (this is the evidence)

The six gaps are **real coverage gaps**, each naming its principle-precedent SG and a candidate new TR home:

| Gap | Fault class | Principle precedent | Why it's NOT that TR |
|---|---|---|---|
| 1 | frame-header validity (bad magic) | — (none) | no kernel SG covers frame-header validity |
| 2 | sequence monotonicity | SG-014 (federation anti-rollback) | TR-014 is `reconcile_reports` on federation reports, not the bus |
| 3 | message deadline freshness | SG-003 / SG-005 (staleness) | TR-003 = watchdog, TR-005 = posture-cache TTL; not a per-message deadline |
| 4 | payload integrity (CRC) | SG-010 (audit-chain integrity) | TR-010 is the audit log chain, not a message payload |
| 5 | FFI payload bounds (oversize) | OCCY_FFI_EVIDENCE / OCCY_DFA | FFI robustness has no kernel SG/TR |
| 6 | replay (`seq==last`) | SG-014 (federation replay) | same as gap 2 — federation-only |

**Verified absence:** `grep` for magic / frame-header / CRC / payload-integrity / message-sequence across the SG + RTM docs returns **nothing** — the EPIC #270 transport-contract surface (framing, ordering, freshness, integrity, bounds) is genuinely untraced in the current RTM (authored for the HTTP verifier + governor + adapters). Surfacing these six is exactly what `RTM_GAP_REPORT.md` exists for.

> **Adding the candidate TRs to the RTM itself is a separate `docs/safety/**` change requiring its own safety review — explicitly NOT this PR.** #272 only traces against the RTM as it stands.

### CSV — proposed format (gap report has no per-test table to match)

`RTM_GAP_REPORT.md` has **no per-test CSV evidence table** (its tables are markdown: `goal | ASIL | description | tests`, no timing columns). Per the instruction, the harness emits a **proposed** format, labelled "proposed" in the output:

```
harness_row,rtm_id,tr_id,fault_class,verdict_expected,verdict_observed,pass,p50_ns,p99_ns,max_ns,wcet_status
```

`harness_row` is the **local** index (never an RTM id); `wcet_status` is the constant `TBD-QNX-TARGET` (host timing is never WCET, #274).

### No behavior change (asserted + verified)

Injection logic and the Rust judge are **untouched** — only labels/columns/docs changed. The 8 verdict outcomes are **byte-identical to #284's run**: `Ok, StaleHeader, SequenceRegress, DeadlineMissed, PayloadCorrupt, PayloadOversize, KinematicLimit, SequenceRegress`. `cmake` + `ctest` **2/2 green**; gate **PASS**; SG-05 still short-circuits in the shim (p50 ≈ 38 ns). Diff = only `tools/qnx-rtm-harness/**`; `docs/safety/` untouched; talisman `997fb7ae…` byte-identical.

References #272, #271, EPIC #270.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_