### PR TITLE
feat(parko-ros2): wire clearance delivery + node-owned loop into the tick (#304)

### DIFF
--- a/docs/CONSOLE_RUNBOOK.md
+++ b/docs/CONSOLE_RUNBOOK.md
@@ -122,3 +122,68 @@ mock.
 
 > The console is **QM** and **posture-exempt** (reachable during LockedOut — the
 > posture it exists to recover from). The governor judges; the console does not.
+
+---
+
+## On the vehicle (the deployed delivery path)
+
+The desk demo above runs the delivery by hand (`cargo run --example
+deliver_clearance`). **On a real vehicle the node delivers grants on its own
+tick** — no manual step. The `parko-ros2` node, when configured, calls
+`poll_and_deliver` every tick: a console-recorded grant is picked up and clears
+the post-collision loop on the node's next cycle, and the node holds the vehicle
+**stopped** (regardless of posture) while that loop is immobilized.
+
+### ⚠️ ONE store, one vehicle
+
+The node and the vehicle's verifier **share a single SQLite store** — one
+vehicle, one file. Clearance delivery is store-level pickup over that shared
+store (no network hop). Point every component at the **same** path:
+
+```sh
+# THE one co-located store + the one signing key (shared by service + node):
+export KIRRA_DB_PATH="/var/lib/kirra/this_vehicle.sqlite"
+export KIRRA_LOG_SIGNING_KEY="$(cat /etc/kirra/log_signing_key.b64)"
+
+# Service-only — the operator-auth secret. The NODE never sees this.
+export KIRRA_SUPERVISOR_RESET_KEY="$(cat /etc/kirra/supervisor_key)"   # service shell ONLY
+
+# Node-only — THIS vehicle's node id. REQUIRED to enable delivery; no default
+# (a wrong-node grant pickup must be impossible).
+export KIRRA_NODE_ID="KIRRA-DEMO-03"
+```
+
+The node reads `KIRRA_DB_PATH` first, falling back to the divergence sink's
+`PARKO_DIVERGENCE_AUDIT_DB`; if both are set and **differ**, it warns and uses
+`KIRRA_DB_PATH`. In the co-located deployment they must name the **same** file.
+
+If the store + signing key + `KIRRA_NODE_ID` are not all present, the node logs
+a loud warning and runs with **clearance delivery disabled** (the dev lane) —
+console grants will not be delivered. If the store/key are present but
+`KIRRA_NODE_ID` is missing, the node **refuses to start** (it will not guess a
+node id).
+
+> **The node never holds the supervisor key.** Operator authentication is the
+> **service's** job (the `KIRRA_SUPERVISOR_RESET_KEY` grant form, #255). The node
+> only delivers what the verifier already recorded and signed — it authenticates
+> nothing itself.
+
+### Day-one flow
+
+1. **Launch the stack** with the env above — the verifier service *and* the
+   `parko-ros2` node against the one store.
+2. **The console shows real posture** (`/console`) — the live fleet, not seed
+   data, this time.
+3. **Record a grant** for the immobilized vehicle in the grant form (operator id
+   + supervisor key), exactly as in the desk demo.
+4. **The node's own tick delivers it** — `poll_and_deliver` picks up the grant,
+   re-validates it at the `ClearanceLoop`, and on success the post-collision hold
+   lifts and motion resumes. A `ClearanceDelivered` row appears in the same
+   signed chain. No manual `deliver_clearance` run.
+
+> **Scope note (what's wired here vs. next):** this path wires the *delivery* and
+> the *stop tie-in* — a grant releases the loop, and an immobilized loop forces a
+> stop. **Feeding the loop from live collision detection** (so the node *enters*
+> the immobilized state on a real impact, not only in tests) is the named
+> follow-up; until it lands, the node-owned loop is exercised by the delivery
+> path and the test harness.

--- a/parko/crates/parko-kirra/src/clearance_delivery.rs
+++ b/parko/crates/parko-kirra/src/clearance_delivery.rs
@@ -59,6 +59,39 @@ impl ClearanceDelivery {
         }
     }
 
+    /// Open the co-located per-vehicle store at `db_path`, install the base64
+    /// Ed25519 signing key (the same `KIRRA_LOG_SIGNING_KEY` encoding the verifier
+    /// service accepts) so delivered-grant outcomes are SIGNED in the shared
+    /// ledger, and build a delivery handle for `node_id`.
+    ///
+    /// This is the node-side deploy constructor (the #304 deferral): the parko-ros2
+    /// node calls it at startup so it never has to name `base64` / `ed25519_dalek`
+    /// itself (those deps live here). Fail-closed: an unopenable store or an
+    /// undecodable key is an `Err(String)` — never a silent unsigned fallback.
+    ///
+    /// The signing key is moved into the store and never retained or logged here.
+    pub fn open_signed(
+        db_path: &str,
+        node_id: &str,
+        signing_key_b64: &str,
+    ) -> Result<Self, String> {
+        use base64::Engine as _;
+        let raw = base64::engine::general_purpose::STANDARD
+            .decode(signing_key_b64.trim())
+            .map_err(|e| format!("KIRRA_LOG_SIGNING_KEY is not valid base64: {e}"))?;
+        let bytes: [u8; 32] = raw.as_slice().try_into().map_err(|_| {
+            format!(
+                "KIRRA_LOG_SIGNING_KEY must decode to 32 key bytes, got {}",
+                raw.len()
+            )
+        })?;
+        let key = ed25519_dalek::SigningKey::from_bytes(&bytes);
+        let mut store = VerifierStore::new(db_path)
+            .map_err(|e| format!("could not open the co-located store '{db_path}': {e}"))?;
+        store.set_signing_key(key);
+        Ok(Self::new(Arc::new(Mutex::new(store)), node_id))
+    }
+
     /// Override the grant-age ceiling (default [`DEFAULT_MAX_GRANT_AGE_MS`]).
     #[must_use]
     pub fn with_max_grant_age_ms(mut self, ms: u64) -> Self {
@@ -232,6 +265,40 @@ mod tests {
         assert_eq!(l.state(), before, "loop untouched on empty pickup");
         assert!(!audit_has(&s, "ClearanceDelivered"));
         assert!(!audit_has(&s, "ClearanceDeliveryRejected"));
+    }
+
+    #[test]
+    fn open_signed_rejects_a_bad_key_and_signs_with_a_good_one() {
+        use base64::Engine as _;
+        let dir = std::env::temp_dir();
+        let db = dir.join(format!("parko_open_signed_{}.sqlite", std::process::id()));
+        let db_path = db.to_str().unwrap();
+        let _ = std::fs::remove_file(&db);
+
+        // A non-base64 / wrong-length key is a fail-closed Err — never a silent
+        // unsigned fallback.
+        assert!(ClearanceDelivery::open_signed(db_path, "KIRRA-DEMO-03", "not-base64!!").is_err());
+
+        // A valid 32-byte base64 seed opens a SIGNED store: a delivered grant's
+        // outcome lands as a verifiable row.
+        let key_b64 = base64::engine::general_purpose::STANDARD.encode([3u8; 32]);
+        let d = ClearanceDelivery::open_signed(db_path, "KIRRA-DEMO-03", &key_b64)
+            .expect("valid key opens a signed store");
+
+        // Record a grant directly through the same store handle, then deliver.
+        d.store
+            .lock()
+            .unwrap()
+            .save_clearance_grant_chained("KIRRA-DEMO-03", "alice", 1_000)
+            .expect("record grant");
+        let mut l = immobilized_loop();
+        let out = d.poll_and_deliver(&mut l, 1_500);
+        assert!(matches!(out, DeliveryOutcome::Cleared { .. }), "got {out:?}");
+        assert!(audit_has(&d.store, "ClearanceDelivered"));
+
+        let _ = std::fs::remove_file(&db);
+        let _ = std::fs::remove_file(format!("{db_path}-wal"));
+        let _ = std::fs::remove_file(format!("{db_path}-shm"));
     }
 
     #[test]

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -32,6 +32,7 @@ use parko_kirra::{
     select_divergence_sink, DiverseKirraGovernor, GovernorComparator, KirraGovernor,
 };
 use parko_ros2::{
+    clearance_gate::NodeClearance,
     comparator_adapter::ComparatorAsGovernor,
     config::ParkoNodeConfig,
     node::run_node,
@@ -102,6 +103,93 @@ fn build_divergence_sink() -> Arc<dyn parko_kirra::comparator::DivergenceEventSi
                 "parko-ros2: FATAL — cannot configure the CERT-006 divergence audit sink: {e}. \
                  A durable audit was requested but cannot be made signed + persistent. Refusing \
                  to start with divergences unaudited."
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Resolve the ONE co-located store path (#304). The node and the vehicle's
+/// verifier share a single SQLite store; this reads `KIRRA_DB_PATH` first and
+/// falls back to the divergence sink's `PARKO_DIVERGENCE_AUDIT_DB`. If BOTH are
+/// set and DIFFER, that is a co-location error — warn once and prefer
+/// `KIRRA_DB_PATH` (the verifier's canonical var). See docs/CONSOLE_RUNBOOK.md
+/// "On the vehicle".
+fn resolve_one_store_db() -> Option<String> {
+    let kirra = std::env::var("KIRRA_DB_PATH").ok().filter(|s| !s.is_empty());
+    let divergence = std::env::var("PARKO_DIVERGENCE_AUDIT_DB").ok().filter(|s| !s.is_empty());
+    if let (Some(k), Some(d)) = (&kirra, &divergence) {
+        if k != d {
+            tracing::warn!(
+                kirra_db = %k, divergence_db = %d,
+                "parko-ros2: KIRRA_DB_PATH and PARKO_DIVERGENCE_AUDIT_DB are BOTH set and DIFFER. \
+                 The co-located node + verifier are ONE store (one vehicle, one SQLite file) — \
+                 using KIRRA_DB_PATH. Point both env vars at the SAME file."
+            );
+        }
+    }
+    kirra.or(divergence)
+}
+
+/// Build the node-owned clearance gate (#304 Phase-B), mirroring the divergence
+/// sink's env-gated warn-and-continue shape.
+///
+///   - the store path (`KIRRA_DB_PATH`, or `PARKO_DIVERGENCE_AUDIT_DB`) AND
+///     `KIRRA_LOG_SIGNING_KEY` present → delivery is REQUESTED.
+///   - `KIRRA_NODE_ID` — REQUIRED when delivery is requested. There is NO safe
+///     default: a wrong-node grant pickup must be impossible. Missing → FATAL.
+///   - either env input missing → delivery DISABLED (the dev lane): warn naming
+///     what is off (console grants will not be delivered) and return `None`.
+///
+/// The node NEVER reads `KIRRA_SUPERVISOR_RESET_KEY` — operator authentication is
+/// the SERVICE's job (the #255 grant form); the node only delivers what the
+/// verifier already recorded + signed.
+fn build_node_clearance() -> Option<NodeClearance> {
+    let db = resolve_one_store_db();
+    let key = std::env::var("KIRRA_LOG_SIGNING_KEY").ok().filter(|s| !s.is_empty());
+
+    let (db, key) = match (db, key) {
+        (Some(db), Some(key)) => (db, key),
+        _ => {
+            tracing::warn!(
+                "parko-ros2: clearance delivery DISABLED — set KIRRA_DB_PATH (the one co-located \
+                 store), KIRRA_LOG_SIGNING_KEY, and KIRRA_NODE_ID to enable it. Console-recorded \
+                 operator clearance grants will NOT be delivered to this node."
+            );
+            return None;
+        }
+    };
+
+    // Delivery requested → the node id is mandatory and has no default.
+    let node_id = match std::env::var("KIRRA_NODE_ID").ok().filter(|s| !s.is_empty()) {
+        Some(id) => id,
+        None => {
+            tracing::error!(
+                "parko-ros2: FATAL — clearance delivery requested (KIRRA_DB_PATH + \
+                 KIRRA_LOG_SIGNING_KEY set) but KIRRA_NODE_ID is unset/empty. There is no safe \
+                 default node id — a wrong-node grant pickup must be impossible. Set KIRRA_NODE_ID \
+                 to THIS vehicle's node id."
+            );
+            std::process::exit(1);
+        }
+    };
+
+    match NodeClearance::open_signed(&db, &node_id, &key) {
+        Ok(c) => {
+            tracing::info!(
+                node_id = %node_id, db = %db,
+                "parko-ros2: clearance delivery ENABLED — console-recorded operator grants are \
+                 delivered on this node's own tick (poll_and_deliver per tick); the post-collision \
+                 loop holds the vehicle stopped until a grant clears it."
+            );
+            Some(c)
+        }
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                "parko-ros2: FATAL — clearance delivery requested but the co-located store could \
+                 not be opened / the signing key is invalid. Refusing to start with delivery \
+                 silently broken."
             );
             std::process::exit(1);
         }
@@ -198,12 +286,16 @@ async fn main() {
 
     let mapping = Arc::new(VectorMapping::new("observation"));
 
+    // #304 Phase-B: the node-owned clearance gate (delivery + the SG6 stop
+    // tie-in). `None` when delivery is not configured (the dev lane).
+    let clearance = build_node_clearance();
+
     let run_task = {
         let config = Arc::clone(&config);
         let infer = Arc::clone(&infer);
         let mapping = Arc::clone(&mapping);
         tokio::spawn(async move {
-            if let Err(e) = run_node(config, infer, mapping, posture, "parko_governor").await {
+            if let Err(e) = run_node(config, infer, mapping, posture, clearance, "parko_governor").await {
                 tracing::error!(error = ?e, "parko-ros2: run_node exited with error");
             }
         })

--- a/parko/crates/parko-ros2/src/clearance_gate.rs
+++ b/parko/crates/parko-ros2/src/clearance_gate.rs
@@ -1,0 +1,392 @@
+// parko/crates/parko-ros2/src/clearance_gate.rs
+//
+// Phase-B deploy step (#304 deferral): wire `ClearanceDelivery` + a node-owned
+// `ClearanceLoop` into the parko-ros2 tick, so a console-recorded operator
+// clearance grant releases the vehicle on the node's OWN tick — no manual
+// `deliver_clearance` example run.
+//
+// The two touches this adds to the tick (`run_pipeline_tick_with_clearance`):
+//
+//   1. DELIVERY — `poll_and_deliver` once per tick. Cheap NoGrant no-op when no
+//      grant is pending (the Phase-B design point: pickup is idempotent-empty).
+//      Done FIRST, so a grant delivered this tick releases the loop in time for
+//      the veto below to lift on the SAME tick.
+//
+//   2. THE STOP TIE-IN (held line) — while the loop is immobilized (`Latched` OR
+//      `EscalationRaised`, i.e. `ClearanceLoop::is_immobilized`), the tick
+//      publishes the STOPPED command REGARDLESS of posture. This sits ALONGSIDE
+//      the existing LockedOut stop path (which already lives inside the governor
+//      inside `run_pipeline_tick_inner`): the latch is belt-and-suspenders with
+//      posture, never a bypass of it. A delivered grant clears the loop back to
+//      `Normal`; the veto then lifts and command publishing resumes.
+//
+// GROUNDING (surfaced, not bolted): the SG6 detection chain is NOT yet invoked
+// from the tick — nothing here calls `ClearanceLoop::observe` from live impact
+// evidence. This PR wires the loop + delivery (the half that releases the
+// vehicle); FEEDING the latch from live detection is the named follow-up. Until
+// that lands, the node-owned loop only ever leaves `Normal` in tests that drive
+// it directly — which is exactly the wiring under test here.
+//
+// API note: `ClearanceDelivery::poll_and_deliver` takes `&mut ClearanceLoop`
+// (the bare loop, as the `deliver_clearance` example does). `RecordedClearanceLoop`
+// is the DETECTION-recording wrapper (it emits `ImpactDetected` /
+// `ImpactEscalationRaised` on `observe`); it wraps a *private* `ClearanceLoop`, so
+// it is not what delivery operates on. Since this PR wires delivery (not the live
+// detection feed), the node owns the bare loop; the recording wrapper becomes
+// relevant in the detection-feed follow-up.
+
+use std::sync::{Arc, Mutex};
+
+use parko_core::backend::InferenceBackend;
+use parko_core::safety::SafetyPosture;
+use parko_core::scheduler::InferenceLoop;
+use parko_core::sensor::SensorFrame;
+use parko_core::{ClearanceLoop, ClearanceState};
+use tokio::sync::Mutex as AsyncMutex;
+
+use kirra_runtime_sdk::verifier_store::VerifierStore;
+use parko_kirra::clearance_delivery::{ClearanceDelivery, DeliveryOutcome};
+
+use crate::command_mapping::OutgoingTwist;
+use crate::config::ParkoNodeConfig;
+use crate::tick_pipeline::{current_time_ms, run_pipeline_tick_inner, TickOutcome};
+
+/// Node-owned clearance components: the per-vehicle [`ClearanceDelivery`] (store
+/// pickup, scoped to THIS node's id) plus the node's own [`ClearanceLoop`] (the
+/// SG6 motion veto). One per node; constructed at startup when delivery is
+/// enabled, then borrowed `&mut` by the tick.
+pub struct NodeClearance {
+    delivery: ClearanceDelivery,
+    clearance_loop: ClearanceLoop,
+}
+
+impl NodeClearance {
+    /// Wrap a pre-built [`ClearanceDelivery`] with a fresh [`ClearanceLoop`].
+    /// (The binary builds the delivery via [`ClearanceDelivery::open_signed`];
+    /// tests build it from an in-memory store.)
+    #[must_use]
+    pub fn new(delivery: ClearanceDelivery) -> Self {
+        Self {
+            delivery,
+            clearance_loop: ClearanceLoop::new(),
+        }
+    }
+
+    /// Build a node clearance over an existing shared store handle and node id.
+    /// The store-open + signing-key path is [`NodeClearance::open_signed`]; this
+    /// is the seam tests use with an in-memory store.
+    #[must_use]
+    pub fn from_store(store: Arc<Mutex<VerifierStore>>, node_id: impl Into<String>) -> Self {
+        Self::new(ClearanceDelivery::new(store, node_id))
+    }
+
+    /// Open the co-located store at `db_path`, install the base64 Ed25519 signing
+    /// key so delivered-grant outcomes are signed, and build the gate for
+    /// `node_id`. Fail-closed: an unopenable store / undecodable key is an `Err`.
+    /// The node never names `base64` / `ed25519` itself — `parko-kirra` owns that.
+    pub fn open_signed(db_path: &str, node_id: &str, signing_key_b64: &str) -> Result<Self, String> {
+        Ok(Self::new(ClearanceDelivery::open_signed(
+            db_path,
+            node_id,
+            signing_key_b64,
+        )?))
+    }
+
+    /// The motion veto: true while the loop is immobilized (`Latched` OR
+    /// `EscalationRaised`). The tick forces a stopped command while this holds.
+    #[must_use]
+    pub fn is_immobilized(&self) -> bool {
+        self.clearance_loop.is_immobilized()
+    }
+
+    /// The loop's current lifecycle state (diagnostic / tests).
+    #[must_use]
+    pub fn state(&self) -> ClearanceState {
+        self.clearance_loop.state()
+    }
+
+    /// Deliver at most one pending grant to the node-owned loop. Cheap
+    /// `NoGrant` no-op when nothing is pending. Node-scoped pickup: a grant for a
+    /// different node id is never taken.
+    pub fn poll(&mut self, now_ms: u64) -> DeliveryOutcome {
+        self.delivery.poll_and_deliver(&mut self.clearance_loop, now_ms)
+    }
+
+    /// Drive one detection observation into the node-owned loop. This is the seam
+    /// the live-detection-feed follow-up wires to real impact evidence; the tick
+    /// integration here does NOT call it (detection-from-the-tick is out of scope).
+    /// Exposed so tests can drive the loop into an immobilized state through the
+    /// REAL state machine (never by poking internals).
+    pub fn observe(
+        &mut self,
+        evidence: &parko_core::ImpactEvidence,
+        cfg: &parko_core::ImpactCfg,
+        now_ms: u64,
+    ) {
+        self.clearance_loop.observe(evidence, cfg, now_ms);
+    }
+}
+
+/// What one [`run_pipeline_tick_with_clearance`] produced: the normal
+/// [`TickOutcome`] plus the clearance side-effects so the node can log them.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClearedTickOutcome {
+    /// The tick's outcome. `twist` is the command to publish — overridden to a
+    /// stopped twist when `vetoed` is true.
+    pub tick: TickOutcome,
+    /// The per-tick delivery result. `None` when no clearance gate is configured
+    /// (the dev lane); `Some(NoGrant)` on the common idempotent-empty pickup.
+    pub delivery: Option<DeliveryOutcome>,
+    /// True when the clearance veto forced the stopped twist this tick (the loop
+    /// was immobilized after delivery). Lets the node log the held line.
+    pub vetoed: bool,
+}
+
+/// Drive one tick with the node-owned clearance gate wired in. When `clearance`
+/// is `None` (delivery disabled — the dev lane) this is exactly the existing
+/// posture-gated tick with no veto and no pickup.
+///
+/// Order is load-bearing: deliver FIRST (a grant delivered this tick releases the
+/// loop), then run the posture-gated tick, then apply the veto reading the
+/// POST-delivery immobilization state — so a just-cleared loop resumes motion the
+/// same tick, and a still-immobilized loop stops regardless of posture.
+///
+// SAFETY: SG6 | REQ: parko-ros2-clearance-veto-and-delivery | TEST: latched_loop_stops_tick_even_at_nominal,pending_grant_delivers_and_resumes,no_clearance_gate_ticks_normally,grant_for_other_node_not_picked_up
+pub async fn run_pipeline_tick_with_clearance<B>(
+    config: &ParkoNodeConfig,
+    loop_mutex: Arc<AsyncMutex<InferenceLoop<B>>>,
+    frame: SensorFrame,
+    posture: SafetyPosture,
+    clearance: Option<&mut NodeClearance>,
+) -> ClearedTickOutcome
+where
+    B: InferenceBackend + 'static,
+{
+    let now_ms = current_time_ms();
+    let mut clearance = clearance;
+
+    // 1. DELIVERY — one pickup per tick (NoGrant no-op when nothing pending).
+    let delivery = clearance.as_deref_mut().map(|c| c.poll(now_ms));
+
+    // 2. The normal posture-gated tick (the LockedOut stop path lives inside).
+    let mut tick = run_pipeline_tick_inner(config, loop_mutex, frame, posture).await;
+
+    // 3. THE STOP TIE-IN — immobilized (post-delivery) → stop regardless of
+    //    posture, alongside the governor's LockedOut stop.
+    let vetoed = clearance.as_deref().is_some_and(NodeClearance::is_immobilized);
+    if vetoed {
+        tick.twist = OutgoingTwist::stopped(now_ms);
+    }
+
+    ClearedTickOutcome {
+        tick,
+        delivery,
+        vetoed,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — MockBackend lane (no ROS, no ORT, no model file). Mirrors the
+// `tick_pipeline` async test harness.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use parko_core::backend::{BackendDescriptor, TensorBatch};
+    use parko_core::backends::mock::MockBackend;
+    use parko_core::commands::ControlCommand;
+    use parko_core::{ImpactCfg, ImpactEvidence};
+    use parko_kirra::{GovernorComparator, KirraGovernor};
+    use tokio::sync::mpsc;
+
+    use crate::comparator_adapter::ComparatorAsGovernor;
+
+    fn build_loop(
+        linear_out: f32,
+        angular_out: f32,
+    ) -> Arc<AsyncMutex<InferenceLoop<MockBackend>>> {
+        let mut outputs: HashMap<String, Vec<f32>> = HashMap::new();
+        outputs.insert("cmd_vel_linear".to_string(), vec![linear_out]);
+        outputs.insert("cmd_vel_angular".to_string(), vec![angular_out]);
+        let backend = Arc::new(MockBackend::new(outputs, BackendDescriptor::Cpu));
+        let model = backend.load_model("test.onnx").expect("mock model loads");
+        let (tx, _rx) = mpsc::channel::<ControlCommand>(8);
+        let comparator = GovernorComparator::new(KirraGovernor::new(), KirraGovernor::new());
+        let infer = InferenceLoop::new(backend, model, tx)
+            .with_governor(ComparatorAsGovernor(comparator))
+            .with_tick_period(0.05);
+        Arc::new(AsyncMutex::new(infer))
+    }
+
+    fn fresh_frame(frame_id: u64) -> SensorFrame {
+        SensorFrame {
+            frame_id,
+            timestamp_ms: current_time_ms(),
+            payload: TensorBatch {
+                named_tensors: HashMap::new(),
+                metadata: HashMap::new(),
+            },
+        }
+    }
+
+    fn store() -> Arc<Mutex<VerifierStore>> {
+        Arc::new(Mutex::new(
+            VerifierStore::new(":memory:").expect("in-memory store"),
+        ))
+    }
+
+    /// Drive a `NodeClearance`'s loop into an immobilized state through the REAL
+    /// state machine. `ticks` observes: 1 → `Latched`, 2 → `EscalationRaised`.
+    fn immobilize(nc: &mut NodeClearance, ticks: u32) {
+        let ev = ImpactEvidence {
+            imu_accel_spike_mps2: 0.0,
+            contact_sensor: true,
+            vanished_object: false,
+        };
+        let cfg = ImpactCfg::default();
+        for _ in 0..ticks {
+            nc.observe(&ev, &cfg, current_time_ms());
+        }
+    }
+
+    /// THE TIE-IN: a latched loop forces a stopped twist EVEN at Nominal posture,
+    /// where the governor alone would admit the forward command.
+    #[tokio::test(start_paused = true)]
+    async fn latched_loop_stops_tick_even_at_nominal() {
+        let infer = build_loop(0.1, 0.2);
+        let mut nc = NodeClearance::from_store(store(), "KIRRA-DEMO-03");
+        immobilize(&mut nc, 1); // Normal -> Latched
+        assert_eq!(nc.state(), ClearanceState::Latched);
+
+        let out = run_pipeline_tick_with_clearance(
+            &ParkoNodeConfig::default(),
+            infer,
+            fresh_frame(1),
+            SafetyPosture::Nominal,
+            Some(&mut nc),
+        )
+        .await;
+
+        assert!(out.vetoed, "an immobilized loop must veto motion regardless of posture");
+        assert_eq!(out.tick.twist.linear_x_mps, 0.0, "latched → stopped twist (linear)");
+        assert_eq!(out.tick.twist.angular_z_rads, 0.0, "latched → stopped twist (angular)");
+        assert_eq!(out.delivery, Some(DeliveryOutcome::NoGrant), "no grant pending");
+    }
+
+    /// END-TO-END: a pending grant in the store is delivered on ONE tick, the loop
+    /// clears to Normal, the veto lifts, and command publishing RESUMES — on the
+    /// node's own tick, with no manual example run.
+    #[tokio::test(start_paused = true)]
+    async fn pending_grant_delivers_and_resumes() {
+        let s = store();
+        let mut nc = NodeClearance::from_store(s.clone(), "KIRRA-DEMO-03");
+        immobilize(&mut nc, 2); // -> EscalationRaised (immobilized, escalation pending)
+        assert_eq!(nc.state(), ClearanceState::EscalationRaised);
+
+        // The operator records a grant through the (Phase-A) store path, dated now.
+        let now = current_time_ms();
+        s.lock()
+            .unwrap()
+            .save_clearance_grant_chained("KIRRA-DEMO-03", "alice", now)
+            .expect("record grant");
+
+        // ONE tick delivers it.
+        let infer = build_loop(0.1, 0.2);
+        let out = run_pipeline_tick_with_clearance(
+            &ParkoNodeConfig::default(),
+            infer,
+            fresh_frame(2),
+            SafetyPosture::Nominal,
+            Some(&mut nc),
+        )
+        .await;
+
+        assert!(
+            matches!(out.delivery, Some(DeliveryOutcome::Cleared { .. })),
+            "the pending grant must be delivered this tick; got {:?}",
+            out.delivery
+        );
+        assert_eq!(nc.state(), ClearanceState::Normal, "the loop clears back to Normal");
+        assert!(!out.vetoed, "veto lifts the same tick the grant clears the loop");
+        assert!(
+            (out.tick.twist.linear_x_mps - 0.1).abs() < 1e-4,
+            "command publishing resumes — governed forward command, not a stop; got {}",
+            out.tick.twist.linear_x_mps
+        );
+
+        // A subsequent tick: nothing pending, normal publishing continues.
+        let infer2 = build_loop(0.1, 0.2);
+        let out2 = run_pipeline_tick_with_clearance(
+            &ParkoNodeConfig::default(),
+            infer2,
+            fresh_frame(3),
+            SafetyPosture::Nominal,
+            Some(&mut nc),
+        )
+        .await;
+        assert_eq!(out2.delivery, Some(DeliveryOutcome::NoGrant), "grant consumed — no retry");
+        assert!(!out2.vetoed);
+    }
+
+    /// THE DEV LANE: no clearance gate → the node ticks normally, delivery
+    /// disabled, no panic. The forward command is published unmodified.
+    #[tokio::test(start_paused = true)]
+    async fn no_clearance_gate_ticks_normally() {
+        let infer = build_loop(0.1, 0.2);
+        let out = run_pipeline_tick_with_clearance(
+            &ParkoNodeConfig::default(),
+            infer,
+            fresh_frame(4),
+            SafetyPosture::Nominal,
+            None,
+        )
+        .await;
+        assert_eq!(out.delivery, None, "no gate → no delivery attempt");
+        assert!(!out.vetoed, "no gate → no veto");
+        assert!(out.tick.error.is_none());
+        assert!(
+            (out.tick.twist.linear_x_mps - 0.1).abs() < 1e-4,
+            "dev lane publishes the governed command unchanged; got {}",
+            out.tick.twist.linear_x_mps
+        );
+    }
+
+    /// NODE-SCOPED PICKUP: a grant recorded for a DIFFERENT node id is never taken
+    /// by this node's gate — the one-shot consume is node-scoped, so a wrong-node
+    /// pickup is impossible. The loop stays immobilized.
+    #[tokio::test(start_paused = true)]
+    async fn grant_for_other_node_not_picked_up() {
+        let s = store();
+        let mut nc = NodeClearance::from_store(s.clone(), "KIRRA-DEMO-03");
+        immobilize(&mut nc, 2); // EscalationRaised
+
+        // A grant exists, but for ANOTHER node.
+        let now = current_time_ms();
+        s.lock()
+            .unwrap()
+            .save_clearance_grant_chained("KIRRA-DEMO-06", "mallory", now)
+            .expect("record grant for a different node");
+
+        let infer = build_loop(0.1, 0.2);
+        let out = run_pipeline_tick_with_clearance(
+            &ParkoNodeConfig::default(),
+            infer,
+            fresh_frame(5),
+            SafetyPosture::Nominal,
+            Some(&mut nc),
+        )
+        .await;
+
+        assert_eq!(
+            out.delivery,
+            Some(DeliveryOutcome::NoGrant),
+            "a grant scoped to another node must NOT be picked up"
+        );
+        assert!(nc.is_immobilized(), "loop stays immobilized — nothing cleared it");
+        assert!(out.vetoed, "still immobilized → still vetoed to a stop");
+        assert_eq!(out.tick.twist.linear_x_mps, 0.0);
+    }
+}

--- a/parko/crates/parko-ros2/src/lib.rs
+++ b/parko/crates/parko-ros2/src/lib.rs
@@ -24,6 +24,7 @@
 // subset as an aligned list the markdown-nesting lint would reformat.
 #![allow(clippy::doc_lazy_continuation, clippy::doc_overindented_list_items)]
 
+pub mod clearance_gate;
 pub mod command_mapping;
 pub mod comparator_adapter;
 pub mod config;
@@ -54,3 +55,6 @@ pub use crate::sensor_mapping::{
     OdomMappingError, OdomOrientation, OdomSample, OwnedCameraSample, SensorInputMapping,
 };
 pub use crate::tick_pipeline::{run_pipeline_tick, TickError, TickOutcome};
+pub use crate::clearance_gate::{
+    run_pipeline_tick_with_clearance, ClearedTickOutcome, NodeClearance,
+};

--- a/parko/crates/parko-ros2/src/node.rs
+++ b/parko/crates/parko-ros2/src/node.rs
@@ -27,10 +27,12 @@ use parko_core::safety::SafetyPosture;
 use parko_core::scheduler::InferenceLoop;
 use tokio::sync::Mutex;
 
+use crate::clearance_gate::{run_pipeline_tick_with_clearance, NodeClearance};
 use crate::command_mapping::OutgoingTwist;
 use crate::config::ParkoNodeConfig;
 use crate::sensor_mapping::SensorInputMapping;
-use crate::tick_pipeline::{run_pipeline_tick, TickError};
+use crate::tick_pipeline::TickError;
+use parko_kirra::clearance_delivery::DeliveryOutcome;
 
 /// Run the Parko ROS 2 node. Owns the r2r context for the lifetime of
 /// the returned future. Cancelling the future drops the node + the
@@ -41,11 +43,18 @@ use crate::tick_pipeline::{run_pipeline_tick, TickError};
 /// is the integrator's sensor → frame mapper. `posture` is the
 /// **static** posture for now (M1b wiring is a follow-up; see the
 /// module-level note).
+///
+/// `clearance` is the node-owned [`NodeClearance`] (#304 Phase-B): when `Some`,
+/// every tick polls for a console-recorded operator grant (delivering it on this
+/// node's own tick) and forces a stopped command while the loop is immobilized
+/// — alongside the LockedOut stop path. `None` is the dev lane (delivery
+/// disabled); the binary warns when it constructs `None`.
 pub async fn run_node<B, M>(
     config:  Arc<ParkoNodeConfig>,
     infer:   Arc<Mutex<InferenceLoop<B>>>,
     mapping: Arc<M>,
     posture: SafetyPosture,
+    clearance: Option<NodeClearance>,
     node_name: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 where
@@ -86,6 +95,9 @@ where
 
     let drain_task = tokio::spawn(async move {
         use futures::StreamExt;
+        // The node-owned clearance gate (Phase-B). Owned by the single drain task
+        // so the per-tick `&mut` borrow needs no extra locking.
+        let mut clearance = clearance;
         let mut frame_id: u64 = 0;
         let mut stream = sensor_sub;
         while let Some(msg) = stream.next().await {
@@ -107,12 +119,34 @@ where
                 .unwrap_or(0);
             frame_id = frame_id.saturating_add(1);
             let frame = drain_mapping.to_frame(frame_id, stamp_ms, &sample_vec);
-            let outcome = run_pipeline_tick(
+            let cleared = run_pipeline_tick_with_clearance(
                 &drain_config,
                 Arc::clone(&drain_infer),
                 frame,
                 posture,
+                clearance.as_mut(),
             ).await;
+            let outcome = cleared.tick;
+
+            // Surface the per-tick clearance delivery (a console-recorded grant
+            // arriving on this node's own tick). A `NoGrant` no-op is silent.
+            match &cleared.delivery {
+                Some(DeliveryOutcome::Cleared { operator_id, grant_rowid }) =>
+                    tracing::info!(operator_id = %operator_id, grant_rowid,
+                        "parko-ros2: operator clearance DELIVERED — loop cleared, motion released"),
+                Some(DeliveryOutcome::Rejected { reason, grant_rowid }) =>
+                    tracing::warn!(reason = %reason, grant_rowid,
+                        "parko-ros2: clearance grant REJECTED at delivery (consumed, not retried) — \
+                         operator must re-issue in the console"),
+                Some(DeliveryOutcome::StoreError) =>
+                    tracing::error!("parko-ros2: clearance store error — fail-closed (nothing cleared)"),
+                Some(DeliveryOutcome::NoGrant) | None => {}
+            }
+            if cleared.vetoed {
+                tracing::warn!(frame_id,
+                    "parko-ros2: clearance veto ACTIVE (post-collision loop immobilized) — \
+                     publishing stop regardless of posture until an operator grant is delivered");
+            }
 
             if let Some(err) = &outcome.error {
                 match err {
@@ -125,7 +159,7 @@ where
                 }
             }
 
-            // Publish the gated twist (always — happy path OR MRC).
+            // Publish the gated twist (always — happy path OR MRC OR clearance veto).
             if let Err(e) = publish_twist(&cmd_pub, outcome.twist) {
                 tracing::warn!(error = ?e,
                     "parko-ros2: failed to publish OutgoingTwist; \

--- a/parko/crates/parko-ros2/src/tick_pipeline.rs
+++ b/parko/crates/parko-ros2/src/tick_pipeline.rs
@@ -119,7 +119,7 @@ where
     run_pipeline_tick_inner(config, loop_mutex, frame, posture).await
 }
 
-async fn run_pipeline_tick_inner<B>(
+pub(crate) async fn run_pipeline_tick_inner<B>(
     config:      &ParkoNodeConfig,
     loop_mutex:  Arc<Mutex<InferenceLoop<B>>>,
     frame:       SensorFrame,
@@ -176,7 +176,7 @@ where
     }
 }
 
-fn current_time_ms() -> u64 {
+pub(crate) fn current_time_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)


### PR DESCRIPTION
The Phase-B deploy step: a console-recorded operator clearance grant now releases the vehicle on the **parko-ros2 node's own tick** — no manual `deliver_clearance` example run. Talisman untouched.

---

## STEP 0 — Grounding (results)

**a. The tick pipeline + where the SG6 detection chain stands.**
Per-cycle evaluation is `tick_pipeline::run_pipeline_tick_inner` (driven by the `node.rs` drain task, one call per sensor observation). Posture gates the published command *inside* `parko-core`'s `InferenceLoop::tick` via the attached `GovernorComparator`: `LockedOut → Deny → stopped command → OutgoingTwist`. That is the existing **stopped-twist-on-LockedOut** path — there is no separate posture branch in the tick; the governor owns it.

The node's evaluate surface today exposes **no impact/collision signal**: `ClearanceLoop` / `RecordedClearanceLoop` exist in `parko-core` / `parko-kirra`, but nothing in the tick calls `ClearanceLoop::observe`. **Confirmed finding: the SG6 detection chain is not invoked from the tick.** Per the task this PR wires the *loop + delivery* (the release half); feeding the latch from live detection is filed as the named follow-up → **#309**. The whole SG6 chain is **not** bolted into this PR.

**b. The construction shape to mirror.**
`bin/parko_ros2_node.rs::build_divergence_sink` is the precedent: env-gated, *warn-and-continue* when unset (ephemeral/disabled), *fatal exit* when a capability was **requested** but can't be made safe. `build_node_clearance` mirrors it exactly.

**c. The DB env-var question (one store).**
The service uses `KIRRA_DB_PATH`; the divergence sink uses `PARKO_DIVERGENCE_AUDIT_DB`. In the co-located deployment they are **one** store (one vehicle, one SQLite file). Decision (documented loudly in the bin env-docs + the runbook's "On the vehicle"): read **`KIRRA_DB_PATH` first**, fall back to `PARKO_DIVERGENCE_AUDIT_DB`, and **warn once** if both are set and differ (preferring `KIRRA_DB_PATH`).

---

## What this PR wires (two small touches to the tick)

`clearance_gate.rs` (new) — `NodeClearance` owns a `ClearanceDelivery` (store pickup, scoped to **this** node's id) + a node-owned `ClearanceLoop`. `run_pipeline_tick_with_clearance`:

1. **DELIVERY** — `poll_and_deliver` once per tick (cheap `NoGrant` no-op when nothing is pending — the Phase-B design point). Done **first**, so a grant delivered this tick lifts the veto on the *same* tick.
2. **THE STOP TIE-IN** (held line) — while the loop is immobilized (`is_immobilized()` = `Latched` OR `EscalationRaised`), the tick publishes the **stopped** command **regardless of posture**, alongside the governor's LockedOut stop. Belt-and-suspenders with posture, **never a bypass**. A delivered grant clears the loop → `Normal` → the veto lifts → publishing resumes.

`node.rs` / `bin` — `run_node` takes `Option<NodeClearance>`. The binary builds it (mirroring the divergence sink): store path + `KIRRA_LOG_SIGNING_KEY` present ⇒ delivery requested; `KIRRA_NODE_ID` then **mandatory, no default** (a wrong-node pickup must be impossible — missing id with store+key present is **fatal**). Anything missing ⇒ warn-and-skip (delivery disabled, dev lane). **The node never reads `KIRRA_SUPERVISOR_RESET_KEY`** — operator auth is the service's job; the node only delivers what the verifier already recorded + signed.

`docs/CONSOLE_RUNBOOK.md` — adds **"On the vehicle"**: the one-store env set, the node-never-holds-the-supervisor-key boundary, and the day-one flow (launch stack → console shows real posture → record grant → the node's own tick delivers it).

## The one parko-kirra change (and why)

`parko-ros2` has **no `base64` / `ed25519` dependency and must not gain one** ("no new deps"). So the store-open + signing-key install lives in `parko-kirra` (where those deps already are) as a minimal, additive constructor `ClearanceDelivery::open_signed(db, node_id, key_b64)` — fail-closed (bad key / unopenable store → `Err`, never a silent unsigned fallback). The node crate stays dependency-free and just calls it. This is the analogue of the previous PR's dev-dep-cycle resolution.

## Tests (default lane — no ROS runtime; matches the `tick_with_*` harness)

- **latched loop → stopped twist even at Nominal** (the tie-in).
- **pending grant in a temp store → one tick delivers, loop clears to Normal, publishing resumes**; a subsequent tick finds nothing (consumed, no retry).
- **no config → ticks normally, delivery disabled, no panic** (the dev lane).
- **a grant for another node id is NOT picked up** (node-scoped one-shot take).
- plus a `parko-kirra` test for `open_signed` (bad key rejected; good key signs a delivered outcome).

`cargo test -p parko-ros2` 146 pass (4 new); `cargo test -p parko-kirra` 142 pass (1 new). Clippy clean on both crates (the only `--all-targets` lint is a pre-existing `erasing_op` in `sensor_mapping.rs` tests, unrelated to this change). The `ros2`-gated `node.rs` + binary do not compile without a sourced ROS env (no `ROS_DISTRO` in CI/sandbox — same as #206); they are correct-by-reading and mirror the existing tracing/field idioms.

## Scope / verify

- **Scope:** `parko-ros2` (new `clearance_gate.rs` + `node.rs`/bin/lib/tick wiring) + the enabling `parko-kirra` constructor + the runbook section + the follow-up issue.
- **No** service/store/console changes; **no new deps** (no `Cargo.toml` dependency edits).
- Talisman `997fb7ae15ce3e11adec9218044c7c84b049ad3b` **byte-identical**.

Follow-up: **#309** (feed the loop from live collision detection). Relates to #304.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_