### PR TITLE
review follow-up: H-3 store-Err re-arm, M-11/M-10 hardening, clippy debt

### DIFF
--- a/crates/kirra-core/src/containment.rs
+++ b/crates/kirra-core/src/containment.rs
@@ -428,15 +428,30 @@ fn polygon_vertex(corridor: &Corridor, idx: usize) -> Point {
 /// invariant to world rotation/translation and to corridor curvature (rigid
 /// motions preserve orientation), so a single fixed expected sign is valid for
 /// straight, curved, and lane-change corridors alike. O(N+M), no heap.
+///
+/// Vertices are shifted by the first polygon vertex before the cross products.
+/// The signed area is translation-invariant in exact arithmetic, but the raw
+/// `a.x * b.y` form loses precision when coordinates are large (a world frame —
+/// UTM ~1e6, ECEF ~6.4e6) relative to the corridor's own area; the rest of
+/// `containment` works in relative differences and is translation-stable
+/// (`verdict_is_translation_invariant`), so referencing to vertex 0 keeps this
+/// gate consistent with that discipline. Modeled offsets up to ~1e8 never flip
+/// the sign, but this removes the dependence entirely.
 #[inline]
 fn corridor_signed_area_2x(corridor: &Corridor) -> f64 {
     let n_total = corridor.left.len() + corridor.right.len();
+    if n_total == 0 {
+        return 0.0;
+    }
+    let origin = polygon_vertex(corridor, 0);
     let mut acc = 0.0;
     let mut k = 0;
     while k < n_total {
         let a = polygon_vertex(corridor, k);
         let b = polygon_vertex(corridor, (k + 1) % n_total);
-        acc += a.x_m * b.y_m - b.x_m * a.y_m;
+        let (ax, ay) = (a.x_m - origin.x_m, a.y_m - origin.y_m);
+        let (bx, by) = (b.x_m - origin.x_m, b.y_m - origin.y_m);
+        acc += ax * by - bx * ay;
         k += 1;
     }
     acc
@@ -818,6 +833,38 @@ mod tests {
             validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted),
             EnforceAction::Allow,
             "a consistently-wound curved corridor must still Allow (no over-rejection)"
+        );
+    }
+
+    /// Winding gate robustness: the same well-formed / swapped corridors at an
+    /// ECEF-scale world offset must still Allow / fail-closed respectively. Locks
+    /// the reference-origin shoelace (the naive absolute-coordinate form loses
+    /// precision far from the origin).
+    #[test]
+    fn containment_winding_stable_at_large_world_offset() {
+        let (ox, oy) = (4.5e6_f64, 4.5e6_f64); // ~ECEF magnitude
+        let (n, half_w, x_max) = (8usize, 3.0_f64, 100.0_f64);
+        let mut left = Vec::with_capacity(n);
+        let mut right = Vec::with_capacity(n);
+        for i in 0..n {
+            let x = ox + i as f64 * (x_max / (n as f64 - 1.0));
+            left.push(Point { x_m: x, y_m: oy + half_w });
+            right.push(Point { x_m: x, y_m: oy - half_w });
+        }
+        let traj = vec![pose(ox + 50.0, oy, 0.0)];
+
+        let corridor = healthy_corridor(&left, &right);
+        assert_eq!(
+            validate_trajectory_containment(&traj, &corridor, &sedan(), FrameTrust::Trusted),
+            EnforceAction::Allow,
+            "a well-formed corridor at a large world offset must still Allow"
+        );
+
+        let swapped = healthy_corridor(&right, &left);
+        assert_eq!(
+            validate_trajectory_containment(&traj, &swapped, &sedan(), FrameTrust::Trusted),
+            EnforceAction::DenyBreach(DenyCode::DrivableSpaceDeparture),
+            "a swapped corridor at a large world offset must still fail closed"
         );
     }
 

--- a/src/bin/kirra_verifier_service/attestation.rs
+++ b/src/bin/kirra_verifier_service/attestation.rs
@@ -35,12 +35,12 @@ pub(crate) async fn register_node(
         // SAFETY: SG-HA-3 — durable write off the async worker pool.
         let node_id_p = req.node_id.clone();
         let require = req.require_tpm_quote;
-        let policy_err = match svc.app.store.call(move |store| {
-            store.set_node_attestation_policy(&node_id_p, require)
-        }).await {
-            Ok(Ok(())) => false,
-            _ => true,
-        };
+        let policy_err = !matches!(
+            svc.app.store.call(move |store| {
+                store.set_node_attestation_policy(&node_id_p, require)
+            }).await,
+            Ok(Ok(()))
+        );
         if policy_err {
             return (StatusCode::INTERNAL_SERVER_ERROR,
                     Json(json!({ "error": "failed to persist attestation policy" }))).into_response();

--- a/src/bin/kirra_verifier_service/fleet.rs
+++ b/src/bin/kirra_verifier_service/fleet.rs
@@ -214,12 +214,9 @@ pub(crate) async fn handle_sensor_fault_report(
 
     // SAFETY: SG-HA-3 — read off the worker pool via read replica.
     let node_id_cf = req.source_node_id.clone();
-    let confidence_floor = match svc.app.store.call_read(move |store| {
+    let confidence_floor = svc.app.store.call_read(move |store| {
         store.load_av_confidence_floor(&node_id_cf).unwrap_or(None).unwrap_or(0.70)
-    }).await {
-        Ok(v) => v,
-        Err(_) => 0.70,
-    };
+    }).await.unwrap_or(0.70);
 
     let is_degraded = req.hardware_fault_detected || req.confidence_score < confidence_floor;
 

--- a/src/kirra_core.rs
+++ b/src/kirra_core.rs
@@ -155,6 +155,19 @@ impl<C: SafetyContract> KirraKernelGovernor<C> {
         // sentinel remains the right place to FAIL-FAST on such a config.
         let constraint_cap_min = cap_min.min(cap_max);
         let constraint_cap_max = cap_min.max(cap_max);
+        // A non-finite `initial_scalar` would poison `last_validated_scalar`: the
+        // Degraded decel-to-stop bound reads `current.signum()` / `current.abs()`
+        // (#410), so a NaN current emits a NaN setpoint. Normal flow washes it out
+        // on the first FullAutonomy tick before Degraded is reachable, but make the
+        // stored value finite-by-construction rather than rely on that ordering.
+        // Fall back to the contract's safe setpoint (then 0.0 if that is itself
+        // non-finite — a deeper config error the startup sentinel should reject).
+        let initial_scalar = if initial_scalar.is_finite() {
+            initial_scalar
+        } else {
+            let fb = contract.fallback();
+            if fb.is_finite() { fb } else { 0.0 }
+        };
         Self {
             contract,
             trust_engine: RuntimeTrustEngine::new(),

--- a/src/posture_engine_v2.rs
+++ b/src/posture_engine_v2.rs
@@ -903,7 +903,7 @@ mod posture_engine_v2_tests {
         for _ in 0..200 {
             if let Ok(guard) = cache.read() {
                 if let Some(c) = guard.as_ref() {
-                    cached = Some(c.clone());
+                    cached = Some(*c);
                     break;
                 }
             }

--- a/src/telemetry_watchdog.rs
+++ b/src/telemetry_watchdog.rs
@@ -339,9 +339,20 @@ fn watchdog_sweep_once_inner(
                 );
             }
             Err(e) => {
+                // The dirty flag was already cleared by the swap above, but this
+                // refresh did NOT happen — re-arm it so the NEXT sweep retries the
+                // prompt refresh instead of dropping a freshly-registered node back
+                // into the ~30 s periodic window (which would re-open the H-3
+                // fail-open precisely while the store is unhealthy). Idempotent: a
+                // periodic refresh is unaffected (it re-fires on the 30 s timer),
+                // and a redundant set just triggers one extra refresh attempt.
+                if registry_dirty {
+                    app.av_registry_dirty
+                        .store(true, std::sync::atomic::Ordering::Release);
+                }
                 tracing::error!(
                     error = %e,
-                    "Watchdog: failed to refresh node list — using cached list"
+                    "Watchdog: failed to refresh node list — using cached list, re-armed prompt refresh"
                 );
             }
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -98,6 +98,27 @@ fn test_degraded_refuses_reversal_through_zero() {
 }
 
 #[test]
+fn test_nonfinite_initial_scalar_is_normalized_to_finite() {
+    // A NaN initial_scalar would poison `last_validated_scalar`, and the Degraded
+    // decel-to-stop bound (`current.signum() * …`) would then emit NaN. The
+    // constructor normalizes it to the contract's finite safe setpoint.
+    let mut gov = KirraKernelGovernor::new(velocity_contract(), f64::NAN, -2.0, 2.0);
+    assert!(
+        gov.last_validated_scalar.is_finite(),
+        "non-finite initial_scalar must be normalized to a finite value"
+    );
+    assert_eq!(gov.last_validated_scalar, velocity_contract().fallback_linear_speed);
+
+    // A Degraded tick must therefore emit a finite setpoint, not NaN.
+    gov.trust_engine.decay_trust(30); // -> ConstrainedAdvisory (Degraded)
+    let res = gov.evaluate(1.0, 1.0);
+    assert!(
+        res.sanitized_scalar.is_finite(),
+        "Degraded output must be finite even after a non-finite initial_scalar"
+    );
+}
+
+#[test]
 fn test_type_safe_llm_parser_rejection_of_injections() {
     let parser = UnstructuredTextParser;
     let malicious_injection = r#"{


### PR DESCRIPTION
## Principal-review follow-ups to the pen-test remediation

Acting on a review of the last 15 commits. One real (if low-probability) bug, two robustness hardenings, and pre-existing clippy debt that currently leaves `main` **red** on `clippy --all-targets`.

### 🟠 H-3 (#633) — prompt refresh lost on a transient store error
`watchdog_sweep_once` swaps `av_registry_dirty` → false **before** the node-list load. If that load returns `Err`, the refresh is skipped but the flag stays cleared — so a freshly-registered node drops back into the ~30 s periodic window, **precisely while the store is unhealthy**: a smaller re-opening of the exact fail-open H-3 closed. The `Err` arm now re-arms the flag (only when it was the dirty trigger) so the next sweep retries promptly. *(The `Err` path isn't easily unit-testable without a store-error injection seam; the fix is a direct inverse of the swap.)*

### 🟡 M-11 (#632) — winding shoelace referenced to vertex 0
`corridor_signed_area_2x` summed `a.x*b.y − b.x*a.y` on **absolute** world coordinates — the one piece of `containment` that wasn't translation-stable (the rest works in relative differences and is proptested via `verdict_is_translation_invariant`). I **modeled** the f64 behavior at UTM/ECEF/absurd offsets (up to ~1e8): the sign **never flips**, so this is robustness, not a live bug. Shifting by the first polygon vertex removes the dependence and restores the module's discipline. New test: a well-formed / swapped corridor at an ECEF-scale offset still Allows / fails closed.

### 🟡 M-10 (#631) — constructor normalizes a non-finite `initial_scalar`
The Degraded decel-to-stop bound reads `current.signum()`/`current.abs()`, so a NaN `last_validated_scalar` would emit a NaN setpoint. Normal flow washes it out before Degraded is reachable, but `KirraKernelGovernor::new` now coerces a non-finite initial scalar to the contract's finite safe setpoint (then `0.0`). New test asserts a NaN init is normalized and a Degraded tick stays finite.

### 🧹 Pre-existing clippy debt (unrelated — confirmed by stashing my changes)
`main` (`4ce8b7b`) already fails `clippy --tests -D warnings` from recent refactor merges; restored green:
- `attestation.rs` `match` → `!matches!`
- `fleet.rs` `match` → `Result::unwrap_or`
- `posture_engine_v2.rs` `.clone()` on a `Copy` type → deref

I folded these in because (a) a review should surface them and (b) they'd otherwise red this PR's CI. If you'd rather keep this PR pure, I can split them into a separate `chore(clippy)` PR.

### Verification
- 640 lib tests + `kirra-core` / `kirra-ros2-adapter` suites green.
- `cargo clippy -p kirra-verifier -p kirra-core --lib --tests --bins -- -D warnings` clean.

### Not included (from the review, as optional)
- Refactor: unify the in-repo decel-to-stop-and-hold logic into a shared `degraded_decel_hold_scalar` in `kirra-core`.
- Tooling nits: `pin-actions.sh` regex-escape `ref`; `install.sh` anchor the `grep -F` archive match. Both fail-*closed*; say the word and I'll do a small `chore` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_