### PR TITLE
Reset recovery streak on watchdog timeout

### DIFF
--- a/src/telemetry_watchdog.rs
+++ b/src/telemetry_watchdog.rs
@@ -394,6 +394,17 @@ fn watchdog_sweep_once_inner(
                     "Watchdog: sensor node silent beyond timeout — marking Untrusted"
                 );
 
+                // Q4: a timed-out node must earn a FULL recovery-streak window
+                // again before it can be re-trusted — otherwise a node that had
+                // accumulated (threshold - 1) healthy reports before going silent
+                // would re-trust on its very first report after recovery, bypassing
+                // the hysteresis. Disk-first (store write before the trust mutation
+                // below), and `*_preserving_telemetry` so the timeout does NOT
+                // fabricate a fresh `last_telemetry_ms` (no report actually arrived).
+                let _ = app
+                    .store
+                    .with(|store| store.reset_recovery_streak_preserving_telemetry(&entry.node_id));
+
                 match app.mark_node_untrusted(&entry.node_id, "TELEMETRY_TIMEOUT", now) {
                     Ok(true) => {
                         let trigger = PostureRecalcTrigger::WatchdogTimeout {
@@ -932,6 +943,64 @@ mod watchdog_di_tests {
             }
             other => panic!("expected WatchdogTimeout, got {other:?}"),
         }
+    }
+
+    /// Q4 regression: a watchdog timeout must RESET the node's recovery streak
+    /// (so a node that had accumulated nearly a full streak before going silent
+    /// cannot re-trust on its first post-recovery report), WITHOUT fabricating a
+    /// fresh `last_telemetry_ms` (no report arrived).
+    #[test]
+    fn test_watchdog_timeout_resets_recovery_streak_preserving_telemetry_q4() {
+        let anchor: u64 = 12_000_000;
+        let now = anchor + AV_TELEMETRY_TIMEOUT_MS + 250;
+        let clock = VirtualClock::starting_at(now);
+
+        let store = VerifierStore::new(":memory:").expect("memory store");
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+        // Register the AV row (last_telemetry_ms = anchor) and drive the recovery
+        // streak up to threshold-1 = 4 (each increment re-stamps last_telemetry_ms
+        // to `anchor`, the same value).
+        app.store.with(|s| {
+            s.register_av_subsystem_meta("lidar_front", "Perception", "LDR-1", 0.70, anchor)
+                .expect("register av meta");
+            for _ in 0..(crate::recovery_hysteresis::AV_RECOVERY_STREAK_THRESHOLD - 1) {
+                s.increment_recovery_streak("lidar_front", anchor)
+                    .expect("increment streak");
+            }
+        });
+        assert_eq!(
+            app.store.with(|s| s.load_recovery_streak("lidar_front").unwrap()).0,
+            crate::recovery_hysteresis::AV_RECOVERY_STREAK_THRESHOLD - 1,
+            "precondition: streak is threshold-1"
+        );
+        insert_trusted_node(&app, "lidar_front", anchor);
+
+        let (tx, _rx) = mpsc::channel::<PostureRecalcTrigger>(128);
+        let mut node_health = prepopulated_node_health("lidar_front", anchor);
+        let mut last_node_refresh_ms: u64 = now;
+
+        watchdog_sweep_once(
+            &app,
+            &tx,
+            clock.as_ref(),
+            &mut node_health,
+            &mut last_node_refresh_ms,
+        );
+
+        // Node is untrusted, streak is cleared, and the telemetry timestamp is
+        // PRESERVED (the timeout did not invent a fresh last-seen).
+        assert_eq!(
+            app.nodes.get("lidar_front").unwrap().status,
+            NodeTrustState::Untrusted("TELEMETRY_TIMEOUT".to_string()),
+        );
+        let (count, start) = app.store.with(|s| s.load_recovery_streak("lidar_front").unwrap());
+        assert_eq!(count, 0, "watchdog timeout must reset the recovery streak");
+        assert_eq!(start, 0, "watchdog timeout must clear the streak-start stamp");
+        assert_eq!(
+            app.store.with(|s| s.get_last_telemetry_timestamp("lidar_front").unwrap()),
+            anchor,
+            "watchdog timeout must NOT fabricate a fresh last_telemetry_ms"
+        );
     }
 
     /// B4 regression (transient): a FULL posture-engine channel after a watchdog

--- a/src/verifier_store/av_subsystem.rs
+++ b/src/verifier_store/av_subsystem.rs
@@ -105,6 +105,26 @@ impl VerifierStore {
         Ok(())
     }
 
+    /// Reset the recovery streak WITHOUT touching `last_telemetry_ms` (Q4).
+    ///
+    /// The sibling `reset_recovery_streak` stamps `last_telemetry_ms = now`
+    /// because its callers reset on the RECEIPT of a (fault) report — the report
+    /// genuinely arrived "now". The telemetry watchdog is the opposite case: a
+    /// node went SILENT past the timeout, so NO report arrived. Resetting the
+    /// streak there must NOT fabricate a fresh "last seen" (which would reset the
+    /// watchdog's own silence detection). This variant clears only the streak
+    /// counters so a timed-out node must earn a full `AV_RECOVERY_STREAK_THRESHOLD`
+    /// window again before it can be re-trusted.
+    pub fn reset_recovery_streak_preserving_telemetry(&self, node_id: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE av_subsystem_meta
+             SET recovery_streak_count = 0, recovery_streak_start_ms = 0
+             WHERE node_id = ?1",
+            params![node_id],
+        )?;
+        Ok(())
+    }
+
     pub fn increment_recovery_streak(&self, node_id: &str, now_ms: u64) -> Result<u32> {
         self.conn.execute(
             "UPDATE av_subsystem_meta

--- a/src/verifier_store/tests.rs
+++ b/src/verifier_store/tests.rs
@@ -90,6 +90,30 @@ mod attestation_registry_tests {
         assert_eq!(start, 0);
     }
 
+    // Q4: the watchdog timeout path resets the streak WITHOUT stamping a fresh
+    // last_telemetry_ms (no report arrived). Streak clears; telemetry timestamp
+    // is preserved (unlike `reset_recovery_streak`, which sets it to `now`).
+    #[test]
+    fn test_reset_recovery_streak_preserving_telemetry() {
+        let store = in_memory();
+        store.register_av_subsystem_meta("lidar", "Perception", "LDR-1", 0.70, 5_000).unwrap();
+        store.increment_recovery_streak("lidar", 5_000).unwrap();
+        store.increment_recovery_streak("lidar", 5_000).unwrap();
+        assert_eq!(store.load_recovery_streak("lidar").unwrap().0, 2);
+        assert_eq!(store.get_last_telemetry_timestamp("lidar").unwrap(), 5_000);
+
+        store.reset_recovery_streak_preserving_telemetry("lidar").unwrap();
+
+        let (count, start) = store.load_recovery_streak("lidar").unwrap();
+        assert_eq!(count, 0, "streak must be cleared");
+        assert_eq!(start, 0, "streak start must be cleared");
+        assert_eq!(
+            store.get_last_telemetry_timestamp("lidar").unwrap(),
+            5_000,
+            "last_telemetry_ms must be PRESERVED — the timeout must not fabricate a fresh last-seen"
+        );
+    }
+
     #[test]
     fn test_generation_persistence() {
         let store = in_memory();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Quick-win Q4 (the last open item in the Quick Wins tier). The telemetry watchdog marks a silent node `Untrusted("TELEMETRY_TIMEOUT")` but previously left its AV recovery streak intact. A node that had accumulated `AV_RECOVERY_STREAK_THRESHOLD - 1` (4) consecutive healthy reports before going silent could therefore re-trust on its **first** healthy report after recovery — bypassing the hysteresis window the streak exists to enforce.

This resets the recovery streak on the watchdog timeout path, disk-first, so a timed-out node must earn a full fresh streak window again before it can be re-trusted.

### Changes
- New `VerifierStore::reset_recovery_streak_preserving_telemetry(node_id)`: clears the streak counters **without** touching `last_telemetry_ms`. (The existing `reset_recovery_streak` stamps `last_telemetry_ms = now` because its callers reset on the *receipt* of a fault report; the watchdog timeout is the opposite — no report arrived — so it must not fabricate a fresh "last seen", which would also reset the watchdog's own silence detection.)
- `telemetry_watchdog`: on a fresh timeout (inside the `already_timed_out` guard), reset the streak via the preserving variant **before** the disk-first `mark_node_untrusted`.

## Testing
- `cargo +stable test --locked -p kirra-verifier --lib telemetry_watchdog` (20 passed, incl. new `test_watchdog_timeout_resets_recovery_streak_preserving_telemetry_q4`)
- `cargo +stable test --locked -p kirra-verifier --lib reset_recovery_streak_preserving` (store-level: streak cleared, `last_telemetry_ms` preserved)
- `cargo +stable clippy -p kirra-verifier -- -D warnings` clean

## Notes
- The reset sits inside the existing `!already_timed_out` short-circuit, so sustained silence does not re-reset every 100 ms sweep.
- This completes Q1–Q5: Q1 #638, Q2 #636, Q3 #639/#645, Q5 #641 (all merged), Q4 here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

