### PR TITLE
Materialize a route corridor through a junction (TurnAt foundation)

### DIFF
--- a/crates/kirra-map/src/lanemap.rs
+++ b/crates/kirra-map/src/lanemap.rs
@@ -536,6 +536,41 @@ impl LaneGraph {
         })
     }
 
+    /// Materialize a **route** (a longitudinal lane-id sequence from
+    /// [`route`](Self::route)) into one continuous drivable [`LaneCorridor`] that
+    /// FOLLOWS the route through any turns — the longitudinal counterpart to
+    /// [`corridor_over`](Self::corridor_over) (which spans laterally-adjacent lanes for
+    /// a road *cross-section*). Each route lane's centerline is offset to its own
+    /// ±`half_width_m`, and the per-lane left/right boundary polylines are concatenated
+    /// end-to-end, so the corridor **curves through a junction** exactly as the route
+    /// lanes do. This is the handle the planner follows and KIRRA re-reads for an
+    /// intersection turn (a route `[ego_lane → junction_lane → exit_lane]`).
+    ///
+    /// Seam dedup: where one lane's offset boundary ends at the next lane's start (a
+    /// shared junction node), the duplicated vertex is dropped so the polyline carries
+    /// no zero-length segment. Returns `None` if `route` is empty, any id is unknown, or
+    /// the result degenerates to fewer than two vertices a side (fail-closed).
+    ///
+    /// **Geometry assumption (stated, not hidden):** the route lanes are expected to
+    /// connect end-to-end (lane *i*'s centerline terminus ≈ lane *i+1*'s start), as a
+    /// Lanelet2 successor chain does, and a junction *turn* lane carries a smooth **arc**
+    /// centerline so the offset stays kink-free — a hard L-corner would spike the
+    /// implied steering rate, which KIRRA would then (correctly) clamp/refuse. The
+    /// materializer trusts the map's geometry: it concatenates, it does not re-fit
+    /// corners. Typed lane boundaries along a route (for a mid-turn lane change) are a
+    /// tracked follow-up; a turn follows the route centerline and needs only the corridor.
+    #[must_use]
+    pub fn route_corridor(&self, route: &[u64], confidence: f32, age_ms: u64) -> Option<LaneCorridor> {
+        let lanes = self.resolve(route)?;
+        let mut left: Vec<Point> = Vec::new();
+        let mut right: Vec<Point> = Vec::new();
+        for lane in lanes {
+            concat_dedup(&mut left, &offset_polyline(&lane.centerline, lane.half_width_m));
+            concat_dedup(&mut right, &offset_polyline(&lane.centerline, -lane.half_width_m));
+        }
+        (left.len() >= 2 && right.len() >= 2).then_some(LaneCorridor { left, right, confidence, age_ms })
+    }
+
     /// Derive the typed lane boundaries across a span of lanes, expressed as
     /// lateral offsets **relative to `ego_lane`'s centerline** (the frame Occy's
     /// `lane_boundaries` input uses). Boundaries shared between adjacent lanes are
@@ -652,6 +687,17 @@ fn x_extent(a: &[Point], b: &[Point]) -> Option<(f64, f64)> {
     let x0 = a.iter().chain(b).map(|p| p.x_m).fold(f64::INFINITY, f64::min);
     let x1 = a.iter().chain(b).map(|p| p.x_m).fold(f64::NEG_INFINITY, f64::max);
     (x0.is_finite() && x1.is_finite() && x1 > x0).then_some((x0, x1))
+}
+
+/// Append `pts` onto `acc`, dropping `pts`'s first vertex if it coincides (within a
+/// tolerance) with `acc`'s last — so concatenating consecutive route-lane boundary
+/// polylines at a shared junction node leaves no zero-length segment.
+fn concat_dedup(acc: &mut Vec<Point>, pts: &[Point]) {
+    let start = match (acc.last(), pts.first()) {
+        (Some(last), Some(first)) if (last.x_m - first.x_m).hypot(last.y_m - first.y_m) <= 1e-6 => 1,
+        _ => 0,
+    };
+    acc.extend_from_slice(&pts[start..]);
 }
 
 /// Offset a centerline polyline laterally by `signed_offset` (>0 = +y/left side)
@@ -969,6 +1015,93 @@ mod tests {
             .with_lane(Lane::straight(3, 0.0, 60.0, 90.0, 1.75, LineType::Solid, LineType::Solid));
         assert_eq!(g.route(1, 3), None);
         assert_eq!(g.route(1, 2), Some(vec![1, 2]));
+    }
+
+    // ----- Route corridor (longitudinal stitch through a junction) ---------
+
+    /// A quarter-circle arc (n+1 points) from `start_angle` sweeping +π/2 about
+    /// `(cx, cy)` at radius `r` — a smooth left-turn centerline.
+    fn quarter_arc(cx: f64, cy: f64, r: f64, start_angle: f64, n: usize) -> Vec<Point> {
+        (0..=n)
+            .map(|i| {
+                let t = start_angle + std::f64::consts::FRAC_PI_2 * (i as f64 / n as f64);
+                Point { x_m: cx + r * t.cos(), y_m: cy + r * t.sin() }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn route_corridor_concats_a_straight_succession_deduping_the_seam() {
+        // Two straight lanes end-to-end: 1 (x 0..20) → 2 (x 20..40), both at y=0.
+        let g = LaneGraph::new()
+            .with_lane(
+                Lane::straight(1, 0.0, 0.0, 20.0, 2.0, LineType::Solid, LineType::Solid)
+                    .with_edge(LaneEdge::Successor { to: 2 }),
+            )
+            .with_lane(Lane::straight(2, 0.0, 20.0, 40.0, 2.0, LineType::Solid, LineType::Solid));
+        assert_eq!(g.route(1, 2), Some(vec![1, 2]));
+
+        let c = g.route_corridor(&[1, 2], 0.95, 10).expect("stitch");
+        // Seam at x=20 deduped → 3 vertices a side, spanning x 0..40 at ±2.
+        assert_eq!(c.left_boundary().len(), 3, "shared seam vertex deduped: {:?}", c.left_boundary());
+        assert_eq!(c.right_boundary().len(), 3);
+        assert!(c.left_boundary().iter().all(|p| (p.y_m - 2.0).abs() < 1e-9));
+        assert!(c.right_boundary().iter().all(|p| (p.y_m + 2.0).abs() < 1e-9));
+        assert!((c.left_boundary().last().unwrap().x_m - 40.0).abs() < 1e-9, "spans to x=40");
+    }
+
+    #[test]
+    fn route_corridor_curves_through_a_left_turn() {
+        // Ego straight (0,0)→(20,0); a quarter-arc junction lane curving LEFT from
+        // (20,0) up to (30,10); a vertical exit lane (30,10)→(30,30). The stitched
+        // corridor must FOLLOW the turn — its boundaries swing from heading-east to
+        // heading-north (the exit), not stay flat.
+        let arc = quarter_arc(20.0, 10.0, 10.0, -std::f64::consts::FRAC_PI_2, 8); // (20,0)→(30,10)
+        let junction = Lane {
+            id: 2,
+            centerline: arc,
+            half_width_m: 2.0,
+            left_line: LineType::Solid,
+            right_line: LineType::Solid,
+            heading_rad: std::f64::consts::FRAC_PI_4, // mean of the turn; not load-bearing here
+            edges: vec![LaneEdge::Successor { to: 3 }],
+        };
+        let exit = Lane {
+            id: 3,
+            centerline: vec![Point { x_m: 30.0, y_m: 10.0 }, Point { x_m: 30.0, y_m: 30.0 }],
+            half_width_m: 2.0,
+            left_line: LineType::Solid,
+            right_line: LineType::Solid,
+            heading_rad: std::f64::consts::FRAC_PI_2, // north
+            edges: Vec::new(),
+        };
+        let g = LaneGraph::new()
+            .with_lane(
+                Lane::straight(1, 0.0, 0.0, 20.0, 2.0, LineType::Solid, LineType::Solid)
+                    .with_edge(LaneEdge::Successor { to: 2 }),
+            )
+            .with_lane(junction)
+            .with_lane(exit);
+
+        let route = g.route(1, 3).expect("route through the junction");
+        assert_eq!(route, vec![1, 2, 3]);
+        let c = g.route_corridor(&route, 0.95, 10).expect("stitch the turn");
+
+        // The corridor starts flat (east, y≈0) and ends pointed north (x≈30, y≈30) —
+        // i.e. it genuinely turned, not stayed on the entry heading.
+        let last_l = *c.left_boundary().last().unwrap();
+        assert!(last_l.y_m > 25.0, "corridor reaches up the exit lane, got y={}", last_l.y_m);
+        assert!((last_l.x_m - 30.0).abs() < 3.0, "and is laterally at the exit (x≈30±half), got x={}", last_l.x_m);
+        // Sanity: the entry is still near the origin heading east.
+        assert!(c.right_boundary()[0].x_m.abs() < 1e-6, "entry starts at x≈0");
+    }
+
+    #[test]
+    fn route_corridor_fails_closed_on_unknown_or_empty() {
+        let g = LaneGraph::new()
+            .with_lane(Lane::straight(1, 0.0, 0.0, 20.0, 2.0, LineType::Solid, LineType::Solid));
+        assert!(g.route_corridor(&[], 0.95, 10).is_none(), "empty route → None");
+        assert!(g.route_corridor(&[1, 99], 0.95, 10).is_none(), "unknown id → None");
     }
 
     // ----- Right-of-way: cede vs non-yield, consistent from one source -----

--- a/crates/kirra-planner/tests/turn_at_junction.rs
+++ b/crates/kirra-planner/tests/turn_at_junction.rs
@@ -1,0 +1,153 @@
+//! End-to-end: **follow a route through a junction turn → Occy → KIRRA**.
+//!
+//! The map-side TurnAt primitive. A route `[ego_lane → arc junction_lane → exit_lane]`
+//! is materialized into one continuous corridor by `LaneGraph::route_corridor` (the
+//! longitudinal counterpart to `corridor_over`), handed to the planner as `map`, and the
+//! EXISTING planner follows the curving centerline through the turn while KIRRA bounds it
+//! (containment + steering-rate / lateral-accel along the arc). No `plan()` surgery — a
+//! turn is a curved corridor, which the planner already smooths, speeds for curvature, and
+//! the checker already bounds.
+//!
+//! The doer-checker split holds at the junction: Occy proposes following the route arc;
+//! KIRRA admits a gently-radiused turn and refuses one too tight to take safely.
+//!
+//! The Mick `TurnAt { direction }` intent (which needs the LaneGraph threaded into the
+//! grounding seam) is a tracked follow-up; this proves the maneuver it will drive.
+
+use kirra_planner::{
+    EgoState, FleetPosture, GeometricPlanner, Goal, Lane, LaneEdge, LaneGraph, LineType, PlanInput,
+    Planner, Pose, ProposalKind, TrajectoryVerdict,
+};
+use kirra_ros2_adapter::corridor::Point;
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+/// A quarter-circle arc (n+1 points) sweeping +π/2 about `(cx, cy)` from `start_angle` —
+/// a smooth LEFT-turn centerline.
+fn quarter_arc(cx: f64, cy: f64, r: f64, start_angle: f64, n: usize) -> Vec<Point> {
+    (0..=n)
+        .map(|i| {
+            let t = start_angle + std::f64::consts::FRAC_PI_2 * (i as f64 / n as f64);
+            Point { x_m: cx + r * t.cos(), y_m: cy + r * t.sin() }
+        })
+        .collect()
+}
+
+/// A left-turn junction of arc radius `r` and lane half-width `half`:
+///   lane 1 — straight ego approach (0,0)→(20,0), heading east;
+///   lane 2 — quarter-arc turning LEFT from (20,0) up to (20+r, r);
+///   lane 3 — straight exit running NORTH (20+r, r)→(20+r, r+20).
+fn left_turn(r: f64, half: f64) -> LaneGraph {
+    let line = LineType::Solid;
+    let arc = quarter_arc(20.0, r, r, -std::f64::consts::FRAC_PI_2, 12);
+    let junction = Lane {
+        id: 2,
+        centerline: arc,
+        half_width_m: half,
+        left_line: line,
+        right_line: line,
+        heading_rad: std::f64::consts::FRAC_PI_4,
+        edges: vec![LaneEdge::Successor { to: 3 }],
+    };
+    let exit = Lane {
+        id: 3,
+        centerline: vec![Point { x_m: 20.0 + r, y_m: r }, Point { x_m: 20.0 + r, y_m: r + 20.0 }],
+        half_width_m: half,
+        left_line: line,
+        right_line: line,
+        heading_rad: std::f64::consts::FRAC_PI_2,
+        edges: Vec::new(),
+    };
+    LaneGraph::new()
+        .with_lane(
+            Lane::straight(1, 0.0, 0.0, 20.0, half, line, line).with_edge(LaneEdge::Successor { to: 2 }),
+        )
+        .with_lane(junction)
+        .with_lane(exit)
+}
+
+/// Plan from the ego approach toward a goal up the exit lane, following the stitched route
+/// corridor; return the plan + KIRRA's verdict on it (checked against the same corridor).
+fn plan_turn(r: f64, half: f64) -> (kirra_planner::PlanOutput, TrajectoryVerdict, f64) {
+    let g = left_turn(r, half);
+    let route = g.route(1, 3).expect("route through the junction");
+    let map = g.route_corridor(&route, 0.95, 10).expect("stitch the route corridor");
+
+    let input = PlanInput {
+        ego: EgoState {
+            // Near the junction mouth, so one planning horizon covers the bulk of the turn
+            // (the closed loop completes it over ticks). A few metres of approach remain so
+            // the footprint sits inside the corridor, not poking behind its start.
+            pose: Pose { x_m: 16.0, y_m: 0.0, heading_rad: 0.0 },
+            linear_x_mps: 2.0,
+            yaw_rate_rads: 0.0,
+            stamp_ms: 0,
+        },
+        // Goal up the exit lane (north of the turn).
+        goal: Goal { target: Pose { x_m: 20.0 + r, y_m: r + 12.0, heading_rad: std::f64::consts::FRAC_PI_2 } },
+        map: &map,
+        objects: &[],
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+        request_overtake: false,
+        request_pull_over: false,
+    };
+    let mut occy = GeometricPlanner::default();
+    let plan = occy.plan(&input);
+    let verdict = validate_trajectory_slow(
+        &plan.trajectory, &map, &[], &VehicleConfig::default_urban(), None, FleetPosture::Nominal,
+    );
+    let max_heading = plan
+        .trajectory
+        .iter()
+        .map(|p| p.pose.heading_rad)
+        .fold(f64::MIN, f64::max);
+    (plan, verdict, max_heading)
+}
+
+#[test]
+fn the_planner_follows_a_gentle_junction_turn_and_kirra_admits() {
+    // A comfortably-radiused left turn: the path swings from heading-east toward
+    // heading-north (it genuinely turns), reaches up into the exit lane, and KIRRA
+    // admits it (the curvature is within the steering-rate / lateral-accel envelope).
+    let r = 12.0;
+    let (plan, verdict, max_heading) = plan_turn(r, 3.0);
+
+    assert_eq!(plan.kind, ProposalKind::Motion, "the ego drives the turn, not HOLD");
+    // It turns: heading climbs well past 45° toward the north (π/2) exit.
+    assert!(max_heading > 1.0, "the path turns toward north, got max heading {max_heading} rad");
+    // It drives deep into the turn — most of the way up the arc toward the exit (the
+    // final stretch completes over subsequent ticks; one horizon covers the bulk).
+    let max_y = plan.trajectory.iter().map(|p| p.pose.y_m).fold(f64::MIN, f64::max);
+    assert!(max_y > 0.6 * r, "the path climbs through the turn, got max_y {max_y} (arc top {r})");
+    assert!(
+        matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "a gentle turn is within the envelope → KIRRA admits, got {verdict:?}"
+    );
+}
+
+#[test]
+fn kirra_bounds_a_too_tight_junction_turn() {
+    // The doer-checker payoff. A very tight radius forces curvature beyond the comfortable
+    // envelope; Occy still proposes following the route arc, but KIRRA does not pass it
+    // cleanly — the steering-rate / containment bound bites (a Clamp derate at minimum, or
+    // an outright MRC refusal). The checker, not the planner, owns the turn's safety.
+    let (_, gentle, _) = plan_turn(12.0, 3.0);
+    let (_, tight, _) = plan_turn(3.0, 3.0);
+
+    assert!(
+        matches!(gentle, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "control: the gentle turn admits, got {gentle:?}"
+    );
+    assert_ne!(
+        tight, TrajectoryVerdict::Accept,
+        "a too-tight turn is NOT cleanly accepted — KIRRA bounds it (Clamp or MRC), got {tight:?}"
+    );
+}


### PR DESCRIPTION
## What

Adds the missing map primitive for following a route through an **intersection turn**, and proves the existing planner + checker handle it end-to-end.

## The gap

`LaneGraph::route()` already selects a lane sequence, and `corridor_over()` stitches lanes **laterally** (a road *cross-section*) — but nothing stitched a route **longitudinally** into one continuous corridor that *curves through a junction*. That was the only thing missing to drive a turn.

## The headline finding

**No `plan()` surgery was needed.** The scoping paid off: a junction turn is just a *curved corridor*, which the existing planner already smooths (Chaikin), slows for (curvature-aware speed), and follows (per-pose heading), and which KIRRA already bounds (containment + steering-rate / lateral-accel). So this PR is a clean map primitive plus an end-to-end proof — not planner changes.

## Changes

- **`kirra-map`: `LaneGraph::route_corridor(route, conf, age) -> Option<LaneCorridor>`** — concatenates each route lane's ±`half_width` offset boundaries end-to-end (deduping the shared junction-node seam) so the corridor follows the route through any turns. The longitudinal counterpart to `corridor_over`. Fail-closed on empty / unknown ids.
  - *Honest scope (documented in the method):* it trusts the map's geometry to connect end-to-end and to carry a **smooth arc** at a turn lane — an L-corner would spike the implied steering rate, which KIRRA then clamps/refuses. Typed route boundaries (for a *mid-turn* lane change) are a tracked follow-up; a turn follows the route centerline and needs only the corridor.

- **`kirra-planner` `tests/turn_at_junction.rs`** — a left-turn junction (straight approach → quarter-arc junction lane → north exit), routed and materialized, then planned toward the exit goal:
  - **gentle turn** → the path swings toward north, climbs deep into the arc, and KIRRA **admits** it;
  - **too-tight radius** → Occy still proposes following the arc, but KIRRA does **not** cleanly accept it (Clamp / MRC) — the checker, not the planner, owns the turn's safety.

## Follow-up

The Mick `TurnAt { direction: Left | Right | Straight }` intent needs the `LaneGraph` threaded into the grounding seam (today the brain only sees `PlanInput.map` / `WorldContext`) and is a tracked, architecturally-significant follow-up. This PR is the maneuver it will drive.

## Tests

kirra-map 38 (incl. 3 new `route_corridor` tests: straight-succession seam dedup, left-turn curvature, fail-closed), kirra-planner 97 lib + 2 new junction integration tests; `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_