### PR TITLE
parko: wire warm_up() into node startup via InferenceBackend trait hook (PARK-021 #2)

### DIFF
--- a/docs/adr/0010-parko-backend-construction-and-warmup-wiring.md
+++ b/docs/adr/0010-parko-backend-construction-and-warmup-wiring.md
@@ -2,11 +2,32 @@
 
 | Field | Value |
 |---|---|
-| Status | **Proposed** |
+| Status | **Partially accepted** — warm-up *hook* wired; backend *construction* home still open |
 | Date | 2026-06-19 |
-| Deciders | Project owner (pending) |
+| Deciders | Project owner (pending on the construction/selection half) |
 | Issues | #415 (PARK-021 #2 — engine warm-up) |
-| Code | `parko/crates/parko-tensorrt/src/lib.rs` (`TrtBackend::warm_up`, `WarmUpReport`), `parko/crates/parko-core/src/backend_selector.rs` |
+| Code | `parko-core::backend::InferenceBackend::warm_up` (hook), `parko-tensorrt` (`warm_up_report`/`engine_sha`/trait impl), `parko-ros2` `parko_ros2_node::build_loop` (call site) |
+
+## Update (implemented) — the warm-up wiring is a TRAIT HOOK, not a parko-kirra factory
+
+This ADR originally guessed the wiring belonged in a `parko-kirra` integration
+factory. Inspection corrected that: `parko-kirra` constructs no backends, and the
+real runtime entrypoint is the `parko_ros2_node` binary, which holds the backend
+behind an `Arc<B: InferenceBackend>` and calls `load_model` in `build_loop`. So the
+warm-up was wired as a **lifecycle hook on the `InferenceBackend` trait** instead:
+
+- `parko-core`: `fn warm_up(&self, &ModelHandle) -> Result<(), BackendError>` with a
+  default **no-op** (CPU/OpenVINO/mock need no warm-up). `&self` because backends are
+  shared behind `Arc`.
+- `parko-tensorrt`: overrides it to force the engine build; `warm_up_report` (now
+  `&self`, SHA captured via a `OnceLock` exposed by `engine_sha()`) carries the detail.
+- `parko-ros2`: `build_loop` calls `backend.warm_up(&model)` right after `load_model`,
+  **fail-closed** (exit 4) — the node refuses to serve against an unbuilt engine.
+
+No `parko-kirra` factory and no new crate were needed for the hook. The **remaining
+open question** is narrower than first framed: only *where the concrete `TrtBackend`
+gets constructed/selected* in the node (it currently builds only mock / CPU-ORT). The
+trait hook means whoever constructs it gets warm-up for free.
 
 ## Context
 

--- a/parko/crates/parko-core/src/backend.rs
+++ b/parko/crates/parko-core/src/backend.rs
@@ -138,6 +138,20 @@ pub trait InferenceBackend: Send + Sync {
     fn descriptor(&self) -> BackendDescriptor {
         BackendDescriptor::Cpu
     }
+
+    /// Startup lifecycle hook — do any first-use work NOW (at node startup, after
+    /// `load_model`) so the first real command never pays it. The default is a
+    /// no-op: most backends (CPU ORT, OpenVINO, the mock) need no warm-up.
+    ///
+    /// Hardware backends that build/cache engines override this — e.g. the
+    /// TensorRT backend forces its multi-second per-model/shape engine build here
+    /// (PARK-021 #2). Called through a shared `&self` because the runtime node
+    /// holds the backend behind an `Arc`. FAIL-CLOSED: an `Err` means the backend
+    /// could not be made ready, and the node must REFUSE to start rather than serve
+    /// against an unbuilt engine.
+    fn warm_up(&self, _model: &ModelHandle) -> Result<(), BackendError> {
+        Ok(())
+    }
 }
 
 /// The SINGLE source of inference thread count, shared by every inference

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -225,6 +225,17 @@ where
             std::process::exit(3);
         });
 
+    // PARK-021 #2: warm up the backend BEFORE the loop serves any command, so a
+    // multi-second first-use cost (e.g. the TensorRT engine build) never lands on
+    // the first real command. No-op for backends that need no warm-up (mock, CPU
+    // ORT). FAIL-CLOSED: if warm-up fails the backend is not ready, so refuse to
+    // start rather than serve against an unbuilt/cold engine.
+    backend.warm_up(&model)
+        .unwrap_or_else(|e| {
+            eprintln!("parko_ros2_node: backend.warm_up failed — refusing to start (fail-closed): {e:?}");
+            std::process::exit(4);
+        });
+
     let (actuator_tx, mut actuator_rx) = mpsc::channel::<ControlCommand>(8);
 
     // The scheduler's actuator_tx receives the post-governor command

--- a/parko/crates/parko-tensorrt/src/lib.rs
+++ b/parko/crates/parko-tensorrt/src/lib.rs
@@ -25,6 +25,7 @@
 // (hardware-measured)", logged — not a bitwise-determinism claim.
 
 use std::collections::HashMap;
+use std::sync::OnceLock;
 use std::time::Instant;
 
 use ort::ep::TensorRT;
@@ -145,6 +146,11 @@ pub fn resolve_engine_cache_path(explicit: Option<&str>) -> String {
 pub struct TrtBackend {
     core: OrtRunCore,
     posture: TrtPosture,
+    /// SHA-256 of the serialized engine, captured by `warm_up` once an engine
+    /// exists on disk. Interior-mutable so warm-up can run through a shared
+    /// `&self` (backends are held behind `Arc` in the runtime node) and set it
+    /// exactly once.
+    warmed_engine_sha: OnceLock<String>,
 }
 
 impl TrtBackend {
@@ -200,6 +206,7 @@ impl TrtBackend {
         Ok(Self {
             core: OrtRunCore::new(session, "ort_trt"),
             posture,
+            warmed_engine_sha: OnceLock::new(),
         })
     }
 
@@ -209,18 +216,28 @@ impl TrtBackend {
         &self.posture
     }
 
+    /// The SHA-256 of the cached engine captured by [`Self::warm_up_report`] (or
+    /// the trait [`InferenceBackend::warm_up`]). `None` until warm-up has run and
+    /// an engine exists on disk.
+    #[must_use]
+    pub fn engine_sha(&self) -> Option<&str> {
+        self.warmed_engine_sha.get().map(String::as_str)
+    }
+
     /// Force the per-model/shape TensorRT engine to build (or deserialize from the
     /// on-disk cache) NOW — at startup — so the multi-second first-build never lands
     /// on the first real command (PARK-021 #2). Runs ONE inference with a
     /// shape-correct zero input (output discarded; the engine build depends on the
-    /// input SHAPE, not its values), then captures the cached engine's SHA-256 into
-    /// `TrtPosture.engine_sha`. Idempotent: against a warm cache it only
-    /// deserializes. Measured cold build on a Jetson Orin (MNIST) is ~2.2 s — the
-    /// budget this moves off the hot path; bigger models cost more.
+    /// input SHAPE, not its values), then captures the cached engine's SHA-256 (see
+    /// [`Self::engine_sha`]). Idempotent: against a warm cache it only deserializes.
+    /// Measured cold build on a Jetson Orin (MNIST) is ~2.2 s — the budget this moves
+    /// off the hot path; bigger models cost more.
     ///
-    /// Takes `&mut self` because it populates the posture's `engine_sha`. The
-    /// Nominal `run` hot path is unchanged.
-    pub fn warm_up(&mut self, model: &ModelHandle) -> Result<WarmUpReport, BackendError> {
+    /// Takes `&self` (interior-mutable SHA capture) so it can run through the `Arc`
+    /// the runtime node holds the backend behind. The Nominal `run` hot path is
+    /// unchanged. The trait hook [`InferenceBackend::warm_up`] calls this and
+    /// discards the report; use this method directly when the report is wanted.
+    pub fn warm_up_report(&self, model: &ModelHandle) -> Result<WarmUpReport, BackendError> {
         if model.input_shapes.is_empty() {
             return Err(BackendError::InitializationError(
                 "warm_up: model declares no inputs — cannot synthesize a warm-up batch".into(),
@@ -239,12 +256,13 @@ impl TrtBackend {
         let _ = self.run(model, &batch)?;
         let warmed_ms = t0.elapsed().as_millis();
 
-        // Capture the serialized engine's SHA-256 → engine_sha (the #2 hook: the SHA
-        // is None until an engine actually exists on hardware).
+        // Capture the serialized engine's SHA-256 (the #2 hook: None until an engine
+        // actually exists on hardware). Stored once via the OnceLock so the capture
+        // survives through the shared `&self`; a second warm-up keeps the first SHA.
         let (engine_file, engine_sha256, engine_bytes) =
             sha256_cached_engine(&self.posture.engine_cache_path);
         if let Some(sha) = &engine_sha256 {
-            self.posture.engine_sha = Some(sha.clone());
+            let _ = self.warmed_engine_sha.set(sha.clone());
         }
 
         tracing::info!(
@@ -266,7 +284,7 @@ impl TrtBackend {
     }
 }
 
-/// Outcome of [`TrtBackend::warm_up`] — the engine was forced to build/deserialize
+/// Outcome of [`TrtBackend::warm_up_report`] — the engine was forced to build/deserialize
 /// before any real command, and the cached engine fingerprinted for the audit log.
 #[derive(Debug, Clone)]
 pub struct WarmUpReport {
@@ -348,6 +366,15 @@ impl InferenceBackend for TrtBackend {
         self.core.run(model, inputs)
     }
 
+    /// The startup lifecycle hook (PARK-021 #2): build/cache the TRT engine now so
+    /// the cold build never lands on the first real command. Delegates to
+    /// [`Self::warm_up_report`] and discards the detailed report (the report is
+    /// logged inside; `engine_sha()` exposes the captured SHA). Fail-closed: a
+    /// build failure propagates so the node refuses to advertise ready.
+    fn warm_up(&self, model: &ModelHandle) -> Result<(), BackendError> {
+        self.warm_up_report(model).map(|_| ())
+    }
+
     fn descriptor(&self) -> BackendDescriptor {
         BackendDescriptor::TensorRT
     }
@@ -373,12 +400,13 @@ impl InferenceBackend for TrtBackend {
 /// 1. **Real `load_model`/`run` output** — DONE (#414). `tests/positive_probe.rs`
 ///    is green on the Orin: `with_config` Ok, descriptor TensorRT, MNIST runs.
 ///    The inference path is shared (`OrtRunCore`).
-/// 2. **Engine build / cache + warm-up** — IMPLEMENTED ([`TrtBackend::warm_up`],
-///    #415). Forces the per-model/shape engine build at startup and captures the
-///    serialized engine's SHA-256 into `TrtPosture.engine_sha`.
-///    `tests/engine_cache_probe.rs` measured ~2.2 s cold build vs warm cache reuse
-///    on the Orin (the budget warm-up moves off the hot path); the cache key
-///    includes the GPU arch (`…_sm87.engine`). `tests/warmup_probe.rs` validates it.
+/// 2. **Engine build / cache + warm-up** — IMPLEMENTED + WIRED (#415, ADR-0010).
+///    The [`InferenceBackend::warm_up`] trait hook (default no-op) is overridden here
+///    via [`TrtBackend::warm_up_report`] to force the per-model/shape engine build at
+///    startup and capture the engine's SHA-256 (see [`TrtBackend::engine_sha`]).
+///    `parko_ros2_node` calls it after `load_model`, fail-closed. `engine_cache_probe`
+///    measured ~2.2 s cold vs warm reuse on the Orin; cache key includes the GPU arch
+///    (`…_sm87.engine`). `tests/warmup_probe.rs` validates it.
 /// 3. **Precision validation / TF32** — MEASURED (#415). `tests/tf32_probe.rs`
 ///    (one-shot differential): `NVIDIA_TF32_OVERRIDE=0` is INERT for the ort TRT
 ///    EP, and #4's drift is fp32-epsilon scale (~3e-7, ~3000× below TF32 ε), i.e.

--- a/parko/crates/parko-tensorrt/tests/warmup_probe.rs
+++ b/parko/crates/parko-tensorrt/tests/warmup_probe.rs
@@ -39,7 +39,8 @@ fn trt_warm_up_builds_engine_and_populates_engine_sha() {
     let _ = std::fs::remove_dir_all(&cache);
     let cfg = TrtConfig { engine_cache_path: cache.to_string_lossy().into_owned() };
 
-    let mut backend = match TrtBackend::with_config(model_path, &cfg) {
+    // &self warm-up (runs through Arc in the node) — no `mut` needed.
+    let backend = match TrtBackend::with_config(model_path, &cfg) {
         Ok(b) => b,
         Err(e) => {
             assert!(
@@ -51,40 +52,43 @@ fn trt_warm_up_builds_engine_and_populates_engine_sha() {
         }
     };
 
-    // engine_sha is None until an engine actually exists on hardware.
+    // engine_sha is None until warm-up has built/located an engine on disk.
     assert_eq!(
-        backend.posture().engine_sha,
+        backend.engine_sha(),
         None,
-        "engine_sha must be None before warm-up (no engine built yet)",
+        "engine_sha() must be None before warm-up (no engine built yet)",
     );
 
     let model = backend.load_model(model_path).expect("MNIST model introspection failed");
 
     // COLD warm-up — forces the engine build and captures its SHA-256.
-    let cold = backend.warm_up(&model).expect("cold warm_up failed");
+    let cold = backend.warm_up_report(&model).expect("cold warm_up failed");
     let sha = cold
         .engine_sha256
         .clone()
         .expect("warm_up must capture the engine SHA-256 after a cold build");
     assert_eq!(sha.len(), 64, "SHA-256 hex must be 64 chars, got {}", sha.len());
     assert_eq!(
-        backend.posture().engine_sha.as_deref(),
+        backend.engine_sha(),
         Some(sha.as_str()),
-        "warm_up must mirror the engine SHA into the posture",
+        "warm_up must capture the engine SHA into the backend (engine_sha())",
     );
     assert!(cold.engine_bytes.unwrap_or(0) > 0, "engine file must be non-empty");
 
-    // WARM warm-up — idempotent: same on-disk engine ⇒ identical SHA.
-    let warm = backend.warm_up(&model).expect("warm warm_up failed");
+    // WARM warm-up — idempotent: same on-disk engine ⇒ identical SHA. Also exercise
+    // the trait hook (returns ()), proving the generic startup path works.
+    let warm = backend.warm_up_report(&model).expect("warm warm_up failed");
     assert_eq!(
         warm.engine_sha256.as_deref(),
         Some(sha.as_str()),
         "a second warm-up against the warm cache must yield the SAME engine_sha (idempotent)",
     );
+    InferenceBackend::warm_up(&backend, &model).expect("trait warm_up hook must succeed when EP is present");
+    assert_eq!(backend.engine_sha(), Some(sha.as_str()), "engine_sha() stable across the trait hook");
 
     println!(
         "WARM-UP PROBE PASSED — cold warm_up {} ms, warm warm_up {} ms. \
-         engine '{}' {} B, engine_sha256={} (mirrored into posture; idempotent across both runs).",
+         engine '{}' {} B, engine_sha256={} (captured via engine_sha(); idempotent; trait hook ok).",
         cold.warmed_ms,
         warm.warmed_ms,
         cold.engine_file.as_deref().unwrap_or("<none>"),


### PR DESCRIPTION
Wires `TrtBackend::warm_up()` (PARK-021 #2) into the runtime node so it actually runs at startup — it previously had no caller. Follow-on to #417 / ADR-0010.

## Approach (corrects ADR-0010's guess)

ADR-0010 originally assumed a `parko-kirra` factory. Inspection corrected that: `parko-kirra` constructs no backends, and the real entrypoint is the **`parko_ros2_node`** binary, which holds the backend behind `Arc<B: InferenceBackend>` and calls `load_model` in `build_loop`. So warm-up is wired as a **backend-agnostic lifecycle hook**, not a factory:

- **parko-core** — new trait method `InferenceBackend::warm_up(&self, &ModelHandle) -> Result<(), BackendError>` with a **default no-op** (CPU ORT / OpenVINO / mock need none). `&self` so it's callable through the `Arc` the node holds.
- **parko-tensorrt** — refactor the inherent warm-up to `&self` (renamed `warm_up_report`; engine SHA captured via a `OnceLock`, exposed by `engine_sha()`), and override the trait hook to force the engine build. Drops the prior `&mut self` + posture mutation so it's `Arc`-callable.
- **parko-ros2** — `build_loop` calls `backend.warm_up(&model)` right after `load_model`, **fail-closed** (exit 4): refuse to serve against an unbuilt engine.

Existing backend impls inherit the default unchanged.

## Validation
- `parko-core` (189) + `parko-tensorrt` (6) lib tests pass; all backend crates build; `warmup_probe` updated for the `&self` API + trait hook and self-skips off-hardware; installer self-test 16/16; rustdoc intra-doc links resolve.
- The node bin (`--features ros2`) can't build in the sandbox (no ROS2 distro — `r2r_rcl` build script) but compiles in CI's **ros2 adapter build** job; the edit mirrors the existing `load_model` fail-closed pattern exactly.

## Scope / still open
The trait hook means whoever constructs the backend gets warm-up for free. The remaining open item (ADR-0010, narrowed) is only **where the concrete `TrtBackend` is constructed/selected** in the node — it currently builds mock / CPU-ORT only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_