### PR TITLE
parko scene-RSS: admit a safe stationary queue (§4 conjunction, consistent with #536)

### DIFF
--- a/parko/crates/parko-core/src/rss.rs
+++ b/parko/crates/parko-core/src/rss.rs
@@ -65,6 +65,17 @@ pub const RSS_LONGITUDINAL_CONFLICT_M: f64 = 8.0;
 /// danger conjunction while each remains a fail-closed layer.)
 pub const RSS_LONGITUDINAL_OVERLAP_M: f64 = 2.5;
 
+/// Object/ego lateral-velocity magnitude (m/s) above which a same-lane object is treated as
+/// **cutting in** (a genuine side-collision risk) rather than a straight-running lead or a
+/// member of a stationary queue. The lateral (side) RSS is the CONJUNCTION partner of the
+/// longitudinal check: a side collision needs the pair ABREAST (longitudinally unsafe) OR
+/// closing laterally. Below this threshold a *longitudinally-safe* object triggers no lateral
+/// veto — admitting a safe same-lane stop (a stopped queue / a stopped lead the ego halts
+/// behind) that the reaction-time swerve term in `lateral_safe_distance` otherwise rejected
+/// (the §4 over-rejection) — while any real lateral closing is still caught. Small, so only
+/// genuine lateral stillness is admitted; the gate fails closed on a non-finite separation first.
+pub const RSS_LATERAL_MOTION_EPS_MPS: f64 = 0.1;
+
 #[inline]
 fn finite_positive(x: f64) -> bool {
     x.is_finite() && x > 0.0

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -51,7 +51,8 @@ use kirra_core::FleetPosture;
 use parko_core::commands::ControlCommand;
 use parko_core::rss::{
     lateral_safe_distance, longitudinal_safe_distance, occlusion_limited_speed,
-    opposite_direction_safe_distance, RSS_LONGITUDINAL_CONFLICT_M, RSS_LONGITUDINAL_OVERLAP_M,
+    opposite_direction_safe_distance, RSS_LATERAL_MOTION_EPS_MPS, RSS_LONGITUDINAL_CONFLICT_M,
+    RSS_LONGITUDINAL_OVERLAP_M,
 };
 use kirra_core::frame_integrity::{resolve_frame_trust, FrameIntegrity, FrameIntegrityCfg, FrameTrust};
 use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
@@ -263,13 +264,30 @@ pub fn compute_scene_rss(scene: &AgentScene, params: &RssParams) -> RssState {
         // Lateral defence-in-depth bounds safety only when the object is also
         // longitudinally CLOSE — a lead well ahead / oncoming traffic safely
         // passing in the next lane is longitudinally distant, so its lateral gap
-        // does not bound safety (it over-rejected before — §4).
+        // does not bound safety (it over-rejected before — §4). And WITHIN that
+        // proximity it bounds safety only when a side collision is actually possible:
+        // the pair ABREAST (longitudinally unsafe) OR closing laterally (a cut-in —
+        // either actor has lateral velocity). A longitudinally-SAFE, laterally-
+        // STATIONARY object — a stopped queue member, or a stopped lead the ego halts
+        // behind — is neither, so it is admitted instead of spuriously vetoed by the
+        // reaction-time swerve term in `lateral_safe_distance` (the §4 over-rejection of
+        // a safe same-lane stop). This strictly NARROWS the lateral veto (an added
+        // precondition), so it can only admit longitudinally-safe + laterally-still pairs
+        // — never a state with lateral motion or abreast danger. Mirrors the kirra-core
+        // checker's RSS-conjunction fix.
         let lat_safe = if !a.actual_lateral_separation_m.is_finite() {
             false
         } else if a.actual_longitudinal_gap_m > RSS_LONGITUDINAL_CONFLICT_M {
             true
         } else {
-            a.actual_lateral_separation_m >= required_lat
+            let lon_unsafe = a.actual_longitudinal_gap_m < required_long;
+            let lateral_cut_in = a.obj_lat_vel.abs() > RSS_LATERAL_MOTION_EPS_MPS
+                || a.ego_lat_vel.abs() > RSS_LATERAL_MOTION_EPS_MPS;
+            if lon_unsafe || lateral_cut_in {
+                a.actual_lateral_separation_m >= required_lat
+            } else {
+                true // longitudinally-safe + laterally-stationary → no side collision possible
+            }
         };
         let pair_safe = lon_safe && lat_safe;
         if !pair_safe {
@@ -1742,6 +1760,41 @@ mod scene_rss_tests {
     fn all_safe_scene_is_safe() {
         let scene = AgentScene::Agents(vec![safe_agent(), safe_agent(), safe_agent()]);
         assert!(compute_scene_rss(&scene, &params()).safe);
+    }
+
+    #[test]
+    fn rss_conjunction_admits_a_safe_stationary_queue() {
+        // The §4 RSS-conjunction fix (mirroring the kirra-core checker): a stopped ego a safe
+        // longitudinal distance behind a stopped object — within the 8 m proximity band,
+        // dead-center — is now SAFE. The lateral side-RSS no longer vetoes a longitudinally-safe,
+        // laterally-stationary pair via the reaction-time swerve term.
+        let queue = RssAgent {
+            ego_vel: 0.0,
+            lead_vel: 0.0,
+            actual_longitudinal_gap_m: 4.0, // safe for two stopped vehicles, within 8 m
+            ego_lat_vel: 0.0,
+            obj_lat_vel: 0.0,
+            actual_lateral_separation_m: 0.0, // dead center
+            oncoming: false,
+        };
+        assert!(
+            compute_scene_rss(&AgentScene::Agents(vec![queue]), &params()).safe,
+            "a stopped queue (longitudinally safe, laterally still) must be admitted"
+        );
+
+        // The veto only NARROWS for genuine stillness — the same close, dead-center pair is
+        // STILL unsafe if it is closing laterally (a cut-in) ...
+        let cut_in = RssAgent { ego_lat_vel: 2.0, obj_lat_vel: 2.0, ..queue };
+        assert!(
+            !compute_scene_rss(&AgentScene::Agents(vec![cut_in]), &params()).safe,
+            "the same close dead-center pair CLOSING laterally is still vetoed"
+        );
+        // ... or longitudinally unsafe (abreast).
+        let abreast = RssAgent { actual_longitudinal_gap_m: 0.2, ..queue };
+        assert!(
+            !compute_scene_rss(&AgentScene::Agents(vec![abreast]), &params()).safe,
+            "a longitudinally-unsafe (abreast) pair is still vetoed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Applies the kirra-core RSS-conjunction fix (#536) to the **diverse governor's** scene RSS, so the two independent checkers agree on a safe stationary queue (and the divergence→posture comparator from #537 won't spuriously flag the difference).

`compute_scene_rss` had the **same §4 over-rejection**: within the 8 m longitudinal-conflict band the lateral side-RSS vetoed any pair whose lateral separation fell below `required_lat` — and `lateral_safe_distance(0,0) ≈ 1 m` from the reaction-time swerve term, so a **stopped ego dead-center behind a stopped object (a safe queue)** was vetoed even though the two are one-behind-the-other at a safe distance, **not abreast**.

## Fix (mirrors `validate_trajectory_slow`)

Within the proximity band, the lateral veto fires only when a side collision is actually possible — the pair **abreast** (`actual_gap < required_long`) **or** **closing laterally** (a cut-in: either `ego_lat_vel` or `obj_lat_vel` beyond the new `RSS_LATERAL_MOTION_EPS_MPS = 0.1`). A longitudinally-safe, laterally-stationary pair is neither → admitted. New constant in `parko-core::rss` alongside the existing band constants.

**Monotone-safe:** strictly narrows the lateral veto (an added precondition), so it can only admit longitudinally-safe + laterally-still pairs — never a state with lateral motion or abreast danger. The longitudinal (rear-end / head-on) gate is unchanged; each axis still fails closed first on a non-finite input.

## Tests

A safe stationary queue (stopped, dead-center, within 8 m) is now admitted; the same close dead-center pair **closing laterally** is still vetoed; a **longitudinally-unsafe (abreast)** pair is still vetoed. The existing `lat_unsafe_agent` (a 2 m/s lateral cut-in) and the longitudinal tests are unchanged.

parko-kirra (158 lib) + parko-core green; clippy `--all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_