### PR TITLE
Clean up CERT-003 RTM gap stubs

### DIFF
--- a/docs/safety/RTM_GAP_REPORT.md
+++ b/docs/safety/RTM_GAP_REPORT.md
@@ -72,15 +72,35 @@ mechanism gaps rather than faked.
 | SG-013 | B | **CLOSED** | `tests/cert_003_rtm_gap_stubs.rs::test_safety_goal_sg_013_recovery_hysteresis_streak_and_window` (external — the whole closure is public): 4 healthy reports → `StreakBuilding{4}`; 5th in-window → `RecoveryConfirmed{5}`; >10s gap → `WindowExpired` then rebuild-to-4 (no confirm); injected unhealthy report (the production `reset_recovery_streak` path) → reset, rebuild-to-4 (no confirm). Time injected via explicit `now_ms`. |
 | SG-015 | B | **CLOSED** | `src/security.rs` mod `sg_015_admin_token_tests`: the env-check is factored into pure `admin_token_ok(provided, configured)` (uses `constant_time_compare`, never `==`); `require_admin_token` calls it while preserving the 503 (configured absent/empty) vs 401 (provided absent/mismatch) mapping. Truth table tested in-crate without env-var mutation (INVARIANT #13). |
 
-Net: SG-009, SG-013, SG-015 fully CLOSED; SG-010 tamper-detection CLOSED with an
-explicit startup-verification sub-gap; SG-012 is an open mechanism gap. Each
-non-pointer mechanism carries a `// Verifies: SG-NNN` tag. The two open items
-are mechanism (behavior) changes, deliberately excluded from this test-only,
-no-behavior-change increment.
+Net: SG-009, SG-012, SG-013, SG-015 fully CLOSED; SG-010 tamper-detection CLOSED
+with an explicit startup-verification sub-gap. Each non-pointer mechanism
+carries a `// Verifies: SG-NNN` tag. The remaining SG-010 startup-verification
+item is a behavior change (verify-and-abort before listener bind), deliberately
+excluded from the original test-only, no-behavior-change increment.
+
+## Update — M6 RTM stub cleanup (2026-06-28)
+
+The old `#[ignore]` / `todo!()` placeholders in
+`tests/cert_003_rtm_gap_stubs.rs` have been removed for implemented goals. The
+file now contains executable integration tests where the relevant API is public
+(for example SG-007 causal-log propagation and SG-013 recovery hysteresis), and
+comment-only pointers where the evidence must live in-crate or in-bin because it
+drives private seams (for example SG-003, SG-008, SG-009, SG-010, SG-015). SG-012
+is no longer a mechanism gap: dedicated and unified DNP3 handlers both write the
+mandatory audit record before returning an admitted broadcast verdict and block
+the broadcast when the mandatory audit write is unavailable.
+
+This report's original "Gaps" and "Recommendation" sections below are retained
+as historical baseline material from the 2026-05/06 CERT-003 investigation; they
+no longer describe the live test inventory.
 
 ## Gaps — goals without any test coverage
 
-After CERT-004 these **8** safety goals (down from 11) still have no real test in the codebase. SG-006, SG-014, and SG-016 were closed and now live in `tests/fault_injection.rs`. The remaining 8 stubs are in `tests/cert_003_rtm_gap_stubs.rs`, with infrastructure-required notes added for SG-010, SG-013, and SG-015.
+**Historical baseline (superseded by the updates above).** After CERT-004 these
+**8** safety goals (down from 11) still had no real test in the codebase.
+SG-006, SG-014, and SG-016 were closed and lived in `tests/fault_injection.rs`.
+The remaining 8 placeholders were in `tests/cert_003_rtm_gap_stubs.rs`, with
+infrastructure-required notes added for SG-010, SG-013, and SG-015.
 
 | Goal | ASIL | Description (one line) | Missing RTM-named tests |
 |---|---|---|---|
@@ -114,7 +134,9 @@ These 5 goals have one named test in the codebase but the other two RTM-required
 
 ## Recommendation
 
-The RTM in its current state is **not defensible for an ASIL-D certification assessment.** Two distinct deficiencies that must be closed in this order:
+**Historical recommendation (superseded by subsequent CERT-003/M6 work).** The
+RTM in its then-current state was **not defensible for an ASIL-D certification
+assessment**. Two distinct deficiencies had to be closed in this order:
 
 1. **Implement the 11 missing zero-coverage tests first** (highest priority — most are ASIL B/C/D safety properties with no automated check today). Test stubs are landed in `tests/cert_003_rtm_gap_stubs.rs`; replace each `todo!()` body with the verification logic per the RTM's TR-N description for that goal. ASIL-D goals (SG-003, 006, 007, 008) should be implemented before ASIL B/C ones.
 2. **Implement the 2nd and 3rd test for each single-coverage goal** (SG-001, 002, 004, 005, 011). The existing one-test-per-goal pattern provides no defense against test mutation or deletion.

--- a/tests/cert_003_rtm_gap_stubs.rs
+++ b/tests/cert_003_rtm_gap_stubs.rs
@@ -1,18 +1,17 @@
-// CERT-003 — RTM Gap Test Stubs
+// CERT-003 — RTM Coverage Reconciliation
 //
-// One #[ignore]'d stub per Safety Goal that currently has zero
-// corresponding test coverage in the codebase. The RTM names specific
-// tests for each goal but those tests do not exist yet. Stubs here
-// preserve the goal-ID-to-test mapping so the gaps are visible to
-// `cargo test`, `--list`, and CI without falsifying coverage numbers.
-//
-// Each stub uses `todo!()` so that removing the `#[ignore]` without
-// implementing the body causes an immediate panic rather than a silent
-// pass. Tracked in CERT-003 (work/decisions.md ADL-011).
+// This file originally held `#[ignore]`/`todo!()` placeholders for RTM entries
+// whose named tests did not exist. Those placeholders are gone for implemented
+// goals: either the evidence lives here (when the public API is reachable from
+// an integration test) or the comment below points to the in-crate / binary test
+// that exercises a private seam. Do not add a placeholder for an implemented
+// goal — add or reference real executable evidence instead. If a mechanism is
+// genuinely missing, keep it documented in the RTM gap report rather than
+// falsifying coverage with a passing stub.
 //
 // Safety goal definitions: docs/safety/SAFETY_GOALS.md
 // Traceability matrix:    docs/safety/REQUIREMENTS_TRACEABILITY.md
-// Gap report:             docs/safety/RTM_GAP_REPORT.md
+// Historical gap report:  docs/safety/RTM_GAP_REPORT.md
 
 // SG-003 — Sensor Timeout Fault Detection (ASIL D): IMPLEMENTED (CERT-003).
 // The RTM-named tests live in `src/telemetry_watchdog.rs` mod `sg_003_cert_tests`
@@ -22,11 +21,9 @@
 // which is `pub(crate)`, so they must be in-crate unit tests — not this external
 // integration file. The mechanism carries a `// Verifies: SG-003` tag.
 
-#[test]
-#[ignore = "Implemented in tests/fault_injection.rs — test_safety_goal_sg_006_unknown_command_denial"]
-fn test_safety_goal_sg_006_unknown_command_denial() {
-    // See tests/fault_injection.rs for full implementation (CERT-004).
-}
+// SG-006 — Unknown Command Denial in All Posture States (ASIL D): IMPLEMENTED.
+// Evidence lives in `tests/fault_injection.rs`:
+// `test_safety_goal_sg_006_unknown_command_denial`.
 
 // SG-007 — Cross-Asset Fleet Lockout Propagation (ASIL D): CLOSED.
 // The propagation SAFETY PROPERTY (leader LockedOut → all Nominal followers
@@ -120,12 +117,9 @@ fn test_safety_goal_sg_007_causal_log_records_propagation_event() {
 // (decision: stale→promote / fresh→hold / inclusive boundary / clock-skew-safe;
 // ACT: mode_active false→true, durable promotion record + audit event, posture
 // recalc populates the cache). `promotion_decision` carries `// Verifies: SG-009`.
-#[test]
-#[ignore = "Implemented in src/standby_monitor.rs — mod sg_009_promotion_act_tests"]
-fn test_safety_goal_sg_009_ha_standby_promotion_within_timeout() {
-    // See src/standby_monitor.rs mod sg_009_promotion_act_tests (CERT-003).
-}
 
+// SG-009 executable evidence lives in `src/standby_monitor.rs`
+// `sg_009_promotion_act_tests`.
 // SG-010 — Audit Chain Tamper Detection (ASIL B): tamper-detection IMPLEMENTED;
 // startup-verification sub-gap OPEN.
 //
@@ -143,32 +137,15 @@ fn test_safety_goal_sg_009_ha_standby_promotion_within_timeout() {
 // `TcpListener::bind` and verifies the chain on demand via `/system/audit/verify`
 // (plus a shutdown checkpoint). Wiring verify-and-abort into startup is a
 // behavior change, out of scope for a test-only increment.
-#[test]
-#[ignore = "Implemented in src/verifier_store.rs — mod sg_010_audit_tamper_tests (startup-verify sub-gap OPEN, see note)"]
-fn test_safety_goal_sg_010_audit_chain_tamper_detection() {
-    // See src/verifier_store.rs mod sg_010_audit_tamper_tests (CERT-003).
-}
-
-// SG-012 — DNP3 Broadcast Command Mandatory Audit (ASIL B): MECHANISM GAP (OPEN).
-//
-// Investigated (CERT-003, 2026-06-08): the property is NOT testable today because
-// the mechanism does not exist. `src/adapters/dnp3.rs::Dnp3Adapter::evaluate` is a
-// PURE classifier — it returns a `Dnp3Evaluation { is_broadcast, is_control, ... }`
-// and nothing else. There is:
-//   - no audit-chain write on the DNP3 path (broadcast or otherwise),
-//   - no control-output application at this layer, hence
-//   - no "audit-before-control" ordering and no "block control on audit-write
-//     failure" fail-closed path to assert.
-// The only caller, `protocol_adapter.rs` (the `/industrial/dnp3/evaluate` route),
-// likewise just classifies. Writing a passing test here would assert nothing
-// (DO NOT FAKE COVERAGE). Closing SG-012 requires ADDING the mandatory-audit-
-// before-control mechanism — a behavior change, out of scope for a test-only
-// increment. Reported as an open mechanism gap. See RTM_GAP_REPORT.md (SG-012).
-#[test]
-#[ignore = "MECHANISM GAP (CERT-003): DNP3 audit-before-control does not exist; see note + RTM_GAP_REPORT.md"]
-fn test_safety_goal_sg_012_dnp3_broadcast_mandatory_audit() {
-    todo!("SG-012 mechanism (mandatory audit before control output) not implemented — see note above")
-}
+// SG-012 — DNP3 Broadcast Command Mandatory Audit (ASIL B): IMPLEMENTED.
+// The dedicated DNP3 handler and the unified industrial path now both write a
+// tamper-evident audit record before returning an admitted broadcast verdict, and
+// block a broadcast if that mandatory audit write is unavailable. Evidence lives
+// in `src/bin/kirra_verifier_service.rs`:
+//   - `sg_012_dnp3_broadcast_audit_tests::test_dnp3_broadcast_always_audited`
+//   - `sg_012_dnp3_broadcast_audit_tests::test_store_recovers_after_poison_broadcast_still_evaluates`
+// plus the unified-path tests in `src/bin/kirra_verifier_service/industrial.rs`
+// and `protocol_adapter::unified_tests`.
 
 // SG-013 — Recovery Hysteresis Streak and Window Enforcement (ASIL B): IMPLEMENTED
 // here (external) — the whole closure is reachable through the PUBLIC API
@@ -288,14 +265,10 @@ fn test_safety_goal_sg_013_recovery_hysteresis_streak_and_window() {
     }
 }
 
-#[test]
-#[ignore = "Implemented in tests/fault_injection.rs — test_safety_goal_sg_014_federation_report_replay_prevention"]
-fn test_safety_goal_sg_014_federation_report_replay_prevention() {
-    // See tests/fault_injection.rs for full implementation (CERT-004).
-    // Note: nonce-burn replay prevention (persistence-layer) remains
-    // out of scope for the in-memory unit; covered separately by an
-    // integration test against VerifierStore in a future increment.
-}
+// SG-014 — Federation Report Replay Prevention (ASIL B): IMPLEMENTED.
+// Evidence lives in `tests/fault_injection.rs`
+// (`test_safety_goal_sg_014_federation_report_replay_prevention`) and the
+// VerifierStore/fleet-transport nonce-burn tests.
 
 // SG-015 — Admin Token Absent Fail-Closed (ASIL B): IMPLEMENTED.
 // The env-var check is factored out of the `require_admin_token` middleware into
@@ -308,14 +281,8 @@ fn test_safety_goal_sg_014_federation_report_replay_prevention() {
 // middleware still maps configured-absent/empty → 503 and provided-absent/
 // mismatch → 401 (behavior unchanged); it now calls `admin_token_ok` for the
 // comparison. `admin_token_ok` carries `// Verifies: SG-015`.
-#[test]
-#[ignore = "Implemented in src/security.rs — mod sg_015_admin_token_tests"]
-fn test_safety_goal_sg_015_admin_token_absent_fail_closed() {
-    // See src/security.rs mod sg_015_admin_token_tests (CERT-003).
-}
+// SG-015 executable evidence lives in `src/security.rs`
+// `sg_015_admin_token_tests`.
 
-#[test]
-#[ignore = "Implemented in tests/fault_injection.rs — test_safety_goal_sg_016_dds_actuator_volatile_durability"]
-fn test_safety_goal_sg_016_dds_actuator_volatile_durability() {
-    // See tests/fault_injection.rs for full implementation (CERT-004).
-}
+// SG-016 executable evidence lives in `tests/fault_injection.rs`:
+// `test_safety_goal_sg_016_dds_actuator_volatile_durability`.

--- a/tests/fault_injection.rs
+++ b/tests/fault_injection.rs
@@ -7,12 +7,12 @@
 // asserting the system's safe-state response per
 // docs/safety/SAFE_STATE_SPECIFICATION.md.
 //
-// This commit lands implementations for 3 of 16 safety goals
-// (SG-006, SG-014, SG-016). The remaining 8 zero-coverage goals
-// (SG-003, 007, 008, 009, 010, 012, 013, 015) remain as
-// #[ignore]'d stubs in tests/cert_003_rtm_gap_stubs.rs with
-// detailed TODO comments documenting the test infrastructure they
-// each require.
+// This suite originally closed the first CERT-004 fault-injection slice
+// (SG-006, SG-014, SG-016). The broader CERT-003 RTM reconciliation has since
+// replaced the old ignored placeholders in `tests/cert_003_rtm_gap_stubs.rs`
+// with executable tests or precise pointers to in-crate / binary tests for
+// private seams. Keep this file focused on externally-drivable safe-state
+// injections.
 //
 // Tracking: CERT-004, ADL-010 / ADL-011 in work/decisions.md.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Medium-term item M6. The CERT-003 RTM reconciliation file still described itself as a set of `#[ignore]` / `todo!()` stubs even though most of those gaps now have real executable evidence (often in-crate/in-bin because the seam is private). It also still contained ignored pointer stubs for implemented goals, plus a stale SG-012 mechanism-gap `todo!()` even though the DNP3 mandatory audit mechanism has since landed.

### Changes
- Rename/reframe `tests/cert_003_rtm_gap_stubs.rs` as RTM coverage reconciliation rather than a stub file.
- Remove obsolete ignored pointer tests for implemented goals (SG-006, SG-009, SG-010, SG-014, SG-015, SG-016) and replace them with comment-only evidence pointers to the real executable tests.
- Replace the stale SG-012 `MECHANISM GAP` ignored `todo!()` with an implemented-evidence note pointing at the dedicated and unified DNP3 mandatory-audit tests/handlers.
- Refresh the `tests/fault_injection.rs` header so it no longer claims the remaining goals are ignored stubs.
- Update `docs/safety/RTM_GAP_REPORT.md` to mark SG-012 closed, record the M6 cleanup, and label the old gaps/recommendation sections as historical baseline material.

## Testing
- `cargo +stable test --locked --test cert_003_rtm_gap_stubs --test fault_injection`
  - `cert_003_rtm_gap_stubs`: 2 passed, 0 ignored
  - `fault_injection`: 4 passed, 0 ignored

## Notes
- There is no `AGENTS.md` file in this checkout (`Glob **/AGENTS.md` returned no matches), so I could not directly edit the referenced lines. The stale guidance relevant to M6 was in `tests/cert_003_rtm_gap_stubs.rs`, `tests/fault_injection.rs`, and `docs/safety/RTM_GAP_REPORT.md`.
- `docs/safety/REQUIREMENTS_TRACEABILITY.md` and `SAFE_STATE_SPECIFICATION.md` still contain broader historical `✗` / `PENDING` markers. I kept this PR scoped to M6's stub/gap cleanup; a full RTM table reconciliation is a larger documentation pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-260367dc-5e65-47e4-8034-5b5261d7206f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

