### PR TITLE
ci: lint test targets (clippy --all-targets) + ShellCheck & Helm-lint gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,13 +387,26 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Clippy
+        # --all-targets lints tests/benches/examples too — test-code lint debt
+        # had been slipping past the lib+bins-only default (review follow-up).
         run: |
-          cargo clippy --workspace -- \
+          cargo clippy --workspace --all-targets -- \
             -D warnings \
             -W clippy::all \
             -A clippy::module_name_repetitions \
             -A clippy::must_use_candidate \
             2>&1 | tee clippy-report.txt
+      - name: ShellCheck (shellcheck is preinstalled on the runner)
+        # -S error: gate on real bugs, not style. The whole tracked script set is
+        # error-clean today; a new error-level finding fails CI.
+        run: |
+          git ls-files '*.sh' | xargs -r shellcheck -S error 2>&1 | tee shellcheck-report.txt
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+      - name: Lint the Helm chart
+        # Default values (ClusterIP, ingress disabled) do NOT trip the H-1
+        # fail-closed transport guards, so a clean chart lints green.
+        run: helm lint helm/kirra 2>&1 | tee helm-lint-report.txt
       - name: Dependency audit
         run: cargo audit 2>&1 | tee audit-report.txt
       - name: Upload reports
@@ -403,6 +416,8 @@ jobs:
           name: static-analysis-reports
           path: |
             clippy-report.txt
+            shellcheck-report.txt
+            helm-lint-report.txt
             audit-report.txt
 
   parko-install-framework:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,7 +400,7 @@ jobs:
         # -S error: gate on real bugs, not style. The whole tracked script set is
         # error-clean today; a new error-level finding fails CI.
         run: |
-          git ls-files '*.sh' | xargs -r shellcheck -S error 2>&1 | tee shellcheck-report.txt
+          git ls-files -z -- '*.sh' | xargs -0 -r shellcheck -S error 2>&1 | tee shellcheck-report.txt
       - name: Install Helm
         uses: azure/setup-helm@v4
       - name: Lint the Helm chart

--- a/crates/kirra-fleet-transport/src/lib.rs
+++ b/crates/kirra-fleet-transport/src/lib.rs
@@ -693,11 +693,11 @@ mod core_tests {
     fn report_ingest_accepts_once_and_burns_nonce() {
         let (sk, pk) = keypair();
         let counter = RejectionCounter::new();
-        let mut store = VerifierStore::new(":memory:").unwrap();
+        let store = VerifierStore::new(":memory:").unwrap();
         let report = signed_report(&sk, "robot-01", Some(7)); // issued 1_000, expires 6_000
         let bytes = encode_report(&report).unwrap();
 
-        let got = ingest_report(&mut store, &bytes, &pk, &counter, 1_001).unwrap();
+        let got = ingest_report(&store, &bytes, &pk, &counter, 1_001).unwrap();
         assert_eq!(got, report);
         assert_eq!(counter.snapshot().accepted, 1);
         // The accepted report burned its nonce — a manual re-burn now returns false.
@@ -715,14 +715,14 @@ mod core_tests {
         // would have replayed it forever; ingest_report does not.
         let (sk, pk) = keypair();
         let counter = RejectionCounter::new();
-        let mut store = VerifierStore::new(":memory:").unwrap();
+        let store = VerifierStore::new(":memory:").unwrap();
         let report = signed_report(&sk, "robot-07", None);
         let bytes = encode_report(&report).unwrap();
 
-        ingest_report(&mut store, &bytes, &pk, &counter, 1_001).unwrap();
+        ingest_report(&store, &bytes, &pk, &counter, 1_001).unwrap();
         assert_eq!(counter.snapshot().accepted, 1);
 
-        let err = ingest_report(&mut store, &bytes, &pk, &counter, 1_002).unwrap_err();
+        let err = ingest_report(&store, &bytes, &pk, &counter, 1_002).unwrap_err();
         assert_eq!(err, RejectReason::Replayed);
         assert_eq!(counter.snapshot().replayed, 1);
         assert_eq!(counter.snapshot().accepted, 1, "the replay must NOT count as accepted");
@@ -734,11 +734,11 @@ mod core_tests {
         // rejected and — crucially — does NOT burn its nonce (freshness gates first).
         let (sk, pk) = keypair();
         let counter = RejectionCounter::new();
-        let mut store = VerifierStore::new(":memory:").unwrap();
+        let store = VerifierStore::new(":memory:").unwrap();
         let report = signed_report(&sk, "robot-08", None); // expires_at_ms = 6_000
         let bytes = encode_report(&report).unwrap();
 
-        let err = ingest_report(&mut store, &bytes, &pk, &counter, 6_001).unwrap_err();
+        let err = ingest_report(&store, &bytes, &pk, &counter, 6_001).unwrap_err();
         assert_eq!(err, RejectReason::Expired);
         assert_eq!(counter.snapshot().expired, 1);
         assert!(
@@ -751,12 +751,12 @@ mod core_tests {
     fn report_with_empty_nonce_is_malformed() {
         let (sk, pk) = keypair();
         let counter = RejectionCounter::new();
-        let mut store = VerifierStore::new(":memory:").unwrap();
+        let store = VerifierStore::new(":memory:").unwrap();
         let mut report = signed_report(&sk, "robot-09", None);
         report.nonce_hex = String::new(); // strip the replay nonce
         let bytes = encode_report(&report).unwrap();
 
-        let err = ingest_report(&mut store, &bytes, &pk, &counter, 1_001).unwrap_err();
+        let err = ingest_report(&store, &bytes, &pk, &counter, 1_001).unwrap_err();
         assert_eq!(err, RejectReason::Malformed("empty nonce_hex".into()));
         assert_eq!(counter.snapshot().malformed, 1);
     }
@@ -769,12 +769,12 @@ mod core_tests {
         // substituting it breaks the signature → BadSignature, never a nonce burn.
         let (sk, pk) = keypair();
         let counter = RejectionCounter::new();
-        let mut store = VerifierStore::new(":memory:").unwrap();
+        let store = VerifierStore::new(":memory:").unwrap();
         let mut report = signed_report(&sk, "robot-A", None);
         report.source_controller_id = "controller-B".into(); // re-target after signing
         let bytes = encode_report(&report).unwrap();
 
-        let err = ingest_report(&mut store, &bytes, &pk, &counter, 1_001).unwrap_err();
+        let err = ingest_report(&store, &bytes, &pk, &counter, 1_001).unwrap_err();
         assert_eq!(err, RejectReason::BadSignature, "controller-id substitution must break the sig");
         assert_eq!(counter.snapshot().bad_signature, 1);
         assert!(


### PR DESCRIPTION
## Review follow-ups: CI quality gates

The Static Analysis clippy step ran `cargo clippy --workspace` **without `--all-targets`**, so test/bench/example code was never linted — exactly how the test-target lint debt (the stuff I kept tripping over) accumulated. This closes that hole and adds two more gates.

### 1. clippy `--all-targets`
Now lints tests too. The only remaining test-target debt across the whole workspace was `kirra-fleet-transport`'s `ingest_report` tests passing `&mut store` to a `&S` function (`unnecessary_mut_passed` + the consequent unused `mut`) — **fixed** (test-only; 19 tests still pass). Verified `clippy --workspace --all-targets` is **green** locally.

### 2. ShellCheck (`-S error`)
Over every tracked `*.sh`. The whole script set is **error-clean today** (verified locally; shellcheck is preinstalled on GitHub runners), so the gate is green now and catches real shell bugs (quoting, unset vars, etc.) going forward.

### 3. `helm lint helm/kirra`
Via `azure/setup-helm`. With default values (ClusterIP, ingress disabled) the H-1 fail-closed transport guards don't trip, so a clean chart lints green.

> ⚠️ **The one gate I could NOT verify locally:** helm isn't installable in the dev sandbox (egress proxy 403). Validated structurally only; the **first CI run confirms it**. If it flags anything, it'll be a quick follow-up.

### Verified locally
- `cargo clippy --workspace --all-targets -- -D warnings …` — clean.
- `git ls-files '*.sh' | xargs shellcheck -S error` — exit 0.
- `ci.yml` is valid YAML.

### Still deferred (reported, not attempted — they're not "lint" follow-ups)
The major dep bumps need real migration work, and two are **blocked**, not just hard:
- **rand 0.9** — blocked *upstream*: `ed25519-dalek` 2.x pins `rand_core` 0.6, incompatible with rand 0.9's `rand_core` 0.9 `OsRng`. Can't take until ed25519-dalek supports rand_core 0.9.
- **rusqlite 0.40** — `libsqlite3-sys` needs the unstable `cfg_select` → a **Rust toolchain bump** decision.
- **bincode 1→3, arrow/parquet 58→59** — API rewrites in `kirra-collector`; dedicated PRs if you want them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_