### PR TITLE
style: clear 5 pre-existing clippy lints (collector / proposal-bench)

### DIFF
--- a/crates/kirra-collector/src/join.rs
+++ b/crates/kirra-collector/src/join.rs
@@ -31,9 +31,9 @@ fn keys_agree(msg: &BusMessage, rec: &CaptureRecord) -> bool {
     let Some(t) = rec.traj.as_ref() else {
         return true; // gateway records have no cross-check keys
     };
-    let asset_ok = msg.asset_id.as_deref().map_or(true, |a| a == t.asset_id);
-    let traj_ok = msg.trajectory_id.map_or(true, |id| id == t.trajectory_id);
-    let objs_ok = msg.objects_ms.map_or(true, |o| o == t.objects_ms);
+    let asset_ok = msg.asset_id.as_deref().is_none_or(|a| a == t.asset_id);
+    let traj_ok = msg.trajectory_id.is_none_or(|id| id == t.trajectory_id);
+    let objs_ok = msg.objects_ms.is_none_or(|o| o == t.objects_ms);
     asset_ok && traj_ok && objs_ok
 }
 

--- a/crates/kirra-collector/src/manifest.rs
+++ b/crates/kirra-collector/src/manifest.rs
@@ -193,7 +193,7 @@ pub fn write_manifest(manifest: &Manifest, out_dir: &Path) -> Result<PathBuf, Co
     std::fs::create_dir_all(out_dir).map_err(CollectorError::Io)?;
     let path = out_dir.join("manifest.json");
     let json = serde_json::to_string_pretty(manifest)
-        .map_err(|e| CollectorError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)))?;
+        .map_err(|e| CollectorError::Io(std::io::Error::other(e)))?;
     std::fs::write(&path, json).map_err(CollectorError::Io)?;
     Ok(path)
 }

--- a/crates/kirra-proposal-bench/src/main.rs
+++ b/crates/kirra-proposal-bench/src/main.rs
@@ -77,7 +77,7 @@ fn main() -> std::io::Result<()> {
     ];
 
     eprintln!("kirra-proposal-bench → {addr} ({} cases)\n", cases.len());
-    println!("{:<20} | {:<26} | {}", "CASE", "REASON", "VERDICT");
+    println!("{:<20} | {:<26} | VERDICT", "CASE", "REASON");
     println!("{}", "-".repeat(78));
 
     let mut buf = [0u8; 4096];


### PR DESCRIPTION
Mechanical, behavior-preserving fixes for the **5 pre-existing clippy lints** surfaced while verifying that the de-monolith work (#493) added none. Independent of #493 (own branch off `main`; disjoint files).

- **`kirra-collector/join.rs` ×3** — `Option::map_or(true, p)` → `is_none_or(p)` (`unnecessary_map_or`; identical truth table).
- **`kirra-collector/manifest.rs`** — `io::Error::new(ErrorKind::Other, e)` → `io::Error::other(e)` (`io_other_error`; identical error).
- **`kirra-proposal-bench/main.rs`** — inline the trailing `"{}", "VERDICT"` header column into the literal (trivial format-arg lint; identical output).

Auto-applied via `cargo clippy --fix`, reviewed. Both crates: **clippy clean, tests green** (collector 16 + 8 pass). No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_