### PR TITLE
ci: add hardened quality-guardrail ratchet (line count / panic budget / ownership)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - name: Quality guardrails (ratchet — line count / panic budget / ownership)
+        # Pure-Python, no toolchain needed, so it runs first and fails fast/cheap.
+        # Pins per-file line count, code-only panic/unwrap/expect counts, and the
+        # State<Arc<AppState>> ownership rule (CLAUDE.md #11) to the recorded
+        # baseline; only a regression past the ceiling fails. See
+        # ci/check_quality_guardrails.py for the update protocol.
+        #
+        # `set -o pipefail` so the script's non-zero exit (a guardrail
+        # regression) FAILS the job — without it the `tee` pipe returns tee's
+        # exit code and masks the violation (mirrors the Dependency audit step).
+        run: |
+          set -o pipefail
+          python3 ci/check_quality_guardrails.py | tee quality-guardrails-report.txt
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Clippy
@@ -430,6 +443,7 @@ jobs:
             shellcheck-report.txt
             helm-lint-report.txt
             audit-report.txt
+            quality-guardrails-report.txt
 
   parko-install-framework:
     name: Parko Multi-Backend Install Framework (shell, no hardware)

--- a/ci/check_quality_guardrails.py
+++ b/ci/check_quality_guardrails.py
@@ -10,9 +10,13 @@ Three guardrails, all read from ``ci/quality_guardrails_baseline.json``:
 * ``max_lines``      — per-file line-count ceiling (keeps the entry-point
                        monolith from regrowing after it is split up).
 * ``panic_budget``   — per-file ceiling on ``unwrap(`` / ``expect(`` /
-                       ``panic!(`` occurrences in *code* (comments and string
-                       literals are stripped before counting, so prose that
-                       merely mentions these never trips the gate). This is an
+                       ``panic!(`` occurrences in *code* (comments and escaped
+                       double-quoted string-literal contents are stripped before
+                       counting, so prose in those never trips the gate; raw
+                       strings are intentionally NOT stripped — see
+                       ``strip_rust_noise`` — so editing a raw-string body that
+                       contains one of these tokens can still move the count).
+                       This is an
                        interim ratchet; the strategic replacement is clippy's
                        ``unwrap_used`` / ``expect_used`` / ``panic`` lints with a
                        justified ``#[allow]`` at each sanctioned fail-closed
@@ -55,10 +59,14 @@ def strip_rust_noise(text: str) -> str:
 
     This is an approximate lexer, not a full Rust parser: it handles ``//`` line
     comments, ``/* ... */`` block comments (non-nested — the dominant case), and
-    ``"..."`` strings with backslash escapes. Raw strings (``r"..."``) are left
-    as-is; they are vanishingly rare for these patterns and erring toward
-    *counting* a possible occurrence keeps the ratchet fail-safe (it can only
-    over-count, never hide a real call)."""
+    ``"..."`` strings with backslash escapes. Raw strings (e.g. ``r#"..."#``) are
+    deliberately left as-is to avoid the added complexity of matching variable
+    hash-delimiters. Note raw strings ARE common in the guarded files (HTTP/JSON
+    response bodies), so a raw-string body that happens to contain ``unwrap(`` /
+    ``expect(`` / ``panic!(`` would be counted. This is conservative (fail-safe):
+    it can only over-count, never hide a real call — but it does mean editing
+    such a raw-string literal can change the counted total even when no
+    executable code changed."""
     out: list[str] = []
     i = 0
     n = len(text)

--- a/ci/check_quality_guardrails.py
+++ b/ci/check_quality_guardrails.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Fail CI on quality-guardrail regressions for high-risk runtime modules.
+
+This is a *ratchet*: it pins per-file metrics to a baseline and fails only when
+a metric grows past its recorded ceiling. Decreases are always allowed (and are
+the point — they let you tighten the baseline as the monolith is decomposed).
+
+Three guardrails, all read from ``ci/quality_guardrails_baseline.json``:
+
+* ``max_lines``      — per-file line-count ceiling (keeps the entry-point
+                       monolith from regrowing after it is split up).
+* ``panic_budget``   — per-file ceiling on ``unwrap(`` / ``expect(`` /
+                       ``panic!(`` occurrences in *code* (comments and string
+                       literals are stripped before counting, so prose that
+                       merely mentions these never trips the gate). This is an
+                       interim ratchet; the strategic replacement is clippy's
+                       ``unwrap_used`` / ``expect_used`` / ``panic`` lints with a
+                       justified ``#[allow]`` at each sanctioned fail-closed
+                       site (e.g. the deliberate ``.lock().unwrap()`` calls that
+                       rely on ``panic = "abort"``). Tracked as a follow-up.
+* ``ownership_scope``— files that must never reintroduce
+                       ``State<Arc<AppState>>`` (handlers take
+                       ``State<Arc<ServiceState>>`` — CLAUDE.md invariant #11).
+
+Robustness notes (hardening over the original draft):
+* A baseline path that no longer exists on disk is reported as a loud WARNING
+  and skipped, never an unhandled ``FileNotFoundError``. Renaming/splitting a
+  tracked file (exactly what the architecture-review refactors do) must not
+  crash the gate; the warning tells the maintainer to update the baseline.
+* All diagnostics are emitted with repo-relative paths for stable output.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+BASELINE_PATH = REPO / "ci" / "quality_guardrails_baseline.json"
+
+PANIC_PATTERN = re.compile(r"unwrap\(|expect\(|panic!\(")
+OWNERSHIP_FORBIDDEN_PATTERNS = {
+    "State<Arc<AppState>> in handler runtime (use ServiceState — CLAUDE.md #11)": re.compile(
+        r"State<Arc<AppState>>"
+    ),
+}
+
+
+def strip_rust_noise(text: str) -> str:
+    """Return ``text`` with Rust line/block comments and double-quoted string
+    literal *contents* removed, so textual pattern counting sees only code.
+
+    This is an approximate lexer, not a full Rust parser: it handles ``//`` line
+    comments, ``/* ... */`` block comments (non-nested — the dominant case), and
+    ``"..."`` strings with backslash escapes. Raw strings (``r"..."``) are left
+    as-is; they are vanishingly rare for these patterns and erring toward
+    *counting* a possible occurrence keeps the ratchet fail-safe (it can only
+    over-count, never hide a real call)."""
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_line_comment = False
+    in_block_comment = False
+    in_string = False
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if in_line_comment:
+            if c == "\n":
+                in_line_comment = False
+                out.append(c)
+            i += 1
+            continue
+        if in_block_comment:
+            if c == "*" and nxt == "/":
+                in_block_comment = False
+                i += 2
+                continue
+            if c == "\n":
+                out.append(c)
+            i += 1
+            continue
+        if in_string:
+            if c == "\\":
+                i += 2  # skip escaped char
+                continue
+            if c == '"':
+                in_string = False
+            i += 1
+            continue
+        # not in any comment/string
+        if c == "/" and nxt == "/":
+            in_line_comment = True
+            i += 2
+            continue
+        if c == "/" and nxt == "*":
+            in_block_comment = True
+            i += 2
+            continue
+        if c == '"':
+            in_string = True
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def line_count(path: Path) -> int:
+    return sum(1 for _ in path.read_text(encoding="utf-8").splitlines())
+
+
+def panic_count(path: Path) -> int:
+    code = strip_rust_noise(path.read_text(encoding="utf-8"))
+    return len(PANIC_PATTERN.findall(code))
+
+
+def main() -> int:
+    baseline = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    def resolve(rel: str) -> Path | None:
+        path = REPO / rel
+        if not path.is_file():
+            warnings.append(
+                f"{rel}: tracked by the guardrail baseline but not found on disk "
+                f"(renamed/removed?) — update ci/quality_guardrails_baseline.json"
+            )
+            return None
+        return path
+
+    current_lines: dict[str, int] = {}
+    for rel, max_lines in baseline.get("max_lines", {}).items():
+        path = resolve(rel)
+        if path is None:
+            continue
+        lines = line_count(path)
+        current_lines[rel] = lines
+        if lines > max_lines:
+            errors.append(f"{rel}: {lines} lines > guardrail max {max_lines}")
+
+    current_panic_counts: dict[str, int] = {}
+    for rel, max_count in baseline.get("panic_budget", {}).items():
+        path = resolve(rel)
+        if path is None:
+            continue
+        count = panic_count(path)
+        current_panic_counts[rel] = count
+        if count > max_count:
+            errors.append(
+                f"{rel}: panic/unwrap/expect count {count} > guardrail max {max_count}"
+            )
+
+    for description, pattern in OWNERSHIP_FORBIDDEN_PATTERNS.items():
+        for rel in baseline.get("ownership_scope", []):
+            path = resolve(rel)
+            if path is None:
+                continue
+            # Strip comments/strings so an explanatory mention of the
+            # anti-pattern (e.g. a "use ServiceState, not AppState" note) does
+            # not register as a violation — only real code does.
+            if pattern.search(strip_rust_noise(path.read_text(encoding="utf-8"))):
+                errors.append(f"{rel}: ownership violation ({description})")
+
+    print("=== Quality guardrail metrics ===")
+    print(json.dumps({"lines": current_lines, "panic_budget": current_panic_counts}, indent=2))
+
+    if warnings:
+        print("\n=== Guardrail warnings (non-fatal) ===")
+        for warn in warnings:
+            print(f"- {warn}")
+
+    if errors:
+        print("\n=== Guardrail violations ===")
+        for err in errors:
+            print(f"- {err}")
+        print(
+            "\nFix the regression first. If the growth is intentional and reviewed, "
+            "raise the relevant ceiling in ci/quality_guardrails_baseline.json with a "
+            "justification in the PR. Decreases never need a baseline change."
+        )
+        return 1
+
+    print("\nAll quality guardrails satisfied.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/quality_guardrails_baseline.json
+++ b/ci/quality_guardrails_baseline.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Quality-guardrail ratchet baseline. Metrics may only DECREASE without review; an INCREASE fails CI (see ci/check_quality_guardrails.py). Seeded 2026-06-30 from the then-current tree. When a refactor legitimately raises a ceiling, bump it here with a justification in the PR; when it lowers one, tighten it here to lock the gain.",
+  "max_lines": {
+    "src/bin/kirra_verifier_service.rs": 3953,
+    "src/gateway/mod.rs": 434,
+    "src/verifier.rs": 1092,
+    "src/gateway/policy_layer.rs": 1036
+  },
+  "panic_budget": {
+    "src/bin/kirra_verifier_service.rs": 128,
+    "src/gateway/mod.rs": 10,
+    "src/verifier.rs": 27,
+    "src/gateway/policy_layer.rs": 14
+  },
+  "ownership_scope": [
+    "src/bin/kirra_verifier_service.rs",
+    "src/gateway/mod.rs",
+    "src/gateway/policy_layer.rs"
+  ]
+}

--- a/ci/quality_guardrails_baseline.json
+++ b/ci/quality_guardrails_baseline.json
@@ -14,6 +14,16 @@
   },
   "ownership_scope": [
     "src/bin/kirra_verifier_service.rs",
+    "src/bin/kirra_verifier_service/attestation.rs",
+    "src/bin/kirra_verifier_service/fleet.rs",
+    "src/bin/kirra_verifier_service/audit.rs",
+    "src/bin/kirra_verifier_service/action_filter.rs",
+    "src/bin/kirra_verifier_service/industrial.rs",
+    "src/bin/kirra_verifier_service/federation.rs",
+    "src/bin/kirra_verifier_service/actuator.rs",
+    "src/bin/kirra_verifier_service/fabric.rs",
+    "src/bin/kirra_verifier_service/console.rs",
+    "src/bin/kirra_verifier_service/operators.rs",
     "src/gateway/mod.rs",
     "src/gateway/policy_layer.rs"
   ]


### PR DESCRIPTION
## What

Adds a **ratchet** gate for high-risk runtime modules: it pins per-file metrics to a recorded baseline and fails CI only when a metric grows past its ceiling. Decreases are always allowed — that's the point, so the baseline can be tightened as the entry-point monolith is decomposed (PRs #719/#720/#721).

Files:
- `ci/check_quality_guardrails.py` — the gate.
- `ci/quality_guardrails_baseline.json` — the baseline, seeded from the current tree (gate is **green on commit**).
- `.github/workflows/ci.yml` — wires it into the existing `static-analysis` job.

## Three guardrails

| Guardrail | What it pins | Why |
|---|---|---|
| `max_lines` | per-file line-count ceiling | keeps the split-up monolith (`kirra_verifier_service.rs`) from regrowing |
| `panic_budget` | per-file `unwrap(`/`expect(`/`panic!(` count in **code only** | ratchet against new fail-open-by-panic surface |
| `ownership_scope` | forbids `State<Arc<AppState>>` in handler files | CLAUDE.md invariant #11 (handlers take `State<Arc<ServiceState>>`) |

## Hardening over the original draft

This is the reviewed, hardened version of an earlier draft that would have crashed and false-positived:

1. **No more crash on a missing path.** The draft did an unguarded `read_text()` on every baseline path → `FileNotFoundError` the moment a tracked file is renamed/split (exactly what the refactor PRs do). Now a missing path is a **loud non-fatal warning** and is skipped, telling the maintainer to update the baseline.
2. **Comment/string-aware panic counting.** The draft's regex counted occurrences inside comments and string literals. The hardened version strips Rust line/block comments and double-quoted string contents before matching. Verified: a synthetic sample with 5 raw matches counts only the **2 real calls**. (On the current tracked files raw == stripped, so the baseline is honest; the stripping protects against future prose.)
3. **Consistent repo-relative diagnostics** (the draft mixed absolute and relative paths).
4. **The gate actually gates.** The CI step uses `set -o pipefail` so the script's non-zero exit isn't masked by `| tee` (the same trap the Dependency-audit step calls out).

## On the panic budget specifically

It's documented in the script as an **interim ratchet**. The strategic replacement is clippy's `unwrap_used` / `expect_used` / `panic` lints with a justified `#[allow]` at each sanctioned fail-closed site (e.g. the deliberate `.lock().unwrap()` calls that rely on `panic = "abort"`) — which can distinguish intentional from risky in a way a count cannot. Tracked as a follow-up rather than forcing a large, noisy `#[allow]` migration into this PR.

## Verification

- `python3 -m py_compile` ✓, baseline JSON parses ✓, `ci.yml` parses ✓
- Green run on current tree → exit 0
- Failure path (tightened ceiling) → exit 1 with the violation listed
- Missing-path → non-fatal warning, exit 0
- Stripper unit check → 5 raw / 2 real

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_