### PR TITLE
fix(audit): single authoritative verify verdict so a bad signature can't pass as chain_intact (#690)

### DIFF
--- a/src/bin/kirra_verifier_service/audit.rs
+++ b/src/bin/kirra_verifier_service/audit.rs
@@ -33,9 +33,11 @@ pub(crate) async fn verify_audit_chain(
             // #77 anchor-head high-water mark: detects tail truncation/deletion.
             "head_verified": r.head_verified,
             "head_status": r.head_status,
-            // Overall verdict folds in the head check so a truncated chain
-            // (rows internally consistent but tail deleted) reads as not-verified.
-            "verified": r.chain_intact && r.signature_valid && r.head_verified,
+            // Overall verdict (#690): the single authoritative accessor folds in
+            // hash linkage, signatures, AND the head check, so a truncated chain
+            // (rows internally consistent but tail deleted) or a row with a valid
+            // hash but invalid signature both read as not-verified.
+            "verified": r.verified(),
         })).into_response(),
         Ok(Err(_)) => (StatusCode::INTERNAL_SERVER_ERROR,
                        Json(json!({ "error": "audit chain query failed" }))).into_response(),

--- a/src/bin/kirra_verifier_service/fabric.rs
+++ b/src/bin/kirra_verifier_service/fabric.rs
@@ -256,7 +256,7 @@ pub(crate) async fn verify_causal_chain(
             "public_key_b64": r.public_key_b64,
             "head_verified": r.head_verified,
             "head_status": r.head_status,
-            "verified": r.chain_intact && r.signature_valid && r.head_verified,
+            "verified": r.verified(), // #690: single authoritative verdict
         })).into_response(),
         _ => (StatusCode::INTERNAL_SERVER_ERROR,
                    Json(json!({ "error": "causal chain query failed" }))).into_response(),

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -14,6 +14,11 @@ use crate::federation::FederatedTrustReport;
 use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
 
 pub struct AuditChainVerifyResult {
+    /// Hash-linkage integrity ONLY (recomputed record hash matches, prev-linkage
+    /// unbroken, no sequence gap). NOT sufficient on its own: the record hash does
+    /// not cover the row signature, so a tampered/invalid signature leaves this
+    /// `true` while `signature_valid` is `false` (#690). Gate trust on
+    /// [`verified()`](Self::verified), never on this field alone.
     pub chain_intact: bool,
     pub total_entries: u64,
     pub latest_hash: String,
@@ -36,6 +41,22 @@ pub struct AuditChainVerifyResult {
     pub head_status: String,
 }
 
+impl AuditChainVerifyResult {
+    /// THE authoritative verdict (#690). The chain is trustworthy only if ALL three
+    /// independent checks hold:
+    /// - `chain_intact` — no in-place row edit / broken prev-linkage / sequence gap;
+    /// - `signature_valid` — every signed row verifies under its key (a bad signature,
+    ///   e.g. a failed `KEY_ROTATION` row, sets this `false` even though the hashes
+    ///   still link, since the record hash does not cover the signature);
+    /// - `head_verified` — no tail truncation/deletion (the signed anchor-head matches
+    ///   the chain tail).
+    ///
+    /// Callers MUST gate trust on this, never on `chain_intact` alone.
+    pub fn verified(&self) -> bool {
+        self.chain_intact && self.signature_valid && self.head_verified
+    }
+}
+
 /// Verification verdict for the fabric causal-log forensic chain (#87).
 /// Same shape as [`AuditChainVerifyResult`]: `chain_intact` covers in-place
 /// row edits (recomputed record hash mismatch, broken prev-linkage, sequence
@@ -43,6 +64,11 @@ pub struct AuditChainVerifyResult {
 /// anchor-head high-water mark. Together they cover edit + truncation.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct CausalChainVerifyResult {
+    /// Hash-linkage integrity ONLY (recomputed record hash matches, prev-linkage
+    /// unbroken, no sequence gap). NOT sufficient on its own: the record hash does
+    /// not cover the row signature, so a tampered/invalid signature leaves this
+    /// `true` while `signature_valid` is `false` (#690). Gate trust on
+    /// [`verified()`](Self::verified), never on this field alone.
     pub chain_intact: bool,
     pub total_entries: u64,
     pub latest_hash: String,
@@ -55,6 +81,16 @@ pub struct CausalChainVerifyResult {
     pub public_key_b64: Option<String>,
     pub head_verified: bool,
     pub head_status: String,
+}
+
+impl CausalChainVerifyResult {
+    /// THE authoritative verdict (#690): `chain_intact && signature_valid &&
+    /// head_verified`. Like [`AuditChainVerifyResult::verified`], `chain_intact`
+    /// alone is NOT sufficient — a tampered signature leaves it `true` while
+    /// `signature_valid` is `false`. Gate trust on this.
+    pub fn verified(&self) -> bool {
+        self.chain_intact && self.signature_valid && self.head_verified
+    }
 }
 
 #[derive(serde::Serialize)]

--- a/src/verifier_store/tests.rs
+++ b/src/verifier_store/tests.rs
@@ -1688,6 +1688,42 @@ mod audit_anchor_head_77_tests {
         assert_eq!(r.total_entries, 3);
     }
 
+    /// #690: a row whose SIGNATURE is tampered (its signed payload / record hash
+    /// untouched) leaves the hash chain internally consistent — `chain_intact ==
+    /// true` — but the signature no longer verifies, so the AUTHORITATIVE verdict
+    /// `verified()` must be false. This is exactly the gap a caller keying off
+    /// `chain_intact` alone would miss (the motivating case being a failed
+    /// `KEY_ROTATION` row, which also strands every later row signed by the
+    /// un-absorbed rotated key).
+    #[test]
+    fn tampered_signature_keeps_chain_intact_but_fails_verified_690() {
+        let (mut s, vk) = signed_store();
+        append3(&mut s);
+        // Corrupt ONLY the signature of the middle row (sequence 1) by flipping its
+        // first base64 char to a guaranteed-different one. The record hash does not
+        // cover `signature_b64`, so the hash walk still links cleanly.
+        let changed = s
+            .raw_conn()
+            .execute(
+                "UPDATE audit_log_chain \
+                 SET signature_b64 = CASE WHEN substr(signature_b64,1,1)='A' THEN 'B' ELSE 'A' END \
+                                     || substr(signature_b64, 2) \
+                 WHERE sequence = 1",
+                [],
+            )
+            .unwrap();
+        assert_eq!(changed, 1, "exactly the middle row's signature was altered");
+
+        let r = s.verify_audit_chain_full(Some(&vk)).unwrap();
+        assert!(r.chain_intact, "hash linkage is untouched — chain_intact stays true");
+        assert!(!r.signature_valid, "the tampered signature must fail to verify");
+        assert!(
+            !r.verified(),
+            "the authoritative verdict folds in signatures → a hash-intact, bad-signature chain is NOT verified"
+        );
+        assert!(r.first_invalid_signature_index.is_some(), "the offending row is named");
+    }
+
     /// EMPTY chain → no head required, clean.
     #[test]
     fn empty_chain_needs_no_head() {


### PR DESCRIPTION
Fixes #690.

## Problem
`verify_audit_chain_full` (and the fabric `verify_causal_chain_integrity`) return `chain_intact`, `signature_valid`, and `head_verified` as **separate** fields. `chain_intact` is hash-linkage only, and the record hash does **not** cover the row signature — so a tampered/invalid signature (the motivating case: a failed `KEY_ROTATION` row, which the keyring then doesn't absorb, stranding every later row signed by the rotated key as "unknown key") leaves `chain_intact == true` while `signature_valid == false`. Any caller gating trust on `chain_intact` alone would miss it.

## Fix
- Add an authoritative **`verified()`** accessor to both `AuditChainVerifyResult` and `CausalChainVerifyResult`:
  ```rust
  pub fn verified(&self) -> bool { self.chain_intact && self.signature_valid && self.head_verified }
  ```
  with a doc comment explaining all three independent checks (in-place edit, signatures, truncation) must hold.
- Document the `chain_intact` field as **NOT sufficient on its own**, pointing at `verified()`.
- Route the two HTTP verify handlers (`/system/audit/verify` and the fabric causal verify) through `r.verified()` instead of inlining `chain_intact && signature_valid && head_verified`. The individual fields stay in the JSON response for diagnostics.

No behavior change for the HTTP endpoints (they already inlined the conjunction) — the value is the **single canonical verdict** that removes the foot-gun for any future caller.

## Test
`tampered_signature_keeps_chain_intact_but_fails_verified_690`: corrupts a row's `signature_b64` in place (record hash untouched), then asserts `chain_intact == true`, `signature_valid == false`, and **`verified() == false`** (plus the offending row is named).

## Verification
- `cargo test -p kirra-verifier --locked` — all pass (642 lib + integration; new test green).
- `cargo clippy -p kirra-verifier --all-targets --locked -- -D warnings …` — clean.

## Acceptance criteria
- [x] A test with a tampered signature asserts the overall verdict is failure even though hash links are intact.
- [x] No production caller treats `chain_intact` as sufficient on its own (both handlers use `verified()`; the field is documented as insufficient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_