### PR TITLE
fix(fleet): close the clearance-grant replay hole on the untrusted carrier (#322)

### DIFF
--- a/crates/kirra-fleet-transport/Cargo.toml
+++ b/crates/kirra-fleet-transport/Cargo.toml
@@ -42,9 +42,11 @@ serde_json = "1"
 # payload; verify against the controller's registered public key).
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 base64 = "0.22"
+# Per-grant nonce minting on the signing side (#322 replay defense): 16 random
+# bytes → hex, burned exactly once at ingest (verify-AND-consume).
+rand = "0.8"
 
 [dev-dependencies]
 # zenoh is async; the in-process two-session round-trip tests need a runtime.
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tempfile = "3"
-rand = "0.8"

--- a/crates/kirra-fleet-transport/src/lib.rs
+++ b/crates/kirra-fleet-transport/src/lib.rs
@@ -79,6 +79,14 @@ pub enum RejectReason {
     Decode(String),
     /// The payload decoded but is structurally invalid (e.g. empty node/operator).
     Malformed(String),
+    /// The signature verified but the grant's freshness window has closed
+    /// (`now_ms >= expires_at_ms`). A stale-but-authentic grant replayed off the
+    /// carrier outside its TTL — rejected fail-closed.
+    Expired,
+    /// The signature verified and the grant is fresh, but its nonce was already
+    /// burned — i.e. this exact grant has been ingested before. A replay of a
+    /// captured, still-in-window grant — rejected fail-closed (verify-AND-consume).
+    Replayed,
     /// A verified grant could not be written to the store (fail-closed).
     StoreError(String),
 }
@@ -92,6 +100,8 @@ impl RejectReason {
             RejectReason::BadSignature => "bad_signature",
             RejectReason::Decode(_) => "decode_error",
             RejectReason::Malformed(_) => "malformed",
+            RejectReason::Expired => "expired",
+            RejectReason::Replayed => "replayed",
             RejectReason::StoreError(_) => "store_error",
         }
     }
@@ -105,6 +115,8 @@ pub struct RejectionCounter {
     bad_signature: AtomicU64,
     decode_error: AtomicU64,
     malformed: AtomicU64,
+    expired: AtomicU64,
+    replayed: AtomicU64,
     store_error: AtomicU64,
     accepted: AtomicU64,
 }
@@ -122,6 +134,8 @@ impl RejectionCounter {
             RejectReason::BadSignature => &self.bad_signature,
             RejectReason::Decode(_) => &self.decode_error,
             RejectReason::Malformed(_) => &self.malformed,
+            RejectReason::Expired => &self.expired,
+            RejectReason::Replayed => &self.replayed,
             RejectReason::StoreError(_) => &self.store_error,
         };
         slot.fetch_add(1, Ordering::Relaxed);
@@ -139,6 +153,8 @@ impl RejectionCounter {
             bad_signature: self.bad_signature.load(Ordering::Relaxed),
             decode_error: self.decode_error.load(Ordering::Relaxed),
             malformed: self.malformed.load(Ordering::Relaxed),
+            expired: self.expired.load(Ordering::Relaxed),
+            replayed: self.replayed.load(Ordering::Relaxed),
             store_error: self.store_error.load(Ordering::Relaxed),
             accepted: self.accepted.load(Ordering::Relaxed),
         }
@@ -148,7 +164,8 @@ impl RejectionCounter {
     #[must_use]
     pub fn total_rejected(&self) -> u64 {
         let s = self.snapshot();
-        s.unsigned + s.bad_signature + s.decode_error + s.malformed + s.store_error
+        s.unsigned + s.bad_signature + s.decode_error + s.malformed + s.expired + s.replayed
+            + s.store_error
     }
 }
 
@@ -159,6 +176,8 @@ pub struct RejectionSnapshot {
     pub bad_signature: u64,
     pub decode_error: u64,
     pub malformed: u64,
+    pub expired: u64,
+    pub replayed: u64,
     pub store_error: u64,
     pub accepted: u64,
 }
@@ -222,6 +241,15 @@ pub fn accept_report(
 // Signed clearance grant (the down lane) — reuses the federation Ed25519 pattern
 // ---------------------------------------------------------------------------
 
+/// Freshness window for a signed clearance grant (ms). A grant is valid from
+/// `granted_at_ms` until `granted_at_ms + FLEET_GRANT_TTL_MS`; after that an
+/// otherwise-authentic grant replayed off the carrier is rejected as `Expired`.
+/// Two minutes accommodates a cellular ops→vehicle hop while bounding the window in
+/// which a captured grant could be replayed before its nonce burn (the nonce burn is
+/// the hard, single-use defense; the TTL bounds the worst case and lets the vehicle
+/// reject obviously-stale traffic without a store round-trip).
+pub const FLEET_GRANT_TTL_MS: u64 = 120_000;
+
 /// An operator clearance grant signed by the issuing controller for transport over
 /// the untrusted fleet carrier. The vehicle verifies the signature against the
 /// controller's registered public key BEFORE writing it to the store.
@@ -229,26 +257,47 @@ pub fn accept_report(
 /// The signature is over a canonical payload of the *semantic* fields
 /// ([`canonical_grant_payload`]), NOT the wire bytes — so the codec is independent
 /// of the trust root (mirrors `canonical_federation_payload_v2`).
+///
+/// **Replay defense (#322).** Both the `nonce_hex` (a per-grant unique token) and
+/// `expires_at_ms` (the freshness deadline) are inside the signed payload, so an
+/// attacker on the untrusted carrier cannot mint a fresh nonce or extend the TTL
+/// without invalidating the signature. The vehicle enforces both at ingest:
+/// verify-AND-consume burns the nonce exactly once, and the TTL bounds the window.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SignedClearanceGrant {
     pub node_id: String,
     pub operator_id: String,
     pub granted_at_ms: u64,
+    /// Freshness deadline (ms, same clock domain as `granted_at_ms`). Signed.
+    pub expires_at_ms: u64,
+    /// Per-grant unique nonce (hex). Burned exactly once at ingest. Signed.
+    pub nonce_hex: String,
     pub signature_b64: String,
 }
 
-/// The canonical bytes an Ed25519 signature covers for a clearance grant.
+/// The canonical bytes an Ed25519 signature covers for a clearance grant. Includes
+/// the replay-defense fields (`expires_at_ms`, `nonce_hex`) so they are tamper-evident.
 #[must_use]
-pub fn canonical_grant_payload(node_id: &str, operator_id: &str, granted_at_ms: u64) -> String {
+pub fn canonical_grant_payload(
+    node_id: &str,
+    operator_id: &str,
+    granted_at_ms: u64,
+    expires_at_ms: u64,
+    nonce_hex: &str,
+) -> String {
     serde_json::json!({
         "node_id": node_id,
         "operator_id": operator_id,
         "granted_at_ms": granted_at_ms,
+        "expires_at_ms": expires_at_ms,
+        "nonce_hex": nonce_hex,
     })
     .to_string()
 }
 
-/// Sign a clearance grant with the issuing controller's key (ops/cloud side).
+/// Sign a clearance grant with the issuing controller's key (ops/cloud side). Mints a
+/// fresh random `nonce_hex` and sets `expires_at_ms = granted_at_ms + FLEET_GRANT_TTL_MS`,
+/// then signs over both — so the grant is single-use and time-bounded on the wire.
 #[must_use]
 pub fn sign_clearance_grant(
     signing_key: &SigningKey,
@@ -256,14 +305,31 @@ pub fn sign_clearance_grant(
     operator_id: &str,
     granted_at_ms: u64,
 ) -> SignedClearanceGrant {
-    let payload = canonical_grant_payload(node_id, operator_id, granted_at_ms);
+    let mut nonce = [0u8; 16];
+    rand::Rng::fill(&mut rand::thread_rng(), &mut nonce);
+    let nonce_hex = hex_encode(&nonce);
+    let expires_at_ms = granted_at_ms.saturating_add(FLEET_GRANT_TTL_MS);
+    let payload =
+        canonical_grant_payload(node_id, operator_id, granted_at_ms, expires_at_ms, &nonce_hex);
     let sig: Signature = signing_key.sign(payload.as_bytes());
     SignedClearanceGrant {
         node_id: node_id.to_string(),
         operator_id: operator_id.to_string(),
         granted_at_ms,
+        expires_at_ms,
+        nonce_hex,
         signature_b64: B64.encode(sig.to_bytes()),
     }
+}
+
+/// Lowercase-hex encode (small, dependency-free — avoids pulling the `hex` crate
+/// into this leaf for a 16-byte nonce).
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
 }
 
 /// Verify a clearance grant's Ed25519 signature against `public_key_b64`. Fail-closed
@@ -276,7 +342,13 @@ pub fn verify_clearance_grant(grant: &SignedClearanceGrant, public_key_b64: &str
     let Ok(sig_array) = <[u8; 64]>::try_from(sig_bytes.as_slice()) else { return false };
     let Ok(key) = VerifyingKey::from_bytes(&pk_array) else { return false };
     let sig = Signature::from_bytes(&sig_array);
-    let payload = canonical_grant_payload(&grant.node_id, &grant.operator_id, grant.granted_at_ms);
+    let payload = canonical_grant_payload(
+        &grant.node_id,
+        &grant.operator_id,
+        grant.granted_at_ms,
+        grant.expires_at_ms,
+        &grant.nonce_hex,
+    );
     key.verify(payload.as_bytes(), &sig).is_ok()
 }
 
@@ -284,14 +356,22 @@ pub fn verify_clearance_grant(grant: &SignedClearanceGrant, public_key_b64: &str
 /// Phase-A store path as a `PENDING-NODE-TRANSPORT` row — the same row Phase-B's
 /// `take_pending_clearance_grant` consumes. No new schema, no second release path.
 ///
-/// Verify-FIRST, fail-closed: an unsigned / bad-signature / structurally-malformed
-/// grant is rejected + counted and NEVER reaches the store. Returns the store rowid
-/// on success.
+/// Verify-FIRST, fail-closed: an unsigned / bad-signature / structurally-malformed /
+/// expired / replayed grant is rejected + counted and NEVER reaches the store.
+/// Returns the store rowid on success.
+///
+/// **Replay defense (#322).** After the signature verifies, the grant must be both
+/// FRESH (`now_ms < expires_at_ms`, else [`RejectReason::Expired`]) and UNSEEN — the
+/// nonce is burned via [`VerifierStore::burn_federation_nonce`] in one atomic
+/// verify-AND-consume step; a nonce already on record means the same grant was
+/// ingested before ([`RejectReason::Replayed`]). The burn happens BEFORE the store
+/// write so a replay can never land a duplicate PENDING row.
 pub fn ingest_clearance_grant(
     store: &mut VerifierStore,
     grant: &SignedClearanceGrant,
     public_key_b64: &str,
     counter: &RejectionCounter,
+    now_ms: u64,
 ) -> Result<i64, RejectReason> {
     if grant.signature_b64.trim().is_empty() {
         let r = RejectReason::Unsigned;
@@ -303,13 +383,41 @@ pub fn ingest_clearance_grant(
         counter.record(&r);
         return Err(r);
     }
+    if grant.nonce_hex.trim().is_empty() {
+        let r = RejectReason::Malformed("empty nonce_hex".into());
+        counter.record(&r);
+        return Err(r);
+    }
     if !verify_clearance_grant(grant, public_key_b64) {
         let r = RejectReason::BadSignature;
         counter.record(&r);
         return Err(r);
     }
-    // Verified → the existing Phase-A path (writes the PENDING row + signed audit
-    // event). Phase-B picks it up unchanged.
+    // Authentic — now enforce freshness BEFORE consuming the nonce, so a stale grant
+    // never burns a nonce slot.
+    if now_ms >= grant.expires_at_ms {
+        let r = RejectReason::Expired;
+        counter.record(&r);
+        return Err(r);
+    }
+    // Verify-AND-consume: atomically claim the nonce. `Ok(false)` = already burned =
+    // a replay of a still-fresh captured grant. Burn BEFORE the store write so a
+    // replay can never produce a duplicate PENDING row.
+    match store.burn_federation_nonce(&grant.nonce_hex) {
+        Ok(true) => {} // first use — proceed
+        Ok(false) => {
+            let r = RejectReason::Replayed;
+            counter.record(&r);
+            return Err(r);
+        }
+        Err(e) => {
+            let r = RejectReason::StoreError(e.to_string());
+            counter.record(&r);
+            return Err(r);
+        }
+    }
+    // Verified, fresh, first-use → the existing Phase-A path (writes the PENDING row +
+    // signed audit event). Phase-B picks it up unchanged.
     match store.save_clearance_grant_chained(&grant.node_id, &grant.operator_id, grant.granted_at_ms) {
         Ok(rowid) => {
             counter.record_accepted();
@@ -425,7 +533,7 @@ mod core_tests {
         let mut store = VerifierStore::new(":memory:").unwrap();
 
         let grant = sign_clearance_grant(&sk, "robot-01", "alice", 1_000);
-        let rowid = ingest_clearance_grant(&mut store, &grant, &pk, &counter).unwrap();
+        let rowid = ingest_clearance_grant(&mut store, &grant, &pk, &counter, 1_001).unwrap();
         assert!(rowid > 0);
         assert_eq!(counter.snapshot().accepted, 1);
 
@@ -448,10 +556,74 @@ mod core_tests {
         let mut grant = sign_clearance_grant(&sk, "robot-01", "alice", 1_000);
         // Tamper: change the operator AFTER signing → signature no longer matches.
         grant.operator_id = "mallory".into();
-        let err = ingest_clearance_grant(&mut store, &grant, &pk, &counter).unwrap_err();
+        let err = ingest_clearance_grant(&mut store, &grant, &pk, &counter, 1_001).unwrap_err();
         assert_eq!(err, RejectReason::BadSignature);
         assert_eq!(counter.snapshot().bad_signature, 1);
         // Nothing was written — Phase-B finds no pending row.
         assert!(store.take_pending_clearance_grant("robot-01", 2_000).unwrap().is_none());
+    }
+
+    #[test]
+    fn replayed_grant_is_rejected_and_lands_no_second_row() {
+        // #322 — THE REPLAY PROOF: the SAME signed grant, captured off the
+        // untrusted carrier and re-delivered while still fresh, is rejected on the
+        // second ingest (its nonce is already burned) and writes NO second row.
+        let (sk, pk) = keypair();
+        let counter = RejectionCounter::new();
+        let mut store = VerifierStore::new(":memory:").unwrap();
+
+        let grant = sign_clearance_grant(&sk, "robot-07", "alice", 1_000);
+
+        // First delivery — accepted, lands the PENDING row.
+        let rowid = ingest_clearance_grant(&mut store, &grant, &pk, &counter, 1_001).unwrap();
+        assert!(rowid > 0);
+        assert_eq!(counter.snapshot().accepted, 1);
+
+        // Verbatim replay (same bytes, still inside the TTL) — rejected as Replayed.
+        let err = ingest_clearance_grant(&mut store, &grant, &pk, &counter, 1_002).unwrap_err();
+        assert_eq!(err, RejectReason::Replayed);
+        assert_eq!(counter.snapshot().replayed, 1);
+        assert_eq!(counter.snapshot().accepted, 1, "the replay must NOT count as accepted");
+
+        // Exactly one row reached Phase-B — the replay produced no duplicate.
+        assert!(store.take_pending_clearance_grant("robot-07", 1_500).unwrap().is_some());
+        assert!(store.take_pending_clearance_grant("robot-07", 1_600).unwrap().is_none());
+    }
+
+    #[test]
+    fn expired_grant_is_rejected_and_burns_no_nonce() {
+        // An authentic-but-stale grant replayed past its TTL is rejected as Expired
+        // and — crucially — does NOT burn its nonce, so a legitimate re-issue of the
+        // same logical grant is unaffected.
+        let (sk, pk) = keypair();
+        let counter = RejectionCounter::new();
+        let mut store = VerifierStore::new(":memory:").unwrap();
+
+        let grant = sign_clearance_grant(&sk, "robot-08", "alice", 1_000);
+        // now_ms past expires_at_ms (1_000 + FLEET_GRANT_TTL_MS).
+        let stale_now = 1_000 + FLEET_GRANT_TTL_MS + 1;
+        let err = ingest_clearance_grant(&mut store, &grant, &pk, &counter, stale_now).unwrap_err();
+        assert_eq!(err, RejectReason::Expired);
+        assert_eq!(counter.snapshot().expired, 1);
+
+        // Nothing written, and the nonce was never burned (freshness gates before burn).
+        assert!(store.take_pending_clearance_grant("robot-08", stale_now).unwrap().is_none());
+        assert!(
+            store.burn_federation_nonce(&grant.nonce_hex).unwrap(),
+            "nonce must still be free → first burn returns true"
+        );
+    }
+
+    #[test]
+    fn grant_with_empty_nonce_is_malformed() {
+        let (sk, pk) = keypair();
+        let counter = RejectionCounter::new();
+        let mut store = VerifierStore::new(":memory:").unwrap();
+
+        let mut grant = sign_clearance_grant(&sk, "robot-09", "alice", 1_000);
+        grant.nonce_hex = String::new(); // strip the nonce
+        let err = ingest_clearance_grant(&mut store, &grant, &pk, &counter, 1_001).unwrap_err();
+        assert_eq!(err, RejectReason::Malformed("empty nonce_hex".into()));
+        assert_eq!(counter.snapshot().malformed, 1);
     }
 }

--- a/crates/kirra-fleet-transport/src/transport.rs
+++ b/crates/kirra-fleet-transport/src/transport.rs
@@ -121,6 +121,7 @@ impl GrantIngest {
         store: &mut VerifierStore,
         public_key_b64: &str,
         counter: &RejectionCounter,
+        now_ms: u64,
     ) -> Result<i64, RejectReason> {
         let sample = self
             .subscriber
@@ -134,7 +135,7 @@ impl GrantIngest {
                 counter.record(&r);
                 r
             })?;
-        ingest_clearance_grant(store, &grant, public_key_b64, counter)
+        ingest_clearance_grant(store, &grant, public_key_b64, counter, now_ms)
     }
 }
 
@@ -297,7 +298,7 @@ mod transport_tests {
         let counter = RejectionCounter::new();
         let rowid = tokio::time::timeout(
             std::time::Duration::from_secs(5),
-            ingest.recv_and_ingest(&mut store, &pk, &counter),
+            ingest.recv_and_ingest(&mut store, &pk, &counter, 1_001),
         )
         .await
         .expect("recv timed out")

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -1682,6 +1682,33 @@ impl VerifierStore {
         Ok(count > 0)
     }
 
+    /// Atomically *burn* a nonce: claim it on first use, reject it on replay.
+    ///
+    /// Returns `Ok(true)` if the nonce was newly recorded (first time seen →
+    /// the caller may proceed) and `Ok(false)` if it was already present (a
+    /// replay → the caller must reject). This is the verify-AND-consume primitive
+    /// the untrusted fleet carrier needs: a single `INSERT OR IGNORE` against the
+    /// `nonce_hex PRIMARY KEY` makes the claim atomic — there is no check-then-act
+    /// window for two concurrent ingests of the same captured payload to both win.
+    ///
+    /// The write rides the `synchronous=FULL` durable connection (same as the
+    /// federation report nonce burn), falling back to the main connection for an
+    /// in-memory store. The `seen_at_ms` column is diagnostic only — replay
+    /// correctness depends solely on the primary-key conflict, never on the clock.
+    pub fn burn_federation_nonce(&self, nonce_hex: &str) -> Result<bool> {
+        let seen_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        let changed = self.durable_ref().execute(
+            "INSERT OR IGNORE INTO federation_report_nonces
+                 (nonce_hex, source_controller_id, seen_at_ms)
+             VALUES (?1, ?2, ?3)",
+            params![nonce_hex, "fleet-grant-lane", seen_at_ms],
+        )?;
+        Ok(changed > 0)
+    }
+
     pub fn load_federated_reports_for_asset(
         &self,
         asset_id: &str,


### PR DESCRIPTION
## The hole (#322)

The down-lane `SignedClearanceGrant` carried **no nonce and no expiry**, so a grant captured off the **untrusted** Zenoh carrier could be replayed verbatim to re-authorize an operator clearance indefinitely. On an untrusted carrier, verify-only is not enough — authenticity must be paired with **single-use + freshness**.

## The fix

**SDK (`src/verifier_store.rs`)** — one new primitive:
- `burn_federation_nonce(&self, nonce_hex) -> Result<bool>` — atomic `INSERT OR IGNORE` against the `nonce_hex PRIMARY KEY` on the `synchronous=FULL` durable connection (falls back to the main conn for in-memory). `Ok(true)` = first use, `Ok(false)` = replay. No check-then-act window.

**Fleet crate (`kirra-fleet-transport`):**
- `SignedClearanceGrant` gains `nonce_hex` + `expires_at_ms`, both folded into the signed `canonical_grant_payload` → tamper-evident (an attacker cannot mint a fresh nonce or extend the TTL without breaking the signature).
- `sign_clearance_grant` mints a random per-grant nonce and sets `expires_at_ms = granted_at_ms + FLEET_GRANT_TTL_MS` (120s). Public signature unchanged.
- `ingest_clearance_grant(…, now_ms)` now, **after** signature verification: enforces **freshness** (`now_ms < expires_at_ms`, else `Expired`), then **verify-AND-consume** of the nonce (`Replayed` if already burned). The burn precedes the store write so a replay can never land a duplicate `PENDING` row; freshness gates **before** the burn so a stale grant never consumes a nonce slot.
- New `RejectReason::Expired` / `Replayed` + `RejectionCounter` slots; `rand` promoted to a regular dependency for nonce minting.

## Deliberate non-change

`accept_report` (the federation-report lane) is left untouched. Those nonces are owned and burned by the SDK's own `save_federated_report_chained` pipeline; a second burn here would falsely reject downstream as a replay (double-burn). The clearance-grant lane is the actual replay hole — the report lane already has a single-authority replay contract.

## Cross-node binding (A3) — by construction, now pinned

`node_id` is the **first** field of the signed `canonical_grant_payload`, so the A3 cross-node property holds by construction: presenting a node-A grant as node-B's requires substituting `node_id`, which breaks the Ed25519 signature → `BadSignature`. This is now pinned explicitly by the named test `grant_for_node_a_rejected_as_node_b` (commit `22211db`).

## Verification

- `cargo test -p kirra-fleet-transport` → **13/13 pass**, including:
  - `replayed_grant_is_rejected_and_lands_no_second_row` (replay rejected, no duplicate row)
  - `expired_grant_is_rejected_and_burns_no_nonce` (stale rejected without burning the nonce)
  - `grant_with_empty_nonce_is_malformed`
  - `grant_for_node_a_rejected_as_node_b` (A3 cross-node binding)
  - plus the existing happy-path + over-the-wire zenoh round-trips.
- `cargo clippy` clean on both `kirra-runtime-sdk` and `kirra-fleet-transport`.

Scope: `src/verifier_store.rs`, `crates/kirra-fleet-transport/{Cargo.toml, src/lib.rs, src/transport.rs}`.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58