### PR TITLE
fix(console): mobile navigation drawer + hamburger

### DIFF
--- a/console/components/shell/mobile-nav.tsx
+++ b/console/components/shell/mobile-nav.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Menu, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { navGroups } from './nav-items'
+
+// Mobile navigation: a hamburger button + slide-in drawer, shown only below the
+// `lg` breakpoint (where the desktop sidebar is hidden). Closes on navigation,
+// on backdrop tap, and on Escape.
+export function MobileNav() {
+  const [open, setOpen] = useState(false)
+  const path = usePathname()
+
+  useEffect(() => { setOpen(false) }, [path])
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    document.addEventListener('keydown', onKey)
+    document.body.style.overflow = 'hidden'
+    return () => { document.removeEventListener('keydown', onKey); document.body.style.overflow = '' }
+  }, [open])
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        aria-label="Open navigation menu"
+        className="rounded-lg border border-line bg-panel p-2 text-muted hover:text-ink lg:hidden"
+      >
+        <Menu className="h-4 w-4" />
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 lg:hidden" role="dialog" aria-modal="true" aria-label="Navigation">
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setOpen(false)} />
+          <aside className="absolute left-0 top-0 flex h-full w-[270px] max-w-[82%] flex-col border-r border-line bg-surface shadow-panel">
+            <div className="flex h-14 shrink-0 items-center justify-between border-b border-line px-4">
+              <div className="leading-none">
+                <div className="font-display text-[15px] font-semibold tracking-[3px] text-ink">KIRRA</div>
+                <div className="font-mono text-[9px] uppercase tracking-[2px] text-faint">Mission Console</div>
+              </div>
+              <button onClick={() => setOpen(false)} aria-label="Close navigation menu" className="rounded-lg border border-line bg-panel p-2 text-muted hover:text-ink">
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <nav className="scrollbar-thin flex-1 overflow-y-auto px-3 py-4">
+              {navGroups.map((g) => (
+                <div key={g.label} className="mb-5">
+                  <p className="px-3 pb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-faint">{g.label}</p>
+                  <ul className="space-y-0.5">
+                    {g.items.map((it) => {
+                      const active = path === it.href
+                      const Icon = it.icon
+                      return (
+                        <li key={it.href}>
+                          <Link
+                            href={it.href}
+                            onClick={() => setOpen(false)}
+                            className={cn('group flex items-center gap-3 rounded-lg px-3 py-2.5 text-[13px] transition-colors', active ? 'bg-white/[0.06] text-ink' : 'text-muted hover:bg-white/[0.03] hover:text-ink')}
+                          >
+                            <Icon className={cn('h-4 w-4', active ? 'text-safe' : 'text-faint group-hover:text-muted')} strokeWidth={1.75} />
+                            <span>{it.label}</span>
+                            {active && <span className="ml-auto h-1.5 w-1.5 rounded-full bg-safe" />}
+                          </Link>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </div>
+              ))}
+            </nav>
+
+            <div className="border-t border-line p-3">
+              <div className="flex items-center gap-2">
+                <span className="h-2 w-2 rounded-full bg-safe" />
+                <span className="font-mono text-[11px] text-muted">All systems nominal</span>
+              </div>
+            </div>
+          </aside>
+        </div>
+      )}
+    </>
+  )
+}

--- a/console/components/shell/nav-items.ts
+++ b/console/components/shell/nav-items.ts
@@ -1,0 +1,38 @@
+import { LayoutDashboard, Boxes, ShieldCheck, Activity, Radio, Route, Brain, Bell, AlertTriangle, FileCheck2, BarChart3, Database, FileText, Settings } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+export interface NavItem { href: string; label: string; icon: LucideIcon }
+export interface NavGroup { label: string; items: NavItem[] }
+
+// Shared navigation model used by both the desktop sidebar and the mobile drawer.
+export const navGroups: NavGroup[] = [
+  {
+    label: 'Operations',
+    items: [
+      { href: '/', label: 'Overview', icon: LayoutDashboard },
+      { href: '/fleet', label: 'Fleet Operations', icon: Boxes },
+      { href: '/safety', label: 'Safety Governor', icon: ShieldCheck },
+      { href: '/runtime', label: 'Runtime Health', icon: Activity },
+      { href: '/telemetry', label: 'Telemetry', icon: Radio },
+      { href: '/missions', label: 'Mission Timeline', icon: Route },
+    ],
+  },
+  {
+    label: 'Governance',
+    items: [
+      { href: '/oversight', label: 'AI Oversight', icon: Brain },
+      { href: '/events', label: 'Events', icon: Bell },
+      { href: '/incidents', label: 'Incident Review', icon: AlertTriangle },
+      { href: '/compliance', label: 'Compliance', icon: FileCheck2 },
+    ],
+  },
+  {
+    label: 'Insight',
+    items: [
+      { href: '/analytics', label: 'Analytics', icon: BarChart3 },
+      { href: '/explorer', label: 'Telemetry Explorer', icon: Database },
+      { href: '/reports', label: 'Reports', icon: FileText },
+      { href: '/settings', label: 'Settings', icon: Settings },
+    ],
+  },
+]

--- a/console/components/shell/sidebar.tsx
+++ b/console/components/shell/sidebar.tsx
@@ -3,46 +3,14 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
-import { LayoutDashboard, Boxes, ShieldCheck, Activity, Radio, Route, Brain, Bell, AlertTriangle, FileCheck2, BarChart3, Database, FileText, Settings } from 'lucide-react'
-
-const groups = [
-  {
-    label: 'Operations',
-    items: [
-      { href: '/', label: 'Overview', icon: LayoutDashboard },
-      { href: '/fleet', label: 'Fleet Operations', icon: Boxes },
-      { href: '/safety', label: 'Safety Governor', icon: ShieldCheck },
-      { href: '/runtime', label: 'Runtime Health', icon: Activity },
-      { href: '/telemetry', label: 'Telemetry', icon: Radio },
-      { href: '/missions', label: 'Mission Timeline', icon: Route },
-    ],
-  },
-  {
-    label: 'Governance',
-    items: [
-      { href: '/oversight', label: 'AI Oversight', icon: Brain },
-      { href: '/events', label: 'Events', icon: Bell },
-      { href: '/incidents', label: 'Incident Review', icon: AlertTriangle },
-      { href: '/compliance', label: 'Compliance', icon: FileCheck2 },
-    ],
-  },
-  {
-    label: 'Insight',
-    items: [
-      { href: '/analytics', label: 'Analytics', icon: BarChart3 },
-      { href: '/explorer', label: 'Telemetry Explorer', icon: Database },
-      { href: '/reports', label: 'Reports', icon: FileText },
-      { href: '/settings', label: 'Settings', icon: Settings },
-    ],
-  },
-]
+import { navGroups } from './nav-items'
 
 export function Sidebar() {
   const path = usePathname()
   return (
     <aside className="hidden h-full w-[244px] shrink-0 flex-col border-r border-line bg-surface lg:flex">
       <nav className="scrollbar-thin flex-1 overflow-y-auto px-3 py-4">
-        {groups.map((g) => (
+        {navGroups.map((g) => (
           <div key={g.label} className="mb-5">
             <p className="px-3 pb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-faint">{g.label}</p>
             <ul className="space-y-0.5">

--- a/console/components/shell/top-nav.tsx
+++ b/console/components/shell/top-nav.tsx
@@ -2,6 +2,7 @@
 
 import { Search, Bell, ChevronDown } from 'lucide-react'
 import { Pill } from '@/components/ui/primitives'
+import { MobileNav } from '@/components/shell/mobile-nav'
 
 function KMark() {
   return (
@@ -25,6 +26,7 @@ function KMark() {
 export function TopNav() {
   return (
     <header className="sticky top-0 z-30 flex h-14 items-center gap-3 border-b border-line bg-bg/70 px-4 backdrop-blur-xl">
+      <MobileNav />
       <div className="flex items-center gap-2.5">
         <KMark />
         <div className="leading-none">


### PR DESCRIPTION
## Mobile users couldn't navigate

The sidebar is `hidden lg:flex`, so below the `lg` breakpoint it's gone — and there was **no hamburger to open it**, leaving mobile users stranded on Overview (per the reported screenshot). The desktop dashboard was fine.

## Fix
- **Hamburger** in the top nav (`lg:hidden`) opens a **slide-in drawer** with the full navigation.
- **MobileNav** drawer: backdrop tap, Escape, or selecting a route closes it; body scroll locks while open; accessible (`role="dialog"`, `aria-modal`, labelled buttons).
- Extracted the nav model to a shared **`nav-items.ts`** so the desktop `Sidebar` and the mobile drawer stay in sync (single source of truth) — no more duplicated route lists.
- Desktop is **visually unchanged**: sidebar still `lg:flex`, hamburger is `lg:hidden`.

## Verified
`next build` clean — compiles, lint + type validation pass, **25/25** routes prerender (Next 15.5.19).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_