### PR TITLE
Fix GitHub Pages deploy: self-enable Pages (enablement: true)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,6 +34,8 @@ jobs:
       # Enables Pages (build type = GitHub Actions) if not already enabled.
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Fix the failed Pages deploy

The first deploy run after merging #342 [failed](https://github.com/justinlooney/kirra-runtime-sdk/actions/runs/27484019629) with:

```
Get Pages site failed. Please verify that the repository has Pages enabled
and configured to build using GitHub Actions... (configure-pages ran with enablement: false)
```

GitHub Pages was never enabled on the repo, and `actions/configure-pages@v5` defaults to `enablement: false`, so it errored instead of enabling it.

## Change
One line — `enablement: true` on the Configure Pages step. The workflow's `pages: write` token lets it enable Pages itself (build type = GitHub Actions), so **no manual repo-Settings toggle is needed** (handy since the GitHub mobile app doesn't expose Pages settings).

On merge, the deploy re-runs, self-enables Pages, and publishes `website/`.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_