### PR TITLE
test(service): federation-submit handler E2E (closes store-offload coverage gap)

### DIFF
--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -5970,3 +5970,185 @@ mod store_offload_tests {
         assert!(matches!(n, Ok(42)), "closure return value must propagate; got {n:?}");
     }
 }
+
+// ---------------------------------------------------------------------------
+// Federation-submit handler E2E (closes the coverage gap flagged in the
+// store-offload PR). Drives `submit_federated_report` directly against a real
+// in-memory store with a registered controller and genuinely Ed25519-signed
+// reports, exercising the full refactored path: offload via `with_store_blocking`
+// → the locked commit closure → store persistence + nonce burn → outcome mapping.
+//
+// This is a HANDLER-level test, not full-router: the route is admin+identity
+// gated via `KIRRA_ADMIN_TOKEN` (env), which cannot be set safely in the parallel
+// test runner (INVARIANT #13). The auth/router layer is unchanged by the offload
+// refactor; this test covers the handler logic the refactor actually touched.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod federation_submit_e2e_tests {
+    use super::submit_federated_report;
+    use std::sync::Arc;
+    use axum::extract::State;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::{body::to_bytes, Json};
+    use base64::{engine::general_purpose::STANDARD as b64, Engine as _};
+    use ed25519_dalek::{Signer, SigningKey};
+    use kirra_verifier::federation_reconciliation::{
+        canonical_federation_payload_v2, FederatedTrustReportV2,
+    };
+    use kirra_verifier::posture_cache::{now_ms, ServiceState, SharedPostureCache};
+    use kirra_verifier::verifier::{AppState, FleetPosture, VerifierOperationMode};
+    use kirra_verifier::verifier_store::VerifierStore;
+
+    fn service() -> Arc<ServiceState> {
+        let store = VerifierStore::new(":memory:").expect("in-memory store");
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+        // An Active node must hold a claimed epoch, or the federation commit's #79
+        // in-transaction fence rejects every write as Fenced. Mirror startup's
+        // claim-then-store: claim epoch 1 on the fresh ha_state row and publish it.
+        {
+            let claimed = app
+                .store
+                .lock()
+                .unwrap()
+                .try_claim_epoch(0, "test-instance", 0)
+                .unwrap()
+                .expect("claim initial epoch on fresh store");
+            app.held_epoch.store(claimed, std::sync::atomic::Ordering::SeqCst);
+        }
+        let posture_cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
+        Arc::new(ServiceState {
+            app,
+            posture_cache,
+            started_at_ms: now_ms(),
+            audit_verifying_key: None,
+            fabric_router: Arc::new(kirra_verifier::fabric::router::FabricRouter::new()),
+            fabric_telemetry: Arc::new(kirra_verifier::fabric::telemetry::FabricTelemetry::new()),
+            fabric_causal_log: Arc::new(
+                kirra_verifier::fabric::causal_log::FabricCausalLog::new_in_memory(None),
+            ),
+            posture_engine_tx: std::sync::OnceLock::new(),
+            perception_cap: kirra_verifier::gateway::perception_monitor::empty_perception_cap(),
+            perception_monitor_enabled: false,
+        })
+    }
+
+    fn register(svc: &ServiceState, controller: &str, sk: &SigningKey) {
+        let pk_b64 = b64.encode(sk.verifying_key().to_bytes());
+        svc.app
+            .store
+            .lock()
+            .unwrap()
+            .save_trusted_federation_controller(controller, &pk_b64, now_ms())
+            .expect("register controller");
+    }
+
+    /// A fresh, correctly Ed25519-signed v2 report (issued "now" → inside the
+    /// 5 s replay window) for `controller`/`asset`/`nonce`.
+    fn signed_report(
+        sk: &SigningKey,
+        controller: &str,
+        asset: &str,
+        nonce: &str,
+        generation: Option<u64>,
+    ) -> FederatedTrustReportV2 {
+        let now = now_ms();
+        let mut report = FederatedTrustReportV2 {
+            source_controller_id: controller.to_string(),
+            asset_id: asset.to_string(),
+            posture: FleetPosture::Degraded,
+            issued_at_ms: now,
+            expires_at_ms: now + 30_000,
+            nonce_hex: nonce.to_string(),
+            signature_b64: String::new(),
+            source_generation: generation,
+        };
+        let sig = sk.sign(canonical_federation_payload_v2(&report).as_bytes());
+        report.signature_b64 = b64.encode(sig.to_bytes());
+        report
+    }
+
+    async fn submit(
+        svc: Arc<ServiceState>,
+        report: FederatedTrustReportV2,
+    ) -> (StatusCode, serde_json::Value) {
+        let resp = submit_federated_report(State(svc), Json(report)).await.into_response();
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.expect("read body");
+        let json = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+        (status, json)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn accepts_valid_report_persists_and_burns_nonce() {
+        let svc = service();
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        register(&svc, "ctrl-a", &sk);
+
+        let (status, body) =
+            submit(svc.clone(), signed_report(&sk, "ctrl-a", "lidar_front", "nonce-aaaa", Some(412)))
+                .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["accepted"], serde_json::json!(true), "valid report must be accepted: {body}");
+
+        let store = svc.app.store.lock().unwrap();
+        assert!(
+            !store.load_federated_reports_for_asset("lidar_front").unwrap().is_empty(),
+            "an accepted report must be persisted"
+        );
+        assert!(
+            store.has_seen_federation_nonce("nonce-aaaa").unwrap(),
+            "an accepted report must burn its nonce"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn replayed_nonce_is_rejected() {
+        let svc = service();
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        register(&svc, "ctrl-a", &sk);
+        let report = signed_report(&sk, "ctrl-a", "lidar_front", "nonce-dup", Some(1));
+
+        let (_, first) = submit(svc.clone(), report.clone()).await;
+        assert_eq!(first["accepted"], serde_json::json!(true), "first submit must be accepted: {first}");
+
+        let (_, second) = submit(svc.clone(), report).await;
+        assert_eq!(second["accepted"], serde_json::json!(false));
+        assert_eq!(
+            second["reason"], serde_json::json!("FEDERATED_NONCE_REPLAY"),
+            "a replayed nonce must be rejected: {second}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unregistered_controller_is_rejected() {
+        let svc = service();
+        let sk = SigningKey::from_bytes(&[9u8; 32]); // never registered
+        let (_, body) =
+            submit(svc, signed_report(&sk, "ctrl-unknown", "lidar_front", "nonce-x", None)).await;
+        assert_eq!(body["accepted"], serde_json::json!(false));
+        assert_eq!(
+            body["reason"], serde_json::json!("UNREGISTERED_FEDERATION_CONTROLLER"), "{body}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tampered_signature_is_rejected() {
+        let svc = service();
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        register(&svc, "ctrl-a", &sk);
+        let mut report = signed_report(&sk, "ctrl-a", "lidar_front", "nonce-bad", None);
+        report.signature_b64 = b64.encode([0u8; 64]); // tamper after signing
+
+        let (_, body) = submit(svc.clone(), report).await;
+        assert_eq!(body["accepted"], serde_json::json!(false));
+        assert_eq!(
+            body["reason"], serde_json::json!("INVALID_FEDERATION_SIGNATURE"), "{body}"
+        );
+        // A signature-rejected report must NOT burn the nonce.
+        assert!(
+            !svc.app.store.lock().unwrap().has_seen_federation_nonce("nonce-bad").unwrap(),
+            "a rejected report must not burn its nonce"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #577 (heavy-op store offload), which landed with the federation/backup/audit handlers **covered by construction + helper tests but no endpoint test** — a gap I flagged explicitly in that PR. This adds a real handler-level E2E test for the refactored `submit_federated_report`, so the offloaded federation commit path is now directly tested rather than asserted "by construction."

## What it covers

`federation_submit_e2e_tests` drives `submit_federated_report` directly against a real in-memory `VerifierStore` with a registered controller and **genuinely Ed25519-signed v2 reports**, exercising the full refactored path: `with_store_blocking` offload → the locked commit closure → store persistence + nonce burn → outcome mapping. Cases:

- **Accept** — valid signed report → `accepted: true`, **persisted** (`load_federated_reports_for_asset`) and its **nonce burned** (`has_seen_federation_nonce`).
- **Nonce replay** — resubmitting the same report → `FEDERATED_NONCE_REPLAY`.
- **Unregistered controller** → `UNREGISTERED_FEDERATION_CONTROLLER`.
- **Tampered signature** → `INVALID_FEDERATION_SIGNATURE`, and the nonce is **not** burned on rejection.

The test builder claims an HA epoch so the **#79 in-transaction fence** passes (mirrors startup) — which also exercises that the offloaded commit's fence path is wired correctly.

## Scope note (stated plainly)

This is a **handler-level** test, not full-router: the route is admin+identity gated via `KIRRA_ADMIN_TOKEN` (env), which can't be set safely in the parallel test runner (INVARIANT #13). The auth/router middleware is unchanged by the offload refactor, so this targets exactly the handler logic the refactor touched. A full-router test would additionally need a way to inject the admin token without `set_var`; that remains a separate, broader testing-infrastructure item.

## Testing

Test-only change (no production code touched). All 18 root-crate test binaries pass; the bin (incl. tests) is clippy-clean under the CI flags. The 4 new tests pass on top of the merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_