### PR TITLE
Junction safety + RSS completeness (occlusion, multi-modal, divergence)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,12 @@
 
 ## Project Identity
 
-- **Crate**: `kirra-verifier` (lib ident `kirra_verifier`; lib + bin dual-crate, `crate-type = ["rlib", "cdylib"]`). Renamed from `kirra-runtime-sdk` once nothing lean depended on it (the GitHub repo remains `kirra-runtime-sdk`).
+- **Workspace**: a Cargo workspace. The ROOT member is the **`kirra-verifier`** crate (the fleet-legitimacy engine + governor service, documented in the bulk of this file). The **doer-checker / planning / perception** side lives under `crates/*` (see **Workspace Crates** below). `parko/` is a **separate** workspace (the ML + diverse-governor side). Most AV/Occy work happens in `crates/kirra-planner`, `kirra-map`, `kirra-taj`, `kirra-ros2-adapter`, and `parko/`.
+- **Root crate**: `kirra-verifier` (lib ident `kirra_verifier`; lib + bin dual-crate, `crate-type = ["rlib", "cdylib"]`). Renamed from `kirra-runtime-sdk` once nothing lean depended on it (the GitHub repo remains `kirra-runtime-sdk`).
 - **Edition**: 2021
 - **Primary binary**: `kirra_verifier_service` (`src/bin/kirra_verifier_service.rs`)
 - **Secondary binary**: `kirra_carla_client` (`src/bin/kirra_carla_client.rs`)
-- **Test suite**: `cargo test`
+- **Test suite**: `cargo test` (root). For a scoped crate use `cargo test -p <crate>`. `parko/` is its own workspace: `cd parko && cargo test`. The `kirra-ros2-adapter` `node.rs` is `#[cfg(feature = "ros2")]` and needs a sourced ROS 2 toolchain (`r2r`) — it is built ONLY by CI's `ros2 adapter build (--features ros2)` job, never by a default build.
 - **Remote**: `kirra-systems/kirra-runtime-sdk`
 - **Repo root in prompts**: use `~/kirra-runtime-sdk` (not `/home/user/...` or `/home/user/aegis`)
 
@@ -157,6 +158,72 @@ src/
 | `trusted_federation_controllers` | Ed25519 public key registry |
 | `federation_report_nonces` | Burned nonces (replay prevention) |
 | `attestation_identity_registry` | Hardware fingerprint (AK public key digest) per node |
+
+---
+
+## Workspace Crates — the doer-checker / planning / perception side
+
+Everything above documents the **`kirra-verifier`** root crate. The AV/Occy stack lives in
+sibling crates. The load-bearing thesis: **a planner (the DOER) PROPOSES a trajectory; KIRRA
+(the CHECKER) BOUNDS it.** The doer is swappable (geometric, learned, LLM-driven) and is never
+trusted for safety; the checker is the invariant.
+
+| Crate | Role |
+|-------|------|
+| `crates/kirra-core` | Lean shared types (no heavy deps): `corridor` (`CorridorSource`, `Point`, `MockCorridorSource`), `trajectory` (`PerceivedObject`, `Pose`, `TrajectoryPoint`, `TrajectoryVerdict`), `containment` (`MAX_TRAJECTORY_HORIZON`), `FleetPosture`, `kinematics_sim`, `capture`, `perception_monitor`, `KirraKernelGovernor`. Almost everything else depends on this, NOT on the heavy adapter. |
+| `crates/kirra-ros2-adapter` | **The #131 Option-B CHECKER + ROS 2 node.** `validation.rs` — `validate_trajectory_slow` / `validate_trajectory_slow_capped`: containment + per-pose kinematics + **RSS** (the §4 conjunction: danger needs BOTH longitudinal AND lateral unsafe) + **occlusion (RSS Rule 4)** + **multi-modal predictive RSS** (`predictive_rss_breach` over `PredictedMode`s). `prediction.rs` — the multi-modal **mode producer** (`predicted_modes_from_objects` / `slow_loop_modes`: CV always, CTRV when a tracker yaw is fresh). `perception_redundancy.rs` — the True-Redundancy `cross_check` + `resolve_redundancy_cap`. `state.rs` — `AdaptorState` (primary + secondary object channels, yaw channel). `node.rs` (**ros2-gated**) — slow/fast dual-rate loops, subscriptions. |
+| `crates/kirra-planner` | **Occy, the geometric DOER + the Mick intent seam.** `GeometricPlanner` / `Planner` trait / `PlanInput` / `PlanOutput`. `mick.rs` — `plan_for_intent` grounds a `MickIntent` (`GoTo` / `LaneChange` / `Cruise` / `Overtake` / `PullOver` / `TurnAt` / **`RouteTo`** multi-junction). `learned.rs` — `LearnedPlanner` (speed-only Hydra-MDP) + **`LearnedManeuverPlanner`** (2-D lateral×speed vocabulary, routes around). `behavior.rs` — `TrafficControl` (signs/signals + **`OccludedApproach`** speed cap). `fast_loop.rs`, `mick_llm.rs`, `mick_capture.rs`. |
+| `crates/kirra-map` | **Lanelet2-lite lane graph** (`kirra_map::lanemap`). `LaneGraph` (`route` Dijkstra, `route_corridor` / `route_drivable` stitch a multi-junction corridor, `route_to_point`, right-of-way / `junction_context`, **occlusion `sight_distance`**), `Lane`, `LaneCorridor`, `LineType` / `lane_lines`. Re-exported by `kirra-planner`. |
+| `crates/kirra-taj` | **Taj, the R2 perception layer (ADR-0015).** Phase-A geometric corridor/objects from lidar; Phase-B semantic fusion (`clip_corridor_to_hazards` / `binding_hazard` / `hazard_clip_x` — water/obstacle hazards tighten the corridor); **`SemanticEvalSummary`** — the safety-weighted perception eval harness (`UnsafeMiss` / `OverConservative` / `Correct`, `hazard_recall`). |
+| `crates/kirra-mick` | Mick examples / eval harness binaries (`mick_intersection`, `mick_eval`). |
+| `crates/kirra-fleet-transport` | Zenoh-backed fleet transport (ADR-0007). |
+| `crates/kirra-governor-service`, `kirra-proposal-bench`, `kirra-wire-client` | Two-box prototype tools (UDP governor + proposal sweep + shared wire mirror; ADR-0001). |
+| `crates/kirra-capture-schema`, `kirra-collector` | Governor-correction capture wire schema + collector (supervised-learning data path). |
+| `parko/` (separate workspace) | **The ML + diverse-governor side.** `parko-core` (`SafetyGovernor` trait, `SafetyPosture` with `escalate()`, RSS, `InferenceLoop` scheduler, `detector`), `parko-kirra` (`KirraGovernor`, `GovernorComparator` — two diverse governors, divergence accumulator → `recommended_posture()`), `parko-ros2` (`run_pipeline_tick` — divergence escalates the effective posture), `parko-onnx`/`parko-openvino`/`parko-tensorrt` (inference backends, hardware/CI-gated). |
+
+### Doer-checker key algorithms (planner / checker side)
+
+**RSS §4 conjunction** (`validate_trajectory_slow`): a collision needs the object unsafe
+LONGITUDINALLY **and** LATERALLY at once. The lateral side-RSS fires only when abreast
+(`lon_unsafe`) OR the object is closing laterally (a cut-in). This admits a safe stationary
+queue / a stopped lead the ego halts behind (was over-rejected by the reaction-time swerve term).
+
+**Multi-modal predictive RSS** (gap #3, LIVE): the snapshot RSS evaluates an object at its
+CURRENT position; the predictive pass rolls each `PredictedMode` forward in TIME and checks the
+time-matched ego pose — catching a cut-in / turn-in the snapshot filtered as laterally clear.
+Worst-case over modes (one dangerous hypothesis refuses). Producer: `predicted_modes_from_objects`
+(CV always; CTRV when the tracker yaw feed is fresh — stale yaw degrades to CV-only, not a fault).
+
+**Perception-divergence monitor** (gap #2b, True-Redundancy, LIVE): `cross_check` requires two
+independent perception channels to AGREE; a divergence (phantom / miss / speed mismatch) OR a
+silent secondary (redundancy lost) → `resolve_redundancy_cap` → `Some(0.0)` MRC-floor cap,
+composed into the Track-C `apply_perception_cap` derate. Env-gated (`KIRRA_PERCEPTION_REDUNDANCY_ENABLED`).
+
+**Occlusion-aware speed bound at junctions** (gap #1): `behavior::OccludedApproach` caps the
+approach speed to the assured-clear-distance speed (RSS Rule 4) for the junction's sight distance,
+so the ego CREEPS into a blind junction. Sight distance carried per approach-lane on `LaneGraph`.
+
+**Multi-junction routing** (`MickIntent::RouteTo`): resolve ego + destination lanes, `route_to_point`
+(Dijkstra picks the turn at each junction), materialize the stitched `route_corridor`, follow it.
+Re-resolved from the ego pose each tick (receding horizon). KIRRA bounds the corridor.
+
+**Learned doer** (`learned.rs`): a fixed trajectory vocabulary scored by a seeded-ES-fit MLP,
+distilled from a `Teacher` (`SafetyAware` vs `ProgressOnly`). `LearnedManeuverPlanner` adds a 2-D
+(lateral offset × speed) vocabulary so the net can ROUTE AROUND — KIRRA admits a band-clearing
+pass that fits the corridor, rejects one that doesn't or a misaligned straight-through.
+
+### Doer-checker invariants (NEVER violate)
+
+- The planner only **PROPOSES**; the checker (`validate_trajectory_slow*`) is the sole safety
+  authority. A planner change must keep its nominal output **checker-admissible**.
+- `PlanOutput::safe_stop` (the always-available MRC proposal) must always exist — a planner with
+  no stop output deadlocks the loop.
+- The RSS §4 **conjunction** (lateral fires only on abreast-OR-cut-in) must not regress to
+  lateral-on-proximity-alone (it over-rejects safe stationary objects).
+- New predictive bounds (occlusion, multi-modal, divergence) are **derate-only / fail-closed**:
+  absent input → no-op (byte-identical Nominal WCET path); a fault → an MRC-floor cap via
+  `apply_perception_cap`, never a relaxation. The WCET-critical per-pose `validate_vehicle_command`
+  path is UNCHANGED.
 
 ---
 
@@ -338,6 +405,12 @@ proptest = "1"  # dev-dependency
 | `KIRRA_SUPERVISOR_RESET_KEY` | Yes (reset ops) | — | Must be non-empty, ≤ 64 bytes |
 | `KIRRA_CANOPEN_NODE_MAP` | No | — | CANopen node-id → fleet-node-id map (#84), `canid:fleet_node` comma-separated (e.g. `5:robot-01,6:robot-02`). Unset → every NMT-offline is unattributed (fail-closed) |
 | `KIRRA_FABRIC_ASSET_ID` | No | — | Local fabric asset id fed by the verifier→fabric posture feed (#88). Unset/empty → feed inert (asset keeps its `Degraded` registration seed) |
+
+**`kirra-ros2-adapter` slow-loop env gates** (consumed in `node.rs`, opt-in, default off →
+byte-identical prior behaviour): `KIRRA_PERCEPTION_DERATE_ENABLED` (Track-C perception-derate cap),
+`KIRRA_PERCEPTION_REDUNDANCY_ENABLED` (the True-Redundancy divergence monitor — enables the
+`~/input/objects_secondary` channel-B subscription; enabled-but-silent-B → fail closed),
+`KIRRA_SUBSCRIPTION_STALENESS_MS` (subscription/channel freshness budget).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ Modern robotic and autonomous deployments increasingly rely on AI models to gene
 ### Autonomous Vehicle / Occy line
 - **SG2 drivable-space containment (ENFORCED)** — lateral margin ≥ 0.40 m against the HD-map corridor
 - **Option-B per-trajectory wiring** — two-rate (slow @ planning / fast @ control) Governor check on Autoware
-- **RSS-over-horizon** — IEEE 2846 safe-distance enforcement via parko-core (SG3)
+- **RSS-over-horizon** — IEEE 2846 safe-distance enforcement (SG3), as the **§4 conjunction** (danger needs BOTH longitudinal AND lateral unsafe — admits a safe stationary queue / stopped lead), plus **occlusion (RSS Rule 4)**, **multi-modal predictive RSS** (CV/CTRV modes, worst-cased), and a **True-Redundancy perception-divergence monitor** (two channels must agree; divergence → MRC-floor)
+- **Doer-checker planner (Occy)** — a swappable, never-trusted DOER (geometric / learned / LLM-driven Mick intents incl. **multi-junction `RouteTo`** and **occlusion-aware junction creep**) PROPOSES; KIRRA BOUNDS. `LearnedManeuverPlanner` proves a 2-D learned vocabulary stays governed.
 - **MRC publication** — `TrajectoryVerdict::{Accept,Clamp,MRCFallback,Pending}` published to the vehicle stack
 - **Lanelet2 corridor source** — cxx-rs wrapper around `lanelet2_core` + `boost::serialization` for `LaneletMapBin.data`
 - **Subscription-staleness watchdog** — fast-loop refuses to advance when trajectory / objects / odometry feeds go silent
@@ -602,6 +603,35 @@ KIRRA_VERIFIER_MODE=passive_standby KIRRA_INSTANCE_ID=kirra-standby ./kirra_veri
 ## Releases
 
 ### v1.2.0 (Occy line — in progress)
+
+**Junction safety + RSS completeness (doer-checker depth)**
+- **Multi-junction routing** — `MickIntent::RouteTo { x_m, y_m }`: resolve ego + destination
+  lanes, plan the lane-id route across every junction (`LaneGraph::route_to_point`, Dijkstra),
+  follow the stitched `route_corridor` through each turn; re-resolved from the ego pose each tick
+  (receding horizon). KIRRA bounds the corridor exactly as any other.
+- **Dynamic obstacle mid-turn** — the doer yields (predictive yield) / follows (lead-match) a
+  moving obstacle on the *curved* route corridor, and KIRRA's per-pose RSS bounds it; a dedicated
+  mid-turn predictive-yield gap (aligned to the checker's longitudinal-conflict distance) makes the
+  yield checker-*admissible* instead of fail-closing to MRC.
+- **Occlusion-aware speed bound at junctions** (RSS Rule 4, lateral) — a blind junction caps the
+  approach speed to the assured-clear-distance speed (`behavior::OccludedApproach`), so the ego
+  CREEPS in able to stop for emergent cross-traffic; sight distance carried per approach-lane on
+  `LaneGraph`.
+- **Multi-modal-prediction-aware RSS** (LIVE) — the checker's `predictive_rss_breach` now runs on
+  real perception: `prediction::predicted_modes_from_objects` rolls live objects into CV (+ CTRV
+  when the tracker yaw feed is fresh) `PredictedMode`s, worst-cased — catching a cut-in / turn-in
+  the snapshot RSS filtered as laterally clear.
+- **Perception-divergence assurance monitor** (True-Redundancy analog, LIVE) — `cross_check` of two
+  independent perception channels; a divergence (phantom / miss / speed mismatch) or a silent
+  redundant channel maps to an MRC-floor cap composed into the Track-C derate. Channel B feeds from
+  a `~/input/objects_secondary` subscription, gated on `KIRRA_PERCEPTION_REDUNDANCY_ENABLED`.
+- **Learned *maneuvering* doer** — `LearnedManeuverPlanner`: the Hydra-MDP-shaped learned planner
+  generalized to a 2-D (lateral offset × speed) trajectory vocabulary, so the learned scorer can
+  route AROUND a hazard — bounded by KIRRA (admits a band-clearing pass that fits, rejects one that
+  doesn't or a misaligned straight-through).
+- **Safety-weighted perception eval** — `kirra-taj::SemanticEvalSummary`: scores the semantic
+  detector at the fusion level (`UnsafeMiss` / `OverConservative` / `Correct`, `hazard_recall`,
+  per-class breakdown) — a missed hazard is the headline bar, not mAP.
 
 **S131 Option-B per-trajectory wiring on Autoware (#131 — closed)**
 - New `crates/kirra-ros2-adapter` crate (feature-gated on `ros2`)

--- a/crates/kirra-map/src/lanemap.rs
+++ b/crates/kirra-map/src/lanemap.rs
@@ -319,13 +319,44 @@ pub struct LaneGraph {
     ///
     /// [`cedes_to_ego`]: Self::cedes_to_ego
     priority_over: BTreeMap<u64, BTreeSet<u64>>,
+    /// **Junction occlusion**: `approach lane → assured-clear sight distance (m)` toward the
+    /// junction's cross-traffic conflict. Populated from the map + perception (a building /
+    /// hedge / parked car limits the view at the approach). Drives the occluded-junction
+    /// approach speed cap so the ego CREEPS into a blind junction (RSS Rule 4 applied laterally
+    /// at the junction). A lane absent from this map has an open view (no occlusion cap).
+    occlusion_sight: BTreeMap<u64, f64>,
 }
 
 impl LaneGraph {
     /// An empty graph.
     #[must_use]
     pub fn new() -> Self {
-        Self { lanes: BTreeMap::new(), priority_over: BTreeMap::new() }
+        Self { lanes: BTreeMap::new(), priority_over: BTreeMap::new(), occlusion_sight: BTreeMap::new() }
+    }
+
+    /// Record that approach `lane` has limited cross-traffic visibility — `sight_distance_m` of
+    /// assured-clear sight toward the junction conflict (a blind corner). Drives the occluded-
+    /// approach speed cap. A non-finite / negative distance is ignored (fail-safe: treated as no
+    /// occlusion datum rather than a spurious 0-speed creep).
+    pub fn set_occluded_approach(&mut self, lane: u64, sight_distance_m: f64) {
+        if sight_distance_m.is_finite() && sight_distance_m >= 0.0 {
+            self.occlusion_sight.insert(lane, sight_distance_m);
+        }
+    }
+
+    /// Builder form of [`set_occluded_approach`](Self::set_occluded_approach).
+    #[must_use]
+    pub fn with_occluded_approach(mut self, lane: u64, sight_distance_m: f64) -> Self {
+        self.set_occluded_approach(lane, sight_distance_m);
+        self
+    }
+
+    /// The assured-clear sight distance (m) toward the junction conflict for `lane`, or `None`
+    /// if the approach has an open view (no occlusion datum). The source the occluded-approach
+    /// speed cap is derived from.
+    #[must_use]
+    pub fn sight_distance(&self, lane: u64) -> Option<f64> {
+        self.occlusion_sight.get(&lane).copied()
     }
 
     /// Record that `priority_lane` has right-of-way over `yielding_lane` — traffic in
@@ -1285,6 +1316,20 @@ mod tests {
         let in_l1 = [obj(9, 15.0, 0.0)];
         assert_eq!(g.non_yielding_to_ego(2, &in_l1), vec![9]);
         assert!(g.cedes_to_ego(2, &in_l1).is_empty());
+    }
+
+    #[test]
+    fn occluded_approach_sight_distance_round_trips_and_fails_safe() {
+        let g = LaneGraph::new()
+            .with_lane(Lane::straight(1, 0.0, 0.0, 30.0, 2.0, LineType::Solid, LineType::Solid))
+            .with_occluded_approach(1, 6.0);
+        assert_eq!(g.sight_distance(1), Some(6.0), "the sight distance round-trips");
+        assert_eq!(g.sight_distance(2), None, "a lane with no datum has an open view");
+
+        // Non-finite / negative distances are ignored (no spurious occlusion datum).
+        let g2 = LaneGraph::new().with_occluded_approach(5, f64::NAN).with_occluded_approach(6, -3.0);
+        assert_eq!(g2.sight_distance(5), None, "NaN sight ignored (fail-safe)");
+        assert_eq!(g2.sight_distance(6), None, "negative sight ignored (fail-safe)");
     }
 
     #[test]

--- a/crates/kirra-planner/src/behavior.rs
+++ b/crates/kirra-planner/src/behavior.rs
@@ -84,6 +84,38 @@ pub enum TrafficControl {
     /// Rail / level crossing (R15-1): stop at the line when `must_stop` (a train
     /// is approaching, the gate is down, or the crossing signal is active).
     RailCrossing { stop_line_x_m: f64, must_stop: bool },
+    /// **Occluded junction approach** — RSS Rule 4 (caution under limited visibility)
+    /// applied LATERALLY at a junction. The ego is approaching the conflict point at
+    /// `conflict_line_x_m` but a building / parked car / hedge blocks its view of cross
+    /// traffic, so it has assured-clear sight of only `sight_distance_m` toward it. Unobserved
+    /// space is treated as possibly occupied by an emerging vehicle, so the approach speed is
+    /// capped to the **assured-clear-distance speed** — the most the ego may carry and still
+    /// brake to a stop within what it can see ([`assured_clear_distance_speed_cap`]). The ego
+    /// therefore CREEPS into a blind junction, fast where the view is open and slow where it is
+    /// not; as it nears the corner and perception reports more sight, the cap relaxes. The cap
+    /// applies only while the conflict is still ahead (once passed, the junction is cleared).
+    /// This is the behavioral/legal "slow for a blind corner" rule; KIRRA's RSS still bounds
+    /// any cross vehicle that actually becomes visible.
+    OccludedApproach { conflict_line_x_m: f64, sight_distance_m: f64 },
+}
+
+/// RSS reaction time (s) for the occlusion speed bound — the conservative SAE-L4 value, matched
+/// to the checker's `RSS_REACTION_TIME_S` so the doer's cap composes with the checker's bound.
+const OCCLUSION_REACTION_TIME_S: f64 = 0.5;
+
+/// RSS Rule 4 — the **assured-clear-distance** speed bound: the maximum speed (m/s) from which
+/// the ego can brake to a stop within `visible_m`, treating unobserved space beyond as
+/// potentially occupied. Includes the reaction distance ([`OCCLUSION_REACTION_TIME_S`]).
+/// Solves `v·t + v²/(2a) = visible` for `v`: `v = sqrt((a·t)² + 2·a·visible) − a·t`, clamped at
+/// 0. Mirrors the checker's `assured_clear_distance_speed_cap` so a doer plan capped here
+/// (with a comfortable decel ≤ the checker's brake decel) is checker-admissible, not just
+/// fail-closed.
+#[must_use]
+pub fn assured_clear_distance_speed_cap(visible_m: f64, brake_decel_mps2: f64) -> f64 {
+    let a = brake_decel_mps2.max(0.0);
+    let d = visible_m.max(0.0);
+    let t = OCCLUSION_REACTION_TIME_S;
+    (((a * t).powi(2) + 2.0 * a * d).sqrt() - a * t).max(0.0)
 }
 
 /// Tunables for the behavioral layer.
@@ -94,11 +126,16 @@ pub struct BehaviorConfig {
     pub amber_comfortable_decel_mps2: f64,
     /// Speed approaching a YIELD / flashing-amber control (slow, ready to stop).
     pub yield_speed_mps: f64,
+    /// Comfortable deceleration used to derive the occluded-junction approach speed cap (the
+    /// assured-clear-distance bound). Kept at/below a vehicle's hard brake so the doer's
+    /// occlusion cap is conservative w.r.t. the checker's RSS Rule 4 — the doer slows enough
+    /// that the resulting plan is checker-admissible.
+    pub occlusion_brake_decel_mps2: f64,
 }
 
 impl Default for BehaviorConfig {
     fn default() -> Self {
-        Self { amber_comfortable_decel_mps2: 3.0, yield_speed_mps: 4.0 }
+        Self { amber_comfortable_decel_mps2: 3.0, yield_speed_mps: 4.0, occlusion_brake_decel_mps2: 3.0 }
     }
 }
 
@@ -187,6 +224,17 @@ pub fn evaluate_controls(
                     out.add_stop(stop_line_x_m);
                 }
             }
+            TrafficControl::OccludedApproach { conflict_line_x_m, sight_distance_m } => {
+                // While the blind junction is still ahead, cap the speed to what the ego can
+                // stop within its assured-clear sight — it creeps in, ready for emergent
+                // cross-traffic. Once the conflict is passed, the junction is cleared (no cap).
+                if ahead(conflict_line_x_m) {
+                    out.add_cap(assured_clear_distance_speed_cap(
+                        sight_distance_m,
+                        cfg.occlusion_brake_decel_mps2,
+                    ));
+                }
+            }
             TrafficControl::SpeedLimit { from_x_m, limit_mps } => {
                 // In effect once we are at/after the sign, OR approaching it (we
                 // must already be at the limit by the time we reach it).
@@ -228,7 +276,7 @@ pub use kirra_map::lane_lines::{lateral_move_permitted, LaneBoundary, LineType};
 mod tests {
     use super::*;
 
-    const CFG: BehaviorConfig = BehaviorConfig { amber_comfortable_decel_mps2: 3.0, yield_speed_mps: 4.0 };
+    const CFG: BehaviorConfig = BehaviorConfig { amber_comfortable_decel_mps2: 3.0, yield_speed_mps: 4.0, occlusion_brake_decel_mps2: 3.0 };
 
     #[test]
     fn red_light_requires_stop_green_does_not() {
@@ -307,6 +355,44 @@ mod tests {
             TrafficControl::StopSign { stop_line_x_m: 12.0, satisfied: false },
         ];
         assert_eq!(evaluate_controls(&controls, 2.0, 6.0, &CFG).stop_x_m, Some(12.0));
+    }
+
+    #[test]
+    fn occluded_approach_caps_speed_to_the_assured_clear_distance() {
+        // 5 m of assured-clear sight toward a conflict 30 m ahead: cap = ACD(5, a=3, t=0.5) =
+        // sqrt(2.25 + 30) − 1.5 ≈ 4.18 m/s. A short-sight blind corner forces a creep.
+        let occ = [TrafficControl::OccludedApproach { conflict_line_x_m: 30.0, sight_distance_m: 5.0 }];
+        let cap = evaluate_controls(&occ, 5.0, 8.0, &CFG).speed_cap_mps.expect("occlusion caps speed");
+        let expect = assured_clear_distance_speed_cap(5.0, 3.0);
+        assert!((cap - expect).abs() < 1e-9, "cap is the ACD speed, got {cap} expect {expect}");
+        assert!(cap < 8.0, "the blind approach is slower than cruise, got {cap}");
+    }
+
+    #[test]
+    fn shorter_sight_caps_lower_more_blind_means_slower() {
+        let near = evaluate_controls(&[TrafficControl::OccludedApproach { conflict_line_x_m: 30.0, sight_distance_m: 3.0 }], 5.0, 8.0, &CFG).speed_cap_mps.unwrap();
+        let far = evaluate_controls(&[TrafficControl::OccludedApproach { conflict_line_x_m: 30.0, sight_distance_m: 12.0 }], 5.0, 8.0, &CFG).speed_cap_mps.unwrap();
+        assert!(near < far, "less sight → lower cap (creep more), got near {near} far {far}");
+        // A wide-open view imposes effectively no creep (the cap exceeds a normal cruise).
+        let open = evaluate_controls(&[TrafficControl::OccludedApproach { conflict_line_x_m: 30.0, sight_distance_m: 80.0 }], 5.0, 8.0, &CFG).speed_cap_mps.unwrap();
+        assert!(open > 12.0, "a clear view does not meaningfully cap, got {open}");
+    }
+
+    #[test]
+    fn occluded_approach_stops_capping_once_the_conflict_is_passed() {
+        // Conflict behind the ego (already through the junction) → no cap.
+        let passed = [TrafficControl::OccludedApproach { conflict_line_x_m: 10.0, sight_distance_m: 4.0 }];
+        assert_eq!(evaluate_controls(&passed, 15.0, 8.0, &CFG).speed_cap_mps, None);
+    }
+
+    #[test]
+    fn occlusion_cap_composes_with_other_speed_caps_taking_the_lowest() {
+        // A 4 m/s yield-like school-zone cap vs the ACD cap; the binding (lower) one wins.
+        let controls = [
+            TrafficControl::OccludedApproach { conflict_line_x_m: 40.0, sight_distance_m: 20.0 }, // ~9 m/s
+            TrafficControl::SchoolZone { from_x_m: 0.0, to_x_m: 50.0, limit_mps: 4.0, active: true },
+        ];
+        assert_eq!(evaluate_controls(&controls, 10.0, 10.0, &CFG).speed_cap_mps, Some(4.0));
     }
 
     // The lane-line crossing-rule tests moved with their types to

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -415,6 +415,19 @@ pub struct GeometricPlannerConfig {
     /// Longitudinal gap left between the controlled stop and the nearest in-path
     /// object — the planner stops this far short of it.
     pub object_stop_gap_m: f64,
+    /// Longitudinal gap left before a PREDICTED crossing / cut-in conflict (the
+    /// [`predict_yield_s`](GeometricPlanner::predict_yield_s) stop-line), distinct from the
+    /// static `object_stop_gap_m`. It is larger because a crossing object is still *laterally*
+    /// approaching the yield point: a stop only `object_stop_gap_m` short can leave the ego —
+    /// especially mid-turn, where the curving heading rotates the crosser to the edge of the
+    /// checker's lateral-alignment band — inside the checker's longitudinal-conflict window,
+    /// where its lateral RSS against a cutting-in object binds and MRC-rejects the yield. Set
+    /// to the checker's longitudinal-conflict distance (`RSS_LONGITUDINAL_CONFLICT_M` = 8 m) so
+    /// the stopped ego sits OUTSIDE that window — making a predicted-crossing yield
+    /// checker-ADMISSIBLE (a smooth doer yield) across straight AND curved geometry, instead of
+    /// fail-closing to the checker's safe-stop. On a straight road the outcome is unchanged
+    /// (already admissible); the ego merely yields a few metres earlier.
+    pub predictive_yield_gap_m: f64,
     /// Speed cap while an in-path object limits travel: the planner approaches a
     /// hazard slowly so the RSS following distance stays satisfied the whole way
     /// in (a planner that brakes only geometrically still over-speeds mid-approach
@@ -524,6 +537,7 @@ impl Default for GeometricPlannerConfig {
             goal_tolerance_m: 0.5,
             object_lane_tolerance_m: 2.0,
             object_stop_gap_m: 5.0,
+            predictive_yield_gap_m: 8.0,
             object_approach_speed_mps: 2.0,
             lateral_clearance_target_m: 4.5,
             lateral_offset_max_m: 3.0,
@@ -1206,7 +1220,7 @@ impl Planner for GeometricPlanner {
             if let Some(s_conflict) = self.predict_yield_s(
                 obj, input.motion, input.predicted_paths, &guide, s_ego, cur, target,
             ) {
-                let yield_s = s_conflict - self.cfg.object_stop_gap_m;
+                let yield_s = s_conflict - self.cfg.predictive_yield_gap_m;
                 if yield_s < s_limit {
                     s_limit = yield_s;
                     limit_kind = LimitKind::Yield;

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -469,31 +469,43 @@ fn derive_controls(world: &PlanInput<'_>) -> Vec<TrafficControl> {
     let Some(lane_id) = graph.lane_at(MapPoint { x_m: ego.x_m, y_m: ego.y_m }) else {
         return Vec::new();
     };
-    let Some(control) = graph.lane(lane_id).and_then(|l| l.control.map(|c| (c, l.stop_line_x()))) else {
-        return Vec::new();
-    };
-    let (control, line_x) = control;
-    let tc = match control {
-        LaneControl::Yield => TrafficControl::YieldSign { line_x_m: line_x },
-        LaneControl::Stop => {
-            let dist = line_x - ego.x_m;
-            let satisfied = world.ego.linear_x_mps.abs() < STOP_SATISFIED_SPEED_MPS
-                && dist > 0.0
-                && dist < STOP_SATISFIED_DIST_M;
-            TrafficControl::StopSign { stop_line_x_m: line_x, satisfied }
-        }
-        LaneControl::TrafficLight => {
-            // Live signal state for the governed (ego) lane — fail-closed to RED when the
-            // perception/V2X feed has no entry, so an unknown light HOLDS rather than runs it.
-            let state = world
-                .signal_states
-                .iter()
-                .find(|(id, _)| *id == lane_id)
-                .map_or(SignalState::Red, |(_, s)| *s);
-            TrafficControl::TrafficLight { stop_line_x_m: line_x, state }
-        }
-    };
-    vec![tc]
+    let lane = graph.lane(lane_id);
+    let mut out: Vec<TrafficControl> = Vec::new();
+
+    // Regulatory sign / signal at the lane terminus (its junction approach).
+    if let Some((control, line_x)) = lane.and_then(|l| l.control.map(|c| (c, l.stop_line_x()))) {
+        out.push(match control {
+            LaneControl::Yield => TrafficControl::YieldSign { line_x_m: line_x },
+            LaneControl::Stop => {
+                let dist = line_x - ego.x_m;
+                let satisfied = world.ego.linear_x_mps.abs() < STOP_SATISFIED_SPEED_MPS
+                    && dist > 0.0
+                    && dist < STOP_SATISFIED_DIST_M;
+                TrafficControl::StopSign { stop_line_x_m: line_x, satisfied }
+            }
+            LaneControl::TrafficLight => {
+                // Live signal state for the governed (ego) lane — fail-closed to RED when the
+                // perception/V2X feed has no entry, so an unknown light HOLDS rather than runs it.
+                let state = world
+                    .signal_states
+                    .iter()
+                    .find(|(id, _)| *id == lane_id)
+                    .map_or(SignalState::Red, |(_, s)| *s);
+                TrafficControl::TrafficLight { stop_line_x_m: line_x, state }
+            }
+        });
+    }
+
+    // Occluded junction approach: if the ego lane has limited cross-traffic visibility, derive
+    // the assured-clear-distance speed cap toward its terminus (the conflict line) so the ego
+    // creeps into the blind junction (RSS Rule 4). Composes with any sign control above (a blind
+    // STOP/YIELD approach gets both the stop/yield line AND the creep cap). A lane with an open
+    // view contributes nothing.
+    if let (Some(sight), Some(conflict_x)) = (graph.sight_distance(lane_id), lane.map(Lane::stop_line_x)) {
+        out.push(TrafficControl::OccludedApproach { conflict_line_x_m: conflict_x, sight_distance_m: sight });
+    }
+
+    out
 }
 
 /// Pick the ego lane's successor that turns `direction` (successor-by-heading): the matching

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -97,6 +97,21 @@ pub enum MickIntent {
     /// bounds the route corridor exactly as it bounds any corridor (a too-tight turn is
     /// refused).
     TurnAt { direction: TurnDirection },
+    /// Drive to a **world-frame destination across as many junctions as it takes** — the
+    /// multi-junction sibling of [`TurnAt`] (one junction) and [`GoTo`] (geometry, no
+    /// topology). Honored only if a `lane_graph` is supplied, the ego resolves to a lane,
+    /// the destination point resolves to a lane, and a route connects them: grounding plans
+    /// the lane-id route ([`LaneGraph::route_to_point`], Dijkstra — it takes the correct
+    /// turn at *each* junction and changes lane only when the route requires it),
+    /// materializes that whole route's corridor ([`LaneGraph::route_corridor`], which curves
+    /// through every junction on the way), and follows it toward the destination. No graph /
+    /// ego off-map / destination off-map / unreachable → fail-closed HOLD. The planner only
+    /// PROPOSES along the route; KIRRA bounds the materialized corridor exactly as it bounds
+    /// any other (a too-tight turn anywhere on the route is refused). The route is re-planned
+    /// each tick, so it is robust to the ego being nudged between lanes (receding horizon).
+    ///
+    /// [`GoTo`]: MickIntent::GoTo
+    RouteTo { x_m: f64, y_m: f64 },
 }
 
 /// LLM JSON wire schema (tagged on `"intent"`). Kept separate from [`MickIntent`]
@@ -118,6 +133,8 @@ enum IntentJson {
     PullOver,
     #[serde(rename = "turn_at")]
     TurnAt { direction: String },
+    #[serde(rename = "route_to")]
+    RouteTo { x_m: f64, y_m: f64 },
 }
 
 impl MickIntent {
@@ -152,6 +169,7 @@ impl MickIntent {
                 };
                 MickIntent::TurnAt { direction: dir }
             }
+            IntentJson::RouteTo { x_m, y_m } => MickIntent::RouteTo { x_m, y_m },
         };
         if !intent.is_finite() {
             return Err("MICK_NONFINITE_INTENT");
@@ -168,6 +186,7 @@ impl MickIntent {
             MickIntent::Overtake => true,
             MickIntent::PullOver => true,
             MickIntent::TurnAt { .. } => true,
+            MickIntent::RouteTo { x_m, y_m } => x_m.is_finite() && y_m.is_finite(),
         }
     }
 }
@@ -311,40 +330,95 @@ pub fn plan_for_intent(
             let Some(route) = turn_route(graph, ego_lane, direction) else {
                 return PlanOutput::safe_stop(world.ego.pose);
             };
-            let Some(corridor) = graph.route_corridor(&route, ROUTE_CORRIDOR_CONFIDENCE, ROUTE_CORRIDOR_AGE_MS)
-            else {
+            // Follow the turn's route corridor; the goal is unchanged (the turn drives toward
+            // whatever the world goal already is). KIRRA bounds it like any corridor.
+            plan_along_route(planner, world, graph, ego_lane, &route, world.goal)
+        }
+        MickIntent::RouteTo { x_m, y_m } => {
+            // Multi-junction routing: resolve ego + destination lanes and plan the lane-id
+            // route between them, FAIL-CLOSED at every step (no graph / ego off-map /
+            // destination off-map / unreachable → HOLD). `route_to_point` (Dijkstra) takes
+            // the correct turn at EACH junction; `plan_along_route` materializes that whole
+            // route's corridor (curving through every junction) and follows it. KIRRA bounds
+            // the corridor exactly as it bounds a single-junction turn.
+            if !x_m.is_finite() || !y_m.is_finite() {
+                return PlanOutput::safe_stop(world.ego.pose);
+            }
+            let Some(graph) = world.lane_graph else {
                 return PlanOutput::safe_stop(world.ego.pose);
             };
-            // Widen the turn: the route's full width (route + lateral neighbors) is the
-            // `drivable` area a route-around / lane-change may borrow WITHIN the turn, and the
-            // typed lines over the ego lane + its neighbors gate that lateral move. Only when
-            // the integrator didn't supply them; `None`/empty → the single-lane turn-follow.
-            let drivable = if world.drivable.is_none() {
-                graph.route_drivable(&route, ROUTE_CORRIDOR_CONFIDENCE, ROUTE_CORRIDOR_AGE_MS)
-            } else {
-                None
+            let ego_pt = MapPoint { x_m: world.ego.pose.x_m, y_m: world.ego.pose.y_m };
+            let Some(ego_lane) = graph.lane_at(ego_pt) else {
+                return PlanOutput::safe_stop(world.ego.pose);
             };
-            let lane = graph.lane(ego_lane);
-            let neighbors: Vec<u64> = std::iter::once(ego_lane)
-                .chain(lane.and_then(Lane::left_neighbor))
-                .chain(lane.and_then(Lane::right_neighbor))
-                .collect();
-            let boundaries = if world.lane_boundaries.is_empty() {
-                graph.boundaries_relative_to(ego_lane, &neighbors)
-            } else {
-                None
+            let Some(route) = graph.route_to_point(ego_lane, MapPoint { x_m, y_m }) else {
+                return PlanOutput::safe_stop(world.ego.pose);
             };
-            planner.plan(&PlanInput {
-                map: &corridor,
-                drivable: drivable
-                    .as_ref()
-                    .map(|d| d as &dyn CorridorSource)
-                    .or(world.drivable),
-                lane_boundaries: boundaries.as_deref().unwrap_or(world.lane_boundaries),
-                ..world.clone()
-            })
+            // Drive toward the destination point (world frame), keeping the world's heading
+            // reference — the same goal override `GoTo` uses, but along the routed corridor.
+            let goal = Goal {
+                target: Pose { x_m, y_m, heading_rad: world.goal.target.heading_rad },
+            };
+            plan_along_route(planner, world, graph, ego_lane, &route, goal)
         }
     }
+}
+
+/// Materialize a lane-id `route` into its drivable corridor and plan along it toward `goal`.
+/// The shared grounding behind the single-junction [`MickIntent::TurnAt`] and the
+/// multi-junction [`MickIntent::RouteTo`]: both reduce to "follow THIS route's corridor",
+/// differing only in how the route is chosen and whether the goal is overridden.
+///
+/// Materializes three map-derived inputs (each only when the integrator didn't hand-supply
+/// the corresponding field, so an explicit input is never overridden):
+/// * the reference corridor ([`LaneGraph::route_corridor`]) the path follows — `map`;
+/// * the widened drivable area ([`LaneGraph::route_drivable`]) a route-around / lane-change
+///   may borrow within a turn — `drivable`;
+/// * the typed lane boundaries over the ego lane + its lateral neighbors — `lane_boundaries`.
+///
+/// **Fail-closed:** a degenerate route corridor (`route_corridor` → `None`) HOLDs. KIRRA
+/// bounds the materialized corridor regardless — the planner only PROPOSES along it.
+fn plan_along_route(
+    planner: &mut impl Planner,
+    world: &PlanInput,
+    graph: &LaneGraph,
+    ego_lane: u64,
+    route: &[u64],
+    goal: Goal,
+) -> PlanOutput {
+    let Some(corridor) = graph.route_corridor(route, ROUTE_CORRIDOR_CONFIDENCE, ROUTE_CORRIDOR_AGE_MS)
+    else {
+        return PlanOutput::safe_stop(world.ego.pose);
+    };
+    // Widen the route: its full width (route + lateral neighbors) is the `drivable` area a
+    // route-around / lane-change may borrow WITHIN the route, and the typed lines over the ego
+    // lane + its neighbors gate that lateral move. Only when the integrator didn't supply them;
+    // `None`/empty → the single-lane route-follow.
+    let drivable = if world.drivable.is_none() {
+        graph.route_drivable(route, ROUTE_CORRIDOR_CONFIDENCE, ROUTE_CORRIDOR_AGE_MS)
+    } else {
+        None
+    };
+    let lane = graph.lane(ego_lane);
+    let neighbors: Vec<u64> = std::iter::once(ego_lane)
+        .chain(lane.and_then(Lane::left_neighbor))
+        .chain(lane.and_then(Lane::right_neighbor))
+        .collect();
+    let boundaries = if world.lane_boundaries.is_empty() {
+        graph.boundaries_relative_to(ego_lane, &neighbors)
+    } else {
+        None
+    };
+    planner.plan(&PlanInput {
+        goal,
+        map: &corridor,
+        drivable: drivable
+            .as_ref()
+            .map(|d| d as &dyn CorridorSource)
+            .or(world.drivable),
+        lane_boundaries: boundaries.as_deref().unwrap_or(world.lane_boundaries),
+        ..world.clone()
+    })
 }
 
 /// Map-server health stamped on a route corridor materialized for a `TurnAt`: fresh and
@@ -1283,6 +1357,141 @@ mod tests {
         assert_eq!(plan.kind, crate::ProposalKind::Motion, "mid-arc TurnAt continues the turn, not a HOLD");
         let max_y = plan.trajectory.iter().map(|p| p.pose.y_m).fold(f64::MIN, f64::max);
         assert!(max_y > 5.0, "the continued turn climbs the arc toward the exit (y≈12), got max_y {max_y}");
+    }
+
+    // ----- the RouteTo intent (multi-junction routing) -----
+
+    /// A planner that records the reference corridor (`map`) it was grounded with — so a test
+    /// can assert that `RouteTo` materialized the WHOLE multi-junction route's corridor (it
+    /// curves up into the final exit lane), not just the ego's current straight lane.
+    struct MapRecorder {
+        left_last: Option<MapPoint>,
+        left_len: usize,
+    }
+    impl Planner for MapRecorder {
+        fn plan(&mut self, input: &PlanInput<'_>) -> PlanOutput {
+            let lb = input.map.left_boundary();
+            self.left_len = lb.len();
+            self.left_last = lb.last().copied();
+            PlanOutput::safe_stop(input.ego.pose)
+        }
+    }
+
+    /// A quarter-circle arc (n+1 points) sweeping `sweep` rad (±π/2) from `start_angle` about
+    /// `(cx, cy)` at radius `r` — a smooth turn centerline (+ = CCW/left, − = CW/right).
+    fn quarter_arc(cx: f64, cy: f64, r: f64, start_angle: f64, sweep: f64, n: usize) -> Vec<MapPoint> {
+        (0..=n)
+            .map(|i| {
+                let t = start_angle + sweep * (i as f64 / n as f64);
+                MapPoint { x_m: cx + r * t.cos(), y_m: cy + r * t.sin() }
+            })
+            .collect()
+    }
+
+    /// A **two-junction** route: straight east (1) → LEFT arc (2) → straight north (3) → RIGHT
+    /// arc (4) → straight east (5). Lane 1 also carries a DECOY right branch (6, a dead-end
+    /// south) so reaching the destination genuinely requires the router to pick the correct
+    /// branch at the first junction. Lanes are 3 m half-width (the turning footprint stays
+    /// contained, cf. the closed-loop turn test); arcs use r = 12.
+    fn two_junction_route() -> crate::LaneGraph {
+        use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI};
+        let r = 12.0;
+        // J1: left arc (CCW), centre (30,12), θ −π/2→0: (30,0)→(42,12), east→north.
+        let arc_left = quarter_arc(30.0, 12.0, r, -FRAC_PI_2, FRAC_PI_2, 12);
+        // J2: right arc (CW), centre (54,40), θ π→π/2: (42,40)→(54,52), north→east.
+        let arc_right = quarter_arc(54.0, 40.0, r, PI, -FRAC_PI_2, 12);
+        let lane = |id, cl: Vec<MapPoint>, heading, succ: &[u64]| crate::Lane {
+            id,
+            centerline: cl,
+            half_width_m: 3.0,
+            left_line: crate::LineType::Solid,
+            right_line: crate::LineType::Solid,
+            heading_rad: heading,
+            edges: succ.iter().map(|&to| crate::LaneEdge::Successor { to }).collect(),
+            control: None,
+        };
+        crate::LaneGraph::new()
+            .with_lane(lane(1, vec![MapPoint { x_m: 0.0, y_m: 0.0 }, MapPoint { x_m: 30.0, y_m: 0.0 }], 0.0, &[2, 6]))
+            .with_lane(lane(2, arc_left, FRAC_PI_4, &[3]))
+            .with_lane(lane(3, vec![MapPoint { x_m: 42.0, y_m: 12.0 }, MapPoint { x_m: 42.0, y_m: 40.0 }], FRAC_PI_2, &[4]))
+            .with_lane(lane(4, arc_right, FRAC_PI_4, &[5]))
+            .with_lane(lane(5, vec![MapPoint { x_m: 54.0, y_m: 52.0 }, MapPoint { x_m: 80.0, y_m: 52.0 }], 0.0, &[]))
+            // Decoy: a right branch off lane 1 heading south, dead-ending (never reaches 5).
+            .with_lane(lane(6, vec![MapPoint { x_m: 30.0, y_m: 0.0 }, MapPoint { x_m: 30.0, y_m: -20.0 }], -FRAC_PI_2, &[]))
+    }
+
+    #[test]
+    fn route_to_llm_json_parses_and_fails_closed_on_nonfinite() {
+        assert_eq!(
+            MickIntent::from_llm_json(r#"{"intent":"route_to","x_m":72.0,"y_m":52.0}"#).unwrap(),
+            MickIntent::RouteTo { x_m: 72.0, y_m: 52.0 }
+        );
+        // A hallucinated non-finite destination must fail closed (caller HOLDs), never flow in.
+        assert!(MickIntent::from_llm_json(r#"{"intent":"route_to","x_m":1e400,"y_m":0.0}"#).is_err());
+        assert!(MickIntent::from_llm_json(r#"{"intent":"route_to","y_m":0.0}"#).is_err(), "missing field fails closed");
+    }
+
+    #[test]
+    fn route_to_grounds_a_multi_junction_route_following_the_stitched_corridor() {
+        // The router must pick the LEFT branch at J1 (over the decoy) to reach the destination
+        // in lane 5, then the route corridor stitches BOTH turns into one materialized handle.
+        let g = two_junction_route();
+        assert_eq!(g.route_to_point(1, Point { x_m: 72.0, y_m: 52.0 }), Some(vec![1, 2, 3, 4, 5]),
+            "routing selects the correct branch at each junction across both turns");
+
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let ego = EgoState {
+            pose: Pose { x_m: 16.0, y_m: 0.0, heading_rad: 0.0 },
+            linear_x_mps: 4.0,
+            yaw_rate_rads: 0.0,
+            stamp_ms: 0,
+        };
+        let w = PlanInput { ego, map: &corr, lane_graph: Some(&g), ..world(&corr, &[], &[]) };
+
+        // The corridor the planner is grounded with is the WHOLE route's, curving through both
+        // junctions up into the final east-bound exit lane (its far end sits at y≈52, x≈80) —
+        // not the flat world corridor (which would end at y≈0). That is the multi-junction stitch.
+        let mut rec = MapRecorder { left_last: None, left_len: 0 };
+        let _ = plan_for_intent(&mut rec, &MickIntent::RouteTo { x_m: 72.0, y_m: 52.0 }, &w);
+        let last = rec.left_last.expect("the route corridor was materialized and grounded");
+        assert!(last.y_m > 45.0, "the stitched corridor climbs through both junctions into lane 5 (y≈52), got y={}", last.y_m);
+        assert!(last.x_m > 60.0, "and reaches east along the final exit lane, got x={}", last.x_m);
+
+        // And a real planner produces a MOTION plan along it (not a fail-closed HOLD).
+        let plan = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::RouteTo { x_m: 72.0, y_m: 52.0 }, &w);
+        assert_eq!(plan.kind, crate::ProposalKind::Motion, "RouteTo grounds a motion plan along the route");
+    }
+
+    #[test]
+    fn route_to_fails_closed_when_it_cannot_route() {
+        let g = two_junction_route();
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let on_map = EgoState {
+            pose: Pose { x_m: 16.0, y_m: 0.0, heading_rad: 0.0 },
+            linear_x_mps: 4.0,
+            yaw_rate_rads: 0.0,
+            stamp_ms: 0,
+        };
+        let is_hold = |p: &PlanOutput| p.kind == crate::ProposalKind::SafeStop && p.trajectory.iter().all(|t| t.velocity_mps == 0.0);
+
+        // No lane graph → HOLD.
+        let no_graph = PlanInput { ego: on_map, map: &corr, lane_graph: None, ..world(&corr, &[], &[]) };
+        assert!(is_hold(&plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::RouteTo { x_m: 72.0, y_m: 52.0 }, &no_graph)), "no graph → HOLD");
+
+        // Ego off the mapped road → HOLD.
+        let off = EgoState { pose: Pose { x_m: 16.0, y_m: 99.0, heading_rad: 0.0 }, ..on_map };
+        let ego_off = PlanInput { ego: off, map: &corr, lane_graph: Some(&g), ..world(&corr, &[], &[]) };
+        assert!(is_hold(&plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::RouteTo { x_m: 72.0, y_m: 52.0 }, &ego_off)), "ego off-map → HOLD");
+
+        // Destination off the mapped road → HOLD.
+        let w = PlanInput { ego: on_map, map: &corr, lane_graph: Some(&g), ..world(&corr, &[], &[]) };
+        assert!(is_hold(&plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::RouteTo { x_m: 72.0, y_m: 999.0 }, &w)), "destination off-map → HOLD");
+
+        // Reachable-only-via-the-decoy is fine, but a genuinely unreachable destination HOLDs:
+        // the decoy lane 6 is a dead-end, so a point beyond it that no route reaches → HOLD.
+        // (Routing to the decoy's own lane is reachable; pick a point off every lane instead —
+        // covered above. Here assert a non-finite destination also HOLDs at grounding.)
+        assert!(is_hold(&plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::RouteTo { x_m: f64::NAN, y_m: 0.0 }, &w)), "non-finite destination → HOLD");
     }
 
     // ----- junction right-of-way wired into cedes_to_ego_ids -----

--- a/crates/kirra-planner/src/mick_capture.rs
+++ b/crates/kirra-planner/src/mick_capture.rs
@@ -95,6 +95,8 @@ impl MickDecisionRecord {
             MickIntent::Overtake => ("overtake", None, None, None, None),
             MickIntent::PullOver => ("pull_over", None, None, None, None),
             MickIntent::TurnAt { .. } => ("turn_at", None, None, None, None),
+            // The routed destination reuses the goal_x_m/goal_y_m record fields.
+            MickIntent::RouteTo { x_m, y_m } => ("route_to", Some(x_m), Some(y_m), None, None),
         };
         let turn_direction = match *intent {
             MickIntent::TurnAt { direction } => Some(direction.as_str()),

--- a/crates/kirra-planner/src/mick_llm.rs
+++ b/crates/kirra-planner/src/mick_llm.rs
@@ -45,6 +45,7 @@ Respond with ONLY one JSON object (no prose, no code fence), in one of these for
   {{\"intent\":\"overtake\"}}                                   pass the slow/stopped lead ahead\n\
   {{\"intent\":\"pull_over\"}}                                  get to the road edge and stop\n\
   {{\"intent\":\"turn_at\",\"direction\":\"left|right|straight\"}}  take the junction branch that way\n\
+  {{\"intent\":\"route_to\",\"x_m\":<number>,\"y_m\":<number>}}  drive to a destination via the road network\n\
   {{\"intent\":\"hold\"}}                                       stop and hold\n\
 \n\
 Drive smoothly and comfortably; ease off near objects and when posture is DEGRADED. You \
@@ -63,6 +64,7 @@ Examples (situation → intent):\n\
 {{\"intent\":\"pull_over\"}}\n\
 - a junction ahead and the goal is to your left → {{\"intent\":\"turn_at\",\"direction\":\"left\"}}\n\
 - the goal is off to one side and reachable → {{\"intent\":\"go_to\",\"x_m\":20,\"y_m\":-4}}\n\
+- a far destination reachable through several junctions → {{\"intent\":\"route_to\",\"x_m\":120,\"y_m\":40}}\n\
 \n\
 Situation:\n{situation}\n\
 \n\
@@ -95,7 +97,7 @@ pub fn intent_schema() -> serde_json::Value {
         "properties": {
             "intent": {
                 "type": "string",
-                "enum": ["go_to", "lane_change", "hold", "cruise", "overtake", "pull_over", "turn_at"]
+                "enum": ["go_to", "lane_change", "hold", "cruise", "overtake", "pull_over", "turn_at", "route_to"]
             },
             "x_m": { "type": "number" },
             "y_m": { "type": "number" },
@@ -178,7 +180,7 @@ mod tests {
     fn prompt_carries_the_schema_and_the_situation() {
         let p = build_prompt(&sample_ctx());
         // The typed-intent contract the model must follow.
-        for tag in ["cruise", "go_to", "lane_change", "overtake", "pull_over", "turn_at", "hold"] {
+        for tag in ["cruise", "go_to", "lane_change", "overtake", "pull_over", "turn_at", "route_to", "hold"] {
             assert!(p.contains(tag), "prompt must list the {tag} intent");
         }
         // The ego-relative situation is embedded (serialized WorldContext).
@@ -219,6 +221,7 @@ mod tests {
             (r#"{"intent":"overtake"}"#, "overtake"),
             (r#"{"intent":"pull_over"}"#, "pull_over"),
             (r#"{"intent":"turn_at","direction":"left"}"#, "turn_at"),
+            (r#"{"intent":"route_to","x_m":120.0,"y_m":40.0}"#, "route_to"),
         ];
         for (json, tag) in cases {
             assert!(enum_tags.contains(&tag.to_string()), "schema enum must list {tag}");

--- a/crates/kirra-planner/tests/dynamic_obstacle_mid_turn.rs
+++ b/crates/kirra-planner/tests/dynamic_obstacle_mid_turn.rs
@@ -111,6 +111,16 @@ fn a_dynamic_crosser_mid_turn_is_yielded_by_the_doer_and_bounded_by_kirra() {
     assert!(terminal_v(&yielded) < 0.5, "the yield is a decel-to-stop, terminal v {}", terminal_v(&yielded));
     assert!(max_y(&yielded) < max_y(&clear) - 4.0, "the doer yields well short of the clear-turn reach");
 
+    // Doer-checker AGREEMENT (the predictive-yield-gap refinement): the doer's yield leaves the
+    // checker's longitudinal-conflict distance before the crossing, so the stopped ego sits
+    // outside the window where the lateral RSS against the cutting-in crosser binds → KIRRA
+    // ADMITS the smooth yield instead of fail-closing to a safe-stop MRC.
+    assert!(
+        admitted(verdict(&yielded.trajectory, &map, &objs)),
+        "KIRRA admits the doer's predictive-yield mid-turn (smooth yield, not fail-closed MRC), got {:?}",
+        verdict(&yielded.trajectory, &map, &objs)
+    );
+
     // KIRRA independently bounds the dynamic obstacle mid-turn: the clear-turn trajectory, driven
     // INTO the crosser, is refused (the laterally cutting-in crosser breaches RSS on the arc).
     assert_eq!(

--- a/crates/kirra-planner/tests/dynamic_obstacle_mid_turn.rs
+++ b/crates/kirra-planner/tests/dynamic_obstacle_mid_turn.rs
@@ -1,0 +1,152 @@
+//! **A dynamic obstacle encountered MID-TURN — doer adapts on the curved arc, KIRRA bounds it.**
+//!
+//! The junction tests (`turn_at_junction`, `intersection_closed_loop`, `multi_junction_route`)
+//! drive turns on a CLEAR route, or with a static vehicle safely off the path. This pins the
+//! missing case: a *moving* obstacle that conflicts with the ego while it is committed to the
+//! turn — the realistic junction hazard (a vehicle crossing the exit, a slow lead in it). The
+//! ego is following the stitched route corridor's CURVED centerline, so this also proves the
+//! planner's predictive-yield and lead-follow logic (which project objects onto the `guide`) and
+//! KIRRA's per-pose RSS both work on a curved trajectory, not just a straight one.
+//!
+//! Two complementary behaviors, the doer-checker split at the junction:
+//!   * a crossing HAZARD the ego cannot safely clear → the doer YIELDS (decelerates to a stop
+//!     short on the arc) AND KIRRA refuses an unsafe drive-through (fail-closed defense in depth);
+//!   * a slow LEAD moving up the exit ahead → the doer FOLLOWS it (speed-matched) and KIRRA
+//!     ADMITS the follow, while still refusing the cruise-through plan (doer-checker agreement on
+//!     a safe maneuver, the checker bounding the unsafe alternative).
+
+use kirra_planner::{
+    EgoState, FleetPosture, GeometricPlanner, Goal, Lane, LaneEdge, LaneGraph, LineType, MotionState,
+    PerceivedObject, PlanInput, Planner, Pose, ProposalKind, TrajectoryVerdict,
+};
+use kirra_ros2_adapter::corridor::Point;
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+/// A quarter-circle arc (n+1 points) sweeping +π/2 about `(cx, cy)` from `start` — a smooth
+/// LEFT-turn centerline.
+fn quarter_arc(cx: f64, cy: f64, r: f64, start: f64, n: usize) -> Vec<Point> {
+    (0..=n)
+        .map(|i| {
+            let t = start + std::f64::consts::FRAC_PI_2 * (i as f64 / n as f64);
+            Point { x_m: cx + r * t.cos(), y_m: cy + r * t.sin() }
+        })
+        .collect()
+}
+
+/// Left-turn junction (arc radius `r`, lane half-width 3): approach east (1) → LEFT arc (2) →
+/// straight north exit (3, at x = 20+r).
+fn left_turn(r: f64) -> LaneGraph {
+    let line = LineType::Solid;
+    let arc = quarter_arc(20.0, r, r, -std::f64::consts::FRAC_PI_2, 12);
+    LaneGraph::new()
+        .with_lane(Lane::straight(1, 0.0, 0.0, 20.0, 3.0, line, line).with_edge(LaneEdge::Successor { to: 2 }))
+        .with_lane(Lane { id: 2, centerline: arc, half_width_m: 3.0, left_line: line, right_line: line, heading_rad: std::f64::consts::FRAC_PI_4, edges: vec![LaneEdge::Successor { to: 3 }], control: None })
+        .with_lane(Lane { id: 3, centerline: vec![Point { x_m: 20.0 + r, y_m: r }, Point { x_m: 20.0 + r, y_m: r + 20.0 }], half_width_m: 3.0, left_line: line, right_line: line, heading_rad: std::f64::consts::FRAC_PI_2, edges: Vec::new(), control: None })
+}
+
+const R: f64 = 12.0;
+
+/// The ego committed to the turn, low on the arc (heading part-way between east and north),
+/// driving toward a goal up the exit lane along the stitched route corridor.
+fn mid_turn_world<'a>(map: &'a dyn kirra_ros2_adapter::corridor::CorridorSource, objects: &'a [PerceivedObject], motion: &'a [MotionState]) -> PlanInput<'a> {
+    PlanInput {
+        ego: EgoState { pose: Pose { x_m: 23.5, y_m: 1.0, heading_rad: 0.4 }, linear_x_mps: 3.0, yaw_rate_rads: 0.0, stamp_ms: 0 },
+        goal: Goal { target: Pose { x_m: 20.0 + R, y_m: R + 16.0, heading_rad: std::f64::consts::FRAC_PI_2 } },
+        map,
+        objects,
+        controls: &[],
+        lane_boundaries: &[],
+        motion,
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+        request_overtake: false,
+        request_pull_over: false,
+        lane_graph: None,
+        signal_states: &[],
+    }
+}
+
+fn verdict(traj: &[kirra_planner::TrajectoryPoint], map: &dyn kirra_ros2_adapter::corridor::CorridorSource, objs: &[PerceivedObject]) -> TrajectoryVerdict {
+    validate_trajectory_slow(traj, map, objs, &VehicleConfig::default_urban(), None, FleetPosture::Nominal)
+}
+fn admitted(v: TrajectoryVerdict) -> bool {
+    matches!(v, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp)
+}
+fn max_y(p: &kirra_planner::PlanOutput) -> f64 {
+    p.trajectory.iter().map(|t| t.pose.y_m).fold(f64::MIN, f64::max)
+}
+fn terminal_v(p: &kirra_planner::PlanOutput) -> f64 {
+    p.trajectory.last().map(|t| t.velocity_mps).unwrap_or(0.0)
+}
+
+#[test]
+fn a_dynamic_crosser_mid_turn_is_yielded_by_the_doer_and_bounded_by_kirra() {
+    let g = left_turn(R);
+    let route = g.route(1, 3).unwrap();
+    let map = g.route_corridor(&route, 0.95, 10).unwrap();
+    let mut occy = GeometricPlanner::default();
+
+    // Control: on a CLEAR turn the ego drives up through the junction past y=18 and KIRRA admits.
+    let clear = occy.plan(&mid_turn_world(&map, &[], &[]));
+    assert_eq!(clear.kind, ProposalKind::Motion);
+    assert!(max_y(&clear) > 18.0, "clear turn climbs through the junction, got max_y {}", max_y(&clear));
+    assert!(admitted(verdict(&clear.trajectory, &map, &[])), "KIRRA admits the clear turn");
+
+    // A vehicle crossing the EXIT lane westbound, lingering in the conflict band. At planning
+    // time it sits 4 m right of the exit centerline → OUT of the stop-short lane band, so the
+    // PREDICTIVE yield (rolling its motion forward onto the curved guide) is what must catch it.
+    let crosser = PerceivedObject { id: 7, pos: Point { x_m: 36.0, y_m: 18.0 }, velocity_mps: 1.5, heading_rad: std::f64::consts::PI, vel: Point { x_m: -1.5, y_m: 0.0 } };
+    let objs = [crosser];
+    let motion = [MotionState { id: 7, yaw_rate_rad_s: 0.0 }];
+
+    // The doer YIELDS: predictive yield fires on the curved arc → the plan decelerates to a stop
+    // SHORT of the crosser (well below the clear plan's reach), rather than driving into it.
+    let yielded = occy.plan(&mid_turn_world(&map, &objs, &motion));
+    assert!(max_y(&yielded) < 15.0, "the doer stops short of the crossing hazard, got max_y {}", max_y(&yielded));
+    assert!(terminal_v(&yielded) < 0.5, "the yield is a decel-to-stop, terminal v {}", terminal_v(&yielded));
+    assert!(max_y(&yielded) < max_y(&clear) - 4.0, "the doer yields well short of the clear-turn reach");
+
+    // KIRRA independently bounds the dynamic obstacle mid-turn: the clear-turn trajectory, driven
+    // INTO the crosser, is refused (the laterally cutting-in crosser breaches RSS on the arc).
+    assert_eq!(
+        verdict(&clear.trajectory, &map, &objs),
+        TrajectoryVerdict::MRCFallback,
+        "KIRRA refuses driving the turn through the crossing hazard"
+    );
+}
+
+#[test]
+fn a_dynamic_lead_mid_turn_is_followed_by_the_doer_and_kirra_admits_the_follow() {
+    let g = left_turn(R);
+    let route = g.route(1, 3).unwrap();
+    let map = g.route_corridor(&route, 0.95, 10).unwrap();
+    let mut occy = GeometricPlanner::default();
+
+    let clear = occy.plan(&mid_turn_world(&map, &[], &[]));
+
+    // A slow vehicle moving NORTH up the exit lane ahead — same direction as the ego's exit. The
+    // doer should treat it as a moving LEAD: follow at a gap (speed-matched), not blow past it.
+    let lead = PerceivedObject { id: 8, pos: Point { x_m: 20.0 + R, y_m: 18.0 }, velocity_mps: 1.5, heading_rad: std::f64::consts::FRAC_PI_2, vel: Point { x_m: 0.0, y_m: 1.5 } };
+    let objs = [lead];
+    let motion = [MotionState { id: 8, yaw_rate_rad_s: 0.0 }];
+
+    // The doer FOLLOWS the dynamic lead: a motion plan that holds well back behind it (much less
+    // reach than the clear turn) — and KIRRA ADMITS the follow (rear-end RSS satisfied on the arc).
+    let follow = occy.plan(&mid_turn_world(&map, &objs, &motion));
+    assert_eq!(follow.kind, ProposalKind::Motion, "the doer follows the lead (motion), not a dead HOLD");
+    assert!(max_y(&follow) < max_y(&clear) - 5.0, "the follow holds back behind the lead, got max_y {} vs clear {}", max_y(&follow), max_y(&clear));
+    assert!(admitted(verdict(&follow.trajectory, &map, &objs)), "KIRRA admits the speed-matched follow through the turn");
+
+    // The payoff: the cruise-through plan (ignoring the lead) is refused — KIRRA bounds the
+    // dynamic lead mid-turn even though the doer-followed alternative is admitted.
+    assert_eq!(
+        verdict(&clear.trajectory, &map, &objs),
+        TrajectoryVerdict::MRCFallback,
+        "KIRRA refuses cruising the turn into the slow lead"
+    );
+}

--- a/crates/kirra-planner/tests/multi_junction_route.rs
+++ b/crates/kirra-planner/tests/multi_junction_route.rs
@@ -1,0 +1,152 @@
+//! Deterministic proof for **multi-junction routing** (`MickIntent::RouteTo`): a scripted
+//! `RouteTo` brain is handed a destination several junctions away, and the ego drives the whole
+//! **two-junction** route closed-loop — LEFT through the first junction, NORTH along the
+//! connector, then RIGHT through the second — reaching the final east-bound exit lane, with
+//! KIRRA bounding every pose it takes.
+//!
+//! This is the destination-routing sibling of `intersection_closed_loop.rs` (one junction,
+//! `TurnAt`): there the brain names a turn; here it names a *place*, and the planner resolves the
+//! lane-id route across BOTH junctions (`LaneGraph::route_to_point`, Dijkstra — it must pick the
+//! correct branch at the first junction over a decoy that dead-ends), materializes that whole
+//! route's corridor (curving through every junction), and follows it. The route is re-resolved
+//! from the ego *pose* each replan, so as the ego advances lane by lane the remaining route
+//! shrinks — receding-horizon multi-junction following with no per-tick route state. The same
+//! dual-rate loop drives it: the slow loop re-plans/validates (promoting only KIRRA-ADMITTED
+//! plans), the fast loop tracks the admitted trajectory by elapsed time.
+
+use kirra_planner::{
+    EgoState, FastLoopTracker, FleetPosture, GeometricPlanner, Goal, Lane, LaneCorridor, LaneEdge,
+    LaneGraph, LineType, MickDriver, MickIntent, PlanInput, Pose, ScriptedBrain, TrajectoryVerdict,
+};
+use kirra_ros2_adapter::corridor::{CorridorSource, Point};
+use kirra_ros2_adapter::state::PerceivedObject;
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+const FAST_DT_S: f64 = 0.1;
+const FAST_DT_MS: u64 = 100;
+const TICKS: usize = 240;
+const MRC_DECEL: f64 = 3.0;
+const REPLAN_MS: u64 = 500;
+const R: f64 = 12.0;
+
+/// A quarter-circle arc (n+1 points) sweeping `sweep` rad (±π/2) from `start_angle` about
+/// `(cx, cy)` (+ = CCW/left, − = CW/right).
+fn quarter_arc(cx: f64, cy: f64, r: f64, start_angle: f64, sweep: f64, n: usize) -> Vec<Point> {
+    (0..=n)
+        .map(|i| {
+            let t = start_angle + sweep * (i as f64 / n as f64);
+            Point { x_m: cx + r * t.cos(), y_m: cy + r * t.sin() }
+        })
+        .collect()
+}
+
+/// Two-junction route: straight east (1) → LEFT arc (2) → straight north (3) → RIGHT arc (4) →
+/// straight east (5). Lane 1 carries a DECOY right branch (6, a dead-end south) so reaching the
+/// destination requires the router to pick the correct branch at the first junction.
+fn two_junction_route() -> LaneGraph {
+    use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI};
+    let arc_left = quarter_arc(30.0, 12.0, R, -FRAC_PI_2, FRAC_PI_2, 12); // (30,0)→(42,12) east→north (CCW)
+    let arc_right = quarter_arc(54.0, 40.0, R, PI, -FRAC_PI_2, 12); // (42,40)→(54,52) north→east (CW)
+    let lane = |id, cl: Vec<Point>, heading, succ: &[u64]| Lane {
+        id,
+        centerline: cl,
+        half_width_m: 3.0,
+        left_line: LineType::Solid,
+        right_line: LineType::Solid,
+        heading_rad: heading,
+        edges: succ.iter().map(|&to| LaneEdge::Successor { to }).collect(),
+        control: None,
+    };
+    LaneGraph::new()
+        .with_lane(lane(1, vec![Point { x_m: 0.0, y_m: 0.0 }, Point { x_m: 30.0, y_m: 0.0 }], 0.0, &[2, 6]))
+        .with_lane(lane(2, arc_left, FRAC_PI_4, &[3]))
+        .with_lane(lane(3, vec![Point { x_m: 42.0, y_m: 12.0 }, Point { x_m: 42.0, y_m: 40.0 }], FRAC_PI_2, &[4]))
+        .with_lane(lane(4, arc_right, FRAC_PI_4, &[5]))
+        .with_lane(lane(5, vec![Point { x_m: 54.0, y_m: 52.0 }, Point { x_m: 80.0, y_m: 52.0 }], 0.0, &[]))
+        .with_lane(lane(6, vec![Point { x_m: 30.0, y_m: 0.0 }, Point { x_m: 30.0, y_m: -20.0 }], -FRAC_PI_2, &[]))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn world<'a>(ego: EgoState, map: &'a dyn CorridorSource, objects: &'a [PerceivedObject], g: &'a LaneGraph, goal: Pose) -> PlanInput<'a> {
+    PlanInput {
+        ego,
+        goal: Goal { target: goal },
+        map,
+        objects,
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+        request_overtake: false,
+        request_pull_over: false,
+        lane_graph: Some(g),
+        signal_states: &[],
+    }
+}
+
+#[test]
+fn route_to_drives_the_whole_two_junction_route_kirra_bounding_throughout() {
+    let g = two_junction_route();
+    // Sanity: the router selects the correct branch at the first junction (over the decoy) and
+    // stitches the full route across BOTH turns.
+    let route_ids = g.route(1, 5).expect("route across both junctions");
+    assert_eq!(route_ids, vec![1, 2, 3, 4, 5], "the router picks the left branch at J1, not the decoy");
+    // The full-route corridor KIRRA validates against (the planner re-materializes its own sub-
+    // corridor from the current ego lane each tick; that is contained in this one).
+    let route: LaneCorridor = g.route_corridor(&route_ids, 0.95, 5).expect("stitch the route corridor");
+
+    let goal = Pose { x_m: 72.0, y_m: 52.0, heading_rad: 0.0 };
+    let objs: [PerceivedObject; 0] = [];
+
+    // The brain just keeps naming the destination; the planner re-routes from the ego pose every
+    // replan, so the remaining route shrinks as the ego advances through each junction.
+    let mut driver = MickDriver::new(ScriptedBrain::new(vec![MickIntent::RouteTo { x_m: 72.0, y_m: 52.0 }; 120]));
+    let mut occy = GeometricPlanner::default();
+    let mut tracker = FastLoopTracker::new();
+
+    let mut ego = EgoState { pose: Pose { x_m: 16.0, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: 5.0, yaw_rate_rads: 0.0, stamp_ms: 0 };
+    let mut last_replan_ms: Option<u64> = None;
+    let mut ego_max_heading = f64::MIN;
+    let (mut promotions, mut admitted_promotions) = (0u32, 0u32);
+
+    for tick in 1..=TICKS {
+        let now_ms = tick as u64 * FAST_DT_MS;
+
+        let replan_due = tracker.is_exhausted(now_ms) || last_replan_ms.is_none_or(|t| now_ms.saturating_sub(t) >= REPLAN_MS);
+        if replan_due {
+            let w = world(ego, &route, &objs, &g, goal);
+            let plan = driver.drive_tick(&w, &mut occy, now_ms);
+            let v = validate_trajectory_slow(&plan.trajectory, &route, &objs, &VehicleConfig::default_urban(), None, FleetPosture::Nominal);
+            promotions += 1;
+            if matches!(v, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp) {
+                admitted_promotions += 1;
+                tracker.promote(plan, now_ms);
+                last_replan_ms = Some(now_ms);
+            }
+        }
+
+        ego = match tracker.track(now_ms) {
+            Some(cmd) => EgoState { pose: cmd.pose, linear_x_mps: cmd.velocity_mps, yaw_rate_rads: 0.0, stamp_ms: now_ms },
+            None => EgoState { pose: ego.pose, linear_x_mps: (ego.linear_x_mps - MRC_DECEL * FAST_DT_S).max(0.0), yaw_rate_rads: 0.0, stamp_ms: now_ms },
+        };
+        ego_max_heading = ego_max_heading.max(ego.pose.heading_rad);
+    }
+
+    println!("ego_final=({:.2},{:.2})  ego_max_heading={ego_max_heading:.2}  admitted={admitted_promotions}/{promotions}", ego.pose.x_m, ego.pose.y_m);
+
+    // (1) KIRRA bounds every pose: the fast loop only ever tracks a KIRRA-admitted trajectory.
+    assert!(admitted_promotions > 0, "KIRRA admitted the trajectories the fast loop tracked");
+    // (2) The ego swung NORTH negotiating the first (left) junction — heading reached ≈ π/2.
+    assert!(ego_max_heading > 1.4, "the ego turns north through the first junction (≈π/2), got max heading {ego_max_heading}");
+    // (3) The ego completed BOTH turns and reached the final EAST-bound exit lane (lane 5 runs
+    //     x 54..80 at y≈52) — only reachable by routing the left arc, the connector, and the
+    //     right arc in sequence. This is the multi-junction route driven end to end.
+    assert!(ego.pose.y_m > 45.0, "the ego reaches the final exit lane (y≈52), got y={}", ego.pose.y_m);
+    assert!(ego.pose.x_m > 58.0, "and travels east along it past the second junction, got x={}", ego.pose.x_m);
+}

--- a/crates/kirra-planner/tests/occluded_junction.rs
+++ b/crates/kirra-planner/tests/occluded_junction.rs
@@ -1,0 +1,126 @@
+//! **Occlusion-aware speed bound at junctions** — RSS Rule 4 applied LATERALLY at a blind
+//! junction. The forward assured-clear-distance bound (a stopped hazard in your own lane beyond
+//! visibility) already lives in the checker; this is its junction sibling: a building / hedge /
+//! parked car blocks the ego's view of CROSS traffic, so it must creep in slowly enough to stop
+//! for a vehicle that could emerge from the unseen approach.
+//!
+//! The map flags the approach lane's assured-clear sight distance toward the conflict; Occy's
+//! behavioral layer turns it into an approach speed cap = the most the ego can carry and still
+//! brake within what it can see. The doer therefore drives an open junction at cruise and CREEPS
+//! a blind one — and KIRRA still bounds the result. This pins the doer behavior end to end (map
+//! → `derive_controls` → behavioral cap → Occy → KIRRA), and that an open-view junction is
+//! unaffected.
+
+use kirra_planner::{
+    plan_for_intent, EgoState, FleetPosture, GeometricPlanner, Goal, Lane, LaneControl, LaneEdge,
+    LaneGraph, LineType, MickIntent, PlanInput, Pose, ProposalKind, TrajectoryVerdict,
+};
+use kirra_ros2_adapter::corridor::{CorridorSource, MockCorridorSource};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+/// A single straight approach lane (0,0)→(40,0) east; the junction conflict sits at its
+/// terminus (x=40). `sight` optionally flags it as occluded with that assured-clear distance.
+fn approach(sight: Option<f64>) -> LaneGraph {
+    let line = LineType::Solid;
+    let mut g = LaneGraph::new()
+        .with_lane(Lane::straight(1, 0.0, 0.0, 40.0, 3.0, line, line).with_edge(LaneEdge::Successor { to: 2 }))
+        .with_lane(Lane::straight(2, 0.0, 40.0, 80.0, 3.0, line, line));
+    if let Some(d) = sight {
+        g = g.with_occluded_approach(1, d);
+    }
+    g
+}
+
+fn world<'a>(map: &'a dyn CorridorSource, g: &'a LaneGraph) -> PlanInput<'a> {
+    PlanInput {
+        // Start slow so the planner ACCELERATES up toward the binding speed target — then the
+        // trajectory's peak speed reflects the cap (an open junction climbs to cruise; a blind
+        // one is held at the assured-clear creep speed).
+        ego: EgoState { pose: Pose { x_m: 8.0, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: 2.0, yaw_rate_rads: 0.0, stamp_ms: 0 },
+        goal: Goal { target: Pose { x_m: 60.0, y_m: 0.0, heading_rad: 0.0 } },
+        map,
+        objects: &[],
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+        request_overtake: false,
+        request_pull_over: false,
+        lane_graph: Some(g),
+        signal_states: &[],
+    }
+}
+
+fn peak_speed(p: &kirra_planner::PlanOutput) -> f64 {
+    p.trajectory.iter().map(|t| t.velocity_mps).fold(0.0, f64::max)
+}
+
+#[test]
+fn the_ego_creeps_into_a_blind_junction_but_cruises_an_open_one() {
+    let corr = MockCorridorSource::straight_5m_half_width(100.0);
+    let intent = MickIntent::GoTo { x_m: 60.0, y_m: 0.0 };
+    let cfg = VehicleConfig::default_urban();
+    let admit = |p: &kirra_planner::PlanOutput| matches!(
+        validate_trajectory_slow(&p.trajectory, &corr, &[], &cfg, None, FleetPosture::Nominal),
+        TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp
+    );
+
+    // OPEN junction (no occlusion datum): the ego approaches at its normal cruise speed.
+    let open_g = approach(None);
+    let open = plan_for_intent(&mut GeometricPlanner::default(), &intent, &world(&corr, &open_g));
+    assert_eq!(open.kind, ProposalKind::Motion);
+    let open_peak = peak_speed(&open);
+    assert!(open_peak > 6.0, "an open junction is taken at cruise, got peak {open_peak}");
+    assert!(admit(&open), "KIRRA admits the open-junction approach");
+
+    // BLIND junction: only ~5 m of assured-clear sight toward the conflict. The ego CREEPS — its
+    // peak speed drops to the assured-clear-distance bound (~4 m/s), well below the open case —
+    // so it can stop for cross-traffic emerging from the unseen approach. KIRRA admits the creep.
+    let blind_g = approach(Some(5.0));
+    let blind = plan_for_intent(&mut GeometricPlanner::default(), &intent, &world(&corr, &blind_g));
+    assert_eq!(blind.kind, ProposalKind::Motion, "the ego still proceeds (creeps), it does not HOLD");
+    let blind_peak = peak_speed(&blind);
+    assert!(blind_peak < 5.0, "the blind approach is creep-capped to the assured-clear speed, got peak {blind_peak}");
+    assert!(blind_peak < open_peak - 1.5, "the blind junction is taken markedly slower than the open one ({blind_peak} vs {open_peak})");
+    assert!(admit(&blind), "KIRRA admits the occlusion-creep approach");
+
+    // The blinder the corner, the slower the creep: 3 m of sight is slower still than 5 m.
+    let blinder_g = approach(Some(3.0));
+    let blinder = plan_for_intent(&mut GeometricPlanner::default(), &intent, &world(&corr, &blinder_g));
+    assert!(peak_speed(&blinder) < blind_peak, "less sight → slower creep ({} vs {blind_peak})", peak_speed(&blinder));
+}
+
+#[test]
+fn occlusion_creep_composes_with_a_stop_sign_at_the_same_blind_junction() {
+    // A blind approach that ALSO carries a STOP sign: the ego must both stop at the line AND
+    // creep on the way in. Until it has stopped (satisfied), the stop line binds; the occlusion
+    // cap shapes the approach speed regardless. Here the ego is moving, so the stop line is
+    // active → it decelerates to the line, and never exceeds the creep cap getting there.
+    let corr = MockCorridorSource::straight_5m_half_width(100.0);
+    let line = LineType::Solid;
+    let g = LaneGraph::new()
+        .with_lane(
+            Lane::straight(1, 0.0, 0.0, 40.0, 3.0, line, line)
+                .with_control(LaneControl::Stop)
+                .with_edge(LaneEdge::Successor { to: 2 }),
+        )
+        .with_lane(Lane::straight(2, 0.0, 40.0, 80.0, 3.0, line, line))
+        .with_occluded_approach(1, 5.0);
+
+    let out = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::GoTo { x_m: 60.0, y_m: 0.0 }, &world(&corr, &g));
+    // Stops at/before the line (x=40) — the stop sign binds.
+    let max_x = out.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max);
+    assert!(max_x <= 41.0, "stops at the stop line, got max_x {max_x}");
+    // And never exceeds the occlusion creep cap (~4 m/s) on the way in.
+    assert!(peak_speed(&out) < 5.0, "the blind+stop approach stays under the creep cap, got peak {}", peak_speed(&out));
+    assert!(
+        matches!(validate_trajectory_slow(&out.trajectory, &corr, &[], &VehicleConfig::default_urban(), None, FleetPosture::Nominal), TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "KIRRA admits the blind stop-controlled approach"
+    );
+}

--- a/crates/kirra-ros2-adapter/src/lib.rs
+++ b/crates/kirra-ros2-adapter/src/lib.rs
@@ -21,6 +21,10 @@ pub mod corridor;
 pub mod geometry;
 pub mod state;
 pub mod validation;
+// Multi-modal predictive-RSS mode producer (gap #3) — rolls live perceived objects into
+// CV/CTRV `PredictedMode` hypotheses so the checker's multi-modal pass runs against real
+// perception. Pure, non-ros2-gated; tested under default features.
+pub mod prediction;
 // Perception redundancy cross-check (True-Redundancy analog) — pure, non-ros2-gated.
 pub mod perception_redundancy;
 // KIRRA-OCCY-PMON-003 slice-1 — pure perception-ingest shim/orchestration

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -218,6 +218,19 @@ pub async fn run_adapter(
         "~/input/objects",
         r2r::QosProfile::default(),
     )?;
+    // Redundant (channel-B) objects subscription — a SECOND, INDEPENDENT PredictedObjects topic
+    // (e.g. a camera-only world model vs the primary radar+lidar) feeding the True-Redundancy
+    // cross-check (gap #2b). Registered ONLY when the divergence monitor is enabled, so a
+    // deployment without redundancy adds no subscription. Remap `~/input/objects_secondary` to
+    // the redundant detector's topic in the launch file.
+    let obj_b_stream = if perception_redundancy_enabled() {
+        Some(node.subscribe::<r2r::autoware_perception_msgs::msg::PredictedObjects>(
+            "~/input/objects_secondary",
+            r2r::QosProfile::default(),
+        )?)
+    } else {
+        None
+    };
     let _map_sub = node.subscribe_untyped(
         "~/input/map",
         "autoware_map_msgs/msg/LaneletMapBin",
@@ -333,6 +346,30 @@ pub async fn run_adapter(
         }
         tracing::error!("objects subscription stream closed — staleness will fire fleet-wide");
     });
+
+    // Redundant (channel-B) objects drain — only spawned when the monitor is enabled and the
+    // subscription was registered above. Each message updates the secondary snapshot AND stamps
+    // its freshness (one call); the slow loop cross-checks it against the primary channel. If
+    // this stream closes (the redundant detector dies), channel B goes stale → the divergence
+    // monitor fails closed (redundancy lost), the intended fail-safe.
+    if let Some(obj_b_stream) = obj_b_stream {
+        let obj_state_b = Arc::clone(&state);
+        tokio::spawn(async move {
+            let mut s = obj_b_stream;
+            while let Some(msg) = s.next().await {
+                let now = now_ms_wall();
+                tracing::info!(
+                    target: "kirra::ingress",
+                    topic = "objects_secondary",
+                    stamp_ms = now,
+                    "subscription_callback"
+                );
+                let parsed = crate::parsing::parse_predicted_objects(&msg);
+                obj_state_b.update_objects_secondary(parsed, now);
+            }
+            tracing::error!("redundant objects subscription stream closed — divergence monitor will fail closed");
+        });
+    }
 
     let odom_state = Arc::clone(&state);
     tokio::spawn(async move {

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -46,6 +46,12 @@ use crate::state::{
 use crate::validation::{
     check_command_conforms, validate_trajectory_slow_capped, ConformanceVerdict, IncomingControl,
 };
+use crate::prediction::predicted_modes_from_objects;
+
+/// Horizon / step for the multi-modal predictive-RSS mode rollout in the slow loop (matches the
+/// planner's prediction horizon; the checker time-matches each sample to a trajectory pose).
+const SLOW_PRED_HORIZON_S: f64 = 3.0;
+const SLOW_PRED_DT_S: f64 = 0.5;
 // KIRRA-OCCY-PMON-003 slice-1: pure ingest orchestration (safety logic lives
 // in `perception_ingest` + the kernel; this node only forwards to them).
 use crate::perception_ingest::{perception_derate_enabled, publish_perception_tick};
@@ -419,6 +425,18 @@ pub async fn run_adapter(
                 now_wall,
             );
 
+            // Multi-modal predictive RSS (gap #3) — make the checker's previously-dormant pass
+            // LIVE: roll the live perceived objects forward into PredictedMode hypotheses. A
+            // per-object turn-rate channel is not yet plumbed into the slow loop, so only the
+            // kinematic CV mode is produced here (already strengthens the snapshot RSS by catching
+            // a cut-in that is laterally clear NOW but moves into the path). The producer adds the
+            // CTRV turn-in hypothesis as soon as the tracker's yaw estimate reaches this site (the
+            // planner already consumes it on its side); passing the yaw map flips it on with no
+            // other change.
+            let predicted_owned =
+                predicted_modes_from_objects(&objects, &[], SLOW_PRED_HORIZON_S, SLOW_PRED_DT_S);
+            let predicted_modes: Vec<_> = predicted_owned.iter().map(|m| m.as_mode()).collect();
+
             let verdict = validate_trajectory_slow_capped(
                 &traj.points,
                 slow_corridor.as_ref(),
@@ -431,9 +449,11 @@ pub async fn run_adapter(
                 // does not yet supply a visibility range → None (no-op), mirroring
                 // the perception-derate cap's pre-wiring state.
                 None,
-                // Multi-modal predictive RSS: prediction does not yet supply per-object
-                // modes here → None (no-op); the snapshot RSS remains the bound.
-                None,
+                // Multi-modal predictive RSS (gap #3) — now LIVE: the CV (and, once a yaw
+                // channel lands, CTRV) modes rolled from the live objects above. The checker
+                // worst-cases over them, refusing a trajectory a predicted cut-in / turn-in
+                // breaches even though the snapshot showed the object laterally clear.
+                Some(&predicted_modes),
                 // Frame/localization integrity (S-FI1): the LIVE frame trust resolved from the
                 // integrator's per-tick `update_frame_integrity` report. With no source wired
                 // this returns `Trusted` — the AOU-LOCALIZATION-001 seam (byte-for-byte the

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -46,7 +46,7 @@ use crate::state::{
 use crate::validation::{
     check_command_conforms, validate_trajectory_slow_capped, ConformanceVerdict, IncomingControl,
 };
-use crate::prediction::predicted_modes_from_objects;
+use crate::prediction::slow_loop_modes;
 use crate::perception_redundancy::{
     more_restrictive_cap, perception_redundancy_enabled, resolve_redundancy_cap, RedundancyConfig,
 };
@@ -451,16 +451,24 @@ pub async fn run_adapter(
             let effective_perception_cap =
                 more_restrictive_cap(effective_perception_cap, redundancy_cap);
 
-            // Multi-modal predictive RSS (gap #3) — make the checker's previously-dormant pass
-            // LIVE: roll the live perceived objects forward into PredictedMode hypotheses. A
-            // per-object turn-rate channel is not yet plumbed into the slow loop, so only the
-            // kinematic CV mode is produced here (already strengthens the snapshot RSS by catching
-            // a cut-in that is laterally clear NOW but moves into the path). The producer adds the
-            // CTRV turn-in hypothesis as soon as the tracker's yaw estimate reaches this site (the
-            // planner already consumes it on its side); passing the yaw map flips it on with no
-            // other change.
-            let predicted_owned =
-                predicted_modes_from_objects(&objects, &[], SLOW_PRED_HORIZON_S, SLOW_PRED_DT_S);
+            // Multi-modal predictive RSS (gap #3) — roll the live objects into PredictedMode
+            // hypotheses for the checker's predictive pass. The tracker's per-object yaw estimate
+            // (the SAME CTRV estimate the planner consumes as MotionState) is read from the yaw
+            // channel and, when FRESH, adds a CTRV turn-in mode alongside CV — genuinely
+            // multi-modal. A stale / unconfigured yaw feed degrades to CV-only (the CV mode +
+            // snapshot RSS still bound the object); it is dropped, not trusted, never a fault.
+            let object_yaw_rates = slow_state.snapshot_object_yaw_rates();
+            let object_yaw_ms =
+                slow_state.last_object_yaw_ms.load(std::sync::atomic::Ordering::Relaxed);
+            let object_yaw_fresh = object_yaw_ms != 0
+                && now_wall.saturating_sub(object_yaw_ms) <= subscription_staleness_timeout_ms();
+            let predicted_owned = slow_loop_modes(
+                &objects,
+                &object_yaw_rates,
+                object_yaw_fresh,
+                SLOW_PRED_HORIZON_S,
+                SLOW_PRED_DT_S,
+            );
             let predicted_modes: Vec<_> = predicted_owned.iter().map(|m| m.as_mode()).collect();
 
             let verdict = validate_trajectory_slow_capped(
@@ -475,8 +483,8 @@ pub async fn run_adapter(
                 // does not yet supply a visibility range → None (no-op), mirroring
                 // the perception-derate cap's pre-wiring state.
                 None,
-                // Multi-modal predictive RSS (gap #3) — now LIVE: the CV (and, once a yaw
-                // channel lands, CTRV) modes rolled from the live objects above. The checker
+                // Multi-modal predictive RSS (gap #3) — LIVE: the CV (and, when the tracker yaw
+                // feed is fresh, CTRV) modes rolled from the live objects above. The checker
                 // worst-cases over them, refusing a trajectory a predicted cut-in / turn-in
                 // breaches even though the snapshot showed the object laterally clear.
                 Some(&predicted_modes),

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -47,6 +47,9 @@ use crate::validation::{
     check_command_conforms, validate_trajectory_slow_capped, ConformanceVerdict, IncomingControl,
 };
 use crate::prediction::predicted_modes_from_objects;
+use crate::perception_redundancy::{
+    more_restrictive_cap, perception_redundancy_enabled, resolve_redundancy_cap, RedundancyConfig,
+};
 
 /// Horizon / step for the multi-modal predictive-RSS mode rollout in the slow loop (matches the
 /// planner's prediction horizon; the checker time-matches each sample to a trajectory pose).
@@ -424,6 +427,29 @@ pub async fn run_adapter(
                 &perception_cache,
                 now_wall,
             );
+
+            // Perception-divergence assurance monitor (True-Redundancy analog, gap #2b) — now
+            // LIVE: cross-check the primary perception channel against the optional redundant
+            // channel B. A divergence (a phantom/missed object, or a speed mismatch), OR a
+            // configured-but-silent channel B (redundancy LOST), maps to an MRC-floor cap that
+            // composes into the SAME Track-C derate (`apply_perception_cap`) — a controlled stop
+            // with no change to the WCET-critical per-pose checker. Disabled (no channel B
+            // configured) → no-op, byte-identical prior behaviour.
+            let objects_b = slow_state.snapshot_objects_secondary();
+            let objects_b_ms =
+                slow_state.last_objects_b_ms.load(std::sync::atomic::Ordering::Relaxed);
+            let objects_b_fresh = objects_b_ms != 0
+                && now_wall.saturating_sub(objects_b_ms) <= subscription_staleness_timeout_ms();
+            let redundancy_cap = resolve_redundancy_cap(
+                perception_redundancy_enabled(),
+                &objects,
+                &objects_b,
+                objects_b_fresh,
+                RedundancyConfig::default(),
+            );
+            // The more-restrictive of the Track-C derate cap and the divergence cap binds.
+            let effective_perception_cap =
+                more_restrictive_cap(effective_perception_cap, redundancy_cap);
 
             // Multi-modal predictive RSS (gap #3) — make the checker's previously-dormant pass
             // LIVE: roll the live perceived objects forward into PredictedMode hypotheses. A

--- a/crates/kirra-ros2-adapter/src/perception_redundancy.rs
+++ b/crates/kirra-ros2-adapter/src/perception_redundancy.rs
@@ -80,6 +80,65 @@ impl RedundancyVerdict {
     }
 }
 
+/// Env gate enabling the perception-divergence monitor — a SECOND perception channel is
+/// configured and should be cross-checked. Truthy = `1`/`true`/`yes` (case-insensitive); unset
+/// or anything else = disabled (no redundant channel → the monitor is a no-op).
+pub const PERCEPTION_REDUNDANCY_ENABLED_ENV: &str = "KIRRA_PERCEPTION_REDUNDANCY_ENABLED";
+
+/// Read the redundancy-monitor enable gate from the environment (mirrors
+/// `perception_derate_enabled`). Disabled unless explicitly truthy.
+#[must_use]
+pub fn perception_redundancy_enabled() -> bool {
+    std::env::var(PERCEPTION_REDUNDANCY_ENABLED_ENV)
+        .map(|v| {
+            let t = v.trim();
+            t == "1" || t.eq_ignore_ascii_case("true") || t.eq_ignore_ascii_case("yes")
+        })
+        .unwrap_or(false)
+}
+
+/// Resolve the perception-divergence MRC cap for one slow-loop tick — the orchestration that
+/// makes the [`cross_check`] monitor LIVE and composes its verdict into the same Track-C
+/// perception derate (`apply_perception_cap`), so a divergence reaches the actuator as a
+/// controlled stop without touching the WCET-critical per-pose checker. Four states, mirroring
+/// `resolve_perception_cap`:
+///
+/// 1. **DISABLED** (no redundant channel configured) → `None`. Byte-identical prior behaviour.
+/// 2. enabled, secondary **FRESH** + channels **consistent** → `None` (no cap).
+/// 3. enabled, secondary **FRESH** + channels **diverged** → `Some(0.0)` (fail closed: at least
+///    one channel is wrong and neither can be trusted).
+/// 4. enabled, secondary **STALE / silent** → `Some(0.0)` (the redundant channel dropped out, so
+///    the primary can no longer be cross-checked — redundancy LOST → fail closed, the
+///    True-Redundancy doctrine).
+#[must_use]
+pub fn resolve_redundancy_cap(
+    enabled: bool,
+    primary: &[PerceivedObject],
+    secondary: &[PerceivedObject],
+    secondary_fresh: bool,
+    cfg: RedundancyConfig,
+) -> Option<f64> {
+    if !enabled {
+        return None; // no redundant channel → monitor inert (state 1)
+    }
+    if !secondary_fresh {
+        return Some(0.0); // lost the redundant channel → cannot cross-check → fail closed (state 4)
+    }
+    cross_check(primary, secondary, cfg).to_perception_cap() // states 2 & 3
+}
+
+/// Compose two optional perception caps into the MORE RESTRICTIVE one: `None` = no cap, `Some` =
+/// a speed ceiling, and the lower ceiling wins (an MRC-floor `Some(0.0)` always binds). Lets the
+/// divergence cap fold into the existing Track-C derate cap without either masking the other.
+#[must_use]
+pub fn more_restrictive_cap(a: Option<f64>, b: Option<f64>) -> Option<f64> {
+    match (a, b) {
+        (Some(x), Some(y)) => Some(x.min(y)),
+        (Some(x), None) | (None, Some(x)) => Some(x),
+        (None, None) => None,
+    }
+}
+
 /// Cross-check two INDEPENDENT perception channels. Fail-closed: returns the FIRST
 /// divergence found (an unmatched object in either direction, or a speed mismatch on a
 /// matched pair). Matching is nearest-position within `cfg.position_tol_m`.
@@ -217,5 +276,50 @@ mod tests {
             }
             other => panic!("expected a speed mismatch, got {other:?}"),
         }
+    }
+
+    // ----- the live-monitor resolution (4-state machine) -----
+
+    #[test]
+    fn disabled_monitor_is_inert_even_when_channels_diverge() {
+        // State 1: a stark divergence, but the monitor is off → no cap (byte-identical prior).
+        let a = [obj(1, 20.0, 0.0, 0.0)];
+        let b: [PerceivedObject; 0] = [];
+        assert_eq!(resolve_redundancy_cap(false, &a, &b, true, RedundancyConfig::default()), None);
+    }
+
+    #[test]
+    fn enabled_consistent_channels_add_no_cap() {
+        // State 2: enabled, fresh secondary, channels agree → None.
+        let a = [obj(1, 20.0, 0.0, 5.0)];
+        let b = [obj(7, 20.3, 0.1, 5.4)];
+        assert_eq!(resolve_redundancy_cap(true, &a, &b, true, RedundancyConfig::default()), None);
+    }
+
+    #[test]
+    fn enabled_diverged_channels_cap_to_mrc() {
+        // State 3: enabled, fresh, a phantom in A that B misses → MRC-floor cap.
+        let a = [obj(1, 20.0, 0.0, 0.0)];
+        let b: [PerceivedObject; 0] = [];
+        assert_eq!(resolve_redundancy_cap(true, &a, &b, true, RedundancyConfig::default()), Some(0.0));
+    }
+
+    #[test]
+    fn enabled_but_silent_secondary_fails_closed() {
+        // State 4: the redundant channel went stale → redundancy lost → fail closed, EVEN IF the
+        // last secondary snapshot happens to still agree (it is no longer assured-fresh).
+        let a = [obj(1, 20.0, 0.0, 5.0)];
+        let b = [obj(7, 20.3, 0.1, 5.4)];
+        assert_eq!(resolve_redundancy_cap(true, &a, &b, false, RedundancyConfig::default()), Some(0.0));
+    }
+
+    #[test]
+    fn more_restrictive_cap_takes_the_lower_ceiling() {
+        use super::more_restrictive_cap;
+        assert_eq!(more_restrictive_cap(None, None), None);
+        assert_eq!(more_restrictive_cap(Some(3.0), None), Some(3.0));
+        assert_eq!(more_restrictive_cap(None, Some(2.0)), Some(2.0));
+        assert_eq!(more_restrictive_cap(Some(3.0), Some(0.0)), Some(0.0), "an MRC floor binds");
+        assert_eq!(more_restrictive_cap(Some(5.0), Some(2.0)), Some(2.0));
     }
 }

--- a/crates/kirra-ros2-adapter/src/prediction.rs
+++ b/crates/kirra-ros2-adapter/src/prediction.rs
@@ -111,6 +111,24 @@ pub fn predicted_modes_from_objects(
     modes
 }
 
+/// Build the slow-loop predicted modes from live `objects` plus the tracker's per-object
+/// `yaw_rates`, **gated on the yaw feed's freshness**. A FRESH yaw map adds the CTRV turn-in
+/// hypothesis (genuinely multi-modal); a STALE / unconfigured one degrades to CV-only — a stale
+/// estimate would keep predicting a turn-in after the object straightened, so the enhancement is
+/// dropped rather than trusted. Dropping it is NOT a fault (unlike a lost redundancy channel):
+/// the CV mode (and the snapshot RSS) still bound the object.
+#[must_use]
+pub fn slow_loop_modes(
+    objects: &[PerceivedObject],
+    yaw_rates: &[(u64, f64)],
+    yaw_fresh: bool,
+    horizon_s: f64,
+    dt_s: f64,
+) -> Vec<OwnedPredictedMode> {
+    let yaw: &[(u64, f64)] = if yaw_fresh { yaw_rates } else { &[] };
+    predicted_modes_from_objects(objects, yaw, horizon_s, dt_s)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -154,6 +172,21 @@ mod tests {
         let o = obj(1, 10.0, 0.0, 3.0, 0.0);
         let modes = predicted_modes_from_objects(&[o], &[(1, 0.005)], 2.0, 0.5);
         assert_eq!(modes.len(), 1, "sub-epsilon yaw → no duplicate CTRV mode");
+    }
+
+    #[test]
+    fn slow_loop_modes_adds_ctrv_only_when_the_yaw_feed_is_fresh() {
+        let o = obj(1, 10.0, 0.0, 3.0, 0.0);
+        let yaw = [(1u64, 0.4)];
+        // Fresh yaw → CV + CTRV (genuinely multi-modal).
+        let fresh = slow_loop_modes(&[o], &yaw, true, 2.0, 0.5);
+        assert_eq!(fresh.len(), 2, "fresh yaw adds the CTRV hypothesis");
+        // Stale yaw → CV only (the turn estimate is dropped, not trusted) — never a fault.
+        let stale = slow_loop_modes(&[o], &yaw, false, 2.0, 0.5);
+        assert_eq!(stale.len(), 1, "stale yaw degrades to CV-only");
+        // No yaw configured behaves like stale.
+        let none = slow_loop_modes(&[o], &[], true, 2.0, 0.5);
+        assert_eq!(none.len(), 1, "no yaw map → CV-only");
     }
 
     #[test]

--- a/crates/kirra-ros2-adapter/src/prediction.rs
+++ b/crates/kirra-ros2-adapter/src/prediction.rs
@@ -1,0 +1,168 @@
+//! **Multi-modal predictive-RSS mode producer** — roll each live perceived object forward into
+//! one or more `PredictedMode` hypotheses, so the checker's multi-modal predictive RSS pass
+//! (`predictive_rss_breach`, gap #3) runs against REAL perception instead of staying dormant
+//! (the slow loop previously passed `predicted_modes = None`, leaving the snapshot RSS as the
+//! sole bound).
+//!
+//! # Why this matters (what the snapshot pass misses)
+//!
+//! The snapshot RSS extrapolates an object from its instantaneous velocity but evaluates it at
+//! its CURRENT position; an object that is laterally CLEAR now is filtered out (§4 lateral
+//! alignment) even if its motion carries it INTO the ego's path. Rolling the position forward in
+//! TIME and checking each step against the time-matched ego pose catches that cut-in.
+//!
+//! # The modes
+//!
+//! - **Constant-velocity (CV)** — always emitted, from the object's reported velocity vector.
+//!   Catches the straight-line cut-in above.
+//! - **Constant-turn-rate (CTRV)** — emitted when a per-object turn rate is known (the tracker's
+//!   yaw estimate, supplied via `yaw_rates`). A genuinely DISTINCT hypothesis: a turning object's
+//!   CV mode may stay clear while its CTRV mode curves into the path. The checker worst-cases
+//!   over every mode, so one dangerous hypothesis is enough to refuse — the point of *multi-modal*
+//!   prediction. A negligible turn rate adds no CTRV mode (it would duplicate CV).
+
+use crate::corridor::Point;
+use crate::state::PerceivedObject;
+use crate::validation::{PredictedMode, PredictedSample};
+
+/// Turn rate (rad/s) below which CTRV ≈ CV — no distinct CTRV mode is emitted (it would just
+/// duplicate the CV hypothesis and the worst-case is unchanged).
+pub const CTRV_YAW_EPS_RAD_S: f64 = 0.02;
+
+/// An owned predicted mode (owns its samples, unlike the borrowed [`PredictedMode`] the checker
+/// consumes). Build the borrowed view with [`as_mode`](Self::as_mode) at the call site.
+#[derive(Debug, Clone)]
+pub struct OwnedPredictedMode {
+    pub object_id: u64,
+    pub samples: Vec<PredictedSample>,
+}
+
+impl OwnedPredictedMode {
+    /// Borrow this owned mode as a [`PredictedMode`] for the checker.
+    #[must_use]
+    pub fn as_mode(&self) -> PredictedMode<'_> {
+        PredictedMode { object_id: self.object_id, samples: &self.samples }
+    }
+}
+
+/// Number of sample steps over `[0, horizon_s]` at `dt_s` (≥ 1).
+fn step_count(horizon_s: f64, dt_s: f64) -> usize {
+    (horizon_s.max(0.0) / dt_s).ceil().max(1.0) as usize
+}
+
+/// Roll `obj` forward on CONSTANT VELOCITY (its reported velocity vector) — a straight-line
+/// hypothesis sampled at `dt_s` over `[0, horizon_s]`.
+fn cv_samples(obj: &PerceivedObject, horizon_s: f64, dt_s: f64) -> Vec<PredictedSample> {
+    let n = step_count(horizon_s, dt_s);
+    (0..=n)
+        .map(|i| {
+            let t = i as f64 * dt_s;
+            PredictedSample {
+                pos: Point { x_m: obj.pos.x_m + obj.vel.x_m * t, y_m: obj.pos.y_m + obj.vel.y_m * t },
+                time_from_start_s: t,
+            }
+        })
+        .collect()
+}
+
+/// Roll `obj` forward on CONSTANT TURN RATE: travel at its current speed while the heading turns
+/// at `yaw_rate_rad_s`. The divergent hypothesis for a turning object (curves where CV goes
+/// straight). Euler-integrated at `dt_s`.
+fn ctrv_samples(obj: &PerceivedObject, yaw_rate_rad_s: f64, horizon_s: f64, dt_s: f64) -> Vec<PredictedSample> {
+    let n = step_count(horizon_s, dt_s);
+    let speed = obj.velocity_mps;
+    let mut heading = obj.vel.y_m.atan2(obj.vel.x_m);
+    let (mut x, mut y) = (obj.pos.x_m, obj.pos.y_m);
+    let mut out = Vec::with_capacity(n + 1);
+    out.push(PredictedSample { pos: Point { x_m: x, y_m: y }, time_from_start_s: 0.0 });
+    for i in 1..=n {
+        heading += yaw_rate_rad_s * dt_s;
+        x += speed * heading.cos() * dt_s;
+        y += speed * heading.sin() * dt_s;
+        out.push(PredictedSample { pos: Point { x_m: x, y_m: y }, time_from_start_s: i as f64 * dt_s });
+    }
+    out
+}
+
+/// Produce the multi-modal predicted-mode set for `objects` over `[0, horizon_s]` sampled at
+/// `dt_s`: a CV mode per object, plus a CTRV mode for any object whose turn rate (looked up in
+/// `yaw_rates` as `(object_id, yaw_rate_rad_s)`) exceeds [`CTRV_YAW_EPS_RAD_S`]. Pass `yaw_rates`
+/// empty for CV-only (the kinematic bound from snapshot velocity, with no tracker turn estimate).
+///
+/// Returns owned modes; borrow them as `&[PredictedMode]` via [`OwnedPredictedMode::as_mode`] for
+/// `validate_trajectory_slow_capped`. A non-positive `dt_s` is floored to a small step.
+#[must_use]
+pub fn predicted_modes_from_objects(
+    objects: &[PerceivedObject],
+    yaw_rates: &[(u64, f64)],
+    horizon_s: f64,
+    dt_s: f64,
+) -> Vec<OwnedPredictedMode> {
+    let dt = dt_s.max(1e-3);
+    let mut modes = Vec::with_capacity(objects.len());
+    for obj in objects {
+        modes.push(OwnedPredictedMode { object_id: obj.id, samples: cv_samples(obj, horizon_s, dt) });
+        if let Some(&(_, yaw)) = yaw_rates.iter().find(|(id, _)| *id == obj.id) {
+            if yaw.abs() > CTRV_YAW_EPS_RAD_S {
+                modes.push(OwnedPredictedMode { object_id: obj.id, samples: ctrv_samples(obj, yaw, horizon_s, dt) });
+            }
+        }
+    }
+    modes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obj(id: u64, x: f64, y: f64, vx: f64, vy: f64) -> PerceivedObject {
+        PerceivedObject {
+            id,
+            pos: Point { x_m: x, y_m: y },
+            velocity_mps: vx.hypot(vy),
+            heading_rad: vy.atan2(vx),
+            vel: Point { x_m: vx, y_m: vy },
+        }
+    }
+
+    #[test]
+    fn cv_mode_rolls_position_forward_on_velocity() {
+        let o = obj(1, 10.0, 0.0, 2.0, -1.0);
+        let modes = predicted_modes_from_objects(&[o], &[], 2.0, 1.0);
+        assert_eq!(modes.len(), 1, "no yaw rate → CV mode only");
+        let s = &modes[0].samples;
+        // t=0 at the snapshot, t=1 advanced by (2,-1), t=2 by (4,-2).
+        assert!((s[0].pos.x_m - 10.0).abs() < 1e-9 && (s[0].pos.y_m - 0.0).abs() < 1e-9);
+        assert!((s[1].pos.x_m - 12.0).abs() < 1e-9 && (s[1].pos.y_m + 1.0).abs() < 1e-9);
+        assert!((s[2].pos.x_m - 14.0).abs() < 1e-9 && (s[2].pos.y_m + 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn a_turn_rate_adds_a_distinct_ctrv_mode() {
+        let o = obj(1, 10.0, 0.0, 3.0, 0.0); // moving +x
+        let modes = predicted_modes_from_objects(&[o], &[(1, 0.4)], 2.0, 0.5);
+        assert_eq!(modes.len(), 2, "CV + CTRV for a turning object");
+        // The CTRV mode curves (gains lateral y) where CV stays on the axis.
+        let cv = &modes[0].samples;
+        let ctrv = &modes[1].samples;
+        assert!(cv.last().unwrap().pos.y_m.abs() < 1e-9, "CV stays on the x-axis");
+        assert!(ctrv.last().unwrap().pos.y_m > 0.5, "CTRV curves off-axis (+y), got {}", ctrv.last().unwrap().pos.y_m);
+    }
+
+    #[test]
+    fn a_negligible_turn_rate_adds_no_redundant_mode() {
+        let o = obj(1, 10.0, 0.0, 3.0, 0.0);
+        let modes = predicted_modes_from_objects(&[o], &[(1, 0.005)], 2.0, 0.5);
+        assert_eq!(modes.len(), 1, "sub-epsilon yaw → no duplicate CTRV mode");
+    }
+
+    #[test]
+    fn each_object_gets_its_own_modes() {
+        let modes = predicted_modes_from_objects(&[obj(1, 0.0, 0.0, 1.0, 0.0), obj(2, 5.0, 0.0, 1.0, 0.0)], &[(2, 0.3)], 1.0, 0.5);
+        // obj1 CV only, obj2 CV+CTRV → 3 modes, ids preserved.
+        assert_eq!(modes.len(), 3);
+        assert_eq!(modes[0].object_id, 1);
+        assert_eq!(modes[1].object_id, 2);
+        assert_eq!(modes[2].object_id, 2);
+    }
+}

--- a/crates/kirra-ros2-adapter/src/state.rs
+++ b/crates/kirra-ros2-adapter/src/state.rs
@@ -213,6 +213,11 @@ pub struct AdaptorState {
     /// `objects_cache` when the divergence monitor is enabled. Empty/never-written when no
     /// redundant channel is configured (the monitor stays inert).
     pub objects_cache_b: Arc<RwLock<Vec<PerceivedObject>>>,
+    /// Per-object **turn-rate** estimates `(object_id, yaw_rate_rad_s)` from the tracker — the
+    /// SAME CTRV estimate the planner consumes as `MotionState`, supplied to the checker so the
+    /// multi-modal predictive RSS (gap #3) can add the CTRV turn-in hypothesis, not just CV.
+    /// Empty/never-written when no tracker yaw feed is configured (the pass stays CV-only).
+    pub object_yaw_rates: Arc<RwLock<Vec<(u64, f64)>>>,
     /// Per-asset vehicle config (Phase 2A: single config, shared). Phase
     /// 4 may make this per-asset.
     pub config: Arc<VehicleConfig>,
@@ -232,6 +237,10 @@ pub struct AdaptorState {
     /// (0 = none yet). The slow loop checks it against the staleness timeout: a configured
     /// redundant channel that goes silent is a redundancy loss → fail closed.
     pub last_objects_b_ms:  Arc<AtomicU64>,
+    /// Wall-clock-ms when the LAST per-object yaw-rate estimate arrived (0 = none yet). A STALE
+    /// yaw feed degrades the predictive pass to CV-only (the estimate would keep predicting a
+    /// turn-in after the object straightened) — an enhancement dropped, NOT a fault.
+    pub last_object_yaw_ms: Arc<AtomicU64>,
     /// Wall-clock-ms when the LAST nav_msgs::Odometry message arrived.
     pub last_odom_ms:       Arc<AtomicU64>,
 
@@ -285,11 +294,13 @@ impl AdaptorState {
             by_asset: DashMap::new(),
             objects_cache: Arc::new(RwLock::new(Vec::new())),
             objects_cache_b: Arc::new(RwLock::new(Vec::new())),
+            object_yaw_rates: Arc::new(RwLock::new(Vec::new())),
             config: Arc::new(config),
             latest_odom: Arc::new(RwLock::new(None)),
             last_trajectory_ms: Arc::new(AtomicU64::new(0)),
             last_objects_ms:    Arc::new(AtomicU64::new(0)),
             last_objects_b_ms:  Arc::new(AtomicU64::new(0)),
+            last_object_yaw_ms: Arc::new(AtomicU64::new(0)),
             last_odom_ms:       Arc::new(AtomicU64::new(0)),
             posture_tracker:    Arc::new(RwLock::new(
                 PostureTracker::nominal_default_no_source())),
@@ -307,11 +318,13 @@ impl AdaptorState {
             by_asset: DashMap::new(),
             objects_cache: Arc::new(RwLock::new(Vec::new())),
             objects_cache_b: Arc::new(RwLock::new(Vec::new())),
+            object_yaw_rates: Arc::new(RwLock::new(Vec::new())),
             config: Arc::new(config),
             latest_odom: Arc::new(RwLock::new(None)),
             last_trajectory_ms: Arc::new(AtomicU64::new(0)),
             last_objects_ms:    Arc::new(AtomicU64::new(0)),
             last_objects_b_ms:  Arc::new(AtomicU64::new(0)),
+            last_object_yaw_ms: Arc::new(AtomicU64::new(0)),
             last_odom_ms:       Arc::new(AtomicU64::new(0)),
             posture_tracker:    Arc::new(RwLock::new(
                 PostureTracker::nominal_default_no_source())),
@@ -332,11 +345,13 @@ impl AdaptorState {
             by_asset: DashMap::new(),
             objects_cache: Arc::new(RwLock::new(Vec::new())),
             objects_cache_b: Arc::new(RwLock::new(Vec::new())),
+            object_yaw_rates: Arc::new(RwLock::new(Vec::new())),
             config: Arc::new(config),
             latest_odom: Arc::new(RwLock::new(None)),
             last_trajectory_ms: Arc::new(AtomicU64::new(0)),
             last_objects_ms:    Arc::new(AtomicU64::new(0)),
             last_objects_b_ms:  Arc::new(AtomicU64::new(0)),
+            last_object_yaw_ms: Arc::new(AtomicU64::new(0)),
             last_odom_ms:       Arc::new(AtomicU64::new(0)),
             posture_tracker:    Arc::new(RwLock::new(
                 PostureTracker::with_source())),
@@ -522,6 +537,27 @@ impl AdaptorState {
             .unwrap_or_default()
     }
 
+    /// Replace the per-object yaw-rate estimates `(object_id, yaw_rate_rad_s)` and stamp arrival
+    /// at `now_ms`. Called by the integrator's tracker feed (the same CTRV estimate the planner
+    /// gets as `MotionState`); the slow loop reads it to add CTRV modes to the predictive RSS.
+    pub fn update_object_yaw_rates(&self, rates: Vec<(u64, f64)>, now_ms: u64) {
+        self.last_object_yaw_ms.store(now_ms, Ordering::Relaxed);
+        if let Ok(mut guard) = self.object_yaw_rates.write() {
+            *guard = rates;
+        } else {
+            tracing::error!("object_yaw_rates RwLock POISONED — yaw estimate dropped (→ CV-only)");
+        }
+    }
+
+    /// Read-and-clone of the latest per-object yaw-rate estimates. Empty when no tracker yaw feed
+    /// is configured (→ the predictive pass stays CV-only).
+    pub fn snapshot_object_yaw_rates(&self) -> Vec<(u64, f64)> {
+        self.object_yaw_rates
+            .read()
+            .map(|g| g.clone())
+            .unwrap_or_default()
+    }
+
     /// Installs (or replaces) the accepted trajectory for `asset_id`.
     /// Called by the slow loop on verdict::Accept. Returns the previous
     /// trajectory if one existed (useful for tests / audit).
@@ -635,6 +671,20 @@ mod tests {
         assert_eq!(state.last_objects_b_ms.load(Ordering::Relaxed), 7_000, "B arrival stamped");
         // The primary channel is untouched by a secondary write.
         assert!(state.snapshot_objects().is_empty(), "channel A independent of channel B");
+    }
+
+    /// The per-object yaw-rate channel round-trips and stamps freshness, independent of the
+    /// object channels.
+    #[test]
+    fn test_object_yaw_channel_round_trips_and_stamps() {
+        let state = AdaptorState::new();
+        assert!(state.snapshot_object_yaw_rates().is_empty());
+        assert_eq!(state.last_object_yaw_ms.load(Ordering::Relaxed), 0);
+
+        state.update_object_yaw_rates(vec![(5, 0.3), (9, -0.4)], 8_000);
+        let got = state.snapshot_object_yaw_rates();
+        assert_eq!(got, vec![(5, 0.3), (9, -0.4)]);
+        assert_eq!(state.last_object_yaw_ms.load(Ordering::Relaxed), 8_000, "yaw arrival stamped");
     }
 
     /// Phase-1 GAP: a fresh adapter has no trajectory for any asset and

--- a/crates/kirra-ros2-adapter/src/state.rs
+++ b/crates/kirra-ros2-adapter/src/state.rs
@@ -208,6 +208,11 @@ pub struct AdaptorState {
     /// validation and CLONE; the slow loop does NOT hold the lock across
     /// the computation. Writes replace the whole vector.
     pub objects_cache: Arc<RwLock<Vec<PerceivedObject>>>,
+    /// SECOND, independent perception snapshot (the True-Redundancy analog, gap #2b). Written by
+    /// an optional redundant PredictedObjects subscriber; the slow loop cross-checks it against
+    /// `objects_cache` when the divergence monitor is enabled. Empty/never-written when no
+    /// redundant channel is configured (the monitor stays inert).
+    pub objects_cache_b: Arc<RwLock<Vec<PerceivedObject>>>,
     /// Per-asset vehicle config (Phase 2A: single config, shared). Phase
     /// 4 may make this per-asset.
     pub config: Arc<VehicleConfig>,
@@ -223,6 +228,10 @@ pub struct AdaptorState {
     pub last_trajectory_ms: Arc<AtomicU64>,
     /// Wall-clock-ms when the LAST PredictedObjects message arrived.
     pub last_objects_ms:    Arc<AtomicU64>,
+    /// Wall-clock-ms when the LAST *redundant* (channel-B) PredictedObjects message arrived
+    /// (0 = none yet). The slow loop checks it against the staleness timeout: a configured
+    /// redundant channel that goes silent is a redundancy loss → fail closed.
+    pub last_objects_b_ms:  Arc<AtomicU64>,
     /// Wall-clock-ms when the LAST nav_msgs::Odometry message arrived.
     pub last_odom_ms:       Arc<AtomicU64>,
 
@@ -275,10 +284,12 @@ impl AdaptorState {
         Arc::new(Self {
             by_asset: DashMap::new(),
             objects_cache: Arc::new(RwLock::new(Vec::new())),
+            objects_cache_b: Arc::new(RwLock::new(Vec::new())),
             config: Arc::new(config),
             latest_odom: Arc::new(RwLock::new(None)),
             last_trajectory_ms: Arc::new(AtomicU64::new(0)),
             last_objects_ms:    Arc::new(AtomicU64::new(0)),
+            last_objects_b_ms:  Arc::new(AtomicU64::new(0)),
             last_odom_ms:       Arc::new(AtomicU64::new(0)),
             posture_tracker:    Arc::new(RwLock::new(
                 PostureTracker::nominal_default_no_source())),
@@ -295,10 +306,12 @@ impl AdaptorState {
         Arc::new(Self {
             by_asset: DashMap::new(),
             objects_cache: Arc::new(RwLock::new(Vec::new())),
+            objects_cache_b: Arc::new(RwLock::new(Vec::new())),
             config: Arc::new(config),
             latest_odom: Arc::new(RwLock::new(None)),
             last_trajectory_ms: Arc::new(AtomicU64::new(0)),
             last_objects_ms:    Arc::new(AtomicU64::new(0)),
+            last_objects_b_ms:  Arc::new(AtomicU64::new(0)),
             last_odom_ms:       Arc::new(AtomicU64::new(0)),
             posture_tracker:    Arc::new(RwLock::new(
                 PostureTracker::nominal_default_no_source())),
@@ -318,10 +331,12 @@ impl AdaptorState {
         Arc::new(Self {
             by_asset: DashMap::new(),
             objects_cache: Arc::new(RwLock::new(Vec::new())),
+            objects_cache_b: Arc::new(RwLock::new(Vec::new())),
             config: Arc::new(config),
             latest_odom: Arc::new(RwLock::new(None)),
             last_trajectory_ms: Arc::new(AtomicU64::new(0)),
             last_objects_ms:    Arc::new(AtomicU64::new(0)),
+            last_objects_b_ms:  Arc::new(AtomicU64::new(0)),
             last_odom_ms:       Arc::new(AtomicU64::new(0)),
             posture_tracker:    Arc::new(RwLock::new(
                 PostureTracker::with_source())),
@@ -483,6 +498,30 @@ impl AdaptorState {
             .unwrap_or_default()
     }
 
+    /// Replace the SECONDARY (redundant channel-B) perception snapshot and stamp its arrival at
+    /// `now_ms` (the slow loop's staleness check reads that stamp). Called by the optional
+    /// redundant PredictedObjects subscriber; mirrors [`update_objects`](Self::update_objects)
+    /// including the fail-closed RwLock-poisoning handling. Freshness is stamped here (not via a
+    /// separate `touch`) so a redundant channel is liveness-tracked with one call.
+    pub fn update_objects_secondary(&self, objects: Vec<PerceivedObject>, now_ms: u64) {
+        self.last_objects_b_ms.store(now_ms, Ordering::Relaxed);
+        if let Ok(mut guard) = self.objects_cache_b.write() {
+            *guard = objects;
+        } else {
+            tracing::error!("objects_cache_b RwLock POISONED — redundant perception snapshot dropped");
+        }
+    }
+
+    /// Read-and-clone of the latest SECONDARY (channel-B) perception snapshot. The slow loop
+    /// cross-checks this against [`snapshot_objects`](Self::snapshot_objects) when the divergence
+    /// monitor is enabled.
+    pub fn snapshot_objects_secondary(&self) -> Vec<PerceivedObject> {
+        self.objects_cache_b
+            .read()
+            .map(|g| g.clone())
+            .unwrap_or_default()
+    }
+
     /// Installs (or replaces) the accepted trajectory for `asset_id`.
     /// Called by the slow loop on verdict::Accept. Returns the previous
     /// trajectory if one existed (useful for tests / audit).
@@ -571,6 +610,31 @@ mod tests {
             velocity_mps: v,
             time_from_start_s: t,
         }
+    }
+
+    /// The redundant (channel-B) perception snapshot round-trips through its own cache and stamps
+    /// freshness, independently of the primary channel.
+    #[test]
+    fn test_secondary_perception_channel_round_trips_and_stamps() {
+        let state = AdaptorState::new();
+        // Fresh: empty and never stamped.
+        assert!(state.snapshot_objects_secondary().is_empty());
+        assert_eq!(state.last_objects_b_ms.load(Ordering::Relaxed), 0);
+
+        let objs = vec![PerceivedObject {
+            id: 5,
+            pos: crate::corridor::Point { x_m: 12.0, y_m: -1.0 },
+            velocity_mps: 3.0,
+            heading_rad: 0.0,
+            vel: crate::corridor::Point { x_m: 3.0, y_m: 0.0 },
+        }];
+        state.update_objects_secondary(objs.clone(), 7_000);
+        let got = state.snapshot_objects_secondary();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].id, 5);
+        assert_eq!(state.last_objects_b_ms.load(Ordering::Relaxed), 7_000, "B arrival stamped");
+        // The primary channel is untouched by a secondary write.
+        assert!(state.snapshot_objects().is_empty(), "channel A independent of channel B");
     }
 
     /// Phase-1 GAP: a fresh adapter has no trajectory for any asset and

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -645,6 +645,82 @@ fn predictive_rss_catches_a_predicted_cut_in() {
         "a predicted cut-in into the ego's path must be refused; got {verdict:?}");
 }
 
+// ---- The PRODUCER: derive modes from live objects (gap #3 made live) ----
+//
+// The tests above hand-build modes; these prove `predicted_modes_from_objects` turns LIVE
+// perceived objects into modes the checker then acts on — the bridge that makes the multi-modal
+// pass run against real perception instead of dormant `None`.
+
+use kirra_ros2_adapter::prediction::predicted_modes_from_objects;
+
+fn perceived(id: u64, x: f64, y: f64, vx: f64, vy: f64) -> PerceivedObject {
+    PerceivedObject {
+        id,
+        pos: Point { x_m: x, y_m: y },
+        velocity_mps: vx.hypot(vy),
+        heading_rad: vy.atan2(vx),
+        vel: Point { x_m: vx, y_m: vy },
+    }
+}
+
+#[test]
+fn produced_cv_mode_catches_a_cut_in_the_snapshot_rss_misses() {
+    // An object laterally CLEAR at the snapshot (y=-5, well outside the 4 m alignment band) but
+    // moving +y so its constant-velocity rollout crosses INTO the ego lane just ahead. The
+    // snapshot pass skips it (out of lane now); the PRODUCED CV mode catches the cut-in.
+    let trajectory = straight_trajectory(30, 2.0, 0.1); // ego 2 m/s straight at y=0, x: 5 → ~10.8
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let obj = perceived(1, 10.0, -5.0, 0.0, 2.5); // crosses y=0 at t=2, at x=10 (just ahead)
+
+    // Snapshot-only (object passed, no produced modes): laterally clear now → admitted.
+    let snapshot_only = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, None, FrameTrust::Trusted,
+    );
+    assert!(matches!(snapshot_only, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "snapshot RSS alone sees the object as out-of-lane → admits; got {snapshot_only:?}");
+
+    // With the PRODUCED CV mode, the predicted cut-in is caught → refused.
+    let owned = predicted_modes_from_objects(&[obj], &[], 3.0, 0.5);
+    let modes: Vec<_> = owned.iter().map(|m| m.as_mode()).collect();
+    let with_modes = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), FrameTrust::Trusted,
+    );
+    assert_eq!(with_modes, TrajectoryVerdict::MRCFallback,
+        "the produced CV mode catches the cut-in the snapshot missed; got {with_modes:?}");
+}
+
+#[test]
+fn produced_ctrv_mode_catches_a_turn_in_that_cv_misses_multimodal_payoff() {
+    // An object PARALLEL to the ego lane (moving +x in the next lane, never crossing on CV) but
+    // TURNING toward the ego lane. CV alone keeps it clear → admit. The PRODUCED CTRV mode (from
+    // the tracker's yaw estimate) curves it INTO the path → refuse. Worst-case over modes: the
+    // single dangerous hypothesis decides — the point of multi-modal prediction.
+    let trajectory = straight_trajectory(30, 2.0, 0.1);
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let obj = perceived(1, 9.0, -4.5, 3.0, 0.0); // parallel +x near the right lane
+
+    // CV-only (no yaw): the object stays in its lane → admitted.
+    let cv_owned = predicted_modes_from_objects(&[obj], &[], 3.0, 0.5);
+    let cv_modes: Vec<_> = cv_owned.iter().map(|m| m.as_mode()).collect();
+    let cv = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&cv_modes), FrameTrust::Trusted,
+    );
+    assert!(matches!(cv, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "CV alone: a lane-parallel object is admitted; got {cv:?}");
+
+    // CV + CTRV (yaw rate turning it into the ego lane): the turn-in hypothesis refuses.
+    let mm_owned = predicted_modes_from_objects(&[obj], &[(1, 0.9)], 3.0, 0.5);
+    assert_eq!(mm_owned.len(), 2, "the turning object yields BOTH a CV and a CTRV mode");
+    let mm_modes: Vec<_> = mm_owned.iter().map(|m| m.as_mode()).collect();
+    let mm = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&mm_modes), FrameTrust::Trusted,
+    );
+    assert_eq!(mm, TrajectoryVerdict::MRCFallback,
+        "the produced CTRV turn-in mode catches what CV missed; got {mm:?}");
+}
+
 #[test]
 fn predictive_rss_is_a_no_op_when_no_modes_are_supplied() {
     // Same cut-in geometry, but no predicted modes → the pass is skipped (snapshot


### PR DESCRIPTION
Eight commits accumulated on the branch after #542 merged — the junction-safety arc and the RSS-completeness productionization. One PR (they share the branch; couldn't be separate open PRs).

## ⚠️ Validation note — read first

The last four commits touch `crates/kirra-ros2-adapter/src/node.rs`, which is `#[cfg(feature = "ros2")]` and pulls the optional `r2r` crate (needs a sourced ROS 2 toolchain). **That toolchain isn't in the authoring sandbox, so node.rs cannot be compiled there** — the default-feature build *excludes* it. The node.rs slow-loop wiring + the redundant subscriber are reviewed by inspection and are faithful mirrors of existing patterns, but their only real compiler check is the **`ros2 adapter build (--features ros2)`** CI job. The non-node logic (producers, resolve functions, state channels, fresh-gating) is unit-tested and green under default features.

## Junction safety

- **`274bc80` RouteTo** — a multi-junction routing intent: resolve ego+destination lanes, plan the lane-id route (`route_to_point`), follow the stitched corridor through every junction; KIRRA bounds it. Closed-loop two-junction proof.
- **`3399eab` dynamic obstacle mid-turn** — proves the doer-checker stack handles a *moving* obstacle while committed to a turn (predictive yield + lead-follow on the curved guide; KIRRA bounds).
- **`bab4443` predictive-yield gap** — a dedicated mid-turn yield gap aligned to the checker's longitudinal-conflict distance, so a crossing-hazard yield is checker-*admissible* (smooth) instead of fail-closing to MRC.
- **`dd8b0ed` occlusion-aware speed bound at junctions** (RSS Rule 4, lateral) — a blind junction caps the approach speed to the assured-clear-distance speed; the ego creeps. (gap #1)

## RSS completeness (made live in the slow loop)

- **`bd2997d` multi-modal predictive RSS** (gap #3) — a mode producer rolls live objects into CV (+CTRV) `PredictedMode`s; wired into the slow loop (was dormant `None`).
- **`a45c971` perception-divergence monitor** (gap #2b, True-Redundancy) — `resolve_redundancy_cap` + a second perception channel; a divergence / silent-secondary maps to an MRC-floor cap composed into the Track-C derate.
- **`3452f62` CTRV yaw channel** — plumb the tracker's per-object yaw into the slow loop (fresh-gated); the predictive pass is now genuinely multi-modal (CV+CTRV).
- **`65f40da` redundant subscriber** — the `~/input/objects_secondary` subscription feeding channel B, end-to-end.

Default-feature suites green across kirra-planner / kirra-map / kirra-ros2-adapter; clippy clean. The ros2 build is the gating check for the node.rs changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_