### PR TITLE
chore: QNX cargo targets + gitignore artifacts + remove unused EgoOdom import (#206 build fix)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,10 @@
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+
+[target.x86_64-pc-nto-qnx800]
+linker = "qcc"
+rustflags = ["-C", "link-args=-Vgcc_ntox86_64"]
+
+[target.aarch64-unknown-nto-qnx800]
+linker = "qcc"
+rustflags = ["-C", "link-args=-Vgcc_ntoaarch64le"]

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@ mutants.out/
 ros2_ws/build/
 ros2_ws/install/
 ros2_ws/log/
+
+# local bootstrap scripts + SQLite verifier stores
+occy_bootstrap.sh
+occy_standards.sh
+*.sqlite
+*.sqlite-shm
+*.sqlite-wal

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -40,7 +40,7 @@ use tokio::sync::mpsc;
 
 use crate::corridor::CorridorSource;
 use crate::state::{
-    AdaptorState, EgoOdom, TrajectoryPoint, TrajectoryVerdict,
+    AdaptorState, TrajectoryPoint, TrajectoryVerdict,
     SUBSCRIPTION_STALENESS_TIMEOUT_MS,
 };
 use crate::validation::{


### PR DESCRIPTION
## What
Three housekeeping changes from the June 2026 QNX hardware session:

**`.cargo/config.toml`** — QNX cross-compile targets for the hardware day:
- `x86_64-pc-nto-qnx800` (linker=qcc, -Vgcc_ntox86_64) — laptop/VM target
- `aarch64-unknown-nto-qnx800` (linker=qcc, -Vgcc_ntoaarch64le) — Jetson Orin NX target (ready for when the hardware arrives)

**`.gitignore`** — exclude demo artifacts and session scripts: `*.sqlite`, `*.sqlite-shm`, `*.sqlite-wal`, `occy_bootstrap.sh`, `occy_standards.sh`

**`crates/kirra-ros2-adapter/src/node.rs`** — remove unused `EgoOdom` import (the warning that was blocking the `--features ros2` build).

## Build result (bench — Ubuntu 24.04 Jazzy, June 2026)
`cargo build -p kirra-ros2-adapter --features ros2` → Finished, zero warnings, zero errors (Autoware message workspace sourced).

## Verification
Diff = exactly 3 files. Talisman 997fb7ae15ce3e11adec9218044c7c84b049ad3b byte-identical.

Relates to #206.