### PR TITLE
supply-chain: make installer checksum verification mandatory / fail-closed (H-4)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,6 +44,29 @@ The installer will:
 
 **The whole process takes under 2 minutes.**
 
+### Download integrity (supply-chain)
+
+When the installer downloads the binary from GitHub releases it **verifies the
+`SHA256SUMS` checksum and refuses to install on any failure** (missing checksum
+file, download error, archive not listed, or a hash mismatch) — it never installs
+an unverified binary. Every release publishes `SHA256SUMS`.
+
+This is an **integrity** check: `SHA256SUMS` is fetched over the same channel as
+the binary, so it protects against corruption and a binary-only swap, but not
+against an adversary who can replace *both* artifacts. For stronger guarantees:
+
+- **Pin a known-good release** rather than installing whatever is latest, and
+  compare its `SHA256SUMS` against a copy obtained out-of-band.
+- **Installing from a downloaded release archive** (`sudo bash install.sh`):
+  verify the archive against its published `SHA256SUMS` *before* extracting —
+  the bundled-binary path trusts the archive you already have.
+- **Roadmap:** signed releases (cosign keyless over `SHA256SUMS`, verified
+  against the repo's GitHub OIDC identity) for end-to-end authenticity.
+
+> Note: `curl … | sudo bash` executes the installer as root over the network; its
+> only protection is TLS to `raw.githubusercontent.com`. To inspect first,
+> download `install.sh`, review it, then run `sudo bash install.sh`.
+
 ---
 
 ## What the Installer Asks

--- a/install.sh
+++ b/install.sh
@@ -292,25 +292,42 @@ else
     curl -fsSL --progress-bar "${DOWNLOAD_URL}" -o "${ARCHIVE}" || \
         fatal "Download failed. URL: ${DOWNLOAD_URL}"
 
-    # Verify checksum if available
-    if [ -n "${CHECKSUM_URL}" ]; then
-        info "Verifying checksum..."
-        CHECKSUMS="${TMPDIR}/SHA256SUMS"
-        curl -fsSL "${CHECKSUM_URL}" -o "${CHECKSUMS}" 2>/dev/null || \
-            warn "Checksum file unavailable — skipping verification"
-
-        if [ -f "${CHECKSUMS}" ]; then
-            ARCHIVE_NAME=$(basename "${DOWNLOAD_URL}")
-            if grep -q "${ARCHIVE_NAME}" "${CHECKSUMS}"; then
-                (cd "${TMPDIR}" && \
-                    grep "${ARCHIVE_NAME}" SHA256SUMS | \
-                    sed "s|${ARCHIVE_NAME}|kirra.tar.gz|" | \
-                    sha256sum -c --quiet) || \
-                    fatal "Checksum verification FAILED — download may be corrupt or tampered"
-                success "Checksum verified"
-            fi
-        fi
+    # Verify checksum — MANDATORY, fail-closed (H-4).
+    #
+    # A tampered or poisoned release that OMITS or STRIPS SHA256SUMS must NEVER
+    # result in an unverified binary being installed as root. The previous
+    # "verify if available" form skipped verification whenever the checksum asset
+    # was missing, its download failed, or the archive name was absent from it —
+    # so an attacker who served a malicious binary and simply withheld the
+    # checksum bypassed the check entirely. Every Kirra release publishes
+    # SHA256SUMS (see .github/workflows/release.yml), so each of those is now a
+    # hard failure, not a skip.
+    #
+    # NOTE — integrity, NOT authenticity: SHA256SUMS is fetched over the SAME
+    # channel as the binary, so this defends against corruption and a binary-only
+    # swap, but NOT against an attacker who can replace BOTH artifacts. Signed
+    # releases (cosign keyless over SHA256SUMS, verified against the repo's GitHub
+    # OIDC identity) are the tracked authenticity follow-up — see INSTALL.md.
+    if [ -z "${CHECKSUM_URL}" ]; then
+        fatal "No SHA256SUMS published for this release — refusing to install an UNVERIFIED binary. Every Kirra release publishes one; its absence indicates a tampered or incomplete release."
     fi
+
+    info "Verifying checksum..."
+    CHECKSUMS="${TMPDIR}/SHA256SUMS"
+    curl -fsSL "${CHECKSUM_URL}" -o "${CHECKSUMS}" || \
+        fatal "Could not download SHA256SUMS (${CHECKSUM_URL}) — refusing to install an UNVERIFIED binary."
+
+    ARCHIVE_NAME=$(basename "${DOWNLOAD_URL}")
+    if ! grep -qF "${ARCHIVE_NAME}" "${CHECKSUMS}"; then
+        fatal "SHA256SUMS does not list ${ARCHIVE_NAME} — refusing to install an UNVERIFIED binary."
+    fi
+
+    (cd "${TMPDIR}" && \
+        grep -F "${ARCHIVE_NAME}" SHA256SUMS | \
+        sed "s|${ARCHIVE_NAME}|kirra.tar.gz|" | \
+        sha256sum -c --quiet) || \
+        fatal "Checksum verification FAILED — download is corrupt or tampered. Aborting."
+    success "Checksum verified"
 
     # Extract
     info "Extracting..."


### PR DESCRIPTION
## Pen-test supply-chain fix — H-4

### The fail-open
`install.sh` (the `curl … | sudo bash` installer) downloads the verifier binary from GitHub releases and installs it **as root**. Its checksum verification was *"verify if available"* and fail-open in three places:

1. no `SHA256SUMS` asset in the release listing → the whole verify block is skipped;
2. `SHA256SUMS` download fails → `warn "skipping verification"` and **continue**;
3. archive name not present in `SHA256SUMS` → inner check silently skipped.

So an adversary serving a tampered binary needed only to **omit/strip the checksum** and the installer would install the unverified binary as root → full host + safety-governor compromise. Every Kirra release **does** publish `SHA256SUMS` (`.github/workflows/release.yml`), so the "if available" guard bought nothing but the bypass.

### The fix — mandatory, fail-closed
Verification now **`fatal`s instead of skipping** on each of: missing `SHA256SUMS` asset, unreadable checksum download, archive absent from `SHA256SUMS`, or hash mismatch. The membership match is hardened to `grep -F` (fixed-string).

Proven against synthetic releases (no network needed):
| case | result |
|------|--------|
| genuine archive matches `SHA256SUMS` | **accept** |
| tampered payload | **reject** (hash mismatch → abort) |
| archive not listed in `SHA256SUMS` | **reject** (abort) |

All rejects exit nonzero → the installer `fatal`s. `bash -n` clean.

### Honest scope — integrity, not authenticity
`SHA256SUMS` is fetched over the **same channel** as the binary, so this defends against corruption and a binary-only swap, but **not** against an adversary who can replace *both* artifacts. The fully-correct fix — **cosign keyless signing over `SHA256SUMS`** in the release pipeline + pinned-OIDC-identity verification in the installer — needs release-workflow signing and is documented as the tracked follow-up.

`INSTALL.md` gains a **"Download integrity"** section: the mandatory check, the integrity-vs-authenticity caveat, version pinning, the archive-path self-verify step, and a `curl | bash` root-exec note.

### Validation caveat
`shellcheck` isn't available in the sandbox, so the script was validated with `bash -n` + a focused unit test of the verification pipeline (above), not a full lint or a live end-to-end install. Recommend a `shellcheck` CI step (none exists today).

No application code changed. Part of the supply-chain batch (H-4; M-6/M-7 to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_