### PR TITLE
fix: contact sticky-until-read (#320) + is_active grant gate (#323)

### DIFF
--- a/parko/crates/parko-ros2/src/clearance_gate.rs
+++ b/parko/crates/parko-ros2/src/clearance_gate.rs
@@ -57,6 +57,7 @@
 // it is not what delivery operates on. The node owns the bare loop; recording the
 // detection edges to the signed chain is a separate concern tracked with #309.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use parko_core::backend::InferenceBackend;
@@ -88,6 +89,39 @@ pub struct ImpactInputs {
     /// The latest contact-sensor reading (`false` when no contact topic is
     /// configured — a missing sensor reads as "no contact", reduced coverage).
     pub contact: bool,
+}
+
+/// Sticky-until-read contact flag (#320). Contact is a definitive SG6 collision
+/// trigger and a boolean EDGE — the most likely signal to be transient. The
+/// subscriber writes via [`assert`](Self::assert) (OR in any `true`; a later
+/// `false` is a no-op), and the tick reads via [`drain`](Self::drain) (consume the
+/// sticky `true` and reset). So a contact pulse that asserts and de-asserts between
+/// two 50 ms ticks is **not lost** (the bug was a plain `store`/`load`, which a
+/// `false` write would overwrite away), and one contact event latches exactly once
+/// rather than every subsequent tick. Lives here (the default-lane tick harness,
+/// with [`ImpactInputs`]) so the semantics are CI-tested without ROS; `node.rs`
+/// (fully `ros2`-gated) only wires the subscription to it.
+#[derive(Debug, Default)]
+pub struct ContactCell {
+    fired: AtomicBool,
+}
+
+impl ContactCell {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Write side: OR in the latest reading — sticky on any `true`.
+    pub fn assert(&self, value: bool) {
+        self.fired.fetch_or(value, Ordering::Release);
+    }
+
+    /// Read side: drain — return whether contact fired since the last drain, and
+    /// reset the flag atomically.
+    pub fn drain(&self) -> bool {
+        self.fired.swap(false, Ordering::Acquire)
+    }
 }
 
 /// Convention-free deceleration proxy: the Euclidean magnitude of the IMU
@@ -333,6 +367,28 @@ where
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    // ---- #320: contact ContactCell sticky-until-read --------------------
+
+    /// A contact pulse that asserts then de-asserts BEFORE the tick reads it is
+    /// NOT lost — the old `store`/`load` would have seen the trailing `false`.
+    #[test]
+    fn contact_pulse_between_ticks_is_not_lost() {
+        let cell = ContactCell::new();
+        cell.assert(true); // the pulse
+        cell.assert(false); // de-assert before the tick reads
+        assert!(cell.drain(), "a sub-tick contact pulse must survive to the next tick read");
+    }
+
+    /// One contact event latches exactly ONCE — after the tick drains a `true`,
+    /// the next tick sees `false` (no double-latch every subsequent tick).
+    #[test]
+    fn contact_resets_after_tick_read() {
+        let cell = ContactCell::new();
+        cell.assert(true);
+        assert!(cell.drain(), "first read sees the contact");
+        assert!(!cell.drain(), "second read is reset — one event latches once");
+    }
 
     use parko_core::backend::{BackendDescriptor, TensorBatch};
     use parko_core::backends::mock::MockBackend;

--- a/parko/crates/parko-ros2/src/node.rs
+++ b/parko/crates/parko-ros2/src/node.rs
@@ -20,7 +20,6 @@
 //     next-milestone deliverable. For M2 the node accepts a posture
 //     parameter (CLI / env) and defaults to `Nominal`.
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 
 use parko_core::backend::InferenceBackend;
@@ -28,7 +27,9 @@ use parko_core::safety::SafetyPosture;
 use parko_core::scheduler::InferenceLoop;
 use tokio::sync::Mutex;
 
-use crate::clearance_gate::{run_pipeline_tick_with_clearance, ImpactInputs, NodeClearance};
+use crate::clearance_gate::{
+    run_pipeline_tick_with_clearance, ContactCell, ImpactInputs, NodeClearance,
+};
 use crate::command_mapping::OutgoingTwist;
 use crate::config::ParkoNodeConfig;
 use crate::imu_shim::imu_msg_to_sample;
@@ -93,14 +94,17 @@ where
     // --- SG6 impact-detection sources (#309) --------------------------
     //
     // Optional IMU (decel) + contact subscriptions feed the per-tick
-    // `ImpactInputs`. Each runs a background drain task that writes the
-    // LATEST reading into a shared cell; the tick reads them. A missing
-    // source is REDUCED detection coverage, logged loudly — never a
-    // fabricated reading (absent IMU → no decel; absent contact → `false`).
-    // Detection only matters when the clearance gate is active.
+    // `ImpactInputs`. Each runs a background drain task; the IMU task writes the
+    // LATEST sample (a spike present at read time survives), the contact task is
+    // STICKY-UNTIL-READ (#320) so a sub-tick pulse is not lost. A missing source
+    // is REDUCED detection coverage, logged loudly — never a fabricated reading
+    // (absent IMU → no decel; absent contact → `false`). Detection only matters
+    // when the clearance gate is active.
     let detection_enabled = clearance.is_some();
     let latest_imu: Arc<StdMutex<Option<ImuSample>>> = Arc::new(StdMutex::new(None));
-    let contact_state: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+    // Contact is sticky-until-read so a sub-tick pulse is not lost — see
+    // [`ContactCell`] (#320), the CI-tested semantics this transport just wires.
+    let contact_state: Arc<ContactCell> = Arc::new(ContactCell::new());
 
     if detection_enabled {
         match &config.imu_topic {
@@ -136,7 +140,7 @@ where
                     use futures::StreamExt;
                     let mut s = contact_stream;
                     while let Some(msg) = s.next().await {
-                        cell.store(msg.data, Ordering::Relaxed);
+                        cell.assert(msg.data); // sticky-until-read (#320)
                     }
                     tracing::warn!("parko-ros2: contact stream closed — contact detection now inactive");
                 });
@@ -194,7 +198,7 @@ where
             // Absent sources read as their no-signal defaults (no fabrication).
             let impact_inputs = ImpactInputs {
                 imu: drain_imu.lock().ok().and_then(|g| *g),
-                contact: drain_contact.load(Ordering::Relaxed),
+                contact: drain_contact.drain(), // sticky-until-read drain (#320)
             };
 
             let cleared = run_pipeline_tick_with_clearance(

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -2993,6 +2993,14 @@ async fn console_clearance_grant(
     headers: HeaderMap,
     Json(req): Json<ClearanceGrantRequest>,
 ) -> impl IntoResponse {
+    // HA split-brain guard (#323): recording a grant is a store MUTATION. The
+    // `/console` posture-exemption keeps this reachable during LockedOut, but that
+    // is about POSTURE — it does NOT justify a passive-standby instance writing
+    // grants and diverging from the primary. Fail-closed like every other mutation.
+    if !svc.app.is_active() {
+        return (StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({ "error": "instance is in passive standby mode" }))).into_response();
+    }
     let now = now_ms();
     let operator_id = req.operator_id.trim().to_string();
     let node_id = req.node_id.trim().to_string();
@@ -4555,5 +4563,21 @@ mod console_phase_a_tests {
         let blob = serde_json::to_string(&page.entries).unwrap();
         assert!(blob.contains("supervisor-break-glass"),
             "break-glass auth_method recorded distinctly in the signed chain");
+    }
+
+    /// #323 — a passive-standby instance must REJECT a clearance-grant write (the
+    /// HA split-brain guard), mirroring every other mutation handler. The
+    /// `/console` posture-exemption keeps it reachable, but is_active() fail-closes.
+    #[tokio::test]
+    async fn standby_instance_rejects_clearance_grant() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        // Demote this instance to passive standby.
+        svc.app.mode_active.store(false, std::sync::atomic::Ordering::SeqCst);
+        // Any grant shape — the is_active guard fires FIRST, before auth.
+        let body = json!({"node_id":"robot-01","operator_id":"alice","nonce":"00","signature_b64":"AAAA"}).to_string();
+        let (s, _b) = post_json(svc, "/console/clearance-grants", body, None).await;
+        assert_eq!(s, StatusCode::SERVICE_UNAVAILABLE,
+            "a passive-standby instance must not accept grant writes (split-brain guard)");
     }
 }


### PR DESCRIPTION
Two contained fixes from the code-review register **#319**. No design decisions, no new deps, no `parko-core` changes. Talisman `997fb7ae…` byte-identical (first + last).

## H1 — contact sensor sticky-until-read (#320)

The contact cell was a plain `AtomicBool` written with `store(msg.data)` and read with `load()`. A contact closure that asserts **and de-asserts between two 50 ms ticks** was silently overwritten away — the trailing `false` write clobbered the pulse. Contact is a **definitive** SG6 collision trigger; the latch is sticky but evidence delivery into it was not.

**Fix:** sticky-until-read — `fetch_or(value)` on write (any `true` latches; a later `false` is a no-op) + `swap(false)` on read (drain, so one event latches exactly once, not every subsequent tick).

**Grounded deviation from "two files":** `node.rs` is **entirely** `#[cfg(feature = "ros2")]` (gated in `lib.rs`), so it can't host a no-ROS test and an inline atomic there would be untested. The semantics therefore live in a small **`ContactCell`** type in `clearance_gate.rs` — the default-lane tick harness, alongside `ImpactInputs` — which `node.rs` wires the subscription to (`assert`/`drain`, 2 call sites + the import). This makes the fix **CI-tested** rather than correct-by-reading; the review's meta-point was that copies drift, so a tested type *is* the fix.

## H4 — `console_clearance_grant` is_active() gate (#323)

The handler performs a store mutation but never checked `is_active()`, so a **passive-standby** instance accepted grant writes and diverged from the primary (split-brain). Every other mutation handler checks this first.

**Fix:** the canonical `is_active` guard (copied verbatim from the node-register handler) as the first line — fail-closed 503 on standby. Distinct from the `/console` posture-exemption (that's posture; this is HA mode).

## Tests
- `contact_pulse_between_ticks_is_not_lost`, `contact_resets_after_tick_read` (clearance_gate, no ROS).
- `standby_instance_rejects_clearance_grant` (service — demotes via `mode_active`, asserts 503).

## Verify
parko-ros2 **155** (+2), SDK bin **46** (+1), SDK lib **611**, parko-kirra Phase-B **8** (delivery unaffected); **clippy clean**; talisman byte-identical. Diff = `node.rs` + `clearance_gate.rs` (the `ContactCell` home, per above) + the service handler/test.

Closes #320. Closes #323. References #319.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_