### PR TITLE
feat(console): Global Ops Map + Environmental Awareness

### DIFF
--- a/console/app/fleet/page.tsx
+++ b/console/app/fleet/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
-import { twins } from '@/lib/fleet'
+import { WorldMap } from '@/components/ui/world-map'
+import { twins, sites, siteRows } from '@/lib/fleet'
 import { postureTone } from '@/lib/mock'
 import type { Tone } from '@/lib/types'
 
@@ -21,6 +22,30 @@ export default function FleetPage() {
           {degraded > 0 && <Pill tone="warn">{degraded} degraded</Pill>}
           {locked > 0 && <Pill tone="crit">{locked} locked out</Pill>}
         </div>
+      </div>
+
+      {/* ── Global Ops Map (#1) ── */}
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Global Operations" subtitle={`${siteRows.length} sites · ${siteRows.reduce((a, s) => a + s.assets, 0)} assets worldwide`} action={<Pill tone="ice">all regions</Pill>}>
+          <WorldMap sites={sites} height={300} />
+        </Panel>
+        <Panel title="Sites" subtitle="aggregate posture by region" dense>
+          <ul>
+            {siteRows.map((s) => (
+              <li key={s.id} className="flex items-center gap-3 border-b border-line px-4 py-3 last:border-0">
+                <StatusDot tone={s.tone} pulse={s.tone !== 'safe'} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] text-ink">{s.name}</div>
+                  <div className="font-mono text-[10px] text-faint">{s.region}</div>
+                </div>
+                <div className="text-right font-mono text-[11px]">
+                  <div className="text-ink">{s.assets}</div>
+                  <div className={s.degraded > 0 ? 'text-warn' : 'text-faint'}>{s.degraded > 0 ? `${s.degraded} degraded` : 'all nominal'}</div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Panel>
       </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">

--- a/console/app/telemetry/page.tsx
+++ b/console/app/telemetry/page.tsx
@@ -2,7 +2,9 @@ import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
 import { TrendArea } from '@/components/charts/charts'
 import { DualLine } from '@/components/charts/extra2'
 import { PositionMap } from '@/components/ui/position-map'
-import { velocity, battery, actuator, sensors, actuatorLog, path, ego } from '@/lib/telemetry'
+import { OccupancyView } from '@/components/ui/occupancy-view'
+import { velocity, battery, actuator, sensors, actuatorLog, path, ego, actors, awareness } from '@/lib/telemetry'
+import type { Tone } from '@/lib/types'
 
 export default function TelemetryPage() {
   return (
@@ -23,6 +25,26 @@ export default function TelemetryPage() {
         <Quick label="Heading" value="041" unit="°" />
         <Quick label="Battery" value="73" unit="%" />
         <Quick label="Link RSSI" value="−61" unit="dBm" />
+      </div>
+
+      {/* ── Environmental Awareness (#14) ── */}
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Environmental Awareness" subtitle="ego-centric occupancy · sensor fusion · detected actors" action={<Pill tone="ice">perception</Pill>}>
+          <OccupancyView actors={actors} height={340} />
+        </Panel>
+        <Panel title="Perception Summary" subtitle="situational state">
+          <div className="space-y-3">
+            {awareness.map((a) => (
+              <div key={a.label} className="flex items-center justify-between rounded-lg border border-line bg-bg/40 px-3 py-2.5">
+                <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{a.label}</span>
+                <span className={`font-mono text-[13px] ${txt(a.tone)}`}>{a.value}</span>
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 border-t border-line pt-3 font-mono text-[10px] leading-relaxed text-muted">
+            360° LiDAR + front radar + camera fans fuse into the occupancy grid. The Governor gates any command that would breach the human-proximity or hazard keep-out envelope.
+          </div>
+        </Panel>
       </div>
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
@@ -86,3 +108,5 @@ function Quick({ label, value, unit }: { label: string; value: string; unit: str
     </div>
   )
 }
+
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }

--- a/console/components/ui/occupancy-view.tsx
+++ b/console/components/ui/occupancy-view.tsx
@@ -1,0 +1,66 @@
+import type { Tone } from '@/lib/types'
+
+// Environmental Awareness — an ego-centric occupancy view. The asset sits at the
+// bottom-center facing up; sensor coverage (360° LiDAR, front radar cone, camera
+// fans) is drawn, with detected actors and a hazard keep-out zone overlaid.
+
+export interface Actor { x: number; y: number; kind: 'person' | 'vehicle' | 'static'; tone: Tone; label?: string }
+
+const fill: Record<string, string> = { safe: '#2fe6a6', warn: '#ffb020', crit: '#ff5468', ice: '#5cc6ff', muted: '#9aa6bd' }
+
+export function OccupancyView({ actors, height = 320 }: { actors: Actor[]; height?: number }) {
+  const ex = 50, ey = 84 // ego position
+  return (
+    <svg viewBox="0 0 100 100" style={{ height }} className="w-full" role="img" aria-label="environmental awareness">
+      <defs>
+        <radialGradient id="occ-lidar" cx="50%" cy="84%" r="60%">
+          <stop offset="0%" stopColor="rgba(92,198,255,0.10)" />
+          <stop offset="100%" stopColor="rgba(92,198,255,0)" />
+        </radialGradient>
+        <pattern id="occ-grid" width="10" height="10" patternUnits="userSpaceOnUse">
+          <path d="M10 0H0V10" fill="none" stroke="rgba(150,166,198,0.05)" strokeWidth="0.3" />
+        </pattern>
+      </defs>
+      <rect width="100" height="100" fill="url(#occ-grid)" />
+
+      {/* 360 LiDAR coverage */}
+      <circle cx={ex} cy={ey} r="60" fill="url(#occ-lidar)" />
+      {[20, 38, 56].map((r) => (
+        <circle key={r} cx={ex} cy={ey} r={r} fill="none" stroke="rgba(92,198,255,0.14)" strokeWidth="0.3" strokeDasharray="1 2" />
+      ))}
+
+      {/* front radar cone */}
+      <path d={`M${ex},${ey} L${ex - 22},${ey - 70} A74,74 0 0,1 ${ex + 22},${ey - 70} Z`} fill="rgba(47,230,166,0.05)" stroke="rgba(47,230,166,0.22)" strokeWidth="0.3" />
+      {/* camera fans */}
+      <path d={`M${ex},${ey} L${ex - 30},${ey - 30} A42,42 0 0,1 ${ex - 6},${ey - 42} Z`} fill="rgba(154,166,189,0.04)" stroke="rgba(154,166,189,0.12)" strokeWidth="0.25" />
+      <path d={`M${ex},${ey} L${ex + 6},${ey - 42} A42,42 0 0,1 ${ex + 30},${ey - 30} Z`} fill="rgba(154,166,189,0.04)" stroke="rgba(154,166,189,0.12)" strokeWidth="0.25" />
+
+      {/* drivable corridor */}
+      <path d={`M${ex - 9},${ey} L${ex - 6},20 L${ex + 6},20 L${ex + 9},${ey} Z`} fill="rgba(47,230,166,0.04)" stroke="rgba(47,230,166,0.2)" strokeWidth="0.3" strokeDasharray="2 1.5" />
+
+      {/* hazard keep-out zone */}
+      <rect x="62" y="30" width="22" height="20" rx="2" fill="rgba(255,84,104,0.07)" stroke="rgba(255,84,104,0.4)" strokeWidth="0.4" strokeDasharray="1.5 1" />
+      <text x="73" y="41" fill="#ff5468" fontSize="2.6" fontFamily="monospace" textAnchor="middle">HAZARD</text>
+
+      {/* detected actors */}
+      {actors.map((a, i) => (
+        <g key={i}>
+          <circle cx={a.x} cy={a.y} r="2.8" fill="none" stroke={fill[a.tone]} strokeOpacity="0.35" strokeWidth="0.4" />
+          {a.kind === 'vehicle' ? (
+            <rect x={a.x - 1.6} y={a.y - 1.6} width="3.2" height="3.2" rx="0.5" fill={fill[a.tone]} />
+          ) : (
+            <circle cx={a.x} cy={a.y} r="1.4" fill={fill[a.tone]} />
+          )}
+          {a.label && <text x={a.x + 3.4} y={a.y + 1} fill={fill[a.tone]} fontSize="2.4" fontFamily="monospace">{a.label}</text>}
+        </g>
+      ))}
+
+      {/* ego asset */}
+      <g>
+        <polygon points={`${ex},${ey - 4} ${ex - 3},${ey + 3} ${ex + 3},${ey + 3}`} fill="#5cc6ff" />
+        <circle cx={ex} cy={ey} r="5.5" fill="none" stroke="#5cc6ff" strokeOpacity="0.5" strokeWidth="0.4" />
+        <text x={ex} y={ey + 9} fill="#9aa6bd" fontSize="2.4" fontFamily="monospace" textAnchor="middle">ego · KIRRA-09</text>
+      </g>
+    </svg>
+  )
+}

--- a/console/components/ui/world-map.tsx
+++ b/console/components/ui/world-map.tsx
@@ -1,0 +1,51 @@
+import type { Tone } from '@/lib/types'
+
+// Global Ops Map — a stylized world view of fleet sites. Not a precise geographic
+// projection; an abstract graticule with site markers and arcs back to the
+// control hub, color-coded by site posture.
+
+export interface Site { id: string; name: string; region: string; x: number; y: number; assets: number; tone: Tone; hub?: boolean }
+
+const stroke: Record<string, string> = { safe: '#2fe6a6', warn: '#ffb020', crit: '#ff5468', ice: '#5cc6ff', muted: '#69728a' }
+
+export function WorldMap({ sites, height = 300 }: { sites: Site[]; height?: number }) {
+  const hub = sites.find((s) => s.hub) ?? sites[0]
+  // rough continent silhouettes (abstract — suggestion, not cartography)
+  const land = [
+    'M8,18 Q14,12 22,15 Q28,17 26,24 Q20,30 13,27 Q6,24 8,18 Z',
+    'M30,26 Q33,20 38,22 Q40,30 36,38 Q32,42 30,36 Q28,30 30,26 Z',
+    'M44,14 Q54,9 64,13 Q70,16 66,22 Q56,26 48,22 Q43,19 44,14 Z',
+    'M70,24 Q78,20 86,23 Q92,27 88,33 Q80,36 73,32 Q68,28 70,24 Z',
+  ]
+  return (
+    <svg viewBox="0 0 100 50" style={{ height }} className="w-full" role="img" aria-label="global operations map">
+      <defs>
+        <pattern id="wm-grat" width="8.33" height="8.33" patternUnits="userSpaceOnUse">
+          <path d="M8.33 0H0V8.33" fill="none" stroke="rgba(92,198,255,0.07)" strokeWidth="0.25" />
+        </pattern>
+      </defs>
+      <rect x="2" y="2" width="96" height="46" rx="3" fill="url(#wm-grat)" stroke="rgba(150,166,198,0.12)" strokeWidth="0.3" />
+
+      {land.map((d, i) => (
+        <path key={i} d={d} fill="rgba(154,166,189,0.07)" stroke="rgba(154,166,189,0.18)" strokeWidth="0.3" />
+      ))}
+
+      {/* arcs back to the control hub */}
+      {sites.filter((s) => !s.hub).map((s) => {
+        const midX = (s.x + hub.x) / 2
+        const midY = Math.min(s.y, hub.y) - 8
+        return <path key={`arc-${s.id}`} d={`M${s.x},${s.y} Q${midX},${midY} ${hub.x},${hub.y}`} fill="none" stroke={stroke[s.tone]} strokeOpacity="0.3" strokeWidth="0.35" strokeDasharray="1.5 1.5" />
+      })}
+
+      {/* site markers */}
+      {sites.map((s) => (
+        <g key={s.id}>
+          <circle cx={s.x} cy={s.y} r={s.hub ? 2.4 : 1.8} fill="none" stroke={stroke[s.tone]} strokeOpacity="0.35" strokeWidth="0.4" />
+          <circle cx={s.x} cy={s.y} r={s.hub ? 1.2 : 0.9} fill={stroke[s.tone]} />
+          <text x={s.x} y={s.y - 3} fill="#e9edf6" fontSize="2.4" fontFamily="monospace" textAnchor="middle">{s.name}</text>
+          <text x={s.x} y={s.y + 4.4} fill="#69728a" fontSize="2" fontFamily="monospace" textAnchor="middle">{s.assets} assets</text>
+        </g>
+      ))}
+    </svg>
+  )
+}

--- a/console/lib/fleet.ts
+++ b/console/lib/fleet.ts
@@ -162,3 +162,24 @@ export const twins: Twin[] = roster.map((r, i) => {
 export function twinById(id: string): Twin | undefined {
   return twins.find((t) => t.id === id)
 }
+
+// ── Global Ops Map (#1) ───────────────────────────────────────────────
+// Fleet sites worldwide, color-coded by aggregate site posture. `hub` is the
+// control center all sites arc back to. Coords are in a 0..100 × 0..50 viewBox.
+export const sites: { id: string; name: string; region: string; x: number; y: number; assets: number; tone: Tone; hub?: boolean }[] = [
+  { id: 'sf', name: 'San Francisco', region: 'US-West · HQ', x: 16, y: 22, assets: 142, tone: 'warn', hub: true },
+  { id: 'aus', name: 'Austin', region: 'US-Central', x: 26, y: 28, assets: 88, tone: 'safe' },
+  { id: 'rot', name: 'Rotterdam', region: 'EU-West', x: 50, y: 17, assets: 64, tone: 'safe' },
+  { id: 'sin', name: 'Singapore', region: 'APAC', x: 76, y: 34, assets: 51, tone: 'safe' },
+  { id: 'tok', name: 'Tokyo', region: 'APAC-North', x: 86, y: 22, assets: 37, tone: 'safe' },
+]
+
+export interface SiteRow { id: string; name: string; region: string; assets: number; degraded: number; tone: Tone }
+
+export const siteRows: SiteRow[] = [
+  { id: 'sf', name: 'San Francisco', region: 'US-West · HQ', assets: 142, degraded: 2, tone: 'warn' },
+  { id: 'aus', name: 'Austin', region: 'US-Central', assets: 88, degraded: 0, tone: 'safe' },
+  { id: 'rot', name: 'Rotterdam', region: 'EU-West', assets: 64, degraded: 0, tone: 'safe' },
+  { id: 'sin', name: 'Singapore', region: 'APAC', assets: 51, degraded: 0, tone: 'safe' },
+  { id: 'tok', name: 'Tokyo', region: 'APAC-North', assets: 37, degraded: 0, tone: 'safe' },
+]

--- a/console/lib/telemetry.ts
+++ b/console/lib/telemetry.ts
@@ -48,3 +48,22 @@ export const path: PosPoint[] = Array.from({ length: 40 }).map((_, i) => {
   return { x: 8 + t * 84, y: 50 + Math.sin(t * Math.PI * 3) * 28 + (Math.random() - 0.5) * 2 }
 })
 export const ego: PosPoint = path[25]
+
+// ── Environmental Awareness (#14) ──────────────────────────────────────
+// Detected actors in the ego frame for the occupancy view. Coords are in the
+// 0..100 occupancy viewBox; the ego sits at (50, 84) facing up.
+export const actors: { x: number; y: number; kind: 'person' | 'vehicle' | 'static'; tone: Tone; label?: string }[] = [
+  { x: 44, y: 50, kind: 'person', tone: 'warn', label: 'pedestrian · 9 m' },
+  { x: 58, y: 60, kind: 'vehicle', tone: 'ice', label: 'AMR · 6 m' },
+  { x: 36, y: 38, kind: 'static', tone: 'muted', label: 'pallet' },
+  { x: 70, y: 44, kind: 'static', tone: 'crit', label: 'keep-out' },
+  { x: 52, y: 30, kind: 'person', tone: 'safe', label: 'worker · 18 m' },
+]
+
+export interface AwarenessStat { label: string; value: string; tone: Tone }
+export const awareness: AwarenessStat[] = [
+  { label: 'Tracked actors', value: '5', tone: 'ice' },
+  { label: 'Nearest pedestrian', value: '9.0 m', tone: 'warn' },
+  { label: 'Drivable corridor', value: 'clear', tone: 'safe' },
+  { label: 'Hazard zones', value: '1 active', tone: 'crit' },
+]


### PR DESCRIPTION
## Drop 10 — the final two roadmap items

### Global Ops Map (#1) — `/fleet`
**Global Operations** — a stylized world map of fleet sites (San Francisco HQ, Austin, Rotterdam, Singapore, Tokyo) with great-circle-style arcs back to the control hub, site markers color-coded by aggregate posture, plus a per-site roster (assets / degraded count).

### Environmental Awareness (#14) — `/telemetry`
**Environmental Awareness** — an ego-centric occupancy view fusing **360° LiDAR**, a **front radar cone**, and **camera fans**, with detected actors (pedestrians, AMRs, static obstacles), a drivable corridor, and a **hazard keep-out zone**; paired with a perception summary (tracked actors, nearest pedestrian, corridor state, active hazards) and a note that the Governor gates any command breaching the human-proximity / keep-out envelope.

New presentational components (`world-map.tsx`, `occupancy-view.tsx`); data added to `lib/fleet` and `lib/telemetry`. Additive. No `src/` changes.

**🎯 This completes the full 15-item enterprise roadmap.**

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_