### PR TITLE
docs(adr): resolutions for #405 (ADR-0011) and #406 (ADR-0012) — for owner sign-off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,10 +237,17 @@ PROMOTION_TIMEOUT_MS         = 10_000     // standby promotes if primary silent 
   (c) no re-initiation — if `|current| <= STOP_EPSILON_MPS` (0.05), any `|proposed| > STOP_EPSILON_MPS`
   → `DenyCode::DegradedReinitiationDenied` (HOLD at zero); a reversal through a stop is also re-initiation.
 - A denied command → MRC controlled stop; the Governor never authors re-acceleration.
-- Wired at ALL four enforcement points: gateway `enforce_actuator_safety_envelope`,
+- Implemented at four enforcement points: gateway `enforce_actuator_safety_envelope`,
   fabric `AssetGovernor::evaluate_command`, ros2-adapter `validate_trajectory_slow`,
   parko-kirra `KirraGovernor::apply_mrc_profile` (the last also gates an independent
-  angular-velocity channel via `STOP_EPSILON_RAD_S` for differential drive).
+  angular-velocity channel via `STOP_EPSILON_RAD_S` for differential drive). **REACHABILITY
+  CAVEAT (#405 / ADR-0011):** the three *direct* callers (fabric / parko-kirra / ros2-adapter)
+  invoke the gate directly and ARE reachable. The gateway `enforce_actuator_safety_envelope`
+  branch is currently **UNREACHABLE on the HTTP `/actuator/motion/command` path** — the outer
+  `enforce_posture_routing` gate 503s Degraded `WriteState` before the inner envelope runs, so
+  the decel-to-stop branch is dead code there. Resolution recorded in ADR-0011 (the `503 → 0.0`
+  consumer fix is the safety floor; relaxing the outer gate is a follow-on design choice). Do
+  not cite the gateway HTTP path as a live decel-to-stop enforcement point until that lands.
 - The Nominal WCET-critical `validate_vehicle_command` path is UNCHANGED.
 - "MRC" disambiguation: Degraded MRC = decel-to-stop *envelope* (bounds a converging
   command); LockedOut MRC fallback = safe-stop *maneuver* (all commands denied).

--- a/docs/adr/0011-degraded-http-actuator-503-vs-decel-gate.md
+++ b/docs/adr/0011-degraded-http-actuator-503-vs-decel-gate.md
@@ -2,10 +2,10 @@
 
 | Field | Value |
 |---|---|
-| Status | **Open** — decision pending owner HARA/DFA + ADR sign-off. Not a free A-vs-B choice (see Finding). |
-| Date | 2026-06-20 |
-| Deciders | Project / safety-case owner (pending) |
-| Issues | #405 (this), #406 (sequenced behind — MRC divergence), #70 (Degraded decel-to-stop-and-HOLD design) |
+| Status | **Proposed resolution (2026-06-21)** — owner direction set; ratified on merge. Supersedes the prior "Open / deferred" status (see Decision). |
+| Date | 2026-06-20 (finding) · 2026-06-21 (resolution) |
+| Deciders | Project / safety-case owner |
+| Issues | #405 (this), #406 (sequenced behind — MRC divergence, ADR-0012), #70 (Degraded decel-to-stop-and-HOLD design) |
 | Code | `src/bin/kirra_verifier_service.rs` (router assembly), `src/gateway/policy_layer.rs`, `src/posture_cache.rs` (`should_route_command`), `src/bin/kirra_carla_client.rs` (the actuator consumer) |
 
 ## Context
@@ -58,7 +58,9 @@ catch-all `Err`, and the consumer holds the last command (no decel). The ROS int
 Degraded command is denied with 503 and **nothing converts that to a decel-to-stop** — the
 vehicle holds its pre-Degraded speed until a separate watchdog fires. That is the **opposite**
 of Issue #70's intent (Cruise SF Oct-2023 pullover-drag lesson) and a latent hazard. So this
-is **not** a free choice between A and B — there is a **gap to close** regardless.
+is **not** a free choice between A and B — there is a **gap to close** regardless. The client
+*creates* the no-command condition on 503 (it does not resolve it), whereas on 400/403 it
+actively authors a zero command — an asymmetry in the consumer's deny handling.
 
 ## Options (owner decision)
 
@@ -86,13 +88,42 @@ becomes live under Option A (or any non-HTTP caller). Reconciling it needs (a) a
 authoritative-MRC decision and (b) **per-platform derate factors derived from the HARA /
 safety case** — the 5.0 m/s figure is load-bearing (CLAUDE.md / `SAFE_STATE_SPECIFICATION`
 SS-002) and must not be chosen for convenience. #406 stays blocked behind #405 and its numbers
-come from the safety case.
+come from the safety case. The #406 decision is recorded in **ADR-0012**.
 
 ## Decision
 
-**Deferred to the safety-case owner** (HARA/DFA + ADR sign-off). The verified finding above —
-not an opinion — is the input: the conservative interim reading is that the gap (503 →
-hold-last-command, no decel) should be closed regardless of A vs B⁺, but even the stopgap
-(consumers fail-closed to a stop on 503) is a behavioral change pending owner direction. This
-ADR exists so that "why does Degraded deny the HTTP actuator path?" has a recorded answer for
-an assessor, and so the relaxation of a deliberate invariant is never done silently.
+> The prior status was **Open / deferred to the safety-case owner**. The owner direction below
+> was set on 2026-06-21 following the verified egress trace; **merging this ADR ratifies it.**
+> A deliberate fail-closed invariant is never relaxed silently — the decision lives here, in
+> the open, for any assessor reading the trail.
+
+**Resolution (2026-06-21) — owner direction:**
+
+1. **The `503 → controlled-stop` consumer fix is the SAFETY FLOOR — do it first, independent
+   of A vs B.** Map `503` in the actuator consumer to an `enforced 0.0 / 0.0` controlled stop,
+   exactly as `400` / `403` already are (`src/bin/kirra_carla_client.rs`, and the production
+   interceptor as its mirror). This removes the hazard **at the layer the kernel controls**,
+   restores the consumer invariant *"every deny-shaped response authors a safe command,"* and
+   does **not** depend on the integrator-owned DBW. It is correct under either A or B and is
+   therefore not an A/B question — it is just correct.
+2. **Option A becomes a follow-on DESIGN choice, not a safety requirement.** Once the consumer
+   safe-stops on 503, A only upgrades a flat-zero stop to a richer *converging-decel* stop. If
+   adopted it is still HARA/DFA-gated (it relaxes the documented "Degraded = ReadTelemetry
+   only" invariant), but it is no longer load-bearing for the safety floor.
+3. **Bare B (document the 503 contract + annotate dead branches, no consumer fix) is
+   REJECTED.** It parks the hazard on the unconfirmed DBW no-fresh-command watchdog (Dataspeed
+   command-freshness spec) — an integrator/hardware assumption, not a kernel guarantee.
+4. **DBW watchdog = defense-in-depth, not the safety floor.** Confirm the Dataspeed
+   command-freshness behavior and record it as an Assumption of Use, but the `503 → 0.0` fix
+   is what lets the safety case stop depending on it.
+
+**Evidence:** the verified in-repo egress trace (Finding above) — full four-way client trace
+and the contrast with the fail-safe ROS2/parko path (which publishes an affirmative MRC
+command on any deny, but bypasses the HTTP posture gate) is recorded on issue #405:
+https://github.com/kirra-systems/kirra-runtime-sdk/issues/405#issuecomment-4761893645
+
+**Still required either way:** the assembled-router (`build_app`) Degraded actuator test, and
+the CLAUDE.md "wired at all four points" correction.
+
+**Implementation** (the consumer `503 → 0.0` fix + the test) lands from a laptop (large
+governor sources; web `git push` unavailable). This ADR records the decision, which does not.

--- a/docs/adr/0012-authoritative-mrc-envelope-per-asset.md
+++ b/docs/adr/0012-authoritative-mrc-envelope-per-asset.md
@@ -1,0 +1,60 @@
+# ADR-0012: One authoritative MRC (Degraded) envelope per asset
+
+| Field | Value |
+|---|---|
+| Status | **Proposed resolution (2026-06-21)** — owner direction set; ratified on merge. |
+| Date | 2026-06-21 |
+| Deciders | Project / safety-case owner |
+| Issues | #406 (this), #405 / ADR-0011 (sequenced ahead — HTTP-path reachability), #70 (Degraded decel-to-stop), `SAFE_STATE_SPECIFICATION` SS-002 |
+| Code | `src/fabric/governor.rs` (`KinematicProfileType::mrc_contract`), `src/gateway/kinematics_contract.rs` (`mrc_fallback_profile`), `src/gateway/policy_layer.rs` (Degraded branch) |
+
+## Context
+
+Two MRC (Minimal Risk Condition / Degraded) envelope definitions disagree for the **same
+asset + posture**:
+
+- **Fabric** — `KinematicProfileType::mrc_contract()` derives the MRC by a uniform
+  **0.3× speed / 0.4× accel / 0.5× steering** derate of the *nominal* profile. For an
+  automotive asset (nominal `max_speed_mps = 35.0`): `35.0 × 0.3 = ` **10.5 m/s**.
+- **Canonical / gateway** — `mrc_fallback_profile()`, a hand-tuned profile used by
+  `enforce_actuator_safety_envelope` / the policy layer: **5.0 m/s**.
+
+The **5.0 m/s** figure is load-bearing in the safety case (Cruise SF Oct-2023 ~3 m/s post-stop
+pullover-drag, *"under a 5 m/s crawl ceiling"*; CLAUDE.md / `SAFE_STATE_SPECIFICATION` SS-002).
+The fabric's **10.5 m/s** is **2× looser** than the validated number — not a rounding gap.
+
+Separately, the gateway's Degraded branch applies `mrc_fallback_profile()` (the automotive
+5.0) **unconditionally to every platform**. So a `RobotNominal` asset (nominal 1.8 m/s) gets a
+5.0 m/s Degraded ceiling — nonsensically *looser* than its platform-aware `1.8 × 0.3 = 0.54`.
+There is no single authoritative answer to *"what is the MRC envelope for asset X in
+Degraded"*, and which definition is looser depends on the platform.
+
+## Decision (resolved 2026-06-21) — owner direction
+
+1. **Authoritative MRC = the validated profile, not the computed derate (Option A).** Map
+   automotive fabric assets to `mrc_fallback_profile()` so fabric and gateway agree at the
+   safety-case **5.0** for automotive. Keep the per-platform `0.3× / 0.4× / 0.5×` derate only
+   for non-automotive platforms, with each platform's derate factors **derived from its HARA /
+   safety case**, documented, and not chosen for convenience. Aligning to the validated 5.0
+   over a 2×-looser computed number is the conservative call; trusting a generic derate to
+   land near the safety-case figure is not a safety argument.
+2. **The "gateway applies automotive 5.0 to all platforms" defect is SEPARATE and
+   UNCONDITIONAL.** Make the gateway Degraded branch profile-aware — resolve the asset's
+   `KinematicProfileType` and use *its* `mrc_contract()` rather than the automotive fallback
+   for every platform. This is wrong **regardless of #405 / Option A** and is not gated behind
+   the reachability decision; it can land independently.
+3. **Cross-point invariant + test.** The same asset + Degraded posture must yield the **same
+   effective MRC speed ceiling** at every enforcement point (gateway HTTP envelope, fabric
+   `AssetGovernor`, ros2-adapter, parko-kirra). Add a test asserting this so a future
+   enforcement point cannot silently ship a drifted copy.
+
+## Sequencing
+
+The fabric Degraded branch (and this divergence) is **latent on the HTTP path** — 503'd by the
+same outer `enforce_posture_routing` gate as #405 (see ADR-0011) — so the divergence becomes
+*live* only under #405 Option A or via a non-HTTP caller of `route_command`. The
+source-of-truth reconciliation (item 1) is therefore **sequenced behind the #405 resolution**.
+The all-platforms gateway defect (item 2) is **unconditional** and may land independently.
+
+All numbers come from the safety case (SS-002), never convenience. Implementation lands from a
+laptop (large governor sources); this ADR records the decision, which does not.


### PR DESCRIPTION
## For owner sign-off — **merge ratifies the decision** (nothing applied silently)

Records the resolutions reached in the safety-case review for #405 and #406, plus the doc correction ADR-0011 calls for. **Docs-only** — no code changes; the *implementations* still land from a laptop. Merging this is the formal sign-off.

### ADR-0011 (updated) — Degraded HTTP actuator 503 (#405)
Was "Open / deferred to owner." Now records the owner direction:
- **`503 → 0.0` controlled-stop consumer fix is the safety floor** — do it first, correct under either A or B (it's not an A/B question). Mirrors the existing `400`/`403` handling; removes the hazard at the layer the kernel controls; restores "every deny authors a safe command."
- **Option A** (let Degraded `WriteState` reach `enforce_degraded_decel_to_stop`) → a follow-on **design** choice (converging-decel vs. flat-zero), not a safety requirement; still HARA/DFA-gated if adopted.
- **Bare B** (document-only) → **rejected** (parks the hazard on the unconfirmed DBW watchdog).
- **DBW watchdog** → defense-in-depth, not the safety floor.
- Carries the verified four-way client-egress trace + the link to the #405 evidence comment.

### ADR-0012 (new) — Authoritative MRC envelope per asset (#406)
- **Option A**: align automotive fabric MRC to the validated `mrc_fallback_profile()` **5.0** (vs. the 2×-looser computed 10.5); per-platform derates derived from the safety case.
- The **"gateway applies automotive 5.0 to all platforms"** defect is **separate + unconditional** (fix the gateway Degraded branch to be profile-aware) — not gated behind #405.
- Cross-point invariant test: same asset+Degraded ⇒ same effective ceiling everywhere.
- Sequenced behind #405 for HTTP reachability; the all-platforms fix can land independently.

### CLAUDE.md (corrected) — the "wired at all four points" claim
ADR-0011's resolution lists this fix. The decel-to-stop "wired at all four enforcement points" line now carries a **reachability caveat**: the gateway `enforce_actuator_safety_envelope` branch is **unreachable on the HTTP `/actuator/motion/command` path** (the outer gate 503s Degraded `WriteState` first); only the three direct callers reach it. Cross-refs ADR-0011. (+9/−2, surgical.)

### What still needs the laptop (out of scope here)
The `503 → 0.0` consumer fix + the assembled-router Degraded test (#405), and the MRC reconciliation + cross-point test (#406) — all touch the large governor sources.

Refs #405, #406, #410, #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)