### PR TITLE
Implement governor-routed authenticated e-stop request (#412, ADR-0013)

### DIFF
--- a/docs/adr/0013-governor-routed-authenticated-estop.md
+++ b/docs/adr/0013-governor-routed-authenticated-estop.md
@@ -2,11 +2,11 @@
 
 | Field | Value |
 |---|---|
-| Status | **Proposed (design note — precedes code)** — for owner sign-off; ratified on merge. |
-| Date | 2026-06-21 |
+| Status | **Accepted** — verifier-side implementation landed (#412); the console action (UI) remains the one deferred step. |
+| Date | 2026-06-21 (design); implemented 2026-06-30 |
 | Deciders | Project / safety-case owner |
 | Issues | #412 (this), #314 (operator identity), #410 / #405 (MRC / decel-to-stop), ADR-0006 (the QM↔safety boundary), #411 (console safety-theater fix) |
-| Code (when built) | `src/verifier.rs` / `src/bin/kirra_verifier_service.rs` (governor-request endpoint, mirrors the clearance loop), the audit chain, the MRC vocabulary (`TRAJECTORY_MRC_FALLBACK`) |
+| Code | `POST /console/estop-requests` → `console_estop_request` (`src/bin/kirra_verifier_service/operators.rs`), the domain-separated signing payload (`attestation::operator_stop_signing_payload` / `OPERATOR_STOP_DOMAIN`), the MRC command (`supervisor_tripped` + `posture_engine::force_lockout`), and the chain events `OperatorStopRequested` → `GovernorMRCCommanded`. |
 
 ## Principle
 
@@ -79,16 +79,26 @@ clearance.
 This **design note first** (this ADR). Then implementation (laptop; end-to-end
 **hardware-gated** — needs a running governor + actuator path):
 
-1. the governor-request endpoint (mirror the clearance endpoint),
-2. the signed-request path (reuse the operator-identity verify-then-consume),
-3. the chain events (`OperatorStopRequested` → `GovernorMRCCommanded`),
-4. the console "Request Emergency Stop" action.
+1. ✅ the governor-request endpoint (`POST /console/estop-requests`, mirrors the clearance endpoint),
+2. ✅ the signed-request path (reuses the operator-identity verify-then-consume, under a
+   domain-distinct `OPERATOR_STOP_DOMAIN` so a clearance signature can't be replayed as a stop),
+3. ✅ the chain events (`OperatorStopRequested` → `GovernorMRCCommanded`), with the MRC commanded
+   under the governor's own authority (sticky `supervisor_tripped` + `force_lockout`),
+4. ⬜ the console "Request Emergency Stop" action (UI — deferred; the console correctly has no
+   E-stop button today, #411).
+
+Items 1–3 (the verifier-side core) are implemented + unit-tested (operator-signed happy path
+commands the MRC + chains both events; domain separation rejects a clearance signature; unknown
+operator / replay / passive-standby all fail closed). End-to-end validation remains
+hardware-gated.
 
 Cross-ref: #314, the clearance-loop PRs, ADR-0006 (the boundary), #411 (console
 safety-theater fix).
 
 ## Status
 
-**Proposed — for owner sign-off** (merge ratifies, as with ADR-0011 / ADR-0012). This records
-the **request-not-command** architecture *before* code so the implementation cannot drift into
-the console→actuator anti-pattern.
+**Accepted** — the request-not-command architecture was recorded *before* code (the original
+design note), and the verifier-side implementation now follows it exactly: the only inbound
+affordance is an authenticated REQUEST; the governor commands the MRC under its own authority;
+the console never touches the actuator. The console "Request Emergency Stop" action (UI) is the
+one remaining deferred step, and end-to-end validation is hardware-gated.

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -234,6 +234,32 @@ pub fn operator_grant_signing_payload(operator_id: &str, node_id: &str, nonce: &
     payload
 }
 
+/// Domain tag for an operator EMERGENCY-STOP request (#412 / ADR-0013). DISTINCT
+/// from [`OPERATOR_GRANT_DOMAIN`] so a clearance (RELEASE) signature can NEVER be
+/// replayed as a stop request, nor vice versa — the two verbs ride the same
+/// authenticated channel but are cryptographically non-interchangeable.
+pub const OPERATOR_STOP_DOMAIN: &[u8] = b"KIRRA-OPERATOR-ESTOP-v1";
+
+/// The exact byte payload an operator signs for an EMERGENCY-STOP request on
+/// `(operator_id, node_id, nonce)` (#412 / ADR-0013). Same length-prefixed,
+/// domain-separated discipline as [`operator_grant_signing_payload`], but under
+/// [`OPERATOR_STOP_DOMAIN`] — the stop is the clearance verb INVERTED, and the
+/// distinct domain is what makes a clearance signature unusable as a stop (and
+/// vice versa). The browser (WebCrypto) and the server MUST construct this
+/// identically.
+#[must_use]
+pub fn operator_stop_signing_payload(operator_id: &str, node_id: &str, nonce: &str) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(OPERATOR_STOP_DOMAIN.len() + 24
+        + operator_id.len() + node_id.len() + nonce.len());
+    payload.extend_from_slice(OPERATOR_STOP_DOMAIN);
+    for field in [operator_id, node_id, nonce] {
+        let b = field.as_bytes();
+        payload.extend_from_slice(&(b.len() as u64).to_le_bytes());
+        payload.extend_from_slice(b);
+    }
+    payload
+}
+
 /// Verify an Ed25519 signature over `payload` against a PEM-encoded public key.
 /// Fail-closed: a malformed key, a non-64-byte signature, or a bad signature all
 /// return `false`. Uses `verify_strict` (the same path as node attestation).
@@ -357,6 +383,18 @@ mod tests {
     use ed25519_dalek::{Signer, SigningKey};
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// #412 — the e-stop and clearance payloads MUST differ for identical inputs
+    /// (distinct domain tags), so a clearance signature can never satisfy an e-stop
+    /// verification and vice versa.
+    #[test]
+    fn stop_and_grant_payloads_are_domain_separated() {
+        let g = operator_grant_signing_payload("alice", "robot-01", "deadbeef");
+        let s = operator_stop_signing_payload("alice", "robot-01", "deadbeef");
+        assert_ne!(g, s, "stop and grant payloads must not collide for the same inputs");
+        assert!(s.starts_with(OPERATOR_STOP_DOMAIN), "stop payload carries its own domain tag");
+        assert!(g.starts_with(OPERATOR_GRANT_DOMAIN), "grant payload carries its own domain tag");
+    }
 
     /// Per-call counter mixed into the seed so two keypairs created in the
     /// same nanosecond are still distinct.

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -1361,6 +1361,30 @@ async fn audit_grant_rejection(
     }).await;
 }
 
+/// #412 / ADR-0013 — audit a REJECTED operator e-stop request to the signed
+/// chain (distinct event type from a clearance rejection). A rejected stop never
+/// commanded the MRC; the record is the non-repudiable trail of the attempt.
+async fn audit_estop_rejection(
+    app: &kirra_verifier::verifier::AppState,
+    reason: &str,
+    node_id: &str,
+    operator_id: &str,
+    now: u64,
+) {
+    let store = app.store.clone();
+    let reason = reason.to_string();
+    let node_id = node_id.to_string();
+    let operator_id = operator_id.to_string();
+    let _ = store.call(move |s| {
+        let _ = s.append_clearance_audit_event(
+            "OperatorStopRequestRejected",
+            &json!({ "reason": reason, "node_id": node_id, "operator_id": operator_id })
+                .to_string(),
+            now,
+        );
+    }).await;
+}
+
 /// #326 — the operator clearance-challenge map key. Length-prefixing the
 /// `operator_id` makes the `operator/node` split UNAMBIGUOUS regardless of any
 /// delimiter characters in either id: `("a|b","c")` → `"3:a|b:c"` and
@@ -1417,6 +1441,20 @@ struct ClearanceGrantRequest {
     nonce: Option<String>,
     #[serde(default)]
     signature_b64: Option<String>,
+}
+
+/// #412 / ADR-0013 — a governor-routed authenticated EMERGENCY-STOP request. The
+/// operator signs `operator_stop_signing_payload(operator_id, node_id, nonce)`
+/// (domain-distinct from a clearance grant, so the two verbs are not
+/// interchangeable). Unlike the RECORD-ONLY clearance grant, accepting this
+/// REQUEST drives the governor to command the MRC (sticky fleet LockedOut) under
+/// its own authority — the console never touches the actuator.
+#[derive(Deserialize)]
+struct OperatorStopRequest {
+    node_id: String,
+    operator_id: String,
+    nonce: String,
+    signature_b64: String,
 }
 
 
@@ -1559,7 +1597,12 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
         // #314 Phase 1 — operator clearance-challenge (unauthenticated; the nonce
         // alone grants nothing — only a valid signature over it does).
         .route("/console/clearance-challenge", get(clearance_challenge))
-        .route("/console/clearance-grants", post(console_clearance_grant));
+        .route("/console/clearance-grants", post(console_clearance_grant))
+        // #412 / ADR-0013 — governor-routed authenticated emergency-stop REQUEST
+        // (the clearance verb inverted). Operator-signed over the same challenge
+        // nonce; accepting it makes the GOVERNOR command the MRC (sticky LockedOut)
+        // under its own authority — the console never touches the actuator.
+        .route("/console/estop-requests", post(console_estop_request));
 
     Router::new()
         .merge(probe_routes)
@@ -3231,6 +3274,15 @@ mod console_phase_a_tests {
         b64e.encode(sk.sign(&payload).to_bytes())
     }
 
+    /// #412 — sign the EMERGENCY-STOP payload (domain-distinct from a grant).
+    fn sign_stop_b64(sk: &SigningKey, operator_id: &str, node_id: &str, nonce: &str) -> String {
+        use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
+        let payload = kirra_verifier::attestation::operator_stop_signing_payload(
+            operator_id, node_id, nonce,
+        );
+        b64e.encode(sk.sign(&payload).to_bytes())
+    }
+
     fn register_op(svc: &Arc<ServiceState>, operator_id: &str, pem: &str) {
         svc.app.store.with(|s| s.register_operator(operator_id, pem, 1)).unwrap();
     }
@@ -3553,6 +3605,105 @@ mod console_phase_a_tests {
         let (s, _b) = post_json(svc, "/console/clearance-grants", body, None).await;
         assert_eq!(s, StatusCode::SERVICE_UNAVAILABLE,
             "a passive-standby instance must not accept grant writes (split-brain guard)");
+    }
+
+    // ----- #412 / ADR-0013 governor-routed authenticated e-stop request --------
+
+    /// HAPPY PATH: an operator-signed stop request makes the GOVERNOR command the
+    /// MRC under its own authority — supervisor_tripped is set and BOTH chain
+    /// events (request + governor action) are recorded.
+    #[tokio::test]
+    async fn estop_request_commands_mrc_and_chains_both_events() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        let (sk, pem) = operator_keypair(31);
+        register_op(&svc, "alice", &pem);
+        let (_c, cb) = get(svc.clone(),
+            "/console/clearance-challenge?operator_id=alice&node_id=robot-01").await;
+        let nonce = parse_nonce(&cb);
+        let sig = sign_stop_b64(&sk, "alice", "robot-01", &nonce);
+        let body = json!({"node_id":"robot-01","operator_id":"alice","nonce":nonce,"signature_b64":sig}).to_string();
+
+        let (s, b) = post_json(svc.clone(), "/console/estop-requests", body, None).await;
+        assert_eq!(s, StatusCode::OK, "operator-signed stop accepted; body={b}");
+        assert!(b.contains("stop_commanded") && b.contains("MRC_COMMANDED"), "body={b}");
+
+        // The governor commanded the sticky MRC under its own authority.
+        assert!(svc.app.supervisor_tripped.load(std::sync::atomic::Ordering::SeqCst),
+            "an accepted e-stop must set the sticky supervisor_tripped flag (force_lockout)");
+        let (_s, ab) = get(svc.clone(), "/console/audit?limit=50").await;
+        assert!(ab.contains("OperatorStopRequested"), "the authenticated request is chained");
+        assert!(ab.contains("GovernorMRCCommanded"), "the governor's MRC action is chained");
+        let fp = kirra_verifier::attestation::operator_key_fingerprint(&pem).unwrap();
+        assert!(ab.contains(&fp), "the request event carries the operator key fingerprint (non-repudiation)");
+    }
+
+    /// THE DOMAIN-SEPARATION SECURITY PROPERTY: a CLEARANCE (release) signature
+    /// must NOT be accepted as a STOP request (different signing domain). Without
+    /// domain separation an operator's release could be replayed as a stop.
+    #[tokio::test]
+    async fn clearance_signature_is_not_accepted_as_an_estop() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        let (sk, pem) = operator_keypair(32);
+        register_op(&svc, "alice", &pem);
+        let (_c, cb) = get(svc.clone(),
+            "/console/clearance-challenge?operator_id=alice&node_id=robot-01").await;
+        let nonce = parse_nonce(&cb);
+        // Sign the GRANT payload, submit to the e-stop endpoint.
+        let grant_sig = sign_grant_b64(&sk, "alice", "robot-01", &nonce);
+        let body = json!({"node_id":"robot-01","operator_id":"alice","nonce":nonce,"signature_b64":grant_sig}).to_string();
+        let (s, b) = post_json(svc.clone(), "/console/estop-requests", body, None).await;
+        assert_eq!(s, StatusCode::UNAUTHORIZED,
+            "a clearance signature must not satisfy the e-stop domain; body={b}");
+        assert!(!svc.app.supervisor_tripped.load(std::sync::atomic::Ordering::SeqCst),
+            "a rejected e-stop must NOT command the MRC");
+        let (_s, ab) = get(svc.clone(), "/console/audit?limit=50").await;
+        assert!(ab.contains("OperatorStopRequestRejected") && ab.contains("bad_signature"));
+    }
+
+    /// UNKNOWN operator → 403, audited, no MRC.
+    #[tokio::test]
+    async fn estop_unknown_operator_rejected_403() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        let body = json!({"node_id":"robot-01","operator_id":"ghost","nonce":"00","signature_b64":"AAAA"}).to_string();
+        let (s, b) = post_json(svc.clone(), "/console/estop-requests", body, None).await;
+        assert_eq!(s, StatusCode::FORBIDDEN, "unknown operator rejected; body={b}");
+        assert!(!svc.app.supervisor_tripped.load(std::sync::atomic::Ordering::SeqCst));
+        let (_s, ab) = get(svc.clone(), "/console/audit?limit=50").await;
+        assert!(ab.contains("OperatorStopRequestRejected") && ab.contains("unknown_operator"));
+    }
+
+    /// REPLAY: a stop nonce is single-use — the second identical request is rejected.
+    #[tokio::test]
+    async fn estop_nonce_replay_is_rejected() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        let (sk, pem) = operator_keypair(33);
+        register_op(&svc, "alice", &pem);
+        let (_c, cb) = get(svc.clone(),
+            "/console/clearance-challenge?operator_id=alice&node_id=robot-01").await;
+        let nonce = parse_nonce(&cb);
+        let sig = sign_stop_b64(&sk, "alice", "robot-01", &nonce);
+        let body = json!({"node_id":"robot-01","operator_id":"alice","nonce":nonce,"signature_b64":sig}).to_string();
+        let (s1, _) = post_json(svc.clone(), "/console/estop-requests", body.clone(), None).await;
+        assert_eq!(s1, StatusCode::OK, "first stop accepted");
+        let (s2, b2) = post_json(svc.clone(), "/console/estop-requests", body, None).await;
+        assert_eq!(s2, StatusCode::UNAUTHORIZED, "replayed stop nonce rejected; body={b2}");
+    }
+
+    /// HA split-brain guard: a passive-standby instance must not command the MRC.
+    #[tokio::test]
+    async fn standby_instance_rejects_estop_request() {
+        let svc = build_state();
+        seed_node(&svc, "robot-01");
+        svc.app.mode_active.store(false, std::sync::atomic::Ordering::SeqCst);
+        let body = json!({"node_id":"robot-01","operator_id":"alice","nonce":"00","signature_b64":"AAAA"}).to_string();
+        let (s, _b) = post_json(svc.clone(), "/console/estop-requests", body, None).await;
+        assert_eq!(s, StatusCode::SERVICE_UNAVAILABLE,
+            "a passive-standby instance must not command the MRC (split-brain guard)");
+        assert!(!svc.app.supervisor_tripped.load(std::sync::atomic::Ordering::SeqCst));
     }
 }
 

--- a/src/bin/kirra_verifier_service/operators.rs
+++ b/src/bin/kirra_verifier_service/operators.rs
@@ -448,11 +448,25 @@ pub(crate) async fn console_estop_request(
         }))).into_response();
     }
 
-    // 4. The target must be a registered node (mirrors the clearance grant).
+    // 4. The target must be a registered node. A store/read FAILURE is NOT an
+    //    "unregistered node" — distinguish it: a genuine not-found → 422, but a
+    //    lookup error → 500 (still fail-closed: the MRC is never commanded, and the
+    //    audit reason is accurate rather than a misleading client-error). The
+    //    closure preserves the query Result (not `unwrap_or(false)`) so the two
+    //    cases are separable (Copilot PR #718).
     let node_id_c = node_id.clone();
-    let registered = svc.app.store.call_read(move |store| {
-        Ok::<bool, ()>(store.node_exists(&node_id_c).unwrap_or(false))
-    }).await.ok().and_then(|r| r.ok()).unwrap_or(false);
+    let lookup = svc.app.store.call_read(move |store| {
+        store.node_exists(&node_id_c).map_err(|_| ())
+    }).await;
+    let registered = match lookup {
+        Ok(Ok(exists)) => exists,
+        _ => {
+            audit_estop_rejection(&svc.app, "node_lookup_failed", &node_id, &operator_id, now).await;
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({
+                "status": "error", "reason": "node registration lookup failed"
+            }))).into_response();
+        }
+    };
     if !registered {
         audit_estop_rejection(&svc.app, "unregistered_node", &node_id, &operator_id, now).await;
         return (StatusCode::UNPROCESSABLE_ENTITY, Json(json!({

--- a/src/bin/kirra_verifier_service/operators.rs
+++ b/src/bin/kirra_verifier_service/operators.rs
@@ -347,3 +347,178 @@ pub(crate) async fn console_clearance_grant(
                    Json(json!({ "status": "error", "reason": "store task failed" }))).into_response(),
     }
 }
+
+/// POST /console/estop-requests — a governor-routed authenticated EMERGENCY-STOP
+/// request (#412 / ADR-0013). The clearance verb INVERTED: an authenticated
+/// operator REQUESTS a stop and the governor, judging the request, commands the
+/// MRC under ITS OWN authority. The console asks; the governor acts — the QM-domain
+/// console NEVER touches the actuator (ADR-0006 boundary).
+///
+/// Operator-signed ONLY (no supervisor break-glass): ADR-0013 constraint #2
+/// requires the stop be NON-REPUDIABLE — provably the operator's in the chain —
+/// which a shared key cannot give. Handler order mirrors `console_clearance_grant`
+/// / `verify_attestation`: load operator (unknown/revoked → 403) → VERIFY the
+/// stop signature (domain-distinct from a clearance grant) → CONSUME the nonce
+/// (verify-then-consume; replay → 401) → node registered → chain
+/// `OperatorStopRequested`, command the MRC (sticky fleet LockedOut), chain
+/// `GovernorMRCCommanded`.
+///
+/// Unlike the RECORD-ONLY clearance grant, accepting this request DOES mutate
+/// posture — that is the point: the governor commands the MRC. Recovery is a
+/// deliberate supervisor reset (the clearance/release inverse), not automatic.
+pub(crate) async fn console_estop_request(
+    State(svc): State<Arc<ServiceState>>,
+    Json(req): Json<OperatorStopRequest>,
+) -> impl IntoResponse {
+    // HA split-brain guard: commanding the MRC is a posture mutation; a passive
+    // standby must not act and diverge from the primary (mirrors the clearance grant).
+    if !svc.app.is_active() {
+        return (StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({ "error": "instance is in passive standby mode" }))).into_response();
+    }
+    let now = now_ms();
+    let operator_id = req.operator_id.trim().to_string();
+    let node_id = req.node_id.trim().to_string();
+    let nonce = req.nonce.trim().to_string();
+    let sig_b64 = req.signature_b64.trim().to_string();
+
+    if operator_id.is_empty() || node_id.is_empty() || nonce.is_empty() || sig_b64.is_empty() {
+        audit_estop_rejection(&svc.app, "malformed_request", &node_id, &operator_id, now).await;
+        return (StatusCode::UNPROCESSABLE_ENTITY, Json(json!({
+            "status": "rejected",
+            "reason": "operator_id, node_id, nonce, and signature_b64 are all required"
+        }))).into_response();
+    }
+
+    // 1. Load operator — unknown / revoked → 403, audited.
+    let op_id_c = operator_id.clone();
+    let maybe_op = svc.app.store.call_read(move |s| {
+        Ok::<_, ()>(s.load_operator(&op_id_c).ok().flatten())
+    }).await.ok().and_then(|r| r.ok()).flatten();
+    let operator = match maybe_op {
+        Some(op) if op.is_active() => op,
+        Some(_) => {
+            audit_estop_rejection(&svc.app, "revoked_operator", &node_id, &operator_id, now).await;
+            return (StatusCode::FORBIDDEN, Json(json!({
+                "status": "rejected", "reason": "operator is revoked"
+            }))).into_response();
+        }
+        None => {
+            audit_estop_rejection(&svc.app, "unknown_operator", &node_id, &operator_id, now).await;
+            return (StatusCode::FORBIDDEN, Json(json!({
+                "status": "rejected", "reason": "operator is not registered"
+            }))).into_response();
+        }
+    };
+
+    // 2. VERIFY the stop signature FIRST (before the nonce is consumed). The
+    //    payload is under OPERATOR_STOP_DOMAIN — a clearance signature cannot
+    //    satisfy it, nor vice versa.
+    use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
+    let sig_bytes = match b64e.decode(sig_b64.as_str()) {
+        Ok(b) => b,
+        Err(_) => {
+            audit_estop_rejection(&svc.app, "malformed_signature", &node_id, &operator_id, now).await;
+            return (StatusCode::UNAUTHORIZED, Json(json!({
+                "status": "rejected", "reason": "signature is not valid base64"
+            }))).into_response();
+        }
+    };
+    let payload = kirra_verifier::attestation::operator_stop_signing_payload(
+        &operator_id, &node_id, &nonce,
+    );
+    if !kirra_verifier::attestation::verify_ed25519_pem_signature(
+        &operator.pubkey_pem, &payload, &sig_bytes,
+    ) {
+        audit_estop_rejection(&svc.app, "bad_signature", &node_id, &operator_id, now).await;
+        return (StatusCode::UNAUTHORIZED, Json(json!({
+            "status": "rejected", "reason": "signature verification failed"
+        }))).into_response();
+    }
+
+    // 3. CONSUME the nonce (verify-then-consume; replay/expired → 401). Reuses the
+    //    SAME challenge channel as clearance — the domain-distinct payload above is
+    //    what keeps the two verbs non-interchangeable.
+    let key = composite_challenge_key(&operator_id, &node_id);
+    if !svc.app.consume_clearance_challenge(&key, &nonce, now) {
+        audit_estop_rejection(&svc.app, "nonce_replay_or_expired", &node_id, &operator_id, now).await;
+        return (StatusCode::UNAUTHORIZED, Json(json!({
+            "status": "rejected",
+            "reason": "challenge nonce absent, expired, or already used (replay rejected)"
+        }))).into_response();
+    }
+
+    // 4. The target must be a registered node (mirrors the clearance grant).
+    let node_id_c = node_id.clone();
+    let registered = svc.app.store.call_read(move |store| {
+        Ok::<bool, ()>(store.node_exists(&node_id_c).unwrap_or(false))
+    }).await.ok().and_then(|r| r.ok()).unwrap_or(false);
+    if !registered {
+        audit_estop_rejection(&svc.app, "unregistered_node", &node_id, &operator_id, now).await;
+        return (StatusCode::UNPROCESSABLE_ENTITY, Json(json!({
+            "status": "rejected", "reason": "node_id is not a registered node"
+        }))).into_response();
+    }
+
+    let fingerprint = kirra_verifier::attestation::operator_key_fingerprint(&operator.pubkey_pem);
+
+    // 5a. Chain the authenticated REQUEST (who/when) — non-repudiable.
+    {
+        let node_id_c = node_id.clone();
+        let op_id_c = operator_id.clone();
+        let fp_c = fingerprint.clone();
+        let _ = svc.app.store.call(move |s| {
+            let _ = s.append_clearance_audit_event(
+                "OperatorStopRequested",
+                &json!({
+                    "node_id": node_id_c,
+                    "operator_id": op_id_c,
+                    "operator_key_fingerprint": fp_c,
+                    "auth_method": "operator-signed",
+                }).to_string(),
+                now,
+            );
+        }).await;
+    }
+
+    // 5b. Command the MRC under the GOVERNOR's own authority — sticky fleet
+    //     LockedOut. The exact escalation idiom (force_lockout doc / telemetry
+    //     watchdog): set the sticky flag THEN force the cache, so any surviving
+    //     recalc keeps producing LockedOut. The console asks; the governor acts.
+    svc.app.supervisor_tripped.store(true, std::sync::atomic::Ordering::SeqCst);
+    kirra_verifier::posture_engine::force_lockout(&svc.posture_cache, now);
+
+    // 5c. Chain what the governor DID (reconstructable after the fact).
+    {
+        let node_id_c = node_id.clone();
+        let op_id_c = operator_id.clone();
+        let _ = svc.app.store.call(move |s| {
+            let _ = s.append_clearance_audit_event(
+                "GovernorMRCCommanded",
+                &json!({
+                    "node_id": node_id_c,
+                    "operator_id": op_id_c,
+                    "mrc": "TRAJECTORY_MRC_FALLBACK",
+                    "posture": "LockedOut",
+                    "trigger": "operator-estop-request",
+                }).to_string(),
+                now,
+            );
+        }).await;
+    }
+
+    tracing::warn!(node_id = %node_id, operator_id = %operator_id,
+        "OPERATOR E-STOP REQUEST authenticated — governor commanded the MRC (sticky LockedOut). \
+         The console did not touch the actuator; recovery is a deliberate supervisor reset.");
+
+    (StatusCode::OK, Json(json!({
+        "status": "stop_commanded",
+        "node_id": node_id,
+        "operator_id": operator_id,
+        "operator_key_fingerprint": fingerprint,
+        "governor_action": "MRC_COMMANDED",
+        "posture": "LockedOut",
+        "requested_at_ms": now,
+        "note": "the governor commanded the MRC under its own authority; the console did not touch the actuator. Recovery requires a deliberate supervisor reset (the clearance inverse).",
+    }))).into_response()
+}


### PR DESCRIPTION
Implements #412 (verifier-side core). The design note **ADR-0013** is already on main; this lands items 1–3 of its sequencing. Item 4 (console UI) stays deferred and end-to-end is hardware-gated, per the ADR.

## The principle (ADR-0013 / ADR-0006)
An emergency stop must **not** be a console→actuator command — the QM-domain console holds no actuator authority. A software e-stop enters as an **authenticated REQUEST** to the fail-closed governor, which commands the MRC under **its own** authority. The console asks; the governor acts. This is the clearance loop **inverted** — same authenticated channel, opposite verb.

## What landed
- **`attestation::operator_stop_signing_payload`** under a distinct **`OPERATOR_STOP_DOMAIN`** — domain separation so a clearance (RELEASE) signature can **never** be replayed as a STOP, nor vice versa.
- **`POST /console/estop-requests`** (`console_estop_request`) — operator-signed only (ADR constraint #2: non-repudiable, which a shared key can't provide). Handler order mirrors `console_clearance_grant`: HA-active guard (503) → load operator (403 unknown/revoked) → **verify** the stop signature (401) → **consume** the nonce, verify-then-consume (401 replay) → node registered (422) → chain `OperatorStopRequested` → command the MRC → chain `GovernorMRCCommanded`.
- **MRC under the governor's own authority** via the documented sticky-escalation idiom (`supervisor_tripped` + `posture_engine::force_lockout`) — the same path the telemetry watchdog uses. The console never touches the actuator. Recovery is a deliberate supervisor reset (the clearance/release inverse), not automatic.
- Rejections chained distinctly (`OperatorStopRequestRejected`).

## Reuse, not a new mechanism
Reuses operator identity (#314), the Ed25519 verify-then-consume, the same challenge-nonce channel, the audit chain, and the MRC vocabulary — exactly as ADR-0013 prescribes. The frozen kinematics talisman is untouched.

## Tests
- Operator-signed happy path → 200, sets `supervisor_tripped`, chains **both** events (with the operator key fingerprint for non-repudiation).
- **Domain separation**: a clearance signature submitted to `/console/estop-requests` → 401, no MRC commanded (the key security property).
- Unknown operator (403), nonce replay (401), passive-standby (503) — all fail closed without commanding the MRC.
- An attestation unit test pins the stop/grant payload domain separation.

Service builds + `clippy` clean; `console_phase_a_tests` (32) + `attestation` (31) green. ADR-0013 status updated to **Accepted** (verifier-side landed; console UI is the remaining deferred step).

## Not in scope (per ADR-0013)
The console "Request Emergency Stop" UI action (item 4) and hardware-gated end-to-end validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_