### PR TITLE
feat(fleet): Zenoh fleet transport — ADR + spike (untrusted carrier, QM-only, grants terminate at the store) (#296)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner"]
+members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-fleet-transport"]
 resolver = "2"
 
 [package]

--- a/crates/kirra-fleet-transport/Cargo.toml
+++ b/crates/kirra-fleet-transport/Cargo.toml
@@ -1,0 +1,50 @@
+# crates/kirra-fleet-transport/Cargo.toml
+#
+# #296 — the FLEET-LANE transport spike (vehicle ↔ ops/cloud). STRICTLY QM:
+# Zenoh never appears in the safety partition or the boundary channel (ADR-0006
+# Clause 2; ADR-0007). This crate is a LEAF consumer that depends on the SDK;
+# nothing under src/gateway/ or any safety path may depend on it.
+#
+# TLS DELIBERATELY OFF (the toolchain-wall mitigation + the trust model): zenoh's
+# default TLS/QUIC stack pulls an rcgen/time chain that does not compile on the
+# bench toolchain (rustc 1.94.1, E0119). We disable it — and trust does NOT come
+# from transport TLS anyway (it comes from Ed25519 payload signatures, ADR-0007
+# Clause 1), so dropping TLS costs no trust. `transport_tcp` gives the localhost
+# peer transport the in-process tests use. If a future transitive dep ever breaks
+# the resolve, the `zenoh-pinned-deps-1-75` lockdown is the escape hatch.
+[package]
+name = "kirra-fleet-transport"
+version = "0.1.0"
+edition = "2021"
+description = "Fleet-lane (QM) Zenoh transport spike for KIRRA — untrusted carrier; trust is Ed25519 payload signatures; grants terminate at the verifier store (#296). Not a safety artifact."
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+
+[dependencies]
+# The SDK is the source of truth for the fleet payload types + their verification:
+# FederatedTrustReportV2 / verify_federated_report_signature_v2 / FleetPosture and
+# the Phase-A clearance-grant store path. This crate adds NO new payload trust
+# logic of its own beyond a grant envelope that reuses the same Ed25519 pattern.
+kirra-runtime-sdk = { path = "../.." }
+
+# The fleet carrier. default-features OFF (no TLS/QUIC — see the manifest note);
+# `transport_tcp` = the localhost peer transport; `unstable` only for the explicit
+# endpoint config the deterministic in-process tests wire (not the data path).
+zenoh = { version = "1", default-features = false, features = ["transport_tcp", "unstable"] }
+
+serde = { version = "1", features = ["derive"] }
+# JSON on the fleet wire (NOT bincode like kirra-wire-client's governor hot path):
+# the fleet lane is a debuggable ops/cloud hop and trust is anchored in the
+# Ed25519 signature over the canonical payload, not the codec — so JSON costs no
+# trust and buys cross-tooling debuggability.
+serde_json = "1"
+# The grant envelope reuses the federation Ed25519 pattern (sign a canonical
+# payload; verify against the controller's registered public key).
+ed25519-dalek = { version = "2", features = ["rand_core"] }
+base64 = "0.22"
+
+[dev-dependencies]
+# zenoh is async; the in-process two-session round-trip tests need a runtime.
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+tempfile = "3"
+rand = "0.8"

--- a/crates/kirra-fleet-transport/README.md
+++ b/crates/kirra-fleet-transport/README.md
@@ -1,0 +1,57 @@
+# kirra-fleet-transport — fleet-lane (QM) Zenoh transport spike (#296)
+
+The **fleet lane**: vehicle ↔ ops/cloud transport for cellular / distributed
+fleets. The decision lives in [`docs/adr/0007-fleet-transport-zenoh.md`](../../docs/adr/0007-fleet-transport-zenoh.md);
+this crate is the spike.
+
+## The three clauses (ADR-0007), in one paragraph
+
+Zenoh is an **untrusted carrier** — trust derives from **Ed25519 payload
+signatures** (federation reports via the SDK's
+`verify_federated_report_signature_v2`; grants via this crate's
+`verify_clearance_grant`), **never** from transport identity, topic name, or
+Zenoh's own auth, and every ingest **verifies before use** with unsigned /
+bad-signature / malformed payloads rejected and **counted** (`RejectionCounter`)
+[Clause 1]. It is **strictly QM**: this crate is a **leaf** consumer that depends
+on the SDK, and **nothing under `src/gateway/` or any safety path may depend on
+it** — ADR-0006 Clause 2's boundary asymmetry is the parent rule [Clause 2]. The
+down-lane grant **terminates at the vehicle's verifier store**: a verified grant
+is written through the **existing** Phase-A path (`save_clearance_grant_chained`,
+a `PENDING` row) and Phase-B's one-shot pickup + two-checkpoint delivery proceed
+**unchanged** — remote transport composes with the clearance design, it never
+creates a second release path [Clause 3].
+
+## Layout
+
+- **`lib.rs`** — the transport-free **trust + codec core**: the namespace key
+  expressions, `accept_report` (decode → **verify-first**), the signed-grant
+  envelope (`sign_clearance_grant` / `verify_clearance_grant`), `ingest_clearance_grant`
+  (verify → existing store path), and `RejectionCounter`. Unit-tested with no
+  Zenoh session.
+- **`transport.rs`** — the thin Zenoh edge: `FleetPublisher`, `FleetSubscriber`
+  (`recv_report` verifies before surfacing), `GrantIngest` (`recv_and_ingest`).
+  Tested with two **in-process peer sessions** (no router, localhost TCP, multicast
+  off).
+
+## Build / sandbox note (the bench is the build authority)
+
+This crate **builds and tests in the authoring sandbox** (rustc 1.94.1) — but only
+with Zenoh's **TLS/QUIC features disabled** (`default-features = false`, just
+`transport_tcp` + `unstable`). Zenoh's *default* TLS stack pulls an
+`rcgen` / `time` dependency chain that **does not compile on rustc 1.94.1**
+(`E0119`, a conflicting-impl break) — the anticipated MSRV/toolchain wall. We
+disable TLS deliberately: **TLS is confidentiality defense-in-depth, not the trust
+root** (the trust root is the Ed25519 payload signature), so dropping it costs no
+trust for the spike. The **bench is the authority** for the TLS-enabled production
+config; if a future transitive dep ever breaks the resolve, the
+`zenoh-pinned-deps-1-75` lockdown is the escape hatch.
+
+The Zenoh tests require a **multi-threaded** tokio runtime
+(`#[tokio::test(flavor = "multi_thread", …)]`) — Zenoh's runtime rejects the
+current-thread scheduler.
+
+## What this spike is NOT
+
+Router / cellular / NAT deployment (ops/router territory), QoS / `AdvancedPublisher`
+delivery guarantees (named future — `zenoh-ext`), and the multi-tenant fleet side
+with a per-controller key registry (#314). See the ADR's *Honest limits*.

--- a/crates/kirra-fleet-transport/src/lib.rs
+++ b/crates/kirra-fleet-transport/src/lib.rs
@@ -1,0 +1,457 @@
+//! # kirra-fleet-transport — the FLEET-LANE (QM) Zenoh transport spike (#296)
+//!
+//! Vehicle ↔ ops/cloud transport for cellular / distributed fleets. The decision
+//! and its three clauses live in `docs/adr/0007-fleet-transport-zenoh.md`; this
+//! crate is the spike. Restated:
+//!
+//! 1. **Untrusted carrier (the trust rule).** Zenoh is an UNTRUSTED CARRIER.
+//!    Trust derives from **Ed25519 payload signatures** — federation reports via
+//!    [`kirra_runtime_sdk::federation_reconciliation::verify_federated_report_signature_v2`],
+//!    grants via [`verify_clearance_grant`] — **never** from transport identity, a
+//!    topic name, or Zenoh's own auth. Every ingest **verifies before use**;
+//!    unsigned / bad-signature / malformed payloads are rejected and **counted**
+//!    ([`RejectionCounter`]).
+//! 2. **Strictly QM (the domain rule).** This crate is a LEAF consumer that
+//!    depends on the SDK. **Nothing under `src/gateway/` or any safety path may
+//!    depend on it** (ADR-0006 Clause 2's boundary asymmetry is the parent rule).
+//! 3. **Grants terminate at the store (the grant rule).** The remote grant lane
+//!    writes a *verified* grant through the **existing** Phase-A store path
+//!    ([`VerifierStore::save_clearance_grant_chained`]) as a `PENDING` row;
+//!    Phase-B's one-shot pickup + two-checkpoint delivery proceed UNCHANGED. No
+//!    new store schema, no second release path.
+//!
+//! This module ([`lib`](self)) is the **transport-free trust + codec core** — the
+//! load-bearing safety logic, unit-tested without any Zenoh session. The Zenoh
+//! pub/sub edge is in [`transport`].
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+
+use kirra_runtime_sdk::federation_reconciliation::{
+    verify_federated_report_signature_v2, FederatedTrustReportV2,
+};
+use kirra_runtime_sdk::verifier::FleetPosture;
+use kirra_runtime_sdk::verifier_store::VerifierStore;
+
+pub mod transport;
+
+// ---------------------------------------------------------------------------
+// Namespace — versioned key expressions
+// ---------------------------------------------------------------------------
+//
+// Up (vehicle → ops/cloud): trust reports + posture summaries.
+// Down (ops/cloud → vehicle): clearance grants.
+// The `v1` segment is the wire-contract version; a breaking change bumps it.
+
+/// Key expression for a node's signed trust report (vehicle → fleet).
+#[must_use]
+pub fn key_trust_report(node_id: &str) -> String {
+    format!("kirra/v1/fleet/{node_id}/trust-report")
+}
+
+/// Key expression for a node's posture summary (vehicle → fleet).
+#[must_use]
+pub fn key_posture(node_id: &str) -> String {
+    format!("kirra/v1/fleet/{node_id}/posture")
+}
+
+/// Key expression for a node's clearance grant (ops/cloud → vehicle).
+#[must_use]
+pub fn key_clearance_grant(node_id: &str) -> String {
+    format!("kirra/v1/ops/{node_id}/clearance-grant")
+}
+
+// ---------------------------------------------------------------------------
+// Rejection accounting (surfaced for ops)
+// ---------------------------------------------------------------------------
+
+/// Why a received payload was rejected BEFORE use. Surfaced via [`RejectionCounter`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RejectReason {
+    /// The payload carried no signature (empty `signature_b64`).
+    Unsigned,
+    /// The Ed25519 signature did not verify against the expected key.
+    BadSignature,
+    /// The payload could not be decoded from the wire bytes.
+    Decode(String),
+    /// The payload decoded but is structurally invalid (e.g. empty node/operator).
+    Malformed(String),
+    /// A verified grant could not be written to the store (fail-closed).
+    StoreError(String),
+}
+
+impl RejectReason {
+    /// A short, stable code for ops dashboards / logs.
+    #[must_use]
+    pub fn code(&self) -> &'static str {
+        match self {
+            RejectReason::Unsigned => "unsigned",
+            RejectReason::BadSignature => "bad_signature",
+            RejectReason::Decode(_) => "decode_error",
+            RejectReason::Malformed(_) => "malformed",
+            RejectReason::StoreError(_) => "store_error",
+        }
+    }
+}
+
+/// Operator-observable rejected-payload counters. An untrusted carrier WILL deliver
+/// junk and tampered payloads; this makes the rejections visible rather than silent.
+#[derive(Debug, Default)]
+pub struct RejectionCounter {
+    unsigned: AtomicU64,
+    bad_signature: AtomicU64,
+    decode_error: AtomicU64,
+    malformed: AtomicU64,
+    store_error: AtomicU64,
+    accepted: AtomicU64,
+}
+
+impl RejectionCounter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a rejection by reason.
+    pub fn record(&self, reason: &RejectReason) {
+        let slot = match reason {
+            RejectReason::Unsigned => &self.unsigned,
+            RejectReason::BadSignature => &self.bad_signature,
+            RejectReason::Decode(_) => &self.decode_error,
+            RejectReason::Malformed(_) => &self.malformed,
+            RejectReason::StoreError(_) => &self.store_error,
+        };
+        slot.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record an accepted (verified) payload.
+    pub fn record_accepted(&self) {
+        self.accepted.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> RejectionSnapshot {
+        RejectionSnapshot {
+            unsigned: self.unsigned.load(Ordering::Relaxed),
+            bad_signature: self.bad_signature.load(Ordering::Relaxed),
+            decode_error: self.decode_error.load(Ordering::Relaxed),
+            malformed: self.malformed.load(Ordering::Relaxed),
+            store_error: self.store_error.load(Ordering::Relaxed),
+            accepted: self.accepted.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Total rejected across all reasons.
+    #[must_use]
+    pub fn total_rejected(&self) -> u64 {
+        let s = self.snapshot();
+        s.unsigned + s.bad_signature + s.decode_error + s.malformed + s.store_error
+    }
+}
+
+/// A point-in-time copy of [`RejectionCounter`] for ops surfacing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RejectionSnapshot {
+    pub unsigned: u64,
+    pub bad_signature: u64,
+    pub decode_error: u64,
+    pub malformed: u64,
+    pub store_error: u64,
+    pub accepted: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Fleet posture summary (a small vehicle → fleet status payload)
+// ---------------------------------------------------------------------------
+
+/// A compact, *unsigned* posture summary for the fleet dashboard. Posture is
+/// advisory telemetry, not an authority signal — the authoritative, signed path is
+/// the [`FederatedTrustReportV2`]. (A future hardening may sign these too; for the
+/// spike they are debug/telemetry only and never drive a safety decision.)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PostureSummary {
+    pub node_id: String,
+    pub posture: FleetPosture,
+    pub generated_at_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Report codec (JSON — fleet-lane debuggability; trust is in the signature)
+// ---------------------------------------------------------------------------
+
+/// Encode a signed trust report for the fleet wire (JSON).
+pub fn encode_report(report: &FederatedTrustReportV2) -> Result<Vec<u8>, RejectReason> {
+    serde_json::to_vec(report).map_err(|e| RejectReason::Decode(e.to_string()))
+}
+
+/// Decode + **verify** a trust report from wire bytes against `public_key_b64`.
+/// **Verification happens BEFORE the report is surfaced to any caller** — an
+/// unsigned / bad-signature / malformed payload is rejected and the `counter` is
+/// incremented; only a verified report is returned.
+pub fn accept_report(
+    bytes: &[u8],
+    public_key_b64: &str,
+    counter: &RejectionCounter,
+) -> Result<FederatedTrustReportV2, RejectReason> {
+    let report: FederatedTrustReportV2 = match serde_json::from_slice(bytes) {
+        Ok(r) => r,
+        Err(e) => {
+            let reason = RejectReason::Decode(e.to_string());
+            counter.record(&reason);
+            return Err(reason);
+        }
+    };
+    if report.signature_b64.trim().is_empty() {
+        counter.record(&RejectReason::Unsigned);
+        return Err(RejectReason::Unsigned);
+    }
+    // THE TRUST RULE — verify the Ed25519 signature over the canonical payload
+    // BEFORE the report is used. Trust is the signature, never the carrier.
+    if !verify_federated_report_signature_v2(&report, public_key_b64) {
+        counter.record(&RejectReason::BadSignature);
+        return Err(RejectReason::BadSignature);
+    }
+    counter.record_accepted();
+    Ok(report)
+}
+
+// ---------------------------------------------------------------------------
+// Signed clearance grant (the down lane) — reuses the federation Ed25519 pattern
+// ---------------------------------------------------------------------------
+
+/// An operator clearance grant signed by the issuing controller for transport over
+/// the untrusted fleet carrier. The vehicle verifies the signature against the
+/// controller's registered public key BEFORE writing it to the store.
+///
+/// The signature is over a canonical payload of the *semantic* fields
+/// ([`canonical_grant_payload`]), NOT the wire bytes — so the codec is independent
+/// of the trust root (mirrors `canonical_federation_payload_v2`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedClearanceGrant {
+    pub node_id: String,
+    pub operator_id: String,
+    pub granted_at_ms: u64,
+    pub signature_b64: String,
+}
+
+/// The canonical bytes an Ed25519 signature covers for a clearance grant.
+#[must_use]
+pub fn canonical_grant_payload(node_id: &str, operator_id: &str, granted_at_ms: u64) -> String {
+    serde_json::json!({
+        "node_id": node_id,
+        "operator_id": operator_id,
+        "granted_at_ms": granted_at_ms,
+    })
+    .to_string()
+}
+
+/// Sign a clearance grant with the issuing controller's key (ops/cloud side).
+#[must_use]
+pub fn sign_clearance_grant(
+    signing_key: &SigningKey,
+    node_id: &str,
+    operator_id: &str,
+    granted_at_ms: u64,
+) -> SignedClearanceGrant {
+    let payload = canonical_grant_payload(node_id, operator_id, granted_at_ms);
+    let sig: Signature = signing_key.sign(payload.as_bytes());
+    SignedClearanceGrant {
+        node_id: node_id.to_string(),
+        operator_id: operator_id.to_string(),
+        granted_at_ms,
+        signature_b64: B64.encode(sig.to_bytes()),
+    }
+}
+
+/// Verify a clearance grant's Ed25519 signature against `public_key_b64`. Fail-closed
+/// on any malformed key / signature.
+#[must_use]
+pub fn verify_clearance_grant(grant: &SignedClearanceGrant, public_key_b64: &str) -> bool {
+    let Ok(pk_bytes) = B64.decode(public_key_b64) else { return false };
+    let Ok(sig_bytes) = B64.decode(grant.signature_b64.as_bytes()) else { return false };
+    let Ok(pk_array) = <[u8; 32]>::try_from(pk_bytes.as_slice()) else { return false };
+    let Ok(sig_array) = <[u8; 64]>::try_from(sig_bytes.as_slice()) else { return false };
+    let Ok(key) = VerifyingKey::from_bytes(&pk_array) else { return false };
+    let sig = Signature::from_bytes(&sig_array);
+    let payload = canonical_grant_payload(&grant.node_id, &grant.operator_id, grant.granted_at_ms);
+    key.verify(payload.as_bytes(), &sig).is_ok()
+}
+
+/// **THE GRANT RULE.** Verify a received grant, then write it through the EXISTING
+/// Phase-A store path as a `PENDING-NODE-TRANSPORT` row — the same row Phase-B's
+/// `take_pending_clearance_grant` consumes. No new schema, no second release path.
+///
+/// Verify-FIRST, fail-closed: an unsigned / bad-signature / structurally-malformed
+/// grant is rejected + counted and NEVER reaches the store. Returns the store rowid
+/// on success.
+pub fn ingest_clearance_grant(
+    store: &mut VerifierStore,
+    grant: &SignedClearanceGrant,
+    public_key_b64: &str,
+    counter: &RejectionCounter,
+) -> Result<i64, RejectReason> {
+    if grant.signature_b64.trim().is_empty() {
+        let r = RejectReason::Unsigned;
+        counter.record(&r);
+        return Err(r);
+    }
+    if grant.node_id.trim().is_empty() || grant.operator_id.trim().is_empty() {
+        let r = RejectReason::Malformed("empty node_id or operator_id".into());
+        counter.record(&r);
+        return Err(r);
+    }
+    if !verify_clearance_grant(grant, public_key_b64) {
+        let r = RejectReason::BadSignature;
+        counter.record(&r);
+        return Err(r);
+    }
+    // Verified → the existing Phase-A path (writes the PENDING row + signed audit
+    // event). Phase-B picks it up unchanged.
+    match store.save_clearance_grant_chained(&grant.node_id, &grant.operator_id, grant.granted_at_ms) {
+        Ok(rowid) => {
+            counter.record_accepted();
+            Ok(rowid)
+        }
+        Err(e) => {
+            let r = RejectReason::StoreError(e.to_string());
+            counter.record(&r);
+            Err(r)
+        }
+    }
+}
+
+#[cfg(test)]
+mod core_tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn keypair() -> (SigningKey, String) {
+        let mut seed = [0u8; 32];
+        rand::Rng::fill(&mut rand::thread_rng(), &mut seed);
+        let sk = SigningKey::from_bytes(&seed);
+        let pk_b64 = B64.encode(sk.verifying_key().to_bytes());
+        (sk, pk_b64)
+    }
+
+    /// A genuinely signed report, built the way the verifier signs (over the
+    /// canonical v2 payload).
+    fn signed_report(sk: &SigningKey, asset: &str, gen: Option<u64>) -> FederatedTrustReportV2 {
+        use kirra_runtime_sdk::federation_reconciliation::canonical_federation_payload_v2;
+        let mut report = FederatedTrustReportV2 {
+            source_controller_id: "controller-A".into(),
+            asset_id: asset.into(),
+            posture: FleetPosture::Nominal,
+            issued_at_ms: 1_000,
+            expires_at_ms: 6_000,
+            nonce_hex: "deadbeef".into(),
+            signature_b64: String::new(),
+            source_generation: gen,
+        };
+        let sig = sk.sign(canonical_federation_payload_v2(&report).as_bytes());
+        report.signature_b64 = B64.encode(sig.to_bytes());
+        report
+    }
+
+    #[test]
+    fn report_round_trips_and_verifies() {
+        let (sk, pk) = keypair();
+        let counter = RejectionCounter::new();
+        let report = signed_report(&sk, "robot-01", Some(7));
+        let bytes = encode_report(&report).unwrap();
+        let got = accept_report(&bytes, &pk, &counter).unwrap();
+        assert_eq!(got, report);
+        assert_eq!(counter.snapshot().accepted, 1);
+        assert_eq!(counter.total_rejected(), 0);
+    }
+
+    #[test]
+    fn tampered_report_is_rejected_and_counted() {
+        let (sk, pk) = keypair();
+        let counter = RejectionCounter::new();
+        let report = signed_report(&sk, "robot-01", Some(7));
+        let mut bytes = encode_report(&report).unwrap();
+        // Flip a byte in the asset_id region — the signature no longer matches the
+        // canonical payload. (Find the 'r' of "robot-01" and bump it.)
+        let pos = bytes.windows(8).position(|w| w == b"robot-01").expect("asset in json");
+        bytes[pos] ^= 0x01;
+        let err = accept_report(&bytes, &pk, &counter).unwrap_err();
+        assert_eq!(err, RejectReason::BadSignature, "tamper must be a bad-signature reject");
+        assert_eq!(counter.snapshot().bad_signature, 1);
+        assert_eq!(counter.snapshot().accepted, 0);
+    }
+
+    #[test]
+    fn unsigned_report_is_rejected_and_counted() {
+        let (_sk, pk) = keypair();
+        let counter = RejectionCounter::new();
+        let report = FederatedTrustReportV2 {
+            source_controller_id: "c".into(),
+            asset_id: "robot-01".into(),
+            posture: FleetPosture::Nominal,
+            issued_at_ms: 1,
+            expires_at_ms: 2,
+            nonce_hex: "00".into(),
+            signature_b64: String::new(), // UNSIGNED
+            source_generation: None,
+        };
+        let bytes = encode_report(&report).unwrap();
+        let err = accept_report(&bytes, &pk, &counter).unwrap_err();
+        assert_eq!(err, RejectReason::Unsigned);
+        assert_eq!(counter.snapshot().unsigned, 1);
+    }
+
+    #[test]
+    fn report_signed_by_wrong_key_is_bad_signature() {
+        let (sk, _pk) = keypair();
+        let (_other, attacker_pk) = keypair();
+        let counter = RejectionCounter::new();
+        let report = signed_report(&sk, "robot-01", None);
+        let bytes = encode_report(&report).unwrap();
+        // Verify against an UNRELATED key → bad signature, never accepted.
+        let err = accept_report(&bytes, &attacker_pk, &counter).unwrap_err();
+        assert_eq!(err, RejectReason::BadSignature);
+    }
+
+    #[test]
+    fn grant_relay_lands_a_pending_row_that_phase_b_consumes() {
+        // THE COMPOSITION PROOF: a verified grant goes through the EXISTING
+        // Phase-A store path and is then consumed by the EXISTING Phase-B
+        // one-shot pickup — no new schema, no new release path.
+        let (sk, pk) = keypair();
+        let counter = RejectionCounter::new();
+        let mut store = VerifierStore::new(":memory:").unwrap();
+
+        let grant = sign_clearance_grant(&sk, "robot-01", "alice", 1_000);
+        let rowid = ingest_clearance_grant(&mut store, &grant, &pk, &counter).unwrap();
+        assert!(rowid > 0);
+        assert_eq!(counter.snapshot().accepted, 1);
+
+        // Phase-B's EXISTING one-shot pickup finds exactly that PENDING row.
+        let picked = store.take_pending_clearance_grant("robot-01", 1_500).unwrap();
+        let picked = picked.expect("the relayed grant is a pending row Phase-B consumes");
+        assert_eq!(picked.node_id, "robot-01");
+        assert_eq!(picked.operator_id, "alice");
+        assert_eq!(picked.granted_at_ms, 1_000);
+        // Exactly once — a second pickup finds nothing.
+        assert!(store.take_pending_clearance_grant("robot-01", 1_600).unwrap().is_none());
+    }
+
+    #[test]
+    fn tampered_grant_never_reaches_the_store() {
+        let (sk, pk) = keypair();
+        let counter = RejectionCounter::new();
+        let mut store = VerifierStore::new(":memory:").unwrap();
+
+        let mut grant = sign_clearance_grant(&sk, "robot-01", "alice", 1_000);
+        // Tamper: change the operator AFTER signing → signature no longer matches.
+        grant.operator_id = "mallory".into();
+        let err = ingest_clearance_grant(&mut store, &grant, &pk, &counter).unwrap_err();
+        assert_eq!(err, RejectReason::BadSignature);
+        assert_eq!(counter.snapshot().bad_signature, 1);
+        // Nothing was written — Phase-B finds no pending row.
+        assert!(store.take_pending_clearance_grant("robot-01", 2_000).unwrap().is_none());
+    }
+}

--- a/crates/kirra-fleet-transport/src/transport.rs
+++ b/crates/kirra-fleet-transport/src/transport.rs
@@ -1,0 +1,316 @@
+//! The Zenoh pub/sub edge of the fleet lane. Thin: it carries bytes and, on
+//! ingest, **verifies before surfacing** (ADR-0007 Clause 1) — the carrier never
+//! hands a caller an unverified payload. All trust/codec logic lives in the crate
+//! root ([`crate`]); this module is transport only.
+
+use zenoh::Session;
+
+use kirra_runtime_sdk::federation_reconciliation::FederatedTrustReportV2;
+use kirra_runtime_sdk::verifier_store::VerifierStore;
+
+use crate::{
+    accept_report, encode_report, ingest_clearance_grant, key_clearance_grant, key_posture,
+    key_trust_report, FleetPosture, PostureSummary, RejectReason, RejectionCounter,
+    SignedClearanceGrant,
+};
+
+/// Vehicle-side publisher (vehicle → ops/cloud). Publishes signed trust reports +
+/// posture summaries on the versioned `kirra/v1/fleet/{node_id}/…` keys.
+pub struct FleetPublisher {
+    session: Session,
+}
+
+impl FleetPublisher {
+    #[must_use]
+    pub fn new(session: Session) -> Self {
+        Self { session }
+    }
+
+    /// Publish a signed [`FederatedTrustReportV2`] for its asset.
+    pub async fn publish_report(&self, report: &FederatedTrustReportV2) -> Result<(), String> {
+        let bytes = encode_report(report).map_err(|e| format!("{e:?}"))?;
+        self.session
+            .put(key_trust_report(&report.asset_id), bytes)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    /// Publish a posture summary (advisory telemetry; see [`PostureSummary`]).
+    pub async fn publish_posture(&self, node_id: &str, posture: FleetPosture, now_ms: u64) -> Result<(), String> {
+        let summary = PostureSummary { node_id: node_id.to_string(), posture, generated_at_ms: now_ms };
+        let bytes = serde_json::to_vec(&summary).map_err(|e| e.to_string())?;
+        self.session
+            .put(key_posture(node_id), bytes)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    /// Ops/cloud-side: publish a SIGNED clearance grant DOWN to a vehicle. (In a
+    /// real deployment this runs on the ops controller; co-located here for the
+    /// spike.) The signature is the trust root — the vehicle verifies before use.
+    pub async fn publish_clearance_grant(&self, grant: &SignedClearanceGrant) -> Result<(), String> {
+        let bytes = serde_json::to_vec(grant).map_err(|e| e.to_string())?;
+        self.session
+            .put(key_clearance_grant(&grant.node_id), bytes)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    /// Access the underlying session (e.g. to close it).
+    #[must_use]
+    pub fn session(&self) -> &Session {
+        &self.session
+    }
+}
+
+/// Fleet-side subscriber for a node's signed trust reports. `recv_report`
+/// **verifies the signature before returning** — an unsigned / bad-sig / malformed
+/// payload is rejected and counted, never surfaced.
+pub struct FleetSubscriber {
+    subscriber: zenoh::pubsub::Subscriber<zenoh::handlers::FifoChannelHandler<zenoh::sample::Sample>>,
+}
+
+impl FleetSubscriber {
+    /// Declare a subscriber on `kirra/v1/fleet/{node_id}/trust-report`.
+    pub async fn declare(session: &Session, node_id: &str) -> Result<Self, String> {
+        let subscriber = session
+            .declare_subscriber(key_trust_report(node_id))
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(Self { subscriber })
+    }
+
+    /// Receive the next payload, **verify it against `public_key_b64`**, and return
+    /// the verified report. Rejections increment `counter`.
+    pub async fn recv_report(
+        &self,
+        public_key_b64: &str,
+        counter: &RejectionCounter,
+    ) -> Result<FederatedTrustReportV2, RejectReason> {
+        let sample = self
+            .subscriber
+            .recv_async()
+            .await
+            .map_err(|e| RejectReason::Decode(format!("recv: {e}")))?;
+        let bytes = sample.payload().to_bytes();
+        accept_report(&bytes, public_key_b64, counter)
+    }
+}
+
+/// Vehicle-side subscriber for DOWN-lane clearance grants. `recv_and_ingest`
+/// verifies the signature then writes the grant through the EXISTING Phase-A store
+/// path (a `PENDING` row Phase-B consumes) — never a second release path.
+pub struct GrantIngest {
+    subscriber: zenoh::pubsub::Subscriber<zenoh::handlers::FifoChannelHandler<zenoh::sample::Sample>>,
+}
+
+impl GrantIngest {
+    /// Declare a subscriber on `kirra/v1/ops/{node_id}/clearance-grant`.
+    pub async fn declare(session: &Session, node_id: &str) -> Result<Self, String> {
+        let subscriber = session
+            .declare_subscriber(key_clearance_grant(node_id))
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(Self { subscriber })
+    }
+
+    /// Receive the next grant, verify it against `public_key_b64`, and on success
+    /// write it to `store` via the Phase-A path. Returns the store rowid.
+    pub async fn recv_and_ingest(
+        &self,
+        store: &mut VerifierStore,
+        public_key_b64: &str,
+        counter: &RejectionCounter,
+    ) -> Result<i64, RejectReason> {
+        let sample = self
+            .subscriber
+            .recv_async()
+            .await
+            .map_err(|e| RejectReason::Decode(format!("recv: {e}")))?;
+        let bytes = sample.payload().to_bytes();
+        let grant: SignedClearanceGrant = serde_json::from_slice(&bytes)
+            .map_err(|e| {
+                let r = RejectReason::Decode(e.to_string());
+                counter.record(&r);
+                r
+            })?;
+        ingest_clearance_grant(store, &grant, public_key_b64, counter)
+    }
+}
+
+#[cfg(test)]
+mod transport_tests {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+    use ed25519_dalek::{Signer, SigningKey};
+    use kirra_runtime_sdk::federation_reconciliation::canonical_federation_payload_v2;
+
+    use crate::{sign_clearance_grant, key_trust_report};
+
+    fn keypair() -> (SigningKey, String) {
+        let mut seed = [0u8; 32];
+        rand::Rng::fill(&mut rand::thread_rng(), &mut seed);
+        let sk = SigningKey::from_bytes(&seed);
+        let pk = B64.encode(sk.verifying_key().to_bytes());
+        (sk, pk)
+    }
+
+    fn signed_report(sk: &SigningKey, asset: &str) -> FederatedTrustReportV2 {
+        let mut r = FederatedTrustReportV2 {
+            source_controller_id: "controller-A".into(),
+            asset_id: asset.into(),
+            posture: FleetPosture::Nominal,
+            issued_at_ms: 1_000,
+            expires_at_ms: 6_000,
+            nonce_hex: "deadbeef".into(),
+            signature_b64: String::new(),
+            source_generation: Some(3),
+        };
+        let sig = sk.sign(canonical_federation_payload_v2(&r).as_bytes());
+        r.signature_b64 = B64.encode(sig.to_bytes());
+        r
+    }
+
+    fn free_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    /// A deterministic in-process peer config: explicit TCP endpoint, multicast
+    /// scouting OFF (so the two sessions connect ONLY to each other — no router,
+    /// no network discovery).
+    fn peer_config(listen: Option<&str>, connect: Option<&str>) -> zenoh::Config {
+        let mut c = zenoh::Config::default();
+        c.insert_json5("mode", "\"peer\"").unwrap();
+        c.insert_json5("scouting/multicast/enabled", "false").unwrap();
+        c.insert_json5("scouting/gossip/enabled", "false").unwrap();
+        // ALWAYS set listen explicitly — `[]` on the connect-only side — so zenoh
+        // never falls back to its default `tcp/[::]:0` (IPv6) listener, which the
+        // sandbox does not support. The connector dials out; it need not listen.
+        let listen_json = match listen {
+            Some(l) => format!("[\"{l}\"]"),
+            None => "[]".to_string(),
+        };
+        c.insert_json5("listen/endpoints", &listen_json).unwrap();
+        if let Some(cn) = connect {
+            c.insert_json5("connect/endpoints", &format!("[\"{cn}\"]")).unwrap();
+        }
+        c
+    }
+
+    async fn settle() {
+        // Allow the TCP session + subscription state to propagate between peers.
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+    }
+
+    /// REPORT ROUND-TRIP over two in-process Zenoh peer sessions: publish a signed
+    /// report, receive it on the other session, and verify it lands intact and
+    /// signature-valid.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn report_round_trip_over_two_peer_sessions_verifies() {
+        let (sk, pk) = keypair();
+        let ep = format!("tcp/127.0.0.1:{}", free_port());
+
+        // Subscriber session listens; publisher session connects to it.
+        let sub_session = zenoh::open(peer_config(Some(&ep), None)).await.unwrap();
+        let subscriber = FleetSubscriber::declare(&sub_session, "robot-01").await.unwrap();
+
+        let pub_session = zenoh::open(peer_config(None, Some(&ep))).await.unwrap();
+        let publisher = FleetPublisher::new(pub_session);
+        settle().await;
+
+        let report = signed_report(&sk, "robot-01");
+        publisher.publish_report(&report).await.unwrap();
+
+        let counter = RejectionCounter::new();
+        let got = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            subscriber.recv_report(&pk, &counter),
+        )
+        .await
+        .expect("recv timed out — the carrier did not deliver")
+        .expect("verified report");
+
+        assert_eq!(got, report);
+        assert_eq!(counter.snapshot().accepted, 1);
+        assert_eq!(counter.total_rejected(), 0);
+    }
+
+    /// TAMPER over the wire: a byte flipped in the published payload is rejected at
+    /// the subscriber (bad signature) and counted — the carrier cannot launder a
+    /// tampered payload into an accepted one.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tampered_payload_over_the_wire_is_rejected_and_counted() {
+        let (sk, pk) = keypair();
+        let ep = format!("tcp/127.0.0.1:{}", free_port());
+
+        let sub_session = zenoh::open(peer_config(Some(&ep), None)).await.unwrap();
+        let subscriber = FleetSubscriber::declare(&sub_session, "robot-02").await.unwrap();
+        let pub_session = zenoh::open(peer_config(None, Some(&ep))).await.unwrap();
+        settle().await;
+
+        // Publish raw tampered bytes directly on the key (a hostile/garbled carrier).
+        let report = signed_report(&sk, "robot-02");
+        let mut bytes = encode_report(&report).unwrap();
+        let pos = bytes.windows(8).position(|w| w == b"robot-02").unwrap();
+        bytes[pos] ^= 0x01;
+        pub_session.put(key_trust_report("robot-02"), bytes).await.unwrap();
+
+        let counter = RejectionCounter::new();
+        let err = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            subscriber.recv_report(&pk, &counter),
+        )
+        .await
+        .expect("recv timed out")
+        .unwrap_err();
+        assert_eq!(err, RejectReason::BadSignature);
+        assert_eq!(counter.snapshot().bad_signature, 1);
+        assert_eq!(counter.snapshot().accepted, 0);
+    }
+
+    /// GRANT RELAY over Zenoh → the EXISTING store → the EXISTING Phase-B pickup.
+    /// The composition proof end-to-end across the real carrier: a signed grant
+    /// published down-lane lands a PENDING row that `take_pending_clearance_grant`
+    /// then consumes exactly once.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn grant_relay_over_the_wire_lands_a_pending_row_phase_b_consumes() {
+        let (sk, pk) = keypair();
+        let ep = format!("tcp/127.0.0.1:{}", free_port());
+
+        // Vehicle side declares the grant-ingest subscriber + owns the store.
+        let veh_session = zenoh::open(peer_config(Some(&ep), None)).await.unwrap();
+        let ingest = GrantIngest::declare(&veh_session, "robot-03").await.unwrap();
+        let mut store = VerifierStore::new(":memory:").unwrap();
+
+        // Ops side connects + publishes the signed grant.
+        let ops_session = zenoh::open(peer_config(None, Some(&ep))).await.unwrap();
+        let ops = FleetPublisher::new(ops_session);
+        settle().await;
+
+        let grant = sign_clearance_grant(&sk, "robot-03", "alice", 1_000);
+        ops.publish_clearance_grant(&grant).await.unwrap();
+
+        let counter = RejectionCounter::new();
+        let rowid = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            ingest.recv_and_ingest(&mut store, &pk, &counter),
+        )
+        .await
+        .expect("recv timed out")
+        .expect("verified grant ingested");
+        assert!(rowid > 0);
+        assert_eq!(counter.snapshot().accepted, 1);
+
+        // The EXISTING Phase-B one-shot pickup consumes exactly that row.
+        let picked = store
+            .take_pending_clearance_grant("robot-03", 1_500)
+            .unwrap()
+            .expect("relayed grant is the pending row Phase-B picks up");
+        assert_eq!(picked.operator_id, "alice");
+        assert!(store.take_pending_clearance_grant("robot-03", 1_600).unwrap().is_none());
+    }
+}

--- a/docs/adr/0007-fleet-transport-zenoh.md
+++ b/docs/adr/0007-fleet-transport-zenoh.md
@@ -1,0 +1,152 @@
+# ADR-0007: Fleet transport — Zenoh on the QM fleet lane; an untrusted carrier under Ed25519 payload trust; grants terminate at the verifier store
+
+| Field | Value |
+|---|---|
+| Status | **Accepted (direction)** — spike landed; see *Conditions that reopen this decision* |
+| Date | 2026-06-12 |
+| Deciders | Project owner |
+| Issues | #296 (this ADR + spike); #304 (the remote-grant variant it composes with); #314 (multi-tenant fleet side); the market driver `docs/MARKET_AUTONOMOUS_SERVICES.md` |
+| Doc | `crates/kirra-fleet-transport/README.md` (the spike) |
+| Builds on | **ADR-0006 Clause 2** (the frozen-layout boundary asymmetry — the parent rule that keeps a fleet transport OUT of the safety path) |
+
+## Context
+
+KIRRA's safety argument rests on an **independent safety channel** and a
+**frozen-layout partition boundary** (ADR-0004 / ADR-0006): the governor's
+authority never travels over a general-purpose network transport. Separately,
+KIRRA has a **fleet lane** — vehicle ↔ ops/cloud — that carries QM traffic:
+federated trust reports (`FederatedTrustReportV2`), fleet-posture dissemination,
+and (the #304 deferral) **remote operator clearance grants**.
+
+The autonomous-services market (`docs/MARKET_AUTONOMOUS_SERVICES.md`) makes this
+lane strategic: sidewalk-courier and delivery-AV fleets are **cellular** and
+**distributed**, with single operators and platforms spanning many vehicles. The
+trust reports and posture they generate are only useful if they cross the
+wide-area hop — and a remote grant must reach the vehicle. That hop needs a
+transport. It must **never** become a safety-bearing channel.
+
+The federation payloads already carry their own cryptographic trust: the v2 report
+is Ed25519-signed over a **canonical payload** (`canonical_federation_payload_v2`),
+verified by `verify_federated_report_signature_v2` — so the **trust is in the
+payload, independent of whatever carries it.** That is the hinge this decision
+turns on.
+
+## Decision
+
+Adopt **Zenoh** (`zenoh` + `zenoh-ext` **stable** APIs only, per upstream
+guidance) as the fleet-lane transport for cellular/distributed fleets. Three
+clauses, each load-bearing and **distinct**.
+
+### Clause 1 — the transport is an UNTRUSTED CARRIER (the trust rule)
+
+Trust derives from **Ed25519 payload signatures**, **never** from transport
+identity, topic name, or Zenoh's own authentication:
+
+- Trust reports — `verify_federated_report_signature_v2` over the canonical v2
+  payload (SDK).
+- Clearance grants — a signed envelope (`SignedClearanceGrant`) verified by
+  `verify_clearance_grant` against the issuing controller's registered public key,
+  reusing the **same** canonical-payload + Ed25519 pattern.
+
+**Every ingest verifies BEFORE use.** The carrier never surfaces an unverified
+payload to a caller; unsigned / bad-signature / malformed payloads are **rejected
+and counted** (`RejectionCounter`, surfaced for ops). Zenoh-level TLS/auth is
+**confidentiality defense-in-depth, not the trust root** — a deployment may enable
+it, but the safety/trust argument does not depend on it. (Concretely: the spike
+disables TLS to dodge a bench-toolchain dep wall, and **loses no trust** by doing
+so — see *Honest limits*.)
+
+### Clause 2 — strictly QM / fleet lane (the domain rule)
+
+Zenoh is the **fleet lane only** (robot↔robot, robot↔cloud) and **never the safety
+channel.** The crate `kirra-fleet-transport` is a **LEAF** consumer: it depends on
+the SDK; **nothing under `src/gateway/`, the governor, the boundary channel, or any
+safety path may ever depend on it.** The dependency edge points one way, downhill,
+out of the safety domain.
+
+This is **ADR-0006 Clause 2's asymmetry applied**: across the partition boundary
+the transport is a frozen `#[repr(C)]` layout precisely so that discovery,
+lifecycle, and version-compat machinery stay out of the TCB — a fleet transport
+with all of that machinery belongs strictly on the QM side. ADR-0006 Clause 2 holds
+even if Zenoh were dropped entirely; this ADR can never weaken it.
+
+### Clause 3 — the remote grant TERMINATES AT THE VERIFIER STORE (the grant rule)
+
+The down-lane grant composes with the operator-console clearance design; it does
+**not** create a second release path:
+
+1. The ops/cloud side publishes a **signed** `SignedClearanceGrant`.
+2. The vehicle side's subscriber **verifies the signature**, then writes the grant
+   through the **EXISTING Phase-A path** — `VerifierStore::save_clearance_grant_chained`
+   — which lands a `PENDING-NODE-TRANSPORT` row and a signed audit event.
+3. **Phase-B is unchanged**: `take_pending_clearance_grant` (the one-shot,
+   exactly-once consume) + the loop's two-checkpoint re-validation at delivery
+   proceed exactly as before.
+
+**No new store schema. No new release semantics.** Remote transport is just another
+way a `PENDING` row arrives; everything downstream is the audited, one-shot path
+that already exists. (If the store had lacked a public write API for this, the
+correct move would have been to STOP rather than add a route/schema — it did not;
+`save_clearance_grant_chained` is public and is exactly that seam.)
+
+## Namespace — versioned key expressions
+
+`v1` is the wire-contract version; a breaking change bumps it. Up-lane and
+down-lane are split by the `fleet/` vs `ops/` segment:
+
+| Direction | Key expression | Payload |
+|---|---|---|
+| Up (vehicle → fleet) | `kirra/v1/fleet/{node_id}/trust-report` | signed `FederatedTrustReportV2` |
+| Up (vehicle → fleet) | `kirra/v1/fleet/{node_id}/posture` | `PostureSummary` (advisory telemetry) |
+| Down (ops → vehicle) | `kirra/v1/ops/{node_id}/clearance-grant` | signed `SignedClearanceGrant` |
+
+## Wire codec
+
+**JSON** (`serde_json`) on the fleet wire — **not** the bincode of
+`kirra-wire-client`'s governor UDP hot path: the fleet lane is a debuggable
+ops/cloud hop and trust is anchored in the Ed25519 signature over the *canonical*
+payload (not the wire bytes), so JSON costs no trust and buys cross-tooling
+debuggability.
+
+## Considered and rejected
+
+- **Zenoh as (or near) the safety channel** — rejected by Clause 2 / ADR-0006 C2:
+  a general-purpose pub/sub transport in the safety partition imports its entire
+  discovery/lifecycle/version surface into the TCB.
+- **Trust from transport identity / topic ACLs / Zenoh auth** — rejected by
+  Clause 1: that would make the carrier the trust root. Trust is the payload
+  signature; the carrier is replaceable.
+- **A second remote release path for grants** — rejected by Clause 3: the grant
+  must land as a `PENDING` row in the existing store and be consumed by the
+  existing one-shot Phase-B pickup; a parallel release path would be an
+  unaudited bypass.
+- **bincode on the fleet wire** (to match `kirra-wire-client`) — not chosen:
+  the governor hot path values compactness; the fleet lane values debuggability,
+  and the codec is trust-irrelevant here.
+
+## Honest limits (named, not built)
+
+- **Router / cellular / NAT** — real fleets need a Zenoh router and cellular/NAT
+  traversal; that is **ops/router deployment territory** (a deployment doc), not
+  this crate. The spike uses in-process localhost peer sessions.
+- **QoS / delivery guarantees** — `zenoh-ext`'s `AdvancedPublisher` / reliability
+  is the path to delivery guarantees over a lossy cellular link; a **named
+  future**, not in the spike.
+- **Multi-tenant fleet side** — a per-controller **public-key registry** (which
+  key verifies which source) and per-operator identity at fleet scale is **#314**.
+  The spike verifies against a supplied key; it does not yet manage a keyring.
+- **TLS + the toolchain wall (MSRV).** Zenoh's *default* TLS/QUIC features pull an
+  `rcgen`/`time` chain that does **not compile on the bench toolchain** (rustc
+  1.94.1, `E0119`). The spike disables TLS (`default-features = false`,
+  `transport_tcp` + `unstable`) — which, per Clause 1, costs no trust. The **bench
+  is the build authority** for the TLS-enabled production config; the
+  `zenoh-pinned-deps-1-75` dependency lockdown remains the escape hatch if a future
+  transitive break appears. Zenoh's runtime additionally requires a multi-threaded
+  scheduler (the tests use `flavor = "multi_thread"`).
+
+## Conditions that reopen this decision
+
+- A QoS/reliability requirement that `zenoh-ext` stable APIs cannot meet.
+- A certification finding that the QM/safety split (Clause 2) is insufficiently
+  enforced (e.g. a discovered dependency edge into a safety crate).
+- A move of the wire-contract version (`v1` → `v2`) that changes payload trust.


### PR DESCRIPTION
The **fleet lane** (vehicle ↔ ops/cloud) for cellular / distributed fleets: ADR-0007 + a working spike crate. **STRICTLY QM** — Zenoh never appears in the safety partition or the boundary channel (ADR-0006 Clause 2 is the parent rule). Talisman `997fb7ae15ce3e11adec9218044c7c84b049ad3b` **byte-identical** (checked first + last).

## ADR-0007 — three load-bearing clauses

1. **Untrusted carrier.** Trust derives from **Ed25519 payload signatures** — reports via the SDK's `verify_federated_report_signature_v2`, grants via a signed envelope reusing the same canonical-payload pattern — **never** transport identity, topic name, or Zenoh auth. Every ingest **verifies before use**; unsigned / bad-sig / malformed payloads are rejected and **counted** (`RejectionCounter`). TLS is confidentiality defense-in-depth, *not* the trust root.
2. **Strictly QM.** The crate is a **leaf** consumer of the SDK; **nothing under `src/gateway/` or any safety path may depend on it.** ADR-0006 Clause 2's boundary asymmetry applied.
3. **Grants terminate at the store.** A verified grant is written through the **existing** Phase-A path (`save_clearance_grant_chained`, a `PENDING` row); **Phase-B's one-shot pickup + two-checkpoint delivery proceed unchanged.** No new schema, no second release path.

Plus: versioned key expressions (`kirra/v1/fleet|ops/{node_id}/…`, up/down split), the JSON-codec justification (debuggable hop; trust is the signature, not the codec), and an honest-limits section (router/cellular, QoS/`AdvancedPublisher`, #314 multi-tenant, the TLS/MSRV toolchain wall).

## `crates/kirra-fleet-transport` (new workspace member)

- **`lib.rs`** — the transport-free **trust + codec core**: namespace keys, `accept_report` (decode → **verify-first**), the `SignedClearanceGrant` envelope (`sign`/`verify`), `ingest_clearance_grant` (verify → existing store path), `RejectionCounter`.
- **`transport.rs`** — the thin Zenoh edge: `FleetPublisher`, `FleetSubscriber` (`recv_report` verifies before surfacing), `GrantIngest`.

## Tests — green in-sandbox (9/9)

6 core (no session) + **3 over two in-process Zenoh peer sessions** (no router, localhost TCP, multicast off):
- report **round-trip verifies**;
- a **tampered over-the-wire** payload is rejected (bad signature) and counted — the carrier can't launder a tamper into an accept;
- the **grant relay lands a `PENDING` row that the existing `take_pending_clearance_grant` consumes exactly once** — the composition proof end-to-end.

## Build / toolchain note (the bench is the authority)

The spike **builds and tests in the sandbox** (rustc 1.94.1) with Zenoh's **TLS/QUIC disabled** (`default-features = false`, `transport_tcp` + `unstable`). Zenoh's *default* TLS stack pulls an `rcgen`/`time` chain that **does not compile on 1.94.1** (`E0119`) — the anticipated MSRV wall. Disabling TLS **costs no trust** (the trust root is the payload signature, Clause 1); the bench is the authority for the TLS-enabled production config, with the `zenoh-pinned-deps-1-75` lockdown as the escape hatch. (Zenoh's runtime also requires a multi-thread scheduler — the tests use `flavor = "multi_thread"`.)

## Scope / verify

- **Scope:** the ADR + the new crate + **one** workspace-members line. **No** `src/gateway`, **no** parko, **no** service-route/schema changes — the store write goes through the existing public `save_clearance_grant_chained`; trust verification reuses the existing federation Ed25519 path.
- `cargo test -p kirra-fleet-transport` **9/9 green**; **clippy clean**; talisman byte-identical.

## What remains (per the ADR honest-limits)

Router/cellular/NAT deployment (ops territory), QoS/`AdvancedPublisher` delivery guarantees (named future), and the multi-tenant per-controller key registry (**#314**).

References #296, #304 (the remote-grant variant this composes with), #314 (multi-tenant fleet side), `docs/MARKET_AUTONOMOUS_SERVICES.md`, ADR-0006.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_