### PR TITLE
docs(#274): QNX WCET bring-up — cross-compile recipe + SCHED_FIFO measurement wrapper (drafted, not run)

### DIFF
--- a/docs/safety/WCET_QNX_BRINGUP.md
+++ b/docs/safety/WCET_QNX_BRINGUP.md
@@ -1,0 +1,133 @@
+# WCET QNX Bring-Up (#274) — verdict-path WCET on a QNX SDP 8.0 target
+
+| Field | Value |
+|---|---|
+| Status | **Draft — defined build, not run** (no QNX hardware in this task). |
+| Date | 2026-06-21 |
+| Owner | Project / safety-case owner |
+| Issue | #274 (EPIC #270, QNX governor lane). RTM tracing #272 (done). |
+| Scope | Cross-compile the no_std verdict **judge** (`tools/qnx-rtm-harness/kirra_judge.rs`) for a QNX target and measure its per-verdict WCET under `SCHED_FIFO`, replacing the harness placeholder `wcet_status = TBD-QNX-TARGET`. |
+| Companions | `tools/qnx-rtm-harness/` (README, `QNX_MAPPING.md`, `CMakeLists.txt`, `kirra_judge.rs`, `kirra_ffi.h`, `wcet_measure.cpp`), `docs/adr/KIRRA_QNX_CROSSCOMPILE.md`, `docs/safety/WCET_MEASUREMENT_METHODOLOGY.md`, `src/wcet_gate.rs`, `ASSUMPTIONS_OF_USE.md` (AOU-HW-QNX-TARGET-001), ADR-0001. |
+
+## Hard boundaries (read first)
+
+**1. A Jetson cannot run QNX.** Jetson modules (Orin NX / AGX Orin / Jetson Thor) run **L4T / Linux** — they are the *doer-side* robotics lane (Parko inference, the Rosmaster R2 bring-up, Mick/Taj). They have **no QNX support** and **cannot** produce a QNX-target WCET row (AOU-HW-QNX-TARGET-001). The measurement runs on a **separate** QNX target. Never describe it as "on Jetson under QNX."
+
+**2. Two QNX targets, two phases.**
+- **Phase I (feasibility):** QNX SDP 8.0 on an **aarch64 eval board** (preferred) or **x86_64 VM** (fallback). Produces a *real* QNX-target-under-FIFO number — far stronger than the host-Linux-indicative CI number, sufficient to substantiate the Phase I sub-100 µs verdict claim. **Not cert-grade.**
+- **Phase II (cert-grade):** **NVIDIA DRIVE AGX Orin / Thor + QNX OS for Safety**, Ferrocene-qualified Rust — the certified FTTI number. (Ferrocene's *qualified* QNX target is `qnx710`, **not** `qnx800`; the cert Rust toolchain is its own decision — see `KIRRA_QNX_CROSSCOMPILE.md`.)
+
+**3. Lane.** This is **checker-side Objective 1** — distinct from the Parko / §2-readiness work and the Mick / Taj / Linux robotics lane.
+
+## Why this sidesteps the #189 / #66–#67 blockers
+
+The WCET target is the **`#![no_std]`, zero-alloc, `core`-only** judge. It links `core` + a few platform symbols (`pthread / dl / m`) and uses **no `std` / `libc` / `socket2` / `tokio`**. So it does **not** depend on the QNX `std` package that #189 (nto80 libc) is blocked on, nor the async networking #66/#67 gate. Those block the **full async verifier**; they do **not** block the verdict core. The judge is dependency-free **by design** precisely so the WCET artifact is portable to a cert target ahead of the full runtime.
+
+## 1. Cross-compile recipe
+
+### 1a. Target triple — TBD pending the Phase-II / DRIVE-access decision
+
+```
+<TARGET_TRIPLE_TBD>
+```
+
+| Phase / target | Triple |
+|---|---|
+| Phase I eval board (aarch64) | `aarch64-unknown-nto-qnx800` |
+| Phase I VM (x86_64) | `x86_64-pc-nto-qnx800` |
+| Phase II DRIVE Orin / Thor (aarch64) | `aarch64-unknown-nto-qnx800` (cert Rust = Ferrocene `qnx710` — separate decision) |
+
+Do **not** hard-pin the triple in the build until the target is confirmed; substitute `<TARGET_TRIPLE_TBD>` everywhere below.
+
+### 1b. The judge — `rustc` → `libkirra_judge.a` (no_std staticlib, QNX target)
+
+Host build today (from `CMakeLists.txt`):
+
+```bash
+rustc --edition 2021 --crate-type staticlib --crate-name kirra_judge \
+      -C panic=abort -C opt-level=2 -C debuginfo=0 \
+      -o libkirra_judge.a kirra_judge.rs
+```
+
+QNX cross-build — add the target; **nothing else about the judge changes** (it is no_std, so no QNX `std` is required):
+
+```bash
+# Source the QNX SDP 8.0 env (provides qcc + the nto target machinery):
+source ~/qnx800/qnxsdp-env.sh
+
+# Because the judge is no_std (core-only), prefer QNX SDP 8.0's bundled Rust
+# (it ships the nto-qnx800 target). With upstream nightly instead, `core` is
+# available without building std — `-Zbuild-std=core` — or via a custom
+# target.json for the nto tuple. rustup ships NO prebuilt std for nto (and we
+# need none here).
+rustc --edition 2021 --target <TARGET_TRIPLE_TBD> \
+      --crate-type staticlib --crate-name kirra_judge \
+      -C panic=abort -C opt-level=2 -C debuginfo=0 \
+      -o libkirra_judge.a kirra_judge.rs
+```
+
+### 1c. The C++ shim + harness + measurement — `qcc` / `q++`
+
+C++17, exception-free, RTTI-free (the integration-boundary discipline). Build with QNX's `qcc` / `q++`:
+
+```bash
+qcc -V    # confirm the variant string in YOUR install, e.g. gcc_ntoaarch64_cxx
+
+q++ -Vgcc_ntoaarch64_cxx -std=c++17 -Wall -Wextra -Werror -fno-exceptions -fno-rtti \
+    -O2 -I tools/qnx-rtm-harness \
+    tools/qnx-rtm-harness/kirra_shim.cpp tools/qnx-rtm-harness/wcet_measure.cpp \
+    -o wcet_measure \
+    libkirra_judge.a -lpthread
+# QNX provides pthread/m/dl via libc; -ldl/-lm may be unneeded on QNX — confirm per `qcc -V`.
+```
+
+### 1d. CMake hook extension (gated; host build unchanged)
+
+The existing hook is a **comment** in `CMakeLists.txt`. Make it real, gated by a `KIRRA_QNX_TARGET` option so the host build stays byte-identical when OFF:
+
+```cmake
+option(KIRRA_QNX_TARGET "Cross-compile the judge + harness for a QNX target" OFF)
+set(KIRRA_RUSTC_TARGET "<TARGET_TRIPLE_TBD>" CACHE STRING "rustc nto-qnx800 tuple")
+
+set(KIRRA_JUDGE_RUSTC_FLAGS --edition 2021 --crate-type staticlib
+    --crate-name kirra_judge -C panic=abort -C opt-level=2 -C debuginfo=0)
+if(KIRRA_QNX_TARGET)
+  list(APPEND KIRRA_JUDGE_RUSTC_FLAGS --target ${KIRRA_RUSTC_TARGET})
+  # select qcc/q++ via -DCMAKE_TOOLCHAIN_FILE=qnx.cmake, and add wcet_measure.cpp
+  # as an executable linked against ${KIRRA_JUDGE_LINK}.
+endif()
+# ... feed ${KIRRA_JUDGE_RUSTC_FLAGS} into the rustc add_custom_command ...
+```
+
+## 2. SCHED_FIFO measurement wrapper
+
+Drop-in: **`tools/qnx-rtm-harness/wcet_measure.cpp`** (in this PR). It times the verdict ENTRY `kirra_judge_assess` (`kirra_ffi.h`) and emits the `wcet_status` CSV row. Key properties it encodes:
+
+- **WCET path = the OK / admissible view.** The judge runs `magic → sequence → deadline → integrity → kinematic` in order and returns early on the first failure — so the longest path is the all-pass case. A failing case would time a short-circuit, not the WCET. The wrapper asserts the view returns `KIRRA_VERDICT_OK` before measuring.
+- **`SCHED_FIFO`, max priority, pinned isolated core.** POSIX `pthread_setschedparam(SCHED_FIFO, max)` + affinity (works on a Linux eval VM with `isolcpus=<cpu>`). On QNX, also set the runmask via `ThreadCtl(_NTO_TCTL_RUNMASK_GET_AND_SET_INHERIT, ...)`. SCHED_FIFO needs privilege; the wrapper warns and downgrades to INDICATIVE if not granted.
+- **Cache / branch-predictor warm-up** (10 000 discarded iterations) before the measured 1 000 000.
+- **Capture `max` + `p99.9`** (sorted-tail percentile) + `min` / `median` for context.
+- **Monotonic high-res clock** (`clock_gettime(CLOCK_MONOTONIC)`); the constant clock self-overhead sits inside each sample, making the reported MAX a **conservative** (slightly over) bound — safe for a WCET. On QNX prefer `ClockCycles()` + `SYSPAGE` `cycles_per_sec` and subtract the measured clock overhead.
+
+The wrapper is **not yet wired into CMake** — it is staged for the gated QNX build (§1d).
+
+## 3. Output — the CSV row + FTTI linkage
+
+```
+metric,target,sched,n,warmup,max_ns,p999_ns,wcet_status
+kirra_judge_assess,<TARGET_TRIPLE_TBD>,SCHED_FIFO,1000000,10000,<max>,<p999>,QNX-TARGET-MEASURED
+```
+
+- Replaces the harness placeholder `wcet_status = TBD-QNX-TARGET`.
+- The **structural boundedness argument** (`src/wcet_gate.rs` — a finite WCET exists by construction; **target 100 µs**, host CI threshold 1000 µs) supplies *that a bound exists*; this measurement supplies *its magnitude on a real QNX / FIFO target*. Together they feed the FTTI: `verdict_WCET + actuation_latency < control_cycle < 0.5 s reaction`.
+- **Phase I** number = feasibility (eval / VM). **Phase II** = cert-grade on DRIVE + QNX OS for Safety + Ferrocene-qualified Rust.
+
+## Done vs. remaining
+
+| | State |
+|---|---|
+| no_std judge (C-ABI `kirra_judge_assess`) | done (`kirra_judge.rs`) |
+| host-indicative WCET + CI regression gate | done (`src/wcet_gate.rs`) |
+| FDIT/RTM matrix traced to kernel RTM | done (#272, `QNX_MAPPING.md`) |
+| cross-compile recipe + measurement wrapper | **done (this PR — drafted, not run)** |
+| run on a QNX target, capture the row, update CSV + methodology | **remaining (#274 — needs a QNX target)** |

--- a/tools/qnx-rtm-harness/wcet_measure.cpp
+++ b/tools/qnx-rtm-harness/wcet_measure.cpp
@@ -1,0 +1,136 @@
+// tools/qnx-rtm-harness/wcet_measure.cpp
+//
+// Objective 1 (#274) — per-verdict WCET measurement of the no_std judge
+// `kirra_judge_assess` on a QNX SDP 8.0 target under SCHED_FIFO.
+//
+// DRAFT — a defined build, not yet run. Not wired into CMakeLists (it is gated
+// behind the QNX cross-build; see docs/safety/WCET_QNX_BRINGUP.md). Compiles on a
+// host for a smoke run, but a host/Linux number is INDICATIVE only — ONLY a
+// QNX-target-under-FIFO number is a WCET claim.
+//
+// BOUNDARIES (see WCET_QNX_BRINGUP.md):
+//   * A Jetson cannot run QNX (L4T/Linux, doer-side). The QNX target is separate.
+//   * Phase I = QNX SDP 8.0 on an aarch64 eval board (preferred) / x86_64 VM
+//     (fallback) — feasibility, not cert-grade. Phase II = NVIDIA DRIVE + QNX OS
+//     for Safety + Ferrocene-qualified Rust — the certified number.
+//
+// WCET PATH: the OK/admissible view. The judge runs magic → sequence → deadline
+// → integrity → kinematic IN ORDER and returns early on the first failure, so the
+// LONGEST path is the all-pass (admissible) case. Timing a failing case would
+// time a short-circuit, not the WCET.
+
+#include "kirra_ffi.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include <ctime>
+#include <pthread.h>
+#include <sched.h>
+
+namespace {
+
+constexpr std::size_t WARMUP_ITERS  = 10'000;
+constexpr std::size_t MEASURE_ITERS = 1'000'000;
+
+// Build the OK/admissible view — the WCET path (no early short-circuit).
+KirraContractView make_admissible_view(const std::uint8_t *payload, std::uint32_t len) {
+    KirraContractView v{};
+    v.payload                = payload;
+    v.magic                  = KIRRA_CONTRACT_MAGIC;
+    v.sequence               = 2;            // > last_accepted → not a regress/replay
+    v.last_accepted_sequence = 1;
+    v.now_monotonic_ns       = 1'000;        // now < deadline → not missed
+    v.deadline_monotonic_ns  = 1'000'000;
+    v.payload_len            = len;
+    v.commanded_velocity     = 0;            // within the PROXY envelope → no kinematic limit
+    v.integrity_ok           = 1;
+    v.header_torn            = 0;
+    return v;
+}
+
+// Monotonic nanoseconds. clock_gettime self-overhead (~tens of ns) is inside each
+// sample and is roughly constant, so the reported MAX is a CONSERVATIVE (slightly
+// over) WCET — safe for a bound. On QNX prefer ClockCycles() + SYSPAGE
+// cycles_per_sec for finer resolution, and subtract the measured clock overhead.
+std::uint64_t now_ns() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<std::uint64_t>(ts.tv_sec) * 1'000'000'000ull
+         + static_cast<std::uint64_t>(ts.tv_nsec);
+}
+
+// Raise to SCHED_FIFO max priority and pin to one isolated core.
+//   * POSIX form (works on a Linux eval VM; isolate the core with isolcpus=<cpu>).
+//   * On QNX, ALSO set the runmask via
+//       ThreadCtl(_NTO_TCTL_RUNMASK_GET_AND_SET_INHERIT, &mask)
+//     and SchedSet() the FIFO priority. SCHED_FIFO requires privilege.
+void enter_rt(int cpu) {
+    struct sched_param sp{};
+    sp.sched_priority = sched_get_priority_max(SCHED_FIFO);
+    if (pthread_setschedparam(pthread_self(), SCHED_FIFO, &sp) != 0) {
+        std::fprintf(stderr,
+            "WARN: SCHED_FIFO not granted (need privilege) — timing is INDICATIVE only\n");
+    }
+#if defined(__linux__)
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    CPU_SET(cpu, &set);
+    pthread_setaffinity_np(pthread_self(), sizeof(set), &set);
+#else
+    (void)cpu;  // QNX: pin via ThreadCtl(_NTO_TCTL_RUNMASK_GET_AND_SET_INHERIT, ...)
+#endif
+}
+
+} // namespace
+
+int main() {
+    enter_rt(/*cpu=*/1);
+
+    static const std::uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+    KirraContractView v = make_admissible_view(payload, sizeof(payload));
+
+    // Guard: the WCET path MUST return OK, else we are timing a short-circuit.
+    if (kirra_judge_assess(&v) != KIRRA_VERDICT_OK) {
+        std::fprintf(stderr, "FATAL: admissible view did not return OK — wrong WCET path\n");
+        return 2;
+    }
+
+    // Warm caches / branch predictors. `volatile` sink defeats DCE; the extern
+    // "C" call into the separately-linked staticlib cannot be inlined or elided.
+    volatile std::uint8_t sink = 0;
+    for (std::size_t i = 0; i < WARMUP_ITERS; ++i)
+        sink = static_cast<std::uint8_t>(sink ^ kirra_judge_assess(&v));
+
+    std::vector<std::uint64_t> samples;
+    samples.reserve(MEASURE_ITERS);
+    for (std::size_t i = 0; i < MEASURE_ITERS; ++i) {
+        const std::uint64_t t0 = now_ns();
+        sink = static_cast<std::uint8_t>(sink ^ kirra_judge_assess(&v));
+        const std::uint64_t t1 = now_ns();
+        samples.push_back(t1 - t0);
+    }
+    (void)sink;
+
+    std::sort(samples.begin(), samples.end());
+    const std::uint64_t mn   = samples.front();
+    const std::uint64_t med  = samples[samples.size() / 2];
+    const std::uint64_t p999 = samples[(samples.size() * 999) / 1000];
+    const std::uint64_t mx   = samples.back();
+
+    std::printf("WCET kirra_judge_assess  n=%zu  min=%lluns  med=%lluns  p99.9=%lluns  MAX=%lluns\n",
+                MEASURE_ITERS,
+                (unsigned long long)mn, (unsigned long long)med,
+                (unsigned long long)p999, (unsigned long long)mx);
+
+    // CSV row — replaces the harness placeholder `wcet_status = TBD-QNX-TARGET`.
+    // Substitute <TARGET_TRIPLE_TBD> with the confirmed nto-qnx800 tuple.
+    std::printf("metric,target,sched,n,warmup,max_ns,p999_ns,wcet_status\n");
+    std::printf("kirra_judge_assess,<TARGET_TRIPLE_TBD>,SCHED_FIFO,%zu,%zu,%llu,%llu,QNX-TARGET-MEASURED\n",
+                MEASURE_ITERS, WARMUP_ITERS,
+                (unsigned long long)mx, (unsigned long long)p999);
+    return 0;
+}


### PR DESCRIPTION
## Objective 1 (#274) — QNX WCET bring-up, **drafted not run** (no QNX hardware needed for this)

Cross-compile recipe + `SCHED_FIFO` measurement wrapper for the verdict-path WCET, so #274 is a **defined build, not research**.

### The de-risk
The WCET target is the **`#[no_std]`, zero-alloc, `core`-only** judge (`kirra_judge.rs` → `libkirra_judge.a`, C-ABI `kirra_judge_assess`). It uses **no `std` / `libc` / `socket2` / `tokio`, so it sidesteps the #189 (nto80 libc) and #66/#67 blockers** — those gate the *full async verifier*, not the verdict core.

### What's in this PR
- **`tools/qnx-rtm-harness/wcet_measure.cpp`** — times `kirra_judge_assess` on the **OK/admissible view** (the WCET path — every check runs; failures short-circuit earlier), under `SCHED_FIFO` max priority on a pinned isolated core, cache-warmed, capturing `max` + `p99.9` → the `wcet_status` CSV row. Syntax-checked against the real `kirra_ffi.h`. *Not* wired into CMake (gated behind the QNX cross-build).
- **`docs/safety/WCET_QNX_BRINGUP.md`** — the rustc `nto-qnx800` recipe for the no_std judge + `qcc` for the harness + the gated CMake hook, the `SCHED_FIFO` protocol, and the FTTI linkage (structural bound from `wcet_gate.rs` × measured magnitude).

### Hard boundaries encoded in the writeup
- **A Jetson cannot run QNX** (L4T/Linux, doer-side) — the measurement is on a separate QNX target (AOU-HW-QNX-TARGET-001).
- **Two targets / phases:** Phase I = QNX SDP 8.0 on an aarch64 eval board / x86_64 VM (feasibility); Phase II = NVIDIA DRIVE + QNX OS for Safety + Ferrocene-qualified Rust (cert-grade).
- This is **checker-side Objective 1** — distinct from the Parko/§2 and Mick/Taj/Linux lanes.

`<TARGET_TRIPLE_TBD>` left as a placeholder pending the DRIVE-access decision — not hard-pinned.

Refs #274, #270, #272, AOU-HW-QNX-TARGET-001, ADR-0001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_