### PR TITLE
feat(transport): authenticate UDP governor path + enforce actuator DDS QoS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,8 +1996,10 @@ name = "kirra-governor-service"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "hmac",
  "kirra-core",
  "serde",
+ "sha2",
 ]
 
 [[package]]

--- a/crates/kirra-governor-service/Cargo.toml
+++ b/crates/kirra-governor-service/Cargo.toml
@@ -30,3 +30,8 @@ path = "src/main.rs"
 kirra-core = { path = "../kirra-core" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1.3"
+# Message authentication for the UDP command path (HMAC-SHA256). Both are pure
+# Rust, no_std-capable, and async/ROS-free — consistent with the QNX/cert-target
+# dependency discipline above. Versions pinned to the workspace root.
+hmac = "0.12"
+sha2 = "0.10"

--- a/crates/kirra-governor-service/src/main.rs
+++ b/crates/kirra-governor-service/src/main.rs
@@ -14,13 +14,31 @@
 // PROTOTYPE STAGE (QM, not the cert build): regular Rust over UDP. The
 // Ferrocene / `no_std` / ASIL-D factoring and the shared-memory mailbox are a
 // later stage and do not block the demo — see ADR-0001 and the bring-up runbook.
+//
+// AUTHENTICATION (review B2): the UDP command path is a vehicle-control surface,
+// so it is NOT trusted by source address. Every datagram (both directions) carries
+// a 32-byte HMAC-SHA256 tag over its body, keyed by a pre-shared secret
+// (`KIRRA_GOVERNOR_PSK`, REQUIRED — absent/empty → the governor refuses to start,
+// fail-closed). An unauthenticated request is dropped SILENTLY (no reply), so a
+// forged source address cannot turn the governor into a reflector; replies are
+// MAC'd too, so a spoofed verdict (e.g. a forged "Allow") cannot be injected at
+// the car. The M6 watchdog now REJECTS (rather than only logging) a replayed /
+// non-advancing sequence, and — when `KIRRA_GOVERNOR_FRESHNESS_MS` is set —
+// rejects stale / future-dated proposals, emitting a fail-closed safe-state verdict.
 
+use hmac::{Hmac, Mac};
 use kirra_core::kinematics_contract::{
     validate_vehicle_command, DenyCode, EnforceAction, ProposedVehicleCommand,
     VehicleKinematicsContract,
 };
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 use std::net::UdpSocket;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Length of the HMAC-SHA256 authentication tag prepended to every datagram.
+const MAC_LEN: usize = 32;
 
 /// Default listen address (override with `KIRRA_GOVERNOR_ADDR`).
 const DEFAULT_ADDR: &str = "0.0.0.0:9760";
@@ -92,29 +110,153 @@ fn decide(proposal: &Proposal, contract: &VehicleKinematicsContract) -> Verdict 
     }
 }
 
-/// Minimal M6 watchdog state (staleness check stubbed for the prototype; the
-/// safe-state wiring comes later per the runbook). For now it only flags a
-/// non-monotonic sequence, which would indicate a reordered/replayed proposal.
-#[derive(Default)]
+/// Compute the HMAC-SHA256 tag over `body` with the pre-shared key. HMAC accepts
+/// a key of any length, so this never fails for a non-empty key.
+fn compute_mac(psk: &[u8], body: &[u8]) -> [u8; MAC_LEN] {
+    let mut mac = HmacSha256::new_from_slice(psk).expect("HMAC accepts any key length");
+    mac.update(body);
+    let out = mac.finalize().into_bytes();
+    let mut tag = [0u8; MAC_LEN];
+    tag.copy_from_slice(&out);
+    tag
+}
+
+/// Constant-time verification that `tag` authenticates `body` under `psk`.
+/// `Mac::verify_slice` is constant-time; an empty key (which should be impossible
+/// past the startup check) fails closed.
+fn verify_mac(psk: &[u8], body: &[u8], tag: &[u8]) -> bool {
+    let mut mac = match HmacSha256::new_from_slice(psk) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    mac.update(body);
+    mac.verify_slice(tag).is_ok()
+}
+
+/// Frame the wire response: `tag(32) || bincode(verdict)`, so the car can
+/// authenticate the verdict and reject a spoofed one.
+fn frame_response(psk: &[u8], verdict: &Verdict) -> Result<Vec<u8>, bincode::Error> {
+    let body = bincode::serialize(verdict)?;
+    let tag = compute_mac(psk, &body);
+    let mut out = Vec::with_capacity(MAC_LEN + body.len());
+    out.extend_from_slice(&tag);
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+/// Outcome of the M6 freshness/replay watchdog for one proposal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WatchdogVerdict {
+    /// Fresh and sequence-advancing — safe to evaluate.
+    Fresh,
+    /// Sequence did not strictly advance — a reordered / replayed proposal.
+    Replay,
+    /// `ts_nanos` is older than the freshness window — a delayed / held command.
+    Stale,
+    /// `ts_nanos` is ahead of now beyond the window — clock skew / forgery.
+    FutureDated,
+}
+
+impl WatchdogVerdict {
+    fn as_str(self) -> &'static str {
+        match self {
+            WatchdogVerdict::Fresh => "FRESH",
+            WatchdogVerdict::Replay => "REPLAY",
+            WatchdogVerdict::Stale => "STALE",
+            WatchdogVerdict::FutureDated => "FUTURE_DATED",
+        }
+    }
+}
+
+/// M6 watchdog state. Sequence-replay rejection is ALWAYS active (it needs no
+/// clock). Absolute-time staleness is opt-in via `freshness_window_nanos`
+/// (`KIRRA_GOVERNOR_FRESHNESS_MS`) because it requires the car and governor
+/// clocks to be roughly synchronized (AOU-TIMESYNC-001); when unset, only the
+/// clock-free replay check runs.
 struct WatchdogState {
     last_seq: Option<u64>,
-    last_ts_nanos: Option<u128>,
+    freshness_window_nanos: Option<u128>,
 }
 
 impl WatchdogState {
-    /// Records the proposal and returns `false` if the sequence did not advance
-    /// (the caller logs it). Staleness-vs-deadline and the safe-state emission
-    /// are deliberately NOT implemented yet (M6).
-    fn observe(&mut self, proposal: &Proposal) -> bool {
-        let monotonic = self.last_seq.map(|p| proposal.seq > p).unwrap_or(true);
+    fn new(freshness_window_nanos: Option<u128>) -> Self {
+        Self {
+            last_seq: None,
+            freshness_window_nanos,
+        }
+    }
+
+    /// Classify a proposal against the replay and freshness rules. Advances the
+    /// stored sequence ONLY on `Fresh`, so a rejected (replayed/stale) proposal
+    /// can neither poison the high-water mark nor be laundered into acceptance.
+    fn observe(&mut self, proposal: &Proposal, now_nanos: u128) -> WatchdogVerdict {
+        // Replay: the sequence must strictly advance. The MAC already prevents an
+        // attacker forging a NEW high sequence, so monotonic-seq + MAC together
+        // reject both forged and captured-and-replayed datagrams.
+        if let Some(prev) = self.last_seq {
+            if proposal.seq <= prev {
+                return WatchdogVerdict::Replay;
+            }
+        }
+
+        // Freshness (opt-in; needs car/governor clock sync per AOU-TIMESYNC-001).
+        if let Some(window) = self.freshness_window_nanos {
+            if proposal.ts_nanos > now_nanos {
+                if proposal.ts_nanos - now_nanos > window {
+                    return WatchdogVerdict::FutureDated;
+                }
+            } else if now_nanos - proposal.ts_nanos > window {
+                return WatchdogVerdict::Stale;
+            }
+        }
+
         self.last_seq = Some(proposal.seq);
-        self.last_ts_nanos = Some(proposal.ts_nanos);
-        monotonic
+        WatchdogVerdict::Fresh
+    }
+}
+
+/// Current wall-clock time in nanoseconds since the UNIX epoch (read once per
+/// request in `main` and passed into the pure watchdog for testability).
+fn now_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}
+
+/// The fail-closed safe-state verdict emitted for an authenticated-but-untrustworthy
+/// frame (replay / stale / future-dated): a `FrameIntegrityUntrusted` deny, so the
+/// car safe-stops rather than acting on the questionable command.
+fn safe_state_verdict(seq: u64) -> Verdict {
+    Verdict {
+        seq,
+        action: EnforceAction::DenyBreach(DenyCode::FrameIntegrityUntrusted),
+        reason_code: deny_code_num(DenyCode::FrameIntegrityUntrusted),
     }
 }
 
 fn main() -> std::io::Result<()> {
     let addr = std::env::var("KIRRA_GOVERNOR_ADDR").unwrap_or_else(|_| DEFAULT_ADDR.to_string());
+
+    // The UDP command path MUST be authenticated (review B2). No PSK → refuse to
+    // start, fail-closed (an unauthenticated vehicle-control surface is the bug).
+    let psk = std::env::var("KIRRA_GOVERNOR_PSK").unwrap_or_default();
+    if psk.trim().is_empty() {
+        eprintln!(
+            "FATAL: KIRRA_GOVERNOR_PSK is unset/empty — the UDP command path must be \
+             authenticated (HMAC-SHA256). Refusing to start fail-open."
+        );
+        std::process::exit(1);
+    }
+    let psk = psk.into_bytes();
+
+    // Optional absolute-time staleness window (AOU-TIMESYNC-001: requires the car
+    // and governor clocks to be roughly synchronized). Unset → only the clock-free
+    // sequence-replay check runs.
+    let freshness_window_nanos = std::env::var("KIRRA_GOVERNOR_FRESHNESS_MS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .map(|ms| ms as u128 * 1_000_000);
 
     // The governor enforces its OWN envelope. Nominal reference profile for the
     // prototype; the MRC fallback profile is available for a degraded mode.
@@ -122,19 +264,37 @@ fn main() -> std::io::Result<()> {
 
     let socket = UdpSocket::bind(&addr)?;
     eprintln!(
-        "kirra-governor-service: listening on {addr} (UDP), \
-         contract = nominal_reference_profile, effective_max_speed = {:.2} m/s",
-        contract.effective_max_speed_mps()
+        "kirra-governor-service: listening on {addr} (UDP, HMAC-SHA256 authenticated), \
+         contract = nominal_reference_profile, effective_max_speed = {:.2} m/s, \
+         freshness_window = {}",
+        contract.effective_max_speed_mps(),
+        freshness_window_nanos
+            .map(|w| format!("{} ms", w / 1_000_000))
+            .unwrap_or_else(|| "disabled (seq-replay only)".to_string()),
     );
 
-    let mut watchdog = WatchdogState::default();
+    let mut watchdog = WatchdogState::new(freshness_window_nanos);
     // One UDP datagram per proposal; 64 KiB is far above the fixed-schema size.
     let mut buf = vec![0u8; 64 * 1024];
 
     loop {
         let (n, peer) = socket.recv_from(&mut buf)?;
+        let frame = &buf[..n];
 
-        let proposal: Proposal = match bincode::deserialize(&buf[..n]) {
+        // Authenticate first: frame = tag(32) || bincode(Proposal). A frame too
+        // short to carry a tag, or one whose tag does not verify, is dropped
+        // SILENTLY — no reply to a forged source (anti-reflection).
+        if frame.len() < MAC_LEN {
+            eprintln!("drop: short frame ({} bytes) from {peer}", frame.len());
+            continue;
+        }
+        let (tag, body) = frame.split_at(MAC_LEN);
+        if !verify_mac(&psk, body, tag) {
+            eprintln!("drop: unauthenticated datagram from {peer} (bad MAC; no reply)");
+            continue;
+        }
+
+        let proposal: Proposal = match bincode::deserialize(body) {
             Ok(p) => p,
             Err(e) => {
                 eprintln!("decode error from {peer}: {e}");
@@ -142,16 +302,21 @@ fn main() -> std::io::Result<()> {
             }
         };
 
-        if !watchdog.observe(&proposal) {
-            eprintln!(
-                "watchdog: non-monotonic seq {} from {peer} (staleness/safe-state is M6, stubbed)",
-                proposal.seq
-            );
-        }
+        // Authenticated peer: classify freshness/replay, then either evaluate or
+        // emit the fail-closed safe-state deny.
+        let verdict = match watchdog.observe(&proposal, now_nanos()) {
+            WatchdogVerdict::Fresh => decide(&proposal, &contract),
+            rejected => {
+                eprintln!(
+                    "watchdog {} seq {} from {peer} -> safe-state deny",
+                    rejected.as_str(),
+                    proposal.seq
+                );
+                safe_state_verdict(proposal.seq)
+            }
+        };
 
-        let verdict = decide(&proposal, &contract);
-
-        match bincode::serialize(&verdict) {
+        match frame_response(&psk, &verdict) {
             Ok(bytes) => {
                 if let Err(e) = socket.send_to(&bytes, peer) {
                     eprintln!("send error to {peer}: {e}");
@@ -232,14 +397,106 @@ mod service_tests {
     }
 
     #[test]
-    fn watchdog_flags_non_monotonic_seq() {
-        let mut wd = WatchdogState::default();
+    fn watchdog_rejects_replayed_seq() {
+        // No freshness window → only the clock-free replay check is active.
+        let mut wd = WatchdogState::new(None);
         let mut p = steady(1.0, 0.0);
         p.seq = 5;
-        assert!(wd.observe(&p), "first observation is always monotonic");
+        assert_eq!(wd.observe(&p, 0), WatchdogVerdict::Fresh, "first observation is fresh");
         p.seq = 4;
-        assert!(!wd.observe(&p), "a lower seq must be flagged as non-monotonic");
+        assert_eq!(
+            wd.observe(&p, 0),
+            WatchdogVerdict::Replay,
+            "a lower seq is a replay and must be rejected"
+        );
+        p.seq = 5;
+        assert_eq!(
+            wd.observe(&p, 0),
+            WatchdogVerdict::Replay,
+            "an equal seq (re-sent datagram) is also a replay"
+        );
         p.seq = 6;
-        assert!(wd.observe(&p), "an advancing seq is monotonic again");
+        assert_eq!(wd.observe(&p, 0), WatchdogVerdict::Fresh, "an advancing seq is fresh again");
+    }
+
+    #[test]
+    fn watchdog_rejected_proposal_does_not_advance_highwater() {
+        // A replayed proposal must not poison the sequence high-water mark.
+        let mut wd = WatchdogState::new(None);
+        let mut p = steady(1.0, 0.0);
+        p.seq = 10;
+        assert_eq!(wd.observe(&p, 0), WatchdogVerdict::Fresh);
+        p.seq = 3;
+        assert_eq!(wd.observe(&p, 0), WatchdogVerdict::Replay);
+        // The high-water mark is still 10, so seq 11 is the next acceptable one.
+        p.seq = 11;
+        assert_eq!(wd.observe(&p, 0), WatchdogVerdict::Fresh);
+    }
+
+    #[test]
+    fn watchdog_freshness_window_rejects_stale_and_future() {
+        // 100 ms window, expressed in nanoseconds.
+        let window_ns: u128 = 100 * 1_000_000;
+        let now: u128 = 10_000_000_000; // arbitrary "now"
+        let mut wd = WatchdogState::new(Some(window_ns));
+
+        // Within window → fresh.
+        let mut p = steady(1.0, 0.0);
+        p.seq = 1;
+        p.ts_nanos = now - 50 * 1_000_000;
+        assert_eq!(wd.observe(&p, now), WatchdogVerdict::Fresh);
+
+        // Older than the window → stale (seq still advances so it is not a replay).
+        p.seq = 2;
+        p.ts_nanos = now - 250 * 1_000_000;
+        assert_eq!(wd.observe(&p, now), WatchdogVerdict::Stale);
+
+        // Future-dated beyond the window → forgery/skew rejection.
+        p.seq = 3;
+        p.ts_nanos = now + 250 * 1_000_000;
+        assert_eq!(wd.observe(&p, now), WatchdogVerdict::FutureDated);
+    }
+
+    #[test]
+    fn watchdog_freshness_disabled_ignores_timestamps() {
+        // No window → an ancient timestamp is accepted (replay check still gates seq).
+        let mut wd = WatchdogState::new(None);
+        let mut p = steady(1.0, 0.0);
+        p.seq = 1;
+        p.ts_nanos = 0;
+        assert_eq!(wd.observe(&p, 10_000_000_000), WatchdogVerdict::Fresh);
+    }
+
+    #[test]
+    fn mac_round_trips_and_rejects_tamper() {
+        let psk = b"shared-bench-secret";
+        let body = bincode::serialize(&steady(1.0, 0.0)).expect("encode");
+        let tag = compute_mac(psk, &body);
+        assert!(verify_mac(psk, &body, &tag), "a valid tag must verify");
+
+        // Wrong key → reject.
+        assert!(!verify_mac(b"other-key", &body, &tag), "a tag under another key must fail");
+
+        // Tampered body → reject.
+        let mut tampered = body.clone();
+        tampered[0] ^= 0xFF;
+        assert!(!verify_mac(psk, &tampered, &tag), "a tampered body must fail authentication");
+
+        // Tampered tag → reject.
+        let mut bad_tag = tag;
+        bad_tag[0] ^= 0xFF;
+        assert!(!verify_mac(psk, &body, &bad_tag), "a tampered tag must fail authentication");
+    }
+
+    #[test]
+    fn framed_response_is_authenticated_and_decodes() {
+        let psk = b"shared-bench-secret";
+        let verdict = safe_state_verdict(7);
+        let framed = frame_response(psk, &verdict).expect("frame");
+        assert!(framed.len() > MAC_LEN, "framed response carries tag + body");
+        let (tag, body) = framed.split_at(MAC_LEN);
+        assert!(verify_mac(psk, body, tag), "the car must be able to authenticate the verdict");
+        // The body is the serialized verdict; reason_code is FrameIntegrityUntrusted (11).
+        assert_eq!(verdict.reason_code, 11);
     }
 }

--- a/src/bin/ai_robot_demo.rs
+++ b/src/bin/ai_robot_demo.rs
@@ -3,7 +3,7 @@
 
 use kirra_verifier::kinematics_contract::KinematicContract;
 use kirra_verifier::robotics_alignment::AlignmentBridge;
-use kirra_verifier::dds_bridge::DdsPublisherBridge;
+use kirra_verifier::dds_bridge::{DdsPublisherBridge, DdsQosProfile};
 
 fn main() {
     let contract = KinematicContract {
@@ -13,6 +13,10 @@ fn main() {
         fallback_linear_speed: 0.0,
     };
     let bridge = AlignmentBridge::new(contract);
+
+    // Actuator topics publish under the frozen critical QoS profile; the publish
+    // seam enforces Volatile + latest-wins + bounded-lifespan fail-closed.
+    let actuator_qos = DdsQosProfile::critical_actuator_profile();
 
     let intents = [
         r#"{"action": "MOVE", "velocity": 1.0}"#,
@@ -25,10 +29,12 @@ fn main() {
         println!("Intent: {}", intent);
         match bridge.align_and_serialize_intent(intent) {
             Ok((output, frame)) => {
-                let dds_payload = DdsPublisherBridge::wrap_cdr_encapsulation(&frame);
                 println!("  Resolution: {:?}", output.resolution);
                 println!("  Narrative:  {}", output.narrative);
-                println!("  DDS Frame:  {}", hex::encode(&dds_payload));
+                match DdsPublisherBridge::publish_actuator_command(&frame, &actuator_qos) {
+                    Ok(dds_payload) => println!("  DDS Frame:  {}", hex::encode(&dds_payload)),
+                    Err(v) => println!("  DDS REFUSED: {v}"),
+                }
             }
             Err(e) => println!("  Parse error: {}", e),
         }

--- a/src/dds_bridge.rs
+++ b/src/dds_bridge.rs
@@ -1,31 +1,202 @@
 // src/dds_bridge.rs
+//
+// DDS publisher bridge for actuator command topics.
+//
+// SAFETY (SG-016, INV-10): an actuator topic MUST use Volatile durability. A
+// TransientLocal actuator topic would let a late-joining / reconnecting
+// subscriber replay the LAST-published command — a stale actuation a vehicle
+// could act on after a dropout. KeepAll / KeepLast(n>1) history is the same class
+// of hazard (a backed-up subscriber drains stale commands), and an unbounded
+// Lifespan lets a sample outlive its deadline.
+//
+// The actuator QoS profile used to be DESCRIPTIVE — `critical_actuator_profile`
+// had no caller, so the Volatile rule was only a source-level assertion checked by
+// the SG-016 test. It is now ENFORCED at the publish seam: `publish_actuator_command`
+// validates the profile (`actuator_admissibility`) and REFUSES to emit a frame
+// under a non-Volatile / non-latest-wins / unbounded-lifespan profile (fail-closed),
+// so a misconfigured topic cannot replay a stale command at runtime, not just in test.
 
-pub enum DdsReliability { Reliable, BestEffort }
-pub enum DdsDurability { Volatile, TransientLocal }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DdsReliability {
+    Reliable,
+    BestEffort,
+}
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DdsDurability {
+    Volatile,
+    TransientLocal,
+}
+
+/// History QoS. For actuation the only safe policy is `KeepLast(1)` (latest-wins);
+/// `KeepAll` (or `KeepLast(n>1)`) would queue commands and let a backed-up
+/// subscriber drain stale ones after a stall.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DdsHistory {
+    KeepLast(u16),
+    KeepAll,
+}
+
+/// Liveliness QoS — the publisher asserts liveliness automatically within
+/// `lease_ms`; a subscriber that misses the lease treats the writer as LOST
+/// (so a silent governor reads as a fault to fail-close against, never as a
+/// held last-command).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DdsLiveliness {
+    Automatic { lease_ms: u32 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DdsQosProfile {
     pub reliability: DdsReliability,
     pub durability: DdsDurability,
+    pub history: DdsHistory,
+    pub liveliness: DdsLiveliness,
+    /// Command validity horizon (ms): a sample older than this is dropped by the
+    /// middleware before any subscriber sees it (kept ≈ the deadline).
+    pub lifespan_ms: u32,
     pub deadline_ms: u32,
 }
 
 impl DdsQosProfile {
+    /// The frozen actuator-topic profile: Reliable + Volatile + KeepLast(1),
+    /// Lifespan = deadline, automatic liveliness at the deadline lease.
     pub fn critical_actuator_profile() -> Self {
         Self {
             reliability: DdsReliability::Reliable,
             durability: DdsDurability::Volatile,
+            history: DdsHistory::KeepLast(1),
+            liveliness: DdsLiveliness::Automatic { lease_ms: 20 },
+            lifespan_ms: 20,
             deadline_ms: 20,
         }
+    }
+
+    /// Fail-closed QoS admissibility for an ACTUATOR topic. Returns the specific
+    /// violation so a caller / `startup_sentinel` can log which rule failed.
+    pub fn actuator_admissibility(&self) -> Result<(), DdsQosViolation> {
+        // INV-10 / SG-016: Volatile only — TransientLocal would replay a stale
+        // command to a reconnecting subscriber.
+        if self.durability != DdsDurability::Volatile {
+            return Err(DdsQosViolation::NonVolatileActuatorTopic);
+        }
+        // Latest-wins only — KeepAll / KeepLast(n>1) can drain stale commands.
+        if self.history != DdsHistory::KeepLast(1) {
+            return Err(DdsQosViolation::NonLatestWinsActuatorTopic);
+        }
+        // A command with no validity horizon can outlive its deadline.
+        if self.lifespan_ms == 0 {
+            return Err(DdsQosViolation::UnboundedLifespan);
+        }
+        Ok(())
+    }
+}
+
+/// A QoS misconfiguration that would make an actuator topic unsafe. Carrying the
+/// specific rule (rather than a bool) lets the publish seam and startup sentinel
+/// log WHICH invariant a profile violated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DdsQosViolation {
+    NonVolatileActuatorTopic,
+    NonLatestWinsActuatorTopic,
+    UnboundedLifespan,
+}
+
+impl DdsQosViolation {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DdsQosViolation::NonVolatileActuatorTopic => "DDS_ACTUATOR_NON_VOLATILE",
+            DdsQosViolation::NonLatestWinsActuatorTopic => "DDS_ACTUATOR_NON_LATEST_WINS",
+            DdsQosViolation::UnboundedLifespan => "DDS_ACTUATOR_UNBOUNDED_LIFESPAN",
+        }
+    }
+}
+
+impl std::fmt::Display for DdsQosViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
 pub struct DdsPublisherBridge;
 
 impl DdsPublisherBridge {
+    /// Prepend the 4-byte CDR (little-endian) encapsulation header to a payload.
+    /// Transport-level framing only; carries no QoS guarantee on its own.
     pub fn wrap_cdr_encapsulation(payload: &[u8]) -> Vec<u8> {
         let mut wrapped = Vec::with_capacity(4 + payload.len());
         wrapped.extend_from_slice(&[0x00, 0x01, 0x00, 0x00]);
         wrapped.extend_from_slice(payload);
         wrapped
+    }
+
+    /// Publish an actuator command under `profile`, ENFORCING the actuator QoS
+    /// invariant FIRST (fail-closed): a non-Volatile / non-latest-wins /
+    /// unbounded-lifespan profile is REFUSED — no frame is produced — so a
+    /// misconfigured topic can never replay a stale command. On success returns
+    /// the CDR-encapsulated frame ready for the writer.
+    pub fn publish_actuator_command(
+        payload: &[u8],
+        profile: &DdsQosProfile,
+    ) -> Result<Vec<u8>, DdsQosViolation> {
+        profile.actuator_admissibility()?;
+        Ok(Self::wrap_cdr_encapsulation(payload))
+    }
+}
+
+#[cfg(test)]
+mod dds_qos_tests {
+    use super::*;
+
+    #[test]
+    fn critical_profile_is_admissible_and_publishes() {
+        let profile = DdsQosProfile::critical_actuator_profile();
+        assert!(profile.actuator_admissibility().is_ok());
+        let frame = DdsPublisherBridge::publish_actuator_command(&[0xAA, 0xBB], &profile)
+            .expect("the frozen critical profile must be admissible");
+        // CDR header (4 bytes) + payload.
+        assert_eq!(&frame[..4], &[0x00, 0x01, 0x00, 0x00]);
+        assert_eq!(&frame[4..], &[0xAA, 0xBB]);
+    }
+
+    #[test]
+    fn transient_local_actuator_topic_is_refused() {
+        let mut profile = DdsQosProfile::critical_actuator_profile();
+        profile.durability = DdsDurability::TransientLocal;
+        assert_eq!(
+            profile.actuator_admissibility(),
+            Err(DdsQosViolation::NonVolatileActuatorTopic)
+        );
+        // The publish seam must emit NO frame for a TransientLocal actuator topic.
+        assert_eq!(
+            DdsPublisherBridge::publish_actuator_command(&[0x01], &profile),
+            Err(DdsQosViolation::NonVolatileActuatorTopic),
+            "INV-10/SG-016: a TransientLocal actuator topic could replay stale \
+             commands and must be refused fail-closed"
+        );
+    }
+
+    #[test]
+    fn keep_all_or_deep_history_is_refused() {
+        for history in [DdsHistory::KeepAll, DdsHistory::KeepLast(8)] {
+            let mut profile = DdsQosProfile::critical_actuator_profile();
+            profile.history = history;
+            assert_eq!(
+                DdsPublisherBridge::publish_actuator_command(&[0x01], &profile),
+                Err(DdsQosViolation::NonLatestWinsActuatorTopic),
+                "non-latest-wins history {history:?} can drain stale commands and must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn unbounded_lifespan_is_refused() {
+        let mut profile = DdsQosProfile::critical_actuator_profile();
+        profile.lifespan_ms = 0;
+        assert_eq!(
+            DdsPublisherBridge::publish_actuator_command(&[0x01], &profile),
+            Err(DdsQosViolation::UnboundedLifespan),
+            "a command with no validity horizon can outlive its deadline"
+        );
     }
 }


### PR DESCRIPTION
Closes the engineering review's **two remaining transport-tier safety gaps** — **B2** (unauthenticated, spoofable UDP governor + stubbed staleness watchdog) and the **dead DDS QoS profile** (the Volatile actuator invariant was asserted in a test but never enforced at a publisher). Neither change touches the verified per-pose kernel path.

## 1 — UDP governor authentication + watchdog (B2)

`kirra-governor-service` is a vehicle-**control** surface that previously trusted the `recv_from` source address with no authentication, and its M6 watchdog only *logged* a replayed sequence (`ts_nanos` carried but unused).

- **Mandatory HMAC-SHA256 auth.** PSK from `KIRRA_GOVERNOR_PSK` — **required**; absent/empty → the governor **refuses to start** (fail-closed, mirroring the `KIRRA_ADMIN_TOKEN` discipline). Every datagram carries a 32-byte tag over its body, verified **constant-time** (`Mac::verify_slice`).
- **Anti-reflection.** An unauthenticated datagram is dropped **silently** — no reply to a forged source. Replies are **MAC'd too** (mutual auth), so an attacker cannot inject a spoofed verdict (e.g. a forged `Allow`) at the car.
- **Watchdog now rejects, not just logs.** A non-advancing / replayed sequence → fail-closed **safe-state deny** (`FrameIntegrityUntrusted`). MAC + monotonic-seq together defeat both *forged* and *captured-and-replayed* datagrams; a rejected proposal never advances the sequence high-water mark.
- **Opt-in staleness window.** `KIRRA_GOVERNOR_FRESHNESS_MS` rejects stale / future-dated proposals. The clock-free seq-replay check is **always on**; absolute-time staleness is opt-in because it needs car/governor clock sync (AOU-TIMESYNC-001).

New deps: `hmac` + `sha2` (pure-Rust, no_std-capable, async/ROS-free — consistent with the crate's QNX/cert-target dependency discipline; versions pinned to the workspace root).

## 2 — DDS actuator QoS enforcement

`critical_actuator_profile()` was **dead code** — the Volatile rule lived only as a source-level assertion checked by the SG-016 test.

- **Enforced at the publish seam.** New `publish_actuator_command()` validates the profile and **refuses (fail-closed)** any non-Volatile / non-latest-wins / unbounded-lifespan actuator topic, so a misconfigured topic cannot replay a stale command **at runtime**, not just in test.
- **Added the missing QoS fields** the review named: `History` (`KeepLast(1)`), `Liveliness` (automatic lease), `Lifespan` (≈ deadline). `ai_robot_demo` now publishes through the enforced seam, giving `critical_actuator_profile` a **real caller**. The SG-016 invariant (`durability: DdsDurability::Volatile`; no `TransientLocal` topic config) is preserved.

### Scope / honesty note
This `dds_bridge.rs` is the Rust stub seam; the real RMW/Cyclone publisher is the C++ bridge. This PR closes the **dead-code / unenforced-invariant** gap by enforcing the actuator QoS rules at the Rust publish boundary — it is not a full DDS integration, and it doesn't claim to be.

## Testing

- **Governor:** MAC round-trip + tamper (wrong key / mutated body / mutated tag), replay rejection (lower **and** equal seq), high-water-mark non-poisoning, freshness-window stale/future rejection, freshness-disabled path, authenticated framed response.
- **DDS:** QoS admissibility — `TransientLocal` / `KeepAll` / deep-history / unbounded-lifespan all refused; critical profile admissible and publishes; SG-016 still green.
- Full workspace suite (**78 test binaries**) and clippy under the CI flags: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_