### PR TITLE
Stack-inline checker scratch buffers

### DIFF
--- a/crates/kirra-trajectory/Cargo.toml
+++ b/crates/kirra-trajectory/Cargo.toml
@@ -33,7 +33,11 @@ publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 kirra-core = { path = "../kirra-core" }
 # RSS longitudinal/lateral/opposite-direction safe-distance kernels.
 parko-core = { path = "../../parko/crates/parko-core" }
-# Stack-resident predicted-sample buffers in `prediction` (no per-mode heap Vec).
-smallvec = "1"
+# Stack-resident scratch buffers: predicted-sample runs in `prediction` and the
+# per-tick containment kernel-point/pose buffers in `validation` (M3). The
+# `const_generics` feature provides `Array` for arbitrary inline sizes (e.g. the
+# MAX_TRAJECTORY_HORIZON = 50 / MAX_CORRIDOR_VERTICES = 128 bounds), not just the
+# fixed power-of-two set.
+smallvec = { version = "1", features = ["const_generics"] }
 # `config` logs a one-time warning when no ODD speed cap is configured.
 tracing = "0.1"

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -16,9 +16,11 @@
 // kinematics is recorded but does NOT short-circuit — containment +
 // RSS still get a vote.
 
+use smallvec::SmallVec;
+
 use kirra_core::containment::{
     self as containment, Corridor, Pose as KernelPose,
-    Point as KernelPoint,
+    Point as KernelPoint, MAX_CORRIDOR_VERTICES, MAX_TRAJECTORY_HORIZON,
 };
 use kirra_core::kinematics_contract::{
     enforce_degraded_decel_to_stop, validate_vehicle_command, EnforceAction, ProposedVehicleCommand,
@@ -198,12 +200,19 @@ pub fn validate_trajectory_slow_capped(
     // ----- A) Containment (SG2) ----------------------------------------
     //
     // Materialize the kernel-side Corridor from the trait. The trait
-    // returns adapter `Point`s; we need kernel `Point`s. The field
-    // shapes are identical so the conversion is a 1-for-1 copy.
-    let left_kernel:  Vec<KernelPoint> = corridor.left_boundary().iter()
-        .map(adapter_to_kernel_point).collect();
-    let right_kernel: Vec<KernelPoint> = corridor.right_boundary().iter()
-        .map(adapter_to_kernel_point).collect();
+    // returns adapter `Point`s; we need kernel `Point`s (distinct structs,
+    // identical field shape → a 1-for-1 copy).
+    //
+    // M3: these per-tick scratch buffers are STACK-INLINE `SmallVec`s sized to
+    // the checker's own input bounds (`MAX_CORRIDOR_VERTICES` per corridor side,
+    // `MAX_TRAJECTORY_HORIZON` poses). A valid input therefore allocates NO heap
+    // on the ~10 Hz slow-loop path; an over-bound input spills to the heap but is
+    // rejected by the containment shape/horizon checks anyway, so the spill is
+    // both rare and harmless.
+    let left_kernel: SmallVec<[KernelPoint; MAX_CORRIDOR_VERTICES]> =
+        corridor.left_boundary().iter().map(adapter_to_kernel_point).collect();
+    let right_kernel: SmallVec<[KernelPoint; MAX_CORRIDOR_VERTICES]> =
+        corridor.right_boundary().iter().map(adapter_to_kernel_point).collect();
     let kernel_corridor = Corridor {
         left:           &left_kernel,
         right:          &right_kernel,
@@ -213,7 +222,8 @@ pub fn validate_trajectory_slow_capped(
         max_age_ms:     SLOW_LOOP_MAX_CORRIDOR_AGE_MS,
     };
     let footprint = config.to_vehicle_footprint();
-    let poses: Vec<KernelPose> = trajectory.iter().map(|p| adapter_to_kernel_pose(&p.pose)).collect();
+    let poses: SmallVec<[KernelPose; MAX_TRAJECTORY_HORIZON]> =
+        trajectory.iter().map(|p| adapter_to_kernel_pose(&p.pose)).collect();
 
     let containment_verdict = containment::validate_trajectory_containment(
         &poses, &kernel_corridor, &footprint, frame_trust,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Medium-term item M3. The slow-loop checker (`validate_trajectory_slow_capped`) allocated three heap `Vec`s per validation (~10 Hz) to convert the trait's adapter `Point`/`Pose` into the distinct kernel `Point`/`Pose` types the containment checker borrows:
- `left_kernel` / `right_kernel` (corridor sides)
- `poses` (trajectory)

### Change
These are now stack-inline `SmallVec`s sized to the checker's own input bounds:
- `SmallVec<[KernelPoint; MAX_CORRIDOR_VERTICES]>` (128) per corridor side
- `SmallVec<[KernelPose; MAX_TRAJECTORY_HORIZON]>` (50) for the poses

A valid input therefore performs **no heap allocation** on the slow-loop path. An over-bound input would spill to the heap, but containment already rejects those (`is_shape_valid` enforces `≤ MAX_CORRIDOR_VERTICES`; `> MAX_TRAJECTORY_HORIZON` → `DenyBreach(TrajectoryHorizonExceeded)`), so the spill is rare and harmless. The `Corridor` borrow and `validate_trajectory_containment` call are unchanged (`SmallVec` derefs to the slice the kernel API expects).

Enables `smallvec`'s `const_generics` feature (already a dependency) so the inline sizes can be the exact `MAX_*` constants rather than the fixed power-of-two set.

## Testing
- `cargo +stable test --locked -p kirra-trajectory` (55 passed — the full checker suite, unchanged verdicts)
- `cargo +stable test --locked -p kirra-ros2-adapter --no-default-features` (45 + suites — the adapter re-exporting the checker)
- `cargo +stable build --locked -p kirra-planner` (downstream consumer)
- `cargo +stable clippy -p kirra-trajectory -- -D warnings` clean

## Notes
- Result-identical: only the buffer storage changed (heap `Vec` → inline `SmallVec`); the conversion, corridor construction, and containment call are byte-for-byte the same.
- The WCET-critical per-pose `validate_vehicle_command` path is untouched.
- Stack cost is bounded and small (~5 KB per call: 2×128×16 B + 50×24 B) on the slow-loop blocking task.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

