### PR TITLE
Derive junction stop / yield signs from the map into the loop

### DIFF
--- a/crates/kirra-map/src/lanelet2.rs
+++ b/crates/kirra-map/src/lanelet2.rs
@@ -140,6 +140,9 @@ pub fn parse_lanelet2_osm(xml: &str) -> Result<LaneGraph, Lanelet2ParseError> {
             right_line: ways[&ll.right].line,
             heading_rad,
             edges: connectivity(ll, &raw_lanelets, &ways),
+            // Regulatory controls (stop / yield signs) are a separate Lanelet2
+            // regulatory-element parse — not wired from the .osm yet; None for now.
+            control: None,
         });
     }
 

--- a/crates/kirra-map/src/lanemap.rs
+++ b/crates/kirra-map/src/lanemap.rs
@@ -64,6 +64,19 @@ pub enum LaneEdge {
     RightNeighbor { to: u64 },
 }
 
+/// A regulatory control the ego faces at the **end** of a lane — the static sign at the
+/// junction approach, the stop line being the lane's terminus. (A Lanelet2 `traffic_sign` /
+/// `right_of_way` regulatory element.) Dynamic signals — a traffic light's red/green state —
+/// are deliberately NOT modeled here: they need a live perception / V2X state source, a
+/// tracked follow-up. Maps to a [`crate::behavior::TrafficControl`] at the loop boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LaneControl {
+    /// STOP sign (MUTCD R1-1): full stop at the line, then proceed.
+    Stop,
+    /// YIELD / give-way (R1-2): slow, prepared to stop.
+    Yield,
+}
+
 /// One lane: a centerline polyline, a typed boundary on each side, and its
 /// connectivity. The boundary `LineType`s carry the crossing rules
 /// ([`LaneBoundary::may_cross`]) that gate Occy's lateral maneuvers; the
@@ -93,6 +106,11 @@ pub struct Lane {
     pub heading_rad: f64,
     /// Connectivity (successors + lateral neighbors).
     pub edges: Vec<LaneEdge>,
+    /// Optional regulatory control the ego faces at this lane's END (its junction
+    /// approach) — a STOP / YIELD sign whose stop line is the lane terminus. `None` = no
+    /// control (the common open lane). Derived into a [`crate::behavior::TrafficControl`]
+    /// at the loop boundary; a too-far / behind control is a no-op.
+    pub control: Option<LaneControl>,
 }
 
 impl Lane {
@@ -120,6 +138,7 @@ impl Lane {
             right_line,
             heading_rad: 0.0, // forward (+X) by default; oncoming lanes set π
             edges: Vec::new(),
+            control: None,
         }
     }
 
@@ -128,6 +147,21 @@ impl Lane {
     pub fn with_edge(mut self, edge: LaneEdge) -> Self {
         self.edges.push(edge);
         self
+    }
+
+    /// Builder: set the regulatory control the ego faces at this lane's end.
+    #[must_use]
+    pub fn with_control(mut self, control: LaneControl) -> Self {
+        self.control = Some(control);
+        self
+    }
+
+    /// World-frame x of this lane's terminus along travel — where a junction control's stop
+    /// line sits (the last centerline vertex). Straight-approach assumption, matching the
+    /// behavioral layer's longitudinal (ego-frame-x) stop-line model.
+    #[must_use]
+    pub fn stop_line_x(&self) -> f64 {
+        self.centerline.last().map_or(0.0, |p| p.x_m)
     }
 
     /// Builder: set the lane's travel direction (world heading, radians). Use `π`
@@ -1065,7 +1099,7 @@ mod tests {
             right_line: LineType::Solid,
             heading_rad: std::f64::consts::FRAC_PI_4, // mean of the turn; not load-bearing here
             edges: vec![LaneEdge::Successor { to: 3 }],
-        };
+            control: None,        };
         let exit = Lane {
             id: 3,
             centerline: vec![Point { x_m: 30.0, y_m: 10.0 }, Point { x_m: 30.0, y_m: 30.0 }],
@@ -1074,6 +1108,7 @@ mod tests {
             right_line: LineType::Solid,
             heading_rad: std::f64::consts::FRAC_PI_2, // north
             edges: Vec::new(),
+            control: None,
         };
         let g = LaneGraph::new()
             .with_lane(

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -54,7 +54,9 @@ pub use behavior::{
 };
 
 pub mod lanemap;
-pub use lanemap::{JunctionContext, Lane, LaneCorridor, LaneEdge, LaneGraph, MAX_ROUTE_LANES};
+pub use lanemap::{
+    JunctionContext, Lane, LaneControl, LaneCorridor, LaneEdge, LaneGraph, MAX_ROUTE_LANES,
+};
 
 pub mod lanelet2;
 pub use lanelet2::{parse_lanelet2_osm, Lanelet2ParseError};

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -16,7 +16,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{FleetPosture, Goal, LaneGraph, PlanInput, PlanOutput, Planner, Pose, MAX_ROUTE_LANES};
+use crate::behavior::TrafficControl;
+use crate::{
+    FleetPosture, Goal, LaneControl, LaneGraph, PlanInput, PlanOutput, Planner, Pose,
+    MAX_ROUTE_LANES,
+};
 use kirra_core::corridor::Point as MapPoint;
 
 /// Which way a [`MickIntent::TurnAt`] heads at the next junction, relative to the ego
@@ -222,18 +226,31 @@ pub fn plan_for_intent(
     intent: &MickIntent,
     world: &PlanInput,
 ) -> PlanOutput {
-    // Junction wiring: when a lane graph is supplied and the integrator did NOT hand a cede
-    // list, derive `cedes_to_ego_ids` from the map's right-of-way (`junction_context`), so
-    // the ego asserts map-granted priority over yielding-lane agents instead of waiting for
-    // the integrator to supply the list. Fail-safe — no graph / ego off-map → empty → the
-    // ego yields to everyone; an explicit list is never overridden; KIRRA still backstops
-    // every crossing agent. (`must_yield_to` needs no wiring here: the planner already
-    // yields to every non-cede agent; that set is the parko-boundary input.)
-    let derived_cedes: Vec<u64>;
+    // Junction wiring: when a lane graph is supplied and the integrator did NOT hand the
+    // corresponding list, derive it from the map — `cedes_to_ego_ids` from the right-of-way
+    // (`junction_context`, so the ego asserts map-granted priority over yielding-lane agents)
+    // and `controls` from the approach lane's STOP / YIELD sign (`derive_controls`, so the
+    // ego stops/slows at the junction). Fail-safe — no graph / ego off-map → empty (yield to
+    // all, no extra stop); an integrator-supplied list is never overridden; KIRRA still
+    // backstops every agent and bounds the motion. (`must_yield_to` needs no wiring: the
+    // planner already yields to every non-cede agent; that set is the parko-boundary input.)
+    let derived_cedes: Vec<u64> = if world.lane_graph.is_some() && world.cedes_to_ego_ids.is_empty() {
+        derive_cedes_to_ego(world)
+    } else {
+        Vec::new()
+    };
+    let derived_controls: Vec<TrafficControl> = if world.lane_graph.is_some() && world.controls.is_empty() {
+        derive_controls(world)
+    } else {
+        Vec::new()
+    };
     let enriched: PlanInput;
-    let world: &PlanInput = if world.lane_graph.is_some() && world.cedes_to_ego_ids.is_empty() {
-        derived_cedes = derive_cedes_to_ego(world);
-        enriched = PlanInput { cedes_to_ego_ids: &derived_cedes, ..world.clone() };
+    let world: &PlanInput = if !derived_cedes.is_empty() || !derived_controls.is_empty() {
+        enriched = PlanInput {
+            cedes_to_ego_ids: if derived_cedes.is_empty() { world.cedes_to_ego_ids } else { &derived_cedes },
+            controls: if derived_controls.is_empty() { world.controls } else { &derived_controls },
+            ..world.clone()
+        };
         &enriched
     } else {
         world
@@ -322,6 +339,47 @@ fn derive_cedes_to_ego(world: &PlanInput<'_>) -> Vec<u64> {
         }
         None => Vec::new(),
     }
+}
+
+/// Speed (m/s) below which the ego counts as having stopped for a STOP-sign full stop.
+const STOP_SATISFIED_SPEED_MPS: f64 = 0.3;
+/// Distance (m) before the stop line within which a near-stopped ego is `satisfied`.
+const STOP_SATISFIED_DIST_M: f64 = 2.0;
+
+/// Derive the regulatory [`TrafficControl`]s the ego currently faces from the lane graph:
+/// the STOP / YIELD sign at the end of the ego's lane (its junction approach), mapped to the
+/// behavioral-layer control. Empty if there is no graph, the ego is off the mapped road, or
+/// its lane carries no control (fail-safe → nothing beyond what objects/posture impose).
+///
+/// STOP is **stateless stop-and-go**: `satisfied` once the ego is essentially stopped just
+/// before the line (`< STOP_SATISFIED_SPEED_MPS` within `STOP_SATISFIED_DIST_M`), so it
+/// proceeds. This approximates the legal full-stop dwell without loop memory — in the closed
+/// loop the ego decelerates to the line then creeps across; a precisely-latched full-stop
+/// dwell is a tracked follow-up. KIRRA bounds the actual motion regardless. YIELD is exact
+/// (a speed cap at the line).
+fn derive_controls(world: &PlanInput<'_>) -> Vec<TrafficControl> {
+    let Some(graph) = world.lane_graph else {
+        return Vec::new();
+    };
+    let ego = world.ego.pose;
+    let Some(lane_id) = graph.lane_at(MapPoint { x_m: ego.x_m, y_m: ego.y_m }) else {
+        return Vec::new();
+    };
+    let Some(control) = graph.lane(lane_id).and_then(|l| l.control.map(|c| (c, l.stop_line_x()))) else {
+        return Vec::new();
+    };
+    let (control, line_x) = control;
+    let tc = match control {
+        LaneControl::Yield => TrafficControl::YieldSign { line_x_m: line_x },
+        LaneControl::Stop => {
+            let dist = line_x - ego.x_m;
+            let satisfied = world.ego.linear_x_mps.abs() < STOP_SATISFIED_SPEED_MPS
+                && dist > 0.0
+                && dist < STOP_SATISFIED_DIST_M;
+            TrafficControl::StopSign { stop_line_x_m: line_x, satisfied }
+        }
+    };
+    vec![tc]
 }
 
 /// Pick the ego lane's successor that turns `direction` (successor-by-heading): the matching
@@ -1139,6 +1197,96 @@ mod tests {
         let mut rec = CedeRecorder { cedes: vec![1] };
         let _ = plan_for_intent(&mut rec, &MickIntent::GoTo { x_m: 25.0, y_m: 0.0 }, &w);
         assert!(rec.cedes.is_empty(), "no graph → empty cede list (fail-safe: yield to all)");
+    }
+
+    // ----- junction STOP / YIELD signs wired into the loop -----
+
+    /// A planner that records the `controls` it was grounded with.
+    struct ControlRecorder {
+        controls: Vec<TrafficControl>,
+    }
+    impl Planner for ControlRecorder {
+        fn plan(&mut self, input: &PlanInput<'_>) -> PlanOutput {
+            self.controls = input.controls.to_vec();
+            PlanOutput::safe_stop(input.ego.pose)
+        }
+    }
+
+    /// A single approach lane (0,0)→(18,0) carrying control `c` at its terminus (x=18).
+    fn lane_with_control(c: LaneControl) -> crate::LaneGraph {
+        crate::LaneGraph::new().with_lane(
+            crate::Lane::straight(1, 0.0, 0.0, 18.0, 2.0, crate::LineType::Solid, crate::LineType::Solid)
+                .with_control(c),
+        )
+    }
+
+    fn derived_controls_for<'a>(g: &'a crate::LaneGraph, ego: EgoState, corr: &'a MockCorridorSource) -> Vec<TrafficControl> {
+        let w = PlanInput { ego, map: corr, lane_graph: Some(g), ..world(corr, &[], &[]) };
+        let mut rec = ControlRecorder { controls: Vec::new() };
+        let _ = plan_for_intent(&mut rec, &MickIntent::GoTo { x_m: 50.0, y_m: 0.0 }, &w);
+        rec.controls
+    }
+
+    fn ego_at(x: f64, v: f64) -> EgoState {
+        EgoState { pose: Pose { x_m: x, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: v, yaw_rate_rads: 0.0, stamp_ms: 0 }
+    }
+
+    #[test]
+    fn a_stop_sign_derives_an_unsatisfied_stop_while_approaching() {
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        // Approaching at speed, well before the line → not satisfied (stop imposed).
+        let controls = derived_controls_for(&lane_with_control(LaneControl::Stop), ego_at(5.0, 2.0), &corr);
+        assert_eq!(controls, vec![TrafficControl::StopSign { stop_line_x_m: 18.0, satisfied: false }]);
+    }
+
+    #[test]
+    fn a_stop_sign_is_satisfied_once_stopped_at_the_line() {
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        // Essentially stopped just before the line → satisfied (proceed) — the stateless go.
+        let controls = derived_controls_for(&lane_with_control(LaneControl::Stop), ego_at(17.0, 0.0), &corr);
+        assert_eq!(controls, vec![TrafficControl::StopSign { stop_line_x_m: 18.0, satisfied: true }]);
+    }
+
+    #[test]
+    fn a_yield_sign_derives_a_yield_control() {
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let controls = derived_controls_for(&lane_with_control(LaneControl::Yield), ego_at(5.0, 2.0), &corr);
+        assert_eq!(controls, vec![TrafficControl::YieldSign { line_x_m: 18.0 }]);
+    }
+
+    #[test]
+    fn no_control_derives_nothing_and_explicit_controls_stand() {
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        // A lane with no control → nothing derived.
+        let plain = crate::LaneGraph::new()
+            .with_lane(crate::Lane::straight(1, 0.0, 0.0, 18.0, 2.0, crate::LineType::Solid, crate::LineType::Solid));
+        assert!(derived_controls_for(&plain, ego_at(5.0, 2.0), &corr).is_empty());
+
+        // An explicit integrator control list is never overridden by the map.
+        let g = lane_with_control(LaneControl::Stop);
+        let explicit = [TrafficControl::YieldSign { line_x_m: 9.0 }];
+        let w = PlanInput { ego: ego_at(5.0, 2.0), map: &corr, lane_graph: Some(&g), controls: &explicit, ..world(&corr, &[], &[]) };
+        let mut rec = ControlRecorder { controls: Vec::new() };
+        let _ = plan_for_intent(&mut rec, &MickIntent::GoTo { x_m: 50.0, y_m: 0.0 }, &w);
+        assert_eq!(rec.controls, vec![TrafficControl::YieldSign { line_x_m: 9.0 }], "explicit controls stand");
+    }
+
+    #[test]
+    fn the_planner_stops_at_a_map_derived_stop_line() {
+        // End to end: the derived StopSign makes Occy decelerate to a stop at the line (x=18)
+        // and not pass it — the junction stop is real, not just recorded.
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let g = lane_with_control(LaneControl::Stop);
+        let w = PlanInput { ego: ego_at(5.0, 2.0), map: &corr, lane_graph: Some(&g), ..world(&corr, &[], &[]) };
+        let plan = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::GoTo { x_m: 50.0, y_m: 0.0 }, &w);
+
+        let max_x = plan.trajectory.iter().map(|t| t.pose.x_m).fold(f64::MIN, f64::max);
+        assert!(max_x <= 18.5, "the plan holds at/before the stop line x=18, got max_x {max_x}");
+        assert!(
+            plan.trajectory.last().unwrap().velocity_mps < 0.5,
+            "and comes to a stop at the line (final v {})",
+            plan.trajectory.last().unwrap().velocity_mps
+        );
     }
 
     // ----- the dual-rate driver: System-2 intent rate vs System-1 grounding rate -----

--- a/crates/kirra-planner/tests/mick_turn_at.rs
+++ b/crates/kirra-planner/tests/mick_turn_at.rs
@@ -33,7 +33,7 @@ fn arc(cx: f64, cy: f64, r: f64, start: f64, sweep: f64, n: usize) -> Vec<Point>
 
 fn lane(id: u64, centerline: Vec<Point>, heading_rad: f64, succ: Option<u64>) -> Lane {
     let edges = succ.map(|s| vec![LaneEdge::Successor { to: s }]).unwrap_or_default();
-    Lane { id, centerline, half_width_m: HALF, left_line: LineType::Solid, right_line: LineType::Solid, heading_rad, edges }
+    Lane { id, centerline, half_width_m: HALF, left_line: LineType::Solid, right_line: LineType::Solid, heading_rad, edges, control: None }
 }
 
 /// A junction with a LEFT and a RIGHT branch off a straight approach (no straight branch):

--- a/crates/kirra-planner/tests/turn_at_junction.rs
+++ b/crates/kirra-planner/tests/turn_at_junction.rs
@@ -47,7 +47,7 @@ fn left_turn(r: f64, half: f64) -> LaneGraph {
         right_line: line,
         heading_rad: std::f64::consts::FRAC_PI_4,
         edges: vec![LaneEdge::Successor { to: 3 }],
-    };
+        control: None,    };
     let exit = Lane {
         id: 3,
         centerline: vec![Point { x_m: 20.0 + r, y_m: r }, Point { x_m: 20.0 + r, y_m: r + 20.0 }],
@@ -56,6 +56,7 @@ fn left_turn(r: f64, half: f64) -> LaneGraph {
         right_line: line,
         heading_rad: std::f64::consts::FRAC_PI_2,
         edges: Vec::new(),
+        control: None,
     };
     LaneGraph::new()
         .with_lane(


### PR DESCRIPTION
## What

Completes "drive an intersection." #528 wired the map's **right-of-way** (who yields); this wires the map's regulatory **STOP / YIELD signs** (where to stop). Together they compose into a real intersection maneuver: **stop at the line → yield to priority traffic → proceed.**

The planner already obeys `TrafficControl` via `evaluate_controls` (a hard stop line, even the amber dilemma-zone rule), but `controls` was integrator-supplied and the `LaneGraph` carried no sign info. That was the gap.

## Changes

- **kirra-map**: `LaneControl { Stop, Yield }` + an optional `Lane.control` at the lane's end (the stop line = lane terminus, `Lane::stop_line_x`) + a `with_control` builder. The Lanelet2 regulatory-element parse is a noted follow-up (`control: None` from the parser for now).
- **kirra-planner**: `plan_for_intent` derives `controls` from the ego lane's sign when a `lane_graph` is present and the integrator did **not** supply controls — the **same enrichment site and fail-safe rules** as #528's `cedes_to_ego`: no graph / off-map / no sign → empty; an explicit list is never overridden; KIRRA bounds the motion.

## The one honest simplification

- **YIELD** is exact (a speed cap at the line).
- **STOP** is **stateless stop-and-go**: `satisfied` once the ego is essentially stopped just before the line, so it proceeds — an approximation of the legal full-stop *dwell* (in the closed loop the ego decelerates to the line then creeps across the last ~2 m). A precisely-latched full-stop dwell needs loop memory and is a tracked follow-up.
- **TrafficLight** is deliberately out of scope — a signal's red/green state needs a live perception / V2X pipeline, not the static map.

## Tests

`mick.rs`: stop → unsatisfied-while-approaching; stop → satisfied-once-stopped; yield → speed cap; no-sign → nothing derived + explicit-controls-stand; and an **end-to-end** "the planner decelerates to a stop at the map-derived stop line and doesn't pass it." All `Lane` construction sites updated with the new field.

kirra-planner 107 lib + kirra-map 38 + kirra-mick green; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Net effect

The lane graph now drives the full intersection: **turns** (#526/#527), **yielding** (#528), and **stop/yield signs** (this PR) — all fail-closed and KIRRA-bounded, with the brain only ever naming a direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_