### PR TITLE
On-Orin Mick·Taj·Occy·KIRRA stack: doer bridge, perception derate, Gazebo + systemd, and the sidewalk-courier ODD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,6 +2015,7 @@ dependencies = [
  "kirra-core",
  "kirra-planner",
  "kirra-ros2-adapter",
+ "kirra-taj",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/kirra-mick/Cargo.toml
+++ b/crates/kirra-mick/Cargo.toml
@@ -29,3 +29,7 @@ serde_json = "1"
 # VehicleConfig + the mock corridor.
 kirra-ros2-adapter = { path = "../kirra-ros2-adapter", default-features = false }
 kirra-core = { path = "../kirra-core" }
+# Taj (ADR-0015) perception for the `taj_occy_kirra_stack` example — the four-component
+# on-Orin stack (Taj → Mick → Occy → KIRRA). Taj is lean (kirra-core only, no ROS), so
+# this keeps the example off the adapter's ros2/tokio tree.
+kirra-taj = { path = "../kirra-taj" }

--- a/crates/kirra-mick/examples/drive_session.rs
+++ b/crates/kirra-mick/examples/drive_session.rs
@@ -1,0 +1,121 @@
+//! **A deterministic closed-loop drive session with Occy as the DOER and KIRRA as the CHECKER.**
+//!
+//! Where `governor_drive_session.py` uses a toy controller and the HTTP governor, this runs the
+//! REAL planner: each slow tick Occy grounds a Mick intent into a trajectory (`plan_for_intent`),
+//! KIRRA validates it (`validate_trajectory_slow`), and only an ADMITTED trajectory is committed to
+//! the fast-loop tracker that carries the ego forward — exactly the dual-rate loop the AV stack
+//! uses, with no LLM and no GPU. Every decision is recorded (`MickDecisionRecord`) and scored
+//! (`MickEvalSummary`), and a per-tick divergence line (proposed peak speed → checker verdict) is
+//! printed, so Occy's performance is *measured* against the checker over a continuous drive.
+//!
+//! The ego drives a route that goes straight, then through a curve, to an exit — so the verdict
+//! mix reflects real geometry. The clear straight admits; a fraction of Occy's continuous
+//! curve-following proposals are REFUSED (→ MRC fallback) — a closed-loop divergence the discrete
+//! scenario tests don't surface, and exactly the tuning hotspot this harness exists to find. The
+//! verdict split is the tuning signal. Tune the DOER from this, never the checker's envelope.
+//!
+//! Run: `cargo run -p kirra-mick --example drive_session`
+
+use kirra_planner::{
+    plan_for_intent, EgoState, FastLoopTracker, FleetPosture, GeometricPlanner,
+    GeometricPlannerConfig, Goal, Lane, LaneEdge, LaneGraph, LineType, MickDecisionRecord,
+    MickEvalSummary, MickIntent, PlanInput, Pose, ProposalKind,
+};
+use kirra_ros2_adapter::corridor::{CorridorSource, Point};
+use kirra_ros2_adapter::state::TrajectoryVerdict;
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+const FAST_DT_MS: u64 = 100; // 10 Hz fast loop
+const FAST_DT_S: f64 = 0.1;
+const REPLAN_MS: u64 = 300; // slow-loop (Occy) replan cadence
+const TICKS: usize = 120; // 12 s drive
+const MRC_DECEL: f64 = 3.0;
+
+const R: f64 = 22.0;
+
+/// A route graph that runs straight (0,0)→(30,0), curves LEFT through an arc, then exits north —
+/// the route Occy grounds (`RouteTo`) and KIRRA bounds.
+fn route_graph() -> LaneGraph {
+    let arc: Vec<Point> = (0..=12)
+        .map(|i| {
+            let t = -std::f64::consts::FRAC_PI_2 + std::f64::consts::FRAC_PI_2 * (i as f64 / 12.0);
+            Point { x_m: 30.0 + R * t.cos(), y_m: R + R * t.sin() }
+        })
+        .collect();
+    LaneGraph::new()
+        .with_lane(Lane::straight(1, 0.0, 0.0, 30.0, 3.0, LineType::Solid, LineType::Solid).with_edge(LaneEdge::Successor { to: 2 }))
+        .with_lane(Lane {
+            id: 2, centerline: arc, half_width_m: 3.0, left_line: LineType::Solid, right_line: LineType::Solid,
+            heading_rad: std::f64::consts::FRAC_PI_2, edges: vec![LaneEdge::Successor { to: 3 }], control: None,
+        })
+        .with_lane(Lane {
+            id: 3, centerline: vec![Point { x_m: 30.0 + R, y_m: R }, Point { x_m: 30.0 + R, y_m: R + 20.0 }],
+            half_width_m: 3.0, left_line: LineType::Solid, right_line: LineType::Solid,
+            heading_rad: std::f64::consts::FRAC_PI_2, edges: Vec::new(), control: None,
+        })
+}
+
+fn world<'a>(ego: EgoState, map: &'a dyn CorridorSource, g: &'a LaneGraph, goal: Pose) -> PlanInput<'a> {
+    PlanInput {
+        ego, goal: Goal { target: goal }, map, objects: &[], controls: &[], lane_boundaries: &[], motion: &[],
+        predicted_paths: &[], cedes_to_ego_ids: &[], lane_change_to_m: None, no_overtake_ids: &[], drivable: None,
+        posture: FleetPosture::Nominal, target_speed_mps: None, request_overtake: false, request_pull_over: false,
+        lane_graph: Some(g), signal_states: &[],
+    }
+}
+
+fn main() {
+    let g = route_graph();
+    let route = g.route(1, 3).expect("route 1→3");
+    let corr = g.route_corridor(&route, 0.95, 0).expect("route corridor"); // KIRRA's validation corridor
+    // Exit lane tops out at (30+R, R+20) = (52, 42); aim a couple of metres short of the top.
+    let goal = Pose { x_m: 30.0 + R, y_m: R + 16.0, heading_rad: std::f64::consts::FRAC_PI_2 };
+    let cfg = GeometricPlannerConfig { cruise_speed_mps: 10.0, ..Default::default() };
+    let mut occy = GeometricPlanner::new(cfg);
+    let vcfg = VehicleConfig::default_urban();
+
+    let mut ego = EgoState { pose: Pose { x_m: 2.0, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: 6.0, yaw_rate_rads: 0.0, stamp_ms: 0 };
+    let mut tracker = FastLoopTracker::new();
+    let mut last_replan: Option<u64> = None;
+    let mut records: Vec<MickDecisionRecord> = Vec::new();
+
+    println!("Occy(doer) → KIRRA(checker) closed-loop drive — straight, curve, exit");
+    println!("   t(s)  ego.x  ego.y    v    proposed_vmax   verdict");
+    for tick in 1..=TICKS {
+        let now = tick as u64 * FAST_DT_MS;
+
+        // SLOW loop: Occy proposes, KIRRA checks, admit→commit.
+        if tracker.is_exhausted(now) || last_replan.is_none_or(|t| now.saturating_sub(t) >= REPLAN_MS) {
+            let w = world(ego, &corr, &g, goal);
+            let intent = MickIntent::RouteTo { x_m: goal.x_m, y_m: goal.y_m };
+            let plan = plan_for_intent(&mut occy, &intent, &w);
+            let verdict = validate_trajectory_slow(&plan.trajectory, &corr, &[], &vcfg, None, FleetPosture::Nominal);
+            let vmax = plan.trajectory.iter().map(|p| p.velocity_mps).fold(0.0_f64, f64::max);
+            records.push(MickDecisionRecord::new(tick as u64, now, &intent, &plan, verdict));
+            println!("  {:>5.1} {:>6.2} {:>6.2} {:>5.2}    {:>9.2}     {verdict:?}",
+                now as f64 / 1000.0, ego.pose.x_m, ego.pose.y_m, ego.linear_x_mps, vmax);
+            if matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp) && plan.kind == ProposalKind::Motion {
+                tracker.promote(plan, now);
+                last_replan = Some(now);
+            }
+        }
+
+        // FAST loop: track the committed trajectory; MRC-decel if none.
+        ego = match tracker.track(now) {
+            Some(cmd) => EgoState { pose: cmd.pose, linear_x_mps: cmd.velocity_mps, yaw_rate_rads: 0.0, stamp_ms: now },
+            None => EgoState { pose: ego.pose, linear_x_mps: (ego.linear_x_mps - MRC_DECEL * FAST_DT_S).max(0.0), yaw_rate_rads: 0.0, stamp_ms: now },
+        };
+        if (ego.pose.x_m - goal.x_m).hypot(ego.pose.y_m - goal.y_m) < 2.0 {
+            println!("  reached the exit at t={:.1}s", now as f64 / 1000.0);
+            break;
+        }
+    }
+
+    let summary = MickEvalSummary::from_records(&records);
+    println!("\n{summary}");
+    println!("  → Occy as the doer; the verdict mix is the tuning scorecard. Here the STRAIGHT admits");
+    println!("    (clamp = a minor derate) while a fraction of the CURVE proposals are REFUSED — the");
+    println!("    closed-loop tuning HOTSPOT (continuous curve-following the discrete scenario tests miss).");
+    println!("    Every refused proposal fell back to MRC; KIRRA bounded every committed pose. Tune the");
+    println!("    DOER's curve speed/line from this, never the checker's envelope.");
+}

--- a/crates/kirra-mick/examples/planner_service.rs
+++ b/crates/kirra-mick/examples/planner_service.rs
@@ -53,28 +53,48 @@ struct PlanRequest {
 }
 fn default_cruise() -> f64 { 10.0 }
 
-/// Override fields for the checker's `VehicleConfig` (all optional; absent fields keep the
-/// urban-car default). Half-extents are bumper-to-centre, matching `VehicleConfig`.
+/// Vehicle profile for BOTH the checker (`VehicleConfig`) and the doer's lateral-clearance
+/// target. `class` picks the base sibling profile (`robotaxi` default, or `courier` for a
+/// small robot — see docs/CONTRACT_PROFILES.md); the remaining fields fine-tune it. All
+/// optional; absent → the urban-car/robotaxi default, so the AV path is unchanged.
 #[derive(Deserialize)]
 struct VehicleReq {
+    class: Option<String>,
     wheelbase_m: Option<f64>,
     half_length_m: Option<f64>,
     half_width_m: Option<f64>,
     max_speed_mps: Option<f64>,
     max_steering_deg: Option<f64>,
+    /// Per-class RSS lateral-alignment band (m). Robotaxi 4.0; a small robot needs a
+    /// tighter band to pass an obstacle a car couldn't (the checker side of the pass).
+    rss_lateral_alignment_tolerance_m: Option<f64>,
+    /// The DOER's lateral clearance target (m) — how much room Occy demands before it will
+    /// PROPOSE a pass. Robot scale must drop this (default 4.5 is car-scale) or Occy never
+    /// proposes the pass in the first place; the checker (`rss_...`) then admits it.
+    lateral_clearance_target_m: Option<f64>,
 }
 
-/// Build the checker's `VehicleConfig` from the request (urban-car default + overrides).
+/// Build the checker's `VehicleConfig` from the request: a base sibling profile selected by
+/// `class`, then explicit overrides. Absent → `default_urban` (robotaxi), unchanged.
 fn vehicle_config(req: &PlanRequest) -> VehicleConfig {
-    let mut v = VehicleConfig::default_urban();
+    let mut v = match req.vehicle.as_ref().and_then(|o| o.class.as_deref()) {
+        Some("courier") | Some("robot") => VehicleConfig::courier(),
+        _ => VehicleConfig::default_urban(),
+    };
     if let Some(o) = &req.vehicle {
         if let Some(x) = o.wheelbase_m { v.wheelbase_m = x; }
         if let Some(x) = o.half_length_m { v.half_length_m = x; }
         if let Some(x) = o.half_width_m { v.half_width_m = x; }
         if let Some(x) = o.max_speed_mps { v.max_speed_mps = x; }
         if let Some(x) = o.max_steering_deg { v.max_steering_rad = x.to_radians(); }
+        if let Some(x) = o.rss_lateral_alignment_tolerance_m { v.rss_lateral_alignment_tolerance_m = x; }
     }
     v
+}
+
+/// The DOER's lateral-clearance target from the request (default keeps the planner default).
+fn lateral_clearance_target(req: &PlanRequest) -> Option<f64> {
+    req.vehicle.as_ref().and_then(|o| o.lateral_clearance_target_m)
 }
 
 #[derive(Serialize)]
@@ -114,8 +134,11 @@ fn handle_plan(req: &PlanRequest) -> PlanResponse {
         lane_graph: None, signal_states: &[],
     };
 
-    // The DOER: real Occy grounds the GoTo intent.
-    let cfg = GeometricPlannerConfig { cruise_speed_mps: req.cruise, ..Default::default() };
+    // The DOER: real Occy grounds the GoTo intent. A robot profile drops the lateral-
+    // clearance target so Occy will PROPOSE a robot-scale pass (the car-scale 4.5 default
+    // never fits a robot corridor); the checker's per-class RSS band then admits it.
+    let mut cfg = GeometricPlannerConfig { cruise_speed_mps: req.cruise, ..Default::default() };
+    if let Some(ct) = lateral_clearance_target(req) { cfg.lateral_clearance_target_m = ct; }
     let plan = plan_for_intent(&mut GeometricPlanner::new(cfg), &MickIntent::GoTo { x_m: req.goal.x, y_m: req.goal.y }, &world);
     // The CHECKER: KIRRA's verdict on the proposal (the client applies it / falls back accordingly).
     let verdict = validate_trajectory_slow(&plan.trajectory, &corr, &objects, &vehicle_config(req), None, FleetPosture::Nominal);

--- a/crates/kirra-mick/examples/planner_service.rs
+++ b/crates/kirra-mick/examples/planner_service.rs
@@ -44,8 +44,38 @@ struct PlanRequest {
     right: Vec<[f64; 2]>,
     #[serde(default)]
     objects: Vec<ObjReq>,
+    /// Optional vehicle footprint/kinematics for the CHECKER. Absent → the urban-car
+    /// default (4.8 m). A small differential robot (e.g. a Rosmaster) MUST pass its own
+    /// dimensions, or the car-sized footprint can't fit a robot-scale corridor and KIRRA
+    /// MRCs every plan.
+    #[serde(default)]
+    vehicle: Option<VehicleReq>,
 }
 fn default_cruise() -> f64 { 10.0 }
+
+/// Override fields for the checker's `VehicleConfig` (all optional; absent fields keep the
+/// urban-car default). Half-extents are bumper-to-centre, matching `VehicleConfig`.
+#[derive(Deserialize)]
+struct VehicleReq {
+    wheelbase_m: Option<f64>,
+    half_length_m: Option<f64>,
+    half_width_m: Option<f64>,
+    max_speed_mps: Option<f64>,
+    max_steering_deg: Option<f64>,
+}
+
+/// Build the checker's `VehicleConfig` from the request (urban-car default + overrides).
+fn vehicle_config(req: &PlanRequest) -> VehicleConfig {
+    let mut v = VehicleConfig::default_urban();
+    if let Some(o) = &req.vehicle {
+        if let Some(x) = o.wheelbase_m { v.wheelbase_m = x; }
+        if let Some(x) = o.half_length_m { v.half_length_m = x; }
+        if let Some(x) = o.half_width_m { v.half_width_m = x; }
+        if let Some(x) = o.max_speed_mps { v.max_speed_mps = x; }
+        if let Some(x) = o.max_steering_deg { v.max_steering_rad = x.to_radians(); }
+    }
+    v
+}
 
 #[derive(Serialize)]
 struct TrajPt { x: f64, y: f64, heading: f64, v: f64, t: f64 }
@@ -88,7 +118,7 @@ fn handle_plan(req: &PlanRequest) -> PlanResponse {
     let cfg = GeometricPlannerConfig { cruise_speed_mps: req.cruise, ..Default::default() };
     let plan = plan_for_intent(&mut GeometricPlanner::new(cfg), &MickIntent::GoTo { x_m: req.goal.x, y_m: req.goal.y }, &world);
     // The CHECKER: KIRRA's verdict on the proposal (the client applies it / falls back accordingly).
-    let verdict = validate_trajectory_slow(&plan.trajectory, &corr, &objects, &VehicleConfig::default_urban(), None, FleetPosture::Nominal);
+    let verdict = validate_trajectory_slow(&plan.trajectory, &corr, &objects, &vehicle_config(req), None, FleetPosture::Nominal);
 
     PlanResponse {
         kind: match plan.kind { ProposalKind::Motion => "Motion", ProposalKind::SafeStop => "SafeStop" }.to_string(),

--- a/crates/kirra-mick/examples/planner_service.rs
+++ b/crates/kirra-mick/examples/planner_service.rs
@@ -136,10 +136,15 @@ fn handle_plan(req: &PlanRequest) -> PlanResponse {
         lane_graph: None, signal_states: &[],
     };
 
-    // The DOER: real Occy grounds the GoTo intent. A robot profile drops the lateral-
-    // clearance target so Occy will PROPOSE a robot-scale pass (the car-scale 4.5 default
-    // never fits a robot corridor); the checker's per-class RSS band then admits it.
-    let mut cfg = GeometricPlannerConfig { cruise_speed_mps: req.cruise, ..Default::default() };
+    // The DOER: real Occy grounds the GoTo intent. A courier class selects the robot-scale
+    // planner preset (stops ~1 m short, routes around with the courier clearance, small
+    // footprint) so Occy PROPOSES robot-scale motion the car-scale default never would; the
+    // checker's per-class profile then bounds it. `class` mirrors the VehicleConfig selector.
+    let mut cfg = match req.vehicle.as_ref().and_then(|o| o.class.as_deref()) {
+        Some("courier") | Some("robot") | Some("sidewalk") => GeometricPlannerConfig::courier(),
+        _ => GeometricPlannerConfig::default(),
+    };
+    cfg.cruise_speed_mps = req.cruise;
     if let Some(ct) = lateral_clearance_target(req) { cfg.lateral_clearance_target_m = ct; }
     let plan = plan_for_intent(&mut GeometricPlanner::new(cfg), &MickIntent::GoTo { x_m: req.goal.x, y_m: req.goal.y }, &world);
     // The CHECKER: KIRRA's verdict on the proposal (the client applies it / falls back accordingly).

--- a/crates/kirra-mick/examples/planner_service.rs
+++ b/crates/kirra-mick/examples/planner_service.rs
@@ -77,9 +77,11 @@ struct VehicleReq {
 /// Build the checker's `VehicleConfig` from the request: a base sibling profile selected by
 /// `class`, then explicit overrides. Absent → `default_urban` (robotaxi), unchanged.
 fn vehicle_config(req: &PlanRequest) -> VehicleConfig {
+    // Select the base sibling profile via the single slow-loop class selector (mirrors the
+    // fast-loop VehicleClass::from_str). Absent class → robotaxi (default_urban), unchanged.
     let mut v = match req.vehicle.as_ref().and_then(|o| o.class.as_deref()) {
-        Some("courier") | Some("robot") => VehicleConfig::courier(),
-        _ => VehicleConfig::default_urban(),
+        Some(class) => VehicleConfig::for_class(class),
+        None => VehicleConfig::default_urban(),
     };
     if let Some(o) = &req.vehicle {
         if let Some(x) = o.wheelbase_m { v.wheelbase_m = x; }

--- a/crates/kirra-mick/examples/planner_service.rs
+++ b/crates/kirra-mick/examples/planner_service.rs
@@ -1,0 +1,159 @@
+//! **A tiny HTTP planner endpoint wrapping the REAL Occy + KIRRA.** Lets a non-Rust client (e.g.
+//! the CARLA Python harness) drive egos with the actual planner instead of a placeholder
+//! controller: POST a world snapshot, get back Occy's KIRRA-validated trajectory.
+//!
+//! It deliberately lives in `kirra-mick` (the doer/demo side), NOT the safety-critical verifier
+//! crate — this serves the DOER's proposal; the governor's enforcement is the separate verifier
+//! service. A hand-rolled `std::net` HTTP/1.1 server keeps it dependency-free.
+//!
+//!   cargo run -p kirra-mick --example planner_service      # listens on 127.0.0.1:8100
+//!
+//!   POST /plan   {"ego":{"x":..,"y":..,"heading":..,"speed":..},
+//!                 "goal":{"x":..,"y":..}, "cruise":10.0,
+//!                 "left":[[x,y],..], "right":[[x,y],..],       # drivable corridor boundaries
+//!                 "objects":[{"id":1,"x":..,"y":..,"vx":..,"vy":..}]}
+//!     → {"kind":"Motion|SafeStop", "verdict":"Accept|Clamp|MRCFallback",
+//!        "trajectory":[{"x":..,"y":..,"heading":..,"v":..,"t":..}, ..]}
+//!   GET /health  → {"status":"ok"}
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+
+use kirra_planner::{
+    plan_for_intent, EgoState, FleetPosture, GeometricPlanner, GeometricPlannerConfig, Goal,
+    MickIntent, PlanInput, Pose, ProposalKind,
+};
+use kirra_ros2_adapter::corridor::{CorridorSource, Point};
+use kirra_ros2_adapter::state::{PerceivedObject, TrajectoryVerdict};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct Xy { x: f64, y: f64 }
+#[derive(Deserialize)]
+struct EgoReq { x: f64, y: f64, heading: f64, speed: f64 }
+#[derive(Deserialize)]
+struct ObjReq { id: u64, x: f64, y: f64, vx: f64, vy: f64 }
+#[derive(Deserialize)]
+struct PlanRequest {
+    ego: EgoReq,
+    goal: Xy,
+    #[serde(default = "default_cruise")]
+    cruise: f64,
+    left: Vec<[f64; 2]>,
+    right: Vec<[f64; 2]>,
+    #[serde(default)]
+    objects: Vec<ObjReq>,
+}
+fn default_cruise() -> f64 { 10.0 }
+
+#[derive(Serialize)]
+struct TrajPt { x: f64, y: f64, heading: f64, v: f64, t: f64 }
+#[derive(Serialize)]
+struct PlanResponse { kind: String, verdict: String, trajectory: Vec<TrajPt> }
+
+/// A `CorridorSource` straight off the request's boundary polylines.
+struct ReqCorridor { left: Vec<Point>, right: Vec<Point> }
+impl CorridorSource for ReqCorridor {
+    fn left_boundary(&self) -> &[Point] { &self.left }
+    fn right_boundary(&self) -> &[Point] { &self.right }
+    fn confidence(&self) -> f32 { 0.95 }
+    fn age_ms(&self) -> u64 { 10 }
+}
+
+fn pts(v: &[[f64; 2]]) -> Vec<Point> {
+    v.iter().map(|p| Point { x_m: p[0], y_m: p[1] }).collect()
+}
+
+fn handle_plan(req: &PlanRequest) -> PlanResponse {
+    let corr = ReqCorridor { left: pts(&req.left), right: pts(&req.right) };
+    let objects: Vec<PerceivedObject> = req.objects.iter().map(|o| PerceivedObject {
+        id: o.id,
+        pos: Point { x_m: o.x, y_m: o.y },
+        velocity_mps: o.vx.hypot(o.vy),
+        heading_rad: o.vy.atan2(o.vx),
+        vel: Point { x_m: o.vx, y_m: o.vy },
+    }).collect();
+
+    let world = PlanInput {
+        ego: EgoState { pose: Pose { x_m: req.ego.x, y_m: req.ego.y, heading_rad: req.ego.heading }, linear_x_mps: req.ego.speed, yaw_rate_rads: 0.0, stamp_ms: 0 },
+        goal: Goal { target: Pose { x_m: req.goal.x, y_m: req.goal.y, heading_rad: req.ego.heading } },
+        map: &corr, objects: &objects, controls: &[], lane_boundaries: &[], motion: &[], predicted_paths: &[],
+        cedes_to_ego_ids: &[], lane_change_to_m: None, no_overtake_ids: &[], drivable: None,
+        posture: FleetPosture::Nominal, target_speed_mps: None, request_overtake: false, request_pull_over: false,
+        lane_graph: None, signal_states: &[],
+    };
+
+    // The DOER: real Occy grounds the GoTo intent.
+    let cfg = GeometricPlannerConfig { cruise_speed_mps: req.cruise, ..Default::default() };
+    let plan = plan_for_intent(&mut GeometricPlanner::new(cfg), &MickIntent::GoTo { x_m: req.goal.x, y_m: req.goal.y }, &world);
+    // The CHECKER: KIRRA's verdict on the proposal (the client applies it / falls back accordingly).
+    let verdict = validate_trajectory_slow(&plan.trajectory, &corr, &objects, &VehicleConfig::default_urban(), None, FleetPosture::Nominal);
+
+    PlanResponse {
+        kind: match plan.kind { ProposalKind::Motion => "Motion", ProposalKind::SafeStop => "SafeStop" }.to_string(),
+        verdict: match verdict {
+            TrajectoryVerdict::Accept => "Accept",
+            TrajectoryVerdict::Clamp => "Clamp",
+            TrajectoryVerdict::MRCFallback => "MRCFallback",
+            other => return PlanResponse { kind: "SafeStop".into(), verdict: format!("{other:?}"), trajectory: vec![] },
+        }.to_string(),
+        trajectory: plan.trajectory.iter().map(|p| TrajPt {
+            x: p.pose.x_m, y: p.pose.y_m, heading: p.pose.heading_rad, v: p.velocity_mps, t: p.time_from_start_s,
+        }).collect(),
+    }
+}
+
+fn respond(stream: &mut TcpStream, status: &str, body: &str) {
+    let msg = format!("HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len());
+    let _ = stream.write_all(msg.as_bytes());
+}
+
+fn serve(mut stream: TcpStream) {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).is_err() { return; }
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).is_err() || line == "\r\n" || line.is_empty() { break; }
+        if let Some(v) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            content_length = v.trim().parse().unwrap_or(0);
+        }
+    }
+    let mut parts = request_line.split_whitespace();
+    let (method, path) = (parts.next().unwrap_or(""), parts.next().unwrap_or(""));
+
+    if method == "GET" && path == "/health" {
+        respond(&mut stream, "200 OK", "{\"status\":\"ok\"}");
+        return;
+    }
+    if method == "POST" && path == "/plan" {
+        let mut body = vec![0u8; content_length];
+        if reader.read_exact(&mut body).is_err() {
+            respond(&mut stream, "400 Bad Request", "{\"error\":\"short body\"}");
+            return;
+        }
+        match serde_json::from_slice::<PlanRequest>(&body) {
+            Ok(req) => {
+                let resp = handle_plan(&req);
+                respond(&mut stream, "200 OK", &serde_json::to_string(&resp).unwrap());
+            }
+            Err(e) => respond(&mut stream, "400 Bad Request", &format!("{{\"error\":\"{e}\"}}")),
+        }
+        return;
+    }
+    respond(&mut stream, "404 Not Found", "{\"error\":\"unknown route\"}");
+}
+
+fn main() {
+    let addr = std::env::var("KIRRA_PLANNER_ADDR").unwrap_or_else(|_| "127.0.0.1:8100".to_string());
+    let listener = TcpListener::bind(&addr).unwrap_or_else(|e| { eprintln!("planner_service: bind {addr}: {e}"); std::process::exit(1); });
+    println!("Occy planner service on http://{addr}  (POST /plan, GET /health)");
+    for stream in listener.incoming() {
+        match stream {
+            Ok(s) => serve(s),
+            Err(e) => eprintln!("planner_service: accept error: {e}"),
+        }
+    }
+}

--- a/crates/kirra-mick/examples/sidewalk_session.rs
+++ b/crates/kirra-mick/examples/sidewalk_session.rs
@@ -58,7 +58,9 @@ fn run_scenario(
 ) {
     let corridor = MockCorridorSource::straight_5m_half_width(100.0);
     let vcfg = VehicleConfig::courier(); // the checker judges a small robot, not a car
-    let mut occy = GeometricPlanner::new(GeometricPlannerConfig { cruise_speed_mps: CREEP_CRUISE_MPS, ..Default::default() });
+    // The DOER's robot-scale planner preset (ADR-0027 / step B): stop ~1 m short of a person,
+    // route around with the courier clearance, small footprint — overridden cruise to creep.
+    let mut occy = GeometricPlanner::new(GeometricPlannerConfig { cruise_speed_mps: CREEP_CRUISE_MPS, ..GeometricPlannerConfig::courier() });
 
     let mut ego_x = ego_start_x;
     let mut speed = 0.0;

--- a/crates/kirra-mick/examples/sidewalk_session.rs
+++ b/crates/kirra-mick/examples/sidewalk_session.rs
@@ -1,0 +1,145 @@
+//! **A deterministic sidewalk-courier drive exercising the ADR-0027 behaviors end to end.**
+//! Mick authors a sidewalk intent each tick, Occy grounds it, KIRRA (the COURIER profile)
+//! bounds it, and only an admitted plan carries the ego forward — so the new `Yield` and
+//! `CrossWhenClear` primitives are shown COMPOSING in a continuous drive, not just in unit tests.
+//!
+//! Two scenarios:
+//!   1. **Yield** — the courier creeps down a sidewalk toward a goal; a pedestrian steps across
+//!      its path. The courier slows, stops a standoff short, HOLDS while the pedestrian is in the
+//!      way, then resumes once clear. (`MickIntent::Yield`)
+//!   2. **CrossWhenClear** — the courier reaches a crosswalk; a car crosses its line. It waits at
+//!      the curb while the car is closing, then steps off once the gap is clear. (`MickIntent::CrossWhenClear`)
+//!
+//! No GPU, no ROS — pure aarch64-native compute, the same path that runs on the Orin.
+//!
+//! Run: `cargo run -p kirra-mick --example sidewalk_session`
+
+use kirra_planner::{
+    plan_for_intent, EgoState, FleetPosture, GeometricPlanner, GeometricPlannerConfig, Goal,
+    MickIntent, PlanInput, Pose, ProposalKind, TrajectoryPoint,
+};
+use kirra_ros2_adapter::corridor::{MockCorridorSource, Point};
+use kirra_ros2_adapter::state::{PerceivedObject, TrajectoryVerdict};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+const DT: f64 = 0.2; // 5 Hz
+const CREEP_CRUISE_MPS: f64 = 1.5; // sidewalk creep
+const STOP_EPS: f64 = 0.05;
+
+/// The committed speed: the validated trajectory's planned velocity ~0.4 s in (what the fast loop
+/// would track), so a capped/creeping plan carries the right speed and a stop carries zero.
+fn committed_speed(traj: &[TrajectoryPoint]) -> f64 {
+    traj.iter()
+        .find(|p| p.time_from_start_s >= 0.4)
+        .or_else(|| traj.last())
+        .map_or(0.0, |p| p.velocity_mps)
+}
+
+fn obj(id: u64, x: f64, y: f64, vx: f64, vy: f64) -> PerceivedObject {
+    PerceivedObject {
+        id,
+        pos: Point { x_m: x, y_m: y },
+        velocity_mps: vx.hypot(vy),
+        heading_rad: vy.atan2(vx),
+        vel: Point { x_m: vx, y_m: vy },
+    }
+}
+
+/// Run one temporal scenario: each tick build the world, ground `intent_at(tick, goal)`, let KIRRA
+/// (courier profile) judge it, commit the admitted speed onto the ego (along +X), advance the
+/// agents. Returns `(moved_ticks, held_ticks, reached, all_admitted)`.
+fn run_scenario(
+    label: &str,
+    goal_x: f64,
+    ego_start_x: f64,
+    ticks: usize,
+    intent: MickIntent,
+    agents_at: impl Fn(usize) -> Vec<PerceivedObject>,
+) {
+    let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+    let vcfg = VehicleConfig::courier(); // the checker judges a small robot, not a car
+    let mut occy = GeometricPlanner::new(GeometricPlannerConfig { cruise_speed_mps: CREEP_CRUISE_MPS, ..Default::default() });
+
+    let mut ego_x = ego_start_x;
+    let mut speed = 0.0;
+    let (mut moved, mut held, mut divergences) = (0usize, 0usize, 0usize);
+    let mut reached = false;
+
+    println!("== {label} ==");
+    println!("  t(s)  ego_x  speed  occy        kirra        agents");
+    for tick in 0..ticks {
+        let now = (tick as f64 * DT * 1000.0) as u64;
+        let agents = agents_at(tick);
+
+        let world = PlanInput {
+            ego: EgoState { pose: Pose { x_m: ego_x, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: speed, yaw_rate_rads: 0.0, stamp_ms: now },
+            goal: Goal { target: Pose { x_m: goal_x, y_m: 0.0, heading_rad: 0.0 } },
+            map: &corridor,
+            objects: &agents,
+            controls: &[], lane_boundaries: &[], motion: &[], predicted_paths: &[],
+            cedes_to_ego_ids: &[], lane_change_to_m: None, no_overtake_ids: &[], drivable: None,
+            posture: FleetPosture::Nominal, target_speed_mps: None,
+            request_overtake: false, request_pull_over: false, lane_graph: None, signal_states: &[],
+        };
+        let plan = plan_for_intent(&mut occy, &intent, &world);
+        let verdict = validate_trajectory_slow(&plan.trajectory, &corridor, &agents, &vcfg, None, FleetPosture::Nominal);
+
+        let admitted = matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp) && plan.kind == ProposalKind::Motion;
+        let cmd_v = if admitted { committed_speed(&plan.trajectory) } else { 0.0 };
+        // Occy proposed motion but KIRRA refused it → a doer/checker DIVERGENCE (the courier still
+        // holds, fail-safe; this is the tuning signal, not a fault — KIRRA backstops the doer).
+        if plan.kind == ProposalKind::Motion && !admitted { divergences += 1; }
+        if cmd_v > STOP_EPS { moved += 1; } else { held += 1; }
+
+        speed = cmd_v;
+        ego_x += cmd_v * DT;
+
+        // Compact trace: print transitions + a few samples.
+        if tick % 4 == 0 || (cmd_v <= STOP_EPS) != (speed <= STOP_EPS) {
+            let near = agents.iter().min_by(|a, b| a.pos.x_m.total_cmp(&b.pos.x_m))
+                .map(|a| format!("nearest@({:.1},{:.1})", a.pos.x_m, a.pos.y_m)).unwrap_or_else(|| "—".into());
+            println!("  {:>4.1} {:>6.2} {:>6.2}  {:<11} {:<12} {near}",
+                now as f64 / 1000.0, ego_x, cmd_v, format!("{:?}", plan.kind), format!("{verdict:?}"));
+        }
+        if ego_x >= goal_x - 0.6 {
+            reached = true;
+            println!("  reached the goal at t={:.1}s", now as f64 / 1000.0);
+            break;
+        }
+    }
+
+    println!("  scorecard: moved {moved} ticks, held {held} ticks (gave way / waited), reached_goal={reached}, \
+              doer/checker divergences={divergences} (KIRRA backstopped; every committed pose was admitted)");
+    println!();
+}
+
+fn main() {
+    println!("Sidewalk courier — Mick(intent) → Occy(doer) → KIRRA(courier checker), ADR-0027\n");
+
+    // 1) YIELD: a pedestrian STANDS in the courier's path at x=9 (in the personal-space band) for
+    //    ~6 s, then steps aside. The courier creeps in under the yield cap, stops ~1 m short, HOLDS
+    //    while the person is there, then resumes once they clear and reaches the goal.
+    run_scenario(
+        "Yield to a pedestrian in the path",
+        16.0, 2.0, 110,
+        MickIntent::Yield { x_m: 16.0, y_m: 0.0 },
+        |tick| {
+            // Stationary in the path until t=6 s, then steps aside (+Y) out of the band.
+            let y = if tick < 30 { 0.0 } else { 0.30 * (tick as f64 - 30.0) * DT * 5.0 };
+            vec![obj(1, 9.0, y, 0.0, 0.0)]
+        },
+    );
+
+    // 2) CROSS-WHEN-CLEAR: the courier is at the curb (x=2), crossing an ~8 m road to x=10. A car
+    //    crosses its line at x=6, reaching y=0 at ~t=10 then receding. The courier waits, then crosses.
+    run_scenario(
+        "Cross a crosswalk when clear",
+        10.0, 2.0, 110,
+        MickIntent::CrossWhenClear { x_m: 10.0, y_m: 0.0 },
+        |tick| vec![obj(2, 6.0, -12.0 + 6.0 * (tick as f64 * DT), 0.0, 6.0)], // car crossing +Y at 6 m/s
+    );
+
+    println!("  Mick proposes a sidewalk intent; Occy grounds it; KIRRA (courier profile) bounds it.");
+    println!("  Yield: the courier gives way to a pedestrian, then resumes. CrossWhenClear: it waits");
+    println!("  at the curb for the car, then steps off. Every committed pose cleared the checker.");
+}

--- a/crates/kirra-mick/examples/taj_occy_kirra_stack.rs
+++ b/crates/kirra-mick/examples/taj_occy_kirra_stack.rs
@@ -1,0 +1,171 @@
+//! **The full on-vehicle stack in one process — Taj → Mick → Occy → KIRRA — sized for a
+//! Jetson Orin NX 16GB (ADR-0014).** No GPU, no CARLA, no ROS: pure aarch64-native Rust
+//! compute, so it runs on the Orin (or any box) exactly as it would on the robot's
+//! System-2 board.
+//!
+//! Each scenario walks the real ADR-0014 propose→govern pipeline once:
+//!
+//!   1. **Taj** (`kirra-taj`, ADR-0015 Phase A) turns a synthetic forward range scan into
+//!      the Kirra perception contract — a drivable `CorridorSource` + `PerceivedObject`s.
+//!      (On the robot this is the R2 lidar/depth feed; the geometry is identical.)
+//!   2. **Mick** (`kirra_planner::mick`) is the intent seam: an LLM authors a TYPED
+//!      `MickIntent` as JSON, parsed fail-closed by `MickIntent::from_llm_json`. Here a
+//!      fixed `go_to` intent stands in for the brain — swap in `kirra-mick`'s Ollama
+//!      `ModelClient` (local Gemma on the Orin) and nothing downstream changes.
+//!   3. **Occy** (`kirra-planner`) grounds the intent against Taj's perception into a
+//!      proposed trajectory (`plan_for_intent`). Occy only PROPOSES.
+//!   4. **KIRRA** (`validate_trajectory_slow`, the #131 checker) is the sole safety
+//!      authority — it bounds Occy's proposal against Taj's corridor + objects.
+//!
+//! The scenarios sweep the regimes the stack must get right: a clear corridor (admit), a
+//! stopped car ahead (controlled stop, admitted), an off-centre obstacle in a wide corridor
+//! (route around, admitted), and a LockedOut posture (refuse everything). The load-bearing
+//! property across all of them: **Occy is never trusted to stop — KIRRA is.** Taj tightens
+//! the envelope, Occy proposes, KIRRA disposes. The footprint is pure Rust compute, so this
+//! is exactly what runs on the Orin NX System-2 board.
+//!
+//! Run: `cargo run -p kirra-mick --example taj_occy_kirra_stack`
+
+use kirra_planner::{
+    plan_for_intent, EgoState, FleetPosture, GeometricPlanner, GeometricPlannerConfig, Goal,
+    MickIntent, PlanInput, Pose, ProposalKind,
+};
+use kirra_ros2_adapter::corridor::Point;
+use kirra_ros2_adapter::state::{PerceivedObject, TrajectoryVerdict};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+use kirra_taj::{LaserScan, TajConfig, TajPhaseA};
+use std::f64::consts::PI;
+
+/// Forward 181-ray scan (`-π/2..+π/2`, 1° steps) from a per-ray range fn — a
+/// `sensor_msgs/LaserScan` subset, the shape the R2 lidar publishes.
+fn forward_scan<F: Fn(f64) -> Option<f64>>(range_max: f64, f: F) -> LaserScan {
+    let n = 181usize;
+    let angle_min = -PI / 2.0;
+    let angle_inc = PI / (n as f64 - 1.0);
+    let ranges = (0..n)
+        .map(|i| {
+            let theta = angle_min + i as f64 * angle_inc;
+            match f(theta) {
+                Some(r) if (0.05..=range_max).contains(&r) => r as f32,
+                _ => (range_max + 1.0) as f32, // no return
+            }
+        })
+        .collect();
+    LaserScan { angle_min_rad: angle_min, angle_increment_rad: angle_inc, range_min_m: 0.05, range_max_m: range_max, ranges, stamp_ms: 1 }
+}
+
+/// Two walls at `y = ±half_width`, plus an optional in-path blob at `(blob_x, 0)`
+/// (rays within `±half_angle` return at `blob_x / cos θ`). Mirrors the proven
+/// `taj_occy_kirra_stack` integration scenes.
+fn corridor_scan(half_width: f64, blob: Option<(f64, f64)>) -> LaserScan {
+    forward_scan(20.0, |theta| {
+        let s = theta.sin();
+        let wall = if s.abs() < 1e-3 { f64::INFINITY } else { half_width / s.abs() };
+        let blob_r = match blob {
+            Some((bx, half_angle)) if theta.abs() < half_angle => bx / theta.cos(),
+            _ => f64::INFINITY,
+        };
+        let r = wall.min(blob_r);
+        if r.is_finite() { Some(r) } else { None }
+    })
+}
+
+struct Outcome {
+    objects: usize,
+    kind: ProposalKind,
+    verdict: TrajectoryVerdict,
+    min_y: f64,
+    vmax: f64,
+}
+
+/// One pass of the full stack: Taj perception → Mick intent → Occy plan → KIRRA verdict.
+fn run_stack(
+    scan: &LaserScan,
+    extent_m: f64,
+    extra_objects: &[PerceivedObject],
+    ego: Pose,
+    intent: &MickIntent,
+    goal: Pose,
+    posture: FleetPosture,
+) -> Outcome {
+    // 1) Taj — scan → corridor + objects. The corridor must extend past the plan's footprint
+    //    horizon, so the forward extent scales with how far ahead the goal sits.
+    let taj = TajPhaseA::new(TajConfig { forward_extent_m: extent_m, ..Default::default() });
+    let mut perception = taj.process(scan, 2);
+    perception.objects.extend_from_slice(extra_objects);
+
+    // 2+3) Mick's intent + Occy grounds it against Taj's perception.
+    let world = PlanInput {
+        ego: EgoState { pose: ego, linear_x_mps: 2.0, yaw_rate_rads: 0.0, stamp_ms: 0 },
+        goal: Goal { target: goal },
+        map: &perception.corridor,
+        objects: &perception.objects,
+        controls: &[], lane_boundaries: &[], motion: &[], predicted_paths: &[],
+        cedes_to_ego_ids: &[], lane_change_to_m: None, no_overtake_ids: &[], drivable: None,
+        posture: posture.clone(), target_speed_mps: None,
+        request_overtake: false, request_pull_over: false, lane_graph: None, signal_states: &[],
+    };
+    let mut occy = GeometricPlanner::new(GeometricPlannerConfig { cruise_speed_mps: 4.0, ..Default::default() });
+    let plan = plan_for_intent(&mut occy, intent, &world);
+
+    // 4) KIRRA — the sole safety authority bounds Occy's proposal.
+    let verdict = validate_trajectory_slow(&plan.trajectory, &perception.corridor, &perception.objects, &VehicleConfig::default_urban(), None, posture);
+
+    Outcome {
+        objects: perception.objects.len(),
+        kind: plan.kind,
+        verdict,
+        min_y: plan.trajectory.iter().map(|p| p.pose.y_m).fold(0.0_f64, f64::min),
+        vmax: plan.trajectory.iter().map(|p| p.velocity_mps).fold(0.0_f64, f64::max),
+    }
+}
+
+/// Mick: the brain authors a TYPED intent as JSON, parsed fail-closed. (Swap the string
+/// for `kirra-mick`'s Ollama `ModelClient` output on the Orin — nothing downstream changes.)
+fn mick_goto(x_m: f64, y_m: f64) -> MickIntent {
+    let json = format!(r#"{{"intent":"go_to","x_m":{x_m:.1},"y_m":{y_m:.1}}}"#);
+    MickIntent::from_llm_json(&json).expect("Mick parses a well-formed go_to intent")
+}
+
+fn main() {
+    println!("Taj(perception) → Mick(intent) → Occy(doer) → KIRRA(checker) — on-Orin stack (ADR-0014), headless\n");
+    println!("  {:<34} {:>5}  {:<9} {:<12} {:>6}  {:<8}", "scenario", "objs", "occy", "kirra", "min_y", "result");
+    println!("  {}", "-".repeat(86));
+
+    // 1) Clear corridor — Occy proposes motion, KIRRA admits.
+    let s = corridor_scan(5.0, None);
+    let o = run_stack(&s, 20.0, &[], Pose { x_m: 2.0, y_m: 0.0, heading_rad: 0.0 }, &mick_goto(6.0, 0.0), Pose { x_m: 6.0, y_m: 0.0, heading_rad: 0.0 }, FleetPosture::Nominal);
+    report("clear corridor", &o, "drives (KIRRA admits)");
+
+    // 2) Stopped car dead ahead — Occy brakes to a controlled stop behind it; KIRRA ADMITS
+    //    that safe same-lane stop (the §4 RSS-conjunction admits a halt behind a stopped lead).
+    let s = corridor_scan(5.0, Some((4.0, 0.12)));
+    let o = run_stack(&s, 20.0, &[], Pose { x_m: 2.0, y_m: 0.0, heading_rad: 0.0 }, &mick_goto(6.0, 0.0), Pose { x_m: 6.0, y_m: 0.0, heading_rad: 0.0 }, FleetPosture::Nominal);
+    report("stopped car ahead", &o, "controlled stop behind it (admitted)");
+
+    // 3) Off-centre obstacle in a wide corridor — Occy routes AROUND it (path offsets to
+    //    min_y ≤ -1), KIRRA admits the offset pass.
+    let s = corridor_scan(5.0, None);
+    let off_centre = [PerceivedObject { id: 99, pos: Point { x_m: 20.0, y_m: 3.0 }, velocity_mps: 0.0, heading_rad: 0.0, vel: Point { x_m: 0.0, y_m: 0.0 } }];
+    let o = run_stack(&s, 40.0, &off_centre, Pose { x_m: 8.0, y_m: 0.0, heading_rad: 0.0 }, &mick_goto(30.0, 0.0), Pose { x_m: 30.0, y_m: 0.0, heading_rad: 0.0 }, FleetPosture::Nominal);
+    report("off-centre obstacle, wide road", &o, "routes around (admitted)");
+
+    // 4) LockedOut posture — the fault flows through the whole stack: Occy may only propose
+    //    safe-stop, and KIRRA refuses all motion. Fail-closed regardless of what Occy wants.
+    let s = corridor_scan(5.0, None);
+    let o = run_stack(&s, 20.0, &[], Pose { x_m: 2.0, y_m: 0.0, heading_rad: 0.0 }, &mick_goto(6.0, 0.0), Pose { x_m: 6.0, y_m: 0.0, heading_rad: 0.0 }, FleetPosture::LockedOut);
+    report("LockedOut posture", &o, "KIRRA refuses all motion (MRC)");
+
+    println!("\n  All four components ran in one aarch64-native process — no GPU, no CARLA, no ROS.");
+    println!("  Taj produced the corridor+objects; Mick the intent; Occy proposed; KIRRA disposed.");
+    println!("  Across every regime Occy only PROPOSES; KIRRA is the sole authority that admits or");
+    println!("  refuses. This is exactly the System-2 stack that runs on the Orin NX 16GB (ADR-0014).");
+}
+
+fn report(name: &str, o: &Outcome, result: &str) {
+    println!(
+        "  {:<34} {:>5}  {:<9} {:<12} {:>6.2}  {}",
+        name, o.objects, format!("{:?}", o.kind), format!("{:?}", o.verdict), o.min_y, result,
+    );
+    let _ = o.vmax; // vmax available for richer scorecards; not shown in this row
+}

--- a/crates/kirra-mick/examples/taj_service.rs
+++ b/crates/kirra-mick/examples/taj_service.rs
@@ -58,6 +58,9 @@ fn default_lane_half() -> f64 { 0.6 }
 fn default_floor() -> f32 { 0.5 }
 
 #[derive(Serialize)]
+struct ObjOut { id: u64, x: f64, y: f64, vx: f64, vy: f64 }
+
+#[derive(Serialize)]
 struct PerceptionResponse {
     healthy: bool,
     confidence: f32,
@@ -66,6 +69,12 @@ struct PerceptionResponse {
     nearest_object_m: Option<f64>,
     object_count: usize,
     speed_cap_mps: f64,
+    // The corridor geometry + objects, in the SAME shapes the Occy planner endpoint
+    // (`planner_service` POST /plan) consumes, so the doer bridge can pass them straight
+    // through: left/right boundary polylines as [[x,y],..] and objects as {id,x,y,vx,vy}.
+    left: Vec<[f64; 2]>,
+    right: Vec<[f64; 2]>,
+    objects: Vec<ObjOut>,
 }
 
 /// The corridor's straight-ahead reach: the smaller of the two boundary polylines'
@@ -117,6 +126,17 @@ fn handle_perception(req: &PerceptionRequest) -> PerceptionResponse {
         0.0
     };
 
+    let to_poly = |pts: &[kirra_core::corridor::Point]| -> Vec<[f64; 2]> {
+        pts.iter().map(|p| [p.x_m, p.y_m]).collect()
+    };
+    let left = to_poly(perception.corridor.left_boundary());
+    let right = to_poly(perception.corridor.right_boundary());
+    let objects = perception
+        .objects
+        .iter()
+        .map(|o| ObjOut { id: o.id, x: o.pos.x_m, y: o.pos.y_m, vx: o.vel.x_m, vy: o.vel.y_m })
+        .collect();
+
     PerceptionResponse {
         healthy,
         confidence,
@@ -125,6 +145,9 @@ fn handle_perception(req: &PerceptionRequest) -> PerceptionResponse {
         nearest_object_m,
         object_count: perception.objects.len(),
         speed_cap_mps,
+        left,
+        right,
+        objects,
     }
 }
 

--- a/crates/kirra-mick/examples/taj_service.rs
+++ b/crates/kirra-mick/examples/taj_service.rs
@@ -1,0 +1,183 @@
+//! **A tiny HTTP perception sidecar wrapping the REAL Taj (ADR-0015 Phase A).** Lets the
+//! Python ROS 2 `cmd_vel` path derive a perception speed cap from raw lidar without
+//! reimplementing Taj: POST a `LaserScan`, get back the geometric corridor's health plus an
+//! **assured-clear-distance (ACD) speed cap** — the speed from which the robot can still stop
+//! within the clear distance ahead (RSS Rule 4 / the ADR-0014 "lidar safety buffer").
+//!
+//! It is a perception PRODUCER, not the safety authority — Taj tightens the envelope, the
+//! KIRRA governor still bounds the result. The cap composes BEFORE the governor on the
+//! cmd_vel path (the doer's proposal is derated; the governor disposes). A hand-rolled
+//! `std::net` HTTP/1.1 server keeps it dependency-free, mirroring `planner_service`.
+//!
+//!   cargo run -p kirra-mick --example taj_service          # listens on 127.0.0.1:8101
+//!
+//!   POST /perception  {"angle_min_rad":..,"angle_increment_rad":..,"range_min_m":..,
+//!                      "range_max_m":..,"ranges":[..],"stamp_ms":..,
+//!                      "forward_extent_m":20.0,        # optional Taj horizon
+//!                      "decel_mps2":1.5,"margin_m":0.4,"lane_half_m":0.6,  # optional ACD params
+//!                      "confidence_floor":0.5}         # optional health floor
+//!     → {"healthy":true,"confidence":0.95,"age_ms":0,"clear_distance_m":..,
+//!        "nearest_object_m":..,"object_count":..,"speed_cap_mps":..}
+//!   GET /health  → {"status":"ok"}
+//!
+//! Fail-closed: perception below the confidence floor → `healthy:false` and `speed_cap_mps:0.0`
+//! (the MRC floor — the consumer holds). An empty / all-no-return scan reads as an unhealthy
+//! corridor, so the cap is 0, never an unbounded pass.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+
+use kirra_core::corridor::CorridorSource;
+use kirra_taj::{LaserScan, TajConfig, TajPhaseA};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct PerceptionRequest {
+    angle_min_rad: f64,
+    angle_increment_rad: f64,
+    range_min_m: f64,
+    range_max_m: f64,
+    ranges: Vec<f32>,
+    #[serde(default)]
+    stamp_ms: u64,
+    #[serde(default = "default_extent")]
+    forward_extent_m: f64,
+    #[serde(default = "default_decel")]
+    decel_mps2: f64,
+    #[serde(default = "default_margin")]
+    margin_m: f64,
+    #[serde(default = "default_lane_half")]
+    lane_half_m: f64,
+    #[serde(default = "default_floor")]
+    confidence_floor: f32,
+}
+fn default_extent() -> f64 { 20.0 }
+fn default_decel() -> f64 { 1.5 }
+fn default_margin() -> f64 { 0.4 }
+fn default_lane_half() -> f64 { 0.6 }
+fn default_floor() -> f32 { 0.5 }
+
+#[derive(Serialize)]
+struct PerceptionResponse {
+    healthy: bool,
+    confidence: f32,
+    age_ms: u64,
+    clear_distance_m: f64,
+    nearest_object_m: Option<f64>,
+    object_count: usize,
+    speed_cap_mps: f64,
+}
+
+/// The corridor's straight-ahead reach: the smaller of the two boundary polylines'
+/// furthest forward point. Taj clips this at a dead-ahead obstacle, so it already
+/// encodes the clear distance for the centre of the lane.
+fn corridor_reach(corr: &impl CorridorSource) -> f64 {
+    let far = |pts: &[kirra_core::corridor::Point]| pts.iter().map(|p| p.x_m).fold(0.0_f64, f64::max);
+    far(corr.left_boundary()).min(far(corr.right_boundary()))
+}
+
+fn handle_perception(req: &PerceptionRequest) -> PerceptionResponse {
+    let scan = LaserScan {
+        angle_min_rad: req.angle_min_rad,
+        angle_increment_rad: req.angle_increment_rad,
+        range_min_m: req.range_min_m,
+        range_max_m: req.range_max_m,
+        ranges: req.ranges.clone(),
+        stamp_ms: req.stamp_ms,
+    };
+    // Process at the scan's own stamp → age 0; wall-clock staleness is the consumer's job
+    // (the ROS node times the cap topic), keeping this service stateless.
+    let taj = TajPhaseA::new(TajConfig { forward_extent_m: req.forward_extent_m, ..Default::default() });
+    let perception = taj.process(&scan, req.stamp_ms);
+
+    let confidence = perception.corridor.confidence();
+    let age_ms = perception.corridor.age_ms();
+    let healthy = confidence >= req.confidence_floor;
+
+    // The nearest IN-LANE object (|y| within half a lane), as a discrete clear-distance
+    // bound that complements the corridor reach (a Phase-B object need not clip the corridor).
+    let nearest_object_m = perception
+        .objects
+        .iter()
+        .filter(|o| o.pos.y_m.abs() <= req.lane_half_m && o.pos.x_m > 0.0)
+        .map(|o| o.pos.x_m)
+        .fold(f64::INFINITY, f64::min);
+    let nearest_object_m = nearest_object_m.is_finite().then_some(nearest_object_m);
+
+    // Clear distance = the tighter of the corridor reach and the nearest in-lane object.
+    let clear = corridor_reach(&perception.corridor)
+        .min(nearest_object_m.unwrap_or(f64::INFINITY))
+        .max(0.0);
+
+    // ACD cap: the speed from which a `decel_mps2` brake still stops within (clear - margin).
+    // Unhealthy perception → 0.0 (MRC floor): never trust an empty/low-confidence corridor.
+    let speed_cap_mps = if healthy {
+        (2.0 * req.decel_mps2 * (clear - req.margin_m).max(0.0)).sqrt()
+    } else {
+        0.0
+    };
+
+    PerceptionResponse {
+        healthy,
+        confidence,
+        age_ms,
+        clear_distance_m: clear,
+        nearest_object_m,
+        object_count: perception.objects.len(),
+        speed_cap_mps,
+    }
+}
+
+fn respond(stream: &mut TcpStream, status: &str, body: &str) {
+    let msg = format!("HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len());
+    let _ = stream.write_all(msg.as_bytes());
+}
+
+fn serve(mut stream: TcpStream) {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).is_err() { return; }
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).is_err() || line == "\r\n" || line.is_empty() { break; }
+        if let Some(v) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            content_length = v.trim().parse().unwrap_or(0);
+        }
+    }
+    let mut parts = request_line.split_whitespace();
+    let (method, path) = (parts.next().unwrap_or(""), parts.next().unwrap_or(""));
+
+    if method == "GET" && path == "/health" {
+        respond(&mut stream, "200 OK", "{\"status\":\"ok\"}");
+        return;
+    }
+    if method == "POST" && path == "/perception" {
+        let mut body = vec![0u8; content_length];
+        if reader.read_exact(&mut body).is_err() {
+            respond(&mut stream, "400 Bad Request", "{\"error\":\"short body\"}");
+            return;
+        }
+        match serde_json::from_slice::<PerceptionRequest>(&body) {
+            Ok(req) => {
+                let resp = handle_perception(&req);
+                respond(&mut stream, "200 OK", &serde_json::to_string(&resp).unwrap());
+            }
+            Err(e) => respond(&mut stream, "400 Bad Request", &format!("{{\"error\":\"{e}\"}}")),
+        }
+        return;
+    }
+    respond(&mut stream, "404 Not Found", "{\"error\":\"unknown route\"}");
+}
+
+fn main() {
+    let addr = std::env::var("KIRRA_TAJ_ADDR").unwrap_or_else(|_| "127.0.0.1:8101".to_string());
+    let listener = TcpListener::bind(&addr).unwrap_or_else(|e| { eprintln!("taj_service: bind {addr}: {e}"); std::process::exit(1); });
+    println!("Taj perception service on http://{addr}  (POST /perception, GET /health)");
+    for stream in listener.incoming() {
+        match stream {
+            Ok(s) => serve(s),
+            Err(e) => eprintln!("taj_service: accept error: {e}"),
+        }
+    }
+}

--- a/crates/kirra-planner/src/behavior.rs
+++ b/crates/kirra-planner/src/behavior.rs
@@ -205,6 +205,89 @@ pub fn interactive_proceed(conflicts: &[InteractiveConflict], critical_gap_s: f6
     conflicts.iter().all(|c| agent_time_to_conflict(c, reaccel) > critical_gap_s)
 }
 
+// ===========================================================================
+// Sidewalk-courier behavior primitives (ADR-0027): yield to pedestrians, and
+// cross a road at a crosswalk only when clear. The sidewalk ODD's defining
+// behaviors — give way to people, creep, wait at the curb — not road maneuvers.
+// ===========================================================================
+
+/// Lateral half-width (m) of the courier's "personal-space" band around its path: a VRU within
+/// this of the path centerline is treated as in the way and triggers a yield. Wider than the
+/// footprint on purpose — give people room.
+pub const DEFAULT_VRU_YIELD_BAND_HALF_WIDTH_M: f64 = 0.8;
+
+/// Standoff (m): the courier comes to rest this far BEFORE the VRU it yields to, never
+/// bumper-to-toe.
+pub const DEFAULT_VRU_YIELD_STANDOFF_M: f64 = 1.0;
+
+/// One perceived pedestrian / VRU relative to the ego path: longitudinal distance ahead and
+/// lateral offset from the path centerline (both m, ego frame; `ahead_m > 0` = in front).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VruApproach {
+    pub ahead_m: f64,
+    pub lateral_offset_m: f64,
+}
+
+/// **Yield to a pedestrian (give way).** The sidewalk courier's defining behavior: slow so it can
+/// stop a `standoff_m` before the nearest VRU in its personal-space band, and HOLD at zero while
+/// one is within the standoff — resuming when clear. Returns the speed cap (m/s), or `None` when
+/// no VRU is in the band (no yield needed). The cap reuses the assured-clear-distance bound over
+/// the gap to the standoff, so a VRU within the standoff → `Some(0.0)` (stop and give way).
+///
+/// Derate-only / fail-closed: it can only LOWER the speed; it composes with the other speed caps
+/// (take the lowest). A non-finite / behind / out-of-band VRU is excluded (not a conflict); KIRRA's
+/// containment + impact-energy bound independently backstop a misjudged yield.
+// SAFETY: SG1 | REQ: sidewalk-yield-to-vru-speed-cap | TEST: no_vru_in_band_means_no_yield_cap,a_vru_ahead_caps_speed_to_stop_before_the_standoff,a_vru_within_the_standoff_stops_the_courier,an_out_of_band_vru_does_not_trigger_a_yield,the_nearest_in_band_vru_binds_the_yield_cap
+#[must_use]
+pub fn yield_to_vru_speed_cap(
+    vrus: &[VruApproach],
+    band_half_width_m: f64,
+    standoff_m: f64,
+    brake_decel_mps2: f64,
+) -> Option<f64> {
+    let nearest = vrus
+        .iter()
+        .filter(|v| v.ahead_m > 0.0 && v.lateral_offset_m.abs() <= band_half_width_m)
+        .map(|v| v.ahead_m)
+        .fold(f64::INFINITY, f64::min);
+    nearest
+        .is_finite()
+        .then(|| assured_clear_distance_speed_cap((nearest - standoff_m).max(0.0), brake_decel_mps2))
+}
+
+/// Safety margin (s) added to a crosswalk crossing's clear time before the courier commits.
+pub const DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S: f64 = 2.0;
+
+/// The critical gap (s) a slow courier needs to cross a road of width `crossing_width_m` at
+/// `creep_speed_mps`: its own clear time (`width / speed`) plus a margin. A pedestrian-pace robot
+/// needs a LARGER gap than a car — this makes that explicit instead of borrowing the car's ~4 s
+/// turn gap. Fail-safe: a non-positive creep speed clamps to a tiny value → a huge gap → HOLD.
+#[must_use]
+pub fn crosswalk_critical_gap_s(crossing_width_m: f64, creep_speed_mps: f64, margin_s: f64) -> f64 {
+    crossing_width_m.max(0.0) / creep_speed_mps.max(1e-3) + margin_s.max(0.0)
+}
+
+/// **Cross a road at a crosswalk only when clear.** The gate: the courier steps off only if EVERY
+/// conflicting road agent's worst-case time to the crossing exceeds the courier's own clear time
+/// ([`crosswalk_critical_gap_s`]) — the Stackelberg [`interactive_proceed`] model, so a slow /
+/// yielding car is modelled re-accelerating, never trusted to stay slow. Otherwise HOLD at the
+/// curb. Fail-closed (a NaN time ⇒ HOLD); KIRRA's crossing RSS backstops a misjudged step-off.
+// SAFETY: SG5 | REQ: sidewalk-crosswalk-gap-acceptance | TEST: an_empty_crossing_is_clear,an_ample_gap_lets_the_courier_cross,a_tight_gap_holds_at_the_curb,a_wider_road_needs_a_bigger_gap,a_slow_but_close_car_is_not_trusted_at_the_crosswalk
+#[must_use]
+pub fn cross_when_clear(
+    conflicts: &[InteractiveConflict],
+    crossing_width_m: f64,
+    creep_speed_mps: f64,
+    margin_s: f64,
+    reaccel: f64,
+) -> bool {
+    interactive_proceed(
+        conflicts,
+        crosswalk_critical_gap_s(crossing_width_m, creep_speed_mps, margin_s),
+        reaccel,
+    )
+}
+
 /// Tunables for the behavioral layer.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BehaviorConfig {
@@ -592,5 +675,80 @@ mod tests {
     #[test]
     fn a_nonfinite_conflict_fails_closed() {
         assert!(!interactive_proceed(&[conflict(f64::NAN, 4.0)], GAP, A));
+    }
+
+    // --- sidewalk-courier primitives (ADR-0027) -----------------------------
+
+    const BAND: f64 = DEFAULT_VRU_YIELD_BAND_HALF_WIDTH_M; // 0.8
+    const STANDOFF: f64 = DEFAULT_VRU_YIELD_STANDOFF_M;    // 1.0
+    const DECEL: f64 = 1.0;
+
+    fn vru(ahead_m: f64, lateral_offset_m: f64) -> VruApproach {
+        VruApproach { ahead_m, lateral_offset_m }
+    }
+
+    #[test]
+    fn no_vru_in_band_means_no_yield_cap() {
+        assert_eq!(yield_to_vru_speed_cap(&[], BAND, STANDOFF, DECEL), None);
+    }
+
+    #[test]
+    fn a_vru_ahead_caps_speed_to_stop_before_the_standoff() {
+        // A pedestrian 4 m ahead, in band → a positive cap (= ACD over 4 - 1 = 3 m), below cruise.
+        let cap = yield_to_vru_speed_cap(&[vru(4.0, 0.0)], BAND, STANDOFF, DECEL).unwrap();
+        assert!(cap > 0.0 && cap < 3.0, "expected a finite creep cap, got {cap}");
+    }
+
+    #[test]
+    fn a_vru_within_the_standoff_stops_the_courier() {
+        // A pedestrian inside the standoff → stop and give way (cap 0).
+        assert_eq!(yield_to_vru_speed_cap(&[vru(0.6, 0.0)], BAND, STANDOFF, DECEL), Some(0.0));
+    }
+
+    #[test]
+    fn an_out_of_band_vru_does_not_trigger_a_yield() {
+        // A pedestrian off to the side (beyond the personal-space band) → no yield cap.
+        assert_eq!(yield_to_vru_speed_cap(&[vru(3.0, 1.5)], BAND, STANDOFF, DECEL), None);
+        // Behind the courier → not a conflict.
+        assert_eq!(yield_to_vru_speed_cap(&[vru(-2.0, 0.0)], BAND, STANDOFF, DECEL), None);
+    }
+
+    #[test]
+    fn the_nearest_in_band_vru_binds_the_yield_cap() {
+        let far = yield_to_vru_speed_cap(&[vru(6.0, 0.0)], BAND, STANDOFF, DECEL).unwrap();
+        let near = yield_to_vru_speed_cap(&[vru(6.0, 0.0), vru(2.0, 0.3)], BAND, STANDOFF, DECEL).unwrap();
+        assert!(near < far, "the nearer pedestrian must bind the lower cap ({near} < {far})");
+    }
+
+    #[test]
+    fn an_empty_crossing_is_clear() {
+        assert!(cross_when_clear(&[], 6.0, 1.0, DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S, A));
+    }
+
+    #[test]
+    fn an_ample_gap_lets_the_courier_cross() {
+        // A car far away (40 m at 4 m/s = 10 s) vs a 6 m road at 1 m/s (gap ≈ 8 s) → cross.
+        assert!(cross_when_clear(&[conflict(40.0, 4.0)], 6.0, 1.0, DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S, A));
+    }
+
+    #[test]
+    fn a_tight_gap_holds_at_the_curb() {
+        // A car 12 m at 4 m/s = 3 s vs the ~8 s the courier needs → HOLD.
+        assert!(!cross_when_clear(&[conflict(12.0, 4.0)], 6.0, 1.0, DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S, A));
+    }
+
+    #[test]
+    fn a_wider_road_needs_a_bigger_gap() {
+        // Same car gap (a committed agent ~6.25 s away): clears a narrow road, holds for a wide one.
+        let cars = [conflict(25.0, 4.0)];
+        assert!(cross_when_clear(&cars, 2.0, 1.0, DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S, A));   // 2 m → ~4 s needed
+        assert!(!cross_when_clear(&cars, 8.0, 1.0, DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S, A));  // 8 m → ~10 s needed
+    }
+
+    #[test]
+    fn a_slow_but_close_car_is_not_trusted_at_the_crosswalk() {
+        // A car crawling at 0.5 m/s just 8 m away reads as 16 s by d/v, but the interaction model
+        // worst-cases its re-acceleration → it is NOT trusted; the courier holds.
+        assert!(!cross_when_clear(&[conflict(8.0, 0.5)], 6.0, 1.0, DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S, A));
     }
 }

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -596,6 +596,45 @@ impl Default for GeometricPlannerConfig {
     }
 }
 
+impl GeometricPlannerConfig {
+    /// **Sidewalk-courier preset** (ADR-0027) — the DOER's robot-scale geometry. The default is
+    /// car-scale: it stops 5 m behind an in-path object and demands 4.5 m of lateral room to route
+    /// around one, which makes a small robot creep nowhere and refuse passes a robot-sized corridor
+    /// could admit. This preset scales those to a courier: stop ~1 m short (the Yield standoff),
+    /// route around with the courier's ~0.7 m clearance (just over the courier RSS band so a
+    /// cleared object is still RSS-filtered), and a small footprint so an offset path fits a narrow
+    /// corridor.
+    ///
+    /// This is the **untrusted DOER side only** — it changes only what Occy *proposes*; KIRRA's
+    /// checker (the courier `VehicleConfig`) still bounds every plan, so a too-aggressive number
+    /// here costs availability, never safety. `cruise_speed_mps` is overridden by the caller.
+    /// `predictive_yield_gap_m` deliberately stays at the default (the checker's longitudinal
+    /// conflict window) so a predicted-CROSSING yield remains checker-admissible.
+    #[must_use]
+    pub fn courier() -> Self {
+        Self {
+            cruise_speed_mps: 1.5,
+            max_accel_mps2: 1.0,
+            max_decel_mps2: 1.5,
+            object_lane_tolerance_m: 0.6,
+            object_stop_gap_m: 1.0,        // stop ~1 m short (the Yield standoff), not 5 m
+            object_approach_speed_mps: 1.0,
+            lateral_clearance_target_m: 0.7, // just over the courier RSS band (0.6) → cleared object RSS-filtered
+            lateral_offset_max_m: 1.0,
+            vehicle_half_width_m: 0.2,
+            containment_margin_m: 0.2,
+            vehicle_length_m: 0.4,
+            lateral_pass_speed_mps: 1.0,
+            lead_lateral_band_m: 0.6,
+            lead_following_gap_m: 1.5,
+            prediction_lane_half_m: 0.6,
+            overtake_offset_max_m: 1.5,
+            wheelbase_m: 0.2,
+            ..Self::default()
+        }
+    }
+}
+
 /// A deterministic geometric go-to-goal planner: it follows the drivable
 /// **corridor centerline** toward the goal with a trapezoidal speed profile that
 /// tapers to a controlled stop at the goal.
@@ -2842,6 +2881,37 @@ mod tests {
         assert_eq!(out.kind, ProposalKind::Motion, "routes around, does not stop");
         let min_y = out.trajectory.iter().map(|t| t.pose.y_m).fold(0.0, f64::min);
         assert!(min_y <= -1.0, "path offsets away from the object, got min_y {min_y}");
+    }
+
+    #[test]
+    fn courier_preset_stops_closer_to_an_in_path_object_than_the_car_default() {
+        // The doer-side courier tuning (ADR-0027 / step B): the car default stops 5 m behind an
+        // in-path object; the courier stops ~1 m short (the Yield standoff), so it advances much
+        // closer before holding — and KIRRA (courier profile) still admits the closer stop.
+        // Object close enough that BOTH reach their stop point within one planning horizon, so the
+        // comparison isolates the stop GAP (not the courier's lower cruise speed).
+        let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+        let objs = [obj_at(10.0, 0.0)]; // dead-centre object 8 m ahead of the ego
+
+        let car = GeometricPlanner::default().plan(&input_with_objects(&corridor, 2.0, 30.0, &objs));
+        let courier = GeometricPlanner::new(GeometricPlannerConfig::courier())
+            .plan(&input_with_objects(&corridor, 2.0, 30.0, &objs));
+
+        let reach = |o: &PlanOutput| o.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max);
+        assert_eq!(car.kind, ProposalKind::Motion);
+        assert_eq!(courier.kind, ProposalKind::Motion);
+        // Car holds ~5 m short; the courier advances notably closer in a single plan (its full
+        // ~1 m-short stop point is reached over successive replans — receding horizon — and its
+        // slow creep approach means one horizon doesn't cover the whole way).
+        assert!(reach(&courier) > reach(&car) + 1.0,
+            "courier advances closer (1 m gap vs 5 m): courier {:.1} m vs car {:.1} m", reach(&courier), reach(&car));
+
+        // The closer courier stop is still admitted by the courier checker.
+        let verdict = validate_trajectory_slow(
+            &courier.trajectory, &corridor, &objs, &VehicleConfig::courier(), None, FleetPosture::Nominal,
+        );
+        assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+            "courier checker admits the closer stop, got {verdict:?}");
     }
 
     #[test]

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -17,9 +17,17 @@
 use serde::{Deserialize, Serialize};
 
 use crate::behavior::{
-    interactive_proceed, InteractiveConflict, SignalState, TrafficControl, DEFAULT_AGENT_REACCEL_MPS2,
-    DEFAULT_TURN_CRITICAL_GAP_S,
+    cross_when_clear, interactive_proceed, yield_to_vru_speed_cap, InteractiveConflict, SignalState,
+    TrafficControl, VruApproach, DEFAULT_AGENT_REACCEL_MPS2, DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S,
+    DEFAULT_TURN_CRITICAL_GAP_S, DEFAULT_VRU_YIELD_BAND_HALF_WIDTH_M, DEFAULT_VRU_YIELD_STANDOFF_M,
 };
+
+/// Comfortable courier brake (m/s²) used to derive the yield speed cap — gentle so the cap is
+/// conservative w.r.t. the checker's brake, keeping the yielded plan checker-admissible.
+const COURIER_YIELD_BRAKE_MPS2: f64 = 1.5;
+/// Courier creep / crossing speed (m/s) — pedestrian pace. The planner clamps and KIRRA caps
+/// again, so this only ever slows the motion.
+const COURIER_CREEP_MPS: f64 = 1.0;
 use crate::{
     FleetPosture, Goal, Lane, LaneControl, LaneGraph, PlanInput, PlanOutput, Planner, Pose,
     PredictedPath, MAX_ROUTE_LANES,
@@ -115,6 +123,18 @@ pub enum MickIntent {
     ///
     /// [`GoTo`]: MickIntent::GoTo
     RouteTo { x_m: f64, y_m: f64 },
+    /// **Sidewalk-courier: yield to pedestrians while following the goal** (ADR-0027). Drives
+    /// toward `{x_m, y_m}` but caps speed to give way to the nearest VRU in its personal-space
+    /// band — creeping to a stop a standoff before a pedestrian and HOLDing while one is in the
+    /// way, then resuming when clear ([`behavior::yield_to_vru_speed_cap`]). The defining
+    /// sidewalk behavior; KIRRA's containment + impact-energy bound backstop it.
+    Yield { x_m: f64, y_m: f64 },
+    /// **Sidewalk-courier: cross a road at a crosswalk only when clear** (ADR-0027). Steps off
+    /// toward `{x_m, y_m}` ONLY if every conflicting road agent is far enough that even its
+    /// worst-case re-acceleration cannot reach the crossing before the slow courier clears it
+    /// ([`behavior::cross_when_clear`]); otherwise HOLDs at the curb. KIRRA's crossing RSS
+    /// backstops a misjudged step-off.
+    CrossWhenClear { x_m: f64, y_m: f64 },
 }
 
 /// LLM JSON wire schema (tagged on `"intent"`). Kept separate from [`MickIntent`]
@@ -138,6 +158,10 @@ enum IntentJson {
     TurnAt { direction: String },
     #[serde(rename = "route_to")]
     RouteTo { x_m: f64, y_m: f64 },
+    #[serde(rename = "yield")]
+    Yield { x_m: f64, y_m: f64 },
+    #[serde(rename = "cross_when_clear")]
+    CrossWhenClear { x_m: f64, y_m: f64 },
 }
 
 impl MickIntent {
@@ -173,6 +197,8 @@ impl MickIntent {
                 MickIntent::TurnAt { direction: dir }
             }
             IntentJson::RouteTo { x_m, y_m } => MickIntent::RouteTo { x_m, y_m },
+            IntentJson::Yield { x_m, y_m } => MickIntent::Yield { x_m, y_m },
+            IntentJson::CrossWhenClear { x_m, y_m } => MickIntent::CrossWhenClear { x_m, y_m },
         };
         if !intent.is_finite() {
             return Err("MICK_NONFINITE_INTENT");
@@ -190,6 +216,8 @@ impl MickIntent {
             MickIntent::PullOver => true,
             MickIntent::TurnAt { .. } => true,
             MickIntent::RouteTo { x_m, y_m } => x_m.is_finite() && y_m.is_finite(),
+            MickIntent::Yield { x_m, y_m } => x_m.is_finite() && y_m.is_finite(),
+            MickIntent::CrossWhenClear { x_m, y_m } => x_m.is_finite() && y_m.is_finite(),
         }
     }
 }
@@ -408,7 +436,70 @@ pub fn plan_for_intent(
             };
             plan_along_route(planner, world, graph, ego_lane, &route, goal)
         }
+        MickIntent::Yield { x_m, y_m } => {
+            // Sidewalk yield (ADR-0027): follow the goal but cap speed to give way to the nearest
+            // pedestrian in the courier's path band — creep to a stop a standoff before it, HOLD
+            // while one is in the way, resume when clear. KIRRA's containment + energy bound backstop.
+            if !x_m.is_finite() || !y_m.is_finite() {
+                return PlanOutput::safe_stop(world.ego.pose);
+            }
+            let vrus = vru_approaches(world);
+            let cap = yield_to_vru_speed_cap(
+                &vrus,
+                DEFAULT_VRU_YIELD_BAND_HALF_WIDTH_M,
+                DEFAULT_VRU_YIELD_STANDOFF_M,
+                COURIER_YIELD_BRAKE_MPS2,
+            );
+            let goal = Goal { target: Pose { x_m, y_m, heading_rad: world.goal.target.heading_rad } };
+            match cap {
+                // A pedestrian within the standoff → give way: stop and hold.
+                Some(c) if c <= f64::EPSILON => PlanOutput::safe_stop(world.ego.pose),
+                // A pedestrian ahead → creep toward the goal at the yield cap.
+                Some(c) => planner.plan(&PlanInput { goal, target_speed_mps: Some(c), ..world.clone() }),
+                // No pedestrian in the band → follow the goal (KIRRA + the courier cap still bound it).
+                None => planner.plan(&PlanInput { goal, ..world.clone() }),
+            }
+        }
+        MickIntent::CrossWhenClear { x_m, y_m } => {
+            // Sidewalk crosswalk crossing (ADR-0027): step off toward the far curb ONLY when every
+            // conflicting road agent is far enough that even its worst-case re-acceleration cannot
+            // reach the crossing before the slow courier clears it; else HOLD at the curb.
+            if !x_m.is_finite() || !y_m.is_finite() {
+                return PlanOutput::safe_stop(world.ego.pose);
+            }
+            let crossing = MapPoint { x_m, y_m };
+            let conflicts = turn_interactive_conflicts(world, crossing, world.cedes_to_ego_ids);
+            // The span the courier must clear ≈ ego→far-curb distance; it crosses at creep pace.
+            let width = (x_m - world.ego.pose.x_m).hypot(y_m - world.ego.pose.y_m);
+            if !cross_when_clear(
+                &conflicts,
+                width,
+                COURIER_CREEP_MPS,
+                DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S,
+                DEFAULT_AGENT_REACCEL_MPS2,
+            ) {
+                return PlanOutput::safe_stop(world.ego.pose); // not clear → wait at the curb
+            }
+            let goal = Goal { target: Pose { x_m, y_m, heading_rad: world.goal.target.heading_rad } };
+            planner.plan(&PlanInput { goal, target_speed_mps: Some(COURIER_CREEP_MPS), ..world.clone() })
+        }
     }
+}
+
+/// Pedestrians/VRUs ahead of the ego, in its frame, for the sidewalk yield ([`MickIntent::Yield`]).
+/// Each perceived object is transformed into `(ahead_m, lateral_offset_m)` relative to the ego's
+/// heading; the yield primitive then keeps only those in the personal-space band. On a sidewalk the
+/// courier yields to ANY object ahead — there is no "ignore another lane".
+fn vru_approaches(world: &PlanInput<'_>) -> Vec<VruApproach> {
+    let (sin_h, cos_h) = world.ego.pose.heading_rad.sin_cos();
+    world
+        .objects
+        .iter()
+        .map(|o| {
+            let (dx, dy) = (o.pos.x_m - world.ego.pose.x_m, o.pos.y_m - world.ego.pose.y_m);
+            VruApproach { ahead_m: dx * cos_h + dy * sin_h, lateral_offset_m: -dx * sin_h + dy * cos_h }
+        })
+        .collect()
 }
 
 /// Materialize a lane-id `route` into its drivable corridor and plan along it toward `goal`.
@@ -1100,6 +1191,76 @@ mod tests {
         let max_x = out.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max);
         assert!(max_x > 10.0, "Mick's GoTo drives the ego toward the goal, got {max_x}");
         assert!(admits(&out.trajectory, &corr, &[]), "KIRRA admits the grounded plan");
+    }
+
+    // --- sidewalk-courier intents (ADR-0027) --------------------------------
+
+    fn pedestrian(x: f64, y: f64) -> PerceivedObject {
+        PerceivedObject { id: 7, pos: Point { x_m: x, y_m: y }, velocity_mps: 0.0, heading_rad: 0.0, vel: Point { x_m: 0.0, y_m: 0.0 } }
+    }
+    fn crossing_car(x: f64, y: f64, vx: f64, vy: f64) -> PerceivedObject {
+        PerceivedObject { id: 8, pos: Point { x_m: x, y_m: y }, velocity_mps: vx.hypot(vy), heading_rad: vy.atan2(vx), vel: Point { x_m: vx, y_m: vy } }
+    }
+
+    #[test]
+    fn yield_stops_for_a_pedestrian_within_the_standoff() {
+        // Ego at x=5; a pedestrian 0.5 m ahead (inside the 1.0 m standoff) → give way: stop.
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let objs = [pedestrian(5.5, 0.0)];
+        let w = world(&corr, &objs, &[]);
+        let out = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::Yield { x_m: 40.0, y_m: 0.0 }, &w);
+        assert_eq!(out.kind, ProposalKind::SafeStop, "courier yields (stops) for a pedestrian in the way");
+    }
+
+    #[test]
+    fn yield_drives_toward_the_goal_when_the_path_is_clear() {
+        // No pedestrian in the band → Yield follows the goal (KIRRA + the courier cap still bound it).
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let w = world(&corr, &[], &[]);
+        let out = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::Yield { x_m: 40.0, y_m: 0.0 }, &w);
+        assert_eq!(out.kind, ProposalKind::Motion);
+        assert!(out.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max) > 8.0, "advances toward the goal");
+    }
+
+    #[test]
+    fn yield_with_an_off_band_pedestrian_defers_to_a_plain_goto() {
+        // A pedestrian 2 m to the side (beyond the 0.8 m personal-space band) adds NO yield cap, so
+        // Yield must behave exactly like GoTo (whatever the obstacle-aware planner does with the
+        // side object, Yield does too — the yield primitive contributes nothing here).
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let objs = [pedestrian(8.0, 2.0)];
+        let w = world(&corr, &objs, &[]);
+        let yld = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::Yield { x_m: 40.0, y_m: 0.0 }, &w);
+        let goto = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::GoTo { x_m: 40.0, y_m: 0.0 }, &w);
+        assert_eq!(yld.kind, goto.kind, "an off-band pedestrian: Yield defers to plain GoTo");
+    }
+
+    #[test]
+    fn cross_when_clear_crosses_an_empty_road() {
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let w = world(&corr, &[], &[]);
+        let out = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::CrossWhenClear { x_m: 12.0, y_m: 0.0 }, &w);
+        assert_eq!(out.kind, ProposalKind::Motion, "an empty crosswalk → step off");
+    }
+
+    #[test]
+    fn cross_when_clear_holds_at_the_curb_for_oncoming_traffic() {
+        // A car closing on the crossing point (12,0) from the side at 10 m/s, ~2 s away — far less
+        // than the ~9 s the slow courier needs to clear a 7 m road → HOLD at the curb.
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let objs = [crossing_car(12.0, -20.0, 0.0, 10.0)];
+        let w = world(&corr, &objs, &[]);
+        let out = plan_for_intent(&mut GeometricPlanner::default(), &MickIntent::CrossWhenClear { x_m: 12.0, y_m: 0.0 }, &w);
+        assert_eq!(out.kind, ProposalKind::SafeStop, "a closing car holds the courier at the curb");
+    }
+
+    #[test]
+    fn from_llm_json_round_trips_the_sidewalk_intents() {
+        assert_eq!(MickIntent::from_llm_json(r#"{"intent":"yield","x_m":12.0,"y_m":0.0}"#).unwrap(),
+                   MickIntent::Yield { x_m: 12.0, y_m: 0.0 });
+        assert_eq!(MickIntent::from_llm_json(r#"{"intent":"cross_when_clear","x_m":12.0,"y_m":3.0}"#).unwrap(),
+                   MickIntent::CrossWhenClear { x_m: 12.0, y_m: 3.0 });
+        assert!(MickIntent::from_llm_json(r#"{"intent":"yield","x_m":null,"y_m":0.0}"#).is_err(), "malformed → fail-closed");
     }
 
     #[test]

--- a/crates/kirra-planner/src/mick_capture.rs
+++ b/crates/kirra-planner/src/mick_capture.rs
@@ -97,6 +97,9 @@ impl MickDecisionRecord {
             MickIntent::TurnAt { .. } => ("turn_at", None, None, None, None),
             // The routed destination reuses the goal_x_m/goal_y_m record fields.
             MickIntent::RouteTo { x_m, y_m } => ("route_to", Some(x_m), Some(y_m), None, None),
+            // Sidewalk-courier intents (ADR-0027) — the goal point is the destination/far-curb.
+            MickIntent::Yield { x_m, y_m } => ("yield", Some(x_m), Some(y_m), None, None),
+            MickIntent::CrossWhenClear { x_m, y_m } => ("cross_when_clear", Some(x_m), Some(y_m), None, None),
         };
         let turn_direction = match *intent {
             MickIntent::TurnAt { direction } => Some(direction.as_str()),

--- a/crates/kirra-ros2-adapter/src/config.rs
+++ b/crates/kirra-ros2-adapter/src/config.rs
@@ -126,6 +126,40 @@ impl VehicleConfig {
         }
     }
 
+    /// **Delivery-AV class** (road pod, mid-speed) — the sibling between courier and robotaxi,
+    /// per `docs/CONTRACT_PROFILES.md` Delivery-AV column (footprint 1.1 × 2.9 m, wheelbase
+    /// 1.9 m, max 12 m/s, ODD cap 11 m/s, accel 1.8, brake 4.0, steering 33°). The RSS band
+    /// (2.0 m) sits between the courier's sidewalk lane and the robotaxi's road lane.
+    /// **VALIDATION-PENDING**. Included so the slow-loop class family mirrors the fast-loop one.
+    pub fn delivery_av() -> Self {
+        Self {
+            wheelbase_m:        1.9,
+            track_width_m:      0.9,
+            half_length_m:      1.45,   // → length 2.9 m
+            half_width_m:       0.55,   // → width  1.1 m
+            max_speed_mps:      12.0,
+            max_accel_mps2:     1.8,
+            max_decel_mps2:     4.0,
+            max_steering_rad:   33.0_f64.to_radians(),
+            odd_speed_cap_mps:  Some(11.0),
+            rss_lateral_alignment_tolerance_m: 2.0,
+        }
+    }
+
+    /// **The single slow-loop class selector** — the counterpart of the fast-loop
+    /// `VehicleClass::from_str` + `contract_for` (`src/gateway/contract_profiles.rs`), keyed by
+    /// the same class STRING (the two live in dependency-separated workspaces, so they select by
+    /// name, not a shared import — the CONTRACT_PROFILES.md cited-copy discipline). Unknown /
+    /// absent → `default_urban` (robotaxi): the most conservative footprint, so an unrecognized
+    /// class fails safe (over-contains → holds) rather than under-bounding a vehicle.
+    pub fn for_class(class: &str) -> Self {
+        match class.trim().to_ascii_lowercase().as_str() {
+            "courier" | "robot" | "sidewalk" => Self::courier(),
+            "delivery-av" | "delivery_av" | "deliveryav" => Self::delivery_av(),
+            _ => Self::default_urban(), // robotaxi / unknown → frozen reference (fail-safe)
+        }
+    }
+
     /// Deployment-time check. Logs a WARN if no ODD cap is configured or
     /// if the vehicle physical max sits above the cap by more than its
     /// own value (i.e. the integrator hasn't actually tightened the
@@ -258,6 +292,31 @@ mod tests {
             DEFAULT_RSS_LATERAL_ALIGNMENT_TOLERANCE_M
         );
         assert_eq!(DEFAULT_RSS_LATERAL_ALIGNMENT_TOLERANCE_M, 4.0);
+    }
+
+    #[test]
+    fn for_class_selects_the_sibling_profiles_by_name() {
+        // One selector, keyed by the same class string the fast-loop VehicleClass parses.
+        assert_eq!(VehicleConfig::for_class("courier").rss_lateral_alignment_tolerance_m, 0.6);
+        assert_eq!(VehicleConfig::for_class("sidewalk").max_speed_mps, 3.0);          // courier alias
+        assert_eq!(VehicleConfig::for_class("delivery-av").rss_lateral_alignment_tolerance_m, 2.0);
+        assert_eq!(VehicleConfig::for_class("robotaxi").rss_lateral_alignment_tolerance_m, 4.0);
+        // Unknown / absent → robotaxi (frozen reference), the fail-safe default.
+        assert_eq!(VehicleConfig::for_class("nonsense").half_length_m,
+                   VehicleConfig::default_urban().half_length_m);
+        assert_eq!(VehicleConfig::for_class("  Courier  ").rss_lateral_alignment_tolerance_m, 0.6);
+    }
+
+    #[test]
+    fn slow_loop_class_family_is_ordered_courier_lt_delivery_lt_robotaxi() {
+        // The family is monotone in the dimensions that scale with vehicle size/speed —
+        // the cited-copy mirror of the fast-loop contract family.
+        let (c, d, r) = (VehicleConfig::courier(), VehicleConfig::delivery_av(), VehicleConfig::default_urban());
+        for f in [|v: &VehicleConfig| v.rss_lateral_alignment_tolerance_m,
+                  |v: &VehicleConfig| v.max_speed_mps,
+                  |v: &VehicleConfig| v.half_length_m] {
+            assert!(f(&c) < f(&d) && f(&d) < f(&r), "courier < delivery-av < robotaxi expected");
+        }
     }
 
     #[test]

--- a/crates/kirra-ros2-adapter/src/config.rs
+++ b/crates/kirra-ros2-adapter/src/config.rs
@@ -60,7 +60,21 @@ pub struct VehicleConfig {
     /// [`VehicleConfig::warn_if_missing_odd_cap`] — a deployment that
     /// drops the cap by accident is loud, not silent.
     pub odd_speed_cap_mps: Option<f64>,
+
+    /// **RSS lateral-alignment band** (m): the lateral offset below which an object is
+    /// "in my lane" and so subject to RSS longitudinal evaluation; beyond it, containment
+    /// covers it. This is **per-class** — a lane-width-scale number for a robotaxi (4.0 m),
+    /// but a much tighter band for a small robot (a sidewalk courier's "lane" is ~1 m wide,
+    /// not ~4 m). Making it a config field instead of a global constant is what lets a small
+    /// robot pass an obstacle a robotaxi could not, WITHOUT changing the robotaxi number
+    /// (see `docs/CONTRACT_PROFILES.md`, the sibling rule).
+    pub rss_lateral_alignment_tolerance_m: f64,
 }
+
+/// Robotaxi-class RSS lateral band (m) — the frozen reference value (was the module
+/// constant `RSS_LATERAL_ALIGNMENT_TOLERANCE_M` in `validation.rs`). `default_urban` uses
+/// this verbatim, so the robotaxi/AV path is byte-identical.
+pub const DEFAULT_RSS_LATERAL_ALIGNMENT_TOLERANCE_M: f64 = 4.0;
 
 impl VehicleConfig {
     /// Defaults for an urban mid-size AV. Matches the kernel's
@@ -83,6 +97,32 @@ impl VehicleConfig {
             // 35° steering rack on a 2.8 m wheelbase ≈ 0.6109 rad.
             max_steering_rad:   35.0_f64.to_radians(),
             odd_speed_cap_mps:  Some(URBAN_ODD_SPEED_CAP_MPS),
+            rss_lateral_alignment_tolerance_m: DEFAULT_RSS_LATERAL_ALIGNMENT_TOLERANCE_M,
+        }
+    }
+
+    /// **Courier / small-robot class** (a sibling of [`default_urban`], per
+    /// `docs/CONTRACT_PROFILES.md`). Robot-scale footprint + kinematics + a tight RSS
+    /// lateral band so the slow-loop checker judges a sidewalk/indoor robot, not a 4.8 m
+    /// car. The checker LOGIC is identical to the robotaxi path — only these numbers differ,
+    /// and `default_urban` is untouched, so the AV profile cannot regress.
+    ///
+    /// Numbers track the `docs/CONTRACT_PROFILES.md` Courier column (footprint 0.6 × 0.9 m,
+    /// wheelbase 0.5 m, max 3.0 m/s, ODD cap 2.5 m/s, accel 1.0, brake 3.0, steering 30°) and
+    /// are **VALIDATION-PENDING** — placeholders with a stated basis, not certified values.
+    /// The RSS band (0.6 m) is the courier "lane" half-scale; tune per chassis.
+    pub fn courier() -> Self {
+        Self {
+            wheelbase_m:        0.5,
+            track_width_m:      0.4,
+            half_length_m:      0.45,   // → length 0.9 m
+            half_width_m:       0.3,    // → width  0.6 m
+            max_speed_mps:      3.0,
+            max_accel_mps2:     1.0,
+            max_decel_mps2:     3.0,
+            max_steering_rad:   30.0_f64.to_radians(),
+            odd_speed_cap_mps:  Some(2.5),
+            rss_lateral_alignment_tolerance_m: 0.6,
         }
     }
 
@@ -207,6 +247,31 @@ impl VehicleConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_urban_rss_band_is_the_frozen_robotaxi_value() {
+        // The robotaxi/AV path must be byte-identical: the RSS lateral band stays the
+        // 4.0 m that was the global constant before it became per-class (#1 / the
+        // CONTRACT_PROFILES.md sibling rule — change a number ⇒ change it deliberately).
+        assert_eq!(
+            VehicleConfig::default_urban().rss_lateral_alignment_tolerance_m,
+            DEFAULT_RSS_LATERAL_ALIGNMENT_TOLERANCE_M
+        );
+        assert_eq!(DEFAULT_RSS_LATERAL_ALIGNMENT_TOLERANCE_M, 4.0);
+    }
+
+    #[test]
+    fn courier_is_a_smaller_sibling_not_the_robotaxi() {
+        // The small-robot profile differs ONLY in numbers (tighter band, smaller
+        // footprint, lower speed) — it is a sibling, not a fork of the logic.
+        let robot = VehicleConfig::courier();
+        let car = VehicleConfig::default_urban();
+        assert!(robot.rss_lateral_alignment_tolerance_m < car.rss_lateral_alignment_tolerance_m);
+        assert!(robot.half_length_m < car.half_length_m);
+        assert!(robot.half_width_m < car.half_width_m);
+        assert!(robot.max_speed_mps < car.max_speed_mps);
+        assert_eq!(robot.rss_lateral_alignment_tolerance_m, 0.6);
+    }
 
     #[test]
     fn default_urban_matches_kernel_nominal_geometry() {

--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -54,11 +54,12 @@ const RSS_REACTION_TIME_S: f64 = 0.5;
 /// rejecting a trajectory for float noise / a sub-decimetre overshoot of the cap.
 const OCCLUSION_SPEED_TOL_MPS: f64 = 0.1;
 
-/// Distance below which two objects are considered laterally aligned
-/// (and therefore subject to RSS longitudinal evaluation). Anything
-/// beyond this lateral offset is in another corridor; containment
-/// covers it.
-const RSS_LATERAL_ALIGNMENT_TOLERANCE_M: f64 = 4.0;
+// The RSS lateral-alignment band (distance below which two objects are laterally
+// aligned and so subject to RSS longitudinal evaluation; beyond it, containment covers
+// it) is now a PER-CLASS field on `VehicleConfig`
+// (`rss_lateral_alignment_tolerance_m`), not a global constant — a robotaxi uses a
+// lane-width-scale 4.0 m, a small robot a much tighter band. The robotaxi value lives in
+// `config::DEFAULT_RSS_LATERAL_ALIGNMENT_TOLERANCE_M` (see docs/CONTRACT_PROFILES.md).
 
 /// Object lateral-velocity magnitude (m/s) above which a same-lane object is treated as
 /// **cutting in** (a genuine side-collision risk) rather than a straight-running lead or a
@@ -318,8 +319,8 @@ pub fn validate_trajectory_slow_capped(
                 continue;
             }
             // Lateral filter — object is in a different lane; let
-            // containment cover it.
-            if dy_ego.abs() > RSS_LATERAL_ALIGNMENT_TOLERANCE_M {
+            // containment cover it. Per-class band (robotaxi 4.0 m; robot tighter).
+            if dy_ego.abs() > config.rss_lateral_alignment_tolerance_m {
                 continue;
             }
 
@@ -511,7 +512,7 @@ fn predictive_rss_breach(
             if dx_ego <= 0.0 {
                 continue; // behind the ego at that time
             }
-            if dy_ego.abs() > RSS_LATERAL_ALIGNMENT_TOLERANCE_M {
+            if dy_ego.abs() > config.rss_lateral_alignment_tolerance_m {
                 continue; // predicted to be in another corridor — containment covers it
             }
             if dy_ego.abs() < RSS_LONGITUDINAL_OVERLAP_M {

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -115,6 +115,47 @@ fn test_rss_violation_rejects() {
 }
 
 // ---------------------------------------------------------------------------
+// 3a. Per-class RSS lateral band — a small-robot (courier) profile admits a side
+//     object a robotaxi refuses, WITHOUT changing the robotaxi number (#1 / the
+//     CONTRACT_PROFILES.md sibling rule). The checker LOGIC is identical; only the
+//     `rss_lateral_alignment_tolerance_m` differs between the two profiles.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn courier_admits_a_side_object_a_robotaxi_refuses() {
+    // A stationary object ~1 m ahead and 1.0 m to the SIDE — inside both the robotaxi
+    // 4.0 m RSS lateral band AND the 2.5 m longitudinal-overlap band, so the robotaxi
+    // evaluates it as a near lead → MRC. For the courier (0.6 m band) it is in ANOTHER
+    // lane → filtered → containment covers it → admitted. Same scene, same checker.
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let objects = vec![PerceivedObject {
+        id: 1,
+        pos: Point { x_m: 6.0, y_m: 1.0 },
+        velocity_mps: 0.0,
+        heading_rad: 0.0,
+        vel: Point { x_m: 0.0, y_m: 0.0 },
+    }];
+
+    // Robotaxi (default_urban, band 4.0 m) — REFUSES.
+    let robotaxi = straight_trajectory(5, 10.0, 0.1);
+    let v_taxi = validate_trajectory_slow(
+        &robotaxi, &corridor, &objects,
+        &VehicleConfig::default_urban(), None, FleetPosture::Nominal,
+    );
+    assert_eq!(v_taxi, TrajectoryVerdict::MRCFallback,
+        "robotaxi: a 1 m-ahead object within the 4 m band is RSS-evaluated → MRC; got {v_taxi:?}");
+
+    // Courier (band 0.6 m, robot speed) — ADMITS the SAME scene.
+    let courier = straight_trajectory(5, 2.0, 0.1);
+    let v_courier = validate_trajectory_slow(
+        &courier, &corridor, &objects,
+        &VehicleConfig::courier(), None, FleetPosture::Nominal,
+    );
+    assert!(matches!(v_courier, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "courier: the same object is beyond the 0.6 m band → containment covers it → admitted; got {v_courier:?}");
+}
+
+// ---------------------------------------------------------------------------
 // 3b. Head-on (oncoming) RSS — direction flips the verdict at the same gap
 // ---------------------------------------------------------------------------
 

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,86 @@
+# Kirra on boot — systemd units
+
+Bring the on-box Kirra governor stack up automatically on the Orin (or any
+systemd host): the **verifier** (governance plane, `:8090`), the **Occy planner**
+sidecar (`:8100`), and the **Taj perception** sidecar (`:8101`).
+
+| Unit | What it runs | Port | Secrets |
+|---|---|---|---|
+| `kirra-verifier.service` | `kirra_verifier_service` (fail-closed governor, `Type=notify` + watchdog) | 8090 | yes (env file) |
+| `kirra-planner.service` | `planner_service` (Occy `POST /plan`) | 8100 | no |
+| `kirra-taj.service` | `taj_service` (Taj `POST /perception` — the cmd_vel cap) | 8101 | no |
+| `kirra.target` | groups all three for one-command lifecycle | — | — |
+
+## Install
+
+```bash
+# 1. build the binaries (or run scripts/orin_bringup.sh)
+cargo build --release --bin kirra_verifier_service
+cargo build --release -p kirra-mick --example planner_service --example taj_service
+
+# 2. install + enable on boot (idempotent)
+sudo deploy/systemd/install.sh
+```
+
+`install.sh` creates the `kirra` system user, copies the three binaries to
+`/opt/kirra/`, **generates `/etc/kirra/kirra.env` with strong random secrets** if it
+doesn't exist (it never overwrites an existing one, and no secret is ever committed),
+installs the units + a `PartOf=` drop-in so the target owns the verifier too, and
+`enable --now`s `kirra.target`.
+
+Read the generated admin token (for ROS clients / the console):
+
+```bash
+sudo sed -n 's/^KIRRA_ADMIN_TOKEN=//p' /etc/kirra/kirra.env
+```
+
+## Operate
+
+```bash
+systemctl status kirra.target                 # at-a-glance health of all three
+systemctl restart kirra.target                # bounce the whole stack
+systemctl stop kirra.target                    # take it down (leaves it enabled on boot)
+journalctl -u kirra-verifier -f                # follow the verifier log
+```
+
+## How it stays up (fail-closed)
+
+- The verifier is `Type=notify` with a 10 s **watchdog**: a hung-but-alive process
+  (e.g. a stalled posture engine → stale cache) misses the ping and systemd restarts
+  it — the same direction the in-process gate already fails.
+- The verifier **exits at startup** if `KIRRA_ADMIN_TOKEN` is absent/empty (SG-008).
+  `StartLimitIntervalSec=0` (in `[Unit]`) disables the start-rate limiter, so it keeps
+  retrying and **self-heals** the moment `/etc/kirra/kirra.env` is populated — it never
+  lands in a permanent `failed` state because a secret was briefly missing.
+- The sidecars `Restart=always`. All three are sandboxed (`User=kirra`,
+  `ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`, restricted address families).
+
+## Secrets
+
+`/etc/kirra/kirra.env` (mode 600, owned by `kirra`) is the **only** source of
+`KIRRA_ADMIN_TOKEN` and `KIRRA_SUPERVISOR_RESET_KEY` — no hardcoded fallback
+(INVARIANTS #6/#7). It is generated at install time and never committed; the
+committed `kirra.env.example` is a placeholder template. To rotate, delete the file
+and re-run `install.sh` (or edit it and `systemctl restart kirra.target`).
+
+## Robot / ROS clients
+
+The verifier binds `127.0.0.1:8090`, so the ROS `cmd_vel` interceptor on the same box
+reaches it at `http://localhost:8090`. Pass the token to the launch:
+
+```bash
+export KIRRA_ADMIN_TOKEN=$(sudo sed -n 's/^KIRRA_ADMIN_TOKEN=//p' /etc/kirra/kirra.env)
+ros2 launch kirra_safety kirra_with_robot.launch.py \
+    kirra_token:=$KIRRA_ADMIN_TOKEN use_perception_cap:=true start_sidecars:=false
+```
+
+Use `start_sidecars:=false` (and the Gazebo demo's `start_verifier:=false`) when the
+stack is already running under systemd — otherwise the launch's own sidecars would
+double-bind the ports.
+
+## Uninstall
+
+```bash
+sudo deploy/systemd/uninstall.sh            # remove units + /opt/kirra (keeps secrets + DB)
+sudo deploy/systemd/uninstall.sh --purge    # also remove /etc/kirra and /var/lib/kirra
+```

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Install the Kirra governor stack (verifier + Occy planner + Taj perception) as
+# systemd services that come up on boot. Single-box (the Orin): everything local.
+#
+#   sudo deploy/systemd/install.sh
+#
+# What it does (idempotent):
+#   1. creates the `kirra` system user,
+#   2. copies the three release binaries to /opt/kirra/,
+#   3. generates /etc/kirra/kirra.env with strong RANDOM secrets if absent
+#      (never overwrites an existing one; no secret is ever committed),
+#   4. installs the unit files + a PartOf= drop-in so `kirra.target` owns the
+#      verifier too,
+#   5. enables + starts kirra.target (so the stack boots automatically).
+#
+# Build the binaries first (or run scripts/orin_bringup.sh):
+#   cargo build --release --bin kirra_verifier_service
+#   cargo build --release -p kirra-mick --example planner_service --example taj_service
+set -euo pipefail
+
+[[ $EUID -eq 0 ]] || { echo "error: run as root (sudo deploy/systemd/install.sh)"; exit 1; }
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REL="${KIRRA_RELEASE_DIR:-$REPO/target/release}"
+UNITS="$REPO/deploy/systemd"
+OPT=/opt/kirra
+ENVDIR=/etc/kirra
+ENVFILE="$ENVDIR/kirra.env"
+
+echo "== 1. kirra system user =="
+if id kirra &>/dev/null; then
+  echo "  user 'kirra' exists"
+else
+  useradd --system --no-create-home --shell /usr/sbin/nologin kirra
+  echo "  created system user 'kirra'"
+fi
+
+echo "== 2. binaries -> $OPT =="
+declare -A SRC=(
+  [kirra_verifier_service]="$REL/kirra_verifier_service"
+  [planner_service]="$REL/examples/planner_service"
+  [taj_service]="$REL/examples/taj_service"
+)
+for name in "${!SRC[@]}"; do
+  [[ -x "${SRC[$name]}" ]] || {
+    echo "error: missing ${SRC[$name]} — build it first:"
+    echo "  cargo build --release --bin kirra_verifier_service"
+    echo "  cargo build --release -p kirra-mick --example planner_service --example taj_service"
+    exit 1
+  }
+done
+install -d -m 0755 "$OPT"
+for name in "${!SRC[@]}"; do
+  install -m 0755 "${SRC[$name]}" "$OPT/$name"
+  echo "  installed $OPT/$name"
+done
+
+echo "== 3. secrets -> $ENVFILE =="
+install -d -m 0750 -o kirra -g kirra "$ENVDIR"
+if [[ -f "$ENVFILE" ]]; then
+  echo "  $ENVFILE exists — leaving it untouched (your secrets are preserved)"
+else
+  gen() { LC_ALL=C tr -dc 'a-f0-9' < /dev/urandom | head -c "$1"; }
+  admin="$(gen 64)"          # admin bearer token (64 hex chars)
+  reset="$(gen 48)"          # supervisor reset key (48 bytes, <= 64)
+  umask 077
+  cat > "$ENVFILE" <<EOF
+# /etc/kirra/kirra.env — generated $(date -u +%FT%TZ) by deploy/systemd/install.sh.
+# SECRETS — keep private (mode 600). Regenerate by deleting this file and re-running.
+KIRRA_ADMIN_TOKEN=$admin
+KIRRA_SUPERVISOR_RESET_KEY=$reset
+EOF
+  chown kirra:kirra "$ENVFILE"; chmod 600 "$ENVFILE"
+  echo "  generated $ENVFILE with random secrets"
+  echo "  (read the admin token for clients: sudo sed -n 's/^KIRRA_ADMIN_TOKEN=//p' $ENVFILE)"
+fi
+
+echo "== 4. unit files + verifier PartOf drop-in =="
+install -m 0644 "$UNITS/kirra-verifier.service" /etc/systemd/system/kirra-verifier.service
+install -m 0644 "$UNITS/kirra-planner.service"  /etc/systemd/system/kirra-planner.service
+install -m 0644 "$UNITS/kirra-taj.service"      /etc/systemd/system/kirra-taj.service
+install -m 0644 "$UNITS/kirra.target"           /etc/systemd/system/kirra.target
+# Make kirra.target own the verifier too, without editing the committed unit.
+dropin=/etc/systemd/system/kirra-verifier.service.d
+install -d -m 0755 "$dropin"
+cat > "$dropin/10-kirra-target.conf" <<'EOF'
+[Unit]
+PartOf=kirra.target
+EOF
+echo "  installed 4 units + PartOf drop-in"
+
+echo "== 5. enable + start =="
+systemctl daemon-reload
+systemctl enable kirra.target kirra-verifier.service kirra-planner.service kirra-taj.service >/dev/null
+systemctl restart kirra.target
+echo
+echo "done — the Kirra stack is enabled on boot."
+echo "  status:  systemctl status kirra.target kirra-verifier kirra-planner kirra-taj"
+echo "  logs:    journalctl -u kirra-verifier -f"
+echo "  stack:   verifier :8090  ·  planner :8100  ·  taj :8101"

--- a/deploy/systemd/kirra-planner.service
+++ b/deploy/systemd/kirra-planner.service
@@ -1,0 +1,38 @@
+# deploy/systemd/kirra-planner.service
+#
+# systemd unit for the Occy planner sidecar (the kirra-mick `planner_service`
+# example): a small HTTP endpoint (POST /plan) that grounds a Mick intent with the
+# real planner + checker. It is a DOER-side sidecar — not safety-critical, no
+# secrets, no persistent state — so the sandbox is simpler than the verifier's.
+#
+# Companion to kirra-verifier.service; install/enable via deploy/systemd/install.sh.
+
+[Unit]
+Description=Kirra Occy planner sidecar (POST /plan)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+After=network-online.target
+Wants=network-online.target
+PartOf=kirra.target
+
+[Service]
+Type=simple
+ExecStart=/opt/kirra/planner_service
+Environment=KIRRA_PLANNER_ADDR=127.0.0.1:8100
+# Optional shared config (bind-addr overrides etc.); '-' makes it non-fatal if absent.
+EnvironmentFile=-/etc/kirra/kirra.env
+Restart=always
+RestartSec=3
+# Least privilege.
+User=kirra
+Group=kirra
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/kirra-taj.service
+++ b/deploy/systemd/kirra-taj.service
@@ -1,0 +1,38 @@
+# deploy/systemd/kirra-taj.service
+#
+# systemd unit for the Taj perception sidecar (the kirra-mick `taj_service`
+# example): a small HTTP endpoint (POST /perception) that turns a LaserScan into
+# the geometric corridor + an assured-clear-distance speed cap for the cmd_vel
+# path. Perception PRODUCER, not the safety authority — no secrets, no state.
+#
+# Companion to kirra-verifier.service; install/enable via deploy/systemd/install.sh.
+
+[Unit]
+Description=Kirra Taj perception sidecar (POST /perception — cmd_vel speed cap)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+After=network-online.target
+Wants=network-online.target
+PartOf=kirra.target
+
+[Service]
+Type=simple
+ExecStart=/opt/kirra/taj_service
+Environment=KIRRA_TAJ_ADDR=127.0.0.1:8101
+# Optional shared config (bind-addr overrides etc.); '-' makes it non-fatal if absent.
+EnvironmentFile=-/etc/kirra/kirra.env
+Restart=always
+RestartSec=3
+# Least privilege.
+User=kirra
+Group=kirra
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/kirra-verifier.service
+++ b/deploy/systemd/kirra-verifier.service
@@ -14,6 +14,11 @@ Description=Kirra runtime safety verifier (fail-closed governor)
 Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
 After=network-online.target
 Wants=network-online.target
+# Disable the start-rate limiter so a safety service is ALWAYS brought back: the
+# verifier exits(1) at startup if KIRRA_ADMIN_TOKEN is absent/empty (SG-008), so it
+# must keep retrying and self-heal once /etc/kirra/kirra.env is populated. (This key
+# lives in [Unit], not [Service] — systemd ignores it under [Service].)
+StartLimitIntervalSec=0
 
 [Service]
 Type=notify
@@ -28,11 +33,10 @@ WatchdogSec=10s
 
 # Fail-closed restart: process death is already safe (panic=abort, DDS Volatile
 # durability, HA heartbeat absence within PROMOTION_TIMEOUT_MS); systemd brings
-# it back. A watchdog miss counts as a failure → restart. StartLimitIntervalSec=0
-# disables start-rate limiting so a safety service is always brought back.
+# it back. A watchdog miss counts as a failure → restart. (The start-rate limiter
+# is disabled in the [Unit] section above, so restarts are never given up on.)
 Restart=on-failure
 RestartSec=2s
-StartLimitIntervalSec=0
 
 # Secrets/config (KIRRA_ADMIN_TOKEN, KIRRA_SUPERVISOR_RESET_KEY, KIRRA_DB_PATH,
 # KIRRA_VERIFIER_ADDR, ...) via an operator-provided file. '-' makes it optional.

--- a/deploy/systemd/kirra.env.example
+++ b/deploy/systemd/kirra.env.example
@@ -1,0 +1,31 @@
+# deploy/systemd/kirra.env.example
+#
+# TEMPLATE for /etc/kirra/kirra.env — the EnvironmentFile the Kirra units read.
+# The real file holds SECRETS and must NEVER be committed. Install it at
+# /etc/kirra/kirra.env, owned by the kirra user, mode 600.
+#
+# deploy/systemd/install.sh generates a real one with strong random tokens if it
+# is absent (so you normally never edit this by hand). To create it manually:
+#
+#   sudo install -d -m 0750 -o kirra -g kirra /etc/kirra
+#   sudo install -m 0600 -o kirra -g kirra deploy/systemd/kirra.env.example /etc/kirra/kirra.env
+#   # then fill in strong random values, e.g.:
+#   #   KIRRA_ADMIN_TOKEN=$(tr -dc 'a-f0-9' </dev/urandom | head -c 64)
+#   #   KIRRA_SUPERVISOR_RESET_KEY=$(tr -dc 'a-f0-9' </dev/urandom | head -c 48)
+#
+# INVARIANTS: both come from this file ONLY (no hardcoded fallback). The verifier
+# EXITS at startup if KIRRA_ADMIN_TOKEN is absent/empty (SG-008, fail-closed), so
+# systemd will restart-loop until this file is populated. The reset key must be
+# non-empty and <= 64 bytes.
+
+# Bearer token for admin/mutation routes (REQUIRED, no length limit).
+KIRRA_ADMIN_TOKEN=
+
+# Supervisor reset key (REQUIRED for reset ops; non-empty, <= 64 bytes).
+KIRRA_SUPERVISOR_RESET_KEY=
+
+# --- Optional overrides (the units already set sensible defaults) ---
+# KIRRA_VERIFIER_ADDR=127.0.0.1:8090
+# KIRRA_DB_PATH=/var/lib/kirra/kirra_verifier.sqlite
+# KIRRA_PLANNER_ADDR=127.0.0.1:8100
+# KIRRA_TAJ_ADDR=127.0.0.1:8101

--- a/deploy/systemd/kirra.target
+++ b/deploy/systemd/kirra.target
@@ -1,0 +1,22 @@
+# deploy/systemd/kirra.target
+#
+# A grouping target for the whole on-box Kirra stack: the verifier (governance
+# plane) + the Occy planner + the Taj perception sidecars. `Wants=` pulls all
+# three in; combined with the PartOf= on each service (the verifier gets a
+# PartOf drop-in from install.sh), this gives one-command lifecycle:
+#
+#   systemctl start kirra.target      # bring the whole stack up
+#   systemctl stop kirra.target       # take it all down
+#   systemctl restart kirra.target    # bounce all three
+#   systemctl status kirra.target     # at-a-glance health
+#
+# Enabling it (install.sh does) also brings the stack up on boot.
+
+[Unit]
+Description=Kirra governor stack (verifier + Occy planner + Taj perception)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+Wants=kirra-verifier.service kirra-planner.service kirra-taj.service
+After=network-online.target
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/uninstall.sh
+++ b/deploy/systemd/uninstall.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Remove the Kirra systemd services. Leaves /etc/kirra (your secrets) and
+# /var/lib/kirra (the verifier DB) in place by default — pass --purge to delete them.
+#
+#   sudo deploy/systemd/uninstall.sh [--purge]
+set -euo pipefail
+[[ $EUID -eq 0 ]] || { echo "error: run as root (sudo)"; exit 1; }
+
+PURGE=0
+[[ "${1:-}" == "--purge" ]] && PURGE=1
+
+systemctl disable --now kirra.target kirra-verifier.service kirra-planner.service kirra-taj.service 2>/dev/null || true
+rm -f /etc/systemd/system/kirra-verifier.service \
+      /etc/systemd/system/kirra-planner.service \
+      /etc/systemd/system/kirra-taj.service \
+      /etc/systemd/system/kirra.target
+rm -rf /etc/systemd/system/kirra-verifier.service.d
+rm -rf /opt/kirra
+systemctl daemon-reload
+echo "removed units + /opt/kirra binaries"
+
+if [[ "$PURGE" == "1" ]]; then
+  rm -rf /etc/kirra /var/lib/kirra
+  echo "purged /etc/kirra (secrets) and /var/lib/kirra (DB)"
+else
+  echo "kept /etc/kirra (secrets) and /var/lib/kirra (DB) — pass --purge to remove them"
+fi

--- a/docs/CONTRACT_PROFILES.md
+++ b/docs/CONTRACT_PROFILES.md
@@ -5,7 +5,7 @@
 | Issues | **#312** (per-class profiles), **#313** (VRU-dense courier profile) |
 | Status | **NORMATIVE** for the per-class numbers — both code sides cite this table by parameter id |
 | Req id | **KIRRA-CLASS-PROFILES-001** |
-| Owns | `src/gateway/contract_profiles.rs` (envelope) · `parko-core/src/impact.rs::impact_cfg_for_class` (SG6 threshold) |
+| Owns | `src/gateway/contract_profiles.rs` (envelope) · `parko-core/src/impact.rs::impact_cfg_for_class` (SG6 threshold) · `crates/kirra-ros2-adapter/src/config.rs` (`VehicleConfig::{courier,delivery_av,default_urban,for_class}` — the slow-loop sibling family, incl. `rss_lateral_band`; ADR-0027) |
 
 > **This table is the single source of truth for the per-class numbers.** The two
 > code sides live in **separate workspaces with no dependency edge** (the SDK
@@ -61,6 +61,7 @@ Units: speed/cap m/s; accel/brake/lat m/s²; steering deg; rate deg/s; distances
 | `*.follow` | 2.0 | 3.5 | 2.0 | VALIDATION-PENDING |
 | `*.lat_accel` | 1.5 | 2.5 | 3.5 | VALIDATION-PENDING |
 | `*.wheelbase` | 0.5 | 1.9 | 2.8 | VALIDATION-PENDING |
+| `*.rss_lateral_band` (slow-loop RSS lateral-alignment, ADR-0027) | **0.6** | **2.0** | 4.0 (frozen) | VALIDATION-PENDING / INHERITED-FROZEN |
 | `*.footprint` (w×l, overhangs) | 0.6 × 0.9 (0.2/0.2) | 1.1 × 2.9 (0.5/0.5) | 1.85 × 4.8 (0.9/1.1) | VALIDATION-PENDING |
 | `*.impact_spike` (SG6, parko; **deviation** `\|‖a‖−G\|`, #321) | **2.5** | **8.0** | **22.0** | VALIDATION-PENDING |
 | `*.impact_confirm` (M / N consecutive, #321) | **2 / 3** | **2 / 3** | **1 / 1** | VALIDATION-PENDING |

--- a/docs/adr/0027-sidewalk-courier-odd.md
+++ b/docs/adr/0027-sidewalk-courier-odd.md
@@ -1,0 +1,124 @@
+# ADR-0027: Sidewalk courier ODD — a pedestrian-space class, not a shrunk car
+
+| Field | Value |
+|---|---|
+| Status | **Proposed (design note)** — ratified on merge. |
+| Date | 2026-06-25 |
+| Deciders | Project / safety-case owner |
+| Safety goals | **SG1** (KIRRA bounds the doer — here a *creep + assured-clear-distance* envelope, not RSS car-following); **SG6** (impact energy — the courier's defining bound, `impact_cfg_for_class(Courier)`); **SG2** (drivable-surface containment — stay on the walkable strip) |
+| Cross-refs | `docs/CONTRACT_PROFILES.md` (the Courier column + the new `*.rss_lateral_band` row); `docs/MARKET_AUTONOMOUS_SERVICES.md` §"Sidewalk couriers" (Serve / Coco / Starship); ADR-0014 (Orin NX single-box deployment); #312 (per-class profiles), #313 (VRU-dense courier); `VehicleClass::Courier` (`src/gateway/contract_profiles.rs`, `parko-core/src/impact.rs`); `VehicleConfig::courier()` (`crates/kirra-ros2-adapter/src/config.rs`); the Occy doer bridge (`docs/testing/OCCY_DOER_BRIDGE.md`) |
+
+## Context
+
+A sidewalk delivery robot (Rosmaster-class on a Jetson Orin NX; the commercial analogues are
+Serve Robotics, Coco, Starship) is **not a small car**. Its operational design domain, its
+dominant hazard, and therefore its safety model are different in kind, not degree:
+
+- the dominant hazard is **striking a pedestrian / VRU**, not a vehicle collision at speed;
+- it operates in **pedestrian space** (sidewalks, plazas, campus paths, crosswalks), not road lanes;
+- it moves at **walking-to-jog pace** and must *creep and yield*, not lane-keep and car-follow.
+
+Treating it as a scaled-down robotaxi imports the wrong frame: RSS car-following gaps, lane
+containment, head-on RSS, and junction right-of-way are mostly irrelevant on a sidewalk, while the
+bounds that actually matter — **creep speed, assured-clear-distance, ultra-low impact energy,
+stay-on-the-walkable-surface, yield-to-people** — are under-weighted. The earlier per-class RSS
+band work (#1) made the *mechanism* per-class but framed the win as "drive **past** a side object a
+car stops for" — which is car-think in reverse: a courier near a pedestrian should **creep,
+yield-ready**, not blow past *or* full-stop-and-give-up.
+
+The repo already names this class (`VehicleClass::Courier` = "sidewalk courier — pedestrian-space,
+low-speed", #313), with a fast-loop envelope (`courier_nominal` / `courier_mrc`) and a
+pedestrian-energy SG6 threshold (`impact_cfg_for_class(Courier)`, spike 2.5 vs robotaxi 22). This
+ADR pins the **ODD, the safety model, and the behavior/intent model** so the Courier class rests on
+a written domain rather than ad-hoc numbers.
+
+## Decision
+
+Adopt the **Sidewalk Courier** as a first-class ODD with its own safety and behavior model,
+realized as the existing `VehicleClass::Courier` profile family (sibling to Robotaxi / Delivery-AV;
+the **Robotaxi numbers stay frozen** — ADR/§ CONTRACT_PROFILES sibling rule).
+
+### 1. ODD (where it is allowed to operate)
+
+- **Space:** sidewalks, shared paths, plazas, campus walkways; road only at **marked crosswalks**.
+- **Speed:** creep regime — ODD cap **2.5 m/s** (`courier` `odd_speed_cap_mps`), typically well below
+  it; the *assured-clear-distance* cap (Taj) routinely holds it lower in company.
+- **Agents:** pedestrian-dense (VRU-dense, #313) — people, strollers, dogs, cyclists at low speed.
+- **Conditions:** daylight + fair-weather first; geofenced; a human teleop fallback for edge cases.
+- **Out of ODD → fail to a safe state:** leaving the geofence, losing localization, or a perception
+  fault yields a **controlled stop / hold**, not a degraded crawl into traffic.
+
+### 2. Safety model (the checker bounds, in priority order)
+
+The courier's safety case rests on **low energy + creep + see-before-you-go**, not gap-keeping:
+
+1. **Impact energy (SG6, defining).** Kinetic energy kept so low a contact is non-injurious —
+   `impact_cfg_for_class(Courier)` spike threshold (2.5, VALIDATION-PENDING). This is the bound a
+   sidewalk robot is *certified on*, the way a robotaxi is certified on RSS gaps.
+2. **Creep speed cap.** The Courier ODD speed cap (2.5 m/s) is the absolute ceiling; the doer cruises
+   below it.
+3. **Assured-clear-distance / visibility (SG1, primary derate).** The Taj perception cap — speed
+   bounded by the clear distance ahead (RSS Rule 4) — is the *primary* moment-to-moment bound: the
+   robot **creeps to what it can see** and slows near anything. Already built (the cmd_vel
+   perception cap; `docs/testing/OCCY_DOER_BRIDGE.md`).
+4. **Drivable-surface containment (SG2).** Stay on the walkable strip (Taj corridor); leaving it is
+   refused exactly as a road ego leaving its lane is.
+5. **RSS car-following — DE-EMPHASIZED to a backstop.** The lateral-alignment band is tightened to
+   the courier's ~1 m "lane" (`rss_lateral_band` = 0.6 m), so RSS rarely fires; on a sidewalk the
+   creep cap + energy bound + ACD carry the safety case, and RSS is retained only as a
+   defense-in-depth backstop, never the primary tool. (This corrects the #1 framing.)
+
+The checker **logic** is identical to the robotaxi's — only these numbers differ, and the robotaxi
+numbers are unchanged and frozen-by-test, so the courier profile **cannot regress the AV path**.
+
+### 3. Behavior / intent model (the doer — Mick / Occy)
+
+Sidewalk intents replace road maneuvers. Mick authors, Occy grounds, KIRRA bounds:
+
+| Sidewalk intent | Meaning | (Road analogue it REPLACES) |
+|---|---|---|
+| `FollowPath` | track the walkable corridor at creep | lane-keeping |
+| `Yield` | slow/stop and give way to a person | (none — couriers always yield) |
+| `CrossWhenClear` | wait for a clear gap / signal, then cross a road at a crosswalk | junction right-of-way |
+| `Hold` | stop and wait (blocked path, out-of-ODD, operator) | MRC hold |
+
+What is **NOT** in the courier doer: lane-change, overtake, merge, asserting into junction
+right-of-way. A courier does not negotiate for position; it yields and creeps. (`Yield` /
+`CrossWhenClear` are the doer-side follow-up that ADR-0014's Mick seam already accommodates; this
+ADR pins the set, the wiring is tracked separately.)
+
+### 4. Class mapping (one selector, two loops, cited copies)
+
+The Courier profile already spans the stack; the per-class numbers are **cited copies** across the
+two dependency-separated workspaces (the CONTRACT_PROFILES.md single-source-of-truth rule):
+
+| Surface | Courier realization |
+|---|---|
+| Fast-loop kinematic contract | `contract_for(VehicleClass::Courier)` → `courier_nominal` / `courier_mrc` |
+| Impact / SG6 | `impact_cfg_for_class(VehicleClass::Courier)` (spike 2.5) |
+| Slow-loop checker | `VehicleConfig::courier()` (footprint 0.6×0.9, wheelbase 0.5, 3.0 m/s, ODD 2.5, **rss_band 0.6**) |
+| Doer (Occy) | the `class:"courier"` profile on the planner endpoint + the Occy doer bridge |
+| Selector | the **class string** (`courier` / `robotaxi` / `delivery-av`) parsed on both sides (`VehicleClass::from_str`, `VehicleConfig::for_class`) — no shared import across the workspace boundary |
+
+### 5. Deployment
+
+Single-box on the Orin NX (ADR-0014), the "**Courier end**" of the platform strategy — a
+QNX-native single-SoC variant is the certifiable target (`docs/MARKET_AUTONOMOUS_SERVICES.md`,
+`parko/QNX_BACKEND_SELECTION.md`). The doer (Occy/Mick + perception) is the untrusted partition;
+KIRRA is the creep+energy+ACD boundary.
+
+## Consequences
+
+- The Rosmaster validates the **Courier class**, not a degraded robotaxi — and in doing so it
+  hardens the per-class profile machinery the whole family (incl. the robotaxi) depends on.
+- The AV / robotaxi effort is **untouched and frozen** (guaranteed by
+  `default_urban_rss_band_is_the_frozen_robotaxi_value`); the two ODDs share *logic*, never *numbers*.
+- Follow-ups (tracked, not in this ADR): the doer-side sidewalk intents (`Yield` / `CrossWhenClear`
+  / creep-through-crowd) in Mick/Occy; certified Courier impact + creep numbers (today
+  VALIDATION-PENDING); pedestrian detection via Parko feeding the same objects seam.
+
+## Status
+
+**Proposed — for owner sign-off** (merge ratifies, as with ADR-0011/0012/0013/0014). Records the
+sidewalk-courier ODD + safety/behavior model before further courier code, so the build rests on a
+written domain. Implementation of the class selector + slow-loop sibling family follows (step b).

--- a/docs/adr/0027-sidewalk-courier-odd.md
+++ b/docs/adr/0027-sidewalk-courier-odd.md
@@ -93,7 +93,9 @@ HOLDs while one is in the way; `CrossWhenClear` steps off only when every confli
 worst-case re-acceleration still can't reach the crossing before the slow courier clears it (the
 Stackelberg `interactive_proceed` model), else HOLDs at the curb. `FollowPath` ≈ `GoTo`/`Cruise` at
 creep; `Hold` already exists. `creep-through-crowd` (a soft nudge through dense pedestrians) remains
-a follow-up.
+a follow-up. The two behaviors are shown composing in a continuous drive (give way to a pedestrian
+and resume; wait at a curb for a car and cross) by `cargo run -p kirra-mick --example
+sidewalk_session` — Mick → Occy → KIRRA (courier profile), every committed pose checker-admitted.
 
 ### 4. Class mapping (one selector, two loops, cited copies)
 

--- a/docs/adr/0027-sidewalk-courier-odd.md
+++ b/docs/adr/0027-sidewalk-courier-odd.md
@@ -83,9 +83,17 @@ Sidewalk intents replace road maneuvers. Mick authors, Occy grounds, KIRRA bound
 | `Hold` | stop and wait (blocked path, out-of-ODD, operator) | MRC hold |
 
 What is **NOT** in the courier doer: lane-change, overtake, merge, asserting into junction
-right-of-way. A courier does not negotiate for position; it yields and creeps. (`Yield` /
-`CrossWhenClear` are the doer-side follow-up that ADR-0014's Mick seam already accommodates; this
-ADR pins the set, the wiring is tracked separately.)
+right-of-way. A courier does not negotiate for position; it yields and creeps.
+
+**`Yield` and `CrossWhenClear` are now implemented** (`crates/kirra-planner/src/behavior.rs`:
+`yield_to_vru_speed_cap`, `cross_when_clear`/`crosswalk_critical_gap_s`; grounded in
+`plan_for_intent`; authored over the Mick LLM JSON seam as `MickIntent::{Yield, CrossWhenClear}`).
+`Yield` creeps to a stop a standoff before the nearest pedestrian in the courier's path band and
+HOLDs while one is in the way; `CrossWhenClear` steps off only when every conflicting road agent's
+worst-case re-acceleration still can't reach the crossing before the slow courier clears it (the
+Stackelberg `interactive_proceed` model), else HOLDs at the curb. `FollowPath` ≈ `GoTo`/`Cruise` at
+creep; `Hold` already exists. `creep-through-crowd` (a soft nudge through dense pedestrians) remains
+a follow-up.
 
 ### 4. Class mapping (one selector, two loops, cited copies)
 

--- a/docs/testing/DRIVE_SESSION_SETUP.md
+++ b/docs/testing/DRIVE_SESSION_SETUP.md
@@ -57,6 +57,23 @@ KIRRA_VERIFIER_URL=http://localhost:8090 KIRRA_ADMIN_TOKEN=test-token \
   governor is only **observed** (non-intrusive) — pure data collection.
 - Requires the `carla` Python package importable (the CARLA egg / `pip install carla`).
 
+## 2c. Drive with REAL Occy as the doer (not the placeholder controller)
+
+The harnesses above use a built-in controller as the doer. To drive egos with the
+**actual planner**, run the Occy planner endpoint and point the harness at it:
+
+```bash
+cargo run -p kirra-mick --example planner_service          # Occy on :8100 (POST /plan)
+
+KIRRA_VERIFIER_URL=http://localhost:8090 \
+  python3 scripts/carla_drive_session.py --town Town03 --egos 3 --occy http://localhost:8100
+```
+
+Per tick, the harness builds a corridor from the map's lane waypoints ahead of each ego,
+POSTs the world snapshot to `/plan`, and drives from Occy's KIRRA-validated trajectory.
+`crates/kirra-mick/examples/drive_session.rs` is the same Occy↔KIRRA loop fully in Rust
+(no CARLA), with the `MickEvalSummary` scorecard — use it to sanity-check the doer offline.
+
 ## 3. Tune from the capture
 
 Each JSONL row carries the proposal, the enforced result, and the per-axis Δ. Use it to:

--- a/docs/testing/DRIVE_SESSION_SETUP.md
+++ b/docs/testing/DRIVE_SESSION_SETUP.md
@@ -82,5 +82,36 @@ Each JSONL row carries the proposal, the enforced result, and the per-axis Δ. U
 - make the doer propose checker-admissible commands more often (geometric tuning, or
   as training data for the learned doer).
 
-For the heavier supervised-learning path, map each row to a `CaptureRecord`
-(`kirra-capture-schema`) and run it through `kirra-collector` to build the Parquet dataset.
+## 4. Build the supervised-learning dataset (wired)
+
+`governor_drive_session.py` already emits the two files `kirra-collector` joins —
+alongside `drive_session.jsonl` it writes `drive_session.capture.jsonl` (one
+`kirra-capture-schema::CaptureRecord` per tick: `ALLOW` / `CLAMP_LINEAR` /
+`CLAMP_STEERING` / `DENY`, with the clamped value in `safe_value`) and
+`drive_session.bag.json` (the matching `BusMessage` array — the doer-side stamp
+each record joins against). Feed them straight into the collector:
+
+```bash
+cargo run -p kirra-collector -- \
+  --capture drive_session.capture.jsonl \
+  --bag-json drive_session.bag.json \
+  --out dataset/ --window-ms 100
+```
+
+A 120-tick headless run produces a partitioned Parquet dataset + manifest:
+
+```
+reconciliation:
+  records_in            = 120 (gateway 120, trajectory 0; 0 duplicate(s) dropped)
+  interventions / passes= 28 / 92
+  joined / orphans      = 120 / 0 (orphan_rate 0.000)
+dataset/
+  manifest.json
+  doer_version=occy-drive-demo/source=COMMAND_GATEWAY/part-000.parquet
+```
+
+Each Parquet row carries the governor's correction joined to the doer's proposal
++ version — the supervised target for tuning the **doer** to propose
+checker-admissible commands. The collector depends on `kirra-capture-schema`
+**only** (never the verifier), so it is mechanically incapable of reaching the
+verdict path.

--- a/docs/testing/DRIVE_SESSION_SETUP.md
+++ b/docs/testing/DRIVE_SESSION_SETUP.md
@@ -1,0 +1,69 @@
+# Drive-session simulator — observe egos + collect doer↔checker tuning data
+
+Two host-side harnesses drive an ego (or a fleet) through the **real Kirra governor**
+and log every `(proposed, enforced, divergence)` decision as JSONL, so the planner's
+performance can be **measured** against the checker and the **doer** tuned.
+
+| Harness | Needs | What it gives |
+|---|---|---|
+| `scripts/governor_drive_session.py` | just the verifier | a headless kinematic ego — proves the loop, no GPU. **Runnable anywhere.** |
+| `scripts/carla_drive_session.py` | CARLA server (GPU) + verifier | a fleet driving a real **CARLA city**, spectator camera, the same capture. |
+
+The doer–checker contract is preserved end to end: the doer **proposes**, KIRRA
+**bounds both axes**, the enforced command is applied, and the divergence is the
+tuning signal. **Tune the doer from this data — never the checker's envelope** (the
+speed cap, the 0.40 m margin, the RSS bounds are safety-derived invariants).
+
+## 1. Start the governor
+
+```bash
+KIRRA_ADMIN_TOKEN=test-token \
+KIRRA_SUPERVISOR_RESET_KEY=test-reset-key \
+KIRRA_DB_PATH=/tmp/kirra.sqlite \
+cargo run --bin kirra_verifier_service        # listens on :8090
+```
+
+> Run **one** instance per DB/port. Multiple instances sharing a port (`SO_REUSEPORT`)
+> load-balance requests, and the HA one-writer fencing can self-demote an instance to
+> PassiveStandby (admin/mutation routes then 503). One clean instance = no fencing.
+
+## 2a. Headless (no GPU) — prove the loop / collect data anywhere
+
+```bash
+KIRRA_VERIFIER_URL=http://localhost:8090 KIRRA_ADMIN_TOKEN=test-token \
+  python3 scripts/governor_drive_session.py 120 drive_session.jsonl
+```
+
+Sample scorecard (this is what it printed against a local governor):
+
+```
+intervention rate:   28/120  (23.3%)
+mean |Δv| (clamp):   2.224 m/s   (max 29.88)   # over-speed bursts ClampLinear'd
+mean |Δsteer|:       2.146 deg                 # sharp-steer bursts ClampSteering'd
+```
+
+## 2b. CARLA city (GPU) — watch a fleet drive + collect
+
+```bash
+# CARLA server already running (e.g. ./CarlaUE4.sh)
+KIRRA_VERIFIER_URL=http://localhost:8090 KIRRA_ADMIN_TOKEN=test-token \
+  python3 scripts/carla_drive_session.py --town Town03 --egos 3 --ticks 4000 --follow 0
+```
+
+- The **spectator camera** chases ego `--follow`, so you watch the city drive live.
+- `--enforce` (default): the governor-enforced control is applied — the real
+  doer-checker loop.
+- `--shadow`: the CARLA Traffic Manager autopilot drives realistically and the
+  governor is only **observed** (non-intrusive) — pure data collection.
+- Requires the `carla` Python package importable (the CARLA egg / `pip install carla`).
+
+## 3. Tune from the capture
+
+Each JSONL row carries the proposal, the enforced result, and the per-axis Δ. Use it to:
+- track the **intervention rate** and **mean clamp magnitude** over a run (the scorecard);
+- find **where** the doer over-reaches (cluster by map x/y, maneuver, speed);
+- make the doer propose checker-admissible commands more often (geometric tuning, or
+  as training data for the learned doer).
+
+For the heavier supervised-learning path, map each row to a `CaptureRecord`
+(`kirra-capture-schema`) and run it through `kirra-collector` to build the Parquet dataset.

--- a/docs/testing/GAZEBO_ON_ORIN.md
+++ b/docs/testing/GAZEBO_ON_ORIN.md
@@ -1,0 +1,98 @@
+# Watch Taj + KIRRA stop a robot in Gazebo (on the Orin)
+
+A single `ros2 launch` spins up a Gazebo robot that drives itself toward a wall while a
+naive "doer" keeps commanding it forward — and **Taj's corridor cap + the KIRRA governor
+brake it to a controlled stop before the wall.** It's the doer-checker thesis made
+watchable, and it runs entirely on the Jetson Orin NX (single-box, no second machine, no
+CARLA). Gazebo (Classic) is ARM-native and renders fine on the Orin for one small robot.
+
+## What's in the demo
+
+```
+doer_commander ─/cmd_vel_raw→ cmd_vel_interceptor ─/cmd_vel→ Gazebo robot
+   (naive: 1.2 m/s forward)         │   ▲
+                                    │   └── Taj cap (perception_governor → taj_service)
+   Gazebo lidar ─/scan─────────────┘        applied BEFORE the KIRRA governor
+```
+
+- **`worlds/kirra_corridor.world`** — a short corridor with side walls and a red end wall.
+- **`urdf/kirra_bot.urdf`** — a differential-drive robot with a forward 180° lidar
+  (`/scan`); its diff-drive plugin consumes `/cmd_vel` (the KIRRA-enforced command).
+- **`doer_commander`** — the untrusted proposer: commands a constant 1.2 m/s forward and
+  never brakes. KIRRA + Taj are what stop the robot.
+- The **Kirra safety stack** (`kirra_with_robot.launch.py`, included): the interceptor with
+  the Taj cap on, the `perception_governor`, and the Rust planner/Taj sidecars.
+
+## Prerequisites (on the Orin)
+
+```bash
+# ROS 2 + Gazebo Classic ROS integration (JetPack 6 / Ubuntu 22.04 / Humble)
+sudo apt-get install -y ros-humble-gazebo-ros-pkgs ros-humble-robot-state-publisher
+
+# Build the Rust sidecars + verifier once (or run scripts/orin_bringup.sh)
+cd ~/kirra-runtime-sdk
+cargo build --release -p kirra-mick --example planner_service --example taj_service
+cargo build --release --bin kirra_verifier_service
+
+# Build the ROS package
+cd ros2_ws && colcon build --packages-select kirra_safety && source install/setup.bash
+```
+
+## Run it
+
+```bash
+export KIRRA_ADMIN_TOKEN=test-token KIRRA_SUPERVISOR_RESET_KEY=test-reset-key
+ros2 launch kirra_safety kirra_gazebo_demo.launch.py
+```
+
+That one command starts **everything**: the KIRRA verifier, the planner + Taj sidecars, the
+safety nodes, Gazebo + the robot, and the doer. (If you already have the verifier/sidecars
+up via `scripts/orin_bringup.sh --serve`, pass `start_verifier:=false` — the included stack
+still starts its own sidecars, so use the bring-up OR the launch, not both, to avoid
+double-binding the ports.)
+
+## What you'll see
+
+The robot accelerates down the corridor at the doer's commanded speed, then — as it nears
+the red wall — **slows and stops a short standoff before it**, and holds, even though the
+doer is still commanding 1.2 m/s. The deceleration is Taj's assured-clear-distance cap
+(the clear distance shrinks as the wall approaches) applied ahead of the governor.
+
+Watch the decision live:
+
+```bash
+ros2 topic echo /kirra/enforcement_action     # e.g. Allow:v=1.20  →  Allow:v=0.74|PERCEPTION_CAP  →  ...|PERCEPTION_CAP (v→0)
+ros2 topic echo /kirra/perception_speed_cap    # the ACD cap (m/s) falling as the wall nears
+ros2 topic echo /kirra/perception_health       # OK:clear=…m:cap=…
+ros2 topic echo /cmd_vel                        # the enforced command actually driving the wheels
+```
+
+`rviz2` with the `/scan` and `/odom` displays makes the lidar fan and the stop obvious.
+
+## Knobs
+
+| arg / param | default | effect |
+|---|---|---|
+| `forward_speed_mps` (launch) | `1.2` | the doer's naive commanded speed. |
+| `gui` (launch) | `true` | `false` runs gzserver headless (data only — useful over SSH). |
+| `start_verifier` (launch) | `true` | set `false` if the verifier is already running. |
+| `decel_mps2` / `margin_m` (perception_governor params) | `1.5` / `0.4` | the ACD model: lower decel or larger margin → the cap bites earlier / stops further back. |
+| `confidence_floor` | `0.5` | corridor confidence below this → unhealthy → 0 cap (fail-closed). |
+
+To make the derate more dramatic, raise `forward_speed_mps` or lower `decel_mps2` (a gentler
+assumed brake caps the speed from further out). Remember: **tune the doer / the ACD model,
+never the checker's envelope** — KIRRA's bound is the invariant.
+
+## Fail-closed, live
+
+Kill the Taj sidecar mid-run (`pkill -f taj_service`) and the robot **stops**: the cap topic
+goes stale, the interceptor fails closed (the `PERCEPTION_STALE` reason appears on
+`/kirra/enforcement_action`), and the doer's forward command no longer reaches the wheels. A
+perception fault holds the robot rather than letting it coast into the wall.
+
+## Note on Gazebo versions
+
+This demo targets **Gazebo Classic** (`gazebo_ros_pkgs`) for the fewest moving parts. The
+modern **Gazebo (gz sim, Harmonic) + `ros_gz`** path works too — swap the `gzserver`/`gzclient`
+processes for `ros_gz_sim`'s `gz sim`, add a `ros_gz_bridge` for `/scan` and `/cmd_vel`, and
+keep everything else (the safety stack, the doer, the URDF sensors) the same.

--- a/docs/testing/OCCY_DOER_BRIDGE.md
+++ b/docs/testing/OCCY_DOER_BRIDGE.md
@@ -97,10 +97,12 @@ courier verdict is `Accept` (admitted)** — same scene, same checker logic — 
 number stays frozen (`courier_admits_a_side_object_a_robotaxi_refuses`). So the small robot can
 now be *judged* as a robot, not a 4.8 m car.
 
-**Still a doer-side follow-up.** The checker now *admits* a robot-scale side pass, but Occy
-(the doer) still *proposes* `SafeStop` for an in-corridor object at robot scale — proposing the
-pass is the untrusted doer's own robot-scale tuning, separate from the safety checker. And
-bend-following additionally needs Phase-B perception (Taj Phase A only makes straight corridors).
+**Doer-side robot tuning (done).** `GeometricPlannerConfig::courier()` is the robot-scale planner
+preset (ADR-0027): Occy stops ~1 m short of an in-path object (the Yield standoff, not the car's
+5 m) and routes around with the courier's ~0.7 m clearance (not 4.5 m). `planner_service` selects
+it for `class:"courier"`, so the courier now *proposes* robot-scale motion the car default never
+would, and the per-class checker admits it. (Bend-FOLLOWING still needs Phase-B perception — Taj
+Phase A only makes straight corridors.)
 
 ## Where Mick and Parko plug in (Phase 2)
 

--- a/docs/testing/OCCY_DOER_BRIDGE.md
+++ b/docs/testing/OCCY_DOER_BRIDGE.md
@@ -62,6 +62,14 @@ Defaults are Rosmaster-class; tune them to your chassis:
 | `max_steering_deg` | 30 | steering limit (Ackermann) |
 | `corridor_back_m` | 0.5 | how far to extend the corridor behind the robot (footprint containment) |
 | `lookahead_m` | 0.8 | pure-pursuit lookahead |
+| `vehicle_class` | `courier` | per-class checker profile (`courier` = small robot, `robotaxi` = the frozen AV) |
+| `rss_lateral_alignment_tolerance_m` | 0.6 | per-class RSS lateral band — robot "lane" width, not the car's 4 m |
+| `lateral_clearance_target_m` | 0.6 | how much room the DOER (Occy) demands before proposing a pass |
+
+The `vehicle_class` selects a **sibling profile** in the checker (`VehicleConfig::courier()` vs
+`default_urban()`), per [`docs/CONTRACT_PROFILES.md`](../CONTRACT_PROFILES.md). The robotaxi
+numbers are **frozen and unchanged** (proven by `default_urban_rss_band_is_the_frozen_robotaxi_value`),
+so the small-robot profile **cannot regress the AV path** — the only difference is the numbers.
 
 ## What it does today (honest scope)
 
@@ -76,9 +84,19 @@ Verified end to end (real `taj_service` + `planner_service` + the real `doer_cor
 So today the doer **drives straight down clear corridors and stops before obstacles** —
 exactly the right first-hardware behavior (the robot moves and is safe). `GoTo` tracks the
 drivable **corridor centerline**, so it does not beeline to an off-axis goal; turning follows
-the corridor. **Turning to follow a bend / routing around an obstacle needs robot-scaled
-RSS/containment constants** in the checker (currently car-tuned) — a tracked follow-up — plus,
-for bends, Phase-B perception (Taj Phase A only makes straight corridors).
+the corridor.
+
+**Per-class checker profile (done).** The slow-loop checker's RSS lateral band is now a
+per-class number (`VehicleConfig::courier()` 0.6 m vs robotaxi 4.0 m), proven end to end: for
+a side object 0.8 m off the path, the **robotaxi verdict is `MRCFallback` (refused) and the
+courier verdict is `Accept` (admitted)** — same scene, same checker logic — while the robotaxi
+number stays frozen (`courier_admits_a_side_object_a_robotaxi_refuses`). So the small robot can
+now be *judged* as a robot, not a 4.8 m car.
+
+**Still a doer-side follow-up.** The checker now *admits* a robot-scale side pass, but Occy
+(the doer) still *proposes* `SafeStop` for an in-corridor object at robot scale — proposing the
+pass is the untrusted doer's own robot-scale tuning, separate from the safety checker. And
+bend-following additionally needs Phase-B perception (Taj Phase A only makes straight corridors).
 
 ## Where Mick and Parko plug in (Phase 2)
 

--- a/docs/testing/OCCY_DOER_BRIDGE.md
+++ b/docs/testing/OCCY_DOER_BRIDGE.md
@@ -66,10 +66,14 @@ Defaults are Rosmaster-class; tune them to your chassis:
 | `rss_lateral_alignment_tolerance_m` | 0.6 | per-class RSS lateral band — robot "lane" width, not the car's 4 m |
 | `lateral_clearance_target_m` | 0.6 | how much room the DOER (Occy) demands before proposing a pass |
 
-The `vehicle_class` selects a **sibling profile** in the checker (`VehicleConfig::courier()` vs
-`default_urban()`), per [`docs/CONTRACT_PROFILES.md`](../CONTRACT_PROFILES.md). The robotaxi
-numbers are **frozen and unchanged** (proven by `default_urban_rss_band_is_the_frozen_robotaxi_value`),
-so the small-robot profile **cannot regress the AV path** — the only difference is the numbers.
+The `vehicle_class` selects a **sibling profile** in the checker via the single
+`VehicleConfig::for_class()` selector (`courier` / `delivery-av` / `robotaxi`), the slow-loop
+counterpart of the fast-loop `VehicleClass` — per [`docs/CONTRACT_PROFILES.md`](../CONTRACT_PROFILES.md)
+and **[ADR-0027](../adr/0027-sidewalk-courier-odd.md)** (the sidewalk-courier ODD: a pedestrian-space
+class, not a shrunk car — creep + assured-clear-distance + impact-energy, *not* RSS car-following).
+The robotaxi numbers are **frozen and unchanged** (proven by
+`default_urban_rss_band_is_the_frozen_robotaxi_value`), so the courier profile **cannot regress the
+AV path** — the only difference is the numbers.
 
 ## What it does today (honest scope)
 

--- a/docs/testing/OCCY_DOER_BRIDGE.md
+++ b/docs/testing/OCCY_DOER_BRIDGE.md
@@ -1,0 +1,90 @@
+# Occy doer bridge — drive the robot to a goal, governed by KIRRA
+
+This is the **doer**: the piece that makes real Occy drive the robot to a goal, with Taj
+perceiving and KIRRA governing. It closes the loop "Mick/Occy proposes → KIRRA disposes" on
+hardware. The five pieces working together (Mick · Taj · Occy · KIRRA, with Parko as the
+Phase-2 perception upgrade):
+
+```
+  goal (RViz / Mick) ─/goal_pose─┐
+  /odom (pose, speed) ───────────┤
+  /scan (lidar) ──▶ Taj :8101 (corridor + objects) ─┐
+                                 ▼                   ▼
+                         occy_doer ──▶ Occy :8100 /plan (proposes + KIRRA slow-loop)
+                                 │
+                          pure-pursuit → Twist
+                                 ▼
+            /cmd_vel_raw ─▶ cmd_vel_interceptor [Taj speed cap + KIRRA fast-loop] ─/cmd_vel─▶ wheels
+```
+
+Each tick (`occy_doer`, default 5 Hz):
+1. read the robot pose + speed (`/odom`) and the current goal (`/goal_pose`),
+2. POST the latest scan to **Taj** → the geometric corridor (left/right polylines) + objects,
+3. transform the goal into the base frame, extend the corridor behind the robot (footprint
+   containment), and POST `{ego, goal, corridor, objects, vehicle}` to **Occy** `/plan`,
+4. turn Occy's **KIRRA-validated** trajectory into a Twist (pure pursuit) on `/cmd_vel_raw`.
+
+**Occy only PROPOSES; KIRRA DISPOSES — twice:** the planner runs the slow-loop checker
+(`validate_trajectory_slow`) and returns a verdict; the `cmd_vel_interceptor` then re-checks
+every command with the fast-loop kinematic governor + the Taj speed cap. The doer is
+**fail-soft**: no goal, a stale scan, a service error, or a refused plan all publish a zero
+Twist (hold) — and even if it didn't, the interceptor + governor are the safety authority.
+
+## Run it
+
+```bash
+# sidecars + verifier (systemd, or scripts/orin_bringup.sh --serve, or the launch starts them)
+ros2 launch kirra_safety kirra_with_robot.launch.py \
+    kirra_token:=$KIRRA_ADMIN_TOKEN \
+    use_occy_doer:=true use_perception_cap:=true
+# then publish a goal — in RViz click "2D Goal Pose", or:
+ros2 topic pub --once /goal_pose geometry_msgs/PoseStamped \
+    '{header: {frame_id: odom}, pose: {position: {x: 2.0, y: 0.0}}}'
+```
+
+The robot drives toward the goal down the clear corridor and stops on arrival (or before an
+obstacle). Prereqs: the Yahboom/Rosmaster base + lidar drivers (publishing `/scan`, `/odom`,
+subscribing `/cmd_vel`), and the Occy planner sidecar (+ Taj). The launch starts the Rust
+sidecars itself unless `start_sidecars:=false`.
+
+## Robot sizing (important)
+
+The checker judges a **vehicle footprint**. The planner's default is an urban car (4.8 m) —
+which cannot fit a robot-scale lidar corridor, so KIRRA would MRC every plan. `occy_doer`
+therefore tells the planner the robot's real size via the `/plan` request's `vehicle` block.
+Defaults are Rosmaster-class; tune them to your chassis:
+
+| param | default | meaning |
+|---|---|---|
+| `wheelbase_m` | 0.2 | axle-to-axle |
+| `half_length_m` / `half_width_m` | 0.18 / 0.15 | bumper-to-centre half extents |
+| `max_speed_mps` | 1.2 | doer cruise / checker max |
+| `max_steering_deg` | 30 | steering limit (Ackermann) |
+| `corridor_back_m` | 0.5 | how far to extend the corridor behind the robot (footprint containment) |
+| `lookahead_m` | 0.8 | pure-pursuit lookahead |
+
+## What it does today (honest scope)
+
+Verified end to end (real `taj_service` + `planner_service` + the real `doer_core` decision):
+
+| scene | result |
+|---|---|
+| clear corridor, goal ahead | **DRIVE** ~1.2 m/s (Occy `Motion`/`Clamp`) |
+| obstacle dead-ahead | **HOLD** — Occy proposes a controlled stop |
+| bending corridor | Occy **proposes** the turn (`path_maxy≠0`) but the car-tuned checker conservatively MRCs it at robot scale → **HOLD** (fail-closed) |
+
+So today the doer **drives straight down clear corridors and stops before obstacles** —
+exactly the right first-hardware behavior (the robot moves and is safe). `GoTo` tracks the
+drivable **corridor centerline**, so it does not beeline to an off-axis goal; turning follows
+the corridor. **Turning to follow a bend / routing around an obstacle needs robot-scaled
+RSS/containment constants** in the checker (currently car-tuned) — a tracked follow-up — plus,
+for bends, Phase-B perception (Taj Phase A only makes straight corridors).
+
+## Where Mick and Parko plug in (Phase 2)
+
+- **Mick (the LLM brain):** instead of an RViz goal, Mick publishes the goal/intent — the
+  doer is intent-source-agnostic. A richer `/plan` that takes a typed `MickIntent`
+  (RouteTo/TurnAt) would let the LLM command turns at junctions.
+- **Parko (the ML detector):** its semantic objects feed the same `objects` list the doer
+  already passes to the planner — richer and longer-range than Taj's geometric clusters.
+  The doer's seam is unchanged; Parko is hardware/model-gated bring-up.

--- a/docs/testing/ORIN_NX_STACK_BRINGUP.md
+++ b/docs/testing/ORIN_NX_STACK_BRINGUP.md
@@ -8,9 +8,10 @@ then (optionally) bring up the governance plane so a ROS 2 / Python client can d
 > **The Orin is the robot's brain, not a sim host.** CARLA's photoreal server is x86 + desktop
 > GPU only — it does *not* run on the Orin. You don't need it: the stack below is pure Rust
 > compute (no GPU, no CARLA, no ROS required to run the demo), so it executes on the Orin
-> exactly as it would on the vehicle. For visuals on the Orin use Gazebo/Ignition (ARM-native,
-> wired in `ros2_ws/src/kirra_safety`); for CARLA cities put CARLA in the cloud with the Orin
-> as the client.
+> exactly as it would on the vehicle. For a watchable robot sim on the Orin, the Gazebo demo
+> (ARM-native) drives a robot into a wall and Taj+KIRRA brake it — see
+> [GAZEBO_ON_ORIN.md](GAZEBO_ON_ORIN.md). For CARLA cities put CARLA in the cloud with the
+> Orin as the client.
 
 ## The four components
 

--- a/docs/testing/ORIN_NX_STACK_BRINGUP.md
+++ b/docs/testing/ORIN_NX_STACK_BRINGUP.md
@@ -47,7 +47,7 @@ git clone https://github.com/kirra-systems/kirra-runtime-sdk && cd kirra-runtime
 
 ```bash
 scripts/orin_bringup.sh            # build the 4 components + run the headless stack demo
-scripts/orin_bringup.sh --serve    # ALSO start the verifier (:8090) + Occy planner (:8100)
+scripts/orin_bringup.sh --serve    # ALSO start verifier (:8090) + Occy planner (:8100) + Taj (:8101)
 ```
 
 The script sanity-checks the toolchain, detects the Jetson, builds release binaries, and runs
@@ -73,8 +73,10 @@ regime Occy only PROPOSES; KIRRA admits or refuses. In **LockedOut**, KIRRA refu
 
 ## 2. Drive real egos through the live governor
 
-With `--serve` the **governance plane** (the verifier on `:8090`) and the **Occy planner
-endpoint** (`POST /plan` on `:8100`) are up. Point a client at them:
+With `--serve` the **governance plane** (the verifier on `:8090`), the **Occy planner
+endpoint** (`POST /plan` on `:8100`), and the **Taj perception sidecar** (`POST /perception`
+on `:8101` — the cmd_vel speed cap) are up, each health-checked before the banner prints.
+Point a client at them:
 
 - **On the robot** — the `ros2_ws/src/kirra_safety` launch wires the R2's `cmd_vel` through the
   governor (Ackermann envelope + posture + LLM-claim filtering). This is ADR-0014 **Phase 1**:

--- a/docs/testing/ORIN_NX_STACK_BRINGUP.md
+++ b/docs/testing/ORIN_NX_STACK_BRINGUP.md
@@ -1,0 +1,116 @@
+# Mick · Taj · Occy · KIRRA on a Jetson Orin NX 16GB
+
+The full Kirra **System-2** stack runs natively on a Jetson Orin NX 16GB — the deployment
+target of **[ADR-0014](../adr/0014-rosmaster-r2-orin-nx-kirra-integration.md)**. This is the
+bring-up recipe: build the four components for aarch64, prove the doer-checker loop headless,
+then (optionally) bring up the governance plane so a ROS 2 / Python client can drive real egos.
+
+> **The Orin is the robot's brain, not a sim host.** CARLA's photoreal server is x86 + desktop
+> GPU only — it does *not* run on the Orin. You don't need it: the stack below is pure Rust
+> compute (no GPU, no CARLA, no ROS required to run the demo), so it executes on the Orin
+> exactly as it would on the vehicle. For visuals on the Orin use Gazebo/Ignition (ARM-native,
+> wired in `ros2_ws/src/kirra_safety`); for CARLA cities put CARLA in the cloud with the Orin
+> as the client.
+
+## The four components
+
+| Component | Crate | Role (ADR-0014 / ADR-0015) |
+|---|---|---|
+| **Taj** | `kirra-taj` | Perception — R2 lidar/depth → the Kirra perception contract (corridor + objects + health). Phase A is geometric/model-free; Phase B is the Parko TensorRT detector. |
+| **Mick** | `kirra_planner::mick` | The intent seam — an LLM authors a TYPED `MickIntent` as JSON, parsed **fail-closed** (`from_llm_json`). The local model (Gemma via Ollama) lives in `kirra-mick`. |
+| **Occy** | `kirra-planner` | The DOER — grounds Mick's intent against Taj's perception into a proposed trajectory (`plan_for_intent`). Only PROPOSES. |
+| **KIRRA** | `validate_trajectory_slow` (`kirra-ros2-adapter`) + `kirra_verifier_service` | The CHECKER — the sole safety authority. Bounds Occy's proposal (RSS + containment + kinematics + posture); the verifier service is the governance/console plane. |
+
+The one rule, end to end: **the brain PROPOSES a typed claim; KIRRA DISPOSES; only a validated,
+clamped command reaches the actuator.** Occy is never trusted to stop — KIRRA is.
+
+## Hardware reality (Orin NX 16GB)
+
+- **KIRRA's footprint is ~zero** — Rust, no ROS/tokio in the governor core.
+- **System 2 is the tight budget**, not KIRRA: a small instruct LLM (Gemma 3 4B / Llama 3.2 3B,
+  Q4 via TensorRT-LLM) + a small TensorRT detector + ROS 2 + buffers fit 16 GB unified but must
+  be managed. A heavy lidar DNN run concurrently is where it breaks.
+- **Fail-closed covers a slow/cloud brain**: if System 2 stalls or a cloud link drops, the
+  governor HOLDs (Degraded/MRC). A laggy brain costs *availability*, never *safety*.
+- Power: 10–25 W; set a mode with `nvpmodel`.
+
+## 0. Prerequisites on the Orin
+
+```bash
+# Rust toolchain (native aarch64 — no cross-compile needed when building ON the Orin)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+sudo apt-get install -y build-essential pkg-config   # cc/linker for the bundled SQLite etc.
+git clone https://github.com/kirra-systems/kirra-runtime-sdk && cd kirra-runtime-sdk
+```
+
+## 1. One-command bring-up
+
+```bash
+scripts/orin_bringup.sh            # build the 4 components + run the headless stack demo
+scripts/orin_bringup.sh --serve    # ALSO start the verifier (:8090) + Occy planner (:8100)
+```
+
+The script sanity-checks the toolchain, detects the Jetson, builds release binaries, and runs
+the headless four-component demo. Expected output:
+
+```
+Taj(perception) → Mick(intent) → Occy(doer) → KIRRA(checker) — on-Orin stack (ADR-0014), headless
+
+  scenario                            objs  occy      kirra         min_y  result
+  --------------------------------------------------------------------------------------
+  clear corridor                         2  Motion    Clamp          0.00  drives (KIRRA admits)
+  stopped car ahead                      3  SafeStop  Accept         0.00  controlled stop behind it (admitted)
+  off-centre obstacle, wide road         3  Motion    Clamp         -1.50  routes around (admitted)
+  LockedOut posture                      2  SafeStop  MRCFallback    0.00  KIRRA refuses all motion (MRC)
+```
+
+Each row is one full pass of Taj→Mick→Occy→KIRRA. The load-bearing property: across every
+regime Occy only PROPOSES; KIRRA admits or refuses. In **LockedOut**, KIRRA refuses all motion
+*even though Occy proposed only a safe-stop* — the fault flows through the whole stack.
+
+> Run it by hand any time: `cargo run --release -p kirra-mick --example taj_occy_kirra_stack`.
+> The same loop fully in Rust against a route graph (no Taj) is the `drive_session` example.
+
+## 2. Drive real egos through the live governor
+
+With `--serve` the **governance plane** (the verifier on `:8090`) and the **Occy planner
+endpoint** (`POST /plan` on `:8100`) are up. Point a client at them:
+
+- **On the robot** — the `ros2_ws/src/kirra_safety` launch wires the R2's `cmd_vel` through the
+  governor (Ackermann envelope + posture + LLM-claim filtering). This is ADR-0014 **Phase 1**:
+  a complete governed-robot loop with no perception model, light Jetson load. Add Taj's geometric
+  corridor next; the Parko TensorRT detector is **Phase 2**.
+- **Headless / desktop** — `scripts/governor_drive_session.py` drives a kinematic ego through the
+  real governor and captures the divergence (and a `kirra-collector` dataset; see
+  [DRIVE_SESSION_SETUP.md](DRIVE_SESSION_SETUP.md)).
+- **Occy as the doer** — `scripts/carla_drive_session.py --occy http://127.0.0.1:8100` drives egos
+  with the actual planner via the endpoint.
+
+```bash
+KIRRA_ADMIN_TOKEN=… KIRRA_SUPERVISOR_RESET_KEY=… scripts/orin_bringup.sh --serve
+```
+
+(`KIRRA_ADMIN_TOKEN` and `KIRRA_SUPERVISOR_RESET_KEY` are required and fail-closed — absent/empty
+→ admin routes 503. See the root `CLAUDE.md` env table.)
+
+## 3. Topology — single-box vs two-box
+
+- **Single-box (this script, Phase 1).** Everything on the Orin; freedom-from-interference rests
+  on partition/hypervisor isolation (the #270 / #278 QNX path).
+- **Two-box (stronger separation, recommended for the safety demo).** System 2 (Taj + Mick + Occy)
+  on the Orin; the **KIRRA governor on a separate small board** (a Raspberry Pi is the better
+  governor box — zero GPU needed, lower power, GPIO for the E-stop audit), linked by the
+  `kirra-governor-service` UDP wire. A memory/GPU/thermal fault in System 2 then *physically*
+  cannot starve the governor.
+
+See [ADR-0014](../adr/0014-rosmaster-r2-orin-nx-kirra-integration.md) §"Compute topology" for the
+governor-box trade-off and the cert-correctness caveat (the certifiable governor target remains
+QNX on a safety MCU; the hardwired E-stop is independent of compute, ADR-0013).
+
+## What's gated (not built by the demo)
+
+- **ROS 2 node** (`kirra-ros2-adapter` `node.rs`) — needs a sourced ROS 2 toolchain (`r2r`),
+  built only with `--features ros2`. The bring-up demo deliberately avoids it so it runs with no
+  ROS install.
+- **Parko TensorRT detector** (Phase 2 perception) — hardware/CI-gated; Phase A Taj is model-free
+  and runs today.

--- a/docs/testing/ORIN_NX_STACK_BRINGUP.md
+++ b/docs/testing/ORIN_NX_STACK_BRINGUP.md
@@ -78,8 +78,11 @@ endpoint** (`POST /plan` on `:8100`) are up. Point a client at them:
 
 - **On the robot** — the `ros2_ws/src/kirra_safety` launch wires the R2's `cmd_vel` through the
   governor (Ackermann envelope + posture + LLM-claim filtering). This is ADR-0014 **Phase 1**:
-  a complete governed-robot loop with no perception model, light Jetson load. Add Taj's geometric
-  corridor next; the Parko TensorRT detector is **Phase 2**.
+  a complete governed-robot loop, light Jetson load. **Taj's geometric corridor is now wired into
+  this path**: the `perception_governor` node turns `/scan` into an assured-clear-distance speed
+  cap (via the `taj_service` sidecar) that derates `cmd_vel` before the governor — opt-in,
+  fail-closed (`use_perception_cap:=true`; see `ros2_ws/src/kirra_safety/README.md`). The Parko
+  TensorRT detector (semantic objects) is **Phase 2**.
 - **Headless / desktop** — `scripts/governor_drive_session.py` drives a kinematic ego through the
   real governor and captures the divergence (and a `kirra-collector` dataset; see
   [DRIVE_SESSION_SETUP.md](DRIVE_SESSION_SETUP.md)).

--- a/docs/testing/ORIN_NX_STACK_BRINGUP.md
+++ b/docs/testing/ORIN_NX_STACK_BRINGUP.md
@@ -51,6 +51,11 @@ scripts/orin_bringup.sh            # build the 4 components + run the headless s
 scripts/orin_bringup.sh --serve    # ALSO start verifier (:8090) + Occy planner (:8100) + Taj (:8101)
 ```
 
+To run the verifier + sidecars **on boot** instead of by hand, install the systemd units:
+`sudo deploy/systemd/install.sh` (see [`deploy/systemd/README.md`](../../deploy/systemd/README.md)).
+When the stack is running under systemd, launch the robot with `start_sidecars:=false`
+(and the Gazebo demo's `start_verifier:=false`) so the launch doesn't double-bind the ports.
+
 The script sanity-checks the toolchain, detects the Jetson, builds release binaries, and runs
 the headless four-component demo. Expected output:
 

--- a/docs/testing/ORIN_NX_STACK_BRINGUP.md
+++ b/docs/testing/ORIN_NX_STACK_BRINGUP.md
@@ -83,8 +83,11 @@ Point a client at them:
   a complete governed-robot loop, light Jetson load. **Taj's geometric corridor is now wired into
   this path**: the `perception_governor` node turns `/scan` into an assured-clear-distance speed
   cap (via the `taj_service` sidecar) that derates `cmd_vel` before the governor — opt-in,
-  fail-closed (`use_perception_cap:=true`; see `ros2_ws/src/kirra_safety/README.md`). The Parko
-  TensorRT detector (semantic objects) is **Phase 2**.
+  fail-closed (`use_perception_cap:=true`; see `ros2_ws/src/kirra_safety/README.md`). The launch
+  starts the Rust sidecars (Occy planner + Taj) itself, so one `ros2 launch` brings up the whole
+  governed stack — but pass `start_sidecars:=false` if you already started them via
+  `orin_bringup.sh --serve` (otherwise the ports double-bind). The Parko TensorRT detector
+  (semantic objects) is **Phase 2**.
 - **Headless / desktop** — `scripts/governor_drive_session.py` drives a kinematic ego through the
   real governor and captures the divergence (and a `kirra-collector` dataset; see
   [DRIVE_SESSION_SETUP.md](DRIVE_SESSION_SETUP.md)).

--- a/ros2_ws/src/kirra_safety/README.md
+++ b/ros2_ws/src/kirra_safety/README.md
@@ -13,10 +13,13 @@ Provides four nodes that enforce kinematic contracts, derive a perception speed 
 
 The `perception_governor` node wires **Taj** (the geometric perception layer, ADR-0015)
 into the live `cmd_vel` path. It subscribes to `/scan`, forwards each scan to the **Taj
-service** — a thin HTTP sidecar over the real `kirra-taj` crate
-(`cargo run -p kirra-mick --example taj_service`, listens on `:8101`) — and publishes the
-**assured-clear-distance speed cap** (the speed from which the robot can still stop within
-the clear distance ahead, RSS Rule 4 / the ADR-0014 "lidar safety buffer").
+service** — a thin HTTP sidecar over the real `kirra-taj` crate (the `taj_service` binary,
+`:8101`) — and publishes the **assured-clear-distance speed cap** (the speed from which the
+robot can still stop within the clear distance ahead, RSS Rule 4 / the ADR-0014 "lidar
+safety buffer"). The launch starts the Rust sidecars (Occy planner `:8100` + Taj `:8101`)
+itself via `ExecuteProcess` — no separate terminal — so a single `ros2 launch` brings up the
+whole governed stack on the Orin (single-box). They respawn on a transient crash; the
+interceptor fails closed meanwhile.
 
 The `cmd_vel_interceptor` applies that cap to the proposed forward speed **before** the
 KIRRA governor: Taj *tightens* the envelope, the governor still *bounds* the result. It is
@@ -30,13 +33,26 @@ tested in `test/test_perception_cap.py`):
 /cmd_vel_raw → cmd_vel_interceptor [apply cap, then KIRRA /actuator/motion/command] → /cmd_vel
 ```
 
-Enable it:
+Enable it (the launch builds nothing — build the sidecars once, then launch starts them):
 
 ```bash
-cargo run -p kirra-mick --example taj_service        # start the Taj sidecar (:8101)
+# build the Rust sidecars once (or run scripts/orin_bringup.sh)
+cargo build --release -p kirra-mick --example planner_service --example taj_service
+
+# one launch brings up the sidecars + the ROS safety nodes
 ros2 launch kirra_safety kirra_with_robot.launch.py \
     kirra_token:=$KIRRA_ADMIN_TOKEN use_perception_cap:=true
 ```
+
+Launch arguments that control the folded-in sidecars:
+
+| arg | default | meaning |
+|---|---|---|
+| `start_sidecars` | `true` | start the Rust sidecars from this launch. Set **`false`** if they're already running (e.g. `scripts/orin_bringup.sh --serve`) to avoid double-binding the ports. |
+| `start_planner_service` | `true` | start the Occy planner sidecar (`:8100`). |
+| `use_perception_cap` | `false` | enable the Taj cap; also gates the Taj sidecar + `perception_governor`. |
+| `sidecar_dir` | `~/kirra-runtime-sdk/target/release/examples` | where the `planner_service`/`taj_service` binaries are (or `KIRRA_SIDECAR_DIR`). |
+| `planner_addr` / `taj_addr` | `127.0.0.1:8100` / `:8101` | sidecar bind addresses (`taj_addr` must match `taj_url`). |
 
 ## Quick Start
 

--- a/ros2_ws/src/kirra_safety/README.md
+++ b/ros2_ws/src/kirra_safety/README.md
@@ -2,10 +2,11 @@
 
 ROS2 safety interlock package for the Kirra runtime legitimacy engine.
 
-Provides four nodes that enforce kinematic contracts, derive a perception speed cap, monitor sensor health, and gate motion commands based on fleet posture:
+Provides the nodes that enforce kinematic contracts, derive a perception speed cap, drive the robot to a goal, monitor sensor health, and gate motion commands based on fleet posture:
 
 - **cmd_vel_interceptor** — intercepts `/cmd_vel`, enforces via Kirra, publishes to `/cmd_vel_safe`
 - **perception_governor** — turns `/scan` into Taj's corridor and an assured-clear-distance (ACD) speed cap on `/kirra/perception_speed_cap` (see below)
+- **occy_doer** — the DOER: drives the robot to a `/goal_pose` using Occy + Taj + KIRRA, publishing proposals to `/cmd_vel_raw` (see [`docs/testing/OCCY_DOER_BRIDGE.md`](../../../../docs/testing/OCCY_DOER_BRIDGE.md))
 - **sensor_monitor** — reports LiDAR, IMU, camera, and odometry health to Kirra
 - **posture_subscriber** — bridges the Kirra SSE posture stream to ROS2 topics and triggers emergency stops on `LockedOut` transitions
 

--- a/ros2_ws/src/kirra_safety/README.md
+++ b/ros2_ws/src/kirra_safety/README.md
@@ -2,11 +2,41 @@
 
 ROS2 safety interlock package for the Kirra runtime legitimacy engine.
 
-Provides three nodes that enforce kinematic contracts, monitor sensor health, and gate motion commands based on fleet posture:
+Provides four nodes that enforce kinematic contracts, derive a perception speed cap, monitor sensor health, and gate motion commands based on fleet posture:
 
 - **cmd_vel_interceptor** — intercepts `/cmd_vel`, enforces via Kirra, publishes to `/cmd_vel_safe`
+- **perception_governor** — turns `/scan` into Taj's corridor and an assured-clear-distance (ACD) speed cap on `/kirra/perception_speed_cap` (see below)
 - **sensor_monitor** — reports LiDAR, IMU, camera, and odometry health to Kirra
 - **posture_subscriber** — bridges the Kirra SSE posture stream to ROS2 topics and triggers emergency stops on `LockedOut` transitions
+
+## Taj corridor → cmd_vel speed cap (opt-in)
+
+The `perception_governor` node wires **Taj** (the geometric perception layer, ADR-0015)
+into the live `cmd_vel` path. It subscribes to `/scan`, forwards each scan to the **Taj
+service** — a thin HTTP sidecar over the real `kirra-taj` crate
+(`cargo run -p kirra-mick --example taj_service`, listens on `:8101`) — and publishes the
+**assured-clear-distance speed cap** (the speed from which the robot can still stop within
+the clear distance ahead, RSS Rule 4 / the ADR-0014 "lidar safety buffer").
+
+The `cmd_vel_interceptor` applies that cap to the proposed forward speed **before** the
+KIRRA governor: Taj *tightens* the envelope, the governor still *bounds* the result. It is
+opt-in (`use_perception_cap`, default off → byte-identical prior path) and **fail-closed** —
+a stale/absent cap or an unhealthy corridor holds the robot (the clamp is pure and unit
+tested in `test/test_perception_cap.py`):
+
+```
+/scan → perception_governor → taj_service (kirra-taj) → /kirra/perception_speed_cap
+                                                              │
+/cmd_vel_raw → cmd_vel_interceptor [apply cap, then KIRRA /actuator/motion/command] → /cmd_vel
+```
+
+Enable it:
+
+```bash
+cargo run -p kirra-mick --example taj_service        # start the Taj sidecar (:8101)
+ros2 launch kirra_safety kirra_with_robot.launch.py \
+    kirra_token:=$KIRRA_ADMIN_TOKEN use_perception_cap:=true
+```
 
 ## Quick Start
 

--- a/ros2_ws/src/kirra_safety/README.md
+++ b/ros2_ws/src/kirra_safety/README.md
@@ -63,6 +63,18 @@ source install/setup.bash
 ros2 launch kirra_safety kirra_with_robot.launch.py kirra_token:=$KIRRA_ADMIN_TOKEN
 ```
 
+## Gazebo demo — watch Taj + KIRRA stop a robot
+
+`kirra_gazebo_demo.launch.py` drives a simulated robot toward a wall while a naive doer
+keeps commanding it forward; Taj's corridor cap + the governor brake it to a controlled
+stop. One command brings up the verifier, sidecars, safety nodes, Gazebo, robot, and doer.
+See [`docs/testing/GAZEBO_ON_ORIN.md`](../../../../docs/testing/GAZEBO_ON_ORIN.md).
+
+```bash
+export KIRRA_ADMIN_TOKEN=test-token KIRRA_SUPERVISOR_RESET_KEY=test-reset-key
+ros2 launch kirra_safety kirra_gazebo_demo.launch.py
+```
+
 ## Full Documentation
 
 See [`docs/ros2_interlock.md`](../../../../docs/ros2_interlock.md) for:

--- a/ros2_ws/src/kirra_safety/config/kirra_params.yaml
+++ b/ros2_ws/src/kirra_safety/config/kirra_params.yaml
@@ -11,6 +11,22 @@ cmd_vel_interceptor:
     posture_topic: "/kirra/fleet_posture"
     timeout_ms: 50               # Kirra API timeout (ms) -- fail-closed on timeout
     fallback_on_timeout: "stop"  # "stop" (fail-closed) or "passthrough" (degraded mode)
+    use_perception_cap: false    # opt-in: apply Taj's assured-clear-distance cap before the governor
+    perception_cap_topic: "/kirra/perception_speed_cap"
+    perception_cap_stale_ms: 300 # cap older than this is a perception fault -> fail-closed stop
+
+perception_governor:
+  ros__parameters:
+    taj_url: "http://localhost:8101"   # the Taj perception sidecar (kirra-mick example taj_service)
+    scan_topic: "/scan"
+    cap_topic: "/kirra/perception_speed_cap"
+    health_topic: "/kirra/perception_health"
+    timeout_ms: 40
+    forward_extent_m: 8.0        # Taj geometric horizon (m)
+    decel_mps2: 1.5              # assumed comfortable brake for the ACD cap
+    margin_m: 0.4                # standoff distance (matches the checker's lateral margin)
+    lane_half_m: 0.6             # in-lane half-width for object gating (m)
+    confidence_floor: 0.5        # corridor confidence below this -> unhealthy -> 0.0 cap
 
 sensor_monitor:
   ros__parameters:

--- a/ros2_ws/src/kirra_safety/kirra_safety/cmd_vel_interceptor.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/cmd_vel_interceptor.py
@@ -23,9 +23,10 @@ import threading
 import rclpy
 from rclpy.node import Node
 from geometry_msgs.msg import Twist
-from std_msgs.msg import String
+from std_msgs.msg import String, Float64
 
 from kirra_safety.enforcement_decision import decide_enforcement, Forward
+from kirra_safety.perception_cap import apply_perception_cap, DISABLED
 
 try:
     import requests
@@ -53,6 +54,12 @@ class CmdVelInterceptor(Node):
         self.declare_parameter('posture_topic', '/kirra/fleet_posture')
         self.declare_parameter('timeout_ms', 50)
         self.declare_parameter('fallback_on_timeout', 'stop')
+        # Taj perception derate (opt-in). When enabled, Taj's assured-clear-distance cap
+        # (published by the perception_governor node) tightens the proposed forward speed
+        # BEFORE the governor — Taj tightens, KIRRA bounds. Default OFF → byte-identical path.
+        self.declare_parameter('use_perception_cap', False)
+        self.declare_parameter('perception_cap_topic', '/kirra/perception_speed_cap')
+        self.declare_parameter('perception_cap_stale_ms', 300)
 
         self._kirra_url = self.get_parameter('kirra_url').value
         self._kirra_token = self.get_parameter('kirra_token').value
@@ -61,6 +68,8 @@ class CmdVelInterceptor(Node):
         self._max_speed_mps = self.get_parameter('max_speed_mps').value
         self._timeout_s = self.get_parameter('timeout_ms').value / 1000.0
         self._fallback = self.get_parameter('fallback_on_timeout').value
+        self._use_perception_cap = self.get_parameter('use_perception_cap').value
+        self._cap_stale_s = self.get_parameter('perception_cap_stale_ms').value / 1000.0
 
         input_topic = self.get_parameter('input_topic').value
         output_topic = self.get_parameter('output_topic').value
@@ -71,6 +80,9 @@ class CmdVelInterceptor(Node):
         self._current_steering_deg = 0.0
         self._last_cmd_time = time.monotonic()
         self._lock = threading.Lock()
+        # Latest Taj perception cap (m/s) and the monotonic time it arrived.
+        self._perception_cap = None
+        self._perception_cap_time = None
 
         # Publishers
         self._pub_safe = self.create_publisher(Twist, output_topic, 10)
@@ -83,6 +95,13 @@ class CmdVelInterceptor(Node):
             self._on_cmd_vel,
             10,
         )
+        if self._use_perception_cap:
+            self._sub_cap = self.create_subscription(
+                Float64,
+                self.get_parameter('perception_cap_topic').value,
+                self._on_perception_cap,
+                10,
+            )
 
         if not REQUESTS_AVAILABLE:
             self.get_logger().error(
@@ -142,12 +161,36 @@ class CmdVelInterceptor(Node):
             'current_steering_angle_deg': current_s,
         }
 
+    def _on_perception_cap(self, msg: Float64):
+        with self._lock:
+            self._perception_cap = float(msg.data)
+            self._perception_cap_time = time.monotonic()
+
+    def _apply_perception_cap(self, proposed: dict) -> str:
+        """Tighten the proposed forward speed to Taj's ACD cap, fail-closed. Returns a
+        short reason suffix for the action log ('' when the derate is off)."""
+        if not self._use_perception_cap:
+            return ''
+        with self._lock:
+            cap = self._perception_cap
+            cap_time = self._perception_cap_time
+        cap_age = (time.monotonic() - cap_time) if cap_time is not None else None
+        capped_v, reason = apply_perception_cap(
+            proposed['linear_velocity_mps'], cap, cap_age,
+            enabled=True, stale_s=self._cap_stale_s,
+        )
+        proposed['linear_velocity_mps'] = capped_v
+        return '' if reason == DISABLED else f'|{reason}'
+
     def _on_cmd_vel(self, msg: Twist):
         if not REQUESTS_AVAILABLE:
             self._publish_stop('NO_REQUESTS_LIB')
             return
 
         proposed = self._twist_to_proposed_command(msg)
+        # Taj tightens the proposed speed BEFORE the governor (perception derate); the
+        # governor then bounds whatever survives. Fail-closed on a stale/absent cap.
+        cap_suffix = self._apply_perception_cap(proposed)
 
         try:
             resp = requests.post(
@@ -175,7 +218,7 @@ class CmdVelInterceptor(Node):
                     safe_twist = self._build_safe_twist(
                         msg, decision.enforced_v, decision.enforced_s)
                     self._pub_safe.publish(safe_twist)
-                    self._publish_action(f'{decision.action}:v={decision.enforced_v:.2f}')
+                    self._publish_action(f'{decision.action}:v={decision.enforced_v:.2f}{cap_suffix}')
 
                     with self._lock:
                         self._current_velocity_mps = decision.enforced_v

--- a/ros2_ws/src/kirra_safety/kirra_safety/doer_commander.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/doer_commander.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Kirra demo "doer" — the untrusted proposer.
+
+Publishes a constant forward Twist on /cmd_vel_raw (the planner's PROPOSAL). It is
+deliberately naive: it keeps commanding the robot forward into the wall and never brakes.
+KIRRA (the governor) plus Taj (the corridor speed cap) are what stop the robot — the doer
+is never trusted to. This is the doer-checker thesis made watchable in Gazebo.
+
+Topic flow:
+  doer_commander → /cmd_vel_raw → cmd_vel_interceptor [Taj cap + KIRRA] → /cmd_vel → robot
+"""
+
+import rclpy
+from rclpy.node import Node
+from geometry_msgs.msg import Twist
+
+
+class DoerCommander(Node):
+    def __init__(self):
+        super().__init__('doer_commander')
+        self.declare_parameter('cmd_topic', '/cmd_vel_raw')
+        self.declare_parameter('forward_speed_mps', 1.2)  # naive constant forward command
+        self.declare_parameter('publish_hz', 10.0)
+
+        self._speed = self.get_parameter('forward_speed_mps').value
+        topic = self.get_parameter('cmd_topic').value
+        hz = self.get_parameter('publish_hz').value
+
+        self._pub = self.create_publisher(Twist, topic, 10)
+        self.create_timer(1.0 / hz, self._tick)
+        self.get_logger().info(
+            f'doer_commander: proposing {self._speed:.2f} m/s forward on {topic} '
+            f'(never brakes — KIRRA + Taj stop the robot)'
+        )
+
+    def _tick(self):
+        msg = Twist()
+        msg.linear.x = float(self._speed)
+        self._pub.publish(msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = DoerCommander()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2_ws/src/kirra_safety/kirra_safety/doer_core.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/doer_core.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Pure geometry/decision helpers for the Occy doer bridge (occy_doer).
+
+No ROS, no HTTP — just the math that turns a goal + Occy's KIRRA-validated trajectory
+into a `/cmd_vel_raw` Twist. Kept pure so the safety-relevant conversion is unit
+testable standalone (the same discipline as perception_cap / enforcement_decision).
+
+Frames: the robot base frame has +X forward, +Y left (ROS REP-103). The planner runs in
+this base frame (ego at the origin, heading 0); the goal is transformed into it here.
+"""
+
+import math
+
+
+def yaw_from_quaternion(x, y, z, w):
+    """Planar yaw (rad) from a quaternion (full formula; robust for non-planar tilt)."""
+    siny_cosp = 2.0 * (w * z + x * y)
+    cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
+    return math.atan2(siny_cosp, cosy_cosp)
+
+
+def goal_to_base(robot_x, robot_y, robot_yaw, goal_x, goal_y):
+    """Transform a goal from the odom/world frame into the robot base frame.
+
+    Returns (gx, gy): the goal expressed with the robot at the origin facing +X.
+    """
+    dx = goal_x - robot_x
+    dy = goal_y - robot_y
+    c, s = math.cos(-robot_yaw), math.sin(-robot_yaw)
+    return c * dx - s * dy, s * dx + c * dy
+
+
+def goal_reached(goal_base_x, goal_base_y, tolerance_m):
+    """True once the goal (in base frame) is within tolerance of the robot."""
+    return math.hypot(goal_base_x, goal_base_y) <= tolerance_m
+
+
+def extend_corridor_back(left, right, back_m):
+    """Prepend a straight back-extension to each corridor polyline.
+
+    Taj reports only FORWARD free space (x >= 0 from the lidar), but the robot's footprint
+    extends behind the sensor at the origin. Without this, the checker sees the rear of the
+    footprint outside the corridor and MRCs every plan. The area just behind the robot —
+    where it already sits — is assumed clear, so we extend each boundary straight back.
+    """
+    def ext(poly):
+        if not poly:
+            return poly
+        x0, y0 = poly[0][0], poly[0][1]
+        return [[x0 - back_m, y0]] + [list(p) for p in poly]
+    return ext(left), ext(right)
+
+
+def _lookahead_point(traj, lookahead_m):
+    """The first trajectory point at/after `lookahead_m` of straight-line distance from
+    the ego (base-frame origin); falls back to the last point. `traj` is a list of dicts
+    with at least x, y (and optionally v)."""
+    for p in traj:
+        if math.hypot(p["x"], p["y"]) >= lookahead_m:
+            return p
+    return traj[-1] if traj else None
+
+
+def trajectory_to_twist(traj, lookahead_m, max_v, max_w):
+    """Pure-pursuit conversion of a base-frame trajectory to (v, w).
+
+    Curvature to the lookahead point (lx, ly): kappa = 2*ly / (lx^2 + ly^2); w = v*kappa.
+    +Y (left) → +w (CCW), matching ROS. v is the planned speed at the lookahead point,
+    capped at max_v; w is clamped to +/- max_w. Empty trajectory → (0, 0).
+    """
+    pt = _lookahead_point(traj, lookahead_m)
+    if pt is None:
+        return 0.0, 0.0
+    lx, ly = pt["x"], pt["y"]
+    dist2 = lx * lx + ly * ly
+    v = min(abs(pt.get("v", max_v)), max_v)
+    if dist2 < 1e-6:
+        return 0.0, 0.0
+    if lx <= 0.0:
+        # Lookahead is at/behind the axle — rotate in place toward it rather than lunging.
+        w = math.copysign(max_w, ly if ly != 0.0 else 1.0)
+        return 0.0, w
+    kappa = 2.0 * ly / dist2
+    w = max(-max_w, min(max_w, v * kappa))
+    return v, w
+
+
+def decide(plan_json, lookahead_m, max_v, max_w):
+    """Turn an Occy /plan response into (v, w, reason).
+
+    HOLD (0, 0) unless Occy proposed motion AND KIRRA's slow-loop verdict admits it
+    (Accept|Clamp). A SafeStop proposal, an MRC/refused verdict, or an empty trajectory
+    all hold — the doer never commands motion the checker already refused. The downstream
+    cmd_vel_interceptor re-checks every command anyway (fast-loop KIRRA + Taj cap).
+    """
+    kind = plan_json.get("kind")
+    verdict = plan_json.get("verdict")
+    traj = plan_json.get("trajectory") or []
+    if kind == "SafeStop" or verdict not in ("Accept", "Clamp") or not traj:
+        return 0.0, 0.0, f"HOLD:{kind}/{verdict}"
+    v, w = trajectory_to_twist(traj, lookahead_m, max_v, max_w)
+    return v, w, f"DRIVE:{verdict}"

--- a/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Occy doer bridge — the planner that decides where to go (the DOER).
+
+This is the missing piece that makes real Occy drive the robot to a goal, governed by
+KIRRA. Each tick it:
+  1. reads the robot pose + speed (/odom) and the current goal (/goal_pose, e.g. RViz
+     "2D Goal Pose", or an LLM/Mick publisher),
+  2. POSTs the latest lidar scan (/scan) to the Taj sidecar → the geometric corridor
+     (left/right polylines) + objects,
+  3. POSTs {ego, goal-in-base, Taj corridor, objects} to the Occy planner sidecar
+     (/plan) → a KIRRA-validated trajectory,
+  4. converts that trajectory to a Twist (pure pursuit) and publishes it on
+     /cmd_vel_raw — the PROPOSAL.
+
+The proposal then flows through the cmd_vel_interceptor (Taj speed cap + the KIRRA
+kinematic governor) before reaching the wheels, so Occy only PROPOSES and KIRRA still
+DISPOSES — twice (the planner runs the slow-loop checker; the interceptor runs the
+fast-loop one). The doer is fail-soft: no goal, a stale scan, a service error, or a
+refused plan all publish a zero Twist (hold).
+
+  doer (this node) ─/cmd_vel_raw→ cmd_vel_interceptor [Taj cap + KIRRA] ─/cmd_vel→ wheels
+
+Where Parko fits (Phase 2): when the Parko ML detector is up, its semantic objects feed
+the same `objects` list (richer than Taj's geometric clusters) — this node's seam is
+unchanged. Mick (the LLM) fits by publishing the goal/intent instead of RViz.
+"""
+
+import time
+
+import rclpy
+from rclpy.node import Node
+from geometry_msgs.msg import Twist, PoseStamped
+from nav_msgs.msg import Odometry
+from sensor_msgs.msg import LaserScan
+
+from kirra_safety.doer_core import (
+    yaw_from_quaternion, goal_to_base, goal_reached, decide, extend_corridor_back,
+)
+
+try:
+    import requests
+    REQUESTS_AVAILABLE = True
+except ImportError:
+    REQUESTS_AVAILABLE = False
+
+ZERO = Twist()
+
+
+class OccyDoer(Node):
+    def __init__(self):
+        super().__init__('occy_doer')
+        self.declare_parameter('taj_url', 'http://localhost:8101')
+        self.declare_parameter('planner_url', 'http://localhost:8100')
+        self.declare_parameter('odom_topic', '/odom')
+        self.declare_parameter('goal_topic', '/goal_pose')
+        self.declare_parameter('scan_topic', '/scan')
+        self.declare_parameter('cmd_topic', '/cmd_vel_raw')
+        self.declare_parameter('plan_hz', 5.0)
+        self.declare_parameter('cruise_speed_mps', 1.2)
+        self.declare_parameter('max_speed_mps', 1.2)
+        self.declare_parameter('max_yaw_rate_rps', 1.5)
+        self.declare_parameter('lookahead_m', 0.8)
+        self.declare_parameter('goal_tolerance_m', 0.25)
+        self.declare_parameter('forward_extent_m', 8.0)
+        self.declare_parameter('scan_stale_s', 0.5)
+        self.declare_parameter('http_timeout_ms', 60)
+        # The robot's footprint/kinematics for the CHECKER. A small differential robot MUST
+        # pass these, or the planner's default urban-car (4.8 m) footprint can't fit a
+        # robot-scale corridor and KIRRA MRCs every plan. Defaults: a Rosmaster-class robot.
+        self.declare_parameter('wheelbase_m', 0.2)
+        self.declare_parameter('half_length_m', 0.18)
+        self.declare_parameter('half_width_m', 0.15)
+        self.declare_parameter('max_steering_deg', 30.0)
+        # Extend the corridor behind the robot so its footprint (which sits behind the lidar
+        # at the origin) is contained — Taj only reports forward free space.
+        self.declare_parameter('corridor_back_m', 0.5)
+
+        self._taj = self.get_parameter('taj_url').value.rstrip('/')
+        self._planner = self.get_parameter('planner_url').value.rstrip('/')
+        self._cruise = self.get_parameter('cruise_speed_mps').value
+        self._max_v = self.get_parameter('max_speed_mps').value
+        self._max_w = self.get_parameter('max_yaw_rate_rps').value
+        self._lookahead = self.get_parameter('lookahead_m').value
+        self._goal_tol = self.get_parameter('goal_tolerance_m').value
+        self._extent = self.get_parameter('forward_extent_m').value
+        self._scan_stale_s = self.get_parameter('scan_stale_s').value
+        self._timeout_s = self.get_parameter('http_timeout_ms').value / 1000.0
+        self._back_m = self.get_parameter('corridor_back_m').value
+        self._vehicle = {
+            'wheelbase_m': self.get_parameter('wheelbase_m').value,
+            'half_length_m': self.get_parameter('half_length_m').value,
+            'half_width_m': self.get_parameter('half_width_m').value,
+            'max_speed_mps': self.get_parameter('max_speed_mps').value,
+            'max_steering_deg': self.get_parameter('max_steering_deg').value,
+        }
+
+        self._pose = None         # (x, y, yaw, speed)
+        self._goal = None         # (x, y) in the odom/world frame
+        self._scan = None         # (LaserScan, monotonic_recv_time)
+
+        self._pub = self.create_publisher(Twist, self.get_parameter('cmd_topic').value, 10)
+        self.create_subscription(Odometry, self.get_parameter('odom_topic').value, self._on_odom, 20)
+        self.create_subscription(PoseStamped, self.get_parameter('goal_topic').value, self._on_goal, 10)
+        self.create_subscription(LaserScan, self.get_parameter('scan_topic').value, self._on_scan, 10)
+        self.create_timer(1.0 / self.get_parameter('plan_hz').value, self._tick)
+
+        if not REQUESTS_AVAILABLE:
+            self.get_logger().error('python3-requests missing — doer holds (publishes zero).')
+        self.get_logger().info(
+            f'occy_doer: Taj({self._taj}) + Occy({self._planner}) -> '
+            f'{self.get_parameter("cmd_topic").value}. Send a goal on '
+            f'{self.get_parameter("goal_topic").value} (RViz "2D Goal Pose").'
+        )
+
+    # --- subscriptions ------------------------------------------------------
+    def _on_odom(self, msg: Odometry):
+        p, q = msg.pose.pose.position, msg.pose.pose.orientation
+        yaw = yaw_from_quaternion(q.x, q.y, q.z, q.w)
+        speed = msg.twist.twist.linear.x
+        self._pose = (p.x, p.y, yaw, speed)
+
+    def _on_goal(self, msg: PoseStamped):
+        self._goal = (msg.pose.position.x, msg.pose.position.y)
+        self.get_logger().info(f'new goal: ({self._goal[0]:.2f}, {self._goal[1]:.2f})')
+
+    def _on_scan(self, msg: LaserScan):
+        self._scan = (msg, time.monotonic())
+
+    # --- the doer loop ------------------------------------------------------
+    def _hold(self, why: str):
+        self._pub.publish(ZERO)
+        self.get_logger().debug(f'hold: {why}')
+
+    def _tick(self):
+        if not REQUESTS_AVAILABLE:
+            return self._hold('no-requests')
+        if self._pose is None or self._goal is None:
+            return self._hold('awaiting pose/goal')
+        if self._scan is None or (time.monotonic() - self._scan[1]) > self._scan_stale_s:
+            return self._hold('stale-scan')  # fail-soft: no fresh perception → hold
+
+        rx, ry, ryaw, speed = self._pose
+        gx, gy = goal_to_base(rx, ry, ryaw, self._goal[0], self._goal[1])
+        if goal_reached(gx, gy, self._goal_tol):
+            return self._hold('goal-reached')
+
+        scan = self._scan[0]
+        try:
+            taj = requests.post(f'{self._taj}/perception', timeout=self._timeout_s, json={
+                'angle_min_rad': float(scan.angle_min),
+                'angle_increment_rad': float(scan.angle_increment),
+                'range_min_m': float(scan.range_min),
+                'range_max_m': float(scan.range_max),
+                'ranges': [float(r) for r in scan.ranges],
+                'stamp_ms': 0, 'forward_extent_m': self._extent,
+            }).json()
+
+            # Extend the Taj corridor behind the robot (footprint containment) and tell the
+            # checker the robot's real size, so KIRRA judges a robot — not a 4.8 m car.
+            left, right = extend_corridor_back(taj.get('left', []), taj.get('right', []), self._back_m)
+            plan = requests.post(f'{self._planner}/plan', timeout=self._timeout_s, json={
+                'ego': {'x': 0.0, 'y': 0.0, 'heading': 0.0, 'speed': float(speed)},
+                'goal': {'x': gx, 'y': gy},
+                'cruise': self._cruise,
+                'left': left,
+                'right': right,
+                'objects': taj.get('objects', []),
+                'vehicle': self._vehicle,
+            }).json()
+        except Exception as e:  # noqa: BLE001 — any fault holds (fail-soft)
+            return self._hold(f'service-error:{e}')
+
+        v, w, reason = decide(plan, self._lookahead, self._max_v, self._max_w)
+        twist = Twist()
+        twist.linear.x = v
+        twist.angular.z = w
+        self._pub.publish(twist)
+        self.get_logger().debug(f'{reason}  v={v:.2f} w={w:.2f}  goal_base=({gx:.1f},{gy:.1f})')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = OccyDoer()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
@@ -68,10 +68,15 @@ class OccyDoer(Node):
         # The robot's footprint/kinematics for the CHECKER. A small differential robot MUST
         # pass these, or the planner's default urban-car (4.8 m) footprint can't fit a
         # robot-scale corridor and KIRRA MRCs every plan. Defaults: a Rosmaster-class robot.
+        self.declare_parameter('vehicle_class', 'courier')  # per-class checker profile (CONTRACT_PROFILES.md)
         self.declare_parameter('wheelbase_m', 0.2)
         self.declare_parameter('half_length_m', 0.18)
         self.declare_parameter('half_width_m', 0.15)
         self.declare_parameter('max_steering_deg', 30.0)
+        # Per-class RSS band (checker) + the doer's lateral-clearance target. Robot-scale so
+        # the small robot is judged as a robot, not a 4.8 m car. See CONTRACT_PROFILES.md.
+        self.declare_parameter('rss_lateral_alignment_tolerance_m', 0.6)
+        self.declare_parameter('lateral_clearance_target_m', 0.6)
         # Extend the corridor behind the robot so its footprint (which sits behind the lidar
         # at the origin) is contained — Taj only reports forward free space.
         self.declare_parameter('corridor_back_m', 0.5)
@@ -88,11 +93,15 @@ class OccyDoer(Node):
         self._timeout_s = self.get_parameter('http_timeout_ms').value / 1000.0
         self._back_m = self.get_parameter('corridor_back_m').value
         self._vehicle = {
+            'class': self.get_parameter('vehicle_class').value,
             'wheelbase_m': self.get_parameter('wheelbase_m').value,
             'half_length_m': self.get_parameter('half_length_m').value,
             'half_width_m': self.get_parameter('half_width_m').value,
             'max_speed_mps': self.get_parameter('max_speed_mps').value,
             'max_steering_deg': self.get_parameter('max_steering_deg').value,
+            'rss_lateral_alignment_tolerance_m':
+                self.get_parameter('rss_lateral_alignment_tolerance_m').value,
+            'lateral_clearance_target_m': self.get_parameter('lateral_clearance_target_m').value,
         }
 
         self._pose = None         # (x, y, yaw, speed)

--- a/ros2_ws/src/kirra_safety/kirra_safety/perception_cap.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/perception_cap.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Pure, fail-closed perception-cap clamp for the cmd_vel interceptor.
+
+Taj (the geometric perception layer, ADR-0015) turns the lidar scan into a drivable
+corridor and publishes an **assured-clear-distance (ACD) speed cap** — the speed from
+which the robot can still stop within the clear distance ahead. This module applies that
+cap to the doer's proposed forward speed BEFORE the command reaches the KIRRA governor:
+Taj *tightens* the envelope, the governor still *bounds* the result.
+
+It is deliberately a pure function (no ROS, no I/O) so the safety-critical clamp is unit
+testable standalone — the same discipline as `enforcement_decision.py`.
+
+Fail-closed rules (a perception fault must never let the robot speed up):
+  - `enabled` False                 → no derate at all (opt-in; byte-identical prior path).
+  - cap missing / older than `stale_s` → STOP (0.0). A silent or stale Taj is a fault.
+  - cap non-finite or negative        → STOP (0.0). A malformed cap is a fault.
+  - otherwise                          → clamp |speed| to the cap, preserving direction.
+"""
+
+import math
+
+
+# Result reasons (also used as the enforcement-action suffix for monitoring).
+DISABLED = "PERCEPTION_DISABLED"
+STALE = "PERCEPTION_STALE"
+INVALID = "PERCEPTION_INVALID"
+CAPPED = "PERCEPTION_CAP"
+PASS = "PERCEPTION_PASS"
+
+
+def apply_perception_cap(proposed_mps, cap_mps, cap_age_s, enabled, stale_s):
+    """
+    Return (effective_speed_mps, reason).
+
+    `proposed_mps`  the doer's proposed forward speed (signed; sign = direction).
+    `cap_mps`       the latest ACD cap from Taj, or None if none received yet.
+    `cap_age_s`     wall-clock age of that cap in seconds, or None.
+    `enabled`       whether the perception derate is active (opt-in).
+    `stale_s`       max cap age before it is treated as a perception fault.
+    """
+    if not enabled:
+        return proposed_mps, DISABLED
+
+    # Missing or stale cap → the perception feed is not trustworthy → fail closed.
+    if cap_mps is None or cap_age_s is None or cap_age_s > stale_s:
+        return 0.0, STALE
+
+    # Malformed cap → fail closed (never trust a non-finite / negative bound).
+    if not math.isfinite(cap_mps) or cap_mps < 0.0:
+        return 0.0, INVALID
+
+    sign = 1.0 if proposed_mps >= 0.0 else -1.0
+    magnitude = min(abs(proposed_mps), cap_mps)
+    reason = CAPPED if magnitude < abs(proposed_mps) else PASS
+    return sign * magnitude, reason

--- a/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Kirra Perception Governor (Taj corridor -> cmd_vel speed cap)
+
+Subscribes to the robot's lidar (/scan), forwards each scan to the Taj perception
+service (a thin HTTP wrapper over the real `kirra-taj` geometric corridor), and
+publishes the resulting **assured-clear-distance (ACD) speed cap** on
+/kirra/perception_speed_cap. The cmd_vel interceptor applies that cap to the doer's
+proposed speed BEFORE the KIRRA governor — Taj tightens the envelope, KIRRA bounds.
+
+Topic flow:
+  /scan (sensor_msgs/LaserScan) [FROM lidar]
+      |
+  Taj service  POST /perception (HTTP)   -> corridor health + ACD speed cap
+      |
+  /kirra/perception_speed_cap (std_msgs/Float64) [TO cmd_vel interceptor]
+  /kirra/perception_health    (std_msgs/String)  [FOR monitoring]
+
+Fail-closed: a Taj-service error/timeout, or an unhealthy corridor, publishes a 0.0
+cap (the MRC floor). The interceptor additionally fails closed if this topic goes
+stale (see perception_cap.apply_perception_cap), so a crashed governor also stops the
+robot rather than freezing the last cap.
+"""
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import LaserScan
+from std_msgs.msg import Float64, String
+
+try:
+    import requests
+    REQUESTS_AVAILABLE = True
+except ImportError:
+    REQUESTS_AVAILABLE = False
+
+
+class PerceptionGovernor(Node):
+    def __init__(self):
+        super().__init__('perception_governor')
+
+        self.declare_parameter('taj_url', 'http://localhost:8101')
+        self.declare_parameter('scan_topic', '/scan')
+        self.declare_parameter('cap_topic', '/kirra/perception_speed_cap')
+        self.declare_parameter('health_topic', '/kirra/perception_health')
+        self.declare_parameter('timeout_ms', 40)
+        # ACD parameters (forwarded to the Taj service; conservative R2 defaults).
+        self.declare_parameter('forward_extent_m', 8.0)   # Taj geometric horizon
+        self.declare_parameter('decel_mps2', 1.5)         # assumed comfortable brake
+        self.declare_parameter('margin_m', 0.4)           # standoff (matches the checker margin)
+        self.declare_parameter('lane_half_m', 0.6)        # in-lane half-width for object gating
+        self.declare_parameter('confidence_floor', 0.5)   # below this → unhealthy → 0.0 cap
+
+        self._taj_url = self.get_parameter('taj_url').value
+        self._timeout_s = self.get_parameter('timeout_ms').value / 1000.0
+        self._extent = self.get_parameter('forward_extent_m').value
+        self._decel = self.get_parameter('decel_mps2').value
+        self._margin = self.get_parameter('margin_m').value
+        self._lane_half = self.get_parameter('lane_half_m').value
+        self._floor = self.get_parameter('confidence_floor').value
+
+        scan_topic = self.get_parameter('scan_topic').value
+        self._pub_cap = self.create_publisher(Float64, self.get_parameter('cap_topic').value, 10)
+        self._pub_health = self.create_publisher(String, self.get_parameter('health_topic').value, 10)
+        self.create_subscription(LaserScan, scan_topic, self._on_scan, 10)
+
+        if not REQUESTS_AVAILABLE:
+            self.get_logger().error(
+                'python3-requests not installed. Perception cap disabled — publishing 0.0 '
+                '(fail-closed): the interceptor will hold until Taj caps arrive.'
+            )
+
+        self.get_logger().info(
+            f'Kirra perception governor started: {scan_topic} -> Taj({self._taj_url}) '
+            f'-> {self.get_parameter("cap_topic").value}'
+        )
+
+    def _publish(self, cap_mps: float, health: str):
+        self._pub_cap.publish(Float64(data=float(cap_mps)))
+        self._pub_health.publish(String(data=health))
+
+    def _on_scan(self, msg: LaserScan):
+        if not REQUESTS_AVAILABLE:
+            self._publish(0.0, 'NO_REQUESTS_LIB')
+            return
+
+        # ROS2 LaserScan stamp -> ms; the Taj service is stateless on time (we process at
+        # the scan stamp; wall-clock staleness is enforced downstream on the cap topic).
+        stamp = msg.header.stamp
+        stamp_ms = int(stamp.sec * 1000 + stamp.nanosec / 1_000_000)
+        body = {
+            'angle_min_rad': float(msg.angle_min),
+            'angle_increment_rad': float(msg.angle_increment),
+            'range_min_m': float(msg.range_min),
+            'range_max_m': float(msg.range_max),
+            'ranges': [float(r) for r in msg.ranges],
+            'stamp_ms': stamp_ms,
+            'forward_extent_m': self._extent,
+            'decel_mps2': self._decel,
+            'margin_m': self._margin,
+            'lane_half_m': self._lane_half,
+            'confidence_floor': self._floor,
+        }
+        try:
+            resp = requests.post(
+                f'{self._taj_url}/perception', json=body, timeout=self._timeout_s)
+            if resp.status_code != 200:
+                self._publish(0.0, f'TAJ_HTTP_{resp.status_code}')
+                return
+            data = resp.json()
+            cap = data.get('speed_cap_mps')
+            if cap is None or not isinstance(cap, (int, float)):
+                self._publish(0.0, 'TAJ_MALFORMED')
+                return
+            healthy = bool(data.get('healthy', False))
+            clear = data.get('clear_distance_m', float('nan'))
+            self._publish(
+                cap,
+                f'{"OK" if healthy else "UNHEALTHY"}:clear={clear:.1f}m:cap={cap:.2f}',
+            )
+        except requests.Timeout:
+            self._publish(0.0, 'TAJ_TIMEOUT')
+        except requests.ConnectionError:
+            self._publish(0.0, 'TAJ_UNREACHABLE')
+        except Exception as e:  # noqa: BLE001 - fail closed on any fault
+            self.get_logger().error(f'perception governor error: {e}')
+            self._publish(0.0, 'TAJ_ERROR')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = PerceptionGovernor()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2_ws/src/kirra_safety/launch/kirra_gazebo_demo.launch.py
+++ b/ros2_ws/src/kirra_safety/launch/kirra_gazebo_demo.launch.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Watch Taj + KIRRA stop a robot in Gazebo (single-box, runs on the Orin).
+
+Brings up, in one command:
+  - Gazebo Classic with a short corridor + an end wall (kirra_corridor.world),
+  - a differential-drive robot with a forward 180-degree lidar (kirra_bot.urdf),
+  - the Kirra safety stack (cmd_vel_interceptor + perception_governor + the Rust
+    planner/Taj sidecars), via the shared kirra_with_robot.launch.py,
+  - the "doer" (doer_commander) naively commanding the robot forward,
+  - optionally the KIRRA verifier itself (start_verifier).
+
+The robot drives toward the wall; Taj's corridor sees the wall as a shrinking clear
+distance and publishes an assured-clear-distance speed cap; the interceptor applies it
+before the governor (Taj tightens, KIRRA bounds); the robot brakes to a controlled stop
+before the wall — even though the doer keeps commanding forward.
+
+Run (verifier secrets in the env):
+  export KIRRA_ADMIN_TOKEN=... KIRRA_SUPERVISOR_RESET_KEY=...
+  ros2 launch kirra_safety kirra_gazebo_demo.launch.py
+
+Prereqs on the Orin: ROS 2 + gazebo_ros_pkgs (Gazebo Classic), and the Rust sidecars
++ verifier built once (cargo build --release ... / scripts/orin_bringup.sh).
+"""
+
+import os
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription,
+)
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+HOME = os.path.expanduser('~')
+DEFAULT_BUILD_DIR = os.environ.get(
+    'KIRRA_BUILD_DIR', os.path.join(HOME, 'kirra-runtime-sdk', 'target', 'release'))
+
+
+def generate_launch_description():
+    pkg = FindPackageShare('kirra_safety')
+
+    kirra_token_arg = DeclareLaunchArgument(
+        'kirra_token', default_value=os.environ.get('KIRRA_ADMIN_TOKEN', ''),
+        description='Kirra admin token (defaults to $KIRRA_ADMIN_TOKEN).')
+    world_arg = DeclareLaunchArgument(
+        'world', default_value=PathJoinSubstitution([pkg, 'worlds', 'kirra_corridor.world']),
+        description='Gazebo world file.')
+    forward_speed_arg = DeclareLaunchArgument(
+        'forward_speed_mps', default_value='1.2',
+        description="The doer's naive constant forward command (m/s).")
+    start_verifier_arg = DeclareLaunchArgument(
+        'start_verifier', default_value='true',
+        description='Start the KIRRA verifier from this launch (needs KIRRA_ADMIN_TOKEN + '
+                    'KIRRA_SUPERVISOR_RESET_KEY in the env). Set false if it is already up.')
+    verifier_bin_arg = DeclareLaunchArgument(
+        'verifier_bin', default_value=os.path.join(DEFAULT_BUILD_DIR, 'kirra_verifier_service'),
+        description='Path to the kirra_verifier_service binary.')
+    gui_arg = DeclareLaunchArgument(
+        'gui', default_value='true', description='Run the Gazebo client GUI (false = headless).')
+
+    kirra_token = LaunchConfiguration('kirra_token')
+    world = LaunchConfiguration('world')
+    forward_speed = LaunchConfiguration('forward_speed_mps')
+    start_verifier = LaunchConfiguration('start_verifier')
+    verifier_bin = LaunchConfiguration('verifier_bin')
+    gui = LaunchConfiguration('gui')
+
+    robot_urdf = PathJoinSubstitution([pkg, 'urdf', 'kirra_bot.urdf'])
+    robot_description = ParameterValue(Command(['cat ', robot_urdf]), value_type=str)
+
+    # KIRRA verifier (optional) — the governance plane the interceptor calls. Inherits the
+    # KIRRA_* secrets from the launching shell; respawns on a transient crash.
+    verifier = ExecuteProcess(
+        name='kirra_verifier_service',
+        cmd=[verifier_bin],
+        condition=IfCondition(start_verifier),
+        respawn=True, respawn_delay=2.0, output='screen',
+    )
+
+    # Gazebo Classic with the ROS factory + init plugins (so spawn_entity works).
+    gzserver = ExecuteProcess(
+        name='gzserver',
+        cmd=['gzserver', '--verbose', '-s', 'libgazebo_ros_init.so',
+             '-s', 'libgazebo_ros_factory.so', world],
+        output='screen',
+    )
+    gzclient = ExecuteProcess(
+        name='gzclient', cmd=['gzclient'], condition=IfCondition(gui), output='screen')
+
+    # Robot state publisher (sim time) + spawn the robot into Gazebo.
+    rsp = Node(
+        package='robot_state_publisher', executable='robot_state_publisher',
+        parameters=[{'robot_description': robot_description, 'use_sim_time': True}],
+        output='screen',
+    )
+    spawn = Node(
+        package='gazebo_ros', executable='spawn_entity.py',
+        arguments=['-topic', 'robot_description', '-entity', 'kirra_bot',
+                   '-x', '0', '-y', '0', '-z', '0.1'],
+        output='screen',
+    )
+
+    # The Kirra safety stack + Rust sidecars (interceptor, perception_governor, planner,
+    # taj_service, sensor_monitor, posture_subscriber) — reuse the shared launch with the
+    # Taj cap ON and sim time ON.
+    safety_stack = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [PathJoinSubstitution([pkg, 'launch', 'kirra_with_robot.launch.py'])]),
+        launch_arguments={
+            'kirra_token': kirra_token,
+            'use_sim_time': 'true',
+            'use_perception_cap': 'true',
+            'start_sidecars': 'true',
+        }.items(),
+    )
+
+    # The untrusted doer: command the robot forward forever; KIRRA + Taj stop it.
+    doer = Node(
+        package='kirra_safety', executable='doer_commander', name='doer_commander',
+        parameters=[{'cmd_topic': '/cmd_vel_raw', 'forward_speed_mps': forward_speed,
+                     'use_sim_time': True}],
+        output='screen',
+    )
+
+    return LaunchDescription([
+        kirra_token_arg, world_arg, forward_speed_arg, start_verifier_arg,
+        verifier_bin_arg, gui_arg,
+        verifier, gzserver, gzclient, rsp, spawn, safety_stack, doer,
+    ])

--- a/ros2_ws/src/kirra_safety/launch/kirra_with_robot.launch.py
+++ b/ros2_ws/src/kirra_safety/launch/kirra_with_robot.launch.py
@@ -50,6 +50,18 @@ def generate_launch_description():
         description='Enable the Taj corridor speed derate on the cmd_vel path '
                     '(requires the taj_service sidecar + perception_governor node)',
     )
+    use_occy_doer_arg = DeclareLaunchArgument(
+        'use_occy_doer',
+        default_value='false',
+        description='Run the Occy doer bridge: drives the robot to a /goal_pose using the '
+                    'planner + Taj + KIRRA (publishes proposals to /cmd_vel_raw). Needs the '
+                    'planner sidecar (and Taj if use_perception_cap).',
+    )
+    planner_url_arg = DeclareLaunchArgument(
+        'planner_url',
+        default_value='http://localhost:8100',
+        description='Occy planner sidecar URL (kirra-mick example planner_service).',
+    )
     taj_url_arg = DeclareLaunchArgument(
         'taj_url',
         default_value='http://localhost:8101',
@@ -88,6 +100,8 @@ def generate_launch_description():
     kirra_token = LaunchConfiguration('kirra_token')
     use_sim_time = LaunchConfiguration('use_sim_time')
     use_perception_cap = LaunchConfiguration('use_perception_cap')
+    use_occy_doer = LaunchConfiguration('use_occy_doer')
+    planner_url = LaunchConfiguration('planner_url')
     taj_url = LaunchConfiguration('taj_url')
     start_sidecars = LaunchConfiguration('start_sidecars')
     start_planner_service = LaunchConfiguration('start_planner_service')
@@ -100,8 +114,11 @@ def generate_launch_description():
     # otherwise). The perception_governor node mirrors the Taj-service condition.
     planner_cond = IfCondition(PythonExpression(
         ["'", start_sidecars, "' == 'true' and '", start_planner_service, "' == 'true'"]))
+    # Taj is needed by the perception cap AND by the Occy doer (for the corridor), so start
+    # it when sidecars are on and EITHER is enabled.
     taj_cond = IfCondition(PythonExpression(
-        ["'", start_sidecars, "' == 'true' and '", use_perception_cap, "' == 'true'"]))
+        ["'", start_sidecars, "' == 'true' and ('",
+         use_perception_cap, "' == 'true' or '", use_occy_doer, "' == 'true')"]))
 
     params_file = PathJoinSubstitution([
         FindPackageShare('kirra_safety'), 'config', 'kirra_params.yaml'
@@ -150,6 +167,22 @@ def generate_launch_description():
         output='screen',
     )
 
+    # The Occy DOER (opt-in): drives the robot to a /goal_pose. Each tick it feeds the robot
+    # pose + goal + the Taj corridor to the planner sidecar (/plan) and republishes the
+    # KIRRA-validated trajectory to /cmd_vel_raw — which the interceptor then re-governs.
+    # Occy PROPOSES; KIRRA DISPOSES (twice: planner slow-loop + interceptor fast-loop).
+    occy_doer = Node(
+        package='kirra_safety',
+        executable='occy_doer',
+        name='occy_doer',
+        condition=IfCondition(use_occy_doer),
+        parameters=[
+            params_file,
+            {'taj_url': taj_url, 'planner_url': planner_url, 'use_sim_time': use_sim_time},
+        ],
+        output='screen',
+    )
+
     # Taj corridor -> assured-clear-distance speed cap on the cmd_vel path. Subscribes /scan,
     # POSTs to the taj_service sidecar, publishes /kirra/perception_speed_cap. The interceptor
     # applies it (opt-in via use_perception_cap) BEFORE the governor — Taj tightens, KIRRA bounds.
@@ -192,6 +225,8 @@ def generate_launch_description():
         kirra_token_arg,
         use_sim_time_arg,
         use_perception_cap_arg,
+        use_occy_doer_arg,
+        planner_url_arg,
         taj_url_arg,
         start_sidecars_arg,
         start_planner_service_arg,
@@ -201,6 +236,7 @@ def generate_launch_description():
         planner_service,
         taj_service,
         cmd_vel_interceptor,
+        occy_doer,
         perception_governor,
         sensor_monitor,
         posture_subscriber,

--- a/ros2_ws/src/kirra_safety/launch/kirra_with_robot.launch.py
+++ b/ros2_ws/src/kirra_safety/launch/kirra_with_robot.launch.py
@@ -35,10 +35,23 @@ def generate_launch_description():
         default_value='false',
         description='Use simulation time (for Gazebo/Isaac Sim)',
     )
+    use_perception_cap_arg = DeclareLaunchArgument(
+        'use_perception_cap',
+        default_value='false',
+        description='Enable the Taj corridor speed derate on the cmd_vel path '
+                    '(requires the taj_service sidecar + perception_governor node)',
+    )
+    taj_url_arg = DeclareLaunchArgument(
+        'taj_url',
+        default_value='http://localhost:8101',
+        description='Taj perception sidecar URL (kirra-mick example taj_service)',
+    )
 
     kirra_url = LaunchConfiguration('kirra_url')
     kirra_token = LaunchConfiguration('kirra_token')
     use_sim_time = LaunchConfiguration('use_sim_time')
+    use_perception_cap = LaunchConfiguration('use_perception_cap')
+    taj_url = LaunchConfiguration('taj_url')
 
     params_file = PathJoinSubstitution([
         FindPackageShare('kirra_safety'), 'config', 'kirra_params.yaml'
@@ -57,7 +70,22 @@ def generate_launch_description():
                 'input_topic': '/cmd_vel_raw',
                 'output_topic': '/cmd_vel',
                 'use_sim_time': use_sim_time,
+                'use_perception_cap': use_perception_cap,
             },
+        ],
+        output='screen',
+    )
+
+    # Taj corridor -> assured-clear-distance speed cap on the cmd_vel path. Subscribes /scan,
+    # POSTs to the taj_service sidecar, publishes /kirra/perception_speed_cap. The interceptor
+    # applies it (opt-in via use_perception_cap) BEFORE the governor — Taj tightens, KIRRA bounds.
+    perception_governor = Node(
+        package='kirra_safety',
+        executable='perception_governor',
+        name='perception_governor',
+        parameters=[
+            params_file,
+            {'taj_url': taj_url, 'use_sim_time': use_sim_time},
         ],
         output='screen',
     )
@@ -88,7 +116,10 @@ def generate_launch_description():
         kirra_url_arg,
         kirra_token_arg,
         use_sim_time_arg,
+        use_perception_cap_arg,
+        taj_url_arg,
         cmd_vel_interceptor,
+        perception_governor,
         sensor_monitor,
         posture_subscriber,
         # NOTE: Add nav2_bringup and robot_description includes here.

--- a/ros2_ws/src/kirra_safety/launch/kirra_with_robot.launch.py
+++ b/ros2_ws/src/kirra_safety/launch/kirra_with_robot.launch.py
@@ -12,11 +12,20 @@ This ensures: nav2 -> Kirra -> motors (not nav2 -> motors directly)
 
 import os
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
+
+# Where the Rust sidecar binaries (planner_service, taj_service) live. Built by
+# `cargo build --release -p kirra-mick --example {planner_service,taj_service}` (or
+# scripts/orin_bringup.sh). Overridable via KIRRA_SIDECAR_DIR or the sidecar_dir arg.
+DEFAULT_SIDECAR_DIR = os.environ.get(
+    'KIRRA_SIDECAR_DIR',
+    os.path.join(os.path.expanduser('~'), 'kirra-runtime-sdk', 'target', 'release', 'examples'),
+)
 
 
 def generate_launch_description():
@@ -46,16 +55,81 @@ def generate_launch_description():
         default_value='http://localhost:8101',
         description='Taj perception sidecar URL (kirra-mick example taj_service)',
     )
+    # --- Rust sidecars folded into this launch (single-box: everything on the Orin) ---
+    start_sidecars_arg = DeclareLaunchArgument(
+        'start_sidecars',
+        default_value='true',
+        description='Start the Rust sidecars (Occy planner + Taj perception) from this launch. '
+                    'Set false if you start them separately (e.g. scripts/orin_bringup.sh --serve).',
+    )
+    start_planner_service_arg = DeclareLaunchArgument(
+        'start_planner_service',
+        default_value='true',
+        description='Start the Occy planner sidecar (planner_service, POST /plan).',
+    )
+    sidecar_dir_arg = DeclareLaunchArgument(
+        'sidecar_dir',
+        default_value=DEFAULT_SIDECAR_DIR,
+        description='Directory holding the planner_service + taj_service release binaries.',
+    )
+    planner_addr_arg = DeclareLaunchArgument(
+        'planner_addr',
+        default_value='127.0.0.1:8100',
+        description='Bind address for the Occy planner sidecar (KIRRA_PLANNER_ADDR).',
+    )
+    taj_addr_arg = DeclareLaunchArgument(
+        'taj_addr',
+        default_value='127.0.0.1:8101',
+        description='Bind address for the Taj perception sidecar (KIRRA_TAJ_ADDR); '
+                    'must match taj_url.',
+    )
 
     kirra_url = LaunchConfiguration('kirra_url')
     kirra_token = LaunchConfiguration('kirra_token')
     use_sim_time = LaunchConfiguration('use_sim_time')
     use_perception_cap = LaunchConfiguration('use_perception_cap')
     taj_url = LaunchConfiguration('taj_url')
+    start_sidecars = LaunchConfiguration('start_sidecars')
+    start_planner_service = LaunchConfiguration('start_planner_service')
+    sidecar_dir = LaunchConfiguration('sidecar_dir')
+    planner_addr = LaunchConfiguration('planner_addr')
+    taj_addr = LaunchConfiguration('taj_addr')
+
+    # Conditions: the planner runs when sidecars are on AND planner is wanted; the Taj
+    # service runs when sidecars are on AND the perception cap is enabled (no point
+    # otherwise). The perception_governor node mirrors the Taj-service condition.
+    planner_cond = IfCondition(PythonExpression(
+        ["'", start_sidecars, "' == 'true' and '", start_planner_service, "' == 'true'"]))
+    taj_cond = IfCondition(PythonExpression(
+        ["'", start_sidecars, "' == 'true' and '", use_perception_cap, "' == 'true'"]))
 
     params_file = PathJoinSubstitution([
         FindPackageShare('kirra_safety'), 'config', 'kirra_params.yaml'
     ])
+
+    # --- Rust sidecars (ExecuteProcess) --------------------------------------------------
+    # The Occy planner endpoint (POST /plan). respawn so a transient crash recovers; the
+    # interceptor fails closed meanwhile.
+    planner_service = ExecuteProcess(
+        name='planner_service',
+        cmd=[PathJoinSubstitution([sidecar_dir, 'planner_service'])],
+        additional_env={'KIRRA_PLANNER_ADDR': planner_addr},
+        condition=planner_cond,
+        respawn=True,
+        respawn_delay=2.0,
+        output='screen',
+    )
+    # The Taj perception sidecar (POST /perception). Only started when the cmd_vel
+    # perception cap is enabled — the perception_governor below POSTs /scan to it.
+    taj_service = ExecuteProcess(
+        name='taj_service',
+        cmd=[PathJoinSubstitution([sidecar_dir, 'taj_service'])],
+        additional_env={'KIRRA_TAJ_ADDR': taj_addr},
+        condition=taj_cond,
+        respawn=True,
+        respawn_delay=2.0,
+        output='screen',
+    )
 
     # Kirra safety nodes -- intercept /cmd_vel_raw (from nav2), output to /cmd_vel (to motors)
     cmd_vel_interceptor = Node(
@@ -83,6 +157,7 @@ def generate_launch_description():
         package='kirra_safety',
         executable='perception_governor',
         name='perception_governor',
+        condition=IfCondition(use_perception_cap),
         parameters=[
             params_file,
             {'taj_url': taj_url, 'use_sim_time': use_sim_time},
@@ -118,6 +193,13 @@ def generate_launch_description():
         use_sim_time_arg,
         use_perception_cap_arg,
         taj_url_arg,
+        start_sidecars_arg,
+        start_planner_service_arg,
+        sidecar_dir_arg,
+        planner_addr_arg,
+        taj_addr_arg,
+        planner_service,
+        taj_service,
         cmd_vel_interceptor,
         perception_governor,
         sensor_monitor,

--- a/ros2_ws/src/kirra_safety/package.xml
+++ b/ros2_ws/src/kirra_safety/package.xml
@@ -16,6 +16,11 @@
   <exec_depend>python3-requests</exec_depend>
   <exec_depend>python3-sseclient-py</exec_depend>
 
+  <!-- Gazebo demo (kirra_gazebo_demo.launch.py): Gazebo Classic + robot spawn -->
+  <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>gazebo_plugins</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/ros2_ws/src/kirra_safety/setup.py
+++ b/ros2_ws/src/kirra_safety/setup.py
@@ -16,6 +16,10 @@ setup(
             glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
         (os.path.join('share', package_name, 'config'),
             glob(os.path.join('config', '*.yaml'))),
+        (os.path.join('share', package_name, 'worlds'),
+            glob(os.path.join('worlds', '*.world'))),
+        (os.path.join('share', package_name, 'urdf'),
+            glob(os.path.join('urdf', '*.urdf'))),
     ],
     install_requires=['setuptools'],
     zip_safe=True,
@@ -30,6 +34,7 @@ setup(
             'sensor_monitor = kirra_safety.sensor_monitor:main',
             'posture_subscriber = kirra_safety.posture_subscriber:main',
             'perception_governor = kirra_safety.perception_governor:main',
+            'doer_commander = kirra_safety.doer_commander:main',
         ],
     },
 )

--- a/ros2_ws/src/kirra_safety/setup.py
+++ b/ros2_ws/src/kirra_safety/setup.py
@@ -29,6 +29,7 @@ setup(
             'cmd_vel_interceptor = kirra_safety.cmd_vel_interceptor:main',
             'sensor_monitor = kirra_safety.sensor_monitor:main',
             'posture_subscriber = kirra_safety.posture_subscriber:main',
+            'perception_governor = kirra_safety.perception_governor:main',
         ],
     },
 )

--- a/ros2_ws/src/kirra_safety/setup.py
+++ b/ros2_ws/src/kirra_safety/setup.py
@@ -35,6 +35,7 @@ setup(
             'posture_subscriber = kirra_safety.posture_subscriber:main',
             'perception_governor = kirra_safety.perception_governor:main',
             'doer_commander = kirra_safety.doer_commander:main',
+            'occy_doer = kirra_safety.occy_doer:main',
         ],
     },
 )

--- a/ros2_ws/src/kirra_safety/test/test_doer_core.py
+++ b/ros2_ws/src/kirra_safety/test/test_doer_core.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for the pure Occy-doer geometry/decision helpers (no ROS, no HTTP).
+
+Run:  pytest ros2_ws/src/kirra_safety/test/test_doer_core.py
+"""
+
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "kirra_safety"))
+from doer_core import (  # noqa: E402
+    yaw_from_quaternion, goal_to_base, goal_reached, trajectory_to_twist, decide,
+    extend_corridor_back,
+)
+
+
+def test_extend_corridor_back_prepends_behind_origin():
+    left, right = [[0.0, 1.0], [5.0, 1.0]], [[0.0, -1.0], [5.0, -1.0]]
+    l2, r2 = extend_corridor_back(left, right, 0.5)
+    assert l2[0] == [-0.5, 1.0] and r2[0] == [-0.5, -1.0]   # prepended back point
+    assert l2[1:] == left and r2[1:] == right               # original points preserved
+    assert extend_corridor_back([], [], 0.5) == ([], [])    # empty stays empty
+
+
+def test_yaw_from_quaternion_basic():
+    assert abs(yaw_from_quaternion(0, 0, 0, 1)) < 1e-9          # identity → 0
+    assert abs(yaw_from_quaternion(0, 0, math.sin(math.pi/4), math.cos(math.pi/4)) - math.pi/2) < 1e-6
+
+
+def test_goal_to_base_translation_only():
+    # Robot at (1,0) facing +X, goal at (4,0) → 3 m straight ahead.
+    gx, gy = goal_to_base(1.0, 0.0, 0.0, 4.0, 0.0)
+    assert abs(gx - 3.0) < 1e-9 and abs(gy) < 1e-9
+
+
+def test_goal_to_base_rotation():
+    # Robot at origin facing +Y (yaw=pi/2); a goal due east (3,0) is 3 m to the robot's RIGHT.
+    gx, gy = goal_to_base(0.0, 0.0, math.pi/2, 3.0, 0.0)
+    assert abs(gx) < 1e-6          # nothing ahead
+    assert abs(gy + 3.0) < 1e-6    # 3 m to the right → -Y in base frame
+
+
+def test_goal_reached():
+    assert goal_reached(0.1, 0.05, 0.2)
+    assert not goal_reached(1.0, 0.0, 0.2)
+
+
+def test_trajectory_to_twist_straight_ahead_no_turn():
+    traj = [{"x": x, "y": 0.0, "v": 1.0} for x in (0.0, 0.5, 1.0, 1.5)]
+    v, w = trajectory_to_twist(traj, lookahead_m=1.0, max_v=1.2, max_w=2.0)
+    assert abs(v - 1.0) < 1e-9 and abs(w) < 1e-9
+
+
+def test_trajectory_to_twist_left_curve_turns_left():
+    # Lookahead point off to the left (+Y) → positive (CCW) angular velocity.
+    traj = [{"x": 1.0, "y": 0.0, "v": 1.0}, {"x": 1.4, "y": 0.5, "v": 1.0}]
+    v, w = trajectory_to_twist(traj, lookahead_m=1.2, max_v=1.2, max_w=2.0)
+    assert v > 0 and w > 0
+
+
+def test_trajectory_to_twist_caps_speed_and_turn():
+    traj = [{"x": 0.2, "y": 1.0, "v": 5.0}]  # demands a hard left at high speed
+    v, w = trajectory_to_twist(traj, lookahead_m=0.1, max_v=1.2, max_w=1.5)
+    assert v <= 1.2 + 1e-9 and abs(w) <= 1.5 + 1e-9
+
+
+def test_trajectory_to_twist_empty_is_stop():
+    assert trajectory_to_twist([], 1.0, 1.2, 2.0) == (0.0, 0.0)
+
+
+def test_decide_drives_on_accept():
+    plan = {"kind": "Motion", "verdict": "Accept",
+            "trajectory": [{"x": 1.0, "y": 0.0, "v": 1.0}, {"x": 1.5, "y": 0.0, "v": 1.0}]}
+    v, w, reason = decide(plan, 1.0, 1.2, 2.0)
+    assert v > 0 and reason.startswith("DRIVE")
+
+
+def test_decide_holds_on_safe_stop():
+    plan = {"kind": "SafeStop", "verdict": "Accept", "trajectory": []}
+    assert decide(plan, 1.0, 1.2, 2.0) == (0.0, 0.0, "HOLD:SafeStop/Accept")
+
+
+def test_decide_holds_on_refused_verdict():
+    # Occy proposed motion but KIRRA's slow loop refused it → the doer holds.
+    plan = {"kind": "Motion", "verdict": "MRCFallback",
+            "trajectory": [{"x": 1.0, "y": 0.0, "v": 1.0}]}
+    v, w, reason = decide(plan, 1.0, 1.2, 2.0)
+    assert (v, w) == (0.0, 0.0) and reason.startswith("HOLD")

--- a/ros2_ws/src/kirra_safety/test/test_perception_cap.py
+++ b/ros2_ws/src/kirra_safety/test/test_perception_cap.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for the pure, fail-closed perception-cap clamp.
+
+No ROS / rclpy needed — imports the pure `perception_cap` module directly. The
+load-bearing cases are the fail-closed ones: a missing/stale/malformed cap must
+STOP the robot (0.0), never let the proposed command through unchanged.
+
+Run:  pytest ros2_ws/src/kirra_safety/test/test_perception_cap.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "kirra_safety"))
+from perception_cap import (  # noqa: E402
+    apply_perception_cap,
+    DISABLED,
+    STALE,
+    INVALID,
+    CAPPED,
+    PASS,
+)
+
+STALE_S = 0.5
+
+
+def test_disabled_is_a_pure_passthrough():
+    # Opt-in: when off, the proposed command is untouched (byte-identical prior path).
+    v, reason = apply_perception_cap(1.8, cap_mps=0.0, cap_age_s=0.0, enabled=False, stale_s=STALE_S)
+    assert v == 1.8 and reason == DISABLED
+
+
+def test_missing_cap_fails_closed():
+    v, reason = apply_perception_cap(1.8, cap_mps=None, cap_age_s=None, enabled=True, stale_s=STALE_S)
+    assert v == 0.0 and reason == STALE
+
+
+def test_stale_cap_fails_closed():
+    # A cap older than the staleness budget is a perception fault → stop.
+    v, reason = apply_perception_cap(1.8, cap_mps=3.0, cap_age_s=0.9, enabled=True, stale_s=STALE_S)
+    assert v == 0.0 and reason == STALE
+
+
+def test_nonfinite_or_negative_cap_fails_closed():
+    for bad in (float("nan"), float("inf"), -1.0):
+        v, reason = apply_perception_cap(1.8, cap_mps=bad, cap_age_s=0.0, enabled=True, stale_s=STALE_S)
+        assert v == 0.0 and reason == INVALID
+
+
+def test_fresh_cap_clamps_when_proposed_exceeds_it():
+    # Proposed 1.8 m/s, Taj allows only 0.9 → clamp to 0.9.
+    v, reason = apply_perception_cap(1.8, cap_mps=0.9, cap_age_s=0.1, enabled=True, stale_s=STALE_S)
+    assert v == 0.9 and reason == CAPPED
+
+
+def test_fresh_cap_passes_when_proposed_is_under_it():
+    # Proposed 0.4 m/s, Taj allows 3.0 → unchanged (Taj only tightens, never loosens).
+    v, reason = apply_perception_cap(0.4, cap_mps=3.0, cap_age_s=0.1, enabled=True, stale_s=STALE_S)
+    assert v == 0.4 and reason == PASS
+
+
+def test_zero_cap_holds_the_robot():
+    # Taj at the MRC floor (obstacle in the standoff / unhealthy corridor) → hold.
+    v, reason = apply_perception_cap(1.8, cap_mps=0.0, cap_age_s=0.0, enabled=True, stale_s=STALE_S)
+    assert v == 0.0 and reason == CAPPED
+
+
+def test_reverse_direction_is_preserved_and_clamped():
+    # Backing up at -1.8, cap 0.5 → -0.5 (magnitude clamped, sign kept).
+    v, reason = apply_perception_cap(-1.8, cap_mps=0.5, cap_age_s=0.1, enabled=True, stale_s=STALE_S)
+    assert v == -0.5 and reason == CAPPED

--- a/ros2_ws/src/kirra_safety/urdf/kirra_bot.urdf
+++ b/ros2_ws/src/kirra_safety/urdf/kirra_bot.urdf
@@ -1,0 +1,162 @@
+<?xml version="1.0"?>
+<!-- A minimal differential-drive robot with a forward 180-degree 2D lidar, for the Kirra
+     Gazebo demo. The gazebo_ros_diff_drive plugin subscribes to /cmd_vel (the KIRRA-enforced
+     output of the cmd_vel_interceptor) and the gazebo_ros_ray_sensor plugin publishes /scan
+     (consumed by the perception_governor -> Taj). Plain URDF (no xacro) so it is directly
+     XML-valid and needs no expansion step. -->
+<robot name="kirra_bot">
+
+  <!-- Chassis -->
+  <link name="base_link">
+    <inertial>
+      <mass value="3.0"/>
+      <inertia ixx="0.03" ixy="0" ixz="0" iyy="0.03" iyz="0" izz="0.05"/>
+    </inertial>
+    <collision>
+      <geometry><box size="0.3 0.3 0.12"/></geometry>
+    </collision>
+    <visual>
+      <geometry><box size="0.3 0.3 0.12"/></geometry>
+      <material name="body"><color rgba="0.1 0.4 0.7 1"/></material>
+    </visual>
+  </link>
+
+  <!-- Left wheel -->
+  <link name="left_wheel">
+    <inertial>
+      <mass value="0.2"/>
+      <inertia ixx="0.0005" ixy="0" ixz="0" iyy="0.0005" iyz="0" izz="0.0008"/>
+    </inertial>
+    <collision>
+      <origin rpy="1.5708 0 0"/>
+      <geometry><cylinder radius="0.05" length="0.04"/></geometry>
+    </collision>
+    <visual>
+      <origin rpy="1.5708 0 0"/>
+      <geometry><cylinder radius="0.05" length="0.04"/></geometry>
+      <material name="wheel"><color rgba="0.1 0.1 0.1 1"/></material>
+    </visual>
+  </link>
+  <joint name="left_wheel_joint" type="continuous">
+    <parent link="base_link"/>
+    <child link="left_wheel"/>
+    <origin xyz="0 0.17 -0.04"/>
+    <axis xyz="0 1 0"/>
+  </joint>
+
+  <!-- Right wheel -->
+  <link name="right_wheel">
+    <inertial>
+      <mass value="0.2"/>
+      <inertia ixx="0.0005" ixy="0" ixz="0" iyy="0.0005" iyz="0" izz="0.0008"/>
+    </inertial>
+    <collision>
+      <origin rpy="1.5708 0 0"/>
+      <geometry><cylinder radius="0.05" length="0.04"/></geometry>
+    </collision>
+    <visual>
+      <origin rpy="1.5708 0 0"/>
+      <geometry><cylinder radius="0.05" length="0.04"/></geometry>
+      <material name="wheel"><color rgba="0.1 0.1 0.1 1"/></material>
+    </visual>
+  </link>
+  <joint name="right_wheel_joint" type="continuous">
+    <parent link="base_link"/>
+    <child link="right_wheel"/>
+    <origin xyz="0 -0.17 -0.04"/>
+    <axis xyz="0 1 0"/>
+  </joint>
+
+  <!-- Front caster (a low-friction sphere keeps the chassis level) -->
+  <link name="caster">
+    <inertial>
+      <mass value="0.05"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+    <collision><geometry><sphere radius="0.03"/></geometry></collision>
+    <visual><geometry><sphere radius="0.03"/></geometry></visual>
+  </link>
+  <joint name="caster_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="caster"/>
+    <origin xyz="0.12 0 -0.07"/>
+  </joint>
+
+  <!-- Lidar mount -->
+  <link name="lidar_link">
+    <inertial>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+    <visual>
+      <geometry><cylinder radius="0.03" length="0.04"/></geometry>
+      <material name="lidar"><color rgba="0.2 0.2 0.2 1"/></material>
+    </visual>
+  </link>
+  <joint name="lidar_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="lidar_link"/>
+    <origin xyz="0.1 0 0.09"/>
+  </joint>
+
+  <!-- Low-friction caster so the diff drive turns cleanly -->
+  <gazebo reference="caster">
+    <mu1>0.0</mu1>
+    <mu2>0.0</mu2>
+  </gazebo>
+
+  <!-- Differential drive: subscribes /cmd_vel (the KIRRA-enforced safe command), publishes odom + tf -->
+  <gazebo>
+    <plugin name="diff_drive" filename="libgazebo_ros_diff_drive.so">
+      <ros><namespace>/</namespace></ros>
+      <left_joint>left_wheel_joint</left_joint>
+      <right_joint>right_wheel_joint</right_joint>
+      <wheel_separation>0.34</wheel_separation>
+      <wheel_diameter>0.1</wheel_diameter>
+      <max_wheel_torque>10.0</max_wheel_torque>
+      <max_wheel_acceleration>2.0</max_wheel_acceleration>
+      <command_topic>cmd_vel</command_topic>
+      <publish_odom>true</publish_odom>
+      <publish_odom_tf>true</publish_odom_tf>
+      <publish_wheel_tf>true</publish_wheel_tf>
+      <odometry_topic>odom</odometry_topic>
+      <odometry_frame>odom</odometry_frame>
+      <robot_base_frame>base_link</robot_base_frame>
+    </plugin>
+  </gazebo>
+
+  <!-- Forward 180-degree 2D lidar: publishes /scan (sensor_msgs/LaserScan), the same forward
+       cone Taj's corridor is derived from (matches the taj_service -pi/2..+pi/2 expectation). -->
+  <gazebo reference="lidar_link">
+    <sensor name="lidar" type="ray">
+      <pose>0 0 0 0 0 0</pose>
+      <always_on>true</always_on>
+      <visualize>true</visualize>
+      <update_rate>10</update_rate>
+      <ray>
+        <scan>
+          <horizontal>
+            <samples>181</samples>
+            <resolution>1</resolution>
+            <min_angle>-1.5708</min_angle>
+            <max_angle>1.5708</max_angle>
+          </horizontal>
+        </scan>
+        <range>
+          <min>0.12</min>
+          <max>8.0</max>
+          <resolution>0.01</resolution>
+        </range>
+      </ray>
+      <plugin name="lidar_plugin" filename="libgazebo_ros_ray_sensor.so">
+        <ros>
+          <namespace>/</namespace>
+          <remapping>~/out:=scan</remapping>
+        </ros>
+        <output_type>sensor_msgs/LaserScan</output_type>
+        <frame_name>lidar_link</frame_name>
+      </plugin>
+    </sensor>
+  </gazebo>
+
+</robot>

--- a/ros2_ws/src/kirra_safety/worlds/kirra_corridor.world
+++ b/ros2_ws/src/kirra_safety/worlds/kirra_corridor.world
@@ -1,0 +1,50 @@
+<?xml version="1.0" ?>
+<!-- A short straight corridor with an end wall, for the Kirra cmd_vel-derate demo.
+     The robot starts at the origin facing +X and is commanded forward by the (untrusted)
+     doer; Taj's corridor sees the end wall as a shrinking clear distance and derates the
+     speed, KIRRA bounds it, and the robot brakes to a controlled stop before the wall. -->
+<sdf version="1.6">
+  <world name="kirra_corridor">
+    <include><uri>model://sun</uri></include>
+    <include><uri>model://ground_plane</uri></include>
+
+    <!-- Left wall (y = +1.5), 10 m long -->
+    <model name="wall_left">
+      <static>true</static>
+      <pose>5 1.5 0.5 0 0 0</pose>
+      <link name="link">
+        <collision name="c"><geometry><box><size>10 0.1 1.0</size></box></geometry></collision>
+        <visual name="v"><geometry><box><size>10 0.1 1.0</size></box></geometry>
+          <material><ambient>0.6 0.6 0.6 1</ambient><diffuse>0.7 0.7 0.7 1</diffuse></material></visual>
+      </link>
+    </model>
+
+    <!-- Right wall (y = -1.5), 10 m long -->
+    <model name="wall_right">
+      <static>true</static>
+      <pose>5 -1.5 0.5 0 0 0</pose>
+      <link name="link">
+        <collision name="c"><geometry><box><size>10 0.1 1.0</size></box></geometry></collision>
+        <visual name="v"><geometry><box><size>10 0.1 1.0</size></box></geometry>
+          <material><ambient>0.6 0.6 0.6 1</ambient><diffuse>0.7 0.7 0.7 1</diffuse></material></visual>
+      </link>
+    </model>
+
+    <!-- End wall dead ahead at x = 5 m: the obstacle Taj caps the approach speed against. -->
+    <model name="wall_end">
+      <static>true</static>
+      <pose>5 0 0.5 0 0 0</pose>
+      <link name="link">
+        <collision name="c"><geometry><box><size>0.2 3.0 1.0</size></box></geometry></collision>
+        <visual name="v"><geometry><box><size>0.2 3.0 1.0</size></box></geometry>
+          <material><ambient>0.7 0.2 0.2 1</ambient><diffuse>0.9 0.25 0.25 1</diffuse></material></visual>
+      </link>
+    </model>
+
+    <gui>
+      <camera name="user_camera">
+        <pose>-3 -4 4 0 0.5 0.7</pose>
+      </camera>
+    </gui>
+  </world>
+</sdf>

--- a/scripts/carla_drive_session.py
+++ b/scripts/carla_drive_session.py
@@ -23,6 +23,9 @@ per-run scorecard (intervention rate, mean clamp per axis) prints at the end.
   --shadow   autopilot drives; the governor is evaluated but NOT applied (pure
              observation + data collection, non-intrusive).
   --enforce  apply the governor-enforced control (the real doer-checker loop). [default]
+  --occy URL the DOER is REAL Occy via the planner endpoint (cargo run -p kirra-mick
+             --example planner_service) instead of the built-in lane-follower; the
+             corridor is built from the map waypoints and Occy's trajectory drives.
 
 SAFETY: tune the DOER from this data (propose checker-admissible commands more
 often); NEVER the checker's envelope — the speed cap, the 0.40 m margin, and the
@@ -92,6 +95,58 @@ def propose(world_map, vehicle, tick):
     return target_v, steer_deg
 
 
+def occy_propose(occy_url, world, world_map, vehicle, ego_idx):
+    """The DOER = REAL Occy via the planner endpoint. Build a corridor from the map's waypoints
+    ahead of the ego, post the world snapshot, and extract a (target speed, steering angle) from the
+    returned KIRRA-validated trajectory ~0.3 s ahead. Falls back to the local controller on error."""
+    import urllib.request
+    tf = vehicle.get_transform()
+    wp = world_map.get_waypoint(tf.location, project_to_road=True, lane_type=carla.LaneType.Driving)
+    if not wp:
+        return None
+    # Sample the lane ahead; left/right boundaries are ± half lane-width along each waypoint's right.
+    left, right, chain = [], [], wp
+    for _ in range(20):
+        nx = chain.next(2.0)
+        if not nx:
+            break
+        chain = nx[0]
+        rv = chain.transform.get_right_vector()
+        hw = chain.lane_width / 2.0
+        c = chain.transform.location
+        left.append([c.x - rv.x * hw, c.y - rv.y * hw])
+        right.append([c.x + rv.x * hw, c.y + rv.y * hw])
+    if len(left) < 2:
+        return None
+    goal = [(left[-1][0] + right[-1][0]) / 2.0, (left[-1][1] + right[-1][1]) / 2.0]
+    objs = []
+    for a in world.get_actors().filter("vehicle.*"):
+        if a.id == vehicle.id:
+            continue
+        al, av = a.get_location(), a.get_velocity()
+        objs.append({"id": int(a.id) % 100000, "x": al.x, "y": al.y, "vx": av.x, "vy": av.y})
+    req = {
+        "ego": {"x": tf.location.x, "y": tf.location.y, "heading": math.radians(tf.rotation.yaw), "speed": speed_of(vehicle)},
+        "goal": {"x": goal[0], "y": goal[1]}, "cruise": CRUISE_MPS,
+        "left": left, "right": right, "objects": objs,
+    }
+    try:
+        r = urllib.request.Request(occy_url.rstrip("/") + "/plan", data=json.dumps(req).encode(), method="POST")
+        r.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(r, timeout=5) as resp:
+            plan = json.loads(resp.read())
+    except Exception as e:
+        print(f"occy ego {ego_idx}: {e}", file=sys.stderr)
+        return None
+    traj = plan.get("trajectory", [])
+    if plan.get("kind") != "Motion" or len(traj) < 4:
+        return 0.0, 0.0  # Occy holds → propose a stop
+    pt = traj[min(3, len(traj) - 1)]  # ~0.3 s ahead
+    desired = math.degrees(math.atan2(pt["y"] - tf.location.y, pt["x"] - tf.location.x))
+    steer = max(-MAX_STEER_DEG, min(MAX_STEER_DEG, (desired - tf.rotation.yaw + 180.0) % 360.0 - 180.0))
+    return pt["v"], steer
+
+
 def enforced_to_control(target_v, steer_deg, current_v):
     """Map an enforced (target speed, steering angle) back to a CARLA control."""
     steer = max(-1.0, min(1.0, steer_deg / MAX_STEER_DEG))
@@ -111,6 +166,8 @@ def main():
     ap.add_argument("--ticks", type=int, default=4000)
     ap.add_argument("--follow", type=int, default=0, help="ego index the spectator follows")
     ap.add_argument("--out", default="carla_drive_session.jsonl")
+    ap.add_argument("--occy", default=None, help="planner-service URL (e.g. http://localhost:8100) — "
+                    "drive with REAL Occy instead of the built-in lane-follower doer")
     mode = ap.add_mutually_exclusive_group()
     mode.add_argument("--enforce", dest="enforce", action="store_true", default=True)
     mode.add_argument("--shadow", dest="enforce", action="store_false")
@@ -166,7 +223,14 @@ def main():
             for idx, ego in enumerate(egos):
                 cur_v = speed_of(ego)
                 cur_steer = ego.get_control().steer * MAX_STEER_DEG
-                tv, sd = propose(wmap, ego, tick)
+                # The DOER: real Occy via the planner endpoint, or the built-in lane-follower.
+                tv = sd = None
+                if args.occy:
+                    res = occy_propose(args.occy, world, wmap, ego, idx)
+                    if res is not None:
+                        tv, sd = res
+                if tv is None:
+                    tv, sd = propose(wmap, ego, tick)
                 proposal = {
                     "linear_velocity_mps": tv, "current_velocity_mps": cur_v,
                     "delta_time_s": dt, "steering_angle_deg": sd,

--- a/scripts/carla_drive_session.py
+++ b/scripts/carla_drive_session.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+Observe a fleet of ego vehicles driving a REAL CARLA city, bounded by the REAL
+Kirra governor, and collect doer<->checker divergence data for tuning.
+
+Each synchronous tick, for every ego:
+  1. DOER  — a lane-following controller proposes (target speed, steering angle)
+             from the CARLA map's waypoints (+ periodic over-reach to exercise
+             the checker).
+  2. CHECKER — the proposal is POSTed to the live verifier's
+               /actuator/motion/command, which bounds BOTH axes.
+  3. ACTUATE — the *enforced* command is converted back to a CARLA control and
+               applied. (In --shadow it is observed only, autopilot drives.)
+  4. CAPTURE — (proposed, enforced, divergence, action) is logged as JSONL.
+
+The spectator camera follows one ego so you watch the city drive live. A
+per-run scorecard (intervention rate, mean clamp per axis) prints at the end.
+
+  # CARLA server already running (a Town map), Kirra verifier on :8090
+  KIRRA_VERIFIER_URL=http://localhost:8090 KIRRA_ADMIN_TOKEN=test-token \
+    python3 scripts/carla_drive_session.py --town Town03 --egos 3 --ticks 4000 --follow 0
+
+  --shadow   autopilot drives; the governor is evaluated but NOT applied (pure
+             observation + data collection, non-intrusive).
+  --enforce  apply the governor-enforced control (the real doer-checker loop). [default]
+
+SAFETY: tune the DOER from this data (propose checker-admissible commands more
+often); NEVER the checker's envelope — the speed cap, the 0.40 m margin, and the
+RSS bounds are safety-derived invariants, not knobs.
+
+NOTE: requires a GPU + CARLA server; this script is the host-side harness only.
+"""
+import argparse
+import json
+import math
+import os
+import sys
+import time
+import urllib.request
+
+import carla  # the CARLA Python egg / pip package must be importable
+
+
+# --------------------------------------------------------------------------- #
+# The real checker — thin client over the verifier's actuator-enforcement API.
+# --------------------------------------------------------------------------- #
+class Governor:
+    def __init__(self, url, token):
+        self.endpoint = url.rstrip("/") + "/actuator/motion/command"
+        self.token = token
+
+    def enforce(self, proposed):
+        req = urllib.request.Request(self.endpoint, data=json.dumps(proposed).encode(), method="POST")
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Authorization", f"Bearer {self.token}")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read())
+
+
+# --------------------------------------------------------------------------- #
+# The doer — a lane-following controller proposing (target_v, steer_deg).
+# --------------------------------------------------------------------------- #
+MAX_STEER_DEG = 35.0   # road-wheel angle that maps to CARLA steer = ±1
+CRUISE_MPS = 12.0
+LOOKAHEAD_M = 6.0
+
+
+def speed_of(vehicle):
+    v = vehicle.get_velocity()
+    return math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z)
+
+
+def propose(world_map, vehicle, tick):
+    """Pure-pursuit-ish lane follow toward the next waypoint, + periodic over-reach."""
+    tf = vehicle.get_transform()
+    loc = tf.location
+    wp = world_map.get_waypoint(loc, project_to_road=True, lane_type=carla.LaneType.Driving)
+    nxts = wp.next(LOOKAHEAD_M) if wp else []
+    steer_deg = 0.0
+    if nxts:
+        target = nxts[0].transform.location
+        # Heading error between the vehicle's forward and the bearing to the target.
+        desired = math.degrees(math.atan2(target.y - loc.y, target.x - loc.x))
+        err = (desired - tf.rotation.yaw + 180.0) % 360.0 - 180.0
+        steer_deg = max(-MAX_STEER_DEG, min(MAX_STEER_DEG, err))
+    target_v = CRUISE_MPS
+    # Edge-case injection so the checker has something to bound (the tuning signal).
+    if tick % 200 == 0:
+        target_v = 30.0          # over-speed burst
+    elif tick % 130 == 0:
+        steer_deg = 30.0         # sharp lateral snap
+    return target_v, steer_deg
+
+
+def enforced_to_control(target_v, steer_deg, current_v):
+    """Map an enforced (target speed, steering angle) back to a CARLA control."""
+    steer = max(-1.0, min(1.0, steer_deg / MAX_STEER_DEG))
+    err = target_v - current_v
+    if err >= 0.0:
+        return carla.VehicleControl(throttle=min(1.0, 0.25 * err + 0.15), steer=steer, brake=0.0)
+    return carla.VehicleControl(throttle=0.0, steer=steer, brake=min(1.0, -0.25 * err))
+
+
+# --------------------------------------------------------------------------- #
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="localhost")
+    ap.add_argument("--port", type=int, default=2000)
+    ap.add_argument("--town", default="Town03")
+    ap.add_argument("--egos", type=int, default=3)
+    ap.add_argument("--ticks", type=int, default=4000)
+    ap.add_argument("--follow", type=int, default=0, help="ego index the spectator follows")
+    ap.add_argument("--out", default="carla_drive_session.jsonl")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--enforce", dest="enforce", action="store_true", default=True)
+    mode.add_argument("--shadow", dest="enforce", action="store_false")
+    args = ap.parse_args()
+
+    gov = Governor(os.environ.get("KIRRA_VERIFIER_URL", "http://localhost:8090"),
+                   os.environ.get("KIRRA_ADMIN_TOKEN", "test-token"))
+
+    client = carla.Client(args.host, args.port)
+    client.set_timeout(20.0)
+    world = client.load_world(args.town)
+    wmap = world.get_map()
+    original = world.get_settings()
+    spectator = world.get_spectator()
+    egos = []
+    dt = 0.05  # 20 Hz
+    interventions = total = 0
+    sum_dv = sum_ds = max_dv = 0.0
+
+    try:
+        settings = world.get_settings()
+        settings.synchronous_mode = True
+        settings.fixed_delta_seconds = dt
+        world.apply_settings(settings)
+
+        bp = world.get_blueprint_library().filter("vehicle.tesla.model3")[0]
+        spawns = wmap.get_spawn_points()
+        for i in range(min(args.egos, len(spawns))):
+            v = world.try_spawn_actor(bp, spawns[i])
+            if v:
+                if not args.enforce:
+                    v.set_autopilot(True)  # shadow: let the TM drive; we only observe
+                egos.append(v)
+        if not egos:
+            raise RuntimeError("no egos could be spawned (all points blocked?)")
+        print(f"[carla] {args.town}: spawned {len(egos)} egos, "
+              f"{'ENFORCE (governor controls)' if args.enforce else 'SHADOW (autopilot drives, governor observed)'}")
+
+        sink = open(args.out, "w")
+        for tick in range(args.ticks):
+            world.tick()
+            snap = world.get_snapshot()
+            t = snap.timestamp.elapsed_seconds
+
+            # Follow one ego with the spectator (a chase camera).
+            if 0 <= args.follow < len(egos):
+                ftf = egos[args.follow].get_transform()
+                back = ftf.get_forward_vector()
+                spectator.set_transform(carla.Transform(
+                    carla.Location(x=ftf.location.x - 8 * back.x, y=ftf.location.y - 8 * back.y, z=ftf.location.z + 5),
+                    carla.Rotation(pitch=-15, yaw=ftf.rotation.yaw)))
+
+            for idx, ego in enumerate(egos):
+                cur_v = speed_of(ego)
+                cur_steer = ego.get_control().steer * MAX_STEER_DEG
+                tv, sd = propose(wmap, ego, tick)
+                proposal = {
+                    "linear_velocity_mps": tv, "current_velocity_mps": cur_v,
+                    "delta_time_s": dt, "steering_angle_deg": sd,
+                    "current_steering_angle_deg": cur_steer,
+                }
+                try:
+                    resp = gov.enforce(proposal)
+                except Exception as e:
+                    print(f"tick {tick} ego {idx}: governor error {e}", file=sys.stderr)
+                    continue
+                enf_v = resp.get("enforced_linear_velocity_mps", tv)
+                enf_s = resp.get("enforced_steering_angle_deg", sd)
+                action = resp.get("action", "Allow")
+
+                if args.enforce:
+                    ego.apply_control(enforced_to_control(enf_v, enf_s, cur_v))
+
+                dv, ds = abs(tv - enf_v), abs(sd - enf_s)
+                total += 1
+                interventions += int(action != "Allow")
+                sum_dv += dv; sum_ds += ds; max_dv = max(max_dv, dv)
+                sink.write(json.dumps({
+                    "t": round(t, 3), "ego": idx,
+                    "x": round(ego.get_transform().location.x, 2),
+                    "y": round(ego.get_transform().location.y, 2),
+                    "speed": round(cur_v, 2), "action": action,
+                    "proposed": {"v": tv, "steer": round(sd, 2)},
+                    "enforced": {"v": enf_v, "steer": round(enf_s, 2)},
+                    "divergence": {"dv": round(dv, 3), "dsteer": round(ds, 3)},
+                }) + "\n")
+            if tick % 200 == 0:
+                sink.flush()
+        sink.close()
+    except KeyboardInterrupt:
+        print("\n[carla] interrupted by operator")
+    finally:
+        # Sync-mode teardown: revert settings BEFORE destroying actors (avoids a hang).
+        world.apply_settings(original)
+        client.apply_batch([carla.command.DestroyActor(e) for e in egos])
+        n = max(total, 1)
+        print("=== CARLA drive-session scorecard ===")
+        print(f"  log:               {args.out}")
+        print(f"  egos×ticks:        {total} decisions")
+        print(f"  intervention rate: {interventions}/{total}  ({100*interventions/n:.1f}%)")
+        print(f"  mean |Δv|:         {sum_dv/n:.3f} m/s   (max {max_dv:.2f})")
+        print(f"  mean |Δsteer|:     {sum_ds/n:.3f} deg")
+        print("  → lower intervention / smaller Δ = a better-aligned DOER (tune the doer, not the envelope)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/governor_drive_session.py
+++ b/scripts/governor_drive_session.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Drive an ego through the REAL Kirra governor and collect doer↔checker divergence
+data for tuning — the corrected, working shape of a CARLA tuning loop.
+
+Unlike a mock checker, every proposed command is POSTed to the live verifier's
+`/actuator/motion/command`, the *enforced* result is applied to the (kinematic)
+ego, and the (proposed, enforced, divergence) tuple is logged as JSONL. The
+governor bounds BOTH axes; this harness only proposes and records.
+
+  KIRRA_VERIFIER_URL=http://localhost:8090 KIRRA_ADMIN_TOKEN=test-token \
+    python3 scripts/governor_drive_session.py [ticks] [out.jsonl]
+
+To graduate to CARLA: replace `KinematicEgo` reads/writes with CARLA actor
+state + `apply_control`, and replace `Doer.propose` with your planner / ROS 2
+bridge. The governor call and the capture stay identical.
+
+SAFETY NOTE: tune the DOER from this data (make it propose checker-admissible
+commands more often), NEVER the checker's envelope — the speed cap, the 0.40 m
+margin, and the RSS bounds are safety-derived invariants, not knobs.
+"""
+import json
+import math
+import os
+import sys
+import time
+import urllib.request
+
+
+class Governor:
+    """Thin client over the real verifier's actuator-enforcement endpoint."""
+    def __init__(self, url: str, token: str):
+        self.endpoint = url.rstrip("/") + "/actuator/motion/command"
+        self.token = token
+
+    def enforce(self, proposed: dict) -> dict:
+        body = json.dumps(proposed).encode()
+        req = urllib.request.Request(self.endpoint, data=body, method="POST")
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Authorization", f"Bearer {self.token}")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read())
+
+
+class KinematicEgo:
+    """A minimal bicycle-ish ego the enforced command is integrated onto."""
+    def __init__(self):
+        self.x = 0.0
+        self.heading = 0.0
+        self.speed = 0.0
+        self.wheelbase = 2.7
+
+    def apply(self, v_mps: float, steer_deg: float, dt: float):
+        self.speed = v_mps
+        self.heading += (v_mps / self.wheelbase) * math.tan(math.radians(steer_deg)) * dt
+        self.x += v_mps * math.cos(self.heading) * dt
+
+
+class Doer:
+    """The proposer. Cruises, and periodically over-reaches (an aggressive merge /
+    a hallucinated over-speed) so the governor has something to bound — the
+    interventions are the tuning signal."""
+    def propose(self, tick: int, ego: KinematicEgo, dt: float) -> dict:
+        v, steer = 12.0, 0.0
+        if tick % 17 == 0:        # over-speed burst
+            v = 30.0
+        elif tick % 11 == 0:      # sharp lateral snap
+            steer = 28.0
+        return {
+            "linear_velocity_mps": v,
+            "current_velocity_mps": ego.speed,
+            "delta_time_s": dt,
+            "steering_angle_deg": steer,
+            "current_steering_angle_deg": 0.0,
+        }
+
+
+def main():
+    url = os.environ.get("KIRRA_VERIFIER_URL", "http://localhost:8090")
+    token = os.environ.get("KIRRA_ADMIN_TOKEN", "test-token")
+    ticks = int(sys.argv[1]) if len(sys.argv) > 1 else 120
+    out_path = sys.argv[2] if len(sys.argv) > 2 else "drive_session.jsonl"
+    dt = 0.05  # 20 Hz
+
+    gov, ego, doer = Governor(url, token), KinematicEgo(), Doer()
+    interventions = 0
+    sum_dv = sum_dsteer = max_dv = 0.0
+
+    with open(out_path, "w") as sink:
+        for tick in range(ticks):
+            proposed = doer.propose(tick, ego, dt)
+            try:
+                resp = gov.enforce(proposed)
+            except Exception as e:
+                print(f"tick {tick}: governor error {e}", file=sys.stderr)
+                continue
+
+            enf_v = resp.get("enforced_linear_velocity_mps", proposed["linear_velocity_mps"])
+            enf_steer = resp.get("enforced_steering_angle_deg", proposed["steering_angle_deg"])
+            action = resp.get("action", "Allow")
+            ego.apply(enf_v, enf_steer, dt)
+
+            dv = abs(proposed["linear_velocity_mps"] - enf_v)
+            dsteer = abs(proposed["steering_angle_deg"] - enf_steer)
+            intervened = action != "Allow"
+            interventions += int(intervened)
+            sum_dv += dv
+            sum_dsteer += dsteer
+            max_dv = max(max_dv, dv)
+
+            sink.write(json.dumps({
+                "t": round(tick * dt, 3),
+                "ego_x": round(ego.x, 3),
+                "ego_speed": round(ego.speed, 3),
+                "action": action,
+                "proposed": {"v": proposed["linear_velocity_mps"], "steer": proposed["steering_angle_deg"]},
+                "enforced": {"v": enf_v, "steer": enf_steer},
+                "divergence": {"dv": round(dv, 3), "dsteer": round(dsteer, 3)},
+            }) + "\n")
+
+    n = max(ticks, 1)
+    print(f"=== Governor drive-session scorecard ({ticks} ticks @ {1/dt:.0f} Hz) ===")
+    print(f"  log:                 {out_path}")
+    print(f"  intervention rate:   {interventions}/{ticks}  ({100*interventions/n:.1f}%)")
+    print(f"  mean |Δv| (clamp):   {sum_dv/n:.3f} m/s   (max {max_dv:.2f})")
+    print(f"  mean |Δsteer|:       {sum_dsteer/n:.3f} deg")
+    print(f"  ego advanced to x =  {ego.x:.1f} m   (final speed {ego.speed:.1f} m/s)")
+    print("  → lower intervention rate / smaller Δ = a better-aligned DOER (tune the doer, not the envelope)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/governor_drive_session.py
+++ b/scripts/governor_drive_session.py
@@ -11,6 +11,19 @@ governor bounds BOTH axes; this harness only proposes and records.
   KIRRA_VERIFIER_URL=http://localhost:8090 KIRRA_ADMIN_TOKEN=test-token \
     python3 scripts/governor_drive_session.py [ticks] [out.jsonl]
 
+Besides the human-readable divergence log (`out.jsonl`), it ALSO emits the two
+files `kirra-collector` joins into a supervised dataset:
+  - `<out>.capture.jsonl` — one `kirra_capture_schema::CaptureRecord` per tick
+    (the governor's correction: ALLOW / CLAMP_LINEAR / CLAMP_STEERING / DENY).
+  - `<out>.bag.json`       — the matching bus recording (a JSON array of
+    `BusMessage`, the doer-side proposal stamp the record joins against).
+Feed them straight into the collector:
+  cargo run -p kirra-collector -- \
+    --capture <out>.capture.jsonl --bag-json <out>.bag.json \
+    --out dataset/ --window-ms 100
+The capture crate (`kirra-capture-schema`) is the ONLY shared dependency — the
+collector never links the verifier, so it cannot reach the verdict path.
+
 To graduate to CARLA: replace `KinematicEgo` reads/writes with CARLA actor
 state + `apply_control`, and replace `Doer.propose` with your planner / ROS 2
 bridge. The governor call and the capture stay identical.
@@ -75,18 +88,54 @@ class Doer:
         }
 
 
+def capture_record(tick, t_wall_ms, proposed, action, enf_v, enf_steer, resp):
+    """Map one governor decision onto the `kirra_capture_schema::CaptureRecord`
+    wire shape (SCREAMING_SNAKE outcome; `safe_value` carries the clamped value)."""
+    if action == "ClampLinear":
+        outcome, safe_value, deny_code = "CLAMP_LINEAR", enf_v, None
+    elif action == "ClampSteering":
+        outcome, safe_value, deny_code = "CLAMP_STEERING", enf_steer, None
+    elif action == "DenyBreach":
+        outcome, safe_value, deny_code = "DENY", None, resp.get("deny_code") or resp.get("reason")
+    else:  # "Allow"
+        outcome, safe_value, deny_code = "ALLOW", None, None
+    return {
+        "decision_seq": tick,
+        "t_mono_ns": t_wall_ms * 1_000_000,
+        "t_wall_ms": t_wall_ms,
+        "source": "COMMAND_GATEWAY",
+        "proposed": {
+            "linear_velocity_mps": proposed["linear_velocity_mps"],
+            "current_velocity_mps": proposed["current_velocity_mps"],
+            "steering_angle_deg": proposed["steering_angle_deg"],
+            "current_steering_angle_deg": proposed["current_steering_angle_deg"],
+            "delta_time_s": proposed["delta_time_s"],
+        },
+        "outcome": outcome,
+        "deny_code": deny_code,
+        "safe_value": safe_value,
+        "mrc": bool(resp.get("mrc", False)),
+        "posture": "NOMINAL",
+        "derate_enabled": False,
+    }
+
+
 def main():
     url = os.environ.get("KIRRA_VERIFIER_URL", "http://localhost:8090")
     token = os.environ.get("KIRRA_ADMIN_TOKEN", "test-token")
     ticks = int(sys.argv[1]) if len(sys.argv) > 1 else 120
     out_path = sys.argv[2] if len(sys.argv) > 2 else "drive_session.jsonl"
+    base = out_path[:-6] if out_path.endswith(".jsonl") else out_path
+    capture_path, bag_path = base + ".capture.jsonl", base + ".bag.json"
     dt = 0.05  # 20 Hz
+    doer_version = "occy-drive-demo"
 
     gov, ego, doer = Governor(url, token), KinematicEgo(), Doer()
     interventions = 0
     sum_dv = sum_dsteer = max_dv = 0.0
+    bus = []  # the matching bus recording (one BusMessage per emitted record)
 
-    with open(out_path, "w") as sink:
+    with open(out_path, "w") as sink, open(capture_path, "w") as cap:
         for tick in range(ticks):
             proposed = doer.propose(tick, ego, dt)
             try:
@@ -118,14 +167,34 @@ def main():
                 "divergence": {"dv": round(dv, 3), "dsteer": round(dsteer, 3)},
             }) + "\n")
 
+            # The supervised-dataset pair: the CaptureRecord (what KIRRA corrected)
+            # + the BusMessage it joins against (the doer-side proposal, same stamp).
+            t_wall_ms = tick * int(dt * 1000)
+            cap.write(json.dumps(capture_record(tick, t_wall_ms, proposed, action, enf_v, enf_steer, resp)) + "\n")
+            bus.append({
+                "t_wall_ms": t_wall_ms,
+                "doer_version": doer_version,
+                "asset_id": "ego",
+                "trajectory_id": tick,
+                "objects_ms": t_wall_ms,
+                "bulk_ref": f"mem://drive#{tick}",
+            })
+
+    with open(bag_path, "w") as bag:
+        json.dump(bus, bag)
+
     n = max(ticks, 1)
     print(f"=== Governor drive-session scorecard ({ticks} ticks @ {1/dt:.0f} Hz) ===")
     print(f"  log:                 {out_path}")
+    print(f"  capture (collector): {capture_path}")
+    print(f"  bus    (collector):  {bag_path}")
     print(f"  intervention rate:   {interventions}/{ticks}  ({100*interventions/n:.1f}%)")
     print(f"  mean |Δv| (clamp):   {sum_dv/n:.3f} m/s   (max {max_dv:.2f})")
     print(f"  mean |Δsteer|:       {sum_dsteer/n:.3f} deg")
     print(f"  ego advanced to x =  {ego.x:.1f} m   (final speed {ego.speed:.1f} m/s)")
     print("  → lower intervention rate / smaller Δ = a better-aligned DOER (tune the doer, not the envelope)")
+    print(f"  → feed the dataset: cargo run -p kirra-collector -- "
+          f"--capture {capture_path} --bag-json {bag_path} --out dataset/ --window-ms 100")
 
 
 if __name__ == "__main__":

--- a/scripts/orin_bringup.sh
+++ b/scripts/orin_bringup.sh
@@ -45,20 +45,23 @@ else
 fi
 
 echo "== 2. build the four components + governance plane (release) =="
-# The stack demo (Taj→Mick→Occy→KIRRA) and the verifier service. Release on the Orin.
+# The stack demo (Taj→Mick→Occy→KIRRA), the HTTP sidecars (Occy planner + Taj
+# perception), and the verifier service. Release on the Orin.
 cargo build --release -p kirra-mick --example taj_occy_kirra_stack
 cargo build --release -p kirra-mick --example planner_service
+cargo build --release -p kirra-mick --example taj_service
 cargo build --release --bin kirra_verifier_service
 
 echo "== 3. run the headless stack demo (Taj · Mick · Occy · KIRRA) =="
 cargo run --release -p kirra-mick --example taj_occy_kirra_stack
 
 if [[ "$SERVE" == "1" ]]; then
-  echo "== 4. start the governance plane + Occy planner endpoint =="
+  echo "== 4. start the governance plane + Occy planner + Taj perception sidecars =="
   : "${KIRRA_ADMIN_TOKEN:?set KIRRA_ADMIN_TOKEN (admin/mutation routes fail-closed without it)}"
   : "${KIRRA_SUPERVISOR_RESET_KEY:?set KIRRA_SUPERVISOR_RESET_KEY (non-empty, <=64 bytes)}"
   export KIRRA_DB_PATH="${KIRRA_DB_PATH:-/tmp/kirra_orin.sqlite}"
   export KIRRA_VERIFIER_ADDR="${KIRRA_VERIFIER_ADDR:-127.0.0.1:8090}"
+  export KIRRA_TAJ_ADDR="${KIRRA_TAJ_ADDR:-127.0.0.1:8101}"
 
   echo "  starting KIRRA verifier service on $KIRRA_VERIFIER_ADDR (governance/console plane)…"
   ./target/release/kirra_verifier_service &
@@ -66,12 +69,28 @@ if [[ "$SERVE" == "1" ]]; then
   echo "  starting Occy planner endpoint on 127.0.0.1:8100 (POST /plan)…"
   ./target/release/examples/planner_service &
   PLAN=$!
-  trap 'kill $VER $PLAN 2>/dev/null || true' EXIT INT TERM
+  echo "  starting Taj perception sidecar on $KIRRA_TAJ_ADDR (POST /perception — the cmd_vel speed cap)…"
+  ./target/release/examples/taj_service &
+  TAJ=$!
+  trap 'kill $VER $PLAN $TAJ 2>/dev/null || true' EXIT INT TERM
+
+  # Wait for the three sidecars to answer their health checks before declaring up.
+  for svc in "verifier|http://$KIRRA_VERIFIER_ADDR/health" "planner|http://127.0.0.1:8100/health" "taj|http://$KIRRA_TAJ_ADDR/health"; do
+    name="${svc%%|*}"; url="${svc##*|}"
+    for _ in $(seq 1 20); do
+      curl -sf "$url" >/dev/null 2>&1 && { echo "  ✓ $name up ($url)"; break; }
+      sleep 0.5
+    done
+  done
+
   echo
   echo "  Stack is up. Drive real egos against it with a ROS 2 node or the Python harness:"
   echo "    KIRRA_VERIFIER_URL=http://$KIRRA_VERIFIER_ADDR KIRRA_ADMIN_TOKEN=\$KIRRA_ADMIN_TOKEN \\"
   echo "      python3 scripts/carla_drive_session.py --occy http://127.0.0.1:8100   # Occy as the doer"
-  echo "    (on the robot: the ros2_ws/src/kirra_safety launch wires cmd_vel through the same governor.)"
+  echo "  On the robot, the ros2_ws/src/kirra_safety launch wires cmd_vel through the same governor,"
+  echo "  and Taj's corridor derates it (the perception_governor node POSTs /scan to the sidecar above):"
+  echo "    ros2 launch kirra_safety kirra_with_robot.launch.py \\"
+  echo "      kirra_token:=\$KIRRA_ADMIN_TOKEN taj_url:=http://$KIRRA_TAJ_ADDR use_perception_cap:=true"
   echo "  Ctrl-C to stop."
   wait
 fi

--- a/scripts/orin_bringup.sh
+++ b/scripts/orin_bringup.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Bring up the full Kirra System-2 stack — Taj · Mick · Occy · KIRRA — on a Jetson
+# Orin NX 16GB (ADR-0014), built NATIVELY for aarch64. No GPU, no CARLA, no ROS are
+# required: the doer-checker stack is pure Rust compute, so it builds and runs on the
+# Orin exactly as it would on the robot's System-2 board.
+#
+# What it does:
+#   1. sanity-checks the toolchain (and the Orin, if that's where you're running it),
+#   2. builds the four components + the governance plane (the verifier service),
+#   3. runs the headless four-component stack demo (Taj→Mick→Occy→KIRRA),
+#   4. optionally starts the KIRRA verifier service (the governance/console plane) and
+#      the Occy planner HTTP endpoint, so a ROS 2 / Python client can drive real egos.
+#
+# Usage:
+#   scripts/orin_bringup.sh            # build + run the headless stack demo
+#   scripts/orin_bringup.sh --serve    # also start the verifier (:8090) + planner (:8100)
+#
+# This is the SINGLE-BOX bring-up (Phase 1 of ADR-0014). The stronger two-box topology
+# (governor on a separate Pi over the kirra-governor-service UDP wire) is documented in
+# docs/testing/ORIN_NX_STACK_BRINGUP.md.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SERVE=0
+[[ "${1:-}" == "--serve" ]] && SERVE=1
+
+echo "== 1. toolchain + platform =="
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "  cargo not found. Install Rust (rustup) first:"
+  echo "    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+  exit 1
+fi
+echo "  rustc: $(rustc --version)"
+ARCH="$(uname -m)"
+echo "  arch:  $ARCH"
+if [[ "$ARCH" == "aarch64" ]]; then
+  echo "  → aarch64: native Orin/Jetson build."
+  if [[ -r /etc/nv_tegra_release ]]; then
+    echo "  → Jetson detected: $(head -1 /etc/nv_tegra_release)"
+    echo "    tip: run 'sudo nvpmodel -q' / set a power mode; the governor is ~0 W, System-2 is the budget."
+  fi
+else
+  echo "  → $ARCH: not a Jetson; this still builds the SAME stack (the demo is hardware-agnostic)."
+fi
+
+echo "== 2. build the four components + governance plane (release) =="
+# The stack demo (Taj→Mick→Occy→KIRRA) and the verifier service. Release on the Orin.
+cargo build --release -p kirra-mick --example taj_occy_kirra_stack
+cargo build --release -p kirra-mick --example planner_service
+cargo build --release --bin kirra_verifier_service
+
+echo "== 3. run the headless stack demo (Taj · Mick · Occy · KIRRA) =="
+cargo run --release -p kirra-mick --example taj_occy_kirra_stack
+
+if [[ "$SERVE" == "1" ]]; then
+  echo "== 4. start the governance plane + Occy planner endpoint =="
+  : "${KIRRA_ADMIN_TOKEN:?set KIRRA_ADMIN_TOKEN (admin/mutation routes fail-closed without it)}"
+  : "${KIRRA_SUPERVISOR_RESET_KEY:?set KIRRA_SUPERVISOR_RESET_KEY (non-empty, <=64 bytes)}"
+  export KIRRA_DB_PATH="${KIRRA_DB_PATH:-/tmp/kirra_orin.sqlite}"
+  export KIRRA_VERIFIER_ADDR="${KIRRA_VERIFIER_ADDR:-127.0.0.1:8090}"
+
+  echo "  starting KIRRA verifier service on $KIRRA_VERIFIER_ADDR (governance/console plane)…"
+  ./target/release/kirra_verifier_service &
+  VER=$!
+  echo "  starting Occy planner endpoint on 127.0.0.1:8100 (POST /plan)…"
+  ./target/release/examples/planner_service &
+  PLAN=$!
+  trap 'kill $VER $PLAN 2>/dev/null || true' EXIT INT TERM
+  echo
+  echo "  Stack is up. Drive real egos against it with a ROS 2 node or the Python harness:"
+  echo "    KIRRA_VERIFIER_URL=http://$KIRRA_VERIFIER_ADDR KIRRA_ADMIN_TOKEN=\$KIRRA_ADMIN_TOKEN \\"
+  echo "      python3 scripts/carla_drive_session.py --occy http://127.0.0.1:8100   # Occy as the doer"
+  echo "    (on the robot: the ros2_ws/src/kirra_safety launch wires cmd_vel through the same governor.)"
+  echo "  Ctrl-C to stop."
+  wait
+fi


### PR DESCRIPTION
## What this is

The end-to-end **doer→checker loop on a Jetson Orin NX**, plus the data/observability/deployment scaffolding around it, and a clean **per-platform profile** so a small robot and a road AV share *logic* but never *numbers*. Everything is additive/opt-in — the robotaxi/AV path is frozen and proven unchanged.

The thesis throughout: **Mick/Occy proposes, KIRRA disposes.** The doer is swappable and untrusted; the checker is the invariant.

## Highlights

### Doer-checker loop on hardware
- **`occy_doer`** ROS node — the missing doer: each tick it feeds robot pose + goal + the Taj corridor to the Occy planner endpoint and republishes the KIRRA-validated trajectory to `/cmd_vel_raw` (then re-governed by the interceptor). Pure goal-frame transform + pure-pursuit + drive/hold decision factored into `doer_core.py` (13 unit tests, no ROS).
- **`planner_service`** (Occy `POST /plan`) + **`taj_service`** (Taj `POST /perception`) HTTP sidecars over the real Rust crates.
- **`taj_occy_kirra_stack`** example — all four components in one aarch64-native process across clear/stop/route-around/locked-out regimes.

### Taj → live `cmd_vel` perception derate (ADR-0014 "lidar safety buffer")
- `taj_service` turns a scan into an **assured-clear-distance speed cap**; `perception_governor` publishes it; the interceptor applies it **before** the governor — Taj tightens, KIRRA bounds. Opt-in, fail-closed (`perception_cap.py`, 8 unit tests). Verified end-to-end: clear→1.8, obstacle 1.0 m→1.34, in-standoff→0, stale→0.

### Observe + deploy
- **Gazebo-on-Orin demo** (`kirra_gazebo_demo.launch.py`) — a robot drives into a wall; Taj+KIRRA brake it to a controlled stop. ARM-native, single command.
- **systemd units** (`deploy/systemd/`) — verifier + planner + Taj come up on boot; `install.sh` generates strong secrets (none committed); fixed a latent `StartLimitIntervalSec` placement bug in the verifier unit.
- **`scripts/orin_bringup.sh`** — native build + `--serve` brings up all three sidecars (health-checked).
- **kirra-collector wiring** — drive-session divergence → `CaptureRecord` JSONL + bag → Parquet supervised dataset (joined 120/120, demonstrated).

### Per-platform profiles (the structural guarantee)
- The slow-loop checker's **RSS lateral band is now per-class** (`VehicleConfig` field), with `default_urban` (robotaxi) **frozen at 4.0 m by test** and a `courier()` sibling at 0.6 m.
- **`VehicleConfig::for_class()`** + `delivery_av()` — the slow-loop class family mirrors the fast-loop `VehicleClass`, selected by one class string.
- **[ADR-0027](docs/adr/0027-sidewalk-courier-odd.md)** — pins the **Sidewalk Courier ODD**: a pedestrian-space class (creep + assured-clear-distance + impact-energy + drivable-surface containment; RSS car-following demoted to a backstop), not a shrunk car. `CONTRACT_PROFILES.md` gains the `*.rss_lateral_band` row.

## Safety invariants held
- Robotaxi/AV path **byte-identical and frozen-by-test** (`default_urban_rss_band_is_the_frozen_robotaxi_value`); the two ODDs share logic, never numbers.
- Perception derate is opt-in (default off → identical prior path) and fail-closed.
- Secrets are env-only with no hardcoded fallback; none committed.
- `kirra-collector` depends on `kirra-capture-schema` only (never the verifier); the planner/Taj endpoints live in `kirra-mick`, not the verifier crate.

## Validation
- `kirra-ros2-adapter`: 67 lib + 30 integration tests green (incl. the new per-class + frozen-value tests).
- `kirra-planner` suites green (no downstream regression); `cargo clippy` clean on touched crates.
- ROS Python: 34 unit tests green; nodes/launches syntax-checked + structurally validated (the live `ros2 launch` requires ROS/Gazebo on the Orin).
- systemd units pass `systemd-analyze verify`.

## Honest scope
- Today the robot **drives straight down clear corridors and stops before obstacles** — the right first-hardware behavior. The per-class change fixes the **checker** (it now *admits* a robot-scale side pass); the **doer** proposing the pass, and the sidewalk intents (`Yield`/`CrossWhenClear`), are tracked doer-side follow-ups with zero safety-case impact.
- The Rust sidecars, the perception derate, the per-class profile, and the collector pipeline are *run/tested here*; the full `ros2 launch` + Gazebo render need the Orin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58)_