### PR TITLE
feat(timing): land kirra-wcet-bench on main (L1 / #274)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,6 +2224,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-wcet-bench"
+version = "0.1.0"
+dependencies = [
+ "kirra-core",
+ "kirra-timing",
+]
+
+[[package]]
 name = "kirra-wire-client"
 version = "0.1.0"
 dependencies = [
@@ -2688,6 +2696,7 @@ dependencies = [
  "parko-kirra",
  "proptest",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-timing", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
+members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
 resolver = "2"
 
 [package]

--- a/crates/kirra-timing/src/lib.rs
+++ b/crates/kirra-timing/src/lib.rs
@@ -82,8 +82,12 @@ pub use report::{Report, StageReport};
 pub mod stage {
     /// Perception input ingest (e.g. trajectory/odometry arrival → validation entry).
     pub const PERCEPTION_INPUT: &str = "perception_input";
-    /// Governor / checker execution (the verdict path).
+    /// Governor / checker execution (the verdict path) under the Nominal contract.
     pub const GOVERNOR_EXEC: &str = "governor_exec";
+    /// Governor / checker execution under the MRC fallback contract (the
+    /// decel-to-stop envelope verdict path) — a distinct label from
+    /// [`GOVERNOR_EXEC`] so downstream tooling can join on either profile.
+    pub const GOVERNOR_EXEC_MRC: &str = "governor_exec_mrc";
     /// Parko (ML) evaluation tick.
     pub const PARKO_EVAL: &str = "parko_eval";
     /// Actuator command publication.

--- a/crates/kirra-wcet-bench/Cargo.toml
+++ b/crates/kirra-wcet-bench/Cargo.toml
@@ -1,0 +1,30 @@
+# crates/kirra-wcet-bench/Cargo.toml
+#
+# L1 / #274 host-side WCET REPORT GENERATOR. A lean, std bench binary that drives
+# the host-buildable governor verdict path (`kirra_core::kinematics_contract::
+# validate_vehicle_command`) through the `kirra-timing` primitives and emits a
+# deterministic, environment-tagged report (human table → stderr, CSV → stdout).
+#
+# INDICATIVE BY CONSTRUCTION: it uses `StdMonotonicClock` (an `Instant`-backed
+# host clock), so it can NEVER mint a certified-WCET tag — the env is clamped to
+# host/ci-runner/other. Certified WCET still comes only from the QNX target under
+# FIFO via `tools/qnx-rtm-harness/wcet_measure.cpp` (the methodology's rule).
+#
+# Depends ONLY on the two lean crates (kirra-core + kirra-timing) — not the heavy
+# verifier service. Mirrors the `kirra-proposal-bench` dev-bench precedent.
+[package]
+name = "kirra-wcet-bench"
+version = "0.1.0"
+edition = "2021"
+description = "DEV host-indicative WCET report generator: measures the governor verdict path via kirra-timing and emits an env-tagged CSV/table. Not a certified-WCET artifact (#274)."
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+
+[[bin]]
+name = "kirra-wcet-bench"
+path = "src/main.rs"
+
+[dependencies]
+kirra-core = { path = "../kirra-core" }
+kirra-timing = { path = "../kirra-timing", features = ["std"] }

--- a/crates/kirra-wcet-bench/src/main.rs
+++ b/crates/kirra-wcet-bench/src/main.rs
@@ -1,0 +1,192 @@
+//! Host-indicative WCET report generator (#274 / L1).
+//!
+//! Drives the host-buildable **governor verdict path**
+//! (`kirra_core::kinematics_contract::validate_vehicle_command`) through the
+//! [`kirra_timing`] primitives and prints a deterministic, environment-tagged
+//! report: the human table + INDICATIVE banner to **stderr**, the machine CSV to
+//! **stdout** (so `kirra-wcet-bench > report.csv` captures the artifact cleanly).
+//!
+//! ## Indicative by construction
+//!
+//! This binary uses [`StdMonotonicClock`] — an `Instant`-backed *host* clock — so
+//! it can NEVER produce certified WCET. The environment is clamped to
+//! `host` / `ci-runner` / `other`; a request for `qnx-target-fifo` is refused and
+//! downgraded with a note. Certified WCET comes only from the QNX target under
+//! FIFO scheduling via `tools/qnx-rtm-harness/wcet_measure.cpp` (the
+//! `WCET_MEASUREMENT_METHODOLOGY.md` host-indicative rule).
+//!
+//! ## Configuration (env vars)
+//!
+//! - `KIRRA_WCET_ENV`    — `host` (default) | `ci-runner` | `other`.
+//! - `KIRRA_WCET_ITERS`  — measured iterations per stage (default 100_000).
+//! - `KIRRA_WCET_WARMUP` — warm-up iterations per stage, not recorded (default 10_000).
+//!
+//! Scope: only the governor verdict stage is host-buildable. The perception /
+//! parko / actuator stages are `ros2`/target-gated and measured by the harness
+//! wiring follow-up; they are listed here as NOT-MEASURED rather than faked.
+
+use std::hint::black_box;
+
+use kirra_core::kinematics_contract::{
+    validate_vehicle_command, EnforceAction, ProposedVehicleCommand, VehicleKinematicsContract,
+};
+use kirra_timing::{stage, MeasurementEnv, MonotonicClock, Report, StageReport, StdMonotonicClock};
+
+/// Histogram resolution for the governor verdict path: 4096 buckets × 10 ns =
+/// 0..40.96 µs, well above the sub-µs verdict and the ~10× CI threshold.
+const BUCKETS: usize = 4096;
+const BUCKET_WIDTH_NS: u64 = 10;
+
+fn parse_env(raw: Option<String>) -> (MeasurementEnv, Option<&'static str>) {
+    match raw.as_deref() {
+        None | Some("host") | Some("") => (MeasurementEnv::Host, None),
+        Some("ci-runner") | Some("ci") => (MeasurementEnv::CiRunner, None),
+        Some("other") => (MeasurementEnv::Other, None),
+        // Refuse to mint a certified tag from a host (std-clock) run.
+        Some(other) => (
+            MeasurementEnv::Host,
+            Some(if other == "qnx-target-fifo" {
+                "KIRRA_WCET_ENV=qnx-target-fifo refused: this host bench uses a std clock and \
+                 cannot produce certified WCET. Use tools/qnx-rtm-harness on the QNX target. \
+                 Tagging this run as 'host' (indicative)."
+            } else {
+                "unrecognized KIRRA_WCET_ENV; defaulting to 'host' (indicative)."
+            }),
+        ),
+    }
+}
+
+fn parse_count(name: &str, default: u32) -> u32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(default)
+}
+
+/// Full-depth **Allow** command under the NOMINAL profile (max_accel 2.5,
+/// max_steering_rate 45 °/s, max_speed 35): accel `(10.1-10.0)/0.05 = 2.0 ≤ 2.5`,
+/// steering rate `(1.5-1.0)/0.05 = 10 ≤ 45`, speed `10.1 ≤ 35`, lateral accel ≪
+/// 3.5 — so NO guard clamps and every P0..P6 check runs to completion. That
+/// full-pipeline Allow is the worst-case (longest) verdict path; an early clamp
+/// or deny returns sooner and would UNDER-report WCET. `assert_allow` verifies
+/// this at runtime so a contract change can't silently turn it into an
+/// early-return measurement.
+fn nominal_allow_cmd() -> ProposedVehicleCommand {
+    ProposedVehicleCommand {
+        linear_velocity_mps: 10.1,
+        current_velocity_mps: 10.0,
+        delta_time_s: 0.05,
+        steering_angle_deg: 1.5,
+        current_steering_angle_deg: 1.0,
+    }
+}
+
+/// Full-depth **Allow** command under the MRC profile (max_accel 1.0,
+/// max_steering_rate 20 °/s, max_speed 5): accel `(3.04-3.0)/0.05 = 0.8 ≤ 1.0`,
+/// rate `(0.7-0.5)/0.05 = 4 ≤ 20`, speed `3.04 ≤ 5` — Allow, full pipeline. The
+/// previous bench reused the nominal 10 m/s command here, which exceeds the MRC
+/// 5 m/s ceiling and returned an immediate P2 clamp (not the full MRC pipeline).
+fn mrc_allow_cmd() -> ProposedVehicleCommand {
+    ProposedVehicleCommand {
+        linear_velocity_mps: 3.04,
+        current_velocity_mps: 3.0,
+        delta_time_s: 0.05,
+        steering_angle_deg: 0.7,
+        current_steering_angle_deg: 0.5,
+    }
+}
+
+/// Verify a command actually reaches [`EnforceAction::Allow`] under `contract`
+/// before it is used to characterize the worst-case Allow path. Fail loudly
+/// (exit 2) rather than silently measure a shorter early-return path.
+fn assert_allow(label: &str, cmd: &ProposedVehicleCommand, contract: &VehicleKinematicsContract) {
+    let verdict = validate_vehicle_command(cmd, contract);
+    if verdict != EnforceAction::Allow {
+        eprintln!(
+            "[kirra-wcet-bench] FATAL: the '{label}' command does not reach EnforceAction::Allow \
+             (got {verdict:?}); the bench would measure an early-return path, not the worst-case \
+             full pipeline. Adjust the command shape to the current contract limits."
+        );
+        std::process::exit(2);
+    }
+}
+
+/// Measure `f` over `warmup` (discarded) + `iters` (recorded) iterations into a
+/// fresh channel, returning the snapshot. Each sample includes the TWO
+/// per-iteration monotonic clock reads (`now_nanos` at the start and again
+/// inside `elapsed_nanos_since`) — conservatively counted as observer overhead
+/// (methodology §2: include rather than subtract).
+fn measure(
+    clock: &StdMonotonicClock,
+    warmup: u32,
+    iters: u32,
+    mut f: impl FnMut(),
+) -> kirra_timing::ChannelStats {
+    for _ in 0..warmup {
+        f();
+    }
+    let mut ch: kirra_timing::WcetChannel<BUCKETS> = kirra_timing::WcetChannel::new(BUCKET_WIDTH_NS);
+    for _ in 0..iters {
+        let t0 = clock.now_nanos();
+        f();
+        ch.record_nanos(clock.elapsed_nanos_since(t0));
+    }
+    ch.snapshot()
+}
+
+fn main() {
+    let (env, note) = parse_env(std::env::var("KIRRA_WCET_ENV").ok());
+    if let Some(msg) = note {
+        eprintln!("[kirra-wcet-bench] {msg}");
+    }
+    let iters = parse_count("KIRRA_WCET_ITERS", 100_000);
+    let warmup = parse_count("KIRRA_WCET_WARMUP", 10_000);
+    eprintln!(
+        "[kirra-wcet-bench] env={} iters={iters} warmup={warmup} (host-indicative)",
+        env.label()
+    );
+
+    let clock = StdMonotonicClock::new();
+
+    // Stage: governor verdict — the host-buildable SG9 safety check, worst-case
+    // (full-pipeline) Allow path under the Nominal profile and under the MRC
+    // profile. Each command is verified to actually reach Allow before measuring.
+    let nominal_contract = VehicleKinematicsContract::nominal_reference_profile();
+    let mrc_contract = VehicleKinematicsContract::mrc_fallback_profile();
+    let nominal_command = nominal_allow_cmd();
+    let mrc_command = mrc_allow_cmd();
+    assert_allow("governor_exec (nominal)", &nominal_command, &nominal_contract);
+    assert_allow("governor_exec_mrc", &mrc_command, &mrc_contract);
+
+    let governor = measure(&clock, warmup, iters, || {
+        let _ = black_box(validate_vehicle_command(
+            black_box(&nominal_command),
+            black_box(&nominal_contract),
+        ));
+    });
+    let governor_mrc = measure(&clock, warmup, iters, || {
+        let _ = black_box(validate_vehicle_command(
+            black_box(&mrc_command),
+            black_box(&mrc_contract),
+        ));
+    });
+
+    let stages = [
+        StageReport::new(stage::GOVERNOR_EXEC, governor),
+        StageReport::new("governor_exec_mrc", governor_mrc),
+    ];
+    let report = Report::new(env, "host-default", &stages);
+
+    // Human table + banner → stderr (diagnostic); CSV → stdout (the artifact).
+    eprintln!("{report}");
+    eprintln!(
+        "[kirra-wcet-bench] NOT MEASURED on host (ros2/target-gated, see harness follow-up): {}, {}, {}",
+        stage::PERCEPTION_INPUT,
+        stage::PARKO_EVAL,
+        stage::ACTUATOR_PUBLISH,
+    );
+    let mut csv = String::new();
+    report.write_csv(&mut csv).expect("writing to a String cannot fail");
+    print!("{csv}");
+}

--- a/crates/kirra-wcet-bench/src/main.rs
+++ b/crates/kirra-wcet-bench/src/main.rs
@@ -17,7 +17,7 @@
 //!
 //! ## Configuration (env vars)
 //!
-//! - `KIRRA_WCET_ENV`    — `host` (default) | `ci-runner` | `other`.
+//! - `KIRRA_WCET_ENV`    — `host` (default) | `ci-runner` (alias `ci`) | `other`.
 //! - `KIRRA_WCET_ITERS`  — measured iterations per stage (default 100_000).
 //! - `KIRRA_WCET_WARMUP` — warm-up iterations per stage, not recorded (default 10_000).
 //!
@@ -174,7 +174,7 @@ fn main() {
 
     let stages = [
         StageReport::new(stage::GOVERNOR_EXEC, governor),
-        StageReport::new("governor_exec_mrc", governor_mrc),
+        StageReport::new(stage::GOVERNOR_EXEC_MRC, governor_mrc),
     ];
     let report = Report::new(env, "host-default", &stages);
 


### PR DESCRIPTION
## Why

The `kirra-wcet-bench` crate was reviewed and merged in **#728** — but only into its *stacked base* (`feat/l1-kirra-timing`). When **#727** (`kirra-timing`) landed on `main`, it carried just the timing crate, leaving the bench **stranded** on the intermediate branch. As a result `kirra-timing` currently has **zero consumers on `main`**. This PR re-lands the already-reviewed crate directly on `main` — no behavior change from #728, just the correct base.

## What's in it: `crates/kirra-wcet-bench`

A lean `std` binary that drives the host-buildable **governor verdict path** (`kirra_core::kinematics_contract::validate_vehicle_command`) through the `kirra-timing` primitives and emits a deterministic, environment-tagged report:
- human table + **INDICATIVE** banner → **stderr**
- machine CSV → **stdout** (so `kirra-wcet-bench > report.csv` captures the artifact)

Depends only on the two lean crates (`kirra-core` + `kirra-timing`), not the heavy verifier — mirroring the `kirra-proposal-bench` precedent.

## Indicative by construction (the methodology rule, enforced in the tool)

- Uses `StdMonotonicClock` (host `Instant`), so it **cannot** mint a certified-WCET tag.
- `KIRRA_WCET_ENV` is clamped to `host` / `ci-runner` / `other`; a `qnx-target-fifo` request is **refused** with a pointer to `tools/qnx-rtm-harness` (the only certified path, per `WCET_MEASUREMENT_METHODOLOGY.md`).
- `assert_allow` verifies both the Nominal and MRC commands actually reach `EnforceAction::Allow`, so the bench measures the **worst-case full pipeline**, never an early-return clamp.
- Only the governor stage is host-buildable; perception / parko / actuator are listed **NOT-MEASURED (ros2/target-gated)** rather than faked.

## Verification (run on host against current `main`)

```
$ KIRRA_WCET_ITERS=5000 cargo run -q -p kirra-wcet-bench
governor_exec,host,host-default,5000,69,78,24724,354,80,110,110,INDICATIVE-NOT-WCET
governor_exec_mrc,host,host-default,5000,67,77,11332,159,80,130,140,INDICATIVE-NOT-WCET
```

- governor verdict ~78 ns mean / 110 ns p99.9 / ~25 µs max — `max` is scheduler jitter, exactly why the methodology gates on **p99.9**, not max.
- `KIRRA_WCET_ENV=qnx-target-fifo` → **refused**, downgraded to `host`.
- `cargo clippy -p kirra-wcet-bench --all-targets -- -D warnings`: clean.
- `cargo metadata --locked`: consistent. The full re-resolve also syncs a missing `parko-core` `serde_json` lock entry (pre-existing drift from the merged L5 #729).

## Safety-rule compliance

No determinism reduction, no hidden globals, no new `unsafe`, no alloc in the measured closure, no weakened boundaries. The tool structurally cannot misrepresent host numbers as WCET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_