### PR TITLE
security: fail closed when the live node set is empty (M-9)

### DIFF
--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -47,6 +47,11 @@ pub fn next_generation() -> u64 {
 ///   2. Any Degraded node  → FleetPosture::Degraded
 ///   3. All nominal        → FleetPosture::Nominal
 ///
+/// An EMPTY set aggregates to `Nominal` here — correct at this pure layer (no
+/// node is Degraded/LockedOut). The fail-closed POLICY for an empty *live* set
+/// on an Active verifier ("no nodes" ≠ "healthy") lives one layer up in
+/// `recalculate_and_broadcast` (M-9), which overrides this to LockedOut.
+///
 /// Pure function — no I/O, no side effects.
 pub fn derive_fleet_posture(node_postures: &[FleetNodePosture]) -> FleetPosture {
     let mut any_degraded = false;
@@ -105,6 +110,36 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     // Step 2: Derive aggregate posture — pure function, no I/O.
     let dag_posture = derive_fleet_posture(&node_postures);
 
+    // M-9 (fail-closed on an empty live-node set): the pure `derive_fleet_posture`
+    // aggregates an empty set to `Nominal` — correct AT THAT LAYER (no node is
+    // LockedOut/Degraded), but on an ACTIVE verifier "no nodes" is "no positive
+    // trust evidence", not "the fleet is healthy". Caching Nominal here is
+    // fail-OPEN: `should_route_command` reads Nominal as "admit everything",
+    // so an actuator command would be authorized while the governor is blind.
+    //
+    // So an empty live set forces LockedOut (blocks all command routing). It is
+    // NOT sticky — it is recomputed every recalc, so it auto-recovers to the
+    // DAG posture the instant a node is registered (registration routes are not
+    // posture-gated), with no human reset. The store cross-check only selects the
+    // REASON for observability: a hydration/consistency gap (durable registry
+    // non-empty while memory is empty) vs a genuinely empty fleet (cold start /
+    // nothing deployed). Queried ONLY on the empty path, so the steady-state hot
+    // path takes no extra store lock.
+    let empty_live_set = node_ids.is_empty();
+    let empty_set_reason = if empty_live_set {
+        let registered = app
+            .store
+            .with(|store| store.count_nodes())
+            .unwrap_or(0);
+        Some(if registered > 0 {
+            "EMPTY_LIVE_SET_HYDRATION_GAP"
+        } else {
+            "EMPTY_LIVE_SET_NO_NODES"
+        })
+    } else {
+        None
+    };
+
     // RSS / flood escalation: an active RSS violation OR active flood condition
     // elevates Nominal to Degraded. The Nominal-only guard means LockedOut /
     // Degraded (from the DAG) are NEVER downgraded by this check; the two
@@ -134,6 +169,11 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     let new_posture = if app.supervisor_tripped.load(std::sync::atomic::Ordering::SeqCst)
         || app.frame_lockout_active.load(std::sync::atomic::Ordering::SeqCst)
     {
+        FleetPosture::LockedOut
+    } else if empty_live_set {
+        // M-9: no live nodes → no positive trust evidence → fail closed.
+        // Shares LockedOut with the sticky flags but is itself non-sticky
+        // (auto-recovers when a node registers — see the comment above).
         FleetPosture::LockedOut
     } else if escalate {
         FleetPosture::Degraded
@@ -171,8 +211,17 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
         "is_transition":    is_transition,
         "generation":       generation,
         "node_count":       node_postures.len(),
+        "empty_set_reason": empty_set_reason,
         "computed_at_ms":   ts,
     });
+
+    if let Some(reason) = empty_set_reason {
+        tracing::warn!(
+            reason     = reason,
+            generation = generation,
+            "M-9 fail-closed: empty live-node set on an Active verifier — forcing LockedOut (no positive trust evidence)"
+        );
+    }
 
     let event_type = if is_transition {
         "SYSTEM_POSTURE_TRANSITION"
@@ -424,6 +473,19 @@ mod posture_engine_tests {
         assert!(is_transition);
     }
 
+    fn registered_trusted_node(id: &str) -> crate::verifier::RegisteredNode {
+        crate::verifier::RegisteredNode {
+            node_id: id.to_string(),
+            status: NodeTrustState::Trusted,
+            registered_at_ms: 1,
+            last_trust_update_ms: 1,
+            ak_public_pem: None,
+            expected_pcr16_digest_hex: None,
+            site: None,
+            firmware_version: None,
+        }
+    }
+
     #[test]
     fn test_recalculate_and_broadcast_writes_to_cache() {
         use std::sync::Arc;
@@ -434,6 +496,12 @@ mod posture_engine_tests {
         let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
         let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
 
+        // A live, Trusted node — so the happy path genuinely derives Nominal
+        // (M-9: an EMPTY live set now fails closed to LockedOut, see the
+        // dedicated tests below).
+        app.persist_and_insert_node(registered_trusted_node("node-1"))
+            .unwrap();
+
         recalculate_and_broadcast(&app, &cache);
 
         // Happy path: audit committed → cache + broadcast may proceed.
@@ -442,6 +510,91 @@ mod posture_engine_tests {
         let entry = guard.as_ref().unwrap();
         assert_eq!(entry.posture, FleetPosture::Nominal);
         assert!(entry.generation > 0);
+    }
+
+    // M-9 fail-closed: an empty live-node set on an Active verifier is "no
+    // positive trust evidence", NOT "healthy". The pure `derive_fleet_posture`
+    // still aggregates `[]` → Nominal (test above), but the engine overrides it.
+
+    #[test]
+    fn test_empty_live_set_fails_closed_to_locked_out() {
+        use std::sync::Arc;
+        use crate::verifier::{AppState, VerifierOperationMode};
+        use crate::verifier_store::VerifierStore;
+
+        let store = VerifierStore::new(":memory:").unwrap();
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+        let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
+
+        // Genuinely empty fleet (durable registry is empty too) — still must NOT
+        // certify Nominal; an Active governor with nothing to govern fails closed.
+        recalculate_and_broadcast(&app, &cache);
+
+        let guard = cache.read().unwrap();
+        assert_eq!(
+            guard.as_ref().unwrap().posture,
+            FleetPosture::LockedOut,
+            "an empty live-node set must fail closed to LockedOut, never Nominal"
+        );
+    }
+
+    #[test]
+    fn test_empty_live_set_with_orphaned_store_nodes_is_locked_out() {
+        use std::sync::Arc;
+        use crate::verifier::{AppState, VerifierOperationMode};
+        use crate::verifier_store::VerifierStore;
+
+        let store = VerifierStore::new(":memory:").unwrap();
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+        let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
+
+        // Hydration/consistency gap: the durable registry holds a node, but the
+        // in-memory live set was never populated with it (write to the store
+        // ONLY — bypassing `persist_and_insert_node`'s memory insert). This is
+        // the dangerous fail-open the cross-check targets; it must fail closed.
+        app.store
+            .with(|s| s.save_node(&registered_trusted_node("orphan")))
+            .unwrap();
+        assert!(app.nodes.is_empty(), "in-memory live set must be empty for this case");
+
+        recalculate_and_broadcast(&app, &cache);
+
+        let guard = cache.read().unwrap();
+        assert_eq!(
+            guard.as_ref().unwrap().posture,
+            FleetPosture::LockedOut,
+            "an empty live set while the store holds nodes (hydration gap) must fail closed"
+        );
+    }
+
+    #[test]
+    fn test_empty_live_set_lockout_auto_recovers_on_registration() {
+        use std::sync::Arc;
+        use crate::verifier::{AppState, VerifierOperationMode};
+        use crate::verifier_store::VerifierStore;
+
+        let store = VerifierStore::new(":memory:").unwrap();
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+        let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
+
+        // Empty → LockedOut.
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(
+            cache.read().unwrap().as_ref().unwrap().posture,
+            FleetPosture::LockedOut
+        );
+
+        // The empty-set LockedOut is NOT sticky (unlike supervisor_tripped):
+        // registering a Trusted node and recalculating recovers to Nominal with
+        // no human reset.
+        app.persist_and_insert_node(registered_trusted_node("node-1"))
+            .unwrap();
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(
+            cache.read().unwrap().as_ref().unwrap().posture,
+            FleetPosture::Nominal,
+            "empty-set LockedOut must auto-recover once a Trusted node registers"
+        );
     }
 
     #[test]
@@ -575,13 +728,21 @@ mod posture_engine_tests {
     // Driven through the real authoritative write path (`recalculate_and_broadcast`,
     // audit-commit-gated), reading the resulting cache posture. DAG postures are
     // forced by inserting nodes: Untrusted → LockedOut, Unknown → Degraded,
-    // empty/Trusted → Nominal (per `recursive_calculate`).
+    // Trusted → Nominal (per `recursive_calculate`).
+    //
+    // These tests exercise the operational ESCALATION layer (flood / frame / RSS)
+    // composing ON TOP OF a healthy fleet, so `active_app` seeds one Trusted
+    // baseline node — i.e. a real, non-empty Nominal DAG. (Without it the M-9
+    // empty-live-set guard would fail the whole fleet closed to LockedOut before
+    // any escalation is considered — that guard has its own dedicated tests.)
 
     fn active_app() -> std::sync::Arc<AppState> {
         use crate::verifier::VerifierOperationMode;
         use crate::verifier_store::VerifierStore;
         let store = VerifierStore::new(":memory:").unwrap();
-        std::sync::Arc::new(AppState::new(store, VerifierOperationMode::Active))
+        let app = std::sync::Arc::new(AppState::new(store, VerifierOperationMode::Active));
+        insert_node(&app, "baseline", NodeTrustState::Trusted);
+        app
     }
 
     fn insert_node(app: &AppState, id: &str, status: NodeTrustState) {

--- a/src/posture_engine_v2.rs
+++ b/src/posture_engine_v2.rs
@@ -764,13 +764,29 @@ mod posture_engine_v2_tests {
     #[tokio::test]
     async fn test_periodic_refresh_restamps_cache_without_changing_posture() {
         use std::sync::Arc;
-        use crate::verifier::{AppState, FleetPosture, VerifierOperationMode};
+        use crate::verifier::{AppState, FleetPosture, NodeTrustState, RegisteredNode, VerifierOperationMode};
         use crate::verifier_store::VerifierStore;
         use crate::posture_cache::SharedPostureCache;
 
         let store = VerifierStore::new(":memory:").unwrap();
         let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
         let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
+
+        // A live, Trusted node gives a genuine Nominal baseline. (Without it the
+        // M-9 empty-live-set guard fails closed to LockedOut — the re-stamp
+        // semantics under test are about an UNCHANGED posture, so a real Nominal
+        // fleet is the right fixture here.)
+        app.persist_and_insert_node(RegisteredNode {
+            node_id: "node-1".to_string(),
+            status: NodeTrustState::Trusted,
+            registered_at_ms: 1,
+            last_trust_update_ms: 1,
+            ak_public_pem: None,
+            expected_pcr16_digest_hex: None,
+            site: None,
+            firmware_version: None,
+        })
+        .unwrap();
 
         crate::posture_engine::recalculate_and_broadcast(&app, &cache);
         let first = cache.read().unwrap().as_ref().cloned()

--- a/src/verifier_store/nodes.rs
+++ b/src/verifier_store/nodes.rs
@@ -164,4 +164,19 @@ impl VerifierStore {
         )?;
         Ok(n > 0)
     }
+
+    /// Number of nodes registered in the durable registry.
+    ///
+    /// Cheap `COUNT(*)` (no row materialization, unlike `load_nodes`). Used by
+    /// the posture engine's M-9 empty-live-set guard to distinguish a genuinely
+    /// empty fleet (`0` here too) from a hydration/consistency gap (the in-memory
+    /// `app.nodes` is empty while the durable registry still holds nodes) — both
+    /// fail closed, but the reason code differs for operators.
+    pub fn count_nodes(&self) -> Result<i64> {
+        self.conn.query_row(
+            "SELECT COUNT(*) FROM nodes",
+            [],
+            |row| row.get(0),
+        )
+    }
 }

--- a/tests/governor_closes_loop_proof.rs
+++ b/tests/governor_closes_loop_proof.rs
@@ -365,6 +365,10 @@ async fn axis2a_sensor_fault_drives_posture_to_locked_out() {
 async fn axis2a_rss_fault_drives_posture_to_degraded() {
     let store = VerifierStore::new(":memory:").unwrap();
     let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+    // A real, Trusted AV DAG → genuine Nominal baseline (matching the sibling
+    // sensor-fault test), so the RSS fault escalates Nominal → Degraded. (An
+    // EMPTY live set now fails closed to LockedOut — the M-9 guard.)
+    register_av_infra(&app);
     let cache: SharedPostureCache =
         Arc::new(std::sync::RwLock::new(Some(CachedFleetPosture::new(FleetPosture::Nominal))));
 

--- a/tests/rss_posture_tests.rs
+++ b/tests/rss_posture_tests.rs
@@ -9,7 +9,9 @@
 
 use std::sync::Arc;
 
-use kirra_verifier::verifier::{AppState, FleetPosture, VerifierOperationMode};
+use kirra_verifier::verifier::{
+    AppState, FleetPosture, NodeTrustState, RegisteredNode, VerifierOperationMode,
+};
 use kirra_verifier::posture_cache::{CachedFleetPosture, SharedPostureCache};
 use kirra_verifier::scenario_runner::{PostureAssertion, ScenarioEvent, ScenarioRunner};
 use kirra_verifier::verifier_store::VerifierStore;
@@ -19,7 +21,21 @@ use parko_core::RssState;
 fn build_rss_test_app() -> (Arc<AppState>, SharedPostureCache) {
     let store = VerifierStore::new(":memory:").expect("in-memory store");
     let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
-    // No nodes registered — DAG returns Nominal; RSS violation layer under test.
+    // One live, Trusted node → the DAG genuinely derives Nominal, so the RSS
+    // violation layer under test escalates from a real Nominal baseline. (An
+    // EMPTY live set now fails closed to LockedOut — the M-9 guard — which would
+    // mask the escalation this test targets.)
+    app.persist_and_insert_node(RegisteredNode {
+        node_id: "rss-node".to_string(),
+        status: NodeTrustState::Trusted,
+        registered_at_ms: 1,
+        last_trust_update_ms: 1,
+        ak_public_pem: None,
+        expected_pcr16_digest_hex: None,
+        site: None,
+        firmware_version: None,
+    })
+    .expect("register baseline node");
     let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(Some(
         CachedFleetPosture::new(FleetPosture::Nominal),
     )));

--- a/tests/rss_simulation.rs
+++ b/tests/rss_simulation.rs
@@ -37,6 +37,21 @@ use parko_kirra::{KirraGovernor, MRC_VELOCITY_CEILING_MPS};
 fn build_app() -> (Arc<AppState>, SharedPostureCache) {
     let store = VerifierStore::new(":memory:").expect("in-memory store");
     let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+    // One live, Trusted node → the DAG genuinely derives Nominal, so the RSS
+    // escalation under test is layered on a real Nominal fleet. (An EMPTY live
+    // set now fails closed to LockedOut — the M-9 guard — which would mask the
+    // Nominal → Degraded escalation these tests assert.)
+    app.persist_and_insert_node(RegisteredNode {
+        node_id: "rss-sim-node".to_string(),
+        status: NodeTrustState::Trusted,
+        registered_at_ms: 1,
+        last_trust_update_ms: 1,
+        ak_public_pem: None,
+        expected_pcr16_digest_hex: None,
+        site: None,
+        firmware_version: None,
+    })
+    .expect("register baseline node");
     let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(Some(
         CachedFleetPosture::new(FleetPosture::Nominal),
     )));


### PR DESCRIPTION
## Pen-test "safety fail-open" fix — M-9 (empty live-node set → Nominal)

Verified real against current `main` before fixing.

### The fail-open
The pure `derive_fleet_posture` aggregates an **empty** node set to `Nominal` — correct *at that layer* (no node is Degraded/LockedOut) — and on an Active verifier that result flowed straight through `recalculate_and_broadcast` into a Nominal posture cache. `should_route_command` reads `Nominal` as "admit everything", so an actuator/write command would be **authorized while the governor has zero nodes** — i.e. zero positive trust evidence about anything. "No nodes" is not "the fleet is healthy"; certifying Nominal there is fail-**open**.

### The fix (fail-closed)
Single chokepoint — every caller (the coalescing posture-engine worker, standby promotion, scenario runner) funnels through `recalculate_and_broadcast`:

- An **empty live-node set on an Active verifier overrides the derived posture to `LockedOut`** (blocks all command routing). The pure aggregator stays honest; the *policy* lives one layer up.
- The override is **not sticky** (unlike `supervisor_tripped` / `frame_lockout_active`): it's recomputed every recalc, so it **auto-recovers** to the DAG posture the instant a node registers — registration routes aren't posture-gated — with **no human reset**. Proven by `test_empty_live_set_lockout_auto_recovers_on_registration`.
- A store cross-check (`VerifierStore::count_nodes`, a cheap `COUNT(*)`) selects the audit/trace **reason** only — distinguishing a **hydration/consistency gap** (`EMPTY_LIVE_SET_HYDRATION_GAP`: durable registry non-empty while memory is empty — the dangerous case) from a **genuinely empty fleet** (`EMPTY_LIVE_SET_NO_NODES`: cold start). Queried **only on the empty path**, so the steady-state hot path takes no extra store lock. The reason lands in the posture audit payload and a `warn!` log.

### Design choice: policy at the engine layer, not the aggregator
`derive_fleet_posture([]) == Nominal` is **kept** as the honest pure-function contract; the safety override is localized to `recalculate_and_broadcast`. This keeps the pure function unit-testable and puts the fail-closed decision where the I/O/context (Active-vs-Standby, store count) actually lives.

### Tests
- New: `test_empty_live_set_fails_closed_to_locked_out` (genuinely empty → LockedOut), `test_empty_live_set_with_orphaned_store_nodes_is_locked_out` (hydration gap → LockedOut), `test_empty_live_set_lockout_auto_recovers_on_registration`.
- Several existing escalation/lifecycle tests built an **empty** Active app and leaned on empty→Nominal to assert RSS/flood/frame escalation. They now seed a Trusted baseline node so the escalation is genuinely layered on a real Nominal fleet — the realistic state (those operational faults only fire when nodes exist). Touched: `posture_engine` `active_app` helper + the v2 periodic-refresh test; integration `rss_posture_tests`, `rss_simulation`, `governor_closes_loop_proof`.

### Verification
- Full suite green **except one pre-existing, unrelated failure** — `dds_bridge::dds_qos_tests::readback_accepts_exact_match_and_writer_round_trips`, a CDR encapsulation options-byte mismatch (`[0,1,0,2]` vs `[0,1,0,0]`) that **also fails on the base** (confirmed by stashing this change) and is untouched here.
- `cargo clippy --lib --tests -- -D warnings` clean.

Independent of (and non-overlapping with) the H-2 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_