### PR TITLE
chore(console): wire ESLint into the build (was silently skipped)

### DIFF
--- a/console/.eslintrc.json
+++ b/console/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": "next/core-web-vitals",
+  "ignorePatterns": [".next/", "node_modules/", "next-env.d.ts"]
+}

--- a/console/app/explorer/page.tsx
+++ b/console/app/explorer/page.tsx
@@ -14,20 +14,20 @@ export default function ExplorerPage() {
   const [range, setRange] = useState<(typeof ranges)[number]>('24h')
   const [sel, setSel] = useState<string[]>(DEFAULT)
 
-  const chosen = sel.map(signalById)
+  const chosen = useMemo(() => sel.map(signalById), [sel])
 
   const rows = useMemo(() => timeAxis.map((t, i) => {
     const r: { t: string; [k: string]: string | number } = { t }
     for (const s of chosen) r[s.id] = s.norm[i]
     return r
-  }), [sel])
+  }), [chosen])
 
   const series = chosen.map((s) => ({ key: s.id, label: `${s.label} (${s.unit})`, color: s.color }))
 
   // Pairwise Pearson correlation over raw values of the selected signals.
   const corr = useMemo(
     () => chosen.map((a) => chosen.map((b) => pearson(a.values, b.values))),
-    [sel]
+    [chosen]
   )
 
   function toggle(id: string) {

--- a/console/package.json
+++ b/console/package.json
@@ -25,6 +25,8 @@
     "@types/react-dom": "^18.3.1",
     "tailwindcss": "^3.4.14",
     "postcss": "^8.4.47",
-    "autoprefixer": "^10.4.20"
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "15.5.19"
   }
 }


### PR DESCRIPTION
## Why
A code-review pass found the console had **no ESLint config and no `eslint` dependency**. The `"lint": "next lint"` script was interactive/unusable, and — more importantly — `next build` was only enforcing **type-checking**, silently skipping ESLint. So hooks bugs (`react-hooks/exhaustive-deps`), accessibility, and Next.js correctness rules were never gating anything.

## What
- Add `eslint@^8.57.1` + `eslint-config-next@15.5.19` (devDeps) and `.eslintrc.json` extending **`next/core-web-vitals`**. With a config + the dep present, `next build`'s "Linting and checking validity of types" step now actually runs ESLint, and lint **errors fail the build** (`eslint.ignoreDuringBuilds` is unset → default `false`).
- Fix the only two findings the new lint surfaced — `react-hooks/exhaustive-deps` warnings in the **Telemetry Explorer**: memoize `chosen` on `[sel]` and have the dependent `rows`/`corr` memos depend on `chosen`. Behaviour is identical and memoization is preserved (the prior `[sel]` keys were correct, but the rule couldn't see through `chosen = sel.map(...)`).

## Verification
- `npx next lint` → **✔ No ESLint warnings or errors** (exit 0).
- `npx next build` → exit 0, 27/27 routes; the build log shows the lint+types step running.
- **Negative test (enforcement is real):** injecting a `react/no-unescaped-entities` error into a throwaway component made `next lint` report the error and exit **1** (then removed). So a future lint regression will now fail the build instead of passing silently.
- `npx tsc --noEmit` → exit 0.

No runtime/behaviour change; this is a CI-hardening chore plus a no-op refactor of the two memo deps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_