### PR TITLE
build: digest-pin all runtime container base images (#686, M-7 half)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,11 @@
 # gateway image + one target-parameterized backend flow.
 
 # ── Stage 1: build ───────────────────────────────────────────────────────────
-FROM rust:1-alpine AS builder
+# #686: digest-pinned (multi-arch index digest) so the build is reproducible and
+# a re-tagged upstream image can't silently change the build. The `:1-alpine` tag
+# is kept for readability; the `@sha256:` digest is authoritative. Bumped by
+# Dependabot (docker ecosystem) — see .github/dependabot.yml.
+FROM rust:1-alpine@sha256:f87aa870663e2b57ec8c69de82c7eedf7383bee987eef7612c0359635eaadb41 AS builder
 
 RUN apk add --no-cache musl-dev gcc
 
@@ -24,7 +28,8 @@ COPY . .
 RUN cargo build --release --bin kirra_verifier_service
 
 # ── Stage 2: runtime ─────────────────────────────────────────────────────────
-FROM alpine:3
+# #686: digest-pinned (see Stage 1). Bumped by Dependabot (docker ecosystem).
+FROM alpine:3@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 RUN apk add --no-cache curl && \
     addgroup -S -g 1000 kirra && \

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,11 +1,13 @@
-FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
+# #686: digest-pinned base image (Dependabot `docker` bumps it). Tag kept for readability.
+FROM --platform=$BUILDPLATFORM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
 WORKDIR /app
 COPY package.json ./
 RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginx:alpine
+# #686: digest-pinned base image (Dependabot `docker` bumps it).
+FROM nginx:alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa
 COPY --from=builder /app/dist /usr/share/nginx/html
 EXPOSE 80
 HEALTHCHECK --interval=10s --timeout=3s \

--- a/deploy/docker/Dockerfile.native
+++ b/deploy/docker/Dockerfile.native
@@ -1,10 +1,12 @@
-FROM rust:1.96-slim-bookworm AS builder
+# #686: digest-pinned base image (Dependabot `docker` bumps it). Tag kept for readability.
+FROM rust:1.96-slim-bookworm@sha256:4732ca96fd086cb9be682050c3f0176288eebaac2b80aa2bcefccfaf198e1950 AS builder
 
 WORKDIR /build
 COPY . .
 RUN cargo build --release
 
-FROM debian:bookworm-slim
+# #686: digest-pinned base image (Dependabot `docker` bumps it).
+FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/deploy/docker/Dockerfile.parko-ort-cpu
+++ b/deploy/docker/Dockerfile.parko-ort-cpu
@@ -16,7 +16,8 @@
 # configure and no posture config file is added.
 
 # =============================== BUILD STAGE ===============================
-FROM ros:jazzy-ros-base AS build
+# #686: digest-pinned base image (Dependabot `docker` bumps it).
+FROM ros:jazzy-ros-base@sha256:6513503d0b10e919fbe8134981d4f9d19b5c1f9b045b87a9fe3b0b9e03e7c2a9 AS build
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -75,7 +76,8 @@ RUN set -euo pipefail; \
 
 # ============================== RUNTIME STAGE ==============================
 # ros:jazzy-ros-base again — r2r needs rcl/rmw/typesupport at runtime.
-FROM ros:jazzy-ros-base AS runtime
+# #686: digest-pinned base image (Dependabot `docker` bumps it).
+FROM ros:jazzy-ros-base@sha256:6513503d0b10e919fbe8134981d4f9d19b5c1f9b045b87a9fe3b0b9e03e7c2a9 AS runtime
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Addresses the **digest-pinning half** of #686 (SECURITY.md M-7). Does **not** fully close #686 — see "Remaining" below — so no `Fixes:` keyword.

## What this does
Pins every **runtime** Dockerfile `FROM` to an immutable multi-arch **index digest**, keeping the readable tag alongside (`image:tag@sha256:…`):

| File | Images pinned |
|------|---------------|
| `Dockerfile` | `rust:1-alpine`, `alpine:3` |
| `dashboard/Dockerfile` | `node:20-alpine`, `nginx:alpine` |
| `deploy/docker/Dockerfile.native` | `rust:1.96-slim-bookworm`, `debian:bookworm-slim` |
| `deploy/docker/Dockerfile.parko-ort-cpu` | `ros:jazzy-ros-base` (build + runtime) |

Every digest was **resolved against the live registry** with `docker buildx imagetools inspect` (the index digest, so all platforms still resolve) — none are guessed. This makes builds reproducible and stops a re-tagged upstream image from silently changing a build. Dependabot's `docker` ecosystem (already configured) refreshes them via PRs.

`.cursor/Dockerfile` is intentionally left unpinned — it's the Cursor dev container, outside M-7's runtime-image scope.

## Remaining for #686 (the GitHub Actions SHA-pinning half)
This half is **already tooled** — `scripts/pin-actions.sh` (with `--check`), `.github/dependabot.yml` (`github-actions`), and SECURITY.md M-6 — but I **could not apply it here**: `pin-actions.sh` resolves tags via `git ls-remote https://github.com/…`, and this build sandbox blocks github.com egress (HTTP 403); the GitHub MCP is scoped to this repo only. The script itself documents this. **I won't fabricate commit SHAs**, so the action pins must be applied from a network-enabled environment:

```
scripts/pin-actions.sh        # run in CI or on a maintainer host (needs github.com egress)
# commit the rewritten workflows, then:
scripts/pin-actions.sh --check  # wire into CI as the enforcement gate
```

## Verification
- All 8 runtime `FROM` lines now carry `@sha256:` digests (verified by grep); digests resolved live, not guessed.
- No code/test changes; Dockerfile syntax (`image:tag@sha256:…`) is standard. Could not `docker build` here (image pulls blocked), but the digests are the registry's current index digests.

## Suggested follow-up
A tiny issue to "run pin-actions.sh + wire `--check` into CI" so the Actions half isn't lost — I can file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_