### PR TITLE
fix(ha): supervise background safety loops + harden HA promotion (review C2 + H3)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,9 @@ pub mod protocol_adapter;
 pub mod adapters;
 pub mod fabric;
 pub mod standby_monitor;
+/// Background-task supervisor (review finding C2): re-spawns dead safety loops and
+/// escalates the fleet to fail-closed LockedOut if a critical loop is wedged.
+pub mod supervisor;
 pub mod kinematics_sim;
 
 #[cfg(test)]

--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -94,7 +94,16 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     let escalate = (app.rss_active_violation.load(std::sync::atomic::Ordering::SeqCst)
         || app.flood_condition_active.load(std::sync::atomic::Ordering::SeqCst))
         && dag_posture == FleetPosture::Nominal;
-    let new_posture = if escalate {
+    // C2 supervisor escalation has ABSOLUTE priority over the DAG and the
+    // operational (rss/flood) escalation: if a critical background safety loop is
+    // wedged past its restart budget, `supervisor_tripped` is set and the whole
+    // fleet is forced LockedOut here. Because the engine itself honors the flag,
+    // the forced LockedOut STICKS across every subsequent recalc (a recovered DAG
+    // can never silently downgrade it). Recovery is a human/HA reset, matching
+    // LockedOut semantics. SAFETY: SG9 fail-closed on safety-loop death (review C2).
+    let new_posture = if app.supervisor_tripped.load(std::sync::atomic::Ordering::SeqCst) {
+        FleetPosture::LockedOut
+    } else if escalate {
         FleetPosture::Degraded
     } else {
         dag_posture
@@ -225,6 +234,25 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
             "Fleet posture transition"
         );
     }
+}
+
+/// Force the posture cache to `LockedOut` immediately (C2 supervisor escalation).
+///
+/// Writes a `LockedOut` entry with a freshly-bumped generation so it wins the
+/// monotonic compare-and-swap, WITHOUT going through `recalculate_and_broadcast`
+/// (which may be the very task that died). Callers MUST also set
+/// `AppState::supervisor_tripped` so any *surviving* recalc keeps producing
+/// LockedOut — this function only makes the lockout instantaneous; the sticky flag
+/// makes it durable. Fail-closed by construction: a poisoned cache lock is the
+/// gate's own LockedOut signal, so a failed write here still denies.
+pub fn force_lockout(cache: &SharedPostureCache, ts_ms: u64) {
+    let candidate =
+        CachedFleetPosture::new_with_generation(FleetPosture::LockedOut, next_generation(), ts_ms);
+    let wrote = replace_cache_if_newer(cache, candidate);
+    tracing::error!(
+        wrote_cache = wrote,
+        "C2 escalation: posture cache forced to LockedOut (critical safety loop wedged)"
+    );
 }
 
 /// Replaces the cached posture ONLY if `candidate.generation` is strictly
@@ -392,6 +420,59 @@ mod posture_engine_tests {
         let entry = guard.as_ref().unwrap();
         assert_eq!(entry.posture, FleetPosture::Nominal);
         assert!(entry.generation > 0);
+    }
+
+    #[test]
+    fn test_supervisor_tripped_forces_locked_out_over_healthy_dag() {
+        use std::sync::Arc;
+        use std::sync::atomic::Ordering;
+        use crate::verifier::{AppState, VerifierOperationMode};
+        use crate::verifier_store::VerifierStore;
+
+        let store = VerifierStore::new(":memory:").unwrap();
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+        let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
+
+        // Healthy empty DAG would normally be Nominal (see the test above).
+        // Trip the C2 supervisor flag: recalc must force LockedOut regardless.
+        app.supervisor_tripped.store(true, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        {
+            let guard = cache.read().unwrap();
+            assert_eq!(
+                guard.as_ref().unwrap().posture,
+                FleetPosture::LockedOut,
+                "supervisor_tripped must force LockedOut over a healthy DAG"
+            );
+        }
+
+        // Sticky: a subsequent recalc (e.g. DAG still healthy) must NOT downgrade.
+        recalculate_and_broadcast(&app, &cache);
+        {
+            let guard = cache.read().unwrap();
+            assert_eq!(
+                guard.as_ref().unwrap().posture,
+                FleetPosture::LockedOut,
+                "forced LockedOut must STICK across recalcs while the flag is set"
+            );
+        }
+    }
+
+    #[test]
+    fn test_force_lockout_writes_locked_out_with_bumped_generation() {
+        use std::sync::Arc;
+        use crate::posture_cache::CachedFleetPosture;
+
+        let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(Some(
+            CachedFleetPosture::new_with_generation(FleetPosture::Nominal, 1, 1_000),
+        )));
+
+        force_lockout(&cache, 2_000);
+
+        let guard = cache.read().unwrap();
+        let entry = guard.as_ref().unwrap();
+        assert_eq!(entry.posture, FleetPosture::LockedOut);
+        assert!(entry.generation > 1, "force_lockout must bump the generation to win the CAS");
     }
 
     #[test]

--- a/src/posture_engine_v2.rs
+++ b/src/posture_engine_v2.rs
@@ -264,44 +264,76 @@ pub fn start_posture_engine_worker(
     app: Arc<AppState>,
     cache: SharedPostureCache,
 ) -> PostureEngineSender {
-    let (tx, mut rx) = mpsc::channel::<PostureRecalcTrigger>(128);
+    let (tx, rx) = mpsc::channel::<PostureRecalcTrigger>(128);
+    // C2: the worker is supervised, so its receiver must survive a re-spawn. The
+    // `mpsc::Receiver` is not `Clone`, so it lives behind an `Arc<Mutex<…>>` that
+    // each (re)started future re-locks. Only ever one task holds the lock at a time.
+    let rx = Arc::new(tokio::sync::Mutex::new(rx));
 
-    tokio::spawn(async move {
-        loop {
-            let first = match rx.recv().await {
-                Some(t) => t,
-                None    => {
-                    tracing::info!("Posture engine worker: trigger channel closed, exiting");
-                    break;
+    // C2 escalation: a wedged posture worker means recalculation stops. That is
+    // ALREADY fail-closed after `POSTURE_CACHE_TTL_MS` (the cache goes stale and the
+    // gate denies), but we make it immediate and sticky: set the flag and force the
+    // cache to LockedOut directly (the worker is the dead task, so we cannot rely on
+    // a recalc to apply the flag).
+    let escalate: crate::supervisor::Escalation = {
+        let app = Arc::clone(&app);
+        let cache = cache.clone();
+        Arc::new(move || {
+            app.supervisor_tripped
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            crate::posture_engine::force_lockout(&cache, now_ms_engine());
+        })
+    };
+
+    crate::supervisor::spawn_supervised(
+        "posture_engine_worker",
+        /* critical   */ true,
+        /* run-forever */ false, // a closed trigger channel is a legitimate shutdown exit
+        Some(escalate),
+        move || {
+            let app = Arc::clone(&app);
+            let cache = cache.clone();
+            let rx = Arc::clone(&rx);
+            async move {
+                let mut rx = rx.lock().await;
+                loop {
+                    let first = match rx.recv().await {
+                        Some(t) => t,
+                        None => {
+                            tracing::info!("Posture engine worker: trigger channel closed, exiting");
+                            break;
+                        }
+                    };
+
+                    let mut batch: Vec<PostureRecalcTrigger> = vec![first];
+                    while let Ok(trigger) = rx.try_recv() {
+                        batch.push(trigger);
+                    }
+
+                    let batch_size = batch.len();
+                    let trigger_summary: Vec<String> =
+                        batch.iter().map(|t| t.to_string()).collect();
+
+                    if batch_size > 1 {
+                        tracing::debug!(
+                            batch_size = batch_size,
+                            triggers   = ?trigger_summary,
+                            "Posture engine: coalescing {batch_size} triggers into single recalculation"
+                        );
+                    }
+
+                    let now = now_ms_engine();
+                    for trigger in &batch {
+                        if let PostureRecalcTrigger::RssViolation(ref rss) = *trigger {
+                            apply_rss_state(&app, rss, now);
+                        }
+                    }
+
+                    recalculate_and_broadcast_with_context(&app, &cache, &trigger_summary);
                 }
-            };
-
-            let mut batch: Vec<PostureRecalcTrigger> = vec![first];
-            while let Ok(trigger) = rx.try_recv() {
-                batch.push(trigger);
             }
-
-            let batch_size = batch.len();
-            let trigger_summary: Vec<String> = batch.iter().map(|t| t.to_string()).collect();
-
-            if batch_size > 1 {
-                tracing::debug!(
-                    batch_size = batch_size,
-                    triggers   = ?trigger_summary,
-                    "Posture engine: coalescing {batch_size} triggers into single recalculation"
-                );
-            }
-
-            let now = now_ms_engine();
-            for trigger in &batch {
-                if let PostureRecalcTrigger::RssViolation(ref rss) = *trigger {
-                    apply_rss_state(&app, rss, now);
-                }
-            }
-
-            recalculate_and_broadcast_with_context(&app, &cache, &trigger_summary);
-        }
-    });
+        },
+    );
 
     tx
 }

--- a/src/standby_monitor.rs
+++ b/src/standby_monitor.rs
@@ -104,9 +104,45 @@ pub fn instance_id() -> String {
         }
     }
     static FALLBACK_ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-    FALLBACK_ID.get_or_init(|| {
-        format!("kirra-{}", now_ms())
-    }).clone()
+    FALLBACK_ID.get_or_init(stable_fallback_instance_id).clone()
+}
+
+/// Derive a fallback instance id that is STABLE across process restarts (HA
+/// Part B / review H3+L2). The startup epoch-reclaim path keys on the instance
+/// id: a node that crashed mid-promotion must present the SAME id on reboot to
+/// reclaim its own durable epoch. The previous `kirra-<now_ms>` fallback changed
+/// on every restart, breaking that reclaim. Resolution order (most→least stable):
+///   1. `/etc/machine-id` — the canonical per-host stable identity (distinct per
+///      container/host in an HA deployment).
+///   2. A persisted id file (`KIRRA_INSTANCE_ID_FILE`, else `kirra_instance_id`
+///      in the CWD): read if present, else generate once and best-effort persist.
+///   3. Last resort: `kirra-<now_ms>` with a LOUD warning (not stable — operators
+///      should set `KIRRA_INSTANCE_ID` / `HOSTNAME` in any real HA deployment).
+fn stable_fallback_instance_id() -> String {
+    if let Ok(mid) = std::fs::read_to_string("/etc/machine-id") {
+        let mid = mid.trim();
+        if !mid.is_empty() {
+            return format!("kirra-{mid}");
+        }
+    }
+
+    let path = std::env::var("KIRRA_INSTANCE_ID_FILE")
+        .unwrap_or_else(|_| "kirra_instance_id".to_string());
+    if let Ok(existing) = std::fs::read_to_string(&path) {
+        let existing = existing.trim();
+        if !existing.is_empty() {
+            return existing.to_string();
+        }
+    }
+    let generated = format!("kirra-{}", now_ms());
+    if let Err(e) = std::fs::write(&path, &generated) {
+        tracing::warn!(
+            error = %e, path = %path, instance_id = %generated,
+            "instance_id: could not persist generated fallback id — it will NOT be stable across \
+             restarts; set KIRRA_INSTANCE_ID or HOSTNAME for HA"
+        );
+    }
+    generated
 }
 
 // ---------------------------------------------------------------------------
@@ -130,7 +166,20 @@ pub fn instance_id() -> String {
 /// in PassiveStandby mode.
 pub fn spawn_heartbeat_writer(app: Arc<AppState>) {
     let id = instance_id();
-    tokio::spawn(async move {
+    // C2: supervised so a panic doesn't silently stop heartbeats (which would
+    // trigger a spurious standby promotion). NON-critical — a genuinely dead
+    // heartbeat is the DESIGNED failover signal, so no LockedOut escalation;
+    // run_forever=false because exiting on fence / promoted-over is legitimate.
+    crate::supervisor::spawn_supervised(
+        "ha_heartbeat_writer",
+        /* critical   */ false,
+        /* run-forever */ false,
+        None,
+        move || heartbeat_loop(Arc::clone(&app), id.clone()),
+    );
+}
+
+async fn heartbeat_loop(app: Arc<AppState>, id: String) {
         let interval_ms = std::env::var("KIRRA_HEARTBEAT_INTERVAL")
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
@@ -226,7 +275,6 @@ pub fn spawn_heartbeat_writer(app: Arc<AppState>) {
                 }
             }
         }
-    });
 }
 
 // ---------------------------------------------------------------------------
@@ -326,7 +374,19 @@ impl HeartbeatFreshness {
 /// of heartbeat state. Use for manual failover or testing.
 pub fn spawn_promotion_monitor(app: Arc<AppState>, cache: SharedPostureCache) {
     let id = instance_id();
-    tokio::spawn(async move {
+    // C2: supervised so a panic doesn't permanently disable failover. NON-critical
+    // (a standby cannot serve writes anyway, so a LockedOut escalation is moot);
+    // run_forever=false because exiting after a successful promotion is legitimate.
+    crate::supervisor::spawn_supervised(
+        "ha_promotion_monitor",
+        /* critical   */ false,
+        /* run-forever */ false,
+        None,
+        move || promotion_loop(Arc::clone(&app), cache.clone(), id.clone()),
+    );
+}
+
+async fn promotion_loop(app: Arc<AppState>, cache: SharedPostureCache, id: String) {
         let poll_ms = std::env::var("KIRRA_PROMOTION_POLL")
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
@@ -346,7 +406,12 @@ pub fn spawn_promotion_monitor(app: Arc<AppState>, cache: SharedPostureCache) {
                 instance_id = %id,
                 "KIRRA_FORCE_PROMOTE=1: bypassing heartbeat check, promoting immediately"
             );
-            perform_promotion(&app, &cache, &id, "FORCE_PROMOTE").await;
+            if perform_promotion(&app, &cache, &id, "FORCE_PROMOTE").await {
+                // HA Part B (review H3): a newly-Active node MUST start heartbeating
+                // so any tertiary standby sees it as alive — otherwise it is Active
+                // but invisible, inviting a spurious second promotion / epoch churn.
+                spawn_heartbeat_writer(Arc::clone(&app));
+            }
             return;
         }
 
@@ -418,7 +483,12 @@ pub fn spawn_promotion_monitor(app: Arc<AppState>, cache: SharedPostureCache) {
                     timeout_ms  = timeout_ms,
                     "Primary heartbeat token unchanged past timeout — promoting to Active"
                 );
-                perform_promotion(&app, &cache, &id, "HEARTBEAT_TIMEOUT").await;
+                if perform_promotion(&app, &cache, &id, "HEARTBEAT_TIMEOUT").await {
+                    // HA Part B (review H3): start heartbeating as the new Active so
+                    // a tertiary standby sees this node alive (no invisible-Active
+                    // window / spurious re-promotion).
+                    spawn_heartbeat_writer(Arc::clone(&app));
+                }
                 return;
             } else {
                 tracing::debug!(
@@ -428,7 +498,6 @@ pub fn spawn_promotion_monitor(app: Arc<AppState>, cache: SharedPostureCache) {
                 );
             }
         }
-    });
 }
 
 // ---------------------------------------------------------------------------
@@ -440,7 +509,7 @@ async fn perform_promotion(
     cache: &SharedPostureCache,
     id: &str,
     reason: &str,
-) {
+) -> bool {
     let ts = now_ms();
 
     // Step 1: DURABLE epoch claim (the real split-brain fence).
@@ -458,13 +527,13 @@ async fn perform_promotion(
             Err(e) => {
                 tracing::error!(error = %e, instance_id = %id,
                     "promotion: cannot read epoch — aborting");
-                return;
+                return false;
             }
         },
         Err(_) => {
             tracing::error!(instance_id = %id,
                 "promotion: store lock poisoned reading epoch — aborting");
-            return;
+            return false;
         }
     };
 
@@ -480,18 +549,18 @@ async fn perform_promotion(
                     reason      = %reason,
                     "promotion ABORTED — epoch already advanced by another instance (durable fence held)"
                 );
-                return;
+                return false;
             }
             Err(e) => {
                 tracing::error!(error = %e, instance_id = %id,
                     "promotion: epoch claim execute failed — aborting");
-                return;
+                return false;
             }
         },
         Err(_) => {
             tracing::error!(instance_id = %id,
                 "promotion: store lock poisoned during claim — aborting");
-            return;
+            return false;
         }
     };
 
@@ -518,7 +587,7 @@ async fn perform_promotion(
                     error = %e, instance_id = %id, epoch = new_epoch, reason = %reason,
                     "promotion ABORTED — cannot ensure hash-v2 audit anchor; staying PassiveStandby (fail-closed, mode_active stays false, no promotion record)"
                 );
-                return;
+                return false;
             }
         }
         Err(_) => {
@@ -526,7 +595,7 @@ async fn perform_promotion(
                 instance_id = %id, epoch = new_epoch, reason = %reason,
                 "promotion ABORTED — store lock poisoned ensuring hash-v2 audit anchor; staying PassiveStandby (fail-closed)"
             );
-            return;
+            return false;
         }
     }
 
@@ -633,6 +702,9 @@ async fn perform_promotion(
             "Promotion recalc did NOT yield a fresh posture — node FAIL-CLOSED (non-serving) until posture recovers; the mutation gate blocks commands on the stale cache"
         ),
     }
+
+    // Promotion succeeded (durable epoch claimed, audit anchored, mode flipped).
+    true
 }
 
 // ---------------------------------------------------------------------------

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -1,0 +1,234 @@
+// src/supervisor.rs
+//
+// Background-task supervisor (review finding C2).
+//
+// The verifier's safety loops run as detached tokio tasks: the telemetry
+// watchdog (SG-003 dead-man's switch), the HA heartbeat writer and promotion
+// monitor, and the posture-engine recalculation worker. Before this, each was
+// `tokio::spawn`-ed with its `JoinHandle` DROPPED — so a panic killed the task
+// SILENTLY with no restart. For the watchdog that is fail-OPEN: a silent sensor
+// would never be marked Untrusted, posture would never recalculate, and
+// actuators would stay live.
+//
+// `spawn_supervised` re-spawns a dead task with bounded backoff. If a CRITICAL
+// task crashes repeatedly within a rolling window (a deterministic panic, not a
+// transient blip), the supervisor runs the ESCALATION — which forces the whole
+// fleet to a fail-closed `FleetPosture::LockedOut` — and then keeps retrying at a
+// slower cadence. It NEVER silently gives up.
+//
+// Escalation policy (operator-selected): "Force LockedOut + keep retrying" — the
+// node stays observable (`/health` still answers, HA can still see it) while every
+// actuator gate fails closed. See `posture_engine::force_lockout` +
+// `AppState::supervisor_tripped` (the sticky flag the posture engine honors so the
+// forced LockedOut survives subsequent recalcs).
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+
+/// Restarts permitted within [`SUPERVISOR_RESTART_WINDOW`] before a CRITICAL task
+/// is declared wedged and the supervisor escalates the fleet to LockedOut.
+pub const SUPERVISOR_RESTART_BUDGET: u32 = 5;
+
+/// Rolling window over which the restart budget is counted. A task that runs
+/// cleanly for longer than this resets its budget (a fresh transient blip later
+/// is not held against an earlier, unrelated one).
+pub const SUPERVISOR_RESTART_WINDOW: Duration = Duration::from_secs(60);
+
+/// Backoff between ordinary restarts. The loops are cheap to respawn; this only
+/// prevents a hot busy-restart loop on an immediate panic.
+pub const SUPERVISOR_RESTART_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Retry cadence AFTER a critical task has tripped escalation. Slower, because the
+/// fleet is already failed closed; a transient resource exhaustion may still clear
+/// and let the task come back (though the LockedOut trip itself is sticky until a
+/// human/HA reset, matching LockedOut semantics).
+pub const SUPERVISOR_ESCALATED_RETRY: Duration = Duration::from_secs(5);
+
+/// The escalation invoked when a CRITICAL supervised task exhausts its restart
+/// budget. Constructed by the caller (it captures the `AppState` flag + posture
+/// cache); see [`crate::posture_engine::force_lockout`].
+pub type Escalation = Arc<dyn Fn() + Send + Sync>;
+
+/// Spawn `make_future` under supervision and return the supervisor's own handle.
+///
+/// `make_future` is called once per (re)start to build a FRESH task future from
+/// owned/cloned state, so loop-local state (intervals, in-memory maps) is rebuilt
+/// on each restart.
+///
+/// - On a **panic**, the task is always restarted (a panic is a bug, never a
+///   legitimate exit).
+/// - On a **normal return**, behavior depends on `restart_on_return`: tasks that
+///   must run forever (the watchdog) set it `true` (an unexpected return is a
+///   failure); tasks with a legitimate terminal state (the heartbeat writer
+///   exiting on fence, the promotion monitor exiting after it promotes) set it
+///   `false`, and the supervisor stops cleanly.
+/// - If `critical` and the restart budget is exhausted, `escalate` runs once and
+///   the supervisor keeps retrying at [`SUPERVISOR_ESCALATED_RETRY`].
+pub fn spawn_supervised<F, Fut>(
+    name: &'static str,
+    critical: bool,
+    restart_on_return: bool,
+    escalate: Option<Escalation>,
+    make_future: F,
+) -> JoinHandle<()>
+where
+    F: Fn() -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut window_start = Instant::now();
+        let mut restarts_in_window: u32 = 0;
+        let mut escalated = false;
+
+        loop {
+            let inner: JoinHandle<()> = tokio::spawn(make_future());
+            match inner.await {
+                Ok(()) if !restart_on_return => {
+                    tracing::info!(
+                        task = name,
+                        "supervised task returned normally (legitimate terminal state) — supervisor stopping"
+                    );
+                    return;
+                }
+                Ok(()) => {
+                    tracing::error!(
+                        task = name,
+                        "supervised task returned unexpectedly (must run forever) — restarting"
+                    );
+                }
+                Err(e) if e.is_panic() => {
+                    tracing::error!(task = name, "supervised task PANICKED — restarting");
+                }
+                Err(e) => {
+                    // Cancelled (only at runtime shutdown). Do not hot-loop.
+                    tracing::warn!(task = name, error = %e, "supervised task cancelled — supervisor stopping");
+                    return;
+                }
+            }
+
+            // Rolling-window restart accounting.
+            let now = Instant::now();
+            if now.duration_since(window_start) > SUPERVISOR_RESTART_WINDOW {
+                window_start = now;
+                restarts_in_window = 0;
+                // NOTE: we deliberately do NOT clear `escalated`. A forced fleet
+                // LockedOut is sticky (human/HA reset), matching LockedOut
+                // semantics — a task that later recovers must not silently
+                // un-lock the fleet.
+            }
+            restarts_in_window += 1;
+
+            if critical && restarts_in_window > SUPERVISOR_RESTART_BUDGET {
+                if !escalated {
+                    tracing::error!(
+                        task = name,
+                        restarts = restarts_in_window,
+                        window_s = SUPERVISOR_RESTART_WINDOW.as_secs(),
+                        "CRITICAL supervised task exceeded restart budget — escalating fleet to LockedOut (fail-closed) and retrying slowly"
+                    );
+                    if let Some(ref esc) = escalate {
+                        esc();
+                    }
+                    escalated = true;
+                }
+                tokio::time::sleep(SUPERVISOR_ESCALATED_RETRY).await;
+            } else {
+                tokio::time::sleep(SUPERVISOR_RESTART_BACKOFF).await;
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A panicking task is restarted; after the budget is exhausted the
+    /// escalation fires exactly once. We use a tiny accelerated config by
+    /// driving many quick panics inside the 60 s window.
+    #[tokio::test(start_paused = true)]
+    async fn panicking_critical_task_escalates_once_after_budget() {
+        let runs = Arc::new(AtomicU32::new(0));
+        let escalations = Arc::new(AtomicU32::new(0));
+
+        let runs_c = Arc::clone(&runs);
+        let esc_c = Arc::clone(&escalations);
+        let escalate: Escalation = Arc::new(move || {
+            esc_c.fetch_add(1, Ordering::SeqCst);
+        });
+
+        let _sup = spawn_supervised(
+            "test-critical",
+            true,
+            true,
+            Some(escalate),
+            move || {
+                let runs_inner = Arc::clone(&runs_c);
+                async move {
+                    runs_inner.fetch_add(1, Ordering::SeqCst);
+                    panic!("deterministic test panic");
+                }
+            },
+        );
+
+        // Advance virtual time through enough backoff cycles to blow the budget.
+        // Budget is 5 within 60s; each ordinary restart waits 500ms, then the
+        // escalated cadence is 5s. Advance generously but stay inside the window.
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(600)).await;
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            runs.load(Ordering::SeqCst) > SUPERVISOR_RESTART_BUDGET,
+            "task should have been restarted past the budget"
+        );
+        assert_eq!(
+            escalations.load(Ordering::SeqCst),
+            1,
+            "escalation must fire exactly once, not on every subsequent failure"
+        );
+    }
+
+    /// A task that returns normally with `restart_on_return = false` stops the
+    /// supervisor (legitimate terminal state — e.g. the promotion monitor after
+    /// it promotes) and never escalates.
+    #[tokio::test(start_paused = true)]
+    async fn normal_return_without_restart_stops_supervisor() {
+        let runs = Arc::new(AtomicU32::new(0));
+        let escalations = Arc::new(AtomicU32::new(0));
+
+        let runs_c = Arc::clone(&runs);
+        let esc_c = Arc::clone(&escalations);
+        let escalate: Escalation = Arc::new(move || {
+            esc_c.fetch_add(1, Ordering::SeqCst);
+        });
+
+        let _sup = spawn_supervised(
+            "test-completes",
+            true,
+            false,
+            Some(escalate),
+            move || {
+                let runs_inner = Arc::clone(&runs_c);
+                async move {
+                    runs_inner.fetch_add(1, Ordering::SeqCst);
+                    // returns normally
+                }
+            },
+        );
+
+        for _ in 0..5 {
+            tokio::time::sleep(Duration::from_millis(600)).await;
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(runs.load(Ordering::SeqCst), 1, "task must run once and not be restarted");
+        assert_eq!(escalations.load(Ordering::SeqCst), 0, "no escalation on a legitimate exit");
+    }
+}

--- a/src/telemetry_watchdog.rs
+++ b/src/telemetry_watchdog.rs
@@ -140,21 +140,49 @@ pub fn spawn_telemetry_watchdog_with_clock(
     posture_engine_tx: PostureEngineSender,
     clock: Arc<dyn Clock>,
 ) {
-    tokio::spawn(async move {
-        let mut sweep_interval = interval(Duration::from_millis(AV_WATCHDOG_SWEEP_MS));
-        let mut last_node_refresh_ms: u64 = 0;
-        let mut node_health: HashMap<String, WatchdogNodeEntry> = HashMap::new();
-        loop {
-            sweep_interval.tick().await;
-            watchdog_sweep_once(
-                &app,
-                &posture_engine_tx,
-                clock.as_ref(),
-                &mut node_health,
-                &mut last_node_refresh_ms,
-            );
-        }
-    });
+    // C2: a wedged watchdog is fail-OPEN (a silent sensor would never be marked
+    // Untrusted), so it is supervised as CRITICAL. On repeated panic the
+    // escalation sets the sticky `supervisor_tripped` flag and nudges the
+    // (surviving) posture engine to recompute — which then reads the flag and
+    // forces LockedOut. The watchdog holds no cache handle, so it escalates via
+    // the engine; if the engine ITSELF is the dead task, its own supervisor
+    // force-writes the cache directly.
+    let escalate: crate::supervisor::Escalation = {
+        let app = Arc::clone(&app);
+        let tx = posture_engine_tx.clone();
+        Arc::new(move || {
+            app.supervisor_tripped
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            let _ = tx.try_send(PostureRecalcTrigger::PeriodicRefresh);
+        })
+    };
+
+    crate::supervisor::spawn_supervised(
+        "telemetry_watchdog",
+        /* critical   */ true,
+        /* run-forever */ true,
+        Some(escalate),
+        move || {
+            let app = Arc::clone(&app);
+            let posture_engine_tx = posture_engine_tx.clone();
+            let clock = Arc::clone(&clock);
+            async move {
+                let mut sweep_interval = interval(Duration::from_millis(AV_WATCHDOG_SWEEP_MS));
+                let mut last_node_refresh_ms: u64 = 0;
+                let mut node_health: HashMap<String, WatchdogNodeEntry> = HashMap::new();
+                loop {
+                    sweep_interval.tick().await;
+                    watchdog_sweep_once(
+                        &app,
+                        &posture_engine_tx,
+                        clock.as_ref(),
+                        &mut node_health,
+                        &mut last_node_refresh_ms,
+                    );
+                }
+            }
+        },
+    );
 }
 
 /// One sweep cycle of the watchdog: refresh the node list (rate-limited

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -246,6 +246,17 @@ pub struct AppState {
     /// sustained #98 WATER_UNTRAVERSABLE vetoes) is a deferred cross-subsystem
     /// follow-up; this flag is read-only in the current code (defaults false).
     pub flood_condition_active: Arc<AtomicBool>,
+    /// C2 supervisor trip flag (review finding C2). Set by `supervisor::spawn_supervised`
+    /// when a CRITICAL background safety loop (the telemetry watchdog, the posture
+    /// engine worker, the HA heartbeat writer / promotion monitor) crashes past its
+    /// restart budget. The posture engine reads it and forces `FleetPosture::LockedOut`
+    /// unconditionally (highest priority, overriding the DAG), so a wedged safety loop
+    /// fails the whole fleet closed instead of silently leaving actuators live. Sticky:
+    /// once tripped it stays tripped until process restart (a recovered loop within the
+    /// restart window clears the supervisor's local counter but NOT this flag — recovery
+    /// from a forced fleet lockout is an explicit human/HA action, matching LockedOut's
+    /// human-reset semantics). Defaults false.
+    pub supervisor_tripped: Arc<AtomicBool>,
     /// Recovery streak for clearing an active RSS violation.
     pub rss_recovery_streak: Arc<Mutex<RssRecoveryStreak>>,
     /// #104 — the currently-open post-incident forensic sequence (correlation id
@@ -285,6 +296,7 @@ impl AppState {
             transport_identity: TransportIdentityConfig::from_env(),
             rss_active_violation: Arc::new(AtomicBool::new(false)),
             flood_condition_active: Arc::new(AtomicBool::new(false)),
+            supervisor_tripped: Arc::new(AtomicBool::new(false)),
             rss_recovery_streak: Arc::new(Mutex::new(RssRecoveryStreak { count: 0, start_ms: 0 })),
             current_incident: Arc::new(Mutex::new(None)),
             post_incident_write_failures: Arc::new(AtomicU64::new(0)),


### PR DESCRIPTION
## Review findings C2 (CRITICAL) + H3 (HIGH) — supervise the background safety loops; harden HA promotion

### C2 — background safety loops were unsupervised
The telemetry watchdog, HA heartbeat writer, HA promotion monitor, and the posture-engine recalculation worker were each `tokio::spawn`-ed with their `JoinHandle` discarded. A panic killed the task **silently with no restart** — for the watchdog that's fail-OPEN (the C1 fix stopped one panic source; this fixes the structural gap for *any* panic).

**New `src/supervisor.rs`:** `spawn_supervised(name, critical, run_forever, escalate, make_future)`
- Re-spawns a dead task with bounded backoff, distinguishing a **panic** (always a failure → restart) from a **legitimate normal return** (`run_forever=false` for the heartbeat writer / promotion monitor, which exit on fence / after promoting).
- **Escalation policy (you chose "Force LockedOut + keep retrying"):** if a CRITICAL task exhausts its restart budget (5 within 60 s — a deterministic panic, not a blip), the supervisor forces the fleet to fail-closed `LockedOut` and keeps retrying at a slow cadence. It never silently gives up, and the node stays observable (`/health`, HA visibility).
- **Sticky mechanism:** new `AppState::supervisor_tripped` flag, honored by `posture_engine::recalculate_and_broadcast` with **absolute priority** (forces LockedOut over the DAG / rss / flood), so the forced lockout survives every later recalc until a human/HA reset — matching LockedOut semantics. `posture_engine::force_lockout` applies it to the cache instantly (used when the dead task *is* the engine worker).
- **Criticality split:** watchdog + posture-worker = critical (escalate); heartbeat writer + promotion monitor = non-critical (a dead heartbeat is the *designed* failover signal; a standby can't serve anyway) → supervised for restart only.
- The worker's non-`Clone` mpsc `Receiver` now lives behind `Arc<Mutex<…>>` so a re-spawned worker can re-acquire it.

### H3 + L2 — HA promotion hardening
- `perform_promotion` now returns `bool`; on success the newly-Active node **spawns its heartbeat writer**. Previously a promoted standby was Active but never heartbeat — Active-but-invisible, inviting a spurious second promotion / epoch churn.
- `instance_id()` fallback is now **stable across restarts** (`/etc/machine-id`, then a persisted id file) instead of `kirra-<now_ms>`, so a node that crashed mid-promotion reliably reclaims its own durable epoch on reboot (the reclaim path keys on a stable id).

### Tests
Supervisor: restart-past-budget-then-escalate-once; legitimate-exit stops cleanly. Posture engine: `supervisor_tripped` forces **and sticks** LockedOut over a healthy DAG; `force_lockout` bumps the generation. Full workspace suite green; `clippy --all-targets -D warnings` clean.

> Note: the wall-clock WCET test is unaffected — it only flakes under concurrent CPU load locally and passes in its dedicated CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWXgETCGcdP6XXErwLHkFk)_