### PR TITLE
feat(console): live fabric-state panel on Digital Twin (/fleet/[id])

### DIFF
--- a/console/app/fleet/[id]/page.tsx
+++ b/console/app/fleet/[id]/page.tsx
@@ -6,6 +6,7 @@ import { PositionMap } from '@/components/ui/position-map'
 import { PoseView } from '@/components/ui/pose-view'
 import { PostureTrend } from '@/components/ui/posture-trend'
 import { FederationPanel } from '@/components/ui/federation-panel'
+import { FabricStatePanel } from '@/components/ui/fabric-state-panel'
 import { Spark } from '@/components/charts/charts'
 import { twinById, twins } from '@/lib/fleet'
 import { postureTone } from '@/lib/mock'
@@ -124,6 +125,9 @@ export default async function TwinPage({ params }: { params: Promise<{ id: strin
 
           {/* ── Live cross-controller federated trust ── */}
           <FederationPanel nodeId={t.name} />
+
+          {/* ── Live cross-asset fabric governance state ── */}
+          <FabricStatePanel nodeId={t.name} />
         </div>
       </div>
 

--- a/console/components/ui/fabric-state-panel.tsx
+++ b/console/components/ui/fabric-state-panel.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { Panel, Pill } from '@/components/ui/primitives'
+import { useFabricState } from '@/lib/api/hooks'
+import { postureTone } from '@/lib/api/types'
+import type { Tone } from '@/lib/types'
+
+// Per-asset fabric governance state (GET /fabric/state, admin via the proxy):
+// the asset's posture in the cross-asset fabric DAG. Self-contained client panel
+// so the server-rendered twin page stays a server component. Admin-gated, so it
+// shows demo data unless the deploy is configured with a verifier token.
+export function FabricStatePanel({ nodeId }: { nodeId: string }) {
+  const { state, fabricGen, source } = useFabricState(nodeId)
+  const tone: Tone = state.inFabric ? postureTone(state.posture) : 'muted'
+
+  return (
+    <Panel
+      title="Fabric State"
+      subtitle={source === 'live' ? `live · GET /fabric/state · gen ${fabricGen}` : 'demo · cross-asset DAG'}
+      action={source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}
+    >
+      {state.inFabric ? (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="font-mono text-[11px] uppercase tracking-wider text-faint">Fabric posture</span>
+            <span className={`font-mono text-[12px] ${txt(tone)}`}>{state.posture}</span>
+          </div>
+          <KV k="Asset generation" v={`${state.generation}`} />
+          <KV k="Contributing nodes" v={state.contributingNodes.length ? state.contributingNodes.join(', ') : '—'} />
+          <div className="flex items-center justify-between border-t border-line pt-3">
+            <span className="font-mono text-[11px] uppercase tracking-wider text-faint">Blocked by</span>
+            <span className={`font-mono text-[12px] ${state.blockedBy.length ? 'text-crit' : 'text-muted'}`}>
+              {state.blockedBy.length ? state.blockedBy.join(', ') : 'nothing'}
+            </span>
+          </div>
+        </div>
+      ) : (
+        <p className="py-2 font-mono text-[11px] text-faint">asset not registered in the fabric</p>
+      )}
+    </Panel>
+  )
+}
+
+function KV({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{k}</span>
+      <span className="truncate font-mono text-xs text-ink">{v}</span>
+    </div>
+  )
+}
+
+function txt(t: Tone) {
+  return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted'
+}

--- a/console/lib/api/client.ts
+++ b/console/lib/api/client.ts
@@ -1,5 +1,5 @@
 import { PROXY_BASE } from './config'
-import type { AuditPage, AuditVerify, FabricTelemetry, FederationReports, FleetNodePosture, HealthResponse, NodeHistory } from './types'
+import type { AuditPage, AuditVerify, FabricState, FabricTelemetry, FederationReports, FleetNodePosture, HealthResponse, NodeHistory } from './types'
 
 // Sentinel thrown when the proxy reports demo mode (no backend configured).
 // Distinguishes "intentionally offline" from "backend down" for labeling.
@@ -31,4 +31,5 @@ export const kirra = {
     getJSON<NodeHistory>(`/fleet/history/${encodeURIComponent(id)}`, signal),
   federationReports: (assetId: string, signal?: AbortSignal) =>
     getJSON<FederationReports>(`/federation/reports/${encodeURIComponent(assetId)}`, signal),
+  fabricState: (signal?: AbortSignal) => getJSON<FabricState>('/fabric/state', signal),
 }

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { kirra, DemoMode } from './client'
-import type { AuditEntry, AuditVerify, FabricTelemetry, FederatedReport, FleetNodePosture, FleetPostureState, NodeHistoryEntry, PostureStreamEvent } from './types'
+import type { AuditEntry, AuditVerify, AssetPosture, FabricTelemetry, FederatedReport, FleetNodePosture, FleetPostureState, NodeHistoryEntry, PostureStreamEvent } from './types'
 import { robots } from '@/lib/mock'
 import { log as demoEvents, sources as demoSources } from '@/lib/events'
 import { incidents as demoIncidents } from '@/lib/incidents'
@@ -408,4 +408,62 @@ export function useFederationReports(nodeId: string, pollMs = 15000): { rows: Fe
   }, [nodeId, pollMs])
 
   return { rows, source }
+}
+
+// Per-asset fabric governance state (GET /fabric/state, admin via the proxy):
+// the asset's posture in the cross-asset fabric DAG, its generation, the nodes
+// contributing to it, and what (if anything) blocks it. Demo fallback otherwise.
+export interface FabricAssetState {
+  inFabric: boolean
+  posture: FleetPostureState
+  generation: number
+  contributingNodes: string[]
+  blockedBy: string[]
+}
+
+function demoFabricState(nodeId: string): { state: FabricAssetState; fabricGen: number } {
+  const twin = demoTwins.find((t) => t.name === nodeId)
+  const posture = (twin?.posture ?? 'Nominal') as FleetPostureState
+  return {
+    state: {
+      inFabric: true,
+      posture,
+      generation: 4471,
+      contributingNodes: [nodeId, 'fleet-dag'],
+      blockedBy: posture === 'LockedOut' ? ['cross_asset_propagation'] : [],
+    },
+    fabricGen: 4471,
+  }
+}
+
+export function useFabricState(nodeId: string, pollMs = 12000): {
+  state: FabricAssetState
+  fabricGen: number
+  source: Source
+} {
+  const [data, setData] = useState(() => ({ ...demoFabricState(nodeId), source: 'demo' as Source }))
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const fs = await kirra.fabricState(ctrl.signal)
+        const a: AssetPosture | undefined = fs.assets.find((x) => x.asset_id === nodeId)
+        const state: FabricAssetState = a
+          ? { inFabric: true, posture: a.posture, generation: a.generation, contributingNodes: a.contributing_nodes, blockedBy: a.blocked_by }
+          : { inFabric: false, posture: 'Nominal', generation: 0, contributingNodes: [], blockedBy: [] }
+        setData({ state, fabricGen: fs.fabric_generation, source: 'live' })
+        timer = setTimeout(load, pollMs)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { setData({ ...demoFabricState(nodeId), source: 'demo' }); return }
+        setData({ ...demoFabricState(nodeId), source: 'demo' }); timer = setTimeout(load, pollMs)
+      }
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [nodeId, pollMs])
+
+  return data
 }

--- a/console/lib/api/types.ts
+++ b/console/lib/api/types.ts
@@ -95,6 +95,27 @@ export interface FederationReports {
   reports: FederatedReport[]
 }
 
+// Fabric governance state — GET /fabric/state (admin). Per-asset posture in the
+// cross-asset fabric DAG plus fleet-wide counts. `posture` is a plain
+// FleetPosture (serde struct field — not double-encoded like federation).
+export interface AssetPosture {
+  asset_id: string
+  posture: FleetPostureState
+  generation: number
+  computed_at_ms: number
+  contributing_nodes: string[]
+  blocked_by: string[]
+}
+export interface FabricState {
+  total_assets: number
+  nominal_count: number
+  degraded_count: number
+  locked_out_count: number
+  assets: AssetPosture[]
+  fabric_generation: number
+  computed_at_ms: number
+}
+
 export function trustLabel(s: NodeTrustState): string {
   return typeof s === 'string' ? s : 'Untrusted'
 }


### PR DESCRIPTION
## What

Adds a **Fabric State** panel to the Digital Twin page (`/fleet/[id]`), beneath Federated Trust. It reads `GET /fabric/state` through the read-only console proxy and shows the asset's governance state in the cross-asset fabric DAG: its **fabric posture**, **generation**, **contributing nodes**, and **what blocks it** (if anything).

Unlike the posture-trend and federation panels, `/fabric/state` is **admin-gated**, so this panel shows demo data unless the deploy is configured with a verifier token (`KIRRA_ADMIN_TOKEN`) — it lights up automatically for a token-configured deploy, and degrades to demo otherwise like every other surface. This completes the trust/governance column on the twin (attestation → federation → fabric).

## How

- **`types.ts`** — `AssetPosture` / `FabricState` wire types. Note: `AssetPosture.posture` is a plain `FleetPosture` serde struct field (`"Nominal"`), **not** double-encoded like the federation `posture` string — no normalization needed.
- **`client.ts`** — `fabricState()` reader.
- **`hooks.ts`** — `useFabricState(nodeId)`: picks this asset's row out of `fabric_state.assets` (matched by `asset_id`), exposes `inFabric` so an unregistered asset renders an explicit empty state; demo fallback shaped from the twin roster.
- **`fabric-state-panel.tsx`** — new `FabricStatePanel` **client** component (fabric posture, generation, contributing nodes, blocked-by, live/demo pill). Self-contained so the twin page stays a server component.
- **`fleet/[id]/page.tsx`** — render `<FabricStatePanel nodeId={t.name} />` under Federated Trust in the right column.

## Safety / scope

- Read-only via the existing proxy; no token in the client, no mutation, no new env. The proxy allow-list already permits `^fabric/(assets|state|telemetry|causal-log)$` — unchanged.
- Admin-gated upstream: in a token-less deploy the proxy returns `x-kirra-mode: demo` (or 401/403 if misconfigured) and the panel falls back to demo — never blank, never implies live.
- An asset not present in the fabric renders "asset not registered in the fabric" rather than a misleading Nominal.

## Verification

- `npx next build` (Next.js 15.5.19) → exit 0, 27/27 routes generated (lint + type validation enabled). No new warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_