### PR TITLE
Header logo (bigger, transparent) + live action_filter.py terminal

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -133,16 +133,16 @@ body::before {
 }
 .nav.is-stuck { background: var(--bg-glass); backdrop-filter: blur(14px); padding-top: 14px; padding-bottom: 14px; border-bottom: 1px solid var(--line); }
 .nav__brand { display: flex; align-items: center; gap: 10px; font-family: var(--font-display); font-weight: 700; letter-spacing: 3px; font-size: 15px; }
-/* Brand PNG mark — mix-blend hides its dark bg over the dark site; a gentle
-   breathing-glow gives it life (the K can't have data travel inside a flat image). */
-.nav__logo { width: 30px; height: 30px; display: inline-block; vertical-align: middle; flex: none; object-fit: contain; mix-blend-mode: screen; animation: logo-breathe 3.4s ease-in-out infinite; }
-.preloader__logo { width: 88px; height: 88px; object-fit: contain; mix-blend-mode: screen; animation: logo-breathe 3.4s ease-in-out infinite; }
+/* Brand mark — its dark background is knocked out to transparent at runtime
+   (js/logomask.js), then a gentle breathing-glow follows the K's shape. */
+.nav__logo { width: 44px; height: 44px; display: inline-block; vertical-align: middle; flex: none; object-fit: contain; animation: logo-breathe 3.6s ease-in-out infinite; }
+.preloader__logo { width: 96px; height: 96px; object-fit: contain; animation: logo-breathe 3.6s ease-in-out infinite; }
 @keyframes logo-breathe {
-  0%, 100% { filter: brightness(0.9); transform: scale(1); }
-  50%      { filter: brightness(1.28); transform: scale(1.04); }
+  0%, 100% { filter: brightness(0.95) drop-shadow(0 0 3px rgba(52,245,166,0.45)); transform: scale(1); }
+  50%      { filter: brightness(1.25) drop-shadow(0 0 9px rgba(92,240,255,0.7)); transform: scale(1.05); }
 }
 @media (prefers-reduced-motion: reduce) {
-  .nav__logo, .preloader__logo { animation: none; filter: brightness(1.05); }
+  .nav__logo, .preloader__logo { animation: none; filter: brightness(1.08) drop-shadow(0 0 4px rgba(52,245,166,0.5)); }
 }
 .nav__links { display: flex; gap: 30px; font-size: 14px; color: var(--ink-soft); }
 .nav__links a { position: relative; }
@@ -276,7 +276,18 @@ section { position: relative; z-index: 3; }
 .code-dot { width: 11px; height: 11px; border-radius: 50%; background: #2a3142; }
 .code-dot:nth-child(1){ background:#ff5f57; } .code-dot:nth-child(2){ background:#febc2e; } .code-dot:nth-child(3){ background:#28c840; }
 .code-window__title { margin-left: 10px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-mute); }
-.code-window__body { padding: 24px 26px; font-family: var(--font-mono); font-size: 13.5px; line-height: 1.85; color: var(--ink-soft); overflow-x: auto; }
+.code-window__body { padding: 24px 26px; font-family: var(--font-mono); font-size: 13.5px; line-height: 1.85; color: var(--ink-soft); overflow-x: auto; min-height: 360px; }
+/* live action_filter.py terminal */
+.t-line { white-space: pre; min-height: 1.25em; }
+.t-prompt { color: var(--cyan); }
+.t-code { color: var(--ink-soft); }
+.t-dim { color: var(--ink-mute); font-style: italic; }
+.t-ok { color: var(--green); }
+.t-warn { color: var(--amber); }
+.t-bad { color: var(--red); }
+.t-cursor { display: inline-block; width: 8px; height: 1.05em; background: var(--green); vertical-align: -2px; margin-left: 1px; animation: t-blink 1s steps(1) infinite; }
+@keyframes t-blink { 50% { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) { .t-cursor { animation: none; } }
 .c-kw { color: #ff79c6; } .c-fn { color: var(--cyan); } .c-str { color: var(--green); } .c-num { color: var(--amber); } .c-cm { color: var(--ink-mute); font-style: italic; }
 @media (max-width: 900px) { .quickstart { grid-template-columns: 1fr; } }
 

--- a/website/index.html
+++ b/website/index.html
@@ -264,7 +264,7 @@
             <span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span>
             <span class="code-window__title">action_filter.py</span>
           </div>
-<pre class="code-window__body"><code><span class="c-kw">import</span> kirra
+<pre class="code-window__body"><code id="termBody"><span class="c-kw">import</span> kirra
 
 governor = kirra.<span class="c-fn">Governor</span>(<span class="c-str">"https://verifier.fleet.local"</span>)
 
@@ -339,5 +339,7 @@ verdict = governor.<span class="c-fn">evaluate</span>(
   <script type="module" src="js/main.js"></script>
   <script type="module" src="js/flow.js"></script>
   <script type="module" src="js/notes.js"></script>
+  <script type="module" src="js/terminal.js"></script>
+  <script type="module" src="js/logomask.js"></script>
 </body>
 </html>

--- a/website/js/logomask.js
+++ b/website/js/logomask.js
@@ -1,0 +1,48 @@
+// ============================================================
+// KIRRA — logo background knockout
+// mix-blend-mode can't reach the lattice behind the fixed nav, so the PNG's
+// dark square shows as a hard box. Instead, chroma-key the near-black pixels
+// to transparent at runtime (soft alpha by luminance) and reuse the result
+// for every logo. Same-origin image → canvas stays untainted.
+// ============================================================
+
+function maskLogo(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => {
+      try {
+        const c = document.createElement('canvas');
+        c.width = img.naturalWidth;
+        c.height = img.naturalHeight;
+        const ctx = c.getContext('2d');
+        ctx.drawImage(img, 0, 0);
+        const d = ctx.getImageData(0, 0, c.width, c.height);
+        const p = d.data;
+        for (let i = 0; i < p.length; i += 4) {
+          const lum = Math.max(p[i], p[i + 1], p[i + 2]); // brightest channel
+          let a = (lum - 10) * 3;                          // dark → transparent, soft edge
+          p[i + 3] = a < 0 ? 0 : a > 255 ? 255 : a;
+        }
+        ctx.putImageData(d, 0, 0);
+        resolve(c.toDataURL('image/png'));
+      } catch (e) { reject(e); }
+    };
+    img.onerror = reject;
+    img.src = src;
+  });
+}
+
+async function applyMask() {
+  const slots = document.querySelectorAll('.nav__logo, .preloader__logo');
+  if (!slots.length) return;
+  const src = slots[0].getAttribute('src');
+  if (!src) return;
+  try {
+    const url = await maskLogo(src);
+    slots.forEach((el) => { el.src = url; });
+  } catch { /* leave the original PNG on failure */ }
+}
+
+if (document.readyState !== 'loading') applyMask();
+else document.addEventListener('DOMContentLoaded', applyMask);

--- a/website/js/terminal.js
+++ b/website/js/terminal.js
@@ -1,0 +1,79 @@
+// ============================================================
+// KIRRA — live action_filter.py terminal
+// Types real Kirra usage, then "runs" it: the Governor evaluating LLM
+// actions against live posture and printing verdicts (ALLOW / CLAMP /
+// DENY), with a blinking cursor. Loops. Respects prefers-reduced-motion.
+// ============================================================
+
+const LINES = [
+  { t: '$ python action_filter.py', c: 't-prompt' },
+  { t: '', c: '' },
+  { t: 'import kirra', c: 't-code' },
+  { t: 'gov = kirra.Governor("verifier.fleet.local")', c: 't-code' },
+  { t: '', c: '' },
+  { t: '# every action is judged against live fleet posture', c: 't-dim' },
+  { t: 'gov.evaluate("robot-07", cmd_vel=1.2)', c: 't-code' },
+  { t: '  ✓ ALLOW   Nominal · dispatched', c: 't-ok' },
+  { t: 'gov.evaluate("robot-07", cmd_vel=999)', c: 't-code' },
+  { t: '  ⊘ CLAMP   999 → 2.0 m/s · envelope cap', c: 't-warn' },
+  { t: 'gov.evaluate("robot-07", "drive_to_moon")', c: 't-code' },
+  { t: '  ✕ DENY    unknown action · blocked', c: 't-bad' },
+  { t: 'gov.evaluate("robot-07", cmd_vel=1.2)   # Degraded', c: 't-code' },
+  { t: '  ✕ DENY    kinetic write blocked', c: 't-bad' },
+  { t: '', c: '' },
+  { t: "# fail-closed — if trust isn't proven, nothing moves", c: 't-dim' },
+];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function startTerminal() {
+  const el = document.getElementById('termBody');
+  if (!el) return;
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const cursor = document.createElement('span');
+  cursor.className = 't-cursor';
+
+  function renderStatic() {
+    el.textContent = '';
+    for (const line of LINES) {
+      const div = document.createElement('div');
+      div.className = 't-line ' + line.c;
+      div.textContent = line.t || ' ';
+      el.appendChild(div);
+    }
+  }
+
+  async function run() {
+    el.textContent = '';
+    for (const line of LINES) {
+      const div = document.createElement('div');
+      div.className = 't-line ' + line.c;
+      el.appendChild(div);
+      div.appendChild(cursor);
+      if (/t-(ok|warn|bad)/.test(line.c)) await sleep(360); // "executing…"
+      for (const ch of line.t) {
+        div.insertBefore(document.createTextNode(ch), cursor);
+        await sleep(line.c === 't-ok' || line.c === 't-warn' || line.c === 't-bad' ? 12 : 17);
+      }
+      await sleep(line.t ? 70 : 40);
+    }
+    await sleep(2600);
+    run();
+  }
+
+  if (reduced) { renderStatic(); return; }
+
+  // start once the section scrolls into view
+  let started = false;
+  const io = new IntersectionObserver((entries) => {
+    if (entries.some((e) => e.isIntersecting) && !started) {
+      started = true;
+      io.disconnect();
+      run();
+    }
+  }, { threshold: 0.2 });
+  io.observe(el);
+}
+
+if (document.readyState !== 'loading') startTerminal();
+else document.addEventListener('DOMContentLoaded', startTerminal);


### PR DESCRIPTION
Website-only. Two requests from the live review.

## 1. Header logo: bigger + no black box
- Enlarged in the nav (30 → 44px).
- The PNG's dark square was showing as a hard box because `mix-blend-mode` can't reach the lattice behind the **fixed** nav. Fix: `js/logomask.js` chroma-keys the near-black pixels to transparent at runtime (soft alpha by luminance, same-origin canvas), so the K floats with no box on any background.
- Breathing-glow now `drop-shadow`s the K's actual shape (green→cyan pulse).

## 2. Live `action_filter.py` terminal
- Replaces the static snippet with a typing terminal (`js/terminal.js`): types real Kirra usage, then "runs" it — the Governor evaluating actions and printing **✓ ALLOW / ⊘ CLAMP / ✕ DENY** verdicts (incl. the 999→2.0 m/s clamp and Degraded block) with a **blinking cursor**. Loops, starts on scroll, reduced-motion safe (renders static).

## Verified
`node --check` on both modules; refs wired; assets serve 200.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_