### PR TITLE
Parse Lanelet2 traffic-sign / traffic-light regulatory elements

### DIFF
--- a/crates/kirra-map/src/lanelet2.rs
+++ b/crates/kirra-map/src/lanelet2.rs
@@ -3,8 +3,10 @@
 //! Lanelet2 maps are stored in OSM-XML: `<node>` points (local metric `local_x` /
 //! `local_y`), `<way>` linestrings (lane boundaries, with a `subtype` marking), and
 //! `<relation type=lanelet>` = a `left` + `right` boundary way. This parses that subset
-//! into the planner's [`LaneGraph`] — centerlines, half-widths, typed lane lines, and
-//! connectivity — **without the C++ `lanelet2_core` library**. Only Lanelet2's advanced
+//! into the planner's [`LaneGraph`] — centerlines, half-widths, typed lane lines,
+//! connectivity, and the **`regulatory_element` relations**: `right_of_way` (priority →
+//! yields-to edges) and `traffic_sign` / `traffic_light` (a lane's STOP / YIELD / TRAFFIC
+//! LIGHT [`LaneControl`]) — **without the C++ `lanelet2_core` library**. Only Lanelet2's advanced
 //! geometry/routing ops needed that lib; the `LaneGraph` + its router (`route`) already
 //! cover routing, so all we need from the file is the primitives.
 //!
@@ -18,7 +20,7 @@ use kirra_core::corridor::Point;
 use roxmltree::Document;
 
 use crate::lane_lines::LineType;
-use crate::lanemap::{Lane, LaneEdge, LaneGraph};
+use crate::lanemap::{Lane, LaneControl, LaneEdge, LaneGraph};
 
 /// Why a Lanelet2 `.osm` document could not be turned into a [`LaneGraph`].
 #[derive(Debug, PartialEq)]
@@ -52,6 +54,8 @@ pub fn parse_lanelet2_osm(xml: &str) -> Result<LaneGraph, Lanelet2ParseError> {
     let mut raw_lanelets: Vec<RawLanelet> = Vec::new();
     // `right_of_way` regulatory elements, as (priority lanes, yielding lanes).
     let mut right_of_way: Vec<(Vec<u64>, Vec<u64>)> = Vec::new();
+    // `traffic_sign` / `traffic_light` regulatory elements, resolved to controls after the scan.
+    let mut raw_regs: Vec<RawReg> = Vec::new();
 
     for el in root.children().filter(roxmltree::Node::is_element) {
         match el.tag_name().name() {
@@ -70,8 +74,9 @@ pub fn parse_lanelet2_osm(xml: &str) -> Result<LaneGraph, Lanelet2ParseError> {
                     .filter(|c| c.has_tag_name("nd"))
                     .filter_map(|c| attr_u64(&c, "ref"))
                     .collect();
-                let line = line_type_of(tag_value(&el, "type"), tag_value(&el, "subtype"));
-                ways.insert(id, Way { node_ids, line });
+                let subtype = tag_value(&el, "subtype");
+                let line = line_type_of(tag_value(&el, "type"), subtype);
+                ways.insert(id, Way { node_ids, line, subtype: subtype.map(str::to_string) });
             }
             "relation" => match tag_value(&el, "type") {
                 Some("lanelet") => {
@@ -92,19 +97,43 @@ pub fn parse_lanelet2_osm(xml: &str) -> Result<LaneGraph, Lanelet2ParseError> {
                     let (Some(left), Some(right)) = (first_ref("left"), first_ref("right")) else {
                         return Err(Lanelet2ParseError::IncompleteLanelet(id));
                     };
-                    raw_lanelets.push(RawLanelet { id, left, right });
+                    // Regulatory elements this lanelet is subject to (role `regulatory_element`).
+                    let reg_elems: Vec<u64> = el
+                        .children()
+                        .filter(|c| c.has_tag_name("member"))
+                        .filter(|c| c.attribute("role") == Some("regulatory_element"))
+                        .filter_map(|c| attr_u64(&c, "ref"))
+                        .collect();
+                    raw_lanelets.push(RawLanelet { id, left, right, reg_elems });
                 }
-                Some("regulatory_element") if tag_value(&el, "subtype") == Some("right_of_way") => {
-                    // Members reference lanelets by id: role `right_of_way` = the lanes
-                    // with priority, role `yield` = the lanes that must cede.
-                    let refs_with_role = |r: &str| -> Vec<u64> {
-                        el.children()
+                Some("regulatory_element") => {
+                    let Some(reg_id) = attr_u64(&el, "id") else { continue };
+                    if tag_value(&el, "subtype") == Some("right_of_way") {
+                        // Members reference lanelets by id: role `right_of_way` = the lanes
+                        // with priority, role `yield` = the lanes that must cede.
+                        let refs_with_role = |r: &str| -> Vec<u64> {
+                            el.children()
+                                .filter(|c| c.has_tag_name("member"))
+                                .filter(|c| c.attribute("role") == Some(r))
+                                .filter_map(|c| attr_u64(&c, "ref"))
+                                .collect()
+                        };
+                        right_of_way.push((refs_with_role("right_of_way"), refs_with_role("yield")));
+                    } else {
+                        // A traffic-sign / traffic-light element: collect it raw and resolve to a
+                        // control after the scan (the `refers` way may appear later in the file).
+                        let refers = el
+                            .children()
                             .filter(|c| c.has_tag_name("member"))
-                            .filter(|c| c.attribute("role") == Some(r))
-                            .filter_map(|c| attr_u64(&c, "ref"))
-                            .collect()
-                    };
-                    right_of_way.push((refs_with_role("right_of_way"), refs_with_role("yield")));
+                            .find(|c| c.attribute("role") == Some("refers"))
+                            .and_then(|c| attr_u64(&c, "ref"));
+                        raw_regs.push(RawReg {
+                            id: reg_id,
+                            subtype: tag_value(&el, "subtype").map(str::to_string),
+                            sign_type: tag_value(&el, "sign_type").map(str::to_string),
+                            refers,
+                        });
+                    }
                 }
                 _ => {}
             },
@@ -120,6 +149,26 @@ pub fn parse_lanelet2_osm(xml: &str) -> Result<LaneGraph, Lanelet2ParseError> {
             .map(|n| nodes.get(n).copied().ok_or(Lanelet2ParseError::DanglingNodeRef { way: way_id, node: *n }))
             .collect()
     };
+
+    // Resolve each traffic-sign / traffic-light regulatory element to a control. A light is a
+    // light; a sign's stop-vs-yield comes from its `sign_type` tag, else its `refers` way's
+    // subtype; some maps put the specific sign straight in the element subtype. An unrecognized
+    // element yields nothing (the parser never fabricates a stop). `reg_id → control`.
+    let mut reg_controls: BTreeMap<u64, LaneControl> = BTreeMap::new();
+    for r in &raw_regs {
+        let control = match r.subtype.as_deref() {
+            Some("traffic_light") => Some(LaneControl::TrafficLight),
+            Some("traffic_sign") => r
+                .sign_type
+                .as_deref()
+                .and_then(sign_control)
+                .or_else(|| r.refers.and_then(|w| ways.get(&w)).and_then(|w| w.subtype.as_deref()).and_then(sign_control)),
+            other => other.and_then(sign_control), // direct-subtype convention (e.g. subtype=stop_sign)
+        };
+        if let Some(c) = control {
+            reg_controls.insert(r.id, c);
+        }
+    }
 
     let mut graph = LaneGraph::new();
     for ll in &raw_lanelets {
@@ -140,9 +189,9 @@ pub fn parse_lanelet2_osm(xml: &str) -> Result<LaneGraph, Lanelet2ParseError> {
             right_line: ways[&ll.right].line,
             heading_rad,
             edges: connectivity(ll, &raw_lanelets, &ways),
-            // Regulatory controls (stop / yield signs) are a separate Lanelet2
-            // regulatory-element parse — not wired from the .osm yet; None for now.
-            control: None,
+            // The regulatory control (STOP / YIELD sign or TRAFFIC LIGHT) from the first of this
+            // lanelet's `regulatory_element` members that resolves to one; `None` if it has none.
+            control: ll.reg_elems.iter().find_map(|e| reg_controls.get(e).copied()),
         });
     }
 
@@ -174,12 +223,27 @@ fn is_driveable_subtype(subtype: Option<&str>) -> bool {
 struct Way {
     node_ids: Vec<u64>,
     line: LineType,
+    /// Raw `subtype` tag, kept so a `traffic_sign` regulatory element that `refers` to this
+    /// way (the sign linestring) can resolve the specific sign (stop vs yield).
+    subtype: Option<String>,
 }
 
 struct RawLanelet {
     id: u64,
     left: u64,
     right: u64,
+    /// Ids of the `regulatory_element` relations this lanelet references (role
+    /// `regulatory_element`) — resolved to a [`LaneControl`] after the full parse.
+    reg_elems: Vec<u64>,
+}
+
+/// A regulatory element collected during the scan, resolved to a control afterward (so it is
+/// order-independent — the `refers` way may appear after the relation).
+struct RawReg {
+    id: u64,
+    subtype: Option<String>,
+    sign_type: Option<String>,
+    refers: Option<u64>,
 }
 
 /// Derive a lanelet's edges from shared OSM ids: a lateral neighbor shares a boundary
@@ -238,6 +302,18 @@ fn heading_of(centerline: &[Point]) -> f64 {
     match (centerline.first(), centerline.last()) {
         (Some(a), Some(b)) if a != b => (b.y_m - a.y_m).atan2(b.x_m - a.x_m),
         _ => 0.0,
+    }
+}
+
+/// Map a Lanelet2 traffic-sign identifier (a `sign_type`, a `refers` way `subtype`, or a
+/// direct element subtype) to a STOP / YIELD [`LaneControl`]. Recognizes the descriptive
+/// names and the common German (`deNNN`) / US (`usR1-N`) MUTCD codes, case-insensitively.
+/// An unrecognized identifier yields `None` — the parser does not fabricate a control.
+fn sign_control(id: &str) -> Option<LaneControl> {
+    match id.trim().to_ascii_lowercase().as_str() {
+        "stop_sign" | "stop" | "de206" | "usr1-1" => Some(LaneControl::Stop),
+        "yield_sign" | "yield" | "give_way" | "de205" | "usr1-2" => Some(LaneControl::Yield),
+        _ => None,
     }
 }
 
@@ -404,6 +480,61 @@ mod tests {
         assert_eq!(g.cedes_to_ego(1, &objs), vec![42]);
         // The ego in the yielding lane asserts no priority.
         assert!(g.cedes_to_ego(2, &objs).is_empty());
+    }
+
+    #[test]
+    fn traffic_sign_and_light_regulatory_elements_set_the_lane_control() {
+        // Lanelet 1 → STOP (traffic_sign whose `refers` way 90 has subtype stop_sign);
+        // lanelet 2 → TRAFFIC LIGHT; lanelet 3 → YIELD (traffic_sign with a `sign_type` code);
+        // lanelet 4 → uncontrolled (its sign is unrecognized — the parser never fabricates one).
+        let xml = r#"<osm>
+  <node id="1"><tag k="local_x" v="0"/><tag k="local_y" v="1.75"/></node>
+  <node id="2"><tag k="local_x" v="30"/><tag k="local_y" v="1.75"/></node>
+  <node id="3"><tag k="local_x" v="0"/><tag k="local_y" v="-1.75"/></node>
+  <node id="4"><tag k="local_x" v="30"/><tag k="local_y" v="-1.75"/></node>
+  <node id="5"><tag k="local_x" v="0"/><tag k="local_y" v="11.75"/></node>
+  <node id="6"><tag k="local_x" v="30"/><tag k="local_y" v="11.75"/></node>
+  <node id="7"><tag k="local_x" v="0"/><tag k="local_y" v="8.25"/></node>
+  <node id="8"><tag k="local_x" v="30"/><tag k="local_y" v="8.25"/></node>
+  <node id="9"><tag k="local_x" v="0"/><tag k="local_y" v="21.75"/></node>
+  <node id="10"><tag k="local_x" v="30"/><tag k="local_y" v="21.75"/></node>
+  <node id="11"><tag k="local_x" v="0"/><tag k="local_y" v="18.25"/></node>
+  <node id="12"><tag k="local_x" v="30"/><tag k="local_y" v="18.25"/></node>
+  <node id="13"><tag k="local_x" v="0"/><tag k="local_y" v="31.75"/></node>
+  <node id="14"><tag k="local_x" v="30"/><tag k="local_y" v="31.75"/></node>
+  <node id="15"><tag k="local_x" v="0"/><tag k="local_y" v="28.25"/></node>
+  <node id="16"><tag k="local_x" v="30"/><tag k="local_y" v="28.25"/></node>
+  <way id="10"><nd ref="1"/><nd ref="2"/><tag k="subtype" v="solid"/></way>
+  <way id="11"><nd ref="3"/><nd ref="4"/><tag k="subtype" v="solid"/></way>
+  <way id="20"><nd ref="5"/><nd ref="6"/><tag k="subtype" v="solid"/></way>
+  <way id="21"><nd ref="7"/><nd ref="8"/><tag k="subtype" v="solid"/></way>
+  <way id="30"><nd ref="9"/><nd ref="10"/><tag k="subtype" v="solid"/></way>
+  <way id="31"><nd ref="11"/><nd ref="12"/><tag k="subtype" v="solid"/></way>
+  <way id="40"><nd ref="13"/><nd ref="14"/><tag k="subtype" v="solid"/></way>
+  <way id="41"><nd ref="15"/><nd ref="16"/><tag k="subtype" v="solid"/></way>
+  <way id="90"><nd ref="2"/><tag k="type" v="traffic_sign"/><tag k="subtype" v="stop_sign"/></way>
+  <relation id="1"><tag k="type" v="lanelet"/><member type="way" role="left" ref="10"/><member type="way" role="right" ref="11"/><member type="relation" role="regulatory_element" ref="50"/></relation>
+  <relation id="2"><tag k="type" v="lanelet"/><member type="way" role="left" ref="20"/><member type="way" role="right" ref="21"/><member type="relation" role="regulatory_element" ref="60"/></relation>
+  <relation id="3"><tag k="type" v="lanelet"/><member type="way" role="left" ref="30"/><member type="way" role="right" ref="31"/><member type="relation" role="regulatory_element" ref="70"/></relation>
+  <relation id="4"><tag k="type" v="lanelet"/><member type="way" role="left" ref="40"/><member type="way" role="right" ref="41"/><member type="relation" role="regulatory_element" ref="80"/></relation>
+  <relation id="50"><tag k="type" v="regulatory_element"/><tag k="subtype" v="traffic_sign"/><member type="way" role="refers" ref="90"/></relation>
+  <relation id="60"><tag k="type" v="regulatory_element"/><tag k="subtype" v="traffic_light"/></relation>
+  <relation id="70"><tag k="type" v="regulatory_element"/><tag k="subtype" v="traffic_sign"/><tag k="sign_type" v="de205"/></relation>
+  <relation id="80"><tag k="type" v="regulatory_element"/><tag k="subtype" v="traffic_sign"/><tag k="sign_type" v="speed_limit_50"/></relation>
+</osm>"#;
+        let g = parse_lanelet2_osm(xml).unwrap();
+        assert_eq!(g.lane(1).unwrap().control, Some(LaneControl::Stop), "STOP via refers-way subtype stop_sign");
+        assert_eq!(g.lane(2).unwrap().control, Some(LaneControl::TrafficLight), "TRAFFIC LIGHT");
+        assert_eq!(g.lane(3).unwrap().control, Some(LaneControl::Yield), "YIELD via sign_type de205");
+        assert_eq!(g.lane(4).unwrap().control, None, "an unrecognized sign fabricates no control");
+    }
+
+    #[test]
+    fn a_lanelet_with_no_regulatory_element_is_uncontrolled() {
+        // The CHAIN fixture has no regulatory elements → every lane's control is None.
+        let g = parse_lanelet2_osm(CHAIN).unwrap();
+        assert!(g.lane(100).unwrap().control.is_none());
+        assert!(g.lane(200).unwrap().control.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Completes the Lanelet2 regulatory parse. The parser already derived `right_of_way` regulatory elements (priority → yields-to edges); now it also wires **`traffic_sign` and `traffic_light`** regulatory elements to a lane's `LaneControl` — so **STOP / YIELD / TRAFFIC LIGHT come from a real `.osm` map, not a hand-built fixture**.

## Changes (kirra-map `lanelet2.rs`)

- A lanelet's `regulatory_element` member ids are collected, then resolved **after the full scan** (order-independent — the `refers` way may appear after the relation): `traffic_light` → `TrafficLight`; `traffic_sign` → the specific sign from a `sign_type` tag, else the `refers` way's `subtype`, else a direct element subtype.
- `sign_control()` maps the descriptive names (`stop_sign` / `yield_sign` / `give_way`) and the common German (`deNNN`) / US (`usR1-N`) MUTCD codes, case-insensitively. **An unrecognized sign yields no control — the parser never fabricates a stop** (fail-open on parse; KIRRA backstops physical safety regardless).
- `Way` now keeps its raw `subtype` so a sign's `refers` way resolves; the lane's control is the first of its `regulatory_element` members that resolves to one.

These land straight on the existing `derive_controls` path (#529/#531): a parsed sign/light grounds the same stop-at-line / yield / red-hold behavior in the closed loop — now **fed by the map**.

## Tests

A lanelet → STOP via a refers-way `stop_sign`; another → TRAFFIC LIGHT; another → YIELD via `sign_type de205`; an unrecognized sign → `None`; a lanelet with no regulatory element → `None`. Existing right-of-way + geometry tests unchanged.

kirra-map + kirra-planner green; `cargo clippy -p kirra-map -p kirra-planner --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_