### PR TITLE
feat(keyring): resolve the audit signing key read-only via the registry (#329 residual, Phase A.1)

### DIFF
--- a/docs/adr/0008-key-registry.md
+++ b/docs/adr/0008-key-registry.md
@@ -109,10 +109,14 @@ no migration risk: the stores are untouched, only the read path is unified.
 
 ## Honest limits (named, not built)
 
-- **The audit signing key is NOT in this registry.** It is an in-memory `SigningKey`
-  on the store — no rotation, no persisted public entry. Resolving it through a registry
-  of *stored* keys would be a lie; it is a **named residual**, documented in the module,
-  not silently omitted.
+- **The audit signing key is resolvable READ-ONLY (Phase A.1, #329 residual).** The
+  `AuditSigning` role resolves the chain's verifying key from the store's in-memory
+  signer, keyed by the key's `verifying_key_id` fingerprint (the same id the audit
+  chain stamps in `key_id`), so a chain row's `key_id` resolves to a key through the
+  registry. **Still deferred:** rotation + a persisted key *history* — the registry
+  knows only the ONE current in-memory key, so any other fingerprint is `None`, and a
+  key rotated away cannot be resolved to verify its historical rows. That wider change
+  touches the store schema + the chain trust model (see *Conditions that reopen*).
 - **Encoding migration is deferred.** Phase A normalizes at the read boundary; it does
   **not** rewrite the stores to a single on-disk format. One abstraction now; one
   on-disk encoding is named future work.

--- a/src/key_registry.rs
+++ b/src/key_registry.rs
@@ -9,6 +9,7 @@
 //! | Federation controller| `trusted_federation_controllers` | `public_key_b64`  | raw b64  |
 //! | Operator             | `operators`                      | `pubkey_pem`      | SPKI PEM |
 //! | Fleet-grant signer   | `trusted_federation_controllers` | `public_key_b64`  | raw b64  |
+//! | Audit signer         | in-memory `SigningKey` (store)   | —                 | raw bytes|
 //!
 //! Before this, every verification site re-implemented the load + the decode, and
 //! the fleet crate verified against a **caller-supplied** `public_key_b64: &str` —
@@ -21,9 +22,13 @@
 //! Decision + rationale: `docs/adr/0008-key-registry.md` (ADR-0008).
 //!
 //! ## Named residuals (ADR-0008, honest limits)
-//! - **The audit signing key is NOT in this registry.** It is an in-memory
-//!   `SigningKey` on the store (no rotation, no persisted public entry); resolving it
-//!   here would be a lie. Documented as a residual, not silently omitted.
+//! - **The audit signing key is resolvable READ-ONLY (#329 residual, Phase A.1).**
+//!   [`KeyRole::AuditSigning`] resolves the chain's verifying key from the store's
+//!   in-memory signer, keyed by the key's `verifying_key_id` fingerprint (the same id
+//!   the audit chain stamps in its `key_id` column) — so a chain row's `key_id` can be
+//!   resolved to a key through the registry. **Rotation + persisted key history remain
+//!   deferred:** the registry knows only the ONE current in-memory key, so a request
+//!   for any fingerprint other than the live signer's is `None`.
 //! - **Encoding migration is deferred.** This normalizes at the *read* boundary
 //!   (PEM/b64 → bytes); it does NOT rewrite the stores to one on-disk format. One
 //!   abstraction now; one on-disk encoding is named future work.
@@ -50,6 +55,11 @@ pub enum KeyRole {
     /// `public_key_b64` from `trusted_federation_controllers` — the same registry as
     /// [`KeyRole::FederationController`]; the role marks fleet-grant intent.
     FleetGrant,
+    /// The store's in-memory audit signing key (read-only, #329 residual). The
+    /// `principal_id` is the key's `verifying_key_id` fingerprint (as stamped in the
+    /// audit chain's `key_id`); resolves ONLY the single live signer — there is no
+    /// rotation/history, so any other fingerprint is `None`.
+    AuditSigning,
 }
 
 /// A read-only unified view over the four key stores, wrapping a [`VerifierStore`].
@@ -89,6 +99,15 @@ impl<'a> KeyRegistry<'a> {
                 Some(op) if op.revoked_at_ms.is_none() => pem_to_key_bytes(&op.pubkey_pem),
                 _ => None,
             },
+            KeyRole::AuditSigning => self.store.audit_verifying_key().and_then(|vk| {
+                // Resolve ONLY when the requested fingerprint matches the live signer
+                // (no key history) — fail-closed for any other id.
+                if crate::audit_chain::verifying_key_id(&vk) == principal_id {
+                    Some(vk.to_bytes())
+                } else {
+                    None
+                }
+            }),
         };
         Ok(bytes)
     }
@@ -267,5 +286,45 @@ mod tests {
             None,
             "a wrong-length stored key is rejected (None), not a panic"
         );
+    }
+
+    #[test]
+    fn audit_signing_key_resolves_readonly_by_fingerprint() {
+        let (sk, _pem, _b64) = keypair(11);
+        let mut store = store();
+
+        // No signer installed → None for any fingerprint (fail-closed).
+        {
+            let reg = KeyRegistry::new(&store);
+            assert_eq!(
+                reg.resolve_ed25519_pubkey("anything", KeyRole::AuditSigning).unwrap(),
+                None,
+                "no audit signer installed → None"
+            );
+        }
+
+        let vk = sk.verifying_key();
+        let fp = crate::audit_chain::verifying_key_id(&vk);
+        store.set_signing_key(sk.clone());
+        let reg = KeyRegistry::new(&store);
+
+        // The live audit key resolves by its verifying_key_id (the chain's key_id).
+        assert_eq!(
+            reg.resolve_ed25519_pubkey(&fp, KeyRole::AuditSigning).unwrap(),
+            Some(vk.to_bytes()),
+            "the live audit key resolves by its verifying_key_id"
+        );
+        // Any other fingerprint → None (no rotation / no key history — the residual).
+        assert_eq!(
+            reg.resolve_ed25519_pubkey("deadbeef", KeyRole::AuditSigning).unwrap(),
+            None,
+            "only the single live signer resolves — rotation/history still deferred"
+        );
+
+        // verify_for over the audit key: good sig true; wrong fingerprint false.
+        let payload = b"a-signed-audit-event";
+        let sig = B64.encode(sk.sign(payload).to_bytes());
+        assert!(reg.verify_for(&fp, KeyRole::AuditSigning, payload, &sig), "audit-key signature verifies");
+        assert!(!reg.verify_for("wrong-fp", KeyRole::AuditSigning, payload, &sig), "wrong fingerprint → false");
     }
 }

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -656,6 +656,15 @@ impl VerifierStore {
         self.signing_key = Some(key);
     }
 
+    /// The PUBLIC half of the in-memory audit signing key, or `None` if no key is
+    /// installed. Read-only exposure (#329 residual): lets the
+    /// [`crate::key_registry::KeyRegistry`] resolve the chain's verifying key through
+    /// the unified registry. There is exactly ONE audit signer and it is volatile
+    /// (no rotation, no persisted history) — that wider residual is still deferred.
+    pub fn audit_verifying_key(&self) -> Option<ed25519_dalek::VerifyingKey> {
+        self.signing_key.as_ref().map(|sk| sk.verifying_key())
+    }
+
     /// TEST-ONLY tamper seam (SG-010): hands a test the raw rusqlite connection
     /// so it can mutate a previously-written `audit_log_chain` row out of band —
     /// exactly what a tamperer with disk access would do. Used to prove


### PR DESCRIPTION
Phase A.1 of the #329 residuals — the **read-only** slice you selected. Additive: **no schema change, no chain-format change, no rotation**. The two heavier residuals (audit-key rotation + persisted history; on-disk encoding migration) remain deferred and named.

## What it does
Before this, the audit signing key — the root of the tamper-evident ledger — was the one principal the unified `KeyRegistry` (#337) could *not* resolve, because it's an in-memory `SigningKey` on the store, not a stored row. This completes the registry's read coverage:

- **`VerifierStore::audit_verifying_key() -> Option<VerifyingKey>`** — read-only exposure of the public half of the in-memory signer.
- **`KeyRole::AuditSigning`** — `resolve_ed25519_pubkey` resolves the chain's verifying key keyed by the key's **`verifying_key_id` fingerprint** (the exact id the audit chain already stamps in its `key_id` column). So a chain row's `key_id` now resolves to a key *through the registry* — the natural verify path.

**Fail-closed:** no signer installed, or any fingerprint other than the single live signer's, → `None`. The registry holds no key history, so a key rotated away cannot be resolved — that's the deferred part, called out explicitly.

## Still deferred (named in ADR-0008)
- **Rotation + persisted key history** — touches the store schema *and* the chain trust model (verifying historical rows across rotations). ADR-worthy; in *Conditions that reopen this decision*.
- **On-disk encoding migration** — normalization stays at the read boundary.

## Verification
`KeyRegistry` tests (now 7): no-signer → None; the live key resolves by its fingerprint → exact 32 bytes; a different fingerprint → None; `verify_for` over the audit key good/bad. Root workspace **green**, clippy **clean**, talisman `997fb7ae…` **byte-identical**.

Refs #319, #337, ADR-0008. Advances #329 (Phase A.1).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_