### PR TITLE
feat(gateway): per-class contract profile family + VRU courier profile — siblings of the frozen instance (#312, #313)

### DIFF
--- a/docs/CONTRACT_PROFILES.md
+++ b/docs/CONTRACT_PROFILES.md
@@ -1,0 +1,147 @@
+# Per-Class Contract Profiles — the Kinematic Contract Family
+
+| Field | Value |
+|---|---|
+| Issues | **#312** (per-class profiles), **#313** (VRU-dense courier profile) |
+| Status | **NORMATIVE** for the per-class numbers — both code sides cite this table by parameter id |
+| Req id | **KIRRA-CLASS-PROFILES-001** |
+| Owns | `src/gateway/contract_profiles.rs` (envelope) · `parko-core/src/impact.rs::impact_cfg_for_class` (SG6 threshold) |
+
+> **This table is the single source of truth for the per-class numbers.** The two
+> code sides live in **separate workspaces with no dependency edge** (the SDK
+> gateway and parko-core), so they **cannot share values by import** — each carries
+> a deliberate, *cited* copy keyed to the parameter ids below. **Change a number ⇒
+> change it in all three places** (this table, `contract_profiles.rs`,
+> `impact_cfg_for_class`). A hidden copy is a future divergence; a cited copy is a
+> maintained one.
+
+---
+
+## The sibling rule (the held line)
+
+The frozen instance `src/gateway/kinematics_contract.rs`
+(`nominal_reference_profile` / `mrc_fallback_profile`, talisman blob
+`997fb7ae15ce3e11adec9218044c7c84b049ad3b`) is **NOT edited**. Per-class profiles
+are **siblings**: new constructors that *return the existing public
+`VehicleKinematicsContract` struct*, exactly the idiom the two canonical
+constructors already establish. The **robotaxi** class member **IS** the frozen
+instance — `contract_for(Robotaxi)` delegates to `nominal_reference_profile()`
+verbatim (zero new numbers), proven by a field-for-field equality test. A profile
+that required changing the talisman's layout would be a **finding, not a feature**.
+
+The family grows *beside* the frozen instance; the governor, the signed audit
+chain, and the operator console are **unchanged** across classes — the per-class
+delta is confined to the parameters below. See `docs/MARKET_AUTONOMOUS_SERVICES.md`
+§3c (why the market needs this) and `docs/ARCHITECTURE_STACK.md` §2 (the
+three-domain model + the frozen-talisman rule).
+
+## Status legend
+
+- **INHERITED-FROZEN** — equals the frozen instance; zero new number (robotaxi).
+- **VALIDATION-PENDING** — a flagged placeholder with a stated basis; **not** a
+  certified value (track-test / SOTIF / bench characterization pending). Same
+  honesty as the frozen instance's own footprint numbers and `ImpactCfg::default`.
+- **CONFIRMED** — a certified/validated value. *(None yet — this family is new.)*
+
+---
+
+## The class table (Nominal envelope)
+
+Every number below is **VALIDATION-PENDING** unless marked INHERITED-FROZEN.
+Units: speed/cap m/s; accel/brake/lat m/s²; steering deg; rate deg/s; distances m.
+
+| Param id | Courier (sidewalk) | Delivery-AV (road pod) | Robotaxi | Status (courier/dav) |
+|---|---|---|---|---|
+| `*.max_speed` | 3.0 | 12.0 | 35.0 | VALIDATION-PENDING / INHERITED-FROZEN |
+| `*.odd_cap` | **2.5** | **11.0** | 22.35 (`URBAN_ODD_SPEED_CAP_MPS`, ADR-0001) | VALIDATION-PENDING / INHERITED |
+| `*.accel` | 1.0 | 1.8 | 2.5 | VALIDATION-PENDING |
+| `*.brake` | 3.0 | 4.0 | 4.5 | VALIDATION-PENDING |
+| `*.steering` | 30.0 | 33.0 | 35.0 | VALIDATION-PENDING |
+| `*.steering_rate` | 30.0 | 40.0 | 45.0 | VALIDATION-PENDING |
+| `*.follow` | 2.0 | 3.5 | 2.0 | VALIDATION-PENDING |
+| `*.lat_accel` | 1.5 | 2.5 | 3.5 | VALIDATION-PENDING |
+| `*.wheelbase` | 0.5 | 1.9 | 2.8 | VALIDATION-PENDING |
+| `*.footprint` (w×l, overhangs) | 0.6 × 0.9 (0.2/0.2) | 1.1 × 2.9 (0.5/0.5) | 1.85 × 4.8 (0.9/1.1) | VALIDATION-PENDING |
+| `*.impact_spike` (SG6, parko) | **8.0** | **18.0** | 30.0 (`ImpactCfg::default`) | VALIDATION-PENDING / INHERITED-FROZEN |
+
+**MRC fallback** (degraded posture) is a stricter sibling per class: every limit
+≤ that class's Nominal limit, `follow` ≥ Nominal (the conservative direction), and
+the **footprint identical** (the vehicle does not shrink in degraded posture).
+These relations are asserted as structural invariants (see the validation gate).
+
+### Ordering sanity (asserted)
+`courier.effective_cap (2.5) < delivery-av (11.0) < robotaxi (35.0)` and
+`courier.impact_spike (8.0) < delivery-av (18.0) < robotaxi (30.0)`.
+
+---
+
+## VRU-dense rationale (#313 — why each courier bound is shaped by pedestrian proximity)
+
+The sidewalk-courier class operates in **VRU-dense pedestrian space**; commercial
+sidewalk-delivery fleets run at roughly **1.5–3 m/s** (walking-pace multiples).
+Every courier bound is shaped by that proximity:
+
+- **`odd_cap` = 2.5 m/s** — ~1.8× a 1.4 m/s walking pace; inside the 1.5–3 m/s
+  operating band. The pedestrian-space operational ceiling (sibling of
+  `URBAN_ODD_SPEED_CAP_MPS`, same ADR-0001 framing of an ODD cap distinct from the
+  mechanical max).
+- **`accel` = 1.0 m/s²** — gentle starts near pedestrians.
+- **`brake` = 3.0 m/s²** — firm service brake → **short absolute stopping distance**
+  (≈ 1.04 m at 2.5 m/s). Short stopping distance is the VRU-dense priority, and
+  `brake ≥ accel` holds.
+- **`lat_accel` = 1.5 m/s²** — gentle lateral comfort near VRUs (matches the frozen
+  MRC lateral limit); the bicycle-model clamp further bounds steering at speed.
+- **`follow` = 2.0 m** — conservative *relative to* the low speed (~0.8 s headway at
+  2.5 m/s plus the robot's short reaction).
+- **footprint** (0.6 × 0.9 m, 0.5 m wheelbase) — a small sidewalk robot; tight
+  envelopes for pedestrian-space maneuvering. All dimensions strictly positive.
+- **`impact_spike` = 8.0 m/s² (parko / SG6)** — a sidewalk collision at walking pace
+  produces a **small** decel signature, far below a road crash, so the trigger is
+  more sensitive — but above ordinary curb/bump jolts. **This value genuinely needs
+  bench characterization of low-speed collision decel signatures**; it is a flagged
+  placeholder, not a guessed certified number.
+
+---
+
+## The validation gate (the family's certification story)
+
+A profile that fails the frozen instance's properties **does not ship.** That
+inheritance is the gate: the proptest battery in
+`src/gateway/kinematics_proptest.rs` is **parameterized over every family member**
+(courier / delivery-av / robotaxi, Nominal + MRC). Each member must pass the same
+profile-agnostic properties — no panic, clamp-in-bounds, allow-implies-safe,
+bicycle-model-after-clamp, deterministic — plus the structural invariants
+(`brake ≥ accel`, `mrc ≤ nominal` per limit field, footprint positive, `cap ≤
+max_speed`). The robotaxi member's field-for-field equality with the frozen
+instance is the zero-drift proof.
+
+---
+
+## Selection rule — FAIL-CLOSED
+
+`VehicleClass::from_str` accepts case-insensitive `"courier"` / `"delivery-av"` /
+`"robotaxi"`. **Any other string is an `Err`** (the `KIRRA_BACKEND` pattern): a
+typo'd class must **never** silently select another class's (e.g. faster) envelope.
+There is no default class.
+
+## Deployment note (named, not built)
+
+Class **selection is integrator configuration** — the deployment chooses the class
+its vehicle belongs to, and the governor loads `contract_for(class)` /
+`impact_cfg_for_class(class)`. **Wiring class selection into the service / node
+binaries (an env var or config field) is a later step — named here, not built in
+this change.** This change delivers the profile *family* + the validation gate +
+the normative table; the binary plumbing is the remaining #312 work.
+
+---
+
+## Cross-references
+
+- `src/gateway/contract_profiles.rs` — the envelope family + `VehicleClass`
+  (fail-closed) + the per-class ODD-cap consts.
+- `parko-core/src/impact.rs::impact_cfg_for_class` — the SG6 per-class threshold
+  (the cited cross-workspace sibling).
+- `src/gateway/kinematics_contract.rs` — the **frozen instance** (talisman); never
+  edited.
+- `docs/MARKET_AUTONOMOUS_SERVICES.md` §3c · `docs/ARCHITECTURE_STACK.md` §2 ·
+  `docs/adr/0001-occy-odd-speed-cap.md` (the ODD-cap framing).

--- a/parko/crates/parko-core/src/impact.rs
+++ b/parko/crates/parko-core/src/impact.rs
@@ -49,6 +49,55 @@ impl Default for ImpactCfg {
     }
 }
 
+/// The vehicle class an [`ImpactCfg`] is selected for (#312 / #313). The SG6
+/// impact-decel threshold is class-shaped: a sidewalk collision at walking pace
+/// produces a far smaller decel signature than a road-speed crash.
+///
+/// CROSS-WORKSPACE DUPLICATION (stated, not hidden). The kinematic-envelope side
+/// of this family lives in `kirra-runtime-sdk`'s
+/// `src/gateway/contract_profiles.rs` (`VehicleClass` + `contract_for`). parko-core
+/// and the SDK gateway are **separate workspaces with no dependency edge**, so this
+/// class enum and the thresholds below **cannot be shared by import** — they are a
+/// deliberate, CITED copy. The single source of truth for the per-class numbers is
+/// the normative table `docs/CONTRACT_PROFILES.md`; both sides cite it by parameter
+/// id. A hidden copy is a future divergence; a cited copy is a maintained one — if
+/// you change a number here, change `docs/CONTRACT_PROFILES.md` and the SDK side too.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VehicleClass {
+    /// Sidewalk courier — pedestrian-space, low-speed (#313).
+    Courier,
+    /// Road-going delivery AV (Nuro-shape pod).
+    DeliveryAv,
+    /// Robotaxi — full-speed. The frozen reference; uses [`ImpactCfg::default`].
+    Robotaxi,
+}
+
+/// The SG6 [`ImpactCfg`] for `class`. **Does NOT touch [`ImpactCfg::default`]** —
+/// the robotaxi member delegates to it (the default IS the robotaxi-class value;
+/// zero new number), and the other members are siblings.
+///
+/// Every non-inherited threshold is **VALIDATION-PENDING** (bench/SOTIF
+/// characterization, NOT certified) and is the parko mirror of the value in
+/// `docs/CONTRACT_PROFILES.md` (param `*.impact_spike`).
+#[must_use]
+pub fn impact_cfg_for_class(class: VehicleClass) -> ImpactCfg {
+    match class {
+        // Robotaxi = the frozen default (road-speed collision-grade decel, 30 m/s²).
+        VehicleClass::Robotaxi => ImpactCfg::default(),
+        // VALIDATION-PENDING: a road-pod collision at ~11 m/s decelerates less
+        // violently than a full-speed crash; a mid threshold pending bench data.
+        // (CONTRACT_PROFILES.md delivery-av.impact_spike)
+        VehicleClass::DeliveryAv => ImpactCfg { spike_threshold_mps2: 18.0 },
+        // VALIDATION-PENDING: a sidewalk collision at walking pace produces a SMALL
+        // decel signature — far below the road threshold — so the trigger must be
+        // more sensitive, but ABOVE ordinary curb/bump jolts. This value genuinely
+        // needs bench characterization of low-speed collision decel signatures; it
+        // is a flagged placeholder, NOT a guessed certified number.
+        // (CONTRACT_PROFILES.md courier.impact_spike)
+        VehicleClass::Courier => ImpactCfg { spike_threshold_mps2: 8.0 },
+    }
+}
+
 /// Conservative, fail-closed fusion: an impact is declared iff **ANY** signal
 /// fires —
 ///   * `contact_sensor` (definitive), OR
@@ -498,6 +547,43 @@ mod tests {
 
     fn cfg() -> ImpactCfg {
         ImpactCfg::default() // spike_threshold = 30.0
+    }
+
+    // --- Per-class ImpactCfg family (#312 / #313) --------------------------
+
+    #[test]
+    fn impact_cfg_for_class_is_constructible_for_every_class() {
+        for class in [VehicleClass::Courier, VehicleClass::DeliveryAv, VehicleClass::Robotaxi] {
+            let c = impact_cfg_for_class(class);
+            assert!(c.spike_threshold_mps2.is_finite() && c.spike_threshold_mps2 > 0.0,
+                "{class:?} threshold must be a positive finite value, got {}", c.spike_threshold_mps2);
+        }
+    }
+
+    #[test]
+    fn robotaxi_impact_cfg_is_the_frozen_default_courier_differs() {
+        // Robotaxi delegates to the frozen default (zero new number).
+        assert_eq!(
+            impact_cfg_for_class(VehicleClass::Robotaxi).spike_threshold_mps2,
+            ImpactCfg::default().spike_threshold_mps2,
+            "robotaxi must be the frozen default threshold"
+        );
+        // Courier is more sensitive (lower threshold) — a sidewalk collision is a
+        // smaller decel signature; it must NOT equal the robotaxi/road value.
+        let courier = impact_cfg_for_class(VehicleClass::Courier).spike_threshold_mps2;
+        let robotaxi = impact_cfg_for_class(VehicleClass::Robotaxi).spike_threshold_mps2;
+        assert!(courier != robotaxi, "courier threshold must differ from robotaxi");
+        assert!(courier < robotaxi, "courier (sidewalk) must be more sensitive than robotaxi (road)");
+        // Ordering sanity across the family: courier < delivery-av < robotaxi.
+        let delivery = impact_cfg_for_class(VehicleClass::DeliveryAv).spike_threshold_mps2;
+        assert!(courier < delivery && delivery < robotaxi,
+            "threshold ordering courier {courier} < delivery-av {delivery} < robotaxi {robotaxi}");
+    }
+
+    #[test]
+    fn impact_cfg_default_is_untouched() {
+        // The frozen default must remain exactly 30.0 (the family adds beside it).
+        assert_eq!(ImpactCfg::default().spike_threshold_mps2, 30.0);
     }
 
     fn clean() -> ImpactEvidence {

--- a/parko/crates/parko-core/src/lib.rs
+++ b/parko/crates/parko-core/src/lib.rs
@@ -73,9 +73,9 @@ pub use commit_zone::{
     CommitZoneMap, CommitZoneScene, ExitClearanceEvidence, NonYieldingAgent, NonYieldingScene,
 };
 pub use impact::{
-    is_impact, ClearanceLoop, ClearanceRejection, ClearanceState, ImpactCfg, ImpactEvidence,
-    ImpactLatch, OperatorClearanceGrant, VanishedCfg, VanishedObjectDetector,
-    DEFAULT_MAX_GRANT_AGE_MS,
+    impact_cfg_for_class, is_impact, ClearanceLoop, ClearanceRejection, ClearanceState, ImpactCfg,
+    ImpactEvidence, ImpactLatch, OperatorClearanceGrant, VanishedCfg, VanishedObjectDetector,
+    VehicleClass, DEFAULT_MAX_GRANT_AGE_MS,
 };
 pub use localization::{
     gate_commit_zone_scene, gate_water_scene, localization_trusted, LocalizationCfg,

--- a/src/gateway/contract_profiles.rs
+++ b/src/gateway/contract_profiles.rs
@@ -1,0 +1,403 @@
+// src/gateway/contract_profiles.rs
+//
+// Per-class kinematic contract profiles (#312) + the VRU-dense sidewalk-courier
+// profile (#313). The contract is a FAMILY parameterized by vehicle class —
+// courier (pedestrian-space, low-speed) / delivery-AV (road-going pod) / robotaxi
+// (full-speed) — sharing ONE governor, ONE signed chain, ONE console. The
+// per-class delta is confined to the envelope + ODD caps (+ the SG6 ImpactCfg
+// thresholds, which live in the parko workspace — see docs/CONTRACT_PROFILES.md).
+//
+// THE HELD LINE — siblings, never edits. The frozen instance
+// `src/gateway/kinematics_contract.rs` (talisman blob
+// 997fb7ae15ce3e11adec9218044c7c84b049ad3b) is NOT touched. Profiles are SIBLINGS:
+// new constructors here that return the existing public `VehicleKinematicsContract`
+// struct, exactly the idiom `nominal_reference_profile` / `mrc_fallback_profile`
+// already establish. The robotaxi class member IS the frozen instance (delegated
+// verbatim — zero new numbers); a profile that changed the talisman's layout would
+// be a finding, not a feature.
+//
+// NUMBER DISCIPLINE — every non-inherited number below is **VALIDATION-PENDING**
+// (track-test / SOTIF-derived, NOT a certified constant — the same honesty the
+// frozen instance and `ImpactCfg::default` already carry) and states its basis +
+// the normative anchor `docs/CONTRACT_PROFILES.md` (the per-parameter table). No
+// number appears here without a stated basis.
+//
+// SELECTION is FAIL-CLOSED (the `KIRRA_BACKEND` pattern): an unknown class string
+// is an `Err`, never a silent fallback to another class's envelope — a typo must
+// never select the wrong (e.g. faster) profile.
+//
+// CROSS-WORKSPACE DUPLICATION (stated, not hidden). The SG6 impact-decel side of
+// this family lives in the parko workspace: `parko-core`'s
+// `impact.rs::impact_cfg_for_class` (+ its own `VehicleClass`). parko-core and this
+// SDK gateway are **separate workspaces with no dependency edge**, so the class enum
+// and the per-class numbers **cannot be shared by import** — the copy is deliberate
+// and CITED. The single source of truth for every per-class number is the normative
+// table `docs/CONTRACT_PROFILES.md`; both sides cite it by parameter id. Change a
+// number here ⇒ change `docs/CONTRACT_PROFILES.md` and the parko side too.
+//
+// SAFETY: contract family | REQ: KIRRA-CLASS-PROFILES-001 | TEST: courier_str_roundtrips_case_insensitive,unknown_class_is_fail_closed_err,robotaxi_equals_frozen_nominal_field_for_field,robotaxi_mrc_equals_frozen_mrc,cap_ordering_courier_lt_deliveryav_lt_robotaxi,every_profile_brake_geq_accel,every_profile_footprint_positive,every_profile_cap_leq_max_speed,mrc_leq_nominal_per_field_every_class
+//
+// Cross-refs: docs/CONTRACT_PROFILES.md (normative home), docs/ARCHITECTURE_STACK.md
+// §2 (the three-domain model + the frozen-talisman rule), docs/MARKET_AUTONOMOUS_SERVICES.md
+// §3c (why the market needs the family), ADR-0001 (the ODD speed-cap framing).
+
+use std::str::FromStr;
+
+use crate::gateway::kinematics_contract::{
+    VehicleKinematicsContract, URBAN_ODD_SPEED_CAP_MPS,
+};
+
+// ---------------------------------------------------------------------------
+// Per-class ODD operational speed caps
+// ---------------------------------------------------------------------------
+//
+// Defined beside `URBAN_ODD_SPEED_CAP_MPS`'s pattern (the ODD ceiling is a
+// safety-case operational cap, distinct from the vehicle physical maximum — see
+// ADR-0001 and `VehicleKinematicsContract::effective_max_speed_mps`). These do NOT
+// modify the existing const; they are the per-class siblings of it.
+
+/// Sidewalk-courier ODD operational speed cap (m/s). **VALIDATION-PENDING.**
+///
+/// Basis: commercial sidewalk-delivery fleets operate at roughly **1.5–3 m/s**
+/// (walking-pace multiples); 2.5 m/s (~1.8× a 1.4 m/s walking pace) sits inside
+/// that band as a conservative pedestrian-space ceiling. NOT a certified value —
+/// see `docs/CONTRACT_PROFILES.md` (param `courier.odd_cap`).
+pub const COURIER_ODD_SPEED_CAP_MPS: f64 = 2.5;
+
+/// Road-going delivery-AV (pod) ODD operational speed cap (m/s).
+/// **VALIDATION-PENDING.**
+///
+/// Basis: the Nuro-shape road pod runs a low-speed-road ODD (~25 mph ≈ 11.2 m/s);
+/// 11.0 m/s is a conservative round-down. Between the courier and robotaxi caps.
+/// NOT a certified value — see `docs/CONTRACT_PROFILES.md` (param `delivery-av.odd_cap`).
+pub const DELIVERY_AV_ODD_SPEED_CAP_MPS: f64 = 11.0;
+
+/// Robotaxi-class ODD operational speed cap (m/s). **INHERITED** — this is exactly
+/// the existing urban Occy ODD cap (`URBAN_ODD_SPEED_CAP_MPS` = 22.35, ADR-0001 /
+/// SPEED_ENVELOPE.md / KIRRA-OCCY-SPEED-VAL-001). No new number: the robotaxi class
+/// IS the frozen reference deployment. Documented here for the family table; note
+/// `contract_for(Robotaxi)` returns the frozen instance verbatim (`odd_speed_cap_mps:
+/// None` — the deployment applies the cap, per the frozen instance's own doc).
+pub const ROBOTAXI_ODD_SPEED_CAP_MPS: f64 = URBAN_ODD_SPEED_CAP_MPS;
+
+// The ODD-cap ordering is a family invariant, pinned at COMPILE time: a sidewalk
+// robot's ceiling is below a road pod's is below a robotaxi's. (Compile-time
+// assertions are the clippy-approved way to assert on constants.)
+const _: () = assert!(COURIER_ODD_SPEED_CAP_MPS < DELIVERY_AV_ODD_SPEED_CAP_MPS);
+const _: () = assert!(DELIVERY_AV_ODD_SPEED_CAP_MPS < ROBOTAXI_ODD_SPEED_CAP_MPS);
+
+// ---------------------------------------------------------------------------
+// Vehicle class
+// ---------------------------------------------------------------------------
+
+/// The vehicle class a contract profile is selected for. Selection is FAIL-CLOSED:
+/// see [`VehicleClass::from_str`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VehicleClass {
+    /// Sidewalk courier — pedestrian-space, low-speed, small footprint (#313).
+    Courier,
+    /// Road-going delivery AV — low-speed-road pod (Nuro-shape).
+    DeliveryAv,
+    /// Robotaxi — full-speed mixed-traffic. The frozen reference instance.
+    Robotaxi,
+}
+
+impl FromStr for VehicleClass {
+    type Err = String;
+
+    /// Case-insensitive parse of `"courier"` / `"delivery-av"` / `"robotaxi"`.
+    ///
+    /// FAIL-CLOSED (the `KIRRA_BACKEND` selection pattern): any other string —
+    /// including a near-miss typo — is an `Err`, never a silent fallback to a
+    /// default class. A mis-typed class must NEVER select another class's
+    /// (e.g. faster) envelope.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "courier" => Ok(VehicleClass::Courier),
+            "delivery-av" => Ok(VehicleClass::DeliveryAv),
+            "robotaxi" => Ok(VehicleClass::Robotaxi),
+            other => Err(format!(
+                "unknown vehicle class {other:?}; expected one of \
+                 courier | delivery-av | robotaxi (fail-closed — no default)"
+            )),
+        }
+    }
+}
+
+impl VehicleClass {
+    /// The class's canonical lowercase id (the inverse of [`from_str`](Self::from_str)).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            VehicleClass::Courier => "courier",
+            VehicleClass::DeliveryAv => "delivery-av",
+            VehicleClass::Robotaxi => "robotaxi",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The Nominal profile family
+// ---------------------------------------------------------------------------
+
+/// The **Nominal** kinematic contract for `class`. The robotaxi member delegates to
+/// the frozen `nominal_reference_profile()` verbatim (zero new numbers); the courier
+/// and delivery-AV members are siblings whose numbers are VALIDATION-PENDING (see the
+/// per-field basis in the constructors and `docs/CONTRACT_PROFILES.md`).
+#[must_use]
+pub fn contract_for(class: VehicleClass) -> VehicleKinematicsContract {
+    match class {
+        VehicleClass::Robotaxi => VehicleKinematicsContract::nominal_reference_profile(),
+        VehicleClass::DeliveryAv => delivery_av_nominal(),
+        VehicleClass::Courier => courier_nominal(),
+    }
+}
+
+/// The **MRC fallback** kinematic contract for `class` (degraded posture). The
+/// robotaxi member delegates to the frozen `mrc_fallback_profile()` verbatim; the
+/// courier / delivery-AV members are stricter siblings (every field ≤ the class's
+/// Nominal limit, except `min_follow_distance_m` which is ≥, and the footprint which
+/// is identical — the vehicle does not shrink in degraded posture).
+#[must_use]
+pub fn mrc_fallback_for(class: VehicleClass) -> VehicleKinematicsContract {
+    match class {
+        VehicleClass::Robotaxi => VehicleKinematicsContract::mrc_fallback_profile(),
+        VehicleClass::DeliveryAv => delivery_av_mrc(),
+        VehicleClass::Courier => courier_mrc(),
+    }
+}
+
+// --- Courier (sidewalk, VRU-dense) — the #313 profile ----------------------
+//
+// VRU-dense rationale (see docs/CONTRACT_PROFILES.md "VRU-dense rationale"): every
+// bound is shaped by pedestrian proximity — low absolute speed, short stopping
+// distances, gentle lateral comfort, a small footprint.
+
+fn courier_nominal() -> VehicleKinematicsContract {
+    VehicleKinematicsContract {
+        // VALIDATION-PENDING: mechanical top of the ~1.5–3 m/s sidewalk operating
+        // band; the ODD cap (2.5) sits just below it so the effective ceiling is
+        // the cap. (CONTRACT_PROFILES.md courier.max_speed)
+        max_speed_mps: 3.0,
+        // VALIDATION-PENDING: gentle acceleration near pedestrians. (courier.accel)
+        max_accel_mps2: 1.0,
+        // VALIDATION-PENDING: firm service brake → SHORT absolute stopping distance
+        // (at 2.5 m/s, v²/2b ≈ 1.04 m), the VRU-dense priority. brake ≥ accel.
+        // (courier.brake)
+        max_brake_mps2: 3.0,
+        // VALIDATION-PENDING: tight maneuvering in pedestrian space; effective
+        // steering is further bounded by the low lateral-accel limit below via the
+        // bicycle-model clamp. (courier.steering)
+        max_steering_deg: 30.0,
+        // VALIDATION-PENDING: moderate steering slew for a small platform. (courier.steering_rate)
+        max_steering_rate_deg_s: 30.0,
+        // VALIDATION-PENDING: conservative follow distance RELATIVE to the low speed
+        // (~0.8 s headway at 2.5 m/s, plus the robot's short reaction). (courier.follow)
+        min_follow_distance_m: 2.0,
+        // VALIDATION-PENDING: gentle lateral comfort near VRUs (matches the frozen
+        // MRC lateral limit). (courier.lat_accel)
+        max_lateral_accel_mps2: 1.5,
+        // VALIDATION-PENDING: small sidewalk-robot wheelbase. (courier.wheelbase)
+        wheelbase_m: 0.5,
+        // VALIDATION-PENDING: narrow sidewalk footprint (small delivery robot).
+        // width/length/overhangs all positive. (courier.footprint)
+        width_m: 0.6,
+        length_m: 0.9,
+        overhang_front_m: 0.2,
+        overhang_rear_m: 0.2,
+        // The pedestrian-space ODD ceiling (sibling of URBAN_ODD_SPEED_CAP_MPS).
+        odd_speed_cap_mps: Some(COURIER_ODD_SPEED_CAP_MPS),
+    }
+}
+
+fn courier_mrc() -> VehicleKinematicsContract {
+    VehicleKinematicsContract {
+        // VALIDATION-PENDING: degraded crawl. (courier.mrc.max_speed)
+        max_speed_mps: 1.0,
+        max_accel_mps2: 0.5,    // VALIDATION-PENDING (≥ ? brake below) (courier.mrc.accel)
+        max_brake_mps2: 2.0,    // VALIDATION-PENDING: brake ≥ accel. (courier.mrc.brake)
+        max_steering_deg: 15.0, // VALIDATION-PENDING (courier.mrc.steering)
+        max_steering_rate_deg_s: 15.0, // VALIDATION-PENDING (courier.mrc.steering_rate)
+        min_follow_distance_m: 3.0,    // VALIDATION-PENDING: ≥ nominal follow (courier.mrc.follow)
+        max_lateral_accel_mps2: 0.75,  // VALIDATION-PENDING (courier.mrc.lat_accel)
+        // Footprint is platform geometry — IDENTICAL to courier nominal (the vehicle
+        // does not shrink in degraded posture).
+        wheelbase_m: 0.5,
+        width_m: 0.6,
+        length_m: 0.9,
+        overhang_front_m: 0.2,
+        overhang_rear_m: 0.2,
+        // MRC crawl (1.0) is already below the courier ODD cap; leave None so min()
+        // selects 1.0 (the frozen-MRC idiom).
+        odd_speed_cap_mps: None,
+    }
+}
+
+// --- Delivery AV (road-going pod, Nuro-shape) ------------------------------
+//
+// Between courier and robotaxi on every limit; every number VALIDATION-PENDING.
+
+fn delivery_av_nominal() -> VehicleKinematicsContract {
+    VehicleKinematicsContract {
+        // VALIDATION-PENDING: mechanical max above the ~25 mph (11 m/s) road-pod ODD
+        // cap. (delivery-av.max_speed)
+        max_speed_mps: 12.0,
+        max_accel_mps2: 1.8,    // VALIDATION-PENDING: between courier 1.0 and robotaxi 2.5 (delivery-av.accel)
+        max_brake_mps2: 4.0,    // VALIDATION-PENDING: firm service brake; ≥ accel (delivery-av.brake)
+        max_steering_deg: 33.0, // VALIDATION-PENDING (delivery-av.steering)
+        max_steering_rate_deg_s: 40.0, // VALIDATION-PENDING (delivery-av.steering_rate)
+        min_follow_distance_m: 3.5,    // VALIDATION-PENDING: ~0.3 s @ 11 m/s + reaction (delivery-av.follow)
+        max_lateral_accel_mps2: 2.5,   // VALIDATION-PENDING: between courier 1.5 and robotaxi 3.5 (delivery-av.lat_accel)
+        wheelbase_m: 1.9,       // VALIDATION-PENDING: small road pod (delivery-av.wheelbase)
+        width_m: 1.1,           // VALIDATION-PENDING: narrow pod footprint (delivery-av.footprint)
+        length_m: 2.9,
+        overhang_front_m: 0.5,
+        overhang_rear_m: 0.5,
+        odd_speed_cap_mps: Some(DELIVERY_AV_ODD_SPEED_CAP_MPS),
+    }
+}
+
+fn delivery_av_mrc() -> VehicleKinematicsContract {
+    VehicleKinematicsContract {
+        max_speed_mps: 4.0,     // VALIDATION-PENDING (delivery-av.mrc.max_speed)
+        max_accel_mps2: 1.0,    // VALIDATION-PENDING (delivery-av.mrc.accel)
+        max_brake_mps2: 3.0,    // VALIDATION-PENDING: brake ≥ accel (delivery-av.mrc.brake)
+        max_steering_deg: 15.0, // VALIDATION-PENDING (delivery-av.mrc.steering)
+        max_steering_rate_deg_s: 20.0, // VALIDATION-PENDING (delivery-av.mrc.steering_rate)
+        min_follow_distance_m: 5.0,    // VALIDATION-PENDING: ≥ nominal follow (delivery-av.mrc.follow)
+        max_lateral_accel_mps2: 1.5,   // VALIDATION-PENDING (delivery-av.mrc.lat_accel)
+        // Footprint IDENTICAL to delivery-av nominal.
+        wheelbase_m: 1.9,
+        width_m: 1.1,
+        length_m: 2.9,
+        overhang_front_m: 0.5,
+        overhang_rear_m: 0.5,
+        odd_speed_cap_mps: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every family member, Nominal + MRC, as (name, nominal, mrc).
+    fn family() -> Vec<(VehicleClass, VehicleKinematicsContract, VehicleKinematicsContract)> {
+        [VehicleClass::Courier, VehicleClass::DeliveryAv, VehicleClass::Robotaxi]
+            .into_iter()
+            .map(|c| (c, contract_for(c), mrc_fallback_for(c)))
+            .collect()
+    }
+
+    #[test]
+    fn courier_str_roundtrips_case_insensitive() {
+        for s in ["courier", "Courier", "COURIER", "  courier  "] {
+            assert_eq!(VehicleClass::from_str(s).unwrap(), VehicleClass::Courier, "{s:?}");
+        }
+        assert_eq!(VehicleClass::from_str("delivery-av").unwrap(), VehicleClass::DeliveryAv);
+        assert_eq!(VehicleClass::from_str("ROBOTAXI").unwrap(), VehicleClass::Robotaxi);
+        // round-trip through as_str
+        for c in [VehicleClass::Courier, VehicleClass::DeliveryAv, VehicleClass::Robotaxi] {
+            assert_eq!(VehicleClass::from_str(c.as_str()).unwrap(), c);
+        }
+    }
+
+    #[test]
+    fn unknown_class_is_fail_closed_err() {
+        // A typo / garbage / empty must be Err — NEVER a silent fallback class.
+        for s in ["", "robotaxii", "delivery_av", "car", "truck", "couri er"] {
+            assert!(VehicleClass::from_str(s).is_err(), "expected fail-closed Err for {s:?}");
+        }
+    }
+
+    #[test]
+    fn robotaxi_equals_frozen_nominal_field_for_field() {
+        // The zero-drift inheritance proof: contract_for(Robotaxi) IS the frozen
+        // instance, verbatim. PartialEq compares every field.
+        assert_eq!(
+            contract_for(VehicleClass::Robotaxi),
+            VehicleKinematicsContract::nominal_reference_profile(),
+            "robotaxi nominal must equal the frozen instance field-for-field (zero new numbers)"
+        );
+    }
+
+    #[test]
+    fn robotaxi_mrc_equals_frozen_mrc() {
+        assert_eq!(
+            mrc_fallback_for(VehicleClass::Robotaxi),
+            VehicleKinematicsContract::mrc_fallback_profile(),
+        );
+    }
+
+    #[test]
+    fn cap_ordering_courier_lt_deliveryav_lt_robotaxi() {
+        // Ordering sanity on the runtime-effective ceiling: a sidewalk robot is
+        // slower than a road pod is slower than a robotaxi.
+        let courier = contract_for(VehicleClass::Courier).effective_max_speed_mps();
+        let delivery = contract_for(VehicleClass::DeliveryAv).effective_max_speed_mps();
+        let robotaxi = contract_for(VehicleClass::Robotaxi).effective_max_speed_mps();
+        assert!(courier < delivery, "courier {courier} !< delivery-av {delivery}");
+        assert!(delivery < robotaxi, "delivery-av {delivery} !< robotaxi {robotaxi}");
+        // (The documented ODD-cap consts agree with this ordering — pinned at
+        // compile time via the `const _: () = assert!(...)` checks beside the consts.)
+    }
+
+    #[test]
+    fn every_profile_brake_geq_accel() {
+        for (c, nom, mrc) in family() {
+            assert!(nom.max_brake_mps2 >= nom.max_accel_mps2,
+                "{c:?} nominal brake {} < accel {}", nom.max_brake_mps2, nom.max_accel_mps2);
+            assert!(mrc.max_brake_mps2 >= mrc.max_accel_mps2,
+                "{c:?} mrc brake {} < accel {}", mrc.max_brake_mps2, mrc.max_accel_mps2);
+        }
+    }
+
+    #[test]
+    fn every_profile_footprint_positive() {
+        for (c, nom, mrc) in family() {
+            for (label, k) in [("nominal", nom), ("mrc", mrc)] {
+                assert!(k.wheelbase_m > 0.0, "{c:?} {label} wheelbase");
+                assert!(k.width_m > 0.0, "{c:?} {label} width");
+                assert!(k.length_m > 0.0, "{c:?} {label} length");
+                assert!(k.overhang_front_m > 0.0, "{c:?} {label} front overhang");
+                assert!(k.overhang_rear_m > 0.0, "{c:?} {label} rear overhang");
+            }
+        }
+    }
+
+    #[test]
+    fn every_profile_cap_leq_max_speed() {
+        for (c, nom, mrc) in family() {
+            for (label, k) in [("nominal", nom), ("mrc", mrc)] {
+                if let Some(cap) = k.odd_speed_cap_mps {
+                    assert!(cap <= k.max_speed_mps,
+                        "{c:?} {label} odd cap {cap} > max_speed {}", k.max_speed_mps);
+                }
+                // effective ceiling never exceeds the mechanical max.
+                assert!(k.effective_max_speed_mps() <= k.max_speed_mps + 1e-9, "{c:?} {label}");
+            }
+        }
+    }
+
+    #[test]
+    fn mrc_leq_nominal_per_field_every_class() {
+        for (c, nom, mrc) in family() {
+            // The limit fields: MRC is no more permissive than Nominal.
+            assert!(mrc.max_speed_mps <= nom.max_speed_mps, "{c:?} speed");
+            assert!(mrc.max_accel_mps2 <= nom.max_accel_mps2, "{c:?} accel");
+            assert!(mrc.max_brake_mps2 <= nom.max_brake_mps2, "{c:?} brake");
+            assert!(mrc.max_steering_deg <= nom.max_steering_deg, "{c:?} steering");
+            assert!(mrc.max_steering_rate_deg_s <= nom.max_steering_rate_deg_s, "{c:?} steering_rate");
+            assert!(mrc.max_lateral_accel_mps2 <= nom.max_lateral_accel_mps2, "{c:?} lat_accel");
+            // Following distance is the conservative direction: MRC ≥ Nominal.
+            assert!(mrc.min_follow_distance_m >= nom.min_follow_distance_m, "{c:?} follow");
+            // Footprint is platform geometry — identical (the vehicle doesn't shrink).
+            assert_eq!(mrc.wheelbase_m, nom.wheelbase_m, "{c:?} wheelbase");
+            assert_eq!(mrc.width_m, nom.width_m, "{c:?} width");
+            assert_eq!(mrc.length_m, nom.length_m, "{c:?} length");
+        }
+    }
+}

--- a/src/gateway/kinematics_proptest.rs
+++ b/src/gateway/kinematics_proptest.rs
@@ -33,6 +33,20 @@ use proptest::prelude::*;
 use crate::gateway::kinematics_contract::{
     validate_vehicle_command, EnforceAction, ProposedVehicleCommand, VehicleKinematicsContract,
 };
+use crate::gateway::contract_profiles::{contract_for, mrc_fallback_for, VehicleClass};
+
+/// EVERY member of the contract family (Nominal + MRC for all three classes),
+/// as `(label, contract)`. The validation gate (#312): a profile that fails the
+/// frozen instance's properties does not ship — that inheritance IS the family's
+/// certification story, so the same battery runs against every member.
+fn family_contracts() -> Vec<(&'static str, VehicleKinematicsContract)> {
+    let mut v = Vec::new();
+    for class in [VehicleClass::Courier, VehicleClass::DeliveryAv, VehicleClass::Robotaxi] {
+        v.push((class.as_str(), contract_for(class)));
+        v.push((class.as_str(), mrc_fallback_for(class)));
+    }
+    v
+}
 
 // ---------------------------------------------------------------------------
 // Strategies
@@ -379,6 +393,129 @@ proptest! {
                  nominal: {nominal_result:?}, mrc: Allow",
                 cmd.linear_velocity_mps, cmd.delta_time_s, cmd.steering_angle_deg
             );
+        }
+    }
+}
+
+// ===========================================================================
+// THE VALIDATION GATE (#312/#313) — the SAME property battery, run against
+// EVERY family member (courier / delivery-av / robotaxi, Nominal + MRC). These
+// properties are profile-agnostic: each reads the contract's OWN fields, so a new
+// class member inherits the frozen instance's certification by passing them. A
+// member that fails any of these does not ship.
+// ===========================================================================
+
+proptest! {
+    /// NO_PANIC — no family member panics on any finite input.
+    #[test]
+    fn prop_family_no_panic_on_finite(cmd in finite_command()) {
+        for (_label, contract) in family_contracts() {
+            let _ = validate_vehicle_command(&cmd, &contract);
+        }
+    }
+}
+
+proptest! {
+    /// NO_PANIC + DENY — every member denies a nonfinite field (never panics,
+    /// never silently admits).
+    #[test]
+    fn prop_family_nonfinite_always_denied(
+        bad in nonfinite_f64(),
+        field_idx in 0usize..5,
+    ) {
+        let cmd = command_with_one_nonfinite_field(bad, field_idx);
+        for (label, contract) in family_contracts() {
+            let result = validate_vehicle_command(&cmd, &contract);
+            prop_assert!(
+                matches!(result, EnforceAction::DenyBreach(_)),
+                "{label}: nonfinite field {field_idx}={bad} must DenyBreach, got {result:?}"
+            );
+        }
+    }
+}
+
+proptest! {
+    /// CLAMP_IN_BOUNDS — every member's ClampLinear/ClampSteering output satisfies
+    /// THAT member's own contract (finite + within its bounds).
+    #[test]
+    fn prop_family_clamp_in_bounds(cmd in valid_dt_command()) {
+        for (label, contract) in family_contracts() {
+            match validate_vehicle_command(&cmd, &contract) {
+                EnforceAction::ClampLinear(v) => {
+                    prop_assert!(v.is_finite(), "{label}: ClampLinear {v} not finite");
+                    prop_assert!(v.abs() <= contract.max_speed_mps + 1e-9,
+                        "{label}: ClampLinear {v} > max_speed {}", contract.max_speed_mps);
+                }
+                EnforceAction::ClampSteering(d) => {
+                    prop_assert!(d.is_finite(), "{label}: ClampSteering {d} not finite");
+                    prop_assert!(d.abs() <= contract.max_steering_deg + 1e-9,
+                        "{label}: ClampSteering {d} > max_steering {}", contract.max_steering_deg);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+proptest! {
+    /// ALLOW_IMPLIES_SAFE — an Allow from any member implies that member's speed,
+    /// steering, and bicycle-model lateral-accel invariants all hold.
+    #[test]
+    fn prop_family_allow_implies_safe(cmd in valid_dt_command()) {
+        for (label, contract) in family_contracts() {
+            if let EnforceAction::Allow = validate_vehicle_command(&cmd, &contract) {
+                prop_assert!(cmd.linear_velocity_mps.abs() <= contract.max_speed_mps + 1e-9,
+                    "{label}: Allow speed {} > {}", cmd.linear_velocity_mps, contract.max_speed_mps);
+                prop_assert!(cmd.steering_angle_deg.abs() <= contract.max_steering_deg + 1e-9,
+                    "{label}: Allow steering {} > {}", cmd.steering_angle_deg, contract.max_steering_deg);
+                let v2 = cmd.linear_velocity_mps.powi(2);
+                if v2 > 1e-6 && contract.wheelbase_m > 1e-6 {
+                    let lat = (v2 * cmd.steering_angle_deg.to_radians().tan().abs())
+                        / contract.wheelbase_m;
+                    prop_assert!(lat <= contract.max_lateral_accel_mps2 + 1e-6,
+                        "{label}: Allow lateral {lat:.6} > {}", contract.max_lateral_accel_mps2);
+                }
+            }
+        }
+    }
+}
+
+proptest! {
+    /// BICYCLE_MODEL_AFTER_CLAMP — a member's ClampSteering output satisfies that
+    /// member's lateral-accel limit.
+    #[test]
+    fn prop_family_clamp_steering_satisfies_lateral(cmd in valid_dt_command()) {
+        for (label, contract) in family_contracts() {
+            if let EnforceAction::ClampSteering(safe_delta) = validate_vehicle_command(&cmd, &contract) {
+                let v2 = cmd.linear_velocity_mps.powi(2);
+                if v2 > 1e-6 && contract.wheelbase_m > 1e-6 && safe_delta.is_finite() {
+                    let lat = (v2 * safe_delta.to_radians().tan().abs()) / contract.wheelbase_m;
+                    prop_assert!(lat <= contract.max_lateral_accel_mps2 + 1e-6,
+                        "{label}: ClampSteering({safe_delta:.4}) lat {lat:.6} > {}",
+                        contract.max_lateral_accel_mps2);
+                }
+            }
+        }
+    }
+}
+
+proptest! {
+    /// DETERMINISTIC — every member is deterministic (discriminant-stable; clamp
+    /// values bit-identical).
+    #[test]
+    fn prop_family_deterministic(cmd in finite_command()) {
+        for (label, contract) in family_contracts() {
+            let r1 = validate_vehicle_command(&cmd, &contract);
+            let r2 = validate_vehicle_command(&cmd, &contract);
+            prop_assert_eq!(std::mem::discriminant(&r1), std::mem::discriminant(&r2),
+                "{} not deterministic", label);
+            match (&r1, &r2) {
+                (EnforceAction::ClampLinear(a), EnforceAction::ClampLinear(b)) =>
+                    prop_assert_eq!(a.to_bits(), b.to_bits()),
+                (EnforceAction::ClampSteering(a), EnforceAction::ClampSteering(b)) =>
+                    prop_assert_eq!(a.to_bits(), b.to_bits()),
+                _ => {}
+            }
         }
     }
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -5,6 +5,7 @@ pub mod policy;
 pub mod policy_layer;
 pub mod cmd_vel;
 pub mod kinematics_contract;
+pub mod contract_profiles;
 pub mod containment;
 pub mod perception_monitor;
 


### PR DESCRIPTION
The kinematic contract becomes a **family parameterized by vehicle class** (courier / delivery-AV / robotaxi), sharing one governor, one signed chain, one console. **THE HELD LINE:** `src/gateway/kinematics_contract.rs` is **NOT touched** — talisman blob `997fb7ae15ce3e11adec9218044c7c84b049ad3b` **byte-identical** (checked first thing on `main` and last thing before commit). Profiles are **siblings**: new constructors that return the existing public `VehicleKinematicsContract`, exactly the `nominal_reference_profile` / `mrc_fallback_profile` idiom.

## What landed

**`src/gateway/contract_profiles.rs` (new)** — `VehicleClass { Courier, DeliveryAv, Robotaxi }` with **fail-closed** `FromStr` (unknown string → `Err`, the `KIRRA_BACKEND` pattern; a typo must never select another class's envelope). `contract_for` / `mrc_fallback_for`:
- **Robotaxi** delegates to the frozen instance **verbatim** — zero new numbers, proven field-for-field.
- **Courier (#313)** — sidewalk / VRU-dense: low speed, small footprint, short stopping distance, gentle lateral comfort.
- **Delivery-AV** — Nuro-shape road pod, between the two.
- Every non-inherited number is **VALIDATION-PENDING** with a one-line basis + the doc anchor. Per-class ODD-cap consts sit beside `URBAN_ODD_SPEED_CAP_MPS` (the existing const is untouched), with a compile-time ordering invariant.

**`src/gateway/kinematics_proptest.rs` — THE VALIDATION GATE.** The property battery is now **parameterized over every family member** (Nominal + MRC for all three classes). Each must pass the same profile-agnostic properties — no-panic, clamp-in-bounds, allow-implies-safe, bicycle-after-clamp, deterministic. A profile that fails the frozen instance's properties **does not ship** — that inheritance is the family's certification story. Structural invariants (`brake ≥ accel`, `mrc ≤ nominal` per limit field, footprint positive, `cap ≤ max_speed`) + the robotaxi==frozen equality proof live in `contract_profiles` tests.

**`parko-core/src/impact.rs` — the family's SG6 member.** `impact_cfg_for_class` (courier 8.0 / delivery-av 18.0 VALIDATION-PENDING; robotaxi = the frozen `ImpactCfg::default` 30.0). `Default` **untouched**. **Grounded dependency reality:** parko-core and the SDK gateway are **separate workspaces with no dependency edge**, so class values **cannot be shared by import** — the duplication is **stated explicitly in both files with reciprocal cites**, and `docs/CONTRACT_PROFILES.md` is the normative table both key to. The courier threshold is flagged as needing bench characterization of low-speed collision decel signatures (not a guessed number).

**`docs/CONTRACT_PROFILES.md` (new)** — the normative per-parameter × class table (status CONFIRMED / VALIDATION-PENDING / INHERITED-FROZEN), the sibling rule, the VRU-dense rationale per courier bound (#313), the fail-closed selection rule, and the deployment note. Cross-refs MARKET_AUTONOMOUS_SERVICES §3c, ARCHITECTURE_STACK §2, ADR-0001.

## Verify

- **Talisman `997fb7ae…` byte-identical** (first + last verification step).
- `cargo test` green **both workspaces**: SDK lib **611 pass** (9 new `contract_profiles` + 6 new family proptests), parko-core incl. 3 new `impact_cfg_for_class` tests.
- **Clippy clean** both workspaces.
- Scope = the 6 files only (new module + module registration + proptest parameterization + the parko sibling + the export + the doc). **No** change to the frozen instance, the governor decision logic, or any binary.

## Issue disposition

- **#313 — closing as delivered-within-#312:** the VRU-dense courier profile IS the courier family member (envelope + ODD caps + SG6 threshold + the VRU-dense rationale doc section), shipped here.
- **#312 — keeping open:** the **binary wiring** of class selection (an env var / config field that loads `contract_for(class)` / `impact_cfg_for_class(class)`) is named in the deployment note but **not built** in this change — that remainder warrants keeping #312 open.

References #312, #313, `docs/MARKET_AUTONOMOUS_SERVICES.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_