### PR TITLE
feat(console): server proxy + live audit-chain wiring

### DIFF
--- a/console/.env.example
+++ b/console/.env.example
@@ -1,10 +1,17 @@
 # Kirra Mission Console — environment
-
-# Base URL of a live Kirra verifier service. When unset, the console runs on
-# bundled demo data. When set, the Live Fleet screen (/live) and the top-nav
-# connection indicator poll the verifier's public read endpoints (/health,
-# /fleet/posture) and fall back to demo data on error. No token is required —
-# these are the verifier's public read-only tier.
 #
-# NEXT_PUBLIC_* values are inlined into the client bundle at build time.
-NEXT_PUBLIC_KIRRA_API_URL=
+# The console reads the verifier through a same-origin SERVER proxy
+# (app/api/kirra/[...path]). These are server-side vars (NOT NEXT_PUBLIC) — the
+# token never reaches the browser, and there is no CORS. When KIRRA_API_URL is
+# unset the proxy reports demo mode and every screen falls back to mock data.
+
+# Base URL of the Kirra verifier service (unset → demo mode).
+KIRRA_API_URL=
+
+# Bearer token for admin / identity-gated reads (e.g. /system/audit/verify,
+# /fabric/*). Optional — public reads (/health, /fleet/posture, /console/audit)
+# work without it.
+KIRRA_ADMIN_TOKEN=
+
+# x-kirra-client-id for identity-gated reads (e.g. the posture SSE stream).
+KIRRA_CLIENT_ID=

--- a/console/README.md
+++ b/console/README.md
@@ -26,6 +26,7 @@ console/
     layout.tsx          # shell: top nav + sidebar grid
     page.tsx            # Fleet Overview
     [...slug]/page.tsx  # styled placeholder for not-yet-built modules
+    api/kirra/          # server proxy to the verifier (token-injecting, CORS-free)
     globals.css         # design tokens + base
   components/
     shell/              # top-nav, sidebar
@@ -52,34 +53,35 @@ console/
 ## Live data
 
 The console runs on bundled mock data by default (the public demo always works).
-To bind it to a real Kirra verifier service, set its base URL at build time:
+To bind it to a real Kirra verifier, point the **server-side proxy** at it:
 
 ```bash
-# console/.env.local
-NEXT_PUBLIC_KIRRA_API_URL=https://your-verifier.example.com
+# console/.env.local  (server-side — NOT shipped to the browser)
+KIRRA_API_URL=https://your-verifier.example.com
+KIRRA_ADMIN_TOKEN=…    # optional — for admin / identity-gated reads
+KIRRA_CLIENT_ID=…      # optional — x-kirra-client-id for the SSE stream
 ```
 
-When set, the **Live Fleet** screen (`/live`) and the top-nav connection
-indicator poll the verifier's **public read endpoints** and fall back to demo
-data on any error:
+Requests go through a same-origin proxy route (`app/api/kirra/[...path]`) which
+injects the token server-side, removes CORS, and only forwards an **allow-listed
+set of read-only GET** paths. The hooks fall back to demo data whenever the
+proxy reports demo mode (`KIRRA_API_URL` unset) or the verifier is unreachable.
 
-| Endpoint | Use |
-|----------|-----|
-| `GET /health` | connection indicator (`Live · connected` / `Backend offline` / `Demo data`) |
-| `GET /fleet/posture` | live per-node posture table; transitions become the event feed |
+Currently wired (Live Fleet `/live` + top-nav indicator):
 
-These endpoints are the verifier's **public read-only tier** — no token is
-shipped to the browser. The auth-gated SSE stream (`/system/posture/stream`) is
-intentionally **not** consumed client-side; the live event feed is derived from
-posture-change polling instead.
+| Source | Endpoint | Tier |
+|--------|----------|------|
+| connection indicator | `GET /health` | public |
+| per-node posture + transition feed | `GET /fleet/posture` | public |
+| audit-chain integrity | `GET /system/audit/verify` | admin (via proxy) |
+| audit event ledger | `GET /console/audit` | public |
 
-**CORS:** if the console and verifier are on different origins, the verifier
-must send CORS headers (or sit behind the same origin / a reverse proxy). A
-server-side proxy route (to also carry the admin token for the SSE stream and
-mutation routes) is the natural next increment.
+Because the proxy holds the token, the richer admin/identity-gated reads
+(`/fabric/*`, `/system/audit/export`, `/system/posture/stream` SSE) are now
+reachable too — wiring more screens is incremental from here.
 
 Wire types live in `lib/api/types.ts` and mirror the verifier's serde shapes
-(`FleetNodePosture`, `NodeTrustState`, `FleetPosture`).
+(`FleetNodePosture`, `NodeTrustState`, `FleetPosture`, audit verify/page).
 
 ## Roadmap (build increments)
 

--- a/console/app/api/kirra/[...path]/route.ts
+++ b/console/app/api/kirra/[...path]/route.ts
@@ -1,0 +1,62 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+// Server-side proxy to the Kirra verifier. Keeps the admin token / client-id on
+// the server (never shipped to the browser), removes CORS (same-origin), and
+// lets the console read admin- and identity-gated endpoints. Read-only: only
+// GET, and only an allow-listed set of verifier read paths are forwarded.
+//
+// Server env (NOT NEXT_PUBLIC — stays server-side):
+//   KIRRA_API_URL       base URL of the verifier (unset → demo mode)
+//   KIRRA_ADMIN_TOKEN   Bearer token for admin/identity-gated reads
+//   KIRRA_CLIENT_ID     x-kirra-client-id for identity-gated reads
+
+const ALLOW: RegExp[] = [
+  /^health$/, /^ready$/,
+  /^fleet\/posture$/, /^fleet\/posture\/[^/]+$/,
+  /^fleet\/history\/[^/]+$/, /^fleet\/flapping\/[^/]+$/,
+  /^attestation\/status\/[^/]+$/,
+  /^federation\/reports\/[^/]+$/,
+  /^system\/audit\/verify$/, /^system\/audit\/causal\/verify$/, /^system\/audit\/export$/,
+  /^fabric\/(assets|state|telemetry|causal-log)$/, /^fabric\/telemetry\/[^/]+$/, /^fabric\/causal-log\/[^/]+$/,
+  /^console\/(fleet|audit|escalations)$/,
+  /^system\/posture\/stream$/,
+]
+
+function demo() {
+  return NextResponse.json({ status: 'demo' }, { status: 503, headers: { 'x-kirra-mode': 'demo' } })
+}
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const base = process.env.KIRRA_API_URL?.replace(/\/+$/, '')
+  if (!base) return demo()
+
+  const { path } = await params
+  const rel = (path ?? []).join('/')
+  if (!ALLOW.some((re) => re.test(rel))) {
+    return NextResponse.json({ error: 'path not allowed' }, { status: 403 })
+  }
+
+  const headers: Record<string, string> = { accept: req.headers.get('accept') ?? 'application/json' }
+  if (process.env.KIRRA_ADMIN_TOKEN) headers.authorization = `Bearer ${process.env.KIRRA_ADMIN_TOKEN}`
+  if (process.env.KIRRA_CLIENT_ID) headers['x-kirra-client-id'] = process.env.KIRRA_CLIENT_ID
+
+  try {
+    const upstream = await fetch(`${base}/${rel}${req.nextUrl.search}`, {
+      method: 'GET',
+      headers,
+      cache: 'no-store',
+      signal: req.signal,
+    })
+    // Pass the body straight through (works for JSON and text/event-stream).
+    const out = new Headers()
+    const ct = upstream.headers.get('content-type')
+    if (ct) out.set('content-type', ct)
+    out.set('cache-control', 'no-store')
+    return new NextResponse(upstream.body, { status: upstream.status, headers: out })
+  } catch (e) {
+    return NextResponse.json({ error: 'verifier unreachable', detail: String((e as Error)?.message ?? e) }, { status: 502 })
+  }
+}

--- a/console/app/live/page.tsx
+++ b/console/app/live/page.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
-import { useLiveFleet } from '@/lib/api/hooks'
+import { useLiveFleet, useAuditChain } from '@/lib/api/hooks'
 import { postureTone, trustLabel, trustReason, trustTone, type FleetPostureState } from '@/lib/api/types'
 import type { Tone } from '@/lib/types'
 
 export default function LivePage() {
   const { fleet, events, source, error, updatedAt } = useLiveFleet(5000)
+  const audit = useAuditChain(15000)
   const counts = fleet.reduce(
     (a, n) => { a[n.propagated_status] = (a[n.propagated_status] ?? 0) + 1; return a },
     {} as Record<FleetPostureState, number>
@@ -36,7 +37,7 @@ export default function LivePage() {
           </p>
         ) : (
           <p className="text-[13px] text-muted">
-            Running on bundled demo data. Set <code className="rounded bg-bg/60 px-1.5 py-0.5 font-mono text-[12px] text-ice">NEXT_PUBLIC_KIRRA_API_URL</code> to a verifier base URL to go live — these read endpoints are public (no token).
+            Running on bundled demo data. Set <code className="rounded bg-bg/60 px-1.5 py-0.5 font-mono text-[12px] text-ice">KIRRA_API_URL</code> (server-side) to a verifier base URL — the same-origin proxy carries the read through and falls back here on any error.
             {error && <span className="text-warn"> · last attempt: {error}</span>}
           </p>
         )}
@@ -105,8 +106,60 @@ export default function LivePage() {
           )}
         </Panel>
       </div>
+
+      {/* ── Live audit chain ── */}
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel title="Audit Chain Integrity" subtitle="SHA-256 hash-chained ledger · GET /system/audit/verify" action={audit.source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}>
+          <div className="flex items-center gap-3">
+            <StatusDot tone={audit.verify.chain_intact ? 'safe' : 'crit'} pulse={!audit.verify.chain_intact} />
+            <span className={`font-display text-2xl font-semibold ${audit.verify.chain_intact ? 'text-safe' : 'text-crit'}`}>
+              {audit.verify.chain_intact ? 'Chain intact' : 'Chain broken'}
+            </span>
+          </div>
+          <div className="mt-4 space-y-3">
+            <KV k="Total entries" v={audit.verify.total_entries.toLocaleString()} />
+            <KV k="Signed / unsigned" v={`${audit.verify.signed_entries.toLocaleString()} / ${audit.verify.unsigned_entries.toLocaleString()}`} />
+            <KV k="Signature valid" v={audit.verify.signature_valid ? 'yes' : 'no'} tone={audit.verify.signature_valid ? 'safe' : 'crit'} />
+            <KV k="Head" v={audit.verify.head_status} />
+            <KV k="Latest hash" v={audit.verify.latest_hash} />
+          </div>
+        </Panel>
+
+        <Panel className="xl:col-span-2" title="Audit Events" subtitle="tamper-evident ledger · GET /console/audit" dense>
+          <ul>
+            {audit.entries.map((e) => (
+              <li key={e.id} className="flex items-start gap-3 border-b border-line px-4 py-2.5 last:border-0">
+                <StatusDot tone={auditTone(e.event_type)} />
+                <span className="w-20 shrink-0 font-mono text-[10px] text-faint">{new Date(e.timestamp_ms).toLocaleTimeString()}</span>
+                <span className="w-24 shrink-0 font-mono text-[10px] uppercase tracking-wider text-muted">{e.source}</span>
+                <div className="min-w-0 flex-1">
+                  <div className={`truncate font-mono text-[11px] ${txt(auditTone(e.event_type))}`}>{e.event_type}</div>
+                  <div className="truncate font-mono text-[10px] text-faint">{e.payload}</div>
+                </div>
+                <span className={`shrink-0 font-mono text-[9px] uppercase ${e.signature_status === 'verified' ? 'text-safe' : 'text-faint'}`}>{e.signature_status}</span>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      </div>
     </div>
   )
+}
+
+function KV({ k, v, tone }: { k: string; v: string; tone?: Tone }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{k}</span>
+      <span className={`font-mono text-xs ${tone ? txt(tone) : 'text-ink'}`}>{v}</span>
+    </div>
+  )
+}
+
+function auditTone(eventType: string): Tone {
+  if (/BREACH|DENY|LOCKEDOUT|CYCLE|REVOK|FAULT/i.test(eventType)) return 'crit'
+  if (/DEGRADED|CLAMP|TRANSITION|WARN/i.test(eventType)) return 'warn'
+  if (/FEDERATION|DDS|LATENCY/i.test(eventType)) return 'ice'
+  return 'safe'
 }
 
 function Metric({ label, value, tone }: { label: string; value: string; tone: Tone }) {

--- a/console/lib/api/client.ts
+++ b/console/lib/api/client.ts
@@ -1,26 +1,29 @@
-import { API_BASE } from './config'
-import type { FleetNodePosture, HealthResponse } from './types'
+import { PROXY_BASE } from './config'
+import type { AuditPage, AuditVerify, FleetNodePosture, HealthResponse } from './types'
 
-// Thin typed client over the verifier's public read endpoints. All calls are
-// no-store and abortable. CORS note: when the console and verifier are on
-// different origins, the verifier must send CORS headers (or sit behind the
-// same origin / a reverse proxy) for these browser fetches to succeed.
+// Sentinel thrown when the proxy reports demo mode (no backend configured).
+// Distinguishes "intentionally offline" from "backend down" for labeling.
+export class DemoMode extends Error {
+  constructor() { super('demo'); this.name = 'DemoMode' }
+}
 
 async function getJSON<T>(path: string, signal?: AbortSignal): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetch(`${PROXY_BASE}${path}`, {
     method: 'GET',
     headers: { accept: 'application/json' },
     cache: 'no-store',
     signal,
   })
+  if (res.headers.get('x-kirra-mode') === 'demo') throw new DemoMode()
   if (!res.ok) throw new Error(`GET ${path} → ${res.status}`)
   return (await res.json()) as T
 }
 
 export const kirra = {
   health: (signal?: AbortSignal) => getJSON<HealthResponse>('/health', signal),
-  ready: (signal?: AbortSignal) => getJSON<HealthResponse>('/ready', signal),
   fleetPosture: (signal?: AbortSignal) => getJSON<{ fleet: FleetNodePosture[] }>('/fleet/posture', signal),
   nodePosture: (id: string, signal?: AbortSignal) =>
     getJSON<FleetNodePosture>(`/fleet/posture/${encodeURIComponent(id)}`, signal),
+  auditVerify: (signal?: AbortSignal) => getJSON<AuditVerify>('/system/audit/verify', signal),
+  auditPage: (limit = 12, signal?: AbortSignal) => getJSON<AuditPage>(`/console/audit?limit=${limit}`, signal),
 }

--- a/console/lib/api/config.ts
+++ b/console/lib/api/config.ts
@@ -1,11 +1,8 @@
-// Live-data configuration. The console talks to a real Kirra verifier service
-// when NEXT_PUBLIC_KIRRA_API_URL is set at build time; otherwise it runs on the
-// bundled mock data ("demo" mode) so the public deploy always works.
-//
-// The endpoints used here (/health, /fleet/posture) are the verifier's
-// PUBLIC read-only tier — no token required, so nothing secret is shipped to
-// the client. The auth-gated SSE stream is intentionally NOT consumed from the
-// browser; the live event feed is derived from posture-change polling instead.
+// The console reads the verifier through a same-origin server proxy
+// (app/api/kirra/[...path]). Whether live data is available is decided at
+// REQUEST time by the proxy (server env KIRRA_API_URL) — not at build time — so
+// there is no NEXT_PUBLIC flag and nothing backend-specific in the bundle.
+// When the proxy reports demo mode (header x-kirra-mode: demo / 503), the hooks
+// fall back to bundled mock data.
 
-export const API_BASE = (process.env.NEXT_PUBLIC_KIRRA_API_URL ?? '').replace(/\/+$/, '')
-export const IS_LIVE = API_BASE.length > 0
+export const PROXY_BASE = '/api/kirra'

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -1,15 +1,17 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { IS_LIVE } from './config'
-import { kirra } from './client'
-import type { FleetNodePosture, FleetPostureState, PostureStreamEvent } from './types'
+import { kirra, DemoMode } from './client'
+import type { AuditEntry, AuditVerify, FleetNodePosture, FleetPostureState, PostureStreamEvent } from './types'
 import { robots } from '@/lib/mock'
 
 export type Source = 'live' | 'demo'
 export type LinkStatus = 'connecting' | 'ok' | 'down' | 'demo'
 
-// Demo fleet derived from the bundled mock roster, shaped like the wire type.
+const isDemo = (e: unknown) => e instanceof DemoMode
+const isAbort = (e: unknown) => (e as { name?: string })?.name === 'AbortError'
+
+// ── Demo fallbacks (shaped exactly like the wire types) ────────────────────
 function demoFleet(): FleetNodePosture[] {
   return robots.map((r) => ({
     node_id: r.name,
@@ -22,21 +24,49 @@ function demoFleet(): FleetNodePosture[] {
   }))
 }
 
-// Polls /health so the shell can show a live connection indicator.
+const DEMO_VERIFY: AuditVerify = {
+  chain_intact: true, total_entries: 184220, latest_hash: '0x9f3a…c1',
+  signing_enabled: true, signed_entries: 184220, unsigned_entries: 0,
+  signature_valid: true, public_key_b64: 'demo', head_verified: true,
+  head_status: 'verified', verified: true,
+}
+function demoAudit(): AuditEntry[] {
+  const now = Date.now()
+  const rows: Array<[string, string, string]> = [
+    ['KINEMATIC_ENVELOPE_BREACH', 'governor', 'KIRRA-13 cmd_vel 999 m/s → DENY'],
+    ['POSTURE_TRANSITION', 'fleet', 'KIRRA-10 → Degraded (confidence 0.41)'],
+    ['ATTESTATION_TRUSTED', 'attestation', 'KIRRA-09 Ed25519 verified'],
+    ['FEDERATION_REPORT_ACCEPTED', 'federation', 'peer-controller-west gen 4471'],
+    ['NOMINAL_VALID_KINEMATICS', 'governor', 'KIRRA-08 cmd_vel 1.2 m/s → ALLOW'],
+  ]
+  return rows.map(([event_type, source, payload], i) => ({
+    id: 184220 - i, timestamp_ms: now - i * 41000, event_type, source, payload,
+    prev_hash: '0x…', entry_hash: '0x…', signature_b64: 'demo', signature_status: 'verified',
+  }))
+}
+
+function mkEvent(p: FleetNodePosture, type: string): PostureStreamEvent {
+  return { event_type: type, node_id: p.node_id, emitted_at_ms: Date.now(), posture: p }
+}
+
+// ── Hooks ─────────────────────────────────────────────────────
+
+// Polls /health through the proxy for the shell connection indicator.
 export function useHealth(pollMs = 10000): { status: LinkStatus } {
-  const [status, setStatus] = useState<LinkStatus>(IS_LIVE ? 'connecting' : 'demo')
+  const [status, setStatus] = useState<LinkStatus>('connecting')
   useEffect(() => {
-    if (!IS_LIVE) return
     const ctrl = new AbortController()
     let timer: ReturnType<typeof setTimeout>
     const ping = async () => {
       try {
         const h = await kirra.health(ctrl.signal)
         setStatus(h.status === 'ok' ? 'ok' : 'down')
+        timer = setTimeout(ping, pollMs)
       } catch (e) {
-        if ((e as { name?: string })?.name !== 'AbortError') setStatus('down')
+        if (isAbort(e)) return
+        if (isDemo(e)) { setStatus('demo'); return } // no backend — stop
+        setStatus('down'); timer = setTimeout(ping, pollMs)
       }
-      timer = setTimeout(ping, pollMs)
     }
     ping()
     return () => { ctrl.abort(); clearTimeout(timer) }
@@ -44,14 +74,9 @@ export function useHealth(pollMs = 10000): { status: LinkStatus } {
   return { status }
 }
 
-function mkEvent(p: FleetNodePosture, type: string): PostureStreamEvent {
-  return { event_type: type, node_id: p.node_id, emitted_at_ms: Date.now(), posture: p }
-}
-
-// Live fleet posture + a derived event feed. In live mode it polls
-// /fleet/posture and emits an event whenever a node's posture transitions; in
-// demo mode it serves the mock roster and rotates synthetic events so the feed
-// still breathes. Always falls back to demo on a fetch error.
+// Live fleet posture + a derived posture-transition event feed. Polls the proxy;
+// emits an event when a node's propagated posture changes. Falls back to demo
+// data and rotating synthetic events when no backend is configured / reachable.
 export function useLiveFleet(pollMs = 5000): {
   fleet: FleetNodePosture[]
   events: PostureStreamEvent[]
@@ -61,53 +86,85 @@ export function useLiveFleet(pollMs = 5000): {
 } {
   const [fleet, setFleet] = useState<FleetNodePosture[]>(() => demoFleet())
   const [events, setEvents] = useState<PostureStreamEvent[]>([])
-  const [source, setSource] = useState<Source>(IS_LIVE ? 'live' : 'demo')
+  const [source, setSource] = useState<Source>('demo')
   const [error, setError] = useState<string | null>(null)
   const [updatedAt, setUpdatedAt] = useState<number | null>(null)
   const prev = useRef<Map<string, FleetPostureState>>(new Map())
+  const demoTimer = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
-    // ── Demo mode: static fleet + rotating synthetic events ──
-    if (!IS_LIVE) {
-      const f = demoFleet()
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+
+    const startDemo = () => {
+      if (demoTimer.current) return
+      const f = demoFleet(); setFleet(f); setSource('demo')
       let k = 0
-      const id = setInterval(() => {
+      demoTimer.current = setInterval(() => {
         const p = f[k % f.length]; k += 1
         setEvents((cur) => [mkEvent(p, 'POSTURE_RECALCULATED'), ...cur].slice(0, 40))
       }, 2600)
-      return () => clearInterval(id)
     }
 
-    // ── Live mode: poll, diff, derive transition events ──
-    const ctrl = new AbortController()
-    let timer: ReturnType<typeof setTimeout>
     const load = async () => {
       try {
         const { fleet: next } = await kirra.fleetPosture(ctrl.signal)
+        if (demoTimer.current) { clearInterval(demoTimer.current); demoTimer.current = null }
         const seeded = prev.current.size > 0
         const fresh: PostureStreamEvent[] = []
         for (const n of next) {
           const before = prev.current.get(n.node_id)
-          if (seeded && before !== undefined && before !== n.propagated_status) {
-            fresh.push(mkEvent(n, 'POSTURE_TRANSITION'))
-          }
+          if (seeded && before !== undefined && before !== n.propagated_status) fresh.push(mkEvent(n, 'POSTURE_TRANSITION'))
           prev.current.set(n.node_id, n.propagated_status)
         }
-        setFleet(next)
+        setFleet(next); setSource('live'); setError(null); setUpdatedAt(Date.now())
         if (fresh.length) setEvents((cur) => [...fresh, ...cur].slice(0, 40))
-        setSource('live'); setError(null); setUpdatedAt(Date.now())
+        timer = setTimeout(load, pollMs)
       } catch (e) {
-        if ((e as { name?: string })?.name !== 'AbortError') {
-          setError(String((e as Error)?.message ?? e))
-          setSource('demo')
-          setFleet(demoFleet())
-        }
+        if (isAbort(e)) return
+        if (isDemo(e)) { startDemo(); return }       // no backend — settle into demo
+        setError(String((e as Error)?.message ?? e)) // backend down — show demo, keep retrying
+        startDemo(); timer = setTimeout(load, pollMs)
       }
-      timer = setTimeout(load, pollMs)
+    }
+    load()
+    return () => {
+      ctrl.abort(); clearTimeout(timer)
+      if (demoTimer.current) { clearInterval(demoTimer.current); demoTimer.current = null }
+    }
+  }, [pollMs])
+
+  return { fleet, events, source, error, updatedAt }
+}
+
+// Audit-chain integrity + recent entries (verify is admin-gated, entries are
+// public /console/audit — both flow through the proxy).
+export function useAuditChain(pollMs = 15000): {
+  verify: AuditVerify
+  entries: AuditEntry[]
+  source: Source
+} {
+  const [verify, setVerify] = useState<AuditVerify>(DEMO_VERIFY)
+  const [entries, setEntries] = useState<AuditEntry[]>(() => demoAudit())
+  const [source, setSource] = useState<Source>('demo')
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const [v, page] = await Promise.all([kirra.auditVerify(ctrl.signal), kirra.auditPage(12, ctrl.signal)])
+        setVerify(v); setEntries(page.entries); setSource('live')
+        timer = setTimeout(load, pollMs)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { setSource('demo'); return }
+        setSource('demo'); timer = setTimeout(load, pollMs)
+      }
     }
     load()
     return () => { ctrl.abort(); clearTimeout(timer) }
   }, [pollMs])
 
-  return { fleet, events, source, error, updatedAt }
+  return { verify, entries, source }
 }

--- a/console/lib/api/types.ts
+++ b/console/lib/api/types.ts
@@ -24,6 +24,38 @@ export interface PostureStreamEvent {
 
 export interface HealthResponse { status: string }
 
+// Audit chain — /system/audit/verify (admin) and /console/audit (public).
+export interface AuditVerify {
+  chain_intact: boolean
+  total_entries: number
+  latest_hash: string
+  signing_enabled: boolean
+  signed_entries: number
+  unsigned_entries: number
+  signature_valid: boolean
+  public_key_b64: string | null
+  head_verified: boolean
+  head_status: string
+  verified: boolean
+}
+export interface AuditEntry {
+  id: number
+  timestamp_ms: number
+  event_type: string
+  source: string
+  payload: string
+  prev_hash: string
+  entry_hash: string
+  signature_b64: string | null
+  signature_status: string
+}
+export interface AuditPage {
+  entries: AuditEntry[]
+  total: number
+  public_key_b64: string | null
+  chain_intact: boolean
+}
+
 export function trustLabel(s: NodeTrustState): string {
   return typeof s === 'string' ? s : 'Untrusted'
 }


### PR DESCRIPTION
## Server proxy → unlocks the token-gated reads, then wires the audit chain live

Following the gap audit, this builds the **foundation** (a same-origin server proxy) and wires the next batch of genuinely-feedable sources through it.

### Server proxy — `app/api/kirra/[...path]`
- **Read-only, allow-listed GET** forwarder. Injects `KIRRA_ADMIN_TOKEN` / `KIRRA_CLIENT_ID` **server-side** (never reaches the browser), removes **CORS** (same-origin), and streams bodies through (JSON **and** `text/event-stream` for the future SSE).
- When `KIRRA_API_URL` is unset → returns demo (`x-kirra-mode: demo`), so the client falls back to mock.
- This is what makes the admin/identity-gated reads (`/fabric/*`, `/system/audit/*`, the posture SSE) reachable at all.

### Client/hooks refactor
- Client now calls the proxy (`/api/kirra/...`). A `DemoMode` sentinel cleanly separates **"no backend"** from **"backend down"** for labeling.
- Dropped the build-time `NEXT_PUBLIC` flag — live-vs-demo is decided **per request** by the proxy.

### Newly wired (real data, with mock fallback)
- **Audit Chain Integrity** (`GET /system/audit/verify`, admin via proxy) — chain intact, total entries, signed/unsigned, signature valid, head, latest hash.
- **Audit Events ledger** (`GET /console/audit`, public) — tamper-evident entries with source + signature status, color-coded by event type.
- Both added to **`/live`** alongside the existing posture table/feed.

### Safety / deploy
- **No token in the client bundle.** **Unset env → demo everywhere**, so the public Vercel deploy is unchanged.
- No Rust changes — the "add small read endpoints" option (av-subsystem meta, operator roster) remains the clean follow-up.

### Verified
Clean `next build` — compiles, lint + type validation pass, **27/27** routes; the proxy is a dynamic function route (`ƒ /api/kirra/[...path]`). Next 15.5.19.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_