### PR TITLE
feat(console): live posture-history trend on Digital Twin (/fleet/[id])

### DIFF
--- a/console/app/fleet/[id]/page.tsx
+++ b/console/app/fleet/[id]/page.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft } from 'lucide-react'
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
 import { PositionMap } from '@/components/ui/position-map'
 import { PoseView } from '@/components/ui/pose-view'
+import { PostureTrend } from '@/components/ui/posture-trend'
 import { Spark } from '@/components/charts/charts'
 import { twinById, twins } from '@/lib/fleet'
 import { postureTone } from '@/lib/mock'
@@ -65,6 +66,9 @@ export default async function TwinPage({ params }: { params: Promise<{ id: strin
           </div>
         </Panel>
       </div>
+
+      {/* ── Live posture-history trend ── */}
+      <PostureTrend nodeId={t.name} />
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
         <Panel className="xl:col-span-2" title="Kinematic Envelope" subtitle="proposed vs certified hard limits">

--- a/console/components/ui/posture-trend.tsx
+++ b/console/components/ui/posture-trend.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { Panel, Pill } from '@/components/ui/primitives'
+import { Spark } from '@/components/charts/charts'
+import { useNodeHistory } from '@/lib/api/hooks'
+
+// Live posture-history trend for a single asset (GET /fleet/history/{node_id},
+// public). Self-contained client panel so the server-rendered twin page is
+// untouched. Trend is the numeric posture level over time (Nominal=2…Locked=0).
+export function PostureTrend({ nodeId }: { nodeId: string }) {
+  const { points, events, lastReason, source } = useNodeHistory(nodeId)
+  const current = points.length ? points[points.length - 1].v : 2
+  const tone = current >= 2 ? 'safe' : current === 1 ? 'warn' : 'crit'
+  const label = current >= 2 ? 'Nominal' : current === 1 ? 'Degraded' : 'LockedOut'
+
+  return (
+    <Panel
+      title="Posture History"
+      subtitle={`${source === 'live' ? 'live · GET /fleet/history' : 'demo'} · ${events} events`}
+      action={source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}
+    >
+      <div className="mb-3 flex items-baseline gap-2">
+        <span className={`font-display text-xl font-semibold ${txt(tone)}`}>{label}</span>
+        <span className="font-mono text-[11px] text-faint">current posture</span>
+      </div>
+      <Spark data={points} color={tone} />
+      <div className="mt-3 flex items-center justify-between border-t border-line pt-3 font-mono text-[10px] text-faint">
+        <span>Nominal → Degraded → LockedOut</span>
+        <span className={lastReason ? txt(tone) : ''}>{lastReason ?? 'no faults in window'}</span>
+      </div>
+    </Panel>
+  )
+}
+
+function txt(t: 'safe' | 'warn' | 'crit') { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : 'text-crit' }

--- a/console/lib/api/client.ts
+++ b/console/lib/api/client.ts
@@ -1,5 +1,5 @@
 import { PROXY_BASE } from './config'
-import type { AuditPage, AuditVerify, FabricTelemetry, FleetNodePosture, HealthResponse } from './types'
+import type { AuditPage, AuditVerify, FabricTelemetry, FleetNodePosture, HealthResponse, NodeHistory } from './types'
 
 // Sentinel thrown when the proxy reports demo mode (no backend configured).
 // Distinguishes "intentionally offline" from "backend down" for labeling.
@@ -27,4 +27,6 @@ export const kirra = {
   auditVerify: (signal?: AbortSignal) => getJSON<AuditVerify>('/system/audit/verify', signal),
   auditPage: (limit = 12, signal?: AbortSignal) => getJSON<AuditPage>(`/console/audit?limit=${limit}`, signal),
   fabricTelemetry: (signal?: AbortSignal) => getJSON<FabricTelemetry>('/fabric/telemetry', signal),
+  nodeHistory: (id: string, signal?: AbortSignal) =>
+    getJSON<NodeHistory>(`/fleet/history/${encodeURIComponent(id)}`, signal),
 }

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -2,11 +2,12 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { kirra, DemoMode } from './client'
-import type { AuditEntry, AuditVerify, FabricTelemetry, FleetNodePosture, FleetPostureState, PostureStreamEvent } from './types'
+import type { AuditEntry, AuditVerify, FabricTelemetry, FleetNodePosture, FleetPostureState, NodeHistoryEntry, PostureStreamEvent } from './types'
 import { robots } from '@/lib/mock'
 import { log as demoEvents, sources as demoSources } from '@/lib/events'
 import { incidents as demoIncidents } from '@/lib/incidents'
-import type { Tone } from '@/lib/types'
+import { twins as demoTwins } from '@/lib/fleet'
+import type { Tone, SeriesPoint } from '@/lib/types'
 
 // Shared severity classifier for verifier event/audit types.
 export function eventTone(eventType: string): Tone {
@@ -305,4 +306,55 @@ export function useFabricTelemetry(pollMs = 10000): { data: FabricTelemetry; sou
   }, [pollMs])
 
   return { data, source }
+}
+
+// Per-node posture history (GET /fleet/history/{node_id}, public) → a numeric
+// posture-level trend (Nominal=2, Degraded=1, LockedOut=0) for a sparkline.
+const postureLevel = (p: FleetPostureState): number => (p === 'Nominal' ? 2 : p === 'Degraded' ? 1 : 0)
+
+function entryLevel(e: NodeHistoryEntry): number {
+  if (e.posture) return postureLevel(e.posture.propagated_status)
+  return eventTone(e.event_type) === 'crit' ? 0 : eventTone(e.event_type) === 'warn' ? 1 : 2
+}
+
+function demoNodeTrend(nodeId: string): { points: SeriesPoint[]; events: number; lastReason: string | null } {
+  const twin = demoTwins.find((t) => t.name === nodeId)
+  const end = twin ? postureLevel(twin.posture) : 2
+  // Mostly Nominal, converging to the node's current level over the last few steps.
+  const levels = [2, 2, 2, 2, 2, 2, 2, 2, Math.min(2, end + 1), end, end, end]
+  const now = Date.now()
+  const points = levels.map((v, i) => ({ t: new Date(now - (levels.length - i) * 1800000).toLocaleTimeString(), v }))
+  const lastReason = end === 0 ? 'lockout · human reset required' : end === 1 ? 'sensor confidence < 0.60 floor' : null
+  return { points, events: levels.length, lastReason }
+}
+
+export function useNodeHistory(nodeId: string, pollMs = 20000): {
+  points: SeriesPoint[]
+  events: number
+  lastReason: string | null
+  source: Source
+} {
+  const [state, setState] = useState(() => ({ ...demoNodeTrend(nodeId), source: 'demo' as Source }))
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const { history } = await kirra.nodeHistory(nodeId, ctrl.signal)
+        const chrono = [...history].reverse() // API returns newest-first
+        const points: SeriesPoint[] = chrono.map((e) => ({ t: new Date(e.created_at_ms).toLocaleTimeString(), v: entryLevel(e) }))
+        setState({ points, events: history.length, lastReason: history[0]?.reason ?? null, source: 'live' })
+        timer = setTimeout(load, pollMs)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { setState({ ...demoNodeTrend(nodeId), source: 'demo' }); return }
+        setState({ ...demoNodeTrend(nodeId), source: 'demo' }); timer = setTimeout(load, pollMs)
+      }
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [nodeId, pollMs])
+
+  return state
 }

--- a/console/lib/api/types.ts
+++ b/console/lib/api/types.ts
@@ -68,6 +68,18 @@ export interface FabricTelemetry {
   computed_at_ms: number
 }
 
+// Per-node posture history — GET /fleet/history/{node_id} (public).
+export interface NodeHistoryEntry {
+  event_type: string
+  posture: FleetNodePosture | null
+  reason: string | null
+  created_at_ms: number
+}
+export interface NodeHistory {
+  node_id: string
+  history: NodeHistoryEntry[]
+}
+
 export function trustLabel(s: NodeTrustState): string {
   return typeof s === 'string' ? s : 'Untrusted'
 }


### PR DESCRIPTION
## What

Adds a **live posture-history trend** to the Digital Twin page (`/fleet/[id]`). A new self-contained `PostureTrend` client panel reads the public `GET /fleet/history/{node_id}` endpoint through the read-only console proxy and renders the node's posture as a numeric-level sparkline over time (**Nominal = 2 → Degraded = 1 → LockedOut = 0**), with the current posture label and the most-recent fault reason.

This makes the twin's posture *real* — previously the twin page was entirely mock. It is the last genuinely-clean live win that needs **no admin token and no laptop**: `/fleet/history/{node_id}` is a public endpoint.

## How

- **`types.ts`** — `NodeHistoryEntry` / `NodeHistory` wire types mirroring the verifier serde shape.
- **`client.ts`** — `nodeHistory(id)` reader (same `getJSON` + DemoMode pattern as the other readers).
- **`hooks.ts`** — `useNodeHistory(nodeId)`: maps history (newest-first from the API) into a chronological posture-level series; demo fallback (`demoNodeTrend`) shaped from the existing twin roster so the public deploy is unchanged.
- **`posture-trend.tsx`** — new `PostureTrend` **client** component (Spark sparkline, live/demo pill, last-fault reason). Self-contained so the server-rendered twin page stays a server component.
- **`fleet/[id]/page.tsx`** — render `<PostureTrend nodeId={t.name} />` after the live-telemetry grid; one import + one element.

## Safety / scope

- Read-only public endpoint via the existing proxy; no token, no mutation, no new env.
- Falls back to demo data when no backend is configured (`x-kirra-mode: demo`) or unreachable — identical labeling discipline to the other live surfaces.
- Server twin page barely touched (import + element); all live logic isolated in the client sub-component.

## Verification

- `npx next build` → exit 0, 27/27 routes generated (lint + type validation enabled). No new warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_