### PR TITLE
feat(console): live Fabric Telemetry panel on Runtime

### DIFF
--- a/console/app/runtime/page.tsx
+++ b/console/app/runtime/page.tsx
@@ -2,6 +2,7 @@ import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
 import { Spark } from '@/components/charts/charts'
 import { LatencyLines } from '@/components/charts/extra'
 import { TopologyMap } from '@/components/ui/topology-map'
+import { FabricTelemetryPanel } from '@/components/ui/fabric-telemetry'
 import { resources, latency, network, partitions, nodes, ddsTopics, ddsPeers, topoNodes, topoEdges } from '@/lib/runtime'
 import type { Tone } from '@/lib/types'
 
@@ -109,6 +110,9 @@ export default function RuntimePage() {
           <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-ice" /> transport</span>
         </div>
       </Panel>
+
+      {/* ── Live fabric governance telemetry ── */}
+      <FabricTelemetryPanel />
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
         <Panel title="Hypervisor & Partition Isolation" subtitle="QNX safety partition · isolated guests" dense>

--- a/console/components/ui/fabric-telemetry.tsx
+++ b/console/components/ui/fabric-telemetry.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { useFabricTelemetry } from '@/lib/api/hooks'
+import type { Tone } from '@/lib/types'
+
+// Live fabric governance telemetry (GET /fabric/telemetry, admin via proxy).
+// Self-contained client panel so the server-rendered Runtime page is untouched.
+export function FabricTelemetryPanel() {
+  const { data, source } = useFabricTelemetry(10000)
+  const postureRows = Object.entries(data.assets_by_posture)
+  const typeRows = Object.entries(data.assets_by_type)
+  const denialPct = data.fabric_denial_rate * 100
+
+  return (
+    <Panel
+      title="Fabric Telemetry"
+      subtitle="governed-command throughput · GET /fabric/telemetry"
+      action={source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}
+    >
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <Metric label="Active assets" value={`${data.active_assets} / ${data.total_assets}`} tone="ice" />
+        <Metric label="Commands · min" value={data.total_commands_per_minute.toFixed(0)} tone="safe" />
+        <Metric label="Denial rate" value={`${denialPct.toFixed(2)}%`} tone={denialPct > 5 ? 'crit' : denialPct > 1 ? 'warn' : 'safe'} />
+        <Metric label="Top denials" value={data.highest_denial_asset ?? '—'} tone={data.highest_denial_asset ? 'warn' : 'muted'} />
+      </div>
+
+      <div className="mt-5 grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <div>
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-wider text-faint">Assets by posture</div>
+          <ul className="space-y-2.5">
+            {postureRows.map(([posture, count]) => {
+              const tone = postureToneOf(posture)
+              return (
+                <li key={posture}>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="flex items-center gap-2 text-[12px] text-ink"><StatusDot tone={tone} />{posture}</span>
+                    <span className="font-mono text-[11px] text-muted">{count}</span>
+                  </div>
+                  <div className="mt-1.5"><Meter value={data.total_assets ? (count / data.total_assets) * 100 : 0} tone={tone} /></div>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+
+        <div>
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-wider text-faint">Assets by type</div>
+          <ul>
+            {typeRows.map(([type, count]) => (
+              <li key={type} className="flex items-center justify-between border-b border-line py-2 last:border-0 font-mono text-[12px]">
+                <span className="text-ink">{type}</span>
+                <span className="text-muted">{count}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </Panel>
+  )
+}
+
+function Metric({ label, value, tone }: { label: string; value: string; tone: Tone }) {
+  return (
+    <div className="rounded-lg border border-line bg-bg/40 p-3">
+      <div className="font-mono text-[10px] uppercase tracking-wider text-faint">{label}</div>
+      <div className={`mt-1.5 font-display text-[20px] font-semibold leading-none ${value.length > 9 ? 'text-[14px]' : ''} ${txt(tone)}`}>{value}</div>
+    </div>
+  )
+}
+
+function postureToneOf(p: string): Tone {
+  return p === 'Nominal' ? 'safe' : p === 'Degraded' ? 'warn' : p === 'LockedOut' ? 'crit' : 'muted'
+}
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }

--- a/console/lib/api/client.ts
+++ b/console/lib/api/client.ts
@@ -1,5 +1,5 @@
 import { PROXY_BASE } from './config'
-import type { AuditPage, AuditVerify, FleetNodePosture, HealthResponse } from './types'
+import type { AuditPage, AuditVerify, FabricTelemetry, FleetNodePosture, HealthResponse } from './types'
 
 // Sentinel thrown when the proxy reports demo mode (no backend configured).
 // Distinguishes "intentionally offline" from "backend down" for labeling.
@@ -26,4 +26,5 @@ export const kirra = {
     getJSON<FleetNodePosture>(`/fleet/posture/${encodeURIComponent(id)}`, signal),
   auditVerify: (signal?: AbortSignal) => getJSON<AuditVerify>('/system/audit/verify', signal),
   auditPage: (limit = 12, signal?: AbortSignal) => getJSON<AuditPage>(`/console/audit?limit=${limit}`, signal),
+  fabricTelemetry: (signal?: AbortSignal) => getJSON<FabricTelemetry>('/fabric/telemetry', signal),
 }

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { kirra, DemoMode } from './client'
-import type { AuditEntry, AuditVerify, FleetNodePosture, FleetPostureState, PostureStreamEvent } from './types'
+import type { AuditEntry, AuditVerify, FabricTelemetry, FleetNodePosture, FleetPostureState, PostureStreamEvent } from './types'
 import { robots } from '@/lib/mock'
 import { log as demoEvents, sources as demoSources } from '@/lib/events'
 import { incidents as demoIncidents } from '@/lib/incidents'
@@ -267,4 +267,42 @@ export function useIncidentHistory(limit = 80): { rows: IncidentRow[]; source: S
   }, [limit])
 
   return { rows, source }
+}
+
+// Fabric governance telemetry — GET /fabric/telemetry (admin via the proxy):
+// commands/min, denial rate, asset distribution. Demo fallback otherwise.
+const DEMO_FABRIC: FabricTelemetry = {
+  total_assets: 8,
+  active_assets: 6,
+  total_commands_per_minute: 312.4,
+  fabric_denial_rate: 0.012,
+  assets_by_type: { 'AMR-400': 2, 'Atlas-X': 2, 'Spot-V2': 2, 'Forklift-A': 2 },
+  assets_by_posture: { Nominal: 6, Degraded: 1, LockedOut: 1 },
+  highest_denial_asset: 'KIRRA-13',
+  computed_at_ms: Date.now(),
+}
+
+export function useFabricTelemetry(pollMs = 10000): { data: FabricTelemetry; source: Source } {
+  const [data, setData] = useState<FabricTelemetry>(DEMO_FABRIC)
+  const [source, setSource] = useState<Source>('demo')
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const t = await kirra.fabricTelemetry(ctrl.signal)
+        setData(t); setSource('live')
+        timer = setTimeout(load, pollMs)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { setSource('demo'); return }
+        setSource('demo'); timer = setTimeout(load, pollMs)
+      }
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [pollMs])
+
+  return { data, source }
 }

--- a/console/lib/api/types.ts
+++ b/console/lib/api/types.ts
@@ -56,6 +56,18 @@ export interface AuditPage {
   chain_intact: boolean
 }
 
+// Fabric governance telemetry — GET /fabric/telemetry (admin).
+export interface FabricTelemetry {
+  total_assets: number
+  active_assets: number
+  total_commands_per_minute: number
+  fabric_denial_rate: number
+  assets_by_type: Record<string, number>
+  assets_by_posture: Record<string, number>
+  highest_denial_asset: string | null
+  computed_at_ms: number
+}
+
 export function trustLabel(s: NodeTrustState): string {
   return typeof s === 'string' ? s : 'Untrusted'
 }


### PR DESCRIPTION
A live **Fabric Telemetry** panel on `/runtime`, fed by `GET /fabric/telemetry` (admin via the proxy — already in the allow-list).

- **Top metrics** — active/total assets, governed commands/min, fabric denial rate (color-graded), highest-denial asset
- **Assets by posture** — Nominal/Degraded/LockedOut with bars
- **Assets by type** — per-model distribution
- Live/demo pill, mock fallback

Implemented as a self-contained client component (`components/ui/fabric-telemetry.tsx`) so the server-rendered Runtime page only gains one import + one line. Plus the `FabricTelemetry` wire type, a `fabricTelemetry()` client method, and a `useFabricTelemetry` hook.

This one needs `KIRRA_ADMIN_TOKEN` set on the proxy to go live (admin-tier endpoint); demo fallback otherwise — so the public deploy is unchanged. Verified — clean `next build`, lint + types, 27/27 routes.

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_