### PR TITLE
feat(console): Event Stream + Analytics & Risk Forecasting

### DIFF
--- a/console/app/analytics/page.tsx
+++ b/console/app/analytics/page.tsx
@@ -1,0 +1,90 @@
+import { Panel, Pill, Meter } from '@/components/ui/primitives'
+import { TrendArea, Spark } from '@/components/charts/charts'
+import { DualLine } from '@/components/charts/extra2'
+import { kpiWall, throughputTrend, riskForecast, riskDrivers, projections } from '@/lib/analytics'
+import type { Tone } from '@/lib/types'
+
+export default function AnalyticsPage() {
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-ink">Analytics & Risk Forecasting</h1>
+          <p className="font-mono text-[11px] text-faint">executive KPIs · fleet trends · forward risk projection</p>
+        </div>
+        <Pill tone="ice">30-day window</Pill>
+      </div>
+
+      {/* Executive KPI Wall (#9) */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-6">
+        {kpiWall.map((k) => (
+          <div key={k.label} className="rounded-xl border border-line bg-panel p-4 shadow-panel">
+            <div className="font-mono text-[10px] uppercase tracking-wider text-faint">{k.label}</div>
+            <div className="mt-2 flex items-baseline gap-1">
+              <span className="font-display text-[24px] font-semibold leading-none text-ink">{k.value}</span>
+              {k.unit && <span className="font-mono text-[11px] text-muted">{k.unit}</span>}
+            </div>
+            <div className={`mt-1 font-mono text-[10px] ${txt(k.tone)}`}>{k.delta}</div>
+            <div className="mt-2"><Spark data={k.spark} color={k.tone === 'muted' ? 'ice' : k.tone} /></div>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Operational Risk Forecast" subtitle="composite risk index · observed vs projected (90% ceiling)" action={<Pill tone="warn">rising</Pill>}>
+          <DualLine
+            data={riskForecast as unknown as { t: string; [k: string]: string | number }[]}
+            keys={['observed', 'forecast']}
+            colors={['#5cc6ff', '#ffb020']}
+            height={230}
+          />
+          <p className="mt-2 font-mono text-[10px] text-faint">Observed (ice) holds through 19:00; forecast (amber) projects a climb into the evening shift change.</p>
+        </Panel>
+
+        <Panel title="Risk Projection" subtitle="banded outlook">
+          <ul className="space-y-3">
+            {projections.map((p) => (
+              <li key={p.window} className="rounded-lg border border-line bg-bg/40 p-3">
+                <div className="flex items-center justify-between">
+                  <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{p.window}</span>
+                  <span className={`rounded px-1.5 py-0.5 font-mono text-[10px] uppercase ${badge(p.tone)}`}>{p.band}</span>
+                </div>
+                <div className="mt-2 flex items-end gap-2">
+                  <span className={`font-display text-2xl font-semibold ${txt(p.tone)}`}>{p.score}</span>
+                  <span className="mb-1 font-mono text-[10px] text-faint">/ 100 risk</span>
+                </div>
+                <p className="mt-1 text-[11px] text-muted">{p.note}</p>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Fleet Throughput" subtitle="commands / min · 24h">
+          <TrendArea data={throughputTrend} color="ice" height={210} />
+        </Panel>
+
+        <Panel title="Risk Drivers" subtitle="contribution to projected risk" dense>
+          <ul className="px-4 py-2">
+            {riskDrivers.map((d) => (
+              <li key={d.name} className="border-b border-line py-3 last:border-0">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[12px] text-ink">{d.name}</span>
+                  <span className="flex items-center gap-1.5 font-mono text-[11px] text-muted">
+                    <span className={txt(d.tone)}>{arrow(d.trend)}</span>{d.contribution}%
+                  </span>
+                </div>
+                <div className="mt-2"><Meter value={d.contribution} tone={d.tone} /></div>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      </div>
+    </div>
+  )
+}
+
+function arrow(t: 'rising' | 'flat' | 'falling') { return t === 'rising' ? '▲' : t === 'falling' ? '▼' : '▬' }
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
+function badge(t: Tone) { return t === 'safe' ? 'bg-safe/15 text-safe' : t === 'warn' ? 'bg-warn/15 text-warn' : t === 'crit' ? 'bg-crit/15 text-crit' : 'bg-ice/15 text-ice' }

--- a/console/app/events/page.tsx
+++ b/console/app/events/page.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
+import { log, sources, sourceTone, type EventSource } from '@/lib/events'
+import type { Tone } from '@/lib/types'
+
+type SevFilter = 'all' | 'crit' | 'warn' | 'safe'
+
+export default function EventsPage() {
+  const [src, setSrc] = useState<EventSource | 'all'>('all')
+  const [sev, setSev] = useState<SevFilter>('all')
+
+  const filtered = useMemo(
+    () => log.filter((e) => (src === 'all' || e.source === src) && (sev === 'all' || e.tone === sev)),
+    [src, sev]
+  )
+
+  const counts = useMemo(() => ({
+    crit: log.filter((e) => e.tone === 'crit').length,
+    warn: log.filter((e) => e.tone === 'warn').length,
+    safe: log.filter((e) => e.tone === 'safe').length,
+  }), [])
+
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-ink">Event Stream</h1>
+          <p className="font-mono text-[11px] text-faint">unified fail-closed event log · all subsystems</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Pill tone="crit">{counts.crit} critical</Pill>
+          <Pill tone="warn">{counts.warn} warning</Pill>
+          <Pill tone="safe">{counts.safe} nominal</Pill>
+        </div>
+      </div>
+
+      <Panel
+        title="Live Events"
+        subtitle={`${filtered.length} of ${log.length} events`}
+        action={
+          <div className="flex items-center gap-1">
+            {(['all', 'crit', 'warn', 'safe'] as SevFilter[]).map((s) => (
+              <Chip key={s} active={sev === s} tone={s === 'all' ? 'muted' : (s as Tone)} onClick={() => setSev(s)}>{s === 'all' ? 'All' : s.toUpperCase()}</Chip>
+            ))}
+          </div>
+        }
+        dense
+      >
+        {/* source filter row */}
+        <div className="flex flex-wrap items-center gap-1.5 border-b border-line px-4 py-3">
+          <Chip active={src === 'all'} tone="muted" onClick={() => setSrc('all')}>all sources</Chip>
+          {sources.map((s) => (
+            <Chip key={s} active={src === s} tone={sourceTone(s)} onClick={() => setSrc(s)}>{s}</Chip>
+          ))}
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="px-4 py-12 text-center font-mono text-[12px] text-faint">no events match the current filter</div>
+        ) : (
+          <ul>
+            {filtered.map((e) => (
+              <li key={e.id} className="flex items-start gap-4 border-b border-line px-4 py-3 last:border-0 hover:bg-white/[0.02]">
+                <StatusDot tone={e.tone} pulse={e.tone === 'crit'} />
+                <span className="w-16 shrink-0 font-mono text-[11px] text-faint">{e.ts}</span>
+                <span className={`w-24 shrink-0 font-mono text-[10px] uppercase tracking-wider ${txt(sourceTone(e.source))}`}>{e.source}</span>
+                <div className="min-w-0 flex-1">
+                  <p className={`text-[12px] ${e.tone === 'crit' ? 'text-ink' : 'text-muted'}`}>{e.message}</p>
+                  {e.code && <span className={`mt-1 inline-block font-mono text-[10px] ${txt(e.tone)}`}>{e.code}</span>}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Panel>
+    </div>
+  )
+}
+
+function Chip({ children, active, tone, onClick }: { children: React.ReactNode; active: boolean; tone: Tone; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider transition-colors ${active ? `${ring(tone)} ${txt(tone)} bg-white/[0.04] ring-1` : 'text-faint hover:text-muted'}`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
+function ring(t: Tone) { return t === 'safe' ? 'ring-safe/30' : t === 'warn' ? 'ring-warn/30' : t === 'crit' ? 'ring-crit/30' : t === 'ice' ? 'ring-ice/30' : 'ring-white/10' }

--- a/console/lib/analytics.ts
+++ b/console/lib/analytics.ts
@@ -1,0 +1,68 @@
+import type { SeriesPoint, Tone } from './types'
+
+// Analytics & Risk Forecasting — executive KPI wall, fleet-wide trends, and a
+// forward-looking operational-risk projection with its driving factors.
+
+function g(n: number, b: number, j: number, drift = 0): SeriesPoint[] {
+  const o: SeriesPoint[] = []
+  let v = b
+  for (let i = 0; i < n; i++) {
+    v += (Math.random() - 0.5) * j + drift
+    v = Math.max(0, v)
+    o.push({ t: `${String(i).padStart(2, '0')}:00`, v: Math.round(v * 10) / 10 })
+  }
+  return o
+}
+
+export interface ExecKpi { label: string; value: string; unit?: string; delta: string; tone: Tone; spark: SeriesPoint[] }
+
+export const kpiWall: ExecKpi[] = [
+  { label: 'Fleet availability', value: '99.98', unit: '%', delta: '+0.02 · 30d', tone: 'safe', spark: g(24, 99, 0.3) },
+  { label: 'Safety interventions', value: '3', unit: '24h', delta: '+1', tone: 'warn', spark: g(24, 2, 1) },
+  { label: 'Mean verdict latency', value: '38', unit: 'µs', delta: '−4 µs', tone: 'safe', spark: g(24, 40, 4) },
+  { label: 'Envelope excursions', value: '0', unit: '30d', delta: 'zero', tone: 'safe', spark: g(24, 0.2, 0.4) },
+  { label: 'Missions completed', value: '1,284', delta: '+96 · 7d', tone: 'ice', spark: g(24, 50, 6) },
+  { label: 'Audit-chain integrity', value: '100', unit: '%', delta: 'no breaks', tone: 'safe', spark: g(24, 100, 0.1) },
+]
+
+export const throughputTrend: SeriesPoint[] = g(24, 820, 90)
+export const interventionTrend: SeriesPoint[] = g(24, 4, 2)
+
+// Operational-risk forecast. `observed` is the realized composite risk index;
+// `forecast` projects the next horizon; `upper` is the 90% confidence ceiling.
+export type RiskRow = { t: string; observed: number | null; forecast: number; upper: number }
+
+export const riskForecast: RiskRow[] = (() => {
+  const rows: RiskRow[] = []
+  let obs = 16
+  for (let i = 0; i < 12; i++) {
+    obs += (Math.random() - 0.45) * 3
+    obs = Math.max(6, Math.min(40, obs))
+    rows.push({ t: `${String(8 + i).padStart(2, '0')}:00`, observed: Math.round(obs), forecast: Math.round(obs), upper: Math.round(obs + 4) })
+  }
+  // forward horizon — observed drops out, forecast climbs (congestion + radar drift)
+  let fc = rows[rows.length - 1].forecast
+  for (let i = 0; i < 6; i++) {
+    fc += 2.4 + Math.random()
+    rows.push({ t: `${String(20 + i).padStart(2, '0')}:00`, observed: null, forecast: Math.round(fc), upper: Math.round(fc + 6 + i) })
+  }
+  return rows
+})()
+
+export interface RiskDriver { name: string; contribution: number; trend: 'rising' | 'flat' | 'falling'; tone: Tone }
+
+export const riskDrivers: RiskDriver[] = [
+  { name: 'Radar sensor degradation', contribution: 38, trend: 'rising', tone: 'warn' },
+  { name: 'Aisle congestion (shift change)', contribution: 27, trend: 'rising', tone: 'warn' },
+  { name: 'Battery depletion (KIRRA-13/10)', contribution: 18, trend: 'flat', tone: 'ice' },
+  { name: 'DDS jitter', contribution: 11, trend: 'falling', tone: 'safe' },
+  { name: 'Pedestrian proximity', contribution: 6, trend: 'flat', tone: 'safe' },
+]
+
+export interface Projection { window: string; band: string; score: number; tone: Tone; note: string }
+
+export const projections: Projection[] = [
+  { window: 'Next 1h', band: 'LOW', score: 19, tone: 'safe', note: 'within nominal operating envelope' },
+  { window: 'Next 4h', band: 'MEDIUM', score: 34, tone: 'warn', note: 'radar drift + shift-change congestion' },
+  { window: 'Next 12h', band: 'MEDIUM', score: 41, tone: 'warn', note: 'recommend radar service window before 22:00' },
+]

--- a/console/lib/events.ts
+++ b/console/lib/events.ts
@@ -1,0 +1,40 @@
+import type { EventItem, Tone } from './types'
+
+// Event Stream — the unified fail-closed event log across every Kirra subsystem.
+// Each row carries a source channel + severity tone for filtering.
+
+export type EventSource = 'governor' | 'fleet' | 'telemetry' | 'compliance' | 'federation' | 'attestation'
+
+export interface LogEvent extends EventItem {
+  source: EventSource
+  code?: string
+}
+
+export const sources: EventSource[] = ['governor', 'fleet', 'telemetry', 'compliance', 'federation', 'attestation']
+
+export const log: LogEvent[] = [
+  { id: 'e01', tone: 'crit', source: 'governor', ts: '12:04:21', code: 'KINEMATIC_ENVELOPE_BREACH', message: 'DENY — KIRRA-13 cmd_vel 999 m/s rejected at envelope check' },
+  { id: 'e02', tone: 'crit', source: 'governor', ts: '12:02:40', code: 'CYCLE_DETECTED', message: 'LOCKEDOUT — cycle detected in dependency DAG; KIRRA-13 isolated' },
+  { id: 'e03', tone: 'warn', source: 'fleet', ts: '12:03:58', code: 'POSTURE_DEGRADED', message: 'KIRRA-10 entered Degraded posture (sensor confidence 0.41 < 0.60 floor)' },
+  { id: 'e04', tone: 'warn', source: 'governor', ts: '12:04:09', code: 'DEGRADED_DECEL_ENVELOPE', message: 'CLAMP — KIRRA-13 3.4 m/s → 2.0 m/s on MRC decel trajectory' },
+  { id: 'e05', tone: 'safe', source: 'governor', ts: '12:03:30', code: 'NOMINAL_VALID_KINEMATICS', message: 'ALLOW — cmd_vel 1.2 m/s dispatched to KIRRA-09' },
+  { id: 'e06', tone: 'ice', source: 'telemetry', ts: '12:03:12', message: 'DDS latency p99 = 14 ms (within FTTI budget 50 ms)' },
+  { id: 'e07', tone: 'warn', source: 'telemetry', ts: '12:02:55', message: '/sensor/radar deadline miss-rate 4.1% — front radar degraded' },
+  { id: 'e08', tone: 'crit', source: 'attestation', ts: '11:58:02', message: 'KIRRA-13 attestation revoked — liveliness lost, trust state Untrusted' },
+  { id: 'e09', tone: 'safe', source: 'attestation', ts: '12:04:50', message: 'KIRRA-09 Ed25519 attestation verified — PCR16 match' },
+  { id: 'e10', tone: 'safe', source: 'compliance', ts: '12:01:05', message: 'Audit chain verified · 184,220 links · no breaks' },
+  { id: 'e11', tone: 'warn', source: 'federation', ts: '11:31:09', message: 'Federated report from peer-controller-west rejected — replay nonce already burned' },
+  { id: 'e12', tone: 'safe', source: 'federation', ts: '11:40:51', message: 'Federated trust report accepted from peer-controller-west (gen 4471)' },
+  { id: 'e13', tone: 'safe', source: 'governor', ts: '12:01:48', code: 'DEGRADED_READ_ONLY_PERMITTED', message: 'ALLOW — KIRRA-11 read_telemetry permitted in Degraded' },
+  { id: 'e14', tone: 'warn', source: 'governor', ts: '11:58:03', code: 'DEGRADED_POSTURE_KINETIC_DENIED', message: 'DENY — KIRRA-10 kinetic write denied in Degraded posture' },
+  { id: 'e15', tone: 'crit', source: 'governor', ts: '12:03:41', code: 'UNKNOWN_ACTION_TYPE', message: 'DENY — KIRRA-09 unknown action "drive_to_moon" rejected' },
+  { id: 'e16', tone: 'safe', source: 'fleet', ts: '11:52:30', message: 'KIRRA-12 returned to Nominal — recovery streak 5/5 confirmed' },
+  { id: 'e17', tone: 'ice', source: 'telemetry', ts: '11:50:14', message: 'Throughput 2.4 Gb/s · packet loss 0.01% · jitter 0.4 ms' },
+  { id: 'e18', tone: 'safe', source: 'compliance', ts: '11:45:00', message: 'Signed firmware v2.4.1 provenance check passed on Governor partition' },
+  { id: 'e19', tone: 'warn', source: 'attestation', ts: '11:43:22', message: 'KIRRA-10 PCR16 drift warning — re-attestation scheduled' },
+  { id: 'e20', tone: 'safe', source: 'fleet', ts: '11:30:10', message: 'Fleet posture recalculated — gen 4470 — 6 Nominal / 1 Degraded / 1 LockedOut' },
+]
+
+export function sourceTone(s: EventSource): Tone {
+  return s === 'governor' ? 'crit' : s === 'fleet' ? 'warn' : s === 'telemetry' ? 'ice' : s === 'compliance' ? 'safe' : s === 'federation' ? 'ice' : 'warn'
+}


### PR DESCRIPTION
## Drop 7 — fills two placeholder routes

### Event Stream (`/events`)
Unified fail-closed event log across **governor, fleet, telemetry, compliance, federation, attestation**. Interactive **source + severity filters** (chips), reason-code annotations, severity counts, and an empty-state. Client component.

### Analytics & Risk Forecasting (`/analytics`)
- **Executive KPI Wall (#9)** — availability, safety interventions, mean verdict latency, envelope excursions, missions completed, audit-chain integrity — each with a sparkline.
- **Operational Risk Forecast (#15)** — observed-vs-projected composite risk index (`DualLine`, observed line stops at "now", forecast climbs into the evening shift change), banded **1h / 4h / 12h** projections, and a ranked **risk-driver** breakdown (radar degradation, congestion, battery, jitter, proximity).
- **Fleet throughput** trend.

Mock data only. No `src/` changes. Ten of twelve sidebar routes are now real screens (`/reports`, `/settings` remain).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_