### PR TITLE
SG2 containment proptests + S-DG1 divergence-posture spec (+ #4 dropped)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,6 +1969,7 @@ name = "kirra-core"
 version = "0.1.0"
 dependencies = [
  "kirra-capture-schema",
+ "proptest",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/kirra-core/Cargo.toml
+++ b/crates/kirra-core/Cargo.toml
@@ -48,3 +48,6 @@ kirra-capture-schema = { path = "../kirra-capture-schema", optional = true }
 # SCREAMING_SNAKE_CASE DenyCode token via JSON serialization. Test-only for the
 # default (serde-only) build — the `capture` feature promotes serde_json to a normal dep.
 serde_json = "1"
+# Property-based tests for the SG2 containment invariant (admitted ⟹ corners within
+# margin), asserted against a closed-form straight-corridor reference. Test-only.
+proptest = "1"

--- a/crates/kirra-core/tests/containment_proptest.rs
+++ b/crates/kirra-core/tests/containment_proptest.rs
@@ -1,0 +1,101 @@
+//! **SG2 containment — property tests.** The unit tests pin specific cases; these assert
+//! the *invariant* across thousands of random trajectories. The load-bearing one is the
+//! core safety property stated as a differential check against a **closed-form reference**:
+//! for a straight, axis-aligned corridor with a heading-0 footprint, a trajectory is
+//! Allowed *iff* every footprint corner is at least `margin` inside the lateral boundaries
+//! — pure algebra, no re-implementation of the production geometry. So a mismatch means the
+//! production check admitted something it shouldn't (or rejected something it should admit).
+
+use kirra_core::containment::{
+    validate_trajectory_containment, Corridor, Point, Pose, VehicleFootprint,
+    MAX_TRAJECTORY_HORIZON,
+};
+use kirra_core::frame_integrity::{containment_margin_m, FrameTrust};
+use kirra_core::kinematics_contract::{DenyCode, EnforceAction, VehicleKinematicsContract};
+use proptest::prelude::*;
+
+/// A long, straight, axis-aligned corridor: left edge at `y = +HALF`, right at `y = -HALF`,
+/// spanning `x ∈ [0, LEN]`. Long enough that the end-cap margin never binds.
+const HALF: f64 = 5.0;
+const LEN: f64 = 200.0;
+/// Keep poses in a longitudinal middle band so only the lateral edges gate (the closed-form
+/// case); the caps at x=0 / x=LEN stay tens of metres away — far beyond any margin.
+const X_LO: f64 = 50.0;
+const X_HI: f64 = 150.0;
+
+fn footprint() -> VehicleFootprint {
+    VehicleFootprint::from(&VehicleKinematicsContract::nominal_reference_profile())
+}
+
+fn straight_corridor<'a>(left: &'a [Point], right: &'a [Point]) -> Corridor<'a> {
+    Corridor { left, right, confidence: 1.0, age_ms: 0, min_confidence: 0.5, max_age_ms: 5_000 }
+}
+
+proptest! {
+    /// **The SG2 core invariant, differential vs closed form.** For the straight
+    /// axis-aligned corridor + heading-0 footprint, the worst corner's lateral reach is
+    /// `|y| + width/2`, so the verdict must be `Allow` iff `|y| + width/2 ≤ HALF − margin`
+    /// for *every* pose. We assert the production check agrees with that algebra.
+    #[test]
+    fn admitted_iff_every_corner_is_within_lateral_margin(
+        ys in prop::collection::vec(-(HALF + 2.0)..(HALF + 2.0), 1..=MAX_TRAJECTORY_HORIZON),
+        x0 in X_LO..X_HI,
+    ) {
+        let fp = footprint();
+        let half_w = fp.width_m * 0.5;
+        let margin = containment_margin_m(FrameTrust::Trusted).expect("Trusted has a margin");
+
+        // March x forward inside the safe band (so the cap margin can never bind), heading 0.
+        let dx = (X_HI - x0) / (MAX_TRAJECTORY_HORIZON as f64);
+        let traj: Vec<Pose> = ys.iter().enumerate()
+            .map(|(i, &y)| Pose { x_m: x0 + i as f64 * dx, y_m: y, heading_rad: 0.0 })
+            .collect();
+
+        let left  = [Point { x_m: 0.0, y_m: HALF },  Point { x_m: LEN, y_m: HALF }];
+        let right = [Point { x_m: 0.0, y_m: -HALF }, Point { x_m: LEN, y_m: -HALF }];
+        let corridor = straight_corridor(&left, &right);
+
+        // Closed-form reference: slack of the WORST pose's worst corner to the nearer edge,
+        // minus the margin. Admit iff that's ≥ 0.
+        let worst_slack = traj.iter()
+            .map(|p| HALF - margin - (p.y_m.abs() + half_w))
+            .fold(f64::INFINITY, f64::min);
+
+        // Dead-band: production uses squared distances; skip cases within 1e-6 of the exact
+        // boundary, where linear-vs-squared FP rounding could legitimately disagree.
+        prop_assume!(worst_slack.abs() > 1e-6);
+
+        let verdict = validate_trajectory_containment(&traj, &corridor, &fp, FrameTrust::Trusted);
+        if worst_slack > 0.0 {
+            prop_assert_eq!(verdict, EnforceAction::Allow,
+                "every corner ≥ margin inside ⇒ Allow (worst_slack={})", worst_slack);
+        } else {
+            prop_assert_eq!(verdict, EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
+                "a corner within margin of / past the boundary ⇒ Deny (worst_slack={})", worst_slack);
+        }
+    }
+
+    /// **Translation invariance.** Containment is frame-relative: translating the whole
+    /// trajectory AND the corridor by the same vector must not change the verdict. Catches
+    /// any absolute-coordinate leakage.
+    #[test]
+    fn verdict_is_translation_invariant(
+        ys in prop::collection::vec(-8.0_f64..8.0, 1..=20usize),
+        tx in -500.0_f64..500.0,
+        ty in -500.0_f64..500.0,
+    ) {
+        let fp = footprint();
+        let verdict_at = |ox: f64, oy: f64| {
+            let traj: Vec<Pose> = ys.iter().enumerate()
+                .map(|(i, &y)| Pose { x_m: ox + 50.0 + i as f64 * 2.0, y_m: oy + y, heading_rad: 0.0 })
+                .collect();
+            let left  = [Point { x_m: ox, y_m: oy + HALF },  Point { x_m: ox + LEN, y_m: oy + HALF }];
+            let right = [Point { x_m: ox, y_m: oy - HALF }, Point { x_m: ox + LEN, y_m: oy - HALF }];
+            // Corridor borrows the local arrays; evaluate before they drop.
+            let corridor = straight_corridor(&left, &right);
+            validate_trajectory_containment(&traj, &corridor, &fp, FrameTrust::Trusted)
+        };
+        prop_assert_eq!(verdict_at(0.0, 0.0), verdict_at(tx, ty),
+            "containment verdict must be invariant under a common translation");
+    }
+}

--- a/docs/safety/STAGE_S-DG1_DIVERGENCE_POSTURE.md
+++ b/docs/safety/STAGE_S-DG1_DIVERGENCE_POSTURE.md
@@ -1,0 +1,114 @@
+# Stage S-DG1 — Governor-Divergence → Fleet Posture
+
+> **STATUS: PROPOSED.** Design of record only — **no implementation**, and **not a safety
+> claim** until ACCEPTED via a future ADR. The RTM / TRACEABILITY_MATRIX must NOT list
+> S-DG1 as ENFORCED until S-DG1c lands. (Same governance as S-FI1.)
+
+## 1. Motivation
+
+Parko runs **two independent governors** over every command — a primary
+(`DiverseKirraGovernor`) and a shadow — and a `GovernorComparator` reconciles them to a
+safe output. A *disagreement* between two independently-derived safety governors is one of
+the strongest fault signatures the system can observe: it means at least one governor is
+wrong, and we cannot tell which. Today that disagreement is **reconciled locally and
+audited** (`DivergenceEventSink`) — but it does **not** drive the fleet posture. A
+persistent governor disagreement should fail the fleet *closed*, exactly as a stale
+localization frame does (S-FI1). This stage promotes the existing local divergence signal
+into a first-class, fail-closed **posture** input.
+
+This is the diverse-redundancy analogue of the frame-integrity gate: turn a *detected*
+fault from "logged" into "drives the safe state."
+
+## 2. Current state (grounded in real symbols)
+
+- `parko_kirra::comparator::GovernorComparator` compares primary vs shadow and produces a
+  reconciled command.
+- `comparator::DivergenceEvent` already carries: `primary_lin/shadow_lin/delta_lin`,
+  `primary_ang/shadow_ang/delta_ang`, an **`accumulator: u32`** (sustained-divergence
+  counter), the **`reconciled_lin/reconciled_ang`** safe output, and an
+  **`escalated_to_lockout: bool`** flag.
+- `comparator::DivergenceEventSink` (+ `AuditChainLinkerDivergenceSink`) durably,
+  signed-and-hash-linked, **audits** each divergence.
+- **Gap:** the `accumulator` / `escalated_to_lockout` state affects the *local command
+  reconciliation* and the *audit*, but is **not wired to the kirra-core posture engine**
+  (`FleetPosture` / `posture_engine_v2`). A diverging fleet keeps running at Nominal posture.
+
+So the detection, accumulation, and escalation logic **already exist**; S-DG1 is the
+*wiring* of that existing signal into posture — it does not invent a new divergence metric.
+
+## 3. Design
+
+**Reuse the comparator's existing accumulator + escalation; do not invent a new criterion.**
+
+- **Posture-relevant divergence = the comparator's `accumulator`-significant divergence**
+  (its existing threshold), NOT every nonzero `delta_lin/ang`. Small clamp-magnitude deltas
+  are *expected* from diverse computation (two correct-but-different governors will not
+  produce bit-identical clamps); the existing accumulator already filters those. Keying
+  posture off the accumulator threshold means posture reacts to *sustained, significant*
+  disagreement, not numerical noise.
+- **Mapping (mirrors S-FI1 / SS-002):**
+  - accumulator crosses its significance threshold → **immediate `Degraded`** (decel-to-stop
+    -and-HOLD MRC). The first significant tick drops posture; no grace period.
+  - existing `escalated_to_lockout` → **`LockedOut`** (human reset) — a sustained / repeated
+    disagreement is a genuine fault (a real governor bug or a corrupted input), not a
+    transient, so it earns a human inspection.
+  - divergence clears → **auto-recover** via the existing `recovery_hysteresis` machinery
+    (N consecutive agreeing ticks), Degraded → Nominal.
+- **Defense-in-depth unchanged:** the comparator STILL reconciles every command to the safe
+  output regardless of posture. Posture is an *additional* fail-closed consequence, never a
+  replacement for reconciliation.
+
+### New kirra-core surface (additive)
+- `posture_engine_v2::LockoutReason::GovernorDivergence` (new structured reason code).
+- `posture_engine_v2::PostureRecalcTrigger::GovernorDivergence { significant, escalated }`
+  (typed trigger), mirroring the frame-integrity trigger shape.
+
+### Cross-workspace emission (the key mechanism)
+parko is a **separate workspace** depending on kirra-core; it must drive the verifier's
+posture engine without a dependency inversion. So the comparator gains an **optional
+posture-trigger sink** — `PostureSignalSink` — dependency-injected exactly like the
+existing `DivergenceEventSink`. parko-ros2 wires it to the `PostureEngineSender`; an
+integrator who runs the comparator standalone leaves it `None` (audit-only, today's
+behavior). No new hard edge parko→kirra-core posture internals.
+
+## 4. Sub-stages
+
+- **S-DG1a** — kirra-core: add `LockoutReason::GovernorDivergence` +
+  `PostureRecalcTrigger::GovernorDivergence`. Module + posture-engine handling only;
+  touches nothing in parko. (The exhaustive `LockoutReason`/trigger matches force a
+  compile error to handle it — no silent gap.)
+- **S-DG1b** — parko-kirra: add the optional `PostureSignalSink` to `GovernorComparator`;
+  emit on the accumulator-significant / escalated transitions (reusing the existing state).
+- **S-DG1c** — parko-ros2: wire the sink to the `PostureEngineSender`; integration test.
+- Each sub-stage held for review; S-DG1c is the first that changes runtime behavior.
+
+## 5. Test matrix
+
+| Case | Expectation |
+|------|-------------|
+| tiny clamp-magnitude delta (below accumulator threshold) | audit yes, **posture unchanged** |
+| accumulator crosses significance threshold | **Degraded** (immediate), audit yes |
+| sustained / `escalated_to_lockout` | **LockedOut**, audit yes |
+| divergence clears, N agreeing ticks | auto-recover Degraded → Nominal |
+| asymmetry test | every divergence is audited; only *significant* divergence moves posture |
+| `PostureSignalSink = None` | byte-for-byte today's behavior (audit-only) |
+
+## 6. Assumptions of use / honesty
+
+- This **strengthens** diverse-redundancy from "divergence is recorded" to "sustained
+  divergence fails the fleet closed." It does not change the reconciled command path.
+- It does **not** claim to identify *which* governor is wrong — it cannot. The safe
+  disposition under "one of two governors is wrong, unknown which" is to stop (Degraded)
+  and, if it persists, require a human (LockedOut). Diagnosing the offending governor is a
+  separate offline activity over the signed divergence audit.
+
+## 7. Decisions needed before S-DG1a
+
+1. **Significance threshold** — reuse the comparator's existing `accumulator` threshold for
+   posture-significance (recommended — one source of truth, already validated), or introduce
+   a separate posture threshold? Recommend **reuse**.
+2. **Immediate-Degraded** — confirm posture drops on the *first* significant tick (no grace);
+   graduation governs only Degraded→LockedOut. Recommend **confirm** (consistent with S-FI1).
+3. **Emission mechanism** — the dependency-injected `PostureSignalSink` (recommended, mirrors
+   `DivergenceEventSink`) vs a direct `PostureEngineSender` handle threaded into the
+   comparator? Recommend the **DI sink**.


### PR DESCRIPTION
Cheap-wins batch wrap-up. Two deliverables + one honest non-delivery.

## ✅ #3 — SG2 containment property tests (kirra-core)
Hardens the core invariant across thousands of random trajectories (no behavior change):
- **`admitted_iff_every_corner_is_within_lateral_margin`** — differential vs a **closed-form reference** (straight axis-aligned corridor + heading-0 footprint: `Allow` iff `|y| + width/2 ≤ HALF − margin` for every pose). A mismatch would mean the checker admitted a trajectory outside the margin — the exact failure the SG2 case must exclude.
- **`verdict_is_translation_invariant`** — common translation of trajectory + corridor must not change the verdict.
- Adds `proptest` as a kirra-core **dev**-dependency. Both pass (256 cases); lib 157 tests green; CI clippy clean.

## ✅ #2 → reclassified as a PROPOSED spec — `docs/safety/STAGE_S-DG1_DIVERGENCE_POSTURE.md`
Turning the parko diverse-governor disagreement into a posture transition is a **new safety-state change**, so it gets the S-FI1 treatment (spec first, code behind it) rather than a silent quick-PR. Grounded finding: the detection already exists — `GovernorComparator`/`DivergenceEvent` already carry the deltas, an `accumulator`, the reconciled safe output, and an `escalated_to_lockout` flag; only the **wiring to the kirra-core posture engine** is missing. The spec proposes reusing that existing accumulator (immediate `Degraded` on significance, `escalated_to_lockout` → `LockedOut`, auto-recover via hysteresis), emitted across the workspace boundary via a DI `PostureSignalSink`. PROPOSED only — no code.

## ❌ #4 — Occy de-timid: dropped (honest no-op)
Investigated empirically: even with an *extreme* `object_stop_gap_m = 0.5`, the closed-loop ego still stops at `reached = 9.05`. So the ~16 m gap I saw is **KIRRA's RSS following-distance floor** (the safety bound) binding as the ego closes in — **not planner timidity.** Reducing the planner's gap is a no-op; "de-timiding" further would mean loosening KIRRA's RSS, which is the safety floor. So there's nothing safe to change here, and shipping it would be a no-op at best. Dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)