### PR TITLE
feat(occy): junction integration entry point — pose+objects → both consumer sets

### DIFF
--- a/crates/kirra-planner/src/lanemap.rs
+++ b/crates/kirra-planner/src/lanemap.rs
@@ -249,6 +249,20 @@ impl CorridorSource for LaneCorridor {
     }
 }
 
+/// The map-derived junction reasoning for one tick — the output of
+/// [`LaneGraph::junction_context`]. Carries the resolved ego lane and BOTH
+/// consumer-ready right-of-way sets, derived from the one `priority_over` map so they
+/// cannot disagree. The deployment maps each set to its path's runtime type.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct JunctionContext {
+    /// The ego's lane, or `None` if it is off the mapped road (→ empty sets).
+    pub ego_lane: Option<u64>,
+    /// Objects that cede to the ego → Occy's `PlanInput.cedes_to_ego_ids`.
+    pub cedes_to_ego: Vec<u64>,
+    /// Objects the ego must yield to / wait for → Parko SG5's `NonYieldingScene`.
+    pub must_yield_to: Vec<u64>,
+}
+
 /// A collection of connected [`Lane`]s — the Lanelet2-lite lane graph. Lanes are
 /// keyed by id (deterministic iteration). The planner derives a corridor + typed
 /// boundaries from a chosen span of lanes; a real route (the preferred-primitive
@@ -343,6 +357,30 @@ impl LaneGraph {
             .filter(|o| self.lane_at(o.pos).is_some_and(|l| priority_lanes.contains(&l)))
             .map(|o| o.id)
             .collect()
+    }
+
+    /// **The junction integration entry point.** Resolve the ego's lane from its
+    /// *pose* (the input a deployment actually has — not a lane id) and derive BOTH
+    /// consumer-ready sets from the one right-of-way map, in a single pass:
+    ///
+    /// * `cedes_to_ego` → drop straight into Occy's `PlanInput.cedes_to_ego_ids`;
+    /// * `must_yield_to` → map to Parko SG5's `NonYieldingScene` at the parko boundary.
+    ///
+    /// This is the deployment-integration step packaged: it turns *ego pose + perceived
+    /// objects* into the two junction sets either path consumes, consistent by
+    /// construction (both from `priority_over`). Fail-safe: an ego off the mapped road
+    /// yields empty sets (no `ego_lane`) — the path's own gates (Occy's snapshot yield,
+    /// Parko's fail-closed veto, KIRRA's RSS) still apply.
+    #[must_use]
+    pub fn junction_context(&self, ego_pos: Point, objects: &[PerceivedObject]) -> JunctionContext {
+        match self.lane_at(ego_pos) {
+            Some(ego_lane) => JunctionContext {
+                ego_lane: Some(ego_lane),
+                cedes_to_ego: self.cedes_to_ego(ego_lane, objects),
+                must_yield_to: self.non_yielding_to_ego(ego_lane, objects),
+            },
+            None => JunctionContext::default(),
+        }
     }
 
     /// Insert (or replace) a lane.
@@ -966,5 +1004,34 @@ mod tests {
         let in_l1 = [obj(9, 15.0, 0.0)];
         assert_eq!(g.non_yielding_to_ego(2, &in_l1), vec![9]);
         assert!(g.cedes_to_ego(2, &in_l1).is_empty());
+    }
+
+    #[test]
+    fn junction_context_resolves_the_ego_lane_and_both_sets() {
+        use kirra_ros2_adapter::state::PerceivedObject;
+        let g = LaneGraph::new()
+            .with_lane(Lane::straight(1, 0.0, 0.0, 30.0, 2.5, LineType::Solid, LineType::Solid))
+            .with_lane(Lane::straight(2, 10.0, 0.0, 30.0, 2.5, LineType::Solid, LineType::Solid))
+            .with_right_of_way(1, 2);
+        let obj = |id, x, y| PerceivedObject {
+            id,
+            pos: Point { x_m: x, y_m: y },
+            velocity_mps: 3.0,
+            heading_rad: 0.0,
+            vel: Point { x_m: 3.0, y_m: 0.0 },
+        };
+        let objs = [obj(7, 15.0, 10.0)];
+
+        // Ego in lane 1 (priority): one call resolves the lane + both sets.
+        let ctx = g.junction_context(Point { x_m: 15.0, y_m: 0.0 }, &objs);
+        assert_eq!(ctx.ego_lane, Some(1));
+        assert_eq!(ctx.cedes_to_ego, vec![7]);
+        assert!(ctx.must_yield_to.is_empty());
+
+        // Off the mapped road → empty context (fail-safe).
+        assert_eq!(
+            g.junction_context(Point { x_m: 15.0, y_m: 99.0 }, &objs),
+            JunctionContext::default()
+        );
     }
 }

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -48,7 +48,7 @@ pub use behavior::{
 };
 
 pub mod lanemap;
-pub use lanemap::{Lane, LaneCorridor, LaneEdge, LaneGraph, MAX_ROUTE_LANES};
+pub use lanemap::{JunctionContext, Lane, LaneCorridor, LaneEdge, LaneGraph, MAX_ROUTE_LANES};
 
 pub mod lanelet2;
 pub use lanelet2::{parse_lanelet2_osm, Lanelet2ParseError};
@@ -2735,6 +2735,37 @@ mod tests {
         let proceeded = p.plan(&inp);
         let p_max = proceeded.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max);
         assert!(p_max > 22.0, "ceding agent → ego asserts priority and proceeds, got {p_max}");
+    }
+
+    #[test]
+    fn junction_context_integration_derives_the_cede_list_occy_consumes() {
+        // THE INTEGRATION LAYER, end-to-end: a Lanelet2-style map (ego lane 100 has
+        // right-of-way over the crossing lane 200) → `junction_context(ego_pose, objs)`
+        // → the cede list Occy consumes → the ego asserts priority and proceeds. The
+        // MAP derives what `junction_right_of_way_lets_the_ego_proceed` supplied by hand.
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let objs = [crossing_obj_at(20.0, 5.0, 0.0, -3.0)]; // id 1, in the crossing lane
+
+        let map = LaneGraph::new()
+            .with_lane(Lane::straight(100, 0.0, 0.0, 100.0, 2.5, LineType::Solid, LineType::Solid))
+            .with_lane(Lane::straight(200, 5.0, 0.0, 40.0, 2.5, LineType::Solid, LineType::Solid))
+            .with_right_of_way(100, 200);
+
+        // The integration call: ego POSE + objects → both junction sets.
+        let ctx = map.junction_context(Point { x_m: 8.0, y_m: 0.0 }, &objs);
+        assert_eq!(ctx.ego_lane, Some(100));
+        assert_eq!(ctx.cedes_to_ego, vec![1], "map derives the cede list");
+        assert!(ctx.must_yield_to.is_empty());
+
+        // Feed the DERIVED cede list straight into Occy → it proceeds against the agent.
+        let mut p = GeometricPlanner::default();
+        let inp = PlanInput {
+            cedes_to_ego_ids: &ctx.cedes_to_ego,
+            ..input_with_objects(&corridor, 8.0, 35.0, &objs)
+        };
+        let out = p.plan(&inp);
+        let max_x = out.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max);
+        assert!(max_x > 22.0, "map-derived cede list → ego proceeds, got {max_x}");
     }
 
     #[test]


### PR DESCRIPTION
## What

The **integration entry point** for the map-derived junction reasoning (the `cedes_to_ego` / `non_yielding_to_ego` pair landed in #491). A single call that turns the inputs a deployment actually has — **ego pose + perceived objects** — into both consumer-ready right-of-way sets, *resolving the ego lane* (which the lane-id methods can't do themselves).

- **`JunctionContext { ego_lane, cedes_to_ego, must_yield_to }`** — the per-tick result.
- **`LaneGraph::junction_context(ego_pos, objects)`** — resolves the ego lane via `lane_at`, then derives both sets from the one `priority_over` map. `cedes_to_ego` → Occy's `PlanInput.cedes_to_ego_ids` (direct field assignment); `must_yield_to` → Parko SG5's `NonYieldingScene` (thin adapter at the parko boundary). Off-map ego → empty (fail-safe; each path's own gates still apply).

Why the map side: `parko` is a **separate cargo workspace**, so this packages the integration where both parallel paths share — the map.

## Tests

`junction_context` resolves the lane + both sets (off-map → empty); and **end-to-end** — a map (ego lane has right-of-way over a crossing lane) → `junction_context` → the cede list → **Occy asserts priority and proceeds**. The map now *derives* what the hand-written `junction_right_of_way` test supplied. Planner suite green (102 lib tests); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_