### PR TITLE
Compute fleet posture with one shared memo

### DIFF
--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -19,7 +19,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt as _;
 
 use kirra_verifier::verifier::{
-    validate_client_identity_headers, AppState, BackupExport, FlapStatus, FleetNodePosture,
+    validate_client_identity_headers, AppState, BackupExport, FlapStatus,
     FleetPosture, HealthResponse, NodeTrustState, PostureStreamEvent, RegisteredNode, VerifierOperationMode,
 };
 use kirra_verifier::verifier_store::{DurableWriteError, VerifierStore};

--- a/src/bin/kirra_verifier_service/fleet.rs
+++ b/src/bin/kirra_verifier_service/fleet.rs
@@ -62,10 +62,10 @@ pub(crate) async fn export_backup(State(svc): State<Arc<ServiceState>>) -> impl 
 }
 
 pub(crate) async fn get_fleet_posture(State(svc): State<Arc<ServiceState>>) -> impl IntoResponse {
-    let postures: Vec<FleetNodePosture> = svc.app.nodes
-        .iter()
-        .map(|entry| svc.app.calculate_posture(entry.key()))
-        .collect();
+    // M2: one shared-memo whole-fleet pass (O(N+E)) instead of O(N·(N+E))
+    // per-node recomputation, and no `nodes.iter()` guard held across the
+    // re-entrant DAG walk (the B1 hazard). Result is identical.
+    let postures = svc.app.calculate_fleet_posture();
     Json(json!({ "fleet": postures }))
 }
 

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -506,6 +506,28 @@ impl AppState {
         (*posture).clone()
     }
 
+    /// Whole-fleet per-node posture in ONE pass with a SHARED `black` memo
+    /// (review P3): O(N+E) instead of the O(N·(N+E)) of calling
+    /// [`calculate_posture`](Self::calculate_posture) once per node (each with a
+    /// fresh memo). Result is IDENTICAL to mapping `calculate_posture` over every
+    /// registered node — the per-node verdict is root-independent, so one shared
+    /// memo only ever reuses fully-resolved verdicts (proven in
+    /// `shared_memo_equivalence_tests`).
+    ///
+    /// The node-id set is snapshotted FIRST (the `nodes` shard guards are dropped
+    /// before any traversal), so the re-entrant `nodes.get(...)` inside the DAG
+    /// walk cannot deadlock against a held `nodes.iter()` guard — the same B1
+    /// hazard the posture-engine recalc already avoids. (The previous
+    /// `/fleet/posture` handler iterated `nodes` while calling `calculate_posture`
+    /// per entry, holding the iter guard across re-entrant gets.)
+    pub fn calculate_fleet_posture(&self) -> Vec<FleetNodePosture> {
+        let ids: Vec<String> = self.nodes.iter().map(|e| e.key().clone()).collect();
+        let mut black: HashMap<Arc<str>, Arc<FleetNodePosture>> = HashMap::new();
+        ids.iter()
+            .map(|id| self.calculate_posture_memoized(id.as_str(), &mut black))
+            .collect()
+    }
+
     fn recursive_calculate(
         &self,
         node_id: &str,
@@ -979,6 +1001,36 @@ mod shared_memo_equivalence_tests {
         assert_eq!(app.calculate_posture("d").propagated_status, FleetPosture::LockedOut,
             "d inherits c's LockedOut");
         assert_shared_equals_per_call(&app);
+    }
+
+    /// M2: `calculate_fleet_posture` (the shared-memo whole-fleet pass that the
+    /// `/fleet/posture` handler now uses) must yield, for every registered node,
+    /// the SAME `FleetNodePosture` as the per-node `calculate_posture`, and cover
+    /// exactly the registered id set.
+    #[test]
+    fn calculate_fleet_posture_matches_per_node_m2() {
+        let app = app();
+        app.persist_and_insert_node(node("a", NodeTrustState::Trusted)).unwrap();
+        app.persist_and_insert_node(node("b", NodeTrustState::Trusted)).unwrap();
+        app.persist_and_insert_node(node("x", NodeTrustState::Untrusted("fault".into()))).unwrap();
+        app.persist_and_insert_deps("b", vec!["a".into(), "x".into()]).unwrap();
+
+        let fleet = app.calculate_fleet_posture();
+        assert_eq!(fleet.len(), 3, "one posture per registered node");
+
+        for fp in &fleet {
+            let per_node = app.calculate_posture(fp.node_id.as_ref());
+            assert_eq!(
+                format!("{fp:?}"),
+                format!("{per_node:?}"),
+                "fleet entry must equal per-node calculate_posture for {}",
+                fp.node_id
+            );
+        }
+
+        let mut got: Vec<String> = fleet.iter().map(|p| p.node_id.to_string()).collect();
+        got.sort();
+        assert_eq!(got, vec!["a".to_string(), "b".to_string(), "x".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Medium-term item M2. `GET /fleet/posture` recomputed the DAG posture **per node** — `nodes.iter().map(|e| calculate_posture(e.key()))` — i.e. N independent traversals each with a fresh memo: **O(N·(N+E))** per request. It also held the `nodes.iter()` shard guard across the re-entrant `nodes.get(...)` inside each `calculate_posture` (the same re-entrant-DashMap class as the B1 hazard).

### Change
- New `AppState::calculate_fleet_posture() -> Vec<FleetNodePosture>`: snapshots the node-id set first (drops the iter guard), then resolves the whole fleet through **one shared `black` memo** — **O(N+E)** — reusing the existing P3 `calculate_posture_memoized`. Result is identical to the per-node mapping (the per-node verdict is root-independent; proven by the existing `shared_memo_equivalence_tests`).
- `get_fleet_posture` now calls it. The JSON shape (`{"fleet": [...]}`) is unchanged.

This is a pure, result-identical speedup (O(N²)→O(N+E)) that also removes the latent re-entrant-guard deadlock risk on the read path. `get_node_posture` is already a single O(N+E) traversal and is unchanged.

## Testing
- `cargo +stable test --locked -p kirra-verifier --lib` (incl. new `calculate_fleet_posture_matches_per_node_m2`, which asserts every fleet entry equals the per-node `calculate_posture` and covers exactly the registered id set)
- `cargo +stable test --locked -p kirra-verifier --bins` (service module: 73 passed)
- `cargo +stable clippy -p kirra-verifier -- -D warnings` clean (removed a now-unused `FleetNodePosture` import)

## Scope note
I implemented the safe, **result-identical** core of M2 (the O(N²)→O(N+E) shared-memo pass, the named hot spot). I deliberately did **not** add a cross-request generation-keyed cache: that would change the read endpoint's semantics from "live" to "last-recalc generation" (gate-consistent, but a product behavior change with staleness-vs-live implications) and is better made explicitly. The shared-memo pass already removes the quadratic cost; per-generation result caching can layer on top later if polling load warrants it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

