### PR TITLE
ci: tighten bin ceiling + track startup.rs after #721 extraction

### DIFF
--- a/ci/quality_guardrails_baseline.json
+++ b/ci/quality_guardrails_baseline.json
@@ -1,19 +1,22 @@
 {
-  "_comment": "Quality-guardrail ratchet baseline. Metrics may only DECREASE without review; an INCREASE fails CI (see ci/check_quality_guardrails.py). Reconciled 2026-06-30 to merged main: PRs #719 (gateway listener extraction + fail-closed exit binds) and #720 (startup fail-down: panic!/expect → tracing::error!+exit(1) match arms + subscriber init) legitimately grew the two line ceilings; the same work LOWERED the panic budgets, tightened here to lock the gain. When #721 (startup.rs extraction) merges, the bin line ceiling can be tightened again and startup.rs added to ownership_scope.",
+  "_comment": "Quality-guardrail ratchet baseline. Metrics may only DECREASE without review; an INCREASE fails CI (see ci/check_quality_guardrails.py). #721 (startup.rs extraction) then merged, removing ~227 lines from the bin — bin line ceiling tightened 4186→3959 to lock that gain, and the new SG-008 startup.rs is now tracked (line ceiling + panic_budget 0, keeping the fail-closed predicate panic-free) and added to ownership_scope. When a refactor legitimately raises a ceiling, bump it with a justification in the PR; when it lowers one, tighten it here.",
   "max_lines": {
-    "src/bin/kirra_verifier_service.rs": 4186,
+    "src/bin/kirra_verifier_service.rs": 3959,
+    "src/bin/kirra_verifier_service/startup.rs": 248,
     "src/gateway/mod.rs": 507,
     "src/verifier.rs": 1092,
     "src/gateway/policy_layer.rs": 1036
   },
   "panic_budget": {
     "src/bin/kirra_verifier_service.rs": 117,
+    "src/bin/kirra_verifier_service/startup.rs": 0,
     "src/gateway/mod.rs": 7,
     "src/verifier.rs": 27,
     "src/gateway/policy_layer.rs": 14
   },
   "ownership_scope": [
     "src/bin/kirra_verifier_service.rs",
+    "src/bin/kirra_verifier_service/startup.rs",
     "src/bin/kirra_verifier_service/attestation.rs",
     "src/bin/kirra_verifier_service/fleet.rs",
     "src/bin/kirra_verifier_service/audit.rs",


### PR DESCRIPTION
## Why

Follow-up to #721 (SG-008 startup sentinel extraction) and #723 (baseline reconcile). #721 moved ~227 lines out of the bin into `src/bin/kirra_verifier_service/startup.rs`. Because #721 merged *ahead* of #723, the baseline ended up **loose** (bin ceiling 4186 vs actual 3959) and `startup.rs` was untracked — `main` stayed **green** throughout, this is hygiene, not a fix.

## What changed

- **Tighten** `src/bin/kirra_verifier_service.rs` `max_lines` 4186 → **3959**, locking in the extraction's reduction.
- **Track `startup.rs`** (the new SG-008 file):
  - `max_lines` 248
  - `panic_budget` **0** — the fail-closed predicate is pure (returns `Result`; `exit` happens in `main`), so pinning 0 keeps it panic-free going forward.
  - added to `ownership_scope`.

`gateway/mod.rs` (507) and the others are unchanged.

## Verification

`python3 ci/check_quality_guardrails.py` → **exit 0** against `main`, now with all five tracked files exact-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_