### PR TITLE
Configure Cursor cloud Rust toolchain

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,23 @@
+FROM rust:1.96-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Cursor Cloud Agents use this image for repository work. Rust 1.96 provides an
+# edition-2024-aware Cargo, which is required by the locked getrandom v0.4.2
+# manifest. Keep native build tools here so `cargo test --locked` works without
+# per-agent rustup/toolchain setup.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    build-essential \
+    pkg-config \
+    clang \
+    libclang-dev \
+    cmake \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:${PATH}
+
+WORKDIR /workspace

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "cargo fetch --locked"
+}

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -5,6 +5,17 @@
 - Architecture: x86_64
 - QEMU: 8.2.2 installed (x86_64 + aarch64)
 
+## Cursor Cloud Agents
+- Repo-level environment config: `.cursor/environment.json`
+- Base image: `.cursor/Dockerfile`
+- Rust toolchain: `rust:1.96-bookworm`
+
+The locked dependency graph includes crates whose manifests require
+edition-2024-aware Cargo (for example `getrandom v0.4.2`). Cursor Cloud Agents
+therefore use the repo-level Dockerfile instead of relying on the platform
+default Rust/Cargo version. This lets plain `cargo test --locked` work without a
+per-agent `rustup toolchain install stable`.
+
 ## Cross-compilation Targets
 
 | Target | Status | Use |

--- a/deploy/docker/Dockerfile.native
+++ b/deploy/docker/Dockerfile.native
@@ -1,4 +1,4 @@
-FROM rust:1.80-slim-bookworm AS builder
+FROM rust:1.96-slim-bookworm AS builder
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add repo-level Cursor Cloud Agent environment config in `.cursor/environment.json`.
- Add `.cursor/Dockerfile` based on `rust:1.96-bookworm` so future agents start with an edition-2024-aware Cargo.
- Document the Cloud Agent Rust requirement in `ENVIRONMENT.md`.
- Update `deploy/docker/Dockerfile.native` from Rust 1.80 to Rust 1.96 so the native container builder is compatible with the current lockfile.

## Testing
- `python3 -m json.tool .cursor/environment.json`
- `cargo +stable metadata --locked --no-deps`

## Notes
- This is intended to avoid per-agent `rustup toolchain install stable` for `cargo test --locked`; Cursor should build/reuse the repo-level `.cursor` environment image.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

