### PR TITLE
feat(console): derive Incident History from the live audit ledger

### DIFF
--- a/console/app/incidents/page.tsx
+++ b/console/app/incidents/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from 'react'
 import { Play, Pause, SkipBack, RotateCcw } from 'lucide-react'
 import { Panel, Pill, StatusDot, Meter } from '@/components/ui/primitives'
 import { ReplayMap } from '@/components/ui/replay-map'
-import { incidents, replay, featured, rootCause, replaySpatial, replayActors, replayHazard } from '@/lib/incidents'
+import { useIncidentHistory } from '@/lib/api/hooks'
+import { replay, featured, rootCause, replaySpatial, replayActors, replayHazard } from '@/lib/incidents'
 import { postureTone } from '@/lib/mock'
 import type { Tone } from '@/lib/types'
 
@@ -15,6 +16,7 @@ export default function IncidentsPage() {
   const [playing, setPlaying] = useState(false)
   const frame = replay[i]
   const spatial = replaySpatial[i]
+  const history = useIncidentHistory(80)
 
   useEffect(() => {
     if (!playing) return
@@ -178,7 +180,12 @@ export default function IncidentsPage() {
         </Panel>
       </div>
 
-      <Panel title="Incident History" subtitle="all logged fail-closed events" dense>
+      <Panel
+        title="Incident History"
+        subtitle={history.source === 'live' ? 'derived from the audit ledger · GET /console/audit' : 'all logged fail-closed events'}
+        action={history.source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}
+        dense
+      >
         <div className="overflow-x-auto">
           <table className="w-full min-w-[760px] text-left">
             <thead>
@@ -192,13 +199,13 @@ export default function IncidentsPage() {
               </tr>
             </thead>
             <tbody className="font-mono text-[12px]">
-              {incidents.map((inc) => (
+              {history.rows.map((inc) => (
                 <tr key={inc.id} className={`border-b border-line last:border-0 hover:bg-white/[0.02] ${inc.id === featured.id ? 'bg-white/[0.03]' : ''}`}>
                   <td className={`px-4 py-2.5 ${txt(inc.tone)}`}>{inc.id}</td>
                   <td className="px-4 py-2.5 text-faint">{inc.ts}</td>
                   <td className="px-4 py-2.5 text-ink">{inc.asset}</td>
                   <td className="px-4 py-2.5 text-muted">{inc.title}</td>
-                  <td className="px-4 py-2.5 text-muted">{inc.durationS}s</td>
+                  <td className="px-4 py-2.5 text-muted">{inc.duration}</td>
                   <td className="px-4 py-2.5 text-ink">{inc.status}</td>
                 </tr>
               ))}

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -5,6 +5,7 @@ import { kirra, DemoMode } from './client'
 import type { AuditEntry, AuditVerify, FleetNodePosture, FleetPostureState, PostureStreamEvent } from './types'
 import { robots } from '@/lib/mock'
 import { log as demoEvents, sources as demoSources } from '@/lib/events'
+import { incidents as demoIncidents } from '@/lib/incidents'
 import type { Tone } from '@/lib/types'
 
 // Shared severity classifier for verifier event/audit types.
@@ -222,4 +223,48 @@ export function useEventFeed(limit = 60): { rows: FeedRow[]; sources: string[]; 
   }, [limit])
 
   return { rows, sources, source }
+}
+
+// Incident history derived from the audit ledger (/console/audit, public):
+// crit/warn events become incident rows. Mock incidents are the fallback.
+export interface IncidentRow { id: string; ts: string; asset: string; title: string; duration: string; status: string; tone: Tone }
+
+function demoIncidentRows(): IncidentRow[] {
+  return demoIncidents.map((i) => ({ id: i.id, ts: i.ts, asset: i.asset, title: i.title, duration: `${i.durationS}s`, status: i.status, tone: i.tone }))
+}
+
+export function useIncidentHistory(limit = 80): { rows: IncidentRow[]; source: Source } {
+  const [rows, setRows] = useState<IncidentRow[]>(() => demoIncidentRows())
+  const [source, setSource] = useState<Source>('demo')
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const page = await kirra.auditPage(limit, ctrl.signal)
+        const inc: IncidentRow[] = page.entries
+          .filter((e) => { const t = eventTone(e.event_type); return t === 'crit' || t === 'warn' })
+          .map((e) => ({
+            id: `INC-${e.id}`,
+            ts: new Date(e.timestamp_ms).toLocaleString(),
+            asset: e.payload.match(/KIRRA-\d+|fleet-dag/)?.[0] ?? '—',
+            title: e.event_type,
+            duration: '—',
+            status: 'logged',
+            tone: eventTone(e.event_type),
+          }))
+        setRows(inc); setSource('live')
+        timer = setTimeout(load, 12000)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { setRows(demoIncidentRows()); setSource('demo'); return }
+        setRows(demoIncidentRows()); setSource('demo'); timer = setTimeout(load, 12000)
+      }
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [limit])
+
+  return { rows, source }
 }


### PR DESCRIPTION
The `/incidents` **Incident History** table now reads from `GET /console/audit` (public) through the proxy — crit/warn audit events become incident rows (asset parsed from the payload, severity from the event type), with the mock incident list as fallback.

The featured **replay deck** and **spatial/sensor playback** stay mock — the verifier doesn't serve trajectories or sensor frames (per the gap audit).

- New `useIncidentHistory` hook (audit-derived rows, demo fallback).
- Incident History panel shows live/demo; duration shows "—" when live (audit has no duration).

Verified — clean `next build`, lint + types, 27/27 routes.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_