### PR TITLE
Stage S-PK1 — Platform Kinematics: spec + S-PK1a (Ackermann) + S-PK1b (diff-drive)

### DIFF
--- a/crates/kirra-core/src/lib.rs
+++ b/crates/kirra-core/src/lib.rs
@@ -41,6 +41,13 @@ pub mod containment;
 /// This sub-stage is the module only — it does not yet touch containment / posture / parko.
 pub mod frame_integrity;
 
+/// The platform-kinematics abstraction (Stage S-PK1) — one platform-parameterized
+/// governor surface (`PlatformKinematics` / `PlatformVerdict` / `AckermannPlatform`)
+/// so containment / RSS / decel-to-stop extend to non-Ackermann platforms. The
+/// Ackermann impl is a verbatim adapter over the frozen `validate_vehicle_command`;
+/// PROPOSED design of record in `docs/safety/STAGE_S-PK1_PLATFORM_KINEMATICS.md`.
+pub mod platform_kinematics;
+
 /// The shared non-finite governor-input guard (`all_finite`, the #410 convergence point).
 /// A dependency-free predicate every governor entry calls. Relocated here verbatim
 /// (de-monolith Stage 5); re-exported by `kirra_verifier::governor_guard` so the

--- a/crates/kirra-core/src/platform_kinematics.rs
+++ b/crates/kirra-core/src/platform_kinematics.rs
@@ -43,10 +43,12 @@ use crate::kinematics_contract::{
 pub trait PlatformVerdict {
     /// True iff the command was admitted (possibly clamped) — i.e. NOT a breach.
     fn is_admitted(&self) -> bool;
-    /// The byte-stable audit/deny reason token when the verdict denies, else
-    /// `None`. (For Ackermann this is `DenyCode::reason()`, preserving the
-    /// existing audit-chain strings.)
-    fn deny_reason(&self) -> Option<&'static str>;
+    /// The audit/deny reason token when the verdict denies, else `None`.
+    /// Borrowed from the verdict (`&self` lifetime), so platforms with a
+    /// `&'static` token (Ackermann's `DenyCode::reason()`) and platforms with a
+    /// runtime reason string (e.g. parko's `EnforcementAction::Deny { reason }`)
+    /// both fit — surfaced by the differential-drive sibling (S-PK1b).
+    fn deny_reason(&self) -> Option<&str>;
 }
 
 /// The frozen Ackermann verdict ([`EnforceAction`]) is admitted unless it is a
@@ -55,7 +57,7 @@ impl PlatformVerdict for EnforceAction {
     fn is_admitted(&self) -> bool {
         !matches!(self, EnforceAction::DenyBreach(_))
     }
-    fn deny_reason(&self) -> Option<&'static str> {
+    fn deny_reason(&self) -> Option<&str> {
         match self {
             EnforceAction::DenyBreach(code) => Some(code.reason()),
             _ => None,

--- a/crates/kirra-core/src/platform_kinematics.rs
+++ b/crates/kirra-core/src/platform_kinematics.rs
@@ -1,0 +1,223 @@
+//! **kirra-core platform-kinematics abstraction** (Stage S-PK1a).
+//!
+//! One platform-parameterized governor surface so the existing safety
+//! architecture (envelope, containment, RSS, decel-to-stop, frame-integrity)
+//! extends to non-Ackermann platforms. See
+//! `docs/safety/STAGE_S-PK1_PLATFORM_KINEMATICS.md`.
+//!
+//! # The shared surface is minimal and behavioral (D1–D3)
+//!
+//! Each platform's *shape* stays in its impl; the trait exposes only the safety
+//! *primitives* the cross-checks consume:
+//! - [`PlatformKinematics::evaluate`] — the per-command kinematic verdict (the
+//!   talisman's job for Ackermann), returning a platform-specific
+//!   [`PlatformKinematics::Verdict`] bounded by [`PlatformVerdict`] so audit /
+//!   posture / consumer-safe-stop act on any platform uniformly.
+//! - [`PlatformKinematics::footprint`] — for SG2 containment.
+//! - [`PlatformKinematics::max_speed_mps`] / [`max_brake_mps2`] /
+//!   [`stop_epsilon_mps`] — the limits the decel-to-stop gate / RSS reason about.
+//!
+//! **Mechanism is hidden.** `wheelbase_m`, steering geometry, ICR, etc. stay
+//! private to the impl's `evaluate`; the moment one is on the trait, that
+//! platform has leaked into the abstraction.
+//!
+//! # S-PK1a scope
+//!
+//! This sub-stage adds the trait + bound + the **Ackermann verbatim adapter**
+//! only. The adapter's `evaluate` *literally calls* the frozen
+//! [`validate_vehicle_command`], so behaviour is unchanged by construction; the
+//! equivalence test proves it. The differential-drive sibling and the
+//! containment/RSS wiring are S-PK1b / S-PK1c. The scalar `KirraKernelGovernor`
+//! is the composable primitive (clamp + rate-limit), **not** a platform (D3).
+
+use crate::containment::VehicleFootprint;
+use crate::kinematics_contract::{
+    validate_vehicle_command, EnforceAction, ProposedVehicleCommand, VehicleKinematicsContract,
+    STOP_EPSILON_MPS,
+};
+
+/// Uniform safety view over any platform's per-command verdict, so the audit /
+/// posture / consumer-safe-stop paths act on every platform identically without
+/// knowing its actuation shape. The bound is deliberately tiny — per-platform
+/// fidelity lives in the concrete verdict type, not here.
+pub trait PlatformVerdict {
+    /// True iff the command was admitted (possibly clamped) — i.e. NOT a breach.
+    fn is_admitted(&self) -> bool;
+    /// The byte-stable audit/deny reason token when the verdict denies, else
+    /// `None`. (For Ackermann this is `DenyCode::reason()`, preserving the
+    /// existing audit-chain strings.)
+    fn deny_reason(&self) -> Option<&'static str>;
+}
+
+/// The frozen Ackermann verdict ([`EnforceAction`]) is admitted unless it is a
+/// `DenyBreach`. This impl reads the existing enum; it does not change it.
+impl PlatformVerdict for EnforceAction {
+    fn is_admitted(&self) -> bool {
+        !matches!(self, EnforceAction::DenyBreach(_))
+    }
+    fn deny_reason(&self) -> Option<&'static str> {
+        match self {
+            EnforceAction::DenyBreach(code) => Some(code.reason()),
+            _ => None,
+        }
+    }
+}
+
+/// A platform the governor bounds spatially. One abstraction *for platforms*;
+/// the scalar clamp/rate-limit primitive that platforms are *built from* is a
+/// separate thing (the `KirraKernelGovernor`), never a `PlatformKinematics`.
+pub trait PlatformKinematics {
+    /// The proposed-command type this platform evaluates (Ackermann:
+    /// [`ProposedVehicleCommand`]).
+    type Command;
+    /// Per-tick state beyond the command, if any (Ackermann is stateless — the
+    /// current velocity/steering ride in the command — so `()`).
+    type State;
+    /// The platform-specific verdict (Ackermann: [`EnforceAction`], unchanged).
+    type Verdict: PlatformVerdict;
+
+    /// Per-command kinematic verdict — the hard-envelope check.
+    fn evaluate(&self, command: &Self::Command, state: &Self::State) -> Self::Verdict;
+
+    /// 2D spatial footprint for SG2 drivable-space containment.
+    fn footprint(&self) -> VehicleFootprint;
+
+    /// Maximum permitted speed magnitude (m/s) — a hard upper bound the
+    /// cross-checks reason about.
+    fn max_speed_mps(&self) -> f64;
+    /// Maximum service-braking deceleration magnitude (m/s²) — the decel
+    /// capability the decel-to-stop gate / RSS reason about.
+    fn max_brake_mps2(&self) -> f64;
+    /// Speed magnitude at/below which the platform is "stopped" for the
+    /// converge-to-zero / no-re-initiation rule.
+    fn stop_epsilon_mps(&self) -> f64;
+}
+
+/// Ackermann (bicycle-model) platform — a **verbatim adapter** over the frozen
+/// kinematics-contract talisman. `evaluate` calls [`validate_vehicle_command`]
+/// unchanged; `footprint` is the existing [`VehicleFootprint`] projection. The
+/// AV safety case is preserved exactly: this wraps the talisman, never modifies
+/// it.
+#[derive(Debug, Clone)]
+pub struct AckermannPlatform {
+    pub contract: VehicleKinematicsContract,
+}
+
+impl AckermannPlatform {
+    pub fn new(contract: VehicleKinematicsContract) -> Self {
+        Self { contract }
+    }
+}
+
+// SAFETY: SG9 SG2 | REQ: platform-kinematics-ackermann-adapter | TEST: ackermann_evaluate_is_verbatim_validate_vehicle_command,ackermann_footprint_matches_contract_projection,ackermann_verdict_admitted_and_reason,ackermann_accessors_mirror_contract
+impl PlatformKinematics for AckermannPlatform {
+    type Command = ProposedVehicleCommand;
+    type State = ();
+    type Verdict = EnforceAction;
+
+    #[inline]
+    fn evaluate(&self, command: &ProposedVehicleCommand, _state: &()) -> EnforceAction {
+        // VERBATIM — the frozen talisman. Zero behaviour delta by construction.
+        validate_vehicle_command(command, &self.contract)
+    }
+
+    #[inline]
+    fn footprint(&self) -> VehicleFootprint {
+        VehicleFootprint::from(&self.contract)
+    }
+
+    #[inline]
+    fn max_speed_mps(&self) -> f64 {
+        self.contract.max_speed_mps
+    }
+
+    #[inline]
+    fn max_brake_mps2(&self) -> f64 {
+        self.contract.max_brake_mps2
+    }
+
+    #[inline]
+    fn stop_epsilon_mps(&self) -> f64 {
+        STOP_EPSILON_MPS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contract() -> VehicleKinematicsContract {
+        VehicleKinematicsContract::nominal_reference_profile()
+    }
+
+    fn cmd(linear: f64, current: f64, dt: f64, steer: f64, cur_steer: f64) -> ProposedVehicleCommand {
+        ProposedVehicleCommand {
+            linear_velocity_mps: linear,
+            current_velocity_mps: current,
+            delta_time_s: dt,
+            steering_angle_deg: steer,
+            current_steering_angle_deg: cur_steer,
+        }
+    }
+
+    /// THE zero-delta proof: the adapter's verdict is identical to calling the
+    /// frozen talisman directly, across a battery covering Allow / Clamp / Deny /
+    /// NaN paths.
+    #[test]
+    fn ackermann_evaluate_is_verbatim_validate_vehicle_command() {
+        let c = contract();
+        let platform = AckermannPlatform::new(c.clone());
+        let battery = [
+            cmd(5.0, 5.0, 0.1, 0.0, 0.0),        // clean → Allow
+            cmd(1000.0, 5.0, 0.1, 0.0, 0.0),     // over speed → Clamp/Deny
+            cmd(5.0, 5.0, 0.1, 90.0, 0.0),       // over steering
+            cmd(5.0, 5.0, 0.1, 10.0, 0.0),       // lateral-accel territory
+            cmd(f64::NAN, 5.0, 0.1, 0.0, 0.0),   // NaN → DenyBreach
+            cmd(5.0, 5.0, 0.0, 0.0, 0.0),        // dt=0 → DenyBreach
+            cmd(-3.0, -2.0, 0.1, -5.0, -5.0),    // reverse
+        ];
+        for command in battery {
+            assert_eq!(
+                platform.evaluate(&command, &()),
+                validate_vehicle_command(&command, &c),
+                "adapter must be byte-identical to the talisman for {command:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ackermann_footprint_matches_contract_projection() {
+        let c = contract();
+        let platform = AckermannPlatform::new(c.clone());
+        let direct = VehicleFootprint::from(&c);
+        let viatrait = platform.footprint();
+        assert_eq!(direct.width_m, viatrait.width_m);
+        assert_eq!(direct.length_m, viatrait.length_m);
+        assert_eq!(direct.wheelbase_m, viatrait.wheelbase_m);
+        assert_eq!(direct.overhang_front_m, viatrait.overhang_front_m);
+        assert_eq!(direct.overhang_rear_m, viatrait.overhang_rear_m);
+    }
+
+    #[test]
+    fn ackermann_verdict_admitted_and_reason() {
+        // Allow is admitted with no reason; a NaN command denies with the
+        // existing byte-stable token.
+        assert!(EnforceAction::Allow.is_admitted());
+        assert_eq!(EnforceAction::Allow.deny_reason(), None);
+
+        let c = contract();
+        let platform = AckermannPlatform::new(c);
+        let denied = platform.evaluate(&cmd(f64::NAN, 5.0, 0.1, 0.0, 0.0), &());
+        assert!(!denied.is_admitted(), "a NaN command must not be admitted");
+        assert!(denied.deny_reason().is_some(), "a denied verdict must carry a reason token");
+    }
+
+    #[test]
+    fn ackermann_accessors_mirror_contract() {
+        let c = contract();
+        let platform = AckermannPlatform::new(c.clone());
+        assert_eq!(platform.max_speed_mps(), c.max_speed_mps);
+        assert_eq!(platform.max_brake_mps2(), c.max_brake_mps2);
+        assert_eq!(platform.stop_epsilon_mps(), STOP_EPSILON_MPS);
+    }
+}

--- a/docs/safety/STAGE_S-PK1_PLATFORM_KINEMATICS.md
+++ b/docs/safety/STAGE_S-PK1_PLATFORM_KINEMATICS.md
@@ -1,0 +1,184 @@
+# Stage S-PK1 — Platform Kinematics (one platform-parameterized governor)
+
+> ## ⚠ PROPOSED — NOT A SAFETY CLAIM
+> This is a **design proposal**. It is **not implementation** and confers **no
+> safety coverage** until **ACCEPTED via ADR-0017** and its sub-stages land. The
+> RTM / `TRACEABILITY_MATRIX` must **NOT** list S-PK1 (or any new-platform safety
+> goal) as ENFORCED until the corresponding sub-stage is complete. A PROPOSED
+> safety doc is fine in `docs/safety/`; a PROPOSED doc *counted as coverage* is the
+> failure mode this banner prevents.
+
+**Status:** PROPOSED — design-for-review. No code written. Awaiting owner sign-off.
+**Date:** 2026-06-24
+**Owner:** Kirra Systems, LLC
+**Scope:** Lift the governor's three scattered, platform-specific expressions into a
+single **platform-parameterized kinematic contract** so the existing safety
+surface (envelope, containment, RSS, decel-to-stop, frame-integrity) extends to
+non-Ackermann platforms. This is the Track-3 keystone: the prerequisite for the
+doer–checker thesis to hold *at all* on a new platform.
+**Future decision of record:** ADR-0017 (filed on acceptance).
+**Companion:** the frame-integrity gate (`STAGE_S-FI1_FRAME_INTEGRITY_GATE.md`) is
+the model for format and discipline.
+
+---
+
+## 1. Problem (grounded in code)
+
+The governor's safety surface is **Ackermann-shaped**, and the platform expressions
+are **scattered across three places**, not parameterized behind one abstraction:
+
+1. **Ackermann bicycle** — `VehicleKinematicsContract` + `validate_vehicle_command`
+   (`crates/kirra-core/src/kinematics_contract.rs`): `max_steering_deg`,
+   `wheelbase_m`, lateral accel `a_lat = v²·tan(δ)/L`. The **angular channel is
+   "intentionally NOT gated here for the Ackermann"** (`kinematics_contract.rs:354`)
+   — it is implied by speed × steering.
+2. **Differential drive** — a **separate** angular-velocity channel bolted on in
+   `parko-kirra` (`angular_bound.rs`, `diverse.rs`; #407), applying the
+   converge-to-zero / no-re-initiation rule to an independent `ω` channel via
+   `STOP_EPSILON_RAD_S`.
+3. **Generic scalar** — `KirraKernelGovernor<C: SafetyContract>`
+   (`src/kirra_core.rs`): a third primitive that clamps a single scalar against a
+   `SafetyContract`.
+
+And **containment is 2D only** — `validate_trajectory_containment`
+(`crates/kirra-core/src/containment.rs`) has **no z / altitude / joint** terms
+(verified: zero such fields).
+
+**Consequence.** The governor can only bound a robot whose physics it can
+*express*. Today it cannot express a diff-drive's envelope in one place, let alone
+an omni or a quadrotor. So on any non-Ackermann platform, *every doer* (nav,
+SLAM, planning, behavior) would be **unbounded** until a platform-parameterized
+contract exists.
+
+## 2. The two risk classes (same lens as S-FI1)
+
+Frame-integrity reordered Track 2 by splitting items into *frame-defining* (the
+checker's own inputs, which it cannot de-risk) vs *doer-side* (bounded by the
+checker). Track 3 splits the same way — and **only one item is checker-side**:
+
+**Checker-side (extends the safety guarantee to new platforms):**
+- **#2 Platform kinematics** — THE keystone. The governor's ability to *express* a
+  platform's envelope is part of the safety surface, not a doer. Until #2 lands,
+  the doers below are unbounded on any non-Ackermann platform.
+- *(Sub-item, smaller)* **free-space containment** hiding inside #1 — see §6.
+
+**Doer-side (bounded by the existing checker once #2 lands → build per-platform):**
+- #1 free-space navigation, #3 SLAM, #4 fleet orchestration, #5 behavior framework.
+
+## 3. The payoff — Track 3 is mostly Track 2 re-parameterized
+
+These are **not** parallel greenfields; they reuse the existing safety core:
+
+| Track-3 doer | Re-uses | Behind which checker |
+|---|---|---|
+| #3 SLAM | Track-2 localization (a different doer) | the **same** S-FI1 frame-integrity gate |
+| #1 free-space nav | Track-2 planning | the **same** SG2 containment (corridor+footprint, polygon inside-test — lane-agnostic; the lane assumption lives in `kirra-map`, the doer's map, not the governor) |
+| #5 behavior framework | the existing `action_filter`/`action_policy` (LLM-action→governor) and Mick (intent→governor) | the governor envelope — skills propose, the governor bounds |
+
+So building **#2 extends the entire existing safety architecture** — envelope,
+containment, RSS, decel-to-stop, frame-integrity — to new platforms **at once**.
+The rest is doer capability we already know how to bound.
+
+## 4. The design crux — unify the VERDICT, not just the envelope
+
+"Same checker, different envelope" is true for **containment** (a polygon
+inside-test is drive-agnostic). It is **NOT** sufficient for the **kinematic
+contract verdict**, which is where the three expressions genuinely differ:
+
+- Ackermann returns `EnforceAction{ Allow, ClampLinear(f64), ClampSteering(f64),
+  DenyBreach(DenyCode) }`. **`ClampSteering` is meaningless for differential
+  drive**, which clamps *angular velocity* `ω`, not a steering angle. The scalar
+  kernel has yet another shape.
+
+So a `PlatformKinematics` abstraction must reconcile **clamp semantics** across
+drive types, not just swap numbers behind one `EnforceAction`. This is the open
+design question this stage must answer. Two candidate shapes:
+
+- **(A) Generalized verdict** — a drive-agnostic actuation verdict with a
+  *longitudinal* channel and an *angular* channel (`ClampAngular(f64)`), where
+  Ackermann maps steering→angular via the bicycle relation and diff-drive uses
+  `ω` directly. One verdict type; per-platform channel meaning.
+- **(B) Associated verdict type** — `trait PlatformKinematics { type Verdict; … }`,
+  Ackermann's `Verdict = EnforceAction` (unchanged, frozen), diff-drive defines
+  its own. Maximal back-compat (the talisman verdict is literally untouched), at
+  the cost of N verdict types downstream consumers must handle.
+
+**Recommendation:** start from (B) for the Ackermann adapter (zero change to the
+frozen verdict — see §5), and evaluate (A) as the diff-drive sibling lands, when
+the actual channel-unification cost is concrete rather than speculative. The spec
+does not pre-commit; the trait shape is the first reviewable artifact.
+
+## 5. The non-negotiable constraint — additive around the frozen talisman
+
+`validate_vehicle_command` / `VehicleKinematicsContract` is **INV-3-adjacent
+frozen**. S-PK1 must **wrap or relocate it, never modify it** — the same
+discipline as the de-monolith (the talisman only ever gets wrapped or relocated).
+
+- The **Ackermann implementation IS the existing talisman, untouched** — exposed
+  through the new trait by a **verbatim adapter** (zero behaviour change).
+- Diff-drive / omni become **sibling implementations** under the trait.
+- This preserves the **entire existing AV safety case** while generalizing, and it
+  makes the regression argument trivial: **the existing 42 talisman tests + parko's
+  angular-channel tests are the proof that unification changed nothing.** If they
+  stay green against the verbatim adapter, the abstraction is behaviour-preserving.
+
+## 6. Free-space containment — doer-side, *conditionally*
+
+#1 (free-space nav) is doer-side **iff** free space stays a *single closed
+boundary polygon*: containment's PNPoly handles any polygon, so a
+two-polyline-corridor → closed-region swap is a doer-side map change with **at most
+a modest containment input generalization** (closed polygon vs two boundary
+polylines), not a checker rewrite.
+
+It becomes **checker-side** only if free space needs *interior keep-out holes*
+enforced **by containment** (obstacles-as-geometry) rather than by the
+planner/RSS. Multi-polygon / hole support in the inside-test is a real checker
+extension. **Decision deferred:** keep obstacles in the planner/RSS domain (#1
+stays doer-side) unless a platform requires containment-enforced keep-outs; if so,
+that is a scoped checker sub-stage (S-PK-adjacent), surfaced here so it is never
+smuggled in as "just a different polygon."
+
+## 7. Tiers (do A first)
+
+| Tier | Platforms | Checker work | Recommendation |
+|---|---|---|---|
+| **A — ground holonomy** | diff-drive, omni (AMR/AGV) | Unify Ackermann contract + parko's separate angular channel + the scalar kernel under one `PlatformKinematics`. **Same 2D footprint+corridor checker, different envelope + verdict.** Pieces exist, just scattered → extension, not greenfield. | **Do first.** Highest leverage, lowest risk; covers the dominant robot segment. |
+| **B — aerial** | quadrotor, etc. | **3D containment** (2D today) **AND** a new envelope (thrust/attitude/altitude-rate, not speed/steering). Both a checker extension and a Tier-A-style envelope impl. | After A. |
+| **C — manipulator** | arms | Joint-space reachable-set / self-collision — a **different safety surface**, not a parameter of the ground/aerial one. Double cost: very-high doer **plus** a whole new checker. | **Cut** unless a customer is paying for arms. |
+
+## 8. Sequencing (smallest reviewable move first, S-FI discipline)
+
+- **S-PK1a** — the `PlatformKinematics` trait + the **Ackermann impl as a verbatim
+  adapter** over the frozen `validate_vehicle_command` / `VehicleKinematicsContract`.
+  Zero behaviour change; **proven by the existing 42 talisman tests** re-run through
+  the adapter. No other code touched.
+- **S-PK1b** — the **differential-drive sibling** impl under the trait, lifting
+  parko's `angular_bound` channel into the unified shape (parko's angular tests are
+  the regression proof). Resolve the verdict-unification question (§4) here, with
+  the diff-drive verdict concrete.
+- **S-PK1c** — wire **containment + RSS** to consume `PlatformKinematics` (footprint
+  + envelope from the trait); confirm the 2D checker is drive-agnostic. Free-space
+  boundary-polygon generalization only if/when #1 needs it (§6).
+- **S-PK1d** — (optional, gated by a customer) Tier-B 3D containment + aerial
+  envelope.
+- **S-PK1e** — RTM / AoU updates + ADR-0017 to Accepted; new-platform safety goals
+  marked ENFORCED only here.
+
+## 9. What this stage explicitly does NOT do
+
+- It does **not** modify the frozen talisman (`validate_vehicle_command`).
+- It does **not** build any doer (nav / SLAM / orchestration / behavior) — those
+  are bounded *after* the trait exists.
+- It does **not** add 3D containment (Tier B) or manipulator safety (Tier C, cut).
+- It does **not** claim ENFORCED coverage for any new platform until S-PK1e.
+
+## 10. Open questions for review
+
+1. **Verdict unification (§4):** associated-type (B) first, or generalized
+   angular-channel verdict (A) up front? (Recommend B→evaluate A.)
+2. **Trait surface:** does `PlatformKinematics` expose `footprint()` + an
+   `evaluate(command, state) -> Verdict`, or separate envelope-accessor methods the
+   existing checkers read? (First reviewable artifact in S-PK1a.)
+3. **Scalar kernel:** fold `KirraKernelGovernor` in as a degenerate
+   single-channel `PlatformKinematics`, or leave it as a distinct generic? (Lean:
+   fold it, so there is genuinely *one* abstraction.)

--- a/docs/safety/STAGE_S-PK1_PLATFORM_KINEMATICS.md
+++ b/docs/safety/STAGE_S-PK1_PLATFORM_KINEMATICS.md
@@ -155,10 +155,31 @@ smuggled in as "just a different polygon."
   `validate_vehicle_command`, and an equivalence test asserts
   `AckermannPlatform.evaluate(cmd) == validate_vehicle_command(cmd, contract)` over
   a command battery; the existing talisman tests are unchanged. No other code touched.
-- **S-PK1b** — the **differential-drive sibling** impl under the trait, lifting
-  parko's `angular_bound` channel into the unified shape (parko's angular tests are
-  the regression proof). Resolve the verdict-unification question (§4) here, with
-  the diff-drive verdict concrete.
+- **S-PK1b** — ✅ the **differential-drive sibling** (`parko-kirra/src/platform.rs`):
+  `DiffDrivePlatform<G: SafetyGovernor>` wraps parko's existing diff-drive
+  `SafetyGovernor::evaluate` (verbatim), with `Command = ControlCommand`,
+  `State = DiffDriveState{previous, dt, posture}`, `Verdict = DiffDriveVerdict`.
+  D1 confirmed against a genuinely different verdict (`EnforcementAction`'s
+  explicit linear/angular clamps). **Three things the second platform surfaced:**
+  (i) **`deny_reason` generalized `&'static str` → `&str`** in the kirra-core trait
+  — parko's `Deny{reason: String}` is a runtime string, not a static token (the
+  `&'static` was an Ackermann-ism); (ii) **orphan rule** → `DiffDriveVerdict`
+  newtype over `EnforcementAction` (also keeps parko-core kirra-core-free per
+  S-FI1c); (iii) **`&State` earns its keep** — diff-drive needs previous/dt/posture
+  (Ackermann's is `()`). parko-core 198 + parko-kirra 153 tests pass; kirra-core +
+  parko clippy + workspace clean.
+
+  **Two findings flagged for review (open):**
+  - **Footprint shape.** `VehicleFootprint` is rear-axle/bicycle-shaped; diff-drive
+    uses the geometric-center convention (`wheelbase_m = 0`, symmetric overhangs)
+    via `DiffDrivePlatform::centered_footprint`. Works, but whether the shared
+    footprint type should be genericized (drive-agnostic) is a candidate S-PK1c
+    decision.
+  - **`evaluate` scope asymmetry.** Ackermann's `evaluate` is pure kinematics
+    (`validate_vehicle_command`); diff-drive's wraps `SafetyGovernor::evaluate`,
+    which in parko folds in the pushed RSS verdict — wider scope. Reflects parko's
+    existing architecture (no separate public pure-kinematic entry); separating it
+    is out of S-PK1b scope.
 - **S-PK1c** — wire **containment + RSS** to consume `PlatformKinematics` (footprint
   + envelope from the trait); confirm the 2D checker is drive-agnostic. Free-space
   boundary-polygon generalization only if/when #1 needs it (§6).

--- a/docs/safety/STAGE_S-PK1_PLATFORM_KINEMATICS.md
+++ b/docs/safety/STAGE_S-PK1_PLATFORM_KINEMATICS.md
@@ -148,10 +148,13 @@ smuggled in as "just a different polygon."
 
 ## 8. Sequencing (smallest reviewable move first, S-FI discipline)
 
-- **S-PK1a** — the `PlatformKinematics` trait + the **Ackermann impl as a verbatim
-  adapter** over the frozen `validate_vehicle_command` / `VehicleKinematicsContract`.
-  Zero behaviour change; **proven by the existing 42 talisman tests** re-run through
-  the adapter. No other code touched.
+- **S-PK1a** — ✅ the `PlatformKinematics` trait + `PlatformVerdict` bound + the
+  **Ackermann impl as a verbatim adapter** over the frozen `validate_vehicle_command`
+  / `VehicleKinematicsContract` (`crates/kirra-core/src/platform_kinematics.rs`).
+  Zero behaviour change — the adapter's `evaluate` *literally calls*
+  `validate_vehicle_command`, and an equivalence test asserts
+  `AckermannPlatform.evaluate(cmd) == validate_vehicle_command(cmd, contract)` over
+  a command battery; the existing talisman tests are unchanged. No other code touched.
 - **S-PK1b** — the **differential-drive sibling** impl under the trait, lifting
   parko's `angular_bound` channel into the unified shape (parko's angular tests are
   the regression proof). Resolve the verdict-unification question (§4) here, with
@@ -172,13 +175,65 @@ smuggled in as "just a different polygon."
 - It does **not** add 3D containment (Tier B) or manipulator safety (Tier C, cut).
 - It does **not** claim ENFORCED coverage for any new platform until S-PK1e.
 
-## 10. Open questions for review
+## 10. Design decisions (RESOLVED — owner, 2026-06-24)
 
-1. **Verdict unification (§4):** associated-type (B) first, or generalized
-   angular-channel verdict (A) up front? (Recommend B→evaluate A.)
-2. **Trait surface:** does `PlatformKinematics` expose `footprint()` + an
-   `evaluate(command, state) -> Verdict`, or separate envelope-accessor methods the
-   existing checkers read? (First reviewable artifact in S-PK1a.)
-3. **Scalar kernel:** fold `KirraKernelGovernor` in as a degenerate
-   single-channel `PlatformKinematics`, or leave it as a distinct generic? (Lean:
-   fold it, so there is genuinely *one* abstraction.)
+The three questions are one question seen from three angles — *how much of each
+platform's shape leaks into the shared surface* — and all resolve the same way:
+**keep the shared surface minimal and behavioral; per-platform shape stays in the
+impl.**
+
+**D1 — Verdict: associated type, NOT generalized-angular.**
+`trait PlatformKinematics { type Verdict: PlatformVerdict; … }`, with
+`Ackermann::Verdict = EnforceAction` **untouched** (the frozen talisman / audit
+reason strings / QNX `deny_code_num` demand byte-identity). A generalized
+angular verdict is a trap — it is the *second* platform's shape (linear+angular)
+masquerading as the abstraction; it already fails omni (`vx, vy, ω`) and aerial
+(6-DOF). The shared bound is tiny, so audit / posture / consumer-safe-stop act on
+any verdict uniformly without knowing its actuation shape:
+
+```rust
+/// Uniform safety view over any platform's per-command verdict.
+pub trait PlatformVerdict {
+    /// True iff the command was admitted (possibly clamped) — NOT a breach.
+    fn is_admitted(&self) -> bool;
+    /// Byte-stable audit/deny token when the verdict denies, else None.
+    fn deny_reason(&self) -> Option<&'static str>;
+}
+```
+
+**D2 — Trait surface: `evaluate` + `footprint()` + the few cross-check primitives.**
+Exactly the union of what the three existing sibling checks consume — no more:
+- `evaluate(&Command, &State) -> Verdict` — the per-command kinematic verdict.
+- `footprint() -> VehicleFootprint` — for SG2 containment.
+- the small kinematic *limits* the decel-to-stop gate / RSS reason about:
+  `max_speed_mps()`, `max_brake_mps2()`, `stop_epsilon_mps()`.
+
+NOT evaluate-only (that starves RSS and the decel gate, which are separate sibling
+checks today — keep them separate; give them accessors). NOT the full accessor bag:
+**mechanism stays private** (`wheelbase_m`, steering geometry, ICR live inside the
+impl's `evaluate`). The moment `wheelbase_m` is on the trait, a checker can read it
+and Ackermann has leaked into the abstraction. The trait exposes safety
+*primitives*; it hides kinematic *mechanism*.
+
+**D3 — Scalar `KirraKernelGovernor`: the composable PRIMITIVE, not a platform.**
+Folding it in is a category error: a scalar channel has **no footprint and no
+spatial containment**, so `footprint()` would return a meaningless degenerate
+value the containment check must special-case — exactly the silent-degenerate a
+safety surface must not have. It is a different *level*: `PlatformKinematics` is "a
+robot the governor bounds spatially"; the scalar kernel is "clamp one scalar with a
+rate limit" — a primitive the platform impls **compose** (a diff-drive's `evaluate`
+scalar-clamps per channel), and the lean ASIL-D / C-FFI surface (#404) keeps using
+it directly. One abstraction *for platforms*; one primitive *platforms are built
+from*. Cleaner layering than collapsing two different things under a trait with a
+meaningless footprint.
+
+### How they compose
+
+- **Ackermann** = verbatim adapter: `Verdict = EnforceAction`,
+  `evaluate = validate_vehicle_command`, `footprint = VehicleFootprint::from`.
+  Zero behaviour change — provable by the existing talisman tests (S-PK1a).
+- **DiffDrive** = sibling impl: its own `(linear, angular)` verdict, composing the
+  scalar clamp/rate-limit primitive per channel + the converge-to-zero rule (#407)
+  it already has in parko (S-PK1b).
+- **Scalar kernel** = unchanged primitive, used by the impls and the FFI; never a
+  platform.

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -67,6 +67,7 @@ pub mod audit_sink;
 pub mod clearance_delivery;
 pub mod comparator;
 pub mod diverse;
+pub mod platform;
 pub use angular_bound::{AngularVelocityBound, PlatformParams, ROLLOVER_MIN_LINEAR_VELOCITY_MPS};
 pub use clearance_delivery::{ClearanceDelivery, DeliveryOutcome};
 pub use audit_sink::{

--- a/parko/crates/parko-kirra/src/platform.rs
+++ b/parko/crates/parko-kirra/src/platform.rs
@@ -1,0 +1,231 @@
+//! **Differential-drive platform** under the kirra-core `PlatformKinematics`
+//! abstraction (Stage S-PK1b) — the first non-Ackermann sibling.
+//!
+//! This is the diff-drive analog of `kirra_core::platform_kinematics::AckermannPlatform`:
+//! a **wrapper** over parko's existing `SafetyGovernor` diff-drive evaluation, not a
+//! reimplementation. It proves the abstraction holds for a genuinely different
+//! verdict shape (`EnforcementAction`'s explicit linear/angular clamp channels vs
+//! Ackermann's `EnforceAction`).
+//!
+//! # What the second platform surfaced (see STAGE_S-PK1_PLATFORM_KINEMATICS.md)
+//!
+//! - **Verdict (D1) holds** via a `DiffDriveVerdict` newtype: the orphan rule
+//!   forbids `impl PlatformVerdict for EnforcementAction` here (neither the trait
+//!   nor `EnforcementAction` is local to this crate), so we wrap it. The newtype
+//!   also keeps parko-core kirra-core-free (S-FI1c).
+//! - **`&State` (D2) earns its keep**: diff-drive's per-command verdict needs the
+//!   previous command, `delta_time_s`, and posture — carried in [`DiffDriveState`].
+//!   (Ackermann is stateless → `()`.)
+//! - **`deny_reason` generalized** from `&'static str` to `&str` upstream:
+//!   parko's `Deny { reason: String }` is a runtime string, not a static token.
+//!
+//! # FINDINGS flagged for review (footprint shape, evaluate scope)
+//!
+//! - **Footprint convention:** `VehicleFootprint` is rear-axle/bicycle-shaped. A
+//!   diff-drive is represented with the **geometric-center** convention
+//!   (`wheelbase_m = 0`, `overhang_front = overhang_rear = length/2`), so the
+//!   footprint corners come out symmetric about the (center) pose. This works, but
+//!   whether the shared footprint type should be genericized (drive-agnostic) is a
+//!   candidate S-PK1c refinement, not decided here.
+//! - **`evaluate` scope asymmetry:** Ackermann's `evaluate` is *pure kinematics*
+//!   (`validate_vehicle_command`). Diff-drive's `evaluate` wraps
+//!   `SafetyGovernor::evaluate`, which in parko folds in the *pushed* RSS verdict —
+//!   so its scope is wider than Ackermann's. This reflects parko's existing
+//!   checker architecture (the kinematic envelope is not exposed as a separate
+//!   public entry); separating it is out of S-PK1b scope.
+
+use kirra_core::containment::VehicleFootprint;
+use kirra_core::platform_kinematics::{PlatformKinematics, PlatformVerdict};
+use parko_core::commands::ControlCommand;
+use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
+
+/// Diff-drive verdict — a newtype over parko's [`EnforcementAction`] so the
+/// kirra-core [`PlatformVerdict`] bound can be implemented here without violating
+/// the orphan rule. `Deref`s to the inner action for ergonomic access.
+/// (`EnforcementAction` is not `PartialEq`, so neither is this; compare via the
+/// `PlatformVerdict` view or `Debug`.)
+#[derive(Debug, Clone)]
+pub struct DiffDriveVerdict(pub EnforcementAction);
+
+impl std::ops::Deref for DiffDriveVerdict {
+    type Target = EnforcementAction;
+    fn deref(&self) -> &EnforcementAction {
+        &self.0
+    }
+}
+
+impl PlatformVerdict for DiffDriveVerdict {
+    fn is_admitted(&self) -> bool {
+        // Allow / any Clamp* are admitted (possibly modified) commands; only a
+        // hard Deny is a breach.
+        !matches!(self.0, EnforcementAction::Deny { .. })
+    }
+    fn deny_reason(&self) -> Option<&str> {
+        match &self.0 {
+            EnforcementAction::Deny { reason } => Some(reason.as_str()),
+            _ => None,
+        }
+    }
+}
+
+/// Per-tick state the diff-drive verdict needs beyond the proposed command —
+/// the [`PlatformKinematics::State`] for this platform. (Ackermann's is `()`.)
+#[derive(Debug, Clone)]
+pub struct DiffDriveState {
+    pub previous: Option<ControlCommand>,
+    pub delta_time_s: f64,
+    pub posture: SafetyPosture,
+}
+
+/// Differential-drive platform — wraps a parko `SafetyGovernor` (the diff-drive
+/// per-command checker) plus the platform's footprint and the kinematic limits the
+/// cross-checks read. Generic over the governor so it composes with `KirraGovernor`
+/// or any `SafetyGovernor` (e.g. a diverse/shadow channel).
+#[derive(Debug, Clone)]
+pub struct DiffDrivePlatform<G: SafetyGovernor> {
+    governor: G,
+    footprint: VehicleFootprint,
+    max_speed_mps: f64,
+    max_brake_mps2: f64,
+    stop_epsilon_mps: f64,
+}
+
+impl<G: SafetyGovernor> DiffDrivePlatform<G> {
+    /// `footprint` should use the geometric-center convention (`wheelbase_m = 0`,
+    /// symmetric overhangs) — see the module FINDINGS note. Use
+    /// [`Self::centered_footprint`] to build one from width/length.
+    pub fn new(
+        governor: G,
+        footprint: VehicleFootprint,
+        max_speed_mps: f64,
+        max_brake_mps2: f64,
+        stop_epsilon_mps: f64,
+    ) -> Self {
+        Self { governor, footprint, max_speed_mps, max_brake_mps2, stop_epsilon_mps }
+    }
+
+    /// Build a center-referenced [`VehicleFootprint`] for a `width_m × length_m`
+    /// differential-drive robot: `wheelbase_m = 0`, symmetric overhangs, so the
+    /// containment corners are symmetric about the (center) pose.
+    pub fn centered_footprint(width_m: f64, length_m: f64) -> VehicleFootprint {
+        VehicleFootprint {
+            width_m,
+            length_m,
+            overhang_front_m: length_m / 2.0,
+            overhang_rear_m: length_m / 2.0,
+            wheelbase_m: 0.0,
+        }
+    }
+}
+
+// SAFETY: SG8 SG9 | REQ: platform-kinematics-diffdrive-sibling | TEST: diffdrive_evaluate_wraps_governor,diffdrive_verdict_admitted_and_reason,diffdrive_clamp_is_admitted,diffdrive_footprint_and_accessors,centered_footprint_is_symmetric
+impl<G: SafetyGovernor> PlatformKinematics for DiffDrivePlatform<G> {
+    type Command = ControlCommand;
+    type State = DiffDriveState;
+    type Verdict = DiffDriveVerdict;
+
+    fn evaluate(&self, command: &ControlCommand, state: &DiffDriveState) -> DiffDriveVerdict {
+        // Wraps parko's existing diff-drive per-command verdict VERBATIM.
+        DiffDriveVerdict(self.governor.evaluate(
+            command,
+            state.previous.as_ref(),
+            state.delta_time_s,
+            state.posture,
+        ))
+    }
+
+    fn footprint(&self) -> VehicleFootprint {
+        self.footprint
+    }
+
+    fn max_speed_mps(&self) -> f64 {
+        self.max_speed_mps
+    }
+
+    fn max_brake_mps2(&self) -> f64 {
+        self.max_brake_mps2
+    }
+
+    fn stop_epsilon_mps(&self) -> f64 {
+        self.stop_epsilon_mps
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::KirraGovernor;
+
+    fn platform() -> DiffDrivePlatform<KirraGovernor> {
+        DiffDrivePlatform::new(
+            KirraGovernor::new(),
+            DiffDrivePlatform::<KirraGovernor>::centered_footprint(0.6, 0.9),
+            1.5,  // max_speed_mps
+            1.0,  // max_brake_mps2
+            0.05, // stop_epsilon_mps (linear)
+        )
+    }
+
+    fn state(posture: SafetyPosture) -> DiffDriveState {
+        DiffDriveState { previous: None, delta_time_s: 0.1, posture }
+    }
+
+    /// The wrapper's verdict is exactly the governor's verdict (verbatim).
+    #[test]
+    fn diffdrive_evaluate_wraps_governor() {
+        let p = platform();
+        let gov = KirraGovernor::new();
+        let cmd = ControlCommand { linear_velocity: 0.5, angular_velocity: 0.2, timestamp_ms: 0 };
+        let st = state(SafetyPosture::Nominal);
+        let via_trait = p.evaluate(&cmd, &st);
+        let direct = gov.evaluate(&cmd, st.previous.as_ref(), st.delta_time_s, st.posture);
+        // EnforcementAction is not PartialEq → compare via Debug.
+        assert_eq!(
+            format!("{:?}", via_trait.0),
+            format!("{direct:?}"),
+            "the platform verdict must equal the wrapped governor verdict"
+        );
+    }
+
+    #[test]
+    fn diffdrive_verdict_admitted_and_reason() {
+        let allow = DiffDriveVerdict(EnforcementAction::Allow);
+        assert!(allow.is_admitted());
+        assert_eq!(allow.deny_reason(), None);
+
+        let deny = DiffDriveVerdict(EnforcementAction::Deny { reason: "TEST_DENY".to_string() });
+        assert!(!deny.is_admitted(), "a Deny must not be admitted");
+        assert_eq!(deny.deny_reason(), Some("TEST_DENY"), "a Deny must surface its runtime reason");
+    }
+
+    #[test]
+    fn diffdrive_clamp_is_admitted() {
+        // Clamp* are admitted (modified-but-allowed) commands, not breaches.
+        for v in [
+            EnforcementAction::ClampLinearVelocity(0.3),
+            EnforcementAction::ClampAngularVelocity(0.1),
+            EnforcementAction::ClampMotion { linear: Some(0.2), angular: None },
+        ] {
+            assert!(DiffDriveVerdict(v).is_admitted());
+        }
+    }
+
+    #[test]
+    fn diffdrive_footprint_and_accessors() {
+        let p = platform();
+        let fp = p.footprint();
+        assert_eq!(fp.width_m, 0.6);
+        assert_eq!(fp.length_m, 0.9);
+        assert_eq!(p.max_speed_mps(), 1.5);
+        assert_eq!(p.max_brake_mps2(), 1.0);
+        assert_eq!(p.stop_epsilon_mps(), 0.05);
+    }
+
+    #[test]
+    fn centered_footprint_is_symmetric() {
+        let fp = DiffDrivePlatform::<KirraGovernor>::centered_footprint(0.6, 0.9);
+        assert_eq!(fp.wheelbase_m, 0.0, "diff-drive uses the center convention (no wheelbase)");
+        assert_eq!(fp.overhang_front_m, fp.overhang_rear_m, "overhangs symmetric about the center pose");
+        assert_eq!(fp.overhang_front_m, 0.45);
+    }
+}


### PR DESCRIPTION
## Summary

The Track-3 keystone: lift the governor's three scattered, platform-specific expressions into one **platform-parameterized kinematic contract**, so the existing safety surface (envelope, containment, RSS, decel-to-stop, frame-integrity) extends to non-Ackermann platforms. Mirrors how the frame-integrity gate (#517) was the Track-2 keystone.

Contains the **PROPOSED spec** + the first reviewable code move **S-PK1a** (still draft).

## Grounded problem (verified in code)

Safety surface is Ackermann-shaped, scattered across three places: the Ackermann bicycle talisman (`validate_vehicle_command`; angular "intentionally NOT gated here", `kinematics_contract.rs:354`), a *separate* diff-drive angular channel in parko (`angular_bound.rs`, #407), and the generic scalar `KirraKernelGovernor`. Containment is 2D only. The governor can only bound a robot whose physics it can *express*.

## Resolved design decisions (spec §10)

- **D1 — associated `Verdict`, not generalized-angular.** `Ackermann::Verdict = EnforceAction` untouched (frozen talisman / audit strings / QNX `deny_code_num`). Generalized-angular is the *second* platform's shape masquerading as the abstraction (fails omni/aerial). A tiny `PlatformVerdict` bound (`is_admitted` + `deny_reason`) gives audit/posture/safe-stop a uniform view.
- **D2 — `evaluate` + `footprint()` + the few cross-check primitives** (`max_speed_mps`/`max_brake_mps2`/`stop_epsilon_mps`). Mechanism (`wheelbase_m`, steering geometry, ICR) stays **private** to the impl.
- **D3 — scalar kernel stays the composable primitive**, never a degenerate platform (no footprint ⇒ no meaningless degenerate on the safety surface; keeps the lean ASIL-D/FFI surface).

## S-PK1a (code in this PR)

`crates/kirra-core/src/platform_kinematics.rs`: the `PlatformKinematics` trait + `PlatformVerdict` bound + `AckermannPlatform` as a **verbatim adapter** — `evaluate` *literally calls* `validate_vehicle_command`; `footprint` = `VehicleFootprint::from`. Zero behaviour change by construction; the zero-delta test asserts adapter == talisman over an Allow/Clamp/Deny/NaN battery. **The frozen talisman is wrapped, never modified.**

kirra-core 157 tests pass; clippy + workspace check clean.

## Status / sequencing

PROPOSED — not a safety claim; RTM must not mark new-platform goals ENFORCED until the sub-stages land (ADR-0017 on acceptance). Next: **S-PK1b** (diff-drive sibling — resolves the verdict shape concretely) → **S-PK1c** (wire containment/RSS to consume the trait). Tier B (aerial) gated; Tier C (manipulator) cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)