### PR TITLE
ci: make cargo audit gating so advisories fail the build (#687)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,18 @@ jobs:
         # fail-closed transport guards, so a clean chart lints green.
         run: helm lint helm/kirra 2>&1 | tee helm-lint-report.txt
       - name: Dependency audit
-        run: cargo audit 2>&1 | tee audit-report.txt
+        # GATING (#687): `set -o pipefail` so `cargo audit`'s non-zero exit (a
+        # RUSTSEC advisory against a workspace dependency) FAILS the job — the
+        # `tee` pipe would otherwise return tee's exit code and mask it. Made
+        # explicit so the gate does not depend on the runner's implicit bash
+        # defaults or a future `shell:`/`defaults.run` override. The report is
+        # still captured for the `if: always()` upload step below, so a failing
+        # run still publishes the advisory details as an artifact. To accept a
+        # specific advisory deliberately, add an ignore entry in `.cargo/audit.toml`
+        # rather than removing this gate.
+        run: |
+          set -o pipefail
+          cargo audit 2>&1 | tee audit-report.txt
       - name: Upload reports
         uses: actions/upload-artifact@v7
         if: always()


### PR DESCRIPTION
Fixes #687.

## Problem
The `Dependency audit` step ran:
```yaml
run: cargo audit 2>&1 | tee audit-report.txt
```
Under `bash -e` **without** `pipefail`, a pipeline's exit code is that of the **last** command (`tee`, which returns 0), so `cargo audit`'s non-zero exit on a RUSTSEC advisory was masked — the audit was informational only.

## Fix
```yaml
run: |
  set -o pipefail
  cargo audit 2>&1 | tee audit-report.txt
```
`set -o pipefail` makes the pipeline fail when `cargo audit` fails, so a workspace advisory now fails the job. Made **explicit** rather than relying on GitHub's implicit bash default (which may or may not enable `pipefail`, and could change with a runner update or a future `shell:`/`defaults.run` override). The `Upload reports` step is `if: always()`, so a failing run still publishes `audit-report.txt` as an artifact. The escape hatch for deliberately accepting a specific advisory is `.cargo/audit.toml` (documented inline), not removing the gate.

## Verification
- **Shell semantics proven locally:**
  - `bash -e -c 'false | tee /dev/null; echo $?'` → prints `0` (failure masked — the bug)
  - `bash -e -c 'set -o pipefail; false | tee /dev/null'` → pipeline fails, `-e` aborts (rc=1 — the fix)
- YAML parses; all 10 jobs intact.

## Heads-up
I could **not** pre-check the current advisory state locally — `cargo audit` was installed, but fetching the RustSec advisory DB is blocked in this sandbox (HTTP 403 via the proxy); it works on GitHub's runners. So **the first gated CI run will surface any pre-existing advisory** in `Cargo.lock`. That is the gate working as intended — if it flags something, either bump the dependency or add a scoped `.cargo/audit.toml` ignore (with a rationale). Worth watching this PR's `static-analysis` job.

## Scope note
This is the core gating fix (issue acceptance: "a RUSTSEC advisory fails the CI job"). The optional `deny.toml` + `cargo deny` (bans/sources/licenses) from #687's secondary bullet (BD3) is deferred — it's a larger, policy-laden change that deserves its own PR.

## Acceptance criteria
- [x] A RUSTSEC advisory against a workspace dependency fails the CI job.
- [ ] (Optional) `deny.toml` + `cargo deny` — deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_