### PR TITLE
feat(kirra): remaining P1 — perception-divergence monitor + multi-modal predictive RSS

### DIFF
--- a/crates/kirra-ros2-adapter/src/lib.rs
+++ b/crates/kirra-ros2-adapter/src/lib.rs
@@ -21,6 +21,8 @@ pub mod corridor;
 pub mod geometry;
 pub mod state;
 pub mod validation;
+// Perception redundancy cross-check (True-Redundancy analog) — pure, non-ros2-gated.
+pub mod perception_redundancy;
 // KIRRA-OCCY-PMON-003 slice-1 — pure perception-ingest shim/orchestration
 // (non-ros2-gated; safety logic tested under default features).
 pub mod perception_ingest;

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -431,6 +431,9 @@ pub async fn run_adapter(
                 // does not yet supply a visibility range → None (no-op), mirroring
                 // the perception-derate cap's pre-wiring state.
                 None,
+                // Multi-modal predictive RSS: prediction does not yet supply per-object
+                // modes here → None (no-op); the snapshot RSS remains the bound.
+                None,
             );
             let now_ms = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)

--- a/crates/kirra-ros2-adapter/src/perception_redundancy.rs
+++ b/crates/kirra-ros2-adapter/src/perception_redundancy.rs
@@ -1,0 +1,221 @@
+//! **Perception redundancy cross-check** — a fail-closed assurance monitor, the
+//! True-Redundancy analog (gap #2b / P1).
+//!
+//! Mobileye's *True Redundancy* runs two INDEPENDENT world models (camera-only vs.
+//! radar+lidar) as mutual backups. KIRRA promotes that idea from a perception design
+//! into an **assurance check**: given two independent perception channels, verify they
+//! AGREE — and **fail closed** when they don't. A divergence means at least one channel
+//! is wrong and neither can be trusted: a *phantom* object (present in one channel,
+//! absent in the other) or a *mismatched* object (matched by position but disagreeing
+//! on speed) is exactly the single-channel fault redundancy exists to catch.
+//!
+//! The verdict composes with the existing Track-C perception derate: a divergence maps
+//! to an MRC-floor speed cap (`to_perception_cap` → `Some(0.0)`), so KIRRA brings the
+//! vehicle to a controlled stop via the *same* `apply_perception_cap` path — no change
+//! to the WCET-critical checker.
+
+use crate::state::PerceivedObject;
+
+/// Tolerances for declaring two channels' objects "the same".
+#[derive(Debug, Clone, Copy)]
+pub struct RedundancyConfig {
+    /// Max position disagreement (m) for two objects to be considered a match.
+    pub position_tol_m: f64,
+    /// Max speed-magnitude disagreement (m/s) a matched pair may have.
+    pub velocity_tol_mps: f64,
+}
+
+impl Default for RedundancyConfig {
+    fn default() -> Self {
+        // Conservative defaults: ~1 vehicle-width of position slack, a brisk-walk of
+        // speed slack. Tighter than this risks flapping on sensor noise; looser risks
+        // missing a real single-channel fault.
+        Self { position_tol_m: 2.0, velocity_tol_mps: 1.5 }
+    }
+}
+
+/// Which channel an unmatched object came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Channel {
+    A,
+    B,
+}
+
+/// Why two perception channels diverged.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DivergenceReason {
+    /// An object in one channel has no counterpart within `position_tol_m` in the
+    /// other — a phantom (false positive) or a miss (false negative). The dangerous case.
+    Unmatched { id: u64, channel: Channel },
+    /// A position-matched pair disagrees on speed beyond `velocity_tol_mps`.
+    SpeedMismatch { id_a: u64, id_b: u64, delta_mps: f64 },
+}
+
+/// The cross-check verdict.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RedundancyVerdict {
+    /// Both channels agree within tolerance → perception is trusted.
+    Consistent,
+    /// The channels disagree → at least one is wrong. Fail closed.
+    Diverged(DivergenceReason),
+}
+
+impl RedundancyVerdict {
+    /// Compose into the Track-C perception derate: a divergence is an MRC-floor cap
+    /// (`Some(0.0)` → controlled stop via `apply_perception_cap`); consistency adds no
+    /// cap (`None`). This is how the monitor reaches the actuator without touching the
+    /// per-pose checker.
+    #[must_use]
+    pub fn to_perception_cap(self) -> Option<f64> {
+        match self {
+            RedundancyVerdict::Consistent => None,
+            RedundancyVerdict::Diverged(_) => Some(0.0),
+        }
+    }
+
+    /// Whether perception diverged (and the system must fail closed).
+    #[must_use]
+    pub fn is_diverged(self) -> bool {
+        matches!(self, RedundancyVerdict::Diverged(_))
+    }
+}
+
+/// Cross-check two INDEPENDENT perception channels. Fail-closed: returns the FIRST
+/// divergence found (an unmatched object in either direction, or a speed mismatch on a
+/// matched pair). Matching is nearest-position within `cfg.position_tol_m`.
+///
+/// Determinism: objects are matched in input order, nearest-first; ties broken by the
+/// other channel's index. Empty-vs-empty is `Consistent`; an object on only one side
+/// is always a divergence (a sensor that sees a hazard the other misses must not be
+/// silently trusted *or* silently ignored).
+#[must_use]
+pub fn cross_check(
+    channel_a: &[PerceivedObject],
+    channel_b: &[PerceivedObject],
+    cfg: RedundancyConfig,
+) -> RedundancyVerdict {
+    // Every A must have a B counterpart (and agree on speed).
+    if let Some(reason) = unmatched_or_mismatched(channel_a, channel_b, cfg, Channel::A) {
+        return RedundancyVerdict::Diverged(reason);
+    }
+    // And every B must have an A counterpart (catches B-only phantoms / A misses).
+    // Speed is already checked above; here we only need the existence direction.
+    for b in channel_b {
+        if nearest_within(b, channel_a, cfg.position_tol_m).is_none() {
+            return RedundancyVerdict::Diverged(DivergenceReason::Unmatched {
+                id: b.id,
+                channel: Channel::B,
+            });
+        }
+    }
+    RedundancyVerdict::Consistent
+}
+
+/// For each object in `from`, require a position-match in `other` and speed agreement.
+fn unmatched_or_mismatched(
+    from: &[PerceivedObject],
+    other: &[PerceivedObject],
+    cfg: RedundancyConfig,
+    from_channel: Channel,
+) -> Option<DivergenceReason> {
+    for o in from {
+        match nearest_within(o, other, cfg.position_tol_m) {
+            None => {
+                return Some(DivergenceReason::Unmatched { id: o.id, channel: from_channel });
+            }
+            Some(m) => {
+                let delta = (o.velocity_mps - m.velocity_mps).abs();
+                if delta > cfg.velocity_tol_mps {
+                    // Order the ids A-then-B regardless of which side `from` is.
+                    let (id_a, id_b) = match from_channel {
+                        Channel::A => (o.id, m.id),
+                        Channel::B => (m.id, o.id),
+                    };
+                    return Some(DivergenceReason::SpeedMismatch { id_a, id_b, delta_mps: delta });
+                }
+            }
+        }
+    }
+    None
+}
+
+/// The nearest object in `candidates` within `tol_m` of `target` (by Euclidean
+/// position), if any.
+fn nearest_within<'a>(
+    target: &PerceivedObject,
+    candidates: &'a [PerceivedObject],
+    tol_m: f64,
+) -> Option<&'a PerceivedObject> {
+    candidates
+        .iter()
+        .map(|c| (c, (c.pos.x_m - target.pos.x_m).hypot(c.pos.y_m - target.pos.y_m)))
+        .filter(|(_, d)| *d <= tol_m)
+        .min_by(|(_, d1), (_, d2)| d1.total_cmp(d2))
+        .map(|(c, _)| c)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::corridor::Point;
+
+    fn obj(id: u64, x: f64, y: f64, v: f64) -> PerceivedObject {
+        PerceivedObject {
+            id,
+            pos: Point { x_m: x, y_m: y },
+            velocity_mps: v,
+            heading_rad: 0.0,
+            vel: Point { x_m: v, y_m: 0.0 },
+        }
+    }
+
+    #[test]
+    fn agreeing_channels_are_consistent() {
+        let a = [obj(1, 20.0, 0.0, 5.0), obj(2, 35.0, -3.0, 0.0)];
+        // Same world, slightly noisy ids/positions/speeds within tolerance.
+        let b = [obj(7, 20.4, 0.1, 5.6), obj(9, 34.8, -3.2, 0.0)];
+        let v = cross_check(&a, &b, RedundancyConfig::default());
+        assert_eq!(v, RedundancyVerdict::Consistent);
+        assert_eq!(v.to_perception_cap(), None);
+    }
+
+    #[test]
+    fn empty_channels_are_consistent() {
+        assert_eq!(cross_check(&[], &[], RedundancyConfig::default()), RedundancyVerdict::Consistent);
+    }
+
+    #[test]
+    fn a_phantom_in_one_channel_diverges_and_caps_to_mrc() {
+        // Channel A sees a stopped car at x=20 that B does not → fail closed.
+        let a = [obj(1, 20.0, 0.0, 0.0)];
+        let b: [PerceivedObject; 0] = [];
+        let v = cross_check(&a, &b, RedundancyConfig::default());
+        assert!(v.is_diverged());
+        assert_eq!(v, RedundancyVerdict::Diverged(DivergenceReason::Unmatched { id: 1, channel: Channel::A }));
+        assert_eq!(v.to_perception_cap(), Some(0.0), "divergence → MRC-floor cap");
+    }
+
+    #[test]
+    fn an_object_only_in_channel_b_also_diverges() {
+        let a: [PerceivedObject; 0] = [];
+        let b = [obj(4, 18.0, 0.5, 2.0)];
+        assert_eq!(
+            cross_check(&a, &b, RedundancyConfig::default()),
+            RedundancyVerdict::Diverged(DivergenceReason::Unmatched { id: 4, channel: Channel::B })
+        );
+    }
+
+    #[test]
+    fn a_matched_pair_disagreeing_on_speed_diverges() {
+        // Same position, wildly different speed (one channel says stopped, one says fast).
+        let a = [obj(1, 20.0, 0.0, 0.0)];
+        let b = [obj(2, 20.3, 0.0, 8.0)];
+        match cross_check(&a, &b, RedundancyConfig::default()) {
+            RedundancyVerdict::Diverged(DivergenceReason::SpeedMismatch { id_a, id_b, delta_mps }) => {
+                assert_eq!((id_a, id_b), (1, 2));
+                assert!((delta_mps - 8.0).abs() < 1e-9);
+            }
+            other => panic!("expected a speed mismatch, got {other:?}"),
+        }
+    }
+}

--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -59,6 +59,25 @@ const OCCLUSION_SPEED_TOL_MPS: f64 = 0.1;
 /// covers it.
 const RSS_LATERAL_ALIGNMENT_TOLERANCE_M: f64 = 4.0;
 
+/// One predicted future position of an object at a time, in the world frame. A
+/// sequence of these forms one predicted **mode** (hypothesis); the inter-sample
+/// motion supplies the predicted velocity (no separate speed field to keep stale).
+#[derive(Debug, Clone, Copy)]
+pub struct PredictedSample {
+    pub pos: Point,
+    pub time_from_start_s: f64,
+}
+
+/// One predicted **mode** for an object — e.g. lane-follow, a cut-in, or a turn. An
+/// object may carry several modes; the predictive RSS pass requires the ego to be
+/// safe against **every** mode (worst-case), so a single dangerous hypothesis is
+/// enough to refuse. Modes are perception/prediction-supplied (`None` → the pass is a
+/// no-op and the snapshot RSS is the sole bound, the back-compat behaviour).
+pub struct PredictedMode<'a> {
+    pub object_id: u64,
+    pub samples: &'a [PredictedSample],
+}
+
 /// Compose the three slow-loop checks into one verdict. First-rejection-
 /// wins on containment and RSS; Clamp is recorded but does not
 /// short-circuit (containment + RSS still vote).
@@ -101,7 +120,7 @@ pub fn validate_trajectory_slow(
     // `validate_trajectory_slow_capped` with the resolved Track-C cap
     // (KIRRA-OCCY-PMON-003 slice-1).
     validate_trajectory_slow_capped(
-        trajectory, corridor, objects, config, latest_odom, posture, None, None,
+        trajectory, corridor, objects, config, latest_odom, posture, None, None, None,
     )
 }
 
@@ -138,6 +157,7 @@ pub fn validate_trajectory_slow_capped(
     posture: FleetPosture,
     effective_perception_cap: Option<f64>,
     visibility_range_m: Option<f64>,
+    predicted_modes: Option<&[PredictedMode<'_>]>,
 ) -> TrajectoryVerdict {
     // ----- Posture short-circuit (M1) ----------------------------------
     //
@@ -353,6 +373,22 @@ pub fn validate_trajectory_slow_capped(
         }
     }
 
+    // ----- C2) Multi-modal predictive RSS (space-time over modes) ------
+    //
+    // The snapshot RSS above extrapolates each object from its instantaneous
+    // velocity (the CV mode). When perception supplies predicted MODES, also
+    // require the ego to be safe against each one, time-matched: at the moment
+    // the ego reaches a pose, where could the object be? A predicted cut-in /
+    // turn that brings the object into the ego's path is caught here even though
+    // the snapshot showed it laterally clear. Uses the SAME §4 lateral-alignment +
+    // longitudinal-overlap gating, so a mode that stays in its own lane is skipped
+    // (this generalizes §4, it does not regress it). Absent input → no-op.
+    if let Some(modes) = predicted_modes {
+        if predictive_rss_breach(trajectory, modes, config) {
+            return TrajectoryVerdict::MRCFallback;
+        }
+    }
+
     // ----- D) Limited-visibility / occlusion bound (RSS Rule 4) --------
     //
     // Gated on a perception-supplied assured-clear distance. A trajectory that
@@ -412,6 +448,78 @@ fn outruns_assured_clear_distance(
             return true;
         }
         prev = Some(p);
+    }
+    false
+}
+
+/// The trajectory pose closest in TIME to `t` (the ego's where-am-I-when index).
+fn nearest_in_time(trajectory: &[TrajectoryPoint], t: f64) -> Option<&TrajectoryPoint> {
+    trajectory
+        .iter()
+        .min_by(|a, b| (a.time_from_start_s - t).abs().total_cmp(&(b.time_from_start_s - t).abs()))
+}
+
+/// True if any predicted mode brings an object into a longitudinal RSS shortfall with
+/// the time-matched ego pose. Mirrors the snapshot RSS pass (same `dx_ego`/`dy_ego`
+/// ego-frame projection, same §4 lateral-alignment + longitudinal-overlap gating, same
+/// same-/opposite-direction primitive), but evaluates the object at its PREDICTED
+/// position+velocity (derived from the inter-sample motion) rather than its snapshot.
+fn predictive_rss_breach(
+    trajectory: &[TrajectoryPoint],
+    modes: &[PredictedMode<'_>],
+    config: &VehicleConfig,
+) -> bool {
+    for mode in modes {
+        for pair in mode.samples.windows(2) {
+            let (a, b) = (pair[0], pair[1]);
+            let dt = b.time_from_start_s - a.time_from_start_s;
+            if dt <= 0.0 {
+                continue; // non-monotonic samples — skip (fail-open on malformed *input*,
+                          // the snapshot RSS still bounds the real object)
+            }
+            let ovx = (b.pos.x_m - a.pos.x_m) / dt;
+            let ovy = (b.pos.y_m - a.pos.y_m) / dt;
+
+            let Some(ego) = nearest_in_time(trajectory, a.time_from_start_s) else { continue };
+            let dx = a.pos.x_m - ego.pose.x_m;
+            let dy = a.pos.y_m - ego.pose.y_m;
+            let cos_h = ego.pose.heading_rad.cos();
+            let sin_h = ego.pose.heading_rad.sin();
+            let dx_ego = cos_h * dx + sin_h * dy; // longitudinal
+            let dy_ego = -sin_h * dx + cos_h * dy; // lateral
+
+            if dx_ego <= 0.0 {
+                continue; // behind the ego at that time
+            }
+            if dy_ego.abs() > RSS_LATERAL_ALIGNMENT_TOLERANCE_M {
+                continue; // predicted to be in another corridor — containment covers it
+            }
+            if dy_ego.abs() < RSS_LONGITUDINAL_OVERLAP_M {
+                let obj_lon_v = ovx * cos_h + ovy * sin_h; // predicted closing component
+                let lon_required = if obj_lon_v < 0.0 {
+                    opposite_direction_safe_distance(
+                        ego.velocity_mps,
+                        obj_lon_v.abs(),
+                        RSS_REACTION_TIME_S,
+                        config.max_accel_mps2,
+                        config.max_decel_mps2,
+                        config.max_decel_mps2,
+                    )
+                } else {
+                    longitudinal_safe_distance(
+                        ego.velocity_mps,
+                        obj_lon_v,
+                        RSS_REACTION_TIME_S,
+                        config.max_accel_mps2,
+                        config.max_decel_mps2,
+                        config.max_decel_mps2,
+                    )
+                };
+                if dx_ego < lon_required {
+                    return true;
+                }
+            }
+        }
     }
     false
 }

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -516,7 +516,7 @@ fn occlusion_rejects_a_trajectory_that_outruns_assured_clear_distance() {
     let cfg = VehicleConfig::default_urban();
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(5.0),
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(5.0), None,
     );
     assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
         "10 m/s into 5 m of visibility outruns the assured clear distance; got {verdict:?}");
@@ -532,7 +532,7 @@ fn occlusion_bound_is_gated_off_when_no_visibility_is_supplied() {
     let cfg = VehicleConfig::default_urban();
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None,
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None, None,
     );
     assert_ne!(verdict, TrajectoryVerdict::MRCFallback,
         "with no visibility input the occlusion bound is a no-op; got {verdict:?}");
@@ -548,8 +548,90 @@ fn occlusion_admits_a_decel_to_stop_within_visibility() {
     let cfg = VehicleConfig::default_urban();
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(20.0),
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(20.0), None,
     );
     assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
         "a decel-to-stop within the assured clear distance is admissible; got {verdict:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Multi-modal predictive RSS (space-time over predicted modes)
+// ---------------------------------------------------------------------------
+
+use kirra_ros2_adapter::validation::{PredictedMode, PredictedSample};
+
+/// Build a predicted mode: an object moving in a straight line from `(x0,y0)` at
+/// `(vx,vy)` m/s, sampled every 0.5 s over `horizon_s`.
+fn linear_mode(id: u64, x0: f64, y0: f64, vx: f64, vy: f64, horizon_s: f64) -> Vec<PredictedSample> {
+    let mut t = 0.0;
+    let mut out = Vec::new();
+    while t <= horizon_s + 1e-9 {
+        out.push(PredictedSample {
+            pos: Point { x_m: x0 + vx * t, y_m: y0 + vy * t },
+            time_from_start_s: t,
+        });
+        t += 0.5;
+    }
+    let _ = id;
+    out
+}
+
+#[test]
+fn predictive_rss_does_not_regress_a_lane_keeping_neighbor() {
+    // A fast car ABREAST in the next lane (y=-3.5), predicted to STAY in its lane.
+    // The §4 lateral gating must keep admitting the ego — the predicted mode never
+    // overlaps the ego's path.
+    let trajectory = straight_trajectory(20, 6.0, 0.1); // ego 6 m/s straight at y=0
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let samples = linear_mode(1, 6.0, -3.5, 9.0, 0.0, 2.0); // fast, but stays at y=-3.5
+    let modes = [PredictedMode { object_id: 1, samples: &samples }];
+
+    let verdict = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes),
+    );
+    assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "a neighbor predicted to keep its lane must not be rejected; got {verdict:?}");
+}
+
+#[test]
+fn predictive_rss_catches_a_predicted_cut_in() {
+    // The SAME kind of neighbor, but its predicted mode now CUTS IN: it crosses from
+    // the right lane (y=-3.5) INTO the ego's lane just ahead of the ego, then sits
+    // there slow. The snapshot (t=0) shows it laterally clear in another lane, but the
+    // predicted mode brings it into the path within the RSS gap → MRCFallback.
+    let trajectory = straight_trajectory(20, 3.0, 0.1); // ego 3 m/s, x: 5 → ~10.7
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    // Phase 1 (t 0→1.0): cross from (9,-3.5) to (9,0). Phase 2 (t 1.0→2.0): creep
+    // forward in-lane at ~0.6 m/s — 1 m ahead of the ego when it arrives at x=8 (t=1.0).
+    let samples = [
+        PredictedSample { pos: Point { x_m: 9.0, y_m: -3.5 }, time_from_start_s: 0.0 },
+        PredictedSample { pos: Point { x_m: 9.0, y_m: -1.75 }, time_from_start_s: 0.5 },
+        PredictedSample { pos: Point { x_m: 9.0, y_m: 0.0 }, time_from_start_s: 1.0 },
+        PredictedSample { pos: Point { x_m: 9.3, y_m: 0.0 }, time_from_start_s: 1.5 },
+        PredictedSample { pos: Point { x_m: 9.6, y_m: 0.0 }, time_from_start_s: 2.0 },
+    ];
+    let modes = [PredictedMode { object_id: 1, samples: &samples }];
+
+    let verdict = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes),
+    );
+    assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
+        "a predicted cut-in into the ego's path must be refused; got {verdict:?}");
+}
+
+#[test]
+fn predictive_rss_is_a_no_op_when_no_modes_are_supplied() {
+    // Same cut-in geometry, but no predicted modes → the pass is skipped (snapshot
+    // RSS sees no object at all here), so the trajectory is not MRC'd for prediction.
+    let trajectory = straight_trajectory(20, 6.0, 0.1);
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+
+    let verdict = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, None,
+    );
+    assert_ne!(verdict, TrajectoryVerdict::MRCFallback,
+        "with no predicted modes the predictive pass is a no-op; got {verdict:?}");
 }


### PR DESCRIPTION
The two remaining P1 checker-completeness items from the stack gap analysis.

## 1. Perception redundancy cross-check — True-Redundancy analog (gap #2b)

Mobileye's *True Redundancy* runs two **independent** world models as mutual backups. KIRRA promotes that into an **assurance check** (`perception_redundancy::cross_check`): given two independent perception channels, verify they **agree** and **fail closed** when they don't.

- `Diverged` reasons: **`Unmatched`** (a phantom/miss, checked both directions) or **`SpeedMismatch`** (matched pair disagreeing on speed). Nearest-position matching; deterministic; empty-vs-empty is `Consistent`.
- `RedundancyVerdict::to_perception_cap()` → a divergence is an **MRC-floor cap** (`Some(0.0)`) via the *same* `apply_perception_cap` path — reaches the actuator **without touching the WCET-critical checker**.

5 tests; self-contained, non-`ros2`-gated.

## 2. Multi-modal predictive RSS — space-time bound over predicted modes (gap #3)

The snapshot RSS extrapolated each object from its instantaneous velocity (CV mode), so a predicted **cut-in / turn** shown laterally clear slipped through. This adds a space-time RSS pass over perception-supplied predicted **modes**.

**Industry-leading framing:** everyone has multi-modal prediction in their *planner* (Autoware, NVIDIA); none has it as a separate **formal bound that holds for any doer**. In the checker, it bounds the learned planner (#484) on prediction too.

- `PredictedSample {pos, time}` + `PredictedMode {object_id, samples}`; inter-sample motion gives the predicted velocity. New `predicted_modes: Option<&[PredictedMode]>` on `validate_trajectory_slow_capped` (pass C2). The ego pose nearest **in time** is found and the **same §4 gating** (ego-frame projection + lateral-alignment + longitudinal-overlap + same/opposite primitive) is applied to the object's *predicted* position/velocity. Breach → `MRCFallback`.
- **Non-regression by construction:** reuses the §4 gating, so a mode that keeps its lane is skipped exactly as a snapshot object is — it **generalizes §4** (more precise *and* more complete). `None` → no-op, Nominal WCET path byte-identical. `node.rs` passes `None` (prediction not yet sourced here).

3 tests: lane-keeping neighbor → admitted (the §4 non-regression guard); predicted cut-in ahead within the RSS gap → `MRCFallback`; no modes → no-op.

Adapter suite green; clippy clean (one pre-existing unrelated `DerateCode` warning remains). **With this, all of P0/P1/P2 from the gap analysis that are buildable in this environment are done.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58