### PR TITLE
Fail closed on poisoned perception cache

### DIFF
--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -569,7 +569,29 @@ pub async fn run_adapter(
         let mut rx = trajectory_rx;
         while let Some(traj) = rx.recv().await {
             let start = std::time::Instant::now();
-            let objects = slow_state.snapshot_objects();
+            // M7 (fail-closed): a POISONED objects cache returns `None`. Do NOT
+            // validate against a phantom-empty object set (RSS would see no
+            // obstacles and could pass an unsafe trajectory). Install an
+            // MRCFallback verdict — which removes the accepted slot, so the fast
+            // loop publishes MRC — and skip this candidate.
+            let objects = match slow_state.snapshot_objects() {
+                Some(o) => o,
+                None => {
+                    tracing::error!(
+                        asset_id = %traj.asset_id,
+                        trajectory_id = traj.trajectory_id,
+                        "objects_cache POISONED — slow loop failing closed to MRCFallback"
+                    );
+                    slow_state.update_trajectory(
+                        traj.asset_id.clone(),
+                        traj.trajectory_id,
+                        traj.points.clone(),
+                        TrajectoryVerdict::MRCFallback,
+                        now_ms_fresh(),
+                    );
+                    continue;
+                }
+            };
             let odom = slow_state.snapshot_odom();
             let posture = slow_state.current_posture();
 

--- a/crates/kirra-ros2-adapter/src/state.rs
+++ b/crates/kirra-ros2-adapter/src/state.rs
@@ -389,10 +389,6 @@ impl AdaptorState {
         if let Ok(mut guard) = self.objects_cache.write() {
             *guard = objects;
         } else {
-            // RwLock poisoning is fail-closed-by-extension: a poisoned
-            // cache reads as an empty Vec next cycle (no objects → RSS is
-            // trivially safe, but containment + posture cache failures
-            // catch the bigger picture). Log loudly.
             tracing::error!(
                 "objects_cache RwLock POISONED — perception snapshot dropped"
             );
@@ -402,11 +398,26 @@ impl AdaptorState {
     /// Read-and-clone of the latest perception snapshot. The slow loop
     /// uses this exactly once per validation; never holds the lock
     /// across the computation.
-    pub fn snapshot_objects(&self) -> Vec<PerceivedObject> {
-        self.objects_cache
-            .read()
-            .map(|g| g.clone())
-            .unwrap_or_default()
+    ///
+    /// M7 (fail-closed): returns `None` when the lock is POISONED. An empty
+    /// `Some(vec![])` means "genuinely no objects" (RSS trivially clear is then
+    /// correct); a POISONED cache is NOT that — the object set is unknown, and
+    /// returning an empty Vec there would make RSS see no obstacles and pass an
+    /// unsafe trajectory (fail-OPEN). The caller MUST treat `None` as a
+    /// fail-closed MRC, never as "no objects". (Contrast `snapshot_objects_secondary`,
+    /// where a silent/empty channel B is already handled fail-closed by the
+    /// redundancy monitor's lost-channel → MRC-floor cap.)
+    pub fn snapshot_objects(&self) -> Option<Vec<PerceivedObject>> {
+        match self.objects_cache.read() {
+            Ok(guard) => Some(guard.clone()),
+            Err(_) => {
+                tracing::error!(
+                    "objects_cache RwLock POISONED — failing slow loop closed (MRC); \
+                     refusing to validate against a phantom-empty object set"
+                );
+                None
+            }
+        }
     }
 
     /// Replace the SECONDARY (redundant channel-B) perception snapshot and stamp its arrival at
@@ -587,7 +598,40 @@ mod tests {
         assert_eq!(got[0].id, 5);
         assert_eq!(state.last_objects_b_ms.load(Ordering::Relaxed), 7_000, "B arrival stamped");
         // The primary channel is untouched by a secondary write.
-        assert!(state.snapshot_objects().is_empty(), "channel A independent of channel B");
+        assert!(
+            state.snapshot_objects().expect("readable").is_empty(),
+            "channel A independent of channel B"
+        );
+    }
+
+    /// M7 (fail-closed): a POISONED primary objects cache must read as `None`
+    /// (→ the slow loop MRCs), NOT an empty Vec (which would make RSS see no
+    /// obstacles and pass an unsafe trajectory — fail-open). A non-poisoned
+    /// empty cache stays `Some(vec![])`.
+    #[test]
+    fn poisoned_objects_cache_snapshots_none_not_empty() {
+        use std::sync::Arc;
+
+        let state = Arc::new(AdaptorState::new());
+        // Healthy empty cache → Some(empty), distinct from the poisoned case.
+        assert_eq!(
+            state.snapshot_objects().map(|v| v.len()),
+            Some(0),
+            "a healthy empty cache must be Some(empty), not None"
+        );
+
+        // Poison the primary objects RwLock: panic while holding the write guard.
+        let poison = Arc::clone(&state);
+        let _ = std::thread::spawn(move || {
+            let _guard = poison.objects_cache.write().expect("acquire write before poison");
+            panic!("intentional poison for M7 fail-closed test");
+        })
+        .join();
+
+        assert!(
+            state.snapshot_objects().is_none(),
+            "a POISONED objects cache must snapshot None (fail-closed → MRC), never an empty Vec"
+        );
     }
 
     /// The per-object yaw-rate channel round-trips and stamps freshness, independent of the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Medium-term item M7 (the original B6 finding — the one fail-open path in the M-tier). `AdaptorState::snapshot_objects` returned an **empty Vec** when the `objects_cache` RwLock was poisoned. An empty object set makes the RSS collision check trivially safe, so a poisoned perception cache could let the checker pass an unsafe trajectory (it would see *no obstacles*).

### Change
- `snapshot_objects` now returns `Option<Vec<PerceivedObject>>`:
  - `Some(vec![])` = genuinely no objects (RSS-clear is correct).
  - `None` = **poisoned / unreadable** — the object set is unknown.
- The ROS 2 slow loop treats `None` as fail-closed: it installs an `MRCFallback` verdict (which removes the accepted slot, so the fast loop publishes MRC) and skips the candidate — it never validates against a phantom-empty object set.

The sibling snapshots (odom / frame / channel-B / yaw) already drop-and-log on poison; the difference is that an empty *primary object list* is specifically unsafe for RSS, so it needs the explicit MRC rather than a silent empty.

## Testing
- `cargo +stable test --locked -p kirra-ros2-adapter --no-default-features` (35 + suites passed)
- New `state::tests::poisoned_objects_cache_snapshots_none_not_empty`: a healthy empty cache → `Some(empty)`; a poisoned cache (panic while holding the write guard) → `None`.
- `cargo +stable clippy -p kirra-ros2-adapter --no-default-features -- -D warnings` clean.

## Notes
- The slow-loop wiring lives in the `ros2`-gated `node.rs` (can't be compiled without a ROS toolchain here); it's covered by CI's `ros2-adapter-build` job. The fail-closed contract itself (the `None`-on-poison behavior) is fully unit-tested in the default build via `state.rs`.
- Only callers of `snapshot_objects` are `node.rs` (slow loop) and the `state.rs` tests — no external consumers, so the signature change is contained.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

