### PR TITLE
Kirra Mission Console — Drop 1: foundation + Fleet Overview

### DIFF
--- a/console/.gitignore
+++ b/console/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+out
+.env*
+*.tsbuildinfo
+next-env.d.ts

--- a/console/README.md
+++ b/console/README.md
@@ -1,0 +1,59 @@
+# Kirra Mission Console
+
+Enterprise robotics & AI-safety operations dashboard for the Kirra Systems runtime governor — fleet operations, safety-governor oversight, runtime health, telemetry, and compliance.
+
+> Design language: Palantir Foundry x mission-control x autonomous-systems ops. Dark-first, graphite surfaces, restrained safety/amber/critical/ice accents. Built to be credible to operators and safety auditors while presenting at executive level.
+
+## Stack
+
+- **Next.js 15** (App Router) · **React 18** · **TypeScript**
+- **TailwindCSS** with shadcn-style CSS-variable tokens
+- **Recharts** (engineering-grade charts) · **Framer Motion** (subtle motion) · **lucide-react**
+
+## Run
+
+```bash
+cd console
+npm install
+npm run dev   # http://localhost:3000
+```
+
+## Architecture
+
+```
+console/
+  app/
+    layout.tsx          # shell: top nav + sidebar grid
+    page.tsx            # Fleet Overview
+    [...slug]/page.tsx  # styled placeholder for not-yet-built modules
+    globals.css         # design tokens + base
+  components/
+    shell/              # top-nav, sidebar
+    ui/primitives.tsx   # Panel, Stat, Pill, Meter, StatusDot
+    charts/charts.tsx   # TrendArea, Spark, ScoreRing (Recharts)
+  lib/
+    types.ts            # domain model (Robot, KPI, Posture, EventItem)
+    mock.ts             # mock fleet + telemetry data
+  tailwind.config.ts    # color tokens, fonts, shadows
+```
+
+## Design tokens
+
+| Token | Use |
+|-------|-----|
+| `bg` / `surface` / `panel` / `elevated` | graphite surface stack |
+| `ink` / `muted` / `faint` | text hierarchy |
+| `safe` (green) | compliant / nominal |
+| `warn` (amber) | warnings / degraded |
+| `crit` (red) | critical interventions |
+| `ice` (blue) | telemetry / analytics |
+
+## Roadmap (build increments)
+
+- **Drop 1 (this):** design system, app shell, component library, **Fleet Overview**.
+- **Drop 2:** Safety Governor Command Center, Runtime Health.
+- **Drop 3:** Telemetry visualization, Mission Operations timeline.
+- **Drop 4:** Compliance Center, AI Decision Oversight, Incident Review.
+- **Drop 5:** Analytics, Reports, Settings, mobile adaptations.
+
+© 2026 Kirra Systems, LLC · Proprietary & confidential.

--- a/console/app/[...slug]/page.tsx
+++ b/console/app/[...slug]/page.tsx
@@ -1,0 +1,19 @@
+import { Panel } from '@/components/ui/primitives'
+
+export default async function ModulePlaceholder({ params }: { params: Promise<{ slug: string[] }> }) {
+  const { slug } = await params
+  const name = (slug?.[0] ?? 'module').replace(/-/g, ' ')
+  return (
+    <div className="mx-auto max-w-[1500px] p-6">
+      <h1 className="font-display text-xl font-semibold capitalize text-ink">{name}</h1>
+      <p className="mb-6 font-mono text-[11px] text-faint">module scaffold</p>
+      <Panel>
+        <div className="grid place-items-center gap-2 py-20 text-center">
+          <span className="h-2 w-2 rounded-full bg-ice" />
+          <p className="font-display text-lg text-ink">Module in development</p>
+          <p className="max-w-sm text-sm text-muted">This screen is part of the Kirra Mission Console build-out. Operational widgets, engineering charts, and cross-linked drill-downs ship in the next increment.</p>
+        </div>
+      </Panel>
+    </div>
+  )
+}

--- a/console/app/globals.css
+++ b/console/app/globals.css
@@ -1,0 +1,37 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  /* graphite surfaces (space-separated RGB channels for tailwind alpha) */
+  --bg: 8 10 16;
+  --surface: 11 14 22;
+  --panel: 16 20 30;
+  --elevated: 22 27 39;
+  --ink: 233 237 246;
+  --muted: 154 166 189;
+  --faint: 105 114 138;
+  /* restrained state accents */
+  --safe: 47 230 166;
+  --warn: 255 176 32;
+  --crit: 255 84 104;
+  --ice: 92 198 255;
+}
+
+@layer base {
+  html, body { height: 100%; }
+  body {
+    background: rgb(var(--bg));
+    color: rgb(var(--ink));
+    -webkit-font-smoothing: antialiased;
+  }
+}
+
+@layer utilities {
+  .scrollbar-thin::-webkit-scrollbar { width: 8px; height: 8px; }
+  .scrollbar-thin::-webkit-scrollbar-thumb { background: rgba(150,166,198,0.18); border-radius: 8px; }
+  .scrollbar-thin::-webkit-scrollbar-track { background: transparent; }
+  .grid-bg { background-image: radial-gradient(rgba(150,166,198,0.06) 1px, transparent 1px); background-size: 22px 22px; }
+}
+
+::selection { background: rgb(var(--safe)); color: #04130d; }

--- a/console/app/layout.tsx
+++ b/console/app/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next'
+import { Space_Grotesk, Inter, JetBrains_Mono } from 'next/font/google'
+import './globals.css'
+import { Sidebar } from '@/components/shell/sidebar'
+import { TopNav } from '@/components/shell/top-nav'
+
+const display = Space_Grotesk({ subsets: ['latin'], variable: '--font-display' })
+const sans = Inter({ subsets: ['latin'], variable: '--font-sans' })
+const mono = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mono' })
+
+export const metadata: Metadata = {
+  title: 'Kirra Mission Console',
+  description: 'Fleet operations & AI safety governance for autonomous systems.',
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className={`${display.variable} ${sans.variable} ${mono.variable} dark`}>
+      <body className="font-sans antialiased">
+        <div className="flex h-screen overflow-hidden bg-bg">
+          <Sidebar />
+          <div className="flex min-w-0 flex-1 flex-col">
+            <TopNav />
+            <main className="scrollbar-thin flex-1 overflow-y-auto">{children}</main>
+          </div>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/console/app/page.tsx
+++ b/console/app/page.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from 'react'
+import { Panel, Stat, Pill, StatusDot, Meter } from '@/components/ui/primitives'
+import { TrendArea, Spark, ScoreRing } from '@/components/charts/charts'
+import { kpis, robots, events, series, postureTone } from '@/lib/mock'
+
+export default function OverviewPage() {
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-ink">Fleet Overview</h1>
+          <p className="font-mono text-[11px] text-faint">PRODUCTION · us-fleet-1 · updated 2s ago</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Pill tone="safe">Fleet Nominal</Pill>
+          <Pill tone="ice">E-Stop Armed</Pill>
+          <button className="rounded-lg border border-line bg-panel px-3 py-1.5 font-mono text-[11px] text-muted hover:text-ink">Last 24h</button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-5">
+        {kpis.map((k) => (
+          <Stat key={k.label} label={k.label} value={k.value} unit={k.unit} delta={k.delta} tone={k.tone}>
+            {k.spark && <Spark data={k.spark} color={k.tone === 'muted' ? 'ice' : k.tone} />}
+          </Stat>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Fleet Throughput" subtitle="commands evaluated · per second" action={<Pill tone="ice">live</Pill>}>
+          <TrendArea data={series.throughput} color="ice" height={220} />
+        </Panel>
+        <Panel title="Safety Governor" subtitle="real-time verdict engine">
+          <div className="flex items-center gap-4">
+            <div className="w-1/2"><ScoreRing value={98} color="safe" label="Safety Score" /></div>
+            <div className="w-1/2 space-y-3">
+              <Row label="State" value={<Pill tone="safe">Nominal</Pill>} />
+              <Row label="E-Stop" value={<span className="font-mono text-xs text-safe">ARMED</span>} />
+              <Row label="Constraints" value={<span className="font-mono text-xs text-ink">42 / 42</span>} />
+              <Row label="Violations 24h" value={<span className="font-mono text-xs text-warn">3</span>} />
+            </div>
+          </div>
+        </Panel>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Active Fleet" subtitle={`${robots.length} units`} dense>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-left">
+              <thead>
+                <tr className="border-b border-line font-mono text-[10px] uppercase tracking-wider text-faint">
+                  <th className="px-4 py-2 font-normal">Unit</th>
+                  <th className="px-4 py-2 font-normal">Posture</th>
+                  <th className="px-4 py-2 font-normal">Mission</th>
+                  <th className="px-4 py-2 font-normal">Battery</th>
+                  <th className="px-4 py-2 font-normal">Latency</th>
+                  <th className="px-4 py-2 font-normal">Status</th>
+                </tr>
+              </thead>
+              <tbody className="font-mono text-[12px]">
+                {robots.map((r) => (
+                  <tr key={r.id} className="border-b border-line last:border-0 hover:bg-white/[0.02]">
+                    <td className="px-4 py-2.5"><div className="text-ink">{r.name}</div><div className="text-[10px] text-faint">{r.model}</div></td>
+                    <td className="px-4 py-2.5"><Pill tone={postureTone(r.posture)}>{r.posture}</Pill></td>
+                    <td className="px-4 py-2.5 text-muted">{r.mission}</td>
+                    <td className="px-4 py-2.5"><div className="flex items-center gap-2"><span className="w-9 text-ink">{r.battery}%</span><div className="w-16"><Meter value={r.battery} tone={r.battery < 25 ? 'crit' : r.battery < 50 ? 'warn' : 'safe'} /></div></div></td>
+                    <td className="px-4 py-2.5 text-muted">{r.latencyMs}ms</td>
+                    <td className="px-4 py-2.5"><span className="inline-flex items-center gap-2 text-muted"><StatusDot tone={r.status === 'online' ? 'safe' : r.status === 'standby' ? 'warn' : 'muted'} pulse={r.status === 'online'} />{r.status}</span></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Panel>
+
+        <Panel title="Event Stream" subtitle="governor + fleet" action={<Pill tone="ice">live</Pill>} dense>
+          <ul className="divide-y divide-line">
+            {events.map((e) => (
+              <li key={e.id} className="flex gap-3 px-4 py-3">
+                <span className="mt-1.5"><StatusDot tone={e.tone} /></span>
+                <div className="min-w-0">
+                  <p className="text-[12px] leading-snug text-ink">{e.message}</p>
+                  <p className="mt-0.5 font-mono text-[10px] text-faint">{e.source} · {e.ts}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      </div>
+    </div>
+  )
+}
+
+function Row({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{label}</span>
+      {value}
+    </div>
+  )
+}

--- a/console/app/runtime/page.tsx
+++ b/console/app/runtime/page.tsx
@@ -1,0 +1,104 @@
+import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { Spark } from '@/components/charts/charts'
+import { LatencyLines } from '@/components/charts/extra'
+import { resources, latency, network, partitions, nodes } from '@/lib/runtime'
+import type { Tone } from '@/lib/types'
+
+export default function RuntimePage() {
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-ink">Runtime Health</h1>
+          <p className="font-mono text-[11px] text-faint">compute · transport · isolation</p>
+        </div>
+        <Pill tone="safe">All partitions enforced</Pill>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {resources.map((r) => (
+          <div key={r.label} className="rounded-xl border border-line bg-panel p-4 shadow-panel">
+            <div className="flex items-center justify-between">
+              <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{r.label}</span>
+              <span className={`font-mono text-[11px] ${txt(r.tone)}`}>{r.pct}%</span>
+            </div>
+            <div className="mt-2 font-display text-2xl font-semibold text-ink">{r.pct}<span className="text-sm text-muted">%</span></div>
+            <div className="mt-3"><Meter value={r.pct} tone={r.tone} /></div>
+            <p className="mt-2 font-mono text-[10px] text-faint">{r.detail}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="DDS Latency" subtitle="p50 / p99 · ms · FTTI budget 50ms" action={<Pill tone="ice">live</Pill>}>
+          <LatencyLines data={latency} height={210} />
+        </Panel>
+        <Panel title="Network Health">
+          <div className="space-y-4">
+            {network.map((n) => (
+              <div key={n.label}>
+                <div className="flex items-center justify-between">
+                  <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{n.label}</span>
+                  <span className="font-mono text-xs text-ink">{n.value}<span className="text-muted"> {n.unit}</span></span>
+                </div>
+                <div className="mt-1"><Spark data={n.spark} color={n.tone === 'muted' ? 'ice' : n.tone} /></div>
+              </div>
+            ))}
+          </div>
+        </Panel>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <Panel title="Hypervisor & Partition Isolation" subtitle="QNX safety partition · isolated guests" dense>
+          <ul>
+            {partitions.map((p) => (
+              <li key={p.name} className="flex items-center gap-4 border-b border-line px-4 py-3 last:border-0">
+                <StatusDot tone={p.tone} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="truncate text-[13px] text-ink">{p.name}</span>
+                    <Pill tone={p.tone}>{p.isolation}</Pill>
+                  </div>
+                  <div className="mt-2 flex items-center gap-3">
+                    <span className="font-mono text-[10px] text-faint">CPU budget</span>
+                    <div className="flex-1"><Meter value={p.cpuBudget} tone={p.cpuBudget > 85 ? 'warn' : 'safe'} /></div>
+                    <span className="w-9 text-right font-mono text-[10px] text-muted">{p.cpuBudget}%</span>
+                  </div>
+                  <p className="mt-1 font-mono text-[10px] text-faint">{p.role}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+
+        <Panel title="Node Health" subtitle={`${nodes.length} compute nodes`} dense>
+          <div className="grid grid-cols-2 gap-px bg-line sm:grid-cols-3">
+            {nodes.map((n) => (
+              <div key={n.id} className="bg-panel p-3">
+                <div className="flex items-center justify-between">
+                  <span className="font-mono text-[11px] text-ink">{n.id}</span>
+                  <StatusDot tone={n.tone} />
+                </div>
+                <div className="mt-2 space-y-1.5 font-mono text-[10px] text-faint">
+                  <Row2 k="cpu" v={`${n.cpu}%`} />
+                  <Row2 k="mem" v={`${n.mem}%`} />
+                  <Row2 k="temp" v={`${n.tempC}°C`} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </Panel>
+      </div>
+    </div>
+  )
+}
+
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
+function Row2({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span>{k}</span>
+      <span className="text-muted">{v}</span>
+    </div>
+  )
+}

--- a/console/app/safety/page.tsx
+++ b/console/app/safety/page.tsx
@@ -1,0 +1,162 @@
+import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { ScoreRing } from '@/components/charts/charts'
+import { constraints, violations, interventions, verdictMix } from '@/lib/safety'
+import type { Tone } from '@/lib/types'
+
+export default function SafetyPage() {
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-ink">Safety Governor</h1>
+          <p className="font-mono text-[11px] text-faint">command center · fail-closed verdict engine</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Pill tone="safe">State: Nominal</Pill>
+          <button className="rounded-lg border border-crit/40 bg-crit/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-wider text-crit hover:bg-crit/20">Emergency Stop</button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <Panel title="Safety Score" subtitle="composite governance index">
+          <ScoreRing value={98} color="safe" label="of 100" />
+          <div className="mt-2 grid grid-cols-3 gap-2 text-center font-mono text-[10px] uppercase tracking-wider text-faint">
+            <div><div className="text-sm text-safe">A+</div>envelope</div>
+            <div><div className="text-sm text-safe">100%</div>coverage</div>
+            <div><div className="text-sm text-warn">3</div>open</div>
+          </div>
+        </Panel>
+
+        <Panel title="Emergency Stop Readiness">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <span className="font-display text-2xl font-semibold text-safe">ARMED</span>
+              <StatusDot tone="safe" pulse />
+            </div>
+            <KV k="Stop-path latency" v="42 ms" />
+            <KV k="Last self-test" v="08:00:00 · pass" />
+            <KV k="Redundant channels" v="2 / 2 healthy" />
+            <KV k="MRC profile" v="decel-to-stop · hold" />
+          </div>
+        </Panel>
+
+        <Panel title="Verdict Throughput" subtitle="last 24h">
+          <div className="mb-3 flex items-baseline gap-2">
+            <span className="font-display text-3xl font-semibold text-ink">{(verdictMix.allow + verdictMix.clamp + verdictMix.deny).toLocaleString()}</span>
+            <span className="font-mono text-xs text-muted">decisions</span>
+          </div>
+          <VerdictBar allow={verdictMix.allow} clamp={verdictMix.clamp} deny={verdictMix.deny} />
+        </Panel>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <Panel title="Constraint Monitoring" subtitle="active safety goals & envelopes" dense>
+          <ul>
+            {constraints.map((c) => (
+              <li key={c.id} className="flex items-center gap-4 border-b border-line px-4 py-3 last:border-0">
+                <StatusDot tone={c.tone} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="truncate text-[13px] text-ink">{c.name}</span>
+                    <span className="font-mono text-[11px] text-muted">{c.value} <span className="text-faint">/ {c.limit}</span></span>
+                  </div>
+                  <div className="mt-2 flex items-center gap-3">
+                    <div className="flex-1"><Meter value={c.util} tone={c.tone} /></div>
+                    <span className={`font-mono text-[10px] uppercase tracking-wider ${txt(c.tone)}`}>{c.status}</span>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+
+        <Panel title="Intervention History" subtitle="governor actions" dense>
+          <ul className="px-4 py-2">
+            {interventions.map((it, idx) => (
+              <li key={it.id} className="relative flex gap-4 pb-5 pl-2 last:pb-2">
+                {idx < interventions.length - 1 && <span className="absolute left-[11px] top-4 h-full w-px bg-line" />}
+                <span className={`mt-1 h-2.5 w-2.5 shrink-0 rounded-full ${dotBg(it.tone)}`} />
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className={`rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold ${badge(it.tone)}`}>{it.kind}</span>
+                    <span className="font-mono text-[10px] text-faint">{it.ts}</span>
+                  </div>
+                  <p className="mt-1 text-[12px] text-muted">{it.detail}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      </div>
+
+      <Panel title="Rule Violations" subtitle="fail-closed denials & lockouts" dense>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-left">
+            <thead>
+              <tr className="border-b border-line font-mono text-[10px] uppercase tracking-wider text-faint">
+                <th className="px-4 py-2 font-normal">Time</th>
+                <th className="px-4 py-2 font-normal">Rule</th>
+                <th className="px-4 py-2 font-normal">Asset</th>
+                <th className="px-4 py-2 font-normal">Action</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono text-[12px]">
+              {violations.map((v) => (
+                <tr key={v.id} className="border-b border-line last:border-0 hover:bg-white/[0.02]">
+                  <td className="px-4 py-2.5 text-faint">{v.ts}</td>
+                  <td className={`px-4 py-2.5 ${v.tone === 'crit' ? 'text-crit' : 'text-warn'}`}>{v.rule}</td>
+                  <td className="px-4 py-2.5 text-ink">{v.asset}</td>
+                  <td className="px-4 py-2.5 text-muted">{v.action}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Panel>
+    </div>
+  )
+}
+
+function KV({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{k}</span>
+      <span className="font-mono text-xs text-ink">{v}</span>
+    </div>
+  )
+}
+
+function VerdictBar({ allow, clamp, deny }: { allow: number; clamp: number; deny: number }) {
+  const total = allow + clamp + deny
+  const p = (n: number) => `${(n / total) * 100}%`
+  return (
+    <div>
+      <div className="flex h-2 overflow-hidden rounded-full bg-white/5">
+        <div className="bg-safe" style={{ width: p(allow) }} />
+        <div className="bg-warn" style={{ width: p(clamp) }} />
+        <div className="bg-crit" style={{ width: p(deny) }} />
+      </div>
+      <div className="mt-3 grid grid-cols-3 gap-2 font-mono text-[11px]">
+        <Leg tone="safe" label="ALLOW" value={allow} />
+        <Leg tone="warn" label="CLAMP" value={clamp} />
+        <Leg tone="crit" label="DENY" value={deny} />
+      </div>
+    </div>
+  )
+}
+
+function Leg({ tone, label, value }: { tone: Tone; label: string; value: number }) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5">
+        <span className={`h-2 w-2 rounded-full ${dotBg(tone)}`} />
+        <span className="text-faint">{label}</span>
+      </div>
+      <div className="mt-0.5 text-ink">{value.toLocaleString()}</div>
+    </div>
+  )
+}
+
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
+function dotBg(t: Tone) { return t === 'safe' ? 'bg-safe' : t === 'warn' ? 'bg-warn' : t === 'crit' ? 'bg-crit' : t === 'ice' ? 'bg-ice' : 'bg-muted' }
+function badge(t: Tone) { return t === 'safe' ? 'bg-safe/15 text-safe' : t === 'warn' ? 'bg-warn/15 text-warn' : t === 'crit' ? 'bg-crit/15 text-crit' : 'bg-ice/15 text-ice' }

--- a/console/components/charts/charts.tsx
+++ b/console/components/charts/charts.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { Area, AreaChart, ResponsiveContainer, Tooltip, XAxis, YAxis, CartesianGrid, RadialBar, RadialBarChart, PolarAngleAxis } from 'recharts'
+import type { SeriesPoint } from '@/lib/types'
+
+const COLORS = { safe: '#2fe6a6', warn: '#ffb020', crit: '#ff5468', ice: '#5cc6ff' } as const
+type ChartColor = keyof typeof COLORS
+
+export function TrendArea({ data, color = 'ice', height = 200 }: { data: SeriesPoint[]; color?: ChartColor; height?: number }) {
+  const c = COLORS[color]
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <AreaChart data={data} margin={{ top: 6, right: 8, left: -16, bottom: 0 }}>
+        <defs>
+          <linearGradient id={`grad-${color}`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={c} stopOpacity={0.35} />
+            <stop offset="100%" stopColor={c} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid stroke="rgba(150,166,198,0.08)" vertical={false} />
+        <XAxis dataKey="t" tick={{ fill: '#69728a', fontSize: 10, fontFamily: 'monospace' }} axisLine={false} tickLine={false} minTickGap={28} />
+        <YAxis tick={{ fill: '#69728a', fontSize: 10, fontFamily: 'monospace' }} axisLine={false} tickLine={false} width={42} />
+        <Tooltip
+          contentStyle={{ background: '#10141e', border: '1px solid rgba(150,166,198,0.22)', borderRadius: 10, fontFamily: 'monospace', fontSize: 12 }}
+          labelStyle={{ color: '#9aa6bd' }}
+          itemStyle={{ color: c }}
+        />
+        <Area type="monotone" dataKey="v" stroke={c} strokeWidth={1.6} fill={`url(#grad-${color})`} dot={false} />
+      </AreaChart>
+    </ResponsiveContainer>
+  )
+}
+
+export function Spark({ data, color = 'ice' }: { data: SeriesPoint[]; color?: ChartColor }) {
+  const c = COLORS[color]
+  return (
+    <ResponsiveContainer width="100%" height={38}>
+      <AreaChart data={data} margin={{ top: 2, right: 0, left: 0, bottom: 0 }}>
+        <defs>
+          <linearGradient id={`spark-${color}`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={c} stopOpacity={0.3} />
+            <stop offset="100%" stopColor={c} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <Area type="monotone" dataKey="v" stroke={c} strokeWidth={1.4} fill={`url(#spark-${color})`} dot={false} />
+      </AreaChart>
+    </ResponsiveContainer>
+  )
+}
+
+export function ScoreRing({ value, color = 'safe', label }: { value: number; color?: ChartColor; label?: string }) {
+  const c = COLORS[color]
+  return (
+    <div className="relative">
+      <ResponsiveContainer width="100%" height={150}>
+        <RadialBarChart innerRadius="78%" outerRadius="100%" data={[{ value }]} startAngle={220} endAngle={-40}>
+          <PolarAngleAxis type="number" domain={[0, 100]} tick={false} />
+          <RadialBar dataKey="value" cornerRadius={8} fill={c} background={{ fill: 'rgba(255,255,255,0.05)' }} />
+        </RadialBarChart>
+      </ResponsiveContainer>
+      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+        <span className="font-display text-3xl font-semibold text-ink">{value}</span>
+        {label && <span className="font-mono text-[10px] uppercase tracking-wider text-faint">{label}</span>}
+      </div>
+    </div>
+  )
+}

--- a/console/components/charts/extra.tsx
+++ b/console/components/charts/extra.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis, CartesianGrid, Legend } from 'recharts'
+
+export function LatencyLines({ data, height = 200 }: { data: { t: string; p50: number; p99: number }[]; height?: number }) {
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <LineChart data={data} margin={{ top: 6, right: 8, left: -16, bottom: 0 }}>
+        <CartesianGrid stroke="rgba(150,166,198,0.08)" vertical={false} />
+        <XAxis dataKey="t" tick={{ fill: '#69728a', fontSize: 10, fontFamily: 'monospace' }} axisLine={false} tickLine={false} minTickGap={28} />
+        <YAxis tick={{ fill: '#69728a', fontSize: 10, fontFamily: 'monospace' }} axisLine={false} tickLine={false} width={42} unit="ms" />
+        <Tooltip contentStyle={{ background: '#10141e', border: '1px solid rgba(150,166,198,0.22)', borderRadius: 10, fontFamily: 'monospace', fontSize: 12 }} labelStyle={{ color: '#9aa6bd' }} />
+        <Legend wrapperStyle={{ fontFamily: 'monospace', fontSize: 10, color: '#69728a' }} iconType="plainline" />
+        <Line type="monotone" dataKey="p50" stroke="#5cc6ff" strokeWidth={1.6} dot={false} name="p50" />
+        <Line type="monotone" dataKey="p99" stroke="#ffb020" strokeWidth={1.6} dot={false} name="p99" />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/console/components/shell/sidebar.tsx
+++ b/console/components/shell/sidebar.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import { LayoutDashboard, Boxes, ShieldCheck, Activity, Radio, Route, Brain, Bell, AlertTriangle, FileCheck2, BarChart3, FileText, Settings } from 'lucide-react'
+
+const groups = [
+  {
+    label: 'Operations',
+    items: [
+      { href: '/', label: 'Overview', icon: LayoutDashboard },
+      { href: '/fleet', label: 'Fleet Operations', icon: Boxes },
+      { href: '/safety', label: 'Safety Governor', icon: ShieldCheck },
+      { href: '/runtime', label: 'Runtime Health', icon: Activity },
+      { href: '/telemetry', label: 'Telemetry', icon: Radio },
+      { href: '/missions', label: 'Mission Timeline', icon: Route },
+    ],
+  },
+  {
+    label: 'Governance',
+    items: [
+      { href: '/oversight', label: 'AI Oversight', icon: Brain },
+      { href: '/events', label: 'Events', icon: Bell },
+      { href: '/incidents', label: 'Incident Review', icon: AlertTriangle },
+      { href: '/compliance', label: 'Compliance', icon: FileCheck2 },
+    ],
+  },
+  {
+    label: 'Insight',
+    items: [
+      { href: '/analytics', label: 'Analytics', icon: BarChart3 },
+      { href: '/reports', label: 'Reports', icon: FileText },
+      { href: '/settings', label: 'Settings', icon: Settings },
+    ],
+  },
+]
+
+export function Sidebar() {
+  const path = usePathname()
+  return (
+    <aside className="hidden h-full w-[244px] shrink-0 flex-col border-r border-line bg-surface lg:flex">
+      <nav className="scrollbar-thin flex-1 overflow-y-auto px-3 py-4">
+        {groups.map((g) => (
+          <div key={g.label} className="mb-5">
+            <p className="px-3 pb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-faint">{g.label}</p>
+            <ul className="space-y-0.5">
+              {g.items.map((it) => {
+                const active = path === it.href
+                const Icon = it.icon
+                return (
+                  <li key={it.href}>
+                    <Link href={it.href} className={cn('group flex items-center gap-3 rounded-lg px-3 py-2 text-[13px] transition-colors', active ? 'bg-white/[0.06] text-ink' : 'text-muted hover:bg-white/[0.03] hover:text-ink')}>
+                      <Icon className={cn('h-4 w-4', active ? 'text-safe' : 'text-faint group-hover:text-muted')} strokeWidth={1.75} />
+                      <span>{it.label}</span>
+                      {active && <span className="ml-auto h-1.5 w-1.5 rounded-full bg-safe" />}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        ))}
+      </nav>
+      <div className="border-t border-line p-3">
+        <div className="rounded-lg border border-line bg-panel p-3">
+          <div className="flex items-center gap-2">
+            <span className="h-2 w-2 rounded-full bg-safe" />
+            <span className="font-mono text-[11px] text-muted">All systems nominal</span>
+          </div>
+          <p className="mt-1 font-mono text-[10px] text-faint">v1.2.0 · region us-fleet-1</p>
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/console/components/shell/top-nav.tsx
+++ b/console/components/shell/top-nav.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { Search, Bell, ChevronDown } from 'lucide-react'
+import { Pill } from '@/components/ui/primitives'
+
+function KMark() {
+  return (
+    <svg viewBox="0 0 64 64" className="h-7 w-7" aria-hidden="true">
+      <g stroke="#2fe6a6" strokeWidth="3" strokeLinecap="round" opacity="0.9">
+        <line x1="20" y1="12" x2="20" y2="52" />
+        <line x1="20" y1="32" x2="46" y2="12" />
+        <line x1="20" y1="32" x2="46" y2="52" />
+      </g>
+      <g fill="#2fe6a6">
+        <circle cx="20" cy="12" r="3" />
+        <circle cx="20" cy="52" r="3" />
+        <circle cx="46" cy="12" r="3" />
+        <circle cx="46" cy="52" r="3" />
+      </g>
+      <circle cx="20" cy="32" r="5" fill="#5cc6ff" />
+    </svg>
+  )
+}
+
+export function TopNav() {
+  return (
+    <header className="sticky top-0 z-30 flex h-14 items-center gap-3 border-b border-line bg-bg/70 px-4 backdrop-blur-xl">
+      <div className="flex items-center gap-2.5">
+        <KMark />
+        <div className="leading-none">
+          <div className="font-display text-[15px] font-semibold tracking-[3px] text-ink">KIRRA</div>
+          <div className="font-mono text-[9px] uppercase tracking-[2px] text-faint">Mission Console</div>
+        </div>
+      </div>
+      <div className="ml-2 hidden sm:block"><Pill tone="safe">Governor Online</Pill></div>
+      <button className="ml-1 hidden items-center gap-2 rounded-lg border border-line bg-panel px-3 py-1.5 font-mono text-[11px] text-muted hover:text-ink xl:flex">
+        PRODUCTION · us-fleet-1 <ChevronDown className="h-3.5 w-3.5 text-faint" />
+      </button>
+      <div className="relative ml-auto hidden w-72 items-center md:flex">
+        <Search className="absolute left-3 h-4 w-4 text-faint" />
+        <input placeholder="Search robots, missions, events…" className="w-full rounded-lg border border-line bg-panel py-2 pl-9 pr-3 text-[13px] text-ink outline-none placeholder:text-faint focus:border-line-strong" />
+      </div>
+      <button className="relative ml-auto rounded-lg border border-line bg-panel p-2 text-muted hover:text-ink md:ml-0">
+        <Bell className="h-4 w-4" />
+        <span className="absolute right-1.5 top-1.5 h-1.5 w-1.5 rounded-full bg-warn" />
+      </button>
+      <div className="flex items-center gap-2 rounded-lg border border-line bg-panel py-1 pl-1 pr-2.5">
+        <div className="grid h-7 w-7 place-items-center rounded-md bg-gradient-to-br from-safe/30 to-ice/20 font-display text-xs font-semibold text-ink">JL</div>
+        <div className="hidden leading-none sm:block">
+          <div className="text-[12px] text-ink">J. Looney</div>
+          <div className="font-mono text-[10px] text-faint">Operator · Admin</div>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/console/components/ui/primitives.tsx
+++ b/console/components/ui/primitives.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+import type { Tone } from '@/lib/types'
+
+const toneText: Record<Tone, string> = { safe: 'text-safe', warn: 'text-warn', crit: 'text-crit', ice: 'text-ice', muted: 'text-muted' }
+const toneBg: Record<Tone, string> = { safe: 'bg-safe/10', warn: 'bg-warn/10', crit: 'bg-crit/10', ice: 'bg-ice/10', muted: 'bg-white/5' }
+const toneRing: Record<Tone, string> = { safe: 'ring-safe/30', warn: 'ring-warn/30', crit: 'ring-crit/30', ice: 'ring-ice/30', muted: 'ring-white/10' }
+const toneDot: Record<Tone, string> = { safe: 'bg-safe', warn: 'bg-warn', crit: 'bg-crit', ice: 'bg-ice', muted: 'bg-muted' }
+
+export function Panel({ title, subtitle, action, children, className, dense }: { title?: string; subtitle?: string; action?: ReactNode; children: ReactNode; className?: string; dense?: boolean }) {
+  return (
+    <section className={cn('rounded-xl border border-line bg-panel shadow-panel', className)}>
+      {(title || action) && (
+        <header className="flex items-center justify-between gap-3 border-b border-line px-4 py-3">
+          <div>
+            {title && <h3 className="font-display text-[13px] font-semibold tracking-wide text-ink">{title}</h3>}
+            {subtitle && <p className="mt-0.5 font-mono text-[11px] text-faint">{subtitle}</p>}
+          </div>
+          {action}
+        </header>
+      )}
+      <div className={cn(dense ? 'p-0' : 'p-4')}>{children}</div>
+    </section>
+  )
+}
+
+export function StatusDot({ tone, pulse }: { tone: Tone; pulse?: boolean }) {
+  return (
+    <span className={cn('relative inline-flex h-2 w-2 rounded-full', toneDot[tone])}>
+      {pulse && <span className={cn('absolute inset-0 animate-ping rounded-full opacity-60', toneDot[tone])} />}
+    </span>
+  )
+}
+
+export function Pill({ tone, children }: { tone: Tone; children: ReactNode }) {
+  return (
+    <span className={cn('inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider ring-1', toneText[tone], toneBg[tone], toneRing[tone])}>
+      <StatusDot tone={tone} />
+      {children}
+    </span>
+  )
+}
+
+export function Stat({ label, value, unit, delta, tone = 'ice', children }: { label: string; value: string | number; unit?: string; delta?: string; tone?: Tone; children?: ReactNode }) {
+  return (
+    <div className="rounded-xl border border-line bg-panel p-4 shadow-panel">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{label}</span>
+        {delta && <span className={cn('font-mono text-[11px]', toneText[tone])}>{delta}</span>}
+      </div>
+      <div className="mt-2 flex items-baseline gap-1.5">
+        <span className="font-display text-[28px] font-semibold leading-none text-ink">{value}</span>
+        {unit && <span className="font-mono text-xs text-muted">{unit}</span>}
+      </div>
+      {children && <div className="mt-3">{children}</div>}
+    </div>
+  )
+}
+
+export function Meter({ value, tone = 'safe' }: { value: number; tone?: Tone }) {
+  return (
+    <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/5">
+      <div className={cn('h-full rounded-full', toneDot[tone])} style={{ width: `${Math.max(2, Math.min(100, value))}%` }} />
+    </div>
+  )
+}
+
+export function SectionLabel({ children, right }: { children: ReactNode; right?: ReactNode }) {
+  return (
+    <div className="mb-3 flex items-center justify-between">
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.2em] text-faint">{children}</h2>
+      {right}
+    </div>
+  )
+}

--- a/console/lib/mock.ts
+++ b/console/lib/mock.ts
@@ -1,0 +1,51 @@
+import type { KPI, Robot, EventItem, SeriesPoint, Posture, Tone } from '@/lib/types'
+
+function gen(n: number, base: number, jitter: number, drift = 0): SeriesPoint[] {
+  const out: SeriesPoint[] = []
+  let v = base
+  for (let i = 0; i < n; i++) {
+    v += (Math.random() - 0.5) * jitter + drift
+    v = Math.max(0, v)
+    out.push({ t: `${String(i % 24).padStart(2, '0')}:00`, v: Math.round(v) })
+  }
+  return out
+}
+
+export const series = {
+  throughput: gen(24, 820, 120),
+  velocity: gen(24, 12, 4),
+}
+
+export const kpis: KPI[] = [
+  { label: 'Active Robots', value: 142, unit: 'online', delta: '+6', tone: 'safe', spark: gen(20, 130, 8) },
+  { label: 'Connected Systems', value: 38, unit: 'nodes', delta: '+1', tone: 'ice', spark: gen(20, 36, 2) },
+  { label: 'Autonomous Missions', value: 27, unit: 'running', delta: '−2', tone: 'ice', spark: gen(20, 28, 3) },
+  { label: 'Safety Interventions', value: 3, unit: '24h', delta: '+1', tone: 'warn', spark: gen(20, 2, 1) },
+  { label: 'Runtime Uptime', value: '99.98', unit: '%', delta: '30d', tone: 'safe', spark: gen(20, 99, 0.4) },
+]
+
+const POS: Posture[] = ['Nominal', 'Nominal', 'Nominal', 'Degraded', 'Nominal', 'Nominal', 'LockedOut', 'Nominal']
+
+export const robots: Robot[] = Array.from({ length: 8 }).map((_, i) => ({
+  id: `r${i + 1}`,
+  name: `KIRRA-${String(i + 7).padStart(2, '0')}`,
+  model: ['Atlas-X', 'Spot-V2', 'AMR-400', 'Forklift-A'][i % 4],
+  posture: POS[i],
+  status: (POS[i] === 'LockedOut' ? 'standby' : i % 5 === 4 ? 'standby' : 'online') as Robot['status'],
+  battery: [88, 64, 41, 22, 73, 95, 12, 57][i],
+  mission: ['Patrol Loop B', 'Pick & Place', 'Yard Transit', 'Inspection', 'Charging', 'Pallet Run', '— HOLD —', 'Survey'][i],
+  latencyMs: [8, 11, 14, 22, 9, 7, 31, 12][i],
+}))
+
+export const events: EventItem[] = [
+  { id: 'e1', tone: 'crit', source: 'governor', ts: '12:04:21', message: 'DENY · KINEMATIC_ENVELOPE_BREACH — KIRRA-13 cmd_vel 999 m/s' },
+  { id: 'e2', tone: 'warn', source: 'fleet', ts: '12:03:58', message: 'KIRRA-10 entered Degraded posture (sensor confidence 0.41)' },
+  { id: 'e3', tone: 'safe', source: 'governor', ts: '12:03:30', message: 'ALLOW · cmd_vel 1.2 m/s dispatched to KIRRA-09' },
+  { id: 'e4', tone: 'ice', source: 'telemetry', ts: '12:03:12', message: 'DDS latency p99 = 14ms (within FTTI budget)' },
+  { id: 'e5', tone: 'crit', source: 'governor', ts: '12:02:40', message: 'LOCKEDOUT · cycle detected in dependency DAG — KIRRA-13 isolated' },
+  { id: 'e6', tone: 'safe', source: 'compliance', ts: '12:01:05', message: 'Audit chain verified · 184,220 links · no breaks' },
+]
+
+export function postureTone(p: Posture): Tone {
+  return p === 'Nominal' ? 'safe' : p === 'Degraded' ? 'warn' : 'crit'
+}

--- a/console/lib/runtime.ts
+++ b/console/lib/runtime.ts
@@ -1,0 +1,53 @@
+import type { SeriesPoint, Tone } from './types'
+
+function g(n: number, b: number, j: number): SeriesPoint[] {
+  const o: SeriesPoint[] = []
+  let v = b
+  for (let i = 0; i < n; i++) {
+    v += (Math.random() - 0.5) * j
+    v = Math.max(0, v)
+    o.push({ t: `${String(i).padStart(2, '0')}:00`, v: Math.round(v) })
+  }
+  return o
+}
+
+export interface Resource { label: string; pct: number; detail: string; tone: Tone }
+export interface Partition { name: string; role: string; cpuBudget: number; isolation: 'ENFORCED' | 'DEGRADED'; tone: Tone }
+export interface NodeHealth { id: string; cpu: number; mem: number; tempC: number; tone: Tone }
+export interface NetStat { label: string; value: string; unit: string; tone: Tone; spark: SeriesPoint[] }
+export interface LatPoint { t: string; p50: number; p99: number }
+
+export const resources: Resource[] = [
+  { label: 'CPU', pct: 38, detail: '12 cores · QNX SMP', tone: 'safe' },
+  { label: 'Memory', pct: 54, detail: '18.2 / 32 GB', tone: 'safe' },
+  { label: 'GPU', pct: 61, detail: 'Orin · inference', tone: 'safe' },
+  { label: 'Disk I/O', pct: 23, detail: 'audit ledger WAL', tone: 'safe' },
+]
+
+export const latency: LatPoint[] = Array.from({ length: 24 }).map((_, i) => {
+  const base = 7 + Math.round(Math.sin(i / 3) * 2)
+  return { t: `${String(i).padStart(2, '0')}:00`, p50: base + Math.round(Math.random() * 2), p99: base + 8 + Math.round(Math.random() * 8) }
+})
+
+export const network: NetStat[] = [
+  { label: 'Throughput', value: '2.4', unit: 'Gb/s', tone: 'safe', spark: g(20, 24, 4) },
+  { label: 'Packet loss', value: '0.01', unit: '%', tone: 'safe', spark: g(20, 2, 1) },
+  { label: 'Jitter', value: '0.4', unit: 'ms', tone: 'safe', spark: g(20, 4, 2) },
+  { label: 'Connected nodes', value: '38 / 38', unit: '', tone: 'safe', spark: g(20, 38, 1) },
+]
+
+export const partitions: Partition[] = [
+  { name: 'Governor (QNX safety)', role: 'ASIL-D · FIFO scheduling', cpuBudget: 34, isolation: 'ENFORCED', tone: 'safe' },
+  { name: 'Autoware guest', role: 'planner · isolated VM', cpuBudget: 58, isolation: 'ENFORCED', tone: 'safe' },
+  { name: 'Telemetry / Capture', role: 'best-effort', cpuBudget: 19, isolation: 'ENFORCED', tone: 'safe' },
+  { name: 'Comms bridge (DDS)', role: 'Volatile QoS', cpuBudget: 27, isolation: 'ENFORCED', tone: 'safe' },
+]
+
+export const nodes: NodeHealth[] = [
+  { id: 'node-1', cpu: 31, mem: 40, tempC: 48 },
+  { id: 'node-2', cpu: 44, mem: 55, tempC: 52 },
+  { id: 'node-3', cpu: 38, mem: 48, tempC: 50 },
+  { id: 'node-4', cpu: 62, mem: 71, tempC: 61 },
+  { id: 'node-5', cpu: 28, mem: 35, tempC: 46 },
+  { id: 'node-6', cpu: 49, mem: 52, tempC: 54 },
+].map((n) => ({ ...n, tone: (n.cpu > 80 || n.tempC > 70 ? 'crit' : n.cpu > 60 || n.tempC > 60 ? 'warn' : 'safe') as Tone }))

--- a/console/lib/safety.ts
+++ b/console/lib/safety.ts
@@ -1,0 +1,31 @@
+import type { Tone } from './types'
+
+export interface Constraint { id: string; name: string; value: string; limit: string; util: number; tone: Tone; status: string }
+export interface Violation { id: string; ts: string; rule: string; asset: string; action: string; tone: Tone }
+export interface Intervention { id: string; ts: string; kind: 'CLAMP' | 'DENY' | 'MRC' | 'ALLOW'; detail: string; tone: Tone }
+
+export const constraints: Constraint[] = [
+  { id: 'c1', name: 'Speed envelope (SG1)', value: '1.2 m/s', limit: '≤ 22.4 m/s', util: 6, tone: 'safe', status: 'OK' },
+  { id: 'c2', name: 'Lateral containment (SG2)', value: '0.78 m', limit: '≥ 0.40 m', util: 51, tone: 'safe', status: 'OK' },
+  { id: 'c3', name: 'RSS safety distance (SG3)', value: '14.2 m', limit: '≥ 9.0 m', util: 63, tone: 'safe', status: 'OK' },
+  { id: 'c4', name: 'Geofence boundary', value: 'inside', limit: 'corridor', util: 34, tone: 'safe', status: 'OK' },
+  { id: 'c5', name: 'Comms heartbeat', value: '420 ms', limit: '≤ 2000 ms', util: 21, tone: 'safe', status: 'OK' },
+  { id: 'c6', name: 'Sensor confidence floor', value: '0.41', limit: '≥ 0.60', util: 96, tone: 'warn', status: 'DEGRADED' },
+]
+
+export const violations: Violation[] = [
+  { id: 'v1', ts: '12:04:21', rule: 'KINEMATIC_ENVELOPE_BREACH', asset: 'KIRRA-13', action: 'DENY → MRC stop', tone: 'crit' },
+  { id: 'v2', ts: '11:58:03', rule: 'DEGRADED_POSTURE_KINETIC_DENIED', asset: 'KIRRA-10', action: 'DENY', tone: 'warn' },
+  { id: 'v3', ts: '11:41:55', rule: 'UNKNOWN_ACTION_TYPE', asset: 'KIRRA-09', action: 'DENY', tone: 'warn' },
+  { id: 'v4', ts: '10:22:10', rule: 'CYCLE_DETECTED', asset: 'fleet-dag', action: 'LOCKEDOUT', tone: 'crit' },
+]
+
+export const interventions: Intervention[] = [
+  { id: 'i1', ts: '12:04:21', kind: 'DENY', detail: 'KIRRA-13 cmd_vel 999 m/s — envelope breach', tone: 'crit' },
+  { id: 'i2', ts: '12:01:09', kind: 'CLAMP', detail: 'KIRRA-08 4.1 m/s → 2.0 m/s (MRC decel)', tone: 'warn' },
+  { id: 'i3', ts: '11:58:03', kind: 'DENY', detail: 'KIRRA-10 kinetic write in Degraded', tone: 'warn' },
+  { id: 'i4', ts: '11:30:44', kind: 'MRC', detail: 'KIRRA-13 controlled stop — human reset pending', tone: 'crit' },
+  { id: 'i5', ts: '11:02:18', kind: 'ALLOW', detail: 'KIRRA-09 cmd_vel 1.2 m/s dispatched', tone: 'safe' },
+]
+
+export const verdictMix = { allow: 18420, clamp: 142, deny: 37 }

--- a/console/lib/types.ts
+++ b/console/lib/types.ts
@@ -1,0 +1,35 @@
+export type Tone = 'safe' | 'warn' | 'crit' | 'ice' | 'muted'
+export type Posture = 'Nominal' | 'Degraded' | 'LockedOut'
+
+export interface SeriesPoint {
+  t: string
+  v: number
+}
+
+export interface KPI {
+  label: string
+  value: string | number
+  unit?: string
+  delta?: string
+  tone: Tone
+  spark?: SeriesPoint[]
+}
+
+export interface Robot {
+  id: string
+  name: string
+  model: string
+  posture: Posture
+  status: 'online' | 'standby' | 'offline'
+  battery: number
+  mission: string
+  latencyMs: number
+}
+
+export interface EventItem {
+  id: string
+  tone: Tone
+  source: string
+  ts: string
+  message: string
+}

--- a/console/lib/utils.ts
+++ b/console/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/console/next.config.mjs
+++ b/console/next.config.mjs
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+export default nextConfig;

--- a/console/package.json
+++ b/console/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "kirra-console",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.1.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "framer-motion": "^11.11.0",
+    "recharts": "^2.13.0",
+    "lucide-react": "^0.460.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.5.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "@types/node": "^22.9.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "tailwindcss": "^3.4.14",
+    "postcss": "^8.4.47",
+    "autoprefixer": "^10.4.20"
+  }
+}

--- a/console/postcss.config.mjs
+++ b/console/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+export default config;

--- a/console/tailwind.config.ts
+++ b/console/tailwind.config.ts
@@ -1,0 +1,35 @@
+import type { Config } from 'tailwindcss'
+
+export default {
+  darkMode: 'class',
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        bg: 'rgb(var(--bg) / <alpha-value>)',
+        surface: 'rgb(var(--surface) / <alpha-value>)',
+        panel: 'rgb(var(--panel) / <alpha-value>)',
+        elevated: 'rgb(var(--elevated) / <alpha-value>)',
+        ink: 'rgb(var(--ink) / <alpha-value>)',
+        muted: 'rgb(var(--muted) / <alpha-value>)',
+        faint: 'rgb(var(--faint) / <alpha-value>)',
+        safe: 'rgb(var(--safe) / <alpha-value>)',
+        warn: 'rgb(var(--warn) / <alpha-value>)',
+        crit: 'rgb(var(--crit) / <alpha-value>)',
+        ice: 'rgb(var(--ice) / <alpha-value>)',
+        line: 'rgba(150, 166, 198, 0.10)',
+        'line-strong': 'rgba(150, 166, 198, 0.22)',
+      },
+      fontFamily: {
+        display: ['var(--font-display)', 'system-ui', 'sans-serif'],
+        sans: ['var(--font-sans)', 'system-ui', 'sans-serif'],
+        mono: ['var(--font-mono)', 'ui-monospace', 'monospace'],
+      },
+      borderRadius: { xl: '14px' },
+      boxShadow: {
+        panel: '0 1px 0 0 rgba(255,255,255,0.02) inset, 0 20px 44px -28px rgba(0,0,0,0.75)',
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config

--- a/console/tsconfig.json
+++ b/console/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "ES2020"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
New **`console/`** app — the Kirra Mission Console (enterprise robotics & AI-safety operations dashboard). Self-contained Next.js app; cleanly extractable to its own `kirra-console` repo later. Does not affect the Rust SDK or the marketing site.

## Drop 1 (this) — foundation + Fleet Overview
- **Design system**: graphite surface stack, restrained safety/amber/critical/ice accents, Space Grotesk/Inter/JetBrains Mono — matches Kirra's identity, aerospace/defense restraint (no neon).
- **App shell**: glass top nav (logo, governor status, env selector, search, notifications, profile) + grouped left sidebar (Operations / Governance / Insight).
- **Component library**: `Panel`, `Stat`, `Pill`, `Meter`, `StatusDot`; chart wrappers `TrendArea` / `Spark` / `ScoreRing` (Recharts).
- **Fleet Overview screen**: KPI row w/ sparklines, live throughput trend, Safety Governor panel (score ring + state/e-stop/constraints), active-fleet table (posture/battery/latency/status), and a governor+fleet event stream.
- Catch-all route renders a styled "module in development" placeholder so every sidebar item is navigable (no 404s).

## Stack
Next.js 15 (App Router) · React 18 · TypeScript · TailwindCSS (shadcn-style tokens) · Recharts · Framer Motion · lucide-react.

## Run
```bash
cd console && npm install && npm run dev
```

## Next drops (onto this branch)
2: Safety Governor Command Center + Runtime Health · 3: Telemetry + Mission Ops · 4: Compliance + AI Oversight + Incident Review · 5: Analytics/Reports/Settings + mobile.

> Note: authored via the GitHub API (this session can't run `npm`), so please `npm install && npm run dev` to verify before merging.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_