### PR TITLE
fix(console): pin next to 15.5.19 (patched RSC CVE) — verified-commit supersede of #367

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "^15.1.6",
+    "next": "15.5.19",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "framer-motion": "^11.11.0",


### PR DESCRIPTION
## Supersedes #367 with a verified commit

The vercel[bot] PR **#367** (React Server Components CVE) is correct in intent but **blocked by branch protection: "Commits must have verified signatures."** Bot commits are unsigned, so it can't merge. This PR makes the equivalent fix via a GitHub-API commit, which is signature-verified, so it merges cleanly.

### Why this differs from #367 (and is better)
- `main`'s `console/package.json` carried a floating `"next": "^15.1.6"` with **no committed lockfile**, so Vercel already resolves the latest 15.x at build time — **15.5.19**, which is patched.
- #367 would have pinned to **15.1.11**, which is *older* than what's deploying now — a downgrade.
- This pins to an exact **`15.5.19`** (the latest patched 15.x): keeps the patched version, makes the build deterministic without needing a lockfile, and never downgrades.

### Verified locally
`next build` on the exact pin:
```
▲ Next.js 15.5.19
✓ Compiled successfully
  Linting and checking validity of types ...
✓ Generating static pages
```

One-line dependency change. No `src/` changes. Closes out the #367 security advisory.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_