### PR TITLE
Terminal → real Kirra Rust (action_filter.rs) + load page at top

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -262,7 +262,7 @@
         <div class="code-window">
           <div class="code-window__bar">
             <span class="code-dot"></span><span class="code-dot"></span><span class="code-dot"></span>
-            <span class="code-window__title">action_filter.py</span>
+            <span class="code-window__title">action_filter.rs</span>
           </div>
 <pre class="code-window__body"><code id="termBody"><span class="c-kw">import</span> kirra
 

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -10,6 +10,11 @@ const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 function boot() {
   const gsap = window.gsap;
   if (!gsap) { return void setTimeout(boot, 50); } // wait for CDN
+
+  // Always resolve at the top — don't let the browser restore a scroll offset.
+  if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+  window.scrollTo(0, 0);
+
   const { ScrollTrigger } = window;
   if (window.ScrollTrigger) gsap.registerPlugin(window.ScrollTrigger);
   const ST = window.ScrollTrigger;
@@ -34,6 +39,7 @@ function boot() {
   sceneReady.then(() => { sceneDone = true; });
 
   function finishPreloader() {
+    window.scrollTo(0, 0);
     const tl = gsap.timeline();
     tl.to(pre, { yPercent: -100, duration: 1, ease: 'power4.inOut', onComplete: () => pre && (pre.style.display = 'none') })
       .add(introHero, '-=0.5');

--- a/website/js/terminal.js
+++ b/website/js/terminal.js
@@ -9,22 +9,24 @@
 // line = { c?: lineColourClass, text?: string }  — single colour
 //      | { segs: [ [text, tokenClass], ... ] }   — syntax-coloured code
 const LINES = [
-  { c: 't-prompt', text: '$ python action_filter.py' },
+  { c: 't-prompt', text: '$ cargo run --example action_filter' },
   { text: '' },
-  { segs: [['import ', 'c-kw'], ['kirra', '']] },
-  { segs: [['gov = kirra.', ''], ['Governor', 'c-fn'], ['(', ''], ['"verifier.fleet.local"', 'c-str'], [')', '']] },
+  { segs: [['use ', 'c-kw'], ['kirra::action_filter::', ''], ['evaluate_action_claim', 'c-fn'], [';', '']] },
+  { segs: [['use ', 'c-kw'], ['kirra::verifier::FleetPosture', ''], [';', '']] },
   { text: '' },
-  { c: 'c-cm', text: '# every action is judged against live fleet posture' },
-  { segs: [['gov.', ''], ['evaluate', 'c-fn'], ['(', ''], ['"robot-07"', 'c-str'], [', cmd_vel=', ''], ['1.2', 'c-num'], [')', '']] },
-  { c: 't-ok', text: '  ✓ ALLOW   Nominal · dispatched' },
-  { segs: [['gov.', ''], ['evaluate', 'c-fn'], ['(', ''], ['"robot-07"', 'c-str'], [', cmd_vel=', ''], ['999', 'c-num'], [')', '']] },
-  { c: 't-warn', text: '  ⊘ CLAMP   999 → 2.0 m/s · envelope cap' },
-  { segs: [['gov.', ''], ['evaluate', 'c-fn'], ['(', ''], ['"robot-07"', 'c-str'], [', ', ''], ['"drive_to_moon"', 'c-str'], [')', '']] },
-  { c: 't-bad', text: '  ✕ DENY    unknown action · blocked' },
-  { segs: [['gov.', ''], ['evaluate', 'c-fn'], ['(', ''], ['"robot-07"', 'c-str'], [', cmd_vel=', ''], ['1.2', 'c-num'], [')', ''], ['   # Degraded', 'c-cm']] },
-  { c: 't-bad', text: '  ✕ DENY    kinetic write blocked' },
+  { c: 'c-cm', text: '// every agent action is judged against live posture' },
+  { segs: [['let ', 'c-kw'], ['d = ', ''], ['evaluate_action_claim', 'c-fn'], ['(claim, ', ''], ['FleetPosture::Nominal', 'c-num'], [')', '']] },
+  { c: 't-ok', text: '  ✓ allowed=true    NOMINAL_VALID_KINEMATICS' },
+  { c: 'c-cm', text: '// claim.payload = { "linear": 999.0 }' },
+  { c: 't-bad', text: '  ✕ allowed=false   KINEMATIC_ENVELOPE_BREACH' },
+  { c: 'c-cm', text: '// claim.action_type = "drive_to_moon"' },
+  { c: 't-bad', text: '  ✕ allowed=false   UNKNOWN_ACTION_TYPE' },
+  { c: 'c-cm', text: '// posture = FleetPosture::Degraded' },
+  { c: 't-bad', text: '  ✕ allowed=false   DEGRADED_POSTURE_KINETIC_DENIED' },
+  { c: 'c-cm', text: '// claim.action_type = "read_telemetry"' },
+  { c: 't-ok', text: '  ✓ allowed=true    DEGRADED_READ_ONLY_PERMITTED' },
   { text: '' },
-  { c: 'c-cm', text: "# fail-closed — if trust isn't proven, nothing moves" },
+  { c: 'c-cm', text: "// fail-closed — if trust isn't proven, nothing moves" },
 ];
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));


### PR DESCRIPTION
Website-only. Two fixes from the desktop review.

## 1. Terminal → real Kirra Rust
`action_filter` is a **Rust** module (`src/action_filter.rs`); the Python files are just LLM client examples. So the terminal now shows real Rust — `evaluate_action_claim(claim, FleetPosture)` returning `ActionDecision { allowed, reason }` with the **actual reason codes** from the source: `NOMINAL_VALID_KINEMATICS`, `KINEMATIC_ENVELOPE_BREACH`, `UNKNOWN_ACTION_TYPE`, `DEGRADED_POSTURE_KINETIC_DENIED`, `DEGRADED_READ_ONLY_PERMITTED`. Window retitled **`action_filter.rs`**. Syntax-coloured + blinking cursor as before.

## 2. Page loads at the top
On desktop it was resolving slightly scrolled down (past the hero eyebrow) — the browser was restoring a scroll offset. Set `history.scrollRestoration = 'manual'` + `scrollTo(0,0)` on boot and when the preloader lifts.

Verified: `node --check` on both modules; title updated.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_