### PR TITLE
docs(#409): SG2 containment fidelity notes + correct the stale PENDING-WIRING header

### DIFF
--- a/src/gateway/containment.rs
+++ b/src/gateway/containment.rs
@@ -2,13 +2,23 @@
 //
 // SG2 — drivable-space containment check.
 //
-// PENDING-WIRING: this module implements the SG2 corridor-containment check
-// as a SIBLING entry point to `validate_vehicle_command`. The live request
-// path (`ProposedVehicleCommand` over HTTP) is UNCHANGED here — it remains
-// per-command. Activating SG2 enforcement on live traffic requires the
-// Option-B trajectory + corridor wiring (filed as a dedicated follow-up
-// issue alongside this commit). Until that wires through, this module is
-// unit-tested against constructed inputs.
+// SG2 WIRING STATUS (confirmed/updated per #409 — supersedes the original
+// "PENDING-WIRING" note): this module is the SG2 corridor-containment checker, a
+// SIBLING entry point to `validate_vehicle_command`. SG2 is now ENFORCED via the
+// Option-B per-trajectory path — the follow-up #131 ("Realize Option-B
+// per-trajectory checking") is CLOSED/completed. Concretely, the kirra-ros2
+// adapter slow loop (`crates/kirra-ros2-adapter/src/validation.rs`) calls
+// `validate_trajectory_containment` per accepted trajectory; a non-`Allow`
+// verdict returns `TrajectoryVerdict::MRCFallback`, collapsing the per-asset slot
+// so the fast loop publishes the MRC. See `docs/safety/TRACEABILITY_MATRIX.md`
+// (SG2 = ENFORCED) and `docs/safety/OCCY_SG2_MARGIN.md`
+// (KIRRA-OCCY-SG2-MARGIN-001).
+//
+// The SDK's own live HTTP request path (`ProposedVehicleCommand`) is UNCHANGED —
+// it remains per-command; SG2 is enforced in the ROS 2 deployment topology by
+// the adapter, not by the per-command HTTP handler. This module is also
+// unit-tested directly against constructed inputs. (Related: #128 SG2 coverage
+// hole, #126 Perception Input Contract.)
 //
 // Design (per the discovery report + design prompt):
 //   - Sibling entry `validate_trajectory_containment(traj, corridor, footprint)`
@@ -106,6 +116,20 @@ impl Corridor<'_> {
     /// shape-valid (≥ 2 vertices per side, ≤ `MAX_CORRIDOR_VERTICES`).
     /// Failure → conservative containment failure (the entry function
     /// returns `DenyCode::DrivableSpaceDeparture`).
+    ///
+    /// # Trust boundary: polygon simplicity / winding is NOT validated (#409 Obs 2)
+    ///
+    /// This checks confidence, age, and per-side vertex counts, but NOT that the
+    /// implicit polygon is SIMPLE (non-self-intersecting), nor that `left` is
+    /// actually left of `right` (consistent winding). A malformed corridor —
+    /// sides crossing or swapped — yields a self-intersecting polygon where the
+    /// PNPoly inside/outside result is ill-defined; unlike the other failure modes
+    /// (non-finite vertex, degenerate `n_total < 4` — both conservatively rejected
+    /// in `corner_inside_corridor`), this one is NOT guaranteed to fail in the
+    /// safe direction. Supplying a well-formed corridor is the integrator's
+    /// Perception Input Contract (#126) responsibility. Tracked defensive-hardening
+    /// option: require the two sides to be monotone-advancing along the corridor
+    /// axis, or test winding-sign consistency → conservative reject otherwise.
     pub fn is_healthy(&self) -> bool {
         self.confidence >= self.min_confidence
             && self.age_ms <= self.max_age_ms
@@ -265,6 +289,21 @@ fn footprint_corners(pose: &Pose, f: &VehicleFootprint) -> [Point; 4] {
 /// ray-cast winding for the inside test and (b) the minimum squared
 /// distance from the corner to any edge. The corner passes iff it is
 /// inside AND min-distance ≥ margin.
+///
+/// # Over-conservatism: the lateral margin also binds the end-caps (#409 Obs 1)
+///
+/// The loop closes via `(k + 1) % n_total`, so it includes the two END-CAP edges
+/// (corridor front `left[N-1] -> right[M-1]` and the closing back
+/// `right[0] -> left[0]`). `min_dist_sq` is taken over ALL edges including these
+/// caps, so `CONTAINMENT_LATERAL_MARGIN_M` — a documented *lateral* margin — is
+/// ALSO enforced longitudinally, shrinking the usable corridor by that margin at
+/// each end. This is fail-SAFE (it rejects more, never less), and a no-op when
+/// corridors extend well beyond the footprint horizon — the assumed case, since
+/// the Perception Input Contract (#126) supplies a corridor ahead of the vehicle.
+/// On a short / sensor-range-truncated corridor it could spuriously reject a pose
+/// validly within the lateral boundaries yet near a cap. Tracked alternative:
+/// exclude the two cap edges from the *margin* test while keeping them in the
+/// *inside* test.
 fn corner_inside_corridor(corner: &Point, corridor: &Corridor, margin_sq: f64) -> bool {
     if !point_is_finite(corner) {
         return false;


### PR DESCRIPTION
Addresses **#409** (SG2 drivable-space, sub-issue of the #410 epic) — explicitly *"not a bug report"*: the geometry in `src/gateway/containment.rs` is verified correct/conservative. Docs only, no behavior change.

## The substantive finding — Obs 3: the header was stale
The module header claimed `PENDING-WIRING` — *"awaits the Option-B trajectory + corridor wiring (filed as a dedicated follow-up)"*. **That's out of date.** I traced it:
- The follow-up **#131** ("Realize Option-B per-trajectory checking") is **closed/completed**.
- SG2 **is enforced**: `crates/kirra-ros2-adapter/src/validation.rs:161` calls `validate_trajectory_containment` per accepted trajectory and returns `TrajectoryVerdict::MRCFallback` on any non-`Allow`.
- `docs/safety/TRACEABILITY_MATRIX.md` already says **SG2 = ENFORCED**.

So the header (PENDING) contradicted the matrix (ENFORCED) and the actual wiring. I rewrote it to the accurate state: **SG2 enforced via the adapter Option-B slow loop**; the SDK's own per-command HTTP path is unchanged. Links #131/#128/#126.

## The two geometry observations (documented, not "fixed")
- **Obs 1** — `corner_inside_corridor`'s `min_dist_sq` includes the two **end-cap** edges, so the *lateral* `CONTAINMENT_LATERAL_MARGIN_M` is also enforced longitudinally — **fail-safe** over-conservatism, a no-op when corridors exceed the footprint horizon. Documents the tracked alternative (exclude caps from the *margin* test, keep them in the *inside* test).
- **Obs 2** — `is_healthy` does **not** validate polygon simplicity/winding; a self-intersecting corridor is the one `is_healthy` failure mode **not** guaranteed to fail safe. Well-formedness is the integrator's Perception Input Contract (#126) responsibility; documents the tracked defensive-check option.

## Discipline (same as #405/#406/#408)
No behavior changed and **no safety-case numbers invented** — Obs 1's cap-exclusion and Obs 2's winding-check are real but **owner-gated** options (the cap-exclusion would *relax* a currently fail-safe behavior; the winding-check risks false-positives on valid curved corridors), so they're documented as tracked alternatives, not unilaterally implemented.

## Verification
`cargo test -p kirra-runtime-sdk --lib containment` = **20 pass**; clippy clean; no new rustdoc warnings. `+46/-7`, docs only.

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_