### PR TITLE
feat(console): wire to live verifier data (REST posture + demo fallback)

### DIFF
--- a/console/.env.example
+++ b/console/.env.example
@@ -1,0 +1,10 @@
+# Kirra Mission Console — environment
+
+# Base URL of a live Kirra verifier service. When unset, the console runs on
+# bundled demo data. When set, the Live Fleet screen (/live) and the top-nav
+# connection indicator poll the verifier's public read endpoints (/health,
+# /fleet/posture) and fall back to demo data on error. No token is required —
+# these are the verifier's public read-only tier.
+#
+# NEXT_PUBLIC_* values are inlined into the client bundle at build time.
+NEXT_PUBLIC_KIRRA_API_URL=

--- a/console/README.md
+++ b/console/README.md
@@ -34,6 +34,7 @@ console/
   lib/
     types.ts            # domain model (Robot, KPI, Posture, EventItem)
     mock.ts             # mock fleet + telemetry data
+    api/                # live verifier client + hooks (types, client, hooks)
   tailwind.config.ts    # color tokens, fonts, shadows
 ```
 
@@ -47,6 +48,38 @@ console/
 | `warn` (amber) | warnings / degraded |
 | `crit` (red) | critical interventions |
 | `ice` (blue) | telemetry / analytics |
+
+## Live data
+
+The console runs on bundled mock data by default (the public demo always works).
+To bind it to a real Kirra verifier service, set its base URL at build time:
+
+```bash
+# console/.env.local
+NEXT_PUBLIC_KIRRA_API_URL=https://your-verifier.example.com
+```
+
+When set, the **Live Fleet** screen (`/live`) and the top-nav connection
+indicator poll the verifier's **public read endpoints** and fall back to demo
+data on any error:
+
+| Endpoint | Use |
+|----------|-----|
+| `GET /health` | connection indicator (`Live · connected` / `Backend offline` / `Demo data`) |
+| `GET /fleet/posture` | live per-node posture table; transitions become the event feed |
+
+These endpoints are the verifier's **public read-only tier** — no token is
+shipped to the browser. The auth-gated SSE stream (`/system/posture/stream`) is
+intentionally **not** consumed client-side; the live event feed is derived from
+posture-change polling instead.
+
+**CORS:** if the console and verifier are on different origins, the verifier
+must send CORS headers (or sit behind the same origin / a reverse proxy). A
+server-side proxy route (to also carry the admin token for the SSE stream and
+mutation routes) is the natural next increment.
+
+Wire types live in `lib/api/types.ts` and mirror the verifier's serde shapes
+(`FleetNodePosture`, `NodeTrustState`, `FleetPosture`).
 
 ## Roadmap (build increments)
 

--- a/console/app/live/page.tsx
+++ b/console/app/live/page.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
+import { useLiveFleet } from '@/lib/api/hooks'
+import { postureTone, trustLabel, trustReason, trustTone, type FleetPostureState } from '@/lib/api/types'
+import type { Tone } from '@/lib/types'
+
+export default function LivePage() {
+  const { fleet, events, source, error, updatedAt } = useLiveFleet(5000)
+  const counts = fleet.reduce(
+    (a, n) => { a[n.propagated_status] = (a[n.propagated_status] ?? 0) + 1; return a },
+    {} as Record<FleetPostureState, number>
+  )
+
+  return (
+    <div className="mx-auto max-w-[1500px] space-y-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-ink">Live Fleet</h1>
+          <p className="font-mono text-[11px] text-faint">
+            verifier · GET /fleet/posture · {source === 'live' ? `updated ${updatedAt ? new Date(updatedAt).toLocaleTimeString() : '—'}` : 'mock fallback'}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {source === 'live'
+            ? <Pill tone="safe">Live · connected</Pill>
+            : <Pill tone="ice">Demo data</Pill>}
+        </div>
+      </div>
+
+      {/* Data-source banner */}
+      <div className={`rounded-xl border p-4 ${source === 'live' ? 'border-safe/30 bg-safe/[0.04]' : 'border-line bg-panel'}`}>
+        {source === 'live' ? (
+          <p className="text-[13px] text-muted">
+            Connected to a live Kirra verifier. Posture is polled every 5 s; the event feed is derived from posture transitions.
+          </p>
+        ) : (
+          <p className="text-[13px] text-muted">
+            Running on bundled demo data. Set <code className="rounded bg-bg/60 px-1.5 py-0.5 font-mono text-[12px] text-ice">NEXT_PUBLIC_KIRRA_API_URL</code> to a verifier base URL to go live — these read endpoints are public (no token).
+            {error && <span className="text-warn"> · last attempt: {error}</span>}
+          </p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <Metric label="Nodes" value={`${fleet.length}`} tone="ice" />
+        <Metric label="Nominal" value={`${counts.Nominal ?? 0}`} tone="safe" />
+        <Metric label="Degraded" value={`${counts.Degraded ?? 0}`} tone="warn" />
+        <Metric label="Locked out" value={`${counts.LockedOut ?? 0}`} tone="crit" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Fleet Posture" subtitle="propagated posture · per node · gray/black DAG" dense>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-left">
+              <thead>
+                <tr className="border-b border-line font-mono text-[10px] uppercase tracking-wider text-faint">
+                  <th className="px-4 py-2 font-normal">Node</th>
+                  <th className="px-4 py-2 font-normal">Local trust</th>
+                  <th className="px-4 py-2 font-normal">Propagated</th>
+                  <th className="px-4 py-2 font-normal">Blocked by</th>
+                </tr>
+              </thead>
+              <tbody className="font-mono text-[12px]">
+                {fleet.map((n) => (
+                  <tr key={n.node_id} className="border-b border-line last:border-0 hover:bg-white/[0.02]">
+                    <td className="px-4 py-2.5 text-ink">{n.node_id}</td>
+                    <td className={`px-4 py-2.5 ${txt(trustTone(n.local_status))}`} title={trustReason(n.local_status) ?? ''}>
+                      {trustLabel(n.local_status)}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${badge(postureTone(n.propagated_status))}`}>{n.propagated_status}</span>
+                    </td>
+                    <td className="px-4 py-2.5 text-faint">{n.blocked_by.length ? n.blocked_by.join(', ') : '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Panel>
+
+        <Panel title="Posture Events" subtitle={source === 'live' ? 'transitions · live' : 'synthetic · demo'} dense>
+          {events.length === 0 ? (
+            <div className="px-4 py-10 text-center font-mono text-[12px] text-faint">awaiting posture transitions…</div>
+          ) : (
+            <ul>
+              {events.map((e, idx) => {
+                const tone = e.posture ? postureTone(e.posture.propagated_status) : 'muted'
+                return (
+                  <li key={`${e.node_id}-${e.emitted_at_ms}-${idx}`} className="flex items-start gap-3 border-b border-line px-4 py-3 last:border-0">
+                    <StatusDot tone={tone} pulse={tone === 'crit'} />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 font-mono text-[10px] text-faint">
+                        <span>{new Date(e.emitted_at_ms).toLocaleTimeString()}</span>
+                        <span className={txt(tone)}>{e.event_type}</span>
+                      </div>
+                      <p className="mt-0.5 truncate font-mono text-[12px] text-ink">
+                        {e.node_id ?? 'fleet'} {e.posture ? `→ ${e.posture.propagated_status}` : ''}
+                      </p>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </Panel>
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, value, tone }: { label: string; value: string; tone: Tone }) {
+  return (
+    <div className="rounded-xl border border-line bg-panel p-4 shadow-panel">
+      <div className="font-mono text-[11px] uppercase tracking-wider text-faint">{label}</div>
+      <div className={`mt-1.5 font-display text-[26px] font-semibold leading-none ${txt(tone)}`}>{value}</div>
+    </div>
+  )
+}
+
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
+function badge(t: Tone) { return t === 'safe' ? 'bg-safe/15 text-safe' : t === 'warn' ? 'bg-warn/15 text-warn' : t === 'crit' ? 'bg-crit/15 text-crit' : 'bg-ice/15 text-ice' }

--- a/console/components/shell/connection-status.tsx
+++ b/console/components/shell/connection-status.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useHealth } from '@/lib/api/hooks'
+import { Pill } from '@/components/ui/primitives'
+
+// Shell indicator: reflects whether the console is bound to a live Kirra
+// verifier (NEXT_PUBLIC_KIRRA_API_URL) and whether it is reachable.
+export function ConnectionStatus() {
+  const { status } = useHealth()
+  if (status === 'demo') return <Pill tone="ice">Demo data</Pill>
+  if (status === 'ok') return <Pill tone="safe">Live · connected</Pill>
+  if (status === 'connecting') return <Pill tone="warn">Connecting…</Pill>
+  return <Pill tone="crit">Backend offline</Pill>
+}

--- a/console/components/shell/nav-items.ts
+++ b/console/components/shell/nav-items.ts
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Globe, Boxes, ShieldCheck, Activity, Radio, Route, Brain, Bell, AlertTriangle, FileCheck2, BarChart3, Database, FileText, Settings } from 'lucide-react'
+import { LayoutDashboard, Globe, Boxes, ShieldCheck, Activity, Radio, Route, Rss, Brain, Bell, AlertTriangle, FileCheck2, BarChart3, Database, FileText, Settings } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 export interface NavItem { href: string; label: string; icon: LucideIcon }
@@ -10,6 +10,7 @@ export const navGroups: NavGroup[] = [
     label: 'Operations',
     items: [
       { href: '/', label: 'Overview', icon: LayoutDashboard },
+      { href: '/live', label: 'Live Fleet', icon: Rss },
       { href: '/global', label: 'Global Operations', icon: Globe },
       { href: '/fleet', label: 'Fleet Operations', icon: Boxes },
       { href: '/safety', label: 'Safety Governor', icon: ShieldCheck },

--- a/console/components/shell/top-nav.tsx
+++ b/console/components/shell/top-nav.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { Search, Bell, ChevronDown } from 'lucide-react'
-import { Pill } from '@/components/ui/primitives'
 import { MobileNav } from '@/components/shell/mobile-nav'
+import { ConnectionStatus } from '@/components/shell/connection-status'
 
 function KMark() {
   // Trust-lattice "K" — mirrors the marketing-site logo: a constellation of
@@ -61,7 +61,7 @@ export function TopNav() {
           <div className="font-mono text-[9px] uppercase tracking-[2px] text-faint">Mission Console</div>
         </div>
       </div>
-      <div className="ml-2 hidden sm:block"><Pill tone="safe">Governor Online</Pill></div>
+      <div className="ml-2 hidden sm:block"><ConnectionStatus /></div>
       <button className="ml-1 hidden items-center gap-2 rounded-lg border border-line bg-panel px-3 py-1.5 font-mono text-[11px] text-muted hover:text-ink xl:flex">
         PRODUCTION · us-fleet-1 <ChevronDown className="h-3.5 w-3.5 text-faint" />
       </button>

--- a/console/lib/api/client.ts
+++ b/console/lib/api/client.ts
@@ -1,0 +1,26 @@
+import { API_BASE } from './config'
+import type { FleetNodePosture, HealthResponse } from './types'
+
+// Thin typed client over the verifier's public read endpoints. All calls are
+// no-store and abortable. CORS note: when the console and verifier are on
+// different origins, the verifier must send CORS headers (or sit behind the
+// same origin / a reverse proxy) for these browser fetches to succeed.
+
+async function getJSON<T>(path: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'GET',
+    headers: { accept: 'application/json' },
+    cache: 'no-store',
+    signal,
+  })
+  if (!res.ok) throw new Error(`GET ${path} → ${res.status}`)
+  return (await res.json()) as T
+}
+
+export const kirra = {
+  health: (signal?: AbortSignal) => getJSON<HealthResponse>('/health', signal),
+  ready: (signal?: AbortSignal) => getJSON<HealthResponse>('/ready', signal),
+  fleetPosture: (signal?: AbortSignal) => getJSON<{ fleet: FleetNodePosture[] }>('/fleet/posture', signal),
+  nodePosture: (id: string, signal?: AbortSignal) =>
+    getJSON<FleetNodePosture>(`/fleet/posture/${encodeURIComponent(id)}`, signal),
+}

--- a/console/lib/api/config.ts
+++ b/console/lib/api/config.ts
@@ -1,0 +1,11 @@
+// Live-data configuration. The console talks to a real Kirra verifier service
+// when NEXT_PUBLIC_KIRRA_API_URL is set at build time; otherwise it runs on the
+// bundled mock data ("demo" mode) so the public deploy always works.
+//
+// The endpoints used here (/health, /fleet/posture) are the verifier's
+// PUBLIC read-only tier — no token required, so nothing secret is shipped to
+// the client. The auth-gated SSE stream is intentionally NOT consumed from the
+// browser; the live event feed is derived from posture-change polling instead.
+
+export const API_BASE = (process.env.NEXT_PUBLIC_KIRRA_API_URL ?? '').replace(/\/+$/, '')
+export const IS_LIVE = API_BASE.length > 0

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -1,0 +1,113 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { IS_LIVE } from './config'
+import { kirra } from './client'
+import type { FleetNodePosture, FleetPostureState, PostureStreamEvent } from './types'
+import { robots } from '@/lib/mock'
+
+export type Source = 'live' | 'demo'
+export type LinkStatus = 'connecting' | 'ok' | 'down' | 'demo'
+
+// Demo fleet derived from the bundled mock roster, shaped like the wire type.
+function demoFleet(): FleetNodePosture[] {
+  return robots.map((r) => ({
+    node_id: r.name,
+    local_status:
+      r.posture === 'LockedOut' ? { Untrusted: 'lockout · human reset required' }
+      : r.posture === 'Degraded' ? { Untrusted: 'sensor confidence < 0.60 floor' }
+      : 'Trusted',
+    propagated_status: r.posture as FleetPostureState,
+    blocked_by: r.posture === 'LockedOut' ? ['fleet-dag'] : [],
+  }))
+}
+
+// Polls /health so the shell can show a live connection indicator.
+export function useHealth(pollMs = 10000): { status: LinkStatus } {
+  const [status, setStatus] = useState<LinkStatus>(IS_LIVE ? 'connecting' : 'demo')
+  useEffect(() => {
+    if (!IS_LIVE) return
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const ping = async () => {
+      try {
+        const h = await kirra.health(ctrl.signal)
+        setStatus(h.status === 'ok' ? 'ok' : 'down')
+      } catch (e) {
+        if ((e as { name?: string })?.name !== 'AbortError') setStatus('down')
+      }
+      timer = setTimeout(ping, pollMs)
+    }
+    ping()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [pollMs])
+  return { status }
+}
+
+function mkEvent(p: FleetNodePosture, type: string): PostureStreamEvent {
+  return { event_type: type, node_id: p.node_id, emitted_at_ms: Date.now(), posture: p }
+}
+
+// Live fleet posture + a derived event feed. In live mode it polls
+// /fleet/posture and emits an event whenever a node's posture transitions; in
+// demo mode it serves the mock roster and rotates synthetic events so the feed
+// still breathes. Always falls back to demo on a fetch error.
+export function useLiveFleet(pollMs = 5000): {
+  fleet: FleetNodePosture[]
+  events: PostureStreamEvent[]
+  source: Source
+  error: string | null
+  updatedAt: number | null
+} {
+  const [fleet, setFleet] = useState<FleetNodePosture[]>(() => demoFleet())
+  const [events, setEvents] = useState<PostureStreamEvent[]>([])
+  const [source, setSource] = useState<Source>(IS_LIVE ? 'live' : 'demo')
+  const [error, setError] = useState<string | null>(null)
+  const [updatedAt, setUpdatedAt] = useState<number | null>(null)
+  const prev = useRef<Map<string, FleetPostureState>>(new Map())
+
+  useEffect(() => {
+    // ── Demo mode: static fleet + rotating synthetic events ──
+    if (!IS_LIVE) {
+      const f = demoFleet()
+      let k = 0
+      const id = setInterval(() => {
+        const p = f[k % f.length]; k += 1
+        setEvents((cur) => [mkEvent(p, 'POSTURE_RECALCULATED'), ...cur].slice(0, 40))
+      }, 2600)
+      return () => clearInterval(id)
+    }
+
+    // ── Live mode: poll, diff, derive transition events ──
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const { fleet: next } = await kirra.fleetPosture(ctrl.signal)
+        const seeded = prev.current.size > 0
+        const fresh: PostureStreamEvent[] = []
+        for (const n of next) {
+          const before = prev.current.get(n.node_id)
+          if (seeded && before !== undefined && before !== n.propagated_status) {
+            fresh.push(mkEvent(n, 'POSTURE_TRANSITION'))
+          }
+          prev.current.set(n.node_id, n.propagated_status)
+        }
+        setFleet(next)
+        if (fresh.length) setEvents((cur) => [...fresh, ...cur].slice(0, 40))
+        setSource('live'); setError(null); setUpdatedAt(Date.now())
+      } catch (e) {
+        if ((e as { name?: string })?.name !== 'AbortError') {
+          setError(String((e as Error)?.message ?? e))
+          setSource('demo')
+          setFleet(demoFleet())
+        }
+      }
+      timer = setTimeout(load, pollMs)
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [pollMs])
+
+  return { fleet, events, source, error, updatedAt }
+}

--- a/console/lib/api/types.ts
+++ b/console/lib/api/types.ts
@@ -1,0 +1,39 @@
+import type { Tone } from '@/lib/types'
+
+// Wire types mirroring the verifier service's serde shapes (src/verifier.rs).
+//   FleetPosture       -> "Nominal" | "Degraded" | "LockedOut"
+//   NodeTrustState     -> "Trusted" | "Unknown" | { Untrusted: "<reason>" }
+//   FleetNodePosture   -> { node_id, local_status, propagated_status, blocked_by }
+
+export type FleetPostureState = 'Nominal' | 'Degraded' | 'LockedOut'
+export type NodeTrustState = 'Trusted' | 'Unknown' | { Untrusted: string }
+
+export interface FleetNodePosture {
+  node_id: string
+  local_status: NodeTrustState
+  propagated_status: FleetPostureState
+  blocked_by: string[]
+}
+
+export interface PostureStreamEvent {
+  event_type: string
+  node_id: string | null
+  emitted_at_ms: number
+  posture: FleetNodePosture | null
+}
+
+export interface HealthResponse { status: string }
+
+export function trustLabel(s: NodeTrustState): string {
+  return typeof s === 'string' ? s : 'Untrusted'
+}
+export function trustReason(s: NodeTrustState): string | null {
+  return typeof s === 'string' ? null : s.Untrusted
+}
+
+export function postureTone(p: FleetPostureState): Tone {
+  return p === 'Nominal' ? 'safe' : p === 'Degraded' ? 'warn' : 'crit'
+}
+export function trustTone(s: NodeTrustState): Tone {
+  return typeof s === 'string' ? (s === 'Trusted' ? 'safe' : 'muted') : 'crit'
+}


### PR DESCRIPTION
## First live-data increment — the console can now talk to a real verifier

Turns the console from a pure demo into a tool that reflects a live Kirra verifier, grounded in the service's **actual serde shapes** (read from `src/bin/kirra_verifier_service.rs` + `src/verifier.rs`), with a safe fallback so the public deploy is unchanged.

### What's wired
- **`lib/api/`** — typed client over the verifier's **public read endpoints** (`/health`, `/fleet/posture`) and wire types mirroring `FleetNodePosture` / `NodeTrustState` (`"Trusted" | "Unknown" | {Untrusted}`) / `FleetPosture`.
- **Hooks** — `useHealth` (connection indicator) and `useLiveFleet` (polls `/fleet/posture` every 5 s, derives posture-**transition** events by diffing polls, and **falls back to demo data on any error**).
- **`/live` "Live Fleet"** screen (sidebar → Operations) — connection banner, live per-node posture table (local trust / propagated posture / blocked-by), a derived posture-event feed, and Nominal/Degraded/LockedOut counts.
- **Top-nav connection pill** — `Live · connected` / `Connecting…` / `Backend offline` / `Demo data`, replacing the static "Governor Online" pill.
- **README + `.env.example`** — documents `NEXT_PUBLIC_KIRRA_API_URL`, the public-tier rationale, and the CORS / server-proxy follow-up.

### Safety / design
- **No secrets reach the client.** Only the verifier's public read-only tier is used. The auth-gated SSE stream (`/system/posture/stream`) is intentionally *not* consumed browser-side; the live feed is derived from posture-change polling instead.
- **Unset env → demo everywhere.** The Vercel build has no `NEXT_PUBLIC_KIRRA_API_URL`, so every screen keeps rendering bundled mock data exactly as today — zero risk to the live site.
- **CORS** and a token-carrying **server proxy** (for the SSE stream + mutations) are documented as the natural next increment.

### Verified
Clean `next build` — compiles, lint + type validation pass, **27/27** routes (added `/live`), Next 15.5.19.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_