### PR TITLE
Add the live Gemma intersection demo (junction-stack capstone)

### DIFF
--- a/crates/kirra-mick/examples/mick_intersection.rs
+++ b/crates/kirra-mick/examples/mick_intersection.rs
@@ -1,0 +1,218 @@
+//! **Watch real Gemma negotiate a signalized intersection — bounded by KIRRA.** The
+//! capstone that drives the whole junction stack end-to-end with a live model:
+//!
+//!   - #524 grammar-constrained intent decode  (Gemma → typed `MickIntent`)
+//!   - #527 `TurnAt` grounding                 (route the chosen branch through the junction)
+//!   - #528 right-of-way → cedes               (priority over a yielding-lane crosser)
+//!   - #529 / #531 stop line / traffic light   (HOLD on red, proceed on green)
+//!   - #525 decision capture                   (intent → grounding → verdict, JSONL)
+//!   - KIRRA                                    (bounds every proposal the model induces)
+//!
+//! The scene: the ego approaches a junction whose lane carries a TRAFFIC LIGHT and a LEFT
+//! turn branch, with a crossing lane the ego has right-of-way over. The light starts RED —
+//! the ego decelerates to the stop line and HOLDS no matter what Gemma asks — then turns
+//! GREEN, and the ego tracks the route corridor left through the junction toward the goal
+//! across it. Nothing the model says can make the car run the red, cross into the crosser,
+//! or over-cut the turn: Occy grounds the intent against the map-derived controls and KIRRA
+//! bounds the result. (The model emits `turn_at` / `go_to`; the goal sits across the
+//! junction, so a goal-seeking intent tracks the turn. A bare `turn_at` is a single-shot
+//! approach maneuver — see the deterministic `intersection_closed_loop` test.)
+//!
+//! Dual-rate, like `mick_chauffeur`: the FAST loop conforms at 10 Hz; the SLOW System-2 path
+//! only re-asks Gemma for a new intent every ~500 ms, so you watch a maneuver persist between
+//! the model's (infrequent) decisions.
+//!
+//! Run it:
+//!   ollama pull gemma3:4b           # one-time
+//!   cargo run -p kirra-mick --example mick_intersection
+//!
+//! No Ollama? The driver fails closed — HOLD throughout, the safe default. The model can
+//! never make the car unsafe; this binary only shows the loop.
+
+use kirra_planner::{
+    EgoState, FleetPosture, GeometricPlanner, Goal, Lane, LaneControl, LaneCorridor, LaneEdge,
+    LaneGraph, LineType, LlmBrain, MickDecisionRecord, MickDriver, MickEvalLog, PlanInput,
+    PlanOutput, Pose, SignalState,
+};
+use kirra_mick::OllamaClient;
+use kirra_ros2_adapter::corridor::{CorridorSource, Point};
+use kirra_ros2_adapter::state::{PerceivedObject, TrajectoryVerdict};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+const FAST_DT_S: f64 = 0.1; // 10 Hz fast loop
+const FAST_DT_MS: u64 = 100;
+const TICKS: usize = 80; // 8 s — approach, hold on red, then track the turn on green
+const MRC_DECEL: f64 = 3.0;
+const GREEN_AT_MS: u64 = 3500; // the light flips RED → GREEN at 3.5 s (after the ego has held)
+const TURN_RADIUS: f64 = 12.0; // gentle enough for the turn corridor to admit (cf. #526)
+const APPROACH_END: f64 = 30.0; // ego lane runs (0,0)→(30,0); the stop line is here
+
+/// A signalized LEFT-turn junction with a yielding crossing lane:
+///   1  ego approach (0,0)→(30,0), TRAFFIC LIGHT at the stop line, priority over lane 3,
+///      Successor → 2 (the left arc)
+///   2  left-turn arc (30,0)→(42,12), heading +π/2, Successor → 5
+///   5  north exit (42,12)→(42,32)
+///   3  crossing lane (yields to 1), off to the right where the left-turning ego never goes
+fn junction() -> LaneGraph {
+    let r = TURN_RADIUS;
+    let arc: Vec<Point> = (0..=12)
+        .map(|i| {
+            let t = -std::f64::consts::FRAC_PI_2 + std::f64::consts::FRAC_PI_2 * (i as f64 / 12.0);
+            Point { x_m: APPROACH_END + r * t.cos(), y_m: r + r * t.sin() }
+        })
+        .collect();
+    LaneGraph::new()
+        .with_lane(
+            Lane::straight(1, 0.0, 0.0, APPROACH_END, 3.0, LineType::Solid, LineType::Solid)
+                .with_control(LaneControl::TrafficLight)
+                .with_edge(LaneEdge::Successor { to: 2 }),
+        )
+        .with_lane(Lane {
+            id: 2,
+            centerline: arc,
+            half_width_m: 3.0,
+            left_line: LineType::Solid,
+            right_line: LineType::Solid,
+            heading_rad: std::f64::consts::FRAC_PI_2,
+            edges: vec![LaneEdge::Successor { to: 5 }],
+            control: None,
+        })
+        .with_lane(Lane {
+            id: 5,
+            centerline: vec![Point { x_m: APPROACH_END + r, y_m: r }, Point { x_m: APPROACH_END + r, y_m: r + 20.0 }],
+            half_width_m: 3.0,
+            left_line: LineType::Solid,
+            right_line: LineType::Solid,
+            heading_rad: std::f64::consts::FRAC_PI_2,
+            edges: Vec::new(),
+            control: None,
+        })
+        // Crossing lane the ego has priority over (a vehicle sits in it, off the turn path).
+        .with_lane(
+            Lane::straight(3, -10.0, 36.0, 25.0, 2.0, LineType::Solid, LineType::Solid)
+                .with_heading(std::f64::consts::FRAC_PI_2),
+        )
+        .with_right_of_way(1, 3)
+}
+
+fn world<'a>(
+    ego: EgoState,
+    map: &'a dyn CorridorSource,
+    objects: &'a [PerceivedObject],
+    signal_states: &'a [(u64, SignalState)],
+    graph: &'a LaneGraph,
+    goal: Pose,
+) -> PlanInput<'a> {
+    PlanInput {
+        ego,
+        goal: Goal { target: goal },
+        map,
+        objects,
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+        request_overtake: false,
+        request_pull_over: false,
+        lane_graph: Some(graph),
+        signal_states,
+    }
+}
+
+fn verdict(plan: &PlanOutput, corr: &dyn CorridorSource, objs: &[PerceivedObject]) -> TrajectoryVerdict {
+    validate_trajectory_slow(&plan.trajectory, corr, objs, &VehicleConfig::default_urban(), None, FleetPosture::Nominal)
+}
+
+/// The (pose, velocity) at time `t` along a plan — the fast-loop conformance target.
+fn target_at(plan: &PlanOutput, t: f64) -> Option<(Pose, f64)> {
+    plan.trajectory
+        .iter()
+        .find(|p| p.time_from_start_s >= t)
+        .or_else(|| plan.trajectory.last())
+        .map(|p| (p.pose, p.velocity_mps))
+}
+
+fn main() {
+    let client = OllamaClient::new();
+    let url = std::env::var("KIRRA_OLLAMA_URL").unwrap_or_else(|_| "http://localhost:11434".into());
+    println!("Mick intersection — model = {} @ {url}  (fast loop 10 Hz, Gemma ~2 Hz)", client.model());
+    println!("   signalized LEFT turn: HOLD on red → turn on green @ {:.1}s; right-of-way over a crosser; KIRRA bounds all.", GREEN_AT_MS as f64 / 1000.0);
+
+    let mut driver = MickDriver::new(LlmBrain::new(client));
+    let mut occy = GeometricPlanner::default();
+
+    let g = junction();
+    // The reference path AND the KIRRA containment corridor: the full route through the turn.
+    // The ego tracks it toward the cross-junction goal; the red light HOLDs it at the line.
+    let route: LaneCorridor = g.route(1, 5).and_then(|r| g.route_corridor(&r, 0.95, 5)).expect("route corridor");
+    // A stationary vehicle in the crossing lane (id 7), off the left-turn path — the ego has
+    // right-of-way over it; the cede is derived live and printed so you see #528 firing.
+    let objs = [PerceivedObject { id: 7, pos: Point { x_m: 33.0, y_m: -10.0 }, velocity_mps: 0.0, heading_rad: std::f64::consts::FRAC_PI_2, vel: Point { x_m: 0.0, y_m: 0.0 } }];
+    let goal = Pose { x_m: APPROACH_END + TURN_RADIUS, y_m: 28.0, heading_rad: std::f64::consts::FRAC_PI_2 };
+
+    let mut ego = EgoState { pose: Pose { x_m: 16.0, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: 5.0, yaw_rate_rads: 0.0, stamp_ms: 0 };
+    let mut accepted: Option<PlanOutput> = None;
+    let mut slot_t = 0.0_f64;
+
+    let mut eval = MickEvalLog::from_env();
+    if eval.is_some() {
+        println!("   (mick-eval capture ON → KIRRA_MICK_EVAL_PATH or kirra_mick_eval.jsonl)");
+    }
+
+    println!("   t(s)   ego.x  ego.y     v   light   intent (System-2)        cedes   kirra");
+    for tick in 1..=TICKS {
+        let now_ms = tick as u64 * FAST_DT_MS;
+        // The live signal feed: RED until GREEN_AT_MS, then GREEN. Keyed by the governed lane.
+        let light = if now_ms < GREEN_AT_MS { SignalState::Red } else { SignalState::Green };
+        let signals = [(1u64, light)];
+        let w = world(ego, &route, &objs, &signals, &g, goal);
+
+        let plan = driver.drive_tick(&w, &mut occy, now_ms);
+        let v = verdict(&plan, &route, &objs);
+        let admitted = matches!(v, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp);
+
+        // The cede set the grounding derived from the map's right-of-way (observability).
+        let cedes = derived_cedes(&w);
+
+        if let (Some(log), Some(intent)) = (eval.as_mut(), driver.current_intent()) {
+            let _ = log.append(&MickDecisionRecord::new(tick as u64, now_ms, &intent, &plan, v));
+        }
+
+        if admitted {
+            accepted = Some(plan);
+            slot_t = 0.0;
+        }
+        slot_t += FAST_DT_S;
+        ego = match accepted.as_ref().and_then(|p| target_at(p, slot_t)) {
+            Some((pose, vel)) => EgoState { pose, linear_x_mps: vel, yaw_rate_rads: 0.0, stamp_ms: now_ms },
+            None => EgoState {
+                pose: ego.pose, linear_x_mps: (ego.linear_x_mps - MRC_DECEL * FAST_DT_S).max(0.0),
+                yaw_rate_rads: 0.0, stamp_ms: now_ms,
+            },
+        };
+
+        let intent = driver.current_intent();
+        let light_s = if light == SignalState::Red { "RED " } else { "GREEN" };
+        println!(
+            "{:>6.1}  {:>6.2} {:>6.2}  {:>5.2}   {light_s}   {:<22?}  {:>5?}   {v:?}",
+            now_ms as f64 / 1000.0, ego.pose.x_m, ego.pose.y_m, ego.linear_x_mps, intent, cedes,
+        );
+    }
+    println!(
+        "final ego = ({:.1}, {:.1}) — held at the line on red, then turned left on green; right-of-way asserted; KIRRA bounded every tick.",
+        ego.pose.x_m, ego.pose.y_m
+    );
+}
+
+/// The cede set the junction's right-of-way grants the ego at its current pose — what
+/// `plan_for_intent` derives internally and feeds the planner (surfaced here for the trace).
+fn derived_cedes(w: &PlanInput<'_>) -> Vec<u64> {
+    let Some(g) = w.lane_graph else { return Vec::new() };
+    g.junction_context(Point { x_m: w.ego.pose.x_m, y_m: w.ego.pose.y_m }, w.objects).cedes_to_ego
+}

--- a/crates/kirra-planner/tests/intersection_closed_loop.rs
+++ b/crates/kirra-planner/tests/intersection_closed_loop.rs
@@ -1,0 +1,173 @@
+//! Deterministic proof for the `mick_intersection` demo: a scripted goal-seeking brain drives
+//! a signalized left-turn junction closed-loop, and the whole stack behaves. The TRAFFIC
+//! LIGHT (#531) HOLDs the ego at the stop line while RED (it never crosses); on GREEN the
+//! grounding authors a LEFT-turn trajectory through the junction along the materialized route
+//! corridor (#526/#527 geometry) and KIRRA admits it; the map's right-of-way (#528) derives
+//! the crossing vehicle into the cede set; and KIRRA admits every tick. The example shows the
+//! same loop with a *live* model; this pins the geometry/wiring with no Ollama dependency.
+//!
+//! Note on the maneuver: the brain heads for the goal across the junction (`GoTo`), so the
+//! ego tracks the route corridor through the arc — robust under per-tick re-planning. A bare
+//! `TurnAt` is a single-shot *approach* maneuver (it resolves the branch from the approach
+//! lane); sustaining it tick-by-tick through the arc is a separate follow-up.
+
+use kirra_planner::{
+    EgoState, FleetPosture, GeometricPlanner, Goal, Lane, LaneControl, LaneCorridor, LaneEdge,
+    LaneGraph, LineType, MickDriver, MickIntent, PlanInput, PlanOutput, Pose, ScriptedBrain,
+    SignalState, TrajectoryVerdict,
+};
+use kirra_ros2_adapter::corridor::{CorridorSource, Point};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+const FAST_DT_S: f64 = 0.1;
+const FAST_DT_MS: u64 = 100;
+const TICKS: usize = 120;
+const MRC_DECEL: f64 = 3.0;
+const GREEN_AT_MS: u64 = 3500;
+const TURN_RADIUS: f64 = 12.0;
+const APPROACH_END: f64 = 30.0;
+
+fn junction() -> LaneGraph {
+    let r = TURN_RADIUS;
+    let arc: Vec<Point> = (0..=12)
+        .map(|i| {
+            let t = -std::f64::consts::FRAC_PI_2 + std::f64::consts::FRAC_PI_2 * (i as f64 / 12.0);
+            Point { x_m: APPROACH_END + r * t.cos(), y_m: r + r * t.sin() }
+        })
+        .collect();
+    LaneGraph::new()
+        .with_lane(
+            Lane::straight(1, 0.0, 0.0, APPROACH_END, 3.0, LineType::Solid, LineType::Solid)
+                .with_control(LaneControl::TrafficLight)
+                .with_edge(LaneEdge::Successor { to: 2 }),
+        )
+        .with_lane(Lane {
+            id: 2,
+            centerline: arc,
+            half_width_m: 3.0,
+            left_line: LineType::Solid,
+            right_line: LineType::Solid,
+            heading_rad: std::f64::consts::FRAC_PI_2,
+            edges: vec![LaneEdge::Successor { to: 5 }],
+            control: None,
+        })
+        .with_lane(Lane {
+            id: 5,
+            centerline: vec![Point { x_m: APPROACH_END + r, y_m: r }, Point { x_m: APPROACH_END + r, y_m: r + 20.0 }],
+            half_width_m: 3.0,
+            left_line: LineType::Solid,
+            right_line: LineType::Solid,
+            heading_rad: std::f64::consts::FRAC_PI_2,
+            edges: Vec::new(),
+            control: None,
+        })
+        .with_lane(
+            Lane::straight(3, -10.0, 36.0, 25.0, 2.0, LineType::Solid, LineType::Solid)
+                .with_heading(std::f64::consts::FRAC_PI_2),
+        )
+        .with_right_of_way(1, 3)
+}
+
+fn world<'a>(
+    ego: EgoState,
+    map: &'a dyn CorridorSource,
+    objects: &'a [PerceivedObject],
+    signals: &'a [(u64, SignalState)],
+    g: &'a LaneGraph,
+    goal: Pose,
+) -> PlanInput<'a> {
+    PlanInput {
+        ego,
+        goal: Goal { target: goal },
+        map,
+        objects,
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+        request_overtake: false,
+        request_pull_over: false,
+        lane_graph: Some(g),
+        signal_states: signals,
+    }
+}
+
+use kirra_ros2_adapter::state::PerceivedObject;
+
+fn target_at(plan: &PlanOutput, t: f64) -> Option<(Pose, f64)> {
+    plan.trajectory.iter().find(|p| p.time_from_start_s >= t).or_else(|| plan.trajectory.last()).map(|p| (p.pose, p.velocity_mps))
+}
+
+#[test]
+fn gemma_holds_on_red_then_turns_left_on_green_kirra_bounding_throughout() {
+    let g = junction();
+    let route: LaneCorridor = g.route(1, 5).and_then(|r| g.route_corridor(&r, 0.95, 5)).expect("route");
+    // A stationary vehicle in the crossing lane (id 7), well off the left-turn path — the ego
+    // has map right-of-way over it on approach (the cede is derived), and it never interferes.
+    let objs = [PerceivedObject { id: 7, pos: Point { x_m: 33.0, y_m: -10.0 }, velocity_mps: 0.0, heading_rad: std::f64::consts::FRAC_PI_2, vel: Point { x_m: 0.0, y_m: 0.0 } }];
+    let goal = Pose { x_m: APPROACH_END + TURN_RADIUS, y_m: 28.0, heading_rad: std::f64::consts::FRAC_PI_2 };
+
+    // The model heads for the goal across the junction (a left turn): grounding follows the
+    // materialized route corridor through the arc, the red light HOLDs it at the line first.
+    let mut driver = MickDriver::new(ScriptedBrain::new(vec![MickIntent::GoTo { x_m: 42.0, y_m: 28.0 }; 20]));
+    let mut occy = GeometricPlanner::default();
+
+    let mut ego = EgoState { pose: Pose { x_m: 16.0, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: 5.0, yaw_rate_rads: 0.0, stamp_ms: 0 };
+    let mut accepted: Option<PlanOutput> = None;
+    let mut slot_t = 0.0_f64;
+
+    let mut red_max_x = f64::MIN;
+    let mut all_admitted = true;
+    let cede_at_approach = g.junction_context(Point { x_m: ego.pose.x_m, y_m: ego.pose.y_m }, &objs).cedes_to_ego;
+    let mut ego_max_y = f64::MIN;
+    let mut green_plan_max_y = f64::MIN; // how far into the arc the admitted GREEN plan reaches
+
+    for tick in 1..=TICKS {
+        let now_ms = tick as u64 * FAST_DT_MS;
+        let light = if now_ms < GREEN_AT_MS { SignalState::Red } else { SignalState::Green };
+        let signals = [(1u64, light)];
+        let w = world(ego, &route, &objs, &signals, &g, goal);
+
+        let plan = driver.drive_tick(&w, &mut occy, now_ms);
+        let v = validate_trajectory_slow(&plan.trajectory, &route, &objs, &VehicleConfig::default_urban(), None, FleetPosture::Nominal);
+        let admitted = matches!(v, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp);
+        all_admitted &= admitted;
+
+        if admitted && light == SignalState::Green {
+            let plan_y = plan.trajectory.iter().map(|p| p.pose.y_m).fold(f64::MIN, f64::max);
+            green_plan_max_y = green_plan_max_y.max(plan_y);
+        }
+
+        if admitted { accepted = Some(plan); slot_t = 0.0; }
+        slot_t += FAST_DT_S;
+        ego = match accepted.as_ref().and_then(|p| target_at(p, slot_t)) {
+            Some((pose, vel)) => EgoState { pose, linear_x_mps: vel, yaw_rate_rads: 0.0, stamp_ms: now_ms },
+            None => EgoState { pose: ego.pose, linear_x_mps: (ego.linear_x_mps - MRC_DECEL * FAST_DT_S).max(0.0), yaw_rate_rads: 0.0, stamp_ms: now_ms },
+        };
+
+        if light == SignalState::Red { red_max_x = red_max_x.max(ego.pose.x_m); }
+        ego_max_y = ego_max_y.max(ego.pose.y_m);
+    }
+
+    println!("red_max_x={red_max_x:.2}  ego_final=({:.2},{:.2})  ego_max_y={ego_max_y:.2}  green_plan_max_y={green_plan_max_y:.2}  cedes={cede_at_approach:?}  admitted={all_admitted}", ego.pose.x_m, ego.pose.y_m);
+
+    // (1) KIRRA bounds every tick of the negotiation.
+    assert!(all_admitted, "KIRRA admits every tick of the junction negotiation");
+    // (2) #528 — the map's right-of-way derives the crossing vehicle into the cede set.
+    assert_eq!(cede_at_approach, vec![7], "the crossing vehicle is derived into the cede set (right-of-way)");
+    // (3) #531 — the RED light HOLDs the ego at/before the stop line (it never crosses).
+    assert!(red_max_x <= APPROACH_END + 0.6, "the ego HOLDs at/before the stop line while RED (never crosses x={APPROACH_END}), got red_max_x {red_max_x}");
+    // (4) on GREEN the planner produces an admitted LEFT-turn trajectory deep into the arc
+    //     (#526/#527 route geometry) — the turn the red light had vetoed is now authored.
+    assert!(green_plan_max_y > 8.0, "on GREEN an admitted plan turns deep into the arc, got green_plan_max_y {green_plan_max_y}");
+    // (5) and the ego is released from the line into the turn (it crosses and climbs the arc).
+    //     The full traversal is gradual — the planner accelerates gently from the stop and the
+    //     fast loop conforms 0.1 s at a time — so this asserts release, not completion.
+    assert!(ego_max_y > 1.0 && ego.pose.x_m > APPROACH_END, "GREEN releases the ego into the turn, got ego_max_y {ego_max_y} x {}", ego.pose.x_m);
+}


### PR DESCRIPTION
## What

The capstone that drives the whole **#524–#531 junction stack end-to-end** at a signalized left-turn junction, with a live model. Purely additive — one example, one test, no core changes.

## Changes

- **`examples/mick_intersection.rs`** (kirra-mick) — the watch-it demo. A live model (Gemma via Ollama) emits intents; Occy grounds them against the map-derived controls; KIRRA bounds the result. The junction approach lane carries a **traffic light** (#531) and a left-turn branch, with a crossing lane the ego has **right-of-way** over (#528). The light starts **red** — the ego HOLDs at the stop line no matter what the model asks — then **green**, and the ego tracks the route corridor left through the junction toward the goal across it. Dual-rate like `mick_chauffeur` (10 Hz conform, ~2 Hz System-2); decision capture (#525) wired via `MickEvalLog`; **no Ollama → fails closed to HOLD**.

- **`tests/intersection_closed_loop.rs`** (kirra-planner) — the deterministic proof (no Ollama). A scripted goal-seeking brain over the same junction asserts: KIRRA admits **every** tick; the RED light HOLDs the ego at/before the stop line (never crosses); on GREEN the grounding authors an **admitted left-turn trajectory deep into the arc** (`green_plan_max_y ≈ 19 m`, through the quarter into the exit); the map right-of-way derives the crossing vehicle into the cede set; GREEN releases the ego into the turn.

## Honest findings (surfaced while wiring it, documented in-code)

- The route corridor needs **~3 m half-width** for the turning footprint to stay contained (a 1.75 m half-lane MRC-rejects the swept turn) — the figure from the #526 turn test.
- **`TurnAt` is a single-shot *approach* maneuver**: it resolves the branch from the approach lane, so re-issuing it tick-by-tick HOLDs once the ego leaves that lane. The robust closed-loop way through the curve is to track the route corridor toward the cross-junction goal (`GoTo`). A committed-route / route-progress state for `TurnAt` is a follow-up.
- The planner accelerates gently from a dead stop, so the full traversal is gradual; the test asserts **release + an admitted turn plan**, not completion.

## Tests

kirra-planner `intersection_closed_loop` passes; `mick_intersection` example builds and runs (HOLDs without Ollama); `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_