### PR TITLE
refactor(core): de-monolith Stage 2 — untangle the governor from heavy modules

### DIFF
--- a/crates/kirra-core/src/lib.rs
+++ b/crates/kirra-core/src/lib.rs
@@ -31,3 +31,18 @@ pub enum FleetPosture {
     Degraded,
     LockedOut,
 }
+
+/// Event payload written to the audit chain when the Track-C perception
+/// monitor (KIRRA-OCCY-PMON-001) applies a derate. `reason` is the byte-stable
+/// `DerateCode` token (SCREAMING_SNAKE_CASE) and is used as the chain
+/// `event_type`; `cap_mps` is the resulting permitted-speed cap (`0.0` =
+/// controlled stop). All fields are included in the SHA-256 hash.
+///
+/// Stage 2: relocated here (a lean, dependency-light event payload) so the gateway's
+/// `perception_monitor` does not import the heavy `audit_chain` (rusqlite) to name it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerceptionDerateEvent {
+    pub reason: String,
+    pub cap_mps: f64,
+    pub timestamp_ms: u64,
+}

--- a/src/audit_chain.rs
+++ b/src/audit_chain.rs
@@ -16,17 +16,10 @@ pub struct RssViolationEvent {
     pub timestamp_ms: u64,
 }
 
-/// Event payload written to the audit chain when the Track-C perception
-/// monitor (KIRRA-OCCY-PMON-001) applies a derate. `reason` is the byte-stable
-/// `DerateCode` token (SCREAMING_SNAKE_CASE) and is used as the chain
-/// `event_type`; `cap_mps` is the resulting permitted-speed cap (`0.0` =
-/// controlled stop). All fields are included in the SHA-256 hash.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct PerceptionDerateEvent {
-    pub reason: String,
-    pub cap_mps: f64,
-    pub timestamp_ms: u64,
-}
+// `PerceptionDerateEvent` moved to the lean `kirra-core` crate (de-monolith Stage 2)
+// so the gateway's `perception_monitor` can name it without importing this heavy
+// (rusqlite) module. Re-exported so every existing `crate::audit_chain::*` path holds.
+pub use kirra_core::PerceptionDerateEvent;
 
 /// Typed audit entries for the hash-chained ledger.
 /// Each variant is serialised to JSON and becomes the `event_json` column value.

--- a/src/gateway/interceptor.rs
+++ b/src/gateway/interceptor.rs
@@ -7,4 +7,5 @@
 pub use crate::posture_cache::{
     CachedFleetPosture, SharedPostureCache, now_ms, should_route_command,
 };
-pub use crate::verifier::{FleetPosture, NodeTrustState};
+// From the lean foundation, not the heavy `verifier` module (Stage 2) — same types.
+pub use kirra_core::{FleetPosture, NodeTrustState};

--- a/src/gateway/perception_monitor.rs
+++ b/src/gateway/perception_monitor.rs
@@ -28,7 +28,9 @@
 //     not yet a single function (see doc §5.2 / §7).
 //   - `wcet_gate` budget registration for both guards.
 
-use crate::audit_chain::PerceptionDerateEvent;
+// Imported from the lean foundation, not the heavy `audit_chain` (Stage 2): the
+// gateway/governor surface stays free of the verifier service's deps.
+use kirra_core::PerceptionDerateEvent;
 
 // ---------------------------------------------------------------------------
 // Bounds & constants

--- a/src/gateway/policy.rs
+++ b/src/gateway/policy.rs
@@ -332,7 +332,7 @@ mod tests {
     #[test]
     fn test_unrecognized_write_path_denied_in_all_postures() {
         use crate::posture_cache::{should_route_command, CachedFleetPosture, POSTURE_CACHE_TTL_MS};
-        use crate::verifier::FleetPosture;
+        use kirra_core::FleetPosture;
 
         let cmd = classify_http_command("POST", "/admin/shutdown");
         assert_eq!(cmd, OperationalCommand::Unknown);


### PR DESCRIPTION
**De-monolith Stage 2** — removes the gateway/governor's last imports of the verifier-service's heavy modules, so **Stage 3 can move the governor (the kinematics-contract talisman) to `kirra-core` cleanly.**

## What

- **Move `PerceptionDerateEvent`** (a plain serde struct — no rusqlite) from the heavy `audit_chain` (rusqlite) to `kirra-core`; re-export from `audit_chain` so every `crate::audit_chain::PerceptionDerateEvent` path holds.
- **Repoint the gateway's imports at the lean foundation directly:**
  - `gateway/perception_monitor` → `kirra_core::PerceptionDerateEvent` (was `crate::audit_chain::…` — its only heavy-module import);
  - `gateway/interceptor` → `kirra_core::{FleetPosture, NodeTrustState}` (was `crate::verifier::…`; same types, now from kirra-core);
  - `gateway/policy` test → `kirra_core::FleetPosture`.

**Result:** the gateway has **zero** imports of `verifier` / `audit_chain` / the other heavy modules (verified by scan). `policy_layer.rs` is the HTTP layer that stays in the service by design.

## Safety

Pure move + re-export — **no logic changed**. (The talisman itself isn't touched yet — that's Stage 3, which you'll review closely.)

## Gate

Root crate builds; **all 633 lib tests pass**; `kirra-core` + root **clippy clean**; **parko-kirra builds** (consumes the re-exports). `kirra-core` stays lean (serde only).

## Next

Stage 3 — move the governor / kinematics-contract **talisman** to `kirra-core` (verbatim block, owner-reviewed), now that nothing in it reaches into the heavy modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_