### PR TITLE
feat(console): wire Compliance audit chain live

### DIFF
--- a/console/app/compliance/page.tsx
+++ b/console/app/compliance/page.tsx
@@ -1,8 +1,12 @@
+'use client'
+
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
-import { certs, tests, sbom, firmware, policyLogs } from '@/lib/compliance'
+import { useAuditChain } from '@/lib/api/hooks'
+import { certs, tests, sbom, firmware } from '@/lib/compliance'
 import type { Tone } from '@/lib/types'
 
 export default function CompliancePage() {
+  const audit = useAuditChain(15000)
   const totalPassed = tests.reduce((a, t) => a + t.passed, 0)
   const totalTests = tests.reduce((a, t) => a + t.total, 0)
   const coverage = ((totalPassed / totalTests) * 100).toFixed(1)
@@ -15,7 +19,7 @@ export default function CompliancePage() {
           <p className="font-mono text-[11px] text-faint">functional-safety evidence · audit-ready posture</p>
         </div>
         <div className="flex items-center gap-2">
-          <Pill tone="safe">ASIL D · certified</Pill>
+          {audit.source === 'live' ? <Pill tone="safe">audit chain · live</Pill> : <Pill tone="ice">audit chain · demo</Pill>}
           <Pill tone="ice">{coverage}% verification coverage</Pill>
         </div>
       </div>
@@ -39,8 +43,48 @@ export default function CompliancePage() {
         ))}
       </div>
 
+      {/* ── Live from the verifier: tamper-evident audit chain ── */}
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
-        <Panel className="xl:col-span-2" title="Verification Test Results" subtitle="safety-case evidence suites">
+        <Panel
+          title="Audit Chain Integrity"
+          subtitle="SHA-256 hash-chained ledger · GET /system/audit/verify"
+          action={audit.source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}
+        >
+          <div className="flex items-center gap-3">
+            <StatusDot tone={audit.verify.chain_intact ? 'safe' : 'crit'} pulse={!audit.verify.chain_intact} />
+            <span className={`font-display text-2xl font-semibold ${audit.verify.chain_intact ? 'text-safe' : 'text-crit'}`}>
+              {audit.verify.chain_intact ? 'Chain intact' : 'Chain broken'}
+            </span>
+          </div>
+          <div className="mt-4 space-y-3">
+            <KV k="Total entries" v={audit.verify.total_entries.toLocaleString()} />
+            <KV k="Signed / unsigned" v={`${audit.verify.signed_entries.toLocaleString()} / ${audit.verify.unsigned_entries.toLocaleString()}`} />
+            <KV k="Signature valid" v={audit.verify.signature_valid ? 'yes' : 'no'} tone={audit.verify.signature_valid ? 'safe' : 'crit'} />
+            <KV k="Head" v={audit.verify.head_status} />
+            <KV k="Latest hash" v={audit.verify.latest_hash} />
+          </div>
+        </Panel>
+
+        <Panel className="xl:col-span-2" title="Audit Ledger" subtitle="tamper-evident enforcement events · GET /console/audit" dense>
+          <ul>
+            {audit.entries.map((e) => (
+              <li key={e.id} className="flex items-center gap-4 border-b border-line px-4 py-3 last:border-0">
+                <StatusDot tone={auditTone(e.event_type)} />
+                <span className="w-20 shrink-0 font-mono text-[10px] text-faint">{new Date(e.timestamp_ms).toLocaleTimeString()}</span>
+                <span className="w-24 shrink-0 font-mono text-[10px] uppercase tracking-wider text-muted">{e.source}</span>
+                <div className="min-w-0 flex-1">
+                  <div className={`truncate font-mono text-[11px] ${txt(auditTone(e.event_type))}`}>{e.event_type}</div>
+                  <div className="truncate font-mono text-[10px] text-faint">{e.payload}</div>
+                </div>
+                <span className={`shrink-0 font-mono text-[9px] uppercase ${e.signature_status === 'verified' ? 'text-safe' : 'text-faint'}`}>{e.signature_status}</span>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Verification Test Results" subtitle="safety-case evidence suites · static artifact">
           <ul className="space-y-4">
             {tests.map((t) => {
               const pct = (t.passed / t.total) * 100
@@ -60,7 +104,7 @@ export default function CompliancePage() {
           </ul>
         </Panel>
 
-        <Panel title="Software Bill of Materials" subtitle="cert-scoped dependency provenance" dense>
+        <Panel title="Software Bill of Materials" subtitle="cert-scoped · static artifact" dense>
           <ul>
             {sbom.map((s) => (
               <li key={s.id} className="flex items-center gap-3 border-b border-line px-4 py-2.5 last:border-0">
@@ -81,8 +125,8 @@ export default function CompliancePage() {
         </Panel>
       </div>
 
-      <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
-        <Panel title="Signed Firmware Provenance" subtitle="Ed25519 release attestation" dense>
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Panel className="xl:col-span-2" title="Signed Firmware Provenance" subtitle="Ed25519 release attestation · static artifact" dense>
           <ul>
             {firmware.map((f) => (
               <li key={f.id} className="flex items-center gap-4 border-b border-line px-4 py-3 last:border-0">
@@ -102,24 +146,46 @@ export default function CompliancePage() {
           </ul>
         </Panel>
 
-        <Panel title="Policy Enforcement Log" subtitle="fail-closed authorization events" dense>
-          <ul>
-            {policyLogs.map((p) => (
-              <li key={p.id} className="flex items-center gap-4 border-b border-line px-4 py-3 last:border-0">
-                <span className={`rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold ${badge(p.tone)}`}>{p.outcome}</span>
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-[12px] text-ink">{p.policy}</p>
-                  <p className="mt-0.5 font-mono text-[10px] text-faint">{p.actor}</p>
-                </div>
-                <span className="font-mono text-[10px] text-faint">{p.ts}</span>
-              </li>
-            ))}
+        <Panel title="Evidence Sources" subtitle="what's live vs static">
+          <ul className="space-y-3">
+            <SourceRow label="Audit chain & ledger" detail={audit.source === 'live' ? 'live · verifier' : 'demo'} tone={audit.source === 'live' ? 'safe' : 'ice'} live={audit.source === 'live'} />
+            <SourceRow label="Certifications (ISO/IEC/UL)" detail="static evidence" tone="muted" />
+            <SourceRow label="Verification tests" detail="CI artifact" tone="muted" />
+            <SourceRow label="Software bill of materials" detail="build artifact" tone="muted" />
+            <SourceRow label="Signed firmware" detail="release attestation" tone="muted" />
           </ul>
+          <p className="mt-4 border-t border-line pt-3 font-mono text-[10px] leading-relaxed text-faint">
+            The audit chain is read live from the verifier&apos;s tamper-evident ledger. Certifications, tests, SBOM, and firmware provenance are point-in-time evidence artifacts, not runtime endpoints.
+          </p>
         </Panel>
       </div>
     </div>
   )
 }
 
+function KV({ k, v, tone }: { k: string; v: string; tone?: Tone }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{k}</span>
+      <span className={`font-mono text-xs ${tone ? txt(tone) : 'text-ink'}`}>{v}</span>
+    </div>
+  )
+}
+
+function SourceRow({ label, detail, tone, live }: { label: string; detail: string; tone: Tone; live?: boolean }) {
+  return (
+    <li className="flex items-center justify-between">
+      <span className="flex items-center gap-2 text-[12px] text-ink"><StatusDot tone={tone} pulse={live} />{label}</span>
+      <span className={`font-mono text-[10px] uppercase tracking-wider ${txt(tone)}`}>{detail}</span>
+    </li>
+  )
+}
+
+function auditTone(eventType: string): Tone {
+  if (/BREACH|DENY|LOCKEDOUT|CYCLE|REVOK|FAULT|BLOCKED/i.test(eventType)) return 'crit'
+  if (/DEGRADED|CLAMP|TRANSITION|WARN/i.test(eventType)) return 'warn'
+  if (/FEDERATION|DDS|LATENCY/i.test(eventType)) return 'ice'
+  return 'safe'
+}
+
 function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
-function badge(t: Tone) { return t === 'safe' ? 'bg-safe/15 text-safe' : t === 'warn' ? 'bg-warn/15 text-warn' : t === 'crit' ? 'bg-crit/15 text-crit' : 'bg-ice/15 text-ice' }


### PR DESCRIPTION
## Compliance now reads the real tamper-evident ledger

The compliance-relevant data the verifier *actually* serves is the audit chain — so that's now live (through the proxy), and the rest of the screen is honestly labeled as static evidence.

### Live (via proxy)
- **Audit Chain Integrity** — `GET /system/audit/verify` (admin): chain intact, total entries, signed/unsigned, signature valid, head status, latest hash.
- **Audit Ledger** — `GET /console/audit` (public): tamper-evident enforcement events, color-coded by event type with signature status.

### Honestly labeled as static
- **Evidence Sources** panel makes the split explicit: audit = live·verifier; **certifications / verification tests / SBOM / signed firmware** = point-in-time artifacts (those panels are now subtitled "static artifact").
- Header pill reflects audit-chain live vs demo.

Converted to a client component; uses `useAuditChain` with **mock fallback**, so the public deploy is unchanged until `KIRRA_API_URL` is set. No Rust changes.

Verified — clean `next build`, lint + types pass, 27/27 routes (Next 15.5.19).

Next: the Rust read-endpoint additions (`av_subsystem_meta`, operator roster, structured decisions) so Safety / Settings / Oversight can go live too.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_