### PR TITLE
de-monolith Stage 6a: relocate the lean corridor + trajectory substrate to kirra-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,6 +2024,7 @@ dependencies = [
  "cxx-build",
  "dashmap",
  "futures",
+ "kirra-core",
  "kirra-runtime-sdk",
  "parko-core",
  "r2r",

--- a/crates/kirra-core/src/corridor.rs
+++ b/crates/kirra-core/src/corridor.rs
@@ -1,0 +1,123 @@
+// crates/kirra-core/src/corridor.rs (de-monolith Stage 6a: relocated verbatim from the
+// kirra-ros2-adapter `corridor` module)
+//
+// CorridorSource — the seam between the map/perception side (Lanelet2 +
+// localization in production) and the slow-loop containment check. The lean
+// trait + `Point` + `MockCorridorSource` live here so the shared lane map
+// (kirra-map) and the planner can depend on them without the heavy adapter.
+// The Lanelet2 cxx bridge (C++ linkage, feature-gated) STAYS in the adapter and
+// impls this trait.
+//
+// `Point` matches `kirra_core::containment::Point` field-for-field. The match is
+// by convention here; the slow loop converts via a field-for-field copy (no
+// semantic translation) so it can call `validate_trajectory_containment`.
+
+/// 2D point in world frame. Field-compatible with
+/// `kirra_core::containment::Point`. The match is by convention here; the slow
+/// loop copies field-for-field into the safety-kernel type.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point {
+    pub x_m: f64,
+    pub y_m: f64,
+}
+
+/// Trait-object friendly view of a drivable-space corridor. The slow loop
+/// reads the four accessors per per-trajectory validation and never
+/// materializes a separate corridor allocation.
+///
+/// Implementors own the underlying polyline storage (typically a `Vec<Point>`)
+/// and return borrows into it. This keeps `Corridor<'a>` (the kernel-side
+/// type that `validate_trajectory_containment` consumes) constructable
+/// without copy.
+pub trait CorridorSource: Send + Sync {
+    /// Left boundary polyline, advancing in the same direction along the
+    /// corridor as `right_boundary`.
+    fn left_boundary(&self) -> &[Point];
+
+    /// Right boundary polyline.
+    fn right_boundary(&self) -> &[Point];
+
+    /// Source confidence, `[0.0, 1.0]`. Compared against
+    /// `min_confidence` on the kernel-side `Corridor` to decide health.
+    fn confidence(&self) -> f32;
+
+    /// Snapshot age in ms vs. now. Compared against `max_age_ms` on the
+    /// kernel-side `Corridor` to decide freshness.
+    fn age_ms(&self) -> u64;
+}
+
+/// 5 m half-width straight corridor along the +X axis. Sole purpose:
+/// exercise the adapter end-to-end in Phase 1 unit / smoke tests
+/// without a Lanelet2 dependency. Production builds use a Lanelet2-
+/// derived source (Phase 2).
+pub struct MockCorridorSource {
+    left: Vec<Point>,
+    right: Vec<Point>,
+    confidence: f32,
+    age_ms: u64,
+}
+
+impl MockCorridorSource {
+    /// 5 m half-width × `length_m` long corridor centred on the +X axis.
+    /// Both polylines have two vertices (the minimum the kernel accepts).
+    pub fn straight_5m_half_width(length_m: f64) -> Self {
+        Self {
+            left:  vec![Point { x_m: 0.0, y_m:  5.0 }, Point { x_m: length_m, y_m:  5.0 }],
+            right: vec![Point { x_m: 0.0, y_m: -5.0 }, Point { x_m: length_m, y_m: -5.0 }],
+            confidence: 0.95,
+            age_ms: 10,
+        }
+    }
+
+    /// Custom-tuned mock for staleness / low-confidence tests.
+    pub fn with_health(mut self, confidence: f32, age_ms: u64) -> Self {
+        self.confidence = confidence;
+        self.age_ms = age_ms;
+        self
+    }
+}
+
+impl CorridorSource for MockCorridorSource {
+    fn left_boundary(&self) -> &[Point]  { &self.left }
+    fn right_boundary(&self) -> &[Point] { &self.right }
+    fn confidence(&self) -> f32          { self.confidence }
+    fn age_ms(&self) -> u64              { self.age_ms }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_5m_corridor_has_2_vertex_polylines() {
+        let c = MockCorridorSource::straight_5m_half_width(100.0);
+        assert_eq!(c.left_boundary().len(), 2);
+        assert_eq!(c.right_boundary().len(), 2);
+        // Half-width = 5 m on each side.
+        assert_eq!(c.left_boundary()[0].y_m, 5.0);
+        assert_eq!(c.right_boundary()[0].y_m, -5.0);
+    }
+
+    #[test]
+    fn mock_with_health_overrides_confidence_and_age() {
+        let c = MockCorridorSource::straight_5m_half_width(50.0).with_health(0.3, 1_000);
+        assert_eq!(c.confidence(), 0.3);
+        assert_eq!(c.age_ms(), 1_000);
+    }
+
+    /// The trait object form is what the adapter Node carries. Confirm
+    /// `Arc<dyn CorridorSource>` constructs and the methods dispatch
+    /// dynamically.
+    #[test]
+    fn corridor_source_is_dyn_safe() {
+        use std::sync::Arc;
+        let src: Arc<dyn CorridorSource> =
+            Arc::new(MockCorridorSource::straight_5m_half_width(20.0));
+        assert_eq!(src.left_boundary().len(), 2);
+        assert!(src.confidence() > 0.0);
+    }
+}

--- a/crates/kirra-core/src/lib.rs
+++ b/crates/kirra-core/src/lib.rs
@@ -45,6 +45,18 @@ pub mod governor_guard;
 /// by `kirra_runtime_sdk::posture_tracker` so the ROS2 adapter and the parko-ros2 node hold.
 pub mod posture_tracker;
 
+/// The lean drivable-corridor seam (`Point` / `CorridorSource` / `MockCorridorSource`).
+/// Relocated verbatim from the kirra-ros2-adapter (de-monolith Stage 6a) so the shared
+/// lane map (kirra-map) and the planner can build on it without the heavy adapter; the
+/// adapter re-exports it (and the feature-gated Lanelet2 cxx source impls the trait).
+pub mod corridor;
+
+/// The lean trajectory/perception data types (`Pose` / `TrajectoryPoint` /
+/// `TrajectoryVerdict` / `PerceivedObject`) — pure plain-old-data the planner and the
+/// shared lane map consume. Relocated verbatim from the kirra-ros2-adapter `state` module
+/// (de-monolith Stage 6a); the adapter's heavy `AdaptorState` re-exports them.
+pub mod trajectory;
+
 /// A registered node's trust state, as decided by attestation and the recovery
 /// hysteresis. `Untrusted` carries a human-readable reason tag.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/kirra-core/src/trajectory.rs
+++ b/crates/kirra-core/src/trajectory.rs
@@ -1,0 +1,74 @@
+// crates/kirra-core/src/trajectory.rs (de-monolith Stage 6a: relocated verbatim from the
+// kirra-ros2-adapter `state` module)
+//
+// The lean trajectory/perception data types the planner and the shared lane map
+// (kirra-map) consume: `Pose`, `TrajectoryPoint`, `TrajectoryVerdict`, and
+// `PerceivedObject`. These are pure plain-old-data — no DashMap, no PostureTracker,
+// no async. The adapter's `AdaptorState` runtime store, `AcceptedTrajectory` slot
+// record, `EgoOdom`, and `IncomingTrajectory` STAY in the adapter (they couple to the
+// DashMap concurrency model) and reference these types via re-export.
+
+use crate::corridor::Point;
+
+/// One pose along a trajectory, in world frame. The shape matches
+/// `kirra_core::containment::Pose` so a conversion is field-for-field (no
+/// semantic translation required).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Pose {
+    pub x_m: f64,
+    pub y_m: f64,
+    pub heading_rad: f64,
+}
+
+/// One sample from an Autoware-shaped trajectory. The `time_from_start_s`
+/// is the planner's intended time-to-pose; the slow loop uses it to derive
+/// per-step `delta_time_s` for the kinematics check.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TrajectoryPoint {
+    pub pose: Pose,
+    pub velocity_mps: f64,
+    pub time_from_start_s: f64,
+}
+
+/// Outcome of validating a candidate trajectory. The slow loop emits this
+/// when it promotes (or refuses to promote) a new trajectory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrajectoryVerdict {
+    /// Promoted — the per-asset slot now holds this trajectory; the fast
+    /// loop will conform commands to it.
+    Accept,
+    /// Clamp-only path: per-pose kinematics requested a Clamp (linear or
+    /// steering) on at least one pose, but containment + RSS both passed.
+    /// The caller's policy is "promote a speed-derated variant" — see
+    /// design §3. Fast loop treats this as a special Accept where the
+    /// permissible-velocity envelope is below the planner's commanded
+    /// velocity; safe to drive but not at the planned speed.
+    Clamp,
+    /// Refused — the slow loop rejected the candidate (or no candidate
+    /// has ever been validated). Fast loop must MRC.
+    MRCFallback,
+    /// Initial / transitional state, set when an asset is registered but
+    /// no validation has completed yet. Always fails closed
+    /// (`fail_closed()` collapses this to `MRCFallback`).
+    Pending,
+}
+
+/// A perceived object reported by the integrator's perception stack.
+/// The fields are the minimal set RSS needs (the slow loop runs
+/// `longitudinal_safe_distance` + `lateral_safe_distance` per object × per
+/// pose). Position is the centroid in world frame; heading is the object's
+/// motion direction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PerceivedObject {
+    pub id: u64,
+    pub pos: Point,
+    pub velocity_mps: f64,
+    pub heading_rad: f64,
+    /// Reported map-frame ground-velocity **vector** `{x_m, y_m}` (m/s),
+    /// preserved from the upstream Autoware twist (KIRRA-OCCY-PMON-003 §5
+    /// sub-decision = PRESERVE). `velocity_mps` stays the magnitude RSS uses;
+    /// `vel` feeds the Track-C kinematic-plausibility ceiling (a vector-
+    /// magnitude check). Frame note: rests on the upstream message contract
+    /// being map/world-frame absolute — see PMON-003 §4 / D4.
+    pub vel: Point,
+}

--- a/crates/kirra-ros2-adapter/Cargo.toml
+++ b/crates/kirra-ros2-adapter/Cargo.toml
@@ -67,6 +67,11 @@ dashmap = "6"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 
+# Lean foundation — the corridor seam (`Point`/`CorridorSource`/`MockCorridorSource`)
+# and the trajectory/perception data types (`Pose`/`TrajectoryPoint`/`TrajectoryVerdict`/
+# `PerceivedObject`) live here (de-monolith Stage 6a), so the shared lane map and the
+# planner build on them without the heavy adapter. serde-only, no ROS/async.
+kirra-core        = { path = "../kirra-core" }
 # Safety kernel — pulled in Phase 2A so the slow-loop validator can call
 # `validate_trajectory_containment` (SG2) and `validate_vehicle_command`
 # (per-pose kinematics). NOT feature-gated: the algorithm is needed in

--- a/crates/kirra-ros2-adapter/src/corridor/mod.rs
+++ b/crates/kirra-ros2-adapter/src/corridor/mod.rs
@@ -1,12 +1,15 @@
 // crates/kirra-ros2-adapter/src/corridor/mod.rs
 //
 // Sub-modules:
-//   - this file: the `CorridorSource` trait + `MockCorridorSource`
-//     (always built; no ROS deps).
+//   - the `CorridorSource` trait + `Point` + `MockCorridorSource` now live in the
+//     lean `kirra-core` crate (de-monolith Stage 6a) and are re-exported below, so
+//     the shared lane map (kirra-map) and the planner can depend on them without the
+//     heavy adapter. Every existing `crate::corridor::*` /
+//     `kirra_ros2_adapter::corridor::*` path keeps the SAME type — zero churn.
 //   - `lanelet2_bridge` (feature `lanelet2`): the cxx::bridge calling into
 //     the lanelet2_core C++ boost::serialization deserializer.
 //   - `lanelet2` (feature `lanelet2`): the `Lanelet2CorridorSource` impl
-//     of `CorridorSource`.
+//     of `CorridorSource` (impls the now-`kirra-core` trait for its local type).
 //
 // The lanelet2 corridor bridge is gated on the `lanelet2` feature (which
 // implies `ros2`), NOT on `ros2` alone — the perception-governance path
@@ -16,6 +19,10 @@
 // localization in production) and the slow-loop containment check.
 //
 
+// The lean trait + `Point` + `MockCorridorSource` — same types, now sourced from
+// `kirra-core` (relocated verbatim in Stage 6a).
+pub use kirra_core::corridor::{CorridorSource, MockCorridorSource, Point};
+
 #[cfg(feature = "lanelet2")]
 pub mod lanelet2_bridge;
 
@@ -24,129 +31,3 @@ pub mod lanelet2;
 
 #[cfg(feature = "lanelet2")]
 pub use self::lanelet2::{Lanelet2CorridorSource, Lanelet2Error};
-
-// ---------------------------------------------------------------------------
-// The trait + Mock impl — always built, no ROS deps.
-//
-// Phase 1 ships a single `MockCorridorSource` (a 5 m half-width straight
-// corridor) so the adapter and its state machine can be exercised
-// end-to-end without bringing Lanelet2 into the build. Phase 2 will add
-// a `Lanelet2CorridorSource` that derives the corridor from a `MapBin`
-// + ego-pose; the slow loop will see an identical trait surface.
-//
-// `Point` matches `kirra_runtime_sdk::gateway::containment::Point`
-// field-for-field. Phase 2 swaps to the kirra-runtime-sdk type via a
-// `From` impl (no semantic translation) so the slow loop can call
-// `validate_trajectory_containment(traj, corridor, footprint)` without
-// copying polylines.
-
-/// 2D point in world frame. Field-compatible with
-/// `kirra_runtime_sdk::gateway::containment::Point`. The match is by
-/// convention here; Phase 2 promotes this to a re-export of the
-/// safety-kernel type.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Point {
-    pub x_m: f64,
-    pub y_m: f64,
-}
-
-/// Trait-object friendly view of a drivable-space corridor. The slow loop
-/// reads the four accessors per per-trajectory validation and never
-/// materializes a separate corridor allocation.
-///
-/// Implementors own the underlying polyline storage (typically a `Vec<Point>`)
-/// and return borrows into it. This keeps `Corridor<'a>` (the kernel-side
-/// type that `validate_trajectory_containment` consumes) constructable
-/// without copy.
-pub trait CorridorSource: Send + Sync {
-    /// Left boundary polyline, advancing in the same direction along the
-    /// corridor as `right_boundary`.
-    fn left_boundary(&self) -> &[Point];
-
-    /// Right boundary polyline.
-    fn right_boundary(&self) -> &[Point];
-
-    /// Source confidence, `[0.0, 1.0]`. Compared against
-    /// `min_confidence` on the kernel-side `Corridor` to decide health.
-    fn confidence(&self) -> f32;
-
-    /// Snapshot age in ms vs. now. Compared against `max_age_ms` on the
-    /// kernel-side `Corridor` to decide freshness.
-    fn age_ms(&self) -> u64;
-}
-
-/// 5 m half-width straight corridor along the +X axis. Sole purpose:
-/// exercise the adapter end-to-end in Phase 1 unit / smoke tests
-/// without a Lanelet2 dependency. Production builds use a Lanelet2-
-/// derived source (Phase 2).
-pub struct MockCorridorSource {
-    left: Vec<Point>,
-    right: Vec<Point>,
-    confidence: f32,
-    age_ms: u64,
-}
-
-impl MockCorridorSource {
-    /// 5 m half-width × `length_m` long corridor centred on the +X axis.
-    /// Both polylines have two vertices (the minimum the kernel accepts).
-    pub fn straight_5m_half_width(length_m: f64) -> Self {
-        Self {
-            left:  vec![Point { x_m: 0.0, y_m:  5.0 }, Point { x_m: length_m, y_m:  5.0 }],
-            right: vec![Point { x_m: 0.0, y_m: -5.0 }, Point { x_m: length_m, y_m: -5.0 }],
-            confidence: 0.95,
-            age_ms: 10,
-        }
-    }
-
-    /// Custom-tuned mock for staleness / low-confidence tests.
-    pub fn with_health(mut self, confidence: f32, age_ms: u64) -> Self {
-        self.confidence = confidence;
-        self.age_ms = age_ms;
-        self
-    }
-}
-
-impl CorridorSource for MockCorridorSource {
-    fn left_boundary(&self) -> &[Point]  { &self.left }
-    fn right_boundary(&self) -> &[Point] { &self.right }
-    fn confidence(&self) -> f32          { self.confidence }
-    fn age_ms(&self) -> u64              { self.age_ms }
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn mock_5m_corridor_has_2_vertex_polylines() {
-        let c = MockCorridorSource::straight_5m_half_width(100.0);
-        assert_eq!(c.left_boundary().len(), 2);
-        assert_eq!(c.right_boundary().len(), 2);
-        // Half-width = 5 m on each side.
-        assert_eq!(c.left_boundary()[0].y_m, 5.0);
-        assert_eq!(c.right_boundary()[0].y_m, -5.0);
-    }
-
-    #[test]
-    fn mock_with_health_overrides_confidence_and_age() {
-        let c = MockCorridorSource::straight_5m_half_width(50.0).with_health(0.3, 1_000);
-        assert_eq!(c.confidence(), 0.3);
-        assert_eq!(c.age_ms(), 1_000);
-    }
-
-    /// The trait object form is what the adapter Node carries. Confirm
-    /// `Arc<dyn CorridorSource>` constructs and the methods dispatch
-    /// dynamically.
-    #[test]
-    fn corridor_source_is_dyn_safe() {
-        use std::sync::Arc;
-        let src: Arc<dyn CorridorSource> =
-            Arc::new(MockCorridorSource::straight_5m_half_width(20.0));
-        assert_eq!(src.left_boundary().len(), 2);
-        assert!(src.confidence() > 0.0);
-    }
-}

--- a/crates/kirra-ros2-adapter/src/state.rs
+++ b/crates/kirra-ros2-adapter/src/state.rs
@@ -23,51 +23,17 @@ use std::sync::{Arc, RwLock};
 use kirra_runtime_sdk::verifier::FleetPosture;
 
 use crate::config::VehicleConfig;
-use crate::corridor::Point;
 use kirra_runtime_sdk::posture_tracker::PostureTracker;
 
-/// One pose along a trajectory, in world frame. The shape matches
-/// `kirra_runtime_sdk::gateway::containment::Pose` so a Phase 2 conversion
-/// is field-for-field (no semantic translation required).
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Pose {
-    pub x_m: f64,
-    pub y_m: f64,
-    pub heading_rad: f64,
-}
+// The lean trajectory/perception data types now live in the `kirra-core` crate
+// (de-monolith Stage 6a); re-exported here so every existing `crate::state::*` /
+// `kirra_ros2_adapter::state::*` path keeps the SAME type. `AdaptorState` and
+// `AcceptedTrajectory` (below, both heavy/DashMap-coupled — they stay) consume them
+// unchanged.
+pub use kirra_core::trajectory::{PerceivedObject, Pose, TrajectoryPoint, TrajectoryVerdict};
 
-/// One sample from an Autoware-shaped trajectory. The `time_from_start_s`
-/// is the planner's intended time-to-pose; the slow loop uses it to derive
-/// per-step `delta_time_s` for the kinematics check.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct TrajectoryPoint {
-    pub pose: Pose,
-    pub velocity_mps: f64,
-    pub time_from_start_s: f64,
-}
-
-/// Outcome of validating a candidate trajectory. The slow loop emits this
-/// when it promotes (or refuses to promote) a new trajectory.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TrajectoryVerdict {
-    /// Promoted — the per-asset slot now holds this trajectory; the fast
-    /// loop will conform commands to it.
-    Accept,
-    /// Clamp-only path: per-pose kinematics requested a Clamp (linear or
-    /// steering) on at least one pose, but containment + RSS both passed.
-    /// The caller's policy is "promote a speed-derated variant" — see
-    /// design §3. Fast loop treats this as a special Accept where the
-    /// permissible-velocity envelope is below the planner's commanded
-    /// velocity; safe to drive but not at the planned speed.
-    Clamp,
-    /// Refused — the slow loop rejected the candidate (or no candidate
-    /// has ever been validated). Fast loop must MRC.
-    MRCFallback,
-    /// Initial / transitional state, set when an asset is registered but
-    /// no validation has completed yet. Always fails closed
-    /// (`fail_closed()` collapses this to `MRCFallback`).
-    Pending,
-}
+// `Pose`, `TrajectoryPoint`, and `TrajectoryVerdict` were relocated verbatim to
+// `kirra_core::trajectory` (de-monolith Stage 6a) and are re-exported above.
 
 /// The per-asset accepted-trajectory record held in `AdaptorState`.
 #[derive(Debug, Clone)]
@@ -177,25 +143,8 @@ impl AcceptedTrajectory {
     }
 }
 
-/// A perceived object reported by the integrator's perception stack.
-/// The fields are the minimal set RSS needs (the slow loop runs
-/// `longitudinal_safe_distance` + `lateral_safe_distance` per object × per
-/// pose). Position is the centroid in world frame; heading is the object's
-/// motion direction.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct PerceivedObject {
-    pub id: u64,
-    pub pos: Point,
-    pub velocity_mps: f64,
-    pub heading_rad: f64,
-    /// Reported map-frame ground-velocity **vector** `{x_m, y_m}` (m/s),
-    /// preserved from the upstream Autoware twist (KIRRA-OCCY-PMON-003 §5
-    /// sub-decision = PRESERVE). `velocity_mps` stays the magnitude RSS uses;
-    /// `vel` feeds the Track-C kinematic-plausibility ceiling (a vector-
-    /// magnitude check). Frame note: rests on the upstream message contract
-    /// being map/world-frame absolute — see PMON-003 §4 / D4.
-    pub vel: Point,
-}
+// `PerceivedObject` was relocated verbatim to `kirra_core::trajectory`
+// (de-monolith Stage 6a) and is re-exported above.
 
 /// Phase 4c — typed-payload envelope for a freshly-received trajectory
 /// after the r2r-side parser has extracted the planner-published points.


### PR DESCRIPTION
## Stage 6a of the de-monolith — extract the lean corridor + trajectory substrate

The first half of the adapter de-monolith. Pulls the dependency-light geometry/perception substrate out of the heavy `kirra-ros2-adapter` into `kirra-core`, so the shared lane map (`kirra-map`, Stage 6b) and the planner can build on it without the adapter's tokio/dashmap/r2r tree. **Pure move + re-export — every existing path keeps the same type.**

### Moved into `kirra-core` (verbatim — fields, variants, derives, trait, impls all byte-identical; only doc comments differ)
- `kirra_core::corridor` ← `Point`, `CorridorSource`, `MockCorridorSource` (+ 3 corridor unit tests)
- `kirra_core::trajectory` ← `Pose`, `TrajectoryPoint`, `TrajectoryVerdict`, `PerceivedObject`

Proof the four trajectory types are faithful:
```
# field/variant/derive lines — ORIGINAL state.rs vs NEW kirra-core/trajectory.rs: identical
pub struct Pose { x_m, y_m, heading_rad }          #[derive(Debug, Clone, Copy, PartialEq)]
pub struct TrajectoryPoint { pose, velocity_mps, time_from_start_s }
pub enum TrajectoryVerdict { Accept, Clamp, MRCFallback, Pending }   (+ Eq)
pub struct PerceivedObject { id, pos, velocity_mps, heading_rad, vel }
# corridor: CODE IDENTICAL modulo the lanelet2 module lines (which stay in the adapter)
```

### Stays in the adapter (correctly heavy / coupled) — now consuming the moved types via re-export
- `AdaptorState` (DashMap + PostureTracker), `AcceptedTrajectory` (slot record + its state-machine tests), `EgoOdom`, `IncomingTrajectory`, all the `AdaptorState` tests
- The feature-gated **Lanelet2 cxx bridge** (C++ linkage) — `Lanelet2CorridorSource` now impls the relocated `kirra_core` trait for its local type (a coherent foreign-trait-for-local-type impl)

The adapter's `corridor`/`state` modules become thin re-export surfaces, so every existing `kirra_ros2_adapter::corridor::{Point, CorridorSource, MockCorridorSource}` / `::state::{Pose, TrajectoryPoint, TrajectoryVerdict, PerceivedObject}` path (planner, `validation.rs`, `node.rs`, tests) is unchanged. The adapter gains a direct `kirra-core` dep and **keeps** `kirra-runtime-sdk` (validation still needs `perception_monitor` + the kernel — a later step if the adapter is to fully shed the heavy dep).

### Unblocks Stage 6b
Lifting the planner's `lanemap.rs` (`LaneGraph` / right-of-way / routing) into a standalone `kirra-map` crate on this lean substrate — the shared lane map originally requested.

### Verification
- Root build + tests green: kirra-core **75** (incl. the 3 relocated corridor tests), adapter **42** + **22** validation + integration green via re-export, planner **102** + integration green consuming the substrate transparently
- CI-equivalent `cargo clippy --workspace -- -D warnings …` clean
- Parko logic green (parko-core **204**, parko-kirra **148**, parko-ros2 **168**)
- No `#[path]` hazards; moves proven field/variant/derive-identical by diff
- (parko-onnx ORT-env failures remain pre-existing/unrelated — no native ONNX lib in this container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_