### PR TITLE
feat(console): operator console Phase A — read views + authenticated grant recording (delivery = Phase B)

### DIFF
--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -4,9 +4,9 @@
 use axum::{
     extract::{Path, Query, Request, State},
     extract::rejection::JsonRejection,
-    http::{header, StatusCode},
+    http::{header, HeaderMap, StatusCode},
     middleware::{self, Next},
-    response::{sse::{Event, KeepAlive, Sse}, IntoResponse, Response},
+    response::{sse::{Event, KeepAlive, Sse}, Html, IntoResponse, Response},
     routing::{get, post},
     Extension, Json, Router,
 };
@@ -25,7 +25,7 @@ use kirra_runtime_sdk::verifier::{
 use kirra_runtime_sdk::verifier_store::{DurableWriteError, VerifierStore};
 use kirra_runtime_sdk::posture_cache::{now_ms, ServiceState, POSTURE_CACHE_TTL_MS};
 use kirra_runtime_sdk::posture_engine_v2::{resolve_posture_with_reason, LockoutReason};
-use kirra_runtime_sdk::security::admin_token_ok;
+use kirra_runtime_sdk::security::{admin_token_ok, constant_time_compare};
 use kirra_runtime_sdk::action_filter::{evaluate_action_claim, ActionClaim};
 use kirra_runtime_sdk::protocol_adapter::{
     evaluate_unified_industrial_request, UnifiedIndustrialRequest,
@@ -2629,6 +2629,265 @@ async fn main() {
         .expect("server error");
 }
 
+// ===========================================================================
+// Operator console — Phase A (#103 SG6).
+//
+// A real UI served by this service against real store data, plus the ONE
+// authenticated inbound affordance: recording a supervisor clearance grant.
+//
+// THE HONESTY RULE (Phase A): nothing here releases a vehicle. A grant is
+// RECORDED AND SIGNED; release happens only when Phase B delivers it to the
+// node's `ClearanceLoop`. The response, the audit payload, and the UI all say
+// so (`delivery: pending-phase-b` / `PENDING-NODE-TRANSPORT`).
+//
+// Reachability: the `/console` plane is posture-EXEMPT (see
+// `gateway::policy_layer::is_posture_exempt`) — it must work *during* LockedOut,
+// which is exactly when an operator needs it. The reads are QM; the grant is
+// gated by the supervisor key below.
+// ===========================================================================
+
+/// GET /console — the operator console UI. One self-contained static file
+/// embedded at build time (`include_str!`): inline CSS+JS, no CDN, no build
+/// step — it works air-gapped.
+async fn console_html() -> impl IntoResponse {
+    Html(include_str!("../../static/console.html"))
+}
+
+/// GET /console/fleet — per-node posture summary from the durable store
+/// (`load_nodes`). QM read. `note` is the Untrusted reason carried on the node's
+/// trust state (the latest trust note); `null` for Trusted/Unknown.
+async fn console_fleet(State(svc): State<Arc<ServiceState>>) -> impl IntoResponse {
+    let nodes = match svc.app.store.lock() {
+        Ok(store) => match store.load_nodes() {
+            Ok(n) => n,
+            Err(_) => {
+                return (StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({ "error": "load_nodes failed" }))).into_response()
+            }
+        },
+        Err(_) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": "store lock poisoned" }))).into_response()
+        }
+    };
+    let fleet: Vec<_> = nodes
+        .iter()
+        .map(|n| {
+            let (posture, note) = match &n.status {
+                NodeTrustState::Trusted => ("Trusted", None),
+                NodeTrustState::Untrusted(reason) => ("Untrusted", Some(reason.clone())),
+                NodeTrustState::Unknown => ("Unknown", None),
+            };
+            json!({
+                "node_id": n.node_id,
+                "posture": posture,
+                "note": note,
+                "last_seen_ms": n.last_trust_update_ms,
+            })
+        })
+        .collect();
+    Json(json!({ "fleet": fleet, "total": fleet.len() })).into_response()
+}
+
+#[derive(Deserialize)]
+struct ConsoleAuditQuery {
+    limit: Option<u64>,
+    offset: Option<u64>,
+}
+
+/// GET /console/audit?limit=&offset= — passthrough to `load_audit_chain_page`.
+///
+/// GROUNDING NOTE: `load_audit_chain_page` is **offset-paginated** (DESC by id),
+/// not before-seq cursored. The console pages by offset (the "load older" control
+/// increments `offset` over the DESC feed — the same backward paging the original
+/// `?before=<seq>` intent describes). Returns exactly what the page rows carry
+/// (sequence, event_type, payload, signature key-id, per-row signature status,
+/// and the page-level `chain_intact` flag) — no invented fields. QM read.
+async fn console_audit(
+    State(svc): State<Arc<ServiceState>>,
+    Query(params): Query<ConsoleAuditQuery>,
+) -> impl IntoResponse {
+    let limit = params.limit.unwrap_or(50).min(500);
+    let offset = params.offset.unwrap_or(0);
+    let vk = svc.audit_verifying_key.as_ref();
+    match svc.app.store.lock() {
+        Ok(store) => match store.load_audit_chain_page(limit, offset, vk) {
+            Ok(page) => Json(page).into_response(),
+            Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
+                       Json(json!({ "error": "audit query failed" }))).into_response(),
+        },
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
+                   Json(json!({ "error": "store lock poisoned" }))).into_response(),
+    }
+}
+
+/// GET /console/escalations — derived view of OPEN SG6 escalations.
+///
+/// CONSERVATIVE SUPERSET + AMBIGUITY NOTE: the SG6 impact lifecycle events
+/// (`ImpactDetected` / `ImpactEscalationRaised` / `ImpactCleared`, parko-kirra
+/// `audit_sink`, #102/#103) DO land in this audit chain — but their payloads
+/// (`ImpactDetectedPayload`) carry **no node/asset id**, so per-node attribution
+/// is NOT derivable from the chain alone. This view therefore returns the
+/// fleet-level OPEN superset over a single timeline: scanning most-recent-first,
+/// the detect/raise events seen before the first `ImpactCleared` are "open"
+/// (events since the last clear). It passes through whatever each event row
+/// carries — no fabricated node_id. Per-node attribution is a Phase-B / event-
+/// taxonomy enhancement. QM read.
+async fn console_escalations(State(svc): State<Arc<ServiceState>>) -> impl IntoResponse {
+    let vk = svc.audit_verifying_key.as_ref();
+    let page = match svc.app.store.lock() {
+        Ok(store) => match store.load_audit_chain_page(1000, 0, vk) {
+            Ok(p) => p,
+            Err(_) => {
+                return (StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({ "error": "audit query failed" }))).into_response()
+            }
+        },
+        Err(_) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": "store lock poisoned" }))).into_response()
+        }
+    };
+    let mut open = Vec::new();
+    for e in &page.entries {
+        let v = serde_json::to_value(e).unwrap_or(serde_json::Value::Null);
+        let et = v.get("event_type").and_then(|x| x.as_str()).unwrap_or("");
+        if et == "ImpactCleared" {
+            break; // most-recent clear closes the single-timeline superset
+        }
+        if et == "ImpactDetected" || et == "ImpactEscalationRaised" {
+            open.push(v);
+        }
+    }
+    Json(json!({
+        "open_escalations": open,
+        "count": open.len(),
+        "note": "fleet-level superset — impact events carry no node id (see handler doc); attribution is Phase B",
+    }))
+    .into_response()
+}
+
+/// Pure supervisor-key decision (testable without env — INV-13 forbids `set_var`
+/// in multithreaded tests). REUSES the #255 mechanism: the value is the
+/// `KIRRA_SUPERVISOR_RESET_KEY`, constant-time compared. Fail-closed:
+/// unconfigured / empty / `> 64` bytes (INVARIANT #7) → 503; missing or
+/// mismatched provided key → 401.
+fn supervisor_key_ok(provided: Option<&str>, configured: Option<&str>) -> Result<(), StatusCode> {
+    let configured = configured.filter(|v| !v.is_empty()).ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    if configured.len() > 64 {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    let provided = provided.ok_or(StatusCode::UNAUTHORIZED)?;
+    if !constant_time_compare(provided.as_bytes(), configured.as_bytes()) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    Ok(())
+}
+
+/// Env-reading wrapper: pulls `KIRRA_SUPERVISOR_RESET_KEY` (env-only, INVARIANT
+/// #7) and the `x-kirra-supervisor-key` header, then delegates to
+/// [`supervisor_key_ok`].
+fn check_supervisor_key(headers: &HeaderMap) -> Result<(), StatusCode> {
+    let configured = std::env::var("KIRRA_SUPERVISOR_RESET_KEY").ok();
+    let provided = headers
+        .get("x-kirra-supervisor-key")
+        .and_then(|h| h.to_str().ok());
+    supervisor_key_ok(provided, configured.as_deref())
+}
+
+#[derive(Deserialize)]
+struct ClearanceGrantRequest {
+    node_id: String,
+    operator_id: String,
+}
+
+/// POST /console/clearance-grants — the ONE inbound console affordance.
+///
+/// **RECORD-ONLY (Phase A):** records + signs a supervisor clearance grant; it
+/// does NOT release the node (delivery to the node `ClearanceLoop` is Phase B).
+/// Auth = the #255 supervisor key (`x-kirra-supervisor-key`). The server stamps
+/// `granted_at_ms` from ITS clock — the client never supplies a timestamp (a
+/// client time would re-open the future-dating hole the loop's validation
+/// closes). Never mutates posture.
+async fn console_clearance_grant(
+    State(svc): State<Arc<ServiceState>>,
+    headers: HeaderMap,
+    Json(req): Json<ClearanceGrantRequest>,
+) -> impl IntoResponse {
+    let now = now_ms();
+
+    // 1. Supervisor authorization (reused #255 mechanism).
+    if let Err(code) = check_supervisor_key(&headers) {
+        // A *provided-but-rejected* attempt (401) is audited; a server-misconfig
+        // (503, key unset) is not an operator attempt. Never record key bytes.
+        if code == StatusCode::UNAUTHORIZED {
+            let payload = json!({
+                "reason": "unauthorized",
+                "node_id": req.node_id,
+                "operator_id": req.operator_id,
+            })
+            .to_string();
+            if let Ok(mut store) = svc.app.store.lock() {
+                let _ = store.append_clearance_audit_event(
+                    "OperatorClearanceGrantRejected", &payload, now);
+            }
+        }
+        return (code,
+                Json(json!({ "status": "rejected", "reason": "supervisor authorization failed" })))
+            .into_response();
+    }
+
+    // 2. Well-formedness, server-side (mirrors OperatorClearanceGrant::is_well_formed).
+    let operator_id = req.operator_id.trim();
+    if operator_id.is_empty() {
+        let payload = json!({ "reason": "empty_operator_id", "node_id": req.node_id }).to_string();
+        if let Ok(mut store) = svc.app.store.lock() {
+            let _ = store.append_clearance_audit_event(
+                "OperatorClearanceGrantRejected", &payload, now);
+        }
+        return (StatusCode::UNPROCESSABLE_ENTITY,
+                Json(json!({ "status": "rejected", "reason": "operator_id must be non-empty" })))
+            .into_response();
+    }
+    let registered = match svc.app.store.lock() {
+        Ok(store) => store.node_exists(&req.node_id).unwrap_or(false),
+        Err(_) => false,
+    };
+    if !registered {
+        let payload = json!({
+            "reason": "unregistered_node",
+            "node_id": req.node_id,
+            "operator_id": operator_id,
+        })
+        .to_string();
+        if let Ok(mut store) = svc.app.store.lock() {
+            let _ = store.append_clearance_audit_event(
+                "OperatorClearanceGrantRejected", &payload, now);
+        }
+        return (StatusCode::UNPROCESSABLE_ENTITY,
+                Json(json!({ "status": "rejected", "reason": "node_id is not a registered node" })))
+            .into_response();
+    }
+
+    // 3. Record + sign — RECORD-ONLY. Delivery is Phase B; posture is untouched.
+    match svc.app.store.lock() {
+        Ok(mut store) => match store.save_clearance_grant_chained(&req.node_id, operator_id, now) {
+            Ok(_id) => (StatusCode::OK, Json(json!({
+                "status": "recorded",
+                "delivery": "pending-phase-b",
+                "node_id": req.node_id,
+                "operator_id": operator_id,
+                "granted_at_ms": now,
+                "note": "grant recorded and signed; the vehicle is NOT released — delivery to the node ClearanceLoop is Phase B",
+            }))).into_response(),
+            Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
+                       Json(json!({ "status": "error", "reason": "persist failed" }))).into_response(),
+        },
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
+                   Json(json!({ "status": "error", "reason": "store lock poisoned" }))).into_response(),
+    }
+}
+
 /// Assembles the complete production router from a fully-initialized
 /// `ServiceState`. Extracted verbatim from `main()` (issue #72) so the EXACT
 /// assembled router can be exercised by the binary-internal posture-gate test
@@ -2703,6 +2962,18 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
         .allow_methods(Any)
         .allow_headers(Any);
 
+    // Operator console — Phase A (#103 SG6). Reads are QM; the one mutation
+    // (clearance-grant recording) is gated by the supervisor key IN the handler,
+    // so this group carries no auth layer. The whole `/console` plane is
+    // posture-exempt (gateway::policy_layer::is_posture_exempt) so it stays
+    // reachable during LockedOut — the posture it exists to recover from.
+    let console_routes = Router::new()
+        .route("/console", get(console_html))
+        .route("/console/fleet", get(console_fleet))
+        .route("/console/audit", get(console_audit))
+        .route("/console/escalations", get(console_escalations))
+        .route("/console/clearance-grants", post(console_clearance_grant));
+
     Router::new()
         .merge(probe_routes)
         .merge(identity_gated_routes)
@@ -2710,6 +2981,7 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
         .merge(actuator_routes)
         .merge(attestation_routes)
         .merge(read_routes)
+        .merge(console_routes)
         .with_state(svc_state.clone())
         .layer(cors)
         // Outermost layer: command-classification + posture-routing gate.
@@ -3639,5 +3911,210 @@ mod systemd_notify_tests {
         let mut buf = [0u8; 64];
         let n = listener.recv(&mut buf).expect("recv");
         assert_eq!(&buf[..n], b"READY=1", "the exact sd_notify datagram must be delivered");
+    }
+}
+
+// ===========================================================================
+// Operator console — Phase A tests (#103 SG6).
+// ===========================================================================
+#[cfg(test)]
+mod console_phase_a_tests {
+    use super::{build_app, supervisor_key_ok};
+
+    use std::sync::Arc;
+
+    use axum::body::{to_bytes, Body};
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt; // oneshot
+
+    use kirra_runtime_sdk::posture_cache::{ServiceState, SharedPostureCache};
+    use kirra_runtime_sdk::verifier::{
+        AppState, NodeTrustState, RegisteredNode, VerifierOperationMode,
+    };
+    use kirra_runtime_sdk::verifier_store::VerifierStore;
+
+    fn build_state() -> Arc<ServiceState> {
+        let store = VerifierStore::new(":memory:").expect("in-memory store");
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+        let posture_cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
+        Arc::new(ServiceState {
+            app,
+            posture_cache,
+            audit_verifying_key: None,
+            fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
+            fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
+            fabric_causal_log: Arc::new(
+                kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None),
+            ),
+            posture_engine_tx: std::sync::OnceLock::new(),
+            perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+            perception_monitor_enabled: false,
+        })
+    }
+
+    fn seed_node(svc: &Arc<ServiceState>, node_id: &str) {
+        let node = RegisteredNode {
+            node_id: node_id.to_string(),
+            status: NodeTrustState::Untrusted("post-collision latch".to_string()),
+            registered_at_ms: 1,
+            last_trust_update_ms: 1_700_000_000_000,
+            ak_public_pem: None,
+            expected_pcr16_digest_hex: None,
+        };
+        svc.app.persist_and_insert_node(node).expect("seed node");
+    }
+
+    async fn get(svc: Arc<ServiceState>, path: &str) -> (StatusCode, String) {
+        let resp = build_app(svc)
+            .oneshot(Request::builder().method("GET").uri(path).body(Body::empty()).unwrap())
+            .await
+            .expect("router");
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+        (status, String::from_utf8_lossy(&bytes).to_string())
+    }
+
+    #[tokio::test]
+    async fn console_html_is_served() {
+        let (status, body) = get(build_state(), "/console").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.contains("OPERATOR CONSOLE"), "the embedded UI must be served");
+    }
+
+    #[tokio::test]
+    async fn console_fleet_returns_seeded_node() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        let (status, body) = get(svc, "/console/fleet").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.contains("robot-01"), "fleet view must list the seeded node");
+        assert!(body.contains("Untrusted"), "posture mapped from NodeTrustState");
+        assert!(body.contains("post-collision latch"), "the Untrusted note carries through");
+    }
+
+    #[tokio::test]
+    async fn console_audit_returns_a_page() {
+        let (status, body) = get(build_state(), "/console/audit?limit=10").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.contains("\"entries\""), "audit page passthrough");
+        assert!(body.contains("\"chain_intact\""), "the chain-verified flag is exposed");
+    }
+
+    #[tokio::test]
+    async fn grant_without_supervisor_env_is_fail_closed_503() {
+        // No KIRRA_SUPERVISOR_RESET_KEY in the test env → fail-closed 503 (never
+        // a silent accept). The 401/422 paths require the env set, which a
+        // multithreaded test cannot do (INV-13); those are covered by the pure
+        // `supervisor_key_ok` truth table + the store-level audit/grant tests.
+        let svc = build_state();
+        let resp = build_app(svc)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/console/clearance-grants")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"node_id":"robot-01","operator_id":"alice"}"#))
+                    .unwrap(),
+            )
+            .await
+            .expect("router");
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn console_plane_is_posture_exempt_with_cold_cache() {
+        // `build_state()` has a COLD (None) posture cache. A non-exempt READ
+        // would be denied 503 by the posture gate on a cold cache (fail-closed) —
+        // the `/console` plane returns 200, proving it is posture-exempt
+        // (reachable to observe and recover, e.g. during LockedOut). Regression
+        // lock for `gateway::policy_layer::is_posture_exempt`.
+        let (status, _) = get(build_state(), "/console/fleet").await;
+        assert_eq!(status, StatusCode::OK, "the /console plane must be posture-exempt");
+    }
+
+    #[test]
+    fn supervisor_key_ok_truth_table() {
+        // unconfigured / empty / over-length → 503 (fail-closed, INV-7)
+        assert_eq!(supervisor_key_ok(Some("k"), None), Err(StatusCode::SERVICE_UNAVAILABLE));
+        assert_eq!(supervisor_key_ok(Some("k"), Some("")), Err(StatusCode::SERVICE_UNAVAILABLE));
+        let too_long = "x".repeat(65);
+        assert_eq!(supervisor_key_ok(Some("x"), Some(&too_long)), Err(StatusCode::SERVICE_UNAVAILABLE));
+        // configured but no / wrong key → 401 ("no auth → 401")
+        assert_eq!(supervisor_key_ok(None, Some("secret")), Err(StatusCode::UNAUTHORIZED));
+        assert_eq!(supervisor_key_ok(Some("wrong"), Some("secret")), Err(StatusCode::UNAUTHORIZED));
+        // correct key → Ok
+        assert_eq!(supervisor_key_ok(Some("secret"), Some("secret")), Ok(()));
+    }
+
+    #[test]
+    fn valid_grant_recorded_in_chain_with_pending_marker() {
+        let store = VerifierStore::new(":memory:").expect("store");
+        let app = AppState::new(store, VerifierOperationMode::Active);
+        {
+            let mut s = app.store.lock().unwrap();
+            s.save_clearance_grant_chained("robot-01", "alice", 1_700_000_000_000)
+                .expect("record grant");
+        }
+        let page = app.store.lock().unwrap().load_audit_chain_page(50, 0, None).expect("page");
+        let found = page.entries.iter().any(|e| {
+            let v = serde_json::to_value(e).unwrap();
+            v.get("event_type").and_then(|x| x.as_str()) == Some("OperatorClearanceGrantIssued")
+                && serde_json::to_string(&v).unwrap().contains("PENDING-NODE-TRANSPORT")
+        });
+        assert!(found, "the grant must be a signed chain event with the PENDING delivery marker");
+    }
+
+    #[test]
+    fn rejected_attempt_is_audited() {
+        let store = VerifierStore::new(":memory:").expect("store");
+        let app = AppState::new(store, VerifierOperationMode::Active);
+        {
+            let mut s = app.store.lock().unwrap();
+            s.append_clearance_audit_event(
+                "OperatorClearanceGrantRejected",
+                r#"{"reason":"empty_operator_id","node_id":"robot-01"}"#,
+                1_700_000_000_000,
+            )
+            .expect("audit reject");
+        }
+        let page = app.store.lock().unwrap().load_audit_chain_page(50, 0, None).expect("page");
+        assert!(
+            page.entries.iter().any(|e| serde_json::to_value(e).unwrap()
+                .get("event_type").and_then(|x| x.as_str()) == Some("OperatorClearanceGrantRejected")),
+            "a rejected attempt must leave a signed audit row"
+        );
+    }
+
+    #[test]
+    fn grant_never_mutates_posture() {
+        // The Phase-A honesty proof: recording a grant changes NO posture.
+        let store = VerifierStore::new(":memory:").expect("store");
+        let app = AppState::new(store, VerifierOperationMode::Active);
+        seed_node_app(&app, "robot-01");
+
+        let before = app.calculate_posture("robot-01");
+        {
+            let mut s = app.store.lock().unwrap();
+            s.save_clearance_grant_chained("robot-01", "alice", 1_700_000_000_000)
+                .expect("record grant");
+        }
+        let after = app.calculate_posture("robot-01");
+        assert_eq!(
+            serde_json::to_string(&before).unwrap(),
+            serde_json::to_string(&after).unwrap(),
+            "a recorded grant must NOT mutate posture (Phase A records; it does not release)"
+        );
+    }
+
+    fn seed_node_app(app: &AppState, node_id: &str) {
+        let node = RegisteredNode {
+            node_id: node_id.to_string(),
+            status: NodeTrustState::Untrusted("post-collision latch".to_string()),
+            registered_at_ms: 1,
+            last_trust_update_ms: 1_700_000_000_000,
+            ak_public_pem: None,
+            expected_pcr16_digest_hex: None,
+        };
+        app.persist_and_insert_node(node).expect("seed node");
     }
 }

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -417,6 +417,16 @@ pub async fn enforce_actuator_safety_envelope(
 /// as a follow-up against the safety docs.
 fn is_posture_exempt(path: &str) -> bool {
     matches!(path, "/health" | "/health/live" | "/ready" | "/metrics")
+        // Operator console (#103 SG6 / Phase A): the observe-and-recover plane.
+        // It MUST be reachable regardless of fleet posture — it is exactly the
+        // plane an operator uses to SEE a LockedOut fleet and record a supervisor
+        // clearance grant; a posture-gated console would lock the operator out of
+        // the recovery affordance when it is most needed. Its one mutation
+        // (`POST /console/clearance-grants`) is gated by the supervisor key IN THE
+        // HANDLER (an out-of-band operator action, not a fleet command), not by
+        // fleet posture. Reads under `/console` are QM.
+        || path == "/console"
+        || path.starts_with("/console/")
 }
 
 /// Global command-classification + posture-routing gate.

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -413,8 +413,11 @@ pub async fn enforce_actuator_safety_envelope(
 /// initially `None`, which `should_route_command` blocks unconditionally)
 /// and prevents external liveness probes from confirming the process is
 /// alive. The minimal allowlist below is liveness + metrics only;
-/// readiness MAY still reflect posture inside its own handler. Tracked
-/// as a follow-up against the safety docs.
+/// readiness MAY still reflect posture inside its own handler. The full
+/// exemption registry — liveness/observability + the `/console` plane — and the
+/// "`/console` is read-only EXCEPT the supervisor-key-gated grant" invariant are
+/// documented in the safety docs per #306. The set is pinned by
+/// `console_exemption_set_is_pinned` below.
 fn is_posture_exempt(path: &str) -> bool {
     matches!(path, "/health" | "/health/live" | "/ready" | "/metrics")
         // Operator console (#103 SG6 / Phase A): the observe-and-recover plane.
@@ -538,6 +541,33 @@ mod actuator_middleware_tests {
     use super::*;
     use crate::gateway::kinematics_contract::{ProposedVehicleCommand, VehicleKinematicsContract};
     use crate::verifier::FleetPosture;
+
+    /// Pin the posture-exemption set in BOTH directions (#306). The failure modes
+    /// it guards are asymmetric and both bad: silently GAINING an exemption
+    /// un-gates a real path; silently LOSING the `/console` exemption locks the
+    /// operator out of the recovery affordance exactly when the fleet is
+    /// LockedOut — the worst regression this file can have. A refactor of
+    /// `is_posture_exempt` must keep this green.
+    #[test]
+    fn console_exemption_set_is_pinned() {
+        // EXEMPT: liveness/observability + the whole /console plane (reads AND the
+        // supervisor-gated grant — the grant's gate is the key, not posture).
+        for p in [
+            "/health", "/health/live", "/ready", "/metrics",
+            "/console", "/console/fleet", "/console/audit",
+            "/console/escalations", "/console/clearance-grants",
+        ] {
+            assert!(is_posture_exempt(p), "{p} MUST be posture-exempt");
+        }
+        // NOT EXEMPT: prefix-confusion guard — a near-miss must not ride in on a
+        // loose prefix, and a normal gated path stays gated.
+        for p in [
+            "/consoleX", "/console-x", "/consol", "/con",
+            "/fleet/posture", "/attestation/register", "/",
+        ] {
+            assert!(!is_posture_exempt(p), "{p} must NOT be posture-exempt");
+        }
+    }
 
     /// The body cap must comfortably exceed a serialized worst-case
     /// ProposedVehicleCommand so the cap can never reject a legitimate

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -349,6 +349,22 @@ impl VerifierStore {
             [],
         )?;
 
+        // Operator clearance grants (#103 SG6 / operator-console Phase A).
+        // RECORD-ONLY: a row here is a recorded + audit-chained supervisor grant;
+        // it does NOT release any node. Delivery to the node's ClearanceLoop is
+        // Phase B (node transport) — `delivery` stays 'PENDING-NODE-TRANSPORT'.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS clearance_grants (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                node_id        TEXT    NOT NULL,
+                operator_id    TEXT    NOT NULL,
+                granted_at_ms  INTEGER NOT NULL,
+                delivery       TEXT    NOT NULL DEFAULT 'PENDING-NODE-TRANSPORT',
+                created_at_ms  INTEGER NOT NULL
+            )",
+            [],
+        )?;
+
         // AV subsystem metadata: confidence floors, telemetry timestamps, recovery streak.
         conn.execute(
             "CREATE TABLE IF NOT EXISTS av_subsystem_meta (
@@ -1222,6 +1238,78 @@ impl VerifierStore {
         )?;
         crate::audit_chain::AuditChainLinker::append_audit_event_tx(
             &tx, event_type, posture_json, created_at_ms as i64, self.signing_key.as_ref(),
+        )?;
+        tx.commit()
+    }
+
+    /// True iff `node_id` is a registered node — clearance-grant well-formedness
+    /// (operator-console Phase A; mirrors `OperatorClearanceGrant::is_well_formed`'s
+    /// "the node must exist" half).
+    pub fn node_exists(&self, node_id: &str) -> Result<bool> {
+        let n: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM nodes WHERE node_id = ?1",
+            params![node_id],
+            |row| row.get(0),
+        )?;
+        Ok(n > 0)
+    }
+
+    /// Persist a supervisor clearance grant — **RECORD-ONLY** (operator-console
+    /// Phase A). One transaction writes the `clearance_grants` row (Phase-B
+    /// pickup, `delivery = PENDING-NODE-TRANSPORT`) AND appends a signed,
+    /// hash-chained `OperatorClearanceGrantIssued` audit event. It records and
+    /// signs the grant; it does **NOT** release the node — delivery to the node's
+    /// `ClearanceLoop` is Phase B. Mirrors `save_posture_event_chained`'s
+    /// table+chain transaction. Does not touch nodes / posture. Returns the row id.
+    pub fn save_clearance_grant_chained(
+        &mut self,
+        node_id: &str,
+        operator_id: &str,
+        granted_at_ms: u64,
+    ) -> Result<i64> {
+        let payload = serde_json::json!({
+            "node_id": node_id,
+            "operator_id": operator_id,
+            "granted_at_ms": granted_at_ms,
+            "delivery": "PENDING-NODE-TRANSPORT",
+        })
+        .to_string();
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "INSERT INTO clearance_grants
+             (node_id, operator_id, granted_at_ms, delivery, created_at_ms)
+             VALUES (?1, ?2, ?3, 'PENDING-NODE-TRANSPORT', ?4)",
+            params![node_id, operator_id, granted_at_ms as i64, granted_at_ms as i64],
+        )?;
+        let id = tx.last_insert_rowid();
+        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
+            &tx,
+            "OperatorClearanceGrantIssued",
+            &payload,
+            granted_at_ms as i64,
+            self.signing_key.as_ref(),
+        )?;
+        tx.commit()?;
+        Ok(id)
+    }
+
+    /// Append a signed, hash-chained console audit event with **no** other table
+    /// write — used for REJECTED clearance attempts (unauthorized / malformed).
+    /// The `payload_json` must NEVER contain the supervisor key bytes (outcome +
+    /// reason + attempted ids only).
+    pub fn append_clearance_audit_event(
+        &mut self,
+        event_type: &str,
+        payload_json: &str,
+        created_at_ms: u64,
+    ) -> Result<()> {
+        let tx = self.conn.transaction()?;
+        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
+            &tx,
+            event_type,
+            payload_json,
+            created_at_ms as i64,
+            self.signing_key.as_ref(),
         )?;
         tx.commit()
     }

--- a/static/console.html
+++ b/static/console.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>KIRRA Operator Console — Phase A</title>
+<!--
+  Operator console, Phase A (#103 SG6). ONE self-contained file: inline CSS+JS,
+  no CDN, no build step — works air-gapped.
+
+  HONESTY RULE: this UI never claims more than the system did. The clearance
+  grant is RECORDED AND SIGNED; the vehicle is NOT released here. Release happens
+  when Phase B delivers the grant to the node's ClearanceLoop. No recovery
+  animation, no "released" state — a grant renders as
+  "GRANT RECORDED — DELIVERY PENDING (PHASE B)".
+
+  The supervisor key is held in memory for the session only — NEVER localStorage.
+-->
+<style>
+  :root { --bg:#0b0e13; --panel:#141a23; --line:#222c39; --ink:#d7e0ea; --dim:#8595a8;
+          --ok:#2ec27e; --warn:#e0a52b; --bad:#e0533b; --accent:#4a86e8; --pend:#7c8aa0; }
+  * { box-sizing:border-box; }
+  body { margin:0; font:14px/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+         background:var(--bg); color:var(--ink); }
+  header { display:flex; align-items:center; gap:18px; padding:12px 18px;
+           background:var(--panel); border-bottom:1px solid var(--line); flex-wrap:wrap; }
+  header h1 { font-size:15px; margin:0; letter-spacing:.5px; }
+  .badge { padding:2px 8px; border-radius:10px; font-size:11px; border:1px solid var(--line); color:var(--dim); }
+  .chainhead { color:var(--accent); }
+  main { display:grid; grid-template-columns:1fr 1fr; gap:14px; padding:14px; }
+  @media (max-width:880px){ main { grid-template-columns:1fr; } }
+  section { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:12px; min-width:0; }
+  section h2 { font-size:12px; text-transform:uppercase; letter-spacing:1px; color:var(--dim);
+               margin:0 0 10px; border-bottom:1px solid var(--line); padding-bottom:6px; }
+  .tiles { display:flex; flex-wrap:wrap; gap:8px; }
+  .tile { border:1px solid var(--line); border-radius:6px; padding:8px 10px; min-width:150px; }
+  .tile .nid { font-weight:600; }
+  .tile .note { color:var(--dim); font-size:12px; word-break:break-word; }
+  .p-Trusted { border-left:3px solid var(--ok); }
+  .p-Untrusted { border-left:3px solid var(--warn); }
+  .p-Unknown { border-left:3px solid var(--pend); }
+  .pill { display:inline-block; padding:1px 7px; border-radius:9px; font-size:11px; }
+  .pill.Trusted{ background:rgba(46,194,126,.15); color:var(--ok); }
+  .pill.Untrusted{ background:rgba(224,165,43,.15); color:var(--warn); }
+  .pill.Unknown{ background:rgba(124,138,160,.15); color:var(--pend); }
+  .feed { max-height:340px; overflow:auto; }
+  .row { border-bottom:1px solid var(--line); padding:6px 0; font-size:12px; }
+  .row .et { color:var(--accent); }
+  .row .sig-verified { color:var(--ok); } .row .sig-unsigned,.row .sig-unverified { color:var(--warn); }
+  .row pre { margin:4px 0 0; color:var(--dim); white-space:pre-wrap; word-break:break-word; font-size:11px; }
+  label { display:block; margin:8px 0 3px; color:var(--dim); font-size:12px; }
+  input { width:100%; background:var(--bg); border:1px solid var(--line); color:var(--ink);
+          border-radius:5px; padding:7px; font:inherit; }
+  button { margin-top:12px; background:var(--accent); color:#fff; border:0; border-radius:5px;
+           padding:8px 14px; font:inherit; cursor:pointer; }
+  button:disabled { opacity:.5; cursor:default; }
+  .result { margin-top:10px; padding:9px; border-radius:5px; font-size:13px; display:none; }
+  .result.recorded { display:block; background:rgba(74,134,232,.12); border:1px solid var(--accent); }
+  .result.rejected { display:block; background:rgba(224,83,59,.12); border:1px solid var(--bad); color:var(--bad); }
+  .result .pend { color:var(--warn); font-weight:600; }
+  .empty { color:var(--dim); font-style:italic; }
+  footer { padding:12px 18px; color:var(--dim); font-size:11px; border-top:1px solid var(--line);
+           background:var(--panel); line-height:1.6; }
+  .err { color:var(--bad); }
+</style>
+</head>
+<body>
+<header>
+  <h1>KIRRA · OPERATOR CONSOLE</h1>
+  <span class="badge">PHASE A · read views + authenticated grant recording</span>
+  <span class="badge">chain head: <span class="chainhead" id="chainhead">—</span></span>
+  <span class="badge" id="chainint">chain: —</span>
+  <span class="badge" id="conn">polling…</span>
+</header>
+
+<main>
+  <section>
+    <h2>Fleet posture</h2>
+    <div class="tiles" id="fleet"><span class="empty">loading…</span></div>
+  </section>
+
+  <section>
+    <h2>Escalation docket (SG6, open)</h2>
+    <div id="escalations"><span class="empty">loading…</span></div>
+  </section>
+
+  <section>
+    <h2>Supervisor clearance grant <span class="badge">RECORD-ONLY · delivery = Phase B</span></h2>
+    <form id="grantform" autocomplete="off">
+      <label for="node_id">Node id (must be registered)</label>
+      <input id="node_id" name="node_id" required>
+      <label for="operator_id">Operator id</label>
+      <input id="operator_id" name="operator_id" required>
+      <label for="supkey">Supervisor key (held in memory for this session only — never stored)</label>
+      <input id="supkey" name="supkey" type="password" required>
+      <button type="submit" id="grantbtn">Record clearance grant</button>
+    </form>
+    <div class="result" id="grantresult"></div>
+  </section>
+
+  <section>
+    <h2>Audit chain feed</h2>
+    <div class="feed" id="audit"><span class="empty">loading…</span></div>
+  </section>
+</main>
+
+<footer>
+  <strong>QM domain.</strong> This console is a <em>read-only view</em> of the
+  verifier's real store, plus <em>one</em> authenticated affordance: recording a
+  supervisor clearance grant. It does not — and in Phase A cannot — release a
+  vehicle: a grant is recorded and cryptographically signed into the audit chain;
+  delivery to the node's <code>ClearanceLoop</code> is Phase B. The governor
+  judges; this UI does not. Posture-exempt so it stays reachable during LockedOut.
+</footer>
+
+<script>
+"use strict";
+const POLL_MS = 4000;
+const enc = (s) => String(s == null ? "" : s);
+function esc(s){ return enc(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+
+async function getJSON(path){
+  const r = await fetch(path, { headers: { "accept":"application/json" } });
+  if(!r.ok) throw new Error(path+" → "+r.status);
+  return r.json();
+}
+
+function renderFleet(d){
+  const el = document.getElementById("fleet");
+  const fleet = (d && d.fleet) || [];
+  if(!fleet.length){ el.innerHTML = '<span class="empty">no registered nodes</span>'; return; }
+  el.innerHTML = fleet.map(n => {
+    const p = esc(n.posture||"Unknown");
+    const note = n.note ? '<div class="note">'+esc(n.note)+'</div>' : '';
+    const seen = n.last_seen_ms ? new Date(Number(n.last_seen_ms)).toISOString().replace('T',' ').replace('Z','') : '—';
+    return '<div class="tile p-'+p+'"><div class="nid">'+esc(n.node_id)+
+           ' <span class="pill '+p+'">'+p+'</span></div>'+note+
+           '<div class="note">last seen: '+esc(seen)+'</div></div>';
+  }).join("");
+}
+
+function payloadOf(e){
+  // field-tolerant: the page rows carry whatever they carry — show what's there.
+  return e.event_json ?? e.payload ?? e.posture_json ?? null;
+}
+function sigOf(e){ return e.signature_status ?? (e.signature ? "signed" : "unsigned"); }
+
+function renderEscalations(d){
+  const el = document.getElementById("escalations");
+  const open = (d && d.open_escalations) || [];
+  if(!open.length){ el.innerHTML = '<span class="empty">no open escalations</span>'; return; }
+  el.innerHTML = '<div class="note" style="color:var(--dim);font-size:11px;margin-bottom:6px">'+
+    esc((d && d.note) || "")+'</div>' + open.map(e => {
+      const pl = payloadOf(e);
+      return '<div class="row"><span class="et">'+esc(e.event_type||"?")+'</span>'+
+        (e.sequence!=null?(' · seq '+esc(e.sequence)):'')+
+        (pl?('<pre>'+esc(typeof pl==="string"?pl:JSON.stringify(pl))+'</pre>'):'')+'</div>';
+  }).join("");
+}
+
+function renderAudit(d){
+  const el = document.getElementById("audit");
+  const entries = (d && d.entries) || [];
+  const head = entries[0] || null;
+  document.getElementById("chainhead").textContent = head ? (head.sequence ?? head.id ?? "—") : "—";
+  const ci = document.getElementById("chainint");
+  if(d && typeof d.chain_intact === "boolean"){
+    ci.textContent = "chain: " + (d.chain_intact ? "verified ✓" : "BROKEN ✗");
+    ci.style.color = d.chain_intact ? "var(--ok)" : "var(--bad)";
+  }
+  if(!entries.length){ el.innerHTML = '<span class="empty">no audit entries</span>'; return; }
+  el.innerHTML = entries.map(e => {
+    const sig = esc(sigOf(e)); const pl = payloadOf(e);
+    const sigcls = /verif/i.test(sig) ? "sig-verified" : (/unsigned/i.test(sig)?"sig-unsigned":"sig-unverified");
+    return '<div class="row"><span class="et">'+esc(e.event_type||"?")+'</span>'+
+      (e.sequence!=null?(' · seq '+esc(e.sequence)):'')+
+      ' · <span class="'+sigcls+'">'+sig+'</span>'+
+      (e.key_id?(' · key '+esc(e.key_id)):'')+
+      (pl?('<pre>'+esc(typeof pl==="string"?pl:JSON.stringify(pl))+'</pre>'):'')+'</div>';
+  }).join("");
+}
+
+async function poll(){
+  const conn = document.getElementById("conn");
+  try {
+    const [fleet, esc_, audit] = await Promise.all([
+      getJSON("/console/fleet"), getJSON("/console/escalations"), getJSON("/console/audit?limit=50"),
+    ]);
+    renderFleet(fleet); renderEscalations(esc_); renderAudit(audit);
+    conn.textContent = "updated " + new Date().toLocaleTimeString(); conn.classList.remove("err");
+  } catch(e){ conn.textContent = "poll error: "+e.message; conn.classList.add("err"); }
+}
+
+document.getElementById("grantform").addEventListener("submit", async (ev) => {
+  ev.preventDefault();
+  const btn = document.getElementById("grantbtn");
+  const res = document.getElementById("grantresult");
+  const node_id = document.getElementById("node_id").value.trim();
+  const operator_id = document.getElementById("operator_id").value.trim();
+  const supkey = document.getElementById("supkey").value; // in-memory only; never stored
+  btn.disabled = true; res.className = "result"; res.style.display = "none";
+  try {
+    const r = await fetch("/console/clearance-grants", {
+      method: "POST",
+      headers: { "content-type":"application/json", "x-kirra-supervisor-key": supkey },
+      body: JSON.stringify({ node_id, operator_id }),
+    });
+    const body = await r.json().catch(() => ({}));
+    if(r.ok && body.status === "recorded"){
+      res.className = "result recorded";
+      res.innerHTML = '<span class="pend">GRANT RECORDED — DELIVERY PENDING (PHASE B)</span><br>'+
+        'node <b>'+esc(body.node_id)+'</b> · operator <b>'+esc(body.operator_id)+'</b> · '+
+        'granted_at '+esc(body.granted_at_ms)+'<br>'+
+        '<span style="color:var(--dim)">'+esc(body.note||"")+'</span>';
+      document.getElementById("supkey").value = ""; // drop the key from the field
+      poll();
+    } else {
+      res.className = "result rejected";
+      res.innerHTML = 'REJECTED ('+r.status+'): '+esc(body.reason || "request refused");
+    }
+  } catch(e){
+    res.className = "result rejected"; res.innerHTML = "REJECTED: "+esc(e.message);
+  } finally {
+    document.getElementById("supkey").value = ""; // never retain the key
+    btn.disabled = false;
+  }
+});
+
+poll();
+setInterval(poll, POLL_MS);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Operator console — Phase A: read views + authenticated grant recording (#304)

A real UI served by `kirra_verifier_service` against **real store data**, plus the **one** authenticated inbound affordance — recording a supervisor clearance grant. **No new dependencies** (axum 0.8 + tower-http already present); the UI is **one self-contained file** embedded via `include_str!`. Talisman untouched.

### The phase plan
- **Phase A (this PR):** observe + **record-and-sign** a grant. Delivery to the node is out of scope.
- **Phase B (deferred — the #267 / #103 deferral):** grant **transport to the node's `ClearanceLoop`** — node-side pickup of the `clearance_grants` rows, delivery, and the actual release.

### The honesty rule (load-bearing)
**Nothing here releases a vehicle.** The grant is *recorded and cryptographically signed* into the audit chain (`OperatorClearanceGrantIssued`, `delivery = PENDING-NODE-TRANSPORT`); the response, the audit payload, and the UI all say `delivery: pending-phase-b`. The UI renders **"GRANT RECORDED — DELIVERY PENDING (PHASE B)"** — the mockup's recovery-tick animation is deliberately **absent** (it would display a release that hasn't happened). A test asserts the grant **never mutates posture**.

### Read endpoints (QM)
`GET /console` (embedded UI) · `/console/fleet` (per-node posture from `load_nodes` — posture from `NodeTrustState`, the Untrusted note, last_seen) · `/console/audit` (passthrough to `load_audit_chain_page`) · `/console/escalations` (derived open SG6 escalations).

Two grounded honesty notes in the handlers:
- `load_audit_chain_page` is **offset-paginated** (DESC by id), not before-seq — the console pages by offset; I documented this rather than fake a `before` cursor.
- The SG6 impact events **carry no node id** (`ImpactDetectedPayload`), so `/console/escalations` returns the **conservative fleet-level superset** with the ambiguity documented; per-node attribution is Phase B.

### POST /console/clearance-grants (the one inbound affordance)
- **Auth reuses the #255 supervisor mechanism**: `KIRRA_SUPERVISOR_RESET_KEY` (env-only, INV-7), `constant_time_compare`d, over an `x-kirra-supervisor-key` header. Unconfigured/empty/>64B → 503; missing/bad key → 401 + an audited rejected attempt (**key bytes never recorded**).
- **Server stamps `granted_at_ms` from its clock** — the client never supplies a timestamp (no future-dating).
- Well-formedness mirrors `OperatorClearanceGrant::is_well_formed` (non-empty `operator_id`; `node_id` must be registered) → 422 + `OperatorClearanceGrantRejected` audit.
- Success → `save_clearance_grant_chained` (a `clearance_grants` row for Phase-B pickup **and** the signed chain event) → `{status:"recorded", delivery:"pending-phase-b"}`.

### One required `src/` touch (flagged)
`src/gateway/policy_layer.rs::is_posture_exempt` now covers the `/console` plane — **load-bearing**: the console must be reachable **during LockedOut** (that's exactly when an operator records a clearance). The grant's real gate is the supervisor key in the handler, not fleet posture (it's an out-of-band operator action, not a fleet command). This is the only change outside the listed scope; it's in `src/`, not parko, no deps.

### Persistence
`verifier_store` gains the `clearance_grants` table + `node_exists` / `save_clearance_grant_chained` / `append_clearance_audit_event`, mirroring `save_posture_event_chained`'s table + signed-chain transaction.

### Verified
`cargo test` green — **9 console** + 37 bin + policy_layer 8 + verifier_store 64; **clippy clean**; **no new Cargo deps** (Cargo.toml untouched); diff = the 3 `src/` files + `static/console.html`; talisman `997fb7ae…` byte-identical. (The env-gated 401/422 HTTP paths are covered via the pure `supervisor_key_ok` truth table + store-level audit/grant tests, because INV-13 forbids `set_var` in multithreaded tests.)

References #304, #103, #267.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_