### PR TITLE
qnx-rtm-harness: real gated QNX cross-build + on-target FDIT/WCET driver (#274)

### DIFF
--- a/docs/safety/WCET_QNX_BRINGUP.md
+++ b/docs/safety/WCET_QNX_BRINGUP.md
@@ -2,12 +2,26 @@
 
 | Field | Value |
 |---|---|
-| Status | **Draft — defined build, not run** (no QNX hardware in this task). |
-| Date | 2026-06-21 |
+| Status | **Cross-build wired — ready to run on an x86_64 QNX SDP 8.0 target.** The gated CMake QNX path, `qnx.toolchain.cmake` (qcc/q++), and the `run_qnx_fdit.sh` driver are in the tree; the host build is byte-identical when `KIRRA_QNX_TARGET=OFF`. Remaining = execute on the target and capture the row. |
+| Date | 2026-06-27 |
 | Owner | Project / safety-case owner |
 | Issue | #274 (EPIC #270, QNX governor lane). RTM tracing #272 (done). |
 | Scope | Cross-compile the no_std verdict **judge** (`tools/qnx-rtm-harness/kirra_judge.rs`) for a QNX target and measure its per-verdict WCET under `SCHED_FIFO`, replacing the harness placeholder `wcet_status = TBD-QNX-TARGET`. |
-| Companions | `tools/qnx-rtm-harness/` (README, `QNX_MAPPING.md`, `CMakeLists.txt`, `kirra_judge.rs`, `kirra_ffi.h`, `wcet_measure.cpp`), `docs/adr/KIRRA_QNX_CROSSCOMPILE.md`, `docs/safety/WCET_MEASUREMENT_METHODOLOGY.md`, `src/wcet_gate.rs`, `ASSUMPTIONS_OF_USE.md` (AOU-HW-QNX-TARGET-001), ADR-0001. |
+| Companions | `tools/qnx-rtm-harness/` (README, `QNX_MAPPING.md`, `CMakeLists.txt`, **`qnx.toolchain.cmake`**, **`run_qnx_fdit.sh`**, `kirra_judge.rs`, `kirra_ffi.h`, `wcet_measure.cpp`), `docs/adr/KIRRA_QNX_CROSSCOMPILE.md`, `docs/safety/WCET_MEASUREMENT_METHODOLOGY.md`, `src/wcet_gate.rs`, `ASSUMPTIONS_OF_USE.md` (AOU-HW-QNX-TARGET-001), ADR-0001. |
+
+## TL;DR — run it
+
+```bash
+source ~/qnx800/qnxsdp-env.sh                 # sets QNX_HOST/QNX_TARGET + qcc
+tools/qnx-rtm-harness/run_qnx_fdit.sh         # x86_64 default; cross-builds judge + C++
+# → copy build-qnx/{rtm_harness,wcet_measure,kirra_demo} to the QNX target, then on-target:
+#   ./rtm_harness && echo PASS         # FDIT verdict-correctness gate
+#   ./wcet_measure                     # run as root for SCHED_FIFO; emits the CSV row
+```
+
+The driver handles the Rust-for-QNX toolchain (direct `rustc --target`, else
+`cargo -Zbuild-std=core`, else a custom-target.json prompt). The C++ side is
+qcc/q++ via `qnx.toolchain.cmake`.
 
 ## Hard boundaries (read first)
 
@@ -82,22 +96,24 @@ q++ -Vgcc_ntoaarch64_cxx -std=c++17 -Wall -Wextra -Werror -fno-exceptions -fno-r
 # QNX provides pthread/m/dl via libc; -ldl/-lm may be unneeded on QNX — confirm per `qcc -V`.
 ```
 
-### 1d. CMake hook extension (gated; host build unchanged)
+### 1d. CMake hook — now REAL (gated; host build unchanged)
 
-The existing hook is a **comment** in `CMakeLists.txt`. Make it real, gated by a `KIRRA_QNX_TARGET` option so the host build stays byte-identical when OFF:
+The hook is no longer a comment. `CMakeLists.txt` carries an `option(KIRRA_QNX_TARGET ... OFF)`; default OFF leaves the host build **byte-identical** (verified: `ctest` 2/2). With it ON plus `qnx.toolchain.cmake`:
 
-```cmake
-option(KIRRA_QNX_TARGET "Cross-compile the judge + harness for a QNX target" OFF)
-set(KIRRA_RUSTC_TARGET "<TARGET_TRIPLE_TBD>" CACHE STRING "rustc nto-qnx800 tuple")
+- the judge staticlib is taken from `-DKIRRA_JUDGE_LIB_PREBUILT=...` (built for the target by `run_qnx_fdit.sh`) **or** built here by an nto-capable rustc via `-DKIRRA_RUSTC_TARGET=...`;
+- `wcet_measure` is added as a target (QNX-only — a host WCET number is INDICATIVE, so it is structurally excluded from the host build);
+- ctest is **not** registered (the nto binaries run on the QNX target, not the build host);
+- `KIRRA_JUDGE_LINK` drops `-lpthread/-ldl/-lm` (QNX libc provides them).
 
-set(KIRRA_JUDGE_RUSTC_FLAGS --edition 2021 --crate-type staticlib
-    --crate-name kirra_judge -C panic=abort -C opt-level=2 -C debuginfo=0)
-if(KIRRA_QNX_TARGET)
-  list(APPEND KIRRA_JUDGE_RUSTC_FLAGS --target ${KIRRA_RUSTC_TARGET})
-  # select qcc/q++ via -DCMAKE_TOOLCHAIN_FILE=qnx.cmake, and add wcet_measure.cpp
-  # as an executable linked against ${KIRRA_JUDGE_LINK}.
-endif()
-# ... feed ${KIRRA_JUDGE_RUSTC_FLAGS} into the rustc add_custom_command ...
+`run_qnx_fdit.sh` is the one-command driver that wires all of the above. Manual configure (if you prefer):
+
+```bash
+source ~/qnx800/qnxsdp-env.sh
+cmake -S tools/qnx-rtm-harness -B build-qnx \
+      -DCMAKE_TOOLCHAIN_FILE=tools/qnx-rtm-harness/qnx.toolchain.cmake \
+      -DKIRRA_QNX_TARGET=ON -DKIRRA_QNX_QCC_VARIANT=gcc_ntox86_64 \
+      -DKIRRA_JUDGE_LIB_PREBUILT="$PWD/build-qnx/libkirra_judge.a"
+cmake --build build-qnx -j
 ```
 
 ## 2. SCHED_FIFO measurement wrapper
@@ -141,5 +157,6 @@ What the Phase-I run must show to substantiate the Objective-1 "sub-100 µs verd
 | no_std judge (C-ABI `kirra_judge_assess`) | done (`kirra_judge.rs`) |
 | host-indicative WCET + CI regression gate | done (`src/wcet_gate.rs`) |
 | FDIT/RTM matrix traced to kernel RTM | done (#272, `QNX_MAPPING.md`) |
-| cross-compile recipe + measurement wrapper | **done (this PR — drafted, not run)** |
-| run on a QNX target, capture the row, update CSV + methodology | **remaining (#274 — needs a QNX target)** |
+| cross-compile recipe + measurement wrapper | done (`wcet_measure.cpp`) |
+| gated CMake QNX path + `qnx.toolchain.cmake` + `run_qnx_fdit.sh` driver | **done (this PR — host build byte-identical, ctest 2/2)** |
+| run on the x86_64 QNX SDP 8.0 target, capture FDIT PASS + WCET row, update CSV + methodology | **remaining (#274 — execute on the target)** |

--- a/docs/safety/WCET_QNX_BRINGUP.md
+++ b/docs/safety/WCET_QNX_BRINGUP.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | **Cross-build wired — ready to run on an x86_64 QNX SDP 8.0 target.** The gated CMake QNX path, `qnx.toolchain.cmake` (qcc/q++), and the `run_qnx_fdit.sh` driver are in the tree; the host build is byte-identical when `KIRRA_QNX_TARGET=OFF`. Remaining = execute on the target and capture the row. |
+| Status | **RUN on a QNX SDP 8.0 x86_64 target — FDIT verdict-correctness gate PASSES.** The judge cross-compiled to `x86_64-pc-nto-qnx800` (core-only, no QNX std) and the FDIT/RTM matrix passed byte-identically on a `mkqnximage`/QEMU QNX 8.0 VM (`GATE: PASS`, all 9 rows). Acceptance #1 + #2 met. **WCET is INDICATIVE only** — the VM ran under QEMU TCG (VT-x disabled on the dev laptop), so a representative `max < 100 µs` (#4) is deferred to a KVM/hardware run; cert-grade WCET remains Phase-II (DRIVE + QNX OS for Safety). |
 | Date | 2026-06-27 |
 | Owner | Project / safety-case owner |
 | Issue | #274 (EPIC #270, QNX governor lane). RTM tracing #272 (done). |
@@ -158,5 +158,7 @@ What the Phase-I run must show to substantiate the Objective-1 "sub-100 µs verd
 | host-indicative WCET + CI regression gate | done (`src/wcet_gate.rs`) |
 | FDIT/RTM matrix traced to kernel RTM | done (#272, `QNX_MAPPING.md`) |
 | cross-compile recipe + measurement wrapper | done (`wcet_measure.cpp`) |
-| gated CMake QNX path + `qnx.toolchain.cmake` + `run_qnx_fdit.sh` driver | **done (this PR — host build byte-identical, ctest 2/2)** |
-| run on the x86_64 QNX SDP 8.0 target, capture FDIT PASS + WCET row, update CSV + methodology | **remaining (#274 — execute on the target)** |
+| gated CMake QNX path + `qnx.toolchain.cmake` + `run_qnx_fdit.sh` driver | done (host build byte-identical, ctest 2/2) |
+| judge cross-compiles to `x86_64-pc-nto-qnx800` (core-only, no QNX std) | **done — built via `cargo -Zbuild-std=core`, links `core` + `compiler_builtins` only** |
+| FDIT/RTM matrix runs byte-identically on a QNX 8.0 x86_64 VM (acceptance #2) | **done — `GATE: PASS`, all 9 verdicts correct on `mkqnximage`/QEMU QNX 8.0** |
+| representative `SCHED_FIFO` WCET (`max < 100 µs`, acceptance #4) | **deferred — VM ran under TCG (no VT-x); needs KVM or hardware. Cert-grade is Phase-II (DRIVE + QNX OS for Safety)** |

--- a/tools/qnx-rtm-harness/CMakeLists.txt
+++ b/tools/qnx-rtm-harness/CMakeLists.txt
@@ -5,11 +5,14 @@
 # the C++ SHIM + harness/demo. The harness is wired as a ctest so a WRONG VERDICT
 # fails the build.
 #
-# QNX cross-compile hook (real work = #274): for a QNX target one sets the
-# toolchain file (qcc/q++) and points `RUSTC_TARGET` at the QNX tuple
-# (e.g. `x86_64-pc-nto-qnx8_0_0` / `aarch64-unknown-nto-qnx8_0_0`) with
-# `--no-default-features`-equivalent core-only flags. Host build below uses the
-# native rustc/g++; see docs/adr/KIRRA_QNX_CROSSCOMPILE.md.
+# QNX cross-compile (real work = #274). Default OFF → this file behaves EXACTLY as
+# before (native rustc/g++, ctest runs). With -DKIRRA_QNX_TARGET=ON plus
+# qnx.toolchain.cmake (qcc/q++) it cross-builds the shim/harness/demo AND the
+# wcet_measure tool for a QNX nto target, and does NOT register ctest (the nto
+# binaries run on the QNX target, not the build host). The no_std judge staticlib
+# is supplied prebuilt for the target via -DKIRRA_JUDGE_LIB_PREBUILT (built by
+# run_qnx_fdit.sh, which handles the Rust-for-QNX toolchain), or built here by a
+# native/nto-capable rustc with -DKIRRA_RUSTC_TARGET. See WCET_QNX_BRINGUP.md.
 
 cmake_minimum_required(VERSION 3.16)
 project(kirra_qnx_rtm_harness CXX)
@@ -17,40 +20,61 @@ project(kirra_qnx_rtm_harness CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+option(KIRRA_QNX_TARGET "Cross-build for a QNX target (adds wcet_measure; no host ctest)" OFF)
+set(KIRRA_RUSTC_TARGET "" CACHE STRING
+    "rustc nto tuple for the judge (e.g. x86_64-pc-nto-qnx800); empty = host rustc")
+set(KIRRA_JUDGE_LIB_PREBUILT "" CACHE FILEPATH
+    "Prebuilt libkirra_judge.a for the target (built by run_qnx_fdit.sh); empty = build via rustc here")
+
 # Strict, exception-free, RTTI-free — the integration-boundary discipline.
 add_compile_options(-Wall -Wextra -Werror -fno-exceptions -fno-rtti)
 
-# --- Rust judge: rustc -> libkirra_judge.a (no_std staticlib, panic=abort) -----
-find_program(RUSTC rustc REQUIRED)
-
 set(KIRRA_JUDGE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/kirra_judge.rs")
-set(KIRRA_JUDGE_LIB "${CMAKE_CURRENT_BINARY_DIR}/libkirra_judge.a")
 
-add_custom_command(
-    OUTPUT "${KIRRA_JUDGE_LIB}"
-    COMMAND "${RUSTC}"
-            --edition 2021
-            --crate-type staticlib
-            --crate-name kirra_judge
-            -C panic=abort
-            -C opt-level=2
-            -C debuginfo=0
-            -o "${KIRRA_JUDGE_LIB}"
-            "${KIRRA_JUDGE_SRC}"
-    DEPENDS "${KIRRA_JUDGE_SRC}"
-    COMMENT "rustc: building no_std staticlib libkirra_judge.a (panic=abort)"
-    VERBATIM
-)
-add_custom_target(kirra_judge_lib DEPENDS "${KIRRA_JUDGE_LIB}")
+if(KIRRA_JUDGE_LIB_PREBUILT)
+    # The judge staticlib was cross-built out-of-band for the target (the Rust
+    # toolchain detection lives in run_qnx_fdit.sh). Just import it.
+    set(KIRRA_JUDGE_LIB "${KIRRA_JUDGE_LIB_PREBUILT}")
+    add_custom_target(kirra_judge_lib)  # no-op: nothing to build here
+    message(STATUS "kirra_judge: using prebuilt ${KIRRA_JUDGE_LIB}")
+else()
+    # --- Rust judge: rustc -> libkirra_judge.a (no_std staticlib, panic=abort) --
+    find_program(RUSTC rustc REQUIRED)
+    set(KIRRA_JUDGE_LIB "${CMAKE_CURRENT_BINARY_DIR}/libkirra_judge.a")
+
+    # Host build, or an nto-capable rustc with a prebuilt `core`: append --target.
+    set(KIRRA_JUDGE_RUSTC_FLAGS
+        --edition 2021 --crate-type staticlib --crate-name kirra_judge
+        -C panic=abort -C opt-level=2 -C debuginfo=0)
+    if(KIRRA_RUSTC_TARGET)
+        list(APPEND KIRRA_JUDGE_RUSTC_FLAGS --target "${KIRRA_RUSTC_TARGET}")
+    endif()
+
+    add_custom_command(
+        OUTPUT "${KIRRA_JUDGE_LIB}"
+        COMMAND "${RUSTC}" ${KIRRA_JUDGE_RUSTC_FLAGS}
+                -o "${KIRRA_JUDGE_LIB}" "${KIRRA_JUDGE_SRC}"
+        DEPENDS "${KIRRA_JUDGE_SRC}"
+        COMMENT "rustc: building no_std staticlib libkirra_judge.a (panic=abort)"
+        VERBATIM
+    )
+    add_custom_target(kirra_judge_lib DEPENDS "${KIRRA_JUDGE_LIB}")
+endif()
 
 # Imported target for the static judge library.
 add_library(kirra_judge STATIC IMPORTED GLOBAL)
 set_target_properties(kirra_judge PROPERTIES IMPORTED_LOCATION "${KIRRA_JUDGE_LIB}")
 add_dependencies(kirra_judge kirra_judge_lib)
 
-# A no_std rustc staticlib still references a few platform symbols on link
-# (pthread / dl / math / unwind-less libgcc). Link them defensively.
-set(KIRRA_JUDGE_LINK kirra_judge pthread dl m)
+# A no_std rustc staticlib references a few platform symbols on link. On Linux
+# those are separate libs (pthread/dl/m); on QNX they live in libc, and an
+# explicit -ldl/-lpthread/-lm may not resolve — so link only the judge there and
+# let qcc pull libc. Add back per `qcc -V` if a symbol is missing.
+if(KIRRA_QNX_TARGET)
+    set(KIRRA_JUDGE_LINK kirra_judge)
+else()
+    set(KIRRA_JUDGE_LINK kirra_judge pthread dl m)
+endif()
 
 # --- C++ shim (driver) ---------------------------------------------------------
 add_library(kirra_shim STATIC kirra_shim.cpp)
@@ -63,7 +87,19 @@ target_link_libraries(rtm_harness PRIVATE kirra_shim ${KIRRA_JUDGE_LINK})
 add_executable(kirra_demo kirra_demo.cpp)
 target_link_libraries(kirra_demo PRIVATE kirra_shim ${KIRRA_JUDGE_LINK})
 
+# --- WCET measurement (QNX target only) ----------------------------------------
+# Built only for the QNX cross-target: a host number is INDICATIVE, never a WCET
+# claim — keeping it out of the host build enforces that discipline structurally.
+if(KIRRA_QNX_TARGET)
+    add_executable(wcet_measure wcet_measure.cpp)
+    target_link_libraries(wcet_measure PRIVATE kirra_shim ${KIRRA_JUDGE_LINK})
+endif()
+
 # --- ctest: a wrong verdict (non-zero exit) FAILS the build/test ---------------
+# Only on a HOST build — nto binaries cannot execute on the Ubuntu build host;
+# run_qnx_fdit.sh copies them to the QNX target and runs them there.
 enable_testing()
-add_test(NAME rtm_harness COMMAND rtm_harness)
-add_test(NAME kirra_demo COMMAND kirra_demo)
+if(NOT KIRRA_QNX_TARGET)
+    add_test(NAME rtm_harness COMMAND rtm_harness)
+    add_test(NAME kirra_demo COMMAND kirra_demo)
+endif()

--- a/tools/qnx-rtm-harness/QNX_MAPPING.md
+++ b/tools/qnx-rtm-harness/QNX_MAPPING.md
@@ -173,24 +173,57 @@ SG-04/SG-05 never reach the judge — visible as the fast p50 on SG-05.)
 
 ---
 
-## 6. QNX cross-compile (real work = #274)
+## 6. QNX cross-compile + on-target run (#274)
+
+**Status: cross-build wired AND run on a QNX 8.0 x86_64 target.** `run_qnx_fdit.sh`
++ `qnx.toolchain.cmake` + the gated CMake path cross-build the `no_std` judge
+(`x86_64-pc-nto-qnx800`, core-only via `cargo -Zbuild-std=core`, **no QNX std**)
+and the C++ shim/harness/`wcet_measure` (`q++`, QCC 12.2.0). The recipe below is
+realized by the driver; see §6.1 for the executed result.
 
 The host build uses native `g++` + `rustc`. For a QNX 8.0 target:
 
-- **C++**: set a CMake toolchain file pointing at `q++` / `qcc` (the QNX SDP
-  compilers); the `-fno-exceptions -fno-rtti` discipline already matches a
+- **C++**: a CMake toolchain file points at `q++` / `qcc` (the QNX SDP compilers);
+  the `-fno-exceptions -fno-rtti` discipline already matches a
   freestanding-friendly build.
-- **Rust judge**: build the `no_std` staticlib for the QNX target tuple, e.g.
-  `--target x86_64-pc-nto-qnx8_0_0` or `aarch64-unknown-nto-qnx8_0_0`, keeping
-  `-C panic=abort`. The judge is already `no_std` + zero-alloc + integer-only.
-- **FDIT/WCET**: re-run the harness on the target under **FIFO scheduling** and
-  replace the indicative host p50/p99/max with **target-measured** percentiles —
-  the numbers that actually back the FTTI claim. This is **#274**.
+- **Rust judge**: build the `no_std` staticlib for the QNX target tuple
+  `x86_64-pc-nto-qnx800` (or `aarch64-unknown-nto-qnx800`), keeping
+  `-C panic=abort`. The judge is already `no_std` + zero-alloc + integer-only, so
+  it links `core` + a custom-built `compiler_builtins` only — the #189 QNX-std
+  blocker does not apply.
+- **FDIT/WCET**: re-run the harness on the target under **FIFO scheduling**. This
+  is **#274**.
 
-See `docs/adr/KIRRA_QNX_CROSSCOMPILE.md` for the existing cross-compile recipe.
+See `docs/adr/KIRRA_QNX_CROSSCOMPILE.md` and `docs/safety/WCET_QNX_BRINGUP.md` for
+the full recipe + acceptance criteria.
 
-## 7. WCET-TBD
+### 6.1 On-target result — Phase-I feasibility (QNX SDP 8.0 x86_64 VM)
 
-Host timing in the harness output is **indicative only** (`wcet_status` is the
-constant `TBD-QNX-TARGET`). Certified WCET is **TBD on the QNX target (#274)**; the
-PASS gate is **verdict correctness**, never timing.
+Executed on a QNX 8.0 `mkqnximage`/QEMU x86_64 VM (the binaries baked into the IFS,
+auto-run at boot). **The cross-compiled matrix passes byte-identically on QNX:**
+
+```
+GATE (verdict correctness): PASS          # all 9 rows verdict_observed == verdict_expected
+```
+
+This satisfies the **verdict-correctness** acceptance for Phase-I (cross-compilation
+changed not one verdict — SG-00..SG-08 all PASS on the nto-qnx800 binary, including
+the corrected replay rule SG-07 → `SequenceRegress` and the seqlock torn-write
+SG-08 → `StaleHeader`).
+
+**Timing on this run is INDICATIVE ONLY — the VM ran under QEMU TCG (software
+emulation), NOT KVM** (the dev laptop has VT-x disabled in firmware). A representative
+`SCHED_FIFO` WCET requires KVM (near-native) or hardware; under TCG the absolute
+numbers carry full interpreter + VM-deschedule overhead (observed: median ≈ 3.6 µs,
+p99.9 ≈ 10.6 µs, **max ≈ 2.2 ms** — the millisecond max is emulation jitter, not the
+judge). So the `max < 100 µs` criterion is **deferred** to a KVM/hardware run; the
+typical-case single-digit-µs figure even under heavy emulation is feasibility-positive.
+
+## 7. WCET — Phase-I indicative, cert-grade TBD
+
+The on-target run (§6.1) produced a real QNX-`SCHED_FIFO` row, but **under TCG
+emulation it is INDICATIVE, never a WCET**. The harness CSV still carries the
+`TBD-QNX-TARGET` discipline for the certified figure. Cert-grade WCET is **Phase-II**:
+NVIDIA DRIVE (Orin/Thor) + QNX OS for Safety + Ferrocene-qualified Rust under FIFO —
+that number, not a VM figure, backs the FTTI claim. The PASS gate remains **verdict
+correctness**, which is now demonstrated on a real QNX target.

--- a/tools/qnx-rtm-harness/README.md
+++ b/tools/qnx-rtm-harness/README.md
@@ -121,10 +121,28 @@ row. See `docs/safety/ASSUMPTIONS_OF_USE.md` → **AOU-HW-QNX-TARGET-001**.
 `src/gateway/kinematics_contract.rs`; this harness **references** it, never
 imports it, and its number must never be read as a certified bound.
 
-## QNX
+## QNX cross-build + on-target FDIT/WCET (#274)
 
-`CMakeLists.txt` notes the QNX cross-compile hook as a comment; the real
-cross-compile + on-target FDIT/WCET work is **#274**. The harness→kernel-RTM
-tracing (**#272**, done) is in `QNX_MAPPING.md`; **adding the candidate `NO-RTM-ID`
-TRs to the RTM itself is a separate `docs/safety/**` change with its own review —
-not part of #272**, which only traces against the RTM as it stands.
+The QNX cross-compile is now **real and gated**, not a comment. The host build is
+**byte-identical** when `KIRRA_QNX_TARGET=OFF` (default) — `ctest` 2/2 as above.
+To cross-build for an **x86_64 QNX SDP 8.0** target and run the FDIT matrix +
+per-verdict WCET on it:
+
+```sh
+source ~/qnx800/qnxsdp-env.sh          # sets QNX_HOST/QNX_TARGET + qcc
+tools/qnx-rtm-harness/run_qnx_fdit.sh  # builds judge (nto) + shim/harness/wcet (qcc)
+# copy build-qnx/{rtm_harness,wcet_measure,kirra_demo} to the QNX target, then:
+#   ./rtm_harness && echo PASS   # verdict-correctness gate, on-target
+#   ./wcet_measure               # SCHED_FIFO WCET row (run as root); replaces TBD-QNX-TARGET
+```
+
+Pieces: `qnx.toolchain.cmake` (qcc/q++, x86_64 default), the `KIRRA_QNX_TARGET`
+CMake path (adds `wcet_measure`, drops the host-only `-lpthread/-ldl/-lm`, skips
+host ctest), and `run_qnx_fdit.sh` (handles the Rust-for-QNX toolchain: direct
+`rustc --target`, else `cargo -Zbuild-std=core`, else a custom-target.json prompt).
+Full recipe + Phase-I acceptance criteria: **`docs/safety/WCET_QNX_BRINGUP.md`**.
+
+The harness→kernel-RTM tracing (**#272**, done) is in `QNX_MAPPING.md`; **adding
+the candidate `NO-RTM-ID` TRs to the RTM itself is a separate `docs/safety/**`
+change with its own review — not part of #272**, which only traces against the
+RTM as it stands.

--- a/tools/qnx-rtm-harness/qnx.toolchain.cmake
+++ b/tools/qnx-rtm-harness/qnx.toolchain.cmake
@@ -1,0 +1,53 @@
+# qnx.toolchain.cmake — QNX SDP 8.0 cross-toolchain for the RTM harness (#274).
+#
+# Selects qcc/q++ as the C/C++ compilers and points the find-root at the QNX
+# target sysroot. x86_64 is the default (the Phase-I now-path); switch the variant
+# for an aarch64 board. Source `qnxsdp-env.sh` BEFORE configuring so QNX_HOST /
+# QNX_TARGET (and qcc) are on PATH.
+#
+# Usage (normally via run_qnx_fdit.sh, which sets the prebuilt judge lib too):
+#   source ~/qnx800/qnxsdp-env.sh
+#   cmake -S tools/qnx-rtm-harness -B build-qnx \
+#         -DCMAKE_TOOLCHAIN_FILE=tools/qnx-rtm-harness/qnx.toolchain.cmake \
+#         -DKIRRA_QNX_TARGET=ON -DKIRRA_QNX_QCC_VARIANT=gcc_ntox86_64 \
+#         -DKIRRA_JUDGE_LIB_PREBUILT=/abs/path/libkirra_judge.a
+
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_SYSTEM_VERSION 8.0.0)
+
+if("$ENV{QNX_HOST}" STREQUAL "" OR "$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR
+        "QNX_HOST/QNX_TARGET are unset — source qnxsdp-env.sh first "
+        "(e.g. `source ~/qnx800/qnxsdp-env.sh`).")
+endif()
+
+# The qcc/q++ COMPILATION VARIANT (`qcc -V` lists what your install provides).
+#   x86_64  → gcc_ntox86_64
+#   aarch64 → gcc_ntoaarch64le
+# Override with -DKIRRA_QNX_QCC_VARIANT=... if your SDP names it differently
+# (older SDP 7 used a `_cxx` suffix for the C++ variant).
+if(NOT DEFINED KIRRA_QNX_QCC_VARIANT)
+    set(KIRRA_QNX_QCC_VARIANT "gcc_ntox86_64")
+endif()
+
+if(KIRRA_QNX_QCC_VARIANT MATCHES "aarch64")
+    set(CMAKE_SYSTEM_PROCESSOR aarch64)
+else()
+    set(CMAKE_SYSTEM_PROCESSOR x86_64)
+endif()
+
+set(CMAKE_C_COMPILER   qcc)
+set(CMAKE_CXX_COMPILER q++)
+
+# qcc/q++ pick the cross target from the -V variant; inject it on every compile
+# AND link (the compiler check, the objects, and the final link all need it).
+set(CMAKE_C_FLAGS_INIT          "-V${KIRRA_QNX_QCC_VARIANT}")
+set(CMAKE_CXX_FLAGS_INIT        "-V${KIRRA_QNX_QCC_VARIANT}")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-V${KIRRA_QNX_QCC_VARIANT}")
+
+# Resolve libs/headers in the QNX sysroot, never the host's.
+set(CMAKE_FIND_ROOT_PATH "$ENV{QNX_TARGET}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/tools/qnx-rtm-harness/results/qnx800-x86_64-vm-tcg.txt
+++ b/tools/qnx-rtm-harness/results/qnx800-x86_64-vm-tcg.txt
@@ -1,0 +1,39 @@
+KIRRA #274 — on-target FDIT + WCET evidence (Phase-I feasibility)
+================================================================
+Target : QNX SDP 8.0, x86_64, mkqnximage/QEMU VM
+Accel  : QEMU TCG (software emulation) — VT-x disabled on dev laptop, NO KVM
+Build  : judge x86_64-pc-nto-qnx800 (cargo -Zbuild-std=core, no QNX std);
+         C++ via q++ (QCC 12.2.0). Binaries baked into the IFS, auto-run at boot.
+Date   : 2026-06-27
+
+GATE  : verdict correctness — the ONLY pass criterion. Result: PASS (all 9 rows).
+WCET  : INDICATIVE ONLY under TCG (interpreter + VM-deschedule overhead). The
+        millisecond `max` is emulation jitter, not the judge. A representative
+        SCHED_FIFO WCET (max < 100us, acceptance #4) needs KVM or hardware;
+        cert-grade WCET is Phase-II (NVIDIA DRIVE + QNX OS for Safety + Ferrocene).
+
+--- FDIT / RTM matrix (verbatim, on QNX) ----------------------------------------
+row    fault class            rtm            ok     verdict             p50(ns)    p99(ns)    max(ns)
+-------------------------------------------------------------------------------------------------
+SG-00  valid                  CONTROL        PASS   Ok                    35817     760498    3978246
+SG-01  bad-magic              NO-RTM-ID      PASS   StaleHeader           31468     138863    2222155
+SG-02  sequence-regress       NO-RTM-ID      PASS   SequenceRegress       31531     194874    7801932
+SG-03  deadline-missed        NO-RTM-ID      PASS   DeadlineMissed        31685     166417    2124281
+SG-04  payload-corrupt (CRC)  NO-RTM-ID      PASS   PayloadCorrupt        31173     182458    1833711
+SG-05  payload-oversize       NO-RTM-ID      PASS   PayloadOversize       10426      33412    9808246
+SG-06  over-envelope          SG-001/TR-001  PASS   KinematicLimit        31928     226044    3006376
+SG-07  replay (seq==last)     NO-RTM-ID      PASS   SequenceRegress       35527     196192    6282267
+SG-08  torn-write (odd gen)   NO-RTM-ID      PASS   StaleHeader           14237     117876    2244993
+
+GATE (verdict correctness): PASS
+FDIT_EXIT=0
+
+--- wcet_measure (INDICATIVE — TCG, not a WCET claim) ---------------------------
+WCET kirra_judge_assess  n=1000000  min=3300ns  med=3581ns  p99.9=10630ns  MAX=2198963ns
+metric,target,sched,n,warmup,max_ns,p999_ns,wcet_status
+kirra_judge_assess,x86_64-pc-nto-qnx800(TCG),SCHED_FIFO,1000000,10000,2198963,10630,INDICATIVE-TCG-NO-KVM
+WCET_EXIT=0
+
+Note: the harness binary emits `QNX-TARGET-MEASURED` in its own CSV; for THIS run
+that is downgraded to INDICATIVE-TCG-NO-KVM here because the VM had no KVM. The
+verdict-correctness PASS is unaffected by emulation and is the load-bearing result.

--- a/tools/qnx-rtm-harness/run_qnx_fdit.sh
+++ b/tools/qnx-rtm-harness/run_qnx_fdit.sh
@@ -72,7 +72,11 @@ build_judge_buildstd() {
     local C="$BUILD/judge-crate"
     mkdir -p "$C/src"
     cp "$JUDGE_SRC" "$C/src/lib.rs"
+    # The leading empty [workspace] table DETACHES this throwaway crate from the
+    # repo's parent Cargo workspace (else cargo refuses to build it).
     cat > "$C/Cargo.toml" <<EOF
+[workspace]
+
 [package]
 name = "kirra_judge"
 version = "0.0.0"
@@ -84,11 +88,22 @@ panic = "abort"
 opt-level = 2
 debug = false
 EOF
-    # RUSTC_BOOTSTRAP=1 lets a stable rustc accept -Z if no nightly is installed;
-    # prefer an explicit nightly when present.
+    # build-std needs the rust-src component for the active toolchain.
+    if ! rustc --print sysroot >/dev/null 2>&1 \
+         || [[ ! -d "$(rustc --print sysroot)/lib/rustlib/src/rust" ]]; then
+        echo "[judge] NOTE: rust-src not found — run 'rustup component add rust-src' \
+(and on stable, this uses RUSTC_BOOTSTRAP=1)." >&2
+    fi
     local tgt="$RUST_TARGET"
-    ( cd "$C" && RUSTC_BOOTSTRAP=1 cargo build --release \
-            -Z build-std=core --target "$tgt" ) || return 1
+    local log="$BUILD/cargo_buildstd.log"
+    # Prefer an installed nightly; else RUSTC_BOOTSTRAP=1 lets stable accept -Z.
+    if rustc +nightly --version >/dev/null 2>&1; then
+        ( cd "$C" && cargo +nightly build --release \
+                -Z build-std=core --target "$tgt" ) 2>&1 | tee "$log" || return 1
+    else
+        ( cd "$C" && RUSTC_BOOTSTRAP=1 cargo build --release \
+                -Z build-std=core --target "$tgt" ) 2>&1 | tee "$log" || return 1
+    fi
     local base; base="$(basename "${tgt%.json}")"
     cp "$C/target/$base/release/libkirra_judge.a" "$JUDGE_LIB"
 }
@@ -102,15 +117,18 @@ else
     cat >&2 <<EOF
 
 [judge] FAILED to build the judge for '$RUST_TARGET'.
-        Your rustc does not list this nto tuple and the build-std fallback did
-        not succeed. Most likely fix — supply a custom target spec and re-run:
-
+        Logs:
+          direct rustc : $BUILD/rustc_direct.log
+          cargo build-std : $BUILD/cargo_buildstd.log
+        Most common causes:
+          * rust-src missing  → rustup component add rust-src
+          * no nightly + stable too old for -Z build-std
+        If rustc does NOT list the tuple at all (it DID here), supply a custom
+        target spec instead:
           rustc +nightly -Z unstable-options --target x86_64-pc-nto-qnx710 \\
                 --print target-spec-json > ~/nto-qnx800.json
-          # edit the file: set "os":"nto", llvm triple to ...-nto-qnx8.0.0,
-          # linker to qcc, then:
+          # set "os":"nto", llvm triple ...-nto-qnx8.0.0, linker qcc, then:
           KIRRA_RUST_TARGET_JSON=~/nto-qnx800.json $0
-
         (See docs/safety/WCET_QNX_BRINGUP.md §1 and docs/adr/KIRRA_QNX_CROSSCOMPILE.md.)
 EOF
     exit 1

--- a/tools/qnx-rtm-harness/run_qnx_fdit.sh
+++ b/tools/qnx-rtm-harness/run_qnx_fdit.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# run_qnx_fdit.sh — Phase-I QNX on-target FDIT + WCET bring-up (#274, EPIC #270).
+#
+# Cross-builds, on an Ubuntu host with QNX SDP 8.0, the no_std verdict JUDGE
+# (libkirra_judge.a) + the C++ shim/harness/demo + wcet_measure for an x86_64 QNX
+# target, then tells you how to run them ON the QNX target. The host build path is
+# untouched (this script is the QNX path only).
+#
+# It owns the part that varies most — getting rustc to emit `core` for the nto
+# target — and tries, in order:
+#   1) direct `rustc --target <nto>` (works if your rustc ships a prebuilt core,
+#      e.g. a QNX-vendor / Ferrocene toolchain);
+#   2) `cargo -Z build-std=core --target <nto>` (upstream nightly + rust-src);
+#   3) if neither knows the tuple, prints the custom target.json next step.
+# The C++ side is always qcc/q++ via qnx.toolchain.cmake.
+#
+# Prereqs: `source ~/qnx800/qnxsdp-env.sh` first (sets QNX_HOST/QNX_TARGET + qcc).
+#
+# Env overrides:
+#   KIRRA_QNX_ARCH        x86_64 (default) | aarch64
+#   KIRRA_RUSTC_TARGET    override the rustc tuple (default per arch)
+#   KIRRA_QNX_QCC_VARIANT override the qcc -V variant (default per arch)
+#   KIRRA_RUST_TARGET_JSON path to a custom target spec (forces the build-std path)
+set -euo pipefail
+
+: "${QNX_HOST:?source qnxsdp-env.sh first (QNX_HOST unset)}"
+: "${QNX_TARGET:?source qnxsdp-env.sh first (QNX_TARGET unset)}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD="$HERE/build-qnx"
+JUDGE_SRC="$HERE/kirra_judge.rs"
+JUDGE_LIB="$BUILD/libkirra_judge.a"
+
+ARCH="${KIRRA_QNX_ARCH:-x86_64}"
+case "$ARCH" in
+    x86_64)
+        RUST_TARGET="${KIRRA_RUSTC_TARGET:-x86_64-pc-nto-qnx800}"
+        QCC_VARIANT="${KIRRA_QNX_QCC_VARIANT:-gcc_ntox86_64}" ;;
+    aarch64*)
+        RUST_TARGET="${KIRRA_RUSTC_TARGET:-aarch64-unknown-nto-qnx800}"
+        QCC_VARIANT="${KIRRA_QNX_QCC_VARIANT:-gcc_ntoaarch64le}" ;;
+    *) echo "unknown KIRRA_QNX_ARCH=$ARCH (use x86_64 | aarch64)" >&2; exit 2 ;;
+esac
+
+# A custom target.json forces tuple = the file and the build-std path.
+if [[ -n "${KIRRA_RUST_TARGET_JSON:-}" ]]; then
+    RUST_TARGET="$KIRRA_RUST_TARGET_JSON"
+fi
+
+mkdir -p "$BUILD"
+echo "=============================================================="
+echo " QNX FDIT/WCET bring-up (#274)"
+echo "   arch         : $ARCH"
+echo "   rustc target : $RUST_TARGET"
+echo "   qcc variant  : $QCC_VARIANT"
+echo "   QNX_TARGET   : $QNX_TARGET"
+echo "=============================================================="
+
+# ---- 1. Build the no_std judge staticlib for the QNX target ------------------
+build_judge_direct() {
+    rustc --print target-list 2>/dev/null | grep -qx "$RUST_TARGET" || return 1
+    echo "[judge] rustc knows '$RUST_TARGET' — trying a direct cross-build (prebuilt core)…"
+    rustc --edition 2021 --target "$RUST_TARGET" \
+          --crate-type staticlib --crate-name kirra_judge \
+          -C panic=abort -C opt-level=2 -C debuginfo=0 \
+          -o "$JUDGE_LIB" "$JUDGE_SRC" 2>"$BUILD/rustc_direct.log"
+}
+
+build_judge_buildstd() {
+    command -v cargo >/dev/null || { echo "[judge] cargo not found for -Zbuild-std fallback" >&2; return 1; }
+    echo "[judge] falling back to cargo -Z build-std=core (nightly + rust-src)…"
+    local C="$BUILD/judge-crate"
+    mkdir -p "$C/src"
+    cp "$JUDGE_SRC" "$C/src/lib.rs"
+    cat > "$C/Cargo.toml" <<EOF
+[package]
+name = "kirra_judge"
+version = "0.0.0"
+edition = "2021"
+[lib]
+crate-type = ["staticlib"]
+[profile.release]
+panic = "abort"
+opt-level = 2
+debug = false
+EOF
+    # RUSTC_BOOTSTRAP=1 lets a stable rustc accept -Z if no nightly is installed;
+    # prefer an explicit nightly when present.
+    local tgt="$RUST_TARGET"
+    ( cd "$C" && RUSTC_BOOTSTRAP=1 cargo build --release \
+            -Z build-std=core --target "$tgt" ) || return 1
+    local base; base="$(basename "${tgt%.json}")"
+    cp "$C/target/$base/release/libkirra_judge.a" "$JUDGE_LIB"
+}
+
+echo "## 1/3  Building the no_std judge for $RUST_TARGET"
+if build_judge_direct; then
+    echo "[judge] ok: direct rustc cross-build → $JUDGE_LIB"
+elif build_judge_buildstd; then
+    echo "[judge] ok: cargo build-std cross-build → $JUDGE_LIB"
+else
+    cat >&2 <<EOF
+
+[judge] FAILED to build the judge for '$RUST_TARGET'.
+        Your rustc does not list this nto tuple and the build-std fallback did
+        not succeed. Most likely fix — supply a custom target spec and re-run:
+
+          rustc +nightly -Z unstable-options --target x86_64-pc-nto-qnx710 \\
+                --print target-spec-json > ~/nto-qnx800.json
+          # edit the file: set "os":"nto", llvm triple to ...-nto-qnx8.0.0,
+          # linker to qcc, then:
+          KIRRA_RUST_TARGET_JSON=~/nto-qnx800.json $0
+
+        (See docs/safety/WCET_QNX_BRINGUP.md §1 and docs/adr/KIRRA_QNX_CROSSCOMPILE.md.)
+EOF
+    exit 1
+fi
+
+# ---- 2. Cross-build the C++ shim/harness/demo/wcet with qcc ------------------
+echo "## 2/3  Configuring + cross-building C++ (qcc) against the prebuilt judge"
+cmake -S "$HERE" -B "$BUILD" \
+      -DCMAKE_TOOLCHAIN_FILE="$HERE/qnx.toolchain.cmake" \
+      -DKIRRA_QNX_TARGET=ON \
+      -DKIRRA_QNX_QCC_VARIANT="$QCC_VARIANT" \
+      -DKIRRA_JUDGE_LIB_PREBUILT="$JUDGE_LIB"
+cmake --build "$BUILD" -j
+
+# ---- 3. How to run on the QNX target ----------------------------------------
+cat <<EOF
+
+## 3/3  Built nto binaries (these will NOT run on this Ubuntu host):
+   $BUILD/rtm_harness     FDIT/RTM matrix — exits non-zero on ANY wrong verdict
+   $BUILD/wcet_measure    SCHED_FIFO per-verdict WCET row (run as root for FIFO)
+   $BUILD/kirra_demo      end-to-end demo incl. a replay
+
+On the x86_64 QNX target (copy them over, e.g. scp / a shared image), run:
+
+   ./rtm_harness && echo "FDIT: every verdict correct on QNX (gate PASS)"
+   ./kirra_demo
+   ./wcet_measure         # run as root so SCHED_FIFO is granted (else INDICATIVE)
+
+Acceptance (WCET_QNX_BRINGUP.md §4): rtm_harness PASS byte-identically on-target,
+and wcet_measure's MAX < 100 µs replaces 'TBD-QNX-TARGET' with 'QNX-TARGET-MEASURED'.
+Paste both outputs back and we'll fold the CSV row into QNX_MAPPING.md.
+EOF


### PR DESCRIPTION
## #274 — turn the QNX cross-compile from a comment into a runnable path

The harness had all the on-target pieces (no_std judge, FDIT/RTM matrix, `wcet_measure.cpp`) but the QNX cross-build was still just a comment in `CMakeLists.txt`. This wires it up — gated — so the FDIT verdict-correctness matrix and per-verdict WCET can run on an **x86_64 QNX SDP 8.0** target. **Host build is byte-identical when the gate is OFF (default): `ctest` still 2/2.**

### What's in the tree now
- **`CMakeLists.txt`** — `option(KIRRA_QNX_TARGET OFF)`. When ON (with the toolchain file): adds the `wcet_measure` target (QNX-only — a host WCET number is INDICATIVE, so it's *structurally* excluded from the host build), drops the host-only `-lpthread/-ldl/-lm` (QNX libc provides them), and skips host ctest (nto binaries run on the target). The judge staticlib comes from `-DKIRRA_JUDGE_LIB_PREBUILT` (built for the target by the driver) or an nto-capable rustc via `-DKIRRA_RUSTC_TARGET`.
- **`qnx.toolchain.cmake`** — qcc/q++ cross-toolchain, x86_64 default (`gcc_ntox86_64`), aarch64 one-flag switch, QNX_TARGET sysroot find-root.
- **`run_qnx_fdit.sh`** — one-command driver. Owns the part that varies most — getting rustc to emit `core` for the nto target: tries direct `rustc --target`, then `cargo -Zbuild-std=core` (nightly + rust-src), then prompts for a custom `target.json`. Then qcc-builds the C++ and prints the on-target run steps.
- **Docs** — `WCET_QNX_BRINGUP.md` status → "cross-build wired, ready to run" with a TL;DR + the now-real §1d; harness README QNX section updated.

### How it runs (on the laptop + QNX target)
```bash
source ~/qnx800/qnxsdp-env.sh
tools/qnx-rtm-harness/run_qnx_fdit.sh        # cross-builds judge + C++
# copy build-qnx/{rtm_harness,wcet_measure,kirra_demo} to the QNX target:
./rtm_harness && echo PASS                   # FDIT verdict-correctness gate, on-target
sudo ./wcet_measure                          # SCHED_FIFO WCET row → replaces TBD-QNX-TARGET
```

### Honest scope
Verified here: the **host** build/ctest is byte-identical (gate OFF), the script is `bash -n`-clean, and the CMake gating wires `wcet_measure` + the prebuilt-judge import. **Not** run here — there's no QNX SDP in CI, so the actual cross-compile (qcc variant, rustc nto tuple, `build-std` vs prebuilt `core`) and the on-target FDIT PASS + sub-100µs WCET row are the remaining #274 step, to be executed on the x86_64 QNX target via the driver. Expect a round or two of toolchain-specific tuning (qcc `-V` variant string, the Rust-for-QNX path) — the script's probes + logs are built for that.

### Acceptance (per `WCET_QNX_BRINGUP.md` §4)
1. judge cross-compiles to `*-nto-qnx800` (core-only, no QNX std);
2. FDIT matrix passes **byte-identically** on the target;
3. real `SCHED_FIFO` max + p99.9 for `kirra_judge_assess`;
4. `max < 100 µs` → CSV row flips `TBD-QNX-TARGET` → `QNX-TARGET-MEASURED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_