### PR TITLE
feat(occy): unmarked-road keep-right — LineType::Unmarked + implicit two-lane synthesis

### DIFF
--- a/crates/kirra-planner/src/behavior.rs
+++ b/crates/kirra-planner/src/behavior.rs
@@ -243,6 +243,16 @@ pub enum LineType {
     /// Combined with the broken marking facing the -y (right) side: the -y side
     /// may cross; the +y (solid) side may not.
     BrokenOnRight,
+    /// **Unmarked** — no painted line at all (an undivided road / dirt road
+    /// centerline). Crossing is *permitted* either direction (like [`Broken`]),
+    /// because the law does not forbid using the other half to pass when clear.
+    /// The absence of paint does NOT remove the rule of the road, though: the
+    /// **keep-right positional default** is a separate concern, modeled
+    /// structurally by placing the ego's lane on the right half of the road (see
+    /// `lanemap::LaneGraph::from_undivided_corridor`), not by this crossing flag.
+    ///
+    /// [`Broken`]: LineType::Broken
+    Unmarked,
 }
 
 /// A lane boundary at lateral offset `y_m` from the path centerline (+y left).
@@ -264,7 +274,8 @@ impl LaneBoundary {
             return true;
         }
         match self.line {
-            LineType::Broken => true,
+            // Permissive: dashed paint, or no paint at all (undivided road).
+            LineType::Broken | LineType::Unmarked => true,
             LineType::Solid | LineType::DoubleSolid => false,
             // Combined: only the side the broken marking faces may cross.
             LineType::BrokenOnLeft => from_side > 0.0,
@@ -374,6 +385,16 @@ mod tests {
         assert!(!solid.may_cross(0.0, -1.5), "solid: no crossing");
         let double = LaneBoundary { y_m: 0.5, line: LineType::DoubleSolid };
         assert!(!double.may_cross(0.0, 2.0), "double solid: no crossing");
+    }
+
+    #[test]
+    fn unmarked_line_allows_crossing_like_broken() {
+        // No paint (undivided / dirt road centerline) → crossing permitted either
+        // way, same as a broken line. (Keep-right is a positional default handled
+        // elsewhere, not a crossing prohibition.)
+        let unmarked = LaneBoundary { y_m: 0.0, line: LineType::Unmarked };
+        assert!(unmarked.may_cross(-1.0, 1.0), "unmarked: cross left OK");
+        assert!(unmarked.may_cross(1.0, -1.0), "unmarked: cross right OK");
     }
 
     #[test]

--- a/crates/kirra-planner/src/lanemap.rs
+++ b/crates/kirra-planner/src/lanemap.rs
@@ -298,6 +298,63 @@ impl LaneGraph {
         Some(out)
     }
 
+    /// Synthesize a two-lane **undivided** road from a single wide drivable
+    /// `corridor` — the unmarked-road / dirt-road case. On a road with no painted
+    /// centerline, perception ([`kirra_taj`](../../kirra_taj/index.html)) reports
+    /// one wide corridor, and "follow the centerline" would drive the ego **down
+    /// the middle** — wrong, and unsafe w.r.t. oncoming traffic. The US rule of the
+    /// road (keep **right**, UVC §11-301) still applies even with no paint.
+    ///
+    /// This applies that rule **structurally**: split the road at its midline into
+    /// a right-half **ego** lane and a left-half **oncoming** lane, divided by an
+    /// [`LineType::Unmarked`] centerline (crossable — you may use the other half to
+    /// pass when clear). The ego then "keeps right" simply by following its
+    /// synthesized lane's corridor ([`Lane::corridor`]) — no special biasing logic,
+    /// it reuses the same lane-following the marked-road case uses.
+    ///
+    /// **Honest scope:** the *travel direction* of the oncoming lane (it runs the
+    /// opposite way) is not yet encoded — the oncoming lane is marked only
+    /// structurally (the left neighbor). Directionality is needed for the head-on
+    /// RSS check (the oncoming-traffic collision bound) and lands with it.
+    ///
+    /// Returns `None` if the corridor boundaries are empty/degenerate or not a
+    /// `+y`-left / `-y`-right road.
+    #[must_use]
+    pub fn from_undivided_corridor(
+        corridor: &dyn CorridorSource,
+        ego_lane_id: u64,
+        oncoming_lane_id: u64,
+    ) -> Option<Self> {
+        let left = corridor.left_boundary();
+        let right = corridor.right_boundary();
+        if left.len() < 2 || right.len() < 2 {
+            return None;
+        }
+        let left_y = mean_y_of(left);
+        let right_y = mean_y_of(right);
+        if left_y <= right_y {
+            return None; // not a +y-left / -y-right road
+        }
+        let (x0, x1) = x_extent(left, right)?;
+        let mid = 0.5 * (left_y + right_y);
+        let lane_half = 0.25 * (left_y - right_y); // a quarter of the total width
+        let ego_c = 0.5 * (mid + right_y); // center of the right half
+        let onc_c = 0.5 * (left_y + mid); // center of the left half
+
+        let mut g = LaneGraph::new();
+        // Ego (right half): unmarked centerline on the LEFT, road edge on the right.
+        g.add_lane(
+            Lane::straight(ego_lane_id, ego_c, x0, x1, lane_half, LineType::Unmarked, LineType::Solid)
+                .with_edge(LaneEdge::LeftNeighbor { to: oncoming_lane_id }),
+        );
+        // Oncoming (left half): road edge on the left, unmarked centerline on the right.
+        g.add_lane(
+            Lane::straight(oncoming_lane_id, onc_c, x0, x1, lane_half, LineType::Solid, LineType::Unmarked)
+                .with_edge(LaneEdge::RightNeighbor { to: ego_lane_id }),
+        );
+        Some(g)
+    }
+
     /// Resolve a slice of ids to lane refs, or `None` if any is missing/empty.
     fn resolve(&self, lane_ids: &[u64]) -> Option<Vec<&Lane>> {
         if lane_ids.is_empty() {
@@ -305,6 +362,19 @@ impl LaneGraph {
         }
         lane_ids.iter().map(|id| self.lanes.get(id)).collect()
     }
+}
+
+/// Mean lateral position of a boundary polyline.
+fn mean_y_of(pts: &[Point]) -> f64 {
+    pts.iter().map(|p| p.y_m).sum::<f64>() / pts.len() as f64
+}
+
+/// Longitudinal `[x_min, x_max]` spanned by two boundary polylines, or `None` if
+/// degenerate (non-finite or zero length).
+fn x_extent(a: &[Point], b: &[Point]) -> Option<(f64, f64)> {
+    let x0 = a.iter().chain(b).map(|p| p.x_m).fold(f64::INFINITY, f64::min);
+    let x1 = a.iter().chain(b).map(|p| p.x_m).fold(f64::NEG_INFINITY, f64::max);
+    (x0.is_finite() && x1.is_finite() && x1 > x0).then_some((x0, x1))
 }
 
 /// Offset a centerline polyline laterally by `signed_offset` (>0 = +y/left side)
@@ -414,6 +484,70 @@ mod tests {
         assert!(g.corridor_over(&[1, 99], 0.95, 10).is_none());
         assert!(g.boundaries_relative_to(1, &[]).is_none());
         assert!(g.boundaries_relative_to(99, &[1]).is_none());
+    }
+
+    #[test]
+    fn undivided_corridor_synthesizes_keep_right_split() {
+        use kirra_ros2_adapter::corridor::MockCorridorSource;
+        // A 10 m-wide undivided road (±5). Keep-right split → ego on the right half.
+        let road = MockCorridorSource::straight_5m_half_width(100.0);
+        let g = LaneGraph::from_undivided_corridor(&road, 1, 2).expect("synthesize");
+        let ego = g.lane(1).unwrap();
+        let onc = g.lane(2).unwrap();
+        // Each synthesized lane is a quarter-width half-lane (2.5 m), centered in
+        // its half: ego at -2.5 (right), oncoming at +2.5 (left).
+        assert!((ego.centerline[0].y_m + 2.5).abs() < 1e-9, "ego keeps right (-2.5)");
+        assert!((onc.centerline[0].y_m - 2.5).abs() < 1e-9, "oncoming is the left half (+2.5)");
+        assert!((ego.half_width_m - 2.5).abs() < 1e-9);
+        // The shared centerline is UNMARKED (crossable to pass), road edges SOLID.
+        assert_eq!(ego.left_line, LineType::Unmarked, "ego↔oncoming divider unmarked");
+        assert_eq!(ego.right_line, LineType::Solid, "right road edge");
+        assert_eq!(onc.right_line, LineType::Unmarked);
+        assert_eq!(ego.left_neighbor(), Some(2));
+    }
+
+    #[test]
+    fn ego_lane_corridor_keeps_right_of_the_road_center() {
+        use kirra_ros2_adapter::corridor::{CorridorSource, MockCorridorSource};
+        let road = MockCorridorSource::straight_5m_half_width(100.0);
+        let g = LaneGraph::from_undivided_corridor(&road, 1, 2).unwrap();
+        let ego = g.lane(1).unwrap().corridor(0.95, 10);
+        // The ego-lane corridor spans the RIGHT half: [-5, 0], never crossing the
+        // road center into the +y (oncoming) half.
+        for p in ego.left_boundary().iter().chain(ego.right_boundary()) {
+            assert!(p.y_m <= 1e-9, "ego lane stays right of center, got y={}", p.y_m);
+        }
+        assert!((ego.left_boundary()[0].y_m).abs() < 1e-9, "left edge at the road center (0)");
+        assert!((ego.right_boundary()[0].y_m + 5.0).abs() < 1e-9, "right edge at the road edge (-5)");
+    }
+
+    #[test]
+    fn degenerate_corridor_fails_closed() {
+        // An inline source whose boundaries are flipped (left below right) — not a
+        // valid +y-left / -y-right road → synthesis fails closed (None).
+        struct FlippedSource {
+            left: Vec<Point>,
+            right: Vec<Point>,
+        }
+        impl CorridorSource for FlippedSource {
+            fn left_boundary(&self) -> &[Point] {
+                &self.left
+            }
+            fn right_boundary(&self) -> &[Point] {
+                &self.right
+            }
+            fn confidence(&self) -> f32 {
+                0.9
+            }
+            fn age_ms(&self) -> u64 {
+                5
+            }
+        }
+        let flipped = FlippedSource {
+            left: vec![Point { x_m: 0.0, y_m: -5.0 }, Point { x_m: 50.0, y_m: -5.0 }],
+            right: vec![Point { x_m: 0.0, y_m: 5.0 }, Point { x_m: 50.0, y_m: 5.0 }],
+        };
+        assert!(LaneGraph::from_undivided_corridor(&flipped, 1, 2).is_none());
     }
 
     #[test]

--- a/crates/kirra-planner/tests/unmarked_road_keep_right.rs
+++ b/crates/kirra-planner/tests/unmarked_road_keep_right.rs
@@ -1,0 +1,79 @@
+//! End-to-end: **unmarked road → keep-right → Occy → KIRRA**.
+//!
+//! On a road with no painted centerline (an undivided two-lane road, or a dirt
+//! road) perception reports **one wide drivable corridor**. Following that
+//! corridor's centerline would drive the ego **down the middle** — wrong, and
+//! unsafe w.r.t. oncoming traffic. The US rule of the road (keep **right**) still
+//! applies with no paint on the ground.
+//!
+//! This proves the substrate applies keep-right **structurally**:
+//! [`LaneGraph::from_undivided_corridor`] splits the wide road into a right-half
+//! ego lane and a left-half oncoming lane (divided by an unmarked, crossable
+//! centerline), and the ego "keeps right" simply by following its synthesized
+//! lane. The contrast test shows the divergence: naive centering drives the
+//! middle; the keep-right derivation drives the right half — and KIRRA admits it.
+
+use kirra_planner::{
+    EgoState, FleetPosture, GeometricPlanner, Goal, LaneGraph, PlanInput, Planner, Pose,
+    TrajectoryVerdict,
+};
+use kirra_ros2_adapter::corridor::{CorridorSource, MockCorridorSource};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+/// Plan straight ahead along `map`, ego starting on the road center (y=0), and
+/// return the most-rightward (min) `y` the path reaches + KIRRA's verdict.
+fn drive(map: &dyn CorridorSource) -> (f64, TrajectoryVerdict) {
+    let input = PlanInput {
+        ego: EgoState {
+            pose: Pose { x_m: 5.0, y_m: 0.0, heading_rad: 0.0 },
+            linear_x_mps: 2.0,
+            yaw_rate_rads: 0.0,
+            stamp_ms: 0,
+        },
+        goal: Goal { target: Pose { x_m: 40.0, y_m: 0.0, heading_rad: 0.0 } },
+        map,
+        objects: &[],
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        lane_change_to_m: None,
+        posture: FleetPosture::Nominal,
+    };
+    let mut planner = GeometricPlanner::default();
+    let plan = planner.plan(&input);
+    let verdict = validate_trajectory_slow(
+        &plan.trajectory,
+        map,
+        &[],
+        &VehicleConfig::default_urban(),
+        None,
+        FleetPosture::Nominal,
+    );
+    let min_y = plan.trajectory.iter().map(|t| t.pose.y_m).fold(0.0, f64::min);
+    (min_y, verdict)
+}
+
+#[test]
+fn keep_right_drives_the_right_half_not_the_middle() {
+    // One wide (±5) undivided road — no centerline paint.
+    let road = MockCorridorSource::straight_5m_half_width(100.0);
+
+    // Naive: follow the wide corridor directly → drives down the MIDDLE (y≈0).
+    let (naive_min_y, naive_verdict) = drive(&road);
+    assert!(naive_min_y > -0.5, "naive centering drives the middle, got min_y {naive_min_y}");
+    assert!(matches!(naive_verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp));
+
+    // Keep-right: synthesize the two-lane split and follow the EGO (right) lane.
+    let g = LaneGraph::from_undivided_corridor(&road, 1, 2).expect("synthesize undivided road");
+    let ego_lane = g.lane(1).unwrap().corridor(0.95, 10);
+    let (kr_min_y, kr_verdict) = drive(&ego_lane);
+    assert!(kr_min_y <= -2.0, "keep-right drives the right half, got min_y {kr_min_y}");
+    assert!(
+        matches!(kr_verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "KIRRA admits the keep-right plan, got {kr_verdict:?}"
+    );
+
+    // The point: same road, the keep-right derivation sits a full half-lane right
+    // of the naive one.
+    assert!(kr_min_y < naive_min_y - 1.5, "keep-right is meaningfully right of center");
+}


### PR DESCRIPTION
## What

Handles the **no-centerline road** — an undivided two-lane road, or a dirt road — where perception reports **one wide drivable corridor**. Following that corridor's centerline would drive the ego **down the middle**: wrong, and unsafe w.r.t. oncoming traffic. "No paint" is not "no rule" — the US **keep-right** default (UVC §11-301) still binds.

Two parts, each consistent with the existing doctrine (behavioral/legal rules live in Occy; KIRRA owns the physical collision bound):

- **`LineType::Unmarked`** (`behavior.rs`) — an unmarked centerline. Crossing is **permitted** either way (like `Broken` — you may use the other half to pass when clear). Keep-right is *not* a crossing prohibition, so it's modeled separately (structurally), not by this flag.
- **`LaneGraph::from_undivided_corridor`** (`lanemap.rs`) — applies keep-right **structurally**: split the wide road at its midline into a right-half **ego** lane and a left-half **oncoming** lane, divided by an `Unmarked` (crossable) centerline. The ego then keeps right simply by *following its synthesized lane's corridor* — reusing the marked-road lane-following from #463, with **no special biasing logic**.

## End-to-end proof

`tests/unmarked_road_keep_right.rs`: on the same wide (±5) undivided road, **naive centering drives the middle (y≈0)** while the **keep-right derivation drives the right half (y≈−2.5)** — a full half-lane to the right — and KIRRA admits it. The contrast makes the value explicit: the synthesis *is* the keep-right logic.

## Honest scope

The oncoming lane's **travel direction** (it runs the opposite way) is not yet encoded — it's marked only structurally (the left neighbor). Directionality is needed for the **head-on / oncoming RSS check**, which is the real safety bound on an overtake against oncoming traffic. That check does not exist yet: KIRRA's longitudinal RSS is a **same-direction-only primitive** by explicit contract (`parko-core/src/rss.rs:141`, tracked #408 Obs 3 — *"oncoming-actor geometry is out of scope … must be handled by a dedicated formula"*). It lands with the directionality, as the next piece in this arc.

This is piece 1 of the unmarked/oncoming two-lane arc: **(1) keep-right ← this PR**, (2) directionality + overtake-across-the-unmarked-center, (3) head-on RSS in KIRRA.

## Tests

- +1 `behavior` unit test (`Unmarked` crosses like `Broken`).
- +3 `lanemap` unit tests (keep-right split geometry, ego-lane stays right of center, degenerate corridor fails closed).
- +1 end-to-end test (keep-right vs naive centering).
- Full `kirra-planner` + `kirra-taj` suites green; `kirra-planner` clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_