### PR TITLE
fix: decel deviation convention + M-of-N confirmation window + courier threshold (#321/H2+A1)

### DIFF
--- a/docs/CONTRACT_PROFILES.md
+++ b/docs/CONTRACT_PROFILES.md
@@ -62,16 +62,30 @@ Units: speed/cap m/s; accel/brake/lat m/s²; steering deg; rate deg/s; distances
 | `*.lat_accel` | 1.5 | 2.5 | 3.5 | VALIDATION-PENDING |
 | `*.wheelbase` | 0.5 | 1.9 | 2.8 | VALIDATION-PENDING |
 | `*.footprint` (w×l, overhangs) | 0.6 × 0.9 (0.2/0.2) | 1.1 × 2.9 (0.5/0.5) | 1.85 × 4.8 (0.9/1.1) | VALIDATION-PENDING |
-| `*.impact_spike` (SG6, parko) | **8.0** | **18.0** | 30.0 (`ImpactCfg::default`) | VALIDATION-PENDING / INHERITED-FROZEN |
+| `*.impact_spike` (SG6, parko; **deviation** `\|‖a‖−G\|`, #321) | **2.5** | **8.0** | **22.0** | VALIDATION-PENDING |
+| `*.impact_confirm` (M / N consecutive, #321) | **2 / 3** | **2 / 3** | **1 / 1** | VALIDATION-PENDING |
+| **convention** (SG6 decel, #321 / ADL-013) | `\|‖a‖ − G\|`, `G = 9.80665 m/s²` (ISO 80000-3); confirm = M consecutive of last N | same | same | DECIDED (residual: orientation-corrected projection, named future) |
 
 **MRC fallback** (degraded posture) is a stricter sibling per class: every limit
 ≤ that class's Nominal limit, `follow` ≥ Nominal (the conservative direction), and
 the **footprint identical** (the vehicle does not shrink in degraded posture).
 These relations are asserted as structural invariants (see the validation gate).
 
+> **#321 / ADL-013 — `impact_spike` is now a gravity-DEVIATION threshold, not a raw
+> norm.** The old courier `8.0` was a **raw-norm** number BELOW the ~9.81 m/s² gravity
+> floor — a static, level courier read `‖a‖ ≈ 9.81 > 8.0` and **latched on gravity
+> alone**. The convention is now `\|‖a‖ − G\|` (≈ 0 at rest), debounced by an
+> **M-consecutive-of-N** window (a single-tick jolt does not latch; `M=1/N=1` =
+> single-tick / frozen behavior). Robotaxi moves off the raw-norm `30.0` default to a
+> `22.0` deviation (M=1/N=1 — a highway crash is unambiguous in one tick; the FTTI
+> permits no confirmation delay). `ImpactCfg::default()` keeps `30.0` (M=1/N=1) for
+> zero regression in the default path. Residual: the deviation under-represents a
+> purely horizontal impulse (vector combination with gravity); orientation-corrected
+> projection is the named future improvement, gated on a reliable quaternion.
+
 ### Ordering sanity (asserted)
 `courier.effective_cap (2.5) < delivery-av (11.0) < robotaxi (35.0)` and
-`courier.impact_spike (8.0) < delivery-av (18.0) < robotaxi (30.0)`.
+`courier.impact_spike (2.5) < delivery-av (8.0) < robotaxi (22.0)` (deviation units).
 
 ---
 
@@ -95,11 +109,14 @@ Every courier bound is shaped by that proximity:
   2.5 m/s plus the robot's short reaction).
 - **footprint** (0.6 × 0.9 m, 0.5 m wheelbase) — a small sidewalk robot; tight
   envelopes for pedestrian-space maneuvering. All dimensions strictly positive.
-- **`impact_spike` = 8.0 m/s² (parko / SG6)** — a sidewalk collision at walking pace
-  produces a **small** decel signature, far below a road crash, so the trigger is
-  more sensitive — but above ordinary curb/bump jolts. **This value genuinely needs
-  bench characterization of low-speed collision decel signatures**; it is a flagged
-  placeholder, not a guessed certified number.
+- **`impact_spike` = 2.5 m/s² DEVIATION, confirm 2-of-3 (parko / SG6, #321)** — a
+  sidewalk collision at walking pace produces a **small** decel deviation, far below a
+  road crash, so the trigger is more sensitive — but the **gravity-deviation
+  convention** (`\|‖a‖ − G\|`, ≈ 0 at rest) means it is no longer below the gravity
+  floor (the old `8.0` raw-norm was, and a static courier latched on gravity), and the
+  **2-of-3 consecutive** window debounces the curb/bump jolts a courier hits often.
+  **Still genuinely needs bench characterization of low-speed collision decel
+  signatures**; a flagged placeholder, not a guessed certified number. See ADL-013.
 
 ---
 

--- a/parko/crates/parko-core/src/impact.rs
+++ b/parko/crates/parko-core/src/impact.rs
@@ -34,18 +34,58 @@ pub struct ImpactEvidence {
 /// Fusion config. `spike_threshold_mps2` is a PARAMETER with a conservative
 /// **VALIDATION-PENDING** default — a track-test / SOTIF-derived value, NOT a
 /// certified constant (the same honesty as #98's water thresholds).
+///
+/// Since #321 (ADL-013) the IMU term is a **gravity-DEVIATION** threshold
+/// (`|‖a‖ − G|`), not a raw norm — so a static vehicle reads ≈ 0 and no class
+/// false-latches at rest. The decel detection is also debounced by an M-of-N
+/// **consecutive** confirmation window (`confirmation_m` / `confirmation_n`); the
+/// `M=1, N=1` default is the single-tick frozen behavior (zero regression).
 #[derive(Debug, Clone, Copy)]
 pub struct ImpactCfg {
-    /// IMU deceleration magnitude (m/s²) above which a *finite* spike is read as
-    /// a collision-grade impact.
+    /// IMU deceleration **deviation** (m/s², `|‖a‖ − G|`) above which a *finite*
+    /// observation is a collision-grade impact tick (#321 / ADL-013).
     pub spike_threshold_mps2: f64,
+    /// Confirmation window: a decel detection is confirmed only on a run of `≥ M`
+    /// CONSECUTIVE above-threshold ticks (a debounce against single-tick jolts —
+    /// NOT an M-of-N vote). `1` = single-tick (frozen behavior).
+    pub confirmation_m: u8,
+    /// Window size: the last `N` observations the confirmation run is sought in.
+    /// `N >= M`. `1` = single-tick.
+    pub confirmation_n: u8,
 }
 
 impl Default for ImpactCfg {
     fn default() -> Self {
         // VALIDATION-PENDING placeholder — a hard, collision-grade deceleration.
-        // NOT a certified value.
-        Self { spike_threshold_mps2: 30.0 }
+        // NOT a certified value. Threshold left at 30.0 across the #321 convention
+        // change so the default path has ZERO regression; M=1/N=1 = single-tick.
+        Self { spike_threshold_mps2: 30.0, confirmation_m: 1, confirmation_n: 1 }
+    }
+}
+
+impl ImpactCfg {
+    /// Config-load validation (#321 / ADL-013 §4). Fail-closed on a nonsensical
+    /// config: a deviation threshold `≤ 1.0` would trip on sensor noise; `M < 1`
+    /// can never confirm; `N < M` can never hold a run of `M`.
+    pub fn validate(&self) -> Result<(), String> {
+        // Fail-closed on any non-sane value: NaN/Inf (never a usable threshold) or
+        // <= 1.0 (would trip on sensor noise).
+        if !self.spike_threshold_mps2.is_finite() || self.spike_threshold_mps2 <= 1.0 {
+            return Err(format!(
+                "spike_threshold_mps2 must be a finite value > 1.0 (deviation units), got {}",
+                self.spike_threshold_mps2
+            ));
+        }
+        if self.confirmation_m < 1 {
+            return Err("confirmation_m must be >= 1".to_string());
+        }
+        if self.confirmation_n < self.confirmation_m {
+            return Err(format!(
+                "confirmation_n ({}) must be >= confirmation_m ({})",
+                self.confirmation_n, self.confirmation_m
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -81,21 +121,43 @@ pub enum VehicleClass {
 /// `docs/CONTRACT_PROFILES.md` (param `*.impact_spike`).
 #[must_use]
 pub fn impact_cfg_for_class(class: VehicleClass) -> ImpactCfg {
-    match class {
-        // Robotaxi = the frozen default (road-speed collision-grade decel, 30 m/s²).
-        VehicleClass::Robotaxi => ImpactCfg::default(),
-        // VALIDATION-PENDING: a road-pod collision at ~11 m/s decelerates less
-        // violently than a full-speed crash; a mid threshold pending bench data.
-        // (CONTRACT_PROFILES.md delivery-av.impact_spike)
-        VehicleClass::DeliveryAv => ImpactCfg { spike_threshold_mps2: 18.0 },
-        // VALIDATION-PENDING: a sidewalk collision at walking pace produces a SMALL
-        // decel signature — far below the road threshold — so the trigger must be
-        // more sensitive, but ABOVE ordinary curb/bump jolts. This value genuinely
-        // needs bench characterization of low-speed collision decel signatures; it
-        // is a flagged placeholder, NOT a guessed certified number.
-        // (CONTRACT_PROFILES.md courier.impact_spike)
-        VehicleClass::Courier => ImpactCfg { spike_threshold_mps2: 8.0 },
-    }
+    // All thresholds are DEVIATION (`|‖a‖ − G|`) units since #321 / ADL-013, and
+    // all are VALIDATION-PENDING. (CONTRACT_PROFILES.md `*.impact_spike` is the
+    // normative table; both this and the SDK gateway cite it.)
+    let cfg = match class {
+        // VALIDATION-PENDING: full-speed collision-grade decel (~30 m/s² raw-norm
+        // ≈ 20–22 deviation once combined with gravity). M=1/N=1 — a highway crash
+        // is unambiguous in one tick and the FTTI is tight (no confirmation delay).
+        // (NOTE: no longer == ImpactCfg::default(); the convention change moves the
+        // robotaxi number off the raw-norm 30.) (CONTRACT_PROFILES.md robotaxi.impact_spike)
+        VehicleClass::Robotaxi => ImpactCfg {
+            spike_threshold_mps2: 22.0,
+            confirmation_m: 1,
+            confirmation_n: 1,
+        },
+        // VALIDATION-PENDING: a road-pod collision at ~11 m/s decelerates harder
+        // than a sidewalk hit, less than a full crash; mid deviation, debounced
+        // 2-of-3 against road bumps. (CONTRACT_PROFILES.md delivery-av.impact_spike)
+        VehicleClass::DeliveryAv => ImpactCfg {
+            spike_threshold_mps2: 8.0,
+            confirmation_m: 2,
+            confirmation_n: 3,
+        },
+        // VALIDATION-PENDING: a sidewalk collision at walking pace (~1.5–3 m/s) is a
+        // SMALL but distinct deviation — above ordinary curb/bump jolts, which the
+        // 2-of-3 consecutive window debounces (a courier strikes curbs often).
+        // REPLACES the old 8.0 raw-norm, which was BELOW the ~9.81 gravity floor (a
+        // static courier latched on gravity alone — the #321 bug). Needs bench
+        // characterization. (CONTRACT_PROFILES.md courier.impact_spike)
+        VehicleClass::Courier => ImpactCfg {
+            spike_threshold_mps2: 2.5,
+            confirmation_m: 2,
+            confirmation_n: 3,
+        },
+    };
+    // The built-in profiles are compile-time constants and must always be valid.
+    debug_assert!(cfg.validate().is_ok(), "built-in {class:?} ImpactCfg invalid: {:?}", cfg.validate());
+    cfg
 }
 
 /// Conservative, fail-closed fusion: an impact is declared iff **ANY** signal
@@ -561,23 +623,53 @@ mod tests {
     }
 
     #[test]
-    fn robotaxi_impact_cfg_is_the_frozen_default_courier_differs() {
-        // Robotaxi delegates to the frozen default (zero new number).
-        assert_eq!(
-            impact_cfg_for_class(VehicleClass::Robotaxi).spike_threshold_mps2,
-            ImpactCfg::default().spike_threshold_mps2,
-            "robotaxi must be the frozen default threshold"
-        );
-        // Courier is more sensitive (lower threshold) — a sidewalk collision is a
-        // smaller decel signature; it must NOT equal the robotaxi/road value.
+    fn class_threshold_ordering_and_robotaxi_off_default() {
+        // Deviation-convention ordering (#321 / ADL-013): courier < delivery-av <
+        // robotaxi — a sidewalk collision is a smaller deviation than a road crash.
         let courier = impact_cfg_for_class(VehicleClass::Courier).spike_threshold_mps2;
-        let robotaxi = impact_cfg_for_class(VehicleClass::Robotaxi).spike_threshold_mps2;
-        assert!(courier != robotaxi, "courier threshold must differ from robotaxi");
-        assert!(courier < robotaxi, "courier (sidewalk) must be more sensitive than robotaxi (road)");
-        // Ordering sanity across the family: courier < delivery-av < robotaxi.
         let delivery = impact_cfg_for_class(VehicleClass::DeliveryAv).spike_threshold_mps2;
+        let robotaxi = impact_cfg_for_class(VehicleClass::Robotaxi).spike_threshold_mps2;
         assert!(courier < delivery && delivery < robotaxi,
             "threshold ordering courier {courier} < delivery-av {delivery} < robotaxi {robotaxi}");
+        // The #321 convention change moves robotaxi OFF the raw-norm default (30.0):
+        // it is now an explicit deviation threshold.
+        assert!((robotaxi - ImpactCfg::default().spike_threshold_mps2).abs() > f64::EPSILON,
+            "robotaxi deviation threshold ({robotaxi}) is no longer the raw-norm default (30.0)");
+        // The courier number is the #321 fix: ABOVE 1.0 (noise) and BELOW the ~9.81
+        // gravity floor (the old 8.0 raw-norm was below gravity → false-latched at rest).
+        assert!(courier > 1.0 && courier < 9.80665,
+            "courier deviation threshold {courier} sits between noise and gravity");
+    }
+
+    #[test]
+    fn impact_cfg_validate_rejects_nonsense() {
+        // threshold <= 1.0 → Err
+        assert!(ImpactCfg { spike_threshold_mps2: 1.0, confirmation_m: 1, confirmation_n: 1 }
+            .validate().is_err());
+        assert!(ImpactCfg { spike_threshold_mps2: 0.5, confirmation_m: 1, confirmation_n: 1 }
+            .validate().is_err());
+        // M < 1 → Err
+        assert!(ImpactCfg { spike_threshold_mps2: 5.0, confirmation_m: 0, confirmation_n: 1 }
+            .validate().is_err());
+        // N < M → Err
+        assert!(ImpactCfg { spike_threshold_mps2: 5.0, confirmation_m: 3, confirmation_n: 2 }
+            .validate().is_err());
+        // a sane cfg validates
+        assert!(ImpactCfg { spike_threshold_mps2: 2.5, confirmation_m: 2, confirmation_n: 3 }
+            .validate().is_ok());
+    }
+
+    #[test]
+    fn every_class_impact_cfg_passes_validation() {
+        // Exhaustive over the family (M <= N, threshold > 1.0) — the built-in
+        // profiles must always be valid.
+        for class in [VehicleClass::Courier, VehicleClass::DeliveryAv, VehicleClass::Robotaxi] {
+            let cfg = impact_cfg_for_class(class);
+            assert!(cfg.validate().is_ok(), "{class:?} cfg failed validation: {:?}", cfg.validate());
+            assert!(cfg.confirmation_m >= 1 && cfg.confirmation_n >= cfg.confirmation_m,
+                "{class:?} M/N invariant");
+        }
+        assert!(ImpactCfg::default().validate().is_ok());
     }
 
     #[test]

--- a/parko/crates/parko-ros2/src/clearance_gate.rs
+++ b/parko/crates/parko-ros2/src/clearance_gate.rs
@@ -124,30 +124,86 @@ impl ContactCell {
     }
 }
 
-/// Convention-free deceleration proxy: the Euclidean magnitude of the IMU
-/// linear-acceleration vector (m/s²). We deliberately do NOT assume a forward
-/// axis or remove gravity — both would invent a convention the sample does not
-/// carry (gravity removal needs the orientation, which is `Option` and may be
-/// absent). `ImpactEvidence::imu_accel_spike_mps2` is a "spike MAGNITUDE", and
-/// the threshold (default 30 m/s²) sits well above the ~9.81 m/s² gravity
-/// baseline, so a static vehicle never crosses it; a collision-grade total
-/// acceleration crosses it regardless of impact direction.
+/// Standard gravity (m/s², ISO 80000-3 / CGPM). The decel-deviation baseline.
+const STANDARD_GRAVITY_MPS2: f64 = 9.80665;
+
+/// Gravity-deviation decel proxy (#321 / ADL-013): `| ‖a‖ − G |`, the absolute
+/// deviation of the accelerometer-vector magnitude from standard gravity. At rest
+/// `‖a‖ ≈ G` ⇒ ≈ 0, so **no class false-latches on gravity** (the H2 floor bug:
+/// the old raw-norm `‖a‖` read ~9.81 at rest, below the courier threshold).
+///
+/// RESIDUAL (named, not fixed here): because `‖a‖` combines the impulse with gravity
+/// vectorially, this under-represents a purely horizontal impulse
+/// (`√(c²+G²) − G < c`). The better convention subtracts the gravity VECTOR via the
+/// orientation quaternion (`‖a − R·g‖`), but that needs a *reliable* orientation
+/// (`ImuSample::orientation` is `Option` and a fabricated identity quaternion would
+/// assert a false attitude). Orientation-corrected projection is the named future
+/// improvement; the deviation convention is the floor-bug fix that ships now, with
+/// thresholds set conservatively to absorb the residual.
 #[must_use]
-fn decel_magnitude(imu: &ImuSample) -> f64 {
+fn decel_deviation(imu: &ImuSample) -> f64 {
     let a = imu.linear_acceleration;
-    ((a[0] as f64).powi(2) + (a[1] as f64).powi(2) + (a[2] as f64).powi(2)).sqrt()
+    let norm = ((a[0] as f64).powi(2) + (a[1] as f64).powi(2) + (a[2] as f64).powi(2)).sqrt();
+    (norm - STANDARD_GRAVITY_MPS2).abs()
 }
 
-/// Build the SG6 [`ImpactEvidence`] for one tick from the node's live inputs +
-/// the (already-evaluated) vanished flag. An absent IMU contributes `0.0` (a
-/// finite below-threshold value — "no spike observed", never a NaN or a
-/// fabricated spike).
-#[must_use]
-fn assemble_evidence(inputs: &ImpactInputs, vanished: bool) -> ImpactEvidence {
-    ImpactEvidence {
-        imu_accel_spike_mps2: inputs.imu.as_ref().map_or(0.0, decel_magnitude),
-        contact_sensor: inputs.contact,
-        vanished_object: vanished,
+/// Decel confirmation debounce (#321 / ADL-013): a detection is confirmed only on a
+/// run of `≥ M` **CONSECUTIVE** above-threshold ticks within the last `N`
+/// observations — a debounce against single-tick jolts (pothole/curb), NOT an
+/// M-of-N vote (so `T,F,T` does NOT confirm). Holds a `VecDeque<bool>` bounded at
+/// capacity `N`. `M=1/N=1` (the default cfg) = single-tick / frozen behavior.
+///
+/// Lives here (the default-lane tick harness, alongside [`ContactCell`]) so the
+/// stateful confirmation is CI-tested without ROS; `node.rs` stays a thin transport.
+#[derive(Debug, Default)]
+pub struct SpikeDebouncer {
+    window: std::collections::VecDeque<bool>,
+}
+
+impl SpikeDebouncer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record one observation: `deviation > threshold` is a "hit". Evicts the
+    /// oldest if the window is at capacity `N`.
+    pub fn observe(&mut self, deviation: f64, cfg: &ImpactCfg) {
+        let n = cfg.confirmation_n.max(1) as usize;
+        self.window.push_back(deviation > cfg.spike_threshold_mps2);
+        while self.window.len() > n {
+            self.window.pop_front();
+        }
+    }
+
+    /// True iff the window holds a run of `≥ M` consecutive hits.
+    #[must_use]
+    pub fn is_confirmed(&self, cfg: &ImpactCfg) -> bool {
+        let m = cfg.confirmation_m.max(1) as usize;
+        let mut run = 0usize;
+        for &hit in &self.window {
+            if hit {
+                run += 1;
+                if run >= m {
+                    return true;
+                }
+            } else {
+                run = 0;
+            }
+        }
+        false
+    }
+
+    /// [`is_confirmed`](Self::is_confirmed), and on a `true` CONSUME it by resetting
+    /// the window (so one collision confirms once, and the next incident needs a
+    /// fresh run). Mirrors [`ContactCell::drain`]'s consume semantics — but only
+    /// resets on a confirm, so the window can ACCUMULATE across ticks toward `M`.
+    pub fn drain_confirmed(&mut self, cfg: &ImpactCfg) -> bool {
+        let confirmed = self.is_confirmed(cfg);
+        if confirmed {
+            self.window.clear();
+        }
+        confirmed
     }
 }
 
@@ -168,6 +224,9 @@ pub struct NodeClearance {
     vanished: Option<VanishedObjectDetector>,
     /// Config for the vanished detector (parko-core default until tuned).
     vanished_cfg: VanishedCfg,
+    /// Decel confirmation debounce (#321) — per-node stateful, M-of-N consecutive
+    /// from `cfg.confirmation_*`.
+    spike_debouncer: SpikeDebouncer,
 }
 
 impl NodeClearance {
@@ -185,6 +244,7 @@ impl NodeClearance {
             cfg: ImpactCfg::default(),
             vanished: None,
             vanished_cfg: VanishedCfg::default(),
+            spike_debouncer: SpikeDebouncer::new(),
         }
     }
 
@@ -263,7 +323,26 @@ impl NodeClearance {
             (Some(det), Some(sc)) => det.observe(sc, now_ms, &self.vanished_cfg),
             _ => false,
         };
-        let evidence = assemble_evidence(inputs, vanished);
+        // Decel (#321): gravity-DEVIATION through the M-of-N confirmation debounce.
+        // An absent IMU contributes NO decel and does not advance the window (never
+        // a fabricated spike). A confirmed run reports the deviation; else 0.0.
+        let imu_accel_spike_mps2 = match &inputs.imu {
+            Some(imu) => {
+                let dev = decel_deviation(imu);
+                self.spike_debouncer.observe(dev, &self.cfg);
+                if self.spike_debouncer.drain_confirmed(&self.cfg) {
+                    dev
+                } else {
+                    0.0
+                }
+            }
+            None => 0.0,
+        };
+        let evidence = ImpactEvidence {
+            imu_accel_spike_mps2,
+            contact_sensor: inputs.contact,
+            vanished_object: vanished,
+        };
         self.clearance_loop.observe(&evidence, &self.cfg, now_ms);
     }
 
@@ -388,6 +467,78 @@ mod tests {
         cell.assert(true);
         assert!(cell.drain(), "first read sees the contact");
         assert!(!cell.drain(), "second read is reset — one event latches once");
+    }
+
+    // ---- #321: decel deviation convention + SpikeDebouncer --------------
+
+    fn imu_with(ax: f32, ay: f32, az: f32) -> ImuSample {
+        ImuSample { linear_acceleration: [ax, ay, az], angular_velocity: [0.0; 3], orientation: None }
+    }
+
+    /// A flat, RESTING IMU (gravity only) reads ≈ 0 deviation — the #321 fix: it is
+    /// FAR below the courier threshold (2.5), so a static courier never false-latches
+    /// (the old raw-norm read ~9.81 > 8.0 and latched on gravity alone).
+    #[test]
+    fn static_resting_imu_deviation_is_below_courier_threshold() {
+        let dev = decel_deviation(&imu_with(0.0, 0.0, 9.80665));
+        assert!(dev < 1e-3, "resting deviation must be ≈ 0, got {dev}");
+        let courier = parko_core::impact_cfg_for_class(parko_core::VehicleClass::Courier);
+        assert!(dev < courier.spike_threshold_mps2,
+            "resting deviation {dev} must be below the courier threshold {}", courier.spike_threshold_mps2);
+    }
+
+    /// Parametric deviation: a known acceleration vector → expected `|‖a‖ − G|`.
+    #[test]
+    fn decel_deviation_matches_formula() {
+        // ‖(40,0,0)‖ = 40 → |40 − 9.80665| = 30.19335
+        let dev = decel_deviation(&imu_with(40.0, 0.0, 0.0));
+        assert!((dev - (40.0 - 9.80665)).abs() < 1e-3, "got {dev}");
+        // free-fall ‖(0,0,0)‖ = 0 → |0 − G| = G (a secondary anomaly trigger)
+        let ff = decel_deviation(&imu_with(0.0, 0.0, 0.0));
+        assert!((ff - 9.80665).abs() < 1e-3, "free-fall deviation = G, got {ff}");
+    }
+
+    fn cfg_mn(threshold: f64, m: u8, n: u8) -> ImpactCfg {
+        ImpactCfg { spike_threshold_mps2: threshold, confirmation_m: m, confirmation_n: n }
+    }
+
+    /// M=2/N=3: one hit not confirmed; two CONSECUTIVE hits confirmed + drain
+    /// resets; the non-consecutive T,F,T never confirms; sub-threshold never confirms.
+    #[test]
+    fn spike_debouncer_m2_n3_requires_consecutive() {
+        let cfg = cfg_mn(2.5, 2, 3);
+        let mut d = SpikeDebouncer::new();
+
+        // one hit → not confirmed
+        d.observe(5.0, &cfg);
+        assert!(!d.drain_confirmed(&cfg), "single hit must not confirm M=2");
+        // a SECOND consecutive hit → confirmed, and drain resets the window
+        d.observe(5.0, &cfg);
+        assert!(d.drain_confirmed(&cfg), "two consecutive hits confirm M=2");
+        assert!(!d.is_confirmed(&cfg), "drain reset the window after a confirm");
+
+        // non-consecutive T,F,T → never confirms (the debounce, not a vote)
+        let mut d2 = SpikeDebouncer::new();
+        d2.observe(5.0, &cfg); assert!(!d2.drain_confirmed(&cfg));
+        d2.observe(0.0, &cfg); assert!(!d2.drain_confirmed(&cfg));
+        d2.observe(5.0, &cfg); assert!(!d2.drain_confirmed(&cfg), "T,F,T is non-consecutive → not confirmed");
+
+        // sub-threshold forever → never confirms
+        let mut d3 = SpikeDebouncer::new();
+        for _ in 0..10 { d3.observe(1.0, &cfg); assert!(!d3.drain_confirmed(&cfg)); }
+    }
+
+    /// M=1/N=1 (robotaxi / default): a single above-threshold tick confirms
+    /// immediately — the frozen single-tick behavior (zero regression).
+    #[test]
+    fn spike_debouncer_m1_n1_confirms_single_tick() {
+        let cfg = cfg_mn(22.0, 1, 1);
+        let mut d = SpikeDebouncer::new();
+        d.observe(25.0, &cfg);
+        assert!(d.drain_confirmed(&cfg), "M=1/N=1 confirms on one hit");
+        // a sub-threshold tick does not
+        d.observe(10.0, &cfg);
+        assert!(!d.drain_confirmed(&cfg));
     }
 
     use parko_core::backend::{BackendDescriptor, TensorBatch};

--- a/parko/crates/parko-ros2/src/config.rs
+++ b/parko/crates/parko-ros2/src/config.rs
@@ -121,6 +121,9 @@ impl ParkoNodeConfig {
     pub fn impact_cfg(&self) -> parko_core::ImpactCfg {
         parko_core::ImpactCfg {
             spike_threshold_mps2: self.spike_threshold_mps2,
+            // #321: M/N confirmation defaults (single-tick) come from the default;
+            // the node-config surface only tunes the threshold today.
+            ..parko_core::ImpactCfg::default()
         }
     }
 }

--- a/work/decisions.md
+++ b/work/decisions.md
@@ -724,3 +724,79 @@ public download.
   confirmation all ride #36 / a #276 engagement).
 
 
+## ADL-013 — SG6 decel convention: gravity-deviation + M-of-N confirmation window (#321)
+
+**Date:** 2026-06-12
+**Status:** Decided — implemented in this PR. Thresholds are **VALIDATION-PENDING** (bench/SOTIF characterization rides the eventual hardware day); the *convention* and the *window mechanism* are decided.
+**Deciders:** Justin Looney
+**Source:** Code-review register #319 (finding H2+A1). The prior raw-norm proxy (`‖a‖`, gravity-inclusive) had a floor bug: at rest `‖a‖ ≈ 9.80665`, so the courier threshold of 8.0 was *below gravity* — a static, level courier latched on gravity alone — and a single-tick jolt permanently latched (human clearance required). Both are fixed here.
+**Cross-refs:** #321 (this fix), #319 (register), #311 (the raw-norm proxy this replaces), #312/#316 (the per-class contract family), `docs/CONTRACT_PROFILES.md` (the normative `*.impact_spike` rows + the convention row), `parko/crates/parko-core/src/impact.rs` (`ImpactCfg`), `parko/crates/parko-ros2/src/clearance_gate.rs` (`decel_deviation` / `SpikeDebouncer`).
+
+### 1. Convention — gravity-DEVIATION, not raw norm
+
+The IMU decel proxy is now the **absolute deviation of the accelerometer-vector
+magnitude from standard gravity**:
+
+> `decel_deviation = | ‖a‖ − G |`,  `G = 9.80665 m/s²` (ISO 80000-3 / CGPM standard gravity).
+
+At rest `‖a‖ ≈ G` ⇒ deviation ≈ 0, so **no threshold below gravity is needed and no
+class false-latches at rest** — the H2 floor bug is structurally removed. A
+collision-grade deceleration raises `‖a‖` ⇒ a large deviation; free-fall lowers `‖a‖`
+⇒ also a large deviation (a robot going off a curb edge is an anomaly worth latching —
+acceptable secondary trigger).
+
+**Named residual (orientation-corrected projection).** Because `‖a‖` combines the
+collision impulse with gravity *vectorially*, the deviation still under-represents a
+purely horizontal impulse (`√(c²+G²) − G < c`). The better convention subtracts the
+gravity vector using the orientation quaternion (`‖a − R·g‖`), but that requires a
+**reliable** orientation (`ImuSample::orientation` is `Option` and may be absent —
+and a fabricated identity quaternion would assert a false attitude, exactly the hazard
+`imu_shim` guards). So orientation-corrected projection is a **named future
+improvement**, gated on a trustworthy quaternion; the deviation convention is the
+floor-bug fix that ships now, with thresholds set conservatively to absorb the
+residual.
+
+### 2. Confirmation window — M consecutive of the last N (a debounce, not a vote)
+
+`ImpactCfg` gains `confirmation_m: u8` and `confirmation_n: u8`. A decel detection is
+**confirmed** only when the last `N` observations contain a run of **≥ M CONSECUTIVE**
+above-threshold ticks. This is a *debounce against a single-tick jolt* (pothole, curb
+strike), NOT an M-of-N vote: `T,F,T` does **not** confirm (no consecutive run) — a
+sustained deceleration is the signal, two scattered jolts are not. (`SpikeDebouncer`
+holds a `VecDeque<bool>` bounded at capacity `N`; `drain_confirmed` consumes the
+confirmation by resetting the window only when it fires.)
+
+**Defaults `M=1, N=1` ⇒ zero regression:** a single tick above threshold confirms
+immediately — bit-identical to the prior single-tick behavior. Every existing
+`is_impact` / latch test passes unchanged; that default IS the backward-compat proof.
+
+### 3. Revised per-class thresholds (deviation units; M-of-N) — all VALIDATION-PENDING
+
+| class | threshold (`|‖a‖−G|`, m/s²) | M / N | basis |
+|---|---|---|---|
+| Courier (sidewalk) | **2.5** | 2 / 3 | walking-pace (~1.5–3 m/s) collision is a small but distinct deviation; above ordinary curb/bump jolts, which M=2/N=3 debounces; a courier strikes curbs often. (replaces the old **8.0 raw-norm**, which was *below gravity*.) |
+| Delivery-AV (road pod) | **8.0** | 2 / 3 | ~11 m/s road-pod collision decelerates harder than a sidewalk hit, less than a full crash; mid deviation, debounced against road bumps. |
+| Robotaxi | **22.0** | 1 / 1 | full-speed collision-grade decel (~30 m/s² raw-norm ≈ 20–22 deviation once combined with gravity). **M=1/N=1: a highway crash is unambiguous in one tick and the FTTI is tight — no latency budget to wait for confirmation.** |
+| `ImpactCfg::default()` | 30.0 (unchanged) | 1 / 1 | the conservative fallback when no class is selected; threshold left at 30.0 so the convention change introduces zero regression in the default path. |
+
+**The latency-vs-false-latch tradeoff (the A1 decision):** lower-speed classes
+(courier / delivery-AV) accept a 2-of-3 confirmation delay (≤ ~150 ms at 20 Hz) to
+reject the frequent benign jolts of pedestrian/road-pod operation; the robotaxi class
+refuses that delay (M=1) because at highway speed the collision is unambiguous and the
+fault-tolerant time interval does not permit it. M/N is therefore a **per-class**
+parameter, not a global constant.
+
+### 4. Config-load validation
+
+`ImpactCfg::validate()` enforces `spike_threshold_mps2 > 1.0` (a deviation threshold ≤
+1 would trip on noise) ∧ `confirmation_m ≥ 1` ∧ `confirmation_n ≥ confirmation_m`. Every
+built-in `impact_cfg_for_class` profile is asserted valid; a future bad built-in trips
+in tests.
+
+### 5. Named residuals (not fixed here)
+- **Orientation-corrected projection** (§1) — gated on a reliable quaternion.
+- **Threshold + M/N certification** — all numbers are VALIDATION-PENDING placeholders;
+  bench characterization of low-speed collision decel signatures replaces them.
+- **Per-class wiring into the node binary** — selecting `impact_cfg_for_class(class)`
+  at runtime is the #312 remainder; until then the node uses the default (30.0, 1/1).
+


### PR DESCRIPTION
Fixes #321 (H2+A1) from the code-review register #319. **ADL-013** (`work/decisions.md`) is the design authority. Talisman `997fb7ae…` byte-identical (first + last); `parko-core` `ImpactCfg` gains fields but is **not restructured** (`is_impact` unchanged); no new deps.

## The bug (two coupled defects)
- **H2:** the decel proxy was the raw norm `‖a‖`, which is ~9.81 at rest — so the courier `impact_spike = 8.0` was **below gravity**; a static, level courier latched on gravity alone.
- **A1:** a single-tick jolt (pothole/curb) permanently latched (human clearance required).

## The fix
**Convention → gravity-DEVIATION.** `decel_deviation = | ‖a‖ − G |`, `G = 9.80665 m/s²` (ISO 80000-3). At rest ≈ 0 ⇒ the floor bug is structurally removed. *Residual (named, not fixed):* `‖a‖` combines the impulse with gravity vectorially, so it under-represents a purely horizontal impulse; orientation-corrected projection (`‖a − R·g‖`) is the future improvement, gated on a reliable quaternion.

**Confirmation window → M consecutive of last N.** `ImpactCfg` gains `confirmation_m`/`confirmation_n`. A `SpikeDebouncer` (alongside `ContactCell`) confirms only on a run of ≥ M **consecutive** above-threshold ticks — a debounce against single-tick jolts, **not an M-of-N vote** (`T,F,T` does *not* confirm). **Default `M=1/N=1` = single-tick / frozen behavior ⇒ zero regression.**

> **Note on a task contradiction I had to resolve:** the spec said `is_confirmed = "≥ M trues"` (a count) but its own test required `T,F,T → not confirmed (non-consecutive)`. The test is the authoritative behavioral contract and the safety-meaningful reading (a *sustained* deceleration, not two scattered jolts), so I implemented **M-consecutive** and documented the reconciliation in ADL-013 + the code.

**Revised thresholds (deviation units, all VALIDATION-PENDING):**
| class | threshold | M/N | why |
|---|---|---|---|
| Courier | **2.5** | 2/3 | walking-pace collision; above noise, below gravity; debounce curb jolts |
| Delivery-AV | **8.0** | 2/3 | road-pod mid-deviation; debounce road bumps |
| Robotaxi | **22.0** | 1/1 | full-speed crash unambiguous in one tick; tight FTTI, no confirmation delay |
| `ImpactCfg::default()` | 30.0 (unchanged) | 1/1 | conservative fallback; **zero regression in the default path** |

Robotaxi moves **off** the raw-norm `30.0` default (the convention changed); `validate()` enforces `threshold finite & > 1.0`, `M ≥ 1`, `N ≥ M`, debug-asserted on every built-in.

## Two grounded deviations from the listed scope
1. **`node.rs` is unchanged** (the task listed it). Per the #320 precedent — stateful detection belongs in the **default-lane, CI-tested** `clearance_gate.rs`, not the `ros2`-gated `node.rs` — the debouncer lives in `NodeClearance`/`observe_tick`. `node.rs` already passes `ImpactInputs { imu, contact }`; no change needed.
2. **`config.rs` is changed** (one token: `..Default::default()`) — a required compile fix for the additive `ImpactCfg` fields. Not service/store/console.

## Verify
`decel_deviation` formula + **static-resting < courier-threshold (the #321 regression proof)**; `SpikeDebouncer` M=2/N=3 consecutive + M=1/N=1 single-tick (backward-compat proof); `validate()` rejects `≤1.0`/`M>N`/non-finite; every class passes validation. **parko-core 33, parko-ros2 159, parko-kirra 142, SDK lib 611 — all green; clippy clean.** `CONTRACT_PROFILES.md` updated (deviation rows + M/N row + convention row + courier rationale). No Cargo/SDK-src/talisman changes.

Closes #321. References #319, ADL-013.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_