### PR TITLE
chore(deps): coordinated RustCrypto upgrade — sha2 0.11, hmac 0.13, getrandom 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -518,6 +518,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,7 +631,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -664,6 +673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +703,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -741,6 +762,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -827,6 +857,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,15 +887,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1024,7 +1072,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1043,9 +1091,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1106,7 +1166,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1538,7 +1598,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1606,6 +1675,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1930,7 +2008,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1961,7 +2039,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2013,10 +2091,10 @@ name = "kirra-governor-service"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "hmac",
+ "hmac 0.13.0",
  "kirra-core",
  "serde",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2109,9 +2187,9 @@ dependencies = [
  "base64",
  "dashmap",
  "ed25519-dalek",
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http",
  "kirra-capture-schema",
  "kirra-contract-channel",
@@ -2125,7 +2203,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2714,7 +2792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3111,7 +3189,7 @@ dependencies = [
  "bindgen",
  "os_str_bytes",
  "regex",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3722,8 +3800,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3738,7 +3827,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -5281,7 +5370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44b80a042fc71419fc4952a90c9cbcfb323c0ced048125d8b44fd362f184045f"
 dependencies = [
  "aes",
- "hmac",
+ "hmac 0.12.1",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "sha3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,8 @@ kirra-capture-schema = { path = "crates/kirra-capture-schema" }
 # identity), so enabling it is benign here.
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-hmac = "0.12"
-sha2 = "0.10"
+hmac = "0.13"
+sha2 = "0.11"
 hex = "0.4"
 dashmap = "6"
 axum = "0.8"
@@ -99,7 +99,7 @@ ed25519-dalek = { version = "2", features = ["rand_core", "pkcs8"] }
 # OS CSPRNG primitive for attestation challenge nonces (#147). Already in the
 # tree transitively via ed25519-dalek's rand_core; declared directly so the
 # library can source unpredictable nonces (no weak/time-based RNG).
-getrandom = "0.2"
+getrandom = "0.3"
 base64 = "0.22"
 tokio-stream = { version = "0.1", features = ["sync"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }

--- a/crates/kirra-collector/Cargo.toml
+++ b/crates/kirra-collector/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 arrow = "58"
 parquet = "58"
-sha2 = "0.10"
+sha2 = "0.11"
 # [C2] real rosbag2 db3 backend (Db3BagReader). bundled = vendored SQLite (no system dep).
 rusqlite = { version = "0.31", features = ["bundled"] }
 # [C2] real rosbag2 MCAP backend (McapBagReader). default features bring lz4+zstd

--- a/crates/kirra-governor-service/Cargo.toml
+++ b/crates/kirra-governor-service/Cargo.toml
@@ -33,5 +33,5 @@ bincode = "1.3"
 # Message authentication for the UDP command path (HMAC-SHA256). Both are pure
 # Rust, no_std-capable, and async/ROS-free — consistent with the QNX/cert-target
 # dependency discipline above. Versions pinned to the workspace root.
-hmac = "0.12"
-sha2 = "0.10"
+hmac = "0.13"
+sha2 = "0.11"

--- a/crates/kirra-governor-service/src/main.rs
+++ b/crates/kirra-governor-service/src/main.rs
@@ -26,6 +26,9 @@
 // non-advancing sequence, and — when `KIRRA_GOVERNOR_FRESHNESS_MS` is set —
 // rejects stale / future-dated proposals, emitting a fail-closed safe-state verdict.
 
+// hmac 0.13 / digest 0.11: `Mac` brings update/finalize/verify; `new_from_slice`
+// now lives on `KeyInit` (it was reachable via `Mac` in hmac 0.12).
+use hmac::digest::KeyInit;
 use hmac::{Hmac, Mac};
 use kirra_core::kinematics_contract::{
     validate_vehicle_command, DenyCode, EnforceAction, ProposedVehicleCommand,

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -615,6 +615,7 @@ mod tests {
     /// and it is not a signature by the node's AK regardless.)
     #[test]
     fn legacy_admin_token_hmac_proof_is_rejected() {
+        use hmac::digest::KeyInit; // hmac 0.13: `new_from_slice` moved to `KeyInit`
         use hmac::{Hmac, Mac};
         use sha2::Sha256;
         type HmacSha256 = Hmac<Sha256>;

--- a/src/post_incident.rs
+++ b/src/post_incident.rs
@@ -77,7 +77,7 @@ fn posture_str(p: &FleetPosture) -> &'static str {
 /// is NEVER left without a correlation id.
 fn new_correlation_id(ts: u64, generation: u64) -> String {
     let mut bytes = [0u8; 16];
-    if getrandom::getrandom(&mut bytes).is_ok() {
+    if getrandom::fill(&mut bytes).is_ok() {
         let mut s = String::with_capacity(4 + 32);
         s.push_str("inc-");
         for b in bytes {

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -702,7 +702,7 @@ impl AppState {
 #[must_use]
 pub fn generate_challenge_nonce() -> u64 {
     let mut bytes = [0u8; 8];
-    getrandom::getrandom(&mut bytes)
+    getrandom::fill(&mut bytes)
         .expect("OS CSPRNG (getrandom) unavailable — cannot issue a secure attestation nonce");
     u64::from_le_bytes(bytes)
 }


### PR DESCRIPTION
## Why a coordinated PR (replaces #664, #673, #671)

The individual Dependabot bumps each **failed to compile** because they split the RustCrypto `digest` generation: sha2 0.11 (digest 0.11) against hmac 0.12 (digest 0.10) leaves `Sha256` not implementing the traits `Hmac` expects (the `CoreProxy`/`BlockSizeUser` errors from the triage). This upgrades them **together** so the graph our code uses is on digest 0.11.

## Changes
Manifests (root + `kirra-collector` + `kirra-governor-service`): **sha2 0.10→0.11, hmac 0.12→0.13, getrandom 0.2→0.3**.

Code (small — high-level APIs are otherwise stable):
- **getrandom**: `getrandom::getrandom(buf)` → `getrandom::fill(buf)` (renamed in 0.3) at the two nonce sites (`verifier.rs`, `post_incident.rs`).
- **hmac 0.13**: `new_from_slice` moved from `Mac` to the `KeyInit` trait — added `use hmac::digest::KeyInit;` at the two HMAC sites (`kirra-governor-service/main.rs`, `attestation.rs` test).
- **sha2 `Digest` API is unchanged** — every SHA-256 site (audit chain, `tpm_quote`, `governor_release`, collector manifest, causal log) compiles as-is.

SHA-256 / HMAC-SHA256 are standardized → output bytes are identical, **no data migration**. The old majors still resolve transitively for `ed25519-dalek` etc. (they don't interop with our direct use — fine).

## Validation
- `cargo check --workspace` clean.
- **639 lib tests pass** — incl. audit-chain hash-continuity, attestation HMAC, getrandom-nonce paths.
- `kirra-governor-service` (16) + `kirra-collector` tests pass; root integration tests pass.
- Migration's own code is clippy-clean.

## Not included (validated as separate work)
- **rand 0.9** (#675) — harder: ed25519 keygen `OsRng`/`CryptoRngCore` rework; fails its test build.
- **rusqlite** (#668, needs a newer Rust toolchain), **bincode/arrow/parquet** (API rewrites).

## ⚠️ Merge order
This branch's full `clippy --workspace` is red **only** on the pre-existing `kirra-trajectory` + bin `attestation`/`fleet` lints that **#678** fixes. **Merge #678 first** and this goes green. (Recurring across all current PRs — #678 is the unblocker.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_