### PR TITLE
feat(keyring): unified KeyRegistry — one abstraction over four key stores (#329/ARCH GAP)

### DIFF
--- a/crates/kirra-fleet-transport/src/lib.rs
+++ b/crates/kirra-fleet-transport/src/lib.rs
@@ -33,6 +33,7 @@ use serde::{Deserialize, Serialize};
 use kirra_runtime_sdk::federation_reconciliation::{
     verify_federated_report_signature_v2, FederatedTrustReportV2,
 };
+use kirra_runtime_sdk::key_registry::{KeyRegistry, KeyRole};
 use kirra_runtime_sdk::verifier::FleetPosture;
 use kirra_runtime_sdk::verifier_store::VerifierStore;
 
@@ -237,6 +238,29 @@ pub fn accept_report(
     Ok(report)
 }
 
+/// Registry-backed [`accept_report`] (#329) — the **fleet-deployment** path. Resolves
+/// the controller's key from the unified [`KeyRegistry`] (grounded in a STORED
+/// registration, not a caller-supplied `public_key_b64` string), then delegates to
+/// [`accept_report`]. The `&str` variant remains for test/spike callers without a
+/// store. Fail-closed: an unresolvable principal (unknown controller / malformed
+/// stored key) is a counted [`RejectReason::BadSignature`] reject — the report is
+/// untrusted, never accepted by default.
+pub fn accept_report_from_registry(
+    bytes: &[u8],
+    principal_id: &str,
+    registry: &KeyRegistry,
+    counter: &RejectionCounter,
+) -> Result<FederatedTrustReportV2, RejectReason> {
+    let key_b64 = match registry.resolve_ed25519_pubkey(principal_id, KeyRole::FederationController) {
+        Ok(Some(k)) => B64.encode(k),
+        _ => {
+            counter.record(&RejectReason::BadSignature);
+            return Err(RejectReason::BadSignature);
+        }
+    };
+    accept_report(bytes, &key_b64, counter)
+}
+
 // ---------------------------------------------------------------------------
 // Signed clearance grant (the down lane) — reuses the federation Ed25519 pattern
 // ---------------------------------------------------------------------------
@@ -429,6 +453,37 @@ pub fn ingest_clearance_grant(
             Err(r)
         }
     }
+}
+
+/// Registry-backed [`ingest_clearance_grant`] (#329) — the **fleet-deployment** path.
+/// Resolves the grant signer's key from the unified [`KeyRegistry`] (the
+/// [`KeyRole::FleetGrant`] registry), then delegates to [`ingest_clearance_grant`].
+///
+/// Takes `principal_id` rather than a `&KeyRegistry` ON PURPOSE: the registry borrows
+/// the store IMMUTABLY but `ingest_clearance_grant` needs it MUTABLY (it burns the
+/// nonce + writes the row), so the two borrows cannot coexist. The key is resolved in
+/// a scoped immutable borrow that ends BEFORE the mutating store path. The `&str`
+/// variant remains the test/spike path. Fail-closed: an unresolvable signer is a
+/// counted [`RejectReason::BadSignature`] reject.
+pub fn ingest_clearance_grant_from_registry(
+    store: &mut VerifierStore,
+    grant: &SignedClearanceGrant,
+    principal_id: &str,
+    counter: &RejectionCounter,
+    now_ms: u64,
+) -> Result<i64, RejectReason> {
+    let key_b64 = {
+        let registry = KeyRegistry::new(store);
+        match registry.resolve_ed25519_pubkey(principal_id, KeyRole::FleetGrant) {
+            Ok(Some(k)) => B64.encode(k),
+            _ => {
+                counter.record(&RejectReason::BadSignature);
+                return Err(RejectReason::BadSignature);
+            }
+        }
+        // the registry's immutable borrow of `store` ends here
+    };
+    ingest_clearance_grant(store, grant, &key_b64, counter, now_ms)
 }
 
 #[cfg(test)]
@@ -645,5 +700,41 @@ mod core_tests {
         // Neither node sees a pending row — the cross-node grant reached no store.
         assert!(store.take_pending_clearance_grant("robot-A", 2_000).unwrap().is_none());
         assert!(store.take_pending_clearance_grant("robot-B", 2_000).unwrap().is_none());
+    }
+
+    /// #329 — THE REGISTRY COMPOSITION PROOF: the fleet-deployment ingest resolves the
+    /// grant signer's key from the unified `KeyRegistry` (a STORED federation-controller
+    /// registration), not a caller-supplied string. A registered signer's grant lands
+    /// the PENDING row Phase-B consumes; an unregistered signer is fail-closed.
+    #[test]
+    fn e2e_fleet_ingest_via_registry() {
+        let (sk, pk_b64) = keypair(); // pk_b64 = raw-32 verifying key (the controller registry format)
+        let counter = RejectionCounter::new();
+        let mut store = VerifierStore::new(":memory:").unwrap();
+        // Register the fleet-grant signer in the trusted-controller registry.
+        store.save_trusted_federation_controller("ops-controller", &pk_b64, 1).unwrap();
+
+        // Sign + ingest THROUGH THE REGISTRY (no caller-supplied key string).
+        let grant = sign_clearance_grant(&sk, "robot-77", "alice", 1_000);
+        let rowid =
+            ingest_clearance_grant_from_registry(&mut store, &grant, "ops-controller", &counter, 1_001)
+                .unwrap();
+        assert!(rowid > 0);
+        assert_eq!(counter.snapshot().accepted, 1);
+
+        // The registry-resolved verification produced the EXISTING Phase-B pending row.
+        let picked = store
+            .take_pending_clearance_grant("robot-77", 1_500)
+            .unwrap()
+            .expect("registry-ingested grant is a pending row Phase-B consumes");
+        assert_eq!(picked.operator_id, "alice");
+
+        // An UNREGISTERED signer principal is fail-closed (BadSignature) — nothing written.
+        let grant2 = sign_clearance_grant(&sk, "robot-78", "bob", 2_000);
+        let err =
+            ingest_clearance_grant_from_registry(&mut store, &grant2, "no-such-controller", &counter, 2_001)
+                .unwrap_err();
+        assert_eq!(err, RejectReason::BadSignature, "an unresolvable signer is fail-closed");
+        assert!(store.take_pending_clearance_grant("robot-78", 2_500).unwrap().is_none());
     }
 }

--- a/docs/adr/0008-key-registry.md
+++ b/docs/adr/0008-key-registry.md
@@ -1,0 +1,132 @@
+# ADR-0008: Unified key registry — one abstraction over four key stores; trust grounded in stored registrations, not caller-supplied strings
+
+| Field | Value |
+|---|---|
+| Status | **Accepted (Phase A)** — registry abstraction + fleet adoption landed; see *Conditions that reopen this decision* |
+| Date | 2026-06-12 |
+| Deciders | Project owner |
+| Issues | #329 (this ADR + the `KeyRegistry`); #319 (the review register this is gap-2 of); #314 (the multi-tenant operator identity that motivated the keyring note); #296/#317 (the fleet transport whose caller-supplied key this replaces) |
+| Doc | `src/key_registry.rs` (the abstraction); `crates/kirra-fleet-transport/README.md` (the adopting crate) |
+| Builds on | **ADR-0007 Clause 1** (the untrusted-carrier rule — trust is the Ed25519 payload signature; this ADR answers *which key* verifies it) |
+
+## Context
+
+Trust in this system is grounded in Ed25519 public keys. But those keys live in
+**four** different principal stores in **three** different encodings, each with its
+own ad-hoc load + decode at every verification site:
+
+| Principal | Table | Column | Encoding |
+|---|---|---|---|
+| Node (attestation) | `nodes` | `ak_public_pem` | SPKI PEM |
+| Federation controller | `trusted_federation_controllers` | `public_key_b64` | raw b64 |
+| Operator | `operators` | `pubkey_pem` | SPKI PEM |
+| Fleet-grant signer | `trusted_federation_controllers` | `public_key_b64` | raw b64 |
+
+Two problems follow. First, **duplication**: every site that verifies a signature
+re-implements the row load and the encoding decode, so a normalization bug (or a
+revocation check, like "is this operator still active?") has to be re-gotten-right in
+each place. Second, and more serious, the **fleet crate took a caller-supplied
+`public_key_b64: &str`** (`accept_report`, `ingest_clearance_grant`): the *caller*
+decided which key to trust on each verify call. That is a trust-grounding gap — an
+authentic signature over the wrong key is still the wrong principal. The #319 review
+register named this as architecture gap 2; #314's operator-identity work and
+#296/#317's fleet transport both pointed at "a keyring that maps which key verifies
+which source" as the missing abstraction.
+
+## Decision
+
+Add a **`KeyRegistry`** struct in the SDK (`src/key_registry.rs`) that unifies the
+lookup across all four principal types behind a single API. It is an **additive
+wrapper** over `VerifierStore` — **no table schema changes, no encoding migration, no
+breaking API changes, no existing API removal.**
+
+```rust
+pub enum KeyRole { NodeAttestation, FederationController, Operator, FleetGrant }
+
+pub struct KeyRegistry<'a> { /* &VerifierStore */ }
+
+impl KeyRegistry<'_> {
+    pub fn new(store: &VerifierStore) -> KeyRegistry<'_>;
+    pub fn resolve_ed25519_pubkey(&self, principal_id: &str, role: KeyRole)
+        -> Result<Option<[u8; 32]>>;
+    pub fn verify_for(&self, principal_id: &str, role: KeyRole,
+                      payload: &[u8], signature_b64: &str) -> bool;
+}
+```
+
+Three properties make it load-bearing:
+
+### 1 — one normalized output (raw 32 bytes), normalized at the read boundary
+`resolve_ed25519_pubkey` returns the **raw 32-byte** Ed25519 key regardless of how the
+backing table stores it. **PEM → bytes** reuses the existing, tested SPKI parser
+(`attestation::parse_ed25519_public_pem`) rather than a hand-rolled offset; **b64 →
+bytes** decodes and **requires exactly 32 bytes** — a wrong-length or undecodable key
+is rejected with a logged warning and `None`, never a panic and never a
+truncated/padded key. Four tables, three encodings in, **one encoding out.**
+
+### 2 — fail-closed resolution
+Every "cannot resolve" is `Ok(None)`, never a trusted default: unknown principal,
+**revoked operator** (checked `revoked_at_ms IS NULL`), absent key, or malformed
+stored key. `Err` is reserved for an actual SQL failure. `verify_for` collapses all of
+these — plus a malformed/bad signature — to `false`, so an unknown principal can never
+be ignored into an accept.
+
+### 3 — the fleet crate consults the registry (the trust-grounding fix)
+The fleet crate gains registry variants — `accept_report_from_registry` and
+`ingest_clearance_grant_from_registry` — that resolve the verifying key **from a
+stored registration** keyed by `principal_id`, instead of trusting a `&str` the caller
+passed in. The original `&str` signatures **stay** (backward compatibility, and for
+test/spike callers without a store); the registry variants are the **fleet-deployment**
+path. After this, a fleet trust claim is grounded in *who is registered*, not *what
+string the caller supplied*.
+
+> Note on the ingest variant's signature: it takes `principal_id` (not a
+> `&KeyRegistry`) because the registry borrows the store **immutably** while
+> `ingest_clearance_grant` needs it **mutably** (it burns the replay nonce + writes the
+> row). The key is resolved in a scoped immutable borrow that ends *before* the
+> mutating path — the borrow checker forbids the two coexisting on one store.
+
+## Rationale
+
+The abstraction is small and the change is additive precisely because the trust model
+was already right (ADR-0007 Clause 1: trust is the signature). What was missing was a
+single answer to *which key*. Centralizing the load + the encoding normalization + the
+revocation check in one tested place removes a class of "re-gotten-wrong-per-site"
+bugs, and routing the fleet verify through it closes the caller-supplied-key gap with
+no migration risk: the stores are untouched, only the read path is unified.
+
+## Considered and rejected
+
+- **Migrate all stores to one on-disk encoding now.** Rejected for Phase A: a schema
+  + data migration across four tables carries real risk for zero behavioral gain over
+  read-boundary normalization. Named as deferred future work below, not silently
+  dropped.
+- **Put the registry on `AppState` instead of wrapping `VerifierStore`.** Rejected:
+  the keys live in the store; wrapping the store keeps the abstraction usable by any
+  store holder (the fleet crate has a store, not an `AppState`).
+- **Change the fleet `&str` APIs in place.** Rejected: that would break the test/spike
+  callers and the backward-compat contract. Additive variants instead.
+
+## Honest limits (named, not built)
+
+- **The audit signing key is NOT in this registry.** It is an in-memory `SigningKey`
+  on the store — no rotation, no persisted public entry. Resolving it through a registry
+  of *stored* keys would be a lie; it is a **named residual**, documented in the module,
+  not silently omitted.
+- **Encoding migration is deferred.** Phase A normalizes at the read boundary; it does
+  **not** rewrite the stores to a single on-disk format. One abstraction now; one
+  on-disk encoding is named future work.
+- **Resolution is point-lookup, not cache.** Each `resolve` is a store read. If a hot
+  verify path needs it, a caching layer is an additive future step (the abstraction
+  boundary makes it a drop-in).
+
+## Conditions that reopen this decision
+
+- A **fifth principal type** or a key store that is not a single `(id → key)` row
+  (e.g. multi-key principals / key history) — the `KeyRole` enum + single-row model
+  would need extension.
+- A need to **rotate or register the audit signing key** as a first-class principal —
+  that pulls the named residual into scope and changes the store, not just the read
+  path.
+- Adopting **one on-disk encoding** (the deferred migration) — at which point the
+  read-boundary normalization simplifies to a single decode.

--- a/src/key_registry.rs
+++ b/src/key_registry.rs
@@ -1,0 +1,271 @@
+//! # KeyRegistry (#329) — one abstraction over four key stores
+//!
+//! Trust in this system is grounded in Ed25519 public keys, but those keys live in
+//! **four** different stores in **three** different encodings:
+//!
+//! | Principal            | Table                            | Column            | Encoding |
+//! |----------------------|----------------------------------|-------------------|----------|
+//! | Node (attestation)   | `nodes`                          | `ak_public_pem`   | SPKI PEM |
+//! | Federation controller| `trusted_federation_controllers` | `public_key_b64`  | raw b64  |
+//! | Operator             | `operators`                      | `pubkey_pem`      | SPKI PEM |
+//! | Fleet-grant signer   | `trusted_federation_controllers` | `public_key_b64`  | raw b64  |
+//!
+//! Before this, every verification site re-implemented the load + the decode, and
+//! the fleet crate verified against a **caller-supplied** `public_key_b64: &str` —
+//! the caller decided which key to trust per call. [`KeyRegistry`] is an **additive
+//! wrapper** over [`VerifierStore`] that unifies the lookup behind one API,
+//! [`KeyRegistry::resolve_ed25519_pubkey`], which returns the **raw 32-byte** key
+//! normalized from whatever encoding the table holds. Fleet verification now grounds
+//! trust in a *stored registration*, not a string the caller passed in.
+//!
+//! Decision + rationale: `docs/adr/0008-key-registry.md` (ADR-0008).
+//!
+//! ## Named residuals (ADR-0008, honest limits)
+//! - **The audit signing key is NOT in this registry.** It is an in-memory
+//!   `SigningKey` on the store (no rotation, no persisted public entry); resolving it
+//!   here would be a lie. Documented as a residual, not silently omitted.
+//! - **Encoding migration is deferred.** This normalizes at the *read* boundary
+//!   (PEM/b64 → bytes); it does NOT rewrite the stores to one on-disk format. One
+//!   abstraction now; one on-disk encoding is named future work.
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use ed25519_dalek::{Signature, VerifyingKey};
+use rusqlite::Result;
+
+use crate::verifier_store::VerifierStore;
+
+/// Which principal store a key is resolved from. The role names the *intent* of the
+/// lookup; `FederationController` and `FleetGrant` resolve from the SAME table (the
+/// trusted-controller registry) — the registry is the single lookup, the role
+/// disambiguates the caller's purpose at the call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyRole {
+    /// `ak_public_pem` from the `nodes` table (node attestation identity).
+    NodeAttestation,
+    /// `public_key_b64` from `trusted_federation_controllers`.
+    FederationController,
+    /// `pubkey_pem` from the `operators` table. A revoked operator resolves to
+    /// `None` (treated as unknown).
+    Operator,
+    /// `public_key_b64` from `trusted_federation_controllers` — the same registry as
+    /// [`KeyRole::FederationController`]; the role marks fleet-grant intent.
+    FleetGrant,
+}
+
+/// A read-only unified view over the four key stores, wrapping a [`VerifierStore`].
+/// Borrows the store immutably for its lifetime.
+pub struct KeyRegistry<'a> {
+    store: &'a VerifierStore,
+}
+
+impl<'a> KeyRegistry<'a> {
+    #[must_use]
+    pub fn new(store: &'a VerifierStore) -> KeyRegistry<'a> {
+        KeyRegistry { store }
+    }
+
+    /// Resolve a principal's Ed25519 public key to its **raw 32 bytes**, normalized
+    /// from whatever encoding the backing table uses. Returns `Ok(None)` for an
+    /// unknown principal, a revoked operator, a malformed/wrong-length stored key, or
+    /// a principal with no registered key — every "cannot resolve" is a `None`, never
+    /// a trusted default. `Err` is reserved for an actual store (SQL) failure.
+    pub fn resolve_ed25519_pubkey(
+        &self,
+        principal_id: &str,
+        role: KeyRole,
+    ) -> Result<Option<[u8; 32]>> {
+        let bytes = match role {
+            KeyRole::NodeAttestation => self
+                .store
+                .load_node(principal_id)?
+                .and_then(|n| n.ak_public_pem)
+                .and_then(|pem| pem_to_key_bytes(&pem)),
+            KeyRole::FederationController | KeyRole::FleetGrant => self
+                .store
+                .load_trusted_federation_controller_key(principal_id)?
+                .and_then(|b64| b64_to_key_bytes(&b64)),
+            KeyRole::Operator => match self.store.load_operator(principal_id)? {
+                // A revoked operator is treated as unknown — None, never a key.
+                Some(op) if op.revoked_at_ms.is_none() => pem_to_key_bytes(&op.pubkey_pem),
+                _ => None,
+            },
+        };
+        Ok(bytes)
+    }
+
+    /// Verify an Ed25519 `signature_b64` over `payload` for `principal_id` in one
+    /// call. **Fail-closed:** an unknown principal, a store error, a malformed key,
+    /// or a malformed/bad signature all return `false` — never an `Err` a caller
+    /// might ignore into an accept. Uses `verify_strict` (the attestation path).
+    #[must_use]
+    pub fn verify_for(
+        &self,
+        principal_id: &str,
+        role: KeyRole,
+        payload: &[u8],
+        signature_b64: &str,
+    ) -> bool {
+        let Ok(Some(key_bytes)) = self.resolve_ed25519_pubkey(principal_id, role) else {
+            return false;
+        };
+        let Ok(vk) = VerifyingKey::from_bytes(&key_bytes) else { return false };
+        let Ok(sig_raw) = B64.decode(signature_b64.trim()) else { return false };
+        let Ok(sig_arr) = <[u8; 64]>::try_from(sig_raw.as_slice()) else { return false };
+        vk.verify_strict(payload, &Signature::from_bytes(&sig_arr)).is_ok()
+    }
+}
+
+/// SPKI PEM → raw 32-byte Ed25519 key, via the existing, tested SPKI parser
+/// ([`crate::attestation::parse_ed25519_public_pem`]) — NOT a hand-rolled offset.
+/// `None` on any malformed PEM.
+fn pem_to_key_bytes(pem: &str) -> Option<[u8; 32]> {
+    crate::attestation::parse_ed25519_public_pem(pem).map(|vk| vk.to_bytes())
+}
+
+/// base64 raw key → 32 bytes. A wrong-length or undecodable key is rejected with a
+/// logged warning and `None` — never a panic, never a truncated/padded key.
+fn b64_to_key_bytes(b64: &str) -> Option<[u8; 32]> {
+    let raw = match B64.decode(b64.trim()) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "key_registry: stored base64 key failed to decode — rejected");
+            return None;
+        }
+    };
+    match <[u8; 32]>::try_from(raw.as_slice()) {
+        Ok(k) => Some(k),
+        Err(_) => {
+            tracing::warn!(len = raw.len(), "key_registry: stored key is not 32 bytes — rejected");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::verifier::{NodeTrustState, RegisteredNode};
+    use ed25519_dalek::{Signer, SigningKey};
+
+    /// A deterministic keypair + its SPKI PEM (the in-repo RFC-8410 12-byte prefix
+    /// convention) — derived from a seed, NOT a hardcoded key.
+    fn keypair(seed: u8) -> (SigningKey, String, String) {
+        const ED25519_SPKI_PREFIX: [u8; 12] =
+            [0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00];
+        let sk = SigningKey::from_bytes(&[seed; 32]);
+        let raw = sk.verifying_key().to_bytes();
+        let mut der = ED25519_SPKI_PREFIX.to_vec();
+        der.extend_from_slice(&raw);
+        let pem = format!(
+            "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----\n",
+            B64.encode(&der)
+        );
+        let raw_b64 = B64.encode(raw);
+        (sk, pem, raw_b64)
+    }
+
+    fn store() -> VerifierStore {
+        VerifierStore::new(":memory:").expect("in-memory store")
+    }
+
+    fn save_node_with_pem(store: &VerifierStore, node_id: &str, pem: Option<String>) {
+        store
+            .save_node(&RegisteredNode {
+                node_id: node_id.to_string(),
+                status: NodeTrustState::Trusted,
+                registered_at_ms: 1,
+                last_trust_update_ms: 1,
+                ak_public_pem: pem,
+                expected_pcr16_digest_hex: None,
+            })
+            .expect("save node");
+    }
+
+    #[test]
+    fn pem_node_key_resolves_to_correct_32_bytes() {
+        let (sk, pem, _b64) = keypair(7);
+        let store = store();
+        save_node_with_pem(&store, "robot-01", Some(pem));
+        let reg = KeyRegistry::new(&store);
+        let got = reg.resolve_ed25519_pubkey("robot-01", KeyRole::NodeAttestation).unwrap();
+        assert_eq!(got, Some(sk.verifying_key().to_bytes()), "PEM node key → the exact 32 bytes");
+    }
+
+    #[test]
+    fn b64_and_pem_paths_agree_encoding_parity() {
+        // The SAME key registered as a federation controller (raw b64) and as a node
+        // (SPKI PEM) must resolve to the SAME 32 bytes — the normalization is parity.
+        let (sk, pem, raw_b64) = keypair(9);
+        let store = store();
+        save_node_with_pem(&store, "node-A", Some(pem));
+        store.save_trusted_federation_controller("ctrl-A", &raw_b64, 1).unwrap();
+        let reg = KeyRegistry::new(&store);
+        let via_pem = reg.resolve_ed25519_pubkey("node-A", KeyRole::NodeAttestation).unwrap();
+        let via_b64 = reg.resolve_ed25519_pubkey("ctrl-A", KeyRole::FederationController).unwrap();
+        assert_eq!(via_pem, Some(sk.verifying_key().to_bytes()));
+        assert_eq!(via_pem, via_b64, "PEM and b64 paths normalize to identical bytes");
+        // FleetGrant resolves from the same controller registry.
+        let via_fleet = reg.resolve_ed25519_pubkey("ctrl-A", KeyRole::FleetGrant).unwrap();
+        assert_eq!(via_fleet, via_b64, "FleetGrant shares the controller registry");
+    }
+
+    #[test]
+    fn unknown_principal_is_none_not_error() {
+        let store = store();
+        let reg = KeyRegistry::new(&store);
+        assert_eq!(reg.resolve_ed25519_pubkey("ghost", KeyRole::NodeAttestation).unwrap(), None);
+        assert_eq!(reg.resolve_ed25519_pubkey("ghost", KeyRole::FederationController).unwrap(), None);
+        assert_eq!(reg.resolve_ed25519_pubkey("ghost", KeyRole::Operator).unwrap(), None);
+    }
+
+    #[test]
+    fn revoked_operator_resolves_to_none() {
+        let (_sk, pem, _b64) = keypair(3);
+        let mut store = store();
+        store.register_operator("alice", &pem, 1).unwrap();
+        let reg = KeyRegistry::new(&store);
+        assert!(reg.resolve_ed25519_pubkey("alice", KeyRole::Operator).unwrap().is_some(), "active resolves");
+        // Revoke, then it must read as unknown.
+        store.revoke_operator("alice", 2).unwrap();
+        let reg = KeyRegistry::new(&store);
+        assert_eq!(
+            reg.resolve_ed25519_pubkey("alice", KeyRole::Operator).unwrap(),
+            None,
+            "a revoked operator resolves to None (treated as unknown)"
+        );
+    }
+
+    #[test]
+    fn verify_for_good_bad_and_unknown() {
+        let (sk, pem, _b64) = keypair(5);
+        let store = store();
+        save_node_with_pem(&store, "robot-02", Some(pem));
+        let reg = KeyRegistry::new(&store);
+
+        let payload = b"attestation-challenge-bytes";
+        let good = B64.encode(sk.sign(payload).to_bytes());
+        assert!(reg.verify_for("robot-02", KeyRole::NodeAttestation, payload, &good), "valid sig → true");
+
+        // Tampered payload → bad signature.
+        assert!(!reg.verify_for("robot-02", KeyRole::NodeAttestation, b"different", &good), "bad sig → false");
+
+        // Unknown principal → false (fail-closed), never an ignored error.
+        assert!(!reg.verify_for("ghost", KeyRole::NodeAttestation, payload, &good), "unknown → false");
+
+        // Malformed signature base64 → false.
+        assert!(!reg.verify_for("robot-02", KeyRole::NodeAttestation, payload, "!!notb64"), "malformed sig → false");
+    }
+
+    #[test]
+    fn wrong_length_b64_key_is_none_no_panic() {
+        let store = store();
+        // 16 bytes, not 32 — a structurally invalid Ed25519 key.
+        store.save_trusted_federation_controller("ctrl-bad", &B64.encode([0u8; 16]), 1).unwrap();
+        let reg = KeyRegistry::new(&store);
+        assert_eq!(
+            reg.resolve_ed25519_pubkey("ctrl-bad", KeyRole::FederationController).unwrap(),
+            None,
+            "a wrong-length stored key is rejected (None), not a panic"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod startup_sentinel;
 pub mod attestation;
 pub mod verifier;
 pub mod verifier_store;
+pub mod key_registry;
 pub mod posture_cache;
 pub mod posture_engine;
 pub mod posture_engine_v2;

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -1061,6 +1061,35 @@ impl VerifierStore {
         rows.collect()
     }
 
+    /// Load a single registered node by id, or `None` if unregistered. Additive
+    /// single-row loader (mirrors [`load_operator`] / `load_trusted_federation_controller_key`)
+    /// — the targeted lookup [`crate::key_registry::KeyRegistry`] uses to resolve a
+    /// node's `ak_public_pem` without scanning the whole registry.
+    pub fn load_node(&self, node_id: &str) -> Result<Option<RegisteredNode>> {
+        use rusqlite::OptionalExtension;
+        self.conn
+            .query_row(
+                "SELECT node_id, status_json, registered_at_ms, last_trust_update_ms,
+                        ak_public_pem, expected_pcr16_digest_hex
+                 FROM nodes WHERE node_id = ?1",
+                params![node_id],
+                |row| {
+                    let status_json: String = row.get(1)?;
+                    let status: NodeTrustState =
+                        serde_json::from_str(&status_json).unwrap_or(NodeTrustState::Unknown);
+                    Ok(RegisteredNode {
+                        node_id: row.get(0)?,
+                        status,
+                        registered_at_ms: row.get::<_, i64>(2)? as u64,
+                        last_trust_update_ms: row.get::<_, i64>(3)? as u64,
+                        ak_public_pem: row.get(4)?,
+                        expected_pcr16_digest_hex: row.get(5)?,
+                    })
+                },
+            )
+            .optional()
+    }
+
     pub fn save_dependencies(&self, node_id: &str, deps: &[String]) -> Result<()> {
         self.conn.execute(
             "DELETE FROM dependencies WHERE node_id = ?1",


### PR DESCRIPTION
ARCH GAP #329 (review register #319, gap 2). An **additive wrapper**: no table schema changes, no encoding migration, no breaking API changes, no existing API removal. Decision: **ADR-0008** (`docs/adr/0008-key-registry.md`).

## The gap
Trust is grounded in Ed25519 keys, but they live in **four** stores in **three** encodings, each with ad-hoc load + decode per verify site — and the fleet crate verified against a **caller-supplied `public_key_b64: &str`**: the caller decided *which* key to trust on each call. An authentic signature over the wrong key is still the wrong principal.

## The fix — `src/key_registry.rs`
```rust
pub enum KeyRole { NodeAttestation, FederationController, Operator, FleetGrant }
pub struct KeyRegistry<'a> { /* &VerifierStore */ }
fn resolve_ed25519_pubkey(&self, principal_id, role) -> Result<Option<[u8;32]>>;
fn verify_for(&self, principal_id, role, payload, signature_b64) -> bool;
```
- **One normalized output (raw 32 bytes).** PEM → bytes reuses the existing tested SPKI parser (`attestation::parse_ed25519_public_pem`), not a hand-rolled offset; b64 → bytes requires **exactly 32** (wrong-length rejected + logged, never a panic). Four tables, three encodings in, one out.
- **Fail-closed.** Unknown principal / **revoked operator** (`revoked_at_ms IS NULL`) / absent / malformed key → `Ok(None)`; `verify_for` collapses all of those + a bad signature to `false`. `Err` only for an actual SQL failure.
- `FederationController` and `FleetGrant` resolve from the same trusted-controller registry — the role names the caller's intent.

Reuses the existing single-row loaders + one **additive** `VerifierStore::load_node` (mirrors `load_operator` / `load_trusted_federation_controller_key`).

## Fleet adoption — the trust-grounding fix
`accept_report_from_registry` and `ingest_clearance_grant_from_registry` resolve the verifying key **from a stored registration** keyed by `principal_id`, instead of a caller string. The original `&str` variants **stay** (backward compat + test/spike); the registry variants are the **fleet-deployment** path.

> The ingest variant takes `principal_id` (not `&KeyRegistry`) on purpose: the registry borrows the store immutably while `ingest_clearance_grant` needs it mutably (it burns the replay nonce + writes the row). The key is resolved in a scoped immutable borrow that ends *before* the mutating path — the two cannot coexist on one store.

## Named residuals (ADR-0008, honest limits)
- **The audit signing key is NOT in the registry** — in-memory `SigningKey`, no rotation, no persisted public entry; resolving it here would be a lie. Documented, not omitted.
- **Encoding migration is deferred** — normalization is at the read boundary; the stores are not rewritten to one on-disk format. Named future work.

## Verification
- `KeyRegistry` tests: PEM resolves to correct 32 bytes; **b64/PEM encoding parity** (same key, both paths → identical bytes); unknown → None; **revoked operator → None**; `verify_for` good/bad/unknown; **wrong-length → None, no panic**.
- `e2e_fleet_ingest_via_registry` (fleet crate — parko-kirra can't see the fleet crate, so it lives where the variant does): register a controller key → sign a grant → ingest via the registry variant → assert the PENDING row Phase-B consumes; an unregistered signer is fail-closed.
- Root workspace **green**, `cargo clippy --all-targets` **clean**, talisman `997fb7ae…` **byte-identical** (untouched).

Refs #319, ADR-0008. Closes #329 (Phase A — registry abstraction + fleet adoption; named residuals tracked).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_