### PR TITLE
federation: per-controller generation high-water gate + in-chain gap marker (review item 20)

### DIFF
--- a/src/bin/kirra_verifier_service/audit.rs
+++ b/src/bin/kirra_verifier_service/audit.rs
@@ -105,9 +105,12 @@ pub(crate) async fn handle_audit_rotate_key(
             (StatusCode::SERVICE_UNAVAILABLE,
              Json(json!({ "error": "fenced: epoch superseded; instance demoted to passive standby" }))).into_response()
         }
-        // NonceReplay cannot arise here (key rotation never touches the nonce
-        // table); fold it into the generic server-error arm for exhaustiveness.
-        Err(DurableWriteError::Db(_) | DurableWriteError::NonceReplay) => (StatusCode::INTERNAL_SERVER_ERROR,
+        // NonceReplay / GenerationRegress cannot arise here (key rotation touches
+        // neither the nonce nor the federation-generation tables); fold them into the
+        // generic server-error arm for exhaustiveness.
+        Err(DurableWriteError::Db(_)
+            | DurableWriteError::NonceReplay
+            | DurableWriteError::GenerationRegress { .. }) => (StatusCode::INTERNAL_SERVER_ERROR,
                    Json(json!({ "error": "failed to record key rotation" }))).into_response(),
     }
 }

--- a/src/bin/kirra_verifier_service/federation.rs
+++ b/src/bin/kirra_verifier_service/federation.rs
@@ -115,6 +115,21 @@ pub(crate) async fn submit_federated_report(
                 );
                 FedCommitOutcome::Rejected("FEDERATED_NONCE_REPLAY")
             }
+            Err(DurableWriteError::GenerationRegress { found, high_water }) => {
+                // Item 20: a validly-signed but stale (older-generation) report that
+                // slipped inside the freshness window. Reject fail-closed with a clean
+                // audit trail — the report was NOT persisted and no nonce was burned.
+                let event = json!({ "source_controller_id": report.source_controller_id,
+                                    "asset_id": report.asset_id,
+                                    "offered_generation": found,
+                                    "high_water_generation": high_water,
+                                    "reason": "FEDERATION_GENERATION_REGRESS" });
+                let _ = store.save_posture_event_chained(
+                    "federation_gateway", "FEDERATION_REJECTED",
+                    &event.to_string(), Some("generation regress/replay"), received_at_ms,
+                );
+                FedCommitOutcome::Rejected("FEDERATED_GENERATION_REGRESS")
+            }
             Err(DurableWriteError::Fenced(reason)) => FedCommitOutcome::Fenced(format!("{reason:?}")),
             Err(DurableWriteError::Db(_)) => FedCommitOutcome::InternalError("failed to persist federated report"),
         }

--- a/src/federation_reconciliation.rs
+++ b/src/federation_reconciliation.rs
@@ -402,6 +402,39 @@ mod federation_reconciliation_tests {
         assert_eq!(v2_payload, v1_payload);
     }
 
+    /// Item 20 — BYTE-STABILITY pin. The canonical payload is the exact byte string
+    /// the Ed25519 signature is computed over; any reordering, key rename, or
+    /// whitespace change silently breaks cross-controller verification (a signed
+    /// report from peer B would no longer verify here). These assertions pin the
+    /// serialized bytes so such a regression fails CI instead of the field.
+    #[test]
+    fn test_canonical_payload_v2_byte_stability_with_generation() {
+        let r = degraded("ctrl-a", 1000, Some(412));
+        let payload = canonical_federation_payload_v2(&r);
+        // serde_json serializes a Map with sorted keys (no preserve_order feature),
+        // so the field order is deterministic and alphabetical.
+        assert_eq!(
+            payload,
+            r#"{"asset_id":"lidar_front","expires_at_ms":31000,"issued_at_ms":1000,"nonce_hex":"ctrl-a_1000","posture":"Degraded","source_controller_id":"ctrl-a","source_generation":412}"#
+        );
+    }
+
+    /// Item 20 — BYTE-STABILITY pin for the v1-compat (no-generation) payload. It
+    /// must be byte-identical to the v1 canonical payload (no `source_generation`
+    /// key at all), or a v1 controller's signature would fail to verify on the v2
+    /// path. This is the wire-compat contract, asserted on exact bytes.
+    #[test]
+    fn test_canonical_payload_v2_byte_stability_without_generation() {
+        let r = nominal("ctrl-a", 1000, None);
+        let payload = canonical_federation_payload_v2(&r);
+        assert_eq!(
+            payload,
+            r#"{"asset_id":"lidar_front","expires_at_ms":31000,"issued_at_ms":1000,"nonce_hex":"ctrl-a_1000","posture":"Nominal","source_controller_id":"ctrl-a"}"#
+        );
+        // And it equals the v1 canonical payload byte-for-byte (the compat contract).
+        assert_eq!(payload, crate::federation::canonical_federation_payload(&r.as_v1()));
+    }
+
     #[test]
     fn test_payload_with_generation_includes_generation_field() {
         let r = degraded("ctrl-a", 1000, Some(412));

--- a/src/verifier_store/audit.rs
+++ b/src/verifier_store/audit.rs
@@ -483,6 +483,27 @@ impl VerifierStore {
             )",
             [],
         )?;
+        // Per-(controller, asset) generation HIGH-WATER mark. The nonce table stops a
+        // byte-identical replay, but two genuinely-distinct, validly-signed reports
+        // from one controller — a newer (higher-generation) and an older one — can
+        // still arrive out of order inside the freshness window; without a high-water
+        // gate the stale one would last-write-win at storage and the read-time
+        // reconciliation (`authoritative_posture`) would then have to undo it. This
+        // table makes generation regression fail-closed AT INGEST: a report whose
+        // generation is <= the stored mark for its (controller, asset) is rejected
+        // before it persists. A forward JUMP (generation > mark + 1) is accepted but
+        // leaves an in-chain FEDERATION_GENERATION_GAP audit marker recording the
+        // skipped generations (reports lost to a partition).
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS federation_generation_highwater (
+                source_controller_id TEXT NOT NULL,
+                asset_id             TEXT NOT NULL,
+                last_generation      INTEGER NOT NULL,
+                last_seen_ms         INTEGER NOT NULL,
+                PRIMARY KEY (source_controller_id, asset_id)
+            )",
+            [],
+        )?;
         // Per-asset report lookups order by received_at_ms; the nonce retention
         // sweep deletes by seen_at_ms on every federation accept. Both scan
         // unindexed columns without these.

--- a/src/verifier_store/federation.rs
+++ b/src/verifier_store/federation.rs
@@ -27,6 +27,56 @@ impl VerifierStore {
         // fenced after the request-path gate check cannot land a stale report.
         Self::assert_epoch_held(&tx, held_epoch)?;
 
+        // Item 20 — per-(controller, asset) GENERATION HIGH-WATER gate. Runs inside
+        // the Immediate write lock (no interleave). Only v2 reports (a supplied
+        // `source_generation`) are gated; a v1 report (None) keeps its legacy
+        // timestamp-ordered behaviour. Two outcomes that matter here:
+        //   * regress/replay: `gen <= high_water` → abort the whole commit
+        //     (fail-closed; the stale report never persists and no nonce is burned);
+        //   * forward GAP: `gen > high_water + 1` → accept, but record the skipped
+        //     generations as an in-chain audit marker (below, after the report row).
+        // `gap_from` carries the prior high-water when a gap is detected so the
+        // marker can be appended in the SAME transaction as the accepted report.
+        let mut gap_from: Option<u64> = None;
+        if let Some(gen) = source_generation {
+            let high_water: Option<u64> = tx
+                .query_row(
+                    "SELECT last_generation FROM federation_generation_highwater
+                     WHERE source_controller_id = ?1 AND asset_id = ?2",
+                    params![report.source_controller_id, report.asset_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map(|g| Some(g as u64))
+                .or_else(|e| match e {
+                    rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                    other => Err(other),
+                })?;
+
+            if let Some(hw) = high_water {
+                if gen <= hw {
+                    // tx drops here → atomic rollback. Fail-closed.
+                    return Err(DurableWriteError::GenerationRegress { found: gen, high_water: hw });
+                }
+                if gen > hw + 1 {
+                    gap_from = Some(hw);
+                }
+            }
+
+            // Advance the high-water within the same tx (UPSERT; the gate above
+            // guarantees strict advance for an existing row).
+            tx.execute(
+                "INSERT INTO federation_generation_highwater
+                     (source_controller_id, asset_id, last_generation, last_seen_ms)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(source_controller_id, asset_id)
+                 DO UPDATE SET last_generation = ?3, last_seen_ms = ?4",
+                params![
+                    report.source_controller_id, report.asset_id,
+                    gen as i64, received_at_ms as i64,
+                ],
+            )?;
+        }
+
         let posture_json = serde_json::to_string(&report.posture)
             .map_err(|_| rusqlite::Error::InvalidQuery)?;
 
@@ -76,6 +126,31 @@ impl VerifierStore {
             received_at_ms as i64,
             signing_key.as_ref(),
         )?;
+
+        // Item 20 — in-chain AUDIT_GAP marker. A forward generation jump means this
+        // controller's intermediate reports never reached us (a partition / drop):
+        // the chain MUST record that we are missing generations `hw+1 ..= gen-1`, so a
+        // later auditor sees an explicit, tamper-evident "coverage gap" instead of an
+        // unexplained generation discontinuity. Same tx as the accepted report → the
+        // marker is committed iff the report is.
+        if let (Some(hw), Some(gen)) = (gap_from, source_generation) {
+            let gap = serde_json::json!({
+                "source_controller_id": report.source_controller_id,
+                "asset_id": report.asset_id,
+                "last_accepted_generation": hw,
+                "observed_generation": gen,
+                "missing_from_generation": hw + 1,
+                "missing_through_generation": gen - 1,
+                "skipped_generations": gen - hw - 1,
+            });
+            crate::audit_chain::AuditChainLinker::append_audit_event_tx(
+                &tx,
+                "FEDERATION_GENERATION_GAP",
+                &gap.to_string(),
+                received_at_ms as i64,
+                signing_key.as_ref(),
+            )?;
+        }
 
         // Bounded retention (review M2): the nonce table is the durable anti-replay
         // set, but it only ever grew (rising disk + fsync cost). A nonce aged past

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -166,6 +166,14 @@ pub enum DurableWriteError {
     /// transaction). Distinct from `Db` so the handler maps it to a clean
     /// `FEDERATED_NONCE_REPLAY` rejection (+ audit), NOT an opaque HTTP 500.
     NonceReplay,
+    /// Item 20: the report's `source_generation` is <= the per-(controller, asset)
+    /// high-water mark — a generation regression or replay of an older signed
+    /// report that slipped inside the freshness window. The transaction is aborted
+    /// (report NOT persisted, nonce NOT burned, high-water NOT advanced), so the
+    /// handler maps it to a clean `FEDERATED_GENERATION_REGRESS` rejection (+ audit),
+    /// NOT an opaque HTTP 500. `found` is the offered generation; `high_water` is the
+    /// last accepted generation it failed to exceed.
+    GenerationRegress { found: u64, high_water: u64 },
     Db(rusqlite::Error),
 }
 
@@ -194,6 +202,10 @@ impl std::fmt::Display for DurableWriteError {
             DurableWriteError::NonceReplay => {
                 write!(f, "durable write rejected: federation nonce already burned (replay)")
             }
+            DurableWriteError::GenerationRegress { found, high_water } => write!(
+                f,
+                "durable write rejected: federation generation {found} <= high-water {high_water} (regress/replay)"
+            ),
             DurableWriteError::Db(e) => write!(f, "durable write failed: {e}"),
         }
     }

--- a/src/verifier_store/tests.rs
+++ b/src/verifier_store/tests.rs
@@ -768,6 +768,96 @@ mod durability_tests {
         assert_eq!(count, 1, "the replayed report must NOT have been persisted (atomic rollback)");
     }
 
+    /// Item 20 — the per-(controller, asset) generation high-water gate ACCEPTS a
+    /// strictly-ascending generation and advances the mark each time.
+    #[test]
+    fn generation_highwater_accepts_ascending() {
+        let mut s = VerifierStore::new(":memory:").unwrap();
+        assert_eq!(s.try_claim_epoch(0, "A", 1).unwrap(), Some(1));
+        s.save_federated_report_chained(&report("g1"), Some(10), 2_000, 1).unwrap();
+        s.save_federated_report_chained(&report("g2"), Some(11), 2_001, 1).unwrap();
+        s.save_federated_report_chained(&report("g3"), Some(50), 2_002, 1).unwrap();
+        let hw: i64 = s.conn.query_row(
+            "SELECT last_generation FROM federation_generation_highwater
+             WHERE source_controller_id = 'ctrl-A' AND asset_id = 'asset-1'",
+            [], |r| r.get(0),
+        ).unwrap();
+        assert_eq!(hw, 50, "the high-water mark advances to the latest accepted generation");
+    }
+
+    /// Item 20 — a report whose generation is <= the high-water (a regress, or an
+    /// equal-generation replay of a distinct signed report) is REJECTED fail-closed
+    /// and the whole commit rolls back: no report row, no burned nonce.
+    #[test]
+    fn generation_highwater_rejects_regress_and_rolls_back() {
+        let mut s = VerifierStore::new(":memory:").unwrap();
+        assert_eq!(s.try_claim_epoch(0, "A", 1).unwrap(), Some(1));
+        s.save_federated_report_chained(&report("hi"), Some(20), 2_000, 1).unwrap();
+
+        for (nonce, gen) in [("lo", 19u64), ("eq", 20u64)] {
+            let res = s.save_federated_report_chained(&report(nonce), Some(gen), 2_010, 1);
+            assert!(
+                matches!(res, Err(DurableWriteError::GenerationRegress { found, high_water })
+                    if found == gen && high_water == 20),
+                "generation {gen} <= high-water 20 must surface as GenerationRegress, got {res:?}"
+            );
+            assert!(!s.has_seen_federation_nonce(nonce).unwrap(),
+                "a rejected report must NOT have burned its nonce (atomic rollback)");
+        }
+
+        let count: i64 = s.conn.query_row(
+            "SELECT COUNT(*) FROM federated_trust_reports WHERE asset_id = 'asset-1'",
+            [], |r| r.get(0),
+        ).unwrap();
+        assert_eq!(count, 1, "only the first (gen 20) report persists; the regresses rolled back");
+    }
+
+    /// Item 20 — a v1 report (no generation) is NOT gated and does not seed the
+    /// high-water table, preserving backward-compatible timestamp ordering.
+    #[test]
+    fn generation_highwater_skips_v1_reports() {
+        let mut s = VerifierStore::new(":memory:").unwrap();
+        assert_eq!(s.try_claim_epoch(0, "A", 1).unwrap(), Some(1));
+        s.save_federated_report_chained(&report("v1a"), None, 2_000, 1).unwrap();
+        s.save_federated_report_chained(&report("v1b"), None, 2_001, 1).unwrap();
+        let rows: i64 = s.conn.query_row(
+            "SELECT COUNT(*) FROM federation_generation_highwater", [], |r| r.get(0),
+        ).unwrap();
+        assert_eq!(rows, 0, "a v1 (None-generation) report must not touch the high-water table");
+    }
+
+    /// Item 20 — a forward generation JUMP (gen > high-water + 1) is accepted but
+    /// records an in-chain FEDERATION_GENERATION_GAP marker naming the skipped
+    /// generations; a contiguous +1 step does NOT.
+    #[test]
+    fn generation_gap_emits_in_chain_audit_marker() {
+        let mut s = VerifierStore::new(":memory:").unwrap();
+        assert_eq!(s.try_claim_epoch(0, "A", 1).unwrap(), Some(1));
+        s.save_federated_report_chained(&report("base"), Some(5), 2_000, 1).unwrap();
+        // Contiguous step: no gap marker.
+        s.save_federated_report_chained(&report("step"), Some(6), 2_001, 1).unwrap();
+        // Jump 6 -> 9: missing 7,8 -> one gap marker.
+        s.save_federated_report_chained(&report("jump"), Some(9), 2_002, 1).unwrap();
+
+        let markers: i64 = s.conn.query_row(
+            "SELECT COUNT(*) FROM audit_log_chain WHERE event_type = 'FEDERATION_GENERATION_GAP'",
+            [], |r| r.get(0),
+        ).unwrap();
+        assert_eq!(markers, 1, "exactly one gap marker for the 6->9 jump (the +1 step emits none)");
+
+        let payload: String = s.conn.query_row(
+            "SELECT event_json FROM audit_log_chain
+             WHERE event_type = 'FEDERATION_GENERATION_GAP'",
+            [], |r| r.get(0),
+        ).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(v["last_accepted_generation"], 6);
+        assert_eq!(v["observed_generation"], 9);
+        assert_eq!(v["missing_from_generation"], 7);
+        assert_eq!(v["missing_through_generation"], 8);
+        assert_eq!(v["skipped_generations"], 2);
+    }
+
     /// M2: accepting a report prunes nonces older than the retention horizon, so the
     /// anti-replay table stays bounded. Pruning an aged nonce is safe — a replay of
     /// its report fails the freshness gate on its fixed signed issued_at_ms — this


### PR DESCRIPTION
## Review item 20 — federation per-controller generation high-water + canonical-payload byte-stability + in-chain AUDIT_GAP marker

The federation layer persisted `source_generation` and reconciled it at **read** time (`authoritative_posture`), but **ingest had no generation gate**. The nonce table stops only a byte-identical replay — two genuinely-distinct, validly-signed reports from one controller (a newer and an older), each with its own nonce, arriving out of order inside the freshness window, would last-write-win at storage, leaving read-time reconciliation to undo a stale write. This PR closes the hole at ingest.

### Generation high-water gate
New `federation_generation_highwater(source_controller_id, asset_id, last_generation, last_seen_ms)` table. Inside the existing Immediate-locked federation commit (no interleave), a v2 report is gated:
- `generation <= high-water` for its `(controller, asset)` → the **whole commit aborts** (`DurableWriteError::GenerationRegress`): report not persisted, nonce not burned, mark not advanced. Fail-closed.
- Strictly-greater → accept and advance the mark.
- **v1 reports (`None` generation) are ungated** — backward-compatible timestamp ordering preserved; they don't seed the table.

### In-chain AUDIT_GAP marker
A forward generation **jump** (`generation > high-water + 1`) is accepted but appends a `FEDERATION_GENERATION_GAP` audit event **in the same transaction**, naming the skipped generations (reports lost to a partition) — an explicit, tamper-evident coverage gap in the hash chain instead of an unexplained discontinuity. A contiguous `+1` step emits none.

### Handler wiring
`GenerationRegress` → clean `FEDERATED_GENERATION_REGRESS` rejection + posture-event audit (not an opaque 500). The key-rotation match arm folds the new variant into its server-error case for exhaustiveness (it can never arise there).

### Canonical-payload byte-stability pins
Exact-byte assertions on `canonical_federation_payload_v2` for both the with-generation and v1-compat (no-generation) cases — the latter asserted **byte-identical** to the v1 `canonical_federation_payload`. This is the signed-bytes wire contract: a refactor that reorders or renames keys now fails CI instead of silently breaking cross-controller Ed25519 verification.

## Tests
- Store gate: accept-ascending (+ mark advances), reject-regress/equal with atomic rollback (nonce not burned), skip-v1 (table untouched), gap-marker payload fields.
- Reconciliation: two byte-stability pins (with/without generation + v1 equality).
- 81 store + 31 federation lib tests pass; `cargo clippy -p kirra-verifier --lib --bins -- -D warnings` clean.

## Invariants preserved
The 5-step acceptance pipeline (structural → key → signature → nonce → atomic commit), the HA epoch fence (first statement in the tx), nonce single-use burn, and bounded nonce retention are all unchanged; the generation gate sits inside the same atomic commit and is purely additive and fail-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_