### PR TITLE
chore: license consistency — proprietary authoritative, publish=false fence on all crates (#11 resolution)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ homepage = "https://kirrasystems.com"
 authors = ["Justin Looney <justin@kirrasystems.io>"]
 keywords = ["safety", "autonomous", "robotics", "automotive", "runtime"]
 categories = ["embedded", "safety-critical"]
+license-file = "COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [lib]
 name = "kirra_runtime_sdk"

--- a/crates/kirra-capture-schema/Cargo.toml
+++ b/crates/kirra-capture-schema/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 description = "Wire schema for Kirra's learning-loop capture records — the single authoritative, governor-free type set shared by the SDK emitters and the offline collector."
 repository = "https://github.com/justinlooney/kirra-runtime-sdk"
 authors = ["Justin Looney <justin@kirrasystems.io>"]
-license = "MIT OR Apache-2.0"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 # §0 SAFETY BOUNDARY: this crate depends on `serde` ONLY. It carries no governor
 # types and no logic — just the leaf record shapes. The offline collector depends

--- a/crates/kirra-collector/Cargo.toml
+++ b/crates/kirra-collector/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 description = "Offline learning-loop collector: joins Kirra capture JSONL to a bus recording and writes a training-ready Parquet dataset. Depends on kirra-capture-schema ONLY — never the governor (docs/COLLECTOR_DESIGN.md §0)."
 repository = "https://github.com/justinlooney/kirra-runtime-sdk"
 authors = ["Justin Looney <justin@kirrasystems.io>"]
-license = "MIT OR Apache-2.0"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [dependencies]
 kirra-capture-schema = { path = "../kirra-capture-schema" }

--- a/crates/kirra-governor-service/Cargo.toml
+++ b/crates/kirra-governor-service/Cargo.toml
@@ -14,7 +14,8 @@ name = "kirra-governor-service"
 version = "0.1.0"
 edition = "2021"
 description = "Minimal UDP KIRRA governor (two-box prototype); wraps the verdict core verbatim. serde + bincode + std only — no ROS/async."
-license = "Apache-2.0"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [[bin]]
 name = "kirra-governor-service"

--- a/crates/kirra-proposal-bench/Cargo.toml
+++ b/crates/kirra-proposal-bench/Cargo.toml
@@ -9,7 +9,8 @@ name = "kirra-proposal-bench"
 version = "0.1.0"
 edition = "2021"
 description = "DEV/TEST UDP bench for kirra-governor-service — sends a proposal sweep and prints the verdict table. Not a safety artifact."
-license = "Apache-2.0"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [[bin]]
 name = "kirra-proposal-bench"

--- a/crates/kirra-ros2-adapter/Cargo.toml
+++ b/crates/kirra-ros2-adapter/Cargo.toml
@@ -30,7 +30,8 @@ name = "kirra-ros2-adapter"
 version = "0.1.0"
 edition = "2021"
 description = "ROS 2 adapter for the Kirra Governor (Option-B per-trajectory wiring, S131 Phase 1)"
-license = "Apache-2.0 OR MIT"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [features]
 # Default build = no ROS deps. Enables the state machine + corridor trait

--- a/crates/kirra-wire-client/Cargo.toml
+++ b/crates/kirra-wire-client/Cargo.toml
@@ -12,7 +12,8 @@ name = "kirra-wire-client"
 version = "0.1.0"
 edition = "2021"
 description = "DEV/TEST client-side mirror of the kirra-governor-service UDP wire schema (serde + bincode). Not a safety artifact."
-license = "Apache-2.0"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/parko/crates/parko-core/Cargo.toml
+++ b/parko/crates/parko-core/Cargo.toml
@@ -3,7 +3,8 @@ name = "parko-core"
 version = "0.1.0"
 edition = "2021"
 description = "Core types and traits for vendor-neutral ML inference runtime"
-license = "Apache-2.0"
+license-file = "../../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [features]
 # Exposes test-only seams (e.g. set_state_for_test) to integration tests.

--- a/parko/crates/parko-kirra/Cargo.toml
+++ b/parko/crates/parko-kirra/Cargo.toml
@@ -3,7 +3,8 @@ name = "parko-kirra"
 version = "0.1.0"
 edition = "2021"
 description = "Adapter that bridges parko-core's SafetyGovernor trait to the kirra-runtime-sdk kinematics contract"
-license = "Apache-2.0"
+license-file = "../../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [dependencies]
 parko-core = { path = "../parko-core" }

--- a/parko/crates/parko-onnx/Cargo.toml
+++ b/parko/crates/parko-onnx/Cargo.toml
@@ -3,7 +3,8 @@ name = "parko-onnx"
 version = "0.1.0"
 edition = "2021"
 description = "ONNX Runtime backend for parko-core via ort"
-license = "Apache-2.0"
+license-file = "../../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [features]
 # CUDA execution provider (NVIDIA GPU). Enables ort's `cuda` feature, which

--- a/parko/crates/parko-openvino/Cargo.toml
+++ b/parko/crates/parko-openvino/Cargo.toml
@@ -16,7 +16,8 @@ name = "parko-openvino"
 version = "0.1.0"
 edition = "2021"
 description = "OpenVINO inference backend for parko-core (CPU device; runtime-linked)"
-license = "Apache-2.0"
+license-file = "../../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [dependencies]
 parko-core = { path = "../parko-core" }

--- a/parko/crates/parko-ros2/Cargo.toml
+++ b/parko/crates/parko-ros2/Cargo.toml
@@ -18,7 +18,8 @@ name = "parko-ros2"
 version = "0.1.0"
 edition = "2021"
 description = "ROS 2 node for Parko's end-to-end ML control path (M2; parallel to kirra-ros2-adapter)"
-license = "Apache-2.0 OR MIT"
+license-file = "../../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [features]
 # Default = no ROS / no ORT. The state-machine + mapping tests run

--- a/parko/crates/parko-tensorrt/Cargo.toml
+++ b/parko/crates/parko-tensorrt/Cargo.toml
@@ -3,7 +3,8 @@ name = "parko-tensorrt"
 version = "0.1.0"
 edition = "2021"
 description = "TensorRT (NVIDIA Jetson) backend for parko-core via ort's TensorRT execution provider"
-license = "Apache-2.0"
+license-file = "../../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [dependencies]
 parko-core = { path = "../parko-core" }

--- a/tools/iceoryx2-spike/Cargo.toml
+++ b/tools/iceoryx2-spike/Cargo.toml
@@ -9,7 +9,8 @@
 name = "iceoryx2-spike"
 version = "0.0.0"
 edition = "2021"
-publish = false
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+license-file = "../../COPYRIGHT"
 description = "Host-side iceoryx2 feature-subset + fault-matrix spike (#273)"
 
 # PINNED — host-side feature-subset spike (#273). Version recorded in README.


### PR DESCRIPTION
## License consistency — proprietary authoritative, `publish = false` fence (#11 resolution)

Started as the #11 (PARK-006) parko-core v0.1.0 **publish-readiness verification**. The verification surfaced a repo-wide licensing contradiction; per owner decision this PR resolves that instead of completing the publish.

### Stale steps in #11 (as written)
- `version = "0.1.0"` was **already set** on main — the "set version" step was done.
- The **tag is not this PR's job** (tags point at merged commits) — see the owner step below.

### The contradiction found
During `cargo publish --dry-run`, the manifest metadata was checked against the repo's actual license artifact:
- **Every** crate manifest declared an open-source SPDX license (`Apache-2.0`, `Apache-2.0 OR MIT`, `MIT OR Apache-2.0`).
- The repo's only license artifact, **`COPYRIGHT`**, declares the software **proprietary**: *"All rights reserved. This software is proprietary and confidential. No license is granted to use, copy, modify, or distribute…"* There is **no `LICENSE` file**.

These contradict, and publishing under the wrong license is serious — so I surfaced it rather than guessing.

### Owner decision → this PR
**The `COPYRIGHT` file is authoritative; the Apache/MIT manifest fields were erroneous boilerplate.** Every `[package]` manifest in the repo (**14**) now:
- declares **`license-file = "<rel>/COPYRIGHT"`** (correct relative depth per crate), replacing any `license = "…"` SPDX claim — **no crate retains an Apache/MIT claim**;
- sets **`publish = false`** (the fence).

Manifests changed (14): root `./Cargo.toml`; `crates/{kirra-capture-schema, kirra-collector, kirra-governor-service, kirra-proposal-bench, kirra-ros2-adapter, kirra-wire-client}`; `parko/crates/{parko-core, parko-kirra, parko-onnx, parko-openvino, parko-ros2, parko-tensorrt}`; `tools/iceoryx2-spike` (was already `publish=false`; `license-file` added).

No code, dependencies, versions, or the talisman touched (`997fb7ae…` byte-identical). `publish=false` and `license-file` are inert to builds.

### Evidence — the fence works
`cargo publish --dry-run -p parko-core` now **refuses** (it passed before this change):
```
error: `parko-core` cannot be published.
`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
```
(For the record, the dev-dep cycle was also confirmed earlier: the version-less path dev-dep on `parko-kirra` is stripped at packaging — the baseline dry-run packaged lib-only and verified clean — but publication is now fenced regardless.)

### Verified
- Full **SDK root workspace** + **parko workspace** + **iceoryx2-spike** build green.
- `cargo test -p parko-core` green (178 lib + 8).
- Diff = **14 `Cargo.toml` only**; talisman byte-identical.

### #11 closing note
The publish goal is **superseded**. The `v0.1.0` version stands, and an **internal milestone tag** remains available to the owner (`git tag parko-core-v0.1.0 <merge-commit> && git push origin parko-core-v0.1.0`) — tags are not publication — but **crates.io publication is intentionally fenced off**.

Resolves #11.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_