### PR TITLE
Stage 7 hotfix: declare reqwest `json` feature on the adapter's ros2 build (fixes red main)

### DIFF
--- a/crates/kirra-ros2-adapter/Cargo.toml
+++ b/crates/kirra-ros2-adapter/Cargo.toml
@@ -109,11 +109,13 @@ tracing-subscriber = { version = "0.3", features = ["json", "env-filter"], optio
 futures = { version = "0.3", optional = true }
 
 # M1b — SSE client for the verifier's /system/posture/stream endpoint.
-# `reqwest` is already a workspace-wide dep (via the kernel's
-# kirra_carla_client); the adapter binary uses its streaming API to pump
-# posture events into `PostureTracker`. Gated on `ros2` because the
-# transport only matters when the binary is built.
-reqwest    = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"], optional = true }
+# The adapter binary uses its streaming API to pump posture events into
+# `PostureTracker`, and `response.json()` to parse them. Gated on `ros2`
+# because the transport only matters when the binary is built. The `json`
+# feature is declared explicitly here (de-monolith Stage 7): it was previously
+# activated transitively via the now-severed `kirra-runtime-sdk` reqwest dep
+# through Cargo feature unification.
+reqwest    = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"], optional = true }
 serde_json = { version = "1",    optional = true }
 bytes      = { version = "1",    optional = true }
 


### PR DESCRIPTION
## Hotfix — `main`'s `--features ros2` build is currently red

PR #502 (de-monolith Stage 7) merged before this one-line follow-up landed, so `main` contains the commit whose `ros2 adapter build (--features ros2)` CI job fails:

```
error[E0599]: no method named `json` found for struct `reqwest::Response`
  --> crates/kirra-ros2-adapter/src/posture_source.rs:208:32
```

### Root cause
Severing the `kirra-runtime-sdk` edge (Stage 7) removed a **transitive feature activation**. The adapter's `reqwest` dep is `default-features = false` and only listed `rustls-tls` + `stream`; the `json` method was available purely because `kirra-runtime-sdk`'s `reqwest` dep carried the `json` feature and Cargo unifies features across the build graph. With the SDK edge gone, `json` is no longer pulled in — so the ros2 binary's `response.json()` no longer compiles.

### Fix
Declare `"json"` explicitly on the adapter's own `reqwest` dependency (the feature it actually uses). `cargo tree -p kirra-ros2-adapter --features ros2` confirms `reqwest feature "json"` is now active. The full ros2 build can only be verified in CI — r2r's build script requires a sourced ROS distro — which is exactly what this PR re-triggers.

Scope: a single dependency line in `crates/kirra-ros2-adapter/Cargo.toml` (plus an explanatory comment). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWXgETCGcdP6XXErwLHkFk)_