### PR TITLE
Frame-integrity gate (Stage S-FI1a/b) + competitive gap analysis

### DIFF
--- a/crates/kirra-core/src/containment.rs
+++ b/crates/kirra-core/src/containment.rs
@@ -32,6 +32,7 @@
 //     → `DenyCode::DrivableSpaceDeparture` (SG4 untraversable-default pattern).
 //   - Zero heap allocation; all loops bounded; scalar f64 math; no recursion.
 
+use crate::frame_integrity::{containment_margin_m, FrameTrust};
 use crate::kinematics_contract::{DenyCode, EnforceAction, VehicleKinematicsContract};
 
 /// Maximum number of poses in a trajectory the Governor will inspect per call.
@@ -169,33 +170,45 @@ impl From<&VehicleKinematicsContract> for VehicleFootprint {
 // The check
 // ---------------------------------------------------------------------------
 
-// SAFETY: SG2 | REQ: drivable-space-containment | TEST: containment_allows_pose_centered_in_straight_corridor,containment_rejects_pose_outside_left,containment_rejects_pose_outside_right,containment_rejects_oncoming_excursion,containment_rejects_footprint_corner_clip,containment_rejects_when_corridor_unhealthy_low_confidence,containment_rejects_when_corridor_unhealthy_stale,containment_rejects_when_trajectory_exceeds_horizon,containment_allows_lane_change_within_wide_corridor,deny_code_drivable_space_departure_renders_stable_token
-/// SG2 drivable-space containment check.
+// SAFETY: SG2 | REQ: drivable-space-containment,frame-integrity-gate | TEST: containment_allows_pose_centered_in_straight_corridor,containment_rejects_pose_outside_left,containment_rejects_pose_outside_right,containment_rejects_oncoming_excursion,containment_rejects_footprint_corner_clip,containment_rejects_when_corridor_unhealthy_low_confidence,containment_rejects_when_corridor_unhealthy_stale,containment_rejects_when_trajectory_exceeds_horizon,containment_allows_lane_change_within_wide_corridor,deny_code_drivable_space_departure_renders_stable_token,checked_untrusted_refuses_before_geometry,checked_degraded_margin_is_stricter_than_trusted,checked_trusted_matches_shim
+/// SG2 drivable-space containment check, **frame-integrity-gated** (Stage S-FI1).
 ///
-/// For each pose in `trajectory`, computes the 4 vehicle footprint corners
-/// in world frame and asserts every corner lies inside the `corridor`
-/// polygon with at least `CONTAINMENT_LATERAL_MARGIN_M` margin. Any
-/// failure → `EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture)`
-/// → caller commits the standing MRC.
+/// Resolves the lateral margin from the [`FrameTrust`] verdict
+/// ([`containment_margin_m`]): `Trusted` → 0.40 m primary, `Degraded` → 0.75 m
+/// fallback, `Untrusted` → refuse. The frame gate runs **FIRST**: an `Untrusted`
+/// frame means the corridor cannot be trusted to be correctly placed relative to
+/// the ego, so we refuse to validate geometry at all and return
+/// `DenyBreach(DenyCode::FrameIntegrityUntrusted)` (→ caller commits the MRC,
+/// the frame-trust-minimal maneuver). This is the one fault class the governor
+/// structurally cannot otherwise catch, because localization is the governor's
+/// own coordinate-frame input (AOU-LOCALIZATION-001, `ASSUMPTIONS_OF_USE.md`).
 ///
-/// Conservative behavior: an absent / stale / low-confidence / degenerate
-/// corridor (`!corridor.is_healthy()`) is treated as a containment failure,
-/// NOT as "skip the check." See OCCY_FAULT_MODEL.md §3 sensor-availability
-/// rule and OCCY_INDEPENDENT_DETECTOR.md SG4 untraversable-default pattern.
+/// For a trusted/degraded frame, each pose's 4 footprint corners must lie inside
+/// the `corridor` polygon by at least the selected margin; any failure (incl. an
+/// absent / stale / low-confidence / degenerate corridor — conservative per
+/// OCCY_FAULT_MODEL.md §3) → `DenyBreach(DenyCode::DrivableSpaceDeparture)`.
+/// Note a *larger* margin is *stricter*, so `Degraded` rejects strictly more
+/// than `Trusted` — graduation tightens safety under worse localization.
 ///
-/// Bounded properties (per `wcet_gate` framing):
-///   - `trajectory.len() ≤ MAX_TRAJECTORY_HORIZON` (else conservative reject).
-///   - Per-pose work is `O(left.len() + right.len())`; total work is
-///     `O(trajectory.len() × (left.len() + right.len()) × 4)`. With the
-///     `MAX_*` caps that's `≤ 50 × 256 × 4 = 51 200` polygon-edge tests
-///     per call.
-///   - No heap allocation; no recursion; scalar f64 only.
+/// Bounded properties (per `wcet_gate` framing): the frame gate adds O(1) work
+/// (a `match`); the geometry loop is unchanged — `trajectory.len() ≤
+/// MAX_TRAJECTORY_HORIZON`, per-pose `O(left.len() + right.len())`, total
+/// `≤ 50 × 256 × 4 = 51 200` polygon-edge tests; no heap, no recursion, scalar
+/// f64 only.
 #[must_use]
-pub fn validate_trajectory_containment(
+pub fn validate_trajectory_containment_checked(
     trajectory: &[Pose],
     corridor: &Corridor,
     footprint: &VehicleFootprint,
+    frame_trust: FrameTrust,
 ) -> EnforceAction {
+    // Frame-integrity gate FIRST (S-FI1): refuse to validate geometry in an
+    // untrusted frame. `None` margin ⇒ Untrusted ⇒ fail closed.
+    let margin = match containment_margin_m(frame_trust) {
+        Some(m) => m,
+        None => return EnforceAction::DenyBreach(DenyCode::FrameIntegrityUntrusted),
+    };
+
     // Conservative gates: any of these failing → containment failure (NOT
     // skip-the-check). Aligns with OCCY_FAULT_MODEL §3.
     if !corridor.is_healthy() {
@@ -209,7 +222,7 @@ pub fn validate_trajectory_containment(
         return EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture);
     }
 
-    let margin_sq = CONTAINMENT_LATERAL_MARGIN_M * CONTAINMENT_LATERAL_MARGIN_M;
+    let margin_sq = margin * margin;
 
     for pose in trajectory.iter() {
         if !pose_is_finite(pose) {
@@ -224,6 +237,26 @@ pub fn validate_trajectory_containment(
     }
 
     EnforceAction::Allow
+}
+
+/// Frame-trust-ASSERTING shim (Stage S-FI1b). Delegates to
+/// [`validate_trajectory_containment_checked`] with [`FrameTrust::Trusted`] —
+/// i.e. it ASSUMES the integrator's localization holds AOU-LOCALIZATION-001
+/// (≤ 0.10 m 95th-pct lateral error → primary 0.40 m margin), the legacy
+/// behavior before the frame-integrity gate existed.
+///
+/// This is the 3-arg entry the four enforcement points (gateway / fabric /
+/// ros2-adapter / parko-kirra) still call. The S-FI1e migration repoints them to
+/// the checked entry — sourcing a real [`FrameIntegrity`] per tick — and removes
+/// this shim. Until then this carries AOU-LOCALIZATION-001 inline. Do NOT call
+/// from new code; call the checked entry with a resolved frame trust.
+#[must_use]
+pub fn validate_trajectory_containment(
+    trajectory: &[Pose],
+    corridor: &Corridor,
+    footprint: &VehicleFootprint,
+) -> EnforceAction {
+    validate_trajectory_containment_checked(trajectory, corridor, footprint, FrameTrust::Trusted)
 }
 
 // ---------------------------------------------------------------------------
@@ -441,6 +474,70 @@ mod tests {
         let traj = vec![pose(20.0, 0.0, 0.0), pose(30.0, 0.0, 0.0)];
         let action = validate_trajectory_containment(&traj, &corridor, &sedan());
         assert_eq!(action, EnforceAction::Allow, "centered pose must Allow");
+    }
+
+    // --- Stage S-FI1b: frame-integrity gate ---------------------------------
+
+    #[test]
+    fn checked_untrusted_refuses_before_geometry() {
+        use crate::frame_integrity::FrameTrust;
+        // A pose that WOULD Allow under a trusted frame (centered, wide corridor)
+        // must still be refused when the frame is Untrusted — the gate runs before
+        // any geometry is considered.
+        let (left, right) = straight_corridor(3.0, 100.0);
+        let corridor = healthy_corridor(&left, &right);
+        let traj = vec![pose(50.0, 0.0, 0.0)];
+        let action = validate_trajectory_containment_checked(
+            &traj,
+            &corridor,
+            &sedan(),
+            FrameTrust::Untrusted,
+        );
+        assert_eq!(
+            action,
+            EnforceAction::DenyBreach(DenyCode::FrameIntegrityUntrusted),
+            "untrusted frame must refuse with FrameIntegrityUntrusted, even for a safe pose"
+        );
+    }
+
+    #[test]
+    fn checked_degraded_margin_is_stricter_than_trusted() {
+        use crate::frame_integrity::FrameTrust;
+        // sedan half-width 0.925 m; corridor half-width 1.425 m → lateral
+        // clearance 0.50 m, which is ≥ 0.40 (primary) but < 0.75 (fallback).
+        // Pose at x = 50 sits far from the end-caps so only the lateral edges bind.
+        let (left, right) = straight_corridor(1.425, 100.0);
+        let corridor = healthy_corridor(&left, &right);
+        let traj = vec![pose(50.0, 0.0, 0.0)];
+        assert_eq!(
+            validate_trajectory_containment_checked(&traj, &corridor, &sedan(), FrameTrust::Trusted),
+            EnforceAction::Allow,
+            "0.50 m clearance passes the 0.40 m primary margin (Trusted)"
+        );
+        assert_eq!(
+            validate_trajectory_containment_checked(
+                &traj,
+                &corridor,
+                &sedan(),
+                FrameTrust::Degraded
+            ),
+            EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
+            "0.50 m clearance fails the stricter 0.75 m fallback margin (Degraded)"
+        );
+    }
+
+    #[test]
+    fn checked_trusted_matches_shim() {
+        use crate::frame_integrity::FrameTrust;
+        // The 3-arg trust-asserting shim must be byte-identical to checked(Trusted).
+        let (left, right) = straight_corridor(3.0, 100.0);
+        let corridor = healthy_corridor(&left, &right);
+        let traj = vec![pose(50.0, 0.0, 0.0)];
+        assert_eq!(
+            validate_trajectory_containment(&traj, &corridor, &sedan()),
+            validate_trajectory_containment_checked(&traj, &corridor, &sedan(), FrameTrust::Trusted),
+            "the 3-arg shim must equal checked(Trusted)"
+        );
     }
 
     #[test]

--- a/crates/kirra-core/src/frame_integrity.rs
+++ b/crates/kirra-core/src/frame_integrity.rs
@@ -1,0 +1,326 @@
+//! **kirra-core frame-integrity gate** (Stage S-FI1a) — the fail-closed runtime
+//! check behind `AOU-LOCALIZATION-001`.
+//!
+//! # Why this module exists
+//!
+//! `containment::validate_trajectory_containment` (SG2) reasons about the ego
+//! footprint inside a map-anchored corridor. Every such map-anchored judgement
+//! is interpreted *through the ego pose* — so a wrong pose silently mislocates
+//! the corridor (and every commit-zone / water veto) and the checker validates
+//! against the wrong world **without any single check observing the fault**
+//! (`ASSUMPTIONS_OF_USE.md` AOU-LOCALIZATION-001). Localization is the one input
+//! the governor structurally cannot de-risk, because it is the governor's *own*
+//! coordinate-frame input.
+//!
+//! This module turns that static assumption into a runtime check: it consumes
+//! the integrator's per-tick frame-integrity report and resolves a **graduated**
+//! verdict that selects the containment margin and drives the posture engine.
+//!
+//! # Design commitments (Stage S-FI1, see `docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md`)
+//!
+//! * **Graduated, not binary.** The verdict carries three regimes — Trusted
+//!   (0.40 m primary margin), Degraded (0.75 m fallback margin), Untrusted
+//!   (refuse to validate) — selected from the *reported error value*, not a bool.
+//! * **Frame-integrity, not localization-only.** [`FrameIntegrity::Reported`]
+//!   carries a [`LocalizationChannel`] today; calibration / time-sync are
+//!   RESERVED sibling channels (Stage S-FI2) so the enum shape never changes to
+//!   add them.
+//! * **Fail-closed-immediately.** `Unknown` (absent ≠ healthy), non-finite, or
+//!   stale → `Untrusted` on the FIRST tick. Hysteresis (Stage S-FI1d) governs
+//!   only the Degraded→LockedOut escalation, never a grace period on the initial
+//!   fail-closed response.
+//! * **Self-report, honestly.** This narrows AOU-LOCALIZATION-001 to a *checked
+//!   self-report*; independent KIRRA-computed integrity is the named follow-on
+//!   (Stage S-FI3), not this stage.
+//!
+//! # WCET
+//!
+//! [`resolve_frame_trust`] and [`containment_margin_m`] are O(1): scalar `f64`
+//! comparisons and `match`, no heap, no recursion. They ride the `wcet_gate`
+//! structural-boundedness argument unchanged.
+//!
+//! # Scope of S-FI1a
+//!
+//! This sub-stage is the PURE module only — types + resolver + margin selection
+//! + tests. It does NOT touch `containment.rs`, the posture engine, parko, or any
+//! call site; those are S-FI1b–e. The new `DenyCode::FrameIntegrityUntrusted`
+//! and the containment parameter are introduced in S-FI1b.
+
+/// One channel of the ego coordinate-frame's integrity. Localization is the
+/// first and dominant channel; calibration / time-sync are RESERVED siblings
+/// (Stage S-FI2) — they manifest *as* pose error in the fused frame
+/// (`AOU-TIMESYNC-001`), so they belong to the same frame-defining class.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LocalizationChannel {
+    /// 95th-percentile lateral (cross-track) position error, metres.
+    /// Non-finite → fail closed (an unverifiable pose is no pose).
+    pub lateral_error_95_m: f64,
+    /// Age (ms) of this snapshot vs now. Above the cfg bound → stale → fail
+    /// closed (a stale pose is unobserved travel; see the staleness × speed
+    /// coupling in the stage spec §3).
+    pub age_ms: u64,
+}
+
+/// What the integrator's frame-integrity channel reports THIS tick.
+///
+/// Mirrors the established ABSENT-vs-KNOWN discipline (cf. [`crate::containment::Corridor`],
+/// parko `LocalizationIntegrity`): an ABSENT report is NOT a healthy frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FrameIntegrity {
+    /// No report this tick → NOT trusted (absent ≠ healthy; the #238 trap — a
+    /// missing pose-quality signal is not "the pose is fine").
+    Unknown,
+    /// The integrator reported a frame-quality estimate.
+    Reported {
+        /// The localization channel (dominant, present today).
+        localization: LocalizationChannel,
+        // RESERVED (Stage S-FI2):
+        //   calibration: Option<CalibrationChannel>,
+        //   time_sync:   Option<TimeSyncChannel>,
+    },
+}
+
+/// Graduated frame-trust verdict. Maps 1:1 to a containment margin
+/// ([`containment_margin_m`]) AND a posture class (Stage S-FI1d).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameTrust {
+    /// ε ≤ primary bound, fresh, finite → PRIMARY margin (0.40 m), posture
+    /// Nominal.
+    Trusted,
+    /// primary < ε ≤ fallback bound, fresh, finite → FALLBACK margin (0.75 m),
+    /// posture Degraded. "Wrong but bounded": widen the margin to absorb the
+    /// larger error and keep moving conservatively.
+    Degraded,
+    /// absent / stale / non-finite / ε > fallback → containment refuses to
+    /// validate; the MRC controlled-stop (decel along current heading) is the
+    /// frame-trust-minimal maneuver. Posture: immediate Degraded, escalating to
+    /// LockedOut if sustained / flapping (Stage S-FI1d).
+    Untrusted,
+}
+
+/// Configuration for the frame-integrity gate.
+///
+/// The bounds are **documented, sourced, VALIDATION-PENDING** placeholders — NOT
+/// manufactured FTTI numbers. `primary` couples to the 0.40 m SG2 margin
+/// derivation (KIRRA-OCCY-SG2-MARGIN-001); `fallback` couples to the 0.75 m
+/// conservative margin (urban-canyon worst case, `OCCY_SG2_MARGIN.md` §2/§3).
+/// `max_age_ms` is a liveness placeholder — see the staleness × speed coupling
+/// note in the stage spec: it is NOT a standalone safety bound.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FrameIntegrityCfg {
+    /// ε ≤ this → [`FrameTrust::Trusted`]. Default `0.10` m (G2 AoU bound).
+    pub primary_max_lateral_error_95_m: f64,
+    /// primary < ε ≤ this → [`FrameTrust::Degraded`]. Default `0.30` m
+    /// (urban-canyon worst case the 0.75 m fallback margin is derived against).
+    pub fallback_max_lateral_error_95_m: f64,
+    /// Maximum acceptable staleness (ms). Default `500` — VALIDATION-PENDING;
+    /// tie to the per-cycle localization-path FTTI on allocation. Matches the
+    /// parko `LocalizationCfg` default.
+    pub max_age_ms: u64,
+}
+
+impl Default for FrameIntegrityCfg {
+    fn default() -> Self {
+        Self {
+            primary_max_lateral_error_95_m: 0.10,
+            fallback_max_lateral_error_95_m: 0.30,
+            max_age_ms: 500,
+        }
+    }
+}
+
+/// The 0.75 m conservative-fallback lateral containment margin (metres),
+/// promoted from `OCCY_SG2_MARGIN.md` §3 to code. Selected by
+/// [`containment_margin_m`] under [`FrameTrust::Degraded`]. The PRIMARY 0.40 m
+/// margin stays its existing constant ([`crate::containment::CONTAINMENT_LATERAL_MARGIN_M`])
+/// for audit / derivation stability.
+pub const CONTAINMENT_LATERAL_MARGIN_FALLBACK_M: f64 = 0.75;
+
+/// Resolve the graduated frame-trust verdict for this tick. Fail-closed on
+/// every uncertain input — `Unknown`, non-finite ε, stale, or ε beyond the
+/// fallback bound all yield [`FrameTrust::Untrusted`].
+///
+/// O(1), scalar-only, no allocation (WCET-clean).
+// SAFETY: SG2 | REQ: frame-integrity-gate | TEST: unknown_is_untrusted,nonfinite_is_untrusted,stale_is_untrusted,primary_boundary_is_trusted,just_over_primary_is_degraded,fallback_boundary_is_degraded,just_over_fallback_is_untrusted
+#[must_use]
+pub fn resolve_frame_trust(integrity: &FrameIntegrity, cfg: &FrameIntegrityCfg) -> FrameTrust {
+    let LocalizationChannel {
+        lateral_error_95_m: e,
+        age_ms,
+    } = match *integrity {
+        FrameIntegrity::Unknown => return FrameTrust::Untrusted,
+        FrameIntegrity::Reported { localization } => localization,
+    };
+
+    // Unverifiable or stale → fail closed. (A non-finite error is no pose; a
+    // stale pose is unobserved travel.)
+    if !e.is_finite() || age_ms > cfg.max_age_ms {
+        return FrameTrust::Untrusted;
+    }
+
+    if e <= cfg.primary_max_lateral_error_95_m {
+        FrameTrust::Trusted
+    } else if e <= cfg.fallback_max_lateral_error_95_m {
+        FrameTrust::Degraded
+    } else {
+        // Beyond the conservative-fallback bound → fail closed.
+        FrameTrust::Untrusted
+    }
+}
+
+/// The lateral containment margin (metres) for a frame-trust verdict, or `None`
+/// when the frame is [`FrameTrust::Untrusted`] and containment must refuse to
+/// validate.
+///
+/// Note the geometry direction: a *larger* margin is *stricter* (more inward),
+/// so `Degraded` (0.75 m) rejects MORE than `Trusted` (0.40 m). Graduation
+/// tightens safety under worse localization — it never loosens it.
+///
+/// O(1), no allocation (WCET-clean).
+// SAFETY: SG2 | REQ: frame-integrity-gate | TEST: margin_trusted_is_primary,margin_degraded_is_fallback,margin_untrusted_is_none,degraded_margin_is_stricter_than_trusted
+#[must_use]
+pub fn containment_margin_m(trust: FrameTrust) -> Option<f64> {
+    match trust {
+        FrameTrust::Trusted => Some(crate::containment::CONTAINMENT_LATERAL_MARGIN_M),
+        FrameTrust::Degraded => Some(CONTAINMENT_LATERAL_MARGIN_FALLBACK_M),
+        FrameTrust::Untrusted => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reported(lateral_error_95_m: f64, age_ms: u64) -> FrameIntegrity {
+        FrameIntegrity::Reported {
+            localization: LocalizationChannel {
+                lateral_error_95_m,
+                age_ms,
+            },
+        }
+    }
+
+    // --- resolve_frame_trust -------------------------------------------------
+
+    #[test]
+    fn unknown_is_untrusted() {
+        // Absent report ≠ healthy pose.
+        assert_eq!(
+            resolve_frame_trust(&FrameIntegrity::Unknown, &FrameIntegrityCfg::default()),
+            FrameTrust::Untrusted
+        );
+    }
+
+    #[test]
+    fn nonfinite_is_untrusted() {
+        let cfg = FrameIntegrityCfg::default();
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert_eq!(
+                resolve_frame_trust(&reported(bad, 0), &cfg),
+                FrameTrust::Untrusted,
+                "non-finite error must fail closed ({bad})"
+            );
+        }
+    }
+
+    #[test]
+    fn stale_is_untrusted() {
+        let cfg = FrameIntegrityCfg::default();
+        // Even a perfect ε is untrusted if the snapshot is stale.
+        assert_eq!(
+            resolve_frame_trust(&reported(0.0, cfg.max_age_ms + 1), &cfg),
+            FrameTrust::Untrusted
+        );
+    }
+
+    #[test]
+    fn primary_boundary_is_trusted() {
+        let cfg = FrameIntegrityCfg::default();
+        // ε exactly at the primary bound is Trusted (≤, inclusive).
+        assert_eq!(
+            resolve_frame_trust(&reported(cfg.primary_max_lateral_error_95_m, 0), &cfg),
+            FrameTrust::Trusted
+        );
+    }
+
+    #[test]
+    fn just_over_primary_is_degraded() {
+        let cfg = FrameIntegrityCfg::default();
+        assert_eq!(
+            resolve_frame_trust(&reported(cfg.primary_max_lateral_error_95_m + 1e-9, 0), &cfg),
+            FrameTrust::Degraded
+        );
+    }
+
+    #[test]
+    fn fallback_boundary_is_degraded() {
+        let cfg = FrameIntegrityCfg::default();
+        // ε exactly at the fallback bound is still Degraded (≤, inclusive).
+        assert_eq!(
+            resolve_frame_trust(&reported(cfg.fallback_max_lateral_error_95_m, 0), &cfg),
+            FrameTrust::Degraded
+        );
+    }
+
+    #[test]
+    fn just_over_fallback_is_untrusted() {
+        let cfg = FrameIntegrityCfg::default();
+        assert_eq!(
+            resolve_frame_trust(&reported(cfg.fallback_max_lateral_error_95_m + 1e-9, 0), &cfg),
+            FrameTrust::Untrusted
+        );
+    }
+
+    #[test]
+    fn fresh_at_max_age_is_not_stale() {
+        let cfg = FrameIntegrityCfg::default();
+        // age_ms == max_age_ms is fresh (the gate is `>`, not `>=`).
+        assert_eq!(
+            resolve_frame_trust(&reported(0.05, cfg.max_age_ms), &cfg),
+            FrameTrust::Trusted
+        );
+    }
+
+    // --- containment_margin_m ------------------------------------------------
+
+    #[test]
+    fn margin_trusted_is_primary() {
+        assert_eq!(
+            containment_margin_m(FrameTrust::Trusted),
+            Some(crate::containment::CONTAINMENT_LATERAL_MARGIN_M)
+        );
+    }
+
+    #[test]
+    fn margin_degraded_is_fallback() {
+        assert_eq!(
+            containment_margin_m(FrameTrust::Degraded),
+            Some(CONTAINMENT_LATERAL_MARGIN_FALLBACK_M)
+        );
+    }
+
+    #[test]
+    fn margin_untrusted_is_none() {
+        // Untrusted ⇒ containment must refuse to validate.
+        assert_eq!(containment_margin_m(FrameTrust::Untrusted), None);
+    }
+
+    #[test]
+    fn degraded_margin_is_stricter_than_trusted() {
+        // A larger margin is stricter (more inward). Graduation must TIGHTEN
+        // under worse localization, never loosen.
+        let trusted = containment_margin_m(FrameTrust::Trusted).unwrap();
+        let degraded = containment_margin_m(FrameTrust::Degraded).unwrap();
+        assert!(
+            degraded > trusted,
+            "fallback margin ({degraded}) must exceed primary ({trusted})"
+        );
+    }
+
+    #[test]
+    fn fallback_bound_above_primary_bound() {
+        // Config sanity: the bands must be ordered, else Degraded is unreachable.
+        let cfg = FrameIntegrityCfg::default();
+        assert!(cfg.fallback_max_lateral_error_95_m > cfg.primary_max_lateral_error_95_m);
+    }
+}

--- a/crates/kirra-core/src/kinematics_contract.rs
+++ b/crates/kirra-core/src/kinematics_contract.rs
@@ -257,6 +257,20 @@ pub enum DenyCode {
     /// and the actuator falls to the MRC controlled-stop. Issued by
     /// `enforce_degraded_decel_to_stop`. (Issue #70.)
     DegradedSpeedIncreaseDenied,
+    /// Safety: SG-002 ≅ SG2. Frame/localization integrity is UNTRUSTED this tick
+    /// (absent / stale / non-finite / 95th-pct lateral error beyond the
+    /// conservative-fallback bound), so the map-anchored corridor cannot be
+    /// trusted to be correctly placed relative to the ego. Containment refuses to
+    /// validate (it does not reason about geometry in an untrusted frame) and the
+    /// actuator falls to the MRC controlled-stop — the frame-trust-minimal
+    /// maneuver. Issued by `containment::validate_trajectory_containment_checked`
+    /// when the [`crate::frame_integrity::FrameTrust`] verdict is `Untrusted`.
+    /// (Stage S-FI1 — behind AOU-LOCALIZATION-001.)
+    ///
+    /// APPENDED LAST deliberately: the bincode variant index is the wire tag
+    /// (see `kirra-wire-client` `ClientDenyCode`), so existing indices 0–9 must
+    /// not shift.
+    FrameIntegrityUntrusted,
 }
 
 impl DenyCode {
@@ -276,6 +290,7 @@ impl DenyCode {
             Self::DrivableSpaceDeparture => "DRIVABLE_SPACE_DEPARTURE",
             Self::DegradedReinitiationDenied  => "DEGRADED_REINITIATION_DENIED",
             Self::DegradedSpeedIncreaseDenied => "DEGRADED_SPEED_INCREASE_DENIED",
+            Self::FrameIntegrityUntrusted     => "FRAME_INTEGRITY_UNTRUSTED",
         }
     }
 }
@@ -1217,6 +1232,8 @@ mod kinematics_contract_tests {
             // Issue #70 — Degraded decel-to-stop-and-hold reason codes.
             DenyCode::DegradedReinitiationDenied,
             DenyCode::DegradedSpeedIncreaseDenied,
+            // Stage S-FI1 — frame/localization-integrity gate (AOU-LOCALIZATION-001).
+            DenyCode::FrameIntegrityUntrusted,
         ];
         for code in all {
             assert_eq!(

--- a/crates/kirra-core/src/lib.rs
+++ b/crates/kirra-core/src/lib.rs
@@ -33,6 +33,14 @@ pub mod kinematics_contract;
 /// existing path (the ROS2 adapter, the planner) holds.
 pub mod containment;
 
+/// The fail-closed frame-integrity gate (Stage S-FI1a, behind AOU-LOCALIZATION-001) —
+/// the graduated localization-trust verdict (`FrameIntegrity` / `FrameTrust` /
+/// `resolve_frame_trust` / `containment_margin_m`) that selects the SG2 containment
+/// margin and (later sub-stages) drives the posture engine. Pure, scalar, WCET-clean;
+/// PROPOSED design of record in `docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md`.
+/// This sub-stage is the module only — it does not yet touch containment / posture / parko.
+pub mod frame_integrity;
+
 /// The shared non-finite governor-input guard (`all_finite`, the #410 convergence point).
 /// A dependency-free predicate every governor entry calls. Relocated here verbatim
 /// (de-monolith Stage 5); re-exported by `kirra_verifier::governor_guard` so the

--- a/crates/kirra-governor-service/src/main.rs
+++ b/crates/kirra-governor-service/src/main.rs
@@ -52,7 +52,7 @@ pub struct Verdict {
     pub reason_code: u32,
 }
 
-/// Stable numeric reason code: `0` = no breach (Accept / Clamp); `1..=10` map
+/// Stable numeric reason code: `0` = no breach (Accept / Clamp); `1..=11` map
 /// 1:1 to `DenyCode`. Kept as an explicit match so adding a `DenyCode` variant
 /// upstream forces a compile error here (no silent gap).
 fn reason_code(action: &EnforceAction) -> u32 {
@@ -76,6 +76,7 @@ fn deny_code_num(code: DenyCode) -> u32 {
         DenyCode::DrivableSpaceDeparture => 8,
         DenyCode::DegradedReinitiationDenied => 9,
         DenyCode::DegradedSpeedIncreaseDenied => 10,
+        DenyCode::FrameIntegrityUntrusted => 11,
     }
 }
 

--- a/crates/kirra-wire-client/src/lib.rs
+++ b/crates/kirra-wire-client/src/lib.rs
@@ -66,6 +66,7 @@ pub enum ClientDenyCode {
     DrivableSpaceDeparture,      // 7
     DegradedReinitiationDenied,  // 8
     DegradedSpeedIncreaseDenied, // 9
+    FrameIntegrityUntrusted,     // 10  (Stage S-FI1 — appended last; index = wire tag)
 }
 
 /// Mirror of core `EnforceAction` — variants in the SAME ORDER.
@@ -147,7 +148,7 @@ mod wire_layout {
     }
 
     #[test]
-    fn all_ten_deny_codes_pin_their_index() {
+    fn all_eleven_deny_codes_pin_their_index() {
         // Each DenyCode must encode at its declared position. The DenyBreach
         // inner index sits at byte offset 12 (seq[0..8] + DenyBreach-tag[8..12]).
         let codes = [
@@ -161,6 +162,7 @@ mod wire_layout {
             ClientDenyCode::DrivableSpaceDeparture,
             ClientDenyCode::DegradedReinitiationDenied,
             ClientDenyCode::DegradedSpeedIncreaseDenied,
+            ClientDenyCode::FrameIntegrityUntrusted, // 10 (Stage S-FI1)
         ];
         for (i, code) in codes.iter().enumerate() {
             let v = Verdict {

--- a/docs/analysis/KIRRA_GAP_ANALYSIS.md
+++ b/docs/analysis/KIRRA_GAP_ANALYSIS.md
@@ -1,0 +1,148 @@
+# Kirra — Competitive Gap Analysis
+
+*Where Kirra leads, matches, and lags the best-in-class — and what to build to get there.*
+
+**Date:** 2026-06-24
+**Status:** Strategy / external-benchmarking document (not a safety-case artifact)
+**Method:** Multi-source web research (fan-out search → source fetch → adversarial 3-vote verification of every external claim) fused with the Kirra codebase profile. Every external factual claim below carries a citation that survived independent verification. Claims that failed verification were dropped.
+
+> **Read this first — what kind of document this is.** This is a candid market/technical positioning analysis, not a marketing sheet and not a safety case. Where Kirra is aspirational rather than certified, it says so plainly. The single most important conclusion is in §1: **Kirra is not competing with full-stack AV systems or with certified RTOSes — it is a runtime-assurance + fleet-trust layer, and its true peers are a mix of one commercial niche, an academic research field, and a set of standards.**
+
+---
+
+## 1. Kirra's category and its true peers
+
+Kirra is a **distributed runtime-assurance (RTA) + fleet-trust/governance layer**. It is explicitly *not* a perception→planning→control stack; it wraps or sits beside one and treats the planner (e.g. Autoware/ROS 2) as an untrusted guest. That single architectural choice — an untrusted "advanced controller" supervised by a trusted fail-closed "safe controller" — places Kirra squarely in the **Simplex / Run-Time Assurance** lineage.
+
+This matters because it means Kirra's competitors are **not** Waymo, NVIDIA DRIVE, or Apex.Grace *as systems*. Its real peer set splits into four groups:
+
+| Peer group | Who | Relationship to Kirra |
+|---|---|---|
+| **A. Certified safety middleware / RTOS islands** | Apex.AI (Apex.Grace / Apex.OS Cert), Green Hills (INTEGRITY, µ-velOSity, µ-visor), BlackBerry QNX + TTTech Auto MotionWise, ETAS/EB/Vector AUTOSAR Adaptive, Wind River | **Not direct competitors — they are the layer *below* Kirra.** They provide the certified RTOS/partition Kirra wants to run *on*. Kirra is an application-layer governor; they are the foundation. They are also the bar Kirra is measured against on *certification*. |
+| **B. Runtime-assurance / Simplex frameworks** | SOTER on ROS, DARPA Assured Autonomy RTA work, NASA RTA, classic Simplex | **Kirra's true architectural peers.** Mostly academic/research, not productized. This is the category Kirra most directly *is*. |
+| **C. AI/LLM-output-to-actuator governance** | AgentSpec, RoboGuard | **Kirra's most novel and most contested frontier.** A live and fast-moving research area as of 2025 — Kirra is *not* alone here, contrary to an early hypothesis. |
+| **D. Fleet trust / attestation / OTA / cyber standards** | Uptane, TPM/DICE, ISO/SAE 21434, UNECE WP.29 R155/R156 | **The standards Kirra's trust layer should map to.** Kirra has the mechanisms; it lacks the standards alignment. |
+
+The headline framing for the owner: **Kirra is a credible, unusually complete *open-source RTA + fleet-trust governor*. Its differentiation is real (fail-closed-by-construction breadth, cryptographic fleet federation, LLM-output governance). Its gap is equally real and entirely predictable: none of it is independently certified, and the certified middleware vendors own the "trust" word in the automotive buyer's mind via paper Kirra doesn't have.**
+
+---
+
+## 2. Comparison matrix: Kirra vs the field
+
+Legend: ●●● strong / ●●○ partial / ●○○ nascent or absent. "Cert" = independent functional-safety certification.
+
+| Dimension | **Kirra** | Apex.Grace / Apex.OS (A) | Green Hills INTEGRITY (A) | QNX + MotionWise (A) | SOTER / academic RTA (B) | AgentSpec / RoboGuard (C) |
+|---|---|---|---|---|---|---|
+| Runtime safety model (Simplex/RTA) | ●●● governor + posture engine | ●○○ (substrate, not a monitor) | ●○○ (separation only) | ●●○ (deterministic sched.) | ●●● canonical AC/SC/decision | ●●○ (LLM-specific monitor) |
+| Fail-closed enforcement in code | ●●● (envelope-first clamp, NaN/Inf reject, decel-to-stop MRC, Unknown-deny) | ●●○ | ●●○ (freedom-from-interference) | ●●○ | ●●● | ●●○ |
+| Attestation / node trust | ●●● per-node Ed25519 challenge-response | ●○○ | ●●○ (secure boot ecosystem) | ●●○ (HSM/secure boot) | ○○○ | ○○○ |
+| Cryptographic fleet federation | ●●● signed cross-controller reports, nonce burn, generation reconciliation | ●○○ | ○○○ | ○○○ | ○○○ | ○○○ |
+| HA / redundancy / anti-split-brain | ●●● epoch-fenced promotion, watchdog escalation | ●●○ | ●●● | ●●● | ●○○ | ○○○ |
+| Real-time / WCET + certified RTOS partition | ●●○ **roadmap** (QNX partition, seqlock contract, WCET *methodology* + CI gate; host numbers indicative only) | ●●● ASIL-D runtime | ●●● ASIL-D separation kernel | ●●● ASIL-D RTOS + det. sched. | ●○○ | ○○○ |
+| Functional-safety **certification** | ●○○ **aspirational only — uncertified** | ●●● ASIL-D (SEooC) [1][6] | ●●● ASIL-D + SIL3 + EN50128/50657 SIL4 [4][5][7] | ●●● ASIL-D RTOS [3] | ○○○ | ○○○ |
+| AI/LLM-output governance | ●●● action filter + typed envelope gate, integrated into a fielded governor | ○○○ | ○○○ | ○○○ | ○○○ | ●●● (but research-only, narrow) [11][14] |
+| Cross-domain breadth (AV + robots + edge + industrial) | ●●● ROS2/DDS/Modbus/OPC-UA/CANopen | ●●○ (auto + some robotics) | ●●○ | ●○○ (auto SDV) | ●○○ (robotics) | ●●○ |
+| Openness | ●●● open source | ●○○ commercial | ○○○ proprietary | ●●● papers/open | ●●● papers/open |
+| Maturity / adoption | ●●○ pre-production, no field deployments cited | ●●● shipping in production programs | ●●● decades, safety-critical | ●●● production SDV | ●○○ research | ●○○ research |
+
+---
+
+## 3. Where Kirra LEADS / is genuinely differentiated
+
+These are specific and defensible — not marketing.
+
+1. **Breadth of fail-closed-by-construction enforcement in one open governor.** The academic RTA peers (SOTER) prove the *pattern* — an untrusted advanced controller defaulting to a verified safe controller on anomaly [8][9][10] — but as research artifacts. Kirra ships that pattern *plus* envelope-first clamping, NaN/Inf rejection at every entry, the "Degraded = controlled decel-to-stop-and-HOLD" MRC envelope, and an `Unknown`-command default-deny, as one coherent, testable codebase. The combination of RTA discipline + production-style invariants in open source is rare.
+
+2. **Cryptographic fleet *federation* is essentially uncontested in this peer set.** None of the certified-middleware vendors, none of the RTA frameworks, and none of the LLM-guardrail projects offer Ed25519-signed cross-controller trust reports with durable single-use nonce burn and generation-ordered reconciliation. This is Kirra's most distinctive systems-level capability. The closest *standards* (Uptane for OTA, TPM/DICE for attestation) solve adjacent problems, not live runtime fleet-posture trust.
+
+3. **Runtime attestation wired directly into the safety posture.** Per-node Ed25519 challenge-response gating a fleet posture engine (Nominal/Degraded/LockedOut over a DAG) is a stronger coupling of *identity* to *authority-to-act* than the middleware peers expose at the application layer. They give you secure boot and an HSM; Kirra gives you a live, revocable, posture-linked trust state.
+
+4. **LLM-output-to-actuator governance integrated into a real governor.** This frontier is *not* unique to Kirra — AgentSpec (a DSL of triggers/predicates/enforcement for LLM agents, spanning embodied agents and autonomous driving, ~ms overhead, 100% AV-compliance in eval) [11][12][13] and RoboGuard (two-stage guardrail cutting unsafe-plan execution from >92% to <3% under jailbreak) [14][15][16] are direct conceptual peers. **But** both are research prototypes focused on the LLM-reasoning layer. Kirra's differentiation is that its action filter is the *front door of a fail-closed kinematic governor*: even a "compliant" LLM action is still clamped by the envelope. Kirra fuses the AgentSpec/RoboGuard idea with the SOTER idea — that fusion is the novel part, not the LLM gating alone.
+
+---
+
+## 4. Where Kirra MATCHES the field
+
+- **The RTA architecture itself.** Kirra's untrusted-planner-as-guest + fail-closed-governor design is the textbook Simplex AC/SC/decision-module structure [8][9]. This is good company — it's the accepted academic approach — but it is *table stakes* within group B, not a differentiator there. Kirra matches; it doesn't exceed the conceptual state of the art.
+- **HA / anti-split-brain.** Epoch-fenced promotion via conditional-CAS is solid and on par with what mature middleware provides. Comparable, not ahead.
+- **Cross-domain transport.** ROS2 + DDS + Modbus/OPC-UA + CANopen is a genuinely broad integration surface, matching or exceeding the breadth of the commercial peers (most of which are automotive-first).
+
+---
+
+## 5. Where Kirra LAGS / has gaps vs best-in-class
+
+Candid and prioritized by how much they block real-world adoption.
+
+1. **No independent functional-safety certification — this is the dominant gap.** Apex.Grace is ISO 26262 **ASIL-D** certified as a SEooC [1]; Apex.OS Cert is **TÜV Nord** ASIL-D [6]; Green Hills INTEGRITY's separation kernel is pre-certified ASIL-D [7] and µ-velOSity carries ASIL-D + IEC 61508 SIL 3 + EN 50128/50657 SIL 4 [4]; QNX SDP 8 is a certified RTOS foundation [3]. Kirra's ISO 26262 / IEC 61508 mapping is **aspirational documentation, not a certificate.** Against safety-critical buyers, uncertified ≈ unusable for the actual safety function, regardless of code quality.
+
+2. **No certified RTOS/partition under the governor yet.** The QNX-partition + seqlock hypervisor contract + WCET methodology is a *roadmap*, and Kirra correctly marks its host WCET numbers as indicative (not target-validated). The peers already *run on* ASIL-D separation kernels [7] with deterministic time-triggered scheduling [3]. Until Kirra's governor executes on a certified partition with target-validated WCET, its real-time safety claims are unproven where it counts.
+
+3. **No tool qualification.** Certified offerings come with qualified toolchains (compilers, debuggers, libraries). Kirra's Rust toolchain is not qualified for safety use — a hard requirement for any ASIL claim.
+
+4. **No SOTIF (ISO 21448) story.** Kirra governs *commands*; it does not address performance limitations / insufficiencies of the nominal function (sensor/perception limitations in the absence of faults). Best-in-class AV safety cases treat SOTIF as co-equal with 26262.
+
+5. **No formal verification of the invariants.** Kirra's invariants are enforced and tested in code, but not machine-checked. Best-in-class RTA research increasingly pairs the safe controller with formal proofs (reachability, temporal-logic guarantees — cf. RoboGuard's temporal-logic specs [15]). Kirra's "formal-ish" should become "formal" for the core envelope/MRC logic.
+
+6. **No redundant/diverse sensing or independent assessment.** Kirra is single-channel logic. ASIL-D typically demands redundancy/diversity and an independent safety assessor. Neither is present.
+
+7. **No standards alignment for the trust layer.** Kirra's federation/attestation mechanisms are strong but not mapped to **ISO/SAE 21434** (cyber engineering) or **UNECE WP.29 R155/R156** (CSMS/SUMS), and its OTA/update trust is not aligned to **Uptane**. The mechanisms exist; the *conformance* doesn't.
+
+8. **Maturity/adoption.** No cited field deployments. The commercial peers are in production programs. This is expected for an open project but is a real go-to-market gap.
+
+---
+
+## 6. Standards landscape — what best-in-class compliance looks like
+
+| Standard | Scope | Best-in-class bar | Kirra today |
+|---|---|---|---|
+| **ISO 26262** | Automotive functional safety (E/E) | ASIL-D cert via accredited assessor (TÜV) [4][6][7] | Mapping docs only |
+| **ISO 21448 (SOTIF)** | Safety of the intended function (no-fault insufficiencies) | Documented SOTIF analysis + validation | Absent |
+| **IEC 61508** | Cross-industry functional safety (SIL) | SIL 3/4 cert [4] | Mapping docs only |
+| **UL 4600** | Safety case for autonomous products | Goal-based safety case w/ independent review | Not started |
+| **IEEE 2846 / RSS** | Formal assumptions for AV decision safety | RSS-style minimum-safe-distance model adopted/published | RSS-style checks present, not conformance-stated |
+| **ISO/SAE 21434** | Automotive cybersecurity engineering | CSMS + TARA + assessment | Strong mechanisms, no conformance |
+| **UNECE WP.29 R155/R156** | Type-approval CSMS/SUMS (mandatory in many markets) | Certified CSMS + SUMS | Not mapped |
+
+Best-in-class is a *portfolio*: 26262 (faults) **+** 21448 (insufficiencies) **+** 21434/R155 (security) **+** UL 4600 (overall safety case), each independently assessed. Kirra has the *engineering* for several but the *paper* for none.
+
+---
+
+## 7. Prioritized, phased roadmap to best-in-class in the niche
+
+Effort = rough order of magnitude. Impact = how much it moves Kirra toward credible/adoptable.
+
+### Phase 0 — Credibility hardening (0–3 mo, low effort, high impact)
+- **Publish the safety case as a UL-4600-style GSN argument**, explicitly stating what *is* and *is not* certified. Turns "aspirational" from a liability into honesty that buyers respect. *(Low / High)*
+- **Map the trust layer to ISO/SAE 21434 + Uptane** on paper; identify deltas. Cheap, and it converts existing mechanisms into a conformance narrative. *(Low / High)*
+- **Formalize the core envelope + MRC + `should_route_command` logic** (model-check the state machine / reachability of the decel-to-stop). Highest-leverage step toward "formal" vs "formal-ish." *(Med / High)*
+
+### Phase 1 — Make the real-time safety claim true (3–9 mo, high effort, high impact)
+- **Stand the governor up on a certified partition** (QNX SDP 8 or INTEGRITY) and produce **target-validated WCET** under FIFO scheduling — retire the "indicative" caveat for the hot path. This is the single biggest technical credibility unlock. *(High / High)*
+- **SOTIF (ISO 21448) analysis** for the perception-degradation derate (Track-C) and corridor containment — the natural place Kirra already touches insufficiencies. *(Med / High)*
+
+### Phase 2 — Earn the paper (9–24 mo, very high effort, decisive impact)
+- **Pursue ISO 26262 SEooC certification of the governor** (the bounded, O(1), no-alloc command path is the right scope — mirror Apex.Grace's SEooC strategy [1]). *(Very High / Decisive)*
+- **Tool qualification** for the Rust toolchain subset used in the certified scope. *(High / Required-for-cert)*
+- **Engage an independent safety assessor** and add redundancy/diversity to the safe-controller channel. *(High / Required-for-ASIL-D)*
+
+### Phase 3 — Extend the moat (parallel, opportunistic)
+- **Productize fleet federation as the headline feature** — it's the least-contested differentiator. Publish a protocol spec; pursue interop. *(Med / High)*
+- **Publish the LLM-governance + RTA fusion** (the AgentSpec/RoboGuard-meets-Simplex story) as a paper/benchmark to claim the frontier before it crowds. *(Med / Med-High)*
+
+**Minimum to be credible end-to-end:** Phase 0 + the QNX-partition/WCET item from Phase 1. **Minimum to win in the niche:** add Phase 2 SEooC certification of the governor and lead with federation.
+
+---
+
+## Sources
+
+All external claims below passed independent 3-vote adversarial verification; uncited statements are reasoning over Kirra's own profile.
+
+- [1] Apex.AI — Apex.Grace ISO 26262 ASIL-D (SEooC). https://www.apex.ai/apexgrace
+- [3] BlackBerry QNX + TTTech Auto — MotionWise Schedule for QNX SDP 8.0 (deterministic time-triggered scheduling on certified RTOS). https://www.tttech-auto.com/newsroom/blackberry-qnx-and-tttech-auto-launch-new-motionwise-scheduling-solution-qnx-8
+- [4][5] Green Hills Software — µ-velOSity (TÜV Nord: ISO 26262 ASIL-D, IEC 61508 SIL 3, EN 50128/50657 SIL 4) and µ-visor hypervisor. https://www.businesswire.com/news/home/20250311164318/en/Green-Hills-Software-Expands-Its-Safety-Certified-Solutions-for-Microcontrollers-with-a-Focus-on-Automotive-and-Industrial-Markets
+- [6][7] Green Hills + Apex.AI — Apex.OS Cert TÜV Nord ASIL-D; INTEGRITY separation kernel pre-certified ASIL-D. https://ghs.com/news/20220105_CES_Integrity_Apex_OS_ASIL_D_driving.html
+- [8][9][10] SOTER on ROS — Simplex/RTA framework (AC + safe controller + decision module). https://arxiv.org/pdf/2008.09707
+- [11][12][13] AgentSpec — runtime enforcement DSL for LLM agents (embodied + autonomous driving). https://arxiv.org/abs/2503.18666
+- [14][15][16] RoboGuard — two-stage runtime guardrail for LLM-enabled robots. https://arxiv.org/abs/2503.07885
+
+*Note on research limits:* several primary-source pages (Mobileye RSS, IEEE 2846, NVIDIA Halos, Uptane, UNECE R155 explainers) were reached but returned no independently verifiable extracted claims in this run and are treated as background, not citations. RSS/IEEE 2846 and Uptane/21434/WP.29 specifics in §6 reflect established domain knowledge, not freshly verified quotes — re-verify before external publication.

--- a/docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md
+++ b/docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md
@@ -1,0 +1,260 @@
+# Stage S-FI1 — Unified Frame-Integrity Gate (kirra-core)
+
+**Status:** PROPOSED — design-for-review. No code written. Awaiting owner sign-off before implementation, per de-monolith stage discipline.
+**Date:** 2026-06-24
+**Owner:** Kirra Systems, LLC
+**Scope:** Promote localization-integrity from a parko-only self-report gate into a first-class, fail-closed **frame-integrity input** in `kirra-core`, wired into the SG2 containment check and the posture engine. Closes the gap behind **AOU-LOCALIZATION-001** by turning a static margin *assumption* into a runtime *check*.
+**Future decision of record:** ADR-0016 (to be filed on acceptance).
+
+---
+
+## 1. Problem (grounded)
+
+`validate_trajectory_containment` (`crates/kirra-core/src/containment.rs:194`) takes a `&[Pose]`, a `&Corridor`, and a `&VehicleFootprint`. It checks `pose_is_finite` (NaN/Inf only — `:234`) and asserts every footprint corner is inside the corridor polygon by at least `CONTAINMENT_LATERAL_MARGIN_M = 0.40 m` (`:66`). **It has no localization-integrity input.** The 0.40 m margin is a *static* discharge of a *runtime* property: it is sized assuming the integrator holds ≤ 0.10 m 95th-pct lateral error (`AOU-LOCALIZATION-001`).
+
+This is the **one fault class the governor structurally cannot catch**, because localization is the governor's *own* coordinate-frame input: a pose error silently mislocates the corridor and *every* map-anchored veto, and the checker validates against the wrong world without any single check observing the fault. The safety case already states this (`ASSUMPTIONS_OF_USE.md:660`).
+
+Integrity logic *does* exist — but only in parko (`parko/crates/parko-core/src/localization.rs`), as a **binary self-report gate** (`localization_trusted() -> bool`, `:79`) feeding only parko's discrete map-anchored scene gates (`gate_commit_zone_scene`, `gate_water_scene`). The main verifier never sees it.
+
+## 2. Design principle
+
+Apply Kirra's own thesis to localization: **you don't need great localization to be safe; you need to detect untrustworthy localization and fail closed — then grow the doer (EKF → SLAM) behind that gate.** Build the checker first; the localization *capability* becomes a doer bounded by an integrity checker, exactly like the planner.
+
+Four design commitments (the deltas from a naive "lift parko's bool up"):
+
+1. **Graduated, not binary.** kirra-core already encodes three regimes (0.40 m primary / 0.75 m fallback / fail-closed). The unified gate selects the margin from the *reported error value*; it does not flatten to a bool.
+2. **Frame-integrity, not localization-only.** Calibration error and time-sync skew manifest *as* pose error in the fused frame (`AOU-TIMESYNC-001`). The input is named and shaped for the whole frame-defining class, with localization as the first (dominant) channel.
+3. **Honest about self-report.** This *narrows* AOU-LOCALIZATION-001 to a *checked self-report*; it does not eliminate it. Independent KIRRA-computed integrity (map-matching residual / multi-source divergence) is the named follow-on, not this stage.
+4. **Two consumers, two thresholds, one input.** Containment may run in the fallback band (0.75 m). The discrete map-anchored vetoes (commit-zone, water earn-back) may **not** — they require strict `Trusted`. The unified type makes that asymmetry explicit and intentional.
+
+---
+
+## 3. New types (`crates/kirra-core/src/frame_integrity.rs`, new module)
+
+```rust
+/// One channel of the ego coordinate-frame's integrity. Localization is the
+/// first and dominant channel; calibration / time-sync are reserved siblings
+/// (Stage S-FI2) so the enum shape never has to change to add them.
+#[derive(Debug, Clone, Copy)]
+pub struct LocalizationChannel {
+    /// 95th-percentile lateral (cross-track) position error, metres.
+    /// Non-finite → fail closed (an unverifiable pose is no pose).
+    pub lateral_error_95_m: f64,
+    /// Age (ms) of this snapshot vs now. Above cfg bound → stale → fail closed.
+    pub age_ms: u64,
+}
+
+/// What the integrator's frame-integrity channel reports THIS tick.
+/// Mirrors the established ABSENT-vs-KNOWN discipline (cf. `Corridor`,
+/// parko `LocalizationIntegrity`): an ABSENT report is NOT a healthy frame.
+#[derive(Debug, Clone, Copy)]
+pub enum FrameIntegrity {
+    /// No report this tick → NOT trusted (absent ≠ healthy; the #238 trap).
+    Unknown,
+    Reported {
+        localization: LocalizationChannel,
+        // RESERVED (Stage S-FI2): calibration: Option<CalibrationChannel>,
+        //                         time_sync:   Option<TimeSyncChannel>,
+    },
+}
+
+/// Graduated verdict. Maps 1:1 to a containment margin AND a posture class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameTrust {
+    /// ε ≤ primary bound, fresh, finite → PRIMARY margin (0.40 m), Nominal.
+    Trusted,
+    /// primary < ε ≤ fallback bound, fresh, finite → FALLBACK margin (0.75 m),
+    /// posture Degraded. "Wrong but bounded": we widen the margin to absorb the
+    /// larger error and keep moving conservatively.
+    Degraded,
+    /// absent / stale / non-finite / ε > fallback → containment refuses to
+    /// validate; MRC controlled-stop. (Posture mapping: §6.)
+    Untrusted,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FrameIntegrityCfg {
+    /// ε ≤ this → Trusted. Default 0.10 m — the G2 AoU bound the 0.40 m primary
+    /// containment margin is derived against (KIRRA-OCCY-SG2-MARGIN-001).
+    pub primary_max_lateral_error_95_m: f64,
+    /// primary < ε ≤ this → Degraded. Default 0.30 m — the urban-canyon
+    /// worst-case the 0.75 m fallback margin is derived against
+    /// (OCCY_SG2_MARGIN.md §2/§3).
+    pub fallback_max_lateral_error_95_m: f64,
+    /// Staleness bound (ms). Default 500 — VALIDATION-PENDING; tie to per-cycle
+    /// FTTI on integration (matches parko `LocalizationCfg` default).
+    pub max_age_ms: u64,
+}
+
+impl Default for FrameIntegrityCfg {
+    fn default() -> Self {
+        Self {
+            primary_max_lateral_error_95_m: 0.10,
+            fallback_max_lateral_error_95_m: 0.30,
+            max_age_ms: 500,
+        }
+    }
+}
+```
+
+### Resolver + margin selection (both O(1), no alloc — fits `wcet_gate`)
+
+```rust
+// SAFETY: SG2 | REQ: frame-integrity-gate | TEST: see §7
+#[must_use]
+pub fn resolve_frame_trust(integrity: &FrameIntegrity, cfg: &FrameIntegrityCfg) -> FrameTrust {
+    let LocalizationChannel { lateral_error_95_m: e, age_ms } = match *integrity {
+        FrameIntegrity::Unknown => return FrameTrust::Untrusted,
+        FrameIntegrity::Reported { localization } => localization,
+    };
+    if !e.is_finite() || age_ms > cfg.max_age_ms {
+        return FrameTrust::Untrusted;           // unverifiable / stale → fail closed
+    }
+    if e <= cfg.primary_max_lateral_error_95_m  { FrameTrust::Trusted }
+    else if e <= cfg.fallback_max_lateral_error_95_m { FrameTrust::Degraded }
+    else { FrameTrust::Untrusted }              // beyond fallback → fail closed
+}
+
+/// PRIMARY stays the existing constant (audit/derivation stability). FALLBACK
+/// is the documented conservative margin, promoted from doc to code.
+pub const CONTAINMENT_LATERAL_MARGIN_M: f64 = 0.40;          // unchanged
+pub const CONTAINMENT_LATERAL_MARGIN_FALLBACK_M: f64 = 0.75; // new
+
+/// `None` ⇒ do not validate; fail closed.
+#[must_use]
+pub fn containment_margin_m(trust: FrameTrust) -> Option<f64> {
+    match trust {
+        FrameTrust::Trusted   => Some(CONTAINMENT_LATERAL_MARGIN_M),
+        FrameTrust::Degraded  => Some(CONTAINMENT_LATERAL_MARGIN_FALLBACK_M),
+        FrameTrust::Untrusted => None,
+    }
+}
+```
+
+---
+
+## 4. Containment change (`crates/kirra-core/src/containment.rs`)
+
+New `DenyCode` variant (`kinematics_contract.rs:221`; existing variants/strings untouched → audit-chain hash stability preserved):
+
+```rust
+/// Safety: SG-002 ≅ SG2. Frame/localization integrity is untrusted this tick
+/// (absent / stale / non-finite / lateral error beyond the fallback bound), so
+/// the map-anchored corridor cannot be trusted to be correctly placed relative
+/// to the ego. Containment refuses to validate. Issued by
+/// `validate_trajectory_containment` when `FrameTrust::Untrusted`.
+FrameIntegrityUntrusted,        // reason(): "FRAME_INTEGRITY_UNTRUSTED"
+```
+
+Signature gains **one parameter** (`frame_trust`); the margin becomes a local instead of a const:
+
+```rust
+pub fn validate_trajectory_containment(
+    trajectory: &[Pose],
+    corridor: &Corridor,
+    footprint: &VehicleFootprint,
+    frame_trust: FrameTrust,        // NEW
+) -> EnforceAction {
+    let margin = match containment_margin_m(frame_trust) {
+        Some(m) => m,
+        None => return EnforceAction::DenyBreach(DenyCode::FrameIntegrityUntrusted),
+    };
+    // ... existing corridor.is_healthy() / horizon / footprint_is_finite gates UNCHANGED ...
+    let margin_sq = margin * margin;            // was: CONTAINMENT_LATERAL_MARGIN_M²
+    // ... existing per-pose corner loop UNCHANGED ...
+}
+```
+
+Note the geometry direction: a *larger* margin is *stricter* (more inward), so `Degraded` (0.75 m) **rejects more** than `Trusted` (0.40 m). Graduation tightens safety under worse localization — it never loosens it.
+
+---
+
+## 5. parko re-point (`parko/crates/parko-core/src/localization.rs`)
+
+parko's binary scene gates (`gate_commit_zone_scene`, `gate_water_scene`) keep their `bool` signature. The canonical type/cfg move to kirra-core; parko consumes a **strict** bool view:
+
+```rust
+pub use kirra_core::frame_integrity::{FrameIntegrity, FrameIntegrityCfg, FrameTrust, resolve_frame_trust};
+
+/// Map-anchored discrete vetoes require STRICT trust — `Degraded` (the 0.75 m
+/// band) is good enough for *continuous* containment but NOT for trusting a
+/// mapped commit-zone / ford LOCATION. Hence: Trusted only.
+pub fn localization_trusted(integrity: &FrameIntegrity, cfg: &FrameIntegrityCfg) -> bool {
+    matches!(resolve_frame_trust(integrity, cfg), FrameTrust::Trusted)
+}
+```
+
+parko's existing `test_loc_*` tests become adapter tests over the unified resolver (same boundary cases; `Degraded` band now asserts `localization_trusted == false`, which is the existing 0.10 m semantics preserved). `gate_commit_zone_scene` / `gate_water_scene` and their tests are **unchanged**.
+
+---
+
+## 6. Posture wiring (`src/posture_engine_v2.rs`)
+
+New reason + trigger (existing variants untouched):
+
+```rust
+// LockoutReason (:21)
+FrameIntegrityUntrusted,    // "FRAME_INTEGRITY_UNTRUSTED"
+
+// PostureRecalcTrigger (:165)
+FrameIntegrityChanged { trust: FrameTrust },
+```
+
+**Posture mapping — the one decision flagged for review:**
+
+| `FrameTrust` | Containment | Posture | Recovery |
+|---|---|---|---|
+| `Trusted` | 0.40 m | Nominal | — |
+| `Degraded` | 0.75 m | **Degraded** (decel-to-stop-HOLD MRC) | automatic on return to `Trusted` |
+| `Untrusted` (transient) | refuse → MRC stop | **Degraded** (MRC) | automatic on reacquire |
+| `Untrusted` (sustained / flapping) | refuse → MRC stop | **LockedOut** | human reset |
+
+Rationale: localization loss (GNSS dropout, NDT divergence) is a classic *transient* — forcing a human reset on every dropout is operationally untenable and not safety-required (the vehicle is already safely stopped). So transient `Untrusted` → Degraded-MRC (auto-recover); **sustained/flapping** `Untrusted` escalates to LockedOut by **reusing the existing AV recovery-hysteresis machinery** (`recovery_hysteresis.rs`: streak/window, `AV_RECOVERY_*`). This keeps the decel-to-stop-and-HOLD semantics self-consistent: Degraded posture + containment-refuses = exactly the decel-to-stop MRC the governor already authors, and the governor never authors re-acceleration.
+
+**Open question for you:** confirm transient `Untrusted` → Degraded (not straight to LockedOut). I believe Degraded-with-escalation is correct and matches SS-002, but it's the load-bearing choice in this stage.
+
+---
+
+## 7. Call sites — the four enforcement points
+
+Each must source a `FrameIntegrity` for the tick and pass `resolve_frame_trust(...)` into containment. **Sourcing the integrity report at each point is where the integrator contract surfaces** and is the bulk of the integration work:
+
+1. **gateway** `enforce_actuator_safety_envelope` — frame-integrity from the perception input contract alongside the corridor.
+2. **fabric** `AssetGovernor::evaluate_command` — per-asset integrity in the command envelope.
+3. **ros2-adapter** `validate_trajectory_slow` — integrity from the ROS2 localization-quality topic.
+4. **parko-kirra** `KirraGovernor::apply_mrc_profile` — already has `LocalizationIntegrity`; re-point to the unified type.
+
+A temporary `validate_trajectory_containment_assuming_trusted(...)` shim (delegates with `FrameTrust::Trusted`, `#[doc(hidden)]`, deny-listed in CI) may be used to keep tests/benches compiling during the call-site migration, removed at stage close. No production path keeps it.
+
+---
+
+## 8. Test matrix
+
+**`resolve_frame_trust`:** Unknown→Untrusted; non-finite ε→Untrusted; `age > max_age`→Untrusted; ε=0.10 (boundary)→Trusted; ε=0.10+δ→Degraded; ε=0.30 (boundary)→Degraded; ε=0.30+δ→Untrusted.
+**`containment_margin_m`:** Trusted→0.40; Degraded→0.75; Untrusted→None.
+**`validate_trajectory_containment`:** Untrusted→`DenyBreach(FrameIntegrityUntrusted)`; near-edge pose that **passes at 0.40 but fails at 0.75** (proves graduation tightens); Trusted pose centred→Allow; existing containment tests get `FrameTrust::Trusted` and must stay green (no regression).
+**parko asymmetry (key):** ε in (0.10, 0.30] → containment Allows (Degraded/0.75) **but** `gate_commit_zone_scene → Unknown` (strict view false). This single test captures the two-thresholds-one-input design.
+**Posture:** Degraded trust → Degraded posture; transient Untrusted → Degraded; sustained Untrusted via hysteresis → LockedOut.
+
+## 9. Safety-case updates
+
+- **AOU-LOCALIZATION-001** (`ASSUMPTIONS_OF_USE.md:650`): status → *narrowed* — "pose is correct" becomes "the frame-integrity self-report is honest and correctly characterized"; graduated primary/fallback regimes are now runtime-selected, not statically assumed; sustained-untrusted → LockedOut. Remains **AoU-GAP** (self-report).
+- **New AOU-FRAME-INTEGRITY-SELFREPORT-001** (OPEN): the integrity channel is integrator self-reported; independent KIRRA-computed integrity (map-matching residual, multi-source divergence, RAIM-style cross-check) is the de-risking endgame — **Stage S-FI3**, not this stage.
+- **AOU-TIMESYNC-001**: cross-reference — the reserved `time_sync`/`calibration` channels (Stage S-FI2) are the runtime home for its frame-affecting component.
+- New `wcet_gate` rows for `resolve_frame_trust` / `containment_margin_m` (O(1), branch-only, no alloc).
+
+## 10. What this stage explicitly does NOT do
+
+- No EKF / GNSS-IMU fusion / SLAM (the *doer* — built behind this gate later).
+- No independent integrity computation (Stage S-FI3).
+- No calibration/time-sync channels (reserved shape only; Stage S-FI2).
+- No change to the Nominal WCET-critical `validate_vehicle_command` path.
+
+## 11. Sequencing
+
+S-FI1a: `frame_integrity` module + types + resolver + tests (kirra-core, no call-site change; shim in place).
+S-FI1b: containment signature + `DenyCode` + tests.
+S-FI1c: parko re-point.
+S-FI1d: posture wiring + hysteresis escalation.
+S-FI1e: four call sites + integrator-contract surfacing; remove shim.
+S-FI1f: safety-case/AoU updates; ADR-0016 to Accepted.

--- a/docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md
+++ b/docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md
@@ -180,14 +180,23 @@ New `DenyCode` variant (`kinematics_contract.rs:221`; existing variants/strings 
 FrameIntegrityUntrusted,        // reason(): "FRAME_INTEGRITY_UNTRUSTED"
 ```
 
-Signature gains **one parameter** (`frame_trust`); the margin becomes a local instead of a const:
+**As-built note (S-FI1b):** to keep the four call sites compiling *untouched*
+(the "held before call sites" constraint), the gated logic went into a **new**
+4-arg entry `validate_trajectory_containment_checked(.., frame_trust)`, and the
+existing `validate_trajectory_containment(traj, corridor, footprint)` was demoted
+to a **trust-asserting shim** that delegates with `FrameTrust::Trusted`. This is
+behaviourally identical to "signature gains one param + `_assuming_trusted` shim"
+but inverts which name is the shim, so existing callers need zero edits now.
+S-FI1e flips callers to `_checked` (with a resolved trust), then collapses the
+names (the gated entry becomes `validate_trajectory_containment`, shim removed).
 
 ```rust
-pub fn validate_trajectory_containment(
+#[must_use]
+pub fn validate_trajectory_containment_checked(
     trajectory: &[Pose],
     corridor: &Corridor,
     footprint: &VehicleFootprint,
-    frame_trust: FrameTrust,        // NEW
+    frame_trust: FrameTrust,        // NEW gated entry
 ) -> EnforceAction {
     let margin = match containment_margin_m(frame_trust) {
         Some(m) => m,
@@ -196,6 +205,14 @@ pub fn validate_trajectory_containment(
     // ... existing corridor.is_healthy() / horizon / footprint_is_finite gates UNCHANGED ...
     let margin_sq = margin * margin;            // was: CONTAINMENT_LATERAL_MARGIN_M²
     // ... existing per-pose corner loop UNCHANGED ...
+}
+
+/// Trust-asserting shim (carries AOU-LOCALIZATION-001 inline until S-FI1e).
+#[must_use]
+pub fn validate_trajectory_containment(
+    trajectory: &[Pose], corridor: &Corridor, footprint: &VehicleFootprint,
+) -> EnforceAction {
+    validate_trajectory_containment_checked(trajectory, corridor, footprint, FrameTrust::Trusted)
 }
 ```
 
@@ -285,7 +302,12 @@ Each must source a `FrameIntegrity` for the tick and pass `resolve_frame_trust(.
 3. **ros2-adapter** `validate_trajectory_slow` — integrity from the ROS2 localization-quality topic.
 4. **parko-kirra** `KirraGovernor::apply_mrc_profile` — already has `LocalizationIntegrity`; re-point to the unified type.
 
-A temporary `validate_trajectory_containment_assuming_trusted(...)` shim (delegates with `FrameTrust::Trusted`, `#[doc(hidden)]`, deny-listed in CI) may be used to keep tests/benches compiling during the call-site migration, removed at stage close. No production path keeps it.
+**As-built (S-FI1b):** the shim role is filled by the existing
+`validate_trajectory_containment` (3-arg) delegating with `FrameTrust::Trusted`
+(see §4), so all four call sites compile **unchanged** at S-FI1b. S-FI1e sources a
+real `FrameIntegrity` at each point, switches the call to `_checked`, then
+collapses the names and removes the shim. No production path keeps the shim past
+stage close.
 
 ---
 
@@ -315,8 +337,8 @@ A temporary `validate_trajectory_containment_assuming_trusted(...)` shim (delega
 
 ## 11. Sequencing
 
-S-FI1a: `frame_integrity` module + types + resolver + tests (kirra-core, no call-site change; shim in place).
-S-FI1b: containment signature + `DenyCode` + tests.
+S-FI1a: ✅ DONE — `frame_integrity` module + types + resolver + tests (kirra-core, no call-site change).
+S-FI1b: ✅ DONE — gated `validate_trajectory_containment_checked` + trust-asserting shim; `DenyCode::FrameIntegrityUntrusted` (appended last); forced matches discharged (`reason()` + display test, governor-service `deny_code_num` → 11, wire-client `ClientDenyCode` mirror + drift test); 3 new containment tests (untrusted-refuses, degraded-stricter-than-trusted, shim==checked). Workspace compiles (default features); call sites untouched.
 S-FI1c: parko re-point.
 S-FI1d: posture wiring + hysteresis escalation.
 S-FI1e: four call sites + integrator-contract surfacing; remove shim.

--- a/docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md
+++ b/docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md
@@ -1,5 +1,13 @@
 # Stage S-FI1 — Unified Frame-Integrity Gate (kirra-core)
 
+> ## ⚠ PROPOSED — NOT A SAFETY CLAIM
+> This document is a **design proposal**. It is **not implementation** and confers
+> **no safety coverage** until **ACCEPTED via ADR-0016** and all sub-stages
+> (S-FI1a–f) have landed. **The RTM / `TRACEABILITY_MATRIX` must NOT list S-FI1
+> (or its SGs / `DenyCode::FrameIntegrityUntrusted`) as ENFORCED until S-FI1f.**
+> A PROPOSED safety doc in `docs/safety/` is fine; a PROPOSED doc *counted as
+> coverage* is the failure mode this banner exists to prevent.
+
 **Status:** PROPOSED — design-for-review. No code written. Awaiting owner sign-off before implementation, per de-monolith stage discipline.
 **Date:** 2026-06-24
 **Owner:** Kirra Systems, LLC
@@ -131,6 +139,32 @@ pub fn containment_margin_m(trust: FrameTrust) -> Option<f64> {
 }
 ```
 
+### Finding — staleness × speed are coupled through the margin (keep the defaults honest)
+
+The defaults (0.30 m fallback, 500 ms staleness) are **documented, sourced,
+VALIDATION-PENDING placeholders** — *not* manufactured FTTI numbers. We do **not**
+tie them to a specific FTTI now: the localization-path FTTI is unallocated, and
+inventing one would be false precision violating the project's host-indicative
+vs QNX-target-FIFO discipline (the `TBD-QNX-TARGET` pattern). They are recorded as
+named, sourced, pending constants with their derivation dependency, to be resolved
+by a later FTTI allocation — not re-guessed.
+
+But the fixed `max_age_ms` quietly hides a coupling the spec must name so nobody
+reads it as "safe at any speed": **a stale pose is unobserved travel, and
+unobserved travel consumes the containment margin.** A 500 ms-stale pose at 5 m/s
+is **2.5 m** of unobserved motion — which blows the 0.75 m fallback margin. The
+honest invariant is:
+
+> `max_stale_travel ≤ margin`  ⇒  the staleness bound is only safe below
+> `v ≈ margin / max_age` (≈ **1.5 m/s** at 0.75 m / 500 ms).
+
+Above that speed you must either tighten staleness or **cap speed under degraded
+localization**. The 500 ms is a fine *liveness* placeholder; it is **not** a
+standalone safety bound. This coupling is exactly what the eventual FTTI allocation
+(and any degraded-localization speed cap) must resolve — captured here so the
+placeholder stays honest in the interim. *(Speed-cap-under-degraded-localization is
+a tracked follow-on, not S-FI1.)*
+
 ---
 
 ## 4. Containment change (`crates/kirra-core/src/containment.rs`)
@@ -209,9 +243,36 @@ FrameIntegrityChanged { trust: FrameTrust },
 | `Untrusted` (transient) | refuse → MRC stop | **Degraded** (MRC) | automatic on reacquire |
 | `Untrusted` (sustained / flapping) | refuse → MRC stop | **LockedOut** | human reset |
 
-Rationale: localization loss (GNSS dropout, NDT divergence) is a classic *transient* — forcing a human reset on every dropout is operationally untenable and not safety-required (the vehicle is already safely stopped). So transient `Untrusted` → Degraded-MRC (auto-recover); **sustained/flapping** `Untrusted` escalates to LockedOut by **reusing the existing AV recovery-hysteresis machinery** (`recovery_hysteresis.rs`: streak/window, `AV_RECOVERY_*`). This keeps the decel-to-stop-and-HOLD semantics self-consistent: Degraded posture + containment-refuses = exactly the decel-to-stop MRC the governor already authors, and the governor never authors re-acceleration.
+**The drop to Degraded is IMMEDIATE — fail-closed on the FIRST `Untrusted` tick.**
+There is **no grace period** on the initial response. Hysteresis governs ONLY the
+*Degraded → LockedOut escalation* (and the *earn-back* to Trusted) — never a delay
+on the initial fail-closed. Fail-closed-immediately and auto-recovery are separate
+axes; this stage must not conflate them.
 
-**Open question for you:** confirm transient `Untrusted` → Degraded (not straight to LockedOut). I believe Degraded-with-escalation is correct and matches SS-002, but it's the load-bearing choice in this stage.
+**Why Degraded is the *correct* response, not merely the convenient one.**
+Degraded's MRC — decel-to-stop along the current heading — is the
+**frame-trust-minimal maneuver**: braking on your current path is a *relative*
+action (IMU / wheel-odometry: slow down, hold heading) that **does not depend on
+the untrusted global pose**. So when localization is lost, "stop where you are" is
+precisely the action that needs the *least* of the thing you have lost. That is
+why straight-to-LockedOut would be *over*-conservative: it would demand a human
+reset to perform the one maneuver that was always safe to do *without* trustworthy
+localization. Degraded here is the safety-correct posture, not just the usable one.
+
+**The escalation is the honest part.** *Sustained* or *flapping* `Untrusted` is a
+**fault signature, not a transient** — a genuine sensor failure, or (worth naming
+explicitly) **possible GNSS spoofing** — and that earns LockedOut / human-reset.
+Reuse the existing machinery: an **inverted streak** over `recovery_hysteresis.rs`
+(N consecutive `Untrusted` ticks, or `Untrusted` persisting past a bounded window)
+plus the existing flapping detector (`fleet/flapping`). Net: **instant Degraded →
+auto-recover if transient → escalate to LockedOut if it persists/flaps.** This is
+consistent with SS-002 and keeps the decel-to-stop-and-HOLD semantics
+self-consistent (Degraded + containment-refuses = exactly the MRC the governor
+already authors; the governor never authors re-acceleration).
+
+**Decision: CONFIRMED** (owner, 2026-06-24) — immediate Degraded, hysteretic
+escalation to LockedOut, with the frame-trust-minimal-maneuver rationale above as
+the safety argument of record.
 
 ---
 
@@ -242,6 +303,8 @@ A temporary `validate_trajectory_containment_assuming_trusted(...)` shim (delega
 - **New AOU-FRAME-INTEGRITY-SELFREPORT-001** (OPEN): the integrity channel is integrator self-reported; independent KIRRA-computed integrity (map-matching residual, multi-source divergence, RAIM-style cross-check) is the de-risking endgame — **Stage S-FI3**, not this stage.
 - **AOU-TIMESYNC-001**: cross-reference — the reserved `time_sync`/`calibration` channels (Stage S-FI2) are the runtime home for its frame-affecting component.
 - New `wcet_gate` rows for `resolve_frame_trust` / `containment_margin_m` (O(1), branch-only, no alloc).
+- **RTM guardrail:** `TRACEABILITY_MATRIX` must NOT count S-FI1 / its SGs / `DenyCode::FrameIntegrityUntrusted` as ENFORCED until S-FI1f lands (see top banner).
+- **Record the staleness × speed coupling** (§3 Finding) as an open derivation dependency on the localization-path FTTI allocation, with degraded-localization speed-cap as the tracked follow-on.
 
 ## 10. What this stage explicitly does NOT do
 


### PR DESCRIPTION
## Summary

Two threads of work:

1. **Strategy docs** — a cited competitive gap analysis and the design that fell out of it.
2. **Stage S-FI1 (a + b)** — the first code: a fail-closed **frame-integrity gate** in `kirra-core` behind `AOU-LOCALIZATION-001`, wired into the SG2 containment check. Built in small, independently reviewable sub-stages; **held before the four enforcement call sites** (they compile untouched via a trust-asserting shim).

Also carries one pre-existing build-hygiene commit (`569683f`) that was already on this branch.

## Why the frame-integrity gate

`validate_trajectory_containment` reasons about the ego footprint inside a map-anchored corridor, but had **no localization-integrity input** — the 0.40 m margin statically *assumed* the integrator holds ≤ 0.10 m lateral error (`AOU-LOCALIZATION-001`). Localization is the one fault class the governor structurally cannot otherwise catch, because it is the governor's *own* coordinate-frame input: a wrong pose silently mislocates the corridor and every map-anchored veto, and the checker validates against the wrong world. This stage turns that static *assumption* into a runtime *check*.

Integrity logic already existed in parko as a binary self-report gate; this promotes it into `kirra-core` as a first-class, **graduated** verdict.

## What's in it

**S-FI1a — pure module** (`crates/kirra-core/src/frame_integrity.rs`)
- `FrameIntegrity` / `LocalizationChannel` (reserved calibration + time-sync siblings) / `FrameTrust` / `FrameIntegrityCfg`.
- `resolve_frame_trust()` — fail-closed on absent / non-finite / stale / beyond-fallback.
- `containment_margin_m()` — graduated **0.40 primary / 0.75 fallback / None = refuse**.
- O(1), scalar, no-alloc (WCET-clean). 13 boundary-exact unit tests.

**S-FI1b — containment wiring**
- `DenyCode::FrameIntegrityUntrusted` — **appended last** (the bincode variant index is the wire tag; existing indices must not shift).
- `validate_trajectory_containment_checked(.., frame_trust)` — frame gate runs **first** (`Untrusted` → refuse before any geometry); margin selected from the verdict. A *larger* margin is *stricter*, so `Degraded` rejects strictly more than `Trusted` — graduation tightens safety, never loosens it.
- Existing `validate_trajectory_containment` demoted to a 3-arg **trust-asserting shim** (`FrameTrust::Trusted`) so the four call sites are untouched until S-FI1e.
- Forced exhaustive matches discharged (no silent gap): governor-service `deny_code_num`, wire-client `ClientDenyCode` mirror + drift test, the display-token test. QNX judge unaffected (own `VERDICT_*` codes).

**Docs**
- `docs/analysis/KIRRA_GAP_ANALYSIS.md` — Kirra vs best-in-class (RTA/Simplex, certified middleware, LLM-output governance, fleet-trust standards); every external claim independently verified.
- `docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md` — the full stage spec.

## Safety notes for reviewers

- **The stage spec is `PROPOSED`, not a safety claim.** It carries an unmissable banner and an RTM guardrail: S-FI1 / its SGs / `DenyCode::FrameIntegrityUntrusted` must **not** be counted as ENFORCED in `TRACEABILITY_MATRIX` until S-FI1f lands.
- **Posture mapping (confirmed):** immediate Degraded on the first `Untrusted` tick (fail-closed-immediately, no grace period); hysteretic escalation to LockedOut only if sustained/flapping. Rationale: decel-to-stop is the *frame-trust-minimal maneuver* — it needs the least of the thing you've lost. *(Wiring is S-FI1d, not in this PR.)*
- **Staleness × speed coupling** is documented: `max_stale_travel ≤ margin` — the 500 ms default is a liveness placeholder, not a standalone safety bound; the FTTI derivation is recorded as an open dependency rather than guessed.
- The frozen `validate_vehicle_command` talisman is **untouched**; this is a capability change to the SG2 sibling only.

## Verification

`kirra-core` 154 tests, `kirra-wire-client` 5, `kirra-governor-service` 6 — all pass. Full-workspace `cargo check` clean (default features). Clippy clean on touched crates.

## Not in this PR (next sub-stages)

S-FI1c (parko re-point) · S-FI1d (posture wiring + escalation) · S-FI1e (four call sites + collapse the shim) · S-FI1f (safety-case/RTM updates + ADR-0016).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWXgETCGcdP6XXErwLHkFk)_