### PR TITLE
deploy: TLS transport for the verifier API + fail-closed plaintext guard (H-1)

### DIFF
--- a/docs/safety/ASSUMPTIONS_OF_USE.md
+++ b/docs/safety/ASSUMPTIONS_OF_USE.md
@@ -54,6 +54,7 @@ the verification passes for the target deployment.
 | AOU-TIMESYNC-001 | Sensor/message timestamps consumed by governor staleness/deadline validation are synchronized, monotonic, drift-bounded vs the boundary clock domain, and converted to it before publication (HVCHAN §5 non-mixing rule) | Integrator (time sync / platform) | **AoU-GAP** — integrator obligation; drift bound **VALIDATION-PENDING** (set with the FTTI budget, #274/#278) | the governor staleness/deadline barrier (HVCHAN §3 judge; the #271 harness + #273 spike deadline checks); PTP/gPTP expected discharge |
 | AOU-HW-QNX-TARGET-001 | The QNX-resident safety partition and its **certified-WCET** evidence run on an NVIDIA **DRIVE** platform (DRIVE AGX Orin / DRIVE AGX Thor) running DRIVE OS + QNX OS for Safety — **NOT** a Jetson module (Orin NX / AGX Orin / Jetson Thor), which runs L4T/Linux and which NVIDIA does **not** support QNX on | Integrator (hardware / platform) | **AoU-GAP** — pre-production HW gate; vendor-fixed (informational) | the QNX-target WCET / FTTI claim (`TBD-QNX-TARGET`, #274); the EPIC #270 QNX safety-partition lane; ADR `KIRRA_QNX_CROSSCOMPILE` aarch64 path |
 | AOU-PLATFORM-GEOMETRY-001 | A non-Ackermann platform deployed behind the `PlatformKinematics` abstraction supplies a footprint and kinematic limits (via its impl) that MATCH the physical platform; for a platform using the center-convention `VehicleFootprint` (`wheelbase_m = 0`, symmetric overhangs), the supplied pose is the **geometric center** | Integrator (platform) | **AoU** (by design) — abstraction + SG2 seam IMPLEMENTED and dual-platform-PROVEN (S-PK1a/b/c, ADR-0027); a live non-Ackermann **deployment** is **DEPLOYMENT-PENDING** (integrator wires a node consuming `validate_platform_containment` + supplies verified geometry/limits). The Ackermann path is unchanged/ENFORCED | SG2 drivable-space containment for any platform via `validate_platform_containment` (`crates/kirra-core/src/platform_kinematics.rs`); the per-platform envelope (`evaluate`) + RSS stay platform-specific |
+| AOU-TRANSPORT-TLS-001 | The verifier HTTP API (admin token + mutation routes) is reached only over a TLS-terminated / encrypted transport; plaintext exposure beyond a trusted cluster-internal path is prohibited | Integrator (deployment / platform) | **AoU** (by design) — chart fail-closed guard + TLS Ingress live (H-1); cert/issuer integrator-supplied | the confidentiality of `KIRRA_ADMIN_TOKEN` (Tier-2 Bearer auth) and the integrity of all mutation routes — `constant_time_compare` defends the comparison, not the wire |
 
 ---
 
@@ -1073,3 +1074,59 @@ Ackermann path — generalized to the trait.
 - `parko/crates/parko-kirra/src/platform.rs` — `DiffDrivePlatform`,
   `centered_footprint`, `diffdrive_is_bounded_by_the_generic_containment_seam`.
 - ADR-0027; `docs/safety/STAGE_S-PK1_PLATFORM_KINEMATICS.md`.
+
+---
+
+## AOU-TRANSPORT-TLS-001 — The verifier API is reached only over a TLS-terminated transport
+
+### Assumption
+> *Every client of the verifier HTTP API — admin tooling, the ROS 2 interlock
+> interceptor, federation peers, operator consoles — reaches it over a
+> TLS-terminated / encrypted transport. The plaintext listener
+> (`KIRRA_VERIFIER_ADDR`, default `0.0.0.0:8090`) is bound only to a trusted,
+> cluster-internal path; TLS is terminated by the deployment (a TLS Ingress, an
+> L7 load balancer, or a service-mesh mTLS sidecar) before any untrusted network
+> segment. The verifier process itself speaks plaintext HTTP by design (ADR-0006
+> Clause 3 keeps crypto/transport at the integration boundary, not the governor
+> hot path).*
+
+### Why it is load-bearing
+Tier-2 routes authenticate with a static Bearer token (`KIRRA_ADMIN_TOKEN`) and
+Tier-1 routes add an `x-kirra-client-id` header. The in-process defenses are real
+but **comparison-side only**: `constant_time_compare` stops a timing oracle, and
+`require_admin_token` fails closed on an absent token. None of that protects the
+token **on the wire** — over plaintext HTTP the `Authorization: Bearer …` header
+and every state-mutating body (attestation registration, dependency edges,
+federation reports, supervisor reset) are transmitted in cleartext, so a
+passive on-path observer captures the admin token and can then drive the full
+mutation surface of the safety governor. (`docs/ros2_interlock.md` already records
+this for the interceptor: *"include the admin token in every HTTP request — use
+TLS in production to prevent token interception."*)
+
+### Status / scope
+- **Chart fail-closed guard — LIVE (H-1).** `helm/kirra` refuses to render when the
+  Service is exposed externally (`LoadBalancer` / `NodePort`) or the Ingress is
+  enabled without a `tls:` block, unless the operator sets
+  `kirra.allowInsecureTransport=true` to acknowledge external TLS termination. The
+  default `ClusterIP` (cluster-internal) is unaffected.
+- **TLS Ingress — PROVIDED.** `helm/kirra/templates/ingress.yaml` (opt-in,
+  `ingress.enabled` + `ingress.tls`) is the supported termination point;
+  cert/issuer (e.g. cert-manager) is integrator-supplied.
+- **In-process TLS (rustls) — NOT provided** (deliberate, ADR-0006 Clause 3). If a
+  deployment cannot terminate TLS in front of the process, that is a separate
+  request, not this AoU.
+
+### Consequence if violated
+A cleartext-exposed verifier leaks `KIRRA_ADMIN_TOKEN` to any on-path observer →
+full unauthorized control of the mutation surface (node trust, dependency graph,
+federation, supervisor reset) → the fail-closed posture engine can be driven
+arbitrarily. This is a confidentiality/integrity break of the entire admin
+control plane, not a single route.
+
+### Evidence
+- `helm/kirra/templates/ingress.yaml`, `helm/kirra/templates/service.yaml`
+  (fail-closed guard), `helm/kirra/values.yaml` (`ingress`,
+  `kirra.allowInsecureTransport`).
+- `docs/ros2_interlock.md` (interceptor token-over-TLS note).
+- Route auth matrix: `CLAUDE.md` / `docs/v1_route_authorization_matrix.md`
+  (Tier-1 / Tier-2 routes that carry the token).

--- a/helm/kirra/templates/NOTES.txt
+++ b/helm/kirra/templates/NOTES.txt
@@ -1,5 +1,21 @@
 Kirra Safety Kernel deployed successfully.
 
+{{- if .Values.ingress.enabled }}
+{{- $scheme := ternary "https" "http" (not (empty .Values.ingress.tls)) }}
+
+Verifier API (via Ingress):
+{{- range $host := .Values.ingress.hosts }}
+  {{- range $host.paths }}
+  {{ $scheme }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- if not .Values.ingress.tls }}
+
+  ⚠️  SECURITY (H-1): this Ingress has NO TLS — the admin Bearer token and all
+      mutation traffic cross the network in CLEARTEXT. Add an ingress.tls block.
+{{- end }}
+{{- end }}
+
 Verifier API:
 {{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get svc {{ include "kirra.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}")

--- a/helm/kirra/templates/ingress.yaml
+++ b/helm/kirra/templates/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kirra.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- /*
+  H-1 / AOU-TRANSPORT-TLS-001: this Ingress is the supported way to terminate
+  TLS in front of the verifier. An Ingress WITHOUT a `tls:` block serves the
+  admin API (and its Bearer token) over plaintext at the edge, which defeats the
+  purpose — refuse to render in that case so a cleartext exposure can never ship
+  silently. Set kirra.allowInsecureTransport=true ONLY if TLS is terminated by
+  infrastructure outside this chart (an external L7 LB / service mesh mTLS).
+*/}}
+{{- if and (not .Values.ingress.tls) (not .Values.kirra.allowInsecureTransport) }}
+{{- fail "SECURITY (H-1 / AOU-TRANSPORT-TLS-001): ingress.enabled=true but ingress.tls is empty — the admin Bearer token and all mutation traffic would cross the network in CLEARTEXT. Provide an ingress.tls block, or set kirra.allowInsecureTransport=true to acknowledge that TLS is terminated by external infrastructure." }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "kirra.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/kirra/templates/service.yaml
+++ b/helm/kirra/templates/service.yaml
@@ -1,3 +1,20 @@
+{{- /*
+  H-1 / AOU-TRANSPORT-TLS-001 fail-closed transport guard.
+  The verifier API speaks PLAINTEXT HTTP — the admin Bearer token and every
+  state-mutating request are sent in cleartext. A LoadBalancer / NodePort Service
+  exposes that plaintext endpoint OUTSIDE the cluster. Refuse to render unless
+  either (a) a TLS-terminating Ingress is configured, or (b) the operator
+  explicitly acknowledges that TLS is handled by external infrastructure. The
+  default ClusterIP (cluster-internal) is unaffected, so existing in-cluster
+  installs are not impacted — only an actually-external, un-encrypted exposure is
+  blocked.
+*/}}
+{{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+{{- $hasIngressTls := and .Values.ingress.enabled .Values.ingress.tls }}
+{{- if and (not $hasIngressTls) (not .Values.kirra.allowInsecureTransport) }}
+{{- fail (printf "SECURITY (H-1 / AOU-TRANSPORT-TLS-001): service.type=%s exposes the verifier OUTSIDE the cluster but no TLS is configured — the admin Bearer token and all mutation traffic would cross the network in CLEARTEXT. Enable a TLS Ingress (ingress.enabled=true with ingress.tls), or set kirra.allowInsecureTransport=true to acknowledge that TLS is terminated by external infrastructure." .Values.service.type) }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/kirra/values.yaml
+++ b/helm/kirra/values.yaml
@@ -13,6 +13,34 @@ service:
   type: ClusterIP
   port: 8090
 
+# --- Transport security (H-1 / AOU-TRANSPORT-TLS-001) ------------------------
+# IMPORTANT: the verifier API speaks PLAINTEXT HTTP on `service.port`. The admin
+# Bearer token (KIRRA_ADMIN_TOKEN) and EVERY state-mutating request are therefore
+# sent in CLEARTEXT on the wire. The default ClusterIP keeps that traffic
+# cluster-internal; any exposure beyond a trusted, encrypted path MUST terminate
+# TLS in front of the service.
+#
+# This Ingress is the supported way to terminate TLS. The chart FAILS to render
+# (fail-closed) if the Service is exposed via LoadBalancer/NodePort, or this
+# Ingress is enabled, without a TLS config — set `kirra.allowInsecureTransport`
+# only if TLS is handled by external infrastructure (an L7 LB / mesh mTLS).
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: kirra.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  # TLS is REQUIRED for any real exposure. Leaving this empty with a
+  # LoadBalancer/NodePort Service or an enabled Ingress is refused at render time.
+  tls: []
+    # - secretName: kirra-tls
+    #   hosts:
+    #     - kirra.example.com
+
 persistence:
   enabled: true
   storageClass: ""
@@ -28,6 +56,13 @@ kirra:
 
   verifierMode: active        # active | passive_standby
   trustedIngressMode: false   # require x-kirra-client-id header on identity-gated routes
+
+  # H-1 / AOU-TRANSPORT-TLS-001 escape hatch. Leave false. Set true ONLY when TLS
+  # for the verifier API is terminated by infrastructure OUTSIDE this chart (an
+  # external L7 load balancer or a service mesh with mTLS). When false (default),
+  # the chart refuses to render an external (LoadBalancer/NodePort) Service or a
+  # non-TLS Ingress, so a cleartext admin endpoint can never ship by accident.
+  allowInsecureTransport: false
 
 resources:
   limits:


### PR DESCRIPTION
## Pen-test deployment fix — H-1 (TLS transport)

### The gap
The verifier HTTP API speaks **plaintext HTTP** (`KIRRA_VERIFIER_ADDR`, default `:8090`). Tier-2 routes authenticate with the static `KIRRA_ADMIN_TOKEN` Bearer token; Tier-1 add `x-kirra-client-id`. The in-process defenses (`constant_time_compare`, `require_admin_token`) are **comparison-side only** — they do **not** protect the token *on the wire*.

`helm/kirra` shipped **Service-only, no Ingress, no TLS, no warning**. Any non-loopback exposure sends the admin token and every mutation body (attestation registration, dependency edges, federation reports, supervisor reset) in cleartext to an on-path observer → **full unauthorized control of the governor's mutation surface**. The requirement was already noted in `docs/ros2_interlock.md` (*"use TLS in production to prevent token interception"*) but never **provided or enforced** in the deployment.

### The fix (deployment layer)
Per ADR-0006 Clause 3 (crypto/transport at the integration boundary, not the governor hot path), this terminates TLS in front of the process rather than adding in-process rustls:

- **`templates/ingress.yaml`** — opt-in TLS-terminating Ingress (canonical `networking.k8s.io/v1`: className / annotations / hosts / tls). **Refuses to render** (`fail`) if enabled without a `tls:` block.
- **`templates/service.yaml`** — **fail-closed guard**: a `LoadBalancer`/`NodePort` Service (external exposure) without a TLS Ingress is refused at render time. The default **`ClusterIP` (cluster-internal) is unaffected** — existing in-cluster installs are not impacted; only an actually-external cleartext exposure is blocked.
- **`kirra.allowInsecureTransport`** (default `false`) — explicit escape hatch for operators who terminate TLS via external infra (L7 LB / mesh mTLS).
- **`values.yaml`** `ingress` block + prominent cleartext warning; **`NOTES.txt`** prints the `https://` URL when TLS is configured and a ⚠️ warning when it isn't.
- **`docs/safety/ASSUMPTIONS_OF_USE.md`** — new **`AOU-TRANSPORT-TLS-001`** (index row + full SEooC entry: assumption, load-bearing rationale, status, consequence-if-violated, evidence).

### Design note — fail-closed by default, matching the repo ethos
Rather than ship a silent opt-in, the chart **refuses to render an external cleartext endpoint**. This is a (deliberate) behavior change *only* for insecure configs: `ClusterIP` default and any TLS-configured exposure render unchanged; a `LoadBalancer`/`NodePort` without TLS now fails with an actionable message until the operator adds TLS or sets `allowInsecureTransport=true`. If you'd prefer a warning-only posture, say so and I'll downgrade the guard.

### Honest scope / validation
- **helm is not installable in the build sandbox** (proxy returns 403), so the chart was validated **structurally** — balanced Go-template blocks/delimiters and the canonical `helm create` ingress shape — **not** via a live `helm lint` / `helm template`. I recommend adding a `helm lint` CI step (none exists today); happy to add it in a follow-up.
- The **duplicate `charts/kirra-verifier/` chart has the same gap** — left to the **H-6/M-8** "second un-hardened chart" finding rather than fixing it twice here.

No application code changed; no Rust build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_