### PR TITLE
style(ros2-adapter): fix pre-existing doc-comment clippy lints

### DIFF
--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -425,7 +425,8 @@ fn adapter_to_kernel_pose(p: &Pose) -> KernelPose {
 ///     (the FIRST segment passes the odom-derived estimate; subsequent
 ///     segments pass the prior segment's commanded steering)
 ///   - `steering_angle_deg`         = bicycle-model approx:
-///        steering = atan2(δheading * wheelbase, velocity * δt) → degrees
+///     steering = atan2(δheading * wheelbase, velocity * δt) → degrees
+///
 /// The bicycle-model approximation matches the kernel's P6 (lateral-accel)
 /// model and is the canonical pose-pair → steering-angle conversion.
 /// Field names match `ProposedVehicleCommand` exactly (Step 0).


### PR DESCRIPTION
## What

Clears the 4 pre-existing clippy doc-formatting warnings in `kirra-ros2-adapter` (the ones that have been showing up as `kirra-ros2-adapter (lib) generated 4 warnings` on recent PR clippy runs). They're all in one rustdoc comment above `pose_pair_to_command` (`validation.rs`):

- **`doc_overindented_list_items`** — the wrapped `steering = atan2(…)` continuation of the `- steering_angle_deg` bullet was indented 9 spaces; re-indented to 4.
- **`doc-list-item-without-indentation` ×3** — the three trailing bicycle-model prose lines sat directly after the bulleted list with no separator, so clippy read them as malformed list continuations; added a blank `///` line so they render as their own paragraph.

## Why

Newer clippy (rust 1.96) started flagging these; they predate this work and appear on `main`. Documentation-only — no behavioral or correctness change. `cargo clippy -p kirra-ros2-adapter` is now clean; full adapter test suite green (37+5+8+14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_