### PR TITLE
Rename crate kirra-runtime-sdk → kirra-verifier (lib ident kirra_verifier)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         # Authoritative WCET measurement. Runs on stable, non-instrumented,
         # without llvm-cov. The coverage job above skips these tests because
         # instrumentation overhead invalidates wall-clock thresholds.
-        run: cargo test -p kirra-runtime-sdk --lib wcet_gate::ci_gate_tests
+        run: cargo test -p kirra-verifier --lib wcet_gate::ci_gate_tests
 
   parko-safety:
     name: Parko Safety Tests (no ROS, no ORT)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Identity
 
-- **Crate**: `kirra-runtime-sdk` (lib + bin dual-crate, `crate-type = ["rlib", "cdylib"]`)
+- **Crate**: `kirra-verifier` (lib ident `kirra_verifier`; lib + bin dual-crate, `crate-type = ["rlib", "cdylib"]`). Renamed from `kirra-runtime-sdk` once nothing lean depended on it (the GitHub repo remains `kirra-runtime-sdk`).
 - **Edition**: 2021
 - **Primary binary**: `kirra_verifier_service` (`src/bin/kirra_verifier_service.rs`)
 - **Secondary binary**: `kirra_carla_client` (`src/bin/kirra_carla_client.rs`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
- "kirra-runtime-sdk",
+ "kirra-verifier",
  "rand 0.8.6",
  "serde",
  "serde_json",
@@ -2046,7 +2046,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "kirra-runtime-sdk"
+name = "kirra-taj"
+version = "0.1.0"
+dependencies = [
+ "kirra-ros2-adapter",
+ "kirra-verifier",
+]
+
+[[package]]
+name = "kirra-verifier"
 version = "1.1.2"
 dependencies = [
  "axum",
@@ -2076,14 +2084,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tss-esapi",
-]
-
-[[package]]
-name = "kirra-taj"
-version = "0.1.0"
-dependencies = [
- "kirra-ros2-adapter",
- "kirra-runtime-sdk",
 ]
 
 [[package]]
@@ -2571,7 +2571,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "kirra-core",
- "kirra-runtime-sdk",
+ "kirra-verifier",
  "parko-core",
  "proptest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # --- Workspace ----------------------------------------------------------------
 #
 # Top-level workspace (S131 Phase 1, #131). Members:
-#   - "."                          — the root `kirra-runtime-sdk` crate (lib +
+#   - "."                          — the root `kirra-verifier` crate (lib +
 #                                     bins, this manifest).
 #   - "crates/kirra-ros2-adapter"  — the ROS 2 adapter (Phase 1 skeleton; the
 #                                     entry point for Option-B per-trajectory
@@ -17,7 +17,7 @@ members = [".", "crates/kirra-core", "crates/kirra-ros2-adapter", "crates/kirra-
 resolver = "2"
 
 [package]
-name = "kirra-runtime-sdk"
+name = "kirra-verifier"
 version = "1.1.2"
 edition = "2021"
 description = "Vendor-neutral runtime safety kernel for autonomous vehicles, robots, and drones"
@@ -30,7 +30,7 @@ license-file = "COPYRIGHT"
 publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [lib]
-name = "kirra_runtime_sdk"
+name = "kirra_verifier"
 crate-type = ["rlib", "cdylib"]
 
 # Release builds use `panic = "abort"` so an unrecoverable panic on the

--- a/crates/kirra-capture-schema/Cargo.toml
+++ b/crates/kirra-capture-schema/Cargo.toml
@@ -10,7 +10,7 @@ publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 # §0 SAFETY BOUNDARY: this crate depends on `serde` ONLY. It carries no governor
 # types and no logic — just the leaf record shapes. The offline collector depends
-# on THIS crate (never on `kirra-runtime-sdk`), which is what mechanically
+# on THIS crate (never on `kirra-verifier`), which is what mechanically
 # guarantees the collector cannot link or reach the verdict path.
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/kirra-capture-schema/src/lib.rs
+++ b/crates/kirra-capture-schema/src/lib.rs
@@ -3,7 +3,7 @@
 // Wire schema for Kirra's learning-loop capture records (docs/COLLECTOR_DESIGN.md
 // [D6 / C1]). This is the SINGLE authoritative definition of the on-disk capture
 // JSONL shape, shared by two sides:
-//   - the SDK emitters (`kirra_runtime_sdk::capture`), which BUILD records via
+//   - the SDK emitters (`kirra_verifier::capture`), which BUILD records via
 //     constructors that touch governor types and SERIALIZE them, and
 //   - the offline `kirra-collector`, which DESERIALIZES them to assemble the
 //     training dataset.

--- a/crates/kirra-core/Cargo.toml
+++ b/crates/kirra-core/Cargo.toml
@@ -1,7 +1,7 @@
 # crates/kirra-core/Cargo.toml
 #
 # kirra-core — the LEAN safety/contract foundation extracted from the
-# kirra-runtime-sdk monolith (de-monolith Stage 1, ADR pending). Deliberately
+# kirra-verifier monolith (de-monolith Stage 1, ADR pending). Deliberately
 # dependency-light: NO tokio / axum / rusqlite / reqwest / ML. Crates that need the
 # foundational types (the adapter, the planner, the map, parko) depend on THIS, so the
 # certified-governor surface does not drag the verifier service's heavy tree.

--- a/crates/kirra-core/src/capture.rs
+++ b/crates/kirra-core/src/capture.rs
@@ -47,7 +47,7 @@ use crate::FleetPosture;
 // The capture record wire schema lives in the governor-free
 // `kirra-capture-schema` crate (docs/COLLECTOR_DESIGN.md [C1]); re-export it so
 // every existing `crate::capture::{CaptureRecord, ...}` /
-// `kirra_runtime_sdk::capture::*` path keeps resolving, and so the SDK and the
+// `kirra_verifier::capture::*` path keeps resolving, and so the SDK and the
 // offline collector share ONE authoritative definition with no drift.
 pub use kirra_capture_schema::*;
 

--- a/crates/kirra-core/src/lib.rs
+++ b/crates/kirra-core/src/lib.rs
@@ -9,9 +9,9 @@
 //! unchanged.
 //!
 //! Stage 1: the fleet posture / node trust types, previously defined in the heavy
-//! `kirra_runtime_sdk::verifier` module and imported across the whole stack.
+//! `kirra_verifier::verifier` module and imported across the whole stack.
 
-// Mirror the parent crate's doc-lint posture (`kirra_runtime_sdk` lib root) so the
+// Mirror the parent crate's doc-lint posture (`kirra_verifier` lib root) so the
 // verbatim-relocated modules (the kinematics-contract talisman, the SG2 containment
 // checker) keep their byte-identical doc comments — the safety-derivation tables use
 // aligned arithmetic continuations that these two pedantic doc lints would otherwise
@@ -23,26 +23,26 @@ use serde::{Deserialize, Serialize};
 /// The FROZEN kinematics-contract talisman — the deterministic vehicle flight-envelope
 /// safety contract (`EnforceAction` / `DenyCode` / `VehicleKinematicsContract` /
 /// `validate_vehicle_command`). Relocated here verbatim (de-monolith Stage 3); re-exported
-/// by `kirra_runtime_sdk::gateway::kinematics_contract` so every existing path holds.
+/// by `kirra_verifier::gateway::kinematics_contract` so every existing path holds.
 pub mod kinematics_contract;
 
 /// The SG2 drivable-space containment checker — the per-trajectory corridor-containment
 /// sibling of `validate_vehicle_command` (`VehicleFootprint` / `Corridor` / `Pose` /
 /// `validate_trajectory_containment` / `MAX_TRAJECTORY_HORIZON`). Relocated here verbatim
-/// (de-monolith Stage 4); re-exported by `kirra_runtime_sdk::gateway::containment` so every
+/// (de-monolith Stage 4); re-exported by `kirra_verifier::gateway::containment` so every
 /// existing path (the ROS2 adapter, the planner) holds.
 pub mod containment;
 
 /// The shared non-finite governor-input guard (`all_finite`, the #410 convergence point).
 /// A dependency-free predicate every governor entry calls. Relocated here verbatim
-/// (de-monolith Stage 5); re-exported by `kirra_runtime_sdk::governor_guard` so the
+/// (de-monolith Stage 5); re-exported by `kirra_verifier::governor_guard` so the
 /// SDK's internal callers (the scalar kernel, the C FFI) and parko's diverse governor hold.
 pub mod governor_guard;
 
 /// The fail-closed fleet-posture state machine (`PostureTracker` /
 /// `POSTURE_STALENESS_TIMEOUT_MS`) — a pure, deterministic, clock-injected machine whose
 /// only input is `FleetPosture`. Relocated here verbatim (de-monolith Stage 5); re-exported
-/// by `kirra_runtime_sdk::posture_tracker` so the ROS2 adapter and the parko-ros2 node hold.
+/// by `kirra_verifier::posture_tracker` so the ROS2 adapter and the parko-ros2 node hold.
 pub mod posture_tracker;
 
 /// The lean drivable-corridor seam (`Point` / `CorridorSource` / `MockCorridorSource`).
@@ -63,7 +63,7 @@ pub mod trajectory;
 /// dependency-light (`std::sync` + the kinematics-contract talisman + `PerceptionDerateEvent`),
 /// so it rides on the lean foundation. Relocated verbatim from the SDK's
 /// `gateway::perception_monitor` (de-monolith Stage 7); re-exported by
-/// `kirra_runtime_sdk::gateway::perception_monitor` so every existing path (the verifier
+/// `kirra_verifier::gateway::perception_monitor` so every existing path (the verifier
 /// service, the ROS2 adapter) holds.
 pub mod perception_monitor;
 
@@ -71,7 +71,7 @@ pub mod perception_monitor;
 /// `apply_enforce_action` / `run_simulation`) — the deterministic bicycle-model integrator
 /// the scenario harness uses to assert physical outcomes. Pure physics over the
 /// kinematics-contract talisman; no service/runtime deps. Relocated verbatim from the SDK
-/// (de-monolith Stage 7); re-exported by `kirra_runtime_sdk::kinematics_sim`.
+/// (de-monolith Stage 7); re-exported by `kirra_verifier::kinematics_sim`.
 pub mod kinematics_sim;
 
 /// The learning-loop capture channel — the record BUILDERS (`record_from_verdict` /
@@ -81,7 +81,7 @@ pub mod kinematics_sim;
 /// because the writer pulls `tokio` / `serde_json` / `tracing` — crates that only need the
 /// foundation (the planner, the lane map, parko, the governor-service) keep core serde-only.
 /// Relocated verbatim from the SDK (de-monolith Stage 7); re-exported by
-/// `kirra_runtime_sdk::capture`.
+/// `kirra_verifier::capture`.
 #[cfg(feature = "capture")]
 pub mod capture;
 

--- a/crates/kirra-fleet-transport/Cargo.toml
+++ b/crates/kirra-fleet-transport/Cargo.toml
@@ -26,7 +26,7 @@ publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 # FederatedTrustReportV2 / verify_federated_report_signature_v2 / FleetPosture and
 # the Phase-A clearance-grant store path. This crate adds NO new payload trust
 # logic of its own beyond a grant envelope that reuses the same Ed25519 pattern.
-kirra-runtime-sdk = { path = "../.." }
+kirra-verifier = { path = "../.." }
 
 # The fleet carrier. default-features OFF (no TLS/QUIC — see the manifest note);
 # `transport_tcp` = the localhost peer transport; `unstable` only for the explicit

--- a/crates/kirra-fleet-transport/src/lib.rs
+++ b/crates/kirra-fleet-transport/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! 1. **Untrusted carrier (the trust rule).** Zenoh is an UNTRUSTED CARRIER.
 //!    Trust derives from **Ed25519 payload signatures** — federation reports via
-//!    [`kirra_runtime_sdk::federation_reconciliation::verify_federated_report_signature_v2`],
+//!    [`kirra_verifier::federation_reconciliation::verify_federated_report_signature_v2`],
 //!    grants via [`verify_clearance_grant`] — **never** from transport identity, a
 //!    topic name, or Zenoh's own auth. Every ingest **verifies before use**;
 //!    unsigned / bad-signature / malformed payloads are rejected and **counted**
@@ -30,12 +30,12 @@ use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
-use kirra_runtime_sdk::federation_reconciliation::{
+use kirra_verifier::federation_reconciliation::{
     evaluate_federated_report_v2, verify_federated_report_signature_v2, FederatedTrustReportV2,
 };
-use kirra_runtime_sdk::key_registry::{KeyRegistry, KeyRole};
-use kirra_runtime_sdk::verifier::FleetPosture;
-use kirra_runtime_sdk::verifier_store::VerifierStore;
+use kirra_verifier::key_registry::{KeyRegistry, KeyRole};
+use kirra_verifier::verifier::FleetPosture;
+use kirra_verifier::verifier_store::VerifierStore;
 
 pub mod transport;
 
@@ -603,7 +603,7 @@ mod core_tests {
     /// A genuinely signed report, built the way the verifier signs (over the
     /// canonical v2 payload).
     fn signed_report(sk: &SigningKey, asset: &str, gen: Option<u64>) -> FederatedTrustReportV2 {
-        use kirra_runtime_sdk::federation_reconciliation::canonical_federation_payload_v2;
+        use kirra_verifier::federation_reconciliation::canonical_federation_payload_v2;
         let mut report = FederatedTrustReportV2 {
             source_controller_id: "controller-A".into(),
             asset_id: asset.into(),

--- a/crates/kirra-fleet-transport/src/transport.rs
+++ b/crates/kirra-fleet-transport/src/transport.rs
@@ -5,8 +5,8 @@
 
 use zenoh::Session;
 
-use kirra_runtime_sdk::federation_reconciliation::FederatedTrustReportV2;
-use kirra_runtime_sdk::verifier_store::VerifierStore;
+use kirra_verifier::federation_reconciliation::FederatedTrustReportV2;
+use kirra_verifier::verifier_store::VerifierStore;
 
 use crate::{
     accept_report, encode_report, ingest_clearance_grant, key_clearance_grant, key_posture,
@@ -144,7 +144,7 @@ mod transport_tests {
     use super::*;
     use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
     use ed25519_dalek::{Signer, SigningKey};
-    use kirra_runtime_sdk::federation_reconciliation::canonical_federation_payload_v2;
+    use kirra_verifier::federation_reconciliation::canonical_federation_payload_v2;
 
     use crate::{sign_clearance_grant, key_trust_report};
 

--- a/crates/kirra-governor-service/Cargo.toml
+++ b/crates/kirra-governor-service/Cargo.toml
@@ -5,7 +5,7 @@
 #
 # DEPENDENCY DISCIPLINE (ADR-0001): this target depends ONLY on serde + bincode
 # + std (via the lean `kirra-core` crate). It deliberately does NOT depend on the
-# parent `kirra-runtime-sdk` crate (which pulls tokio/axum/rusqlite/reqwest) —
+# parent `kirra-verifier` crate (which pulls tokio/axum/rusqlite/reqwest) —
 # instead it depends on `kirra-core`, which carries the EXISTING verdict core (the
 # kinematics-contract talisman) verbatim, so the verdict logic is the real,
 # unmodified one while the dependency tree stays minimal and ROS/async-free for the

--- a/crates/kirra-proposal-bench/Cargo.toml
+++ b/crates/kirra-proposal-bench/Cargo.toml
@@ -3,7 +3,7 @@
 # DEV/TEST ONLY — a UDP bench tool that exercises a running
 # kirra-governor-service across a sweep of proposals and prints the verdicts.
 # NOT a shipped or safety artifact. Depends only on the shared wire mirror
-# (kirra-wire-client) → serde + bincode + std; no kirra-runtime-sdk, no ROS/async.
+# (kirra-wire-client) → serde + bincode + std; no kirra-verifier, no ROS/async.
 [package]
 name = "kirra-proposal-bench"
 version = "0.1.0"

--- a/crates/kirra-ros2-adapter/Cargo.toml
+++ b/crates/kirra-ros2-adapter/Cargo.toml
@@ -3,7 +3,7 @@
 # S131 Phase 1 — Option-B per-trajectory wiring adapter (skeleton).
 #
 # Owns the ROS 2 ↔ Rust bridge for the Kirra Governor. Built as a separate
-# crate so the safety kernel (`kirra-runtime-sdk`) stays free of ROS deps
+# crate so the safety kernel (`kirra-verifier`) stays free of ROS deps
 # and can ship on platforms that don't carry rclpy / ros-base. Production
 # integrators that DO run ROS 2 (e.g. Autoware) enable the `ros2` feature
 # here and link this crate into their node graph.
@@ -11,7 +11,7 @@
 # Current state (the Option-B wiring is LIVE; this header began as a Phase-1
 # skeleton note and is updated to match reality):
 #   - This crate depends ONLY on the lean `kirra-core` for safety logic
-#     (de-monolith Stage 7); the heavy `kirra-runtime-sdk` verifier service is
+#     (de-monolith Stage 7); the heavy `kirra-verifier` verifier service is
 #     no longer a dependency.
 #   - The slow loop CALLS `validate_trajectory_containment` per accepted
 #     trajectory at `src/validation.rs:161` (from
@@ -79,7 +79,7 @@ tracing = "0.1"
 # kinematics-contract talisman (`validate_vehicle_command`), the `PostureTracker`, the
 # Track-C `perception_monitor`, the `kinematics_sim` integrator, and (behind the `capture`
 # feature, enabled by `ros2` below) the learning-loop capture builders + writer. The heavy
-# `kirra-runtime-sdk` (axum/rusqlite/reqwest verifier service) is NO LONGER a dependency —
+# `kirra-verifier` (axum/rusqlite/reqwest verifier service) is NO LONGER a dependency —
 # this severs the adapter→SDK edge and, transitively, the planner's last SDK pull.
 kirra-core        = { path = "../kirra-core" }
 parko-core        = { path = "../../parko/crates/parko-core" }
@@ -113,7 +113,7 @@ futures = { version = "0.3", optional = true }
 # `PostureTracker`, and `response.json()` to parse them. Gated on `ros2`
 # because the transport only matters when the binary is built. The `json`
 # feature is declared explicitly here (de-monolith Stage 7): it was previously
-# activated transitively via the now-severed `kirra-runtime-sdk` reqwest dep
+# activated transitively via the now-severed `kirra-verifier` reqwest dep
 # through Cargo feature unification.
 reqwest    = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"], optional = true }
 serde_json = { version = "1",    optional = true }

--- a/crates/kirra-taj/Cargo.toml
+++ b/crates/kirra-taj/Cargo.toml
@@ -30,4 +30,4 @@ kirra-ros2-adapter = { path = "../kirra-ros2-adapter", default-features = false 
 [dev-dependencies]
 # Integration test only: prove Taj's corridor output feeds the real #131 checker.
 # FleetPosture lives in the SDK; the checker entry + config in the adapter.
-kirra-runtime-sdk = { path = "../.." }
+kirra-verifier = { path = "../.." }

--- a/crates/kirra-taj/src/lib.rs
+++ b/crates/kirra-taj/src/lib.rs
@@ -640,7 +640,7 @@ mod tests {
     fn taj_corridor_feeds_the_checker() {
         use kirra_ros2_adapter::state::{Pose, TrajectoryPoint};
         use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
-        use kirra_runtime_sdk::verifier::FleetPosture;
+        use kirra_verifier::verifier::FleetPosture;
 
         // A 3 m half-width corridor from walls; feed a short centered trajectory.
         let taj = TajPhaseA::default();
@@ -787,7 +787,7 @@ mod tests {
         use kirra_ros2_adapter::corridor::MockCorridorSource;
         use kirra_ros2_adapter::state::{Pose, TrajectoryPoint};
         use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
-        use kirra_runtime_sdk::verifier::FleetPosture;
+        use kirra_verifier::verifier::FleetPosture;
 
         let corridor = MockCorridorSource::straight_5m_half_width(100.0);
         let tp = |x: f64, t: f64| TrajectoryPoint {
@@ -869,7 +869,7 @@ mod tests {
         use kirra_ros2_adapter::corridor::CorridorSource as _;
         use kirra_ros2_adapter::state::{Pose, TrajectoryPoint};
         use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
-        use kirra_runtime_sdk::verifier::FleetPosture;
+        use kirra_verifier::verifier::FleetPosture;
 
         let taj = TajPhaseA::new(TajConfig { forward_extent_m: 20.0, ..Default::default() });
         let perception = taj.process(&walls_scan(5.0, 30.0), 0);

--- a/crates/kirra-wire-client/Cargo.toml
+++ b/crates/kirra-wire-client/Cargo.toml
@@ -6,7 +6,7 @@
 # sole source of truth. This crate exists so the dev bench and the (future) car
 # bridge node share ONE definition of the wire types instead of each re-rolling
 # them. Pure serde + bincode + std; it deliberately does NOT depend on
-# kirra-runtime-sdk.
+# kirra-verifier.
 [package]
 name = "kirra-wire-client"
 version = "0.1.0"

--- a/docs/MIGRATION_AEGIS_TO_KIRRA.md
+++ b/docs/MIGRATION_AEGIS_TO_KIRRA.md
@@ -42,7 +42,7 @@ stale. Any integrator still exporting `AEGIS_*` must switch:
 |-----|-----|
 | binary `aegis_verifier_service` | `kirra_verifier_service` |
 | binary `aegis_carla_client` | `kirra_carla_client` |
-| link flag `-laegis_runtime_sdk` | `-lkirra_runtime_sdk` (lib `kirra_runtime_sdk`) |
+| link flag `-laegis_runtime_sdk` | `-lkirra_verifier` (lib `kirra_verifier`) |
 | release archive `aegis-<ver>-<target>.tar.gz` | `kirra-<ver>-<target>.tar.gz` |
 
 ### Deploy / runtime layout

--- a/parko/INTEGRATION.md
+++ b/parko/INTEGRATION.md
@@ -169,7 +169,7 @@ implementation) which returns one of:
 ### 3.1 Linear-axis enforcement
 
 The linear axis is bridged through the Kirra kinematics contract
-(`kirra_runtime_sdk::gateway::kinematics_contract::validate_vehicle_command`).
+(`kirra_verifier::gateway::kinematics_contract::validate_vehicle_command`).
 The relevant fields of `VehicleKinematicsContract`:
 
 | Field | Purpose |
@@ -303,7 +303,7 @@ Fail-closed contract (see `crates/kirra-ros2-adapter/src/bin/kirra_ros2_adapter_
 | URL set + admin token present | `Live` + spawn SSE task | live posture from the verifier |
 | URL set + admin token missing | `ConfiguredNoTransport` + WARN | **Degraded** (held until the operator fixes the config + restarts) |
 
-The state machine itself is `kirra_runtime_sdk::posture_tracker::PostureTracker`
+The state machine itself is `kirra_verifier::posture_tracker::PostureTracker`
 in the kernel — shared between the adapter and parko-ros2.
 
 `POSTURE_STALENESS_TIMEOUT_MS = 6_000` (the staleness derate threshold).
@@ -443,7 +443,7 @@ let camera_mapping = CameraMapping::new(CameraConfig {
 ### 8.2 Kinematics contract
 
 ```rust
-use kirra_runtime_sdk::gateway::kinematics_contract::{
+use kirra_verifier::gateway::kinematics_contract::{
     URBAN_ODD_SPEED_CAP_MPS, VehicleKinematicsContract,
 };
 

--- a/parko/crates/parko-kirra/Cargo.toml
+++ b/parko/crates/parko-kirra/Cargo.toml
@@ -14,7 +14,7 @@ parko-core = { path = "../parko-core" }
 kirra-core = { path = "../../../crates/kirra-core" }
 # Kept for the SQLite `VerifierStore` durable audit/clearance sink (heavy, verifier-tier;
 # see audit_sink / clearance_delivery) — not on the governor hot path.
-kirra-runtime-sdk = { path = "../../.." }
+kirra-verifier = { path = "../../.." }
 # CERT-006 durable divergence sink: serialise DivergenceEvent → JSON and persist
 # it through the SDK's hash-chained, signed audit log (VerifierStore).
 serde = { version = "1", features = ["derive"] }

--- a/parko/crates/parko-kirra/README.md
+++ b/parko/crates/parko-kirra/README.md
@@ -4,7 +4,7 @@ A `SafetyGovernor` implementation for parko-core, backed by the Kirra runtime SD
 
 ## What this does
 
-Implements parko-core's `SafetyGovernor` trait by calling `kirra_runtime_sdk::gateway::kinematics_contract::validate_vehicle_command` with the active vehicle kinematics contract profile (nominal or MRC fallback).
+Implements parko-core's `SafetyGovernor` trait by calling `kirra_verifier::gateway::kinematics_contract::validate_vehicle_command` with the active vehicle kinematics contract profile (nominal or MRC fallback).
 
 When attached to a `parko_core::InferenceLoop` via `with_governor()`, proposed control commands are evaluated against the Kirra contract before being passed to actuators. Commands exceeding the contract's bounds are clamped to safe values; commands violating hard invariants result in a full stop.
 

--- a/parko/crates/parko-kirra/examples/deliver_clearance.rs
+++ b/parko/crates/parko-kirra/examples/deliver_clearance.rs
@@ -23,7 +23,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
 use ed25519_dalek::SigningKey;
 
-use kirra_runtime_sdk::verifier_store::VerifierStore;
+use kirra_verifier::verifier_store::VerifierStore;
 use parko_core::{ClearanceLoop, ImpactCfg, ImpactEvidence};
 use parko_kirra::clearance_delivery::{ClearanceDelivery, DeliveryOutcome};
 

--- a/parko/crates/parko-kirra/src/audit_sink.rs
+++ b/parko/crates/parko-kirra/src/audit_sink.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, Mutex};
 
 use base64::Engine as _;
 use ed25519_dalek::SigningKey;
-use kirra_runtime_sdk::verifier_store::VerifierStore;
+use kirra_verifier::verifier_store::VerifierStore;
 use parko_core::{
     ClearanceLoop, ClearanceRejection, ClearanceState, ImpactCfg, ImpactEvidence, ImpactLatch,
     OperatorClearanceGrant,

--- a/parko/crates/parko-kirra/src/clearance_delivery.rs
+++ b/parko/crates/parko-kirra/src/clearance_delivery.rs
@@ -24,7 +24,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use kirra_runtime_sdk::verifier_store::VerifierStore;
+use kirra_verifier::verifier_store::VerifierStore;
 use parko_core::{ClearanceLoop, OperatorClearanceGrant, DEFAULT_MAX_GRANT_AGE_MS};
 
 /// The result of one [`ClearanceDelivery::poll_and_deliver`].

--- a/parko/crates/parko-kirra/tests/clearance_e2e_integration.rs
+++ b/parko/crates/parko-kirra/tests/clearance_e2e_integration.rs
@@ -23,11 +23,11 @@ use std::sync::{Arc, Mutex};
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
 
-use kirra_runtime_sdk::attestation::{
+use kirra_verifier::attestation::{
     operator_grant_signing_payload, operator_key_fingerprint, verify_ed25519_pem_signature,
 };
-use kirra_runtime_sdk::verifier::{AppState, VerifierOperationMode};
-use kirra_runtime_sdk::verifier_store::{AuditExportPage, VerifierStore};
+use kirra_verifier::verifier::{AppState, VerifierOperationMode};
+use kirra_verifier::verifier_store::{AuditExportPage, VerifierStore};
 
 use parko_core::{
     impact_cfg_for_class, is_impact, ClearanceLoop, ClearanceState, ImpactCfg, ImpactEvidence,

--- a/parko/crates/parko-ros2/Cargo.toml
+++ b/parko/crates/parko-ros2/Cargo.toml
@@ -67,7 +67,7 @@ parko-kirra = { path = "../parko-kirra" }
 kirra-core = { path = "../../../crates/kirra-core" }
 # Kept for the SQLite `VerifierStore` the clearance gate persists through (heavy,
 # verifier-tier; see clearance_gate) — not on the governor hot path.
-kirra-runtime-sdk = { path = "../../.." }
+kirra-verifier = { path = "../../.." }
 
 # Async runtime. Default features so `tokio::spawn` and `mpsc` channels
 # are available in both lanes (the scheduler already uses them).

--- a/parko/crates/parko-ros2/src/clearance_gate.rs
+++ b/parko/crates/parko-ros2/src/clearance_gate.rs
@@ -70,7 +70,7 @@ use parko_core::{
 };
 use tokio::sync::Mutex as AsyncMutex;
 
-use kirra_runtime_sdk::verifier_store::VerifierStore;
+use kirra_verifier::verifier_store::VerifierStore;
 use parko_kirra::clearance_delivery::{ClearanceDelivery, DeliveryOutcome};
 
 use crate::command_mapping::OutgoingTwist;

--- a/ros2_ws/src/kirra_bridge_cpp/CMakeLists.txt
+++ b/ros2_ws/src/kirra_bridge_cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(kirra_bridge_node PRIVATE "${CMAKE_CURRENT_SOURCE_DIR
 target_link_directories(kirra_bridge_node PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../../target/release")
 
 ament_target_dependencies(kirra_bridge_node rclcpp geometry_msgs std_msgs)
-target_link_libraries(kirra_bridge_node kirra_runtime_sdk)
+target_link_libraries(kirra_bridge_node kirra_verifier)
 
 set_target_properties(kirra_bridge_node PROPERTIES INSTALL_RPATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../target/release")
 

--- a/scripts/build_native_test.sh
+++ b/scripts/build_native_test.sh
@@ -17,7 +17,7 @@ echo "Compiling native test..."
 g++ -std=c++17 -o "${TEST_BIN}" "${TEST_SRC}" \
     -I "${INCLUDE_PATH}" \
     -L "${LIB_PATH}" \
-    -lkirra_runtime_sdk \
+    -lkirra_verifier \
     -Wl,-rpath,"${LIB_PATH}"
 
 echo "Running native test..."

--- a/src/bin/ai_robot_demo.rs
+++ b/src/bin/ai_robot_demo.rs
@@ -1,9 +1,9 @@
 // src/bin/ai_robot_demo.rs
 // Demonstrates the Kirra AI robot safety pipeline with CDR-framed DDS output.
 
-use kirra_runtime_sdk::kinematics_contract::KinematicContract;
-use kirra_runtime_sdk::robotics_alignment::AlignmentBridge;
-use kirra_runtime_sdk::dds_bridge::DdsPublisherBridge;
+use kirra_verifier::kinematics_contract::KinematicContract;
+use kirra_verifier::robotics_alignment::AlignmentBridge;
+use kirra_verifier::dds_bridge::DdsPublisherBridge;
 
 fn main() {
     let contract = KinematicContract {

--- a/src/bin/ai_robot_sim_diagnostic.rs
+++ b/src/bin/ai_robot_sim_diagnostic.rs
@@ -1,10 +1,10 @@
 // src/bin/ai_robot_sim_diagnostic.rs
 // Simulation diagnostic tool for Kirra safety governor validation.
 
-use kirra_runtime_sdk::kirra_core::KirraKernelGovernor;
-use kirra_runtime_sdk::kinematics_contract::KinematicContract;
-use kirra_runtime_sdk::action_filter::ActionFilter;
-use kirra_runtime_sdk::action_policy::UnstructuredTextParser;
+use kirra_verifier::kirra_core::KirraKernelGovernor;
+use kirra_verifier::kinematics_contract::KinematicContract;
+use kirra_verifier::action_filter::ActionFilter;
+use kirra_verifier::action_policy::UnstructuredTextParser;
 
 fn main() {
     println!("=== Kirra Sim Diagnostic v1.0-rc20 ===\n");

--- a/src/bin/kirra_console_demo_seed.rs
+++ b/src/bin/kirra_console_demo_seed.rs
@@ -24,12 +24,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
 use ed25519_dalek::SigningKey;
 
-use kirra_runtime_sdk::verifier::{NodeTrustState, RegisteredNode};
-use kirra_runtime_sdk::verifier_store::VerifierStore;
+use kirra_verifier::verifier::{NodeTrustState, RegisteredNode};
+use kirra_verifier::verifier_store::VerifierStore;
 
 // The REAL SG6 impact-event vocabulary, mirrored as literals. We cannot IMPORT
 // the parko-kirra `audit_sink` constants here because `parko-kirra` is only a
-// DEV-dependency of this crate (it depends on `kirra-runtime-sdk`, so a normal
+// DEV-dependency of this crate (it depends on `kirra-verifier`, so a normal
 // dependency would be a cycle). These strings are kept byte-identical to
 // `parko_kirra::audit_sink::{IMPACT_DETECTED_EVENT_TYPE,
 // IMPACT_ESCALATION_RAISED_EVENT_TYPE, IMPACT_AUDIT_SOURCE}` and the

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -18,41 +18,41 @@ use std::sync::Arc;
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt as _;
 
-use kirra_runtime_sdk::verifier::{
+use kirra_verifier::verifier::{
     validate_client_identity_headers, AppState, BackupExport, FlapStatus, FleetNodePosture,
     FleetPosture, HealthResponse, NodeTrustState, PostureStreamEvent, RegisteredNode, VerifierOperationMode,
 };
-use kirra_runtime_sdk::verifier_store::{DurableWriteError, VerifierStore};
-use kirra_runtime_sdk::posture_cache::{now_ms, ServiceState, POSTURE_CACHE_TTL_MS};
-use kirra_runtime_sdk::posture_engine_v2::{resolve_posture_with_reason, LockoutReason};
-use kirra_runtime_sdk::security::{admin_token_ok, constant_time_compare};
-use kirra_runtime_sdk::action_filter::{evaluate_action_claim, ActionClaim};
-use kirra_runtime_sdk::protocol_adapter::{
+use kirra_verifier::verifier_store::{DurableWriteError, VerifierStore};
+use kirra_verifier::posture_cache::{now_ms, ServiceState, POSTURE_CACHE_TTL_MS};
+use kirra_verifier::posture_engine_v2::{resolve_posture_with_reason, LockoutReason};
+use kirra_verifier::security::{admin_token_ok, constant_time_compare};
+use kirra_verifier::action_filter::{evaluate_action_claim, ActionClaim};
+use kirra_verifier::protocol_adapter::{
     evaluate_unified_industrial_request, UnifiedIndustrialRequest,
 };
-use kirra_runtime_sdk::adapters::ethernet_ip::{EtherNetIpAdapter, EtherNetIpMessage};
-use kirra_runtime_sdk::adapters::canopen::{CanOpenAdapter, CanOpenMessage};
-use kirra_runtime_sdk::adapters::dnp3::{Dnp3Adapter, Dnp3Message};
-use kirra_runtime_sdk::federation::{
+use kirra_verifier::adapters::ethernet_ip::{EtherNetIpAdapter, EtherNetIpMessage};
+use kirra_verifier::adapters::canopen::{CanOpenAdapter, CanOpenMessage};
+use kirra_verifier::adapters::dnp3::{Dnp3Adapter, Dnp3Message};
+use kirra_verifier::federation::{
     evaluate_federated_report,
     verify_federated_report_signature,
     FederatedTrustReport,
     RegisterFederationControllerRequest,
     ReportEvaluation,
 };
-use kirra_runtime_sdk::standby_monitor::{
+use kirra_verifier::standby_monitor::{
     instance_id as ha_instance_id, spawn_heartbeat_writer, spawn_promotion_monitor,
     HEARTBEAT_KEY, PROMOTION_TIMEOUT_MS,
 };
-use kirra_runtime_sdk::gateway::kinematics_contract::ProposedVehicleCommand;
-use kirra_runtime_sdk::gateway::policy_layer::{
+use kirra_verifier::gateway::kinematics_contract::ProposedVehicleCommand;
+use kirra_verifier::gateway::policy_layer::{
     enforce_actuator_safety_envelope, enforce_posture_routing, EnforcementOutcome,
 };
-use kirra_runtime_sdk::recovery_hysteresis::{evaluate_recovery_report, HysteresisDecision};
-use kirra_runtime_sdk::fabric::asset::{AssetPosture, AssetType, FabricAsset, KinematicProfileType};
-use kirra_runtime_sdk::fabric::router::FabricRouter;
-use kirra_runtime_sdk::fabric::telemetry::FabricTelemetry;
-use kirra_runtime_sdk::fabric::causal_log::FabricCausalLog;
+use kirra_verifier::recovery_hysteresis::{evaluate_recovery_report, HysteresisDecision};
+use kirra_verifier::fabric::asset::{AssetPosture, AssetType, FabricAsset, KinematicProfileType};
+use kirra_verifier::fabric::router::FabricRouter;
+use kirra_verifier::fabric::telemetry::FabricTelemetry;
+use kirra_verifier::fabric::causal_log::FabricCausalLog;
 
 // --- Auth middleware ---------------------------------------------------------
 
@@ -183,7 +183,7 @@ async fn require_client_identity(
 /// not maintain a posture cache. A `try_send` failure (channel full or
 /// worker gone) is logged; the periodic-refresh loop will fail-close the
 /// cache and gate on its own if the worker has truly died.
-fn enqueue_recalc(svc: &ServiceState, trigger: kirra_runtime_sdk::posture_engine_v2::PostureRecalcTrigger) {
+fn enqueue_recalc(svc: &ServiceState, trigger: kirra_verifier::posture_engine_v2::PostureRecalcTrigger) {
     if let Some(tx) = svc.posture_engine_tx.get() {
         if let Err(e) = tx.try_send(trigger) {
             tracing::warn!(error = %e,
@@ -555,7 +555,7 @@ async fn issue_challenge(
     // clock. A `SystemTime`-derived nonce is predictable and can collide within
     // a single nanosecond; single-use + TTL + node-binding are enforced by the
     // challenge store and the verify-then-consume order in `verify_attestation`.
-    let nonce = kirra_runtime_sdk::verifier::generate_challenge_nonce();
+    let nonce = kirra_verifier::verifier::generate_challenge_nonce();
     svc.app.issue_challenge(&node_id, nonce, now_ms());
     (StatusCode::OK, Json(json!({ "node_id": node_id, "nonce": nonce }))).into_response()
 }
@@ -586,7 +586,7 @@ async fn verify_attestation(
                         Json(json!({ "error": "node not registered" }))).into_response(),
     };
 
-    if let Err(reason) = kirra_runtime_sdk::attestation::verify_attestation_proof(
+    if let Err(reason) = kirra_verifier::attestation::verify_attestation_proof(
         ak_public_pem.as_deref(),
         &req.node_id,
         req.nonce,
@@ -596,7 +596,7 @@ async fn verify_attestation(
         // failing proof is an authentication failure (401). Either way the
         // attestation is REFUSED — never accepted by default.
         let status = match reason {
-            kirra_runtime_sdk::attestation::AttestationError::NoRegisteredKey => {
+            kirra_verifier::attestation::AttestationError::NoRegisteredKey => {
                 StatusCode::FORBIDDEN
             }
             _ => StatusCode::UNAUTHORIZED,
@@ -643,7 +643,7 @@ async fn verify_attestation(
         }
     }
     emit_posture_event(&svc.app, "NODE_STATUS_CHANGED", Some(req.node_id.clone()));
-    enqueue_recalc(&svc, kirra_runtime_sdk::posture_engine_v2::PostureRecalcTrigger::NodeTrustChanged {
+    enqueue_recalc(&svc, kirra_verifier::posture_engine_v2::PostureRecalcTrigger::NodeTrustChanged {
         node_id: req.node_id.clone(),
         reason:  "ATTESTATION_TRUSTED".to_string(),
     });
@@ -749,7 +749,7 @@ async fn list_operators(State(svc): State<Arc<ServiceState>>) -> impl IntoRespon
                         let active = r.is_active();
                         OperatorView {
                             operator_key_fingerprint:
-                                kirra_runtime_sdk::attestation::operator_key_fingerprint(&r.pubkey_pem)
+                                kirra_verifier::attestation::operator_key_fingerprint(&r.pubkey_pem)
                                     .unwrap_or_else(|| "unparseable".to_string()),
                             operator_id: r.operator_id,
                             registered_at_ms: r.registered_at_ms,
@@ -795,7 +795,7 @@ async fn register_dependencies(
         }
     }
     emit_posture_event(&svc.app, "DEPENDENCY_GRAPH_MUTATED", Some(req.node_id.clone()));
-    enqueue_recalc(&svc, kirra_runtime_sdk::posture_engine_v2::PostureRecalcTrigger::DependencyGraphChanged);
+    enqueue_recalc(&svc, kirra_verifier::posture_engine_v2::PostureRecalcTrigger::DependencyGraphChanged);
 
     (StatusCode::OK, Json(json!({ "node_id": req.node_id, "dependencies_registered": true }))).into_response()
 }
@@ -924,7 +924,7 @@ async fn handle_audit_rotate_key(
                 Json(json!({ "error": "new_signing_key_b64 must be a base64 32-byte ed25519 seed" }))).into_response(),
         }
     };
-    let new_key_id = kirra_runtime_sdk::audit_chain::verifying_key_id(&new_signing_key.verifying_key());
+    let new_key_id = kirra_verifier::audit_chain::verifying_key_id(&new_signing_key.verifying_key());
     // #79: pass our held fencing token so the durable write re-checks it INSIDE
     // the transaction, closing the gate→commit TOCTOU.
     let held_epoch = svc.app.held_epoch.load(std::sync::atomic::Ordering::SeqCst);
@@ -1142,7 +1142,7 @@ async fn evaluate_ethernet_ip_adapter(
 
     let posture_str = format!("{:?}", posture);
     let eval = EtherNetIpAdapter::evaluate(&msg);
-    let (allowed, denial_reason) = kirra_runtime_sdk::protocol_adapter::command_allowed_for_posture_pub(&eval.command, &posture);
+    let (allowed, denial_reason) = kirra_verifier::protocol_adapter::command_allowed_for_posture_pub(&eval.command, &posture);
     let audit_ref = now_ms().to_string();
 
     if !allowed {
@@ -1206,7 +1206,7 @@ async fn evaluate_canopen_adapter(
 
     let posture_str = format!("{:?}", posture);
     let eval = CanOpenAdapter::evaluate(&msg);
-    let (allowed, denial_reason) = kirra_runtime_sdk::protocol_adapter::command_allowed_for_posture_pub(&eval.command, &posture);
+    let (allowed, denial_reason) = kirra_verifier::protocol_adapter::command_allowed_for_posture_pub(&eval.command, &posture);
     let audit_ref = now_ms().to_string();
 
     // #84: resolve the CANopen bus node-id to a FLEET node so an NMT-offline
@@ -1214,7 +1214,7 @@ async fn evaluate_canopen_adapter(
     // unregistered ids are FAIL-CLOSED — surfaced as an unattributed offline
     // (distinct audit event + warning + response flag), never a silent no-op.
     let offline_outcome = if eval.triggers_recalculation {
-        use kirra_runtime_sdk::adapters::canopen::{classify_nmt_offline, global_resolve};
+        use kirra_verifier::adapters::canopen::{classify_nmt_offline, global_resolve};
         let resolved = global_resolve(eval.node_id);
         let registered = resolved
             .as_deref()
@@ -1229,8 +1229,8 @@ async fn evaluate_canopen_adapter(
     // actually marked offline (if any) is recorded for the audit + response.
     let mut attributed_fleet_node: Option<String> = None;
     if let Some(outcome) = &offline_outcome {
-        use kirra_runtime_sdk::adapters::canopen::{NmtOfflineOutcome, UnattributedReason};
-        use kirra_runtime_sdk::posture_engine_v2::PostureRecalcTrigger;
+        use kirra_verifier::adapters::canopen::{NmtOfflineOutcome, UnattributedReason};
+        use kirra_verifier::posture_engine_v2::PostureRecalcTrigger;
         match outcome {
             NmtOfflineOutcome::Attributed { fleet_node_id } => {
                 match svc.app.mark_node_untrusted(fleet_node_id, "CANOPEN_NMT_OFFLINE", now_ms()) {
@@ -1355,7 +1355,7 @@ async fn evaluate_dnp3_adapter(
 
     let posture_str = format!("{:?}", posture);
     let eval = Dnp3Adapter::evaluate(&msg);
-    let (allowed, denial_reason) = kirra_runtime_sdk::protocol_adapter::command_allowed_for_posture_pub(&eval.command, &posture);
+    let (allowed, denial_reason) = kirra_verifier::protocol_adapter::command_allowed_for_posture_pub(&eval.command, &posture);
     let audit_ref = now_ms().to_string();
 
     // SG-012 / H-011 — a DNP3 broadcast control command must carry a
@@ -1716,7 +1716,7 @@ async fn handle_sensor_fault_report(
         }
 
         emit_posture_event(&svc.app, "NODE_STATUS_CHANGED", Some(req.source_node_id.clone()));
-        enqueue_recalc(&svc, kirra_runtime_sdk::posture_engine_v2::PostureRecalcTrigger::NodeTrustChanged {
+        enqueue_recalc(&svc, kirra_verifier::posture_engine_v2::PostureRecalcTrigger::NodeTrustChanged {
             node_id: req.source_node_id.clone(),
             reason:  format!("SENSOR_FAULT:{reason}"),
         });
@@ -1791,7 +1791,7 @@ async fn handle_sensor_fault_report(
             }
 
             emit_posture_event(&svc.app, "NODE_STATUS_CHANGED", Some(req.source_node_id.clone()));
-            enqueue_recalc(&svc, kirra_runtime_sdk::posture_engine_v2::PostureRecalcTrigger::NodeTrustChanged {
+            enqueue_recalc(&svc, kirra_verifier::posture_engine_v2::PostureRecalcTrigger::NodeTrustChanged {
                 node_id: req.source_node_id.clone(),
                 reason:  "SENSOR_RECOVERY_CONFIRMED".to_string(),
             });
@@ -1959,14 +1959,14 @@ async fn handle_fabric_command(
     // KIRRA-OCCY-PMON-002: resolve the perception-derate cap O(1) here (the
     // handler holds `svc`/`ServiceState`) and thread it through to the fabric
     // governor's Nominal arm. `None` while the monitor is disabled (default).
-    let perception_cap = kirra_runtime_sdk::gateway::perception_monitor::resolve_perception_cap(
+    let perception_cap = kirra_verifier::gateway::perception_monitor::resolve_perception_cap(
         svc.perception_monitor_enabled,
         &svc.perception_cap,
         now_ms(),
     );
     match svc.fabric_router.route_command(&asset_id, &cmd, perception_cap) {
         Ok(action) => {
-            use kirra_runtime_sdk::gateway::kinematics_contract::EnforceAction;
+            use kirra_verifier::gateway::kinematics_contract::EnforceAction;
             let action_str = format!("{:?}", action);
             let now = now_ms();
             let fabric_generation = svc.fabric_router.fabric_state().fabric_generation;
@@ -1981,7 +1981,7 @@ async fn handle_fabric_command(
             // FAIL-CLOSED: deny when no enforced command can be produced —
             // `DenyBreach`, OR (defensively) a clamp whose enforced value is
             // non-finite. We NEVER return the unclamped command.
-            let enforced = kirra_runtime_sdk::kinematics_sim::apply_enforce_action(&cmd, &action)
+            let enforced = kirra_verifier::kinematics_sim::apply_enforce_action(&cmd, &action)
                 .filter(|c| c.linear_velocity_mps.is_finite() && c.steering_angle_deg.is_finite());
 
             match enforced {
@@ -2087,7 +2087,7 @@ async fn handle_fabric_causal_log(
     // inside export_page so a forensic export is never unbounded.
     let limit = q
         .limit
-        .unwrap_or(kirra_runtime_sdk::fabric::causal_log::CAUSAL_EXPORT_MAX_PAGE);
+        .unwrap_or(kirra_verifier::fabric::causal_log::CAUSAL_EXPORT_MAX_PAGE);
     let offset = q.offset.unwrap_or(0);
     let entries = svc.fabric_causal_log.export_page(from, to, limit, offset);
     let total = entries.len();
@@ -2244,7 +2244,7 @@ async fn main() {
     // node-offline event marks the correct asset (effectful recalc). Sourced
     // from KIRRA_CANOPEN_NODE_MAP; unset → empty map (every offline is then
     // unattributed, handled fail-closed in evaluate_canopen_adapter).
-    kirra_runtime_sdk::adapters::canopen::init_node_map_from_env();
+    kirra_verifier::adapters::canopen::init_node_map_from_env();
 
     let audit_signing_key: Option<ed25519_dalek::SigningKey> =
         std::env::var("KIRRA_LOG_SIGNING_KEY").ok()
@@ -2274,7 +2274,7 @@ async fn main() {
         let admission = store
             .admit_signing_key(key.clone(), adopt, pinned.as_deref(), now_ms())
             .expect("failed to admit audit signing key against the durable trust map");
-        use kirra_runtime_sdk::verifier_store::KeyAdmission;
+        use kirra_verifier::verifier_store::KeyAdmission;
         match admission {
             KeyAdmission::Resumed
             | KeyAdmission::BackfilledGenesis
@@ -2315,15 +2315,15 @@ async fn main() {
     // kinematic-violation audit record off the verdict path. Done before
     // the listener binds so no request can race the install.
     let audit_tx =
-        kirra_runtime_sdk::audit_writer::spawn_audit_writer(Arc::clone(&app_state));
+        kirra_verifier::audit_writer::spawn_audit_writer(Arc::clone(&app_state));
     app_state.install_audit_writer(audit_tx);
 
     // Learning-loop capture writer (Phase 1, #190) — DEFAULT OFF. Only spawned +
     // installed when KIRRA_CAPTURE_ENABLED is set; unset → no writer, and the
     // gateway emit is a pure no-op (capture_writer_tx stays None). Non-safety
     // side channel; mirrors the audit writer wiring above.
-    if kirra_runtime_sdk::capture::capture_enabled() {
-        let capture_tx = kirra_runtime_sdk::capture::spawn_capture_writer();
+    if kirra_verifier::capture::capture_enabled() {
+        let capture_tx = kirra_verifier::capture::spawn_capture_writer();
         app_state.install_capture_writer(capture_tx);
         tracing::info!("learning-loop capture ENABLED (KIRRA_CAPTURE_ENABLED) — verdict records → JSONL sink");
     }
@@ -2359,7 +2359,7 @@ async fn main() {
         // KIRRA-OCCY-PMON-002: perception-derate composition. DEFAULT OFF —
         // pure no-op (state 1) until #126 wires a real perception ingest and a
         // deployment enables the monitor + starts the publisher worker.
-        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
         perception_monitor_enabled: false,
     });
 
@@ -2587,13 +2587,13 @@ async fn main() {
     // not require it there).
     let mut watchdog_spawned = false;
     if svc_state.app.is_active() {
-        kirra_runtime_sdk::posture_engine::recalculate_and_broadcast(
+        kirra_verifier::posture_engine::recalculate_and_broadcast(
             &svc_state.app,
             &svc_state.posture_cache,
         );
         tracing::info!("posture: initial recalc complete; cache populated");
 
-        let posture_tx = kirra_runtime_sdk::posture_engine_v2::start_posture_engine_worker(
+        let posture_tx = kirra_verifier::posture_engine_v2::start_posture_engine_worker(
             Arc::clone(&svc_state.app),
             Arc::clone(&svc_state.posture_cache),
         );
@@ -2614,20 +2614,20 @@ async fn main() {
         // worker consumes and recomputes the posture (typically
         // collapsing to LockedOut for the affected node, which fails
         // the actuator gate closed).
-        kirra_runtime_sdk::telemetry_watchdog::spawn_telemetry_watchdog(
+        kirra_verifier::telemetry_watchdog::spawn_telemetry_watchdog(
             Arc::clone(&svc_state.app),
             posture_tx.clone(),
         );
         watchdog_spawned = true;
         tracing::info!(
-            timeout_ms = kirra_runtime_sdk::telemetry_watchdog::AV_TELEMETRY_TIMEOUT_MS,
+            timeout_ms = kirra_verifier::telemetry_watchdog::AV_TELEMETRY_TIMEOUT_MS,
             "telemetry watchdog spawned (SG9 sensor-liveness)"
         );
 
         let refresh_tx = posture_tx;
         tokio::spawn(async move {
             let mut tick = tokio::time::interval(std::time::Duration::from_millis(
-                kirra_runtime_sdk::posture_cache::POSTURE_REFRESH_INTERVAL_MS,
+                kirra_verifier::posture_cache::POSTURE_REFRESH_INTERVAL_MS,
             ));
             // First tick fires immediately; skip it (the synchronous
             // initial recalc above already covered cold start).
@@ -2635,7 +2635,7 @@ async fn main() {
             loop {
                 tick.tick().await;
                 if refresh_tx
-                    .try_send(kirra_runtime_sdk::posture_engine_v2::PostureRecalcTrigger::PeriodicRefresh)
+                    .try_send(kirra_verifier::posture_engine_v2::PostureRecalcTrigger::PeriodicRefresh)
                     .is_err()
                 {
                     tracing::error!(
@@ -2646,8 +2646,8 @@ async fn main() {
             }
         });
         tracing::info!(
-            interval_ms = kirra_runtime_sdk::posture_cache::POSTURE_REFRESH_INTERVAL_MS,
-            ttl_ms = kirra_runtime_sdk::posture_cache::POSTURE_CACHE_TTL_MS,
+            interval_ms = kirra_verifier::posture_cache::POSTURE_REFRESH_INTERVAL_MS,
+            ttl_ms = kirra_verifier::posture_cache::POSTURE_CACHE_TTL_MS,
             "posture: periodic refresh loop started"
         );
 
@@ -2934,7 +2934,7 @@ async fn console_runtime(State(svc): State<Arc<ServiceState>>) -> impl IntoRespo
     Json(json!({
         "mode": mode,
         "uptime_ms": now.saturating_sub(svc.started_at_ms),
-        "posture_generation": kirra_runtime_sdk::posture_engine::POSTURE_GENERATION
+        "posture_generation": kirra_verifier::posture_engine::POSTURE_GENERATION
             .load(std::sync::atomic::Ordering::SeqCst),
         "last_recalc_ms": last_recalc_ms,
         "posture_cache_ttl_ms": POSTURE_CACHE_TTL_MS,
@@ -3204,7 +3204,7 @@ fn check_supervisor_key(headers: &HeaderMap) -> Result<(), StatusCode> {
 
 /// Audit a clearance-grant rejection (never records key bytes / signatures).
 fn audit_grant_rejection(
-    app: &kirra_runtime_sdk::verifier::AppState,
+    app: &kirra_verifier::verifier::AppState,
     reason: &str,
     node_id: &str,
     operator_id: &str,
@@ -3278,7 +3278,7 @@ async fn register_operator(
         }))).into_response();
     }
     // Fail-closed: the PEM must parse as a valid Ed25519 SPKI public key.
-    let fingerprint = match kirra_runtime_sdk::attestation::operator_key_fingerprint(
+    let fingerprint = match kirra_verifier::attestation::operator_key_fingerprint(
         &req.ed25519_pubkey_pem,
     ) {
         Some(fp) => fp,
@@ -3405,7 +3405,7 @@ async fn clearance_challenge(
         Err(_) => false,
     };
     // Hex string (not a u64) so the in-browser signing flow never loses precision.
-    let nonce_hex = format!("{:016x}", kirra_runtime_sdk::verifier::generate_challenge_nonce());
+    let nonce_hex = format!("{:016x}", kirra_verifier::verifier::generate_challenge_nonce());
     // #325: store a REAL challenge only for an active operator; everyone else gets a
     // decoy nonce that is never recorded (no oracle, no map growth). #326: the
     // challenge-map key is length-prefixed (unambiguous operator/node split).
@@ -3510,10 +3510,10 @@ async fn console_clearance_grant(
                 }))).into_response();
             }
         };
-        let payload = kirra_runtime_sdk::attestation::operator_grant_signing_payload(
+        let payload = kirra_verifier::attestation::operator_grant_signing_payload(
             &operator_id, &node_id, &nonce,
         );
-        if !kirra_runtime_sdk::attestation::verify_ed25519_pem_signature(
+        if !kirra_verifier::attestation::verify_ed25519_pem_signature(
             &operator.pubkey_pem, &payload, &sig_bytes,
         ) {
             audit_grant_rejection(&svc.app, "bad_signature", &node_id, &operator_id, now);
@@ -3531,7 +3531,7 @@ async fn console_clearance_grant(
                 "reason": "challenge nonce absent, expired, or already used (replay rejected)"
             }))).into_response();
         }
-        let fp = kirra_runtime_sdk::attestation::operator_key_fingerprint(&operator.pubkey_pem);
+        let fp = kirra_verifier::attestation::operator_key_fingerprint(&operator.pubkey_pem);
         ("operator-signed", fp)
     } else {
         // === BREAK-GLASS PATH — the named, distinctly-audited supervisor fallback.
@@ -3892,11 +3892,11 @@ mod posture_gate_real_router_tests {
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt; // for `oneshot`
 
-    use kirra_runtime_sdk::posture_cache::{
+    use kirra_verifier::posture_cache::{
         now_ms, CachedFleetPosture, ServiceState, SharedPostureCache,
     };
-    use kirra_runtime_sdk::verifier::{AppState, FleetPosture, VerifierOperationMode};
-    use kirra_runtime_sdk::verifier_store::VerifierStore;
+    use kirra_verifier::verifier::{AppState, FleetPosture, VerifierOperationMode};
+    use kirra_verifier::verifier_store::VerifierStore;
 
     /// Builds an Active `ServiceState` with the given seeded posture (or a
     /// cold cache when `None`), mirroring the production field set.
@@ -3909,11 +3909,11 @@ mod posture_gate_real_router_tests {
             posture_cache,
             started_at_ms: now_ms(),
             audit_verifying_key: None,
-            fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-            fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-            fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+            fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+            fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+            fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
             posture_engine_tx: std::sync::OnceLock::new(),
-            perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+            perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
             perception_monitor_enabled: false,
         })
     }
@@ -4089,15 +4089,15 @@ mod fabric_posture_feed_tests {
 
     use std::sync::Arc;
 
-    use kirra_runtime_sdk::fabric::asset::{
+    use kirra_verifier::fabric::asset::{
         AssetType, FabricAsset, KinematicProfileType,
     };
-    use kirra_runtime_sdk::fabric::router::FabricRouter;
-    use kirra_runtime_sdk::posture_cache::{
+    use kirra_verifier::fabric::router::FabricRouter;
+    use kirra_verifier::posture_cache::{
         now_ms, CachedFleetPosture, ServiceState, SharedPostureCache,
     };
-    use kirra_runtime_sdk::verifier::{AppState, FleetPosture, VerifierOperationMode};
-    use kirra_runtime_sdk::verifier_store::VerifierStore;
+    use kirra_verifier::verifier::{AppState, FleetPosture, VerifierOperationMode};
+    use kirra_verifier::verifier_store::VerifierStore;
 
     const LOCAL: &str = "local-asset";
 
@@ -4128,10 +4128,10 @@ mod fabric_posture_feed_tests {
             started_at_ms: now_ms(),
             audit_verifying_key: None,
             fabric_router,
-            fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-            fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+            fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+            fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
             posture_engine_tx: std::sync::OnceLock::new(),
-            perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+            perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
             perception_monitor_enabled: false,
         })
     }
@@ -4236,14 +4236,14 @@ mod fabric_command_authoritative_tests {
     use axum::response::IntoResponse;
     use axum::Json;
 
-    use kirra_runtime_sdk::fabric::asset::{
+    use kirra_verifier::fabric::asset::{
         AssetPosture, AssetType, FabricAsset, KinematicProfileType,
     };
-    use kirra_runtime_sdk::fabric::router::FabricRouter;
-    use kirra_runtime_sdk::gateway::kinematics_contract::ProposedVehicleCommand;
-    use kirra_runtime_sdk::posture_cache::{now_ms, ServiceState, SharedPostureCache};
-    use kirra_runtime_sdk::verifier::{AppState, FleetPosture, VerifierOperationMode};
-    use kirra_runtime_sdk::verifier_store::VerifierStore;
+    use kirra_verifier::fabric::router::FabricRouter;
+    use kirra_verifier::gateway::kinematics_contract::ProposedVehicleCommand;
+    use kirra_verifier::posture_cache::{now_ms, ServiceState, SharedPostureCache};
+    use kirra_verifier::verifier::{AppState, FleetPosture, VerifierOperationMode};
+    use kirra_verifier::verifier_store::VerifierStore;
 
     const ASSET: &str = "av-01";
 
@@ -4282,10 +4282,10 @@ mod fabric_command_authoritative_tests {
             started_at_ms: now_ms(),
             audit_verifying_key: None,
             fabric_router,
-            fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-            fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+            fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+            fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
             posture_engine_tx: std::sync::OnceLock::new(),
-            perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+            perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
             perception_monitor_enabled: false,
         })
     }
@@ -4367,12 +4367,12 @@ mod attestation_nonce_handler_tests {
     use axum::Json;
     use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
 
-    use kirra_runtime_sdk::attestation::attestation_signing_payload;
-    use kirra_runtime_sdk::posture_cache::{now_ms, ServiceState, SharedPostureCache};
-    use kirra_runtime_sdk::verifier::{
+    use kirra_verifier::attestation::attestation_signing_payload;
+    use kirra_verifier::posture_cache::{now_ms, ServiceState, SharedPostureCache};
+    use kirra_verifier::verifier::{
         AppState, NodeTrustState, RegisteredNode, VerifierOperationMode,
     };
-    use kirra_runtime_sdk::verifier_store::VerifierStore;
+    use kirra_verifier::verifier_store::VerifierStore;
 
     const NODE: &str = "edge-node-1";
 
@@ -4413,11 +4413,11 @@ mod attestation_nonce_handler_tests {
             posture_cache,
             started_at_ms: now_ms(),
             audit_verifying_key: None,
-            fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-            fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-            fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+            fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+            fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+            fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
             posture_engine_tx: std::sync::OnceLock::new(),
-            perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+            perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
             perception_monitor_enabled: false,
         })
     }
@@ -4472,13 +4472,13 @@ mod local_asset_lockedout_seed_tests {
 
     use std::sync::Arc;
 
-    use kirra_runtime_sdk::fabric::asset::{AssetType, FabricAsset, KinematicProfileType};
-    use kirra_runtime_sdk::fabric::router::FabricRouter;
-    use kirra_runtime_sdk::posture_cache::{
+    use kirra_verifier::fabric::asset::{AssetType, FabricAsset, KinematicProfileType};
+    use kirra_verifier::fabric::router::FabricRouter;
+    use kirra_verifier::posture_cache::{
         now_ms, CachedFleetPosture, ServiceState, SharedPostureCache,
     };
-    use kirra_runtime_sdk::verifier::{AppState, FleetPosture, VerifierOperationMode};
-    use kirra_runtime_sdk::verifier_store::VerifierStore;
+    use kirra_verifier::verifier::{AppState, FleetPosture, VerifierOperationMode};
+    use kirra_verifier::verifier_store::VerifierStore;
 
     const LOCAL: &str = "av-local";
     const PEER: &str = "av-peer";
@@ -4511,10 +4511,10 @@ mod local_asset_lockedout_seed_tests {
             started_at_ms: now_ms(),
             audit_verifying_key: None,
             fabric_router,
-            fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-            fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+            fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+            fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
             posture_engine_tx: std::sync::OnceLock::new(),
-            perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+            perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
             perception_monitor_enabled: false,
         })
     }
@@ -4590,10 +4590,10 @@ mod dnp3_mandatory_audit_tests {
     use axum::response::IntoResponse;
     use axum::Json;
 
-    use kirra_runtime_sdk::adapters::dnp3::{Dnp3Message, Dnp3Object, DNP3_BROADCAST_ADDRESS};
-    use kirra_runtime_sdk::posture_cache::{now_ms, CachedFleetPosture, ServiceState, SharedPostureCache};
-    use kirra_runtime_sdk::verifier::{AppState, FleetPosture, VerifierOperationMode};
-    use kirra_runtime_sdk::verifier_store::VerifierStore;
+    use kirra_verifier::adapters::dnp3::{Dnp3Message, Dnp3Object, DNP3_BROADCAST_ADDRESS};
+    use kirra_verifier::posture_cache::{now_ms, CachedFleetPosture, ServiceState, SharedPostureCache};
+    use kirra_verifier::verifier::{AppState, FleetPosture, VerifierOperationMode};
+    use kirra_verifier::verifier_store::VerifierStore;
 
     fn svc() -> Arc<ServiceState> {
         let store = VerifierStore::new(":memory:").expect("in-memory store");
@@ -4607,11 +4607,11 @@ mod dnp3_mandatory_audit_tests {
             posture_cache,
             started_at_ms: now_ms(),
             audit_verifying_key: None,
-            fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-            fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-            fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+            fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+            fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+            fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
             posture_engine_tx: std::sync::OnceLock::new(),
-            perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+            perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
             perception_monitor_enabled: false,
         })
     }
@@ -4737,13 +4737,13 @@ mod console_phase_a_tests {
     use axum::response::IntoResponse;
     use tower::ServiceExt; // oneshot
 
-    use kirra_runtime_sdk::posture_cache::{
+    use kirra_verifier::posture_cache::{
         now_ms, ServiceState, SharedPostureCache, POSTURE_CACHE_TTL_MS,
     };
-    use kirra_runtime_sdk::verifier::{
+    use kirra_verifier::verifier::{
         AppState, NodeTrustState, RegisteredNode, VerifierOperationMode,
     };
-    use kirra_runtime_sdk::verifier_store::VerifierStore;
+    use kirra_verifier::verifier_store::VerifierStore;
 
     fn build_state() -> Arc<ServiceState> {
         let store = VerifierStore::new(":memory:").expect("in-memory store");
@@ -4754,13 +4754,13 @@ mod console_phase_a_tests {
             posture_cache,
             started_at_ms: now_ms(),
             audit_verifying_key: None,
-            fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-            fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
+            fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+            fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
             fabric_causal_log: Arc::new(
-                kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None),
+                kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None),
             ),
             posture_engine_tx: std::sync::OnceLock::new(),
-            perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+            perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
             perception_monitor_enabled: false,
         })
     }
@@ -4974,7 +4974,7 @@ mod console_phase_a_tests {
         {
             let mut store = svc.app.store.lock().unwrap();
             let posture_json =
-                serde_json::to_string(&kirra_runtime_sdk::verifier::FleetPosture::Nominal).unwrap();
+                serde_json::to_string(&kirra_verifier::verifier::FleetPosture::Nominal).unwrap();
             store
                 .save_posture_event_chained(
                     "robot-09",
@@ -5117,7 +5117,7 @@ mod console_phase_a_tests {
 
     fn sign_grant_b64(sk: &SigningKey, operator_id: &str, node_id: &str, nonce: &str) -> String {
         use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
-        let payload = kirra_runtime_sdk::attestation::operator_grant_signing_payload(
+        let payload = kirra_verifier::attestation::operator_grant_signing_payload(
             operator_id, node_id, nonce,
         );
         b64e.encode(sk.sign(&payload).to_bytes())
@@ -5314,7 +5314,7 @@ mod console_phase_a_tests {
         let (gs, gb) = post_json(svc.clone(), "/console/clearance-grants", body, None).await;
         assert_eq!(gs, StatusCode::OK, "operator-signed grant recorded; body={gb}");
         assert!(gb.contains("operator-signed"), "auth_method in response");
-        let fp = kirra_runtime_sdk::attestation::operator_key_fingerprint(&pem).unwrap();
+        let fp = kirra_verifier::attestation::operator_key_fingerprint(&pem).unwrap();
         assert!(gb.contains(&fp), "response carries the key fingerprint");
 
         let (_s, ab) = get(svc.clone(), "/console/audit?limit=50").await;

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -4,7 +4,7 @@
 // `kirra-core` crate behind its off-by-default `capture` feature (de-monolith Stage 7) so
 // the ROS2 adapter's slow-loop emit point can build records without pulling the verifier
 // service's heavy tree. Re-exported here so every existing `crate::capture::*` (and
-// `kirra_runtime_sdk::capture::*`) path keeps the SAME type — zero churn, zero logic change.
+// `kirra_verifier::capture::*`) path keeps the SAME type — zero churn, zero logic change.
 //
 // The builders + writer now live in `kirra_core::capture` (which itself re-exports the
 // governor-free `kirra_capture_schema` wire types). The SDK enables `kirra-core/capture`

--- a/src/gateway/containment.rs
+++ b/src/gateway/containment.rs
@@ -3,7 +3,7 @@
 // The SG2 drivable-space containment checker moved VERBATIM to the lean `kirra-core`
 // crate (de-monolith Stage 4) so the certified governor surface (the ROS2 adapter, the
 // planner) need not pull the verifier service's heavy tree. Re-exported here so every
-// existing `crate::gateway::containment::*` (and `kirra_runtime_sdk::gateway::
+// existing `crate::gateway::containment::*` (and `kirra_verifier::gateway::
 // containment::*`) path keeps the SAME type — zero churn, zero logic change.
 //
 // The checker and its tests now live in `kirra_core::containment`. SG2 wiring is

--- a/src/gateway/kinematics_contract.rs
+++ b/src/gateway/kinematics_contract.rs
@@ -3,7 +3,7 @@
 // The FROZEN kinematics-contract talisman moved VERBATIM to the lean `kirra-core` crate
 // (de-monolith Stage 3) so the certified governor surface need not pull the verifier
 // service's heavy tree. Re-exported here so every existing
-// `crate::gateway::kinematics_contract::*` (and `kirra_runtime_sdk::gateway::
+// `crate::gateway::kinematics_contract::*` (and `kirra_verifier::gateway::
 // kinematics_contract::*`) path keeps the SAME type — zero churn, zero logic change.
 //
 // The contract and its tests now live in `kirra_core::kinematics_contract`. The talisman

--- a/src/gateway/perception_monitor.rs
+++ b/src/gateway/perception_monitor.rs
@@ -3,7 +3,7 @@
 // The Track-C perception monitor (KIRRA-OCCY-PMON-001) moved VERBATIM to the lean
 // `kirra-core` crate (de-monolith Stage 7) so the ROS2 adapter can call it without
 // pulling the verifier service's heavy tree. Re-exported here so every existing
-// `crate::gateway::perception_monitor::*` (and `kirra_runtime_sdk::gateway::
+// `crate::gateway::perception_monitor::*` (and `kirra_verifier::gateway::
 // perception_monitor::*`) path keeps the SAME type — zero churn, zero logic change.
 //
 // The monitor and its tests now live in `kirra_core::perception_monitor`. It is pure +

--- a/src/governor_guard.rs
+++ b/src/governor_guard.rs
@@ -3,7 +3,7 @@
 // The shared non-finite governor-input guard (`all_finite`, the #410 convergence
 // point) moved VERBATIM to the lean `kirra-core` crate (de-monolith Stage 5) so the
 // certified governor surface need not pull the verifier service's heavy tree. Re-exported
-// here so every existing `crate::governor_guard::*` (and `kirra_runtime_sdk::
+// here so every existing `crate::governor_guard::*` (and `kirra_verifier::
 // governor_guard::*`) path — the scalar kernel, the C FFI, parko's diverse governor —
 // keeps the SAME predicate. Zero churn, zero logic change.
 pub use kirra_core::governor_guard::*;

--- a/src/kinematics_sim.rs
+++ b/src/kinematics_sim.rs
@@ -3,7 +3,7 @@
 // The kinematic forward simulator moved VERBATIM to the lean `kirra-core` crate
 // (de-monolith Stage 7) so the scenario harness and the ROS2 adapter's tests can use it
 // without pulling the verifier service's heavy tree. Re-exported here so every existing
-// `crate::kinematics_sim::*` (and `kirra_runtime_sdk::kinematics_sim::*`) path keeps the
+// `crate::kinematics_sim::*` (and `kirra_verifier::kinematics_sim::*`) path keeps the
 // SAME type — zero churn, zero logic change.
 //
 // The simulator and its tests now live in `kirra_core::kinematics_sim`. It is pure

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@
 
 use std::env;
 use std::sync::mpsc::channel;
-use kirra_runtime_sdk::config::KirraRuntimeConfig;
-use kirra_runtime_sdk::gateway::{KirraLiveGateway, GatewayConfig};
+use kirra_verifier::config::KirraRuntimeConfig;
+use kirra_verifier::gateway::{KirraLiveGateway, GatewayConfig};
 
 fn main() {
     let args: Vec<String> = env::args().collect();

--- a/src/posture_tracker.rs
+++ b/src/posture_tracker.rs
@@ -4,7 +4,7 @@
 // `POSTURE_STALENESS_TIMEOUT_MS`) moved VERBATIM to the lean `kirra-core` crate
 // (de-monolith Stage 5) so the certified governor surface (the ROS2 adapter, the
 // parko-ros2 node) need not pull the verifier service's heavy tree. Re-exported here so
-// every existing `crate::posture_tracker::*` (and `kirra_runtime_sdk::posture_tracker::*`)
+// every existing `crate::posture_tracker::*` (and `kirra_verifier::posture_tracker::*`)
 // path keeps the SAME type. The tracker is unchanged: a pure, deterministic,
 // clock-injected state machine whose only input is `FleetPosture`.
 pub use kirra_core::posture_tracker::*;

--- a/tests/actuator_envelope_integration.rs
+++ b/tests/actuator_envelope_integration.rs
@@ -18,17 +18,17 @@ use axum::{Extension, Json, Router};
 use serde_json::Value;
 use tower::ServiceExt; // for `oneshot`
 
-use kirra_runtime_sdk::gateway::kinematics_contract::{
+use kirra_verifier::gateway::kinematics_contract::{
     ProposedVehicleCommand, VehicleKinematicsContract,
 };
-use kirra_runtime_sdk::gateway::policy_layer::{
+use kirra_verifier::gateway::policy_layer::{
     enforce_actuator_safety_envelope, enforce_posture_routing, EnforcementOutcome,
 };
-use kirra_runtime_sdk::posture_cache::{
+use kirra_verifier::posture_cache::{
     CachedFleetPosture, ServiceState, SharedPostureCache,
 };
-use kirra_runtime_sdk::verifier::{AppState, FleetPosture, VerifierOperationMode};
-use kirra_runtime_sdk::verifier_store::VerifierStore;
+use kirra_verifier::verifier::{AppState, FleetPosture, VerifierOperationMode};
+use kirra_verifier::verifier_store::VerifierStore;
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -42,13 +42,13 @@ fn build_state_with_posture(posture: FleetPosture) -> Arc<ServiceState> {
     Arc::new(ServiceState {
         app,
         posture_cache,
-        started_at_ms: kirra_runtime_sdk::posture_cache::now_ms(),
+        started_at_ms: kirra_verifier::posture_cache::now_ms(),
         audit_verifying_key: None,
-        fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-        fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-        fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+        fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+        fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+        fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
-        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
         perception_monitor_enabled: false,
     })
 }
@@ -448,10 +448,10 @@ async fn test_perception_cap_enabled_fresh_clamps_to_published_cap() {
     let app_state = Arc::new(AppState::new(store, VerifierOperationMode::Active));
     let posture_cache: SharedPostureCache =
         Arc::new(std::sync::RwLock::new(Some(CachedFleetPosture::new(FleetPosture::Nominal))));
-    let perception_cap = kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap();
+    let perception_cap = kirra_verifier::gateway::perception_monitor::empty_perception_cap();
     {
-        use kirra_runtime_sdk::gateway::perception_monitor::{CachedPerceptionCap, DerateCode};
-        let now = kirra_runtime_sdk::posture_cache::now_ms();
+        use kirra_verifier::gateway::perception_monitor::{CachedPerceptionCap, DerateCode};
+        let now = kirra_verifier::posture_cache::now_ms();
         *perception_cap.write().unwrap() = Some(CachedPerceptionCap {
             cap_mps: 3.0,
             generated_at_ms: now,
@@ -462,11 +462,11 @@ async fn test_perception_cap_enabled_fresh_clamps_to_published_cap() {
     let svc = Arc::new(ServiceState {
         app: app_state,
         posture_cache,
-        started_at_ms: kirra_runtime_sdk::posture_cache::now_ms(),
+        started_at_ms: kirra_verifier::posture_cache::now_ms(),
         audit_verifying_key: None,
-        fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-        fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-        fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+        fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+        fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+        fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
         perception_cap,
         perception_monitor_enabled: true,
@@ -502,9 +502,9 @@ async fn test_perception_cap_enabled_stale_controlled_stop() {
     let app_state = Arc::new(AppState::new(store, VerifierOperationMode::Active));
     let posture_cache: SharedPostureCache =
         Arc::new(std::sync::RwLock::new(Some(CachedFleetPosture::new(FleetPosture::Nominal))));
-    let perception_cap = kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap();
+    let perception_cap = kirra_verifier::gateway::perception_monitor::empty_perception_cap();
     {
-        use kirra_runtime_sdk::gateway::perception_monitor::{CachedPerceptionCap, DerateCode};
+        use kirra_verifier::gateway::perception_monitor::{CachedPerceptionCap, DerateCode};
         // generated far in the past relative to a tiny TTL → stale on read.
         *perception_cap.write().unwrap() = Some(CachedPerceptionCap {
             cap_mps: 9.0,
@@ -516,11 +516,11 @@ async fn test_perception_cap_enabled_stale_controlled_stop() {
     let svc = Arc::new(ServiceState {
         app: app_state,
         posture_cache,
-        started_at_ms: kirra_runtime_sdk::posture_cache::now_ms(),
+        started_at_ms: kirra_verifier::posture_cache::now_ms(),
         audit_verifying_key: None,
-        fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-        fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-        fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+        fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+        fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+        fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
         perception_cap,
         perception_monitor_enabled: true,
@@ -559,10 +559,10 @@ async fn test_capstone_missing_enforcement_outcome_extension_fails_closed_500() 
 /// Build a Nominal state with a capture writer installed; return (svc, rx) so the
 /// test can both drive the gateway and observe the emitted records.
 fn build_state_with_capture()
-    -> (Arc<ServiceState>, tokio::sync::mpsc::Receiver<kirra_runtime_sdk::capture::CaptureRecord>)
+    -> (Arc<ServiceState>, tokio::sync::mpsc::Receiver<kirra_verifier::capture::CaptureRecord>)
 {
-    use kirra_runtime_sdk::verifier::{AppState, VerifierOperationMode};
-    use kirra_runtime_sdk::verifier_store::VerifierStore;
+    use kirra_verifier::verifier::{AppState, VerifierOperationMode};
+    use kirra_verifier::verifier_store::VerifierStore;
     let store = VerifierStore::new(":memory:").expect("in-memory store");
     let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
     let (tx, rx) = tokio::sync::mpsc::channel(16);
@@ -572,13 +572,13 @@ fn build_state_with_capture()
     let svc = Arc::new(ServiceState {
         app,
         posture_cache,
-        started_at_ms: kirra_runtime_sdk::posture_cache::now_ms(),
+        started_at_ms: kirra_verifier::posture_cache::now_ms(),
         audit_verifying_key: None,
-        fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-        fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-        fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+        fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+        fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+        fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
-        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
         perception_monitor_enabled: false,
     });
     (svc, rx)
@@ -608,7 +608,7 @@ async fn test_capture_on_vs_off_responses_identical() {
 /// outcome + the substituted safe value — passes included (selection-bias).
 #[tokio::test]
 async fn test_capture_emits_a_record_per_arm() {
-    use kirra_runtime_sdk::capture::CaptureOutcome;
+    use kirra_verifier::capture::CaptureOutcome;
 
     // Allow.
     let (svc, mut rx) = build_state_with_capture();

--- a/tests/actuator_middleware_integration.rs
+++ b/tests/actuator_middleware_integration.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use kirra_runtime_sdk::{
+use kirra_verifier::{
     posture_cache::{CachedFleetPosture, ServiceState, SharedPostureCache},
     verifier::{AppState, FleetPosture, VerifierOperationMode},
     verifier_store::VerifierStore,
@@ -26,13 +26,13 @@ fn build_state(posture: FleetPosture) -> Arc<ServiceState> {
     Arc::new(ServiceState {
         app,
         posture_cache,
-        started_at_ms: kirra_runtime_sdk::posture_cache::now_ms(),
+        started_at_ms: kirra_verifier::posture_cache::now_ms(),
         audit_verifying_key: None,
-        fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-        fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-        fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+        fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+        fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+        fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
-        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
         perception_monitor_enabled: false,
     })
 }
@@ -44,13 +44,13 @@ fn build_state_empty_cache() -> Arc<ServiceState> {
     Arc::new(ServiceState {
         app,
         posture_cache,
-        started_at_ms: kirra_runtime_sdk::posture_cache::now_ms(),
+        started_at_ms: kirra_verifier::posture_cache::now_ms(),
         audit_verifying_key: None,
-        fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-        fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-        fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+        fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+        fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+        fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
-        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
         perception_monitor_enabled: false,
     })
 }

--- a/tests/cert_003_rtm_gap_stubs.rs
+++ b/tests/cert_003_rtm_gap_stubs.rs
@@ -39,10 +39,10 @@ fn test_safety_goal_sg_006_unknown_command_denial() {
 #[test]
 fn test_safety_goal_sg_007_causal_log_records_propagation_event() {
     use std::collections::HashMap;
-    use kirra_runtime_sdk::fabric::router::FabricRouter;
-    use kirra_runtime_sdk::fabric::causal_log::FabricCausalLog;
-    use kirra_runtime_sdk::fabric::asset::{AssetPosture, AssetType, FabricAsset, KinematicProfileType};
-    use kirra_runtime_sdk::verifier::FleetPosture;
+    use kirra_verifier::fabric::router::FabricRouter;
+    use kirra_verifier::fabric::causal_log::FabricCausalLog;
+    use kirra_verifier::fabric::asset::{AssetPosture, AssetType, FabricAsset, KinematicProfileType};
+    use kirra_verifier::verifier::FleetPosture;
 
     fn convoy_av(id: &str, role: &str) -> FabricAsset {
         let mut metadata = HashMap::new();
@@ -185,11 +185,11 @@ fn test_safety_goal_sg_012_dnp3_broadcast_mandatory_audit() {
 // backdoor.
 #[test]
 fn test_safety_goal_sg_013_recovery_hysteresis_streak_and_window() {
-    use kirra_runtime_sdk::recovery_hysteresis::{
+    use kirra_verifier::recovery_hysteresis::{
         evaluate_recovery_report, HysteresisDecision, AV_RECOVERY_STREAK_THRESHOLD,
         AV_RECOVERY_WINDOW_MS,
     };
-    use kirra_runtime_sdk::verifier_store::VerifierStore;
+    use kirra_verifier::verifier_store::VerifierStore;
 
     assert_eq!(AV_RECOVERY_STREAK_THRESHOLD, 5, "spec pins the threshold at 5");
 

--- a/tests/fault_injection.rs
+++ b/tests/fault_injection.rs
@@ -16,12 +16,12 @@
 //
 // Tracking: CERT-004, ADL-010 / ADL-011 in work/decisions.md.
 
-use kirra_runtime_sdk::federation::{
+use kirra_verifier::federation::{
     evaluate_federated_report, FederatedTrustReport, FEDERATION_REPLAY_WINDOW_MS,
 };
-use kirra_runtime_sdk::gateway::policy::OperationalCommand;
-use kirra_runtime_sdk::posture_cache::{should_route_command, CachedFleetPosture};
-use kirra_runtime_sdk::verifier::FleetPosture;
+use kirra_verifier::gateway::policy::OperationalCommand;
+use kirra_verifier::posture_cache::{should_route_command, CachedFleetPosture};
+use kirra_verifier::verifier::FleetPosture;
 
 // ============================================================================
 // SG-006 (ASIL D) — Unknown command denial in all posture states
@@ -238,10 +238,10 @@ fn test_safety_goal_sg_016_dds_actuator_volatile_durability() {
 #[test]
 fn test_safety_goal_sg_007_cross_asset_lockout_propagation() {
     use std::collections::HashMap;
-    use kirra_runtime_sdk::fabric::asset::{
+    use kirra_verifier::fabric::asset::{
         AssetPosture, AssetType, FabricAsset, KinematicProfileType,
     };
-    use kirra_runtime_sdk::fabric::router::FabricRouter;
+    use kirra_verifier::fabric::router::FabricRouter;
 
     fn convoy_asset(id: &str, role: &str) -> FabricAsset {
         let mut metadata = HashMap::new();

--- a/tests/governor_closes_loop_proof.rs
+++ b/tests/governor_closes_loop_proof.rs
@@ -32,21 +32,21 @@ use axum::{Extension, Json, Router};
 use serde_json::Value;
 use tower::ServiceExt; // oneshot
 
-use kirra_runtime_sdk::gateway::kinematics_contract::{
+use kirra_verifier::gateway::kinematics_contract::{
     ProposedVehicleCommand, VehicleKinematicsContract,
 };
-use kirra_runtime_sdk::gateway::policy_layer::{
+use kirra_verifier::gateway::policy_layer::{
     enforce_actuator_safety_envelope, EnforcementOutcome,
 };
-use kirra_runtime_sdk::kinematics_sim::VehicleState;
-use kirra_runtime_sdk::posture_cache::{
+use kirra_verifier::kinematics_sim::VehicleState;
+use kirra_verifier::posture_cache::{
     CachedFleetPosture, ServiceState, SharedPostureCache,
 };
-use kirra_runtime_sdk::scenario_runner::{PostureAssertion, ScenarioEvent, ScenarioRunner};
-use kirra_runtime_sdk::verifier::{
+use kirra_verifier::scenario_runner::{PostureAssertion, ScenarioEvent, ScenarioRunner};
+use kirra_verifier::verifier::{
     AppState, FleetPosture, NodeTrustState, RegisteredNode, VerifierOperationMode,
 };
-use kirra_runtime_sdk::verifier_store::VerifierStore;
+use kirra_verifier::verifier_store::VerifierStore;
 
 const DT_S: f64 = 0.05;
 const TOL: f64 = 1e-6;
@@ -74,13 +74,13 @@ fn service_state_from(app: Arc<AppState>, cache: SharedPostureCache) -> Arc<Serv
     Arc::new(ServiceState {
         app,
         posture_cache: cache,
-        started_at_ms: kirra_runtime_sdk::posture_cache::now_ms(),
+        started_at_ms: kirra_verifier::posture_cache::now_ms(),
         audit_verifying_key: None,
-        fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-        fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-        fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+        fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+        fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+        fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
-        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
         perception_monitor_enabled: false,
     })
 }

--- a/tests/posture_gate_integration.rs
+++ b/tests/posture_gate_integration.rs
@@ -33,12 +33,12 @@ use axum::routing::{get, post};
 use axum::Router;
 use tower::ServiceExt; // for `oneshot`
 
-use kirra_runtime_sdk::gateway::policy_layer::enforce_posture_routing;
-use kirra_runtime_sdk::posture_cache::{
+use kirra_verifier::gateway::policy_layer::enforce_posture_routing;
+use kirra_verifier::posture_cache::{
     CachedFleetPosture, ServiceState, SharedPostureCache,
 };
-use kirra_runtime_sdk::verifier::{AppState, FleetPosture, VerifierOperationMode};
-use kirra_runtime_sdk::verifier_store::VerifierStore;
+use kirra_verifier::verifier::{AppState, FleetPosture, VerifierOperationMode};
+use kirra_verifier::verifier_store::VerifierStore;
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -60,13 +60,13 @@ fn build_state(initial: Option<CachedFleetPosture>) -> Arc<ServiceState> {
     Arc::new(ServiceState {
         app,
         posture_cache,
-        started_at_ms: kirra_runtime_sdk::posture_cache::now_ms(),
+        started_at_ms: kirra_verifier::posture_cache::now_ms(),
         audit_verifying_key: None,
-        fabric_router: Arc::new(kirra_runtime_sdk::fabric::router::FabricRouter::new()),
-        fabric_telemetry: Arc::new(kirra_runtime_sdk::fabric::telemetry::FabricTelemetry::new()),
-        fabric_causal_log: Arc::new(kirra_runtime_sdk::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
+        fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+        fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+        fabric_causal_log: Arc::new(kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None)),
         posture_engine_tx: std::sync::OnceLock::new(),
-        perception_cap: kirra_runtime_sdk::gateway::perception_monitor::empty_perception_cap(),
+        perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
         perception_monitor_enabled: false,
     })
 }

--- a/tests/rss_posture_tests.rs
+++ b/tests/rss_posture_tests.rs
@@ -9,11 +9,11 @@
 
 use std::sync::Arc;
 
-use kirra_runtime_sdk::verifier::{AppState, FleetPosture, VerifierOperationMode};
-use kirra_runtime_sdk::posture_cache::{CachedFleetPosture, SharedPostureCache};
-use kirra_runtime_sdk::scenario_runner::{PostureAssertion, ScenarioEvent, ScenarioRunner};
-use kirra_runtime_sdk::verifier_store::VerifierStore;
-use kirra_runtime_sdk::recovery_hysteresis::AV_RECOVERY_STREAK_THRESHOLD;
+use kirra_verifier::verifier::{AppState, FleetPosture, VerifierOperationMode};
+use kirra_verifier::posture_cache::{CachedFleetPosture, SharedPostureCache};
+use kirra_verifier::scenario_runner::{PostureAssertion, ScenarioEvent, ScenarioRunner};
+use kirra_verifier::verifier_store::VerifierStore;
+use kirra_verifier::recovery_hysteresis::AV_RECOVERY_STREAK_THRESHOLD;
 use parko_core::RssState;
 
 fn build_rss_test_app() -> (Arc<AppState>, SharedPostureCache) {

--- a/tests/rss_simulation.rs
+++ b/tests/rss_simulation.rs
@@ -15,15 +15,15 @@ use std::sync::Arc;
 
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
-use kirra_runtime_sdk::posture_cache::{CachedFleetPosture, SharedPostureCache};
-use kirra_runtime_sdk::posture_engine::recalculate_and_broadcast;
-use kirra_runtime_sdk::posture_engine_v2::apply_rss_state;
-use kirra_runtime_sdk::recovery_hysteresis::AV_RECOVERY_STREAK_THRESHOLD;
-use kirra_runtime_sdk::scenario_runner::{PostureAssertion, ScenarioEvent, ScenarioRunner};
-use kirra_runtime_sdk::verifier::{
+use kirra_verifier::posture_cache::{CachedFleetPosture, SharedPostureCache};
+use kirra_verifier::posture_engine::recalculate_and_broadcast;
+use kirra_verifier::posture_engine_v2::apply_rss_state;
+use kirra_verifier::recovery_hysteresis::AV_RECOVERY_STREAK_THRESHOLD;
+use kirra_verifier::scenario_runner::{PostureAssertion, ScenarioEvent, ScenarioRunner};
+use kirra_verifier::verifier::{
     AppState, FleetPosture, NodeTrustState, RegisteredNode, VerifierOperationMode,
 };
-use kirra_runtime_sdk::verifier_store::VerifierStore;
+use kirra_verifier::verifier_store::VerifierStore;
 
 use parko_core::commands::ControlCommand;
 use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};

--- a/tests/temporal_scenario_tests.rs
+++ b/tests/temporal_scenario_tests.rs
@@ -27,14 +27,14 @@
 
 use std::sync::Arc;
 
-use kirra_runtime_sdk::verifier::{AppState, FleetPosture, NodeTrustState, VerifierOperationMode};
-use kirra_runtime_sdk::posture_cache::{CachedFleetPosture, SharedPostureCache};
-use kirra_runtime_sdk::scenario_runner::{
+use kirra_verifier::verifier::{AppState, FleetPosture, NodeTrustState, VerifierOperationMode};
+use kirra_verifier::posture_cache::{CachedFleetPosture, SharedPostureCache};
+use kirra_verifier::scenario_runner::{
     PostureAssertion, ScenarioEvent, ScenarioRunner,
 };
-use kirra_runtime_sdk::clock::{Clock, VirtualClock};
-use kirra_runtime_sdk::recovery_hysteresis::AV_RECOVERY_STREAK_THRESHOLD;
-use kirra_runtime_sdk::posture_engine::POSTURE_CACHE_TTL_MS;
+use kirra_verifier::clock::{Clock, VirtualClock};
+use kirra_verifier::recovery_hysteresis::AV_RECOVERY_STREAK_THRESHOLD;
+use kirra_verifier::posture_engine::POSTURE_CACHE_TTL_MS;
 
 // ---------------------------------------------------------------------------
 // Test infrastructure helpers
@@ -54,7 +54,7 @@ async fn build_av_test_infrastructure() -> (
     SharedPostureCache,
     Arc<VirtualClock>,
 ) {
-    use kirra_runtime_sdk::verifier_store::VerifierStore;
+    use kirra_verifier::verifier_store::VerifierStore;
 
     let store = VerifierStore::new(":memory:").expect("in-memory store");
     let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
@@ -91,7 +91,7 @@ async fn build_av_test_infrastructure() -> (
     // Initialize all nodes as Trusted in the DashMap
     for node_id in &["lidar_front", "camera_front", "gps_primary",
                      "perception_fusion", "trajectory_planner"] {
-        app.nodes.insert(node_id.to_string(), kirra_runtime_sdk::verifier::RegisteredNode {
+        app.nodes.insert(node_id.to_string(), kirra_verifier::verifier::RegisteredNode {
             node_id: node_id.to_string(),
             status: NodeTrustState::Trusted,
             registered_at_ms: 0,

--- a/tools/iceoryx2-spike/Cargo.toml
+++ b/tools/iceoryx2-spike/Cargo.toml
@@ -1,4 +1,4 @@
-# Standalone spike crate — NOT a member of the kirra-runtime-sdk workspace.
+# Standalone spike crate — NOT a member of the kirra-verifier workspace.
 # The empty [workspace] table below makes this its own workspace root, so it
 # carries its own Cargo.lock and iceoryx2 never enters any SDK/parko crate's
 # dependency tree (this is a spike, not an adoption — adoption is the #275 ADR's

--- a/work/backlog.md
+++ b/work/backlog.md
@@ -748,7 +748,7 @@ AUTHORITY MODEL (canonical, commits 9943aa9/e1ba1a2/21c3a35):
 FILE: kirra-runtime-sdk/tests/rss_simulation.rs
 
 REQUIREMENTS:
-1. Use ScenarioRunner from kirra_runtime_sdk::scenario_runner.
+1. Use ScenarioRunner from kirra_verifier::scenario_runner.
 2. Use actual clock type from prerequisite check. No sleep().
 3. 10,000 scenarios × 10 ticks. Deterministic seed.
    Include scenarios that reach LockedOut posture as well as Degraded.

--- a/work/pending_prompts.md
+++ b/work/pending_prompts.md
@@ -332,7 +332,7 @@ Requirements:
 Create kirra-runtime-sdk/tests/rss_simulation.rs.
 
 Requirements:
-1. Use ScenarioRunner from kirra_runtime_sdk::scenario_runner.
+1. Use ScenarioRunner from kirra_verifier::scenario_runner.
 2. Use MockClock (or VirtualClock — check actual name in src/clock.rs); no sleep.
 3. Generate 10_000 scenarios: each is 10 ticks with varying kinematic state.
    Some gaps below safe distance; some above.


### PR DESCRIPTION
## The final de-monolith reframe — `kirra-runtime-sdk` → `kirra-verifier`

Now that **nothing lean depends on the crate** (Stage 7 severed the ROS2 adapter and the planner; the only remaining consumers are the heavy `VerifierStore`/federation ones — `kirra-taj`, `kirra-fleet-transport`, `parko-ros2`, `parko-kirra`), the "runtime-sdk" identity no longer fits: this crate **is** the verifier service. This PR retires the old name.

### What changed
- **Package** `kirra-runtime-sdk` → `kirra-verifier`; **`[lib] name`** `kirra_runtime_sdk` → `kirra_verifier`. The cdylib/rlib artifact follows (`libkirra_verifier.{so,a}`).
- **~273 `kirra_runtime_sdk::` references** repointed to `kirra_verifier::` across the SDK bins, the workspace tests, `kirra-taj`, `kirra-fleet-transport`, `parko-ros2`, `parko-kirra`, and the Stage-7 re-export shims. (The underscore lib ident never appears in a URL or path, so this was a safe global rewrite.)
- **Path-dependency keys** updated in the 4 dependent crates' manifests.
- **CI:** the one build-critical hyphen reference, `cargo test -p kirra-runtime-sdk …` → `-p kirra-verifier`.

### What deliberately did NOT change
- The **`kirra_verifier_service` binary** name (unchanged).
- The **GitHub repository** stays `kirra-runtime-sdk`: every `github.com/kirra-systems/kirra-runtime-sdk` URL, the `repository` manifest field, `install.sh`'s `GITHUB_REPO`, the systemd-unit `Documentation=` URLs, and checkout-directory references are preserved. **Repo identity ≠ crate identity.**

### Verification
- `cargo build --workspace` — clean.
- `cargo test --workspace` — **1395 passed, 0 failed** (no regression vs pre-rename).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.

Mechanical rename only — no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWXgETCGcdP6XXErwLHkFk)_