### PR TITLE
feat(posture-gate): Option A — defer Degraded actuator command to inner decel gate (ADR-0011)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,11 @@ PROMOTION_TIMEOUT_MS         = 10_000     // standby promotes if primary silent 
 - `Unknown` → `false` immediately (before posture check)
 - Stale cache (TTL exceeded) → `false`
 - `LockedOut` → blocks everything
-- `Degraded` → allows `ReadTelemetry` only
+- `Degraded` → allows `ReadTelemetry` AND `ActuatorMotion` only (Option A / ADR-0011):
+  `ActuatorMotion` is the one write classification (`POST /actuator/motion/command`,
+  exact match) mounted behind the inner `enforce_actuator_safety_envelope` decel gate,
+  so the outer gate defers its Degraded verdict to that gate instead of 503-ing it.
+  Every other `WriteState` / `SystemMutation` is still denied in Degraded.
 - `Nominal` → allows all except `Unknown`
 
 **Degraded = Controlled Decel-to-Stop-and-HOLD** (`enforce_degraded_decel_to_stop`, issue #70):
@@ -241,13 +245,16 @@ PROMOTION_TIMEOUT_MS         = 10_000     // standby promotes if primary silent 
   fabric `AssetGovernor::evaluate_command`, ros2-adapter `validate_trajectory_slow`,
   parko-kirra `KirraGovernor::apply_mrc_profile` (the last also gates an independent
   angular-velocity channel via `STOP_EPSILON_RAD_S` for differential drive). **REACHABILITY
-  CAVEAT (#405 / ADR-0011):** the three *direct* callers (fabric / parko-kirra / ros2-adapter)
-  invoke the gate directly and ARE reachable. The gateway `enforce_actuator_safety_envelope`
-  branch is currently **UNREACHABLE on the HTTP `/actuator/motion/command` path** — the outer
-  `enforce_posture_routing` gate 503s Degraded `WriteState` before the inner envelope runs, so
-  the decel-to-stop branch is dead code there. Resolution recorded in ADR-0011 (the `503 → 0.0`
-  consumer fix is the safety floor; relaxing the outer gate is a follow-on design choice). Do
-  not cite the gateway HTTP path as a live decel-to-stop enforcement point until that lands.
+  (#405 / ADR-0011, Option A adopted):** all four enforcement points are now live. The three
+  *direct* callers (fabric / parko-kirra / ros2-adapter) invoke the gate directly; the gateway
+  `enforce_actuator_safety_envelope` branch is now **reachable on the HTTP
+  `/actuator/motion/command` path** because the outer `enforce_posture_routing` gate classifies
+  that exact route as `OperationalCommand::ActuatorMotion` and `should_route_command` admits it
+  under Degraded (deferring the verdict to the inner decel gate) — every OTHER `WriteState`
+  stays 503 under Degraded. The `503 → 0.0` consumer safe-stop (#405) remains the defense-in-depth
+  safety floor for the LockedOut/stale 503s and any non-gated write. Auth note: on the assembled
+  router the actuator route is still admin-gated, so the auth-free Degraded-deferral proof lives
+  in `tests/posture_gate_integration.rs` (INV-13 forbids `set_var` in the binary-internal test).
 - The Nominal WCET-critical `validate_vehicle_command` path is UNCHANGED.
 - "MRC" disambiguation: Degraded MRC = decel-to-stop *envelope* (bounds a converging
   command); LockedOut MRC fallback = safe-stop *maneuver* (all commands denied).

--- a/docs/adr/0011-degraded-http-actuator-503-vs-decel-gate.md
+++ b/docs/adr/0011-degraded-http-actuator-503-vs-decel-gate.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 |---|---|
-| Status | **Proposed resolution (2026-06-21)** — owner direction set; ratified on merge. Supersedes the prior "Open / deferred" status (see Decision). |
-| Date | 2026-06-20 (finding) · 2026-06-21 (resolution) |
+| Status | **Accepted (2026-06-22)** — owner direction ratified; **Option A adopted** and implemented (see Update). Supersedes the prior "Proposed resolution / Open / deferred" status. |
+| Date | 2026-06-20 (finding) · 2026-06-21 (resolution) · 2026-06-22 (Option A adopted) |
 | Deciders | Project / safety-case owner |
 | Issues | #405 (this), #406 (sequenced behind — MRC divergence, ADR-0012), #70 (Degraded decel-to-stop-and-HOLD design) |
 | Code | `src/bin/kirra_verifier_service.rs` (router assembly), `src/gateway/policy_layer.rs`, `src/posture_cache.rs` (`should_route_command`), `src/bin/kirra_carla_client.rs` (the actuator consumer) |
@@ -127,3 +127,39 @@ the CLAUDE.md "wired at all four points" correction.
 
 **Implementation** (the consumer `503 → 0.0` fix + the test) lands from a laptop (large
 governor sources; web `git push` unavailable). This ADR records the decision, which does not.
+
+## Update (2026-06-22) — Option A adopted and implemented
+
+With the `503 → 0.0` safety floor (#405) already merged, the owner adopted **Option A**: the
+HTTP `/actuator/motion/command` path is relaxed under Degraded so it reaches the inner
+`enforce_degraded_decel_to_stop` gate, upgrading the flat-zero stop to a *converging-decel*
+command. Scope is deliberately minimal and fail-closed by construction:
+
+1. **New classification `OperationalCommand::ActuatorMotion`** (`src/gateway/policy.rs`),
+   returned for the **exact** path `/actuator/motion/command` — the *only* route mounted
+   behind the inner envelope in `build_app`. A non-exact `/actuator/*` sibling falls through to
+   `WriteState` and stays fail-closed, so the relaxation cannot leak to a route with no inner
+   kinematic gate.
+2. **`should_route_command` Degraded arm** (`src/posture_cache.rs`) now admits
+   `ReadTelemetry | ActuatorMotion`. Every other `WriteState` / `SystemMutation` is still 503
+   under Degraded; `LockedOut` still denies **all** commands (deny-all preserved at the outer
+   gate, with the inner envelope's 403 as defense-in-depth); `Unknown` and stale/cold-cache
+   fail-closed paths are unchanged. `ActuatorMotion` is still treated as a state mutation by the
+   HA epoch fence in `enforce_posture_routing`.
+3. **Envelope unchanged.** The Degraded path uses `mrc_fallback_profile()` (**5.0 m/s**, the
+   load-bearing SS-002 number). The fabric command path (`/fabric/command/{asset_id}`) is **not**
+   relaxed — it stays `WriteState` → 503 under Degraded — so the **#406 MRC divergence
+   (ADR-0012) remains dormant** and is not made live by this change.
+4. **Tests:** the authoritative auth-free deferral proof is
+   `tests/posture_gate_integration.rs::test_degraded_defers_actuator_motion_but_blocks_other_writes`
+   (actuator → 200 through the outer gate, generic write → 503); unit coverage in
+   `policy.rs` (classification, exact-match scoping) and `posture_cache.rs` (Degraded admits
+   ActuatorMotion; LockedOut/stale/cold still deny it); the binary-internal real-router test
+   `degraded_actuator_write_reaches_inner_envelope_on_real_router` proves it on the assembled
+   `build_app` when a token is configured (the actuator route is admin-gated, and INV-13 forbids
+   `set_var` in that multithreaded test). The CLAUDE.md "Degraded = ReadTelemetry only" line and
+   the four-enforcement-points reachability caveat are corrected.
+
+The `503 → 0.0` consumer safe-stop (#405) remains in place as defense-in-depth for the
+LockedOut/stale 503s and any non-gated write; the integrator DBW command-freshness watchdog
+remains an Assumption of Use (defense-in-depth, not the floor).

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -3983,32 +3983,81 @@ mod posture_gate_real_router_tests {
         );
     }
 
-    /// ADR-0011 reachability pin: under **Degraded** the OUTER posture gate
-    /// 503s the actuator WRITE before the inner `enforce_actuator_safety_envelope`
-    /// decel-to-stop branch can run — `should_route_command` admits only
-    /// `ReadTelemetry` in Degraded, and a POST to `/actuator/motion/command`
-    /// classifies as `WriteState`. So on the HTTP `/actuator/motion/command`
-    /// path that decel-to-stop branch is dead code; the real Degraded safety
-    /// floor is the consumer-side `503 → 0.0` safe-stop (#405), not the inner
-    /// envelope. This test pins the gate behavior: Degraded WriteState is denied
-    /// 503 on the real assembled router, identically to LockedOut — the exact
-    /// 503 the #405 client now maps to an explicit safe-stop. Do NOT cite the
-    /// gateway HTTP path as a live decel-to-stop enforcement point while this
-    /// holds (ADR-0011).
+    /// Option A / ADR-0011 on the REAL assembled router: under **Degraded** the
+    /// outer posture gate now DEFERS the actuator-motion command to the inner
+    /// `enforce_actuator_safety_envelope` (decel-to-stop) instead of 503-ing it
+    /// (`should_route_command` Degraded admits `ReadTelemetry` + `ActuatorMotion`).
+    ///
+    /// On the real assembly the layer after the posture gate is
+    /// `require_admin_token`, which 503s when `KIRRA_ADMIN_TOKEN` is unset — and
+    /// INV-13 forbids `set_var` in this multithreaded test — so a token-less
+    /// Degraded POST is 503 at the ADMIN layer, masking the deferral by status.
+    /// The authoritative auth-free proof therefore lives in
+    /// `tests/posture_gate_integration.rs::test_degraded_defers_actuator_motion_but_blocks_other_writes`.
+    /// Here we prove it on the REAL assembly WHEN a token is configured: an
+    /// authenticated Degraded POST reaches the inner envelope (its verdict is a
+    /// 200/clamp or 400, never the posture/admin 503 nor 401), while the
+    /// authenticated LockedOut control still 503s at the posture gate, before the
+    /// envelope. With no token the test degrades to the robust LockedOut control.
     #[tokio::test]
-    async fn degraded_blocks_actuator_write_on_real_router() {
-        let status = status_through_real_app(
+    async fn degraded_actuator_write_reaches_inner_envelope_on_real_router() {
+        use axum::http::header;
+
+        async fn post_actuator(
+            svc: Arc<ServiceState>,
+            bearer: Option<&str>,
+            body: &str,
+        ) -> StatusCode {
+            let mut rb = Request::builder()
+                .method("POST")
+                .uri("/actuator/motion/command")
+                .header("content-type", "application/json");
+            if let Some(tok) = bearer {
+                rb = rb.header(header::AUTHORIZATION, format!("Bearer {tok}"));
+            }
+            build_app(svc)
+                .oneshot(rb.body(Body::from(body.to_string())).expect("build request"))
+                .await
+                .expect("router service should not panic")
+                .status()
+        }
+
+        let token = std::env::var("KIRRA_ADMIN_TOKEN").unwrap_or_default();
+        if token.is_empty() {
+            // No token: the actuator route is admin-gated, so a Degraded POST is
+            // 503 at the admin layer (indistinguishable by status from a posture
+            // denial). Assert only the robust LockedOut control here; the Option A
+            // deferral is proven auth-free in the integration test referenced above.
+            let locked = post_actuator(state_with(FleetPosture::LockedOut), None, "{}").await;
+            assert_eq!(
+                locked,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "LockedOut must 503 at the posture gate on the real router; got {locked}"
+            );
+            return;
+        }
+
+        // Authenticated. A valid decel command (4.0 -> 3.0 m/s, within MRC 5.0)
+        // reaches the inner envelope under Degraded and is admitted there — the
+        // status is the ENVELOPE verdict, never the posture/admin 503 or 401.
+        let degraded = post_actuator(
             state_with(FleetPosture::Degraded),
-            "POST",
-            "/actuator/motion/command",
+            Some(&token),
+            r#"{"linear_velocity_mps":3.0,"current_velocity_mps":4.0,"delta_time_s":0.1,"steering_angle_deg":0.0,"current_steering_angle_deg":0.0}"#,
         )
         .await;
+        assert!(
+            degraded != StatusCode::SERVICE_UNAVAILABLE && degraded != StatusCode::UNAUTHORIZED,
+            "Degraded actuator command must reach the inner envelope on the real router \
+             (Option A) — not a posture/admin 503 or 401; got {degraded}"
+        );
+
+        // LockedOut control: still denied at the posture gate, before the envelope.
+        let locked = post_actuator(state_with(FleetPosture::LockedOut), Some(&token), "{}").await;
         assert_eq!(
-            status,
+            locked,
             StatusCode::SERVICE_UNAVAILABLE,
-            "the real router must deny POST /actuator/motion/command under Degraded \
-             (outer posture gate 503s WriteState before the inner envelope runs, \
-             ADR-0011); got {status}"
+            "LockedOut must still 503 at the posture gate even authenticated; got {locked}"
         );
     }
 

--- a/src/gateway/policy.rs
+++ b/src/gateway/policy.rs
@@ -6,6 +6,15 @@ pub enum OperationalCommand {
     ReadTelemetry,
     /// Actuator writes and velocity commands. Denied when LockedOut.
     WriteState,
+    /// Actuator motion command on the ONE route gated by an inner kinematic
+    /// safety envelope (`/actuator/motion/command`). Allowed under Nominal AND
+    /// Degraded — under Degraded the inner `enforce_degraded_decel_to_stop` gate
+    /// (decel-to-stop-and-HOLD over the MRC 5.0 m/s envelope) authors the safe
+    /// verdict, so the OUTER posture gate defers to it instead of returning a
+    /// blanket 503 (Option A / ADR-0011). Denied under LockedOut and on a
+    /// stale/cold cache (fail-closed), exactly like any other state write — and
+    /// it is still treated as a state mutation by the HA epoch fence.
+    ActuatorMotion,
     /// Firmware, reboot, config mutations. Denied unless Nominal.
     SystemMutation,
     /// Unrecognised HTTP method. Denied in ALL postures (fail-closed).
@@ -42,7 +51,18 @@ pub fn classify_http_command(method: &str, path: &str) -> OperationalCommand {
         "DELETE" => OperationalCommand::SystemMutation,
 
         "POST" | "PUT" => {
-            if is_write_state_path(path) {
+            if path == "/actuator/motion/command" {
+                // The ONLY actuator route mounted with the inner
+                // `enforce_actuator_safety_envelope` decel-to-stop gate (see
+                // `build_app`). Classed distinctly so the outer posture gate can
+                // DEFER the Degraded verdict to that inner kinematic gate
+                // (Option A / ADR-0011) instead of a blanket 503 — while every
+                // other WriteState path stays fail-closed under Degraded. Exact
+                // match (not a `/actuator` prefix) so a future actuator route
+                // without an inner gate cannot inherit the relaxation: it falls
+                // to the `is_write_state_path` arm and stays fail-closed.
+                OperationalCommand::ActuatorMotion
+            } else if is_write_state_path(path) {
                 OperationalCommand::WriteState
             } else if is_system_mutation_path(path) {
                 OperationalCommand::SystemMutation
@@ -129,6 +149,37 @@ mod tests {
     fn test_classifies_actuator_as_write_state() {
         assert_eq!(classify_http_command("POST", "/actuator/servo"), OperationalCommand::WriteState);
         assert_eq!(classify_http_command("PUT",  "/actuator/valve"), OperationalCommand::WriteState);
+    }
+
+    /// Option A / ADR-0011: the ONE actuator route mounted behind the inner
+    /// `enforce_actuator_safety_envelope` decel gate classifies as the distinct
+    /// `ActuatorMotion`, so the outer posture gate defers its Degraded verdict to
+    /// that inner gate instead of a blanket 503. Match is EXACT — a sibling
+    /// `/actuator/*` path without an inner gate must stay `WriteState`
+    /// (fail-closed under Degraded), so the relaxation cannot leak to a route
+    /// that has no kinematic envelope behind it.
+    #[test]
+    fn test_actuator_motion_command_classifies_as_actuator_motion() {
+        assert_eq!(
+            classify_http_command("POST", "/actuator/motion/command"),
+            OperationalCommand::ActuatorMotion,
+            "the inner-gated actuator route must classify as ActuatorMotion (Option A)"
+        );
+        // Query string must not defeat the exact match.
+        assert_eq!(
+            classify_http_command("POST", "/actuator/motion/command?dry_run=1"),
+            OperationalCommand::ActuatorMotion
+        );
+        // Sibling actuator paths (NO inner gate mounted) stay fail-closed WriteState.
+        assert_eq!(
+            classify_http_command("POST", "/actuator/motion/command/extra"),
+            OperationalCommand::WriteState,
+            "a non-exact actuator sub-path must NOT inherit the ActuatorMotion relaxation"
+        );
+        assert_eq!(
+            classify_http_command("POST", "/actuator/servo"),
+            OperationalCommand::WriteState
+        );
     }
 
     #[test]
@@ -235,8 +286,10 @@ mod tests {
     #[test]
     fn test_known_write_paths_preserved() {
         // Control-plane / actuator WriteState endpoints.
+        // NOTE: `/actuator/motion/command` is intentionally absent here — it
+        // classifies as `ActuatorMotion` (Option A / ADR-0011), asserted
+        // separately in `test_actuator_motion_command_classifies_as_actuator_motion`.
         for p in [
-            "/actuator/motion/command",
             "/cmd_vel",
             "/action_filter/evaluate",
             "/attestation/register",

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -488,7 +488,12 @@ pub async fn enforce_posture_routing(
     // re-check is the authoritative one.
     let is_mutation = matches!(
         cmd,
-        OperationalCommand::WriteState | OperationalCommand::SystemMutation
+        OperationalCommand::WriteState
+            | OperationalCommand::SystemMutation
+            // ActuatorMotion is a physical state write — it MUST still be fenced
+            // by the HA epoch guard even though the posture gate defers its
+            // Degraded verdict to the inner kinematic envelope (Option A).
+            | OperationalCommand::ActuatorMotion
     );
     if is_mutation {
         let held = svc.app.held_epoch.load(std::sync::atomic::Ordering::SeqCst);

--- a/src/posture_cache.rs
+++ b/src/posture_cache.rs
@@ -202,7 +202,8 @@ pub fn now_ms() -> u64 {
 ///   - OperationalCommand::Unknown → false BEFORE posture check (invariant #9)
 ///   - Stale cache → false (fail-closed, uses entry.is_stale() from CachedFleetPosture)
 ///   - LockedOut → false for all commands
-///   - Degraded → true for ReadTelemetry only
+///   - Degraded → true for ReadTelemetry and the inner-gated ActuatorMotion
+///                command only (Option A / ADR-0011); every other write denied
 ///   - Nominal → true for all except Unknown
 ///
 /// The `now_ms` parameter accepts an injected clock value. In tests, pass
@@ -244,7 +245,19 @@ pub fn should_route_command(
 
     match entry.posture {
         FleetPosture::Nominal   => true,
-        FleetPosture::Degraded  => command == OperationalCommand::ReadTelemetry,
+        // Degraded admits safe reads AND the inner-gated actuator-motion command
+        // (Option A / ADR-0011): `ActuatorMotion` is the ONE write path mounted
+        // behind `enforce_actuator_safety_envelope`, whose Degraded branch runs
+        // `enforce_degraded_decel_to_stop` (decel-to-stop-and-HOLD, MRC 5.0 m/s).
+        // The outer gate defers that command to the inner kinematic gate rather
+        // than 503-ing it, so a Degraded vehicle bleeds speed to a controlled
+        // stop instead of holding its pre-Degraded speed. Every OTHER WriteState
+        // / SystemMutation stays denied here. LockedOut still denies even
+        // ActuatorMotion below (deny-all preserved at both gates).
+        FleetPosture::Degraded  => matches!(
+            command,
+            OperationalCommand::ReadTelemetry | OperationalCommand::ActuatorMotion
+        ),
         FleetPosture::LockedOut => false,
     }
 }
@@ -371,16 +384,48 @@ mod posture_cache_tests {
     }
 
     #[test]
-    fn test_degraded_posture_allows_only_read_telemetry() {
+    fn test_degraded_posture_allows_read_and_actuator_motion_only() {
+        // Option A / ADR-0011: Degraded admits ReadTelemetry AND the inner-gated
+        // ActuatorMotion (deferred to `enforce_degraded_decel_to_stop`), but
+        // still denies every other write (WriteState / SystemMutation) and the
+        // fail-closed Unknown.
         let cache = fresh_cache(FleetPosture::Degraded);
         let ts = now_ms();
-        assert!(should_route_command(&cache, ts, OperationalCommand::ReadTelemetry));
+        assert!(should_route_command(&cache, ts, OperationalCommand::ReadTelemetry),
+            "Degraded must allow ReadTelemetry");
+        assert!(should_route_command(&cache, ts, OperationalCommand::ActuatorMotion),
+            "Degraded must defer ActuatorMotion to the inner kinematic gate (Option A)");
+        assert!(!should_route_command(&cache, ts, OperationalCommand::WriteState),
+            "Degraded must still deny generic WriteState (no inner gate)");
+        assert!(!should_route_command(&cache, ts, OperationalCommand::SystemMutation),
+            "Degraded must still deny SystemMutation");
+        assert!(!should_route_command(&cache, ts, OperationalCommand::Unknown),
+            "Degraded must deny Unknown (fail-closed)");
     }
 
     #[test]
     fn test_lockedout_posture_denies_all_commands() {
+        // Deny-all is preserved at the OUTER gate even for ActuatorMotion: under
+        // LockedOut the command never reaches the inner envelope (Option A relaxes
+        // Degraded ONLY, never LockedOut).
         let cache = fresh_cache(FleetPosture::LockedOut);
         let ts = now_ms();
         assert!(!should_route_command(&cache, ts, OperationalCommand::ReadTelemetry));
+        assert!(!should_route_command(&cache, ts, OperationalCommand::ActuatorMotion),
+            "LockedOut must deny ActuatorMotion at the outer gate (deny-all preserved)");
+        assert!(!should_route_command(&cache, ts, OperationalCommand::WriteState));
+    }
+
+    #[test]
+    fn test_actuator_motion_fails_closed_on_stale_and_cold_cache() {
+        // The Degraded relaxation must NOT weaken the stale/cold fail-closed
+        // rule: ActuatorMotion is denied with no fresh posture, exactly like any
+        // other command.
+        let ts = now_ms();
+        assert!(!should_route_command(&None, ts, OperationalCommand::ActuatorMotion),
+            "cold cache (None) must deny ActuatorMotion — fail-closed");
+        let stale = stale_cache(FleetPosture::Degraded);
+        assert!(!should_route_command(&stale, ts, OperationalCommand::ActuatorMotion),
+            "stale Degraded cache must deny ActuatorMotion — fail-closed");
     }
 }

--- a/tests/posture_gate_integration.rs
+++ b/tests/posture_gate_integration.rs
@@ -90,10 +90,17 @@ fn build_test_app(svc: Arc<ServiceState>) -> Router {
     let actuator_routes = Router::new()
         .route("/actuator/motion/command", post(ok_handler));
 
+    // A generic state-write route (classifies as WriteState, has NO inner
+    // kinematic gate) — used to prove Option A relaxes ONLY the inner-gated
+    // actuator route under Degraded, while every other write stays 503.
+    let generic_write_routes = Router::new()
+        .route("/fleet/dependencies", post(ok_handler));
+
     Router::new()
         .merge(probe_routes)
         .merge(read_routes)
         .merge(actuator_routes)
+        .merge(generic_write_routes)
         .with_state(svc.clone())
         .layer(axum::middleware::from_fn_with_state(
             Arc::clone(&svc),
@@ -179,18 +186,43 @@ async fn test_lockedout_blocks_functional_reads() {
 }
 
 // ---------------------------------------------------------------------------
-// 4. Degraded posture: a WriteState command is denied 503. `should_route_command`
-// only permits `ReadTelemetry` under Degraded.
+// 4. Degraded posture (Option A / ADR-0011): the inner-gated actuator-motion
+// command is DEFERRED past the outer gate to its inner kinematic envelope
+// (here a stub returns 200, proving the gate stepped aside), while EVERY OTHER
+// WriteState — one with no inner gate — is still denied 503. This is the
+// authoritative auth-free proof of the Option A relaxation: the representative
+// router carries only `enforce_posture_routing`, so the actuator 200 vs generic
+// 503 contrast is the posture gate's decision, not masked by auth or the
+// envelope. (`should_route_command` Degraded now admits ReadTelemetry +
+// ActuatorMotion only.)
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_degraded_blocks_writes() {
-    let svc = build_state_with_posture(FleetPosture::Degraded);
-    let status = req_status(build_test_app(svc), "POST", "/actuator/motion/command").await;
+async fn test_degraded_defers_actuator_motion_but_blocks_other_writes() {
+    // The inner-gated actuator route passes the outer gate under Degraded.
+    let actuator = req_status(
+        build_test_app(build_state_with_posture(FleetPosture::Degraded)),
+        "POST",
+        "/actuator/motion/command",
+    )
+    .await;
     assert_eq!(
-        status,
+        actuator,
+        StatusCode::OK,
+        "Degraded must DEFER /actuator/motion/command to the inner gate (Option A); got {actuator}"
+    );
+
+    // A generic write (no inner kinematic gate) is still denied.
+    let generic = req_status(
+        build_test_app(build_state_with_posture(FleetPosture::Degraded)),
+        "POST",
+        "/fleet/dependencies",
+    )
+    .await;
+    assert_eq!(
+        generic,
         StatusCode::SERVICE_UNAVAILABLE,
-        "Degraded must block actuator writes (only ReadTelemetry allowed); got {status}"
+        "Degraded must still block a generic WriteState with no inner gate; got {generic}"
     );
 }
 


### PR DESCRIPTION
## Option A (ADR-0011): defer the Degraded actuator command to the inner decel gate

With the `503 → 0.0` safety floor (#405) already merged, this adopts **ADR-0011 Option A**: on the HTTP `/actuator/motion/command` path, a Degraded-posture command is no longer blanket-503'd by the outer `enforce_posture_routing` gate. It is now **deferred to the inner `enforce_actuator_safety_envelope` decel-to-stop gate**, which authors a *converging-decel* command (MRC 5.0 m/s) instead of a flat stop — restoring issue #70's intent on the HTTP path. The #405 consumer safe-stop stays in place as defense-in-depth for the LockedOut/stale 503s.

### Behavior matrix (new)
| Posture | `/actuator/motion/command` | All other WriteState |
|---|---|---|
| Nominal | inner gate (full envelope) | allowed |
| **Degraded** | **inner gate → decel-to-stop (200 decel / 400 deny)** | **503** |
| LockedOut | outer gate **503** (deny-all preserved) | 503 |
| stale / cold | **503** (fail-closed) | 503 |

### Scope — minimal and fail-closed by construction
- **New `OperationalCommand::ActuatorMotion`** (`policy.rs`), returned for the **exact** path `/actuator/motion/command` — the *only* route mounted behind the inner envelope in `build_app`. A non-exact `/actuator/*` sibling falls through to `WriteState` and stays fail-closed, so the relaxation can't leak to a route with no inner kinematic gate.
- **`should_route_command`** Degraded arm admits `ReadTelemetry | ActuatorMotion` only; every other `WriteState`/`SystemMutation` still 503s under Degraded. **LockedOut still denies all** at the outer gate (deny-all preserved; inner 403 is defense-in-depth). `Unknown` + stale/cold fail-closed unchanged. `ActuatorMotion` is still fenced as a state mutation by the HA epoch guard.
- **Envelope unchanged** — Degraded uses `mrc_fallback_profile()` (**5.0 m/s**, the load-bearing SS-002 number). The fabric command path is **not** relaxed, so **#406 / ADR-0012 (MRC divergence) stays dormant**.

### Tests
- **Authoritative auth-free proof:** `tests/posture_gate_integration.rs::test_degraded_defers_actuator_motion_but_blocks_other_writes` — actuator → 200 through the outer gate, generic write → 503 (representative router carries only `enforce_posture_routing`, no auth/envelope masking).
- Classification + exact-match scoping in `policy.rs`; Degraded-admits / LockedOut-stale-cold-denies `ActuatorMotion` in `posture_cache.rs`.
- Binary-internal real-router test `degraded_actuator_write_reaches_inner_envelope_on_real_router` proves it on the assembled `build_app` when a token is configured (the actuator route is admin-gated, and INV-13 forbids `set_var` in that multithreaded test — hence the auth-free test is authoritative).
- **Full suite: 633 lib + all integration tests green.**

### Docs
- ADR-0011 status → **Accepted**, with an "Option A adopted and implemented" section.
- CLAUDE.md: corrected the "Degraded = ReadTelemetry only" line and the four-enforcement-points reachability caveat (the gateway HTTP path is now a live decel-to-stop enforcement point).

Refs #405, #70, ADR-0011 (ADR-0012/#406 intentionally left dormant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_