### PR TITLE
feat(occy/taj): geometric reference planner + Taj Phase-A perception scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,6 +2054,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-taj"
+version = "0.1.0"
+dependencies = [
+ "kirra-ros2-adapter",
+ "kirra-runtime-sdk",
+]
+
+[[package]]
 name = "kirra-wire-client"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-fleet-transport"]
+members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-taj", "crates/kirra-fleet-transport"]
 resolver = "2"
 
 [package]

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -740,10 +740,14 @@ mod tests {
 
     #[test]
     fn checker_catches_reacceleration_in_degraded() {
-        // INDEPENDENCE: if Occy (wrongly) re-accelerated in Degraded, the
-        // checker's Degraded non-increasing gate (#70) catches it — proving the
-        // safety property holds even when the planner violates its own
-        // Conservative contract. In-corridor but speed-INCREASING (2 → 5 m/s).
+        // INDEPENDENCE, tested at the MARGIN: if Occy (wrongly) re-accelerated in
+        // Degraded, the checker's #70 non-increasing gate catches it. We inject
+        // the SUBTLEST realistic drift — a 5% re-acceleration (2.0 → 2.1 m/s),
+        // not an obvious jump — because that is where independence is actually
+        // tested: a checker that only catches gross violations is not a real
+        // backstop. The gate denies on `proposed > current + 1e-9`, so this
+        // marginal increase must still hard-reject (→ MRCFallback). In-corridor
+        // and otherwise well-formed, so the ONLY denial reason is the increase.
         let corridor = MockCorridorSource::straight_5m_half_width(100.0);
         let traj = vec![
             TrajectoryPoint {
@@ -752,8 +756,8 @@ mod tests {
                 time_from_start_s: 0.0,
             },
             TrajectoryPoint {
-                pose: Pose { x_m: 10.5, y_m: 0.0, heading_rad: 0.0 },
-                velocity_mps: 5.0,
+                pose: Pose { x_m: 10.205, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: 2.1, // a mere +0.1 m/s — subtle, but a re-acceleration
                 time_from_start_s: 0.1,
             },
         ];
@@ -765,10 +769,10 @@ mod tests {
             None,
             FleetPosture::Degraded,
         );
-        assert_ne!(
+        assert_eq!(
             verdict,
-            TrajectoryVerdict::Accept,
-            "checker must not Accept re-acceleration in Degraded, got {verdict:?}"
+            TrajectoryVerdict::MRCFallback,
+            "checker must reject even a marginal re-acceleration in Degraded, got {verdict:?}"
         );
     }
 }

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -664,4 +664,111 @@ mod tests {
         assert!(out.trajectory.len() <= 21, "horizon cap respected");
         assert!(out.trajectory.len() >= 2);
     }
+
+    // --- Independence: KIRRA judges Occy, it does not rubber-stamp it -------
+    //
+    // The `geometric_planner_output_is_checker_admissible` test proves the
+    // checker ADMITS a good proposal. These prove the converse — that the same
+    // test *can fail* — by feeding the REAL checker hand-built trajectories
+    // standing in for a MISBEHAVING planner. They show the checker exercises
+    // judgment on Occy's output and backstops it independently of Occy's own
+    // good behavior (the safety argument rests on the checker, not on Occy).
+
+    #[test]
+    fn checker_rejects_out_of_corridor_trajectory() {
+        // A trajectory leaving the 5 m corridor (y = 10) → hard reject. Proves
+        // the admissibility check is not a rubber stamp.
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let traj = vec![
+            TrajectoryPoint {
+                pose: Pose { x_m: 10.0, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: 2.0,
+                time_from_start_s: 0.0,
+            },
+            TrajectoryPoint {
+                pose: Pose { x_m: 12.0, y_m: 10.0, heading_rad: 1.3 },
+                velocity_mps: 2.0,
+                time_from_start_s: 1.0,
+            },
+        ];
+        let verdict = validate_trajectory_slow(
+            &traj,
+            &corridor,
+            &[],
+            &VehicleConfig::default_urban(),
+            None,
+            FleetPosture::Nominal,
+        );
+        assert_eq!(
+            verdict,
+            TrajectoryVerdict::MRCFallback,
+            "checker must reject a departure from the drivable corridor"
+        );
+    }
+
+    #[test]
+    fn checker_does_not_clean_accept_overspeed_trajectory() {
+        // In-corridor but at 50 m/s (> 35 max): the checker derates (Clamp) or
+        // refuses — it never clean-Accepts. Proves the checker judges speed.
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let traj = vec![
+            TrajectoryPoint {
+                pose: Pose { x_m: 10.0, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: 50.0,
+                time_from_start_s: 0.0,
+            },
+            TrajectoryPoint {
+                pose: Pose { x_m: 15.0, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: 50.0,
+                time_from_start_s: 0.1,
+            },
+        ];
+        let verdict = validate_trajectory_slow(
+            &traj,
+            &corridor,
+            &[],
+            &VehicleConfig::default_urban(),
+            None,
+            FleetPosture::Nominal,
+        );
+        assert_ne!(
+            verdict,
+            TrajectoryVerdict::Accept,
+            "checker must not clean-Accept an overspeed trajectory, got {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn checker_catches_reacceleration_in_degraded() {
+        // INDEPENDENCE: if Occy (wrongly) re-accelerated in Degraded, the
+        // checker's Degraded non-increasing gate (#70) catches it — proving the
+        // safety property holds even when the planner violates its own
+        // Conservative contract. In-corridor but speed-INCREASING (2 → 5 m/s).
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let traj = vec![
+            TrajectoryPoint {
+                pose: Pose { x_m: 10.0, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: 2.0,
+                time_from_start_s: 0.0,
+            },
+            TrajectoryPoint {
+                pose: Pose { x_m: 10.5, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: 5.0,
+                time_from_start_s: 0.1,
+            },
+        ];
+        let verdict = validate_trajectory_slow(
+            &traj,
+            &corridor,
+            &[],
+            &VehicleConfig::default_urban(),
+            None,
+            FleetPosture::Degraded,
+        );
+        assert_ne!(
+            verdict,
+            TrajectoryVerdict::Accept,
+            "checker must not Accept re-acceleration in Degraded, got {verdict:?}"
+        );
+    }
 }

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -36,7 +36,11 @@
 pub use kirra_ros2_adapter::state::{Pose, TrajectoryPoint, TrajectoryVerdict};
 pub use kirra_runtime_sdk::verifier::FleetPosture;
 
-use kirra_ros2_adapter::corridor::CorridorSource;
+use kirra_ros2_adapter::corridor::{CorridorSource, Point};
+// Derive (never guess) the checker's hard trajectory-length cap: the #131
+// containment gate rejects `len > MAX_TRAJECTORY_HORIZON`, so a proposal must
+// stay within it (including the terminal stop point) to be admissible.
+use kirra_runtime_sdk::gateway::containment::MAX_TRAJECTORY_HORIZON;
 
 /// Ego world-state the planner consumes.
 ///
@@ -170,6 +174,288 @@ impl Planner for StopPlanner {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Phase-1 geometric reference planner (#90 — Occy 1.A).
+// ---------------------------------------------------------------------------
+
+/// Speed at/under which a proposal is "stopped" — mirrors the SDK
+/// `STOP_EPSILON_MPS` Degraded HOLD threshold. A terminal point at or below
+/// this is the controlled stop-and-hold.
+const STOP_EPSILON_MPS: f64 = 0.05;
+
+/// Tunables for [`GeometricPlanner`].
+///
+/// Defaults stay **inside** `VehicleConfig::default_urban` kinematic limits
+/// (accel ≤ 2.5, decel ≤ 4.5, speed ≤ 35 m/s) so a nominal in-corridor proposal
+/// is *checker-admissible* (`Accept`/`Clamp`), not merely consumable. The
+/// planner still PROPOSES — the checker is the authority — but a planner whose
+/// nominal output the real checker refuses is not a useful reference.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GeometricPlannerConfig {
+    /// Nominal (`Full`) cruise speed target.
+    pub cruise_speed_mps: f64,
+    /// `Degraded`/`Conservative` derate: target = `cruise * factor`, additionally
+    /// clamped to be **non-increasing** vs. the ego's current speed (decel-only).
+    pub conservative_factor: f64,
+    /// Acceleration cap used to ramp toward the target speed.
+    pub max_accel_mps2: f64,
+    /// Deceleration cap used to taper to a controlled stop at the goal.
+    pub max_decel_mps2: f64,
+    /// Time spacing between emitted trajectory points.
+    pub sample_dt_s: f64,
+    /// Horizon cap — bounds the proposal allocation (rolling-horizon planning).
+    pub max_points: usize,
+    /// Travel remaining at/under which the goal is "reached" → controlled stop.
+    pub goal_tolerance_m: f64,
+}
+
+impl Default for GeometricPlannerConfig {
+    fn default() -> Self {
+        Self {
+            cruise_speed_mps: 8.0,
+            conservative_factor: 0.5,
+            max_accel_mps2: 2.0,
+            max_decel_mps2: 2.5,
+            sample_dt_s: 0.1,
+            max_points: 50,
+            goal_tolerance_m: 0.5,
+        }
+    }
+}
+
+/// A deterministic geometric go-to-goal planner: it follows the drivable
+/// **corridor centerline** toward the goal with a trapezoidal speed profile that
+/// tapers to a controlled stop at the goal.
+///
+/// **It PROPOSES; the checker decides.** Containment is respected *by
+/// construction* (the centerline is the laterally-safest path), and the speed
+/// profile stays within urban kinematic limits, but the planner is never the
+/// safety authority — `validate_trajectory_slow` is. Posture-mode gated:
+/// - `Full` → cruise to the goal.
+/// - `Conservative` (`Degraded`) → derated **and non-increasing** speed
+///   (decel-only; never re-accelerates), mirroring the SDK Degraded semantics.
+/// - `MrcOnly` (`LockedOut`) → only ever proposes [`PlanOutput::safe_stop`].
+///
+/// If the corridor boundaries don't pair into a usable centerline (need ≥ 2
+/// vertices each), it falls back to a straight ego→goal guide. If the goal is
+/// already within tolerance, or the mode admits no forward speed, it HOLDs
+/// (safe-stop) — the planner never authors re-acceleration.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GeometricPlanner {
+    pub cfg: GeometricPlannerConfig,
+}
+
+impl GeometricPlanner {
+    #[must_use]
+    pub fn new(cfg: GeometricPlannerConfig) -> Self {
+        Self { cfg }
+    }
+}
+
+// SAFETY: occy planner proposes within corridor + urban kinematic limits; checker decides | REQ: Occy-1.A (#90) | TEST: kirra_planner::tests::{geometric_planner_proposes_motion_toward_goal, geometric_planner_output_is_checker_admissible, geometric_planner_locked_out_only_stops, geometric_planner_degraded_is_non_increasing, geometric_planner_at_goal_holds, geometric_planner_respects_horizon_cap}
+impl Planner for GeometricPlanner {
+    fn plan(&mut self, input: &PlanInput<'_>) -> PlanOutput {
+        // LockedOut → the planner may only ever propose safe-stop.
+        let mode = planner_mode(input.posture.clone());
+        if mode == PlannerMode::MrcOnly {
+            return PlanOutput::safe_stop(input.ego.pose);
+        }
+
+        let cur = input.ego.linear_x_mps.abs();
+        let target = match mode {
+            PlannerMode::Full => self.cfg.cruise_speed_mps,
+            // Degraded: derated AND non-increasing (decel-only; no re-accel).
+            PlannerMode::Conservative => {
+                (self.cfg.cruise_speed_mps * self.cfg.conservative_factor).min(cur)
+            }
+            PlannerMode::MrcOnly => unreachable!("handled above"),
+        };
+
+        // Guide path: corridor centerline if usable, else a straight ego→goal line.
+        let center = centerline_from(input.map.left_boundary(), input.map.right_boundary());
+        let guide: Vec<(f64, f64)> = if center.len() >= 2 {
+            center
+        } else {
+            vec![
+                (input.ego.pose.x_m, input.ego.pose.y_m),
+                (input.goal.target.x_m, input.goal.target.y_m),
+            ]
+        };
+
+        // Travel window: ego projection → goal projection along the guide.
+        let s_ego = project_arc_length(&guide, input.ego.pose.x_m, input.ego.pose.y_m);
+        let s_goal = project_arc_length(&guide, input.goal.target.x_m, input.goal.target.y_m);
+        let dist = (s_goal - s_ego).max(0.0);
+
+        // Arrived, or the mode admits no forward speed → HOLD (never re-accelerate).
+        if dist <= self.cfg.goal_tolerance_m || target <= STOP_EPSILON_MPS {
+            return PlanOutput::safe_stop(input.ego.pose);
+        }
+
+        // Trapezoidal speed-profiled resample of the guide.
+        //
+        // Reserve one slot under the checker's `MAX_TRAJECTORY_HORIZON` so the
+        // terminal controlled-stop point can always be appended without pushing
+        // the proposal over the cap (which the containment gate rejects).
+        let budget = self
+            .cfg
+            .max_points
+            .min(MAX_TRAJECTORY_HORIZON.saturating_sub(1))
+            .max(2);
+        let dt = self.cfg.sample_dt_s.max(1e-3);
+        let decel = self.cfg.max_decel_mps2.max(1e-3);
+        let mut traj: Vec<TrajectoryPoint> = Vec::with_capacity(budget + 1);
+        let mut s = 0.0_f64; // distance travelled from ego along the guide
+        let mut v = cur.min(target.max(cur)); // start at current speed
+        let mut t = 0.0_f64;
+        let mut reached = false;
+
+        while traj.len() < budget {
+            let along = s_ego + s;
+            let (x, y) = point_at(&guide, along);
+            let heading = heading_at(&guide, along);
+            traj.push(TrajectoryPoint {
+                pose: Pose { x_m: x, y_m: y, heading_rad: heading },
+                velocity_mps: v,
+                time_from_start_s: t,
+            });
+
+            let remaining = dist - s;
+            if remaining <= self.cfg.goal_tolerance_m {
+                reached = true;
+                break;
+            }
+            // Brake when within stopping distance, else accelerate toward target.
+            let brake_dist = (v * v) / (2.0 * decel);
+            if remaining <= brake_dist {
+                v = (v - decel * dt).max(0.0);
+            } else {
+                v = (v + self.cfg.max_accel_mps2 * dt).min(target);
+            }
+            s += v * dt;
+            t += dt;
+        }
+
+        // On reaching the goal, pin a clean zero-velocity hold at the goal
+        // projection (controlled stop-and-hold). On horizon truncation we leave
+        // the rolling-horizon tail as-is — the next plan cycle continues it.
+        if reached && traj.last().is_none_or(|p| p.velocity_mps > STOP_EPSILON_MPS) {
+            let (gx, gy) = point_at(&guide, s_goal);
+            let gh = heading_at(&guide, s_goal);
+            traj.push(TrajectoryPoint {
+                pose: Pose { x_m: gx, y_m: gy, heading_rad: gh },
+                velocity_mps: 0.0,
+                time_from_start_s: t + dt,
+            });
+        }
+
+        // The checker requires ≥ 2 points; if geometry degenerated, HOLD.
+        if traj.len() < 2 {
+            return PlanOutput::safe_stop(input.ego.pose);
+        }
+        PlanOutput { trajectory: traj, kind: ProposalKind::Motion }
+    }
+}
+
+// --- geometry helpers (private; pure, allocation-bounded by polyline length) ---
+
+fn dist2d(ax: f64, ay: f64, bx: f64, by: f64) -> f64 {
+    ((bx - ax).powi(2) + (by - ay).powi(2)).sqrt()
+}
+
+/// Corridor centerline = pairwise midpoints of the boundary polylines over their
+/// shared prefix. `len < 2` means "unusable" (caller falls back to ego→goal).
+fn centerline_from(left: &[Point], right: &[Point]) -> Vec<(f64, f64)> {
+    let n = left.len().min(right.len());
+    (0..n)
+        .map(|i| {
+            (
+                0.5 * (left[i].x_m + right[i].x_m),
+                0.5 * (left[i].y_m + right[i].y_m),
+            )
+        })
+        .collect()
+}
+
+/// Prefix-sum arc length up to each vertex.
+fn cumulative(poly: &[(f64, f64)]) -> Vec<f64> {
+    let mut acc = Vec::with_capacity(poly.len());
+    let mut total = 0.0;
+    for (i, &(x, y)) in poly.iter().enumerate() {
+        if i > 0 {
+            total += dist2d(poly[i - 1].0, poly[i - 1].1, x, y);
+        }
+        acc.push(total);
+    }
+    acc
+}
+
+/// Point on the polyline at arc length `s` (clamped to `[0, total]`).
+fn point_at(poly: &[(f64, f64)], s: f64) -> (f64, f64) {
+    match poly.len() {
+        0 => return (0.0, 0.0),
+        1 => return poly[0],
+        _ => {}
+    }
+    let cum = cumulative(poly);
+    let total = *cum.last().unwrap();
+    let s = s.clamp(0.0, total);
+    for i in 1..poly.len() {
+        if s <= cum[i] {
+            let seg = cum[i] - cum[i - 1];
+            let f = if seg > 1e-9 { (s - cum[i - 1]) / seg } else { 0.0 };
+            return (
+                poly[i - 1].0 + f * (poly[i].0 - poly[i - 1].0),
+                poly[i - 1].1 + f * (poly[i].1 - poly[i - 1].1),
+            );
+        }
+    }
+    *poly.last().unwrap()
+}
+
+/// Tangent heading (rad) of the polyline at arc length `s`.
+fn heading_at(poly: &[(f64, f64)], s: f64) -> f64 {
+    if poly.len() < 2 {
+        return 0.0;
+    }
+    let cum = cumulative(poly);
+    let total = *cum.last().unwrap();
+    let s = s.clamp(0.0, total);
+    for i in 1..poly.len() {
+        if s <= cum[i] + 1e-9 {
+            return (poly[i].1 - poly[i - 1].1).atan2(poly[i].0 - poly[i - 1].0);
+        }
+    }
+    let n = poly.len();
+    (poly[n - 1].1 - poly[n - 2].1).atan2(poly[n - 1].0 - poly[n - 2].0)
+}
+
+/// Arc length of the point on the polyline nearest to `(qx, qy)`.
+fn project_arc_length(poly: &[(f64, f64)], qx: f64, qy: f64) -> f64 {
+    if poly.len() < 2 {
+        return 0.0;
+    }
+    let cum = cumulative(poly);
+    let mut best = (f64::INFINITY, 0.0_f64);
+    for i in 1..poly.len() {
+        let (ax, ay) = poly[i - 1];
+        let (bx, by) = poly[i];
+        let (ex, ey) = (bx - ax, by - ay);
+        let seg2 = ex * ex + ey * ey;
+        let t = if seg2 > 1e-9 {
+            (((qx - ax) * ex + (qy - ay) * ey) / seg2).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let (px, py) = (ax + t * ex, ay + t * ey);
+        let d = dist2d(qx, qy, px, py);
+        if d < best.0 {
+            best = (d, cum[i - 1] + t * (cum[i] - cum[i - 1]));
+        }
+    }
+    best.1
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,5 +520,148 @@ mod tests {
         assert_eq!(planner_mode(FleetPosture::Nominal), PlannerMode::Full);
         assert_eq!(planner_mode(FleetPosture::Degraded), PlannerMode::Conservative);
         assert_eq!(planner_mode(FleetPosture::LockedOut), PlannerMode::MrcOnly);
+    }
+
+    // --- GeometricPlanner (Phase-1 reference) -------------------------------
+
+    /// Ego positioned a few metres INTO the corridor (so the vehicle footprint's
+    /// rear stays inside the drivable space), with a goal reachable inside the
+    /// horizon — the setup a containment-admissible proposal needs.
+    fn inside_corridor_input(map: &dyn CorridorSource) -> PlanInput<'_> {
+        PlanInput {
+            ego: EgoState {
+                pose: Pose { x_m: 10.0, y_m: 0.0, heading_rad: 0.0 },
+                linear_x_mps: 3.0,
+                yaw_rate_rads: 0.0,
+                stamp_ms: 0,
+            },
+            goal: Goal { target: Pose { x_m: 25.0, y_m: 0.0, heading_rad: 0.0 } },
+            map,
+            posture: FleetPosture::Nominal,
+        }
+    }
+
+    #[test]
+    fn geometric_planner_proposes_motion_toward_goal() {
+        // Default sample: goal (x=50) is beyond the rolling horizon, so this is
+        // the "drive toward the goal" case (no terminal stop), checked for
+        // monotonic in-corridor motion that ramps up.
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&sample_input(&corridor));
+
+        assert_eq!(out.kind, ProposalKind::Motion);
+        assert!(out.trajectory.len() >= 2, "checker requires >= 2 points");
+        // Centerline is along +X at y = 0 → poses advance in +X and stay centered.
+        let xs: Vec<f64> = out.trajectory.iter().map(|t| t.pose.x_m).collect();
+        assert!(
+            xs.windows(2).all(|w| w[1] >= w[0] - 1e-6),
+            "trajectory is monotonic along the corridor"
+        );
+        assert!(
+            out.trajectory.iter().all(|t| t.pose.y_m.abs() < 5.0),
+            "every pose stays inside the 5 m half-width corridor"
+        );
+        // Ramps up from the 3 m/s current speed toward cruise.
+        let vmax = out.trajectory.iter().map(|t| t.velocity_mps).fold(0.0, f64::max);
+        assert!(vmax > 3.0, "proposal accelerates toward cruise, got vmax {vmax}");
+    }
+
+    #[test]
+    fn geometric_planner_reaches_goal_and_stops() {
+        // A goal inside the horizon → reaches it with a controlled stop-and-hold.
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&inside_corridor_input(&corridor));
+
+        assert_eq!(out.kind, ProposalKind::Motion);
+        assert!(
+            out.trajectory.last().unwrap().velocity_mps <= STOP_EPSILON_MPS,
+            "terminal point is a controlled stop at the goal"
+        );
+    }
+
+    #[test]
+    fn geometric_planner_output_is_checker_admissible() {
+        // The strong claim: the real #131 checker ADMITS a nominal in-corridor
+        // proposal (Accept or Clamp — both "safe to drive"), not just consumes it.
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&inside_corridor_input(&corridor));
+        assert!(out.trajectory.len() <= MAX_TRAJECTORY_HORIZON, "within checker horizon");
+
+        let verdict = validate_trajectory_slow(
+            &out.trajectory,
+            &corridor,
+            &[], // no perceived objects
+            &VehicleConfig::default_urban(),
+            None, // no odom
+            FleetPosture::Nominal,
+        );
+        assert!(
+            matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+            "checker should admit the nominal proposal, got {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn geometric_planner_locked_out_only_stops() {
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let mut input = sample_input(&corridor);
+        input.posture = FleetPosture::LockedOut;
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&input);
+
+        assert_eq!(out.kind, ProposalKind::SafeStop);
+        assert!(out.trajectory.iter().all(|t| t.velocity_mps == 0.0));
+    }
+
+    #[test]
+    fn geometric_planner_degraded_is_non_increasing() {
+        // Ego moving at 2 m/s, cruise 8 m/s: Degraded must never propose a speed
+        // above the current speed (decel-only; no re-acceleration).
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let mut input = sample_input(&corridor);
+        input.posture = FleetPosture::Degraded;
+        input.ego.linear_x_mps = 2.0;
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&input);
+
+        let vmax = out
+            .trajectory
+            .iter()
+            .map(|t| t.velocity_mps)
+            .fold(0.0_f64, f64::max);
+        assert!(
+            vmax <= 2.0 + 1e-9,
+            "Degraded proposal must be non-increasing vs current speed, got {vmax}"
+        );
+    }
+
+    #[test]
+    fn geometric_planner_at_goal_holds() {
+        // Goal coincident with ego → arrived → HOLD (safe-stop), never re-accelerate.
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let mut input = sample_input(&corridor);
+        input.goal.target = input.ego.pose;
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&input);
+
+        assert_eq!(out.kind, ProposalKind::SafeStop);
+    }
+
+    #[test]
+    fn geometric_planner_respects_horizon_cap() {
+        // A far goal must not exceed the bounded horizon.
+        let corridor = MockCorridorSource::straight_5m_half_width(10_000.0);
+        let mut input = sample_input(&corridor);
+        input.goal.target = Pose { x_m: 9_000.0, y_m: 0.0, heading_rad: 0.0 };
+        let cfg = GeometricPlannerConfig { max_points: 20, ..Default::default() };
+        let mut p = GeometricPlanner::new(cfg);
+        let out = p.plan(&input);
+
+        // max_points proposal points (+ at most one terminal stop point if reached).
+        assert!(out.trajectory.len() <= 21, "horizon cap respected");
+        assert!(out.trajectory.len() >= 2);
     }
 }

--- a/crates/kirra-taj/Cargo.toml
+++ b/crates/kirra-taj/Cargo.toml
@@ -1,0 +1,33 @@
+# crates/kirra-taj/Cargo.toml
+#
+# Taj — Rosmaster R2 perception layer (ADR-0015), Phase A (geometric, model-free).
+#
+# Taj PRODUCES the Kirra perception input contract — a `CorridorSource` (drivable
+# corridor) + `Vec<PerceivedObject>` (obstacles) + per-output health — from raw
+# range data. It IMPORTS those contract types from `kirra-ros2-adapter` and NEVER
+# redefines them (the same "derivation, not invention" discipline as
+# `kirra-planner`): Taj is a *producer* of the same contract the #131 checker
+# consumes. Phase B (the Parko ML detector) is later work; this crate is the
+# geometric Phase-A scaffold.
+#
+# `default-features = false` keeps ROS / r2r out of the build (the adapter's
+# `default = []`); the geometric pipeline is pure compute, sim-testable with
+# synthetic scans and no R2 hardware.
+[package]
+name = "kirra-taj"
+version = "0.1.0"
+edition = "2021"
+description = "Taj — R2 perception layer (ADR-0015) Phase A: raw range data → the Kirra perception input contract (corridor + objects + health). Geometric, model-free."
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+
+[dependencies]
+# The perception-input contract types Taj produces: CorridorSource + Point and
+# PerceivedObject. default-features = false → no ROS (adapter `default = []`).
+kirra-ros2-adapter = { path = "../kirra-ros2-adapter", default-features = false }
+
+[dev-dependencies]
+# Integration test only: prove Taj's corridor output feeds the real #131 checker.
+# FleetPosture lives in the SDK; the checker entry + config in the adapter.
+kirra-runtime-sdk = { path = "../.." }

--- a/crates/kirra-taj/src/lib.rs
+++ b/crates/kirra-taj/src/lib.rs
@@ -1,0 +1,381 @@
+//! kirra-taj — **Taj**, the Rosmaster R2 perception layer (ADR-0015), **Phase A**
+//! (geometric, model-free).
+//!
+//! # What Taj is
+//!
+//! Taj turns raw range data (R2 lidar / depth) into the **Kirra perception input
+//! contract** — the same contract the #131 checker consumes:
+//!
+//! - a drivable **corridor** as a [`CorridorSource`] ([`TajCorridor`]),
+//! - a set of **obstacles** as `Vec<PerceivedObject>`,
+//! - per-output **health** (confidence + snapshot age).
+//!
+//! # Derivation, not invention
+//!
+//! Like `kirra-planner`, Taj **imports** the contract types from
+//! `kirra-ros2-adapter` and never redefines them: `CorridorSource` / `Point`
+//! (the corridor seam) and [`PerceivedObject`] (the obstacle the slow loop runs
+//! RSS against). Taj is a *producer* of the contract; KIRRA *bounds and derates*
+//! whatever Taj reports — Taj tightens the envelope, it never loosens it
+//! (ADR-0015). A low-confidence or empty Taj output makes the corridor unhealthy,
+//! and the checker fails closed.
+//!
+//! # Phase A scope
+//!
+//! Phase A is **geometric and model-free** — pure compute, sim-testable with
+//! synthetic scans and **no R2 hardware**. It produces a conservative straight
+//! corridor (bounded by the nearest lateral obstacle on each side within the
+//! forward cone) and Euclidean-clustered single-frame objects. Phase B (the
+//! Parko ML detector, semantic objects, temporal velocity) is later work; the
+//! safety plumbing proven here is reused unchanged.
+
+use kirra_ros2_adapter::corridor::{CorridorSource, Point};
+use kirra_ros2_adapter::state::PerceivedObject;
+
+/// Minimal range-scan input — a `sensor_msgs/LaserScan` subset.
+///
+/// Angles are measured from the ego **+X** axis (forward); **+Y** is left.
+/// `ranges[i]` is the distance along the ray at
+/// `angle_min_rad + i * angle_increment_rad`. A range outside
+/// `[range_min_m, range_max_m]` (or non-finite) is treated as **no return**.
+#[derive(Debug, Clone)]
+pub struct LaserScan {
+    pub angle_min_rad: f64,
+    pub angle_increment_rad: f64,
+    pub range_min_m: f64,
+    pub range_max_m: f64,
+    pub ranges: Vec<f32>,
+    /// Acquisition timestamp (ms). Feeds the corridor `age_ms` health field.
+    pub stamp_ms: u64,
+}
+
+/// Phase-A pipeline tunables.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TajConfig {
+    /// Forward distance over which the drivable corridor is estimated.
+    pub forward_extent_m: f64,
+    /// Half-width assumed when NO obstacle bounds a side (open space); also the
+    /// hard cap on the estimated half-width.
+    pub open_half_width_m: f64,
+    /// Max gap between consecutive returns that still belong to one object.
+    pub cluster_gap_m: f64,
+    /// Minimum returns for a cluster to be reported as an object (noise floor).
+    pub min_cluster_points: usize,
+}
+
+impl Default for TajConfig {
+    fn default() -> Self {
+        Self {
+            forward_extent_m: 8.0,
+            open_half_width_m: 5.0,
+            cluster_gap_m: 0.5,
+            min_cluster_points: 3,
+        }
+    }
+}
+
+/// A drivable corridor produced by Taj — an owned [`CorridorSource`].
+///
+/// Phase A produces a conservative **straight** corridor bounded by the nearest
+/// lateral obstacle on each side within the forward cone. (Limitation, stated
+/// honestly: an obstacle *dead ahead* is treated as narrowing the corridor
+/// laterally — conservatively safe, since it shrinks the drivable space toward a
+/// stop. Per-station corridor shaping is Phase-B/later work.)
+#[derive(Debug, Clone)]
+pub struct TajCorridor {
+    left: Vec<Point>,
+    right: Vec<Point>,
+    confidence: f32,
+    age_ms: u64,
+}
+
+impl CorridorSource for TajCorridor {
+    fn left_boundary(&self) -> &[Point] {
+        &self.left
+    }
+    fn right_boundary(&self) -> &[Point] {
+        &self.right
+    }
+    fn confidence(&self) -> f32 {
+        self.confidence
+    }
+    fn age_ms(&self) -> u64 {
+        self.age_ms
+    }
+}
+
+/// One Phase-A perception output frame: the contract Taj feeds to KIRRA.
+#[derive(Debug, Clone)]
+pub struct TajPerception {
+    pub corridor: TajCorridor,
+    pub objects: Vec<PerceivedObject>,
+    pub stamp_ms: u64,
+}
+
+/// Taj Phase-A geometric perception pipeline.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TajPhaseA {
+    pub cfg: TajConfig,
+}
+
+impl TajPhaseA {
+    #[must_use]
+    pub fn new(cfg: TajConfig) -> Self {
+        Self { cfg }
+    }
+
+    /// Convert a scan to ego-frame Cartesian points, dropping invalid returns.
+    /// The result is angle-ordered (same order as `scan.ranges`).
+    #[must_use]
+    pub fn scan_to_points(&self, scan: &LaserScan) -> Vec<(f64, f64)> {
+        let mut pts = Vec::with_capacity(scan.ranges.len());
+        for (i, &r) in scan.ranges.iter().enumerate() {
+            let r = f64::from(r);
+            if !r.is_finite() || r < scan.range_min_m || r > scan.range_max_m {
+                continue; // no return on this ray
+            }
+            let theta = scan.angle_min_rad + (i as f64) * scan.angle_increment_rad;
+            pts.push((r * theta.cos(), r * theta.sin()));
+        }
+        pts
+    }
+
+    /// Run the full Phase-A pipeline: scan → corridor + objects + health.
+    #[must_use]
+    pub fn process(&self, scan: &LaserScan, now_ms: u64) -> TajPerception {
+        let points = self.scan_to_points(scan);
+        // Confidence = fraction of rays that produced a valid return. An empty /
+        // all-invalid scan → 0.0 → the corridor is unhealthy → checker MRCs.
+        let total = scan.ranges.len().max(1);
+        let confidence = (points.len() as f32 / total as f32).clamp(0.0, 1.0);
+
+        let corridor = self.extract_corridor(&points, confidence, now_ms, scan.stamp_ms);
+        let objects = self.cluster_objects(&points);
+        TajPerception { corridor, objects, stamp_ms: scan.stamp_ms }
+    }
+
+    /// Conservative straight corridor: bounded by the nearest lateral obstacle on
+    /// each side within the forward cone (the tightest lateral bound seen ahead).
+    /// A side with no obstacle opens to `open_half_width_m`.
+    fn extract_corridor(
+        &self,
+        points: &[(f64, f64)],
+        confidence: f32,
+        now_ms: u64,
+        stamp_ms: u64,
+    ) -> TajCorridor {
+        let ext = self.cfg.forward_extent_m;
+        let cap = self.cfg.open_half_width_m;
+
+        let mut left_y = cap; // nearest left obstacle = smallest positive y
+        let mut right_y = -cap; // nearest right obstacle = largest negative y
+        for &(x, y) in points {
+            if x <= 0.0 || x > ext {
+                continue; // forward cone only
+            }
+            if y > 0.0 && y < left_y {
+                left_y = y;
+            } else if y < 0.0 && y > right_y {
+                right_y = y;
+            }
+        }
+        // Keep a non-degenerate width and stay within the cap (defensive).
+        left_y = left_y.clamp(1e-3, cap);
+        right_y = right_y.clamp(-cap, -1e-3);
+
+        TajCorridor {
+            left: vec![
+                Point { x_m: 0.0, y_m: left_y },
+                Point { x_m: ext, y_m: left_y },
+            ],
+            right: vec![
+                Point { x_m: 0.0, y_m: right_y },
+                Point { x_m: ext, y_m: right_y },
+            ],
+            confidence,
+            age_ms: now_ms.saturating_sub(stamp_ms),
+        }
+    }
+
+    /// Euclidean clustering of angle-ordered returns into objects. Single-frame,
+    /// so velocity is unknown → reported as `0.0` (Phase B / temporal tracking
+    /// adds motion). Each run of consecutive points within `cluster_gap_m`, of at
+    /// least `min_cluster_points`, becomes one [`PerceivedObject`] at its centroid.
+    fn cluster_objects(&self, points: &[(f64, f64)]) -> Vec<PerceivedObject> {
+        let mut objects = Vec::new();
+        if points.is_empty() {
+            return objects;
+        }
+        let gap = self.cfg.cluster_gap_m;
+        let mut start = 0usize;
+        let mut next_id: u64 = 0;
+
+        for i in 1..=points.len() {
+            let split = i == points.len() || {
+                let (ax, ay) = points[i - 1];
+                let (bx, by) = points[i];
+                ((bx - ax).powi(2) + (by - ay).powi(2)).sqrt() > gap
+            };
+            if split {
+                let cluster = &points[start..i];
+                if cluster.len() >= self.cfg.min_cluster_points {
+                    let n = cluster.len() as f64;
+                    let (sx, sy) = cluster
+                        .iter()
+                        .fold((0.0, 0.0), |(ax, ay), &(x, y)| (ax + x, ay + y));
+                    objects.push(PerceivedObject {
+                        id: next_id,
+                        pos: Point { x_m: sx / n, y_m: sy / n },
+                        velocity_mps: 0.0,
+                        heading_rad: 0.0,
+                        vel: Point { x_m: 0.0, y_m: 0.0 },
+                    });
+                    next_id += 1;
+                }
+                start = i;
+            }
+        }
+        objects
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kirra_ros2_adapter::state::TrajectoryVerdict;
+    use std::f64::consts::PI;
+
+    /// Build a forward 180° scan (`-π/2 .. +π/2`, 1° steps) from a per-ray range
+    /// function. `None` (or out-of-range) → no return.
+    fn scan_from<F: Fn(f64) -> Option<f64>>(range_max: f64, stamp_ms: u64, f: F) -> LaserScan {
+        let n = 181usize;
+        let angle_min = -PI / 2.0;
+        let angle_inc = PI / (n as f64 - 1.0);
+        let ranges = (0..n)
+            .map(|i| {
+                let theta = angle_min + i as f64 * angle_inc;
+                match f(theta) {
+                    Some(r) if r >= 0.05 && r <= range_max => r as f32,
+                    _ => (range_max + 1.0) as f32, // out of range → no return
+                }
+            })
+            .collect();
+        LaserScan {
+            angle_min_rad: angle_min,
+            angle_increment_rad: angle_inc,
+            range_min_m: 0.05,
+            range_max_m: range_max,
+            ranges,
+            stamp_ms,
+        }
+    }
+
+    /// Two parallel walls at `y = ±half_width` along the corridor.
+    fn walls_scan(half_width: f64, range_max: f64) -> LaserScan {
+        scan_from(range_max, 0, |theta| {
+            let s = theta.sin();
+            if s.abs() < 1e-3 {
+                None // straight ahead: parallel wall is infinitely far → no return
+            } else {
+                Some(half_width / s.abs())
+            }
+        })
+    }
+
+    #[test]
+    fn clear_corridor_from_parallel_walls() {
+        let taj = TajPhaseA::default();
+        let out = taj.process(&walls_scan(2.0, 10.0), 5);
+
+        // Nearest left/right obstacle ≈ ±2 m.
+        assert!(
+            (out.corridor.left_boundary()[0].y_m - 2.0).abs() < 0.3,
+            "left ≈ +2, got {}",
+            out.corridor.left_boundary()[0].y_m
+        );
+        assert!(
+            (out.corridor.right_boundary()[0].y_m + 2.0).abs() < 0.3,
+            "right ≈ -2, got {}",
+            out.corridor.right_boundary()[0].y_m
+        );
+        assert!(out.corridor.confidence() > 0.5, "walls give good coverage");
+        assert_eq!(out.corridor.left_boundary().len(), 2);
+        assert_eq!(out.corridor.age_ms(), 5);
+    }
+
+    #[test]
+    fn obstacle_ahead_clusters_to_one_object() {
+        // A ~±8.6° blob of returns at 5 m dead ahead; everything else no-return.
+        let taj = TajPhaseA::default();
+        let scan = scan_from(10.0, 0, |theta| if theta.abs() < 0.15 { Some(5.0) } else { None });
+        let out = taj.process(&scan, 0);
+
+        assert_eq!(out.objects.len(), 1, "one blob → one object");
+        let o = &out.objects[0];
+        assert!(
+            (o.pos.x_m - 5.0).abs() < 0.5 && o.pos.y_m.abs() < 0.8,
+            "object near (5,0), got ({},{})",
+            o.pos.x_m,
+            o.pos.y_m
+        );
+        assert_eq!(o.velocity_mps, 0.0, "single-frame → velocity reported as 0");
+    }
+
+    #[test]
+    fn taj_corridor_feeds_the_checker() {
+        use kirra_ros2_adapter::state::{Pose, TrajectoryPoint};
+        use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+        use kirra_runtime_sdk::verifier::FleetPosture;
+
+        // A 3 m half-width corridor from walls; feed a short centered trajectory.
+        let taj = TajPhaseA::default();
+        let out = taj.process(&walls_scan(3.0, 12.0), 1);
+
+        let traj = vec![
+            TrajectoryPoint {
+                pose: Pose { x_m: 2.0, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: 1.0,
+                time_from_start_s: 0.0,
+            },
+            TrajectoryPoint {
+                pose: Pose { x_m: 3.0, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: 1.0,
+                time_from_start_s: 1.0,
+            },
+        ];
+        // Taj's corridor IS a real `CorridorSource` the #131 checker consumes; a
+        // centered, in-corridor trajectory is admitted.
+        let verdict = validate_trajectory_slow(
+            &traj,
+            &out.corridor,
+            &[],
+            &VehicleConfig::default_urban(),
+            None,
+            FleetPosture::Nominal,
+        );
+        assert!(
+            matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+            "checker should admit a centered in-corridor trajectory on Taj's corridor, got {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn empty_scan_is_low_confidence_and_unhealthy() {
+        // No obstacles detected at all → zero-confidence corridor, no objects.
+        let taj = TajPhaseA::default();
+        let out = taj.process(&scan_from(10.0, 0, |_| None), 0);
+
+        assert_eq!(out.objects.len(), 0);
+        assert_eq!(out.corridor.confidence(), 0.0, "no valid returns → zero confidence");
+        // Fail-closed: 0.0 < the checker's SLOW_LOOP_MIN_CORRIDOR_CONFIDENCE → MRC.
+    }
+
+    #[test]
+    fn taj_corridor_is_dyn_corridor_source() {
+        let taj = TajPhaseA::default();
+        let out = taj.process(&walls_scan(2.0, 10.0), 0);
+        let dynref: &dyn CorridorSource = &out.corridor;
+        assert_eq!(dynref.left_boundary().len(), 2);
+        assert!(dynref.confidence() > 0.0);
+    }
+}


### PR DESCRIPTION
## Taj → Occy → KIRRA: a real geometric planner + the Taj Phase-A perception scaffold

Two **doer-side** additions, both *deriving from* (never redefining) the existing #131 checker contract — the same "derivation, not invention" discipline as the `kirra-planner` Phase-0 lock. Both are **proposers/producers**; KIRRA remains the safety authority.

### Occy — `GeometricPlanner` (`kirra-planner`, #90 / Occy 1.A)
Replaces the "always safe-stop" reference with a real deterministic planner:
- **Follows the corridor centerline** toward the goal with a trapezoidal speed profile that tapers to a controlled stop-and-hold at the goal.
- **Posture-gated**: `Full` → cruise; `Conservative` (Degraded) → derated **and non-increasing** (decel-only, never re-accelerates — mirrors SDK Degraded semantics); `MrcOnly` (LockedOut) → safe-stop only.
- **Containment by construction** (centerline = laterally safest path); accel/decel/speed defaults stay inside `VehicleConfig::default_urban` limits.
- **Honors the checker's `MAX_TRAJECTORY_HORIZON`** (imported, not guessed), reserving a slot for the terminal stop point.
- Strongest test: the **real `validate_trajectory_slow` admits** the nominal in-corridor proposal (`Accept`/`Clamp`), not just consumes it. **11/11 tests pass**; `StopPlanner` and the locked Phase-0 types are untouched.

### Taj — new crate `kirra-taj`, Phase-A geometric perception (ADR-0015)
The perception **producer** of the same contract KIRRA consumes:
- Raw range scan → **`TajCorridor`** (owned `CorridorSource`) + **`Vec<PerceivedObject>`** + health (confidence + age). Imports the contract types from `kirra-ros2-adapter`; never redefines them.
- Model-free, **sim-testable with synthetic scans, no R2 hardware**: forward-cone nearest-lateral-obstacle corridor + Euclidean object clustering; empty/invalid scans → 0 confidence → **fail-closed** at the checker.
- Integration test feeds Taj's corridor into the **real #131 checker** → admitted. **5/5 tests pass**. `default-features = false` keeps ROS out of the build.

### Verification
- `cargo build --workspace` clean; both crates' tests green (16 total); clippy-clean on both new files (the only clippy warnings are pre-existing in `validation.rs`, untouched).
- The stack now exists end-to-end as code: **Taj (perception) → Occy (planner) → KIRRA (checker)**.

Refs #90, ADR-0015. Adds workspace member `crates/kirra-taj`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_