### PR TITLE
ci: retry ros-tooling/setup-ros once (transient ros2-apt-source rate-limit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,7 +411,23 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
-      - uses: ros-tooling/setup-ros@v0.7
+      - id: setup_ros
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
+        # setup-ros installs the new `ros2-apt-source` deb, resolving its version
+        # via an UNAUTHENTICATED api.github.com call (60/hr, per shared runner IP).
+        # When that rate-limits, the version comes back empty -> the deb URL 404s
+        # -> `curl --fail` exits 22 -> the action fails. It is transient, so the
+        # first attempt is tolerant and we retry once after a short delay; the
+        # retry is authoritative (a persistent failure still reds the job).
+        continue-on-error: true
+      - name: setup-ros delay before retry (transient ros-apt-source rate-limit)
+        if: steps.setup_ros.outcome == 'failure'
+        run: sleep 90
+      - name: setup-ros (retry)
+        if: steps.setup_ros.outcome == 'failure'
+        uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: jazzy
       - name: Build curated message workspace


### PR DESCRIPTION
## What

Makes the `ros2-adapter-build` job resilient to a transient `ros-tooling/setup-ros` failure: **retry the action once after a short delay.**

## Why

`setup-ros@v0.7` installs the new `ros2-apt-source` deb, resolving its version via an **unauthenticated** `api.github.com` call (`releases/latest`). On GitHub Actions that's throttled to 60 req/hr per shared runner IP. When it rate-limits, the version comes back **empty** → the download URL collapses to `.../download//ros2-apt-source_._all.deb` → **404** → `curl --fail` exits **22** → the action fails. Observed failure:

```
curl --fail --location ... -o /tmp/ros2-apt-source.deb "https://github.com/.../download/${VER}/..."
Error: The process '/usr/bin/bash' failed with exit code 22
```

It's transient — a re-run usually passes. This makes it not *recur*.

## How

```yaml
- id: setup_ros
  uses: ros-tooling/setup-ros@v0.7
  with: { required-ros-distributions: jazzy }
  continue-on-error: true          # tolerate the transient first attempt
- if: steps.setup_ros.outcome == 'failure'
  run: sleep 90
- if: steps.setup_ros.outcome == 'failure'
  uses: ros-tooling/setup-ros@v0.7  # authoritative retry — persistent failure still reds the job
  with: { required-ros-distributions: jazzy }
```

- **No version guessing, no rewrite of the ROS install** — minimal and reversible.
- The retry is **authoritative** (no `continue-on-error` on it), so a *persistent* failure still blocks. It only absorbs the rate-limit blip.
- Affects **only** the non-gating `--features ros2` adapter lane — not the safety-kernel tests.

YAML validated (`yaml.safe_load`); the committed blob hash equals the locally git-applied patch's blob, so the change is exactly these 16 lines and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_