### PR TITLE
Brand mark (SVG trust-lattice logo + favicon) and stat-label legibility

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -274,7 +274,7 @@ section { position: relative; z-index: 3; }
 .stats { max-width: var(--maxw); margin: 0 auto; padding: clamp(60px, 8vh, 120px) clamp(20px, 5vw, 56px); display: grid; grid-template-columns: repeat(4, 1fr); gap: 30px; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .stat { text-align: center; }
 .stat__num { display: block; font-family: var(--font-display); font-weight: 700; font-size: clamp(2.2rem, 5vw, 3.6rem); letter-spacing: -0.03em; background: linear-gradient(180deg, var(--ink), var(--green)); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
-.stat__label { color: var(--ink-mute); font-size: 0.9rem; }
+.stat__label { color: var(--ink-soft); font-size: 0.9rem; text-shadow: 0 1px 14px rgba(4,6,12,0.6); }
 @media (max-width: 760px) { .stats { grid-template-columns: repeat(2, 1fr); gap: 40px 20px; } }
 
 /* ───────── CTA ───────── */


### PR DESCRIPTION
Two changes, website-only.

### 1. SVG logo mark + favicon
Hand-built scalable brand mark (concept ① from the logo set): the site's `◇` evolved into a **fleet trust-lattice** — four corner nodes + a brighter central **governor** node gating the graph — in the brand palette (`#34f5a6`) with a soft glow.
- New `website/assets/kirra-mark.svg`
- Replaces the `◇` glyph in the **nav** and **footer**
- Wired as the **SVG favicon** + `theme-color`
- Pure vector — crisp at any size, no raster needed

### 2. Stat-label legibility
`.stat__label` used `--ink-mute` and washed out against the lattice; bumped to `--ink-soft` + text-shadow (matching the posture-note / manifesto fixes).

### Verified
SVG is valid XML; all assets serve 200 locally; CSS-only + markup swaps, no JS/structure change. Merging auto-deploys (`website/**`).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58