### PR TITLE
feat(console): operator-proven identity — Ed25519 signed grants, verify-then-consume, break-glass named (#314 Phase 1)

### DIFF
--- a/docs/CONSOLE_RUNBOOK.md
+++ b/docs/CONSOLE_RUNBOOK.md
@@ -84,6 +84,87 @@ A fresh `KIRRA_DB_PATH` re-seeds cleanly (step 2).
 
 ---
 
+## Operator onboarding (#314 Phase 1 — operator-proven identity)
+
+The console's primary clearance path is **operator-signed**: a registered operator
+proves possession of their Ed25519 private key by signing a server challenge, so a
+grant becomes **non-repudiable chain evidence** (the signed ledger records *which
+key* authorized the release), not a self-reported string. The attestation pattern,
+applied to humans.
+
+(`$KIRRA_ADMIN_TOKEN` is exported in step 1; `$BASE` is the running service.)
+
+```sh
+export BASE="http://127.0.0.1:8090"
+```
+
+### 1. Generate an operator keypair (the private key NEVER leaves the operator)
+
+```sh
+openssl genpkey -algorithm ed25519 -out operator_priv.pem      # PRIVATE — keep secret
+openssl pkey -in operator_priv.pem -pubout -out operator_pub.pem  # PUBLIC — to register
+```
+
+### 2. Register the operator's PUBLIC key (admin-gated — a SEPARATE power from the supervisor key)
+
+```sh
+jq -n --arg op alice --arg pem "$(cat operator_pub.pem)" \
+   '{operator_id:$op, ed25519_pubkey_pem:$pem}' \
+ | curl -s -X POST "$BASE/console/operators" \
+     -H "authorization: Bearer $KIRRA_ADMIN_TOKEN" \
+     -H "content-type: application/json" --data-binary @-
+# → {"operator_id":"alice","operator_key_fingerprint":"...","status":"registered"}
+```
+
+Revoke with `POST $BASE/console/operators/alice/revoke` (also admin-gated). A revoked
+operator can never clear a grant.
+
+### 3. Sign a grant — in the browser (primary)
+
+In the grant card, enter the node id + operator id, **paste the operator private key
+PEM** (held in memory for the session only — never `localStorage`, never sent; the
+page signs locally via WebCrypto Ed25519), and submit. The page fetches a one-time
+challenge, signs the canonical payload, and posts the signature. The grant card shows
+the **auth method** + the **key fingerprint**.
+
+### 3-alt. Sign a grant — CLI (when WebCrypto Ed25519 is unavailable)
+
+The console feature-detects WebCrypto Ed25519; if the browser lacks it the in-page
+form is replaced with a pointer here (it does **not** silently fall back to
+break-glass). Sign from the CLI instead — this Python snippet mirrors the server's
+canonical payload exactly:
+
+```python
+import base64, struct, json, urllib.request
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+BASE, op, node = "http://127.0.0.1:8090", "alice", "robot-01"
+priv = load_pem_private_key(open("operator_priv.pem","rb").read(), None)
+nonce = json.load(urllib.request.urlopen(
+    f"{BASE}/console/clearance-challenge?operator_id={op}&node_id={node}"))["nonce"]
+lp = lambda s: struct.pack("<Q", len(s.encode())) + s.encode()        # u64-LE length prefix
+payload = b"KIRRA-OPERATOR-GRANT-v1" + lp(op) + lp(node) + lp(nonce)   # == operator_grant_signing_payload
+sig = base64.b64encode(priv.sign(payload)).decode()
+req = urllib.request.Request(f"{BASE}/console/clearance-grants", method="POST",
+    data=json.dumps({"node_id":node,"operator_id":op,"nonce":nonce,"signature_b64":sig}).encode(),
+    headers={"content-type":"application/json"})
+print(urllib.request.urlopen(req).read().decode())
+```
+
+### Break-glass policy (the named, audited supervisor fallback)
+
+The shared supervisor key (`KIRRA_SUPERVISOR_RESET_KEY`, #255) **remains** as an
+explicitly-named **break-glass** path — recorded distinctly as
+`auth_method="supervisor-break-glass"` and logged loudly — **because a fleet locked
+out of recovery by a lost operator key is its own safety failure**. It is the
+console's *secondary* affordance (a collapsed "Break-glass" panel), never the
+primary. **Deployments that don't want it disable it by unsetting
+`KIRRA_SUPERVISOR_RESET_KEY`** (the route then fail-closes 503 for break-glass while
+operator-signed grants keep working). Use it only when an operator key is genuinely
+unavailable; every use is auditable and visibly distinct from operator-signed grants.
+
+---
+
 ## What you're looking at (one pane at a time)
 
 For a first-time viewer — each pane is a window onto a **real** mechanism, not a

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -137,7 +137,7 @@ pub fn attestation_signing_payload(node_id: &str, nonce: u64) -> Vec<u8> {
 /// stripped here as plain text; the resulting DER is parsed by the vetted
 /// `spki` parser via `VerifyingKey::from_public_key_der`. Returns `None` on
 /// any malformation — callers fail closed.
-fn parse_ed25519_public_pem(pem: &str) -> Option<VerifyingKey> {
+pub fn parse_ed25519_public_pem(pem: &str) -> Option<VerifyingKey> {
     let der_b64: String = pem
         .lines()
         .map(str::trim)
@@ -145,6 +145,62 @@ fn parse_ed25519_public_pem(pem: &str) -> Option<VerifyingKey> {
         .collect();
     let der = B64.decode(der_b64.as_bytes()).ok()?;
     VerifyingKey::from_public_key_der(&der).ok()
+}
+
+// ---------------------------------------------------------------------------
+// Operator-proven identity (#314 Phase 1) — the attestation pattern applied to
+// HUMANS. A registered operator proves possession of their Ed25519 private key
+// by signing a challenge, exactly as a node proves possession of its AK. REUSES
+// the same PEM parser, the same domain-separated/length-prefixed canonicalization
+// style, and `verify_strict`.
+// ---------------------------------------------------------------------------
+
+/// Domain tag for an operator clearance-grant signature. Distinct from
+/// [`ATTESTATION_DOMAIN`] so an operator signature can never be cross-replayed as
+/// a node attestation (or vice versa).
+pub const OPERATOR_GRANT_DOMAIN: &[u8] = b"KIRRA-OPERATOR-GRANT-v1";
+
+/// The exact byte payload an operator signs (with their private key) and the
+/// verifier reconstructs, for a clearance grant on `(operator_id, node_id, nonce)`.
+///
+/// Domain-separated and **length-prefixed on every field** (u64 LE length, then
+/// the field bytes) — the same anti-collision discipline as
+/// [`attestation_signing_payload`], extended to three fields. The browser
+/// (WebCrypto) and the server MUST construct this identically. `nonce` is the
+/// challenge nonce as the hex string the server issued (a string, not a u64, so the
+/// in-browser flow never loses precision on a > 2^53 value).
+#[must_use]
+pub fn operator_grant_signing_payload(operator_id: &str, node_id: &str, nonce: &str) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(OPERATOR_GRANT_DOMAIN.len() + 24
+        + operator_id.len() + node_id.len() + nonce.len());
+    payload.extend_from_slice(OPERATOR_GRANT_DOMAIN);
+    for field in [operator_id, node_id, nonce] {
+        let b = field.as_bytes();
+        payload.extend_from_slice(&(b.len() as u64).to_le_bytes());
+        payload.extend_from_slice(b);
+    }
+    payload
+}
+
+/// Verify an Ed25519 signature over `payload` against a PEM-encoded public key.
+/// Fail-closed: a malformed key, a non-64-byte signature, or a bad signature all
+/// return `false`. Uses `verify_strict` (the same path as node attestation).
+#[must_use]
+pub fn verify_ed25519_pem_signature(pem: &str, payload: &[u8], signature_bytes: &[u8]) -> bool {
+    let Some(vk) = parse_ed25519_public_pem(pem) else { return false };
+    let Ok(sig_array) = <[u8; ED25519_SIGNATURE_LEN]>::try_from(signature_bytes) else {
+        return false;
+    };
+    vk.verify_strict(payload, &Signature::from_bytes(&sig_array)).is_ok()
+}
+
+/// A short, stable fingerprint for a PEM-encoded Ed25519 public key — the
+/// `audit_chain::verifying_key_id` convention reused for operators. `None` if the
+/// PEM is not a valid Ed25519 SPKI key. Recorded with each grant for
+/// non-repudiation (WHICH key signed it).
+#[must_use]
+pub fn operator_key_fingerprint(pem: &str) -> Option<String> {
+    parse_ed25519_public_pem(pem).map(|vk| crate::audit_chain::verifying_key_id(&vk))
 }
 
 /// Verify a node attestation proof (issue #73).

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -2801,89 +2801,311 @@ fn check_supervisor_key(headers: &HeaderMap) -> Result<(), StatusCode> {
     supervisor_key_ok(provided, configured.as_deref())
 }
 
+// ---------------------------------------------------------------------------
+// #314 Phase 1 — operator-proven identity (the attestation pattern for humans)
+// ---------------------------------------------------------------------------
+
+/// Audit a clearance-grant rejection (never records key bytes / signatures).
+fn audit_grant_rejection(
+    app: &kirra_runtime_sdk::verifier::AppState,
+    reason: &str,
+    node_id: &str,
+    operator_id: &str,
+    now: u64,
+) {
+    if let Ok(mut store) = app.store.lock() {
+        let _ = store.append_clearance_audit_event(
+            "OperatorClearanceGrantRejected",
+            &json!({ "reason": reason, "node_id": node_id, "operator_id": operator_id }).to_string(),
+            now,
+        );
+    }
+}
+
+#[derive(Deserialize)]
+struct RegisterOperatorRequest {
+    operator_id: String,
+    ed25519_pubkey_pem: String,
+}
+
+/// POST /console/operators — register (or rotate) an operator's Ed25519 PUBLIC key
+/// (#314 Phase 1). **ADMIN-token-gated** (the node-registration precedent). Admin
+/// and supervisor are SEPARATE powers: this route lives behind
+/// `require_admin_token`, so the **supervisor key cannot register operators**. The
+/// private key NEVER reaches the server — only the public key is stored.
+async fn register_operator(
+    State(svc): State<Arc<ServiceState>>,
+    Json(req): Json<RegisterOperatorRequest>,
+) -> impl IntoResponse {
+    let operator_id = req.operator_id.trim();
+    if operator_id.is_empty() {
+        return (StatusCode::UNPROCESSABLE_ENTITY,
+                Json(json!({ "error": "operator_id must be non-empty" }))).into_response();
+    }
+    // Fail-closed: the PEM must parse as a valid Ed25519 SPKI public key.
+    let fingerprint = match kirra_runtime_sdk::attestation::operator_key_fingerprint(
+        &req.ed25519_pubkey_pem,
+    ) {
+        Some(fp) => fp,
+        None => return (StatusCode::UNPROCESSABLE_ENTITY, Json(json!({
+            "error": "ed25519_pubkey_pem is not a valid Ed25519 SubjectPublicKeyInfo PEM"
+        }))).into_response(),
+    };
+    let now = now_ms();
+    match svc.app.store.lock() {
+        Ok(mut store) => {
+            if store.register_operator(operator_id, &req.ed25519_pubkey_pem, now).is_err() {
+                return (StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({ "error": "persist failed" }))).into_response();
+            }
+            let _ = store.append_clearance_audit_event(
+                "OperatorRegistered",
+                &json!({ "operator_id": operator_id, "operator_key_fingerprint": fingerprint })
+                    .to_string(),
+                now,
+            );
+            (StatusCode::CREATED, Json(json!({
+                "operator_id": operator_id,
+                "operator_key_fingerprint": fingerprint,
+                "status": "registered",
+            }))).into_response()
+        }
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
+                   Json(json!({ "error": "store lock poisoned" }))).into_response(),
+    }
+}
+
+/// POST /console/operators/{operator_id}/revoke — revoke an operator (#314).
+/// ADMIN-token-gated. A revoked operator can never clear a grant.
+async fn revoke_operator(
+    State(svc): State<Arc<ServiceState>>,
+    Path(operator_id): Path<String>,
+) -> impl IntoResponse {
+    let now = now_ms();
+    match svc.app.store.lock() {
+        Ok(mut store) => match store.revoke_operator(&operator_id, now) {
+            Ok(true) => {
+                let _ = store.append_clearance_audit_event(
+                    "OperatorRevoked",
+                    &json!({ "operator_id": operator_id }).to_string(),
+                    now,
+                );
+                (StatusCode::OK, Json(json!({ "operator_id": operator_id, "status": "revoked" })))
+                    .into_response()
+            }
+            Ok(false) => (StatusCode::NOT_FOUND,
+                          Json(json!({ "error": "operator not found or already revoked" })))
+                .into_response(),
+            Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
+                       Json(json!({ "error": "persist failed" }))).into_response(),
+        },
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
+                   Json(json!({ "error": "store lock poisoned" }))).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct ClearanceChallengeQuery {
+    operator_id: String,
+    node_id: String,
+}
+
+/// GET /console/clearance-challenge?operator_id=&node_id= — issue a one-time nonce
+/// the operator signs to prove key possession (#314 Phase 1; the attestation
+/// challenge-issuance pattern). Unauthenticated (the nonce alone grants nothing —
+/// only a valid signature over it does); we 403 unknown/revoked operators so a
+/// challenge is never issued to a non-operator. Short TTL; stored volatile for
+/// verify-then-consume at grant time.
+async fn clearance_challenge(
+    State(svc): State<Arc<ServiceState>>,
+    Query(q): Query<ClearanceChallengeQuery>,
+) -> impl IntoResponse {
+    if !svc.app.is_active() {
+        return (StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({ "error": "instance is in passive standby mode" }))).into_response();
+    }
+    let operator_id = q.operator_id.trim();
+    let node_id = q.node_id.trim();
+    if operator_id.is_empty() || node_id.is_empty() {
+        return (StatusCode::UNPROCESSABLE_ENTITY,
+                Json(json!({ "error": "operator_id and node_id are required" }))).into_response();
+    }
+    let active = match svc.app.store.lock() {
+        Ok(store) => store
+            .load_operator(operator_id)
+            .ok()
+            .flatten()
+            .map(|o| o.is_active())
+            .unwrap_or(false),
+        Err(_) => false,
+    };
+    if !active {
+        return (StatusCode::FORBIDDEN,
+                Json(json!({ "error": "unknown or revoked operator" }))).into_response();
+    }
+    // Hex string (not a u64) so the in-browser signing flow never loses precision.
+    let nonce_hex = format!("{:016x}", kirra_runtime_sdk::verifier::generate_challenge_nonce());
+    let key = format!("{operator_id}|{node_id}");
+    svc.app.issue_clearance_challenge(&key, nonce_hex.clone(), now_ms());
+    (StatusCode::OK, Json(json!({
+        "operator_id": operator_id,
+        "node_id": node_id,
+        "nonce": nonce_hex,
+        "ttl_ms": 30_000,
+    }))).into_response()
+}
+
 #[derive(Deserialize)]
 struct ClearanceGrantRequest {
     node_id: String,
     operator_id: String,
+    /// Operator-signed path: the challenge nonce (as issued) + the base64 Ed25519
+    /// signature over `operator_grant_signing_payload(operator_id, node_id, nonce)`.
+    #[serde(default)]
+    nonce: Option<String>,
+    #[serde(default)]
+    signature_b64: Option<String>,
 }
 
-/// POST /console/clearance-grants — the ONE inbound console affordance.
+/// POST /console/clearance-grants — the ONE inbound console affordance, upgraded
+/// to operator-proven identity (#314 Phase 1).
 ///
-/// **RECORD-ONLY (Phase A):** records + signs a supervisor clearance grant; it
-/// does NOT release the node (delivery to the node `ClearanceLoop` is Phase B).
-/// Auth = the #255 supervisor key (`x-kirra-supervisor-key`). The server stamps
-/// `granted_at_ms` from ITS clock — the client never supplies a timestamp (a
-/// client time would re-open the future-dating hole the loop's validation
-/// closes). Never mutates posture.
+/// **RECORD-ONLY (Phase A):** records + signs a clearance grant; it does NOT
+/// release the node (delivery to the node `ClearanceLoop` is Phase B). The server
+/// stamps `granted_at_ms` from ITS clock (no client time → no future-dating).
+/// Never mutates posture.
+///
+/// Two auth paths:
+///   * **operator-signed (PRIMARY):** a registered operator proves key possession
+///     by signing the challenge nonce. Handler order mirrors `verify_attestation`:
+///     load operator (unknown/revoked → 403) → VERIFY signature → CONSUME nonce
+///     (verify-then-consume; replay → 401) → well-formedness → record with
+///     `auth_method="operator-signed"` + the key fingerprint, BOTH embedded in the
+///     signed chain event (the non-repudiation payoff).
+///   * **supervisor-break-glass (NAMED FALLBACK):** the shared `KIRRA_SUPERVISOR_
+///     RESET_KEY` (#255) REMAINS as an explicitly-named break-glass path —
+///     `auth_method="supervisor-break-glass"`, audited distinctly and loudly —
+///     because a fleet locked out of recovery by a lost operator key is its OWN
+///     safety failure. Deployments disable it by unsetting the env. The console UI
+///     presents operator-signed as the primary flow.
 async fn console_clearance_grant(
     State(svc): State<Arc<ServiceState>>,
     headers: HeaderMap,
     Json(req): Json<ClearanceGrantRequest>,
 ) -> impl IntoResponse {
     let now = now_ms();
+    let operator_id = req.operator_id.trim().to_string();
+    let node_id = req.node_id.trim().to_string();
 
-    // 1. Supervisor authorization (reused #255 mechanism).
-    if let Err(code) = check_supervisor_key(&headers) {
-        // A *provided-but-rejected* attempt (401) is audited; a server-misconfig
-        // (503, key unset) is not an operator attempt. Never record key bytes.
-        if code == StatusCode::UNAUTHORIZED {
-            let payload = json!({
-                "reason": "unauthorized",
-                "node_id": req.node_id,
-                "operator_id": req.operator_id,
-            })
-            .to_string();
-            if let Ok(mut store) = svc.app.store.lock() {
-                let _ = store.append_clearance_audit_event(
-                    "OperatorClearanceGrantRejected", &payload, now);
+    let operator_signed = req.signature_b64.as_deref().is_some_and(|s| !s.is_empty());
+
+    let (auth_method, fingerprint): (&str, Option<String>) = if operator_signed {
+        // === OPERATOR-SIGNED PATH — verify-then-consume (mirrors verify_attestation).
+        let nonce = req.nonce.clone().unwrap_or_default();
+        let sig_b64 = req.signature_b64.clone().unwrap_or_default();
+        if nonce.is_empty() {
+            audit_grant_rejection(&svc.app, "missing_nonce", &node_id, &operator_id, now);
+            return (StatusCode::UNPROCESSABLE_ENTITY, Json(json!({
+                "status": "rejected", "reason": "nonce required for an operator-signed grant"
+            }))).into_response();
+        }
+        // 1. Load operator — unknown / revoked → 403, audited.
+        let operator = match svc.app.store.lock().ok().and_then(|s| s.load_operator(&operator_id).ok().flatten()) {
+            Some(op) if op.is_active() => op,
+            Some(_) => {
+                audit_grant_rejection(&svc.app, "revoked_operator", &node_id, &operator_id, now);
+                return (StatusCode::FORBIDDEN, Json(json!({
+                    "status": "rejected", "reason": "operator is revoked"
+                }))).into_response();
             }
+            None => {
+                audit_grant_rejection(&svc.app, "unknown_operator", &node_id, &operator_id, now);
+                return (StatusCode::FORBIDDEN, Json(json!({
+                    "status": "rejected", "reason": "operator is not registered"
+                }))).into_response();
+            }
+        };
+        // 2. VERIFY signature FIRST (before the nonce is consumed).
+        use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
+        let sig_bytes = match b64e.decode(sig_b64.trim()) {
+            Ok(b) => b,
+            Err(_) => {
+                audit_grant_rejection(&svc.app, "malformed_signature", &node_id, &operator_id, now);
+                return (StatusCode::UNAUTHORIZED, Json(json!({
+                    "status": "rejected", "reason": "signature is not valid base64"
+                }))).into_response();
+            }
+        };
+        let payload = kirra_runtime_sdk::attestation::operator_grant_signing_payload(
+            &operator_id, &node_id, &nonce,
+        );
+        if !kirra_runtime_sdk::attestation::verify_ed25519_pem_signature(
+            &operator.pubkey_pem, &payload, &sig_bytes,
+        ) {
+            audit_grant_rejection(&svc.app, "bad_signature", &node_id, &operator_id, now);
+            return (StatusCode::UNAUTHORIZED, Json(json!({
+                "status": "rejected", "reason": "signature verification failed"
+            }))).into_response();
         }
-        return (code,
-                Json(json!({ "status": "rejected", "reason": "supervisor authorization failed" })))
-            .into_response();
-    }
+        // 3. CONSUME the nonce (verify-then-consume; replay/expired → 401, audited).
+        let key = format!("{operator_id}|{node_id}");
+        if !svc.app.consume_clearance_challenge(&key, &nonce, now) {
+            audit_grant_rejection(&svc.app, "nonce_replay_or_expired", &node_id, &operator_id, now);
+            return (StatusCode::UNAUTHORIZED, Json(json!({
+                "status": "rejected",
+                "reason": "challenge nonce absent, expired, or already used (replay rejected)"
+            }))).into_response();
+        }
+        let fp = kirra_runtime_sdk::attestation::operator_key_fingerprint(&operator.pubkey_pem);
+        ("operator-signed", fp)
+    } else {
+        // === BREAK-GLASS PATH — the named, distinctly-audited supervisor fallback.
+        if let Err(code) = check_supervisor_key(&headers) {
+            if code == StatusCode::UNAUTHORIZED {
+                audit_grant_rejection(&svc.app, "supervisor_unauthorized", &node_id, &operator_id, now);
+            }
+            return (code, Json(json!({
+                "status": "rejected",
+                "reason": "no operator signature and supervisor authorization failed"
+            }))).into_response();
+        }
+        tracing::warn!(node_id = %node_id, operator_id = %operator_id,
+            "BREAK-GLASS clearance grant via supervisor key — operator-signed path bypassed \
+             (auth_method=supervisor-break-glass; audited distinctly)");
+        ("supervisor-break-glass", None)
+    };
 
-    // 2. Well-formedness, server-side (mirrors OperatorClearanceGrant::is_well_formed).
-    let operator_id = req.operator_id.trim();
+    // Shared well-formedness (mirrors OperatorClearanceGrant::is_well_formed).
     if operator_id.is_empty() {
-        let payload = json!({ "reason": "empty_operator_id", "node_id": req.node_id }).to_string();
-        if let Ok(mut store) = svc.app.store.lock() {
-            let _ = store.append_clearance_audit_event(
-                "OperatorClearanceGrantRejected", &payload, now);
-        }
-        return (StatusCode::UNPROCESSABLE_ENTITY,
-                Json(json!({ "status": "rejected", "reason": "operator_id must be non-empty" })))
-            .into_response();
+        audit_grant_rejection(&svc.app, "empty_operator_id", &node_id, &operator_id, now);
+        return (StatusCode::UNPROCESSABLE_ENTITY, Json(json!({
+            "status": "rejected", "reason": "operator_id must be non-empty"
+        }))).into_response();
     }
     let registered = match svc.app.store.lock() {
-        Ok(store) => store.node_exists(&req.node_id).unwrap_or(false),
+        Ok(store) => store.node_exists(&node_id).unwrap_or(false),
         Err(_) => false,
     };
     if !registered {
-        let payload = json!({
-            "reason": "unregistered_node",
-            "node_id": req.node_id,
-            "operator_id": operator_id,
-        })
-        .to_string();
-        if let Ok(mut store) = svc.app.store.lock() {
-            let _ = store.append_clearance_audit_event(
-                "OperatorClearanceGrantRejected", &payload, now);
-        }
-        return (StatusCode::UNPROCESSABLE_ENTITY,
-                Json(json!({ "status": "rejected", "reason": "node_id is not a registered node" })))
-            .into_response();
+        audit_grant_rejection(&svc.app, "unregistered_node", &node_id, &operator_id, now);
+        return (StatusCode::UNPROCESSABLE_ENTITY, Json(json!({
+            "status": "rejected", "reason": "node_id is not a registered node"
+        }))).into_response();
     }
 
-    // 3. Record + sign — RECORD-ONLY. Delivery is Phase B; posture is untouched.
+    // Record + sign — RECORD-ONLY. Delivery is Phase B; posture is untouched.
     match svc.app.store.lock() {
-        Ok(mut store) => match store.save_clearance_grant_chained(&req.node_id, operator_id, now) {
+        Ok(mut store) => match store.save_clearance_grant_chained_with_auth(
+            &node_id, &operator_id, now, auth_method, fingerprint.as_deref(),
+        ) {
             Ok(_id) => (StatusCode::OK, Json(json!({
                 "status": "recorded",
                 "delivery": "pending-phase-b",
-                "node_id": req.node_id,
+                "node_id": node_id,
                 "operator_id": operator_id,
                 "granted_at_ms": now,
+                "auth_method": auth_method,
+                "operator_key_fingerprint": fingerprint,
                 "note": "grant recorded and signed; the vehicle is NOT released — delivery to the node ClearanceLoop is Phase B",
             }))).into_response(),
             Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
@@ -2929,6 +3151,10 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
         .route("/system/audit/rotate-signing-key", post(handle_audit_rotate_key))
         .route("/federation/controllers/register", post(register_federation_controller))
         .route("/attestation/identity/register", post(register_node_identity))
+        // #314 Phase 1 — operator registry. ADMIN-gated (separate power from the
+        // supervisor key); posture-exempt by the /console/ path prefix.
+        .route("/console/operators", post(register_operator))
+        .route("/console/operators/{operator_id}/revoke", post(revoke_operator))
         .route("/fabric/assets/register", post(handle_register_fabric_asset))
         .route("/fabric/assets", get(handle_list_fabric_assets))
         .route("/fabric/state", get(handle_fabric_state))
@@ -2978,6 +3204,9 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
         .route("/console/fleet", get(console_fleet))
         .route("/console/audit", get(console_audit))
         .route("/console/escalations", get(console_escalations))
+        // #314 Phase 1 — operator clearance-challenge (unauthenticated; the nonce
+        // alone grants nothing — only a valid signature over it does).
+        .route("/console/clearance-challenge", get(clearance_challenge))
         .route("/console/clearance-grants", post(console_clearance_grant));
 
     Router::new()
@@ -3927,6 +4156,7 @@ mod systemd_notify_tests {
 mod console_phase_a_tests {
     use super::{build_app, supervisor_key_ok};
 
+    use serde_json::json;
     use std::sync::Arc;
 
     use axum::body::{to_bytes, Body};
@@ -4122,5 +4352,208 @@ mod console_phase_a_tests {
             expected_pcr16_digest_hex: None,
         };
         app.persist_and_insert_node(node).expect("seed node");
+    }
+
+    // ===================================================================
+    // #314 Phase 1 — operator-proven identity. The operator-signed flow uses
+    // NO env (no admin / supervisor key), so it is fully exercisable here; the
+    // operator is seeded via the store directly (the admin route's gating is
+    // proved separately, since INV-13 forbids set_var in a multithread test).
+    // ===================================================================
+
+    use ed25519_dalek::{Signer, SigningKey};
+
+    /// A deterministic test operator keypair + its SPKI PEM (reuses the in-repo
+    /// RFC-8410 prefix convention from `attestation_nonce_handler_tests`).
+    fn operator_keypair(seed: u8) -> (SigningKey, String) {
+        use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
+        const ED25519_SPKI_PREFIX: [u8; 12] =
+            [0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00];
+        let sk = SigningKey::from_bytes(&[seed; 32]);
+        let mut der = ED25519_SPKI_PREFIX.to_vec();
+        der.extend_from_slice(sk.verifying_key().as_bytes());
+        let pem = format!(
+            "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----\n",
+            b64e.encode(&der)
+        );
+        (sk, pem)
+    }
+
+    fn sign_grant_b64(sk: &SigningKey, operator_id: &str, node_id: &str, nonce: &str) -> String {
+        use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
+        let payload = kirra_runtime_sdk::attestation::operator_grant_signing_payload(
+            operator_id, node_id, nonce,
+        );
+        b64e.encode(sk.sign(&payload).to_bytes())
+    }
+
+    fn register_op(svc: &Arc<ServiceState>, operator_id: &str, pem: &str) {
+        svc.app.store.lock().unwrap().register_operator(operator_id, pem, 1).unwrap();
+    }
+
+    fn parse_nonce(body: &str) -> String {
+        serde_json::from_str::<serde_json::Value>(body)
+            .unwrap()
+            .get("nonce")
+            .and_then(|x| x.as_str())
+            .expect("challenge body has a nonce")
+            .to_string()
+    }
+
+    async fn post_json(
+        svc: Arc<ServiceState>,
+        path: &str,
+        body: String,
+        supervisor_key: Option<&str>,
+    ) -> (StatusCode, String) {
+        let mut rb = Request::builder()
+            .method("POST")
+            .uri(path)
+            .header("content-type", "application/json");
+        if let Some(k) = supervisor_key {
+            rb = rb.header("x-kirra-supervisor-key", k);
+        }
+        let resp = build_app(svc).oneshot(rb.body(Body::from(body)).unwrap()).await.expect("router");
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+        (status, String::from_utf8_lossy(&bytes).to_string())
+    }
+
+    /// HAPPY PATH + the ADDITIVE PROOF: an operator-signed grant records with the
+    /// key fingerprint in the signed chain, and the EXISTING Phase-B
+    /// `take_pending_clearance_grant` consumes the new row shape unchanged.
+    #[tokio::test]
+    async fn operator_signed_grant_records_fingerprint_and_phase_b_consumes() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        let (sk, pem) = operator_keypair(7);
+        register_op(&svc, "alice", &pem);
+
+        let (cs, cb) = get(svc.clone(),
+            "/console/clearance-challenge?operator_id=alice&node_id=robot-01").await;
+        assert_eq!(cs, StatusCode::OK, "challenge issued; body={cb}");
+        let nonce = parse_nonce(&cb);
+
+        let sig = sign_grant_b64(&sk, "alice", "robot-01", &nonce);
+        let body = json!({"node_id":"robot-01","operator_id":"alice","nonce":nonce,"signature_b64":sig}).to_string();
+        let (gs, gb) = post_json(svc.clone(), "/console/clearance-grants", body, None).await;
+        assert_eq!(gs, StatusCode::OK, "operator-signed grant recorded; body={gb}");
+        assert!(gb.contains("operator-signed"), "auth_method in response");
+        let fp = kirra_runtime_sdk::attestation::operator_key_fingerprint(&pem).unwrap();
+        assert!(gb.contains(&fp), "response carries the key fingerprint");
+
+        let (_s, ab) = get(svc.clone(), "/console/audit?limit=50").await;
+        assert!(ab.contains("OperatorClearanceGrantIssued"));
+        assert!(ab.contains("operator-signed"), "chain event carries auth_method");
+        assert!(ab.contains(&fp), "chain event carries the fingerprint (non-repudiation)");
+
+        // THE ADDITIVE PROOF — Phase-B pickup is unchanged by the new columns.
+        let picked = svc.app.store.lock().unwrap()
+            .take_pending_clearance_grant("robot-01", 9_999_999_999_999).unwrap()
+            .expect("Phase-B consumes the operator-signed grant row");
+        assert_eq!(picked.operator_id, "alice");
+    }
+
+    /// VERIFY-THEN-CONSUME: a replayed nonce is rejected on the second use.
+    #[tokio::test]
+    async fn nonce_replay_is_rejected_and_audited() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        let (sk, pem) = operator_keypair(8);
+        register_op(&svc, "alice", &pem);
+        let (_c, cb) = get(svc.clone(),
+            "/console/clearance-challenge?operator_id=alice&node_id=robot-01").await;
+        let nonce = parse_nonce(&cb);
+        let sig = sign_grant_b64(&sk, "alice", "robot-01", &nonce);
+        let body = json!({"node_id":"robot-01","operator_id":"alice","nonce":nonce,"signature_b64":sig}).to_string();
+
+        let (s1, _) = post_json(svc.clone(), "/console/clearance-grants", body.clone(), None).await;
+        assert_eq!(s1, StatusCode::OK, "first use accepted");
+        let (s2, b2) = post_json(svc.clone(), "/console/clearance-grants", body, None).await;
+        assert_eq!(s2, StatusCode::UNAUTHORIZED, "replayed nonce rejected; body={b2}");
+        let (_s, ab) = get(svc.clone(), "/console/audit?limit=50").await;
+        assert!(ab.contains("nonce_replay_or_expired"), "the replay is audited");
+    }
+
+    /// BAD SIGNATURE (signed by the wrong key) → 401, audited. Verify happens
+    /// before the nonce is consumed.
+    #[tokio::test]
+    async fn bad_signature_is_rejected_and_audited() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        let (_sk, pem) = operator_keypair(9);
+        register_op(&svc, "alice", &pem);
+        let (_c, cb) = get(svc.clone(),
+            "/console/clearance-challenge?operator_id=alice&node_id=robot-01").await;
+        let nonce = parse_nonce(&cb);
+        let (wrong, _wpem) = operator_keypair(99);
+        let sig = sign_grant_b64(&wrong, "alice", "robot-01", &nonce);
+        let body = json!({"node_id":"robot-01","operator_id":"alice","nonce":nonce,"signature_b64":sig}).to_string();
+        let (s, b) = post_json(svc.clone(), "/console/clearance-grants", body, None).await;
+        assert_eq!(s, StatusCode::UNAUTHORIZED, "wrong-key signature rejected; body={b}");
+        let (_s, ab) = get(svc.clone(), "/console/audit?limit=50").await;
+        assert!(ab.contains("bad_signature"));
+    }
+
+    /// UNKNOWN operator → 403, audited (load operator fails before anything else).
+    #[tokio::test]
+    async fn unknown_operator_is_rejected_403_audited() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        let body = json!({"node_id":"robot-01","operator_id":"ghost","nonce":"00","signature_b64":"AAAA"}).to_string();
+        let (s, b) = post_json(svc.clone(), "/console/clearance-grants", body, None).await;
+        assert_eq!(s, StatusCode::FORBIDDEN, "unknown operator rejected; body={b}");
+        let (_s, ab) = get(svc.clone(), "/console/audit?limit=50").await;
+        assert!(ab.contains("unknown_operator"));
+    }
+
+    /// REVOKED operator → 403, audited.
+    #[tokio::test]
+    async fn revoked_operator_is_rejected_403_audited() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        let (sk, pem) = operator_keypair(11);
+        register_op(&svc, "alice", &pem);
+        svc.app.store.lock().unwrap().revoke_operator("alice", 2).unwrap();
+        let sig = sign_grant_b64(&sk, "alice", "robot-01", "00");
+        let body = json!({"node_id":"robot-01","operator_id":"alice","nonce":"00","signature_b64":sig}).to_string();
+        let (s, b) = post_json(svc.clone(), "/console/clearance-grants", body, None).await;
+        assert_eq!(s, StatusCode::FORBIDDEN, "revoked operator rejected; body={b}");
+        let (_s, ab) = get(svc.clone(), "/console/audit?limit=50").await;
+        assert!(ab.contains("revoked_operator"));
+    }
+
+    /// SEPARATE POWERS: operator registration is ADMIN-gated, NOT supervisor-gated.
+    /// A supervisor key alone (no admin token) cannot register an operator. (Env
+    /// unset → require_admin_token 503; with the env set it would be 401 — the
+    /// admin_token_ok decision is unit-tested elsewhere. Either way: never 2xx.)
+    #[tokio::test]
+    async fn supervisor_key_cannot_register_operators_admin_gated() {
+        let svc = build_state();
+        let (_sk, pem) = operator_keypair(12);
+        let body = json!({"operator_id":"alice","ed25519_pubkey_pem":pem}).to_string();
+        let (s, _b) = post_json(svc, "/console/operators", body, Some("a-supervisor-value")).await;
+        assert_eq!(s, StatusCode::SERVICE_UNAVAILABLE,
+            "operator registration is admin-gated — the supervisor key does not open it");
+    }
+
+    /// BREAK-GLASS is DISTINCTLY audited. The success path needs the supervisor env
+    /// (INV-13 forbids set_var here), so prove the distinct-audit property at the
+    /// store level: the auth_method "supervisor-break-glass" lands in the signed
+    /// chain, visibly different from "operator-signed".
+    #[test]
+    fn break_glass_auth_method_is_distinct_in_the_chain() {
+        let store = VerifierStore::new(":memory:").expect("store");
+        let app = AppState::new(store, VerifierOperationMode::Active);
+        {
+            let mut s = app.store.lock().unwrap();
+            s.save_clearance_grant_chained_with_auth(
+                "robot-01", "alice", 1_700_000_000_000, "supervisor-break-glass", None,
+            ).unwrap();
+        }
+        let page = app.store.lock().unwrap().load_audit_chain_page(50, 0, None).unwrap();
+        let blob = serde_json::to_string(&page.entries).unwrap();
+        assert!(blob.contains("supervisor-break-glass"),
+            "break-glass auth_method recorded distinctly in the signed chain");
     }
 }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -50,6 +50,18 @@ pub struct ChallengeEntry {
     pub expires_at_ms: u64,
 }
 
+/// Volatile operator clearance-challenge entry (#314 Phase 1). The human analogue
+/// of [`ChallengeEntry`]: a one-time nonce an operator must sign to prove key
+/// possession before a grant is recorded. The nonce is a HEX STRING (not a u64) so
+/// the in-browser WebCrypto flow never loses precision on a > 2^53 value. Same
+/// volatility discipline as `pending_challenges` (INVARIANT #5): never persisted,
+/// TTL-bounded, single-use.
+#[derive(Debug, Clone)]
+pub struct ClearanceChallengeEntry {
+    pub nonce_hex: String,
+    pub expires_at_ms: u64,
+}
+
 /// Flap-detection result for a node over the last 5 minutes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FlapStatus {
@@ -178,6 +190,10 @@ pub struct AppState {
     pub dependency_graph: DashMap<String, Vec<String>>,
     /// Volatile in-memory challenge map — nonces are never persisted to SQLite.
     pub pending_challenges: DashMap<String, ChallengeEntry>,
+    /// Volatile operator clearance-challenge map (#314 Phase 1) — keyed by
+    /// `"{operator_id}|{node_id}"`. Same volatility discipline as
+    /// `pending_challenges` (INVARIANT #5): never persisted, TTL-bounded, single-use.
+    pub pending_clearance_challenges: DashMap<String, ClearanceChallengeEntry>,
     /// Durable store for nodes and dependency graph (write-through, read on boot).
     pub store: Arc<Mutex<VerifierStore>>,
     /// Runtime-mutable operational mode.
@@ -260,6 +276,7 @@ impl AppState {
             nodes: DashMap::new(),
             dependency_graph: DashMap::new(),
             pending_challenges: DashMap::new(),
+            pending_clearance_challenges: DashMap::new(),
             store: Arc::new(Mutex::new(store)),
             mode_active: Arc::new(AtomicBool::new(mode == VerifierOperationMode::Active)),
             held_epoch: Arc::new(AtomicU64::new(0)),
@@ -472,6 +489,32 @@ impl AppState {
             nonce,
             expires_at_ms: now_ms + CHALLENGE_TTL_MS,
         });
+    }
+
+    /// Issue an operator clearance-challenge nonce, keyed by `(operator_id,
+    /// node_id)` (#314 Phase 1). Mirrors [`issue_challenge`](Self::issue_challenge):
+    /// prunes expired entries, per-key overwrite, TTL-bounded.
+    pub fn issue_clearance_challenge(&self, key: &str, nonce_hex: String, now_ms: u64) {
+        self.pending_clearance_challenges
+            .retain(|_, e| now_ms <= e.expires_at_ms);
+        self.pending_clearance_challenges.insert(
+            key.to_string(),
+            ClearanceChallengeEntry { nonce_hex, expires_at_ms: now_ms + CHALLENGE_TTL_MS },
+        );
+    }
+
+    /// Consume an operator clearance-challenge nonce — the VERIFY-THEN-CONSUME
+    /// half (the caller verifies the signature FIRST). Atomic `remove` so a
+    /// replay finds nothing. Returns false if absent, expired, or mismatched.
+    pub fn consume_clearance_challenge(&self, key: &str, nonce_hex: &str, now_ms: u64) -> bool {
+        let entry = match self.pending_clearance_challenges.remove(key) {
+            Some((_, e)) => e,
+            None => return false,
+        };
+        if now_ms > entry.expires_at_ms {
+            return false;
+        }
+        entry.nonce_hex == nonce_hex
     }
 }
 

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -82,6 +82,24 @@ pub struct PendingClearanceGrant {
     pub granted_at_ms: u64,
 }
 
+/// A registered operator (#314 Phase 1). `pubkey_pem` is the PUBLIC key only.
+#[derive(Debug, Clone)]
+pub struct OperatorRecord {
+    pub operator_id: String,
+    pub pubkey_pem: String,
+    pub registered_at_ms: u64,
+    /// `None` = active; `Some(ms)` = revoked at that time (cannot clear grants).
+    pub revoked_at_ms: Option<u64>,
+}
+
+impl OperatorRecord {
+    /// True iff the operator is registered and not revoked.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        self.revoked_at_ms.is_none()
+    }
+}
+
 /// The latest clearance grant's delivery state for a node (console read surface).
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ClearanceGrantState {
@@ -399,6 +417,12 @@ impl VerifierStore {
             "ALTER TABLE clearance_grants ADD COLUMN consumed_at_ms INTEGER",
             "ALTER TABLE clearance_grants ADD COLUMN outcome TEXT",
             "ALTER TABLE clearance_grants ADD COLUMN outcome_detail TEXT",
+            // #314 Phase 1 — operator-proven identity. ADDITIVE: how the grant was
+            // authorized ("operator-signed" / "supervisor-break-glass" /
+            // "unspecified") and WHICH operator key signed it (fingerprint). Phase-B
+            // `take_pending_clearance_grant` does not read these — delivery unchanged.
+            "ALTER TABLE clearance_grants ADD COLUMN auth_method TEXT",
+            "ALTER TABLE clearance_grants ADD COLUMN operator_key_fingerprint TEXT",
         ] {
             if let Err(e) = conn.execute(col_sql, []) {
                 if !e.to_string().contains("duplicate column name") {
@@ -406,6 +430,20 @@ impl VerifierStore {
                 }
             }
         }
+
+        // #314 Phase 1 — registered operators (per-operator Ed25519 identity).
+        // `pubkey_pem` is the operator's PUBLIC key only (no private material ever
+        // touches the server). `revoked_at_ms` NULL = active; a revoked operator
+        // can never clear a grant. Mirrors the `nodes` registry shape.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS operators (
+                operator_id       TEXT    PRIMARY KEY,
+                pubkey_pem        TEXT    NOT NULL,
+                registered_at_ms  INTEGER NOT NULL,
+                revoked_at_ms     INTEGER
+            )",
+            [],
+        )?;
 
         // AV subsystem metadata: confidence floors, telemetry timestamps, recovery streak.
         conn.execute(
@@ -1309,19 +1347,52 @@ impl VerifierStore {
         operator_id: &str,
         granted_at_ms: u64,
     ) -> Result<i64> {
+        // Backward-compatible: existing callers (Phase-B tests, the fleet relay,
+        // the demo seed) record with auth_method = "unspecified". The auth-aware
+        // path below is what the upgraded console route uses.
+        self.save_clearance_grant_chained_with_auth(
+            node_id, operator_id, granted_at_ms, "unspecified", None,
+        )
+    }
+
+    /// Record a clearance grant with its **authorization provenance** (#314 Phase
+    /// 1) — `auth_method` (`operator-signed` / `supervisor-break-glass` /
+    /// `unspecified`) and the signing operator's key `fingerprint`. Both are
+    /// written to the (additive) grant columns AND embedded in the
+    /// `OperatorClearanceGrantIssued` chain event — the non-repudiation payoff: the
+    /// signed ledger records WHO authorized the release and with WHICH key. The
+    /// `PENDING-NODE-TRANSPORT` row + the columns Phase-B reads are unchanged.
+    pub fn save_clearance_grant_chained_with_auth(
+        &mut self,
+        node_id: &str,
+        operator_id: &str,
+        granted_at_ms: u64,
+        auth_method: &str,
+        operator_key_fingerprint: Option<&str>,
+    ) -> Result<i64> {
         let payload = serde_json::json!({
             "node_id": node_id,
             "operator_id": operator_id,
             "granted_at_ms": granted_at_ms,
             "delivery": "PENDING-NODE-TRANSPORT",
+            "auth_method": auth_method,
+            "operator_key_fingerprint": operator_key_fingerprint,
         })
         .to_string();
         let tx = self.conn.transaction()?;
         tx.execute(
             "INSERT INTO clearance_grants
-             (node_id, operator_id, granted_at_ms, delivery, created_at_ms)
-             VALUES (?1, ?2, ?3, 'PENDING-NODE-TRANSPORT', ?4)",
-            params![node_id, operator_id, granted_at_ms as i64, granted_at_ms as i64],
+             (node_id, operator_id, granted_at_ms, delivery, created_at_ms,
+              auth_method, operator_key_fingerprint)
+             VALUES (?1, ?2, ?3, 'PENDING-NODE-TRANSPORT', ?4, ?5, ?6)",
+            params![
+                node_id,
+                operator_id,
+                granted_at_ms as i64,
+                granted_at_ms as i64,
+                auth_method,
+                operator_key_fingerprint,
+            ],
         )?;
         let id = tx.last_insert_rowid();
         crate::audit_chain::AuditChainLinker::append_audit_event_tx(
@@ -1333,6 +1404,60 @@ impl VerifierStore {
         )?;
         tx.commit()?;
         Ok(id)
+    }
+
+    // --- #314 Phase 1 — operator registry -----------------------------------
+
+    /// Register (or re-register / rotate) an operator's Ed25519 PUBLIC key.
+    /// Re-registration overwrites the key and CLEARS any prior revocation (a fresh
+    /// key for an operator is an active operator). Admin-gated at the route layer.
+    pub fn register_operator(
+        &mut self,
+        operator_id: &str,
+        pubkey_pem: &str,
+        now_ms: u64,
+    ) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO operators (operator_id, pubkey_pem, registered_at_ms, revoked_at_ms)
+             VALUES (?1, ?2, ?3, NULL)
+             ON CONFLICT(operator_id) DO UPDATE SET
+                 pubkey_pem = excluded.pubkey_pem,
+                 registered_at_ms = excluded.registered_at_ms,
+                 revoked_at_ms = NULL",
+            params![operator_id, pubkey_pem, now_ms as i64],
+        )?;
+        Ok(())
+    }
+
+    /// Revoke an operator (sets `revoked_at_ms`). Returns `true` if an ACTIVE
+    /// operator was revoked, `false` if absent or already revoked.
+    pub fn revoke_operator(&mut self, operator_id: &str, now_ms: u64) -> Result<bool> {
+        let n = self.conn.execute(
+            "UPDATE operators SET revoked_at_ms = ?2
+             WHERE operator_id = ?1 AND revoked_at_ms IS NULL",
+            params![operator_id, now_ms as i64],
+        )?;
+        Ok(n > 0)
+    }
+
+    /// Load an operator record (active or revoked), or `None` if unregistered.
+    pub fn load_operator(&self, operator_id: &str) -> Result<Option<OperatorRecord>> {
+        use rusqlite::OptionalExtension;
+        self.conn
+            .query_row(
+                "SELECT operator_id, pubkey_pem, registered_at_ms, revoked_at_ms
+                 FROM operators WHERE operator_id = ?1",
+                params![operator_id],
+                |row| {
+                    Ok(OperatorRecord {
+                        operator_id: row.get(0)?,
+                        pubkey_pem: row.get(1)?,
+                        registered_at_ms: row.get::<_, i64>(2)? as u64,
+                        revoked_at_ms: row.get::<_, Option<i64>>(3)?.map(|v| v as u64),
+                    })
+                },
+            )
+            .optional()
     }
 
     /// Append a signed, hash-chained console audit event with **no** other table

--- a/static/console.html
+++ b/static/console.html
@@ -53,8 +53,14 @@
   .row .sig-verified { color:var(--ok); } .row .sig-unsigned,.row .sig-unverified { color:var(--warn); }
   .row pre { margin:4px 0 0; color:var(--dim); white-space:pre-wrap; word-break:break-word; font-size:11px; }
   label { display:block; margin:8px 0 3px; color:var(--dim); font-size:12px; }
-  input { width:100%; background:var(--bg); border:1px solid var(--line); color:var(--ink);
+  input, textarea { width:100%; background:var(--bg); border:1px solid var(--line); color:var(--ink);
           border-radius:5px; padding:7px; font:inherit; }
+  textarea { resize:vertical; min-height:64px; }
+  details { margin-top:14px; border-top:1px dashed var(--line); padding-top:8px; }
+  summary { cursor:pointer; color:var(--warn); font-size:12px; }
+  .fp { color:var(--accent); }
+  .cli { background:var(--bg); border:1px solid var(--line); border-radius:5px; padding:8px;
+         font-size:11px; color:var(--dim); white-space:pre-wrap; word-break:break-word; }
   button { margin-top:12px; background:var(--accent); color:#fff; border:0; border-radius:5px;
            padding:8px 14px; font:inherit; cursor:pointer; }
   button:disabled { opacity:.5; cursor:default; }
@@ -89,17 +95,50 @@
   </section>
 
   <section>
-    <h2>Supervisor clearance grant <span class="badge">RECORD-ONLY · delivery = Phase B</span></h2>
-    <form id="grantform" autocomplete="off">
-      <label for="node_id">Node id (must be registered)</label>
-      <input id="node_id" name="node_id" required>
-      <label for="operator_id">Operator id</label>
-      <input id="operator_id" name="operator_id" required>
-      <label for="supkey">Supervisor key (held in memory for this session only — never stored)</label>
-      <input id="supkey" name="supkey" type="password" required>
-      <button type="submit" id="grantbtn">Record clearance grant</button>
-    </form>
-    <div class="result" id="grantresult"></div>
+    <h2>Clearance grant <span class="badge">RECORD-ONLY · delivery = Phase B</span></h2>
+
+    <!-- PRIMARY: operator-proven identity (#314). The operator signs the
+         challenge in-browser with their Ed25519 private key (WebCrypto). The
+         private key is held in memory ONLY — never localStorage, never sent. -->
+    <div id="opsigned">
+      <form id="grantform" autocomplete="off">
+        <label for="node_id">Node id (must be registered)</label>
+        <input id="node_id" name="node_id" required>
+        <label for="operator_id">Operator id (must be a registered operator)</label>
+        <input id="operator_id" name="operator_id" required>
+        <label for="opkey">Operator private key — PKCS#8 PEM (in memory for this session only — NEVER stored, NEVER sent; the page signs locally)</label>
+        <textarea id="opkey" rows="4" placeholder="-----BEGIN PRIVATE KEY-----&#10;...&#10;-----END PRIVATE KEY-----" required></textarea>
+        <button type="submit" id="grantbtn">Sign &amp; record clearance grant</button>
+      </form>
+      <div class="result" id="grantresult"></div>
+    </div>
+
+    <!-- FALLBACK: shown only when WebCrypto Ed25519 is unavailable. We do NOT
+         silently fall back to break-glass — we point to the documented CLI flow. -->
+    <div id="clifallback" style="display:none">
+      <p class="err">This browser cannot sign Ed25519 in-page (WebCrypto Ed25519 unavailable, or not a secure context).</p>
+      <p style="color:var(--dim);font-size:12px">Use the documented <b>CLI signing flow</b> in
+        <code>docs/CONSOLE_RUNBOOK.md</code> → “Operator onboarding”. Do NOT use break-glass for a routine grant.</p>
+    </div>
+
+    <!-- BREAK-GLASS: the named, distinctly-audited supervisor fallback (#255).
+         Present but secondary; deployments disable it by unsetting the env. -->
+    <details id="breakglass">
+      <summary>Break-glass · supervisor key (named fallback — audited distinctly as <code>supervisor-break-glass</code>)</summary>
+      <p style="color:var(--dim);font-size:11px;margin:6px 0">
+        Use ONLY when an operator key is lost/unavailable — a fleet locked out of recovery is its own safety failure.
+        Every break-glass grant is recorded distinctly in the signed chain.</p>
+      <form id="bgform" autocomplete="off">
+        <label for="bg_node_id">Node id</label>
+        <input id="bg_node_id" required>
+        <label for="bg_operator_id">Operator id</label>
+        <input id="bg_operator_id" required>
+        <label for="bg_supkey">Supervisor key (in memory only — never stored)</label>
+        <input id="bg_supkey" type="password" required>
+        <button type="submit" id="bgbtn">Break-glass record</button>
+      </form>
+      <div class="result" id="bgresult"></div>
+    </details>
   </section>
 
   <section>
@@ -233,39 +272,115 @@ async function poll(){
   } catch(e){ conn.textContent = "poll error: "+e.message; conn.classList.add("err"); }
 }
 
+// ---- #314 operator-proven identity (WebCrypto Ed25519, in-page signing) ----
+function pemToDer(pem){
+  const b64 = enc(pem).replace(/-----[^-]+-----/g, "").replace(/[^A-Za-z0-9+/=]/g, "");
+  const bin = atob(b64); const u = new Uint8Array(bin.length);
+  for(let i=0;i<bin.length;i++) u[i] = bin.charCodeAt(i);
+  return u;
+}
+function b64FromBytes(buf){
+  const u = new Uint8Array(buf); let s = "";
+  for(let i=0;i<u.length;i++) s += String.fromCharCode(u[i]);
+  return btoa(s);
+}
+// MUST byte-match Rust attestation::operator_grant_signing_payload:
+//   "KIRRA-OPERATOR-GRANT-v1" || for f in [operator_id,node_id,nonce]: u64_le(len(f)) || f
+function operatorGrantPayload(operatorId, nodeId, nonce){
+  const te = new TextEncoder();
+  const domain = te.encode("KIRRA-OPERATOR-GRANT-v1");
+  const fields = [operatorId, nodeId, nonce].map(s => te.encode(s));
+  let total = domain.length; for(const f of fields) total += 8 + f.length;
+  const buf = new Uint8Array(total); let o = 0;
+  buf.set(domain, o); o += domain.length;
+  for(const f of fields){
+    new DataView(buf.buffer, o, 8).setBigUint64(0, BigInt(f.length), true); o += 8;
+    buf.set(f, o); o += f.length;
+  }
+  return buf;
+}
+async function ed25519Supported(){
+  try {
+    if(!(window.crypto && crypto.subtle)) return false;
+    return !!(await crypto.subtle.generateKey({name:"Ed25519"}, false, ["sign","verify"]));
+  } catch(_){ return false; }
+}
+
+function showRecorded(res, body){
+  res.className = "result recorded";
+  res.innerHTML = '<span class="pend">GRANT RECORDED — DELIVERY PENDING</span><br>'+
+    'node <b>'+esc(body.node_id)+'</b> · operator <b>'+esc(body.operator_id)+'</b><br>'+
+    'auth: <b>'+esc(body.auth_method||"?")+'</b>'+
+    (body.operator_key_fingerprint ? (' · key <span class="fp">'+esc(body.operator_key_fingerprint)+'</span>') : '')+'<br>'+
+    '<span style="color:var(--dim)">'+esc(body.note||"")+'</span>';
+  lastGrant = { node_id: body.node_id }; // follow its delivery lifecycle on poll
+  poll();
+}
+function showRejected(res, status, reason){
+  res.className = "result rejected";
+  res.innerHTML = 'REJECTED ('+esc(status)+'): '+esc(reason || "request refused");
+}
+
+// PRIMARY: operator-signed grant. Fetch challenge → sign locally → submit.
 document.getElementById("grantform").addEventListener("submit", async (ev) => {
   ev.preventDefault();
   const btn = document.getElementById("grantbtn");
   const res = document.getElementById("grantresult");
+  const opkeyEl = document.getElementById("opkey");
   const node_id = document.getElementById("node_id").value.trim();
   const operator_id = document.getElementById("operator_id").value.trim();
-  const supkey = document.getElementById("supkey").value; // in-memory only; never stored
+  const pem = opkeyEl.value; // memory only; never stored, never sent
+  btn.disabled = true; res.className = "result"; res.style.display = "none";
+  try {
+    let key;
+    try { key = await crypto.subtle.importKey("pkcs8", pemToDer(pem), {name:"Ed25519"}, false, ["sign"]); }
+    catch(_){ showRejected(res, "key", "private key is not a valid PKCS#8 Ed25519 PEM"); return; }
+    const cr = await fetch("/console/clearance-challenge?operator_id="+encodeURIComponent(operator_id)+
+                           "&node_id="+encodeURIComponent(node_id), { headers:{accept:"application/json"} });
+    const cbody = await cr.json().catch(() => ({}));
+    if(!cr.ok){ showRejected(res, cr.status, cbody.error || "could not get a challenge (is the operator registered?)"); return; }
+    const sigBuf = await crypto.subtle.sign({name:"Ed25519"}, key,
+                       operatorGrantPayload(operator_id, node_id, cbody.nonce));
+    const r = await fetch("/console/clearance-grants", {
+      method:"POST", headers:{"content-type":"application/json"},
+      body: JSON.stringify({ node_id, operator_id, nonce: cbody.nonce, signature_b64: b64FromBytes(sigBuf) }),
+    });
+    const body = await r.json().catch(() => ({}));
+    if(r.ok && body.status === "recorded") showRecorded(res, body);
+    else showRejected(res, r.status, body.reason);
+  } catch(e){ showRejected(res, "err", e.message); }
+  finally { opkeyEl.value = ""; btn.disabled = false; } // drop the key from the field
+});
+
+// FALLBACK: break-glass via the supervisor key (named, audited distinctly).
+document.getElementById("bgform").addEventListener("submit", async (ev) => {
+  ev.preventDefault();
+  const btn = document.getElementById("bgbtn");
+  const res = document.getElementById("bgresult");
+  const supEl = document.getElementById("bg_supkey");
+  const node_id = document.getElementById("bg_node_id").value.trim();
+  const operator_id = document.getElementById("bg_operator_id").value.trim();
+  const supkey = supEl.value; // in-memory only; never stored
   btn.disabled = true; res.className = "result"; res.style.display = "none";
   try {
     const r = await fetch("/console/clearance-grants", {
-      method: "POST",
-      headers: { "content-type":"application/json", "x-kirra-supervisor-key": supkey },
+      method:"POST",
+      headers:{ "content-type":"application/json", "x-kirra-supervisor-key": supkey },
       body: JSON.stringify({ node_id, operator_id }),
     });
     const body = await r.json().catch(() => ({}));
-    if(r.ok && body.status === "recorded"){
-      res.className = "result recorded";
-      res.innerHTML = '<span class="pend">GRANT RECORDED — DELIVERY PENDING</span><br>'+
-        'node <b>'+esc(body.node_id)+'</b> · operator <b>'+esc(body.operator_id)+'</b> · '+
-        'granted_at '+esc(body.granted_at_ms)+'<br>'+
-        '<span style="color:var(--dim)">'+esc(body.note||"")+'</span>';
-      lastGrant = { node_id: body.node_id }; // follow its delivery lifecycle on poll
-      document.getElementById("supkey").value = ""; // drop the key from the field
-      poll();
-    } else {
-      res.className = "result rejected";
-      res.innerHTML = 'REJECTED ('+r.status+'): '+esc(body.reason || "request refused");
-    }
-  } catch(e){
-    res.className = "result rejected"; res.innerHTML = "REJECTED: "+esc(e.message);
-  } finally {
-    document.getElementById("supkey").value = ""; // never retain the key
-    btn.disabled = false;
+    if(r.ok && body.status === "recorded") showRecorded(res, body);
+    else showRejected(res, r.status, body.reason);
+  } catch(e){ showRejected(res, "err", e.message); }
+  finally { supEl.value = ""; btn.disabled = false; } // never retain the key
+});
+
+// Feature-detect WebCrypto Ed25519. If unavailable, hide the in-page signing form
+// and surface the documented CLI flow — NEVER a silent break-glass fallback.
+ed25519Supported().then(ok => {
+  if(!ok){
+    document.getElementById("opsigned").style.display = "none";
+    document.getElementById("clifallback").style.display = "block";
   }
 });
 


### PR DESCRIPTION
**Phase 1 of #314** — per-operator **cryptographic** identity (the scale half is Phase 2; see below). The **attestation pattern applied to humans**: registered Ed25519 operator keys, challenge-signed grant requests, verify-then-consume nonces — so a clearance grant becomes **non-repudiable chain evidence** (the signed ledger records *who* authorized the release and with *which key*) instead of a self-reported string. Talisman `997fb7ae…` byte-identical (first + last).

## Reuse, not a parallel mechanism (the STEP-0 discipline)

- The operator challenge **mirrors the node-attestation nonce machinery exactly**: `verifier.rs` gains a sibling **volatile** `DashMap` (`pending_clearance_challenges`) + `issue_clearance_challenge`/`consume_clearance_challenge` (INV-5: never persisted, TTL-bounded, single-use; verify-then-consume via atomic `remove`).
- `attestation.rs` gains **additive** helpers reusing the existing ed25519 surface: `parse_ed25519_public_pem` made `pub`; `operator_grant_signing_payload` (the same domain-separated, length-prefixed canonicalization style as `attestation_signing_payload`); `verify_ed25519_pem_signature`; `operator_key_fingerprint` (via the `audit_chain::verifying_key_id` convention). **No new deps.**

## What landed

**`verifier_store.rs`** — `operators` table (id PK, pubkey PEM, registered_at, revoked_at nullable) + `register_operator`/`revoke_operator`/`load_operator`. `clearance_grants` gains `auth_method` + `operator_key_fingerprint` as **additive** columns (the ADD-COLUMN migration convention). `save_clearance_grant_chained` **keeps its 3-arg signature** (delegates, `auth_method="unspecified"`) so every existing caller is unbroken; `save_clearance_grant_chained_with_auth` writes the provenance and embeds it in the `OperatorClearanceGrantIssued` chain event. **Phase-B `take_pending` reads the same columns — delivery UNCHANGED.**

**Service routes:**
- `POST /console/operators` (+ `/{id}/revoke`) — **admin-token-gated** (the node-registration precedent; a **separate power** from the supervisor key).
- `GET /console/clearance-challenge` — issue a nonce (the attestation issuance pattern; a hex string so the in-browser flow keeps precision).
- `POST /console/clearance-grants` **upgraded.** Operator-signed path mirrors `verify_attestation`'s order: **load operator** (unknown/revoked → 403, audited) → **VERIFY signature** → **CONSUME nonce** (replay → 401, audited) → well-formedness → record `auth_method="operator-signed"` + fingerprint in the signed chain.

**The break-glass decision (named):** the shared supervisor key (#255) **remains** as an explicitly-named `auth_method="supervisor-break-glass"` path — audited distinctly and loudly — **because a fleet locked out of recovery by a lost operator key is its own safety failure.** Deployments disable it by unsetting `KIRRA_SUPERVISOR_RESET_KEY`. The console presents operator-signed as primary.

**`console.html`** — **WebCrypto Ed25519 in-browser signing** as the primary flow (operator pastes their PKCS#8 private key, **memory only** — the `localStorage` ban stands; the page fetches the challenge, signs locally, submits). **Feature-detect:** no WebCrypto Ed25519 → show the documented **CLI alternative**, not a silent break-glass fallback. Break-glass is a collapsed secondary panel. Grant cards show the auth method + key fingerprint.

**Runbook** — operator onboarding (keygen, admin registration, the browser + CLI signing flows) + the break-glass policy paragraph.

## Tests (7 new — all env-free via store-seeded operators, since INV-13 forbids `set_var`)

- operator-signed **happy path** records the fingerprint in the chain **and the EXISTING Phase-B `take_pending` consumes the new row** (the additive proof);
- **nonce replay rejected** (the verify-then-consume proof);
- **bad signature → 401** audited; **unknown → 403**; **revoked → 403**;
- **supervisor key CANNOT register operators** (admin-gated — separate powers);
- break-glass `auth_method` lands distinctly in the chain.

`cargo test` green: SDK **611 lib + 45 bin**; parko-kirra **Phase-B unbroken** (the 3-arg path still works). Clippy clean. **No parko changes; no new deps;** talisman byte-identical.

## The Phase 1 / Phase 2 split

**Phase 1 (this PR) = cryptographic identity.** **Phase 2 = scale:** `load_nodes` pagination, fleet rollups, console virtualization for thousands of nodes, per-operator identity at fleet scale — **plus the Zenoh per-controller key registry from #317** (the fleet transport verifies against a supplied key; the keyring that maps *which key verifies which source* is the multi-tenant Phase-2 work).

References #314, #317 (the keyring note), the attestation precedent (`verify_attestation` / `src/attestation.rs`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_