### PR TITLE
chore(console): re-enable type checking & lint in build

### DIFF
--- a/console/next.config.mjs
+++ b/console/next.config.mjs
@@ -1,9 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  // Temporary: unblock Vercel preview deploys while we finish tightening types.
-  // TODO: remove both once `next build` is fully clean.
-  eslint: { ignoreDuringBuilds: true },
-  typescript: { ignoreBuildErrors: true },
 };
 export default nextConfig;


### PR DESCRIPTION
## Re-enable build-time type checking & lint

Removes the two temporary escape hatches in `console/next.config.mjs` (`typescript.ignoreBuildErrors` and `eslint.ignoreDuringBuilds`) that were added to unblock the first Vercel preview deploys.

### Verified locally with a full production build
Pulled the complete console from `main`, `npm install`, then `next build` with the hatches removed:

```
✓ Compiled successfully in 12.0s
  Linting and checking validity of types ...
✓ Generating static pages (24/24)
```

Zero type errors, zero lint errors. All 24 routes prerender — including the 8 `/fleet/[id]` digital-twin pages via `generateStaticParams`. The codebase was already type-clean; only the config flags needed removing.

No `src/` changes. The Rust safety core is untouched.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_