### PR TITLE
feat(scada): bound DNP3 Analog Output magnitude (fail-closed) [hardening 1/2]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,6 +405,7 @@ proptest = "1"  # dev-dependency
 | `KIRRA_SUPERVISOR_RESET_KEY` | Yes (reset ops) | — | Must be non-empty, ≤ 64 bytes |
 | `KIRRA_CANOPEN_NODE_MAP` | No | — | CANopen node-id → fleet-node-id map (#84), `canid:fleet_node` comma-separated (e.g. `5:robot-01,6:robot-02`). Unset → every NMT-offline is unattributed (fail-closed) |
 | `KIRRA_FABRIC_ASSET_ID` | No | — | Local fabric asset id fed by the verifier→fabric posture feed (#88). Unset/empty → feed inert (asset keeps its `Degraded` registration seed) |
+| `KIRRA_DNP3_ANALOG_OUTPUT_ENVELOPE` | No | — | DNP3 Analog Output (g41) magnitude envelope as `min:max` (e.g. `-100.0:100.0`). A control write (Operate/Direct_Operate) whose decoded setpoint is outside the envelope is denied. Unset/invalid → analog control writes are **denied (fail-closed)**; faithfully-undecodable g41 payloads are also refused (never fabricated) |
 
 **`kirra-ros2-adapter` slow-loop env gates** (consumed in `node.rs`, opt-in, default off →
 byte-identical prior behaviour): `KIRRA_PERCEPTION_DERATE_ENABLED` (Track-C perception-derate cap),

--- a/src/adapters/dnp3.rs
+++ b/src/adapters/dnp3.rs
@@ -1,5 +1,7 @@
 // src/adapters/dnp3.rs
 
+use std::sync::OnceLock;
+
 use serde::{Deserialize, Serialize};
 use crate::gateway::policy::OperationalCommand;
 
@@ -69,6 +71,130 @@ impl Dnp3Adapter {
             critical_infrastructure_relevant,
         }
     }
+
+    /// MAGNITUDE BOUND — Analog Output (DNP3 group 41) setpoints on a CONTROL
+    /// request must lie inside the integrator-configured envelope; otherwise the
+    /// command is REFUSED. This closes the gap where the adapter classified a
+    /// control's *type* (`SystemMutation`/`WriteState`) but never bounded the
+    /// commanded *value* — a master could Direct_Operate an analog output to any
+    /// magnitude and be admitted on posture alone.
+    ///
+    /// Fail-closed, mirroring `protocol_adapter`'s "faithfully decode or refuse,
+    /// never fabricate" discipline (#85):
+    ///   - a g41 object whose `data` does not match its variation's width →
+    ///     `Err(DNP3_ANALOG_OUTPUT_UNDECODABLE)` (no fabricated value),
+    ///   - a NaN/Inf float setpoint → `Err(DNP3_ANALOG_OUTPUT_NONFINITE)`,
+    ///   - NO envelope configured → `Err(DNP3_ANALOG_OUTPUT_ENVELOPE_UNCONFIGURED)`
+    ///     (an analog control write cannot be bounded, so it is denied — the
+    ///     fail-closed default),
+    ///   - a value outside `[min, max]` → `Err(DNP3_ANALOG_OUTPUT_ENVELOPE_BREACH)`.
+    ///
+    /// Only the control function codes (Select / Operate / Direct_Operate[_NR],
+    /// 0x03–0x06) carry a commanded setpoint; reads/responses are not bounded.
+    /// A control with no g41 object (e.g. a CROB-only relay op) is `Ok` here —
+    /// CROB is a relay control block, not a scalar magnitude.
+    pub fn bound_analog_control(
+        msg: &Dnp3Message,
+        envelope: Option<&AnalogOutputEnvelope>,
+    ) -> Result<(), &'static str> {
+        // Only Select/Operate/Direct_Operate[_NR] carry a commanded setpoint.
+        if !matches!(msg.function_code, 0x03..=0x06) {
+            return Ok(());
+        }
+        for obj in &msg.objects {
+            if obj.group != 41 {
+                continue; // not an Analog Output Block command
+            }
+            let value = decode_analog_setpoint(obj.variation, &obj.data)
+                .ok_or("DNP3_ANALOG_OUTPUT_UNDECODABLE")?;
+            if !value.is_finite() {
+                return Err("DNP3_ANALOG_OUTPUT_NONFINITE");
+            }
+            let env = envelope.ok_or("DNP3_ANALOG_OUTPUT_ENVELOPE_UNCONFIGURED")?;
+            if !env.admits(value) {
+                return Err("DNP3_ANALOG_OUTPUT_ENVELOPE_BREACH");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Faithfully decode a DNP3 group-41 (Analog Output Block) setpoint from its
+/// object `data`, per IEEE 1815 variations. Returns `None` (undecodable) when the
+/// variation is unknown or `data` is too short for the variation's value width —
+/// never a fabricated value. The trailing control-status octet (if present) is
+/// ignored; only the leading value bytes are read (little-endian per IEEE 1815).
+pub fn decode_analog_setpoint(variation: u8, data: &[u8]) -> Option<f64> {
+    match variation {
+        1 if data.len() >= 4 => Some(i32::from_le_bytes([data[0], data[1], data[2], data[3]]) as f64),
+        2 if data.len() >= 2 => Some(i16::from_le_bytes([data[0], data[1]]) as f64),
+        3 if data.len() >= 4 => Some(f32::from_le_bytes([data[0], data[1], data[2], data[3]]) as f64),
+        4 if data.len() >= 8 => {
+            Some(f64::from_le_bytes([
+                data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+            ]))
+        }
+        _ => None,
+    }
+}
+
+/// Inclusive `[min, max]` envelope an Analog Output setpoint must lie within.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AnalogOutputEnvelope {
+    pub min: f64,
+    pub max: f64,
+}
+
+impl AnalogOutputEnvelope {
+    /// Parse a `"min:max"` spec (e.g. `"-100.0:100.0"`). Returns `None` on a
+    /// malformed spec, non-finite bounds, or `min > max` — so a bad config never
+    /// silently yields a permissive (or inverted) envelope; the caller then treats
+    /// the envelope as unconfigured (fail-closed).
+    pub fn parse(spec: &str) -> Option<Self> {
+        let (min_s, max_s) = spec.trim().split_once(':')?;
+        let min = min_s.trim().parse::<f64>().ok()?;
+        let max = max_s.trim().parse::<f64>().ok()?;
+        if !min.is_finite() || !max.is_finite() || min > max {
+            return None;
+        }
+        Some(Self { min, max })
+    }
+
+    pub fn admits(&self, value: f64) -> bool {
+        value.is_finite() && value >= self.min && value <= self.max
+    }
+}
+
+/// Env var carrying the DNP3 Analog Output envelope as `"min:max"`.
+/// Unset/malformed → no envelope → analog control writes are denied (fail-closed).
+pub const DNP3_ANALOG_OUTPUT_ENVELOPE_ENV: &str = "KIRRA_DNP3_ANALOG_OUTPUT_ENVELOPE";
+
+/// Process-wide DNP3 Analog Output envelope, initialized once at startup from the
+/// environment. Kept out of `ServiceState`/`AppState` (mirrors the CANopen node
+/// map) so this adapter-layer bound needs no change to their construction sites.
+static GLOBAL_AO_ENVELOPE: OnceLock<Option<AnalogOutputEnvelope>> = OnceLock::new();
+
+/// Initialize the global Analog Output envelope from
+/// `KIRRA_DNP3_ANALOG_OUTPUT_ENVELOPE`. Idempotent; call once at startup.
+pub fn init_analog_envelope_from_env() {
+    let parsed = std::env::var(DNP3_ANALOG_OUTPUT_ENVELOPE_ENV)
+        .ok()
+        .and_then(|spec| AnalogOutputEnvelope::parse(&spec));
+    if GLOBAL_AO_ENVELOPE.set(parsed).is_ok() {
+        match parsed {
+            Some(env) => tracing::info!(min = env.min, max = env.max,
+                "DNP3 Analog Output envelope configured"),
+            None => tracing::warn!(
+                "DNP3 Analog Output envelope UNCONFIGURED/invalid — analog control writes will be denied (fail-closed)"
+            ),
+        }
+    }
+}
+
+/// The configured global Analog Output envelope, or `None` (unconfigured →
+/// fail-closed deny) — including before `init_analog_envelope_from_env` runs.
+pub fn global_analog_envelope() -> Option<AnalogOutputEnvelope> {
+    GLOBAL_AO_ENVELOPE.get().copied().flatten()
 }
 
 #[cfg(test)]
@@ -213,5 +339,97 @@ mod tests {
     fn test_zero_length_data_in_object() {
         let e = Dnp3Adapter::evaluate(&msg(0x01, 0x0001, vec![obj(1)]));
         assert_eq!(e.command, OperationalCommand::ReadTelemetry);
+    }
+
+    // --- Analog Output (group 41) magnitude bounding -----------------------
+
+    fn ao(variation: u8, data: Vec<u8>) -> Dnp3Object {
+        Dnp3Object { group: 41, variation, data }
+    }
+
+    #[test]
+    fn decode_setpoint_per_variation() {
+        // v1: 32-bit signed int (LE); v2: 16-bit; v3: f32; v4: f64.
+        assert_eq!(decode_analog_setpoint(1, &50i32.to_le_bytes()), Some(50.0));
+        assert_eq!(decode_analog_setpoint(1, &(-7i32).to_le_bytes()), Some(-7.0));
+        assert_eq!(decode_analog_setpoint(2, &1234i16.to_le_bytes()), Some(1234.0));
+        assert_eq!(decode_analog_setpoint(3, &1.5f32.to_le_bytes()), Some(1.5));
+        assert_eq!(decode_analog_setpoint(4, &(-2.25f64).to_le_bytes()), Some(-2.25));
+    }
+
+    #[test]
+    fn decode_setpoint_fails_closed_on_short_or_unknown() {
+        assert_eq!(decode_analog_setpoint(1, &[0u8; 3]), None, "v1 needs 4 bytes");
+        assert_eq!(decode_analog_setpoint(2, &[0u8; 1]), None, "v2 needs 2 bytes");
+        assert_eq!(decode_analog_setpoint(4, &[0u8; 7]), None, "v4 needs 8 bytes");
+        assert_eq!(decode_analog_setpoint(9, &[0u8; 8]), None, "unknown variation undecodable");
+    }
+
+    #[test]
+    fn envelope_parse_rejects_bad_specs() {
+        assert_eq!(AnalogOutputEnvelope::parse("-100:100"), Some(AnalogOutputEnvelope { min: -100.0, max: 100.0 }));
+        assert_eq!(AnalogOutputEnvelope::parse(" -5.5 : 5.5 "), Some(AnalogOutputEnvelope { min: -5.5, max: 5.5 }));
+        assert!(AnalogOutputEnvelope::parse("nocolon").is_none());
+        assert!(AnalogOutputEnvelope::parse("a:b").is_none());
+        assert!(AnalogOutputEnvelope::parse("10:5").is_none(), "min > max rejected");
+        assert!(AnalogOutputEnvelope::parse("inf:5").is_none(), "non-finite rejected");
+    }
+
+    #[test]
+    fn control_analog_in_envelope_is_admitted() {
+        let env = AnalogOutputEnvelope { min: -100.0, max: 100.0 };
+        let m = msg(0x05, 0x0001, vec![ao(1, 50i32.to_le_bytes().to_vec())]); // Direct_Operate, value 50
+        assert_eq!(Dnp3Adapter::bound_analog_control(&m, Some(&env)), Ok(()));
+    }
+
+    #[test]
+    fn control_analog_out_of_envelope_is_refused() {
+        let env = AnalogOutputEnvelope { min: -100.0, max: 100.0 };
+        let m = msg(0x05, 0x0001, vec![ao(1, 999i32.to_le_bytes().to_vec())]);
+        assert_eq!(
+            Dnp3Adapter::bound_analog_control(&m, Some(&env)),
+            Err("DNP3_ANALOG_OUTPUT_ENVELOPE_BREACH")
+        );
+    }
+
+    #[test]
+    fn control_analog_without_envelope_is_fail_closed() {
+        let m = msg(0x05, 0x0001, vec![ao(1, 50i32.to_le_bytes().to_vec())]);
+        assert_eq!(
+            Dnp3Adapter::bound_analog_control(&m, None),
+            Err("DNP3_ANALOG_OUTPUT_ENVELOPE_UNCONFIGURED"),
+            "an analog control write that cannot be bounded must be denied"
+        );
+    }
+
+    #[test]
+    fn control_analog_undecodable_is_refused() {
+        let env = AnalogOutputEnvelope { min: -100.0, max: 100.0 };
+        let m = msg(0x05, 0x0001, vec![ao(1, vec![0x01, 0x02])]); // v1 needs 4 bytes
+        assert_eq!(
+            Dnp3Adapter::bound_analog_control(&m, Some(&env)),
+            Err("DNP3_ANALOG_OUTPUT_UNDECODABLE")
+        );
+    }
+
+    #[test]
+    fn control_analog_nonfinite_is_refused() {
+        let env = AnalogOutputEnvelope { min: -100.0, max: 100.0 };
+        let m = msg(0x05, 0x0001, vec![ao(3, f32::NAN.to_le_bytes().to_vec())]); // v3 NaN
+        assert_eq!(
+            Dnp3Adapter::bound_analog_control(&m, Some(&env)),
+            Err("DNP3_ANALOG_OUTPUT_NONFINITE")
+        );
+    }
+
+    #[test]
+    fn non_control_and_crob_only_are_not_bounded() {
+        let env = AnalogOutputEnvelope { min: -1.0, max: 1.0 };
+        // A READ carrying a g41 object is not a command → not bounded.
+        let read = msg(0x01, 0x0001, vec![ao(1, 999i32.to_le_bytes().to_vec())]);
+        assert_eq!(Dnp3Adapter::bound_analog_control(&read, Some(&env)), Ok(()));
+        // A control with only a CROB (g12) carries no scalar setpoint → Ok here.
+        let crob = msg(0x05, 0x0001, vec![obj(12)]);
+        assert_eq!(Dnp3Adapter::bound_analog_control(&crob, Some(&env)), Ok(()));
     }
 }

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -1560,6 +1560,21 @@ async fn evaluate_dnp3_adapter(
     let mut denial_reason = denial_reason;
     let mut status = StatusCode::OK;
 
+    // MAGNITUDE BOUND: a posture-admitted Analog Output (g41) control must also lie
+    // within the configured envelope — else REFUSE (fail-closed: also when no
+    // envelope is configured or the value is undecodable). Only applied on the
+    // posture-allowed path; a posture denial outranks and is reported as-is. The
+    // override-to-denied flows into the audit block below as an action-denied event.
+    if allowed {
+        if let Err(reason) = Dnp3Adapter::bound_analog_control(
+            &msg,
+            kirra_verifier::adapters::dnp3::global_analog_envelope().as_ref(),
+        ) {
+            allowed = false;
+            denial_reason = Some(reason.to_string());
+        }
+    }
+
     if eval.is_broadcast || eval.is_control || !allowed {
         let event_type = if eval.is_broadcast {
             "DNP3_BROADCAST_COMMAND"
@@ -2474,6 +2489,10 @@ async fn main() {
     // from KIRRA_CANOPEN_NODE_MAP; unset → empty map (every offline is then
     // unattributed, handled fail-closed in evaluate_canopen_adapter).
     kirra_verifier::adapters::canopen::init_node_map_from_env();
+
+    // DNP3 Analog Output magnitude envelope from KIRRA_DNP3_ANALOG_OUTPUT_ENVELOPE
+    // ("min:max"); unset/invalid → analog control writes are denied (fail-closed).
+    kirra_verifier::adapters::dnp3::init_analog_envelope_from_env();
 
     let audit_signing_key: Option<ed25519_dalek::SigningKey> =
         std::env::var("KIRRA_LOG_SIGNING_KEY").ok()

--- a/src/protocol_adapter.rs
+++ b/src/protocol_adapter.rs
@@ -236,7 +236,20 @@ pub fn evaluate_unified_industrial_request(
             let msg: Dnp3Message = serde_json::from_value(req.message)
                 .map_err(|e| format!("MALFORMED_DNP3_MESSAGE: {e}"))?;
             let eval = Dnp3Adapter::evaluate(&msg);
-            let (allowed, denial_reason) = command_allowed_for_posture_pub(&eval.command, &posture);
+            let (mut allowed, mut denial_reason) = command_allowed_for_posture_pub(&eval.command, &posture);
+            // MAGNITUDE BOUND: a posture-admitted Analog Output (g41) control must
+            // also be within the configured envelope (fail-closed otherwise). Same
+            // bound the dedicated /industrial/dnp3/evaluate handler applies, so both
+            // DNP3 entry points enforce it identically.
+            if allowed {
+                if let Err(reason) = Dnp3Adapter::bound_analog_control(
+                    &msg,
+                    crate::adapters::dnp3::global_analog_envelope().as_ref(),
+                ) {
+                    allowed = false;
+                    denial_reason = Some(reason.to_string());
+                }
+            }
             Ok(UnifiedEvaluationResult {
                 protocol: "dnp3".to_string(),
                 command: eval.command,
@@ -472,5 +485,29 @@ mod unified_tests {
         // EtherNet/IP Get_Attribute_Single (0x0E) = ReadTelemetry → allowed even in Degraded
         let r = evaluate_unified_industrial_request(eip_request(), FleetPosture::Degraded).unwrap();
         assert!(r.allowed);
+    }
+
+    #[test]
+    fn test_dnp3_analog_control_magnitude_bound_is_wired_fail_closed() {
+        // A DNP3 Direct_Operate (0x05) carrying an Analog Output (g41) value is a
+        // posture-admissible SystemMutation under Nominal, but the magnitude bound
+        // must additionally gate it. The global envelope is unset in the test
+        // process → fail-closed: the analog control is DENIED. Proves the bound is
+        // wired into the unified path (not just the dedicated handler).
+        let req = UnifiedIndustrialRequest {
+            protocol: IndustrialProtocol::Dnp3,
+            message: serde_json::json!({
+                "source_address": 1, "dest_address": 0x0001, "function_code": 0x05,
+                "data_link_control": 0,
+                "objects": [{ "group": 41, "variation": 1, "data": 50i32.to_le_bytes().to_vec() }],
+                "source_node": "sub_01"
+            }),
+        };
+        let r = evaluate_unified_industrial_request(req, FleetPosture::Nominal).unwrap();
+        assert!(!r.allowed, "an unbounded analog control must be denied (fail-closed)");
+        assert_eq!(
+            r.denial_reason.as_deref(),
+            Some("DNP3_ANALOG_OUTPUT_ENVELOPE_UNCONFIGURED")
+        );
     }
 }


### PR DESCRIPTION
Part 1 of the SCADA/industrial hardening from the engineering review (magnitude-bounding; replay/freshness follows as part 2).

## Problem

The DNP3 adapter classified a control's **type** (`SystemMutation`/`WriteState`) but never bounded the commanded **value** — a master could `Direct_Operate` an Analog Output to *any* magnitude and be admitted on posture alone. For a CHECKER whose thesis is "bound the magnitude," that was the most meaningful industrial gap.

## What changed

Magnitude bounding for DNP3 **group-41 (Analog Output Block)** setpoints on control writes (Select/Operate/Direct_Operate[_NR], fc 0x03–0x06). Faithful + fail-closed, mirroring `protocol_adapter`'s "**decode or refuse, never fabricate**" discipline (#85):

- `decode_analog_setpoint()` — decodes the value per **IEEE-1815 variation** (v1 i32, v2 i16, v3 f32, v4 f64, little-endian). A payload too short for its variation → **undecodable** (no fabricated value).
- `AnalogOutputEnvelope` (`min:max`) from `KIRRA_DNP3_ANALOG_OUTPUT_ENVELOPE`; a malformed / non-finite / inverted (`min>max`) spec is rejected (treated as unconfigured).
- `bound_analog_control()` **denies** a g41 control when: undecodable, non-finite, **no envelope configured** (an unbounded analog write is refused — the fail-closed default you selected), or value outside `[min,max]`. A control with no g41 (e.g. CROB-only) is **not** bounded (CROB is a relay op, not a scalar). Reads/responses are not bounded.

Wired into **both** DNP3 entry points — the dedicated `/industrial/dnp3/evaluate` handler and the unified `/industrial/evaluate` path — so they enforce identically; the override-to-denied flows into the existing DNP3 audit block. The global envelope is initialized once at startup from env (mirrors the CANopen node map).

## Scope (explicit)

**DNP3 Analog Output only.** Device-specific **CANopen PDO/SDO** and **CIP attribute** magnitudes are deliberately left classified-but-unbounded: faithfully decoding "the value" there needs a device object dictionary, and fabricating an interpretation would violate the same discipline. That's a documented follow-up. The units of an analog output are integrator-specific, hence the configured envelope + fail-closed-when-unconfigured model (your chosen option).

## Testing

10 new `dnp3` unit tests (decode per-variation, envelope parse incl. inverted/non-finite rejection, all 5 deny reasons, non-control/CROB-not-bounded) + a unified-path test proving the bound is wired and fail-closed when unconfigured. Documents `KIRRA_DNP3_ANALOG_OUTPUT_ENVELOPE` in CLAUDE.md. All 18 test binaries pass; clippy clean under the CI flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_