### PR TITLE
feat(mick): the fast/slow loop — demo fix + dual-rate MickDriver + live example

### DIFF
--- a/crates/kirra-mick/examples/mick_chauffeur.rs
+++ b/crates/kirra-mick/examples/mick_chauffeur.rs
@@ -1,27 +1,32 @@
-//! **Watch real Gemma drive — bounded by KIRRA.** Runs the closed loop with a LIVE
-//! `LlmBrain<OllamaClient>`: each tick a local Gemma proposes a typed intent, Occy grounds
-//! it, KIRRA judges it, and the ego advances (admitted → conform; rejected → MRC/hold).
-//! The per-tick trace prints what the model chose and what the governor did with it.
+//! **Watch real Gemma drive — bounded by KIRRA, at realistic dual rates.** Runs the
+//! closed loop with a live `MickDriver<LlmBrain<OllamaClient>>`: the FAST loop ticks at
+//! 10 Hz (grounding the current intent against the fresh world and conforming to the
+//! KIRRA-accepted trajectory), while the SLOW System-2 path only re-asks Gemma for a new
+//! *intent* every ~500 ms. The trace prints, each tick, the intent Gemma last chose and
+//! what the governor did — so you can see the maneuver *persist* between the model's
+//! (infrequent) decisions while the trajectory keeps tracking live perception.
 //!
 //! Run it:
 //!   ollama pull gemma3:4b           # one-time
 //!   cargo run -p kirra-mick --example mick_chauffeur
 //!
-//! No Ollama running? The brain fails closed every tick — you'll see HOLD throughout,
-//! which is exactly the safe behavior. The model can never make the car unsafe: its intent
-//! is grounded by Occy and bounded by KIRRA; this binary only shows the loop.
+//! No Ollama running? The driver fails closed — you'll see HOLD throughout, exactly the
+//! safe default. The model can never make the car unsafe: its intent is grounded by Occy
+//! and bounded by KIRRA; this binary only shows the loop.
 
 use kirra_core::FleetPosture;
 use kirra_mick::OllamaClient;
 use kirra_planner::{
-    mick_drive_once, EgoState, GeometricPlanner, Goal, LlmBrain, PlanInput, PlanOutput, Pose,
+    EgoState, GeometricPlanner, Goal, LlmBrain, MickDriver, PlanInput, PlanOutput, Pose,
 };
 use kirra_ros2_adapter::corridor::{CorridorSource, MockCorridorSource, Point};
 use kirra_ros2_adapter::state::{PerceivedObject, TrajectoryVerdict};
 use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
 
-const TICK_DT: f64 = 0.5;
-const TICKS: usize = 12;
+const FAST_DT_S: f64 = 0.1; // 10 Hz fast loop
+const FAST_DT_MS: u64 = 100;
+const TICKS: usize = 24; // 2.4 s
+const MRC_DECEL: f64 = 3.0;
 
 fn world<'a>(ego: EgoState, map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> PlanInput<'a> {
     PlanInput {
@@ -46,43 +51,58 @@ fn verdict(plan: &PlanOutput, corr: &dyn CorridorSource, objs: &[PerceivedObject
     validate_trajectory_slow(&plan.trajectory, corr, objs, &VehicleConfig::default_urban(), None, FleetPosture::Nominal)
 }
 
-fn advance(ego: EgoState, plan: &PlanOutput, admitted: bool, t_ms: u64) -> EgoState {
-    if !admitted {
-        return EgoState {
-            pose: ego.pose,
-            linear_x_mps: (ego.linear_x_mps - 3.0 * TICK_DT).max(0.0),
-            yaw_rate_rads: 0.0,
-            stamp_ms: t_ms,
-        };
-    }
-    let tp = plan.trajectory.iter().find(|p| p.time_from_start_s >= TICK_DT).or_else(|| plan.trajectory.last());
-    match tp {
-        Some(p) => EgoState { pose: p.pose, linear_x_mps: p.velocity_mps, yaw_rate_rads: 0.0, stamp_ms: t_ms },
-        None => ego,
-    }
+/// The (pose, velocity) at time `t` along a plan — the fast-loop conformance target.
+fn target_at(plan: &PlanOutput, t: f64) -> Option<(Pose, f64)> {
+    plan.trajectory
+        .iter()
+        .find(|p| p.time_from_start_s >= t)
+        .or_else(|| plan.trajectory.last())
+        .map(|p| (p.pose, p.velocity_mps))
 }
 
 fn main() {
     let client = OllamaClient::new();
-    println!("Mick chauffeur — model = {} @ {}", client.model(), std::env::var("KIRRA_OLLAMA_URL").unwrap_or_else(|_| "http://localhost:11434".into()));
-    let mut mick = LlmBrain::new(client);
+    let url = std::env::var("KIRRA_OLLAMA_URL").unwrap_or_else(|_| "http://localhost:11434".into());
+    println!("Mick chauffeur — model = {} @ {url}  (fast loop 10 Hz, Gemma ~2 Hz)", client.model());
+
+    // Dual-rate driver: defaults = decide every 500 ms (System-2), hold if stale > 2 s.
+    let mut driver = MickDriver::new(LlmBrain::new(client));
     let mut occy = GeometricPlanner::default();
 
-    // A straight road with a stopped car at x=30 — we should see Gemma drive up and the
-    // system hold short / KIRRA bound it before the obstacle.
+    // Straight road, stopped car at x=30 — Gemma should drive up; KIRRA holds it ~4 m short.
     let corr = MockCorridorSource::straight_5m_half_width(100.0);
     let objs = [PerceivedObject { id: 1, pos: Point { x_m: 30.0, y_m: 0.0 }, velocity_mps: 0.0, heading_rad: 0.0, vel: Point { x_m: 0.0, y_m: 0.0 } }];
 
     let mut ego = EgoState { pose: Pose { x_m: 5.0, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: 2.0, yaw_rate_rads: 0.0, stamp_ms: 0 };
-    println!("  tick     ego.x       v  kirra-verdict");
+    let mut accepted: Option<PlanOutput> = None;
+    let mut slot_t = 0.0_f64;
+
+    println!("   t(s)   ego.x      v   intent (System-2)        kirra-verdict");
     for tick in 1..=TICKS {
+        let now_ms = tick as u64 * FAST_DT_MS;
         let w = world(ego, &corr, &objs);
-        // mick_drive_once asks Gemma; a model error fails closed to a safe stop.
-        let plan = mick_drive_once(&mut mick, &w, &mut occy);
+        // drive_tick re-asks Gemma only when the System-2 interval has elapsed; otherwise it
+        // grounds the cached intent. A model error / staleness fails closed to Hold.
+        let plan = driver.drive_tick(&w, &mut occy, now_ms);
         let v = verdict(&plan, &corr, &objs);
         let admitted = matches!(v, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp);
-        println!("{tick:>4}  {:>8.2}  {:>6.2}  {v:?}", ego.pose.x_m, ego.linear_x_mps);
-        ego = advance(ego, &plan, admitted, tick as u64 * 500);
+
+        // Fast/slow conformance: promote on admit, otherwise keep tracking the last slot.
+        if admitted {
+            accepted = Some(plan);
+            slot_t = 0.0;
+        }
+        slot_t += FAST_DT_S;
+        ego = match accepted.as_ref().and_then(|p| target_at(p, slot_t)) {
+            Some((pose, vel)) => EgoState { pose, linear_x_mps: vel, yaw_rate_rads: 0.0, stamp_ms: now_ms },
+            None => EgoState {
+                pose: ego.pose, linear_x_mps: (ego.linear_x_mps - MRC_DECEL * FAST_DT_S).max(0.0),
+                yaw_rate_rads: 0.0, stamp_ms: now_ms,
+            },
+        };
+
+        let intent = driver.current_intent();
+        println!("{:>6.1}  {:>6.2}  {:>5.2}   {:<22?}  {v:?}", now_ms as f64 / 1000.0, ego.pose.x_m, ego.linear_x_mps, intent);
     }
-    println!("final ego.x = {:.2} (obstacle at x=30 — the chauffeur never reaches it)", ego.pose.x_m);
+    println!("final ego.x = {:.2} (obstacle at x=30 — the chauffeur holds ~4 m short, never reaching it)", ego.pose.x_m);
 }

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -61,8 +61,9 @@ pub use lanelet2::{parse_lanelet2_osm, Lanelet2ParseError};
 
 pub mod mick;
 pub use mick::{
-    mick_drive_once, plan_for_intent, MickBrain, MickError, MickIntent, ObjectView, ScriptedBrain,
-    WorldContext, MICK_MAX_OBJECTS,
+    mick_drive_once, plan_for_intent, MickBrain, MickDriver, MickError, MickIntent, ObjectView,
+    ScriptedBrain, WorldContext, DEFAULT_DECIDE_INTERVAL_MS, DEFAULT_INTENT_STALENESS_MS,
+    MICK_MAX_OBJECTS,
 };
 
 /// Mick's model-agnostic LLM brain (prompt render + reply parse behind the `MickBrain`

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -341,6 +341,97 @@ pub fn mick_drive_once(
     }
 }
 
+/// Default System-2 cadence: re-ask the brain for an intent at ~2 Hz. A local 4B model
+/// cannot be called at the fast-loop rate (10–50 Hz) on a vehicle, and the *maneuver*
+/// rarely needs to change that fast. VALIDATION-PENDING (tune per model latency + ODD).
+pub const DEFAULT_DECIDE_INTERVAL_MS: u64 = 500;
+/// Default intent staleness bound: if the brain has produced no fresh intent within this
+/// window (it is timing out / erroring), the driver fails closed to `Hold` rather than
+/// grounding an arbitrarily-old maneuver. ~4× the decide interval — tolerates a few missed
+/// decisions before holding. VALIDATION-PENDING.
+pub const DEFAULT_INTENT_STALENESS_MS: u64 = 2_000;
+
+/// **The dual-rate Mick driver — the deployable form of the brain seam.**
+///
+/// `mick_drive_once` asks the brain *every* call; that is fine for sim but wrong for a
+/// vehicle, where the brain is a slow System-2 model. `MickDriver` separates the two rates:
+/// the **slow path** re-asks the brain for an *intent* only every `decide_interval_ms`
+/// (System-2), while the **fast path** grounds the cached intent against the FRESH world on
+/// *every* tick (System-1) — so the trajectory tracks live perception even though the
+/// maneuver is stable, and KIRRA still bounds every grounded trajectory.
+///
+/// **Fail-closed on a stale brain.** A re-decide that fails keeps the last cached intent
+/// (still safe — it is re-grounded live and re-checked by KIRRA), but the intent *ages*; if
+/// no fresh intent arrives within `intent_staleness_ms`, the driver grounds `Hold` instead
+/// (a controlled stop), mirroring the posture-tracker staleness rule. Cold start with no
+/// intent yet also grounds `Hold`.
+pub struct MickDriver<B: MickBrain> {
+    brain: B,
+    decide_interval_ms: u64,
+    intent_staleness_ms: u64,
+    /// The last intent the brain produced and when (`now_ms`). `None` until the first
+    /// successful decision.
+    cached: Option<(MickIntent, u64)>,
+}
+
+impl<B: MickBrain> MickDriver<B> {
+    /// Construct with the default System-2 cadence + staleness bound.
+    #[must_use]
+    pub fn new(brain: B) -> Self {
+        Self::with_rates(brain, DEFAULT_DECIDE_INTERVAL_MS, DEFAULT_INTENT_STALENESS_MS)
+    }
+
+    /// Construct with explicit `decide_interval_ms` (re-decide cadence) and
+    /// `intent_staleness_ms` (beyond which a non-refreshed intent → `Hold`).
+    #[must_use]
+    pub fn with_rates(brain: B, decide_interval_ms: u64, intent_staleness_ms: u64) -> Self {
+        Self { brain, decide_interval_ms, intent_staleness_ms, cached: None }
+    }
+
+    /// The current cached intent (for observability / tests), if any.
+    #[must_use]
+    pub fn current_intent(&self) -> Option<MickIntent> {
+        self.cached.map(|(intent, _)| intent)
+    }
+
+    /// One fast-loop tick at wall-clock `now_ms`: re-ask the brain only if the System-2
+    /// interval has elapsed (or there is no intent yet), then ground the current intent
+    /// against the fresh `world`. Always returns a grounded `PlanOutput` — a stale/absent
+    /// intent grounds `Hold` (fail-closed). The result is still a proposal KIRRA bounds.
+    pub fn drive_tick(
+        &mut self,
+        world: &PlanInput<'_>,
+        planner: &mut impl Planner,
+        now_ms: u64,
+    ) -> PlanOutput {
+        // Slow path: re-decide when due (interval elapsed) or no intent cached yet.
+        let due = match self.cached {
+            Some((_, decided_at)) => now_ms.saturating_sub(decided_at) >= self.decide_interval_ms,
+            None => true,
+        };
+        if due {
+            let ctx = WorldContext::from_plan_input(world);
+            if let Ok(intent) = self.brain.decide(&ctx) {
+                self.cached = Some((intent, now_ms));
+            }
+            // On a brain failure we KEEP the (now-ageing) cached intent — it is still
+            // re-grounded live and re-checked by KIRRA — and let the staleness gate below
+            // decide whether it is too old to use.
+        }
+
+        // Choose the intent to ground: the cached one iff still fresh, else fail closed.
+        let intent = match self.cached {
+            Some((intent, decided_at)) if now_ms.saturating_sub(decided_at) <= self.intent_staleness_ms => {
+                intent
+            }
+            _ => MickIntent::Hold,
+        };
+
+        // Fast path: ground the chosen intent against the FRESH world, every tick.
+        plan_for_intent(planner, &intent, world)
+    }
+}
+
 /// Posture → stable prompt token. Kept in lock-step with `FleetPosture`.
 fn posture_token(p: FleetPosture) -> &'static str {
     match p {
@@ -662,5 +753,108 @@ mod tests {
         );
         // 1e400 overflows to Inf → finiteness gate rejects it (fail-closed).
         assert!(MickIntent::from_llm_json(r#"{"intent":"cruise","target_speed_mps":1e400}"#).is_err());
+    }
+
+    // ----- the dual-rate driver: System-2 intent rate vs System-1 grounding rate -----
+
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    /// A brain that counts its `decide` calls (via a shared counter) and returns a fixed reply.
+    struct CountingBrain {
+        calls: Rc<Cell<u32>>,
+        reply: Result<MickIntent, MickError>,
+    }
+    impl MickBrain for CountingBrain {
+        fn decide(&mut self, _ctx: &WorldContext) -> Result<MickIntent, MickError> {
+            self.calls.set(self.calls.get() + 1);
+            self.reply
+        }
+    }
+
+    #[test]
+    fn driver_asks_the_brain_at_the_slow_rate_but_grounds_every_tick() {
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let w = cruising_world(&corr);
+        let mut p = GeometricPlanner::default();
+        let calls = Rc::new(Cell::new(0));
+        let brain = CountingBrain { calls: Rc::clone(&calls), reply: Ok(MickIntent::Cruise { target_speed_mps: 5.0 }) };
+        // Decide at 2 Hz (500 ms); run 20 fast ticks at 100 ms (10 Hz).
+        let mut driver = MickDriver::with_rates(brain, 500, 2_000);
+
+        let mut grounded = 0;
+        for tick in 1..=20u64 {
+            let out = driver.drive_tick(&w, &mut p, tick * 100);
+            // Fast path runs EVERY tick — always a grounded proposal.
+            assert!(matches!(out.kind, ProposalKind::Motion | ProposalKind::SafeStop));
+            grounded += 1;
+        }
+        assert_eq!(grounded, 20, "the fast path grounds an output on every tick");
+        // Slow path: ~1 decision per 500 ms over 2 s (+ the cold-start one), NOT 20.
+        let n = calls.get();
+        assert!((3..=6).contains(&n), "brain decided at the System-2 rate, not every tick: {n} calls / 20 ticks");
+        assert_eq!(driver.current_intent(), Some(MickIntent::Cruise { target_speed_mps: 5.0 }));
+    }
+
+    #[test]
+    fn driver_grounds_the_cached_intent_between_decisions() {
+        // The brain replies once, then would change its mind — but between re-decides the
+        // SAME cached intent is grounded each fast tick.
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let w = world(&corr, &[], &[]);
+        let mut p = GeometricPlanner::default();
+        let calls = Rc::new(Cell::new(0));
+        let brain = CountingBrain { calls: Rc::clone(&calls), reply: Ok(MickIntent::Hold) };
+        let mut driver = MickDriver::with_rates(brain, 1_000, 5_000);
+
+        driver.drive_tick(&w, &mut p, 100); // cold decide → Hold cached
+        assert_eq!(calls.get(), 1);
+        // Three more fast ticks before the 1 s interval elapses → no new decision.
+        for t in [200u64, 300, 400] {
+            driver.drive_tick(&w, &mut p, t);
+        }
+        assert_eq!(calls.get(), 1, "no re-decision before the interval elapses");
+        assert_eq!(driver.current_intent(), Some(MickIntent::Hold));
+    }
+
+    #[test]
+    fn driver_fails_closed_to_hold_when_the_brain_goes_stale() {
+        // The brain succeeds once (Cruise), then errors forever. After the staleness window
+        // the driver must HOLD rather than keep grounding the arbitrarily-old intent.
+        struct OnceThenErr { calls: Rc<Cell<u32>> }
+        impl MickBrain for OnceThenErr {
+            fn decide(&mut self, _ctx: &WorldContext) -> Result<MickIntent, MickError> {
+                self.calls.set(self.calls.get() + 1);
+                if self.calls.get() == 1 { Ok(MickIntent::Cruise { target_speed_mps: 5.0 }) } else { Err("down") }
+            }
+        }
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let w = cruising_world(&corr); // far goal so a fresh Cruise grounds to motion
+        let mut p = GeometricPlanner::default();
+        let calls = Rc::new(Cell::new(0));
+        // decide every 500 ms, stale after 1500 ms.
+        let mut driver = MickDriver::with_rates(OnceThenErr { calls: Rc::clone(&calls) }, 500, 1_500);
+
+        let out0 = driver.drive_tick(&w, &mut p, 0); // succeeds → Cruise (Motion)
+        assert_eq!(out0.kind, ProposalKind::Motion, "fresh Cruise grounds to motion");
+        // Within the staleness window the (now-erroring) brain leaves the last intent usable.
+        let out1 = driver.drive_tick(&w, &mut p, 1_000);
+        assert_eq!(out1.kind, ProposalKind::Motion, "intent still fresh enough → still driving");
+        // Past the staleness window → fail closed to Hold (a controlled stop).
+        let out2 = driver.drive_tick(&w, &mut p, 2_000);
+        assert_eq!(out2.kind, ProposalKind::SafeStop, "stale brain → HOLD (fail-closed)");
+    }
+
+    #[test]
+    fn driver_cold_start_with_a_failing_brain_holds() {
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let w = world(&corr, &[], &[]);
+        let mut p = GeometricPlanner::default();
+        let calls = Rc::new(Cell::new(0));
+        let brain = CountingBrain { calls: Rc::clone(&calls), reply: Err("no model") };
+        let mut driver = MickDriver::new(brain);
+        let out = driver.drive_tick(&w, &mut p, 0);
+        assert_eq!(out.kind, ProposalKind::SafeStop, "no intent ever → HOLD");
+        assert_eq!(driver.current_intent(), None);
     }
 }

--- a/crates/kirra-planner/tests/mick_closed_loop.rs
+++ b/crates/kirra-planner/tests/mick_closed_loop.rs
@@ -1,12 +1,15 @@
 //! **Mick chauffeur — the CLOSED LOOP.** The other Mick tests judge one proposal; this
-//! one runs the loop over time: each tick the brain proposes an intent, Occy grounds it,
-//! KIRRA judges it, and the ego state ADVANCES — admitted → conform to the plan, rejected
-//! → the fast loop's MRC (decelerate, hold). Repeat. The safety claim is then a property
-//! of the whole *run*, not a single verdict:
+//! one runs the loop over time, modeling the REAL fast/slow loop: each tick the brain
+//! proposes an intent, Occy grounds it, KIRRA judges it, and — on an admitting verdict —
+//! the slow loop PROMOTES the trajectory into the `accepted` slot; the fast loop then
+//! continuously CONFORMS the ego to that slot. A momentary reject is NOT a slam-stop: the
+//! slot simply isn't updated and the fast loop keeps tracking the last accepted plan to
+//! its KIRRA-admitted stop. MRC fires only when there is NO accepted slot at all. The
+//! safety claim is a property of the whole *run*, not a single verdict:
 //!
 //!   1. a good chauffeur cruises and makes progress on a clear road;
-//!   2. facing a hazard, the chauffeur is grounded to stop SHORT and KIRRA admits it —
-//!      the ego creeps up and holds, never reaching the obstacle;
+//!   2. facing a hazard, Occy stops short and KIRRA admits it — the ego noses up to ~4 m
+//!      behind the obstacle (the closest RSS admits) and holds, never reaching it;
 //!   3. THE PAYOFF — a persistently RECKLESS doer (a stand-in for a misaligned learned
 //!      brain) tries to drive through the hazard *every tick*; KIRRA rejects it *every
 //!      tick*, the ego MRCs, and across the entire run the ego never reaches the obstacle.
@@ -90,26 +93,10 @@ fn kirra_admits(plan: &PlanOutput, corr: &dyn CorridorSource, objs: &[PerceivedO
     )
 }
 
-/// Advance the ego one tick. Admitted → conform to the accepted trajectory (the pose ~one
-/// tick in). Rejected → the fast loop's MRC: shed speed toward 0 and hold position.
-fn advance(ego: EgoState, plan: &PlanOutput, admitted: bool, t_ms: u64) -> EgoState {
-    if !admitted {
-        return EgoState {
-            pose: ego.pose,
-            linear_x_mps: (ego.linear_x_mps - MRC_DECEL * TICK_DT).max(0.0),
-            yaw_rate_rads: 0.0,
-            stamp_ms: t_ms,
-        };
-    }
-    let tp = plan
-        .trajectory
-        .iter()
-        .find(|p| p.time_from_start_s >= TICK_DT)
-        .or_else(|| plan.trajectory.last());
-    match tp {
-        Some(p) => EgoState { pose: p.pose, linear_x_mps: p.velocity_mps, yaw_rate_rads: 0.0, stamp_ms: t_ms },
-        None => ego,
-    }
+/// The pose+velocity at time `t` along a plan (the fast-loop conformance target): the
+/// first point at/after `t`, else the final point (a held stop).
+fn pose_at(plan: &PlanOutput, t: f64) -> Option<&TrajectoryPoint> {
+    plan.trajectory.iter().find(|p| p.time_from_start_s >= t).or_else(|| plan.trajectory.last())
 }
 
 /// Run the closed loop for `ticks` and return `(ego trace, was-every-tick-admitted)`.
@@ -131,12 +118,36 @@ fn drive(
     };
     let mut trace = vec![ego];
     let mut all_admitted = true;
+    // Model the REAL fast/slow loop: the slow loop only promotes a trajectory into the
+    // `accepted` slot on an admitting verdict; the fast loop continuously CONFORMS to that
+    // slot (tracking time `slot_t` along it). A momentary reject does NOT discard the slot
+    // and does NOT slam the ego to a stop — it simply isn't promoted, and the fast loop
+    // keeps tracking the last accepted plan toward its (KIRRA-admitted) stop. MRC happens
+    // only when there is no accepted slot at all (e.g. a reckless doer rejected every tick).
+    let mut accepted: Option<PlanOutput> = None;
+    let mut slot_t = 0.0_f64;
     for tick in 1..=ticks {
         let w = world(ego, map, objects);
         let plan = mick_drive_once(brain, &w, planner);
         let admitted = kirra_admits(&plan, map, objects);
         all_admitted &= admitted;
-        ego = advance(ego, &plan, admitted, tick as u64 * (TICK_DT * 1000.0) as u64);
+        if admitted {
+            accepted = Some(plan); // slow loop promotes the fresh trajectory
+            slot_t = 0.0;
+        }
+        slot_t += TICK_DT;
+        ego = match accepted.as_ref().and_then(|p| pose_at(p, slot_t)) {
+            // Fast loop conforms to the accepted slot, advancing along it.
+            Some(tp) => EgoState {
+                pose: tp.pose, linear_x_mps: tp.velocity_mps, yaw_rate_rads: 0.0,
+                stamp_ms: tick as u64 * (TICK_DT * 1000.0) as u64,
+            },
+            // No accepted slot ever → MRC: shed speed and hold.
+            None => EgoState {
+                pose: ego.pose, linear_x_mps: (ego.linear_x_mps - MRC_DECEL * TICK_DT).max(0.0),
+                yaw_rate_rads: 0.0, stamp_ms: tick as u64 * (TICK_DT * 1000.0) as u64,
+            },
+        };
         trace.push(ego);
     }
     (trace, all_admitted)
@@ -168,10 +179,14 @@ fn chauffeur_holds_short_of_a_hazard_across_the_whole_run() {
     // whether by Occy grounding the plan to stop short OR by KIRRA MRC-ing it as the ego
     // closes in (defense in depth). Either way the chauffeur is held safe.
     assert!(reached < HAZARD_X, "the ego must never reach the hazard, reached {reached}");
-    // And it is a real approach, not a refusal to move — it drives forward from the x=5
-    // start toward the hazard before holding (the planner keeps a conservative stop-short
-    // gap, so it settles a few metres in rather than nosing right up to the obstacle).
-    assert!(reached > 7.0, "the chauffeur drives up toward the hazard, reached {reached}");
+    // And it NOSES UP to the obstacle — the rear axle reaches ~16-17 m, i.e. the front
+    // bumper (~4 m ahead, rear-axle convention) holds ~4 m behind the object at x=25, the
+    // closest KIRRA's RSS admits. With the fast/slow-loop conformance this is a smooth
+    // approach-and-hold, not the chattering ~9 m stall the prior crude MRC-on-reject model
+    // produced. The residual ~4 m gap is the footprint length + the RSS following distance,
+    // not planner timidity (shrinking it further would require an RSS-tapered approach
+    // profile in the planner, never loosening the checker).
+    assert!(reached > 14.0, "the chauffeur noses up close to the hazard, reached {reached}");
 }
 
 #[test]


### PR DESCRIPTION
Three commits, one theme: the **fast/slow (dual-rate) loop** — modeled in the demo, implemented in the driver, and adopted in the live example.

## 1. "16 m short of the hazard" — diagnosed and fixed (demo harness)
Instrumented instead of guessing. **Two causes, only one real:** the plan stops ~4 m behind the obstacle's front bumper (legit RSS), but the ego only reached 9 because the demo's crude `advance` hard-MRC'd on any reject and chattered near the RSS edge. **Fix:** model the real fast/slow loop (promote to an `accepted` slot on admit; fast loop conforms; a momentary reject doesn't slam-stop). Ego now noses up to `16.60` smoothly. (My earlier "drop it" was a too-quick call — owned in the commit.)

## 2. Dual-rate `MickDriver` — makes Mick deployable
A 4B model can't run at 10–50 Hz on a vehicle. `MickDriver` splits the rates: **slow path** re-asks the brain for an *intent* every `decide_interval_ms` (~2 Hz); **fast path** grounds the cached intent vs the fresh world every tick (KIRRA bounds each). **Fail-closed staleness:** brain down past `intent_staleness_ms` → `Hold`; cold start → `Hold`; a momentary error keeps the last intent (re-grounded + re-checked). Clock-injected `now_ms`; 4 deterministic tests.

## 3. Live example adopts it
`mick_chauffeur` now runs `MickDriver<LlmBrain<OllamaClient>>` at a 10 Hz fast loop with Gemma at ~2 Hz, and prints an `intent (System-2)` column so you can **watch the maneuver persist between the model's infrequent decisions** while the trajectory tracks live perception — ~5 Gemma calls over 2.4 s instead of 24. Fail-closed verified (no Ollama → Hold).

### Verification
kirra-planner lib **86** + closed-loop/integration green; kirra-mick example builds + runs; clippy clean under `-D warnings --all-targets`; production `GeometricPlannerConfig` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)