### PR TITLE
Intern DAG node ids as Arc<str> (review P5, full)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,12 @@ parko-core = { path = "parko/crates/parko-core" }
 # Governor-free wire schema for capture records, shared verbatim with the offline
 # collector (docs/COLLECTOR_DESIGN.md [C1]). Re-exported by `crate::capture`.
 kirra-capture-schema = { path = "crates/kirra-capture-schema" }
-serde = { version = "1.0", features = ["derive"] }
+# `rc`: enables serde's Serialize impls for `Arc`/`Rc`. Needed because
+# `FleetNodePosture` interns its node ids as `Arc<str>` (review P5) and is
+# serialized into HTTP/SSE responses. We never DESERIALIZE an `Arc`/`Rc`
+# (the feature's only sharp edge — deserialization doesn't preserve shared
+# identity), so enabling it is benign here.
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 hmac = "0.12"
 sha2 = "0.10"

--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -95,7 +95,7 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     // others is traversed once and black-hit by the rest — O(N·(N+E)) → ~O(N+E).
     // (The per-call gray cycle-detection set stays fresh inside
     // `calculate_posture_memoized`.)
-    let mut black: std::collections::HashMap<String, std::sync::Arc<FleetNodePosture>> =
+    let mut black: std::collections::HashMap<std::sync::Arc<str>, std::sync::Arc<FleetNodePosture>> =
         std::collections::HashMap::new();
     let node_postures: Vec<FleetNodePosture> = node_ids
         .iter()
@@ -322,7 +322,7 @@ mod posture_engine_tests {
 
     fn nominal(id: &str) -> FleetNodePosture {
         FleetNodePosture {
-            node_id: id.to_string(),
+            node_id: Arc::from(id),
             local_status: NodeTrustState::Trusted,
             propagated_status: FleetPosture::Nominal,
             blocked_by: vec![],
@@ -331,19 +331,19 @@ mod posture_engine_tests {
 
     fn degraded(id: &str, blocked_by: &str) -> FleetNodePosture {
         FleetNodePosture {
-            node_id: id.to_string(),
+            node_id: Arc::from(id),
             local_status: NodeTrustState::Untrusted("test".to_string()),
             propagated_status: FleetPosture::Degraded,
-            blocked_by: vec![blocked_by.to_string()],
+            blocked_by: vec![Arc::from(blocked_by)],
         }
     }
 
     fn locked(id: &str, blocked_by: &str) -> FleetNodePosture {
         FleetNodePosture {
-            node_id: id.to_string(),
+            node_id: Arc::from(id),
             local_status: NodeTrustState::Untrusted("test".to_string()),
             propagated_status: FleetPosture::LockedOut,
-            blocked_by: vec![blocked_by.to_string()],
+            blocked_by: vec![Arc::from(blocked_by)],
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -224,7 +224,7 @@ fn test_posture_locked_out_dep_propagates_locked_out_not_degraded() {
     let posture = state.calculate_posture("parent");
     assert_eq!(posture.propagated_status, FleetPosture::LockedOut,
         "LockedOut dependency must propagate LockedOut to parent, not be softened to Degraded");
-    assert!(posture.blocked_by.contains(&"dep".to_string()));
+    assert!(posture.blocked_by.iter().any(|s| &**s == "dep"));
 }
 
 // --- HTTP command classification tests ---------------------------------------

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -115,10 +115,18 @@ pub struct BackupExport {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FleetNodePosture {
-    pub node_id: String,
+    /// Interned node id (review P5). One `Arc<str>` per distinct id is minted
+    /// per whole-fleet recalc (in `recursive_calculate`) and shared by
+    /// `Arc::clone` into the gray set, the `black` memo key, this field, and
+    /// every parent's `blocked_by` — so a node depended on by K others costs one
+    /// id allocation, not K+. Serializes/compares exactly like the prior
+    /// `String` (it derefs to `str`).
+    pub node_id: Arc<str>,
     pub local_status: NodeTrustState,
     pub propagated_status: FleetPosture,
-    pub blocked_by: Vec<String>,
+    /// Interned blocking-dependency ids — each is an `Arc::clone` of that dep's
+    /// own `node_id`, not a fresh allocation (review P5).
+    pub blocked_by: Vec<Arc<str>>,
 }
 
 /// Capacity of the bounded broadcast channel for posture stream events.
@@ -439,7 +447,7 @@ impl AppState {
     }
 
     pub fn calculate_posture(&self, node_id: &str) -> FleetNodePosture {
-        let mut black: HashMap<String, Arc<FleetNodePosture>> = HashMap::new();
+        let mut black: HashMap<Arc<str>, Arc<FleetNodePosture>> = HashMap::new();
         self.calculate_posture_memoized(node_id, &mut black)
     }
 
@@ -455,14 +463,17 @@ impl AppState {
     /// `black`), so sharing `black` only ever reuses fully-resolved verdicts.
     /// The memo stores `Arc<FleetNodePosture>` so a hit is an `Arc::clone`
     /// (refcount bump) rather than a deep clone of the node id + `blocked_by`
-    /// vector (review P5, the contained part — full `Arc<str>` id interning is a
-    /// separate, larger migration).
+    /// vector. Node ids are interned as `Arc<str>` (review P5): the memo key, the
+    /// gray set, every `node_id` field and every `blocked_by` entry share one
+    /// allocation per distinct id, so a hot dependency referenced by K parents
+    /// costs one id allocation rather than K+ `String`s. `Arc<str>: Borrow<str>`
+    /// lets both maps be probed with a plain `&str` (no allocation on a lookup).
     pub fn calculate_posture_memoized(
         &self,
         node_id: &str,
-        black: &mut HashMap<String, Arc<FleetNodePosture>>,
+        black: &mut HashMap<Arc<str>, Arc<FleetNodePosture>>,
     ) -> FleetNodePosture {
-        let mut gray: HashSet<String> = HashSet::new();
+        let mut gray: HashSet<Arc<str>> = HashSet::new();
         // Recursion bound for the stack-overflow backstop below. The gray set
         // already makes a repeated node on the active path impossible without a
         // cycle, so the longest *acyclic* path is at most `nodes.len()` distinct
@@ -478,8 +489,8 @@ impl AppState {
     fn recursive_calculate(
         &self,
         node_id: &str,
-        gray: &mut HashSet<String>,
-        black: &mut HashMap<String, Arc<FleetNodePosture>>,
+        gray: &mut HashSet<Arc<str>>,
+        black: &mut HashMap<Arc<str>, Arc<FleetNodePosture>>,
         depth: usize,
         max_depth: usize,
     ) -> Arc<FleetNodePosture> {
@@ -498,10 +509,10 @@ impl AppState {
         // which is what makes sharing `black` across roots sound (P3).
         if gray.contains(node_id) {
             return Arc::new(FleetNodePosture {
-                node_id: node_id.to_string(),
+                node_id: Arc::from(node_id),
                 local_status: NodeTrustState::Unknown,
                 propagated_status: FleetPosture::LockedOut,
-                blocked_by: vec!["CYCLE_DETECTED".to_string()],
+                blocked_by: vec![Arc::from("CYCLE_DETECTED")],
             });
         }
 
@@ -518,14 +529,18 @@ impl AppState {
         // graph's trust state. Bounding by node count removes that flip entirely.
         if depth >= max_depth {
             return Arc::new(FleetNodePosture {
-                node_id: node_id.to_string(),
+                node_id: Arc::from(node_id),
                 local_status: NodeTrustState::Unknown,
                 propagated_status: FleetPosture::LockedOut,
-                blocked_by: vec!["MAX_DEPTH_EXCEEDED".to_string()],
+                blocked_by: vec![Arc::from("MAX_DEPTH_EXCEEDED")],
             });
         }
 
-        gray.insert(node_id.to_string());
+        // Mint the interned id ONCE for this node; every subsequent use (gray
+        // set, the result's `node_id`, the `black` key, and each parent's
+        // `blocked_by`) is an `Arc::clone` refcount bump, not a new allocation.
+        let id: Arc<str> = Arc::from(node_id);
+        gray.insert(Arc::clone(&id));
 
         let local_status = self.nodes
             .get(node_id)
@@ -537,18 +552,19 @@ impl AppState {
             .map(|d| d.value().clone())
             .unwrap_or_default();
 
-        let mut blocked_by: Vec<String> = Vec::new();
+        let mut blocked_by: Vec<Arc<str>> = Vec::new();
         let mut has_locked_out_dep = false;
 
         for dep_id in &deps {
             let dep_posture = self.recursive_calculate(dep_id, gray, black, depth + 1, max_depth);
             match &dep_posture.propagated_status {
                 FleetPosture::LockedOut => {
-                    blocked_by.push(dep_id.clone());
+                    // Share the dep's interned id rather than re-allocating it.
+                    blocked_by.push(Arc::clone(&dep_posture.node_id));
                     has_locked_out_dep = true;
                 }
                 FleetPosture::Degraded => {
-                    blocked_by.push(dep_id.clone());
+                    blocked_by.push(Arc::clone(&dep_posture.node_id));
                 }
                 FleetPosture::Nominal => {}
             }
@@ -563,14 +579,14 @@ impl AppState {
         };
 
         let posture = Arc::new(FleetNodePosture {
-            node_id: node_id.to_string(),
+            node_id: Arc::clone(&id),
             local_status,
             propagated_status,
             blocked_by,
         });
 
         gray.remove(node_id);
-        black.insert(node_id.to_string(), Arc::clone(&posture));
+        black.insert(id, Arc::clone(&posture));
 
         posture
     }
@@ -845,7 +861,7 @@ mod shared_memo_equivalence_tests {
     fn assert_shared_equals_per_call(app: &AppState) {
         let mut ids: Vec<String> = app.nodes.iter().map(|e| e.key().clone()).collect();
         ids.sort();
-        let mut shared: HashMap<String, Arc<FleetNodePosture>> = HashMap::new();
+        let mut shared: HashMap<Arc<str>, Arc<FleetNodePosture>> = HashMap::new();
         for id in &ids {
             let per_call = app.calculate_posture(id);
             let shared_res = app.calculate_posture_memoized(id, &mut shared);


### PR DESCRIPTION
## What

The **contained** part of P5 (#605) made the `black` memo store `Arc<FleetNodePosture>`, so a memo hit is a refcount bump rather than a deep posture clone. This finishes P5: the node **ids** are now interned as `Arc<str>` instead of re-allocated `String`s throughout the whole-fleet DAG traversal.

`recursive_calculate` mints exactly **one `Arc<str>` per distinct node id** (the first time the node is evaluated) and shares it by `Arc::clone` into:
- the gray (cycle-detection) set,
- the `black` memo key,
- the node's own `FleetNodePosture::node_id`, and
- every parent's `blocked_by` (via `Arc::clone(&dep_posture.node_id)` — reusing the dependency's already-interned id, not re-allocating it from the parent's dependency-list string).

So a hot dependency referenced by K parents now costs **one** id allocation instead of K+ `String`s. No separate interner map is needed: `Arc<str>: Borrow<str>` lets both `gray` and `black` be probed with a plain `&str`, so a lookup still allocates nothing.

## Why it's safe — representation only, semantics byte-identical

- `blocked_by` carries the same ids (a dep's `node_id` always equals the dep id as written in the parent's list).
- `Arc<str>` serializes as a JSON string **exactly like `String`**, so the `/fleet/posture` + SSE wire format is unchanged (the ros2-adapter and any HTTP consumer that deserializes the JSON are unaffected).
- The cycle/`CYCLE_DETECTED` and depth/`MAX_DEPTH_EXCEEDED` sentinels are unchanged.

`FleetNodePosture::{node_id, blocked_by}` move from `String`/`Vec<String>` → `Arc<str>`/`Vec<Arc<str>>`. The struct is serialized (HTTP/SSE) but **never deserialized**, so this needs serde's `rc` feature for the `Serialize` impl on `Arc`. We never deserialize an `Arc`/`Rc` (the feature's only sharp edge — it doesn't preserve shared identity), so enabling it is benign. Production consumers read these fields through `Deref` to `str` and needed **no change**; only three test helpers and one assertion did.

## Verification

- `cargo build --all-targets` / `cargo clippy --lib --bins` — clean, no warnings
- **736 root-crate tests pass**, 0 failed (the DAG traversal, propagation, cycle/depth, and posture-engine suites all exercise this path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_