### PR TITLE
fix(persistence): surface stale-generation rejection from save_last_generation (#695)

### DIFF
--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -243,7 +243,20 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
             ts,
         ) {
             Ok(()) => {
-                let _ = store.save_last_generation(generation);
+                // #695: a `false` here means the generation high-water rejected this
+                // write as stale. In normal operation that's a benign concurrent-
+                // recalc race (another recalc already persisted a higher generation),
+                // so it is logged at debug; a PERSISTENT rejection of the latest
+                // generation would indicate a regression/time-reversal worth
+                // investigating. An Err is a real DB failure.
+                match store.save_last_generation(generation) {
+                    Ok(true) => {}
+                    Ok(false) => tracing::debug!(
+                        generation,
+                        "Generation high-water rejected a stale persist (benign race unless persistent) — #695"
+                    ),
+                    Err(e) => tracing::error!(error = %e, generation, "Failed to persist last generation"),
+                }
                 true
             }
             // SAFETY: SG-HA-4 — DB errors demote node to safe state (fail-closed).

--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -249,13 +249,27 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
                 // so it is logged at debug; a PERSISTENT rejection of the latest
                 // generation would indicate a regression/time-reversal worth
                 // investigating. An Err is a real DB failure.
+                //
+                // We deliberately DO NOT fail the transition closed on this Err
+                // (unlike the audit-chain write below, SG-HA-4). Failing closed
+                // here would not restore the cross-restart monotonicity invariant
+                // anyway: the in-memory `generation` was already claimed by
+                // `next_generation()` (an irreversible `fetch_add`) AND the audit
+                // chain above already committed durably AT this generation. So the
+                // persisted high-water is equally behind whether we proceed or
+                // suppress — suppressing only drops a live, already-audited posture
+                // transition (possibly a safety ESCALATION), which is the wrong
+                // trade. The high-water is a self-healing monotonic max-write (the
+                // next successful recalc re-persists it), and a SYSTEMIC DB failure
+                // is still caught fail-closed by the audit-chain write on the next
+                // cycle. So: log loudly and let the live broadcast proceed.
                 match store.save_last_generation(generation) {
                     Ok(true) => {}
                     Ok(false) => tracing::debug!(
                         generation,
                         "Generation high-water rejected a stale persist (benign race unless persistent) — #695"
                     ),
-                    Err(e) => tracing::error!(error = %e, generation, "Failed to persist last generation"),
+                    Err(e) => tracing::error!(error = %e, generation, "Failed to persist last generation (high-water self-heals on next recalc; live transition not suppressed) — #695"),
                 }
                 true
             }

--- a/src/verifier_store/posture.rs
+++ b/src/verifier_store/posture.rs
@@ -167,20 +167,30 @@ impl VerifierStore {
         }
     }
 
-    pub fn save_last_generation(&self, generation: u64) -> Result<()> {
+    /// Persist the posture generation high-water mark, monotonically.
+    ///
+    /// Returns `Ok(true)` if `generation` was PERSISTED (it was strictly greater
+    /// than the stored value, or the row was created), `Ok(false)` if it was
+    /// REJECTED as stale/regressing (a lower-or-equal generation). #695: the
+    /// monotonic UPSERT silently no-ops on a stale write, so returning the
+    /// rows-affected lets the caller distinguish a benign concurrent-recalc race
+    /// from a genuine generation regression/time-reversal it may want to log.
+    pub fn save_last_generation(&self, generation: u64) -> Result<bool> {
         // Monotonic max-write: never persist a generation lower than the one
         // already stored. Concurrent recalculations each claim a generation
         // then race to persist; a blind INSERT OR REPLACE let a slower thread
         // overwrite a higher value with its lower one, regressing the
         // cross-restart monotonicity that federation peers depend on.
-        self.conn.execute(
+        let changed = self.conn.execute(
             "INSERT INTO posture_engine_state (key, value)
              VALUES ('last_generation', ?1)
              ON CONFLICT(key) DO UPDATE SET value = ?1
              WHERE CAST(?1 AS INTEGER) > CAST(value AS INTEGER)",
             params![generation.to_string()],
         )?;
-        Ok(())
+        // `changed` is 1 when the row was inserted (first write) or updated
+        // (strictly-greater generation), 0 when the `WHERE` rejected a stale write.
+        Ok(changed > 0)
     }
 
     /// Reads an arbitrary key from the posture_engine_state key-value store.

--- a/src/verifier_store/tests.rs
+++ b/src/verifier_store/tests.rs
@@ -121,6 +121,24 @@ mod attestation_registry_tests {
         store.save_last_generation(42).unwrap();
         assert_eq!(store.load_last_generation().unwrap(), 42);
     }
+
+    /// #695: save_last_generation reports whether the write was ACCEPTED, so a
+    /// caller can distinguish a persisted generation from one rejected as stale.
+    #[test]
+    fn test_save_last_generation_reports_acceptance() {
+        let store = in_memory();
+        // First write creates the row → accepted.
+        assert!(store.save_last_generation(10).unwrap(), "first write must be accepted");
+        // Strictly greater → accepted.
+        assert!(store.save_last_generation(11).unwrap(), "a higher generation is accepted");
+        assert_eq!(store.load_last_generation().unwrap(), 11);
+        // Lower → REJECTED (returns false), high-water unchanged.
+        assert!(!store.save_last_generation(5).unwrap(), "a lower generation is rejected");
+        assert_eq!(store.load_last_generation().unwrap(), 11, "stale write must not regress the high-water");
+        // Equal → REJECTED (strict > required).
+        assert!(!store.save_last_generation(11).unwrap(), "an equal generation is rejected (strict >)");
+        assert_eq!(store.load_last_generation().unwrap(), 11);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #695.

## Problem
`save_last_generation` uses a monotonic UPSERT (`… WHERE CAST(?1) > CAST(value)`) but always returned `Ok(())` — whether the generation was persisted **or** silently rejected as stale (a lower-or-equal value). A caller could not tell a successful write from a generation regression / time-reversal it might want to log or escalate.

## Fix
Return `Result<bool>`: `true` when persisted (row created, or strictly-greater update), `false` when rejected (rows-affected `== 0`). The recalc caller now matches on the result and logs a rejection at `debug!` — in normal operation that's a benign concurrent-recalc race (another recalc already persisted a higher generation); a *persistent* rejection of the latest generation would point at a real regression.

All existing callers use `.unwrap()` (the discarded value is now `bool` instead of `()`), so they compile unchanged.

## Test
`test_save_last_generation_reports_acceptance`: first and strictly-greater writes return `true`; lower and equal writes return `false` and leave the high-water unchanged.

## Verification
- `cargo test -p kirra-verifier --lib` — pass (new test green; existing `test_generation_persistence` unchanged).
- `cargo clippy -p kirra-verifier --lib --locked -- -D warnings …` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_