### PR TITLE
Cache-bust CSS/JS (?v=2) so the Rust terminal loads

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -11,7 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="icon" type="image/png" href="assets/kirra-logo.png" />
   <meta name="theme-color" content="#04060c" />
-  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/style.css?v=2" />
 
   <!-- Three.js (module) -->
   <script type="importmap">
@@ -335,11 +335,11 @@ verdict = governor.<span class="c-fn">evaluate</span>(
     <div class="footer__legal">Fail&#8209;closed by construction · Built for robots that can hurt people.</div>
   </footer>
 
-  <script type="module" src="js/scene.js"></script>
-  <script type="module" src="js/main.js"></script>
-  <script type="module" src="js/flow.js"></script>
-  <script type="module" src="js/notes.js"></script>
-  <script type="module" src="js/terminal.js"></script>
-  <script type="module" src="js/logomask.js"></script>
+  <script type="module" src="js/scene.js?v=2"></script>
+  <script type="module" src="js/main.js?v=2"></script>
+  <script type="module" src="js/flow.js?v=2"></script>
+  <script type="module" src="js/notes.js?v=2"></script>
+  <script type="module" src="js/terminal.js?v=2"></script>
+  <script type="module" src="js/logomask.js?v=2"></script>
 </body>
 </html>


### PR DESCRIPTION
The header showed `action_filter.rs` but the terminal still typed Python — the browser was running a **stale cached `terminal.js`**. Version the CSS/JS URLs (`?v=2`) so browsers fetch the current files (the Rust terminal, the scroll fix, the cropped logo).

Website-only, no logic change.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_