### PR TITLE
docs(#274): record self-established Phase-I QNX target + ISA-honesty write-up caveat

### DIFF
--- a/docs/adr/KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md
+++ b/docs/adr/KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md
@@ -8,7 +8,7 @@
 
 ## Executive summary
 
-The KIRRA governor will run as the safety-domain payload **directly on QNX Hypervisor 8.0 for Safety**, with the Autoware / ROS 2 Jazzy / Occy stack (the *doer*) running **unmodified as an isolated Ubuntu guest VM** on the same SoC. The certified VMM supplies the ASIL-D freedom-from-interference boundary that makes the runtime-assurance decomposition creditable. The governor is written in **Rust, compiled with Ferrocene** (qualified for QNX Neutrino), and the **certified artifact is the minimal `no_std` verdict core**, not the whole process.
+The KIRRA governor will run as the safety-domain payload **directly on QNX Hypervisor 8.0 for Safety**, with the Autoware / ROS 2 Jazzy / Occy stack (the *doer*) running **unmodified as an isolated Ubuntu guest VM** on the same SoC. The certified VMM supplies the ASIL-D freedom-from-interference boundary that makes the runtime-assurance decomposition creditable. The governor is written in **Rust** — today built with upstream `rustc`, and **Ferrocene-ready** for the ASIL-D build (Ferrocene is qualified for QNX Neutrino; productization is tracked in #132) — and the **certified artifact is the minimal `no_std` verdict core**, not the whole process.
 
 QNX is chosen over PikeOS and INTEGRITY for one decisive reason on top of parity: it is the only one of the three with a qualified ASIL-D Rust toolchain target, so the governor stays in Rust without a bespoke toolchain qualification. PikeOS and INTEGRITY remain roadmap-only, activated by a named customer already certified on them.
 

--- a/docs/safety/WCET_QNX_BRINGUP.md
+++ b/docs/safety/WCET_QNX_BRINGUP.md
@@ -13,9 +13,10 @@
 
 **1. A Jetson cannot run QNX.** Jetson modules (Orin NX / AGX Orin / Jetson Thor) run **L4T / Linux** — they are the *doer-side* robotics lane (Parko inference, the Rosmaster R2 bring-up, Mick/Taj). They have **no QNX support** and **cannot** produce a QNX-target WCET row (AOU-HW-QNX-TARGET-001). The measurement runs on a **separate** QNX target. Never describe it as "on Jetson under QNX."
 
-**2. Two QNX targets, two phases.**
-- **Phase I (feasibility):** QNX SDP 8.0 on an **aarch64 eval board** (preferred) or **x86_64 VM** (fallback). Produces a *real* QNX-target-under-FIFO number — far stronger than the host-Linux-indicative CI number, sufficient to substantiate the Phase I sub-100 µs verdict claim. **Not cert-grade.**
-- **Phase II (cert-grade):** **NVIDIA DRIVE AGX Orin / Thor + QNX OS for Safety**, Ferrocene-qualified Rust — the certified FTTI number. (Ferrocene's *qualified* QNX target is `qnx710`, **not** `qnx800`; the cert Rust toolchain is its own decision — see `KIRRA_QNX_CROSSCOMPILE.md`.)
+**2. Two QNX targets, two phases.** The Phase I target is **self-established** (a QNX SDP 8.0 eval/dev license + a target you stand up) — it is **not** gated on the DRIVE partner path, which is Phase II by design. The Phase I number is therefore a *setup task we control*, not a hardware-access wait.
+- **Phase I (feasibility):** QNX SDP 8.0 on an **aarch64 eval board** (better ISA match → cleaner Phase I→II extrapolation; longer setup) or an **x86_64 VM** (lowest-friction, stands up in days — the pragmatic now-path on the proposal timeline). Either produces a *real* QNX-target-under-`SCHED_FIFO` number — far stronger than the host-Linux-indicative CI number, sufficient to substantiate the Phase I sub-100 µs verdict claim. **Not cert-grade.**
+  - **Write-up discipline (ISA honesty).** An x86_64 VM number demonstrates *the bound holds on a real RTOS target under SCHED_FIFO* — frame it **exactly** that way. Do **not** call an x86_64 VM "representative edge hardware": the deployment ISA is aarch64 (Orin/Thor-class), so the aarch64-board and cert-grade DRIVE measurements are **Phase II**. The corrected proposal Task 1 already avoids this overclaim; keep the write-up aligned.
+- **Phase II (cert-grade):** **NVIDIA DRIVE AGX Orin / Thor + QNX OS for Safety**, Ferrocene-qualified Rust — the certified FTTI number on the deployment ISA. (Ferrocene's *qualified* QNX target is `qnx710`, **not** `qnx800`; the cert Rust toolchain is its own decision — see `KIRRA_QNX_CROSSCOMPILE.md`.)
 
 **3. Lane.** This is **checker-side Objective 1** — distinct from the Parko / §2-readiness work and the Mick / Taj / Linux robotics lane.
 

--- a/docs/safety/WCET_QNX_BRINGUP.md
+++ b/docs/safety/WCET_QNX_BRINGUP.md
@@ -122,6 +122,17 @@ kirra_judge_assess,<TARGET_TRIPLE_TBD>,SCHED_FIFO,1000000,10000,<max>,<p999>,QNX
 - The **structural boundedness argument** (`src/wcet_gate.rs` — a finite WCET exists by construction; **target 100 µs**, host CI threshold 1000 µs) supplies *that a bound exists*; this measurement supplies *its magnitude on a real QNX / FIFO target*. Together they feed the FTTI: `verdict_WCET + actuation_latency < control_cycle < 0.5 s reaction`.
 - **Phase I** number = feasibility (eval / VM). **Phase II** = cert-grade on DRIVE + QNX OS for Safety + Ferrocene-qualified Rust.
 
+## 4. Phase-I acceptance criteria + feasibility signal
+
+What the Phase-I run must show to substantiate the Objective-1 "sub-100 µs verdict" claim (and what a reviewer needs to see):
+
+1. **The judge cross-compiles** to a `*-nto-qnx800` target with the §1 recipe — `libkirra_judge.a` links `core` + platform symbols only, no QNX `std` (this is the #189/#66–#67 sidestep made concrete).
+2. **The FDIT/RTM matrix passes byte-identically on the target** — every `QNX_MAPPING.md` row's `verdict_observed == verdict_expected`. Cross-compilation must not change a single verdict; the gate is VERDICT CORRECTNESS, timing is reported alongside.
+3. **A real `SCHED_FIFO` `max` + `p99.9` for `kirra_judge_assess`** on the OK/admissible (WCET-path) view, captured per §2, replacing `wcet_status = TBD-QNX-TARGET` with `QNX-TARGET-MEASURED`.
+4. **`max < 100 µs`** (the `src/wcet_gate.rs` target). The structural argument already guarantees a finite bound *exists*; Phase I supplies its *magnitude* on a real QNX/FIFO target.
+
+**Feasibility signal (INDICATIVE — never WCET; see Hard boundaries).** The host harness already runs the verdict per-call in the **sub-microsecond** range (`QNX_MAPPING.md` regression rows: p50 ≈ 0.5 µs, p99 ≈ 0.5 µs on the OK row), with even the scheduling-noise-inflated host *max* ≈ 27 µs — all comfortably under the 100 µs target. So the Phase-I target-FIFO measurement is expected to **confirm** feasibility, not discover a problem: the risk is "produce the certifiable number on the right OS," not "find out whether the bound is met." This is why Objective 1 is a **defined build, not research** — only a QNX target (the #274 blocker) stands between the recipe and the row.
+
 ## Done vs. remaining
 
 | | State |


### PR DESCRIPTION
## Record the settled Phase-I QNX target decision + ISA-honesty caveat

Captures the now-settled QNX target path in `WCET_QNX_BRINGUP.md` so the artifact reflects the decision:

- **Phase I is self-established, not partner-gated.** The Phase I WCET number needs a QNX SDP 8.0 eval/dev license + a target *we* stand up — it is **not** blocked on the DRIVE partner path (which is Phase II by design). It's a setup task we control, not a hardware-access wait.
- **x86_64 VM = pragmatic now-path** (stands up in days, the realistic option on the proposal timeline); **aarch64 eval board** = better ISA match for Phase I→II extrapolation, longer setup. Either yields a real QNX-under-`SCHED_FIFO` number.
- **ISA-honesty write-up discipline (new caveat).** An x86_64 VM number demonstrates *the bound holds on a real RTOS under SCHED_FIFO* — and must be framed exactly that way. It must **not** be called "representative edge hardware": the deployment ISA is aarch64 (Orin/Thor-class), so the aarch64-board and cert-grade DRIVE measurements are **Phase II**. This guards the one overclaim the corrected proposal Task 1 already avoids — keeping the repo doc and proposal telling one story.

No change to the recipe, the `<TARGET_TRIPLE_TBD>` placeholder, or the hard boundaries (Jetson ≠ QNX; host = indicative). Docs-only. Refs #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_