### PR TITLE
Use constant-time clearance nonce comparison

### DIFF
--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
+use crate::security::constant_time_compare;
 use crate::verifier_store::VerifierStore;
 
 /// Maximum recursion depth for dependency graph traversal.
@@ -658,7 +659,7 @@ impl AppState {
         if now_ms > entry.expires_at_ms {
             return false;
         }
-        entry.nonce_hex == nonce_hex
+        constant_time_compare(entry.nonce_hex.as_bytes(), nonce_hex.as_bytes())
     }
 }
 
@@ -844,6 +845,65 @@ mod nonce_lifecycle_tests {
         app.issue_challenge("fresh", 2, later);
         assert!(!app.pending_challenges.contains_key("stale"), "expired entry pruned on issue");
         assert!(app.pending_challenges.contains_key("fresh"), "fresh entry retained");
+    }
+
+    #[test]
+    fn clearance_nonce_exact_match_is_accepted_once() {
+        let app = app();
+        let key = "alice|robot-01";
+        app.issue_clearance_challenge(key, "abcdef0123456789".to_string(), 1_000);
+
+        assert!(
+            app.consume_clearance_challenge(key, "abcdef0123456789", 1_100),
+            "exact clearance nonce must be accepted"
+        );
+        assert!(
+            !app.consume_clearance_challenge(key, "abcdef0123456789", 1_100),
+            "clearance nonce must be single-use"
+        );
+    }
+
+    #[test]
+    fn clearance_nonce_mismatch_is_rejected_and_consumed() {
+        let app = app();
+        let key = "alice|robot-01";
+        app.issue_clearance_challenge(key, "abcdef0123456789".to_string(), 1_000);
+
+        assert!(
+            !app.consume_clearance_challenge(key, "abcdef0123456788", 1_100),
+            "mismatched clearance nonce must be rejected"
+        );
+        assert!(
+            !app.consume_clearance_challenge(key, "abcdef0123456789", 1_100),
+            "a rejected clearance nonce attempt must still burn the challenge"
+        );
+    }
+
+    #[test]
+    fn expired_clearance_nonce_is_rejected() {
+        let app = app();
+        let key = "alice|robot-01";
+        app.issue_clearance_challenge(key, "abcdef0123456789".to_string(), 1_000);
+
+        assert!(
+            !app.consume_clearance_challenge(key, "abcdef0123456789", 1_000 + CHALLENGE_TTL_MS + 1),
+            "expired clearance nonce must be rejected"
+        );
+    }
+
+    #[test]
+    fn long_clearance_nonces_sharing_prefix_are_distinguished() {
+        let app = app();
+        let key = "alice|robot-01";
+        let prefix = "a".repeat(64);
+        let stored = format!("{prefix}1111111111111111");
+        let provided = format!("{prefix}2222222222222222");
+        app.issue_clearance_challenge(key, stored, 1_000);
+
+        assert!(
+            !app.consume_clearance_challenge(key, &provided, 1_100),
+            "clearance nonce comparison must distinguish bytes beyond a 64-byte shared prefix"
+        );
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace operator clearance nonce string equality with `constant_time_compare`.
- Preserve existing verify-then-consume semantics: absent, expired, or mismatched attempts reject and consume the pending entry once removed.
- Add clearance nonce lifecycle tests for exact match, replay, mismatch burn, expiry, and long shared-prefix mismatch.

## Testing
- `cargo +stable test --locked -p kirra-verifier --lib nonce_lifecycle_tests` (9 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

