### PR TITLE
docs: sync README + CLAUDE.md with the EPIC #270 governor-transport lane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,8 @@ src/
 ├── health.rs                 — Health check utilities
 ├── tpm.rs                    — TPM attestation support (optional feature)
 ├── ffi.rs                    — C FFI bindings
+├── wcet_gate.rs              — Governor verdict WCET CI guard (O(1) structural
+│                               boundedness argument; GOVERNOR_VERDICT_WCET_*_MICROS)
 ├── gateway/
 │   ├── mod.rs
 │   ├── policy.rs             — classify_command (path+method → OperationalCommand)
@@ -316,6 +318,38 @@ proptest = "1"  # dev-dependency
 | `KIRRA_SUPERVISOR_RESET_KEY` | Yes (reset ops) | — | Must be non-empty, ≤ 64 bytes |
 | `KIRRA_CANOPEN_NODE_MAP` | No | — | CANopen node-id → fleet-node-id map (#84), `canid:fleet_node` comma-separated (e.g. `5:robot-01,6:robot-02`). Unset → every NMT-offline is unattributed (fail-closed) |
 | `KIRRA_FABRIC_ASSET_ID` | No | — | Local fabric asset id fed by the verifier→fabric posture feed (#88). Unset/empty → feed inert (asset keeps its `Degraded` registration seed) |
+
+---
+
+## EPIC #270 — Governor transport / QNX partition lane
+
+The governor command path is moving to **Rust end-to-end** on a QNX safety
+partition; the Autoware/ROS 2 planner is an isolated guest. The C ABI/FFI is
+demoted to the C/C++ integration boundary (**ADR-0006 Clause 3**) — not the hot path.
+
+- **`tools/qnx-rtm-harness/`** (#271/#272) — C++ **shim** (driver: header-tear /
+  bounds / CRC) → Rust **judge** (checker: `kirra_judge.rs` — the contract verdict on
+  a shim-stabilized snapshot). Built **g++ + rustc directly (no cargo)**; the judge is
+  `no_std`, `panic=abort`, zero-alloc. The FDIT/RTM matrix gates on **VERDICT
+  CORRECTNESS** only; every row is traced to the kernel RTM (`QNX_MAPPING.md`, #272).
+  The concern split is load-bearing: memory faults die in the driver, contract faults
+  reach the judge. Sequence rule mirrors the kernel: `sequence <= last_accepted ⇒
+  reject` (equal = replay).
+- **`tools/iceoryx2-spike/`** (#273) — host-side iceoryx2 feature-subset spike
+  (seqlock-style owned snapshot; same `<=` replay rule; `src/judge.rs`).
+- **`docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md`** (KIRRA-OCCY-HVCHAN-001, #278) —
+  frozen `#[repr(C)]` pointer-free `GovernorContractView` over hypervisor shared
+  memory; 7-step seqlock write/read trust chain; **two-clock-domain model (§5)** with
+  the normative **non-mixing rule** (safety/boundary timing vs system timing).
+- **`docs/safety/WCET_MEASUREMENT_METHODOLOGY.md`** (KIRRA-OCCY-WCET-METH-001,
+  #274/#279) — measurement-based timing-evidence strategy; `src/wcet_gate.rs` holds the
+  O(1) structural boundedness argument + the CI guard.
+- **`AOU-TIMESYNC-001`** (`ASSUMPTIONS_OF_USE.md`) — integrator timestamps must be
+  synchronized/monotonic and **converted to the boundary clock domain before publish**.
+
+**Invariant — host timing is INDICATIVE, never WCET.** Only QNX-target-under-FIFO
+numbers feed an FTTI claim (the harness/spike banners + the methodology enforce this;
+the harness CSV carries `wcet_status = TBD-QNX-TARGET`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,25 @@ companions `KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md`, `KIRRA_BRINGUP_RUNBOOK.md`,
 and `KIRRA_QNX_CROSSCOMPILE.md`. (That file's `ADR-0001` prefix is independent of
 the numbered ODD-cap ADRs in the table above — a known naming overlap.)
 
+### Governor transport / QNX partition lane (EPIC #270)
+
+The governor command path is moving to **Rust end-to-end** on a QNX-resident
+safety partition, with the Autoware/ROS 2 planner as an isolated guest. The C
+ABI / FFI is demoted to the documented C/C++ integration boundary (ADR-0006
+Clause 3) — it is no longer the command hot path.
+
+| Document | Doc ID | Status |
+|----------|--------|--------|
+| Hypervisor contract-channel layout + trust-chain spec (#278) | KIRRA-OCCY-HVCHAN-001 | Draft |
+| WCET measurement methodology (#274 / #279 timing-evidence strategy) | KIRRA-OCCY-WCET-METH-001 | Draft |
+| Assumptions-of-Use register (incl. `AOU-TIMESYNC-001` boundary-clock time-sync) | KIRRA-OCCY-AOU-001 | Draft |
+
+Test-evidence tooling: [`tools/qnx-rtm-harness/`](tools/qnx-rtm-harness/) — a C++
+shim (driver) → Rust judge (checker) FDIT/RTM fault-injection harness, every row
+traced to the kernel RTM (#271 / #272); [`tools/iceoryx2-spike/`](tools/iceoryx2-spike/)
+— the host-side iceoryx2 feature-subset spike (#273). **Host timing is indicative
+only; certified WCET is measured on the QNX target under FIFO scheduling (#274).**
+
 See [docs/safety/](docs/safety/) for the complete safety case foundation,
 [docs/safety/SAFETY_CASE_INDEX.md](docs/safety/SAFETY_CASE_INDEX.md) for the
 full document registry, and [docs/safety/ROADMAP_TO_ASIL_D.md](docs/safety/ROADMAP_TO_ASIL_D.md)
@@ -172,6 +191,7 @@ includes honest caveats, effort estimates, and explicit sequencing dependencies.
 |-------------|-------------|--------|
 | [Autoware (Option-B)](docs/safety/OCCY_131_OPTIONB_DESIGN.md) | Two-rate Governor check on the Autoware ROS 2 stack; per-trajectory verdict with MRC publication | **Implemented (#131 closed)** |
 | [IEEE 2846 / RSS](docs/roadmap/RSS_KIRRA_INTEGRATION.md) | Behavioral safety invariants based on IEEE 2846 — safe distance enforcement given perception state | **Implemented** (parko-core RSS, wired via SG3 in #131) |
+| [QNX governor transport lane](docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md) | Rust-end-to-end command path on a QNX safety partition; hypervisor contract channel + iceoryx2 transport; FFI demoted to integration boundary (EPIC #270) | In progress — RTM harness + HVCHAN/WCET specs landed (#271/#272/#278/#274 docs); QNX cross-compile + hardware fault-injection campaigns blocked (#274/#279) |
 | [Apollo AV Stack](docs/roadmap/APOLLO_KIRRA_INTEGRATION.md) | Cyber RT bridge between Apollo Control and Canbus — kinematic enforcement and lockout in the Apollo pipeline | Planned — after QNX + robot demo |
 | Ferrocene compiler qualification | Switch from upstream `rustc` to Ferrocene + `criticalup.toml` for the ASIL-D toolchain claim | Planned — tracked in #132 |
 


### PR DESCRIPTION
Reflect the landed QNX-lane work (#284 #271, #285 #272, #286 #278/clock, #287 #274/#279 WCET methodology) in the two top-level context docs. No source or behavior change; talisman untouched.

README.md:
- New "Governor transport / QNX partition lane (EPIC #270)" subsection under Safety Certification: HVCHAN spec (KIRRA-OCCY-HVCHAN-001), WCET methodology (KIRRA-OCCY-WCET-METH-001), the AoU register (KIRRA-OCCY-AOU-001, incl. AOU-TIMESYNC-001), plus the qnx-rtm-harness + iceoryx2-spike test-evidence tooling. States the host-indicative / QNX-FIFO-WCET rule.
- Roadmap table: a QNX governor transport lane row (harness + specs landed; QNX cross-compile + hardware campaigns blocked).

CLAUDE.md:
- Module map: add src/wcet_gate.rs (O(1) WCET CI guard).
- New "EPIC #270 — Governor transport / QNX partition lane" section: the shim(driver)/judge(checker) concern split, the tools, HVCHAN two-clock-domain + non-mixing rule, the WCET methodology, AOU-TIMESYNC-001, and the host-timing-is- never-WCET invariant.

Verified: diff = README.md + CLAUDE.md only; all referenced paths/doc-IDs resolve; talisman 997fb7ae... byte-identical.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58