### PR TITLE
Make verifier audit/clearance sink opt-in for parko-kirra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,9 @@ proptest = "1"
 # per-connection, so tampering a row written by one connection from a second
 # connection (the audit-chain tamper scenario, SG-010) requires an on-disk file.
 tempfile = "3"
-parko-kirra = { path = "parko/crates/parko-kirra" }
+# R5: the demo-seed test exercises parko-kirra's `VerifierStore`-backed clearance
+# delivery, so it needs the opt-in `verifier-sink` feature.
+parko-kirra = { path = "parko/crates/parko-kirra", features = ["verifier-sink"] }
 # `test-util` enables `#[tokio::test(start_paused = true)]` + `tokio::time::advance`
 # for deterministic time-driven tests (telemetry_watchdog DI seam, S3 / #115).
 # Test-only feature stacked onto the production tokio dependency above; release

--- a/parko/crates/parko-kirra/Cargo.toml
+++ b/parko/crates/parko-kirra/Cargo.toml
@@ -12,20 +12,42 @@ parko-core = { path = "../parko-core" }
 # The lean foundation (de-monolith Stage 5): the kinematics-contract talisman,
 # FleetPosture, and the shared `all_finite` governor guard — serde-only, no heavy tree.
 kirra-core = { path = "../../../crates/kirra-core" }
-# Kept for the SQLite `VerifierStore` durable audit/clearance sink (heavy, verifier-tier;
-# see audit_sink / clearance_delivery) — not on the governor hot path.
-kirra-verifier = { path = "../../.." }
-# CERT-006 durable divergence sink: serialise DivergenceEvent → JSON and persist
-# it through the SDK's hash-chained, signed audit log (VerifierStore).
+# R5: the heavy SQLite `VerifierStore` durable audit/clearance sink is now OPT-IN
+# behind the `verifier-sink` feature (default OFF) — the governor/comparator core
+# builds on `kirra-core` alone, so a consumer wanting just the diverse-governor +
+# divergence comparator no longer pulls the verifier service tree. The parko-ros2
+# integration node enables `verifier-sink`. (audit_sink / clearance_delivery.)
+kirra-verifier = { path = "../../..", optional = true }
+# DivergenceEvent serialisation (always-on: the comparator emits it regardless of
+# whether a durable sink is wired).
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# `AuditChainLinkerDivergenceSink::open` parses a base64-encoded Ed25519 signing
-# key (KIRRA_LOG_SIGNING_KEY) in non-test code, so these are regular deps.
-ed25519-dalek = { version = "2" }
-base64 = "0.22"
+# Ed25519 signing-key parsing for the durable sinks (`KIRRA_LOG_SIGNING_KEY`) —
+# only used by the `verifier-sink` modules, so gated with the feature.
+ed25519-dalek = { version = "2", optional = true }
+base64 = { version = "0.22", optional = true }
+
+[features]
+default = []
+# R5: durable audit + clearance sinks backed by the SDK SQLite `VerifierStore`
+# (hash-chained, signed ledger). OFF by default so the parko ML core stays lean;
+# enabled by the parko-ros2 integration node and any deployment that persists
+# divergence/clearance. Not on the governor hot path.
+verifier-sink = ["dep:kirra-verifier", "dep:ed25519-dalek", "dep:base64"]
 
 [dev-dependencies]
 proptest = "1"
 # Durability + signing test for AuditChainLinkerDivergenceSink: a file-backed
 # SQLite audit chain.
 tempfile = "3"
+
+# R5: the clearance/audit example + integration test exercise the
+# `VerifierStore`-backed path, so they only build when `verifier-sink` is enabled.
+# Without the feature the default `cargo build/test -p parko-kirra` stays lean.
+[[example]]
+name = "deliver_clearance"
+required-features = ["verifier-sink"]
+
+[[test]]
+name = "clearance_e2e_integration"
+required-features = ["verifier-sink"]

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -64,13 +64,19 @@ use parko_core::{
 };
 
 pub mod angular_bound;
+// R5: the verifier-backed durable sinks are opt-in (feature `verifier-sink`); the
+// governor/comparator core below depends only on `kirra-core`.
+#[cfg(feature = "verifier-sink")]
 pub mod audit_sink;
+#[cfg(feature = "verifier-sink")]
 pub mod clearance_delivery;
 pub mod comparator;
 pub mod diverse;
 pub mod platform;
 pub use angular_bound::{AngularVelocityBound, PlatformParams, ROLLOVER_MIN_LINEAR_VELOCITY_MPS};
+#[cfg(feature = "verifier-sink")]
 pub use clearance_delivery::{ClearanceDelivery, DeliveryOutcome};
+#[cfg(feature = "verifier-sink")]
 pub use audit_sink::{
     select_divergence_sink, select_impact_sink, AuditChainLinkerDivergenceSink, FatalAuditConfig,
     ImpactAuditSink, ImpactClearanceRejectedPayload, ImpactClearedPayload, ImpactDetectedPayload,

--- a/parko/crates/parko-ros2/Cargo.toml
+++ b/parko/crates/parko-ros2/Cargo.toml
@@ -61,7 +61,7 @@ parko-core  = { path = "../parko-core" }
 # The dual-governor comparator that gates every command leaving the
 # loop. This is the safety bridge: Parko produces commands, parko-kirra
 # governs them, KirraGovernor enforces the same envelopes Occy uses.
-parko-kirra = { path = "../parko-kirra" }
+parko-kirra = { path = "../parko-kirra", features = ["verifier-sink"] }
 # The lean foundation (de-monolith Stage 5): FleetPosture + the shared PostureTracker
 # state machine the node reads posture through — serde-only, no heavy tree.
 kirra-core = { path = "../../../crates/kirra-core" }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Refactor R5 from the engineering review: stop forcing the heavy `kirra-verifier` service tree into the parko ML core build. `parko-kirra` previously declared `kirra-verifier` as a hard dependency solely for the durable audit (`audit_sink`) and clearance (`clearance_delivery`) sinks — which are off the governor hot path.

### parko-kirra
- `kirra-verifier` (and the sink-only `ed25519-dalek` / `base64`) are now **optional**, gated behind a new `verifier-sink` feature (default OFF).
- `audit_sink` and `clearance_delivery` modules + their re-exports are `#[cfg(feature = "verifier-sink")]`.
- The clearance example + the `clearance_e2e_integration` test are gated via `required-features` in the manifest.
- The governor / comparator / diverse-governor core continues to build on `kirra-core` alone.

### Consumers
- `parko-ros2` (the integration node) enables `parko-kirra/verifier-sink`.
- The root `kirra-verifier` dev-dependency on `parko-kirra` (used by the `kirra_console_demo_seed` test) enables the feature.

### Result
`cargo build/test -p parko-kirra` (default) no longer compiles `kirra-verifier`/`rusqlite`/`axum` — verified: the default build compiles only `parko-core` + `parko-kirra`. A downstream consumer that wants just the diverse governor + divergence comparator now gets a lean dependency graph; the verifier-backed persistence is explicit opt-in.

## Testing
- `cargo build -p parko-kirra` (default) → compiles **without** kirra-verifier (lean) ✓
- `cargo test -p parko-kirra` (default) → 134 + 3 passed
- `cargo test -p parko-kirra --features verifier-sink` → 161 + 3 + clearance E2E passed
- `cargo build -p parko-ros2` (enables the feature) → builds
- `cargo test -p kirra-verifier --bin kirra_console_demo_seed` → 4 passed (root consumer)
- `cargo clippy -p parko-kirra --features verifier-sink -- -D warnings` clean

## Scope note
This makes the verifier coupling **opt-in** for `parko-kirra` (the core ML adapter), which is the highest-value, lowest-risk slice of R5. Fully removing `kirra-verifier` from the parko **`--workspace`** test lane would additionally require feature-gating `parko-ros2`'s clearance/audit wiring (its `NodeClearance`/`from_store` name verifier types) — a larger, ROS-feature-entangled change deferred as follow-up, since Cargo feature unification means the workspace build still compiles it via the parko-ros2 integration node.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

