### PR TITLE
fix(console): impossible clock-hour axis labels + posture casing drift

### DIFF
--- a/console/app/fleet/page.tsx
+++ b/console/app/fleet/page.tsx
@@ -74,7 +74,7 @@ export default function FleetPage() {
               </div>
 
               <div className="mt-4 flex items-center justify-between">
-                <span className={`font-mono text-[11px] uppercase tracking-wider ${txt(tone)}`}>{posture}</span>
+                <span className={`font-mono text-[11px] font-semibold ${txt(tone)}`}>{posture}</span>
                 <span className="font-mono text-[11px] text-muted">{t.status}</span>
               </div>
 

--- a/console/lib/analytics.ts
+++ b/console/lib/analytics.ts
@@ -9,7 +9,7 @@ function g(n: number, b: number, j: number, drift = 0): SeriesPoint[] {
   for (let i = 0; i < n; i++) {
     v += (Math.random() - 0.5) * j + drift
     v = Math.max(0, v)
-    o.push({ t: `${String(i).padStart(2, '0')}:00`, v: Math.round(v * 10) / 10 })
+    o.push({ t: `${String(i % 24).padStart(2, '0')}:00`, v: Math.round(v * 10) / 10 })
   }
   return o
 }
@@ -38,13 +38,13 @@ export const riskForecast: RiskRow[] = (() => {
   for (let i = 0; i < 12; i++) {
     obs += (Math.random() - 0.45) * 3
     obs = Math.max(6, Math.min(40, obs))
-    rows.push({ t: `${String(8 + i).padStart(2, '0')}:00`, observed: Math.round(obs), forecast: Math.round(obs), upper: Math.round(obs + 4) })
+    rows.push({ t: `${String((8 + i) % 24).padStart(2, '0')}:00`, observed: Math.round(obs), forecast: Math.round(obs), upper: Math.round(obs + 4) })
   }
   // forward horizon — observed drops out, forecast climbs (congestion + radar drift)
   let fc = rows[rows.length - 1].forecast
   for (let i = 0; i < 6; i++) {
     fc += 2.4 + Math.random()
-    rows.push({ t: `${String(20 + i).padStart(2, '0')}:00`, observed: null, forecast: Math.round(fc), upper: Math.round(fc + 6 + i) })
+    rows.push({ t: `${String((20 + i) % 24).padStart(2, '0')}:00`, observed: null, forecast: Math.round(fc), upper: Math.round(fc + 6 + i) })
   }
   return rows
 })()

--- a/console/lib/runtime.ts
+++ b/console/lib/runtime.ts
@@ -6,7 +6,7 @@ function g(n: number, b: number, j: number): SeriesPoint[] {
   for (let i = 0; i < n; i++) {
     v += (Math.random() - 0.5) * j
     v = Math.max(0, v)
-    o.push({ t: `${String(i).padStart(2, '0')}:00`, v: Math.round(v) })
+    o.push({ t: `${String(i % 24).padStart(2, '0')}:00`, v: Math.round(v) })
   }
   return o
 }
@@ -26,7 +26,7 @@ export const resources: Resource[] = [
 
 export const latency: LatPoint[] = Array.from({ length: 24 }).map((_, i) => {
   const base = 7 + Math.round(Math.sin(i / 3) * 2)
-  return { t: `${String(i).padStart(2, '0')}:00`, p50: base + Math.round(Math.random() * 2), p99: base + 8 + Math.round(Math.random() * 8) }
+  return { t: `${String(i % 24).padStart(2, '0')}:00`, p50: base + Math.round(Math.random() * 2), p99: base + 8 + Math.round(Math.random() * 8) }
 })
 
 export const network: NetStat[] = [

--- a/console/lib/telemetry.ts
+++ b/console/lib/telemetry.ts
@@ -6,7 +6,7 @@ function g(n: number, b: number, j: number, drift = 0): SeriesPoint[] {
   for (let i = 0; i < n; i++) {
     v += (Math.random() - 0.5) * j + drift
     v = Math.max(0, v)
-    o.push({ t: `${String(i).padStart(2, '0')}:00`, v: Math.round(v * 10) / 10 })
+    o.push({ t: `${String(i % 24).padStart(2, '0')}:00`, v: Math.round(v * 10) / 10 })
   }
   return o
 }
@@ -20,7 +20,7 @@ export const velocity: SeriesPoint[] = g(30, 1.2, 0.5)
 export const battery: SeriesPoint[] = g(30, 74, 0.6, -0.4)
 
 export const actuator: ActPoint[] = Array.from({ length: 30 }).map((_, i) => ({
-  t: `${String(i).padStart(2, '0')}:00`,
+  t: `${String(i % 24).padStart(2, '0')}:00`,
   steer: Math.round(Math.sin(i / 4) * 18),
   throttle: 30 + Math.round(Math.abs(Math.sin(i / 5)) * 40),
 }))


### PR DESCRIPTION
Two confirmed polish fixes from a mobile-viewport review of the deployed console.

## 1. Impossible clock-hour axis labels (25:00, 29:00)
Several mock time-series generators formatted X-axis labels as `${i}:00` where the index ran past a single day, producing impossible clock strings:
- `lib/analytics.ts` — the operational-risk **forecast horizon** (`20 + i` → up to `25:00`).
- `lib/telemetry.ts` — the 30-point **velocity / battery / actuator** series (`i` up to `29` → `29:00`).
- `lib/runtime.ts` — wrapped defensively (its series are ≤24, but unified for consistency).

Fix: wrap the hour with `% 24` — the convention **already used in `lib/mock.ts`** — so rolling windows cross midnight cleanly (e.g. `…22:00, 23:00, 00:00, 01:00`). Recharts plots by array index, so series order is preserved; only the label string changes.

## 2. Posture enum casing drift (LOCKEDOUT vs LockedOut)
On the **same Fleet page**, the `FleetPosture` value rendered two different ways:
- Asset **cards** (`app/fleet/page.tsx:77`) applied a CSS `uppercase` class → `LOCKEDOUT`.
- Fleet **Roster** table (`:122`) and the **live posture badges** (`app/live/page.tsx`) showed the raw value → `LockedOut`.

Fix: drop `uppercase` on the card so the enum reads in its canonical PascalCase form (matching the API serde value, the roster, and the live page). **Pill chips keep their uppercase styling** — that's the intended chip idiom, applied uniformly to all chips, not to inline enum values.

## Not changed (and why)
- **Table truncation / horizontal clipping** — the data tables already use the recommended responsive pattern (`overflow-x-auto` + `min-w-[…]`), i.e. native horizontal scroll on narrow viewports; the Gantt segments already carry `title=` tooltips for full-text reveal. No code bug to fix there.
- **Gantt micro-icons, regional log metatags, tap-to-expand JSON modals** — these are UX enhancements / design decisions (and the regional tags depend on the per-site backend, issue #397), so they're deliberately out of scope for this fix and noted for a follow-up.

## Verification
- `npx next build` (Next.js 15.5.19) → exit 0, 27/27 routes. Mock-data + class-only changes; no type/lint impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_