### PR TITLE
Curve-correct Frenet boundaries + sustained-divergence posture escalation

### DIFF
--- a/crates/kirra-core/src/lib.rs
+++ b/crates/kirra-core/src/lib.rs
@@ -119,6 +119,47 @@ pub enum FleetPosture {
     LockedOut,
 }
 
+impl FleetPosture {
+    /// Severity rank — higher is more restrictive: `Nominal` < `Degraded` < `LockedOut`.
+    #[must_use]
+    pub fn severity(&self) -> u8 {
+        match self {
+            FleetPosture::Nominal => 0,
+            FleetPosture::Degraded => 1,
+            FleetPosture::LockedOut => 2,
+        }
+    }
+
+    /// The MORE restrictive of two postures — an **escalation-only** combine. A local safety
+    /// signal (a sustained perception-divergence fault, a frame-integrity fault) can make the
+    /// effective posture stricter, never relax it. Mirrors `parko_core`'s `SafetyPosture::escalate`.
+    #[must_use]
+    pub fn escalate(self, other: FleetPosture) -> FleetPosture {
+        if other.severity() > self.severity() {
+            other
+        } else {
+            self
+        }
+    }
+}
+
+#[cfg(test)]
+mod fleet_posture_tests {
+    use super::FleetPosture::{Degraded, LockedOut, Nominal};
+
+    #[test]
+    fn escalate_takes_the_more_restrictive_in_either_order() {
+        assert_eq!(Nominal.escalate(Degraded), Degraded);
+        assert_eq!(Degraded.escalate(Nominal), Degraded);
+        assert_eq!(Degraded.escalate(LockedOut), LockedOut);
+        assert_eq!(LockedOut.escalate(Degraded), LockedOut);
+        assert_eq!(Nominal.escalate(Nominal), Nominal);
+        // Escalation only — a lower posture never relaxes a higher one.
+        assert_eq!(LockedOut.escalate(Nominal), LockedOut);
+        assert!(Nominal.severity() < Degraded.severity() && Degraded.severity() < LockedOut.severity());
+    }
+}
+
 /// Event payload written to the audit chain when the Track-C perception
 /// monitor (KIRRA-OCCY-PMON-001) applies a derate. `reason` is the byte-stable
 /// `DerateCode` token (SCREAMING_SNAKE_CASE) and is used as the chain

--- a/crates/kirra-map/src/lanemap.rs
+++ b/crates/kirra-map/src/lanemap.rs
@@ -752,6 +752,54 @@ impl LaneGraph {
         Some(out)
     }
 
+    /// Like [`boundaries_relative_to`](Self::boundaries_relative_to), but **curve-correct**: the
+    /// lateral offsets are measured in the EGO's Frenet frame at its current station (the
+    /// projection of `ego_pos` onto the ego lane's centerline), not from each lane's GLOBAL
+    /// `mean_y`. On a straight lane the two agree; on a CURVING lane `mean_y` averages the whole
+    /// arc and mis-places a neighbor's boundary relative to where the ego actually is — which can
+    /// mis-gate a lateral maneuver (admit crossing a solid line, or block a legal cross). This
+    /// measures each boundary's signed perpendicular offset from the ego station along the local
+    /// lane normal, so the lane-line crossing rules see the boundary where it really is.
+    ///
+    /// Returns `None` if any id is unknown or the ego centerline is degenerate. The same
+    /// gently-curved / roughly-parallel-lanes assumption as the rest of the lane geometry applies
+    /// (the nearest-point projection approximates the Frenet lateral for parallel lanes).
+    #[must_use]
+    pub fn boundaries_relative_to_at(&self, ego_lane: u64, lane_ids: &[u64], ego_pos: Point) -> Option<Vec<LaneBoundary>> {
+        let ego = self.lanes.get(&ego_lane)?;
+        if ego.centerline.len() < 2 {
+            return None;
+        }
+        // Ego station: the projection of the ego onto its centerline, and the LEFT normal of the
+        // local tangent there (the Frenet lateral axis, +y to the ego's left).
+        let (seg, e) = project_onto_polyline(&ego.centerline, ego_pos);
+        let a = ego.centerline[seg];
+        let b = ego.centerline[seg + 1];
+        let (tx, ty) = (b.x_m - a.x_m, b.y_m - a.y_m);
+        let tlen = tx.hypot(ty).max(1e-9);
+        let (nx, ny) = (-ty / tlen, tx / tlen); // left normal
+
+        let lanes = self.resolve(lane_ids)?;
+        let mut out: Vec<LaneBoundary> = Vec::new();
+        for lane in lanes {
+            for (bd, line) in [
+                (offset_polyline(&lane.centerline, lane.half_width_m), lane.left_line),
+                (offset_polyline(&lane.centerline, -lane.half_width_m), lane.right_line),
+            ] {
+                if bd.len() < 2 {
+                    continue;
+                }
+                let (_, nearest) = project_onto_polyline(&bd, e);
+                // Signed lateral offset of the boundary from the ego station, along the ego normal.
+                let y = (nearest.x_m - e.x_m) * nx + (nearest.y_m - e.y_m) * ny;
+                if !out.iter().any(|x| (x.y_m - y).abs() <= 1e-6) {
+                    out.push(LaneBoundary { y_m: y, line });
+                }
+            }
+        }
+        Some(out)
+    }
+
     /// Synthesize a two-lane **undivided** road from a single wide drivable
     /// `corridor` — the unmarked-road / dirt-road case. On a road with no painted
     /// centerline, perception (`kirra_taj`) reports
@@ -982,6 +1030,63 @@ mod tests {
         assert!(b.iter().any(|x| (x.y_m - 1.75).abs() < 1e-9 && x.line == LineType::Solid));
         assert!(b.iter().any(|x| (x.y_m + 1.75).abs() < 1e-9 && x.line == LineType::Broken));
         assert!(b.iter().any(|x| (x.y_m + 5.25).abs() < 1e-9 && x.line == LineType::Solid));
+    }
+
+    #[test]
+    fn boundaries_relative_to_at_matches_mean_y_on_a_straight_road() {
+        // Regression: on STRAIGHT lanes the curve-correct Frenet measurement reduces to the
+        // global mean_y version — same boundary set, so existing behavior is unchanged.
+        let g = two_lane_road();
+        let mut global = g.boundaries_relative_to(1, &[1, 2]).unwrap();
+        let mut local = g.boundaries_relative_to_at(1, &[1, 2], Point { x_m: 50.0, y_m: 0.0 }).unwrap();
+        let key = |b: &LaneBoundary| (b.y_m * 1e6).round() as i64;
+        global.sort_by_key(key);
+        local.sort_by_key(key);
+        assert_eq!(global.len(), local.len());
+        for (a, b) in global.iter().zip(local.iter()) {
+            assert!((a.y_m - b.y_m).abs() < 1e-6 && a.line == b.line, "straight parity: {a:?} vs {b:?}");
+        }
+    }
+
+    #[test]
+    fn boundaries_relative_to_at_measures_perpendicular_on_a_curve() {
+        // A quarter-arc ego lane (half-width 2). At a mid-arc station the lane's OWN boundaries
+        // are at ±2 PERPENDICULAR to the curve — which the Frenet measurement recovers, where the
+        // global mean_y (averaging the whole arc) would not place them locally.
+        let arc = quarter_arc(0.0, 12.0, 12.0, -std::f64::consts::FRAC_PI_2, 12);
+        let g = LaneGraph::new().with_lane(Lane {
+            id: 1, centerline: arc, half_width_m: 2.0, left_line: LineType::Solid,
+            right_line: LineType::Broken, heading_rad: std::f64::consts::FRAC_PI_4, edges: Vec::new(), control: None,
+        });
+        // A point on the arc around 45° in: (12 cos(-π/4), 12 + 12 sin(-π/4)) ≈ (8.49, 3.51).
+        let bs = g.boundaries_relative_to_at(1, &[1], Point { x_m: 8.49, y_m: 3.51 }).unwrap();
+        assert_eq!(bs.len(), 2, "the lane's own two boundaries");
+        let left = bs.iter().find(|b| b.line == LineType::Solid).unwrap();
+        let right = bs.iter().find(|b| b.line == LineType::Broken).unwrap();
+        assert!((left.y_m - 2.0).abs() < 0.2, "left boundary ≈ +half_width perpendicular, got {}", left.y_m);
+        assert!((right.y_m + 2.0).abs() < 0.2, "right boundary ≈ -half_width perpendicular, got {}", right.y_m);
+    }
+
+    #[test]
+    fn boundaries_relative_to_at_corrects_a_neighbor_on_a_curve() {
+        // A curved ego lane and a concentric-outer neighbor (its centerline offset +4 along the
+        // normal). The Frenet measurement and the global mean_y version DISAGREE on the curve —
+        // the fix changes (corrects) the neighbor boundary placement that gates a lateral cross.
+        let arc = quarter_arc(0.0, 12.0, 12.0, -std::f64::consts::FRAC_PI_2, 12);
+        let neighbor_cl = offset_polyline(&arc, 4.0);
+        let g = LaneGraph::new()
+            .with_lane(Lane { id: 1, centerline: arc, half_width_m: 1.75, left_line: LineType::Broken, right_line: LineType::Solid, heading_rad: 0.0, edges: Vec::new(), control: None })
+            .with_lane(Lane { id: 2, centerline: neighbor_cl, half_width_m: 1.75, left_line: LineType::Solid, right_line: LineType::Broken, heading_rad: 0.0, edges: Vec::new(), control: None });
+        let ego = Point { x_m: 8.49, y_m: 3.51 };
+        let global = g.boundaries_relative_to(1, &[2]).unwrap();
+        let local = g.boundaries_relative_to_at(1, &[2], ego).unwrap();
+        // The neighbor's near boundary, measured perpendicular at the ego station, sits ~+2.25
+        // (4 − 1.75); the global mean_y average mis-places it. They must differ on the curve.
+        let differs = global.iter().zip(local.iter()).any(|(a, b)| (a.y_m - b.y_m).abs() > 0.5);
+        assert!(differs, "curve-correct ≠ global mean_y for a neighbor: global={global:?} local={local:?}");
+        // And the Frenet near-edge is the locally-correct ~2.25 m.
+        let near = local.iter().map(|b| b.y_m).fold(f64::INFINITY, f64::min);
+        assert!((near - 2.25).abs() < 0.4, "near neighbor edge ≈ 4 − half_width perpendicular, got {near}");
     }
 
     #[test]

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -420,7 +420,11 @@ fn plan_along_route(
         .chain(lane.and_then(Lane::right_neighbor))
         .collect();
     let boundaries = if world.lane_boundaries.is_empty() {
-        graph.boundaries_relative_to(ego_lane, &neighbors)
+        // Curve-correct: the lane-line offsets are measured in the ego's Frenet frame at its
+        // current station (not each lane's global mean_y), so the crossing rules see a neighbor
+        // boundary where it actually is through a turn — admitting/blocking a lateral move
+        // correctly on the arc, not just on straights.
+        graph.boundaries_relative_to_at(ego_lane, &neighbors, MapPoint { x_m: world.ego.pose.x_m, y_m: world.ego.pose.y_m })
     } else {
         None
     };

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -48,7 +48,8 @@ use crate::validation::{
 };
 use crate::prediction::slow_loop_modes;
 use crate::perception_redundancy::{
-    more_restrictive_cap, perception_redundancy_enabled, resolve_redundancy_cap, RedundancyConfig,
+    more_restrictive_cap, perception_redundancy_enabled, resolve_redundancy_cap,
+    DivergenceEscalator, RedundancyConfig,
 };
 
 /// Horizon / step for the multi-modal predictive-RSS mode rollout in the slow loop (matches the
@@ -436,6 +437,9 @@ pub async fn run_adapter(
     let capture_tx: Option<mpsc::Sender<CaptureRecord>> =
         capture_enabled().then(spawn_capture_writer);
     let capture_seq = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    // Sustained-divergence posture escalator — persists across slow-loop ticks (owned by this
+    // task), so a divergence that PERSISTS escalates fleet posture, not just this tick's cap.
+    let mut divergence_escalator = DivergenceEscalator::new();
     tokio::spawn(async move {
         let mut rx = trajectory_rx;
         while let Some(traj) = rx.recv().await {
@@ -487,6 +491,15 @@ pub async fn run_adapter(
             // The more-restrictive of the Track-C derate cap and the divergence cap binds.
             let effective_perception_cap =
                 more_restrictive_cap(effective_perception_cap, redundancy_cap);
+
+            // Sustained-divergence → posture escalation (orthogonal to the per-tick MRC cap
+            // above): a divergence (or lost redundant channel) that PERSISTS is a
+            // perception-integrity fault that escalates the EFFECTIVE fleet posture — Degraded,
+            // then LockedOut — so the whole stack degrades, not just this tick's speed. A
+            // momentary blip leaves posture unchanged (the cap handled it); escalation-only, so
+            // it can never relax the verifier-sourced base posture.
+            divergence_escalator.observe(redundancy_cap == Some(0.0), now_wall);
+            let posture = posture.escalate(divergence_escalator.recommended_posture(now_wall));
 
             // Multi-modal predictive RSS (gap #3) — roll the live objects into PredictedMode
             // hypotheses for the checker's predictive pass. The tracker's per-object yaw estimate

--- a/crates/kirra-ros2-adapter/src/perception_redundancy.rs
+++ b/crates/kirra-ros2-adapter/src/perception_redundancy.rs
@@ -15,6 +15,7 @@
 //! to the WCET-critical checker.
 
 use crate::state::PerceivedObject;
+use kirra_core::FleetPosture;
 
 /// Tolerances for declaring two channels' objects "the same".
 #[derive(Debug, Clone, Copy)]
@@ -136,6 +137,69 @@ pub fn more_restrictive_cap(a: Option<f64>, b: Option<f64>) -> Option<f64> {
         (Some(x), Some(y)) => Some(x.min(y)),
         (Some(x), None) | (None, Some(x)) => Some(x),
         (None, None) => None,
+    }
+}
+
+/// Continuous-divergence duration (ms) after which the monitor escalates fleet posture to
+/// `Degraded` — a divergence that PERSISTS this long is no longer a transient sensor blip the
+/// per-tick MRC cap absorbs, but a perception-integrity concern.
+pub const DIVERGENCE_DEGRADE_MS: u64 = 1_000;
+/// Continuous-divergence duration (ms) after which the monitor escalates to `LockedOut` — the
+/// redundant world model has been untrustworthy long enough that a controlled stop + human reset
+/// is warranted, not just a speed cap. Mirrors the verifier's LockedOut "human-reset" semantics.
+pub const DIVERGENCE_LOCKOUT_MS: u64 = 5_000;
+
+/// **Sustained-divergence posture escalator.** The per-tick [`resolve_redundancy_cap`] already
+/// brings the vehicle to a controlled stop on ANY divergence (the MRC-floor cap); this adds the
+/// orthogonal, stickier signal the cap cannot express — a divergence that PERSISTS is a
+/// perception-INTEGRITY fault that should escalate FLEET POSTURE, so the whole stack degrades
+/// (and ultimately locks out for a human reset), not just this tick's speed. Pure and
+/// deterministic (the caller supplies `now_ms`); parallels the frame-integrity S-FI1d hysteresis
+/// and the verifier's recovery-streak pattern. A consistent observation clears the streak.
+#[derive(Debug, Clone, Default)]
+pub struct DivergenceEscalator {
+    /// Wall-clock ms when the CURRENT continuous divergence began; `None` while consistent.
+    diverged_since_ms: Option<u64>,
+}
+
+impl DivergenceEscalator {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record this tick's cross-check outcome. `diverged` = the monitor returned a divergence (a
+    /// phantom/miss/speed-mismatch, OR a lost redundant channel). A consistent tick clears the
+    /// streak — the escalation recovers once perception AGREES again (the per-tick cap and the
+    /// verifier's own posture remain the backstops).
+    pub fn observe(&mut self, diverged: bool, now_ms: u64) {
+        if diverged {
+            self.diverged_since_ms.get_or_insert(now_ms);
+        } else {
+            self.diverged_since_ms = None;
+        }
+    }
+
+    /// The posture this monitor RECOMMENDS at `now_ms`, to be escalated INTO the effective fleet
+    /// posture (`base.escalate(recommended)`): `Nominal` while consistent or only MOMENTARILY
+    /// diverged (the MRC cap handles that); `Degraded` once divergence has persisted
+    /// [`DIVERGENCE_DEGRADE_MS`]; `LockedOut` at [`DIVERGENCE_LOCKOUT_MS`]. Escalation-only — it
+    /// can only make the posture stricter, never relax it.
+    #[must_use]
+    pub fn recommended_posture(&self, now_ms: u64) -> FleetPosture {
+        match self.diverged_since_ms {
+            None => FleetPosture::Nominal,
+            Some(since) => {
+                let elapsed = now_ms.saturating_sub(since);
+                if elapsed >= DIVERGENCE_LOCKOUT_MS {
+                    FleetPosture::LockedOut
+                } else if elapsed >= DIVERGENCE_DEGRADE_MS {
+                    FleetPosture::Degraded
+                } else {
+                    FleetPosture::Nominal // momentary → cap-only, no posture change
+                }
+            }
+        }
     }
 }
 
@@ -321,5 +385,48 @@ mod tests {
         assert_eq!(more_restrictive_cap(None, Some(2.0)), Some(2.0));
         assert_eq!(more_restrictive_cap(Some(3.0), Some(0.0)), Some(0.0), "an MRC floor binds");
         assert_eq!(more_restrictive_cap(Some(5.0), Some(2.0)), Some(2.0));
+    }
+
+    // ----- sustained-divergence posture escalation -----
+
+    #[test]
+    fn a_consistent_stream_never_escalates() {
+        let mut e = DivergenceEscalator::new();
+        e.observe(false, 1_000);
+        e.observe(false, 9_999);
+        assert_eq!(e.recommended_posture(9_999), FleetPosture::Nominal);
+    }
+
+    #[test]
+    fn a_momentary_divergence_does_not_escalate_posture() {
+        // The per-tick MRC cap handles a blip; posture stays Nominal under DIVERGENCE_DEGRADE_MS.
+        let mut e = DivergenceEscalator::new();
+        e.observe(true, 1_000);
+        assert_eq!(e.recommended_posture(1_000 + DIVERGENCE_DEGRADE_MS - 1), FleetPosture::Nominal);
+    }
+
+    #[test]
+    fn a_sustained_divergence_escalates_degraded_then_locked_out() {
+        let mut e = DivergenceEscalator::new();
+        e.observe(true, 1_000); // divergence onset; stays diverged across ticks
+        e.observe(true, 1_500);
+        assert_eq!(e.recommended_posture(1_000 + DIVERGENCE_DEGRADE_MS), FleetPosture::Degraded,
+            "≥ degrade window → Degraded");
+        assert_eq!(e.recommended_posture(1_000 + DIVERGENCE_LOCKOUT_MS), FleetPosture::LockedOut,
+            "≥ lockout window → LockedOut");
+    }
+
+    #[test]
+    fn divergence_clearing_resets_the_streak() {
+        let mut e = DivergenceEscalator::new();
+        e.observe(true, 1_000);
+        // It had been diverging long enough to escalate...
+        assert_eq!(e.recommended_posture(1_000 + DIVERGENCE_LOCKOUT_MS), FleetPosture::LockedOut);
+        // ...but a consistent tick clears it → recovers to Nominal (cap + verifier posture remain).
+        e.observe(false, 1_000 + DIVERGENCE_LOCKOUT_MS + 10);
+        assert_eq!(e.recommended_posture(1_000 + DIVERGENCE_LOCKOUT_MS + 10), FleetPosture::Nominal);
+        // A NEW divergence restarts the streak from its own onset (not the old one).
+        e.observe(true, 100_000);
+        assert_eq!(e.recommended_posture(100_000 + 10), FleetPosture::Nominal, "fresh streak → momentary again");
     }
 }


### PR DESCRIPTION
Two follow-on safety-hardening commits.

## `42ebd40` Curve-correct (Frenet) lane-boundary offsets — default-feature, fully tested
`boundaries_relative_to` placed neighbor lane lines by each lane's **global `mean_y`** — exact on a straight lane, but on a *curving* lane it averages the whole arc and mis-places a boundary relative to the ego's actual station, mis-gating a lateral maneuver through a turn. New **`boundaries_relative_to_at`** measures each boundary's signed offset in the ego's **Frenet frame at its station** (reusing `project_onto_polyline`/`offset_polyline`); on a straight lane it reduces to the `mean_y` result. `plan_along_route` now uses it. Tested: straight parity (regression), curved perpendicular correctness, neighbor-corrects-on-curve.

## `f995354` Sustained perception-divergence → fleet-posture escalation — touches `node.rs`
The redundancy monitor stops the vehicle on *any* divergence (the per-tick MRC cap); a divergence that **persists** is a perception-integrity fault that should escalate **fleet posture**, paralleling the frame-integrity S-FI1d hysteresis.
- `FleetPosture::severity()` + `escalate()` (kirra-core) — escalation-only combine.
- `DivergenceEscalator` (pure streak tracker) — momentary divergence → Nominal (cap handles it); sustained → Degraded (1 s) → LockedOut (5 s); a consistent tick resets.
- `node.rs` slow loop composes `posture = base.escalate(escalator.recommended)` — escalation-only, never relaxes the verifier-sourced base.

## Validation
Default-feature core fully tested — 265 kirra-core+adapter + 226 planner+map tests green (8 new across both commits), clippy clean, workspace builds. **`node.rs` is `#[cfg(feature = "ros2")]`** — its slow-loop wiring (the posture escalation) is reviewed by inspection and validated only by the **`ros2 adapter build (--features ros2)`** CI job, which is the gating check to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_