### PR TITLE
feat(clearance): Phase B — store-level grant delivery to ClearanceLoop (one-shot consume, two-checkpoint validation) (#304)

### DIFF
--- a/parko/crates/parko-kirra/src/clearance_delivery.rs
+++ b/parko/crates/parko-kirra/src/clearance_delivery.rs
@@ -1,0 +1,260 @@
+//! Clearance delivery — node-side Phase B (#304, the #267 deferral).
+//!
+//! Delivers operator clearance grants recorded by the verifier (operator-console
+//! Phase A) to this node's [`ClearanceLoop`].
+//!
+//! **Transport (the decision):** store-level pickup over the shared per-vehicle
+//! [`VerifierStore`] — the SAME channel the #247/#263 audit sinks already use;
+//! **zero new dependencies**.
+//!
+//! **Co-location assumption (stated):** the node and the vehicle's verifier share
+//! the store (one vehicle, one store); the fleet/federation layer is *above* this.
+//! A remote-node wire transport (HTTP / Zenoh) is the future variant — OUT OF SCOPE.
+//!
+//! **Two-checkpoint validation (the held line):** the verifier validates a grant at
+//! RECORD time (Phase A: non-empty operator, registered node). This component
+//! re-validates at DELIVERY time via [`ClearanceLoop::try_clear`] with
+//! `now = pickup time` — so a grant that sat past `max_grant_age_ms` is REJECTED at
+//! the loop even though the verifier accepted it. **Verifier validation is not a
+//! substitute for loop validation.**
+//!
+//! **No retry (the held line):** a rejected-or-stale grant is CONSUMED (one-shot)
+//! and never retried — the operator re-issues through the console. Automatic retry
+//! of a dead grant would be a replay machine.
+
+use std::sync::{Arc, Mutex};
+
+use kirra_runtime_sdk::verifier_store::VerifierStore;
+use parko_core::{ClearanceLoop, OperatorClearanceGrant, DEFAULT_MAX_GRANT_AGE_MS};
+
+/// The result of one [`ClearanceDelivery::poll_and_deliver`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeliveryOutcome {
+    /// No pending grant for this node — pickup is idempotent-empty; the loop is
+    /// untouched.
+    NoGrant,
+    /// A grant was delivered and CLEARED the loop (→ `Normal`).
+    Cleared { operator_id: String, grant_rowid: i64 },
+    /// A grant was picked up but the loop REJECTED it (stale / malformed /
+    /// not-immobilized). It is CONSUMED (never retried); the loop stays as it was.
+    Rejected { reason: &'static str, grant_rowid: i64 },
+    /// The store could not be consulted — fail-closed: nothing is cleared.
+    StoreError,
+}
+
+/// Node-side clearance delivery. Holds the shared store handle + this node's id —
+/// the same shape as the `parko-kirra` audit sinks (the #247 crossing).
+pub struct ClearanceDelivery {
+    store: Arc<Mutex<VerifierStore>>,
+    node_id: String,
+    max_grant_age_ms: u64,
+}
+
+impl ClearanceDelivery {
+    pub fn new(store: Arc<Mutex<VerifierStore>>, node_id: impl Into<String>) -> Self {
+        Self {
+            store,
+            node_id: node_id.into(),
+            max_grant_age_ms: DEFAULT_MAX_GRANT_AGE_MS,
+        }
+    }
+
+    /// Override the grant-age ceiling (default [`DEFAULT_MAX_GRANT_AGE_MS`]).
+    #[must_use]
+    pub fn with_max_grant_age_ms(mut self, ms: u64) -> Self {
+        self.max_grant_age_ms = ms;
+        self
+    }
+
+    /// Take at most one pending grant and deliver it to `clearance_loop`.
+    ///
+    /// CALL SITE: per tick while [`ClearanceLoop::escalation_pending`], or on a
+    /// slow cadence — both are correct because pickup is idempotent-empty when no
+    /// grant exists (an extra call is a `NoGrant` no-op). The grant is CONSUMED at
+    /// pickup, BEFORE the loop verdict, so a rejected grant is never retried.
+    /// (parko-ros2 node wiring is the deploy step, consistent with prior deferrals.)
+    pub fn poll_and_deliver(
+        &self,
+        clearance_loop: &mut ClearanceLoop,
+        now_ms: u64,
+    ) -> DeliveryOutcome {
+        // 1. ONE-SHOT CONSUME — the grant is now spent regardless of the verdict.
+        let row = {
+            let store = match self.store.lock() {
+                Ok(s) => s,
+                Err(_) => return DeliveryOutcome::StoreError,
+            };
+            match store.take_pending_clearance_grant(&self.node_id, now_ms) {
+                Ok(Some(r)) => r,
+                Ok(None) => return DeliveryOutcome::NoGrant,
+                Err(_) => return DeliveryOutcome::StoreError,
+            }
+        };
+
+        // 2. CHECKPOINT 2 — the loop re-validates at DELIVERY time. `granted_at_ms`
+        //    is the verifier's RECORD time (from the row), `now_ms` is pickup time:
+        //    a grant older than `max_grant_age_ms` is rejected HERE even though the
+        //    verifier accepted it at record time.
+        let grant = OperatorClearanceGrant {
+            operator_id: row.operator_id.clone(),
+            granted_at_ms: row.granted_at_ms,
+        };
+        let verdict = clearance_loop.try_clear(&grant, now_ms, self.max_grant_age_ms);
+
+        // 3. Record the outcome (signed). Consumed either way — NO retry.
+        let mut store = match self.store.lock() {
+            Ok(s) => s,
+            Err(_) => return DeliveryOutcome::StoreError,
+        };
+        match verdict {
+            Ok(()) => {
+                let _ = store.record_grant_outcome(row.rowid, "Cleared", None, now_ms);
+                DeliveryOutcome::Cleared {
+                    operator_id: row.operator_id,
+                    grant_rowid: row.rowid,
+                }
+            }
+            Err(rej) => {
+                let reason = rej.reason_code();
+                let _ = store.record_grant_outcome(row.rowid, reason, Some(reason), now_ms);
+                DeliveryOutcome::Rejected {
+                    reason,
+                    grant_rowid: row.rowid,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parko_core::{ClearanceState, ImpactCfg, ImpactEvidence};
+
+    fn store() -> Arc<Mutex<VerifierStore>> {
+        Arc::new(Mutex::new(VerifierStore::new(":memory:").expect("in-memory store")))
+    }
+
+    fn record_grant(s: &Arc<Mutex<VerifierStore>>, node: &str, op: &str, granted_at_ms: u64) {
+        s.lock()
+            .unwrap()
+            .save_clearance_grant_chained(node, op, granted_at_ms)
+            .expect("record grant (Phase-A path)");
+    }
+
+    fn immobilized_loop() -> ClearanceLoop {
+        let mut l = ClearanceLoop::new();
+        let ev = ImpactEvidence {
+            imu_accel_spike_mps2: 0.0,
+            contact_sensor: true,
+            vanished_object: false,
+        };
+        let cfg = ImpactCfg::default();
+        l.observe(&ev, &cfg, 0); // Normal -> Latched
+        l.observe(&ev, &cfg, 0); // Latched -> EscalationRaised (immobilized)
+        assert!(l.is_immobilized() && l.escalation_pending());
+        l
+    }
+
+    fn audit_has(s: &Arc<Mutex<VerifierStore>>, event_type: &str) -> bool {
+        let page = s.lock().unwrap().load_audit_chain_page(200, 0, None).unwrap();
+        page.entries.iter().any(|e| {
+            serde_json::to_value(e)
+                .unwrap()
+                .get("event_type")
+                .and_then(|x| x.as_str())
+                == Some(event_type)
+        })
+    }
+
+    #[test]
+    fn record_then_deliver_clears_loop() {
+        let s = store();
+        record_grant(&s, "robot-01", "alice", 1_000);
+        let mut l = immobilized_loop();
+        let d = ClearanceDelivery::new(s.clone(), "robot-01");
+
+        let out = d.poll_and_deliver(&mut l, 1_500); // within the age window
+        assert!(matches!(out, DeliveryOutcome::Cleared { .. }), "got {out:?}");
+        assert_eq!(l.state(), ClearanceState::Normal, "loop cleared to Normal");
+        assert!(audit_has(&s, "ClearanceDelivered"), "ClearanceDelivered audit present");
+
+        let st = s.lock().unwrap().latest_clearance_grant("robot-01").unwrap().unwrap();
+        assert_eq!(st.outcome.as_deref(), Some("Cleared"));
+        assert!(st.consumed_at_ms.is_some(), "grant consumed");
+    }
+
+    #[test]
+    fn stale_at_delivery_rejected_consumed_then_fresh_grant_clears() {
+        let s = store();
+        record_grant(&s, "robot-01", "alice", 1_000);
+        let mut l = immobilized_loop();
+        let d = ClearanceDelivery::new(s.clone(), "robot-01");
+
+        // pickup far past DEFAULT_MAX_GRANT_AGE_MS → loop rejects (checkpoint 2).
+        let stale_now = 1_000 + DEFAULT_MAX_GRANT_AGE_MS + 1;
+        let out = d.poll_and_deliver(&mut l, stale_now);
+        assert!(
+            matches!(out, DeliveryOutcome::Rejected { reason: "malformed_grant", .. }),
+            "a grant the verifier accepted is still rejected at delivery if stale; got {out:?}"
+        );
+        assert!(l.is_immobilized(), "loop still immobilized after a stale grant");
+        assert!(audit_has(&s, "ClearanceDeliveryRejected"));
+
+        // the stale grant is CONSUMED — a second pickup finds nothing (no retry).
+        assert_eq!(d.poll_and_deliver(&mut l, stale_now + 1), DeliveryOutcome::NoGrant);
+
+        // the operator RE-ISSUES a fresh grant through the console → clears.
+        record_grant(&s, "robot-01", "alice", stale_now + 2);
+        let out2 = d.poll_and_deliver(&mut l, stale_now + 3);
+        assert!(matches!(out2, DeliveryOutcome::Cleared { .. }), "fresh grant clears; got {out2:?}");
+        assert_eq!(l.state(), ClearanceState::Normal);
+    }
+
+    #[test]
+    fn one_shot_second_take_gets_none() {
+        let s = store();
+        record_grant(&s, "robot-01", "alice", 1_000);
+        let first = s.lock().unwrap().take_pending_clearance_grant("robot-01", 1_100).unwrap();
+        let second = s.lock().unwrap().take_pending_clearance_grant("robot-01", 1_101).unwrap();
+        assert!(first.is_some(), "first take gets the grant");
+        assert!(second.is_none(), "second take gets None — exactly-once consume");
+    }
+
+    #[test]
+    fn empty_pickup_is_noop() {
+        let s = store();
+        let mut l = immobilized_loop();
+        let before = l.state();
+        let d = ClearanceDelivery::new(s.clone(), "robot-01");
+
+        assert_eq!(d.poll_and_deliver(&mut l, 1_000), DeliveryOutcome::NoGrant);
+        assert_eq!(l.state(), before, "loop untouched on empty pickup");
+        assert!(!audit_has(&s, "ClearanceDelivered"));
+        assert!(!audit_has(&s, "ClearanceDeliveryRejected"));
+    }
+
+    #[test]
+    fn malformed_row_defense_empty_operator_rejected_consumed() {
+        // Defense-in-depth: Phase A validates operator_id, but if a row somehow
+        // carried an empty operator_id, the loop rejects it (malformed), the grant
+        // is consumed, and it is audited. (We insert the degenerate row directly.)
+        let s = store();
+        s.lock().unwrap().save_clearance_grant_chained("robot-01", "", 1_000).expect("record");
+        let mut l = immobilized_loop();
+        let d = ClearanceDelivery::new(s.clone(), "robot-01");
+
+        let out = d.poll_and_deliver(&mut l, 1_100);
+        assert!(
+            matches!(out, DeliveryOutcome::Rejected { reason: "malformed_grant", .. }),
+            "got {out:?}"
+        );
+        assert!(l.is_immobilized());
+        assert!(audit_has(&s, "ClearanceDeliveryRejected"));
+        assert_eq!(
+            d.poll_and_deliver(&mut l, 1_101),
+            DeliveryOutcome::NoGrant,
+            "consumed, not retried"
+        );
+    }
+}

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -56,9 +56,11 @@ use parko_core::{
 
 pub mod angular_bound;
 pub mod audit_sink;
+pub mod clearance_delivery;
 pub mod comparator;
 pub mod diverse;
 pub use angular_bound::{AngularVelocityBound, PlatformParams, ROLLOVER_MIN_LINEAR_VELOCITY_MPS};
+pub use clearance_delivery::{ClearanceDelivery, DeliveryOutcome};
 pub use audit_sink::{
     select_divergence_sink, select_impact_sink, AuditChainLinkerDivergenceSink, FatalAuditConfig,
     ImpactAuditSink, ImpactClearanceRejectedPayload, ImpactClearedPayload, ImpactDetectedPayload,

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -2657,17 +2657,18 @@ async fn console_html() -> impl IntoResponse {
 /// (`load_nodes`). QM read. `note` is the Untrusted reason carried on the node's
 /// trust state (the latest trust note); `null` for Trusted/Unknown.
 async fn console_fleet(State(svc): State<Arc<ServiceState>>) -> impl IntoResponse {
-    let nodes = match svc.app.store.lock() {
-        Ok(store) => match store.load_nodes() {
-            Ok(n) => n,
-            Err(_) => {
-                return (StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({ "error": "load_nodes failed" }))).into_response()
-            }
-        },
+    let store = match svc.app.store.lock() {
+        Ok(s) => s,
         Err(_) => {
             return (StatusCode::INTERNAL_SERVER_ERROR,
                     Json(json!({ "error": "store lock poisoned" }))).into_response()
+        }
+    };
+    let nodes = match store.load_nodes() {
+        Ok(n) => n,
+        Err(_) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": "load_nodes failed" }))).into_response()
         }
     };
     let fleet: Vec<_> = nodes
@@ -2678,11 +2679,16 @@ async fn console_fleet(State(svc): State<Arc<ServiceState>>) -> impl IntoRespons
                 NodeTrustState::Untrusted(reason) => ("Untrusted", Some(reason.clone())),
                 NodeTrustState::Unknown => ("Unknown", None),
             };
+            // Phase B: the latest clearance grant's delivery state (or null). The
+            // UI derives the lifecycle label (pending / delivered:Cleared /
+            // delivery-rejected:reason) from these raw columns — no invented state.
+            let clearance = store.latest_clearance_grant(&n.node_id).ok().flatten();
             json!({
                 "node_id": n.node_id,
                 "posture": posture,
                 "note": note,
                 "last_seen_ms": n.last_trust_update_ms,
+                "clearance": clearance,
             })
         })
         .collect();

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -71,6 +71,29 @@ pub struct AuditExportPage {
     pub chain_intact: bool,
 }
 
+/// A pending clearance grant taken for delivery (operator-console Phase B, #304).
+#[derive(Debug, Clone)]
+pub struct PendingClearanceGrant {
+    pub rowid: i64,
+    pub node_id: String,
+    pub operator_id: String,
+    /// The verifier's RECORD time (Phase A), NOT the pickup time. The
+    /// `ClearanceLoop` ages the grant against this at delivery (checkpoint 2).
+    pub granted_at_ms: u64,
+}
+
+/// The latest clearance grant's delivery state for a node (console read surface).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ClearanceGrantState {
+    pub granted_at_ms: u64,
+    /// Set once the grant has been taken for delivery (the one-shot consume).
+    pub consumed_at_ms: Option<u64>,
+    /// `"Cleared"` on success, else the loop's rejection reason code. `None`
+    /// while still pending delivery.
+    pub outcome: Option<String>,
+    pub outcome_detail: Option<String>,
+}
+
 // --- HA epoch fence — fail-closed outcomes (issue #79) ----------------------
 
 /// Why the in-transaction HA epoch fence rejected a top-tier durable write.
@@ -360,10 +383,29 @@ impl VerifierStore {
                 operator_id    TEXT    NOT NULL,
                 granted_at_ms  INTEGER NOT NULL,
                 delivery       TEXT    NOT NULL DEFAULT 'PENDING-NODE-TRANSPORT',
-                created_at_ms  INTEGER NOT NULL
+                created_at_ms  INTEGER NOT NULL,
+                consumed_at_ms INTEGER,
+                outcome        TEXT,
+                outcome_detail TEXT
             )",
             [],
         )?;
+        // Phase-B delivery columns (additive, idempotent — upgrade a Phase-A
+        // clearance_grants table that predates these). `consumed_at_ms` is the
+        // one-shot consume marker; `outcome`/`outcome_detail` are the
+        // ClearanceLoop verdict at delivery. Mirrors the audit_log_chain
+        // ADD-COLUMN migration convention below.
+        for col_sql in [
+            "ALTER TABLE clearance_grants ADD COLUMN consumed_at_ms INTEGER",
+            "ALTER TABLE clearance_grants ADD COLUMN outcome TEXT",
+            "ALTER TABLE clearance_grants ADD COLUMN outcome_detail TEXT",
+        ] {
+            if let Err(e) = conn.execute(col_sql, []) {
+                if !e.to_string().contains("duplicate column name") {
+                    return Err(e);
+                }
+            }
+        }
 
         // AV subsystem metadata: confidence floors, telemetry timestamps, recovery streak.
         conn.execute(
@@ -1312,6 +1354,104 @@ impl VerifierStore {
             self.signing_key.as_ref(),
         )?;
         tx.commit()
+    }
+
+    /// **THE ONE-SHOT CONSUME** (operator-console Phase B). In a SINGLE atomic
+    /// `UPDATE … RETURNING`, marks the OLDEST unconsumed grant for `node_id`
+    /// consumed (`consumed_at_ms = now_ms`) and returns it. A grant can be taken
+    /// **exactly once, ever** — double-pickup is impossible by the
+    /// `consumed_at_ms IS NULL` guard combined with the atomic single-statement
+    /// update (SQLite serializes writers), NOT by convention. This is the
+    /// store-level verify-then-consume pattern — the same single-use discipline
+    /// as the attestation nonce (`AppState::consume_challenge`, `src/verifier.rs`:
+    /// atomically removes the pending entry so a replay finds nothing). Returns
+    /// `None` when no pending grant exists (idempotent-empty pickup).
+    pub fn take_pending_clearance_grant(
+        &self,
+        node_id: &str,
+        now_ms: u64,
+    ) -> Result<Option<PendingClearanceGrant>> {
+        use rusqlite::OptionalExtension;
+        self.conn
+            .query_row(
+                "UPDATE clearance_grants
+                    SET consumed_at_ms = ?2
+                  WHERE id = (
+                    SELECT id FROM clearance_grants
+                     WHERE node_id = ?1 AND consumed_at_ms IS NULL
+                     ORDER BY id ASC LIMIT 1)
+                  RETURNING id, node_id, operator_id, granted_at_ms",
+                params![node_id, now_ms as i64],
+                |row| {
+                    Ok(PendingClearanceGrant {
+                        rowid: row.get(0)?,
+                        node_id: row.get(1)?,
+                        operator_id: row.get(2)?,
+                        granted_at_ms: row.get::<_, i64>(3)? as u64,
+                    })
+                },
+            )
+            .optional()
+    }
+
+    /// Record a delivered grant's OUTCOME (operator-console Phase B): the
+    /// `ClearanceLoop` verdict at delivery, plus the chained audit event — ONE
+    /// signed transaction, same shape as Phase A's writes. `outcome == "Cleared"`
+    /// → a `ClearanceDelivered` event; any other `outcome` (a rejection reason
+    /// code) → a `ClearanceDeliveryRejected` event. `now_ms` is supplied (no
+    /// `SystemTime::now()` in the store).
+    pub fn record_grant_outcome(
+        &mut self,
+        grant_rowid: i64,
+        outcome: &str,
+        detail: Option<&str>,
+        now_ms: u64,
+    ) -> Result<()> {
+        let event_type = if outcome == "Cleared" {
+            "ClearanceDelivered"
+        } else {
+            "ClearanceDeliveryRejected"
+        };
+        let payload = serde_json::json!({
+            "grant_rowid": grant_rowid,
+            "outcome": outcome,
+            "detail": detail,
+        })
+        .to_string();
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "UPDATE clearance_grants SET outcome = ?2, outcome_detail = ?3 WHERE id = ?1",
+            params![grant_rowid, outcome, detail],
+        )?;
+        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
+            &tx,
+            event_type,
+            &payload,
+            now_ms as i64,
+            self.signing_key.as_ref(),
+        )?;
+        tx.commit()
+    }
+
+    /// The most recent clearance grant's delivery state for `node_id` (console
+    /// read surface, Phase B). `None` if the node has no grants.
+    pub fn latest_clearance_grant(&self, node_id: &str) -> Result<Option<ClearanceGrantState>> {
+        use rusqlite::OptionalExtension;
+        self.conn
+            .query_row(
+                "SELECT granted_at_ms, consumed_at_ms, outcome, outcome_detail
+                   FROM clearance_grants WHERE node_id = ?1 ORDER BY id DESC LIMIT 1",
+                params![node_id],
+                |row| {
+                    Ok(ClearanceGrantState {
+                        granted_at_ms: row.get::<_, i64>(0)? as u64,
+                        consumed_at_ms: row.get::<_, Option<i64>>(1)?.map(|v| v as u64),
+                        outcome: row.get(2)?,
+                        outcome_detail: row.get(3)?,
+                    })
+                },
+            )
+            .optional()
     }
 
     pub fn save_federated_report_chained(

--- a/static/console.html
+++ b/static/console.html
@@ -43,6 +43,10 @@
   .pill.Trusted{ background:rgba(46,194,126,.15); color:var(--ok); }
   .pill.Untrusted{ background:rgba(224,165,43,.15); color:var(--warn); }
   .pill.Unknown{ background:rgba(124,138,160,.15); color:var(--pend); }
+  .clbadge { margin-top:5px; font-size:11px; padding:2px 7px; border-radius:9px; display:inline-block; }
+  .cl-pending { background:rgba(124,138,160,.15); color:var(--pend); }
+  .cl-cleared { background:rgba(46,194,126,.15); color:var(--ok); }
+  .cl-rejected { background:rgba(224,83,59,.15); color:var(--bad); }
   .feed { max-height:340px; overflow:auto; }
   .row { border-bottom:1px solid var(--line); padding:6px 0; font-size:12px; }
   .row .et { color:var(--accent); }
@@ -107,10 +111,13 @@
 <footer>
   <strong>QM domain.</strong> This console is a <em>read-only view</em> of the
   verifier's real store, plus <em>one</em> authenticated affordance: recording a
-  supervisor clearance grant. It does not — and in Phase A cannot — release a
-  vehicle: a grant is recorded and cryptographically signed into the audit chain;
-  delivery to the node's <code>ClearanceLoop</code> is Phase B. The governor
-  judges; this UI does not. Posture-exempt so it stays reachable during LockedOut.
+  supervisor clearance grant. The UI never claims a release the system hasn't made:
+  a grant is recorded and cryptographically signed, then <em>delivered</em> to the
+  node's <code>ClearanceLoop</code> (Phase B) — which re-validates it and is the
+  thing that actually clears. The card shows <code>RECORDED</code> until a real
+  delivery outcome (<code>CLEARED</code> / <code>REJECTED</code>) exists. The
+  governor judges; this UI does not. Posture-exempt so it stays reachable during
+  LockedOut.
 </footer>
 
 <script>
@@ -125,6 +132,15 @@ async function getJSON(path){
   return r.json();
 }
 
+// Lifecycle label derived ONLY from the real grant columns — the UI never claims
+// more than the row says. Pending stays pending until an outcome row exists.
+function clearanceLabel(c){
+  if(!c) return "";
+  if(c.outcome === "Cleared") return '<div class="clbadge cl-cleared">DELIVERED · CLEARED</div>';
+  if(c.outcome) return '<div class="clbadge cl-rejected">DELIVERY REJECTED · '+esc(c.outcome)+'</div>';
+  return '<div class="clbadge cl-pending">CLEARANCE RECORDED · DELIVERY PENDING</div>';
+}
+
 function renderFleet(d){
   const el = document.getElementById("fleet");
   const fleet = (d && d.fleet) || [];
@@ -135,7 +151,7 @@ function renderFleet(d){
     const seen = n.last_seen_ms ? new Date(Number(n.last_seen_ms)).toISOString().replace('T',' ').replace('Z','') : '—';
     return '<div class="tile p-'+p+'"><div class="nid">'+esc(n.node_id)+
            ' <span class="pill '+p+'">'+p+'</span></div>'+note+
-           '<div class="note">last seen: '+esc(seen)+'</div></div>';
+           '<div class="note">last seen: '+esc(seen)+'</div>'+clearanceLabel(n.clearance)+'</div>';
   }).join("");
 }
 
@@ -180,13 +196,39 @@ function renderAudit(d){
   }).join("");
 }
 
+// The most recent recorded grant this session (node_id only). The grant card
+// follows its REAL lifecycle from the fleet's clearance columns — it shows
+// nothing the system hasn't actually recorded.
+let lastGrant = null;
+
+function updateGrantCard(fleetData){
+  if(!lastGrant) return;
+  const node = ((fleetData && fleetData.fleet) || []).find(n => n.node_id === lastGrant.node_id);
+  const c = node && node.clearance;
+  if(!c || c.outcome == null) return; // still pending → leave the RECORDED label
+  const res = document.getElementById("grantresult");
+  if(c.outcome === "Cleared"){
+    // Recovery progress shown ONLY on a real Cleared outcome + a posture transition.
+    const recovered = node.posture === "Trusted";
+    res.className = "result recorded";
+    res.innerHTML = '<span class="pend" style="color:var(--ok)">DELIVERED · CLEARED</span>'+
+      ' — node <b>'+esc(lastGrant.node_id)+'</b>'+
+      (recovered ? '<br><span style="color:var(--ok)">node posture recovered → Trusted</span>' : '');
+  } else {
+    res.className = "result rejected";
+    res.innerHTML = 'DELIVERY REJECTED · '+esc(c.outcome)+' — node <b>'+esc(lastGrant.node_id)+'</b>'+
+      '<br>re-issue a fresh grant (a stale/dead grant is consumed, never retried).';
+  }
+  lastGrant = null; // terminal outcome — stop tracking
+}
+
 async function poll(){
   const conn = document.getElementById("conn");
   try {
     const [fleet, esc_, audit] = await Promise.all([
       getJSON("/console/fleet"), getJSON("/console/escalations"), getJSON("/console/audit?limit=50"),
     ]);
-    renderFleet(fleet); renderEscalations(esc_); renderAudit(audit);
+    renderFleet(fleet); renderEscalations(esc_); renderAudit(audit); updateGrantCard(fleet);
     conn.textContent = "updated " + new Date().toLocaleTimeString(); conn.classList.remove("err");
   } catch(e){ conn.textContent = "poll error: "+e.message; conn.classList.add("err"); }
 }
@@ -208,10 +250,11 @@ document.getElementById("grantform").addEventListener("submit", async (ev) => {
     const body = await r.json().catch(() => ({}));
     if(r.ok && body.status === "recorded"){
       res.className = "result recorded";
-      res.innerHTML = '<span class="pend">GRANT RECORDED — DELIVERY PENDING (PHASE B)</span><br>'+
+      res.innerHTML = '<span class="pend">GRANT RECORDED — DELIVERY PENDING</span><br>'+
         'node <b>'+esc(body.node_id)+'</b> · operator <b>'+esc(body.operator_id)+'</b> · '+
         'granted_at '+esc(body.granted_at_ms)+'<br>'+
         '<span style="color:var(--dim)">'+esc(body.note||"")+'</span>';
+      lastGrant = { node_id: body.node_id }; // follow its delivery lifecycle on poll
       document.getElementById("supkey").value = ""; // drop the key from the field
       poll();
     } else {


### PR DESCRIPTION
## Phase B — store-level grant delivery to ClearanceLoop (#304, the #267 deferral)

Delivers recorded clearance grants (operator-console Phase A) to the node's `ClearanceLoop`. **No new dependencies**; talisman untouched.

### Transport decision (grounded) + co-location assumption
**Store-level pickup over the shared per-vehicle `VerifierStore`** — the SAME channel the #247/#263 audit sinks already use; zero new deps. **Co-location assumption (stated in the module docs):** the node and the vehicle's verifier share the store (one vehicle, one store); the fleet/federation layer is *above* this. A **remote-node wire transport (HTTP/Zenoh)** is the future variant — **out of scope**.

### Two-checkpoint staleness (the held line)
The verifier validates a grant at **record** time (Phase A: non-empty operator, registered node). `ClearanceDelivery` re-validates at **delivery** time via `ClearanceLoop::try_clear(now = pickup time)`, ageing `granted_at_ms` (the verifier's record time, from the row) against `max_grant_age_ms`. So a grant that sat too long is **rejected at the loop even though the verifier accepted it** — verifier validation is *not* a substitute for loop validation. Proven by the `stale_at_delivery_rejected_consumed_then_fresh_grant_clears` test.

### One-shot consume + no-retry (the held line)
`take_pending_clearance_grant` is a **single atomic `UPDATE … RETURNING`** guarded by `consumed_at_ms IS NULL` — a grant is taken **exactly once, ever**; double-pickup is impossible *by the transaction*, not by convention (the store-level verify-then-consume, same single-use discipline as the attestation nonce `consume_challenge`). The grant is consumed **at pickup, before the verdict**, so a rejected/stale grant is **never retried** — the operator re-issues through the console (automatic retry of a dead grant would be a replay machine).

### What changed
- **`verifier_store.rs`** — `clearance_grants` gains `consumed_at_ms`/`outcome`/`outcome_detail` (CREATE for fresh DBs + **idempotent ALTER ADD COLUMN** for Phase-A DBs, the audit_log_chain migration convention); `take_pending_clearance_grant`, `record_grant_outcome` (writes outcome + the `ClearanceDelivered`/`ClearanceDeliveryRejected` signed chain event), `latest_clearance_grant`.
- **parko-kirra `clearance_delivery.rs`** — `ClearanceDelivery` (holds the store handle + node_id, the audit-sink shape). `poll_and_deliver` documented to run per tick while `escalation_pending()` *or* on a slow cadence (idempotent-empty pickup makes both correct). parko-ros2 node wiring stays the deploy step.
- **Console** — `/console/fleet` carries each node's latest clearance state (raw columns; the UI derives the label). `static/console.html` fleet tiles show the lifecycle badge, and the **grant card follows the real lifecycle** from those columns: the pending label disappears **only when an outcome row exists**, and recovery copy shows **only on a real `Cleared` outcome + a posture transition to Trusted**. Footer honesty updated — the UI never claims a release the system hasn't made.

### Tests (in-process end-to-end — store + real `ClearanceLoop`)
`record → take → try_clear → Cleared` (outcome row + `ClearanceDelivered` audit, loop `Normal`); **stale-at-delivery** rejected + consumed + audited, loop still immobilized, then a fresh grant clears (operator re-issues); **one-shot** second take → `None`; **empty pickup** → `None`, no writes, loop untouched; **malformed-row defense** (empty operator_id) → rejected, consumed, audited.

### Verified
`cargo test` green — SDK lib **596**, bin **38** (incl. all Phase-A console tests), parko-kirra **141+3** (incl. the 5 ClearanceDelivery); **clippy clean** (SDK + parko-kirra); **no new deps**; diff = `verifier_store` + bin + `console.html` + parko-kirra; talisman `997fb7ae…` byte-identical.

### Remaining for the remote-node variant
A wire transport (HTTP/Zenoh) replacing store-level pickup when node and verifier are **not** co-resident — that's the federation layer, named here, deferred.

References #304, #103, #267.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_