### PR TITLE
feat(console): Reports & Releases + System & Operator Control

### DIFF
--- a/console/app/reports/page.tsx
+++ b/console/app/reports/page.tsx
@@ -1,0 +1,105 @@
+import { Download, FileText, ShieldCheck } from 'lucide-react'
+import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { reports, scheduled, rollout, rolloutVersion, versionShare } from '@/lib/reports'
+import type { Tone } from '@/lib/types'
+
+export default function ReportsPage() {
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-ink">Reports & Releases</h1>
+          <p className="font-mono text-[11px] text-faint">generated evidence · scheduled exports · software rollout</p>
+        </div>
+        <button className="flex items-center gap-2 rounded-lg border border-ice/40 bg-ice/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-wider text-ice hover:bg-ice/20">
+          <FileText className="h-3.5 w-3.5" /> Generate report
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Generated Reports" subtitle="signed evidence documents" dense>
+          <ul>
+            {reports.map((r) => (
+              <li key={r.id} className="flex items-center gap-4 border-b border-line px-4 py-3 last:border-0 hover:bg-white/[0.02]">
+                <StatusDot tone={r.tone} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-[13px] text-ink">{r.title}</span>
+                    {r.signed && <ShieldCheck className="h-3.5 w-3.5 shrink-0 text-safe" />}
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px] text-faint">
+                    <span>{r.id}</span><span>·</span><span>{r.kind}</span><span>·</span><span>{r.period}</span><span>·</span><span>{r.ts}</span>
+                  </div>
+                </div>
+                <span className={`rounded px-1.5 py-0.5 font-mono text-[10px] ${badge(r.tone)}`}>{r.format}</span>
+                <button className="flex h-7 w-7 items-center justify-center rounded-lg border border-line text-faint hover:bg-white/[0.04] hover:text-ink" aria-label="download">
+                  <Download className="h-3.5 w-3.5" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+
+        <Panel title="Scheduled Exports" subtitle="recurring deliveries" dense>
+          <ul>
+            {scheduled.map((s) => (
+              <li key={s.id} className="flex items-center gap-3 border-b border-line px-4 py-3 last:border-0">
+                <StatusDot tone={s.tone} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[12px] text-ink">{s.name}</div>
+                  <div className="font-mono text-[10px] text-faint">{s.cadence}</div>
+                </div>
+                <span className="font-mono text-[10px] text-muted">{s.next}</span>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      </div>
+
+      {/* ── Software Rollout / OTA (#11) ── */}
+      <Panel
+        title="Software Rollout"
+        subtitle={`${rolloutVersion.version} · ${rolloutVersion.channel} channel · staged · health-gated`}
+        action={<Pill tone="safe">signed release</Pill>}
+      >
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
+          {rollout.map((r) => (
+            <div key={r.id} className="rounded-xl border border-line bg-panel p-4">
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-[11px] text-ink">{r.ring}</span>
+                <span className={`rounded px-1.5 py-0.5 font-mono text-[9px] uppercase ${badge(r.tone)}`}>{r.status}</span>
+              </div>
+              <div className="mt-3 flex items-baseline gap-1.5">
+                <span className="font-display text-2xl font-semibold text-ink">{r.adoption}</span>
+                <span className="font-mono text-[11px] text-muted">% · {r.assets} assets</span>
+              </div>
+              <div className="mt-3"><Meter value={r.adoption} tone={r.tone} /></div>
+              <p className="mt-2 font-mono text-[10px] text-faint">{r.note}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-5 border-t border-line pt-4">
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-wider text-faint">Fleet version adoption</div>
+          <div className="flex h-3 overflow-hidden rounded-full bg-white/5">
+            {versionShare.map((v) => (
+              <div key={v.version} className={dotBg(v.tone)} style={{ width: `${v.pct}%` }} title={`${v.version} ${v.pct}%`} />
+            ))}
+          </div>
+          <div className="mt-3 flex flex-wrap gap-4 font-mono text-[11px]">
+            {versionShare.map((v) => (
+              <span key={v.version} className="flex items-center gap-1.5">
+                <span className={`h-2 w-2 rounded-full ${dotBg(v.tone)}`} />
+                <span className="text-ink">{v.version}</span>
+                <span className="text-faint">{v.pct}%</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      </Panel>
+    </div>
+  )
+}
+
+function dotBg(t: Tone) { return t === 'safe' ? 'bg-safe' : t === 'warn' ? 'bg-warn' : t === 'crit' ? 'bg-crit' : t === 'ice' ? 'bg-ice' : 'bg-muted' }
+function badge(t: Tone) { return t === 'safe' ? 'bg-safe/15 text-safe' : t === 'warn' ? 'bg-warn/15 text-warn' : t === 'crit' ? 'bg-crit/15 text-crit' : t === 'ice' ? 'bg-ice/15 text-ice' : 'bg-white/5 text-muted' }

--- a/console/app/settings/page.tsx
+++ b/console/app/settings/page.tsx
@@ -1,0 +1,132 @@
+import { AlertOctagon } from 'lucide-react'
+import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
+import { config, flags, operatorActions, operatorSessions, roster } from '@/lib/settings'
+import type { Tone } from '@/lib/types'
+
+export default function SettingsPage() {
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-ink">System & Operator Control</h1>
+          <p className="font-mono text-[11px] text-faint">configuration · feature flags · operator tools · access</p>
+        </div>
+        <Pill tone="safe">fail-closed · governor gates all actions</Pill>
+      </div>
+
+      {/* ── Operator Tools (#12) ── */}
+      <Panel title="Operator Tools" subtitle="human-in-the-loop · every action re-adjudicated by the Governor">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {operatorActions.map((a) => (
+            <button
+              key={a.id}
+              className={`rounded-xl border p-4 text-left transition-colors ${a.critical ? 'border-crit/40 bg-crit/[0.06] hover:bg-crit/[0.12]' : 'border-line bg-panel hover:bg-elevated'}`}
+            >
+              <div className="flex items-center justify-between">
+                <span className={`font-display text-[14px] font-semibold ${txt(a.tone)}`}>{a.name}</span>
+                {a.critical && <AlertOctagon className="h-4 w-4 text-crit" />}
+              </div>
+              <p className="mt-2 text-[11px] leading-snug text-muted">{a.desc}</p>
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-5 border-t border-line pt-4">
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-wider text-faint">Active operator sessions</div>
+          <ul className="space-y-2">
+            {operatorSessions.map((s) => (
+              <li key={s.asset} className="flex items-center gap-3 rounded-lg border border-line bg-bg/40 px-3 py-2">
+                <StatusDot tone={s.tone} pulse={s.tone === 'crit'} />
+                <span className="font-mono text-[12px] text-ink">{s.asset}</span>
+                <span className="text-[12px] text-muted">{s.mode}</span>
+                <span className="ml-auto font-mono text-[10px] text-faint">{s.operator} · since {s.since}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Panel>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <Panel title="System Configuration" subtitle="environment & runtime · secrets redacted" dense>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[520px] text-left">
+              <thead>
+                <tr className="border-b border-line font-mono text-[10px] uppercase tracking-wider text-faint">
+                  <th className="px-4 py-2 font-normal">Key</th>
+                  <th className="px-4 py-2 font-normal">Value</th>
+                  <th className="px-4 py-2 font-normal">Scope</th>
+                </tr>
+              </thead>
+              <tbody className="font-mono text-[12px]">
+                {config.map((c) => (
+                  <tr key={c.key} className="border-b border-line last:border-0 hover:bg-white/[0.02]">
+                    <td className="px-4 py-2.5 text-ink">{c.key}</td>
+                    <td className={`px-4 py-2.5 ${txt(c.tone)}`}>{c.value}</td>
+                    <td className="px-4 py-2.5">
+                      <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] uppercase text-muted">{c.scope}</span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Panel>
+
+        <Panel title="Feature Flags" subtitle="runtime capability toggles" dense>
+          <ul>
+            {flags.map((f) => (
+              <li key={f.name} className="flex items-center gap-4 border-b border-line px-4 py-3 last:border-0">
+                <Toggle on={f.enabled} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[12px] text-ink">{f.name}</div>
+                  <div className="font-mono text-[10px] text-faint">{f.note}</div>
+                </div>
+                <span className={`font-mono text-[10px] uppercase tracking-wider ${f.enabled ? 'text-safe' : 'text-faint'}`}>{f.enabled ? 'on' : 'off'}</span>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      </div>
+
+      <Panel title="Access Control" subtitle="operators & service accounts" dense>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-left">
+            <thead>
+              <tr className="border-b border-line font-mono text-[10px] uppercase tracking-wider text-faint">
+                <th className="px-4 py-2 font-normal">Member</th>
+                <th className="px-4 py-2 font-normal">Role</th>
+                <th className="px-4 py-2 font-normal">Access</th>
+                <th className="px-4 py-2 font-normal">Status</th>
+              </tr>
+            </thead>
+            <tbody className="text-[12px]">
+              {roster.map((m) => (
+                <tr key={m.name} className="border-b border-line last:border-0 hover:bg-white/[0.02]">
+                  <td className="px-4 py-2.5 text-ink">{m.name}</td>
+                  <td className="px-4 py-2.5 text-muted">{m.role}</td>
+                  <td className="px-4 py-2.5 font-mono text-[11px] text-faint">{m.access}</td>
+                  <td className="px-4 py-2.5">
+                    <span className="flex items-center gap-1.5 font-mono text-[11px]">
+                      <StatusDot tone={m.tone} />
+                      <span className={m.status === 'active' ? 'text-ink' : 'text-faint'}>{m.status}</span>
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Panel>
+    </div>
+  )
+}
+
+function Toggle({ on }: { on: boolean }) {
+  return (
+    <span className={`relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors ${on ? 'bg-safe/40' : 'bg-white/10'}`}>
+      <span className={`inline-block h-3 w-3 transform rounded-full transition-transform ${on ? 'translate-x-3.5 bg-safe' : 'translate-x-0.5 bg-muted'}`} />
+    </span>
+  )
+}
+
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }

--- a/console/lib/reports.ts
+++ b/console/lib/reports.ts
@@ -1,0 +1,61 @@
+import type { Tone } from './types'
+
+// Reports & Releases — generated evidence documents (compliance / safety /
+// incident / executive) and the staged software-rollout (OTA) campaign view.
+
+export interface Report {
+  id: string
+  title: string
+  kind: 'Compliance' | 'Safety' | 'Incident' | 'Executive'
+  period: string
+  format: 'PDF' | 'CSV' | 'JSON'
+  signed: boolean
+  ts: string
+  tone: Tone
+}
+
+export const reports: Report[] = [
+  { id: 'RPT-0912', title: 'ISO 26262 functional-safety evidence pack', kind: 'Compliance', period: 'Q2 2026', format: 'PDF', signed: true, ts: '2026-06-12 08:00', tone: 'safe' },
+  { id: 'RPT-0911', title: 'Fleet safety summary — governor verdicts', kind: 'Safety', period: 'May 2026', format: 'PDF', signed: true, ts: '2026-06-01 06:00', tone: 'safe' },
+  { id: 'RPT-0910', title: 'Incident INC-2041 root-cause report', kind: 'Incident', period: '2026-06-14', format: 'PDF', signed: true, ts: '2026-06-14 12:40', tone: 'crit' },
+  { id: 'RPT-0909', title: 'Executive operations review', kind: 'Executive', period: 'Q2 2026', format: 'PDF', signed: false, ts: '2026-06-13 17:20', tone: 'ice' },
+  { id: 'RPT-0908', title: 'Audit-chain integrity export', kind: 'Compliance', period: '30d', format: 'JSON', signed: true, ts: '2026-06-10 00:00', tone: 'safe' },
+  { id: 'RPT-0907', title: 'Verdict throughput dataset', kind: 'Safety', period: '7d', format: 'CSV', signed: false, ts: '2026-06-09 23:00', tone: 'muted' },
+]
+
+export interface Scheduled { id: string; name: string; cadence: string; next: string; tone: Tone }
+
+export const scheduled: Scheduled[] = [
+  { id: 's1', name: 'Daily safety digest', cadence: 'daily · 06:00', next: 'tomorrow 06:00', tone: 'safe' },
+  { id: 's2', name: 'Weekly compliance pack', cadence: 'weekly · Mon', next: 'Mon 08:00', tone: 'safe' },
+  { id: 's3', name: 'Monthly executive review', cadence: 'monthly · 1st', next: 'Jul 1 09:00', tone: 'ice' },
+]
+
+// ── Software Rollout / OTA (#11) ───────────────────────────────────────
+// Each ring gates on the health of the previous ring before adoption advances.
+export interface Rollout {
+  id: string
+  ring: string
+  assets: number
+  adoption: number
+  status: 'rolling' | 'paused' | 'complete' | 'staged'
+  tone: Tone
+  note: string
+}
+
+export const rolloutVersion = { version: 'v2.4.1', channel: 'stable', signed: true, started: '2026-06-10 09:12' }
+
+export const rollout: Rollout[] = [
+  { id: 'ring0', ring: 'Ring 0 · canary', assets: 2, adoption: 100, status: 'complete', tone: 'safe', note: 'soak passed · 48h' },
+  { id: 'ring1', ring: 'Ring 1 · early', assets: 12, adoption: 100, status: 'complete', tone: 'safe', note: 'no regressions' },
+  { id: 'ring2', ring: 'Ring 2 · broad', assets: 86, adoption: 74, status: 'rolling', tone: 'ice', note: 'staged · health-gated' },
+  { id: 'ring3', ring: 'Ring 3 · fleet', assets: 142, adoption: 0, status: 'staged', tone: 'muted', note: 'awaits Ring 2 health gate' },
+]
+
+export interface VersionShare { version: string; pct: number; tone: Tone }
+
+export const versionShare: VersionShare[] = [
+  { version: 'v2.4.1', pct: 71, tone: 'safe' },
+  { version: 'v2.4.0', pct: 26, tone: 'ice' },
+  { version: 'v2.3.6', pct: 3, tone: 'warn' },
+]

--- a/console/lib/settings.ts
+++ b/console/lib/settings.ts
@@ -1,0 +1,53 @@
+import type { Tone } from './types'
+
+// System & Operator Control — runtime configuration, feature flags, the
+// human-in-the-loop operator tools, and access control. Operator actions are
+// always re-adjudicated by the fail-closed Governor; nothing here bypasses it.
+
+export interface ConfigItem { key: string; value: string; scope: 'env' | 'runtime'; note: string; tone: Tone }
+
+export const config: ConfigItem[] = [
+  { key: 'KIRRA_ADMIN_TOKEN', value: '•••••••• set', scope: 'env', note: 'mutation routes · absent → 503 fail-closed', tone: 'safe' },
+  { key: 'KIRRA_SUPERVISOR_RESET_KEY', value: '•••••••• set', scope: 'env', note: 'reset ops · ≤ 64 bytes', tone: 'safe' },
+  { key: 'KIRRA_VERIFIER_MODE', value: 'active', scope: 'runtime', note: 'active / passive_standby', tone: 'safe' },
+  { key: 'KIRRA_TRUSTED_INGRESS_MODE', value: 'true', scope: 'env', note: 'client-id header enforcement', tone: 'safe' },
+  { key: 'KIRRA_VERIFIER_ADDR', value: '0.0.0.0:8090', scope: 'env', note: 'listen address', tone: 'muted' },
+  { key: 'CHALLENGE_TTL_MS', value: '30000', scope: 'runtime', note: 'nonce expiry', tone: 'muted' },
+  { key: 'POSTURE_CACHE_TTL_MS', value: '5000', scope: 'runtime', note: 'cache staleness TTL', tone: 'muted' },
+]
+
+export interface FeatureFlag { name: string; enabled: boolean; note: string }
+
+export const flags: FeatureFlag[] = [
+  { name: 'Federated trust reconciliation v2', enabled: true, note: 'generation-ordered cross-controller reports' },
+  { name: 'AV recovery hysteresis', enabled: true, note: '5 healthy reports / 10s window' },
+  { name: 'Telemetry watchdog', enabled: true, note: '2s fault threshold' },
+  { name: 'iceoryx2 transport spike', enabled: false, note: 'host-side spike — not in cert scope' },
+  { name: 'TPM measured-boot quote', enabled: false, note: 'PCR16 follow-up (tracked)' },
+]
+
+// ── Operator Tools (#12) ──────────────────────────────────────────────
+export interface OperatorAction { id: string; name: string; desc: string; tone: Tone; critical?: boolean }
+
+export const operatorActions: OperatorAction[] = [
+  { id: 'estop', name: 'Fleet E-STOP', desc: 'Command all assets to MRC controlled stop + HOLD', tone: 'crit', critical: true },
+  { id: 'hold', name: 'Hold Selected', desc: 'Pause a single asset at next safe waypoint', tone: 'warn' },
+  { id: 'teleop', name: 'Teleop Handoff', desc: 'Request supervised manual control (governor still gates envelope)', tone: 'ice' },
+  { id: 'reset', name: 'Lockout Reset', desc: 'Human reset of a LockedOut asset — requires supervisor key', tone: 'warn' },
+]
+
+export interface OperatorSession { asset: string; operator: string; mode: string; since: string; tone: Tone }
+
+export const operatorSessions: OperatorSession[] = [
+  { asset: 'KIRRA-13', operator: 'J. Looney', mode: 'Lockout review', since: '11:58', tone: 'crit' },
+  { asset: 'KIRRA-10', operator: 'A. Reyes', mode: 'Supervised teleop', since: '12:01', tone: 'ice' },
+]
+
+export interface Member { name: string; role: string; access: string; status: 'active' | 'idle'; tone: Tone }
+
+export const roster: Member[] = [
+  { name: 'J. Looney', role: 'Fleet Supervisor', access: 'admin · reset key', status: 'active', tone: 'safe' },
+  { name: 'A. Reyes', role: 'Operator', access: 'teleop · hold', status: 'active', tone: 'safe' },
+  { name: 'M. Chen', role: 'Safety Engineer', access: 'read · compliance', status: 'idle', tone: 'muted' },
+  { name: 'svc-orchestrator', role: 'Service account', access: 'mutation · token', status: 'active', tone: 'ice' },
+]


### PR DESCRIPTION
## Drop 8 — completes all twelve sidebar routes

### Reports & Releases (`/reports`)
- **Generated Reports** — compliance / safety / incident / executive documents with signed-provenance markers (shield) and download affordances.
- **Scheduled Exports** — recurring daily/weekly/monthly deliveries.
- **Software Rollout (#11)** — a staged, **health-gated OTA campaign**: canary → early → broad → fleet rings with per-ring adoption, plus a fleet-wide version-share bar (v2.4.1 / v2.4.0 / v2.3.6).

### System & Operator Control (`/settings`)
- **Operator Tools (#12)** — fleet **E-STOP**, hold, supervised **teleop handoff**, and **lockout reset**, each labeled as re-adjudicated by the Governor (nothing bypasses fail-closed); plus active operator sessions.
- **System Configuration** — `KIRRA_*` env/runtime values with secrets redacted (`KIRRA_ADMIN_TOKEN` / `KIRRA_SUPERVISOR_RESET_KEY` shown as set, never exposed).
- **Feature Flags** + **Access Control** roster (operators & service accounts).

All twelve navigation routes are now real screens — the `[...slug]` placeholder is no longer reachable from the sidebar. Mock data only; no `src/` changes.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_