### PR TITLE
feat(console): Robot Digital Twin + interactive Incident Replay

### DIFF
--- a/console/app/fleet/[id]/page.tsx
+++ b/console/app/fleet/[id]/page.tsx
@@ -1,0 +1,147 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ChevronLeft } from 'lucide-react'
+import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { PositionMap } from '@/components/ui/position-map'
+import { twinById, twins } from '@/lib/fleet'
+import { postureTone } from '@/lib/mock'
+import type { Tone } from '@/lib/types'
+
+export function generateStaticParams() {
+  return twins.map((t) => ({ id: t.id }))
+}
+
+export default async function TwinPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const t = twinById(id)
+  if (!t) notFound()
+
+  const tone = postureTone(t.posture)
+
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Link href="/fleet" className="flex h-8 w-8 items-center justify-center rounded-lg border border-line text-faint hover:bg-white/[0.04] hover:text-ink">
+            <ChevronLeft className="h-4 w-4" />
+          </Link>
+          <div>
+            <h1 className="font-display text-xl font-semibold text-ink">{t.name} <span className="font-mono text-[13px] font-normal text-faint">Digital Twin</span></h1>
+            <p className="font-mono text-[11px] text-faint">{t.model} · firmware {t.firmware} · uptime {t.uptime}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Pill tone={tone}>{t.posture}</Pill>
+          <Pill tone={t.attestation.tone}>AK {t.attestation.status}</Pill>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <Metric label="Battery" value={`${t.battery}%`} tone={t.battery < 25 ? 'crit' : t.battery < 50 ? 'warn' : 'safe'} meter={t.battery} />
+        <Metric label="Power draw" value={`${t.drawW} W`} tone="ice" />
+        <Metric label="Est. range" value={`${t.rangeKm.toFixed(1)} km`} tone="ice" />
+        <Metric label="Status" value={t.status} tone={tone} />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Kinematic Envelope" subtitle="proposed vs certified hard limits">
+          <ul className="space-y-4">
+            {t.envelope.map((e) => (
+              <li key={e.axis}>
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[13px] text-ink">{e.axis}</span>
+                  <span className="font-mono text-[11px] text-muted">{e.current} <span className="text-faint">/ {e.limit}</span></span>
+                </div>
+                <div className="mt-2 flex items-center gap-3">
+                  <div className="flex-1"><Meter value={e.util} tone={e.tone} /></div>
+                  <span className={`w-10 text-right font-mono text-[10px] ${txt(e.tone)}`}>{e.util}%</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+
+        <Panel title="Subsystem Health" dense>
+          <ul>
+            {t.subsystems.map((s) => (
+              <li key={s.name} className="flex items-center gap-3 border-b border-line px-4 py-2.5 last:border-0">
+                <StatusDot tone={s.tone} pulse={s.tone === 'crit'} />
+                <span className="flex-1 truncate text-[12px] text-ink">{s.name}</span>
+                <span className="font-mono text-[11px] text-muted">{s.health}%</span>
+                <span className={`w-20 text-right font-mono text-[10px] uppercase tracking-wider ${txt(s.tone)}`}>{s.status}</span>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Position Trace" subtitle="last 40 fixes · ego marker live">
+          <PositionMap path={t.path} ego={t.ego} height={240} />
+        </Panel>
+
+        <div className="space-y-6">
+          <Panel title="Hardware Attestation" subtitle="per-node Ed25519 proof">
+            <div className="space-y-3">
+              <KV k="Node id" v={t.attestation.nodeId} />
+              <KV k="AK digest" v={t.attestation.akDigest} />
+              <KV k="PCR16" v={t.attestation.pcr16} />
+              <KV k="Last verified" v={t.attestation.lastVerified} />
+              <div className="flex items-center justify-between border-t border-line pt-3">
+                <span className="font-mono text-[11px] uppercase tracking-wider text-faint">Trust state</span>
+                <span className={`font-mono text-[12px] ${txt(t.attestation.tone)}`}>{t.attestation.status}</span>
+              </div>
+            </div>
+          </Panel>
+        </div>
+      </div>
+
+      <Panel title="Command Stream" subtitle="recent actuator commands · governor verdict" dense>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-left">
+            <thead>
+              <tr className="border-b border-line font-mono text-[10px] uppercase tracking-wider text-faint">
+                <th className="px-4 py-2 font-normal">Time</th>
+                <th className="px-4 py-2 font-normal">Channel</th>
+                <th className="px-4 py-2 font-normal">Value</th>
+                <th className="px-4 py-2 font-normal">Verdict</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono text-[12px]">
+              {t.commands.map((c, i) => (
+                <tr key={i} className="border-b border-line last:border-0 hover:bg-white/[0.02]">
+                  <td className="px-4 py-2.5 text-faint">{c.ts}</td>
+                  <td className="px-4 py-2.5 text-ink">{c.channel}</td>
+                  <td className="px-4 py-2.5 text-muted">{c.value}</td>
+                  <td className="px-4 py-2.5"><span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${badge(c.tone)}`}>{c.verdict}</span></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Panel>
+    </div>
+  )
+}
+
+function Metric({ label, value, tone, meter }: { label: string; value: string; tone: Tone; meter?: number }) {
+  return (
+    <div className="rounded-xl border border-line bg-panel p-4 shadow-panel">
+      <div className="font-mono text-[11px] uppercase tracking-wider text-faint">{label}</div>
+      <div className={`mt-1.5 font-display text-[20px] font-semibold leading-none ${value.length > 8 ? 'text-[15px]' : ''} ${txt(tone)}`}>{value}</div>
+      {meter !== undefined && <div className="mt-3"><Meter value={meter} tone={tone} /></div>}
+    </div>
+  )
+}
+
+function KV({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{k}</span>
+      <span className="font-mono text-xs text-ink">{v}</span>
+    </div>
+  )
+}
+
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
+function badge(t: Tone) { return t === 'safe' ? 'bg-safe/15 text-safe' : t === 'warn' ? 'bg-warn/15 text-warn' : t === 'crit' ? 'bg-crit/15 text-crit' : 'bg-ice/15 text-ice' }

--- a/console/app/fleet/page.tsx
+++ b/console/app/fleet/page.tsx
@@ -1,0 +1,97 @@
+import Link from 'next/link'
+import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { twins } from '@/lib/fleet'
+import { postureTone } from '@/lib/mock'
+import type { Tone } from '@/lib/types'
+
+export default function FleetPage() {
+  const online = twins.filter((t) => t.posture !== 'LockedOut').length
+  const degraded = twins.filter((t) => t.posture === 'Degraded').length
+  const locked = twins.filter((t) => t.posture === 'LockedOut').length
+
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-ink">Fleet Operations</h1>
+          <p className="font-mono text-[11px] text-faint">{twins.length} assets · select an asset for its digital twin</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Pill tone="safe">{online} active</Pill>
+          {degraded > 0 && <Pill tone="warn">{degraded} degraded</Pill>}
+          {locked > 0 && <Pill tone="crit">{locked} locked out</Pill>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {twins.map((t) => {
+          const tone = postureTone(t.posture)
+          return (
+            <Link key={t.id} href={`/fleet/${t.id}`} className="group rounded-xl border border-line bg-panel p-4 shadow-panel transition-colors hover:border-line-strong hover:bg-elevated">
+              <div className="flex items-start justify-between">
+                <div>
+                  <div className="font-display text-[15px] font-semibold text-ink">{t.name}</div>
+                  <div className="mt-0.5 font-mono text-[11px] text-faint">{t.model}</div>
+                </div>
+                <StatusDot tone={tone} pulse={t.posture !== 'Nominal'} />
+              </div>
+
+              <div className="mt-4 flex items-center justify-between">
+                <span className={`font-mono text-[11px] uppercase tracking-wider ${txt(tone)}`}>{t.posture}</span>
+                <span className="font-mono text-[11px] text-muted">{t.status}</span>
+              </div>
+
+              <div className="mt-3">
+                <div className="flex items-center justify-between font-mono text-[10px] text-faint">
+                  <span>battery</span><span>{t.battery}%</span>
+                </div>
+                <div className="mt-1.5"><Meter value={t.battery} tone={t.battery < 25 ? 'crit' : t.battery < 50 ? 'warn' : 'safe'} /></div>
+              </div>
+
+              <div className="mt-4 grid grid-cols-2 gap-2 border-t border-line pt-3 font-mono text-[10px] text-faint">
+                <div><div className="text-ink">{t.rangeKm.toFixed(1)} km</div>range</div>
+                <div className="text-right"><div className="text-ink">{t.drawW} W</div>draw</div>
+              </div>
+
+              <div className="mt-3 flex items-center justify-between font-mono text-[10px] text-faint">
+                <span>twin →</span>
+                <span className={txt(t.attestation.tone)}>{t.attestation.status}</span>
+              </div>
+            </Link>
+          )
+        })}
+      </div>
+
+      <Panel title="Fleet Roster" subtitle="all assets · tabular" dense>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[760px] text-left">
+            <thead>
+              <tr className="border-b border-line font-mono text-[10px] uppercase tracking-wider text-faint">
+                <th className="px-4 py-2 font-normal">Asset</th>
+                <th className="px-4 py-2 font-normal">Model</th>
+                <th className="px-4 py-2 font-normal">Posture</th>
+                <th className="px-4 py-2 font-normal">Battery</th>
+                <th className="px-4 py-2 font-normal">Attestation</th>
+                <th className="px-4 py-2 font-normal">Uptime</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono text-[12px]">
+              {twins.map((t) => (
+                <tr key={t.id} className="border-b border-line last:border-0 hover:bg-white/[0.02]">
+                  <td className="px-4 py-2.5"><Link href={`/fleet/${t.id}`} className="text-ink hover:text-ice">{t.name}</Link></td>
+                  <td className="px-4 py-2.5 text-muted">{t.model}</td>
+                  <td className={`px-4 py-2.5 ${txt(postureTone(t.posture))}`}>{t.posture}</td>
+                  <td className="px-4 py-2.5 text-muted">{t.battery}%</td>
+                  <td className={`px-4 py-2.5 ${txt(t.attestation.tone)}`}>{t.attestation.status}</td>
+                  <td className="px-4 py-2.5 text-faint">{t.uptime}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Panel>
+    </div>
+  )
+}
+
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }

--- a/console/app/incidents/page.tsx
+++ b/console/app/incidents/page.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Play, Pause, SkipBack, RotateCcw } from 'lucide-react'
+import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
+import { incidents, replay, featured, rootCause } from '@/lib/incidents'
+import { postureTone } from '@/lib/mock'
+import type { Tone } from '@/lib/types'
+
+const MAX_SPEED = 2.6
+
+export default function IncidentsPage() {
+  const [i, setI] = useState(6) // start at the trigger frame (t = 0)
+  const [playing, setPlaying] = useState(false)
+  const frame = replay[i]
+
+  useEffect(() => {
+    if (!playing) return
+    if (i >= replay.length - 1) { setPlaying(false); return }
+    const id = setTimeout(() => setI((p) => Math.min(replay.length - 1, p + 1)), 900)
+    return () => clearTimeout(id)
+  }, [playing, i])
+
+  const restart = () => { setI(0); setPlaying(true) }
+
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-ink">Incident Review & Replay</h1>
+          <p className="font-mono text-[11px] text-faint">{featured.id} · {featured.asset} · {featured.title}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Pill tone="crit">{featured.reason}</Pill>
+          <Pill tone="ice">{featured.status}</Pill>
+        </div>
+      </div>
+
+      {/* Replay deck */}
+      <Panel
+        title="Replay"
+        subtitle={`t = ${frame.t > 0 ? '+' : ''}${frame.t}s · ${frame.clock}`}
+        action={
+          <div className="flex items-center gap-1.5">
+            <DeckBtn onClick={() => { setPlaying(false); setI(0) }} label="To start"><SkipBack className="h-3.5 w-3.5" /></DeckBtn>
+            <DeckBtn onClick={() => setPlaying((p) => !p)} label={playing ? 'Pause' : 'Play'} primary>{playing ? <Pause className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}</DeckBtn>
+            <DeckBtn onClick={restart} label="Replay"><RotateCcw className="h-3.5 w-3.5" /></DeckBtn>
+          </div>
+        }
+      >
+        {/* Timeline strip */}
+        <div className="mb-5">
+          <div className="relative flex items-end gap-1">
+            {replay.map((f, idx) => {
+              const active = idx === i
+              const h = 14 + (f.speed / MAX_SPEED) * 46
+              return (
+                <button
+                  key={idx}
+                  onClick={() => { setPlaying(false); setI(idx) }}
+                  className="group relative flex flex-1 flex-col items-center justify-end"
+                  style={{ height: 64 }}
+                  aria-label={`frame ${f.clock}`}
+                >
+                  <span
+                    className={`w-full rounded-sm transition-all ${barBg(f.tone)} ${active ? 'opacity-100' : 'opacity-40 group-hover:opacity-70'}`}
+                    style={{ height: h }}
+                  />
+                  {f.t === 0 && <span className="absolute -top-1 h-1.5 w-1.5 rounded-full bg-crit" />}
+                </button>
+              )
+            })}
+          </div>
+          <div className="mt-2 flex items-center justify-between font-mono text-[10px] text-faint">
+            <span>{replay[0].clock} · lead-up</span>
+            <span className="text-crit">▲ trigger</span>
+            <span>{replay[replay.length - 1].clock} · safe stop</span>
+          </div>
+          <input
+            type="range" min={0} max={replay.length - 1} value={i}
+            onChange={(e) => { setPlaying(false); setI(Number(e.target.value)) }}
+            className="mt-3 w-full accent-ice"
+            aria-label="scrub timeline"
+          />
+        </div>
+
+        {/* Synced state at frame i */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <StateCard label="Posture">
+            <div className="flex items-center gap-2">
+              <StatusDot tone={postureTone(frame.posture)} pulse={frame.posture !== 'Nominal'} />
+              <span className={`font-display text-2xl font-semibold ${txt(postureTone(frame.posture))}`}>{frame.posture}</span>
+            </div>
+          </StateCard>
+
+          <StateCard label="Commanded speed">
+            <div className="flex items-baseline gap-1.5">
+              <span className="font-display text-2xl font-semibold text-ink">{frame.speed.toFixed(1)}</span>
+              <span className="font-mono text-xs text-muted">m/s</span>
+            </div>
+            <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-white/5">
+              <div className={`h-full rounded-full ${barBg(frame.tone)}`} style={{ width: `${(frame.speed / MAX_SPEED) * 100}%` }} />
+            </div>
+          </StateCard>
+
+          <StateCard label="Governor verdict">
+            <span className={`inline-block rounded px-2 py-1 font-mono text-[13px] font-semibold ${badge(frame.tone)}`}>{frame.verdict}</span>
+          </StateCard>
+        </div>
+
+        <div className="mt-4 rounded-lg border border-line bg-bg/40 p-3">
+          <div className="font-mono text-[10px] uppercase tracking-wider text-faint">Event at {frame.clock}</div>
+          <p className={`mt-1.5 text-[13px] ${txt(frame.tone)}`}>{frame.event}</p>
+        </div>
+      </Panel>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Frame Log" subtitle="full second-by-second reconstruction" dense>
+          <ul>
+            {replay.map((f, idx) => (
+              <li
+                key={idx}
+                className={`flex items-center gap-4 border-b border-line px-4 py-2.5 last:border-0 ${idx === i ? 'bg-white/[0.04]' : idx > i ? 'opacity-40' : ''}`}
+              >
+                <span className="w-10 shrink-0 font-mono text-[11px] text-faint">{f.t > 0 ? '+' : ''}{f.t}s</span>
+                <span className="w-16 shrink-0 font-mono text-[11px] text-muted">{f.clock}</span>
+                <span className={`w-12 shrink-0 rounded px-1.5 py-0.5 text-center font-mono text-[10px] font-semibold ${badge(f.tone)}`}>{f.verdict}</span>
+                <span className="min-w-0 flex-1 truncate text-[12px] text-ink">{f.event}</span>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+
+        <Panel title="Root-Cause Analysis" subtitle="post-incident finding">
+          <ol className="space-y-4">
+            {rootCause.map((r, idx) => (
+              <li key={r.id} className="relative flex gap-3 pl-1">
+                {idx < rootCause.length - 1 && <span className="absolute left-[11px] top-5 h-full w-px bg-line" />}
+                <span className={`mt-0.5 h-2.5 w-2.5 shrink-0 rounded-full ${barBg(r.tone)}`} />
+                <div className="min-w-0">
+                  <div className={`font-mono text-[10px] uppercase tracking-wider ${txt(r.tone)}`}>{r.label}</div>
+                  <p className="mt-1 text-[12px] text-muted">{r.detail}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </Panel>
+      </div>
+
+      <Panel title="Incident History" subtitle="all logged fail-closed events" dense>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[760px] text-left">
+            <thead>
+              <tr className="border-b border-line font-mono text-[10px] uppercase tracking-wider text-faint">
+                <th className="px-4 py-2 font-normal">ID</th>
+                <th className="px-4 py-2 font-normal">Timestamp</th>
+                <th className="px-4 py-2 font-normal">Asset</th>
+                <th className="px-4 py-2 font-normal">Incident</th>
+                <th className="px-4 py-2 font-normal">Duration</th>
+                <th className="px-4 py-2 font-normal">Status</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono text-[12px]">
+              {incidents.map((inc) => (
+                <tr key={inc.id} className={`border-b border-line last:border-0 hover:bg-white/[0.02] ${inc.id === featured.id ? 'bg-white/[0.03]' : ''}`}>
+                  <td className={`px-4 py-2.5 ${txt(inc.tone)}`}>{inc.id}</td>
+                  <td className="px-4 py-2.5 text-faint">{inc.ts}</td>
+                  <td className="px-4 py-2.5 text-ink">{inc.asset}</td>
+                  <td className="px-4 py-2.5 text-muted">{inc.title}</td>
+                  <td className="px-4 py-2.5 text-muted">{inc.durationS}s</td>
+                  <td className="px-4 py-2.5 text-ink">{inc.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Panel>
+    </div>
+  )
+}
+
+function DeckBtn({ children, onClick, label, primary }: { children: React.ReactNode; onClick: () => void; label: string; primary?: boolean }) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={label}
+      className={`flex h-8 w-8 items-center justify-center rounded-lg border transition-colors ${primary ? 'border-ice/40 bg-ice/10 text-ice hover:bg-ice/20' : 'border-line text-faint hover:bg-white/[0.04] hover:text-ink'}`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function StateCard({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-line bg-panel p-4">
+      <div className="font-mono text-[10px] uppercase tracking-wider text-faint">{label}</div>
+      <div className="mt-2">{children}</div>
+    </div>
+  )
+}
+
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
+function badge(t: Tone) { return t === 'safe' ? 'bg-safe/15 text-safe' : t === 'warn' ? 'bg-warn/15 text-warn' : t === 'crit' ? 'bg-crit/15 text-crit' : 'bg-ice/15 text-ice' }
+function barBg(t: Tone) { return t === 'safe' ? 'bg-safe' : t === 'warn' ? 'bg-warn' : t === 'crit' ? 'bg-crit' : t === 'ice' ? 'bg-ice' : 'bg-muted' }

--- a/console/lib/fleet.ts
+++ b/console/lib/fleet.ts
@@ -1,0 +1,164 @@
+import type { Tone, Posture } from './types'
+import type { PosPoint } from './telemetry'
+
+// Robot Digital Twin — the per-asset deep view: subsystem health, the live
+// kinematic envelope (proposed vs certified hard limits), hardware attestation,
+// the recent actuator command stream, and a position trace.
+
+export interface Subsystem { name: string; health: number; status: string; tone: Tone }
+export interface EnvelopeAxis { axis: string; current: string; limit: string; util: number; tone: Tone }
+export interface TwinCommand { ts: string; channel: string; value: string; verdict: 'ALLOW' | 'CLAMP' | 'DENY'; tone: Tone }
+
+export interface TwinAttestation {
+  nodeId: string
+  akDigest: string
+  pcr16: string
+  lastVerified: string
+  status: 'Trusted' | 'Untrusted' | 'Unknown'
+  tone: Tone
+}
+
+export interface Twin {
+  id: string
+  name: string
+  model: string
+  posture: Posture
+  status: string
+  uptime: string
+  firmware: string
+  battery: number
+  drawW: number
+  rangeKm: number
+  subsystems: Subsystem[]
+  envelope: EnvelopeAxis[]
+  attestation: TwinAttestation
+  commands: TwinCommand[]
+  path: PosPoint[]
+  ego: PosPoint
+}
+
+function trace(seed: number): PosPoint[] {
+  return Array.from({ length: 40 }).map((_, i) => {
+    const t = i / 39
+    return { x: 8 + t * 84, y: 50 + Math.sin(t * Math.PI * 2.2 + seed) * 26 + Math.sin(i / 3 + seed) * 2 }
+  })
+}
+
+const base: Record<string, Partial<Twin>> = {
+  degraded: {
+    posture: 'Degraded',
+    subsystems: [
+      { name: 'LiDAR (top)', health: 99, status: 'OK', tone: 'safe' },
+      { name: 'Radar (front)', health: 58, status: 'DEGRADED', tone: 'warn' },
+      { name: 'IMU', health: 100, status: 'OK', tone: 'safe' },
+      { name: 'Drive train', health: 94, status: 'OK', tone: 'safe' },
+      { name: 'Brake channel A/B', health: 100, status: '2/2 OK', tone: 'safe' },
+      { name: 'Comms (DDS)', health: 88, status: 'OK', tone: 'safe' },
+    ],
+    envelope: [
+      { axis: 'Linear velocity', current: '1.8 m/s', limit: '≤ 2.0 m/s (decel)', util: 90, tone: 'warn' },
+      { axis: 'Angular velocity', current: '0.10 rad/s', limit: '≤ 0.80 rad/s', util: 13, tone: 'safe' },
+      { axis: 'Lateral accel', current: '0.6 m/s²', limit: '≤ 2.5 m/s²', util: 24, tone: 'safe' },
+      { axis: 'Sensor confidence', current: '0.52', limit: '≥ 0.60', util: 87, tone: 'warn' },
+    ],
+  },
+  lockedout: {
+    posture: 'LockedOut',
+    status: 'standby',
+    subsystems: [
+      { name: 'LiDAR (top)', health: 96, status: 'OK', tone: 'safe' },
+      { name: 'Radar (front)', health: 0, status: 'FAULT', tone: 'crit' },
+      { name: 'IMU', health: 100, status: 'OK', tone: 'safe' },
+      { name: 'Drive train', health: 0, status: 'HELD', tone: 'crit' },
+      { name: 'Brake channel A/B', health: 100, status: 'ENGAGED', tone: 'safe' },
+      { name: 'Comms (DDS)', health: 71, status: 'OK', tone: 'warn' },
+    ],
+    envelope: [
+      { axis: 'Linear velocity', current: '0.0 m/s', limit: 'all motion denied', util: 100, tone: 'crit' },
+      { axis: 'Angular velocity', current: '0.0 rad/s', limit: 'all motion denied', util: 100, tone: 'crit' },
+      { axis: 'Lateral accel', current: '0.0 m/s²', limit: 'all motion denied', util: 100, tone: 'crit' },
+      { axis: 'Sensor confidence', current: '0.11', limit: '≥ 0.60', util: 100, tone: 'crit' },
+    ],
+  },
+  nominal: {
+    posture: 'Nominal',
+    subsystems: [
+      { name: 'LiDAR (top)', health: 99, status: 'OK', tone: 'safe' },
+      { name: 'Radar (front)', health: 97, status: 'OK', tone: 'safe' },
+      { name: 'IMU', health: 100, status: 'OK', tone: 'safe' },
+      { name: 'Drive train', health: 98, status: 'OK', tone: 'safe' },
+      { name: 'Brake channel A/B', health: 100, status: '2/2 OK', tone: 'safe' },
+      { name: 'Comms (DDS)', health: 99, status: 'OK', tone: 'safe' },
+    ],
+    envelope: [
+      { axis: 'Linear velocity', current: '3.2 m/s', limit: '≤ 22.4 m/s', util: 14, tone: 'safe' },
+      { axis: 'Angular velocity', current: '0.22 rad/s', limit: '≤ 0.80 rad/s', util: 28, tone: 'safe' },
+      { axis: 'Lateral accel', current: '0.9 m/s²', limit: '≤ 2.5 m/s²', util: 36, tone: 'safe' },
+      { axis: 'Sensor confidence', current: '0.94', limit: '≥ 0.60', util: 30, tone: 'safe' },
+    ],
+  },
+}
+
+const commandsNominal: TwinCommand[] = [
+  { ts: '12:04:51', channel: 'cmd_vel.linear', value: '3.20 m/s', verdict: 'ALLOW', tone: 'safe' },
+  { ts: '12:04:51', channel: 'cmd_vel.angular', value: '0.22 rad/s', verdict: 'ALLOW', tone: 'safe' },
+  { ts: '12:04:50', channel: 'drive_to_pose', value: 'aisle-7 → dock-3', verdict: 'ALLOW', tone: 'safe' },
+  { ts: '12:04:49', channel: 'cmd_vel.linear', value: '3.18 m/s', verdict: 'ALLOW', tone: 'safe' },
+]
+const commandsDegraded: TwinCommand[] = [
+  { ts: '12:04:51', channel: 'cmd_vel.linear', value: '3.4 → 2.0 m/s', verdict: 'CLAMP', tone: 'warn' },
+  { ts: '12:04:50', channel: 'grasp_object', value: 'kinetic write', verdict: 'DENY', tone: 'warn' },
+  { ts: '12:04:49', channel: 'read_telemetry', value: 'pose + battery', verdict: 'ALLOW', tone: 'safe' },
+  { ts: '12:04:48', channel: 'cmd_vel.linear', value: '1.80 m/s', verdict: 'ALLOW', tone: 'safe' },
+]
+const commandsLocked: TwinCommand[] = [
+  { ts: '12:02:40', channel: 'cmd_vel.linear', value: '999 m/s', verdict: 'DENY', tone: 'crit' },
+  { ts: '12:02:40', channel: 'MRC', value: 'controlled stop', verdict: 'DENY', tone: 'crit' },
+  { ts: '12:02:41', channel: 'any motion', value: 'human reset pending', verdict: 'DENY', tone: 'crit' },
+]
+
+// Map the 8 roster robots → digital twins with posture-appropriate detail.
+const roster = [
+  { id: 'r1', name: 'KIRRA-07', model: 'Atlas-X', kind: 'nominal', battery: 88, draw: 240, range: 11.4 },
+  { id: 'r2', name: 'KIRRA-08', model: 'Spot-V2', kind: 'nominal', battery: 64, draw: 180, range: 7.9 },
+  { id: 'r3', name: 'KIRRA-09', model: 'AMR-400', kind: 'nominal', battery: 41, draw: 310, range: 5.1 },
+  { id: 'r4', name: 'KIRRA-10', model: 'Forklift-A', kind: 'degraded', battery: 22, draw: 520, range: 2.0 },
+  { id: 'r5', name: 'KIRRA-11', model: 'Atlas-X', kind: 'nominal', battery: 73, draw: 250, range: 9.0 },
+  { id: 'r6', name: 'KIRRA-12', model: 'Spot-V2', kind: 'nominal', battery: 95, draw: 175, range: 12.2 },
+  { id: 'r7', name: 'KIRRA-13', model: 'AMR-400', kind: 'lockedout', battery: 12, draw: 60, range: 0.0 },
+  { id: 'r8', name: 'KIRRA-14', model: 'Forklift-A', kind: 'nominal', battery: 57, draw: 300, range: 6.6 },
+]
+
+function attestationFor(kind: string, name: string): TwinAttestation {
+  if (kind === 'lockedout') return { nodeId: name, akDigest: 'ak:7c1a…9e', pcr16: 'sha256:0xa1…fe', lastVerified: '11:58:02', status: 'Untrusted', tone: 'crit' }
+  if (kind === 'degraded') return { nodeId: name, akDigest: 'ak:33b8…04', pcr16: 'sha256:0x4c…21', lastVerified: '12:03:40', status: 'Trusted', tone: 'safe' }
+  return { nodeId: name, akDigest: 'ak:a9f0…71', pcr16: 'sha256:0x9f…c1', lastVerified: '12:04:50', status: 'Trusted', tone: 'safe' }
+}
+
+export const twins: Twin[] = roster.map((r, i) => {
+  const b = base[r.kind]!
+  const commands = r.kind === 'lockedout' ? commandsLocked : r.kind === 'degraded' ? commandsDegraded : commandsNominal
+  const path = trace(i * 1.3)
+  return {
+    id: r.id,
+    name: r.name,
+    model: r.model,
+    posture: b.posture!,
+    status: r.kind === 'lockedout' ? 'standby · HOLD' : 'online',
+    uptime: r.kind === 'lockedout' ? '— halted —' : ['41d 09h', '12d 22h', '6d 04h', '2d 11h', '88d 01h', '33d 17h', '—', '19d 06h'][i],
+    firmware: r.kind === 'nominal' ? 'v2.4.1' : 'v2.4.1',
+    battery: r.battery,
+    drawW: r.draw,
+    rangeKm: r.range,
+    subsystems: b.subsystems!,
+    envelope: b.envelope!,
+    attestation: attestationFor(r.kind, r.name),
+    commands,
+    path,
+    ego: path[26],
+  }
+})
+
+export function twinById(id: string): Twin | undefined {
+  return twins.find((t) => t.id === id)
+}

--- a/console/lib/incidents.ts
+++ b/console/lib/incidents.ts
@@ -1,0 +1,59 @@
+import type { Tone, Posture } from './types'
+
+// Incident Review & Replay — post-event reconstruction. Each incident carries a
+// frame-by-frame replay timeline so an operator can scrub the seconds around a
+// fail-closed event and watch posture, speed, and the verdict stream evolve.
+
+export interface Incident {
+  id: string
+  ts: string
+  title: string
+  asset: string
+  reason: string
+  posture: Posture
+  status: 'Resolved' | 'Open' | 'Human-reset'
+  tone: Tone
+  durationS: number
+}
+
+export const incidents: Incident[] = [
+  { id: 'INC-2041', ts: '2026-06-14 12:02:40', title: 'Envelope breach → DAG lockout', asset: 'KIRRA-13', reason: 'KINEMATIC_ENVELOPE_BREACH', posture: 'LockedOut', status: 'Human-reset', tone: 'crit', durationS: 12 },
+  { id: 'INC-2038', ts: '2026-06-14 11:58:03', title: 'Sensor confidence floor breach', asset: 'KIRRA-10', reason: 'DEGRADED_POSTURE_KINETIC_DENIED', posture: 'Degraded', status: 'Resolved', tone: 'warn', durationS: 41 },
+  { id: 'INC-2030', ts: '2026-06-14 10:22:10', title: 'Dependency cycle detected', asset: 'fleet-dag', reason: 'CYCLE_DETECTED', posture: 'LockedOut', status: 'Resolved', tone: 'crit', durationS: 8 },
+  { id: 'INC-2024', ts: '2026-06-13 19:41:55', title: 'Unknown action type rejected', asset: 'KIRRA-09', reason: 'UNKNOWN_ACTION_TYPE', posture: 'Nominal', status: 'Resolved', tone: 'warn', durationS: 1 },
+]
+
+export interface ReplayFrame {
+  t: number // seconds relative to incident trigger (negative = lead-up)
+  clock: string
+  speed: number // m/s
+  posture: Posture
+  verdict: 'ALLOW' | 'CLAMP' | 'DENY' | '—'
+  event: string
+  tone: Tone
+}
+
+// The featured replay: INC-2041, the KIRRA-13 envelope breach → lockout.
+export const featured = incidents[0]
+
+export const replay: ReplayFrame[] = [
+  { t: -6, clock: '12:02:34', speed: 1.2, posture: 'Nominal', verdict: 'ALLOW', event: 'cmd_vel 1.2 m/s dispatched — nominal cruise', tone: 'safe' },
+  { t: -5, clock: '12:02:35', speed: 1.4, posture: 'Nominal', verdict: 'ALLOW', event: 'cmd_vel 1.4 m/s — within envelope', tone: 'safe' },
+  { t: -4, clock: '12:02:36', speed: 1.6, posture: 'Nominal', verdict: 'ALLOW', event: 'radar return intermittent — confidence 0.71', tone: 'safe' },
+  { t: -3, clock: '12:02:37', speed: 1.9, posture: 'Nominal', verdict: 'ALLOW', event: 'planner requests acceleration to 2.4 m/s', tone: 'safe' },
+  { t: -2, clock: '12:02:38', speed: 2.2, posture: 'Degraded', verdict: 'CLAMP', event: 'confidence 0.54 < floor → posture Degraded; speed clamped 2.0 m/s', tone: 'warn' },
+  { t: -1, clock: '12:02:39', speed: 2.0, posture: 'Degraded', verdict: 'CLAMP', event: 'planner re-requests 3.1 m/s → decel-bound denied', tone: 'warn' },
+  { t: 0, clock: '12:02:40', speed: 2.0, posture: 'Degraded', verdict: 'DENY', event: 'malformed cmd_vel 999 m/s → KINEMATIC_ENVELOPE_BREACH', tone: 'crit' },
+  { t: 1, clock: '12:02:41', speed: 1.1, posture: 'LockedOut', verdict: 'DENY', event: 'cycle detected in dependency DAG → KIRRA-13 isolated', tone: 'crit' },
+  { t: 2, clock: '12:02:42', speed: 0.3, posture: 'LockedOut', verdict: 'DENY', event: 'MRC controlled stop engaged — brakes A/B', tone: 'crit' },
+  { t: 3, clock: '12:02:43', speed: 0.0, posture: 'LockedOut', verdict: '—', event: 'asset at full stop — HOLD; human reset required', tone: 'crit' },
+]
+
+export interface RootCause { id: string; label: string; detail: string; tone: Tone }
+
+export const rootCause: RootCause[] = [
+  { id: 'rc1', label: 'Trigger', detail: 'Upstream planner emitted cmd_vel linear = 999 m/s', tone: 'crit' },
+  { id: 'rc2', label: 'Contributing', detail: 'Front radar degraded → sensor confidence fell below 0.60 floor', tone: 'warn' },
+  { id: 'rc3', label: 'Governor action', detail: 'DENY at envelope check; DAG lockout isolated the node; MRC stop', tone: 'safe' },
+  { id: 'rc4', label: 'Outcome', detail: 'No motion past breach. Decel-to-stop in 3.0 s. Zero envelope excursion.', tone: 'safe' },
+]


### PR DESCRIPTION
## Drop 5 — Fleet depth + post-incident reconstruction

Three new screens. Sidebar already routes to `/fleet` and `/incidents` (these replace the slug placeholder). All reuse `Panel/Pill/Meter/StatusDot`, `PositionMap`, and `Tone` tokens.

### Fleet Operations (`/fleet`)
Asset roster — card grid + tabular view. Each asset shows posture, battery, range, draw, and attestation state, and drills into its digital twin.

### Robot Digital Twin (`/fleet/[id]`)
Per-asset deep view (Next 15 async params + `generateStaticParams`):
- **Live kinematic envelope** — proposed vs certified hard limits per axis (linear/angular velocity, lateral accel, sensor confidence floor)
- **Subsystem health** — LiDAR/radar/IMU/drive/brake/DDS
- **Position trace** — reuses `PositionMap`
- **Hardware attestation** — per-node Ed25519 proof (node id, AK digest, PCR16, trust state)
- **Command stream** — recent actuator commands with governor verdict
- Posture-appropriate detail across Nominal / Degraded / LockedOut assets (KIRRA-13 lockout shows all-motion-denied + Untrusted AK).

### Incident Replay (`/incidents`)
An **interactive scrubber** reconstructing the seconds around a fail-closed event — INC-2041, KIRRA-13 envelope breach → DAG lockout:
- Play / pause / scrub a 10-frame timeline (lead-up → trigger → decel-to-stop)
- Posture, commanded speed, and governor verdict update in lock-step with the playhead
- Frame log, root-cause analysis, and full incident history
- Client component (`useState`/`useEffect` playback deck)

Mock data only; semantics mirror the real Kirra domain (decel-to-stop, MRC, envelope checks, attestation). No `src/` changes.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_