### PR TITLE
parko: close the divergence→posture loop in the node tick

### DIFF
--- a/parko/crates/parko-core/src/safety.rs
+++ b/parko/crates/parko-core/src/safety.rs
@@ -65,11 +65,57 @@ pub trait SafetyGovernor: Send + Sync {
         delta_time_s: f64,
         posture: SafetyPosture,
     ) -> EnforcementAction;
+
+    /// The fleet posture this governor RECOMMENDS based on its internal state — the seam that
+    /// lets a governor drive posture, not just clamp the current command. Default `Nominal`
+    /// (a plain governor recommends nothing); a redundancy comparator overrides it to escalate
+    /// to `Degraded` / `LockedOut` on persistent disagreement. The runtime reads this after a
+    /// tick and ESCALATES the effective posture with it (`posture.escalate(recommended)`).
+    fn recommended_posture(&self) -> SafetyPosture {
+        SafetyPosture::Nominal
+    }
+}
+
+impl SafetyPosture {
+    /// Severity rank — higher is more restrictive: `Nominal` < `Degraded` < `LockedOut`.
+    #[must_use]
+    pub fn severity(self) -> u8 {
+        match self {
+            SafetyPosture::Nominal => 0,
+            SafetyPosture::Degraded => 1,
+            SafetyPosture::LockedOut => 2,
+        }
+    }
+
+    /// The MORE restrictive of two postures — escalation-only combine (a posture can be made
+    /// stricter by a fault signal, never relaxed).
+    #[must_use]
+    pub fn escalate(self, other: SafetyPosture) -> SafetyPosture {
+        if other.severity() > self.severity() {
+            other
+        } else {
+            self
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn posture_escalate_takes_the_more_restrictive_and_a_plain_governor_recommends_nominal() {
+        use SafetyPosture::{Degraded, LockedOut, Nominal};
+        // Escalation-only: the result is the more severe of the two, in either order; equal is a no-op.
+        assert_eq!(Nominal.escalate(Degraded), Degraded);
+        assert_eq!(Degraded.escalate(Nominal), Degraded);
+        assert_eq!(Degraded.escalate(LockedOut), LockedOut);
+        assert_eq!(LockedOut.escalate(Degraded), LockedOut);
+        assert_eq!(Nominal.escalate(Nominal), Nominal);
+        assert!(Nominal.severity() < Degraded.severity() && Degraded.severity() < LockedOut.severity());
+        // The trait default recommends nothing (a plain governor drives no posture escalation).
+        assert_eq!(AllowAllGovernor.recommended_posture(), Nominal);
+    }
 
     /// Test governor that allows everything.
     struct AllowAllGovernor;

--- a/parko/crates/parko-core/src/scheduler.rs
+++ b/parko/crates/parko-core/src/scheduler.rs
@@ -106,6 +106,18 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
         self
     }
 
+    /// The posture the attached governor RECOMMENDS from its internal state (e.g. a redundancy
+    /// comparator escalating to `Degraded` / `LockedOut` on persistent divergence); `Nominal`
+    /// when no governor is attached. The tick driver reads this each cycle and escalates the
+    /// effective posture with it — closing the divergence→posture loop so a governor
+    /// disagreement actually drives the fleet posture, not just this tick's clamp.
+    #[must_use]
+    pub fn recommended_posture(&self) -> SafetyPosture {
+        self.governor
+            .as_ref()
+            .map_or(SafetyPosture::Nominal, |g| g.recommended_posture())
+    }
+
     /// Set the tick period (used for time-delta calculations passed to
     /// the safety governor). Defaults to 0.05 (20Hz).
     pub fn with_tick_period(mut self, tick_period_s: f64) -> Self {

--- a/parko/crates/parko-onnx/tests/test_onnx_backend.rs
+++ b/parko/crates/parko-onnx/tests/test_onnx_backend.rs
@@ -59,6 +59,34 @@ fn mnist_end_to_end_inference() {
         assert!(s.is_finite(), "non-finite score at index {}: {}", i, s);
     }
 
+    // Golden-output regression pin. Finiteness + shape prove the inference path
+    // *runs*; they do NOT prove it computes the right thing — a transposed input,
+    // a wrong-weights load, or an ABI/layout drift in a future ONNX Runtime can
+    // still emit ten finite scores. With an all-zeros input the MNIST-12 graph is
+    // deterministic (the output is the trailing-layer bias propagated through the
+    // fixed weights), so the logits are a stable fingerprint of correct numerics.
+    //
+    // Captured from a known-green CI run (ORT 1.23.2, CPU EP — the exact pair this
+    // job installs). The tolerance is wide enough to absorb last-ULP CPU/version
+    // float drift yet far tighter than any real numerics regression: a genuine
+    // layout/weights fault shifts these logits by O(0.1+), orders of magnitude
+    // past 1e-2, while the values themselves sit in [-0.13, 0.14]. This pins ORT's
+    // numerics INDEPENDENTLY of the parko-openvino cross-backend equivalence test
+    // (which only catches an ORT/OV *divergence*), so an identical drift in both —
+    // or a skipped OpenVINO job — can no longer pass silently here.
+    const GOLDEN: [f32; 10] = [
+        -0.044856027, 0.007791661, 0.06810082, 0.02999374, -0.12640963, 0.14021875,
+        -0.055284902, -0.049383815, 0.08432205, -0.054540414,
+    ];
+    const TOL: f32 = 1e-2;
+    for (i, (got, want)) in scores.iter().zip(GOLDEN.iter()).enumerate() {
+        assert!(
+            (got - want).abs() <= TOL,
+            "MNIST logit regression at class {i}: got {got}, golden {want}, |Δ|>{TOL} \
+             (an all-zeros-input numerics drift — suspect input layout / weights / ORT ABI)"
+        );
+    }
+
     println!("MNIST inference successful. Output: {:?}", scores);
 }
 

--- a/parko/crates/parko-ros2/src/comparator_adapter.rs
+++ b/parko/crates/parko-ros2/src/comparator_adapter.rs
@@ -35,16 +35,12 @@ impl<S: SafetyGovernor> SafetyGovernor for ComparatorAsGovernor<S> {
     ) -> EnforcementAction {
         self.0.evaluate(proposed, previous, delta_time_s, posture)
     }
-}
 
-impl<S: SafetyGovernor> ComparatorAsGovernor<S> {
-    /// The fleet posture the wrapped comparator's divergence state recommends (see
-    /// [`GovernorComparator::recommended_posture`]). The node reads this after a tick and
-    /// drives the posture engine with it — the seam that turns governor disagreement into a
-    /// live safety posture (`Degraded`, then `LockedOut` when persistent), not just an audit
-    /// line. Escalation-only at the node: `posture = max(posture, governor.recommended_posture())`.
-    #[must_use]
-    pub fn recommended_posture(&self) -> SafetyPosture {
+    /// Surface the wrapped comparator's divergence-derived posture through the `SafetyGovernor`
+    /// trait, so the runtime (which holds a `dyn SafetyGovernor`) can read it after a tick and
+    /// ESCALATE the effective posture — the seam that turns governor disagreement into a live
+    /// safety posture (`Degraded`, then `LockedOut` when persistent), not just an audit line.
+    fn recommended_posture(&self) -> SafetyPosture {
         self.0.recommended_posture()
     }
 }

--- a/parko/crates/parko-ros2/src/tick_pipeline.rs
+++ b/parko/crates/parko-ros2/src/tick_pipeline.rs
@@ -154,7 +154,12 @@ where
     //     `GovernorComparator`) before stamping `active_command`.
     let tick_result = {
         let mut guard = loop_mutex.lock().await;
-        guard.tick(frame, posture).await
+        // Close the divergence→posture loop: a governor that recommends a stricter posture (the
+        // redundancy comparator escalating to Degraded / LockedOut on persistent disagreement)
+        // ESCALATES the effective posture this tick. Escalation-only — it can make the posture
+        // stricter than the source's verdict, never relax it. `Nominal` for a plain governor.
+        let effective_posture = posture.escalate(guard.recommended_posture());
+        guard.tick(frame, effective_posture).await
     };
 
     match tick_result {
@@ -229,6 +234,44 @@ mod tick_pipeline_tests {
         (Arc::new(Mutex::new(infer)), rx)
     }
 
+    /// Build an InferenceLoop with an arbitrary governor (for the divergence→posture test).
+    fn build_loop_with<G: parko_core::safety::SafetyGovernor + 'static>(
+        governor: G,
+        linear_out: f32,
+        angular_out: f32,
+    ) -> Arc<Mutex<InferenceLoop<MockBackend>>> {
+        let mut outputs: HashMap<String, Vec<f32>> = HashMap::new();
+        outputs.insert("cmd_vel_linear".to_string(), vec![linear_out]);
+        outputs.insert("cmd_vel_angular".to_string(), vec![angular_out]);
+        let backend = Arc::new(MockBackend::new(outputs, BackendDescriptor::Cpu));
+        let model = backend.load_model("test.onnx").expect("mock model loads");
+        let (tx, _rx) = mpsc::channel::<ControlCommand>(8);
+        let infer = InferenceLoop::new(backend, model, tx).with_governor(governor).with_tick_period(0.05);
+        Arc::new(Mutex::new(infer))
+    }
+
+    /// A governor that always recommends a fixed posture and stops the command only at LockedOut
+    /// (the relevant slice of a real governor's behaviour for the loop-closing test).
+    struct RecommendsPosture(parko_core::safety::SafetyPosture);
+    impl parko_core::safety::SafetyGovernor for RecommendsPosture {
+        fn evaluate(
+            &self,
+            _proposed: &ControlCommand,
+            _previous: Option<&ControlCommand>,
+            _delta_time_s: f64,
+            posture: SafetyPosture,
+        ) -> parko_core::safety::EnforcementAction {
+            if posture == SafetyPosture::LockedOut {
+                parko_core::safety::EnforcementAction::Deny { reason: "locked out".into() }
+            } else {
+                parko_core::safety::EnforcementAction::Allow
+            }
+        }
+        fn recommended_posture(&self) -> SafetyPosture {
+            self.0
+        }
+    }
+
     fn make_frame(frame_id: u64, age_ms: u64) -> SensorFrame {
         let now = current_time_ms();
         SensorFrame {
@@ -267,6 +310,33 @@ mod tick_pipeline_tests {
             outcome.twist.linear_x_mps);
         assert!((outcome.twist.angular_z_rads - 0.2).abs() < 1e-4,
             "expected angular ~0.2, got {}", outcome.twist.angular_z_rads);
+    }
+
+    // ---- divergence→posture: the governor's recommendation escalates the tick ----
+
+    #[tokio::test(start_paused = true)]
+    async fn governor_recommendation_escalates_the_effective_posture() {
+        // The CLOSED loop: a governor recommending LockedOut escalates the EFFECTIVE posture even
+        // though the source posture is Nominal — so the LockedOut clamp fires and the tick
+        // publishes a STOPPED twist. (Without the loop, evaluate(Nominal) would Allow the
+        // 0.1 m/s command through.) This is the integrator step the #537 seam was built for.
+        let infer = build_loop_with(RecommendsPosture(SafetyPosture::LockedOut), 0.1, 0.2);
+        let outcome = run_pipeline_tick(&default_config(), infer, make_frame(1, 0), SafetyPosture::Nominal).await;
+        assert!(
+            outcome.twist.linear_x_mps.abs() < 1e-6,
+            "a LockedOut RECOMMENDATION escalated the Nominal source → stopped twist, got linear {}",
+            outcome.twist.linear_x_mps
+        );
+
+        // Control: a Nominal recommendation does NOT escalate — the command passes (the loop only
+        // ESCALATES the posture, it never fabricates a stop).
+        let infer2 = build_loop_with(RecommendsPosture(SafetyPosture::Nominal), 0.1, 0.2);
+        let outcome2 = run_pipeline_tick(&default_config(), infer2, make_frame(2, 0), SafetyPosture::Nominal).await;
+        assert!(
+            outcome2.twist.linear_x_mps.abs() > 1e-6,
+            "a Nominal recommendation leaves the command alone, got linear {}",
+            outcome2.twist.linear_x_mps
+        );
     }
 
     /// First-tick acceleration clamp invariant — also useful: the


### PR DESCRIPTION
## What

#537 produced the divergence-derived posture and exposed it on the comparator adapter; this **consumes it in the runtime tick**, so a governor disagreement now actually **drives the fleet posture**, not just clamps the current command. Closes the loop the #537 seam was built for.

## Changes

- **parko-core `SafetyGovernor`** — a new `recommended_posture()` trait method, default `Nominal` (a plain governor recommends nothing), so the runtime — which holds a `dyn SafetyGovernor` — can read it generically.
- **parko-core `SafetyPosture`** — `severity()` (`Nominal` < `Degraded` < `LockedOut`) + `escalate()`, the escalation-only combine (a posture can be made stricter by a fault signal, never relaxed).
- **parko-core `InferenceLoop`** — `recommended_posture()` surfaces the attached governor's recommendation (`Nominal` when none attached).
- **parko-ros2 `ComparatorAsGovernor`** — the recommendation passthrough is now the `SafetyGovernor` *trait* method (was inherent), so it dispatches through the loop's trait object.
- **parko-ros2 `run_pipeline_tick_inner`** — each tick the effective posture is `posture.escalate(guard.recommended_posture())` before the governor runs. **The loop is closed.** Escalation-only: it can make the posture stricter than the source's verdict, never relax it.

So persistent governor divergence → the comparator recommends `Degraded` then `LockedOut` → the tick escalates the effective posture → the LockedOut clamp fires **fleet-wide**, not just the per-command clamp the comparator already applied.

## Tests

`escalate`/`severity` + the trait-default `Nominal` (parko-core); the **tick-level closure** (parko-ros2): a `LockedOut` *recommendation* escalates a `Nominal` source → **stopped twist**, while a `Nominal` recommendation leaves the command alone (escalate-only, never fabricates a stop).

parko-core + parko-kirra + parko-ros2 green; clippy `--all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_