### PR TITLE
fix(qnx-harness): odd/even generation seqlock in the shim (closes review S2)

### DIFF
--- a/tools/qnx-rtm-harness/QNX_MAPPING.md
+++ b/tools/qnx-rtm-harness/QNX_MAPPING.md
@@ -8,7 +8,7 @@ this change (#272 touches only `tools/qnx-rtm-harness/**`).
 
 > **The local `SG-0N` is the HARNESS ROW INDEX, not a kernel RTM id.** The
 > `rtm_id`/`tr_id` columns are the bridge. The mapping is honest: only **one** row
-> has a genuine kernel TR home; **six** are real coverage gaps; one is a control.
+> has a genuine kernel TR home; **seven** are real coverage gaps; one is a control.
 > A shoehorned mapping would be worse than a named gap — the gap IS the evidence
 > (it is exactly what `RTM_GAP_REPORT.md` exists to capture).
 
@@ -26,6 +26,7 @@ this change (#272 touches only `tools/qnx-rtm-harness/**`).
 | SG-05 | payload oversize (bounds) | `PayloadOversize` | `NO-RTM-ID` | `CANDIDATE` | **gap** |
 | SG-06 | over-envelope velocity | `KinematicLimit` | `SG-001` | `TR-001` | **genuine hit (proxy)** |
 | SG-07 | replay (`seq == last`) | `SequenceRegress` | `NO-RTM-ID` | `CANDIDATE` | **gap** |
+| SG-08 | torn write (odd generation) | `StaleHeader` | `NO-RTM-ID` | `CANDIDATE` | **gap** |
 
 ---
 
@@ -47,7 +48,7 @@ this change (#272 touches only `tools/qnx-rtm-harness/**`).
   So this is *proxy/partial* evidence for SG-001 — it does **not** discharge or
   substitute for TR-001's certified `test_speed_above_ceiling_triggers_clamp_linear`.
 
-The six **`NO-RTM-ID`** rows below are honest gaps: each names the **principle
+The seven **`NO-RTM-ID`** rows below are honest gaps: each names the **principle
 precedent** SG (the safety principle that already exists in the kernel for a
 *different* artifact) under which a candidate new TR would live, but **no current
 TR covers the transport-contract instantiation** the harness exercises.
@@ -96,13 +97,24 @@ TR covers the transport-contract instantiation** the harness exercises.
   **complementary barriers** (don't-cache vs do-reject), and neither substitutes for
   the other. Candidate new TR (alongside SG-02) remains needed.
 
+- **SG-08 torn write (odd generation) → `NO-RTM-ID`.** A snapshot caught with an
+  **odd** generation (a write in progress) — or a generation that changes across
+  the copy — is rejected by the shim's **odd/even generation seqlock** (HVCHAN-001
+  §3 steps 2-3) before the FFI, so the judge is never called (a shim-side
+  short-circuit, like SG-05). This replaces the prior compiler-fence-only
+  double-read-compare (review finding **S2**): the seqlock uses a real CPU acquire
+  barrier and a monotonic counter, so it is sound on weakly-ordered targets and
+  not ABA-prone. The mechanism mirrors `crates/kirra-contract-channel`. No kernel
+  TR exists for cross-partition snapshot coherence — candidate new TR under the
+  same FFI-robustness / freedom-from-interference goal as SG-01.
+
 ---
 
 ## 3. Coverage gaps surfaced (the held line)
 
-The harness traces **8 transport-contract fault classes**; against the **current**
+The harness traces **9 transport-contract fault classes**; against the **current**
 kernel RTM, exactly **one** (over-envelope → SG-001/TR-001, proxy) has a real TR
-home. The other **six** are genuine **`NO-RTM-ID`** gaps:
+home. The other **seven** are genuine **`NO-RTM-ID`** gaps:
 
 | Gap | Fault class | Principle precedent | Candidate new TR home |
 |---|---|---|---|
@@ -112,11 +124,13 @@ home. The other **six** are genuine **`NO-RTM-ID`** gaps:
 | 4 | message payload integrity (CRC) | SG-010 (audit-chain integrity) | payload-integrity TR |
 | 5 | FFI payload bounds (oversize) | OCCY_FFI_EVIDENCE / OCCY_DFA (FFI) | FFI-robustness TR |
 | 6 | message replay (`seq == last`) | SG-014 (federation replay) | transport replay TR |
+| 7 | snapshot coherence (torn write / odd generation) | OCCY_FFI_EVIDENCE / OCCY_DFA (FFI) | snapshot-coherence / seqlock TR |
 
 This is the finding, not a defect of the harness: the EPIC #270 iceoryx2/QNX
-**transport-contract** surface (framing, ordering, freshness, integrity, bounds)
-is **not yet represented in the kernel RTM**, which was authored for the HTTP
-verifier + governor + protocol adapters. Surfacing these six gaps is the point.
+**transport-contract** surface (framing, ordering, freshness, integrity, bounds,
+snapshot coherence) is **not yet represented in the kernel RTM**, which was
+authored for the HTTP verifier + governor + protocol adapters. Surfacing these
+seven gaps is the point.
 
 > **Adding these candidate TRs to the RTM itself is a follow-up `docs/safety/**`
 > change requiring its own safety review — it is explicitly NOT part of this PR.**
@@ -148,7 +162,7 @@ should be re-aligned to it (a one-line `printf` change).
 
 ## 5. The concern split (recap)
 
-- **C++ shim = driver** — memory/transport safety: double-read tear detection,
+- **C++ shim = driver** — memory/transport safety: generation-seqlock tear detection,
   bounds (oversize short-circuits, never crosses the FFI), CRC over the payload.
 - **Rust judge = checker** — the contract verdict (magic → sequence → deadline →
   integrity → kinematic) on the shim's stabilized snapshot.

--- a/tools/qnx-rtm-harness/README.md
+++ b/tools/qnx-rtm-harness/README.md
@@ -2,9 +2,9 @@
 
 C++ **shim** (driver) → Rust **judge** (checker) over a frozen `extern "C"`
 contract ABI, with an automated **FDIT / RTM fault-injection** matrix that proves
-**verdict correctness** across eight fault classes. Part of **EPIC #270**
+**verdict correctness** across nine fault classes. Part of **EPIC #270**
 (iceoryx2 transport / QNX governor lane). Each row is **traced to the kernel RTM**
-(**#272** — see `QNX_MAPPING.md`): one genuine hit (SG-001/TR-001, proxy), six
+(**#272** — see `QNX_MAPPING.md`): one genuine hit (SG-001/TR-001, proxy), seven
 honest `NO-RTM-ID` transport-contract gaps, one control.
 
 > Built with **g++ + rustc directly (no cargo)**. The Rust judge is a `no_std`
@@ -22,7 +22,7 @@ runtime component.
 
 | Concern | Owner | What it does |
 |---|---|---|
-| memory / transport safety | **C++ shim** (`kirra_shim.*`) | double-read **tear** detection on the header; **bounds** rejection (oversize **short-circuits in the shim and NEVER crosses the FFI**); in-place **CRC** over the payload |
+| memory / transport safety | **C++ shim** (`kirra_shim.*`) | odd/even generation-**seqlock** tear detection on the header (real `atomic_thread_fence(acquire)`, mirrors `kirra-contract-channel`); **bounds** rejection (oversize **short-circuits in the shim and NEVER crosses the FFI**); in-place **CRC** over the payload |
 | contract verdict | **Rust judge** (`kirra_judge.rs`) | magic → sequence → deadline → integrity → kinematic, on the **stabilized snapshot** the shim hands it |
 
 So `PayloadOversize` and `PayloadCorrupt` are produced by the **shim** (the judge
@@ -46,28 +46,29 @@ built `--crate-type staticlib -C panic=abort` and linked into the C++ executable
 
 ## The fault matrix (gate = verdict correctness only)
 
-Eight rows, each named for **exactly** what it injects, each carrying its grounded
+Nine rows, each named for **exactly** what it injects, each carrying its grounded
 **RTM** mapping (the `row` column is the LOCAL harness index, **not** an RTM id —
 the `rtm` column is the bridge). Host run:
 
 ```
 row    fault class            rtm            ok     verdict             p50(ns)    p99(ns)    max(ns)
 -------------------------------------------------------------------------------------------------
-SG-00  valid                  CONTROL        PASS   Ok                      500        645      19318
-SG-01  bad-magic              NO-RTM-ID      PASS   StaleHeader             500        692     141615
-SG-02  sequence-regress       NO-RTM-ID      PASS   SequenceRegress         500        522      58236
-SG-03  deadline-missed        NO-RTM-ID      PASS   DeadlineMissed          501        524      23158
-SG-04  payload-corrupt (CRC)  NO-RTM-ID      PASS   PayloadCorrupt          499        647      64000
-SG-05  payload-oversize       NO-RTM-ID      PASS   PayloadOversize          38         61       4815
-SG-06  over-envelope          SG-001/TR-001  PASS   KinematicLimit          500        635      69192
-SG-07  replay (seq==last)     NO-RTM-ID      PASS   SequenceRegress         500        531      40385
+SG-00  valid                  CONTROL        PASS   Ok                      182        198      33456
+SG-01  bad-magic              NO-RTM-ID      PASS   StaleHeader             182        185      28346
+SG-02  sequence-regress       NO-RTM-ID      PASS   SequenceRegress         181        185      20384
+SG-03  deadline-missed        NO-RTM-ID      PASS   DeadlineMissed          182        193      24340
+SG-04  payload-corrupt (CRC)  NO-RTM-ID      PASS   PayloadCorrupt          180        183      21842
+SG-05  payload-oversize       NO-RTM-ID      PASS   PayloadOversize          21         23       2911
+SG-06  over-envelope          SG-001/TR-001  PASS   KinematicLimit          182        193      27398
+SG-07  replay (seq==last)     NO-RTM-ID      PASS   SequenceRegress         182        185      45818
+SG-08  torn-write (odd gen)   NO-RTM-ID      PASS   StaleHeader              21         22       2807
 
 GATE (verdict correctness): PASS
 ```
 
 The RTM mapping is **grounded** in `docs/safety/{SAFETY_GOALS,REQUIREMENTS_TRACEABILITY}.md`
 (read-only). Only **over-envelope** has a genuine kernel TR home — **SG-001/TR-001**,
-qualified as PROXY (proxy bound, reject-not-clamp). The other six transport-contract
+qualified as PROXY (proxy bound, reject-not-clamp). The other seven transport-contract
 fault classes are honest **`NO-RTM-ID`** gaps (candidate new TRs for the EPIC #270
 lane), and the valid row is the clean-accept **`CONTROL`**. Full per-row
 justification + the surfaced coverage gaps: **`QNX_MAPPING.md`**.
@@ -78,7 +79,14 @@ justification + the surfaced coverage gaps: **`QNX_MAPPING.md`**.
   matching `tools/iceoryx2-spike/src/judge.rs`). `<` would be a replay hole and is
   **not** used.
 - **SG-05** (and SG-04) short-circuit in the shim — the harness asserts the judge
-  is **not** called for them (visible in the p50 ≈ 39 ns row).
+  is **not** called for them (visible in the p50 ≈ 21 ns row).
+- **SG-08 torn-write (odd generation)** exercises the shim's **odd/even generation
+  seqlock** (HVCHAN-001 §3, mirroring `kirra-contract-channel`): an odd generation
+  (write in progress) or a generation that changes across the copy is rejected as
+  `StaleHeader` in the shim, before the FFI (so the judge is **not** called — it
+  short-circuits like SG-05). This replaces the prior compiler-fence-only
+  double-read-compare (review finding **S2**) with a real `atomic_thread_fence(acquire)`
+  barrier + a monotonic counter — sound on weakly-ordered targets, not ABA-prone.
 
 ## Honesty (WCET-TBD)
 

--- a/tools/qnx-rtm-harness/kirra_ffi.h
+++ b/tools/qnx-rtm-harness/kirra_ffi.h
@@ -47,18 +47,20 @@ extern "C" {
  *
  * Layout: NATURALLY ALIGNED, widest-first AFTER the leading pointer. NOTHING is
  * packed — `repr(C)` on the Rust side matches this field order and the compiler
- * inserts only natural tail padding. (On LP64: payload@0, the five u64 @8..47,
- * payload_len@48, commanded_velocity@52, integrity_ok@56, header_torn@57, 6 B
- * tail pad → sizeof == 64, alignof == 8.)
+ * inserts only natural tail padding. (On LP64: payload@0, generation@8, the five
+ * u64 @16..55, payload_len@56, commanded_velocity@60, integrity_ok@64,
+ * header_torn@65, 6 B tail pad → sizeof == 72, alignof == 8.)
  *
- * `payload` is `const volatile uint8_t*`: the SHIM performs the double-read tear
- * detection and the CRC over this region (volatile = the underlying bytes may be
+ * `payload` is `const volatile uint8_t*`: the SHIM obtains a coherent snapshot via
+ * the GENERATION SEQLOCK (`generation`, below) and computes the CRC over this
+ * region (volatile = the underlying bytes may be
  * concurrently written by an untrusted producer). By the time the JUDGE runs,
  * the shim has stabilized and bounds/CRC-checked the data; the judge reads only
  * the scalar header fields below (it does NOT walk `payload`).
  */
 typedef struct KirraContractView {
     const volatile uint8_t *payload;     /* producer payload region (shim-owned) */
+    uint64_t generation;                 /* seqlock: ODD=write in progress, EVEN=committed */
     uint64_t magic;                      /* must equal KIRRA_CONTRACT_MAGIC      */
     uint64_t sequence;                   /* this command's monotonic sequence    */
     uint64_t last_accepted_sequence;     /* highest already-accepted sequence    */
@@ -67,7 +69,7 @@ typedef struct KirraContractView {
     uint32_t payload_len;                /* valid payload bytes; shim bounds-checks */
     int32_t  commanded_velocity;         /* extracted command scalar (see judge unit) */
     uint8_t  integrity_ok;               /* upstream integrity assertion (1 = set) */
-    uint8_t  header_torn;                /* shim double-read detected a tear (1 = torn) */
+    uint8_t  header_torn;                /* explicit upstream tear flag (1 = torn) */
 } KirraContractView;
 
 /*

--- a/tools/qnx-rtm-harness/kirra_judge.rs
+++ b/tools/qnx-rtm-harness/kirra_judge.rs
@@ -58,6 +58,7 @@ pub const PROXY_MAX_COMMANDED_VELOCITY: i32 = 22_350; // mm/s ≈ 22.35 m/s (PRO
 #[repr(C)]
 pub struct KirraContractView {
     pub payload: *const u8, // const volatile uint8_t* on the C side (shim-owned)
+    pub generation: u64,    // seqlock counter; the SHIM owns the seqlock, the judge ignores it
     pub magic: u64,
     pub sequence: u64,
     pub last_accepted_sequence: u64,
@@ -103,7 +104,8 @@ pub unsafe extern "C" fn kirra_judge_assess(v: *const KirraContractView) -> u8 {
     let view = unsafe { &*v };
 
     // 1. Header magic. A garbled/torn header is fail-closed StaleHeader. (The
-    //    shim's double-read also sets `header_torn`; honor it here too.)
+    //    shim's generation seqlock catches torn writes upstream; the explicit
+    //    `header_torn` flag is honored here too as belt-and-braces.)
     if view.magic != KIRRA_CONTRACT_MAGIC || view.header_torn != 0 {
         return VERDICT_STALE_HEADER;
     }

--- a/tools/qnx-rtm-harness/kirra_shim.cpp
+++ b/tools/qnx-rtm-harness/kirra_shim.cpp
@@ -23,55 +23,59 @@ std::uint32_t crc32_ieee(const std::uint8_t *data, std::uint32_t len) noexcept {
 
 namespace {
 
-// Stabilize the volatile shared header by reading it TWICE and comparing the
-// fields. Equal copies ⇒ no torn write occurred across the reads. `out` receives
-// the stabilized, non-volatile snapshot the judge will see.
+// Bounded seqlock retry budget. A persistently odd generation (writer wedged) or
+// a churning generation exhausts this and FAILS CLOSED (StaleHeader) — never a
+// stale-data accept. Mirrors `kirra-contract-channel`'s MAX_SNAPSHOT_RETRIES.
+constexpr unsigned kMaxSeqlockRetries = 4;
+
+// Obtain a coherent snapshot of the volatile shared header via the odd/even
+// GENERATION SEQLOCK (HVCHAN-001 §3 steps 2-3 — the same mechanism as the
+// certified-style reference in `crates/kirra-contract-channel`). The publisher
+// makes `generation` ODD while writing and EVEN on commit. The reader loads the
+// generation; if odd, a write is in progress; otherwise it copies the body and
+// re-reads the generation, accepting only if it is UNCHANGED and EVEN.
 //
-// Returns true if the snapshot is coherent (and not flagged torn); false on a
-// detected tear. A real producer racing the reader would surface here; the
-// injected `header_torn` flag is honored as a belt-and-braces signal.
-bool stabilize_header(const volatile KirraContractView *hdr,
-                      KirraContractView *out) noexcept {
-    // First read.
-    KirraContractView a;
-    a.payload = hdr->payload;
-    a.magic = hdr->magic;
-    a.sequence = hdr->sequence;
-    a.last_accepted_sequence = hdr->last_accepted_sequence;
-    a.now_monotonic_ns = hdr->now_monotonic_ns;
-    a.deadline_monotonic_ns = hdr->deadline_monotonic_ns;
-    a.payload_len = hdr->payload_len;
-    a.commanded_velocity = hdr->commanded_velocity;
-    a.integrity_ok = hdr->integrity_ok;
-    a.header_torn = hdr->header_torn;
+// A real CPU ACQUIRE BARRIER (`std::atomic_thread_fence(acquire)`) orders the body
+// copy between the two generation reads, so the tear detection is SOUND on
+// weakly-ordered targets (aarch64) — unlike the prior `atomic_signal_fence`
+// (compiler-only, no CPU barrier) double-read-compare, which was also ABA-prone.
+// Retries are bounded; exhaustion ⇒ fail closed. `out` receives the stabilized,
+// non-volatile snapshot the judge will see. Returns true iff the snapshot is
+// coherent AND not flagged torn.
+bool seqlock_acquire_snapshot(const volatile KirraContractView *hdr,
+                              KirraContractView *out) noexcept {
+    for (unsigned attempt = 0; attempt < kMaxSeqlockRetries; ++attempt) {
+        const std::uint64_t g1 = hdr->generation;
+        std::atomic_thread_fence(std::memory_order_acquire); // rmb after reading g1
+        if ((g1 & 1u) != 0u) {
+            continue; // odd ⇒ a write is in progress → retry
+        }
 
-    // Prevent the compiler from coalescing the two volatile reads.
-    std::atomic_signal_fence(std::memory_order_acq_rel);
+        // Copy the whole struct into local, non-volatile memory.
+        KirraContractView a;
+        a.payload = hdr->payload;
+        a.generation = g1;
+        a.magic = hdr->magic;
+        a.sequence = hdr->sequence;
+        a.last_accepted_sequence = hdr->last_accepted_sequence;
+        a.now_monotonic_ns = hdr->now_monotonic_ns;
+        a.deadline_monotonic_ns = hdr->deadline_monotonic_ns;
+        a.payload_len = hdr->payload_len;
+        a.commanded_velocity = hdr->commanded_velocity;
+        a.integrity_ok = hdr->integrity_ok;
+        a.header_torn = hdr->header_torn;
 
-    // Second read.
-    KirraContractView b;
-    b.payload = hdr->payload;
-    b.magic = hdr->magic;
-    b.sequence = hdr->sequence;
-    b.last_accepted_sequence = hdr->last_accepted_sequence;
-    b.now_monotonic_ns = hdr->now_monotonic_ns;
-    b.deadline_monotonic_ns = hdr->deadline_monotonic_ns;
-    b.payload_len = hdr->payload_len;
-    b.commanded_velocity = hdr->commanded_velocity;
-    b.integrity_ok = hdr->integrity_ok;
-    b.header_torn = hdr->header_torn;
-
-    const bool coherent =
-        a.payload == b.payload && a.magic == b.magic && a.sequence == b.sequence &&
-        a.last_accepted_sequence == b.last_accepted_sequence &&
-        a.now_monotonic_ns == b.now_monotonic_ns &&
-        a.deadline_monotonic_ns == b.deadline_monotonic_ns &&
-        a.payload_len == b.payload_len &&
-        a.commanded_velocity == b.commanded_velocity &&
-        a.integrity_ok == b.integrity_ok && a.header_torn == b.header_torn;
-
-    *out = a;
-    return coherent && a.header_torn == 0;
+        std::atomic_thread_fence(std::memory_order_acquire); // rmb before reading g2
+        const std::uint64_t g2 = hdr->generation;
+        if (g1 == g2) {
+            // Unchanged and even ⇒ the copy did not race a writer.
+            *out = a;
+            // Belt-and-braces: an explicit upstream tear flag also fails closed.
+            return a.header_torn == 0;
+        }
+        // generation moved across the copy ⇒ torn → retry.
+    }
+    return false; // bounded retry exhausted ⇒ fail closed
 }
 
 } // namespace
@@ -81,9 +85,9 @@ std::uint8_t shim_process(const ShimInput &in, bool *judge_was_called) noexcept 
         *judge_was_called = false;
     }
 
-    // DRIVER step 1 — tear detection on the header (double-read).
+    // DRIVER step 1 — coherent snapshot via the generation seqlock.
     KirraContractView snap;
-    if (!stabilize_header(in.header, &snap)) {
+    if (!seqlock_acquire_snapshot(in.header, &snap)) {
         return KIRRA_VERDICT_STALE_HEADER;
     }
 

--- a/tools/qnx-rtm-harness/kirra_shim.hpp
+++ b/tools/qnx-rtm-harness/kirra_shim.hpp
@@ -1,9 +1,9 @@
 // kirra_shim.hpp — the C++ SHIM (the driver) for the QNX RTM harness.
 //
 // EPIC #270, issue #271. The concern split (see README + ADR-0006 Clause 3):
-// the SHIM owns MEMORY/TRANSPORT safety — double-read tear detection on the
-// header, bounds rejection (oversize SHORT-CIRCUITS here and NEVER crosses the
-// FFI), and the in-place CRC over the payload. The Rust JUDGE
+// the SHIM owns MEMORY/TRANSPORT safety — odd/even generation-seqlock tear
+// detection on the header, bounds rejection (oversize SHORT-CIRCUITS here and
+// NEVER crosses the FFI), and the in-place CRC over the payload. The Rust JUDGE
 // (`kirra_judge_assess`) renders the CONTRACT verdict on the stabilized snapshot
 // the shim hands it. Memory faults die in the driver; contract faults go to the
 // judge.
@@ -28,8 +28,8 @@ std::uint32_t crc32_ieee(const std::uint8_t *data, std::uint32_t len) noexcept;
 // What the shim driver consumes for one assessment.
 struct ShimInput {
     // The SHARED header, qualified volatile: its bytes may be concurrently
-    // written by an untrusted producer. The shim double-reads it to detect a
-    // torn write before trusting any field.
+    // written by an untrusted producer. The shim reads it under the odd/even
+    // generation seqlock to obtain a coherent snapshot before trusting any field.
     const volatile KirraContractView *header;
     const std::uint8_t *payload;       // payload bytes (header->payload_len valid)
     std::uint32_t declared_crc;        // CRC the producer claims over the payload

--- a/tools/qnx-rtm-harness/rtm_harness.cpp
+++ b/tools/qnx-rtm-harness/rtm_harness.cpp
@@ -65,6 +65,7 @@ struct Baseline {
     Baseline() {
         crc = kirra::crc32_ieee(payload, sizeof(payload));
         view.payload = payload;
+        view.generation = 2;                         // EVEN ⇒ committed (seqlock)
         view.magic = KIRRA_CONTRACT_MAGIC;
         view.last_accepted_sequence = 1000;
         view.sequence = 1001;                       // strictly newer ⇒ valid
@@ -119,6 +120,10 @@ void inj_kinematic(KirraContractView &v, std::uint8_t *, std::uint32_t &) {
 void inj_replay(KirraContractView &v, std::uint8_t *, std::uint32_t &) {
     v.sequence = 1000; // EQUAL to last_accepted ⇒ replay ⇒ SequenceRegress
 }
+void inj_torn_generation(KirraContractView &v, std::uint8_t *, std::uint32_t &) {
+    v.generation = 3; // ODD ⇒ write-in-progress ⇒ seqlock rejects (StaleHeader),
+                      // in the SHIM, before the FFI (judge NOT called).
+}
 
 // Verdicts + injection unchanged from #284; only the RTM-mapping cells are added.
 // Mapping is GROUNDED in REQUIREMENTS_TRACEABILITY.md / SAFETY_GOALS.md — only the
@@ -133,6 +138,7 @@ const Row kRows[] = {
     {"SG-05", "payload-oversize",      "NO-RTM-ID",     "NO-RTM-ID", "CANDIDATE", KIRRA_VERDICT_PAYLOAD_OVERSIZE, false, inj_oversize},
     {"SG-06", "over-envelope",         "SG-001/TR-001", "SG-001",    "TR-001",    KIRRA_VERDICT_KINEMATIC_LIMIT,  true,  inj_kinematic},
     {"SG-07", "replay (seq==last)",    "NO-RTM-ID",     "NO-RTM-ID", "CANDIDATE", KIRRA_VERDICT_SEQUENCE_REGRESS, true,  inj_replay},
+    {"SG-08", "torn-write (odd gen)",  "NO-RTM-ID",     "NO-RTM-ID", "CANDIDATE", KIRRA_VERDICT_STALE_HEADER,     false, inj_torn_generation},
 };
 
 struct RowResult {


### PR DESCRIPTION
Closes the engineering-review **S2** finding. The QNX RTM-harness shim's torn-read detection was a **compiler-only `std::atomic_signal_fence` double-read-compare** over non-atomic `volatile` reads — no CPU barrier, unsound on weakly-ordered targets (aarch64), and ABA-prone. Now that `crates/kirra-contract-channel` has the certified-style reference (#615), the harness uses the **same odd/even generation seqlock the spec mandates** (HVCHAN-001 §3 steps 2-3).

### Changes
- **`kirra_ffi.h` + `kirra_judge.rs`** — add a `generation` field to `KirraContractView` (offset 8, after the pointer) on **both** sides of the `#[repr(C)]` ABI. The shim owns the seqlock; the judge ignores the field. Layout comment updated (`sizeof` 64 → 72).
- **`kirra_shim.cpp`** — `stabilize_header` → `seqlock_acquire_snapshot`: read generation; if **odd**, a write is in progress; else copy the body and re-read; accept only if **unchanged and even**. A real **`std::atomic_thread_fence(acquire)`** barrier orders the copy between the two generation reads (replacing the signal fence). Bounded retries; exhaustion ⇒ fail closed.
- **`rtm_harness.cpp`** — even baseline generation; **new fault row SG-08 "torn-write (odd generation)"** injects an odd generation and asserts it's rejected as `StaleHeader` **in the shim, before the FFI** (judge not called). The harness now actually **exercises** the tear mechanism — *no prior row did*, so the detection was dormant.
- **`README.md` / `QNX_MAPPING.md`** — mechanism description, row count 8 → 9, gap count 6 → 7 (+ the new snapshot-coherence `NO-RTM-ID` gap and its justification).

### Verified locally
g++ 13.3 + rustc 1.94, cmake build clean under `-Wall -Wextra -Werror -fno-exceptions -fno-rtti`; **ctest 2/2; all 9 rows PASS**; SG-08 short-circuits (~21 ns, judge not called). The ABI struct layouts agree (judge rows render correct verdicts). No QNX target needed for the host build — the cross-compile/on-target FDIT/WCET remains #274.

> This is the in-partition harness mechanism; it does not change the cross-partition `GovernorContractView` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_