### PR TITLE
fix(gateway): bound PLC-declared length on the Modbus proxy response path (B2)

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -288,6 +288,13 @@ impl KirraLiveGateway {
                     if plc_socket.write_all(&out_bytes).is_err() { break; }
                     if Self::read_exact_frame(&mut plc_socket, 6, &mut plc_buf[0..6]).is_err() { break; }
                     let p_len = u16::from_be_bytes([plc_buf[4], plc_buf[5]]) as usize;
+                    // B2 (fail-closed): bound the PLC-declared length BEFORE slicing
+                    // `plc_buf[6..6+p_len]`. `plc_buf` is `[0u8; 512]`, so a length
+                    // `> 506` would index past the end → panic → (release `panic=abort`)
+                    // process kill from a single malformed/hostile PLC response. This
+                    // mirrors the identical client-request guard at line 227; without
+                    // it the response path was the one unbounded slice in the proxy.
+                    if p_len == 0 || p_len > 500 { break; }
                     if Self::read_exact_frame(&mut plc_socket, p_len, &mut plc_buf[6..6+p_len]).is_err() { break; }
                     if mut_client.write_all(&plc_buf[0..6+p_len]).is_err() { break; }
                 }


### PR DESCRIPTION
## B2 (HIGH) — remotely-triggerable process kill via unbounded PLC-response slice

The Modbus TCP proxy guards the **client-request** length before slicing its buffer:

```rust
let len = u16::from_be_bytes([buf[4], buf[5]]) as usize;
if len == 0 || len > 500 { break; }          // gateway/mod.rs:227
... &mut buf[6..6+len] ...
```

But the **PLC-response** path had no equivalent guard:

```rust
let p_len = u16::from_be_bytes([plc_buf[4], plc_buf[5]]) as usize;   // up to 65535
... &mut plc_buf[6..6+p_len] ...             // plc_buf is [0u8; 512]
```

Any `p_len > 506` indexes past the 512-byte `plc_buf` → **slice panic** → with release `panic = "abort"` (the project's fail-closed-by-process-death model) this kills the process. A single malformed or hostile PLC response takes down the proxy worker (DoS).

## Fix

Mirror the existing client-side guard exactly before the slice:

```rust
if p_len == 0 || p_len > 500 { break; }
```

The response path is now fail-closed on an out-of-range declared length, identical to the request path. No behavioural change for well-formed frames.

## Verification

- `cargo clippy --workspace -- -D warnings …` — clean
- `cargo test -p kirra-verifier --lib gateway` — 53 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_