### PR TITLE
Widen a TurnAt to its full multi-lane width (route_drivable)

### DIFF
--- a/crates/kirra-map/src/lanemap.rs
+++ b/crates/kirra-map/src/lanemap.rs
@@ -605,6 +605,34 @@ impl LaneGraph {
         (left.len() >= 2 && right.len() >= 2).then_some(LaneCorridor { left, right, confidence, age_ms })
     }
 
+    /// Materialize a **wide** route corridor — the route's lanes PLUS their direct lateral
+    /// neighbors — as the *drivable area* a turn may borrow (the longitudinal counterpart to
+    /// [`corridor_over`], and the wide sibling of [`route_corridor`]). Per route lane the
+    /// outer envelope takes the LEFT edge of its left neighbor (if any, else its own) and the
+    /// RIGHT edge of its right neighbor (if any, else its own); the per-lane outer boundaries
+    /// are concatenated longitudinally (seam-deduped) so the area follows the route at full
+    /// width through any turns.
+    ///
+    /// This is what lets the planner route-around an obstacle or lane-change ACROSS a
+    /// crossable divider *within* a turn: [`route_corridor`] is the reference path (`map`);
+    /// this is the `drivable` width; the typed lines come from [`boundaries_relative_to`]
+    /// over the same lane + neighbors. Returns `None` if `route` is empty, any id is unknown,
+    /// or the result degenerates. **Scope:** one level of lateral neighbor each side (covers
+    /// a two-wide turn); the same smooth-arc geometry caveat as `route_corridor` applies.
+    #[must_use]
+    pub fn route_drivable(&self, route: &[u64], confidence: f32, age_ms: u64) -> Option<LaneCorridor> {
+        let lanes = self.resolve(route)?;
+        let mut left: Vec<Point> = Vec::new();
+        let mut right: Vec<Point> = Vec::new();
+        for lane in lanes {
+            let left_lane = lane.left_neighbor().and_then(|n| self.lanes.get(&n)).unwrap_or(lane);
+            let right_lane = lane.right_neighbor().and_then(|n| self.lanes.get(&n)).unwrap_or(lane);
+            concat_dedup(&mut left, &offset_polyline(&left_lane.centerline, left_lane.half_width_m));
+            concat_dedup(&mut right, &offset_polyline(&right_lane.centerline, -right_lane.half_width_m));
+        }
+        (left.len() >= 2 && right.len() >= 2).then_some(LaneCorridor { left, right, confidence, age_ms })
+    }
+
     /// Derive the typed lane boundaries across a span of lanes, expressed as
     /// lateral offsets **relative to `ego_lane`'s centerline** (the frame Occy's
     /// `lane_boundaries` input uses). Boundaries shared between adjacent lanes are
@@ -1137,6 +1165,32 @@ mod tests {
             .with_lane(Lane::straight(1, 0.0, 0.0, 20.0, 2.0, LineType::Solid, LineType::Solid));
         assert!(g.route_corridor(&[], 0.95, 10).is_none(), "empty route → None");
         assert!(g.route_corridor(&[1, 99], 0.95, 10).is_none(), "unknown id → None");
+    }
+
+    #[test]
+    fn route_drivable_widens_to_include_lateral_neighbors() {
+        // Lane 1 (y=0, half 1.75) with a LEFT neighbor lane 2 (y=3.5). A route over lane 1
+        // alone yields a drivable area spanning BOTH lanes (the borrowable turn width),
+        // where route_corridor stays single-lane.
+        let g = LaneGraph::new()
+            .with_lane(
+                Lane::straight(1, 0.0, 0.0, 30.0, 1.75, LineType::Broken, LineType::Solid)
+                    .with_edge(LaneEdge::LeftNeighbor { to: 2 }),
+            )
+            .with_lane(
+                Lane::straight(2, 3.5, 0.0, 30.0, 1.75, LineType::Solid, LineType::Broken)
+                    .with_edge(LaneEdge::RightNeighbor { to: 1 }),
+            );
+
+        let d = g.route_drivable(&[1], 0.95, 10).expect("widen");
+        assert!((d.left_boundary()[0].y_m - 5.25).abs() < 1e-9, "left widened to the neighbor edge (3.5+1.75), got {}", d.left_boundary()[0].y_m);
+        assert!((d.right_boundary()[0].y_m + 1.75).abs() < 1e-9, "right stays at lane 1's edge");
+
+        let c = g.route_corridor(&[1], 0.95, 10).expect("narrow");
+        assert!((c.left_boundary()[0].y_m - 1.75).abs() < 1e-9, "route_corridor stays single-lane (+1.75)");
+
+        assert!(g.route_drivable(&[], 0.95, 10).is_none(), "empty → None");
+        assert!(g.route_drivable(&[1, 99], 0.95, 10).is_none(), "unknown id → None");
     }
 
     // ----- Right-of-way: cede vs non-yield, consistent from one source -----

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -18,10 +18,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::behavior::TrafficControl;
 use crate::{
-    FleetPosture, Goal, LaneControl, LaneGraph, PlanInput, PlanOutput, Planner, Pose,
+    FleetPosture, Goal, Lane, LaneControl, LaneGraph, PlanInput, PlanOutput, Planner, Pose,
     MAX_ROUTE_LANES,
 };
-use kirra_core::corridor::Point as MapPoint;
+use kirra_core::corridor::{CorridorSource, Point as MapPoint};
 
 /// Which way a [`MickIntent::TurnAt`] heads at the next junction, relative to the ego
 /// lane's travel direction. Resolved to a successor lane by heading at grounding time.
@@ -315,7 +315,34 @@ pub fn plan_for_intent(
             else {
                 return PlanOutput::safe_stop(world.ego.pose);
             };
-            planner.plan(&PlanInput { map: &corridor, ..world.clone() })
+            // Widen the turn: the route's full width (route + lateral neighbors) is the
+            // `drivable` area a route-around / lane-change may borrow WITHIN the turn, and the
+            // typed lines over the ego lane + its neighbors gate that lateral move. Only when
+            // the integrator didn't supply them; `None`/empty → the single-lane turn-follow.
+            let drivable = if world.drivable.is_none() {
+                graph.route_drivable(&route, ROUTE_CORRIDOR_CONFIDENCE, ROUTE_CORRIDOR_AGE_MS)
+            } else {
+                None
+            };
+            let lane = graph.lane(ego_lane);
+            let neighbors: Vec<u64> = std::iter::once(ego_lane)
+                .chain(lane.and_then(Lane::left_neighbor))
+                .chain(lane.and_then(Lane::right_neighbor))
+                .collect();
+            let boundaries = if world.lane_boundaries.is_empty() {
+                graph.boundaries_relative_to(ego_lane, &neighbors)
+            } else {
+                None
+            };
+            planner.plan(&PlanInput {
+                map: &corridor,
+                drivable: drivable
+                    .as_ref()
+                    .map(|d| d as &dyn CorridorSource)
+                    .or(world.drivable),
+                lane_boundaries: boundaries.as_deref().unwrap_or(world.lane_boundaries),
+                ..world.clone()
+            })
         }
     }
 }

--- a/crates/kirra-planner/tests/turn_multilane.rs
+++ b/crates/kirra-planner/tests/turn_multilane.rs
@@ -1,0 +1,153 @@
+//! End-to-end: **a multi-lane turn route — route-around within the turn → Occy → KIRRA**.
+//!
+//! The payoff of the widened TurnAt grounding (#526/#527 gave a single-lane turn; this adds
+//! the *width*). On a turn route whose lanes have lateral neighbors, grounding sets `map` =
+//! `route_corridor` (the reference path through the turn), `drivable` = `route_drivable`
+//! (the route + its neighbors — the borrowable width), and `lane_boundaries` =
+//! `boundaries_relative_to(ego_lane, lane + neighbors)` (the lines). So the planner can
+//! route-around an obstacle on the route by borrowing the neighbor lane across a *crossable*
+//! divider, and KIRRA bounds the result — the mid-route maneuver a single-lane turn corridor
+//! could not express.
+//!
+//! The route-around here is on the (straight) approach segment of the turn route, so the
+//! geometry is robust; the mechanism (borrow the neighbor width along the route) is the same
+//! anywhere on the route.
+
+use kirra_planner::{
+    plan_for_intent, EgoState, FleetPosture, GeometricPlanner, Goal, Lane, LaneEdge, LaneGraph,
+    LineType, MickIntent, PerceivedObject, PlanInput, PlanOutput, Planner, Pose, TrajectoryVerdict,
+    TurnDirection,
+};
+use kirra_ros2_adapter::corridor::{CorridorSource, Point};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+/// A LEFT-turn junction whose approach is a WIDE two-lane carriageway with a crossable
+/// (Broken) divider — wide and long enough for the planner's overtake-based route-around to
+/// fit (its ≥4.5 m RSS clearance + ~13 m ramp; a single 3.5 m neighbor on a short approach
+/// is too tight — the documented narrow-road bound). A lighter lane-change route-around that
+/// would use the width on tight turns too is a tracked follow-up.
+///   1  ego approach (0,0)→(APR,0), y=0, LeftNeighbor 2, Successor → 3 (left arc)
+///   2  wide left neighbor (0,4.5)→(APR,4.5), half 2.75, RightNeighbor 1
+///   3  left-turn arc from (APR,0) up to (APR+R, R), heading +π/2, Successor → 5
+///   5  north exit
+const APR: f64 = 40.0;
+fn multilane_turn(r: f64) -> LaneGraph {
+    let arc: Vec<Point> = (0..=12)
+        .map(|i| {
+            let t = -std::f64::consts::FRAC_PI_2 + std::f64::consts::FRAC_PI_2 * (i as f64 / 12.0);
+            Point { x_m: APR + r * t.cos(), y_m: r + r * t.sin() }
+        })
+        .collect();
+    let turn = Lane {
+        id: 3,
+        centerline: arc,
+        half_width_m: 1.75,
+        left_line: LineType::Solid,
+        right_line: LineType::Solid,
+        heading_rad: std::f64::consts::FRAC_PI_2,
+        edges: vec![LaneEdge::Successor { to: 5 }],
+        control: None,
+    };
+    let exit = Lane {
+        id: 5,
+        centerline: vec![Point { x_m: APR + r, y_m: r }, Point { x_m: APR + r, y_m: r + 20.0 }],
+        half_width_m: 1.75,
+        left_line: LineType::Solid,
+        right_line: LineType::Solid,
+        heading_rad: std::f64::consts::FRAC_PI_2,
+        edges: Vec::new(),
+        control: None,
+    };
+    LaneGraph::new()
+        .with_lane(
+            // ego lane: Broken divider on the LEFT (to lane 2), Solid road edge on the right.
+            Lane::straight(1, 0.0, 0.0, APR, 1.75, LineType::Broken, LineType::Solid)
+                .with_edge(LaneEdge::LeftNeighbor { to: 2 })
+                .with_edge(LaneEdge::Successor { to: 3 }),
+        )
+        .with_lane(
+            // wide neighbor (half 2.75): its right edge (4.5−2.75=1.75) meets the ego lane's
+            // left edge → a clean Broken divider, and its left edge (7.25) gives the overtake
+            // room to fit the 4.5 m clearance + footprint.
+            Lane::straight(2, 4.5, 0.0, APR, 2.75, LineType::Solid, LineType::Broken)
+                .with_edge(LaneEdge::RightNeighbor { to: 1 }),
+        )
+        .with_lane(turn)
+        .with_lane(exit)
+}
+
+fn ego_world<'a>(g: &'a LaneGraph, map: &'a dyn CorridorSource, objects: &'a [PerceivedObject], goal: Pose) -> PlanInput<'a> {
+    PlanInput {
+        ego: EgoState { pose: Pose { x_m: 4.0, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: 3.0, yaw_rate_rads: 0.0, stamp_ms: 0 },
+        goal: Goal { target: goal },
+        map,
+        objects,
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+        request_overtake: false,
+        request_pull_over: false,
+        lane_graph: Some(g),
+    }
+}
+
+/// Records the drivable presence + boundary lines a grounding handed the planner.
+struct WidthRecorder {
+    drivable_present: bool,
+    boundaries: Vec<kirra_planner::LaneBoundary>,
+}
+impl Planner for WidthRecorder {
+    fn plan(&mut self, input: &PlanInput<'_>) -> PlanOutput {
+        self.drivable_present = input.drivable.is_some();
+        self.boundaries = input.lane_boundaries.to_vec();
+        PlanOutput::safe_stop(input.ego.pose)
+    }
+}
+
+#[test]
+fn turn_at_grounding_widens_the_drivable_and_supplies_the_divider_line() {
+    // The wiring: a TurnAt onto a route whose approach has a neighbor gets a wide drivable
+    // and the typed divider line — the inputs a within-turn route-around needs.
+    let g = multilane_turn(12.0);
+    let map = g.lane(1).unwrap().corridor(0.95, 0);
+    let goal = Pose { x_m: 52.0, y_m: 24.0, heading_rad: std::f64::consts::FRAC_PI_2 };
+    let w = ego_world(&g, &map, &[], goal);
+
+    let mut rec = WidthRecorder { drivable_present: false, boundaries: Vec::new() };
+    let _ = plan_for_intent(&mut rec, &MickIntent::TurnAt { direction: TurnDirection::Left }, &w);
+
+    assert!(rec.drivable_present, "TurnAt grounds with a widened drivable area");
+    assert!(
+        rec.boundaries.iter().any(|b| b.line == LineType::Broken && (b.y_m - 1.75).abs() < 1e-6),
+        "the crossable divider to the neighbor lane is supplied, got {:?}",
+        rec.boundaries
+    );
+}
+
+#[test]
+fn the_ego_routes_around_an_obstacle_by_borrowing_the_neighbor_lane_and_kirra_admits() {
+    // An obstacle blocks the ego's lane on the turn route's approach. With only a single-lane
+    // turn corridor the ego could merely stop short; with the widened drivable it borrows the
+    // neighbor lane (crossing the Broken divider), and KIRRA admits the pass.
+    let g = multilane_turn(12.0);
+    let map = g.lane(1).unwrap().corridor(0.95, 0);
+    let drivable = g.route_drivable(&g.route(1, 5).unwrap(), 0.95, 0).unwrap();
+    let stopped = [PerceivedObject { id: 1, pos: Point { x_m: 25.0, y_m: 0.0 }, velocity_mps: 0.0, heading_rad: 0.0, vel: Point { x_m: 0.0, y_m: 0.0 } }];
+    let goal = Pose { x_m: 52.0, y_m: 24.0, heading_rad: std::f64::consts::FRAC_PI_2 };
+    let w = ego_world(&g, &map, &stopped, goal);
+
+    let plan = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::TurnAt { direction: TurnDirection::Left }, &w);
+
+    let max_y = plan.trajectory.iter().map(|t| t.pose.y_m).fold(f64::MIN, f64::max);
+    assert!(max_y > 1.75, "the ego borrows the neighbor lane (crosses the +1.75 divider), got max_y {max_y}");
+
+    let verdict = validate_trajectory_slow(&plan.trajectory, &drivable, &stopped, &VehicleConfig::default_urban(), None, FleetPosture::Nominal);
+    assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp), "KIRRA admits the borrow-the-neighbor route-around, got {verdict:?}");
+}


### PR DESCRIPTION
## What

Adds the *width* to a junction turn so the planner can route-around / lane-change **within** the turn across a crossable divider — the genuinely useful half of the "typed route boundaries" follow-up (#526's note). #526/#527 gave a single-lane turn; this adds the borrowable neighbor width.

## Changes

- **kirra-map**: `LaneGraph::route_drivable(route)` — the route's lanes **plus their direct lateral neighbors** as one outer-envelope corridor (the wide sibling of `route_corridor`, the longitudinal counterpart to `corridor_over`). One neighbor level each side (a two-wide turn); same smooth-arc caveat as `route_corridor`.
- **kirra-planner**: `TurnAt` grounding now also sets `drivable = route_drivable` and `lane_boundaries = boundaries_relative_to(ego_lane, lane+neighbors)` (reusing the existing boundary derivation — so the "typed boundaries" half is free) when the integrator didn't supply them. `map` stays the single-lane `route_corridor` reference path. `None`/empty → the prior single-lane turn-follow.

## Honest finding (documented in the test)

The planner's **only** consumer of `drivable` is the **overtake** maneuver, which needs ≥4.5 m RSS clearance (#451) + a ~13 m ramp. A single 3.5 m neighbor on a short approach is **too tight** for it — the same narrow-road overtake bound. So a within-turn route-around only fits on a **wide + long** route today. The test demonstrates the mechanism on a wide carriageway where it genuinely admits, and the fixture documents the bound. A **lighter lane-change route-around** maneuver (lower clearance, shorter ramp) that would use this width on *tight* turns too is the natural follow-up — flagging it rather than over-claiming what this unlocks.

## Tests

- kirra-map: `route_drivable` widens to the neighbor edge (where `route_corridor` stays single-lane); fail-closed on empty/unknown.
- kirra-planner `turn_multilane.rs`: grounding supplies the wide `drivable` + the `Broken` divider line (Recorder); and an obstacle on the route is passed by **borrowing the neighbor lane**, KIRRA admitting the result.

kirra-planner + kirra-map + kirra-mick green; `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_