### PR TITLE
fix(ros2): explicit sensor-data QoS on the safety-ingress subscriptions (N1)

### DIFF
--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -102,6 +102,33 @@ pub const CONTROL_CHANNEL_CAPACITY: usize = 16;
 /// different rates.
 pub const FAST_LOOP_WCET_BUDGET_US: u128 = 200;
 
+/// N1 — explicit SENSOR-DATA QoS for the high-rate safety-ingress streams
+/// (trajectory / objects / odometry / control). The RMW default
+/// (`QosProfile::default()` = Reliable + KeepLast(10)) BUFFERS up to ten samples,
+/// so after a publisher stall the adapter would drain a backlog of STALE samples
+/// before reaching the current one — the exact stale-drain hazard the
+/// actuator-OUTPUT side already forbids, here on the safety INGRESS.
+///
+/// Sensor-data discipline instead:
+///   * KeepLast(1) — keep ONLY the freshest sample; an older one is overwritten,
+///     never queued, so the validator never sees a backlog after a stall.
+///   * BestEffort — prioritize freshness over delivery-completeness AND maximise
+///     QoS compatibility: a BestEffort SUBSCRIBER accepts both Reliable and
+///     BestEffort publishers, so swapping this in never silently drops a
+///     producer's connection. The monotonic-clock staleness watchdog
+///     (`now_ms_fresh`) remains the authority on a genuine gap.
+///
+/// Deadline + Liveliness are intentionally NOT set here: a subscriber-REQUESTED
+/// deadline/lease the publisher does not OFFER rejects the QoS match and would
+/// blind the adapter — they are a publisher-coordinated follow-up. The latched
+/// map (`~/input/map`, a one-shot TransientLocal blob) and the control feedback
+/// keep their existing profiles (the map is not a high-rate stream and needs its
+/// own durability handling).
+#[inline]
+fn ingress_sensor_qos() -> r2r::QosProfile {
+    r2r::QosProfile::default().best_effort().keep_last(1)
+}
+
 #[inline]
 fn wall_clock_ms() -> u64 {
     std::time::SystemTime::now()
@@ -216,11 +243,11 @@ pub async fn run_adapter(
     // `IngressControlCommand` channel).
     let traj_stream = node.subscribe::<r2r::autoware_planning_msgs::msg::Trajectory>(
         "~/input/trajectory",
-        r2r::QosProfile::default(),
+        ingress_sensor_qos(), // N1: KeepLast(1) + BestEffort — no stale backlog after a stall
     )?;
     let obj_stream = node.subscribe::<r2r::autoware_perception_msgs::msg::PredictedObjects>(
         "~/input/objects",
-        r2r::QosProfile::default(),
+        ingress_sensor_qos(), // N1
     )?;
     // Redundant (channel-B) objects subscription — a SECOND, INDEPENDENT PredictedObjects topic
     // (e.g. a camera-only world model vs the primary radar+lidar) feeding the True-Redundancy
@@ -230,7 +257,7 @@ pub async fn run_adapter(
     let obj_b_stream = if perception_redundancy_enabled() {
         Some(node.subscribe::<r2r::autoware_perception_msgs::msg::PredictedObjects>(
             "~/input/objects_secondary",
-            r2r::QosProfile::default(),
+            ingress_sensor_qos(), // N1
         )?)
     } else {
         None
@@ -242,12 +269,12 @@ pub async fn run_adapter(
     )?;
     let odom_stream = node.subscribe::<r2r::nav_msgs::msg::Odometry>(
         "~/input/odometry",
-        r2r::QosProfile::default(),
+        ingress_sensor_qos(), // N1
     )?;
     let _ctrl_sub = node.subscribe_untyped(
         "~/input/control_cmd",
         "autoware_control_msgs/msg/Control",
-        r2r::QosProfile::default(),
+        ingress_sensor_qos(), // N1: control feedback is also a high-rate fresh-only stream
     )?;
 
     tracing::info!(


### PR DESCRIPTION
## N1 (the review's #1 robotics-correctness gap) — default QoS on safety-critical ingress

Every r2r ingress subscription used `QosProfile::default()` (**Reliable + KeepLast(10)**). KeepLast(10) **buffers up to ten samples**, so after a publisher stall the adapter drains a backlog of **stale** samples before reaching the current one — it could validate up to ten out-of-date trajectories / object sets after a freeze. That's the exact stale-drain hazard the actuator-**output** side already forbids (INV-10), here on the safety **ingress**.

## Fix

The four high-rate streams **+ control feedback** (trajectory / objects / objects_secondary / odometry / control_cmd) now use explicit sensor-data QoS via `ingress_sensor_qos()`:

```rust
r2r::QosProfile::default().best_effort().keep_last(1)
```

- **KeepLast(1)** — keep only the freshest sample; an older one is overwritten, never queued, so the validator never drains a stale backlog after a stall.
- **BestEffort** — freshness over delivery-completeness, and a BestEffort *subscriber* is QoS-compatible with **both** Reliable and BestEffort publishers, so this never silently drops a producer's connection. The monotonic-clock staleness watchdog stays the authority on a genuine gap.

## Scope / deferred

- **Deadline + Liveliness** intentionally deferred: a subscriber-requested deadline the publisher doesn't *offer* rejects the QoS match and would blind the adapter — they need publisher-side coordination (tracked follow-up).
- The **latched map** (`~/input/map`, a one-shot TransientLocal blob, not a high-rate stream) keeps its existing profile.

## Verification

- ros2-gated (`node.rs`, `#[cfg(feature = "ros2")]`) → verified by CI's **"ros2 adapter build (--features ros2)"**; the default workspace build doesn't compile it.
- The r2r 0.9.5 `QosProfile::default().best_effort().keep_last(1)` builder API was confirmed against r2r source (all three are real self-consuming builders).
- `cargo clippy --workspace -D warnings` clean; the default adapter test suite passes (node.rs gated out — no collateral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_