### PR TITLE
fix(console): remove dead E-stop button (safety theater) + SIMULATED-DATA badge for mock-backed routes

### DIFF
--- a/console/app/[...slug]/page.tsx
+++ b/console/app/[...slug]/page.tsx
@@ -1,12 +1,18 @@
 import { Panel } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 
 export default async function ModulePlaceholder({ params }: { params: Promise<{ slug: string[] }> }) {
   const { slug } = await params
   const name = (slug?.[0] ?? 'module').replace(/-/g, ' ')
   return (
     <div className="mx-auto max-w-[1500px] p-6">
-      <h1 className="font-display text-xl font-semibold capitalize text-ink">{name}</h1>
-      <p className="mb-6 font-mono text-[11px] text-faint">module scaffold</p>
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-xl font-semibold capitalize text-ink">{name}</h1>
+          <p className="font-mono text-[11px] text-faint">module scaffold</p>
+        </div>
+        <DemoBadge live={false} />
+      </div>
       <Panel>
         <div className="grid place-items-center gap-2 py-20 text-center">
           <span className="h-2 w-2 rounded-full bg-ice" />

--- a/console/app/analytics/page.tsx
+++ b/console/app/analytics/page.tsx
@@ -1,4 +1,5 @@
 import { Panel, Pill, Meter } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { TrendArea, Spark } from '@/components/charts/charts'
 import { DualLine } from '@/components/charts/extra2'
 import { kpiWall, throughputTrend, riskForecast, riskDrivers, projections } from '@/lib/analytics'
@@ -12,7 +13,10 @@ export default function AnalyticsPage() {
           <h1 className="font-display text-xl font-semibold text-ink">Analytics & Risk Forecasting</h1>
           <p className="font-mono text-[11px] text-faint">executive KPIs · fleet trends · forward risk projection</p>
         </div>
-        <Pill tone="ice">30-day window</Pill>
+        <div className="flex items-center gap-2">
+          <DemoBadge live={false} />
+          <Pill tone="ice">30-day window</Pill>
+        </div>
       </div>
 
       {/* Executive KPI Wall (#9) */}

--- a/console/app/compliance/page.tsx
+++ b/console/app/compliance/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { useRawModal } from '@/components/ui/raw-modal'
 import { useAuditChain } from '@/lib/api/hooks'
 import { certs, tests, sbom, firmware } from '@/lib/compliance'
@@ -21,6 +22,7 @@ export default function CompliancePage() {
           <p className="font-mono text-[11px] text-faint">functional-safety evidence · audit-ready posture</p>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={audit.source === 'live'} />
           {audit.source === 'live' ? <Pill tone="safe">audit chain · live</Pill> : <Pill tone="ice">audit chain · demo</Pill>}
           <Pill tone="ice">{coverage}% verification coverage</Pill>
         </div>

--- a/console/app/events/page.tsx
+++ b/console/app/events/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { useEventFeed } from '@/lib/api/hooks'
 import type { Tone } from '@/lib/types'
 
@@ -33,6 +34,7 @@ export default function EventsPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={source === 'live'} />
           {source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}
           <Pill tone="crit">{counts.crit} critical</Pill>
           <Pill tone="warn">{counts.warn} warning</Pill>

--- a/console/app/explorer/page.tsx
+++ b/console/app/explorer/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react'
 import { Download, Search } from 'lucide-react'
 import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { MultiLine } from '@/components/charts/multiline'
 import { signals, signalById, timeAxis, assets, ranges, anomalies, pearson } from '@/lib/explorer'
 import type { Tone } from '@/lib/types'
@@ -55,9 +56,12 @@ export default function ExplorerPage() {
           <h1 className="font-display text-xl font-semibold text-ink">Telemetry Explorer</h1>
           <p className="font-mono text-[11px] text-faint">data lake · time-aligned signals · correlation & anomaly detection</p>
         </div>
-        <button onClick={exportCsv} className="flex items-center gap-2 rounded-lg border border-ice/40 bg-ice/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-wider text-ice hover:bg-ice/20">
-          <Download className="h-3.5 w-3.5" /> Export CSV
-        </button>
+        <div className="flex items-center gap-2">
+          <DemoBadge live={false} />
+          <button onClick={exportCsv} className="flex items-center gap-2 rounded-lg border border-ice/40 bg-ice/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-wider text-ice hover:bg-ice/20">
+            <Download className="h-3.5 w-3.5" /> Export CSV
+          </button>
+        </div>
       </div>
 
       {/* Query bar */}

--- a/console/app/fleet/[id]/page.tsx
+++ b/console/app/fleet/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ChevronLeft } from 'lucide-react'
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { PositionMap } from '@/components/ui/position-map'
 import { PoseView } from '@/components/ui/pose-view'
 import { PostureTrend } from '@/components/ui/posture-trend'
@@ -36,6 +37,7 @@ export default async function TwinPage({ params }: { params: Promise<{ id: strin
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={false} />
           <Pill tone={tone}>{t.posture}</Pill>
           <Pill tone={t.attestation.tone}>AK {t.attestation.status}</Pill>
         </div>

--- a/console/app/fleet/page.tsx
+++ b/console/app/fleet/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { WorldMap } from '@/components/ui/world-map'
 import { useLiveFleet } from '@/lib/api/hooks'
 import { twins, sites, siteRows, type Twin } from '@/lib/fleet'
@@ -28,6 +29,7 @@ export default function FleetPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={source === 'live'} />
           {source === 'live' ? <Pill tone="safe">posture · live</Pill> : <Pill tone="ice">posture · demo</Pill>}
           <Pill tone="safe">{online} active</Pill>
           {degraded > 0 && <Pill tone="warn">{degraded} degraded</Pill>}

--- a/console/app/global/page.tsx
+++ b/console/app/global/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { CloudRain, Network, Flame } from 'lucide-react'
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { GlobalMap } from '@/components/ui/global-map'
 import { sites, weatherZones, geofences, crossSiteAlerts, regionRisk, totals } from '@/lib/global'
 import type { Tone } from '@/lib/types'
@@ -20,6 +21,7 @@ export default function GlobalPage() {
           <p className="font-mono text-[11px] text-faint">strategic view · {totals.sites} sites · {totals.assets} assets · {totals.active} active</p>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={false} />
           <Pill tone="warn">2 regions elevated</Pill>
           <Pill tone="safe">federation in sync</Pill>
         </div>

--- a/console/app/incidents/page.tsx
+++ b/console/app/incidents/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { Play, Pause, SkipBack, RotateCcw } from 'lucide-react'
 import { Panel, Pill, StatusDot, Meter } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { ReplayMap } from '@/components/ui/replay-map'
 import { useRawModal } from '@/components/ui/raw-modal'
 import { useIncidentHistory } from '@/lib/api/hooks'
@@ -37,6 +38,7 @@ export default function IncidentsPage() {
           <p className="font-mono text-[11px] text-faint">{featured.id} · {featured.asset} · {featured.title}</p>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={history.source === 'live'} />
           <Pill tone="crit">{featured.reason}</Pill>
           <Pill tone="ice">{featured.status}</Pill>
         </div>

--- a/console/app/live/page.tsx
+++ b/console/app/live/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { useLiveFleet, useAuditChain } from '@/lib/api/hooks'
 import { postureTone, trustLabel, trustReason, trustTone, type FleetPostureState } from '@/lib/api/types'
 import type { Tone } from '@/lib/types'
@@ -23,6 +24,7 @@ export default function LivePage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={source === 'live'} />
           {source === 'live'
             ? <Pill tone="safe">Live · connected</Pill>
             : <Pill tone="ice">Demo data</Pill>}

--- a/console/app/missions/page.tsx
+++ b/console/app/missions/page.tsx
@@ -1,5 +1,6 @@
 import { MapPin, Container, Repeat, BatteryCharging, Radar, Pause, Lock, Clock, Circle, type LucideIcon } from 'lucide-react'
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { mission, phases, waypoints, tasks, risk, operatorInterventions, gantt, ganttWindow } from '@/lib/missions'
 import type { Tone } from '@/lib/types'
 
@@ -12,6 +13,7 @@ export default function MissionsPage() {
           <p className="font-mono text-[11px] text-faint">{mission.id} · {mission.name} · {mission.asset}</p>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={false} />
           <Pill tone="ice">In progress</Pill>
           <span className="font-mono text-[11px] text-faint">ETA {mission.eta}</span>
         </div>

--- a/console/app/oversight/page.tsx
+++ b/console/app/oversight/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { useRawModal } from '@/components/ui/raw-modal'
 import { trace, traceSubject, factors } from '@/lib/oversight'
 import { useDecisions } from '@/lib/api/hooks'
@@ -18,6 +19,7 @@ export default function OversightPage() {
           <p className="font-mono text-[11px] text-faint">explainability · every model action adjudicated by the Governor</p>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={source === 'live'} />
           <Pill tone="ice">autoware.planner · v4.2</Pill>
           <Pill tone="safe">{allowShare.toFixed(1)}% allow rate</Pill>
           {source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="ice">demo</Pill>}

--- a/console/app/page.tsx
+++ b/console/app/page.tsx
@@ -1,4 +1,5 @@
 import { Stat, Pill, StatusDot, Meter, Panel } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { Spark } from '@/components/charts/charts'
 import { HeroSafety, FleetTopology, MissionMap, ExecSummary, AuditLedger, EventFeed } from '@/components/command'
 import { kpis, robots, postureTone } from '@/lib/mock'
@@ -12,6 +13,7 @@ export default function OverviewPage() {
           <p className="font-mono text-[11px] text-faint">PRODUCTION · us-fleet-1 · updated 2s ago</p>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={false} />
           <Pill tone="safe">Fleet Nominal</Pill>
           <Pill tone="ice">E-Stop Armed</Pill>
           <button className="rounded-lg border border-line bg-panel px-3 py-1.5 font-mono text-[11px] text-muted hover:text-ink">Last 24h</button>

--- a/console/app/reports/page.tsx
+++ b/console/app/reports/page.tsx
@@ -1,5 +1,6 @@
 import { Download, FileText, ShieldCheck } from 'lucide-react'
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { AuditEvidence } from '@/components/ui/audit-evidence'
 import { reports, scheduled, rollout, rolloutVersion, versionShare } from '@/lib/reports'
 import type { Tone } from '@/lib/types'
@@ -12,9 +13,12 @@ export default function ReportsPage() {
           <h1 className="font-display text-xl font-semibold text-ink">Reports & Releases</h1>
           <p className="font-mono text-[11px] text-faint">generated evidence · scheduled exports · software rollout</p>
         </div>
-        <button className="flex items-center gap-2 rounded-lg border border-ice/40 bg-ice/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-wider text-ice hover:bg-ice/20">
-          <FileText className="h-3.5 w-3.5" /> Generate report
-        </button>
+        <div className="flex items-center gap-2">
+          <DemoBadge live={false} />
+          <button className="flex items-center gap-2 rounded-lg border border-ice/40 bg-ice/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-wider text-ice hover:bg-ice/20">
+            <FileText className="h-3.5 w-3.5" /> Generate report
+          </button>
+        </div>
       </div>
 
       {/* ── Live signed-evidence summary from the audit chain ── */}

--- a/console/app/runtime/page.tsx
+++ b/console/app/runtime/page.tsx
@@ -1,4 +1,5 @@
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { Spark } from '@/components/charts/charts'
 import { LatencyLines } from '@/components/charts/extra'
 import { TopologyMap } from '@/components/ui/topology-map'
@@ -14,7 +15,10 @@ export default function RuntimePage() {
           <h1 className="font-display text-xl font-semibold text-ink">Runtime Health</h1>
           <p className="font-mono text-[11px] text-faint">compute · transport · isolation</p>
         </div>
-        <Pill tone="safe">All partitions enforced</Pill>
+        <div className="flex items-center gap-2">
+          <DemoBadge live={false} />
+          <Pill tone="safe">All partitions enforced</Pill>
+        </div>
       </div>
 
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">

--- a/console/app/safety/page.tsx
+++ b/console/app/safety/page.tsx
@@ -1,4 +1,5 @@
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { ScoreRing } from '@/components/charts/charts'
 import { EnvelopePlot } from '@/components/ui/envelope-plot'
 import { constraints, violations, interventions, verdictMix, envPoints, envelopeBands } from '@/lib/safety'
@@ -13,8 +14,12 @@ export default function SafetyPage() {
           <p className="font-mono text-[11px] text-faint">command center · fail-closed verdict engine</p>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={false} />
           <Pill tone="safe">State: Nominal</Pill>
-          <button className="rounded-lg border border-crit/40 bg-crit/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-wider text-crit hover:bg-crit/20">Emergency Stop</button>
+          {/* Read-only indicator — this console has no actuator authority and
+              must never imply it can trigger a stop. The live stop-path status
+              is the "Emergency Stop Readiness" panel below. */}
+          <Pill tone="safe">E-Stop: ARMED</Pill>
         </div>
       </div>
 

--- a/console/app/settings/page.tsx
+++ b/console/app/settings/page.tsx
@@ -19,21 +19,32 @@ export default function SettingsPage() {
       </div>
 
       {/* ── Operator Tools (#12) ── */}
-      <Panel title="Operator Tools" subtitle="human-in-the-loop · every action re-adjudicated by the Governor">
+      {/* Governed-request catalog — NOT live triggers. The console is QM-domain
+          and holds no actuator authority; each item is an authenticated REQUEST
+          routed to the fail-closed Governor (never console→actuator). Rendered
+          as non-interactive cards (no onClick) — the wired operator→governor
+          request path is tracked in #412. */}
+      <Panel title="Operator Tools" subtitle="human-in-the-loop · authenticated requests routed to the Governor — never a direct actuator command">
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {operatorActions.map((a) => (
-            <button
+            <div
               key={a.id}
-              className={`rounded-xl border p-4 text-left transition-colors ${a.critical ? 'border-crit/40 bg-crit/[0.06] hover:bg-crit/[0.12]' : 'border-line bg-panel hover:bg-elevated'}`}
+              className={`rounded-xl border p-4 text-left ${a.critical ? 'border-crit/40 bg-crit/[0.06]' : 'border-line bg-panel'}`}
             >
               <div className="flex items-center justify-between">
                 <span className={`font-display text-[14px] font-semibold ${txt(a.tone)}`}>{a.name}</span>
                 {a.critical && <AlertOctagon className="h-4 w-4 text-crit" />}
               </div>
               <p className="mt-2 text-[11px] leading-snug text-muted">{a.desc}</p>
-            </button>
+              <span className="mt-3 inline-block rounded-sm bg-white/5 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wider text-faint">request → governor</span>
+            </div>
           ))}
         </div>
+        <p className="mt-4 border-t border-line pt-3 font-mono text-[10px] leading-relaxed text-faint">
+          Display-only in this build. Operator intent enters as an authenticated, signed request to the
+          fail-closed Governor, which adjudicates and commands the MRC under its own authority — the
+          console never touches an actuator. Wired request path tracked in #412.
+        </p>
 
         <div className="mt-5 border-t border-line pt-4">
           <div className="mb-2 font-mono text-[10px] uppercase tracking-wider text-faint">Active operator sessions</div>

--- a/console/app/settings/page.tsx
+++ b/console/app/settings/page.tsx
@@ -1,5 +1,6 @@
 import { AlertOctagon } from 'lucide-react'
 import { Panel, Pill, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { config, flags, operatorActions, operatorSessions, roster } from '@/lib/settings'
 import type { Tone } from '@/lib/types'
 
@@ -11,7 +12,10 @@ export default function SettingsPage() {
           <h1 className="font-display text-xl font-semibold text-ink">System & Operator Control</h1>
           <p className="font-mono text-[11px] text-faint">configuration · feature flags · operator tools · access</p>
         </div>
-        <Pill tone="safe">fail-closed · governor gates all actions</Pill>
+        <div className="flex items-center gap-2">
+          <DemoBadge live={false} />
+          <Pill tone="safe">fail-closed · governor gates all actions</Pill>
+        </div>
       </div>
 
       {/* ── Operator Tools (#12) ── */}

--- a/console/app/telemetry/page.tsx
+++ b/console/app/telemetry/page.tsx
@@ -1,4 +1,5 @@
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
+import { DemoBadge } from '@/components/ui/demo-badge'
 import { TrendArea } from '@/components/charts/charts'
 import { DualLine } from '@/components/charts/extra2'
 import { PositionMap } from '@/components/ui/position-map'
@@ -15,6 +16,7 @@ export default function TelemetryPage() {
           <p className="font-mono text-[11px] text-faint">KIRRA-09 · streaming · 50 Hz</p>
         </div>
         <div className="flex items-center gap-2">
+          <DemoBadge live={false} />
           <Pill tone="ice">live stream</Pill>
           <button className="rounded-lg border border-line bg-panel px-3 py-1.5 font-mono text-[11px] text-muted hover:text-ink">KIRRA-09 ▾</button>
         </div>

--- a/console/components/shell/nav-items.ts
+++ b/console/components/shell/nav-items.ts
@@ -1,7 +1,12 @@
 import { LayoutDashboard, Globe, Boxes, ShieldCheck, Activity, Radio, Route, Rss, Brain, Bell, AlertTriangle, FileCheck2, BarChart3, Database, FileText, Settings } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
-export interface NavItem { href: string; label: string; icon: LucideIcon }
+// `preview: true` marks a route whose screen renders bundled mock data (no live
+// verifier endpoint behind it). The sidebar renders a small "preview" tag so the
+// live-backed routes stand out — the nav-level complement to the per-page
+// DemoBadge ("SIMULATED DATA"). Live-backed routes (live/fleet/oversight/events/
+// incidents/compliance) carry no flag.
+export interface NavItem { href: string; label: string; icon: LucideIcon; preview?: boolean }
 export interface NavGroup { label: string; items: NavItem[] }
 
 // Shared navigation model used by both the desktop sidebar and the mobile drawer.
@@ -9,14 +14,14 @@ export const navGroups: NavGroup[] = [
   {
     label: 'Operations',
     items: [
-      { href: '/', label: 'Overview', icon: LayoutDashboard },
+      { href: '/', label: 'Overview', icon: LayoutDashboard, preview: true },
       { href: '/live', label: 'Live Fleet', icon: Rss },
-      { href: '/global', label: 'Global Operations', icon: Globe },
+      { href: '/global', label: 'Global Operations', icon: Globe, preview: true },
       { href: '/fleet', label: 'Fleet Operations', icon: Boxes },
-      { href: '/safety', label: 'Safety Governor', icon: ShieldCheck },
-      { href: '/runtime', label: 'Runtime Health', icon: Activity },
-      { href: '/telemetry', label: 'Telemetry', icon: Radio },
-      { href: '/missions', label: 'Mission Timeline', icon: Route },
+      { href: '/safety', label: 'Safety Governor', icon: ShieldCheck, preview: true },
+      { href: '/runtime', label: 'Runtime Health', icon: Activity, preview: true },
+      { href: '/telemetry', label: 'Telemetry', icon: Radio, preview: true },
+      { href: '/missions', label: 'Mission Timeline', icon: Route, preview: true },
     ],
   },
   {
@@ -31,10 +36,10 @@ export const navGroups: NavGroup[] = [
   {
     label: 'Insight',
     items: [
-      { href: '/analytics', label: 'Analytics', icon: BarChart3 },
-      { href: '/explorer', label: 'Telemetry Explorer', icon: Database },
-      { href: '/reports', label: 'Reports', icon: FileText },
-      { href: '/settings', label: 'Settings', icon: Settings },
+      { href: '/analytics', label: 'Analytics', icon: BarChart3, preview: true },
+      { href: '/explorer', label: 'Telemetry Explorer', icon: Database, preview: true },
+      { href: '/reports', label: 'Reports', icon: FileText, preview: true },
+      { href: '/settings', label: 'Settings', icon: Settings, preview: true },
     ],
   },
 ]

--- a/console/components/shell/sidebar.tsx
+++ b/console/components/shell/sidebar.tsx
@@ -22,7 +22,11 @@ export function Sidebar() {
                     <Link href={it.href} className={cn('group flex items-center gap-3 rounded-lg px-3 py-2 text-[13px] transition-colors', active ? 'bg-white/[0.06] text-ink' : 'text-muted hover:bg-white/[0.03] hover:text-ink')}>
                       <Icon className={cn('h-4 w-4', active ? 'text-safe' : 'text-faint group-hover:text-muted')} strokeWidth={1.75} />
                       <span>{it.label}</span>
-                      {active && <span className="ml-auto h-1.5 w-1.5 rounded-full bg-safe" />}
+                      {active ? (
+                        <span className="ml-auto h-1.5 w-1.5 rounded-full bg-safe" />
+                      ) : it.preview ? (
+                        <span className="ml-auto rounded-sm bg-warn/10 px-1 py-0.5 font-mono text-[8px] uppercase tracking-wider text-warn/80">preview</span>
+                      ) : null}
                     </Link>
                   </li>
                 )

--- a/console/components/ui/demo-badge.tsx
+++ b/console/components/ui/demo-badge.tsx
@@ -1,0 +1,22 @@
+import { Pill } from '@/components/ui/primitives'
+
+// Read-only data-provenance badge for page headers.
+//
+// The Mission Console is an observe-only (QM-domain) surface with no actuator
+// authority. Most screens render bundled mock data; only a few read the real
+// verifier. This badge makes the data source explicit at a glance — important
+// for grant / acquirer demos where confident-looking numbers must not be
+// mistaken for live readings.
+//
+// `live` is the page's PRIMARY data source:
+//   - true  → the page reads the real verifier (green "LIVE" pill). Pages that
+//             track a runtime `source` should pass `source === 'live'`, so the
+//             badge flips to "SIMULATED DATA" when the backend is unconfigured
+//             and the page has fallen back to demo data.
+//   - false → the page renders bundled mock data (amber "SIMULATED DATA" pill).
+//
+// Purely presentational (no hooks / no handlers) so it renders in both server
+// and client page components.
+export function DemoBadge({ live }: { live: boolean }) {
+  return live ? <Pill tone="safe">Live</Pill> : <Pill tone="warn">Simulated data</Pill>
+}

--- a/console/lib/settings.ts
+++ b/console/lib/settings.ts
@@ -29,11 +29,16 @@ export const flags: FeatureFlag[] = [
 // ── Operator Tools (#12) ──────────────────────────────────────────────
 export interface OperatorAction { id: string; name: string; desc: string; tone: Tone; critical?: boolean }
 
+// Each entry is a governed *request* the operator sends to the fail-closed
+// Governor — never a direct console→actuator command. The console holds no
+// actuator authority; the Governor adjudicates and acts under its own. The
+// authenticated operator→governor request path is tracked in #412; these are
+// display-only in this build (no wired request channel yet).
 export const operatorActions: OperatorAction[] = [
-  { id: 'estop', name: 'Fleet E-STOP', desc: 'Command all assets to MRC controlled stop + HOLD', tone: 'crit', critical: true },
-  { id: 'hold', name: 'Hold Selected', desc: 'Pause a single asset at next safe waypoint', tone: 'warn' },
+  { id: 'estop', name: 'Fleet E-STOP', desc: 'Request governor-commanded MRC controlled-stop + HOLD (all assets)', tone: 'crit', critical: true },
+  { id: 'hold', name: 'Hold Selected', desc: 'Request a single-asset pause at the next safe waypoint', tone: 'warn' },
   { id: 'teleop', name: 'Teleop Handoff', desc: 'Request supervised manual control (governor still gates envelope)', tone: 'ice' },
-  { id: 'reset', name: 'Lockout Reset', desc: 'Human reset of a LockedOut asset — requires supervisor key', tone: 'warn' },
+  { id: 'reset', name: 'Lockout Reset', desc: 'Request human reset of a LockedOut asset — requires supervisor key', tone: 'warn' },
 ]
 
 export interface OperatorSession { asset: string; operator: string; mode: string; since: string; tone: Tone }


### PR DESCRIPTION
## Why

Two console-only credibility/safety fixes ahead of grant & acquirer demos. **Diff is `console/` only — no SDK, Rust, or talisman changes; no write path or `onClick` introduced anywhere.**

### Fix 1 — Remove dead "Emergency Stop" button (safety theater)

`console/app/safety/page.tsx` shipped a styled **Emergency Stop `<button>` with no `onClick` handler**. The console is a read-only / QM-domain observability surface with **no actuator authority** — the fail-closed Governor is the only thing that can command a safe-state. A dead E-stop button is *safety theater*: it implies the console can actuate when it categorically cannot, and a button that looks armed but does nothing is worse than no button in a safety review.

- The `<button>` is **removed** and replaced with a **non-interactive** `<Pill tone="safe">E-Stop: ARMED</Pill>` read-only status indicator.
- **No `onClick`, no write path** — the console must never imply it can actuate.
- The **"Emergency Stop Readiness" indicator panel is unchanged** (it reports readiness; it does not pretend to trigger).

### Fix 2 — `SIMULATED DATA` / `LIVE` provenance badge on every page

13 of the 18 console routes render mock fixtures, not live verifier data. In a demo that's invisible — an acquirer/grant reviewer can't tell which panels are real. New presentational `console/components/ui/demo-badge.tsx` exports `<DemoBadge live={boolean} />`:

- `live={false}` → amber **`SIMULATED DATA`** pill (`tone="warn"`)
- `live={true}` → green **`LIVE`** pill (`tone="safe"`)

Added to all **18 page headers**. The six live-wired pages (fleet, live, oversight, incidents, compliance, events) pass `live={source === 'live'}` — so the badge is **DemoMode-aware** and automatically flips to `SIMULATED DATA` when the backend proxy is unconfigured (503 / `x-kirra-mode: demo`). The remaining mock pages pass `live={false}`. Provenance is now explicit on every screen.

### Fix 3 (bonus) — `preview` tag on mock-backed nav items

`nav-items.ts` gains an optional `preview?: boolean`; `sidebar.tsx` renders a small `preview` tag on the mock-backed routes so the distinction is visible from the nav rail too.

## Verify

- `cd console && npm install && npm run build` → clean (ESLint enforced in-build per #403: `✔ No ESLint warnings or errors`, `next build` exit 0).
- `grep "Emergency Stop" console/app/safety/page.tsx` → only the **readiness panel** title remains; the button is gone.
- `DemoBadge` present on all 18 page headers.
- `git grep -E 'POST|onClick.*actuate|mutation' console/` → still **no write paths**.
- Diff is `console/` only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_