### PR TITLE
Add MickIntent::TurnAt — the brain chooses a junction turn

### DIFF
--- a/crates/kirra-mick/examples/mick_chauffeur.rs
+++ b/crates/kirra-mick/examples/mick_chauffeur.rs
@@ -47,6 +47,7 @@ fn world<'a>(ego: EgoState, map: &'a dyn CorridorSource, objects: &'a [Perceived
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     }
 }
 

--- a/crates/kirra-mick/src/lib.rs
+++ b/crates/kirra-mick/src/lib.rs
@@ -10,7 +10,8 @@
 //!
 //! let mut mick = LlmBrain::new(OllamaClient::new()); // reads KIRRA_OLLAMA_URL / KIRRA_MICK_MODEL
 //! let ctx = WorldContext { ego_speed_mps: 3.0, posture: "NOMINAL", goal_ahead_m: 40.0,
-//!     goal_left_m: 0.0, may_change_left: true, may_change_right: false, objects: Vec::new() };
+//!     goal_left_m: 0.0, may_change_left: true, may_change_right: false, objects: Vec::new(),
+//!     available_turns: Vec::new() };
 //! match mick.decide(&ctx) {
 //!     Ok(intent) => { /* Occy grounds it, KIRRA bounds it */ }
 //!     Err(_)     => { /* model unreachable / hallucinated → HOLD (fail-closed) */ }
@@ -141,6 +142,7 @@ mod tests {
             may_change_left: true,
             may_change_right: false,
             objects: Vec::new(),
+            available_turns: Vec::new(),
         }
     }
 

--- a/crates/kirra-planner/examples/doer_bound_fixture.rs
+++ b/crates/kirra-planner/examples/doer_bound_fixture.rs
@@ -60,6 +60,7 @@ fn world<'a>(map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> Pla
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     }
 }
 

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -62,8 +62,8 @@ pub use lanelet2::{parse_lanelet2_osm, Lanelet2ParseError};
 pub mod mick;
 pub use mick::{
     mick_drive_once, plan_for_intent, MickBrain, MickDriver, MickError, MickIntent, ObjectView,
-    ScriptedBrain, WorldContext, DEFAULT_DECIDE_INTERVAL_MS, DEFAULT_INTENT_STALENESS_MS,
-    MICK_MAX_OBJECTS,
+    ScriptedBrain, TurnDirection, WorldContext, DEFAULT_DECIDE_INTERVAL_MS,
+    DEFAULT_INTENT_STALENESS_MS, MICK_MAX_OBJECTS,
 };
 
 /// Mick's model-agnostic LLM brain (prompt render + reply parse behind the `MickBrain`
@@ -252,6 +252,15 @@ pub struct PlanInput<'a> {
     /// binds first (never drives past a hazard to finish parking), and KIRRA independently
     /// bounds the maneuver. `false` = byte-for-byte prior behavior.
     pub request_pull_over: bool,
+    /// **Lane graph** for junction routing, if available — the substrate Mick's `TurnAt`
+    /// intent grounds against. When `Some`, `plan_for_intent` can resolve the ego lane from
+    /// its pose, pick the direction's turn branch (successor by heading), route through it,
+    /// and follow the materialized route corridor (`LaneGraph::route_corridor`) through the
+    /// turn. `None` = no junction routing (a `TurnAt` intent then fails closed to HOLD), and
+    /// byte-for-byte prior behavior for every other intent. The planner's own corridor-
+    /// following / containment is unchanged; this only supplies the route corridor a turn
+    /// needs, which KIRRA bounds exactly as it bounds any corridor.
+    pub lane_graph: Option<&'a LaneGraph>,
 }
 
 /// Intent label on a proposal.
@@ -1644,6 +1653,7 @@ mod tests {
             target_speed_mps: None,
             request_overtake: false,
             request_pull_over: false,
+            lane_graph: None,
         }
     }
 
@@ -1720,6 +1730,7 @@ mod tests {
             target_speed_mps: None,
             request_overtake: false,
             request_pull_over: false,
+            lane_graph: None,
         }
     }
 
@@ -1868,6 +1879,7 @@ mod tests {
             target_speed_mps: None,
             request_overtake: false,
             request_pull_over: false,
+            lane_graph: None,
         }
     }
 
@@ -2240,6 +2252,7 @@ mod tests {
             target_speed_mps: None,
             request_overtake: false,
             request_pull_over: false,
+            lane_graph: None,
         }
     }
 
@@ -2490,6 +2503,7 @@ mod tests {
             target_speed_mps: None,
             request_overtake: false,
             request_pull_over: false,
+            lane_graph: None,
         }
     }
 
@@ -2603,6 +2617,7 @@ mod tests {
             target_speed_mps: None,
             request_overtake: false,
             request_pull_over: false,
+            lane_graph: None,
         }
     }
 
@@ -3003,6 +3018,7 @@ mod tests {
             target_speed_mps: None,
             request_overtake: false,
             request_pull_over: false,
+            lane_graph: None,
         }
     }
 

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -16,7 +16,44 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{FleetPosture, Goal, PlanInput, PlanOutput, Planner, Pose};
+use crate::{FleetPosture, Goal, LaneGraph, PlanInput, PlanOutput, Planner, Pose, MAX_ROUTE_LANES};
+use kirra_core::corridor::Point as MapPoint;
+
+/// Which way a [`MickIntent::TurnAt`] heads at the next junction, relative to the ego
+/// lane's travel direction. Resolved to a successor lane by heading at grounding time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnDirection {
+    /// A left turn (the successor whose heading rotates ≈ +90°).
+    Left,
+    /// A right turn (≈ −90°).
+    Right,
+    /// Continue straight through the junction (≈ 0°).
+    Straight,
+}
+
+impl TurnDirection {
+    /// The wire / capture token (`left` / `right` / `straight`).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TurnDirection::Left => "left",
+            TurnDirection::Right => "right",
+            TurnDirection::Straight => "straight",
+        }
+    }
+
+    /// Does a successor whose heading differs from the ego lane by `delta_rad`
+    /// (wrapped to (−π, π]) count as this turn? A ±45° band splits straight from the
+    /// left/right quadrants (+ve = left / CCW).
+    fn matches(self, delta_rad: f64) -> bool {
+        const STRAIGHT_BAND: f64 = std::f64::consts::FRAC_PI_4; // ±45°
+        match self {
+            TurnDirection::Straight => delta_rad.abs() < STRAIGHT_BAND,
+            TurnDirection::Left => delta_rad >= STRAIGHT_BAND,
+            TurnDirection::Right => delta_rad <= -STRAIGHT_BAND,
+        }
+    }
+}
 
 /// A high-level intent the LLM brain proposes — the Mick → Occy contract. It maps
 /// ONLY to the goal / maneuver of a plan; it can express nothing about the world
@@ -49,6 +86,13 @@ pub enum MickIntent {
     /// decelerates to a controlled stop. Honored only if the rightward move is lawful and
     /// fits; a nearer hazard still stops the ego first, and KIRRA bounds the parked pose.
     PullOver,
+    /// Take the `direction` branch at the next junction. Honored only if a `lane_graph` is
+    /// supplied, the ego resolves to a lane, and that lane has a successor turning the
+    /// requested way; grounding routes through the branch and follows the materialized
+    /// route corridor through the turn. No graph / no such branch → fail-closed HOLD. KIRRA
+    /// bounds the route corridor exactly as it bounds any corridor (a too-tight turn is
+    /// refused).
+    TurnAt { direction: TurnDirection },
 }
 
 /// LLM JSON wire schema (tagged on `"intent"`). Kept separate from [`MickIntent`]
@@ -68,6 +112,8 @@ enum IntentJson {
     Overtake,
     #[serde(rename = "pull_over")]
     PullOver,
+    #[serde(rename = "turn_at")]
+    TurnAt { direction: String },
 }
 
 impl MickIntent {
@@ -93,6 +139,15 @@ impl MickIntent {
             IntentJson::Cruise { target_speed_mps } => MickIntent::Cruise { target_speed_mps },
             IntentJson::Overtake => MickIntent::Overtake,
             IntentJson::PullOver => MickIntent::PullOver,
+            IntentJson::TurnAt { direction } => {
+                let dir = match direction.as_str() {
+                    "left" => TurnDirection::Left,
+                    "right" => TurnDirection::Right,
+                    "straight" => TurnDirection::Straight,
+                    _ => return Err("MICK_UNKNOWN_TURN_DIRECTION"),
+                };
+                MickIntent::TurnAt { direction: dir }
+            }
         };
         if !intent.is_finite() {
             return Err("MICK_NONFINITE_INTENT");
@@ -108,6 +163,7 @@ impl MickIntent {
             MickIntent::Cruise { target_speed_mps } => target_speed_mps.is_finite(),
             MickIntent::Overtake => true,
             MickIntent::PullOver => true,
+            MickIntent::TurnAt { .. } => true,
         }
     }
 }
@@ -207,7 +263,86 @@ pub fn plan_for_intent(
             // stops the ego first, and KIRRA bounds the parked pose. Safe by construction.
             planner.plan(&PlanInput { request_pull_over: true, ..world.clone() })
         }
+        MickIntent::TurnAt { direction } => {
+            // Resolve the turn against the lane graph, FAIL-CLOSED at every step (no graph
+            // / ego off-map / no branch that way / unroutable / degenerate corridor → HOLD).
+            // On success, follow the materialized route corridor through the junction; KIRRA
+            // bounds it like any corridor (a too-tight turn is refused — proven in #526).
+            let Some(graph) = world.lane_graph else {
+                return PlanOutput::safe_stop(world.ego.pose);
+            };
+            let ego_pt = MapPoint { x_m: world.ego.pose.x_m, y_m: world.ego.pose.y_m };
+            let Some(ego_lane) = graph.lane_at(ego_pt) else {
+                return PlanOutput::safe_stop(world.ego.pose);
+            };
+            let Some(route) = turn_route(graph, ego_lane, direction) else {
+                return PlanOutput::safe_stop(world.ego.pose);
+            };
+            let Some(corridor) = graph.route_corridor(&route, ROUTE_CORRIDOR_CONFIDENCE, ROUTE_CORRIDOR_AGE_MS)
+            else {
+                return PlanOutput::safe_stop(world.ego.pose);
+            };
+            planner.plan(&PlanInput { map: &corridor, ..world.clone() })
+        }
     }
+}
+
+/// Map-server health stamped on a route corridor materialized for a `TurnAt`: fresh and
+/// confident, so the checker's corridor-health gate admits it (the geometry, not staleness,
+/// is what a turn is judged on).
+const ROUTE_CORRIDOR_CONFIDENCE: f32 = 0.95;
+const ROUTE_CORRIDOR_AGE_MS: u64 = 0;
+
+/// Pick the ego lane's successor that turns `direction` (successor-by-heading): the matching
+/// successor whose heading change from the ego lane is smallest in magnitude, ties by id for
+/// determinism. `None` if no successor turns that way.
+fn turn_target(graph: &LaneGraph, ego_lane: u64, direction: TurnDirection) -> Option<u64> {
+    let ego = graph.lane(ego_lane)?;
+    let mut best: Option<(u64, f64)> = None; // (lane id, |delta heading|)
+    for s in ego.successors() {
+        let Some(succ) = graph.lane(s) else { continue };
+        let delta = wrap_pi(succ.heading_rad - ego.heading_rad);
+        if direction.matches(delta) {
+            let score = delta.abs();
+            // Smaller heading change wins; equal scores break by lower id (deterministic).
+            if best.is_none_or(|(bid, bscore)| score < bscore || (score == bscore && s < bid)) {
+                best = Some((s, score));
+            }
+        }
+    }
+    best.map(|(id, _)| id)
+}
+
+/// The route through a `direction` turn: the ego lane, the chosen turn branch, then the
+/// branch's forward successors (deterministic lowest-id, cycle-guarded, bounded by
+/// `MAX_ROUTE_LANES`) so the route corridor spans the approach, the turn, and the exit.
+/// `None` if no successor turns that way.
+fn turn_route(graph: &LaneGraph, ego_lane: u64, direction: TurnDirection) -> Option<Vec<u64>> {
+    let branch = turn_target(graph, ego_lane, direction)?;
+    let mut route = vec![ego_lane, branch];
+    let mut cur = branch;
+    while route.len() < MAX_ROUTE_LANES {
+        match graph.lane(cur).and_then(|l| l.successors().min()) {
+            Some(next) if !route.contains(&next) => {
+                route.push(next);
+                cur = next;
+            }
+            _ => break,
+        }
+    }
+    Some(route)
+}
+
+/// Wrap an angle to `(−π, π]` (the heading-difference frame `TurnDirection::matches` reads).
+fn wrap_pi(a: f64) -> f64 {
+    use std::f64::consts::PI;
+    let mut x = a % (2.0 * PI);
+    if x > PI {
+        x -= 2.0 * PI;
+    } else if x <= -PI {
+        x += 2.0 * PI;
+    }
+    x
 }
 
 // ===========================================================================
@@ -272,6 +407,11 @@ pub struct WorldContext {
     pub may_change_right: bool,
     /// Nearby objects, ego-relative, NEAREST-FIRST, capped at [`MICK_MAX_OBJECTS`].
     pub objects: Vec<ObjectView>,
+    /// Turn branches available at the next junction (`left` / `right` / `straight`), derived
+    /// from the lane graph when one is supplied — so the brain only chooses `turn_at` where a
+    /// branch actually exists (a `turn_at` with no such branch fails closed to HOLD anyway).
+    /// Empty when there is no graph or the ego is off the mapped road.
+    pub available_turns: Vec<&'static str>,
 }
 
 impl WorldContext {
@@ -315,8 +455,28 @@ impl WorldContext {
                 world.lane_boundaries, 0.0, -MICK_LANE_PROBE_M,
             ),
             objects,
+            available_turns: available_turns(world),
         }
     }
+}
+
+/// The turn branches available to the ego at the next junction, derived from the
+/// `lane_graph` (empty if none / ego off-map). Uses the same successor-by-heading
+/// resolution `TurnAt` grounds with, so what the brain is offered is exactly what will
+/// ground.
+fn available_turns(world: &PlanInput<'_>) -> Vec<&'static str> {
+    let Some(graph) = world.lane_graph else {
+        return Vec::new();
+    };
+    let ego_pt = MapPoint { x_m: world.ego.pose.x_m, y_m: world.ego.pose.y_m };
+    let Some(ego_lane) = graph.lane_at(ego_pt) else {
+        return Vec::new();
+    };
+    [TurnDirection::Left, TurnDirection::Right, TurnDirection::Straight]
+        .into_iter()
+        .filter(|d| turn_target(graph, ego_lane, *d).is_some())
+        .map(TurnDirection::as_str)
+        .collect()
 }
 
 /// The pluggable System-2 brain behind Mick. Given the bounded [`WorldContext`], it
@@ -512,6 +672,7 @@ mod tests {
             target_speed_mps: None,
             request_overtake: false,
             request_pull_over: false,
+            lane_graph: None,
         }
     }
 
@@ -846,6 +1007,45 @@ mod tests {
     #[test]
     fn pull_over_llm_json_parses() {
         assert_eq!(MickIntent::from_llm_json(r#"{"intent":"pull_over"}"#).unwrap(), MickIntent::PullOver);
+    }
+
+    // ----- the TurnAt intent (junction turn) -----
+
+    #[test]
+    fn turn_at_llm_json_parses_each_direction_and_fails_closed_otherwise() {
+        let parse = |s| MickIntent::from_llm_json(s);
+        assert_eq!(parse(r#"{"intent":"turn_at","direction":"left"}"#).unwrap(), MickIntent::TurnAt { direction: TurnDirection::Left });
+        assert_eq!(parse(r#"{"intent":"turn_at","direction":"right"}"#).unwrap(), MickIntent::TurnAt { direction: TurnDirection::Right });
+        assert_eq!(parse(r#"{"intent":"turn_at","direction":"straight"}"#).unwrap(), MickIntent::TurnAt { direction: TurnDirection::Straight });
+        assert!(parse(r#"{"intent":"turn_at","direction":"sideways"}"#).is_err(), "unknown direction fails closed");
+        assert!(parse(r#"{"intent":"turn_at"}"#).is_err(), "missing direction fails closed");
+    }
+
+    #[test]
+    fn world_context_lists_the_available_turns_from_the_graph() {
+        use std::f64::consts::FRAC_PI_2;
+        // Approach lane 1 (east) branches LEFT (succ 2, heading +π/2) and RIGHT (succ 4,
+        // heading −π/2); there is no straight branch.
+        let g = crate::LaneGraph::new()
+            .with_lane(
+                crate::Lane::straight(1, 0.0, 0.0, 20.0, 2.0, crate::LineType::Solid, crate::LineType::Solid)
+                    .with_edge(crate::LaneEdge::Successor { to: 2 })
+                    .with_edge(crate::LaneEdge::Successor { to: 4 }),
+            )
+            .with_lane(crate::Lane::straight(2, 10.0, 20.0, 40.0, 2.0, crate::LineType::Solid, crate::LineType::Solid).with_heading(FRAC_PI_2))
+            .with_lane(crate::Lane::straight(4, -10.0, 20.0, 40.0, 2.0, crate::LineType::Solid, crate::LineType::Solid).with_heading(-FRAC_PI_2));
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+
+        // Ego inside lane 1 → both turns surface; no straight branch.
+        let with_graph = PlanInput { map: &corr, lane_graph: Some(&g), ..world(&corr, &[], &[]) };
+        let ctx = WorldContext::from_plan_input(&with_graph);
+        assert!(ctx.available_turns.contains(&"left"), "left branch surfaced: {:?}", ctx.available_turns);
+        assert!(ctx.available_turns.contains(&"right"), "right branch surfaced: {:?}", ctx.available_turns);
+        assert!(!ctx.available_turns.contains(&"straight"), "no straight branch: {:?}", ctx.available_turns);
+
+        // No graph → empty (the brain is offered no turns, and a TurnAt would HOLD anyway).
+        let no_graph = WorldContext::from_plan_input(&world(&corr, &[], &[]));
+        assert!(no_graph.available_turns.is_empty());
     }
 
     // ----- the dual-rate driver: System-2 intent rate vs System-1 grounding rate -----

--- a/crates/kirra-planner/src/mick_capture.rs
+++ b/crates/kirra-planner/src/mick_capture.rs
@@ -58,6 +58,9 @@ pub struct MickDecisionRecord {
     /// `cruise` requested speed, if applicable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_speed_mps: Option<f64>,
+    /// `turn_at` direction (`left` / `right` / `straight`), if applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_direction: Option<&'static str>,
 
     // ----- grounding (what Occy produced) -----
     /// `motion` | `safe_stop`.
@@ -91,6 +94,11 @@ impl MickDecisionRecord {
             MickIntent::Cruise { target_speed_mps } => ("cruise", None, None, None, Some(target_speed_mps)),
             MickIntent::Overtake => ("overtake", None, None, None, None),
             MickIntent::PullOver => ("pull_over", None, None, None, None),
+            MickIntent::TurnAt { .. } => ("turn_at", None, None, None, None),
+        };
+        let turn_direction = match *intent {
+            MickIntent::TurnAt { direction } => Some(direction.as_str()),
+            _ => None,
         };
 
         let proposal_kind = match plan.kind {
@@ -119,6 +127,7 @@ impl MickDecisionRecord {
             goal_x_m,
             goal_y_m,
             lane_offset_m,
+            turn_direction,
             target_speed_mps,
             proposal_kind,
             points: traj.len(),
@@ -217,18 +226,24 @@ mod tests {
     #[test]
     fn intent_kind_and_params_map_per_variant() {
         let plan = motion_plan();
-        let cases: [(MickIntent, &str); 6] = [
+        let cases: [(MickIntent, &str); 7] = [
             (MickIntent::GoTo { x_m: 20.0, y_m: -4.0 }, "go_to"),
             (MickIntent::LaneChange { target_offset_m: 3.5 }, "lane_change"),
             (MickIntent::Hold, "hold"),
             (MickIntent::Cruise { target_speed_mps: 5.0 }, "cruise"),
             (MickIntent::Overtake, "overtake"),
             (MickIntent::PullOver, "pull_over"),
+            (MickIntent::TurnAt { direction: crate::TurnDirection::Left }, "turn_at"),
         ];
         for (intent, kind) in cases {
             let r = MickDecisionRecord::new(0, 0, &intent, &plan, TrajectoryVerdict::Accept);
             assert_eq!(r.intent_kind, kind);
         }
+        // TurnAt carries its direction; non-turn intents leave it None.
+        let turn = MickDecisionRecord::new(0, 0, &MickIntent::TurnAt { direction: crate::TurnDirection::Right }, &plan, TrajectoryVerdict::Accept);
+        assert_eq!(turn.turn_direction, Some("right"));
+        let hold = MickDecisionRecord::new(0, 0, &MickIntent::Hold, &plan, TrajectoryVerdict::Accept);
+        assert_eq!(hold.turn_direction, None);
         // The one relevant parameter is carried; the others stay None.
         let goto = MickDecisionRecord::new(0, 0, &MickIntent::GoTo { x_m: 20.0, y_m: -4.0 }, &plan, TrajectoryVerdict::Accept);
         assert_eq!((goto.goal_x_m, goto.goal_y_m, goto.lane_offset_m, goto.target_speed_mps), (Some(20.0), Some(-4.0), None, None));

--- a/crates/kirra-planner/src/mick_llm.rs
+++ b/crates/kirra-planner/src/mick_llm.rs
@@ -44,6 +44,7 @@ Respond with ONLY one JSON object (no prose, no code fence), in one of these for
   {{\"intent\":\"lane_change\",\"target_offset_m\":<number>}}  shift laterally (+left, -right)\n\
   {{\"intent\":\"overtake\"}}                                   pass the slow/stopped lead ahead\n\
   {{\"intent\":\"pull_over\"}}                                  get to the road edge and stop\n\
+  {{\"intent\":\"turn_at\",\"direction\":\"left|right|straight\"}}  take the junction branch that way\n\
   {{\"intent\":\"hold\"}}                                       stop and hold\n\
 \n\
 Drive smoothly and comfortably; ease off near objects and when posture is DEGRADED. You \
@@ -60,6 +61,7 @@ Examples (situation → intent):\n\
 {{\"intent\":\"overtake\"}}\n\
 - an emergency vehicle (ambulance/police/fire) approaching → \
 {{\"intent\":\"pull_over\"}}\n\
+- a junction ahead and the goal is to your left → {{\"intent\":\"turn_at\",\"direction\":\"left\"}}\n\
 - the goal is off to one side and reachable → {{\"intent\":\"go_to\",\"x_m\":20,\"y_m\":-4}}\n\
 \n\
 Situation:\n{situation}\n\
@@ -93,12 +95,13 @@ pub fn intent_schema() -> serde_json::Value {
         "properties": {
             "intent": {
                 "type": "string",
-                "enum": ["go_to", "lane_change", "hold", "cruise", "overtake", "pull_over"]
+                "enum": ["go_to", "lane_change", "hold", "cruise", "overtake", "pull_over", "turn_at"]
             },
             "x_m": { "type": "number" },
             "y_m": { "type": "number" },
             "target_offset_m": { "type": "number" },
-            "target_speed_mps": { "type": "number" }
+            "target_speed_mps": { "type": "number" },
+            "direction": { "type": "string", "enum": ["left", "right", "straight"] }
         },
         "required": ["intent"],
         "additionalProperties": false
@@ -167,6 +170,7 @@ mod tests {
             may_change_left: true,
             may_change_right: false,
             objects: Vec::new(),
+            available_turns: Vec::new(),
         }
     }
 
@@ -174,7 +178,7 @@ mod tests {
     fn prompt_carries_the_schema_and_the_situation() {
         let p = build_prompt(&sample_ctx());
         // The typed-intent contract the model must follow.
-        for tag in ["cruise", "go_to", "lane_change", "overtake", "pull_over", "hold"] {
+        for tag in ["cruise", "go_to", "lane_change", "overtake", "pull_over", "turn_at", "hold"] {
             assert!(p.contains(tag), "prompt must list the {tag} intent");
         }
         // The ego-relative situation is embedded (serialized WorldContext).
@@ -214,6 +218,7 @@ mod tests {
             (r#"{"intent":"cruise","target_speed_mps":5.0}"#, "cruise"),
             (r#"{"intent":"overtake"}"#, "overtake"),
             (r#"{"intent":"pull_over"}"#, "pull_over"),
+            (r#"{"intent":"turn_at","direction":"left"}"#, "turn_at"),
         ];
         for (json, tag) in cases {
             assert!(enum_tags.contains(&tag.to_string()), "schema enum must list {tag}");

--- a/crates/kirra-planner/tests/adversarial_doer_bounded_by_kirra.rs
+++ b/crates/kirra-planner/tests/adversarial_doer_bounded_by_kirra.rs
@@ -100,6 +100,7 @@ fn world<'a>(map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> Pla
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     }
 }
 

--- a/crates/kirra-planner/tests/lane_graph_to_occy.rs
+++ b/crates/kirra-planner/tests/lane_graph_to_occy.rs
@@ -82,6 +82,7 @@ fn lane_change_across_broken_divider_admits() {
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
@@ -133,6 +134,7 @@ fn lane_change_across_solid_divider_is_refused() {
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);

--- a/crates/kirra-planner/tests/learned_doer_bounded_by_kirra.rs
+++ b/crates/kirra-planner/tests/learned_doer_bounded_by_kirra.rs
@@ -47,6 +47,7 @@ fn world<'a>(map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> Pla
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     }
 }
 

--- a/crates/kirra-planner/tests/mick_closed_loop.rs
+++ b/crates/kirra-planner/tests/mick_closed_loop.rs
@@ -85,6 +85,7 @@ fn world<'a>(ego: EgoState, map: &'a dyn CorridorSource, objects: &'a [Perceived
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     }
 }
 

--- a/crates/kirra-planner/tests/mick_turn_at.rs
+++ b/crates/kirra-planner/tests/mick_turn_at.rs
@@ -1,0 +1,153 @@
+//! End-to-end: **Mick `TurnAt` intent → route through the junction → Occy → KIRRA**.
+//!
+//! The full doer path for an intersection turn. Mick chooses a *direction*; grounding
+//! resolves it against the lane graph (successor-by-heading), routes through the branch,
+//! materializes the route corridor (`route_corridor`), and the planner follows it through
+//! the turn — KIRRA bounding the result. The brain never touches the map; grounding does
+//! all the routing, and the safety case is unchanged (proven in #526's turn tests).
+//!
+//! Junction convention used here: a turn-branch lane's `heading_rad` is its OUTGOING
+//! (destination) direction, so a left branch reads `+π/2` and a right branch `−π/2` — which
+//! is exactly what `TurnDirection`'s ±45° band resolves against.
+
+use kirra_planner::{
+    plan_for_intent, EgoState, FleetPosture, GeometricPlanner, Goal, Lane, LaneEdge, LaneGraph,
+    LineType, MickIntent, PlanInput, PlanOutput, Pose, ProposalKind, TrajectoryVerdict,
+    TurnDirection,
+};
+use kirra_ros2_adapter::corridor::Point;
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+const R: f64 = 12.0;
+const HALF: f64 = 3.0;
+
+/// A quarter-arc (n+1 pts) of radius `r` about `(cx, cy)`, from `start` sweeping `sweep`.
+fn arc(cx: f64, cy: f64, r: f64, start: f64, sweep: f64, n: usize) -> Vec<Point> {
+    (0..=n)
+        .map(|i| {
+            let t = start + sweep * (i as f64 / n as f64);
+            Point { x_m: cx + r * t.cos(), y_m: cy + r * t.sin() }
+        })
+        .collect()
+}
+
+fn lane(id: u64, centerline: Vec<Point>, heading_rad: f64, succ: Option<u64>) -> Lane {
+    let edges = succ.map(|s| vec![LaneEdge::Successor { to: s }]).unwrap_or_default();
+    Lane { id, centerline, half_width_m: HALF, left_line: LineType::Solid, right_line: LineType::Solid, heading_rad, edges }
+}
+
+/// A junction with a LEFT and a RIGHT branch off a straight approach (no straight branch):
+///   1  approach (0,0)→(20,0), east, successors {2, 4}
+///   2  left arc (20,0)→(20+R,R), heading +π/2 → 3 north exit
+///   4  right arc (20,0)→(20+R,−R), heading −π/2 → 5 south exit
+fn junction() -> LaneGraph {
+    let mut g = LaneGraph::new().with_lane(
+        Lane::straight(1, 0.0, 0.0, 20.0, HALF, LineType::Solid, LineType::Solid)
+            .with_edge(LaneEdge::Successor { to: 2 })
+            .with_edge(LaneEdge::Successor { to: 4 }),
+    );
+    // Left branch: arc up, then a north exit.
+    g.add_lane(lane(2, arc(20.0, R, R, -std::f64::consts::FRAC_PI_2, std::f64::consts::FRAC_PI_2, 12), std::f64::consts::FRAC_PI_2, Some(3)));
+    g.add_lane(lane(3, vec![Point { x_m: 20.0 + R, y_m: R }, Point { x_m: 20.0 + R, y_m: R + 20.0 }], std::f64::consts::FRAC_PI_2, None));
+    // Right branch: arc down, then a south exit.
+    g.add_lane(lane(4, arc(20.0, -R, R, std::f64::consts::FRAC_PI_2, -std::f64::consts::FRAC_PI_2, 12), -std::f64::consts::FRAC_PI_2, Some(5)));
+    g.add_lane(lane(5, vec![Point { x_m: 20.0 + R, y_m: -R }, Point { x_m: 20.0 + R, y_m: -R - 20.0 }], -std::f64::consts::FRAC_PI_2, None));
+    g
+}
+
+/// Ground a `TurnAt` from the approach near the junction mouth. `goal` is the exit-lane
+/// target the planner drives toward along the materialized route corridor.
+fn ground_turn<'a>(g: &'a LaneGraph, ego_corr: &'a dyn kirra_ros2_adapter::corridor::CorridorSource, goal: Pose, dir: TurnDirection) -> PlanOutput {
+    let input = PlanInput {
+        ego: EgoState { pose: Pose { x_m: 16.0, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: 2.0, yaw_rate_rads: 0.0, stamp_ms: 0 },
+        goal: Goal { target: goal },
+        map: ego_corr,
+        objects: &[],
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+        request_overtake: false,
+        request_pull_over: false,
+        lane_graph: Some(g),
+    };
+    plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::TurnAt { direction: dir }, &input)
+}
+
+#[test]
+fn mick_turn_left_grounds_through_the_junction_and_kirra_admits() {
+    let g = junction();
+    let ego_corr = g.lane(1).unwrap().corridor(0.95, 0);
+    let goal = Pose { x_m: 20.0 + R, y_m: R + 12.0, heading_rad: std::f64::consts::FRAC_PI_2 };
+    let plan = ground_turn(&g, &ego_corr, goal, TurnDirection::Left);
+
+    assert_eq!(plan.kind, ProposalKind::Motion, "TurnAt grounds to a drive, not HOLD");
+    let max_heading = plan.trajectory.iter().map(|p| p.pose.heading_rad).fold(f64::MIN, f64::max);
+    let max_y = plan.trajectory.iter().map(|p| p.pose.y_m).fold(f64::MIN, f64::max);
+    assert!(max_heading > 1.0, "the path turns LEFT (toward north), got max heading {max_heading}");
+    assert!(max_y > 0.6 * R, "and climbs the left branch, got max_y {max_y}");
+
+    // KIRRA bounds the grounded turn against the same route corridor grounding followed.
+    let route = g.route(1, 3).unwrap();
+    let corr = g.route_corridor(&route, 0.95, 0).unwrap();
+    let verdict = validate_trajectory_slow(&plan.trajectory, &corr, &[], &VehicleConfig::default_urban(), None, FleetPosture::Nominal);
+    assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp), "KIRRA admits the turn, got {verdict:?}");
+}
+
+#[test]
+fn mick_turn_right_picks_the_other_branch() {
+    // The same junction, direction RIGHT → the SOUTH branch (min_y negative): the
+    // successor-by-heading resolution selects by direction, not just "a branch exists".
+    let g = junction();
+    let ego_corr = g.lane(1).unwrap().corridor(0.95, 0);
+    let goal = Pose { x_m: 20.0 + R, y_m: -R - 12.0, heading_rad: -std::f64::consts::FRAC_PI_2 };
+    let plan = ground_turn(&g, &ego_corr, goal, TurnDirection::Right);
+
+    let min_y = plan.trajectory.iter().map(|p| p.pose.y_m).fold(f64::MAX, f64::min);
+    assert!(min_y < -0.6 * R, "RIGHT takes the south branch, got min_y {min_y}");
+}
+
+#[test]
+fn a_turn_with_no_such_branch_fails_closed_to_hold() {
+    // This junction has no STRAIGHT branch off lane 1 → TurnAt Straight must HOLD.
+    let g = junction();
+    let ego_corr = g.lane(1).unwrap().corridor(0.95, 0);
+    let goal = Pose { x_m: 60.0, y_m: 0.0, heading_rad: 0.0 };
+    let plan = ground_turn(&g, &ego_corr, goal, TurnDirection::Straight);
+
+    assert_eq!(plan.kind, ProposalKind::SafeStop, "no straight branch → fail-closed HOLD");
+    assert!(plan.trajectory.iter().all(|p| p.velocity_mps == 0.0));
+}
+
+#[test]
+fn a_turn_without_a_lane_graph_fails_closed_to_hold() {
+    // No lane graph supplied → TurnAt cannot resolve → HOLD (the loop's safe default).
+    let corr = kirra_ros2_adapter::corridor::MockCorridorSource::straight_5m_half_width(100.0);
+    let input = PlanInput {
+        ego: EgoState { pose: Pose { x_m: 5.0, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: 2.0, yaw_rate_rads: 0.0, stamp_ms: 0 },
+        goal: Goal { target: Pose { x_m: 40.0, y_m: 0.0, heading_rad: 0.0 } },
+        map: &corr,
+        objects: &[],
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+        request_overtake: false,
+        request_pull_over: false,
+        lane_graph: None,
+    };
+    let plan = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::TurnAt { direction: TurnDirection::Left }, &input);
+    assert_eq!(plan.kind, ProposalKind::SafeStop, "no graph → fail-closed HOLD");
+}

--- a/crates/kirra-planner/tests/overtake_oncoming.rs
+++ b/crates/kirra-planner/tests/overtake_oncoming.rs
@@ -99,6 +99,7 @@ fn plan_and_check(
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
@@ -264,6 +265,7 @@ fn overtake_world<'a>(
         target_speed_mps: None,
         request_overtake: false, // the MickIntent::Overtake grounding flips this on
         request_pull_over: false,
+        lane_graph: None,
     }
 }
 
@@ -353,6 +355,7 @@ fn a_stopped_school_bus_is_never_overtaken_and_the_ego_holds_behind_it() {
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);

--- a/crates/kirra-planner/tests/pull_over.rs
+++ b/crates/kirra-planner/tests/pull_over.rs
@@ -84,6 +84,7 @@ fn world<'a>(
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over,
+        lane_graph: None,
     }
 }
 

--- a/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
+++ b/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
@@ -102,6 +102,7 @@ fn run_stack(
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
@@ -200,6 +201,7 @@ fn route_around_in_corridor_object_admits() {
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);

--- a/crates/kirra-planner/tests/turn_at_junction.rs
+++ b/crates/kirra-planner/tests/turn_at_junction.rs
@@ -98,6 +98,7 @@ fn plan_turn(r: f64, half: f64) -> (kirra_planner::PlanOutput, TrajectoryVerdict
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     };
     let mut occy = GeometricPlanner::default();
     let plan = occy.plan(&input);

--- a/crates/kirra-planner/tests/unmarked_road_keep_right.rs
+++ b/crates/kirra-planner/tests/unmarked_road_keep_right.rs
@@ -45,6 +45,7 @@ fn drive(map: &dyn CorridorSource) -> (f64, TrajectoryVerdict) {
         target_speed_mps: None,
         request_overtake: false,
         request_pull_over: false,
+        lane_graph: None,
     };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);


### PR DESCRIPTION
## What

Closes the **TurnAt vertical slice**: Mick (the LLM chauffeur brain) can now choose to take a junction branch, grounded against the lane graph and bounded by KIRRA. Builds directly on #526's `route_corridor` primitive.

## The seam

A new **`PlanInput.lane_graph: Option<&LaneGraph>`** field — the established optional-knob pattern (`request_overtake` / `request_pull_over`); `None` = byte-for-byte prior behavior, every literal site updated. No grounding-fn signatures change.

The safety shape is preserved: the brain still only authors a **direction**; grounding does *all* the routing; KIRRA bounds the resulting corridor exactly as proven in #526.

## Changes

- **`MickIntent::TurnAt { direction: TurnDirection(Left|Right|Straight) }`**.
- **Grounding** (`plan_for_intent`): resolve ego lane from pose → pick the successor turning that way (**successor-by-heading**, ±45° band, deterministic by id) → route through the branch + its forward successors → materialize `route_corridor` → follow it. **Fail-closed at every step** (no graph / ego off-map / no such branch / unroutable / degenerate corridor → HOLD). A too-tight turn is refused by KIRRA (per #526).
- **`WorldContext.available_turns`** — the turn branches that actually exist at the next junction, derived with the *same* resolution grounding uses, so the brain only picks `turn_at` where it can ground.
- **LLM surface**: `turn_at` tag + `direction` enum in `intent_schema` (so #524's constrained decoding covers it) + `from_llm_json` arm (unknown / missing direction fails closed) + prompt form & example.
- **`mick_capture`**: `turn_direction` field on `MickDecisionRecord` (so #525's eval log scores turns).

## Tests

- `tests/mick_turn_at.rs`: left grounds through the junction and **KIRRA admits**; right picks the *other* branch (direction selection, not just "a branch exists"); a turn with **no such branch** and a turn with **no graph** both fail closed to HOLD.
- `mick.rs` unit tests: JSON parse per direction + fail-closed on unknown/missing; `available_turns` derivation (and empty without a graph).
- Updated schema-coverage and capture per-variant tests.

kirra-planner 99 lib + 4 turn integration, kirra-map 38, kirra-mick green; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Note on the LLM path

As with #524, the model's actual `turn_at` selection needs a live Ollama (the `live_*` test is `#[ignore]`). CI covers grounding, fail-closed behavior, the schema↔parser equivalence, and the junction resolution — not a real model's choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_