### PR TITLE
ci: reconcile quality-guardrail baseline to merged main (#719/#720 drift)

### DIFF
--- a/ci/quality_guardrails_baseline.json
+++ b/ci/quality_guardrails_baseline.json
@@ -1,14 +1,14 @@
 {
-  "_comment": "Quality-guardrail ratchet baseline. Metrics may only DECREASE without review; an INCREASE fails CI (see ci/check_quality_guardrails.py). Seeded 2026-06-30 from the then-current tree. When a refactor legitimately raises a ceiling, bump it here with a justification in the PR; when it lowers one, tighten it here to lock the gain.",
+  "_comment": "Quality-guardrail ratchet baseline. Metrics may only DECREASE without review; an INCREASE fails CI (see ci/check_quality_guardrails.py). Reconciled 2026-06-30 to merged main: PRs #719 (gateway listener extraction + fail-closed exit binds) and #720 (startup fail-down: panic!/expect → tracing::error!+exit(1) match arms + subscriber init) legitimately grew the two line ceilings; the same work LOWERED the panic budgets, tightened here to lock the gain. When #721 (startup.rs extraction) merges, the bin line ceiling can be tightened again and startup.rs added to ownership_scope.",
   "max_lines": {
-    "src/bin/kirra_verifier_service.rs": 3953,
-    "src/gateway/mod.rs": 434,
+    "src/bin/kirra_verifier_service.rs": 4186,
+    "src/gateway/mod.rs": 507,
     "src/verifier.rs": 1092,
     "src/gateway/policy_layer.rs": 1036
   },
   "panic_budget": {
-    "src/bin/kirra_verifier_service.rs": 128,
-    "src/gateway/mod.rs": 10,
+    "src/bin/kirra_verifier_service.rs": 117,
+    "src/gateway/mod.rs": 7,
     "src/verifier.rs": 27,
     "src/gateway/policy_layer.rs": 14
   },


### PR DESCRIPTION
## Why

The quality-guardrail (#722) is currently **failing on `main`**. Its baseline was seeded from the pre-#719/#720 tree, but those two PRs merged afterward and legitimately grew the tracked files:

```
src/bin/kirra_verifier_service.rs  4186 > 3953  (guardrail max)
src/gateway/mod.rs                  507 > 434
```

This is merge-order drift, not a real regression.

## What changed

- **Raise the two line ceilings** to merged reality (`kirra_verifier_service.rs` → 4186, `gateway/mod.rs` → 507). The growth is reviewed safety work:
  - **#720** converted terse `.expect()`/`panic!()` startup aborts into explicit fail-closed `tracing::error! + std::process::exit(1)` match arms (intentionally more verbose) and added the startup tracing subscriber.
  - **#719** extracted the admin/metrics listener thread bodies and added fail-closed `exit(1)` binds in the PLC proxy gateway.
- **Tighten the panic budgets** the same work lowered (`bin` 128→117, `gateway/mod.rs` 10→7) to lock in the reduction — those PRs replaced `panic!`/`expect` with structured exits. (`verifier.rs` / `policy_layer.rs` unchanged.)

## Follow-up (unchanged plan)

When **#721** (startup.rs extraction) merges it removes ~238 lines from the bin, so the bin ceiling can be tightened again and `startup.rs` added to `ownership_scope`.

## Verification

`python3 ci/check_quality_guardrails.py` → **exit 0** against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_