### PR TITLE
fix(governor-service): depend on kirra-core for the talisman (repairs main after #496)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,6 +1991,7 @@ name = "kirra-governor-service"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "kirra-core",
  "serde",
 ]
 

--- a/crates/kirra-governor-service/Cargo.toml
+++ b/crates/kirra-governor-service/Cargo.toml
@@ -23,5 +23,9 @@ name = "kirra-governor-service"
 path = "src/main.rs"
 
 [dependencies]
+# The FROZEN kinematics-contract talisman (de-monolith Stage 3) — lean (serde-only),
+# so this isolated governor stays minimal. Was a relative `#[path]` include of the
+# root `src/gateway/kinematics_contract.rs`; now a proper dependency on the same code.
+kirra-core = { path = "../kirra-core" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1.3"

--- a/crates/kirra-governor-service/src/main.rs
+++ b/crates/kirra-governor-service/src/main.rs
@@ -16,18 +16,11 @@
 // Ferrocene / `no_std` / ASIL-D factoring and the shared-memory mailbox are a
 // later stage and do not block the demo — see ADR-0001 and the bring-up runbook.
 
-// Compile the real verdict core in verbatim. Path is relative to THIS file:
-// crates/kirra-governor-service/src/ -> ../../../ = repo root -> src/gateway/...
-// `allow(dead_code)`: the core exposes the full contract API (e.g.
-// `enforce_degraded_decel_to_stop`, `mrc_fallback_profile`) that the parent
-// crate uses; this minimal binary only calls `validate_vehicle_command`, so the
-// rest is legitimately unused HERE — not dead. We do not edit the file to
-// silence this (talisman); we scope the allow to the include site.
-#[allow(dead_code)]
-#[path = "../../../src/gateway/kinematics_contract.rs"]
-mod kinematics_contract;
-
-use kinematics_contract::{
+// The real verdict core — the FROZEN kinematics-contract talisman — now lives in the
+// lean `kirra-core` crate (de-monolith Stage 3). This minimal isolated governor depends
+// on it directly (serde-only, no service/runtime deps), replacing the prior relative
+// `#[path]` include of the root `src/gateway/kinematics_contract.rs` (same contract).
+use kirra_core::kinematics_contract::{
     validate_vehicle_command, DenyCode, EnforceAction, ProposedVehicleCommand,
     VehicleKinematicsContract,
 };


### PR DESCRIPTION
## ⚠️ Fixes a red `main`

#496 (Stage 3 — relocate the talisman) merged **without** this follow-through, so `main` currently fails the **Test** + **Branch Coverage** jobs: `kirra-governor-service` (the two-box UDP governor) re-used the contract by a relative `#[path]` include of `src/gateway/kinematics_contract.rs`. After Stage 3 that file is `pub use kirra_core::kinematics_contract::*;`, which the governor crate can't resolve — it didn't depend on `kirra-core`.

(ISO-26262 + WCET passed on #496 — the talisman bytes are unchanged. This is purely the build-wiring of the one crate that *textually included* the talisman file.)

## Fix (also cleaner than the old include)

`kirra-governor-service` now **depends on `kirra-core` and imports the contract directly** — `use kirra_core::kinematics_contract::{…}` — dropping the fragile relative `#[path]` include of a root-crate file. It stays minimal: `kirra-core` is serde-only, exactly the lean-governor profile this binary wants. **No contract change.**

## Verified

The **full workspace compiles with `--tests`** (the Test-job phase that failed); `kirra-governor-service` builds, **6 tests pass**, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_