### PR TITLE
feat(console): deepen Robot Digital Twin — pose, live vitals, thermal, mission (#2)

### DIFF
--- a/console/app/fleet/[id]/page.tsx
+++ b/console/app/fleet/[id]/page.tsx
@@ -3,9 +3,11 @@ import { notFound } from 'next/navigation'
 import { ChevronLeft } from 'lucide-react'
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
 import { PositionMap } from '@/components/ui/position-map'
+import { PoseView } from '@/components/ui/pose-view'
+import { Spark } from '@/components/charts/charts'
 import { twinById, twins } from '@/lib/fleet'
 import { postureTone } from '@/lib/mock'
-import type { Tone } from '@/lib/types'
+import type { Tone, SeriesPoint } from '@/lib/types'
 
 export function generateStaticParams() {
   return twins.map((t) => ({ id: t.id }))
@@ -41,6 +43,27 @@ export default async function TwinPage({ params }: { params: Promise<{ id: strin
         <Metric label="Power draw" value={`${t.drawW} W`} tone="ice" />
         <Metric label="Est. range" value={`${t.rangeKm.toFixed(1)} km`} tone="ice" />
         <Metric label="Status" value={t.status} tone={tone} />
+      </div>
+
+      {/* Pose + live telemetry */}
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel title="Pose & Attitude" subtitle="orientation · IMU">
+          <PoseView pose={t.pose} tone={tone} height={228} />
+          <div className="mt-2 grid grid-cols-4 gap-2 border-t border-line pt-3 text-center font-mono text-[10px] text-faint">
+            <div><div className="text-sm text-ink">{t.pose.yaw}°</div>yaw</div>
+            <div><div className="text-sm text-ink">{t.pose.pitch}°</div>pitch</div>
+            <div><div className="text-sm text-ink">{t.pose.roll}°</div>roll</div>
+            <div><div className="text-sm text-ice">{t.pose.heading.split(' · ')[0]}</div>head</div>
+          </div>
+        </Panel>
+
+        <Panel className="xl:col-span-2" title="Live Telemetry" subtitle="velocity · acceleration · localization confidence" action={<Pill tone="ice">50 Hz</Pill>}>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <Vital label="Velocity" unit="m/s" data={t.vitals.velocity} color="ice" />
+            <Vital label="Acceleration" unit="m/s²" data={t.vitals.accel} color="safe" />
+            <Vital label="Localization conf." unit="%" data={t.vitals.localization} color={confColor(t.vitals.localization)} />
+          </div>
+        </Panel>
       </div>
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
@@ -96,6 +119,57 @@ export default async function TwinPage({ params }: { params: Promise<{ id: strin
         </div>
       </div>
 
+      {/* Thermal + actuator load + mission timeline */}
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel title="Thermal" subtitle="component temperatures" dense>
+          <ul>
+            {t.thermals.map((th) => (
+              <li key={th.name} className="flex items-center gap-3 border-b border-line px-4 py-3 last:border-0">
+                <StatusDot tone={th.tone} pulse={th.tone === 'crit'} />
+                <span className="flex-1 truncate text-[12px] text-ink">{th.name}</span>
+                <div className="w-24"><Meter value={Math.min(100, (th.tempC / 90) * 100)} tone={th.tone} /></div>
+                <span className={`w-12 text-right font-mono text-[12px] ${txt(th.tone)}`}>{th.tempC}°C</span>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+
+        <Panel title="Actuator Load" subtitle="per-channel duty cycle">
+          <ul className="space-y-4">
+            {t.actuators.map((a) => (
+              <li key={a.name}>
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[12px] text-ink">{a.name}</span>
+                  <span className={`font-mono text-[11px] ${txt(a.tone)}`}>{a.loadPct}%</span>
+                </div>
+                <div className="mt-2"><Meter value={a.loadPct} tone={a.tone} /></div>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+
+        <Panel title="Mission Timeline" subtitle="current assignment" dense>
+          <ol className="px-4 py-3">
+            {t.missionPhases.map((p, idx) => {
+              const pt: Tone = p.status === 'done' ? 'safe' : p.status === 'active' ? (/lockout|hold/i.test(p.name) ? 'crit' : 'ice') : 'muted'
+              return (
+                <li key={p.name} className="relative flex gap-3 pb-5 pl-1 last:pb-0">
+                  {idx < t.missionPhases.length - 1 && <span className="absolute left-[5px] top-4 h-full w-px bg-line" />}
+                  <span className={`mt-1 h-2.5 w-2.5 shrink-0 rounded-full ${dotBg(pt)}`} />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-[12px] text-ink">{p.name}</span>
+                      <span className={`font-mono text-[10px] uppercase tracking-wider ${txt(pt)}`}>{p.status}</span>
+                    </div>
+                    {p.status === 'active' && p.pct > 0 && <div className="mt-2"><Meter value={p.pct} tone={pt} /></div>}
+                  </div>
+                </li>
+              )
+            })}
+          </ol>
+        </Panel>
+      </div>
+
       <Panel title="Command Stream" subtitle="recent actuator commands · governor verdict" dense>
         <div className="overflow-x-auto">
           <table className="w-full min-w-[640px] text-left">
@@ -143,5 +217,24 @@ function KV({ k, v }: { k: string; v: string }) {
   )
 }
 
+function Vital({ label, unit, data, color }: { label: string; unit: string; data: SeriesPoint[]; color: 'safe' | 'warn' | 'crit' | 'ice' }) {
+  const last = data[data.length - 1]?.v ?? 0
+  return (
+    <div className="rounded-lg border border-line bg-bg/40 p-3">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-wider text-faint">{label}</span>
+        <span className="font-mono text-[12px] text-ink">{last}<span className="text-muted"> {unit}</span></span>
+      </div>
+      <div className="mt-2"><Spark data={data} color={color} /></div>
+    </div>
+  )
+}
+
+function confColor(data: SeriesPoint[]): 'safe' | 'warn' | 'crit' | 'ice' {
+  const last = data[data.length - 1]?.v ?? 100
+  return last < 20 ? 'crit' : last < 60 ? 'warn' : 'safe'
+}
+
 function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
+function dotBg(t: Tone) { return t === 'safe' ? 'bg-safe' : t === 'warn' ? 'bg-warn' : t === 'crit' ? 'bg-crit' : t === 'ice' ? 'bg-ice' : 'bg-muted' }
 function badge(t: Tone) { return t === 'safe' ? 'bg-safe/15 text-safe' : t === 'warn' ? 'bg-warn/15 text-warn' : t === 'crit' ? 'bg-crit/15 text-crit' : 'bg-ice/15 text-ice' }

--- a/console/components/ui/pose-view.tsx
+++ b/console/components/ui/pose-view.tsx
@@ -1,0 +1,43 @@
+import type { TwinPose } from '@/lib/fleet'
+import type { Tone } from '@/lib/types'
+
+// Robot pose visualization — a top-down chassis on a perspective ground grid,
+// rotated by yaw, with a heading arrow and compass ring. Pitch/roll are surfaced
+// as readouts by the caller. Pure SVG (no three.js); reads as a 3D pose.
+const COL: Record<string, string> = { safe: '#2fe6a6', warn: '#ffb020', crit: '#ff5468', ice: '#5cc6ff', muted: '#9aa6bd' }
+
+export function PoseView({ pose, tone, height = 240 }: { pose: TwinPose; tone: Tone; height?: number }) {
+  const c = COL[tone] ?? COL.ice
+  const cx = 50, cy = 44
+  return (
+    <svg viewBox="0 0 100 84" style={{ height }} className="w-full" role="img" aria-label="robot pose">
+      {/* perspective ground grid */}
+      <g stroke="rgba(150,166,198,0.12)" strokeWidth="0.3" fill="none">
+        {[0, 1, 2, 3, 4].map((i) => {
+          const y = cy + 4 + i * 7
+          const w = 16 + i * 9
+          return <line key={`h${i}`} x1={cx - w} y1={y} x2={cx + w} y2={y} />
+        })}
+        {[-3, -2, -1, 0, 1, 2, 3].map((i) => (
+          <line key={`v${i}`} x1={cx + i * 5.5} y1={cy + 4} x2={cx + i * 16} y2={cy + 32} />
+        ))}
+      </g>
+
+      {/* floor shadow + compass ring */}
+      <ellipse cx={cx} cy={cy + 12} rx="16" ry="4.5" fill={c} opacity="0.08" />
+      <circle cx={cx} cy={cy} r="23" fill="none" stroke="rgba(150,166,198,0.16)" strokeWidth="0.3" strokeDasharray="0.5 3" />
+      <text x={cx} y={cy - 25} fill="#69728a" fontSize="3" fontFamily="monospace" textAnchor="middle">N</text>
+
+      {/* chassis rotated by yaw */}
+      <g transform={`rotate(${pose.yaw} ${cx} ${cy})`}>
+        <rect x={cx - 10} y={cy - 13} width="20" height="26" rx="3" fill="rgba(22,27,39,0.96)" stroke={c} strokeWidth="0.8" />
+        <rect x={cx - 10} y={cy - 13} width="20" height="3" rx="1.5" fill={c} />
+        <polygon points={`${cx},${cy - 19} ${cx - 3},${cy - 14} ${cx + 3},${cy - 14}`} fill={c} />
+        {[[-12.5, -9], [10, -9], [-12.5, 3], [10, 3]].map(([dx, dy], k) => (
+          <rect key={k} x={cx + dx} y={cy + dy} width="2.5" height="7" rx="1" fill={c} opacity="0.6" />
+        ))}
+        <circle cx={cx} cy={cy} r="2.4" fill={c} />
+      </g>
+    </svg>
+  )
+}

--- a/console/lib/fleet.ts
+++ b/console/lib/fleet.ts
@@ -1,4 +1,4 @@
-import type { Tone, Posture } from './types'
+import type { Tone, Posture, SeriesPoint } from './types'
 import type { PosPoint } from './telemetry'
 
 // Robot Digital Twin — the per-asset deep view: subsystem health, the live
@@ -18,6 +18,12 @@ export interface TwinAttestation {
   tone: Tone
 }
 
+export interface TwinPose { yaw: number; pitch: number; roll: number; heading: string }
+export interface TwinVitals { velocity: SeriesPoint[]; accel: SeriesPoint[]; localization: SeriesPoint[] }
+export interface Thermal { name: string; tempC: number; tone: Tone }
+export interface ActuatorLoad { name: string; loadPct: number; tone: Tone }
+export interface MissionPhase { name: string; status: 'done' | 'active' | 'pending'; pct: number }
+
 export interface Twin {
   id: string
   name: string
@@ -35,6 +41,11 @@ export interface Twin {
   commands: TwinCommand[]
   path: PosPoint[]
   ego: PosPoint
+  pose: TwinPose
+  vitals: TwinVitals
+  thermals: Thermal[]
+  actuators: ActuatorLoad[]
+  missionPhases: MissionPhase[]
 }
 
 function trace(seed: number): PosPoint[] {
@@ -117,6 +128,99 @@ const commandsLocked: TwinCommand[] = [
   { ts: '12:02:41', channel: 'any motion', value: 'human reset pending', verdict: 'DENY', tone: 'crit' },
 ]
 
+// Per-kind pose, thermals, actuator load, and mission timeline.
+interface KindDetail { pose: TwinPose; thermals: Thermal[]; actuators: ActuatorLoad[]; missionPhases: MissionPhase[] }
+const detail: Record<string, KindDetail> = {
+  nominal: {
+    pose: { yaw: 41, pitch: 2, roll: -1, heading: 'NE · aisle-7' },
+    thermals: [
+      { name: 'Drive motor', tempC: 48, tone: 'safe' },
+      { name: 'Battery pack', tempC: 32, tone: 'safe' },
+      { name: 'Compute (Orin)', tempC: 61, tone: 'safe' },
+      { name: 'Brake assembly', tempC: 40, tone: 'safe' },
+    ],
+    actuators: [
+      { name: 'Drive · left', loadPct: 38, tone: 'safe' },
+      { name: 'Drive · right', loadPct: 41, tone: 'safe' },
+      { name: 'Steering', loadPct: 22, tone: 'safe' },
+      { name: 'Lift / mast', loadPct: 0, tone: 'safe' },
+    ],
+    missionPhases: [
+      { name: 'Dispatch', status: 'done', pct: 100 },
+      { name: 'Transit', status: 'done', pct: 100 },
+      { name: 'Pick & place', status: 'active', pct: 62 },
+      { name: 'Return', status: 'pending', pct: 0 },
+    ],
+  },
+  degraded: {
+    pose: { yaw: 118, pitch: 1, roll: 0, heading: 'SE · holding' },
+    thermals: [
+      { name: 'Drive motor', tempC: 58, tone: 'warn' },
+      { name: 'Battery pack', tempC: 41, tone: 'safe' },
+      { name: 'Compute (Orin)', tempC: 66, tone: 'warn' },
+      { name: 'Brake assembly', tempC: 47, tone: 'safe' },
+    ],
+    actuators: [
+      { name: 'Drive · left', loadPct: 64, tone: 'warn' },
+      { name: 'Drive · right', loadPct: 61, tone: 'warn' },
+      { name: 'Steering', loadPct: 34, tone: 'safe' },
+      { name: 'Lift / mast', loadPct: 0, tone: 'safe' },
+    ],
+    missionPhases: [
+      { name: 'Survey', status: 'done', pct: 100 },
+      { name: 'Inspect', status: 'active', pct: 40 },
+      { name: 'HOLD (degraded)', status: 'active', pct: 0 },
+      { name: 'Resume', status: 'pending', pct: 0 },
+    ],
+  },
+  lockedout: {
+    pose: { yaw: 0, pitch: 0, roll: 0, heading: 'HOLD · stopped' },
+    thermals: [
+      { name: 'Drive motor', tempC: 30, tone: 'safe' },
+      { name: 'Battery pack', tempC: 78, tone: 'crit' },
+      { name: 'Compute (Orin)', tempC: 55, tone: 'safe' },
+      { name: 'Brake assembly', tempC: 33, tone: 'safe' },
+    ],
+    actuators: [
+      { name: 'Drive · left', loadPct: 0, tone: 'crit' },
+      { name: 'Drive · right', loadPct: 0, tone: 'crit' },
+      { name: 'Steering', loadPct: 0, tone: 'crit' },
+      { name: 'Brake · A/B', loadPct: 100, tone: 'safe' },
+    ],
+    missionPhases: [
+      { name: 'Transit', status: 'done', pct: 100 },
+      { name: 'LOCKOUT', status: 'active', pct: 100 },
+      { name: 'Human reset', status: 'pending', pct: 0 },
+    ],
+  },
+}
+
+// Deterministic 24-sample vitals (no RNG — stable across server render + build).
+function vitalsFor(kind: string, seed: number): TwinVitals {
+  const N = 24
+  const s = (fn: (i: number) => number): SeriesPoint[] =>
+    Array.from({ length: N }, (_, i) => ({ t: String(i).padStart(2, '0'), v: Math.round(fn(i) * 100) / 100 }))
+  if (kind === 'lockedout') {
+    return {
+      velocity: s((i) => Math.max(0, 1.6 - i * 0.12)),
+      accel: s((i) => (i < 6 ? -0.4 : 0)),
+      localization: s(() => 11 + Math.sin(seed) * 2),
+    }
+  }
+  if (kind === 'degraded') {
+    return {
+      velocity: s((i) => Math.max(0, 2.0 + Math.sin(i / 5 + seed) * 0.25 - i * 0.01)),
+      accel: s((i) => Math.cos(i / 5 + seed) * 0.3),
+      localization: s((i) => 54 + Math.sin(i / 6 + seed) * 4),
+    }
+  }
+  return {
+    velocity: s((i) => 3.0 + Math.sin(i / 5 + seed) * 0.6),
+    accel: s((i) => Math.cos(i / 4 + seed) * 0.4),
+    localization: s((i) => 93 + Math.sin(i / 7 + seed) * 3),
+  }
+}
+
 // Map the 8 roster robots → digital twins with posture-appropriate detail.
 const roster = [
   { id: 'r1', name: 'KIRRA-07', model: 'Atlas-X', kind: 'nominal', battery: 88, draw: 240, range: 11.4 },
@@ -156,6 +260,11 @@ export const twins: Twin[] = roster.map((r, i) => {
     commands,
     path,
     ego: path[26],
+    pose: detail[r.kind].pose,
+    vitals: vitalsFor(r.kind, i * 1.3),
+    thermals: detail[r.kind].thermals,
+    actuators: detail[r.kind].actuators,
+    missionPhases: detail[r.kind].missionPhases,
   }
 })
 
@@ -163,7 +272,7 @@ export function twinById(id: string): Twin | undefined {
   return twins.find((t) => t.id === id)
 }
 
-// ── Global Ops Map (#1) ───────────────────────────────────────────────
+// ── Global Ops Map (#1) ─────────────────────────────────────────────────
 // Fleet sites worldwide, color-coded by aggregate site posture. `hub` is the
 // control center all sites arc back to. Coords are in a 0..100 × 0..50 viewBox.
 export const sites: { id: string; name: string; region: string; x: number; y: number; assets: number; tone: Tone; hub?: boolean }[] = [


### PR DESCRIPTION
## Closes the depth gaps on the Robot Digital Twin (`/fleet/[id]`)

The twin had envelope/subsystems/attestation/command-stream; this adds the engineer-favorite deep-dive pieces noted in the roadmap review:

- **Pose & Attitude** — a 3D-style SVG pose view: top-down chassis on a perspective ground grid, **rotated by yaw**, with heading arrow + compass ring; yaw / pitch / roll / heading readouts. (Pure SVG, no three.js.)
- **Live Telemetry** — per-twin **velocity / acceleration / localization-confidence** sparklines at 50 Hz; confidence color-grades by value (KIRRA-13's locked-out twin reads ~11% → crit).
- **Thermal** — per-component temps (drive motor / battery / compute / brake) with bars; the lockout twin surfaces a **battery over-temp (78°C, crit)**.
- **Actuator Load** — per-channel duty cycle (degraded twin shows elevated drive load; lockout shows brakes engaged 100%, drive 0).
- **Mission Timeline** — the robot's current assignment as a vertical stepper; LOCKOUT / HOLD phases render crit / ice.

### Notes
- Vitals are **deterministic** (sine-based, no RNG), so the statically-prerendered twin pages and client hydration match exactly.
- `Twin` model extended in `lib/fleet.ts`; new `PoseView` component.

### Verified
Clean `next build` — compiles, lint + type validation pass, **26/26** routes prerender including all **8** `/fleet/[id]` twins (Next 15.5.19).

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_