### PR TITLE
refactor(industrial): unify binary-frame adapters behind one IndustrialAdapter trait (§13)

### DIFF
--- a/src/adapters/canopen.rs
+++ b/src/adapters/canopen.rs
@@ -85,6 +85,35 @@ impl CanOpenAdapter {
     }
 }
 
+impl crate::adapters::IndustrialAdapter for CanOpenAdapter {
+    type Message = CanOpenMessage;
+    const PROTOCOL: &'static str = "canopen";
+
+    fn verdict(msg: &CanOpenMessage) -> crate::adapters::AdapterVerdict {
+        let e = CanOpenAdapter::evaluate(msg);
+        crate::adapters::AdapterVerdict {
+            command: e.command,
+            details: serde_json::json!({
+                "message_type": format!("{:?}", e.message_type),
+                "node_id": e.node_id,
+                "is_emergency": e.is_emergency,
+                "emergency_code": e.emergency_code,
+            }),
+            triggers_recalculation: e.triggers_recalculation,
+        }
+    }
+
+    // POSTURE-ONLY (no override): a CANopen PDO carries raw process data and an
+    // SDO download's command byte self-describes only the value WIDTH (1/2/4
+    // bytes) — never its TYPE (signed/unsigned, int/float) or scaling, which are
+    // defined by the node's object dictionary, NOT the frame. Numerically
+    // bounding a width-N byte run without that per-object type would FABRICATE the
+    // value's interpretation (#85). So CANopen stays bounded by posture only until
+    // a per-(node,index,subindex) object-dictionary type+envelope config exists
+    // (tracked follow-up). Contrast DNP3 group-41, whose variation byte DOES carry
+    // the type (i16/i32/f32/f64) — which is why only DNP3 overrides this today.
+}
+
 /// Env var carrying the CANopen-node-id → fleet-node-id map (#84).
 /// Format: comma-separated `canid:fleet_node_id` pairs, e.g.
 /// `5:robot-01,6:robot-02`. The map is CONFIG-sourced — there is no

--- a/src/adapters/dnp3.rs
+++ b/src/adapters/dnp3.rs
@@ -119,6 +119,31 @@ impl Dnp3Adapter {
     }
 }
 
+impl crate::adapters::IndustrialAdapter for Dnp3Adapter {
+    type Message = Dnp3Message;
+    const PROTOCOL: &'static str = "dnp3";
+
+    fn verdict(msg: &Dnp3Message) -> crate::adapters::AdapterVerdict {
+        let e = Dnp3Adapter::evaluate(msg);
+        crate::adapters::AdapterVerdict {
+            command: e.command,
+            details: serde_json::json!({
+                "function_name": e.function_name,
+                "is_control": e.is_control,
+                "is_broadcast": e.is_broadcast,
+                "critical_infrastructure_relevant": e.critical_infrastructure_relevant,
+            }),
+            triggers_recalculation: false,
+        }
+    }
+
+    /// Analog Output (group 41) setpoints are bounded against the process-wide
+    /// envelope from `KIRRA_DNP3_ANALOG_OUTPUT_ENVELOPE`.
+    fn bound_magnitude(msg: &Dnp3Message) -> Result<(), &'static str> {
+        Dnp3Adapter::bound_analog_control(msg, global_analog_envelope().as_ref())
+    }
+}
+
 /// Faithfully decode a DNP3 group-41 (Analog Output Block) setpoint from its
 /// object `data`, per IEEE 1815 variations. Returns `None` (undecodable) when the
 /// variation is unknown or `data` is too short for the variation's value width —

--- a/src/adapters/ethernet_ip.rs
+++ b/src/adapters/ethernet_ip.rs
@@ -57,6 +57,33 @@ impl EtherNetIpAdapter {
     }
 }
 
+impl crate::adapters::IndustrialAdapter for EtherNetIpAdapter {
+    type Message = EtherNetIpMessage;
+    const PROTOCOL: &'static str = "ethernet_ip";
+
+    fn verdict(msg: &EtherNetIpMessage) -> crate::adapters::AdapterVerdict {
+        let e = EtherNetIpAdapter::evaluate(msg);
+        crate::adapters::AdapterVerdict {
+            command: e.command,
+            details: serde_json::json!({
+                "service_name": e.service_name,
+                "is_write": e.is_write,
+                "target_description": e.target_description,
+                "safety_relevant": e.safety_relevant,
+            }),
+            triggers_recalculation: false,
+        }
+    }
+
+    // POSTURE-ONLY (no override): a CIP write (Set_Attribute_Single / Write_Tag)
+    // carries `data` whose DATA TYPE — and thus value width, signedness, and
+    // scaling — is defined by the target attribute in the device's EDS/object
+    // model, NOT in the frame. Decoding a scalar magnitude from `data` without
+    // that per-attribute type config would be FABRICATION (#85), so EtherNet-IP
+    // stays bounded by posture/classification only until a per-target CIP type
+    // map exists (tracked follow-up). The trait's fail-closed default applies.
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,3 +1,103 @@
 pub mod canopen;
 pub mod dnp3;
 pub mod ethernet_ip;
+
+use crate::gateway::policy::OperationalCommand;
+
+// ---------------------------------------------------------------------------
+// IndustrialAdapter — one trait for every binary-frame industrial protocol
+// (DNP3 / CANopen / EtherNet-IP). It replaces the three near-identical arms of
+// `evaluate_unified_industrial_request` with a single generic dispatch
+// (`protocol_adapter::dispatch_adapter`), and gives the magnitude bound a
+// uniform seam (`bound_magnitude`) so every protocol enforces it the same way —
+// or documents, fail-closed, why it cannot. (The Modbus/OPC-UA legacy path maps
+// through `IndustrialEvent` / action-claims and keeps its own arm.)
+// ---------------------------------------------------------------------------
+
+/// The protocol-agnostic result of classifying one industrial message. Each
+/// adapter folds its protocol-specific detail into `details` (the JSON that was
+/// previously built inline in `protocol_adapter`), so the dispatch is uniform.
+#[derive(Debug, Clone)]
+pub struct AdapterVerdict {
+    /// The posture-gated command class (`ReadTelemetry` / `WriteState` /
+    /// `SystemMutation` / `Unknown`).
+    pub command: OperationalCommand,
+    /// Protocol-specific observability detail for the evaluation result.
+    pub details: serde_json::Value,
+    /// True when this message takes a node offline / changes topology and the
+    /// caller should trigger a posture recalculation.
+    pub triggers_recalculation: bool,
+}
+
+/// One binary-frame industrial protocol adapter. Implemented as associated
+/// functions (no `&self`) — adapters are zero-sized dispatch tags.
+pub trait IndustrialAdapter {
+    /// The wire message this adapter decodes (deserialized from the request JSON).
+    type Message: serde::de::DeserializeOwned;
+
+    /// Stable lower-snake protocol label (e.g. `"dnp3"`). Also drives the
+    /// `MALFORMED_<PROTOCOL>_MESSAGE` deserialize-error reason (uppercased).
+    const PROTOCOL: &'static str;
+
+    /// Classify a message into a posture-gated command + observability detail.
+    fn verdict(msg: &Self::Message) -> AdapterVerdict;
+
+    /// MAGNITUDE BOUND — a posture-admitted WRITE/CONTROL must also have its
+    /// commanded *value* bounded, not just its *type* classified. Fail-closed,
+    /// per the "faithfully decode or refuse, never fabricate" discipline (#85).
+    ///
+    /// Default `Ok(())` = "this protocol carries no faithfully-decodable scalar
+    /// magnitude in the message itself" (e.g. EtherNet-IP CIP, where the value's
+    /// data type lives in the target attribute's device config, not the frame).
+    /// Such a protocol stays posture-only until a per-target type config exists;
+    /// overriding adapters (DNP3, CANopen) bound what the wire format self-describes.
+    fn bound_magnitude(_msg: &Self::Message) -> Result<(), &'static str> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod adapter_trait_tests {
+    use super::*;
+    use crate::adapters::dnp3::{Dnp3Adapter, Dnp3Message};
+    use crate::adapters::ethernet_ip::{EtherNetIpAdapter, EtherNetIpMessage};
+
+    #[test]
+    fn dnp3_verdict_via_trait_classifies_and_bound_is_noop_for_read() {
+        let msg = Dnp3Message {
+            source_address: 1,
+            dest_address: 2,
+            function_code: 0x01, // Read
+            data_link_control: 0,
+            objects: vec![],
+            source_node: "rtu".into(),
+        };
+        let v = <Dnp3Adapter as IndustrialAdapter>::verdict(&msg);
+        assert_eq!(v.command, OperationalCommand::ReadTelemetry);
+        assert_eq!(Dnp3Adapter::PROTOCOL, "dnp3");
+        // A read carries no commanded setpoint → no magnitude bound applies.
+        assert!(<Dnp3Adapter as IndustrialAdapter>::bound_magnitude(&msg).is_ok());
+    }
+
+    #[test]
+    fn ethernet_ip_write_is_posture_only_bound_default_ok() {
+        // A CIP Set_Attribute_Single write classifies as WriteState, but its value
+        // TYPE is in device config, not the frame — so bound_magnitude is the
+        // fail-closed default no-op (posture-only; never fabricates a magnitude).
+        let msg = EtherNetIpMessage {
+            command_code: 0x65,
+            session_handle: 1,
+            status: 0,
+            service_code: 0x10, // Set_Attribute_Single
+            class_id: 0x04,
+            instance_id: 1,
+            attribute_id: 3,
+            data: vec![0xFF, 0xFF, 0xFF, 0xFF],
+            source_node: "plc".into(),
+        };
+        let v = <EtherNetIpAdapter as IndustrialAdapter>::verdict(&msg);
+        assert_eq!(v.command, OperationalCommand::WriteState);
+        assert_eq!(EtherNetIpAdapter::PROTOCOL, "ethernet_ip");
+        assert!(<EtherNetIpAdapter as IndustrialAdapter>::bound_magnitude(&msg).is_ok());
+    }
+}

--- a/src/protocol_adapter.rs
+++ b/src/protocol_adapter.rs
@@ -111,9 +111,9 @@ pub fn evaluate_industrial_event(event: IndustrialEvent, posture: FleetPosture) 
 // Unified industrial request / evaluation
 // ---------------------------------------------------------------------------
 
-use crate::adapters::ethernet_ip::{EtherNetIpAdapter, EtherNetIpMessage};
-use crate::adapters::canopen::{CanOpenAdapter, CanOpenMessage};
-use crate::adapters::dnp3::{Dnp3Adapter, Dnp3Message};
+use crate::adapters::ethernet_ip::EtherNetIpAdapter;
+use crate::adapters::canopen::CanOpenAdapter;
+use crate::adapters::dnp3::Dnp3Adapter;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct UnifiedIndustrialRequest {
@@ -197,82 +197,46 @@ pub fn evaluate_unified_industrial_request(
             })
         }
 
-        IndustrialProtocol::EthernetIp => {
-            let msg: EtherNetIpMessage = serde_json::from_value(req.message)
-                .map_err(|e| format!("MALFORMED_ETHERNET_IP_MESSAGE: {e}"))?;
-            let eval = EtherNetIpAdapter::evaluate(&msg);
-            let (allowed, denial_reason) = command_allowed_for_posture_pub(&eval.command, &posture);
-            Ok(UnifiedEvaluationResult {
-                protocol: "ethernet_ip".to_string(),
-                command: eval.command,
-                allowed,
-                denial_reason,
-                posture_at_evaluation: posture_str,
-                adapter_details: serde_json::json!({
-                    "service_name": eval.service_name,
-                    "is_write": eval.is_write,
-                    "target_description": eval.target_description,
-                    "safety_relevant": eval.safety_relevant,
-                }),
-                triggers_recalculation: false,
-            })
-        }
+        // The three binary-frame protocols share ONE generic dispatch: classify,
+        // posture-gate, then magnitude-bound (DNP3 enforces its g41 envelope; the
+        // others are posture-only pending per-target type config — see their
+        // `bound_magnitude`). `dispatch_adapter` formats its own posture string.
+        IndustrialProtocol::EthernetIp => dispatch_adapter::<EtherNetIpAdapter>(req.message, posture),
+        IndustrialProtocol::CanOpen => dispatch_adapter::<CanOpenAdapter>(req.message, posture),
+        IndustrialProtocol::Dnp3 => dispatch_adapter::<Dnp3Adapter>(req.message, posture),
+    }
+}
 
-        IndustrialProtocol::CanOpen => {
-            let msg: CanOpenMessage = serde_json::from_value(req.message)
-                .map_err(|e| format!("MALFORMED_CANOPEN_MESSAGE: {e}"))?;
-            let eval = CanOpenAdapter::evaluate(&msg);
-            let (allowed, denial_reason) = command_allowed_for_posture_pub(&eval.command, &posture);
-            Ok(UnifiedEvaluationResult {
-                protocol: "canopen".to_string(),
-                command: eval.command,
-                allowed,
-                denial_reason,
-                posture_at_evaluation: posture_str,
-                adapter_details: serde_json::json!({
-                    "message_type": format!("{:?}", eval.message_type),
-                    "node_id": eval.node_id,
-                    "is_emergency": eval.is_emergency,
-                    "emergency_code": eval.emergency_code,
-                }),
-                triggers_recalculation: eval.triggers_recalculation,
-            })
-        }
-
-        IndustrialProtocol::Dnp3 => {
-            let msg: Dnp3Message = serde_json::from_value(req.message)
-                .map_err(|e| format!("MALFORMED_DNP3_MESSAGE: {e}"))?;
-            let eval = Dnp3Adapter::evaluate(&msg);
-            let (mut allowed, mut denial_reason) = command_allowed_for_posture_pub(&eval.command, &posture);
-            // MAGNITUDE BOUND: a posture-admitted Analog Output (g41) control must
-            // also be within the configured envelope (fail-closed otherwise). Same
-            // bound the dedicated /industrial/dnp3/evaluate handler applies, so both
-            // DNP3 entry points enforce it identically.
-            if allowed {
-                if let Err(reason) = Dnp3Adapter::bound_analog_control(
-                    &msg,
-                    crate::adapters::dnp3::global_analog_envelope().as_ref(),
-                ) {
-                    allowed = false;
-                    denial_reason = Some(reason.to_string());
-                }
-            }
-            Ok(UnifiedEvaluationResult {
-                protocol: "dnp3".to_string(),
-                command: eval.command,
-                allowed,
-                denial_reason,
-                posture_at_evaluation: posture_str,
-                adapter_details: serde_json::json!({
-                    "function_name": eval.function_name,
-                    "is_control": eval.is_control,
-                    "is_broadcast": eval.is_broadcast,
-                    "critical_infrastructure_relevant": eval.critical_infrastructure_relevant,
-                }),
-                triggers_recalculation: false,
-            })
+/// Generic dispatch for every binary-frame industrial adapter (DNP3 / CANopen /
+/// EtherNet-IP). Deserialize the protocol message, classify it into a
+/// posture-gated command, then — only for a posture-ADMITTED command — apply the
+/// adapter's magnitude bound (fail-closed on a breach). Collapses three
+/// formerly-duplicated arms into one path and routes the magnitude bound
+/// uniformly through `IndustrialAdapter::bound_magnitude`.
+fn dispatch_adapter<A: crate::adapters::IndustrialAdapter>(
+    message: serde_json::Value,
+    posture: FleetPosture,
+) -> Result<UnifiedEvaluationResult, String> {
+    let msg: A::Message = serde_json::from_value(message)
+        .map_err(|e| format!("MALFORMED_{}_MESSAGE: {e}", A::PROTOCOL.to_uppercase()))?;
+    let verdict = A::verdict(&msg);
+    let (mut allowed, mut denial_reason) =
+        command_allowed_for_posture_pub(&verdict.command, &posture);
+    if allowed {
+        if let Err(reason) = A::bound_magnitude(&msg) {
+            allowed = false;
+            denial_reason = Some(reason.to_string());
         }
     }
+    Ok(UnifiedEvaluationResult {
+        protocol: A::PROTOCOL.to_string(),
+        command: verdict.command,
+        allowed,
+        denial_reason,
+        posture_at_evaluation: format!("{:?}", posture),
+        adapter_details: verdict.details,
+        triggers_recalculation: verdict.triggers_recalculation,
+    })
 }
 
 pub fn command_allowed_for_posture_pub(


### PR DESCRIPTION
Addresses the §13 industrial-adapter unification from the engineering review. Collapses the three near-identical arms of `evaluate_unified_industrial_request` (DNP3 / CANopen / EtherNet-IP) into one generic dispatch and gives the magnitude bound a single uniform seam.

## What changed

- **New `IndustrialAdapter` trait** (`src/adapters/mod.rs`): `type Message`, `const PROTOCOL`, `verdict(&msg) -> AdapterVerdict`, and `bound_magnitude(&msg)` (fail-closed default `Ok` = "no faithfully-decodable scalar in the frame").
- **DNP3 / CANopen / EtherNet-IP** each impl the trait, delegating to their existing inherent `evaluate` and folding their detail JSON into `AdapterVerdict.details` (better cohesion — the per-protocol JSON moves out of `protocol_adapter`).
- **`dispatch_adapter::<A>()`** replaces the three duplicated arms: deserialize → classify → posture-gate → (if admitted) magnitude-bound. The DNP3 g41 envelope bound now rides the uniform `bound_magnitude` hook — identical behavior, one code path instead of an inline special case. The match shrinks by ~76 LoC.

## Magnitude-bounding scope — an honest finding, not a fabrication

The review's §13 also asked for **CANopen/CIP magnitude bounding**. On close inspection that can't be done faithfully from the wire frame, and the codebase's central #85 invariant ("faithfully decode or refuse, **never fabricate** a magnitude") forbids faking it:

| Protocol | Value **type** in the frame? | Boundable from frame alone? |
|---|---|---|
| **DNP3 group-41** | ✅ yes — IEEE 1815 puts it in the *variation* byte (i16/i32/f32/f64) | ✅ **bounded today** |
| CANopen SDO | ⚠️ width only (command byte) — not type/signedness/scaling | ❌ needs object-dictionary config |
| CANopen PDO | ❌ raw process data | ❌ needs PDO-mapping config |
| EtherNet-IP CIP | ❌ data type is in the target attribute's device model | ❌ needs CIP-attribute config |

So CANopen and EtherNet-IP keep the **fail-closed posture-only default** with a documented reason in their `bound_magnitude`. Faithful CANopen/CIP bounding needs a **per-target type+envelope config framework** (object-dictionary type map for CANopen, CIP-attribute type map for EtherNet-IP) — a tracked follow-up, deliberately not rushed into this PR. This PR puts the uniform seam in place so that framework plugs into one hook.

## Testing

Behavior unchanged — all **564 lib tests** (including the existing DNP3-magnitude and per-protocol evaluation tests) pass through the new dispatch; +2 tests lock in the trait seam (DNP3 verdict + read no-op bound; CIP write posture-only). Root clippy (CI flags) clean; workspace **78/78** + parko ok; warning-free including test targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_