### PR TITLE
fix(http): CORS preflight passes the posture gate + configurable origins (#696)

### DIFF
--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -1498,12 +1498,26 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
         let base = CorsLayer::new().allow_methods(Any).allow_headers(Any);
         match std::env::var("KIRRA_CORS_ALLOWED_ORIGINS") {
             Ok(v) if !v.trim().is_empty() => {
-                let origins: Vec<axum::http::HeaderValue> = v
-                    .split(',')
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty())
-                    .filter_map(|s| s.parse::<axum::http::HeaderValue>().ok())
-                    .collect();
+                // Partition rather than silently dropping: an UNPARSEABLE token is a
+                // likely typo, and silently discarding it would let a misconfigured
+                // allowlist look healthy in production. Collect the rejects and log
+                // them explicitly so the misconfiguration is visible (Copilot #710).
+                let mut origins: Vec<axum::http::HeaderValue> = Vec::new();
+                let mut invalid: Vec<&str> = Vec::new();
+                for tok in v.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+                    match tok.parse::<axum::http::HeaderValue>() {
+                        Ok(hv) => origins.push(hv),
+                        Err(_) => invalid.push(tok),
+                    }
+                }
+                if !invalid.is_empty() {
+                    tracing::warn!(
+                        invalid = ?invalid,
+                        accepted = origins.len(),
+                        "KIRRA_CORS_ALLOWED_ORIGINS contained unparseable origin(s) — \
+                         dropped (likely a typo); the remaining origins are enforced"
+                    );
+                }
                 if origins.is_empty() {
                     tracing::error!(
                         value = %v,

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -1487,10 +1487,36 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
         .route("/fleet/flapping/{node_id}", get(get_node_flap_status))
         .route("/federation/reports/{asset_id}", get(get_federated_reports));
 
-    let cors = CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods(Any)
-        .allow_headers(Any);
+    // #696 (HT2): origins are restrictable to a configured allowlist via
+    // `KIRRA_CORS_ALLOWED_ORIGINS` (comma-separated). Default is `Any`
+    // (back-compat); auth is `Authorization: Bearer` (no cookies / no
+    // `allow_credentials`), so `Any` is not a CSRF vector — the allowlist is
+    // defense-in-depth controlling which web origins may READ responses. A set
+    // env with no parseable origin yields an empty allowlist (deny cross-origin),
+    // logged — fail-closed rather than silently reverting to permissive.
+    let cors = {
+        let base = CorsLayer::new().allow_methods(Any).allow_headers(Any);
+        match std::env::var("KIRRA_CORS_ALLOWED_ORIGINS") {
+            Ok(v) if !v.trim().is_empty() => {
+                let origins: Vec<axum::http::HeaderValue> = v
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .filter_map(|s| s.parse::<axum::http::HeaderValue>().ok())
+                    .collect();
+                if origins.is_empty() {
+                    tracing::error!(
+                        value = %v,
+                        "KIRRA_CORS_ALLOWED_ORIGINS set but no valid origin parsed — \
+                         denying all cross-origin requests (fail-closed)"
+                    );
+                }
+                base.allow_origin(origins)
+            }
+            // Unset / empty → permissive default (unchanged behaviour).
+            _ => base.allow_origin(Any),
+        }
+    };
 
     // Operator console — Phase A (#103 SG6). Reads are QM; the one mutation
     // (clearance-grant recording) is gated by the supervisor key IN the handler,

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -544,13 +544,25 @@ pub async fn enforce_posture_routing(
         return Ok(next.run(req).await);
     }
 
-    // #696 (HT1): let a CORS preflight (OPTIONS) through to the CorsLayer. A
-    // preflight carries no command and no body and authorizes nothing — the
-    // ACTUAL method (GET/POST/…) still hits this gate on the real request. Without
-    // this bypass, `classify_http_command` maps OPTIONS to `Unknown` (denied in
-    // every posture), so this OUTERMOST gate 503s every browser preflight to a
-    // non-exempt path. Not a posture/auth relaxation: nothing actionable runs.
-    if req.method() == axum::http::Method::OPTIONS {
+    // #696 (HT1): let a CORS preflight through to the CorsLayer. A preflight
+    // carries no command and no body and authorizes nothing — the ACTUAL method
+    // (GET/POST/…) still hits this gate on the real request. Without this bypass,
+    // `classify_http_command` maps OPTIONS to `Unknown` (denied in every posture),
+    // so this OUTERMOST gate 503s every browser preflight to a non-exempt path.
+    // Not a posture/auth relaxation: nothing actionable runs.
+    //
+    // Scope the bypass to an ACTUAL CORS preflight — OPTIONS *plus* both the
+    // `Origin` and `Access-Control-Request-Method` headers a browser preflight
+    // always sends (CORS spec §4.8). A bare OPTIONS without those headers is not a
+    // preflight and stays subject to the posture gate, so the exemption can't
+    // widen into a hole if a route ever serves OPTIONS via `any(...)` /
+    // `MethodFilter::all` (Copilot PR #710).
+    let is_cors_preflight = req.method() == axum::http::Method::OPTIONS
+        && req.headers().contains_key(axum::http::header::ORIGIN)
+        && req
+            .headers()
+            .contains_key(axum::http::header::ACCESS_CONTROL_REQUEST_METHOD);
+    if is_cors_preflight {
         return Ok(next.run(req).await);
     }
 

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -544,6 +544,16 @@ pub async fn enforce_posture_routing(
         return Ok(next.run(req).await);
     }
 
+    // #696 (HT1): let a CORS preflight (OPTIONS) through to the CorsLayer. A
+    // preflight carries no command and no body and authorizes nothing — the
+    // ACTUAL method (GET/POST/…) still hits this gate on the real request. Without
+    // this bypass, `classify_http_command` maps OPTIONS to `Unknown` (denied in
+    // every posture), so this OUTERMOST gate 503s every browser preflight to a
+    // non-exempt path. Not a posture/auth relaxation: nothing actionable runs.
+    if req.method() == axum::http::Method::OPTIONS {
+        return Ok(next.run(req).await);
+    }
+
     let method = req.method().as_str();
     let cmd = classify_http_command(method, path);
 

--- a/tests/posture_gate_integration.rs
+++ b/tests/posture_gate_integration.rs
@@ -131,6 +131,23 @@ async fn req_status(app: Router, method: &str, path: &str) -> StatusCode {
         .status()
 }
 
+// An OPTIONS request carrying the two headers a browser CORS preflight always
+// sends (`Origin` + `Access-Control-Request-Method`) — what the posture-gate
+// bypass keys on (#696 / Copilot PR #710).
+async fn options_preflight_status(app: Router, path: &str) -> StatusCode {
+    let req = Request::builder()
+        .method("OPTIONS")
+        .uri(path)
+        .header("origin", "https://dashboard.example")
+        .header("access-control-request-method", "GET")
+        .body(Body::empty())
+        .expect("build request");
+    app.oneshot(req)
+        .await
+        .expect("router service should not panic")
+        .status()
+}
+
 // ---------------------------------------------------------------------------
 // 1. Unknown METHOD on any gated route → 503 (fail-closed) regardless of
 // posture. Confirms the SG-006 invariant ("Unknown denied in all postures
@@ -170,11 +187,35 @@ async fn test_options_preflight_not_blocked_by_posture_gate() {
         FleetPosture::LockedOut,
     ] {
         let svc = build_state_with_posture(posture);
-        let status = req_status(build_test_app(svc), "OPTIONS", "/fleet/posture").await;
+        let status = options_preflight_status(build_test_app(svc), "/fleet/posture").await;
         assert_ne!(
             status,
             StatusCode::SERVICE_UNAVAILABLE,
             "a CORS preflight (OPTIONS) must pass the posture gate in {posture:?}, not 503; got {status}"
+        );
+    }
+}
+
+// #696 / Copilot PR #710: the bypass is scoped to an ACTUAL preflight. A bare
+// OPTIONS WITHOUT the preflight headers is not a CORS preflight and must stay
+// subject to the posture gate (OPTIONS classifies as Unknown → 503 in every
+// posture), so the exemption can't widen into a posture-gate hole if a route
+// ever serves OPTIONS directly.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_bare_options_without_preflight_headers_is_gated() {
+    for posture in [
+        FleetPosture::Nominal,
+        FleetPosture::Degraded,
+        FleetPosture::LockedOut,
+    ] {
+        let svc = build_state_with_posture(posture);
+        let status = req_status(build_test_app(svc), "OPTIONS", "/fleet/posture").await;
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a non-preflight OPTIONS must remain posture-gated in {posture:?}; got {status}"
         );
     }
 }

--- a/tests/posture_gate_integration.rs
+++ b/tests/posture_gate_integration.rs
@@ -155,6 +155,31 @@ async fn test_unknown_method_returns_503_under_any_posture() {
 }
 
 // ---------------------------------------------------------------------------
+// #696 (HT1): a CORS preflight (OPTIONS) must NOT be 503'd by the posture gate
+// — it carries no command and authorizes nothing, and must reach the CorsLayer.
+// Before the fix, OPTIONS classified as Unknown → 503 in every posture. The test
+// app has no CorsLayer, so a gate-passed OPTIONS reaches the router and 405s
+// (no OPTIONS handler) — the point is only that it is NOT the gate's 503.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_options_preflight_not_blocked_by_posture_gate() {
+    for posture in [
+        FleetPosture::Nominal,
+        FleetPosture::Degraded,
+        FleetPosture::LockedOut,
+    ] {
+        let svc = build_state_with_posture(posture);
+        let status = req_status(build_test_app(svc), "OPTIONS", "/fleet/posture").await;
+        assert_ne!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a CORS preflight (OPTIONS) must pass the posture gate in {posture:?}, not 503; got {status}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 2. Cold start (posture_cache = None): a functional READ is denied 503;
 // /health is exempt and still passes (200).
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #696.

## HT1 — preflight no longer 503'd (the functional bug)
`enforce_posture_routing` is the **outermost** layer (wraps `CorsLayer`), so a browser's CORS preflight (`OPTIONS`) hits it first. `classify_http_command` maps `OPTIONS` to `Unknown` → denied in every posture → **503**, so preflight to any non-exempt path fails. Added an `OPTIONS` bypass right after the posture-exempt check: a preflight carries no command and authorizes nothing — it must reach the `CorsLayer` — and the **actual** method (GET/POST/…) still hits the gate on the real request. Not a posture/auth relaxation.

## HT2 — origins restrictable to an allowlist
`KIRRA_CORS_ALLOWED_ORIGINS` (comma-separated) now configures the allowed origins. **Default stays `Any`** (back-compat). Auth is `Authorization: Bearer` (no cookies, no `allow_credentials`), so `Any` is not a CSRF vector — the allowlist is defense-in-depth over which web origins may *read* responses. A set-but-unparseable value yields an empty allowlist (deny cross-origin) with an `error!` log — fail-closed rather than silently permissive.

## Test
`test_options_preflight_not_blocked_by_posture_gate` (in `tests/posture_gate_integration.rs`, which mounts the real gate): `OPTIONS` to a non-exempt path is **not** 503'd in any posture. (The test app has no `CorsLayer`, so a gate-passed OPTIONS reaches the router and 405s — the point is only that it is no longer the gate's 503.)

## Verification
- `cargo build -p kirra-verifier --bin kirra_verifier_service` — compiles (CORS env branch).
- `cargo test -p kirra-verifier --test posture_gate_integration` — pass (new test green; existing gate tests unchanged).
- `cargo clippy -p kirra-verifier --bins --lib --locked -- -D warnings …` — clean.

## Acceptance criteria
- [x] Browser preflight to non-exempt paths succeeds (HT1).
- [x] CORS origins restricted to a configured allowlist (HT2, via `KIRRA_CORS_ALLOWED_ORIGINS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_