### PR TITLE
feat(observability): count audit + capture channel drop-on-full (A3)

### DIFF
--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -275,11 +275,13 @@ pub async fn enforce_actuator_safety_envelope(
         match tx.try_send(rec) {
             Ok(()) => {}
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                svc.app.capture_drops.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 tracing::warn!(
                     "capture queue FULL — dropping verdict record (best-effort; safety never waits)"
                 );
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                svc.app.capture_drops.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 tracing::warn!("capture writer task GONE — verdict record dropped");
             }
         }
@@ -366,12 +368,14 @@ pub async fn enforce_actuator_safety_envelope(
                 match tx.try_send(job) {
                     Ok(()) => {}
                     Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                        svc.app.audit_write_drops.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         tracing::error!(
                             reason = %code,
                             "audit queue FULL — dropping kinematic DenyBreach record; sequence gap will be detectable in the chain"
                         );
                     }
                     Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                        svc.app.audit_write_drops.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         tracing::error!(
                             reason = %code,
                             "audit writer task GONE — kinematic DenyBreach record dropped"

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -295,6 +295,18 @@ pub struct AppState {
     /// that were detected but could not be durably recorded (#245/#247 pattern).
     /// MUST be 0 in a healthy deployment; never gates the verdict path.
     pub command_source_write_failures: Arc<AtomicU64>,
+    /// A3 — operator-observable count of kinematic-DenyBreach AUDIT records that
+    /// were dropped because the bounded audit-writer channel was Full/Closed
+    /// (drop-on-full, INV-4: safety never waits). Drops were previously LOGGED
+    /// only; this counter makes the loss-rate observable (a non-zero / rising
+    /// value = the audit chain has sequence gaps — under-provisioned channel or a
+    /// dead writer). Never gates the verdict path.
+    pub audit_write_drops: Arc<AtomicU64>,
+    /// A3 — operator-observable count of learning-capture verdict records dropped
+    /// on a Full/Closed capture channel. Non-safety (capture is an off-verdict-path
+    /// side channel); surfaced so an integrator can see how much training data the
+    /// channel sizing is shedding.
+    pub capture_drops: Arc<AtomicU64>,
 }
 
 impl AppState {
@@ -329,6 +341,8 @@ impl AppState {
             current_incident: Arc::new(Mutex::new(None)),
             post_incident_write_failures: Arc::new(AtomicU64::new(0)),
             command_source_write_failures: Arc::new(AtomicU64::new(0)),
+            audit_write_drops: Arc::new(AtomicU64::new(0)),
+            capture_drops: Arc::new(AtomicU64::new(0)),
         }
     }
 

--- a/tests/actuator_envelope_integration.rs
+++ b/tests/actuator_envelope_integration.rs
@@ -630,3 +630,46 @@ async fn test_capture_emits_a_record_per_arm() {
     assert_eq!(rec2.safe_value, Some(35.0), "the correction Kirra imposed");
 }
 
+/// A3: the drop-on-full of the bounded audit + capture channels is now COUNTED,
+/// not just logged. With capacity-1 writers and no draining consumer, the first
+/// DenyBreach fills both channels and the second overflows them — bumping
+/// `audit_write_drops` and `capture_drops` while the verdict/response is unchanged
+/// (the drop is off the verdict path).
+#[tokio::test]
+async fn a3_drop_counters_count_audit_and_capture_overflow() {
+    use kirra_verifier::audit_writer::AuditWriteJob;
+    use kirra_verifier::capture::CaptureRecord;
+
+    let svc = build_state_with_posture(FleetPosture::Nominal);
+
+    // Capacity-1, NO draining consumer → first record fills, second overflows.
+    // Keep the receivers alive so the channels report Full (not Closed).
+    let (cap_tx, _cap_rx) = tokio::sync::mpsc::channel::<CaptureRecord>(1);
+    let (aud_tx, _aud_rx) = tokio::sync::mpsc::channel::<AuditWriteJob>(1);
+    svc.app.install_capture_writer(cap_tx);
+    svc.app.install_audit_writer(aud_tx);
+
+    // DenyBreach (negative dt) drives BOTH the capture emit (every arm) and the
+    // audit emit (deny arm).
+    let deny = serde_json::to_vec(&ProposedVehicleCommand {
+        linear_velocity_mps: 5.0,
+        current_velocity_mps: 4.0,
+        delta_time_s: -0.1,
+        steering_angle_deg: 0.0,
+        current_steering_angle_deg: 0.0,
+    })
+    .unwrap();
+
+    // Request 1: both capacity-1 channels fill (no drop yet).
+    let s1 = send(build_actuator_app(Arc::clone(&svc)), Body::from(deny.clone())).await;
+    assert_eq!(s1, StatusCode::BAD_REQUEST, "DenyBreach must 400");
+    assert_eq!(svc.app.capture_drops.load(Ordering::Relaxed), 0, "first capture record fits");
+    assert_eq!(svc.app.audit_write_drops.load(Ordering::Relaxed), 0, "first audit record fits");
+
+    // Request 2: both overflow → the A3 counters increment; response still a clean 400.
+    let s2 = send(build_actuator_app(Arc::clone(&svc)), Body::from(deny)).await;
+    assert_eq!(s2, StatusCode::BAD_REQUEST, "drop is off the verdict path — still 400");
+    assert_eq!(svc.app.capture_drops.load(Ordering::Relaxed), 1, "capture drop counted");
+    assert_eq!(svc.app.audit_write_drops.load(Ordering::Relaxed), 1, "audit drop counted");
+}
+


### PR DESCRIPTION
Closes the third item of the review's correctness batch (**A3**). (A1+A2 are PR #590.)

## The gap

The bounded audit-writer and learning-capture channels drop-on-full (INV-4 — *safety never waits*) with a loud log, but the loss was **not counted**: an operator couldn't see the drop *rate*. A rising audit-drop count means sequence gaps in the signed chain (under-provisioned channel or a dead writer) — exactly the kind of thing that should be observable, not just buried in logs.

## Fix

Two operator-observable `AtomicU64` counters on `AppState`, mirroring the existing `post_incident_write_failures` / `command_source_write_failures` pattern:

- **`audit_write_drops`** — bumped on `Full`/`Closed` of the kinematic-DenyBreach audit `try_send`.
- **`capture_drops`** — bumped on `Full`/`Closed` of the verdict-capture `try_send`.

Both increments sit right beside the existing drop-log branches in `enforce_actuator_safety_envelope`; they never gate the verdict path (the drop is off it). Default 0 in a healthy deployment.

## Test (end-to-end, not by-construction)

An integration test installs **capacity-1** audit + capture writers (no draining consumer), drives a `DenyBreach` through the **real middleware** twice — the first request fills both channels, the second overflows them — and asserts both counters read `1` while the response stays a clean `400` (the drop is off the verdict path).

Root clippy (CI flags) clean; workspace **78/78** ok; warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_