### PR TITLE
feat(console): live federated-trust panel on Digital Twin (/fleet/[id])

### DIFF
--- a/console/app/fleet/[id]/page.tsx
+++ b/console/app/fleet/[id]/page.tsx
@@ -5,6 +5,7 @@ import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
 import { PositionMap } from '@/components/ui/position-map'
 import { PoseView } from '@/components/ui/pose-view'
 import { PostureTrend } from '@/components/ui/posture-trend'
+import { FederationPanel } from '@/components/ui/federation-panel'
 import { Spark } from '@/components/charts/charts'
 import { twinById, twins } from '@/lib/fleet'
 import { postureTone } from '@/lib/mock'
@@ -120,6 +121,9 @@ export default async function TwinPage({ params }: { params: Promise<{ id: strin
               </div>
             </div>
           </Panel>
+
+          {/* ── Live cross-controller federated trust ── */}
+          <FederationPanel nodeId={t.name} />
         </div>
       </div>
 

--- a/console/components/ui/federation-panel.tsx
+++ b/console/components/ui/federation-panel.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
+import { useFederationReports } from '@/lib/api/hooks'
+import { postureTone } from '@/lib/api/types'
+import type { Tone } from '@/lib/types'
+
+// Cross-controller federated trust reports for one asset (GET
+// /federation/reports/{asset_id}, public). Self-contained client panel so the
+// server-rendered twin page stays a server component.
+export function FederationPanel({ nodeId }: { nodeId: string }) {
+  const { rows, source } = useFederationReports(nodeId)
+
+  return (
+    <Panel
+      title="Federated Trust"
+      subtitle={source === 'live' ? 'live · GET /federation/reports' : 'demo · cross-controller'}
+      action={source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}
+    >
+      {rows.length === 0 ? (
+        <p className="py-2 font-mono text-[11px] text-faint">no federated reports for this asset</p>
+      ) : (
+        <ul className="space-y-2.5">
+          {rows.map((r, i) => {
+            const tone: Tone = r.expired ? 'muted' : postureTone(r.posture)
+            return (
+              <li key={`${r.source}-${i}`} className="flex items-center gap-3">
+                <StatusDot tone={tone} />
+                <span className="flex-1 truncate font-mono text-[12px] text-ink">{r.source}</span>
+                <span className={`font-mono text-[11px] ${txt(tone)}`}>{r.posture}</span>
+                <span className="w-28 text-right font-mono text-[10px] text-faint">{r.expiresLabel}</span>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </Panel>
+  )
+}
+
+function txt(t: Tone) {
+  return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted'
+}

--- a/console/lib/api/client.ts
+++ b/console/lib/api/client.ts
@@ -1,5 +1,5 @@
 import { PROXY_BASE } from './config'
-import type { AuditPage, AuditVerify, FabricTelemetry, FleetNodePosture, HealthResponse, NodeHistory } from './types'
+import type { AuditPage, AuditVerify, FabricTelemetry, FederationReports, FleetNodePosture, HealthResponse, NodeHistory } from './types'
 
 // Sentinel thrown when the proxy reports demo mode (no backend configured).
 // Distinguishes "intentionally offline" from "backend down" for labeling.
@@ -29,4 +29,6 @@ export const kirra = {
   fabricTelemetry: (signal?: AbortSignal) => getJSON<FabricTelemetry>('/fabric/telemetry', signal),
   nodeHistory: (id: string, signal?: AbortSignal) =>
     getJSON<NodeHistory>(`/fleet/history/${encodeURIComponent(id)}`, signal),
+  federationReports: (assetId: string, signal?: AbortSignal) =>
+    getJSON<FederationReports>(`/federation/reports/${encodeURIComponent(assetId)}`, signal),
 }

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { kirra, DemoMode } from './client'
-import type { AuditEntry, AuditVerify, FabricTelemetry, FleetNodePosture, FleetPostureState, NodeHistoryEntry, PostureStreamEvent } from './types'
+import type { AuditEntry, AuditVerify, FabricTelemetry, FederatedReport, FleetNodePosture, FleetPostureState, NodeHistoryEntry, PostureStreamEvent } from './types'
 import { robots } from '@/lib/mock'
 import { log as demoEvents, sources as demoSources } from '@/lib/events'
 import { incidents as demoIncidents } from '@/lib/incidents'
@@ -357,4 +357,55 @@ export function useNodeHistory(nodeId: string, pollMs = 20000): {
   }, [nodeId, pollMs])
 
   return state
+}
+
+// Cross-controller federated trust reports for an asset (GET
+// /federation/reports/{asset_id}, public). Normalizes the double-encoded posture
+// and flags freshness against each report's expiry. Demo fallback otherwise.
+export interface FedReportRow { source: string; posture: FleetPostureState; expired: boolean; expiresLabel: string }
+
+function normPosture(raw: string): FleetPostureState {
+  const s = raw.replace(/^"+|"+$/g, '')
+  return s === 'Degraded' ? 'Degraded' : s === 'LockedOut' ? 'LockedOut' : 'Nominal'
+}
+
+function fedRow(r: FederatedReport, now: number): FedReportRow {
+  const expired = r.expires_at_ms <= now
+  const secs = Math.round(Math.abs(r.expires_at_ms - now) / 1000)
+  return { source: r.source_controller_id, posture: normPosture(r.posture), expired, expiresLabel: expired ? `expired ${secs}s ago` : `valid ${secs}s` }
+}
+
+function demoFedReports(nodeId: string): FedReportRow[] {
+  const twin = demoTwins.find((t) => t.name === nodeId)
+  const posture = (twin?.posture ?? 'Nominal') as FleetPostureState
+  return [
+    { source: 'peer-controller-west', posture, expired: false, expiresLabel: 'valid 3s' },
+    { source: 'peer-controller-east', posture: 'Nominal', expired: false, expiresLabel: 'valid 4s' },
+  ]
+}
+
+export function useFederationReports(nodeId: string, pollMs = 15000): { rows: FedReportRow[]; source: Source } {
+  const [rows, setRows] = useState<FedReportRow[]>(() => demoFedReports(nodeId))
+  const [source, setSource] = useState<Source>('demo')
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const { reports } = await kirra.federationReports(nodeId, ctrl.signal)
+        const now = Date.now()
+        setRows(reports.map((r) => fedRow(r, now))); setSource('live')
+        timer = setTimeout(load, pollMs)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { setRows(demoFedReports(nodeId)); setSource('demo'); return }
+        setRows(demoFedReports(nodeId)); setSource('demo'); timer = setTimeout(load, pollMs)
+      }
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [nodeId, pollMs])
+
+  return { rows, source }
 }

--- a/console/lib/api/types.ts
+++ b/console/lib/api/types.ts
@@ -80,6 +80,21 @@ export interface NodeHistory {
   history: NodeHistoryEntry[]
 }
 
+// Cross-controller federated trust reports — GET /federation/reports/{asset_id}
+// (public). `posture` is the JSON-encoded FleetPosture (e.g. "\"Nominal\"") — the
+// store round-trips serde_json::to_string(&FleetPosture), so normalize on read.
+export interface FederatedReport {
+  source_controller_id: string
+  asset_id: string
+  posture: string
+  issued_at_ms: number
+  expires_at_ms: number
+}
+export interface FederationReports {
+  asset_id: string
+  reports: FederatedReport[]
+}
+
 export function trustLabel(s: NodeTrustState): string {
   return typeof s === 'string' ? s : 'Untrusted'
 }


### PR DESCRIPTION
## What

Adds a **Federated Trust** panel to the Digital Twin page (`/fleet/[id]`), beneath Hardware Attestation. It reads the public `GET /federation/reports/{asset_id}` endpoint through the read-only console proxy and lists each cross-controller report for that asset: the **source controller**, its **reported posture**, and **freshness** (valid / expired, relative to each report's `expires_at_ms`).

Like the posture-history trend, this needs **no admin token and no laptop** — `/federation/reports/{asset_id}` is a public endpoint, already on the proxy allow-list.

## How

- **`types.ts`** — `FederatedReport` / `FederationReports` wire types. Note: the verifier stores `posture` as `serde_json::to_string(&FleetPosture)` and round-trips that string, so the field arrives JSON-double-encoded (e.g. `"\"Nominal\""`); the hook normalizes it.
- **`client.ts`** — `federationReports(assetId)` reader.
- **`hooks.ts`** — `useFederationReports(nodeId)`: normalizes posture, flags expiry against `expires_at_ms`, demo fallback shaped from the twin roster.
- **`federation-panel.tsx`** — new `FederationPanel` **client** component (per-controller rows, posture-toned dot, expiry label, live/demo pill). Self-contained so the twin page stays a server component.
- **`fleet/[id]/page.tsx`** — render `<FederationPanel nodeId={t.name} />` inside the right column under Hardware Attestation.

## Safety / scope

- Read-only public endpoint via the existing proxy; no token, no mutation, no new env. The proxy allow-list already permits `^federation/reports/[^/]+$` — unchanged.
- Falls back to demo data when no backend is configured (`x-kirra-mode: demo`) or unreachable — same labeling discipline as the other live surfaces.
- Expired reports render muted (the panel never implies a stale cross-controller report is current).

## Verification

- `npx next build` → exit 0, 27/27 routes generated (lint + type validation enabled). No new warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_