### PR TITLE
fix(checker): normalize Δheading across the ±π wrap in the steering derivation (B9)

### DIFF
--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -819,7 +819,14 @@ fn pose_pair_to_command(
     current_steering_deg: f64,
 ) -> ProposedVehicleCommand {
     let delta_time_s = b.time_from_start_s - a.time_from_start_s;
-    let delta_heading = b.pose.heading_rad - a.pose.heading_rad;
+    // B9: normalize Δheading to [-π, π] before the bicycle-model `atan2`, mirroring
+    // the angular (ω) channel. A trajectory crossing the ±π wrap (e.g. heading
+    // +3.10 → −3.10 rad, a ~0.08 rad physical turn) yields a RAW delta of ~−2π,
+    // which the unwrapped form turned into a huge fictitious steering angle → a
+    // spurious `ClampSteering`. The shortest-arc delta is the real turn.
+    let raw_heading = b.pose.heading_rad - a.pose.heading_rad;
+    let delta_heading =
+        raw_heading - std::f64::consts::TAU * (raw_heading / std::f64::consts::TAU).round();
     // Average velocity over the segment; avoids dividing by ~0 when
     // velocity is small at one endpoint.
     let avg_velocity = 0.5 * (a.velocity_mps + b.velocity_mps);
@@ -939,6 +946,43 @@ mod conversion_tests {
         let cmd = pose_pair_to_command(&a, &b, &cfg, 0.0);
         assert!(cmd.steering_angle_deg > 4.0 && cmd.steering_angle_deg < 7.0,
             "expected ~5.6° steering, got {}", cmd.steering_angle_deg);
+    }
+
+    #[test]
+    fn pose_pair_heading_wrap_is_the_short_arc_not_a_spurious_full_turn_b9() {
+        // B9: a heading crossing the ±π wrap (+3.10 → −3.10 rad) is a ~0.083 rad
+        // SHORT-ARC turn, not a ~2π one. The raw (unwrapped) delta of ~−6.2 rad fed
+        // into the bicycle-model `atan2` produced a huge fictitious steering (~−74°)
+        // → a spurious `ClampSteering`. Normalized, the steering is small and points
+        // the short-arc direction (positive here).
+        let cfg = VehicleConfig::default_urban();
+        let a = TrajectoryPoint {
+            pose: AdapterPose { x_m: 0.0, y_m: 0.0, heading_rad: 3.10 },
+            velocity_mps: 10.0, time_from_start_s: 0.0,
+        };
+        let b = TrajectoryPoint {
+            pose: AdapterPose { x_m: 5.0, y_m: 0.0, heading_rad: -3.10 },
+            velocity_mps: 10.0, time_from_start_s: 0.5,
+        };
+        let cmd = pose_pair_to_command(&a, &b, &cfg, 0.0);
+        assert!(cmd.steering_angle_deg > 0.0 && cmd.steering_angle_deg < 10.0,
+            "a ±π wrap is a short arc, not a full turn; expected a small positive steering, got {}°",
+            cmd.steering_angle_deg);
+
+        // And it matches the EQUIVALENT non-wrapping small turn (0.0 → +0.083 rad).
+        let a2 = TrajectoryPoint {
+            pose: AdapterPose { x_m: 0.0, y_m: 0.0, heading_rad: 0.0 },
+            velocity_mps: 10.0, time_from_start_s: 0.0,
+        };
+        let short = (-3.10_f64) - 3.10 + std::f64::consts::TAU; // the wrapped Δ ≈ 0.0832
+        let b2 = TrajectoryPoint {
+            pose: AdapterPose { x_m: 5.0, y_m: 0.0, heading_rad: short },
+            velocity_mps: 10.0, time_from_start_s: 0.5,
+        };
+        let cmd2 = pose_pair_to_command(&a2, &b2, &cfg, 0.0);
+        assert!((cmd.steering_angle_deg - cmd2.steering_angle_deg).abs() < 1e-9,
+            "the wrap-crossing turn must equal the equivalent short-arc turn: {} vs {}",
+            cmd.steering_angle_deg, cmd2.steering_angle_deg);
     }
 
     #[test]


### PR DESCRIPTION
## B9 (MED) — heading-wrap not normalized in the steering derivation

`pose_pair_to_command` fed a **raw** heading delta into the bicycle-model `atan2`:

```rust
let delta_heading = b.pose.heading_rad - a.pose.heading_rad;   // raw
...
(delta_heading * config.wheelbase_m).atan2(denom)
```

A segment crossing the ±π heading wrap (e.g. `+3.10 → −3.10` rad — a ~0.083 rad physical turn) produces a raw delta of ~`−2π`, which the unwrapped form turns into a **huge fictitious steering angle (~−74°)** → a spurious `ClampSteering` on a nearly-straight segment. The angular (ω) channel already normalizes the same delta (`validation.rs:322`); the steering channel did not.

## Fix

Apply the identical shortest-arc normalization the ω channel uses, before the `atan2`:

```rust
let raw_heading = b.pose.heading_rad - a.pose.heading_rad;
let delta_heading = raw_heading - TAU * (raw_heading / TAU).round();   // → [−π, π]
```

The normalization is the identity for any segment that doesn't cross the wrap, so non-wrapping behaviour is unchanged.

## Test

A `+3.10 → −3.10` rad segment now yields a **small positive** steering, and it matches the equivalent non-wrapping `+0.083` rad turn exactly (`< 1e-9`).

## Verification

- `cargo clippy --workspace -- -D warnings …` — clean
- `cargo test --workspace` — all green (incl. the new regression; existing `pose_pair_*` steering tests unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_