### PR TITLE
Low-severity stragglers: B7 (worker-lock fail-fast), B8 (DAG depth bound), F3 (signum pin), B15 (Modbus width)

### DIFF
--- a/crates/kirra-core/src/kinematics_contract.rs
+++ b/crates/kirra-core/src/kinematics_contract.rs
@@ -393,6 +393,16 @@ pub fn enforce_degraded_decel_to_stop(
 
     // (c') No direction reversal through a stop while moving — commanding the
     // opposite sign at a non-trivial magnitude re-initiates motion in reverse.
+    //
+    // Order-independence / signum safety (F3): `f64::signum` maps +0.0→+1.0 and
+    // -0.0→-1.0, so a bare sign comparison is meaningless near zero. The
+    // `current > STOP_EPSILON_MPS && proposed > STOP_EPSILON_MPS` guard is what
+    // makes this sound — `reversing` is only ACTED ON when both magnitudes are
+    // firmly away from zero, where the sign is unambiguous. That makes the check
+    // independent of where it sits relative to (c)/(b): float jitter around a
+    // hold (e.g. +0.01 ↔ -0.01, both ≤ eps) can never be mistaken for a reversal,
+    // regardless of branch order. (Pinned by
+    // test_degraded_reversal_check_is_signum_order_independent.)
     let reversing = cmd.linear_velocity_mps.signum() != cmd.current_velocity_mps.signum();
     if reversing && current > STOP_EPSILON_MPS && proposed > STOP_EPSILON_MPS {
         return EnforceAction::DenyBreach(DenyCode::DegradedReinitiationDenied);
@@ -1339,5 +1349,39 @@ mod kinematics_contract_tests {
             enforce_degraded_decel_to_stop(&cmd, &mrc),
             EnforceAction::DenyBreach(DenyCode::NanInfLinearVelocity)
         );
+    }
+
+    /// F3: the reversal check (c') is sound near zero precisely because of its
+    /// both-magnitudes-above-STOP_EPSILON guard, so its verdict does not depend on
+    /// `f64::signum`'s ±0.0 convention nor on its position relative to (c)/(b):
+    ///   - a genuine reversal while firmly moving IS denied (sign flip, both > eps);
+    ///   - sign jitter inside the hold band (both ≤ eps, opposite signs incl. ±0.0)
+    ///     is NOT mistaken for a reversal — it stays an allowed standstill hold.
+    #[test]
+    fn test_degraded_reversal_check_is_signum_order_independent() {
+        let mrc = VehicleKinematicsContract::mrc_fallback_profile();
+
+        // Genuine reversal while moving: forward 2.0 → reverse -1.0 → denied.
+        assert_eq!(
+            enforce_degraded_decel_to_stop(&degraded_cmd(2.0, -1.0), &mrc),
+            EnforceAction::DenyBreach(DenyCode::DegradedReinitiationDenied),
+        );
+
+        // Sign jitter around the standstill hold (both magnitudes ≤ eps), every
+        // sign combination — none may be read as a reversal re-initiation. With
+        // both ≤ eps, (c)/(c') cannot fire and the speed is non-increasing, so the
+        // command is an allowed hold.
+        for (current, proposed) in [
+            (0.01_f64, -0.01_f64),  // +tiny → -tiny
+            (-0.01, 0.01),          // -tiny → +tiny
+            (0.0, -0.0),            // +0.0 → -0.0 (the signum ±0.0 corner exactly)
+            (-0.0, 0.0),            // -0.0 → +0.0
+        ] {
+            assert_eq!(
+                enforce_degraded_decel_to_stop(&degraded_cmd(current, proposed), &mrc),
+                EnforceAction::Allow,
+                "near-zero sign jitter ({current} → {proposed}) must hold, not deny as reversal",
+            );
+        }
     }
 }

--- a/src/posture_engine_v2.rs
+++ b/src/posture_engine_v2.rs
@@ -403,7 +403,30 @@ pub fn start_posture_engine_worker(
             let cache = cache.clone();
             let rx = Arc::clone(&rx);
             async move {
-                let mut rx = rx.lock().await;
+                // B7: the supervisor (`spawn_supervised`) awaits the prior task
+                // future to completion (`inner.await`) BEFORE re-invoking this
+                // closure, so any earlier guard is always dropped before we reach
+                // here — `try_lock` therefore succeeds on every legitimate
+                // (re)start. A CONTENDED lock would mean two worker futures are
+                // alive at once (a supervisor-contract violation); do NOT
+                // `lock().await`, which would hang this worker forever and
+                // silently stall recalculation. Fail closed instead: log and
+                // return. The supervisor treats the return as a terminal state and
+                // stops; the posture cache then goes stale and every gate denies
+                // (POSTURE_CACHE_TTL_MS). This makes the single-owner invariant
+                // explicit and fail-fast rather than an unstated drop-ordering
+                // coupling that deadlocks if it is ever broken.
+                let mut rx = match rx.try_lock() {
+                    Ok(guard) => guard,
+                    Err(_) => {
+                        tracing::error!(
+                            "posture engine worker: trigger receiver already held — \
+                             concurrent worker (supervisor invariant violation); exiting \
+                             fail-closed (cache will stale to LockedOut)"
+                        );
+                        return;
+                    }
+                };
                 loop {
                     let first = match rx.recv().await {
                         Some(t) => t,

--- a/src/protocol_adapter.rs
+++ b/src/protocol_adapter.rs
@@ -65,6 +65,23 @@ pub fn map_industrial_event_to_claim(event: &IndustrialEvent) -> Result<ActionCl
             }),
         ),
         Mapped::CmdVelSetpoint => {
+            // FAITHFUL WIDTH (#85, B15): a Modbus holding register is 16 bits on
+            // the wire, so a faithful single-register `write_register` value
+            // occupies the signed-OR-unsigned 16-bit range [-32768, 65535]. A
+            // value outside that cannot have originated from one faithful register
+            // — refuse rather than cast a corrupt `i64` into a setpoint (the
+            // binary adapters reject width mismatches the same way; #85). The
+            // kinematic envelope backstops this downstream, but refusing here
+            // keeps the decode honest instead of fabricating a magnitude from an
+            // unfaithful field. OPC-UA `write_node` carries its own (wider, typed)
+            // value and is NOT constrained to 16 bits, so the guard is scoped to
+            // Modbus.
+            if event.protocol == IndustrialProtocol::Modbus
+                && !(-32768..=65535).contains(&event.value)
+            {
+                return Err("MODBUS_REGISTER_VALUE_UNFAITHFUL_WIDTH");
+            }
+
             // FAITHFUL DECODE: the written register/node value IS the commanded
             // linear setpoint — carry it through verbatim. No synthesized 0.25
             // crawl, no invented scaling. The governor evaluates the REAL
@@ -365,6 +382,52 @@ mod no_fabricated_velocity_tests {
         assert!(!decision.allowed, "an unmappable motion command must NOT be admitted");
         assert!(decision.reason.starts_with("ADAPTER_TRANSLATION_FAILURE"));
         assert!(decision.reason.contains("UNMAPPABLE_TO_KINEMATIC_CLAIM"));
+    }
+
+    // B15: a Modbus single-register value that cannot fit a faithful 16-bit
+    // register ([-32768, 65535]) is refused, not cast into a setpoint.
+    #[test]
+    fn modbus_register_value_beyond_16_bits_is_refused() {
+        for v in [65_536_i64, 70_000, -32_769, i64::MAX, i64::MIN] {
+            assert_eq!(
+                map_industrial_event_to_claim(&modbus_event("write_register", v)).unwrap_err(),
+                "MODBUS_REGISTER_VALUE_UNFAITHFUL_WIDTH",
+                "value {v} is outside a faithful 16-bit register and must be refused",
+            );
+            let decision =
+                evaluate_industrial_event(modbus_event("write_register", v), FleetPosture::Nominal);
+            assert!(!decision.allowed, "an unfaithful-width register write must fail closed");
+            assert!(decision.reason.contains("MODBUS_REGISTER_VALUE_UNFAITHFUL_WIDTH"));
+        }
+    }
+
+    // The faithful 16-bit range (signed OR unsigned) still decodes — the width
+    // guard rejects only values that no single register could carry. The
+    // downstream kinematic envelope, not the width guard, governs magnitude.
+    #[test]
+    fn modbus_register_value_within_16_bits_still_decodes() {
+        for v in [-32_768_i64, -200, 0, 65_535] {
+            let claim = map_industrial_event_to_claim(&modbus_event("write_register", v))
+                .expect("a faithful 16-bit register value decodes");
+            assert_eq!(claim.payload["linear_x"].as_f64().unwrap(), v as f64);
+        }
+    }
+
+    // The 16-bit width guard is Modbus-scoped: an OPC-UA write_node carries its
+    // own wider typed value and must NOT be refused by the Modbus register bound.
+    #[test]
+    fn opcua_write_node_is_not_constrained_to_16_bits() {
+        let event = IndustrialEvent {
+            protocol: IndustrialProtocol::OpcUa,
+            asset_id: "asset-1".to_string(),
+            operation: "write_node".to_string(),
+            address: "ns=2;s=Speed".to_string(),
+            value: 70_000,
+            risk_class: "kinetic_write".to_string(),
+        };
+        let claim = map_industrial_event_to_claim(&event)
+            .expect("an OPC-UA node write is not bound to 16 bits");
+        assert_eq!(claim.payload["linear_x"].as_f64().unwrap(), 70_000.0);
     }
 
     // A generic OPC-UA method call has no velocity semantics → unmappable.

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -476,12 +476,22 @@ impl AppState {
         let mut gray: HashSet<Arc<str>> = HashSet::new();
         // Recursion bound for the stack-overflow backstop below. The gray set
         // already makes a repeated node on the active path impossible without a
-        // cycle, so the longest *acyclic* path is at most `nodes.len()` distinct
-        // nodes. A bound of at least that therefore CANNOT fire on a valid
-        // acyclic graph — making the depth check a pure stack-safety guard
-        // rather than a (traversal-order-dependent) semantic verdict. Floored at
+        // cycle, so the longest *acyclic* path visits at most as many DISTINCT
+        // ids as exist in the graph. That universe is NOT just `nodes` (B8):
+        // `dependency_graph` may carry edges to ids never registered as nodes (a
+        // dangling/forward dependency), and the traversal recurses into them
+        // (they resolve to `Unknown`). A chain of such unregistered ids can be
+        // LONGER than `nodes.len()`, so the old `nodes.len()` bound could fire on
+        // a perfectly acyclic graph and spuriously report LockedOut. Bound by the
+        // full id universe instead: `nodes.len() + dependency_graph.len()`
+        // over-approximates the distinct-id count (every id with an outgoing edge
+        // is a dependency_graph key; a leaf id has no edge and cannot extend a
+        // path), so the depth check CANNOT fire on a valid acyclic graph,
+        // registered or not — keeping it a pure stack-safety guard rather than a
+        // (traversal-order-dependent) semantic verdict. Floored at
         // MAX_DEPENDENCY_DEPTH so a tiny fleet still carries the documented guard.
-        let max_depth = self.nodes.len().max(MAX_DEPENDENCY_DEPTH);
+        let max_depth =
+            (self.nodes.len() + self.dependency_graph.len()).max(MAX_DEPENDENCY_DEPTH);
         let posture = self.recursive_calculate(node_id, &mut gray, black, 0, max_depth);
         (*posture).clone()
     }
@@ -517,16 +527,18 @@ impl AppState {
         }
 
         // Depth backstop — a stack-overflow guard, NOT a semantic verdict. Because
-        // the gray set bounds any acyclic path to `nodes.len()` distinct nodes and
-        // `max_depth >= nodes.len()`, this branch is unreachable on a valid acyclic
-        // graph (a cycle is always caught above first). It exists only so a
+        // the gray set bounds any acyclic path to the number of distinct ids in the
+        // graph and `max_depth` covers that whole id universe (registered nodes +
+        // dependency-graph edges, see above), this branch is unreachable on a valid
+        // acyclic graph (a cycle is always caught above first). It exists only so a
         // pathological graph degrades to fail-closed LockedOut instead of
         // overflowing the stack. The prior `depth >= MAX_DEPENDENCY_DEPTH` fixed cap
         // conflated this with graph validity: because the sentinel was not memoized,
         // a node reachable both within and beyond 10 hops resolved to LockedOut or
         // Nominal depending on which path the DFS reached it by FIRST — so the whole
         // fleet's posture depended on dependency *insertion order* rather than the
-        // graph's trust state. Bounding by node count removes that flip entirely.
+        // graph's trust state. Bounding by the id-universe count removes that flip
+        // entirely, including for chains of unregistered dependency ids (B8).
         if depth >= max_depth {
             return Arc::new(FleetNodePosture {
                 node_id: Arc::from(node_id),
@@ -917,5 +929,41 @@ mod shared_memo_equivalence_tests {
         assert_eq!(app.calculate_posture("t").propagated_status, FleetPosture::Nominal,
             "the independent node is unaffected by the cycle");
         assert_shared_equals_per_call(&app);
+    }
+
+    /// B8: a node whose dependency chain runs through ids that were never
+    /// registered (a dangling/forward dependency) is still a perfectly ACYCLIC
+    /// graph. The depth backstop must bound by the full id universe
+    /// (`nodes.len() + dependency_graph.len()`), NOT by `nodes.len()` alone —
+    /// otherwise a chain of unregistered ids longer than the node count trips
+    /// MAX_DEPTH_EXCEEDED and spuriously reports LockedOut. The verdict must be
+    /// driven by trust state (unregistered → Unknown → Degraded), not by depth.
+    #[test]
+    fn deep_chain_of_unregistered_deps_is_not_depth_locked() {
+        let app = app();
+        app.persist_and_insert_node(node("a", NodeTrustState::Trusted)).unwrap();
+
+        // a -> u1 -> u2 -> ... -> u20, none of the u* registered as nodes. With
+        // only one registered node, the old `nodes.len().max(10)` bound (=10)
+        // would trip at u10; the id-universe bound clears the whole chain. Insert
+        // straight into the in-memory graph (the edges intentionally reference
+        // unregistered ids, which a persisted FK path would not allow).
+        const N: usize = 20;
+        app.dependency_graph.insert("a".to_string(), vec!["u1".to_string()]);
+        for i in 1..N {
+            app.dependency_graph
+                .insert(format!("u{i}"), vec![format!("u{}", i + 1)]);
+        }
+
+        let posture = app.calculate_posture("a");
+        assert_eq!(
+            posture.propagated_status,
+            FleetPosture::Degraded,
+            "an acyclic chain through unregistered (Unknown) deps is Degraded, not depth-locked",
+        );
+        assert!(
+            !posture.blocked_by.iter().any(|b| b.as_ref() == "MAX_DEPTH_EXCEEDED"),
+            "the depth backstop must not fire on a valid acyclic chain of unregistered ids",
+        );
     }
 }


### PR DESCRIPTION
Closes the four remaining low-severity items from the engineering review. Each is bounded, removes a latent fragility, and is pinned with a test. **None change a verdict on a valid input** — they harden invariants that were correct-by-coincidence.

## B7 — posture-engine worker receiver lock
`src/posture_engine_v2.rs`

The supervised worker held `rx.lock().await` for its entire lifetime, relying on an **unstated coupling**: the supervisor must fully drop the prior future (releasing the guard) before the re-spawned future re-locks, or the new worker deadlocks forever and recalculation silently stalls.

Made the single-owner invariant explicit and fail-fast with `try_lock()`: it succeeds on every legitimate (re)start (the supervisor `inner.await`s the prior future to completion first), and a contended lock — two workers alive, a supervisor-contract violation — logs and returns **fail-closed** (cache stales to LockedOut via `POSTURE_CACHE_TTL_MS`) instead of hanging.

## B8 — DAG depth bound vs unregistered dependency ids
`src/verifier.rs`

`dependency_graph` can carry edges to ids never registered as nodes; the traversal recurses into them (they resolve to `Unknown`). The old `nodes.len().max(10)` depth bound assumed the longest acyclic path ≤ `nodes.len()` — **false** for such dangling chains, so a chain of unregistered ids longer than the node count tripped `MAX_DEPTH_EXCEEDED` and spuriously reported LockedOut.

Now bounds by the full id universe: `(nodes.len() + dependency_graph.len()).max(MAX_DEPENDENCY_DEPTH)` — an over-approximation of the distinct-id count, so the backstop cannot fire on any valid acyclic graph. The verdict is again driven by trust state (unregistered → Unknown → Degraded), not by depth.

**Test:** a 20-deep unregistered chain off one registered node is Degraded, not depth-locked.

## F3 — reversal-through-stop signum order-independence
`crates/kirra-core/src/kinematics_contract.rs`

The Degraded `(c')` reversal check uses `f64::signum`, whose ±0.0 convention makes a bare sign comparison meaningless near zero. The existing `current > eps && proposed > eps` both-nonzero guard **already** makes it sound and order-independent — but that reasoning was implicit. Documented it and pinned it with a test that exercises the ±0.0 corner exactly: a genuine reversal while moving is denied; sign jitter inside the hold band (incl. `+0.0 ↔ -0.0`) holds, never misread as a reversal.

## B15 — Modbus faithful register width
`src/protocol_adapter.rs`

A Modbus single-register `write_register` value was cast `i64 → f64` with no width check, unlike the faithful-by-declared-width binary adapters (#85). A holding register is 16 bits, so a faithful value occupies `[-32768, 65535]` (signed or unsigned); a value outside that cannot have come from one register — now **refused** (`MODBUS_REGISTER_VALUE_UNFAITHFUL_WIDTH` → fail closed) rather than fabricating a setpoint from a corrupt field. Scoped to Modbus (OPC-UA `write_node` carries its own wider typed value). Still envelope-backstopped downstream; this keeps the decode honest at the boundary.

**Tests:** out-of-16-bit values refused & fail closed; the faithful range still decodes; OPC-UA `write_node` is not constrained to 16 bits.

## Verification
- `kirra-verifier` (605) + `kirra-core` (167) lib tests pass
- clippy clean on both crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_