### PR TITLE
perf(ros2): run the r2r spin loop on a blocking thread (P4)

### DIFF
--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -814,9 +814,19 @@ pub async fn run_adapter(
 
     // ----- Spin loop ----------------------------------------------------
     //
-    // r2r's spin model is to drive the node's executor on a regular
-    // tick. Phase 4 wires in a shutdown channel; Phase 1 just loops.
-    loop {
+    // r2r's spin model is to drive the node's executor on a regular tick.
+    // `spin_once` is a SYNCHRONOUS, thread-blocking call — it parks the
+    // calling thread on the rcl wait-set for up to its timeout (~10 ms here),
+    // so spinning it directly on the async runtime stalls a tokio worker for
+    // that whole window every tick. Move the spin loop onto a dedicated
+    // blocking thread via `spawn_blocking` so it never occupies a worker;
+    // `node` is owned and unused after this point, so it moves cleanly into
+    // the closure. Phase 4 wires in a shutdown channel; Phase 1 just loops.
+    tokio::task::spawn_blocking(move || loop {
         node.spin_once(Duration::from_millis(10));
-    }
+    })
+    .await
+    .expect("r2r spin-loop blocking task panicked");
+
+    Ok(())
 }


### PR DESCRIPTION
## Problem

`run_adapter`'s spin loop drove the r2r node directly on the async runtime:

```rust
loop {
    node.spin_once(Duration::from_millis(10));
}
```

`spin_once` is a **synchronous, thread-blocking** call — it parks the calling thread on the rcl wait-set for up to its timeout. Running it on a tokio worker stalls that worker for the full ~10 ms tick window, starving the slow/fast-loop tasks scheduled on the same runtime.

## Fix

Move the spin loop onto a dedicated blocking thread via `tokio::task::spawn_blocking`, then `.await` the join handle so `run_adapter` still owns the node's lifetime for the duration. `node` is owned and unused after the subscription wiring, so it moves cleanly into the closure. Behaviour is otherwise identical (same 10 ms tick, same infinite spin).

## Verification

This change is `#[cfg(feature = "ros2")]`-gated (`node.rs` only compiles with a sourced ROS 2 + r2r toolchain), so it is verified by CI's **"ros2 adapter build (--features ros2)"** job. The default workspace build does not compile `node.rs`; the adapter's default test suite (84 tests across the non-ros2 modules) passes locally, confirming no collateral impact on the gated boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_