### PR TITLE
Improve site legibility: dark scrim over lattice + tamer bloom

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -8,7 +8,7 @@
   --bg-2:      #070b15;
   --bg-glass:  rgba(10, 14, 26, 0.55);
   --ink:       #eef2fb;
-  --ink-soft:  #aab4cc;
+  --ink-soft:  #c6cee2;
   --ink-mute:  #6a7593;
   --line:      rgba(140, 160, 200, 0.12);
 
@@ -54,6 +54,19 @@ a { color: inherit; text-decoration: none; }
   height: 100vh;
   z-index: 0;
   pointer-events: none;
+}
+
+/* Dark scrim over the WebGL lattice so foreground text keeps contrast
+   against the bloom (the glow can wash the background near-white, esp. on mobile). */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background:
+    radial-gradient(125% 90% at 50% 16%, rgba(4,6,12,0) 0%, rgba(4,6,12,0.45) 50%, rgba(4,6,12,0.84) 100%),
+    linear-gradient(180deg, rgba(4,6,12,0.34), rgba(4,6,12,0.60));
 }
 
 /* ───────── Grain ───────── */

--- a/website/js/scene.js
+++ b/website/js/scene.js
@@ -52,7 +52,7 @@ function init() {
   renderer.setSize(sizes.w, sizes.h);
   renderer.setClearColor(0x000000, 0);
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = 1.15;
+  renderer.toneMappingExposure = 0.98;
 
   const scene = new THREE.Scene();
   const camera = new THREE.PerspectiveCamera(52, sizes.w / sizes.h, 0.1, 200);
@@ -188,7 +188,7 @@ function init() {
   // ── Post-processing: bloom for the neon glow ──
   const composer = new EffectComposer(renderer);
   composer.addPass(new RenderPass(scene, camera));
-  const bloom = new UnrealBloomPass(new THREE.Vector2(sizes.w, sizes.h), 0.95, 0.55, 0.0);
+  const bloom = new UnrealBloomPass(new THREE.Vector2(sizes.w, sizes.h), 0.5, 0.4, 0.15);
   composer.addPass(bloom);
   composer.addPass(new OutputPass());
   composer.setPixelRatio(pr);
@@ -230,7 +230,7 @@ function init() {
     tmpColor.copy(pc).multiplyScalar(0.5);
     edgeMat.color.lerp(tmpColor, 0.1);
     edgeMat.opacity = 0.14 + state.agitation * 0.12;
-    bloom.strength = 0.9 + state.agitation * 0.5 + state.posture01 * 0.25;
+    bloom.strength = 0.5 + state.agitation * 0.35 + state.posture01 * 0.2;
 
     nodeMat.uniforms.uTime.value = t * (1 + state.agitation * 1.5);
 


### PR DESCRIPTION
## Problem
On mobile the WebGL bloom washes the hero background to near-white, dropping contrast on the lighter body text (the lede became hard to read). The site renders correctly — this is purely legibility.

## Change (website only, 2 files)
- **Dark scrim** over the lattice: a fixed `body::before` (radial + linear gradient, `z-index:1` between canvas and content) so foreground text always has a dark backdrop, regardless of how bright the glow renders.
- **Brighter secondary text**: `--ink-soft` `#aab4cc → #c6cee2`.
- **Tamer bloom** in `scene.js`: tone-mapping exposure `1.15 → 0.98`; `UnrealBloomPass` strength `0.95 → 0.5` with threshold `0.0 → 0.15` (only bright pixels bloom); dynamic strength scaled down to match. The neon lattice still glows — it just stops blowing out the page.

## Verified
`node --check` passes on both JS modules. No structural/content changes — type, layout, and animations untouched.

## Deploy
Merging this is a push to `main` touching `website/**`, which triggers the Pages deploy automatically — no manual run needed.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_