### PR TITLE
feat(parko-core): QNX-safe backend selection rules + deny-by-default enforcement (#38/PARK-026)

### DIFF
--- a/parko/QNX_BACKEND_SELECTION.md
+++ b/parko/QNX_BACKEND_SELECTION.md
@@ -1,0 +1,160 @@
+# QNX-Safe Backend Selection Rules (PARK-026)
+
+| Field | Value |
+|---|---|
+| Requirement | **PARK-026** (issue #38) |
+| Status | **Requirements half DECIDED** + enforced; **availability half PENDING #36** |
+| Enforcement | `parko-core` — `backend_permitted` / `current_platform` (`src/backend_selector.rs`) |
+| Cross-refs | #36 (PARK-024 QNX deployment spike), #37 (PARK-025 QNN+QNX analysis), #34 / PR #290 (`BackendSelector`), ADR-0001, ADR-0006, EPIC #270 |
+
+> **The split (PARK-026).** This issue was labelled *blocked until PARK-024 (#36)
+> confirms which POSIX features QNX exposes*. That blocks only the **availability**
+> half — which backends QNX can actually host. It does **not** block the
+> **requirements** half: the rules KIRRA imposes *regardless* of what QNX offers.
+> This document delivers the requirements half plus a **conservative,
+> deny-by-default** enforcement; every availability row that depends on #36's
+> target findings is marked **PENDING-#36** and is **denied at runtime until
+> confirmed**.
+
+---
+
+## 1. Architecture framing — where these rules apply
+
+The **reference architecture (ADR-0006)** runs the Autoware/ROS 2 planner — and
+parko's ML inference — in an **Ubuntu guest partition**, with the **KIRRA governor
+QNX-resident** on the safety partition and the planner an *isolated guest*. In that
+topology **parko is not on QNX**: it is the guest doer, and the governor validates
+its outputs across the frozen-layout partition boundary.
+
+These rules therefore govern the two cases where inference *does* touch QNX:
+
+- **(a) QNX-native single-OS deployments** — vendor-neutral robots that run parko
+  directly on QNX Neutrino (no hypervisor/guest split), and the #36
+  verifier/governor-on-QNX lane where a backend may be co-resident.
+- **(b) Any future safety-partition inference** — should an inference path ever be
+  admitted onto a QNX safety partition (not the reference path today).
+
+**This document does not make parko-on-QNX the primary path.** Off-QNX behavior is
+**unchanged** (§4): existing Linux/Jetson users see zero difference.
+
+---
+
+## 2. The requirements (decided now — not pending anything)
+
+These hold on QNX **independent of** what #36 finds available. A backend that
+cannot meet them is ineligible for a QNX-native / safety-partition deployment even
+if its runtime *is* present.
+
+### R-1 — No dynamic allocation on the backend hot path
+Steady-state inference (`InferenceBackend::run`) shall perform **no heap
+allocation**. This aligns with the existing parko contracts:
+- **ADL-003**, the zero-copy hot-path contract (`run(&[f32], &mut [f32])`) noted on
+  `InferenceBackend` in `parko/crates/parko-core/src/backend.rs` (the documented
+  future-refactor target); and
+- the **alloc-free Governor hot path (S3 / #115)** — see
+  `parko/crates/parko-kirra/src/lib.rs` ("Governor hot path itself stayed
+  alloc-free").
+
+**Honest current state:** the live `run()` returns an **owned** `TensorBatch`
+(output allocation), which ADL-003 will refactor to the zero-copy form. Until ADL-003
+lands, a QNX-native backend MUST pre-allocate its output buffers at `load_model`
+time and reuse them per `run()` — it must not allocate per inference. Input
+zero-copy (`TensorStorage::Borrowed`) is already supported and shall be used.
+
+### R-2 — Restricted POSIX API surface
+A QNX-native backend (and the loader it pulls in) shall **not** depend on:
+- **`fork` / `exec`** — no process spawning; the single-process model (R-3) forbids it.
+- **`dlopen` beyond the documented loader path** — dynamic loading is permitted
+  *only* via the platform's sanctioned, fixed loader path (the one #36 confirms);
+  arbitrary/relative `dlopen` of vendor blobs at runtime is forbidden.
+- **signals for control flow** — signals may not be used as a control or
+  data-path mechanism (handlers for fault containment are a separate concern);
+  inference progress shall not depend on signal delivery.
+- **unbounded threading** — no unbounded or per-request thread spawning; thread
+  counts shall be **fixed and bounded**, set at init. (Default inference is
+  **single-threaded** for bitwise reproducibility — `InferenceThreads::default()`,
+  `num_threads = 1`; raising it is a logged, deliberate act, never per-request.)
+
+### R-3 — Single-process model
+The backend shall operate **in-process**: no helper processes, no IPC to a
+co-process daemon, no shared-memory inference broker spawned by the backend. The
+governor's trust boundary assumes one process; a backend that forks an inference
+server breaks that assumption and is ineligible.
+
+---
+
+## 3. The availability table (PENDING #36)
+
+Per-backend QNX status. **Conservative rule — stated normatively:** `PENDING-#36`
+means **FORBIDDEN at runtime** until #36 confirms the required facilities on the
+target. This is **deny-by-default**, never allow-until-denied. A row moves to
+`CONFIRMED` only with #36 evidence (and, for QNN, the #37 analysis).
+
+| Backend (`BackendDescriptor`) | Required platform facilities | QNX status | Rationale |
+|---|---|---|---|
+| **Cpu** (parko-onnx CPU EP) | ONNX Runtime CPU build; `libonnxruntime` via the sanctioned loader path (R-2); bounded threads | **PENDING-#36** | CPU inference is the most portable, but an ORT QNX build + the fixed loader path are **unconfirmed** on target. Plausible to confirm first — but denied until #36. |
+| **Cuda** (parko-onnx CUDA EP) | NVIDIA driver + `libcuda` + CUDA EP | **FORBIDDEN** | No CUDA stack on standard QNX Neutrino. Structurally impossible — not a #36 question. |
+| **TensorRT** (parko-tensorrt) | CUDA runtime + TensorRT libs (Jetson) | **FORBIDDEN** | TensorRT is CUDA-based; same basis as Cuda. (A DRIVE-OS CUDA-on-QNX variant is out of scope for this vendor-neutral lane.) |
+| **QualcommQnn** (QNN NPU) | Qualcomm QNN SDK / NPU runtime + loader | **PENDING-#36** | QNN-on-QNX compatibility is exactly the **#37** analysis; gated by it **and** #36. Denied until both confirm. |
+| **TiTidl** (TI TIDL) | TI TIDL runtime + device access | **PENDING-#36** | TIDL runtime availability on QNX unconfirmed. Denied until #36. |
+| **IntelOpenVino** (OpenVINO) | Intel OpenVINO runtime (x86) | **PENDING-#36** | OpenVINO targets Linux/Windows; QNX support unconfirmed (likely unavailable) — denied until #36 confirms either way. |
+| **AmdVitis** (Vitis AI) | AMD Vitis AI / XRT runtime | **PENDING-#36** | Vitis AI / XRT on QNX unconfirmed. Denied until #36. |
+
+**Net current posture on QNX: deny-all.** No backend is `CONFIRMED` yet — `Cuda`
+and `TensorRT` are permanently `FORBIDDEN`; every other backend is `PENDING-#36`
+and therefore denied at runtime. This is the intended conservative starting point;
+rows earn `CONFIRMED` one at a time as #36 (and #37 for QNN) produce target evidence.
+
+---
+
+## 4. Enforcement (parko-core)
+
+The table above is enforced by a **pure, platform-parameterized** policy — testable
+on any host, not buried under `cfg`:
+
+```rust
+pub enum TargetPlatform { Linux, Qnx, Other }
+pub fn current_platform() -> TargetPlatform;                 // cfg(target_os = "nto") => Qnx
+pub fn backend_permitted(platform: TargetPlatform,
+                         d: BackendDescriptor) -> Result<(), BackendError>;
+```
+
+- **Off-QNX (`Linux` / `Other`) → always permitted.** The held line: existing
+  users see **zero** behavior change. The QNX rules engage only on the QNX target.
+- **On QNX → the §3 allowlist.** `FORBIDDEN` and `PENDING-#36` rows **both** return
+  `Err` — the error names this rule doc, and `PENDING` rows name **#36**.
+- **`BackendSelector::new` / `from_env` consult the gate FIRST**, before factory or
+  stub resolution — so a **registered factory cannot bypass** the platform rule
+  (tested). The deterministic **Mock default** (unset `KIRRA_BACKEND`) is
+  platform-agnostic (no hardware, no restricted POSIX) and remains the safe
+  fallback on any target.
+
+`current_platform()` uses `cfg(target_os = "nto")` for QNX; the policy itself takes
+the platform as a **parameter**, so every rule is exercised by host-run unit tests
+(`backend_selector::tests`) without cross-compiling.
+
+---
+
+## 5. What stays blocked on #36 (and #37)
+
+- Moving any `PENDING-#36` row to `CONFIRMED` — requires #36's POSIX-availability
+  findings on the QNX target (ORT build, the sanctioned `dlopen` loader path,
+  threading model, device access).
+- `QualcommQnn` additionally requires the **#37** QNN+QNX compatibility analysis.
+- When a row is confirmed, the change is: (1) update its row here to `CONFIRMED`
+  with the evidence, and (2) move that descriptor to a permitted arm in
+  `backend_permitted`'s QNX match — a one-line, test-covered change. Until then the
+  fence holds deny-by-default.
+
+---
+
+## 6. Cross-references
+
+- **#36** (PARK-024) — QNX deployment spike; the availability evidence this gates on.
+- **#37** (PARK-025) — QNN + QNX compatibility analysis; gates the `QualcommQnn` row.
+- **#34 / PR #290** — `BackendSelector` (factory registry + fail-closed env
+  selection); this is the platform gate layered ahead of its resolution.
+- **ADR-0001** — Governor Deployment Platform.
+- **ADR-0006** — Governor transport; the partition topology (governor QNX-resident,
+  planner an isolated guest) this document's framing rests on.
+- **EPIC #270** — the QNX governor-transport lane.

--- a/parko/crates/parko-core/src/backend_selector.rs
+++ b/parko/crates/parko-core/src/backend_selector.rs
@@ -140,6 +140,76 @@ pub fn descriptor_from_env_str(value: &str) -> Result<BackendDescriptor, Backend
     }
 }
 
+/// The deployment platform a backend would run on.
+///
+/// An explicit *parameter* (not hidden behind `cfg`) so every QNX-safe selection
+/// rule (PARK-026; `parko/QNX_BACKEND_SELECTION.md`) is testable on any host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetPlatform {
+    Linux,
+    Qnx,
+    Other,
+}
+
+/// The platform this binary was compiled for.
+///
+/// QNX Neutrino is `target_os = "nto"`. This `cfg` is the *only* compile-target
+/// dependence; the policy ([`backend_permitted`]) takes the platform as an
+/// argument, so the rules themselves are host-testable.
+#[must_use]
+pub fn current_platform() -> TargetPlatform {
+    #[cfg(target_os = "nto")]
+    {
+        TargetPlatform::Qnx
+    }
+    #[cfg(target_os = "linux")]
+    {
+        TargetPlatform::Linux
+    }
+    #[cfg(not(any(target_os = "nto", target_os = "linux")))]
+    {
+        TargetPlatform::Other
+    }
+}
+
+// SAFETY: parko backend selection | REQ: PARK-026 | TEST: backend_selector::tests::{off_qnx_permits_every_backend, qnx_forbids_cuda_and_tensorrt, qnx_pending_backends_denied_naming_36, platform_gate_precedes_factory}
+/// Apply the QNX-safe backend selection rules (PARK-026) for `platform`.
+///
+/// - **`Linux` / `Other` → always `Ok`.** Off-QNX behavior is unchanged — the held
+///   line: existing users see zero difference; the QNX rules engage only on QNX.
+/// - **`Qnx` → the `parko/QNX_BACKEND_SELECTION.md` §3 allowlist.** `Cuda` and
+///   `TensorRT` are **FORBIDDEN** (no CUDA/TensorRT runtime on QNX Neutrino); every
+///   other descriptor is **PENDING-#36** and **denied by default** until the #36
+///   spike confirms the target's POSIX facilities. Both return `Err` naming the
+///   rule doc; the pending case also names #36. Deny-by-default, never
+///   allow-until-denied — and the `_` arm denies any future (`#[non_exhaustive]`)
+///   descriptor too.
+pub fn backend_permitted(
+    platform: TargetPlatform,
+    d: BackendDescriptor,
+) -> Result<(), BackendError> {
+    const DOC: &str = "parko/QNX_BACKEND_SELECTION.md";
+    match platform {
+        TargetPlatform::Linux | TargetPlatform::Other => Ok(()),
+        TargetPlatform::Qnx => match d {
+            // FORBIDDEN — no CUDA/TensorRT runtime on standard QNX Neutrino.
+            BackendDescriptor::Cuda | BackendDescriptor::TensorRT => {
+                Err(BackendError::InitializationError(format!(
+                    "backend {d:?} is FORBIDDEN on QNX (no CUDA/TensorRT runtime on \
+                     QNX Neutrino); see {DOC} §3"
+                )))
+            }
+            // PENDING-#36 — deny-by-default until the QNX deployment spike (#36)
+            // confirms the required POSIX facilities. `_` also denies any future
+            // descriptor — conservative by design.
+            _ => Err(BackendError::InitializationError(format!(
+                "backend {d:?} is not yet permitted on QNX: POSIX availability \
+                 unconfirmed (deny-by-default until PARK-024 / #36 confirms); see {DOC} §3"
+            ))),
+        },
+    }
+}
+
 /// Owns the selected inference backend.
 ///
 /// Derefs to `dyn InferenceBackend`, so a `BackendSelector` is usable directly
@@ -162,6 +232,22 @@ impl BackendSelector {
     ///    stub is unconstructible. This is always an error, **never a panic**
     ///    and **never a silent substitution** of a different backend.
     pub fn new(descriptor: BackendDescriptor) -> Result<Self, BackendError> {
+        Self::new_for_platform(current_platform(), descriptor)
+    }
+
+    /// [`new`] with the platform as an explicit argument, so the QNX gate
+    /// (PARK-026) is host-testable. The platform rule is consulted **first** —
+    /// before factory or stub resolution — so a registered factory cannot bypass
+    /// it (`parko/QNX_BACKEND_SELECTION.md` §4).
+    ///
+    /// [`new`]: BackendSelector::new
+    fn new_for_platform(
+        platform: TargetPlatform,
+        descriptor: BackendDescriptor,
+    ) -> Result<Self, BackendError> {
+        // PARK-026 platform gate, BEFORE any factory/stub resolution.
+        backend_permitted(platform, descriptor.clone())?;
+
         // 1. Registered real backend wins.
         if let Some(factory) = registered_factory(&descriptor) {
             return factory().map(BackendSelector);
@@ -222,6 +308,10 @@ impl BackendSelector {
     }
 
     /// The unconfigured default: a deterministic zero-output `MockBackend`.
+    ///
+    /// Intentionally bypasses the PARK-026 platform gate: the Mock uses no
+    /// hardware and no restricted POSIX surface, so it is safe on any target and
+    /// is the correct fail-safe fallback on QNX when no real backend is permitted.
     fn default_mock() -> Self {
         BackendSelector(Box::new(MockBackend::new(
             HashMap::new(),
@@ -262,6 +352,20 @@ impl std::fmt::Debug for BackendSelector {
 mod tests {
     use super::*;
     use crate::backend::BackendDescriptor;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Every descriptor, for the platform-policy sweeps.
+    fn all_descriptors() -> [BackendDescriptor; 7] {
+        [
+            BackendDescriptor::Cpu,
+            BackendDescriptor::Cuda,
+            BackendDescriptor::TensorRT,
+            BackendDescriptor::QualcommQnn,
+            BackendDescriptor::TiTidl,
+            BackendDescriptor::IntelOpenVino,
+            BackendDescriptor::AmdVitis,
+        ]
+    }
 
     // The factory registry is process-global and persists across the whole test
     // binary, which runs tests in parallel. To stay race-free, each registry-
@@ -396,5 +500,99 @@ mod tests {
         register_backend_factory(BackendDescriptor::IntelOpenVino, ok_mock_cpu);
         let sel = BackendSelector::from_env_value(Some("OpenVino")).unwrap();
         assert_eq!(sel.load_model("m").unwrap().model_id, "mock::m");
+    }
+
+    // ---- PARK-026 — QNX-safe backend selection rules -----------------------
+
+    #[test]
+    fn off_qnx_permits_every_backend() {
+        // The held line: off-QNX is unchanged — every descriptor is permitted.
+        for p in [TargetPlatform::Linux, TargetPlatform::Other] {
+            for d in all_descriptors() {
+                assert!(
+                    backend_permitted(p, d.clone()).is_ok(),
+                    "{p:?} must permit {d:?} (zero behavior change off-QNX)"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn qnx_forbids_cuda_and_tensorrt() {
+        for d in [BackendDescriptor::Cuda, BackendDescriptor::TensorRT] {
+            let msg = backend_permitted(TargetPlatform::Qnx, d.clone())
+                .unwrap_err()
+                .to_string();
+            assert!(
+                msg.contains("FORBIDDEN") && msg.contains("QNX_BACKEND_SELECTION.md"),
+                "{d:?} on QNX must be FORBIDDEN and name the rule doc, got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn qnx_pending_backends_denied_naming_36() {
+        // PENDING rows are denied by default and name #36 + the rule doc.
+        for d in [
+            BackendDescriptor::Cpu,
+            BackendDescriptor::QualcommQnn,
+            BackendDescriptor::TiTidl,
+            BackendDescriptor::IntelOpenVino,
+            BackendDescriptor::AmdVitis,
+        ] {
+            let msg = backend_permitted(TargetPlatform::Qnx, d.clone())
+                .unwrap_err()
+                .to_string();
+            assert!(
+                msg.contains("#36") && msg.contains("QNX_BACKEND_SELECTION.md"),
+                "PENDING backend {d:?} on QNX must be denied naming #36 + the doc, got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn qnx_is_currently_deny_all() {
+        // Conservative starting posture: NO row is CONFIRMED yet, so QNX denies
+        // every descriptor (FORBIDDEN or PENDING-#36). Encodes deny-by-default.
+        for d in all_descriptors() {
+            assert!(
+                backend_permitted(TargetPlatform::Qnx, d.clone()).is_err(),
+                "{d:?} must be denied on QNX (deny-by-default until #36)"
+            );
+        }
+    }
+
+    // Owns `AmdVitis`. A fn-pointer factory flags whether it ran.
+    static ORDERING_FACTORY_CALLED: AtomicBool = AtomicBool::new(false);
+    fn ordering_flagging_factory() -> Result<Box<dyn InferenceBackend>, BackendError> {
+        ORDERING_FACTORY_CALLED.store(true, Ordering::SeqCst);
+        Ok(Box::new(MockBackend::new(HashMap::new(), BackendDescriptor::Cpu)))
+    }
+
+    #[test]
+    fn platform_gate_precedes_factory() {
+        register_backend_factory(BackendDescriptor::AmdVitis, ordering_flagging_factory);
+
+        // On QNX the gate denies (AmdVitis is PENDING) BEFORE the factory runs —
+        // a registered factory must NOT bypass the platform rule.
+        ORDERING_FACTORY_CALLED.store(false, Ordering::SeqCst);
+        let err = BackendSelector::new_for_platform(TargetPlatform::Qnx, BackendDescriptor::AmdVitis)
+            .unwrap_err();
+        assert!(
+            !ORDERING_FACTORY_CALLED.load(Ordering::SeqCst),
+            "platform gate must deny before the registered factory is consulted"
+        );
+        assert!(matches!(err, BackendError::InitializationError(_)));
+
+        // Off-QNX the same descriptor + factory resolves normally (held line).
+        ORDERING_FACTORY_CALLED.store(false, Ordering::SeqCst);
+        let sel =
+            BackendSelector::new_for_platform(TargetPlatform::Linux, BackendDescriptor::AmdVitis)
+                .unwrap();
+        assert!(
+            ORDERING_FACTORY_CALLED.load(Ordering::SeqCst),
+            "off-QNX the registered factory must run (zero behavior change)"
+        );
+        assert_eq!(sel.descriptor(), BackendDescriptor::Cpu);
     }
 }

--- a/parko/crates/parko-core/src/lib.rs
+++ b/parko/crates/parko-core/src/lib.rs
@@ -45,8 +45,8 @@ pub use backend::{
 };
 
 pub use backend_selector::{
-    descriptor_from_env_str, register_backend_factory, BackendFactory, BackendSelector,
-    KIRRA_BACKEND_ENV,
+    backend_permitted, current_platform, descriptor_from_env_str, register_backend_factory,
+    BackendFactory, BackendSelector, KIRRA_BACKEND_ENV, TargetPlatform,
 };
 
 pub use backends::mock::MockBackend;


### PR DESCRIPTION
## QNX-safe backend selection rules + deny-by-default enforcement (#38 / PARK-026)

### The split (also posted to #38's body)
#38 was labelled *blocked until PARK-024 (#36) confirms which POSIX features QNX exposes*. That blocks only the **availability** half (which backends QNX can host). This PR delivers the **requirements** half — the rules KIRRA imposes *regardless* of what QNX offers — plus conservative **deny-by-default** enforcement. Availability-confirmation stays blocked on #36; every dependent row is marked **PENDING-#36** and denied at runtime.

### `parko/QNX_BACKEND_SELECTION.md` (new)
- **Architecture framing** — the reference architecture (ADR-0006) runs parko in the Ubuntu **guest** with the governor QNX-resident; **parko-on-QNX is not the primary path**. These rules govern (a) QNX-native single-OS robots / the #36 governor-on-QNX lane and (b) future safety-partition inference.
- **Requirements (decided now):** R-1 no dynamic allocation on the backend hot path (anchored to **ADL-003** in `backend.rs` + the alloc-free Governor hot path **S3/#115**; honest note that the current `run()` returns owned outputs pending the ADL-003 zero-copy refactor); R-2 restricted POSIX surface (no `fork`/`exec`, no `dlopen` beyond the sanctioned loader path, no signals-for-control-flow, no unbounded threading — single-thread default = bitwise-reproducible); R-3 single-process model.
- **Availability table (PENDING #36):** `Cuda`/`TensorRT` = **FORBIDDEN** (no CUDA on QNX); `Cpu`/`QNN`/`TIDL`/`OpenVINO`/`Vitis` = **PENDING-#36** (QNN additionally gated by #37). Conservative rule stated normatively: **PENDING == FORBIDDEN at runtime** (deny-by-default). Net current posture: **deny-all**.

### Enforcement (`parko-core`)
- **Pure, platform-parameterized** policy (testable on any host, not buried under `cfg`): `pub enum TargetPlatform { Linux, Qnx, Other }` + `backend_permitted(platform, d) -> Result<(), BackendError>`. **`Linux`/`Other` → `Ok`** (the held line: **zero** off-QNX behavior change). **`Qnx` →** the doc allowlist; FORBIDDEN and PENDING both → `Err` naming the rule doc (PENDING also names **#36**); the `_` arm denies future `#[non_exhaustive]` descriptors too.
- `current_platform()` is the only `cfg` piece (`target_os = "nto"` → `Qnx`).
- `BackendSelector::new` → `new_for_platform(current_platform(), d)`, which consults the gate **before** factory/stub resolution — **a registered factory cannot bypass it** (tested). The deterministic **Mock default** (unset `KIRRA_BACKEND`) bypasses the gate by design: no hardware / no restricted POSIX, the safe QNX fallback.

### Two corrections to the original prompt (by design)
1. **No "fall back to CPU"** for TensorRT — a silent swap to a different backend violates the fail-closed rule from #34 (and CPU is itself PENDING-#36 on QNX). The rule returns `Err`, never a different backend.
2. **QNN does not "proceed"** — PARK-025 (#37) isn't done, so `QualcommQnn` is PENDING and denied by default.

### Tests (host-run via the parameterized fn)
off-QNX permits all 7 descriptors; QNX forbids `Cuda`/`TensorRT` naming the doc; QNX PENDING rows denied naming #36; QNX currently deny-all; **platform gate precedes the factory** (a flag proves the factory is not consulted on QNX, and runs off-QNX).

### Verified
- `cargo test -p parko-core` green — **183** (default, +5 new; existing tests unchanged = the held line) / **186** (`--features backend-tensorrt`).
- **clippy clean** — default + all five backend features.
- parko workspace + SDK build green. Diff = **parko files only** (`QNX_BACKEND_SELECTION.md`, `backend_selector.rs`, `lib.rs`); talisman `997fb7ae…` byte-identical.

The `--target …nto…` cross-build check belongs to #36's hardware lane; enforcement here is verified host-side. **#38 stays open for the availability half (#36).**

References #38, #36, #37, #34/PR #290, ADR-0001, ADR-0006, EPIC #270.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_