### PR TITLE
Add Kirra marketing site + GitHub Pages deploy (kirrasystems.com)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,45 @@
+name: Deploy website to GitHub Pages
+
+# Publishes the static site in website/ to GitHub Pages on every push to main
+# that touches the site (or on manual dispatch).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; newer pushes supersede in-flight ones.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Enables Pages (build type = GitHub Actions) if not already enabled.
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/CNAME
+++ b/website/CNAME
@@ -1,0 +1,1 @@
+kirrasystems.com

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,52 @@
+# Kirra SDK — Marketing Site
+
+An Awwwards-style landing page for the Kirra Runtime SDK, built with
+**Three.js** (a live WebGL "trust lattice") and **GSAP** (scroll
+choreography + micro-interactions).
+
+## What's inside
+
+| File | Role |
+|------|------|
+| `index.html` | Page structure + content (all copy grounded in the real SDK) |
+| `css/style.css` | Design system, posture-driven palette, layout, components |
+| `js/scene.js` | Three.js module — the trust-lattice fleet graph + bloom |
+| `js/main.js` | GSAP — preloader, cursor, magnetic UI, scroll reveals, posture pin |
+
+## Signature interactions
+
+- **Trust Lattice** — a 3D fleet dependency graph (170 nodes, nearest-neighbour
+  edges, traveling "trust packets") rendered with `UnrealBloomPass` for the neon glow.
+  It reacts to the pointer (parallax) and rotates continuously.
+- **Posture-driven colour** — the pinned **Posture** section scrubs the lattice
+  through Kirra's three real states as you scroll:
+  `Nominal` (green) → `Degraded` (amber) → `LockedOut` (red), with rising agitation.
+- **Preloader** that completes only once the WebGL scene is ready (with a 6s safety net).
+- Custom cursor, magnetic buttons, kinetic hero reveal, manifesto word-sweep,
+  animated stat counters, copy-to-clipboard install command.
+
+## Running it
+
+It's fully static — serve the folder with anything:
+
+```bash
+cd website
+python3 -m http.server 8077
+# open http://localhost:8077
+```
+
+## Dependencies (loaded from CDN at runtime)
+
+- `three@0.160.0` + addons (`EffectComposer`, `RenderPass`, `UnrealBloomPass`, `OutputPass`)
+  via an `importmap` from unpkg.
+- `gsap@3.12.5` + `ScrollTrigger` via cdnjs.
+
+> An internet connection is required on first load to fetch these from CDN.
+> To ship fully offline, vendor the two libraries into `website/vendor/` and
+> repoint the `<script>`/`importmap` URLs.
+
+## Accessibility / resilience
+
+- Respects `prefers-reduced-motion` — animations collapse to a static, readable page.
+- If WebGL is unavailable the lattice silently no-ops; the site still renders.
+- If GSAP fails to load, content is shown un-animated rather than hidden.

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -1,0 +1,282 @@
+/* ============================================================
+   KIRRA — award-style landing
+   Palette is posture-driven: green=trusted, amber=degraded, red=lockedout
+   ============================================================ */
+
+:root {
+  --bg:        #04060c;
+  --bg-2:      #070b15;
+  --bg-glass:  rgba(10, 14, 26, 0.55);
+  --ink:       #eef2fb;
+  --ink-soft:  #aab4cc;
+  --ink-mute:  #6a7593;
+  --line:      rgba(140, 160, 200, 0.12);
+
+  --cyan:   #5cf0ff;
+  --green:  #34f5a6;   /* Nominal  */
+  --amber:  #ffb627;   /* Degraded */
+  --red:    #ff4d63;   /* LockedOut */
+
+  --accent: var(--green);
+  --glow:   0 0 40px rgba(52, 245, 166, 0.35);
+
+  --font-display: 'Space Grotesk', system-ui, sans-serif;
+  --font-body:    'Inter', system-ui, sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, monospace;
+
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --maxw: 1280px;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; }
+
+body {
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.55;
+  overflow-x: hidden;
+  cursor: none;
+}
+
+@media (max-width: 860px) { body { cursor: auto; } }
+
+a { color: inherit; text-decoration: none; }
+::selection { background: var(--accent); color: #02040a; }
+
+/* ───────── WebGL canvas ───────── */
+.lattice-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 0;
+  pointer-events: none;
+}
+
+/* ───────── Grain ───────── */
+.grain {
+  position: fixed; inset: -50%;
+  z-index: 2; pointer-events: none; opacity: 0.04;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  animation: grain 6s steps(6) infinite;
+}
+@keyframes grain {
+  0%,100% { transform: translate(0,0); }
+  20% { transform: translate(-4%, 3%); }
+  40% { transform: translate(3%, -5%); }
+  60% { transform: translate(-2%, 4%); }
+  80% { transform: translate(5%, 2%); }
+}
+
+/* ───────── Scroll progress ───────── */
+.scroll-progress {
+  position: fixed; top: 0; left: 0; right: 0; height: 2px;
+  z-index: 60; background: transparent;
+}
+.scroll-progress span {
+  display: block; height: 100%; width: 0%;
+  background: linear-gradient(90deg, var(--green), var(--cyan));
+  box-shadow: 0 0 12px var(--accent);
+  transition: background 0.6s var(--ease);
+}
+
+/* ───────── Custom cursor ───────── */
+.cursor, .cursor-dot { position: fixed; top: 0; left: 0; z-index: 70; pointer-events: none; border-radius: 50%; mix-blend-mode: difference; }
+.cursor { width: 34px; height: 34px; border: 1px solid rgba(255,255,255,0.7); transform: translate(-50%,-50%); transition: width .25s var(--ease), height .25s var(--ease), background .25s; }
+.cursor-dot { width: 5px; height: 5px; background: #fff; transform: translate(-50%,-50%); }
+.cursor.is-hover { width: 56px; height: 56px; background: rgba(255,255,255,0.1); }
+@media (max-width: 860px) { .cursor, .cursor-dot { display: none; } }
+
+/* ───────── Preloader ───────── */
+.preloader {
+  position: fixed; inset: 0; z-index: 100;
+  background: var(--bg);
+  display: flex; align-items: center; justify-content: center;
+}
+.preloader__inner { width: min(420px, 80vw); text-align: center; }
+.preloader__mark { position: relative; width: 90px; height: 90px; margin: 0 auto 34px; display: grid; place-items: center; }
+.preloader__glyph { font-family: var(--font-display); font-weight: 700; font-size: 42px; color: var(--ink); letter-spacing: -2px; }
+.preloader__ring {
+  position: absolute; inset: 0; border-radius: 50%;
+  border: 1.5px solid var(--line); border-top-color: var(--green);
+  animation: spin 1s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+.preloader__bar { height: 2px; background: var(--line); border-radius: 2px; overflow: hidden; }
+.preloader__bar span { display: block; height: 100%; width: 0%; background: linear-gradient(90deg, var(--green), var(--cyan)); }
+.preloader__meta { display: flex; justify-content: space-between; margin-top: 14px; font-family: var(--font-mono); font-size: 11px; letter-spacing: 1px; color: var(--ink-mute); }
+.preloader__pct { color: var(--green); }
+.preloader.is-done { transform: translateY(-100%); transition: transform 1s var(--ease); }
+
+/* ───────── Nav ───────── */
+.nav {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 50;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 22px clamp(20px, 5vw, 56px);
+  transition: backdrop-filter .4s, background .4s, padding .4s var(--ease);
+}
+.nav.is-stuck { background: var(--bg-glass); backdrop-filter: blur(14px); padding-top: 14px; padding-bottom: 14px; border-bottom: 1px solid var(--line); }
+.nav__brand { display: flex; align-items: center; gap: 10px; font-family: var(--font-display); font-weight: 700; letter-spacing: 3px; font-size: 15px; }
+.nav__logo { color: var(--green); font-size: 18px; }
+.nav__links { display: flex; gap: 30px; font-size: 14px; color: var(--ink-soft); }
+.nav__links a { position: relative; }
+.nav__links a::after { content: ''; position: absolute; left: 0; bottom: -5px; width: 0; height: 1px; background: var(--accent); transition: width .35s var(--ease); }
+.nav__links a:hover { color: var(--ink); }
+.nav__links a:hover::after { width: 100%; }
+.nav__cta { display: inline-flex; align-items: center; gap: 7px; font-size: 13px; font-weight: 600; padding: 9px 16px; border: 1px solid var(--line); border-radius: 100px; transition: border-color .3s, background .3s; }
+.nav__cta:hover { border-color: var(--accent); background: rgba(52,245,166,0.06); }
+.nav__cta-arrow { color: var(--accent); }
+@media (max-width: 860px) { .nav__links { display: none; } }
+
+/* ───────── Layout helpers ───────── */
+section { position: relative; z-index: 3; }
+.section-tag { display: inline-block; font-family: var(--font-mono); font-size: 11px; letter-spacing: 3px; color: var(--green); padding: 6px 12px; border: 1px solid rgba(52,245,166,0.25); border-radius: 100px; margin-bottom: 24px; }
+.accent { color: var(--accent); }
+
+/* ───────── Hero ───────── */
+.hero {
+  min-height: 100vh;
+  display: flex; flex-direction: column; justify-content: center;
+  padding: 0 clamp(20px, 5vw, 56px);
+  max-width: var(--maxw); margin: 0 auto;
+}
+.hero__eyebrow { display: inline-flex; align-items: center; gap: 10px; font-family: var(--font-mono); font-size: 12px; letter-spacing: 2px; color: var(--ink-soft); margin-bottom: 28px; }
+.dot { width: 7px; height: 7px; border-radius: 50%; background: var(--green); }
+.dot--live { box-shadow: 0 0 0 0 rgba(52,245,166,0.6); animation: pulse 2s infinite; }
+@keyframes pulse { 0%{box-shadow:0 0 0 0 rgba(52,245,166,.6);} 70%{box-shadow:0 0 0 9px rgba(52,245,166,0);} 100%{box-shadow:0 0 0 0 rgba(52,245,166,0);} }
+
+.hero__title {
+  font-family: var(--font-display); font-weight: 700;
+  font-size: clamp(2.6rem, 8.5vw, 7.5rem);
+  line-height: 0.96; letter-spacing: -0.03em;
+  margin-bottom: 30px;
+}
+.hero__title .line { display: block; overflow: hidden; }
+.hero__title .word { display: inline-block; }
+.hero__title .accent { color: var(--accent); }
+
+.hero__lede { max-width: 620px; font-size: clamp(1rem, 1.6vw, 1.25rem); color: var(--ink-soft); margin-bottom: 36px; }
+.hero__lede em { color: var(--ink); font-style: italic; }
+.hero__actions { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 56px; }
+
+.btn { position: relative; display: inline-flex; align-items: center; gap: 8px; padding: 15px 28px; border-radius: 100px; font-weight: 600; font-size: 15px; overflow: hidden; transition: transform .3s var(--ease); }
+.btn--lg { padding: 18px 36px; font-size: 16px; }
+.btn--primary { background: var(--accent); color: #02040a; box-shadow: var(--glow); }
+.btn--primary::before { content:''; position:absolute; inset:0; background: linear-gradient(120deg, transparent, rgba(255,255,255,0.5), transparent); transform: translateX(-120%); transition: transform .7s var(--ease); }
+.btn--primary:hover::before { transform: translateX(120%); }
+.btn--ghost { border: 1px solid var(--line); color: var(--ink); }
+.btn--ghost:hover { border-color: var(--accent); }
+
+.hero__pipeline { display: inline-flex; align-items: center; gap: 14px; font-family: var(--font-mono); font-size: 13px; color: var(--ink-soft); flex-wrap: wrap; }
+.pipeline__node { padding: 8px 16px; border: 1px solid var(--line); border-radius: 8px; }
+.pipeline__node--kirra { border-color: var(--accent); color: var(--accent); box-shadow: inset 0 0 20px rgba(52,245,166,0.08); }
+.pipeline__arrow { color: var(--ink-mute); }
+
+.hero__scrollcue { position: absolute; bottom: 34px; left: 50%; transform: translateX(-50%); display: flex; flex-direction: column; align-items: center; gap: 10px; font-family: var(--font-mono); font-size: 10px; letter-spacing: 3px; color: var(--ink-mute); }
+.hero__scrollline { width: 1px; height: 46px; background: linear-gradient(var(--ink-mute), transparent); position: relative; overflow: hidden; }
+.hero__scrollline::after { content:''; position:absolute; top:0; left:0; width:100%; height:40%; background: var(--green); animation: scrolldn 1.8s var(--ease) infinite; }
+@keyframes scrolldn { 0%{transform:translateY(-100%);} 100%{transform:translateY(250%);} }
+
+/* ───────── Manifesto ───────── */
+.manifesto { max-width: 1100px; margin: 0 auto; padding: clamp(120px, 22vh, 260px) clamp(20px, 5vw, 56px); }
+.manifesto__text { font-family: var(--font-display); font-weight: 500; font-size: clamp(1.6rem, 4.2vw, 3.4rem); line-height: 1.18; letter-spacing: -0.02em; color: var(--ink-mute); }
+.manifesto__text .hl { color: var(--ink); }
+.hl--red { color: var(--red) !important; }
+.hl--amber { color: var(--amber) !important; }
+.hl--cyan { color: var(--cyan) !important; }
+
+/* ───────── Posture (pinned) ───────── */
+.posture { height: 300vh; }
+.posture__sticky { position: sticky; top: 0; min-height: 100vh; display: flex; flex-direction: column; justify-content: center; max-width: var(--maxw); margin: 0 auto; padding: 0 clamp(20px, 5vw, 56px); }
+.posture__header { text-align: center; margin-bottom: 50px; }
+.posture__heading { font-family: var(--font-display); font-weight: 700; font-size: clamp(3rem, 12vw, 9rem); letter-spacing: -0.04em; line-height: 1; transition: color .6s var(--ease); color: var(--green); }
+.posture__cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+.pcard { padding: 30px; border: 1px solid var(--line); border-radius: 18px; background: var(--bg-glass); backdrop-filter: blur(10px); transition: transform .5s var(--ease), border-color .5s, opacity .5s; opacity: 0.4; }
+.pcard.is-active { opacity: 1; transform: translateY(-8px); }
+.pcard header { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
+.pcard__led { width: 11px; height: 11px; border-radius: 50%; }
+.pcard--nominal { border-color: rgba(52,245,166,0.2); } .pcard--nominal .pcard__led { background: var(--green); box-shadow: 0 0 14px var(--green); }
+.pcard--degraded { border-color: rgba(255,182,39,0.2); } .pcard--degraded .pcard__led { background: var(--amber); box-shadow: 0 0 14px var(--amber); }
+.pcard--locked { border-color: rgba(255,77,99,0.2); } .pcard--locked .pcard__led { background: var(--red); box-shadow: 0 0 14px var(--red); }
+.pcard h3 { font-family: var(--font-display); font-size: 1.4rem; }
+.pcard p { color: var(--ink-soft); font-size: 0.95rem; margin-bottom: 18px; }
+.pcard__verdict { font-family: var(--font-mono); font-size: 12px; color: var(--ink-mute); letter-spacing: 1px; }
+.posture__note { max-width: 760px; margin: 44px auto 0; text-align: center; color: var(--ink-mute); font-size: 0.95rem; }
+.posture__note code { font-family: var(--font-mono); color: var(--ink-soft); }
+@media (max-width: 860px) { .posture { height: auto; } .posture__sticky { position: static; padding-top: 120px; padding-bottom: 120px; } .posture__cards { grid-template-columns: 1fr; } .pcard { opacity: 1; } }
+
+/* ───────── Capabilities ───────── */
+.caps { max-width: var(--maxw); margin: 0 auto; padding: clamp(100px, 14vh, 200px) clamp(20px, 5vw, 56px); }
+.caps__intro { max-width: 720px; margin-bottom: 70px; }
+.caps__title { font-family: var(--font-display); font-weight: 700; font-size: clamp(2rem, 5.5vw, 4rem); letter-spacing: -0.03em; line-height: 1.02; margin-bottom: 22px; }
+.caps__sub { color: var(--ink-soft); font-size: 1.1rem; }
+.caps__grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: var(--line); border: 1px solid var(--line); border-radius: 20px; overflow: hidden; }
+.cap { background: var(--bg); padding: 40px 34px; transition: background .4s; }
+.cap:hover { background: var(--bg-2); }
+.cap__idx { font-family: var(--font-mono); font-size: 12px; color: var(--green); letter-spacing: 2px; }
+.cap h3 { font-family: var(--font-display); font-size: 1.3rem; margin: 18px 0 12px; }
+.cap p { color: var(--ink-soft); font-size: 0.96rem; }
+.cap code { font-family: var(--font-mono); font-size: 0.85em; color: var(--cyan); background: rgba(92,240,255,0.08); padding: 1px 6px; border-radius: 5px; }
+@media (max-width: 980px) { .caps__grid { grid-template-columns: repeat(2,1fr); } }
+@media (max-width: 640px) { .caps__grid { grid-template-columns: 1fr; } }
+
+/* ───────── Occy ───────── */
+.occy { max-width: var(--maxw); margin: 0 auto; padding: clamp(80px, 12vh, 160px) clamp(20px, 5vw, 56px); }
+.occy__head { max-width: 760px; margin-bottom: 56px; }
+.occy__head h2 { font-family: var(--font-display); font-weight: 700; font-size: clamp(1.8rem, 4.6vw, 3.3rem); letter-spacing: -0.02em; line-height: 1.08; margin-bottom: 20px; }
+.occy__head p { color: var(--ink-soft); font-size: 1.08rem; }
+.occy__goals { display: flex; flex-direction: column; gap: 1px; background: var(--line); border: 1px solid var(--line); border-radius: 18px; overflow: hidden; }
+.goal { display: grid; grid-template-columns: 90px 1fr auto; align-items: center; gap: 24px; padding: 26px 32px; background: var(--bg); transition: background .35s, padding-left .35s var(--ease); }
+.goal:hover { background: var(--bg-2); padding-left: 42px; }
+.goal__id { font-family: var(--font-display); font-weight: 700; font-size: 1.5rem; color: var(--green); }
+.goal__body h3 { font-family: var(--font-display); font-size: 1.2rem; }
+.goal__body p { color: var(--ink-mute); font-size: 0.95rem; }
+.goal__asil { font-family: var(--font-mono); font-size: 12px; text-align: right; color: var(--ink-soft); display: flex; flex-direction: column; gap: 4px; }
+.goal__asil span { color: var(--green); letter-spacing: 1px; }
+@media (max-width: 640px) { .goal { grid-template-columns: 60px 1fr; } .goal__asil { grid-column: 1 / -1; text-align: left; flex-direction: row; gap: 10px; } }
+
+/* ───────── Quickstart ───────── */
+.quickstart { max-width: var(--maxw); margin: 0 auto; padding: clamp(80px, 12vh, 160px) clamp(20px, 5vw, 56px); display: grid; grid-template-columns: 1fr 1.1fr; gap: 60px; align-items: center; }
+.quickstart__left h2 { font-family: var(--font-display); font-weight: 700; font-size: clamp(1.7rem, 3.6vw, 2.7rem); letter-spacing: -0.02em; line-height: 1.1; margin-bottom: 20px; }
+.quickstart__left p { color: var(--ink-soft); margin-bottom: 30px; }
+.quickstart__install { display: flex; align-items: center; gap: 12px; background: var(--bg-2); border: 1px solid var(--line); border-radius: 12px; padding: 14px 16px; font-family: var(--font-mono); font-size: 14px; }
+.quickstart__install code { color: var(--green); flex: 1; }
+.copy-btn { font-family: var(--font-mono); font-size: 12px; color: var(--ink); background: rgba(255,255,255,0.05); border: 1px solid var(--line); border-radius: 7px; padding: 7px 12px; cursor: none; transition: background .3s, color .3s; }
+.copy-btn:hover { background: var(--accent); color: #02040a; }
+.copy-btn.is-copied { background: var(--green); color: #02040a; }
+
+.code-window { border: 1px solid var(--line); border-radius: 14px; overflow: hidden; background: linear-gradient(160deg, #0a0f1c, #060a13); box-shadow: 0 40px 120px -40px rgba(0,0,0,0.8), var(--glow); }
+.code-window__bar { display: flex; align-items: center; gap: 8px; padding: 14px 18px; border-bottom: 1px solid var(--line); }
+.code-dot { width: 11px; height: 11px; border-radius: 50%; background: #2a3142; }
+.code-dot:nth-child(1){ background:#ff5f57; } .code-dot:nth-child(2){ background:#febc2e; } .code-dot:nth-child(3){ background:#28c840; }
+.code-window__title { margin-left: 10px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-mute); }
+.code-window__body { padding: 24px 26px; font-family: var(--font-mono); font-size: 13.5px; line-height: 1.85; color: var(--ink-soft); overflow-x: auto; }
+.c-kw { color: #ff79c6; } .c-fn { color: var(--cyan); } .c-str { color: var(--green); } .c-num { color: var(--amber); } .c-cm { color: var(--ink-mute); font-style: italic; }
+@media (max-width: 900px) { .quickstart { grid-template-columns: 1fr; } }
+
+/* ───────── Stats ───────── */
+.stats { max-width: var(--maxw); margin: 0 auto; padding: clamp(60px, 8vh, 120px) clamp(20px, 5vw, 56px); display: grid; grid-template-columns: repeat(4, 1fr); gap: 30px; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.stat { text-align: center; }
+.stat__num { display: block; font-family: var(--font-display); font-weight: 700; font-size: clamp(2.2rem, 5vw, 3.6rem); letter-spacing: -0.03em; background: linear-gradient(180deg, var(--ink), var(--green)); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+.stat__label { color: var(--ink-mute); font-size: 0.9rem; }
+@media (max-width: 760px) { .stats { grid-template-columns: repeat(2, 1fr); gap: 40px 20px; } }
+
+/* ───────── CTA ───────── */
+.cta { position: relative; text-align: center; padding: clamp(120px, 20vh, 240px) clamp(20px, 5vw, 56px); overflow: hidden; }
+.cta__glow { position: absolute; top: 50%; left: 50%; width: 700px; height: 700px; transform: translate(-50%,-50%); background: radial-gradient(circle, rgba(52,245,166,0.18), transparent 60%); filter: blur(40px); z-index: -1; }
+.cta__title { font-family: var(--font-display); font-weight: 700; font-size: clamp(2.4rem, 7vw, 5.5rem); letter-spacing: -0.03em; line-height: 1.02; margin-bottom: 24px; }
+.cta__sub { color: var(--ink-soft); font-size: 1.2rem; margin-bottom: 44px; }
+.cta__actions { display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; }
+
+/* ───────── Footer ───────── */
+.footer { max-width: var(--maxw); margin: 0 auto; padding: 60px clamp(20px, 5vw, 56px); display: flex; flex-wrap: wrap; gap: 24px; align-items: center; justify-content: space-between; border-top: 1px solid var(--line); }
+.footer__brand { font-family: var(--font-display); font-weight: 700; letter-spacing: 2px; font-size: 14px; }
+.footer__cols { display: flex; gap: 28px; font-size: 14px; color: var(--ink-soft); }
+.footer__cols a:hover { color: var(--accent); }
+.footer__legal { width: 100%; font-size: 12px; color: var(--ink-mute); font-family: var(--font-mono); }
+
+/* ───────── Reveal states (GSAP toggles) ───────── */
+[data-fade], [data-reveal], [data-stagger] .word { will-change: transform, opacity; }

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kirra — Fail-Closed Trust for Autonomous Machines</title>
+  <meta name="description" content="Kirra is a distributed runtime legitimacy engine and safety governor for AI-driven robotic and edge systems. It enforces fail-closed trust across a heterogeneous fleet — stopping unsafe commands before they reach actuators." />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/style.css" />
+
+  <!-- Three.js (module) -->
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/"
+    }
+  }
+  </script>
+  <!-- GSAP (global) -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>
+</head>
+<body>
+  <!-- ───────── Preloader ───────── -->
+  <div class="preloader" id="preloader">
+    <div class="preloader__inner">
+      <div class="preloader__mark">
+        <span class="preloader__glyph">K</span>
+        <span class="preloader__ring"></span>
+      </div>
+      <div class="preloader__bar"><span id="preloaderFill"></span></div>
+      <div class="preloader__meta">
+        <span class="preloader__status" id="preloaderStatus">VERIFYING FLEET POSTURE</span>
+        <span class="preloader__pct" id="preloaderPct">0%</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- ───────── Custom cursor ───────── -->
+  <div class="cursor" id="cursor"></div>
+  <div class="cursor-dot" id="cursorDot"></div>
+
+  <!-- ───────── Grain + scroll progress ───────── -->
+  <div class="grain" aria-hidden="true"></div>
+  <div class="scroll-progress"><span id="scrollProgress"></span></div>
+
+  <!-- ───────── WebGL canvas ───────── -->
+  <canvas id="lattice" class="lattice-canvas" aria-hidden="true"></canvas>
+
+  <!-- ───────── Nav ───────── -->
+  <header class="nav" id="nav">
+    <a href="#top" class="nav__brand" data-magnetic>
+      <span class="nav__logo">◇</span>
+      <span class="nav__name">KIRRA</span>
+    </a>
+    <nav class="nav__links">
+      <a href="#posture" data-magnetic>Posture</a>
+      <a href="#capabilities" data-magnetic>Capabilities</a>
+      <a href="#occy" data-magnetic>Occy / AV</a>
+      <a href="#quickstart" data-magnetic>Quickstart</a>
+    </nav>
+    <a href="https://github.com/justinlooney/kirra-runtime-sdk" class="nav__cta" data-magnetic target="_blank" rel="noopener">
+      <span>GitHub</span><span class="nav__cta-arrow">↗</span>
+    </a>
+  </header>
+
+  <main id="top">
+    <!-- ───────── Hero ───────── -->
+    <section class="hero" id="hero">
+      <div class="hero__eyebrow" data-fade>
+        <span class="dot dot--live"></span>
+        RUNTIME LEGITIMACY ENGINE · SAFETY GOVERNOR
+      </div>
+      <h1 class="hero__title">
+        <span class="line"><span class="word">Fail&#8209;closed</span> <span class="word">trust</span></span>
+        <span class="line"><span class="word">for</span> <span class="word accent">autonomous</span></span>
+        <span class="line"><span class="word accent">machines.</span></span>
+      </h1>
+      <p class="hero__lede" data-fade>
+        Kirra sits between your AI and your actuators. Every command — from an LLM,
+        a planner, or an upstream orchestrator — is judged against live fleet posture
+        <em>before</em> a single byte reaches hardware. If trust can't be proven, nothing moves.
+      </p>
+      <div class="hero__actions" data-fade>
+        <a href="#quickstart" class="btn btn--primary" data-magnetic>
+          <span>Drop it in your stack</span>
+        </a>
+        <a href="#posture" class="btn btn--ghost" data-magnetic>
+          <span>See the posture engine</span>
+        </a>
+      </div>
+      <div class="hero__pipeline" data-fade>
+        <span class="pipeline__node">LLM&nbsp;/&nbsp;Planner</span>
+        <span class="pipeline__arrow">→</span>
+        <span class="pipeline__node pipeline__node--kirra">Kirra Governor</span>
+        <span class="pipeline__arrow">→</span>
+        <span class="pipeline__node">Actuator</span>
+      </div>
+      <div class="hero__scrollcue" aria-hidden="true">
+        <span>SCROLL</span><span class="hero__scrollline"></span>
+      </div>
+    </section>
+
+    <!-- ───────── Manifesto / problem ───────── -->
+    <section class="manifesto" id="manifesto">
+      <p class="manifesto__text" data-stagger>
+        A model that hallucinates <span class="hl hl--red">999&nbsp;m/s</span>, invents a
+        non&#8209;existent action, or issues a kinetic command while the fleet is
+        <span class="hl hl--amber">degraded</span> is stopped at the software layer —
+        and the attempt is permanently recorded in a
+        <span class="hl hl--cyan">SHA&#8209;256 hash&#8209;chained ledger.</span>
+      </p>
+    </section>
+
+    <!-- ───────── Posture engine (pinned, color-driven) ───────── -->
+    <section class="posture" id="posture">
+      <div class="posture__sticky">
+        <div class="posture__header">
+          <span class="section-tag">THE POSTURE ENGINE</span>
+          <h2 class="posture__heading" id="postureHeading">Nominal</h2>
+        </div>
+        <div class="posture__cards">
+          <article class="pcard pcard--nominal" data-state="0">
+            <header><span class="pcard__led"></span><h3>Nominal</h3></header>
+            <p>The gray/black DAG resolves clean across the fleet. Kinetic writes are admitted —
+               each still validated against the vehicle kinematics envelope.</p>
+            <span class="pcard__verdict">cmd_vel ✓ · read ✓</span>
+          </article>
+          <article class="pcard pcard--degraded" data-state="1">
+            <header><span class="pcard__led"></span><h3>Degraded</h3></header>
+            <p>Controlled decel&#8209;to&#8209;stop&#8209;and&#8209;HOLD. Speed may only converge to zero;
+               re&#8209;acceleration is denied. The governor never authors a restart.</p>
+            <span class="pcard__verdict">cmd_vel ✗ · read ✓</span>
+          </article>
+          <article class="pcard pcard--locked" data-state="2">
+            <header><span class="pcard__led"></span><h3>LockedOut</h3></header>
+            <p>A cycle, depth breach, or unresolved trust locks the fleet. Everything is denied —
+               down to telemetry. Recovery is a deliberate human reset.</p>
+            <span class="pcard__verdict">cmd_vel ✗ · read ✗</span>
+          </article>
+        </div>
+        <p class="posture__note">
+          Posture is recomputed by a coalescing worker over a real two&#8209;set DAG traversal —
+          gray set for cycle detection, black set for diamond&#8209;DAG memoization. A
+          <code>LockedOut</code> dependency propagates upward as <code>LockedOut</code>, never softened to degraded.
+        </p>
+      </div>
+    </section>
+
+    <!-- ───────── Capabilities grid ───────── -->
+    <section class="caps" id="capabilities">
+      <div class="caps__intro">
+        <span class="section-tag">SECURITY INVARIANTS, NOT FEATURES</span>
+        <h2 class="caps__title" data-fade>Trust is enforced, <br/>never assumed.</h2>
+        <p class="caps__sub" data-fade>Each of these has been blocked or reverted in review more than once.
+          They are invariants — the system fails closed if any one cannot hold.</p>
+      </div>
+      <div class="caps__grid">
+        <article class="cap" data-reveal>
+          <span class="cap__idx">01</span>
+          <h3>Cryptographic attestation</h3>
+          <p>Per&#8209;node Ed25519 proof over a <code>(node_id, nonce)</code> challenge, checked against a
+            registered attestation key. No registered key, malformed proof, or bad signature → reject.</p>
+        </article>
+        <article class="cap" data-reveal>
+          <span class="cap__idx">02</span>
+          <h3>Constant&#8209;time comparison</h3>
+          <p>Every security&#8209;critical token check runs in constant time. Plain <code>==</code> on secret bytes
+            is forbidden across the entire codebase.</p>
+        </article>
+        <article class="cap" data-reveal>
+          <span class="cap__idx">03</span>
+          <h3>Fail&#8209;closed admin gate</h3>
+          <p>Mutation routes require an admin token sourced only from the environment. Absent or empty →
+            <code>503</code>. There is no fail&#8209;open path and no hardcoded fallback.</p>
+        </article>
+        <article class="cap" data-reveal>
+          <span class="cap__idx">04</span>
+          <h3>Tamper&#8209;evident ledger</h3>
+          <p>Every accepted report and denied command links into a SHA&#8209;256 hash&#8209;chained audit log —
+            independently verifiable, append&#8209;only, break&#8209;detecting.</p>
+        </article>
+        <article class="cap" data-reveal>
+          <span class="cap__idx">05</span>
+          <h3>Kinematics envelope</h3>
+          <p>The governor clamps to the absolute hard boundary first, then applies rate&#8209;of&#8209;change limits.
+            The envelope cap always wins. <code>NaN</code>/<code>Inf</code> are rejected before publish.</p>
+        </article>
+        <article class="cap" data-reveal>
+          <span class="cap__idx">06</span>
+          <h3>Bounded&#8209;time verdict</h3>
+          <p>An O(1) structural boundedness argument guards the governor verdict path, with a CI WCET gate.
+            Host timing is indicative; only QNX&#8209;target numbers feed an FTTI claim.</p>
+        </article>
+      </div>
+    </section>
+
+    <!-- ───────── Occy / AV safety goals ───────── -->
+    <section class="occy" id="occy">
+      <div class="occy__head">
+        <span class="section-tag">OCCY LINE · AUTONOMOUS DRIVING</span>
+        <h2 data-fade>An ASIL&#8209;D governor for the planning &amp; control loop.</h2>
+        <p data-fade>A Safety Element out of Context that runs as a two&#8209;rate checker, enforces
+          drivable&#8209;space containment against an HD map, and publishes a Minimal Risk Condition
+          verdict the stack must honor before any trajectory reaches actuators.</p>
+      </div>
+      <div class="occy__goals">
+        <div class="goal" data-reveal>
+          <div class="goal__id">SG1</div>
+          <div class="goal__body"><h3>Speed envelope</h3><p>50&nbsp;mph / 80&nbsp;km/h hard cap.</p></div>
+          <div class="goal__asil">ASIL&nbsp;D<span>ENFORCED</span></div>
+        </div>
+        <div class="goal" data-reveal>
+          <div class="goal__id">SG2</div>
+          <div class="goal__body"><h3>Lateral containment</h3><p>Drivable&#8209;space margin ≥ 0.40&nbsp;m.</p></div>
+          <div class="goal__asil">ASIL&nbsp;D<span>ENFORCED</span></div>
+        </div>
+        <div class="goal" data-reveal>
+          <div class="goal__id">SG3</div>
+          <div class="goal__body"><h3>RSS safety distance</h3><p>Longitudinal &amp; lateral separation.</p></div>
+          <div class="goal__asil">ASIL&nbsp;D<span>ENFORCED</span></div>
+        </div>
+        <div class="goal" data-reveal>
+          <div class="goal__id">SG4</div>
+          <div class="goal__body"><h3>MRC publication</h3><p>On any contract violation.</p></div>
+          <div class="goal__asil">ASIL&nbsp;D<span>ENFORCED</span></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ───────── Quickstart / code ───────── -->
+    <section class="quickstart" id="quickstart">
+      <div class="quickstart__left">
+        <span class="section-tag">FIVE&#8209;MINUTE INTEGRATION</span>
+        <h2 data-fade>Compatible with OpenAI function calling, LangChain tools, or any agent that can POST.</h2>
+        <p data-fade>Drop Kirra between your AI agent and your robot fleet. Every AI&#8209;generated command is
+          evaluated against the live posture before any hardware interaction occurs.</p>
+        <div class="quickstart__install">
+          <code id="installCmd">curl -fsSL kirra.sh/install | sh</code>
+          <button class="copy-btn" data-copy="curl -fsSL kirra.sh/install | sh" data-magnetic>Copy</button>
+        </div>
+      </div>
+      <div class="quickstart__code" data-reveal>
+        <div class="code-window">
+          <div class="code-window__bar">
+            <span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span>
+            <span class="code-window__title">action_filter.py</span>
+          </div>
+<pre class="code-window__body"><code><span class="c-kw">import</span> kirra
+
+governor = kirra.<span class="c-fn">Governor</span>(<span class="c-str">"https://verifier.fleet.local"</span>)
+
+<span class="c-cm"># LLM proposes an action — Kirra judges it against live posture</span>
+verdict = governor.<span class="c-fn">evaluate</span>(
+    node_id=<span class="c-str">"robot-07"</span>,
+    action={<span class="c-str">"type"</span>: <span class="c-str">"cmd_vel"</span>, <span class="c-str">"linear"</span>: <span class="c-num">2.0</span>},
+)
+
+<span class="c-kw">if</span> verdict.allowed:
+    fleet.<span class="c-fn">dispatch</span>(verdict.action)   <span class="c-cm"># clamped to envelope</span>
+<span class="c-kw">else</span>:
+    log.<span class="c-fn">warn</span>(verdict.<span class="c-kw">reason</span>)        <span class="c-cm"># DegradedSpeedIncreaseDenied</span>
+</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <!-- ───────── Stats ───────── -->
+    <section class="stats" id="stats">
+      <div class="stat" data-reveal>
+        <span class="stat__num" data-count="4" data-suffix="">ASIL&nbsp;D</span>
+        <span class="stat__label">Safety goals enforced end&#8209;to&#8209;end</span>
+      </div>
+      <div class="stat" data-reveal>
+        <span class="stat__num" data-count="0">0</span>
+        <span class="stat__label">Fail&#8209;open paths in the codebase</span>
+      </div>
+      <div class="stat" data-reveal>
+        <span class="stat__num" data-count="100" data-suffix="%">0</span>
+        <span class="stat__label">Mutations behind a constant&#8209;time gate</span>
+      </div>
+      <div class="stat" data-reveal>
+        <span class="stat__num" data-count="256" data-suffix="&#8209;bit">0</span>
+        <span class="stat__label">SHA hash&#8209;chained audit ledger</span>
+      </div>
+    </section>
+
+    <!-- ───────── CTA ───────── -->
+    <section class="cta" id="cta">
+      <div class="cta__glow" aria-hidden="true"></div>
+      <h2 class="cta__title" data-fade>If trust can't be proven,<br/><span class="accent">nothing moves.</span></h2>
+      <p class="cta__sub" data-fade>Put a fail&#8209;closed governor between your model and the world.</p>
+      <div class="cta__actions" data-fade>
+        <a href="https://github.com/justinlooney/kirra-runtime-sdk" class="btn btn--primary btn--lg" data-magnetic target="_blank" rel="noopener"><span>Get the SDK</span></a>
+        <a href="https://github.com/justinlooney/kirra-runtime-sdk/blob/main/docs/llm_integration_guide.md" class="btn btn--ghost btn--lg" data-magnetic target="_blank" rel="noopener"><span>Read the integration guide</span></a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer__brand"><span class="nav__logo">◇</span> KIRRA RUNTIME SDK</div>
+    <div class="footer__cols">
+      <a href="https://github.com/justinlooney/kirra-runtime-sdk" target="_blank" rel="noopener">Repository</a>
+      <a href="https://github.com/justinlooney/kirra-runtime-sdk/blob/main/docs/action_filter.md" target="_blank" rel="noopener">Action Filter</a>
+      <a href="https://github.com/justinlooney/kirra-runtime-sdk/blob/main/SECURITY.md" target="_blank" rel="noopener">Security</a>
+    </div>
+    <div class="footer__legal">Fail&#8209;closed by construction · Built for robots that can hurt people.</div>
+  </footer>
+
+  <script type="module" src="js/scene.js"></script>
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -1,0 +1,243 @@
+// ============================================================
+// KIRRA — interaction + scroll choreography (GSAP)
+// Drives the preloader, custom cursor, magnetic UI, scroll
+// reveals, and the pinned posture section that pushes
+// colour state into the WebGL lattice (window.KirraScene).
+// ============================================================
+
+const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+function boot() {
+  const gsap = window.gsap;
+  if (!gsap) { return void setTimeout(boot, 50); } // wait for CDN
+  const { ScrollTrigger } = window;
+  if (window.ScrollTrigger) gsap.registerPlugin(window.ScrollTrigger);
+  const ST = window.ScrollTrigger;
+
+  // ---------- initial hidden states (set only once gsap exists) ----------
+  if (!reduced) {
+    gsap.set('[data-fade]', { y: 26, opacity: 0 });
+    gsap.set('[data-reveal]', { y: 40, opacity: 0 });
+    gsap.set('.hero__title .word', { yPercent: 115 });
+  }
+
+  // ---------- Preloader ----------
+  const pre = document.getElementById('preloader');
+  const fill = document.getElementById('preloaderFill');
+  const pct = document.getElementById('preloaderPct');
+  const status = document.getElementById('preloaderStatus');
+  const statusLines = ['VERIFYING FLEET POSTURE', 'LOADING TRUST LATTICE', 'ATTESTING NODES', 'POSTURE: NOMINAL'];
+
+  const counter = { v: 0 };
+  const sceneReady = (window.KirraScene && window.KirraScene.whenReady) || Promise.resolve();
+  let sceneDone = false;
+  sceneReady.then(() => { sceneDone = true; });
+
+  function finishPreloader() {
+    const tl = gsap.timeline();
+    tl.to(pre, { yPercent: -100, duration: 1, ease: 'power4.inOut', onComplete: () => pre && (pre.style.display = 'none') })
+      .add(introHero, '-=0.5');
+  }
+
+  // progress crawls to 90%, then completes when the scene is ready
+  gsap.to(counter, {
+    v: 90, duration: 1.4, ease: 'power1.inOut',
+    onUpdate() {
+      const p = Math.round(counter.v);
+      if (fill) fill.style.width = p + '%';
+      if (pct) pct.textContent = p + '%';
+      if (status) status.textContent = statusLines[Math.min(statusLines.length - 1, Math.floor(p / 25))];
+    },
+    onComplete() {
+      const wait = () => {
+        if (sceneDone) {
+          gsap.to(counter, {
+            v: 100, duration: 0.5, ease: 'power2.out',
+            onUpdate() { const p = Math.round(counter.v); if (fill) fill.style.width = p + '%'; if (pct) pct.textContent = p + '%'; },
+            onComplete() { if (status) status.textContent = 'POSTURE: NOMINAL'; gsap.delayedCall(0.25, finishPreloader); },
+          });
+        } else { gsap.delayedCall(0.1, wait); }
+      };
+      wait();
+    },
+  });
+  // hard safety net: never trap the user behind the preloader
+  gsap.delayedCall(6, () => { if (pre && pre.style.display !== 'none') { pre.style.display = 'none'; introHero(); } });
+
+  // ---------- Hero intro ----------
+  let heroPlayed = false;
+  function introHero() {
+    if (heroPlayed) return; heroPlayed = true;
+    if (reduced) return;
+    gsap.timeline({ defaults: { ease: 'power4.out' } })
+      .to('.hero__title .word', { yPercent: 0, duration: 1.1, stagger: 0.07 })
+      .to('.hero__eyebrow', { y: 0, opacity: 1, duration: 0.7 }, 0.2)
+      .to('.hero__lede', { y: 0, opacity: 1, duration: 0.8 }, '-=0.7')
+      .to('.hero__actions', { y: 0, opacity: 1, duration: 0.8 }, '-=0.6')
+      .to('.hero__pipeline', { y: 0, opacity: 1, duration: 0.8 }, '-=0.6');
+  }
+
+  // ---------- Custom cursor ----------
+  const cursor = document.getElementById('cursor');
+  const dot = document.getElementById('cursorDot');
+  if (cursor && dot && window.matchMedia('(pointer:fine)').matches) {
+    const xTo = gsap.quickTo(cursor, 'x', { duration: 0.45, ease: 'power3' });
+    const yTo = gsap.quickTo(cursor, 'y', { duration: 0.45, ease: 'power3' });
+    const dxTo = gsap.quickTo(dot, 'x', { duration: 0.12, ease: 'power3' });
+    const dyTo = gsap.quickTo(dot, 'y', { duration: 0.12, ease: 'power3' });
+    window.addEventListener('pointermove', (e) => { xTo(e.clientX); yTo(e.clientY); dxTo(e.clientX); dyTo(e.clientY); });
+    document.querySelectorAll('a, button, [data-magnetic]').forEach((el) => {
+      el.addEventListener('pointerenter', () => cursor.classList.add('is-hover'));
+      el.addEventListener('pointerleave', () => cursor.classList.remove('is-hover'));
+    });
+  }
+
+  // ---------- Magnetic elements ----------
+  if (!reduced) {
+    document.querySelectorAll('[data-magnetic]').forEach((el) => {
+      const strength = 0.4;
+      el.addEventListener('pointermove', (e) => {
+        const r = el.getBoundingClientRect();
+        const mx = e.clientX - (r.left + r.width / 2);
+        const my = e.clientY - (r.top + r.height / 2);
+        gsap.to(el, { x: mx * strength, y: my * strength, duration: 0.5, ease: 'power3.out' });
+      });
+      el.addEventListener('pointerleave', () => gsap.to(el, { x: 0, y: 0, duration: 0.6, ease: 'elastic.out(1,0.4)' }));
+    });
+  }
+
+  // ---------- Nav stuck + scroll progress ----------
+  const nav = document.getElementById('nav');
+  const prog = document.getElementById('scrollProgress');
+  function onScroll() {
+    const y = window.scrollY;
+    if (nav) nav.classList.toggle('is-stuck', y > 60);
+    const max = document.documentElement.scrollHeight - window.innerHeight;
+    if (prog) prog.style.width = (max > 0 ? (y / max) * 100 : 0) + '%';
+  }
+  window.addEventListener('scroll', onScroll, { passive: true });
+  onScroll();
+
+  if (reduced || !ST) {
+    // no scroll animation — just make everything visible
+    gsap.set('[data-fade], [data-reveal]', { clearProps: 'all' });
+    revealManifesto(true); countStats(true);
+    return;
+  }
+
+  // ---------- Scroll reveals ----------
+  gsap.utils.toArray('[data-fade]').forEach((el) => {
+    if (el.closest('.hero')) return; // hero handled by intro
+    gsap.to(el, { y: 0, opacity: 1, duration: 0.9, ease: 'power3.out',
+      scrollTrigger: { trigger: el, start: 'top 86%' } });
+  });
+  ST.batch('[data-reveal]', {
+    start: 'top 85%',
+    onEnter: (els) => gsap.to(els, { y: 0, opacity: 1, duration: 0.9, stagger: 0.09, ease: 'power3.out', overwrite: true }),
+  });
+
+  revealManifesto(false);
+  countStats(false);
+  setupPosture();
+
+  ST.refresh();
+}
+
+// ---------- Manifesto word sweep ----------
+function revealManifesto(instant) {
+  const gsap = window.gsap;
+  const p = document.querySelector('.manifesto__text');
+  if (!p) return;
+  // split top-level into .word spans, keeping existing .hl elements intact
+  const frag = document.createDocumentFragment();
+  Array.from(p.childNodes).forEach((node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      node.textContent.split(/(\s+)/).forEach((tok) => {
+        if (tok.trim() === '') { frag.appendChild(document.createTextNode(tok)); return; }
+        const s = document.createElement('span'); s.className = 'word'; s.style.display = 'inline-block';
+        s.textContent = tok; frag.appendChild(s);
+      });
+    } else {
+      node.classList && node.classList.add('word');
+      node.style && (node.style.display = 'inline-block');
+      frag.appendChild(node);
+    }
+  });
+  p.innerHTML = ''; p.appendChild(frag);
+  const words = p.querySelectorAll('.word');
+  if (instant || !window.ScrollTrigger) return;
+  gsap.set(words, { opacity: 0.12 });
+  gsap.to(words, {
+    opacity: 1, stagger: 0.06, ease: 'none',
+    scrollTrigger: { trigger: p, start: 'top 75%', end: 'bottom 60%', scrub: 1 },
+  });
+}
+
+// ---------- Stat counters ----------
+function countStats(instant) {
+  const gsap = window.gsap;
+  document.querySelectorAll('.stat__num[data-count]').forEach((el) => {
+    const target = parseFloat(el.getAttribute('data-count'));
+    const suffix = el.getAttribute('data-suffix') || '';
+    // skip non-numeric placeholders (e.g. "ASIL D")
+    if (isNaN(target) || !/^\d/.test(el.textContent.trim())) return;
+    const obj = { v: 0 };
+    const apply = () => { el.textContent = Math.round(obj.v) + suffix; };
+    if (instant || !window.ScrollTrigger) { obj.v = target; apply(); return; }
+    gsap.to(obj, { v: target, duration: 1.6, ease: 'power2.out', onUpdate: apply,
+      scrollTrigger: { trigger: el, start: 'top 88%' } });
+  });
+}
+
+// ---------- Pinned posture section → drives the lattice colour ----------
+function setupPosture() {
+  const gsap = window.gsap; const ST = window.ScrollTrigger;
+  const section = document.querySelector('.posture');
+  const heading = document.getElementById('postureHeading');
+  const cards = gsap.utils.toArray('.pcard');
+  if (!section || !heading) return;
+
+  const states = [
+    { name: 'Nominal',   color: '#34f5a6', p: 0.0, agit: 0.05 },
+    { name: 'Degraded',  color: '#ffb627', p: 0.5, agit: 0.45 },
+    { name: 'LockedOut', color: '#ff4d63', p: 1.0, agit: 0.9 },
+  ];
+  let current = -1;
+  function setState(i) {
+    if (i === current) return; current = i;
+    const s = states[i];
+    gsap.to(heading, { color: s.color, duration: 0.5 });
+    heading.textContent = s.name;
+    cards.forEach((c, idx) => c.classList.toggle('is-active', idx === i));
+  }
+  setState(0);
+
+  ST.create({
+    trigger: section, start: 'top top', end: 'bottom bottom', scrub: true,
+    onUpdate(self) {
+      const prog = self.progress;            // 0..1 across the 300vh section
+      if (window.KirraScene) {
+        window.KirraScene.setPosture01(prog);
+        window.KirraScene.setAgitation(Math.min(1, prog * 1.0));
+      }
+      const i = prog < 0.34 ? 0 : prog < 0.67 ? 1 : 2;
+      setState(i);
+    },
+    onLeave() { if (window.KirraScene) { window.KirraScene.setPosture01(0); window.KirraScene.setAgitation(0); } },
+    onLeaveBack() { if (window.KirraScene) { window.KirraScene.setPosture01(0); window.KirraScene.setAgitation(0); } },
+  });
+}
+
+// ---------- Copy button ----------
+document.addEventListener('click', (e) => {
+  const btn = e.target.closest('[data-copy]');
+  if (!btn) return;
+  const text = btn.getAttribute('data-copy');
+  navigator.clipboard?.writeText(text).then(() => {
+    const prev = btn.textContent; btn.textContent = 'Copied'; btn.classList.add('is-copied');
+    setTimeout(() => { btn.textContent = prev; btn.classList.remove('is-copied'); }, 1600);
+  });
+});
+
+if (document.readyState !== 'loading') boot();
+else document.addEventListener('DOMContentLoaded', boot);

--- a/website/js/scene.js
+++ b/website/js/scene.js
@@ -1,0 +1,275 @@
+// ============================================================
+// KIRRA — "Trust Lattice"
+// A live 3D fleet dependency graph. Nodes pulse, trust packets
+// travel the edges, and the whole lattice shifts colour through
+// the posture states (green → amber → red) as you scroll.
+// ============================================================
+import * as THREE from 'three';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass }     from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass }     from 'three/addons/postprocessing/OutputPass.js';
+
+const POSTURE = {
+  green: new THREE.Color('#34f5a6'),
+  amber: new THREE.Color('#ffb627'),
+  red:   new THREE.Color('#ff4d63'),
+};
+
+const state = {
+  posture01: 0,        // 0 green · 0.5 amber · 1 red
+  targetPosture01: 0,
+  agitation: 0,        // 0..1 extra jitter/speed
+  targetAgitation: 0,
+  pointerX: 0, pointerY: 0,
+  targetPX: 0, targetPY: 0,
+};
+
+let readyResolve;
+const whenReady = new Promise((res) => { readyResolve = res; });
+
+function postureColor(t) {
+  const c = new THREE.Color();
+  if (t < 0.5) c.copy(POSTURE.green).lerp(POSTURE.amber, t / 0.5);
+  else         c.copy(POSTURE.amber).lerp(POSTURE.red, (t - 0.5) / 0.5);
+  return c;
+}
+
+function init() {
+  const canvas = document.getElementById('lattice');
+  if (!canvas) { readyResolve(); return; }
+
+  let renderer;
+  try {
+    renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true, powerPreference: 'high-performance' });
+  } catch (e) {
+    readyResolve(); return; // no WebGL — site still works, just no lattice
+  }
+
+  const sizes = { w: window.innerWidth, h: window.innerHeight };
+  const pr = Math.min(window.devicePixelRatio, 2);
+  renderer.setPixelRatio(pr);
+  renderer.setSize(sizes.w, sizes.h);
+  renderer.setClearColor(0x000000, 0);
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.15;
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(52, sizes.w / sizes.h, 0.1, 200);
+  camera.position.set(0, 0, 42);
+
+  const group = new THREE.Group();
+  scene.add(group);
+
+  // ── Build the lattice node cloud (fibonacci shell + inner cluster) ──
+  const NODES = 170;
+  const positions = [];
+  const radius = 17;
+  for (let i = 0; i < NODES; i++) {
+    const shell = i < NODES * 0.72;
+    let r, x, y, z;
+    if (shell) {
+      const k = i + 0.5;
+      const phi = Math.acos(1 - 2 * k / (NODES * 0.72));
+      const theta = Math.PI * (1 + Math.sqrt(5)) * k;
+      r = radius * (0.82 + Math.random() * 0.18);
+      x = Math.sin(phi) * Math.cos(theta) * r;
+      y = Math.sin(phi) * Math.sin(theta) * r;
+      z = Math.cos(phi) * r;
+    } else {
+      r = radius * (0.15 + Math.random() * 0.5);
+      const u = Math.random() * Math.PI * 2, v = Math.acos(2 * Math.random() - 1);
+      x = Math.sin(v) * Math.cos(u) * r;
+      y = Math.sin(v) * Math.sin(u) * r;
+      z = Math.cos(v) * r;
+    }
+    positions.push(new THREE.Vector3(x, y, z));
+  }
+
+  // ── Edges: connect each node to its K nearest neighbours (deduped) ──
+  const K = 3;
+  const edgeSet = new Set();
+  const edges = []; // {a,b}
+  for (let i = 0; i < NODES; i++) {
+    const dists = [];
+    for (let j = 0; j < NODES; j++) if (i !== j) dists.push([j, positions[i].distanceTo(positions[j])]);
+    dists.sort((p, q) => p[1] - q[1]);
+    for (let n = 0; n < K; n++) {
+      const j = dists[n][0];
+      const key = i < j ? `${i}-${j}` : `${j}-${i}`;
+      if (!edgeSet.has(key)) { edgeSet.add(key); edges.push({ a: Math.min(i, j), b: Math.max(i, j) }); }
+    }
+  }
+
+  // ── Nodes (Points w/ soft round shader) ──
+  const nodeGeo = new THREE.BufferGeometry();
+  const nodePos = new Float32Array(NODES * 3);
+  const nodeTint = new Float32Array(NODES * 3);
+  const nodeSize = new Float32Array(NODES);
+  for (let i = 0; i < NODES; i++) {
+    nodePos[i * 3] = positions[i].x; nodePos[i * 3 + 1] = positions[i].y; nodePos[i * 3 + 2] = positions[i].z;
+    const b = 0.6 + Math.random() * 0.4;            // per-node brightness variance
+    nodeTint[i * 3] = b; nodeTint[i * 3 + 1] = b; nodeTint[i * 3 + 2] = b;
+    nodeSize[i] = (Math.random() < 0.12 ? 26 : 13) + Math.random() * 6; // a few hub nodes
+  }
+  nodeGeo.setAttribute('position', new THREE.BufferAttribute(nodePos, 3));
+  nodeGeo.setAttribute('aColor', new THREE.BufferAttribute(nodeTint, 3));
+  nodeGeo.setAttribute('aSize', new THREE.BufferAttribute(nodeSize, 1));
+
+  const nodeMat = new THREE.ShaderMaterial({
+    transparent: true, depthWrite: false,
+    uniforms: { uColor: { value: POSTURE.green.clone() }, uTime: { value: 0 }, uPr: { value: pr } },
+    vertexShader: `
+      attribute float aSize; attribute vec3 aColor;
+      varying vec3 vColor; uniform float uTime; uniform float uPr;
+      void main(){
+        vColor = aColor;
+        vec4 mv = modelViewMatrix * vec4(position,1.0);
+        float pulse = 1.0 + 0.22 * sin(uTime*1.6 + position.x*0.6 + position.y*0.4);
+        gl_PointSize = aSize * pulse * uPr * (300.0 / -mv.z);
+        gl_Position = projectionMatrix * mv;
+      }`,
+    fragmentShader: `
+      varying vec3 vColor; uniform vec3 uColor;
+      void main(){
+        vec2 c = gl_PointCoord - 0.5; float d = length(c);
+        if(d>0.5) discard;
+        float a = smoothstep(0.5,0.05,d);
+        float core = smoothstep(0.22,0.0,d);
+        vec3 col = vColor * uColor;
+        col = mix(col, vec3(1.0), core*0.7);
+        gl_FragColor = vec4(col, a);
+      }`,
+  });
+  const nodePoints = new THREE.Points(nodeGeo, nodeMat);
+  group.add(nodePoints);
+
+  // ── Edges ──
+  const edgePos = new Float32Array(edges.length * 6);
+  for (let e = 0; e < edges.length; e++) {
+    const A = positions[edges[e].a], B = positions[edges[e].b];
+    edgePos[e * 6] = A.x; edgePos[e * 6 + 1] = A.y; edgePos[e * 6 + 2] = A.z;
+    edgePos[e * 6 + 3] = B.x; edgePos[e * 6 + 4] = B.y; edgePos[e * 6 + 5] = B.z;
+  }
+  const edgeGeo = new THREE.BufferGeometry();
+  edgeGeo.setAttribute('position', new THREE.BufferAttribute(edgePos, 3));
+  const edgeMat = new THREE.LineBasicMaterial({ color: POSTURE.green.clone().multiplyScalar(0.5), transparent: true, opacity: 0.16 });
+  const lines = new THREE.LineSegments(edgeGeo, edgeMat);
+  group.add(lines);
+
+  // ── Trust packets travelling the edges ──
+  const PULSES = 90;
+  const pulseGeo = new THREE.BufferGeometry();
+  const pulsePos = new Float32Array(PULSES * 3);
+  const pulseSize = new Float32Array(PULSES);
+  const pulses = [];
+  for (let i = 0; i < PULSES; i++) {
+    pulses.push({ e: Math.floor(Math.random() * edges.length), t: Math.random(), spd: 0.12 + Math.random() * 0.25 });
+    pulseSize[i] = 9 + Math.random() * 7;
+  }
+  pulseGeo.setAttribute('position', new THREE.BufferAttribute(pulsePos, 3));
+  pulseGeo.setAttribute('aSize', new THREE.BufferAttribute(pulseSize, 1));
+  const pulseMat = new THREE.ShaderMaterial({
+    transparent: true, depthWrite: false, blending: THREE.AdditiveBlending,
+    uniforms: { uColor: { value: POSTURE.green.clone() }, uPr: { value: pr } },
+    vertexShader: `
+      attribute float aSize; uniform float uPr;
+      void main(){ vec4 mv = modelViewMatrix*vec4(position,1.0);
+        gl_PointSize = aSize*uPr*(300.0/-mv.z); gl_Position = projectionMatrix*mv; }`,
+    fragmentShader: `
+      uniform vec3 uColor;
+      void main(){ vec2 c = gl_PointCoord-0.5; float d=length(c);
+        if(d>0.5) discard; float a=smoothstep(0.5,0.0,d);
+        gl_FragColor = vec4(uColor + vec3(0.3), a); }`,
+  });
+  const pulsePoints = new THREE.Points(pulseGeo, pulseMat);
+  group.add(pulsePoints);
+
+  // ── Post-processing: bloom for the neon glow ──
+  const composer = new EffectComposer(renderer);
+  composer.addPass(new RenderPass(scene, camera));
+  const bloom = new UnrealBloomPass(new THREE.Vector2(sizes.w, sizes.h), 0.95, 0.55, 0.0);
+  composer.addPass(bloom);
+  composer.addPass(new OutputPass());
+  composer.setPixelRatio(pr);
+  composer.setSize(sizes.w, sizes.h);
+
+  // ── Resize ──
+  function onResize() {
+    sizes.w = window.innerWidth; sizes.h = window.innerHeight;
+    camera.aspect = sizes.w / sizes.h; camera.updateProjectionMatrix();
+    renderer.setSize(sizes.w, sizes.h);
+    composer.setSize(sizes.w, sizes.h);
+    bloom.setSize(sizes.w, sizes.h);
+  }
+  window.addEventListener('resize', onResize);
+
+  // ── Pointer parallax ──
+  window.addEventListener('pointermove', (e) => {
+    state.targetPX = (e.clientX / sizes.w - 0.5) * 2;
+    state.targetPY = (e.clientY / sizes.h - 0.5) * 2;
+  });
+
+  // ── Animation loop ──
+  const clock = new THREE.Clock();
+  const tmpColor = new THREE.Color();
+  function tick() {
+    const t = clock.getElapsedTime();
+    const dt = Math.min(clock.getDelta ? 0.016 : 0.016, 0.033);
+
+    // ease state
+    state.posture01  += (state.targetPosture01  - state.posture01)  * 0.06;
+    state.agitation  += (state.targetAgitation  - state.agitation)  * 0.05;
+    state.pointerX   += (state.targetPX - state.pointerX) * 0.05;
+    state.pointerY   += (state.targetPY - state.pointerY) * 0.05;
+
+    // posture colour
+    const pc = postureColor(state.posture01);
+    nodeMat.uniforms.uColor.value.lerp(pc, 0.1);
+    pulseMat.uniforms.uColor.value.lerp(pc, 0.1);
+    tmpColor.copy(pc).multiplyScalar(0.5);
+    edgeMat.color.lerp(tmpColor, 0.1);
+    edgeMat.opacity = 0.14 + state.agitation * 0.12;
+    bloom.strength = 0.9 + state.agitation * 0.5 + state.posture01 * 0.25;
+
+    nodeMat.uniforms.uTime.value = t * (1 + state.agitation * 1.5);
+
+    // rotate the lattice + pointer parallax
+    group.rotation.y += 0.0011 + state.agitation * 0.002;
+    group.rotation.x += 0.0004;
+    const targetRY = state.pointerX * 0.35;
+    const targetRX = state.pointerY * 0.22;
+    group.rotation.y += (targetRY - (group.rotation.y % (Math.PI * 2))) * 0.0;
+    camera.position.x += (state.pointerX * 3.5 - camera.position.x) * 0.04;
+    camera.position.y += (-state.pointerY * 3.0 - camera.position.y) * 0.04;
+    camera.lookAt(0, 0, 0);
+
+    // advance trust packets along edges
+    const speedScale = 1 + state.agitation * 1.4;
+    for (let i = 0; i < PULSES; i++) {
+      const p = pulses[i];
+      p.t += p.spd * 0.016 * speedScale;
+      if (p.t >= 1) { p.t = 0; p.e = Math.floor(Math.random() * edges.length); }
+      const A = positions[edges[p.e].a], B = positions[edges[p.e].b];
+      pulsePos[i * 3]     = A.x + (B.x - A.x) * p.t;
+      pulsePos[i * 3 + 1] = A.y + (B.y - A.y) * p.t;
+      pulsePos[i * 3 + 2] = A.z + (B.z - A.z) * p.t;
+    }
+    pulseGeo.attributes.position.needsUpdate = true;
+
+    composer.render();
+    requestAnimationFrame(tick);
+  }
+  tick();
+  readyResolve();
+}
+
+// ── Public API consumed by main.js ──
+window.KirraScene = {
+  whenReady,
+  setPosture01(v) { state.targetPosture01 = Math.max(0, Math.min(1, v)); },
+  setAgitation(v) { state.targetAgitation = Math.max(0, Math.min(1, v)); },
+};
+
+if (document.readyState !== 'loading') init();
+else document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## What

A static marketing site for the Kirra SDK (`website/`) plus the CI to publish it to **GitHub Pages** at the custom domain **kirrasystems.com**.

Scoped to 7 files; no source/runtime changes.

## Site (`website/`)
- **Three.js** "trust lattice" — a live 3D fleet dependency graph (nodes, nearest-neighbour edges, traveling trust packets) with `UnrealBloomPass` glow. It *is* Kirra's fleet DAG.
- **GSAP** choreography — preloader gated on the WebGL scene (6s safety net), custom cursor, magnetic UI, kinetic hero reveal, manifesto word-sweep, animated stat counters, copy-to-clipboard.
- **Posture-driven colour** — the pinned Posture section scrubs the lattice through the real states on scroll: `Nominal` (green) → `Degraded` (amber) → `LockedOut` (red).
- All copy grounded in the SDK: fail-closed trust, the posture engine, the security invariants, the Occy ASIL-D safety goals.
- Resilient: respects `prefers-reduced-motion`; degrades gracefully with no WebGL or if GSAP fails to load.

## Deploy
- `.github/workflows/deploy-pages.yml` — on push to `main` touching `website/**`, uploads `website/` and deploys to Pages. `actions/configure-pages` auto-enables Pages (build type = GitHub Actions), so no manual Settings toggle.
- `website/CNAME` → `kirrasystems.com` binds the apex custom domain.

## To go live (after merge)
1. **DNS at GoDaddy** — four `A @` records to GitHub Pages IPs (`185.199.108–111.153`) + `CNAME www → justinlooney.github.io`.
2. On merge, the deploy workflow runs and enables Pages automatically.
3. **Settings → Pages → Enforce HTTPS** once the cert provisions (a few minutes after DNS resolves).

## Notes
- Verified locally: JS modules parse clean (`node --check`); page + assets serve `200`.
- three.js / GSAP load from CDN at runtime (documented in `website/README.md`); can be vendored for a fully offline build if preferred.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_