### PR TITLE
feat(occy): lane-line crossing rules — gate route-around on solid/broken lines

### DIFF
--- a/crates/kirra-planner/src/behavior.rs
+++ b/crates/kirra-planner/src/behavior.rs
@@ -214,6 +214,71 @@ pub fn evaluate_controls(
     out
 }
 
+// ===========================================================================
+// Lane-line crossing rules — the LATERAL behavioral constraint
+//
+// Lane markings govern *when you may cross laterally* (the longitudinal layer
+// above governs *when you stop / how fast*). Like signs, these are LEGAL, not
+// physical — you *can* drive across a solid line; doing so is unlawful, and its
+// collision shadow (oncoming traffic) is still KIRRA's RSS. So the rule lives in
+// Occy: it gates the lateral-avoidance maneuver (route-around / lane offset).
+//
+// Boundaries are given as lateral offsets from the path centerline (+y left).
+// Full typed boundaries with real positions ride on a lane map (the adapter's
+// Lanelet2 seam); this is the rule logic + the route-around gate.
+// ===========================================================================
+
+/// A lane-marking type and its crossing permission (per the rules of the road).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineType {
+    /// Broken / dashed — crossing permitted either direction (when safe).
+    Broken,
+    /// Single solid — no crossing either direction.
+    Solid,
+    /// Double solid — no crossing either direction.
+    DoubleSolid,
+    /// Combined (solid + broken) with the **broken** marking facing the +y (left)
+    /// side: a vehicle on the +y side may cross; the -y (solid) side may not.
+    BrokenOnLeft,
+    /// Combined with the broken marking facing the -y (right) side: the -y side
+    /// may cross; the +y (solid) side may not.
+    BrokenOnRight,
+}
+
+/// A lane boundary at lateral offset `y_m` from the path centerline (+y left).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LaneBoundary {
+    pub y_m: f64,
+    pub line: LineType,
+}
+
+impl LaneBoundary {
+    /// May the ego cross this boundary moving laterally from `from_y` to `to_y`?
+    /// A move that does not cross `y_m` is unconstrained (returns `true`).
+    #[must_use]
+    pub fn may_cross(&self, from_y: f64, to_y: f64) -> bool {
+        let from_side = from_y - self.y_m;
+        let to_side = to_y - self.y_m;
+        // Not crossing this line (same side, or starting exactly on it) → allowed.
+        if from_side.abs() <= 1e-9 || from_side.signum() == to_side.signum() {
+            return true;
+        }
+        match self.line {
+            LineType::Broken => true,
+            LineType::Solid | LineType::DoubleSolid => false,
+            // Combined: only the side the broken marking faces may cross.
+            LineType::BrokenOnLeft => from_side > 0.0,
+            LineType::BrokenOnRight => from_side < 0.0,
+        }
+    }
+}
+
+/// Is a lateral move from `from_y` to `to_y` permitted by ALL lane boundaries?
+#[must_use]
+pub fn lateral_move_permitted(boundaries: &[LaneBoundary], from_y: f64, to_y: f64) -> bool {
+    boundaries.iter().all(|b| b.may_cross(from_y, to_y))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -297,5 +362,48 @@ mod tests {
             TrafficControl::StopSign { stop_line_x_m: 12.0, satisfied: false },
         ];
         assert_eq!(evaluate_controls(&controls, 2.0, 6.0, &CFG).stop_x_m, Some(12.0));
+    }
+
+    // --- lane-line crossing rules ---
+
+    #[test]
+    fn broken_line_allows_crossing_solid_forbids() {
+        let broken = LaneBoundary { y_m: -0.5, line: LineType::Broken };
+        assert!(broken.may_cross(0.0, -1.5), "broken: crossing OK");
+        let solid = LaneBoundary { y_m: -0.5, line: LineType::Solid };
+        assert!(!solid.may_cross(0.0, -1.5), "solid: no crossing");
+        let double = LaneBoundary { y_m: 0.5, line: LineType::DoubleSolid };
+        assert!(!double.may_cross(0.0, 2.0), "double solid: no crossing");
+    }
+
+    #[test]
+    fn not_crossing_a_line_is_unconstrained() {
+        // Move stays on one side of the line → allowed even for a solid line.
+        let solid = LaneBoundary { y_m: -3.0, line: LineType::Solid };
+        assert!(solid.may_cross(0.0, -1.5), "did not reach the line → OK");
+    }
+
+    #[test]
+    fn combined_line_crosses_from_the_broken_side_only() {
+        // Broken faces +y: a vehicle on the +y side may cross down; the -y side may not.
+        let bl = LaneBoundary { y_m: 0.0, line: LineType::BrokenOnLeft };
+        assert!(bl.may_cross(1.0, -1.0), "+y (broken) side may cross");
+        assert!(!bl.may_cross(-1.0, 1.0), "-y (solid) side may NOT cross");
+        // Mirror image.
+        let br = LaneBoundary { y_m: 0.0, line: LineType::BrokenOnRight };
+        assert!(br.may_cross(-1.0, 1.0), "-y (broken) side may cross");
+        assert!(!br.may_cross(1.0, -1.0), "+y (solid) side may NOT cross");
+    }
+
+    #[test]
+    fn lateral_move_permitted_requires_all_boundaries() {
+        let bounds = [
+            LaneBoundary { y_m: -0.5, line: LineType::Broken },
+            LaneBoundary { y_m: -1.0, line: LineType::Solid },
+        ];
+        // Crossing to -1.5 crosses BOTH; the solid one forbids it.
+        assert!(!lateral_move_permitted(&bounds, 0.0, -1.5));
+        // Crossing only to -0.7 crosses just the broken one → allowed.
+        assert!(lateral_move_permitted(&bounds, 0.0, -0.7));
     }
 }

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -43,7 +43,9 @@ use kirra_ros2_adapter::corridor::{CorridorSource, Point};
 use kirra_runtime_sdk::gateway::containment::MAX_TRAJECTORY_HORIZON;
 
 pub mod behavior;
-pub use behavior::{Behavioral, BehaviorConfig, SignalState, TrafficControl};
+pub use behavior::{
+    Behavioral, BehaviorConfig, LaneBoundary, LineType, SignalState, TrafficControl,
+};
 
 /// What set the binding travel limit `s_limit` — selects the speed/brake policy:
 /// `Lead` matches & follows (rolling gap, no brake-to-zero); `ObjectStop` and
@@ -99,6 +101,10 @@ pub struct PlanInput<'a> {
     /// behavioral/legal layer (distinct from KIRRA's physical authority). An
     /// empty slice = no controls. See [`behavior`].
     pub controls: &'a [TrafficControl],
+    /// Lane-line boundaries (lateral offsets from the path centerline) whose
+    /// crossing rules gate the lateral-avoidance maneuver: Occy will not route
+    /// around an object across a solid line. An empty slice = unconstrained.
+    pub lane_boundaries: &'a [LaneBoundary],
     /// Fleet posture → planner mode (see [`planner_mode`]).
     pub posture: FleetPosture,
 }
@@ -337,6 +343,7 @@ impl GeometricPlanner {
         left: &[Point],
         right: &[Point],
         objects: &[PerceivedObject],
+        lane_boundaries: &[LaneBoundary],
         s_ego: f64,
     ) -> LateralBump {
         let ct = self.cfg.lateral_clearance_target_m;
@@ -366,6 +373,12 @@ impl GeometricPlanner {
         // Offset to the FAR side, minimal magnitude to reach `ct` clearance.
         let y_off = signed - ct * if signed >= 0.0 { 1.0 } else { -1.0 };
         if y_off.abs() > self.cfg.lateral_offset_max_m {
+            return LateralBump::NONE;
+        }
+        // Lane-line rule: never route around across a non-crossable line (e.g. a
+        // solid centerline). The legal constraint is Occy's; the collision shadow
+        // (oncoming traffic) stays KIRRA's. Falls back to stop-short.
+        if !behavior::lateral_move_permitted(lane_boundaries, 0.0, y_off) {
             return LateralBump::NONE;
         }
 
@@ -431,6 +444,7 @@ impl Planner for GeometricPlanner {
             input.map.left_boundary(),
             input.map.right_boundary(),
             input.objects,
+            input.lane_boundaries,
             s_ego,
         );
 
@@ -813,6 +827,7 @@ mod tests {
             map,
             objects: &[],
             controls: &[],
+            lane_boundaries: &[],
             posture: FleetPosture::Nominal,
         }
     }
@@ -879,6 +894,7 @@ mod tests {
             map,
             objects: &[],
             controls: &[],
+            lane_boundaries: &[],
             posture: FleetPosture::Nominal,
         }
     }
@@ -1150,6 +1166,7 @@ mod tests {
             map,
             objects,
             controls: &[],
+            lane_boundaries: &[],
             posture: FleetPosture::Nominal,
         }
     }
@@ -1390,6 +1407,7 @@ mod tests {
             map,
             objects: &[],
             controls,
+            lane_boundaries: &[],
             posture: FleetPosture::Nominal,
         }
     }
@@ -1470,6 +1488,75 @@ mod tests {
         assert!(
             matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
             "checker admits the controlled stop at the line, got {verdict:?}"
+        );
+    }
+
+    // --- Lane-line lateral rules: gating route-around ----------------------
+
+    fn input_objs_lanes<'a>(
+        map: &'a dyn CorridorSource,
+        ego_x: f64,
+        goal_x: f64,
+        objects: &'a [PerceivedObject],
+        lanes: &'a [LaneBoundary],
+    ) -> PlanInput<'a> {
+        PlanInput {
+            ego: EgoState {
+                pose: Pose { x_m: ego_x, y_m: 0.0, heading_rad: 0.0 },
+                linear_x_mps: 2.0,
+                yaw_rate_rads: 0.0,
+                stamp_ms: 0,
+            },
+            goal: Goal { target: Pose { x_m: goal_x, y_m: 0.0, heading_rad: 0.0 } },
+            map,
+            objects,
+            controls: &[],
+            lane_boundaries: lanes,
+            posture: FleetPosture::Nominal,
+        }
+    }
+
+    #[test]
+    fn broken_line_permits_route_around() {
+        // Off-center object + a BROKEN line on the offset side → Occy may cross →
+        // routes around (offsets) and the checker admits it.
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let objs = [obj_at(20.0, 3.0)];
+        let broken = [LaneBoundary { y_m: -0.5, line: LineType::Broken }];
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&input_objs_lanes(&corridor, 8.0, 35.0, &objs, &broken));
+
+        let min_y = out.trajectory.iter().map(|t| t.pose.y_m).fold(0.0, f64::min);
+        assert!(min_y <= -1.0, "broken line → routes around, got min_y {min_y}");
+    }
+
+    #[test]
+    fn solid_line_forbids_route_around_and_kirra_backstops() {
+        // Same object, but a SOLID line on the offset side: Occy must NOT cross it
+        // → no route-around (drives straight). Since it can't legally pass the
+        // obstacle, KIRRA (physical authority) rejects the straight path → the
+        // stack stops. Occy obeys the line; KIRRA enforces the collision safety.
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let objs = [obj_at(20.0, 3.0)];
+        let solid = [LaneBoundary { y_m: -0.5, line: LineType::Solid }];
+        let mut p = GeometricPlanner::default();
+        let out = p.plan(&input_objs_lanes(&corridor, 8.0, 35.0, &objs, &solid));
+
+        let min_y = out.trajectory.iter().map(|t| t.pose.y_m).fold(0.0, f64::min);
+        assert!(min_y > -0.5, "solid line → no route-around (no offset), got min_y {min_y}");
+
+        let verdict = validate_trajectory_slow(
+            &out.trajectory,
+            &corridor,
+            &objs,
+            &VehicleConfig::default_urban(),
+            None,
+            FleetPosture::Nominal,
+        );
+        assert_eq!(
+            verdict,
+            TrajectoryVerdict::MRCFallback,
+            "can't legally pass → KIRRA backstops the straight path, got {verdict:?}"
         );
     }
 }

--- a/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
+++ b/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
@@ -91,6 +91,7 @@ fn run_stack(
         map: &perception.corridor,
         objects: &perception.objects,
         controls: &[],
+        lane_boundaries: &[],
         posture: posture.clone(),
     };
     let mut planner = GeometricPlanner::default();
@@ -179,6 +180,7 @@ fn route_around_in_corridor_object_admits() {
         map: &perception.corridor,
         objects: &perception.objects,
         controls: &[],
+        lane_boundaries: &[],
         posture: FleetPosture::Nominal,
     };
     let mut planner = GeometricPlanner::default();


### PR DESCRIPTION
## Occy lane-line crossing rules — the lateral behavioral analog

The **lateral** counterpart to the longitudinal behavioral layer (#456). Lane markings govern *when you may cross laterally*. Like signs, these are **legal, not physical** — you *can* drive across a solid line; doing so is unlawful, and its collision shadow (oncoming traffic) is still KIRRA's RSS. So the rule lives in **Occy** and gates the lateral-avoidance (route-around) maneuver.

### What's added (`behavior.rs`)
- `LineType` {Broken, Solid, DoubleSolid, BrokenOnLeft, BrokenOnRight} + `LaneBoundary { y_m, line }`.
- `may_cross(from_y, to_y)`: **broken** crosses either way, **solid/double** never, **combined** only from the broken side. `lateral_move_permitted` = all boundaries permit.

### Integration (`lib.rs`)
- `PlanInput` gains `lane_boundaries: &[LaneBoundary]`; `compute_bump` refuses an offset that would cross a non-crossable line → falls back (no illegal swerve).

### The honest end-to-end framing
- **Broken** line on the offset side → Occy routes around → KIRRA admits.
- **Solid** line → Occy must *not* cross → drives straight → and since it can't legally pass the obstacle, **KIRRA (physical authority) rejects the straight path → the stack stops.** Occy obeys the line; KIRRA enforces collision safety — defense in depth.

### Scope
Boundaries are lateral offsets from the path centerline; full typed boundaries with real positions ride on a lane map (the adapter's **Lanelet2** seam — exactly the substrate this needs, as the competitive analysis flagged). This PR is the rule logic + the route-around gate.

### Tests — 65 pass (44 planner + 4 stack + 17 Taj), clippy-clean
4 unit (broken/solid/double, not-crossing-is-free, combined-from-broken-side, all-boundaries-required) + 2 integration (broken permits route-around; solid forbids → KIRRA backstops). Existing tests unchanged (empty `lane_boundaries` = unconstrained).

Robotics-build lane — fenced from the Phase-I proposal. Refs #90, ADR-0015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_