### PR TITLE
fix(rss): gate longitudinal RSS on lateral footprint overlap (RSS conjunction, both axes)

### DIFF
--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -1827,9 +1827,12 @@ mod tests {
     #[test]
     fn broken_line_permits_route_around() {
         // Off-center object + a BROKEN line on the offset side → Occy may cross →
-        // routes around (offsets) and the checker admits it.
+        // routes around (offsets) and the checker admits it. The object sits in the
+        // ego's footprint-overlap band (within RSS_LONGITUDINAL_OVERLAP_M) but
+        // outside the stop-short band, so a STRAIGHT path would be a near-miss the
+        // checker rejects (see the SOLID-line pair) — routing around is what clears it.
         let corridor = MockCorridorSource::straight_5m_half_width(100.0);
-        let objs = [obj_at(20.0, 3.0)];
+        let objs = [obj_at(20.0, 2.3)];
         let broken = [LaneBoundary { y_m: -0.5, line: LineType::Broken }];
         let mut p = GeometricPlanner::default();
         let out = p.plan(&input_objs_lanes(&corridor, 8.0, 35.0, &objs, &broken));
@@ -1841,11 +1844,14 @@ mod tests {
     #[test]
     fn solid_line_forbids_route_around_and_kirra_backstops() {
         // Same object, but a SOLID line on the offset side: Occy must NOT cross it
-        // → no route-around (drives straight). Since it can't legally pass the
-        // obstacle, KIRRA (physical authority) rejects the straight path → the
-        // stack stops. Occy obeys the line; KIRRA enforces the collision safety.
+        // → no route-around (drives straight). The object is in the ego's
+        // footprint-overlap band (y=2.3 < RSS_LONGITUDINAL_OVERLAP_M) yet outside
+        // the stop-short band (> object_lane_tolerance), so Occy drives straight
+        // PAST it at cruise — a near-miss the straight path can't avoid — and KIRRA
+        // (physical authority) rejects it. Occy obeys the line; KIRRA enforces the
+        // collision safety.
         let corridor = MockCorridorSource::straight_5m_half_width(100.0);
-        let objs = [obj_at(20.0, 3.0)];
+        let objs = [obj_at(20.0, 2.3)];
         let solid = [LaneBoundary { y_m: -0.5, line: LineType::Solid }];
         let mut p = GeometricPlanner::default();
         let out = p.plan(&input_objs_lanes(&corridor, 8.0, 35.0, &objs, &solid));

--- a/crates/kirra-planner/tests/overtake_oncoming.rs
+++ b/crates/kirra-planner/tests/overtake_oncoming.rs
@@ -152,6 +152,33 @@ fn kirra_admits_the_pass_when_the_oncoming_lane_is_clear() {
 }
 
 #[test]
+fn a_car_centered_in_the_ego_lane_is_now_overtaken_and_admitted() {
+    // The §4 alignment-band payoff. Before the longitudinal-RSS footprint-overlap
+    // gate, a car CENTERED in the ego lane (dead on the reference path) could not
+    // be passed: clearing the wide 4 m lateral-alignment band needed more side room
+    // than the maneuver builds before closing the longitudinal gap. Now the
+    // longitudinal bound only applies within the footprint-overlap band, so the
+    // ego clears it before the gap closes → the pass admits.
+    let g = road(LineType::Unmarked);
+    let (map, drivable) = (ego_corridor(&g), full_road(&g));
+    let centered = PerceivedObject {
+        id: 1,
+        pos: Point { x_m: 24.0, y_m: -2.5 }, // ego-lane centerline (on the reference path)
+        velocity_mps: 0.0,
+        heading_rad: 0.0,
+        vel: Point { x_m: 0.0, y_m: 0.0 },
+    };
+    let (plan, verdict) = plan_and_check(&g, &map, &drivable, &[centered], true);
+
+    let max_y = plan.trajectory.iter().map(|t| t.pose.y_m).fold(f64::MIN, f64::max);
+    assert!(max_y > 0.0, "the pass crosses into the oncoming half, got max_y {max_y}");
+    assert!(
+        matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "a centered-lane car is now passable (footprint-overlap gate), got {verdict:?}"
+    );
+}
+
+#[test]
 fn kirra_refuses_the_pass_when_oncoming_traffic_is_too_close() {
     // Identical to the admitted clear-pass scene, plus a closing oncoming vehicle in
     // the oncoming lane. Occy still proposes the pass (it never reasons about

--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -26,7 +26,7 @@ use kirra_runtime_sdk::gateway::kinematics_contract::{
 use kirra_runtime_sdk::verifier::FleetPosture;
 use parko_core::rss::{
     lateral_safe_distance, longitudinal_safe_distance, opposite_direction_safe_distance,
-    RSS_LONGITUDINAL_CONFLICT_M,
+    RSS_LONGITUDINAL_CONFLICT_M, RSS_LONGITUDINAL_OVERLAP_M,
 };
 
 use crate::config::VehicleConfig;
@@ -268,37 +268,43 @@ pub fn validate_trajectory_slow_capped(
                 continue;
             }
 
-            // Longitudinal RSS — required forward gap. Direction matters: an
-            // ONCOMING vehicle (heading opposes the ego, so its velocity projects
-            // backward onto the ego's forward axis) is a HEAD-ON closure, not a
-            // same-direction lead. Routing it through the same-direction primitive
-            // would discard the closing sign and UNDER-estimate the gap (#408 Obs
-            // 3); the opposite-direction bound (sum of both stopping distances)
-            // applies instead.
-            let obj_lon_v =
-                obj.velocity_mps * (obj.heading_rad - traj_point.pose.heading_rad).cos();
-            let lon_required = if obj_lon_v < 0.0 {
-                // Closing magnitudes; symmetric brake_min (both in their own lanes).
-                opposite_direction_safe_distance(
-                    traj_point.velocity_mps,
-                    obj_lon_v.abs(),
-                    RSS_REACTION_TIME_S,
-                    config.max_accel_mps2,
-                    config.max_decel_mps2,
-                    config.max_decel_mps2,
-                )
-            } else {
-                longitudinal_safe_distance(
-                    traj_point.velocity_mps,
-                    obj.velocity_mps,
-                    RSS_REACTION_TIME_S,
-                    config.max_accel_mps2,
-                    config.max_decel_mps2,
-                    config.max_decel_mps2,
-                )
-            };
-            if dx_ego < lon_required {
-                return TrajectoryVerdict::MRCFallback;
+            // Longitudinal RSS (rear-end / head-on) — GATED ON LATERAL OVERLAP: a
+            // longitudinal collision is only possible when the footprints laterally
+            // overlap (the object is in the ego's path). Applying it to an object
+            // the ego is laterally CLEAR of — a vehicle being passed, or oncoming
+            // traffic safely in the next lane — over-rejected (§4): it was why a car
+            // centered in the ego lane could not be overtaken. Direction matters: an
+            // ONCOMING vehicle (heading opposes the ego, velocity projects backward
+            // onto the ego's forward axis) is a HEAD-ON closure, not a same-direction
+            // lead — routing it through the same-direction primitive would discard
+            // the closing sign and UNDER-estimate the gap (#408 Obs 3); the
+            // opposite-direction bound (sum of both stopping distances) applies.
+            if dy_ego.abs() < RSS_LONGITUDINAL_OVERLAP_M {
+                let obj_lon_v =
+                    obj.velocity_mps * (obj.heading_rad - traj_point.pose.heading_rad).cos();
+                let lon_required = if obj_lon_v < 0.0 {
+                    // Closing magnitudes; symmetric brake_min (both in their lanes).
+                    opposite_direction_safe_distance(
+                        traj_point.velocity_mps,
+                        obj_lon_v.abs(),
+                        RSS_REACTION_TIME_S,
+                        config.max_accel_mps2,
+                        config.max_decel_mps2,
+                        config.max_decel_mps2,
+                    )
+                } else {
+                    longitudinal_safe_distance(
+                        traj_point.velocity_mps,
+                        obj.velocity_mps,
+                        RSS_REACTION_TIME_S,
+                        config.max_accel_mps2,
+                        config.max_decel_mps2,
+                        config.max_decel_mps2,
+                    )
+                };
+                if dx_ego < lon_required {
+                    return TrajectoryVerdict::MRCFallback;
+                }
             }
 
             // Lateral RSS — required side gap. Defence-in-depth against an object

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -120,16 +120,16 @@ fn test_rss_violation_rejects() {
 /// A vehicle ~15 m ahead at 12 m/s, evaluated two ways at IDENTICAL geometry:
 /// as a same-direction lead (pulling away → safe) and as oncoming (head-on
 /// closure → the opposite-direction bound needs ~40 m → MRC). Proves the
-/// adapter checker now keys the *longitudinal* bound off the object's heading.
+/// adapter checker keys the *longitudinal* bound off the object's heading.
 ///
-/// The object sits at y = 3 m — laterally offset enough to clear the lateral RSS
-/// side-gap (so a dead-ahead lateral violation can't be the cause) yet inside the
-/// 4 m alignment tolerance (so it is still evaluated longitudinally). Heading is
-/// then the ONLY thing that differs between the two cases.
+/// The object sits at y = 1.5 m — inside the longitudinal footprint-overlap band
+/// (`RSS_LONGITUDINAL_OVERLAP_M`) so the head-on/lead bound is the live check, and
+/// more than 8 m ahead so the longitudinally-gated *lateral* RSS does not fire (it
+/// can't be the cause). Heading is then the ONLY difference between the two cases.
 fn obj_at(x_m: f64, velocity_mps: f64, heading_rad: f64) -> PerceivedObject {
     PerceivedObject {
         id: 1,
-        pos: Point { x_m, y_m: 3.0 },
+        pos: Point { x_m, y_m: 1.5 },
         velocity_mps,
         heading_rad,
         vel: Point { x_m: 0.0, y_m: 0.0 },

--- a/docs/COMPETITIVE_PLANNER_ANALYSIS.md
+++ b/docs/COMPETITIVE_PLANNER_ANALYSIS.md
@@ -90,23 +90,31 @@ reject. The **overtake** build sharpened the lateral-RSS half of it: during the
 as a lateral threat (the path heading projects the other car's speed into a closing
 lateral component), MRC-ing oncoming *and* same-direction traffic alike.
 
-**Addressed (lateral RSS, longitudinal gate):** the root cause was that the lateral
-safe-distance bound danger *independently* of longitudinal distance, but RSS
-(IEEE 2846 §5; Shalev-Shwartz et al.) defines a dangerous state as the
-**conjunction** — two vehicles cannot collide laterally unless also longitudinally
-close. Both checkers (`validate_trajectory_slow`, `compute_scene_rss`) now **gate**
-the lateral defence-in-depth on `RSS_LONGITUDINAL_CONFLICT_M` (8 m): a lateral
-shortfall is dangerous only when the object is alongside/imminent, so a lead well
-ahead and oncoming traffic safely passing in the next lane no longer trip it (the
-overtake demo's direction-isolation control now passes at the trajectory level, not
-just the #469 unit level). The dominant longitudinal RSS — car-following / head-on —
-is unchanged, and the lateral layer still fails closed for a genuine cut-in.
+**Addressed (the RSS conjunction, both axes).** The root cause was that each
+checker bound danger on EITHER axis *independently*, but RSS (IEEE 2846 §5;
+Shalev-Shwartz et al.) defines a dangerous state as the **conjunction** — a
+collision needs the vehicles unsafe longitudinally AND laterally at once. Both
+checkers (`validate_trajectory_slow`, `compute_scene_rss`) now gate each axis on
+the OTHER's proximity, approximating the conjunction while each axis stays a
+fail-closed layer:
 
-**Remaining:** the longitudinal/alignment half — a car *centered* in the ego lane
-still can't be passed, because clearing the checker's 4 m lateral-alignment band
-needs >4 m of side room (a pass is admissible only for a car near the lane edge or
-on a wide road). And in dense traffic, smartening Occy's policy is the orthogonal
-axis. Mobileye pairs RSS with a *sophisticated* policy **and** carefully-tuned RSS
+- *Lateral* defence-in-depth gated on longitudinal proximity
+  (`RSS_LONGITUDINAL_CONFLICT_M`, 8 m): a lead well ahead and oncoming traffic
+  safely passing in the next lane no longer trip it (the overtake demo's
+  direction-isolation control now passes at the trajectory level, not just the
+  #469 unit level).
+- *Longitudinal* (car-following / head-on) gated on lateral footprint overlap
+  (`RSS_LONGITUDINAL_OVERLAP_M`, 2.5 m): it no longer applies to an object the ego
+  is laterally clear of (a vehicle being passed, oncoming traffic in the adjacent
+  lane). This is what unblocked overtaking a car **centered** in the ego lane on a
+  normal road — clearing footprint overlap, not a 4 m band.
+
+Each gate fails closed first on a non-finite input, and a genuine in-path /
+alongside conflict is still caught — these narrow the checker to RSS-correct, they
+do not open it.
+
+**Remaining:** in dense traffic, smartening Occy's policy is the orthogonal axis.
+Mobileye pairs RSS with a *sophisticated* policy **and** carefully-tuned RSS
 parameters — both levers, not one.
 
 ## 5. Recommended roadmap (in Kirra's grain)
@@ -124,9 +132,9 @@ parameters — both levers, not one.
    (overtake):** the `PlanInput` reference-path vs drivable-area split +
    `compute_overtake_bump` let Occy *propose* a cross-centerline pass into the
    oncoming lane (gated by lane-line type + drivable fit); KIRRA's head-on RSS
-   governs the oncoming risk. **Remaining:** merge / unprotected-turn negotiation,
-   and the §4 RSS-tuning needed for passes to be admitted as routinely as they are
-   proposed.
+   governs the oncoming risk, and the §4 RSS conjunction-gating now admits a
+   centered-lane pass as readily as Occy proposes it. **Remaining:** merge /
+   unprotected-turn negotiation.
 5. **The strategic one** — prove KIRRA bounds a **learned planner**: swap a
    NVIDIA / Hydra-MDP-style net in as the doer and show the safety case is
    *unchanged*. That is the Kirra thesis's killer demo, and it is why Occy's

--- a/parko/crates/parko-core/src/rss.rs
+++ b/parko/crates/parko-core/src/rss.rs
@@ -45,6 +45,26 @@ pub const RSS_FAILSAFE_DISTANCE_M: f64 = 1.0e6;
 /// fully governs any object that is longitudinally unsafe at any range.)
 pub const RSS_LONGITUDINAL_CONFLICT_M: f64 = 8.0;
 
+/// Lateral half-window (metres) within which the **longitudinal** RSS (rear-end /
+/// head-on) is treated as a real conflict by the trajectory/scene checkers.
+///
+/// The dual of `RSS_LONGITUDINAL_CONFLICT_M`: a longitudinal collision is only
+/// geometrically possible when the two vehicles' footprints **laterally overlap**
+/// (one is in the other's path). Applying the longitudinal car-following / head-on
+/// bound to an object the ego is laterally CLEAR of — a vehicle being passed in the
+/// next lane, or oncoming traffic safely in the adjacent lane — is over-conservative
+/// (COMPETITIVE_PLANNER_ANALYSIS §4): it was the reason a car *centered* in the ego
+/// lane could not be overtaken (clearing the wider lane-alignment band needed more
+/// side room than a normal lane affords).
+///
+/// The value is a passenger-vehicle footprint overlap (≈ two half-widths) plus a
+/// small lateral-fluctuation margin — wide enough to catch any in-path object,
+/// narrow enough that a normal-clearance pass is no longer a longitudinal conflict.
+/// (A laterally-CLOSING object is separately covered by the lateral RSS, which is
+/// itself gated on longitudinal proximity — together they approximate the RSS
+/// danger conjunction while each remains a fail-closed layer.)
+pub const RSS_LONGITUDINAL_OVERLAP_M: f64 = 2.5;
+
 #[inline]
 fn finite_positive(x: f64) -> bool {
     x.is_finite() && x > 0.0

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -47,7 +47,7 @@ use kirra_runtime_sdk::verifier::FleetPosture;
 use parko_core::commands::ControlCommand;
 use parko_core::rss::{
     lateral_safe_distance, longitudinal_safe_distance, occlusion_limited_speed,
-    opposite_direction_safe_distance, RSS_LONGITUDINAL_CONFLICT_M,
+    opposite_direction_safe_distance, RSS_LONGITUDINAL_CONFLICT_M, RSS_LONGITUDINAL_OVERLAP_M,
 };
 use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
 use parko_core::{
@@ -236,13 +236,28 @@ pub fn compute_scene_rss(scene: &AgentScene, params: &RssParams) -> RssState {
         // are false); a non-finite agent VELOCITY drove `required_*` to the
         // 1e6 failsafe, so a realistic finite actual gap is `< required` → the
         // pair is unsafe. Either way the agent is evaluated, never skipped.
-        let lon_safe = a.actual_longitudinal_gap_m >= required_long;
-        // Lateral defence-in-depth is GATED on longitudinal proximity (the RSS
-        // conjunction): a lateral shortfall is dangerous only when the object is
-        // also longitudinally close. A lead well ahead / oncoming traffic safely
+        //
+        // RSS danger is the longitudinal∧lateral conjunction; each axis bounds
+        // safety only when the OTHER axis is in conflict, so each is gated on the
+        // other's proximity (§4). Each gate is fail-closed FIRST on its own
+        // non-finite input (a NaN must never read as "safe").
+        //
+        // Longitudinal (rear-end / head-on) bounds safety only when the footprints
+        // laterally OVERLAP — an object the ego is laterally clear of (passed, or
+        // oncoming in the next lane) cannot be a longitudinal collision.
+        let lon_safe = if !a.actual_longitudinal_gap_m.is_finite() {
+            false
+        } else if a.actual_lateral_separation_m.is_finite()
+            && a.actual_lateral_separation_m >= RSS_LONGITUDINAL_OVERLAP_M
+        {
+            true
+        } else {
+            a.actual_longitudinal_gap_m >= required_long
+        };
+        // Lateral defence-in-depth bounds safety only when the object is also
+        // longitudinally CLOSE — a lead well ahead / oncoming traffic safely
         // passing in the next lane is longitudinally distant, so its lateral gap
-        // does not bound safety (it over-rejected before — §4). Fail-closed first:
-        // a non-finite separation is never "safe", regardless of range.
+        // does not bound safety (it over-rejected before — §4).
         let lat_safe = if !a.actual_lateral_separation_m.is_finite() {
             false
         } else if a.actual_longitudinal_gap_m > RSS_LONGITUDINAL_CONFLICT_M {
@@ -1651,15 +1666,19 @@ mod scene_rss_tests {
         }
     }
 
-    /// Huge actual separations on both axes → comfortably safe at these speeds.
+    /// A comfortably-safe IN-LANE lead: a huge longitudinal gap, laterally aligned
+    /// (within the footprint-overlap band so the longitudinal axis is live) but with
+    /// a side gap above the lateral requirement. No lateral motion. Derived
+    /// "longitudinally unsafe" agents inherit this in-lane separation so their
+    /// violation is a real same-lane conflict, not an object the ego is clear of.
     fn safe_agent() -> RssAgent {
         RssAgent {
             ego_vel: 10.0,
             lead_vel: 10.0,
             actual_longitudinal_gap_m: 1000.0,
-            ego_lat_vel: 0.5,
-            obj_lat_vel: 0.5,
-            actual_lateral_separation_m: 1000.0,
+            ego_lat_vel: 0.0,
+            obj_lat_vel: 0.0,
+            actual_lateral_separation_m: 2.0,
             oncoming: false,
         }
     }
@@ -1730,8 +1749,9 @@ mod scene_rss_tests {
         // ~7 m suffices for a 10 m/s same-direction lead; the head-on bound needs
         // ~31 m. 20 m sits between → safe as a lead, unsafe as oncoming.
         let gap = 20.0;
+        // In-lane (laterally overlapping) so the longitudinal axis is live for both.
         let lead = RssAgent { ego_vel: 10.0, lead_vel: 10.0, actual_longitudinal_gap_m: gap,
-            ego_lat_vel: 0.0, obj_lat_vel: 0.0, actual_lateral_separation_m: 1000.0, oncoming: false };
+            ego_lat_vel: 0.0, obj_lat_vel: 0.0, actual_lateral_separation_m: 1.5, oncoming: false };
         let onc = RssAgent { oncoming: true, ..lead };
 
         let lead_state = compute_scene_rss(&AgentScene::Agents(vec![lead]), &params());
@@ -1744,9 +1764,10 @@ mod scene_rss_tests {
 
     #[test]
     fn oncoming_agent_with_ample_gap_is_safe() {
-        // A wide gap clears even the (larger) head-on requirement.
+        // A wide gap clears even the (larger) head-on requirement. In-lane
+        // (laterally overlapping) so the head-on longitudinal bound actually applies.
         let onc = RssAgent { ego_vel: 10.0, lead_vel: 10.0, actual_longitudinal_gap_m: 1000.0,
-            ego_lat_vel: 0.0, obj_lat_vel: 0.0, actual_lateral_separation_m: 1000.0, oncoming: true };
+            ego_lat_vel: 0.0, obj_lat_vel: 0.0, actual_lateral_separation_m: 1.5, oncoming: true };
         assert!(compute_scene_rss(&AgentScene::Agents(vec![onc]), &params()).safe,
             "an oncoming vehicle far enough away is safe under the head-on bound");
     }


### PR DESCRIPTION
## What

Completes the **§4 RSS conjunction** by adding the dual of the lateral gate (#471). A longitudinal (rear-end / head-on) collision is only possible when the two vehicles' footprints **laterally overlap**, so the *dominant* longitudinal bound must not apply to an object the ego is laterally clear of — a vehicle being passed, or oncoming traffic safely in the **adjacent** lane. Applying it there was the over-conservatism that made a car **centered** in the ego lane impossible to overtake (clearing the wide 4 m lateral-alignment band needed more side room than a normal lane affords).

## The change

- **`parko_core::rss::RSS_LONGITUDINAL_OVERLAP_M` (2.5 m)** — footprint overlap (two half-widths) + a small lateral-fluctuation margin; single source of truth.
- **adapter `validate_trajectory_slow`:** the longitudinal (head-on / lead) block runs only when `dy_ego.abs() < RSS_LONGITUDINAL_OVERLAP_M`.
- **parko-kirra `compute_scene_rss`:** longitudinal bounds safety only when the lateral separation is within the overlap band — **fail-closed first** on a non-finite gap/separation.

Both axes are now gated on the other's proximity (approximating the RSS danger **conjunction**) while each stays a fail-closed layer. This **narrows** the checker to RSS-correct — a genuine in-path / alongside conflict is still caught; it does **not** open it.

## Payoff

A car centered in the ego lane is now overtaken **and admitted** on a normal road (`a_car_centered_in_the_ego_lane_is_now_overtaken_and_admitted`). The overtake story is complete: Occy proposes the pass, KIRRA admits it when safe and refuses it for genuine head-on / in-path conflict.

## Test updates (behavior intentionally changed to RSS-correct)

These are merged tests whose *premise* encoded the over-conservatism — each is now a genuine conflict:
- **adapter #469 head-on test:** oncoming car moved into the footprint-overlap band (y 3 → 1.5). An oncoming car safely in the **next** lane no longer MRCs (correct); **in-path** it still does.
- **planner solid-line backstop + its broken-line pair:** object moved to y=2.3 — inside the footprint-overlap band but outside the stop-short band, a real near-miss the straight path can't avoid, so **KIRRA still backstops it**.
- **parko-kirra:** `safe_agent` is now a realistic *in-lane* lead (overlapping but laterally safe, no lateral motion), so derived longitudinal-unsafe agents are a real same-lane conflict; head-on/oncoming agents made in-lane.

## Safety framing

This narrows the **dominant** check, so I was deliberate: the gate is the footprint-overlap geometry (a longitudinal collision is impossible without it), each gate fails closed on its own non-finite input, and every genuine in-path/alongside conflict is still caught (verified by the preserved backstop + head-on-in-path tests). Full workspace green; touched-crate clippy clean (pre-existing unrelated `DerateCode` warning untouched).

Arc: §4 over-conservatism is now closed on **both** axes (lateral #471, longitudinal this PR). COMPETITIVE_PLANNER_ANALYSIS §4/§5 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_