### PR TITLE
feat(parko): wire AuditClient into the decision loop — override + fau…

### DIFF
--- a/parko/crates/parko-core/src/scheduler.rs
+++ b/parko/crates/parko-core/src/scheduler.rs
@@ -10,6 +10,19 @@ use crate::commands::ControlCommand;
 use crate::sensor::SensorFrame;
 use crate::telemetry::{CumulativeJitterEvaluator, PostureSnapshot, RuntimeTelemetry, ThermalState};
 use crate::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
+use crate::audit::{AuditClient, FaultRecord, OverrideRecord};
+
+/// The stable audit reason code for a governor override, or `None` for `Allow`
+/// (the common no-op, which is not recorded).
+fn override_reason(action: &EnforcementAction) -> Option<&'static str> {
+    match action {
+        EnforcementAction::Allow => None,
+        EnforcementAction::ClampLinearVelocity(_) => Some("clamp_linear"),
+        EnforcementAction::ClampAngularVelocity(_) => Some("clamp_angular"),
+        EnforcementAction::ClampMotion { .. } => Some("clamp_motion"),
+        EnforcementAction::Deny { .. } => Some("deny"),
+    }
+}
 
 /// Thresholds for degraded-mode detection.
 ///
@@ -50,6 +63,11 @@ pub struct InferenceLoop<B: InferenceBackend> {
     cached_descriptor: BackendDescriptor,
     governor: Option<Box<dyn SafetyGovernor>>,
     tick_period_s: f64,
+    /// Optional SDK-free audit sink (L5). Default `None` → no records emitted
+    /// (byte-identical behaviour). When set, the decision path reports governor
+    /// overrides and non-finite faults through the `AuditClient` trait, keeping
+    /// it independent of any concrete (e.g. SDK-backed) audit implementation.
+    audit: Option<Arc<dyn AuditClient>>,
 }
 
 fn capabilities_precision(caps: &BackendCapabilities) -> PrecisionMode {
@@ -95,7 +113,18 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
             cached_descriptor,
             governor: None,
             tick_period_s: 0.05,
+            audit: None,
         }
+    }
+
+    /// Attach an [`AuditClient`] so the decision path records governor overrides
+    /// and non-finite faults to a caller-chosen audit sink. Default: none → no
+    /// records emitted (byte-identical). The SDK-free trait keeps the decision
+    /// path independent of the verifier crate (the concrete sink is injected).
+    #[must_use]
+    pub fn with_audit_client(mut self, audit: Arc<dyn AuditClient>) -> Self {
+        self.audit = Some(audit);
+        self
     }
 
     /// Attach a safety governor to this loop. The governor's evaluation
@@ -185,7 +214,17 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
         // the error and crashing the loop.
         let proposed_cmd = match self.parse_inference_to_command(&processed_outputs, loop_start_ms) {
             Ok(cmd) => cmd,
-            Err(_) => {
+            Err(parse_err) => {
+                // Non-finite (NaN/Inf) inference output → fail-closed stopped
+                // command. Audit it as a decision-path fault before returning.
+                if let Some(a) = &self.audit {
+                    a.record_fault(FaultRecord {
+                        tick_ms: loop_start_ms,
+                        code: "nonfinite_command",
+                        detail: parse_err,
+                        posture,
+                    });
+                }
                 let telemetry = RuntimeTelemetry {
                     inference_latency_ms,
                     rolling_jitter_ms,
@@ -216,7 +255,12 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
                 self.tick_period_s,
                 posture,
             );
-            match action {
+            // Capture the doer/ML proposal (Copy reads — zero cost) and the audit
+            // reason BEFORE the match consumes `action`. `override_reason` returns
+            // a `'static` code, so `reason` does not borrow `action`.
+            let reason = override_reason(&action);
+            let (ml_lin, ml_ang) = (proposed_cmd.linear_velocity, proposed_cmd.angular_velocity);
+            let commanded = match action {
                 EnforcementAction::Allow => proposed_cmd,
                 EnforcementAction::ClampLinearVelocity(v) => ControlCommand {
                     linear_velocity: v,
@@ -240,7 +284,22 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
                 EnforcementAction::Deny { reason: _ } => {
                     ControlCommand::stopped(proposed_cmd.timestamp_ms)
                 }
+            };
+            // Audit the override (the governor changed the doer's command). Sparse
+            // and safety-relevant; `Allow` (reason == None) is the common no-op
+            // and is not recorded.
+            if let (Some(a), Some(reason)) = (&self.audit, reason) {
+                a.record_override(OverrideRecord {
+                    tick_ms: loop_start_ms,
+                    reason,
+                    proposed_linear_mps: ml_lin,
+                    proposed_angular_rps: ml_ang,
+                    commanded_linear_mps: commanded.linear_velocity,
+                    commanded_angular_rps: commanded.angular_velocity,
+                    posture,
+                });
             }
+            commanded
         } else {
             proposed_cmd
         };
@@ -604,6 +663,68 @@ mod tests {
 
         let flushed = rx.recv().await.unwrap();
         assert_eq!(flushed.linear_velocity, 2.0);
+    }
+
+    /// L5 — an attached AuditClient records a governor override (and nothing else)
+    /// when the governor changes the doer's command.
+    #[tokio::test]
+    async fn audit_client_records_governor_override() {
+        use crate::audit::MockAuditClient;
+        let backend = Arc::new(ConfigurableBackend { linear: 10.0 });
+        let model = backend.load_model("").unwrap();
+        let (tx, _rx) = mpsc::channel(4);
+        let mock = Arc::new(MockAuditClient::new());
+
+        let mut loop_engine = InferenceLoop::new(backend, model, tx)
+            .with_governor(ClampToTwoGovernor)
+            .with_audit_client(mock.clone());
+        let mut stream = SimpleStream { next_id: 0 };
+
+        let snap = loop_engine
+            .tick(stream.next_frame().unwrap(), SafetyPosture::Nominal)
+            .await
+            .unwrap();
+        assert_eq!(snap.active_command.linear_velocity, 2.0, "governor clamps 10 → 2");
+
+        let (decisions, overrides, faults, health) = mock.counts();
+        assert_eq!(
+            (decisions, faults, health),
+            (0, 0, 0),
+            "only an override should be recorded on a clamped tick"
+        );
+        assert_eq!(overrides, 1, "the governor override must be audited");
+        let ov = &mock.overrides()[0];
+        assert_eq!(ov.reason, "clamp_linear");
+        assert_eq!(ov.proposed_linear_mps, 10.0);
+        assert_eq!(ov.commanded_linear_mps, 2.0);
+        assert_eq!(ov.posture, SafetyPosture::Nominal);
+    }
+
+    /// L5 — an attached AuditClient records a non-finite-inference fault and the
+    /// loop still fail-closes to a stopped command.
+    #[tokio::test]
+    async fn audit_client_records_nonfinite_fault() {
+        use crate::audit::MockAuditClient;
+        let backend = Arc::new(ConfigurableBackend { linear: f32::NAN });
+        let model = backend.load_model("").unwrap();
+        let (tx, _rx) = mpsc::channel(4);
+        let mock = Arc::new(MockAuditClient::new());
+
+        let mut loop_engine =
+            InferenceLoop::new(backend, model, tx).with_audit_client(mock.clone());
+        let mut stream = SimpleStream { next_id: 0 };
+
+        let snap = loop_engine
+            .tick(stream.next_frame().unwrap(), SafetyPosture::Nominal)
+            .await
+            .unwrap();
+        assert!(snap.active_state_degraded, "nonfinite output → degraded snapshot");
+        assert_eq!(snap.active_command.linear_velocity, 0.0, "fail-closed stop");
+
+        let (decisions, overrides, faults, health) = mock.counts();
+        assert_eq!((decisions, overrides, health), (0, 0, 0));
+        assert_eq!(faults, 1, "the non-finite fault must be audited");
+        assert_eq!(mock.faults()[0].code, "nonfinite_command");
     }
 
     #[tokio::test]

--- a/parko/crates/parko-core/src/scheduler.rs
+++ b/parko/crates/parko-core/src/scheduler.rs
@@ -255,11 +255,21 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
                 self.tick_period_s,
                 posture,
             );
-            // Capture the doer/ML proposal (Copy reads — zero cost) and the audit
-            // reason BEFORE the match consumes `action`. `override_reason` returns
-            // a `'static` code, so `reason` does not borrow `action`.
-            let reason = override_reason(&action);
-            let (ml_lin, ml_ang) = (proposed_cmd.linear_velocity, proposed_cmd.angular_velocity);
+            // Compute the audit inputs ONLY when a client is attached AND the
+            // governor actually overrode (`override_reason` is `None` for Allow),
+            // so the hot path is byte-identical when auditing is disabled — nothing
+            // here runs if `self.audit` is `None`. Captured BEFORE the match
+            // consumes `action`; the proposal fields are Copy reads.
+            let audit_override = self.audit.as_ref().and_then(|client| {
+                override_reason(&action).map(|reason| {
+                    (
+                        client,
+                        reason,
+                        proposed_cmd.linear_velocity,
+                        proposed_cmd.angular_velocity,
+                    )
+                })
+            });
             let commanded = match action {
                 EnforcementAction::Allow => proposed_cmd,
                 EnforcementAction::ClampLinearVelocity(v) => ControlCommand {
@@ -286,10 +296,10 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
                 }
             };
             // Audit the override (the governor changed the doer's command). Sparse
-            // and safety-relevant; `Allow` (reason == None) is the common no-op
-            // and is not recorded.
-            if let (Some(a), Some(reason)) = (&self.audit, reason) {
-                a.record_override(OverrideRecord {
+            // and safety-relevant; `Allow` is the common no-op and was already
+            // filtered out above (so `audit_override` is `None` for it).
+            if let Some((client, reason, ml_lin, ml_ang)) = audit_override {
+                client.record_override(OverrideRecord {
                     tick_ms: loop_start_ms,
                     reason,
                     proposed_linear_mps: ml_lin,


### PR DESCRIPTION
…lt (L5 incr. 3)

Make the parko-core decision path RECORD through the SDK-free AuditClient trait, so the audit-relevant decisions are emitted without the loop depending on any concrete (e.g. SDK-backed) implementation. Additive and zero-overhead when no client is attached (default None → byte-identical behaviour).

InferenceLoop gains an optional `Arc<dyn AuditClient>` (builder `with_audit_client`). In `tick`:
- record_fault("nonfinite_command") when inference parsing rejects a NaN/Inf output (before the fail-closed stopped snapshot is returned).
- record_override(reason) when the attached governor changes the doer's command (clamp_linear / clamp_angular / clamp_motion / deny). Allow is the common no-op and is not recorded. The doer proposal is captured via Copy reads and the reason via a 'static code, so there is zero added cost when no client is set.

Deliberately NOT wired this increment: per-tick record_decision / record_health. At 20 Hz those would flood a durable hash-chained ledger; they need a sampling cadence, which is a separate policy decision (documented follow-up). Overrides and faults are sparse and safety-relevant — the right first events to audit.

Scope note: parko-ros2's remaining non-optional kirra-verifier dependency is the CLEARANCE GATE (SG7/SG8 operator clearance), a separate subsystem from the audit path — out of L5's AuditClient scope; removing it is a distinct "clearance store abstraction" task.

Verification: parko-core lib suite 208 passed (2 new tests: a clamped tick records exactly one clamp_linear override with proposed/commanded values; a NaN inference records exactly one nonfinite_command fault and still fail-closes to a stop). clippy --all-targets -- -D warnings clean.


Claude-Session: https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6