### PR TITLE
Constrain Gemma's decoding to the intent JSON-schema (schema-constrained Mick)

### DIFF
--- a/crates/kirra-mick/src/lib.rs
+++ b/crates/kirra-mick/src/lib.rs
@@ -82,12 +82,15 @@ struct GenerateRequest<'a> {
     model: &'a str,
     prompt: &'a str,
     stream: bool,
-    /// Constrained decoding: `"json"` forces Ollama to emit a syntactically valid JSON
-    /// object (grammar-constrained), so Gemma can't wrap the intent in prose or a code
-    /// fence. `from_llm_json` still validates the typed schema + finiteness on top, so a
-    /// well-formed-but-wrong object (unknown tag, NaN) still fails closed — this only
-    /// removes the *framing* failure mode that otherwise forces a needless HOLD.
-    format: &'static str,
+    /// Schema-constrained decoding: Ollama grammar-constrains the output to this JSON
+    /// **schema** (`kirra_planner::intent_schema`), so Gemma can ONLY emit a JSON object
+    /// whose `intent` is a known tag — no prose, no code fence, no hallucinated tag. This
+    /// is strictly tighter than the previous `"json"` (any-JSON) form. `from_llm_json`
+    /// still validates the per-variant fields + finiteness on top (a schema cannot express
+    /// finiteness, and the binding safety decision must stay in our fail-closed parse, not
+    /// the model's decoder), so a schema-valid-but-wrong reply (e.g. `target_speed_mps` =
+    /// `Inf`) still fails closed → HOLD.
+    format: serde_json::Value,
 }
 
 /// The relevant slice of the `/api/generate` response.
@@ -99,7 +102,12 @@ struct GenerateResponse {
 impl ModelClient for OllamaClient {
     fn complete(&self, prompt: &str) -> Result<String, ModelError> {
         let url = format!("{}/api/generate", self.base_url);
-        let body = GenerateRequest { model: &self.model, prompt, stream: false, format: "json" };
+        let body = GenerateRequest {
+            model: &self.model,
+            prompt,
+            stream: false,
+            format: kirra_planner::intent_schema(),
+        };
 
         // Every failure maps to a stable ModelError → LlmBrain fails closed → HOLD.
         let resp = self
@@ -152,6 +160,26 @@ mod tests {
     fn config_defaults_and_overrides() {
         let c = OllamaClient::with("http://example:1234", "llama3.2:3b");
         assert_eq!(c.model(), "llama3.2:3b");
+    }
+
+    /// The request sends the intent schema as Ollama's `format` (an OBJECT, not the string
+    /// `"json"`), so decoding is schema-constrained. CI-safe — no network; just serializes
+    /// the body and inspects the wire shape.
+    #[test]
+    fn request_body_carries_the_intent_schema_as_format() {
+        let body = GenerateRequest {
+            model: "gemma3:4b",
+            prompt: "hi",
+            stream: false,
+            format: kirra_planner::intent_schema(),
+        };
+        let wire: serde_json::Value = serde_json::to_value(&body).expect("body serializes");
+        assert_eq!(wire["format"]["type"], "object", "format is a schema object, not \"json\"");
+        let tags = wire["format"]["properties"]["intent"]["enum"].as_array().expect("intent enum present");
+        assert!(
+            tags.iter().any(|t| t == "pull_over") && tags.iter().any(|t| t == "go_to"),
+            "the constrained tag set is carried on the wire"
+        );
     }
 
     /// Live round-trip — requires `ollama pull gemma3:4b` and a running server. Ignored in

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -70,7 +70,7 @@ pub use mick::{
 /// seam). Pure + testable with a `MockModel`; a concrete `ModelClient` (local Gemma via
 /// Ollama, etc.) plugs in behind a feature/crate.
 pub mod mick_llm;
-pub use mick_llm::{build_prompt, LlmBrain, MockModel, ModelClient, ModelError};
+pub use mick_llm::{build_prompt, intent_schema, LlmBrain, MockModel, ModelClient, ModelError};
 
 pub mod learned;
 pub use learned::{LearnedPlanner, Teacher};

--- a/crates/kirra-planner/src/mick_llm.rs
+++ b/crates/kirra-planner/src/mick_llm.rs
@@ -68,6 +68,43 @@ Intent:"
     )
 }
 
+/// The intent **JSON Schema** — the machine-readable form of the output contract that
+/// `build_prompt` states in prose and that [`MickIntent::from_llm_json`] parses. A backend
+/// that supports schema-constrained / grammar-constrained decoding (e.g. Ollama's `format`)
+/// passes this so the model can ONLY emit a JSON object whose `intent` is one of the known
+/// tags — eliminating the unknown-tag and non-JSON failure modes at the decoder, before a
+/// token is sampled, rather than catching them after the fact with a fail-closed HOLD.
+///
+/// Deliberately constrains the **tag + JSON validity**, not every per-variant field: it
+/// admits the union of the typed fields and requires only `intent`. The remaining checks —
+/// that `go_to` carries finite `x_m`/`y_m`, that a number is not `Inf`/`NaN`, etc. — stay
+/// with [`MickIntent::from_llm_json`], because a schema/grammar cannot express finiteness
+/// and the binding safety decision must remain in our fail-closed parse, never delegated to
+/// the model's decoder. So this is a strict improvement over plain `"json"` that can never
+/// regress: worst case it is exactly as permissive on fields, and strictly tighter on tags.
+///
+/// Source of truth: keep the `enum` below in lockstep with [`MickIntent::from_llm_json`]'s
+/// tags and `build_prompt`'s listed forms (the `intent_schema_lists_every_parseable_tag`
+/// test pins this).
+#[must_use]
+pub fn intent_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "intent": {
+                "type": "string",
+                "enum": ["go_to", "lane_change", "hold", "cruise", "overtake", "pull_over"]
+            },
+            "x_m": { "type": "number" },
+            "y_m": { "type": "number" },
+            "target_offset_m": { "type": "number" },
+            "target_speed_mps": { "type": "number" }
+        },
+        "required": ["intent"],
+        "additionalProperties": false
+    })
+}
+
 /// A [`MickBrain`] driven by any [`ModelClient`]: render the prompt, ask the model, parse
 /// the reply into a typed intent. Fail-closed at every step — a transport error or an
 /// unparseable / out-of-schema reply returns `Err`, on which the caller HOLDs.
@@ -144,6 +181,46 @@ mod tests {
         assert!(p.contains("ego_speed_mps") && p.contains("posture"), "prompt must embed the situation");
         // Few-shot worked examples are present (small models lean on them heavily).
         assert!(p.contains("Examples"), "prompt must carry few-shot examples");
+    }
+
+    #[test]
+    fn intent_schema_is_a_well_formed_object_schema_requiring_the_tag() {
+        let s = intent_schema();
+        assert_eq!(s["type"], "object", "the schema is an object schema");
+        assert_eq!(s["required"], serde_json::json!(["intent"]), "the intent tag is required");
+        assert_eq!(s["additionalProperties"], serde_json::json!(false), "no stray fields admitted");
+        // It must serialize as a JSON object (this is what Ollama's `format` receives).
+        assert!(serde_json::to_string(&s).is_ok(), "the schema serializes");
+    }
+
+    /// THE source-of-truth pin: every tag the schema constrains the model to MUST be one
+    /// the fail-closed parser accepts (with that tag's fields), and vice-versa — so the
+    /// decoder grammar and the typed parse can never drift apart.
+    #[test]
+    fn intent_schema_lists_every_parseable_tag() {
+        let s = intent_schema();
+        let enum_tags: Vec<String> = s["properties"]["intent"]["enum"]
+            .as_array()
+            .expect("intent.enum is an array")
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+
+        // A minimal VALID object for each tag, and the typed intent it must parse to.
+        let cases = [
+            (r#"{"intent":"go_to","x_m":1.0,"y_m":2.0}"#, "go_to"),
+            (r#"{"intent":"lane_change","target_offset_m":3.5}"#, "lane_change"),
+            (r#"{"intent":"hold"}"#, "hold"),
+            (r#"{"intent":"cruise","target_speed_mps":5.0}"#, "cruise"),
+            (r#"{"intent":"overtake"}"#, "overtake"),
+            (r#"{"intent":"pull_over"}"#, "pull_over"),
+        ];
+        for (json, tag) in cases {
+            assert!(enum_tags.contains(&tag.to_string()), "schema enum must list {tag}");
+            assert!(MickIntent::from_llm_json(json).is_ok(), "parser must accept the schema-valid {tag}");
+        }
+        // No extra tags the parser would reject (the enum is exactly the parseable set).
+        assert_eq!(enum_tags.len(), cases.len(), "schema enum lists exactly the parseable tags");
     }
 
     #[test]


### PR DESCRIPTION
## What

Mick's Ollama transport previously sent `format: "json"` — Gemma was grammar-constrained to *any* valid JSON, so a hallucinated/unknown-tag object (`{"intent":"teleport"}`) or a stray-field object was syntactically fine and only caught **after the fact** by the fail-closed parse, wasting a planning tick on a needless HOLD.

This sends the intent **JSON-schema** instead (`kirra_planner::intent_schema`), so Ollama schema-constrains decoding: Gemma can **only** emit a JSON object whose `intent` is one of the six known tags (`go_to`, `lane_change`, `hold`, `cruise`, `overtake`, `pull_over`). The unknown-tag and non-JSON failure modes are removed **at the decoder, before a token is sampled** — not recovered after.

## Where the safety boundary stays

The schema deliberately constrains the **tag + JSON validity**, not every per-variant field: it admits the union of the typed numeric fields and requires only `intent`. The remaining checks — that `go_to` carries finite `x_m`/`y_m`, that a number isn't `Inf`/`NaN` — stay with `MickIntent::from_llm_json`, because:
- a JSON schema / GBNF grammar **cannot express finiteness**, and
- the binding safety decision must remain in our **fail-closed parse**, never delegated to the model's decoder.

So this is a **strict improvement** over plain `"json"` that can never regress: worst case it's exactly as permissive on fields, and strictly tighter on tags. A schema-valid-but-wrong reply (e.g. `target_speed_mps: 1e400` → `Inf`) still fails closed → HOLD.

## Changes

- **kirra-planner**: `intent_schema()` — the machine form of the prompt's prose contract, as the single source of truth next to `IntentJson` (exported). Tests pin the schema's `enum` to *exactly* the parser-accepted tag set, so the decoder grammar and the typed parse can't drift.
- **kirra-mick**: `OllamaClient` sends the schema as the `/api/generate` `format` field; CI-safe wire-shape test (serializes the body, asserts `format` is the schema object with the constrained tag set — no network).

## Source-of-truth discipline

`intent_schema`'s `enum`, `MickIntent::from_llm_json`'s tags, and `build_prompt`'s listed forms are kept in lockstep — the `intent_schema_lists_every_parseable_tag` test enforces it (each schema tag must parse, and the enum is exactly the parseable set).

## Note on verification

The constrained-decoding behavior itself requires a live Ollama (the `live_ollama_*` test is `#[ignore]`, run locally). CI covers the wire shape and the schema↔parser equivalence; it does not exercise a real model's grammar adherence.

## Tests

92 planner lib tests (incl. 2 new schema tests), kirra-mick 3 + 1 ignored (incl. the new wire-shape test); `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_