### PR TITLE
feat(contract-channel): carrier-agnostic seam — reusable Ideal-B reference + end-to-end trust-chain test

### DIFF
--- a/crates/kirra-contract-channel/src/lib.rs
+++ b/crates/kirra-contract-channel/src/lib.rs
@@ -34,6 +34,27 @@
 //! §3 steps 5-6: *"no new crypto primitives are introduced"*). This crate only
 //! produces the **exact validated bytes** that digest signs.
 //!
+//! ## The carrier-agnostic seam ([`ContractReader`] / [`ContractWriter`])
+//!
+//! The two region traits ARE the seam between the **contract** (this crate's
+//! frozen layout + trust chain, which never changes) and the **carrier** (how the
+//! bytes physically cross the boundary, which can). Three carriers bind the same
+//! seam:
+//!
+//! - **Ideal-B — raw hypervisor shared memory (available today).** The target
+//!   binds the traits to a mapped region; the mapping `unsafe` lives in the
+//!   ADR-0006 Clause 3 integration shim, *outside* this `forbid(unsafe)` crate.
+//! - **Ideal-A — a future minimal-footprint iceoryx2 consumer.** If iceoryx2
+//!   offers a static, read-only, no-discovery/lifecycle/pools consumer that fits
+//!   the safety-partition TCB, it binds the *same* traits — the contract and the
+//!   trust chain are byte-for-byte unchanged; only the carrier differs.
+//! - **Host / in-process — [`reference::InProcessRegion`].** An atomics-backed
+//!   region for tests and demos (e.g. two threads sharing one `Arc`), with no
+//!   `unsafe` and no allocation. The reference the target swaps out.
+//!
+//! Because the contract is carrier-agnostic, adopting a better carrier later is a
+//! drop-in: implement the two traits, change nothing else.
+//!
 //! ## Boundary clock domain (HVCHAN-001 §5, R-HV-3)
 //!
 //! All timestamp/deadline fields are defined in the **boundary clock domain**
@@ -49,6 +70,7 @@
 extern crate std;
 
 mod crc;
+pub mod reference;
 mod seqlock;
 mod validate;
 mod view;

--- a/crates/kirra-contract-channel/src/reference.rs
+++ b/crates/kirra-contract-channel/src/reference.rs
@@ -1,0 +1,118 @@
+//! Host / in-process reference carrier (the Ideal-B seam made concrete for tests
+//! and demos). See the crate-level "carrier-agnostic seam" section.
+//!
+//! [`InProcessRegion`] is an atomics-backed shared region implementing both
+//! [`ContractReader`] and [`ContractWriter`] with **no `unsafe` and no
+//! allocation**. It exercises the full publish/coherent-read protocol in one
+//! process (e.g. two threads sharing an `Arc<InProcessRegion>`). The generation
+//! counter carries the ordering (Acquire/Release); body fields are Relaxed (the
+//! seqlock generation fences them).
+//!
+//! The **target** swaps this out: a raw hypervisor-SHM binding (Ideal-B) or a
+//! future minimal-footprint iceoryx2 consumer (Ideal-A) implements the same two
+//! traits over real cross-partition memory. The contract and trust chain are
+//! identical regardless — this is the only thing that changes.
+
+use core::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
+
+use crate::view::MAX_COMMAND_BYTES;
+use crate::{ContractReader, ContractWriter, GovernorContractView};
+
+/// An atomics-backed, in-process stand-in for the shared contract region. Every
+/// field is an atomic so concurrent reader/writer access is well-defined without
+/// `unsafe`. Share it across threads via `Arc<InProcessRegion>`.
+pub struct InProcessRegion {
+    generation: AtomicU64,
+    layout_version: AtomicU32,
+    magic: AtomicU32,
+    sequence: AtomicU64,
+    publication_nanos: AtomicU64,
+    deadline_nanos: AtomicU64,
+    crc32: AtomicU32,
+    command_len: AtomicU32,
+    command: [AtomicU8; MAX_COMMAND_BYTES],
+}
+
+impl InProcessRegion {
+    /// A zeroed region (generation 0 = even/quiescent, no command published yet).
+    pub fn new() -> Self {
+        Self {
+            generation: AtomicU64::new(0),
+            layout_version: AtomicU32::new(0),
+            magic: AtomicU32::new(0),
+            sequence: AtomicU64::new(0),
+            publication_nanos: AtomicU64::new(0),
+            deadline_nanos: AtomicU64::new(0),
+            crc32: AtomicU32::new(0),
+            command_len: AtomicU32::new(0),
+            command: core::array::from_fn(|_| AtomicU8::new(0)),
+        }
+    }
+}
+
+impl Default for InProcessRegion {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ContractReader for InProcessRegion {
+    fn load_generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+    fn copy_view(&self) -> GovernorContractView {
+        let mut command = [0u8; MAX_COMMAND_BYTES];
+        for (i, slot) in command.iter_mut().enumerate() {
+            *slot = self.command[i].load(Ordering::Relaxed);
+        }
+        GovernorContractView {
+            layout_version: self.layout_version.load(Ordering::Relaxed),
+            magic: self.magic.load(Ordering::Relaxed),
+            generation: self.generation.load(Ordering::Relaxed),
+            sequence: self.sequence.load(Ordering::Relaxed),
+            publication_nanos: self.publication_nanos.load(Ordering::Relaxed),
+            deadline_nanos: self.deadline_nanos.load(Ordering::Relaxed),
+            crc32: self.crc32.load(Ordering::Relaxed),
+            command_len: self.command_len.load(Ordering::Relaxed),
+            command,
+        }
+    }
+}
+
+impl ContractWriter for InProcessRegion {
+    fn store_generation(&self, generation: u64) {
+        self.generation.store(generation, Ordering::Release);
+    }
+    fn store_body(&self, view: &GovernorContractView) {
+        // Every field EXCEPT generation (the publish() driver owns the counter).
+        self.layout_version.store(view.layout_version, Ordering::Relaxed);
+        self.magic.store(view.magic, Ordering::Relaxed);
+        self.sequence.store(view.sequence, Ordering::Relaxed);
+        self.publication_nanos.store(view.publication_nanos, Ordering::Relaxed);
+        self.deadline_nanos.store(view.deadline_nanos, Ordering::Relaxed);
+        self.crc32.store(view.crc32, Ordering::Relaxed);
+        self.command_len.store(view.command_len, Ordering::Relaxed);
+        for (i, b) in view.command.iter().enumerate() {
+            self.command[i].store(*b, Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{publish, read_coherent_snapshot, MAX_SNAPSHOT_RETRIES};
+
+    #[test]
+    fn publish_then_read_roundtrips_through_the_region() {
+        let region = InProcessRegion::new();
+        let body = GovernorContractView::new_command(0, 7, 100, 10_000, b"steer").unwrap();
+        let committed = publish(&region, 0, &body);
+
+        let snap = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES).unwrap();
+        assert_eq!(snap.generation, committed);
+        assert_eq!(snap.generation % 2, 0);
+        assert_eq!(snap.sequence, 7);
+        assert_eq!(snap.validated_command(), Some(&b"steer"[..]));
+    }
+}

--- a/crates/kirra-contract-channel/src/seqlock.rs
+++ b/crates/kirra-contract-channel/src/seqlock.rs
@@ -103,9 +103,9 @@ pub fn publish<W: ContractWriter>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::view::{GovernorContractView, MAX_COMMAND_BYTES};
+    use crate::reference::InProcessRegion;
+    use crate::view::GovernorContractView;
     use core::cell::Cell;
-    use core::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
     use std::sync::Arc;
     use std::{thread, vec::Vec};
 
@@ -167,83 +167,6 @@ mod tests {
         assert_eq!(read_coherent_snapshot(&r, 8), Ok(any_view()));
     }
 
-    // ---- a real concurrent region backed by atomics -----------------------
-
-    /// Host stand-in for the hypervisor-mapped region: every field is an atomic,
-    /// so concurrent reader/writer access is well-defined with no `unsafe`. The
-    /// generation carries the ordering (Acquire/Release); body fields are Relaxed.
-    struct AtomicRegion {
-        generation: AtomicU64,
-        layout_version: AtomicU32,
-        magic: AtomicU32,
-        sequence: AtomicU64,
-        publication_nanos: AtomicU64,
-        deadline_nanos: AtomicU64,
-        crc32: AtomicU32,
-        command_len: AtomicU32,
-        command: [AtomicU8; MAX_COMMAND_BYTES],
-    }
-
-    impl AtomicRegion {
-        fn new() -> Self {
-            Self {
-                generation: AtomicU64::new(0),
-                layout_version: AtomicU32::new(0),
-                magic: AtomicU32::new(0),
-                sequence: AtomicU64::new(0),
-                publication_nanos: AtomicU64::new(0),
-                deadline_nanos: AtomicU64::new(0),
-                crc32: AtomicU32::new(0),
-                command_len: AtomicU32::new(0),
-                command: core::array::from_fn(|_| AtomicU8::new(0)),
-            }
-        }
-    }
-
-    impl ContractReader for AtomicRegion {
-        fn load_generation(&self) -> u64 {
-            self.generation.load(Ordering::Acquire)
-        }
-        fn copy_view(&self) -> GovernorContractView {
-            let mut command = [0u8; MAX_COMMAND_BYTES];
-            for (i, slot) in command.iter_mut().enumerate() {
-                *slot = self.command[i].load(Ordering::Relaxed);
-            }
-            GovernorContractView {
-                layout_version: self.layout_version.load(Ordering::Relaxed),
-                magic: self.magic.load(Ordering::Relaxed),
-                generation: self.generation.load(Ordering::Relaxed),
-                sequence: self.sequence.load(Ordering::Relaxed),
-                publication_nanos: self.publication_nanos.load(Ordering::Relaxed),
-                deadline_nanos: self.deadline_nanos.load(Ordering::Relaxed),
-                crc32: self.crc32.load(Ordering::Relaxed),
-                command_len: self.command_len.load(Ordering::Relaxed),
-                command,
-            }
-        }
-    }
-
-    impl ContractWriter for AtomicRegion {
-        fn store_generation(&self, generation: u64) {
-            self.generation.store(generation, Ordering::Release);
-        }
-        fn store_body(&self, view: &GovernorContractView) {
-            // Every field EXCEPT generation. Written field-by-field so a reader
-            // that ignored the seqlock could observe a torn mix — which the
-            // seqlock is precisely what prevents.
-            self.layout_version.store(view.layout_version, Ordering::Relaxed);
-            self.magic.store(view.magic, Ordering::Relaxed);
-            self.sequence.store(view.sequence, Ordering::Relaxed);
-            self.publication_nanos.store(view.publication_nanos, Ordering::Relaxed);
-            self.deadline_nanos.store(view.deadline_nanos, Ordering::Relaxed);
-            self.crc32.store(view.crc32, Ordering::Relaxed);
-            self.command_len.store(view.command_len, Ordering::Relaxed);
-            for (i, b) in view.command.iter().enumerate() {
-                self.command[i].store(*b, Ordering::Relaxed);
-            }
-        }
-    }
-
     #[test]
     fn concurrent_writer_and_reader_never_yield_a_torn_snapshot() {
         // The publisher writes, for sequence s, a view whose fields satisfy a
@@ -251,7 +174,7 @@ mod tests {
         // command's CRC matches `crc32`. A torn snapshot (a mix of two writes)
         // would break the invariant; the seqlock must guarantee every coherent
         // snapshot the reader accepts is internally consistent.
-        let region = Arc::new(AtomicRegion::new());
+        let region = Arc::new(InProcessRegion::new());
         const N: u64 = 20_000;
 
         let w = Arc::clone(&region);

--- a/tests/clause2_trust_chain.rs
+++ b/tests/clause2_trust_chain.rs
@@ -1,0 +1,94 @@
+//! End-to-end Clause 2 trust chain (HVCHAN-001 §3, steps 1-7) composed across the
+//! two crates that implement it:
+//!   - `kirra-contract-channel` — the frozen layout, the odd/even seqlock, and
+//!     validation (steps 1-4); plus the carrier-agnostic `InProcessRegion`
+//!     reference (the Ideal-B seam made concrete for host tests).
+//!   - `kirra_verifier::governor_release` — the digest, the Ed25519 release token,
+//!     and the actuator verify-before-release gate (steps 5-7).
+//!
+//! Neither crate's own tests exercise the FULL chain; this proves the seam between
+//! them and demonstrates the closed claim: "the governor approved exactly the
+//! data represented by this digest, and actuator release is bound to that
+//! approval." The carrier here is in-process; on the target the SAME chain runs
+//! with the reader/writer traits bound to mapped hypervisor SHM (Ideal-B) or a
+//! future minimal-footprint iceoryx2 consumer (Ideal-A) — the contract and the
+//! trust chain are unchanged.
+
+use ed25519_dalek::SigningKey;
+
+use kirra_contract_channel::reference::InProcessRegion;
+use kirra_contract_channel::{
+    publish, read_coherent_snapshot, validate, AcceptedWatermark, ContractFault,
+    GovernorContractView, MAX_SNAPSHOT_RETRIES,
+};
+use kirra_verifier::governor_release::{issue_release_token, verify_release, ReleaseDenied};
+
+/// A monotonic stream of commands flows the whole chain end-to-end: published
+/// under the seqlock, coherently read, validated, signed into a release token,
+/// and released only after the actuator re-derives a matching digest.
+#[test]
+fn monotonic_stream_publishes_validates_signs_and_releases() {
+    let region = InProcessRegion::new();
+    let governor = SigningKey::from_bytes(&[11u8; 32]);
+    let governor_vk = governor.verifying_key();
+
+    let mut committed = 0u64;
+    let mut watermark = AcceptedWatermark::new();
+    const NOW_NANOS: u64 = 500_000;
+
+    for s in 1..=6u64 {
+        let cmd = std::format!("v={s}");
+
+        // Steps 1-2: the (untrusted) guest publishes under the seqlock.
+        let body =
+            GovernorContractView::new_command(0, s, s * 10, 1_000_000, cmd.as_bytes()).unwrap();
+        committed = publish(&region, committed, &body);
+
+        // Step 3: the governor obtains a coherent owned snapshot.
+        let snap = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES)
+            .expect("quiescent region yields a coherent snapshot");
+        assert_eq!(snap.generation, committed);
+
+        // Step 4: the governor validates against the advancing watermark.
+        validate(&snap, NOW_NANOS, &watermark).expect("well-formed, fresh, monotonic");
+        watermark.record(&snap);
+
+        // Steps 5-6: the governor signs a release token over the validated bytes.
+        let token = issue_release_token(&snap, &governor);
+
+        // Step 7: the actuator releases only after re-deriving a matching digest
+        // AND verifying the signature against the trusted governor key.
+        assert_eq!(verify_release(&token, &snap, &governor_vk), Ok(()));
+
+        // Negative: that token must NOT release any OTHER command.
+        let substitute =
+            GovernorContractView::new_command(0, s, s * 10, 1_000_000, b"tamper").unwrap();
+        assert_eq!(
+            verify_release(&token, &substitute, &governor_vk),
+            Err(ReleaseDenied::DigestMismatch),
+            "a release token is bound to the exact bytes the governor approved"
+        );
+    }
+}
+
+/// A replayed command (equal sequence) is rejected at validation (step 4) — it
+/// never reaches the release stage, so no token is ever minted for it.
+#[test]
+fn replayed_command_is_rejected_before_release() {
+    let region = InProcessRegion::new();
+    let mut watermark = AcceptedWatermark::new();
+
+    let first = GovernorContractView::new_command(0, 1, 0, 1_000_000, b"go").unwrap();
+    let committed = publish(&region, 0, &first);
+    let snap = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES).unwrap();
+    assert_eq!(snap.generation, committed);
+    validate(&snap, 0, &watermark).unwrap();
+    watermark.record(&snap);
+
+    // Re-read the same committed region (no new publish) → replay on `sequence`.
+    let replay = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES).unwrap();
+    assert!(matches!(
+        validate(&replay, 0, &watermark),
+        Err(ContractFault::SequenceRegressOrReplay { .. })
+    ));
+}


### PR DESCRIPTION
iceoryx2-lane work that's fully buildable **now** — independent of the QNX target and the toolchain gate — and structured so a future iceoryx2 carrier (**Ideal-A**) drops in behind the same traits with **zero change** to the contract or the trust chain.

### The carrier-agnostic seam, made concrete
The `ContractReader` / `ContractWriter` traits ARE the seam between the **contract** (the frozen layout + trust chain, which never changes) and the **carrier** (how bytes physically cross the boundary, which can):
- **Ideal-B — raw hypervisor SHM (today):** the target binds the traits to a mapped region (mapping `unsafe` lives in the Clause 3 shim, outside this `forbid(unsafe)` crate).
- **Ideal-A — future minimal-footprint iceoryx2 consumer:** binds the *same* traits; contract + trust chain byte-for-byte unchanged.
- **In-process reference:** new `pub mod reference` with `InProcessRegion` — an atomics-backed, `no_std`, no-unsafe, no-alloc carrier for host tests/demos.

The duplicate test-only `AtomicRegion` in `seqlock.rs` is removed; the 20 000-iteration concurrency test now uses the shared reference. `lib.rs` gains a "carrier-agnostic seam" doc section spelling this out.

### End-to-end trust chain (new)
`tests/clause2_trust_chain.rs` composes **both crates** end-to-end (HVCHAN §3 steps 1-7): publish under the seqlock → coherent read → validate → digest → Ed25519 release token → actuator verify-before-release — over a monotonic stream, with the negative cases (a token can't release a substituted command; a replay is rejected at validation before any token is minted). **Nothing previously exercised the full chain across the `kirra-contract-channel` ↔ `governor_release` seam** — each crate only tested its own half.

### Verification
- `kirra-contract-channel`: 24 unit + 3 integration tests pass; clippy `-D warnings` clean.
- New end-to-end test passes; clippy clean.
- No new dependency; iceoryx2 still does not enter the tree.

> Deferred (noted for later): adopting this reference seqlock into the QNX RTM-harness shim (`kirra_shim.cpp`) to close the review's **S2** finding (its torn-read is still a compiler-only `atomic_signal_fence`, not the odd/even seqlock). That's a coordinated C++/FFI change, best done as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_