### PR TITLE
Field Notes: render Substack posts client-side (with cover images)

### DIFF
--- a/scripts/fetch-substack-posts.mjs
+++ b/scripts/fetch-substack-posts.mjs
@@ -45,7 +45,12 @@ function firstImage(block) {
 }
 
 try {
-  const res = await fetch(FEED, { headers: { 'User-Agent': 'kirra-site-build/1.0 (+kirrasystems.com)' } });
+  const res = await fetch(FEED, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+      'Accept': 'application/rss+xml, application/xml;q=0.9, text/xml;q=0.8, */*;q=0.5',
+    },
+  });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const xml = await res.text();
 

--- a/scripts/fetch-substack-posts.mjs
+++ b/scripts/fetch-substack-posts.mjs
@@ -32,6 +32,18 @@ function snippet(html, n = 150) {
   return text.length > n ? text.slice(0, n).replace(/\s+\S*$/, '') + '…' : text;
 }
 
+function firstImage(block) {
+  // Substack item cover lives in <enclosure>, sometimes <media:content>,
+  // otherwise the first <img> inside the CDATA description/content.
+  let m = block.match(/<enclosure[^>]*url="([^"]+)"[^>]*type="image/i);
+  if (m) return decodeEntities(m[1]);
+  m = block.match(/<media:content[^>]*url="([^"]+)"/i);
+  if (m && /\.(jpe?g|png|webp|gif|avif)/i.test(m[1])) return decodeEntities(m[1]);
+  m = block.match(/<img[^>]*\bsrc="([^"]+)"/i);
+  if (m) return decodeEntities(m[1]);
+  return '';
+}
+
 try {
   const res = await fetch(FEED, { headers: { 'User-Agent': 'kirra-site-build/1.0 (+kirrasystems.com)' } });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -54,6 +66,7 @@ try {
         link: tag(b, 'link'),
         date,
         excerpt: snippet(tag(b, 'description')),
+        image: firstImage(b),
       };
     })
     .filter((p) => p.title && /^https?:\/\//.test(p.link));

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -339,12 +339,14 @@ section { position: relative; z-index: 3; }
 .notes__sub { max-width: 620px; margin: 0 auto 32px; color: var(--ink-soft); font-size: 1.08rem; }
 .notes__grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 18px; max-width: 1040px; margin: 0 auto 36px; text-align: left; }
 .notes__grid:empty { display: none; }
-.note-card { display: flex; flex-direction: column; gap: 9px; padding: 22px; border: 1px solid var(--line); border-radius: 14px; background: var(--bg-glass); backdrop-filter: blur(8px); transition: transform .35s var(--ease), border-color .35s; }
+.note-card { display: flex; flex-direction: column; border: 1px solid var(--line); border-radius: 14px; background: var(--bg-glass); backdrop-filter: blur(8px); overflow: hidden; transition: transform .35s var(--ease), border-color .35s; }
 .note-card:hover { transform: translateY(-4px); border-color: var(--accent); }
+.note-card__img { width: 100%; aspect-ratio: 16 / 9; object-fit: cover; display: block; background: var(--bg-2); }
+.note-card__body { display: flex; flex-direction: column; gap: 9px; padding: 20px; }
 .note-card__date { font-family: var(--font-mono); font-size: 11px; letter-spacing: 1px; color: var(--green); }
 .note-card__title { font-family: var(--font-display); font-size: 1.15rem; color: var(--ink); line-height: 1.25; }
 .note-card__excerpt { font-size: 0.9rem; color: var(--ink-soft); line-height: 1.5; }
-.note-card__more { margin-top: auto; font-family: var(--font-mono); font-size: 12px; color: var(--accent); }
+.note-card__more { margin-top: 4px; font-family: var(--font-mono); font-size: 12px; color: var(--accent); }
 
 /* ───────── Reveal states (GSAP toggles) ───────── */
 [data-fade], [data-reveal], [data-stagger] .word { will-change: transform, opacity; }

--- a/website/js/notes.js
+++ b/website/js/notes.js
@@ -1,66 +1,112 @@
-// Render the latest Substack posts (baked into posts.json at deploy time) as
-// cards in the Field Notes section. Same-origin fetch — no CORS, no proxy.
-// If posts.json is empty or missing, the section's subscribe CTA stays as-is.
+// ============================================================
+// KIRRA — Field Notes feed
+// Renders the latest Substack posts as cards. Substack blocks datacenter
+// IPs (so the build-time fetch in CI 403s), therefore we fetch CLIENT-SIDE
+// from the visitor's browser through CORS-friendly reader proxies, trying:
+//   1. posts.json   (baked at build time — used if CI ever succeeds)
+//   2. rss2json     (parsed JSON + thumbnails)
+//   3. allorigins   (raw XML, parsed here)
+// If all fail, the section's subscribe CTA remains as the fallback.
+// ============================================================
+
+const FEED = 'https://justinlooney.substack.com/feed';
+const MAX = 4;
+
+function fmtDate(s) {
+  if (!s) return '';
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+function strip(html, n = 160) {
+  const t = (html || '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+  return t.length > n ? t.slice(0, n).replace(/\s+\S*$/, '') + '…' : t;
+}
+function imgFrom(html) {
+  const m = (html || '').match(/<img[^>]*\bsrc="([^"]+)"/i);
+  return m ? m[1] : '';
+}
+
+async function fromPostsJson() {
+  try {
+    const r = await fetch('posts.json', { cache: 'no-cache' });
+    if (!r.ok) return null;
+    const a = await r.json();
+    return Array.isArray(a) && a.length ? a.slice(0, MAX) : null;
+  } catch { return null; }
+}
+
+async function fromRss2Json() {
+  try {
+    const r = await fetch('https://api.rss2json.com/v1/api.json?rss_url=' + encodeURIComponent(FEED));
+    if (!r.ok) return null;
+    const j = await r.json();
+    if (j.status !== 'ok' || !Array.isArray(j.items) || !j.items.length) return null;
+    return j.items.slice(0, MAX).map((it) => ({
+      title: it.title,
+      link: it.link,
+      date: fmtDate(it.pubDate),
+      excerpt: strip(it.description || it.content),
+      image: it.thumbnail || (it.enclosure && it.enclosure.link) || imgFrom(it.content || it.description),
+    }));
+  } catch { return null; }
+}
+
+async function fromAllOrigins() {
+  try {
+    const r = await fetch('https://api.allorigins.win/raw?url=' + encodeURIComponent(FEED));
+    if (!r.ok) return null;
+    const xml = new DOMParser().parseFromString(await r.text(), 'text/xml');
+    const items = [...xml.querySelectorAll('item')].slice(0, MAX);
+    if (!items.length) return null;
+    return items.map((it) => {
+      const get = (sel) => (it.querySelector(sel) ? it.querySelector(sel).textContent : '') || '';
+      const desc = get('description') || get('encoded');
+      const enc = it.querySelector('enclosure') ? it.querySelector('enclosure').getAttribute('url') : '';
+      return { title: get('title'), link: get('link'), date: fmtDate(get('pubDate')), excerpt: strip(desc), image: enc || imgFrom(desc) };
+    });
+  } catch { return null; }
+}
+
+function render(grid, posts) {
+  const clean = posts.filter((p) => p && typeof p.link === 'string' && /^https?:\/\//.test(p.link) && p.title);
+  if (!clean.length) return false;
+  grid.textContent = '';
+  for (const p of clean) {
+    const card = document.createElement('a');
+    card.className = 'note-card';
+    card.href = p.link; card.target = '_blank'; card.rel = 'noopener';
+
+    if (p.image && /^https?:\/\//.test(p.image)) {
+      const img = document.createElement('img');
+      img.className = 'note-card__img';
+      img.src = p.image; img.alt = ''; img.loading = 'lazy';
+      img.addEventListener('error', () => img.remove());
+      card.appendChild(img);
+    }
+    const body = document.createElement('div');
+    body.className = 'note-card__body';
+    if (p.date) { const d = document.createElement('span'); d.className = 'note-card__date'; d.textContent = p.date; body.appendChild(d); }
+    const t = document.createElement('span'); t.className = 'note-card__title'; t.textContent = p.title; body.appendChild(t);
+    if (p.excerpt) { const e = document.createElement('span'); e.className = 'note-card__excerpt'; e.textContent = p.excerpt; body.appendChild(e); }
+    const m = document.createElement('span'); m.className = 'note-card__more'; m.textContent = 'Read on Substack ↗'; body.appendChild(m);
+    card.appendChild(body);
+    grid.appendChild(card);
+  }
+  grid.classList.add('is-loaded');
+  if (window.ScrollTrigger) window.ScrollTrigger.refresh();
+  return true;
+}
 
 async function loadNotes() {
   const grid = document.getElementById('notesGrid');
   if (!grid) return;
-  try {
-    const res = await fetch('posts.json', { cache: 'no-cache' });
-    if (!res.ok) return;
-    const posts = await res.json();
-    if (!Array.isArray(posts) || posts.length === 0) return;
-
-    for (const p of posts) {
-      if (!p || typeof p.link !== 'string' || !/^https?:\/\//.test(p.link)) continue;
-      const card = document.createElement('a');
-      card.className = 'note-card';
-      card.href = p.link;
-      card.target = '_blank';
-      card.rel = 'noopener';
-
-      if (p.image && /^https?:\/\//.test(p.image)) {
-        const img = document.createElement('img');
-        img.className = 'note-card__img';
-        img.src = p.image;
-        img.alt = '';
-        img.loading = 'lazy';
-        card.appendChild(img);
-      }
-
-      const body = document.createElement('div');
-      body.className = 'note-card__body';
-
-      if (p.date) {
-        const d = document.createElement('span');
-        d.className = 'note-card__date';
-        d.textContent = p.date;
-        body.appendChild(d);
-      }
-      const t = document.createElement('span');
-      t.className = 'note-card__title';
-      t.textContent = p.title || 'Untitled';
-      body.appendChild(t);
-
-      if (p.excerpt) {
-        const e = document.createElement('span');
-        e.className = 'note-card__excerpt';
-        e.textContent = p.excerpt;
-        body.appendChild(e);
-      }
-      const more = document.createElement('span');
-      more.className = 'note-card__more';
-      more.textContent = 'Read on Substack ↗';
-      body.appendChild(more);
-
-      card.appendChild(body);
-      grid.appendChild(card);
-    }
-    grid.classList.add('is-loaded');
-    if (window.ScrollTrigger) window.ScrollTrigger.refresh();
-  } catch (_) {
-    /* keep the subscribe CTA as the fallback */
+  for (const src of [fromPostsJson, fromRss2Json, fromAllOrigins]) {
+    try {
+      const posts = await src();
+      if (posts && render(grid, posts)) return;
+    } catch { /* try next source */ }
   }
+  // all sources failed — keep the subscribe CTA as the fallback
 }
 
 if (document.readyState !== 'loading') loadNotes();

--- a/website/js/notes.js
+++ b/website/js/notes.js
@@ -19,28 +19,41 @@ async function loadNotes() {
       card.target = '_blank';
       card.rel = 'noopener';
 
+      if (p.image && /^https?:\/\//.test(p.image)) {
+        const img = document.createElement('img');
+        img.className = 'note-card__img';
+        img.src = p.image;
+        img.alt = '';
+        img.loading = 'lazy';
+        card.appendChild(img);
+      }
+
+      const body = document.createElement('div');
+      body.className = 'note-card__body';
+
       if (p.date) {
         const d = document.createElement('span');
         d.className = 'note-card__date';
         d.textContent = p.date;
-        card.appendChild(d);
+        body.appendChild(d);
       }
       const t = document.createElement('span');
       t.className = 'note-card__title';
       t.textContent = p.title || 'Untitled';
-      card.appendChild(t);
+      body.appendChild(t);
 
       if (p.excerpt) {
         const e = document.createElement('span');
         e.className = 'note-card__excerpt';
         e.textContent = p.excerpt;
-        card.appendChild(e);
+        body.appendChild(e);
       }
       const more = document.createElement('span');
       more.className = 'note-card__more';
       more.textContent = 'Read on Substack ↗';
-      card.appendChild(more);
+      body.appendChild(more);
 
+      card.appendChild(body);
       grid.appendChild(card);
     }
     grid.classList.add('is-loaded');


### PR DESCRIPTION
Follow-up to #346 so the Field Notes posts actually render.

## Why
The build-time RSS fetch in #346 **403s** — confirmed in the deploy log:
```
Substack fetch skipped (HTTP 403); keeping existing website/posts.json.
```
Substack blocks datacenter IPs (GitHub Actions runners included), so `posts.json` stays empty and no posts show.

## Fix
- **Fetch client-side** from the visitor's browser (residential IPs Substack serves), via CORS reader proxies — `rss2json` first, then `allorigins` — still preferring the build-time `posts.json` if CI ever succeeds.
- **Cover images** on each card (`enclosure` / `media:content` / first `<img>` / rss2json thumbnail) → reads like a blog roll: image · date · title · excerpt · "Read on Substack ↗".
- Broken images self-remove; the subscribe CTA stays as the final fallback if every source fails.
- Build fetch now sends a browser User-Agent (best-effort; harmless if it still 403s).

## Note / trade-off
This pulls your public posts through a third-party reader proxy at runtime (standard for Substack-on-static-site). If you'd rather have **zero third-party dependency**, the alternative is to bake posts into `posts.json` manually — tell me and I'll switch to that (you'd paste post URLs, or we automate via a residential-friendly source).

## Verified
`node --check` passes on the renderer + fetch script. Couldn't exercise the proxies from the sandbox (it 403s all egress), so please confirm the feed renders on the live site after merge.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_