### PR TITLE
Logo auto-crop + bigger; terminal syntax colors

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -135,8 +135,8 @@ body::before {
 .nav__brand { display: flex; align-items: center; gap: 10px; font-family: var(--font-display); font-weight: 700; letter-spacing: 3px; font-size: 15px; }
 /* Brand mark — its dark background is knocked out to transparent at runtime
    (js/logomask.js), then a gentle breathing-glow follows the K's shape. */
-.nav__logo { width: 44px; height: 44px; display: inline-block; vertical-align: middle; flex: none; object-fit: contain; animation: logo-breathe 3.6s ease-in-out infinite; }
-.preloader__logo { width: 96px; height: 96px; object-fit: contain; animation: logo-breathe 3.6s ease-in-out infinite; }
+.nav__logo { width: 50px; height: 50px; display: inline-block; vertical-align: middle; flex: none; object-fit: contain; animation: logo-breathe 3.6s ease-in-out infinite; }
+.preloader__logo { width: 104px; height: 104px; object-fit: contain; animation: logo-breathe 3.6s ease-in-out infinite; }
 @keyframes logo-breathe {
   0%, 100% { filter: brightness(0.95) drop-shadow(0 0 3px rgba(52,245,166,0.45)); transform: scale(1); }
   50%      { filter: brightness(1.25) drop-shadow(0 0 9px rgba(92,240,255,0.7)); transform: scale(1.05); }

--- a/website/js/logomask.js
+++ b/website/js/logomask.js
@@ -1,31 +1,56 @@
 // ============================================================
-// KIRRA — logo background knockout
-// mix-blend-mode can't reach the lattice behind the fixed nav, so the PNG's
-// dark square shows as a hard box. Instead, chroma-key the near-black pixels
-// to transparent at runtime (soft alpha by luminance) and reuse the result
-// for every logo. Same-origin image → canvas stays untainted.
+// KIRRA — logo background knockout + auto-crop
+// mix-blend can't reach the lattice behind the fixed nav, so the PNG's dark
+// square shows as a hard box. Chroma-key the near-black pixels to transparent
+// (soft alpha by luminance), THEN crop to the K's bounding box so it fills the
+// frame (the source has lots of padding). Same-origin image → untainted canvas.
 // ============================================================
 
-function maskLogo(src) {
+function processLogo(src) {
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.crossOrigin = 'anonymous';
     img.onload = () => {
       try {
+        const w = img.naturalWidth, h = img.naturalHeight;
         const c = document.createElement('canvas');
-        c.width = img.naturalWidth;
-        c.height = img.naturalHeight;
+        c.width = w; c.height = h;
         const ctx = c.getContext('2d');
         ctx.drawImage(img, 0, 0);
-        const d = ctx.getImageData(0, 0, c.width, c.height);
+        const d = ctx.getImageData(0, 0, w, h);
         const p = d.data;
-        for (let i = 0; i < p.length; i += 4) {
-          const lum = Math.max(p[i], p[i + 1], p[i + 2]); // brightest channel
-          let a = (lum - 10) * 3;                          // dark → transparent, soft edge
-          p[i + 3] = a < 0 ? 0 : a > 255 ? 255 : a;
+
+        // knock out the dark background + find content bounds
+        let minX = w, minY = h, maxX = 0, maxY = 0;
+        for (let y = 0; y < h; y++) {
+          for (let x = 0; x < w; x++) {
+            const i = (y * w + x) * 4;
+            const lum = Math.max(p[i], p[i + 1], p[i + 2]);
+            let a = (lum - 10) * 3;
+            a = a < 0 ? 0 : a > 255 ? 255 : a;
+            p[i + 3] = a;
+            if (a > 28) {
+              if (x < minX) minX = x; if (x > maxX) maxX = x;
+              if (y < minY) minY = y; if (y > maxY) maxY = y;
+            }
+          }
         }
         ctx.putImageData(d, 0, 0);
-        resolve(c.toDataURL('image/png'));
+
+        // crop to the K (with a little breathing room)
+        if (maxX > minX && maxY > minY) {
+          const pad = Math.round(Math.max(maxX - minX, maxY - minY) * 0.07);
+          const sx = Math.max(0, minX - pad);
+          const sy = Math.max(0, minY - pad);
+          const sw = Math.min(w - sx, maxX - minX + pad * 2);
+          const sh = Math.min(h - sy, maxY - minY + pad * 2);
+          const out = document.createElement('canvas');
+          out.width = sw; out.height = sh;
+          out.getContext('2d').drawImage(c, sx, sy, sw, sh, 0, 0, sw, sh);
+          resolve(out.toDataURL('image/png'));
+        } else {
+          resolve(c.toDataURL('image/png'));
+        }
       } catch (e) { reject(e); }
     };
     img.onerror = reject;
@@ -39,7 +64,7 @@ async function applyMask() {
   const src = slots[0].getAttribute('src');
   if (!src) return;
   try {
-    const url = await maskLogo(src);
+    const url = await processLogo(src);
     slots.forEach((el) => { el.src = url; });
   } catch { /* leave the original PNG on failure */ }
 }

--- a/website/js/terminal.js
+++ b/website/js/terminal.js
@@ -1,27 +1,30 @@
 // ============================================================
 // KIRRA — live action_filter.py terminal
-// Types real Kirra usage, then "runs" it: the Governor evaluating LLM
-// actions against live posture and printing verdicts (ALLOW / CLAMP /
-// DENY), with a blinking cursor. Loops. Respects prefers-reduced-motion.
+// Types real Kirra usage (syntax-highlighted) then "runs" it: the Governor
+// evaluating LLM actions against live posture, printing ALLOW / CLAMP / DENY
+// with a blinking cursor. Loops, starts on scroll, reduced-motion safe.
+// Code tokens reuse the site's c-kw / c-fn / c-str / c-num / c-cm colours.
 // ============================================================
 
+// line = { c?: lineColourClass, text?: string }  — single colour
+//      | { segs: [ [text, tokenClass], ... ] }   — syntax-coloured code
 const LINES = [
-  { t: '$ python action_filter.py', c: 't-prompt' },
-  { t: '', c: '' },
-  { t: 'import kirra', c: 't-code' },
-  { t: 'gov = kirra.Governor("verifier.fleet.local")', c: 't-code' },
-  { t: '', c: '' },
-  { t: '# every action is judged against live fleet posture', c: 't-dim' },
-  { t: 'gov.evaluate("robot-07", cmd_vel=1.2)', c: 't-code' },
-  { t: '  ✓ ALLOW   Nominal · dispatched', c: 't-ok' },
-  { t: 'gov.evaluate("robot-07", cmd_vel=999)', c: 't-code' },
-  { t: '  ⊘ CLAMP   999 → 2.0 m/s · envelope cap', c: 't-warn' },
-  { t: 'gov.evaluate("robot-07", "drive_to_moon")', c: 't-code' },
-  { t: '  ✕ DENY    unknown action · blocked', c: 't-bad' },
-  { t: 'gov.evaluate("robot-07", cmd_vel=1.2)   # Degraded', c: 't-code' },
-  { t: '  ✕ DENY    kinetic write blocked', c: 't-bad' },
-  { t: '', c: '' },
-  { t: "# fail-closed — if trust isn't proven, nothing moves", c: 't-dim' },
+  { c: 't-prompt', text: '$ python action_filter.py' },
+  { text: '' },
+  { segs: [['import ', 'c-kw'], ['kirra', '']] },
+  { segs: [['gov = kirra.', ''], ['Governor', 'c-fn'], ['(', ''], ['"verifier.fleet.local"', 'c-str'], [')', '']] },
+  { text: '' },
+  { c: 'c-cm', text: '# every action is judged against live fleet posture' },
+  { segs: [['gov.', ''], ['evaluate', 'c-fn'], ['(', ''], ['"robot-07"', 'c-str'], [', cmd_vel=', ''], ['1.2', 'c-num'], [')', '']] },
+  { c: 't-ok', text: '  ✓ ALLOW   Nominal · dispatched' },
+  { segs: [['gov.', ''], ['evaluate', 'c-fn'], ['(', ''], ['"robot-07"', 'c-str'], [', cmd_vel=', ''], ['999', 'c-num'], [')', '']] },
+  { c: 't-warn', text: '  ⊘ CLAMP   999 → 2.0 m/s · envelope cap' },
+  { segs: [['gov.', ''], ['evaluate', 'c-fn'], ['(', ''], ['"robot-07"', 'c-str'], [', ', ''], ['"drive_to_moon"', 'c-str'], [')', '']] },
+  { c: 't-bad', text: '  ✕ DENY    unknown action · blocked' },
+  { segs: [['gov.', ''], ['evaluate', 'c-fn'], ['(', ''], ['"robot-07"', 'c-str'], [', cmd_vel=', ''], ['1.2', 'c-num'], [')', ''], ['   # Degraded', 'c-cm']] },
+  { c: 't-bad', text: '  ✕ DENY    kinetic write blocked' },
+  { text: '' },
+  { c: 'c-cm', text: "# fail-closed — if trust isn't proven, nothing moves" },
 ];
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -33,37 +36,50 @@ function startTerminal() {
   const cursor = document.createElement('span');
   cursor.className = 't-cursor';
 
+  function lineSegs(line) { return line.segs || [[line.text || '', '']]; }
+
   function renderStatic() {
     el.textContent = '';
     for (const line of LINES) {
       const div = document.createElement('div');
-      div.className = 't-line ' + line.c;
-      div.textContent = line.t || ' ';
+      div.className = 't-line ' + (line.c || '');
+      for (const [text, cls] of lineSegs(line)) {
+        if (cls) { const s = document.createElement('span'); s.className = cls; s.textContent = text; div.appendChild(s); }
+        else if (text) div.appendChild(document.createTextNode(text));
+      }
       el.appendChild(div);
     }
   }
 
+  async function typeLine(line) {
+    const div = document.createElement('div');
+    div.className = 't-line ' + (line.c || '');
+    el.appendChild(div);
+    div.appendChild(cursor);
+    const isOut = /t-(ok|warn|bad)/.test(line.c || '');
+    if (isOut) await sleep(360); // "executing…"
+    for (const [text, cls] of lineSegs(line)) {
+      let span = null;
+      if (cls) { span = document.createElement('span'); span.className = cls; div.insertBefore(span, cursor); }
+      for (const ch of text) {
+        const node = document.createTextNode(ch);
+        if (span) span.appendChild(node);
+        else div.insertBefore(node, cursor);
+        await sleep(isOut ? 12 : 18);
+      }
+    }
+    await sleep(80);
+  }
+
   async function run() {
     el.textContent = '';
-    for (const line of LINES) {
-      const div = document.createElement('div');
-      div.className = 't-line ' + line.c;
-      el.appendChild(div);
-      div.appendChild(cursor);
-      if (/t-(ok|warn|bad)/.test(line.c)) await sleep(360); // "executing…"
-      for (const ch of line.t) {
-        div.insertBefore(document.createTextNode(ch), cursor);
-        await sleep(line.c === 't-ok' || line.c === 't-warn' || line.c === 't-bad' ? 12 : 17);
-      }
-      await sleep(line.t ? 70 : 40);
-    }
+    for (const line of LINES) await typeLine(line);
     await sleep(2600);
     run();
   }
 
   if (reduced) { renderStatic(); return; }
 
-  // start once the section scrolls into view
   let started = false;
   const io = new IntersectionObserver((entries) => {
     if (entries.some((e) => e.isIntersecting) && !started) {


### PR DESCRIPTION
Follow-up polish (website-only).

- **Logo bigger**: the source PNG has heavy padding, so the K looked small. `logomask.js` now **auto-crops to the K's bounding box** (after the transparent knockout) so it fills the frame — much larger at the same footprint. Sizes bumped too (nav 44→50px, preloader →104px).
- **Terminal real-terminal color**: the typed code is now **syntax-highlighted** (keywords / strings / functions / numbers via the existing `c-*` classes) on top of the coloured ✓ALLOW / ⊘CLAMP / ✕DENY output.

Verified: `node --check` on both modules.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_