### PR TITLE
fix(ros2-adapter): tighten predictive-RSS time-match (A1) + reject implausible CTRV yaw (A2)

### DIFF
--- a/crates/kirra-ros2-adapter/src/prediction.rs
+++ b/crates/kirra-ros2-adapter/src/prediction.rs
@@ -29,6 +29,14 @@ use crate::validation::{PredictedMode, PredictedSample};
 /// duplicate the CV hypothesis and the worst-case is unchanged).
 pub const CTRV_YAW_EPS_RAD_S: f64 = 0.02;
 
+/// Plausibility ceiling on a turning object's lateral acceleration (m/s² ≈ 1 g). A CTRV
+/// hypothesis implies a lateral accel of `speed·|yaw|` (= v²/R); a value beyond this is
+/// PHYSICALLY IMPOSSIBLE for a road vehicle (tyre grip ≈ 1 g), so such a yaw is tracker NOISE,
+/// not a real turn. Emitting its (sharp-curve) CTRV mode would only manufacture a spurious
+/// breach → spurious MRC, so the yaw is rejected and the object degrades to CV-only. A genuine
+/// sharp turn happens at LOW speed (small `speed·yaw`) and is never rejected.
+pub const CTRV_MAX_LATERAL_ACCEL_MPS2: f64 = 10.0;
+
 /// An owned predicted mode (owns its samples, unlike the borrowed [`PredictedMode`] the checker
 /// consumes). Build the borrowed view with [`as_mode`](Self::as_mode) at the call site.
 #[derive(Debug, Clone)]
@@ -148,7 +156,15 @@ pub fn predicted_modes_from_objects(
     for obj in objects {
         modes.push(OwnedPredictedMode { object_id: obj.id, samples: cv_samples(obj, horizon_s, dt) });
         if let Some(&(_, yaw)) = yaw_rates.iter().find(|(id, _)| *id == obj.id) {
-            if yaw.abs() > CTRV_YAW_EPS_RAD_S {
+            // A distinct CTRV mode only when the yaw is BOTH non-negligible AND
+            // CONSISTENT with the object's speed: `speed·|yaw|` (the implied
+            // lateral accel) within a physical cornering ceiling. A yaw beyond it
+            // is tracker noise — its sharp-curve CTRV would manufacture a spurious
+            // breach — so the object degrades to CV-only (A2).
+            let implied_lateral_accel = obj.velocity_mps * yaw.abs();
+            if yaw.abs() > CTRV_YAW_EPS_RAD_S
+                && implied_lateral_accel <= CTRV_MAX_LATERAL_ACCEL_MPS2
+            {
                 modes.push(OwnedPredictedMode { object_id: obj.id, samples: ctrv_samples(obj, yaw, horizon_s, dt) });
             }
         }
@@ -225,6 +241,23 @@ mod tests {
         let o = obj(1, 10.0, 0.0, 3.0, 0.0);
         let modes = predicted_modes_from_objects(&[o], &[(1, 0.005)], &[], 2.0, 0.5);
         assert_eq!(modes.len(), 1, "sub-epsilon yaw → no duplicate CTRV mode");
+    }
+
+    #[test]
+    fn an_implausible_yaw_for_the_speed_is_rejected_as_noise() {
+        // 20 m/s with a 1.0 rad/s turn → implied lateral accel 20 m/s² (>1 g):
+        // physically impossible for a road vehicle, so the yaw is tracker noise
+        // and its CTRV mode is NOT emitted (CV-only) — no spurious sharp-curve
+        // breach (A2).
+        let fast = obj(1, 10.0, 0.0, 20.0, 0.0);
+        let modes = predicted_modes_from_objects(&[fast], &[(1, 1.0)], &[], 2.0, 0.5);
+        assert_eq!(modes.len(), 1, "implausible speed·yaw → CV-only, CTRV rejected");
+
+        // The SAME turn rate at a LOW speed (2 m/s → 2 m/s² lateral) is a genuine
+        // tight turn and IS emitted — the check filters noise, not real maneuvers.
+        let slow = obj(2, 10.0, 0.0, 2.0, 0.0);
+        let modes = predicted_modes_from_objects(&[slow], &[(2, 1.0)], &[], 2.0, 0.5);
+        assert_eq!(modes.len(), 2, "plausible low-speed sharp turn → CV + CTRV");
     }
 
     #[test]

--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -530,11 +530,31 @@ fn outruns_assured_clear_distance(
     false
 }
 
-/// The trajectory pose closest in TIME to `t` (the ego's where-am-I-when index).
-fn nearest_in_time(trajectory: &[TrajectoryPoint], t: f64) -> Option<&TrajectoryPoint> {
-    trajectory
+/// Max time gap (s) between a predicted object sample and the ego pose it is
+/// matched to. Beyond this, the ego's planned trajectory does not actually cover
+/// that time (it is shorter than the prediction horizon, or the sample is past
+/// the last pose), so the "time-matched ego pose" would be a near pose standing
+/// in for a far-future object — a meaningless comparison. One predicted step.
+const PREDICTIVE_TIME_MATCH_TOLERANCE_S: f64 = 0.5;
+
+/// The trajectory pose closest in TIME to `t` (the ego's where-am-I-when index),
+/// but ONLY if that pose is within `tolerance_s` of `t`. Returns `None` when the
+/// nearest pose is further away — i.e. the ego trajectory does not span time `t`
+/// — so the caller skips the sample instead of matching a far-future object to a
+/// near ego pose (the snapshot RSS still bounds the real object).
+fn nearest_in_time(
+    trajectory: &[TrajectoryPoint],
+    t: f64,
+    tolerance_s: f64,
+) -> Option<&TrajectoryPoint> {
+    let nearest = trajectory
         .iter()
-        .min_by(|a, b| (a.time_from_start_s - t).abs().total_cmp(&(b.time_from_start_s - t).abs()))
+        .min_by(|a, b| (a.time_from_start_s - t).abs().total_cmp(&(b.time_from_start_s - t).abs()))?;
+    if (nearest.time_from_start_s - t).abs() <= tolerance_s {
+        Some(nearest)
+    } else {
+        None
+    }
 }
 
 /// True if any predicted mode brings an object into an RSS shortfall with the
@@ -571,7 +591,11 @@ fn predictive_rss_breach(
             let ovx = (b.pos.x_m - a.pos.x_m) / dt;
             let ovy = (b.pos.y_m - a.pos.y_m) / dt;
 
-            let Some(ego) = nearest_in_time(trajectory, a.time_from_start_s) else { continue };
+            let Some(ego) =
+                nearest_in_time(trajectory, a.time_from_start_s, PREDICTIVE_TIME_MATCH_TOLERANCE_S)
+            else {
+                continue; // no ego pose within tolerance at this time — unevaluable
+            };
             let dx = a.pos.x_m - ego.pose.x_m;
             let dy = a.pos.y_m - ego.pose.y_m;
             let cos_h = ego.pose.heading_rad.cos();
@@ -889,6 +913,37 @@ mod conversion_tests {
         let cmd = pose_pair_to_command(&a, &b, &cfg, 0.0);
         assert!(cmd.steering_angle_deg > 4.0 && cmd.steering_angle_deg < 7.0,
             "expected ~5.6° steering, got {}", cmd.steering_angle_deg);
+    }
+
+    #[test]
+    fn nearest_in_time_rejects_a_time_beyond_the_trajectory_span() {
+        // A trajectory spanning [0.0, 1.0] s.
+        let traj: Vec<TrajectoryPoint> = (0..=10)
+            .map(|i| TrajectoryPoint {
+                pose: AdapterPose { x_m: i as f64, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: 10.0,
+                time_from_start_s: i as f64 * 0.1,
+            })
+            .collect();
+
+        // A time WITHIN the span matches the closest pose.
+        let m = nearest_in_time(&traj, 0.55, PREDICTIVE_TIME_MATCH_TOLERANCE_S)
+            .expect("an in-span time matches");
+        assert!((m.time_from_start_s - 0.5).abs() < 1e-9 || (m.time_from_start_s - 0.6).abs() < 1e-9);
+
+        // A time just past the last pose, but within tolerance, still matches it.
+        assert!(
+            nearest_in_time(&traj, 1.4, PREDICTIVE_TIME_MATCH_TOLERANCE_S).is_some(),
+            "t=1.4 is within 0.5 s of the last pose (1.0) → matched"
+        );
+
+        // A FAR-future time (a predicted object beyond the ego's planned horizon)
+        // has NO ego pose within tolerance → None, so the predictive pass skips it
+        // rather than matching it to the near last pose (A1).
+        assert!(
+            nearest_in_time(&traj, 2.5, PREDICTIVE_TIME_MATCH_TOLERANCE_S).is_none(),
+            "t=2.5 is >0.5 s past the last pose (1.0) → unevaluable, must be None"
+        );
     }
 
     // ----- RSS Rule 4: assured-clear-distance speed bound ------------------


### PR DESCRIPTION
Two predictive-RSS correctness refinements from the review's correctness batch (**A1**, **A2**). Both **reduce spurious MRC without weakening a real breach**; the per-pose WCET path is untouched. (A3 — audit-drop counters — is a separate root-crate observability PR.)

## A1 — `nearest_in_time` time-match tolerance

The predictive pass time-matches each predicted object sample to the ego pose nearest in time. A sample **beyond the ego's planned horizon** was matched to the **last (near-in-time) pose** — a far-future object compared against a near ego pose, which is meaningless and can fabricate a breach.

Fix: a `PREDICTIVE_TIME_MATCH_TOLERANCE_S` (0.5 s, one predicted step). If no ego pose is within tolerance of the sample's time, `nearest_in_time` returns `None` and the pass **skips** the sample — the snapshot RSS still bounds the real object (the same fail-open-on-unevaluable disposition the loop already uses for malformed samples).

## A2 — CTRV yaw / speed consistency

A CTRV hypothesis implies a lateral accel of `speed·|yaw|` (= v²/R). A yaw whose implied accel exceeds `CTRV_MAX_LATERAL_ACCEL_MPS2` (10 m/s² ≈ 1 g) is **physically impossible** for a road vehicle → tracker **noise**, and its sharp-curve CTRV mode would manufacture a spurious breach. Reject it (CV-only). A genuine sharp turn happens at **low speed** (small `speed·yaw`) and is never rejected — the check filters noise, not real maneuvers.

## Tests

- `nearest_in_time` matches in-span and within-tolerance times, returns `None` for a far-future time.
- An implausible high-speed + high-yaw object → CV-only; the **same yaw at low speed** still emits CTRV.
- Existing predictive-RSS SAFETY tests unaffected (their trajectories span the predicted times).

Adapter suite + clippy (CI flags) clean; workspace warning-free. No public signatures changed, so the ros2-gated `node.rs` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_