### PR TITLE
KIRRA RSS: admit a safe stationary queue (§4 lateral over-rejection)

### DIFF
--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -2305,30 +2305,36 @@ mod tests {
     }
 
     #[test]
-    fn checker_mrcs_blocked_lane_despite_stop_short() {
-        // INDEPENDENCE: a dead-center object blocks the lane — even though Occy now
-        // proposes a controlled stop short of it (good behavior), KIRRA is the
-        // authority and MRCs the blocked lane (lateral RSS: a same-lane forward
-        // object can't be cleared). Obstacle-awareness = the planner PROPOSING
-        // safety, never overriding the checker.
+    fn checker_admits_a_safe_stop_behind_but_mrcs_driving_into_a_stopped_object() {
+        // A dead-center stopped object. The §4 RSS-conjunction fix: a controlled stop a safe
+        // distance BEHIND it (a stopped queue) is now ADMITTED — the lateral side-RSS no longer
+        // spuriously MRCs a longitudinally-safe, laterally-stationary lead. But KIRRA remains the
+        // authority: a trajectory that drives INTO the object at speed (longitudinally unsafe) is
+        // still MRC'd. The planner proposes safety; the checker bounds genuine danger.
         let corridor = MockCorridorSource::straight_5m_half_width(100.0);
         let objs = [obj_at(30.0, 0.0)];
+        let cfg = VehicleConfig::default_urban();
+
+        // Occy's controlled stop short of the object → now admitted (safe same-lane stop).
         let mut p = GeometricPlanner::default();
         let out = p.plan(&input_with_objects(&corridor, 18.0, 60.0, &objs));
+        let safe = validate_trajectory_slow(&out.trajectory, &corridor, &objs, &cfg, None, FleetPosture::Nominal);
+        assert!(
+            matches!(safe, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+            "a controlled stop a safe distance behind a stopped object is admitted, got {safe:?}"
+        );
 
-        let verdict = validate_trajectory_slow(
-            &out.trajectory,
-            &corridor,
-            &objs,
-            &VehicleConfig::default_urban(),
-            None,
-            FleetPosture::Nominal,
-        );
-        assert_eq!(
-            verdict,
-            TrajectoryVerdict::MRCFallback,
-            "checker MRCs a lane-blocking object regardless of the proposal, got {verdict:?}"
-        );
+        // A trajectory barreling INTO the object at speed (way inside the longitudinal RSS
+        // distance) is still MRC'd — independence preserved.
+        let into: Vec<TrajectoryPoint> = (0..5)
+            .map(|i| TrajectoryPoint {
+                pose: Pose { x_m: 26.0 + i as f64, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: 8.0,
+                time_from_start_s: i as f64 * 0.1,
+            })
+            .collect();
+        let danger = validate_trajectory_slow(&into, &corridor, &objs, &cfg, None, FleetPosture::Nominal);
+        assert_eq!(danger, TrajectoryVerdict::MRCFallback, "driving into the object at speed is MRC'd, got {danger:?}");
     }
 
     #[test]

--- a/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
+++ b/crates/kirra-planner/tests/taj_occy_kirra_stack.rs
@@ -134,19 +134,18 @@ fn clear_corridor_nominal_stack_admits() {
 }
 
 #[test]
-fn obstacle_in_path_stack_fails_closed() {
-    // Same corridor but a blob dead ahead at ~4 m. Defense in depth, both layers
-    // active: Occy is now obstacle-aware so it brakes/HOLDs short of the object
-    // (a controlled stop, not driving in), AND KIRRA independently MRCs the
-    // lane-blocking object (it is the safety authority). The stack fails closed
-    // end-to-end regardless of which layer you trust.
+fn obstacle_in_path_stack_admits_a_controlled_stop_behind_it() {
+    // A blob dead ahead at ~4 m. Occy is obstacle-aware → it brakes/HOLDs to a controlled stop a
+    // safe distance behind it (not driving in), and — with the §4 RSS-conjunction fix — KIRRA now
+    // ADMITS that safe same-lane stop instead of spuriously MRC'ing it. A vehicle halting behind a
+    // stopped hazard is the *correct*, admissible outcome; the stack still fails closed on genuine
+    // danger (see `lockedout_posture_flows_through_stack` and the driving-into checker test).
     let scan = corridor_scan(5.0, Some((4.0, 0.12)));
     let (_kind, verdict) = run_stack(&scan, 2.0, 6.0, FleetPosture::Nominal);
 
-    assert_eq!(
-        verdict,
-        TrajectoryVerdict::MRCFallback,
-        "lane-blocking hazard → KIRRA stops the plan, got {verdict:?}"
+    assert!(
+        matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "the controlled stop behind the lane-blocking hazard is admitted, got {verdict:?}"
     );
 }
 

--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -60,6 +60,17 @@ const OCCLUSION_SPEED_TOL_MPS: f64 = 0.1;
 /// covers it.
 const RSS_LATERAL_ALIGNMENT_TOLERANCE_M: f64 = 4.0;
 
+/// Object lateral-velocity magnitude (m/s) above which a same-lane object is treated as
+/// **cutting in** (a genuine side-collision risk) rather than a straight-running lead or a
+/// member of a stationary queue. The lateral (side) RSS check is the CONJUNCTION partner of
+/// the longitudinal check: a side collision needs the pair ABREAST (longitudinally unsafe) OR
+/// closing laterally. Below this threshold a *longitudinally-safe* object triggers no lateral
+/// MRC — admitting a safe same-lane stop (a stopped queue / a stopped lead the ego halts
+/// behind) that the reaction-time swerve term in `lateral_safe_distance` otherwise rejected
+/// (`COMPETITIVE_PLANNER_ANALYSIS §4`'s over-rejection) — while any real lateral closing is
+/// still caught. Small, so only genuine lateral stillness is admitted; fail-closed elsewhere.
+const RSS_LATERAL_MOTION_EPS_MPS: f64 = 0.1;
+
 /// One predicted future position of an object at a time, in the world frame. A
 /// sequence of these forms one predicted **mode** (hypothesis); the inter-sample
 /// motion supplies the predicted velocity (no separate speed field to keep stale).
@@ -312,59 +323,61 @@ pub fn validate_trajectory_slow_capped(
                 continue;
             }
 
-            // Longitudinal RSS (rear-end / head-on) — GATED ON LATERAL OVERLAP: a
-            // longitudinal collision is only possible when the footprints laterally
-            // overlap (the object is in the ego's path). Applying it to an object
-            // the ego is laterally CLEAR of — a vehicle being passed, or oncoming
-            // traffic safely in the next lane — over-rejected (§4): it was why a car
-            // centered in the ego lane could not be overtaken. Direction matters: an
-            // ONCOMING vehicle (heading opposes the ego, velocity projects backward
-            // onto the ego's forward axis) is a HEAD-ON closure, not a same-direction
-            // lead — routing it through the same-direction primitive would discard
-            // the closing sign and UNDER-estimate the gap (#408 Obs 3); the
-            // opposite-direction bound (sum of both stopping distances) applies.
-            if dy_ego.abs() < RSS_LONGITUDINAL_OVERLAP_M {
-                let obj_lon_v =
-                    obj.velocity_mps * (obj.heading_rad - traj_point.pose.heading_rad).cos();
-                let lon_required = if obj_lon_v < 0.0 {
-                    // Closing magnitudes; symmetric brake_min (both in their lanes).
-                    opposite_direction_safe_distance(
-                        traj_point.velocity_mps,
-                        obj_lon_v.abs(),
-                        RSS_REACTION_TIME_S,
-                        config.max_accel_mps2,
-                        config.max_decel_mps2,
-                        config.max_decel_mps2,
-                    )
-                } else {
-                    longitudinal_safe_distance(
-                        traj_point.velocity_mps,
-                        obj.velocity_mps,
-                        RSS_REACTION_TIME_S,
-                        config.max_accel_mps2,
-                        config.max_decel_mps2,
-                        config.max_decel_mps2,
-                    )
-                };
-                if dx_ego < lon_required {
-                    return TrajectoryVerdict::MRCFallback;
-                }
+            // RSS over the horizon, per object, as the CONJUNCTION of the two axes (IEEE 2846
+            // §5; Shalev-Shwartz et al.): a collision needs the vehicles unsafe longitudinally
+            // AND laterally at once. Compute the longitudinal safe distance once (direction
+            // matters: an ONCOMING vehicle — velocity projects backward onto the ego's forward
+            // axis — is a HEAD-ON closure needing the opposite-direction bound, the sum of both
+            // stopping distances; a same-direction lead uses the rear-end bound, #408 Obs 3).
+            let obj_lon_v =
+                obj.velocity_mps * (obj.heading_rad - traj_point.pose.heading_rad).cos();
+            let lon_required = if obj_lon_v < 0.0 {
+                // Closing magnitudes; symmetric brake_min (both in their lanes).
+                opposite_direction_safe_distance(
+                    traj_point.velocity_mps,
+                    obj_lon_v.abs(),
+                    RSS_REACTION_TIME_S,
+                    config.max_accel_mps2,
+                    config.max_decel_mps2,
+                    config.max_decel_mps2,
+                )
+            } else {
+                longitudinal_safe_distance(
+                    traj_point.velocity_mps,
+                    obj.velocity_mps,
+                    RSS_REACTION_TIME_S,
+                    config.max_accel_mps2,
+                    config.max_decel_mps2,
+                    config.max_decel_mps2,
+                )
+            };
+            let lon_unsafe = dx_ego < lon_required;
+
+            // Longitudinal RSS (rear-end / head-on) — GATED ON LATERAL OVERLAP: a longitudinal
+            // collision is only possible when the footprints laterally overlap (the object is in
+            // the ego's path). Applying it to an object the ego is laterally CLEAR of — a vehicle
+            // being passed, or oncoming traffic safely in the next lane — over-rejected (§4): it
+            // was why a car centered in the ego lane could not be overtaken.
+            if dy_ego.abs() < RSS_LONGITUDINAL_OVERLAP_M && lon_unsafe {
+                return TrajectoryVerdict::MRCFallback;
             }
 
-            // Lateral RSS — required side gap. Defence-in-depth against an object
-            // cutting in beside the ego (the longitudinal check above is the
-            // dominant risk). RSS-GATED ON LONGITUDINAL PROXIMITY: a lateral
-            // shortfall is only dangerous when the object is also longitudinally
-            // close (within `RSS_LONGITUDINAL_CONFLICT_M`) — two vehicles cannot
-            // collide laterally unless they are alongside or imminently so. Without
-            // this gate the check over-rejected a lead well ahead, or oncoming
-            // traffic safely passing in the next lane (COMPETITIVE_PLANNER_ANALYSIS
-            // §4): both are longitudinally distant, so a lateral shortfall there is
-            // not a collision risk. (Object lateral velocity is the component along
-            // the pose normal — Phase 2A assumes 0 if perception lacks per-axis vel.)
-            if dx_ego <= RSS_LONGITUDINAL_CONFLICT_M {
-                let obj_lat_vel =
-                    obj.velocity_mps * (obj.heading_rad - traj_point.pose.heading_rad).sin();
+            // Lateral RSS — required side gap. A side collision needs the footprints ABREAST
+            // (longitudinally unsafe — `lon_unsafe`) OR the object CLOSING LATERALLY (a cut-in:
+            // its velocity has a lateral component). A longitudinally-SAFE, laterally-STATIONARY
+            // object — a stopped queue member, or a stopped lead the ego halts behind — is
+            // neither, so it is admitted instead of spuriously MRC'd by the reaction-time swerve
+            // term in `lateral_safe_distance` (the §4 over-rejection of a safe same-lane stop).
+            // This strictly NARROWS the lateral check (an added precondition), so it can only
+            // admit longitudinally-safe + laterally-still objects — never a state with lateral
+            // motion or abreast danger. RSS-GATED ON LONGITUDINAL PROXIMITY as before. (Object
+            // lateral velocity = the component along the pose normal — Phase 2A assumes 0 if
+            // perception lacks per-axis vel; the ego's own lateral motion is carried by the
+            // trajectory poses, so containment + the abreast term cover an ego swerve.)
+            let obj_lat_vel =
+                obj.velocity_mps * (obj.heading_rad - traj_point.pose.heading_rad).sin();
+            let lateral_cut_in = obj_lat_vel.abs() > RSS_LATERAL_MOTION_EPS_MPS;
+            if dx_ego <= RSS_LONGITUDINAL_CONFLICT_M && (lon_unsafe || lateral_cut_in) {
                 let ego_lat_vel = 0.0; // straight-following assumption per §3
                 let lat_required = lateral_safe_distance(
                     ego_lat_vel,

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -659,3 +659,85 @@ fn predictive_rss_is_a_no_op_when_no_modes_are_supplied() {
     assert_ne!(verdict, TrajectoryVerdict::MRCFallback,
         "with no predicted modes the predictive pass is a no-op; got {verdict:?}");
 }
+
+// ---------------------------------------------------------------------------
+// RSS conjunction (§4): a safe stationary queue is admitted; genuine danger
+// (driving in, or a lateral cut-in) is still rejected. A deterministic SWEEP —
+// property-style coverage of the invariant that the lateral side-RSS only fires
+// on an actual side-collision possibility (abreast OR lateral closing).
+// ---------------------------------------------------------------------------
+
+fn held_ego(x_m: f64) -> Vec<TrajectoryPoint> {
+    (0..3)
+        .map(|i| TrajectoryPoint {
+            pose: Pose { x_m, y_m: 0.0, heading_rad: 0.0 },
+            velocity_mps: 0.0,
+            time_from_start_s: (i as f64) * 0.1,
+        })
+        .collect()
+}
+
+fn stopped_object(x_m: f64, y_m: f64) -> PerceivedObject {
+    PerceivedObject { id: 1, pos: Point { x_m, y_m }, velocity_mps: 0.0, heading_rad: 0.0, vel: Point { x_m: 0.0, y_m: 0.0 } }
+}
+
+#[test]
+fn rss_conjunction_admits_a_safe_stationary_queue() {
+    // INVARIANT (the fix): a STOPPED ego a safe longitudinal distance behind a STOPPED
+    // dead-center object — a stationary queue — is ADMITTED across the whole gap range, not
+    // spuriously MRC'd by the lateral side-RSS (the §4 over-rejection of a safe same-lane stop).
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let ego = held_ego(10.0);
+    for gap_dm in 20..=80 {
+        let gap = gap_dm as f64 / 10.0; // 2.0 .. 8.0 m, 0.1 m steps
+        let objs = [stopped_object(10.0 + gap, 0.0)];
+        let v = validate_trajectory_slow(&ego, &corridor, &objs, &cfg, None, FleetPosture::Nominal);
+        assert_ne!(v, TrajectoryVerdict::MRCFallback, "a stopped queue at gap {gap} m must be admitted, got {v:?}");
+    }
+}
+
+#[test]
+fn rss_conjunction_still_rejects_driving_into_a_stopped_object() {
+    // INVARIANT (safety preserved): an ego at SPEED inside the longitudinal RSS distance of a
+    // stopped object — driving into it — is still MRC'd, across a range of speeds.
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let objs = [stopped_object(30.0, 0.0)];
+    for speed in [3.0, 5.0, 7.0, 9.0] {
+        let into: Vec<TrajectoryPoint> = (0..3)
+            .map(|i| TrajectoryPoint {
+                pose: Pose { x_m: 27.0 + (i as f64), y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: speed,
+                time_from_start_s: (i as f64) * 0.1,
+            })
+            .collect();
+        let v = validate_trajectory_slow(&into, &corridor, &objs, &cfg, None, FleetPosture::Nominal);
+        assert_eq!(v, TrajectoryVerdict::MRCFallback, "driving into a stopped object at {speed} m/s must be MRC'd, got {v:?}");
+    }
+}
+
+#[test]
+fn rss_conjunction_still_rejects_a_lateral_cut_in_at_a_safe_longitudinal_distance() {
+    // INVARIANT (cut-in defense preserved): even with the ego HELD and the object at a SAFE
+    // longitudinal distance (so the longitudinal check alone would pass), an object CLOSING
+    // LATERALLY (a cut-in: nonzero lateral velocity) within the side-gap is still MRC'd — the
+    // fix narrows the lateral check to a genuine side-collision possibility, it does not remove
+    // it. Sweep the lateral approach speed.
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let ego = held_ego(10.0);
+    for lat_speed in [1.0, 2.0, 4.0] {
+        // Object 3 m ahead (longitudinally safe for a stopped ego), 0.3 m to the side, heading
+        // across the ego (lateral velocity component) → a cut-in.
+        let cut_in = PerceivedObject {
+            id: 2,
+            pos: Point { x_m: 13.0, y_m: 0.3 },
+            velocity_mps: lat_speed,
+            heading_rad: std::f64::consts::FRAC_PI_2,
+            vel: Point { x_m: 0.0, y_m: lat_speed },
+        };
+        let v = validate_trajectory_slow(&ego, &corridor, &[cut_in], &cfg, None, FleetPosture::Nominal);
+        assert_eq!(v, TrajectoryVerdict::MRCFallback, "a lateral cut-in at {lat_speed} m/s must be MRC'd, got {v:?}");
+    }
+}


### PR DESCRIPTION
## What

Fixes the actual source of the planner's perceived over-conservatism — which the investigation showed is **KIRRA, not Occy** (every Occy gap sits at KIRRA's admittance floor; loosening any of them MRC-regresses, proven empirically and by the existing doer-checker tests).

For a **safe stationary queue** — the ego stopped a safe longitudinal distance behind a stopped object — the lateral *side-collision* RSS in `validate_trajectory_slow` spuriously fired: `lateral_safe_distance(0,0) ≈ 1 m` from the reaction-time swerve term, so a dead-center follower (`dy≈0`) was MRC'd even though the vehicles are one-behind-the-other at a safe distance, **not abreast**. `COMPETITIVE_PLANNER_ANALYSIS §4` named this.

## Fix — the RSS conjunction

A side collision needs the pair **abreast** (longitudinally unsafe) **or** the object **closing laterally** (a cut-in). So the lateral check now fires only when `lon_unsafe || lateral_cut_in`, in addition to the existing longitudinal-proximity gate. `lon_required` is computed once and shared by both axes; a new constant `RSS_LATERAL_MOTION_EPS_MPS` (0.1) distinguishes a cut-in from a straight lead / stationary queue member.

**Monotone-safe:** this *strictly narrows* the lateral check (an added precondition), so it can only admit longitudinally-safe + laterally-stationary objects (a safe queue) — it can **never** admit a state with lateral motion or abreast danger. The longitudinal (rear-end / head-on) check is unchanged; non-finite inputs still fail closed.

## Validation (property sweeps + the existing suite)

- a stopped ego is **admitted** across the whole safe-gap range (2–8 m) behind a stopped dead-center object — the queue the old check rejected;
- driving **into** a stopped object at speed (3–9 m/s) is still **MRC'd**;
- a lateral **cut-in** at a safe longitudinal distance (1–4 m/s lateral) is still **MRC'd**.

All 78 ros2-adapter + planner + taj + mick tests green; the three tests that *encoded* the old over-rejection are reframed to the corrected behavior (the checker admits the safe stop-behind but still MRCs driving-into; the stack admits the controlled stop; fail-closed is still covered by the LockedOut path).

**Scope:** the SDK's primary checker. The parko-kirra diverse governor has an analogous scene-RSS gate — a consistency follow-up in that separate workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_