### PR TITLE
supply-chain: pin GitHub Actions to SHAs + base images by digest (M-6, M-7)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# Supply-chain update automation (M-6 GitHub Actions, M-7 container base images).
+#
+# This keeps the pinned references CURRENT so they don't rot once pinned:
+#   - github-actions: once actions are SHA-pinned (scripts/pin-actions.sh),
+#     Dependabot bumps the SHA + version comment as new releases land, and
+#     surfaces new major versions to review before adopting.
+#   - docker: tracks base-image updates so digest pins can be refreshed
+#     deliberately rather than drifting on a floating tag.
+#   - cargo: routine dependency hygiene for the two workspaces.
+#
+# Dependabot maintains pins; it does NOT itself convert a tag ref to a SHA — the
+# one-time tag->SHA conversion is scripts/pin-actions.sh (see SECURITY.md).
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # One docker entry per directory that contains a Dockerfile.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /dashboard
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /deploy/docker
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: cargo
+    directory: /parko
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,3 +28,33 @@ Any bypass of these is a critical vulnerability:
 - `verify_attestation` uses real HMAC-SHA256 (never mocked)
 - DDS actuator topics use `Volatile` durability (never `TransientLocal`)
 - `OperationalCommand::Unknown` denied in all posture states
+
+## Supply-chain hardening
+
+### GitHub Actions are pinned to commit SHAs (M-6)
+
+Every third-party and first-party action referenced from `.github/workflows/`
+MUST be pinned to a **full 40-hex commit SHA**, not a mutable tag
+(`@v4`, `@stable`, …). A tag can be force-moved by a compromised action
+maintainer or a hijacked account to point at malicious code, which would then run
+in CI with this repo's `GITHUB_TOKEN` and secrets. A SHA is immutable.
+
+- **Apply the pins:** `scripts/pin-actions.sh` resolves each tag/branch ref to its
+  commit SHA (`git ls-remote`) and rewrites it as
+  `uses: owner/repo@<sha> # <tag>` (idempotent). Run it in a networked
+  environment — egress to `github.com` is required.
+- **Enforce:** `scripts/pin-actions.sh --check` exits non-zero if any mutable-tag
+  reference remains; wire it into CI once the initial pins are applied.
+- **Maintain:** Dependabot (`.github/dependabot.yml`, `github-actions`) bumps the
+  pinned SHA + version comment as new releases ship and surfaces new majors for
+  review.
+
+### Container base images are pinned by digest (M-7)
+
+Container base images (`Dockerfile`, `dashboard/Dockerfile`,
+`deploy/docker/*`) SHOULD be pinned by immutable digest
+(`FROM image:tag@sha256:…`), not a floating tag (`alpine:3`, `node:20-alpine`,
+`ros:jazzy-ros-base`, …) whose contents can change or be re-pushed under the same
+tag. Resolve a digest with
+`docker buildx imagetools inspect <image>:<tag> --format '{{.Manifest.Digest}}'`
+and refresh it deliberately via Dependabot (`.github/dependabot.yml`, `docker`).

--- a/scripts/pin-actions.sh
+++ b/scripts/pin-actions.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# pin-actions.sh — pin GitHub Actions to full commit SHAs (M-6).
+#
+# A `uses: owner/repo@v4` reference trusts a MUTABLE tag: a compromised action
+# maintainer (or a hijacked account) can re-point that tag at malicious code,
+# which then runs in CI with this repo's GITHUB_TOKEN and secrets. Pinning to a
+# full 40-hex commit SHA makes the reference immutable; Dependabot
+# (.github/dependabot.yml) then maintains the SHA as new versions ship.
+#
+# This script resolves each tag/branch ref to its commit SHA via `git ls-remote`
+# (no GitHub auth, no extra tooling) and rewrites the workflow in place as
+#   uses: owner/repo@<40-hex-sha> # <original-ref>
+# It is IDEMPOTENT: an already-SHA-pinned ref is left untouched, and local
+# (`./...`) / docker (`docker://...`) action refs are skipped.
+#
+# Usage:
+#   scripts/pin-actions.sh            # resolve + rewrite (needs network egress to github.com)
+#   scripts/pin-actions.sh --check    # CI gate: exit 1 if any mutable-tag ref remains; no writes
+#
+# NOTE: this repo's build sandbox blocks egress to github.com (policy 403), so
+# the apply mode must run in a networked environment (CI or a maintainer host).
+set -euo pipefail
+
+WORKFLOW_DIR=".github/workflows"
+CHECK_ONLY=0
+[ "${1:-}" = "--check" ] && CHECK_ONLY=1
+
+# Extract "owner/repo@ref" from a `uses:` line (ignores local/docker refs).
+# A ref is "pinned" iff it is exactly 40 lowercase hex chars.
+is_sha() { [[ "$1" =~ ^[0-9a-f]{40}$ ]]; }
+
+resolve_sha() {
+  # $1 = owner/repo, $2 = ref (tag or branch). Prints the commit SHA or fails.
+  local repo="$1" ref="$2" out
+  # Try tag (incl. annotated-tag dereference ^{}), then branch head.
+  out=$(git ls-remote "https://github.com/${repo}.git" \
+          "refs/tags/${ref}^{}" "refs/tags/${ref}" "refs/heads/${ref}" 2>/dev/null \
+        | awk '{print $1}' | tail -1)
+  [ -n "$out" ] && { printf '%s\n' "$out"; return 0; }
+  return 1
+}
+
+unpinned=0
+changed=0
+
+while IFS= read -r file; do
+  while IFS= read -r line; do
+    # Match: optional leading "- ", then uses: owner/repo@ref  (capture repo+ref)
+    if [[ "$line" =~ uses:[[:space:]]*([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)@([^[:space:]#]+) ]]; then
+      repo="${BASH_REMATCH[1]}"; ref="${BASH_REMATCH[2]}"
+      is_sha "$ref" && continue   # already pinned
+      unpinned=$((unpinned + 1))
+      if [ "$CHECK_ONLY" -eq 1 ]; then
+        echo "UNPINNED: ${file}: ${repo}@${ref}"
+        continue
+      fi
+      if sha=$(resolve_sha "$repo" "$ref"); then
+        # Rewrite this exact ref → sha, append the original ref as a comment.
+        # Escape sed-special chars in repo (dots/slashes are literal in our pattern).
+        esc_repo=${repo//\//\\/}
+        sed -i -E "s|uses:([[:space:]]*)${esc_repo}@${ref}([[:space:]]*)\$|uses:\1${esc_repo}@${sha} # ${ref}\2|" "$file"
+        echo "PINNED:   ${file}: ${repo}@${ref} -> ${sha}"
+        changed=$((changed + 1))
+      else
+        echo "ERROR: could not resolve ${repo}@${ref} (network egress to github.com required)" >&2
+        exit 2
+      fi
+    fi
+  done < "$file"
+done < <(find "$WORKFLOW_DIR" -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+
+if [ "$CHECK_ONLY" -eq 1 ]; then
+  if [ "$unpinned" -gt 0 ]; then
+    echo "FAIL: ${unpinned} unpinned action reference(s) — run scripts/pin-actions.sh" >&2
+    exit 1
+  fi
+  echo "OK: all action references are SHA-pinned"
+  exit 0
+fi
+
+echo "Done: ${changed} reference(s) pinned."


### PR DESCRIPTION
## Pen-test supply-chain fixes — M-6 + M-7

### The findings
- **M-6 — GitHub Actions pinned to mutable tags.** Every action in `.github/workflows/` is referenced by a tag (`actions/checkout@v4`, `dtolnay/rust-toolchain@stable`, `softprops/action-gh-release@v2`, `ros-tooling/setup-ros@v0.7`, `codecov/codecov-action@v4`, `docker/*@v3..v6`, …). A tag can be force-moved by a compromised maintainer / hijacked account to point at malicious code, which then runs in CI with this repo's `GITHUB_TOKEN` and secrets. (Workflow `permissions:` blocks already exist — that part is fine.)
- **M-7 — floating container base images.** Base images float on tags (`rust:1-alpine`, `alpine:3`, `node:20-alpine`, `nginx:alpine`, `ros:jazzy-ros-base`); a rebuild pulls whatever the tag currently points to.

### ⚠️ Honest scope — controls + tooling, not the literal pins
The correct fix is pinning actions to commit **SHAs** and images to **`@sha256:` digests** — which requires *resolving* those values from `github.com` and the container registries. **This build sandbox's egress proxy returns a policy `403` for both** (confirmed: `git ls-remote` and registry `curl` are denied), so I cannot resolve them here, and I won't hand-write/guess pins — a wrong pin silently breaks CI. So this PR ships the **controls and the deterministic tooling to apply the pins**, to be run in a networked environment.

### What's in the PR
- **`scripts/pin-actions.sh`** — resolves each `uses:` tag/branch ref → commit SHA via `git ls-remote` and rewrites it to `@<sha> # <tag>` (idempotent; skips already-SHA / local refs). `--check` mode is a **CI gate**: exits non-zero while any mutable-tag ref remains (currently **47** across the 4 workflows). Validated here with `bash -n` + a synthetic rewrite/idempotency test + `--check` against the real workflows.
- **`.github/dependabot.yml`** — `github-actions`, `docker` (one entry per Dockerfile dir), and `cargo` (both workspaces). Keeps the pins current and surfaces new majors; note Dependabot *maintains* SHAs but doesn't do the one-time tag→SHA conversion (that's the script).
- **`SECURITY.md`** — new "Supply-chain hardening" section documenting the actions→SHA policy, the images→digest policy (with the `docker buildx imagetools inspect …` resolve command), and the Dependabot maintenance loop.

### To complete the fix (one networked step)
```bash
scripts/pin-actions.sh            # writes the real SHA pins into the workflows
# review the diff, commit
```
Then wire `scripts/pin-actions.sh --check` into CI to keep them pinned, and refresh image digests via the documented command / Dependabot's docker PRs.

If you'd prefer, I can also add the `--check` gate as a CI job in this PR (kept non-blocking until the pins land, then flipped to required). No application code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_