### PR TITLE
Frame-integrity gate live (Stage S-FI1c/d/e)

### DIFF
--- a/crates/kirra-core/src/containment.rs
+++ b/crates/kirra-core/src/containment.rs
@@ -170,7 +170,7 @@ impl From<&VehicleKinematicsContract> for VehicleFootprint {
 // The check
 // ---------------------------------------------------------------------------
 
-// SAFETY: SG2 | REQ: drivable-space-containment,frame-integrity-gate | TEST: containment_allows_pose_centered_in_straight_corridor,containment_rejects_pose_outside_left,containment_rejects_pose_outside_right,containment_rejects_oncoming_excursion,containment_rejects_footprint_corner_clip,containment_rejects_when_corridor_unhealthy_low_confidence,containment_rejects_when_corridor_unhealthy_stale,containment_rejects_when_trajectory_exceeds_horizon,containment_allows_lane_change_within_wide_corridor,deny_code_drivable_space_departure_renders_stable_token,checked_untrusted_refuses_before_geometry,checked_degraded_margin_is_stricter_than_trusted,checked_trusted_matches_shim
+// SAFETY: SG2 | REQ: drivable-space-containment,frame-integrity-gate | TEST: containment_allows_pose_centered_in_straight_corridor,containment_rejects_pose_outside_left,containment_rejects_pose_outside_right,containment_rejects_oncoming_excursion,containment_rejects_footprint_corner_clip,containment_rejects_when_corridor_unhealthy_low_confidence,containment_rejects_when_corridor_unhealthy_stale,containment_rejects_when_trajectory_exceeds_horizon,containment_allows_lane_change_within_wide_corridor,deny_code_drivable_space_departure_renders_stable_token,untrusted_refuses_before_geometry,degraded_margin_is_stricter_than_trusted
 /// SG2 drivable-space containment check, **frame-integrity-gated** (Stage S-FI1).
 ///
 /// Resolves the lateral margin from the [`FrameTrust`] verdict
@@ -196,7 +196,7 @@ impl From<&VehicleKinematicsContract> for VehicleFootprint {
 /// `≤ 50 × 256 × 4 = 51 200` polygon-edge tests; no heap, no recursion, scalar
 /// f64 only.
 #[must_use]
-pub fn validate_trajectory_containment_checked(
+pub fn validate_trajectory_containment(
     trajectory: &[Pose],
     corridor: &Corridor,
     footprint: &VehicleFootprint,
@@ -237,26 +237,6 @@ pub fn validate_trajectory_containment_checked(
     }
 
     EnforceAction::Allow
-}
-
-/// Frame-trust-ASSERTING shim (Stage S-FI1b). Delegates to
-/// [`validate_trajectory_containment_checked`] with [`FrameTrust::Trusted`] —
-/// i.e. it ASSUMES the integrator's localization holds AOU-LOCALIZATION-001
-/// (≤ 0.10 m 95th-pct lateral error → primary 0.40 m margin), the legacy
-/// behavior before the frame-integrity gate existed.
-///
-/// This is the 3-arg entry the four enforcement points (gateway / fabric /
-/// ros2-adapter / parko-kirra) still call. The S-FI1e migration repoints them to
-/// the checked entry — sourcing a real [`FrameIntegrity`] per tick — and removes
-/// this shim. Until then this carries AOU-LOCALIZATION-001 inline. Do NOT call
-/// from new code; call the checked entry with a resolved frame trust.
-#[must_use]
-pub fn validate_trajectory_containment(
-    trajectory: &[Pose],
-    corridor: &Corridor,
-    footprint: &VehicleFootprint,
-) -> EnforceAction {
-    validate_trajectory_containment_checked(trajectory, corridor, footprint, FrameTrust::Trusted)
 }
 
 // ---------------------------------------------------------------------------
@@ -472,22 +452,21 @@ mod tests {
         let (left, right) = straight_corridor(3.0, 100.0);
         let corridor = healthy_corridor(&left, &right);
         let traj = vec![pose(20.0, 0.0, 0.0), pose(30.0, 0.0, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(action, EnforceAction::Allow, "centered pose must Allow");
     }
 
     // --- Stage S-FI1b: frame-integrity gate ---------------------------------
 
     #[test]
-    fn checked_untrusted_refuses_before_geometry() {
-        use crate::frame_integrity::FrameTrust;
+    fn untrusted_refuses_before_geometry() {
         // A pose that WOULD Allow under a trusted frame (centered, wide corridor)
         // must still be refused when the frame is Untrusted — the gate runs before
         // any geometry is considered.
         let (left, right) = straight_corridor(3.0, 100.0);
         let corridor = healthy_corridor(&left, &right);
         let traj = vec![pose(50.0, 0.0, 0.0)];
-        let action = validate_trajectory_containment_checked(
+        let action = validate_trajectory_containment(
             &traj,
             &corridor,
             &sedan(),
@@ -501,8 +480,7 @@ mod tests {
     }
 
     #[test]
-    fn checked_degraded_margin_is_stricter_than_trusted() {
-        use crate::frame_integrity::FrameTrust;
+    fn degraded_margin_is_stricter_than_trusted() {
         // sedan half-width 0.925 m; corridor half-width 1.425 m → lateral
         // clearance 0.50 m, which is ≥ 0.40 (primary) but < 0.75 (fallback).
         // Pose at x = 50 sits far from the end-caps so only the lateral edges bind.
@@ -510,33 +488,14 @@ mod tests {
         let corridor = healthy_corridor(&left, &right);
         let traj = vec![pose(50.0, 0.0, 0.0)];
         assert_eq!(
-            validate_trajectory_containment_checked(&traj, &corridor, &sedan(), FrameTrust::Trusted),
+            validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted),
             EnforceAction::Allow,
             "0.50 m clearance passes the 0.40 m primary margin (Trusted)"
         );
         assert_eq!(
-            validate_trajectory_containment_checked(
-                &traj,
-                &corridor,
-                &sedan(),
-                FrameTrust::Degraded
-            ),
+            validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Degraded),
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
             "0.50 m clearance fails the stricter 0.75 m fallback margin (Degraded)"
-        );
-    }
-
-    #[test]
-    fn checked_trusted_matches_shim() {
-        use crate::frame_integrity::FrameTrust;
-        // The 3-arg trust-asserting shim must be byte-identical to checked(Trusted).
-        let (left, right) = straight_corridor(3.0, 100.0);
-        let corridor = healthy_corridor(&left, &right);
-        let traj = vec![pose(50.0, 0.0, 0.0)];
-        assert_eq!(
-            validate_trajectory_containment(&traj, &corridor, &sedan()),
-            validate_trajectory_containment_checked(&traj, &corridor, &sedan(), FrameTrust::Trusted),
-            "the 3-arg shim must equal checked(Trusted)"
         );
     }
 
@@ -547,7 +506,7 @@ mod tests {
         let (left, right) = straight_corridor(3.0, 100.0);
         let corridor = healthy_corridor(&left, &right);
         let traj = vec![pose(40.0, 2.5, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
@@ -560,7 +519,7 @@ mod tests {
         let (left, right) = straight_corridor(3.0, 100.0);
         let corridor = healthy_corridor(&left, &right);
         let traj = vec![pose(40.0, -2.5, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture)
@@ -573,7 +532,7 @@ mod tests {
         let (left, right) = straight_corridor(3.0, 100.0);
         let corridor = healthy_corridor(&left, &right);
         let traj = vec![pose(40.0, 0.0, std::f64::consts::FRAC_PI_2)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture)
@@ -591,7 +550,7 @@ mod tests {
         let (left, right) = straight_corridor(3.0, 100.0);
         let corridor = healthy_corridor(&left, &right);
         let traj = vec![pose(40.0, 2.0, 0.1)]; // ~5.7° yaw left
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
@@ -605,7 +564,7 @@ mod tests {
         let mut corridor = healthy_corridor(&left, &right);
         corridor.confidence = 0.1; // below min_confidence
         let traj = vec![pose(20.0, 0.0, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
@@ -619,7 +578,7 @@ mod tests {
         let mut corridor = healthy_corridor(&left, &right);
         corridor.age_ms = 10_000; // > max_age_ms
         let traj = vec![pose(20.0, 0.0, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
@@ -638,7 +597,7 @@ mod tests {
             max_age_ms: 500,
         };
         let traj = vec![pose(0.0, 0.0, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
@@ -654,7 +613,7 @@ mod tests {
         let traj: Vec<Pose> = (0..(MAX_TRAJECTORY_HORIZON + 1))
             .map(|i| pose(i as f64, 0.0, 0.0))
             .collect();
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
@@ -667,7 +626,7 @@ mod tests {
         let (left, right) = straight_corridor(3.0, 100.0);
         let corridor = healthy_corridor(&left, &right);
         let traj: Vec<Pose> = vec![];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture)
@@ -679,7 +638,7 @@ mod tests {
         let (left, right) = straight_corridor(3.0, 100.0);
         let corridor = healthy_corridor(&left, &right);
         let traj = vec![pose(f64::NAN, 0.0, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture)
@@ -701,7 +660,7 @@ mod tests {
                 pose(x, y, 0.0)
             })
             .collect();
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::Allow,
@@ -745,7 +704,7 @@ mod tests {
             min_confidence: 0.5, max_age_ms: 500,
         };
         let traj = vec![pose(20.0, 0.0, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
@@ -769,7 +728,7 @@ mod tests {
             min_confidence: 0.5, max_age_ms: 500,
         };
         let traj = vec![pose(20.0, 0.0, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
@@ -793,7 +752,7 @@ mod tests {
             min_confidence: 0.5, max_age_ms: 500,
         };
         let traj = vec![pose(20.0, 0.0, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
@@ -815,7 +774,7 @@ mod tests {
             min_confidence: 0.5, max_age_ms: 500,
         };
         let traj = vec![pose(20.0, 0.0, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &sedan());
+        let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
@@ -833,7 +792,7 @@ mod tests {
         let mut bad = sedan();
         bad.width_m = f64::NAN;
         let traj = vec![pose(20.0, 0.0, 0.0)];
-        let action = validate_trajectory_containment(&traj, &corridor, &bad);
+        let action = validate_trajectory_containment(&traj, &corridor, &bad, FrameTrust::Trusted);
         assert_eq!(
             action,
             EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),

--- a/crates/kirra-core/src/kinematics_contract.rs
+++ b/crates/kirra-core/src/kinematics_contract.rs
@@ -263,7 +263,7 @@ pub enum DenyCode {
     /// trusted to be correctly placed relative to the ego. Containment refuses to
     /// validate (it does not reason about geometry in an untrusted frame) and the
     /// actuator falls to the MRC controlled-stop — the frame-trust-minimal
-    /// maneuver. Issued by `containment::validate_trajectory_containment_checked`
+    /// maneuver. Issued by `containment::validate_trajectory_containment`
     /// when the [`crate::frame_integrity::FrameTrust`] verdict is `Untrusted`.
     /// (Stage S-FI1 — behind AOU-LOCALIZATION-001.)
     ///

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -434,6 +434,15 @@ pub async fn run_adapter(
                 // Multi-modal predictive RSS: prediction does not yet supply per-object
                 // modes here → None (no-op); the snapshot RSS remains the bound.
                 None,
+                // Frame/localization integrity (S-FI1): no localization-quality
+                // input is wired at this node yet → assert AOU-LOCALIZATION-001
+                // (Trusted → primary 0.40 m containment margin), mirroring the
+                // visibility/predicted-modes pre-wiring state above. Wiring a real
+                // localization-quality source (resolve_frame_trust over an
+                // integrator FrameIntegrity report) is the integrator contract;
+                // until then a sustained localization fault still escalates fleet
+                // posture → LockedOut (S-FI1d), which this loop short-circuits to MRC.
+                kirra_core::frame_integrity::FrameTrust::Trusted,
             );
             let now_ms = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)

--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -23,6 +23,7 @@ use kirra_core::containment::{
 use kirra_core::kinematics_contract::{
     enforce_degraded_decel_to_stop, validate_vehicle_command, EnforceAction, ProposedVehicleCommand,
 };
+use kirra_core::frame_integrity::FrameTrust;
 use kirra_core::FleetPosture;
 use parko_core::rss::{
     lateral_safe_distance, longitudinal_safe_distance, opposite_direction_safe_distance,
@@ -121,6 +122,10 @@ pub fn validate_trajectory_slow(
     // (KIRRA-OCCY-PMON-003 slice-1).
     validate_trajectory_slow_capped(
         trajectory, corridor, objects, config, latest_odom, posture, None, None, None,
+        // Convenience/doer-side wrapper: assert AOU-LOCALIZATION-001 (Trusted →
+        // primary 0.40 m containment margin). The production slow loop passes a
+        // resolved FrameTrust; see `validate_trajectory_slow_capped`.
+        FrameTrust::Trusted,
     )
 }
 
@@ -158,6 +163,7 @@ pub fn validate_trajectory_slow_capped(
     effective_perception_cap: Option<f64>,
     visibility_range_m: Option<f64>,
     predicted_modes: Option<&[PredictedMode<'_>]>,
+    frame_trust: FrameTrust,
 ) -> TrajectoryVerdict {
     // ----- Posture short-circuit (M1) ----------------------------------
     //
@@ -198,7 +204,7 @@ pub fn validate_trajectory_slow_capped(
     let poses: Vec<KernelPose> = trajectory.iter().map(|p| adapter_to_kernel_pose(&p.pose)).collect();
 
     let containment_verdict = containment::validate_trajectory_containment(
-        &poses, &kernel_corridor, &footprint,
+        &poses, &kernel_corridor, &footprint, frame_trust,
     );
     if !matches!(containment_verdict, EnforceAction::Allow) {
         return TrajectoryVerdict::MRCFallback;

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -14,6 +14,7 @@ use kirra_ros2_adapter::{
     state::{PerceivedObject, Pose, TrajectoryPoint, TrajectoryVerdict},
     validation::validate_trajectory_slow,
 };
+use kirra_core::frame_integrity::FrameTrust;
 use kirra_core::FleetPosture;
 
 /// Build a straight n-pose trajectory along +X at uniform velocity.
@@ -516,7 +517,7 @@ fn occlusion_rejects_a_trajectory_that_outruns_assured_clear_distance() {
     let cfg = VehicleConfig::default_urban();
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(5.0), None,
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(5.0), None, FrameTrust::Trusted,
     );
     assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
         "10 m/s into 5 m of visibility outruns the assured clear distance; got {verdict:?}");
@@ -532,10 +533,33 @@ fn occlusion_bound_is_gated_off_when_no_visibility_is_supplied() {
     let cfg = VehicleConfig::default_urban();
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None, None,
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None, None, FrameTrust::Trusted,
     );
     assert_ne!(verdict, TrajectoryVerdict::MRCFallback,
         "with no visibility input the occlusion bound is a no-op; got {verdict:?}");
+}
+
+#[test]
+fn untrusted_frame_mrcs_an_otherwise_clean_trajectory() {
+    // S-FI1e: the frame-integrity gate is LIVE through the adapter. A trajectory
+    // that is accepted under a Trusted frame must MRC under an Untrusted frame —
+    // the containment check refuses to validate geometry in an untrusted frame.
+    let trajectory = straight_trajectory(20, 5.0, 0.1);
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let objects: Vec<PerceivedObject> = Vec::new();
+    let cfg = VehicleConfig::default_urban();
+
+    let trusted = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None, None, FrameTrust::Trusted,
+    );
+    assert_ne!(trusted, TrajectoryVerdict::MRCFallback,
+        "a clean trajectory under a Trusted frame must not MRC; got {trusted:?}");
+
+    let untrusted = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None, None, FrameTrust::Untrusted,
+    );
+    assert_eq!(untrusted, TrajectoryVerdict::MRCFallback,
+        "the SAME clean trajectory must MRC under an Untrusted frame; got {untrusted:?}");
 }
 
 #[test]
@@ -548,7 +572,7 @@ fn occlusion_admits_a_decel_to_stop_within_visibility() {
     let cfg = VehicleConfig::default_urban();
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(20.0), None,
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(20.0), None, FrameTrust::Trusted,
     );
     assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
         "a decel-to-stop within the assured clear distance is admissible; got {verdict:?}");
@@ -588,7 +612,7 @@ fn predictive_rss_does_not_regress_a_lane_keeping_neighbor() {
     let modes = [PredictedMode { object_id: 1, samples: &samples }];
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes),
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), FrameTrust::Trusted,
     );
     assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
         "a neighbor predicted to keep its lane must not be rejected; got {verdict:?}");
@@ -615,7 +639,7 @@ fn predictive_rss_catches_a_predicted_cut_in() {
     let modes = [PredictedMode { object_id: 1, samples: &samples }];
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes),
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), FrameTrust::Trusted,
     );
     assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
         "a predicted cut-in into the ego's path must be refused; got {verdict:?}");
@@ -630,7 +654,7 @@ fn predictive_rss_is_a_no_op_when_no_modes_are_supplied() {
     let cfg = VehicleConfig::default_urban();
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, None,
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, None, FrameTrust::Trusted,
     );
     assert_ne!(verdict, TrajectoryVerdict::MRCFallback,
         "with no predicted modes the predictive pass is a no-op; got {verdict:?}");

--- a/docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md
+++ b/docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md
@@ -237,6 +237,28 @@ pub fn localization_trusted(integrity: &FrameIntegrity, cfg: &FrameIntegrityCfg)
 
 parko's existing `test_loc_*` tests become adapter tests over the unified resolver (same boundary cases; `Degraded` band now asserts `localization_trusted == false`, which is the existing 0.10 m semantics preserved). `gate_commit_zone_scene` / `gate_water_scene` and their tests are **unchanged**.
 
+**As-built (S-FI1c) — unified at the parko-kirra boundary, NOT via parko-core re-export.**
+Discovery: `parko-core` deliberately has **no** `kirra-core` dependency (the manifest
+keeps the ML inference pipeline independent of the safety-kernel build); only
+`parko-kirra` depends on `kirra-core`, and the localization type is used
+*exclusively* there. So rather than couple `parko-core` → `kirra-core` (the literal
+re-export plan above), the unification was done at the consumer:
+- `parko-core/src/localization.rs`: **removed** `LocalizationIntegrity` /
+  `LocalizationCfg` / `localization_trusted` (+ their `test_loc_*`); **kept** only
+  the bool-driven `gate_commit_zone_scene` / `gate_water_scene` (+ `test_gate_*`).
+  `parko-core` stays `kirra-core`-free.
+- `parko-kirra` wrappers (`evaluate_scene_with_commit_zone_localized`,
+  `evaluate_scene_with_water_localized`) now take `&FrameIntegrity` /
+  `&FrameIntegrityCfg` and compute the **strict** view inline:
+  `matches!(resolve_frame_trust(loc, cfg), FrameTrust::Trusted)` → the bool the
+  gates already consume. Behaviour is identical to the old 0.10 m gate (ε in the
+  0.10–0.30 Degraded band reads as untrusted for these discrete map-anchored
+  vetoes), so no parko behaviour change; the `test_loc_*` boundary coverage now
+  lives in kirra-core's `frame_integrity` tests, and the strict-view path is
+  exercised end-to-end by the parko-kirra wrapper tests.
+- Net: one canonical type/resolver (kirra-core), no drift, `parko-core`
+  independence preserved. (Owner-approved deviation, 2026-06-24.)
+
 ---
 
 ## 6. Posture wiring (`src/posture_engine_v2.rs`)
@@ -339,7 +361,7 @@ stage close.
 
 S-FI1a: ✅ DONE — `frame_integrity` module + types + resolver + tests (kirra-core, no call-site change).
 S-FI1b: ✅ DONE — gated `validate_trajectory_containment_checked` + trust-asserting shim; `DenyCode::FrameIntegrityUntrusted` (appended last); forced matches discharged (`reason()` + display test, governor-service `deny_code_num` → 11, wire-client `ClientDenyCode` mirror + drift test); 3 new containment tests (untrusted-refuses, degraded-stricter-than-trusted, shim==checked). Workspace compiles (default features); call sites untouched.
-S-FI1c: parko re-point.
+S-FI1c: ✅ DONE — unified at the parko-kirra boundary (parko-core stays kirra-core-free; type+resolver removed from parko-core, wrappers take `&FrameIntegrity` with a strict `Trusted`-only view). parko-core 198 + parko-kirra 148 tests pass; parko clippy + root workspace check clean.
 S-FI1d: posture wiring + hysteresis escalation.
 S-FI1e: four call sites + integrator-contract surfacing; remove shim.
 S-FI1f: safety-case/AoU updates; ADR-0016 to Accepted.

--- a/docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md
+++ b/docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md
@@ -315,21 +315,36 @@ the safety argument of record.
 
 ---
 
-## 7. Call sites — the four enforcement points
+## 7. Call sites
 
-Each must source a `FrameIntegrity` for the tick and pass `resolve_frame_trust(...)` into containment. **Sourcing the integrity report at each point is where the integrator contract surfaces** and is the bulk of the integration work:
+**Correction to the original plan (verified in code):** SG2 `validate_trajectory_containment`
+has exactly **ONE production call site** — the ros2-adapter slow loop
+(`crates/kirra-ros2-adapter/src/validation.rs`, per the module's SG2-WIRING note)
+— plus the WCET bench harness. The "four enforcement points" in CLAUDE.md refer to
+the *decel-to-stop gate* (`enforce_degraded_decel_to_stop`), a **different**
+function; fabric / parko-kirra / the HTTP gateway do **not** call containment.
+(parko-kirra's frame-integrity input is the discrete-veto path, handled in S-FI1c.)
 
-1. **gateway** `enforce_actuator_safety_envelope` — frame-integrity from the perception input contract alongside the corridor.
-2. **fabric** `AssetGovernor::evaluate_command` — per-asset integrity in the command envelope.
-3. **ros2-adapter** `validate_trajectory_slow` — integrity from the ROS2 localization-quality topic.
-4. **parko-kirra** `KirraGovernor::apply_mrc_profile` — already has `LocalizationIntegrity`; re-point to the unified type.
-
-**As-built (S-FI1b):** the shim role is filled by the existing
-`validate_trajectory_containment` (3-arg) delegating with `FrameTrust::Trusted`
-(see §4), so all four call sites compile **unchanged** at S-FI1b. S-FI1e sources a
-real `FrameIntegrity` at each point, switches the call to `_checked`, then
-collapses the names and removes the shim. No production path keeps the shim past
-stage close.
+**As-built (S-FI1e):**
+- Shim **collapsed**: the 3-arg `validate_trajectory_containment` is gone; the
+  4-arg gated entry now *is* `validate_trajectory_containment`. Internal tests
+  migrated; the shim-equivalence test was removed.
+- `validate_trajectory_slow_capped` gains a `frame_trust: FrameTrust` param,
+  passed into containment. The widely-used convenience wrapper
+  `validate_trajectory_slow` keeps its signature and passes `FrameTrust::Trusted`
+  — so its ~50 doer-side callers (planner / taj / mick tests, examples) are
+  untouched.
+- **Production node** (`node.rs` slow loop) passes a resolved `FrameTrust`.
+  No localization-quality input is wired at the node yet, so it asserts
+  `FrameTrust::Trusted` (= AOU-LOCALIZATION-001, primary 0.40 m) with an explicit
+  integrator-contract comment — mirroring the existing pre-wiring `None`s for
+  `visibility_range_m` / `predicted_modes`. **Sourcing a real localization-quality
+  signal here (construct `FrameIntegrity` → `resolve_frame_trust`) is the
+  integrator contract and is the remaining open item.** A sustained localization
+  fault still escalates fleet posture → LockedOut (S-FI1d), which the slow loop
+  short-circuits to MRC, so the node is not unprotected in the interim.
+- The gate is **live end-to-end**: an adapter integration test proves the SAME
+  clean trajectory is Accepted under `Trusted` and MRC'd under `Untrusted`.
 
 ---
 
@@ -362,6 +377,8 @@ stage close.
 S-FI1a: ✅ DONE — `frame_integrity` module + types + resolver + tests (kirra-core, no call-site change).
 S-FI1b: ✅ DONE — gated `validate_trajectory_containment_checked` + trust-asserting shim; `DenyCode::FrameIntegrityUntrusted` (appended last); forced matches discharged (`reason()` + display test, governor-service `deny_code_num` → 11, wire-client `ClientDenyCode` mirror + drift test); 3 new containment tests (untrusted-refuses, degraded-stricter-than-trusted, shim==checked). Workspace compiles (default features); call sites untouched.
 S-FI1c: ✅ DONE — unified at the parko-kirra boundary (parko-core stays kirra-core-free; type+resolver removed from parko-core, wrappers take `&FrameIntegrity` with a strict `Trusted`-only view). parko-core 198 + parko-kirra 148 tests pass; parko clippy + root workspace check clean.
+S-FI1d: ✅ DONE — fleet posture reacts to frame integrity (AppState frame flags + streaks; posture_engine escalation; `apply_frame_integrity_state` with immediate-Degraded + sticky hysteretic LockedOut; `FrameIntegrityChanged` trigger; `LockoutReason::FrameIntegrityUntrusted`). 47 posture tests pass.
+S-FI1e: ✅ DONE — shim collapsed (4-arg `validate_trajectory_containment` is canonical); `frame_trust` threaded through `validate_trajectory_slow_capped` and the production node (Trusted = AOU-LOCALIZATION-001 seam until a real source is wired); convenience wrapper + ~50 doer callers untouched. Live-gate adapter test passes. **Open item:** wire a real node-side localization-quality source (integrator contract). **Remaining:** S-FI1f (RTM/AoU updates + ADR-0016) before any ENFORCED claim.
 S-FI1d: posture wiring + hysteresis escalation.
 S-FI1e: four call sites + integrator-contract surfacing; remove shim.
 S-FI1f: safety-case/AoU updates; ADR-0016 to Accepted.

--- a/parko/crates/parko-core/src/lib.rs
+++ b/parko/crates/parko-core/src/lib.rs
@@ -79,10 +79,7 @@ pub use impact::{
     ImpactEvidence, ImpactLatch, OperatorClearanceGrant, VanishedCfg, VanishedObjectDetector,
     VehicleClass, DEFAULT_MAX_GRANT_AGE_MS,
 };
-pub use localization::{
-    gate_commit_zone_scene, gate_water_scene, localization_trusted, LocalizationCfg,
-    LocalizationIntegrity,
-};
+pub use localization::{gate_commit_zone_scene, gate_water_scene};
 pub use safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
 pub use water::{water_untraversable_veto, TraversalEvidence, WaterScene, WaterVetoConfig};
 pub use scheduler::{DegradationThresholds, InferenceLoop};

--- a/parko/crates/parko-core/src/localization.rs
+++ b/parko/crates/parko-core/src/localization.rs
@@ -1,94 +1,31 @@
 // parko-core/src/localization.rs
 //
-// SG2 / SG5 — localization-integrity gate over the map-anchored checks (#123,
-// runtime half).
+// SG4 / SG5 — the bool-driven map-anchored scene gates.
 //
-// The G2 ASSUMPTION-OF-USE (OCCY_SAFETY_GOALS.md, ~line 102, ref
-// KIRRA-OCCY-SG2-MARGIN-001) is that the integrator's localization holds a 95th-
-// percentile lateral error of ≤ 0.10 m. EVERY map-anchored trust in this crate —
-// the SG5 commit-zone gate (a mapped rail crossing / box junction), the SG4
-// `MapKnownSafe` water earn-back — is only as sound as that pose. This module is
-// the RUNTIME COMPLEMENT to that static AoU: when the integrator's localization-
-// integrity reporting says the assumption does NOT currently hold (error over
-// bound, stale, or simply unreported), every MAP-DERIVED trust degrades fail-
-// closed.
+// The localization-integrity TYPE and its trust resolver were unified into
+// kirra-core (`kirra_core::frame_integrity`: FrameIntegrity / FrameTrust /
+// resolve_frame_trust) in Stage S-FI1c, so a SINGLE canonical frame-trust
+// verdict drives both the SG2 containment margin (graduated) and these discrete
+// map-anchored vetoes (strict — Trusted only). parko-core stays kirra-core-free:
+// it keeps only the bool-driven gates below; parko-kirra resolves the verdict
+// (strict view) and passes the bool in. See
+// docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md.
 //
-// The formal AoU REGISTER clause is a separate docs PR; this file is the
-// executable gate only (doc-comments excepted).
-//
-// SOURCING NOTE: deriving [`LocalizationIntegrity::Reported`] from the
-// integrator's signals (NDT/ICP match scores, pose covariance, RTK fix status)
-// is integrator/ingestion territory and is DEFERRED — exactly like the agent
-// set, water, occlusion, and commit-zone scenes are supplied check INPUTS.
+// EVERY map-anchored trust here — the SG5 commit-zone gate (a mapped rail
+// crossing / box junction), the SG4 `MapKnownSafe` water earn-back — is only as
+// sound as the ego pose; under an untrusted pose every MAP-DERIVED trust
+// degrades fail-closed. The G2 AoU (≤ 0.10 m 95th-pct lateral) is
+// AOU-LOCALIZATION-001.
 
 use crate::commit_zone::CommitZoneScene;
 use crate::water::{TraversalEvidence, WaterScene};
 
-/// What the integrator's localization-integrity channel reports this tick.
-/// Mirrors the established ABSENT-vs-KNOWN discipline (cf. `WaterScene`,
-/// `CommitZoneScene`, `OcclusionScene`): an ABSENT report is NOT a healthy pose.
-#[derive(Debug, Clone, Copy)]
-pub enum LocalizationIntegrity {
-    /// No integrity report this tick → NOT trusted. DISTINCT from a healthy
-    /// report (the #238 absent-vs-known trap): a missing pose-quality signal is
-    /// not "the pose is fine".
-    Unknown,
-    /// The integrator reported a pose-quality estimate.
-    Reported {
-        /// 95th-percentile lateral position error (m). Compared against the G2
-        /// AoU bound. Non-finite → NOT trusted.
-        lateral_error_95_m: f64,
-        /// Age (ms) of this integrity snapshot vs now. Above `max_age_ms` →
-        /// stale → NOT trusted.
-        age_ms: u64,
-    },
-}
-
-/// Config for the localization-integrity gate.
-#[derive(Debug, Clone, Copy)]
-pub struct LocalizationCfg {
-    /// The G2 AoU bound: maximum 95th-pct lateral error (m) for the pose to be
-    /// trusted for MAP-ANCHORED reasoning. Default `0.10` m — the value the
-    /// OCCY_SAFETY_GOALS.md G2 assumption-of-use is written against
-    /// (KIRRA-OCCY-SG2-MARGIN-001). NOT a free placeholder: this couples to the
-    /// documented safety-goal margin.
-    pub max_lateral_error_95_m: f64,
-    /// Maximum acceptable staleness (ms) of an integrity report. VALIDATION-
-    /// PENDING conservative default — tie to the per-cycle FTTI on integration.
-    pub max_age_ms: u64,
-}
-
-impl Default for LocalizationCfg {
-    fn default() -> Self {
-        Self {
-            max_lateral_error_95_m: 0.10, // G2 AoU bound — KIRRA-OCCY-SG2-MARGIN-001
-            max_age_ms: 500,              // VALIDATION-PENDING conservative default
-        }
-    }
-}
-
-/// SG2/SG5 — is the integrator's localization currently trustworthy for MAP-
-/// ANCHORED reasoning? Mirrors `CommitZoneMap::is_healthy`'s conservative,
-/// finite-checked semantics.
-///
-/// * `Unknown` → `false` (absent ≠ healthy).
-/// * `Reported` → `true` IFF `lateral_error_95_m` is FINITE **and** ≤ the bound
-///   **and** `age_ms` ≤ `max_age_ms`. A non-finite error fails closed (an
-///   unverifiable pose is NO pose).
-// SAFETY: SG2 SG5 | REQ: localization-integrity-gate | TEST: test_loc_bound_boundary,test_loc_just_over_bound_not_trusted,test_loc_stale_not_trusted,test_loc_nonfinite_not_trusted,test_loc_unknown_not_trusted,test_loc_healthy_trusted
-pub fn localization_trusted(integrity: &LocalizationIntegrity, cfg: &LocalizationCfg) -> bool {
-    match *integrity {
-        LocalizationIntegrity::Unknown => false,
-        LocalizationIntegrity::Reported {
-            lateral_error_95_m,
-            age_ms,
-        } => {
-            lateral_error_95_m.is_finite()
-                && lateral_error_95_m <= cfg.max_lateral_error_95_m
-                && age_ms <= cfg.max_age_ms
-        }
-    }
-}
+// LocalizationIntegrity / LocalizationCfg / localization_trusted were relocated
+// to kirra-core `frame_integrity` (FrameIntegrity / FrameIntegrityCfg /
+// FrameTrust / resolve_frame_trust) in Stage S-FI1c — the single canonical
+// frame-trust verdict. parko-kirra resolves it (strict `Trusted`-only view) and
+// passes the resulting `bool` into the gates below. The boundary coverage that
+// `test_loc_*` provided is now in kirra-core's `frame_integrity` tests.
 
 /// SG5 coupling — degrade the commit-zone scene under an UNTRUSTED pose.
 ///
@@ -142,75 +79,9 @@ mod tests {
     use crate::commit_zone::{CommitZoneMap, CommitZoneScene};
     use crate::water::{water_untraversable_veto, TraversalEvidence, WaterScene, WaterVetoConfig};
 
-    fn cfg() -> LocalizationCfg {
-        LocalizationCfg::default() // bound 0.10 m, max_age 500 ms
-    }
-    fn reported(err: f64, age_ms: u64) -> LocalizationIntegrity {
-        LocalizationIntegrity::Reported {
-            lateral_error_95_m: err,
-            age_ms,
-        }
-    }
-
-    // ───────────────────────── localization_trusted ────────────────────────
-
-    /// Boundary: exactly at the 0.10 m bound (and fresh) → trusted (inclusive).
-    #[test]
-    fn test_loc_bound_boundary() {
-        assert!(
-            localization_trusted(&reported(0.10, 50), &cfg()),
-            "error exactly at the bound must be trusted (inclusive)"
-        );
-    }
-
-    /// Just over the bound → NOT trusted.
-    #[test]
-    fn test_loc_just_over_bound_not_trusted() {
-        assert!(
-            !localization_trusted(&reported(0.10 + 1e-9, 50), &cfg()),
-            "error just over the bound must not be trusted"
-        );
-    }
-
-    /// A stale report (age over max) → NOT trusted, even with a good error.
-    #[test]
-    fn test_loc_stale_not_trusted() {
-        assert!(
-            !localization_trusted(&reported(0.01, 1_000), &cfg()),
-            "a stale integrity report must not be trusted"
-        );
-    }
-
-    /// A non-finite error → NOT trusted (an unverifiable pose is no pose).
-    #[test]
-    fn test_loc_nonfinite_not_trusted() {
-        for bad in [f64::NAN, f64::INFINITY] {
-            assert!(
-                !localization_trusted(&reported(bad, 50), &cfg()),
-                "non-finite error must not be trusted ({bad})"
-            );
-        }
-    }
-
-    /// Unknown (no report) is NOT trusted, and is DISTINCT from a healthy report.
-    #[test]
-    fn test_loc_unknown_not_trusted() {
-        assert!(
-            !localization_trusted(&LocalizationIntegrity::Unknown, &cfg()),
-            "an absent integrity report must not be trusted (absent != healthy)"
-        );
-        assert_ne!(
-            localization_trusted(&LocalizationIntegrity::Unknown, &cfg()),
-            localization_trusted(&reported(0.05, 50), &cfg()),
-            "Unknown and a healthy report must differ"
-        );
-    }
-
-    /// A fresh, in-bound report → trusted.
-    #[test]
-    fn test_loc_healthy_trusted() {
-        assert!(localization_trusted(&reported(0.05, 50), &cfg()));
-    }
+    // The localization_trusted boundary tests (test_loc_*) moved with the
+    // resolver to kirra-core `frame_integrity`. The strict `Trusted`-only view
+    // parko applies is exercised end-to-end by the parko-kirra wrapper tests.
 
     // ─────────────────────── gate_commit_zone_scene ────────────────────────
 

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -53,12 +53,13 @@ use parko_core::rss::{
     lateral_safe_distance, longitudinal_safe_distance, occlusion_limited_speed,
     opposite_direction_safe_distance, RSS_LONGITUDINAL_CONFLICT_M, RSS_LONGITUDINAL_OVERLAP_M,
 };
+use kirra_core::frame_integrity::{resolve_frame_trust, FrameIntegrity, FrameIntegrityCfg, FrameTrust};
 use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
 use parko_core::{
-    commit_zone_blocked, gate_commit_zone_scene, gate_water_scene, localization_trusted,
-    water_untraversable_veto, AgentScene, ClearanceLoop, CommitZoneCfg, CommitZoneScene,
-    ImpactEvidence, ImpactLatch, LocalizationCfg, LocalizationIntegrity, OcclusionScene, RssParams,
-    RssState, VanishedCfg, VanishedObjectDetector, WaterScene, WaterVetoConfig, MAX_RSS_AGENTS,
+    commit_zone_blocked, gate_commit_zone_scene, gate_water_scene, water_untraversable_veto,
+    AgentScene, ClearanceLoop, CommitZoneCfg, CommitZoneScene, ImpactEvidence, ImpactLatch,
+    OcclusionScene, RssParams, RssState, VanishedCfg, VanishedObjectDetector, WaterScene,
+    WaterVetoConfig, MAX_RSS_AGENTS,
 };
 
 pub mod angular_bound;
@@ -847,11 +848,15 @@ impl KirraGovernor {
         scene: &AgentScene,
         commit_zone: &CommitZoneScene,
         cz_cfg: &CommitZoneCfg,
-        localization: &LocalizationIntegrity,
-        loc_cfg: &LocalizationCfg,
+        localization: &FrameIntegrity,
+        loc_cfg: &FrameIntegrityCfg,
         params: &RssParams,
     ) -> EnforcementAction {
-        let trusted = localization_trusted(localization, loc_cfg);
+        // STRICT view: a map-anchored commit-zone location may only be trusted
+        // under full `Trusted` (≤ 0.10 m). The `Degraded` fallback band is good
+        // enough for graduated containment but NOT for trusting a mapped zone's
+        // placement, so anything short of `Trusted` gates the scene fail-closed.
+        let trusted = matches!(resolve_frame_trust(localization, loc_cfg), FrameTrust::Trusted);
         let gated = gate_commit_zone_scene(*commit_zone, trusted);
         self.evaluate_scene_with_commit_zone(
             proposed, previous, delta_time_s, posture, scene, &gated, cz_cfg, params,
@@ -875,11 +880,13 @@ impl KirraGovernor {
         scene: &AgentScene,
         water: &WaterScene,
         water_cfg: &WaterVetoConfig,
-        localization: &LocalizationIntegrity,
-        loc_cfg: &LocalizationCfg,
+        localization: &FrameIntegrity,
+        loc_cfg: &FrameIntegrityCfg,
         params: &RssParams,
     ) -> EnforcementAction {
-        let trusted = localization_trusted(localization, loc_cfg);
+        // STRICT view (see commit-zone wrapper): a map-frame ford earn-back may
+        // only be trusted under full `Trusted`; the `Degraded` band gates it.
+        let trusted = matches!(resolve_frame_trust(localization, loc_cfg), FrameTrust::Trusted);
         let gated = gate_water_scene(*water, trusted);
         self.evaluate_scene_with_water(
             proposed, previous, delta_time_s, posture, scene, &gated, water_cfg, params,
@@ -1652,12 +1659,13 @@ mod scene_rss_tests {
     use super::{compute_occlusion_cap, compute_scene_rss, impact_evidence_with_vanished, KirraGovernor};
     use parko_core::commands::ControlCommand;
     use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
+    use kirra_core::frame_integrity::{FrameIntegrity, FrameIntegrityCfg, LocalizationChannel};
     use parko_core::{
         non_yielding_clearance, AgentScene, ClearanceLoop, ClearanceState, CommitZoneCfg,
-        CommitZoneMap, CommitZoneScene, ImpactCfg, ImpactEvidence, ImpactLatch, LocalizationCfg,
-        LocalizationIntegrity, NonYieldingAgent, NonYieldingScene, OcclusionScene,
-        OperatorClearanceGrant, RssAgent, RssParams, RssState, TraversalEvidence, VanishedCfg,
-        VanishedObjectDetector, WaterScene, WaterVetoConfig, MAX_RSS_AGENTS,
+        CommitZoneMap, CommitZoneScene, ImpactCfg, ImpactEvidence, ImpactLatch, NonYieldingAgent,
+        NonYieldingScene, OcclusionScene, OperatorClearanceGrant, RssAgent, RssParams, RssState,
+        TraversalEvidence, VanishedCfg, VanishedObjectDetector, WaterScene, WaterVetoConfig,
+        MAX_RSS_AGENTS,
     };
 
     fn params() -> RssParams {
@@ -2276,19 +2284,21 @@ mod scene_rss_tests {
             zone_length_m: 30.0, proposed_stop_distance_m: None,
         };
         // Sanity: trusted localization → the confirmed zone passes through.
-        let trusted = LocalizationIntegrity::Reported { lateral_error_95_m: 0.05, age_ms: 50 };
+        let trusted = FrameIntegrity::Reported {
+            localization: LocalizationChannel { lateral_error_95_m: 0.05, age_ms: 50 },
+        };
         let ok = gov.evaluate_scene_with_commit_zone_localized(
             &cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal,
             &AgentScene::KnownEmpty, &confirmed, &CommitZoneCfg::default(),
-            &trusted, &LocalizationCfg::default(), &params());
+            &trusted, &FrameIntegrityCfg::default(), &params());
         assert!(matches!(ok, EnforcementAction::Allow),
             "a confirmed zone under trusted localization must pass, got {ok:?}");
         // Untrusted (absent report) → scene degrades to Unknown → overridden.
-        let untrusted = LocalizationIntegrity::Unknown;
+        let untrusted = FrameIntegrity::Unknown;
         let action = gov.evaluate_scene_with_commit_zone_localized(
             &cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal,
             &AgentScene::KnownEmpty, &confirmed, &CommitZoneCfg::default(),
-            &untrusted, &LocalizationCfg::default(), &params());
+            &untrusted, &FrameIntegrityCfg::default(), &params());
         assert!(!matches!(action, EnforcementAction::Allow),
             "untrusted localization must override a healthy commit zone → MRC, got {action:?}");
     }
@@ -2302,17 +2312,19 @@ mod scene_rss_tests {
         let ford = WaterScene::EarnedTraversable { evidence: TraversalEvidence::MapKnownSafe };
         let wcfg = WaterVetoConfig { max_exit_distance_m: 5.0, max_puddle_extent_m: 5.0 };
         // Trusted → the mapped ford permits traversal.
-        let trusted = LocalizationIntegrity::Reported { lateral_error_95_m: 0.05, age_ms: 50 };
+        let trusted = FrameIntegrity::Reported {
+            localization: LocalizationChannel { lateral_error_95_m: 0.05, age_ms: 50 },
+        };
         let ok = gov.evaluate_scene_with_water_localized(
             &cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal,
-            &AgentScene::KnownEmpty, &ford, &wcfg, &trusted, &LocalizationCfg::default(), &params());
+            &AgentScene::KnownEmpty, &ford, &wcfg, &trusted, &FrameIntegrityCfg::default(), &params());
         assert!(matches!(ok, EnforcementAction::Allow),
             "a mapped ford under trusted localization must pass, got {ok:?}");
         // Untrusted → MapKnownSafe stripped → veto.
-        let untrusted = LocalizationIntegrity::Unknown;
+        let untrusted = FrameIntegrity::Unknown;
         let action = gov.evaluate_scene_with_water_localized(
             &cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal,
-            &AgentScene::KnownEmpty, &ford, &wcfg, &untrusted, &LocalizationCfg::default(), &params());
+            &AgentScene::KnownEmpty, &ford, &wcfg, &untrusted, &FrameIntegrityCfg::default(), &params());
         assert!(!matches!(action, EnforcementAction::Allow),
             "untrusted localization must strip the MapKnownSafe ford → veto, got {action:?}");
     }
@@ -2325,10 +2337,10 @@ mod scene_rss_tests {
         gov.update_rss_state(RssState { safe: true, longitudinal_margin: f64::MAX, lateral_margin: f64::MAX });
         let ford = WaterScene::EarnedTraversable { evidence: TraversalEvidence::OperatorAuthorized };
         let wcfg = WaterVetoConfig { max_exit_distance_m: 5.0, max_puddle_extent_m: 5.0 };
-        let untrusted = LocalizationIntegrity::Unknown;
+        let untrusted = FrameIntegrity::Unknown;
         let action = gov.evaluate_scene_with_water_localized(
             &cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal,
-            &AgentScene::KnownEmpty, &ford, &wcfg, &untrusted, &LocalizationCfg::default(), &params());
+            &AgentScene::KnownEmpty, &ford, &wcfg, &untrusted, &FrameIntegrityCfg::default(), &params());
         assert!(matches!(action, EnforcementAction::Allow),
             "operator authority must survive untrusted localization, got {action:?}");
     }

--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -91,8 +91,14 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     // both flags clear and the DAG is Nominal, posture returns to Nominal via
     // this same path (no separate recovery logic).
     // SAFETY: SG4 | REQ: flood-posture-coupling | TEST: test_flood_active_nominal_escalates_to_degraded,test_flood_active_locked_out_stays_locked_out,test_flood_active_degraded_stays_degraded,test_flood_and_rss_compose,test_flood_clears_auto_recovers_to_nominal,test_flood_default_false_is_inert
+    // S-FI1d frame-integrity coupling: a sub-trusted frame (Degraded OR transient
+    // Untrusted) escalates Nominal → Degraded exactly like RSS/flood — the
+    // decel-to-stop MRC is the frame-trust-minimal maneuver. Composes with the
+    // others (any → Degraded); auto-recovers when the flag clears.
+    // SAFETY: SG2 | REQ: frame-integrity-posture-coupling | TEST: test_frame_degraded_active_escalates_nominal,test_frame_degraded_active_locked_out_stays_locked_out,test_frame_and_rss_compose,test_frame_degraded_clears_auto_recovers_to_nominal
     let escalate = (app.rss_active_violation.load(std::sync::atomic::Ordering::SeqCst)
-        || app.flood_condition_active.load(std::sync::atomic::Ordering::SeqCst))
+        || app.flood_condition_active.load(std::sync::atomic::Ordering::SeqCst)
+        || app.frame_degraded_active.load(std::sync::atomic::Ordering::SeqCst))
         && dag_posture == FleetPosture::Nominal;
     // C2 supervisor escalation has ABSOLUTE priority over the DAG and the
     // operational (rss/flood) escalation: if a critical background safety loop is
@@ -101,7 +107,12 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     // the forced LockedOut STICKS across every subsequent recalc (a recovered DAG
     // can never silently downgrade it). Recovery is a human/HA reset, matching
     // LockedOut semantics. SAFETY: SG9 fail-closed on safety-loop death (review C2).
-    let new_posture = if app.supervisor_tripped.load(std::sync::atomic::Ordering::SeqCst) {
+    // A sustained frame-integrity fault (`frame_lockout_active`) shares the
+    // absolute LockedOut priority with `supervisor_tripped`: both are sticky
+    // human-reset conditions that override the DAG and the operational escalation.
+    let new_posture = if app.supervisor_tripped.load(std::sync::atomic::Ordering::SeqCst)
+        || app.frame_lockout_active.load(std::sync::atomic::Ordering::SeqCst)
+    {
         FleetPosture::LockedOut
     } else if escalate {
         FleetPosture::Degraded
@@ -618,6 +629,57 @@ mod posture_engine_tests {
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded),
             "flood does not alter an already-Degraded DAG posture");
+    }
+
+    // --- S-FI1d: frame-integrity posture coupling --------------------------
+
+    #[test]
+    fn test_frame_degraded_active_escalates_nominal() {
+        let app = active_app();
+        let cache = empty_cache();
+        app.frame_degraded_active.store(true, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded),
+            "frame_degraded_active + DAG Nominal must escalate to Degraded");
+    }
+
+    /// frame_lockout_active shares the absolute LockedOut priority with the
+    /// supervisor trip: it forces LockedOut over an otherwise-healthy DAG.
+    #[test]
+    fn test_frame_degraded_active_locked_out_stays_locked_out() {
+        let app = active_app();
+        let cache = empty_cache();
+        app.frame_lockout_active.store(true, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::LockedOut),
+            "frame_lockout_active must force LockedOut over a healthy DAG");
+    }
+
+    /// frame and RSS compose: either active (with Nominal DAG) → Degraded.
+    #[test]
+    fn test_frame_and_rss_compose() {
+        let app = active_app();
+        let cache = empty_cache();
+        app.frame_degraded_active.store(true, Ordering::SeqCst);
+        app.rss_active_violation.store(true, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded),
+            "frame OR rss escalates Nominal → Degraded");
+    }
+
+    /// Clearing the frame-degraded flag auto-recovers to Nominal via the same path.
+    #[test]
+    fn test_frame_degraded_clears_auto_recovers_to_nominal() {
+        let app = active_app();
+        let cache = empty_cache();
+        app.frame_degraded_active.store(true, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded));
+
+        app.frame_degraded_active.store(false, Ordering::SeqCst);
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(cache_posture(&cache), Some(FleetPosture::Nominal),
+            "clearing frame_degraded_active returns posture to Nominal (auto-recovery)");
     }
 
     /// flood and RSS compose: either active (with Nominal DAG) → Degraded.

--- a/src/posture_engine_v2.rs
+++ b/src/posture_engine_v2.rs
@@ -33,6 +33,9 @@ pub enum LockoutReason {
     WatchdogTimeout,
     /// An operator or administrative action explicitly locked out the fleet.
     ManualLockout,
+    /// S-FI1d — frame/localization integrity was `Untrusted` for a sustained
+    /// run (sensor failure / possible GNSS spoofing). Sticky human-reset lockout.
+    FrameIntegrityUntrusted,
 }
 
 impl fmt::Display for LockoutReason {
@@ -45,6 +48,7 @@ impl fmt::Display for LockoutReason {
             Self::PostureEngineFailure  => "POSTURE_ENGINE_FAILURE",
             Self::WatchdogTimeout       => "WATCHDOG_TIMEOUT",
             Self::ManualLockout         => "MANUAL_LOCKOUT",
+            Self::FrameIntegrityUntrusted => "FRAME_INTEGRITY_UNTRUSTED",
         };
         write!(f, "{code}")
     }
@@ -158,6 +162,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use crate::verifier::AppState;
 use parko_core::RssState;
+use kirra_core::frame_integrity::FrameTrust;
 use crate::recovery_hysteresis::{AV_RECOVERY_STREAK_THRESHOLD, AV_RECOVERY_WINDOW_MS};
 
 /// Trigger reason sent to the posture engine worker.
@@ -174,6 +179,10 @@ pub enum PostureRecalcTrigger {
     /// An RSS safe-distance evaluation result (violation or recovery tick).
     /// safe==false activates the violation flag; safe==true advances recovery streak.
     RssViolation(RssState),
+    /// S-FI1d — a frame/localization-integrity verdict for this tick.
+    /// `Degraded`/`Untrusted` activate the frame-degraded flag (→ Degraded);
+    /// sustained `Untrusted` escalates to LockedOut; `Trusted` advances recovery.
+    FrameIntegrityChanged { trust: FrameTrust },
     /// Periodic liveness refresh — recompute and re-stamp the cache so it
     /// never idles past POSTURE_CACHE_TTL_MS. Not tied to any state change.
     /// A no-change recompute produces no transition (no broadcast) but DOES
@@ -196,6 +205,8 @@ impl fmt::Display for PostureRecalcTrigger {
             Self::RssViolation(rss) =>
                 write!(f, "RssViolation(safe={}, lon={:.2}, lat={:.2})",
                     rss.safe, rss.longitudinal_margin, rss.lateral_margin),
+            Self::FrameIntegrityChanged { trust } =>
+                write!(f, "FrameIntegrityChanged({trust:?})"),
             Self::PeriodicRefresh =>
                 write!(f, "PeriodicRefresh"),
         }
@@ -254,6 +265,103 @@ pub fn apply_rss_state(app: &Arc<AppState>, rss: &RssState, now_ms: u64) {
                     required = AV_RECOVERY_STREAK_THRESHOLD,
                     "RSS recovery streak advancing"
                 );
+            }
+        }
+    }
+}
+
+/// Applies a frame/localization-integrity verdict to `AppState` (S-FI1d).
+///
+/// Posture mapping (confirmed; see `docs/safety/STAGE_S-FI1_FRAME_INTEGRITY_GATE.md`):
+///   - `Trusted`   → advance the recovery streak; clear `frame_degraded_active`
+///     once `AV_RECOVERY_STREAK_THRESHOLD` consecutive trusted ticks land within
+///     `AV_RECOVERY_WINDOW_MS`. Resets the untrusted-escalation streak.
+///   - `Degraded`  → set `frame_degraded_active` IMMEDIATELY (→ Degraded). NOT a
+///     sustained-fault signal, so the untrusted streak resets.
+///   - `Untrusted` → set `frame_degraded_active` IMMEDIATELY (→ Degraded MRC, the
+///     frame-trust-minimal maneuver); advance the inverted untrusted streak and,
+///     on reaching the threshold within the window, set the STICKY
+///     `frame_lockout_active` (→ LockedOut, human reset).
+///
+/// Fail-closed-immediately: the drop to Degraded happens on the FIRST sub-trusted
+/// tick — hysteresis governs only the Degraded→LockedOut escalation and the
+/// recovery earn-back, never a grace period on the initial response.
+// SAFETY: SG2 | REQ: frame-integrity-escalates-posture | TEST: test_frame_degraded_escalates_immediately,test_frame_untrusted_sustained_locks_out,test_frame_trusted_recovery_clears_degraded,test_frame_lockout_is_sticky
+pub fn apply_frame_integrity_state(app: &Arc<AppState>, trust: FrameTrust, now_ms: u64) {
+    match trust {
+        FrameTrust::Trusted => {
+            // Recovery: only meaningful while a frame degradation is active.
+            if app.frame_degraded_active.load(Ordering::SeqCst) {
+                if let Ok(mut streak) = app.frame_recovery_streak.lock() {
+                    if streak.start_ms > 0
+                        && now_ms.saturating_sub(streak.start_ms) >= AV_RECOVERY_WINDOW_MS
+                    {
+                        streak.count = 0;
+                        streak.start_ms = 0;
+                    }
+                    if streak.start_ms == 0 {
+                        streak.start_ms = now_ms;
+                    }
+                    streak.count += 1;
+                    if streak.count >= AV_RECOVERY_STREAK_THRESHOLD {
+                        app.frame_degraded_active.store(false, Ordering::SeqCst);
+                        streak.count = 0;
+                        streak.start_ms = 0;
+                        tracing::info!(
+                            threshold = AV_RECOVERY_STREAK_THRESHOLD,
+                            "Frame-integrity recovery confirmed — frame degradation cleared"
+                        );
+                    }
+                }
+            }
+            // A trusted tick breaks any sustained-untrusted run.
+            if let Ok(mut s) = app.frame_untrusted_streak.lock() {
+                s.count = 0;
+                s.start_ms = 0;
+            }
+            // NOTE: `frame_lockout_active` is sticky (human reset) and is NOT
+            // cleared here — matching LockedOut semantics.
+        }
+        FrameTrust::Degraded => {
+            // Immediate Degraded; reset both streaks (not a recovery, not a
+            // sustained-untrusted tick).
+            app.frame_degraded_active.store(true, Ordering::SeqCst);
+            if let Ok(mut s) = app.frame_recovery_streak.lock() {
+                s.count = 0;
+                s.start_ms = 0;
+            }
+            if let Ok(mut s) = app.frame_untrusted_streak.lock() {
+                s.count = 0;
+                s.start_ms = 0;
+            }
+        }
+        FrameTrust::Untrusted => {
+            // Immediate Degraded MRC; a trusted recovery must restart from scratch.
+            app.frame_degraded_active.store(true, Ordering::SeqCst);
+            if let Ok(mut s) = app.frame_recovery_streak.lock() {
+                s.count = 0;
+                s.start_ms = 0;
+            }
+            // Inverted streak toward the sticky LockedOut escalation.
+            if let Ok(mut streak) = app.frame_untrusted_streak.lock() {
+                if streak.start_ms > 0
+                    && now_ms.saturating_sub(streak.start_ms) >= AV_RECOVERY_WINDOW_MS
+                {
+                    streak.count = 0;
+                    streak.start_ms = 0;
+                }
+                if streak.start_ms == 0 {
+                    streak.start_ms = now_ms;
+                }
+                streak.count += 1;
+                if streak.count >= AV_RECOVERY_STREAK_THRESHOLD {
+                    app.frame_lockout_active.store(true, Ordering::SeqCst);
+                    tracing::error!(
+                        reason = %LockoutReason::FrameIntegrityUntrusted,
+                        streak = streak.count,
+                        "Sustained Untrusted frame integrity — escalating fleet to LockedOut (human reset)"
+                    );
+                }
             }
         }
     }
@@ -324,8 +432,14 @@ pub fn start_posture_engine_worker(
 
                     let now = now_ms_engine();
                     for trigger in &batch {
-                        if let PostureRecalcTrigger::RssViolation(ref rss) = *trigger {
-                            apply_rss_state(&app, rss, now);
+                        match *trigger {
+                            PostureRecalcTrigger::RssViolation(ref rss) => {
+                                apply_rss_state(&app, rss, now);
+                            }
+                            PostureRecalcTrigger::FrameIntegrityChanged { trust } => {
+                                apply_frame_integrity_state(&app, trust, now);
+                            }
+                            _ => {}
                         }
                     }
 
@@ -364,6 +478,78 @@ mod posture_engine_v2_tests {
         assert_eq!(LockoutReason::PostureEngineFailure.to_string(), "POSTURE_ENGINE_FAILURE");
         assert_eq!(LockoutReason::WatchdogTimeout.to_string(),      "WATCHDOG_TIMEOUT");
         assert_eq!(LockoutReason::ManualLockout.to_string(),        "MANUAL_LOCKOUT");
+        assert_eq!(LockoutReason::FrameIntegrityUntrusted.to_string(), "FRAME_INTEGRITY_UNTRUSTED");
+    }
+
+    // --- S-FI1d: frame-integrity posture coupling ---------------------------
+
+    fn frame_app() -> Arc<AppState> {
+        use crate::verifier::VerifierOperationMode;
+        use crate::verifier_store::VerifierStore;
+        let store = VerifierStore::new(":memory:").unwrap();
+        Arc::new(AppState::new(store, VerifierOperationMode::Active))
+    }
+
+    #[test]
+    fn test_frame_degraded_escalates_immediately() {
+        let app = frame_app();
+        // A SINGLE Degraded tick sets the flag — no grace period.
+        apply_frame_integrity_state(&app, FrameTrust::Degraded, 1_000);
+        assert!(app.frame_degraded_active.load(Ordering::SeqCst));
+        assert!(!app.frame_lockout_active.load(Ordering::SeqCst),
+            "Degraded must not by itself lock out");
+    }
+
+    #[test]
+    fn test_frame_untrusted_escalates_immediately_then_locks_out_when_sustained() {
+        let app = frame_app();
+        // First Untrusted tick → immediate Degraded, not yet LockedOut.
+        apply_frame_integrity_state(&app, FrameTrust::Untrusted, 1_000);
+        assert!(app.frame_degraded_active.load(Ordering::SeqCst));
+        assert!(!app.frame_lockout_active.load(Ordering::SeqCst),
+            "a single Untrusted tick is the transient decel-to-stop MRC, not LockedOut");
+        // Sustained Untrusted within the window → sticky LockedOut.
+        for i in 1..AV_RECOVERY_STREAK_THRESHOLD {
+            apply_frame_integrity_state(&app, FrameTrust::Untrusted, 1_000 + i as u64 * 10);
+        }
+        assert!(app.frame_lockout_active.load(Ordering::SeqCst),
+            "sustained Untrusted ({AV_RECOVERY_STREAK_THRESHOLD} ticks) must escalate to LockedOut");
+    }
+
+    #[test]
+    fn test_frame_trusted_recovery_clears_degraded() {
+        let app = frame_app();
+        apply_frame_integrity_state(&app, FrameTrust::Degraded, 1_000);
+        assert!(app.frame_degraded_active.load(Ordering::SeqCst));
+        // A full streak of Trusted ticks within the window clears the degradation.
+        for i in 0..AV_RECOVERY_STREAK_THRESHOLD {
+            apply_frame_integrity_state(&app, FrameTrust::Trusted, 1_010 + i as u64 * 10);
+        }
+        assert!(!app.frame_degraded_active.load(Ordering::SeqCst),
+            "a full Trusted recovery streak must clear frame_degraded_active");
+    }
+
+    #[test]
+    fn test_frame_lockout_is_sticky_across_trusted() {
+        let app = frame_app();
+        for i in 0..AV_RECOVERY_STREAK_THRESHOLD {
+            apply_frame_integrity_state(&app, FrameTrust::Untrusted, 1_000 + i as u64 * 10);
+        }
+        assert!(app.frame_lockout_active.load(Ordering::SeqCst), "precondition: locked out");
+        // Trusted recovery does NOT clear a sustained-fault lockout (human reset only).
+        for i in 0..AV_RECOVERY_STREAK_THRESHOLD * 2 {
+            apply_frame_integrity_state(&app, FrameTrust::Trusted, 2_000 + i as u64 * 10);
+        }
+        assert!(app.frame_lockout_active.load(Ordering::SeqCst),
+            "frame_lockout_active must be sticky — only a human/HA reset clears it");
+    }
+
+    #[test]
+    fn test_frame_integrity_trigger_display() {
+        let t = PostureRecalcTrigger::FrameIntegrityChanged { trust: FrameTrust::Untrusted };
+        let s = t.to_string();
+        assert!(s.contains("FrameIntegrityChanged"));
+        assert!(s.contains("Untrusted"));
     }
 
     #[test]

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -259,6 +259,27 @@ pub struct AppState {
     pub supervisor_tripped: Arc<AtomicBool>,
     /// Recovery streak for clearing an active RSS violation.
     pub rss_recovery_streak: Arc<Mutex<RssRecoveryStreak>>,
+    /// S-FI1d — true while frame/localization integrity is below full `Trusted`
+    /// (a `Degraded` *or* `Untrusted` verdict). Read by the posture engine to
+    /// escalate Nominal → Degraded, exactly like `rss_active_violation`. Set
+    /// IMMEDIATELY on the first sub-trusted tick (fail-closed-immediately, no
+    /// grace period); cleared by an `AV_RECOVERY_STREAK_THRESHOLD`-long run of
+    /// `Trusted` ticks (auto-recovery). Defaults false. (AOU-LOCALIZATION-001.)
+    pub frame_degraded_active: Arc<AtomicBool>,
+    /// S-FI1d — true once frame integrity has been `Untrusted` for a SUSTAINED
+    /// run (an inverted streak): a transient localization loss is the
+    /// frame-trust-minimal Degraded MRC (decel-to-stop, auto-recovering), but a
+    /// sustained / repeated fault is a genuine failure (sensor death, possible
+    /// GNSS spoofing) and escalates to `LockedOut`. STICKY like
+    /// `supervisor_tripped` — recovery is an explicit human/HA reset, matching
+    /// LockedOut semantics. Defaults false.
+    pub frame_lockout_active: Arc<AtomicBool>,
+    /// Recovery streak for clearing `frame_degraded_active` (consecutive
+    /// `Trusted` ticks within the recovery window).
+    pub frame_recovery_streak: Arc<Mutex<RssRecoveryStreak>>,
+    /// Inverted streak counting consecutive `Untrusted` ticks toward the
+    /// `frame_lockout_active` escalation (sustained-fault detection).
+    pub frame_untrusted_streak: Arc<Mutex<RssRecoveryStreak>>,
     /// #104 — the currently-open post-incident forensic sequence (correlation id
     /// + ordinal), or `None` when no incident is open. Volatile; the durable
     /// forensic record lives in the signed audit chain.
@@ -298,6 +319,10 @@ impl AppState {
             flood_condition_active: Arc::new(AtomicBool::new(false)),
             supervisor_tripped: Arc::new(AtomicBool::new(false)),
             rss_recovery_streak: Arc::new(Mutex::new(RssRecoveryStreak { count: 0, start_ms: 0 })),
+            frame_degraded_active: Arc::new(AtomicBool::new(false)),
+            frame_lockout_active: Arc::new(AtomicBool::new(false)),
+            frame_recovery_streak: Arc::new(Mutex::new(RssRecoveryStreak { count: 0, start_ms: 0 })),
+            frame_untrusted_streak: Arc::new(Mutex::new(RssRecoveryStreak { count: 0, start_ms: 0 })),
             current_incident: Arc::new(Mutex::new(None)),
             post_incident_write_failures: Arc::new(AtomicU64::new(0)),
             command_source_write_failures: Arc::new(AtomicU64::new(0)),

--- a/src/wcet_gate.rs
+++ b/src/wcet_gate.rs
@@ -372,6 +372,7 @@ mod ci_gate_tests {
             MAX_CORRIDOR_VERTICES, MAX_TRAJECTORY_HORIZON,
         };
         use crate::gateway::kinematics_contract::VehicleKinematicsContract;
+        use kirra_core::frame_integrity::FrameTrust;
 
         let n = MAX_CORRIDOR_VERTICES;
         let half_w = 6.0;
@@ -409,6 +410,8 @@ mod ci_gate_tests {
                 std::hint::black_box(&traj),
                 std::hint::black_box(&corridor),
                 std::hint::black_box(&footprint),
+                // WCET measures the Nominal hot path: Trusted → primary 0.40 m margin.
+                std::hint::black_box(FrameTrust::Trusted),
             ));
         });
         let max_us = max_ns / 1000;


### PR DESCRIPTION
## Summary

Makes the frame-integrity gate (behind `AOU-LOCALIZATION-001`) **live end-to-end**, building on the merged S-FI1a/b (#516). Three sub-stages:

- **S-FI1c** — unify the localization-integrity type into one canonical `kirra-core` verdict (no drift).
- **S-FI1d** — the fleet posture engine now *reacts* to frame integrity.
- **S-FI1e** — collapse the shim; thread a real `FrameTrust` to the production containment call site.

## S-FI1c — unify at the parko-kirra boundary

`parko-core` deliberately has no `kirra-core` dependency (the manifest keeps the ML inference pipeline independent of the safety kernel), and the localization type was used *only* by parko-kirra. So instead of coupling parko-core → kirra-core, the unification happens at the consumer:
- `parko-core/localization.rs` drops `LocalizationIntegrity`/`LocalizationCfg`/`localization_trusted` (+ `test_loc_*`); keeps only the bool-driven `gate_*_scene`. parko-core stays kirra-core-free.
- parko-kirra wrappers take `&FrameIntegrity` and compute the **strict** view `matches!(resolve_frame_trust(..), FrameTrust::Trusted)` — the discrete map-anchored vetoes demand full `Trusted`, where containment tolerates the 0.75 m `Degraded` band (the two-thresholds-one-input asymmetry). Behaviour identical to the old 0.10 m gate.

## S-FI1d — posture coupling (mirrors RSS/flood exactly)

- AppState: `frame_degraded_active` + `frame_lockout_active` + two streaks.
- `posture_engine`: `frame_degraded_active` joins the rss/flood OR-chain (Nominal → Degraded); `frame_lockout_active` joins `supervisor_tripped` at absolute LockedOut priority. Composes; never downgrades a DAG LockedOut; auto-recovers when clear.
- `posture_engine_v2`: `PostureRecalcTrigger::FrameIntegrityChanged { trust }`, `LockoutReason::FrameIntegrityUntrusted`, and `apply_frame_integrity_state()` — **immediate Degraded on the first sub-trusted tick** (no grace period); **sustained `Untrusted` → sticky `frame_lockout_active`** (human reset); a full `Trusted` streak auto-clears the Degraded earn-back.

Confirmed mapping: Trusted→Nominal; Degraded/transient-Untrusted→Degraded (decel-to-stop MRC, the frame-trust-minimal maneuver); sustained Untrusted→LockedOut.

## S-FI1e — collapse the shim, go live

- **Shim collapsed**: the 3-arg `validate_trajectory_containment` is gone; the 4-arg gated entry (`frame_trust: FrameTrust`) is now canonical.
- **One production call site** (correction to the original plan, verified in code): the ros2-adapter slow loop. CLAUDE.md's "four enforcement points" are the *decel gate*, a different function — fabric/parko-kirra/HTTP don't call containment.
- `validate_trajectory_slow_capped` gains `frame_trust`; the convenience wrapper `validate_trajectory_slow` keeps its signature (passes `Trusted`), so its **~50 doer-side callers (planner/taj/mick) are untouched**.
- **Live-gate proof**: an adapter integration test shows the SAME clean trajectory is Accepted under `Trusted` and MRC'd under `Untrusted`.

## Open item (integrator contract)

The production node passes `FrameTrust::Trusted` (= the existing `AOU-LOCALIZATION-001` assumption, 0.40 m) with an explicit comment, mirroring the existing pre-wiring `None`s for `visibility_range_m`/`predicted_modes`. **Wiring a real node-side localization-quality source (`FrameIntegrity` → `resolve_frame_trust`) is the remaining integrator-contract work.** A sustained fault still escalates posture → LockedOut (S-FI1d), which the slow loop short-circuits to MRC, so the node is not unprotected in the interim.

## Safety / status

- **PROPOSED — not a safety claim.** The stage spec carries the banner + RTM guardrail: S-FI1 must **not** be counted ENFORCED in `TRACEABILITY_MATRIX` until **S-FI1f** (RTM/AoU updates + ADR-0016), which is the only remaining sub-stage.
- The frozen `validate_vehicle_command` talisman is untouched; this is the SG2 sibling + posture engine only.

## Verification

`kirra-core` 153 · `parko-core` 198 · `parko-kirra` 148 · `kirra-ros2-adapter` (default) all green incl. the live-gate test · 47 posture tests. Full-workspace `cargo check` + clippy clean. `node.rs` is `ros2`-gated (no ROS in the dev env) — validated by the CI `ros2 adapter build` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWXgETCGcdP6XXErwLHkFk)_