### PR TITLE
feat(occy): behavioral rules layer — obey traffic signs & signals

### DIFF
--- a/crates/kirra-planner/src/behavior.rs
+++ b/crates/kirra-planner/src/behavior.rs
@@ -1,0 +1,301 @@
+//! Occy behavioral rules layer — traffic signs & signals (#90 / Occy 1.C).
+//!
+//! # Scope and doctrine
+//!
+//! This layer makes Occy **obey road rules**. It is deliberately separate from
+//! KIRRA: KIRRA is the *physical* safety governor (collision / kinematic
+//! envelope) and never enforces traffic law; this layer is *behavioral*
+//! (legal/regulatory) and lives in the planner. Running a red light is not a
+//! kinematic violation — it is a legal one — so it belongs here, while the
+//! collision shadow of a red light (cross-traffic) stays with KIRRA's RSS.
+//!
+//! # Grounding in the rules of the road
+//!
+//! Every behaviorally-relevant control reduces to a small set of **longitudinal
+//! constraints** — a *stop/hold line* and/or a *speed cap*. The variants below
+//! cover the regulatory + warning sign families that impose those constraints
+//! (US **MUTCD** R/W/S series; **Vienna Convention** priority / prohibitory /
+//! special-regulation signs), plus signal indications per the **UVC / MUTCD
+//! Part 4**, including:
+//!
+//! - **Stop sign / flashing red** — *full stop, then proceed* (MUTCD R1-1; §4).
+//! - **Yield / flashing amber** — *give way: slow, prepared to stop* (R1-2).
+//! - **Steady red** — *hold at the line until released*.
+//! - **Steady amber** — the lawful **dilemma-zone** rule: *stop if you can do so
+//!   safely; otherwise clear the intersection*. Modeled as "stop only if the
+//!   required deceleration to the line is within a comfortable bound".
+//! - **Speed limit / school zone / work zone / advisory** — *regulatory or
+//!   advisory speed cap* (R2-1, S-series, W13-1).
+//! - **Do-not-enter / wrong-way / road-closed** — *prohibition: no-go* (R5-1).
+//! - **Rail / level crossing** — *stop when a train/gate requires it* (R15-1).
+//!
+//! # Out of longitudinal scope (stated honestly)
+//!
+//! Purely informational **guide** signs impose no constraint (no-op).
+//! Direction/maneuver-specific rules — right-turn-on-red, protected/permitted
+//! turn **arrows**, lane-use control — need *maneuver intent*, which this
+//! longitudinal layer does not model; they are noted, not silently mishandled.
+//! "Satisfied" / signal **state** are caller-managed (the integrator tracks the
+//! full-stop dwell and the live signal phase), keeping this layer pure.
+
+/// A traffic-signal indication (the longitudinally-relevant set). Protected /
+/// permitted **turn arrows** are intentionally omitted — they require maneuver
+/// intent, out of this layer's longitudinal scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalState {
+    /// Proceed.
+    Green,
+    /// Steady amber — stop if able (dilemma-zone rule), else clear.
+    Amber,
+    /// Steady red — hold at the line.
+    Red,
+    /// Flashing red — treat as a STOP sign (full stop, then proceed).
+    FlashingRed,
+    /// Flashing amber — proceed with caution (yield-like; no mandatory stop).
+    FlashingAmber,
+}
+
+/// A traffic control Occy must obey. Positions are longitudinal distances along
+/// the path (ego-frame world x, metres). Each variant maps to a [`Behavioral`]
+/// constraint via [`evaluate_controls`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TrafficControl {
+    /// STOP sign (MUTCD R1-1): full stop at the line, then proceed. `satisfied`
+    /// is set by the integrator once the mandatory full stop has been performed.
+    StopSign { stop_line_x_m: f64, satisfied: bool },
+    /// YIELD / give-way (R1-2): slow to the yield speed, prepared to stop. The
+    /// actual give-way to conflicting traffic is a physical object → KIRRA's RSS.
+    YieldSign { line_x_m: f64 },
+    /// A traffic signal at `stop_line_x_m` showing `state`.
+    TrafficLight { stop_line_x_m: f64, state: SignalState },
+    /// Regulatory speed limit (R2-1) taking effect at `from_x_m`.
+    SpeedLimit { from_x_m: f64, limit_mps: f64 },
+    /// School zone (S-series): `limit_mps` over `[from_x_m, to_x_m]` while `active`
+    /// (flashing beacon / posted hours).
+    SchoolZone { from_x_m: f64, to_x_m: f64, limit_mps: f64, active: bool },
+    /// Work / construction zone: `limit_mps` over `[from_x_m, to_x_m]`.
+    WorkZone { from_x_m: f64, to_x_m: f64, limit_mps: f64 },
+    /// Advisory (warning) speed, e.g. a curve plate (W13-1): a speed cap from
+    /// `from_x_m`. Advisory, but treated as a cap for safe, lawful driving.
+    AdvisorySpeed { from_x_m: f64, limit_mps: f64 },
+    /// Prohibition — DO NOT ENTER / wrong-way / road-closed (R5-1): no-go; the
+    /// plan must stop before the line and not pass it.
+    DoNotEnter { line_x_m: f64 },
+    /// Rail / level crossing (R15-1): stop at the line when `must_stop` (a train
+    /// is approaching, the gate is down, or the crossing signal is active).
+    RailCrossing { stop_line_x_m: f64, must_stop: bool },
+}
+
+/// Tunables for the behavioral layer.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BehaviorConfig {
+    /// Comfortable deceleration used for the amber dilemma-zone test: on amber,
+    /// stop only if the required decel to the line is at/below this.
+    pub amber_comfortable_decel_mps2: f64,
+    /// Speed approaching a YIELD / flashing-amber control (slow, ready to stop).
+    pub yield_speed_mps: f64,
+}
+
+impl Default for BehaviorConfig {
+    fn default() -> Self {
+        Self { amber_comfortable_decel_mps2: 3.0, yield_speed_mps: 4.0 }
+    }
+}
+
+/// The behavioral constraint Occy must apply this cycle: the nearest mandatory
+/// **stop/hold line** ahead (if any) and the binding **speed cap** (if any).
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Behavioral {
+    /// Nearest longitudinal x at which the plan must come to a stop/hold. `None`
+    /// = no mandatory stop from traffic controls.
+    pub stop_x_m: Option<f64>,
+    /// Speed cap in effect over the planned region (regulatory / advisory /
+    /// yield). `None` = no behavioral speed cap.
+    pub speed_cap_mps: Option<f64>,
+}
+
+impl Behavioral {
+    fn add_stop(&mut self, x: f64) {
+        self.stop_x_m = Some(self.stop_x_m.map_or(x, |c| c.min(x)));
+    }
+    fn add_cap(&mut self, v: f64) {
+        self.speed_cap_mps = Some(self.speed_cap_mps.map_or(v, |c| c.min(v)));
+    }
+}
+
+/// Evaluate the active traffic controls into a single [`Behavioral`] constraint,
+/// given the ego's longitudinal position `ego_x` and speed `ego_v`.
+#[must_use]
+pub fn evaluate_controls(
+    controls: &[TrafficControl],
+    ego_x: f64,
+    ego_v: f64,
+    cfg: &BehaviorConfig,
+) -> Behavioral {
+    let mut out = Behavioral::default();
+    // A stop line only constrains us if it is AHEAD.
+    let ahead = |x: f64| x > ego_x;
+    // The lawful amber dilemma test: can we stop at the line within a comfortable
+    // deceleration? If not, clearing is the safe (and legal) action.
+    let can_stop_safely = |line_x: f64| {
+        let d = line_x - ego_x;
+        if d <= 1e-3 {
+            return false; // already at/over the line — cannot stop before it
+        }
+        let required_decel = (ego_v * ego_v) / (2.0 * d);
+        required_decel <= cfg.amber_comfortable_decel_mps2
+    };
+
+    for c in controls {
+        match *c {
+            TrafficControl::StopSign { stop_line_x_m, satisfied } => {
+                if !satisfied && ahead(stop_line_x_m) {
+                    out.add_stop(stop_line_x_m);
+                }
+            }
+            TrafficControl::YieldSign { line_x_m } => {
+                if ahead(line_x_m) {
+                    out.add_cap(cfg.yield_speed_mps);
+                }
+            }
+            TrafficControl::TrafficLight { stop_line_x_m, state } => match state {
+                SignalState::Green => {}
+                SignalState::Red | SignalState::FlashingRed => {
+                    if ahead(stop_line_x_m) {
+                        out.add_stop(stop_line_x_m);
+                    }
+                }
+                SignalState::Amber => {
+                    // Dilemma zone: stop only if it can be done safely; else clear.
+                    if ahead(stop_line_x_m) && can_stop_safely(stop_line_x_m) {
+                        out.add_stop(stop_line_x_m);
+                    }
+                }
+                SignalState::FlashingAmber => {
+                    if ahead(stop_line_x_m) {
+                        out.add_cap(cfg.yield_speed_mps);
+                    }
+                }
+            },
+            TrafficControl::DoNotEnter { line_x_m } => {
+                if ahead(line_x_m) {
+                    out.add_stop(line_x_m);
+                }
+            }
+            TrafficControl::RailCrossing { stop_line_x_m, must_stop } => {
+                if must_stop && ahead(stop_line_x_m) {
+                    out.add_stop(stop_line_x_m);
+                }
+            }
+            TrafficControl::SpeedLimit { from_x_m, limit_mps } => {
+                // In effect once we are at/after the sign, OR approaching it (we
+                // must already be at the limit by the time we reach it).
+                if ego_x >= from_x_m || ahead(from_x_m) {
+                    out.add_cap(limit_mps);
+                }
+            }
+            TrafficControl::AdvisorySpeed { from_x_m, limit_mps } => {
+                if ego_x >= from_x_m || ahead(from_x_m) {
+                    out.add_cap(limit_mps);
+                }
+            }
+            TrafficControl::SchoolZone { from_x_m, to_x_m, limit_mps, active } => {
+                if active && ego_x < to_x_m && (ego_x >= from_x_m || ahead(from_x_m)) {
+                    out.add_cap(limit_mps);
+                }
+            }
+            TrafficControl::WorkZone { from_x_m, to_x_m, limit_mps } => {
+                if ego_x < to_x_m && (ego_x >= from_x_m || ahead(from_x_m)) {
+                    out.add_cap(limit_mps);
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CFG: BehaviorConfig = BehaviorConfig { amber_comfortable_decel_mps2: 3.0, yield_speed_mps: 4.0 };
+
+    #[test]
+    fn red_light_requires_stop_green_does_not() {
+        let red = [TrafficControl::TrafficLight { stop_line_x_m: 20.0, state: SignalState::Red }];
+        assert_eq!(evaluate_controls(&red, 5.0, 8.0, &CFG).stop_x_m, Some(20.0));
+        let green = [TrafficControl::TrafficLight { stop_line_x_m: 20.0, state: SignalState::Green }];
+        assert_eq!(evaluate_controls(&green, 5.0, 8.0, &CFG).stop_x_m, None);
+    }
+
+    #[test]
+    fn stop_sign_stops_until_satisfied() {
+        let unsat = [TrafficControl::StopSign { stop_line_x_m: 15.0, satisfied: false }];
+        assert_eq!(evaluate_controls(&unsat, 5.0, 6.0, &CFG).stop_x_m, Some(15.0));
+        let sat = [TrafficControl::StopSign { stop_line_x_m: 15.0, satisfied: true }];
+        assert_eq!(evaluate_controls(&sat, 5.0, 6.0, &CFG).stop_x_m, None);
+    }
+
+    #[test]
+    fn amber_dilemma_zone_stops_when_safe_clears_when_not() {
+        // Far away & slow → can stop safely → stop.
+        let amber = [TrafficControl::TrafficLight { stop_line_x_m: 40.0, state: SignalState::Amber }];
+        assert_eq!(evaluate_controls(&amber, 5.0, 8.0, &CFG).stop_x_m, Some(40.0));
+        // Close & fast → required decel exceeds comfortable → clear (no stop).
+        // d = 3 m, v = 12 → req_decel = 144/6 = 24 m/s² ≫ 3 → proceed.
+        let amber_close = [TrafficControl::TrafficLight { stop_line_x_m: 8.0, state: SignalState::Amber }];
+        assert_eq!(evaluate_controls(&amber_close, 5.0, 12.0, &CFG).stop_x_m, None);
+    }
+
+    #[test]
+    fn flashing_red_is_a_stop_flashing_amber_is_yield() {
+        let fr = [TrafficControl::TrafficLight { stop_line_x_m: 10.0, state: SignalState::FlashingRed }];
+        assert_eq!(evaluate_controls(&fr, 2.0, 5.0, &CFG).stop_x_m, Some(10.0));
+        let fa = [TrafficControl::TrafficLight { stop_line_x_m: 10.0, state: SignalState::FlashingAmber }];
+        let b = evaluate_controls(&fa, 2.0, 8.0, &CFG);
+        assert_eq!(b.stop_x_m, None);
+        assert_eq!(b.speed_cap_mps, Some(4.0));
+    }
+
+    #[test]
+    fn do_not_enter_is_a_hard_stop() {
+        let dne = [TrafficControl::DoNotEnter { line_x_m: 12.0 }];
+        assert_eq!(evaluate_controls(&dne, 3.0, 6.0, &CFG).stop_x_m, Some(12.0));
+    }
+
+    #[test]
+    fn rail_crossing_stops_only_when_required() {
+        let train = [TrafficControl::RailCrossing { stop_line_x_m: 18.0, must_stop: true }];
+        assert_eq!(evaluate_controls(&train, 2.0, 6.0, &CFG).stop_x_m, Some(18.0));
+        let clear = [TrafficControl::RailCrossing { stop_line_x_m: 18.0, must_stop: false }];
+        assert_eq!(evaluate_controls(&clear, 2.0, 6.0, &CFG).stop_x_m, None);
+    }
+
+    #[test]
+    fn speed_controls_take_the_lowest_cap() {
+        let controls = [
+            TrafficControl::SpeedLimit { from_x_m: 0.0, limit_mps: 13.0 },
+            TrafficControl::SchoolZone { from_x_m: 10.0, to_x_m: 50.0, limit_mps: 7.0, active: true },
+            TrafficControl::AdvisorySpeed { from_x_m: 5.0, limit_mps: 9.0 },
+        ];
+        assert_eq!(evaluate_controls(&controls, 12.0, 10.0, &CFG).speed_cap_mps, Some(7.0));
+    }
+
+    #[test]
+    fn inactive_school_zone_and_passed_zone_do_not_cap() {
+        let inactive = [TrafficControl::SchoolZone { from_x_m: 10.0, to_x_m: 50.0, limit_mps: 7.0, active: false }];
+        assert_eq!(evaluate_controls(&inactive, 12.0, 10.0, &CFG).speed_cap_mps, None);
+        // Already past the work zone end → no cap.
+        let passed = [TrafficControl::WorkZone { from_x_m: 10.0, to_x_m: 20.0, limit_mps: 6.0 }];
+        assert_eq!(evaluate_controls(&passed, 25.0, 10.0, &CFG).speed_cap_mps, None);
+    }
+
+    #[test]
+    fn nearest_stop_line_binds() {
+        let controls = [
+            TrafficControl::TrafficLight { stop_line_x_m: 30.0, state: SignalState::Red },
+            TrafficControl::StopSign { stop_line_x_m: 12.0, satisfied: false },
+        ];
+        assert_eq!(evaluate_controls(&controls, 2.0, 6.0, &CFG).stop_x_m, Some(12.0));
+    }
+}

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -42,6 +42,20 @@ use kirra_ros2_adapter::corridor::{CorridorSource, Point};
 // stay within it (including the terminal stop point) to be admissible.
 use kirra_runtime_sdk::gateway::containment::MAX_TRAJECTORY_HORIZON;
 
+pub mod behavior;
+pub use behavior::{Behavioral, BehaviorConfig, SignalState, TrafficControl};
+
+/// What set the binding travel limit `s_limit` — selects the speed/brake policy:
+/// `Lead` matches & follows (rolling gap, no brake-to-zero); `ObjectStop` and
+/// `Behavioral` decelerate to a hard stop; `Goal` cruises to the goal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LimitKind {
+    Goal,
+    ObjectStop,
+    Lead,
+    Behavioral,
+}
+
 /// Ego world-state the planner consumes.
 ///
 /// `// PHASE-0 LOCKED` — derived from `kirra_ros2_adapter::state::EgoOdom`
@@ -81,6 +95,10 @@ pub struct PlanInput<'a> {
     /// obstacle-aware planner): [`GeometricPlanner`] decelerates to a controlled
     /// stop short of the nearest in-path object. An empty slice = no obstacles.
     pub objects: &'a [PerceivedObject],
+    /// Active traffic controls (signs / signals) the planner must OBEY — the
+    /// behavioral/legal layer (distinct from KIRRA's physical authority). An
+    /// empty slice = no controls. See [`behavior`].
+    pub controls: &'a [TrafficControl],
     /// Fleet posture → planner mode (see [`planner_mode`]).
     pub posture: FleetPosture,
 }
@@ -423,8 +441,8 @@ impl Planner for GeometricPlanner {
         //  - static / slow in-lane object → STOP SHORT of it.
         // (The checker's RSS still backstops every object independently.)
         let mut s_limit = s_goal;
+        let mut limit_kind = LimitKind::Goal;
         let mut lead_match: Option<f64> = None; // slowest lead speed to match
-        let mut lead_gap_limit = false; // is `s_limit` a lead following-gap?
         for obj in input.objects {
             let (s_obj, signed) = project_signed(&guide, obj.pos.x_m, obj.pos.y_m);
             if s_obj <= s_ego {
@@ -443,27 +461,47 @@ impl Planner for GeometricPlanner {
                 let gap = s_obj - self.cfg.lead_following_gap_m;
                 if gap < s_limit {
                     s_limit = gap;
-                    lead_gap_limit = true;
+                    limit_kind = LimitKind::Lead;
                 }
             } else if lateral <= self.cfg.object_lane_tolerance_m {
                 let stop = s_obj - self.cfg.object_stop_gap_m;
                 if stop < s_limit {
                     s_limit = stop;
-                    lead_gap_limit = false;
+                    limit_kind = LimitKind::ObjectStop;
                 }
             }
         }
-        // Target speed: route-around pass cap → match a lead → stop-short approach.
-        let object_limited = s_limit < s_goal - 1e-9;
-        let target = if bump.y_off != 0.0 {
+
+        // Behavioral rules layer: traffic signs & signals impose a hard stop/hold
+        // line and/or a speed cap. Occy OBEYS the rule; KIRRA stays the *physical*
+        // authority (it never enforces traffic law). A nearer mandatory stop line
+        // overrides object/lead handling with a clean decel-to-stop.
+        let behavioral =
+            behavior::evaluate_controls(input.controls, input.ego.pose.x_m, cur, &BehaviorConfig::default());
+        if let Some(stop_x) = behavioral.stop_x_m {
+            let s_stop = project_arc_length(&guide, stop_x, input.ego.pose.y_m);
+            if s_stop > s_ego && s_stop < s_limit {
+                s_limit = s_stop;
+                limit_kind = LimitKind::Behavioral;
+            }
+        }
+
+        // Target speed by the binding limit, then clamped by any behavioral speed
+        // cap (regulatory / advisory / yield).
+        let mut target = if bump.y_off != 0.0 {
             target.min(self.cfg.lateral_pass_speed_mps)
-        } else if let Some(ls) = lead_match {
-            target.min(ls)
-        } else if object_limited {
-            target.min(self.cfg.object_approach_speed_mps)
         } else {
-            target
+            match limit_kind {
+                LimitKind::Lead => target.min(lead_match.unwrap_or(target)),
+                LimitKind::ObjectStop => target.min(self.cfg.object_approach_speed_mps),
+                LimitKind::Goal | LimitKind::Behavioral => target,
+            }
         };
+        if let Some(cap) = behavioral.speed_cap_mps {
+            target = target.min(cap);
+        }
+        // A lead follows at a rolling gap (no brake-to-zero); everything else stops.
+        let lead_gap_limit = limit_kind == LimitKind::Lead;
         let dist = (s_limit - s_ego).max(0.0);
 
         // Arrived, blocked too close to advance, or the mode admits no forward
@@ -774,6 +812,7 @@ mod tests {
             goal: Goal { target: Pose { x_m: 50.0, y_m: 0.0, heading_rad: 0.0 } },
             map,
             objects: &[],
+            controls: &[],
             posture: FleetPosture::Nominal,
         }
     }
@@ -839,6 +878,7 @@ mod tests {
             goal: Goal { target: Pose { x_m: 25.0, y_m: 0.0, heading_rad: 0.0 } },
             map,
             objects: &[],
+            controls: &[],
             posture: FleetPosture::Nominal,
         }
     }
@@ -1109,6 +1149,7 @@ mod tests {
             goal: Goal { target: Pose { x_m: goal_x, y_m: 0.0, heading_rad: 0.0 } },
             map,
             objects,
+            controls: &[],
             posture: FleetPosture::Nominal,
         }
     }
@@ -1327,6 +1368,108 @@ mod tests {
         assert!(
             matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
             "checker admits the speed-matched encounter, got {verdict:?}"
+        );
+    }
+
+    // --- Behavioral rules: traffic signs & signals (#90 / Occy 1.C) ---------
+
+    fn input_with_controls<'a>(
+        map: &'a dyn CorridorSource,
+        ego_x: f64,
+        goal_x: f64,
+        controls: &'a [TrafficControl],
+    ) -> PlanInput<'a> {
+        PlanInput {
+            ego: EgoState {
+                pose: Pose { x_m: ego_x, y_m: 0.0, heading_rad: 0.0 },
+                linear_x_mps: 2.0,
+                yaw_rate_rads: 0.0,
+                stamp_ms: 0,
+            },
+            goal: Goal { target: Pose { x_m: goal_x, y_m: 0.0, heading_rad: 0.0 } },
+            map,
+            objects: &[],
+            controls,
+            posture: FleetPosture::Nominal,
+        }
+    }
+
+    #[test]
+    fn red_light_makes_occy_stop_at_the_line() {
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let controls = [TrafficControl::TrafficLight { stop_line_x_m: 20.0, state: SignalState::Red }];
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&input_with_controls(&corridor, 8.0, 60.0, &controls));
+
+        assert_eq!(out.kind, ProposalKind::Motion);
+        let max_x = out.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max);
+        assert!((18.0..=20.5).contains(&max_x), "stops at the red-light line ~20, got {max_x}");
+        assert!(
+            out.trajectory.last().unwrap().velocity_mps <= STOP_EPSILON_MPS,
+            "controlled stop at the line"
+        );
+    }
+
+    #[test]
+    fn green_light_does_not_stop() {
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let controls = [TrafficControl::TrafficLight { stop_line_x_m: 20.0, state: SignalState::Green }];
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&input_with_controls(&corridor, 8.0, 35.0, &controls));
+
+        let max_x = out.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max);
+        assert!(max_x > 22.0, "green → drives through the light, got max_x {max_x}");
+    }
+
+    #[test]
+    fn speed_limit_caps_the_planner() {
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let controls = [TrafficControl::SpeedLimit { from_x_m: 0.0, limit_mps: 5.0 }];
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&input_with_controls(&corridor, 8.0, 60.0, &controls));
+
+        let vmax = out.trajectory.iter().map(|t| t.velocity_mps).fold(0.0, f64::max);
+        assert!(vmax <= 5.2, "obeys the 5 m/s limit, not cruise 8, got {vmax}");
+        assert!(vmax > 4.0, "still progresses near the limit, got {vmax}");
+    }
+
+    #[test]
+    fn stop_sign_then_satisfied_proceeds() {
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let unsat = [TrafficControl::StopSign { stop_line_x_m: 20.0, satisfied: false }];
+        let sat = [TrafficControl::StopSign { stop_line_x_m: 20.0, satisfied: true }];
+        let mut p = GeometricPlanner::default();
+
+        let stops = p.plan(&input_with_controls(&corridor, 8.0, 60.0, &unsat));
+        let stop_max = stops.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max);
+        assert!(stop_max <= 20.5, "unsatisfied stop sign → stop at the line, got {stop_max}");
+
+        let goes = p.plan(&input_with_controls(&corridor, 8.0, 35.0, &sat));
+        let go_max = goes.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max);
+        assert!(go_max > 22.0, "satisfied stop sign → proceed, got {go_max}");
+    }
+
+    #[test]
+    fn behavioral_stop_is_checker_admissible() {
+        // Obeying a red light produces a clean in-corridor decel-to-stop the
+        // physical checker admits (KIRRA admits the stop; it would still MRC
+        // cross-traffic regardless of the signal).
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let controls = [TrafficControl::TrafficLight { stop_line_x_m: 20.0, state: SignalState::Red }];
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&input_with_controls(&corridor, 8.0, 60.0, &controls));
+
+        let verdict = validate_trajectory_slow(
+            &out.trajectory,
+            &corridor,
+            &[],
+            &VehicleConfig::default_urban(),
+            None,
+            FleetPosture::Nominal,
+        );
+        assert!(
+            matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+            "checker admits the controlled stop at the line, got {verdict:?}"
         );
     }
 }

--- a/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
+++ b/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
@@ -90,6 +90,7 @@ fn run_stack(
         goal: Goal { target: Pose { x_m: goal_x, y_m: 0.0, heading_rad: 0.0 } },
         map: &perception.corridor,
         objects: &perception.objects,
+        controls: &[],
         posture: posture.clone(),
     };
     let mut planner = GeometricPlanner::default();
@@ -177,6 +178,7 @@ fn route_around_in_corridor_object_admits() {
         goal: Goal { target: Pose { x_m: 30.0, y_m: 0.0, heading_rad: 0.0 } },
         map: &perception.corridor,
         objects: &perception.objects,
+        controls: &[],
         posture: FleetPosture::Nominal,
     };
     let mut planner = GeometricPlanner::default();


### PR DESCRIPTION
## Occy behavioral rules layer — obey traffic signs & signals

Adds the behavioral/**legal** layer to Occy, deliberately **separate from KIRRA**: KIRRA is the *physical* safety governor (it never enforces traffic law); this layer makes Occy *obey the rules of the road*. Running a red light is a legal violation, not a kinematic one — so it lives here, while the red light's *collision* shadow (cross-traffic) stays with KIRRA's RSS.

### Coverage — every behavioral effect a sign/light imposes
Grounded in the standard families (US **MUTCD** R/W/S series; **Vienna Convention** priority/prohibitory/special-regulation; signals per **UVC / MUTCD Part 4**), all reduced to two longitudinal constraints — a **stop/hold line** and/or a **speed cap**:
- `SignalState` {Green, Amber, Red, FlashingRed, FlashingAmber}
- `TrafficControl` {StopSign, YieldSign, TrafficLight, SpeedLimit, SchoolZone, WorkZone, AdvisorySpeed, DoNotEnter, RailCrossing}

### Law-consulted nuances (not just "red = stop")
- **Amber dilemma-zone rule**: on steady amber, stop *only if it can be done safely* (required decel ≤ comfortable bound); else clear the intersection — the actual legal standard.
- **Flashing red = stop sign** (full stop then proceed); **flashing amber = yield**.
- Stop sign = full stop *then* proceed (caller tracks the dwell via `satisfied`); do-not-enter / wrong-way = hard no-go; rail crossing holds on train/gate; school/work/advisory speed caps.

### Implementation
- New `src/behavior.rs`: `evaluate_controls → Behavioral { stop_x, speed_cap }`.
- `PlanInput` gains `controls: &[TrafficControl]`; a `LimitKind` refactor (Goal/ObjectStop/Lead/Behavioral) gives each binding limit the right speed/brake policy — a behavioral stop is a clean decel-to-hold at the line.

### Honest scope
Informational guide signs are no-ops; **maneuver-specific** rules (turn-on-red, turn arrows, lane-use, and **lane-line crossing** — a *lateral* rule) need maneuver intent and are out of this *longitudinal* layer — a focused follow-up. Signal **state** and stop-sign `satisfied` are caller-managed (live phase + the full-stop dwell).

### Tests — 59 pass (38 planner + 4 stack + 17 Taj), clippy-clean
9 behavior unit (red/green, stop-sign, **amber dilemma both ways**, flashing signals, do-not-enter, rail crossing, lowest-cap, nearest-stop-binds) + 5 integration (red stops at line, green proceeds, speed-limit caps, stop-sign satisfied/unsatisfied, behavioral stop is checker-admissible). Existing 24 planner tests unchanged (empty `controls` = no-op).

Robotics-build lane — fenced from the Phase-I proposal. Refs #90, ADR-0015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_