### PR TITLE
feat(console): DDS/Network Health + Fleet Mission Gantt

### DIFF
--- a/console/app/missions/page.tsx
+++ b/console/app/missions/page.tsx
@@ -1,5 +1,6 @@
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
-import { mission, phases, waypoints, tasks, risk, operatorInterventions } from '@/lib/missions'
+import { mission, phases, waypoints, tasks, risk, operatorInterventions, gantt, ganttWindow } from '@/lib/missions'
+import type { Tone } from '@/lib/types'
 
 export default function MissionsPage() {
   return (
@@ -14,6 +15,61 @@ export default function MissionsPage() {
           <span className="font-mono text-[11px] text-faint">ETA {mission.eta}</span>
         </div>
       </div>
+
+      {/* ── Fleet Mission Gantt (Drop 6) ── */}
+      <Panel title="Fleet Mission Gantt" subtitle={`${gantt.length} missions · ${ganttWindow.start}–${ganttWindow.end} · ${ganttWindow.label}`} action={<Pill tone="ice">now {clock(ganttWindow.nowFrac)}</Pill>}>
+        {/* axis */}
+        <div className="mb-2 flex items-center">
+          <div className="w-40 shrink-0" />
+          <div className="relative flex-1">
+            <div className="flex justify-between font-mono text-[10px] text-faint">
+              {['10:00', '11:00', '12:00', '13:00', '14:00'].map((h) => <span key={h}>{h}</span>)}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-2.5">
+          {gantt.map((row) => (
+            <div key={row.id} className="flex items-center">
+              <div className="w-40 shrink-0 pr-3">
+                <div className="flex items-center gap-2">
+                  <StatusDot tone={row.tone} pulse={row.status === 'held'} />
+                  <span className="truncate font-mono text-[12px] text-ink">{row.asset}</span>
+                </div>
+                <div className="truncate pl-4 font-mono text-[10px] text-faint">{row.name}</div>
+              </div>
+              <div className="relative h-7 flex-1 overflow-hidden rounded-md border border-line bg-bg/40">
+                {/* hour gridlines */}
+                {[0.25, 0.5, 0.75].map((f) => (
+                  <span key={f} className="absolute top-0 h-full w-px bg-white/[0.04]" style={{ left: `${f * 100}%` }} />
+                ))}
+                {/* now line */}
+                <span className="absolute top-0 z-10 h-full w-px bg-ice/70" style={{ left: `${ganttWindow.nowFrac * 100}%` }} />
+                {/* segments */}
+                {row.segments.map((s, i) => (
+                  <div
+                    key={i}
+                    className={`absolute top-1 flex h-5 items-center overflow-hidden rounded ${segBg(s.tone)} ${s.tone === 'muted' ? 'border border-dashed border-line' : ''}`}
+                    style={{ left: `${s.start * 100}%`, width: `${(s.end - s.start) * 100}%` }}
+                    title={s.phase}
+                  >
+                    <span className={`truncate px-1.5 font-mono text-[9px] ${s.tone === 'muted' ? 'text-faint' : 'text-bg'}`}>{s.phase}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-4 border-t border-line pt-3 font-mono text-[10px] text-faint">
+          <Legend tone="safe" label="completed" />
+          <Legend tone="ice" label="active" />
+          <Legend tone="warn" label="held / degraded" />
+          <Legend tone="crit" label="lockout" />
+          <Legend tone="muted" label="queued" />
+          <span className="ml-auto flex items-center gap-1.5"><span className="h-3 w-px bg-ice/70" /> now</span>
+        </div>
+      </Panel>
 
       <Panel title="Mission Timeline" subtitle={`${mission.progress}% complete · started ${mission.started}`}>
         <div className="mb-4 h-1.5 w-full overflow-hidden rounded-full bg-white/5">
@@ -94,4 +150,23 @@ export default function MissionsPage() {
       </Panel>
     </div>
   )
+}
+
+function Legend({ tone, label }: { tone: Tone; label: string }) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <span className={`h-2.5 w-2.5 rounded-sm ${segBg(tone)}`} />
+      {label}
+    </span>
+  )
+}
+
+function segBg(t: Tone) { return t === 'safe' ? 'bg-safe' : t === 'warn' ? 'bg-warn' : t === 'crit' ? 'bg-crit' : t === 'ice' ? 'bg-ice' : 'bg-muted/40' }
+
+// Convert a window fraction to a wall-clock label for the 10:00–14:00 window.
+function clock(frac: number): string {
+  const totalMin = 4 * 60 * frac
+  const h = 10 + Math.floor(totalMin / 60)
+  const m = Math.round(totalMin % 60)
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
 }

--- a/console/app/runtime/page.tsx
+++ b/console/app/runtime/page.tsx
@@ -1,7 +1,7 @@
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
 import { Spark } from '@/components/charts/charts'
 import { LatencyLines } from '@/components/charts/extra'
-import { resources, latency, network, partitions, nodes } from '@/lib/runtime'
+import { resources, latency, network, partitions, nodes, ddsTopics, ddsPeers } from '@/lib/runtime'
 import type { Tone } from '@/lib/types'
 
 export default function RuntimePage() {
@@ -45,6 +45,56 @@ export default function RuntimePage() {
               </div>
             ))}
           </div>
+        </Panel>
+      </div>
+
+      {/* ── DDS / Network Health (Drop 6) ── */}
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="DDS Topic Health" subtitle="deadline budget vs observed p99 · Volatile durability enforced" dense action={<Pill tone="safe">QoS: Volatile</Pill>}>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-left">
+              <thead>
+                <tr className="border-b border-line font-mono text-[10px] uppercase tracking-wider text-faint">
+                  <th className="px-4 py-2 font-normal">Topic</th>
+                  <th className="px-4 py-2 font-normal">QoS</th>
+                  <th className="px-4 py-2 font-normal">Pub/Sub</th>
+                  <th className="px-4 py-2 font-normal">Deadline</th>
+                  <th className="px-4 py-2 font-normal">Observed</th>
+                  <th className="px-4 py-2 font-normal">Miss rate</th>
+                </tr>
+              </thead>
+              <tbody className="font-mono text-[12px]">
+                {ddsTopics.map((d) => (
+                  <tr key={d.topic} className="border-b border-line last:border-0 hover:bg-white/[0.02]">
+                    <td className="px-4 py-2.5 text-ink">{d.topic}</td>
+                    <td className="px-4 py-2.5 text-ice">{d.qos}</td>
+                    <td className="px-4 py-2.5 text-faint">{d.pubs}/{d.subs}</td>
+                    <td className="px-4 py-2.5 text-muted">{d.deadlineMs} ms</td>
+                    <td className={`px-4 py-2.5 ${d.observedMs > d.deadlineMs * 0.85 ? 'text-warn' : 'text-muted'}`}>{d.observedMs} ms</td>
+                    <td className={`px-4 py-2.5 ${txt(d.tone)}`}>{d.missRate.toFixed(1)}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Panel>
+
+        <Panel title="Participant Discovery" subtitle="DDS liveliness matrix" dense>
+          <ul>
+            {ddsPeers.map((p) => (
+              <li key={p.id} className="flex items-center gap-3 border-b border-line px-4 py-3 last:border-0">
+                <StatusDot tone={p.tone} pulse={p.liveliness === 'LOST'} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-mono text-[12px] text-ink">{p.id}</div>
+                  <div className="font-mono text-[10px] text-faint">{p.role}</div>
+                </div>
+                <div className="text-right">
+                  <div className={`font-mono text-[11px] ${p.liveliness === 'LOST' ? 'text-crit' : 'text-muted'}`}>{p.liveliness}</div>
+                  <div className="font-mono text-[10px] text-faint">{p.rttMs} ms · {p.lastSeen}</div>
+                </div>
+              </li>
+            ))}
+          </ul>
         </Panel>
       </div>
 

--- a/console/lib/missions.ts
+++ b/console/lib/missions.ts
@@ -47,3 +47,70 @@ export const operatorInterventions: { ts: string; detail: string; tone: Tone }[]
   { ts: '11:58', detail: 'Manual hold — crossing clearance', tone: 'warn' },
   { ts: '11:12', detail: 'Re-route approved (aisle 4 blocked)', tone: 'ice' },
 ]
+
+// ── Mission Gantt (Drop 6) ─────────────────────────────────────────────────
+// Concurrent fleet missions across a shared time window. Each segment's
+// start/end are fractions (0..1) of the window; `nowFrac` is the playhead.
+
+export const ganttWindow = { start: '10:00', end: '14:00', label: '4h window', nowFrac: 0.62 }
+
+export interface GanttSeg { phase: string; start: number; end: number; tone: Tone }
+export interface GanttRow {
+  id: string
+  asset: string
+  name: string
+  status: 'active' | 'queued' | 'done' | 'held'
+  tone: Tone
+  segments: GanttSeg[]
+}
+
+export const gantt: GanttRow[] = [
+  {
+    id: 'MSN-4471', asset: 'KIRRA-09', name: 'Yard Logistics Loop', status: 'active', tone: 'ice',
+    segments: [
+      { phase: 'Dispatch', start: 0.10, end: 0.16, tone: 'safe' },
+      { phase: 'Transit A', start: 0.16, end: 0.34, tone: 'safe' },
+      { phase: 'Pick', start: 0.34, end: 0.46, tone: 'safe' },
+      { phase: 'Transit B', start: 0.46, end: 0.66, tone: 'ice' },
+      { phase: 'Place', start: 0.66, end: 0.80, tone: 'muted' },
+      { phase: 'Return', start: 0.80, end: 0.94, tone: 'muted' },
+    ],
+  },
+  {
+    id: 'MSN-4468', asset: 'KIRRA-07', name: 'Perimeter Patrol B', status: 'active', tone: 'ice',
+    segments: [
+      { phase: 'Loop 1', start: 0.04, end: 0.30, tone: 'safe' },
+      { phase: 'Loop 2', start: 0.30, end: 0.56, tone: 'safe' },
+      { phase: 'Loop 3', start: 0.56, end: 0.72, tone: 'ice' },
+      { phase: 'Charge', start: 0.72, end: 0.84, tone: 'muted' },
+    ],
+  },
+  {
+    id: 'MSN-4470', asset: 'KIRRA-12', name: 'Pallet Run 18', status: 'active', tone: 'ice',
+    segments: [
+      { phase: 'Stage', start: 0.20, end: 0.30, tone: 'safe' },
+      { phase: 'Haul', start: 0.30, end: 0.60, tone: 'ice' },
+      { phase: 'Drop', start: 0.60, end: 0.74, tone: 'muted' },
+    ],
+  },
+  {
+    id: 'MSN-4465', asset: 'KIRRA-10', name: 'Aisle Inspection', status: 'held', tone: 'warn',
+    segments: [
+      { phase: 'Survey', start: 0.08, end: 0.40, tone: 'safe' },
+      { phase: 'HOLD (degraded)', start: 0.40, end: 0.62, tone: 'warn' },
+    ],
+  },
+  {
+    id: 'MSN-4461', asset: 'KIRRA-13', name: 'Yard Transit', status: 'held', tone: 'crit',
+    segments: [
+      { phase: 'Transit', start: 0.02, end: 0.50, tone: 'safe' },
+      { phase: 'LOCKOUT', start: 0.50, end: 0.62, tone: 'crit' },
+    ],
+  },
+  {
+    id: 'MSN-4474', asset: 'KIRRA-14', name: 'Survey Sweep', status: 'queued', tone: 'muted',
+    segments: [
+      { phase: 'Queued', start: 0.70, end: 0.96, tone: 'muted' },
+    ],
+  },
+]

--- a/console/lib/runtime.ts
+++ b/console/lib/runtime.ts
@@ -51,3 +51,39 @@ export const nodes: NodeHealth[] = [
   { id: 'node-5', cpu: 28, mem: 35, tempC: 46 },
   { id: 'node-6', cpu: 49, mem: 52, tempC: 54 },
 ].map((n) => ({ ...n, tone: (n.cpu > 80 || n.tempC > 70 ? 'crit' : n.cpu > 60 || n.tempC > 60 ? 'warn' : 'safe') as Tone }))
+
+// ── DDS / Network Health (Drop 6) ──────────────────────────────────────────
+// Per-topic transport health. Actuator/command topics are Volatile durability
+// (the fail-closed invariant — a late publisher must never replay a stale
+// actuator sample). Deadline budgets are watched against observed p99.
+
+export interface DdsTopic {
+  topic: string
+  qos: 'Volatile'
+  deadlineMs: number
+  observedMs: number
+  missRate: number // % of samples missing the deadline
+  pubs: number
+  subs: number
+  tone: Tone
+}
+
+export const ddsTopics: DdsTopic[] = [
+  { topic: '/governor/verdict', qos: 'Volatile', deadlineMs: 20, observedMs: 6, missRate: 0.0, pubs: 1, subs: 6, tone: 'safe' },
+  { topic: '/cmd_vel', qos: 'Volatile', deadlineMs: 50, observedMs: 14, missRate: 0.0, pubs: 8, subs: 8, tone: 'safe' },
+  { topic: '/fleet/posture', qos: 'Volatile', deadlineMs: 100, observedMs: 22, missRate: 0.0, pubs: 1, subs: 38, tone: 'safe' },
+  { topic: '/telemetry/pose', qos: 'Volatile', deadlineMs: 100, observedMs: 31, missRate: 0.2, pubs: 8, subs: 4, tone: 'safe' },
+  { topic: '/sensor/lidar', qos: 'Volatile', deadlineMs: 100, observedMs: 88, missRate: 1.4, pubs: 8, subs: 8, tone: 'warn' },
+  { topic: '/sensor/radar', qos: 'Volatile', deadlineMs: 100, observedMs: 97, missRate: 4.1, pubs: 8, subs: 8, tone: 'warn' },
+]
+
+export interface DdsPeer { id: string; role: string; rttMs: number; liveliness: 'ALIVE' | 'LOST'; lastSeen: string; tone: Tone }
+
+export const ddsPeers: DdsPeer[] = [
+  { id: 'participant-gov-0', role: 'Governor partition', rttMs: 2, liveliness: 'ALIVE', lastSeen: 'now', tone: 'safe' },
+  { id: 'participant-plan-1', role: 'Autoware planner', rttMs: 5, liveliness: 'ALIVE', lastSeen: 'now', tone: 'safe' },
+  { id: 'participant-edge-7', role: 'KIRRA-13 edge', rttMs: 41, liveliness: 'LOST', lastSeen: '11:58:02', tone: 'crit' },
+  { id: 'participant-edge-4', role: 'KIRRA-10 edge', rttMs: 18, liveliness: 'ALIVE', lastSeen: 'now', tone: 'warn' },
+  { id: 'participant-tel-2', role: 'Telemetry capture', rttMs: 7, liveliness: 'ALIVE', lastSeen: 'now', tone: 'safe' },
+  { id: 'participant-fed-w', role: 'Peer controller (west)', rttMs: 24, liveliness: 'ALIVE', lastSeen: 'now', tone: 'safe' },
+]


### PR DESCRIPTION
## Drop 6 — deepens two existing screens (no orphan routes)

### Runtime Health (`/runtime`)
- **DDS Topic Health** — per-topic table: deadline budget vs observed p99, pub/sub fan-out, and **Volatile durability enforcement** (reinforces the fail-closed invariant that actuator topics must never replay a stale sample). `/sensor/radar` shows an elevated miss-rate consistent with the degraded radar elsewhere in the demo.
- **Participant Discovery** — DDS liveliness matrix (RTT, ALIVE/LOST, last-seen). KIRRA-13's edge participant reads liveliness-lost, matching its lockout.

### Mission Operations (`/missions`)
- **Fleet Mission Gantt** — six concurrent fleet missions across a shared 4h window; phase segments positioned on a time axis with a live **now playhead**, hour gridlines, held/degraded and lockout states, queued (dashed) bars, and a legend. KIRRA-13's row terminates in a LOCKOUT segment; KIRRA-10 sits in a degraded HOLD.

Purely additive — all prior sections and data preserved. No `src/` changes.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_