### PR TITLE
perf(store): WAL read-replica pool — decouple read routes from the writer mutex (P3)

### DIFF
--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -535,10 +535,11 @@ enum FedCommitOutcome {
 
 async fn export_backup(State(svc): State<Arc<ServiceState>>) -> impl IntoResponse {
     let exported_at_ms = now_ms();
-    // Three full-table loads (nodes + dependencies + all posture events) under one
-    // lock — the heaviest read. Run it off the worker pool so a large dump cannot
-    // pin a tokio worker (and hold the store mutex on it) for its whole duration.
-    let result = svc.app.store.call(move |store| {
+    // Three full-table loads (nodes + dependencies + all posture events) — the
+    // heaviest read. `call_read` runs it off the worker pool AND against a
+    // read-only replica connection, so a large dump neither pins a tokio worker
+    // nor contends the writer mutex (a concurrent write proceeds unblocked).
+    let result = svc.app.store.call_read(move |store| {
         let nodes = store.load_nodes().ok()?;
         let dependencies = store.load_dependencies().ok()?;
         let posture_events = store.load_all_posture_events().ok()?;
@@ -924,7 +925,7 @@ async fn get_node_history(
     State(svc): State<Arc<ServiceState>>,
     Path(node_id): Path<String>,
 ) -> impl IntoResponse {
-    match svc.app.store.with(|store| store.load_node_history(&node_id)) {
+    match svc.app.store.with_read(|store| store.load_node_history(&node_id)) {
         Ok(history) => Json(json!({ "node_id": node_id, "history": history })).into_response(),
         Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
                    Json(json!({ "error": "failed to load history" }))).into_response(),
@@ -936,7 +937,7 @@ async fn get_node_flap_status(
     Path(node_id): Path<String>,
 ) -> impl IntoResponse {
     let five_minutes_ago = now_ms().saturating_sub(300_000);
-    match svc.app.store.with(|store| store.count_recent_posture_events(&node_id, five_minutes_ago)) {
+    match svc.app.store.with_read(|store| store.count_recent_posture_events(&node_id, five_minutes_ago)) {
         Ok(count) => {
             let status = FlapStatus {
                 node_id: node_id.clone(),
@@ -954,10 +955,11 @@ async fn verify_audit_chain(
     State(svc): State<Arc<ServiceState>>,
 ) -> impl IntoResponse {
     // `VerifyingKey` is `Copy`; copy it into the blocking task. A full-chain scan
-    // with a per-row Ed25519 verification is the heaviest read-side op — run it off
-    // the worker pool so it can't pin a tokio worker (and hold the store mutex).
+    // with a per-row Ed25519 verification is the heaviest read-side op — `call_read`
+    // runs it off the worker pool AND on a read-only replica, so it neither pins a
+    // tokio worker nor contends the writer mutex.
     let vk = svc.audit_verifying_key;
-    let result = svc.app.store.call(move |store| {
+    let result = svc.app.store.call_read(move |store| {
         store.verify_audit_chain_full(vk.as_ref())
     })
     .await;
@@ -999,7 +1001,7 @@ async fn handle_audit_export(
     let limit = params.limit.unwrap_or(100).min(1000);
     let offset = params.offset.unwrap_or(0);
     let vk = svc.audit_verifying_key.as_ref();
-    match svc.app.store.with(|store| store.load_audit_chain_page(limit, offset, vk)) {
+    match svc.app.store.with_read(|store| store.load_audit_chain_page(limit, offset, vk)) {
         Ok(page) => Json(page).into_response(),
         Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
                    Json(json!({ "error": "export query failed" }))).into_response(),
@@ -1806,7 +1808,7 @@ async fn get_federated_reports(
 ) -> impl IntoResponse {
     // Both reads share ONE acquisition (Rule 5). The closure returns a Result so
     // the per-read error responses are produced OUTSIDE the closure (Rule 4).
-    let loaded = svc.app.store.with(|store| {
+    let loaded = svc.app.store.with_read(|store| {
         let reports = store.load_federated_reports_for_asset(&asset_id)
             .map_err(|_| "failed to load reports")?;
         // #329 v2 — generation-ordered conflict resolution. Reconcile the stored

--- a/src/store_handle.rs
+++ b/src/store_handle.rs
@@ -2,33 +2,101 @@
 //
 // StoreHandle — the single access seam for the durable `VerifierStore`.
 //
-// DB-ACTOR MIGRATION, PHASE 1 (this commit): this type replaces the bare
-// `Arc<Mutex<VerifierStore>>` that `AppState` and `FabricCausalLog` used to
-// expose. Every store access now goes through one of two methods:
+// WRITE PATH (phase 1): every mutating / read-then-write access goes through one
+// of two methods against the single WRITER connection:
 //
 //   * `with(|s| ...)`  — synchronous; for background OS threads, tests, and
 //                        sync helpers. Blocks the calling thread for the closure.
 //   * `call(|s| ...).await` — async; runs the closure OFF the tokio worker pool
 //                        (`spawn_blocking`) so the runtime stays responsive.
 //
-// In THIS phase the handle still wraps an `Arc<Mutex<VerifierStore>>`, so the
-// behavior is materially identical to the prior direct-lock code. PHASE 2 swaps
-// the internals for a dedicated-thread actor that OWNS the connection outright —
-// removing the mutex and the lock-poison surface — WITHOUT touching any call
-// site (they keep calling `with` / `call`).
+// READ PATH (phase 2 / review P3): read-only routes go through `with_read` /
+// `call_read`, which dispatch to a POOL of independent READ-ONLY replica
+// connections on the same WAL file — OUTSIDE the writer mutex. In WAL mode a
+// read-only connection sees committed snapshots and neither blocks nor is
+// blocked by the writer, so a read route (fleet posture, history, a full backup
+// export, an audit-chain verify) no longer serializes behind a slow write. The
+// read closures take `&VerifierStore` (read methods are all `&self`), so the
+// type system forbids a write on the read path. For `":memory:"` stores (tests)
+// or if the replicas fail to open, the read path FALLS BACK to the writer —
+// correctness preserved, just without the concurrency benefit.
 //
-// POISON HANDLING — the one intentional behavior delta in phase 1: `with` and
-// `call` both RECOVER a poisoned lock via `into_inner` rather than panicking
-// (`.lock().unwrap()`) or failing closed (`match .lock() { Err => ... }`).
+// POISON HANDLING: `with` / `call` / `with_read` / `call_read` all RECOVER a
+// poisoned lock via `into_inner` rather than panicking or failing closed.
 // rusqlite data is not corrupted by a panicking lock holder (Rust mutex
 // poisoning is conservative, and an aborted SQLite transaction rolls back on
 // drop), so recovery keeps the safety governor evaluating instead of wedging on
-// a one-off panic. This matches what `telemetry_watchdog` already did, and
-// phase 2 removes lock poisoning entirely.
+// a one-off panic. This matches what `telemetry_watchdog` already did.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::verifier_store::VerifierStore;
+
+/// Number of independent read-only replica connections opened per file-backed
+/// store. Bounds read-among-read concurrency (each is a separate WAL reader);
+/// reads never serialize behind the writer regardless. Small: read routes are
+/// light and a handful of extra read-only fds is cheap.
+const READ_REPLICA_POOL_SIZE: usize = 4;
+
+/// The read-only side of a `StoreHandle`: a pool of independent replica
+/// connections, or a fallback to the writer when replicas are unavailable.
+enum ReadReplica {
+    /// File-backed: a round-robin pool of read-only connections, independent of
+    /// the writer mutex.
+    Pool {
+        conns: Vec<Mutex<VerifierStore>>,
+        next: AtomicUsize,
+    },
+    /// `":memory:"` (a 2nd open is a distinct empty db) or an open failure: reads
+    /// fall back to the writer. Correct, just not concurrent.
+    Fallback,
+}
+
+impl ReadReplica {
+    /// Open a read-replica pool for `path`, or `Fallback` for in-memory / on any
+    /// open failure (a degraded-concurrency, never-incorrect outcome).
+    fn open(path: &str) -> Self {
+        if path == ":memory:" {
+            return ReadReplica::Fallback;
+        }
+        let mut conns = Vec::with_capacity(READ_REPLICA_POOL_SIZE);
+        for _ in 0..READ_REPLICA_POOL_SIZE {
+            match VerifierStore::open_read_replica(path) {
+                Ok(replica) => conns.push(Mutex::new(replica)),
+                // A partial pool is still useful; a fully empty one falls back.
+                Err(_) => break,
+            }
+        }
+        if conns.is_empty() {
+            ReadReplica::Fallback
+        } else {
+            ReadReplica::Pool {
+                conns,
+                next: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    /// Run a read-only closure against a pooled replica (round-robin), or the
+    /// writer if no replica is available. `writer` is only touched on `Fallback`.
+    fn dispatch<F, R>(&self, writer: &Mutex<VerifierStore>, f: F) -> R
+    where
+        F: FnOnce(&VerifierStore) -> R,
+    {
+        match self {
+            ReadReplica::Pool { conns, next } => {
+                let i = next.fetch_add(1, Ordering::Relaxed) % conns.len();
+                let guard = conns[i].lock().unwrap_or_else(|p| p.into_inner());
+                f(&guard)
+            }
+            ReadReplica::Fallback => {
+                let guard = writer.lock().unwrap_or_else(|p| p.into_inner());
+                f(&guard)
+            }
+        }
+    }
+}
 
 /// A store access could not run to completion. Distinct from a DB-level error
 /// (which the closure returns itself). Fail-closed: callers map this to a 500 /
@@ -51,28 +119,43 @@ impl std::fmt::Display for StoreError {
 impl std::error::Error for StoreError {}
 
 /// The single access seam for the durable `VerifierStore`. Cheaply cloneable
-/// (shares the underlying store); clone it into background tasks freely.
+/// (shares the underlying store + read pool); clone it into background tasks
+/// freely.
 #[derive(Clone)]
 pub struct StoreHandle {
-    inner: Arc<Mutex<VerifierStore>>,
+    /// The single writer connection — all mutations and read-then-write groups.
+    writer: Arc<Mutex<VerifierStore>>,
+    /// The read-only side: a pool of independent replica connections (or a
+    /// fallback to the writer for in-memory stores).
+    readers: Arc<ReadReplica>,
 }
 
 impl StoreHandle {
-    /// Build a handle that owns `store`.
+    /// Build a handle that owns `store` (the writer) and opens a read-replica
+    /// pool against the same database file (or `Fallback` for `":memory:"`).
     pub fn new(store: VerifierStore) -> Self {
+        let readers = Arc::new(ReadReplica::open(store.path()));
         Self {
-            inner: Arc::new(Mutex::new(store)),
+            writer: Arc::new(Mutex::new(store)),
+            readers,
         }
     }
 
-    /// Wrap an existing `Arc<Mutex<VerifierStore>>` (transitional helper for the
-    /// few call sites that already hold one, e.g. `FabricCausalLog::new`). Phase 2
-    /// removes this along with the mutex.
-    pub fn from_arc(inner: Arc<Mutex<VerifierStore>>) -> Self {
-        Self { inner }
+    /// Wrap an existing `Arc<Mutex<VerifierStore>>` as the writer and open a
+    /// read-replica pool against its database file. (Transitional helper for the
+    /// few call sites that already hold an `Arc<Mutex<VerifierStore>>`, e.g.
+    /// `FabricCausalLog::new`.)
+    pub fn from_arc(writer: Arc<Mutex<VerifierStore>>) -> Self {
+        let path = writer
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .path()
+            .to_string();
+        let readers = Arc::new(ReadReplica::open(&path));
+        Self { writer, readers }
     }
 
-    /// Run `f` against the store from a SYNCHRONOUS context and return its value.
+    /// Run `f` against the WRITER from a SYNCHRONOUS context and return its value.
     /// Poison-tolerant. Use off the async runtime (background OS threads, tests,
     /// sync helpers). Calling this from an async task blocks the worker for the
     /// closure's duration — async callers should use [`StoreHandle::call`].
@@ -80,11 +163,11 @@ impl StoreHandle {
     where
         F: FnOnce(&mut VerifierStore) -> R,
     {
-        let mut guard = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let mut guard = self.writer.lock().unwrap_or_else(|p| p.into_inner());
         f(&mut guard)
     }
 
-    /// Run `f` against the store OFF the async worker threads and await the
+    /// Run `f` against the WRITER OFF the async worker threads and await the
     /// result. The lock acquisition + SQLite work runs on a blocking thread, so a
     /// long write cannot pin a tokio worker. Fail-closed: a panicked / cancelled
     /// task surfaces as `Err(StoreError::TaskFailed)`.
@@ -93,13 +176,41 @@ impl StoreHandle {
         F: FnOnce(&mut VerifierStore) -> R + Send + 'static,
         R: Send + 'static,
     {
-        let inner = Arc::clone(&self.inner);
+        let writer = Arc::clone(&self.writer);
         match tokio::task::spawn_blocking(move || {
-            let mut guard = inner.lock().unwrap_or_else(|p| p.into_inner());
+            let mut guard = writer.lock().unwrap_or_else(|p| p.into_inner());
             f(&mut guard)
         })
         .await
         {
+            Ok(r) => Ok(r),
+            Err(_) => Err(StoreError::TaskFailed),
+        }
+    }
+
+    /// Run a READ-ONLY closure `f` against a read-replica connection (or the
+    /// writer on `Fallback`) from a SYNCHRONOUS context. `f` gets `&VerifierStore`
+    /// (immutable), so only `&self` read methods are reachable — no write can ride
+    /// the read path. Decouples reads from the writer mutex.
+    pub fn with_read<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&VerifierStore) -> R,
+    {
+        self.readers.dispatch(&self.writer, f)
+    }
+
+    /// Async read-only access OFF the worker pool against a read-replica
+    /// connection (or the writer on `Fallback`). The heavy-read win: a full
+    /// backup export / audit-chain verify runs on a blocking thread against a
+    /// replica, never pinning a worker NOR contending the writer mutex.
+    pub async fn call_read<F, R>(&self, f: F) -> Result<R, StoreError>
+    where
+        F: FnOnce(&VerifierStore) -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let readers = Arc::clone(&self.readers);
+        let writer = Arc::clone(&self.writer);
+        match tokio::task::spawn_blocking(move || readers.dispatch(&writer, f)).await {
             Ok(r) => Ok(r),
             Err(_) => Err(StoreError::TaskFailed),
         }
@@ -143,5 +254,85 @@ mod store_handle_tests {
         // A subsequent access still works (recovered via into_inner).
         let n = handle.with(|s| s.load_nodes().map(|v| v.len()).unwrap_or(usize::MAX));
         assert_eq!(n, 0, "the handle recovers a poisoned lock instead of wedging");
+    }
+
+    #[test]
+    fn memory_store_read_falls_back_to_writer() {
+        // `:memory:` → ReadReplica::Fallback; with_read still reads the writer.
+        let handle = StoreHandle::new(temp_store());
+        let n = handle.with_read(|s| s.load_nodes().map(|v| v.len()).unwrap_or(usize::MAX));
+        assert_eq!(n, 0, "in-memory read falls back to the writer and reads consistently");
+    }
+
+    fn file_db_path(tag: &str) -> std::path::PathBuf {
+        // Unique-per-test file under the OS temp dir; pid keeps parallel runs apart.
+        let mut p = std::env::temp_dir();
+        p.push(format!("kirra_store_handle_{}_{}.sqlite", tag, std::process::id()));
+        let _ = std::fs::remove_file(&p);
+        p
+    }
+
+    #[test]
+    fn file_read_replica_sees_committed_writer_data() {
+        use crate::verifier::RegisteredNode;
+        let path = file_db_path("replica_visibility");
+        let handle = StoreHandle::new(VerifierStore::new(path.to_str().unwrap()).expect("store"));
+
+        // Pre-write: the replica pool sees zero nodes.
+        assert_eq!(handle.with_read(|s| s.load_nodes().unwrap().len()), 0);
+
+        // Commit a node through the WRITER.
+        handle.with(|s| {
+            s.save_node(&RegisteredNode {
+                node_id: "node-A".to_string(),
+                status: crate::verifier::NodeTrustState::Unknown,
+                registered_at_ms: 1,
+                last_trust_update_ms: 1,
+                ak_public_pem: None,
+                expected_pcr16_digest_hex: None,
+                site: None,
+                firmware_version: None,
+            })
+            .expect("save_node");
+        });
+
+        // A fresh read transaction on a replica connection must observe the
+        // committed write (WAL read-committed visibility).
+        let nodes = handle.with_read(|s| s.load_nodes().expect("load_nodes"));
+        assert_eq!(nodes.len(), 1, "read replica must see the committed writer node");
+        assert_eq!(nodes[0].node_id, "node-A");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn call_read_offloads_and_reads_replica() {
+        let path = file_db_path("call_read");
+        let handle = StoreHandle::new(VerifierStore::new(path.to_str().unwrap()).expect("store"));
+        let n = handle
+            .call_read(|s| s.load_nodes().map(|v| v.len()).unwrap_or(usize::MAX))
+            .await
+            .expect("call_read completes");
+        assert_eq!(n, 0);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn file_read_path_is_independent_of_the_writer_lock() {
+        // Deterministic proof (no timing/sleep) that a file-backed read does NOT
+        // route through the writer mutex: hold the writer guard on THIS thread and
+        // issue a read inside it. The std Mutex is non-reentrant, so if `with_read`
+        // touched the writer lock this would DEADLOCK; because the file store has an
+        // independent replica pool, the read proceeds on a separate connection.
+        let path = file_db_path("isolation");
+        let handle = StoreHandle::new(VerifierStore::new(path.to_str().unwrap()).expect("store"));
+        handle.with(|_writer_guard_held| {
+            let n = handle.with_read(|s| s.load_nodes().map(|v| v.len()).unwrap_or(usize::MAX));
+            assert_eq!(
+                n, 0,
+                "a file-backed read must proceed on the replica while the writer lock is held"
+            );
+        });
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -211,6 +211,10 @@ fn is_unique_violation(e: &rusqlite::Error) -> bool {
     )
 }
 
+/// Busy timeout for a read-only replica connection (ms): brief, so a reader
+/// rides out a concurrent WAL checkpoint instead of surfacing `SQLITE_BUSY`.
+const READ_REPLICA_BUSY_TIMEOUT_MS: u64 = 250;
+
 pub struct VerifierStore {
     /// Hot/read connection — `synchronous=NORMAL`. Carries the verdict-adjacent
     /// per-command audit (no fsync; throughput-safe at 20 Hz+).
@@ -225,6 +229,10 @@ pub struct VerifierStore {
     /// durable-write seam #165 (active-key + genesis persistence) extends.
     durable_conn: Option<Connection>,
     pub signing_key: Option<ed25519_dalek::SigningKey>,
+    /// The database path this store was opened from (`":memory:"` for in-memory).
+    /// Retained so a [`StoreHandle`](crate::store_handle::StoreHandle) can open
+    /// independent READ-ONLY replica connections to the same WAL file.
+    db_path: String,
 }
 
 // --- audit key-rotation helpers (#76) --------------------------------------
@@ -701,7 +709,45 @@ impl VerifierStore {
             Some(dc)
         };
 
-        Ok(Self { conn, durable_conn, signing_key: None })
+        Ok(Self { conn, durable_conn, signing_key: None, db_path: path.to_string() })
+    }
+
+    /// The database path this store was opened from.
+    pub fn path(&self) -> &str {
+        &self.db_path
+    }
+
+    /// Open an independent READ-ONLY replica connection to an EXISTING WAL
+    /// database (the writer owns all DDL, so this runs no schema setup). In WAL
+    /// mode a read-only connection sees committed snapshots and neither blocks
+    /// nor is blocked by the writer, so routing read-only routes here decouples
+    /// them from the writer mutex (review P3). All read methods are `&self` and
+    /// fresh-prepare their statements, so they work directly against the replica.
+    ///
+    /// Returns `Err` for `":memory:"` — a second `:memory:` open is a DISTINCT
+    /// empty database (same caveat as `durable_conn`), so the caller falls back
+    /// to the writer there.
+    pub fn open_read_replica(path: &str) -> Result<Self> {
+        if path == ":memory:" {
+            return Err(rusqlite::Error::InvalidParameterName(
+                ":memory: has no shareable read replica".to_string(),
+            ));
+        }
+        let conn = Connection::open_with_flags(
+            path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+                | rusqlite::OpenFlags::SQLITE_OPEN_URI
+                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        // A read-only WAL reader can briefly contend with a checkpoint; a short
+        // busy timeout rides it out rather than surfacing SQLITE_BUSY.
+        conn.busy_timeout(std::time::Duration::from_millis(READ_REPLICA_BUSY_TIMEOUT_MS))?;
+        Ok(Self {
+            conn,
+            durable_conn: None,
+            signing_key: None,
+            db_path: path.to_string(),
+        })
     }
 
     /// Durability-critical read/single-write connection: the FULL handle when


### PR DESCRIPTION
Phase 2 of the store-backend work (the documented follow-up to the StoreHandle seam in #582).

## Why this, not the single-owner actor

The originally-planned dedicated-thread actor turned out to be the **wrong target**. I analyzed the call sites first: a single connection behind a `Mutex` and a single actor thread **both serialize all access** — so an actor wouldn't improve throughput. It would also require either a hand-rolled `unsafe` scoped-send (for the borrow-capturing sync `with` path) or churning ~105 call sites. After flagging this, the decision was to pursue the **actual review-P3 win**: read/write concurrency, which SQLite WAL provides via *multiple connections*. This PR delivers that — no `unsafe`, no call-site churn beyond the migrated read routes.

## What changed

- **`VerifierStore::open_read_replica(path)`** — opens an independent **read-only** WAL connection (no DDL; the writer owns schema). Retains `db_path` + adds `path()`. Returns `Err` for `:memory:` (a 2nd open is a distinct db — the same caveat the existing `durable_conn` already documents).
- **`StoreHandle` gains a read side** — a pool of 4 read-only replica connections **outside the writer mutex** — and two methods taking `&VerifierStore` (so the type system forbids a write on the read path):
  - `with_read(|s| …)` — sync read on a pooled replica
  - `call_read(|s| …).await` — async read off the worker pool on a replica
  - `:memory:` / open-failure → **`Fallback`** to the writer (correct, just not concurrent), so tests are unaffected.

In WAL mode a read-only connection sees committed snapshots and neither blocks nor is blocked by the writer, so a read route no longer serializes behind a slow write.

## Migrated reads (highest-value; the rest stay on the writer as the safe default)

- **`export_backup`** (3-table dump) and **`verify_audit_chain`** (full-chain Ed25519) → **`call_read`**: off the worker pool **and** off the writer mutex. These are the heaviest reads — previously a backup/verify held the store lock for its whole duration, blocking every writer.
- `get_node_history`, `get_node_flap_status`, `handle_audit_export`, `get_federated_reports` → **`with_read`**.

Read-then-write and mixed handlers stay on the writer. More read routes can migrate incrementally.

## Tests

- **Replica visibility** (file-backed): a replica observes the writer's committed node — WAL read-committed semantics.
- **Deterministic decoupling proof** (no timing/sleep, per the codebase's deterministic-test discipline): a read is issued *while the writer guard is held on the same thread*. The std `Mutex` is non-reentrant, so this would **deadlock** if `with_read` routed through the writer lock — it passes because the file store reads on an independent replica connection.
- `:memory:` fallback test; async `call_read` test.

Root clippy (CI flags) clean; root `cargo test --workspace` **78/78** ok; parko tests ok; warning-free including test targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_