### PR TITLE
refactor(#410): one shared non-finite governor guard (Tier-1 structural convergence)

### DIFF
--- a/parko/crates/parko-kirra/src/diverse.rs
+++ b/parko/crates/parko-kirra/src/diverse.rs
@@ -287,7 +287,7 @@ impl DiverseKirraGovernor {
         // offending field; the comparator compares physical EFFECT (a hard
         // stop is a hard stop), so a single combined guard with a generic
         // reason is the diverse — and equivalent — form.
-        if !v.is_finite() || !current.is_finite() || !delta_time_s.is_finite() {
+        if !kirra_runtime_sdk::governor_guard::all_finite(&[v, current, delta_time_s]) {
             return EnforcementAction::Deny {
                 reason: "DiverseKirraGovernor: non-finite command input — hard stop".to_string(),
             };

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -25,7 +25,7 @@ pub extern "C" fn kirra_filter_rotate_velocity(proposed_angular: f64, _dt: f64) 
         // `NaN` would be forwarded to the actuator unclamped (#404). Command zero
         // angular rate and decay trust. (`kirra_filter_move_velocity` is fixed
         // transitively — it routes through `evaluate`'s Priority-0 guard.)
-        if !proposed_angular.is_finite() {
+        if !crate::governor_guard::all_finite(&[proposed_angular]) {
             g.trust_engine.decay_trust(30);
             return 0.0;
         }

--- a/src/governor_guard.rs
+++ b/src/governor_guard.rs
@@ -1,0 +1,55 @@
+//! Shared governor input guards — the convergence point for #410.
+//!
+//! The governor enforces "reject non-finite command input" at several independent
+//! enforcement points, and the copies had drifted: the invariant was rigorous on
+//! the AV vehicle path but MISSING on the scalar kernel + C FFI (#404) and the
+//! parko differential-drive channel (#407). This module gives that invariant ONE
+//! implementation every point calls, so the class cannot silently regress at a
+//! NEW enforcement point.
+//!
+//! **Shared = the PREDICATE only.** Each call site keeps its own fail-closed
+//! ACTION (a verdict, `0.0`, an `EnforcementAction::Deny`, an MRC fallback) and
+//! its own diagnostics — only the finite-ness test is centralised here.
+//!
+//! **Call sites (keep this list current — a new governor entry MUST call this):**
+//!   - `kirra_core::KirraKernelGovernor::evaluate` (scalar kernel, #404)
+//!   - `ffi::kirra_filter_rotate_velocity` (C ABI, #404)
+//!   - `parko_kirra::diverse::DiverseKirraGovernor::gate` (separate workspace —
+//!     depends on this crate and imports this predicate, #407)
+//!
+//! The AV reference model `gateway::kinematics_contract::validate_vehicle_command`
+//! intentionally keeps PER-FIELD checks (a distinct `DenyCode` per offending
+//! field); it is the model the peripheral paths converge toward, not a caller of
+//! this combined predicate. The fabric `AssetGovernor` path was reviewed clean in
+//! the #410 sweep and is not an actuator-command ingress that needs this guard.
+
+/// Returns `true` iff every value is IEEE-754 finite (no `NaN`, no `±Inf`).
+///
+/// The shared non-finite-rejection predicate (#410). A `NaN` compares `false`
+/// against every envelope/rate threshold, so an unguarded `NaN` would fall
+/// straight through a governor's comparisons as a "safe" command; every entry
+/// point must reject non-finite input BEFORE any comparison and fail closed.
+/// An empty slice is vacuously finite (`true`).
+#[must_use]
+#[inline]
+pub fn all_finite(values: &[f64]) -> bool {
+    values.iter().all(|v| v.is_finite())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::all_finite;
+
+    #[test]
+    fn accepts_all_finite_rejects_any_nonfinite() {
+        // Vacuously true on empty; true when every value is finite.
+        assert!(all_finite(&[]));
+        assert!(all_finite(&[0.0, -1.5, 1.0e6, f64::MIN, f64::MAX]));
+
+        // False if ANY value is non-finite (NaN or either infinity), in any slot.
+        assert!(!all_finite(&[f64::NAN]));
+        assert!(!all_finite(&[1.0, f64::INFINITY]));
+        assert!(!all_finite(&[f64::NEG_INFINITY, 2.0]));
+        assert!(!all_finite(&[0.0, f64::NAN, 3.0]));
+    }
+}

--- a/src/kirra_core.rs
+++ b/src/kirra_core.rs
@@ -153,7 +153,7 @@ impl<C: SafetyContract> SafetyGovernor for KirraKernelGovernor<C> {
         // an UNSAFE control state. `last_validated_scalar` is intentionally NOT
         // advanced to a tainted value. (#404 — this scalar/FFI ingress was the one
         // path that treated `NaN` as nominal; the vehicle path already guards.)
-        if !proposed_demand.is_finite() || !dt.is_finite() {
+        if !crate::governor_guard::all_finite(&[proposed_demand, dt]) {
             self.trust_engine.decay_trust(30);
             return GovernorInterceptResult {
                 sanitized_scalar: self.contract.fallback(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::doc_lazy_continuation, clippy::doc_overindented_list_items)]
 
 pub mod kirra_core;
+pub mod governor_guard;
 pub mod modbus_adapter;
 pub mod config;
 pub mod kinematics_contract;


### PR DESCRIPTION
Lands the **unblocked half** of #410's structural recommendation: give each drifted invariant *one* implementation every enforcement point calls, so the class can't silently regress at a new point. This is the **non-finite-rejection guard** that had drifted across the scalar kernel (#404), the C FFI (#404), and the parko differential-drive gate (#407).

## Cross-workspace decision (the one real engineering choice)
`parko-kirra` already depends on `kirra-runtime-sdk`, so "one implementation" is *literally* achievable — **a single shared crate helper, not a duplicated copy + conformance test**. New module `kirra_runtime_sdk::governor_guard` exports `all_finite(&[f64]) -> bool`; parko imports it across the existing dependency edge (no *new* boundary crossing).

## Shared = the PREDICATE only (behavior-preserving)
Each call site keeps its own fail-closed *action* and diagnostics — only the finite-ness test is centralized:
- `kirra_core::KirraKernelGovernor::evaluate` — scalar verdict + trust decay
- `ffi::kirra_filter_rotate_velocity` — returns `0.0`
- `parko_kirra::diverse::DiverseKirraGovernor::gate` — `EnforcementAction::Deny` (separate workspace, imports the helper)

Left intentionally unchanged: `validate_vehicle_command` keeps **per-field** checks (distinct `DenyCode` per field — the reference model these converge toward), and the fabric `AssetGovernor` (reviewed clean in the #410 sweep). The `governor_guard` doc names every call site so a new governor entry is reminded to call it.

## Explicitly out of scope (the HARA-gated half)
The *single authoritative MRC resolver* (#406) and the *one Degraded decel-to-stop gate with a single reachability story* (#405) are blocked on the HARA/DFA decision captured in **ADR-0011 (still Open)**. Per the agreed direction, those are **not batched** here — filed as a separate follow-up so the regression-proof isn't held hostage to an unrelated decision.

## Verification
`cargo test -p kirra-runtime-sdk --lib governor_guard` + the #404 `governor_nonfinite`/`ffi_nonfinite` tests = pass; `parko-kirra` diverse tests (incl. `diverse_denies_each_nonfinite_input_in_nominal`) = pass; `clippy --lib` on **both** workspaces = clean. `+59/−3`.

Part of #410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_