### PR TITLE
feat(console): Global Operations — strategic multi-site mission control (#1)

### DIFF
--- a/console/app/global/page.tsx
+++ b/console/app/global/page.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useState } from 'react'
+import { CloudRain, Network, Flame } from 'lucide-react'
+import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { GlobalMap } from '@/components/ui/global-map'
+import { sites, weatherZones, geofences, crossSiteAlerts, regionRisk, totals } from '@/lib/global'
+import type { Tone } from '@/lib/types'
+
+export default function GlobalPage() {
+  const [heatmap, setHeatmap] = useState(true)
+  const [risk, setRisk] = useState(true)
+  const [network, setNetwork] = useState(false)
+
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-ink">Global Operations</h1>
+          <p className="font-mono text-[11px] text-faint">strategic view · {totals.sites} sites · {totals.assets} assets · {totals.active} active</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Pill tone="warn">2 regions elevated</Pill>
+          <Pill tone="safe">federation in sync</Pill>
+        </div>
+      </div>
+
+      {/* top-line metrics */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <Metric label="Sites online" value={`${totals.sites}`} sub="all regions" tone="safe" />
+        <Metric label="Active assets" value={`${totals.active}`} sub={`of ${totals.assets}`} tone="ice" />
+        <Metric label="Interventions · 24h" value={`${totals.interventions}`} sub="fleet-wide" tone="warn" />
+        <Metric label="Regions at risk" value="2" sub="US-West · APAC" tone="warn" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel
+          className="xl:col-span-2"
+          title="Global Operations Map"
+          subtitle="fleet distribution · overlays"
+          action={
+            <div className="flex items-center gap-1.5">
+              <Toggle on={heatmap} tone="warn" onClick={() => setHeatmap((v) => !v)}><Flame className="h-3 w-3" /> Heatmap</Toggle>
+              <Toggle on={risk} tone="ice" onClick={() => setRisk((v) => !v)}><CloudRain className="h-3 w-3" /> Risk</Toggle>
+              <Toggle on={network} tone="safe" onClick={() => setNetwork((v) => !v)}><Network className="h-3 w-3" /> Network</Toggle>
+            </div>
+          }
+        >
+          <GlobalMap sites={sites} weather={weatherZones} geofences={geofences} showHeatmap={heatmap} showRisk={risk} showNetwork={network} height={380} />
+          <div className="mt-3 flex flex-wrap items-center gap-4 border-t border-line pt-3 font-mono text-[10px] text-faint">
+            <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-safe" /> low risk</span>
+            <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-warn" /> elevated</span>
+            <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-ice/70" /> weather system</span>
+            <span className="ml-auto">marker size ∝ fleet size · heatmap ∝ interventions</span>
+          </div>
+        </Panel>
+
+        <Panel title="Cross-Site Alerts" subtitle="regional · last hour" dense>
+          <ul>
+            {crossSiteAlerts.map((a) => (
+              <li key={a.id} className="flex items-start gap-3 border-b border-line px-4 py-3 last:border-0">
+                <StatusDot tone={a.tone} pulse={a.tone === 'warn'} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 font-mono text-[10px] text-faint">
+                    <span>{a.ts}</span><span className={txt(a.tone)}>{a.region}</span>
+                  </div>
+                  <p className="mt-0.5 text-[12px] text-muted">{a.message}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Regional Risk" subtitle="weather · network · geofence" dense>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[560px] text-left">
+              <thead>
+                <tr className="border-b border-line font-mono text-[10px] uppercase tracking-wider text-faint">
+                  <th className="px-4 py-2 font-normal">Region</th>
+                  <th className="px-4 py-2 font-normal">Weather</th>
+                  <th className="px-4 py-2 font-normal">Network</th>
+                  <th className="px-4 py-2 font-normal">Geofence</th>
+                  <th className="px-4 py-2 font-normal">Note</th>
+                </tr>
+              </thead>
+              <tbody className="font-mono text-[12px]">
+                {regionRisk.map((r) => (
+                  <tr key={r.region} className="border-b border-line last:border-0 hover:bg-white/[0.02]">
+                    <td className="px-4 py-2.5 text-ink">{r.region}</td>
+                    <td className="px-4 py-2.5"><Dot tone={r.weather} /></td>
+                    <td className="px-4 py-2.5"><Dot tone={r.network} /></td>
+                    <td className="px-4 py-2.5"><Dot tone={r.geofence} /></td>
+                    <td className="px-4 py-2.5 text-muted">{r.note}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Panel>
+
+        <Panel title="Fleet Distribution" subtitle="assets by site" dense>
+          <ul className="px-4 py-2">
+            {sites.map((s) => (
+              <li key={s.id} className="border-b border-line py-3 last:border-0">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="flex items-center gap-2 text-[12px] text-ink"><StatusDot tone={s.tone} />{s.name}</span>
+                  <span className="font-mono text-[11px] text-muted">{s.assets}</span>
+                </div>
+                <div className="mt-2"><Meter value={(s.assets / totals.assets) * 100} tone={s.tone} /></div>
+                <div className="mt-1 font-mono text-[10px] text-faint">{s.weather} · net {s.network} · {s.interventions} interventions/24h</div>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, value, sub, tone }: { label: string; value: string; sub: string; tone: Tone }) {
+  return (
+    <div className="rounded-xl border border-line bg-panel p-4 shadow-panel">
+      <div className="font-mono text-[11px] uppercase tracking-wider text-faint">{label}</div>
+      <div className={`mt-1.5 font-display text-[26px] font-semibold leading-none ${txt(tone)}`}>{value}</div>
+      <div className="mt-1 font-mono text-[10px] text-faint">{sub}</div>
+    </div>
+  )
+}
+
+function Toggle({ children, on, tone, onClick }: { children: React.ReactNode; on: boolean; tone: Tone; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider transition-colors ${on ? `${ring(tone)} ${txt(tone)} bg-white/[0.04] ring-1` : 'text-faint hover:text-muted'}`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function Dot({ tone }: { tone: Tone }) {
+  return <span className="flex items-center gap-1.5"><span className={`h-2 w-2 rounded-full ${dotBg(tone)}`} /><span className={txt(tone)}>{tone === 'safe' ? 'OK' : tone === 'warn' ? 'watch' : tone === 'crit' ? 'alert' : 'note'}</span></span>
+}
+
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
+function dotBg(t: Tone) { return t === 'safe' ? 'bg-safe' : t === 'warn' ? 'bg-warn' : t === 'crit' ? 'bg-crit' : t === 'ice' ? 'bg-ice' : 'bg-muted' }
+function ring(t: Tone) { return t === 'safe' ? 'ring-safe/30' : t === 'warn' ? 'ring-warn/30' : t === 'crit' ? 'ring-crit/30' : t === 'ice' ? 'ring-ice/30' : 'ring-white/10' }

--- a/console/components/shell/nav-items.ts
+++ b/console/components/shell/nav-items.ts
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Boxes, ShieldCheck, Activity, Radio, Route, Brain, Bell, AlertTriangle, FileCheck2, BarChart3, Database, FileText, Settings } from 'lucide-react'
+import { LayoutDashboard, Globe, Boxes, ShieldCheck, Activity, Radio, Route, Brain, Bell, AlertTriangle, FileCheck2, BarChart3, Database, FileText, Settings } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 export interface NavItem { href: string; label: string; icon: LucideIcon }
@@ -10,6 +10,7 @@ export const navGroups: NavGroup[] = [
     label: 'Operations',
     items: [
       { href: '/', label: 'Overview', icon: LayoutDashboard },
+      { href: '/global', label: 'Global Operations', icon: Globe },
       { href: '/fleet', label: 'Fleet Operations', icon: Boxes },
       { href: '/safety', label: 'Safety Governor', icon: ShieldCheck },
       { href: '/runtime', label: 'Runtime Health', icon: Activity },

--- a/console/components/ui/global-map.tsx
+++ b/console/components/ui/global-map.tsx
@@ -1,0 +1,91 @@
+import type { GlobalSite, WeatherZone, GeoZone } from '@/lib/global'
+
+// Stylized world map with layered operational overlays. Abstract graticule —
+// suggestion, not cartography. Layers (toggleable): risk (weather blobs +
+// geofence zones), network links, and an activity/intervention heatmap.
+
+const C: Record<string, string> = { safe: '#2fe6a6', warn: '#ffb020', crit: '#ff5468', ice: '#5cc6ff', muted: '#69728a' }
+const TONES = ['safe', 'warn', 'crit', 'ice'] as const
+
+const LAND = [
+  'M8,18 Q14,12 22,15 Q28,17 26,24 Q20,30 13,27 Q6,24 8,18 Z',
+  'M30,26 Q33,20 38,22 Q40,30 36,38 Q32,42 30,36 Q28,30 30,26 Z',
+  'M44,14 Q54,9 64,13 Q70,16 66,22 Q56,26 48,22 Q43,19 44,14 Z',
+  'M70,24 Q78,20 86,23 Q92,27 88,33 Q80,36 73,32 Q68,28 70,24 Z',
+]
+
+export function GlobalMap({
+  sites, weather, geofences, showHeatmap, showRisk, showNetwork, height = 360,
+}: {
+  sites: GlobalSite[]
+  weather: WeatherZone[]
+  geofences: GeoZone[]
+  showHeatmap: boolean
+  showRisk: boolean
+  showNetwork: boolean
+  height?: number
+}) {
+  const hub = sites.find((s) => s.hub) ?? sites[0]
+  const maxInt = Math.max(1, ...sites.map((s) => s.interventions))
+  const markerR = (assets: number) => 1.3 + (assets / 142) * 2.1
+
+  return (
+    <svg viewBox="0 0 100 50" style={{ height }} className="w-full" role="img" aria-label="global operations map">
+      <defs>
+        {TONES.map((t) => (
+          <radialGradient key={t} id={`glow-${t}`} cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor={C[t]} stopOpacity="0.5" />
+            <stop offset="65%" stopColor={C[t]} stopOpacity="0.12" />
+            <stop offset="100%" stopColor={C[t]} stopOpacity="0" />
+          </radialGradient>
+        ))}
+        <pattern id="gm-grat" width="8.33" height="8.33" patternUnits="userSpaceOnUse">
+          <path d="M8.33 0H0V8.33" fill="none" stroke="rgba(92,198,255,0.07)" strokeWidth="0.25" />
+        </pattern>
+      </defs>
+
+      <rect x="2" y="2" width="96" height="46" rx="3" fill="url(#gm-grat)" stroke="rgba(150,166,198,0.12)" strokeWidth="0.3" />
+      {LAND.map((d, i) => (
+        <path key={i} d={d} fill="rgba(154,166,189,0.07)" stroke="rgba(154,166,189,0.18)" strokeWidth="0.3" />
+      ))}
+
+      {/* risk overlay: weather systems + geofence zones */}
+      {showRisk && weather.map((w) => (
+        <g key={w.id}>
+          <circle cx={w.x} cy={w.y} r={w.r} fill={`url(#glow-${w.tone})`} />
+          <text x={w.x} y={w.y - w.r + 2} fill={C[w.tone]} fontSize="2.1" fontFamily="monospace" textAnchor="middle" opacity="0.8">{w.label}</text>
+        </g>
+      ))}
+      {showRisk && geofences.map((g) => (
+        <g key={g.id}>
+          <rect x={g.x} y={g.y} width={g.w} height={g.h} rx="1.5" fill="none" stroke={C[g.tone]} strokeOpacity="0.5" strokeWidth="0.35" strokeDasharray="1.4 1" />
+          <text x={g.x + g.w / 2} y={g.y + g.h + 2.4} fill={C[g.tone]} fontSize="1.9" fontFamily="monospace" textAnchor="middle" opacity="0.7">{g.label}</text>
+        </g>
+      ))}
+
+      {/* network links back to the control hub */}
+      {showNetwork && sites.filter((s) => !s.hub).map((s) => {
+        const midX = (s.x + hub.x) / 2
+        const midY = Math.min(s.y, hub.y) - 8
+        return <path key={`net-${s.id}`} d={`M${s.x},${s.y} Q${midX},${midY} ${hub.x},${hub.y}`} fill="none" stroke={C[s.tone]} strokeOpacity="0.35" strokeWidth="0.4" strokeDasharray="1.5 1.5" />
+      })}
+
+      {/* activity / intervention heatmap */}
+      {showHeatmap && sites.map((s) => {
+        const intensity = s.interventions / maxInt
+        const r = 5 + intensity * 11
+        return <circle key={`heat-${s.id}`} cx={s.x} cy={s.y} r={r} fill={`url(#glow-${s.tone})`} opacity={0.55 + intensity * 0.35} />
+      })}
+
+      {/* site markers */}
+      {sites.map((s) => (
+        <g key={s.id}>
+          <circle cx={s.x} cy={s.y} r={markerR(s.assets) + 1.4} fill="none" stroke={C[s.tone]} strokeOpacity="0.35" strokeWidth="0.4" />
+          <circle cx={s.x} cy={s.y} r={markerR(s.assets)} fill={C[s.tone]} />
+          <text x={s.x} y={s.y - markerR(s.assets) - 1.8} fill="#e9edf6" fontSize="2.4" fontFamily="monospace" textAnchor="middle">{s.name}</text>
+          <text x={s.x} y={s.y + markerR(s.assets) + 3.4} fill="#69728a" fontSize="2" fontFamily="monospace" textAnchor="middle">{s.active}/{s.assets}</text>
+        </g>
+      ))}
+    </svg>
+  )
+}

--- a/console/lib/global.ts
+++ b/console/lib/global.ts
@@ -1,0 +1,70 @@
+import type { Tone } from './types'
+
+// Global Operations — the strategic, multi-site mission-control layer: fleet
+// distribution across regions, activity/intervention heatmaps, regional risk
+// overlays (weather / network / geofence), and cross-site alerts.
+
+export type RiskLevel = 'low' | 'elevated' | 'high'
+
+export interface GlobalSite {
+  id: string
+  name: string
+  region: string
+  x: number // 0..100 viewBox
+  y: number // 0..50 viewBox
+  assets: number
+  active: number
+  interventions: number // last 24h
+  risk: RiskLevel
+  tone: Tone
+  weather: string
+  network: string
+  hub?: boolean
+}
+
+export const sites: GlobalSite[] = [
+  { id: 'sf', name: 'San Francisco', region: 'US-West · HQ', x: 16, y: 22, assets: 142, active: 128, interventions: 9, risk: 'elevated', tone: 'warn', weather: 'High wind · fog', network: 'nominal', hub: true },
+  { id: 'aus', name: 'Austin', region: 'US-Central', x: 26, y: 28, assets: 88, active: 84, interventions: 2, risk: 'low', tone: 'safe', weather: 'Clear', network: 'nominal' },
+  { id: 'rot', name: 'Rotterdam', region: 'EU-West', x: 50, y: 17, assets: 64, active: 61, interventions: 1, risk: 'low', tone: 'safe', weather: 'Light rain', network: 'nominal' },
+  { id: 'sin', name: 'Singapore', region: 'APAC', x: 76, y: 34, assets: 51, active: 47, interventions: 4, risk: 'elevated', tone: 'warn', weather: 'Monsoon', network: 'jitter elevated' },
+  { id: 'tok', name: 'Tokyo', region: 'APAC-North', x: 86, y: 22, assets: 37, active: 36, interventions: 1, risk: 'low', tone: 'safe', weather: 'Clear', network: 'nominal' },
+]
+
+// Soft weather systems drawn as radial blobs over a region.
+export interface WeatherZone { id: string; label: string; x: number; y: number; r: number; tone: Tone }
+export const weatherZones: WeatherZone[] = [
+  { id: 'w1', label: 'Pacific wind system', x: 13, y: 22, r: 13, tone: 'warn' },
+  { id: 'w2', label: 'SE-Asia monsoon', x: 76, y: 34, r: 11, tone: 'ice' },
+]
+
+// Geofence corridors / keep-in zones at sites.
+export interface GeoZone { id: string; label: string; x: number; y: number; w: number; h: number; tone: Tone }
+export const geofences: GeoZone[] = [
+  { id: 'g1', label: 'SF yard corridor', x: 11, y: 17, w: 11, h: 10, tone: 'safe' },
+  { id: 'g2', label: 'SIN dock geofence', x: 71, y: 29, w: 11, h: 10, tone: 'warn' },
+]
+
+export interface CrossSiteAlert { id: string; ts: string; region: string; message: string; tone: Tone }
+export const crossSiteAlerts: CrossSiteAlert[] = [
+  { id: 'a1', ts: '23:01', region: 'US-West', message: 'High-wind advisory — 3 SF assets throttled to Degraded envelope', tone: 'warn' },
+  { id: 'a2', ts: '22:54', region: 'APAC', message: 'DDS jitter elevated on Singapore↔HQ federation link (24 ms)', tone: 'warn' },
+  { id: 'a3', ts: '22:40', region: 'APAC', message: 'Monsoon cell entering Singapore yard — geofence watch active', tone: 'ice' },
+  { id: 'a4', ts: '22:18', region: 'EU-West', message: 'Rotterdam geofence breach auto-cleared — asset re-contained', tone: 'safe' },
+  { id: 'a5', ts: '21:50', region: 'Global', message: 'Federation reconciliation complete · gen 4471 · all peers in sync', tone: 'safe' },
+]
+
+export interface RegionRisk { region: string; weather: Tone; network: Tone; geofence: Tone; note: string }
+export const regionRisk: RegionRisk[] = [
+  { region: 'US-West', weather: 'warn', network: 'safe', geofence: 'safe', note: 'wind advisory active' },
+  { region: 'US-Central', weather: 'safe', network: 'safe', geofence: 'safe', note: 'nominal' },
+  { region: 'EU-West', weather: 'safe', network: 'safe', geofence: 'safe', note: 'nominal' },
+  { region: 'APAC', weather: 'ice', network: 'warn', geofence: 'warn', note: 'monsoon + link jitter' },
+  { region: 'APAC-North', weather: 'safe', network: 'safe', geofence: 'safe', note: 'nominal' },
+]
+
+export const totals = {
+  assets: sites.reduce((a, s) => a + s.assets, 0),
+  active: sites.reduce((a, s) => a + s.active, 0),
+  interventions: sites.reduce((a, s) => a + s.interventions, 0),
+  sites: sites.length,
+}


### PR DESCRIPTION
## Deepens the Global Ops Map (#1) into a full strategic view

New dedicated **`/global`** route (sidebar → Operations → *Global Operations*) — the executive "mission control" layer, addressing the gaps noted in the roadmap review (regional risk overlays + activity heatmaps).

### Global Operations Map — toggleable overlays
- **Activity heatmap** — soft glow per site scaled by 24h interventions (SF hottest at 9, APAC next).
- **Regional risk** — weather systems as radial blobs (Pacific wind over SF, SE-Asia monsoon over Singapore) + geofence corridors.
- **Network links** — federation links back to the HQ hub, colored by link health.
- Site markers sized by fleet size, colored by site risk level.

### Surrounding panels
- **Top-line metrics** — sites online, active assets, interventions/24h, regions at risk.
- **Cross-Site Alerts** — wind advisory throttling SF assets, APAC link jitter, monsoon geofence watch, Rotterdam breach cleared, federation in sync.
- **Regional Risk** table — weather / network / geofence status per region.
- **Fleet Distribution** — assets by site with per-site weather/network/intervention context.

New `GlobalMap` component + `lib/global.ts`; new sidebar entry. The existing per-site summary on `/fleet` stays as an in-context glance.

### Verified
Clean `next build` — compiles, lint + type validation pass, **26/26** routes prerender (Next 15.5.19).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_