### PR TITLE
Resolve cargo-audit high advisories: bump quinn-proto + document lz4_flex exception (#713)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,26 @@
+# cargo-audit configuration (read by the CI "Dependency audit" gate; see
+# .github/workflows/ci.yml). Ignored advisories are EXPLICIT, TRACKED exceptions
+# — never a way to silence the gate wholesale. Each entry MUST carry a rationale
+# and a tracking issue, and MUST be revisited on every dependency bump.
+#
+# Vulnerabilities with an in-range upgrade are FIXED by bumping, not ignored:
+#   - RUSTSEC-2026-0185 (quinn-proto): fixed by Cargo.lock bump to 0.11.15.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2026-0041 — lz4_flex 0.10.0: "Decompressing invalid data can leak
+    # information from uninitialized memory or reused output buffer" (high, 8.2).
+    # Pulled ONLY transitively by zenoh-transport 1.9.0, which pins
+    # `lz4_flex ^0.10.0`. The fix versions (>=0.11.6) are OUT of that range, so
+    # there is no in-semver-range upgrade, and 1.9.0 is the latest zenoh release
+    # (nothing newer relaxes the pin) — i.e. no fix is reachable without an
+    # upstream zenoh change or a forked [patch].
+    #
+    # Exposure is bounded: lz4 is used for zenoh transport-frame decompression of
+    # fleet peers, and the federation payloads it carries are Ed25519-authenticated
+    # at the application layer — a crafted frame yields a report that fails
+    # signature verification, not a leak reflected back to the attacker.
+    #
+    # Tracked in #713. REMOVE this entry once zenoh bumps lz4_flex to a fixed line.
+    "RUSTSEC-2026-0041",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,9 +3081,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
Closes #713.

The `Static Analysis (ISO 26262)` cargo-audit gate has been failing **repo-wide** (every open PR + `main`) on two recently-published high RUSTSEC advisories in transitive `zenoh-transport` dependencies. This unblocks it.

## quinn-proto — real fix
[RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) (0.11.14, remote memory exhaustion from unbounded out-of-order stream reassembly, 7.5 high). The fix (`>=0.11.15`) is an in-semver-range patch — bumped via `cargo update -p quinn-proto` (Cargo.lock only).

## lz4_flex — documented, tracked exception
[RUSTSEC-2026-0041](https://rustsec.org/advisories/RUSTSEC-2026-0041) (0.10.0, decompression info-leak, 8.2 high). **No in-range fix exists:** `zenoh-transport 1.9.0` pins `lz4_flex ^0.10.0`, the fix line is `>=0.11.6`, and 1.9.0 is the latest zenoh release — so there's no reachable upgrade without an upstream zenoh change or a forked `[patch]`.

Added a rationale-documented ignore in `.cargo/audit.toml` — the exact mechanism the CI comment (added in #687) prescribes: *"to accept a specific advisory deliberately, add an ignore entry in `.cargo/audit.toml` rather than removing this gate."* The entry references #713 and is to be removed once zenoh bumps lz4_flex.

**Exposure is bounded:** lz4 decompresses zenoh transport frames, and the federation payloads they carry are Ed25519-authenticated at the application layer — a crafted frame yields a report that fails signature verification, not a leak reflected to the attacker.

## Not touched
The non-fatal `cargo audit` warnings (`bincode`/`paste` unmaintained, `anyhow` unsound, yanked `time`/`time-macros`) remain warnings and do not fail the gate.

## Verification
Workspace builds clean with the updated lock (`cargo build --workspace`). `cargo audit` itself can't run in the PR sandbox (RustSec DB fetch from github.com is blocked there), so the gate is validated by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_