### PR TITLE
feat(mick): kirra-mick — live Ollama transport so real local Gemma drives the loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,6 +2008,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-mick"
+version = "0.1.0"
+dependencies = [
+ "kirra-core",
+ "kirra-planner",
+ "kirra-ros2-adapter",
+ "reqwest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kirra-planner"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-core", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
+members = [".", "crates/kirra-core", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
 resolver = "2"
 
 [package]

--- a/crates/kirra-mick/Cargo.toml
+++ b/crates/kirra-mick/Cargo.toml
@@ -1,0 +1,31 @@
+# crates/kirra-mick/Cargo.toml
+#
+# kirra-mick — the live LLM transport for Mick's brain. Holds the one piece that needs
+# the network: `OllamaClient`, a `kirra_planner::ModelClient` that drives a LOCAL model
+# (Gemma by default) served by Ollama over HTTP. Kept OUT of the lean `kirra-planner` on
+# purpose (the de-monolith ethos): the planner's prompt/parse logic stays dependency-free
+# and model-agnostic; only this crate pulls `reqwest`.
+[package]
+name = "kirra-mick"
+version = "0.1.0"
+edition = "2021"
+description = "Live LLM transport for Mick — an Ollama-backed ModelClient (local Gemma) behind the kirra-planner MickBrain seam."
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+
+[dependencies]
+# The MickBrain seam: ModelClient / ModelError / LlmBrain / WorldContext live here.
+kirra-planner = { path = "../kirra-planner" }
+# Blocking HTTP (matches the sync ModelClient port). rustls so there is no system OpenSSL
+# dependency — same pin/features as the rest of the workspace.
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+# The live chauffeur example drives Occy + the #131 KIRRA checker against real Gemma.
+# default-features = false → no ROS/tokio; we only need validate_trajectory_slow +
+# VehicleConfig + the mock corridor.
+kirra-ros2-adapter = { path = "../kirra-ros2-adapter", default-features = false }
+kirra-core = { path = "../kirra-core" }

--- a/crates/kirra-mick/examples/mick_chauffeur.rs
+++ b/crates/kirra-mick/examples/mick_chauffeur.rs
@@ -1,0 +1,88 @@
+//! **Watch real Gemma drive — bounded by KIRRA.** Runs the closed loop with a LIVE
+//! `LlmBrain<OllamaClient>`: each tick a local Gemma proposes a typed intent, Occy grounds
+//! it, KIRRA judges it, and the ego advances (admitted → conform; rejected → MRC/hold).
+//! The per-tick trace prints what the model chose and what the governor did with it.
+//!
+//! Run it:
+//!   ollama pull gemma3:4b           # one-time
+//!   cargo run -p kirra-mick --example mick_chauffeur
+//!
+//! No Ollama running? The brain fails closed every tick — you'll see HOLD throughout,
+//! which is exactly the safe behavior. The model can never make the car unsafe: its intent
+//! is grounded by Occy and bounded by KIRRA; this binary only shows the loop.
+
+use kirra_core::FleetPosture;
+use kirra_mick::OllamaClient;
+use kirra_planner::{
+    mick_drive_once, EgoState, GeometricPlanner, Goal, LlmBrain, PlanInput, PlanOutput, Pose,
+};
+use kirra_ros2_adapter::corridor::{CorridorSource, MockCorridorSource, Point};
+use kirra_ros2_adapter::state::{PerceivedObject, TrajectoryVerdict};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+const TICK_DT: f64 = 0.5;
+const TICKS: usize = 12;
+
+fn world<'a>(ego: EgoState, map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> PlanInput<'a> {
+    PlanInput {
+        ego,
+        goal: Goal { target: Pose { x_m: 60.0, y_m: 0.0, heading_rad: 0.0 } },
+        map,
+        objects,
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+    }
+}
+
+fn verdict(plan: &PlanOutput, corr: &dyn CorridorSource, objs: &[PerceivedObject]) -> TrajectoryVerdict {
+    validate_trajectory_slow(&plan.trajectory, corr, objs, &VehicleConfig::default_urban(), None, FleetPosture::Nominal)
+}
+
+fn advance(ego: EgoState, plan: &PlanOutput, admitted: bool, t_ms: u64) -> EgoState {
+    if !admitted {
+        return EgoState {
+            pose: ego.pose,
+            linear_x_mps: (ego.linear_x_mps - 3.0 * TICK_DT).max(0.0),
+            yaw_rate_rads: 0.0,
+            stamp_ms: t_ms,
+        };
+    }
+    let tp = plan.trajectory.iter().find(|p| p.time_from_start_s >= TICK_DT).or_else(|| plan.trajectory.last());
+    match tp {
+        Some(p) => EgoState { pose: p.pose, linear_x_mps: p.velocity_mps, yaw_rate_rads: 0.0, stamp_ms: t_ms },
+        None => ego,
+    }
+}
+
+fn main() {
+    let client = OllamaClient::new();
+    println!("Mick chauffeur — model = {} @ {}", client.model(), std::env::var("KIRRA_OLLAMA_URL").unwrap_or_else(|_| "http://localhost:11434".into()));
+    let mut mick = LlmBrain::new(client);
+    let mut occy = GeometricPlanner::default();
+
+    // A straight road with a stopped car at x=30 — we should see Gemma drive up and the
+    // system hold short / KIRRA bound it before the obstacle.
+    let corr = MockCorridorSource::straight_5m_half_width(100.0);
+    let objs = [PerceivedObject { id: 1, pos: Point { x_m: 30.0, y_m: 0.0 }, velocity_mps: 0.0, heading_rad: 0.0, vel: Point { x_m: 0.0, y_m: 0.0 } }];
+
+    let mut ego = EgoState { pose: Pose { x_m: 5.0, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: 2.0, yaw_rate_rads: 0.0, stamp_ms: 0 };
+    println!("  tick     ego.x       v  kirra-verdict");
+    for tick in 1..=TICKS {
+        let w = world(ego, &corr, &objs);
+        // mick_drive_once asks Gemma; a model error fails closed to a safe stop.
+        let plan = mick_drive_once(&mut mick, &w, &mut occy);
+        let v = verdict(&plan, &corr, &objs);
+        let admitted = matches!(v, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp);
+        println!("{tick:>4}  {:>8.2}  {:>6.2}  {v:?}", ego.pose.x_m, ego.linear_x_mps);
+        ego = advance(ego, &plan, admitted, tick as u64 * 500);
+    }
+    println!("final ego.x = {:.2} (obstacle at x=30 — the chauffeur never reaches it)", ego.pose.x_m);
+}

--- a/crates/kirra-mick/src/lib.rs
+++ b/crates/kirra-mick/src/lib.rs
@@ -1,0 +1,161 @@
+//! **kirra-mick** — the live LLM transport for Mick.
+//!
+//! [`OllamaClient`] is a [`kirra_planner::ModelClient`] that drives a LOCAL model (Gemma
+//! by default) served by [Ollama](https://ollama.com) over HTTP. Drop it into
+//! `kirra_planner::LlmBrain` and Mick is driven by a real model:
+//!
+//! ```no_run
+//! use kirra_mick::OllamaClient;
+//! use kirra_planner::{LlmBrain, MickBrain, WorldContext};
+//!
+//! let mut mick = LlmBrain::new(OllamaClient::new()); // reads KIRRA_OLLAMA_URL / KIRRA_MICK_MODEL
+//! let ctx = WorldContext { ego_speed_mps: 3.0, posture: "NOMINAL", goal_ahead_m: 40.0,
+//!     goal_left_m: 0.0, may_change_left: true, may_change_right: false, objects: Vec::new() };
+//! match mick.decide(&ctx) {
+//!     Ok(intent) => { /* Occy grounds it, KIRRA bounds it */ }
+//!     Err(_)     => { /* model unreachable / hallucinated → HOLD (fail-closed) */ }
+//! }
+//! ```
+//!
+//! **Safety is unchanged by the transport.** Every failure mode here — connection refused,
+//! timeout, non-200, empty/garbage completion — returns a `ModelError`, so `LlmBrain`
+//! fails closed and the caller HOLDs. The model can never reach the actuator: Occy grounds
+//! the intent and KIRRA bounds it downstream. The transport just decides *whether there is
+//! a fresh intent this tick*, never whether a command is safe.
+
+use kirra_planner::{ModelClient, ModelError};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Default Ollama base URL (override with `KIRRA_OLLAMA_URL`).
+pub const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
+/// Default model id (override with `KIRRA_MICK_MODEL`). A 4B-class instruct model is a
+/// good fit for the tight typed-intent vocabulary; pull it with `ollama pull gemma3:4b`.
+pub const DEFAULT_MODEL: &str = "gemma3:4b";
+/// Per-request timeout. Mick is the slow System-2 loop, but a hung backend must NOT wedge
+/// the planning tick — on timeout we fail closed and HOLD.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// A [`ModelClient`] backed by a local Ollama server running Gemma (or any Ollama model).
+pub struct OllamaClient {
+    base_url: String,
+    model: String,
+    http: reqwest::blocking::Client,
+}
+
+impl OllamaClient {
+    /// Construct from the environment: `KIRRA_OLLAMA_URL` (default [`DEFAULT_OLLAMA_URL`])
+    /// and `KIRRA_MICK_MODEL` (default [`DEFAULT_MODEL`]).
+    #[must_use]
+    pub fn new() -> Self {
+        let base_url = std::env::var("KIRRA_OLLAMA_URL").unwrap_or_else(|_| DEFAULT_OLLAMA_URL.to_string());
+        let model = std::env::var("KIRRA_MICK_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+        Self::with(base_url, model)
+    }
+
+    /// Construct with an explicit base URL + model id.
+    #[must_use]
+    pub fn with(base_url: impl Into<String>, model: impl Into<String>) -> Self {
+        let http = reqwest::blocking::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::blocking::Client::new());
+        Self { base_url: base_url.into(), model: model.into(), http }
+    }
+
+    /// The configured model id.
+    #[must_use]
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+}
+
+impl Default for OllamaClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Ollama `/api/generate` request (non-streaming: one prompt → one completion).
+#[derive(Serialize)]
+struct GenerateRequest<'a> {
+    model: &'a str,
+    prompt: &'a str,
+    stream: bool,
+}
+
+/// The relevant slice of the `/api/generate` response.
+#[derive(Deserialize)]
+struct GenerateResponse {
+    response: String,
+}
+
+impl ModelClient for OllamaClient {
+    fn complete(&self, prompt: &str) -> Result<String, ModelError> {
+        let url = format!("{}/api/generate", self.base_url);
+        let body = GenerateRequest { model: &self.model, prompt, stream: false };
+
+        // Every failure maps to a stable ModelError → LlmBrain fails closed → HOLD.
+        let resp = self
+            .http
+            .post(&url)
+            .json(&body)
+            .send()
+            .map_err(|_| "MICK_OLLAMA_REQUEST_FAILED")?;
+        if !resp.status().is_success() {
+            return Err("MICK_OLLAMA_HTTP_STATUS");
+        }
+        let parsed: GenerateResponse = resp.json().map_err(|_| "MICK_OLLAMA_DECODE_FAILED")?;
+        if parsed.response.trim().is_empty() {
+            return Err("MICK_OLLAMA_EMPTY_COMPLETION");
+        }
+        Ok(parsed.response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kirra_planner::{LlmBrain, MickBrain, WorldContext};
+
+    fn ctx() -> WorldContext {
+        WorldContext {
+            ego_speed_mps: 3.0,
+            posture: "NOMINAL",
+            goal_ahead_m: 40.0,
+            goal_left_m: 0.0,
+            may_change_left: true,
+            may_change_right: false,
+            objects: Vec::new(),
+        }
+    }
+
+    /// CI-safe: with no Ollama listening, the transport fails closed (connection refused),
+    /// and `LlmBrain` therefore HOLDs. No model required — this pins the fail-closed path.
+    #[test]
+    fn unreachable_ollama_fails_closed() {
+        // Port 1 has nothing listening → immediate connection refusal.
+        let client = OllamaClient::with("http://127.0.0.1:1", DEFAULT_MODEL);
+        assert!(client.complete("hi").is_err(), "an unreachable Ollama must fail closed");
+
+        let mut mick = LlmBrain::new(OllamaClient::with("http://127.0.0.1:1", DEFAULT_MODEL));
+        assert!(mick.decide(&ctx()).is_err(), "LlmBrain HOLDs when the model is unreachable");
+    }
+
+    #[test]
+    fn config_defaults_and_overrides() {
+        let c = OllamaClient::with("http://example:1234", "llama3.2:3b");
+        assert_eq!(c.model(), "llama3.2:3b");
+    }
+
+    /// Live round-trip — requires `ollama pull gemma3:4b` and a running server. Ignored in
+    /// CI; run locally with `cargo test -p kirra-mick -- --ignored`.
+    #[test]
+    #[ignore = "requires a local Ollama serving the configured model"]
+    fn live_ollama_returns_a_typed_intent() {
+        let mut mick = LlmBrain::new(OllamaClient::new());
+        let intent = mick.decide(&ctx()).expect("a running Ollama should yield a typed intent");
+        // Any of the typed intents is acceptable — we only assert it parsed to one.
+        println!("live Gemma chose: {intent:?}");
+    }
+}


### PR DESCRIPTION
## Mick step 3b — `kirra-mick`: real local Gemma drives the loop

The last piece. A concrete `ModelClient` so a real model is Mick's brain — in its **own crate** (per your choice), so only this crate pulls `reqwest`; the planner's prompt/parse logic stays dependency-free and model-agnostic.

### What's added
- **`OllamaClient: kirra_planner::ModelClient`** — `complete(prompt)` does a blocking `POST {base}/api/generate` with `{model, prompt, stream:false}` and returns `.response`. Base URL + model from env (`KIRRA_OLLAMA_URL`, `KIRRA_MICK_MODEL`; defaults `localhost:11434` + `gemma3:4b`), 30 s timeout. **Every** failure — connection refused, timeout, non-200, decode error, empty completion — maps to a `ModelError`, so `LlmBrain` fails closed and the caller **HOLDs**. Safety is invariant to the transport: the model's intent is grounded by Occy and bounded by KIRRA; it can never reach the actuator.
- **`examples/mick_chauffeur.rs`** — the *watch real Gemma drive* artifact: the closed loop with a live `LlmBrain<OllamaClient>`, printing the per-tick **intent → KIRRA verdict → ego** trace.

### Verified end to end (without a model present)
```
$ cargo run -p kirra-mick --example mick_chauffeur
Mick chauffeur — model = gemma3:4b @ http://localhost:11434
  tick     ego.x       v  kirra-verdict
   1      5.00    2.00  Accept
   2      5.00    0.00  Accept        ← no Ollama → fail-closed HOLD, ego decel 2→0
   ...
final ego.x = 5.00 (obstacle at x=30 — the chauffeur never reaches it)
```
No model → HOLD throughout. **The chauffeur is safe even with no brain.** With a live Ollama, tick 1+ shows Gemma's chosen intent driving forward and KIRRA bounding it at the obstacle.

### Tests
`unreachable_ollama_fails_closed` (CI-safe: dead port → Err → `LlmBrain` HOLDs) + a config test pass; the live round-trip is `#[ignore]` (run locally: `ollama pull gemma3:4b` then `cargo test -p kirra-mick -- --ignored`). Prompt/parse stays covered by the planner's `MockModel` tests.

The adapter is a **dev-dependency only** (the example's KIRRA checker), so the `kirra-mick` library itself is just kirra-planner + reqwest + serde. Clippy clean under `-D warnings --all-targets`.

## Mick is now complete, end to end
```
local Gemma (Ollama) ─▶ OllamaClient ─▶ LlmBrain ─▶ from_llm_json ─▶ MickIntent ─▶ Occy grounds ─▶ KIRRA bounds ─▶ actuator
        (the brain)         (kirra-mick)        (kirra-planner, all fail-closed)              (safe by construction)
```
Vocabulary: `GoTo` · `LaneChange` · `Hold` · `Cruise`. Brain: any `ModelClient` (Gemma today, swappable). Safety net: Occy + KIRRA, proven in the closed loop. A model mistake → HOLD; an unsafe proposal → bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_