### PR TITLE
B10: honest DenyCode for the over-horizon reject (reject, not truncate)

### DIFF
--- a/crates/kirra-core/src/containment.rs
+++ b/crates/kirra-core/src/containment.rs
@@ -214,8 +214,31 @@ pub fn validate_trajectory_containment(
     if !corridor.is_healthy() {
         return EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture);
     }
-    if trajectory.is_empty() || trajectory.len() > MAX_TRAJECTORY_HORIZON {
+    if trajectory.is_empty() {
         return EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture);
+    }
+    // Over-horizon is a DOER↔CHECKER CONTRACT violation, NOT a geometry
+    // departure — the trajectory may be entirely inside the corridor. The
+    // horizon bounds the per-call verdict WCET and every planner is built and
+    // unit-tested to emit `≤ MAX_TRAJECTORY_HORIZON` poses (`kirra_planner`'s
+    // `HORIZON` == this constant), so an over-length proposal is a misbehaving
+    // doer → fail-closed to the MRC.
+    //
+    // B10 (deliberate, reject-not-truncate): we do NOT truncate to the cap and
+    // validate the prefix. Truncation would silently ADMIT a planner that
+    // ignores the horizon contract — contrary to "the doer is untrusted; the
+    // checker is the invariant." The receding-horizon argument that *would*
+    // justify validating a prefix (the tail is re-planned next tick) presumes a
+    // well-behaved planner that simply emitted finer sampling; but the doers
+    // here are written to the cap, so an over-length proposal is anomalous, not
+    // routine. If a deployment genuinely needs a longer actionable horizon, the
+    // correct change is to raise `MAX_TRAJECTORY_HORIZON` (re-deriving the WCET
+    // budget) — keeping one honest bound — NOT to silently accept a prefix.
+    // A distinct `TrajectoryHorizonExceeded` code (vs `DrivableSpaceDeparture`)
+    // makes the failure diagnosable: an integrator sees "your planner exceeded
+    // the horizon contract", not a misleading "you left the drivable space".
+    if trajectory.len() > MAX_TRAJECTORY_HORIZON {
+        return EnforceAction::DenyBreach(DenyCode::TrajectoryHorizonExceeded);
     }
     // Footprint sanity (NaN/Inf in geometry → fail closed).
     if !footprint_is_finite(footprint) {
@@ -616,8 +639,10 @@ mod tests {
         let action = validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted);
         assert_eq!(
             action,
-            EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
-            "horizon overflow must Reject (conservative)"
+            EnforceAction::DenyBreach(DenyCode::TrajectoryHorizonExceeded),
+            "horizon overflow must Reject (B10: doer-contract violation, fail-closed) \
+             with the honest TrajectoryHorizonExceeded code — NOT DrivableSpaceDeparture \
+             (the trajectory here is entirely inside the corridor)"
         );
     }
 

--- a/crates/kirra-core/src/kinematics_contract.rs
+++ b/crates/kirra-core/src/kinematics_contract.rs
@@ -267,10 +267,28 @@ pub enum DenyCode {
     /// when the [`crate::frame_integrity::FrameTrust`] verdict is `Untrusted`.
     /// (Stage S-FI1 — behind AOU-LOCALIZATION-001.)
     ///
-    /// APPENDED LAST deliberately: the bincode variant index is the wire tag
-    /// (see `kirra-wire-client` `ClientDenyCode`), so existing indices 0–9 must
+    /// Appended after the original 0–9: the bincode variant index is the wire
+    /// tag (see `kirra-wire-client` `ClientDenyCode`), so existing indices must
     /// not shift.
     FrameIntegrityUntrusted,
+    /// Safety: SG-002 ≅ SG2. The proposed trajectory exceeds
+    /// [`crate::containment::MAX_TRAJECTORY_HORIZON`] poses — a DOER↔CHECKER
+    /// CONTRACT violation, NOT a geometric departure. The horizon is a deliberate
+    /// bound: it caps the per-call verdict WCET, and every doer (the geometric
+    /// and learned planners) is built and unit-tested to emit
+    /// `≤ MAX_TRAJECTORY_HORIZON` poses (`kirra_planner`'s `HORIZON` mirrors this
+    /// constant). An over-length proposal therefore means the untrusted doer
+    /// broke the contract, so the checker fail-closes to the MRC rather than
+    /// validating a prefix and silently masking a misbehaving planner (review
+    /// B10 — the explicit reject-not-truncate decision). Carved out of
+    /// `DrivableSpaceDeparture` so the verdict is HONEST: an over-horizon
+    /// trajectory can be entirely INSIDE the corridor, so reporting a
+    /// "drivable space departure" misdiagnosed the failure. Issued by
+    /// `containment::validate_trajectory_containment`.
+    ///
+    /// APPENDED LAST (index 11): the variant index is the bincode wire tag, so
+    /// this must stay at the end and existing indices must not shift.
+    TrajectoryHorizonExceeded,
 }
 
 impl DenyCode {
@@ -291,6 +309,7 @@ impl DenyCode {
             Self::DegradedReinitiationDenied  => "DEGRADED_REINITIATION_DENIED",
             Self::DegradedSpeedIncreaseDenied => "DEGRADED_SPEED_INCREASE_DENIED",
             Self::FrameIntegrityUntrusted     => "FRAME_INTEGRITY_UNTRUSTED",
+            Self::TrajectoryHorizonExceeded   => "TRAJECTORY_HORIZON_EXCEEDED",
         }
     }
 }

--- a/crates/kirra-governor-service/src/main.rs
+++ b/crates/kirra-governor-service/src/main.rs
@@ -95,6 +95,7 @@ fn deny_code_num(code: DenyCode) -> u32 {
         DenyCode::DegradedReinitiationDenied => 9,
         DenyCode::DegradedSpeedIncreaseDenied => 10,
         DenyCode::FrameIntegrityUntrusted => 11,
+        DenyCode::TrajectoryHorizonExceeded => 12,
     }
 }
 

--- a/crates/kirra-wire-client/src/lib.rs
+++ b/crates/kirra-wire-client/src/lib.rs
@@ -67,6 +67,7 @@ pub enum ClientDenyCode {
     DegradedReinitiationDenied,  // 8
     DegradedSpeedIncreaseDenied, // 9
     FrameIntegrityUntrusted,     // 10  (Stage S-FI1 — appended last; index = wire tag)
+    TrajectoryHorizonExceeded,   // 11  (review B10 — over-horizon doer-contract violation)
 }
 
 /// Mirror of core `EnforceAction` — variants in the SAME ORDER.
@@ -148,7 +149,7 @@ mod wire_layout {
     }
 
     #[test]
-    fn all_eleven_deny_codes_pin_their_index() {
+    fn all_twelve_deny_codes_pin_their_index() {
         // Each DenyCode must encode at its declared position. The DenyBreach
         // inner index sits at byte offset 12 (seq[0..8] + DenyBreach-tag[8..12]).
         let codes = [
@@ -163,6 +164,7 @@ mod wire_layout {
             ClientDenyCode::DegradedReinitiationDenied,
             ClientDenyCode::DegradedSpeedIncreaseDenied,
             ClientDenyCode::FrameIntegrityUntrusted, // 10 (Stage S-FI1)
+            ClientDenyCode::TrajectoryHorizonExceeded, // 11 (review B10)
         ];
         for (i, code) in codes.iter().enumerate() {
             let v = Verdict {


### PR DESCRIPTION
## The B10 question

When a planner proposes a trajectory longer than `MAX_TRAJECTORY_HORIZON` (50 poses / ~5 s), should the checker **reject** it wholesale (current) or **truncate** to the cap and validate the actionable prefix?

## Decision: keep rejecting — but make the verdict honest

I came down on **reject, not truncate**, because the evidence is decisive:

- **The horizon is a deliberate doer↔checker contract.** `kirra-planner`'s `learned.rs` hardcodes `const HORIZON: usize = 50; // == MAX_TRAJECTORY_HORIZON (KIRRA's WCET cap)`, every planner variant emits ≤50 poses, and there's a `geometric_planner_respects_horizon_cap` test. An over-length proposal means the **untrusted doer broke the contract** — exactly the fail-closed case the checker exists for.
- **Truncation would silently admit a misbehaving planner**, cutting against "the doer is untrusted; the checker is the invariant." The receding-horizon argument that *could* justify prefix-validation presumes a well-behaved planner that merely sampled finely — but these doers are written to the cap, so over-length is anomalous, not routine.
- If a deployment genuinely needs a longer actionable horizon, the right fix is to **raise `MAX_TRAJECTORY_HORIZON`** (re-deriving the WCET budget) — keeping one honest bound — not to silently accept a prefix.

> If you'd actually prefer the truncate-and-validate-prefix philosophy, this is the PR to say so — the decision is isolated here and easy to flip. (I tried to ask via the question UI but it errored, so I proceeded with the well-justified default.)

## What changed — behaviour-preserving at the verdict level

Over-horizon still collapses to `MRCFallback`; **only the diagnosis improves.** The reject was folded into `DrivableSpaceDeparture`, which is a diagnostic lie — an over-horizon trajectory can be **entirely inside the corridor**.

- New `DenyCode::TrajectoryHorizonExceeded`, **appended last** so the bincode wire tag is stable (indices 0–10 unchanged); reason token `"TRAJECTORY_HORIZON_EXCEEDED"`.
- `validate_trajectory_containment` splits the empty vs over-horizon branch; over-horizon yields the new code, with the contract + reject-not-truncate rationale documented at the site.
- Wire mirror kept in lockstep: `kirra-governor-service` `deny_code_num` (`=> 12`) and `kirra-wire-client` `ClientDenyCode` (+ the index-pinning roundtrip test, now twelve codes).

## Verification

- `cargo build --workspace` / clippy on changed crates — clean
- **kirra-core (161), kirra-ros2-adapter (138), kirra-planner, kirra-wire-client, kirra-governor-service** all pass
- **parko** (separate workspace) builds clean against the new variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_