### PR TITLE
Set up Cursor Cloud dev environment for Kirra

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Rust Cargo workspace ("Kirra" — a fail-closed runtime safety governor).
+The root crate is `kirra-verifier`; sibling crates live under `crates/*`; `parko/`
+is a **separate** Cargo workspace consumed via `path =` deps. See `README.md` and
+`CLAUDE.md` for architecture; standard build/test/run commands are in `README.md`.
+
+### Toolchain (important)
+- The repo has **no `rust-toolchain.toml`** and CI uses the latest **stable** Rust.
+- The base VM image's default rustup toolchain may be pinned to an **older** Rust
+  (e.g. 1.83) that **cannot build the committed `Cargo.lock`** — some transitive
+  deps require `edition2024` (Rust ≥ 1.85). The fix is `rustup default stable`
+  (the startup update script does this). If a build fails with
+  `feature edition2024 is required`, your active toolchain is too old.
+
+### Build / test / lint (matches CI in `.github/workflows/ci.yml`)
+- Build: `cargo build --workspace --locked`
+- Test: `cargo test --workspace --locked` (root workspace does **not** descend into `parko/`).
+- Lint: `cargo clippy --workspace --locked -- -D warnings -W clippy::all -A clippy::module_name_repetitions -A clippy::must_use_candidate`
+- Parko (separate workspace, runtime-free lane): from `parko/`, run
+  `cargo test --workspace --exclude parko-onnx --exclude parko-openvino --exclude parko-tensorrt`.
+  Those three excluded crates `dlopen` native inference runtimes (ONNX Runtime /
+  OpenVINO) at backend init and need libs installed — skip them locally.
+- ROS 2 code is `--features ros2` gated and is **never** built by a default build
+  or `cargo test --workspace`; it needs a sourced ROS 2 (Jazzy) toolchain. Same for
+  the `tpm`/`cyclonedds` features (native libs). Leave all of these OFF for normal work.
+
+### Running the verifier service (the one MUST-run product)
+- Binary: `kirra_verifier_service` (axum HTTP, listens on `0.0.0.0:8090` by default).
+- **`KIRRA_ADMIN_TOKEN` must be set and non-empty or the process aborts at startup**
+  (SG-008 fail-closed invariant), e.g. `KIRRA_ADMIN_TOKEN=demo-admin`.
+- **Non-obvious gotcha — a fresh/empty fleet is `LockedOut`, so EVERY non-exempt
+  route (incl. all `GET /fleet/*` reads and the actuator route) returns `503`.**
+  This is intentional (M-9 "no positive trust evidence → fail closed" in
+  `recalculate_and_broadcast`). Only `/health`, `/ready`, `/metrics`, and the whole
+  `/console` plane are posture-exempt. The posture cache also has a 5 s TTL and
+  fail-closes if its periodic refresh stops.
+- **To get a non-empty fleet for local/dev work, seed the store first** with the
+  dev-only `kirra_console_demo_seed` binary (it refuses a non-empty DB and requires
+  `KIRRA_LOG_SIGNING_KEY` = base64 of a 32-byte ed25519 seed, e.g.
+  `head -c 32 /dev/urandom | base64`). Then start the service against the same
+  `KIRRA_DB_PATH` and the same `KIRRA_LOG_SIGNING_KEY`. The seed populates 6
+  `KIRRA-DEMO-*` nodes + a signed audit chain and makes `http://127.0.0.1:8090/console`
+  showable end-to-end. See `docs/CONSOLE_RUNBOOK.md`.
+- Operator recovery action (works under LockedOut, posture-exempt): record a
+  clearance grant at `POST /console/clearance-grants`. The break-glass path uses
+  the header `x-kirra-supervisor-key: <KIRRA_SUPERVISOR_RESET_KEY>` (the console UI's
+  primary flow is operator-signed instead).
+- `kirra_verifier_service` installs a SIGINT/SIGTERM graceful-shutdown handler that
+  can take a few seconds; if it lingers, kill it by **PID** (never by name).
+
+### Other binaries
+- All other binaries are OPTIONAL/dev (CARLA client needs a simulator; demo/diagnostic
+  bins; the two-box UDP `kirra-governor-service` + `kirra-proposal-bench`; ROS2 nodes).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for the Kirra workspace so future Cloud Agents can build, test, lint, and run the verifier service.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing durable, non-obvious setup/run caveats (toolchain pin gotcha, build/test/lint/parko commands, and the fail-closed empty-fleet `503` behavior + dev seeding flow).
- Proposes a minimal startup update script: ensure the `stable` toolchain is the rustup default and pre-fetch workspace + `parko/` dependencies.

No application code was modified.

## Why the toolchain note matters
The repo has no `rust-toolchain.toml` and CI builds on latest stable. The base VM defaulted to Rust 1.83, which **cannot** build the committed `Cargo.lock` (some transitive deps require `edition2024` / Rust ≥ 1.85). `rustup default stable` resolves this.

## Verification
- `cargo build --workspace --locked` — succeeded
- `cargo test --workspace --locked` — 1903 passed, 0 failed
- `cargo clippy --workspace --locked -- -D warnings ...` — 0 warnings
- `parko` runtime-free lane (`--exclude parko-onnx/openvino/tensorrt`) — 576 passed, 0 failed
- Ran `kirra_verifier_service` end-to-end: seeded a demo fleet via `kirra_console_demo_seed`, served the `/console` operator dashboard, confirmed the governor blocks an actuator command fail-closed (`503`), and recorded a signed operator clearance grant.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69935168-9193-45dc-848e-b9f3d507d740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69935168-9193-45dc-848e-b9f3d507d740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

