### PR TITLE
feat(ros2): arm the clearance loop from live impact detection in the tick (#309)

### DIFF
--- a/docs/CONSOLE_RUNBOOK.md
+++ b/docs/CONSOLE_RUNBOOK.md
@@ -151,6 +151,13 @@ export KIRRA_SUPERVISOR_RESET_KEY="$(cat /etc/kirra/supervisor_key)"   # service
 # Node-only — THIS vehicle's node id. REQUIRED to enable delivery; no default
 # (a wrong-node grant pickup must be impossible).
 export KIRRA_NODE_ID="KIRRA-DEMO-03"
+
+# Node-only — SG6 impact-detection sources (#309). OPTIONAL; each unset topic is
+# REDUCED detection coverage, logged loudly at startup (never a fabricated latch):
+export PARKO_IMU_TOPIC="/imu/data"          # sensor_msgs/Imu  → decel-spike trigger
+export PARKO_CONTACT_TOPIC="/bumper/contact" # std_msgs/Bool    → contact trigger
+# Deployment-tunable decel threshold (m/s²); VALIDATION-PENDING, default 30.0:
+export PARKO_IMPACT_SPIKE_THRESHOLD_MPS2="30.0"
 ```
 
 The node reads `KIRRA_DB_PATH` first, falling back to the divergence sink's
@@ -181,9 +188,31 @@ node id).
    lifts and motion resumes. A `ClearanceDelivered` row appears in the same
    signed chain. No manual `deliver_clearance` run.
 
-> **Scope note (what's wired here vs. next):** this path wires the *delivery* and
-> the *stop tie-in* — a grant releases the loop, and an immobilized loop forces a
-> stop. **Feeding the loop from live collision detection** (so the node *enters*
-> the immobilized state on a real impact, not only in tests) is the named
-> follow-up; until it lands, the node-owned loop is exercised by the delivery
-> path and the test harness.
+### What latches the loop for real (#309)
+
+The node now **arms itself** from live evidence each tick — it no longer needs an
+external driver to enter the post-collision hold:
+
+- **Decel (IMU).** When `PARKO_IMU_TOPIC` is set, the node reads the IMU
+  linear-acceleration magnitude per tick; a value above
+  `PARKO_IMPACT_SPIKE_THRESHOLD_MPS2` (default 30 m/s², well above the ~9.81 m/s²
+  gravity baseline) is a collision-grade impact → the loop latches and the
+  vehicle stops.
+- **Contact.** When `PARKO_CONTACT_TOPIC` is set, a `true` reading is a
+  definitive impact → latch.
+- **Vanished-object — NOT yet wired.** This trigger needs an `AgentScene` per
+  tick, and no scene source flows through the node's tick yet. It is the **named
+  remainder of #309**; until it lands, a person-under-vehicle *disappearance* does
+  not latch from the tick (decel + contact still do).
+
+A **missing** IMU or contact topic is **reduced detection coverage**, stated
+loudly at startup — never a fabricated latch. Once latched (by any armed
+trigger), recovery is exactly the delivery flow above: record a grant → the
+node's own tick delivers it → the hold lifts.
+
+> **Held line (delivery before detection):** within a tick the node delivers a
+> pending grant *before* it runs detection. A grant consumed on a tick is matched
+> against the loop state at pickup; it can never clear an impact that latches on
+> that *same* tick. If both happen at once, the grant clears the old escalation,
+> detection re-latches on the new evidence, the vehicle stays stopped, and the
+> operator re-issues against the new escalation.

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -144,7 +144,7 @@ fn resolve_one_store_db() -> Option<String> {
 /// The node NEVER reads `KIRRA_SUPERVISOR_RESET_KEY` — operator authentication is
 /// the SERVICE's job (the #255 grant form); the node only delivers what the
 /// verifier already recorded + signed.
-fn build_node_clearance() -> Option<NodeClearance> {
+fn build_node_clearance(config: &ParkoNodeConfig) -> Option<NodeClearance> {
     let db = resolve_one_store_db();
     let key = std::env::var("KIRRA_LOG_SIGNING_KEY").ok().filter(|s| !s.is_empty());
 
@@ -178,11 +178,14 @@ fn build_node_clearance() -> Option<NodeClearance> {
         Ok(c) => {
             tracing::info!(
                 node_id = %node_id, db = %db,
+                spike_threshold_mps2 = config.spike_threshold_mps2,
                 "parko-ros2: clearance delivery ENABLED — console-recorded operator grants are \
                  delivered on this node's own tick (poll_and_deliver per tick); the post-collision \
-                 loop holds the vehicle stopped until a grant clears it."
+                 loop holds the vehicle stopped until a grant clears it. SG6 detection armed per \
+                 the configured impact threshold (see the IMU/contact ARMED lines)."
             );
-            Some(c)
+            // #309: thread the (deployment-tunable) impact-fusion config into the gate.
+            Some(c.with_impact_cfg(config.impact_cfg()))
         }
         Err(e) => {
             tracing::error!(
@@ -261,11 +264,39 @@ async fn install_shutdown_handler() {
     }
 }
 
+/// Build the node config from env, overriding the SG6 detection knobs (#309):
+///   - `PARKO_IMU_TOPIC`     — `sensor_msgs/Imu` topic (decel trigger).
+///   - `PARKO_CONTACT_TOPIC` — `std_msgs/Bool` topic (contact trigger).
+///   - `PARKO_IMPACT_SPIKE_THRESHOLD_MPS2` — decel threshold (deployment-tunable,
+///     VALIDATION-PENDING; parko-core default 30 m/s²). A non-numeric value is
+///     ignored with a warning (the safe default stands).
+fn build_config() -> ParkoNodeConfig {
+    let imu_topic = std::env::var("PARKO_IMU_TOPIC").ok().filter(|s| !s.is_empty());
+    let contact_topic = std::env::var("PARKO_CONTACT_TOPIC").ok().filter(|s| !s.is_empty());
+    let mut config = ParkoNodeConfig {
+        imu_topic,
+        contact_topic,
+        ..ParkoNodeConfig::default()
+    };
+    if let Ok(raw) = std::env::var("PARKO_IMPACT_SPIKE_THRESHOLD_MPS2") {
+        match raw.trim().parse::<f64>() {
+            Ok(v) if v.is_finite() && v > 0.0 => config.spike_threshold_mps2 = v,
+            _ => tracing::warn!(
+                value = %raw,
+                "parko-ros2: PARKO_IMPACT_SPIKE_THRESHOLD_MPS2 is not a positive finite number — \
+                 keeping the default {} m/s²",
+                config.spike_threshold_mps2
+            ),
+        }
+    }
+    config
+}
+
 #[tokio::main]
 async fn main() {
     init_tracing();
 
-    let config = Arc::new(ParkoNodeConfig::default());
+    let config = Arc::new(build_config());
     tracing::info!(?config, "parko_ros2_node starting");
 
     // Pick a backend. Today's binary only carries the MockBackend
@@ -287,8 +318,9 @@ async fn main() {
     let mapping = Arc::new(VectorMapping::new("observation"));
 
     // #304 Phase-B: the node-owned clearance gate (delivery + the SG6 stop
-    // tie-in). `None` when delivery is not configured (the dev lane).
-    let clearance = build_node_clearance();
+    // tie-in). #309: armed with the live impact-detection config. `None` when
+    // delivery is not configured (the dev lane).
+    let clearance = build_node_clearance(&config);
 
     let run_task = {
         let config = Arc::clone(&config);

--- a/parko/crates/parko-ros2/src/clearance_gate.rs
+++ b/parko/crates/parko-ros2/src/clearance_gate.rs
@@ -5,14 +5,19 @@
 // clearance grant releases the vehicle on the node's OWN tick — no manual
 // `deliver_clearance` example run.
 //
-// The two touches this adds to the tick (`run_pipeline_tick_with_clearance`):
+// THE THREE TOUCHES this adds to the tick (`run_pipeline_tick_with_clearance`),
+// in this load-bearing order:
 //
 //   1. DELIVERY — `poll_and_deliver` once per tick. Cheap NoGrant no-op when no
 //      grant is pending (the Phase-B design point: pickup is idempotent-empty).
-//      Done FIRST, so a grant delivered this tick releases the loop in time for
-//      the veto below to lift on the SAME tick.
+//      Done FIRST.
 //
-//   2. THE STOP TIE-IN (held line) — while the loop is immobilized (`Latched` OR
+//   2. DETECTION (#309) — assemble this tick's `ImpactEvidence` from the node's
+//      live sensors and `loop.observe(evidence, cfg, now)`, which may LATCH. The
+//      vehicle now latches ITSELF from real evidence, not only via external
+//      drivers.
+//
+//   3. THE STOP TIE-IN (held line) — while the loop is immobilized (`Latched` OR
 //      `EscalationRaised`, i.e. `ClearanceLoop::is_immobilized`), the tick
 //      publishes the STOPPED command REGARDLESS of posture. This sits ALONGSIDE
 //      the existing LockedOut stop path (which already lives inside the governor
@@ -20,20 +25,37 @@
 //      posture, never a bypass of it. A delivered grant clears the loop back to
 //      `Normal`; the veto then lifts and command publishing resumes.
 //
-// GROUNDING (surfaced, not bolted): the SG6 detection chain is NOT yet invoked
-// from the tick — nothing here calls `ClearanceLoop::observe` from live impact
-// evidence. This PR wires the loop + delivery (the half that releases the
-// vehicle); FEEDING the latch from live detection is the named follow-up. Until
-// that lands, the node-owned loop only ever leaves `Normal` in tests that drive
-// it directly — which is exactly the wiring under test here.
+// THE ORDERING HELD LINE (delivery BEFORE detection): a grant consumed in step 1
+// is matched against the loop state at poll time — it can NEVER clear an impact
+// that latches in step 2. If a pending grant AND new impact evidence arrive on
+// the SAME tick, the grant clears the OLD escalation, step 2 re-latches on the
+// new evidence, and step 3 holds the vehicle stopped. The operator re-issues a
+// fresh grant against the NEW escalation. Releasing first then re-latching is the
+// safe direction; the reverse (latch then let a stale grant clear it) is not.
+//
+// WHAT IS ARMED vs DEFERRED (#309 remainder):
+//   * decel (IMU)  — ARMED when `imu_topic` is configured (vector-magnitude
+//                    decel proxy vs `ImpactCfg::spike_threshold_mps2`).
+//   * contact      — ARMED when `contact_topic` is configured.
+//   * vanished     — DEFERRED: `VanishedObjectDetector` needs an `AgentScene`
+//                    per tick, and no scene source flows through the M2 tick yet
+//                    (scenes were always integrator/checker-side input). The
+//                    detector sits behind an `Option` gated on a per-tick scene;
+//                    the node passes `None` today. Sourcing the scene is the
+//                    named remainder of #309. We wire the two REAL triggers now
+//                    rather than block all three on perception plumbing.
+//
+// HONESTY RULE: a missing sensor is REDUCED detection coverage, stated loudly at
+// startup — never a fabricated spike and never a fabricated veto. An absent IMU
+// contributes no decel (not a NaN, not a default spike); an absent contact topic
+// reads `false`; an absent scene yields `vanished = false`.
 //
 // API note: `ClearanceDelivery::poll_and_deliver` takes `&mut ClearanceLoop`
 // (the bare loop, as the `deliver_clearance` example does). `RecordedClearanceLoop`
 // is the DETECTION-recording wrapper (it emits `ImpactDetected` /
 // `ImpactEscalationRaised` on `observe`); it wraps a *private* `ClearanceLoop`, so
-// it is not what delivery operates on. Since this PR wires delivery (not the live
-// detection feed), the node owns the bare loop; the recording wrapper becomes
-// relevant in the detection-feed follow-up.
+// it is not what delivery operates on. The node owns the bare loop; recording the
+// detection edges to the signed chain is a separate concern tracked with #309.
 
 use std::sync::{Arc, Mutex};
 
@@ -41,7 +63,10 @@ use parko_core::backend::InferenceBackend;
 use parko_core::safety::SafetyPosture;
 use parko_core::scheduler::InferenceLoop;
 use parko_core::sensor::SensorFrame;
-use parko_core::{ClearanceLoop, ClearanceState};
+use parko_core::{
+    AgentScene, ClearanceLoop, ClearanceState, ImpactCfg, ImpactEvidence, VanishedCfg,
+    VanishedObjectDetector,
+};
 use tokio::sync::Mutex as AsyncMutex;
 
 use kirra_runtime_sdk::verifier_store::VerifierStore;
@@ -49,7 +74,48 @@ use parko_kirra::clearance_delivery::{ClearanceDelivery, DeliveryOutcome};
 
 use crate::command_mapping::OutgoingTwist;
 use crate::config::ParkoNodeConfig;
+use crate::sensor_mapping::ImuSample;
 use crate::tick_pipeline::{current_time_ms, run_pipeline_tick_inner, TickOutcome};
+
+/// The node's live impact-sensor readings for ONE tick, assembled into an
+/// [`ImpactEvidence`] inside the gate. The node fills this from its optional IMU
+/// + contact subscriptions; absent sources stay at their no-signal defaults.
+#[derive(Debug, Clone, Default)]
+pub struct ImpactInputs {
+    /// The latest IMU sample, or `None` when no IMU topic is configured. `None`
+    /// contributes NO deceleration spike (never a fabricated value).
+    pub imu: Option<ImuSample>,
+    /// The latest contact-sensor reading (`false` when no contact topic is
+    /// configured — a missing sensor reads as "no contact", reduced coverage).
+    pub contact: bool,
+}
+
+/// Convention-free deceleration proxy: the Euclidean magnitude of the IMU
+/// linear-acceleration vector (m/s²). We deliberately do NOT assume a forward
+/// axis or remove gravity — both would invent a convention the sample does not
+/// carry (gravity removal needs the orientation, which is `Option` and may be
+/// absent). `ImpactEvidence::imu_accel_spike_mps2` is a "spike MAGNITUDE", and
+/// the threshold (default 30 m/s²) sits well above the ~9.81 m/s² gravity
+/// baseline, so a static vehicle never crosses it; a collision-grade total
+/// acceleration crosses it regardless of impact direction.
+#[must_use]
+fn decel_magnitude(imu: &ImuSample) -> f64 {
+    let a = imu.linear_acceleration;
+    ((a[0] as f64).powi(2) + (a[1] as f64).powi(2) + (a[2] as f64).powi(2)).sqrt()
+}
+
+/// Build the SG6 [`ImpactEvidence`] for one tick from the node's live inputs +
+/// the (already-evaluated) vanished flag. An absent IMU contributes `0.0` (a
+/// finite below-threshold value — "no spike observed", never a NaN or a
+/// fabricated spike).
+#[must_use]
+fn assemble_evidence(inputs: &ImpactInputs, vanished: bool) -> ImpactEvidence {
+    ImpactEvidence {
+        imu_accel_spike_mps2: inputs.imu.as_ref().map_or(0.0, decel_magnitude),
+        contact_sensor: inputs.contact,
+        vanished_object: vanished,
+    }
+}
 
 /// Node-owned clearance components: the per-vehicle [`ClearanceDelivery`] (store
 /// pickup, scoped to THIS node's id) plus the node's own [`ClearanceLoop`] (the
@@ -58,18 +124,54 @@ use crate::tick_pipeline::{current_time_ms, run_pipeline_tick_inner, TickOutcome
 pub struct NodeClearance {
     delivery: ClearanceDelivery,
     clearance_loop: ClearanceLoop,
+    /// SG6 fusion config (the decel threshold). Deployment-tunable via the node
+    /// config; defaults to [`ImpactCfg::default`].
+    cfg: ImpactCfg,
+    /// The vanished-object detector, behind an `Option` GATED ON A SCENE SOURCE.
+    /// `None` today: no `AgentScene` flows through the M2 tick (the deferred
+    /// remainder of #309). When a scene source lands, this is `Some` and run per
+    /// tick against the supplied scene.
+    vanished: Option<VanishedObjectDetector>,
+    /// Config for the vanished detector (parko-core default until tuned).
+    vanished_cfg: VanishedCfg,
 }
 
 impl NodeClearance {
     /// Wrap a pre-built [`ClearanceDelivery`] with a fresh [`ClearanceLoop`].
     /// (The binary builds the delivery via [`ClearanceDelivery::open_signed`];
-    /// tests build it from an in-memory store.)
+    /// tests build it from an in-memory store.) Impact detection uses
+    /// [`ImpactCfg::default`] until [`with_impact_cfg`](Self::with_impact_cfg)
+    /// tunes it; the vanished trigger is OFF (no scene source) until
+    /// [`with_vanished_detection`](Self::with_vanished_detection) enables it.
     #[must_use]
     pub fn new(delivery: ClearanceDelivery) -> Self {
         Self {
             delivery,
             clearance_loop: ClearanceLoop::new(),
+            cfg: ImpactCfg::default(),
+            vanished: None,
+            vanished_cfg: VanishedCfg::default(),
         }
+    }
+
+    /// Set the SG6 impact-fusion config (the decel spike threshold). The binary
+    /// threads this from `ParkoNodeConfig::impact_cfg()`.
+    #[must_use]
+    pub fn with_impact_cfg(mut self, cfg: ImpactCfg) -> Self {
+        self.cfg = cfg;
+        self
+    }
+
+    /// Enable the vanished-object trigger with the given config. The caller MUST
+    /// also supply an `AgentScene` per tick (via
+    /// [`observe_tick`](Self::observe_tick)) for it to fire — enabling the
+    /// detector without a scene source still yields `vanished = false`. Off by
+    /// default; this is the seam the scene-sourcing follow-up flips on.
+    #[must_use]
+    pub fn with_vanished_detection(mut self, cfg: VanishedCfg) -> Self {
+        self.vanished = Some(VanishedObjectDetector::new());
+        self.vanished_cfg = cfg;
+        self
     }
 
     /// Build a node clearance over an existing shared store handle and node id.
@@ -112,15 +214,33 @@ impl NodeClearance {
         self.delivery.poll_and_deliver(&mut self.clearance_loop, now_ms)
     }
 
-    /// Drive one detection observation into the node-owned loop. This is the seam
-    /// the live-detection-feed follow-up wires to real impact evidence; the tick
-    /// integration here does NOT call it (detection-from-the-tick is out of scope).
-    /// Exposed so tests can drive the loop into an immobilized state through the
-    /// REAL state machine (never by poking internals).
+    /// Assemble this tick's [`ImpactEvidence`] from the node's live inputs and
+    /// drive ONE observation into the loop (#309). The vanished trigger runs the
+    /// detector ONLY when both it is enabled AND a `scene` is supplied; otherwise
+    /// `vanished = false` (the deferred trigger, never fabricated). This is the
+    /// detection step the tick calls between delivery and the immobilized gate.
+    pub fn observe_tick(
+        &mut self,
+        inputs: &ImpactInputs,
+        scene: Option<&AgentScene>,
+        now_ms: u64,
+    ) {
+        let vanished = match (self.vanished.as_mut(), scene) {
+            (Some(det), Some(sc)) => det.observe(sc, now_ms, &self.vanished_cfg),
+            _ => false,
+        };
+        let evidence = assemble_evidence(inputs, vanished);
+        self.clearance_loop.observe(&evidence, &self.cfg, now_ms);
+    }
+
+    /// Drive one observation into the loop from EXPLICIT evidence (bypassing the
+    /// input-assembly + config). The seam tests use to drive the loop into an
+    /// immobilized state through the REAL state machine (never by poking
+    /// internals).
     pub fn observe(
         &mut self,
-        evidence: &parko_core::ImpactEvidence,
-        cfg: &parko_core::ImpactCfg,
+        evidence: &ImpactEvidence,
+        cfg: &ImpactCfg,
         now_ms: u64,
     ) {
         self.clearance_loop.observe(evidence, cfg, now_ms);
@@ -144,20 +264,31 @@ pub struct ClearedTickOutcome {
 
 /// Drive one tick with the node-owned clearance gate wired in. When `clearance`
 /// is `None` (delivery disabled — the dev lane) this is exactly the existing
-/// posture-gated tick with no veto and no pickup.
+/// posture-gated tick with no veto, no pickup, and no detection.
 ///
-/// Order is load-bearing: deliver FIRST (a grant delivered this tick releases the
-/// loop), then run the posture-gated tick, then apply the veto reading the
-/// POST-delivery immobilization state — so a just-cleared loop resumes motion the
-/// same tick, and a still-immobilized loop stops regardless of posture.
+/// Order is load-bearing (see the module doc's HELD LINE): (1) deliver FIRST so a
+/// grant clears the loop against its poll-time state; (2) THEN run detection
+/// (`observe_tick`) which may latch on this tick's evidence — so a grant consumed
+/// in (1) can never clear an impact latched in (2); (3) run the posture-gated
+/// tick; (4) apply the veto reading the POST-delivery, POST-detection
+/// immobilization state. A just-cleared loop with no new impact resumes motion
+/// the same tick; a freshly-latched (or still-immobilized) loop stops regardless
+/// of posture.
 ///
-// SAFETY: SG6 | REQ: parko-ros2-clearance-veto-and-delivery | TEST: latched_loop_stops_tick_even_at_nominal,pending_grant_delivers_and_resumes,no_clearance_gate_ticks_normally,grant_for_other_node_not_picked_up
+/// `inputs` are the node's live impact-sensor readings for this tick; `scene` is
+/// the optional `AgentScene` for the vanished trigger (`None` until a scene
+/// source is wired — the #309 remainder).
+///
+// SAFETY: SG6 | REQ: parko-ros2-clearance-detect-veto-and-delivery | TEST: decel_spike_latches_and_stops_at_nominal,contact_latches,no_signals_never_latch_across_many_ticks,delivery_before_detection_ordering_holds,full_lifecycle_detect_clear_resume,latched_loop_stops_tick_even_at_nominal,pending_grant_delivers_and_resumes,no_clearance_gate_ticks_normally,grant_for_other_node_not_picked_up
+#[allow(clippy::too_many_arguments)]
 pub async fn run_pipeline_tick_with_clearance<B>(
     config: &ParkoNodeConfig,
     loop_mutex: Arc<AsyncMutex<InferenceLoop<B>>>,
     frame: SensorFrame,
     posture: SafetyPosture,
     clearance: Option<&mut NodeClearance>,
+    inputs: &ImpactInputs,
+    scene: Option<&AgentScene>,
 ) -> ClearedTickOutcome
 where
     B: InferenceBackend + 'static,
@@ -166,13 +297,21 @@ where
     let mut clearance = clearance;
 
     // 1. DELIVERY — one pickup per tick (NoGrant no-op when nothing pending).
+    //    Matched against the loop's poll-time state, BEFORE this tick's detection.
     let delivery = clearance.as_deref_mut().map(|c| c.poll(now_ms));
 
-    // 2. The normal posture-gated tick (the LockedOut stop path lives inside).
+    // 2. DETECTION (#309) — assemble live evidence + observe; may latch. Because
+    //    this follows delivery, a grant consumed in step 1 can never clear an
+    //    impact that latches here (the held line).
+    if let Some(c) = clearance.as_deref_mut() {
+        c.observe_tick(inputs, scene, now_ms);
+    }
+
+    // 3. The normal posture-gated tick (the LockedOut stop path lives inside).
     let mut tick = run_pipeline_tick_inner(config, loop_mutex, frame, posture).await;
 
-    // 3. THE STOP TIE-IN — immobilized (post-delivery) → stop regardless of
-    //    posture, alongside the governor's LockedOut stop.
+    // 4. THE STOP TIE-IN — immobilized (post-delivery, post-detection) → stop
+    //    regardless of posture, alongside the governor's LockedOut stop.
     let vetoed = clearance.as_deref().is_some_and(NodeClearance::is_immobilized);
     if vetoed {
         tick.twist = OutgoingTwist::stopped(now_ms);
@@ -267,6 +406,8 @@ mod tests {
             fresh_frame(1),
             SafetyPosture::Nominal,
             Some(&mut nc),
+            &ImpactInputs::default(),
+            None,
         )
         .await;
 
@@ -301,6 +442,8 @@ mod tests {
             fresh_frame(2),
             SafetyPosture::Nominal,
             Some(&mut nc),
+            &ImpactInputs::default(),
+            None,
         )
         .await;
 
@@ -325,6 +468,8 @@ mod tests {
             fresh_frame(3),
             SafetyPosture::Nominal,
             Some(&mut nc),
+            &ImpactInputs::default(),
+            None,
         )
         .await;
         assert_eq!(out2.delivery, Some(DeliveryOutcome::NoGrant), "grant consumed — no retry");
@@ -341,6 +486,8 @@ mod tests {
             infer,
             fresh_frame(4),
             SafetyPosture::Nominal,
+            None,
+            &ImpactInputs::default(),
             None,
         )
         .await;
@@ -377,6 +524,8 @@ mod tests {
             fresh_frame(5),
             SafetyPosture::Nominal,
             Some(&mut nc),
+            &ImpactInputs::default(),
+            None,
         )
         .await;
 
@@ -388,5 +537,209 @@ mod tests {
         assert!(nc.is_immobilized(), "loop stays immobilized — nothing cleared it");
         assert!(out.vetoed, "still immobilized → still vetoed to a stop");
         assert_eq!(out.tick.twist.linear_x_mps, 0.0);
+    }
+
+    // -----------------------------------------------------------------------
+    // #309 — DETECTION-ARMED tick. The loop now latches from live evidence
+    // assembled inside `run_pipeline_tick_with_clearance`, not only via the
+    // manual `observe` driver.
+    // -----------------------------------------------------------------------
+
+    /// An IMU sample whose linear-acceleration vector has magnitude `mag` (m/s²)
+    /// along x. orientation absent (the decel proxy is convention-free).
+    fn imu_accel_mag(mag: f32) -> ImuSample {
+        ImuSample {
+            linear_acceleration: [mag, 0.0, 0.0],
+            angular_velocity: [0.0, 0.0, 0.0],
+            orientation: None,
+        }
+    }
+
+    /// One Nominal-posture tick driving the gate with `inputs` (no scene).
+    async fn tick(nc: &mut NodeClearance, inputs: &ImpactInputs) -> ClearedTickOutcome {
+        run_pipeline_tick_with_clearance(
+            &ParkoNodeConfig::default(),
+            build_loop(0.1, 0.2),
+            fresh_frame(900),
+            SafetyPosture::Nominal,
+            Some(nc),
+            inputs,
+            None,
+        )
+        .await
+    }
+
+    /// DECEL: a spike above threshold latches the loop and the tick publishes a
+    /// stop, even at Nominal posture — the vehicle latches ITSELF.
+    #[tokio::test(start_paused = true)]
+    async fn decel_spike_latches_and_stops_at_nominal() {
+        let infer = build_loop(0.1, 0.2);
+        let mut nc = NodeClearance::from_store(store(), "KIRRA-DEMO-03");
+        assert_eq!(nc.state(), ClearanceState::Normal);
+
+        // 40 m/s² total accel > the 30 m/s² default threshold → impact.
+        let inputs = ImpactInputs { imu: Some(imu_accel_mag(40.0)), contact: false };
+        let out = run_pipeline_tick_with_clearance(
+            &ParkoNodeConfig::default(),
+            infer,
+            fresh_frame(10),
+            SafetyPosture::Nominal,
+            Some(&mut nc),
+            &inputs,
+            None,
+        )
+        .await;
+
+        assert!(nc.is_immobilized(), "a decel spike must latch the loop from the tick");
+        assert!(out.vetoed, "latched → stop regardless of posture");
+        assert_eq!(out.tick.twist.linear_x_mps, 0.0);
+        assert_eq!(out.tick.twist.angular_z_rads, 0.0);
+    }
+
+    /// CONTACT: a contact-sensor true latches the loop and stops the vehicle.
+    #[tokio::test(start_paused = true)]
+    async fn contact_latches() {
+        let infer = build_loop(0.1, 0.2);
+        let mut nc = NodeClearance::from_store(store(), "KIRRA-DEMO-03");
+
+        let inputs = ImpactInputs { imu: None, contact: true };
+        let out = run_pipeline_tick_with_clearance(
+            &ParkoNodeConfig::default(),
+            infer,
+            fresh_frame(11),
+            SafetyPosture::Nominal,
+            Some(&mut nc),
+            &inputs,
+            None,
+        )
+        .await;
+
+        assert!(nc.is_immobilized(), "contact=true is a definitive impact → latch");
+        assert!(out.vetoed);
+        assert_eq!(out.tick.twist.linear_x_mps, 0.0);
+    }
+
+    /// NO-FALSE-LATCH: gravity-only IMU (≈9.81 m/s², below threshold) + no
+    /// contact must NEVER latch, across many ticks. The proof a static / cruising
+    /// vehicle is not spuriously immobilized.
+    #[tokio::test(start_paused = true)]
+    async fn no_signals_never_latch_across_many_ticks() {
+        let mut nc = NodeClearance::from_store(store(), "KIRRA-DEMO-03");
+        // gravity baseline magnitude, well under the 30 m/s² threshold.
+        let inputs = ImpactInputs { imu: Some(imu_accel_mag(9.81)), contact: false };
+
+        for i in 0..50 {
+            let infer = build_loop(0.1, 0.2);
+            let out = run_pipeline_tick_with_clearance(
+                &ParkoNodeConfig::default(),
+                infer,
+                fresh_frame(200 + i),
+                SafetyPosture::Nominal,
+                Some(&mut nc),
+                &inputs,
+                None,
+            )
+            .await;
+            assert_eq!(nc.state(), ClearanceState::Normal, "tick {i}: must not latch on sub-threshold accel");
+            assert!(!out.vetoed, "tick {i}: no veto");
+            assert!(
+                (out.tick.twist.linear_x_mps - 0.1).abs() < 1e-4,
+                "tick {i}: command flows (no spurious stop); got {}",
+                out.tick.twist.linear_x_mps
+            );
+        }
+    }
+
+    /// THE ORDERING PROOF (held line): a pending grant AND new impact evidence on
+    /// the SAME tick. Delivery (step 1) clears the OLD escalation; detection
+    /// (step 2) re-latches on the new evidence; the loop ENDS the tick latched and
+    /// the command is stopped. The grant could not clear the new impact.
+    #[tokio::test(start_paused = true)]
+    async fn delivery_before_detection_ordering_holds() {
+        let s = store();
+        let mut nc = NodeClearance::from_store(s.clone(), "KIRRA-DEMO-03");
+        immobilize(&mut nc, 2); // -> EscalationRaised (the OLD incident)
+        assert_eq!(nc.state(), ClearanceState::EscalationRaised);
+
+        // A grant is pending for the OLD escalation.
+        let now = current_time_ms();
+        s.lock()
+            .unwrap()
+            .save_clearance_grant_chained("KIRRA-DEMO-03", "alice", now)
+            .expect("record grant");
+
+        // Same tick: a NEW impact arrives (contact).
+        let infer = build_loop(0.1, 0.2);
+        let inputs = ImpactInputs { imu: None, contact: true };
+        let out = run_pipeline_tick_with_clearance(
+            &ParkoNodeConfig::default(),
+            infer,
+            fresh_frame(12),
+            SafetyPosture::Nominal,
+            Some(&mut nc),
+            &inputs,
+            None,
+        )
+        .await;
+
+        assert!(
+            matches!(out.delivery, Some(DeliveryOutcome::Cleared { .. })),
+            "the grant is consumed against the OLD escalation; got {:?}",
+            out.delivery
+        );
+        assert_eq!(
+            nc.state(),
+            ClearanceState::Latched,
+            "detection re-latches AFTER delivery — the grant cannot clear the new impact"
+        );
+        assert!(out.vetoed, "re-latched → still stopped");
+        assert_eq!(out.tick.twist.linear_x_mps, 0.0);
+    }
+
+    /// FULL VEHICLE LIFECYCLE, now detection-armed: live impact latches → escalates
+    /// → operator grant clears → motion resumes, all driven through the tick.
+    #[tokio::test(start_paused = true)]
+    async fn full_lifecycle_detect_clear_resume() {
+        let s = store();
+        let mut nc = NodeClearance::from_store(s.clone(), "KIRRA-DEMO-03");
+        let no_impact = ImpactInputs::default();
+
+        // Tick 1: a decel spike LATCHES the loop from live evidence.
+        let spike = ImpactInputs { imu: Some(imu_accel_mag(40.0)), contact: false };
+        let out1 = tick(&mut nc, &spike).await;
+        assert_eq!(nc.state(), ClearanceState::Latched, "tick 1 latches on the spike");
+        assert!(out1.vetoed);
+
+        // Tick 2: no new impact — the transient Latched escalates to operator-required.
+        let out2 = tick(&mut nc, &no_impact).await;
+        assert_eq!(nc.state(), ClearanceState::EscalationRaised, "tick 2 escalates");
+        assert!(out2.vetoed, "still immobilized → still stopped");
+
+        // The operator records a grant.
+        let now = current_time_ms();
+        s.lock()
+            .unwrap()
+            .save_clearance_grant_chained("KIRRA-DEMO-03", "alice", now)
+            .expect("record grant");
+
+        // Tick 3: delivery clears the loop; no new impact → veto lifts, motion resumes.
+        let out3 = tick(&mut nc, &no_impact).await;
+        assert!(
+            matches!(out3.delivery, Some(DeliveryOutcome::Cleared { .. })),
+            "tick 3 delivers the grant; got {:?}",
+            out3.delivery
+        );
+        assert_eq!(nc.state(), ClearanceState::Normal, "loop recovers to Normal");
+        assert!(!out3.vetoed, "veto lifts");
+        assert!(
+            (out3.tick.twist.linear_x_mps - 0.1).abs() < 1e-4,
+            "motion resumes — governed forward command; got {}",
+            out3.tick.twist.linear_x_mps
+        );
+
+        // Tick 4: stays recovered, command continues.
+        let out4 = tick(&mut nc, &no_impact).await;
+        assert_eq!(nc.state(), ClearanceState::Normal);
+        assert!(!out4.vetoed);
     }
 }

--- a/parko/crates/parko-ros2/src/config.rs
+++ b/parko/crates/parko-ros2/src/config.rs
@@ -51,6 +51,27 @@ pub struct ParkoNodeConfig {
     /// from this one value, so their thread counts cannot diverge (the #152
     /// cross-backend asymmetry guard).
     pub num_threads: usize,
+
+    /// SG6 (#309) optional IMU topic (`sensor_msgs/Imu`). When set, the node
+    /// subscribes and feeds the per-tick deceleration spike into the clearance
+    /// loop's impact detection. `None` → no IMU source: the decel trigger is
+    /// inactive (reduced detection coverage, logged at startup — never a
+    /// fabricated spike).
+    pub imu_topic: Option<String>,
+
+    /// SG6 (#309) optional contact-sensor topic (`std_msgs/Bool`). When set, a
+    /// `true` reading is a definitive impact and latches the loop. `None` → no
+    /// contact source: that trigger is inactive (reduced coverage, logged).
+    pub contact_topic: Option<String>,
+
+    /// SG6 (#309) IMU deceleration-spike threshold (m/s²) — the
+    /// [`parko_core::ImpactCfg`] `spike_threshold_mps2`. **Deployment-tunable,
+    /// VALIDATION-PENDING** (parko-core default 30.0 m/s² — a hard,
+    /// collision-grade decel, NOT a certified value). The tick reads the IMU
+    /// linear-acceleration vector magnitude (gravity-inclusive) and latches when
+    /// it exceeds this; the default sits well above the ~9.81 m/s² gravity
+    /// baseline, so a static vehicle never latches. Tune on track-test / SOTIF.
+    pub spike_threshold_mps2: f64,
 }
 
 /// Placeholder for an MRC fallback override. Today's MRC is always
@@ -69,6 +90,12 @@ impl Default for ParkoNodeConfig {
             sensor_staleness_budget_ms: 200,
             mrc_command: OutgoingTwistDefaults,
             num_threads: 1,
+            // SG6 detection sources default OFF — a missing sensor is reduced
+            // coverage, stated loudly at startup, never fabricated.
+            imu_topic: None,
+            contact_topic: None,
+            // parko-core ImpactCfg default (VALIDATION-PENDING, deployment-tunable).
+            spike_threshold_mps2: parko_core::ImpactCfg::default().spike_threshold_mps2,
         }
     }
 }
@@ -85,6 +112,16 @@ impl ParkoNodeConfig {
     #[must_use]
     pub fn inference_threads(&self) -> parko_core::InferenceThreads {
         parko_core::InferenceThreads::new(self.num_threads)
+    }
+
+    /// The SG6 [`parko_core::ImpactCfg`] this node uses for impact fusion,
+    /// built from the (deployment-tunable) `spike_threshold_mps2`. One source,
+    /// so the tick and any diagnostics read the same threshold.
+    #[must_use]
+    pub fn impact_cfg(&self) -> parko_core::ImpactCfg {
+        parko_core::ImpactCfg {
+            spike_threshold_mps2: self.spike_threshold_mps2,
+        }
     }
 }
 
@@ -115,6 +152,25 @@ mod tests {
         assert_eq!(cfg.inference_threads().num_threads, 4);
         assert!(!cfg.inference_threads().bitwise_reproducible(),
             "raising threads gives up bitwise reproducibility");
+    }
+
+    #[test]
+    fn sg6_detection_sources_default_off_and_threshold_is_parko_core_default() {
+        let cfg = ParkoNodeConfig::default();
+        assert!(cfg.imu_topic.is_none(), "IMU source off by default (reduced coverage, stated)");
+        assert!(cfg.contact_topic.is_none(), "contact source off by default");
+        // The threshold mirrors parko-core's ImpactCfg default, and impact_cfg()
+        // round-trips it.
+        let core_default = parko_core::ImpactCfg::default().spike_threshold_mps2;
+        assert!((cfg.spike_threshold_mps2 - core_default).abs() < 1e-9);
+        assert!((cfg.impact_cfg().spike_threshold_mps2 - core_default).abs() < 1e-9);
+    }
+
+    #[test]
+    fn impact_cfg_reflects_a_tuned_threshold() {
+        let cfg = ParkoNodeConfig { spike_threshold_mps2: 22.5, ..ParkoNodeConfig::default() };
+        assert!((cfg.impact_cfg().spike_threshold_mps2 - 22.5).abs() < 1e-9,
+            "impact_cfg() must carry the deployment-tuned threshold");
     }
 
     #[test]

--- a/parko/crates/parko-ros2/src/node.rs
+++ b/parko/crates/parko-ros2/src/node.rs
@@ -20,17 +20,19 @@
 //     next-milestone deliverable. For M2 the node accepts a posture
 //     parameter (CLI / env) and defaults to `Nominal`.
 
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 
 use parko_core::backend::InferenceBackend;
 use parko_core::safety::SafetyPosture;
 use parko_core::scheduler::InferenceLoop;
 use tokio::sync::Mutex;
 
-use crate::clearance_gate::{run_pipeline_tick_with_clearance, NodeClearance};
+use crate::clearance_gate::{run_pipeline_tick_with_clearance, ImpactInputs, NodeClearance};
 use crate::command_mapping::OutgoingTwist;
 use crate::config::ParkoNodeConfig;
-use crate::sensor_mapping::SensorInputMapping;
+use crate::imu_shim::imu_msg_to_sample;
+use crate::sensor_mapping::{ImuSample, SensorInputMapping};
 use crate::tick_pipeline::TickError;
 use parko_kirra::clearance_delivery::DeliveryOutcome;
 
@@ -88,10 +90,78 @@ where
         r2r::QosProfile::default(),
     )?;
 
+    // --- SG6 impact-detection sources (#309) --------------------------
+    //
+    // Optional IMU (decel) + contact subscriptions feed the per-tick
+    // `ImpactInputs`. Each runs a background drain task that writes the
+    // LATEST reading into a shared cell; the tick reads them. A missing
+    // source is REDUCED detection coverage, logged loudly — never a
+    // fabricated reading (absent IMU → no decel; absent contact → `false`).
+    // Detection only matters when the clearance gate is active.
+    let detection_enabled = clearance.is_some();
+    let latest_imu: Arc<StdMutex<Option<ImuSample>>> = Arc::new(StdMutex::new(None));
+    let contact_state: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+
+    if detection_enabled {
+        match &config.imu_topic {
+            Some(topic) => {
+                let imu_stream =
+                    node.subscribe::<r2r::sensor_msgs::msg::Imu>(topic, r2r::QosProfile::default())?;
+                let cell = Arc::clone(&latest_imu);
+                tokio::spawn(async move {
+                    use futures::StreamExt;
+                    let mut s = imu_stream;
+                    while let Some(msg) = s.next().await {
+                        let sample = imu_msg_to_sample(&msg);
+                        if let Ok(mut g) = cell.lock() {
+                            *g = Some(sample);
+                        }
+                    }
+                    tracing::warn!("parko-ros2: IMU stream closed — decel detection now inactive");
+                });
+                tracing::info!(topic = %topic,
+                    "parko-ros2: SG6 decel detection ARMED (IMU → spike-magnitude latch)");
+            }
+            None => tracing::warn!(
+                "parko-ros2: SG6 decel detection NOT wired (no imu_topic) — REDUCED detection \
+                 coverage; the clearance loop will not latch on hard deceleration."
+            ),
+        }
+        match &config.contact_topic {
+            Some(topic) => {
+                let contact_stream =
+                    node.subscribe::<r2r::std_msgs::msg::Bool>(topic, r2r::QosProfile::default())?;
+                let cell = Arc::clone(&contact_state);
+                tokio::spawn(async move {
+                    use futures::StreamExt;
+                    let mut s = contact_stream;
+                    while let Some(msg) = s.next().await {
+                        cell.store(msg.data, Ordering::Relaxed);
+                    }
+                    tracing::warn!("parko-ros2: contact stream closed — contact detection now inactive");
+                });
+                tracing::info!(topic = %topic, "parko-ros2: SG6 contact detection ARMED");
+            }
+            None => tracing::warn!(
+                "parko-ros2: SG6 contact detection NOT wired (no contact_topic) — REDUCED detection \
+                 coverage; the clearance loop will not latch on a contact-sensor hit."
+            ),
+        }
+        // The vanished-object trigger needs an AgentScene per tick; no scene
+        // source flows through the M2 tick yet (the #309 remainder). The node
+        // passes `scene = None`; the detector stays unfed.
+        tracing::warn!(
+            "parko-ros2: SG6 vanished-object detection NOT wired (no AgentScene source in the \
+             tick) — REDUCED detection coverage; tracked as the remainder of #309."
+        );
+    }
+
     // --- Drain task: consume the sensor stream, tick, publish ---------
     let drain_config  = Arc::clone(&config);
     let drain_infer   = Arc::clone(&infer);
     let drain_mapping = Arc::clone(&mapping);
+    let drain_imu     = Arc::clone(&latest_imu);
+    let drain_contact = Arc::clone(&contact_state);
 
     let drain_task = tokio::spawn(async move {
         use futures::StreamExt;
@@ -119,12 +189,22 @@ where
                 .unwrap_or(0);
             frame_id = frame_id.saturating_add(1);
             let frame = drain_mapping.to_frame(frame_id, stamp_ms, &sample_vec);
+
+            // Assemble this tick's SG6 evidence from the latest sensor readings.
+            // Absent sources read as their no-signal defaults (no fabrication).
+            let impact_inputs = ImpactInputs {
+                imu: drain_imu.lock().ok().and_then(|g| *g),
+                contact: drain_contact.load(Ordering::Relaxed),
+            };
+
             let cleared = run_pipeline_tick_with_clearance(
                 &drain_config,
                 Arc::clone(&drain_infer),
                 frame,
                 posture,
                 clearance.as_mut(),
+                &impact_inputs,
+                None, // AgentScene source deferred (#309 remainder)
             ).await;
             let outcome = cleared.tick;
 


### PR DESCRIPTION
Issue #309: arm the node's clearance loop from live SG6 detection in the tick. Before this PR the gate's loop only latched via external drivers (or tests); now the vehicle **latches itself** from real evidence. Talisman untouched.

---

## STEP 0 — Grounding (results)

**a. `ImpactEvidence` / `ImpactCfg` semantics — and a corrected premise.**
`ImpactEvidence { imu_accel_spike_mps2: f64, contact_sensor: bool, vanished_object: bool }`; `ImpactCfg { spike_threshold_mps2: f64 }` (default **30.0 m/s²**, VALIDATION-PENDING). Fusion (`is_impact`) is OR: contact, OR a *finite* IMU spike `> threshold`, OR vanished. The IMU term is a **deceleration-spike magnitude (m/s²)**.

> **Correction surfaced:** the task framed decel as coming "from the IMU sample already in the tick" — **it is not there today.** The M2 node subscribes to a single opaque observation topic (`Float32MultiArray` → `VectorMapping`); the IMU mapping (`imu_shim` / `ImuMapping`) exists but is **unwired** into the node's subscriptions. So decel, like contact, has **no live source** in the current tick. I therefore source decel via a **new optional IMU subscription** (symmetric with contact), reusing the existing `imu_shim::imu_msg_to_sample` — **no invented axis convention**: the decel proxy is the convention-free **vector magnitude** `‖linear_acceleration‖` (no forward-axis assumption; no gravity removal, which would need the `Option`al orientation). The 30 m/s² threshold sits well above the ~9.81 m/s² gravity baseline, so a static vehicle never latches.

**b. `AgentScene` / contact through the tick — both confirmed NO.** No `AgentScene` flows through the tick (scenes were always checker/integrator-side input); no contact input existed. Both are the expected NOs.

**c. The #310 gate ordering** was `poll_and_deliver` → posture tick → immobilized gate. This PR inserts **detection** between delivery and the gate.

---

## What this PR wires

**`clearance_gate.rs`** — the tick gains a DETECTION step (now three touches, in order): **(1) deliver**, **(2) detect** (`observe_tick` assembles `ImpactEvidence` from live inputs and observes the loop — may latch), **(3) the stop tie-in**. New surface:
- `ImpactInputs { imu: Option<ImuSample>, contact: bool }` + `decel_magnitude` (convention-free) + `assemble_evidence` (absent IMU → `0.0`, a finite below-threshold value, never a NaN or fabricated spike).
- `NodeClearance` gains the `ImpactCfg`, an `Option<VanishedObjectDetector>` behind a **per-tick `AgentScene` seam** (the deferred vanished trigger), and `observe_tick`.
- `run_pipeline_tick_with_clearance` takes `&ImpactInputs` + `Option<&AgentScene>`.

**THE ORDERING HELD LINE (delivery before detection):** a grant consumed on a tick is matched against the loop's poll-time state; it can **never** clear an impact that latches on that same tick. Both at once → grant clears the old escalation, detection re-latches on the new evidence, the vehicle stays stopped, the operator re-issues. (Documented in the module doc + proven by a test.)

**`config.rs`** — the node config surface for the detection knobs: `imu_topic` / `contact_topic` (default `None`), `spike_threshold_mps2` (default = parko-core `ImpactCfg`, **deployment-tunable, VALIDATION-PENDING**), and `impact_cfg()`.

**`node.rs`** (ros2) — optional IMU (`sensor_msgs/Imu` via the existing `imu_msg_to_sample`) + contact (`std_msgs/Bool`) subscriptions feed shared latest-reading cells the tick reads into `ImpactInputs`. **A missing source is REDUCED detection coverage, logged loudly at startup — never a fabricated reading.** Scene source is `None` (the #309 remainder), also logged.

**`bin`** (ros2) — `build_config()` reads `PARKO_IMU_TOPIC` / `PARKO_CONTACT_TOPIC` / `PARKO_IMPACT_SPIKE_THRESHOLD_MPS2`; the gate is threaded `with_impact_cfg(config.impact_cfg())`.

**`docs/CONSOLE_RUNBOOK.md`** — "What latches the loop for real": decel + contact armed, vanished deferred, the detection env, and the held-line note.

## What's armed vs deferred (the #309 remainder)

| trigger | status |
|---|---|
| decel (IMU) | **armed** when `PARKO_IMU_TOPIC` set |
| contact | **armed** when `PARKO_CONTACT_TOPIC` set |
| vanished-object | **deferred** — needs an `AgentScene` per tick; no scene source flows through the tick yet. The detector sits behind a per-tick scene `Option` (node passes `None`). Sourcing the scene is the named remainder. |

## Tests (tick harness, no ROS runtime)

- **decel spike above threshold → latch + stop** at Nominal posture.
- **contact=true → latch.**
- **sub-threshold accel (gravity ≈9.81) + no contact → never latches across 50 ticks** (the no-false-latch proof).
- **pending grant + same-tick new impact → grant consumed vs the OLD escalation, loop ends LATCHED, stopped** (the ordering proof).
- **full lifecycle: detect → escalate → grant clears → resume.**
- plus config default / tuned-threshold tests.

`cargo test -p parko-ros2` **153 pass** (7 new). Clippy clean (the only `--all-targets` lint is a pre-existing `erasing_op` in `sensor_mapping.rs` tests, untouched here). The `ros2`-gated `node.rs` + binary don't compile without a sourced ROS env (`r2r_rcl` build script needs `ROS_DISTRO`, same as #206/#310) — correct-by-reading, mirroring the adapter's typed-subscription idiom and the existing `imu_shim`.

## Scope / verify

- **Scope:** `parko-ros2` + the runbook only. **`parko-core` UNTOUCHED** — the evidence/cfg surface needed no change (the scope STOP-and-report condition was not triggered).
- **No new deps**; no `Cargo.toml` dependency edits.
- Talisman `997fb7ae15ce3e11adec9218044c7c84b049ad3b` **byte-identical**.

Closes the armed-detection half of #309; the vanished-object scene source remains tracked there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_