### PR TITLE
feat(occy): active overtake into oncoming lane + PlanInput drivable-area decoupling

### DIFF
--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -130,6 +130,20 @@ pub struct PlanInput<'a> {
     /// lane-line rules permit crossing to that side and the corridor fits;
     /// otherwise the planner stays in lane. `None` = no lane change.
     pub lane_change_to_m: Option<f64>,
+    /// Object ids that must **NOT be passed** — chiefly a **stopped school bus**
+    /// actively loading/unloading (red lights flashing, stop arm extended). US law
+    /// (MUTCD §7D; every state's stop-for-school-bus statute) requires traffic to
+    /// **stop and not overtake** such a bus — on an undivided road in *both*
+    /// directions. This is a **LEGAL** constraint, so it lives in Occy's behavioral
+    /// layer, not KIRRA: passing a bus is not a *collision*, so the physical
+    /// governor never enforces it (cf. running a red light). The integrator /
+    /// perception flags the id; Occy then refuses any route-around or overtake of
+    /// it and holds behind it (stop-short). An empty slice = no such restriction.
+    ///
+    /// Scope (honest): this gates the *pass*; resuming when the bus's lights clear
+    /// is the integrator dropping the id. The divided-highway exception (oncoming
+    /// traffic may proceed past a median) is not modeled — fail-safe is to stop.
+    pub no_overtake_ids: &'a [u64],
     /// Optional **drivable area** distinct from the reference corridor `map` — the
     /// wider space an **overtake** may briefly borrow (e.g. the full undivided road
     /// when `map` is just the ego lane). `map` stays the reference the path follows
@@ -393,6 +407,7 @@ impl GeometricPlanner {
     /// IF the offset both fits the corridor (with footprint + margin) and has room
     /// to ramp in before the object. Otherwise [`LateralBump::NONE`] (the caller
     /// then stops short instead — never an unsafe squeeze).
+    #[allow(clippy::too_many_arguments)]
     fn compute_bump(
         &self,
         guide: &[(f64, f64)],
@@ -400,6 +415,7 @@ impl GeometricPlanner {
         right: &[Point],
         objects: &[PerceivedObject],
         lane_boundaries: &[LaneBoundary],
+        no_overtake: &[u64],
         s_ego: f64,
     ) -> LateralBump {
         let ct = self.cfg.lateral_clearance_target_m;
@@ -408,6 +424,11 @@ impl GeometricPlanner {
         // A moving LEAD is followed (speed-matched), not routed around — skip it.
         let mut best: Option<(f64, f64, f64)> = None; // (s_obj, signed_lateral, obj_x)
         for obj in objects {
+            // A no-pass object (stopped school bus) is never routed around — the
+            // ego must hold behind it (the per-object stop-short does that).
+            if no_overtake.contains(&obj.id) {
+                continue;
+            }
             let (s_obj, signed) = project_signed(guide, obj.pos.x_m, obj.pos.y_m);
             if s_obj <= s_ego || signed.abs() >= ct {
                 continue;
@@ -469,6 +490,7 @@ impl GeometricPlanner {
     /// the pass exposes — KIRRA's head-on RSS is the sole authority on whether the
     /// oncoming lane is clear enough (the doer-checker split). A moving lead is
     /// followed (speed-matched), never overtaken here.
+    #[allow(clippy::too_many_arguments)]
     fn compute_overtake_bump(
         &self,
         guide: &[(f64, f64)],
@@ -476,12 +498,18 @@ impl GeometricPlanner {
         right: &[Point],
         objects: &[PerceivedObject],
         lane_boundaries: &[LaneBoundary],
+        no_overtake: &[u64],
         s_ego: f64,
     ) -> LateralBump {
         let band = self.cfg.object_lane_tolerance_m;
         // Nearest stopped/slow object ahead and IN our lane (a pass candidate).
         let mut best: Option<(f64, f64)> = None; // (s_obj, signed)
         for obj in objects {
+            // A stopped school bus (or any flagged no-pass object) is NEVER
+            // overtaken — it is illegal. Hold behind it (stop-short) instead.
+            if no_overtake.contains(&obj.id) {
+                continue;
+            }
             let (s_obj, signed) = project_signed(guide, obj.pos.x_m, obj.pos.y_m);
             if s_obj <= s_ego || signed.abs() > band {
                 continue;
@@ -677,6 +705,7 @@ impl Planner for GeometricPlanner {
                     input.map.right_boundary(),
                     input.objects,
                     input.lane_boundaries,
+                    input.no_overtake_ids,
                     s_ego,
                 );
                 match input.drivable {
@@ -686,6 +715,7 @@ impl Planner for GeometricPlanner {
                         drivable.right_boundary(),
                         input.objects,
                         input.lane_boundaries,
+                        input.no_overtake_ids,
                         s_ego,
                     ),
                     _ => within,
@@ -1088,6 +1118,7 @@ mod tests {
             lane_boundaries: &[],
             motion: &[],
             lane_change_to_m: None,
+            no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
         }
@@ -1158,6 +1189,7 @@ mod tests {
             lane_boundaries: &[],
             motion: &[],
             lane_change_to_m: None,
+            no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
         }
@@ -1433,6 +1465,7 @@ mod tests {
             lane_boundaries: &[],
             motion: &[],
             lane_change_to_m: None,
+            no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
         }
@@ -1677,6 +1710,7 @@ mod tests {
             lane_boundaries: &[],
             motion: &[],
             lane_change_to_m: None,
+            no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
         }
@@ -1784,6 +1818,7 @@ mod tests {
             lane_boundaries: lanes,
             motion: &[],
             lane_change_to_m: None,
+            no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
         }
@@ -1956,6 +1991,7 @@ mod tests {
             lane_boundaries: lanes,
             motion: &[],
             lane_change_to_m: Some(target),
+            no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
         }

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -130,6 +130,16 @@ pub struct PlanInput<'a> {
     /// lane-line rules permit crossing to that side and the corridor fits;
     /// otherwise the planner stays in lane. `None` = no lane change.
     pub lane_change_to_m: Option<f64>,
+    /// Optional **drivable area** distinct from the reference corridor `map` — the
+    /// wider space an **overtake** may briefly borrow (e.g. the full undivided road
+    /// when `map` is just the ego lane). `map` stays the reference the path follows
+    /// and within-lane route-arounds fit; `drivable`, when present, is the extra
+    /// area a cross-centerline pass may use. `None` → no overtake is attempted and
+    /// behavior is identical to before (the reference corridor is the only space).
+    /// This is the planner-side of Autoware's *reference-path vs drivable-area*
+    /// split; the integrator must pass the SAME corridor to the checker so KIRRA
+    /// independently bounds the oncoming traffic the pass exposes (head-on RSS).
+    pub drivable: Option<&'a dyn CorridorSource>,
     /// Fleet posture → planner mode (see [`planner_mode`]).
     pub posture: FleetPosture,
 }
@@ -309,6 +319,14 @@ pub struct GeometricPlannerConfig {
     pub prediction_lane_half_m: f64,
     /// Min object speed to treat it as a moving "crosser" worth predicting.
     pub crossing_speed_threshold_mps: f64,
+    /// Cap on the lateral offset an **overtake** will take (a pass legitimately
+    /// crosses a full lane, so this exceeds `lateral_offset_max_m`). The overtake
+    /// reuses `lateral_clearance_target_m` for the pass clearance: that clearance
+    /// must exceed the checker's 4 m lateral-alignment band so the passed object is
+    /// RSS-filtered (#451) — which is also why a *narrow* road can't admit a pass
+    /// (>4 m clearance won't fit one oncoming lane). The DRIVABLE corridor fit is
+    /// the real bound; this is a sanity ceiling.
+    pub overtake_offset_max_m: f64,
 }
 
 impl Default for GeometricPlannerConfig {
@@ -337,6 +355,7 @@ impl Default for GeometricPlannerConfig {
             prediction_dt_s: 0.2,
             prediction_lane_half_m: 2.0,
             crossing_speed_threshold_mps: 0.5,
+            overtake_offset_max_m: 7.0,
         }
     }
 }
@@ -432,6 +451,87 @@ impl GeometricPlanner {
         let hold_half = 1.0;
         let hold_start = (s_obj - s_ego) - hold_half;
         if hold_start - ramp_len < 0.0 {
+            return LateralBump::NONE;
+        }
+        LateralBump { y_off, ramp_len, hold_start, hold_end: (s_obj - s_ego) + hold_half }
+    }
+
+    /// **Overtake** a stopped / slow in-lane object by crossing **left** (the
+    /// lawful pass side on a right-driving road) into the adjacent lane, holding
+    /// alongside, then returning — a route-around bump, but it specifically passes
+    /// on the left across a *crossable* centerline, uses a tight object-relative
+    /// clearance (vehicle + gap, not the wide roadside berth), and fits the
+    /// **drivable** area (the full road), not just the reference lane. Returns
+    /// `NONE` (→ stop short) unless the lane line permits the left crossing AND the
+    /// offset path + footprint stays inside `left`/`right` (the drivable boundaries).
+    ///
+    /// This is what Occy *proposes*; it never reasons about the oncoming traffic
+    /// the pass exposes — KIRRA's head-on RSS is the sole authority on whether the
+    /// oncoming lane is clear enough (the doer-checker split). A moving lead is
+    /// followed (speed-matched), never overtaken here.
+    fn compute_overtake_bump(
+        &self,
+        guide: &[(f64, f64)],
+        left: &[Point],
+        right: &[Point],
+        objects: &[PerceivedObject],
+        lane_boundaries: &[LaneBoundary],
+        s_ego: f64,
+    ) -> LateralBump {
+        let band = self.cfg.object_lane_tolerance_m;
+        // Nearest stopped/slow object ahead and IN our lane (a pass candidate).
+        let mut best: Option<(f64, f64)> = None; // (s_obj, signed)
+        for obj in objects {
+            let (s_obj, signed) = project_signed(guide, obj.pos.x_m, obj.pos.y_m);
+            if s_obj <= s_ego || signed.abs() > band {
+                continue;
+            }
+            let h = heading_at(guide, s_obj);
+            let lon_v = obj.vel.x_m * h.cos() + obj.vel.y_m * h.sin();
+            if lon_v > self.cfg.lead_speed_threshold_mps {
+                continue; // a moving lead → follow, don't overtake
+            }
+            if best.is_none_or(|(bs, _)| s_obj < bs) {
+                best = Some((s_obj, signed));
+            }
+        }
+        let (s_obj, signed) = match best {
+            Some(v) => v,
+            None => return LateralBump::NONE,
+        };
+
+        // Pass on the LEFT (+y): path goes to the object's left by the clearance
+        // target. It must exceed the checker's 4 m lateral band so the passed
+        // object is RSS-filtered (#451) — the same berth a within-lane route-around
+        // uses, here taken across the centerline into the drivable area.
+        let clearance = self.cfg.lateral_clearance_target_m;
+        let y_off = signed + clearance;
+        if y_off <= 0.0 || y_off.abs() > self.cfg.overtake_offset_max_m {
+            return LateralBump::NONE;
+        }
+        // Lane-line rule: the centerline must be crossable to the left.
+        if !behavior::lateral_move_permitted(lane_boundaries, 0.0, y_off) {
+            return LateralBump::NONE;
+        }
+        // Drivable fit at the object, GUIDE-relative: the path follows the guide
+        // (the ego lane), offset by `y_off`, and must stay inside the drivable area.
+        let (gx, gy) = point_at(guide, s_obj);
+        let path_y = gy + y_off;
+        let fh = self.cfg.vehicle_half_width_m + self.cfg.containment_margin_m;
+        if path_y + fh > boundary_y_at(left, gx) || path_y - fh < boundary_y_at(right, gx) {
+            return LateralBump::NONE;
+        }
+        // Commit EARLY: ramp from the ego over the whole run-up to the object, so
+        // the lateral clearance has cleared the checker's 4 m band BEFORE the ego
+        // closes within its longitudinal gap. A late, slope-fixed ramp (as the
+        // within-lane route-around uses) would still be sweeping through the band at
+        // close range and KIRRA would MRC the pass. Hold alongside; the return ramp
+        // runs past the horizon (a later cycle completes it — receding-horizon).
+        let hold_half = 1.5;
+        let hold_start = (s_obj - s_ego) - hold_half;
+        let ramp_len = hold_start; // start the lateral move at the ego (up0 = 0)
+        // Reject if the run-up is too short for a gentle (in-envelope) ramp.
+        if ramp_len < y_off.abs() / self.cfg.lateral_ramp_slope.max(1e-3) {
             return LateralBump::NONE;
         }
         LateralBump { y_off, ramp_len, hold_start, hold_end: (s_obj - s_ego) + hold_half }
@@ -566,14 +666,31 @@ impl Planner for GeometricPlanner {
                     s_ego,
                 )
                 .unwrap_or(LateralBump::NONE),
-            None => self.compute_bump(
-                &guide,
-                input.map.left_boundary(),
-                input.map.right_boundary(),
-                input.objects,
-                input.lane_boundaries,
-                s_ego,
-            ),
+            None => {
+                // Within-lane route-around first (stays inside the reference
+                // corridor). If that can't clear the object AND the integrator has
+                // supplied a wider drivable area (an undivided road's full width),
+                // try an overtake that crosses the centerline into it.
+                let within = self.compute_bump(
+                    &guide,
+                    input.map.left_boundary(),
+                    input.map.right_boundary(),
+                    input.objects,
+                    input.lane_boundaries,
+                    s_ego,
+                );
+                match input.drivable {
+                    Some(drivable) if within.y_off == 0.0 => self.compute_overtake_bump(
+                        &guide,
+                        drivable.left_boundary(),
+                        drivable.right_boundary(),
+                        input.objects,
+                        input.lane_boundaries,
+                        s_ego,
+                    ),
+                    _ => within,
+                }
+            }
         };
 
         // Per-object handling, nearest-binding:
@@ -971,6 +1088,7 @@ mod tests {
             lane_boundaries: &[],
             motion: &[],
             lane_change_to_m: None,
+            drivable: None,
             posture: FleetPosture::Nominal,
         }
     }
@@ -1040,6 +1158,7 @@ mod tests {
             lane_boundaries: &[],
             motion: &[],
             lane_change_to_m: None,
+            drivable: None,
             posture: FleetPosture::Nominal,
         }
     }
@@ -1314,6 +1433,7 @@ mod tests {
             lane_boundaries: &[],
             motion: &[],
             lane_change_to_m: None,
+            drivable: None,
             posture: FleetPosture::Nominal,
         }
     }
@@ -1557,6 +1677,7 @@ mod tests {
             lane_boundaries: &[],
             motion: &[],
             lane_change_to_m: None,
+            drivable: None,
             posture: FleetPosture::Nominal,
         }
     }
@@ -1663,6 +1784,7 @@ mod tests {
             lane_boundaries: lanes,
             motion: &[],
             lane_change_to_m: None,
+            drivable: None,
             posture: FleetPosture::Nominal,
         }
     }
@@ -1834,6 +1956,7 @@ mod tests {
             lane_boundaries: lanes,
             motion: &[],
             lane_change_to_m: Some(target),
+            drivable: None,
             posture: FleetPosture::Nominal,
         }
     }

--- a/crates/kirra-planner/tests/lane_graph_to_occy.rs
+++ b/crates/kirra-planner/tests/lane_graph_to_occy.rs
@@ -74,6 +74,7 @@ fn lane_change_across_broken_divider_admits() {
         lane_boundaries: &boundaries,
         motion: &[],
         lane_change_to_m: Some(-3.5),
+        no_overtake_ids: &[],
         drivable: None,
         posture: FleetPosture::Nominal,
     };
@@ -119,6 +120,7 @@ fn lane_change_across_solid_divider_is_refused() {
         lane_boundaries: &boundaries,
         motion: &[],
         lane_change_to_m: Some(3.5),
+        no_overtake_ids: &[],
         drivable: None,
         posture: FleetPosture::Nominal,
     };

--- a/crates/kirra-planner/tests/lane_graph_to_occy.rs
+++ b/crates/kirra-planner/tests/lane_graph_to_occy.rs
@@ -74,6 +74,7 @@ fn lane_change_across_broken_divider_admits() {
         lane_boundaries: &boundaries,
         motion: &[],
         lane_change_to_m: Some(-3.5),
+        drivable: None,
         posture: FleetPosture::Nominal,
     };
     let mut planner = GeometricPlanner::default();
@@ -118,6 +119,7 @@ fn lane_change_across_solid_divider_is_refused() {
         lane_boundaries: &boundaries,
         motion: &[],
         lane_change_to_m: Some(3.5),
+        drivable: None,
         posture: FleetPosture::Nominal,
     };
     let mut planner = GeometricPlanner::default();

--- a/crates/kirra-planner/tests/overtake_oncoming.rs
+++ b/crates/kirra-planner/tests/overtake_oncoming.rs
@@ -1,0 +1,178 @@
+//! End-to-end: **overtake into the oncoming lane → Occy → KIRRA**.
+//!
+//! The sharpest form of the doer-checker split. On an undivided road, Occy passes
+//! a stopped car by crossing the (crossable) centerline into the oncoming lane and
+//! returning — but it never reasons about the oncoming traffic that pass exposes.
+//! **KIRRA's head-on RSS is the sole authority** on whether the oncoming lane is
+//! clear enough. Occy proposes the pass; KIRRA admits it on a clear road and
+//! refuses it when an oncoming vehicle is too close.
+//!
+//! This also exercises the `PlanInput` reference-path vs drivable-area decoupling:
+//! `map` is the ego LANE (the path Occy follows, keep-right) while `drivable` is
+//! the FULL road (the area a pass may borrow). The same `drivable` corridor is
+//! handed to KIRRA so its containment + RSS see the whole road.
+
+use kirra_planner::{
+    EgoState, FleetPosture, GeometricPlanner, Goal, Lane, LaneCorridor, LaneEdge, LaneGraph,
+    LineType, PerceivedObject, PlanInput, Planner, Pose, ProposalKind, TrajectoryVerdict,
+};
+use kirra_ros2_adapter::corridor::{CorridorSource, Point};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+const LEN: f64 = 200.0;
+
+/// A wide undivided road: ego (right) lane center y=-2.5 half 2.5 → spans [-5, 0];
+/// oncoming (left) lane center y=+2.5 half 2.5 → [0, +5], travelling the opposite
+/// way (heading π). `center` is the centerline marking between them.
+fn road(center: LineType) -> LaneGraph {
+    LaneGraph::new()
+        .with_lane(
+            Lane::straight(1, -2.5, 0.0, LEN, 2.5, center, LineType::Solid)
+                .with_edge(LaneEdge::LeftNeighbor { to: 2 }),
+        )
+        .with_lane(
+            Lane::straight(2, 2.5, 0.0, LEN, 2.5, LineType::Solid, center)
+                .with_heading(std::f64::consts::PI)
+                .with_edge(LaneEdge::RightNeighbor { to: 1 }),
+        )
+}
+
+fn ego_corridor(g: &LaneGraph) -> LaneCorridor {
+    g.lane(1).unwrap().corridor(0.95, 5)
+}
+fn full_road(g: &LaneGraph) -> LaneCorridor {
+    g.corridor_over(&[1, 2], 0.95, 5).unwrap()
+}
+
+/// A stopped car in the ego lane, positioned to the right of the lane centerline
+/// (near the road's right edge) so the left pass needs a modest offset.
+fn stopped_car(x_m: f64) -> PerceivedObject {
+    PerceivedObject {
+        id: 1,
+        pos: Point { x_m, y_m: -4.4 },
+        velocity_mps: 0.0,
+        heading_rad: 0.0,
+        vel: Point { x_m: 0.0, y_m: 0.0 },
+    }
+}
+
+/// An oncoming vehicle in the oncoming lane closing on the ego (heading π).
+fn oncoming_car(x_m: f64, speed: f64) -> PerceivedObject {
+    PerceivedObject {
+        id: 2,
+        pos: Point { x_m, y_m: 2.0 },
+        velocity_mps: speed,
+        heading_rad: std::f64::consts::PI,
+        vel: Point { x_m: -speed, y_m: 0.0 },
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn plan_and_check(
+    g: &LaneGraph,
+    map: &dyn CorridorSource,
+    drivable: &dyn CorridorSource,
+    objects: &[PerceivedObject],
+    with_drivable: bool,
+) -> (kirra_planner::PlanOutput, TrajectoryVerdict) {
+    let boundaries = g.boundaries_relative_to(1, &[1, 2]).unwrap();
+    let input = PlanInput {
+        ego: EgoState {
+            pose: Pose { x_m: 6.0, y_m: -2.5, heading_rad: 0.0 },
+            linear_x_mps: 2.0,
+            yaw_rate_rads: 0.0,
+            stamp_ms: 0,
+        },
+        goal: Goal { target: Pose { x_m: 60.0, y_m: -2.5, heading_rad: 0.0 } },
+        map,
+        objects,
+        controls: &[],
+        lane_boundaries: &boundaries,
+        motion: &[],
+        lane_change_to_m: None,
+        drivable: with_drivable.then_some(drivable),
+        posture: FleetPosture::Nominal,
+    };
+    let mut planner = GeometricPlanner::default();
+    let plan = planner.plan(&input);
+    let verdict = validate_trajectory_slow(
+        &plan.trajectory, drivable, objects, &VehicleConfig::default_urban(), None,
+        FleetPosture::Nominal,
+    );
+    (plan, verdict)
+}
+
+#[test]
+fn occy_proposes_an_overtake_across_the_crossable_centerline() {
+    let g = road(LineType::Unmarked);
+    let (map, drivable) = (ego_corridor(&g), full_road(&g));
+    let cars = [stopped_car(24.0)];
+    let (plan, _) = plan_and_check(&g, &map, &drivable, &cars, true);
+
+    assert_eq!(plan.kind, ProposalKind::Motion, "Occy moves to pass, not stops");
+    let max_y = plan.trajectory.iter().map(|t| t.pose.y_m).fold(f64::MIN, f64::max);
+    assert!(max_y > 0.0, "the pass crosses into the oncoming half, got max_y {max_y}");
+}
+
+#[test]
+fn solid_centerline_forbids_the_overtake() {
+    let g = road(LineType::Solid);
+    let (map, drivable) = (ego_corridor(&g), full_road(&g));
+    let cars = [stopped_car(24.0)];
+    let (plan, _) = plan_and_check(&g, &map, &drivable, &cars, true);
+
+    let max_y = plan.trajectory.iter().map(|t| t.pose.y_m).fold(f64::MIN, f64::max);
+    assert!(max_y <= 0.0, "a solid centerline → no pass into oncoming, got max_y {max_y}");
+}
+
+#[test]
+fn no_drivable_area_means_no_overtake() {
+    let g = road(LineType::Unmarked);
+    let (map, drivable) = (ego_corridor(&g), full_road(&g));
+    let cars = [stopped_car(24.0)];
+    // drivable not provided → opt-out → prior behavior (no cross-centerline pass).
+    let (plan, _) = plan_and_check(&g, &map, &drivable, &cars, false);
+
+    let max_y = plan.trajectory.iter().map(|t| t.pose.y_m).fold(f64::MIN, f64::max);
+    assert!(max_y <= 0.0, "without a drivable area Occy does not overtake, got max_y {max_y}");
+}
+
+#[test]
+fn kirra_admits_the_pass_when_the_oncoming_lane_is_clear() {
+    let g = road(LineType::Unmarked);
+    let (map, drivable) = (ego_corridor(&g), full_road(&g));
+    let cars = [stopped_car(24.0)];
+    let (_, verdict) = plan_and_check(&g, &map, &drivable, &cars, true);
+
+    assert!(
+        matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "a clear oncoming lane → KIRRA admits the pass, got {verdict:?}"
+    );
+}
+
+#[test]
+fn kirra_refuses_the_pass_when_oncoming_traffic_is_too_close() {
+    // Identical to the admitted clear-pass scene, plus a closing oncoming vehicle in
+    // the oncoming lane. Occy still proposes the pass (it never reasons about
+    // oncoming); KIRRA refuses. Because the clear case ABOVE admits, the added
+    // oncoming vehicle is the cause — and the checker evaluates the longitudinal
+    // (head-on, opposite-direction) bound FIRST, which fires on the closing
+    // vehicle (~31 m required vs the dozen-metre gap). The checker, not the
+    // planner, owns the decision.
+    //
+    // (Direction-isolation — that the *oncoming* heading specifically is what
+    // triggers the head-on bound vs. a same-direction lead — is proven cleanly at
+    // the checker unit level in the adapter's `validation_tests` (#469); here it is
+    // confounded by the adapter's conservative *lateral* RSS, which MRCs any fast
+    // adjacent-lane vehicle during the angled ramp regardless of direction — a
+    // tracked over-conservatism, COMPETITIVE_PLANNER_ANALYSIS §4.)
+    let g = road(LineType::Unmarked);
+    let (map, drivable) = (ego_corridor(&g), full_road(&g));
+    let cars = [stopped_car(24.0), oncoming_car(38.0, 12.0)];
+    let (_, verdict) = plan_and_check(&g, &map, &drivable, &cars, true);
+
+    assert_eq!(
+        verdict, TrajectoryVerdict::MRCFallback,
+        "oncoming traffic too close → KIRRA refuses the pass, got {verdict:?}"
+    );
+}

--- a/crates/kirra-planner/tests/overtake_oncoming.rs
+++ b/crates/kirra-planner/tests/overtake_oncoming.rs
@@ -90,6 +90,7 @@ fn plan_and_check(
         lane_boundaries: &boundaries,
         motion: &[],
         lane_change_to_m: None,
+        no_overtake_ids: &[],
         drivable: with_drivable.then_some(drivable),
         posture: FleetPosture::Nominal,
     };
@@ -174,5 +175,52 @@ fn kirra_refuses_the_pass_when_oncoming_traffic_is_too_close() {
     assert_eq!(
         verdict, TrajectoryVerdict::MRCFallback,
         "oncoming traffic too close → KIRRA refuses the pass, got {verdict:?}"
+    );
+}
+
+#[test]
+fn a_stopped_school_bus_is_never_overtaken_and_the_ego_holds_behind_it() {
+    // Identical to `occy_proposes_an_overtake...` (which DOES pass the same object),
+    // but the stopped object is flagged a school bus loading children (`no_overtake_
+    // ids`). It is ILLEGAL to pass — so Occy must NOT cross into the oncoming lane
+    // and must hold behind it, even though the centerline is crossable and the pass
+    // is otherwise admissible. The legal rule lives in Occy; KIRRA never enforces it.
+    let g = road(LineType::Unmarked);
+    let (map, drivable) = (ego_corridor(&g), full_road(&g));
+    let boundaries = g.boundaries_relative_to(1, &[1, 2]).unwrap();
+    let bus = stopped_car(24.0); // id == 1
+    let cars = [bus];
+
+    let input = PlanInput {
+        ego: EgoState {
+            pose: Pose { x_m: 6.0, y_m: -2.5, heading_rad: 0.0 },
+            linear_x_mps: 2.0,
+            yaw_rate_rads: 0.0,
+            stamp_ms: 0,
+        },
+        goal: Goal { target: Pose { x_m: 60.0, y_m: -2.5, heading_rad: 0.0 } },
+        map: &map,
+        objects: &cars,
+        controls: &[],
+        lane_boundaries: &boundaries,
+        motion: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[1], // the bus
+        drivable: Some(&drivable),
+        posture: FleetPosture::Nominal,
+    };
+    let mut planner = GeometricPlanner::default();
+    let plan = planner.plan(&input);
+
+    let max_y = plan.trajectory.iter().map(|t| t.pose.y_m).fold(f64::MIN, f64::max);
+    assert!(max_y <= 0.0, "school bus → no pass into oncoming, got max_y {max_y}");
+    // And it HOLDS behind: a controlled decel-to-stop short of the bus (id 1 at
+    // x=24, stop gap 5 → stop ~x=19), never reaching/passing it. (The full stop
+    // completes over the receding horizon; here it is still decelerating in.)
+    let max_x = plan.trajectory.iter().map(|t| t.pose.x_m).fold(f64::MIN, f64::max);
+    assert!(max_x < 20.0, "ego stays behind the bus's stop line, got max_x {max_x}");
+    assert!(
+        plan.trajectory.last().unwrap().velocity_mps <= 2.0,
+        "approaching at the slow object-approach speed (decel-to-stop), not cruising"
     );
 }

--- a/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
+++ b/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
@@ -94,6 +94,7 @@ fn run_stack(
         lane_boundaries: &[],
         motion: &[],
         lane_change_to_m: None,
+        no_overtake_ids: &[],
         drivable: None,
         posture: posture.clone(),
     };
@@ -186,6 +187,7 @@ fn route_around_in_corridor_object_admits() {
         lane_boundaries: &[],
         motion: &[],
         lane_change_to_m: None,
+        no_overtake_ids: &[],
         drivable: None,
         posture: FleetPosture::Nominal,
     };

--- a/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
+++ b/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
@@ -94,6 +94,7 @@ fn run_stack(
         lane_boundaries: &[],
         motion: &[],
         lane_change_to_m: None,
+        drivable: None,
         posture: posture.clone(),
     };
     let mut planner = GeometricPlanner::default();
@@ -185,6 +186,7 @@ fn route_around_in_corridor_object_admits() {
         lane_boundaries: &[],
         motion: &[],
         lane_change_to_m: None,
+        drivable: None,
         posture: FleetPosture::Nominal,
     };
     let mut planner = GeometricPlanner::default();

--- a/crates/kirra-planner/tests/unmarked_road_keep_right.rs
+++ b/crates/kirra-planner/tests/unmarked_road_keep_right.rs
@@ -37,6 +37,7 @@ fn drive(map: &dyn CorridorSource) -> (f64, TrajectoryVerdict) {
         lane_boundaries: &[],
         motion: &[],
         lane_change_to_m: None,
+        drivable: None,
         posture: FleetPosture::Nominal,
     };
     let mut planner = GeometricPlanner::default();

--- a/crates/kirra-planner/tests/unmarked_road_keep_right.rs
+++ b/crates/kirra-planner/tests/unmarked_road_keep_right.rs
@@ -37,6 +37,7 @@ fn drive(map: &dyn CorridorSource) -> (f64, TrajectoryVerdict) {
         lane_boundaries: &[],
         motion: &[],
         lane_change_to_m: None,
+        no_overtake_ids: &[],
         drivable: None,
         posture: FleetPosture::Nominal,
     };

--- a/docs/COMPETITIVE_PLANNER_ANALYSIS.md
+++ b/docs/COMPETITIVE_PLANNER_ANALYSIS.md
@@ -85,10 +85,19 @@ an NVIDIA-style planner as the doer.**
 
 A *too-strict checker + too-simple planner* is **over-conservative**. We hit it
 repeatedly: a dead-ahead lead → MRC (the lateral-RSS floor); an abreast pass →
-reject. In dense traffic, Occy + KIRRA-as-tuned-today would stop too often.
-Mobileye avoids this by pairing RSS with a *sophisticated* policy **and**
-carefully-tuned RSS parameters. So a real improvement axis is **both** smartening
-Occy *and* tuning KIRRA's RSS conservatism — not just one.
+reject. The **overtake** build sharpened it twice more: (a) a car *centered* in the
+ego lane can't be passed at all — the adapter's lateral RSS (≈1.75 m, independent of
+longitudinal distance) MRCs any in-lane-ahead vehicle, so a pass is admissible only
+for a car already near the lane edge; (b) during the *angled* ramp of a pass, the
+lateral RSS treats any **fast adjacent-lane** vehicle as a lateral threat (the path
+heading projects the other car's speed into a closing lateral component), so it MRCs
+oncoming *and* same-direction traffic alike — which is why the overtake demo's
+direction-isolation lives at the checker unit level (#469), not in the trajectory.
+In dense traffic, Occy + KIRRA-as-tuned-today would stop too often. Mobileye avoids
+this by pairing RSS with a *sophisticated* policy **and** carefully-tuned RSS
+parameters. So a real improvement axis is **both** smartening Occy *and* tuning
+KIRRA's RSS conservatism (especially the lateral band's lack of longitudinal
+context) — not just one.
 
 ## 5. Recommended roadmap (in Kirra's grain)
 
@@ -101,7 +110,13 @@ Occy *and* tuning KIRRA's RSS conservatism — not just one.
 2. **Prediction** — even constant-turn-rate / intention priors beat
    constant-velocity.
 3. **Trajectory optimization** — jerk-limited / comfort, replacing the trapezoid.
-4. **Lateral behaviors** — lane-change / merge / overtake decisions.
+4. **Lateral behaviors** — lane-change / merge / overtake decisions. **Done
+   (overtake):** the `PlanInput` reference-path vs drivable-area split +
+   `compute_overtake_bump` let Occy *propose* a cross-centerline pass into the
+   oncoming lane (gated by lane-line type + drivable fit); KIRRA's head-on RSS
+   governs the oncoming risk. **Remaining:** merge / unprotected-turn negotiation,
+   and the §4 RSS-tuning needed for passes to be admitted as routinely as they are
+   proposed.
 5. **The strategic one** — prove KIRRA bounds a **learned planner**: swap a
    NVIDIA / Hydra-MDP-style net in as the doer and show the safety case is
    *unchanged*. That is the Kirra thesis's killer demo, and it is why Occy's


### PR DESCRIPTION
## What

The final piece of the unmarked/oncoming arc (PR 2 of 2). Occy can now **actively pass a stopped/slow in-lane car by crossing a crossable centerline into the oncoming lane** and returning — and **KIRRA governs the oncoming risk**. This is the doer-checker split at its sharpest: Occy *proposes* the pass; KIRRA *bounds* it.

### The decoupling (Autoware's reference-path vs drivable-area, which Occy lacked)

- **`PlanInput.drivable: Option<&dyn CorridorSource>`** — the wider area a pass may borrow (the full undivided road), distinct from `map` (the ego lane Occy follows, keep-right). `None` → **byte-for-byte prior behavior**; overtaking is **opt-in**, gated on the integrator supplying the drivable area. The integrator passes the *same* corridor to the checker so KIRRA's containment + RSS see the whole road.

### The maneuver

- **`GeometricPlanner::compute_overtake_bump`** — passes **left** (the lawful side) across a crossable centerline, fits the **drivable** boundaries (guide-relative), and **commits early** (ramps from the ego) so the lateral clearance has cleared the checker's 4 m band *before* the ego closes within its longitudinal gap. `plan()` tries the within-lane route-around first, then this overtake when it can't clear the object and a drivable area is supplied.

### School-bus exception (legal no-pass)

- **`PlanInput.no_overtake_ids: &[u64]`** — it is **illegal to pass a stopped school bus** loading/unloading (MUTCD §7D; every state's stop-for-school-bus statute). A LEGAL constraint → it lives in Occy's behavioral layer, **not KIRRA** (passing a bus is not a *collision*, cf. running a red light). Both `compute_bump` and `compute_overtake_bump` skip a flagged object → the ego **holds behind it** even where the centerline is crossable and a pass would otherwise be admissible. Divided-highway exception not modeled (fail-safe = stop).

## Tests (`tests/overtake_oncoming.rs`, scene built from the lane substrate)

- Occy **proposes the pass** (path crosses into the oncoming half);
- a **SOLID** centerline forbids it; **no `drivable`** → no overtake (opt-in gate);
- KIRRA **admits** the pass when the oncoming lane is clear;
- KIRRA **refuses** it when an oncoming vehicle is closing (added vehicle flips an otherwise-admitted scene; head-on longitudinal evaluated first);
- a **flagged school bus** at the exact spot Occy *would* pass → **holds behind it** (no crossing into oncoming).

## Honest findings (COMPETITIVE_PLANNER_ANALYSIS §4, updated)

The build sharpened the known over-conservatism twice: **(a)** a car *centered* in the ego lane can't be passed at all — the adapter's lateral RSS (~1.75 m, no longitudinal context) MRCs any in-lane-ahead vehicle, so a pass is admissible only for a car near the lane edge (hence the demo geometry); **(b)** during the *angled* ramp, the lateral RSS treats any **fast adjacent-lane** vehicle as a closing lateral threat and MRCs oncoming *and* same-direction alike — so the head-on **direction-isolation is proven at the checker unit level (#469)**, not in this trajectory. Tuning the checker's lateral band (give it longitudinal context) is the tracked §4 next axis.

## Safety / compat

`drivable` and `no_overtake_ids` default to none → the 67 existing planner tests pass unchanged. Full `kirra-planner` + `kirra-taj` suites green; `kirra-planner` clippy clean.

Arc complete: keep-right #464 · directionality #466 · head-on primitive #467 · scene-wiring #468 · adapter head-on #469 · **overtake + decoupling + school-bus exception ← this PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58