### PR TITLE
feat(adapter): head-on RSS in validate_trajectory_slow (direction-aware longitudinal bound)

### DIFF
--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -25,7 +25,7 @@ use kirra_runtime_sdk::gateway::kinematics_contract::{
 };
 use kirra_runtime_sdk::verifier::FleetPosture;
 use parko_core::rss::{
-    lateral_safe_distance, longitudinal_safe_distance,
+    lateral_safe_distance, longitudinal_safe_distance, opposite_direction_safe_distance,
 };
 
 use crate::config::VehicleConfig;
@@ -267,15 +267,35 @@ pub fn validate_trajectory_slow_capped(
                 continue;
             }
 
-            // Longitudinal RSS — required forward gap.
-            let lon_required = longitudinal_safe_distance(
-                traj_point.velocity_mps,
-                obj.velocity_mps,
-                RSS_REACTION_TIME_S,
-                config.max_accel_mps2,
-                config.max_decel_mps2,
-                config.max_decel_mps2,
-            );
+            // Longitudinal RSS — required forward gap. Direction matters: an
+            // ONCOMING vehicle (heading opposes the ego, so its velocity projects
+            // backward onto the ego's forward axis) is a HEAD-ON closure, not a
+            // same-direction lead. Routing it through the same-direction primitive
+            // would discard the closing sign and UNDER-estimate the gap (#408 Obs
+            // 3); the opposite-direction bound (sum of both stopping distances)
+            // applies instead.
+            let obj_lon_v =
+                obj.velocity_mps * (obj.heading_rad - traj_point.pose.heading_rad).cos();
+            let lon_required = if obj_lon_v < 0.0 {
+                // Closing magnitudes; symmetric brake_min (both in their own lanes).
+                opposite_direction_safe_distance(
+                    traj_point.velocity_mps,
+                    obj_lon_v.abs(),
+                    RSS_REACTION_TIME_S,
+                    config.max_accel_mps2,
+                    config.max_decel_mps2,
+                    config.max_decel_mps2,
+                )
+            } else {
+                longitudinal_safe_distance(
+                    traj_point.velocity_mps,
+                    obj.velocity_mps,
+                    RSS_REACTION_TIME_S,
+                    config.max_accel_mps2,
+                    config.max_decel_mps2,
+                    config.max_decel_mps2,
+                )
+            };
             if dx_ego < lon_required {
                 return TrajectoryVerdict::MRCFallback;
             }

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -114,6 +114,60 @@ fn test_rss_violation_rejects() {
 }
 
 // ---------------------------------------------------------------------------
+// 3b. Head-on (oncoming) RSS — direction flips the verdict at the same gap
+// ---------------------------------------------------------------------------
+
+/// A vehicle ~15 m ahead at 12 m/s, evaluated two ways at IDENTICAL geometry:
+/// as a same-direction lead (pulling away → safe) and as oncoming (head-on
+/// closure → the opposite-direction bound needs ~40 m → MRC). Proves the
+/// adapter checker now keys the *longitudinal* bound off the object's heading.
+///
+/// The object sits at y = 3 m — laterally offset enough to clear the lateral RSS
+/// side-gap (so a dead-ahead lateral violation can't be the cause) yet inside the
+/// 4 m alignment tolerance (so it is still evaluated longitudinally). Heading is
+/// then the ONLY thing that differs between the two cases.
+fn obj_at(x_m: f64, velocity_mps: f64, heading_rad: f64) -> PerceivedObject {
+    PerceivedObject {
+        id: 1,
+        pos: Point { x_m, y_m: 3.0 },
+        velocity_mps,
+        heading_rad,
+        vel: Point { x_m: 0.0, y_m: 0.0 },
+    }
+}
+
+#[test]
+fn oncoming_vehicle_triggers_head_on_rss_mrc() {
+    let trajectory = straight_trajectory(5, 8.0, 0.1); // poses x≈5..8.2
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    // Heading π → opposing travel → head-on closure at |8 + 12| effective.
+    let objects = vec![obj_at(20.0, 12.0, std::f64::consts::PI)];
+    let verdict = validate_trajectory_slow(
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal,
+    );
+    assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
+        "an oncoming vehicle ~15 m ahead must trigger the head-on bound; got {verdict:?}");
+}
+
+#[test]
+fn same_direction_lead_at_identical_gap_is_admitted() {
+    let trajectory = straight_trajectory(5, 8.0, 0.1);
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    // Same position/speed but heading 0 → a same-direction lead pulling away
+    // (12 > ego 8) → near-zero required gap → admitted. Only the heading differs.
+    let objects = vec![obj_at(20.0, 12.0, 0.0)];
+    let verdict = validate_trajectory_slow(
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal,
+    );
+    assert!(
+        matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "a same-direction lead at the same gap is admitted (direction is the only change); got {verdict:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // 4. Kinematics DenyBreach → MRCFallback
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

First of two PRs for the overtake maneuver. This is the **safety-critical, self-contained** half: the Occy-stack checker now bounds **oncoming** traffic with the head-on RSS, so KIRRA can refuse an unsafe head-on closure (the "refuse" half a real overtake needs).

`validate_trajectory_slow` ran *every* object through the same-direction `longitudinal_safe_distance`, passing the scalar `velocity_mps` and **discarding the object's heading**. An oncoming vehicle was mis-checked as a same-direction lead → under-estimated gap (#408 Obs 3). Now it keys off direction:

- Project the object's velocity onto the ego's forward axis (`velocity_mps * cos(obj_heading − pose_heading)`).
- **Closing (negative)** → `opposite_direction_safe_distance` (#467, sum of both stopping distances), symmetric `brake_min`.
- **Same direction** → the existing primitive, **byte-for-byte unchanged**.

This mirrors the parko-kirra scene-level wiring (#468) on the adapter's own per-pose RSS loop — which is the path the Occy stack actually exercises.

## Tests

+2, isolating **direction** as the only variable: an object ~15 m ahead at 12 m/s, placed at y=3 so the *lateral* RSS side-gap passes (a dead-ahead object would trip lateral RSS and mask the result) while staying inside the 4 m alignment tolerance so it's still evaluated longitudinally.
- `heading 0` (same-direction lead pulling away) → **admitted**.
- `heading π` (oncoming) → **MRCFallback** (head-on needs ~40 m vs the ~15 m gap).

Full adapter suite (37+5+8+16) and the Occy stack (#460 etc.) green.

## Next

PR 2 will add the `PlanInput` reference-path/drivable-area decoupling + `compute_overtake_bump` + the end-to-end demo (overtake admitted with no oncoming; refused when oncoming is too close — using *this* PR's head-on bound). Note: an unrelated pre-existing `unused import: DerateCode` warning in `perception_ingest.rs` is untouched here (different file, not introduced by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_