### PR TITLE
dds: real CycloneDDS actuator writer + read-back QoS validation (review item 19 D1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,12 @@ panic = "abort"
 [features]
 ros2 = []
 tpm = ["dep:tss-esapi"]
+# D1 (item 19): the real CycloneDDS actuator writer (`src/dds_cyclonedds.rs`).
+# Links the native CycloneDDS `libddsc` — built ONLY on an integrator host that
+# ships CycloneDDS (e.g. ROS 2 Jazzy), never in the default CI/build container.
+# Pulls NO Rust dependency; the QoS mapping + read-back validation it relies on
+# are pure functions in `dds_bridge.rs`, exercised by the default test suite.
+cyclonedds = []
 
 [dependencies]
 # Lean safety/contract foundation (de-monolith Stage 1): FleetPosture / NodeTrustState

--- a/src/dds_bridge.rs
+++ b/src/dds_bridge.rs
@@ -144,6 +144,270 @@ impl DdsPublisherBridge {
     }
 }
 
+// ===========================================================================
+// D1 — real-writer seam + read-back QoS validation (review item 19)
+// ===========================================================================
+//
+// `actuator_admissibility` validates the profile we ASK FOR. But DDS QoS is
+// REQUESTED-OFFERED: the middleware may negotiate a writer whose effective QoS
+// differs from what we requested (a misconfigured XML profile, an env override,
+// a participant default, or a peer-driven downgrade). For an actuator topic a
+// SILENT downgrade is exactly the INV-10/SG-016 hazard re-opened one layer down:
+// a writer that came back TransientLocal, or with the deadline dropped, can
+// replay or outlive a command even though the profile we handed in was clean.
+//
+// So the real-writer contract is: create the writer, READ ITS QoS BACK
+// (`dds_get_qos` in the CycloneDDS impl), and run it through
+// `validate_qos_readback` — refuse to publish on ANY actuator-relevant
+// relaxation (fail-closed). This module owns that check (host-testable); the
+// `cyclonedds`-gated `dds_cyclonedds` module owns the FFI that feeds it.
+
+/// A read-back QoS mismatch: the writer the middleware actually created is
+/// WEAKER than the actuator profile we requested on some safety-relevant axis.
+/// Each variant names the relaxed policy so the publish seam / startup log can
+/// report which guarantee the middleware failed to honour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QosReadbackError {
+    /// The negotiated writer is not Volatile (e.g. TransientLocal) → a
+    /// reconnecting subscriber could replay the last command.
+    DurabilityRelaxed { requested: DdsDurability, negotiated: DdsDurability },
+    /// History is no longer KeepLast(1) → a backed-up subscriber can drain
+    /// stale commands.
+    HistoryRelaxed { requested: DdsHistory, negotiated: DdsHistory },
+    /// Reliability dropped (Reliable → BestEffort) → commands may be silently
+    /// lost without the writer noticing.
+    ReliabilityRelaxed { requested: DdsReliability, negotiated: DdsReliability },
+    /// The negotiated lifespan is unbounded or LONGER than requested → a sample
+    /// can outlive its validity horizon.
+    LifespanRelaxed { requested_ms: u32, negotiated_ms: u32 },
+    /// The negotiated deadline is unbounded or LONGER than requested → a missed
+    /// publish (silent governor) goes undetected for longer.
+    DeadlineRelaxed { requested_ms: u32, negotiated_ms: u32 },
+    /// The negotiated liveliness lease is LONGER than requested → writer loss is
+    /// detected more slowly.
+    LivelinessLeaseRelaxed { requested_ms: u32, negotiated_ms: u32 },
+}
+
+impl QosReadbackError {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            QosReadbackError::DurabilityRelaxed { .. } => "DDS_READBACK_DURABILITY_RELAXED",
+            QosReadbackError::HistoryRelaxed { .. } => "DDS_READBACK_HISTORY_RELAXED",
+            QosReadbackError::ReliabilityRelaxed { .. } => "DDS_READBACK_RELIABILITY_RELAXED",
+            QosReadbackError::LifespanRelaxed { .. } => "DDS_READBACK_LIFESPAN_RELAXED",
+            QosReadbackError::DeadlineRelaxed { .. } => "DDS_READBACK_DEADLINE_RELAXED",
+            QosReadbackError::LivelinessLeaseRelaxed { .. } => "DDS_READBACK_LIVELINESS_RELAXED",
+        }
+    }
+}
+
+impl std::fmt::Display for QosReadbackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Fail-closed read-back check: the `negotiated` QoS (what the middleware
+/// actually created, read back via `dds_get_qos`) must be AT LEAST AS STRICT as
+/// the `requested` actuator profile on every safety axis. Returns the FIRST
+/// relaxation found (checked in the same order as `actuator_admissibility`).
+///
+/// "At least as strict" for an actuator topic means: same Volatile durability,
+/// same KeepLast(1) history, still Reliable, and a lifespan / deadline / liveliness
+/// lease that is bounded (non-zero) AND not longer than requested. A negotiated
+/// horizon SHORTER than requested is acceptable (stricter); LONGER or zero is a
+/// relaxation and is refused.
+pub fn validate_qos_readback(
+    requested: &DdsQosProfile,
+    negotiated: &DdsQosProfile,
+) -> Result<(), QosReadbackError> {
+    if negotiated.durability != requested.durability {
+        return Err(QosReadbackError::DurabilityRelaxed {
+            requested: requested.durability,
+            negotiated: negotiated.durability,
+        });
+    }
+    if negotiated.history != requested.history {
+        return Err(QosReadbackError::HistoryRelaxed {
+            requested: requested.history,
+            negotiated: negotiated.history,
+        });
+    }
+    if negotiated.reliability != requested.reliability {
+        return Err(QosReadbackError::ReliabilityRelaxed {
+            requested: requested.reliability,
+            negotiated: negotiated.reliability,
+        });
+    }
+    // A zero (unbounded) negotiated horizon is the worst case and is caught by
+    // the `>` comparison too, since requested is non-zero for the critical
+    // profile — but spell it out: 0 means "infinite", which is always relaxed.
+    if negotiated.lifespan_ms == 0 || negotiated.lifespan_ms > requested.lifespan_ms {
+        return Err(QosReadbackError::LifespanRelaxed {
+            requested_ms: requested.lifespan_ms,
+            negotiated_ms: negotiated.lifespan_ms,
+        });
+    }
+    if negotiated.deadline_ms == 0 || negotiated.deadline_ms > requested.deadline_ms {
+        return Err(QosReadbackError::DeadlineRelaxed {
+            requested_ms: requested.deadline_ms,
+            negotiated_ms: negotiated.deadline_ms,
+        });
+    }
+    let DdsLiveliness::Automatic { lease_ms: req_lease } = requested.liveliness;
+    let DdsLiveliness::Automatic { lease_ms: neg_lease } = negotiated.liveliness;
+    if neg_lease == 0 || neg_lease > req_lease {
+        return Err(QosReadbackError::LivelinessLeaseRelaxed {
+            requested_ms: req_lease,
+            negotiated_ms: neg_lease,
+        });
+    }
+    Ok(())
+}
+
+/// The seam a real DDS writer plugs into. The hot path hands the writer a
+/// pre-encapsulated CDR actuator frame; the writer is responsible for having
+/// already validated its NEGOTIATED QoS read-back (fail-closed) at open time.
+/// The `cyclonedds`-gated `CycloneDdsActuatorWriter` is the production impl; a
+/// `LoopbackTestWriter` exercises the seam + read-back logic on the host.
+pub trait DdsActuatorWriter {
+    type Error: std::fmt::Debug;
+
+    /// The QoS the middleware actually negotiated for this writer (read back via
+    /// `dds_get_qos`), so a caller can re-assert `validate_qos_readback`.
+    fn negotiated_qos(&self) -> DdsQosProfile;
+
+    /// Publish one pre-encapsulated CDR actuator frame (e.g. from
+    /// `DdsPublisherBridge::publish_actuator_command`).
+    fn publish(&self, frame: &[u8]) -> Result<(), Self::Error>;
+}
+
+/// CycloneDDS QoS expressed as the raw C-API kind enums + nanosecond durations,
+/// DECOUPLED from the FFI so the whole mapping is host-testable (the FFI glue in
+/// the `cyclonedds`-gated `dds_cyclonedds` module is then a thin pass-through:
+/// these integers go straight into `dds_qset_*` and come straight out of
+/// `dds_qget_*`). Constants mirror `dds/dds.h` (stable ABI; cited per field).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CycloneQosParams {
+    /// `dds_durability_kind_t`
+    pub durability_kind: i32,
+    /// `dds_history_kind_t`
+    pub history_kind: i32,
+    pub history_depth: i32,
+    /// `dds_reliability_kind_t`
+    pub reliability_kind: i32,
+    /// `dds_duration_t` (ns); `INFINITY_NS` = unbounded
+    pub lifespan_ns: i64,
+    pub deadline_ns: i64,
+    /// `dds_liveliness_kind_t`
+    pub liveliness_kind: i32,
+    pub liveliness_lease_ns: i64,
+}
+
+impl CycloneQosParams {
+    // dds/dds.h enum values — part of the CycloneDDS ABI.
+    pub const DURABILITY_VOLATILE: i32 = 0;
+    pub const DURABILITY_TRANSIENT_LOCAL: i32 = 1;
+    pub const HISTORY_KEEP_LAST: i32 = 0;
+    pub const HISTORY_KEEP_ALL: i32 = 1;
+    pub const RELIABILITY_BEST_EFFORT: i32 = 0;
+    pub const RELIABILITY_RELIABLE: i32 = 1;
+    pub const LIVELINESS_AUTOMATIC: i32 = 0;
+    /// `DDS_INFINITY` — the max `dds_duration_t`.
+    pub const INFINITY_NS: i64 = i64::MAX;
+
+    const NS_PER_MS: i64 = 1_000_000;
+}
+
+/// Map an actuator `DdsQosProfile` to the CycloneDDS C-API parameters a writer is
+/// created with. `ms → ns`; a finite, non-zero horizon stays finite. (A zero ms
+/// horizon never reaches here for the critical profile — `actuator_admissibility`
+/// already rejects it — but if one did, it maps to `INFINITY_NS`, which the
+/// read-back validation then refuses, so the fail-closed posture is preserved.)
+pub fn qos_to_cyclone_params(profile: &DdsQosProfile) -> CycloneQosParams {
+    let ms_to_ns = |ms: u32| -> i64 {
+        if ms == 0 {
+            CycloneQosParams::INFINITY_NS
+        } else {
+            (ms as i64).saturating_mul(CycloneQosParams::NS_PER_MS)
+        }
+    };
+    let DdsLiveliness::Automatic { lease_ms } = profile.liveliness;
+    CycloneQosParams {
+        durability_kind: match profile.durability {
+            DdsDurability::Volatile => CycloneQosParams::DURABILITY_VOLATILE,
+            DdsDurability::TransientLocal => CycloneQosParams::DURABILITY_TRANSIENT_LOCAL,
+        },
+        history_kind: match profile.history {
+            DdsHistory::KeepLast(_) => CycloneQosParams::HISTORY_KEEP_LAST,
+            DdsHistory::KeepAll => CycloneQosParams::HISTORY_KEEP_ALL,
+        },
+        history_depth: match profile.history {
+            DdsHistory::KeepLast(n) => n as i32,
+            DdsHistory::KeepAll => 0,
+        },
+        reliability_kind: match profile.reliability {
+            DdsReliability::Reliable => CycloneQosParams::RELIABILITY_RELIABLE,
+            DdsReliability::BestEffort => CycloneQosParams::RELIABILITY_BEST_EFFORT,
+        },
+        lifespan_ns: ms_to_ns(profile.lifespan_ms),
+        deadline_ns: ms_to_ns(profile.deadline_ms),
+        liveliness_kind: CycloneQosParams::LIVELINESS_AUTOMATIC,
+        liveliness_lease_ns: ms_to_ns(lease_ms),
+    }
+}
+
+/// Reconstruct a `DdsQosProfile` from the QoS read back off a live writer
+/// (`dds_qget_*`). Fail-closed: an UNRECOGNISED kind (a durability/history/
+/// reliability/liveliness value Kirra's model can't represent) returns `None`,
+/// which the caller treats as a refusal — never a silent best-effort coercion. An
+/// unbounded or non-positive duration maps to `0` ms (the "unbounded" sentinel),
+/// which `validate_qos_readback` then rejects.
+pub fn cyclone_params_to_qos(p: &CycloneQosParams) -> Option<DdsQosProfile> {
+    // ns → ms, rounding a sub-ms positive UP to 1 ms (so a strict, tiny finite
+    // horizon is never mistaken for the 0 = unbounded sentinel). Unbounded /
+    // non-positive → 0 (unbounded), which fails the read-back check.
+    let ns_to_ms = |ns: i64| -> u32 {
+        if ns <= 0 || ns == CycloneQosParams::INFINITY_NS {
+            0
+        } else {
+            ns.saturating_add(CycloneQosParams::NS_PER_MS - 1)
+                .saturating_div(CycloneQosParams::NS_PER_MS)
+                .min(u32::MAX as i64) as u32
+        }
+    };
+    let durability = match p.durability_kind {
+        CycloneQosParams::DURABILITY_VOLATILE => DdsDurability::Volatile,
+        CycloneQosParams::DURABILITY_TRANSIENT_LOCAL => DdsDurability::TransientLocal,
+        _ => return None, // Transient / Persistent — not in Kirra's actuator model
+    };
+    let history = match p.history_kind {
+        CycloneQosParams::HISTORY_KEEP_LAST => {
+            DdsHistory::KeepLast(p.history_depth.clamp(0, u16::MAX as i32) as u16)
+        }
+        CycloneQosParams::HISTORY_KEEP_ALL => DdsHistory::KeepAll,
+        _ => return None,
+    };
+    let reliability = match p.reliability_kind {
+        CycloneQosParams::RELIABILITY_RELIABLE => DdsReliability::Reliable,
+        CycloneQosParams::RELIABILITY_BEST_EFFORT => DdsReliability::BestEffort,
+        _ => return None,
+    };
+    // Kirra's model only carries AUTOMATIC liveliness; a manual kind is outside
+    // the actuator contract → fail closed.
+    if p.liveliness_kind != CycloneQosParams::LIVELINESS_AUTOMATIC {
+        return None;
+    }
+    Some(DdsQosProfile {
+        reliability,
+        durability,
+        history,
+        liveliness: DdsLiveliness::Automatic { lease_ms: ns_to_ms(p.liveliness_lease_ns) },
+        lifespan_ms: ns_to_ms(p.lifespan_ns),
+        deadline_ms: ns_to_ms(p.deadline_ns),
+    })
+}
+
 #[cfg(test)]
 mod dds_qos_tests {
     use super::*;
@@ -198,5 +462,172 @@ mod dds_qos_tests {
             Err(DdsQosViolation::UnboundedLifespan),
             "a command with no validity horizon can outlive its deadline"
         );
+    }
+
+    // --- D1: read-back QoS validation + writer seam ------------------------
+
+    /// A host writer that records published frames and reports a CONFIGURABLE
+    /// negotiated QoS, so the read-back validation (the part the CycloneDDS impl
+    /// can't run in CI) is exercised on every downgrade path.
+    struct LoopbackTestWriter {
+        negotiated: DdsQosProfile,
+        sent: std::cell::RefCell<Vec<Vec<u8>>>,
+    }
+
+    impl LoopbackTestWriter {
+        fn new(negotiated: DdsQosProfile) -> Self {
+            Self { negotiated, sent: std::cell::RefCell::new(Vec::new()) }
+        }
+    }
+
+    impl DdsActuatorWriter for LoopbackTestWriter {
+        type Error = std::convert::Infallible;
+        fn negotiated_qos(&self) -> DdsQosProfile { self.negotiated }
+        fn publish(&self, frame: &[u8]) -> Result<(), Self::Error> {
+            self.sent.borrow_mut().push(frame.to_vec());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn readback_accepts_exact_match_and_writer_round_trips() {
+        let requested = DdsQosProfile::critical_actuator_profile();
+        let writer = LoopbackTestWriter::new(requested);
+        assert_eq!(validate_qos_readback(&requested, &writer.negotiated_qos()), Ok(()));
+        let frame = DdsPublisherBridge::publish_actuator_command(&[0xDE, 0xAD], &requested).unwrap();
+        writer.publish(&frame).unwrap();
+        let sent = writer.sent.borrow();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(&sent[0][..4], &[0x00, 0x01, 0x00, 0x00], "the writer received the CDR-encapsulated frame");
+    }
+
+    #[test]
+    fn readback_accepts_stricter_horizons() {
+        // A negotiated writer with SHORTER lifespan/deadline/lease is stricter,
+        // not a relaxation → admissible.
+        let requested = DdsQosProfile::critical_actuator_profile();
+        let mut stricter = requested;
+        stricter.lifespan_ms = requested.lifespan_ms - 5;
+        stricter.deadline_ms = requested.deadline_ms - 5;
+        stricter.liveliness = DdsLiveliness::Automatic { lease_ms: 10 };
+        assert_eq!(validate_qos_readback(&requested, &stricter), Ok(()));
+    }
+
+    #[test]
+    fn readback_rejects_transient_local_downgrade() {
+        let requested = DdsQosProfile::critical_actuator_profile();
+        let mut neg = requested;
+        neg.durability = DdsDurability::TransientLocal;
+        assert_eq!(
+            validate_qos_readback(&requested, &neg),
+            Err(QosReadbackError::DurabilityRelaxed {
+                requested: DdsDurability::Volatile,
+                negotiated: DdsDurability::TransientLocal,
+            }),
+            "a writer the middleware created TransientLocal must be refused — INV-10 re-opened on the wire"
+        );
+    }
+
+    #[test]
+    fn readback_rejects_history_and_reliability_downgrades() {
+        let requested = DdsQosProfile::critical_actuator_profile();
+        let mut h = requested;
+        h.history = DdsHistory::KeepLast(8);
+        assert!(matches!(
+            validate_qos_readback(&requested, &h),
+            Err(QosReadbackError::HistoryRelaxed { .. })
+        ));
+        let mut r = requested;
+        r.reliability = DdsReliability::BestEffort;
+        assert!(matches!(
+            validate_qos_readback(&requested, &r),
+            Err(QosReadbackError::ReliabilityRelaxed { .. })
+        ));
+    }
+
+    #[test]
+    fn readback_rejects_unbounded_or_longer_horizons() {
+        let requested = DdsQosProfile::critical_actuator_profile();
+
+        // Zero (unbounded) lifespan.
+        let mut z = requested;
+        z.lifespan_ms = 0;
+        assert!(matches!(
+            validate_qos_readback(&requested, &z),
+            Err(QosReadbackError::LifespanRelaxed { negotiated_ms: 0, .. })
+        ));
+
+        // Longer deadline than requested.
+        let mut d = requested;
+        d.deadline_ms = requested.deadline_ms + 50;
+        assert!(matches!(
+            validate_qos_readback(&requested, &d),
+            Err(QosReadbackError::DeadlineRelaxed { .. })
+        ));
+
+        // Longer liveliness lease (slower loss detection).
+        let mut l = requested;
+        l.liveliness = DdsLiveliness::Automatic { lease_ms: 10_000 };
+        assert!(matches!(
+            validate_qos_readback(&requested, &l),
+            Err(QosReadbackError::LivelinessLeaseRelaxed { .. })
+        ));
+    }
+
+    // --- D1: CycloneDDS QoS mapping (pure, host-tested) --------------------
+
+    #[test]
+    fn cyclone_params_round_trip_the_critical_profile() {
+        let p = DdsQosProfile::critical_actuator_profile();
+        let params = qos_to_cyclone_params(&p);
+        // Spot-check the C-API encoding.
+        assert_eq!(params.durability_kind, CycloneQosParams::DURABILITY_VOLATILE);
+        assert_eq!(params.history_kind, CycloneQosParams::HISTORY_KEEP_LAST);
+        assert_eq!(params.history_depth, 1);
+        assert_eq!(params.reliability_kind, CycloneQosParams::RELIABILITY_RELIABLE);
+        assert_eq!(params.deadline_ns, 20 * 1_000_000, "20 ms → 20_000_000 ns");
+        // Round-trips back to an equal profile and is read-back-admissible.
+        let back = cyclone_params_to_qos(&params).expect("critical profile round-trips");
+        assert_eq!(back, p);
+        assert_eq!(validate_qos_readback(&p, &back), Ok(()));
+    }
+
+    #[test]
+    fn cyclone_params_to_qos_maps_infinity_to_unbounded_and_fails_readback() {
+        let requested = DdsQosProfile::critical_actuator_profile();
+        let mut params = qos_to_cyclone_params(&requested);
+        // A writer that came back with an INFINITE lifespan.
+        params.lifespan_ns = CycloneQosParams::INFINITY_NS;
+        let back = cyclone_params_to_qos(&params).expect("kinds still valid");
+        assert_eq!(back.lifespan_ms, 0, "DDS_INFINITY → 0 ms (unbounded sentinel)");
+        assert!(matches!(
+            validate_qos_readback(&requested, &back),
+            Err(QosReadbackError::LifespanRelaxed { negotiated_ms: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn cyclone_params_to_qos_fails_closed_on_unknown_kind() {
+        let mut params = qos_to_cyclone_params(&DdsQosProfile::critical_actuator_profile());
+        // dds_durability_kind_t = 3 (PERSISTENT) — outside Kirra's actuator model.
+        params.durability_kind = 3;
+        assert_eq!(cyclone_params_to_qos(&params), None,
+            "an unrepresentable durability kind must fail closed, not coerce");
+    }
+
+    #[test]
+    fn cyclone_params_transient_local_round_trips_and_is_caught() {
+        // A writer the middleware made TransientLocal reads back faithfully and is
+        // then rejected by the read-back validation (defense in depth: the mapping
+        // does NOT hide the downgrade).
+        let requested = DdsQosProfile::critical_actuator_profile();
+        let mut params = qos_to_cyclone_params(&requested);
+        params.durability_kind = CycloneQosParams::DURABILITY_TRANSIENT_LOCAL;
+        let back = cyclone_params_to_qos(&params).unwrap();
+        assert_eq!(back.durability, DdsDurability::TransientLocal);
+        assert!(matches!(
+            validate_qos_readback(&requested, &back),
+            Err(QosReadbackError::DurabilityRelaxed { .. })
+        ));
     }
 }

--- a/src/dds_cyclonedds.rs
+++ b/src/dds_cyclonedds.rs
@@ -1,0 +1,289 @@
+// src/dds_cyclonedds.rs
+//
+// D1 (review item 19) — the REAL CycloneDDS actuator writer.
+//
+// ┌───────────────────────────────────────────────────────────────────────────┐
+// │ BUILD GATING. This module is compiled ONLY under `--features cyclonedds`.   │
+// │ It links the native CycloneDDS C library (`libddsc`), which is NOT present  │
+// │ in the default CI/build container, so it is NEVER built by a default        │
+// │ `cargo build`/`cargo test` and CANNOT regress the default path. It is built │
+// │ and run on an integrator host that ships CycloneDDS — e.g. a ROS 2 Jazzy    │
+// │ machine (Jazzy's default RMW is rmw_cyclonedds_cpp, so `libddsc` is on the  │
+// │ library path). The QoS MAPPING and READ-BACK VALIDATION logic this writer   │
+// │ depends on lives in `dds_bridge.rs` as pure functions and IS exercised in   │
+// │ CI (`qos_to_cyclone_params` / `cyclone_params_to_qos` / `validate_qos_      │
+// │ readback`); this file is the thin `unsafe extern "C"` glue around them.     │
+// └───────────────────────────────────────────────────────────────────────────┘
+//
+// WHAT IT ADDS over the byte-framer in `dds_bridge.rs`: a writer created against
+// the live middleware whose NEGOTIATED QoS is read back (`dds_get_qos`) and run
+// through `validate_qos_readback` — so a middleware that silently downgrades an
+// actuator topic (TransientLocal, dropped deadline, BestEffort, …) is refused at
+// open time (fail-closed), not discovered after a stale command actuates.
+//
+// ADR-0006 Clause 3: this FFI is the documented C/C++ INTEGRATION BOUNDARY, not
+// the governor hot path. Kirra owns the QoS gate + read-back; the integrator owns
+// the topic type support (the generated `dds_topic_descriptor_t` for their
+// actuator message) and the sample it publishes.
+
+#![cfg(feature = "cyclonedds")]
+
+use std::ffi::{c_char, c_void, CString};
+
+use crate::dds_bridge::{
+    cyclone_params_to_qos, qos_to_cyclone_params, validate_qos_readback, CycloneQosParams,
+    DdsQosProfile, DdsQosViolation, QosReadbackError,
+};
+
+/// Opaque CycloneDDS `dds_qos_t`.
+#[repr(C)]
+struct DdsQos {
+    _private: [u8; 0],
+}
+
+/// `DDS_DOMAIN_DEFAULT` — use the domain from config/env (`CYCLONEDDS_URI`).
+const DDS_DOMAIN_DEFAULT: u32 = 0xffff_ffff;
+/// Reliable `max_blocking_time` — CycloneDDS's own default is 100 ms.
+const RELIABLE_MAX_BLOCKING_NS: i64 = 100 * 1_000_000;
+
+// Native CycloneDDS C API (dds/dds.h). Signatures are part of the CycloneDDS ABI.
+// `dds_entity_t` = int32, `dds_return_t` = int32, `dds_duration_t` = int64,
+// `dds_domainid_t` = uint32; the QoS kind enums are C `int` (i32) out-params.
+#[link(name = "ddsc")]
+extern "C" {
+    fn dds_create_participant(domain: u32, qos: *const DdsQos, listener: *const c_void) -> i32;
+    fn dds_create_topic(
+        participant: i32,
+        descriptor: *const c_void,
+        name: *const c_char,
+        qos: *const DdsQos,
+        listener: *const c_void,
+    ) -> i32;
+    fn dds_create_writer(
+        participant_or_publisher: i32,
+        topic: i32,
+        qos: *const DdsQos,
+        listener: *const c_void,
+    ) -> i32;
+    fn dds_write(writer: i32, data: *const c_void) -> i32;
+    fn dds_delete(entity: i32) -> i32;
+
+    fn dds_create_qos() -> *mut DdsQos;
+    fn dds_delete_qos(qos: *mut DdsQos);
+    fn dds_qset_durability(qos: *mut DdsQos, kind: i32);
+    fn dds_qset_history(qos: *mut DdsQos, kind: i32, depth: i32);
+    fn dds_qset_reliability(qos: *mut DdsQos, kind: i32, max_blocking_time: i64);
+    fn dds_qset_lifespan(qos: *mut DdsQos, lifespan: i64);
+    fn dds_qset_deadline(qos: *mut DdsQos, deadline: i64);
+    fn dds_qset_liveliness(qos: *mut DdsQos, kind: i32, lease_duration: i64);
+
+    fn dds_get_qos(entity: i32, qos: *mut DdsQos) -> i32;
+    fn dds_qget_durability(qos: *const DdsQos, kind: *mut i32) -> bool;
+    fn dds_qget_history(qos: *const DdsQos, kind: *mut i32, depth: *mut i32) -> bool;
+    fn dds_qget_reliability(qos: *const DdsQos, kind: *mut i32, max_blocking_time: *mut i64)
+        -> bool;
+    fn dds_qget_lifespan(qos: *const DdsQos, lifespan: *mut i64) -> bool;
+    fn dds_qget_deadline(qos: *const DdsQos, deadline: *mut i64) -> bool;
+    fn dds_qget_liveliness(qos: *const DdsQos, kind: *mut i32, lease_duration: *mut i64) -> bool;
+}
+
+/// Why the CycloneDDS actuator writer refused to come up (or to publish). Every
+/// variant is fail-closed — no writer is handed back on error.
+#[derive(Debug)]
+pub enum CycloneDdsError {
+    /// The REQUESTED profile is itself inadmissible (caught before touching DDS).
+    RequestInadmissible(DdsQosViolation),
+    /// A `dds_create_*` call returned a negative `dds_return_t`.
+    EntityCreate { what: &'static str, code: i32 },
+    /// `dds_create_qos` returned NULL.
+    QosAlloc,
+    /// `dds_get_qos` failed, or a `dds_qget_*` getter reported the policy absent —
+    /// we cannot prove the negotiated QoS, so we refuse.
+    ReadbackUnavailable,
+    /// The negotiated QoS used a kind Kirra's model can't represent.
+    ReadbackUnrepresentable,
+    /// The negotiated QoS is weaker than requested on a safety axis.
+    Readback(QosReadbackError),
+    /// `dds_write` returned a negative `dds_return_t`.
+    Publish(i32),
+}
+
+/// A CycloneDDS writer for one actuator topic, created with the Kirra actuator
+/// QoS and proven (read-back) to have negotiated it. Owns its participant /
+/// topic / writer entities and tears them down on drop.
+pub struct CycloneDdsActuatorWriter {
+    participant: i32,
+    topic: i32,
+    writer: i32,
+    negotiated: DdsQosProfile,
+}
+
+impl CycloneDdsActuatorWriter {
+    /// Create a writer for `topic_name` of the integrator-supplied type
+    /// `descriptor` (a `*const dds_topic_descriptor_t` from their generated type
+    /// support), under `profile`. Fails closed if the request is inadmissible, if
+    /// any entity fails to create, or if the writer's READ-BACK QoS is weaker than
+    /// requested.
+    ///
+    /// # Safety
+    /// `descriptor` must be a valid, 'static `dds_topic_descriptor_t` pointer for
+    /// the topic type (as produced by CycloneDDS IDL / rosidl type support).
+    pub unsafe fn create(
+        profile: &DdsQosProfile,
+        topic_name: &str,
+        descriptor: *const c_void,
+    ) -> Result<Self, CycloneDdsError> {
+        // Refuse a bad request before we ever talk to the middleware.
+        profile
+            .actuator_admissibility()
+            .map_err(CycloneDdsError::RequestInadmissible)?;
+
+        let qos = build_qos(profile)?;
+        // From here on, `qos` and any created entities must be cleaned up on every
+        // error path. `Guard` handles the entities; qos is deleted before return.
+        let participant = dds_create_participant(DDS_DOMAIN_DEFAULT, std::ptr::null(), std::ptr::null());
+        if participant < 0 {
+            dds_delete_qos(qos);
+            return Err(CycloneDdsError::EntityCreate { what: "participant", code: participant });
+        }
+        let mut guard = Guard { entity: participant };
+
+        let cname = CString::new(topic_name).map_err(|_| {
+            dds_delete_qos(qos);
+            CycloneDdsError::EntityCreate { what: "topic_name_nul", code: 0 }
+        })?;
+        let topic = dds_create_topic(participant, descriptor, cname.as_ptr(), qos, std::ptr::null());
+        if topic < 0 {
+            dds_delete_qos(qos);
+            return Err(CycloneDdsError::EntityCreate { what: "topic", code: topic });
+        }
+
+        let writer = dds_create_writer(participant, topic, qos, std::ptr::null());
+        dds_delete_qos(qos); // the writer copied what it needs
+        if writer < 0 {
+            return Err(CycloneDdsError::EntityCreate { what: "writer", code: writer });
+        }
+
+        // READ-BACK: prove the writer negotiated at least the requested strictness.
+        let negotiated = read_back_qos(writer)?;
+        validate_qos_readback(profile, &negotiated).map_err(CycloneDdsError::Readback)?;
+
+        // All checks passed — disarm the participant guard (it drops as a no-op at
+        // scope end); the writer/topic are children of the participant and are
+        // deleted with it by `CycloneDdsActuatorWriter`'s own Drop.
+        guard.entity = 0;
+        Ok(Self { participant, topic, writer, negotiated })
+    }
+
+    /// The QoS the middleware actually negotiated (proven read-back-admissible).
+    pub fn negotiated_qos(&self) -> DdsQosProfile {
+        self.negotiated
+    }
+
+    /// Publish one sample of the topic type. `sample` is a pointer to an instance
+    /// of the integrator's generated actuator message (CycloneDDS serializes it
+    /// using the topic's type support). The QoS gate was enforced at `create`.
+    ///
+    /// # Safety
+    /// `sample` must point to a valid instance of the topic's C type.
+    pub unsafe fn publish_sample(&self, sample: *const c_void) -> Result<(), CycloneDdsError> {
+        let rc = dds_write(self.writer, sample);
+        if rc < 0 {
+            return Err(CycloneDdsError::Publish(rc));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for CycloneDdsActuatorWriter {
+    fn drop(&mut self) {
+        // Deleting the participant cascades to its topic + writer children.
+        unsafe {
+            let _ = dds_delete(self.writer);
+            let _ = dds_delete(self.topic);
+            let _ = dds_delete(self.participant);
+        }
+    }
+}
+
+/// Deletes a created entity if still armed (set `entity = 0` to disarm). Ensures
+/// an early-return between participant creation and success doesn't leak it.
+struct Guard {
+    entity: i32,
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        if self.entity > 0 {
+            unsafe {
+                let _ = dds_delete(self.entity);
+            }
+        }
+    }
+}
+
+/// Allocate + populate a `dds_qos_t` from the actuator profile via the pure
+/// `qos_to_cyclone_params` mapping.
+unsafe fn build_qos(profile: &DdsQosProfile) -> Result<*mut DdsQos, CycloneDdsError> {
+    let p = qos_to_cyclone_params(profile);
+    let qos = dds_create_qos();
+    if qos.is_null() {
+        return Err(CycloneDdsError::QosAlloc);
+    }
+    dds_qset_durability(qos, p.durability_kind);
+    dds_qset_history(qos, p.history_kind, p.history_depth);
+    dds_qset_reliability(qos, p.reliability_kind, RELIABLE_MAX_BLOCKING_NS);
+    dds_qset_lifespan(qos, p.lifespan_ns);
+    dds_qset_deadline(qos, p.deadline_ns);
+    dds_qset_liveliness(qos, p.liveliness_kind, p.liveliness_lease_ns);
+    Ok(qos)
+}
+
+/// Read a live writer's QoS back into a `DdsQosProfile` via `dds_get_qos` +
+/// `dds_qget_*`, going through the pure `cyclone_params_to_qos` mapping. Any
+/// failed getter or unrepresentable kind is fail-closed.
+unsafe fn read_back_qos(writer: i32) -> Result<DdsQosProfile, CycloneDdsError> {
+    let qos = dds_create_qos();
+    if qos.is_null() {
+        return Err(CycloneDdsError::QosAlloc);
+    }
+    // Always delete `qos` before returning.
+    let result = (|| {
+        if dds_get_qos(writer, qos) < 0 {
+            return Err(CycloneDdsError::ReadbackUnavailable);
+        }
+        let mut durability_kind = -1;
+        let mut history_kind = -1;
+        let mut history_depth = -1;
+        let mut reliability_kind = -1;
+        let mut max_blocking = -1;
+        let mut lifespan_ns = -1;
+        let mut deadline_ns = -1;
+        let mut liveliness_kind = -1;
+        let mut liveliness_lease_ns = -1;
+
+        let ok = dds_qget_durability(qos, &mut durability_kind)
+            && dds_qget_history(qos, &mut history_kind, &mut history_depth)
+            && dds_qget_reliability(qos, &mut reliability_kind, &mut max_blocking)
+            && dds_qget_lifespan(qos, &mut lifespan_ns)
+            && dds_qget_deadline(qos, &mut deadline_ns)
+            && dds_qget_liveliness(qos, &mut liveliness_kind, &mut liveliness_lease_ns);
+        if !ok {
+            return Err(CycloneDdsError::ReadbackUnavailable);
+        }
+
+        let params = CycloneQosParams {
+            durability_kind,
+            history_kind,
+            history_depth,
+            reliability_kind,
+            lifespan_ns,
+            deadline_ns,
+            liveliness_kind,
+            liveliness_lease_ns,
+        };
+        cyclone_params_to_qos(&params).ok_or(CycloneDdsError::ReadbackUnrepresentable)
+    })();
+    dds_delete_qos(qos);
+    result
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod output;
 pub mod gateway;
 pub mod robotics_alignment;
 pub mod dds_bridge;
+#[cfg(feature = "cyclonedds")]
+pub mod dds_cyclonedds;
 pub mod ffi;
 #[cfg(feature = "tpm")]
 pub mod tpm;


### PR DESCRIPTION
## Review item 19 D1 — real CycloneDDS writer + validate read-back QoS

`actuator_admissibility` (and #623's C1+D2) validate the profile we **request**. But DDS QoS is **requested-offered**: a misconfigured XML profile, an env override, a participant default, or a peer-driven downgrade can hand back a writer that is TransientLocal / BestEffort / deadline-dropped even though the profile we passed in was clean — the INV-10/SG-016 stale-command hazard re-opened one layer down. D1 closes it by creating a real writer, **reading its negotiated QoS back, and validating it fail-closed**.

### Host-verifiable core (built + tested by the default suite)
- **`validate_qos_readback(requested, negotiated)`** — fail-closed check that the negotiated writer is *at least as strict* as the actuator profile on every axis (Volatile, KeepLast(1), Reliable, bounded lifespan/deadline/liveliness-lease not longer than requested). Returns the first relaxation found.
- **`DdsActuatorWriter` trait seam** + a `LoopbackTestWriter` exercising the happy path and every downgrade.
- **`qos_to_cyclone_params` / `cyclone_params_to_qos`** — pure CycloneDDS C-API QoS mapping (kind enums + ns durations), **decoupled from the FFI** so the whole mapping is unit-tested in CI: critical-profile round-trip, `DDS_INFINITY` → unbounded sentinel → read-back rejection, fail-closed on an unrepresentable kind, TransientLocal round-trips and is caught.

### CycloneDDS writer — `src/dds_cyclonedds.rs`, behind default-off `cyclonedds` feature
- Thin `unsafe extern "C"` glue over native `libddsc` (`dds/dds.h`): map QoS → create participant/topic/writer → `dds_get_qos`/`dds_qget_*` read-back → `validate_qos_readback` → refuse (entities torn down) on any relaxation.
- Links the native CycloneDDS lib, so it is **never built in the default CI/container** and cannot regress the default path. It builds/runs on an integrator host that ships CycloneDDS — e.g. **ROS 2 Jazzy** (default RMW `rmw_cyclonedds_cpp`, so `libddsc` is present). Pulls **no** Rust dependency.
- Per **ADR-0006 Clause 3** this FFI is the documented C/C++ integration boundary, not the governor hot path: Kirra owns the QoS gate + read-back; the integrator owns the topic type support (generated `dds_topic_descriptor_t`) and the published sample.

## Verification & honest scope
- `cargo check`/`cargo clippy --features cyclonedds` **type-check the FFI Rust here** (they don't link), so the unsafe/borrow/type surface is validated in this container.
- Native **link + loopback run** happen on the Jazzy host (no `libddsc` in CI).
- 14 `dds_bridge` lib tests pass; clippy clean for **both** default and `cyclonedds`.
- The load-bearing safety piece (read-back QoS validation + QoS mapping) is fully host-tested; the remaining un-CI'd surface is ~25 lines of FFI signatures against the stable CycloneDDS ABI.

## Out of scope (unchanged)
Publishing Kirra's hand-rolled CDR frame *through* CycloneDDS via `dds_writecdr`/serdata is the integrator's sertype seam; the writer publishes a typed sample via `dds_write`. The CDR codec from #623 remains the path for the raw/byte-level transports and interop tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_