### PR TITLE
chore(console): bump Next.js to patched 15.x (CVE-2025-66478)

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "15.1.0",
+    "next": "^15.1.6",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "framer-motion": "^11.11.0",


### PR DESCRIPTION
Bump `next` from pinned `15.1.0` to `^15.1.6` so installs resolve to a patched 15.x (clears the **CVE-2025-66478** warning Vercel surfaced). No code changes.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_