### PR TITLE
perf(governor): &'static MitigationCode — zero-alloc scalar-governor verdict (§8)

### DIFF
--- a/src/action_filter.rs
+++ b/src/action_filter.rs
@@ -39,7 +39,7 @@ impl<C: SafetyContract> ActionFilter<C> {
                 FilterOutput {
                     resolution,
                     sanitized_action: AgentAction::MoveLinear { velocity: intercept.sanitized_scalar },
-                    narrative: intercept.mitigation_narrative.into_owned(),
+                    narrative: intercept.mitigation.to_string(),
                 }
             }
             AgentAction::Rotate { angular_velocity } => {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -268,7 +268,7 @@ impl KirraLiveGateway {
                                     state: system_state_enum,
                                     mode: gov.trust_mode(),
                                     score: gov.trust_engine.current_score,
-                                    narrative: intercept.mitigation_narrative.to_string(),
+                                    narrative: intercept.mitigation.to_string(),
                                 });
                                 flush_payload = Some(rec.clone());
                             }

--- a/src/kirra_core.rs
+++ b/src/kirra_core.rs
@@ -1,6 +1,6 @@
 // src/kirra_core.rs
 
-use crate::{SafetyContract, SafetyGovernor, GovernorInterceptResult, TrustMode};
+use crate::{SafetyContract, SafetyGovernor, GovernorInterceptResult, MitigationCode, TrustMode};
 use crate::security::constant_time_compare;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
@@ -158,7 +158,7 @@ impl<C: SafetyContract> SafetyGovernor for KirraKernelGovernor<C> {
             return GovernorInterceptResult {
                 sanitized_scalar: self.contract.fallback(),
                 asset_in_safe_control_state: false,
-                mitigation_narrative: std::borrow::Cow::Borrowed("NONFINITE_INPUT_REJECTED_FAILSAFE"),
+                mitigation: MitigationCode::NonfiniteInputRejectedFailsafe,
                 was_unsafe_attempt: true,
                 was_rate_breached: false,
             };
@@ -175,7 +175,7 @@ impl<C: SafetyContract> SafetyGovernor for KirraKernelGovernor<C> {
             return GovernorInterceptResult {
                 sanitized_scalar: self.contract.fallback(),
                 asset_in_safe_control_state: false,
-                mitigation_narrative: std::borrow::Cow::Borrowed("INVALID_TIME_DELTA_REJECTED_FAILSAFE"),
+                mitigation: MitigationCode::InvalidTimeDeltaRejectedFailsafe,
                 was_unsafe_attempt: true,
                 was_rate_breached: false,
             };
@@ -211,11 +211,10 @@ impl<C: SafetyContract> SafetyGovernor for KirraKernelGovernor<C> {
 
         let core_bounded_demand = proposed_demand.clamp(self.contract.min_bound(), self.contract.max_bound());
 
-        use std::borrow::Cow;
-        let (sanitized_scalar, narrative): (f64, Cow<'static, str>) = match active_action {
+        let (sanitized_scalar, mitigation): (f64, MitigationCode) = match active_action {
             BehavioralAction::ExecuteUnrestricted => {
                 if is_out_of_envelope {
-                    (core_bounded_demand, Cow::Borrowed("ENVELOPE_CLAMP_TAKES_PRIORITY"))
+                    (core_bounded_demand, MitigationCode::EnvelopeClampTakesPriority)
                 } else if is_rate_breached {
                     let step_direction = (proposed_demand - self.last_validated_scalar).signum();
                     // Gov-M1 (invariant #8 — envelope ALWAYS wins over rate): re-clamp
@@ -228,20 +227,20 @@ impl<C: SafetyContract> SafetyGovernor for KirraKernelGovernor<C> {
                     let rate_clamped_value = (self.last_validated_scalar
                         + (self.contract.max_rate() * dt * step_direction))
                         .clamp(self.contract.min_bound(), self.contract.max_bound());
-                    (rate_clamped_value, Cow::Owned(format!("RATE_CLAMP_ENFORCED: Max {} GPM/s", self.contract.max_rate())))
+                    (rate_clamped_value, MitigationCode::RateClampEnforced { max_rate: self.contract.max_rate() })
                 } else {
-                    (proposed_demand, Cow::Borrowed("PASSTHROUGH_UNRESTRICTED_NORMAL"))
+                    (proposed_demand, MitigationCode::PassthroughUnrestrictedNormal)
                 }
             }
             BehavioralAction::ApplyVelocityCap => {
                 let clamped_value = core_bounded_demand.clamp(self.constraint_cap_min, self.constraint_cap_max);
-                (clamped_value, Cow::Owned(format!("DEGRADED_POSTURE_CLAMP: Bounded inside [{} - {}]", self.constraint_cap_min, self.constraint_cap_max)))
+                (clamped_value, MitigationCode::DegradedPostureClamp { cap_min: self.constraint_cap_min, cap_max: self.constraint_cap_max })
             }
             BehavioralAction::ForceStationaryHold => {
-                (self.last_validated_scalar, Cow::Owned(format!("SHADOW_MODE_HOLD_ENFORCED: Fixed value retained: {:.1}", self.last_validated_scalar)))
+                (self.last_validated_scalar, MitigationCode::ShadowModeHoldEnforced { retained: self.last_validated_scalar })
             }
             BehavioralAction::ExecutePassiveFailsafeLock => {
-                (self.contract.fallback(), Cow::Borrowed("CRITICAL_LOCKOUT: Active fallback state commanded"))
+                (self.contract.fallback(), MitigationCode::CriticalLockoutFallback)
             }
         };
 
@@ -263,7 +262,7 @@ impl<C: SafetyContract> SafetyGovernor for KirraKernelGovernor<C> {
         GovernorInterceptResult {
             sanitized_scalar,
             asset_in_safe_control_state,
-            mitigation_narrative: narrative,
+            mitigation,
             was_unsafe_attempt: is_out_of_envelope || self.continuous_rate_breach_ticks > 5,
             was_rate_breached: is_rate_breached,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,17 +79,126 @@ pub enum TrustMode {
     LockedOut,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GovernorInterceptResult {
     pub sanitized_scalar: f64,
     pub asset_in_safe_control_state: bool,
-    /// `Cow` so the common/failsafe branches carry a `&'static str` discriminant
-    /// with ZERO allocation (the FFI scalar path discards this every tick), while
-    /// the off-nominal clamp branches still embed their numeric detail via an owned
-    /// `format!` — preserving the exact audit-narrative content.
-    pub mitigation_narrative: std::borrow::Cow<'static, str>,
+    /// Structured, `Copy` mitigation code (§8). Replaces the prior per-tick
+    /// `Cow<'static, str>` narrative: EVERY branch — including the three
+    /// off-nominal clamps that used to `format!` a `String` on each `evaluate`
+    /// — now carries only a tag + the numeric detail as `f64` fields, so the
+    /// governor's hot scalar/FFI path (which discards the narrative every tick)
+    /// is ZERO-ALLOC for all verdicts. The human/audit string is formatted
+    /// LAZILY at the record/log sink via `Display`.
+    pub mitigation: MitigationCode,
     pub was_unsafe_attempt: bool,
     pub was_rate_breached: bool,
+}
+
+/// The reason a governor verdict mitigated (clamped / held / failsafed) a
+/// proposed scalar. `Copy + 'static` — carries no heap allocation on the hot
+/// per-tick path. `Display` reproduces the exact prior narrative string for the
+/// audit/log sink, formatting any numeric detail lazily only when recorded.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MitigationCode {
+    /// Non-finite (`NaN`/`Inf`) input rejected; fallback commanded.
+    NonfiniteInputRejectedFailsafe,
+    /// Non-positive timestep rejected; fallback commanded.
+    InvalidTimeDeltaRejectedFailsafe,
+    /// Out-of-envelope demand clamped to the hard bound (envelope wins, INV-8).
+    EnvelopeClampTakesPriority,
+    /// Rate-of-change clamped to the contract maximum.
+    RateClampEnforced { max_rate: f64 },
+    /// In-envelope, in-rate demand passed through unchanged.
+    PassthroughUnrestrictedNormal,
+    /// Degraded posture: demand bounded inside the reduced operating cap.
+    DegradedPostureClamp { cap_min: f64, cap_max: f64 },
+    /// Shadow mode: the last validated scalar is held (no new motion authored).
+    ShadowModeHoldEnforced { retained: f64 },
+    /// LockedOut: the contract fallback state is commanded.
+    CriticalLockoutFallback,
+}
+
+impl std::fmt::Display for MitigationCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MitigationCode::NonfiniteInputRejectedFailsafe => {
+                f.write_str("NONFINITE_INPUT_REJECTED_FAILSAFE")
+            }
+            MitigationCode::InvalidTimeDeltaRejectedFailsafe => {
+                f.write_str("INVALID_TIME_DELTA_REJECTED_FAILSAFE")
+            }
+            MitigationCode::EnvelopeClampTakesPriority => f.write_str("ENVELOPE_CLAMP_TAKES_PRIORITY"),
+            MitigationCode::RateClampEnforced { max_rate } => {
+                write!(f, "RATE_CLAMP_ENFORCED: Max {max_rate} GPM/s")
+            }
+            MitigationCode::PassthroughUnrestrictedNormal => {
+                f.write_str("PASSTHROUGH_UNRESTRICTED_NORMAL")
+            }
+            MitigationCode::DegradedPostureClamp { cap_min, cap_max } => {
+                write!(f, "DEGRADED_POSTURE_CLAMP: Bounded inside [{cap_min} - {cap_max}]")
+            }
+            MitigationCode::ShadowModeHoldEnforced { retained } => {
+                write!(f, "SHADOW_MODE_HOLD_ENFORCED: Fixed value retained: {retained:.1}")
+            }
+            MitigationCode::CriticalLockoutFallback => {
+                f.write_str("CRITICAL_LOCKOUT: Active fallback state commanded")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod mitigation_code_tests {
+    use super::MitigationCode;
+
+    /// `Display` must reproduce the EXACT prior narrative strings — these are
+    /// recorded into the audit/governor-verdict narrative, so a change here is a
+    /// content change. Numeric detail formats lazily (and only when recorded).
+    #[test]
+    fn display_reproduces_the_exact_prior_narratives() {
+        assert_eq!(
+            MitigationCode::NonfiniteInputRejectedFailsafe.to_string(),
+            "NONFINITE_INPUT_REJECTED_FAILSAFE"
+        );
+        assert_eq!(
+            MitigationCode::InvalidTimeDeltaRejectedFailsafe.to_string(),
+            "INVALID_TIME_DELTA_REJECTED_FAILSAFE"
+        );
+        assert_eq!(
+            MitigationCode::EnvelopeClampTakesPriority.to_string(),
+            "ENVELOPE_CLAMP_TAKES_PRIORITY"
+        );
+        assert_eq!(
+            MitigationCode::RateClampEnforced { max_rate: 1.5 }.to_string(),
+            "RATE_CLAMP_ENFORCED: Max 1.5 GPM/s"
+        );
+        assert_eq!(
+            MitigationCode::PassthroughUnrestrictedNormal.to_string(),
+            "PASSTHROUGH_UNRESTRICTED_NORMAL"
+        );
+        assert_eq!(
+            MitigationCode::DegradedPostureClamp { cap_min: 0.0, cap_max: 5.0 }.to_string(),
+            "DEGRADED_POSTURE_CLAMP: Bounded inside [0 - 5]"
+        );
+        assert_eq!(
+            MitigationCode::ShadowModeHoldEnforced { retained: 2.0 }.to_string(),
+            "SHADOW_MODE_HOLD_ENFORCED: Fixed value retained: 2.0"
+        );
+        assert_eq!(
+            MitigationCode::CriticalLockoutFallback.to_string(),
+            "CRITICAL_LOCKOUT: Active fallback state commanded"
+        );
+    }
+
+    #[test]
+    fn mitigation_code_is_copy_and_zero_alloc_on_the_hot_path() {
+        // A trivially-copyable tag: the governor's per-tick result carries this by
+        // value with no heap allocation (the whole point of §8).
+        let c = MitigationCode::RateClampEnforced { max_rate: 3.25 };
+        let copied = c; // Copy, not move
+        assert_eq!(c, copied);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
Finishes the §8 allocation cleanup that #576's `Cow` nominal-path change started.

## The remaining per-tick allocations

The scalar governor's three off-nominal branches (`RATE_CLAMP`, `DEGRADED_CLAMP`, `SHADOW_HOLD`) still `format!`'d a `String` on **every** `evaluate` — even though the FFI scalar path (20 Hz+) discards the narrative each tick.

## Fix

Replace `GovernorInterceptResult.mitigation_narrative: Cow<'static, str>` with a `Copy` **`MitigationCode`** enum (the `DenyCode` pattern): each variant carries a `&'static` tag plus its numeric detail as `f64` fields, so the result is built with **zero heap allocation on every branch** — the whole `GovernorInterceptResult` is now `Copy`. The human/audit string is formatted **lazily** via `Display`, only at the two record/log sinks (`gateway::mod`, `action_filter`), reproducing the prior narratives byte-for-byte.

- `MitigationCode` + `Display` matching the exact prior strings, including lazy numeric detail (`Max {max_rate} GPM/s`, `[{cap_min} - {cap_max}]`, `{retained:.1}`).
- `KirraKernelGovernor::evaluate` returns the code; the `format!`/`Cow::Owned` allocations are gone from the per-tick path.
- The two consumers format at their sink (`.mitigation.to_string()`).

## Testing

A test asserts `Display` reproduces **all eight** prior narratives verbatim (audit content must not drift) and that the code is `Copy`. The existing governor / action-filter / gateway tests pass unchanged (they consume the narrative *string*, which is identical).

Root clippy (CI flags) clean — including no `clone_on_copy` now that the result is `Copy`; workspace **78/78** + parko ok; **578** lib tests ok; warning-free including tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_