### PR TITLE
Complete the sidewalk-courier behavior set: creep-through-crowd + the LLM courier brain (ADR-0027)

### DIFF
--- a/crates/kirra-mick/examples/mick_sidewalk_brain.rs
+++ b/crates/kirra-mick/examples/mick_sidewalk_brain.rs
@@ -1,0 +1,127 @@
+//! **The sidewalk-courier brain: a local LLM authors sidewalk intents, KIRRA bounds them (ADR-0027).**
+//! Mick's `LlmBrain::courier(...)` prompts a pedestrian-space persona offered ONLY the sidewalk
+//! intents (`go_to` / `yield` / `cross_when_clear` / `creep_through` / `hold`) — no road maneuvers —
+//! and is grammar-constrained to them. Each authored intent is grounded by Occy (courier planner)
+//! and bounded by KIRRA (courier checker), so the model can never make the robot unsafe.
+//!
+//! This runs against a deterministic `MockModel` (no network), so it works anywhere — it stands in
+//! for the choice a local Gemma would make per situation. On the Orin, swap one line:
+//!     let brain = LlmBrain::courier(kirra_mick::OllamaClient::courier());   // real Gemma via Ollama
+//!
+//! Run: `cargo run -p kirra-mick --example mick_sidewalk_brain`
+
+use kirra_core::FleetPosture;
+use kirra_planner::{
+    plan_for_intent, EgoState, GeometricPlanner, GeometricPlannerConfig, Goal, LlmBrain, MickBrain,
+    MockModel, ObjectView, PlanInput, Pose, ProposalKind, WorldContext,
+};
+use kirra_ros2_adapter::corridor::{MockCorridorSource, Point};
+use kirra_ros2_adapter::state::{PerceivedObject, TrajectoryVerdict};
+use kirra_ros2_adapter::{validate_trajectory_slow, VehicleConfig};
+
+const EGO_X: f64 = 2.0;
+
+/// A scene: nearby objects (ego-relative ahead/left), and the goal ahead. Builds both the
+/// `WorldContext` the brain sees and the `PlanInput` Occy grounds against.
+struct Scene {
+    objects: Vec<(f64, f64, f64)>, // (ahead_m, left_m, speed_mps)
+    goal_ahead_m: f64,
+}
+
+impl Scene {
+    fn world_context(&self) -> WorldContext {
+        WorldContext {
+            ego_speed_mps: 1.0,
+            posture: "NOMINAL",
+            goal_ahead_m: self.goal_ahead_m,
+            goal_left_m: 0.0,
+            may_change_left: false,
+            may_change_right: false,
+            objects: self.objects.iter().enumerate()
+                .map(|(i, &(a, l, s))| ObjectView { id: i as u64, ahead_m: a, left_m: l, speed_mps: s })
+                .collect(),
+            available_turns: Vec::new(),
+        }
+    }
+    fn perceived(&self) -> Vec<PerceivedObject> {
+        self.objects.iter().enumerate().map(|(i, &(a, l, s))| PerceivedObject {
+            id: i as u64, pos: Point { x_m: EGO_X + a, y_m: l }, velocity_mps: s, heading_rad: 0.0,
+            vel: Point { x_m: 0.0, y_m: s }, // crossing agents move laterally
+        }).collect()
+    }
+}
+
+fn main() {
+    let corr = MockCorridorSource::straight_5m_half_width(100.0);
+    let vcfg = VehicleConfig::courier();
+    let mut occy = GeometricPlanner::new(GeometricPlannerConfig::courier());
+
+    // One look at the prompt the local model actually receives (sidewalk persona, sidewalk intents).
+    let demo = Scene { objects: vec![(3.0, 0.0, 0.0)], goal_ahead_m: 14.0 };
+    println!("===== the courier prompt Gemma sees (excerpt) =====");
+    let prompt = kirra_planner::build_courier_prompt(&demo.world_context());
+    for line in prompt.lines().take(12) { println!("  {line}"); }
+    println!("  ...\n");
+
+    // Scenarios: the situation, and the sidewalk intent the local model emits for it (MockModel
+    // stands in for Gemma). Each is grounded + checked.
+    let scenarios: &[(&str, &str, Scene)] = &[
+        ("clear sidewalk ahead",
+         r#"{"intent":"go_to","x_m":14.0,"y_m":0.0}"#,
+         Scene { objects: vec![], goal_ahead_m: 14.0 }),
+        ("a pedestrian standing in the path",
+         r#"{"intent":"yield","x_m":14.0,"y_m":0.0}"#,
+         Scene { objects: vec![(5.0, 0.0, 0.0)], goal_ahead_m: 14.0 }),
+        ("a dense crowd around the robot",
+         r#"{"intent":"creep_through","x_m":14.0,"y_m":0.0}"#,
+         Scene { objects: vec![(2.5, 0.3, 0.2), (3.5, -0.4, 0.1), (4.0, 0.5, 0.0)], goal_ahead_m: 14.0 }),
+        ("at a crosswalk, a car approaching",
+         r#"{"intent":"cross_when_clear","x_m":9.0,"y_m":0.0}"#,
+         Scene { objects: vec![(4.0, -12.0, 6.0)], goal_ahead_m: 9.0 }),
+    ];
+
+    println!("===== Mick(courier brain) → Occy(doer) → KIRRA(courier checker) =====");
+    println!("  {:<34} {:<16} {:<10} kirra", "situation", "Mick intent", "occy");
+    println!("  {}", "-".repeat(78));
+    for (desc, reply, scene) in scenarios {
+        // The local model authors the intent (MockModel == a fixed Gemma choice for this situation).
+        let mut brain = LlmBrain::courier(MockModel::replying(*reply));
+        let intent = match brain.decide(&scene.world_context()) {
+            Ok(i) => i,
+            Err(e) => { println!("  {desc:<34} <fail-closed: {e}>"); continue; }
+        };
+
+        // Occy grounds it; KIRRA (courier profile) bounds it.
+        let objs = scene.perceived();
+        let world = PlanInput {
+            ego: EgoState { pose: Pose { x_m: EGO_X, y_m: 0.0, heading_rad: 0.0 }, linear_x_mps: 1.0, yaw_rate_rads: 0.0, stamp_ms: 0 },
+            goal: Goal { target: Pose { x_m: EGO_X + scene.goal_ahead_m, y_m: 0.0, heading_rad: 0.0 } },
+            map: &corr, objects: &objs, controls: &[], lane_boundaries: &[], motion: &[], predicted_paths: &[],
+            cedes_to_ego_ids: &[], lane_change_to_m: None, no_overtake_ids: &[], drivable: None,
+            posture: FleetPosture::Nominal, target_speed_mps: None,
+            request_overtake: false, request_pull_over: false, lane_graph: None, signal_states: &[],
+        };
+        let plan = plan_for_intent(&mut occy, &intent, &world);
+        let verdict = validate_trajectory_slow(&plan.trajectory, &corr, &objs, &vcfg, None, FleetPosture::Nominal);
+
+        let intent_tag = match intent {
+            kirra_planner::MickIntent::GoTo { .. } => "go_to",
+            kirra_planner::MickIntent::Yield { .. } => "yield",
+            kirra_planner::MickIntent::CreepThrough { .. } => "creep_through",
+            kirra_planner::MickIntent::CrossWhenClear { .. } => "cross_when_clear",
+            kirra_planner::MickIntent::Hold => "hold",
+            _ => "other",
+        };
+        let kind = match plan.kind { ProposalKind::Motion => "Motion", ProposalKind::SafeStop => "SafeStop" };
+        let v = match verdict {
+            TrajectoryVerdict::Accept => "Accept", TrajectoryVerdict::Clamp => "Clamp",
+            TrajectoryVerdict::MRCFallback => "MRCFallback", other => { println!("{other:?}"); "?" }
+        };
+        println!("  {desc:<34} {intent_tag:<16} {kind:<10} {v}");
+    }
+
+    println!("\n  The courier brain authors only sidewalk intents (grammar-constrained); Occy grounds");
+    println!("  them and KIRRA (courier profile) bounds every one. Swap MockModel for");
+    println!("  OllamaClient::courier() to drive this with a local Gemma on the Orin — the model can");
+    println!("  never make the robot unsafe: its intent is grounded by Occy and bounded by KIRRA.");
+}

--- a/crates/kirra-mick/src/lib.rs
+++ b/crates/kirra-mick/src/lib.rs
@@ -42,11 +42,12 @@ pub struct OllamaClient {
     base_url: String,
     model: String,
     http: reqwest::blocking::Client,
+    persona: kirra_planner::Persona,
 }
 
 impl OllamaClient {
     /// Construct from the environment: `KIRRA_OLLAMA_URL` (default [`DEFAULT_OLLAMA_URL`])
-    /// and `KIRRA_MICK_MODEL` (default [`DEFAULT_MODEL`]).
+    /// and `KIRRA_MICK_MODEL` (default [`DEFAULT_MODEL`]). Chauffeur persona.
     #[must_use]
     pub fn new() -> Self {
         let base_url = std::env::var("KIRRA_OLLAMA_URL").unwrap_or_else(|_| DEFAULT_OLLAMA_URL.to_string());
@@ -54,14 +55,29 @@ impl OllamaClient {
         Self::with(base_url, model)
     }
 
-    /// Construct with an explicit base URL + model id.
+    /// Construct with an explicit base URL + model id. Chauffeur persona.
     #[must_use]
     pub fn with(base_url: impl Into<String>, model: impl Into<String>) -> Self {
         let http = reqwest::blocking::Client::builder()
             .timeout(REQUEST_TIMEOUT)
             .build()
             .unwrap_or_else(|_| reqwest::blocking::Client::new());
-        Self { base_url: base_url.into(), model: model.into(), http }
+        Self { base_url: base_url.into(), model: model.into(), http, persona: kirra_planner::Persona::Chauffeur }
+    }
+
+    /// Set the persona — its constrained-decode schema gates the model's output tags (so a
+    /// sidewalk courier is grammar-constrained to the sidewalk intents). Pair with
+    /// `LlmBrain::courier(...)`, which selects the matching prompt.
+    #[must_use]
+    pub fn with_persona(mut self, persona: kirra_planner::Persona) -> Self {
+        self.persona = persona;
+        self
+    }
+
+    /// A sidewalk-courier Ollama client (constrained to sidewalk intents), from the environment.
+    #[must_use]
+    pub fn courier() -> Self {
+        Self::new().with_persona(kirra_planner::Persona::SidewalkCourier)
     }
 
     /// The configured model id.
@@ -107,7 +123,7 @@ impl ModelClient for OllamaClient {
             model: &self.model,
             prompt,
             stream: false,
-            format: kirra_planner::intent_schema(),
+            format: self.persona.schema(),
         };
 
         // Every failure maps to a stable ModelError → LlmBrain fails closed → HOLD.

--- a/crates/kirra-planner/src/behavior.rs
+++ b/crates/kirra-planner/src/behavior.rs
@@ -288,6 +288,46 @@ pub fn cross_when_clear(
     )
 }
 
+/// Hard contact floor (m): the courier never advances within this of a pedestrian — it stops,
+/// never nudges into someone. Tighter than the Yield standoff (a deliberate, last-resort minimum).
+pub const DEFAULT_CROWD_CONTACT_FLOOR_M: f64 = 0.4;
+
+/// The gentle "nudge" speed (m/s) the courier creeps at through a crowd — slow enough that people
+/// make way and any contact is negligible-energy (KIRRA's impact-energy bound backstops it).
+pub const DEFAULT_CROWD_NUDGE_SPEED_MPS: f64 = 0.3;
+
+/// **Creep through a crowd (a soft nudge, not a freeze).** A pure [`yield_to_vru_speed_cap`] stops a
+/// full standoff (≈1 m) before the nearest pedestrian — which, in a dense crowd, freezes the courier
+/// indefinitely. This relaxes that to a gentle creep: the courier keeps inching forward at up to
+/// `nudge_speed_mps` while a pedestrian is in its path band, ramping to a stop only at the much
+/// tighter `contact_floor_m` (so it NEVER pushes into anyone). Returns the speed cap (m/s), or
+/// `None` when no VRU is in the band. A VRU within the contact floor → `Some(0.0)` (stop).
+///
+/// Derate-only / fail-closed: the cap is `min(nudge, assured-clear-distance over the gap to the
+/// contact floor)`, so it can only LOWER speed and tapers to zero at the floor. It is a deliberate,
+/// opt-in RELAXATION of the full-stop yield for crowd ODDs; the speed stays sub-walking-pace and
+/// KIRRA's impact-energy + containment bounds independently backstop it.
+// SAFETY: SG1 SG6 | REQ: sidewalk-creep-through-crowd | TEST: no_vru_means_no_crowd_cap,a_vru_in_the_crowd_caps_to_a_gentle_nudge,a_vru_at_the_contact_floor_stops_the_courier,the_crowd_nudge_never_exceeds_the_nudge_speed,creep_through_advances_where_a_full_yield_would_freeze
+#[must_use]
+pub fn creep_through_crowd_speed_cap(
+    vrus: &[VruApproach],
+    band_half_width_m: f64,
+    contact_floor_m: f64,
+    nudge_speed_mps: f64,
+    brake_decel_mps2: f64,
+) -> Option<f64> {
+    let nearest = vrus
+        .iter()
+        .filter(|v| v.ahead_m > 0.0 && v.lateral_offset_m.abs() <= band_half_width_m)
+        .map(|v| v.ahead_m)
+        .fold(f64::INFINITY, f64::min);
+    if !nearest.is_finite() {
+        return None;
+    }
+    let acd = assured_clear_distance_speed_cap((nearest - contact_floor_m).max(0.0), brake_decel_mps2);
+    Some(acd.min(nudge_speed_mps.max(0.0)))
+}
+
 /// Tunables for the behavioral layer.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BehaviorConfig {
@@ -750,5 +790,45 @@ mod tests {
         // A car crawling at 0.5 m/s just 8 m away reads as 16 s by d/v, but the interaction model
         // worst-cases its re-acceleration → it is NOT trusted; the courier holds.
         assert!(!cross_when_clear(&[conflict(8.0, 0.5)], 6.0, 1.0, DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S, A));
+    }
+
+    // --- creep through a crowd (ADR-0027) -----------------------------------
+
+    const FLOOR: f64 = DEFAULT_CROWD_CONTACT_FLOOR_M;   // 0.4
+    const NUDGE: f64 = DEFAULT_CROWD_NUDGE_SPEED_MPS;   // 0.3
+
+    #[test]
+    fn no_vru_means_no_crowd_cap() {
+        assert_eq!(creep_through_crowd_speed_cap(&[], BAND, FLOOR, NUDGE, DECEL), None);
+    }
+
+    #[test]
+    fn a_vru_in_the_crowd_caps_to_a_gentle_nudge() {
+        // A pedestrian 1.5 m ahead, in band → a small positive nudge (not a freeze).
+        let cap = creep_through_crowd_speed_cap(&[vru(1.5, 0.0)], BAND, FLOOR, NUDGE, DECEL).unwrap();
+        assert!(cap > 0.0 && cap <= NUDGE + 1e-9, "gentle nudge expected, got {cap}");
+    }
+
+    #[test]
+    fn a_vru_at_the_contact_floor_stops_the_courier() {
+        // A pedestrian inside the hard contact floor → stop (never nudge into someone).
+        assert_eq!(creep_through_crowd_speed_cap(&[vru(0.3, 0.0)], BAND, FLOOR, NUDGE, DECEL), Some(0.0));
+    }
+
+    #[test]
+    fn the_crowd_nudge_never_exceeds_the_nudge_speed() {
+        // Even with lots of clear space, the crowd creep is capped at the nudge speed.
+        let cap = creep_through_crowd_speed_cap(&[vru(10.0, 0.0)], BAND, FLOOR, NUDGE, DECEL).unwrap();
+        assert!((cap - NUDGE).abs() < 1e-9, "capped at the nudge speed, got {cap}");
+    }
+
+    #[test]
+    fn creep_through_advances_where_a_full_yield_would_freeze() {
+        // The payoff: a pedestrian 0.8 m ahead is INSIDE the 1 m Yield standoff → Yield freezes (0).
+        // The crowd creep keeps inching (a positive nudge) because 0.8 m is beyond the 0.4 m floor.
+        let close = [vru(0.8, 0.0)];
+        assert_eq!(yield_to_vru_speed_cap(&close, BAND, STANDOFF, DECEL), Some(0.0), "yield freezes");
+        let crowd = creep_through_crowd_speed_cap(&close, BAND, FLOOR, NUDGE, DECEL).unwrap();
+        assert!(crowd > 0.0, "crowd creep advances where yield freezes, got {crowd}");
     }
 }

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -78,7 +78,10 @@ pub mod mick_llm;
 /// JSONL for offline scoring of the brain against the checker. Observability only.
 pub mod mick_capture;
 pub use mick_capture::{IntentStats, MickDecisionRecord, MickEvalLog, MickEvalSummary};
-pub use mick_llm::{build_prompt, intent_schema, LlmBrain, MockModel, ModelClient, ModelError};
+pub use mick_llm::{
+    build_courier_prompt, build_prompt, courier_intent_schema, intent_schema, LlmBrain, MockModel,
+    ModelClient, ModelError, Persona,
+};
 
 pub mod learned;
 pub use learned::{LearnedManeuverPlanner, LearnedPlanner, Teacher};

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -17,8 +17,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::behavior::{
-    cross_when_clear, interactive_proceed, yield_to_vru_speed_cap, InteractiveConflict, SignalState,
-    TrafficControl, VruApproach, DEFAULT_AGENT_REACCEL_MPS2, DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S,
+    creep_through_crowd_speed_cap, cross_when_clear, interactive_proceed, yield_to_vru_speed_cap,
+    InteractiveConflict, SignalState, TrafficControl, VruApproach, DEFAULT_AGENT_REACCEL_MPS2,
+    DEFAULT_CROSSWALK_CLEARANCE_MARGIN_S, DEFAULT_CROWD_CONTACT_FLOOR_M, DEFAULT_CROWD_NUDGE_SPEED_MPS,
     DEFAULT_TURN_CRITICAL_GAP_S, DEFAULT_VRU_YIELD_BAND_HALF_WIDTH_M, DEFAULT_VRU_YIELD_STANDOFF_M,
 };
 
@@ -135,6 +136,15 @@ pub enum MickIntent {
     /// ([`behavior::cross_when_clear`]); otherwise HOLDs at the curb. KIRRA's crossing RSS
     /// backstops a misjudged step-off.
     CrossWhenClear { x_m: f64, y_m: f64 },
+    /// **Sidewalk-courier: creep through a crowd toward `{x_m, y_m}`** (ADR-0027). Like [`Yield`]
+    /// but, instead of freezing a full standoff before the nearest pedestrian, it keeps inching
+    /// forward at a gentle nudge ([`behavior::creep_through_crowd_speed_cap`]) — stopping only at a
+    /// tight contact floor — so a dense crowd does not deadlock the courier. A deliberate, opt-in
+    /// relaxation of the full-stop yield; the speed stays sub-walking-pace and KIRRA's impact-energy
+    /// + containment bounds backstop it.
+    ///
+    /// [`Yield`]: MickIntent::Yield
+    CreepThrough { x_m: f64, y_m: f64 },
 }
 
 /// LLM JSON wire schema (tagged on `"intent"`). Kept separate from [`MickIntent`]
@@ -162,6 +172,8 @@ enum IntentJson {
     Yield { x_m: f64, y_m: f64 },
     #[serde(rename = "cross_when_clear")]
     CrossWhenClear { x_m: f64, y_m: f64 },
+    #[serde(rename = "creep_through")]
+    CreepThrough { x_m: f64, y_m: f64 },
 }
 
 impl MickIntent {
@@ -199,6 +211,7 @@ impl MickIntent {
             IntentJson::RouteTo { x_m, y_m } => MickIntent::RouteTo { x_m, y_m },
             IntentJson::Yield { x_m, y_m } => MickIntent::Yield { x_m, y_m },
             IntentJson::CrossWhenClear { x_m, y_m } => MickIntent::CrossWhenClear { x_m, y_m },
+            IntentJson::CreepThrough { x_m, y_m } => MickIntent::CreepThrough { x_m, y_m },
         };
         if !intent.is_finite() {
             return Err("MICK_NONFINITE_INTENT");
@@ -218,6 +231,7 @@ impl MickIntent {
             MickIntent::RouteTo { x_m, y_m } => x_m.is_finite() && y_m.is_finite(),
             MickIntent::Yield { x_m, y_m } => x_m.is_finite() && y_m.is_finite(),
             MickIntent::CrossWhenClear { x_m, y_m } => x_m.is_finite() && y_m.is_finite(),
+            MickIntent::CreepThrough { x_m, y_m } => x_m.is_finite() && y_m.is_finite(),
         }
     }
 }
@@ -482,6 +496,31 @@ pub fn plan_for_intent(
             }
             let goal = Goal { target: Pose { x_m, y_m, heading_rad: world.goal.target.heading_rad } };
             planner.plan(&PlanInput { goal, target_speed_mps: Some(COURIER_CREEP_MPS), ..world.clone() })
+        }
+        MickIntent::CreepThrough { x_m, y_m } => {
+            // Sidewalk crowd creep (ADR-0027): like Yield, but inch forward at a gentle nudge through
+            // pedestrians instead of freezing a full standoff back — stopping only at a tight contact
+            // floor. Keeps a dense crowd from deadlocking the courier; KIRRA's impact-energy backstops.
+            if !x_m.is_finite() || !y_m.is_finite() {
+                return PlanOutput::safe_stop(world.ego.pose);
+            }
+            let vrus = vru_approaches(world);
+            let cap = creep_through_crowd_speed_cap(
+                &vrus,
+                DEFAULT_VRU_YIELD_BAND_HALF_WIDTH_M,
+                DEFAULT_CROWD_CONTACT_FLOOR_M,
+                DEFAULT_CROWD_NUDGE_SPEED_MPS,
+                COURIER_YIELD_BRAKE_MPS2,
+            );
+            let goal = Goal { target: Pose { x_m, y_m, heading_rad: world.goal.target.heading_rad } };
+            match cap {
+                // A pedestrian within the contact floor → stop (never nudge into someone).
+                Some(c) if c <= f64::EPSILON => PlanOutput::safe_stop(world.ego.pose),
+                // A pedestrian ahead but beyond the floor → inch forward at the nudge.
+                Some(c) => planner.plan(&PlanInput { goal, target_speed_mps: Some(c), ..world.clone() }),
+                // No pedestrian in the band → follow the goal at creep.
+                None => planner.plan(&PlanInput { goal, target_speed_mps: Some(COURIER_CREEP_MPS), ..world.clone() }),
+            }
         }
     }
 }
@@ -1260,7 +1299,39 @@ mod tests {
                    MickIntent::Yield { x_m: 12.0, y_m: 0.0 });
         assert_eq!(MickIntent::from_llm_json(r#"{"intent":"cross_when_clear","x_m":12.0,"y_m":3.0}"#).unwrap(),
                    MickIntent::CrossWhenClear { x_m: 12.0, y_m: 3.0 });
+        assert_eq!(MickIntent::from_llm_json(r#"{"intent":"creep_through","x_m":12.0,"y_m":0.0}"#).unwrap(),
+                   MickIntent::CreepThrough { x_m: 12.0, y_m: 0.0 });
         assert!(MickIntent::from_llm_json(r#"{"intent":"yield","x_m":null,"y_m":0.0}"#).is_err(), "malformed → fail-closed");
+    }
+
+    fn courier_planner() -> GeometricPlanner {
+        GeometricPlanner::new(crate::GeometricPlannerConfig::courier())
+    }
+
+    #[test]
+    fn creep_through_inches_forward_through_pedestrians() {
+        // A pedestrian 3 m ahead (ego at x=5) in the path band → CreepThrough proposes MOTION (the
+        // courier keeps inching forward through the crowd) rather than freezing. The nudge MAGNITUDE
+        // is enforced by the primitive (creep_through_crowd_speed_cap, unit-tested); here we pin the
+        // load-bearing grounding property: it advances, it does not deadlock.
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let objs = [pedestrian(8.0, 0.0)];
+        let w = world(&corr, &objs, &[]);
+        let creep = plan_for_intent(&mut courier_planner(), &MickIntent::CreepThrough { x_m: 16.0, y_m: 0.0 }, &w);
+        assert_eq!(creep.kind, ProposalKind::Motion, "CreepThrough inches forward through the crowd");
+        let max_x = creep.trajectory.iter().map(|t| t.pose.x_m).fold(0.0, f64::max);
+        assert!(max_x > 5.5, "the courier advances past the ego start, got {max_x:.1}");
+    }
+
+    #[test]
+    fn creep_through_still_stops_when_a_pedestrian_is_at_the_contact_floor() {
+        // A pedestrian within the contact floor (0.3 m ahead) → CreepThrough still stops: it never
+        // nudges into someone.
+        let corr = MockCorridorSource::straight_5m_half_width(100.0);
+        let objs = [pedestrian(5.3, 0.0)]; // ego at x=5 → 0.3 m ahead, inside the 0.4 m floor
+        let w = world(&corr, &objs, &[]);
+        let creep = plan_for_intent(&mut courier_planner(), &MickIntent::CreepThrough { x_m: 16.0, y_m: 0.0 }, &w);
+        assert_eq!(creep.kind, ProposalKind::SafeStop, "stops at the contact floor — never pushes into a person");
     }
 
     #[test]

--- a/crates/kirra-planner/src/mick_capture.rs
+++ b/crates/kirra-planner/src/mick_capture.rs
@@ -100,6 +100,7 @@ impl MickDecisionRecord {
             // Sidewalk-courier intents (ADR-0027) — the goal point is the destination/far-curb.
             MickIntent::Yield { x_m, y_m } => ("yield", Some(x_m), Some(y_m), None, None),
             MickIntent::CrossWhenClear { x_m, y_m } => ("cross_when_clear", Some(x_m), Some(y_m), None, None),
+            MickIntent::CreepThrough { x_m, y_m } => ("creep_through", Some(x_m), Some(y_m), None, None),
         };
         let turn_direction = match *intent {
             MickIntent::TurnAt { direction } => Some(direction.as_str()),

--- a/crates/kirra-planner/src/mick_llm.rs
+++ b/crates/kirra-planner/src/mick_llm.rs
@@ -97,7 +97,8 @@ pub fn intent_schema() -> serde_json::Value {
         "properties": {
             "intent": {
                 "type": "string",
-                "enum": ["go_to", "lane_change", "hold", "cruise", "overtake", "pull_over", "turn_at", "route_to"]
+                "enum": ["go_to", "lane_change", "hold", "cruise", "overtake", "pull_over", "turn_at", "route_to",
+                         "yield", "cross_when_clear", "creep_through"]
             },
             "x_m": { "type": "number" },
             "y_m": { "type": "number" },
@@ -110,23 +111,125 @@ pub fn intent_schema() -> serde_json::Value {
     })
 }
 
+/// Render the world into a **sidewalk-courier** prompt (ADR-0027). Same strict typed-intent
+/// contract and "a governor enforces the hard limits" framing as [`build_prompt`], but a
+/// pedestrian-space persona offered ONLY the sidewalk intents — no road maneuvers (no
+/// lane-change / overtake / junction turns). A courier follows its path, yields to people,
+/// creeps through crowds, and crosses roads only at crosswalks when clear.
+#[must_use]
+pub fn build_courier_prompt(ctx: &WorldContext) -> String {
+    let situation = serde_json::to_string_pretty(ctx).unwrap_or_else(|_| "{}".to_string());
+    format!(
+        "You are Mick, a careful sidewalk delivery courier — a small robot in pedestrian space \
+(sidewalks, plazas, crosswalks). Choose the SINGLE best high-level intent for the situation.\n\
+\n\
+Respond with ONLY one JSON object (no prose, no code fence), in one of these forms:\n\
+  {{\"intent\":\"go_to\",\"x_m\":<number>,\"y_m\":<number>}}        follow the path toward a point (ego frame)\n\
+  {{\"intent\":\"yield\",\"x_m\":<number>,\"y_m\":<number>}}         give way to a pedestrian in your path, then go on\n\
+  {{\"intent\":\"creep_through\",\"x_m\":<number>,\"y_m\":<number>}} inch gently through a crowd of pedestrians\n\
+  {{\"intent\":\"cross_when_clear\",\"x_m\":<number>,\"y_m\":<number>}}  cross a road at a crosswalk, only when clear\n\
+  {{\"intent\":\"hold\"}}                                          stop and hold\n\
+\n\
+You move at a slow, walking pace and ALWAYS give way to people — you never assert. A separate \
+safety governor enforces collision limits and your speed/energy envelope, so you cannot hurt \
+anyone; focus on being polite and making steady progress. Coordinates are ego-relative: \
++ahead is forward, +left is to your left.\n\
+\n\
+Examples (situation → intent):\n\
+- clear path, goal ahead → {{\"intent\":\"go_to\",\"x_m\":8,\"y_m\":0}}\n\
+- a pedestrian standing in your path ahead → {{\"intent\":\"yield\",\"x_m\":8,\"y_m\":0}}\n\
+- a dense crowd of pedestrians around you → {{\"intent\":\"creep_through\",\"x_m\":8,\"y_m\":0}}\n\
+- at a crosswalk, a car approaching on the road → {{\"intent\":\"cross_when_clear\",\"x_m\":9,\"y_m\":0}}\n\
+- blocked, or off your route → {{\"intent\":\"hold\"}}\n\
+\n\
+Situation:\n{situation}\n\
+\n\
+Intent:"
+    )
+}
+
+/// The **courier** intent schema — the constrained-decode subset for the sidewalk persona
+/// ([`build_courier_prompt`]): only the sidewalk tags. Passed to a schema/grammar-constrained
+/// backend so a courier model can ONLY emit a sidewalk intent — it cannot emit a road maneuver
+/// (lane-change/overtake/turn) that does not apply on a sidewalk. A strict subset of
+/// [`intent_schema`]'s enum, so every courier tag is still in the fail-closed parser.
+#[must_use]
+pub fn courier_intent_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "intent": {
+                "type": "string",
+                "enum": ["go_to", "yield", "cross_when_clear", "creep_through", "hold"]
+            },
+            "x_m": { "type": "number" },
+            "y_m": { "type": "number" }
+        },
+        "required": ["intent"],
+        "additionalProperties": false
+    })
+}
+
+/// Which persona [`LlmBrain`] prompts as — a road chauffeur or a sidewalk courier (ADR-0027).
+/// The persona selects the prompt + the constrained-decode schema; the fail-closed parse is the
+/// same for both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Persona {
+    Chauffeur,
+    SidewalkCourier,
+}
+
+impl Persona {
+    /// The prompt for this persona.
+    #[must_use]
+    pub fn prompt(self, ctx: &WorldContext) -> String {
+        match self {
+            Persona::Chauffeur => build_prompt(ctx),
+            Persona::SidewalkCourier => build_courier_prompt(ctx),
+        }
+    }
+
+    /// The constrained-decode schema for this persona (passed to Ollama's `format`).
+    #[must_use]
+    pub fn schema(self) -> serde_json::Value {
+        match self {
+            Persona::Chauffeur => intent_schema(),
+            Persona::SidewalkCourier => courier_intent_schema(),
+        }
+    }
+}
+
 /// A [`MickBrain`] driven by any [`ModelClient`]: render the prompt, ask the model, parse
 /// the reply into a typed intent. Fail-closed at every step — a transport error or an
 /// unparseable / out-of-schema reply returns `Err`, on which the caller HOLDs.
 pub struct LlmBrain<M: ModelClient> {
     model: M,
+    persona: Persona,
 }
 
 impl<M: ModelClient> LlmBrain<M> {
+    /// A road-chauffeur brain (the default persona).
     #[must_use]
     pub fn new(model: M) -> Self {
-        Self { model }
+        Self { model, persona: Persona::Chauffeur }
+    }
+
+    /// A sidewalk-courier brain — prompts the courier persona, offered only sidewalk intents.
+    #[must_use]
+    pub fn courier(model: M) -> Self {
+        Self { model, persona: Persona::SidewalkCourier }
+    }
+
+    /// This brain's persona.
+    #[must_use]
+    pub fn persona(&self) -> Persona {
+        self.persona
     }
 }
 
 impl<M: ModelClient> MickBrain for LlmBrain<M> {
     fn decide(&mut self, ctx: &WorldContext) -> Result<MickIntent, MickError> {
-        let prompt = build_prompt(ctx);
+        let prompt = self.persona.prompt(ctx);
         let raw = self.model.complete(&prompt).map_err(|_| "MICK_MODEL_ERROR")?;
         // from_llm_json is already fail-closed + tolerant of small-model framing.
         MickIntent::from_llm_json(&raw)
@@ -222,6 +325,9 @@ mod tests {
             (r#"{"intent":"pull_over"}"#, "pull_over"),
             (r#"{"intent":"turn_at","direction":"left"}"#, "turn_at"),
             (r#"{"intent":"route_to","x_m":120.0,"y_m":40.0}"#, "route_to"),
+            (r#"{"intent":"yield","x_m":12.0,"y_m":0.0}"#, "yield"),
+            (r#"{"intent":"cross_when_clear","x_m":12.0,"y_m":0.0}"#, "cross_when_clear"),
+            (r#"{"intent":"creep_through","x_m":12.0,"y_m":0.0}"#, "creep_through"),
         ];
         for (json, tag) in cases {
             assert!(enum_tags.contains(&tag.to_string()), "schema enum must list {tag}");
@@ -235,6 +341,44 @@ mod tests {
     fn llm_brain_parses_a_valid_model_reply() {
         let mut brain = LlmBrain::new(MockModel::replying(r#"{"intent":"cruise","target_speed_mps":4.0}"#));
         assert_eq!(brain.decide(&sample_ctx()).unwrap(), MickIntent::Cruise { target_speed_mps: 4.0 });
+    }
+
+    // --- sidewalk-courier persona (ADR-0027 / D) ----------------------------
+
+    #[test]
+    fn courier_prompt_offers_the_sidewalk_intents_and_not_road_maneuvers() {
+        let p = build_courier_prompt(&sample_ctx());
+        for tag in ["go_to", "yield", "cross_when_clear", "creep_through", "hold"] {
+            assert!(p.contains(tag), "courier prompt must offer the {tag} intent");
+        }
+        // A courier does not get road maneuvers.
+        for tag in ["lane_change", "overtake", "turn_at", "route_to"] {
+            assert!(!p.contains(tag), "courier prompt must NOT offer the road maneuver {tag}");
+        }
+        assert!(p.contains("courier") && p.contains("pedestrian"), "the sidewalk persona is present");
+    }
+
+    #[test]
+    fn courier_schema_is_a_subset_of_the_parseable_tags() {
+        let courier: Vec<String> = courier_intent_schema()["properties"]["intent"]["enum"]
+            .as_array().unwrap().iter().map(|v| v.as_str().unwrap().to_string()).collect();
+        let full: Vec<String> = intent_schema()["properties"]["intent"]["enum"]
+            .as_array().unwrap().iter().map(|v| v.as_str().unwrap().to_string()).collect();
+        assert_eq!(courier, ["go_to", "yield", "cross_when_clear", "creep_through", "hold"]);
+        for tag in &courier {
+            assert!(full.contains(tag), "courier tag {tag} must be in the full parseable set");
+        }
+    }
+
+    #[test]
+    fn courier_brain_authors_and_parses_a_sidewalk_intent() {
+        // The courier persona round-trips a sidewalk intent through the brain.
+        let mut brain = LlmBrain::courier(MockModel::replying(r#"{"intent":"yield","x_m":8.0,"y_m":0.0}"#));
+        assert_eq!(brain.persona(), Persona::SidewalkCourier);
+        assert_eq!(brain.decide(&sample_ctx()).unwrap(), MickIntent::Yield { x_m: 8.0, y_m: 0.0 });
+
+        let mut creeper = LlmBrain::courier(MockModel::replying(r#"{"intent":"creep_through","x_m":8.0,"y_m":0.0}"#));
+        assert_eq!(creeper.decide(&sample_ctx()).unwrap(), MickIntent::CreepThrough { x_m: 8.0, y_m: 0.0 });
     }
 
     #[test]

--- a/docs/adr/0027-sidewalk-courier-odd.md
+++ b/docs/adr/0027-sidewalk-courier-odd.md
@@ -92,10 +92,16 @@ right-of-way. A courier does not negotiate for position; it yields and creeps.
 HOLDs while one is in the way; `CrossWhenClear` steps off only when every conflicting road agent's
 worst-case re-acceleration still can't reach the crossing before the slow courier clears it (the
 Stackelberg `interactive_proceed` model), else HOLDs at the curb. `FollowPath` ≈ `GoTo`/`Cruise` at
-creep; `Hold` already exists. `creep-through-crowd` (a soft nudge through dense pedestrians) remains
-a follow-up. The two behaviors are shown composing in a continuous drive (give way to a pedestrian
-and resume; wait at a curb for a car and cross) by `cargo run -p kirra-mick --example
-sidewalk_session` — Mick → Occy → KIRRA (courier profile), every committed pose checker-admitted.
+creep; `Hold` already exists. **`creep-through-crowd` is now implemented too**
+(`behavior::creep_through_crowd_speed_cap` + `MickIntent::CreepThrough`): instead of freezing a
+full standoff before the nearest pedestrian (which deadlocks a dense crowd), the courier inches
+forward at a gentle nudge, stopping only at a tight contact floor so it never pushes into anyone —
+a deliberate, opt-in relaxation of the full-stop yield, sub-walking-pace, KIRRA's impact-energy
+bound backstopping. `Yield` and `CrossWhenClear` are shown composing in a continuous drive (give
+way to a pedestrian and resume; wait at a curb for a car and cross) by `cargo run -p kirra-mick
+--example sidewalk_session` — Mick → Occy → KIRRA (courier profile), every committed pose
+checker-admitted. The full sidewalk intent set (`FollowPath`/`Yield`/`CrossWhenClear`/`CreepThrough`/
+`Hold`) is now in place.
 
 ### 4. Class mapping (one selector, two loops, cited copies)
 

--- a/docs/adr/0027-sidewalk-courier-odd.md
+++ b/docs/adr/0027-sidewalk-courier-odd.md
@@ -103,6 +103,13 @@ way to a pedestrian and resume; wait at a curb for a car and cross) by `cargo ru
 checker-admitted. The full sidewalk intent set (`FollowPath`/`Yield`/`CrossWhenClear`/`CreepThrough`/
 `Hold`) is now in place.
 
+**The LLM authors them too** — a sidewalk-courier brain persona (`build_courier_prompt` /
+`courier_intent_schema` / `LlmBrain::courier` / `OllamaClient::courier`) prompts a pedestrian-space
+persona offered ONLY the sidewalk intents (no road maneuvers) and grammar-constrains a local model
+(Gemma via Ollama on the Orin) to them. The model can never make the robot unsafe: its intent is
+grounded by Occy and bounded by KIRRA. Demonstrated by `cargo run -p kirra-mick --example
+mick_sidewalk_brain` (a deterministic `MockModel` stands in for Gemma, so it runs anywhere).
+
 ### 4. Class mapping (one selector, two loops, cited copies)
 
 The Courier profile already spans the stack; the per-class numbers are **cited copies** across the


### PR DESCRIPTION
## What this is

The last two doer-side pieces of the ADR-0027 sidewalk courier — both untrusted-doer only; KIRRA backstops every proposal.

### C — creep-through-crowd
A pure `Yield` stops a full ~1 m standoff before the nearest pedestrian, which **freezes the courier in a dense crowd**. `creep_through_crowd_speed_cap` relaxes that to a gentle nudge: inch forward at up to ~0.3 m/s while a pedestrian is in the path band, ramping to a stop only at a tight **0.4 m contact floor** (never pushes into anyone). Wired as `MickIntent::CreepThrough` + LLM JSON + `plan_for_intent` grounding. **5 primitive + 3 grounding tests.**

### D — the sidewalk-courier LLM brain persona
Previously the parser accepted the sidewalk intents but the prompt + decode schema still offered only road intents — a constrained-decode model couldn't emit them. Fixed + added a courier persona:
- `intent_schema()` gains the three sidewalk tags (union stays in lockstep with the fail-closed parser; pin test updated).
- **`build_courier_prompt`** (pedestrian-space persona, ONLY sidewalk intents — no lane-change/overtake/turn) + **`courier_intent_schema`** (constrained-decode subset) + **`Persona{Chauffeur,SidewalkCourier}`**. `LlmBrain::courier(model)` prompts the courier persona; `new()` unchanged.
- `OllamaClient` gains a persona (`with_persona`/`courier()`) so a local Gemma is grammar-constrained to sidewalk intents.
- **Example `mick_sidewalk_brain`** — a courier `LlmBrain` (MockModel standing in for Gemma) authors each sidewalk intent; Occy grounds it; KIRRA (courier profile) bounds it. Runs anywhere; swap `MockModel` for `OllamaClient::courier()` for real Gemma on the Orin:

```
situation                          Mick intent      occy       kirra
clear sidewalk ahead               go_to            Motion     Accept
a pedestrian standing in the path  yield            Motion     Clamp
a dense crowd around the robot     creep_through    Motion     Clamp
at a crosswalk, a car approaching  cross_when_clear SafeStop   Accept
```

## Result
The full sidewalk intent set — `FollowPath`/`Yield`/`CrossWhenClear`/`CreepThrough`/`Hold` — is now in place **and** authorable by a local LLM, end to end: Mick proposes, Occy grounds, KIRRA disposes.

## Validation
- **174 `kirra-planner` lib tests + `kirra-mick` green; `cargo clippy` clean.**
- Doer-side only — no checker change. The model can never make the robot unsafe: its intent is grounded by Occy and bounded by KIRRA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrH1GiB4yiGvgDfSVasu58