### PR TITLE
fix(ha): live epoch fence on the actuator admit path (1b)

### DIFF
--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -494,42 +494,75 @@ pub async fn enforce_posture_routing(
     // commit is rejected (and the handler self-demotes) even if it passed this
     // gate. This gate remains the fast first-line fence; the in-transaction
     // re-check is the authoritative one.
-    let is_mutation = matches!(
-        cmd,
-        OperationalCommand::WriteState
-            | OperationalCommand::SystemMutation
-            // ActuatorMotion is a physical state write — it MUST still be fenced
-            // by the HA epoch guard even though the posture gate defers its
-            // Degraded verdict to the inner kinematic envelope (Option A).
-            | OperationalCommand::ActuatorMotion
-    );
-    if is_mutation {
-        let held = svc.app.held_epoch.load(std::sync::atomic::Ordering::SeqCst);
-        // Pass B1 (S3 / #115): read the cached DB epoch atomically instead of
-        // taking `store.lock()` + `current_epoch()` per request. Cache is
-        // re-stamped by `perform_promotion` after a successful CAS and by the
-        // heartbeat writer on every HEARTBEAT_INTERVAL_MS tick — both with
-        // Release. Acquire here pairs with both Releases. A 0 value means
-        // "not yet observed" (cold start before the first heartbeat); fall
-        // through to the existing held==0 / non-Active checks for fail-closed.
-        // The gate + self-demote decision MUST stay on the request path,
-        // before any downstream hand-off.
-        let db = svc.app.cached_db_epoch.load(std::sync::atomic::Ordering::Acquire);
-        if db != 0 && held != 0 && held != db {
-            svc.app
-                .mode_active
-                .store(false, std::sync::atomic::Ordering::SeqCst);
-            tracing::error!(
-                method = %method,
-                path   = %path,
-                held   = held,
-                db     = db,
-                "FENCED — held epoch stale; self-demoting and rejecting mutation (HA split-brain prevention)"
-            );
-            return Err(StatusCode::SERVICE_UNAVAILABLE);
+    let held = svc.app.held_epoch.load(std::sync::atomic::Ordering::SeqCst);
+    match cmd {
+        // 1b — ACTUATOR PATH gets a LIVE epoch fence. Unlike the top-tier durable
+        // writes (federation / key-rotation), an actuator command performs NO
+        // durable write, so there is no transaction to hang an in-transaction
+        // `assert_epoch_held` re-check on — it relied SOLELY on the cached epoch,
+        // which the heartbeat re-stamps only every HEARTBEAT_INTERVAL_MS (~2 s).
+        // During failover the old primary could therefore keep admitting actuator
+        // commands for up to ~2 s after the new primary claimed the epoch (the
+        // review's highest-consequence two-writer residual). Read the LIVE durable
+        // epoch off the WAL read-replica instead (committed-snapshot visibility, so
+        // the new primary's epoch-CAS is seen immediately; `call_read` keeps it off
+        // the tokio worker per P1). This closes the window to ~one command. The
+        // kernel WCET path (`validate_vehicle_command`) is untouched — this read is
+        // on the HTTP gate, which already does serde + Tower work.
+        OperationalCommand::ActuatorMotion if held != 0 => {
+            match svc.app.store.call_read(|s| s.current_epoch()).await {
+                // Still the owner — admit (the downstream decel gate still runs).
+                Ok(Ok(durable)) if durable == held => {}
+                // Superseded: a newer primary owns the epoch. Self-demote + reject.
+                Ok(Ok(durable)) => {
+                    svc.app
+                        .mode_active
+                        .store(false, std::sync::atomic::Ordering::SeqCst);
+                    tracing::error!(
+                        method = %method, path = %path, held = held, durable = durable,
+                        "FENCED (live) — actuator command on a superseded epoch; self-demoting and rejecting (HA split-brain prevention)"
+                    );
+                    return Err(StatusCode::SERVICE_UNAVAILABLE);
+                }
+                // Could not read the live epoch (DB error / task failure / disk
+                // wedge). Cannot confirm ownership → fail closed (review item 1).
+                Ok(Err(_)) | Err(_) => {
+                    tracing::error!(
+                        method = %method, path = %path, held = held,
+                        "actuator epoch read failed — cannot confirm HA ownership; failing closed"
+                    );
+                    return Err(StatusCode::SERVICE_UNAVAILABLE);
+                }
+            }
         }
-        // cached_db_epoch == 0 -> fall through. Existing mode/posture
-        // checks below remain fail-closed for mutations on non-Active.
+        // Other mutations keep the fast CACHED epoch check (Pass B1): they ARE
+        // backstopped by the in-transaction `assert_epoch_held` on their durable
+        // write, so a stale cache here can at worst let one write REACH the durable
+        // layer, where it is rejected. `cached_db_epoch` is re-stamped by
+        // `perform_promotion` (post-CAS) and the heartbeat writer, both Release;
+        // Acquire here pairs with both. A 0 cache (cold start) falls through to the
+        // mode/posture checks below.
+        OperationalCommand::WriteState | OperationalCommand::SystemMutation => {
+            let db = svc.app.cached_db_epoch.load(std::sync::atomic::Ordering::Acquire);
+            if db != 0 && held != 0 && held != db {
+                svc.app
+                    .mode_active
+                    .store(false, std::sync::atomic::Ordering::SeqCst);
+                tracing::error!(
+                    method = %method,
+                    path   = %path,
+                    held   = held,
+                    db     = db,
+                    "FENCED — held epoch stale; self-demoting and rejecting mutation (HA split-brain prevention)"
+                );
+                return Err(StatusCode::SERVICE_UNAVAILABLE);
+            }
+        }
+        // ActuatorMotion with held == 0 (this instance never claimed an epoch —
+        // cold start / standby) falls through to the mode/posture checks below,
+        // which are fail-closed for mutations on a non-Active instance. Reads /
+        // Unknown are not epoch-fenced.
+        _ => {}
     }
 
     // Fail-closed snapshot: poisoned lock -> None -> block.

--- a/tests/posture_gate_integration.rs
+++ b/tests/posture_gate_integration.rs
@@ -271,3 +271,59 @@ async fn test_health_exempt_under_lockedout() {
          route may 404 if not mounted, which still proves the gate stepped aside"
     );
 }
+
+// ---------------------------------------------------------------------------
+// 1b. Actuator-path LIVE epoch fence. The actuator command performs no durable
+// write (so no in-transaction epoch re-check is possible); it now reads the LIVE
+// durable epoch on the admit path instead of a ~2s-stale cached value. The owner
+// passes; a superseded primary is fenced 503 and self-demotes IMMEDIATELY —
+// closing the failover two-writer window the cached fence left open.
+// ---------------------------------------------------------------------------
+
+use std::sync::atomic::Ordering;
+
+#[tokio::test]
+async fn test_actuator_live_epoch_fence_admits_the_owner() {
+    let svc = build_state_with_posture(FleetPosture::Nominal);
+    let now = kirra_verifier::posture_cache::now_ms();
+    // Claim epoch 1 durably, and hold it in memory (this instance IS the owner).
+    let claimed = svc.app.store.with(|s| s.try_claim_epoch(0, "primary", now).unwrap());
+    assert_eq!(claimed, Some(1), "fresh in-memory store claims epoch 1 from genesis 0");
+    svc.app.held_epoch.store(1, Ordering::SeqCst);
+
+    let status = req_status(build_test_app(svc), "POST", "/actuator/motion/command").await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the live epoch owner (held == durable) must pass the actuator fence; got {status}"
+    );
+}
+
+#[tokio::test]
+async fn test_actuator_live_epoch_fence_rejects_a_superseded_primary() {
+    let svc = build_state_with_posture(FleetPosture::Nominal);
+    let now = kirra_verifier::posture_cache::now_ms();
+    // This instance claimed epoch 1 and holds it...
+    assert_eq!(svc.app.store.with(|s| s.try_claim_epoch(0, "old", now).unwrap()), Some(1));
+    svc.app.held_epoch.store(1, Ordering::SeqCst);
+    // ...then a NEW primary claims epoch 2 durably (failover). The old primary's
+    // in-memory held_epoch (1) is now stale; its cached_db_epoch hasn't caught up.
+    assert_eq!(svc.app.store.with(|s| s.try_claim_epoch(1, "new", now).unwrap()), Some(2));
+
+    assert!(svc.app.is_active(), "precondition: still Active before the fenced request");
+    let status = req_status(
+        build_test_app(Arc::clone(&svc)),
+        "POST",
+        "/actuator/motion/command",
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "a superseded primary's actuator command must be fenced 503 by the LIVE read; got {status}"
+    );
+    assert!(
+        !svc.app.is_active(),
+        "the fenced actuator request must self-demote the instance (mode_active → false)"
+    );
+}


### PR DESCRIPTION
## 1b (the review's highest-consequence safety residual) — actuator two-writer window during failover

`enforce_posture_routing` fenced every mutation — including `ActuatorMotion` — against the **cached** durable epoch, re-stamped only on the ~2 s heartbeat. The top-tier durable writes (federation / key-rotation) tolerate that staleness because they **also** re-check the held epoch in-transaction (`assert_epoch_held`), so a stale-cache pass is caught at commit.

But an actuator command performs **no durable write** — there's no transaction to hook a re-check onto — so it relied *solely* on the cached epoch. During failover the old primary could keep admitting actuator commands for up to ~2 s after the new primary claimed the epoch: a real two-writer window on the one path whose entire purpose is gating actuators.

## Fix

The actuator branch now reads the **live** durable epoch off the WAL **read-replica** (`call_read` → committed-snapshot visibility, off the tokio worker per P1) and compares it to the held epoch:

- `held == durable` → still the owner → admit (the inner decel gate still runs);
- `held != durable` → superseded → self-demote (`mode_active → false`) + `503`;
- read error (DB / task / disk wedge) → cannot confirm ownership → **fail closed** (also hardens the actuator path against the review's disk-wedge non-demotion case, item "1").

This closes the window to ~one command. Other mutations keep the fast **cached** check (they have the in-transaction backstop). The kernel WCET path (`validate_vehicle_command`) is untouched — the read is on the HTTP gate, which already does serde + Tower work.

## Tests (auth-free, through the assembled gate, INV-13-compliant)

- `…admits_the_owner` — `held == durable` (epoch 1) → actuator command passes.
- `…rejects_a_superseded_primary` — instance holds epoch 1, a new primary claims epoch 2 durably → the actuator command is fenced `503` **and the instance self-demotes on the same request** (no ~2 s lag).

## Verification

- `cargo clippy --workspace -- -D warnings …` — clean
- `cargo test --workspace` — all green (8 posture-gate integration tests incl. 2 new; existing cached-fence behaviour for other mutations unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_