### PR TITLE
Source the SG6 vanished-object AgentScene through the parko-ros2 tick (#309)

### DIFF
--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -184,6 +184,22 @@ fn build_node_clearance(config: &ParkoNodeConfig) -> Option<NodeClearance> {
                      forces the MRC (stop) until fresh samples resume."
                 );
             }
+            // #309: arm the SG6 vanished-object detector when enabled AND object
+            // perception is configured (lidar + platform_profile → the Taj object
+            // snapshot the node sources the per-tick AgentScene from). Gated the
+            // SAME way as the node's scene sourcing: without object perception the
+            // detector would never be fed, so arming it would be misleading.
+            if config.vanished_detection_enabled
+                && config.lidar_topic.is_some()
+                && config.platform_profile.is_some()
+            {
+                c = c.with_vanished_detection(config.vanished_cfg());
+                tracing::info!(
+                    "parko-ros2: SG6 vanished-object detector ARMED (#309) — a close agent that \
+                     VANISHES between frames latches the clearance loop until an operator grant \
+                     clears it (the person-under-vehicle case)."
+                );
+            }
             Some(c)
         }
         Err(e) => {

--- a/parko/crates/parko-ros2/src/clearance_gate.rs
+++ b/parko/crates/parko-ros2/src/clearance_gate.rs
@@ -33,17 +33,18 @@
 // fresh grant against the NEW escalation. Releasing first then re-latching is the
 // safe direction; the reverse (latch then let a stale grant clear it) is not.
 //
-// WHAT IS ARMED vs DEFERRED (#309 remainder):
+// WHAT IS ARMED (#309 — all three triggers now wired):
 //   * decel (IMU)  — ARMED when `imu_topic` is configured (vector-magnitude
 //                    decel proxy vs `ImpactCfg::spike_threshold_mps2`).
 //   * contact      — ARMED when `contact_topic` is configured.
-//   * vanished     — DEFERRED: `VanishedObjectDetector` needs an `AgentScene`
-//                    per tick, and no scene source flows through the M2 tick yet
-//                    (scenes were always integrator/checker-side input). The
-//                    detector sits behind an `Option` gated on a per-tick scene;
-//                    the node passes `None` today. Sourcing the scene is the
-//                    named remainder of #309. We wire the two REAL triggers now
-//                    rather than block all three on perception plumbing.
+//   * vanished     — ARMED when `vanished_detection_enabled` AND object
+//                    perception (lidar + `platform_profile`) is configured: the
+//                    node sources an `AgentScene` per tick from Taj's perceived
+//                    objects (the SAME snapshot the object-RSS gate uses) and
+//                    passes `Some(&scene)` here. A missing/stale snapshot →
+//                    `AgentScene::Absent` (a gap; never a fabricated latch). The
+//                    seam was a per-tick scene `Option` (the node passed `None`);
+//                    sourcing that scene was the named remainder of #309, now done.
 //
 // HONESTY RULE: a missing sensor is REDUCED detection coverage, stated loudly at
 // startup — never a fabricated spike and never a fabricated veto. An absent IMU
@@ -280,9 +281,9 @@ pub struct NodeClearance {
     /// config; defaults to [`ImpactCfg::default`].
     cfg: ImpactCfg,
     /// The vanished-object detector, behind an `Option` GATED ON A SCENE SOURCE.
-    /// `None` today: no `AgentScene` flows through the M2 tick (the deferred
-    /// remainder of #309). When a scene source lands, this is `Some` and run per
-    /// tick against the supplied scene.
+    /// `Some` when armed via [`with_vanished_detection`](Self::with_vanished_detection):
+    /// the node sources an `AgentScene` per tick from Taj objects (#309) and the
+    /// detector runs against it; `None` leaves it unfed (reduced coverage).
     vanished: Option<VanishedObjectDetector>,
     /// Config for the vanished detector (parko-core default until tuned).
     vanished_cfg: VanishedCfg,
@@ -1048,6 +1049,81 @@ mod tests {
         assert!(nc.is_immobilized(), "contact=true is a definitive impact → latch");
         assert!(out.vetoed);
         assert_eq!(out.tick.twist.linear_x_mps, 0.0);
+    }
+
+    /// VANISHED (#309): with the detector ARMED and a scene sourced per tick, a
+    /// close agent that VANISHES between frames latches the loop and stops the
+    /// vehicle at Nominal — the end-to-end pure path the node's scene sourcing
+    /// drives (`Some(&scene)` instead of the old `None`).
+    #[tokio::test(start_paused = true)]
+    async fn vanished_object_latches_from_scene() {
+        let mut nc = NodeClearance::from_store(store(), "KIRRA-DEMO-03")
+            .with_vanished_detection(VanishedCfg::default());
+        let no_impact = ImpactInputs { imu: Some(imu_accel_mag(9.81)), contact: false };
+
+        // Tick 1 — a close agent 1 m ahead (gap ≤ r_close 2.0): opens the
+        // close-agent obligation; nothing has vanished yet → no latch.
+        let close = AgentScene::Agents(vec![parko_core::RssAgent {
+            ego_vel: 0.0,
+            lead_vel: 0.0,
+            actual_longitudinal_gap_m: 1.0,
+            ego_lat_vel: 0.0,
+            obj_lat_vel: 0.0,
+            actual_lateral_separation_m: 0.0,
+            oncoming: false,
+        }]);
+        let out1 = run_pipeline_tick_with_clearance(
+            &ParkoNodeConfig::default(),
+            build_loop(0.1, 0.2),
+            fresh_frame(20),
+            SafetyPosture::Nominal,
+            Some(&mut nc),
+            &no_impact,
+            Some(&close),
+        )
+        .await;
+        assert_eq!(nc.state(), ClearanceState::Normal, "a present close agent must not latch");
+        assert!(!out1.vetoed);
+
+        // Tick 2 — perception ran and is verified-empty (`KnownEmpty`): the close
+        // agent vanished within the plausibility horizon → latch + stop.
+        let out2 = run_pipeline_tick_with_clearance(
+            &ParkoNodeConfig::default(),
+            build_loop(0.1, 0.2),
+            fresh_frame(21),
+            SafetyPosture::Nominal,
+            Some(&mut nc),
+            &no_impact,
+            Some(&AgentScene::KnownEmpty),
+        )
+        .await;
+        assert!(nc.is_immobilized(), "a close agent that vanished must latch the loop");
+        assert!(out2.vetoed, "latched → stop regardless of posture");
+        assert_eq!(out2.tick.twist.linear_x_mps, 0.0);
+    }
+
+    /// VANISHED NEGATIVE (#309): the same armed loop, but with the detector fed
+    /// `None`/`Absent` scenes (the unarmed-source path) NEVER latches — a missing
+    /// scene is a gap, never a fabricated vanish.
+    #[tokio::test(start_paused = true)]
+    async fn vanished_detector_with_no_scene_never_latches() {
+        let mut nc = NodeClearance::from_store(store(), "KIRRA-DEMO-03")
+            .with_vanished_detection(VanishedCfg::default());
+        let no_impact = ImpactInputs { imu: Some(imu_accel_mag(9.81)), contact: false };
+        for i in 0..5 {
+            let out = run_pipeline_tick_with_clearance(
+                &ParkoNodeConfig::default(),
+                build_loop(0.1, 0.2),
+                fresh_frame(30 + i),
+                SafetyPosture::Nominal,
+                Some(&mut nc),
+                &no_impact,
+                None, // no scene source this tick
+            )
+            .await;
+            assert_eq!(nc.state(), ClearanceState::Normal, "tick {i}: no scene must never latch");
+            assert!(!out.vetoed);
+        }
     }
 
     /// NO-FALSE-LATCH: gravity-only IMU (≈9.81 m/s², below threshold) + no

--- a/parko/crates/parko-ros2/src/config.rs
+++ b/parko/crates/parko-ros2/src/config.rs
@@ -116,6 +116,18 @@ pub struct ParkoNodeConfig {
     /// and `corridor_max_age_ms` as the object-perception staleness budget.
     /// **Default `false`** → byte-identical to the corridor-only Phase 3b.
     pub object_rss_enabled: bool,
+
+    /// #309 remainder — enable the SG6 vanished-object detector. When `true` AND
+    /// lidar + `platform_profile` are configured, the node sources an
+    /// [`AgentScene`](parko_core::AgentScene) from Taj's perceived objects (the
+    /// SAME snapshot the object-RSS gate uses) and feeds it to the node-owned
+    /// `ClearanceLoop` each tick, so a close agent that VANISHES between frames
+    /// (the person-under-vehicle case) latches `Normal → Latched` and immobilizes
+    /// until an operator grant clears it. Opt-in and fail-safe: this arms a
+    /// *latching auto-immobilizer*, so it stays OFF by default and is never
+    /// silently enabled by `object_rss_enabled`. Missing/stale object perception →
+    /// `AgentScene::Absent` (a gap — never a fabricated latch). **Default `false`.**
+    pub vanished_detection_enabled: bool,
 }
 
 /// Placeholder for an MRC fallback override. Today's MRC is always
@@ -153,6 +165,9 @@ impl Default for ParkoNodeConfig {
             // ADR-0029 Phase 3b (object axis): object RSS gate off by default.
             // Opt-in; byte-identical to corridor-only Phase 3b when disabled.
             object_rss_enabled: false,
+            // #309: SG6 vanished-object detection off by default — a latching
+            // auto-immobilizer is opt-in, never silently enabled.
+            vanished_detection_enabled: false,
         }
     }
 }
@@ -182,6 +197,24 @@ impl ParkoNodeConfig {
             // the node-config surface only tunes the threshold today.
             ..parko_core::ImpactCfg::default()
         }
+    }
+
+    /// The SG6 [`parko_core::VanishedCfg`] this node uses for the vanished-object
+    /// frame-diff. The conservative defaults (close range 2.0 m, agent speed cap
+    /// 3.0 m/s, 0.5 m band slack) are documented on `VanishedCfg`; the node-config
+    /// surface does not tune them today (deployment-tunable when a need is real).
+    #[must_use]
+    pub fn vanished_cfg(&self) -> parko_core::VanishedCfg {
+        parko_core::VanishedCfg::default()
+    }
+
+    /// Whether THIS node should source an object snapshot at all — true when the
+    /// object-RSS gate OR the SG6 vanished detector needs it. The lidar task uses
+    /// this to decide whether to populate the object slot (the vanished detector
+    /// reuses the object-RSS snapshot, so either consumer arms the feed).
+    #[must_use]
+    pub fn needs_object_snapshot(&self) -> bool {
+        self.object_rss_enabled || self.vanished_detection_enabled
     }
 }
 

--- a/parko/crates/parko-ros2/src/node.rs
+++ b/parko/crates/parko-ros2/src/node.rs
@@ -336,13 +336,17 @@ where
             // missing/stale snapshot → `AgentScene::Absent` (a gap; the detector
             // never fabricates a latch). Only when armed; otherwise `None` (the
             // detector stays unfed, byte-identical to pre-#309).
-            let obj_snap = drain_objects.lock().ok().and_then(|g| g.clone());
+            //
+            // Build the scene while holding the lock BRIEFLY (over an `&` borrow)
+            // rather than cloning the whole `ObjectSnapshot` — `object_snapshot_to_
+            // vanished_scene` returns an OWNED `AgentScene`, so no snapshot copy is
+            // needed (Copilot PR #716). The guard drops at the end of the closure,
+            // well before the `.await` below (no std-mutex held across await).
             let vanished_scene = drain_vanished_armed.then(|| {
-                object_snapshot_to_vanished_scene(
-                    obj_snap.as_ref(),
-                    drain_config.corridor_max_age_ms,
-                    current_time_ms(),
-                )
+                let now = current_time_ms();
+                let guard = drain_objects.lock().ok();
+                let snap: Option<&ObjectSnapshot> = guard.as_ref().and_then(|g| g.as_ref());
+                object_snapshot_to_vanished_scene(snap, drain_config.corridor_max_age_ms, now)
             });
 
             let cleared = run_pipeline_tick_with_clearance(

--- a/parko/crates/parko-ros2/src/node.rs
+++ b/parko/crates/parko-ros2/src/node.rs
@@ -37,7 +37,9 @@ use crate::containment_gate::{apply_containment_gate, CONTAINMENT_HORIZON_S, CON
 use crate::imu_shim::imu_msg_to_sample;
 use crate::sensor_mapping::{ImuSample, SensorInputMapping};
 use crate::taj_corridor::{laserscan_msg_to_taj, CorridorSnapshot, EGO_REAR_COVER_M};
-use crate::taj_objects::{apply_object_rss_gate, courier_rss_params, ObjectSnapshot};
+use crate::taj_objects::{
+    apply_object_rss_gate, courier_rss_params, object_snapshot_to_vanished_scene, ObjectSnapshot,
+};
 use crate::tick_pipeline::{current_time_ms, TickError};
 use parko_kirra::clearance_delivery::DeliveryOutcome;
 
@@ -162,13 +164,33 @@ where
                  coverage; the clearance loop will not latch on a contact-sensor hit."
             ),
         }
-        // The vanished-object trigger needs an AgentScene per tick; no scene
-        // source flows through the M2 tick yet (the #309 remainder). The node
-        // passes `scene = None`; the detector stays unfed.
-        tracing::warn!(
-            "parko-ros2: SG6 vanished-object detection NOT wired (no AgentScene source in the \
-             tick) — REDUCED detection coverage; tracked as the remainder of #309."
-        );
+        // #309: the SG6 vanished-object detector is fed an AgentScene per tick
+        // when armed (`vanished_detection_enabled`) AND object perception is
+        // available (lidar + platform_profile → the Taj object snapshot the scene
+        // is sourced from). Otherwise it stays unfed — reduced coverage, stated
+        // loudly. (Arming the latching auto-immobilizer happens in the bin's
+        // `build_node_clearance` via `with_vanished_detection`, gated the same way.)
+        if config.vanished_detection_enabled
+            && config.lidar_topic.is_some()
+            && config.platform_profile.is_some()
+        {
+            tracing::info!(
+                "parko-ros2: SG6 vanished-object detection ARMED (#309) — the node sources an \
+                 AgentScene from Taj objects each tick; a close agent that VANISHES between \
+                 frames latches the clearance loop (operator grant required to clear)."
+            );
+        } else if config.vanished_detection_enabled {
+            tracing::warn!(
+                "parko-ros2: SG6 vanished-object detection REQUESTED but object perception is \
+                 not configured (needs lidar_topic + platform_profile) — REDUCED coverage; the \
+                 detector stays unfed (#309)."
+            );
+        } else {
+            tracing::warn!(
+                "parko-ros2: SG6 vanished-object detection NOT enabled — REDUCED detection \
+                 coverage; set vanished_detection_enabled (with lidar + platform_profile) to arm (#309)."
+            );
+        }
     }
 
     // --- ADR-0029 Phase 3b: live SG2 containment (lidar → Taj corridor) ---
@@ -189,7 +211,9 @@ where
                 .subscribe::<r2r::sensor_msgs::msg::LaserScan>(topic, r2r::QosProfile::default())?;
             let cell = Arc::clone(&latest_corridor);
             let obj_cell = Arc::clone(&latest_objects);
-            let store_objects = config.object_rss_enabled;
+            // Populate the object slot when EITHER object-axis consumer needs it:
+            // the SG1 object-RSS gate or the SG6 vanished-object detector (#309).
+            let store_objects = config.needs_object_snapshot();
             // The TEMPORAL tracker (not the single-frame `TajPhaseA`): `track`
             // wraps `phase_a.process`, so the CORRIDOR is byte-identical, but it
             // also associates objects frame-to-frame and estimates each object's
@@ -256,6 +280,12 @@ where
         .as_ref()
         .filter(|_| config.object_rss_enabled && config.lidar_topic.is_some())
         .map(courier_rss_params);
+    // #309: SG6 vanished-object scene sourcing — armed under the SAME condition as
+    // the bin's `with_vanished_detection` (enabled + object perception present),
+    // so the per-tick scene is built only when the detector exists to consume it.
+    let drain_vanished_armed = config.vanished_detection_enabled
+        && config.platform_profile.is_some()
+        && config.lidar_topic.is_some();
 
     let drain_task = tokio::spawn(async move {
         use futures::StreamExt;
@@ -301,6 +331,20 @@ where
                 }
             }
 
+            // #309: source the SG6 vanished-object scene from the latest Taj
+            // objects (the SAME snapshot the object-RSS gate uses below). A
+            // missing/stale snapshot → `AgentScene::Absent` (a gap; the detector
+            // never fabricates a latch). Only when armed; otherwise `None` (the
+            // detector stays unfed, byte-identical to pre-#309).
+            let obj_snap = drain_objects.lock().ok().and_then(|g| g.clone());
+            let vanished_scene = drain_vanished_armed.then(|| {
+                object_snapshot_to_vanished_scene(
+                    obj_snap.as_ref(),
+                    drain_config.corridor_max_age_ms,
+                    current_time_ms(),
+                )
+            });
+
             let cleared = run_pipeline_tick_with_clearance(
                 &drain_config,
                 Arc::clone(&drain_infer),
@@ -308,7 +352,7 @@ where
                 posture,
                 clearance.as_mut(),
                 &impact_inputs,
-                None, // AgentScene source deferred (#309 remainder)
+                vanished_scene.as_ref(),
             ).await;
             let outcome = cleared.tick;
 

--- a/parko/crates/parko-ros2/src/taj_objects.rs
+++ b/parko/crates/parko-ros2/src/taj_objects.rs
@@ -159,6 +159,47 @@ pub fn objects_to_agent_scene(objects: &[PerceivedObject], ego_vel_mps: f64) -> 
     }
 }
 
+/// Build the per-tick [`AgentScene`] from the latest object snapshot, applying
+/// the fail-closed freshness rule shared by BOTH object-axis consumers (the SG1
+/// object-RSS gate and the SG6 vanished-object detector): a missing OR stale
+/// snapshot is [`AgentScene::Absent`] — NEVER [`AgentScene::KnownEmpty`] — so
+/// "no/old perception" is never read as "verified clear". A fresh snapshot is
+/// converted via [`objects_to_agent_scene`].
+#[must_use]
+pub fn object_snapshot_to_scene(
+    objects: Option<&ObjectSnapshot>,
+    max_age_ms: u64,
+    now_ms: u64,
+    ego_vel_mps: f64,
+) -> AgentScene {
+    match objects {
+        Some(snap) if snap.age_ms(now_ms) <= max_age_ms => {
+            objects_to_agent_scene(snap.objects(), ego_vel_mps)
+        }
+        _ => AgentScene::Absent,
+    }
+}
+
+/// The [`AgentScene`] the SG6 vanished-object detector consumes (#309 remainder).
+///
+/// [`VanishedObjectDetector::observe`](parko_core::VanishedObjectDetector::observe)
+/// reads ONLY each agent's `actual_longitudinal_gap_m` (the proximity proxy) —
+/// the RSS kinematic fields (`ego_vel`, `lead_vel`, lateral, `oncoming`) are
+/// irrelevant to the vanish frame-diff — so the ego speed is immaterial here and
+/// is fixed at `0.0`. Freshness is the SAME fail-closed rule as the object-RSS
+/// gate: missing/stale perception → [`AgentScene::Absent`], which the detector
+/// treats as a GAP (it holds its close-agent obligation and never fabricates a
+/// vanish latch). A fresh, verified-clear frame is [`AgentScene::KnownEmpty`] —
+/// the strongest vanish evidence when a close agent was just present.
+#[must_use]
+pub fn object_snapshot_to_vanished_scene(
+    objects: Option<&ObjectSnapshot>,
+    max_age_ms: u64,
+    now_ms: u64,
+) -> AgentScene {
+    object_snapshot_to_scene(objects, max_age_ms, now_ms, 0.0)
+}
+
 /// Compose the RSS object-avoidance gate ONTO a [`TickOutcome`] — the node-side
 /// seam, parallel to [`apply_containment_gate`](crate::containment_gate::apply_containment_gate).
 /// Called after the tick (and after the containment gate) when object perception
@@ -190,13 +231,9 @@ pub fn apply_object_rss_gate(
     }
 
     let ego_vel = outcome.twist.linear_x_mps;
-    // Fail-closed on missing/stale perception: ABSENT, never KnownEmpty.
-    let scene = match objects {
-        Some(snap) if snap.age_ms(now_ms) <= max_age_ms => {
-            objects_to_agent_scene(snap.objects(), ego_vel)
-        }
-        _ => AgentScene::Absent,
-    };
+    // Fail-closed on missing/stale perception: ABSENT, never KnownEmpty (shared
+    // freshness helper, also used by the SG6 vanished-scene source).
+    let scene = object_snapshot_to_scene(objects, max_age_ms, now_ms, ego_vel);
 
     let state = parko_kirra::compute_scene_rss(&scene, params);
     if state.safe {
@@ -262,6 +299,46 @@ mod tests {
         // a forward-driving courier cannot forward-collide with it → KnownEmpty.
         let objs = [object(1, -2.0, 0.0, 0.0, 0.0)];
         assert!(matches!(objects_to_agent_scene(&objs, 1.0), AgentScene::KnownEmpty));
+    }
+
+    // ---- SG6 vanished-scene source (#309) ----------------------------------
+
+    #[test]
+    fn vanished_scene_fresh_empty_is_known_empty() {
+        // Perception ran and saw nothing → KnownEmpty, the strongest vanish
+        // evidence (a close agent that was just present is now gone).
+        let scene = object_snapshot_to_vanished_scene(Some(&snapshot(&[], 100)), 500, 200);
+        assert!(matches!(scene, AgentScene::KnownEmpty));
+    }
+
+    #[test]
+    fn vanished_scene_fresh_close_object_is_agents_with_gap() {
+        // A close object 1 m ahead → Agents, carrying the longitudinal gap the
+        // detector reads as proximity (ego speed is immaterial for the vanish path).
+        let objs = [object(1, 1.0, 0.0, 0.0, 0.0)];
+        let scene = object_snapshot_to_vanished_scene(Some(&snapshot(&objs, 100)), 500, 200);
+        match scene {
+            AgentScene::Agents(v) => {
+                assert_eq!(v.len(), 1);
+                assert_eq!(v[0].actual_longitudinal_gap_m, 1.0);
+            }
+            other => panic!("expected Agents, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vanished_scene_absent_when_missing_or_stale() {
+        // No snapshot → Absent (a GAP — the detector never fabricates a latch).
+        assert!(matches!(
+            object_snapshot_to_vanished_scene(None, 500, 200),
+            AgentScene::Absent
+        ));
+        // Stale snapshot → Absent, even though it holds an (empty) clear frame —
+        // so a sensor dropout cannot be read as the verified-empty vanish trigger.
+        assert!(matches!(
+            object_snapshot_to_vanished_scene(Some(&snapshot(&[], 100)), 500, 5_000),
+            AgentScene::Absent
+        ));
     }
 
     // ---- the gate ----------------------------------------------------------


### PR DESCRIPTION
Closes #309.

## The remaining scope
Detection-arming (IMU + contact) landed in #311. The named remainder was the **vanished-object trigger**: `VanishedObjectDetector` needs an `AgentScene` per tick, but none flowed through the M2 tick (the node passed `scene = None`), so the node-owned `ClearanceLoop` could *release* the vehicle but never *enter* an immobilized state from a close agent that vanished (the person-under-vehicle case). This sources the scene from the object perception the node already runs.

## Pure layer (locally tested)
- **`taj_objects`**: factor the fail-closed freshness rule into a shared `object_snapshot_to_scene` (now used by the existing object-RSS gate too) + a documented `object_snapshot_to_vanished_scene` wrapper. `VanishedObjectDetector::observe` reads **only** each agent's `actual_longitudinal_gap_m` (proximity), so the ego speed is immaterial → `0.0`. Missing/stale snapshot → `AgentScene::Absent` (a gap; the detector never fabricates a latch); a fresh verified-empty frame → `AgentScene::KnownEmpty` (the vanish trigger).
- **`config`**: add opt-in `vanished_detection_enabled` (**default `false`** — this arms a *latching auto-immobilizer*, so it is never silently enabled by `object_rss_enabled`), plus `vanished_cfg()` and `needs_object_snapshot()`.

## Wiring (ros2-gated; CI-verified, not locally compilable)
- **`node`**: store the object snapshot when *either* object-axis consumer needs it; build the vanished scene from the latest Taj objects (the same snapshot the object-RSS gate uses) and pass `Some(&scene)` to `run_pipeline_tick_with_clearance` when armed; flip the "NOT wired" startup warning to ARMED / REQUESTED-but-unconfigured / disabled.
- **`bin`**: arm the detector via `with_vanished_detection` when enabled **and** object perception (lidar + `platform_profile`) is configured.

## Tests (no ROS)
- End-to-end: a close agent (tick 1) that vanishes to `KnownEmpty` (tick 2) latches the loop and stops the vehicle at Nominal — the exact path the node's scene sourcing drives.
- Armed-but-`None`-scene never latches (a gap, never fabricated).
- The scene-source freshness cases (fresh-empty → KnownEmpty, fresh-close → Agents w/ gap, missing/stale → Absent).

**207 default tests pass; clippy clean.** `parko-core` untouched; no new deps.

## Verification boundary
The `parko-ros2` `ros2` feature requires a sourced ROS toolchain (`r2r_rcl` needs `ROS_DISTRO`), so the **gated `node.rs`/`bin` edits compile under CI's parko ros2 build lane, not locally**. The substantive logic (conversion, freshness, `KnownEmpty`/`Absent` discipline, the latch path) all lives in the pure, locally-tested layer; the gated edits are mechanical and mirror the existing object-RSS pattern.

## Out of scope
Issue item 3 (whether the node should own a `RecordedClearanceLoop` so detection edges hit the signed chain) is an open API question, not part of the stated remaining scope (scene sourcing) — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_