### PR TITLE
fix(#404): scalar governor + C FFI reject non-finite input fail-closed

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -20,6 +20,15 @@ pub extern "C" fn kirra_filter_move_velocity(proposed_velocity: f64, dt: f64) ->
 pub extern "C" fn kirra_filter_rotate_velocity(proposed_angular: f64, _dt: f64) -> f64 {
     if let Ok(mut g) = GLOBAL_GOVERNOR.lock() {
         let max = g.contract.max_angular_rate();
+        // Fail-closed on non-finite input: this shim clamps inline (it does NOT go
+        // through `evaluate`), and `NaN.abs() > max` is `false`, so an unguarded
+        // `NaN` would be forwarded to the actuator unclamped (#404). Command zero
+        // angular rate and decay trust. (`kirra_filter_move_velocity` is fixed
+        // transitively — it routes through `evaluate`'s Priority-0 guard.)
+        if !proposed_angular.is_finite() {
+            g.trust_engine.decay_trust(30);
+            return 0.0;
+        }
         if proposed_angular.abs() > max {
             g.trust_engine.decay_trust(30);
             proposed_angular.clamp(-max, max)
@@ -173,5 +182,34 @@ mod reset_clock_tests {
             now > 1_600_000_000_000,
             "supervisor reset must use real wall-clock ms (got {now}), never a frozen 0"
         );
+    }
+}
+
+#[cfg(test)]
+mod ffi_nonfinite_tests {
+    use super::*;
+
+    // #404: both C-ABI shims must fail-closed on non-finite input. The returns are
+    // invariant of prior GLOBAL_GOVERNOR trust state (the non-finite guards short-
+    // circuit before any trust-mode branching), so these are deterministic even
+    // though they share the process-wide governor.
+
+    #[test]
+    fn rotate_velocity_rejects_nonfinite_to_zero() {
+        // Clamps inline (NOT via `evaluate`): NaN.abs() > max is false, so without
+        // the guard a NaN would be forwarded unclamped. Must command zero.
+        assert_eq!(kirra_filter_rotate_velocity(f64::NAN, 0.05), 0.0);
+        assert_eq!(kirra_filter_rotate_velocity(f64::INFINITY, 0.05), 0.0);
+        assert_eq!(kirra_filter_rotate_velocity(f64::NEG_INFINITY, 0.05), 0.0);
+    }
+
+    #[test]
+    fn move_velocity_rejects_nonfinite_to_finite_fallback() {
+        // Fixed transitively by `evaluate`'s Priority-0 guard → contract fallback.
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let out = kirra_filter_move_velocity(bad, 0.05);
+            assert!(out.is_finite(), "move shim must never return non-finite (got {out})");
+            assert_eq!(out, 0.0);
+        }
     }
 }

--- a/src/kirra_core.rs
+++ b/src/kirra_core.rs
@@ -145,6 +145,24 @@ impl<C: SafetyContract> KirraKernelGovernor<C> {
 
 impl<C: SafetyContract> SafetyGovernor for KirraKernelGovernor<C> {
     fn evaluate(&mut self, proposed_demand: f64, mut dt: f64) -> GovernorInterceptResult {
+        // Priority 0 (fail-closed): non-finite input. IEEE-754 `NaN` compares
+        // `false` against every envelope/rate threshold, so an unguarded `NaN`
+        // would fall straight through the `ExecuteUnrestricted` passthrough as a
+        // "safe" command (and a `NaN`/`Inf` `dt` would poison the rate check).
+        // Reject explicitly: command the contract fallback, decay trust, and report
+        // an UNSAFE control state. `last_validated_scalar` is intentionally NOT
+        // advanced to a tainted value. (#404 — this scalar/FFI ingress was the one
+        // path that treated `NaN` as nominal; the vehicle path already guards.)
+        if !proposed_demand.is_finite() || !dt.is_finite() {
+            self.trust_engine.decay_trust(30);
+            return GovernorInterceptResult {
+                sanitized_scalar: self.contract.fallback(),
+                asset_in_safe_control_state: false,
+                mitigation_narrative: "NONFINITE_INPUT_REJECTED_FAILSAFE".to_string(),
+                was_unsafe_attempt: true,
+                was_rate_breached: false,
+            };
+        }
         if dt <= 0.001 { dt = 0.050; }
 
         let prior_trust_mode = self.trust_mode();
@@ -260,5 +278,74 @@ impl CausalFlightRecorder {
             score: entry.score, system_state: entry.state, trust_mode: entry.mode, operator_narrative: entry.narrative,
         });
         if self.journal.len() > 100 { self.journal.pop_front(); }
+    }
+}
+
+#[cfg(test)]
+mod governor_nonfinite_tests {
+    // #404 — the scalar KirraKernelGovernor must fail-closed on non-finite input
+    // (NaN compares false against every threshold, so an unguarded NaN/Inf would
+    // pass through as a "safe" command). kirra_core.rs previously had no tests.
+    use super::KirraKernelGovernor;
+    use crate::kinematics_contract::KinematicContract;
+    use crate::{SafetyContract, SafetyGovernor};
+
+    fn gov() -> KirraKernelGovernor<KinematicContract> {
+        let contract = KinematicContract {
+            max_linear_velocity: 2.0,
+            max_angular_velocity: 1.0,
+            max_linear_acceleration: 10.0,
+            fallback_linear_speed: 0.0,
+        };
+        KirraKernelGovernor::new(contract, 0.0, -2.0, 2.0)
+    }
+
+    #[test]
+    fn nan_demand_is_rejected_failsafe_not_passed_through() {
+        let mut g = gov();
+        let out = g.evaluate(f64::NAN, 0.05);
+        assert!(out.sanitized_scalar.is_finite(), "must never return NaN to an actuator");
+        assert_eq!(out.sanitized_scalar, g.contract.fallback());
+        assert!(!out.asset_in_safe_control_state, "NaN must not read as a safe control state");
+        assert!(out.was_unsafe_attempt);
+    }
+
+    #[test]
+    fn inf_demand_is_rejected_failsafe() {
+        let mut g = gov();
+        for demand in [f64::INFINITY, f64::NEG_INFINITY] {
+            let out = g.evaluate(demand, 0.05);
+            assert!(out.sanitized_scalar.is_finite());
+            assert_eq!(out.sanitized_scalar, g.contract.fallback());
+            assert!(!out.asset_in_safe_control_state);
+        }
+    }
+
+    #[test]
+    fn nan_dt_is_rejected_failsafe() {
+        let mut g = gov();
+        let out = g.evaluate(1.0, f64::NAN);
+        assert!(out.sanitized_scalar.is_finite());
+        assert!(!out.asset_in_safe_control_state);
+    }
+
+    #[test]
+    fn nonfinite_does_not_advance_last_validated_scalar() {
+        let mut g = gov();
+        let before = g.last_validated_scalar;
+        let _ = g.evaluate(f64::NAN, 0.05);
+        assert_eq!(g.last_validated_scalar, before, "tainted value must not be retained");
+    }
+
+    #[test]
+    fn finite_in_envelope_still_passes() {
+        // A genuinely nominal command: in-envelope (|0.4| < 2.0) AND within the
+        // rate limit (0.4 / 0.05 = 8 m/s^2 < the 10 m/s^2 accel cap), so it is a
+        // clean passthrough — distinct from the rate-clamped or fail-closed paths.
+        let mut g = gov();
+        let out = g.evaluate(0.4, 0.05);
+        assert!(out.asset_in_safe_control_state, "a nominal in-envelope, in-rate command must read safe");
+        assert!(!out.was_unsafe_attempt);
+        assert!((out.sanitized_scalar - 0.4).abs() < 1e-9, "got {}", out.sanitized_scalar);
     }
 }


### PR DESCRIPTION
Fixes a **fail-open in a fail-closed governor** (#404): `KirraKernelGovernor::evaluate` had no `is_finite()` check, so a `NaN` command — which compares `false` against every envelope/rate threshold — fell straight through the Nominal `ExecuteUnrestricted` passthrough and was returned with `asset_in_safe_control_state = true`. Reachable through the **C ABI** (`src/ffi.rs`, the ADR-0006 Clause 3 integration boundary).

## Changes
- **`src/kirra_core.rs`** — Priority-0 finite guard at the top of `evaluate`: non-finite `proposed_demand`/`dt` → contract `fallback()`, `asset_in_safe_control_state = false`, trust decayed, `NONFINITE_INPUT_REJECTED_FAILSAFE`. `last_validated_scalar` is **not** advanced to a tainted value. This was the one ingress treating `NaN` as nominal — the vehicle path (`validate_vehicle_command`) and parko governor already guard.
- **`src/ffi.rs`** — `kirra_filter_rotate_velocity` clamps inline (not via `evaluate`), and `NaN.abs() > max` is `false`, so it had the same bug independently → its own guard returns `0.0`. `kirra_filter_move_velocity` is fixed transitively.
- **Tests** — `kirra_core.rs` gains its **first** `#[cfg(test)]` module (`governor_nonfinite_tests`, 5 cases); `ffi.rs` gains `ffi_nonfinite_tests` for both shims.

## A correction to the issue's proposed test
The issue's `finite_in_envelope_still_passes` would actually **fail**: `KinematicContract::max_rate()` = `max_linear_acceleration` = 10.0, so the issue's `evaluate(1.0, 0.05)` is a 20 m/s² rate breach (sanitized 0.5, `safe=false`), not the nominal passthrough it asserts. Changed to `evaluate(0.4, 0.05)` (8 m/s² — genuinely in-rate and in-envelope) so it exercises the real passthrough path. Caught by checking the contract impl, not applying the patch verbatim.

## Acceptance (all ✅)
- [x] `evaluate` rejects non-finite `proposed_demand`/`dt` → fallback + `asset_in_safe_control_state = false`
- [x] `kirra_filter_rotate_velocity` rejects non-finite angular → `0.0`
- [x] New `kirra_core.rs` test module passes
- [x] `cargo test -p kirra-runtime-sdk --lib` = **625 passed** (incl. 7 new); `cargo clippy --all-targets` = **clean**

> Not addressed here (the issue's lower-priority secondary notes): **N1** (single-action `EnforceAction` drops one clamp) and **N2** (the `ExecuteUnrestricted` envelope-xor-rate vs CLAUDE.md invariant #8) — both flagged "not blocking" and warrant their own scoped change.

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_