### PR TITLE
feat(mick): speed control — target_speed_mps knob + Cruise intent

### DIFF
--- a/crates/kirra-planner/examples/doer_bound_fixture.rs
+++ b/crates/kirra-planner/examples/doer_bound_fixture.rs
@@ -57,6 +57,7 @@ fn world<'a>(map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> Pla
         controls: &[], lane_boundaries: &[], motion: &[], predicted_paths: &[],
         cedes_to_ego_ids: &[], lane_change_to_m: None, no_overtake_ids: &[], drivable: None,
         posture: FleetPosture::Nominal,
+        target_speed_mps: None,
     }
 }
 

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -208,6 +208,14 @@ pub struct PlanInput<'a> {
     pub drivable: Option<&'a dyn CorridorSource>,
     /// Fleet posture → planner mode (see [`planner_mode`]).
     pub posture: FleetPosture,
+    /// **Requested cruise speed** (m/s), if any — Mick's "ease off here" / "you can go up
+    /// to the limit" knob. A `Some` value can only LOWER the posture-derived cruise
+    /// ceiling (`min(ceiling, request)`): the caller can slow the chauffeur but can NEVER
+    /// raise it above the configured envelope, and KIRRA still caps independently. A
+    /// non-finite or negative request is ignored (fail-safe → the ceiling stands). In
+    /// `Degraded` it only lowers an already non-increasing target, preserving the
+    /// decel-only invariant. `None` = use the posture ceiling (byte-for-byte prior behavior).
+    pub target_speed_mps: Option<f64>,
 }
 
 /// Intent label on a proposal.
@@ -926,6 +934,15 @@ impl Planner for GeometricPlanner {
             PlannerMode::MrcOnly => unreachable!("handled above"),
         };
 
+        // A requested cruise speed (Mick's chauffeur knob) may only SLOW the planner —
+        // `min(ceiling, request)` — never raise it above the posture-derived ceiling. A
+        // non-finite / negative request is ignored (fail-safe). In Degraded this only
+        // lowers an already non-increasing target, so the decel-only invariant holds.
+        let target = match input.target_speed_mps {
+            Some(req) if req.is_finite() && req >= 0.0 => target.min(req),
+            _ => target,
+        };
+
         // Guide path: corridor centerline if usable, else a straight ego→goal line.
         let center = centerline_from(input.map.left_boundary(), input.map.right_boundary());
         let raw_guide: Vec<(f64, f64)> = if center.len() >= 2 {
@@ -1485,6 +1502,7 @@ mod tests {
             no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
+            target_speed_mps: None,
         }
     }
 
@@ -1558,6 +1576,7 @@ mod tests {
             no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
+            target_speed_mps: None,
         }
     }
 
@@ -1703,6 +1722,7 @@ mod tests {
             no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
+            target_speed_mps: None,
         }
     }
 
@@ -2072,6 +2092,7 @@ mod tests {
             no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
+            target_speed_mps: None,
         }
     }
 
@@ -2319,6 +2340,7 @@ mod tests {
             no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
+            target_speed_mps: None,
         }
     }
 
@@ -2429,6 +2451,7 @@ mod tests {
             no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
+            target_speed_mps: None,
         }
     }
 
@@ -2826,6 +2849,7 @@ mod tests {
             no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
+            target_speed_mps: None,
         }
     }
 

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -33,6 +33,11 @@ pub enum MickIntent {
     LaneChange { target_offset_m: f64 },
     /// Stop and hold.
     Hold,
+    /// Cruise at a requested speed (m/s), keeping the current goal / lane. The request can
+    /// only SLOW the chauffeur: Occy clamps it to `min(posture_ceiling, request)` and KIRRA
+    /// caps it again, so "go faster" never exceeds the safe envelope. A non-finite request
+    /// fails closed (the caller HOLDs).
+    Cruise { target_speed_mps: f64 },
 }
 
 /// LLM JSON wire schema (tagged on `"intent"`). Kept separate from [`MickIntent`]
@@ -46,6 +51,8 @@ enum IntentJson {
     LaneChange { target_offset_m: f64 },
     #[serde(rename = "hold")]
     Hold,
+    #[serde(rename = "cruise")]
+    Cruise { target_speed_mps: f64 },
 }
 
 impl MickIntent {
@@ -68,6 +75,7 @@ impl MickIntent {
             IntentJson::GoTo { x_m, y_m } => MickIntent::GoTo { x_m, y_m },
             IntentJson::LaneChange { target_offset_m } => MickIntent::LaneChange { target_offset_m },
             IntentJson::Hold => MickIntent::Hold,
+            IntentJson::Cruise { target_speed_mps } => MickIntent::Cruise { target_speed_mps },
         };
         if !intent.is_finite() {
             return Err("MICK_NONFINITE_INTENT");
@@ -80,6 +88,7 @@ impl MickIntent {
             MickIntent::GoTo { x_m, y_m } => x_m.is_finite() && y_m.is_finite(),
             MickIntent::LaneChange { target_offset_m } => target_offset_m.is_finite(),
             MickIntent::Hold => true,
+            MickIntent::Cruise { target_speed_mps } => target_speed_mps.is_finite(),
         }
     }
 }
@@ -155,6 +164,17 @@ pub fn plan_for_intent(
                 return PlanOutput::safe_stop(world.ego.pose);
             }
             planner.plan(&PlanInput { lane_change_to_m: Some(target_offset_m), ..world.clone() })
+        }
+        MickIntent::Cruise { target_speed_mps } => {
+            if !target_speed_mps.is_finite() {
+                return PlanOutput::safe_stop(world.ego.pose);
+            }
+            // A negative "cruise" is a hold, not reverse → cap at 0. The planner then
+            // clamps to the posture ceiling and KIRRA caps again, so this only ever slows.
+            planner.plan(&PlanInput {
+                target_speed_mps: Some(target_speed_mps.max(0.0)),
+                ..world.clone()
+            })
         }
     }
 }
@@ -367,6 +387,7 @@ mod tests {
             no_overtake_ids: &[],
             drivable: None,
             posture: FleetPosture::Nominal,
+            target_speed_mps: None,
         }
     }
 
@@ -583,5 +604,63 @@ mod tests {
         let out = mick_drive_once(&mut ErrBrain, &w, &mut p);
         assert_eq!(out.kind, ProposalKind::SafeStop, "a brain failure must HOLD, not drive");
         assert!(out.trajectory.iter().all(|t| t.velocity_mps == 0.0));
+    }
+
+    // ----- speed control: the Cruise intent / target_speed_mps knob -----
+
+    /// A world with a far goal so the planner actually cruises (uncapped it heads toward
+    /// the default 8 m/s).
+    fn cruising_world(corr: &dyn CorridorSource) -> PlanInput<'_> {
+        PlanInput {
+            goal: Goal { target: Pose { x_m: 40.0, y_m: 0.0, heading_rad: 0.0 } },
+            ..world(corr, &[], &[])
+        }
+    }
+
+    fn vmax(out: &PlanOutput) -> f64 {
+        out.trajectory.iter().map(|t| t.velocity_mps).fold(0.0, f64::max)
+    }
+
+    #[test]
+    fn cruise_intent_slows_the_chauffeur_below_the_default() {
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let w = cruising_world(&corr);
+        let mut p = GeometricPlanner::default(); // cruise ceiling 8 m/s
+
+        let fast = plan_for_intent(&mut p, &MickIntent::GoTo { x_m: 40.0, y_m: 0.0 }, &w);
+        let slow = plan_for_intent(&mut p, &MickIntent::Cruise { target_speed_mps: 3.0 }, &w);
+
+        assert!(vmax(&slow) <= 3.0 + 1e-6, "Cruise(3) caps speed at 3, got {}", vmax(&slow));
+        assert!(vmax(&fast) > vmax(&slow), "and it is slower than the uncapped GoTo ({} vs {})", vmax(&fast), vmax(&slow));
+    }
+
+    #[test]
+    fn cruise_request_above_the_ceiling_cannot_speed_up() {
+        // The chauffeur asking to "go 50 m/s" can NEVER exceed the configured envelope —
+        // the request is clamped to the posture ceiling (8), and KIRRA caps again.
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let w = cruising_world(&corr);
+        let mut p = GeometricPlanner::default();
+        let over = plan_for_intent(&mut p, &MickIntent::Cruise { target_speed_mps: 50.0 }, &w);
+        assert!(vmax(&over) <= 8.0 + 1e-6, "a request above the ceiling clamps to the cruise config (8), got {}", vmax(&over));
+    }
+
+    #[test]
+    fn nonfinite_cruise_intent_fails_closed() {
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let w = cruising_world(&corr);
+        let mut p = GeometricPlanner::default();
+        let out = plan_for_intent(&mut p, &MickIntent::Cruise { target_speed_mps: f64::NAN }, &w);
+        assert_eq!(out.kind, ProposalKind::SafeStop, "a NaN cruise speed must HOLD, not flow into the planner");
+    }
+
+    #[test]
+    fn cruise_llm_json_parses_and_rejects_nonfinite() {
+        assert_eq!(
+            MickIntent::from_llm_json(r#"{"intent":"cruise","target_speed_mps":5.0}"#).unwrap(),
+            MickIntent::Cruise { target_speed_mps: 5.0 }
+        );
+        // 1e400 overflows to Inf → finiteness gate rejects it (fail-closed).
+        assert!(MickIntent::from_llm_json(r#"{"intent":"cruise","target_speed_mps":1e400}"#).is_err());
     }
 }

--- a/crates/kirra-planner/tests/adversarial_doer_bounded_by_kirra.rs
+++ b/crates/kirra-planner/tests/adversarial_doer_bounded_by_kirra.rs
@@ -97,6 +97,7 @@ fn world<'a>(map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> Pla
         no_overtake_ids: &[],
         drivable: None,
         posture: FleetPosture::Nominal,
+        target_speed_mps: None,
     }
 }
 

--- a/crates/kirra-planner/tests/lane_graph_to_occy.rs
+++ b/crates/kirra-planner/tests/lane_graph_to_occy.rs
@@ -79,6 +79,7 @@ fn lane_change_across_broken_divider_admits() {
         no_overtake_ids: &[],
         drivable: None,
         posture: FleetPosture::Nominal,
+        target_speed_mps: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
@@ -127,6 +128,7 @@ fn lane_change_across_solid_divider_is_refused() {
         no_overtake_ids: &[],
         drivable: None,
         posture: FleetPosture::Nominal,
+        target_speed_mps: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);

--- a/crates/kirra-planner/tests/learned_doer_bounded_by_kirra.rs
+++ b/crates/kirra-planner/tests/learned_doer_bounded_by_kirra.rs
@@ -44,6 +44,7 @@ fn world<'a>(map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> Pla
         no_overtake_ids: &[],
         drivable: None,
         posture: FleetPosture::Nominal,
+        target_speed_mps: None,
     }
 }
 

--- a/crates/kirra-planner/tests/overtake_oncoming.rs
+++ b/crates/kirra-planner/tests/overtake_oncoming.rs
@@ -95,6 +95,7 @@ fn plan_and_check(
         no_overtake_ids: &[],
         drivable: with_drivable.then_some(drivable),
         posture: FleetPosture::Nominal,
+        target_speed_mps: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
@@ -261,6 +262,7 @@ fn a_stopped_school_bus_is_never_overtaken_and_the_ego_holds_behind_it() {
         no_overtake_ids: &[1], // the bus
         drivable: Some(&drivable),
         posture: FleetPosture::Nominal,
+        target_speed_mps: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);

--- a/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
+++ b/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
@@ -99,6 +99,7 @@ fn run_stack(
         no_overtake_ids: &[],
         drivable: None,
         posture: posture.clone(),
+        target_speed_mps: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
@@ -194,6 +195,7 @@ fn route_around_in_corridor_object_admits() {
         no_overtake_ids: &[],
         drivable: None,
         posture: FleetPosture::Nominal,
+        target_speed_mps: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);

--- a/crates/kirra-planner/tests/unmarked_road_keep_right.rs
+++ b/crates/kirra-planner/tests/unmarked_road_keep_right.rs
@@ -42,6 +42,7 @@ fn drive(map: &dyn CorridorSource) -> (f64, TrajectoryVerdict) {
         no_overtake_ids: &[],
         drivable: None,
         posture: FleetPosture::Nominal,
+        target_speed_mps: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);


### PR DESCRIPTION
## Mick step 1 — speed control (vocabulary growth #1)

Gives the chauffeur its most-used knob — *"ease off on this stretch"*, *"you can go up to the limit here"* — built so the knob can **only ever make it slower**, never faster than allowed.

### The safety design (the point of this PR)
- **`PlanInput.target_speed_mps: Option<f64>`** — a requested cruise speed. In `plan()`, after the posture-derived cruise ceiling is chosen, a `Some(req)` is applied as **`min(ceiling, req)`**: it can only *lower* the target, never raise it above the configured envelope, and KIRRA still caps independently. Non-finite / negative → ignored (fail-safe). In `Degraded` it only lowers an already non-increasing target, so the **decel-only invariant holds**. `None` = byte-for-byte prior behavior.
- **`MickIntent::Cruise { target_speed_mps }`** (+ `"cruise"` JSON tag + finiteness gate) — grounds by setting the knob on the re-borrowed world (a negative "cruise" is a hold, not reverse). A non-finite request **fails closed** to a safe stop.

So the brain can ask to slow down, or ask to "go faster" — and "faster" simply saturates at the safe ceiling. The knob is incapable of producing an unsafe speed.

### Tests (4 new; 76 planner-lib + integration green)
- `Cruise(3)` caps speed at 3 and is slower than the uncapped `GoTo`
- **`Cruise(50)` clamps to the 8 m/s config ceiling — never speeds up** (the load-bearing invariant)
- a `NaN` cruise fails closed to `SafeStop`
- the `"cruise"` JSON parses; a `1e400`→Inf request is rejected

### Mechanics
All full `PlanInput` literals across planner src/tests/example gained `target_speed_mps: None` (struct-update sites inherit it). `PlanInput` is planner-internal, so **no other crate is touched**.

### Verification
kirra-planner lib **76** + all integration suites green; clippy clean under `-D warnings --all-targets`.

### Next
- **ScenarioRunner closed-loop demo** (Mick drives a scene; a bad intent provably caught).
- Then **plug in Gemma** behind the `MickBrain` trait + design the structured-output prompt (the typed `GoTo`/`LaneChange`/`Hold`/`Cruise` vocab is exactly what small models do reliably).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_