### PR TITLE
fix(checker): snapshot RSS reads object motion from the velocity vector, not orientation (D/C-1)

### DIFF
--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -386,8 +386,18 @@ pub fn validate_trajectory_slow_capped(
             // matters: an ONCOMING vehicle — velocity projects backward onto the ego's forward
             // axis — is a HEAD-ON closure needing the opposite-direction bound, the sum of both
             // stopping distances; a same-direction lead uses the rear-end bound, #408 Obs 3).
-            let obj_lon_v =
-                obj.velocity_mps * (obj.heading_rad - traj_point.pose.heading_rad).cos();
+            // D/C-1 (motion-source consistency): project the object's VELOCITY
+            // VECTOR `vel` into the ego frame — the SAME source the predictive and
+            // redundancy passes use — instead of the SPEED MAGNITUDE along the
+            // object's ORIENTATION (`velocity_mps × cos(heading − ego_heading)`).
+            // At ingest `velocity_mps = |vel|` but `heading_rad` is the object's
+            // FACING direction, which diverges from its MOTION direction for a
+            // cut-in / slide / yaw-rate turn — so the old form had the snapshot RSS
+            // and the predictive RSS evaluating DIFFERENT motions for the same
+            // object. Reuses the ego-frame rotation already computed for dx/dy_ego;
+            // the longitudinal bound now takes the true longitudinal closing
+            // component (matching `predictive_rss_breach`), not the full speed.
+            let obj_lon_v = cos_h * obj.vel.x_m + sin_h * obj.vel.y_m;
             let lon_required = if obj_lon_v < 0.0 {
                 // Closing magnitudes; symmetric brake_min (both in their lanes).
                 opposite_direction_safe_distance(
@@ -401,7 +411,7 @@ pub fn validate_trajectory_slow_capped(
             } else {
                 longitudinal_safe_distance(
                     traj_point.velocity_mps,
-                    obj.velocity_mps,
+                    obj_lon_v,
                     RSS_REACTION_TIME_S,
                     config.max_accel_mps2,
                     config.max_decel_mps2,
@@ -431,8 +441,12 @@ pub fn validate_trajectory_slow_capped(
             // lateral velocity = the component along the pose normal — Phase 2A assumes 0 if
             // perception lacks per-axis vel; the ego's own lateral motion is carried by the
             // trajectory poses, so containment + the abreast term cover an ego swerve.)
-            let obj_lat_vel =
-                obj.velocity_mps * (obj.heading_rad - traj_point.pose.heading_rad).sin();
+            // D/C-1: lateral component of the SAME velocity vector (ego-frame
+            // normal), mirroring `predictive_rss_breach`'s `obj_lat_v`. A car still
+            // FACING forward but MOVING laterally (a cut-in) now registers lateral
+            // motion here — the orientation-based `sin(heading − ego)` form read it
+            // as ~0 and could miss the cut-in.
+            let obj_lat_vel = -sin_h * obj.vel.x_m + cos_h * obj.vel.y_m;
             let lateral_cut_in = obj_lat_vel.abs() > RSS_LATERAL_MOTION_EPS_MPS;
             if dx_ego <= RSS_LONGITUDINAL_CONFLICT_M && (lon_unsafe || lateral_cut_in) {
                 let ego_lat_vel = 0.0; // straight-following assumption per §3

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -174,7 +174,15 @@ fn obj_at(x_m: f64, velocity_mps: f64, heading_rad: f64) -> PerceivedObject {
         pos: Point { x_m, y_m: 1.5 },
         velocity_mps,
         heading_rad,
-        vel: Point { x_m: 0.0, y_m: 0.0 },
+        // D/C-1: keep `vel` CONSISTENT with `velocity_mps`/`heading_rad` (as real
+        // ingest does: `velocity_mps = |vel|`). These scenarios use `heading_rad`
+        // as the motion direction, so the velocity vector is the speed rotated by
+        // it. The snapshot RSS now reads motion from `vel`, so leaving it zero
+        // would model a stationary object and contradict the test's intent.
+        vel: Point {
+            x_m: velocity_mps * heading_rad.cos(),
+            y_m: velocity_mps * heading_rad.sin(),
+        },
     }
 }
 
@@ -206,6 +214,62 @@ fn same_direction_lead_at_identical_gap_is_admitted() {
     assert!(
         matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
         "a same-direction lead at the same gap is admitted (direction is the only change); got {verdict:?}"
+    );
+}
+
+#[test]
+fn snapshot_rss_uses_velocity_vector_not_orientation_dc1() {
+    // D/C-1: the snapshot RSS verdict must depend on the object's MOTION (the
+    // velocity vector `vel`), NOT its FACING (`heading_rad`). Two objects with the
+    // SAME velocity vector but different orientations must get the SAME verdict.
+    // Pre-fix the verdict changed with orientation, since lateral motion was read
+    // as `velocity_mps · sin(heading − ego_heading)`.
+    let trajectory = straight_trajectory(20, 3.0, 0.1);
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+
+    let vel = Point { x_m: 0.5, y_m: -2.0 }; // mostly-lateral motion toward the ego lane
+    let pos = Point { x_m: 8.0, y_m: 3.0 };
+    let speed = vel.x_m.hypot(vel.y_m);
+    let facing_forward = PerceivedObject { id: 1, pos, velocity_mps: speed, heading_rad: 0.0, vel };
+    let facing_motion = PerceivedObject {
+        id: 1, pos, velocity_mps: speed, heading_rad: vel.y_m.atan2(vel.x_m), vel,
+    };
+
+    let v_forward = validate_trajectory_slow(
+        &trajectory, &corridor, std::slice::from_ref(&facing_forward), &cfg, None, FleetPosture::Nominal,
+    );
+    let v_motion = validate_trajectory_slow(
+        &trajectory, &corridor, std::slice::from_ref(&facing_motion), &cfg, None, FleetPosture::Nominal,
+    );
+    assert_eq!(
+        format!("{v_forward:?}"), format!("{v_motion:?}"),
+        "snapshot RSS must depend on the velocity vector, not orientation; got {v_forward:?} vs {v_motion:?}"
+    );
+}
+
+#[test]
+fn snapshot_rss_catches_a_forward_facing_lateral_cut_in_dc1() {
+    // An object FACING forward (heading 0) but MOVING laterally into the ego path
+    // must be refused. The orientation-based form read its lateral motion as ~0
+    // (sin(0) = 0) and could miss it; the vector form reads the true lateral
+    // component and catches the cut-in.
+    let ego = held_ego(10.0); // stopped ego at x=10, y=0, heading 0
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let obj = PerceivedObject {
+        id: 1,
+        pos: Point { x_m: 13.0, y_m: 1.0 }, // dx 3 (in the conflict band), small lateral gap
+        velocity_mps: 2.5,
+        heading_rad: 0.0,                    // facing forward, but...
+        vel: Point { x_m: 0.0, y_m: -2.5 },  // ...moving laterally toward the ego
+    };
+    let verdict = validate_trajectory_slow(
+        &ego, &corridor, std::slice::from_ref(&obj), &cfg, None, FleetPosture::Nominal,
+    );
+    assert_eq!(
+        verdict, TrajectoryVerdict::MRCFallback,
+        "a forward-facing object cutting in laterally must be refused (D/C-1 vector motion); got {verdict:?}"
     );
 }
 


### PR DESCRIPTION
## D/C-1 (MED, checker-independence) — motion-source split

The snapshot RSS pass derived the object's longitudinal/lateral motion from the **speed magnitude along the object's ORIENTATION** (`velocity_mps × cos/sin(heading_rad − ego_heading)`), while the predictive and redundancy passes use the velocity **vector** `vel`.

At ingest (`parse_predicted_objects`): `velocity_mps = |vel|`, but `heading_rad = quat_to_yaw(pose.orientation)` — which way the object **faces**, not which way it **moves** (the twist). For an object oriented one way but moving another — a cut-in, a slide, a yaw-rate turn — the two passes evaluated **different motions** for the same object, and the snapshot lateral check could read a real lateral cut-in as ~0 (`sin(0) = 0` for a forward-facing car) and **miss it**.

## Fix

Project the **same** vector `vel` into the ego frame, reusing the `cos_h/sin_h` already computed for `dx/dy_ego`, exactly as `predictive_rss_breach` does:

```
obj_lon_v =  cos_h·vel.x + sin_h·vel.y   (true longitudinal closing component)
obj_lat_v = −sin_h·vel.x + cos_h·vel.y   (true lateral component)
```

The longitudinal bound now takes `obj_lon_v` (the projection), matching the predictive pass. Both RSS passes now evaluate **one consistent motion source**, and the snapshot uses the true velocity (more correct than an orientation proxy — a forward-facing lateral cut-in is now caught, the **fail-closed** direction). The §4 conjunction logic is unchanged.

## D/C-2 deliberately NOT taken

Time-matching the snapshot pass would **relax** a fail-closed-safe over-conservative static-obstacle bound for availability, and the moving-object time-matching it targets is **already done** by the predictive pass (`nearest_in_time`). (Discussed and agreed.)

## Tests

- The `obj_at` helper left `vel = {0,0}` while setting `velocity_mps`/heading — the exact inconsistency this fixes; it now derives `vel` from speed×heading (as real ingest does), so the existing same-direction/oncoming tests use realistic consistent data.
- `…uses_velocity_vector_not_orientation_dc1` — same `vel`, different `heading` → same verdict.
- `…catches_a_forward_facing_lateral_cut_in_dc1` — a forward-facing object moving laterally into the path is refused.

## Verification

- `cargo clippy --workspace -- -D warnings …` — clean
- `cargo test --workspace` — all green (incl. 2 new D/C-1 regressions; all existing RSS/conjunction tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_