### PR TITLE
docs(#306): document the posture-routing exemption registry

### DIFF
--- a/docs/safety/SECURITY_BOUNDARIES.md
+++ b/docs/safety/SECURITY_BOUNDARIES.md
@@ -3,6 +3,7 @@
 **Status:** Evidence / design-decision record.
 **Cross-refs:** `REQUIREMENTS_TRACEABILITY.md` (SG-015), `src/bin/kirra_verifier_service.rs`
 (router construction), `src/security.rs` (`admin_token_ok`, `constant_time_compare`),
+`src/gateway/policy_layer.rs` (`enforce_posture_routing`, `is_posture_exempt`),
 CLAUDE.md "Route Authorization Matrix".
 
 ---
@@ -79,3 +80,79 @@ POSTs) is constructed and merged with **no** such layer. The gate predicate
 `security::admin_token_ok` uses `constant_time_compare` (never `==`) and is unit-tested in
 `src/security.rs` mod `sg_015_admin_token_tests` (absent/empty configured → deny;
 absent/mismatched provided → deny; exact token → allow).
+
+---
+
+## Posture-Routing Gate — the Exemption Registry (#306)
+
+**Claim.** The outermost router layer `enforce_posture_routing`
+(`src/gateway/policy_layer.rs`) gates every inbound request by **fleet posture**:
+each request is classified into an `OperationalCommand` (`classify_http_command`)
+and checked by `should_route_command` against a **fail-closed** snapshot of the
+posture cache (a poisoned / cold `None` cache blocks). A denied request returns
+**HTTP 503** — posture denial is a transient SERVER-STATE condition
+(`LockedOut` / `Degraded` / cold-or-stale cache), retryable once posture recovers,
+matching the `require_admin_token` 503 shape rather than a per-client 403. A small
+**allowlist of posture-EXEMPT paths** (`is_posture_exempt`) bypasses this gate so
+the service stays reachable regardless of posture.
+
+> **The exemption is from *fleet-posture routing* only — NOT from authentication.**
+> Admin-token and supervisor-key gates still apply to any exempt path that carries
+> them.
+
+### Tier 1 — Liveness / observability
+
+`/health`, `/health/live`, `/ready`, `/metrics`.
+
+A literal "gate everything" deadlocks cold start: the posture cache is initially
+`None`, which `should_route_command` blocks unconditionally, and external liveness
+probes could never confirm the process is alive. This tier is liveness + metrics
+only; readiness MAY still reflect posture inside its own handler.
+
+### Tier 2 — The operator-console plane
+
+`/console` and everything under `/console/` (`#103` SG6 / Phase A, PR #305).
+
+The console is the **observe-and-recover plane**, and it **MUST be reachable
+during `LockedOut`** — that is exactly when an operator needs to SEE a locked-out
+fleet and record a supervisor clearance grant. A posture-gated console would lock
+the operator out of the recovery affordance precisely when it is most needed.
+
+#### Console-plane invariant (stated explicitly)
+
+**Everything under `/console` is read-only (QM) EXCEPT the one supervisor-key-gated
+mutation, `POST /console/clearance-grants`.** That mutation is:
+
+- authenticated **in the handler** by the supervisor key — an out-of-band operator
+  action, **not** a fleet command — not by fleet posture; and
+- **record-only**: it records + signs a clearance grant (delivery to the node is
+  Phase B); it never mutates posture.
+
+So the `/console` exemption removes these routes from *posture* routing while the
+single console mutation retains its own (supervisor-key) authentication.
+
+### Why this matters — the regression it guards
+
+Losing the `/console` exemption locks the operator out of the recovery affordance
+exactly when the fleet is `LockedOut` — the worst failure this gate can have. The
+set is therefore pinned in BOTH directions by `console_exemption_set_is_pinned`
+(`policy_layer.rs`): the test fails if a new path silently **gains** exemption
+(un-gates a real fleet path) **or** if the `/console` plane silently **loses** it.
+
+### Assessor note
+
+The posture gate and the admin gate (SG-015 above) are **independent, composed**
+controls: a request under `/console` is exempt from *posture* routing yet, if it
+is the supervisor mutation, still authenticated in-handler. "Posture-exempt" must
+never be read as "unauthenticated." **If a future change adds a non-`/console`
+fleet-mutating route to `is_posture_exempt`, or moves a privileged mutation under a
+posture-exempt prefix without its own auth, this entry must be re-evaluated.**
+
+### Verification (this branch)
+
+`is_posture_exempt` (`src/gateway/policy_layer.rs`) matches exactly
+`/health | /health/live | /ready | /metrics`, plus `path == "/console"` and
+`path.starts_with("/console/")`; `enforce_posture_routing` returns early for those
+and 503-gates everything else against the fail-closed posture snapshot. The
+exemption set is unit-pinned by `console_exemption_set_is_pinned`
+(`src/gateway/policy_layer.rs`).

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -416,7 +416,8 @@ pub async fn enforce_actuator_safety_envelope(
 /// readiness MAY still reflect posture inside its own handler. The full
 /// exemption registry — liveness/observability + the `/console` plane — and the
 /// "`/console` is read-only EXCEPT the supervisor-key-gated grant" invariant are
-/// documented in the safety docs per #306. The set is pinned by
+/// documented in `docs/safety/SECURITY_BOUNDARIES.md` ("Posture-Routing Gate —
+/// the Exemption Registry", #306). The set is pinned by
 /// `console_exemption_set_is_pinned` below.
 fn is_posture_exempt(path: &str) -> bool {
     matches!(path, "/health" | "/health/live" | "/ready" | "/metrics")


### PR DESCRIPTION
## What

Documents the **posture-routing exemption registry** — the small allowlist of paths that `enforce_posture_routing` (`src/gateway/policy_layer.rs`) lets bypass the fleet-posture gate — as an evidence/design-decision record in `docs/safety/SECURITY_BOUNDARIES.md`, and tightens the in-code doc-comment to point at it.

This is a **docs-only** change. No behavior changes; the exemption set itself is unchanged and remains pinned by `console_exemption_set_is_pinned`.

## Content

New section "Posture-Routing Gate — the Exemption Registry (#306)" covering:

- **The claim** — every request is posture-classified and checked against a fail-closed cache snapshot; denial returns `503` (transient server-state, retryable), matching the `require_admin_token` shape rather than a per-client `403`.
- **Tier 1 — liveness/observability** (`/health`, `/health/live`, `/ready`, `/metrics`): why "gate everything" deadlocks cold start (the cache is initially `None`, which blocks unconditionally).
- **Tier 2 — the `/console` plane**: why it MUST stay reachable during `LockedOut` (it's the observe-and-recover plane), and the explicit invariant that **everything under `/console` is read-only EXCEPT the supervisor-key-gated `POST /console/clearance-grants`**, which authenticates in-handler and is record-only.
- **The regression it guards** — the set is pinned in BOTH directions (a path silently gaining *or* losing exemption fails the test).
- **Assessor note** — "posture-exempt" ≠ "unauthenticated"; the posture gate and the SG-015 admin gate are independent, composed controls. Flags the re-evaluation trigger if a future non-`/console` fleet-mutating route is ever added to the allowlist.

## Code touch

One-line doc-comment update on `is_posture_exempt` (`policy_layer.rs`) to cross-reference the new doc section by anchor instead of "the safety docs per #306".

## Tests

`cargo test --lib -- console_exemption_set_is_pinned` → **1 passed** (sanity — the pinned set is unchanged).

Closes #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_