### PR TITLE
feat(console): live wiring for runtime / analytics / sites / versions (#394)

### DIFF
--- a/console/app/analytics/page.tsx
+++ b/console/app/analytics/page.tsx
@@ -1,25 +1,51 @@
+'use client'
+
 import { Panel, Pill, Meter } from '@/components/ui/primitives'
 import { DemoBadge } from '@/components/ui/demo-badge'
 import { TrendArea, Spark } from '@/components/charts/charts'
 import { DualLine } from '@/components/charts/extra2'
-import { kpiWall, throughputTrend, riskForecast, riskDrivers, projections } from '@/lib/analytics'
+import { useAnalytics } from '@/lib/api/hooks'
+import { kpiWall } from '@/lib/analytics'
 import type { Tone } from '@/lib/types'
 
+// Analytics — historical operational trend (#396). This is NOT ML risk
+// forecasting: every series is a backward-looking rollup of what already
+// happened (posture transitions, denial rate, interventions, flapping) over the
+// selected window. Wired to GET /console/analytics?window_ms= with the bundled
+// demo snapshot as fallback. The KPI wall stays mock (out of #396 scope).
+const WINDOW_MS = 30 * 24 * 60 * 60 * 1000 // 30-day window
+
 export default function AnalyticsPage() {
+  const { data, source } = useAnalytics(WINDOW_MS)
+
+  // Posture transitions → a per-bucket time series for the trend chart.
+  const transitionSeries = data.posture_transitions.map((b) => ({
+    t: new Date(b.bucket_start_ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+    degraded: b.to_degraded,
+    lockedout: b.to_lockedout,
+  }))
+  // Denial-rate series → a percentage area trend.
+  const denialSeries = data.denial_rate_series.map((p) => ({
+    t: new Date(p.bucket_start_ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+    v: Math.round(p.denial_rate * 10000) / 100,
+  }))
+  const maxIntervention = Math.max(1, ...data.interventions_by_asset.map((a) => a.clamps + a.denies))
+  const maxFlap = Math.max(1, ...data.flapping_top.map((f) => f.transitions))
+
   return (
     <div className="mx-auto max-w-[1500px] space-y-6 p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <h1 className="font-display text-xl font-semibold text-ink">Analytics & Risk Forecasting</h1>
-          <p className="font-mono text-[11px] text-faint">executive KPIs · fleet trends · forward risk projection</p>
+          <h1 className="font-display text-xl font-semibold text-ink">Analytics &amp; Historical Trends</h1>
+          <p className="font-mono text-[11px] text-faint">executive KPIs · fleet trends · observed-history rollups</p>
         </div>
         <div className="flex items-center gap-2">
-          <DemoBadge live={false} />
+          <DemoBadge live={source === 'live'} />
           <Pill tone="ice">30-day window</Pill>
         </div>
       </div>
 
-      {/* Executive KPI Wall (#9) */}
+      {/* Executive KPI Wall (#9) — bundled mock, out of #396 scope. */}
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-6">
         {kpiWall.map((k) => (
           <div key={k.label} className="rounded-xl border border-line bg-panel p-4 shadow-panel">
@@ -35,60 +61,74 @@ export default function AnalyticsPage() {
       </div>
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
-        <Panel className="xl:col-span-2" title="Operational Risk Forecast" subtitle="composite risk index · observed vs projected (90% ceiling)" action={<Pill tone="warn">rising</Pill>}>
+        <Panel
+          className="xl:col-span-2"
+          title="Posture Transitions"
+          subtitle="observed transitions per bucket · to-Degraded vs to-LockedOut · historical"
+          action={source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="warn">demo</Pill>}
+        >
           <DualLine
-            data={riskForecast as unknown as { t: string; [k: string]: string | number }[]}
-            keys={['observed', 'forecast']}
-            colors={['#5cc6ff', '#ffb020']}
+            data={transitionSeries as unknown as { t: string; [k: string]: string | number }[]}
+            keys={['degraded', 'lockedout']}
+            colors={['#ffb020', '#ff5468']}
             height={230}
           />
-          <p className="mt-2 font-mono text-[10px] text-faint">Observed (ice) holds through 19:00; forecast (amber) projects a climb into the evening shift change.</p>
+          <p className="mt-2 font-mono text-[10px] text-faint">Backward-looking counts of fleet posture transitions over the {WINDOW_MS / (24 * 60 * 60 * 1000)}-day window — not a forecast.</p>
         </Panel>
 
-        <Panel title="Risk Projection" subtitle="banded outlook">
-          <ul className="space-y-3">
-            {projections.map((p) => (
-              <li key={p.window} className="rounded-lg border border-line bg-bg/40 p-3">
-                <div className="flex items-center justify-between">
-                  <span className="font-mono text-[11px] uppercase tracking-wider text-faint">{p.window}</span>
-                  <span className={`rounded px-1.5 py-0.5 font-mono text-[10px] uppercase ${badge(p.tone)}`}>{p.band}</span>
-                </div>
-                <div className="mt-2 flex items-end gap-2">
-                  <span className={`font-display text-2xl font-semibold ${txt(p.tone)}`}>{p.score}</span>
-                  <span className="mb-1 font-mono text-[10px] text-faint">/ 100 risk</span>
-                </div>
-                <p className="mt-1 text-[11px] text-muted">{p.note}</p>
-              </li>
-            ))}
-          </ul>
+        <Panel title="Top Flapping Nodes" subtitle="most posture transitions in window" dense>
+          {data.flapping_top.length === 0 ? (
+            <p className="px-4 py-6 font-mono text-[11px] text-faint">No flapping nodes in window.</p>
+          ) : (
+            <ul className="px-4 py-2">
+              {data.flapping_top.map((f) => (
+                <li key={f.node_id} className="border-b border-line py-3 last:border-0">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="font-mono text-[12px] text-ink">{f.node_id}</span>
+                    <span className="font-mono text-[11px] text-muted">{f.transitions} transitions</span>
+                  </div>
+                  <div className="mt-2"><Meter value={(f.transitions / maxFlap) * 100} tone={f.transitions > maxFlap * 0.66 ? 'crit' : 'warn'} /></div>
+                </li>
+              ))}
+            </ul>
+          )}
         </Panel>
       </div>
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
-        <Panel className="xl:col-span-2" title="Fleet Throughput" subtitle="commands / min · 24h">
-          <TrendArea data={throughputTrend} color="ice" height={210} />
+        <Panel
+          className="xl:col-span-2"
+          title="Denial Rate"
+          subtitle="governed-command denial rate · % · windowed history"
+          action={source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="warn">demo</Pill>}
+        >
+          <TrendArea data={denialSeries} color="warn" height={210} />
         </Panel>
 
-        <Panel title="Risk Drivers" subtitle="contribution to projected risk" dense>
-          <ul className="px-4 py-2">
-            {riskDrivers.map((d) => (
-              <li key={d.name} className="border-b border-line py-3 last:border-0">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-[12px] text-ink">{d.name}</span>
-                  <span className="flex items-center gap-1.5 font-mono text-[11px] text-muted">
-                    <span className={txt(d.tone)}>{arrow(d.trend)}</span>{d.contribution}%
-                  </span>
-                </div>
-                <div className="mt-2"><Meter value={d.contribution} tone={d.tone} /></div>
-              </li>
-            ))}
-          </ul>
+        <Panel title="Interventions by Asset" subtitle="clamps + denies in window" dense>
+          {data.interventions_by_asset.length === 0 ? (
+            <p className="px-4 py-6 font-mono text-[11px] text-faint">No interventions in window.</p>
+          ) : (
+            <ul className="px-4 py-2">
+              {data.interventions_by_asset.map((a) => {
+                const total = a.clamps + a.denies
+                const tone: Tone = a.denies > 0 ? 'crit' : a.clamps > 0 ? 'warn' : 'safe'
+                return (
+                  <li key={a.asset_id} className="border-b border-line py-3 last:border-0">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="font-mono text-[12px] text-ink">{a.asset_id}</span>
+                      <span className="font-mono text-[11px] text-muted">{a.clamps} clamp · {a.denies} deny</span>
+                    </div>
+                    <div className="mt-2"><Meter value={(total / maxIntervention) * 100} tone={tone} /></div>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
         </Panel>
       </div>
     </div>
   )
 }
 
-function arrow(t: 'rising' | 'flat' | 'falling') { return t === 'rising' ? '▲' : t === 'falling' ? '▼' : '▬' }
 function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }
-function badge(t: Tone) { return t === 'safe' ? 'bg-safe/15 text-safe' : t === 'warn' ? 'bg-warn/15 text-warn' : t === 'crit' ? 'bg-crit/15 text-crit' : 'bg-ice/15 text-ice' }

--- a/console/app/api/kirra/[...path]/route.ts
+++ b/console/app/api/kirra/[...path]/route.ts
@@ -22,6 +22,7 @@ const ALLOW: RegExp[] = [
   /^system\/audit\/verify$/, /^system\/audit\/causal\/verify$/, /^system\/audit\/export$/,
   /^fabric\/(assets|state|telemetry|causal-log)$/, /^fabric\/telemetry\/[^/]+$/, /^fabric\/causal-log\/[^/]+$/,
   /^console\/(fleet|audit|escalations)$/,
+  /^console\/(runtime|analytics|sites|versions)$/,
   /^system\/posture\/stream$/,
 ]
 

--- a/console/app/global/page.tsx
+++ b/console/app/global/page.tsx
@@ -6,12 +6,18 @@ import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
 import { DemoBadge } from '@/components/ui/demo-badge'
 import { GlobalMap } from '@/components/ui/global-map'
 import { sites, weatherZones, geofences, crossSiteAlerts, regionRisk, totals } from '@/lib/global'
+import { useSites } from '@/lib/api/hooks'
 import type { Tone } from '@/lib/types'
 
 export default function GlobalPage() {
   const [heatmap, setHeatmap] = useState(true)
   const [risk, setRisk] = useState(true)
   const [network, setNetwork] = useState(false)
+  // Live fleet-distribution rollup (GET /console/sites, #397). Only the Fleet
+  // Distribution panel is wired; the map / weather / geofence overlays stay mock
+  // (out of #397 mandate).
+  const { data: siteData, source: siteSource } = useSites(15000)
+  const liveTotal = siteData.sites.reduce((a, s) => a + s.total, 0) + siteData.unassigned
 
   return (
     <div className="mx-auto max-w-[1500px] space-y-6 p-6">
@@ -102,18 +108,35 @@ export default function GlobalPage() {
           </div>
         </Panel>
 
-        <Panel title="Fleet Distribution" subtitle="assets by site" dense>
+        <Panel
+          title="Fleet Distribution"
+          subtitle="nodes by site · posture rollup"
+          action={siteSource === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="warn">demo</Pill>}
+          dense
+        >
           <ul className="px-4 py-2">
-            {sites.map((s) => (
-              <li key={s.id} className="border-b border-line py-3 last:border-0">
+            {siteData.sites.map((s) => {
+              const tone: Tone = s.lockedout > 0 ? 'crit' : s.degraded > 0 ? 'warn' : 'safe'
+              return (
+                <li key={s.site} className="border-b border-line py-3 last:border-0">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="flex items-center gap-2 text-[12px] text-ink"><StatusDot tone={tone} />{s.site}</span>
+                    <span className="font-mono text-[11px] text-muted">{s.total}</span>
+                  </div>
+                  <div className="mt-2"><Meter value={liveTotal ? (s.total / liveTotal) * 100 : 0} tone={tone} /></div>
+                  <div className="mt-1 font-mono text-[10px] text-faint">{s.nominal} nominal · {s.degraded} degraded · {s.lockedout} locked out</div>
+                </li>
+              )
+            })}
+            {siteData.unassigned > 0 && (
+              <li className="border-b border-line py-3 last:border-0">
                 <div className="flex items-center justify-between gap-3">
-                  <span className="flex items-center gap-2 text-[12px] text-ink"><StatusDot tone={s.tone} />{s.name}</span>
-                  <span className="font-mono text-[11px] text-muted">{s.assets}</span>
+                  <span className="flex items-center gap-2 text-[12px] text-ink"><StatusDot tone="muted" />Unassigned</span>
+                  <span className="font-mono text-[11px] text-muted">{siteData.unassigned}</span>
                 </div>
-                <div className="mt-2"><Meter value={(s.assets / totals.assets) * 100} tone={s.tone} /></div>
-                <div className="mt-1 font-mono text-[10px] text-faint">{s.weather} · net {s.network} · {s.interventions} interventions/24h</div>
+                <div className="mt-1 font-mono text-[10px] text-faint">nodes with no site assignment</div>
               </li>
-            ))}
+            )}
           </ul>
         </Panel>
       </div>

--- a/console/app/reports/page.tsx
+++ b/console/app/reports/page.tsx
@@ -2,7 +2,8 @@ import { Download, FileText, ShieldCheck } from 'lucide-react'
 import { Panel, Pill, Meter, StatusDot } from '@/components/ui/primitives'
 import { DemoBadge } from '@/components/ui/demo-badge'
 import { AuditEvidence } from '@/components/ui/audit-evidence'
-import { reports, scheduled, rollout, rolloutVersion, versionShare } from '@/lib/reports'
+import { VersionAdoptionBar } from '@/components/ui/version-adoption'
+import { reports, scheduled, rollout, rolloutVersion } from '@/lib/reports'
 import type { Tone } from '@/lib/types'
 
 export default function ReportsPage() {
@@ -87,27 +88,11 @@ export default function ReportsPage() {
           ))}
         </div>
 
-        <div className="mt-5 border-t border-line pt-4">
-          <div className="mb-2 font-mono text-[10px] uppercase tracking-wider text-faint">Fleet version adoption</div>
-          <div className="flex h-3 overflow-hidden rounded-full bg-white/5">
-            {versionShare.map((v) => (
-              <div key={v.version} className={dotBg(v.tone)} style={{ width: `${v.pct}%` }} title={`${v.version} ${v.pct}%`} />
-            ))}
-          </div>
-          <div className="mt-3 flex flex-wrap gap-4 font-mono text-[11px]">
-            {versionShare.map((v) => (
-              <span key={v.version} className="flex items-center gap-1.5">
-                <span className={`h-2 w-2 rounded-full ${dotBg(v.tone)}`} />
-                <span className="text-ink">{v.version}</span>
-                <span className="text-faint">{v.pct}%</span>
-              </span>
-            ))}
-          </div>
-        </div>
+        {/* ── Live fleet version-adoption (GET /console/versions, #398) ── */}
+        <VersionAdoptionBar />
       </Panel>
     </div>
   )
 }
 
-function dotBg(t: Tone) { return t === 'safe' ? 'bg-safe' : t === 'warn' ? 'bg-warn' : t === 'crit' ? 'bg-crit' : t === 'ice' ? 'bg-ice' : 'bg-muted' }
 function badge(t: Tone) { return t === 'safe' ? 'bg-safe/15 text-safe' : t === 'warn' ? 'bg-warn/15 text-warn' : t === 'crit' ? 'bg-crit/15 text-crit' : t === 'ice' ? 'bg-ice/15 text-ice' : 'bg-white/5 text-muted' }

--- a/console/app/runtime/page.tsx
+++ b/console/app/runtime/page.tsx
@@ -4,6 +4,7 @@ import { Spark } from '@/components/charts/charts'
 import { LatencyLines } from '@/components/charts/extra'
 import { TopologyMap } from '@/components/ui/topology-map'
 import { FabricTelemetryPanel } from '@/components/ui/fabric-telemetry'
+import { RuntimeHealthPanel } from '@/components/ui/runtime-health'
 import { resources, latency, network, partitions, nodes, ddsTopics, ddsPeers, topoNodes, topoEdges } from '@/lib/runtime'
 import type { Tone } from '@/lib/types'
 
@@ -20,6 +21,9 @@ export default function RuntimePage() {
           <Pill tone="safe">All partitions enforced</Pill>
         </div>
       </div>
+
+      {/* ── Live verifier runtime snapshot (GET /console/runtime, #395) ── */}
+      <RuntimeHealthPanel />
 
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         {resources.map((r) => (

--- a/console/components/ui/runtime-health.tsx
+++ b/console/components/ui/runtime-health.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { Panel, Pill } from '@/components/ui/primitives'
+import { useRuntimeHealth } from '@/lib/api/hooks'
+import type { Tone } from '@/lib/types'
+
+// Live verifier runtime snapshot (GET /console/runtime, #395). Self-contained
+// client panel so the server-rendered Runtime page is untouched — mirrors the
+// FabricTelemetryPanel pattern. Falls back to a bundled demo snapshot when the
+// proxy is in demo mode or the backend is unreachable.
+export function RuntimeHealthPanel() {
+  const { data, source } = useRuntimeHealth(8000)
+  const denialPct = data.fabric_denial_rate * 100
+  const recalcAge = Math.max(0, Date.now() - data.last_recalc_ms)
+
+  return (
+    <Panel
+      title="Verifier Runtime"
+      subtitle="operational snapshot · GET /console/runtime"
+      action={source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="warn">demo</Pill>}
+    >
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <Metric label="Mode" value={data.mode} tone={data.mode === 'Active' ? 'safe' : 'ice'} />
+        <Metric label="Uptime" value={fmtDuration(data.uptime_ms)} tone="ice" />
+        <Metric label="Posture gen" value={`#${data.posture_generation}`} tone="safe" />
+        <Metric label="Last recalc" value={`${fmtAge(recalcAge)} ago`} tone={recalcAge > data.posture_cache_ttl_ms ? 'warn' : 'safe'} />
+        <Metric label="Cache TTL" value={`${(data.posture_cache_ttl_ms / 1000).toFixed(0)}s`} tone="muted" />
+        <Metric label="Nodes" value={`${data.total_nodes}`} tone="ice" />
+        <Metric label="Fabric assets" value={`${data.fabric_assets}`} tone="ice" />
+        <Metric label="Denial rate" value={`${denialPct.toFixed(2)}%`} tone={denialPct > 5 ? 'crit' : denialPct > 1 ? 'warn' : 'safe'} />
+        <Metric label="Audit entries" value={fmtCount(data.audit_entries)} tone="safe" />
+        <Metric label="SSE subscribers" value={`${data.broadcast_subscribers}`} tone="muted" />
+        <Metric
+          label="HA heartbeat age"
+          value={data.ha_heartbeat_age_ms == null ? '—' : `${fmtAge(data.ha_heartbeat_age_ms)} ago`}
+          tone={data.ha_heartbeat_age_ms == null ? 'muted' : data.ha_heartbeat_age_ms > 10000 ? 'crit' : data.ha_heartbeat_age_ms > 5000 ? 'warn' : 'safe'}
+        />
+      </div>
+    </Panel>
+  )
+}
+
+function Metric({ label, value, tone }: { label: string; value: string; tone: Tone }) {
+  return (
+    <div className="rounded-lg border border-line bg-bg/40 p-3">
+      <div className="font-mono text-[10px] uppercase tracking-wider text-faint">{label}</div>
+      <div className={`mt-1.5 font-display text-[20px] font-semibold leading-none ${value.length > 9 ? 'text-[14px]' : ''} ${txt(tone)}`}>{value}</div>
+    </div>
+  )
+}
+
+function fmtDuration(ms: number): string {
+  const s = Math.floor(ms / 1000)
+  const d = Math.floor(s / 86400)
+  const h = Math.floor((s % 86400) / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  if (d > 0) return `${d}d ${h}h`
+  if (h > 0) return `${h}h ${m}m`
+  return `${m}m`
+}
+function fmtAge(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const s = ms / 1000
+  return s < 60 ? `${s.toFixed(1)}s` : `${Math.floor(s / 60)}m`
+}
+function fmtCount(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`
+}
+function txt(t: Tone) { return t === 'safe' ? 'text-safe' : t === 'warn' ? 'text-warn' : t === 'crit' ? 'text-crit' : t === 'ice' ? 'text-ice' : 'text-muted' }

--- a/console/components/ui/version-adoption.tsx
+++ b/console/components/ui/version-adoption.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { Pill } from '@/components/ui/primitives'
+import { useVersions } from '@/lib/api/hooks'
+import type { Tone } from '@/lib/types'
+
+// Live fleet version-adoption bar (GET /console/versions, #398). Self-contained
+// client block so the server-rendered Reports page stays untouched — mirrors the
+// FabricTelemetryPanel pattern. Falls back to a bundled demo snapshot when the
+// proxy is in demo mode or the backend is unreachable. The surrounding
+// rollout-rings / staged-deploy / OTA section stays mock (out of #398 scope).
+export function VersionAdoptionBar() {
+  const { data, source } = useVersions(20000)
+  // Newest versions render greener; older / unknown trend toward warn.
+  const rows = data.versions.map((v, i) => ({ ...v, tone: toneFor(i, data.versions.length) }))
+
+  return (
+    <div className="mt-5 border-t border-line pt-4">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-wider text-faint">Fleet version adoption</span>
+        {source === 'live' ? <Pill tone="safe">live</Pill> : <Pill tone="warn">demo</Pill>}
+      </div>
+      <div className="flex h-3 overflow-hidden rounded-full bg-white/5">
+        {rows.map((v) => (
+          <div key={v.version} className={dotBg(v.tone)} style={{ width: `${v.pct}%` }} title={`${v.version} ${v.pct}% · ${v.count} nodes`} />
+        ))}
+        {data.unknown > 0 && (
+          <div className={dotBg('muted')} style={{ width: `${data.total ? (data.unknown / data.total) * 100 : 0}%` }} title={`unknown · ${data.unknown} nodes`} />
+        )}
+      </div>
+      <div className="mt-3 flex flex-wrap gap-4 font-mono text-[11px]">
+        {rows.map((v) => (
+          <span key={v.version} className="flex items-center gap-1.5">
+            <span className={`h-2 w-2 rounded-full ${dotBg(v.tone)}`} />
+            <span className="text-ink">{v.version}</span>
+            <span className="text-faint">{v.pct}% · {v.count}</span>
+          </span>
+        ))}
+        {data.unknown > 0 && (
+          <span className="flex items-center gap-1.5">
+            <span className={`h-2 w-2 rounded-full ${dotBg('muted')}`} />
+            <span className="text-ink">unknown</span>
+            <span className="text-faint">{data.unknown}</span>
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function toneFor(i: number, n: number): Tone {
+  if (i === 0) return 'safe'
+  if (i === n - 1) return 'warn'
+  return 'ice'
+}
+function dotBg(t: Tone) { return t === 'safe' ? 'bg-safe' : t === 'warn' ? 'bg-warn' : t === 'crit' ? 'bg-crit' : t === 'ice' ? 'bg-ice' : 'bg-muted' }

--- a/console/lib/api/client.ts
+++ b/console/lib/api/client.ts
@@ -1,5 +1,5 @@
 import { PROXY_BASE } from './config'
-import type { AuditPage, AuditVerify, FabricState, FabricTelemetry, FederationReports, FleetNodePosture, HealthResponse, NodeHistory } from './types'
+import type { AuditPage, AuditVerify, ConsoleAnalytics, ConsoleRuntime, ConsoleSites, ConsoleVersions, FabricState, FabricTelemetry, FederationReports, FleetNodePosture, HealthResponse, NodeHistory } from './types'
 
 // Sentinel thrown when the proxy reports demo mode (no backend configured).
 // Distinguishes "intentionally offline" from "backend down" for labeling.
@@ -32,4 +32,9 @@ export const kirra = {
   federationReports: (assetId: string, signal?: AbortSignal) =>
     getJSON<FederationReports>(`/federation/reports/${encodeURIComponent(assetId)}`, signal),
   fabricState: (signal?: AbortSignal) => getJSON<FabricState>('/fabric/state', signal),
+  runtime: (signal?: AbortSignal) => getJSON<ConsoleRuntime>('/console/runtime', signal),
+  analytics: (windowMs: number, signal?: AbortSignal) =>
+    getJSON<ConsoleAnalytics>(`/console/analytics?window_ms=${windowMs}`, signal),
+  sites: (signal?: AbortSignal) => getJSON<ConsoleSites>('/console/sites', signal),
+  versions: (signal?: AbortSignal) => getJSON<ConsoleVersions>('/console/versions', signal),
 }

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { kirra, DemoMode } from './client'
-import type { AuditEntry, AuditVerify, AssetPosture, FabricTelemetry, FederatedReport, FleetNodePosture, FleetPostureState, NodeHistoryEntry, PostureStreamEvent } from './types'
+import type { AuditEntry, AuditVerify, AssetPosture, ConsoleAnalytics, ConsoleRuntime, ConsoleSites, ConsoleVersions, FabricTelemetry, FederatedReport, FleetNodePosture, FleetPostureState, NodeHistoryEntry, PostureStreamEvent } from './types'
 import { robots } from '@/lib/mock'
 import { log as demoEvents, sources as demoSources } from '@/lib/events'
 import { incidents as demoIncidents } from '@/lib/incidents'
@@ -24,7 +24,7 @@ export type LinkStatus = 'connecting' | 'ok' | 'down' | 'demo'
 const isDemo = (e: unknown) => e instanceof DemoMode
 const isAbort = (e: unknown) => (e as { name?: string })?.name === 'AbortError'
 
-// ── Demo fallbacks (shaped exactly like the wire types) ────────────────────
+// ── Demo fallbacks (shaped exactly like the wire types) ─────────────────────
 function demoFleet(): FleetNodePosture[] {
   return robots.map((r) => ({
     node_id: r.name,
@@ -62,7 +62,7 @@ function mkEvent(p: FleetNodePosture, type: string): PostureStreamEvent {
   return { event_type: type, node_id: p.node_id, emitted_at_ms: Date.now(), posture: p }
 }
 
-// ── Hooks ─────────────────────────────────────────────────
+// ── Hooks ────────────────────────────────────
 
 // Polls /health through the proxy for the shell connection indicator.
 export function useHealth(pollMs = 10000): { status: LinkStatus } {
@@ -532,4 +532,184 @@ export function useDecisions(limit = 60): { recent: DecisionRow[]; tally: Decisi
   }, [limit])
 
   return { recent, tally, source }
+}
+
+// ── Console aggregate endpoints (#394) ───────────────────────────────
+// Four read-only console rollups served by the verifier. Each follows the same
+// poll/abort/demo-fallback shape as the hooks above: a bundled demo snapshot is
+// the initial state and the fallback whenever the proxy is in demo mode or the
+// backend is unreachable.
+
+// Runtime health — GET /console/runtime (#395). Operational snapshot of the
+// verifier: mode, uptime, posture generation/cache, fabric denial rate, etc.
+const DEMO_RUNTIME: ConsoleRuntime = {
+  mode: 'Active',
+  uptime_ms: 1000 * 60 * 60 * 73 + 1000 * 60 * 14,
+  posture_generation: 4471,
+  last_recalc_ms: Date.now() - 2200,
+  posture_cache_ttl_ms: 5000,
+  total_nodes: 38,
+  fabric_assets: 8,
+  fabric_denial_rate: 0.012,
+  audit_entries: 184220,
+  broadcast_subscribers: 3,
+  ha_heartbeat_age_ms: 1840,
+}
+
+export function useRuntimeHealth(pollMs = 8000): { data: ConsoleRuntime; source: Source } {
+  const [data, setData] = useState<ConsoleRuntime>(DEMO_RUNTIME)
+  const [source, setSource] = useState<Source>('demo')
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const r = await kirra.runtime(ctrl.signal)
+        setData(r); setSource('live')
+        timer = setTimeout(load, pollMs)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { setSource('demo'); return }
+        setSource('demo'); timer = setTimeout(load, pollMs)
+      }
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [pollMs])
+
+  return { data, source }
+}
+
+// Analytics — GET /console/analytics?window_ms= (#396). Historical trend (NOT a
+// forecast): bucketed posture transitions, denial-rate series, per-asset
+// interventions, flapping nodes over the requested window.
+function demoAnalytics(windowMs: number): ConsoleAnalytics {
+  const now = Date.now()
+  const buckets = 12
+  const step = Math.max(1, Math.floor(windowMs / buckets))
+  const posture_transitions = Array.from({ length: buckets }).map((_, i) => ({
+    bucket_start_ms: now - (buckets - i) * step,
+    to_degraded: Math.round(Math.abs(Math.sin(i / 2)) * 3),
+    to_lockedout: i % 5 === 0 ? 1 : 0,
+    to_nominal: Math.round(Math.abs(Math.cos(i / 2)) * 3),
+  }))
+  const denial_rate_series = Array.from({ length: buckets }).map((_, i) => ({
+    bucket_start_ms: now - (buckets - i) * step,
+    denial_rate: Math.round((0.008 + Math.abs(Math.sin(i / 3)) * 0.02) * 1000) / 1000,
+  }))
+  return {
+    window_ms: windowMs,
+    posture_transitions,
+    denial_rate_series,
+    interventions_by_asset: [
+      { asset_id: 'KIRRA-13', clamps: 14, denies: 6 },
+      { asset_id: 'KIRRA-10', clamps: 9, denies: 2 },
+      { asset_id: 'KIRRA-09', clamps: 3, denies: 0 },
+    ],
+    flapping_top: [
+      { node_id: 'KIRRA-13', transitions: 11 },
+      { node_id: 'KIRRA-10', transitions: 5 },
+    ],
+  }
+}
+
+export function useAnalytics(windowMs = 30 * 24 * 60 * 60 * 1000, pollMs = 30000): { data: ConsoleAnalytics; source: Source } {
+  const [data, setData] = useState<ConsoleAnalytics>(() => demoAnalytics(windowMs))
+  const [source, setSource] = useState<Source>('demo')
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const a = await kirra.analytics(windowMs, ctrl.signal)
+        setData(a); setSource('live')
+        timer = setTimeout(load, pollMs)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { setData(demoAnalytics(windowMs)); setSource('demo'); return }
+        setData(demoAnalytics(windowMs)); setSource('demo'); timer = setTimeout(load, pollMs)
+      }
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [windowMs, pollMs])
+
+  return { data, source }
+}
+
+// Site distribution — GET /console/sites (#397). Fleet posture rolled up per
+// site, plus the count of nodes with no site assignment.
+const DEMO_SITES: ConsoleSites = {
+  sites: [
+    { site: 'San Francisco', total: 142, nominal: 131, degraded: 9, lockedout: 2 },
+    { site: 'Austin', total: 88, nominal: 86, degraded: 2, lockedout: 0 },
+    { site: 'Rotterdam', total: 64, nominal: 63, degraded: 1, lockedout: 0 },
+    { site: 'Singapore', total: 51, nominal: 47, degraded: 4, lockedout: 0 },
+    { site: 'Tokyo', total: 37, nominal: 36, degraded: 1, lockedout: 0 },
+  ],
+  unassigned: 0,
+}
+
+export function useSites(pollMs = 15000): { data: ConsoleSites; source: Source } {
+  const [data, setData] = useState<ConsoleSites>(DEMO_SITES)
+  const [source, setSource] = useState<Source>('demo')
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const s = await kirra.sites(ctrl.signal)
+        setData(s); setSource('live')
+        timer = setTimeout(load, pollMs)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { setSource('demo'); return }
+        setSource('demo'); timer = setTimeout(load, pollMs)
+      }
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [pollMs])
+
+  return { data, source }
+}
+
+// Version adoption — GET /console/versions (#398). Software-version share across
+// the fleet, plus the nodes reporting an unknown version.
+const DEMO_VERSIONS: ConsoleVersions = {
+  versions: [
+    { version: 'v2.4.1', count: 271, pct: 71 },
+    { version: 'v2.4.0', count: 99, pct: 26 },
+    { version: 'v2.3.6', count: 11, pct: 3 },
+  ],
+  total: 382,
+  unknown: 1,
+}
+
+export function useVersions(pollMs = 20000): { data: ConsoleVersions; source: Source } {
+  const [data, setData] = useState<ConsoleVersions>(DEMO_VERSIONS)
+  const [source, setSource] = useState<Source>('demo')
+
+  useEffect(() => {
+    const ctrl = new AbortController()
+    let timer: ReturnType<typeof setTimeout>
+    const load = async () => {
+      try {
+        const v = await kirra.versions(ctrl.signal)
+        setData(v); setSource('live')
+        timer = setTimeout(load, pollMs)
+      } catch (e) {
+        if (isAbort(e)) return
+        if (isDemo(e)) { setSource('demo'); return }
+        setSource('demo'); timer = setTimeout(load, pollMs)
+      }
+    }
+    load()
+    return () => { ctrl.abort(); clearTimeout(timer) }
+  }, [pollMs])
+
+  return { data, source }
 }

--- a/console/lib/api/types.ts
+++ b/console/lib/api/types.ts
@@ -116,6 +116,80 @@ export interface FabricState {
   computed_at_ms: number
 }
 
+// Console runtime health — GET /console/runtime (#395). Single-snapshot view of
+// the verifier's operational state: mode, uptime, posture-engine generation /
+// cache, fabric denial rate, audit size, SSE subscribers, HA heartbeat age.
+export interface ConsoleRuntime {
+  mode: 'Active' | 'PassiveStandby'
+  uptime_ms: number
+  posture_generation: number
+  last_recalc_ms: number
+  posture_cache_ttl_ms: number
+  total_nodes: number
+  fabric_assets: number
+  fabric_denial_rate: number
+  audit_entries: number
+  broadcast_subscribers: number
+  ha_heartbeat_age_ms: number | null
+}
+
+// Console analytics — GET /console/analytics?window_ms= (#396). Historical
+// (NOT forecast) trend series over the requested window: bucketed posture
+// transitions, denial-rate series, per-asset interventions, and flapping nodes.
+export interface PostureTransitionBucket {
+  bucket_start_ms: number
+  to_degraded: number
+  to_lockedout: number
+  to_nominal: number
+}
+export interface DenialRatePoint {
+  bucket_start_ms: number
+  denial_rate: number
+}
+export interface InterventionByAsset {
+  asset_id: string
+  clamps: number
+  denies: number
+}
+export interface FlappingNode {
+  node_id: string
+  transitions: number
+}
+export interface ConsoleAnalytics {
+  window_ms: number
+  posture_transitions: PostureTransitionBucket[]
+  denial_rate_series: DenialRatePoint[]
+  interventions_by_asset: InterventionByAsset[]
+  flapping_top: FlappingNode[]
+}
+
+// Console site distribution — GET /console/sites (#397). Fleet posture rolled up
+// per site, plus the count of nodes with no site assignment.
+export interface SiteDistribution {
+  site: string
+  total: number
+  nominal: number
+  degraded: number
+  lockedout: number
+}
+export interface ConsoleSites {
+  sites: SiteDistribution[]
+  unassigned: number
+}
+
+// Console version adoption — GET /console/versions (#398). Software-version
+// share across the fleet, plus the nodes reporting an unknown version.
+export interface VersionShareEntry {
+  version: string
+  count: number
+  pct: number
+}
+export interface ConsoleVersions {
+  versions: VersionShareEntry[]
+  total: number
+  unknown: number
+}
+
 export function trustLabel(s: NodeTrustState): string {
   return typeof s === 'string' ? s : 'Untrusted'
 }


### PR DESCRIPTION
Frontend wiring for #394 / #395 / #396 / #397 / #398. Wires the Mission Console (`console/`) to four new read-only verifier console endpoints. Low-risk, observe-only (QM-domain) frontend work — no Rust / safety code touched.

## Shared plumbing
- **Proxy allow-list** (`console/app/api/kirra/[...path]/route.ts`): added one anchored regex entry permitting `console/runtime`, `console/analytics`, `console/sites`, `console/versions`. The analytics `?window_ms=` query rides through via the existing `req.nextUrl.search` pass-through (allow-list tests the path only, exactly like `/console/audit?limit=`).
- **Types** (`console/lib/api/types.ts`): added `ConsoleRuntime`, `ConsoleAnalytics` (+ bucket/series sub-types), `ConsoleSites`, `ConsoleVersions` mirroring the #395–#398 JSON shapes.
- **Client** (`console/lib/api/client.ts`): added `kirra.runtime` / `analytics(windowMs)` / `sites` / `versions`.
- **Hooks** (`console/lib/api/hooks.ts`): added `useRuntimeHealth`, `useAnalytics`, `useSites`, `useVersions` following the exact existing poll / AbortController / demo-fallback / `source: 'live' | 'demo'` pattern. Each ships a bundled demo snapshot as initial state + fallback, so pages degrade gracefully before the backend (PR #432) merges.

## Per-page wiring (mock fallback preserved everywhere)
- **Runtime Health** (`console/app/runtime/page.tsx`): added a self-contained `RuntimeHealthPanel` (`components/ui/runtime-health.tsx`, mirroring `FabricTelemetryPanel`) wired to `/console/runtime` — mode, uptime, posture generation, recalc age vs cache TTL, node/asset counts, denial rate, audit size, SSE subscribers, HA heartbeat age (handles the `null` case).
- **Analytics** (`console/app/analytics/page.tsx`): wired to `/console/analytics`. **Dropped the "Risk Forecasting" framing** per #396 — this is historical trend, not ML forecasting. Page title → "Analytics & Historical Trends"; the forecast chart is replaced by observed **Posture Transitions** + **Denial Rate** trends, **Top Flapping Nodes**, and **Interventions by Asset**, all clearly labeled backward-looking. KPI wall left as mock (out of #396 scope).
- **Global Operations** (`console/app/global/page.tsx`): wired **only** the Fleet Distribution panel to `/console/sites` (per-site posture rollup + unassigned). The map / weather / geofence overlays are intentionally **left as mock** (out of #397 mandate).
- **Reports** (`console/app/reports/page.tsx`): wired **only** the fleet version-adoption bar to `/console/versions` via a self-contained `VersionAdoptionBar` (`components/ui/version-adoption.tsx`). The rollout-rings / staged-deploy / OTA-orchestration section is intentionally **left as mock** (out of #398 scope).

## Verification
- `npx tsc --noEmit` — clean (exit 0)
- `npx next lint` — no ESLint warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_