### PR TITLE
feat(console): wire Oversight decisions + Reports audit evidence live

### DIFF
--- a/console/app/oversight/page.tsx
+++ b/console/app/oversight/page.tsx
@@ -1,8 +1,13 @@
+'use client'
+
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
-import { tally, trace, traceSubject, recent, factors } from '@/lib/oversight'
+import { trace, traceSubject, factors } from '@/lib/oversight'
+import { useDecisions } from '@/lib/api/hooks'
 import type { Tone } from '@/lib/types'
 
 export default function OversightPage() {
+  const { recent, tally, source } = useDecisions()
+  const allowShare = tally.find((t) => t.label === 'Allowed')?.share ?? 0
   return (
     <div className="mx-auto max-w-[1500px] space-y-6 p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
@@ -12,7 +17,8 @@ export default function OversightPage() {
         </div>
         <div className="flex items-center gap-2">
           <Pill tone="ice">autoware.planner · v4.2</Pill>
-          <Pill tone="safe">99.0% allow rate · 24h</Pill>
+          <Pill tone="safe">{allowShare.toFixed(1)}% allow rate</Pill>
+          {source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}
         </div>
       </div>
 
@@ -71,7 +77,7 @@ export default function OversightPage() {
         </Panel>
       </div>
 
-      <Panel title="Recent Decisions" subtitle="live adjudication stream" dense>
+      <Panel title="Recent Decisions" subtitle={source === 'live' ? 'live · governor verdicts from the audit ledger' : 'demo · adjudication stream'} dense>
         <div className="overflow-x-auto">
           <table className="w-full min-w-[680px] text-left">
             <thead>

--- a/console/app/reports/page.tsx
+++ b/console/app/reports/page.tsx
@@ -1,5 +1,6 @@
 import { Download, FileText, ShieldCheck } from 'lucide-react'
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { AuditEvidence } from '@/components/ui/audit-evidence'
 import { reports, scheduled, rollout, rolloutVersion, versionShare } from '@/lib/reports'
 import type { Tone } from '@/lib/types'
 
@@ -15,6 +16,9 @@ export default function ReportsPage() {
           <FileText className="h-3.5 w-3.5" /> Generate report
         </button>
       </div>
+
+      {/* ── Live signed-evidence summary from the audit chain ── */}
+      <AuditEvidence />
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
         <Panel className="xl:col-span-2" title="Generated Reports" subtitle="signed evidence documents" dense>

--- a/console/components/ui/audit-evidence.tsx
+++ b/console/components/ui/audit-evidence.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { ShieldCheck, ShieldAlert } from 'lucide-react'
+import { Panel, Pill } from '@/components/ui/primitives'
+import { useAuditChain } from '@/lib/api/hooks'
+
+// Live signed-evidence summary for the Reports page, backed by the audit chain
+// (GET /system/audit/verify, admin via the proxy). This is the one genuinely
+// real artifact behind "generated reports": the tamper-evident hash-chained
+// ledger. Self-contained client panel; falls back to demo when no backend.
+export function AuditEvidence() {
+  const { verify, source } = useAuditChain()
+  const intact = verify.chain_intact && verify.verified
+  const tone = intact ? 'safe' : 'crit'
+
+  return (
+    <Panel
+      title="Audit Evidence"
+      subtitle={source === 'live' ? 'live · GET /system/audit/verify · tamper-evident ledger' : 'demo · hash-chained ledger'}
+      action={source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}
+    >
+      <div className="mb-4 flex items-center gap-3">
+        {intact ? <ShieldCheck className="h-6 w-6 text-safe" /> : <ShieldAlert className="h-6 w-6 text-crit" />}
+        <div>
+          <div className={`font-display text-lg font-semibold ${intact ? 'text-safe' : 'text-crit'}`}>
+            {intact ? 'Chain verified' : 'Chain integrity FAILED'}
+          </div>
+          <div className="font-mono text-[10px] text-faint">head {verify.head_status} · {verify.total_entries.toLocaleString()} entries</div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Stat label="Total entries" value={verify.total_entries.toLocaleString()} tone="ice" />
+        <Stat label="Signed" value={verify.signed_entries.toLocaleString()} tone={verify.unsigned_entries === 0 ? 'safe' : 'warn'} />
+        <Stat label="Unsigned" value={verify.unsigned_entries.toLocaleString()} tone={verify.unsigned_entries === 0 ? 'safe' : 'warn'} />
+        <Stat label="Signatures" value={verify.signature_valid ? 'valid' : 'invalid'} tone={verify.signature_valid ? 'safe' : 'crit'} />
+      </div>
+
+      <div className="mt-4 flex items-center justify-between border-t border-line pt-3">
+        <span className="font-mono text-[10px] uppercase tracking-wider text-faint">Latest hash</span>
+        <span className="truncate font-mono text-[11px] text-muted">{verify.latest_hash}</span>
+      </div>
+    </Panel>
+  )
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone: 'safe' | 'warn' | 'crit' | 'ice' }) {
+  const txt = tone === 'safe' ? 'text-safe' : tone === 'warn' ? 'text-warn' : tone === 'crit' ? 'text-crit' : 'text-ice'
+  return (
+    <div className="rounded-lg border border-line bg-bg/40 p-3">
+      <div className="font-mono text-[10px] uppercase tracking-wider text-faint">{label}</div>
+      <div className={`mt-1 font-display text-[18px] font-semibold leading-none ${txt}`}>{value}</div>
+    </div>
+  )
+}

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -7,6 +7,7 @@ import { robots } from '@/lib/mock'
 import { log as demoEvents, sources as demoSources } from '@/lib/events'
 import { incidents as demoIncidents } from '@/lib/incidents'
 import { twins as demoTwins } from '@/lib/fleet'
+import { recent as demoDecisions, tally as demoTally, type DecisionRow, type DecisionTally, type Verdict } from '@/lib/oversight'
 import type { Tone, SeriesPoint } from '@/lib/types'
 
 // Shared severity classifier for verifier event/audit types.
@@ -466,4 +467,69 @@ export function useFabricState(nodeId: string, pollMs = 12000): {
   }, [nodeId, pollMs])
 
   return data
+}
+
+// AI Decision Oversight — governor verdicts (ALLOW / CLAMP / DENY) and their
+// reason codes are recorded in the audit ledger (/console/audit, public). Filter
+// the ledger to adjudication events and tally them. Demo fallback otherwise.
+function classifyVerdict(eventType: string): Verdict | null {
+  if (/CLAMP/i.test(eventType)) return 'CLAMP'
+  if (/DENY|DENIED|BREACH|REJECT|BLOCKED|UNKNOWN_ACTION/i.test(eventType)) return 'DENY'
+  if (/ALLOW|ADMITTED|VALID|NOMINAL|PERMITTED/i.test(eventType)) return 'ALLOW'
+  return null
+}
+const verdictTone = (v: Verdict): Tone => (v === 'ALLOW' ? 'safe' : v === 'CLAMP' ? 'warn' : 'crit')
+function parseAction(payload: string, source: string): string {
+  return payload.match(/cmd_vel|drive_to_\w+|grasp_\w+|read_telemetry|motion[_ ]?command/i)?.[0] ?? source
+}
+
+export function useDecisions(limit = 60): { recent: DecisionRow[]; tally: DecisionTally[]; source: Source } {
+  const [recent, setRecent] = useState<DecisionRow[]>(() => demoDecisions)
+  const [tally, setTally] = useState<DecisionTally[]>(() => demoTally)
+  const [source, setSource] = useState<Source>('demo')
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const settleDemo = () => { setRecent(demoDecisions); setTally(demoTally); setSource('demo') }
+    const load = async () => {
+      try {
+        const page = await kirra.auditPage(limit, ctrl.signal)
+        const rows: DecisionRow[] = []
+        const counts = { ALLOW: 0, CLAMP: 0, DENY: 0 }
+        for (const e of page.entries) {
+          const v = classifyVerdict(e.event_type)
+          if (!v) continue
+          counts[v] += 1
+          rows.push({
+            id: String(e.id),
+            ts: new Date(e.timestamp_ms).toLocaleTimeString(),
+            asset: e.payload.match(/KIRRA-\d+/)?.[0] ?? '—',
+            actionType: parseAction(e.payload, e.source),
+            verdict: v,
+            reason: e.event_type,
+            tone: verdictTone(v),
+          })
+        }
+        const total = counts.ALLOW + counts.CLAMP + counts.DENY
+        const pct = (n: number) => (total ? Math.round((n / total) * 10000) / 100 : 0)
+        setRecent(rows)
+        setTally([
+          { label: 'Allowed', value: counts.ALLOW, tone: 'safe', share: pct(counts.ALLOW) },
+          { label: 'Clamped', value: counts.CLAMP, tone: 'warn', share: pct(counts.CLAMP) },
+          { label: 'Denied', value: counts.DENY, tone: 'crit', share: pct(counts.DENY) },
+        ])
+        setSource('live')
+        timer = setTimeout(load, 8000)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { settleDemo(); return }
+        settleDemo(); timer = setTimeout(load, 8000)
+      }
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [limit])
+
+  return { recent, tally, source }
 }


### PR DESCRIPTION
## What

Two "bucket-C" surfaces that derive from endpoints **that already exist** — no admin token, no laptop, no new backend:

### AI Decision Oversight (`/oversight`)
The **decision tally** (Allowed / Clamped / Denied) and the **Recent Decisions** table now read governor verdicts from the audit ledger (`/console/audit`, public), classifying each entry by event type (`CLAMP` → CLAMP; `DENY|BREACH|REJECT|BLOCKED|UNKNOWN_ACTION` → DENY; `ALLOW|ADMITTED|VALID|NOMINAL|PERMITTED` → ALLOW) and computing live shares. **Decision Trace** and **Explainability Factors** stay mock — that's per-decision detail the ledger doesn't carry in structured form, so wiring it would be fabrication.

### Reports & Releases (`/reports`)
A new **Audit Evidence** panel backed by the audit chain (`/system/audit/verify`) — the one genuinely real artifact behind "generated reports": the tamper-evident hash-chained ledger (chain-verified state, total/signed/unsigned entries, signature validity, head status, latest hash). **Scheduled exports** and the **software-rollout / OTA** section stay mock (no verifier data source — bucket D).

## How

- **`hooks.ts`** — `useDecisions(limit)`: classifies + tallies ledger adjudication events; demo fallback reuses the existing `@/lib/oversight` `recent`/`tally` (single source of truth for the row shapes).
- **`oversight/page.tsx`** — converted to a client component wired to `useDecisions`; live/demo pill + live allow-rate in the header.
- **`audit-evidence.tsx`** — new self-contained `AuditEvidence` client panel (reuses `useAuditChain`).
- **`reports/page.tsx`** — render `<AuditEvidence />` above the generated-reports grid; page stays a server component.

## Safety / scope

- Read-only via the existing proxy; no token in the client, no mutation, no new env or allow-list change (`/console/audit` and `/system/audit/verify` already permitted).
- Both fall back to demo when no backend is configured (`x-kirra-mode: demo`) — same labeling discipline as every other live surface. Oversight renders a live-but-empty table honestly if the ledger has no adjudication events, rather than inventing rows.

## Verification

- `npx next build` (Next.js 15.5.19) → exit 0, 27/27 routes (`/oversight` and `/reports` now client/live). Lint + type validation enabled; no new warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_