### PR TITLE
feat(console): wire Event Stream to the live audit ledger

### DIFF
--- a/console/app/events/page.tsx
+++ b/console/app/events/page.tsx
@@ -2,34 +2,38 @@
 
 import { useMemo, useState } from 'react'
 import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
-import { log, sources, sourceTone, type EventSource } from '@/lib/events'
+import { useEventFeed } from '@/lib/api/hooks'
 import type { Tone } from '@/lib/types'
 
 type SevFilter = 'all' | 'crit' | 'warn' | 'safe'
 
 export default function EventsPage() {
-  const [src, setSrc] = useState<EventSource | 'all'>('all')
+  const { rows, sources, source } = useEventFeed(60)
+  const [src, setSrc] = useState<string | 'all'>('all')
   const [sev, setSev] = useState<SevFilter>('all')
 
   const filtered = useMemo(
-    () => log.filter((e) => (src === 'all' || e.source === src) && (sev === 'all' || e.tone === sev)),
-    [src, sev]
+    () => rows.filter((e) => (src === 'all' || e.source === src) && (sev === 'all' || e.tone === sev)),
+    [rows, src, sev]
   )
 
   const counts = useMemo(() => ({
-    crit: log.filter((e) => e.tone === 'crit').length,
-    warn: log.filter((e) => e.tone === 'warn').length,
-    safe: log.filter((e) => e.tone === 'safe').length,
-  }), [])
+    crit: rows.filter((e) => e.tone === 'crit').length,
+    warn: rows.filter((e) => e.tone === 'warn').length,
+    safe: rows.filter((e) => e.tone === 'safe').length,
+  }), [rows])
 
   return (
     <div className="mx-auto max-w-[1500px] space-y-6 p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
           <h1 className="font-display text-xl font-semibold text-ink">Event Stream</h1>
-          <p className="font-mono text-[11px] text-faint">unified fail-closed event log · all subsystems</p>
+          <p className="font-mono text-[11px] text-faint">
+            {source === 'live' ? 'live · GET /console/audit · tamper-evident ledger' : 'unified fail-closed event log · demo'}
+          </p>
         </div>
         <div className="flex items-center gap-2">
+          {source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}
           <Pill tone="crit">{counts.crit} critical</Pill>
           <Pill tone="warn">{counts.warn} warning</Pill>
           <Pill tone="safe">{counts.safe} nominal</Pill>
@@ -38,7 +42,7 @@ export default function EventsPage() {
 
       <Panel
         title="Live Events"
-        subtitle={`${filtered.length} of ${log.length} events`}
+        subtitle={`${filtered.length} of ${rows.length} events`}
         action={
           <div className="flex items-center gap-1">
             {(['all', 'crit', 'warn', 'safe'] as SevFilter[]).map((s) => (
@@ -52,7 +56,7 @@ export default function EventsPage() {
         <div className="flex flex-wrap items-center gap-1.5 border-b border-line px-4 py-3">
           <Chip active={src === 'all'} tone="muted" onClick={() => setSrc('all')}>all sources</Chip>
           {sources.map((s) => (
-            <Chip key={s} active={src === s} tone={sourceTone(s)} onClick={() => setSrc(s)}>{s}</Chip>
+            <Chip key={s} active={src === s} tone={srcTone(s)} onClick={() => setSrc(s)}>{s}</Chip>
           ))}
         </div>
 
@@ -64,7 +68,7 @@ export default function EventsPage() {
               <li key={e.id} className="flex items-start gap-4 border-b border-line px-4 py-3 last:border-0 hover:bg-white/[0.02]">
                 <StatusDot tone={e.tone} pulse={e.tone === 'crit'} />
                 <span className="w-16 shrink-0 font-mono text-[11px] text-faint">{e.ts}</span>
-                <span className={`w-24 shrink-0 font-mono text-[10px] uppercase tracking-wider ${txt(sourceTone(e.source))}`}>{e.source}</span>
+                <span className={`w-24 shrink-0 truncate font-mono text-[10px] uppercase tracking-wider ${txt(srcTone(e.source))}`}>{e.source}</span>
                 <div className="min-w-0 flex-1">
                   <p className={`text-[12px] ${e.tone === 'crit' ? 'text-ink' : 'text-muted'}`}>{e.message}</p>
                   {e.code && <span className={`mt-1 inline-block font-mono text-[10px] ${txt(e.tone)}`}>{e.code}</span>}
@@ -87,6 +91,16 @@ function Chip({ children, active, tone, onClick }: { children: React.ReactNode; 
       {children}
     </button>
   )
+}
+
+// Tone for a source channel — known verifier sources mapped, others neutral.
+function srcTone(s: string): Tone {
+  const k = s.toLowerCase()
+  if (k.includes('governor')) return 'crit'
+  if (k.includes('fleet') || k.includes('attestation')) return 'warn'
+  if (k.includes('telemetry') || k.includes('federation') || k.includes('fabric')) return 'ice'
+  if (k.includes('compliance') || k.includes('audit')) return 'safe'
+  return 'muted'
 }
 
 function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -4,6 +4,16 @@ import { useEffect, useRef, useState } from 'react'
 import { kirra, DemoMode } from './client'
 import type { AuditEntry, AuditVerify, FleetNodePosture, FleetPostureState, PostureStreamEvent } from './types'
 import { robots } from '@/lib/mock'
+import { log as demoEvents, sources as demoSources } from '@/lib/events'
+import type { Tone } from '@/lib/types'
+
+// Shared severity classifier for verifier event/audit types.
+export function eventTone(eventType: string): Tone {
+  if (/BREACH|DENY|LOCKEDOUT|CYCLE|REVOK|FAULT|BLOCKED/i.test(eventType)) return 'crit'
+  if (/DEGRADED|CLAMP|TRANSITION|WARN/i.test(eventType)) return 'warn'
+  if (/FEDERATION|DDS|LATENCY/i.test(eventType)) return 'ice'
+  return 'safe'
+}
 
 export type Source = 'live' | 'demo'
 export type LinkStatus = 'connecting' | 'ok' | 'down' | 'demo'
@@ -49,7 +59,7 @@ function mkEvent(p: FleetNodePosture, type: string): PostureStreamEvent {
   return { event_type: type, node_id: p.node_id, emitted_at_ms: Date.now(), posture: p }
 }
 
-// ── Hooks ─────────────────────────────────────────────────────
+// ── Hooks ─────────────────────────────────────────────────
 
 // Polls /health through the proxy for the shell connection indicator.
 export function useHealth(pollMs = 10000): { status: LinkStatus } {
@@ -167,4 +177,49 @@ export function useAuditChain(pollMs = 15000): {
   }, [pollMs])
 
   return { verify, entries, source }
+}
+
+// Unified event feed for the Event Stream: live from the audit ledger
+// (/console/audit, public) with the mock log as fallback. Returns a flat row
+// shape plus the distinct source channels present in the data.
+export interface FeedRow { id: string; tone: Tone; source: string; ts: string; message: string; code?: string }
+
+function demoFeed(): FeedRow[] {
+  return demoEvents.map((e) => ({ id: e.id, tone: e.tone, source: e.source, ts: e.ts, message: e.message, code: e.code }))
+}
+
+export function useEventFeed(limit = 60): { rows: FeedRow[]; sources: string[]; source: Source } {
+  const [rows, setRows] = useState<FeedRow[]>(() => demoFeed())
+  const [sources, setSources] = useState<string[]>([...demoSources])
+  const [source, setSource] = useState<Source>('demo')
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const page = await kirra.auditPage(limit, ctrl.signal)
+        const r: FeedRow[] = page.entries.map((e) => ({
+          id: String(e.id),
+          tone: eventTone(e.event_type),
+          source: e.source,
+          ts: new Date(e.timestamp_ms).toLocaleTimeString(),
+          message: e.payload,
+          code: e.event_type,
+        }))
+        setRows(r)
+        setSources(Array.from(new Set(r.map((x) => x.source))))
+        setSource('live')
+        timer = setTimeout(load, 8000)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { setRows(demoFeed()); setSources([...demoSources]); setSource('demo'); return }
+        setRows(demoFeed()); setSources([...demoSources]); setSource('demo'); timer = setTimeout(load, 8000)
+      }
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [limit])
+
+  return { rows, sources, source }
 }


### PR DESCRIPTION
`/events` now reads the verifier's **tamper-evident ledger** (`GET /console/audit`, public tier) through the proxy — no token needed — with the mock log as fallback.

- New `useEventFeed` hook + shared `eventTone` classifier; maps audit entries → the event-row shape.
- Source filter chips are **derived from the live data's** distinct source channels (falls back to the mock source set in demo).
- Severity + source filtering and counts preserved; header shows live/demo.

`useMemo` deps fixed to depend on `rows` (was stale against module-level mock). Mock fallback intact, so the public deploy is unchanged. Verified — clean `next build`, lint + types, 27/27 routes.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_