### PR TITLE
test: fix stale CDR encapsulation header assertion in dds_bridge

### DIFF
--- a/src/dds_bridge.rs
+++ b/src/dds_bridge.rs
@@ -734,11 +734,20 @@ mod dds_qos_tests {
         let requested = DdsQosProfile::critical_actuator_profile();
         let writer = LoopbackTestWriter::new(requested);
         assert_eq!(validate_qos_readback(&requested, &writer.negotiated_qos()), Ok(()));
+        // A 2-byte body is NOT 4-byte aligned, so `wrap_cdr_encapsulation`
+        // appends `pad = (4 - 2 % 4) % 4 = 2` trailing zero bytes and advertises
+        // that count in the options low byte (DDS-RTPS §10 / DDS-XTypes
+        // §7.6.3.1.2). The full frame is therefore the header `[0x00,0x01,0x00,
+        // 0x02]` (CDR_LE id + options-pad=2), the body, then the 2 pad bytes.
         let frame = DdsPublisherBridge::publish_actuator_command(&[0xDE, 0xAD], &requested).unwrap();
         writer.publish(&frame).unwrap();
         let sent = writer.sent.borrow();
         assert_eq!(sent.len(), 1);
-        assert_eq!(&sent[0][..4], &[0x00, 0x01, 0x00, 0x00], "the writer received the CDR-encapsulated frame");
+        assert_eq!(
+            sent[0],
+            vec![0x00, 0x01, 0x00, 0x02, 0xDE, 0xAD, 0x00, 0x00],
+            "the writer received the CDR-encapsulated frame (header + body + alignment pad)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Pre-existing test failure on `main`

`dds_bridge::dds_qos_tests::readback_accepts_exact_match_and_writer_round_trips` fails deterministically on `main` (surfaced while running the suite for an unrelated change):

```
assertion `left == right` failed: the writer received the CDR-encapsulated frame
  left: [0, 1, 0, 2]
 right: [0, 1, 0, 0]
```

## Root cause — stale test, correct implementation

The test publishes a **2-byte** body and asserts the 4-byte RTPS CDR encapsulation header is `[0x00, 0x01, 0x00, 0x00]` (options pad = 0). But a 2-byte body is not 4-byte aligned, so `wrap_cdr_encapsulation` (`src/dds_bridge.rs:277`) correctly computes:

```rust
let pad = (4 - (payload.len() % 4)) % 4;   // (4 - 2) % 4 = 2
wrapped.extend_from_slice(&[0x00, 0x01, 0x00, pad as u8]);
```

- `[0x00, 0x01]` = representation id `CDR_LE`.
- `[0x00, pad]` = options field; the **low byte carries the alignment pad count** (DDS-RTPS §10 / DDS-XTypes §7.6.3.1.2, documented at `dds_bridge.rs:264-276`).

So the real header is `[0x00, 0x01, 0x00, 0x02]`. The **implementation is correct** — a 2-byte body needs 2 trailing pad bytes to reach a 4-byte boundary, and the options byte advertises that so a compliant reader strips them. The test's hardcoded `0x00` pad byte was stale (predates the pad-in-options-byte fix it references).

## Fix

Assert the **full frame** — header (`CDR_LE` id + options-pad=2), body, then the 2 alignment pad bytes:

```rust
assert_eq!(sent[0], vec[0x00, 0x01, 0x00, 0x02, 0xDE, 0xAD, 0x00, 0x00], ...);
```

This turns a contradictory assertion into one that **locks the documented encapsulation contract** (header + body + pad), so a future regression in the pad math is caught.

## Verification
- `dds_bridge` tests: 19 passed, 0 failed.
- `cargo clippy --lib --tests -- -D warnings` clean.

Independent of the H-2 (#628) and M-9 (#629) PRs; test-only, no production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_