### PR TITLE
ML doer/checker depth: perception eval harness + a maneuvering learned planner

### DIFF
--- a/crates/kirra-planner/src/learned.rs
+++ b/crates/kirra-planner/src/learned.rs
@@ -21,6 +21,11 @@ use crate::{PlanInput, PlanOutput, Planner, Pose, ProposalKind, TrajectoryPoint}
 const IN: usize = 4; // features
 const H: usize = 8; // hidden units
 const K: usize = 4; // vocabulary size
+/// ES steps for the speed-only scorer (4 outputs).
+const SPEED_FIT_ITERS: usize = 6000;
+/// ES steps for the maneuver scorer — the 2-D vocabulary is 3× wider (12 outputs), so it gets
+/// a larger optimization budget to fit the per-candidate map well enough for a correct argmax.
+const MANEUVER_FIT_ITERS: usize = 14_000;
 const HORIZON: usize = 50; // == MAX_TRAJECTORY_HORIZON (KIRRA's WCET cap)
 const DT: f64 = 0.1;
 const ACCEL: f64 = 1.2; // m/s^2 toward a candidate's target speed
@@ -88,39 +93,57 @@ fn featurize(s: &Scene) -> [f64; IN] {
     [s.ego_speed / 8.0, goal_dist / 50.0, obj_dist / 50.0, present]
 }
 
-/// The teacher's score for one candidate — the signal the scorer is distilled to predict.
+/// Progress term: fraction of the max attainable forward travel the trajectory achieves.
+fn progress_of(traj: &[TrajectoryPoint], ego_x: f64) -> f64 {
+    (traj.last().unwrap().pose.x_m - ego_x) / (HORIZON as f64 * DT * TARGET_SPEEDS[K - 1])
+}
+
+/// The safety-aware hazard penalty (`0` for `ProgressOnly`, or no obstacle): heavy for a
+/// collision (< 1.5 m), graded for approaching within `MARGIN`. The min-gap is measured to the
+/// obstacle on the centerline, so a path that eases laterally away EARNS clearance — the same
+/// term that rewards slowing also rewards routing around, which is what lets the 2-D
+/// [`LearnedManeuverPlanner`] learn the pass.
+fn hazard_penalty(traj: &[TrajectoryPoint], scene: &Scene, teacher: Teacher, margin: f64) -> f64 {
+    let Some(ox) = scene.obstacle_x else { return 0.0 };
+    if teacher != Teacher::SafetyAware {
+        return 0.0;
+    }
+    let min_gap = traj.iter().map(|p| (p.pose.x_m - ox).hypot(p.pose.y_m)).fold(f64::MAX, f64::min);
+    if min_gap < 1.5 {
+        -5.0 // collision
+    } else if min_gap < margin {
+        -(1.0 - min_gap / margin) // approach-at-distance
+    } else {
+        0.0
+    }
+}
+
+/// The teacher's score for one speed-only candidate — the signal the scorer is distilled to
+/// predict. Uses the conservative `MARGIN`: with only a speed knob, "keep your distance" means
+/// slow down, so a wide safe margin is what teaches the safety-aware net to brake early.
 fn teacher_score(s: &Scene, target: f64, teacher: Teacher) -> f64 {
     let traj = materialize(s, target);
-    let progress = (traj.last().unwrap().pose.x_m - s.ego_x) / (HORIZON as f64 * DT * TARGET_SPEEDS[K - 1]);
-    let mut score = progress;
-    if let (Teacher::SafetyAware, Some(ox)) = (teacher, s.obstacle_x) {
-        let min_gap = traj
-            .iter()
-            .map(|p| (p.pose.x_m - ox).hypot(p.pose.y_m))
-            .fold(f64::MAX, f64::min);
-        if min_gap < 1.5 {
-            score -= 5.0; // collision
-        } else if min_gap < MARGIN {
-            score -= 1.0 * (1.0 - min_gap / MARGIN); // approach-at-distance
-        }
-    }
-    score
+    progress_of(&traj, s.ego_x) + hazard_penalty(&traj, s, teacher, MARGIN)
 }
 
 // ----------------------------------------------------------------------------
 // The learned scorer: a small MLP, weights fit by a seeded (1+1)-ES
 // ----------------------------------------------------------------------------
 
+/// A small two-layer MLP scorer, generic over its output width `M` (the vocabulary
+/// size). `M = K` for the speed-only [`LearnedPlanner`]; `M = MANEUVER_K` for the 2-D
+/// [`LearnedManeuverPlanner`]. The arithmetic and the RNG draw order are identical for a
+/// given `M`, so generalizing the width does not perturb either planner's trained weights.
 #[derive(Clone, Copy)]
-struct Mlp {
+struct Mlp<const M: usize> {
     w1: [[f64; IN]; H],
     b1: [f64; H],
-    w2: [[f64; H]; K],
-    b2: [f64; K],
+    w2: [[f64; H]; M],
+    b2: [f64; M],
 }
 
-impl Mlp {
-    fn forward(&self, x: &[f64; IN]) -> [f64; K] {
+impl<const M: usize> Mlp<M> {
+    fn forward(&self, x: &[f64; IN]) -> [f64; M] {
         let mut h = [0.0; H];
         for (hj, (w1row, b1j)) in h.iter_mut().zip(self.w1.iter().zip(self.b1.iter())) {
             let mut a = *b1j;
@@ -129,7 +152,7 @@ impl Mlp {
             }
             *hj = a.tanh();
         }
-        let mut y = [0.0; K];
+        let mut y = [0.0; M];
         for (yk, (w2row, b2k)) in y.iter_mut().zip(self.w2.iter().zip(self.b2.iter())) {
             let mut a = *b2k;
             for (w, hj) in w2row.iter().zip(h.iter()) {
@@ -188,10 +211,59 @@ impl Rng {
     }
 }
 
+/// One synthetic training scene: ego at the origin, goal far ahead, a hazard present ~60% of
+/// the time at a random distance. The RNG draw order is fixed here so both planners train on
+/// the SAME scene stream for a given seed (only their per-candidate labels differ).
+fn training_scene(rng: &mut Rng) -> Scene {
+    Scene {
+        ego_x: 5.0,
+        ego_y: 0.0,
+        ego_speed: rng.range(0.0, 4.0),
+        goal_x: 40.0,
+        goal_y: 0.0,
+        obstacle_x: if rng.unit() < 0.6 { Some(rng.range(12.0, 35.0)) } else { None },
+    }
+}
+
+/// Fit an `Mlp<M>` to labelled `(features, per-candidate score)` data by a seeded `(1+1)`
+/// evolution strategy (anneal σ 0.22 → 0.02 over 6000 steps). Deterministic given the RNG
+/// state; shared by both learned planners so the speed-only and maneuvering scorers are fit by
+/// the identical optimizer.
+fn fit<const M: usize>(rng: &mut Rng, data: &[([f64; IN], [f64; M])], iters: usize) -> Mlp<M> {
+    let loss = |m: &Mlp<M>| -> f64 {
+        let mut acc = 0.0;
+        for (x, y) in data {
+            let p = m.forward(x);
+            for k in 0..M {
+                let e = p[k] - y[k];
+                acc += e * e;
+            }
+        }
+        acc / (data.len() * M) as f64
+    };
+
+    // Small random init.
+    let mut best = Mlp::<M> { w1: [[0.0; IN]; H], b1: [0.0; H], w2: [[0.0; H]; M], b2: [0.0; M] };
+    best.perturb(rng, 0.3);
+    let mut best_loss = loss(&best);
+
+    for t in 0..iters {
+        let sigma = 0.2 * (1.0 - t as f64 / iters as f64) + 0.02; // anneal 0.22 → 0.02
+        let mut cand = best;
+        cand.perturb(rng, sigma);
+        let l = loss(&cand);
+        if l < best_loss {
+            best = cand;
+            best_loss = l;
+        }
+    }
+    best
+}
+
 /// A learned planner: the trajectory vocabulary `TARGET_SPEEDS`, scored by a small
 /// MLP distilled from `teacher`. Construct with [`LearnedPlanner::trained`].
 pub struct LearnedPlanner {
-    scorer: Mlp,
+    scorer: Mlp<K>,
     teacher: Teacher,
 }
 
@@ -206,14 +278,7 @@ impl LearnedPlanner {
         // teacher's per-candidate score vector.
         let mut data: Vec<([f64; IN], [f64; K])> = Vec::new();
         for _ in 0..160 {
-            let scene = Scene {
-                ego_x: 5.0,
-                ego_y: 0.0,
-                ego_speed: rng.range(0.0, 4.0),
-                goal_x: 40.0,
-                goal_y: 0.0,
-                obstacle_x: if rng.unit() < 0.6 { Some(rng.range(12.0, 35.0)) } else { None },
-            };
+            let scene = training_scene(&mut rng);
             let feats = featurize(&scene);
             let mut label = [0.0; K];
             for k in 0..K {
@@ -222,36 +287,7 @@ impl LearnedPlanner {
             data.push((feats, label));
         }
 
-        let loss = |m: &Mlp| -> f64 {
-            let mut acc = 0.0;
-            for (x, y) in &data {
-                let p = m.forward(x);
-                for k in 0..K {
-                    let e = p[k] - y[k];
-                    acc += e * e;
-                }
-            }
-            acc / (data.len() * K) as f64
-        };
-
-        // Small random init.
-        let mut best = Mlp { w1: [[0.0; IN]; H], b1: [0.0; H], w2: [[0.0; H]; K], b2: [0.0; K] };
-        best.perturb(&mut rng, 0.3);
-        let mut best_loss = loss(&best);
-
-        let iters = 6000;
-        for t in 0..iters {
-            let sigma = 0.2 * (1.0 - t as f64 / iters as f64) + 0.02; // anneal 0.22 → 0.02
-            let mut cand = best;
-            cand.perturb(&mut rng, sigma);
-            let l = loss(&cand);
-            if l < best_loss {
-                best = cand;
-                best_loss = l;
-            }
-        }
-
-        LearnedPlanner { scorer: best, teacher }
+        LearnedPlanner { scorer: fit(&mut rng, &data, SPEED_FIT_ITERS), teacher }
     }
 
     /// The teacher this planner was distilled from (audit / test introspection).
@@ -259,35 +295,37 @@ impl LearnedPlanner {
         self.teacher
     }
 
-    fn scene_of(input: &PlanInput) -> Scene {
-        let ego = input.ego.pose;
-        let goal = input.goal.target;
-        // Nearest object ahead along +x (the demo road frame).
-        let obstacle_x = input
-            .objects
-            .iter()
-            .map(|o| o.pos.x_m)
-            .filter(|&x| x > ego.x_m)
-            .fold(None, |acc: Option<f64>, x| Some(acc.map_or(x, |a| a.min(x))));
-        Scene { ego_x: ego.x_m, ego_y: ego.y_m, ego_speed: input.ego.linear_x_mps, goal_x: goal.x_m, goal_y: goal.y_m, obstacle_x }
-    }
-
     /// The vocabulary index the scorer ranks highest for `input` (test introspection).
     pub fn chosen_index(&self, input: &PlanInput) -> usize {
-        let scores = self.scorer.forward(&featurize(&Self::scene_of(input)));
+        let scores = self.scorer.forward(&featurize(&scene_of(input)));
         argmax(&scores)
     }
 }
 
 impl Planner for LearnedPlanner {
     fn plan(&mut self, input: &PlanInput<'_>) -> PlanOutput {
-        let scene = Self::scene_of(input);
+        let scene = scene_of(input);
         let best = argmax(&self.scorer.forward(&featurize(&scene)));
         PlanOutput { trajectory: materialize(&scene, TARGET_SPEEDS[best]), kind: ProposalKind::Motion }
     }
 }
 
-fn argmax(v: &[f64; K]) -> usize {
+/// Extract the scorer's primitive [`Scene`] from a `PlanInput` — shared by both learned
+/// planners. Nearest object ahead along +x (the demo road frame, obstacle assumed on the
+/// centerline so the lateral gap is the path's own `y`).
+fn scene_of(input: &PlanInput) -> Scene {
+    let ego = input.ego.pose;
+    let goal = input.goal.target;
+    let obstacle_x = input
+        .objects
+        .iter()
+        .map(|o| o.pos.x_m)
+        .filter(|&x| x > ego.x_m)
+        .fold(None, |acc: Option<f64>, x| Some(acc.map_or(x, |a| a.min(x))));
+    Scene { ego_x: ego.x_m, ego_y: ego.y_m, ego_speed: input.ego.linear_x_mps, goal_x: goal.x_m, goal_y: goal.y_m, obstacle_x }
+}
+
+fn argmax<const M: usize>(v: &[f64; M]) -> usize {
     let mut best = 0;
     for (k, &val) in v.iter().enumerate() {
         if val > v[best] {
@@ -295,4 +333,140 @@ fn argmax(v: &[f64; K]) -> usize {
         }
     }
     best
+}
+
+// ============================================================================
+// The 2-D maneuvering planner: a real Hydra-MDP trajectory vocabulary
+// ============================================================================
+//
+// The speed-only LearnedPlanner above proved the thesis (KIRRA bounds a learned doer) but
+// its vocabulary is four STRAIGHT-line speeds — it can only pick how fast to drive at the
+// goal, never a path. Real Hydra-MDP scores a vocabulary of diverse trajectory *shapes*. This
+// generalizes to a 2-D vocabulary (lateral offset × speed), so the learned scorer can choose
+// to ROUTE AROUND a hazard. KIRRA stays the bound: a pass that fits the corridor is admitted,
+// one that does not is rejected → safe-stop. Same MLP, same teacher, same seam.
+
+/// Lateral pass offsets the vocabulary chooses among (m, +Y left). `0` = straight ahead;
+/// `±4.5` clears KIRRA's 4 m RSS lateral-alignment band, so a pass is RSS-filtered rather than
+/// longitudinally MRC'd (the same 4 m band #536/#451 turn on). A pass only *fits* where the
+/// corridor is wide enough for the offset — else KIRRA rejects it (honest: a narrow road
+/// cannot admit a >4 m pass).
+const LATERAL_OFFSETS: [f64; 3] = [0.0, 4.5, -4.5];
+/// Vocabulary size: every (lateral offset, target speed) pair.
+const MANEUVER_K: usize = LATERAL_OFFSETS.len() * K;
+/// Forward distance over which a candidate eases to its lateral offset, then holds it.
+const TRANSITION_M: f64 = 12.0;
+
+/// Smoothstep on `[0,1]` (clamped) — the lateral easing profile (C¹, zero end-slopes).
+fn smoothstep01(t: f64) -> f64 {
+    let t = t.clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// Candidate index → `(lateral offset, target speed)`. Offset-major so index `0` is
+/// `(straight, stop)` and the straight-ahead candidates occupy the first `K` slots.
+fn maneuver_candidate(c: usize) -> (f64, f64) {
+    (LATERAL_OFFSETS[c / K], TARGET_SPEEDS[c % K])
+}
+
+/// Materialize a 2-D candidate: forward progress under the speed profile while easing the
+/// lateral position to `offset` over the first [`TRANSITION_M`] and holding it — a
+/// lane-change-and-stay shape, heading following the path tangent. Within the horizon cap, so
+/// any KIRRA rejection is about the hazard / corridor fit, not the shape.
+fn materialize_maneuver(s: &Scene, offset: f64, target: f64) -> Vec<TrajectoryPoint> {
+    let mut x = s.ego_x;
+    let mut v = s.ego_speed.max(0.0);
+    let mut prev = (s.ego_x, s.ego_y);
+    (0..HORIZON)
+        .map(|i| {
+            let y = s.ego_y + offset * smoothstep01((x - s.ego_x) / TRANSITION_M);
+            let heading = if i == 0 { 0.0 } else { (y - prev.1).atan2((x - prev.0).max(1e-6)) };
+            let p = TrajectoryPoint {
+                pose: Pose { x_m: x, y_m: y, heading_rad: heading },
+                velocity_mps: v,
+                time_from_start_s: i as f64 * DT,
+            };
+            prev = (x, y);
+            x += v * DT;
+            let step = (ACCEL * DT).min((target - v).abs());
+            v = (v + step * (target - v).signum()).max(0.0);
+            p
+        })
+        .collect()
+}
+
+/// Per-metre cost of a candidate's TERMINAL lateral offset. Forward progress alone is blind to
+/// lateral offset (the path advances in x regardless), so without this both teachers would be
+/// indifferent to a gratuitous detour. A small cost makes straight the default — a pass is
+/// preferred ONLY when its clearance avoids a hazard penalty (which dwarfs it); it never speeds
+/// the vehicle laterally for nothing. Crucially this means a progress-only (misaligned) net
+/// still barrels STRAIGHT through, exactly as in the speed-only demo.
+const LATERAL_DETOUR_COST: f64 = 0.05;
+
+/// The maneuver teacher's safe-clearance margin (m). Unlike the speed-only `MARGIN` (10 m, "keep
+/// far"), this is aligned with KIRRA's 4 m RSS lateral-alignment band: a pass that clears the
+/// band is genuinely safe, so the teacher must NOT keep penalizing it (else it would always
+/// prefer slowing to passing, and the route-around would never be learned). A `LATERAL_OFFSETS`
+/// pass of ±4.5 m clears this, so the safety-aware net learns the pass is both safe AND faster.
+const MANEUVER_CLEAR_MARGIN: f64 = 4.0;
+
+/// The teacher's score for one 2-D candidate. The speed-only teacher's progress + [`hazard_penalty`]
+/// shape, over the maneuvered path (so a candidate easing laterally clear of the hazard earns the
+/// clearance the penalty rewards — what teaches the safety-aware net to PASS, not just slow), minus
+/// a small terminal-offset cost so the pass is never gratuitous. The penalty uses the KIRRA-aligned
+/// [`MANEUVER_CLEAR_MARGIN`] so a band-clearing pass is scored safe.
+fn teacher_score_maneuver(s: &Scene, offset: f64, target: f64, teacher: Teacher) -> f64 {
+    let traj = materialize_maneuver(s, offset, target);
+    let terminal_offset = (traj.last().unwrap().pose.y_m - s.ego_y).abs();
+    progress_of(&traj, s.ego_x) - LATERAL_DETOUR_COST * terminal_offset
+        + hazard_penalty(&traj, s, teacher, MANEUVER_CLEAR_MARGIN)
+}
+
+/// A **maneuvering** learned planner — [`LearnedPlanner`] generalized to a real 2-D
+/// Hydra-MDP trajectory vocabulary (lateral offset × speed). The learned scorer can now route
+/// AROUND a hazard, not merely slow for it; KIRRA remains the invariant bound. Distilled from
+/// the same [`Teacher`] by the same optimizer ([`fit`]) over the same scene stream.
+pub struct LearnedManeuverPlanner {
+    scorer: Mlp<MANEUVER_K>,
+    teacher: Teacher,
+}
+
+impl LearnedManeuverPlanner {
+    /// Fit the 2-D scorer to `teacher` by the shared seeded `(1+1)`-ES. Deterministic: same
+    /// `(seed, teacher)` → same weights. Trains on the SAME synthetic scenes as
+    /// [`LearnedPlanner::trained`] (only the per-candidate labels differ — 12 candidates here).
+    pub fn trained(seed: u64, teacher: Teacher) -> Self {
+        let mut rng = Rng::new(seed);
+        let mut data: Vec<([f64; IN], [f64; MANEUVER_K])> = Vec::new();
+        for _ in 0..180 {
+            let scene = training_scene(&mut rng);
+            let feats = featurize(&scene);
+            let mut label = [0.0; MANEUVER_K];
+            for (c, slot) in label.iter_mut().enumerate() {
+                let (off, spd) = maneuver_candidate(c);
+                *slot = teacher_score_maneuver(&scene, off, spd, teacher);
+            }
+            data.push((feats, label));
+        }
+        LearnedManeuverPlanner { scorer: fit(&mut rng, &data, MANEUVER_FIT_ITERS), teacher }
+    }
+
+    /// The teacher this planner was distilled from (audit / test introspection).
+    pub fn teacher(&self) -> Teacher {
+        self.teacher
+    }
+
+    /// The `(lateral offset, target speed)` the scorer ranks highest for `input` (introspection).
+    #[must_use]
+    pub fn chosen_candidate(&self, input: &PlanInput) -> (f64, f64) {
+        maneuver_candidate(argmax(&self.scorer.forward(&featurize(&scene_of(input)))))
+    }
+}
+
+impl Planner for LearnedManeuverPlanner {
+    fn plan(&mut self, input: &PlanInput<'_>) -> PlanOutput {
+        let scene = scene_of(input);
+        let (offset, speed) = maneuver_candidate(argmax(&self.scorer.forward(&featurize(&scene))));
+        PlanOutput { trajectory: materialize_maneuver(&scene, offset, speed), kind: ProposalKind::Motion }
+    }
 }

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -80,7 +80,7 @@ pub use mick_capture::{IntentStats, MickDecisionRecord, MickEvalLog, MickEvalSum
 pub use mick_llm::{build_prompt, intent_schema, LlmBrain, MockModel, ModelClient, ModelError};
 
 pub mod learned;
-pub use learned::{LearnedPlanner, Teacher};
+pub use learned::{LearnedManeuverPlanner, LearnedPlanner, Teacher};
 
 /// Fast-loop trajectory tracker — the System-1 conformance side of the dual-rate loop, which
 /// follows one admitted trajectory by elapsed time across many fast ticks.

--- a/crates/kirra-planner/tests/learned_maneuver_bounded_by_kirra.rs
+++ b/crates/kirra-planner/tests/learned_maneuver_bounded_by_kirra.rs
@@ -1,0 +1,180 @@
+//! **A real *maneuvering* learned planner behind the seam, still bounded by KIRRA.**
+//!
+//! The speed-only `LearnedPlanner` (see `learned_doer_bounded_by_kirra.rs`) proved the §5
+//! thesis but could only choose how fast to drive STRAIGHT at the goal. `LearnedManeuverPlanner`
+//! generalizes it to a real 2-D Hydra-MDP trajectory vocabulary (lateral offset × speed), so the
+//! learned scorer can ROUTE AROUND a hazard. The safety case is unchanged — KIRRA is still the bound:
+//!
+//!   * on a CLEAR road both regimes drive straight, KIRRA admits;
+//!   * a SAFETY-AWARE net learns to PASS a hazard where the road is wide → KIRRA admits the pass
+//!     (the >4 m clearance clears the RSS lateral band);
+//!   * the SAME pass on a NARROW road does not fit → KIRRA REJECTS it → safe-stop fallback
+//!     (the bound catches a maneuver the corridor cannot contain — the net does not know width);
+//!   * a PROGRESS-ONLY (misaligned) net barrels STRAIGHT through → KIRRA REJECTS it.
+
+use kirra_planner::{
+    plan_for_intent, EgoState, Goal, LearnedManeuverPlanner, MickIntent, PlanInput, PlanOutput,
+    Pose, Teacher,
+};
+use kirra_ros2_adapter::corridor::{CorridorSource, MockCorridorSource, Point};
+use kirra_ros2_adapter::state::{PerceivedObject, TrajectoryVerdict};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+use kirra_core::FleetPosture;
+
+const SEED: u64 = 0xC0FFEE;
+
+/// A straight corridor of arbitrary half-width — the wide road the pass needs (the stock
+/// `MockCorridorSource` is fixed at ±5 m, too narrow to contain a >4 m lateral pass).
+struct WideCorridor {
+    left: Vec<Point>,
+    right: Vec<Point>,
+}
+impl WideCorridor {
+    fn new(half_width_m: f64, length_m: f64) -> Self {
+        Self {
+            left: vec![Point { x_m: 0.0, y_m: half_width_m }, Point { x_m: length_m, y_m: half_width_m }],
+            right: vec![Point { x_m: 0.0, y_m: -half_width_m }, Point { x_m: length_m, y_m: -half_width_m }],
+        }
+    }
+}
+impl CorridorSource for WideCorridor {
+    fn left_boundary(&self) -> &[Point] { &self.left }
+    fn right_boundary(&self) -> &[Point] { &self.right }
+    fn confidence(&self) -> f32 { 0.95 }
+    fn age_ms(&self) -> u64 { 10 }
+}
+
+fn world<'a>(map: &'a dyn CorridorSource, objects: &'a [PerceivedObject]) -> PlanInput<'a> {
+    PlanInput {
+        ego: EgoState {
+            pose: Pose { x_m: 5.0, y_m: 0.0, heading_rad: 0.0 },
+            linear_x_mps: 2.0,
+            yaw_rate_rads: 0.0,
+            stamp_ms: 0,
+        },
+        goal: Goal { target: Pose { x_m: 40.0, y_m: 0.0, heading_rad: 0.0 } },
+        map,
+        objects,
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+        request_overtake: false,
+        request_pull_over: false,
+        lane_graph: None,
+        signal_states: &[],
+    }
+}
+
+fn stopped_car(x: f64) -> PerceivedObject {
+    PerceivedObject { id: 1, pos: Point { x_m: x, y_m: 0.0 }, velocity_mps: 0.0, heading_rad: 0.0, vel: Point { x_m: 0.0, y_m: 0.0 } }
+}
+
+fn kirra_verdict(out: &PlanOutput, corr: &dyn CorridorSource, objs: &[PerceivedObject]) -> TrajectoryVerdict {
+    validate_trajectory_slow(&out.trajectory, corr, objs, &VehicleConfig::default_urban(), None, FleetPosture::Nominal)
+}
+
+fn admitted(v: TrajectoryVerdict) -> bool {
+    matches!(v, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp)
+}
+
+fn reach(out: &PlanOutput) -> f64 {
+    out.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max)
+}
+
+fn max_abs_y(out: &PlanOutput) -> f64 {
+    out.trajectory.iter().map(|t| t.pose.y_m.abs()).fold(0.0, f64::max)
+}
+
+/// Sanity: on a clear road the maneuvering net drives straight toward the goal (no gratuitous
+/// detour — the lateral-cost term makes straight the default), and KIRRA admits.
+#[test]
+fn maneuver_planner_drives_straight_on_a_clear_road() {
+    let corr = MockCorridorSource::straight_5m_half_width(100.0);
+    let w = world(&corr, &[]);
+    let intent = MickIntent::GoTo { x_m: 40.0, y_m: 0.0 };
+
+    for teacher in [Teacher::SafetyAware, Teacher::ProgressOnly] {
+        let mut p = LearnedManeuverPlanner::trained(SEED, teacher);
+        let (offset, _) = p.chosen_candidate(&w);
+        assert_eq!(offset, 0.0, "{teacher:?}: drives straight on a clear road (no detour)");
+        let out = plan_for_intent(&mut p, &intent, &w);
+        assert!(reach(&out) > 15.0, "{teacher:?}: makes progress, got {}", reach(&out));
+        assert!(max_abs_y(&out) < 0.5, "{teacher:?}: stays centered, max|y|={}", max_abs_y(&out));
+        assert!(admitted(kirra_verdict(&out, &corr, &[])), "{teacher:?}: KIRRA admits the clear-road plan");
+    }
+}
+
+/// THE new capability: a SAFETY-AWARE maneuvering net ROUTES AROUND a stopped car where the
+/// road is wide enough — a learned lateral pass, not a slow-down — and KIRRA ADMITS it (the
+/// >4 m clearance clears the RSS lateral-alignment band).
+#[test]
+fn safety_aware_maneuver_routes_around_and_kirra_admits_on_a_wide_road() {
+    let corr = WideCorridor::new(8.0, 100.0);
+    let objs = [stopped_car(25.0)];
+    let w = world(&corr, &objs);
+    let intent = MickIntent::GoTo { x_m: 40.0, y_m: 0.0 };
+
+    let mut p = LearnedManeuverPlanner::trained(SEED, Teacher::SafetyAware);
+    let (offset, _) = p.chosen_candidate(&w);
+    assert!(offset.abs() > 1.0, "the safety-aware net chooses a lateral pass, offset={offset}");
+
+    let out = plan_for_intent(&mut p, &intent, &w);
+    assert!(reach(&out) > 25.0, "the pass drives PAST the hazard (does not stop short), reach={}", reach(&out));
+    assert!(max_abs_y(&out) > 4.0, "the path swings clear of the centerline hazard, max|y|={}", max_abs_y(&out));
+    assert!(admitted(kirra_verdict(&out, &corr, &objs)), "KIRRA admits the route-around on a wide road");
+}
+
+/// The SAME safety-aware pass on a NARROW road does not fit the corridor → KIRRA REJECTS it,
+/// and the always-available safe-stop takes over. The net does not know the corridor width;
+/// KIRRA is the bound that catches the maneuver the road cannot contain.
+#[test]
+fn kirra_bounds_the_pass_that_does_not_fit_a_narrow_road() {
+    let narrow = MockCorridorSource::straight_5m_half_width(100.0); // ±5 m: a >4 m pass won't fit
+    let objs = [stopped_car(25.0)];
+    let w = world(&narrow, &objs);
+    let intent = MickIntent::GoTo { x_m: 40.0, y_m: 0.0 };
+
+    let mut p = LearnedManeuverPlanner::trained(SEED, Teacher::SafetyAware);
+    let (offset, _) = p.chosen_candidate(&w);
+    assert!(offset.abs() > 1.0, "the net still proposes the pass (blind to corridor width), offset={offset}");
+
+    let out = plan_for_intent(&mut p, &intent, &w);
+    assert_eq!(
+        kirra_verdict(&out, &narrow, &objs),
+        TrajectoryVerdict::MRCFallback,
+        "KIRRA rejects the pass the narrow corridor cannot contain"
+    );
+    let fallback = PlanOutput::safe_stop(w.ego.pose);
+    assert!(admitted(kirra_verdict(&fallback, &narrow, &objs)), "the safe-stop fallback is admissible");
+}
+
+/// A PROGRESS-ONLY (misaligned) maneuvering net ignores clearance → it barrels STRAIGHT through
+/// the hazard (the lateral-cost term makes a gratuitous detour strictly worse) → KIRRA REJECTS
+/// it. The 2-D vocabulary does not weaken the bound on a misaligned net.
+#[test]
+fn misaligned_maneuver_planner_barrels_straight_through_and_kirra_rejects() {
+    let corr = WideCorridor::new(8.0, 100.0);
+    let objs = [stopped_car(25.0)];
+    let w = world(&corr, &objs);
+    let intent = MickIntent::GoTo { x_m: 40.0, y_m: 0.0 };
+
+    let mut p = LearnedManeuverPlanner::trained(SEED, Teacher::ProgressOnly);
+    let (offset, _) = p.chosen_candidate(&w);
+    assert_eq!(offset, 0.0, "the misaligned net drives straight (a detour only costs it progress)");
+
+    let out = plan_for_intent(&mut p, &intent, &w);
+    assert!(reach(&out) > 25.0, "it drives through the hazard, reach={}", reach(&out));
+    assert!(max_abs_y(&out) < 0.5, "straight through, not around, max|y|={}", max_abs_y(&out));
+    assert_eq!(
+        kirra_verdict(&out, &corr, &objs),
+        TrajectoryVerdict::MRCFallback,
+        "KIRRA rejects the misaligned straight-through plan"
+    );
+}

--- a/crates/kirra-taj/src/lib.rs
+++ b/crates/kirra-taj/src/lib.rs
@@ -37,6 +37,12 @@
 use kirra_core::corridor::{CorridorSource, Point};
 use kirra_core::trajectory::PerceivedObject;
 
+mod semantic_eval;
+pub use semantic_eval::{
+    score_frame, ClassRecall, FrameOutcome, SemanticEvalFrame, SemanticEvalSummary,
+    DEFAULT_CLIP_TOL_M,
+};
+
 /// Minimal range-scan input — a `sensor_msgs/LaserScan` subset.
 ///
 /// Angles are measured from the ego **+X** axis (forward); **+Y** is left.
@@ -235,6 +241,38 @@ fn truncate_boundary(boundary: &[Point], x_clip: f64) -> Vec<Point> {
     out
 }
 
+/// The **binding hazard** — the nearest non-drivable detection whose lateral span
+/// overlaps the corridor at its near edge, i.e. the one that actually ends the
+/// drivable space. `None` when nothing clips the corridor (every detection is
+/// drivable, or lies laterally clear of it). This is the single decision the
+/// Phase-B fusion turns on; [`clip_corridor_to_hazards`] truncates at exactly this
+/// detection's `near_x_m`, and the eval harness ([`SemanticEvalSummary`]) compares
+/// the binding hazard under ground-truth vs detected labels to score the ML path.
+#[must_use]
+pub fn binding_hazard<'a>(
+    corridor: &TajCorridor,
+    detections: &'a [SemanticDetection],
+) -> Option<&'a SemanticDetection> {
+    detections
+        .iter()
+        .filter(|d| !d.class.is_drivable())
+        // Does the hazard's lateral span overlap the corridor at its near edge?
+        .filter(|d| {
+            let left = boundary_y_at(&corridor.left, d.near_x_m);
+            let right = boundary_y_at(&corridor.right, d.near_x_m);
+            d.lateral_max_m > right && d.lateral_min_m < left
+        })
+        .min_by(|a, b| a.near_x_m.total_cmp(&b.near_x_m))
+}
+
+/// The forward distance at which `detections` end the drivable corridor — the
+/// [`binding_hazard`]'s `near_x_m`, or `None` if nothing clips it. The fusion's
+/// decision distilled to a scalar.
+#[must_use]
+pub fn hazard_clip_x(corridor: &TajCorridor, detections: &[SemanticDetection]) -> Option<f64> {
+    binding_hazard(corridor, detections).map(|d| d.near_x_m)
+}
+
 /// **Phase-B fusion** — clip the drivable corridor at the nearest non-drivable
 /// semantic hazard that laterally overlaps it. The corridor's drivable space ends
 /// at the hazard's edge, so KIRRA's containment rejects any trajectory that would
@@ -245,21 +283,9 @@ pub fn clip_corridor_to_hazards(
     corridor: &TajCorridor,
     detections: &[SemanticDetection],
 ) -> TajCorridor {
-    let mut x_clip = f64::INFINITY;
-    for d in detections {
-        if d.class.is_drivable() {
-            continue;
-        }
-        // Does the hazard's lateral span overlap the corridor at its near edge?
-        let left = boundary_y_at(&corridor.left, d.near_x_m);
-        let right = boundary_y_at(&corridor.right, d.near_x_m);
-        if d.lateral_max_m > right && d.lateral_min_m < left {
-            x_clip = x_clip.min(d.near_x_m);
-        }
-    }
-    if !x_clip.is_finite() {
+    let Some(x_clip) = hazard_clip_x(corridor, detections) else {
         return corridor.clone();
-    }
+    };
     TajCorridor {
         left: truncate_boundary(&corridor.left, x_clip),
         right: truncate_boundary(&corridor.right, x_clip),

--- a/crates/kirra-taj/src/semantic_eval.rs
+++ b/crates/kirra-taj/src/semantic_eval.rs
@@ -1,0 +1,451 @@
+//! **Semantic-perception eval harness** — the perception analog of the Mick brain-eval
+//! scorecard, scoring the ML detector path (Phase B) against labeled ground truth.
+//!
+//! # What it measures, and why it is safety-weighted
+//!
+//! A generic detector metric (mAP, IoU) answers "how good are the boxes". A *safety*
+//! governor asks a sharper question: **does the detector ever let the vehicle drive past a
+//! hazard the world actually contains?** Phase B exists because lidar is blind to water
+//! (specular → no return), so a missed water region reads as free corridor and the vehicle
+//! drives into a lake. That failure — a *missed* hazard — is categorically worse than a
+//! *spurious* one (which merely stops the vehicle early). The scorecard separates them:
+//!
+//! - **Unsafe miss** — the detector's drivable extent runs PAST the ground-truth hazard (or
+//!   misses it entirely). The catastrophic case; the headline metric is `unsafe_miss_rate`,
+//!   which a fielded model must drive to ~0.
+//! - **Over-conservative** — the detector clips the corridor SHORTER than truth requires
+//!   (spurious / too-near hazard). An availability cost (needless slow/stop), never a safety
+//!   breach. Tracked, but not the safety bar.
+//! - **Correct** — extent matches truth within tolerance.
+//!
+//! # Scored at the FUSION, not the raw box
+//!
+//! The oracle is the very fusion KIRRA consumes ([`binding_hazard`] / `hazard_clip_x`): a
+//! detection only matters if it is the *nearest non-drivable region laterally overlapping the
+//! corridor* — exactly the box that ends the drivable space. A perfect box the fusion ignores
+//! (laterally clear, or behind a nearer one) is correctly scored as not mattering; a missed
+//! box only counts against the model when it would have clipped the corridor. So this measures
+//! the model's effect on the safety envelope, not a proxy.
+//!
+//! # Model-free, like the rest of Phase B
+//!
+//! Ground truth and detector output are both `Vec<SemanticDetection>`, so the harness scores
+//! the [`MockSemanticDetector`](crate::MockSemanticDetector) today and the real RGB→TensorRT
+//! detector unchanged once it lands behind the same seam — the eval bar is in place before the
+//! model is, the same discipline the Mick scorecard followed for the brain.
+
+use std::collections::BTreeMap;
+
+use crate::{binding_hazard, hazard_clip_x, SemanticClass, SemanticDetection, TajCorridor};
+
+/// Default clip-distance tolerance (m): a detector extent within this of ground truth counts
+/// as a match. Absorbs sub-meter localization/decode jitter without masking a real miss (a
+/// missed hazard overshoots by metres — the whole corridor opens up).
+pub const DEFAULT_CLIP_TOL_M: f64 = 0.5;
+
+/// One labeled eval frame: a corridor, the GROUND-TRUTH hazards (the labels), and the hazards
+/// the detector PRODUCED for the same frame. Both detection sets are scored through the same
+/// fusion against `corridor`.
+#[derive(Debug, Clone, Copy)]
+pub struct SemanticEvalFrame<'a> {
+    /// The Phase-A geometric corridor the hazards are fused against.
+    pub corridor: &'a TajCorridor,
+    /// Ground-truth (labeled) semantic hazards for this frame.
+    pub truth: &'a [SemanticDetection],
+    /// The hazards the detector under test produced for this frame.
+    pub detected: &'a [SemanticDetection],
+}
+
+/// Per-frame safety verdict: the detector's drivable extent vs ground truth's.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameOutcome {
+    /// Detector's drivable extent matches truth within tolerance.
+    Correct,
+    /// Detector lets the corridor extend PAST the true hazard (or misses it entirely) — the
+    /// vehicle would drive into a hazard ground truth forbids. The catastrophic failure.
+    UnsafeMiss,
+    /// Detector clips the corridor SHORTER than truth requires (spurious / too-near hazard) —
+    /// an availability cost, not a safety breach.
+    OverConservative,
+}
+
+/// `Some(extent)` → the corridor ends there; `None` (unclipped) → effectively unbounded, so
+/// the comparison treats it as `+∞` (a fully-missed true hazard becomes an infinite overshoot
+/// → `UnsafeMiss`, exactly as intended).
+fn extent(clip: Option<f64>) -> f64 {
+    clip.unwrap_or(f64::INFINITY)
+}
+
+/// Score a single frame: compare the detector's drivable extent to ground truth's, both
+/// derived from the shared fusion oracle.
+#[must_use]
+pub fn score_frame(frame: &SemanticEvalFrame, tol_m: f64) -> FrameOutcome {
+    let truth_x = hazard_clip_x(frame.corridor, frame.truth);
+    let det_x = hazard_clip_x(frame.corridor, frame.detected);
+    let (t, d) = (extent(truth_x), extent(det_x));
+    if d > t + tol_m {
+        FrameOutcome::UnsafeMiss
+    } else if d < t - tol_m {
+        FrameOutcome::OverConservative
+    } else {
+        FrameOutcome::Correct
+    }
+}
+
+/// Stable label for a [`SemanticClass`] (the `by_class` recall key).
+fn class_label(c: SemanticClass) -> &'static str {
+    match c {
+        SemanticClass::Road => "road",
+        SemanticClass::Water => "water",
+        SemanticClass::StaticObstacle => "static_obstacle",
+        SemanticClass::Unknown => "unknown",
+    }
+}
+
+/// Recall tally for one ground-truth hazard class: how many binding hazards of this class the
+/// detector caught (did not unsafe-miss).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ClassRecall {
+    /// Frames whose ground-truth binding hazard is this class.
+    pub seen: usize,
+    /// …that the detector caught (clipped at or before the true hazard).
+    pub caught: usize,
+}
+
+impl ClassRecall {
+    /// Caught fraction for this class (0.0 when unseen).
+    #[must_use]
+    pub fn recall(&self) -> f64 {
+        ratio(self.caught, self.seen)
+    }
+}
+
+/// **The perception scorecard** — aggregates scored [`SemanticEvalFrame`]s into safety-weighted
+/// metrics: the headline `unsafe_miss_rate` (a hazard driven past), `hazard_recall` (true
+/// binding hazards caught), the over-conservative (availability) rate, a per-class recall
+/// breakdown (so a Water blind spot — the reason Phase B exists — is visible on its own), and a
+/// mean clip-distance error among co-clipped frames.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SemanticEvalSummary {
+    /// Frames scored.
+    pub frames: usize,
+    /// Detector extent matched truth within tolerance.
+    pub correct: usize,
+    /// Detector drove PAST the true hazard / missed it (safety-critical).
+    pub unsafe_miss: usize,
+    /// Detector clipped earlier than truth (availability cost).
+    pub over_conservative: usize,
+    /// Frames whose GROUND TRUTH has a binding hazard (the corridor SHOULD clip).
+    pub frames_with_true_hazard: usize,
+    /// …of those, the ones the detector caught (outcome ≠ `UnsafeMiss`).
+    pub true_hazards_caught: usize,
+    /// Per ground-truth binding-hazard class recall.
+    pub by_class: BTreeMap<&'static str, ClassRecall>,
+    /// Sum of |det_clip − truth_clip| over frames where BOTH clipped (finite extents).
+    pub sum_abs_clip_err_m: f64,
+    /// Frames where both truth and detector clipped (the `sum_abs_clip_err_m` denominator).
+    pub co_clipped: usize,
+}
+
+impl SemanticEvalSummary {
+    /// Fraction of frames the detector unsafe-missed — **the safety bar** (target ~0).
+    #[must_use]
+    pub fn unsafe_miss_rate(&self) -> f64 {
+        ratio(self.unsafe_miss, self.frames)
+    }
+    /// Fraction clipped too short (availability cost).
+    #[must_use]
+    pub fn over_conservative_rate(&self) -> f64 {
+        ratio(self.over_conservative, self.frames)
+    }
+    /// Fraction matching truth within tolerance.
+    #[must_use]
+    pub fn correct_rate(&self) -> f64 {
+        ratio(self.correct, self.frames)
+    }
+    /// Of frames with a true binding hazard, the fraction the detector caught — the
+    /// safety-critical recall (a miss here is a hazard driven into). 1.0 when there were no
+    /// true hazards to catch (vacuously perfect recall).
+    #[must_use]
+    pub fn hazard_recall(&self) -> f64 {
+        if self.frames_with_true_hazard == 0 {
+            1.0
+        } else {
+            self.true_hazards_caught as f64 / self.frames_with_true_hazard as f64
+        }
+    }
+    /// Mean |det_clip − truth_clip| over frames where both clipped (0.0 when none did).
+    #[must_use]
+    pub fn mean_clip_err_m(&self) -> f64 {
+        if self.co_clipped == 0 {
+            0.0
+        } else {
+            self.sum_abs_clip_err_m / self.co_clipped as f64
+        }
+    }
+
+    fn tally(&mut self, frame: &SemanticEvalFrame, tol_m: f64) {
+        let outcome = score_frame(frame, tol_m);
+        self.frames += 1;
+        match outcome {
+            FrameOutcome::Correct => self.correct += 1,
+            FrameOutcome::UnsafeMiss => self.unsafe_miss += 1,
+            FrameOutcome::OverConservative => self.over_conservative += 1,
+        }
+
+        // Per-class recall is keyed by the GROUND-TRUTH binding hazard: a frame only tests
+        // recall when truth says the corridor should clip.
+        if let Some(truth_hz) = binding_hazard(frame.corridor, frame.truth) {
+            self.frames_with_true_hazard += 1;
+            let caught = outcome != FrameOutcome::UnsafeMiss;
+            if caught {
+                self.true_hazards_caught += 1;
+            }
+            let e = self.by_class.entry(class_label(truth_hz.class)).or_default();
+            e.seen += 1;
+            if caught {
+                e.caught += 1;
+            }
+        }
+
+        // Clip-distance error only where both actually clipped (finite extents).
+        if let (Some(t), Some(d)) = (
+            hazard_clip_x(frame.corridor, frame.truth),
+            hazard_clip_x(frame.corridor, frame.detected),
+        ) {
+            self.sum_abs_clip_err_m += (d - t).abs();
+            self.co_clipped += 1;
+        }
+    }
+
+    /// Score a stream of frames at [`DEFAULT_CLIP_TOL_M`].
+    #[must_use]
+    pub fn from_frames<'a>(frames: impl IntoIterator<Item = SemanticEvalFrame<'a>>) -> Self {
+        Self::from_frames_with_tol(frames, DEFAULT_CLIP_TOL_M)
+    }
+
+    /// Score a stream of frames at an explicit clip tolerance.
+    #[must_use]
+    pub fn from_frames_with_tol<'a>(
+        frames: impl IntoIterator<Item = SemanticEvalFrame<'a>>,
+        tol_m: f64,
+    ) -> Self {
+        let mut s = Self::default();
+        for f in frames {
+            s.tally(&f, tol_m);
+        }
+        s
+    }
+}
+
+impl std::fmt::Display for SemanticEvalSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Semantic perception eval — {} frames", self.frames)?;
+        writeln!(
+            f,
+            "  UNSAFE MISS {:>5} ({:>5.1}%)   <- the safety bar (drive into a hazard)",
+            self.unsafe_miss,
+            100.0 * self.unsafe_miss_rate()
+        )?;
+        writeln!(
+            f,
+            "  over-conserv {:>4} ({:>5.1}%)   correct {} ({:.1}%)",
+            self.over_conservative,
+            100.0 * self.over_conservative_rate(),
+            self.correct,
+            100.0 * self.correct_rate()
+        )?;
+        writeln!(
+            f,
+            "  hazard recall {:>5.1}%  ({}/{} true hazards caught)",
+            100.0 * self.hazard_recall(),
+            self.true_hazards_caught,
+            self.frames_with_true_hazard
+        )?;
+        writeln!(f, "  by class:")?;
+        for (label, r) in &self.by_class {
+            writeln!(
+                f,
+                "    {:<16} recall {:>5.1}%   ({}/{})",
+                label,
+                100.0 * r.recall(),
+                r.caught,
+                r.seen
+            )?;
+        }
+        write!(f, "  mean clip error {:.2} m (over {} co-clipped frames)", self.mean_clip_err_m(), self.co_clipped)
+    }
+}
+
+/// Ratio `n/d` as a fraction, 0.0 when `d == 0`.
+fn ratio(n: usize, d: usize) -> f64 {
+    if d == 0 {
+        0.0
+    } else {
+        n as f64 / d as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{TajConfig, TajPhaseA};
+
+    // A wide-open corridor reaching ~20 m, built from the geometric Phase-A pipeline (same
+    // substrate the fusion tests use), so the binding hazard is the semantic one, not geometry.
+    fn open_corridor() -> TajCorridor {
+        // Two far side walls → a clear forward corridor; reuse the lib test's scan shape.
+        let taj = TajPhaseA::new(TajConfig { forward_extent_m: 20.0, ..Default::default() });
+        // A scan with returns only far out to the sides leaves the forward corridor open.
+        let n = 180usize;
+        let mut ranges = vec![f32::INFINITY; n];
+        // place a couple of far lateral returns so the corridor exists but stays wide
+        ranges[10] = 30.0;
+        ranges[170] = 30.0;
+        let scan = crate::LaserScan {
+            angle_min_rad: -std::f64::consts::FRAC_PI_2,
+            angle_increment_rad: std::f64::consts::PI / (n as f64 - 1.0),
+            range_min_m: 0.1,
+            range_max_m: 40.0,
+            ranges,
+            stamp_ms: 0,
+        };
+        taj.process(&scan, 0).corridor
+    }
+
+    fn hazard(class: SemanticClass, near_x: f64) -> SemanticDetection {
+        SemanticDetection { class, near_x_m: near_x, lateral_min_m: -5.0, lateral_max_m: 5.0 }
+    }
+
+    fn frame<'a>(
+        corridor: &'a TajCorridor,
+        truth: &'a [SemanticDetection],
+        detected: &'a [SemanticDetection],
+    ) -> SemanticEvalFrame<'a> {
+        SemanticEvalFrame { corridor, truth, detected }
+    }
+
+    #[test]
+    fn exact_match_is_correct() {
+        let c = open_corridor();
+        let truth = [hazard(SemanticClass::Water, 8.0)];
+        let det = [hazard(SemanticClass::Water, 8.0)];
+        assert_eq!(score_frame(&frame(&c, &truth, &det), DEFAULT_CLIP_TOL_M), FrameOutcome::Correct);
+    }
+
+    #[test]
+    fn detector_missing_a_true_hazard_is_an_unsafe_miss() {
+        // Truth: water at 8 m. Detector: nothing → corridor stays open past the water.
+        let c = open_corridor();
+        let truth = [hazard(SemanticClass::Water, 8.0)];
+        let det: [SemanticDetection; 0] = [];
+        assert_eq!(score_frame(&frame(&c, &truth, &det), DEFAULT_CLIP_TOL_M), FrameOutcome::UnsafeMiss);
+    }
+
+    #[test]
+    fn detector_seeing_the_hazard_too_far_out_is_an_unsafe_miss() {
+        // Truth clips at 8 m; detector only clips at 14 m → drivable space runs 6 m past truth.
+        let c = open_corridor();
+        let truth = [hazard(SemanticClass::Water, 8.0)];
+        let det = [hazard(SemanticClass::Water, 14.0)];
+        assert_eq!(score_frame(&frame(&c, &truth, &det), DEFAULT_CLIP_TOL_M), FrameOutcome::UnsafeMiss);
+    }
+
+    #[test]
+    fn detector_clipping_earlier_than_truth_is_over_conservative() {
+        // Truth clips at 12 m; detector clips at 5 m → safe but needlessly short.
+        let c = open_corridor();
+        let truth = [hazard(SemanticClass::Water, 12.0)];
+        let det = [hazard(SemanticClass::StaticObstacle, 5.0)];
+        assert_eq!(
+            score_frame(&frame(&c, &truth, &det), DEFAULT_CLIP_TOL_M),
+            FrameOutcome::OverConservative
+        );
+    }
+
+    #[test]
+    fn a_spurious_hazard_with_no_true_one_is_over_conservative_not_unsafe() {
+        // Truth: clear. Detector: invents an obstacle at 6 m → corridor clipped for nothing.
+        let c = open_corridor();
+        let truth: [SemanticDetection; 0] = [];
+        let det = [hazard(SemanticClass::StaticObstacle, 6.0)];
+        assert_eq!(
+            score_frame(&frame(&c, &truth, &det), DEFAULT_CLIP_TOL_M),
+            FrameOutcome::OverConservative
+        );
+    }
+
+    #[test]
+    fn both_clear_is_correct() {
+        let c = open_corridor();
+        let truth: [SemanticDetection; 0] = [];
+        let det: [SemanticDetection; 0] = [];
+        assert_eq!(score_frame(&frame(&c, &truth, &det), DEFAULT_CLIP_TOL_M), FrameOutcome::Correct);
+    }
+
+    #[test]
+    fn summary_aggregates_outcomes_recall_and_per_class() {
+        let c = open_corridor();
+        // Frame 1: water caught exactly → correct, water recall +1/+1.
+        let t1 = [hazard(SemanticClass::Water, 8.0)];
+        let d1 = [hazard(SemanticClass::Water, 8.0)];
+        // Frame 2: water MISSED → unsafe miss, water recall +0/+1.
+        let t2 = [hazard(SemanticClass::Water, 8.0)];
+        let d2: [SemanticDetection; 0] = [];
+        // Frame 3: static obstacle, detector over-clips (safe) → over-conservative, caught.
+        let t3 = [hazard(SemanticClass::StaticObstacle, 12.0)];
+        let d3 = [hazard(SemanticClass::StaticObstacle, 6.0)];
+        let s = SemanticEvalSummary::from_frames([
+            frame(&c, &t1, &d1),
+            frame(&c, &t2, &d2),
+            frame(&c, &t3, &d3),
+        ]);
+
+        assert_eq!(s.frames, 3);
+        assert_eq!((s.correct, s.unsafe_miss, s.over_conservative), (1, 1, 1));
+        assert!((s.unsafe_miss_rate() - 1.0 / 3.0).abs() < 1e-9);
+        // All three frames have a true binding hazard; two were caught (frames 1 and 3).
+        assert_eq!((s.frames_with_true_hazard, s.true_hazards_caught), (3, 2));
+        assert!((s.hazard_recall() - 2.0 / 3.0).abs() < 1e-9);
+        // Per-class: water 1/2 caught, static_obstacle 1/1.
+        assert_eq!(s.by_class["water"], ClassRecall { seen: 2, caught: 1 });
+        assert_eq!(s.by_class["static_obstacle"], ClassRecall { seen: 1, caught: 1 });
+        assert!((s.by_class["water"].recall() - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn no_true_hazards_means_vacuous_full_recall_without_dividing_by_zero() {
+        let c = open_corridor();
+        let truth: [SemanticDetection; 0] = [];
+        let det: [SemanticDetection; 0] = [];
+        let s = SemanticEvalSummary::from_frames([frame(&c, &truth, &det)]);
+        assert_eq!(s.frames_with_true_hazard, 0);
+        assert_eq!(s.hazard_recall(), 1.0, "no hazards to miss → vacuously perfect recall");
+        assert_eq!(s.unsafe_miss_rate(), 0.0);
+        assert_eq!(s.mean_clip_err_m(), 0.0);
+    }
+
+    #[test]
+    fn mean_clip_error_averages_only_co_clipped_frames() {
+        let c = open_corridor();
+        // Co-clipped with a 2 m error.
+        let t1 = [hazard(SemanticClass::Water, 8.0)];
+        let d1 = [hazard(SemanticClass::Water, 10.0)];
+        // Truth clear, detector clear → NOT co-clipped, excluded from the mean.
+        let t2: [SemanticDetection; 0] = [];
+        let d2: [SemanticDetection; 0] = [];
+        let s = SemanticEvalSummary::from_frames([frame(&c, &t1, &d1), frame(&c, &t2, &d2)]);
+        assert_eq!(s.co_clipped, 1);
+        assert!((s.mean_clip_err_m() - 2.0).abs() < 1e-9, "2 m error over 1 co-clipped frame");
+    }
+
+    #[test]
+    fn display_reports_the_safety_headline() {
+        let c = open_corridor();
+        let t = [hazard(SemanticClass::Water, 8.0)];
+        let d: [SemanticDetection; 0] = [];
+        let report = SemanticEvalSummary::from_frames([frame(&c, &t, &d)]).to_string();
+        assert!(report.contains("UNSAFE MISS"), "report surfaces the safety bar: {report}");
+        assert!(report.contains("water"), "report breaks down by class: {report}");
+    }
+}


### PR DESCRIPTION
Two related ML-side steps, both proving the doer-checker thesis deeper. (Two commits on the shared branch — they couldn't be separate open PRs.)

---

## Commit 1 — `kirra-taj`: safety-weighted eval harness for the semantic perception path (`26c2de3`)

The Phase-B semantic detector (lidar-blind hazards — **water** especially) ran behind the `SemanticDetector` seam with a mock and a hardware-gated real model, but there was **no way to score the ML path's output**. This adds the perception analog of the Mick brain-eval scorecard (#535).

**Safety-weighted, not mAP.** The question is "does the detector ever let the vehicle drive *past* a real hazard?" — categorically worse than a spurious detection (which only stops early). Each frame is classed:
- **`UnsafeMiss`** — detector extent runs past the true hazard / misses it. The catastrophic case; `unsafe_miss_rate` is the headline bar.
- **`OverConservative`** — clips shorter than truth (availability cost, not safety).
- **`Correct`** — matches within tolerance.

**Scored at the FUSION, not the raw box:** the oracle is the same `binding_hazard` / `hazard_clip_x` KIRRA consumes, so a box the fusion ignores (laterally clear / behind a nearer one) correctly doesn't count, and a missed box only counts when it would have clipped the corridor. `hazard_recall` + a per-class breakdown surface a Water blind spot on its own. Model-free: scores the mock today, the real RGB→TensorRT detector unchanged once it lands behind the same seam.

kirra-taj green (30 tests, 8 new); clippy clean.

---

## Commit 2 — `kirra-planner`: a real *maneuvering* learned planner behind the doer seam (`40c7c4f`)

The existing `LearnedPlanner` proved the §5 thesis but its vocabulary is four STRAIGHT-line speeds — it can only choose how fast to drive at the goal, never a path. Real Hydra-MDP scores a vocabulary of diverse trajectory *shapes*. `LearnedManeuverPlanner` adds a 2-D vocabulary (lateral offset × speed), so the learned scorer can **route around** a hazard, behind the SAME `Planner` seam, with KIRRA still the bound:

- clear road → both regimes drive straight, KIRRA admits;
- safety-aware, **wide** road → learns to **PASS** the stopped car (>4 m clearance clears KIRRA's RSS band) → KIRRA **admits** the route-around;
- the **same** pass, **narrow** road → doesn't fit the corridor → KIRRA **rejects** → safe-stop (the net is blind to width; KIRRA is the containing bound);
- progress-only → barrels straight through → KIRRA **rejects**.

`Mlp` generalized to const-generic output width — RNG draw order unchanged for K=4, so the speed-only planner's weights and all 3 thesis tests are **untouched**. The maneuver teacher's safe-clearance margin is aligned to KIRRA's 4 m band (a real finding: with only a speed knob "keep distance" means brake; with a lateral knob a band-clearing pass is genuinely safe, so the teacher must value it or the pass is never learned).

kirra-planner green (7 learned-doer tests: 3 thesis unchanged + 4 maneuver); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)