### PR TITLE
fix(parko-ros2): compile the --features ros2 node-binary build (serde_json + radar gate)

### DIFF
--- a/parko/crates/parko-ros2/Cargo.toml
+++ b/parko/crates/parko-ros2/Cargo.toml
@@ -30,7 +30,17 @@ default = []
 
 # Enable the r2r-backed node and the binary entry point. Requires a
 # sourced ROS 2 environment (Humble/Jazzy/Kilted per r2r 0.9.5 support).
-ros2 = ["dep:r2r", "dep:tracing-subscriber", "dep:futures"]
+# Everything this lane touches is BASE-jazzy (sensor_msgs / std_msgs /
+# nav_msgs / geometry_msgs, plus untyped subscriptions whose payload is a
+# `serde_json::Value`), so no curated message workspace is needed.
+ros2 = ["dep:r2r", "dep:tracing-subscriber", "dep:futures", "dep:serde_json"]
+
+# Opt-in: the DEFERRED typed r2r radar adapter (`radar_scan_msg_to_detections`),
+# which references `r2r::radar_msgs::msg::RadarScan`. `radar_msgs` is NOT a
+# base-jazzy package, so this is gated OUT of the plain `ros2` lane (keeping that
+# lane base-jazzy-only); enable it together with a ROS env that provides
+# `radar_msgs` (e.g. `ros-jazzy-radar-msgs`) when the radar path is wired.
+radar-ros2 = ["ros2"]
 
 # Pull in parko-onnx (the production CPU backend). Optional so the
 # default unit-test lane doesn't require libonnxruntime on the build
@@ -74,6 +84,11 @@ tracing-subscriber = { version = "0.3", features = ["json", "env-filter"], optio
 # futures Stream / StreamExt for consuming r2r's untyped subscription
 # streams in the drain tasks. Same pattern as the adapter.
 futures = { version = "0.3", optional = true }
+
+# r2r's untyped subscriptions/publishers exchange `serde_json::Value`; the node
+# builds the geometry_msgs/Twist envelope with `json!`. ros2-only (the default
+# unit-test lane has no r2r and never touches it), hence optional + the feature.
+serde_json = { version = "1", optional = true }
 
 # Optional ONNX backend. The integrator opts in when ORT is installed.
 parko-onnx = { path = "../parko-onnx", optional = true }

--- a/parko/crates/parko-ros2/src/radar_shim.rs
+++ b/parko/crates/parko-ros2/src/radar_shim.rs
@@ -2,7 +2,7 @@
 //
 // radar_msgs/RadarScan → Vec<RadarDetection> extraction shim — the deferred ROS
 // half of the radar mapping. PURE field-copy CORE (no r2r, always compiled,
-// unit-tested) + a THIN r2r ADAPTER (`#[cfg(feature = "ros2")]`, extraction
+// unit-tested) + a THIN r2r ADAPTER (`#[cfg(feature = "radar-ros2")]`, extraction
 // only).
 //
 // SAFETY FRAMING. Upstream of the radar transform → model → governor. The
@@ -65,8 +65,14 @@ pub fn radar_scan_to_detections(returns: &[RadarReturnRaw]) -> Vec<RadarDetectio
     returns.iter().map(radar_return_to_detection).collect()
 }
 
-/// THIN r2r ADAPTER — extraction only. Compiles only under `--features ros2`.
-#[cfg(feature = "ros2")]
+/// THIN r2r ADAPTER — extraction only. Gated on the dedicated `radar-ros2`
+/// feature (which implies `ros2`), NOT plain `ros2`: it references
+/// `r2r::radar_msgs::msg::RadarScan`, and `radar_msgs` is not a base-jazzy
+/// package, so the base `ros2` node-binary lane (base jazzy only) must not
+/// compile it. This adapter is the DEFERRED radar half and currently has no
+/// caller; enable `radar-ros2` alongside a ROS env that provides `radar_msgs`
+/// when the radar path is wired.
+#[cfg(feature = "radar-ros2")]
 pub fn radar_scan_msg_to_detections(
     msg: &r2r::radar_msgs::msg::RadarScan,
 ) -> Vec<RadarDetection> {


### PR DESCRIPTION
Fixes the red `main` CI: the new step `cargo build -p parko-ros2 --bin parko_ros2_node --features ros2,{onnx,tensorrt}-backend` (sourcing **base jazzy**) failed to compile the ros2-gated lib with two errors.

## Errors
1. **`E0432 use serde_json::json`** (`node.rs:297`) — `serde_json` was never declared as a dependency. r2r's untyped subscriptions/publishers exchange `serde_json::Value`, and the node builds the geometry_msgs/Twist envelope with `json!`.
2. **`E0433 r2r::radar_msgs::msg::RadarScan`** (`radar_shim.rs:71`) — `radar_msgs` is **not** a base-jazzy package, so r2r doesn't generate it in the base-jazzy lane. This is the **only** non-base-jazzy typed reference in the crate (every other shim uses `sensor_msgs`/`std_msgs`/`nav_msgs`), it's the **deferred** radar adapter, and `radar_scan_msg_to_detections` **has no caller**.

These only surface under `--features ros2`, which `cargo test --workspace` never compiles — hence green unit lanes but red node-binary build.

## Fix
- Add **`serde_json`** as an optional dep pulled in by the `ros2` feature (the default unit-test lane has no r2r and never touches it).
- Move the deferred typed radar adapter from `#[cfg(feature = "ros2")]` to a new opt-in **`radar-ros2 = ["ros2"]`** feature, keeping the base `ros2` lane **base-jazzy-only** (matching that lane's own documented assumption — *"parko-ros2 uses untyped r2r subscriptions, so base jazzy is enough"*). The pure core (`radar_scan_to_detections`) is unchanged and still always-compiled + unit-tested.

## Verification
- Manifest resolves: `serde_json` is a direct dep under `ros2`, **absent** from the default lane; `radar-ros2` implies `ros2`→`r2r`.
- `cargo build -p parko-ros2` (default) still green.
- The full `ros2` compile needs a sourced ROS env, so CI on this PR is the real confirmation.

## Follow-up (not in this PR)
When the radar path is wired, enable `radar-ros2` in a CI lane that provisions `radar_msgs` (e.g. `ros-jazzy-radar-msgs`, mirroring how the adapter job colcon-builds the autoware msgs) so the typed adapter is compile-tested rather than left to bit-rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_