### PR TITLE
test(posture-gate): pin Degraded actuator-write 503 on the real router (ADR-0011)

### DIFF
--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -3983,6 +3983,35 @@ mod posture_gate_real_router_tests {
         );
     }
 
+    /// ADR-0011 reachability pin: under **Degraded** the OUTER posture gate
+    /// 503s the actuator WRITE before the inner `enforce_actuator_safety_envelope`
+    /// decel-to-stop branch can run — `should_route_command` admits only
+    /// `ReadTelemetry` in Degraded, and a POST to `/actuator/motion/command`
+    /// classifies as `WriteState`. So on the HTTP `/actuator/motion/command`
+    /// path that decel-to-stop branch is dead code; the real Degraded safety
+    /// floor is the consumer-side `503 → 0.0` safe-stop (#405), not the inner
+    /// envelope. This test pins the gate behavior: Degraded WriteState is denied
+    /// 503 on the real assembled router, identically to LockedOut — the exact
+    /// 503 the #405 client now maps to an explicit safe-stop. Do NOT cite the
+    /// gateway HTTP path as a live decel-to-stop enforcement point while this
+    /// holds (ADR-0011).
+    #[tokio::test]
+    async fn degraded_blocks_actuator_write_on_real_router() {
+        let status = status_through_real_app(
+            state_with(FleetPosture::Degraded),
+            "POST",
+            "/actuator/motion/command",
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "the real router must deny POST /actuator/motion/command under Degraded \
+             (outer posture gate 503s WriteState before the inner envelope runs, \
+             ADR-0011); got {status}"
+        );
+    }
+
     /// Exemption wiring on the real assembly: `/health` stays reachable under
     /// LockedOut (liveness is allowlisted by `is_posture_exempt`).
     #[tokio::test]


### PR DESCRIPTION
## Pin the Degraded actuator-write 503 on the real assembled router (ADR-0011)

The binary-internal `posture_gate_real_router_tests` module already proved the **real `build_app()` router** 503s an actuator WRITE under **LockedOut**, but had **no Degraded case**. That gap is exactly the ADR-0011 *reachability caveat* — and it deserved an enforced pin, not just prose.

### What this adds
`degraded_blocks_actuator_write_on_real_router`: drives `POST /actuator/motion/command` through the real assembled router under **Degraded** and asserts **503**.

This locks in the ADR-0011 claim mechanically:
- Under Degraded, the **outer** `enforce_posture_routing` gate denies the write **before** the inner `enforce_actuator_safety_envelope` decel-to-stop branch can run (`should_route_command` admits only `ReadTelemetry` in Degraded; the POST classifies as `WriteState`).
- ⇒ the gateway HTTP path's decel-to-stop branch is **dead code**, and the real Degraded safety floor is the **consumer-side `503 → 0.0` safe-stop (#405)** — the exact 503 the carla client now maps to an explicit safe-stop.

### Verification
- `cargo test --bin kirra_verifier_service posture_gate_real_router_tests` — **5/5 green** (4 existing + this new one).
- Test-only change; no production code touched.

Refs #405, ADR-0011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_