### PR TITLE
security: close the telemetry-watchdog registration window (H-3)

### DIFF
--- a/src/bin/kirra_verifier_service/fleet.rs
+++ b/src/bin/kirra_verifier_service/fleet.rs
@@ -406,5 +406,15 @@ pub(crate) async fn handle_register_av_asset(
         }
     }).await;
 
+    // H-3: the av_subsystem_meta row is now committed (the `call` closure ran).
+    // Signal the telemetry watchdog to refresh its watched-node list on its NEXT
+    // sweep (~100 ms) rather than at the next 30 s periodic refresh — otherwise a
+    // node registered just after a refresh is unmonitored for up to ~28 s, a
+    // fail-OPEN window in which a silent/faulty fresh sensor would go undetected
+    // (breaking the SG-003 detection-latency bound).
+    svc.app
+        .av_registry_dirty
+        .store(true, std::sync::atomic::Ordering::Release);
+
     (StatusCode::OK, Json(json!({ "node_id": req.node_id, "registered": true }))).into_response()
 }

--- a/src/telemetry_watchdog.rs
+++ b/src/telemetry_watchdog.rs
@@ -103,7 +103,9 @@ pub(crate) struct WatchdogNodeEntry {
 ///      (NOT calling recalculate_and_broadcast directly — routes through the
 ///      serialized worker to prevent burst recalculations)
 ///   5. Every `AV_WATCHDOG_NODE_REFRESH_MS`, refreshes the node list from SQLite
-///      to pick up newly registered nodes
+///      to pick up newly registered nodes — OR immediately on the next sweep when
+///      a registration set `AppState::av_registry_dirty` (H-3), so a fresh node is
+///      monitored within one sweep rather than after up to ~28 s.
 ///
 /// # Disk-first ordering
 /// Trust state mutation (memory) happens after the trigger is sent to the engine.
@@ -231,7 +233,19 @@ pub(crate) fn watchdog_sweep_once(
     // briefly (released at the end of its own expression). Same operations
     // in the same order — only the lock scope changes.
     // ----------------------------------------------------------------------
-    if now.saturating_sub(*last_node_refresh_ms) >= AV_WATCHDOG_NODE_REFRESH_MS
+    // H-3: a registration/deregistration sets `av_registry_dirty`, forcing a
+    // refresh on the NEXT sweep instead of waiting up to AV_WATCHDOG_NODE_REFRESH_MS
+    // (30 s) — otherwise a freshly-registered node is unmonitored for ~28 s, a
+    // fail-OPEN window (a silent fresh sensor would never be marked Untrusted until
+    // the periodic refresh finally adds it). Swap-and-clear BEFORE the load: a
+    // registration that lands after this swap but before the load is still picked
+    // up by this load (it reads the committed DB), and if it lands after the load
+    // the flag is set again → caught on the next sweep (≤ one AV_WATCHDOG_SWEEP_MS).
+    let registry_dirty = app
+        .av_registry_dirty
+        .swap(false, std::sync::atomic::Ordering::AcqRel);
+    if registry_dirty
+        || now.saturating_sub(*last_node_refresh_ms) >= AV_WATCHDOG_NODE_REFRESH_MS
         || *last_node_refresh_ms == 0
     {
         // SG-003 fail-CLOSED: recover a poisoned store lock rather than
@@ -741,6 +755,55 @@ mod watchdog_di_tests {
         // (3) refresh stamp advanced to `now`.
         assert_eq!(observed_last_refresh, now,
             "*last_node_refresh_ms must be set to clock.now_ms() after a refresh");
+    }
+
+    /// H-3: a node registered just AFTER a periodic refresh must be picked up on
+    /// the next sweep (via `av_registry_dirty`), not after up to ~28 s. Drives the
+    /// fail-open as a control (within the refresh window + not dirty → not yet
+    /// monitored) and then proves the dirty flag forces a prompt refresh.
+    #[test]
+    fn test_av_registry_dirty_forces_prompt_refresh_within_window() {
+        let store = VerifierStore::new(":memory:").expect("memory store");
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+        // Register an AV subsystem AFTER construction (the realistic case).
+        app.store.with(|store| {
+            store
+                .register_av_subsystem_meta("lidar_front", "LIDAR", "hw-0001", 0.7, 1_000_000)
+                .expect("register av subsystem");
+        });
+
+        let now: u64 = 1_000_500;
+        let clock = VirtualClock::starting_at(now);
+        let (tx, _rx) = mpsc::channel::<PostureRecalcTrigger>(128);
+        let mut node_health: HashMap<String, WatchdogNodeEntry> = HashMap::new();
+        // A RECENT refresh stamp: both the 30 s periodic arm and the cold-start
+        // arm are NOT due, so without the dirty flag this sweep does NOT refresh.
+        let mut last_node_refresh_ms: u64 = now;
+
+        // Control — the ~28 s fail-open: within the window and not dirty, the
+        // freshly-registered node is NOT yet monitored.
+        watchdog_sweep_once(
+            &app, &tx, clock.as_ref(), &mut node_health, &mut last_node_refresh_ms,
+        );
+        assert!(
+            node_health.is_empty(),
+            "control: within the refresh window and not dirty, a fresh node is unmonitored"
+        );
+
+        // H-3: registration sets the dirty flag → the next sweep refreshes promptly.
+        app.av_registry_dirty
+            .store(true, std::sync::atomic::Ordering::Release);
+        watchdog_sweep_once(
+            &app, &tx, clock.as_ref(), &mut node_health, &mut last_node_refresh_ms,
+        );
+        assert!(
+            node_health.contains_key("lidar_front"),
+            "H-3: a dirty registry must force a prompt refresh so the fresh node is monitored within one sweep"
+        );
+        assert!(
+            !app.av_registry_dirty.load(std::sync::atomic::Ordering::Acquire),
+            "the watchdog must clear av_registry_dirty after refreshing"
+        );
     }
 }
 

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -315,6 +315,14 @@ pub struct AppState {
     /// side channel); surfaced so an integrator can see how much training data the
     /// channel sizing is shedding.
     pub capture_drops: Arc<AtomicU64>,
+    /// H-3 — set when an AV subsystem is (de)registered, so the telemetry watchdog
+    /// refreshes its watched-node list on the NEXT sweep instead of waiting up to
+    /// `AV_WATCHDOG_NODE_REFRESH_MS` (30 s). Without this a node registered just
+    /// after a refresh was unmonitored for ~28 s — a fail-OPEN window where a
+    /// freshly-registered sensor could go silent/faulty undetected, breaking the
+    /// SG-003 detection-latency bound (TIMEOUT + one sweep). The watchdog swaps it
+    /// back to false when it refreshes. Defaults false.
+    pub av_registry_dirty: Arc<AtomicBool>,
 }
 
 impl AppState {
@@ -351,6 +359,7 @@ impl AppState {
             command_source_write_failures: Arc::new(AtomicU64::new(0)),
             audit_write_drops: Arc::new(AtomicU64::new(0)),
             capture_drops: Arc::new(AtomicU64::new(0)),
+            av_registry_dirty: Arc::new(AtomicBool::new(false)),
         }
     }
 


### PR DESCRIPTION
## Pen-test "safety fail-open" fix — H-3

Verified real against current `main`.

### The fail-open
The telemetry watchdog learns which AV nodes to monitor **only** via a SQLite node-list refresh rate-limited to `AV_WATCHDOG_NODE_REFRESH_MS = 30 s`. A node registered just *after* a refresh isn't in the watched set for up to ~30 s. During that window its 2 s telemetry timeout is **not enforced** — a sensor that registers and is immediately silent/faulty goes **undetected for up to ~28 s**.

That breaks the advertised **SG-003** detection-latency bound (`AV_TELEMETRY_TIMEOUT_MS + one sweep ≈ 2.1 s`), which `test_watchdog_detection_latency_within_bound` only proves for *already-watched* nodes — the registration window is the gap.

### The fix (event-driven prompt refresh; periodic backstop kept)
- New `AppState::av_registry_dirty: AtomicBool`. The AV-asset registration handler sets it (`Release`) **after** the `av_subsystem_meta` row is committed.
- `watchdog_sweep_once` swaps-and-clears it (`AcqRel`) at the top of the refresh decision; a set flag forces the node-list refresh on **this** sweep regardless of the 30 s timer.
- **Swap-before-load** ordering: a registration racing the load is either picked up by this load (it reads the committed DB) or re-sets the flag and is caught on the next sweep → a fresh node is monitored within one `AV_WATCHDOG_SWEEP_MS` (~100 ms), restoring the SG-003 bound.

The extra SQLite node-list query runs **only when a registration actually occurred** (rare), not every sweep — the periodic-refresh efficiency rationale is preserved.

### Why event-driven rather than shrinking the 30 s interval
Lowering `AV_WATCHDOG_NODE_REFRESH_MS` would only *bound* the window (still fail-open up to the new interval) and would add the node-list query to every sweep. The dirty flag closes the window to one sweep while keeping the steady-state query cadence at 30 s.

### Tests
`test_av_registry_dirty_forces_prompt_refresh_within_window` drives the fail-open as a **control** (recent refresh + not dirty → fresh node unmonitored), then proves the dirty flag forces a prompt refresh and is cleared. All 16 existing watchdog tests unchanged and green.

### Verification
- 16/16 `telemetry_watchdog` tests pass; service binary builds.
- Full lib suite: only red is the **pre-existing, unrelated** `dds_bridge::...readback_accepts_exact_match...` failure (fixed in #630).
- `cargo clippy --lib --bins --tests -- -D warnings` clean.

Independent of #628 / #629 / #630 / #631 / #632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_