### PR TITLE
feat(mick): model-agnostic LLM brain (prompt + parse) behind a ModelClient port

### DIFF
--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -65,6 +65,12 @@ pub use mick::{
     WorldContext, MICK_MAX_OBJECTS,
 };
 
+/// Mick's model-agnostic LLM brain (prompt render + reply parse behind the `MickBrain`
+/// seam). Pure + testable with a `MockModel`; a concrete `ModelClient` (local Gemma via
+/// Ollama, etc.) plugs in behind a feature/crate.
+pub mod mick_llm;
+pub use mick_llm::{build_prompt, LlmBrain, MockModel, ModelClient, ModelError};
+
 pub mod learned;
 pub use learned::{LearnedPlanner, Teacher};
 

--- a/crates/kirra-planner/src/mick_llm.rs
+++ b/crates/kirra-planner/src/mick_llm.rs
@@ -1,0 +1,165 @@
+//! **Mick's LLM brain** — the model-agnostic prompt/parse layer behind the `MickBrain`
+//! seam. This is the *pure, testable* 90% of "plug in Gemma": render the world into a
+//! prompt, ask a model, parse the reply back into a typed [`MickIntent`]. It depends on
+//! NO model and NO network — a [`ModelClient`] is an abstract "prompt → text" port, so the
+//! whole path is exercised with a deterministic [`MockModel`]. A concrete client (a local
+//! Gemma via Ollama, a cloud model) implements [`ModelClient`] behind a feature/crate and
+//! plugs in unchanged.
+//!
+//! Safety is unchanged by *which* model runs: the reply is parsed by the existing
+//! fail-closed [`MickIntent::from_llm_json`] (tolerant of Gemma-style fences/preamble,
+//! strict on schema + finiteness), then Occy grounds it and KIRRA bounds it. A model
+//! error, a refusal, or a hallucinated reply all collapse to an `Err` → the caller HOLDs.
+
+use crate::mick::{MickBrain, MickError, MickIntent, WorldContext};
+
+/// Error from a model backend (transport failure, timeout, empty completion, …). Any
+/// failure collapses here and the brain fails closed — the model is never trusted.
+pub type ModelError = &'static str;
+
+/// Abstract "prompt → completion text" port. A real backend (local Gemma via Ollama,
+/// llama.cpp, a cloud API) implements this; tests use [`MockModel`]. Sync + blocking on
+/// purpose: Mick is the slow System-2 loop, so one blocking call per planning tick at low
+/// rate is fine, and it keeps the `MickBrain` seam synchronous.
+pub trait ModelClient {
+    /// Return the model's raw completion for `prompt`, or a `ModelError`.
+    fn complete(&self, prompt: &str) -> Result<String, ModelError>;
+}
+
+/// Render the world into a driving prompt: the chauffeur persona, the STRICT typed-intent
+/// output contract (one JSON object, matching `MickIntent::from_llm_json`), and the
+/// ego-relative situation (serialized [`WorldContext`]). The persona is told a governor
+/// enforces the hard limits — so the model is freed to focus on *good* driving rather than
+/// re-deriving collision/law/envelope rules it cannot be trusted to get right anyway.
+#[must_use]
+pub fn build_prompt(ctx: &WorldContext) -> String {
+    let situation = serde_json::to_string_pretty(ctx).unwrap_or_else(|_| "{}".to_string());
+    format!(
+        "You are Mick, a careful, law-abiding chauffeur driving an autonomous vehicle. \
+Choose the SINGLE best high-level driving intent for the current situation.\n\
+\n\
+Respond with ONLY one JSON object (no prose, no code fence), in one of these forms:\n\
+  {{\"intent\":\"cruise\",\"target_speed_mps\":<number>}}    keep going, up to this speed\n\
+  {{\"intent\":\"go_to\",\"x_m\":<number>,\"y_m\":<number>}}   head toward a point (ego frame)\n\
+  {{\"intent\":\"lane_change\",\"target_offset_m\":<number>}}  shift laterally (+left, -right)\n\
+  {{\"intent\":\"hold\"}}                                       stop and hold\n\
+\n\
+Drive smoothly and comfortably; ease off near objects and when posture is DEGRADED. You \
+set only the high-level intent — a separate safety governor enforces collision limits, \
+traffic law, and the speed envelope, so you cannot cause a crash. Focus on driving well. \
+Coordinates are ego-relative: +ahead is forward, +left is to your left.\n\
+\n\
+Situation:\n{situation}\n\
+\n\
+Intent:"
+    )
+}
+
+/// A [`MickBrain`] driven by any [`ModelClient`]: render the prompt, ask the model, parse
+/// the reply into a typed intent. Fail-closed at every step — a transport error or an
+/// unparseable / out-of-schema reply returns `Err`, on which the caller HOLDs.
+pub struct LlmBrain<M: ModelClient> {
+    model: M,
+}
+
+impl<M: ModelClient> LlmBrain<M> {
+    #[must_use]
+    pub fn new(model: M) -> Self {
+        Self { model }
+    }
+}
+
+impl<M: ModelClient> MickBrain for LlmBrain<M> {
+    fn decide(&mut self, ctx: &WorldContext) -> Result<MickIntent, MickError> {
+        let prompt = build_prompt(ctx);
+        let raw = self.model.complete(&prompt).map_err(|_| "MICK_MODEL_ERROR")?;
+        // from_llm_json is already fail-closed + tolerant of small-model framing.
+        MickIntent::from_llm_json(&raw)
+    }
+}
+
+/// A deterministic stand-in for a model, for tests / sim: returns a fixed completion (or a
+/// fixed error). Exercises the entire prompt → parse → intent path with no model present.
+pub struct MockModel {
+    response: Result<String, ModelError>,
+}
+
+impl MockModel {
+    /// A model that always replies with `text`.
+    #[must_use]
+    pub fn replying(text: impl Into<String>) -> Self {
+        Self { response: Ok(text.into()) }
+    }
+
+    /// A model whose backend always fails with `err`.
+    #[must_use]
+    pub fn failing(err: ModelError) -> Self {
+        Self { response: Err(err) }
+    }
+}
+
+impl ModelClient for MockModel {
+    fn complete(&self, _prompt: &str) -> Result<String, ModelError> {
+        self.response.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_ctx() -> WorldContext {
+        WorldContext {
+            ego_speed_mps: 3.0,
+            posture: "NOMINAL",
+            goal_ahead_m: 40.0,
+            goal_left_m: 0.0,
+            may_change_left: true,
+            may_change_right: false,
+            objects: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn prompt_carries_the_schema_and_the_situation() {
+        let p = build_prompt(&sample_ctx());
+        // The typed-intent contract the model must follow.
+        for tag in ["cruise", "go_to", "lane_change", "hold"] {
+            assert!(p.contains(tag), "prompt must list the {tag} intent");
+        }
+        // The ego-relative situation is embedded (serialized WorldContext).
+        assert!(p.contains("ego_speed_mps") && p.contains("posture"), "prompt must embed the situation");
+    }
+
+    #[test]
+    fn llm_brain_parses_a_valid_model_reply() {
+        let mut brain = LlmBrain::new(MockModel::replying(r#"{"intent":"cruise","target_speed_mps":4.0}"#));
+        assert_eq!(brain.decide(&sample_ctx()).unwrap(), MickIntent::Cruise { target_speed_mps: 4.0 });
+    }
+
+    #[test]
+    fn llm_brain_tolerates_gemma_framing() {
+        // The tolerant extractor recovers the object from a fence + preamble.
+        let mut brain = LlmBrain::new(MockModel::replying("Sure — here is the intent:\n```json\n{\"intent\":\"hold\"}\n```"));
+        assert_eq!(brain.decide(&sample_ctx()).unwrap(), MickIntent::Hold);
+    }
+
+    #[test]
+    fn llm_brain_fails_closed_on_a_hallucinated_reply() {
+        let mut brain = LlmBrain::new(MockModel::replying("just floor it, trust me"));
+        assert!(brain.decide(&sample_ctx()).is_err(), "unparseable reply must fail closed");
+    }
+
+    #[test]
+    fn llm_brain_fails_closed_on_a_model_error() {
+        let mut brain = LlmBrain::new(MockModel::failing("connection refused"));
+        assert!(brain.decide(&sample_ctx()).is_err(), "a backend error must fail closed");
+    }
+
+    #[test]
+    fn llm_brain_fails_closed_on_a_nonfinite_intent() {
+        // The model emits a syntactically valid object with an overflowing number.
+        let mut brain = LlmBrain::new(MockModel::replying(r#"{"intent":"go_to","x_m":1e400,"y_m":0.0}"#));
+        assert!(brain.decide(&sample_ctx()).is_err(), "a non-finite intent must fail closed");
+    }
+}


### PR DESCRIPTION
## Mick step 3a — the LLM brain (prompt + parse), model-agnostic

The **pure, testable 90%** of "plug in Gemma" — no model, no network, **no new deps**. Renders the world into a driving prompt, asks an abstract model, parses the reply into a typed intent. A concrete backend plugs into one trait, unchanged.

### What's added (all in the lean planner)
- **`ModelClient`** — an abstract `prompt -> completion text` port. Sync/blocking on purpose: Mick is the slow System-2 loop, so a blocking call per tick is fine and keeps the `MickBrain` seam synchronous.
- **`build_prompt(&WorldContext)`** — the chauffeur persona + the **strict typed-intent output contract** (one JSON object matching `from_llm_json`) + the ego-relative situation (serialized `WorldContext`). The persona is told *a governor enforces the hard limits* — so the model is freed to drive **well** instead of re-deriving collision/law/envelope rules it can't be trusted with anyway.
- **`LlmBrain<M: ModelClient>`** — a `MickBrain` that renders → asks → parses via the existing fail-closed, framing-tolerant `from_llm_json`. A transport error, refusal, hallucination, or non-finite intent **all collapse to `Err` → the caller HOLDs**. Safety is invariant to which model runs.
- **`MockModel`** — deterministic stand-in (fixed reply / fixed error) so the whole prompt → parse → intent path is tested with no model present.

### Tests (6)
prompt carries schema + situation · valid reply parses · Gemma fence/preamble tolerated · hallucination fails closed · backend error fails closed · non-finite intent fails closed.

### Verification
kirra-planner lib **82** + all integration/loop suites green; clippy clean under `-D warnings --all-targets`. Planner stays lean — **zero new deps**.

### Next — the live transport (step 3b), a decision for you
Only the thin HTTP call to a local model needs a backend + `reqwest`. Two clean options (in the PR comment / chat) — feature-gated module vs a separate `kirra-mick` crate. I'll wire a real `OllamaClient: ModelClient` once you pick; everything above is already proven against `MockModel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_