### PR TITLE
feat(console): scroll-shadow affordance on wide tables (mobile)

### DIFF
--- a/console/app/globals.css
+++ b/console/app/globals.css
@@ -31,6 +31,23 @@
   .scrollbar-thin::-webkit-scrollbar-track { background: transparent; }
 }
 
+/* Horizontal scroll-shadow affordance for wide tables on narrow viewports.
+   Pure CSS (background-attachment: local): the solid "cover" gradients (panel
+   colour) hide the edge shadows when scrolled to that edge, so a shadow only
+   shows when more table is off-screen — signalling swipe-to-reveal. Scoped to
+   table scroll wrappers via :has(> table); degrades to a plain scroll where
+   :has is unsupported. */
+.overflow-x-auto:has(> table) {
+  background:
+    linear-gradient(to right, rgb(var(--panel)) 30%, rgb(var(--panel) / 0)) left center,
+    linear-gradient(to left, rgb(var(--panel)) 30%, rgb(var(--panel) / 0)) right center,
+    radial-gradient(farthest-side at 0 50%, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0)) left center,
+    radial-gradient(farthest-side at 100% 50%, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0)) right center;
+  background-repeat: no-repeat;
+  background-size: 44px 100%, 44px 100%, 16px 100%, 16px 100%;
+  background-attachment: local, local, scroll, scroll;
+}
+
 /* Subtle mission-control environmental layer (grid + glow), restrained. */
 .app-bg {
   position: fixed;


### PR DESCRIPTION
Addresses the mobile-review point that wide data tables clip at the viewport edge without an obvious cue that they scroll.

## What
A pure-CSS horizontal **scroll-shadow** on the table scroll wrappers: a soft shadow appears at whichever edge has more table off-screen, signalling swipe-to-reveal, and disappears once you reach that edge.

## How
The classic `background-attachment: local` technique — four layered backgrounds on the scroll container: two solid **panel-colour "cover"** gradients (`local`, so they ride with the content) sit over two **shadow** gradients (`scroll`, fixed to the container edges). At an edge the cover hides the shadow; scroll away and the shadow shows.

- **Zero per-page churn:** one rule in `globals.css`, scoped via `.overflow-x-auto:has(> table)` so it targets only the table wrappers — chart/SVG scroll containers are untouched.
- **Graceful degradation:** where `:has()` isn't supported the rule is simply ignored and tables scroll exactly as before (the existing `overflow-x-auto` + `min-w-[…]` is unchanged).
- Cover colour uses the existing `--panel` token (`rgb(var(--panel) / 0)` for the fade), so it matches the dense-panel surface the tables sit on.

## Scope
This was the one enhancement selected from the review's list. The other three (tap-to-expand JSON modals, Gantt micro-icons, regional log metatags) are intentionally not included — the regional tags also depend on the per-site backend (#397).

## Verification
- `npx next build` (Next.js 15.5.19) → exit 0, 27/27 routes. CSS-only change; no JS/type/lint impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_