### PR TITLE
refactor(core): de-monolith Stage 1 — extract FleetPosture/NodeTrustState to kirra-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,6 +1965,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "kirra-fleet-transport"
 version = "0.1.0"
 dependencies = [
@@ -2038,6 +2045,7 @@ dependencies = [
  "hmac",
  "http",
  "kirra-capture-schema",
+ "kirra-core",
  "parko-core",
  "parko-kirra",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-taj", "crates/kirra-fleet-transport"]
+members = [".", "crates/kirra-core", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-taj", "crates/kirra-fleet-transport"]
 resolver = "2"
 
 [package]
@@ -49,6 +49,9 @@ ros2 = []
 tpm = ["dep:tss-esapi"]
 
 [dependencies]
+# Lean safety/contract foundation (de-monolith Stage 1): FleetPosture / NodeTrustState
+# live here; this crate re-exports them so existing paths are unchanged.
+kirra-core = { path = "crates/kirra-core" }
 parko-core = { path = "parko/crates/parko-core" }
 # Governor-free wire schema for capture records, shared verbatim with the offline
 # collector (docs/COLLECTOR_DESIGN.md [C1]). Re-exported by `crate::capture`.

--- a/crates/kirra-core/Cargo.toml
+++ b/crates/kirra-core/Cargo.toml
@@ -1,0 +1,24 @@
+# crates/kirra-core/Cargo.toml
+#
+# kirra-core — the LEAN safety/contract foundation extracted from the
+# kirra-runtime-sdk monolith (de-monolith Stage 1, ADR pending). Deliberately
+# dependency-light: NO tokio / axum / rusqlite / reqwest / ML. Crates that need the
+# foundational types (the adapter, the planner, the map, parko) depend on THIS, so the
+# certified-governor surface does not drag the verifier service's heavy tree.
+#
+# Stage 1 holds the foundational posture types (FleetPosture / NodeTrustState),
+# previously trapped in the heavy `verifier.rs`. Later stages move the governor / the
+# kinematics-contract talisman here as verbatim, re-exported blocks.
+[package]
+name = "kirra-core"
+version = "0.1.0"
+edition = "2021"
+description = "Lean safety/contract foundation for the Kirra stack — no service/runtime deps."
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+
+[dependencies]
+# The posture types are wire-serialized (federation reports, the SSE stream). serde is
+# lean — the only dependency this crate carries.
+serde = { version = "1", features = ["derive"] }

--- a/crates/kirra-core/src/lib.rs
+++ b/crates/kirra-core/src/lib.rs
@@ -1,0 +1,33 @@
+//! **kirra-core** — the lean safety/contract foundation of the Kirra stack.
+//!
+//! This crate carries the dependency-light types and (in later de-monolith stages) the
+//! governor / kinematics-contract talisman, extracted from `kirra-runtime-sdk` so that
+//! the certified-governor surface does not pull the verifier service's heavy tree
+//! (tokio / axum / rusqlite / reqwest) or any ML backend. Consumers that only need the
+//! foundation (the ROS2 adapter, the planner, the lane map, parko) depend on this crate
+//! directly; `kirra-runtime-sdk` re-exports everything here so existing paths are
+//! unchanged.
+//!
+//! Stage 1: the fleet posture / node trust types, previously defined in the heavy
+//! `kirra_runtime_sdk::verifier` module and imported across the whole stack.
+
+use serde::{Deserialize, Serialize};
+
+/// A registered node's trust state, as decided by attestation and the recovery
+/// hysteresis. `Untrusted` carries a human-readable reason tag.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum NodeTrustState {
+    Trusted,
+    Untrusted(String),
+    Unknown,
+}
+
+/// The fleet's safety posture — the spine the whole governor hangs on. `Nominal` →
+/// full operation; `Degraded` → controlled decel-to-stop-and-hold envelope; `LockedOut`
+/// → MRC, human reset required.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum FleetPosture {
+    Nominal,
+    Degraded,
+    LockedOut,
+}

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -16,19 +16,10 @@ pub const MAX_DEPENDENCY_DEPTH: usize = 10;
 /// short enough to limit the replay window if a response is intercepted.
 const CHALLENGE_TTL_MS: u64 = 30_000;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum NodeTrustState {
-    Trusted,
-    Untrusted(String),
-    Unknown,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum FleetPosture {
-    Nominal,
-    Degraded,
-    LockedOut,
-}
+// `FleetPosture` / `NodeTrustState` moved to the lean `kirra-core` crate (de-monolith
+// Stage 1) so the governor/contract surface need not pull this heavy module. Re-exported
+// here so every existing `crate::verifier::FleetPosture` path keeps the same type.
+pub use kirra_core::{FleetPosture, NodeTrustState};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegisteredNode {


### PR DESCRIPTION
**De-monolith Stage 1 of N** — the first, lowest-risk step of splitting the lean safety/contract foundation out of the `kirra-runtime-sdk` monolith (the heavy verifier service: tokio/axum/rusqlite/reqwest), so the certified-governor surface (adapter, planner, map, parko) can depend on a **lean** crate.

## What

- **New `crates/kirra-core`** — dependency-light: **serde only**, no tokio/axum/sqlite/ML (verified via `cargo tree`). Holds `FleetPosture` / `NodeTrustState` — two plain enums previously **trapped** in the heavy `verifier.rs` yet imported across the whole stack (gateway, adapter, planner, federation, posture).
- **`src/verifier.rs` re-exports them** (`pub use kirra_core::{FleetPosture, NodeTrustState}`), so every existing `crate::verifier::FleetPosture` path keeps the **same type** — zero churn at call sites, type identity preserved.

## Safety: pure move + re-export

No logic changed — the verbatim enum definitions relocated. The technique is what makes the whole de-monolith safe: relocate code, re-export from the original module, so behavior is provably unchanged if the suite passes.

## Verification (the per-stage gate)

- `kirra-core` lean dep tree confirmed (serde only).
- Root workspace compiles; **all 18 test groups pass**; adapter + planner compile against the re-exported type.
- **parko-core + parko-kirra build** (they dep `kirra-runtime-sdk` → the re-export).
- **Zero new clippy warnings** (the 7 in the workspace are pre-existing in `kirra-collector`/`kirra-proposal-bench`).

## Next stages (each its own PR, same gate)

2) lean event/contract types · 3) the governor / kinematics-contract **talisman** (verbatim, owner-reviewed) · 4) switch consumers to `kirra-core` · 5) parko deps `kirra-core` · 6) `kirra-runtime-sdk` becomes the verifier-service on `kirra-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_