### PR TITLE
Reject hidden trailing bytes in non-size-indicated CANopen SDO downloads (#694)

### DIFF
--- a/src/adapters/canopen.rs
+++ b/src/adapters/canopen.rs
@@ -276,8 +276,19 @@ impl CanOpenAdapter {
             .expedited_value
             .ok_or("CANOPEN_SDO_SEGMENTED_UNBOUNDABLE")?;
         // Cross-check the frame's declared width against the configured type.
+        let w = spec.ty.width();
         if let Some(indicated) = dl.indicated_width {
-            if indicated != spec.ty.width() {
+            if indicated != w {
+                return Err("CANOPEN_SDO_WIDTH_MISMATCH");
+            }
+        } else {
+            // #694: s=0 (size NOT indicated). The frame declares no value width,
+            // so `decode_le` would read only the leading `w` bytes and silently
+            // ignore the rest — letting an attacker smuggle hidden, device-
+            // interpretable bytes past `[w..]` while the bounded prefix stays
+            // benign. Fail closed: any non-zero byte beyond the configured type
+            // width is an undeclared payload, never faithfully bound here.
+            if value.len() > w && value[w..].iter().any(|&b| b != 0) {
                 return Err("CANOPEN_SDO_WIDTH_MISMATCH");
             }
         }
@@ -473,6 +484,45 @@ mod sdo_bounds_tests {
             CanOpenAdapter::bound_sdo_download(&msg, &b),
             Err("CANOPEN_SDO_UNDECODABLE")
         );
+    }
+
+    #[test]
+    fn s0_hidden_trailing_bytes_past_configured_width_are_denied() {
+        // #694: NON-size-indicated (s=0) expedited download. The configured type
+        // is i16 (width 2). The leading 2 value bytes are a benign in-range 100,
+        // but bytes [2..4] carry undeclared attacker-controlled data. `decode_le`
+        // reads only the leading width and would silently ignore the rest, so the
+        // bound must reject the hidden payload as a width mismatch.
+        let b = bounds("5:0x6042:0=i16:-500:500", false);
+        let idx = 0x6042u16.to_le_bytes();
+        // ccs=1, e=1, s=0 → command byte 0x22; value = 100 (LE) + hidden 0xFFFF.
+        let msg = CanOpenMessage {
+            node_id: 5,
+            function_code: 0xA,
+            data: vec![0x22, idx[0], idx[1], 0x00, 0x64, 0x00, 0xFF, 0xFF],
+            source_node: "rtu-1".into(),
+        };
+        assert_eq!(
+            CanOpenAdapter::bound_sdo_download(&msg, &b),
+            Err("CANOPEN_SDO_WIDTH_MISMATCH")
+        );
+    }
+
+    #[test]
+    fn s0_zero_padded_trailing_bytes_are_admitted() {
+        // #694 companion: an s=0 expedited frame whose bytes beyond the configured
+        // width are all zero carries no hidden payload — the in-range setpoint is
+        // still admitted (the check fails closed only on a NON-zero tail).
+        let b = bounds("5:0x6042:0=i16:-500:500", false);
+        let idx = 0x6042u16.to_le_bytes();
+        // ccs=1, e=1, s=0 → 0x22; value = 100 (LE) then zero padding to 8 bytes.
+        let msg = CanOpenMessage {
+            node_id: 5,
+            function_code: 0xA,
+            data: vec![0x22, idx[0], idx[1], 0x00, 0x64, 0x00, 0x00, 0x00],
+            source_node: "rtu-1".into(),
+        };
+        assert_eq!(CanOpenAdapter::bound_sdo_download(&msg, &b), Ok(()));
     }
 }
 


### PR DESCRIPTION
Closes #694 (finding HA1, Medium).

## Problem
For a configured SDO target, `bound_sdo_download` only cross-checks the frame's declared width against the configured type when the command byte's size bit is set (`s=1`, `indicated_width = Some(..)`). On the `s=0` (non-size-indicated) path — a normal, spec-valid expedited download — there was no width check at all. `BoundSpec::check` → `ScalarType::decode_le` reads only the leading `spec.ty.width()` bytes and silently ignores the rest, so a 4-byte payload against a configured `i16` is bounded on the first 2 bytes while **2 attacker-controlled bytes pass unvalidated** with no `WIDTH_MISMATCH`.

## Fix
On the `s=0` branch, fail closed: any **non-zero** byte beyond the configured type width is treated as an undeclared, device-interpretable payload and denied with `CANOPEN_SDO_WIDTH_MISMATCH`, mirroring the existing `s=1` rejection.

### Why "trailing bytes must be zero" rather than "length must equal width"
The issue's recommendation was to require the value-region length to equal the configured width. But CAN SDO frames are always 8 bytes on the wire, so the expedited value region (`data[4..]`) is *always* 4 bytes regardless of the target type. A strict length-equality check would therefore deny **every** legitimate `s=0` write to any sub-4-byte type (`i8`/`u8`/`i16`/`u16`). The zero-tail rule satisfies the acceptance criterion (hidden non-zero trailing bytes are denied) while still admitting the normal zero-padded frame.

## Tests
- `s0_hidden_trailing_bytes_past_configured_width_are_denied` — `i16` target, benign in-range leading value + `0xFFFF` hidden tail → `CANOPEN_SDO_WIDTH_MISMATCH`.
- `s0_zero_padded_trailing_bytes_are_admitted` — same value, zero-padded tail → `Ok(())`.

All 32 `adapters::canopen` tests pass; `cargo clippy -p kirra-verifier --lib` clean. The Nominal WCET-critical paths are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_