### PR TITLE
fix(governor/store): panic-proof scalar clamp (B5) + SQLite busy_timeout on all connections (P2)

### DIFF
--- a/src/kirra_core.rs
+++ b/src/kirra_core.rs
@@ -130,15 +130,38 @@ pub struct KirraKernelGovernor<C: SafetyContract> {
     pub constraint_cap_max: f64,
 }
 
+/// Order- and NaN-tolerant clamp (B5). `f64::clamp` PANICS when `lo > hi` or
+/// either bound is NaN — and under release `panic = "abort"` that panic is a
+/// governor process kill. This normalizes the bound order and ignores a single
+/// NaN bound, so a misconfigured/inverted cap or contract bound degrades to a
+/// valid clamp instead of aborting the safety governor. (With both bounds NaN
+/// the value passes through unclamped, but the demand is already envelope-bounded
+/// upstream and the construction-time normalization keeps the stored cap finite.)
+#[inline]
+fn safe_clamp(value: f64, lo: f64, hi: f64) -> f64 {
+    value.max(lo.min(hi)).min(lo.max(hi))
+}
+
 impl<C: SafetyContract> KirraKernelGovernor<C> {
     pub fn new(contract: C, initial_scalar: f64, cap_min: f64, cap_max: f64) -> Self {
+        // B5: a misconfigured cap — an inverted pair (`cap_min > cap_max`, e.g. a
+        // sign typo) or a non-finite bound — would make the Degraded
+        // `ApplyVelocityCap` clamp in `evaluate()` panic, and under release
+        // `panic = "abort"` that kills the governor process. Normalize at
+        // construction so the STORED cap is always a valid ordered range: swap an
+        // inverted pair (recovers the likely intent), and let a single NaN collapse
+        // to its finite partner via `min`/`max`. `safe_clamp` at the use sites is
+        // the runtime backstop for any residual (e.g. both-NaN) case. A startup
+        // sentinel remains the right place to FAIL-FAST on such a config.
+        let constraint_cap_min = cap_min.min(cap_max);
+        let constraint_cap_max = cap_min.max(cap_max);
         Self {
             contract,
             trust_engine: RuntimeTrustEngine::new(),
             last_validated_scalar: initial_scalar,
             continuous_rate_breach_ticks: 0,
-            constraint_cap_min: cap_min,
-            constraint_cap_max: cap_max,
+            constraint_cap_min,
+            constraint_cap_max,
         }
     }
 }
@@ -209,7 +232,7 @@ impl<C: SafetyContract> SafetyGovernor for KirraKernelGovernor<C> {
         if is_out_of_envelope { cumulative_penalty += 30; }
         if self.continuous_rate_breach_ticks > 5 { cumulative_penalty += 15; }
 
-        let core_bounded_demand = proposed_demand.clamp(self.contract.min_bound(), self.contract.max_bound());
+        let core_bounded_demand = safe_clamp(proposed_demand, self.contract.min_bound(), self.contract.max_bound());
 
         let (sanitized_scalar, mitigation): (f64, MitigationCode) = match active_action {
             BehavioralAction::ExecuteUnrestricted => {
@@ -224,16 +247,18 @@ impl<C: SafetyContract> SafetyGovernor for KirraKernelGovernor<C> {
                     // envelope when the constructor caps are wider than the bounds; the
                     // unconditional clamp guarantees the emitted scalar is in-envelope,
                     // matching the AV path's `validate_vehicle_command`.
-                    let rate_clamped_value = (self.last_validated_scalar
-                        + (self.contract.max_rate() * dt * step_direction))
-                        .clamp(self.contract.min_bound(), self.contract.max_bound());
+                    let rate_clamped_value = safe_clamp(
+                        self.last_validated_scalar + (self.contract.max_rate() * dt * step_direction),
+                        self.contract.min_bound(),
+                        self.contract.max_bound(),
+                    );
                     (rate_clamped_value, MitigationCode::RateClampEnforced { max_rate: self.contract.max_rate() })
                 } else {
                     (proposed_demand, MitigationCode::PassthroughUnrestrictedNormal)
                 }
             }
             BehavioralAction::ApplyVelocityCap => {
-                let clamped_value = core_bounded_demand.clamp(self.constraint_cap_min, self.constraint_cap_max);
+                let clamped_value = safe_clamp(core_bounded_demand, self.constraint_cap_min, self.constraint_cap_max);
                 (clamped_value, MitigationCode::DegradedPostureClamp { cap_min: self.constraint_cap_min, cap_max: self.constraint_cap_max })
             }
             BehavioralAction::ForceStationaryHold => {
@@ -409,5 +434,51 @@ mod governor_nonfinite_tests {
             "rate-clamped output {} must be inside the hard envelope [-2, 2] (invariant #8)",
             out.sanitized_scalar
         );
+    }
+
+    fn contract() -> KinematicContract {
+        KinematicContract {
+            max_linear_velocity: 2.0,
+            max_angular_velocity: 1.0,
+            max_linear_acceleration: 10.0,
+            fallback_linear_speed: 0.0,
+        }
+    }
+
+    #[test]
+    fn inverted_cap_is_normalized_not_paniced_b5() {
+        // B5: a sign-typo'd cap (cap_min > cap_max) previously made the Degraded
+        // `ApplyVelocityCap` `f64::clamp` panic — and under release `panic =
+        // "abort"` that kills the governor. Construction must normalize the pair to
+        // a valid ordered range instead of aborting.
+        let g = KirraKernelGovernor::new(contract(), 0.0, 2.0, -2.0);
+        assert!(
+            g.constraint_cap_min <= g.constraint_cap_max,
+            "an inverted cap must be normalized to an ordered range"
+        );
+        assert_eq!((g.constraint_cap_min, g.constraint_cap_max), (-2.0, 2.0));
+    }
+
+    #[test]
+    fn safe_clamp_is_order_and_nan_tolerant_b5() {
+        use super::safe_clamp;
+        // Inverted bounds behave as a valid clamp; never panics.
+        assert_eq!(safe_clamp(5.0, 2.0, -2.0), 2.0);
+        assert_eq!(safe_clamp(-5.0, 2.0, -2.0), -2.0);
+        assert_eq!(safe_clamp(0.5, -2.0, 2.0), 0.5);
+        // A single NaN bound collapses to the finite partner (no panic).
+        assert_eq!(safe_clamp(5.0, f64::NAN, 2.0), 2.0);
+        assert_eq!(safe_clamp(-5.0, -2.0, f64::NAN), -2.0);
+        // Both-NaN passes the (already envelope-bounded) value through, no panic.
+        assert!(safe_clamp(1.5, f64::NAN, f64::NAN).is_finite());
+    }
+
+    #[test]
+    fn evaluate_with_inverted_cap_never_panics_b5() {
+        // End-to-end: a governor built with an inverted cap must `evaluate()`
+        // without aborting and still return a finite scalar.
+        let mut g = KirraKernelGovernor::new(contract(), 0.0, 2.0, -2.0);
+        let out = g.evaluate(1.0, 0.05);
+        assert!(out.sanitized_scalar.is_finite());
     }
 }

--- a/src/verifier_store.rs
+++ b/src/verifier_store.rs
@@ -211,9 +211,15 @@ fn is_unique_violation(e: &rusqlite::Error) -> bool {
     )
 }
 
-/// Busy timeout for a read-only replica connection (ms): brief, so a reader
-/// rides out a concurrent WAL checkpoint instead of surfacing `SQLITE_BUSY`.
-const READ_REPLICA_BUSY_TIMEOUT_MS: u64 = 250;
+/// Busy timeout (ms) applied to EVERY connection — writer, durable, and read
+/// replica (P2). Brief, so a connection rides out a concurrent WAL checkpoint
+/// (which briefly locks the WAL) instead of immediately surfacing `SQLITE_BUSY`.
+/// Without it on the writer/durable connections, a checkpoint transient surfaced
+/// as a fail-closed error on the heartbeat/epoch path (a spurious self-demote
+/// signal). 250 ms is well inside the heartbeat interval, so durability is
+/// unaffected — the write either acquires the lock or fails as before, just
+/// after a short, bounded wait.
+const SQLITE_BUSY_TIMEOUT_MS: u64 = 250;
 
 pub struct VerifierStore {
     /// Hot/read connection — `synchronous=NORMAL`. Carries the verdict-adjacent
@@ -404,6 +410,9 @@ impl VerifierStore {
         let conn = Connection::open(path)?;
 
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")?;
+        // P2: ride out a concurrent WAL checkpoint instead of surfacing SQLITE_BUSY
+        // as a fail-closed error (the read replica already does this).
+        conn.busy_timeout(std::time::Duration::from_millis(SQLITE_BUSY_TIMEOUT_MS))?;
 
         conn.execute(
             "CREATE TABLE IF NOT EXISTS nodes (
@@ -706,6 +715,10 @@ impl VerifierStore {
         } else {
             let dc = Connection::open(path)?;
             dc.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;")?;
+            // P2: same checkpoint-transient absorption on the durable (epoch CAS /
+            // nonce burn) connection — a SQLITE_BUSY here would fail an HA epoch or
+            // federation write that is otherwise valid.
+            dc.busy_timeout(std::time::Duration::from_millis(SQLITE_BUSY_TIMEOUT_MS))?;
             Some(dc)
         };
 
@@ -741,7 +754,7 @@ impl VerifierStore {
         )?;
         // A read-only WAL reader can briefly contend with a checkpoint; a short
         // busy timeout rides it out rather than surfacing SQLITE_BUSY.
-        conn.busy_timeout(std::time::Duration::from_millis(READ_REPLICA_BUSY_TIMEOUT_MS))?;
+        conn.busy_timeout(std::time::Duration::from_millis(SQLITE_BUSY_TIMEOUT_MS))?;
         Ok(Self {
             conn,
             durable_conn: None,


### PR DESCRIPTION
Two fail-closed hardening fixes from the engineering review.

## B5 (MED) — `f64::clamp` panic on a misconfigured cap → process abort

`KirraKernelGovernor::new` took `cap_min`/`cap_max` unvalidated, and the Degraded `ApplyVelocityCap` path did:

```rust
core_bounded_demand.clamp(self.constraint_cap_min, self.constraint_cap_max)
```

`f64::clamp` **panics** when `lo > hi` or either bound is NaN — and under release `panic = "abort"` (the project's fail-closed-by-process-death model) that panic is a **governor process kill**. A single config typo (`cap_min = 2.0, cap_max = -2.0`) aborts the safety governor on the Degraded actuator path.

**Fix:**
- `safe_clamp(value, lo, hi)` — order- and NaN-tolerant; replaces `f64::clamp` at **all three** governor clamp sites (the contract-bound clamp, the rate-clamp re-clamp, and the velocity cap), so no clamp site can abort the process.
- `new()` normalizes the stored cap to a valid ordered range — swaps an inverted pair (recovering the likely intent) and lets a single NaN collapse to its finite partner. A startup sentinel remains the right place to additionally *fail-fast* on such a config.

## P2 (MED) — no `busy_timeout` on the writer/durable connections

Only the read-replica connection set a `busy_timeout`; the writer and durable (`synchronous=FULL`) connections did not. A concurrent WAL checkpoint briefly locks the WAL, so a write landing in that window surfaced `SQLITE_BUSY` as a fail-closed error — and on the heartbeat/epoch path that reads as a **spurious self-demote** signal.

**Fix:** apply the same 250 ms `busy_timeout` (constant renamed `SQLITE_BUSY_TIMEOUT_MS`, now shared) to the writer and durable connections. Durability is unaffected — the write still either acquires the lock or fails, just after a short, bounded wait well inside the heartbeat interval.

## Tests

- `inverted_cap_is_normalized_not_paniced_b5` — `(2.0, -2.0)` → stored `(-2.0, 2.0)`.
- `safe_clamp_is_order_and_nan_tolerant_b5` — inverted + single-NaN + both-NaN, no panic.
- `evaluate_with_inverted_cap_never_panics_b5` — end-to-end no-abort regression.

## Verification

- `cargo clippy --workspace -- -D warnings …` — clean
- `cargo test --workspace` — all green (incl. existing pragma/`synchronous` store tests + the 3 new regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_