### PR TITLE
Stage S-PK1c — generic SG2 containment seam over PlatformKinematics

### DIFF
--- a/crates/kirra-core/src/platform_kinematics.rs
+++ b/crates/kirra-core/src/platform_kinematics.rs
@@ -30,7 +30,8 @@
 //! containment/RSS wiring are S-PK1b / S-PK1c. The scalar `KirraKernelGovernor`
 //! is the composable primitive (clamp + rate-limit), **not** a platform (D3).
 
-use crate::containment::VehicleFootprint;
+use crate::containment::{validate_trajectory_containment, Corridor, Pose, VehicleFootprint};
+use crate::frame_integrity::FrameTrust;
 use crate::kinematics_contract::{
     validate_vehicle_command, EnforceAction, ProposedVehicleCommand, VehicleKinematicsContract,
     STOP_EPSILON_MPS,
@@ -144,6 +145,33 @@ impl PlatformKinematics for AckermannPlatform {
     }
 }
 
+/// Bound **any** platform's trajectory by the existing SG2 drivable-space checker
+/// (Stage S-PK1c) — the moment the abstraction goes from *expressible* to
+/// *enforced*. The footprint is sourced from the platform's behavioral
+/// [`PlatformKinematics::footprint`], so a differential-drive robot (and future
+/// omni) is contained by the **same** checker that bounds the Ackermann AV, with
+/// no per-platform reimplementation.
+///
+/// Drive-agnostic by construction: it reads only the trait's footprint, never
+/// platform *mechanism* (wheelbase, ICR). Conformant to the doer-checker
+/// invariants (CLAUDE.md): purely **additive** — it does not touch the
+/// WCET-critical per-pose `validate_vehicle_command` path or any existing slow
+/// loop — and **fail-closed**, since the underlying `validate_trajectory_containment`
+/// refuses an absent / stale / degenerate corridor or an `Untrusted` frame.
+///
+/// Scope: this is the generic *seam* + proof, not a deployment — no live
+/// differential-drive node consumes it yet (diff-drive's checker is parko's
+/// `KirraGovernor`, a separate path).
+#[must_use]
+pub fn validate_platform_containment<P: PlatformKinematics>(
+    platform: &P,
+    trajectory: &[Pose],
+    corridor: &Corridor,
+    frame_trust: FrameTrust,
+) -> EnforceAction {
+    validate_trajectory_containment(trajectory, corridor, &platform.footprint(), frame_trust)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,5 +249,109 @@ mod tests {
         assert_eq!(platform.max_speed_mps(), c.max_speed_mps);
         assert_eq!(platform.max_brake_mps2(), c.max_brake_mps2);
         assert_eq!(platform.stop_epsilon_mps(), STOP_EPSILON_MPS);
+    }
+
+    // --- S-PK1c: the generic containment seam -------------------------------
+
+    use crate::containment::Point;
+    use crate::kinematics_contract::DenyCode;
+
+    /// A second, non-Ackermann platform (narrow footprint) used to prove the seam
+    /// is footprint-driven and drive-agnostic entirely within kirra-core. (The
+    /// real `DiffDrivePlatform` is exercised through the same seam in parko-kirra.)
+    struct TinyBot;
+    impl PlatformKinematics for TinyBot {
+        type Command = ();
+        type State = ();
+        type Verdict = EnforceAction;
+        fn evaluate(&self, _c: &(), _s: &()) -> EnforceAction {
+            EnforceAction::Allow
+        }
+        fn footprint(&self) -> VehicleFootprint {
+            VehicleFootprint {
+                width_m: 0.3,
+                length_m: 0.4,
+                overhang_front_m: 0.2,
+                overhang_rear_m: 0.2,
+                wheelbase_m: 0.0,
+            }
+        }
+        fn max_speed_mps(&self) -> f64 {
+            1.0
+        }
+        fn max_brake_mps2(&self) -> f64 {
+            1.0
+        }
+        fn stop_epsilon_mps(&self) -> f64 {
+            0.05
+        }
+    }
+
+    fn straight_corridor(half_w: f64, x_max: f64) -> (Vec<Point>, Vec<Point>) {
+        let n = 8;
+        let dx = x_max / (n as f64 - 1.0);
+        let mut left = Vec::with_capacity(n);
+        let mut right = Vec::with_capacity(n);
+        for i in 0..n {
+            let x = i as f64 * dx;
+            left.push(Point { x_m: x, y_m: half_w });
+            right.push(Point { x_m: x, y_m: -half_w });
+        }
+        (left, right)
+    }
+
+    fn healthy_corridor<'a>(left: &'a [Point], right: &'a [Point]) -> Corridor<'a> {
+        Corridor { left, right, confidence: 0.95, age_ms: 10, min_confidence: 0.5, max_age_ms: 500 }
+    }
+
+    fn at(x: f64, y: f64) -> Pose {
+        Pose { x_m: x, y_m: y, heading_rad: 0.0 }
+    }
+
+    /// THE thesis proof: the SAME seam + SAME corridor + SAME pose, two platforms.
+    /// A narrow robot fits where a full-width vehicle departs — the verdict differs
+    /// purely from `footprint()`, so SG2 containment is genuinely drive-agnostic.
+    #[test]
+    fn seam_bounds_any_platform_by_footprint() {
+        let (left, right) = straight_corridor(0.7, 100.0); // half-width 0.7 m
+        let corridor = healthy_corridor(&left, &right);
+        let traj = vec![at(50.0, 0.0)];
+
+        let ackermann = AckermannPlatform::new(contract());
+        assert_eq!(
+            validate_platform_containment(&ackermann, &traj, &corridor, FrameTrust::Trusted),
+            EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
+            "a full-width vehicle cannot fit a 1.4 m corridor with margin"
+        );
+        assert_eq!(
+            validate_platform_containment(&TinyBot, &traj, &corridor, FrameTrust::Trusted),
+            EnforceAction::Allow,
+            "a 0.3 m-wide robot fits the SAME corridor — same seam, footprint-driven"
+        );
+    }
+
+    #[test]
+    fn seam_allows_a_platform_within_a_wide_corridor() {
+        let (left, right) = straight_corridor(3.0, 100.0);
+        let corridor = healthy_corridor(&left, &right);
+        let traj = vec![at(50.0, 0.0)];
+        let ackermann = AckermannPlatform::new(contract());
+        assert_eq!(
+            validate_platform_containment(&ackermann, &traj, &corridor, FrameTrust::Trusted),
+            EnforceAction::Allow
+        );
+    }
+
+    /// The seam inherits the frame-integrity gate: an Untrusted frame refuses
+    /// before any geometry, for any platform.
+    #[test]
+    fn seam_inherits_the_frame_gate() {
+        let (left, right) = straight_corridor(3.0, 100.0);
+        let corridor = healthy_corridor(&left, &right);
+        let traj = vec![at(50.0, 0.0)];
+        assert_eq!(
+            validate_platform_containment(&TinyBot, &traj, &corridor, FrameTrust::Untrusted),
+            EnforceAction::DenyBreach(DenyCode::FrameIntegrityUntrusted)
+        );
     }
 }

--- a/docs/safety/STAGE_S-PK1_PLATFORM_KINEMATICS.md
+++ b/docs/safety/STAGE_S-PK1_PLATFORM_KINEMATICS.md
@@ -180,9 +180,21 @@ smuggled in as "just a different polygon."
     which in parko folds in the pushed RSS verdict — wider scope. Reflects parko's
     existing architecture (no separate public pure-kinematic entry); separating it
     is out of S-PK1b scope.
-- **S-PK1c** — wire **containment + RSS** to consume `PlatformKinematics` (footprint
-  + envelope from the trait); confirm the 2D checker is drive-agnostic. Free-space
-  boundary-polygon generalization only if/when #1 needs it (§6).
+- **S-PK1c** — ✅ the generic SG2 **containment seam**:
+  `validate_platform_containment<P: PlatformKinematics>(platform, trajectory,
+  corridor, frame_trust)` (`crates/kirra-core/src/platform_kinematics.rs`) sources
+  the footprint from the trait and runs the existing
+  `validate_trajectory_containment`. Decisions held: footprint stays
+  `VehicleFootprint` + center convention (finding #1); **containment-seam-only — NOT
+  slow-loop unification** (finding #2 acknowledged); RSS / per-command stay
+  platform-specific. Purely additive (per-pose `validate_vehicle_command` path and
+  the Ackermann slow loop UNTOUCHED), fail-closed by construction — conformant to
+  the CLAUDE.md doer-checker invariants. **Dual-platform proof:** a mock narrow
+  platform and the Ackermann AV are bounded by the *same* seam in kirra-core
+  (verdict differs purely from `footprint()`), and the real `DiffDrivePlatform` is
+  bounded by it in parko-kirra. kirra-core 161 + parko-kirra tests pass; clippy +
+  workspace clean. *Scope:* the seam + proof, not a live diff-drive deployment (no
+  diff-drive node consumes it yet; diff-drive's checker remains parko's governor).
 - **S-PK1d** — (optional, gated by a customer) Tier-B 3D containment + aerial
   envelope.
 - **S-PK1e** — RTM / AoU updates + ADR-0017 to Accepted; new-platform safety goals

--- a/parko/crates/parko-kirra/src/platform.rs
+++ b/parko/crates/parko-kirra/src/platform.rs
@@ -228,4 +228,49 @@ mod tests {
         assert_eq!(fp.overhang_front_m, fp.overhang_rear_m, "overhangs symmetric about the center pose");
         assert_eq!(fp.overhang_front_m, 0.45);
     }
+
+    /// S-PK1c: the REAL `DiffDrivePlatform` bounded by the SAME generic SG2 seam
+    /// (`validate_platform_containment`) that bounds the Ackermann AV — the
+    /// thesis demonstrated end-to-end on a non-Ackermann platform.
+    #[test]
+    fn diffdrive_is_bounded_by_the_generic_containment_seam() {
+        use kirra_core::containment::{Corridor, Point, Pose};
+        use kirra_core::frame_integrity::FrameTrust;
+        use kirra_core::kinematics_contract::{DenyCode, EnforceAction};
+        use kirra_core::platform_kinematics::validate_platform_containment;
+
+        let p = platform(); // 0.6 m × 0.9 m diff-drive robot, center convention
+        // Corridor half-width 1.0 m: robot half-width 0.3 + 0.40 margin = 0.70 < 1.0 → fits centered.
+        let n = 8;
+        let dx = 100.0 / (n as f64 - 1.0);
+        let left: Vec<Point> = (0..n).map(|i| Point { x_m: i as f64 * dx, y_m: 1.0 }).collect();
+        let right: Vec<Point> = (0..n).map(|i| Point { x_m: i as f64 * dx, y_m: -1.0 }).collect();
+        let corridor = Corridor {
+            left: &left,
+            right: &right,
+            confidence: 0.95,
+            age_ms: 10,
+            min_confidence: 0.5,
+            max_age_ms: 500,
+        };
+
+        let centered = vec![Pose { x_m: 50.0, y_m: 0.0, heading_rad: 0.0 }];
+        assert!(
+            matches!(
+                validate_platform_containment(&p, &centered, &corridor, FrameTrust::Trusted),
+                EnforceAction::Allow
+            ),
+            "a 0.6 m diff-drive robot fits a 2 m corridor"
+        );
+
+        // Shoved to the edge → its left edge (y = 1.2) departs the corridor.
+        let off = vec![Pose { x_m: 50.0, y_m: 0.9, heading_rad: 0.0 }];
+        assert!(
+            matches!(
+                validate_platform_containment(&p, &off, &corridor, FrameTrust::Trusted),
+                EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture)
+            ),
+            "the same robot departs when shoved to the corridor edge — same SG2 seam"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

The moment the platform abstraction goes from **expressible** to **enforced**: the existing SG2 drivable-space checker now bounds **any** platform through one generic seam. Builds on S-PK1a/b (merged in #518).

```rust
/// Bound any platform's trajectory by the existing SG2 checker, sourcing the
/// footprint from the trait — drive-agnostic.
pub fn validate_platform_containment<P: PlatformKinematics>(
    platform: &P, trajectory: &[Pose], corridor: &Corridor, frame_trust: FrameTrust,
) -> EnforceAction {
    validate_trajectory_containment(trajectory, corridor, &platform.footprint(), frame_trust)
}
```

## Why it matters

S-PK1a/b proved the governor can *describe* two platforms. S-PK1c proves the **existing checker actually bounds any of them** — a differential-drive robot (and future omni) gets drivable-space containment from the *same* checker that bounds the Ackermann AV, with no per-platform reimplementation. It's the Track-3 thesis delivered at minimal cost/risk.

## Properties (conformant to the CLAUDE.md doer-checker invariants)

- **Drive-agnostic:** reads only the trait's behavioral `footprint()`, never platform *mechanism* (wheelbase, ICR).
- **Purely additive:** does **not** touch the WCET-critical per-pose `validate_vehicle_command` path or the existing Ackermann slow loop → zero risk to the AV safety case.
- **Fail-closed by construction:** inherits the underlying `validate_trajectory_containment` gates (absent/stale/degenerate corridor or `Untrusted` frame → `DenyBreach`).

## Dual-platform proof

- **kirra-core:** a mock narrow `TinyBot` and the full-width `AckermannPlatform`, bounded by the *same* seam + corridor + pose — the verdict differs **purely from `footprint()`** (robot fits, vehicle departs).
- **parko-kirra:** the real `DiffDrivePlatform` bounded by the same seam (fits centered, departs at the corridor edge).

## Decisions held / scope

- Footprint stays `VehicleFootprint` + center convention (finding #1).
- **Containment-seam-only — NOT slow-loop unification** (finding #2 acknowledged); RSS / per-command stay platform-specific.
- This is the **seam + proof, not a deployment** — no live diff-drive node consumes it yet (diff-drive's checker remains parko's `KirraGovernor`). Wiring a diff-drive node is a later, gated step.

## Verification
kirra-core 161 tests + parko-kirra platform tests pass; clippy + workspace `cargo check` clean. PROPOSED — not an ENFORCED claim until S-PK1e (RTM/AoU + ADR-0017).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWXgETCGcdP6XXErwLHkFk)_