### PR TITLE
fix(rss): scale the lateral-conflict window by closing speed (#683, #684)

### DIFF
--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -1269,3 +1269,59 @@ fn ackermann_degraded_has_no_angular_stop_gate() {
     assert_ne!(verdict, TrajectoryVerdict::MRCFallback,
         "robotaxi (angular None) must carry no angular stop gate; got {verdict:?}");
 }
+
+// ---------------------------------------------------------------------------
+// #683/#684 — closing-speed-scaled lateral-conflict window
+// ---------------------------------------------------------------------------
+
+#[test]
+fn high_speed_cut_in_beyond_8m_is_caught_dc2() {
+    // #684: at highway-adjacent speed a lateral cut-in originating MORE than the
+    // old fixed 8 m ceiling ahead must still be refused. The ego runs at 18 m/s;
+    // the object sits ~12 m ahead at dy = 3 m (above the 2.5 m overlap gate, inside
+    // the 4 m alignment band) and is closing laterally into the ego lane. The poses
+    // barely advance (0.9 m each), so the object is ≥12 m ahead at EVERY pose —
+    // beyond the old 8 m lateral ceiling, which therefore skipped it (Accept). With
+    // the fix the window is RSS_LONGITUDINAL_CONFLICT_M.max(lon_required) (~50 m at
+    // 18 m/s), so the lateral RSS fires → MRC.
+    let trajectory = straight_trajectory(3, 18.0, 0.05); // poses x = 5.0, 5.9, 6.8
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban(); // ODD cap 22.35 > 18 → no kinematics clamp
+    let objects = vec![PerceivedObject {
+        id: 1,
+        pos: Point { x_m: 19.0, y_m: 3.0 }, // ~12 m ahead, in the 2.5–4 m band
+        velocity_mps: 3.0,
+        heading_rad: -std::f64::consts::FRAC_PI_2, // facing its motion direction
+        vel: Point { x_m: 0.0, y_m: -3.0 },        // closing laterally toward y = 0
+    }];
+    let verdict = validate_trajectory_slow(
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal,
+    );
+    assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
+        "an 18 m/s ego must refuse a lateral cut-in ~12 m ahead (beyond the old 8 m ceiling); got {verdict:?}");
+}
+
+#[test]
+fn stationary_side_object_in_band_beyond_8m_stays_admitted_683() {
+    // #683 regression guard: widening the lateral window must NOT start
+    // over-rejecting a longitudinally-unsafe but laterally-STILL object in the
+    // 2.5–4 m band. The zero-lateral-velocity required gap (= 2·a_lat·ρ² ≈ 1.75 m
+    // at the 3.5 m/s² / 0.5 s defaults) is below the 3 m offset, so the object —
+    // which the ego is closing on longitudinally — is still admitted. Same geometry
+    // as the cut-in test but with zero object velocity.
+    let trajectory = straight_trajectory(3, 18.0, 0.05);
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let objects = vec![PerceivedObject {
+        id: 1,
+        pos: Point { x_m: 19.0, y_m: 3.0 }, // ~12 m ahead, 3 m to the side, STATIONARY
+        velocity_mps: 0.0,
+        heading_rad: 0.0,
+        vel: Point { x_m: 0.0, y_m: 0.0 },
+    }];
+    let verdict = validate_trajectory_slow(
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal,
+    );
+    assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "a stationary object 3 m to the side stays admitted inside the widened window; got {verdict:?}");
+}

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -470,7 +470,21 @@ pub fn validate_trajectory_slow_capped(
             // as ~0 and could miss the cut-in.
             let obj_lat_vel = -sin_h * obj.vel.x_m + cos_h * obj.vel.y_m;
             let lateral_cut_in = obj_lat_vel.abs() > RSS_LATERAL_MOTION_EPS_MPS;
-            if dx_ego <= RSS_LONGITUDINAL_CONFLICT_M && (lon_unsafe || lateral_cut_in) {
+            // #683/#684: scale the lateral-conflict longitudinal window by closing
+            // DISTANCE, floored at the 8 m urban minimum. A FIXED 8 m ceiling clipped
+            // (a) a high-speed cut-in originating farther ahead than 8 m — at the
+            // 22.35 m/s ODD cap, reaction-time travel alone is ~11 m — and (b) a cut-in
+            // in the 2.5–4.0 m lateral band (above the overlap gate, within the
+            // alignment tolerance) once it was >8 m ahead. `lon_required` is already
+            // computed and grows with closing speed, so the lateral risk is evaluated
+            // exactly as far ahead as longitudinal closing matters. This does NOT
+            // over-reject: the `(lon_unsafe || lateral_cut_in)` precondition plus a
+            // small zero-lateral-velocity `lat_required` (= 2·a_lat·ρ² ≈ 1.75 m at the
+            // 3.5 m/s² / 0.5 s defaults, below the overlap width) keep a longitudinally-
+            // unsafe but laterally-STILL in-band object admitted; the narrow overlap
+            // gate (overtaking) is untouched.
+            let lat_conflict_window = RSS_LONGITUDINAL_CONFLICT_M.max(lon_required);
+            if dx_ego <= lat_conflict_window && (lon_unsafe || lateral_cut_in) {
                 let ego_lat_vel = 0.0; // straight-following assumption per §3
                 let lat_required = lateral_safe_distance(
                     ego_lat_vel,
@@ -723,7 +737,10 @@ fn predictive_rss_breach(
             // gate skips.
             let obj_lat_v = -ovx * sin_h + ovy * cos_h;
             let lateral_cut_in = obj_lat_v.abs() > RSS_LATERAL_MOTION_EPS_MPS;
-            if dx_ego <= RSS_LONGITUDINAL_CONFLICT_M && (lon_unsafe || lateral_cut_in) {
+            // #683/#684: closing-speed-scaled lateral window (floored at the 8 m
+            // urban minimum), mirroring the snapshot pass — see its rationale.
+            let lat_conflict_window = RSS_LONGITUDINAL_CONFLICT_M.max(lon_required);
+            if dx_ego <= lat_conflict_window && (lon_unsafe || lateral_cut_in) {
                 let lat_required = lateral_safe_distance(
                     0.0, // straight-following assumption per §3 (ego lateral vel)
                     obj_lat_v,

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -471,8 +471,8 @@ pub fn validate_trajectory_slow_capped(
             let obj_lat_vel = -sin_h * obj.vel.x_m + cos_h * obj.vel.y_m;
             let lateral_cut_in = obj_lat_vel.abs() > RSS_LATERAL_MOTION_EPS_MPS;
             // #683/#684: scale the lateral-conflict longitudinal window by closing
-            // DISTANCE, floored at the 8 m urban minimum. A FIXED 8 m ceiling clipped
-            // (a) a high-speed cut-in originating farther ahead than 8 m — at the
+            // SPEED (via `lon_required`), floored at the 8 m urban minimum. A FIXED 8 m
+            // ceiling clipped (a) a high-speed cut-in originating farther ahead than 8 m — at the
             // 22.35 m/s ODD cap, reaction-time travel alone is ~11 m — and (b) a cut-in
             // in the 2.5–4.0 m lateral band (above the overlap gate, within the
             // alignment tolerance) once it was >8 m ahead. `lon_required` is already

--- a/parko/crates/parko-core/src/rss.rs
+++ b/parko/crates/parko-core/src/rss.rs
@@ -35,11 +35,15 @@ pub const RSS_FAILSAFE_DISTANCE_M: f64 = 1.0e6;
 /// rejects motions RSS deems safe.
 ///
 /// The checkers keep the lateral safe-distance as a fail-closed *defence-in-depth*
-/// layer (catching a cut-in beside the ego), but **gate** it on this longitudinal
-/// proximity: a lateral shortfall is dangerous only when the object is within
-/// `RSS_LONGITUDINAL_CONFLICT_M` longitudinally. The value is deliberately
-/// conservative — a passenger-vehicle length plus a reaction-time closing buffer —
-/// so an imminent cut-in is still caught while distant traffic no longer trips it.
+/// layer (catching a cut-in beside the ego), but **gate** it on longitudinal
+/// proximity. This constant is the **FLOOR** of that gate, not a fixed ceiling:
+/// the trajectory checker uses `RSS_LONGITUDINAL_CONFLICT_M.max(lon_required)` so
+/// the window grows with closing speed (#683/#684). A fixed 8 m ceiling clipped a
+/// high-speed cut-in originating farther ahead than 8 m — at the 22.35 m/s ODD cap
+/// reaction-time travel alone is ~11 m — and a cut-in in the 2.5–4.0 m lateral band
+/// once it was >8 m ahead. The floor keeps an urban-minimum conflict window for
+/// low-speed cases; above it, the longitudinal safe distance governs how far ahead
+/// a lateral shortfall is still considered a conflict.
 ///
 /// (The dominant longitudinal RSS — car-following / head-on — is UNCHANGED and
 /// fully governs any object that is longitudinally unsafe at any range.)

--- a/parko/crates/parko-core/src/rss.rs
+++ b/parko/crates/parko-core/src/rss.rs
@@ -34,16 +34,20 @@ pub const RSS_FAILSAFE_DISTANCE_M: f64 = 1.0e6;
 /// traffic safely passing in the next lane) is therefore over-conservative: it
 /// rejects motions RSS deems safe.
 ///
-/// The checkers keep the lateral safe-distance as a fail-closed *defence-in-depth*
-/// layer (catching a cut-in beside the ego), but **gate** it on longitudinal
-/// proximity. This constant is the **FLOOR** of that gate, not a fixed ceiling:
-/// the trajectory checker uses `RSS_LONGITUDINAL_CONFLICT_M.max(lon_required)` so
-/// the window grows with closing speed (#683/#684). A fixed 8 m ceiling clipped a
-/// high-speed cut-in originating farther ahead than 8 m — at the 22.35 m/s ODD cap
-/// reaction-time travel alone is ~11 m — and a cut-in in the 2.5–4.0 m lateral band
-/// once it was >8 m ahead. The floor keeps an urban-minimum conflict window for
-/// low-speed cases; above it, the longitudinal safe distance governs how far ahead
-/// a lateral shortfall is still considered a conflict.
+/// Both safety checkers keep the lateral safe-distance as a fail-closed
+/// *defence-in-depth* layer (catching a cut-in beside the ego) and **gate** it on
+/// longitudinal proximity. For those gates this constant is the **FLOOR** of the
+/// window, not a fixed ceiling: the trajectory checker
+/// (`kirra_trajectory::validation`) uses `RSS_LONGITUDINAL_CONFLICT_M.max(lon_required)`
+/// and the diverse scene-RSS checker (`parko_kirra`) uses
+/// `RSS_LONGITUDINAL_CONFLICT_M.max(required_long)`, so the window grows with closing
+/// speed (#683/#684). A fixed 8 m ceiling deemed a high-speed cut-in originating
+/// farther ahead than 8 m "laterally safe" — at the 22.35 m/s ODD cap reaction-time
+/// travel alone is ~11 m — and skipped a cut-in in the 2.5–4.0 m lateral band once it
+/// was >8 m ahead. The floor keeps an urban-minimum conflict window for low-speed
+/// cases; above it, the longitudinal safe distance governs how far ahead a lateral
+/// shortfall is still a conflict. (Non-gating references — e.g. a planner's test
+/// positioning — may still read the bare 8 m value.)
 ///
 /// (The dominant longitudinal RSS — car-following / head-on — is UNCHANGED and
 /// fully governs any object that is longitudinally unsafe at any range.)

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -283,7 +283,15 @@ pub fn compute_scene_rss(scene: &AgentScene, params: &RssParams) -> RssState {
         // checker's RSS-conjunction fix.
         let lat_safe = if !a.actual_lateral_separation_m.is_finite() {
             false
-        } else if a.actual_longitudinal_gap_m > RSS_LONGITUDINAL_CONFLICT_M {
+        // #683/#684: the lateral-conflict longitudinal window is the FLOOR
+        // `RSS_LONGITUDINAL_CONFLICT_M` scaled up by closing speed via `required_long`
+        // (the diverse-governor analog of the trajectory checker's `lon_required`). A
+        // FIXED 8 m ceiling deemed a high-speed cut-in originating farther ahead than
+        // 8 m "laterally safe" before `required_lat` was consulted — at the 22.35 m/s
+        // ODD cap reaction-time travel alone is ~11 m. No over-rejection: the
+        // `(lon_unsafe || lateral_cut_in)` precondition still admits a longitudinally-
+        // safe, laterally-still object inside the wider window.
+        } else if a.actual_longitudinal_gap_m > RSS_LONGITUDINAL_CONFLICT_M.max(required_long) {
             true
         } else {
             let lon_unsafe = a.actual_longitudinal_gap_m < required_long;
@@ -1800,6 +1808,50 @@ mod scene_rss_tests {
         assert!(
             !compute_scene_rss(&AgentScene::Agents(vec![abreast]), &params()).safe,
             "a longitudinally-unsafe (abreast) pair is still vetoed"
+        );
+    }
+
+    #[test]
+    fn scene_rss_catches_a_high_speed_cut_in_beyond_8m_dc2() {
+        // #684 in the diverse scene-RSS checker: a high-speed cut-in MORE than the
+        // old fixed 8 m ceiling ahead must be unsafe. ego 18 m/s; object 12 m ahead,
+        // 3 m to the side (lat_sep ≥ overlap → longitudinal axis clear), closing
+        // laterally. Pre-fix `gap > 8` short-circuited `lat_safe = true` → SAFE;
+        // post-fix the window is `max(8, required_long)` (~39 m at 18 m/s) → the
+        // lateral RSS binds → UNSAFE.
+        let cut_in = RssAgent {
+            ego_vel: 18.0,
+            lead_vel: 0.0,
+            actual_longitudinal_gap_m: 12.0, // beyond the old 8 m ceiling
+            ego_lat_vel: 0.0,
+            obj_lat_vel: 3.0,                 // closing laterally (cut-in)
+            actual_lateral_separation_m: 3.0, // 2.5–4 band; ≥ overlap → no rear-end
+            oncoming: false,
+        };
+        assert!(
+            !compute_scene_rss(&AgentScene::Agents(vec![cut_in]), &params()).safe,
+            "an 18 m/s ego must flag a lateral cut-in 12 m ahead as unsafe (beyond the old 8 m ceiling)"
+        );
+    }
+
+    #[test]
+    fn scene_rss_admits_a_stationary_side_object_beyond_8m_683() {
+        // #683 guard: the widened window must NOT over-reject a longitudinally-unsafe
+        // but laterally-STILL object in the 2.5–4 band. Zero lateral velocity → small
+        // required_lat (= 2·a_lat·ρ² = 1.0 m here) < the 3 m separation → still safe.
+        // Same geometry as the cut-in test with zero object velocity.
+        let still = RssAgent {
+            ego_vel: 18.0,
+            lead_vel: 0.0,
+            actual_longitudinal_gap_m: 12.0,
+            ego_lat_vel: 0.0,
+            obj_lat_vel: 0.0, // laterally still
+            actual_lateral_separation_m: 3.0,
+            oncoming: false,
+        };
+        assert!(
+            compute_scene_rss(&AgentScene::Agents(vec![still]), &params()).safe,
+            "a stationary object 3 m to the side stays admitted inside the widened window"
         );
     }
 


### PR DESCRIPTION
Fixes #684. Fixes #683.

> Handled together because they are the same gate logic (#684 itself recommends it).

## Problem
The RSS §4 **lateral** (side / cut-in) check was gated on a **fixed** longitudinal ceiling `RSS_LONGITUDINAL_CONFLICT_M = 8.0 m`:
```rust
if dx_ego <= RSS_LONGITUDINAL_CONFLICT_M && (lon_unsafe || lateral_cut_in) { … }
```
- **#684:** at highway-adjacent speed a genuine lateral cut-in originating **>8 m** ahead is filtered out before `lateral_safe_distance` is consulted — at the 22.35 m/s ODD cap, reaction-time travel alone is ~11 m.
- **#683:** the same fixed ceiling skips a cut-in in the **2.5–4.0 m lateral band** (above the overlap gate, within the alignment tolerance) once it is >8 m ahead.

## Important deviation from the issue text (please note)
#683 suggested *widening the longitudinal-overlap gate* (`RSS_LONGITUDINAL_OVERLAP_M = 2.5 m`) to the alignment tolerance. **I did not do that** — per the constant's own docs, the 2.5 m gate is the *footprint-overlap width*, kept deliberately narrow so a car centered in the lane can be **overtaken** (the original §4 over-rejection fix). Widening it re-breaks overtaking. Working the geometry, **DC1 and DC2 are the same root cause**: the only genuine risk an in-band object poses is a **cut-in**, which is exactly what the fixed lateral ceiling clips. So one change fixes both. (Approach confirmed before implementing.)

## Fix
Gate the lateral check on a **closing-speed-scaled** window, floored at the 8 m urban minimum, at **both** evaluation sites (snapshot + multi-modal predictive):
```rust
let lat_conflict_window = RSS_LONGITUDINAL_CONFLICT_M.max(lon_required);
if dx_ego <= lat_conflict_window && (lon_unsafe || lateral_cut_in) { … }
```
`lon_required` is already computed and grows with closing speed. The `RSS_LONGITUDINAL_CONFLICT_M` doc is updated to describe it as the **floor** of a scaled window.

## Why it's regression-free (no new over-rejection)
The `(lon_unsafe || lateral_cut_in)` precondition is unchanged, and the **zero-lateral-velocity** required gap is `lat_required(0,0) = 2·a_lat·ρ² ≈ 1.75 m` at the 3.5 m/s² / 0.5 s defaults — **below** the 2.5 m overlap width. So a longitudinally-unsafe but laterally-**still** in-band object (`dy ≥ 2.5 m`) stays admitted; only a real lateral closing (larger `lat_required`) trips it. The narrow overlap gate (overtaking) is untouched.

## Tests (`crates/kirra-ros2-adapter/tests/validation_tests.rs`)
- `high_speed_cut_in_beyond_8m_is_caught_dc2` — 18 m/s ego, cut-in ~12 m ahead at `dy=3 m`: **Accept pre-fix → MRC post-fix** (non-vacuous: pre-fix `dx>8` skips lateral and `dy>2.5` skips longitudinal).
- `stationary_side_object_in_band_beyond_8m_stays_admitted_683` — stationary object 3 m to the side stays admitted inside the widened window.

## Verification
- `cargo test -p kirra-trajectory -p kirra-ros2-adapter -p kirra-planner --locked` — all pass, incl. the overtake / learned-doer-bounded suites (no regression).
- `cargo test -p parko-core` (parko workspace) — pass.
- `cargo clippy --all-targets -- -D warnings …` — clean on all affected crates.

## Acceptance criteria
- #684: lateral ceiling scaled by closing speed; high-speed cut-in test added. ✅
- #683: in-band cut-in risk closed (via the same change); band over-rejection guard added; longitudinal-overlap gate intentionally preserved (rationale above). ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_