### PR TITLE
feat(console): Gantt micro-icons replace cropped phase text

### DIFF
--- a/console/app/missions/page.tsx
+++ b/console/app/missions/page.tsx
@@ -1,3 +1,4 @@
+import { MapPin, Container, Repeat, BatteryCharging, Radar, Pause, Lock, Clock, Circle, type LucideIcon } from 'lucide-react'
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
 import { mission, phases, waypoints, tasks, risk, operatorInterventions, gantt, ganttWindow } from '@/lib/missions'
 import type { Tone } from '@/lib/types'
@@ -49,11 +50,11 @@ export default function MissionsPage() {
                 {row.segments.map((s, i) => (
                   <div
                     key={i}
-                    className={`absolute top-1 flex h-5 items-center overflow-hidden rounded ${segBg(s.tone)} ${s.tone === 'muted' ? 'border border-dashed border-line' : ''}`}
+                    className={`absolute top-1 flex h-5 items-center justify-center overflow-hidden rounded ${segBg(s.tone)} ${s.tone === 'muted' ? 'border border-dashed border-line' : ''}`}
                     style={{ left: `${s.start * 100}%`, width: `${(s.end - s.start) * 100}%` }}
                     title={s.phase}
                   >
-                    <span className={`truncate px-1.5 font-mono text-[9px] ${s.tone === 'muted' ? 'text-faint' : 'text-bg'}`}>{s.phase}</span>
+                    <SegIcon phase={s.phase} muted={s.tone === 'muted'} />
                   </div>
                 ))}
               </div>
@@ -68,6 +69,12 @@ export default function MissionsPage() {
           <Legend tone="crit" label="lockout" />
           <Legend tone="muted" label="queued" />
           <span className="ml-auto flex items-center gap-1.5"><span className="h-3 w-px bg-ice/70" /> now</span>
+        </div>
+
+        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-[10px] text-faint">
+          {PHASE_LEGEND.map(({ Icon, label }) => (
+            <span key={label} className="flex items-center gap-1.5"><Icon className="h-3 w-3" strokeWidth={2.5} /> {label}</span>
+          ))}
         </div>
       </Panel>
 
@@ -162,6 +169,38 @@ function Legend({ tone, label }: { tone: Tone; label: string }) {
 }
 
 function segBg(t: Tone) { return t === 'safe' ? 'bg-safe' : t === 'warn' ? 'bg-warn' : t === 'crit' ? 'bg-crit' : t === 'ice' ? 'bg-ice' : 'bg-muted/40' }
+
+// Gantt phase → micro-icon. The 18 mission phases group into a small scannable
+// vocabulary so tiny timeline blocks show an icon (with a `title` tooltip + the
+// legend) instead of a cropped word.
+const PHASE_LEGEND: { Icon: LucideIcon; label: string }[] = [
+  { Icon: MapPin, label: 'transit' },
+  { Icon: Container, label: 'load / unload' },
+  { Icon: Repeat, label: 'loop' },
+  { Icon: BatteryCharging, label: 'charge' },
+  { Icon: Radar, label: 'survey' },
+  { Icon: Pause, label: 'hold' },
+  { Icon: Lock, label: 'lockout' },
+  { Icon: Clock, label: 'queued' },
+]
+
+function phaseIcon(phase: string): LucideIcon {
+  const p = phase.toLowerCase()
+  if (p.includes('lockout')) return Lock
+  if (p.includes('hold')) return Pause
+  if (p.includes('charge')) return BatteryCharging
+  if (p.includes('loop')) return Repeat
+  if (p.includes('survey')) return Radar
+  if (p.includes('queued')) return Clock
+  if (/transit|dispatch|return/.test(p)) return MapPin
+  if (/pick|place|haul|drop|stage/.test(p)) return Container
+  return Circle
+}
+
+function SegIcon({ phase, muted }: { phase: string; muted: boolean }) {
+  const Icon = phaseIcon(phase)
+  return <Icon className={`h-3 w-3 ${muted ? 'text-faint' : 'text-bg'}`} strokeWidth={2.5} />
+}
 
 // Convert a window fraction to a wall-clock label for the 10:00–14:00 window.
 function clock(frac: number): string {


### PR DESCRIPTION
Implements the review's "Transition Gantt Blocks to Micro-Icons" — the Fleet Mission Gantt blocks were squeezing literal phase strings into tiny timeline cells, cropping them to `Surv…`, `HO…`, `L…`.

## What
Each timeline block now shows a **centered micro-icon** instead of a truncated label. The 18 distinct mission phases map to a small, scannable 8-icon vocabulary:

| Icon | Phases |
|------|--------|
| 📍 MapPin — transit | Transit / Transit A / Transit B / Dispatch / Return |
| 📦 Container — load/unload | Pick / Place / Haul / Drop / Stage |
| 🔁 Repeat — loop | Loop 1 / 2 / 3 |
| 🔋 BatteryCharging — charge | Charge |
| 📡 Radar — survey | Survey |
| ⏸ Pause — hold | HOLD (degraded) |
| 🔒 Lock — lockout | LOCKOUT |
| 🕐 Clock — queued | Queued |

The full phase name is preserved on the existing `title` tooltip (hover / long-press), and an **icon legend** is added below the chart. Bar **colours still encode status** (the existing colour legend is unchanged), so no information is lost — just no more cropped words.

## How
- `phaseIcon(phase)` maps a phase string to a lucide icon (regex on a lowercased name, with a `Circle` fallback for anything unmapped).
- `SegIcon` renders the icon (`text-bg` on coloured bars, `text-faint` on muted/queued bars); the block is now `justify-center`.
- `PHASE_LEGEND` drives the new legend row.
- Page stays a server component (icons are static, no client JS needed).

## Verification
- `npx next build` (Next.js 15.5.19) → exit 0, 27/27 routes. Presentation-only change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_