### PR TITLE
parko-ros2: fail-closed TensorRT backend selection in the node + PARK-021 precision/wiring decisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,12 @@ jobs:
       - name: build the onnx + tensorrt backend-selection lanes
         # `parko_ros2::backend_select` compiles exactly ONE backend per feature
         # (mock / onnx / tensorrt), fail-closed, TensorRT taking precedence. The
-        # module is NOT ros2-gated, so these lanes build with no ROS 2 and no ORT
-        # runtime (load-dynamic) — this is the only CI step that compiles the
-        # parko-onnx and parko-tensorrt selection paths in parko-ros2. The mock lane
-        # is already covered by the default-feature workspace test in parko-safety;
-        # the ros2 BINARY call site (main → select_backend, warm_up) remains
-        # uncompiled by CI — tracked as a follow-up (no parko-ros2 --features ros2
-        # build job exists yet).
+        # module is NOT ros2-gated, so these lanes build fast with no ROS 2 and no
+        # ORT runtime (load-dynamic). This compiles the backend_select MODULE; the
+        # ros2 BINARY call site (main → select_backend → build_loop → warm_up) is
+        # compiled by the `ros2-adapter-build` job (jazzy sourced) — together they
+        # cover both halves. The mock lane is covered by the default-feature
+        # workspace test in parko-safety.
         working-directory: parko
         run: |
           cargo build -p parko-ros2 --features onnx-backend
@@ -409,7 +408,7 @@ jobs:
     # Jazzy targets Ubuntu 24.04 (Noble), so pin the runner (the rest of the
     # workflow runs on ubuntu-latest, which is fine for the non-ROS jobs).
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
       - uses: ros-tooling/setup-ros@v0.7
@@ -446,3 +445,18 @@ jobs:
           source /opt/ros/jazzy/setup.bash
           source ros2_ws/install/setup.bash
           cargo build -p kirra-ros2-adapter --features ros2
+      - name: cargo build parko-ros2 node binary (--features ros2 × backend lanes)
+        # PARK-021 #2: the parko-ros2 node BINARY (main → select_backend →
+        # build_loop → backend.warm_up) is r2r/ros2-gated, so neither
+        # `cargo test --workspace` nor the distro-free `parko-ros2-backends` job
+        # (which builds only the backend_select MODULE) ever compiles it. This is
+        # the ONLY CI step that compiles those call sites — build (not check) the
+        # binary on each PRODUCTION backend lane so the warm_up + fail-closed
+        # backend-selection wiring cannot silently rot (evidence-drift guard).
+        # parko-ros2 uses untyped r2r subscriptions, so base jazzy is enough (no
+        # curated msgs workspace needed). ort `load-dynamic` compiles with no ORT
+        # runtime present, so these are clean compile-only gates.
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          cargo build -p parko-ros2 --bin parko_ros2_node --features ros2,onnx-backend
+          cargo build -p parko-ros2 --bin parko_ros2_node --features ros2,tensorrt-backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,28 @@ jobs:
           echo "Excluding runtime-dependent backends: $EXCLUDES"
           cargo test --workspace $EXCLUDES
 
+  parko-ros2-backends:
+    name: Parko ros2 backend-selection lanes (build, no runtime)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: build the onnx + tensorrt backend-selection lanes
+        # `parko_ros2::backend_select` compiles exactly ONE backend per feature
+        # (mock / onnx / tensorrt), fail-closed, TensorRT taking precedence. The
+        # module is NOT ros2-gated, so these lanes build with no ROS 2 and no ORT
+        # runtime (load-dynamic) — this is the only CI step that compiles the
+        # parko-onnx and parko-tensorrt selection paths in parko-ros2. The mock lane
+        # is already covered by the default-feature workspace test in parko-safety;
+        # the ros2 BINARY call site (main → select_backend, warm_up) remains
+        # uncompiled by CI — tracked as a follow-up (no parko-ros2 --features ros2
+        # build job exists yet).
+        working-directory: parko
+        run: |
+          cargo build -p parko-ros2 --features onnx-backend
+          cargo build -p parko-ros2 --features tensorrt-backend
+
   parko-onnx:
     name: Parko ONNX Backend Tests (ORT v1.23.2)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,6 +456,12 @@ jobs:
         # parko-ros2 uses untyped r2r subscriptions, so base jazzy is enough (no
         # curated msgs workspace needed). ort `load-dynamic` compiles with no ORT
         # runtime present, so these are clean compile-only gates.
+        #
+        # working-directory: parko — parko-ros2 lives in the SEPARATE parko/
+        # workspace; `-p parko-ros2 --features` from the repo root fails with
+        # "cannot specify features for packages outside of workspace", so run from
+        # the parko workspace root (mirrors the parko-ros2-backends job).
+        working-directory: parko
         run: |
           source /opt/ros/jazzy/setup.bash
           cargo build -p parko-ros2 --bin parko_ros2_node --features ros2,onnx-backend

--- a/docs/adr/0009-parko-tensorrt-precision-a2-native-nvinfer.md
+++ b/docs/adr/0009-parko-tensorrt-precision-a2-native-nvinfer.md
@@ -2,38 +2,34 @@
 
 | Field | Value |
 |---|---|
-| Status | **Pending safety-case review** — decision deferred to the safety-case owner; neither A1 nor A2 is committed. Engineering recommendation below leans A1, but the choice turns on the certification target's precision allocation. |
+| Status | **Accepted — A1 (ort TRT EP; measured decision-agreement). A2 deferred, data-gated.** |
 | Date | 2026-06-19 |
-| Deciders | Safety-case owner (pending) |
+| Deciders | Project / safety-case owner |
 | Issues | #415 (remaining PARK-021 jetson-gated items), #414 (on-hardware validation, closed) |
 | Code | `parko/crates/parko-tensorrt/src/lib.rs` (`Tf32Control`, `TrtPosture`, `park021_jetson_gated` #3) |
 | Evidence | `tests/tf32_probe.rs`, `tests/equivalence_probe.rs` (Jetson Orin NX, JP6.2, ORT 1.23.0) |
 
-## Decision: deferred to safety-case review
+## Decision: A1 accepted
 
-This choice is **not** made unilaterally in engineering — it is **flagged for the
-safety-case owner**, because A1-vs-A2 turns on whether the certification target allocates
-a positive full-precision requirement to the raw inference output. Neither option is
-committed until that review lands. The two triggers below frame the decision.
-
-## Engineering recommendation (input to that review — leans A1)
-
-**Lean A1 (ort TRT EP); don't build A2 (native nvinfer) speculatively.** The argument is
-architectural, not just the measured drift: **the Kirra Governor is the independent
+**Stay on A1 (ort TRT EP); do NOT build A2 (native nvinfer) now.** The decisive argument
+is architectural, not just the measured drift: **the Kirra Governor is the independent
 safety channel** — it clamps the actuator to the kinematic envelope regardless of what
 the model emits. So the inference backend's bit-precision bears on *decision quality /
-availability*, **not** the hard safety boundary, which the Governor owns. *If* the safety
-case concurs that no requirement is allocated to the raw inference output, a *measured
+availability*, **not** the hard safety boundary, which the Governor owns. A *measured
 decision-agreement* bound (the TRT-vs-CPU-baseline argmax, with the logit drift recorded)
-is the proportionate evidence and `full_precision_guaranteed()` stays honestly `false`.
+is therefore the proportionate evidence; `full_precision_guaranteed()` stays honestly
+`false`, accepted because no safety requirement is allocated to the raw inference output.
 
-**A2 becomes the answer if either trigger fires:** (1) on a production-representative
-model the equivalence probe shows TF32-scale drift (~1e-3) that flips the governed
-decision; or (2) the safety case allocates a positive full-precision requirement to the
-inference output itself (then A2 / `kTF32=false` is mandatory regardless of measurements).
-Tonight's data (drift 2.98e-7 ≈ fp32 ε, TF32 not engaged on MNIST) is consistent with A1,
-but is from MNIST — the trigger-(1) measurement must be re-run on a representative model
-before the recommendation is load-bearing.
+**A2 is reconsidered only if a trigger fires** — this acceptance is data-gated, not
+permanent: (1) on a production-representative model the equivalence probe shows TF32-scale
+drift (~1e-3) that flips the governed decision; or (2) a future HARA/DFA allocates a
+positive full-precision requirement to the inference output itself (then A2 / `kTF32=false`
+is mandatory regardless of measurements), which **supersedes** this ADR.
+
+**Standing obligation:** tonight's supporting data (drift 2.98e-7 ≈ fp32 ε, TF32 not
+engaged) is from MNIST; re-run the trigger-(1) equivalence/TF32 measurement on the
+production-representative model (#415 #4) to confirm A1 holds there — tracked, not blocking
+this acceptance.
 
 ## Context
 

--- a/docs/adr/0009-parko-tensorrt-precision-a2-native-nvinfer.md
+++ b/docs/adr/0009-parko-tensorrt-precision-a2-native-nvinfer.md
@@ -2,36 +2,38 @@
 
 | Field | Value |
 |---|---|
-| Status | **Accepted — A1 (measured decision-agreement); A2 deferred, data-gated.** Ratify in the safety case. |
+| Status | **Pending safety-case review** — decision deferred to the safety-case owner; neither A1 nor A2 is committed. Engineering recommendation below leans A1, but the choice turns on the certification target's precision allocation. |
 | Date | 2026-06-19 |
-| Deciders | Project owner |
+| Deciders | Safety-case owner (pending) |
 | Issues | #415 (remaining PARK-021 jetson-gated items), #414 (on-hardware validation, closed) |
 | Code | `parko/crates/parko-tensorrt/src/lib.rs` (`Tf32Control`, `TrtPosture`, `park021_jetson_gated` #3) |
 | Evidence | `tests/tf32_probe.rs`, `tests/equivalence_probe.rs` (Jetson Orin NX, JP6.2, ORT 1.23.0) |
 
-## Decision (accepted)
+## Decision: deferred to safety-case review
 
-**Stay on A1 (ort TRT EP); do NOT build A2 (native nvinfer) now.** The decisive
-argument is architectural, not just the measured drift: **the Kirra Governor is the
-independent safety channel** — it clamps the actuator to the kinematic envelope
-regardless of what the model emits. So the inference backend's bit-precision bears on
-*decision quality / availability*, **not** the hard safety boundary, which the Governor
-owns. A *measured decision-agreement* bound (the TRT-vs-CPU-baseline argmax, with the
-logit drift recorded) is therefore the proportionate evidence; `full_precision_guaranteed()`
-stays honestly `false`, and that is acceptable because no safety requirement is allocated
-to the raw inference output.
+This choice is **not** made unilaterally in engineering — it is **flagged for the
+safety-case owner**, because A1-vs-A2 turns on whether the certification target allocates
+a positive full-precision requirement to the raw inference output. Neither option is
+committed until that review lands. The two triggers below frame the decision.
 
-A2 is reconsidered **only** if either trigger fires: (1) on a production-representative
+## Engineering recommendation (input to that review — leans A1)
+
+**Lean A1 (ort TRT EP); don't build A2 (native nvinfer) speculatively.** The argument is
+architectural, not just the measured drift: **the Kirra Governor is the independent
+safety channel** — it clamps the actuator to the kinematic envelope regardless of what
+the model emits. So the inference backend's bit-precision bears on *decision quality /
+availability*, **not** the hard safety boundary, which the Governor owns. *If* the safety
+case concurs that no requirement is allocated to the raw inference output, a *measured
+decision-agreement* bound (the TRT-vs-CPU-baseline argmax, with the logit drift recorded)
+is the proportionate evidence and `full_precision_guaranteed()` stays honestly `false`.
+
+**A2 becomes the answer if either trigger fires:** (1) on a production-representative
 model the equivalence probe shows TF32-scale drift (~1e-3) that flips the governed
-decision; or (2) the safety case explicitly allocates a positive full-precision
-requirement to the inference output itself. Tonight's data (drift 2.98e-7 ≈ fp32 ε,
-TF32 not engaged on MNIST) is consistent with A1; the trigger measurement is re-run when
-a representative model exists.
-
-**Caveat:** this is the engineering decision; it must be **ratified by the safety-case
-owner** against the certification target before it is load-bearing in the assurance
-argument. If a future HARA/DFA allocates a precision requirement to the model output,
-this ADR is superseded by an A2 decision.
+decision; or (2) the safety case allocates a positive full-precision requirement to the
+inference output itself (then A2 / `kTF32=false` is mandatory regardless of measurements).
+Tonight's data (drift 2.98e-7 ≈ fp32 ε, TF32 not engaged on MNIST) is consistent with A1,
+but is from MNIST — the trigger-(1) measurement must be re-run on a representative model
+before the recommendation is load-bearing.
 
 ## Context
 

--- a/docs/adr/0009-parko-tensorrt-precision-a2-native-nvinfer.md
+++ b/docs/adr/0009-parko-tensorrt-precision-a2-native-nvinfer.md
@@ -20,6 +20,15 @@ decision-agreement* bound (the TRT-vs-CPU-baseline argmax, with the logit drift 
 is therefore the proportionate evidence; `full_precision_guaranteed()` stays honestly
 `false`, accepted because no safety requirement is allocated to the raw inference output.
 
+For an assessor, the precision decision is **explicitly a consequence of the
+doer/checker independence architecture**, not an isolated numerical judgement: the model
+(doer) proposes; the Governor (checker) — a structurally independent channel with its own
+diverse implementation and its own envelope — disposes. A precision deficiency in the doer
+can degrade *what is proposed* but cannot breach the actuator envelope the checker
+enforces. That is precisely why the inference backend's bit-precision sits **outside** the
+hard safety case, and why A1's measured-agreement evidence is sufficient unless the
+independence argument itself is weakened (see triggers).
+
 **A2 is reconsidered only if a trigger fires** — this acceptance is data-gated, not
 permanent: (1) on a production-representative model the equivalence probe shows TF32-scale
 drift (~1e-3) that flips the governed decision; or (2) a future HARA/DFA allocates a

--- a/docs/adr/0009-parko-tensorrt-precision-a2-native-nvinfer.md
+++ b/docs/adr/0009-parko-tensorrt-precision-a2-native-nvinfer.md
@@ -2,12 +2,36 @@
 
 | Field | Value |
 |---|---|
-| Status | **Proposed** |
+| Status | **Accepted — A1 (measured decision-agreement); A2 deferred, data-gated.** Ratify in the safety case. |
 | Date | 2026-06-19 |
-| Deciders | Project owner (pending) |
+| Deciders | Project owner |
 | Issues | #415 (remaining PARK-021 jetson-gated items), #414 (on-hardware validation, closed) |
 | Code | `parko/crates/parko-tensorrt/src/lib.rs` (`Tf32Control`, `TrtPosture`, `park021_jetson_gated` #3) |
 | Evidence | `tests/tf32_probe.rs`, `tests/equivalence_probe.rs` (Jetson Orin NX, JP6.2, ORT 1.23.0) |
+
+## Decision (accepted)
+
+**Stay on A1 (ort TRT EP); do NOT build A2 (native nvinfer) now.** The decisive
+argument is architectural, not just the measured drift: **the Kirra Governor is the
+independent safety channel** — it clamps the actuator to the kinematic envelope
+regardless of what the model emits. So the inference backend's bit-precision bears on
+*decision quality / availability*, **not** the hard safety boundary, which the Governor
+owns. A *measured decision-agreement* bound (the TRT-vs-CPU-baseline argmax, with the
+logit drift recorded) is therefore the proportionate evidence; `full_precision_guaranteed()`
+stays honestly `false`, and that is acceptable because no safety requirement is allocated
+to the raw inference output.
+
+A2 is reconsidered **only** if either trigger fires: (1) on a production-representative
+model the equivalence probe shows TF32-scale drift (~1e-3) that flips the governed
+decision; or (2) the safety case explicitly allocates a positive full-precision
+requirement to the inference output itself. Tonight's data (drift 2.98e-7 ≈ fp32 ε,
+TF32 not engaged on MNIST) is consistent with A1; the trigger measurement is re-run when
+a representative model exists.
+
+**Caveat:** this is the engineering decision; it must be **ratified by the safety-case
+owner** against the certification target before it is load-bearing in the assurance
+argument. If a future HARA/DFA allocates a precision requirement to the model output,
+this ADR is superseded by an A2 decision.
 
 ## Context
 

--- a/docs/adr/0010-parko-backend-construction-and-warmup-wiring.md
+++ b/docs/adr/0010-parko-backend-construction-and-warmup-wiring.md
@@ -32,11 +32,20 @@ The construction/selection half is now resolved too — as a **compile-time, fai
 feature-gated** selector in the `parko-ros2` *lib* (NOT ros2-gated, so it builds and is
 CI-verified without a ROS 2 distro):
 
-- `(no feature)` → `MockBackend` (dev only) · `onnx-backend` → `parko-onnx OrtBackend`
-  · `tensorrt-backend` → `parko-tensorrt TrtBackend` (takes precedence when both on).
-- Exactly one backend compiles in; a real backend whose runtime/EP is unavailable returns
-  `Err` and the node REFUSES to start (no silent substitution) — mirrors the installer's
-  explicit `--target` and `parko-core::backend_selector`'s "selection is explicit" rule.
+Two explicit gates, both fail-closed, both must agree:
+
+- **Compile-time (authoritative):** `(no feature)` → `MockBackend` (dev only) ·
+  `onnx-backend` → `parko-onnx OrtBackend` · `tensorrt-backend` → `parko-tensorrt
+  TrtBackend` (takes precedence when both on). Exactly one backend compiles in.
+- **Runtime (operator declaration):** if `PARKO_BACKEND` is set it MUST name the
+  compiled-in backend (`mock` / `onnx` / `tensorrt`, case-insensitive) — else the node
+  refuses to start (`verify_backend_env`). It is a cross-check, never a switch (only one
+  backend is compiled in); it catches "deployed the wrong binary". Unset → the
+  compile-time gate stands. This is the "feature **+** explicit env" selection the project
+  owner chose (PARK-021 Q1).
+- A real backend whose runtime/EP is unavailable returns `Err` and the node REFUSES to
+  start (no silent substitution) — mirrors the installer's explicit `--target` and
+  `parko-core::backend_selector`'s "selection is explicit" rule.
 - `parko_ros2_node::main` calls `select_backend(&model_path)` (fail-closed, exit 2), then
   `build_loop` calls the `warm_up` hook (fail-closed, exit 4). The installer's
   `--target tensorrt` maps to building `--features ros2,tensorrt-backend`.

--- a/docs/adr/0010-parko-backend-construction-and-warmup-wiring.md
+++ b/docs/adr/0010-parko-backend-construction-and-warmup-wiring.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | **Partially accepted** — warm-up *hook* wired; backend *construction* home still open |
+| Status | **Accepted** — warm-up *hook* wired (PR #418) + backend *construction/selection* implemented (`parko_ros2::backend_select`) |
 | Date | 2026-06-19 |
 | Deciders | Project owner (pending on the construction/selection half) |
 | Issues | #415 (PARK-021 #2 — engine warm-up) |
@@ -24,10 +24,32 @@ warm-up was wired as a **lifecycle hook on the `InferenceBackend` trait** instea
 - `parko-ros2`: `build_loop` calls `backend.warm_up(&model)` right after `load_model`,
   **fail-closed** (exit 4) — the node refuses to serve against an unbuilt engine.
 
-No `parko-kirra` factory and no new crate were needed for the hook. The **remaining
-open question** is narrower than first framed: only *where the concrete `TrtBackend`
-gets constructed/selected* in the node (it currently builds only mock / CPU-ORT). The
-trait hook means whoever constructs it gets warm-up for free.
+No `parko-kirra` factory and no new crate were needed for the hook.
+
+## Update 2 (implemented) — backend construction/selection: `parko_ros2::backend_select`
+
+The construction/selection half is now resolved too — as a **compile-time, fail-closed,
+feature-gated** selector in the `parko-ros2` *lib* (NOT ros2-gated, so it builds and is
+CI-verified without a ROS 2 distro):
+
+- `(no feature)` → `MockBackend` (dev only) · `onnx-backend` → `parko-onnx OrtBackend`
+  · `tensorrt-backend` → `parko-tensorrt TrtBackend` (takes precedence when both on).
+- Exactly one backend compiles in; a real backend whose runtime/EP is unavailable returns
+  `Err` and the node REFUSES to start (no silent substitution) — mirrors the installer's
+  explicit `--target` and `parko-core::backend_selector`'s "selection is explicit" rule.
+- `parko_ros2_node::main` calls `select_backend(&model_path)` (fail-closed, exit 2), then
+  `build_loop` calls the `warm_up` hook (fail-closed, exit 4). The installer's
+  `--target tensorrt` maps to building `--features ros2,tensorrt-backend`.
+
+**Verified:** all three lanes build (`cargo build -p parko-ros2 --features {onnx,tensorrt}-backend`),
+mock-lane tests pass, runtime-isolation guard still passes (the `parko-tensorrt` dep is
+optional, so `parko-ros2` stays off the runtime-dependent list). A new CI job
+(`parko-ros2-backends`) compiles the onnx/tensorrt lanes.
+
+**Remaining open item (pre-existing CI gap, not introduced here):** no CI job builds the
+`parko-ros2` *binary* with `--features ros2`, so the node `main`/`build_loop` call sites
+(this ADR's wiring + #418's warm-up) are not yet compile-checked by CI. A `parko-ros2
+--features ros2` build job (ROS 2 env, like the kirra-ros2-adapter job) should be added.
 
 ## Context
 

--- a/docs/adr/0010-parko-backend-construction-and-warmup-wiring.md
+++ b/docs/adr/0010-parko-backend-construction-and-warmup-wiring.md
@@ -52,13 +52,16 @@ Two explicit gates, both fail-closed, both must agree:
 
 **Verified:** all three lanes build (`cargo build -p parko-ros2 --features {onnx,tensorrt}-backend`),
 mock-lane tests pass, runtime-isolation guard still passes (the `parko-tensorrt` dep is
-optional, so `parko-ros2` stays off the runtime-dependent list). A new CI job
-(`parko-ros2-backends`) compiles the onnx/tensorrt lanes.
+optional, so `parko-ros2` stays off the runtime-dependent list).
 
-**Remaining open item (pre-existing CI gap, not introduced here):** no CI job builds the
-`parko-ros2` *binary* with `--features ros2`, so the node `main`/`build_loop` call sites
-(this ADR's wiring + #418's warm-up) are not yet compile-checked by CI. A `parko-ros2
---features ros2` build job (ROS 2 env, like the kirra-ros2-adapter job) should be added.
+**CI coverage (both halves, closed in this PR):**
+- `parko-ros2-backends` job — compiles the `backend_select` *module* on the onnx + tensorrt
+  lanes (no ROS 2 / no ORT runtime).
+- `ros2-adapter-build` job (jazzy sourced) — now also builds the `parko_ros2_node` *binary*
+  on the `ros2,onnx-backend` and `ros2,tensorrt-backend` lanes, compiling the node call
+  sites (`main` → `select_backend` → `build_loop` → `warm_up`). This closes the earlier
+  evidence-drift gap: a break in the wiring that makes warm-up real in the node now turns
+  CI red instead of silently passing.
 
 ## Context
 

--- a/parko/crates/parko-ros2/Cargo.toml
+++ b/parko/crates/parko-ros2/Cargo.toml
@@ -37,6 +37,13 @@ ros2 = ["dep:r2r", "dep:tracing-subscriber", "dep:futures"]
 # host.
 onnx-backend = ["dep:parko-onnx"]
 
+# Pull in parko-tensorrt (the NVIDIA Jetson backend). Optional + load-dynamic,
+# so it builds with no CUDA/TensorRT present (the EP is resolved at runtime,
+# fail-closed). TensorRT takes precedence over onnx-backend when both are on
+# (see backend_select). The on-Jetson install selects this via the installer's
+# `--target tensorrt` (which builds with --features ros2,tensorrt-backend).
+tensorrt-backend = ["dep:parko-tensorrt"]
+
 [dependencies]
 # Shared core (sensor model, scheduler, ControlCommand, SafetyGovernor
 # trait, MockBackend).
@@ -70,6 +77,10 @@ futures = { version = "0.3", optional = true }
 
 # Optional ONNX backend. The integrator opts in when ORT is installed.
 parko-onnx = { path = "../parko-onnx", optional = true }
+
+# Optional TensorRT (Jetson) backend. load-dynamic, so building it needs no
+# CUDA/TRT libs; the EP is resolved against the dlopened ORT at runtime.
+parko-tensorrt = { path = "../parko-tensorrt", optional = true }
 
 [dev-dependencies]
 # State-machine tests use parko-core's MockBackend (no ORT, no ROS).

--- a/parko/crates/parko-ros2/src/backend_select.rs
+++ b/parko/crates/parko-ros2/src/backend_select.rs
@@ -4,16 +4,22 @@
 //
 // EXPLICIT, FAIL-CLOSED, NO SILENT SUBSTITUTION — mirrors the installer's
 // `--target` ethos (`scripts/install-parko-backend.sh`) and
-// `parko-core::backend_selector`'s "selection is explicit" rule. Exactly ONE
-// concrete backend compiles in, chosen by Cargo feature:
+// `parko-core::backend_selector`'s "selection is explicit" rule.
 //
-//   (no backend feature)            → MockBackend     (development only)
-//   `onnx-backend`                  → parko-onnx OrtBackend (CPU)
-//   `tensorrt-backend`              → parko-tensorrt TrtBackend (Jetson)
+// TWO explicit gates, both must agree:
+//   1. COMPILE-TIME (authoritative): exactly ONE concrete backend compiles in,
+//      chosen by Cargo feature —
+//        (no backend feature) → MockBackend     (development only)
+//        `onnx-backend`        → parko-onnx OrtBackend (CPU)
+//        `tensorrt-backend`    → parko-tensorrt TrtBackend (Jetson)
+//      TensorRT takes precedence when both backend features are on.
+//   2. RUNTIME (operator declaration): if `PARKO_BACKEND` is set it MUST name the
+//      compiled-in backend (`mock` / `onnx` / `tensorrt`), else the node refuses to
+//      start. This is a fail-closed cross-check — it can never *switch* the backend
+//      (only one is compiled in); it catches "deployed the wrong binary".
 //
-// TensorRT takes precedence when both backend features are on. A real backend
-// whose runtime/EP is unavailable returns `Err` — the node then REFUSES to start
-// rather than fall back to another backend.
+// A real backend whose runtime/EP is unavailable returns `Err` — the node then
+// REFUSES to start rather than fall back to another backend.
 //
 // DELIBERATELY NOT `#[cfg(feature = "ros2")]`: this module compiles (and is
 // verified) without a ROS 2 distro, e.g. `cargo build -p parko-ros2
@@ -39,6 +45,41 @@ pub const SELECTED_BACKEND: &str = "onnx-cpu (parko-onnx)";
 #[cfg(not(any(feature = "tensorrt-backend", feature = "onnx-backend")))]
 pub const SELECTED_BACKEND: &str = "mock (development-only)";
 
+/// The `PARKO_BACKEND` token naming the compiled-in backend (the runtime
+/// cross-check below requires an equal, case-insensitive value when set).
+#[cfg(feature = "tensorrt-backend")]
+pub const SELECTED_BACKEND_TOKEN: &str = "tensorrt";
+#[cfg(all(feature = "onnx-backend", not(feature = "tensorrt-backend")))]
+pub const SELECTED_BACKEND_TOKEN: &str = "onnx";
+#[cfg(not(any(feature = "tensorrt-backend", feature = "onnx-backend")))]
+pub const SELECTED_BACKEND_TOKEN: &str = "mock";
+
+/// Fail-closed cross-check of the operator's `PARKO_BACKEND` declaration against
+/// the compiled-in backend. Unset/empty → the compile-time gate is authoritative
+/// (Ok). Set but mismatched → `Err` (refuse: wrong binary; no runtime switch).
+pub fn verify_backend_env() -> Result<(), BackendError> {
+    check_backend_declaration(std::env::var("PARKO_BACKEND").ok().as_deref())
+}
+
+/// Pure core of [`verify_backend_env`] — takes the declared value so it is
+/// testable without mutating process env (invariant #13: no `set_var`).
+fn check_backend_declaration(declared: Option<&str>) -> Result<(), BackendError> {
+    match declared {
+        Some(v) if !v.trim().is_empty() => {
+            let want = v.trim().to_ascii_lowercase();
+            if want != SELECTED_BACKEND_TOKEN {
+                return Err(BackendError::InitializationError(format!(
+                    "PARKO_BACKEND={want:?} but this binary was built with backend \
+                     {SELECTED_BACKEND_TOKEN:?} ({SELECTED_BACKEND}) — refusing (fail-closed; \
+                     rebuild with the matching --features, never a runtime substitution)"
+                )));
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
 /// A production backend build must be given a real model path, not the dev
 /// sentinel — reject it fail-closed rather than try to load `mock://…`.
 #[cfg(any(feature = "tensorrt-backend", feature = "onnx-backend"))]
@@ -52,24 +93,30 @@ fn require_real_model_path(model_path: &str) -> Result<(), BackendError> {
     Ok(())
 }
 
-/// Construct the compiled-in backend behind an `Arc`. FAIL-CLOSED: returns `Err`
-/// if a real backend's runtime/EP is unavailable; the caller must refuse to start
-/// (never substitute another backend). `warm_up` (the engine build for TensorRT)
-/// runs later, in the node's `build_loop`, via the `InferenceBackend` trait hook.
-#[cfg(feature = "tensorrt-backend")]
+/// Construct the compiled-in backend behind an `Arc`. FAIL-CLOSED on both gates:
+/// the `PARKO_BACKEND` cross-check and the backend's own runtime/EP availability.
+/// The caller must refuse to start on `Err` (never substitute another backend).
+/// `warm_up` (the engine build for TensorRT) runs later, in the node's
+/// `build_loop`, via the `InferenceBackend` trait hook.
 pub fn select_backend(model_path: &str) -> Result<Arc<SelectedBackend>, BackendError> {
+    verify_backend_env()?;
+    construct_backend(model_path)
+}
+
+#[cfg(feature = "tensorrt-backend")]
+fn construct_backend(model_path: &str) -> Result<Arc<SelectedBackend>, BackendError> {
     require_real_model_path(model_path)?;
     Ok(Arc::new(parko_tensorrt::TrtBackend::new(model_path)?))
 }
 
 #[cfg(all(feature = "onnx-backend", not(feature = "tensorrt-backend")))]
-pub fn select_backend(model_path: &str) -> Result<Arc<SelectedBackend>, BackendError> {
+fn construct_backend(model_path: &str) -> Result<Arc<SelectedBackend>, BackendError> {
     require_real_model_path(model_path)?;
     Ok(Arc::new(parko_onnx::OrtBackend::new(model_path)?))
 }
 
 #[cfg(not(any(feature = "tensorrt-backend", feature = "onnx-backend")))]
-pub fn select_backend(_model_path: &str) -> Result<Arc<SelectedBackend>, BackendError> {
+fn construct_backend(_model_path: &str) -> Result<Arc<SelectedBackend>, BackendError> {
     use std::collections::HashMap;
 
     use parko_core::backend::BackendDescriptor;
@@ -84,4 +131,29 @@ pub fn select_backend(_model_path: &str) -> Result<Arc<SelectedBackend>, Backend
     outputs.insert("cmd_vel_linear".to_string(), vec![0.0]);
     outputs.insert("cmd_vel_angular".to_string(), vec![0.0]);
     Ok(Arc::new(MockBackend::new(outputs, BackendDescriptor::Cpu)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parko_backend_unset_or_empty_is_ok() {
+        assert!(check_backend_declaration(None).is_ok());
+        assert!(check_backend_declaration(Some("")).is_ok());
+        assert!(check_backend_declaration(Some("   ")).is_ok());
+    }
+
+    #[test]
+    fn parko_backend_matching_token_is_ok_case_insensitive() {
+        let upper = SELECTED_BACKEND_TOKEN.to_uppercase();
+        assert!(check_backend_declaration(Some(&upper)).is_ok());
+        assert!(check_backend_declaration(Some(&format!("  {SELECTED_BACKEND_TOKEN}  "))).is_ok());
+    }
+
+    #[test]
+    fn parko_backend_mismatch_is_fail_closed() {
+        // Never the compiled-in token regardless of feature set.
+        assert!(check_backend_declaration(Some("definitely-not-a-real-backend")).is_err());
+    }
 }

--- a/parko/crates/parko-ros2/src/backend_select.rs
+++ b/parko/crates/parko-ros2/src/backend_select.rs
@@ -1,0 +1,87 @@
+// parko/crates/parko-ros2/src/backend_select.rs
+//
+// Compile-time backend selection for the Parko node (PARK-021 #2 / ADR-0010).
+//
+// EXPLICIT, FAIL-CLOSED, NO SILENT SUBSTITUTION — mirrors the installer's
+// `--target` ethos (`scripts/install-parko-backend.sh`) and
+// `parko-core::backend_selector`'s "selection is explicit" rule. Exactly ONE
+// concrete backend compiles in, chosen by Cargo feature:
+//
+//   (no backend feature)            → MockBackend     (development only)
+//   `onnx-backend`                  → parko-onnx OrtBackend (CPU)
+//   `tensorrt-backend`              → parko-tensorrt TrtBackend (Jetson)
+//
+// TensorRT takes precedence when both backend features are on. A real backend
+// whose runtime/EP is unavailable returns `Err` — the node then REFUSES to start
+// rather than fall back to another backend.
+//
+// DELIBERATELY NOT `#[cfg(feature = "ros2")]`: this module compiles (and is
+// verified) without a ROS 2 distro, e.g. `cargo build -p parko-ros2
+// --features tensorrt-backend`. The ROS 2 node binary merely calls it.
+
+use std::sync::Arc;
+
+use parko_core::backend::BackendError;
+
+/// The concrete backend type compiled into this build.
+#[cfg(feature = "tensorrt-backend")]
+pub type SelectedBackend = parko_tensorrt::TrtBackend;
+#[cfg(all(feature = "onnx-backend", not(feature = "tensorrt-backend")))]
+pub type SelectedBackend = parko_onnx::OrtBackend;
+#[cfg(not(any(feature = "tensorrt-backend", feature = "onnx-backend")))]
+pub type SelectedBackend = parko_core::backends::mock::MockBackend;
+
+/// Human-readable label for the compiled-in backend (logged at startup).
+#[cfg(feature = "tensorrt-backend")]
+pub const SELECTED_BACKEND: &str = "tensorrt (parko-tensorrt)";
+#[cfg(all(feature = "onnx-backend", not(feature = "tensorrt-backend")))]
+pub const SELECTED_BACKEND: &str = "onnx-cpu (parko-onnx)";
+#[cfg(not(any(feature = "tensorrt-backend", feature = "onnx-backend")))]
+pub const SELECTED_BACKEND: &str = "mock (development-only)";
+
+/// A production backend build must be given a real model path, not the dev
+/// sentinel — reject it fail-closed rather than try to load `mock://…`.
+#[cfg(any(feature = "tensorrt-backend", feature = "onnx-backend"))]
+fn require_real_model_path(model_path: &str) -> Result<(), BackendError> {
+    if model_path.is_empty() || model_path.starts_with("mock://") {
+        return Err(BackendError::InitializationError(format!(
+            "a production backend build ({SELECTED_BACKEND}) requires PARKO_MODEL_PATH to point at a \
+             real model — got {model_path:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// Construct the compiled-in backend behind an `Arc`. FAIL-CLOSED: returns `Err`
+/// if a real backend's runtime/EP is unavailable; the caller must refuse to start
+/// (never substitute another backend). `warm_up` (the engine build for TensorRT)
+/// runs later, in the node's `build_loop`, via the `InferenceBackend` trait hook.
+#[cfg(feature = "tensorrt-backend")]
+pub fn select_backend(model_path: &str) -> Result<Arc<SelectedBackend>, BackendError> {
+    require_real_model_path(model_path)?;
+    Ok(Arc::new(parko_tensorrt::TrtBackend::new(model_path)?))
+}
+
+#[cfg(all(feature = "onnx-backend", not(feature = "tensorrt-backend")))]
+pub fn select_backend(model_path: &str) -> Result<Arc<SelectedBackend>, BackendError> {
+    require_real_model_path(model_path)?;
+    Ok(Arc::new(parko_onnx::OrtBackend::new(model_path)?))
+}
+
+#[cfg(not(any(feature = "tensorrt-backend", feature = "onnx-backend")))]
+pub fn select_backend(_model_path: &str) -> Result<Arc<SelectedBackend>, BackendError> {
+    use std::collections::HashMap;
+
+    use parko_core::backend::BackendDescriptor;
+    use parko_core::backends::mock::MockBackend;
+
+    tracing::warn!(
+        "parko-ros2: using MockBackend (no backend feature compiled in). DEVELOPMENT-ONLY — emits a \
+         fixed zero command. Rebuild with --features ros2,onnx-backend (or tensorrt-backend) + set \
+         PARKO_MODEL_PATH for a production backend."
+    );
+    let mut outputs: HashMap<String, Vec<f32>> = HashMap::new();
+    outputs.insert("cmd_vel_linear".to_string(), vec![0.0]);
+    outputs.insert("cmd_vel_angular".to_string(), vec![0.0]);
+    Ok(Arc::new(MockBackend::new(outputs, BackendDescriptor::Cpu)))
+}

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -20,11 +20,9 @@
 
 #![cfg(feature = "ros2")]
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use parko_core::backend::{BackendDescriptor, InferenceBackend};
-use parko_core::backends::mock::MockBackend;
+use parko_core::backend::InferenceBackend;
 use parko_core::commands::ControlCommand;
 use parko_core::safety::SafetyPosture;
 use parko_core::scheduler::InferenceLoop;
@@ -48,18 +46,6 @@ fn init_tracing() {
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
         .try_init();
-}
-
-fn build_dev_backend() -> Arc<MockBackend> {
-    tracing::warn!(
-        "parko-ros2: using MockBackend (no PARKO_MODEL_PATH set / onnx-backend feature off). \
-         This is DEVELOPMENT-ONLY — the node will emit a fixed zero command. \
-         Set PARKO_MODEL_PATH and rebuild with --features ros2,onnx-backend for the production path."
-    );
-    let mut outputs: HashMap<String, Vec<f32>> = HashMap::new();
-    outputs.insert("cmd_vel_linear".to_string(),  vec![0.0]);
-    outputs.insert("cmd_vel_angular".to_string(), vec![0.0]);
-    Arc::new(MockBackend::new(outputs, BackendDescriptor::Cpu))
 }
 
 /// CERT-006: resolve the comparator divergence sink from the environment,
@@ -334,14 +320,27 @@ async fn main() {
     let config = Arc::new(build_config());
     tracing::info!(?config, "parko_ros2_node starting");
 
-    // Pick a backend. Today's binary only carries the MockBackend
-    // path; production deployments override this with the
-    // `onnx-backend` feature + `PARKO_MODEL_PATH`. The feature-flag
-    // dispatch is a deliberate compile-time gate so a misconfigured
-    // production build can't accidentally fall through to MockBackend.
+    // Pick the backend compiled into THIS build (compile-time feature gate, so a
+    // misconfigured production build can't fall through to the mock). The mock lane
+    // tolerates the dev sentinel; the onnx/tensorrt lanes require a real
+    // PARKO_MODEL_PATH and FAIL-CLOSED if their runtime/EP is absent — never a
+    // silent substitution. See `parko_ros2::backend_select`.
     let model_path = std::env::var("PARKO_MODEL_PATH")
         .unwrap_or_else(|_| "mock://development".to_string());
-    let backend = build_dev_backend();
+    tracing::info!(
+        backend = parko_ros2::backend_select::SELECTED_BACKEND,
+        %model_path,
+        "parko-ros2: selected backend"
+    );
+    let backend = parko_ros2::backend_select::select_backend(&model_path)
+        .unwrap_or_else(|e| {
+            eprintln!(
+                "parko_ros2_node: backend construction failed ({}) for {model_path:?} — refusing to \
+                 start (fail-closed, no fallback): {e:?}",
+                parko_ros2::backend_select::SELECTED_BACKEND,
+            );
+            std::process::exit(2);
+        });
     let infer = build_loop(backend, &model_path, config.tick_period_s);
 
     // M2 posture: static, defaults to Nominal. M1b's `PostureTracker`

--- a/parko/crates/parko-ros2/src/lib.rs
+++ b/parko/crates/parko-ros2/src/lib.rs
@@ -24,6 +24,7 @@
 // subset as an aligned list the markdown-nesting lint would reformat.
 #![allow(clippy::doc_lazy_continuation, clippy::doc_overindented_list_items)]
 
+pub mod backend_select;
 pub mod clearance_gate;
 pub mod command_mapping;
 pub mod comparator_adapter;


### PR DESCRIPTION
Resolves the two open PARK-021 decisions and completes the TensorRT-in-node wiring. Follow-on to #418. Reflects the project owner's answers (PARK-021 Q1/Q2).

## Q1 — Construct/select `TrtBackend` in the node — "feature + explicit env" (ADR-0010, Accepted)

The node previously **always** used `MockBackend` — the `onnx-backend` path was described in comments but never dispatched. This adds **`parko_ros2::backend_select`** with **two fail-closed gates that must agree**:

- **Compile-time (authoritative):** `(no feature)` → `MockBackend` (dev) · `onnx-backend` → `parko-onnx OrtBackend` · `tensorrt-backend` → `parko-tensorrt TrtBackend` (**TRT precedence** when both on). Exactly one compiles in.
- **Runtime (explicit operator declaration):** if `PARKO_BACKEND` is set it **must** name the compiled-in backend (`mock`/`onnx`/`tensorrt`, case-insensitive) or the node **refuses to start** (`verify_backend_env`). A cross-check, never a switch — catches "deployed the wrong binary". This is the "feature **+** explicit env" mechanism chosen for Q1.
- A real backend whose runtime/EP is unavailable returns `Err` → node **refuses to start** (no silent substitution), mirroring the installer's `--target` and `backend_selector`'s "selection is explicit" rule.
- `main` → `select_backend` (fail-closed, exit 2) → `build_loop` runs the `warm_up` hook (fail-closed, exit 4). Installer `--target tensorrt` maps to `--features ros2,tensorrt-backend`.
- Selection is **not** ROS2-gated, so it compiles with no ROS2 distro — new CI job **`parko-ros2-backends`** builds the onnx + tensorrt lanes (the only CI coverage of those paths).

## Q2 — Precision — **A1 accepted** (ADR-0009, Accepted)

Owner decision: **accept A1** (ort TRT EP, measured decision-agreement). The **Governor is the independent safety channel**, so backend bit-precision is *decision-quality*, not the hard safety boundary → a measured decision-agreement bound is proportionate, and `full_precision_guaranteed()` stays honestly `false`. **Data-gated:** A2 (native `nvinfer`, `kTF32=false`) supersedes only if a representative model shows TF32-scale drift that flips a governed decision, or a HARA/DFA allocates a precision requirement to the inference output. Standing obligation: re-run the trigger measurement on the production model (#415 #4) — tracked, not blocking.

## Validation
- All three lanes build (`--features {onnx,tensorrt}-backend` + default); `parko-ros2` tests pass incl. 3 new `backend_select` unit tests (logic parameterized → no `env::set_var`, invariant #13); runtime-isolation guard passes (`parko-tensorrt` dep is optional → `parko-ros2` stays off the runtime-dependent list); `ci.yml` valid.

## Known gap (pre-existing, not introduced here)
No CI job builds `parko-ros2 --features ros2`, so the node **binary** call sites (`main`/`build_loop` — this PR's `select_backend` + #418's `warm_up`) aren't compile-checked by CI. ADR-0010 notes this; a `parko-ros2 --features ros2` build job (ROS2 env, like the kirra-ros2-adapter job) is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58