### PR TITLE
fix(checker): predictive-RSS fails closed on supplied-but-unevaluable modes (B3)

### DIFF
--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -573,20 +573,26 @@ fn nearest_in_time(
 /// proximity) closes that gap. `max_lateral_accel_mps2` is the (posture-/perception-capped)
 /// per-pose contract's lateral-accel bound, so the predictive lateral check uses the SAME
 /// side-gap budget as the snapshot pass.
-// SAFETY: SG1 | REQ: multi-modal-predictive-rss-bound | TEST: predictive_rss_catches_a_predicted_cut_in,predictive_rss_does_not_regress_a_lane_keeping_neighbor,predictive_rss_is_a_no_op_when_no_modes_are_supplied,rss_conjunction_still_rejects_a_lateral_cut_in_at_a_safe_longitudinal_distance,predictive_rss_catches_a_mid_band_lateral_cut_in
+// SAFETY: SG1 | REQ: multi-modal-predictive-rss-bound | TEST: predictive_rss_catches_a_predicted_cut_in,predictive_rss_does_not_regress_a_lane_keeping_neighbor,predictive_rss_is_a_no_op_when_no_modes_are_supplied,rss_conjunction_still_rejects_a_lateral_cut_in_at_a_safe_longitudinal_distance,predictive_rss_catches_a_mid_band_lateral_cut_in,predictive_rss_fails_closed_on_modes_supplied_but_all_unevaluable_b3,predictive_rss_fails_closed_on_modes_with_no_evaluable_window_b3
 fn predictive_rss_breach(
     trajectory: &[TrajectoryPoint],
     modes: &[PredictedMode<'_>],
     config: &VehicleConfig,
     max_lateral_accel_mps2: f64,
 ) -> bool {
+    // B3: track whether ANY sample window was actually evaluable. A non-monotonic
+    // `dt` or an out-of-span time match means "couldn't evaluate this sample" —
+    // distinct from the geometric gates below, which ARE evaluated determinations
+    // ("evaluated → not a threat"). If a non-empty mode set produces NOT ONE
+    // evaluable window, the cut-in detector checked nothing; see the fail-closed
+    // guard after the loop.
+    let mut evaluated_any = false;
     for mode in modes {
         for pair in mode.samples.windows(2) {
             let (a, b) = (pair[0], pair[1]);
             let dt = b.time_from_start_s - a.time_from_start_s;
             if dt <= 0.0 {
-                continue; // non-monotonic samples — skip (fail-open on malformed *input*,
-                          // the snapshot RSS still bounds the real object)
+                continue; // non-monotonic samples — unevaluable (see post-loop guard)
             }
             let ovx = (b.pos.x_m - a.pos.x_m) / dt;
             let ovy = (b.pos.y_m - a.pos.y_m) / dt;
@@ -596,6 +602,9 @@ fn predictive_rss_breach(
             else {
                 continue; // no ego pose within tolerance at this time — unevaluable
             };
+            // Past both unevaluable gates: this window WAS evaluated (whatever the
+            // geometric verdict below).
+            evaluated_any = true;
             let dx = a.pos.x_m - ego.pose.x_m;
             let dy = a.pos.y_m - ego.pose.y_m;
             let cos_h = ego.pose.heading_rad.cos();
@@ -663,6 +672,23 @@ fn predictive_rss_breach(
             }
         }
     }
+
+    // B3 (fail-closed): the caller already treats `predicted_modes == None` /
+    // an EMPTY slice as the legitimate "no prediction supplied" no-op. But a
+    // NON-EMPTY mode set that produced ZERO evaluable windows — every sample
+    // non-monotonic in time, or none within the ego trajectory's time span, or
+    // no inter-sample window at all (a sub-`dt` horizon) — means the multi-modal
+    // predictive pass, the ONLY layer catching a mid-band cut-in the snapshot
+    // filters out, evaluated nothing. Returning `false` here would be a SILENT
+    // FAIL-OPEN that a producer can trigger with equal timestamps or a too-short
+    // horizon. Fail closed instead: derate to the MRC floor (the caller maps
+    // `true` → `TrajectoryVerdict::MRCFallback`). Well-formed modes always have
+    // at least one evaluable window (the t≈0 sample matches the ego start pose),
+    // so the Nominal path is unaffected.
+    if !modes.is_empty() && !evaluated_any {
+        return true;
+    }
+
     false
 }
 

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -842,6 +842,52 @@ fn predictive_rss_is_a_no_op_when_no_modes_are_supplied() {
         "with no predicted modes the predictive pass is a no-op; got {verdict:?}");
 }
 
+#[test]
+fn predictive_rss_fails_closed_on_modes_supplied_but_all_unevaluable_b3() {
+    // B3 (silent fail-open fix): a neighbor whose predicted mode is MALFORMED —
+    // every sample carries the SAME timestamp, so `dt <= 0` for every window and
+    // the multi-modal pass can evaluate NOTHING. Previously it fell through to
+    // "safe" (fail-OPEN): a producer emitting equal timestamps could silently
+    // neutralize the cut-in detector. The geometry is the lane-keeping neighbor
+    // that normally ACCEPTS (so neither the snapshot RSS — no objects passed — nor
+    // any other pass fires); the ONLY thing that can MRC here is the new
+    // fail-closed guard. It must now return MRCFallback.
+    let trajectory = straight_trajectory(20, 6.0, 0.1);
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let samples = [
+        PredictedSample { pos: Point { x_m: 9.0, y_m: -3.5 }, time_from_start_s: 0.0 },
+        PredictedSample { pos: Point { x_m: 9.0, y_m: -3.5 }, time_from_start_s: 0.0 },
+        PredictedSample { pos: Point { x_m: 9.0, y_m: -3.5 }, time_from_start_s: 0.0 },
+    ];
+    let modes = [PredictedMode { object_id: 1, samples: &samples }];
+
+    let verdict = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), FrameTrust::Trusted,
+    );
+    assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
+        "modes supplied but all unevaluable (equal timestamps) must fail closed; got {verdict:?}");
+}
+
+#[test]
+fn predictive_rss_fails_closed_on_modes_with_no_evaluable_window_b3() {
+    // B3: a non-empty mode set whose mode carries only a SINGLE sample — no
+    // inter-sample window at all (the degenerate sub-`dt` horizon the producer can
+    // emit). There is no motion to roll forward, so the pass evaluates nothing and
+    // must fail closed rather than Accept.
+    let trajectory = straight_trajectory(20, 6.0, 0.1);
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let samples = [PredictedSample { pos: Point { x_m: 9.0, y_m: -3.5 }, time_from_start_s: 0.0 }];
+    let modes = [PredictedMode { object_id: 1, samples: &samples }];
+
+    let verdict = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), FrameTrust::Trusted,
+    );
+    assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
+        "a non-empty mode set with no evaluable window must fail closed; got {verdict:?}");
+}
+
 // ---------------------------------------------------------------------------
 // RSS conjunction (§4): a safe stationary queue is admitted; genuine danger
 // (driving in, or a lateral cut-in) is still rejected. A deterministic SWEEP —


### PR DESCRIPTION
## B3 (HIGH / checker-independence) — predictive-RSS silent fail-open

`predictive_rss_breach` is the multi-modal cut-in detector — the **only** layer that catches a mid-band cut-in the snapshot RSS filters out. It `continue`d past every sample window it couldn't evaluate:

```rust
if dt <= 0.0 { continue; }                       // non-monotonic samples
let Some(ego) = nearest_in_time(...) else { continue; };  // no ego pose in the time span
```

…and then fell through to `false` (= safe). So when perception supplied modes that were **all** unevaluable — equal timestamps, or a horizon shorter than one predicted step (single-sample modes → no inter-sample window) — the detector evaluated **nothing** yet reported "safe". A producer emitting malformed timing could silently neutralize the layer that exists specifically to catch what the snapshot misses (`D/C-3` in the review — the most important checker-independence gap).

## Fix

Track whether any window was actually **evaluable** (passed both the monotonic-`dt` and in-span time-match gates — the geometric gates after that are *evaluated determinations*, not skips). If a **non-empty** mode set yields zero evaluable windows, fail closed → the caller maps `true` to `TrajectoryVerdict::MRCFallback`.

- An empty / `None` mode set is still the legitimate "no prediction supplied" no-op.
- Well-formed modes always have an evaluable `t≈0` window (it matches the ego start pose), so the **Nominal path is unchanged** — no over-fire.

## Tests

- `…all_unevaluable_b3` — every sample at the same timestamp (`dt <= 0` for all windows).
- `…no_evaluable_window_b3` — a single-sample mode (no inter-sample window).

Both use a lane-keeping-neighbor geometry that otherwise **Accepts** (no objects passed to the snapshot pass), isolating the new fail-closed guard as the sole cause of the MRC. The existing `…is_a_no_op_when_no_modes_are_supplied` and `…does_not_regress_a_lane_keeping_neighbor` tests pin the no-over-fire side.

## Verification

- `cargo clippy --workspace -- -D warnings …` — clean
- `cargo test --workspace` — all green (41 adapter validation tests incl. 2 new; no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_