### PR TITLE
perf(micro): thread now_ms once per request (§7) + SmallVec predicted-sample buffers (§8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,6 +2058,7 @@ dependencies = [
  "r2r",
  "reqwest",
  "serde_json",
+ "smallvec",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/kirra-ros2-adapter/Cargo.toml
+++ b/crates/kirra-ros2-adapter/Cargo.toml
@@ -75,6 +75,10 @@ dashmap = "6"
 # compiled with a sourced ROS distro in CI; under `ros2` the heavy tree is expected.)
 tokio = { version = "1", features = ["full"], optional = true }
 tracing = "0.1"
+# §8: stack-resident predicted-sample buffers — a slow-loop mode's sample run is
+# small (~7 at a 3 s / 0.5 s horizon), so it lives inline instead of a per-mode
+# heap Vec. Pure-Rust, no_std-capable, async/ROS-free.
+smallvec = "1"
 
 # Lean foundation — the corridor seam (`Point`/`CorridorSource`/`MockCorridorSource`)
 # and the trajectory/perception data types (`Pose`/`TrajectoryPoint`/`TrajectoryVerdict`/

--- a/crates/kirra-ros2-adapter/src/prediction.rs
+++ b/crates/kirra-ros2-adapter/src/prediction.rs
@@ -21,9 +21,15 @@
 //!   over every mode, so one dangerous hypothesis is enough to refuse — the point of *multi-modal*
 //!   prediction. A negligible turn rate adds no CTRV mode (it would duplicate CV).
 
+use smallvec::SmallVec;
+
 use crate::corridor::Point;
 use crate::state::PerceivedObject;
 use crate::validation::{PredictedMode, PredictedSample};
+
+/// A predicted-sample run (§8). Inline up to 8 samples — a 3 s / 0.5 s horizon is
+/// 7, so the common case never heap-allocates; spills to the heap beyond that.
+type SampleVec = SmallVec<[PredictedSample; 8]>;
 
 /// Turn rate (rad/s) below which CTRV ≈ CV — no distinct CTRV mode is emitted (it would just
 /// duplicate the CV hypothesis and the worst-case is unchanged).
@@ -42,7 +48,7 @@ pub const CTRV_MAX_LATERAL_ACCEL_MPS2: f64 = 10.0;
 #[derive(Debug, Clone)]
 pub struct OwnedPredictedMode {
     pub object_id: u64,
-    pub samples: Vec<PredictedSample>,
+    pub samples: SampleVec,
 }
 
 impl OwnedPredictedMode {
@@ -60,7 +66,7 @@ fn step_count(horizon_s: f64, dt_s: f64) -> usize {
 
 /// Roll `obj` forward on CONSTANT VELOCITY (its reported velocity vector) — a straight-line
 /// hypothesis sampled at `dt_s` over `[0, horizon_s]`.
-fn cv_samples(obj: &PerceivedObject, horizon_s: f64, dt_s: f64) -> Vec<PredictedSample> {
+fn cv_samples(obj: &PerceivedObject, horizon_s: f64, dt_s: f64) -> SampleVec {
     let n = step_count(horizon_s, dt_s);
     (0..=n)
         .map(|i| {
@@ -76,12 +82,12 @@ fn cv_samples(obj: &PerceivedObject, horizon_s: f64, dt_s: f64) -> Vec<Predicted
 /// Roll `obj` forward on CONSTANT TURN RATE: travel at its current speed while the heading turns
 /// at `yaw_rate_rad_s`. The divergent hypothesis for a turning object (curves where CV goes
 /// straight). Euler-integrated at `dt_s`.
-fn ctrv_samples(obj: &PerceivedObject, yaw_rate_rad_s: f64, horizon_s: f64, dt_s: f64) -> Vec<PredictedSample> {
+fn ctrv_samples(obj: &PerceivedObject, yaw_rate_rad_s: f64, horizon_s: f64, dt_s: f64) -> SampleVec {
     let n = step_count(horizon_s, dt_s);
     let speed = obj.velocity_mps;
     let mut heading = obj.vel.y_m.atan2(obj.vel.x_m);
     let (mut x, mut y) = (obj.pos.x_m, obj.pos.y_m);
-    let mut out = Vec::with_capacity(n + 1);
+    let mut out = SampleVec::with_capacity(n + 1);
     out.push(PredictedSample { pos: Point { x_m: x, y_m: y }, time_from_start_s: 0.0 });
     for i in 1..=n {
         heading += yaw_rate_rad_s * dt_s;
@@ -123,7 +129,7 @@ fn point_on_polyline(poly: &[Point], dist_m: f64) -> Point {
 /// Roll an object along a geometric **lane-follow** `path` at `speed_mps` — the map-intention
 /// hypothesis: position after travelling `speed*t` along the path. A vehicle on a CURVING lane
 /// traces the curve (which CV/CTRV cannot), and one on a diverging lane stays clear.
-fn lane_follow_samples(path: &[Point], speed_mps: f64, horizon_s: f64, dt_s: f64) -> Vec<PredictedSample> {
+fn lane_follow_samples(path: &[Point], speed_mps: f64, horizon_s: f64, dt_s: f64) -> SampleVec {
     let n = step_count(horizon_s, dt_s);
     (0..=n)
         .map(|i| {

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -220,6 +220,12 @@ pub async fn enforce_actuator_safety_envelope(
     let proposed_cmd: ProposedVehicleCommand =
         serde_json::from_slice(&bytes).map_err(|_| StatusCode::BAD_REQUEST)?;
 
+    // §7: read the clock ONCE per request and thread it — the perception-cap
+    // staleness read, the capture record, and the audit record all want "now" and
+    // are microseconds apart, so a single `SystemTime::now()` syscall is both
+    // cheaper and more consistent than the three separate reads this path used.
+    let now = now_ms();
+
     // Issue #70: Nominal runs the full envelope; Degraded runs the
     // decel-to-stop-and-HOLD gate (non-increasing speed + no re-initiation)
     // over the MRC envelope. LockedOut was already short-circuited above.
@@ -234,7 +240,7 @@ pub async fn enforce_actuator_safety_envelope(
             let eff_cap = resolve_perception_cap(
                 svc.perception_monitor_enabled,
                 &svc.perception_cap,
-                now_ms(),
+                now,
             );
             let contract = apply_perception_cap(
                 &VehicleKinematicsContract::nominal_reference_profile(),
@@ -266,7 +272,7 @@ pub async fn enforce_actuator_safety_envelope(
             svc.app
                 .capture_decision_seq
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
-            now_ms(),
+            now,
             &verdict,
             posture,
             &proposed_cmd,
@@ -359,7 +365,7 @@ pub async fn enforce_actuator_safety_envelope(
                     },
                     violation: code.reason(),
                 },
-                created_at_ms: now_ms() as i64,
+                created_at_ms: now as i64,
                 node_id: "actuator_safety_envelope",
                 reason: "Proposed vehicle command violates non-physical invariants",
             };


### PR DESCRIPTION
Two byte-identical micro-optimizations from the engineering review backlog — pure allocation/syscall reductions, no behavioural change.

## §7 — thread `now_ms` once per request

`enforce_actuator_safety_envelope` (`src/gateway/policy_layer.rs`) read the clock up to **three** times per request:
- the perception-cap staleness read (`resolve_perception_cap`),
- the learning-loop capture record (`record_from_verdict`),
- the audit record (`created_at_ms`).

They are microseconds apart, so a single `let now = now_ms();` threaded through all three is both cheaper (one `SystemTime::now()` syscall instead of three) and more consistent (one timestamp, not three slightly-skewed ones). The Nominal WCET-critical `validate_vehicle_command` path is unchanged.

## §8 — `SmallVec` for the slow-loop predicted-sample buffers

The slow-loop predicted-sample runs are small (~7 samples at a 3 s / 0.5 s horizon), so they now live inline on the stack via `SmallVec<[PredictedSample; 8]>` instead of a per-mode heap `Vec`. Converts `OwnedPredictedMode.samples` and the three sample-builder return types (`cv_samples` / `ctrv_samples` / `lane_follow_samples`); the `&[PredictedSample]` consumers are unchanged (SmallVec derefs to a slice). No allocation on the common path. (Companion to the `MitigationCode` half done in #588.)

## Verification

- `cargo clippy --workspace -- -D warnings -W clippy::all -A clippy::module_name_repetitions -A clippy::must_use_candidate` — clean
- `cargo test --workspace` — all green
- `cargo build --workspace --tests` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_