### PR TITLE
feat(console): tap-to-expand raw-entry modal on forensic logs

### DIFF
--- a/console/app/compliance/page.tsx
+++ b/console/app/compliance/page.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { useRawModal } from '@/components/ui/raw-modal'
 import { useAuditChain } from '@/lib/api/hooks'
 import { certs, tests, sbom, firmware } from '@/lib/compliance'
 import type { Tone } from '@/lib/types'
 
 export default function CompliancePage() {
   const audit = useAuditChain(15000)
+  const raw = useRawModal()
   const totalPassed = tests.reduce((a, t) => a + t.passed, 0)
   const totalTests = tests.reduce((a, t) => a + t.total, 0)
   const coverage = ((totalPassed / totalTests) * 100).toFixed(1)
@@ -68,7 +70,12 @@ export default function CompliancePage() {
         <Panel className="xl:col-span-2" title="Audit Ledger" subtitle="tamper-evident enforcement events · GET /console/audit" dense>
           <ul>
             {audit.entries.map((e) => (
-              <li key={e.id} className="flex items-center gap-4 border-b border-line px-4 py-3 last:border-0">
+              <li
+                key={e.id}
+                onClick={() => raw.open({ title: e.event_type, subtitle: `audit entry #${e.id} · ${e.source}`, data: e })}
+                className="flex cursor-pointer items-center gap-4 border-b border-line px-4 py-3 last:border-0 hover:bg-white/[0.02]"
+                title="tap for raw entry"
+              >
                 <StatusDot tone={auditTone(e.event_type)} />
                 <span className="w-20 shrink-0 font-mono text-[10px] text-faint">{new Date(e.timestamp_ms).toLocaleTimeString()}</span>
                 <span className="w-24 shrink-0 font-mono text-[10px] uppercase tracking-wider text-muted">{e.source}</span>
@@ -159,6 +166,7 @@ export default function CompliancePage() {
           </p>
         </Panel>
       </div>
+      {raw.modal}
     </div>
   )
 }

--- a/console/app/incidents/page.tsx
+++ b/console/app/incidents/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { Play, Pause, SkipBack, RotateCcw } from 'lucide-react'
 import { Panel, Pill, StatusDot, Meter } from '@/components/ui/primitives'
 import { ReplayMap } from '@/components/ui/replay-map'
+import { useRawModal } from '@/components/ui/raw-modal'
 import { useIncidentHistory } from '@/lib/api/hooks'
 import { replay, featured, rootCause, replaySpatial, replayActors, replayHazard } from '@/lib/incidents'
 import { postureTone } from '@/lib/mock'
@@ -17,6 +18,7 @@ export default function IncidentsPage() {
   const frame = replay[i]
   const spatial = replaySpatial[i]
   const history = useIncidentHistory(80)
+  const raw = useRawModal()
 
   useEffect(() => {
     if (!playing) return
@@ -153,7 +155,9 @@ export default function IncidentsPage() {
             {replay.map((f, idx) => (
               <li
                 key={idx}
-                className={`flex items-center gap-4 border-b border-line px-4 py-2.5 last:border-0 ${idx === i ? 'bg-white/[0.04]' : idx > i ? 'opacity-40' : ''}`}
+                onClick={() => { setPlaying(false); setI(idx); raw.open({ title: `Frame ${f.t > 0 ? '+' : ''}${f.t}s`, subtitle: `${f.clock} · ${f.verdict}`, data: f }) }}
+                className={`flex cursor-pointer items-center gap-4 border-b border-line px-4 py-2.5 last:border-0 hover:bg-white/[0.02] ${idx === i ? 'bg-white/[0.04]' : idx > i ? 'opacity-40' : ''}`}
+                title="tap for raw frame"
               >
                 <span className="w-10 shrink-0 font-mono text-[11px] text-faint">{f.t > 0 ? '+' : ''}{f.t}s</span>
                 <span className="w-16 shrink-0 font-mono text-[11px] text-muted">{f.clock}</span>
@@ -200,7 +204,12 @@ export default function IncidentsPage() {
             </thead>
             <tbody className="font-mono text-[12px]">
               {history.rows.map((inc) => (
-                <tr key={inc.id} className={`border-b border-line last:border-0 hover:bg-white/[0.02] ${inc.id === featured.id ? 'bg-white/[0.03]' : ''}`}>
+                <tr
+                  key={inc.id}
+                  onClick={() => raw.open({ title: inc.title, subtitle: `${inc.id} · ${inc.asset}`, data: inc })}
+                  className={`cursor-pointer border-b border-line last:border-0 hover:bg-white/[0.02] ${inc.id === featured.id ? 'bg-white/[0.03]' : ''}`}
+                  title="tap for raw incident"
+                >
                   <td className={`px-4 py-2.5 ${txt(inc.tone)}`}>{inc.id}</td>
                   <td className="px-4 py-2.5 text-faint">{inc.ts}</td>
                   <td className="px-4 py-2.5 text-ink">{inc.asset}</td>
@@ -213,6 +222,7 @@ export default function IncidentsPage() {
           </table>
         </div>
       </Panel>
+      {raw.modal}
     </div>
   )
 }

--- a/console/app/oversight/page.tsx
+++ b/console/app/oversight/page.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { useRawModal } from '@/components/ui/raw-modal'
 import { trace, traceSubject, factors } from '@/lib/oversight'
 import { useDecisions } from '@/lib/api/hooks'
 import type { Tone } from '@/lib/types'
 
 export default function OversightPage() {
   const { recent, tally, source } = useDecisions()
+  const raw = useRawModal()
   const allowShare = tally.find((t) => t.label === 'Allowed')?.share ?? 0
   return (
     <div className="mx-auto max-w-[1500px] space-y-6 p-6">
@@ -91,7 +93,12 @@ export default function OversightPage() {
             </thead>
             <tbody className="font-mono text-[12px]">
               {recent.map((d) => (
-                <tr key={d.id} className="border-b border-line last:border-0 hover:bg-white/[0.02]">
+                <tr
+                  key={d.id}
+                  onClick={() => raw.open({ title: d.reason, subtitle: `${d.verdict} · ${d.asset} · ${d.actionType}`, data: d })}
+                  className="cursor-pointer border-b border-line last:border-0 hover:bg-white/[0.02]"
+                  title="tap for raw decision"
+                >
                   <td className="px-4 py-2.5 text-faint">{d.ts}</td>
                   <td className="px-4 py-2.5 text-ink">{d.asset}</td>
                   <td className="px-4 py-2.5 text-muted">{d.actionType}</td>
@@ -103,6 +110,7 @@ export default function OversightPage() {
           </table>
         </div>
       </Panel>
+      {raw.modal}
     </div>
   )
 }

--- a/console/components/ui/raw-modal.tsx
+++ b/console/components/ui/raw-modal.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+import { X, Copy, Check } from 'lucide-react'
+
+// Tap-to-expand raw-entry modal — for "quick raw log extraction" from forensic
+// tables (audit ledger, governor decisions, incidents). Shows the full entry as
+// pretty-printed JSON (or raw text) with copy-to-clipboard; closes on Escape or
+// backdrop click. Self-contained client component.
+export function RawModal({ title, subtitle, data, onClose }: {
+  title: string
+  subtitle?: string
+  data: unknown
+  onClose: () => void
+}) {
+  const [copied, setCopied] = useState(false)
+  const text = typeof data === 'string' ? data : JSON.stringify(data, null, 2)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const copy = async () => {
+    try { await navigator.clipboard.writeText(text); setCopied(true); setTimeout(() => setCopied(false), 1500) } catch { /* clipboard blocked */ }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center p-0 sm:items-center sm:p-4" role="dialog" aria-modal="true" aria-label={title}>
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative z-10 flex max-h-[80vh] w-full max-w-[640px] flex-col rounded-t-2xl border border-line bg-panel shadow-panel sm:rounded-xl">
+        <div className="flex items-start justify-between gap-4 border-b border-line px-4 py-3">
+          <div className="min-w-0">
+            <div className="truncate font-display text-[15px] font-semibold text-ink">{title}</div>
+            {subtitle && <div className="truncate font-mono text-[10px] text-faint">{subtitle}</div>}
+          </div>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <button
+              onClick={copy}
+              className="flex items-center gap-1.5 rounded-lg border border-line px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider text-faint hover:bg-white/[0.04] hover:text-ink"
+            >
+              {copied ? <Check className="h-3 w-3 text-safe" /> : <Copy className="h-3 w-3" />}
+              {copied ? 'copied' : 'copy'}
+            </button>
+            <button onClick={onClose} aria-label="close" className="flex h-7 w-7 items-center justify-center rounded-lg border border-line text-faint hover:bg-white/[0.04] hover:text-ink">
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+        <pre className="scrollbar-thin overflow-auto px-4 py-3 font-mono text-[11px] leading-relaxed text-muted">{text}</pre>
+      </div>
+    </div>
+  )
+}
+
+// Manages a single raw-modal selection for a page. Rows call `open({...})`;
+// render `{modal}` once near the page root.
+export function useRawModal(): {
+  open: (entry: { title: string; subtitle?: string; data: unknown }) => void
+  modal: ReactNode
+} {
+  const [entry, setEntry] = useState<{ title: string; subtitle?: string; data: unknown } | null>(null)
+  return {
+    open: setEntry,
+    modal: entry ? <RawModal title={entry.title} subtitle={entry.subtitle} data={entry.data} onClose={() => setEntry(null)} /> : null,
+  }
+}


### PR DESCRIPTION
Implements the review's "wrap truncated cells with simple touch targets that open a crisp JSON text modal window for quick raw log extraction."

## What
Rows in the forensic tables/logs become tappable and open a crisp modal showing the **full entry as pretty-printed JSON**, with a **copy-to-clipboard** button and Escape / backdrop-click to close. It renders as a **bottom sheet on mobile** and a **centered dialog on desktop** — so the truncated `…` cells on narrow screens are now fully recoverable with one tap.

Wired into the logs the review named:
- **Compliance → Audit Ledger** — the full `AuditEntry` (timestamps, `prev_hash`/`entry_hash`, signature, payload) — the richest forensic record.
- **Oversight → Recent Decisions** — the governor verdict row (verdict, reason code, asset, action).
- **Incidents → Frame Log** — the second-by-second reconstruction frame (tapping also scrubs the replay to that frame).
- **Incidents → Incident History** — the incident row.

## How
- **`raw-modal.tsx`** — new `RawModal` component + a `useRawModal()` hook. The hook owns a single selection per page; a row calls `raw.open({ title, subtitle, data })` and the page renders `{raw.modal}` once near its root. `data` is stringified with `JSON.stringify(…, null, 2)`, or shown verbatim if already a string.
- Per page: one import, one hook call, an `onClick` + `cursor-pointer` + `title="tap for raw …"` on the rows, and `{raw.modal}` before the root close. No row markup or existing behaviour changed otherwise (the Frame Log row still highlights/scrubs).

## Accessibility / UX
- `role="dialog"` + `aria-modal` + `aria-label`; Escape closes; backdrop click closes; copy button has a transient "copied" state.
- Clipboard write is wrapped in try/catch (degrades silently where the API is blocked).

## Scope
This was the second item picked from the review. Gantt micro-icons and regional log metatags remain deferred (the latter depends on the per-site backend, #397).

## Verification
- `npx next build` (Next.js 15.5.19) → exit 0, 27/27 routes. `/incidents` and `/oversight` grew slightly (modal wiring); no type/lint issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_