### PR TITLE
security: Degraded scalar governor enforces decel-to-stop-and-hold (M-10)

### DIFF
--- a/src/kirra_core.rs
+++ b/src/kirra_core.rs
@@ -258,8 +258,35 @@ impl<C: SafetyContract> SafetyGovernor for KirraKernelGovernor<C> {
                 }
             }
             BehavioralAction::ApplyVelocityCap => {
-                let clamped_value = safe_clamp(core_bounded_demand, self.constraint_cap_min, self.constraint_cap_max);
-                (clamped_value, MitigationCode::DegradedPostureClamp { cap_min: self.constraint_cap_min, cap_max: self.constraint_cap_max })
+                // #410 residual / issue #70: Degraded is decel-to-stop-and-HOLD, NOT a
+                // sustained crawl. The prior pure clamp to [cap_min, cap_max] admitted a
+                // speed INCREASE up to the cap, a re-initiation from a stop, and a
+                // reversal through zero — the post-stop pullover-drag failure mode the
+                // vehicle path's `enforce_degraded_decel_to_stop` (#70) refuses. The
+                // scalar kernel governor (the FFI/scalar ingress, #404) was the one
+                // enforcement point left as a pure clamp.
+                //
+                // Enforce the same non-increasing / no-reinit / no-reversal rule on the
+                // scalar. Cap/envelope first (defense-in-depth, unchanged), THEN the
+                // decel-to-stop bound applied LAST so it is authoritative over any
+                // positive `cap_min` floor: emit `sign(current)·min(|capped|,|current|)`.
+                // This is epsilon-free yet complete — magnitude never exceeds the current
+                // (non-increasing), the sign is forced to the current direction (no
+                // reversal), and at a stop (`|current|≈0`) the magnitude term collapses to
+                // ~0 (no re-initiation) — while a genuine decelerating-toward-zero command
+                // still passes. Unlike the vehicle path there is no separate MRC channel,
+                // so a refused increase/reinit/reversal becomes a non-increasing HOLD in
+                // the current direction (itself a valid decel trajectory). Recovery is
+                // automatic on return to FullAutonomy. The Nominal WCET path is UNCHANGED.
+                let current = self.last_validated_scalar;
+                let capped = safe_clamp(core_bounded_demand, self.constraint_cap_min, self.constraint_cap_max);
+                let held = current.signum() * capped.abs().min(current.abs());
+                if (held - capped).abs() > 1e-9 {
+                    // The decel-to-stop bound actively overrode the (capped) demand.
+                    (held, MitigationCode::DegradedDecelToStopHold { held })
+                } else {
+                    (held, MitigationCode::DegradedPostureClamp { cap_min: self.constraint_cap_min, cap_max: self.constraint_cap_max })
+                }
             }
             BehavioralAction::ForceStationaryHold => {
                 (self.last_validated_scalar, MitigationCode::ShadowModeHoldEnforced { retained: self.last_validated_scalar })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,11 @@ pub enum MitigationCode {
     PassthroughUnrestrictedNormal,
     /// Degraded posture: demand bounded inside the reduced operating cap.
     DegradedPostureClamp { cap_min: f64, cap_max: f64 },
+    /// Degraded posture (#70/#410): the demand was a speed INCREASE, a
+    /// re-initiation from a stop, or a reversal through zero, which the
+    /// decel-to-stop-and-HOLD bound overrode. `held` is the emitted scalar —
+    /// non-increasing in magnitude and keeping the current sign.
+    DegradedDecelToStopHold { held: f64 },
     /// Shadow mode: the last validated scalar is held (no new motion authored).
     ShadowModeHoldEnforced { retained: f64 },
     /// LockedOut: the contract fallback state is commanded.
@@ -143,6 +148,9 @@ impl std::fmt::Display for MitigationCode {
             }
             MitigationCode::DegradedPostureClamp { cap_min, cap_max } => {
                 write!(f, "DEGRADED_POSTURE_CLAMP: Bounded inside [{cap_min} - {cap_max}]")
+            }
+            MitigationCode::DegradedDecelToStopHold { held } => {
+                write!(f, "DEGRADED_DECEL_TO_STOP_HOLD: Non-increasing hold at {held}")
             }
             MitigationCode::ShadowModeHoldEnforced { retained } => {
                 write!(f, "SHADOW_MODE_HOLD_ENFORCED: Fixed value retained: {retained:.1}")

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -34,6 +34,69 @@ fn test_unrestricted_autonomy_envelope_limit_clamping() {
     assert!(res.was_unsafe_attempt);
 }
 
+// --- #70 / #410: Degraded = decel-to-stop-and-HOLD on the scalar kernel governor.
+// Drive the trust engine to ConstrainedAdvisory (score 56..=85 → Degraded /
+// `ApplyVelocityCap`) and prove the branch refuses a speed increase, a
+// re-initiation from a stop, and a reversal through zero, while still admitting a
+// decelerating command. (Mirrors the vehicle path's `enforce_degraded_decel_to_stop`.)
+
+fn velocity_contract() -> KinematicContract {
+    KinematicContract {
+        max_linear_velocity: 2.0,     // symmetric envelope ±2.0
+        max_angular_velocity: 0.5,
+        max_linear_acceleration: 0.1,
+        fallback_linear_speed: 0.0,
+    }
+}
+
+/// Build a governor already in Degraded (ConstrainedAdvisory), holding `current`.
+fn degraded_velocity_governor(current: f64) -> KirraKernelGovernor<KinematicContract> {
+    // caps ±2.0 so the reduced cap does NOT bind — the decel-to-stop bound is the
+    // behaviour under test.
+    let mut gov = KirraKernelGovernor::new(velocity_contract(), current, -2.0, 2.0);
+    gov.trust_engine.decay_trust(30); // 100 → 70 ⇒ ConstrainedAdvisory (Degraded)
+    assert_eq!(gov.trust_engine.mode, crate::TrustMode::ConstrainedAdvisory);
+    gov
+}
+
+#[test]
+fn test_degraded_refuses_speed_increase_holds_current() {
+    // Moving at 1.0, planner demands 1.8 (within envelope AND cap): a pure clamp
+    // would admit 1.8 — a speed INCREASE in Degraded. Decel-to-stop holds at 1.0.
+    let mut gov = degraded_velocity_governor(1.0);
+    let res = gov.evaluate(1.8, 1.0);
+    assert_eq!(res.sanitized_scalar, 1.0, "Degraded must not author a speed increase");
+    assert!(matches!(res.mitigation, crate::MitigationCode::DegradedDecelToStopHold { .. }));
+}
+
+#[test]
+fn test_degraded_admits_deceleration() {
+    // Moving at 1.5, planner demands 0.5 — a decelerating command is admitted.
+    let mut gov = degraded_velocity_governor(1.5);
+    let res = gov.evaluate(0.5, 1.0);
+    assert_eq!(res.sanitized_scalar, 0.5, "a decelerating command must pass under Degraded");
+}
+
+#[test]
+fn test_degraded_refuses_reinitiation_from_stop() {
+    // Stopped (0.0), planner demands 1.5: a pure clamp would re-initiate motion.
+    // Decel-to-stop HOLDs at the stop.
+    let mut gov = degraded_velocity_governor(0.0);
+    let res = gov.evaluate(1.5, 1.0);
+    assert_eq!(res.sanitized_scalar, 0.0, "Degraded must not re-initiate motion from a stop");
+    assert!(matches!(res.mitigation, crate::MitigationCode::DegradedDecelToStopHold { .. }));
+}
+
+#[test]
+fn test_degraded_refuses_reversal_through_zero() {
+    // Moving forward at 1.5, planner demands -1.5 (reverse): the emitted scalar
+    // keeps the current sign — no reversal — at non-increasing magnitude.
+    let mut gov = degraded_velocity_governor(1.5);
+    let res = gov.evaluate(-1.5, 1.0);
+    assert_eq!(res.sanitized_scalar, 1.5, "Degraded must not reverse direction through a stop");
+    assert!(matches!(res.mitigation, crate::MitigationCode::DegradedDecelToStopHold { .. }));
+}
+
 #[test]
 fn test_type_safe_llm_parser_rejection_of_injections() {
     let parser = UnstructuredTextParser;


### PR DESCRIPTION
## Pen-test "safety fail-open" fix — M-10 (the #410 residual)

Verified real against current `main` before fixing.

### The fail-open
`KirraKernelGovernor::evaluate` — the scalar / C-FFI ingress (#404) — was the **one Degraded enforcement point left as a pure clamp**. The `ApplyVelocityCap` branch clamped the demand to `[cap_min, cap_max]` and emitted it:

```rust
let clamped_value = safe_clamp(core_bounded_demand, self.constraint_cap_min, self.constraint_cap_max);
(clamped_value, MitigationCode::DegradedPostureClamp { ... })
```

In Degraded posture that admitted a **speed increase up to the cap**, a **re-initiation from a stop**, and a **reversal through zero** — exactly the post-stop pullover-drag failure mode that issue #70's *"Degraded = controlled decel-to-stop-and-HOLD"* invariant exists to prevent. The other four enforcement points (gateway, fabric `AssetGovernor`, ros2-adapter, parko-kirra) already enforce it via `enforce_degraded_decel_to_stop`; this scalar governor was the residual.

### The fix
The `ApplyVelocityCap` branch now applies the same **non-increasing / no-reinit / no-reversal** rule, expressed on the scalar. Envelope + reduced cap first (defense-in-depth, unchanged), **then** the decel-to-stop bound last (so it wins over any positive `cap_min` floor):

```rust
let held = current.signum() * capped.abs().min(current.abs());
```

This is **epsilon-free yet complete**:
- magnitude never exceeds the current → **non-increasing**;
- sign forced to the current direction → **no reversal**;
- at a stop (`|current|≈0`) the magnitude term collapses to ~0 → **no re-initiation**;
- a genuine **decelerating-toward-zero** command still passes.

For a non-velocity positive-magnitude scalar the reinit/reversal cases are inert and it degrades to a conservative *"non-increasing in Degraded"* cap. There's no separate MRC channel here, so a refused increase/reinit/reversal becomes a non-increasing **hold in the current direction** (itself a valid decel trajectory). **Recovery is automatic** on return to `FullAutonomy`. The Nominal WCET-critical `ExecuteUnrestricted` path is **unchanged**.

### Observability
Adds `MitigationCode::DegradedDecelToStopHold { held }` (audit/verdict narrative), emitted when the decel bound overrides the demand; the admissible-decel case keeps `DegradedPostureClamp`.

### Tests
Four new governor tests driving the trust engine into `ConstrainedAdvisory` (Degraded): refuse speed increase (holds current), admit deceleration, refuse re-initiation from a stop, refuse reversal through zero. Existing FullAutonomy envelope-clamp and `MitigationCode` Display tests unchanged.

### Verification
- M-10 governor tests, `mitigation_code_tests`, and `test_unrestricted_autonomy_envelope_limit_clamping` pass.
- Full lib suite: only red is the **pre-existing, unrelated** `dds_bridge::...readback_accepts_exact_match...` failure (fixed in #630).
- `cargo clippy --lib --tests -- -D warnings` clean.

Independent of the H-2 (#628), M-9 (#629), and dds-test (#630) PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_