### PR TITLE
feat(contract-channel): Clause 2 GovernorContractView + odd/even generation seqlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,6 +1965,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-contract-channel"
+version = "0.1.0"
+
+[[package]]
 name = "kirra-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-core", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
+members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
 resolver = "2"
 
 [package]

--- a/crates/kirra-contract-channel/Cargo.toml
+++ b/crates/kirra-contract-channel/Cargo.toml
@@ -1,0 +1,29 @@
+# kirra-contract-channel — the Clause 2 cross-partition boundary contract.
+#
+# ADR-0006 Clause 2 + HVCHAN-001 (docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md):
+# across the guest<->host partition boundary the transport is NOT a library — it
+# is a FROZEN, versioned, fixed-size #[repr(C)] layout over hypervisor shared
+# memory. This crate is that layout + its normative write/read trust chain.
+#
+# Deliberately minimal-TCB: `no_std`, ZERO dependencies, `#![forbid(unsafe_code)]`.
+# "A frozen layout imports a struct definition" — so this crate is a struct
+# definition plus the seqlock/validation logic, and nothing else. The only place
+# memory-mapping `unsafe` may live is the target integration shim that binds the
+# `ContractReader`/`ContractWriter` traits to the hypervisor-mapped region — that
+# shim is the ADR-0006 Clause 3 integration boundary, OUTSIDE this crate.
+[package]
+name = "kirra-contract-channel"
+version = "0.1.0"
+edition = "2021"
+description = "Frozen #[repr(C)] cross-partition governor contract view + odd/even generation seqlock (ADR-0006 Clause 2 / HVCHAN-001)"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+
+[dependencies]
+# INTENTIONALLY EMPTY. No crypto, no CRC crate, no transport. The CRC-32/IEEE
+# and the canonical little-endian image are implemented in-crate; digest +
+# signing reuse the verifier's EXISTING Ed25519/SHA-256 machinery at the
+# integration seam (HVCHAN-001 §3 steps 5-6: "no new crypto primitives").
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/crates/kirra-contract-channel/src/crc.rs
+++ b/crates/kirra-contract-channel/src/crc.rs
@@ -1,0 +1,44 @@
+//! CRC-32/IEEE (reflected, polynomial `0xEDB88320`) — the integrity check over
+//! the command payload (HVCHAN-001 §3 step 4).
+//!
+//! Implemented in-crate (no dependency) to keep the boundary-contract TCB a
+//! struct definition plus this arithmetic. Standard zlib/Ethernet CRC-32: init
+//! `0xFFFFFFFF`, reflected input/output, final XOR `0xFFFFFFFF`.
+
+/// CRC-32/IEEE over `data`. Matches zlib `crc32` / Ethernet FCS.
+pub fn crc32_ieee(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    let mut i = 0;
+    while i < data.len() {
+        crc ^= data[i] as u32;
+        let mut bit = 0;
+        while bit < 8 {
+            // Reflected: shift right, conditionally xor the reflected polynomial.
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+            bit += 1;
+        }
+        i += 1;
+    }
+    !crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_answer_vectors() {
+        // Canonical CRC-32/IEEE check values.
+        assert_eq!(crc32_ieee(b""), 0x0000_0000);
+        assert_eq!(crc32_ieee(b"123456789"), 0xCBF4_3926);
+        assert_eq!(crc32_ieee(b"The quick brown fox jumps over the lazy dog"), 0x414F_A339);
+    }
+
+    #[test]
+    fn single_bit_flip_changes_crc() {
+        let a = crc32_ieee(b"steer:1.5");
+        let b = crc32_ieee(b"steer:1.6");
+        assert_ne!(a, b);
+    }
+}

--- a/crates/kirra-contract-channel/src/lib.rs
+++ b/crates/kirra-contract-channel/src/lib.rs
@@ -1,0 +1,67 @@
+//! # kirra-contract-channel — the Clause 2 cross-partition boundary contract
+//!
+//! This crate realizes **ADR-0006 Clause 2** and the **HVCHAN-001** specification
+//! (`docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md`): the guest↔host governor
+//! contract channel is **not a transport library** but a **frozen, versioned,
+//! fixed-size `#[repr(C)]` layout over hypervisor shared memory**, written by an
+//! untrusted guest publisher and validated byte-by-byte by the governor, which
+//! **fails closed** on every fault.
+//!
+//! ## What's here
+//!
+//! - [`GovernorContractView`] — the frozen `#[repr(C)]`, pointer-free layout
+//!   (HVCHAN-001 §2). Its byte layout is pinned by compile-time assertions — the
+//!   **freeze IS the safety claim** (the `kinematics_contract.rs` talisman
+//!   discipline). Any change to a field, size, order, or [`MAX_COMMAND_BYTES`]
+//!   requires a new [`LAYOUT_VERSION`], never an in-place edit.
+//! - [`ContractReader`] / [`ContractWriter`] + [`read_coherent_snapshot`] /
+//!   [`publish`] — the **odd/even generation seqlock** (HVCHAN-001 §3 steps 2-3).
+//!   These are generic over the region traits so the **target binds them to the
+//!   hypervisor-mapped region** (the only place memory-mapping `unsafe` lives —
+//!   the ADR-0006 Clause 3 integration shim, *outside* this crate) while the
+//!   protocol logic stays `no_std` + `#![forbid(unsafe_code)]` and host-testable.
+//! - [`validate`] + [`ContractFault`] — the snapshot validation pipeline
+//!   (bounds → CRC → judge) and the fail-closed failure taxonomy (HVCHAN-001 §4).
+//! - [`AcceptedWatermark`] — the monotonic generation/sequence gate
+//!   (`<= last_accepted ⇒ reject`; HVCHAN-001 §3.1), the same rule the #273
+//!   iceoryx2 spike judge and the #79 epoch fence use.
+//!
+//! ## What's deliberately NOT here
+//!
+//! No transport, no crypto primitive, no allocator. The release-token **digest**
+//! is computed over [`GovernorContractView::canonical_image`] by the verifier's
+//! **existing** SHA-256 + Ed25519 machinery at the integration seam (HVCHAN-001
+//! §3 steps 5-6: *"no new crypto primitives are introduced"*). This crate only
+//! produces the **exact validated bytes** that digest signs.
+//!
+//! ## Boundary clock domain (HVCHAN-001 §5, R-HV-3)
+//!
+//! All timestamp/deadline fields are defined in the **boundary clock domain**
+//! (the hypervisor-provided shared monotonic source). [`validate`] takes a
+//! `now_nanos` that the caller MUST read from that same domain — the governor
+//! validation path **never** reads wall/PTP time. Mixing domains is a defined
+//! fault class (the caller's responsibility; see `AOU-TIMESYNC-001`).
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+#[cfg(test)]
+extern crate std;
+
+mod crc;
+mod seqlock;
+mod validate;
+mod view;
+
+pub use crc::crc32_ieee;
+pub use seqlock::{publish, read_coherent_snapshot, ContractReader, ContractWriter, SnapshotFault};
+pub use validate::{validate, AcceptedWatermark, ContractFault};
+pub use view::{
+    GovernorContractView, CANONICAL_IMAGE_LEN, LAYOUT_VERSION, MAGIC, MAX_COMMAND_BYTES,
+};
+
+/// Bounded seqlock-read retry budget (HVCHAN-001 §3 step 3). Retry-exhaustion —
+/// a persistently odd generation or a churning writer — is **fail-closed reject**
+/// ([`SnapshotFault::RetryExhausted`]), never a stale-data accept. DESIGN-INTENT
+/// bound; the on-target figure is #274 work.
+pub const MAX_SNAPSHOT_RETRIES: u32 = 8;

--- a/crates/kirra-contract-channel/src/seqlock.rs
+++ b/crates/kirra-contract-channel/src/seqlock.rs
@@ -1,0 +1,295 @@
+//! The odd/even generation seqlock (HVCHAN-001 §3 steps 2-3).
+//!
+//! The publisher marks `generation` **odd** while a write is in progress and
+//! **even** on commit; the governor obtains a **coherent owned snapshot** by
+//! reading the generation, copying the whole struct into partition-local memory,
+//! and re-reading the generation — accepting only if it is **unchanged and even**.
+//! The governor validates **only its local copy**, never the live shared region
+//! (this, with the read-only mapping of §5, is the torn-read defense). Retries
+//! are **bounded**; retry-exhaustion is **fail-closed reject**.
+//!
+//! Both directions are generic over the region traits so the **target** binds
+//! them to the hypervisor-mapped region (where the mapping `unsafe` lives — the
+//! ADR-0006 Clause 3 integration shim, *outside* this crate), while the protocol
+//! itself stays `#![forbid(unsafe_code)]` and host-testable against atomics.
+
+use crate::view::GovernorContractView;
+
+/// Read access to the shared contract region (the governor side).
+///
+/// Implementors MUST make [`load_generation`](Self::load_generation) an
+/// acquire-ordered read of the seqlock counter, so that a successful
+/// generation re-read also makes the copied body bytes visible.
+pub trait ContractReader {
+    /// Acquire-load the seqlock `generation` counter.
+    fn load_generation(&self) -> u64;
+    /// Copy the current region bytes into a partition-local [`GovernorContractView`].
+    /// The `generation` field of the returned value is not trusted; the caller
+    /// uses the separately-loaded counter for coherence.
+    fn copy_view(&self) -> GovernorContractView;
+}
+
+/// Write access to the shared contract region (the guest publisher side).
+pub trait ContractWriter {
+    /// Release-store the seqlock `generation` counter.
+    fn store_generation(&self, generation: u64);
+    /// Store every body field **except** `generation` (the [`publish`] driver
+    /// owns the generation transitions). Relaxed stores are sufficient — the
+    /// subsequent release-store of the even generation publishes them.
+    fn store_body(&self, view: &GovernorContractView);
+}
+
+/// Why a coherent snapshot could not be obtained within the retry budget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SnapshotFault {
+    /// The generation was persistently odd, or churned across every copy attempt,
+    /// up to `max_retries`. **Fail-closed reject** (HVCHAN-001 §4,
+    /// contract-discipline) — never a stale-data accept.
+    RetryExhausted,
+}
+
+/// Obtain a coherent owned snapshot (HVCHAN-001 §3 step 3).
+///
+/// Returns the local copy iff the generation was **even before the copy and
+/// unchanged after** it. An odd generation (write in progress) or a generation
+/// that moved across the copy (torn) costs a retry; exhausting `max_retries`
+/// fails closed with [`SnapshotFault::RetryExhausted`].
+pub fn read_coherent_snapshot<R: ContractReader>(
+    reader: &R,
+    max_retries: u32,
+) -> Result<GovernorContractView, SnapshotFault> {
+    let mut failures: u32 = 0;
+    loop {
+        let g1 = reader.load_generation();
+        if g1 & 1 == 0 {
+            // Even: no write in progress as of this read. Copy, then re-check.
+            let view = reader.copy_view();
+            let g2 = reader.load_generation();
+            if g2 == g1 {
+                // Unchanged and even ⇒ the copy did not race a writer.
+                return Ok(view);
+            }
+        }
+        // Odd, or the generation moved across the copy ⇒ torn / in-progress.
+        if failures >= max_retries {
+            return Err(SnapshotFault::RetryExhausted);
+        }
+        failures += 1;
+    }
+}
+
+/// Publish `body` under the odd/even seqlock (HVCHAN-001 §3 step 2).
+///
+/// `committed_gen` is the current committed (even) generation; returns the new
+/// committed (even) generation. The body's own `generation` field is ignored —
+/// this driver owns the counter.
+///
+/// Sequence: `generation := committed_gen+1` (odd, write begins) → body →
+/// `generation := committed_gen+2` (even, commit). A reader that observes the
+/// odd value, or a generation change across its copy, retries.
+pub fn publish<W: ContractWriter>(
+    writer: &W,
+    committed_gen: u64,
+    body: &GovernorContractView,
+) -> u64 {
+    let writing = committed_gen.wrapping_add(1); // odd: write in progress
+    writer.store_generation(writing);
+    writer.store_body(body);
+    let next = committed_gen.wrapping_add(2); // even: commit
+    writer.store_generation(next);
+    next
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::view::{GovernorContractView, MAX_COMMAND_BYTES};
+    use core::cell::Cell;
+    use core::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
+    use std::sync::Arc;
+    use std::{thread, vec::Vec};
+
+    // ---- deterministic mocks for the snapshot loop ------------------------
+
+    /// A reader whose `load_generation` replays a scripted sequence; `copy_view`
+    /// returns a fixed view. Lets us drive the seqlock loop precisely.
+    struct ScriptedReader {
+        gens: Vec<u64>,
+        idx: Cell<usize>,
+        view: GovernorContractView,
+    }
+    impl ContractReader for ScriptedReader {
+        fn load_generation(&self) -> u64 {
+            let i = self.idx.get();
+            let g = self.gens[i.min(self.gens.len() - 1)];
+            self.idx.set(i + 1);
+            g
+        }
+        fn copy_view(&self) -> GovernorContractView {
+            self.view
+        }
+    }
+
+    fn any_view() -> GovernorContractView {
+        GovernorContractView::new_command(2, 1, 0, 0, b"x").unwrap()
+    }
+
+    #[test]
+    fn stable_even_generation_yields_a_snapshot() {
+        // g1 even, g2 == g1 ⇒ coherent on the first attempt.
+        let r = ScriptedReader { gens: std::vec![4, 4], idx: Cell::new(0), view: any_view() };
+        assert_eq!(read_coherent_snapshot(&r, 8), Ok(any_view()));
+    }
+
+    #[test]
+    fn persistently_odd_generation_exhausts_and_fails_closed() {
+        // Always odd ⇒ a write never commits ⇒ fail-closed after the budget.
+        let r = ScriptedReader { gens: std::vec![3], idx: Cell::new(0), view: any_view() };
+        assert_eq!(read_coherent_snapshot(&r, 4), Err(SnapshotFault::RetryExhausted));
+    }
+
+    #[test]
+    fn generation_change_across_copy_is_treated_as_torn() {
+        // First attempt: g1=4 (even), g2=6 (writer committed during copy) ⇒ torn,
+        // retry. Second attempt: g1=6, g2=6 ⇒ coherent.
+        let r = ScriptedReader {
+            gens: std::vec![4, 6, 6, 6],
+            idx: Cell::new(0),
+            view: any_view(),
+        };
+        assert_eq!(read_coherent_snapshot(&r, 8), Ok(any_view()));
+    }
+
+    #[test]
+    fn odd_then_even_recovers_within_budget() {
+        // g1=3 (odd, skip+retry), then g1=8,g2=8 (coherent).
+        let r = ScriptedReader { gens: std::vec![3, 8, 8], idx: Cell::new(0), view: any_view() };
+        assert_eq!(read_coherent_snapshot(&r, 8), Ok(any_view()));
+    }
+
+    // ---- a real concurrent region backed by atomics -----------------------
+
+    /// Host stand-in for the hypervisor-mapped region: every field is an atomic,
+    /// so concurrent reader/writer access is well-defined with no `unsafe`. The
+    /// generation carries the ordering (Acquire/Release); body fields are Relaxed.
+    struct AtomicRegion {
+        generation: AtomicU64,
+        layout_version: AtomicU32,
+        magic: AtomicU32,
+        sequence: AtomicU64,
+        publication_nanos: AtomicU64,
+        deadline_nanos: AtomicU64,
+        crc32: AtomicU32,
+        command_len: AtomicU32,
+        command: [AtomicU8; MAX_COMMAND_BYTES],
+    }
+
+    impl AtomicRegion {
+        fn new() -> Self {
+            Self {
+                generation: AtomicU64::new(0),
+                layout_version: AtomicU32::new(0),
+                magic: AtomicU32::new(0),
+                sequence: AtomicU64::new(0),
+                publication_nanos: AtomicU64::new(0),
+                deadline_nanos: AtomicU64::new(0),
+                crc32: AtomicU32::new(0),
+                command_len: AtomicU32::new(0),
+                command: core::array::from_fn(|_| AtomicU8::new(0)),
+            }
+        }
+    }
+
+    impl ContractReader for AtomicRegion {
+        fn load_generation(&self) -> u64 {
+            self.generation.load(Ordering::Acquire)
+        }
+        fn copy_view(&self) -> GovernorContractView {
+            let mut command = [0u8; MAX_COMMAND_BYTES];
+            for (i, slot) in command.iter_mut().enumerate() {
+                *slot = self.command[i].load(Ordering::Relaxed);
+            }
+            GovernorContractView {
+                layout_version: self.layout_version.load(Ordering::Relaxed),
+                magic: self.magic.load(Ordering::Relaxed),
+                generation: self.generation.load(Ordering::Relaxed),
+                sequence: self.sequence.load(Ordering::Relaxed),
+                publication_nanos: self.publication_nanos.load(Ordering::Relaxed),
+                deadline_nanos: self.deadline_nanos.load(Ordering::Relaxed),
+                crc32: self.crc32.load(Ordering::Relaxed),
+                command_len: self.command_len.load(Ordering::Relaxed),
+                command,
+            }
+        }
+    }
+
+    impl ContractWriter for AtomicRegion {
+        fn store_generation(&self, generation: u64) {
+            self.generation.store(generation, Ordering::Release);
+        }
+        fn store_body(&self, view: &GovernorContractView) {
+            // Every field EXCEPT generation. Written field-by-field so a reader
+            // that ignored the seqlock could observe a torn mix — which the
+            // seqlock is precisely what prevents.
+            self.layout_version.store(view.layout_version, Ordering::Relaxed);
+            self.magic.store(view.magic, Ordering::Relaxed);
+            self.sequence.store(view.sequence, Ordering::Relaxed);
+            self.publication_nanos.store(view.publication_nanos, Ordering::Relaxed);
+            self.deadline_nanos.store(view.deadline_nanos, Ordering::Relaxed);
+            self.crc32.store(view.crc32, Ordering::Relaxed);
+            self.command_len.store(view.command_len, Ordering::Relaxed);
+            for (i, b) in view.command.iter().enumerate() {
+                self.command[i].store(*b, Ordering::Relaxed);
+            }
+        }
+    }
+
+    #[test]
+    fn concurrent_writer_and_reader_never_yield_a_torn_snapshot() {
+        // The publisher writes, for sequence s, a view whose fields satisfy a
+        // cross-field invariant: deadline == s*1000, publication == s, and the
+        // command's CRC matches `crc32`. A torn snapshot (a mix of two writes)
+        // would break the invariant; the seqlock must guarantee every coherent
+        // snapshot the reader accepts is internally consistent.
+        let region = Arc::new(AtomicRegion::new());
+        const N: u64 = 20_000;
+
+        let w = Arc::clone(&region);
+        let writer = thread::spawn(move || {
+            let mut committed = 0u64;
+            for s in 1..=N {
+                let cmd = s.to_le_bytes();
+                let body =
+                    GovernorContractView::new_command(0, s, s, s * 1000, &cmd).unwrap();
+                committed = publish(&*w, committed, &body);
+            }
+        });
+
+        let r = Arc::clone(&region);
+        let reader = thread::spawn(move || {
+            let mut seen = 0u64;
+            // Read until the writer has published the last sequence.
+            loop {
+                if let Ok(v) = read_coherent_snapshot(&*r, 64) {
+                    if v.sequence != 0 {
+                        // Cross-field consistency: no torn mix of two writes.
+                        assert_eq!(v.deadline_nanos, v.sequence * 1000, "torn: deadline");
+                        assert_eq!(v.publication_nanos, v.sequence, "torn: publication");
+                        assert_eq!(
+                            v.crc32,
+                            crate::crc::crc32_ieee(&v.sequence.to_le_bytes()),
+                            "torn: command vs crc"
+                        );
+                        seen = v.sequence;
+                    }
+                }
+                if seen == N {
+                    break;
+                }
+            }
+        });
+
+        writer.join().unwrap();
+        reader.join().unwrap();
+    }
+}

--- a/crates/kirra-contract-channel/src/validate.rs
+++ b/crates/kirra-contract-channel/src/validate.rs
@@ -1,0 +1,251 @@
+//! Snapshot validation (HVCHAN-001 §3 step 4) and the fail-closed fault taxonomy
+//! (§4). Runs on the governor's **local owned snapshot**, never the live region.
+//!
+//! Check order is fixed (§2.2 + §3 step 4): `layout_version` → `magic` → bounds
+//! → CRC → `sequence` monotonic → `generation` monotonic → deadline. The first
+//! failing check returns its [`ContractFault`]; there is no fall-through accept.
+//!
+//! This crate owns the **contract-discipline** and **judge** rows of the §4
+//! table. The **hypervisor** rows (read-only mapping R-HV-1, clock-skew bound,
+//! publisher-silent liveness) are enforced outside this crate; in particular the
+//! caller MUST pass a `now_nanos` already in the **boundary clock domain**
+//! (R-HV-3) — this path never reads wall/PTP time, and a cross-domain timestamp
+//! is the integrator's `AOU-TIMESYNC-001` obligation, not a check here.
+
+use crate::crc::crc32_ieee;
+use crate::view::{GovernorContractView, LAYOUT_VERSION, MAGIC, MAX_COMMAND_BYTES};
+
+/// A fail-closed validation failure (HVCHAN-001 §4). Every variant is a reject.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContractFault {
+    /// `layout_version` is not one this build was certified against. Checked
+    /// FIRST; the snapshot is **not** parsed further. (contract-discipline)
+    LayoutVersionMismatch { found: u32, expected: u32 },
+    /// Channel sentinel wrong — gross corruption / wrong region. (contract-discipline)
+    MagicMismatch { found: u32 },
+    /// `command_len` exceeds [`MAX_COMMAND_BYTES`]. (contract-discipline)
+    CommandLenOversize { found: u32, max: u32 },
+    /// CRC over `command[..command_len]` does not match `crc32`. (contract-discipline)
+    CrcMismatch { found: u32, computed: u32 },
+    /// `sequence <= last_accepted` — replay (equal) or regress (lower). (judge)
+    SequenceRegressOrReplay { found: u64, last_accepted: u64 },
+    /// `generation <= last_accepted` — replay/regress of the seqlock counter. (judge)
+    GenerationRegressOrReplay { found: u64, last_accepted: u64 },
+    /// `now_nanos > deadline_nanos` (boundary clock domain). (judge)
+    DeadlineExpired { now: u64, deadline: u64 },
+}
+
+/// The monotonic high-water mark: the `(generation, sequence)` of the last
+/// **accepted** command. Both advance only on a Fresh (accepted) verdict, so a
+/// rejected snapshot can never poison it (HVCHAN-001 §3.1; the #273 spike rule).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AcceptedWatermark {
+    last_generation: u64,
+    last_sequence: u64,
+    initialized: bool,
+}
+
+impl AcceptedWatermark {
+    /// A fresh watermark with nothing accepted yet (the first valid command of
+    /// any `(generation, sequence)` is admissible).
+    pub const fn new() -> Self {
+        Self { last_generation: 0, last_sequence: 0, initialized: false }
+    }
+
+    /// Record `view` as the newest accepted command. Call this **only** after
+    /// [`validate`] returns `Ok` for the same view.
+    pub fn record(&mut self, view: &GovernorContractView) {
+        self.last_generation = view.generation;
+        self.last_sequence = view.sequence;
+        self.initialized = true;
+    }
+
+    /// The last accepted `(generation, sequence)`, or `None` if nothing has been
+    /// accepted yet.
+    pub fn last(&self) -> Option<(u64, u64)> {
+        if self.initialized {
+            Some((self.last_generation, self.last_sequence))
+        } else {
+            None
+        }
+    }
+}
+
+/// Validate a coherent local snapshot against the contract and the monotonic
+/// watermark. `now_nanos` MUST be in the boundary clock domain (R-HV-3).
+///
+/// Returns `Ok(())` iff every check passes; otherwise the first [`ContractFault`].
+/// On `Ok`, the caller advances the watermark via [`AcceptedWatermark::record`]
+/// and proceeds to digest + sign (HVCHAN-001 §3 steps 5-6).
+pub fn validate(
+    view: &GovernorContractView,
+    now_nanos: u64,
+    watermark: &AcceptedWatermark,
+) -> Result<(), ContractFault> {
+    // 1. Version prefix — checked before any other field is interpreted (§2.2).
+    if view.layout_version != LAYOUT_VERSION {
+        return Err(ContractFault::LayoutVersionMismatch {
+            found: view.layout_version,
+            expected: LAYOUT_VERSION,
+        });
+    }
+    // 2. Sentinel.
+    if view.magic != MAGIC {
+        return Err(ContractFault::MagicMismatch { found: view.magic });
+    }
+    // 3. Bounds — before the CRC reads `command[..len]`.
+    let len = view.command_len as usize;
+    if len > MAX_COMMAND_BYTES {
+        return Err(ContractFault::CommandLenOversize {
+            found: view.command_len,
+            max: MAX_COMMAND_BYTES as u32,
+        });
+    }
+    // 4. Integrity.
+    let computed = crc32_ieee(&view.command[..len]);
+    if view.crc32 != computed {
+        return Err(ContractFault::CrcMismatch { found: view.crc32, computed });
+    }
+    // 5/6. Monotonic generation + sequence (`<= last_accepted ⇒ reject`; §3.1).
+    if let Some((last_gen, last_seq)) = watermark.last() {
+        if view.sequence <= last_seq {
+            return Err(ContractFault::SequenceRegressOrReplay {
+                found: view.sequence,
+                last_accepted: last_seq,
+            });
+        }
+        if view.generation <= last_gen {
+            return Err(ContractFault::GenerationRegressOrReplay {
+                found: view.generation,
+                last_accepted: last_gen,
+            });
+        }
+    }
+    // 7. Freshness against the absolute deadline (boundary domain).
+    if now_nanos > view.deadline_nanos {
+        return Err(ContractFault::DeadlineExpired { now: now_nanos, deadline: view.deadline_nanos });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A well-formed view: generation 2 (even), sequence 5, deadline far ahead.
+    fn good() -> GovernorContractView {
+        GovernorContractView::new_command(2, 5, 100, 10_000, b"steer:1.5").unwrap()
+    }
+
+    #[test]
+    fn well_formed_view_with_fresh_watermark_is_accepted() {
+        assert_eq!(validate(&good(), 1_000, &AcceptedWatermark::new()), Ok(()));
+    }
+
+    #[test]
+    fn layout_version_is_checked_first() {
+        let mut v = good();
+        v.layout_version = 999;
+        // Even with everything else also wrong, the version is the reported fault.
+        v.magic = 0;
+        assert_eq!(
+            validate(&v, 1_000, &AcceptedWatermark::new()),
+            Err(ContractFault::LayoutVersionMismatch { found: 999, expected: LAYOUT_VERSION })
+        );
+    }
+
+    #[test]
+    fn wrong_magic_rejects() {
+        let mut v = good();
+        v.magic = 0xDEAD_BEEF;
+        assert_eq!(
+            validate(&v, 1_000, &AcceptedWatermark::new()),
+            Err(ContractFault::MagicMismatch { found: 0xDEAD_BEEF })
+        );
+    }
+
+    #[test]
+    fn oversize_command_len_rejects_before_crc() {
+        let mut v = good();
+        v.command_len = (MAX_COMMAND_BYTES + 1) as u32;
+        assert_eq!(
+            validate(&v, 1_000, &AcceptedWatermark::new()),
+            Err(ContractFault::CommandLenOversize {
+                found: (MAX_COMMAND_BYTES + 1) as u32,
+                max: MAX_COMMAND_BYTES as u32,
+            })
+        );
+    }
+
+    #[test]
+    fn corrupt_command_fails_crc() {
+        let mut v = good();
+        v.command[0] ^= 0xFF; // flip a payload byte; crc32 field now stale
+        match validate(&v, 1_000, &AcceptedWatermark::new()) {
+            Err(ContractFault::CrcMismatch { .. }) => {}
+            other => panic!("expected CrcMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn equal_sequence_is_replay_reject() {
+        let mut wm = AcceptedWatermark::new();
+        wm.record(&good()); // last = (gen 2, seq 5)
+        // Same sequence, higher generation → still a replay on sequence.
+        let mut v = good();
+        v.generation = 4;
+        v.crc32 = crate::crc::crc32_ieee(v.validated_command().unwrap());
+        assert_eq!(
+            validate(&v, 1_000, &wm),
+            Err(ContractFault::SequenceRegressOrReplay { found: 5, last_accepted: 5 })
+        );
+    }
+
+    #[test]
+    fn equal_generation_with_newer_sequence_is_generation_replay() {
+        let mut wm = AcceptedWatermark::new();
+        wm.record(&good()); // last = (gen 2, seq 5)
+        let mut v = good();
+        v.sequence = 6; // newer sequence passes its check…
+        v.generation = 2; // …but the generation regressed/equalled
+        v.crc32 = crate::crc::crc32_ieee(v.validated_command().unwrap());
+        assert_eq!(
+            validate(&v, 1_000, &wm),
+            Err(ContractFault::GenerationRegressOrReplay { found: 2, last_accepted: 2 })
+        );
+    }
+
+    #[test]
+    fn strictly_newer_generation_and_sequence_is_accepted() {
+        let mut wm = AcceptedWatermark::new();
+        wm.record(&good());
+        let mut v = good();
+        v.sequence = 6;
+        v.generation = 4;
+        v.crc32 = crate::crc::crc32_ieee(v.validated_command().unwrap());
+        assert_eq!(validate(&v, 1_000, &wm), Ok(()));
+    }
+
+    #[test]
+    fn expired_deadline_rejects_now_strictly_after() {
+        let v = good(); // deadline 10_000
+        assert_eq!(validate(&v, 10_000, &AcceptedWatermark::new()), Ok(()), "now == deadline is fresh");
+        assert_eq!(
+            validate(&v, 10_001, &AcceptedWatermark::new()),
+            Err(ContractFault::DeadlineExpired { now: 10_001, deadline: 10_000 })
+        );
+    }
+
+    #[test]
+    fn rejected_snapshot_does_not_advance_the_watermark() {
+        let mut wm = AcceptedWatermark::new();
+        wm.record(&good());
+        let before = wm;
+        let mut replay = good(); // seq 5 == last → rejected
+        replay.generation = 8;
+        replay.crc32 = crate::crc::crc32_ieee(replay.validated_command().unwrap());
+        let _ = validate(&replay, 1_000, &wm);
+        // validate() does not mutate the watermark; the caller only records on Ok.
+        assert_eq!(wm, before);
+    }
+}

--- a/crates/kirra-contract-channel/src/view.rs
+++ b/crates/kirra-contract-channel/src/view.rs
@@ -1,0 +1,240 @@
+//! The frozen `#[repr(C)]` cross-partition layout (HVCHAN-001 §2).
+//!
+//! **Layout stability IS the safety claim.** The compile-time assertions at the
+//! bottom of this file pin every field offset, the total size, and the alignment;
+//! they fail the build if the layout drifts. Any intended change is a NEW
+//! [`LAYOUT_VERSION`] with re-validation, never an in-place edit (HVCHAN-001 §2.4).
+
+use crate::crc::crc32_ieee;
+
+/// Command-payload capacity, fixed at the layout version (HVCHAN-001 §2.2,
+/// design-intent 64–128 B). Growing it is a new [`LAYOUT_VERSION`], never an
+/// in-place edit. The command rides **by value** (a fixed array): pointers do
+/// not cross a partition boundary (HVCHAN-001 §2.1).
+pub const MAX_COMMAND_BYTES: usize = 128;
+
+/// Layout version held at **offset 0** so any reader can locate it regardless of
+/// how later fields evolve (a versioned-prefix discipline, like a file magic). A
+/// reader that does not recognize the version **rejects** — it never best-effort
+/// parses a layout it was not built and certified against (HVCHAN-001 §2.2, §4).
+pub const LAYOUT_VERSION: u32 = 1;
+
+/// Fixed channel sentinel (ASCII `"KGCV"` — Kirra Governor Contract View). A
+/// wrong sentinel is a gross-corruption / wrong-region signal ⇒ reject.
+pub const MAGIC: u32 = 0x4B47_4356;
+
+/// Length of [`GovernorContractView::canonical_image`] — the little-endian wire
+/// image the release-token digest is computed over. Equals
+/// `size_of::<GovernorContractView>()` because the layout has **no padding holes**
+/// (the widest-first design); see the assertions below.
+pub const CANONICAL_IMAGE_LEN: usize = 48 + MAX_COMMAND_BYTES;
+
+/// Cross-partition governor contract view — **FROZEN once certified** (HVCHAN-001
+/// §2.4). `#[repr(C)]`, fixed size, pointer-free; mapped **read-only** into the
+/// governor partition. All multi-byte integers are little-endian on the wire.
+///
+/// Every field's writer is the **guest publisher** and its checker is the
+/// **governor**; no field is trusted because the guest set it (HVCHAN-001 §2.3).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GovernorContractView {
+    // --- version-discovery prefix (STABLE across ALL layout versions) ---
+    /// Layout version (offset 0). Checked FIRST, before any other field is
+    /// interpreted — a mismatch ⇒ reject.
+    pub layout_version: u32,
+    /// Channel sentinel. Pairs with `layout_version` to fill 8 bytes (no hole).
+    pub magic: u32,
+
+    // --- widest-first body (natural alignment; NOTHING is packed) ---
+    /// Monotonic write generation; the seqlock counter (odd while writing, even
+    /// on commit). Read before and after the snapshot copy.
+    pub generation: u64,
+    /// Monotonic command sequence — `sequence <= last_accepted ⇒ reject`.
+    pub sequence: u64,
+    /// Publication timestamp (nanoseconds, **boundary clock domain** — §5).
+    pub publication_nanos: u64,
+    /// Absolute deadline (nanoseconds, same domain) — `now > deadline ⇒ reject`.
+    pub deadline_nanos: u64,
+
+    /// CRC-32 (IEEE) over `command[..command_len]`. Checked after the snapshot is
+    /// stable, before the judge.
+    pub crc32: u32,
+    /// Valid command length in bytes; `> MAX_COMMAND_BYTES ⇒ reject`. Pairs with
+    /// `crc32` to 8 bytes.
+    pub command_len: u32,
+
+    /// The command payload, BY VALUE. The command occupies the first
+    /// `command_len` bytes; the remainder is unspecified and never read.
+    pub command: [u8; MAX_COMMAND_BYTES],
+}
+
+impl GovernorContractView {
+    /// Build a committed view carrying `command`, with the fixed
+    /// [`LAYOUT_VERSION`]/[`MAGIC`] and a freshly computed [`crc32`]. Returns
+    /// `None` if the command exceeds [`MAX_COMMAND_BYTES`] (the publisher cannot
+    /// fabricate an oversize frame). The `generation` is the caller's committed
+    /// (even) value; [`publish`](crate::publish) drives the odd/even transitions.
+    pub fn new_command(
+        generation: u64,
+        sequence: u64,
+        publication_nanos: u64,
+        deadline_nanos: u64,
+        command: &[u8],
+    ) -> Option<Self> {
+        if command.len() > MAX_COMMAND_BYTES {
+            return None;
+        }
+        let mut buf = [0u8; MAX_COMMAND_BYTES];
+        buf[..command.len()].copy_from_slice(command);
+        Some(Self {
+            layout_version: LAYOUT_VERSION,
+            magic: MAGIC,
+            generation,
+            sequence,
+            publication_nanos,
+            deadline_nanos,
+            crc32: crc32_ieee(command),
+            command_len: command.len() as u32,
+            command: buf,
+        })
+    }
+
+    /// The valid command bytes, `command[..command_len]`, or `None` if
+    /// `command_len` is out of range. Only call after [`validate`](crate::validate)
+    /// has passed — this is a convenience accessor, not a validation step.
+    pub fn validated_command(&self) -> Option<&[u8]> {
+        let len = self.command_len as usize;
+        if len > MAX_COMMAND_BYTES {
+            return None;
+        }
+        Some(&self.command[..len])
+    }
+
+    /// The canonical **little-endian** byte image (length [`CANONICAL_IMAGE_LEN`]).
+    /// This is the exact, endian-explicit, padding-free serialization the
+    /// release-token digest is signed over (HVCHAN-001 §3 step 5). On a
+    /// little-endian target it is byte-identical to the `#[repr(C)]` image; the
+    /// manual serialization keeps it deterministic and endian-independent without
+    /// any `unsafe` byte reinterpretation.
+    pub fn canonical_image(&self) -> [u8; CANONICAL_IMAGE_LEN] {
+        let mut out = [0u8; CANONICAL_IMAGE_LEN];
+        out[0..4].copy_from_slice(&self.layout_version.to_le_bytes());
+        out[4..8].copy_from_slice(&self.magic.to_le_bytes());
+        out[8..16].copy_from_slice(&self.generation.to_le_bytes());
+        out[16..24].copy_from_slice(&self.sequence.to_le_bytes());
+        out[24..32].copy_from_slice(&self.publication_nanos.to_le_bytes());
+        out[32..40].copy_from_slice(&self.deadline_nanos.to_le_bytes());
+        out[40..44].copy_from_slice(&self.crc32.to_le_bytes());
+        out[44..48].copy_from_slice(&self.command_len.to_le_bytes());
+        out[48..48 + MAX_COMMAND_BYTES].copy_from_slice(&self.command);
+        out
+    }
+
+    /// Parse a canonical little-endian image back into a view. Returns `None` if
+    /// the slice is shorter than [`CANONICAL_IMAGE_LEN`]. The inverse of
+    /// [`canonical_image`](Self::canonical_image); it performs **no validation**
+    /// (that is [`validate`](crate::validate)'s job).
+    pub fn from_canonical_image(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < CANONICAL_IMAGE_LEN {
+            return None;
+        }
+        let u32_at = |o: usize| u32::from_le_bytes([bytes[o], bytes[o + 1], bytes[o + 2], bytes[o + 3]]);
+        let u64_at = |o: usize| {
+            u64::from_le_bytes([
+                bytes[o], bytes[o + 1], bytes[o + 2], bytes[o + 3], bytes[o + 4], bytes[o + 5],
+                bytes[o + 6], bytes[o + 7],
+            ])
+        };
+        let mut command = [0u8; MAX_COMMAND_BYTES];
+        command.copy_from_slice(&bytes[48..48 + MAX_COMMAND_BYTES]);
+        Some(Self {
+            layout_version: u32_at(0),
+            magic: u32_at(4),
+            generation: u64_at(8),
+            sequence: u64_at(16),
+            publication_nanos: u64_at(24),
+            deadline_nanos: u64_at(32),
+            crc32: u32_at(40),
+            command_len: u32_at(44),
+            command,
+        })
+    }
+}
+
+// --------------------------------------------------------------------------
+// FREEZE ASSERTIONS — layout stability IS the safety claim (HVCHAN-001 §2.4).
+// A change to any field, size, order, or MAX_COMMAND_BYTES breaks the build
+// here; that is the point. Fix it by minting a new LAYOUT_VERSION, not by
+// editing these numbers to match a drifted struct.
+// --------------------------------------------------------------------------
+use core::mem::{align_of, offset_of, size_of};
+
+const _: () = assert!(offset_of!(GovernorContractView, layout_version) == 0);
+const _: () = assert!(offset_of!(GovernorContractView, magic) == 4);
+const _: () = assert!(offset_of!(GovernorContractView, generation) == 8);
+const _: () = assert!(offset_of!(GovernorContractView, sequence) == 16);
+const _: () = assert!(offset_of!(GovernorContractView, publication_nanos) == 24);
+const _: () = assert!(offset_of!(GovernorContractView, deadline_nanos) == 32);
+const _: () = assert!(offset_of!(GovernorContractView, crc32) == 40);
+const _: () = assert!(offset_of!(GovernorContractView, command_len) == 44);
+const _: () = assert!(offset_of!(GovernorContractView, command) == 48);
+// Total size has NO interior or trailing padding (widest-first, u32+u32 pairs).
+const _: () = assert!(size_of::<GovernorContractView>() == CANONICAL_IMAGE_LEN);
+const _: () = assert!(size_of::<GovernorContractView>() == 176);
+const _: () = assert!(align_of::<GovernorContractView>() == 8);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_image_roundtrips() {
+        let v = GovernorContractView::new_command(4, 7, 1_000, 2_000, b"steer").unwrap();
+        let img = v.canonical_image();
+        assert_eq!(img.len(), CANONICAL_IMAGE_LEN);
+        assert_eq!(GovernorContractView::from_canonical_image(&img), Some(v));
+    }
+
+    #[test]
+    fn canonical_image_is_little_endian_at_fixed_offsets() {
+        let v = GovernorContractView::new_command(0x0807_0605, 0x0102, 0, 0, b"").unwrap();
+        let img = v.canonical_image();
+        // layout_version @0, magic @4, generation @8 — all LE.
+        assert_eq!(&img[0..4], &LAYOUT_VERSION.to_le_bytes());
+        assert_eq!(&img[4..8], &MAGIC.to_le_bytes());
+        assert_eq!(&img[8..16], &0x0807_0605u64.to_le_bytes());
+        assert_eq!(&img[16..24], &0x0102u64.to_le_bytes());
+    }
+
+    #[test]
+    fn new_command_rejects_oversize_payload() {
+        let too_long = [0u8; MAX_COMMAND_BYTES + 1];
+        assert_eq!(
+            GovernorContractView::new_command(0, 0, 0, 0, &too_long),
+            None
+        );
+    }
+
+    #[test]
+    fn new_command_sets_version_magic_crc_and_len() {
+        let v = GovernorContractView::new_command(2, 3, 0, 0, b"abc").unwrap();
+        assert_eq!(v.layout_version, LAYOUT_VERSION);
+        assert_eq!(v.magic, MAGIC);
+        assert_eq!(v.command_len, 3);
+        assert_eq!(v.crc32, crc32_ieee(b"abc"));
+        assert_eq!(v.validated_command(), Some(&b"abc"[..]));
+    }
+
+    #[test]
+    fn from_canonical_image_rejects_short_slice() {
+        let short = [0u8; CANONICAL_IMAGE_LEN - 1];
+        assert_eq!(GovernorContractView::from_canonical_image(&short), None);
+    }
+
+    #[test]
+    fn validated_command_rejects_out_of_range_len() {
+        let mut v = GovernorContractView::new_command(0, 0, 0, 0, b"x").unwrap();
+        v.command_len = (MAX_COMMAND_BYTES + 1) as u32;
+        assert_eq!(v.validated_command(), None);
+    }
+}

--- a/crates/kirra-contract-channel/tests/end_to_end.rs
+++ b/crates/kirra-contract-channel/tests/end_to_end.rs
@@ -1,0 +1,111 @@
+//! End-to-end trust chain (HVCHAN-001 §3): publish under the seqlock → obtain a
+//! coherent snapshot → validate → advance the watermark → expose the canonical
+//! image the digest signs. Single-threaded, deterministic — it exercises the
+//! protocol wiring, complementing the concurrency test in `src/seqlock.rs`.
+
+use core::cell::{Cell, RefCell};
+
+use kirra_contract_channel::{
+    publish, read_coherent_snapshot, validate, AcceptedWatermark, ContractFault, ContractReader,
+    ContractWriter, GovernorContractView, MAX_SNAPSHOT_RETRIES,
+};
+
+/// A single-threaded stand-in for the shared region: the seqlock generation lives
+/// in `gen`, the body in `view`. `copy_view` overlays the authoritative counter
+/// onto the snapshot's `generation`, mirroring the real region where both sit at
+/// fixed offsets in one mapping.
+struct LocalRegion {
+    gen: Cell<u64>,
+    view: RefCell<GovernorContractView>,
+}
+
+impl LocalRegion {
+    fn new() -> Self {
+        Self {
+            gen: Cell::new(0),
+            view: RefCell::new(GovernorContractView::new_command(0, 0, 0, 0, b"").unwrap()),
+        }
+    }
+    /// Corrupt the stored CRC field, simulating an integrity fault in the region.
+    fn corrupt_crc(&self) {
+        self.view.borrow_mut().crc32 ^= 0xFFFF_FFFF;
+    }
+}
+
+impl ContractReader for LocalRegion {
+    fn load_generation(&self) -> u64 {
+        self.gen.get()
+    }
+    fn copy_view(&self) -> GovernorContractView {
+        let mut v = *self.view.borrow();
+        v.generation = self.gen.get();
+        v
+    }
+}
+
+impl ContractWriter for LocalRegion {
+    fn store_generation(&self, generation: u64) {
+        self.gen.set(generation);
+    }
+    fn store_body(&self, view: &GovernorContractView) {
+        let mut cur = self.view.borrow_mut();
+        let keep_gen = cur.generation;
+        *cur = *view;
+        cur.generation = keep_gen; // the seqlock counter is owned by `gen`
+    }
+}
+
+#[test]
+fn full_trust_chain_accepts_monotonic_stream_and_rejects_replay() {
+    let region = LocalRegion::new();
+    let mut committed = 0u64;
+    let mut watermark = AcceptedWatermark::new();
+
+    // A strictly-increasing stream of commands, each published then validated.
+    for s in 1..=8u64 {
+        let cmd = std::format!("steer:{s}");
+        let body =
+            GovernorContractView::new_command(0, s, s * 10, 1_000_000, cmd.as_bytes()).unwrap();
+        committed = publish(&region, committed, &body);
+
+        let snap = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES)
+            .expect("a quiescent region yields a coherent snapshot");
+
+        // The snapshot carries the committed (even) generation.
+        assert_eq!(snap.generation, committed);
+        assert_eq!(snap.generation % 2, 0);
+
+        // Validates against the advancing watermark; record only on Ok (§3.1).
+        assert_eq!(validate(&snap, 500_000, &watermark), Ok(()));
+        watermark.record(&snap);
+
+        // Digest hook (§3 step 5): the canonical image is the exact validated
+        // bytes, and it round-trips — what the existing Ed25519/SHA-256 machinery
+        // signs is precisely the snapshot the judge approved.
+        let image = snap.canonical_image();
+        assert_eq!(GovernorContractView::from_canonical_image(&image), Some(snap));
+        assert_eq!(snap.validated_command(), Some(cmd.as_bytes()));
+    }
+
+    // No new publish: re-reading the same committed snapshot is a replay — the
+    // monotonic sequence gate rejects it (equal == replay).
+    let stale = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES).unwrap();
+    assert!(matches!(
+        validate(&stale, 500_000, &watermark),
+        Err(ContractFault::SequenceRegressOrReplay { .. })
+    ));
+}
+
+#[test]
+fn integrity_fault_in_the_region_is_caught_on_the_validated_copy() {
+    let region = LocalRegion::new();
+    let body = GovernorContractView::new_command(0, 1, 0, 1_000_000, b"go").unwrap();
+    publish(&region, 0, &body);
+    region.corrupt_crc();
+
+    let snap = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES).unwrap();
+    assert!(matches!(
+        validate(&snap, 0, &AcceptedWatermark::new()),
+        Err(ContractFault::CrcMismatch { .. })
+    ));
+}


### PR DESCRIPTION
Implements **ADR-0006 Clause 2 / HVCHAN-001** — the cross-partition guest↔host governor contract channel — as a new crate, `kirra-contract-channel`. Until now `GovernorContractView` existed only in the spec; this is the real, host-testable artifact.

It's **the most durable part of ADR-0006** (independent of the iceoryx2 toolchain/tier/maturity gates) and the frozen layout the in-partition iceoryx2 transport (Clause 1) ultimately writes into — so it's the natural thing to have in hand for the ekxide engagement (see #614).

### Minimal-TCB, exactly as the ADR argues
*"A frozen layout imports a struct definition."* So: `#[no_std]`, **zero dependencies**, `#[forbid(unsafe_code)]`. iceoryx2 still does not enter the workspace dependency tree; this is pure Rust over a byte region and needs **no QNX target** to build or test.

### What's in it
- **`view.rs`** — the frozen `#[repr(C)]`, pointer-free `GovernorContractView` (§2): version-discovery prefix at offset 0, widest-first body, command **by value** (pointers don't cross a partition boundary). **Compile-time offset/size/align assertions make layout stability the safety claim** (the talisman discipline) — any drift breaks the build; the fix is a new `LAYOUT_VERSION`, never an in-place edit. Plus a deterministic, endian-explicit canonical LE image — the exact bytes the release-token digest signs (§3 step 5), with no `unsafe` byte reinterpretation and **no new crypto**.
- **`crc.rs`** — in-crate CRC-32/IEEE (no dependency), known-answer-pinned.
- **`seqlock.rs`** — the **odd/even generation seqlock** (§3 steps 2-3): `publish()` (odd → body → even) and `read_coherent_snapshot()` (even-copy-even, **bounded retries**, retry-exhaustion ⇒ fail-closed `RetryExhausted`). Generic over `ContractReader`/`ContractWriter` so the **target** binds them to the hypervisor mapping (where the mapping `unsafe` lives — the Clause 3 integration shim, *outside* this crate) while the protocol stays `forbid(unsafe)`. **This is the correct mechanism the QNX shim (`kirra_shim.cpp`) only approximated** with a compiler-only `atomic_signal_fence` — the review's **S2** finding now has a reference seqlock to adopt.
- **`validate.rs`** — the §3-step-4 pipeline in fixed order (`layout_version → magic → bounds → CRC → sequence monotonic → generation monotonic → deadline`) with the fail-closed `ContractFault` taxonomy (§4), and `AcceptedWatermark` (the `<= last_accepted ⇒ reject` rule §3.1; advances **only on accept** so a rejected snapshot can't poison it). `now_nanos` is required in the **boundary clock domain** (R-HV-3) — this path never reads wall/PTP time.

### Tests (25, all green)
Layout freeze + canonical-image roundtrip/LE; CRC known-answer vectors; **every §4 fault row**; equal-sequence / equal-generation replay reject vs strictly-newer accept; deadline boundary; a **20 000-iteration concurrent writer/reader proving no coherent snapshot is ever a torn mix**; and a single-threaded **end-to-end trust chain** (publish → coherent read → validate → record → digest hook) including replay and in-region integrity-fault rejection.

- clippy `-D warnings` clean on `--all-targets`.

### Scope notes
- This is the **boundary contract only**. Wiring it to the actuator-release signing path (§3 steps 6-7, reusing the existing Ed25519/audit-chain machinery) and the target memory-mapping shim are follow-ups.
- Hypervisor-owned §4 rows (read-only mapping R-HV-1, clock-skew bound, publisher-silent liveness) are enforced outside this crate by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_