### PR TITLE
feat(mick): LLM reliability — constrained JSON decoding + few-shot prompt

### DIFF
--- a/crates/kirra-mick/src/lib.rs
+++ b/crates/kirra-mick/src/lib.rs
@@ -82,6 +82,12 @@ struct GenerateRequest<'a> {
     model: &'a str,
     prompt: &'a str,
     stream: bool,
+    /// Constrained decoding: `"json"` forces Ollama to emit a syntactically valid JSON
+    /// object (grammar-constrained), so Gemma can't wrap the intent in prose or a code
+    /// fence. `from_llm_json` still validates the typed schema + finiteness on top, so a
+    /// well-formed-but-wrong object (unknown tag, NaN) still fails closed — this only
+    /// removes the *framing* failure mode that otherwise forces a needless HOLD.
+    format: &'static str,
 }
 
 /// The relevant slice of the `/api/generate` response.
@@ -93,7 +99,7 @@ struct GenerateResponse {
 impl ModelClient for OllamaClient {
     fn complete(&self, prompt: &str) -> Result<String, ModelError> {
         let url = format!("{}/api/generate", self.base_url);
-        let body = GenerateRequest { model: &self.model, prompt, stream: false };
+        let body = GenerateRequest { model: &self.model, prompt, stream: false, format: "json" };
 
         // Every failure maps to a stable ModelError → LlmBrain fails closed → HOLD.
         let resp = self

--- a/crates/kirra-planner/src/mick_llm.rs
+++ b/crates/kirra-planner/src/mick_llm.rs
@@ -49,6 +49,13 @@ set only the high-level intent — a separate safety governor enforces collision
 traffic law, and the speed envelope, so you cannot cause a crash. Focus on driving well. \
 Coordinates are ego-relative: +ahead is forward, +left is to your left.\n\
 \n\
+Examples (situation → intent):\n\
+- open road, no objects, goal far ahead → {{\"intent\":\"cruise\",\"target_speed_mps\":10}}\n\
+- a stopped object close ahead in your path → {{\"intent\":\"hold\"}}\n\
+- a slow object ahead, the goal is past it, a lane change to the left is allowed → \
+{{\"intent\":\"lane_change\",\"target_offset_m\":3.5}}\n\
+- the goal is off to one side and reachable → {{\"intent\":\"go_to\",\"x_m\":20,\"y_m\":-4}}\n\
+\n\
 Situation:\n{situation}\n\
 \n\
 Intent:"
@@ -129,6 +136,8 @@ mod tests {
         }
         // The ego-relative situation is embedded (serialized WorldContext).
         assert!(p.contains("ego_speed_mps") && p.contains("posture"), "prompt must embed the situation");
+        // Few-shot worked examples are present (small models lean on them heavily).
+        assert!(p.contains("Examples"), "prompt must carry few-shot examples");
     }
 
     #[test]


### PR DESCRIPTION
## Cheap win #1 + #5 — Mick LLM reliability

Two complementary, low-risk wins that cut the "small model rambled → fail-closed HOLD" rate when Mick runs on a local Gemma 4B. **Safety is unchanged** — these only reduce *framing* failures; the typed-schema + finiteness gate still fails closed on a wrong intent.

- **Constrained JSON decoding** (`kirra-mick`) — `OllamaClient` sends `format: "json"`, so Ollama grammar-constrains the completion to a valid JSON object. The model can't wrap the intent in prose or a ```json fence. `from_llm_json` still validates the typed schema on top (unknown tag / NaN → still HOLD).
- **Few-shot prompt** (`kirra-planner`) — `build_prompt` now carries four worked `(situation → intent)` examples. 4B-class models lean heavily on these; better intent quality and format adherence for free.

### Verification
prompt test now asserts the few-shot block; kirra-mick + kirra-planner `mick_llm` suites green; clippy clean under `-D warnings --all-targets`.

Next cheap wins queued: parko divergence→posture, the KIRRA "no admitted trajectory escapes by > margin" proptest, and Occy's stop-gap de-timid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_