### PR TITLE
feat(timing): kirra-timing — certifiable WCET instrumentation primitives (L1 / #274)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,6 +2175,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-timing"
+version = "0.1.0"
+
+[[package]]
 name = "kirra-trajectory"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
+members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-timing", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
 resolver = "2"
 
 [package]

--- a/crates/kirra-timing/Cargo.toml
+++ b/crates/kirra-timing/Cargo.toml
@@ -1,0 +1,43 @@
+# kirra-timing — certifiable WCET timing-instrumentation primitives (#274 / L1).
+#
+# A lean, `no_std`, zero-dependency, zero-alloc timing library for the QNX-target
+# WCET measurement campaign. It provides the measurement TYPES (channels,
+# percentile/jitter capture, environment tagging, report rendering) and a
+# zero-overhead-when-disabled instrumentation macro. It deliberately does NOT
+# read any clock itself: the monotonic clock is supplied by the caller via the
+# `MonotonicClock` trait, so the target binds the boundary-domain counter
+# (HVCHAN-001 §5) at the integration seam — exactly the contract-channel
+# "the target binds the region" discipline.
+#
+# Normative rule baked into the types (WCET_MEASUREMENT_METHODOLOGY.md): host
+# numbers are INDICATIVE, never WCET. `MeasurementEnv::is_certified_wcet()` is the
+# single source of truth, and reports print an INDICATIVE banner unless the
+# environment is the QNX target under FIFO scheduling.
+[package]
+name = "kirra-timing"
+version = "0.1.0"
+edition = "2021"
+description = "Certifiable no_std/zero-alloc WCET timing-instrumentation primitives (min/avg/max/jitter + percentiles, env-tagged reports) for the QNX target campaign (#274)"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+
+[dependencies]
+# INTENTIONALLY EMPTY. Like kirra-contract-channel: the certifiable measurement
+# primitives are integer-only and self-contained (no float, no libm, no serde,
+# no transport). The clock is injected via a trait; the only place a concrete
+# clock lives is the caller / target integration shim.
+
+[features]
+default = []
+# `instrument` makes `wcet_measure!` actually read the clock and record. With it
+# OFF (the production default) the macro expands to JUST the measured block — no
+# clock read, no record call, no overhead. This is the certifiable
+# "instrumentation is campaign-only, never the shipped hot path" property.
+instrument = []
+# `std` provides `StdMonotonicClock` (an `Instant`-backed `MonotonicClock`) for
+# host campaigns and CI. Off by default so the crate stays `no_std` for the QNX
+# target, which supplies its own boundary-domain clock.
+std = []
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/crates/kirra-timing/README.md
+++ b/crates/kirra-timing/README.md
@@ -65,7 +65,10 @@ report.write_csv(&mut csv).unwrap();             // machine CSV
 3. **Run the worst-case load** (methodology §3): max-size payload, max rate,
    concurrent fault injection; warm-up separated from the measured set.
 4. **Export** the CSV (`write_csv`) as the campaign artifact and the table for
-   humans. Columns: `metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status`.
+   humans. Columns: `metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status`
+   — an **extended superset** of the `wcet_measure.cpp` row (shares
+   `metric,sched,n,max_ns,p999_ns,wcet_status`; adds `env` + the lower
+   percentiles/moments). Not byte-identical; map columns if joining.
 5. **Gate on the tail** (`p999_ns`), not `max` — the `wcet_gate.rs` precedent:
    `max` is dominated by scheduler/hypervisor jitter on shared hosts.
 

--- a/crates/kirra-timing/README.md
+++ b/crates/kirra-timing/README.md
@@ -1,0 +1,77 @@
+# kirra-timing
+
+Certifiable WCET timing-instrumentation primitives for the QNX-target measurement
+campaign (**#274 / roadmap L1**).
+
+This crate is the reusable *measurement substrate* the WCET campaign builds on:
+per-stage channels that capture exact min/avg/max + jitter and bounded-memory
+percentiles, an environment tag that encodes the host-vs-WCET rule, deterministic
+CSV/table reports, and a `wcet_measure!` macro that is **zero overhead when
+disabled**. It is the missing foundation noted in
+[`docs/safety/WCET_MEASUREMENT_METHODOLOGY.md`](../../docs/safety/WCET_MEASUREMENT_METHODOLOGY.md);
+it does not change any safety logic.
+
+## Properties (all load-bearing)
+
+- **`no_std`, zero dependencies, `#![forbid(unsafe_code)]`** — the
+  `kirra-contract-channel` minimal-TCB discipline. Integer-only math (a pure
+  `isqrt` for jitter); no `f64`, no `libm`, no `serde`, no transport.
+- **No allocation on the hot path.** A `WcetChannel<BUCKETS>` is fixed-size;
+  `record_nanos` is `O(1)`. Percentiles/reports are computed off the hot path.
+- **The crate never reads a clock.** The caller injects a `MonotonicClock`. The
+  QNX target binds the **boundary-domain** monotonic counter
+  ([HVCHAN-001 §5](../../docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md)) at the
+  integration shim; host/CI uses `StdMonotonicClock` (`std` feature).
+- **Host numbers are INDICATIVE, never WCET.** `MeasurementEnv::is_certified_wcet()`
+  is the single source of truth; only `QnxTargetFifo` qualifies, and `Report`
+  prints an INDICATIVE banner / `INDICATIVE-NOT-WCET` status otherwise.
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `instrument` | off | `wcet_measure!` actually reads the clock and records. **Off → the macro expands to just the measured block** (no clock read, no record, no branch). Instrumentation is campaign-only, never the shipped hot path. |
+| `std` | off | Provides `StdMonotonicClock` (an `Instant`-backed clock) for host/CI campaigns. Off keeps the crate `no_std` for the target. |
+
+## Usage
+
+```rust
+use kirra_timing::{WcetChannel, MeasurementEnv, Report, StageReport, stage, wcet_measure};
+
+let clock = my_boundary_domain_clock();          // impl MonotonicClock
+let mut governor: WcetChannel<256> = WcetChannel::new(100); // 256 × 100 ns = 0..25.6 µs
+
+let verdict = wcet_measure!(governor, clock, {
+    run_governor_verdict(/* ... */)              // measured only when `instrument` is on
+});
+
+// Off the hot path, at campaign end:
+let stages = [StageReport::new(stage::GOVERNOR_EXEC, governor.snapshot())];
+let report = Report::new(MeasurementEnv::Host, "host-default", &stages);
+println!("{report}");                            // human table + INDICATIVE banner
+let mut csv = String::new();
+report.write_csv(&mut csv).unwrap();             // machine CSV
+```
+
+## Reproducible measurement procedure
+
+1. **Build with instrumentation on** for the campaign target only:
+   - host/CI (indicative): `cargo test -p kirra-timing --features instrument,std`
+   - QNX target: build the consuming binary with `--features instrument` and bind
+     a `MonotonicClock` to the boundary-domain counter under `SCHED_FIFO`
+     (target build is out of this crate; see `tools/qnx-rtm-harness/`).
+2. **Tag the environment** with the true `MeasurementEnv`. Only `QnxTargetFifo`
+   renders as WCET evidence; everything else is INDICATIVE by construction.
+3. **Run the worst-case load** (methodology §3): max-size payload, max rate,
+   concurrent fault injection; warm-up separated from the measured set.
+4. **Export** the CSV (`write_csv`) as the campaign artifact and the table for
+   humans. Columns: `metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status`.
+5. **Gate on the tail** (`p999_ns`), not `max` — the `wcet_gate.rs` precedent:
+   `max` is dominated by scheduler/hypervisor jitter on shared hosts.
+
+## Scope / status
+
+This crate is the library + its tests. **Wiring it into the `ros2`-gated hot loops
+and the QNX `wcet_measure` harness is a separate, reviewed follow-up** — that step
+needs CI / target validation, and per the methodology the production hot path ships
+with `instrument` **off**.

--- a/crates/kirra-timing/src/channel.rs
+++ b/crates/kirra-timing/src/channel.rs
@@ -1,0 +1,200 @@
+//! [`WcetChannel`] — the zero-alloc, integer-only per-stage measurement sink.
+//!
+//! One channel accumulates the timing samples for ONE execution-loop stage
+//! (perception input, governor execution, parko evaluation, actuator publication,
+//! or total loop). Recording a sample is `O(1)` and allocation-free; the
+//! distribution lives in a fixed-size histogram chosen at construction.
+
+/// Integer square root of a `u128` (Newton's method). Pure-integer so the whole
+/// crate stays `no_std` with no `libm` / float dependency — stddev (jitter) is
+/// computed without ever touching `f64`.
+#[must_use]
+fn isqrt_u128(n: u128) -> u64 {
+    if n == 0 {
+        return 0;
+    }
+    let mut x = n;
+    let mut y = x.div_ceil(2);
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    // x ≤ sqrt(u128::MAX) < 2^64, so the cast is lossless.
+    x as u64
+}
+
+/// An immutable snapshot of a [`WcetChannel`]'s statistics. Non-generic and
+/// `Copy` so reports can hold a uniform slice regardless of histogram size.
+///
+/// All fields are nanoseconds. `min`/`max`/`mean` are exact; `stddev` is the
+/// (population) standard deviation computed from exact integer moments; the
+/// percentiles are histogram-derived and CONSERVATIVE (rounded up to the bucket
+/// upper edge, or to the exact `max` when they fall in the overflow region).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChannelStats {
+    /// Number of samples recorded.
+    pub count: u64,
+    /// Smallest sample (ns); `0` when `count == 0`.
+    pub min_ns: u64,
+    /// Largest sample (ns) — exact. The WCET-relevant figure.
+    pub max_ns: u64,
+    /// Arithmetic mean (ns), integer-truncated.
+    pub mean_ns: u64,
+    /// Population standard deviation (ns) — the jitter figure.
+    pub stddev_ns: u64,
+    /// Peak-to-peak spread (`max - min`, ns) — the second jitter figure.
+    pub peak_to_peak_ns: u64,
+    /// Median (50th percentile), conservative bucket upper edge.
+    pub p50_ns: u64,
+    /// 99th percentile, conservative bucket upper edge.
+    pub p99_ns: u64,
+    /// 99.9th percentile, conservative bucket upper edge. The tail figure the
+    /// `wcet_gate.rs` precedent gates on.
+    pub p999_ns: u64,
+}
+
+impl ChannelStats {
+    /// The zero snapshot (no samples).
+    pub const EMPTY: Self = Self {
+        count: 0,
+        min_ns: 0,
+        max_ns: 0,
+        mean_ns: 0,
+        stddev_ns: 0,
+        peak_to_peak_ns: 0,
+        p50_ns: 0,
+        p99_ns: 0,
+        p999_ns: 0,
+    };
+}
+
+/// A per-stage WCET measurement sink with `BUCKETS` histogram buckets.
+///
+/// Exact streaming aggregates (`count`/`min`/`max`/`sum`/`sum_sq`) give exact
+/// min/avg/max and jitter with no buffer; the fixed histogram gives bounded-memory
+/// percentiles. Everything is `O(1)` per sample and allocation-free, so a channel
+/// is safe to `record_nanos` from inside a deterministic loop (when the
+/// `instrument` feature is on — see [`crate::wcet_measure`]).
+#[derive(Debug, Clone)]
+pub struct WcetChannel<const BUCKETS: usize> {
+    bucket_width_ns: u64,
+    buckets: [u64; BUCKETS],
+    /// Samples at or beyond `BUCKETS * bucket_width_ns`.
+    overflow: u64,
+    count: u64,
+    min_ns: u64,
+    max_ns: u64,
+    sum_ns: u128,
+    sum_sq_ns: u128,
+}
+
+impl<const BUCKETS: usize> WcetChannel<BUCKETS> {
+    /// Create an empty channel whose histogram bucket `i` covers
+    /// `[i * bucket_width_ns, (i + 1) * bucket_width_ns)`. `bucket_width_ns` is
+    /// clamped to at least `1` so binning is always well-defined.
+    #[must_use]
+    pub const fn new(bucket_width_ns: u64) -> Self {
+        Self {
+            bucket_width_ns: if bucket_width_ns == 0 { 1 } else { bucket_width_ns },
+            buckets: [0; BUCKETS],
+            overflow: 0,
+            count: 0,
+            min_ns: u64::MAX,
+            max_ns: 0,
+            sum_ns: 0,
+            sum_sq_ns: 0,
+        }
+    }
+
+    /// Record one elapsed-duration sample (ns). `O(1)`, allocation-free.
+    #[inline]
+    pub fn record_nanos(&mut self, ns: u64) {
+        self.count += 1;
+        if ns < self.min_ns {
+            self.min_ns = ns;
+        }
+        if ns > self.max_ns {
+            self.max_ns = ns;
+        }
+        let ns128 = ns as u128;
+        self.sum_ns += ns128;
+        self.sum_sq_ns += ns128 * ns128;
+
+        let bucket = (ns / self.bucket_width_ns) as usize;
+        if bucket < BUCKETS {
+            self.buckets[bucket] += 1;
+        } else {
+            self.overflow += 1;
+        }
+    }
+
+    /// Number of samples recorded so far.
+    #[must_use]
+    pub const fn count(&self) -> u64 {
+        self.count
+    }
+
+    /// Reset to empty, keeping the configured bucket width — for a fresh campaign
+    /// run without reallocating.
+    pub fn reset(&mut self) {
+        self.buckets = [0; BUCKETS];
+        self.overflow = 0;
+        self.count = 0;
+        self.min_ns = u64::MAX;
+        self.max_ns = 0;
+        self.sum_ns = 0;
+        self.sum_sq_ns = 0;
+    }
+
+    /// Conservative percentile (ns) for `per_mille` ∈ `[0, 1000]`
+    /// (e.g. `500` → p50, `990` → p99, `999` → p99.9). Returns the upper edge of
+    /// the bucket the percentile falls in (rounds up), or the exact `max` when it
+    /// falls in the overflow region — never an optimistic value.
+    #[must_use]
+    pub fn percentile_nanos(&self, per_mille: u32) -> u64 {
+        if self.count == 0 {
+            return 0;
+        }
+        let pm = per_mille.min(1000) as u64;
+        // Ceil so e.g. p100 maps to the last sample, not one short.
+        let threshold = (self.count * pm).div_ceil(1000);
+        let mut cum = 0u64;
+        let mut i = 0;
+        while i < BUCKETS {
+            cum += self.buckets[i];
+            if cum >= threshold {
+                // Upper edge of bucket i, but never report above the exact max.
+                let edge = (i as u64 + 1).saturating_mul(self.bucket_width_ns);
+                return edge.min(self.max_ns);
+            }
+            i += 1;
+        }
+        // Remaining mass is in the overflow region → the exact max bounds it.
+        self.max_ns
+    }
+
+    /// Snapshot the current statistics. Off the hot path (compute when reporting).
+    #[must_use]
+    pub fn snapshot(&self) -> ChannelStats {
+        if self.count == 0 {
+            return ChannelStats::EMPTY;
+        }
+        let count128 = self.count as u128;
+        let mean = self.sum_ns / count128; // integer-truncated
+        // Population variance = E[x^2] - (E[x])^2, computed from exact integer
+        // moments; saturating so truncation in `mean` can't underflow it.
+        let mean_of_sq = self.sum_sq_ns / count128;
+        let variance = mean_of_sq.saturating_sub(mean * mean);
+        ChannelStats {
+            count: self.count,
+            min_ns: self.min_ns,
+            max_ns: self.max_ns,
+            mean_ns: mean as u64,
+            stddev_ns: isqrt_u128(variance),
+            peak_to_peak_ns: self.max_ns - self.min_ns,
+            p50_ns: self.percentile_nanos(500),
+            p99_ns: self.percentile_nanos(990),
+            p999_ns: self.percentile_nanos(999),
+        }
+    }
+}

--- a/crates/kirra-timing/src/channel.rs
+++ b/crates/kirra-timing/src/channel.rs
@@ -120,9 +120,13 @@ impl<const BUCKETS: usize> WcetChannel<BUCKETS> {
         self.sum_ns += ns128;
         self.sum_sq_ns += ns128 * ns128;
 
-        let bucket = (ns / self.bucket_width_ns) as usize;
-        if bucket < BUCKETS {
-            self.buckets[bucket] += 1;
+        // Compute the bucket index in u64 and cast to usize ONLY after the range
+        // check: on a 32-bit target (some QNX/ARM configs) a large sample would
+        // otherwise truncate in the `as usize` cast and be mis-binned into an
+        // in-range bucket instead of `overflow`, skewing the percentiles.
+        let bucket = ns / self.bucket_width_ns;
+        if bucket < BUCKETS as u64 {
+            self.buckets[bucket as usize] += 1;
         } else {
             self.overflow += 1;
         }
@@ -179,12 +183,18 @@ impl<const BUCKETS: usize> WcetChannel<BUCKETS> {
         if self.count == 0 {
             return ChannelStats::EMPTY;
         }
-        let count128 = self.count as u128;
-        let mean = self.sum_ns / count128; // integer-truncated
-        // Population variance = E[x^2] - (E[x])^2, computed from exact integer
-        // moments; saturating so truncation in `mean` can't underflow it.
-        let mean_of_sq = self.sum_sq_ns / count128;
-        let variance = mean_of_sq.saturating_sub(mean * mean);
+        let n = self.count as u128;
+        let mean = self.sum_ns / n; // integer-truncated (fine for the reported mean)
+        // Exact population variance = (n·Σx² − (Σx)²) / n². The division is
+        // deferred to the very end so it is NOT pre-truncated — the moment form
+        // (Σx²/n − (Σx/n)²) truncates BEFORE subtracting and under-estimates
+        // (e.g. samples [10,11] would read stddev 3 instead of ~0). Overflow-safe:
+        // for an extreme campaign size where n·Σx² or (Σx)² exceeds u128, fall
+        // back to the moment form (a conservative, slightly-low estimate).
+        let variance = match (self.sum_sq_ns.checked_mul(n), self.sum_ns.checked_mul(self.sum_ns)) {
+            (Some(n_sum_sq), Some(sum_squared)) => n_sum_sq.saturating_sub(sum_squared) / (n * n),
+            _ => (self.sum_sq_ns / n).saturating_sub(mean * mean),
+        };
         ChannelStats {
             count: self.count,
             min_ns: self.min_ns,

--- a/crates/kirra-timing/src/clock.rs
+++ b/crates/kirra-timing/src/clock.rs
@@ -1,0 +1,66 @@
+//! Monotonic clock abstraction.
+//!
+//! The library never reads a clock itself: the caller injects one via
+//! [`MonotonicClock`]. On the QNX target this binds the hypervisor boundary-domain
+//! monotonic counter (HVCHAN-001 §5) at the integration shim — the contract
+//! channel's "the target binds the region" discipline applied to time. On host /
+//! CI the [`StdMonotonicClock`] (behind the `std` feature) backs campaigns.
+
+/// A monotonic, non-decreasing nanosecond source used ONLY for differencing
+/// (durations) — never as wall-clock or PTP time.
+///
+/// HVCHAN-001 §5 non-mixing rule: the value returned here is a *boundary-domain*
+/// monotonic count; it must not be compared against system/PTP time. The crate
+/// only ever subtracts two reads of the SAME clock to form an elapsed duration.
+pub trait MonotonicClock {
+    /// Monotonic nanoseconds since an arbitrary, fixed epoch. Successive calls
+    /// must be non-decreasing on a given clock instance.
+    fn now_nanos(&self) -> u64;
+
+    /// Elapsed nanoseconds since `start` (a prior [`MonotonicClock::now_nanos`]).
+    /// `saturating_sub` so a non-monotonic read can never produce a wrapped /
+    /// negative-as-huge duration — it reads as `0`, which a downstream WCET gate
+    /// treats conservatively rather than as a spurious tail sample.
+    #[inline]
+    fn elapsed_nanos_since(&self, start: u64) -> u64 {
+        self.now_nanos().saturating_sub(start)
+    }
+}
+
+/// An [`Instant`]-backed monotonic clock for host and CI campaigns.
+///
+/// Indicative-only by construction: pair it with [`crate::MeasurementEnv::Host`]
+/// or [`crate::MeasurementEnv::CiRunner`] so reports are never mislabeled as WCET.
+///
+/// [`Instant`]: std::time::Instant
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, Copy)]
+pub struct StdMonotonicClock {
+    epoch: std::time::Instant,
+}
+
+#[cfg(feature = "std")]
+impl StdMonotonicClock {
+    /// Anchor the epoch at "now". All `now_nanos` reads are relative to it.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { epoch: std::time::Instant::now() }
+    }
+}
+
+#[cfg(feature = "std")]
+impl Default for StdMonotonicClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "std")]
+impl MonotonicClock for StdMonotonicClock {
+    #[inline]
+    fn now_nanos(&self) -> u64 {
+        // `Instant` is monotonic; `as u64` is safe for any realistic campaign
+        // duration (u64 ns ≈ 584 years).
+        self.epoch.elapsed().as_nanos() as u64
+    }
+}

--- a/crates/kirra-timing/src/clock.rs
+++ b/crates/kirra-timing/src/clock.rs
@@ -27,6 +27,16 @@ pub trait MonotonicClock {
     }
 }
 
+/// Blanket impl so a `&Clock` is itself a [`MonotonicClock`]. This lets
+/// [`crate::wcet_measure!`] accept either an owned clock or a reference without
+/// the caller worrying about `&&T` mismatches.
+impl<T: MonotonicClock + ?Sized> MonotonicClock for &T {
+    #[inline]
+    fn now_nanos(&self) -> u64 {
+        (**self).now_nanos()
+    }
+}
+
 /// An [`Instant`]-backed monotonic clock for host and CI campaigns.
 ///
 /// Indicative-only by construction: pair it with [`crate::MeasurementEnv::Host`]

--- a/crates/kirra-timing/src/env.rs
+++ b/crates/kirra-timing/src/env.rs
@@ -1,0 +1,54 @@
+//! Measurement environment tagging — the host-vs-target WCET invariant in types.
+
+/// The environment a timing campaign ran in.
+///
+/// This enum is the **single source of truth** for the normative rule in
+/// `docs/safety/WCET_MEASUREMENT_METHODOLOGY.md`: *host numbers are INDICATIVE,
+/// never WCET; only QNX-target-under-FIFO numbers feed an FTTI claim.* Reports
+/// (see [`crate::report`]) print an INDICATIVE banner and a non-certified
+/// `wcet_status` unless [`MeasurementEnv::is_certified_wcet`] holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MeasurementEnv {
+    /// A developer/shared host. Indicative only.
+    Host,
+    /// A CI runner (shared, virtualized). Indicative only — scheduler/hypervisor
+    /// jitter dominates `max`; this is the `wcet_gate.rs` precedent.
+    CiRunner,
+    /// The QNX safety partition under `SCHED_FIFO`, certified toolchain, frozen
+    /// partition config. The ONLY environment whose numbers are WCET evidence.
+    QnxTargetFifo,
+    /// Any other environment (e.g. QNX target NOT under FIFO). Indicative.
+    Other,
+}
+
+impl MeasurementEnv {
+    /// `true` only for [`MeasurementEnv::QnxTargetFifo`]. Everything else is
+    /// indicative — never presented as WCET (methodology §4 host-indicative rule).
+    #[must_use]
+    pub const fn is_certified_wcet(self) -> bool {
+        matches!(self, Self::QnxTargetFifo)
+    }
+
+    /// Short stable label for CSV / report rows.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Host => "host",
+            Self::CiRunner => "ci-runner",
+            Self::QnxTargetFifo => "qnx-target-fifo",
+            Self::Other => "other",
+        }
+    }
+
+    /// The `wcet_status` token used in CSV exports — mirrors
+    /// `tools/qnx-rtm-harness/wcet_measure.cpp`: `QNX-TARGET-MEASURED` on the
+    /// certified target, `INDICATIVE-NOT-WCET` everywhere else.
+    #[must_use]
+    pub const fn wcet_status(self) -> &'static str {
+        if self.is_certified_wcet() {
+            "QNX-TARGET-MEASURED"
+        } else {
+            "INDICATIVE-NOT-WCET"
+        }
+    }
+}

--- a/crates/kirra-timing/src/lib.rs
+++ b/crates/kirra-timing/src/lib.rs
@@ -36,6 +36,7 @@
 //!
 //! let clock = FakeClock(core::cell::Cell::new(0));
 //! // 256 buckets × 100 ns = 0..25.6 µs histogram; samples beyond go to overflow.
+//! #[allow(unused_mut)] // `mut` is used only when the `instrument` feature is on
 //! let mut governor: WcetChannel<256> = WcetChannel::new(100);
 //!
 //! // With `instrument` ON this brackets the block with clock reads and records
@@ -45,6 +46,7 @@
 //!     true
 //! });
 //! assert!(verdict);
+//! let _stats = governor.snapshot(); // consume off the hot path at campaign end
 //! ```
 //!
 //! Scope note: this increment delivers the library and its tests. Wiring it into
@@ -52,6 +54,10 @@
 //! follow-up (it needs CI / target validation, per the methodology).
 
 #![cfg_attr(not(test), no_std)]
+// Enforce the minimal-TCB guarantee at the crate root too (not only via the
+// Cargo `[lints]` table) — robust even if lint settings change or are bypassed,
+// matching `kirra-contract-channel`.
+#![forbid(unsafe_code)]
 
 // The crate is `no_std` for the target; the optional `std` feature (host/CI
 // clock) needs `std` explicitly linked when not already the test sysroot.
@@ -89,32 +95,36 @@ pub mod stage {
 /// Measure `block`, recording its elapsed nanoseconds into `channel` using
 /// `clock` — **only when the `instrument` feature is enabled**.
 ///
-/// With `instrument` OFF (the production default) this expands to exactly
-/// `{ block }`: no clock read, no record call, no branch — the certifiable
-/// "instrumentation is campaign-only, never the shipped hot path" property. The
-/// macro evaluates to the block's value either way.
+/// Two cfg-gated definitions exist; exactly one is compiled:
+/// - `instrument` ON — brackets `block` with monotonic clock reads via UFCS
+///   (`MonotonicClock::now_nanos(&clock)`, so the trait need not be imported at
+///   the call site, and a `&clock` works via the blanket `&T` impl) and records
+///   the elapsed time. Evaluates to the block's value.
+/// - `instrument` OFF (production default) — expands to **exactly `{ block }`**:
+///   `channel` and `clock` are not evaluated or touched at all, so there is no
+///   clock read, no record call, no branch. This is the certifiable
+///   "instrumentation is campaign-only, never the shipped hot path" property.
 ///
 /// `clock` must implement [`MonotonicClock`]; `channel` must be a mutable
 /// [`WcetChannel`].
+#[cfg(feature = "instrument")]
 #[macro_export]
 macro_rules! wcet_measure {
     ($channel:expr, $clock:expr, $block:block) => {{
-        #[cfg(feature = "instrument")]
-        {
-            let __wcet_start = $crate::MonotonicClock::now_nanos(&$clock);
-            let __wcet_result = $block;
-            let __wcet_elapsed =
-                $crate::MonotonicClock::elapsed_nanos_since(&$clock, __wcet_start);
-            $channel.record_nanos(__wcet_elapsed);
-            __wcet_result
-        }
-        #[cfg(not(feature = "instrument"))]
-        {
-            // Zero overhead: the channel/clock are not touched at all.
-            let _ = (&$channel, &$clock);
-            $block
-        }
+        let __wcet_start = $crate::MonotonicClock::now_nanos(&$clock);
+        let __wcet_result = $block;
+        let __wcet_elapsed = $crate::MonotonicClock::elapsed_nanos_since(&$clock, __wcet_start);
+        $channel.record_nanos(__wcet_elapsed);
+        __wcet_result
     }};
+}
+
+/// Disabled form — see the enabled definition's docs. Expands to exactly the
+/// measured block; `channel`/`clock` are not referenced.
+#[cfg(not(feature = "instrument"))]
+#[macro_export]
+macro_rules! wcet_measure {
+    ($channel:expr, $clock:expr, $block:block) => {{ $block }};
 }
 
 #[cfg(test)]
@@ -163,6 +173,20 @@ mod tests {
         let s = ch.snapshot();
         assert_eq!(s.mean_ns, 5);
         assert_eq!(s.stddev_ns, 2);
+    }
+
+    #[test]
+    fn variance_uses_exact_moments_not_truncated() {
+        // [10, 11]: true population variance is 0.25 → integer floor 0 → stddev 0.
+        // The OLD truncated-moment form (mean=10, mean_of_sq=110) gave variance 10
+        // → stddev 3, a gross over-estimate. The exact (n·Σx²−(Σx)²)/n² form must
+        // floor to 0 here. Regression guard for the deferred-division fix.
+        let mut ch: WcetChannel<64> = WcetChannel::new(1);
+        ch.record_nanos(10);
+        ch.record_nanos(11);
+        let s = ch.snapshot();
+        assert_eq!(s.mean_ns, 10); // 21/2 truncated
+        assert_eq!(s.stddev_ns, 0, "exact variance floors to 0, not the truncated 3");
     }
 
     #[test]
@@ -270,7 +294,9 @@ mod tests {
     #[test]
     fn macro_disabled_is_zero_overhead_passthrough() {
         // Without the `instrument` feature the macro must not touch the channel.
+        // `mut` is only exercised on the enabled path, hence the allow.
         let clock = StepClock::new();
+        #[allow(unused_mut)]
         let mut ch: WcetChannel<8> = WcetChannel::new(1);
         let out = wcet_measure!(ch, clock, {
             clock.set(999);

--- a/crates/kirra-timing/src/lib.rs
+++ b/crates/kirra-timing/src/lib.rs
@@ -1,0 +1,298 @@
+//! # kirra-timing — certifiable WCET timing-instrumentation primitives (#274 / L1)
+//!
+//! A lean, `no_std`, zero-dependency, **zero-alloc** timing library for the
+//! QNX-target WCET measurement campaign. It supplies the measurement *types* —
+//! per-stage channels with exact min/avg/max + jitter and bounded-memory
+//! percentiles ([`WcetChannel`]), an environment tag that encodes the
+//! host-vs-WCET rule ([`MeasurementEnv`]), and deterministic CSV/table reports
+//! ([`report::Report`]) — plus a [`wcet_measure!`] macro that is **zero overhead
+//! when the `instrument` feature is off** (it expands to just the measured block,
+//! with no clock read and no record call).
+//!
+//! ## Design constraints (all load-bearing, mirroring the repo precedents)
+//!
+//! - **`no_std`, zero deps, `#![forbid(unsafe_code)]`** — like
+//!   `kirra-contract-channel`. Integer-only math (a pure-integer `isqrt` for
+//!   jitter), so there is no `f64`/`libm` dependency anywhere.
+//! - **No allocation on the hot path.** A channel is fixed-size; `record_nanos`
+//!   is `O(1)`. Percentile/report computation is done off the hot path.
+//! - **The crate never reads a clock.** The caller injects a [`MonotonicClock`];
+//!   the QNX target binds the boundary-domain monotonic counter (HVCHAN-001 §5)
+//!   at the integration shim. On host/CI use [`StdMonotonicClock`] (`std` feature).
+//! - **Host numbers are INDICATIVE, never WCET** (WCET_MEASUREMENT_METHODOLOGY.md).
+//!   [`MeasurementEnv::is_certified_wcet`] is the one source of truth and reports
+//!   print an INDICATIVE banner unless the environment is the QNX target / FIFO.
+//!
+//! ## Usage
+//!
+//! ```
+//! use kirra_timing::{WcetChannel, MonotonicClock, wcet_measure};
+//!
+//! // A test/host clock; on target this is the boundary-domain counter.
+//! struct FakeClock(core::cell::Cell<u64>);
+//! impl MonotonicClock for FakeClock {
+//!     fn now_nanos(&self) -> u64 { self.0.get() }
+//! }
+//!
+//! let clock = FakeClock(core::cell::Cell::new(0));
+//! // 256 buckets × 100 ns = 0..25.6 µs histogram; samples beyond go to overflow.
+//! let mut governor: WcetChannel<256> = WcetChannel::new(100);
+//!
+//! // With `instrument` ON this brackets the block with clock reads and records
+//! // the elapsed time; with it OFF the macro expands to just `{ ... }`.
+//! let verdict = wcet_measure!(governor, clock, {
+//!     clock.0.set(420); // (stand-in for real work advancing the clock)
+//!     true
+//! });
+//! assert!(verdict);
+//! ```
+//!
+//! Scope note: this increment delivers the library and its tests. Wiring it into
+//! the `ros2`-gated hot loops and the QNX harness is a separate, reviewed
+//! follow-up (it needs CI / target validation, per the methodology).
+
+#![cfg_attr(not(test), no_std)]
+
+// The crate is `no_std` for the target; the optional `std` feature (host/CI
+// clock) needs `std` explicitly linked when not already the test sysroot.
+#[cfg(all(feature = "std", not(test)))]
+extern crate std;
+
+mod channel;
+mod clock;
+mod env;
+pub mod report;
+
+pub use channel::{ChannelStats, WcetChannel};
+pub use clock::MonotonicClock;
+#[cfg(feature = "std")]
+pub use clock::StdMonotonicClock;
+pub use env::MeasurementEnv;
+pub use report::{Report, StageReport};
+
+/// Canonical labels for the five safety-critical execution-loop stages (#274).
+/// Using these constants keeps stage names consistent across crates, the harness,
+/// and the report CSV (so downstream tooling can join on them).
+pub mod stage {
+    /// Perception input ingest (e.g. trajectory/odometry arrival → validation entry).
+    pub const PERCEPTION_INPUT: &str = "perception_input";
+    /// Governor / checker execution (the verdict path).
+    pub const GOVERNOR_EXEC: &str = "governor_exec";
+    /// Parko (ML) evaluation tick.
+    pub const PARKO_EVAL: &str = "parko_eval";
+    /// Actuator command publication.
+    pub const ACTUATOR_PUBLISH: &str = "actuator_publish";
+    /// End-to-end loop latency (input → govern → publish).
+    pub const TOTAL_LOOP: &str = "total_loop";
+}
+
+/// Measure `block`, recording its elapsed nanoseconds into `channel` using
+/// `clock` — **only when the `instrument` feature is enabled**.
+///
+/// With `instrument` OFF (the production default) this expands to exactly
+/// `{ block }`: no clock read, no record call, no branch — the certifiable
+/// "instrumentation is campaign-only, never the shipped hot path" property. The
+/// macro evaluates to the block's value either way.
+///
+/// `clock` must implement [`MonotonicClock`]; `channel` must be a mutable
+/// [`WcetChannel`].
+#[macro_export]
+macro_rules! wcet_measure {
+    ($channel:expr, $clock:expr, $block:block) => {{
+        #[cfg(feature = "instrument")]
+        {
+            let __wcet_start = $crate::MonotonicClock::now_nanos(&$clock);
+            let __wcet_result = $block;
+            let __wcet_elapsed =
+                $crate::MonotonicClock::elapsed_nanos_since(&$clock, __wcet_start);
+            $channel.record_nanos(__wcet_elapsed);
+            __wcet_result
+        }
+        #[cfg(not(feature = "instrument"))]
+        {
+            // Zero overhead: the channel/clock are not touched at all.
+            let _ = (&$channel, &$clock);
+            $block
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::Cell;
+
+    struct StepClock {
+        now: Cell<u64>,
+    }
+    impl StepClock {
+        fn new() -> Self {
+            Self { now: Cell::new(0) }
+        }
+        fn set(&self, v: u64) {
+            self.now.set(v);
+        }
+    }
+    impl MonotonicClock for StepClock {
+        fn now_nanos(&self) -> u64 {
+            self.now.get()
+        }
+    }
+
+    #[test]
+    fn streaming_min_max_mean_are_exact() {
+        let mut ch: WcetChannel<1024> = WcetChannel::new(1);
+        for v in [10u64, 20, 30, 40, 50] {
+            ch.record_nanos(v);
+        }
+        let s = ch.snapshot();
+        assert_eq!(s.count, 5);
+        assert_eq!(s.min_ns, 10);
+        assert_eq!(s.max_ns, 50);
+        assert_eq!(s.mean_ns, 30);
+        assert_eq!(s.peak_to_peak_ns, 40);
+    }
+
+    #[test]
+    fn stddev_matches_float_reference() {
+        let mut ch: WcetChannel<4096> = WcetChannel::new(1);
+        let data = [2u64, 4, 4, 4, 5, 5, 7, 9]; // textbook: mean 5, pop stddev 2
+        for v in data {
+            ch.record_nanos(v);
+        }
+        let s = ch.snapshot();
+        assert_eq!(s.mean_ns, 5);
+        assert_eq!(s.stddev_ns, 2);
+    }
+
+    #[test]
+    fn percentiles_are_conservative_and_bounded_by_max() {
+        // 1000 samples: 990 at 100ns, 10 at 5000ns. p99 ~100..200, p99.9 in tail.
+        let mut ch: WcetChannel<256> = WcetChannel::new(100); // 0..25.6µs
+        for _ in 0..990 {
+            ch.record_nanos(100);
+        }
+        for _ in 0..10 {
+            ch.record_nanos(5000);
+        }
+        let s = ch.snapshot();
+        // p50 well within the 100ns mass; conservative upper edge ≤ max.
+        assert!(s.p50_ns >= 100 && s.p50_ns <= s.max_ns);
+        // p99 still in the low mass (only 1% is in the tail).
+        assert!(s.p99_ns <= 5000);
+        // p99.9 reaches into the tail.
+        assert!(s.p999_ns >= 200, "p999 was {}", s.p999_ns);
+        assert!(s.p999_ns <= s.max_ns);
+        assert_eq!(s.max_ns, 5000);
+    }
+
+    #[test]
+    fn overflow_samples_still_bound_max_and_tail() {
+        // Bucket range is only 0..1000ns; a 9000ns sample lands in overflow.
+        let mut ch: WcetChannel<10> = WcetChannel::new(100);
+        for _ in 0..99 {
+            ch.record_nanos(50);
+        }
+        ch.record_nanos(9000);
+        let s = ch.snapshot();
+        assert_eq!(s.max_ns, 9000); // exact even though it overflowed the histogram
+        // p99.9 (top 0.1% of 100 samples = the one 9000ns) falls in overflow → max.
+        assert_eq!(s.p999_ns, 9000);
+    }
+
+    #[test]
+    fn empty_channel_snapshot_is_zero() {
+        let ch: WcetChannel<8> = WcetChannel::new(100);
+        assert_eq!(ch.snapshot(), ChannelStats::EMPTY);
+        assert_eq!(ch.percentile_nanos(999), 0);
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut ch: WcetChannel<16> = WcetChannel::new(10);
+        ch.record_nanos(123);
+        assert_eq!(ch.count(), 1);
+        ch.reset();
+        assert_eq!(ch.count(), 0);
+        assert_eq!(ch.snapshot(), ChannelStats::EMPTY);
+    }
+
+    #[test]
+    fn env_gating_is_the_single_source_of_truth() {
+        assert!(MeasurementEnv::QnxTargetFifo.is_certified_wcet());
+        assert!(!MeasurementEnv::Host.is_certified_wcet());
+        assert!(!MeasurementEnv::CiRunner.is_certified_wcet());
+        assert!(!MeasurementEnv::Other.is_certified_wcet());
+        assert_eq!(MeasurementEnv::QnxTargetFifo.wcet_status(), "QNX-TARGET-MEASURED");
+        assert_eq!(MeasurementEnv::Host.wcet_status(), "INDICATIVE-NOT-WCET");
+    }
+
+    #[test]
+    fn report_banner_reflects_environment() {
+        extern crate std;
+        use std::string::String;
+
+        let stages = [StageReport::new(stage::GOVERNOR_EXEC, ChannelStats::EMPTY)];
+        let host = Report::new(MeasurementEnv::Host, "host-default", &stages);
+        let mut out = String::new();
+        core::fmt::write(&mut out, format_args!("{host}")).unwrap();
+        assert!(out.contains("INDICATIVE, NOT WCET"));
+        assert!(!host.is_wcet_evidence());
+
+        let target = Report::new(MeasurementEnv::QnxTargetFifo, "SCHED_FIFO", &stages);
+        let mut out2 = String::new();
+        core::fmt::write(&mut out2, format_args!("{target}")).unwrap();
+        assert!(out2.contains("CERTIFIED"));
+        assert!(target.is_wcet_evidence());
+    }
+
+    #[test]
+    fn csv_has_stable_columns_and_status() {
+        extern crate std;
+        use std::string::String;
+
+        let mut ch: WcetChannel<64> = WcetChannel::new(50);
+        ch.record_nanos(100);
+        let stages = [StageReport::new(stage::TOTAL_LOOP, ch.snapshot())];
+        let report = Report::new(MeasurementEnv::CiRunner, "host-default", &stages);
+        let mut csv = String::new();
+        report.write_csv(&mut csv).unwrap();
+        let mut lines = csv.lines();
+        assert_eq!(
+            lines.next().unwrap(),
+            "metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status"
+        );
+        let row = lines.next().unwrap();
+        assert!(row.starts_with("total_loop,ci-runner,host-default,1,"));
+        assert!(row.ends_with(",INDICATIVE-NOT-WCET"));
+    }
+
+    #[test]
+    fn macro_disabled_is_zero_overhead_passthrough() {
+        // Without the `instrument` feature the macro must not touch the channel.
+        let clock = StepClock::new();
+        let mut ch: WcetChannel<8> = WcetChannel::new(1);
+        let out = wcet_measure!(ch, clock, {
+            clock.set(999);
+            7u32 + 1
+        });
+        assert_eq!(out, 8);
+        #[cfg(not(feature = "instrument"))]
+        assert_eq!(ch.count(), 0, "disabled macro must record nothing");
+        #[cfg(feature = "instrument")]
+        assert_eq!(ch.count(), 1, "enabled macro must record one sample");
+    }
+
+    #[cfg(feature = "instrument")]
+    #[test]
+    fn macro_enabled_records_elapsed() {
+        let clock = StepClock::new();
+        let mut ch: WcetChannel<1024> = WcetChannel::new(1);
+        wcet_measure!(ch, clock, {
+            clock.set(250); // elapsed 250ns
+        });
+        let s = ch.snapshot();
+        assert_eq!(s.count, 1);
+        assert_eq!(s.max_ns, 250);
+    }
+}

--- a/crates/kirra-timing/src/report.rs
+++ b/crates/kirra-timing/src/report.rs
@@ -1,0 +1,139 @@
+//! Deterministic report rendering — CSV (machine) and a human-readable table.
+//!
+//! Rendering is `core::fmt`-only: no allocation, no file I/O. The caller writes
+//! the rendered text wherever it wants (stdout, a file, a CI artifact). The
+//! report carries its [`MeasurementEnv`] so every row self-declares whether it is
+//! WCET evidence or merely indicative — the methodology's host-indicative rule,
+//! enforced at render time.
+
+use core::fmt;
+
+use crate::channel::ChannelStats;
+use crate::env::MeasurementEnv;
+
+/// One named stage's statistics within a [`Report`].
+#[derive(Debug, Clone, Copy)]
+pub struct StageReport {
+    /// Stable stage label, e.g. `"perception_input"` or `"governor_exec"`.
+    pub stage: &'static str,
+    /// The stage's measured statistics.
+    pub stats: ChannelStats,
+}
+
+impl StageReport {
+    /// Pair a stage label with its stats.
+    #[must_use]
+    pub const fn new(stage: &'static str, stats: ChannelStats) -> Self {
+        Self { stage, stats }
+    }
+}
+
+/// A complete campaign report: an environment tag, the scheduler description, and
+/// one [`StageReport`] per measured stage.
+#[derive(Debug, Clone, Copy)]
+pub struct Report<'a> {
+    /// Where the measurement ran — gates the WCET-vs-indicative status.
+    pub env: MeasurementEnv,
+    /// Scheduler description, e.g. `"SCHED_FIFO"` (target) or `"host-default"`.
+    pub sched: &'static str,
+    /// One entry per measured stage.
+    pub stages: &'a [StageReport],
+}
+
+impl<'a> Report<'a> {
+    /// Build a report.
+    #[must_use]
+    pub const fn new(env: MeasurementEnv, sched: &'static str, stages: &'a [StageReport]) -> Self {
+        Self { env, sched, stages }
+    }
+
+    /// `true` only when every row is certified WCET evidence (QNX target / FIFO).
+    #[must_use]
+    pub const fn is_wcet_evidence(&self) -> bool {
+        self.env.is_certified_wcet()
+    }
+
+    /// Write the machine-readable CSV (header + one row per stage). Stable column
+    /// order, aligned with `tools/qnx-rtm-harness/wcet_measure.cpp`.
+    ///
+    /// # Errors
+    /// Propagates any [`fmt::Error`] from the writer.
+    pub fn write_csv(&self, w: &mut impl fmt::Write) -> fmt::Result {
+        writeln!(
+            w,
+            "metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status"
+        )?;
+        for s in self.stages {
+            let st = &s.stats;
+            writeln!(
+                w,
+                "{},{},{},{},{},{},{},{},{},{},{},{}",
+                s.stage,
+                self.env.label(),
+                self.sched,
+                st.count,
+                st.min_ns,
+                st.mean_ns,
+                st.max_ns,
+                st.stddev_ns,
+                st.p50_ns,
+                st.p99_ns,
+                st.p999_ns,
+                self.env.wcet_status(),
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// Human-readable rendering: a banner that states WCET-vs-indicative up front,
+/// then a per-stage table. The banner is the methodology rule made visible —
+/// anyone reading a host/CI report is told, unmissably, that it is NOT WCET.
+impl fmt::Display for Report<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_wcet_evidence() {
+            writeln!(
+                f,
+                "=== WCET REPORT — CERTIFIED ({}, {}) ===",
+                self.env.label(),
+                self.sched
+            )?;
+        } else {
+            writeln!(
+                f,
+                "=== TIMING REPORT — INDICATIVE, NOT WCET ({}, {}) ===",
+                self.env.label(),
+                self.sched
+            )?;
+            writeln!(
+                f,
+                "    Host/CI numbers are indicative only. Certified WCET requires the"
+            )?;
+            writeln!(
+                f,
+                "    QNX target under FIFO scheduling (#274). Do not cite as WCET evidence."
+            )?;
+        }
+        writeln!(
+            f,
+            "{:<22} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+            "stage", "n", "min_ns", "mean_ns", "max_ns", "stddev", "p99_ns", "p999_ns"
+        )?;
+        for s in self.stages {
+            let st = &s.stats;
+            writeln!(
+                f,
+                "{:<22} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+                s.stage,
+                st.count,
+                st.min_ns,
+                st.mean_ns,
+                st.max_ns,
+                st.stddev_ns,
+                st.p99_ns,
+                st.p999_ns,
+            )?;
+        }
+        Ok(())
+    }
+}

--- a/crates/kirra-timing/src/report.rs
+++ b/crates/kirra-timing/src/report.rs
@@ -54,7 +54,13 @@ impl<'a> Report<'a> {
     }
 
     /// Write the machine-readable CSV (header + one row per stage). Stable column
-    /// order, aligned with `tools/qnx-rtm-harness/wcet_measure.cpp`.
+    /// order. This is an **extended superset** of the
+    /// `tools/qnx-rtm-harness/wcet_measure.cpp` row
+    /// (`metric,target,sched,n,warmup,max_ns,p999_ns,wcet_status`): it shares
+    /// `metric,sched,n,max_ns,p999_ns,wcet_status` and adds
+    /// `env,min_ns,mean_ns,stddev_ns,p50_ns,p99_ns` (and uses `env` where the
+    /// harness uses `target`). It is NOT byte-identical — downstream tooling that
+    /// expects the exact harness header must map columns, not assume equality.
     ///
     /// # Errors
     /// Propagates any [`fmt::Error`] from the writer.


### PR DESCRIPTION
## Context (roadmap L1 — QNX WCET measurement campaign, #274)

The repo already has a **judge-only, partial** WCET story: `src/wcet_gate.rs` (host CI gate, p99.9), `tools/qnx-rtm-harness/wcet_measure.cpp` (QNX FIFO judge timing), and the methodology/HVCHAN docs. What's missing — and what every other L1/L4/L6 deliverable needs — is a **reusable, certifiable timing-instrumentation library**. This PR adds exactly that, and **nothing else** (no safety logic touched).

## What's added: `crates/kirra-timing`

`no_std`, **zero dependencies**, **zero-alloc**, `#[forbid(unsafe_code)]` — mirroring `kirra-contract-channel`'s minimal-TCB discipline.

- **`WcetChannel<BUCKETS>`** — `O(1)`, allocation-free per-sample sink. Exact streaming **min / avg / max + jitter** (population stddev via a **pure-integer `isqrt`** — no `f64`/`libm`), plus a fixed histogram for **conservative p50/p99/p99.9** (rounded up to the bucket upper edge, bounded by the exact `max`; overflow-safe).
- **`MeasurementEnv`** — the methodology's *host-numbers-are-INDICATIVE-never-WCET* rule **in the type system**. `is_certified_wcet()` (only `QnxTargetFifo`) is the single source of truth; reports print an INDICATIVE banner / `INDICATIVE-NOT-WCET` status otherwise.
- **`MonotonicClock` trait** — the crate **never reads a clock itself**; the QNX target binds the boundary-domain monotonic counter (HVCHAN-001 §5) at the integration shim. `StdMonotonicClock` (behind `std`) backs host/CI.
- **`report::Report`** — deterministic CSV (columns aligned to `wcet_measure.cpp`) + human table via `core::fmt`. No alloc, no file I/O (caller writes).
- **`wcet_measure!` macro** — **zero overhead when the default-off `instrument` feature is absent**: expands to just the measured block (no clock read, no record, no branch). Instrumentation is campaign-only, never the shipped hot path.

## Verification

- default (`no_std`, instrument off): **10 unit + 1 doc test** pass
- `--features instrument,std`: **11 unit + 1 doc test** pass (enabled macro + `StdMonotonicClock`)
- `cargo build -p kirra-timing` (`no_std`) and `--features std` both compile
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `Cargo.lock` updated; `--locked` resolves

## Safety-rule compliance

No determinism reduction, no hidden globals, no new `unsafe` (forbidden), no alloc in the hot path, no mixing of safety/non-safety concerns, no weakened boundaries. The clock-injection design preserves the HVCHAN §5 boundary-domain discipline.

## Scope / what's deliberately NOT here

Library + tests only. **Wiring it into the `ros2`-gated hot loops and the QNX `wcet_measure` harness is a separate, reviewed follow-up** — that needs CI/target validation, and per the methodology the production hot path ships with `instrument` **off**. This keeps the PR small and reviewable per the roadmap's "small PR-sized changes / compile after each milestone" standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_