### PR TITLE
fix(ros2-adapter): monotonic freshness clock — a wall-clock step can't trip fleet-wide MRC (B4)

### DIFF
--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -110,12 +110,15 @@ fn wall_clock_ms() -> u64 {
         .unwrap_or(0)
 }
 
-/// Same as `wall_clock_ms` but with a name that's less likely to collide
-/// inside a closure body that already has a `wall_clock_ms` shadow. The
-/// stamping tasks call this on every received message; it's hot enough
-/// that the call is inlined.
+/// MONOTONIC freshness clock (B4) — the staleness / age clock for the adapter's
+/// subscription stamps, `AcceptedTrajectory::promoted_at_ms`, and the slow/fast
+/// loop freshness comparisons. Delegates to the shared `state::monotonic_now_ms`
+/// so EVERY freshness timestamp in the adapter shares ONE non-decreasing epoch;
+/// a forward wall-clock / NTP step can no longer inflate an age and spuriously
+/// trip staleness → fleet-wide MRC. Wall time (`wall_clock_ms`) is reserved for
+/// audit/correlation record timestamps ONLY. Hot path — inlined.
 #[inline]
-fn now_ms_wall() -> u64 { wall_clock_ms() }
+fn now_ms_fresh() -> u64 { crate::state::monotonic_now_ms() }
 
 /// Trajectory ingress payload. The subscription callback (Phase 2B —
 /// when Lanelet2 wiring lands) deserializes
@@ -288,7 +291,7 @@ pub async fn run_adapter(
         let mut s = traj_stream;
         let mut traj_seq: u64 = 0;
         while let Some(msg) = s.next().await {
-            let now = now_ms_wall();
+            let now = now_ms_fresh();
             // Phase I observability (integration-harness §I.1a): a per-callback
             // entry event PROVES delivery (vs staleness) for the A-vs-B split.
             tracing::info!(
@@ -334,7 +337,7 @@ pub async fn run_adapter(
     tokio::spawn(async move {
         let mut s = obj_stream;
         while let Some(msg) = s.next().await {
-            let now = now_ms_wall();
+            let now = now_ms_fresh();
             tracing::info!(
                 target: "kirra::ingress",
                 topic = "objects",
@@ -358,7 +361,7 @@ pub async fn run_adapter(
         tokio::spawn(async move {
             let mut s = obj_b_stream;
             while let Some(msg) = s.next().await {
-                let now = now_ms_wall();
+                let now = now_ms_fresh();
                 tracing::info!(
                     target: "kirra::ingress",
                     topic = "objects_secondary",
@@ -376,7 +379,7 @@ pub async fn run_adapter(
     tokio::spawn(async move {
         let mut s = odom_stream;
         while let Some(msg) = s.next().await {
-            let now = now_ms_wall();
+            let now = now_ms_fresh();
             tracing::info!(
                 target: "kirra::ingress",
                 topic = "odometry",
@@ -453,20 +456,20 @@ pub async fn run_adapter(
             // the cap ages with the object stream and `resolve_perception_cap`
             // fails closed (state-3 MRC) when objects go silent. If objects are
             // stale/never-seen, sweep an MRC-floor cap proactively.
-            let now_wall = now_ms_wall();
+            let now_mono = now_ms_fresh();
             let objects_ms =
                 slow_state.last_objects_ms.load(std::sync::atomic::Ordering::Relaxed);
             let objects_fresh = objects_ms != 0
-                && now_wall.saturating_sub(objects_ms) <= subscription_staleness_timeout_ms();
+                && now_mono.saturating_sub(objects_ms) <= subscription_staleness_timeout_ms();
             if objects_fresh {
                 publish_perception_tick(&perception_publisher, &objects, objects_ms);
             } else {
-                perception_publisher.sweep_staleness(now_wall);
+                perception_publisher.sweep_staleness(now_mono);
             }
             let effective_perception_cap = resolve_perception_cap(
                 perception_derate_enabled(),
                 &perception_cache,
-                now_wall,
+                now_mono,
             );
 
             // Perception-divergence assurance monitor (True-Redundancy analog, gap #2b) — now
@@ -480,7 +483,7 @@ pub async fn run_adapter(
             let objects_b_ms =
                 slow_state.last_objects_b_ms.load(std::sync::atomic::Ordering::Relaxed);
             let objects_b_fresh = objects_b_ms != 0
-                && now_wall.saturating_sub(objects_b_ms) <= subscription_staleness_timeout_ms();
+                && now_mono.saturating_sub(objects_b_ms) <= subscription_staleness_timeout_ms();
             let redundancy_cap = resolve_redundancy_cap(
                 perception_redundancy_enabled(),
                 &objects,
@@ -498,8 +501,8 @@ pub async fn run_adapter(
             // then LockedOut — so the whole stack degrades, not just this tick's speed. A
             // momentary blip leaves posture unchanged (the cap handled it); escalation-only, so
             // it can never relax the verifier-sourced base posture.
-            divergence_escalator.observe(redundancy_cap == Some(0.0), now_wall);
-            let posture = posture.escalate(divergence_escalator.recommended_posture(now_wall));
+            divergence_escalator.observe(redundancy_cap == Some(0.0), now_mono);
+            let posture = posture.escalate(divergence_escalator.recommended_posture(now_mono));
 
             // Multi-modal predictive RSS (gap #3) — roll the live objects into PredictedMode
             // hypotheses for the checker's predictive pass. The tracker's per-object yaw estimate
@@ -511,7 +514,7 @@ pub async fn run_adapter(
             let object_yaw_ms =
                 slow_state.last_object_yaw_ms.load(std::sync::atomic::Ordering::Relaxed);
             let object_yaw_fresh = object_yaw_ms != 0
-                && now_wall.saturating_sub(object_yaw_ms) <= subscription_staleness_timeout_ms();
+                && now_mono.saturating_sub(object_yaw_ms) <= subscription_staleness_timeout_ms();
             let predicted_owned = slow_loop_modes(
                 &objects,
                 &object_yaw_rates,
@@ -544,18 +547,20 @@ pub async fn run_adapter(
                 // prior behaviour); once a source reports, the gate is live (a poor / non-finite
                 // ε derates the 0.40 m → 0.75 m margin or refuses, a silent source fails closed),
                 // and a sustained fault also escalates fleet posture → LockedOut (S-FI1d).
-                slow_state.snapshot_frame_trust(now_wall),
+                slow_state.snapshot_frame_trust(now_mono),
             );
-            let now_ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0);
+            // B4: the trajectory's `promoted_at_ms` (the fast loop's `is_stale`
+            // anchor) uses the MONOTONIC freshness clock — the SAME `now_mono` the
+            // slow-loop freshness checks use and the same clock the fast loop's
+            // staleness reads — so a forward wall-clock step can never make a fresh
+            // trajectory look stale. (The capture record below keeps a separate
+            // wall timestamp for human/audit correlation.)
             slow_state.update_trajectory(
                 traj.asset_id.clone(),
                 traj.trajectory_id,
                 traj.points.clone(),
                 verdict,
-                now_ms,
+                now_mono,
             );
             let elapsed_us = start.elapsed().as_micros();
             // Phase I observability (integration-harness §I.1b): carry posture +
@@ -563,7 +568,7 @@ pub async fn run_adapter(
             // stale inputs (Branch B) is distinguishable from non-delivery
             // (Branch A) directly from the logs. A never-seen slot (last_*_ms == 0)
             // reports u64::MAX rather than a misleadingly-huge "age since epoch".
-            let now_fresh = now_ms_wall();
+            let now_fresh = now_ms_fresh();
             let age_of =
                 |t: u64| if t == 0 { u64::MAX } else { now_fresh.saturating_sub(t) };
             let traj_age_ms =
@@ -623,7 +628,9 @@ pub async fn run_adapter(
                 };
                 let rec = record_from_trajectory_verdict(
                     capture_seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
-                    now_ms,
+                    // Audit/correlation timestamp — wall-clock (human-readable),
+                    // NOT the staleness clock. Computed only when capture is on.
+                    wall_clock_ms(),
                     decision,
                     posture,
                     ext,
@@ -668,7 +675,10 @@ pub async fn run_adapter(
         let mut rx = control_rx;
         while let Some(in_cmd) = rx.recv().await {
             let start = std::time::Instant::now();
-            let now_ms = wall_clock_ms();
+            // B4: freshness clock is MONOTONIC — must match the subscription
+            // stamps + `promoted_at_ms` so `any_subscription_stale` / `is_stale`
+            // measure a true elapsed age, immune to a wall-clock step.
+            let now_ms = now_ms_fresh();
             let cmd = IncomingControl {
                 velocity_mps: in_cmd.linear_velocity_mps,
                 steering_rad: in_cmd.steering_angle_rad,

--- a/crates/kirra-ros2-adapter/src/state.rs
+++ b/crates/kirra-ros2-adapter/src/state.rs
@@ -278,12 +278,20 @@ pub struct AdaptorState {
     pub last_frame_integrity_ms: Arc<AtomicU64>,
 }
 
+/// Process-monotonic millisecond clock for ALL freshness / staleness / window
+/// math in the adapter (subscription stamps, `AcceptedTrajectory::promoted_at_ms`,
+/// PostureTracker windows). Anchored at first use; only DIFFERENCES are
+/// meaningful — which is all freshness needs (`now - stamp`). Unlike `SystemTime`
+/// (wall-clock), a forward NTP / clock STEP cannot inflate an age and spuriously
+/// trip staleness → fleet-wide MRC (review B4): `Instant` is guaranteed
+/// non-decreasing. Wall-clock time is reserved for audit/correlation record
+/// timestamps only (AOU-TIMESYNC-001), NEVER for staleness.
 #[inline]
-fn now_ms_wall() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
+pub fn monotonic_now_ms() -> u64 {
+    use std::sync::OnceLock;
+    use std::time::Instant;
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    EPOCH.get_or_init(Instant::now).elapsed().as_millis() as u64
 }
 
 impl AdaptorState {
@@ -370,7 +378,7 @@ impl AdaptorState {
     /// the guard so subsequent reads return the new value rather than
     /// inheriting the poison.
     pub fn update_posture(&self, posture: FleetPosture) {
-        let now = now_ms_wall();
+        let now = monotonic_now_ms();
         match self.posture_tracker.write() {
             Ok(mut guard) => guard.observe(now, posture),
             Err(poisoned) => poisoned.into_inner().observe(now, posture),
@@ -378,11 +386,12 @@ impl AdaptorState {
     }
 
     /// Reads the effective fleet posture from the tracker at the current
-    /// wall-clock instant. Fail-closed: a poisoned lock returns
+    /// MONOTONIC instant (B4: the tracker's event-aging windows must not be
+    /// inflated by a wall-clock step). Fail-closed: a poisoned lock returns
     /// `Degraded` rather than `Nominal` so a panic in the writer can
     /// never widen the envelope.
     pub fn current_posture(&self) -> FleetPosture {
-        let now = now_ms_wall();
+        let now = monotonic_now_ms();
         match self.posture_tracker.read() {
             Ok(guard) => guard.current_posture(now),
             // Defensive — if the lock is poisoned and we can't read it,
@@ -639,6 +648,27 @@ impl AdaptorState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn monotonic_now_ms_never_decreases() {
+        // The freshness clock must be non-decreasing across calls (B4): an age
+        // `now - stamp` can then never go NEGATIVE-then-saturate or inflate from a
+        // wall-clock step. `Instant` guarantees monotonicity; this pins it.
+        let a = monotonic_now_ms();
+        let b = monotonic_now_ms();
+        let c = monotonic_now_ms();
+        assert!(b >= a, "monotonic clock went backwards: {b} < {a}");
+        assert!(c >= b, "monotonic clock went backwards: {c} < {b}");
+    }
+
+    #[test]
+    fn monotonic_age_is_bounded_and_non_inflating() {
+        // A stamp taken now, checked an instant later, yields a small age — never
+        // a huge "age since wall epoch". This is the property staleness relies on.
+        let stamp = monotonic_now_ms();
+        let age = monotonic_now_ms().saturating_sub(stamp);
+        assert!(age < 60_000, "an immediate re-check must not look stale (age={age}ms)");
+    }
 
     fn pt(x: f64, y: f64, v: f64, t: f64) -> TrajectoryPoint {
         TrajectoryPoint {


### PR DESCRIPTION
Closes review finding **B4**.

## The bug

The slow/fast loops stamped subscription receipts and `promoted_at_ms` and compared their ages with `SystemTime::now()` (wall-clock). `saturating_sub` made a *backward* step safe, but a forward **NTP / wall-clock step inflates every age at once** → staleness trips → **fleet-wide MRC**, even though nothing actually went stale. A clock correction shouldn't safe-stop the fleet.

## The fix — one monotonic clock for all freshness; wall-clock only for audit

- **`state::monotonic_now_ms()`** — process-monotonic milliseconds from one `OnceLock<Instant>` epoch shared adapter-wide. Only *differences* matter (which is all freshness needs: `now - stamp`), and `Instant` is guaranteed non-decreasing, so an age can never inflate from a clock step. Non-gated → unit-tested.
- **`state.rs`** — `update_posture` / `current_posture` (the PostureTracker event-aging windows) now use it.
- **`node.rs`** (ros2-gated) — the freshness helper `now_ms_fresh()` delegates to it, so **every** subscription stamp + the slow-loop `now_mono` + the fast-loop staleness `now_ms` share **one non-decreasing epoch**. `update_trajectory`'s `promoted_at_ms` (the fast loop's `is_stale` anchor) is monotonic too — so stamps, comparisons, *and* the promote anchor are all on the same clock (a half-fix would mismatch clocks and be worse). Wall-clock survives **only** at the learning-capture record (human/audit correlation), computed lazily.

`AOU-TIMESYNC-001`: staleness is now clock-step-immune; integrator wall timestamps remain for correlation records only.

## Verification & a caveat

- **`state.rs` is non-gated** — 2 new monotonic tests (`never_decreases`, `age_is_bounded_and_non_inflating`) + the existing adapter suite pass; workspace **78/78** ok; adapter clippy (CI flags) clean; warning-free.
- **`node.rs` is `--features ros2`-gated** (needs the `r2r` ROS 2 toolchain), so it does **not** compile in the default build or locally here — it's verified by CI's **"ros2 adapter build (--features ros2)"** job. I reviewed the clock-variable consistency by hand (every freshness site routes through the single monotonic helper; `wall_clock_ms` survives only at the capture record). Please let the ros2 CI job confirm the gated compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_