### PR TITLE
Add map-derived traffic lights (fail-closed to red)

### DIFF
--- a/crates/kirra-map/src/lanemap.rs
+++ b/crates/kirra-map/src/lanemap.rs
@@ -64,17 +64,21 @@ pub enum LaneEdge {
     RightNeighbor { to: u64 },
 }
 
-/// A regulatory control the ego faces at the **end** of a lane — the static sign at the
-/// junction approach, the stop line being the lane's terminus. (A Lanelet2 `traffic_sign` /
-/// `right_of_way` regulatory element.) Dynamic signals — a traffic light's red/green state —
-/// are deliberately NOT modeled here: they need a live perception / V2X state source, a
-/// tracked follow-up. Maps to a [`crate::behavior::TrafficControl`] at the loop boundary.
+/// A regulatory control the ego faces at the **end** of a lane — at the junction approach,
+/// the stop line being the lane's terminus (a Lanelet2 `traffic_sign` / `traffic_light`
+/// regulatory element). The static signs (`Stop` / `Yield`) carry all they need; a
+/// `TrafficLight` carries only its **presence** — the live red/green/amber state is dynamic
+/// (perception / V2X) and supplied at the loop boundary, defaulting fail-closed to *red*
+/// (stop) when unknown. Mapped to a behavioral-layer traffic control at that boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LaneControl {
     /// STOP sign (MUTCD R1-1): full stop at the line, then proceed.
     Stop,
     /// YIELD / give-way (R1-2): slow, prepared to stop.
     Yield,
+    /// Traffic LIGHT at the lane's stop line. Presence only — the live signal state is
+    /// supplied separately each tick (unknown → red / stop, fail-closed).
+    TrafficLight,
 }
 
 /// One lane: a centerline polyline, a typed boundary on each side, and its

--- a/crates/kirra-mick/examples/mick_chauffeur.rs
+++ b/crates/kirra-mick/examples/mick_chauffeur.rs
@@ -48,7 +48,7 @@ fn world<'a>(ego: EgoState, map: &'a dyn CorridorSource, objects: &'a [Perceived
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    }
+        signal_states: &[],    }
 }
 
 fn verdict(plan: &PlanOutput, corr: &dyn CorridorSource, objs: &[PerceivedObject]) -> TrajectoryVerdict {

--- a/crates/kirra-planner/examples/doer_bound_fixture.rs
+++ b/crates/kirra-planner/examples/doer_bound_fixture.rs
@@ -61,7 +61,7 @@ fn world<'a>(map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> Pla
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    }
+        signal_states: &[],    }
 }
 
 fn verdict(out: &PlanOutput, corr: &dyn CorridorSource, objs: &[PerceivedObject]) -> TrajectoryVerdict {

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -263,6 +263,13 @@ pub struct PlanInput<'a> {
     /// following / containment is unchanged; this only supplies the route corridor a turn
     /// needs, which KIRRA bounds exactly as it bounds any corridor.
     pub lane_graph: Option<&'a LaneGraph>,
+    /// **Live traffic-signal states** by governed lane id `(lane_id, state)` — the dynamic
+    /// input a `LaneControl::TrafficLight` needs (perception / V2X). When the ego's lane
+    /// carries a traffic light, its state is looked up here; **absent → red (stop),
+    /// fail-closed**. Empty = no signal info (a light with no state then reads red). Ignored
+    /// for lanes with no light. Only consulted when `lane_graph` is set and the integrator
+    /// did not hand-supply `controls`.
+    pub signal_states: &'a [(u64, behavior::SignalState)],
 }
 
 /// Intent label on a proposal.
@@ -1656,7 +1663,7 @@ mod tests {
             request_overtake: false,
             request_pull_over: false,
             lane_graph: None,
-        }
+            signal_states: &[],        }
     }
 
     #[test]
@@ -1733,7 +1740,7 @@ mod tests {
             request_overtake: false,
             request_pull_over: false,
             lane_graph: None,
-        }
+            signal_states: &[],        }
     }
 
     #[test]
@@ -1882,7 +1889,7 @@ mod tests {
             request_overtake: false,
             request_pull_over: false,
             lane_graph: None,
-        }
+            signal_states: &[],        }
     }
 
     /// Corridor that turns ~22° at x=20 and continues well past it; ego starts
@@ -2255,7 +2262,7 @@ mod tests {
             request_overtake: false,
             request_pull_over: false,
             lane_graph: None,
-        }
+            signal_states: &[],        }
     }
 
     #[test]
@@ -2506,7 +2513,7 @@ mod tests {
             request_overtake: false,
             request_pull_over: false,
             lane_graph: None,
-        }
+            signal_states: &[],        }
     }
 
     #[test]
@@ -2620,7 +2627,7 @@ mod tests {
             request_overtake: false,
             request_pull_over: false,
             lane_graph: None,
-        }
+            signal_states: &[],        }
     }
 
     #[test]
@@ -3021,7 +3028,7 @@ mod tests {
             request_overtake: false,
             request_pull_over: false,
             lane_graph: None,
-        }
+            signal_states: &[],        }
     }
 
     #[test]

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -16,7 +16,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::behavior::TrafficControl;
+use crate::behavior::{SignalState, TrafficControl};
 use crate::{
     FleetPosture, Goal, Lane, LaneControl, LaneGraph, PlanInput, PlanOutput, Planner, Pose,
     MAX_ROUTE_LANES,
@@ -374,16 +374,19 @@ const STOP_SATISFIED_SPEED_MPS: f64 = 0.3;
 const STOP_SATISFIED_DIST_M: f64 = 2.0;
 
 /// Derive the regulatory [`TrafficControl`]s the ego currently faces from the lane graph:
-/// the STOP / YIELD sign at the end of the ego's lane (its junction approach), mapped to the
-/// behavioral-layer control. Empty if there is no graph, the ego is off the mapped road, or
-/// its lane carries no control (fail-safe → nothing beyond what objects/posture impose).
+/// the STOP / YIELD sign or TRAFFIC LIGHT at the end of the ego's lane (its junction
+/// approach), mapped to the behavioral-layer control. Empty if there is no graph, the ego is
+/// off the mapped road, or its lane carries no control (fail-safe → nothing beyond what
+/// objects/posture impose).
 ///
 /// STOP is **stateless stop-and-go**: `satisfied` once the ego is essentially stopped just
 /// before the line (`< STOP_SATISFIED_SPEED_MPS` within `STOP_SATISFIED_DIST_M`), so it
 /// proceeds. This approximates the legal full-stop dwell without loop memory — in the closed
 /// loop the ego decelerates to the line then creeps across; a precisely-latched full-stop
 /// dwell is a tracked follow-up. KIRRA bounds the actual motion regardless. YIELD is exact
-/// (a speed cap at the line).
+/// (a speed cap at the line). A TRAFFIC LIGHT takes its live state from `world.signal_states`
+/// (keyed by the governed lane id), **fail-closed to red** when absent — the behavioral
+/// layer then holds on red / amber-dilemma and clears on green.
 fn derive_controls(world: &PlanInput<'_>) -> Vec<TrafficControl> {
     let Some(graph) = world.lane_graph else {
         return Vec::new();
@@ -404,6 +407,16 @@ fn derive_controls(world: &PlanInput<'_>) -> Vec<TrafficControl> {
                 && dist > 0.0
                 && dist < STOP_SATISFIED_DIST_M;
             TrafficControl::StopSign { stop_line_x_m: line_x, satisfied }
+        }
+        LaneControl::TrafficLight => {
+            // Live signal state for the governed (ego) lane — fail-closed to RED when the
+            // perception/V2X feed has no entry, so an unknown light HOLDS rather than runs it.
+            let state = world
+                .signal_states
+                .iter()
+                .find(|(id, _)| *id == lane_id)
+                .map_or(SignalState::Red, |(_, s)| *s);
+            TrafficControl::TrafficLight { stop_line_x_m: line_x, state }
         }
     };
     vec![tc]
@@ -789,7 +802,7 @@ mod tests {
             request_overtake: false,
             request_pull_over: false,
             lane_graph: None,
-        }
+            signal_states: &[],        }
     }
 
     fn stopped_car(x: f64) -> PerceivedObject {
@@ -1314,6 +1327,43 @@ mod tests {
             "and comes to a stop at the line (final v {})",
             plan.trajectory.last().unwrap().velocity_mps
         );
+    }
+
+    #[test]
+    fn a_traffic_light_takes_its_live_state_and_fails_closed_to_red() {
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let g = lane_with_control(LaneControl::TrafficLight);
+
+        // No signal feed → RED (fail-closed): an unknown light HOLDS.
+        let red_default = derived_controls_for(&g, ego_at(5.0, 2.0), &corr);
+        assert_eq!(red_default, vec![TrafficControl::TrafficLight { stop_line_x_m: 18.0, state: SignalState::Red }]);
+
+        // Live GREEN supplied for the ego's lane → the light passes through as green.
+        let green = [(1u64, SignalState::Green)];
+        let w = PlanInput { ego: ego_at(5.0, 2.0), map: &corr, lane_graph: Some(&g), signal_states: &green, ..world(&corr, &[], &[]) };
+        let mut rec = ControlRecorder { controls: Vec::new() };
+        let _ = plan_for_intent(&mut rec, &MickIntent::GoTo { x_m: 50.0, y_m: 0.0 }, &w);
+        assert_eq!(rec.controls, vec![TrafficControl::TrafficLight { stop_line_x_m: 18.0, state: SignalState::Green }]);
+    }
+
+    #[test]
+    fn the_planner_stops_on_red_and_drives_through_on_green() {
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let g = lane_with_control(LaneControl::TrafficLight);
+
+        // RED (absent state → red): decelerate to a stop at the line, not past it.
+        let w_red = PlanInput { ego: ego_at(5.0, 2.0), map: &corr, lane_graph: Some(&g), ..world(&corr, &[], &[]) };
+        let red = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::GoTo { x_m: 50.0, y_m: 0.0 }, &w_red);
+        let red_max_x = red.trajectory.iter().map(|t| t.pose.x_m).fold(f64::MIN, f64::max);
+        assert!(red_max_x <= 18.5, "red light → stop at the line x=18, got max_x {red_max_x}");
+        assert!(red.trajectory.last().unwrap().velocity_mps < 0.5, "and comes to a stop");
+
+        // GREEN: drive through the line toward the goal.
+        let green = [(1u64, SignalState::Green)];
+        let w_green = PlanInput { ego: ego_at(5.0, 2.0), map: &corr, lane_graph: Some(&g), signal_states: &green, ..world(&corr, &[], &[]) };
+        let go = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::GoTo { x_m: 50.0, y_m: 0.0 }, &w_green);
+        let green_max_x = go.trajectory.iter().map(|t| t.pose.x_m).fold(f64::MIN, f64::max);
+        assert!(green_max_x > 18.5, "green light → drive through the line, got max_x {green_max_x}");
     }
 
     // ----- the dual-rate driver: System-2 intent rate vs System-1 grounding rate -----

--- a/crates/kirra-planner/tests/adversarial_doer_bounded_by_kirra.rs
+++ b/crates/kirra-planner/tests/adversarial_doer_bounded_by_kirra.rs
@@ -101,7 +101,7 @@ fn world<'a>(map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> Pla
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    }
+        signal_states: &[],    }
 }
 
 fn stopped_car(x: f64) -> PerceivedObject {

--- a/crates/kirra-planner/tests/lane_graph_to_occy.rs
+++ b/crates/kirra-planner/tests/lane_graph_to_occy.rs
@@ -83,7 +83,7 @@ fn lane_change_across_broken_divider_admits() {
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    };
+        signal_states: &[],    };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
     let verdict = validate_trajectory_slow(
@@ -135,7 +135,7 @@ fn lane_change_across_solid_divider_is_refused() {
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    };
+        signal_states: &[],    };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
 

--- a/crates/kirra-planner/tests/learned_doer_bounded_by_kirra.rs
+++ b/crates/kirra-planner/tests/learned_doer_bounded_by_kirra.rs
@@ -48,7 +48,7 @@ fn world<'a>(map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> Pla
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    }
+        signal_states: &[],    }
 }
 
 fn stopped_car(x: f64) -> PerceivedObject {

--- a/crates/kirra-planner/tests/mick_closed_loop.rs
+++ b/crates/kirra-planner/tests/mick_closed_loop.rs
@@ -86,7 +86,7 @@ fn world<'a>(ego: EgoState, map: &'a dyn CorridorSource, objects: &'a [Perceived
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    }
+        signal_states: &[],    }
 }
 
 fn kirra_admits(plan: &PlanOutput, corr: &dyn CorridorSource, objs: &[PerceivedObject]) -> bool {

--- a/crates/kirra-planner/tests/mick_turn_at.rs
+++ b/crates/kirra-planner/tests/mick_turn_at.rs
@@ -76,7 +76,7 @@ fn ground_turn<'a>(g: &'a LaneGraph, ego_corr: &'a dyn kirra_ros2_adapter::corri
         request_overtake: false,
         request_pull_over: false,
         lane_graph: Some(g),
-    };
+        signal_states: &[],    };
     plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::TurnAt { direction: dir }, &input)
 }
 
@@ -147,7 +147,7 @@ fn a_turn_without_a_lane_graph_fails_closed_to_hold() {
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    };
+        signal_states: &[],    };
     let plan = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::TurnAt { direction: TurnDirection::Left }, &input);
     assert_eq!(plan.kind, ProposalKind::SafeStop, "no graph → fail-closed HOLD");
 }

--- a/crates/kirra-planner/tests/overtake_oncoming.rs
+++ b/crates/kirra-planner/tests/overtake_oncoming.rs
@@ -100,7 +100,7 @@ fn plan_and_check(
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    };
+        signal_states: &[],    };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
     let verdict = validate_trajectory_slow(
@@ -266,7 +266,7 @@ fn overtake_world<'a>(
         request_overtake: false, // the MickIntent::Overtake grounding flips this on
         request_pull_over: false,
         lane_graph: None,
-    }
+        signal_states: &[],    }
 }
 
 /// **The full Mick path.** A `MickIntent::Overtake` — the LLM chauffeur's discretionary
@@ -356,7 +356,7 @@ fn a_stopped_school_bus_is_never_overtaken_and_the_ego_holds_behind_it() {
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    };
+        signal_states: &[],    };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
 

--- a/crates/kirra-planner/tests/pull_over.rs
+++ b/crates/kirra-planner/tests/pull_over.rs
@@ -85,7 +85,7 @@ fn world<'a>(
         request_overtake: false,
         request_pull_over,
         lane_graph: None,
-    }
+        signal_states: &[],    }
 }
 
 fn verdict(plan: &kirra_planner::PlanOutput, map: &dyn CorridorSource, objs: &[PerceivedObject]) -> TrajectoryVerdict {

--- a/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
+++ b/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
@@ -103,7 +103,7 @@ fn run_stack(
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    };
+        signal_states: &[],    };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
 
@@ -202,7 +202,7 @@ fn route_around_in_corridor_object_admits() {
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    };
+        signal_states: &[],    };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
     let verdict = validate_trajectory_slow(

--- a/crates/kirra-planner/tests/turn_at_junction.rs
+++ b/crates/kirra-planner/tests/turn_at_junction.rs
@@ -100,7 +100,7 @@ fn plan_turn(r: f64, half: f64) -> (kirra_planner::PlanOutput, TrajectoryVerdict
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    };
+        signal_states: &[],    };
     let mut occy = GeometricPlanner::default();
     let plan = occy.plan(&input);
     let verdict = validate_trajectory_slow(

--- a/crates/kirra-planner/tests/turn_multilane.rs
+++ b/crates/kirra-planner/tests/turn_multilane.rs
@@ -95,7 +95,7 @@ fn ego_world<'a>(g: &'a LaneGraph, map: &'a dyn CorridorSource, objects: &'a [Pe
         request_overtake: false,
         request_pull_over: false,
         lane_graph: Some(g),
-    }
+        signal_states: &[],    }
 }
 
 /// Records the drivable presence + boundary lines a grounding handed the planner.

--- a/crates/kirra-planner/tests/unmarked_road_keep_right.rs
+++ b/crates/kirra-planner/tests/unmarked_road_keep_right.rs
@@ -46,7 +46,7 @@ fn drive(map: &dyn CorridorSource) -> (f64, TrajectoryVerdict) {
         request_overtake: false,
         request_pull_over: false,
         lane_graph: None,
-    };
+        signal_states: &[],    };
     let mut planner = GeometricPlanner::default();
     let plan = planner.plan(&input);
     let verdict = validate_trajectory_slow(


### PR DESCRIPTION
## What

Completes the junction-control set deferred from #529. Stop/yield signs are **static** (#529); a traffic light's red/green/amber state is **dynamic**, so the map carries the light's *presence* and the live state is supplied at the loop boundary — defaulting **fail-closed to red** when unknown.

## Changes

- **kirra-map**: `LaneControl::TrafficLight` — presence only, at a lane's stop line.
- **kirra-planner**:
  - `PlanInput.signal_states: &[(u64, SignalState)]` — the live per-governed-lane signal feed (perception / V2X).
  - `derive_controls` maps a `TrafficLight` lane → `TrafficControl::TrafficLight { state }`, looking the state up by the **ego's lane id** and **defaulting to `Red` when the feed has no entry** — an unknown light *holds* rather than runs it.
  - No planner-core change: the behavioral layer (`evaluate_controls`) already handles red / amber-dilemma / green.

Same enrichment site + fail-safe rules as #528 cedes / #529 signs: only when a `lane_graph` is set and the integrator didn't hand-supply `controls`; an explicit list is never overridden; KIRRA bounds the resulting motion.

## Tests

- A light with no feed reads **RED** (fail-closed); a live **GREEN** passes through (mick.rs `derive_controls`).
- End-to-end: the planner **stops at the line on red** and **drives through on green**.
- New `PlanInput.signal_states` field added at every literal construction site.

kirra-planner (109 lib) + kirra-map + kirra-mick + kirra-taj green; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Follow-ups (unchanged, tracked)

A precisely-latched full-stop dwell; shared-signal grouping (one light → many lanes); the Lanelet2 regulatory-element parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_