### PR TITLE
harden(review): C1 watchdog fail-open + H1 nonce-burn + H2 capture durability + Auth M1 stale gate

### DIFF
--- a/crates/kirra-core/src/capture.rs
+++ b/crates/kirra-core/src/capture.rs
@@ -237,8 +237,23 @@ pub fn spawn_capture_writer() -> mpsc::Sender<CaptureRecord> {
             queue_bound = CAPTURE_QUEUE_BOUND, path = %sink_path,
             "capture writer task started"
         );
+        // Block for the next record, then drain everything already queued without
+        // blocking, then fsync the whole batch. Batching the `sync_data` to the
+        // drain-empty point keeps the durability cost off the per-record path while
+        // guaranteeing that, once the queue is momentarily empty, every record handed to
+        // us is on stable storage — so a crash can lose only in-flight records, never a
+        // torn line that was already acknowledged as written.
         while let Some(rec) = rx.blocking_recv() {
             write_one_capture(&mut sink, &rec);
+            // Drain everything already queued without blocking (Empty = caught up,
+            // Disconnected = last sender dropped — both end the drain; a Disconnected
+            // ends the outer loop on the next `blocking_recv`).
+            while let Ok(rec) = rx.try_recv() {
+                write_one_capture(&mut sink, &rec);
+            }
+            if let Err(e) = sink.sync_data() {
+                tracing::error!(error = %e, "capture writer: sync_data failed — batch may not be durable");
+            }
         }
         tracing::info!("capture writer task exiting (channel closed)");
     });
@@ -249,8 +264,13 @@ pub fn spawn_capture_writer() -> mpsc::Sender<CaptureRecord> {
 /// for capture run (off the verdict path).
 fn write_one_capture(sink: &mut std::fs::File, rec: &CaptureRecord) {
     match serde_json::to_string(rec) {
-        Ok(line) => {
-            if let Err(e) = writeln!(sink, "{line}") {
+        Ok(mut line) => {
+            // One `write_all` of the line + newline in a single buffer, rather than
+            // `writeln!` (which can issue several writes and tear the line on crash).
+            // `write_all` retries short writes for us; the batched `sync_data` in the
+            // writer loop then makes the durably-flushed prefix a whole number of lines.
+            line.push('\n');
+            if let Err(e) = sink.write_all(line.as_bytes()) {
                 tracing::error!(error = %e, "capture writer: JSONL append failed; record dropped");
             }
         }

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -945,8 +945,13 @@ async fn handle_audit_rotate_key(
                 (StatusCode::SERVICE_UNAVAILABLE,
                  Json(json!({ "error": "fenced: epoch superseded; instance demoted to passive standby" }))).into_response()
             }
-            Err(DurableWriteError::Db(_)) => (StatusCode::INTERNAL_SERVER_ERROR,
-                       Json(json!({ "error": "failed to record key rotation" }))).into_response(),
+            // NonceReplay is unreachable for key rotation (it burns no nonce); fold it
+            // into the generic write-failure 500 so the match stays exhaustive and any
+            // impossible occurrence still fails closed.
+            Err(DurableWriteError::Db(_)) | Err(DurableWriteError::NonceReplay) => {
+                (StatusCode::INTERNAL_SERVER_ERROR,
+                 Json(json!({ "error": "failed to record key rotation" }))).into_response()
+            }
         },
         Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
                    Json(json!({ "error": "store lock poisoned" }))).into_response(),
@@ -1565,6 +1570,23 @@ async fn submit_federated_report(
 
     match store.save_federated_report_chained(&report, received_at_ms, held_epoch) {
         Ok(()) => Json(evaluation).into_response(),
+        Err(DurableWriteError::NonceReplay) => {
+            // Lost the burn race: a concurrent submit (or an earlier one between our
+            // has_seen check and this commit) already claimed this nonce. The report was
+            // NOT persisted (tx rolled back). Same disposition as the pre-check replay
+            // path — audit + reject as a replay, NOT a 500.
+            let event = json!({ "source_controller_id": report.source_controller_id,
+                                "nonce_hex": report.nonce_hex,
+                                "reason": "FEDERATION_NONCE_REPLAY" });
+            let _ = store.save_posture_event_chained(
+                "federation_gateway", "FEDERATION_REJECTED",
+                &event.to_string(), Some("nonce replay (lost burn race)"), received_at_ms,
+            );
+            Json(ReportEvaluation {
+                accepted: false,
+                reason: "FEDERATED_NONCE_REPLAY".to_string(),
+            }).into_response()
+        }
         Err(DurableWriteError::Fenced(reason)) => {
             // Superseded between the request-path gate and this commit. Mirror
             // the gate: self-demote and reject fail-closed — the report was NOT

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -43,19 +43,23 @@ fn now_ms() -> u64 {
 
 /// Resolves the current FleetPosture from the SharedPostureCache.
 ///
-/// None (cold start or expired cache) and a poisoned RwLock both map to
-/// LockedOut — fail-closed in all ambiguous cases.
+/// Delegates to [`resolve_posture_with_reason`] so this inner safety gate is
+/// **independently** fail-closed on every ambiguous case — a STALE cache (age ≥
+/// `POSTURE_CACHE_TTL_MS`), an empty cache (cold start / reset), and a poisoned RwLock
+/// all map to `LockedOut`. (Auth M1) Previously this only handled `None` and poison and
+/// returned a `Some(cached)` posture WITHOUT a staleness check — fail-closed only because
+/// the outer `should_route_command` gate happened to TTL-check first; the inner gate must
+/// not depend on that. The single source of truth for the freshness rule now lives in
+/// `resolve_posture_with_reason`.
 // SAFETY: SG8 SG9 | REQ: posture-resolve-fails-closed-locked-out | TEST: test_none_cache_denies_all_commands,test_empty_posture_cache_fails_closed_as_locked_out
-// (Poisoned-lock and missing-cache both map to LockedOut; SG8 = correct
-//  MRC selection on degraded, SG9 = fail-closed on lock/cache anomaly.)
+// (Stale-cache, missing-cache, and poisoned-lock all map to LockedOut; SG8 = correct
+//  MRC selection on degraded, SG9 = fail-closed on staleness/lock/cache anomaly.)
 fn resolve_posture(svc: &ServiceState) -> FleetPosture {
-    match svc.posture_cache.read() {
-        Ok(guard) => match guard.as_ref() {
-            Some(cached) => cached.posture.clone(),
-            None => FleetPosture::LockedOut,
-        },
-        Err(_) => FleetPosture::LockedOut,
-    }
+    crate::posture_engine_v2::resolve_posture_with_reason(
+        &svc.posture_cache,
+        crate::posture_cache::POSTURE_CACHE_TTL_MS,
+    )
+    .0
 }
 
 /// The enforcement verdict the actuator middleware reached for one command,

--- a/src/telemetry_watchdog.rs
+++ b/src/telemetry_watchdog.rs
@@ -171,6 +171,20 @@ pub fn spawn_telemetry_watchdog_with_clock(
 // ≥ AV_TELEMETRY_TIMEOUT_MS is marked Untrusted(TELEMETRY_TIMEOUT) and a
 // PostureRecalcTrigger::WatchdogTimeout is sent within one sweep
 // (sg_003_cert_tests + watchdog_di_tests).
+/// Acquire the shared store lock, recovering a poisoned guard instead of panicking.
+///
+/// The telemetry watchdog is the ASIL-D dead-man's switch: it MUST keep sweeping even
+/// if some other handler/writer panicked while holding `app.store` (which poisons the
+/// mutex). A bare `.lock().unwrap()` would propagate that poison, panic the spawned
+/// sweep task, and silently kill the watchdog — a fail-OPEN: a silent LIDAR/IMU would
+/// then never be marked `Untrusted`, posture would never recalculate, and actuators
+/// would stay live. A poisoned guard's data is still readable; we recover it and carry
+/// on, matching the graceful lock handling already in `standby_monitor.rs` /
+/// `audit_writer.rs`.
+fn store_guard(app: &AppState) -> std::sync::MutexGuard<'_, crate::verifier_store::VerifierStore> {
+    app.store.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 pub(crate) fn watchdog_sweep_once(
     app: &Arc<AppState>,
     posture_engine_tx: &PostureEngineSender,
@@ -199,7 +213,7 @@ pub(crate) fn watchdog_sweep_once(
         || *last_node_refresh_ms == 0
     {
         let load_result = {
-            let store = app.store.lock().unwrap();
+            let store = store_guard(app);
             store.load_all_registered_av_node_ids()
         }; // outer guard released here — before any per-node re-lock below
 
@@ -211,7 +225,7 @@ pub(crate) fn watchdog_sweep_once(
                     node_health.entry(node_id.clone()).or_insert_with(|| {
                         // Load initial last_seen from persistent store.
                         // Safe: outer guard already released above.
-                        let last_seen = app.store.lock().unwrap()
+                        let last_seen = store_guard(app)
                             .get_last_telemetry_timestamp(&node_id)
                             .unwrap_or(0);
                         WatchdogNodeEntry {
@@ -246,7 +260,7 @@ pub(crate) fn watchdog_sweep_once(
         // Sync last_seen_ms from the store on each sweep.
         // Lightweight in-memory read path; SQLite is only hit on the node
         // refresh cycle above.
-        if let Ok(ts) = app.store.lock().unwrap().get_last_telemetry_timestamp(&entry.node_id) {
+        if let Ok(ts) = store_guard(app).get_last_telemetry_timestamp(&entry.node_id) {
             if ts > entry.last_seen_ms {
                 // Fresh telemetry received since last sweep — reset warn flag.
                 entry.last_seen_ms = ts;
@@ -638,6 +652,51 @@ mod watchdog_di_tests {
         // (3) refresh stamp advanced to `now`.
         assert_eq!(observed_last_refresh, now,
             "*last_node_refresh_ms must be set to clock.now_ms() after a refresh");
+    }
+
+    /// C1 regression — the dead-man's switch must NOT fail open on a poisoned store
+    /// lock. If a handler/writer panics while holding `app.store`, the mutex is
+    /// poisoned; the sweep must still run (recovering the guard) rather than panic the
+    /// task and silently die. A dead watchdog never marks a silent sensor `Untrusted`.
+    #[test]
+    fn watchdog_sweep_survives_a_poisoned_store_lock() {
+        let store = VerifierStore::new(":memory:").expect("memory store");
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+        store_guard(&app)
+            .register_av_subsystem_meta("lidar_front", "LIDAR", "hw-0001", 0.7, 1_000_000)
+            .expect("register av subsystem");
+        insert_trusted_node(&app, "lidar_front", 1_000_000);
+
+        // Poison the store mutex: a thread panics while holding the lock.
+        let app_poisoner = Arc::clone(&app);
+        let _ = std::thread::spawn(move || {
+            let _g = app_poisoner.store.lock().unwrap();
+            panic!("intentionally poison the store mutex");
+        })
+        .join();
+        assert!(app.store.is_poisoned(), "precondition: the store lock is poisoned");
+
+        // A node silent well past the fault threshold while the lock is poisoned.
+        let now = 1_000_000 + AV_TELEMETRY_TIMEOUT_MS + 1_000;
+        let clock = VirtualClock::starting_at(now);
+        let (tx, _rx) = mpsc::channel::<PostureRecalcTrigger>(128);
+        let mut node_health: HashMap<String, WatchdogNodeEntry> = HashMap::new();
+        let mut last_node_refresh_ms: u64 = 0;
+
+        // Must complete WITHOUT panicking — the whole point of C1.
+        watchdog_sweep_once(&app, &tx, clock.as_ref(), &mut node_health, &mut last_node_refresh_ms);
+
+        // And it actually did its job: the silent node was driven Untrusted through the
+        // recovered guard, not skipped.
+        let status = app
+            .nodes
+            .get("lidar_front")
+            .map(|n| n.status.clone())
+            .expect("node present");
+        assert!(
+            matches!(status, NodeTrustState::Untrusted(_)),
+            "silent node must be marked Untrusted even with a poisoned lock, got {status:?}"
+        );
     }
 }
 

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -147,12 +147,19 @@ pub enum FenceError {
     EpochUnreadable,
 }
 
-/// Error from a top-tier (durable, `synchronous=FULL`) state mutation: either
-/// the HA epoch fence fired (`Fenced`) or the underlying SQLite write failed
-/// (`Db`). Callers self-demote on `Fenced`; both are denials (no partial write).
+/// Error from a top-tier (durable, `synchronous=FULL`) state mutation: the HA epoch
+/// fence fired (`Fenced`), the single-use nonce was already burned (`NonceReplay`), or
+/// the underlying SQLite write failed (`Db`). Callers self-demote on `Fenced`; all are
+/// denials (no partial write — the transaction rolls back).
 #[derive(Debug)]
 pub enum DurableWriteError {
     Fenced(FenceError),
+    /// The federation nonce INSERT hit a PRIMARY KEY conflict — the nonce is already
+    /// burned (a concurrent submit won the race, or it was seen before). This is the
+    /// AUTHORITATIVE replay signal: the nonce row, not the handler's prior
+    /// `has_seen_federation_nonce` check, is what makes a report single-use under
+    /// concurrency. Callers map it to a clean replay rejection, NOT a 500.
+    NonceReplay,
     Db(rusqlite::Error),
 }
 
@@ -177,6 +184,9 @@ impl std::fmt::Display for DurableWriteError {
             ),
             DurableWriteError::Fenced(FenceError::EpochUnreadable) => {
                 write!(f, "durable write fenced: HA epoch unreadable (fail-closed)")
+            }
+            DurableWriteError::NonceReplay => {
+                write!(f, "durable write rejected: federation nonce already burned (replay)")
             }
             DurableWriteError::Db(e) => write!(f, "durable write failed: {e}"),
         }
@@ -1753,11 +1763,28 @@ impl VerifierStore {
             ],
         )?;
 
-        tx.execute(
+        // Burn the nonce — the AUTHORITATIVE single-use claim. This MUST stay a plain
+        // INSERT (never `INSERT OR IGNORE`): the `nonce_hex` PRIMARY KEY makes a duplicate
+        // FAIL right here, and that failure IS the anti-replay guarantee under
+        // concurrency. The handler's prior `has_seen_federation_nonce` check is only a
+        // fast-path optimization — two requests carrying the same nonce can both pass it
+        // and reach this point, where exactly one wins the PK and the other is rejected as
+        // a replay. `INSERT OR IGNORE` would silently skip the duplicate nonce row and let
+        // the report below commit anyway = DOUBLE-ACCEPT. A PK conflict here maps to
+        // `NonceReplay` (the tx rolls back on return), not a generic 500.
+        match tx.execute(
             "INSERT INTO federation_report_nonces (nonce_hex, source_controller_id, seen_at_ms)
              VALUES (?1, ?2, ?3)",
             params![report.nonce_hex, report.source_controller_id, received_at_ms as i64],
-        )?;
+        ) {
+            Ok(_) => {}
+            Err(rusqlite::Error::SqliteFailure(e, _))
+                if e.code == rusqlite::ErrorCode::ConstraintViolation =>
+            {
+                return Err(DurableWriteError::NonceReplay);
+            }
+            Err(e) => return Err(DurableWriteError::Db(e)),
+        }
 
         let audit = serde_json::json!({
             "source_controller_id": report.source_controller_id,
@@ -4165,6 +4192,29 @@ mod durability_tests {
         // #79: held == durable epoch (1) → the fence admits the legitimate write.
         s.save_federated_report_chained(&report("aa"), 2_000, 1).unwrap();
         assert!(s.has_seen_federation_nonce("aa").unwrap());
+    }
+
+    /// H1 — the nonce INSERT is the AUTHORITATIVE single-use claim. A second report
+    /// carrying an already-burned nonce must be rejected as `NonceReplay` (not a generic
+    /// `Db` error → 500), even with the handler's prior `has_seen_federation_nonce` check
+    /// bypassed — this is the concurrency race the handler maps to FEDERATED_NONCE_REPLAY.
+    #[test]
+    fn duplicate_nonce_burn_is_rejected_as_replay() {
+        let mut s = VerifierStore::new(":memory:").unwrap();
+        let held = s.try_claim_epoch(0, "node", 1).unwrap().unwrap();
+        // First submit burns the nonce.
+        s.save_federated_report_chained(&report("abc123"), 2_000, held).unwrap();
+        // A second submit with the SAME nonce (simulating the lost check→burn race) must
+        // hit the PRIMARY KEY and surface as NonceReplay, NOT DurableWriteError::Db.
+        let err = s
+            .save_federated_report_chained(&report("abc123"), 3_000, held)
+            .unwrap_err();
+        assert!(
+            matches!(err, DurableWriteError::NonceReplay),
+            "duplicate nonce must map to NonceReplay, got {err:?}"
+        );
+        // The replay tx rolled back; the original burn is intact.
+        assert!(s.has_seen_federation_nonce("abc123").unwrap());
     }
 
     /// EPOCH NON-REGRESSION (the fence-correctness core of #74): a claim


### PR DESCRIPTION
Hardening batch from the consolidated review — the high-confidence, single-fix items. Each carries a regression test. The design-decision items (C2 supervisor, H3 epoch reclaim, H4 tokio-optional) and the safety-critical scalar-governor changes (M1/M2) are tracked separately.

## 🔴 C1 — telemetry watchdog poisoned-lock fail-open
The ASIL-D dead-man's switch acquired `app.store` with `.lock().unwrap()` at all three sweep sites. A panic elsewhere while holding that lock poisons the mutex → next sweep panics → the spawned task dies silently → a silent LIDAR/IMU is never marked `Untrusted`, posture never recalculates, actuators stay live. **Fail-open in the one place that must fail closed.** Fix: a `store_guard` helper recovers the poisoned guard (`into_inner`), matching `standby_monitor.rs`/`audit_writer.rs`. Test: `watchdog_sweep_survives_a_poisoned_store_lock`.

## 🟠 H1 — federation nonce-burn replay correctness
Check-then-act around the nonce burn: a concurrent same-nonce replay lost the PK race and surfaced as a generic **500 with no `FEDERATED_NONCE_REPLAY` and no audit event** — and a future `INSERT OR IGNORE` "harmonization" would have become a double-accept. Fix: new `DurableWriteError::NonceReplay`; the nonce INSERT is now the authoritative single-use claim (ConstraintViolation → `NonceReplay`, tx rolls back), the handler maps it to the proper replay rejection + audit event, and a load-bearing comment documents the `INSERT OR IGNORE` landmine. Test: `duplicate_nonce_burn_is_rejected_as_replay`.

## 🟠 H2 — capture JSONL writer durability
`writeln!` could tear the final line on crash and the writer never fsynced. Fix: single `write_all` per record + batched `sync_data()` at the drain-empty point (durability off the per-record path; a crash loses only in-flight records, never a torn line). Off the verdict path — data integrity, not safety. The 5 capture tests pass under `--features capture`.

## 🟡 Auth M1 — inner posture gate not independently stale-fail-closed
`policy_layer::resolve_posture` returned a `Some(cached)` posture without a staleness check (safe only because the outer gate TTL-checks first). Fix: delegate to `resolve_posture_with_reason(cache, POSTURE_CACHE_TTL_MS)` so stale/empty/poisoned all map to `LockedOut` from one source of truth.

## Verification
- New regression tests for C1 and H1 pass; capture 5/5 under `--features capture`
- policy_layer 9, actuator_envelope 17, posture_gate 6, verifier_store 69, federation 27 — all green
- SDK lib + bins clippy clean under `-D warnings`; kirra-core capture-feature clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)