### PR TITLE
feat(console): Safety Envelope Visualizer + System Topology Map

### DIFF
--- a/console/app/runtime/page.tsx
+++ b/console/app/runtime/page.tsx
@@ -1,7 +1,8 @@
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
 import { Spark } from '@/components/charts/charts'
 import { LatencyLines } from '@/components/charts/extra'
-import { resources, latency, network, partitions, nodes, ddsTopics, ddsPeers } from '@/lib/runtime'
+import { TopologyMap } from '@/components/ui/topology-map'
+import { resources, latency, network, partitions, nodes, ddsTopics, ddsPeers, topoNodes, topoEdges } from '@/lib/runtime'
 import type { Tone } from '@/lib/types'
 
 export default function RuntimePage() {
@@ -97,6 +98,17 @@ export default function RuntimePage() {
           </ul>
         </Panel>
       </div>
+
+      {/* ── System Topology Map (#10) ── */}
+      <Panel title="System Topology" subtitle="trust core · isolated guests · DDS bus · edge assets" action={<Pill tone="ice">live</Pill>}>
+        <TopologyMap nodes={topoNodes} edges={topoEdges} height={340} />
+        <div className="mt-3 flex flex-wrap items-center gap-4 border-t border-line pt-3 font-mono text-[10px] text-faint">
+          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-safe" /> trusted</span>
+          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-warn" /> degraded</span>
+          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-crit" /> locked out / link lost</span>
+          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-ice" /> transport</span>
+        </div>
+      </Panel>
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
         <Panel title="Hypervisor & Partition Isolation" subtitle="QNX safety partition · isolated guests" dense>

--- a/console/app/safety/page.tsx
+++ b/console/app/safety/page.tsx
@@ -1,6 +1,7 @@
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
 import { ScoreRing } from '@/components/charts/charts'
-import { constraints, violations, interventions, verdictMix } from '@/lib/safety'
+import { EnvelopePlot } from '@/components/ui/envelope-plot'
+import { constraints, violations, interventions, verdictMix, envPoints, envelopeBands } from '@/lib/safety'
 import type { Tone } from '@/lib/types'
 
 export default function SafetyPage() {
@@ -46,6 +47,30 @@ export default function SafetyPage() {
             <span className="font-mono text-xs text-muted">decisions</span>
           </div>
           <VerdictBar allow={verdictMix.allow} clamp={verdictMix.clamp} deny={verdictMix.deny} />
+        </Panel>
+      </div>
+
+      {/* ── Safety Envelope Visualizer (#3) ── */}
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Operating Envelope" subtitle="linear velocity × angular rate · admitted command region" action={<Pill tone="ice">phase plane</Pill>}>
+          <EnvelopePlot points={envPoints} height={320} />
+        </Panel>
+
+        <Panel title="Envelope Bands" subtitle="layered fail-closed limits">
+          <ul className="space-y-3">
+            {envelopeBands.map((b) => (
+              <li key={b.name} className="rounded-lg border border-line bg-bg/40 p-3">
+                <div className="flex items-center gap-2">
+                  <span className={`h-2.5 w-2.5 rounded-sm ${dotBg(b.tone)}`} />
+                  <span className="text-[13px] text-ink">{b.name}</span>
+                </div>
+                <p className="mt-1 pl-[18px] font-mono text-[10px] text-faint">{b.note}</p>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-4 border-t border-line pt-3 font-mono text-[10px] leading-relaxed text-muted">
+            The envelope cap always wins over rate-of-change priority. In Degraded, only non-increasing speed on the decel-to-stop trajectory is admitted; re-acceleration is never authored.
+          </div>
         </Panel>
       </div>
 

--- a/console/components/ui/envelope-plot.tsx
+++ b/console/components/ui/envelope-plot.tsx
@@ -1,0 +1,54 @@
+import type { Tone } from '@/lib/types'
+
+// Safety Envelope Visualizer — a 2D phase plot of the admitted command region.
+// X = linear velocity (−max…+max), Y = steering / angular rate (−max…+max).
+// The hard kinematic limit is the outer boundary; the Degraded decel envelope is
+// the shrunken inner region; sample commands are plotted as ALLOW/CLAMP/DENY.
+
+export interface EnvPoint { vx: number; vy: number; tone: Tone; label?: string }
+
+const dotFill: Record<string, string> = { safe: '#2fe6a6', warn: '#ffb020', crit: '#ff5468', ice: '#5cc6ff', muted: '#9aa6bd' }
+
+export function EnvelopePlot({ points, height = 300 }: { points: EnvPoint[]; height?: number }) {
+  // map a -1..1 coord to the 4..96 viewBox range
+  const mx = (v: number) => 50 + v * 46
+  const my = (v: number) => 50 - v * 46
+  return (
+    <svg viewBox="0 0 100 100" style={{ height }} className="w-full" role="img" aria-label="operating envelope">
+      <defs>
+        <pattern id="env-grid" width="10" height="10" patternUnits="userSpaceOnUse">
+          <path d="M10 0H0V10" fill="none" stroke="rgba(150,166,198,0.06)" strokeWidth="0.3" />
+        </pattern>
+      </defs>
+      <rect x="4" y="4" width="92" height="92" fill="url(#env-grid)" />
+
+      {/* hard kinematic limit */}
+      <rect x="7" y="7" width="86" height="86" rx="14" fill="rgba(92,198,255,0.04)" stroke="rgba(92,198,255,0.45)" strokeWidth="0.6" strokeDasharray="2 1.5" />
+      {/* nominal admitted region */}
+      <rect x="12" y="14" width="76" height="72" rx="12" fill="rgba(47,230,166,0.05)" stroke="rgba(47,230,166,0.4)" strokeWidth="0.6" />
+      {/* degraded decel envelope */}
+      <rect x="34" y="30" width="32" height="40" rx="8" fill="rgba(255,176,32,0.06)" stroke="rgba(255,176,32,0.5)" strokeWidth="0.6" />
+
+      {/* axes */}
+      <line x1="50" y1="7" x2="50" y2="93" stroke="rgba(150,166,198,0.18)" strokeWidth="0.4" />
+      <line x1="7" y1="50" x2="93" y2="50" stroke="rgba(150,166,198,0.18)" strokeWidth="0.4" />
+
+      {/* sample commands */}
+      {points.map((p, i) => (
+        <g key={i}>
+          <circle cx={mx(p.vx)} cy={my(p.vy)} r="2.6" fill="none" stroke={dotFill[p.tone]} strokeOpacity="0.4" strokeWidth="0.5" />
+          <circle cx={mx(p.vx)} cy={my(p.vy)} r="1.3" fill={dotFill[p.tone]} />
+          {p.label && (
+            <text x={mx(p.vx) + 3.4} y={my(p.vy) + 1} fill={dotFill[p.tone]} fontSize="2.6" fontFamily="monospace">{p.label}</text>
+          )}
+        </g>
+      ))}
+
+      {/* axis captions */}
+      <text x="94" y="48" fill="#69728a" fontSize="2.6" fontFamily="monospace" textAnchor="end">+v</text>
+      <text x="6.5" y="48" fill="#69728a" fontSize="2.6" fontFamily="monospace">−v</text>
+      <text x="51" y="10" fill="#69728a" fontSize="2.6" fontFamily="monospace">+ω</text>
+      <text x="51" y="93" fill="#69728a" fontSize="2.6" fontFamily="monospace">−ω</text>
+    </svg>
+  )
+}

--- a/console/components/ui/topology-map.tsx
+++ b/console/components/ui/topology-map.tsx
@@ -1,0 +1,32 @@
+import type { Tone } from '@/lib/types'
+
+// System Topology Map — a node-link view of the runtime: the QNX Governor
+// partition at the trust core, isolated guests, the DDS bus, and edge assets.
+
+export interface TopoNode { id: string; label: string; sub?: string; x: number; y: number; tone: Tone; core?: boolean }
+export interface TopoEdge { from: string; to: string; tone: Tone }
+
+const stroke: Record<string, string> = { safe: '#2fe6a6', warn: '#ffb020', crit: '#ff5468', ice: '#5cc6ff', muted: '#69728a' }
+
+export function TopologyMap({ nodes, edges, height = 340 }: { nodes: TopoNode[]; edges: TopoEdge[]; height?: number }) {
+  const byId = (id: string) => nodes.find((n) => n.id === id)!
+  return (
+    <svg viewBox="0 0 100 70" style={{ height }} className="w-full" role="img" aria-label="system topology">
+      {/* edges */}
+      {edges.map((e, i) => {
+        const a = byId(e.from), b = byId(e.to)
+        return <line key={i} x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke={stroke[e.tone]} strokeOpacity={e.tone === 'crit' ? 0.6 : 0.28} strokeWidth={e.tone === 'crit' ? 0.6 : 0.4} strokeDasharray={e.tone === 'crit' ? '1.5 1' : undefined} />
+      })}
+      {/* nodes */}
+      {nodes.map((n) => (
+        <g key={n.id}>
+          {n.core && <circle cx={n.x} cy={n.y} r="8.4" fill="none" stroke={stroke[n.tone]} strokeOpacity="0.25" strokeWidth="0.4" />}
+          <circle cx={n.x} cy={n.y} r={n.core ? 6 : 4.2} fill="rgba(16,20,30,0.95)" stroke={stroke[n.tone]} strokeWidth={n.core ? 0.8 : 0.5} />
+          <circle cx={n.x} cy={n.y} r="1.1" fill={stroke[n.tone]} />
+          <text x={n.x} y={n.y + (n.core ? 9.6 : 7)} fill="#e9edf6" fontSize="2.5" fontFamily="monospace" textAnchor="middle">{n.label}</text>
+          {n.sub && <text x={n.x} y={n.y + (n.core ? 12.4 : 9.6)} fill="#69728a" fontSize="2" fontFamily="monospace" textAnchor="middle">{n.sub}</text>}
+        </g>
+      ))}
+    </svg>
+  )
+}

--- a/console/lib/runtime.ts
+++ b/console/lib/runtime.ts
@@ -87,3 +87,29 @@ export const ddsPeers: DdsPeer[] = [
   { id: 'participant-tel-2', role: 'Telemetry capture', rttMs: 7, liveliness: 'ALIVE', lastSeen: 'now', tone: 'safe' },
   { id: 'participant-fed-w', role: 'Peer controller (west)', rttMs: 24, liveliness: 'ALIVE', lastSeen: 'now', tone: 'safe' },
 ]
+
+// ── System Topology Map (#10) ─────────────────────────────────────────
+// Node-link view: the QNX Governor at the trust core, isolated guests, the DDS
+// bus, and edge assets. Coords are in a 0..100 × 0..70 viewBox.
+export const topoNodes: { id: string; label: string; sub?: string; x: number; y: number; tone: Tone; core?: boolean }[] = [
+  { id: 'gov', label: 'Governor', sub: 'QNX · ASIL-D', x: 50, y: 34, tone: 'safe', core: true },
+  { id: 'plan', label: 'Autoware', sub: 'guest VM', x: 22, y: 16, tone: 'safe' },
+  { id: 'dds', label: 'DDS bus', sub: 'Volatile QoS', x: 50, y: 12, tone: 'ice' },
+  { id: 'tel', label: 'Telemetry', sub: 'capture', x: 78, y: 16, tone: 'safe' },
+  { id: 'audit', label: 'Audit ledger', sub: 'SHA-256 chain', x: 80, y: 52, tone: 'safe' },
+  { id: 'fed', label: 'Peer (west)', sub: 'federation', x: 20, y: 52, tone: 'safe' },
+  { id: 'e09', label: 'KIRRA-09', sub: 'Nominal', x: 38, y: 60, tone: 'safe' },
+  { id: 'e10', label: 'KIRRA-10', sub: 'Degraded', x: 56, y: 62, tone: 'warn' },
+  { id: 'e13', label: 'KIRRA-13', sub: 'LockedOut', x: 68, y: 36, tone: 'crit' },
+]
+export const topoEdges: { from: string; to: string; tone: Tone }[] = [
+  { from: 'gov', to: 'dds', tone: 'ice' },
+  { from: 'plan', to: 'dds', tone: 'muted' },
+  { from: 'tel', to: 'dds', tone: 'muted' },
+  { from: 'gov', to: 'plan', tone: 'safe' },
+  { from: 'gov', to: 'audit', tone: 'safe' },
+  { from: 'gov', to: 'fed', tone: 'safe' },
+  { from: 'gov', to: 'e09', tone: 'safe' },
+  { from: 'gov', to: 'e10', tone: 'warn' },
+  { from: 'gov', to: 'e13', tone: 'crit' },
+]

--- a/console/lib/safety.ts
+++ b/console/lib/safety.ts
@@ -29,3 +29,22 @@ export const interventions: Intervention[] = [
 ]
 
 export const verdictMix = { allow: 18420, clamp: 142, deny: 37 }
+
+// ── Safety Envelope Visualizer (#3) ─────────────────────────────────────
+// Sample commands plotted on the linear-velocity (vx) × angular-rate (vy) phase
+// plane, normalized to −1…1. The Governor admits a command only inside the
+// active envelope; these illustrate ALLOW / CLAMP / DENY outcomes.
+export const envPoints: { vx: number; vy: number; tone: Tone; label?: string }[] = [
+  { vx: 0.18, vy: 0.10, tone: 'safe', label: 'ALLOW 1.2' },
+  { vx: 0.55, vy: -0.22, tone: 'safe', label: 'ALLOW 3.2' },
+  { vx: 0.86, vy: 0.30, tone: 'warn', label: 'CLAMP' },
+  { vx: 1.06, vy: 0.12, tone: 'crit', label: 'DENY 999' },
+  { vx: -0.30, vy: 0.42, tone: 'warn', label: 'CLAMP ω' },
+]
+
+export interface EnvelopeBand { name: string; tone: Tone; note: string }
+export const envelopeBands: EnvelopeBand[] = [
+  { name: 'Hard kinematic limit', tone: 'ice', note: 'certified envelope · cap always wins' },
+  { name: 'Nominal admitted region', tone: 'safe', note: 'all valid kinematics allowed' },
+  { name: 'Degraded decel envelope', tone: 'warn', note: 'non-increasing speed · decel-to-stop' },
+]


### PR DESCRIPTION
## Drop 9 — two reusable SVG visualizations

### Safety Envelope Visualizer (#3) — `/safety`
**Operating Envelope** phase plot: linear velocity (x) × angular rate (y), normalized to the admitted command region. Three layered fail-closed bands — **hard kinematic limit** (outer, ice/dashed), **nominal admitted region** (safe), **Degraded decel envelope** (warn, inner) — with sample **ALLOW / CLAMP / DENY** commands plotted as points (incl. the `999 m/s` breach landing outside the hard limit). Side panel explains "envelope cap always wins" and the decel-to-stop / no-re-acceleration rule.

### System Topology Map (#10) — `/runtime`
Node-link map of the runtime: the **QNX Governor** at the trust core, isolated Autoware guest, **DDS bus**, telemetry capture, audit ledger, federation peer, and edge assets — color-coded by posture/link health. KIRRA-13's link renders critical (lost), KIRRA-10 degraded.

New presentational components (`envelope-plot.tsx`, `topology-map.tsx`); data added to `lib/safety` and `lib/runtime`. Both sections are additive. No `src/` changes.

**Roadmap status:** 12 of 15 enterprise items shipped — remaining are Global Ops Map (#1) and Environmental Awareness (#14).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_