### PR TITLE
security: fail-closed RSS finiteness gate (H-2) + verify_strict (L-1/L-2)

### DIFF
--- a/crates/kirra-fleet-transport/src/lib.rs
+++ b/crates/kirra-fleet-transport/src/lib.rs
@@ -27,7 +27,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
-use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 use kirra_verifier::federation_reconciliation::{
@@ -474,7 +474,10 @@ pub fn verify_clearance_grant(grant: &SignedClearanceGrant, public_key_b64: &str
         grant.expires_at_ms,
         &grant.nonce_hex,
     );
-    key.verify(payload.as_bytes(), &sig).is_ok()
+    // L-1: verify_strict rejects malleable / non-canonical signatures, matching the
+    // crate-wide crypto discipline (federation uses verify_strict). Inherent method
+    // on VerifyingKey — no Verifier trait needed.
+    key.verify_strict(payload.as_bytes(), &sig).is_ok()
 }
 
 /// **THE GRANT RULE.** Verify a received grant, then write it through the EXISTING

--- a/crates/kirra-ros2-adapter/src/lib.rs
+++ b/crates/kirra-ros2-adapter/src/lib.rs
@@ -16,6 +16,12 @@
 // Design tie-in: see `docs/safety/OCCY_131_OPTIONB_DESIGN.md`
 // (KIRRA-OCCY-OPTIONB-001) for the architecture this skeleton instantiates.
 
+// Mirrors the root crate's decision: this lint fires on intentionally
+// column-aligned ASCII derivation tables in safety doc-comments (e.g. the
+// per-class kinematic-budget tables in `config.rs`), which are read as evidence —
+// the alignment wins over the markdown-nesting pedantry.
+#![allow(clippy::doc_lazy_continuation)]
+
 pub mod config;
 pub mod corridor;
 pub mod geometry;

--- a/crates/kirra-ros2-adapter/src/validation.rs
+++ b/crates/kirra-ros2-adapter/src/validation.rs
@@ -357,6 +357,18 @@ pub fn validate_trajectory_slow_capped(
     // ego corridor laterally, containment handled it; longitudinal is
     // skipped to avoid spurious violations from objects in another lane.
     for obj in objects {
+        // H-2 (fail-closed RSS): a non-finite object field would poison every
+        // RSS `<` / `abs()` comparison below — NaN compares false against every
+        // threshold, so a dangerous object would be NEITHER rejected NOR skipped
+        // and the trajectory wrongly Accepted. A non-finite perception object is
+        // unlocalizable (we cannot even prove it is behind ego or laterally
+        // clear), so it is a perception fault → MRC. Mirrors the `pose_is_finite`
+        // discipline already enforced on the containment path. (The trajectory
+        // itself is already finiteness-guaranteed by the per-pose loop above,
+        // which rejects any NaN-derived command; objects are the unguarded seam.)
+        if !object_fields_finite(obj) {
+            return TrajectoryVerdict::MRCFallback;
+        }
         for traj_point in trajectory {
             let dx = obj.pos.x_m - traj_point.pose.x_m;
             let dy = obj.pos.y_m - traj_point.pose.y_m;
@@ -587,6 +599,23 @@ fn nearest_in_time(
 /// proximity) closes that gap. `max_lateral_accel_mps2` is the (posture-/perception-capped)
 /// per-pose contract's lateral-accel bound, so the predictive lateral check uses the SAME
 /// side-gap budget as the snapshot pass.
+/// Fail-closed finiteness predicate for a perceived object (review finding H-2).
+/// The snapshot RSS loop compares `obj`-derived quantities with `<` / `abs()`;
+/// under a NaN/Inf field every such test evaluates false, so a non-finite object
+/// is NEITHER rejected NOR skipped and the §4 conjunction is silently bypassed.
+/// Every field the RSS pass reads — position, the velocity vector `vel`, the
+/// speed magnitude, and the heading — must be finite, else the object is treated
+/// as a perception fault by the caller (`MRCFallback`).
+#[inline]
+fn object_fields_finite(obj: &PerceivedObject) -> bool {
+    obj.pos.x_m.is_finite()
+        && obj.pos.y_m.is_finite()
+        && obj.vel.x_m.is_finite()
+        && obj.vel.y_m.is_finite()
+        && obj.velocity_mps.is_finite()
+        && obj.heading_rad.is_finite()
+}
+
 // SAFETY: SG1 | REQ: multi-modal-predictive-rss-bound | TEST: predictive_rss_catches_a_predicted_cut_in,predictive_rss_does_not_regress_a_lane_keeping_neighbor,predictive_rss_is_a_no_op_when_no_modes_are_supplied,rss_conjunction_still_rejects_a_lateral_cut_in_at_a_safe_longitudinal_distance,predictive_rss_catches_a_mid_band_lateral_cut_in,predictive_rss_fails_closed_on_modes_supplied_but_all_unevaluable_b3,predictive_rss_fails_closed_on_modes_with_no_evaluable_window_b3
 fn predictive_rss_breach(
     trajectory: &[TrajectoryPoint],
@@ -604,6 +633,17 @@ fn predictive_rss_breach(
     for mode in modes {
         for pair in mode.samples.windows(2) {
             let (a, b) = (pair[0], pair[1]);
+            // H-2 (fail-closed predictive RSS): a non-finite predicted-mode
+            // sample position poisons the closing-rate (`ov*`) and gap math the
+            // same way as the snapshot pass (NaN `<` x == false → no breach
+            // detected). A non-finite prediction is a fault → breach → MRC.
+            if !(a.pos.x_m.is_finite()
+                && a.pos.y_m.is_finite()
+                && b.pos.x_m.is_finite()
+                && b.pos.y_m.is_finite())
+            {
+                return true;
+            }
             let dt = b.time_from_start_s - a.time_from_start_s;
             if dt <= 0.0 {
                 continue; // non-monotonic samples — unevaluable (see post-loop guard)

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -115,6 +115,71 @@ fn test_rss_violation_rejects() {
 }
 
 // ---------------------------------------------------------------------------
+// 3b. H-2 — a NON-FINITE perception object must FAIL CLOSED (MRCFallback), not be
+//     silently skipped. A NaN/Inf field poisons every RSS `<`/`abs()` comparison
+//     (NaN compares false), so pre-fix the dangerous object was neither rejected
+//     nor skipped and the trajectory was wrongly Accepted.
+// ---------------------------------------------------------------------------
+
+/// Control: a FINITE object placed far off-corridor is cleanly skipped and the
+/// trajectory Accepts — so the test below isolates the *non-finite* effect (the
+/// guard must reject only on non-finiteness, never over-reject a clean object).
+#[test]
+fn test_finite_far_object_is_skipped_and_accepts() {
+    let trajectory = straight_trajectory(10, 5.0, 0.1);
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let objects = vec![PerceivedObject {
+        id: 1,
+        pos: Point { x_m: 50.0, y_m: 20.0 }, // far ahead AND 20 m off to the side
+        velocity_mps: 0.0,
+        heading_rad: 0.0,
+        vel: Point { x_m: 0.0, y_m: 0.0 },
+    }];
+    let verdict = validate_trajectory_slow(
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal,
+    );
+    assert_eq!(verdict, TrajectoryVerdict::Accept,
+        "a finite, far, off-corridor object must be skipped (Accept); got {verdict:?}");
+}
+
+/// H-2: each non-finite object field independently fails closed to MRCFallback.
+#[test]
+fn test_nonfinite_object_field_fails_closed_h2() {
+    let trajectory = straight_trajectory(10, 5.0, 0.1);
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+
+    // Base object: far off-corridor, so a FINITE version Accepts (see control
+    // above). Each variant corrupts exactly one field with NaN or Inf.
+    let base = PerceivedObject {
+        id: 1,
+        pos: Point { x_m: 50.0, y_m: 20.0 },
+        velocity_mps: 0.0,
+        heading_rad: 0.0,
+        vel: Point { x_m: 0.0, y_m: 0.0 },
+    };
+
+    let variants: Vec<(&str, PerceivedObject)> = vec![
+        ("pos.x_m=NaN", PerceivedObject { pos: Point { x_m: f64::NAN, y_m: 0.0 }, ..base }),
+        ("pos.y_m=Inf", PerceivedObject { pos: Point { x_m: 50.0, y_m: f64::INFINITY }, ..base }),
+        ("velocity_mps=NaN", PerceivedObject { velocity_mps: f64::NAN, ..base }),
+        ("heading_rad=NaN", PerceivedObject { heading_rad: f64::NAN, ..base }),
+        ("vel.x_m=Inf", PerceivedObject { vel: Point { x_m: f64::INFINITY, y_m: 0.0 }, ..base }),
+        ("vel.y_m=-Inf", PerceivedObject { vel: Point { x_m: 0.0, y_m: f64::NEG_INFINITY }, ..base }),
+    ];
+
+    for (label, obj) in variants {
+        let verdict = validate_trajectory_slow(
+            &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal,
+        );
+        assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
+            "H-2: a non-finite object field ({label}) must fail closed to MRC, not be \
+             silently skipped; got {verdict:?}");
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 3a. Per-class RSS lateral band — a small-robot (courier) profile admits a side
 //     object a robotaxi refuses, WITHOUT changing the robotaxi number (#1 / the
 //     CONTRACT_PROFILES.md sibling rule). The checker LOGIC is identical; only the

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -292,11 +292,14 @@ fn audit_signing_payload(
 /// Verify a base64 Ed25519 signature over `payload` under `vk`.
 fn audit_verify_sig(vk: &ed25519_dalek::VerifyingKey, payload: &str, sig_b64: &str) -> bool {
     use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
-    use ed25519_dalek::{Signature, Verifier};
+    use ed25519_dalek::Signature;
     b64e.decode(sig_b64)
         .ok()
         .and_then(|b| <[u8; 64]>::try_from(b.as_slice()).ok())
-        .map(|arr| vk.verify(payload.as_bytes(), &Signature::from_bytes(&arr)).is_ok())
+        // L-2: verify_strict rejects malleable / non-canonical signatures, matching
+        // the rest of the crate's crypto discipline (the federation path already
+        // uses it). `verify_strict` is inherent on VerifyingKey — no Verifier trait.
+        .map(|arr| vk.verify_strict(payload.as_bytes(), &Signature::from_bytes(&arr)).is_ok())
         .unwrap_or(false)
 }
 


### PR DESCRIPTION
## Pen-test "safety fail-open" fixes — H-2 + L-1/L-2

All findings verified real against current `main` before fixing.

### H-2 (HIGH, safety-critical) — RSS collision check silently bypassed by NaN/Inf
The per-pose kinematics path is finiteness-hardened, but the **RSS object loop** in `validate_trajectory_slow` was not. It read `obj.pos` / `obj.vel` / `obj.velocity_mps` / `obj.heading_rad` and compared with `<`/`abs()` — every such test evaluates **false** under NaN — so a non-finite object (e.g. a stopped lead whose tracker emits `heading_rad = atan2(0,0) = NaN`) was **neither rejected nor skipped**, and the trajectory was wrongly `Accept`ed. That defeats the checker's primary collision invariant — the literal product thesis.

**Fix** (fail-closed; mirrors the containment `pose_is_finite` discipline and the doer-checker "a fault → MRC" invariant):
- `object_fields_finite()` gate at the top of the snapshot RSS object loop — a non-finite object is *unlocalizable* (we cannot even prove it is behind ego or laterally clear), so it is a perception fault → `MRCFallback`.
- A matching guard in `predictive_rss_breach` — a non-finite predicted-mode sample poisons the closing-rate/gap math identically → breach → `MRCFallback`.
- **Tests:** a control (`test_finite_far_object_is_skipped_and_accepts` — proves the guard does *not* over-reject a clean object) and a per-field non-finite sweep (`pos`/`vel`/`velocity_mps`/`heading_rad` × NaN/Inf → `MRCFallback`). This also addresses the report's §10 recommendation to fuzz the RSS object inputs.

### L-1 / L-2 (LOW) — `verify` → `verify_strict`
Two production Ed25519 sites used the malleable `verify` while the rest of the crate uses `verify_strict`. Switched both (rejects non-canonical/malleable signatures), dropping the now-unused `Verifier` imports:
- `crates/kirra-fleet-transport/src/lib.rs` — clearance-grant verify
- `src/verifier_store/mod.rs` — audit-signature verify

### Tooling
Added the root crate's existing `#[allow(clippy::doc_lazy_continuation)]` to the adapter crate — a pre-existing alignment-table doc-comment lint surfaced by a newer clippy — so `clippy -D warnings` is green.

## Verification
- 45 adapter `validation_tests` pass (incl. the 2 new H-2 tests); 81 verifier-store tests; fleet-transport tests.
- `cargo clippy -p kirra-ros2-adapter -p kirra-verifier -p kirra-fleet-transport --lib --tests -- -D warnings` clean.

## Deliberately not in this PR
**M-9** (empty live-node set → `Nominal`) is a *posture-semantics* change — does a zero-node Active fleet fail closed? — with startup ripple. It deserves the registered-count cross-check (distinguishing a hydration gap from a genuinely empty fleet) and isolated review. Recommended as a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_