### PR TITLE
feat(console): incident spatial replay + sensor playback (#8)

### DIFF
--- a/console/app/incidents/page.tsx
+++ b/console/app/incidents/page.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from 'react'
 import { Play, Pause, SkipBack, RotateCcw } from 'lucide-react'
-import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
-import { incidents, replay, featured, rootCause } from '@/lib/incidents'
+import { Panel, Pill, StatusDot, Meter } from '@/components/ui/primitives'
+import { ReplayMap } from '@/components/ui/replay-map'
+import { incidents, replay, featured, rootCause, replaySpatial, replayActors, replayHazard } from '@/lib/incidents'
 import { postureTone } from '@/lib/mock'
 import type { Tone } from '@/lib/types'
 
@@ -13,6 +14,7 @@ export default function IncidentsPage() {
   const [i, setI] = useState(6) // start at the trigger frame (t = 0)
   const [playing, setPlaying] = useState(false)
   const frame = replay[i]
+  const spatial = replaySpatial[i]
 
   useEffect(() => {
     if (!playing) return
@@ -114,6 +116,35 @@ export default function IncidentsPage() {
         </div>
       </Panel>
 
+      {/* ── Spatial replay + sensor playback (#8) ── */}
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Spatial Replay" subtitle="position over time · ego advances with the scrubber" action={<Pill tone="ice">top-down</Pill>}>
+          <ReplayMap frames={replaySpatial} actors={replayActors} hazard={replayHazard} index={i} height={320} />
+          <div className="mt-3 flex flex-wrap items-center gap-4 border-t border-line pt-3 font-mono text-[10px] text-faint">
+            <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-ice" /> traveled path</span>
+            <span className="flex items-center gap-1.5"><span className="h-2 w-px bg-muted" /> planned</span>
+            <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-sm bg-crit/60" /> keep-out zone</span>
+            <span className="ml-auto">front cone = radar health · {spatial.confidence < 0.6 ? 'confidence below floor' : 'nominal'}</span>
+          </div>
+        </Panel>
+
+        <Panel title="Sensor Playback" subtitle={`t = ${frame.t > 0 ? '+' : ''}${frame.t}s · ${frame.clock}`}>
+          <div className="space-y-3">
+            <SensorRow label="LiDAR (top)" tone={spatial.lidar} />
+            <SensorRow label="Radar (front)" tone={spatial.radar} />
+            <SensorRow label="Camera ×6" tone={spatial.camera} />
+          </div>
+          <div className="mt-4 border-t border-line pt-3">
+            <div className="flex items-center justify-between">
+              <span className="font-mono text-[10px] uppercase tracking-wider text-faint">Localization confidence</span>
+              <span className={`font-mono text-[12px] ${confTone(spatial.confidence) === 'safe' ? 'text-safe' : confTone(spatial.confidence) === 'warn' ? 'text-warn' : 'text-crit'}`}>{spatial.confidence.toFixed(2)}</span>
+            </div>
+            <div className="mt-2"><Meter value={spatial.confidence * 100} tone={confTone(spatial.confidence)} /></div>
+            <p className="mt-1.5 font-mono text-[10px] text-faint">floor ≥ 0.60 · {spatial.confidence < 0.6 ? 'breached → Degraded' : 'within floor'}</p>
+          </div>
+        </Panel>
+      </div>
+
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
         <Panel className="xl:col-span-2" title="Frame Log" subtitle="full second-by-second reconstruction" dense>
           <ul>
@@ -199,6 +230,18 @@ function StateCard({ label, children }: { label: string; children: React.ReactNo
     </div>
   )
 }
+
+function SensorRow({ label, tone }: { label: string; tone: Tone }) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-line bg-bg/40 px-3 py-2">
+      <StatusDot tone={tone} pulse={tone === 'crit'} />
+      <span className="flex-1 text-[12px] text-ink">{label}</span>
+      <span className={`font-mono text-[10px] uppercase tracking-wider ${txt(tone)}`}>{tone === 'safe' ? 'OK' : tone === 'warn' ? 'intermittent' : 'fault'}</span>
+    </div>
+  )
+}
+
+function confTone(v: number): Tone { return v < 0.3 ? 'crit' : v < 0.6 ? 'warn' : 'safe' }
 
 function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
 function badge(t: Tone) { return t === 'safe' ? 'bg-safe/15 text-safe' : t === 'warn' ? 'bg-warn/15 text-warn' : t === 'crit' ? 'bg-crit/15 text-crit' : 'bg-ice/15 text-ice' }

--- a/console/components/ui/replay-map.tsx
+++ b/console/components/ui/replay-map.tsx
@@ -1,0 +1,68 @@
+import type { SpatialFrame, ReplayActor } from '@/lib/incidents'
+
+// Forensic spatial replay — a top-down reconstruction of the asset's path around
+// an incident. The ego advances per scrubber frame; the traveled path brightens,
+// the planned path stays faint, and the front radar cone recolors with sensor
+// health. Pure SVG, driven by the page's frame index.
+const C: Record<string, string> = { safe: '#2fe6a6', warn: '#ffb020', crit: '#ff5468', ice: '#5cc6ff', muted: '#9aa6bd' }
+
+export function ReplayMap({
+  frames, actors, hazard, index, height = 320,
+}: {
+  frames: SpatialFrame[]
+  actors: ReplayActor[]
+  hazard: { x: number; y: number; w: number; h: number; label: string }
+  index: number
+  height?: number
+}) {
+  const ego = frames[index].ego
+  const planned = frames.map((f) => `${f.ego.x},${f.ego.y}`).join(' ')
+  const traveled = frames.slice(0, index + 1).map((f) => `${f.ego.x},${f.ego.y}`).join(' ')
+  const radar = C[frames[index].radar]
+  const breached = index >= 6
+
+  return (
+    <svg viewBox="0 0 100 100" style={{ height }} className="w-full" role="img" aria-label="incident spatial replay">
+      <defs>
+        <pattern id="rm-grid" width="8" height="8" patternUnits="userSpaceOnUse">
+          <path d="M8 0H0V8" fill="none" stroke="rgba(150,166,198,0.06)" strokeWidth="0.3" />
+        </pattern>
+      </defs>
+      <rect width="100" height="100" fill="url(#rm-grid)" />
+
+      {/* drivable corridor */}
+      <rect x="6" y="50" width="88" height="18" rx="2" fill="rgba(47,230,166,0.03)" stroke="rgba(47,230,166,0.15)" strokeWidth="0.3" strokeDasharray="2 1.5" />
+
+      {/* hazard keep-out zone */}
+      <rect x={hazard.x} y={hazard.y} width={hazard.w} height={hazard.h} rx="2" fill={breached ? 'rgba(255,84,104,0.10)' : 'rgba(255,84,104,0.05)'} stroke={C.crit} strokeOpacity={breached ? 0.6 : 0.35} strokeWidth="0.4" strokeDasharray="1.5 1" />
+      <text x={hazard.x + hazard.w / 2} y={hazard.y - 1.5} fill={C.crit} fontSize="2.6" fontFamily="monospace" textAnchor="middle" opacity="0.8">{hazard.label}</text>
+
+      {/* planned vs traveled path */}
+      <polyline points={planned} fill="none" stroke="rgba(150,166,198,0.25)" strokeWidth="0.5" strokeDasharray="1.5 1.5" />
+      <polyline points={traveled} fill="none" stroke={C.ice} strokeWidth="0.9" strokeLinecap="round" strokeLinejoin="round" />
+      {frames.slice(0, index + 1).map((f, k) => (
+        <circle key={k} cx={f.ego.x} cy={f.ego.y} r="0.8" fill={C.ice} opacity={0.25 + (k / (index + 1)) * 0.5} />
+      ))}
+
+      {/* detected actors */}
+      {actors.map((a) => (
+        <g key={a.id}>
+          <circle cx={a.x} cy={a.y} r="2.6" fill="none" stroke={C[a.tone]} strokeOpacity="0.35" strokeWidth="0.4" />
+          {a.kind === 'vehicle'
+            ? <rect x={a.x - 1.6} y={a.y - 1.6} width="3.2" height="3.2" rx="0.5" fill={C[a.tone]} />
+            : <circle cx={a.x} cy={a.y} r="1.4" fill={C[a.tone]} />}
+          <text x={a.x + 3.2} y={a.y + 1} fill={C[a.tone]} fontSize="2.4" fontFamily="monospace">{a.label}</text>
+        </g>
+      ))}
+
+      {/* ego: lidar ring + radar cone + chassis */}
+      <g transform={`rotate(${ego.heading} ${ego.x} ${ego.y})`}>
+        <circle cx={ego.x} cy={ego.y} r="9" fill="none" stroke={C.ice} strokeOpacity="0.18" strokeWidth="0.3" strokeDasharray="1 2" />
+        <path d={`M${ego.x},${ego.y} L${ego.x - 6},${ego.y - 15} A16,16 0 0,1 ${ego.x + 6},${ego.y - 15} Z`} fill={radar} fillOpacity="0.10" stroke={radar} strokeOpacity="0.35" strokeWidth="0.3" />
+        <rect x={ego.x - 2.6} y={ego.y - 3.4} width="5.2" height="6.8" rx="1" fill="rgba(22,27,39,0.96)" stroke={breached ? C.crit : C.ice} strokeWidth="0.6" />
+        <polygon points={`${ego.x},${ego.y - 5} ${ego.x - 1.6},${ego.y - 3.2} ${ego.x + 1.6},${ego.y - 3.2}`} fill={breached ? C.crit : C.ice} />
+      </g>
+      <text x={ego.x} y={ego.y + 7} fill="#9aa6bd" fontSize="2.4" fontFamily="monospace" textAnchor="middle">KIRRA-13</text>
+    </svg>
+  )
+}

--- a/console/lib/incidents.ts
+++ b/console/lib/incidents.ts
@@ -49,6 +49,41 @@ export const replay: ReplayFrame[] = [
   { t: 3, clock: '12:02:43', speed: 0.0, posture: 'LockedOut', verdict: '—', event: 'asset at full stop — HOLD; human reset required', tone: 'crit' },
 ]
 
+// ── Spatial replay (#8) ────────────────────────────────────────────────
+// Per-frame ego pose for forensic position-over-time playback, plus detected
+// actors, the hazard keep-out zone, and frame-by-frame sensor health. Indices
+// align 1:1 with `replay` above. Coords are top-down in a 0..100 viewBox.
+
+export interface ReplayActor { id: string; x: number; y: number; kind: 'person' | 'vehicle' | 'static'; label: string; tone: Tone }
+export const replayActors: ReplayActor[] = [
+  { id: 'worker', x: 74, y: 72, kind: 'person', label: 'worker · 9 m', tone: 'warn' },
+  { id: 'amr', x: 64, y: 50, kind: 'vehicle', label: 'AMR-08', tone: 'ice' },
+  { id: 'pallet', x: 44, y: 42, kind: 'static', label: 'pallet', tone: 'muted' },
+]
+
+export const replayHazard = { x: 56, y: 46, w: 18, h: 24, label: 'keep-out' }
+
+export interface SpatialFrame {
+  ego: { x: number; y: number; heading: number }
+  lidar: Tone
+  radar: Tone
+  camera: Tone
+  confidence: number
+}
+
+export const replaySpatial: SpatialFrame[] = [
+  { ego: { x: 12, y: 60, heading: 88 }, lidar: 'safe', radar: 'safe', camera: 'safe', confidence: 0.78 },
+  { ego: { x: 18, y: 59, heading: 89 }, lidar: 'safe', radar: 'safe', camera: 'safe', confidence: 0.74 },
+  { ego: { x: 25, y: 59, heading: 90 }, lidar: 'safe', radar: 'warn', camera: 'safe', confidence: 0.71 },
+  { ego: { x: 33, y: 58, heading: 90 }, lidar: 'safe', radar: 'warn', camera: 'safe', confidence: 0.66 },
+  { ego: { x: 42, y: 58, heading: 91 }, lidar: 'safe', radar: 'warn', camera: 'safe', confidence: 0.54 },
+  { ego: { x: 49, y: 57, heading: 91 }, lidar: 'safe', radar: 'warn', camera: 'safe', confidence: 0.50 },
+  { ego: { x: 55, y: 57, heading: 92 }, lidar: 'safe', radar: 'crit', camera: 'safe', confidence: 0.41 },
+  { ego: { x: 60, y: 56, heading: 92 }, lidar: 'safe', radar: 'warn', camera: 'safe', confidence: 0.30 },
+  { ego: { x: 62.5, y: 56, heading: 92 }, lidar: 'safe', radar: 'warn', camera: 'safe', confidence: 0.18 },
+  { ego: { x: 63.5, y: 56, heading: 92 }, lidar: 'warn', radar: 'warn', camera: 'safe', confidence: 0.11 },
+]
+
 export interface RootCause { id: string; label: string; detail: string; tone: Tone }
 
 export const rootCause: RootCause[] = [


### PR DESCRIPTION
## Closes the last roadmap depth gap

The `/incidents` scrubber already replayed posture/speed/verdict per frame. This adds the **forensic, spatial** layer — synced to the same frame index, so dragging the scrubber drives everything at once:

### Spatial Replay (top-down)
- The **ego (KIRRA-13) advances along its path** as you scrub; the **traveled path brightens** while the **planned path** stays faint.
- The **front radar cone recolors with sensor health** (goes amber → red around the breach), and the **keep-out hazard zone intensifies** after the envelope breach.
- Detected actors overlaid (worker / AMR-08 / pallet) in the drivable corridor.

### Sensor Playback
- Per-frame **LiDAR / radar / camera** status — radar reads *intermittent* in the lead-up and *fault* at the breach frame.
- **Localization-confidence** bar against the 0.60 floor, dropping 0.78 → 0.11 across the incident, with the "breached → Degraded" annotation.

Spatial frames align 1:1 with the existing replay timeline. New `ReplayMap` component; data added to `lib/incidents.ts`.

### Verified
Clean `next build` — compiles, lint + type validation pass, **26/26** routes (Next 15.5.19).

This completes all of the lighter depth gaps from the roadmap review — **#1 Global Ops, #2 Digital Twin, #8 Incident Replay, #13 Telemetry Explorer** are now fully built out.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_