### PR TITLE
chore: build-hygiene — close the tokio leak, repoint taj/planner to kirra-core, add capture CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
         run: cargo test --workspace --locked
       - name: Fault injection tests (ISO 26262 safe-state verification — CERT-004)
         run: cargo test --test fault_injection --locked
+      - name: kirra-core capture-feature tests (review M2 — feature-gated module)
+        # The off-by-default `capture` module is only reached via feature
+        # unification in the workspace run; test it on its own terms so it can
+        # never silently rot if the unification path changes.
+        run: cargo test -p kirra-core --features capture --locked
 
   coverage:
     name: Branch Coverage (MC/DC pending — issue #65)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,6 +2049,7 @@ dependencies = [
 name = "kirra-taj"
 version = "0.1.0"
 dependencies = [
+ "kirra-core",
  "kirra-ros2-adapter",
  "kirra-verifier",
 ]

--- a/crates/kirra-fleet-transport/Cargo.toml
+++ b/crates/kirra-fleet-transport/Cargo.toml
@@ -40,8 +40,9 @@ serde = { version = "1", features = ["derive"] }
 # trust and buys cross-tooling debuggability.
 serde_json = "1"
 # The grant envelope reuses the federation Ed25519 pattern (sign a canonical
-# payload; verify against the controller's registered public key).
-ed25519-dalek = { version = "2", features = ["rand_core"] }
+# payload; verify against the controller's registered public key). No `rand_core`
+# feature — keys are built via `SigningKey::from_bytes`, never `generate` (review L4).
+ed25519-dalek = { version = "2" }
 base64 = "0.22"
 # Per-grant nonce minting on the signing side (#322 replay defense): 16 random
 # bytes → hex, burned exactly once at ingest (verify-AND-consume).

--- a/crates/kirra-planner/Cargo.toml
+++ b/crates/kirra-planner/Cargo.toml
@@ -25,13 +25,12 @@ license-file = "../../COPYRIGHT"
 publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [dependencies]
-# The #131 checker entry + the checked trajectory/corridor/config/ego types.
-# default-features = false → no ROS (adapter `default = []`; `ros2` is opt-in).
-kirra-ros2-adapter = { path = "../kirra-ros2-adapter", default-features = false }
-# FleetPosture + the SG2 containment cap (MAX_TRAJECTORY_HORIZON) for the posture →
-# planner-mode mapping and the trajectory-length bound — now from the lean `kirra-core`
-# crate (de-monolith Stage 4), so the planner no longer pulls the verifier service's
-# heavy tree directly (the adapter dep remains until the adapter is de-monolithed).
+# Build hygiene (review M3): the planner's library needs only the lean contract
+# types — the corridor seam + trajectory/perception types (kirra-core, Stage 6a) and
+# FleetPosture + the SG2 containment cap (kirra-core, Stage 4). The heavy
+# `kirra-ros2-adapter` is now a DEV-dependency only: its `validate_trajectory_slow`
+# checker entry is exercised solely by the tests. So the planner no longer pulls the
+# adapter (and its ros2/tokio tree) into its normal build at all.
 kirra-core = { path = "../kirra-core" }
 # The shared lane-map crate (de-monolith Stage 6b): LaneGraph / routing / right-of-way,
 # the lane-line crossing rules, and the Lanelet2 `.osm` parser. The planner re-exports

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -33,12 +33,16 @@
 // Import (never redefine) the locked upstream types. Re-exported so a Phase-1
 // consumer names them from one place — but they remain the adapter's / SDK's
 // definitions.
-pub use kirra_ros2_adapter::state::{PerceivedObject, Pose, TrajectoryPoint, TrajectoryVerdict};
+pub use kirra_core::trajectory::{PerceivedObject, Pose, TrajectoryPoint, TrajectoryVerdict};
 // FleetPosture + the containment cap now live in the lean `kirra-core` crate
 // (de-monolith Stage 4) — same types, no heavy verifier-service tree pulled directly.
 pub use kirra_core::FleetPosture;
 
-use kirra_ros2_adapter::corridor::{CorridorSource, Point};
+// Build hygiene (review M3): import the corridor seam from the lean `kirra-core`
+// (Stage 6a) rather than the heavy adapter, so the planner's library no longer
+// pulls `kirra-ros2-adapter` (and its ros2/tokio tree). The adapter stays a
+// dev-dependency — its `validate_trajectory_slow` checker entry is used only by tests.
+use kirra_core::corridor::{CorridorSource, Point};
 // Derive (never guess) the checker's hard trajectory-length cap: the #131
 // containment gate rejects `len > MAX_TRAJECTORY_HORIZON`, so a proposal must
 // stay within it (including the terminal stop point) to be admissible.

--- a/crates/kirra-ros2-adapter/Cargo.toml
+++ b/crates/kirra-ros2-adapter/Cargo.toml
@@ -51,7 +51,7 @@ default = []
 # This feature pulls NO C++ / no cxx / no lanelet2 — that is the separate
 # `lanelet2` feature below (the perception governance path is independent of
 # the map/corridor layer). See README.
-ros2 = ["dep:r2r", "dep:tracing-subscriber", "dep:futures", "dep:reqwest", "dep:serde_json", "dep:bytes", "kirra-core/capture"]
+ros2 = ["dep:tokio", "dep:r2r", "dep:tracing-subscriber", "dep:futures", "dep:reqwest", "dep:serde_json", "dep:bytes", "kirra-core/capture"]
 
 # Enable the real Lanelet2CorridorSource — a cxx/C++ wrap of `lanelet2_core`'s
 # boost::serialization deserializer (`fromBinMsg`). Implies `ros2` (the only
@@ -66,7 +66,14 @@ lanelet2 = ["ros2", "dep:cxx", "dep:cxx-build"]
 [dependencies]
 # Concurrency primitives shared with the safety kernel.
 dashmap = "6"
-tokio = { version = "1", features = ["full"] }
+# Build hygiene (review H4): tokio is OPTIONAL and gated on `ros2`. Every tokio use
+# site is in a ros2-gated module (`node.rs`, `posture_source.rs`) or the
+# `required-features = ["ros2"]` binary — the default (non-ros2) library uses none.
+# Before this, the non-optional `tokio = "full"` rode into `kirra-planner` /
+# `kirra-taj` via their adapter dep, defeating the de-monolith. (Kept at `full`
+# rather than a trimmed subset to avoid risking the ros2 build, which can only be
+# compiled with a sourced ROS distro in CI; under `ros2` the heavy tree is expected.)
+tokio = { version = "1", features = ["full"], optional = true }
 tracing = "0.1"
 
 # Lean foundation — the corridor seam (`Point`/`CorridorSource`/`MockCorridorSource`)
@@ -126,8 +133,9 @@ bytes      = { version = "1",    optional = true }
 cxx-build = { version = "1.0", optional = true }
 
 [dev-dependencies]
-# State-machine tests don't need the ros2 feature.
-tokio = { version = "1", features = ["full", "test-util"] }
+# State-machine tests don't need the ros2 feature. (`test-util` dropped — review L5:
+# no test uses start_paused / tokio::time::advance / #[tokio::test].)
+tokio = { version = "1", features = ["full"] }
 
 # Phase 4: the adapter node binary. Feature-gated to `ros2`; the default
 # cargo build does not see this entry. `tracing-subscriber` is only

--- a/crates/kirra-taj/Cargo.toml
+++ b/crates/kirra-taj/Cargo.toml
@@ -23,11 +23,15 @@ license-file = "../../COPYRIGHT"
 publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
 [dependencies]
-# The perception-input contract types Taj produces: CorridorSource + Point and
-# PerceivedObject. default-features = false → no ROS (adapter `default = []`).
-kirra-ros2-adapter = { path = "../kirra-ros2-adapter", default-features = false }
+# The perception-input contract types Taj produces — CorridorSource + Point and
+# PerceivedObject — live in the lean `kirra-core` (de-monolith Stage 6a). Depending
+# on it directly (instead of the heavy `kirra-ros2-adapter`) keeps taj's library off
+# the adapter's ros2/tokio tree (review M3).
+kirra-core = { path = "../kirra-core" }
 
 [dev-dependencies]
-# Integration test only: prove Taj's corridor output feeds the real #131 checker.
-# FleetPosture lives in the SDK; the checker entry + config in the adapter.
+# Integration tests only: prove Taj's corridor output feeds the real #131 checker.
+# FleetPosture lives in the verifier crate; the checker entry (`validate_trajectory_slow`)
+# + `VehicleConfig` in the adapter — both used solely by the tests, hence dev-deps.
 kirra-verifier = { path = "../.." }
+kirra-ros2-adapter = { path = "../kirra-ros2-adapter", default-features = false }

--- a/crates/kirra-taj/src/lib.rs
+++ b/crates/kirra-taj/src/lib.rs
@@ -29,8 +29,13 @@
 //! Parko ML detector, semantic objects, temporal velocity) is later work; the
 //! safety plumbing proven here is reused unchanged.
 
-use kirra_ros2_adapter::corridor::{CorridorSource, Point};
-use kirra_ros2_adapter::state::PerceivedObject;
+// Build hygiene (review M3): the perception-input contract types live in the lean
+// `kirra-core` (Stage 6a relocation); import them directly instead of through the
+// heavy `kirra-ros2-adapter`, so taj's library no longer pulls the adapter (and its
+// ros2/tokio tree). The adapter is now a dev-dependency only (its `validate_trajectory_slow`
+// + `VehicleConfig` are used solely by the integration tests).
+use kirra_core::corridor::{CorridorSource, Point};
+use kirra_core::trajectory::PerceivedObject;
 
 /// Minimal range-scan input — a `sensor_msgs/LaserScan` subset.
 ///


### PR DESCRIPTION
## Build-hygiene batch — finishes the de-monolith (review H4 + M3/M2/L4/L5)

Cleanups only; no logic changes.

### H4 — close the tokio leak
The adapter's `tokio` (`features = "full"`) was a **non-optional** dependency, yet every tokio use site is ros2-gated (`node.rs`, `posture_source.rs`, the `required-features = ["ros2"]` binary). It rode into `kirra-planner` and `kirra-taj` through their adapter dep — defeating the de-monolith. `tokio` is now `optional` and gated on the `ros2` feature (kept at `full` only when ros2 is on, to avoid risking the ROS-only build that can't be compiled outside CI).

### M3 — repoint taj/planner to kirra-core, adapter → dev-dep
`kirra-taj` and `kirra-planner` depended on the heavy adapter for **types** that now live in lean `kirra-core` (the corridor seam + trajectory/perception types, Stage 6a). Their library imports are repointed to `kirra_core::{corridor, trajectory}`, and the adapter drops to a **dev-dependency** (its `validate_trajectory_slow` + `VehicleConfig` are used only by tests).

**Result (verified via `cargo tree`):** planner and taj now pull **zero tokio and zero adapter** in their normal builds. The lone remaining adapter-default tokio node is transitive through `parko-core` and no longer reaches planner/taj. The adapter's own tokio appears only under `ros2` (10 nodes) and is absent from its default build.

### M2 — dedicated capture CI lane
Added `cargo test -p kirra-core --features capture` so the off-by-default capture module is tested on its own terms, not only via workspace feature unification.

### L4 / L5 — drop unused features
- `kirra-fleet-transport`: dropped the unused `rand_core` feature on `ed25519-dalek` (keys built via `from_bytes`, never `generate`).
- adapter: dropped the unused `test-util` feature from its dev `tokio`.

### Verification
`cargo build --workspace` clean; `cargo test --workspace` **1404 passed / 0 failed**; `cargo test -p kirra-core --features capture` green; `clippy --all-targets -D warnings` clean.

---

This is the **last item** from the repository review — every CRITICAL/HIGH/MEDIUM finding is now resolved (C1 #506, C2+HA #508, safe batch #509, and this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWXgETCGcdP6XXErwLHkFk)_