### PR TITLE
fabric: authoritative automotive MRC = canonical 5.0, converge fabric↔gateway (#406, #429; ADR-0012)

### DIFF
--- a/docs/adr/0012-authoritative-mrc-envelope-per-asset.md
+++ b/docs/adr/0012-authoritative-mrc-envelope-per-asset.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 |---|---|
-| Status | **Proposed resolution (2026-06-21)** — owner direction set; ratified on merge. |
-| Date | 2026-06-21 |
+| Status | **Accepted — item 1 + item 3 implemented (2026-06-27)**; item 2 dispositioned (see Update). Owner direction (2026-06-21) ratified on merge. |
+| Date | 2026-06-21 (decision) · 2026-06-27 (implementation) |
 | Deciders | Project / safety-case owner |
 | Issues | #406 (this), #405 / ADR-0011 (sequenced ahead — HTTP-path reachability), #70 (Degraded decel-to-stop), `SAFE_STATE_SPECIFICATION` SS-002 |
 | Code | `src/fabric/governor.rs` (`KinematicProfileType::mrc_contract`), `src/gateway/kinematics_contract.rs` (`mrc_fallback_profile`), `src/gateway/policy_layer.rs` (Degraded branch) |
@@ -58,3 +58,30 @@ The all-platforms gateway defect (item 2) is **unconditional** and may land inde
 
 All numbers come from the safety case (SS-002), never convenience. Implementation lands from a
 laptop (large governor sources); this ADR records the decision, which does not.
+
+## Update (2026-06-27) — implemented (#406 / #429)
+
+ADR-0011 (the #405 reachability decision this was sequenced behind) is **Accepted (Option A)**,
+so item 1 is unblocked. Landed in `src/fabric/governor.rs`:
+
+- **Item 1 (authoritative automotive MRC) — DONE.** `KinematicProfileType::mrc_contract()` now
+  returns the validated `mrc_fallback_profile()` (the safety-case **5.0 m/s**) for
+  `AutomotiveNominal`, instead of the generic `0.3×` derate of the 35 m/s nominal (**10.5 m/s**,
+  2× the validated figure). Non-automotive platforms keep their per-platform `0.3×/0.4×/0.5×`
+  derate unchanged. No new number was introduced — the change adopts the *existing* canonical
+  5.0 and is strictly more conservative (the fabric automotive ceiling tightens 10.5 → 5.0).
+- **Item 3 (cross-point conformance test) — DONE.**
+  `mrc_ceiling_is_authoritative_across_enforcement_points` pins
+  `AutomotiveNominal.mrc_contract() == VehicleKinematicsContract::mrc_fallback_profile()`
+  (full envelope, not just the speed scalar) with a `< 10.5` regression guard; companion tests
+  pin the non-automotive derates and a behavioural over-ceiling clamp.
+- **Item 2 (gateway profile-awareness) — DISPOSITIONED, no code change.** The gateway HTTP
+  actuator path (`enforce_actuator_safety_envelope` / `policy_layer`) is **automotive-only**:
+  it threads **no** per-asset `KinematicProfileType` and hard-codes
+  `nominal_reference_profile()` / `mrc_fallback_profile()`, so the automotive 5.0 is the
+  *correct* envelope there — a non-automotive asset reaches its MRC via the fabric
+  `AssetGovernor` (item 1), not this path. The "applies 5.0 to all platforms" defect is
+  therefore latent only if the gateway envelope is later extended to carry non-automotive
+  assets; **if/when it is, it must resolve the profile through the same `mrc_contract()`**.
+  Tracked as a follow-up rather than forced now (threading a profile through the single-AV HTTP
+  path is a larger design change with no current caller that needs it).

--- a/src/fabric/governor.rs
+++ b/src/fabric/governor.rs
@@ -65,7 +65,27 @@ impl KinematicProfileType {
         }
     }
 
+    /// The authoritative Degraded (MRC) envelope for this profile.
+    ///
+    /// ADR-0012 (#406 / #429): the AUTOMOTIVE Degraded envelope is the VALIDATED
+    /// `mrc_fallback_profile()` — the safety-case **5.0 m/s** crawl ceiling
+    /// (`SAFE_STATE_SPECIFICATION` SS-002; Cruise SF Oct-2023 ~3 m/s post-stop
+    /// pullover-drag, "under a 5 m/s crawl ceiling") — NOT a generic `0.3×` derate
+    /// of the 35 m/s nominal, which lands at **10.5 m/s** (2× the validated figure).
+    /// This converges the fabric automotive MRC onto the SAME ceiling the gateway
+    /// enforces (`enforce_actuator_safety_envelope` / `policy_layer`), eliminating
+    /// the #406 divergence — a future enforcement point cannot ship a looser
+    /// automotive Degraded ceiling. The cross-point invariant is pinned by
+    /// `mrc_ceiling_is_authoritative_across_enforcement_points` below.
+    ///
+    /// Non-automotive platforms keep the per-platform `0.3× / 0.4× / 0.5×` derate;
+    /// each factor is derived from that platform's HARA / safety case (ADR-0012),
+    /// not chosen for convenience.
     pub fn mrc_contract(&self) -> VehicleKinematicsContract {
+        // Automotive: the validated canonical MRC is authoritative (ADR-0012 item 1).
+        if matches!(self, Self::AutomotiveNominal) {
+            return VehicleKinematicsContract::mrc_fallback_profile();
+        }
         let nominal = self.nominal_contract();
         VehicleKinematicsContract {
             max_speed_mps: nominal.max_speed_mps * 0.3,
@@ -161,6 +181,74 @@ mod tests {
         let contract = g.profile.nominal_contract();
         assert_eq!(contract.max_speed_mps, 15.0);
         assert_eq!(contract.max_steering_deg, 180.0);
+    }
+
+    /// ADR-0012 / #406 / #429 — the cross-enforcement-point MRC conformance pin.
+    /// A fabric automotive asset in Degraded must yield the SAME effective MRC
+    /// envelope the gateway enforces (`mrc_fallback_profile`), NOT the old generic
+    /// 0.3× derate (10.5 m/s). A future enforcement point cannot ship a looser
+    /// automotive Degraded ceiling without failing here.
+    #[test]
+    fn mrc_ceiling_is_authoritative_across_enforcement_points() {
+        let fabric_mrc = KinematicProfileType::AutomotiveNominal.mrc_contract();
+        let gateway_mrc = VehicleKinematicsContract::mrc_fallback_profile();
+        // The validated SS-002 crawl ceiling, identical at both points.
+        assert_eq!(fabric_mrc.max_speed_mps, gateway_mrc.max_speed_mps);
+        assert_eq!(fabric_mrc.max_speed_mps, 5.0, "the validated SS-002 5.0 m/s ceiling");
+        // The full envelope converges (not just the speed scalar) — fabric ==
+        // gateway, byte-for-byte, so the whole Degraded contract is authoritative.
+        assert_eq!(
+            fabric_mrc, gateway_mrc,
+            "fabric automotive MRC must BE the canonical mrc_fallback_profile (ADR-0012)"
+        );
+        // Regression guard: the old 0.3× derate of the 35 m/s nominal = 10.5 m/s —
+        // 2× the validated figure (#406). It must never come back.
+        assert!(
+            fabric_mrc.max_speed_mps < 10.5,
+            "automotive MRC must not regress to the 2×-looser generic derate (#406)"
+        );
+    }
+
+    /// ADR-0012 — the authoritative-automotive change must NOT perturb the
+    /// non-automotive platforms; each keeps its per-platform (HARA-derived) derate.
+    #[test]
+    fn non_automotive_mrc_keeps_per_platform_derate() {
+        let robot = KinematicProfileType::RobotNominal.mrc_contract();
+        assert!((robot.max_speed_mps - 1.8 * 0.3).abs() < 1e-9, "robot {}", robot.max_speed_mps);
+        let drone = KinematicProfileType::DroneNominal.mrc_contract();
+        assert!((drone.max_speed_mps - 15.0 * 0.3).abs() < 1e-9, "drone {}", drone.max_speed_mps);
+        let industrial = KinematicProfileType::IndustrialNominal.mrc_contract();
+        assert!(
+            (industrial.max_speed_mps - 0.5 * 0.3).abs() < 1e-9,
+            "industrial {}", industrial.max_speed_mps
+        );
+    }
+
+    /// Behavioural proof the divergence is gone end-to-end: a Degraded automotive
+    /// command at 8 m/s (above the 5.0 ceiling, decelerating) is bounded by the
+    /// authoritative 5.0 envelope at the fabric governor — it would have been
+    /// admitted up to 10.5 under the old derate.
+    #[test]
+    fn degraded_automotive_command_is_bounded_by_the_authoritative_ceiling() {
+        let g = AssetGovernor::new("av01".to_string(), KinematicProfileType::AutomotiveNominal);
+        let contract = g.profile.mrc_contract();
+        assert_eq!(contract.max_speed_mps, 5.0);
+        // A decel command from 8 → 6 m/s: still above the 5.0 MRC ceiling, so the
+        // envelope must bound it (clamp), not pass it through as the old 10.5 would.
+        let cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 6.0,
+            current_velocity_mps: 8.0,
+            delta_time_s: 0.1,
+            steering_angle_deg: 0.0,
+            current_steering_angle_deg: 0.0,
+        };
+        let result = g.evaluate_command(&cmd, &FleetPosture::Degraded, None);
+        // Decelerating + over-ceiling → the decel gate admits but clamps to MRC,
+        // never a clean Allow at 6.0 (which the old 10.5 ceiling would have given).
+        assert!(
+            matches!(result, EnforceAction::ClampLinear(_)),
+            "over-ceiling Degraded decel must clamp to the 5.0 envelope, got {result:?}"
+        );
     }
 
     // Issue #70: Degraded is decel-to-stop-and-HOLD. A re-initiation from a


### PR DESCRIPTION
## #406 / #429 — one authoritative automotive MRC ceiling (ADR-0012)

The fabric `AssetGovernor` and the gateway disagreed on the **automotive Degraded (MRC) ceiling** for the same asset + posture:
- fabric `KinematicProfileType::mrc_contract()` → generic `0.3×` derate of the 35 m/s nominal = **10.5 m/s**
- gateway `mrc_fallback_profile()` (the validated SS-002 crawl ceiling) = **5.0 m/s**

The fabric's 10.5 was **2× the validated figure** — not a rounding gap. This implements the **ratified ADR-0012** decision (now unblocked: ADR-0011 / #405 is Accepted, Option A).

### No new safety number
The change adopts the **existing** canonical `mrc_fallback_profile()` (5.0) and is **strictly more conservative** — the fabric automotive ceiling *tightens* 10.5 → 5.0. Nothing was invented; all numbers come from the safety case.

### What landed (`src/fabric/governor.rs`)
- **Item 1 — authoritative automotive MRC.** `mrc_contract()` returns `mrc_fallback_profile()` for `AutomotiveNominal`. Non-automotive platforms (`Robot`/`Drone`/`Industrial`) keep their per-platform `0.3×/0.4×/0.5×` derate unchanged.
- **Item 3 — cross-point conformance test.** `mrc_ceiling_is_authoritative_across_enforcement_points` pins `AutomotiveNominal.mrc_contract() == VehicleKinematicsContract::mrc_fallback_profile()` (full envelope, not just speed) with a `< 10.5` regression guard. Companion tests pin the non-automotive derates and a behavioural over-ceiling Degraded clamp (8→6 m/s now clamps to the 5.0 envelope; the old 10.5 would have passed it).
- **Item 2 — gateway profile-awareness: dispositioned, no code change.** The gateway HTTP actuator path (`enforce_actuator_safety_envelope` / `policy_layer`) is **automotive-only** — it threads no per-asset `KinematicProfileType` and hard-codes `nominal_reference_profile()` / `mrc_fallback_profile()`, so 5.0 is the *correct* envelope there. A non-automotive asset reaches its MRC via the fabric `AssetGovernor` (item 1). The "5.0 to all platforms" defect is latent only if the gateway envelope is later extended to carry non-automotive assets; ADR-0012 records the follow-up. (Threading a profile through the single-AV HTTP path is a larger change with no current caller needing it.)

### Status of the rest of #429 / #410
- The **#405 Degraded-HTTP reachability** half already shipped via ADR-0011 Option A (CLAUDE.md confirms all four enforcement points live + the assembled-router test).
- The **non-finite guard** (#404/#407 Tier-1) shipped in PR #428.
- So with this, #429's two structural deliverables (authoritative MRC resolver + conformance) are complete for the fabric↔gateway axis.

### Verification
42 fabric lib tests pass (3 new), `cargo clippy -p kirra-verifier --lib -- -D warnings` clean. The only remaining `10.5` literal in the tree is this PR's regression guard. ADR-0012 status updated to **Accepted — item 1 + 3 implemented**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_