### PR TITLE
Wire ROS2 control ingress to fast loop

### DIFF
--- a/crates/kirra-ros2-adapter/Cargo.toml
+++ b/crates/kirra-ros2-adapter/Cargo.toml
@@ -51,7 +51,7 @@ default = []
 # This feature pulls NO C++ / no cxx / no lanelet2 — that is the separate
 # `lanelet2` feature below (the perception governance path is independent of
 # the map/corridor layer). See README.
-ros2 = ["dep:tokio", "dep:r2r", "dep:tracing-subscriber", "dep:futures", "dep:reqwest", "dep:serde_json", "dep:bytes", "kirra-core/capture"]
+ros2 = ["dep:tokio", "dep:r2r", "dep:tracing-subscriber", "dep:futures", "dep:reqwest", "dep:bytes", "kirra-core/capture"]
 
 # Enable the real Lanelet2CorridorSource — a cxx/C++ wrap of `lanelet2_core`'s
 # boost::serialization deserializer (`fromBinMsg`). Implies `ros2` (the only
@@ -127,7 +127,9 @@ futures = { version = "0.3", optional = true }
 # activated transitively via the now-severed `kirra-verifier` reqwest dep
 # through Cargo feature unification.
 reqwest    = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"], optional = true }
-serde_json = { version = "1",    optional = true }
+# Untyped control-command parsing is intentionally pure/non-ROS-gated so the
+# B2 fast-loop ingress contract is unit-tested without a sourced ROS toolchain.
+serde_json = "1"
 bytes      = { version = "1",    optional = true }
 
 [build-dependencies]

--- a/crates/kirra-ros2-adapter/src/control_ingress.rs
+++ b/crates/kirra-ros2-adapter/src/control_ingress.rs
@@ -4,6 +4,8 @@
 // used by the ROS 2 adapter. Kept outside `node.rs` so the ingress contract is
 // unit-tested without requiring a sourced ROS 2/r2r toolchain.
 
+#![cfg_attr(not(feature = "ros2"), allow(dead_code))]
+
 use serde_json::Value;
 
 /// Control-command ingress payload (envelope over the untyped

--- a/crates/kirra-ros2-adapter/src/control_ingress.rs
+++ b/crates/kirra-ros2-adapter/src/control_ingress.rs
@@ -1,0 +1,142 @@
+// crates/kirra-ros2-adapter/src/control_ingress.rs
+//
+// Pure parser for the untyped `autoware_control_msgs/msg/Control` JSON shape
+// used by the ROS 2 adapter. Kept outside `node.rs` so the ingress contract is
+// unit-tested without requiring a sourced ROS 2/r2r toolchain.
+
+use serde_json::Value;
+
+/// Control-command ingress payload (envelope over the untyped
+/// `autoware_control_msgs::Control` JSON map). The fast-loop task converts
+/// this to `IncomingControl` for the conformance check.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IngressControlCommand {
+    pub asset_id: String,
+    pub linear_velocity_mps: f64,
+    pub steering_angle_rad: f64,
+    /// Wall-clock ms from the ROS message stamp, or the receipt timestamp when
+    /// the message carries no usable top-level stamp.
+    pub stamp_ms: u64,
+}
+
+/// Parse the minimal Autoware Control fields consumed by the fast-loop
+/// conformance gate:
+///
+/// - `longitudinal.velocity`
+/// - `lateral.steering_tire_angle`
+///
+/// The adapter publishes the same untyped field shape on `~/output/control_cmd`,
+/// so this parser closes the input/output schema loop. Missing, non-numeric, or
+/// non-finite fields are rejected by the caller, which emits an MRC-triggering
+/// command instead of passing the malformed input through.
+pub fn parse_control_command_json(
+    asset_id: &str,
+    msg: &Value,
+    received_ms: u64,
+) -> Result<IngressControlCommand, &'static str> {
+    let velocity = finite_f64_at(msg, &["longitudinal", "velocity"])
+        .ok_or("missing_or_nonfinite_longitudinal_velocity")?;
+    let steering = finite_f64_at(msg, &["lateral", "steering_tire_angle"])
+        .ok_or("missing_or_nonfinite_lateral_steering_tire_angle")?;
+    Ok(IngressControlCommand {
+        asset_id: asset_id.to_string(),
+        linear_velocity_mps: velocity,
+        steering_angle_rad: steering,
+        stamp_ms: stamp_ms_from_control(msg).unwrap_or(received_ms),
+    })
+}
+
+/// A finite command that the fast-loop conformance check must reject, causing
+/// publication of the configured MRC command. Used for malformed untyped input
+/// so parse failure fails closed instead of producing no gated output.
+pub fn fail_closed_control_command(asset_id: &str, received_ms: u64) -> IngressControlCommand {
+    IngressControlCommand {
+        asset_id: asset_id.to_string(),
+        linear_velocity_mps: f64::MAX,
+        steering_angle_rad: f64::MAX,
+        stamp_ms: received_ms,
+    }
+}
+
+fn finite_f64_at(msg: &Value, path: &[&str]) -> Option<f64> {
+    let mut cur = msg;
+    for key in path {
+        cur = cur.get(*key)?;
+    }
+    let v = cur.as_f64()?;
+    v.is_finite().then_some(v)
+}
+
+fn stamp_ms_from_control(msg: &Value) -> Option<u64> {
+    stamp_ms_from_value(msg.get("stamp")?)
+        .or_else(|| stamp_ms_from_value(msg.get("longitudinal")?.get("stamp")?))
+        .or_else(|| stamp_ms_from_value(msg.get("lateral")?.get("stamp")?))
+}
+
+fn stamp_ms_from_value(stamp: &Value) -> Option<u64> {
+    let sec = stamp.get("sec")?.as_i64()?;
+    if sec < 0 {
+        return None;
+    }
+    let nanosec = stamp.get("nanosec")?.as_u64()?;
+    if nanosec >= 1_000_000_000 {
+        return None;
+    }
+    Some((sec as u64) * 1_000 + nanosec / 1_000_000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_minimal_control_command() {
+        let msg = json!({
+            "stamp": { "sec": 12, "nanosec": 345_000_000_u64 },
+            "lateral": { "steering_tire_angle": 0.125 },
+            "longitudinal": { "velocity": 4.5 }
+        });
+
+        let parsed = parse_control_command_json("ego", &msg, 99).expect("parse control");
+
+        assert_eq!(parsed.asset_id, "ego");
+        assert_eq!(parsed.linear_velocity_mps, 4.5);
+        assert_eq!(parsed.steering_angle_rad, 0.125);
+        assert_eq!(parsed.stamp_ms, 12_345);
+    }
+
+    #[test]
+    fn falls_back_to_receipt_time_without_stamp() {
+        let msg = json!({
+            "lateral": { "steering_tire_angle": -0.25 },
+            "longitudinal": { "velocity": 1.0 }
+        });
+
+        let parsed = parse_control_command_json("ego", &msg, 77).expect("parse control");
+
+        assert_eq!(parsed.stamp_ms, 77);
+        assert_eq!(parsed.steering_angle_rad, -0.25);
+    }
+
+    #[test]
+    fn rejects_missing_required_fields() {
+        let msg = json!({
+            "lateral": { "steering_tire_angle": 0.0 },
+            "longitudinal": {}
+        });
+
+        assert!(parse_control_command_json("ego", &msg, 1).is_err());
+    }
+
+    #[test]
+    fn fail_closed_command_forces_rejection_with_finite_values() {
+        let cmd = fail_closed_control_command("ego", 42);
+
+        assert_eq!(cmd.asset_id, "ego");
+        assert!(cmd.linear_velocity_mps.is_finite());
+        assert!(cmd.steering_angle_rad.is_finite());
+        assert_eq!(cmd.linear_velocity_mps, f64::MAX);
+        assert_eq!(cmd.stamp_ms, 42);
+    }
+}

--- a/crates/kirra-ros2-adapter/src/lib.rs
+++ b/crates/kirra-ros2-adapter/src/lib.rs
@@ -23,6 +23,7 @@
 #![allow(clippy::doc_lazy_continuation)]
 
 pub mod config;
+mod control_ingress;
 pub mod corridor;
 pub mod geometry;
 pub mod state;

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -38,6 +38,8 @@ use std::time::Duration;
 
 use tokio::sync::mpsc;
 
+pub use crate::control_ingress::IngressControlCommand;
+use crate::control_ingress::{fail_closed_control_command, parse_control_command_json};
 use crate::corridor::CorridorSource;
 use crate::state::{
     AdaptorState, TrajectoryPoint, TrajectoryVerdict,
@@ -171,18 +173,6 @@ pub struct IngressTrajectory {
     pub points: Vec<TrajectoryPoint>,
 }
 
-/// Control-command ingress payload (envelope over the typed
-/// `autoware_control_msgs::Control` map). The fast-loop task converts
-/// this to `IncomingControl` for the conformance check.
-#[derive(Debug, Clone)]
-pub struct IngressControlCommand {
-    pub asset_id: String,
-    pub linear_velocity_mps: f64,
-    pub steering_angle_rad: f64,
-    /// Wall-clock ms when the command was received.
-    pub stamp_ms: u64,
-}
-
 /// Outgoing control command — the gated command (pass-through on
 /// Accept, MRC on Reject/no-trajectory). Published on `~/output/control_cmd`
 /// as an UNTYPED `autoware_control_msgs/msg/Control` (mirroring the untyped
@@ -290,9 +280,9 @@ pub async fn run_adapter(
     // task hands to `crate::parsing::*` for the kernel-shape conversion.
     //
     // Map + control_cmd remain untyped (the map is a one-shot binary
-    // blob handed to lanelet2_bridge; the control command's parser is
-    // Phase 5+ scope and is currently logged-only via the
-    // `IngressControlCommand` channel).
+    // blob handed to lanelet2_bridge; the control command uses the pure
+    // JSON parser in `control_ingress` so the fast-loop conformance gate
+    // stays ROS-message-codegen neutral).
     let traj_stream = node.subscribe::<r2r::autoware_planning_msgs::msg::Trajectory>(
         "~/input/trajectory",
         ingress_sensor_qos(), // N1: KeepLast(1) + BestEffort — no stale backlog after a stall
@@ -323,7 +313,7 @@ pub async fn run_adapter(
         "~/input/odometry",
         ingress_sensor_qos(), // N1
     )?;
-    let _ctrl_sub = node.subscribe_untyped(
+    let ctrl_stream = node.subscribe_untyped(
         "~/input/control_cmd",
         "autoware_control_msgs/msg/Control",
         ingress_sensor_qos(), // N1: control feedback is also a high-rate fresh-only stream
@@ -358,6 +348,7 @@ pub async fn run_adapter(
     //                        `trajectory_id`).
     //        - Objects     → `state.update_objects(...)` write-replace.
     //        - Odometry    → `state.update_odom(...)` write-replace.
+    //        - Control     → control_tx channel for the fast-loop gate.
     use futures::StreamExt;
 
     // Per-node asset id. Phase 4c is single-asset (one Governor instance
@@ -410,6 +401,58 @@ pub async fn run_adapter(
             }
         }
         tracing::error!("trajectory subscription stream closed — staleness will fire fleet-wide");
+    });
+
+    let ctrl_tx_clone = control_tx.clone();
+    tokio::spawn(async move {
+        let mut s = ctrl_stream;
+        while let Some(item) = s.next().await {
+            let received_fresh_ms = now_ms_fresh();
+            let received_wall_ms = wall_clock_ms();
+            tracing::info!(
+                target: "kirra::ingress",
+                topic = "control_cmd",
+                stamp_ms = received_fresh_ms,
+                "subscription_callback"
+            );
+
+            let envelope = match item {
+                Ok(msg) => match parse_control_command_json(asset_id_str, &msg, received_wall_ms) {
+                    Ok(cmd) => cmd,
+                    Err(reason) => {
+                        tracing::warn!(
+                            reason = reason,
+                            "control_cmd malformed — forwarding fail-closed command to fast loop"
+                        );
+                        fail_closed_control_command(asset_id_str, received_wall_ms)
+                    }
+                },
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "control_cmd untyped decode failed — forwarding fail-closed command to fast loop"
+                    );
+                    fail_closed_control_command(asset_id_str, received_wall_ms)
+                }
+            };
+
+            match ctrl_tx_clone.try_send(envelope) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    tracing::warn!(
+                        "control channel FULL — dropping command (fast loop is behind; \
+                         staleness will collapse the next read to MRC)"
+                    );
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    tracing::error!(
+                        "control channel CLOSED — fast loop is gone; adapter must restart"
+                    );
+                    return;
+                }
+            }
+        }
+        tracing::error!("control_cmd subscription stream closed — fast loop will stop receiving commands");
     });
 
     let obj_state = Arc::clone(&state);
@@ -861,9 +904,9 @@ pub async fn run_adapter(
         }
     });
 
-    // ----- Drop-on-full helpers (used by the subscription callbacks
-    //       once Phase 2 fills them in). Kept here so Phase 1 fixes the
-    //       drop-on-full policy in one place.
+    // ----- Drop-on-full helpers (legacy local helpers kept for tests /
+    //       future refactors). The live trajectory and control drains above
+    //       enforce this same bounded, never-blocking policy inline.
     #[allow(dead_code)]
     fn try_publish_trajectory(tx: &mpsc::Sender<IngressTrajectory>, item: IngressTrajectory) {
         match tx.try_send(item) {
@@ -901,10 +944,8 @@ pub async fn run_adapter(
         }
     }
 
-    // The trajectory_tx / control_tx senders are kept alive by the
-    // subscription callbacks once Phase 2 wires the typed deserializers
-    // in. For Phase 1 the senders just need to outlive their channel
-    // halves so the tasks above don't see Closed immediately.
+    // The drain tasks own clones. Keep the original senders bound so the
+    // compiler makes lifetime/ownership explicit at the end of setup.
     let _ = (trajectory_tx, control_tx);
 
     // ----- Spin loop ----------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a pure parser for the untyped `autoware_control_msgs/msg/Control` JSON shape used by the ROS 2 adapter.
- Drain `~/input/control_cmd` and forward parsed commands into the fast-loop `control_tx` channel.
- Convert malformed or undecodable control messages into finite fail-closed commands that force the fast loop to publish MRC.
- Preserve the existing public `node::IngressControlCommand` path via re-export.

## Testing
- `cargo +stable test --locked -p kirra-ros2-adapter --no-default-features` (45 passed)
- `rustfmt --edition 2021 --check crates/kirra-ros2-adapter/src/control_ingress.rs`

## Notes
- A package-wide `cargo fmt --check --package kirra-ros2-adapter` currently reports pre-existing formatting differences in unrelated adapter files; this branch keeps formatting scoped to the new parser file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

