### PR TITLE
fix(rss): gate lateral RSS on longitudinal proximity (the RSS conjunction)

### DIFF
--- a/crates/kirra-planner/tests/overtake_oncoming.rs
+++ b/crates/kirra-planner/tests/overtake_oncoming.rs
@@ -156,17 +156,9 @@ fn kirra_refuses_the_pass_when_oncoming_traffic_is_too_close() {
     // Identical to the admitted clear-pass scene, plus a closing oncoming vehicle in
     // the oncoming lane. Occy still proposes the pass (it never reasons about
     // oncoming); KIRRA refuses. Because the clear case ABOVE admits, the added
-    // oncoming vehicle is the cause — and the checker evaluates the longitudinal
-    // (head-on, opposite-direction) bound FIRST, which fires on the closing
-    // vehicle (~31 m required vs the dozen-metre gap). The checker, not the
-    // planner, owns the decision.
-    //
-    // (Direction-isolation — that the *oncoming* heading specifically is what
-    // triggers the head-on bound vs. a same-direction lead — is proven cleanly at
-    // the checker unit level in the adapter's `validation_tests` (#469); here it is
-    // confounded by the adapter's conservative *lateral* RSS, which MRCs any fast
-    // adjacent-lane vehicle during the angled ramp regardless of direction — a
-    // tracked over-conservatism, COMPETITIVE_PLANNER_ANALYSIS §4.)
+    // oncoming vehicle is the cause — the checker's head-on (opposite-direction)
+    // longitudinal bound fires on the closing vehicle (~31 m required vs the
+    // dozen-metre gap). The checker, not the planner, owns the decision.
     let g = road(LineType::Unmarked);
     let (map, drivable) = (ego_corridor(&g), full_road(&g));
     let cars = [stopped_car(24.0), oncoming_car(38.0, 12.0)];
@@ -175,6 +167,36 @@ fn kirra_refuses_the_pass_when_oncoming_traffic_is_too_close() {
     assert_eq!(
         verdict, TrajectoryVerdict::MRCFallback,
         "oncoming traffic too close → KIRRA refuses the pass, got {verdict:?}"
+    );
+}
+
+#[test]
+fn a_same_direction_vehicle_at_the_same_spot_does_not_block_the_pass() {
+    // The clean direction-isolation control, now possible thanks to the §4
+    // lateral-RSS longitudinal gate: a vehicle at the EXACT spot the oncoming one
+    // occupied, but travelling the SAME direction (heading 0, pulling away). It is
+    // longitudinally safe (a receding lead) and — being >8 m ahead — no longer
+    // trips the (now longitudinally-gated) lateral RSS. KIRRA ADMITS. So the
+    // refusal above is the oncoming DIRECTION (the head-on bound), not merely "a
+    // vehicle is present in the pass corridor". (Before the gate, the adapter's
+    // lateral RSS MRC'd this fast adjacent vehicle during the angled ramp too,
+    // masking the result — COMPETITIVE_PLANNER_ANALYSIS §4.)
+    let g = road(LineType::Unmarked);
+    let (map, drivable) = (ego_corridor(&g), full_road(&g));
+    let same_dir = PerceivedObject {
+        id: 2,
+        pos: Point { x_m: 38.0, y_m: 2.0 },
+        velocity_mps: 12.0,
+        heading_rad: 0.0, // same direction, faster → a lead pulling away
+        vel: Point { x_m: 12.0, y_m: 0.0 },
+    };
+    let cars = [stopped_car(24.0), same_dir];
+    let (_, verdict) = plan_and_check(&g, &map, &drivable, &cars, true);
+
+    assert!(
+        matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "a same-direction vehicle at the same spot is admitted; only the oncoming \
+         direction refuses, got {verdict:?}"
     );
 }
 

--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -26,6 +26,7 @@ use kirra_runtime_sdk::gateway::kinematics_contract::{
 use kirra_runtime_sdk::verifier::FleetPosture;
 use parko_core::rss::{
     lateral_safe_distance, longitudinal_safe_distance, opposite_direction_safe_distance,
+    RSS_LONGITUDINAL_CONFLICT_M,
 };
 
 use crate::config::VehicleConfig;
@@ -300,24 +301,30 @@ pub fn validate_trajectory_slow_capped(
                 return TrajectoryVerdict::MRCFallback;
             }
 
-            // Lateral RSS — required side gap. Use the object's
-            // lateral velocity component as the lateral-vel input.
-            // (Phase 2A: assume objects' lateral velocity = 0 if
-            // PerceivedObject does not carry per-axis velocity. The
-            // longitudinal check is the dominant risk; lateral RSS is
-            // defence in depth against an object cutting in.)
-            let obj_lat_vel = obj.velocity_mps * (obj.heading_rad - traj_point.pose.heading_rad).sin();
-            let ego_lat_vel = 0.0; // straight-following assumption per
-                                   // §3 (the per-pose Pose.heading
-                                   // captures any planned curvature).
-            let lat_required = lateral_safe_distance(
-                ego_lat_vel,
-                obj_lat_vel,
-                kinematics.max_lateral_accel_mps2,
-                RSS_REACTION_TIME_S,
-            );
-            if dy_ego.abs() < lat_required {
-                return TrajectoryVerdict::MRCFallback;
+            // Lateral RSS — required side gap. Defence-in-depth against an object
+            // cutting in beside the ego (the longitudinal check above is the
+            // dominant risk). RSS-GATED ON LONGITUDINAL PROXIMITY: a lateral
+            // shortfall is only dangerous when the object is also longitudinally
+            // close (within `RSS_LONGITUDINAL_CONFLICT_M`) — two vehicles cannot
+            // collide laterally unless they are alongside or imminently so. Without
+            // this gate the check over-rejected a lead well ahead, or oncoming
+            // traffic safely passing in the next lane (COMPETITIVE_PLANNER_ANALYSIS
+            // §4): both are longitudinally distant, so a lateral shortfall there is
+            // not a collision risk. (Object lateral velocity is the component along
+            // the pose normal — Phase 2A assumes 0 if perception lacks per-axis vel.)
+            if dx_ego <= RSS_LONGITUDINAL_CONFLICT_M {
+                let obj_lat_vel =
+                    obj.velocity_mps * (obj.heading_rad - traj_point.pose.heading_rad).sin();
+                let ego_lat_vel = 0.0; // straight-following assumption per §3
+                let lat_required = lateral_safe_distance(
+                    ego_lat_vel,
+                    obj_lat_vel,
+                    kinematics.max_lateral_accel_mps2,
+                    RSS_REACTION_TIME_S,
+                );
+                if dy_ego.abs() < lat_required {
+                    return TrajectoryVerdict::MRCFallback;
+                }
             }
         }
     }

--- a/docs/COMPETITIVE_PLANNER_ANALYSIS.md
+++ b/docs/COMPETITIVE_PLANNER_ANALYSIS.md
@@ -85,19 +85,29 @@ an NVIDIA-style planner as the doer.**
 
 A *too-strict checker + too-simple planner* is **over-conservative**. We hit it
 repeatedly: a dead-ahead lead → MRC (the lateral-RSS floor); an abreast pass →
-reject. The **overtake** build sharpened it twice more: (a) a car *centered* in the
-ego lane can't be passed at all — the adapter's lateral RSS (≈1.75 m, independent of
-longitudinal distance) MRCs any in-lane-ahead vehicle, so a pass is admissible only
-for a car already near the lane edge; (b) during the *angled* ramp of a pass, the
-lateral RSS treats any **fast adjacent-lane** vehicle as a lateral threat (the path
-heading projects the other car's speed into a closing lateral component), so it MRCs
-oncoming *and* same-direction traffic alike — which is why the overtake demo's
-direction-isolation lives at the checker unit level (#469), not in the trajectory.
-In dense traffic, Occy + KIRRA-as-tuned-today would stop too often. Mobileye avoids
-this by pairing RSS with a *sophisticated* policy **and** carefully-tuned RSS
-parameters. So a real improvement axis is **both** smartening Occy *and* tuning
-KIRRA's RSS conservatism (especially the lateral band's lack of longitudinal
-context) — not just one.
+reject. The **overtake** build sharpened the lateral-RSS half of it: during the
+*angled* ramp of a pass the lateral RSS treated any **fast adjacent-lane** vehicle
+as a lateral threat (the path heading projects the other car's speed into a closing
+lateral component), MRC-ing oncoming *and* same-direction traffic alike.
+
+**Addressed (lateral RSS, longitudinal gate):** the root cause was that the lateral
+safe-distance bound danger *independently* of longitudinal distance, but RSS
+(IEEE 2846 §5; Shalev-Shwartz et al.) defines a dangerous state as the
+**conjunction** — two vehicles cannot collide laterally unless also longitudinally
+close. Both checkers (`validate_trajectory_slow`, `compute_scene_rss`) now **gate**
+the lateral defence-in-depth on `RSS_LONGITUDINAL_CONFLICT_M` (8 m): a lateral
+shortfall is dangerous only when the object is alongside/imminent, so a lead well
+ahead and oncoming traffic safely passing in the next lane no longer trip it (the
+overtake demo's direction-isolation control now passes at the trajectory level, not
+just the #469 unit level). The dominant longitudinal RSS — car-following / head-on —
+is unchanged, and the lateral layer still fails closed for a genuine cut-in.
+
+**Remaining:** the longitudinal/alignment half — a car *centered* in the ego lane
+still can't be passed, because clearing the checker's 4 m lateral-alignment band
+needs >4 m of side room (a pass is admissible only for a car near the lane edge or
+on a wide road). And in dense traffic, smartening Occy's policy is the orthogonal
+axis. Mobileye pairs RSS with a *sophisticated* policy **and** carefully-tuned RSS
+parameters — both levers, not one.
 
 ## 5. Recommended roadmap (in Kirra's grain)
 

--- a/parko/crates/parko-core/src/rss.rs
+++ b/parko/crates/parko-core/src/rss.rs
@@ -23,6 +23,28 @@ pub struct RssState {
 /// return this large finite distance — the governor will clamp or stop.
 pub const RSS_FAILSAFE_DISTANCE_M: f64 = 1.0e6;
 
+/// Longitudinal half-window (metres) within which a **lateral** RSS shortfall is
+/// treated as a genuine conflict by the trajectory/scene checkers.
+///
+/// RSS (Shalev-Shwartz et al.; IEEE 2846-2022 §5) defines a *dangerous* state as
+/// the **conjunction** of an unsafe longitudinal AND an unsafe lateral distance —
+/// two vehicles cannot collide laterally unless they are also longitudinally
+/// close (alongside or imminently so). A checker that flags a lateral shortfall
+/// for an object that is longitudinally FAR (a lead well ahead, or oncoming
+/// traffic safely passing in the next lane) is therefore over-conservative: it
+/// rejects motions RSS deems safe.
+///
+/// The checkers keep the lateral safe-distance as a fail-closed *defence-in-depth*
+/// layer (catching a cut-in beside the ego), but **gate** it on this longitudinal
+/// proximity: a lateral shortfall is dangerous only when the object is within
+/// `RSS_LONGITUDINAL_CONFLICT_M` longitudinally. The value is deliberately
+/// conservative — a passenger-vehicle length plus a reaction-time closing buffer —
+/// so an imminent cut-in is still caught while distant traffic no longer trips it.
+///
+/// (The dominant longitudinal RSS — car-following / head-on — is UNCHANGED and
+/// fully governs any object that is longitudinally unsafe at any range.)
+pub const RSS_LONGITUDINAL_CONFLICT_M: f64 = 8.0;
+
 #[inline]
 fn finite_positive(x: f64) -> bool {
     x.is_finite() && x > 0.0

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -47,7 +47,7 @@ use kirra_runtime_sdk::verifier::FleetPosture;
 use parko_core::commands::ControlCommand;
 use parko_core::rss::{
     lateral_safe_distance, longitudinal_safe_distance, occlusion_limited_speed,
-    opposite_direction_safe_distance,
+    opposite_direction_safe_distance, RSS_LONGITUDINAL_CONFLICT_M,
 };
 use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
 use parko_core::{
@@ -236,8 +236,21 @@ pub fn compute_scene_rss(scene: &AgentScene, params: &RssParams) -> RssState {
         // are false); a non-finite agent VELOCITY drove `required_*` to the
         // 1e6 failsafe, so a realistic finite actual gap is `< required` → the
         // pair is unsafe. Either way the agent is evaluated, never skipped.
-        let pair_safe = a.actual_longitudinal_gap_m >= required_long
-            && a.actual_lateral_separation_m >= required_lat;
+        let lon_safe = a.actual_longitudinal_gap_m >= required_long;
+        // Lateral defence-in-depth is GATED on longitudinal proximity (the RSS
+        // conjunction): a lateral shortfall is dangerous only when the object is
+        // also longitudinally close. A lead well ahead / oncoming traffic safely
+        // passing in the next lane is longitudinally distant, so its lateral gap
+        // does not bound safety (it over-rejected before — §4). Fail-closed first:
+        // a non-finite separation is never "safe", regardless of range.
+        let lat_safe = if !a.actual_lateral_separation_m.is_finite() {
+            false
+        } else if a.actual_longitudinal_gap_m > RSS_LONGITUDINAL_CONFLICT_M {
+            true
+        } else {
+            a.actual_lateral_separation_m >= required_lat
+        };
+        let pair_safe = lon_safe && lat_safe;
         if !pair_safe {
             all_safe = false;
         }
@@ -1657,6 +1670,12 @@ mod scene_rss_tests {
 
     fn lat_unsafe_agent() -> RssAgent {
         RssAgent {
+            // Stationary longitudinally (tiny required gap) and CLOSE — within
+            // RSS_LONGITUDINAL_CONFLICT_M — so the lateral shortfall is a genuine
+            // alongside conflict, not a distant object the gate now ignores.
+            ego_vel: 0.0,
+            lead_vel: 0.0,
+            actual_longitudinal_gap_m: 4.0,
             ego_lat_vel: 2.0,
             obj_lat_vel: 2.0,
             actual_lateral_separation_m: 0.0,
@@ -1744,6 +1763,24 @@ mod scene_rss_tests {
     fn lateral_axis_is_evaluated() {
         let scene = AgentScene::Agents(vec![lat_unsafe_agent()]);
         assert!(!compute_scene_rss(&scene, &params()).safe, "lateral violation must be caught");
+    }
+
+    /// The lateral defence-in-depth is GATED on longitudinal proximity (the RSS
+    /// conjunction, §4): the SAME lateral shortfall that is unsafe when the object
+    /// is alongside is SAFE when it is longitudinally far — two vehicles cannot
+    /// collide laterally unless also longitudinally close. Before the gate this
+    /// over-rejected a lead well ahead / oncoming traffic in the next lane.
+    #[test]
+    fn a_distant_lateral_shortfall_is_not_a_conflict() {
+        // Same lateral shortfall as `lat_unsafe_agent`, but longitudinally FAR
+        // (well beyond RSS_LONGITUDINAL_CONFLICT_M) → longitudinally safe → not
+        // dangerous.
+        let far = RssAgent { actual_longitudinal_gap_m: 50.0, ..lat_unsafe_agent() };
+        assert!(compute_scene_rss(&AgentScene::Agents(vec![far]), &params()).safe,
+            "a lateral shortfall 50 m ahead is not a collision risk (RSS conjunction)");
+        // Control: the SAME shortfall when alongside is still caught.
+        assert!(!compute_scene_rss(&AgentScene::Agents(vec![lat_unsafe_agent()]), &params()).safe,
+            "the shortfall WHEN ALONGSIDE is still caught (defence-in-depth intact)");
     }
 
     // --- NaN / non-finite → failsafe → unsafe (agent evaluated, not skipped) ---


### PR DESCRIPTION
## What

Tunes the **lateral RSS over-conservatism** flagged in COMPETITIVE_PLANNER_ANALYSIS §4 — the first checker-side (not planner-side) safety improvement in this arc.

Both trajectory/scene checkers (`validate_trajectory_slow`, `compute_scene_rss`) flagged a **lateral** safe-distance shortfall as dangerous *independently of longitudinal distance* — so a lead well ahead, or oncoming traffic safely passing in the next lane, was MRC'd purely on side gap. That is stricter than RSS: the formal model (IEEE 2846 §5; Shalev-Shwartz et al.) defines a dangerous state as the **conjunction** — two vehicles can't collide laterally unless they're also longitudinally close.

## The change (longitudinal gate, not full AND)

Keeps the lateral safe-distance as a fail-closed **defence-in-depth** layer (a genuine cut-in beside the ego is still caught) but **gates** it on longitudinal proximity:

- **`parko_core::rss::RSS_LONGITUDINAL_CONFLICT_M` (8 m)** — single source of truth; a vehicle length + reaction-time closing buffer.
- **adapter:** the lateral block runs only when `dx_ego <= RSS_LONGITUDINAL_CONFLICT_M`.
- **parko-kirra:** lateral bounds safety only when the actual longitudinal gap is within the band — **fail-closed first** on a non-finite separation (NaN never reads as safe; preserves the documented behavior).

The dominant **longitudinal** RSS (car-following / head-on, #467/#469) is **unchanged** and still governs any longitudinally-unsafe object at any range. The 4 m lateral-*alignment* band (the centered-overtake half of §4) is deliberately **not** touched — separate lever.

## Why this is safe to narrow

The prior "MRC on either axis" was a *deliberate* defence-in-depth conservatism (carries `SAFETY: SG1 SG9` fail-closed tags), not a bug — so I confirmed the direction before changing safety semantics. This narrows it to the **RSS-correct conjunction** while keeping the lateral layer for real cut-ins (alongside + laterally intruding → still MRC).

## Payoff

The overtake demo's **direction-isolation control now passes at the trajectory level**: a same-direction vehicle at the *exact* spot an oncoming one is refused is now **admitted** (previously masked because the lateral RSS fired on fast adjacent traffic during the angled ramp). So the head-on refusal is provably the oncoming **direction**, not mere traffic presence.

## Tests

- parko-kirra: `lateral_axis_is_evaluated` updated (agent now alongside, gap 4 m), + new `a_distant_lateral_shortfall_is_not_a_conflict` (far shortfall safe, close one still caught);
- planner: `a_same_direction_vehicle_at_the_same_spot_does_not_block_the_pass` control restored.

Full workspace green; touched-crate clippy clean (the pre-existing unrelated `DerateCode` warning in `perception_ingest.rs` is left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_