### PR TITLE
fix(audit): Immediate-mode audit-chain appends so the chain can't fork (#685)

### DIFF
--- a/src/verifier_store/attestation.rs
+++ b/src/verifier_store/attestation.rs
@@ -11,7 +11,7 @@ impl VerifierStore {
         source: &str,
         registered_at_ms: u64,
     ) -> Result<()> {
-        let tx = self.conn.transaction()?;
+        let tx = Self::audit_tx(&mut self.conn)?; // #685: Immediate — non-forking audit append
 
         tx.execute(
             "INSERT OR REPLACE INTO attestation_identity_registry

--- a/src/verifier_store/audit.rs
+++ b/src/verifier_store/audit.rs
@@ -1033,7 +1033,7 @@ impl VerifierStore {
             // Brand-new chain (rows already carry key_id) — nothing to backfill.
             return Ok(());
         }
-        let tx = self.conn.transaction()?;
+        let tx = Self::audit_tx(&mut self.conn)?; // #685: Immediate — non-forking audit append
         tx.execute(
             "UPDATE audit_log_chain SET key_id = ?1 WHERE key_id IS NULL",
             params![genesis_id],
@@ -1156,7 +1156,7 @@ impl VerifierStore {
         let payload = format!(
             "{{\"v1_head_record_hash\":\"{v1_head}\",\"v1_total_count\":{v1_total},\"migrated_at_ms\":{now_ms}}}"
         );
-        let tx = self.conn.transaction()?;
+        let tx = Self::audit_tx(&mut self.conn)?; // #685: Immediate — non-forking audit append
         crate::audit_chain::AuditChainLinker::append_audit_event_tx(
             &tx,
             "HASH_V2_MIGRATION",

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -814,6 +814,28 @@ impl VerifierStore {
         }
     }
 
+    /// Begin an `Immediate` transaction on the NORMAL connection for an
+    /// audit-chain append (#685).
+    ///
+    /// `audit_log_chain` / `audit_anchor_head` are written from BOTH this
+    /// NORMAL `conn` (per-command audit: posture events, operator grants,
+    /// attestation, migrations) AND the FULL `durable_conn` (`record_key_rotation`,
+    /// the federation commit — both already `Immediate`). `append_audit_event_tx`
+    /// reads the chain tail and then INSERTs; under a DEFERRED transaction the
+    /// read takes only a snapshot, so a write committed on the OTHER connection
+    /// between the tail read and the INSERT could leave the new row linked off a
+    /// stale `previous_hash`/`sequence` — a forked chain caught only later by
+    /// verify. `Immediate` takes SQLite's single-writer WAL lock at `BEGIN`, so
+    /// the tail read happens under the write lock and no other connection can
+    /// interleave a commit: chain integrity rests on the WAL write lock, not on
+    /// the process-wide store mutex. This does NOT change `synchronous` (the
+    /// NORMAL/FULL #74 durability split is preserved) — only the lock-acquisition
+    /// point. Takes `&mut self.conn` (a field borrow) so callers can still read
+    /// `self.signing_key` for the append.
+    fn audit_tx(conn: &mut Connection) -> Result<rusqlite::Transaction<'_>> {
+        conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+    }
+
     /// Force a durable checkpoint: `wal_checkpoint(TRUNCATE)` on the FULL
     /// connection fsyncs the shared WAL into the main DB file, making ALL
     /// committed data durable — including the per-command audit rows written on

--- a/src/verifier_store/operators.rs
+++ b/src/verifier_store/operators.rs
@@ -49,7 +49,7 @@ impl VerifierStore {
             "operator_key_fingerprint": operator_key_fingerprint,
         })
         .to_string();
-        let tx = self.conn.transaction()?;
+        let tx = Self::audit_tx(&mut self.conn)?; // #685: Immediate — non-forking audit append
         tx.execute(
             "INSERT INTO clearance_grants
              (node_id, operator_id, granted_at_ms, delivery, created_at_ms,
@@ -156,7 +156,7 @@ impl VerifierStore {
         payload_json: &str,
         created_at_ms: u64,
     ) -> Result<()> {
-        let tx = self.conn.transaction()?;
+        let tx = Self::audit_tx(&mut self.conn)?; // #685: Immediate — non-forking audit append
         crate::audit_chain::AuditChainLinker::append_audit_event_tx(
             &tx,
             event_type,
@@ -229,7 +229,7 @@ impl VerifierStore {
             "detail": detail,
         })
         .to_string();
-        let tx = self.conn.transaction()?;
+        let tx = Self::audit_tx(&mut self.conn)?; // #685: Immediate — non-forking audit append
         tx.execute(
             "UPDATE clearance_grants SET outcome = ?2, outcome_detail = ?3 WHERE id = ?1",
             params![grant_rowid, outcome, detail],

--- a/src/verifier_store/posture.rs
+++ b/src/verifier_store/posture.rs
@@ -142,7 +142,7 @@ impl VerifierStore {
         reason: Option<&str>,
         created_at_ms: u64,
     ) -> Result<()> {
-        let tx = self.conn.transaction()?;
+        let tx = Self::audit_tx(&mut self.conn)?; // #685: Immediate — non-forking audit append
         tx.execute(
             "INSERT INTO posture_events
              (node_id, event_type, posture_json, reason, created_at_ms)

--- a/src/verifier_store/tests.rs
+++ b/src/verifier_store/tests.rs
@@ -1250,6 +1250,53 @@ mod key_durability_165_tests {
         assert!(r.signature_valid, "all rows (A-signed AND B-signed) verify under the durable seed");
     }
 
+    // --- #685: cross-connection audit chain stays a single unforked line -----
+    // `audit_log_chain` is written from BOTH the NORMAL conn
+    // (`save_posture_event_chained`) and the FULL `durable_conn`
+    // (`record_key_rotation`). On a FILE-backed store the two are DISTINCT
+    // connections, so this exercises the exact two-connection path #685 is about.
+    // Interleave production writers from both connections and assert the chain is
+    // a single unbroken, CONTIGUOUS line — the fork a DEFERRED tail-read risked,
+    // now closed by the `Immediate` `audit_tx` (the tail read holds the WAL write
+    // lock, so the other connection cannot commit a new tail in between).
+    #[test]
+    fn cross_connection_audit_chain_is_unforked() {
+        let db = TmpDb::new("s685");
+        let (a, b) = (key(1), key(2));
+        let mut s = VerifierStore::new(db.path()).unwrap();
+        s.admit_signing_key(a.clone(), false, None, 1).unwrap();
+        let held = s.try_claim_epoch(0, "test-node", 0).unwrap().unwrap();
+
+        // NORMAL-conn audit writes (posture events) interleaved with a FULL-conn
+        // audit write (key rotation), all appending to the same audit_log_chain.
+        s.save_posture_event_chained("n1", "DEGRADED", "{}", None, 10).unwrap();
+        s.save_posture_event_chained("n1", "NOMINAL", "{}", None, 20).unwrap();
+        s.record_key_rotation(b.clone(), "scheduled", 30, held).unwrap(); // durable_conn
+        s.save_posture_event_chained("n2", "DEGRADED", "{}", None, 40).unwrap();
+        s.save_posture_event_chained("n2", "LOCKEDOUT", "{}", None, 50).unwrap();
+
+        // (1) The chain verifies end-to-end across the connection boundary and the
+        //     rotation (rows signed by A before, by B after).
+        let r = s.verify_audit_chain_full(Some(&a.verifying_key())).unwrap();
+        assert!(r.chain_intact, "hash chain intact across the NORMAL/FULL connection boundary");
+        assert!(r.signature_valid, "all rows verify (A-signed and B-signed)");
+        assert_eq!(r.first_invalid_signature_index, None);
+
+        // (2) NO FORK: sequences are contiguous 0..N with no gap, duplicate, or
+        //     branch — exactly what a tail read off a stale previous_hash breaks.
+        let seqs: Vec<i64> = {
+            let mut stmt = s
+                .conn
+                .prepare("SELECT sequence FROM audit_log_chain ORDER BY id ASC")
+                .unwrap();
+            let rows = stmt.query_map([], |r| r.get::<_, i64>(0)).unwrap();
+            rows.map(|x| x.unwrap()).collect()
+        };
+        let expected: Vec<i64> = (0..seqs.len() as i64).collect();
+        assert_eq!(seqs, expected, "audit sequences are contiguous 0..N — chain did not fork");
+        assert_eq!(seqs.len(), 5, "two connections produced one 5-row chain");
+    }
+
     // --- Test 7: WCET — verdict path is independent of the key ledger --------
     #[test]
     fn wcet_verdict_path_does_not_touch_key_ledger() {

--- a/src/verifier_store/tests.rs
+++ b/src/verifier_store/tests.rs
@@ -1250,17 +1250,25 @@ mod key_durability_165_tests {
         assert!(r.signature_valid, "all rows (A-signed AND B-signed) verify under the durable seed");
     }
 
-    // --- #685: cross-connection audit chain stays a single unforked line -----
+    // --- #685: audit chain stays contiguous across both connections ----------
     // `audit_log_chain` is written from BOTH the NORMAL conn
     // (`save_posture_event_chained`) and the FULL `durable_conn`
-    // (`record_key_rotation`). On a FILE-backed store the two are DISTINCT
-    // connections, so this exercises the exact two-connection path #685 is about.
-    // Interleave production writers from both connections and assert the chain is
-    // a single unbroken, CONTIGUOUS line — the fork a DEFERRED tail-read risked,
-    // now closed by the `Immediate` `audit_tx` (the tail read holds the WAL write
-    // lock, so the other connection cannot commit a new tail in between).
+    // (`record_key_rotation`); on a FILE-backed store those are DISTINCT
+    // connections. This is a CONTIGUITY regression test for that two-connection
+    // chain: interleave production writers from both connections and assert one
+    // verifying, unbroken 0..N line across the connection boundary + rotation.
+    //
+    // Scope note (do not over-read): this does NOT force a statement-level
+    // interleave. Under the single-process store mutex the two connections never
+    // write concurrently, and most NORMAL-side writers (this one included) take
+    // the WAL write lock on their domain-row INSERT *before* the audit tail read
+    // regardless of DEFERRED/Immediate. `Immediate` (`audit_tx`) is what makes
+    // the no-fork guarantee hold uniformly and independently of the store mutex
+    // (and fixes the v2-migration path, where the audit append is the first
+    // statement). This test guards the cross-connection invariant; it is not a
+    // proof of the lock ordering itself.
     #[test]
-    fn cross_connection_audit_chain_is_unforked() {
+    fn cross_connection_audit_chain_is_contiguous() {
         let db = TmpDb::new("s685");
         let (a, b) = (key(1), key(2));
         let mut s = VerifierStore::new(db.path()).unwrap();
@@ -1294,7 +1302,7 @@ mod key_durability_165_tests {
         };
         let expected: Vec<i64> = (0..seqs.len() as i64).collect();
         assert_eq!(seqs, expected, "audit sequences are contiguous 0..N — chain did not fork");
-        assert_eq!(seqs.len(), 5, "two connections produced one 5-row chain");
+        assert!(seqs.len() >= 5, "at least the 5 rows this test appended are present");
     }
 
     // --- Test 7: WCET — verdict path is independent of the key ledger --------


### PR DESCRIPTION
Fixes #685.

## Problem
`audit_log_chain` / `audit_anchor_head` are written from **two** SQLite connections to the same WAL DB:
- the **NORMAL** `conn` — per-command audit: `save_posture_event_chained`, operator grants, attestation registration, the key-id backfill / v2 migration;
- the **FULL** `durable_conn` — `record_key_rotation` and the federation commit.

`append_audit_event_tx` reads the chain tail (`ORDER BY id DESC LIMIT 1`) and then INSERTs. The NORMAL-side transactions were **DEFERRED**, so the isolation across the two connections was asymmetric (one side `Immediate`, the other DEFERRED), and chain integrity rested on the global store mutex serializing the two connections rather than on anything intrinsic.

## Scope — what this actually is (honest framing)
This is a **defense-in-depth / uniformity hardening**, not a fix for a live race in the hot path:
- Under the single-process store mutex the two connections never write concurrently, so there is no concurrent fork today.
- Most NORMAL-side writers (`save_posture_event_chained`, operators, attestation, key-id backfill) take the WAL **write** lock on their *domain-row* INSERT **before** the audit tail read, so for them DEFERRED vs `Immediate` is behaviorally identical.
- The one path where `Immediate` genuinely changes behavior is the **v2-migration** (`audit.rs:1159`), where the audit append is the *first* statement in the transaction (so DEFERRED would take only a read snapshot before the tail read).

The value of the change: it makes the no-fork guarantee **uniform and independent of the store mutex** (robust to a future reordering or a change that drops the serialization), removes the DEFERRED/`Immediate` asymmetry, and fixes the v2-migration first-statement path.

## Fix
- Add `VerifierStore::audit_tx`, a single private helper that begins an **`Immediate`** transaction on the NORMAL connection, and route all 7 NORMAL-side audit-chain writers through it.
- `Immediate` takes SQLite's single-writer **WAL write lock at `BEGIN`**, so the tail read always runs under the write lock. The durable-side writers (`record_key_rotation`, federation) already use `Immediate`.
- `synchronous` is **unchanged** on both connections — the deliberate #74 NORMAL/FULL durability split is preserved (no new fsync on the 20 Hz+ hot path); only the lock-acquisition point moves.

Why `Immediate` rather than literally one connection: a single connection would either fsync the hot path (regressing #74) or break `record_key_rotation`'s atomic "key-ledger row + chain row" commit. `Immediate` on the shared WAL write lock gives the same guarantee without those costs.

## Test
`cross_connection_audit_chain_is_contiguous` (file-backed, so `durable_conn` is a distinct connection): interleaves posture-event appends (NORMAL conn) with a key rotation (FULL conn) and asserts the chain verifies end-to-end across the A→B rotation and that sequences are **contiguous `0..N`**. Per review feedback it is documented as a **cross-connection contiguity regression test** — it does *not* force a statement-level interleave (the store mutex precludes concurrency), so it guards the cross-connection invariant rather than proving the lock ordering itself.

## Verification
- `cargo test -p kirra-verifier --locked` — all pass (641 lib + integration suites; new test green).
- `cargo clippy -p kirra-verifier --all-targets --locked -- -D warnings …` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)