### PR TITLE
feat(wcet): canonical CSV schema + enforced gating for the QNX judge measure (L1 / #274)

### DIFF
--- a/crates/kirra-timing/src/lib.rs
+++ b/crates/kirra-timing/src/lib.rs
@@ -74,7 +74,7 @@ pub use clock::MonotonicClock;
 #[cfg(feature = "std")]
 pub use clock::StdMonotonicClock;
 pub use env::MeasurementEnv;
-pub use report::{Report, StageReport};
+pub use report::{Report, StageReport, CSV_HEADER};
 
 /// Canonical labels for the five safety-critical execution-loop stages (#274).
 /// Using these constants keeps stage names consistent across crates, the harness,
@@ -286,9 +286,17 @@ mod tests {
         let mut csv = String::new();
         report.write_csv(&mut csv).unwrap();
         let mut lines = csv.lines();
+        // The emitted header must be the canonical CSV_HEADER verbatim — the QNX
+        // harness's wcet_measure row joins on exactly these columns, so a drift
+        // here would silently break that union. Lock both the literal and the const.
         assert_eq!(
             lines.next().unwrap(),
             "metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status"
+        );
+        assert_eq!(
+            report::CSV_HEADER,
+            "metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status",
+            "CSV_HEADER is the canonical schema the QNX harness mirrors — update both if it changes"
         );
         let row = lines.next().unwrap();
         assert!(row.starts_with("total_loop,ci-runner,host-default,1,"));

--- a/crates/kirra-timing/src/report.rs
+++ b/crates/kirra-timing/src/report.rs
@@ -11,6 +11,15 @@ use core::fmt;
 use crate::channel::ChannelStats;
 use crate::env::MeasurementEnv;
 
+/// The canonical CSV header — the **single source of truth** for the machine
+/// schema shared by every WCET measurement surface (this crate's
+/// [`Report::write_csv`], the host `kirra-wcet-bench`, and the QNX
+/// `tools/qnx-rtm-harness/wcet_measure` row). Downstream tooling joins on these
+/// columns, so the harness emits this byte-for-byte rather than a divergent
+/// subset. Keep [`Report::write_csv`]'s row column order identical to this.
+pub const CSV_HEADER: &str =
+    "metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status";
+
 /// One named stage's statistics within a [`Report`].
 #[derive(Debug, Clone, Copy)]
 pub struct StageReport {
@@ -53,22 +62,16 @@ impl<'a> Report<'a> {
         self.env.is_certified_wcet()
     }
 
-    /// Write the machine-readable CSV (header + one row per stage). Stable column
-    /// order. This is an **extended superset** of the
-    /// `tools/qnx-rtm-harness/wcet_measure.cpp` row
-    /// (`metric,target,sched,n,warmup,max_ns,p999_ns,wcet_status`): it shares
-    /// `metric,sched,n,max_ns,p999_ns,wcet_status` and adds
-    /// `env,min_ns,mean_ns,stddev_ns,p50_ns,p99_ns` (and uses `env` where the
-    /// harness uses `target`). It is NOT byte-identical — downstream tooling that
-    /// expects the exact harness header must map columns, not assume equality.
+    /// Write the machine-readable CSV (header + one row per stage). The header is
+    /// [`CSV_HEADER`], the canonical schema that the QNX
+    /// `tools/qnx-rtm-harness/wcet_measure` row now emits byte-for-byte too, so a
+    /// host report and an on-target report union into one table joinable on
+    /// `metric` + `env`. Row column order matches [`CSV_HEADER`] exactly.
     ///
     /// # Errors
     /// Propagates any [`fmt::Error`] from the writer.
     pub fn write_csv(&self, w: &mut impl fmt::Write) -> fmt::Result {
-        writeln!(
-            w,
-            "metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status"
-        )?;
+        writeln!(w, "{CSV_HEADER}")?;
         for s in self.stages {
             let st = &s.stats;
             writeln!(

--- a/docs/adr/KIRRA_QNX_RUNBOOK.md
+++ b/docs/adr/KIRRA_QNX_RUNBOOK.md
@@ -1,0 +1,187 @@
+# KIRRA QNX Runbook — RTM/FDIT + verdict-path WCET on a QNX SDP 8.0 target
+
+**Status:** Active operator runbook (Phase-I bring-up).
+**Scope:** the step-by-step workflow to cross-build the QNX RTM harness, deploy it
+to a QNX SDP 8.0 target (an x86-64 VM is the Phase-I surrogate), and capture the
+FDIT verdict-correctness gate + the per-verdict WCET CSV row.
+
+This runbook is the **operator how-to**. It does not restate the design — for that
+see, and keep authoritative:
+
+- `docs/safety/WCET_QNX_BRINGUP.md` (#274) — the WCET cross-compile recipe + the
+  Phase-I acceptance criteria + the host-vs-target invariant.
+- `docs/adr/KIRRA_QNX_CROSSCOMPILE.md` — the QNX SDP 8.0 + Rust toolchain install
+  recipe (written for the governor-service binary; the toolchain steps apply here).
+- `tools/qnx-rtm-harness/README.md` + `QNX_MAPPING.md` — the harness internals, the
+  concern split (C++ shim DRIVER vs Rust judge CHECKER), and the RTM traceability.
+- `docs/safety/WCET_MEASUREMENT_METHODOLOGY.md` — why host numbers are INDICATIVE.
+
+---
+
+## 0. Topology — who builds, who runs
+
+The QNX target does **not** build anything. You **cross-compile on a dev host that
+has QNX SDP 8.0 installed**, then copy the resulting `nto` binaries to the QNX
+target and run them there.
+
+| Box | Role | OS / stack |
+|---|---|---|
+| **Dev host** | Cross-compile (`run_qnx_fdit.sh`) | Linux + QNX SDP 8.0 (`qcc`/`q++`) + Rust |
+| **QNX target** | Runs `rtm_harness` / `wcet_measure` / `kirra_demo` | QNX SDP 8.0 (x86-64 VM for Phase-I; NVIDIA DRIVE + QNX OS for Safety for Phase-II) |
+
+For the Phase-I x86 laptop setup the QNX target is a **VM** (KVM/QEMU), which is why
+hardware virtualization (Intel VT-x / AMD-V) must be enabled in BIOS — see §1.
+
+> **Phase boundary (do not skip).** A number from an x86 VM under TCG/KVM is
+> **Phase-I feasibility**, not a certified WCET. Cert-grade WCET is **Phase-II**:
+> NVIDIA DRIVE + QNX OS for Safety + a Ferrocene-qualified Rust under FIFO. The
+> harness encodes this — see `AOU-HW-QNX-TARGET-001` and `QNX_MAPPING.md` §7.
+
+---
+
+## 1. Prerequisites (one-time)
+
+### 1a. Dev host — QNX SDP 8.0 + Rust
+
+```sh
+# QNX SDP 8.0 installed; source its environment (adjust to your install path).
+# Sets QNX_HOST, QNX_TARGET and prepends qcc/q++ to PATH.
+source ~/qnx800/qnxsdp-env.sh
+qcc -V                                   # confirm the qcc variant your SDP ships
+
+# The judge is built no_std (core only). The x86_64-pc-nto-qnx800 target usually
+# has no prebuilt `core` in upstream rustc, so run_qnx_fdit.sh falls back to
+# `cargo -Z build-std=core`, which needs nightly + rust-src:
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
+```
+
+(If your QNX SDP ships its own bundled Rust with the `nto-qnx800` target, the
+script's first path — a direct `rustc --target` cross-build — is used instead and
+nightly/rust-src are not needed. The script tries direct first, then build-std.)
+
+### 1b. QNX target VM (Phase-I, x86 laptop)
+
+- Enable **Intel VT-x** (and **VT-d** if you'll pass through devices) in BIOS, so
+  KVM can run the QNX guest. (HP: Esc → F10; most others: F2 or Del.)
+- Build/boot a QNX SDP 8.0 x86-64 guest image (`mkqnximage` or a prebuilt SDP VM
+  image — this is a QNX SDP step, **outside** this harness; see the QNX SDP docs).
+- Note the guest's IP (`ifconfig` inside QNX) for the `scp` in §3. The default QNX
+  image logs in as **root**, which you want for `SCHED_FIFO`.
+
+---
+
+## 2. Cross-build the harness (dev host)
+
+```sh
+cd ~/kirra-runtime-sdk
+source ~/qnx800/qnxsdp-env.sh            # if not already sourced this shell
+
+# Cross-builds: the no_std judge (libkirra_judge.a, nto) + the C++ shim/harness/
+# demo + wcet_measure, all for the QNX target. x86_64 is the default arch.
+tools/qnx-rtm-harness/run_qnx_fdit.sh
+```
+
+Optional overrides (see the script header): `KIRRA_QNX_ARCH=aarch64`,
+`KIRRA_RUSTC_TARGET=...`, `KIRRA_QNX_QCC_VARIANT=...`, `KIRRA_RUST_TARGET_JSON=...`.
+
+Output lands in `tools/qnx-rtm-harness/build-qnx/`:
+
+| Binary | Purpose |
+|---|---|
+| `rtm_harness` | FDIT/RTM matrix — exits **non-zero on ANY wrong verdict** (the gate) |
+| `wcet_measure` | `SCHED_FIFO` per-verdict WCET row (run as root) |
+| `kirra_demo`   | end-to-end demo incl. a replay rejection |
+
+These are `nto` binaries — they will **not** run on the Linux dev host.
+
+---
+
+## 3. Deploy to the QNX target
+
+```sh
+cd tools/qnx-rtm-harness/build-qnx
+scp rtm_harness wcet_measure kirra_demo root@<qnx-vm-ip>:/tmp/
+```
+
+(Or use a shared image / virtfs mount if the VM has no network route.)
+
+---
+
+## 4. Run on the QNX target (as root)
+
+```sh
+cd /tmp
+
+# 1) The PASS gate — verdict correctness. MUST exit 0.
+./rtm_harness && echo "FDIT: every verdict correct on QNX (gate PASS)"
+
+# 2) End-to-end demo (incl. a replay that must be rejected).
+./kirra_demo
+
+# 3) The WCET row. Run as ROOT so SCHED_FIFO is granted; otherwise the row
+#    self-declares INDICATIVE (see §5).
+./wcet_measure
+```
+
+---
+
+## 5. Interpreting the `wcet_measure` output
+
+The CSV row is the **canonical `kirra_timing::report::CSV_HEADER` schema** — the
+same columns the host `kirra-wcet-bench` emits, so host and on-target rows union
+into one table joinable on `(metric, env)`:
+
+```
+metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status
+kirra_judge_assess,qnx-target-fifo,SCHED_FIFO,1000000,…,QNX-TARGET-MEASURED
+```
+
+The `env` / `wcet_status` columns map onto `kirra_timing::MeasurementEnv` and are
+**gated**, so a row cannot misrepresent itself:
+
+| Where it ran | `env` | `wcet_status` |
+|---|---|---|
+| QNX target, `SCHED_FIFO` granted (root) | `qnx-target-fifo` | `QNX-TARGET-MEASURED` |
+| QNX target, no FIFO (not root) | `other` | `INDICATIVE-NOT-WCET` |
+| A host smoke build | `host` | `INDICATIVE-NOT-WCET` |
+
+The certified pair is emitted **only** under the `kIsQnxTarget && fifo_granted`
+conjunction (a host build cannot mint it even if the host grants `SCHED_FIFO`).
+
+**Phase-I acceptance** (`WCET_QNX_BRINGUP.md` §4): `rtm_harness` PASSes
+byte-identically on-target, and `wcet_measure`'s **`MAX < 100 µs`**. That replaces
+the `TBD-QNX-TARGET` placeholder figure with the measured row. Remember the
+VM-vs-hardware caveat in §0: a VM `QNX-TARGET-MEASURED` is feasibility-grade.
+
+**Send back** the `rtm_harness` PASS line and the two `wcet_measure` lines (the
+human `WCET …` line + the CSV row); the row gets folded into `QNX_MAPPING.md`.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `run_qnx_fdit.sh` aborts: `source qnxsdp-env.sh first` | `QNX_HOST`/`QNX_TARGET` unset — source the SDP env in this shell. |
+| `[judge] FAILED to build the judge` | rust-src/nightly missing → `rustup component add rust-src --toolchain nightly`. If rustc doesn't know the `…-nto-qnx800` tuple at all, use the custom `target.json` path the script prints (`KIRRA_RUST_TARGET_JSON=…`). Logs: `build-qnx/rustc_direct.log`, `build-qnx/cargo_buildstd.log`. |
+| `wcet_measure` row says `host` / `INDICATIVE-NOT-WCET` on the target | The binary wasn't built for `nto` (re-run §2 with the SDP env sourced), or you're not actually on the QNX target. |
+| `wcet_measure` row says `other` / `INDICATIVE-NOT-WCET` | `SCHED_FIFO` not granted — run as **root**. |
+| `MAX` is large (ms) but `p99.9` is single-digit µs | Emulation jitter (TCG). Prefer KVM (VT-x) and an isolated core; the methodology gates on **p99.9, not max** — but Phase-I acceptance is on `MAX < 100 µs`, so a KVM/native run is needed for the gate. |
+| `scp` cannot reach the VM | Get the guest IP via `ifconfig` inside QNX; ensure the VM network (NAT/bridged) routes; or use a shared image/virtfs. |
+
+---
+
+## 7. What this proves (and what it doesn't)
+
+- **Proves (Phase-I):** the judge renders **correct verdicts** on a real QNX target
+  (the FDIT gate), and the verdict path is **bounded and fast** (feasibility-grade
+  WCET). This is the deferred `max < 100 µs` feasibility check.
+- **Does not prove (Phase-II):** a *certified* WCET. That requires DRIVE hardware +
+  QNX OS for Safety + Ferrocene-qualified Rust under FIFO on the frozen partition
+  config — the number that backs the FTTI claim (`verdict_WCET + actuation_latency
+  < control_cycle < 0.5 s`). See `docs/safety/ASIL_DECOMPOSITION.md` §7 and
+  `WCET_MEASUREMENT_METHODOLOGY.md`.
+
+The PASS gate is, and remains, **verdict correctness** — the WCET row is supporting
+timing evidence, staged Phase-I (indicative) → Phase-II (certified).

--- a/docs/adr/KIRRA_QNX_RUNBOOK.md
+++ b/docs/adr/KIRRA_QNX_RUNBOOK.md
@@ -66,6 +66,9 @@ nightly/rust-src are not needed. The script tries direct first, then build-std.)
   KVM can run the QNX guest. (HP: Esc → F10; most others: F2 or Del.)
 - Build/boot a QNX SDP 8.0 x86-64 guest image (`mkqnximage` or a prebuilt SDP VM
   image — this is a QNX SDP step, **outside** this harness; see the QNX SDP docs).
+  A concrete, reproducible `mkqnximage`/QEMU recipe (bridge net, the IFS bake-in +
+  auto-run overlay, the KVM-vs-TCG acceleration check) lives in
+  `tools/qnx-rtm-harness/QNX_VM_RELAUNCH.md`.
 - Note the guest's IP (`ifconfig` inside QNX) for the `scp` in §3. The default QNX
   image logs in as **root**, which you want for `SCHED_FIFO`.
 

--- a/docs/adr/KIRRA_QNX_RUNBOOK.md
+++ b/docs/adr/KIRRA_QNX_RUNBOOK.md
@@ -121,7 +121,14 @@ cd /tmp
 
 # 3) The WCET row. Run as ROOT so SCHED_FIFO is granted; otherwise the row
 #    self-declares INDICATIVE (see §5).
-./wcet_measure
+#
+#    On a VM (KVM/TCG), tag the provenance but DO NOT assert certification —
+#    a VM is Phase-I feasibility, never cert-grade:
+KIRRA_WCET_PLATFORM=kvm ./wcet_measure
+#
+#    ONLY on the certified Phase-II hardware (DRIVE AGX + QNX OS for Safety +
+#    Ferrocene under FIFO) does the operator assert certification:
+#    KIRRA_WCET_CERTIFIED=1 KIRRA_WCET_PLATFORM=drive-agx ./wcet_measure
 ```
 
 ---
@@ -142,12 +149,17 @@ The `env` / `wcet_status` columns map onto `kirra_timing::MeasurementEnv` and ar
 
 | Where it ran | `env` | `wcet_status` |
 |---|---|---|
-| QNX target, `SCHED_FIFO` granted (root) | `qnx-target-fifo` | `QNX-TARGET-MEASURED` |
+| Certified HW + FIFO + `KIRRA_WCET_CERTIFIED=1` | `qnx-target-fifo` | `QNX-TARGET-MEASURED` |
+| QNX **VM** (KVM/TCG), FIFO, no assertion | `other` | `INDICATIVE-NOT-WCET` |
 | QNX target, no FIFO (not root) | `other` | `INDICATIVE-NOT-WCET` |
 | A host smoke build | `host` | `INDICATIVE-NOT-WCET` |
 
-The certified pair is emitted **only** under the `kIsQnxTarget && fifo_granted`
-conjunction (a host build cannot mint it even if the host grants `SCHED_FIFO`).
+The certified pair is emitted **only** under the three-way conjunction
+`kIsQnxTarget && fifo_granted && KIRRA_WCET_CERTIFIED=1`. The explicit operator
+assertion is mandatory because the binary cannot distinguish certified DRIVE/QNX-OS
+hardware from a QNX VM — so a near-native KVM run stays `INDICATIVE` unless someone
+deliberately asserts certified hardware. `KIRRA_WCET_PLATFORM` (e.g. `kvm`) is a
+provenance label echoed in the human banner only; it never changes the verdict.
 
 **Phase-I acceptance** (`WCET_QNX_BRINGUP.md` §4): `rtm_harness` PASSes
 byte-identically on-target, and `wcet_measure`'s **`MAX < 100 µs`**. That replaces

--- a/docs/safety/WCET_QNX_BRINGUP.md
+++ b/docs/safety/WCET_QNX_BRINGUP.md
@@ -150,6 +150,17 @@ What the Phase-I run must show to substantiate the Objective-1 "sub-100 µs verd
 
 **Feasibility signal (INDICATIVE — never WCET; see Hard boundaries).** The host harness already runs the verdict per-call in the **sub-microsecond** range (`QNX_MAPPING.md` regression rows: p50 ≈ 0.5 µs, p99 ≈ 0.5 µs on the OK row), with even the scheduling-noise-inflated host *max* ≈ 27 µs — all comfortably under the 100 µs target. So the Phase-I target-FIFO measurement is expected to **confirm** feasibility, not discover a problem: the risk is "produce the certifiable number on the right OS," not "find out whether the bound is met." This is why Objective 1 is a **defined build, not research** — only a QNX target (the #274 blocker) stands between the recipe and the row.
 
+**Phase-I status (KVM, 2026-06-30).** Criteria 1, 2, and 4 are met on a QNX SDP 8.0
+x86_64 `mkqnximage`/QEMU VM under **KVM**: the judge cross-compiles, the FDIT matrix
+passes byte-identically (`GATE: PASS`, all 9 rows), and **`max = 21.0 µs < 100 µs`**
+(median 40 ns, p99.9 76 ns) — see `QNX_MAPPING.md` §6.2 and
+`tools/qnx-rtm-harness/results/qnx800-x86_64-vm-kvm.txt`. **Criterion 3 is
+deliberately NOT met by this run:** the `QNX-TARGET-MEASURED` token is gated behind
+an explicit `KIRRA_WCET_CERTIFIED` operator assertion (the #274 cert gate) that a
+KVM VM must not set, so the row honestly self-declares `INDICATIVE-NOT-WCET`. A KVM
+VM is feasibility-grade; the certified token is reserved for the Phase-II hardware
+(NVIDIA DRIVE + QNX OS for Safety + Ferrocene), where criterion 3 is satisfied.
+
 ## Done vs. remaining
 
 | | State |

--- a/tools/qnx-rtm-harness/QNX_MAPPING.md
+++ b/tools/qnx-rtm-harness/QNX_MAPPING.md
@@ -234,11 +234,16 @@ correctness**, which is now demonstrated on a real QNX target.
 byte-identical to the host `kirra-wcet-bench` output, so the two union into one
 table joinable on `(metric, env)`. `env`/`wcet_status` map onto
 `kirra_timing::MeasurementEnv`: the certified `qnx-target-fifo` /
-`QNX-TARGET-MEASURED` pair is emitted **only** when the binary was built for the
-QNX target *and* `SCHED_FIFO` was actually granted (the `kIsQnxTarget &&
-fifo_granted` conjunction); a host smoke build self-declares `host` /
-`INDICATIVE-NOT-WCET`, and a QNX run without FIFO privilege declares `other` /
-`INDICATIVE-NOT-WCET` — neither can mint a certified figure. The VM-vs-hardware
-(Phase-I-vs-Phase-II) distinction above is **orthogonal** to this gate and remains
-an assumption-of-use (AOU-HW-QNX-TARGET-001): a `QNX-TARGET-MEASURED` row from a
-KVM/TCG VM is feasibility-grade, not the cert-grade Phase-II number.
+`QNX-TARGET-MEASURED` pair is emitted **only** under a **three-way conjunction** —
+the binary was built for the QNX target (`kIsQnxTarget`), `SCHED_FIFO` was actually
+granted at runtime (`fifo_granted`), **and** the operator explicitly asserted the
+certified Phase-II hardware platform via `KIRRA_WCET_CERTIFIED=1`. The third term
+is mandatory because the binary **cannot** tell certified DRIVE + QNX OS for Safety
+hardware from a QNX **VM** under KVM/TCG (both are `__QNXNTO__` with FIFO) — so the
+VM-vs-hardware (Phase-I-vs-Phase-II) distinction is folded **into the gate**, not
+left to prose. Without the assertion every QNX run — including a near-native KVM
+VM — self-declares `other` / `INDICATIVE-NOT-WCET`; a host smoke build declares
+`host` / `INDICATIVE-NOT-WCET`. A VM thus **cannot** mint a certified figure by
+accident (fail-honest, `AOU-HW-QNX-TARGET-001`). Provenance (e.g. `kvm` vs `tcg`)
+is carried in the human banner via the free-form `KIRRA_WCET_PLATFORM` label, which
+never changes the verdict.

--- a/tools/qnx-rtm-harness/QNX_MAPPING.md
+++ b/tools/qnx-rtm-harness/QNX_MAPPING.md
@@ -216,8 +216,26 @@ emulation), NOT KVM** (the dev laptop has VT-x disabled in firmware). A represen
 `SCHED_FIFO` WCET requires KVM (near-native) or hardware; under TCG the absolute
 numbers carry full interpreter + VM-deschedule overhead (observed: median ≈ 3.6 µs,
 p99.9 ≈ 10.6 µs, **max ≈ 2.2 ms** — the millisecond max is emulation jitter, not the
-judge). So the `max < 100 µs` criterion is **deferred** to a KVM/hardware run; the
+judge). So the `max < 100 µs` criterion was **deferred** to a KVM/hardware run; the
 typical-case single-digit-µs figure even under heavy emulation is feasibility-positive.
+
+### 6.2 On-target result — KVM (acceptance-#4 met, INDICATIVE)
+
+Re-run on the same `mkqnximage`/QEMU VM with **VT-x enabled → QEMU KVM**
+(`-enable-kvm -cpu host`). **GATE: PASS (all 9 rows)** again — verdict correctness
+is unaffected by the accelerator. Timing collapses ~100× vs TCG and the deferred
+`max < 100 µs` acceptance-#4 target is now **met as a KVM-INDICATIVE result**:
+
+```
+WCET kirra_judge_assess  n=1000000  min=31ns  med=40ns  p99.9=76ns  MAX=21001ns  [INDICATIVE — platform=kvm]
+kirra_judge_assess,other,host-default,1000000,31,41,21001,70,40,48,76,INDICATIVE-NOT-WCET
+```
+
+median 40 ns, p99.9 **76 ns**, **max 21.0 µs** (vs TCG max 2.20 ms). Full evidence:
+`results/qnx800-x86_64-vm-kvm.txt`. This is **Phase-I feasibility, not cert-grade** —
+a VM on an x86_64 laptop is not the deployment ISA, and the post-#274 cert gate
+correctly emits `INDICATIVE-NOT-WCET` (the operator did not assert
+`KIRRA_WCET_CERTIFIED`). Cert-grade WCET remains Phase-II (§7).
 
 ## 7. WCET — Phase-I indicative, cert-grade TBD
 

--- a/tools/qnx-rtm-harness/QNX_MAPPING.md
+++ b/tools/qnx-rtm-harness/QNX_MAPPING.md
@@ -227,3 +227,18 @@ emulation it is INDICATIVE, never a WCET**. The harness CSV still carries the
 NVIDIA DRIVE (Orin/Thor) + QNX OS for Safety + Ferrocene-qualified Rust under FIFO —
 that number, not a VM figure, backs the FTTI claim. The PASS gate remains **verdict
 correctness**, which is now demonstrated on a real QNX target.
+
+**`wcet_measure` CSV schema (#274).** The row is now the **canonical
+`kirra_timing::report::CSV_HEADER`** schema
+(`metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status`),
+byte-identical to the host `kirra-wcet-bench` output, so the two union into one
+table joinable on `(metric, env)`. `env`/`wcet_status` map onto
+`kirra_timing::MeasurementEnv`: the certified `qnx-target-fifo` /
+`QNX-TARGET-MEASURED` pair is emitted **only** when the binary was built for the
+QNX target *and* `SCHED_FIFO` was actually granted (the `kIsQnxTarget &&
+fifo_granted` conjunction); a host smoke build self-declares `host` /
+`INDICATIVE-NOT-WCET`, and a QNX run without FIFO privilege declares `other` /
+`INDICATIVE-NOT-WCET` — neither can mint a certified figure. The VM-vs-hardware
+(Phase-I-vs-Phase-II) distinction above is **orthogonal** to this gate and remains
+an assumption-of-use (AOU-HW-QNX-TARGET-001): a `QNX-TARGET-MEASURED` row from a
+KVM/TCG VM is feasibility-grade, not the cert-grade Phase-II number.

--- a/tools/qnx-rtm-harness/QNX_VM_RELAUNCH.md
+++ b/tools/qnx-rtm-harness/QNX_VM_RELAUNCH.md
@@ -1,0 +1,162 @@
+# QNX SDP 8.0 x86_64 VM — Relaunch Runbook (#274)
+
+Reproducible recipe for spinning up the QNX 8.0 `mkqnximage`/QEMU VM and running
+the on-target FDIT matrix + `wcet_measure`. Recovered verbatim from the bring-up
+session.
+
+**This run's one change vs. last time: KVM instead of TCG.** Last time the dev
+laptop had VT-x disabled (no `/dev/kvm`), so QEMU fell back to TCG software
+emulation and the WCET numbers were jitter-dominated (`max ~2.2 ms`). With Intel
+virtualization now enabled, QEMU can use KVM (near-native), making the
+acceptance-#4 attempt (`max < 100 µs`) reachable as a **Phase-I-indicative**
+result.
+
+> All commands run on the **dev laptop**, not in CI/sandbox. Paths reflect that
+> machine (`/opt/qnx800/sdp2`, `~/qnxvm`, `/home/justin/...`).
+
+## Environment
+
+| Thing | Value |
+|---|---|
+| SDP install | `/opt/qnx800/sdp2` |
+| SDP env script | `source /opt/qnx800/sdp2/qnxsdp-env.sh` |
+| `mkqnximage` | `/opt/qnx800/sdp2/host/common/bin/mkqnximage` |
+| VM workdir | `~/qnxvm` |
+| VM IP / host | `172.31.1.10` / `qnxvm` (bridge `br0`) |
+| Target tuple | `x86_64-pc-nto-qnx800` |
+| Toolchain | judge: `cargo -Zbuild-std=core` (core-only, no QNX std); C++: `q++` QCC 12.2.0 |
+
+The `~/qnxvm/local/snippets/*.custom` overlay files **persist** across rebuilds —
+if `~/qnxvm` was not wiped, the bake-in + auto-run blocks are still present and
+you can skip straight to the quick path.
+
+## Quick path (overlay still present from last time)
+
+```bash
+# 1. SDP env
+source /opt/qnx800/sdp2/qnxsdp-env.sh
+
+# 2. Re-cross-build the binaries the overlay references (regenerates build-qnx/)
+cd ~/kirra-runtime-sdk
+tools/qnx-rtm-harness/run_qnx_fdit.sh
+
+# 3. Confirm KVM is now live (the point of the reboot)
+ls -l /dev/kvm && grep -Eoc '(vmx)' /proc/cpuinfo
+
+# 4. Rebuild the image + boot headless
+cd ~/qnxvm
+/opt/qnx800/sdp2/host/common/bin/mkqnximage --build --run=-h
+
+# 5. Read the auto-run results off the serial console
+sleep 30
+sed -n '/KIRRA-274 FDIT START/,/KIRRA-274 DONE/p' ~/qnxvm/output/qemu.out
+```
+
+## Make sure step 4 actually uses KVM
+
+Last time the generated QEMU line was `--cpu max` with **no** `-enable-kvm` (TCG,
+because `/dev/kvm` was absent). Check whether `--run` picked up KVM this time:
+
+```bash
+grep -m1 'QEMU Command' ~/qnxvm/output/qemu.out   # look for -enable-kvm / accel=kvm
+```
+
+If it's **still not** KVM, build the image without running, then launch QEMU
+directly with acceleration (last time's exact generated command + `-enable-kvm
+-cpu host`, duplicate `-nographic` dropped):
+
+```bash
+cd ~/qnxvm
+/opt/qnx800/sdp2/host/common/bin/mkqnximage --build      # rebuild IFS only, don't run
+qemu-system-x86_64 -enable-kvm -cpu host -smp 2 -m 1G \
+  -drive file=output/disk-qemu.vmdk,if=ide,id=drv0 \
+  -netdev bridge,br=br0,id=net0 -device virtio-net-pci,netdev=net0,mac=52:54:00:e3:a6:d3 \
+  -pidfile output/qemu.pid -nographic -kernel output/ifs.bin \
+  -serial file:output/qemu.out \
+  -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 &
+sleep 30
+sed -n '/KIRRA-274 FDIT START/,/KIRRA-274 DONE/p' ~/qnxvm/output/qemu.out
+```
+
+The `br0` bridge + `qemu-bridge-helper` were already configured last time (network
+came up), so this should just work.
+
+## If `~/qnxvm` is fresh — recreate it + the bake-in (full recipe)
+
+```bash
+# create the VM (bridge net, root login, ssh key, headless)
+mkdir -p ~/qnxvm && cd ~/qnxvm
+/opt/qnx800/sdp2/host/common/bin/mkqnximage \
+  --type=qemu --ip=172.31.1.10 --hostname=qnxvm \
+  --users=root/root --ssh-ident="$HOME/.ssh/id_ed25519.pub" \
+  --build --run=-h
+
+# bake the 3 binaries into the boot IFS (they land in /proc/boot -> on PATH)
+cat >> ~/qnxvm/local/snippets/ifs_files.custom <<'EOF'
+[perms=0755 uid=0 gid=0] rtm_harness = /home/justin/kirra-runtime-sdk/tools/qnx-rtm-harness/build-qnx/rtm_harness
+[perms=0755 uid=0 gid=0] wcet_measure = /home/justin/kirra-runtime-sdk/tools/qnx-rtm-harness/build-qnx/wcet_measure
+[perms=0755 uid=0 gid=0] kirra_demo = /home/justin/kirra-runtime-sdk/tools/qnx-rtm-harness/build-qnx/kirra_demo
+EOF
+
+# auto-run them at boot; output goes to the serial console (output/qemu.out)
+cat >> ~/qnxvm/local/snippets/post_start.custom <<'EOF'
+echo "===== KIRRA-274 FDIT START ====="
+rtm_harness
+echo "KIRRA-274 FDIT_EXIT=$?"
+echo "===== KIRRA-274 WCET START ====="
+wcet_measure
+echo "KIRRA-274 WCET_EXIT=$?"
+echo "===== KIRRA-274 DONE ====="
+EOF
+```
+
+> **Auto-run + the cert gate (`wcet_measure`, after PR #734).** The bake-in above
+> runs `wcet_measure` with no env, so it self-declares `other` /
+> `INDICATIVE-NOT-WCET` — correct for a VM. To tag KVM provenance in the banner,
+> change the `post_start.custom` line to `KIRRA_WCET_PLATFORM=kvm wcet_measure`.
+> **Never** set `KIRRA_WCET_CERTIFIED=1` on the VM — that flag is reserved for the
+> Phase-II certified hardware and is the only thing that promotes a row to
+> `QNX-TARGET-MEASURED`.
+
+Then run steps 4–5 (or the direct-KVM launch) above.
+
+## Useful adjuncts
+
+```bash
+/opt/qnx800/sdp2/host/common/bin/mkqnximage --getip    # prints 172.31.1.10
+/opt/qnx800/sdp2/host/common/bin/mkqnximage --stop     # stop the VM
+tail -n 80 ~/qnxvm/output/qemu.out                     # watch boot / console
+```
+
+## After the run — honesty labelling
+
+- **Gate = verdict correctness.** `GATE: PASS` (all 9 rows) is the load-bearing
+  result; emulation/virtualization does not affect it.
+- **WCET under KVM is `INDICATIVE-KVM`, not cert-grade.** A KVM VM is near-native
+  but is still a VM on an x86_64 laptop, not the deployment ISA. Record the row as
+  `x86_64-pc-nto-qnx800(KVM) / INDICATIVE-KVM` — do **not** promote it to
+  `QNX-TARGET-MEASURED`.
+  - *Token vs. label.* `INDICATIVE-KVM` is the **human label** for the recorded
+    results file / `QNX_MAPPING.md` prose. The machine **CSV token** emitted by
+    `wcet_measure` is the canonical `INDICATIVE-NOT-WCET` (with `env=other`,
+    `sched=host-default`, and `platform=kvm` in the human banner) — see
+    `QNX_MAPPING.md` §7. They are consistent: both say "not WCET evidence"; the
+    `(KVM)` provenance lives in the banner + this label, not in the canonical
+    `wcet_status` column (which stays a `kirra_timing::MeasurementEnv` token so the
+    host-vs-target join holds).
+- **Cert-grade WCET is Phase-II:** NVIDIA DRIVE AGX (Orin/Thor) + QNX OS for
+  Safety + Ferrocene-qualified Rust under SCHED_FIFO. That number, not a VM
+  figure, backs the FTTI claim.
+- Save the `KIRRA-274 …` block to
+  `tools/qnx-rtm-harness/results/qnx800-x86_64-vm-kvm.txt` (beside the TCG one);
+  if `max < 100 µs`, update `QNX_MAPPING.md §6.1` and `WCET_QNX_BRINGUP.md` to
+  record the KVM-indicative acceptance-#4 attempt.
+
+## See also
+
+- `tools/qnx-rtm-harness/README.md` — harness overview, the FDIT matrix
+- `tools/qnx-rtm-harness/run_qnx_fdit.sh` — the cross-build driver
+- `tools/qnx-rtm-harness/QNX_MAPPING.md` §6 / §6.1 — on-target run + recorded result
+- `docs/adr/KIRRA_QNX_RUNBOOK.md` — the general cross-build → deploy → run runbook
+- `docs/safety/WCET_QNX_BRINGUP.md` — full recipe + Phase-I acceptance criteria
+- `tools/qnx-rtm-harness/results/qnx800-x86_64-vm-tcg.txt` — prior TCG run evidence

--- a/tools/qnx-rtm-harness/results/qnx800-x86_64-vm-kvm.txt
+++ b/tools/qnx-rtm-harness/results/qnx800-x86_64-vm-kvm.txt
@@ -1,0 +1,53 @@
+KIRRA #274 — on-target FDIT + WCET evidence (Phase-I feasibility, KVM)
+=====================================================================
+Target : QNX SDP 8.0, x86_64, mkqnximage/QEMU VM
+Accel  : QEMU KVM (near-native) — VT-x ENABLED on dev laptop (-enable-kvm -cpu host)
+Build  : judge x86_64-pc-nto-qnx800 (cargo -Zbuild-std=core, no QNX std);
+         C++ via q++ (QCC 12.2.0). Binaries baked into the IFS, auto-run at boot.
+Date   : 2026-06-30
+
+GATE  : verdict correctness — the ONLY pass criterion. Result: PASS (all 9 rows).
+WCET  : INDICATIVE-KVM. KVM is near-native, so the absolute numbers are far
+        cleaner than the TCG run (max 21 us vs 2.2 ms) and the `max < 100 us`
+        acceptance-#4 target is now MET — but a VM on an x86_64 laptop is still
+        NOT the deployment ISA. This is Phase-I feasibility, not cert-grade.
+        Cert-grade WCET is Phase-II (NVIDIA DRIVE + QNX OS for Safety + Ferrocene
+        under SCHED_FIFO); that number, not a VM figure, backs the FTTI claim.
+
+--- FDIT / RTM matrix (verbatim, on QNX) ----------------------------------------
+row    fault class            rtm            ok     verdict             p50(ns)    p99(ns)    max(ns)
+-------------------------------------------------------------------------------------------------
+SG-00  valid                  CONTROL        PASS   Ok                      786        882      21126
+SG-01  bad-magic              NO-RTM-ID      PASS   StaleHeader             786        810      21235
+SG-02  sequence-regress       NO-RTM-ID      PASS   SequenceRegress         786        884      19745
+SG-03  deadline-missed        NO-RTM-ID      PASS   DeadlineMissed          786        868      18536
+SG-04  payload-corrupt (CRC)  NO-RTM-ID      PASS   PayloadCorrupt          786        807      18065
+SG-05  payload-oversize       NO-RTM-ID      PASS   PayloadOversize          80         96       4181
+SG-06  over-envelope          SG-001/TR-001  PASS   KinematicLimit          786        813      23802
+SG-07  replay (seq==last)     NO-RTM-ID      PASS   SequenceRegress         786        880      19827
+SG-08  torn-write (odd gen)   NO-RTM-ID      PASS   StaleHeader             104        124      17971
+
+GATE (verdict correctness): PASS
+FDIT_EXIT=0
+
+--- wcet_measure (INDICATIVE-KVM — canonical schema, post-#734 cert gate) --------
+WCET kirra_judge_assess  n=1000000  min=31ns  med=40ns  p99.9=76ns  MAX=21001ns  [INDICATIVE — not a WCET claim; platform=kvm]
+metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status
+kirra_judge_assess,other,host-default,1000000,31,41,21001,70,40,48,76,INDICATIVE-NOT-WCET
+WCET_EXIT=0
+
+Acceptance #4 (`max < 100 us`): MET as a KVM-INDICATIVE result (max = 21.0 us).
+Contrast the TCG run (qnx800-x86_64-vm-tcg.txt): max 2.20 ms — KVM is ~100x cleaner.
+
+Notes:
+- Unlike the TCG run, the binary did NOT need a manual downgrade: with the #274
+  cert gate (`kIsQnxTarget && fifo_granted && KIRRA_WCET_CERTIFIED`) the row
+  self-declares `INDICATIVE-NOT-WCET` because the VM operator did not assert
+  certified hardware (`KIRRA_WCET_CERTIFIED` unset). `platform=kvm` (banner)
+  records the provenance. A VM can no longer mint `QNX-TARGET-MEASURED`.
+- The CSV above reads `sched=host-default`, but the run genuinely ran under
+  SCHED_FIFO (root auto-run context; no "SCHED_FIFO not granted" WARN was
+  emitted). That label was tied to the cert flag in the binary that produced this
+  row; the accompanying sched-label fix decouples `sched` from the cert verdict
+  (`sched = fifo_granted ? "SCHED_FIFO" : "host-default"`), so a re-run emits
+  `sched=SCHED_FIFO`. The `INDICATIVE-NOT-WCET` verdict is unchanged.

--- a/tools/qnx-rtm-harness/wcet_measure.cpp
+++ b/tools/qnx-rtm-harness/wcet_measure.cpp
@@ -25,6 +25,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <vector>
 
 #include <ctime>
@@ -182,23 +184,45 @@ int main() {
                           / (static_cast<__uint128_t>(n) * n);
     const std::uint64_t stddev = isqrt_u128(var);
 
-    // Certified iff on the QNX target AND FIFO actually granted (conjunction —
-    // mirrors MeasurementEnv::is_certified_wcet). Everything else is INDICATIVE.
-    const bool certified = kIsQnxTarget && fifo_granted;
+    // Certified WCET requires THREE things, ALL of which must hold:
+    //   (1) compiled for the QNX target (kIsQnxTarget),
+    //   (2) SCHED_FIFO actually granted at runtime (fifo_granted),
+    //   (3) an EXPLICIT operator assertion that this is the certified Phase-II
+    //       hardware platform: KIRRA_WCET_CERTIFIED=1 (or =true).
+    // (3) is mandatory because the binary CANNOT distinguish certified DRIVE +
+    // QNX OS for Safety hardware from a QNX VM under KVM/TCG — both are __QNXNTO__
+    // with FIFO. Defaulting to INDICATIVE makes an accidental overclaim from a VM
+    // IMPOSSIBLE (fail-honest, AOU-HW-QNX-TARGET-001): a VM operator simply does
+    // not set the flag, so a near-native KVM number stays INDICATIVE. The free-form
+    // KIRRA_WCET_PLATFORM (e.g. "kvm", "tcg", "drive-agx") is echoed into the human
+    // banner for provenance only — it never changes the verdict.
+    const char *cert_env = std::getenv("KIRRA_WCET_CERTIFIED");
+    const bool cert_asserted = cert_env != nullptr
+        && (std::strcmp(cert_env, "1") == 0 || std::strcmp(cert_env, "true") == 0);
+    const char *platform = std::getenv("KIRRA_WCET_PLATFORM");
+    const bool certified = kIsQnxTarget && fifo_granted && cert_asserted;
 
-    std::printf("WCET kirra_judge_assess  n=%zu  min=%lluns  med=%lluns  p99.9=%lluns  MAX=%lluns%s\n",
-                MEASURE_ITERS,
-                (unsigned long long)mn, (unsigned long long)p50,
-                (unsigned long long)p999, (unsigned long long)mx,
-                certified ? "" : "  [INDICATIVE — not a WCET claim]");
+    if (certified) {
+        std::printf("WCET kirra_judge_assess  n=%zu  min=%lluns  med=%lluns  p99.9=%lluns  "
+                    "MAX=%lluns  [CERTIFIED — QNX target, FIFO, operator-asserted Phase-II HW]\n",
+                    MEASURE_ITERS, (unsigned long long)mn, (unsigned long long)p50,
+                    (unsigned long long)p999, (unsigned long long)mx);
+    } else {
+        std::printf("WCET kirra_judge_assess  n=%zu  min=%lluns  med=%lluns  p99.9=%lluns  "
+                    "MAX=%lluns  [INDICATIVE — not a WCET claim%s%s]\n",
+                    MEASURE_ITERS, (unsigned long long)mn, (unsigned long long)p50,
+                    (unsigned long long)p999, (unsigned long long)mx,
+                    platform ? "; platform=" : "", platform ? platform : "");
+    }
 
     // CSV row in the CANONICAL schema — byte-identical to
     // kirra_timing::report::CSV_HEADER and kirra_timing::MeasurementEnv tokens, so
     // a host kirra-wcet-bench report and this on-target row union into one table
-    // joinable on (metric, env). `env`/`sched`/`wcet_status` map exactly onto the
-    // MeasurementEnv variants: QNX+FIFO → qnx-target-fifo / QNX-TARGET-MEASURED;
-    // QNX without FIFO → other; a host smoke build → host. Only the certified
-    // conjunction emits QNX-TARGET-MEASURED, never a fabricated figure.
+    // joinable on (metric, env). `env`/`sched`/`wcet_status` map onto the
+    // MeasurementEnv variants: certified → qnx-target-fifo / QNX-TARGET-MEASURED;
+    // any QNX run that is NOT operator-asserted-certified (incl. a KVM/TCG VM, or
+    // no FIFO) → other / INDICATIVE-NOT-WCET; a host smoke build → host. Provenance
+    // (KVM vs hardware) lives in the human banner above, not the canonical token.
     const char *env    = certified ? "qnx-target-fifo" : (kIsQnxTarget ? "other" : "host");
     const char *sched  = certified ? "SCHED_FIFO" : "host-default";
     const char *status = certified ? "QNX-TARGET-MEASURED" : "INDICATIVE-NOT-WCET";

--- a/tools/qnx-rtm-harness/wcet_measure.cpp
+++ b/tools/qnx-rtm-harness/wcet_measure.cpp
@@ -64,6 +64,35 @@ KirraContractView make_admissible_view(const std::uint8_t *payload, std::uint32_
     return v;
 }
 
+// Floor integer sqrt of a 128-bit value via Newton's method — the same fast
+// O(log) algorithm as kirra_timing's `isqrt_u128` (NOT an O(sqrt(var)) linear
+// scan, which can run billions of iterations on the large variance that
+// emulation jitter produces).
+std::uint64_t isqrt_u128(__uint128_t n) {
+    if (n == 0) return 0;
+    __uint128_t x = n, y = (x + 1) >> 1;
+    while (y < x) {
+        x = y;
+        y = (x + n / x) >> 1;
+    }
+    return static_cast<std::uint64_t>(x);
+}
+
+// Nearest-rank percentile matching kirra_timing's "ceil threshold" semantics:
+// the smallest sample value v such that at least `num/den` of the samples are
+// <= v. Rank = ceil(n · num / den) (1-based), clamped to [1, n]; index = rank-1.
+// This avoids the off-by-one of `sorted[(n·p)/den]` (which, e.g. for n=100,
+// reads the max for p99) and is comparable to the host kirra-timing output.
+std::uint64_t percentile(const std::vector<std::uint64_t> &sorted,
+                         std::uint64_t num, std::uint64_t den) {
+    const std::size_t n = sorted.size();
+    if (n == 0) return 0;
+    __uint128_t rank = (static_cast<__uint128_t>(n) * num + (den - 1)) / den; // ceil
+    if (rank < 1) rank = 1;
+    if (rank > n) rank = n;
+    return sorted[static_cast<std::size_t>(rank) - 1];
+}
+
 // Monotonic nanoseconds. clock_gettime self-overhead (~tens of ns) is inside each
 // sample and is roughly constant, so the reported MAX is a CONSERVATIVE (slightly
 // over) WCET — safe for a bound. On QNX prefer ClockCycles() + SYSPAGE
@@ -134,13 +163,14 @@ int main() {
 
     std::sort(samples.begin(), samples.end());
     const std::uint64_t mn   = samples.front();
-    const std::uint64_t p50  = samples[samples.size() / 2];
-    const std::uint64_t p99  = samples[(samples.size() * 99) / 100];
-    const std::uint64_t p999 = samples[(samples.size() * 999) / 1000];
+    const std::uint64_t p50  = percentile(samples, 50, 100);
+    const std::uint64_t p99  = percentile(samples, 99, 100);
+    const std::uint64_t p999 = percentile(samples, 999, 1000);
     const std::uint64_t mx   = samples.back();
 
     // Mean + population stddev (integer, matching kirra_timing::ChannelStats: the
-    // exact (n·Σx²−(Σx)²)/n² variance form, floor-rooted). Σx² fits in u128.
+    // exact (n·Σx²−(Σx)²)/n² variance form, floor-rooted via Newton's isqrt). Σx²
+    // fits in u128.
     __uint128_t sum = 0, sum_sq = 0;
     for (const std::uint64_t s : samples) {
         sum += s;
@@ -150,8 +180,7 @@ int main() {
     const std::uint64_t mean = static_cast<std::uint64_t>(sum / n);
     const __uint128_t var = (static_cast<__uint128_t>(n) * sum_sq - sum * sum)
                           / (static_cast<__uint128_t>(n) * n);
-    std::uint64_t stddev = 0;
-    while ((static_cast<__uint128_t>(stddev) + 1) * (stddev + 1) <= var) ++stddev;
+    const std::uint64_t stddev = isqrt_u128(var);
 
     // Certified iff on the QNX target AND FIFO actually granted (conjunction —
     // mirrors MeasurementEnv::is_certified_wcet). Everything else is INDICATIVE.

--- a/tools/qnx-rtm-harness/wcet_measure.cpp
+++ b/tools/qnx-rtm-harness/wcet_measure.cpp
@@ -224,7 +224,11 @@ int main() {
     // no FIFO) → other / INDICATIVE-NOT-WCET; a host smoke build → host. Provenance
     // (KVM vs hardware) lives in the human banner above, not the canonical token.
     const char *env    = certified ? "qnx-target-fifo" : (kIsQnxTarget ? "other" : "host");
-    const char *sched  = certified ? "SCHED_FIFO" : "host-default";
+    // `sched` reflects the ACTUAL scheduler obtained at runtime (an objective
+    // fact), independent of the cert assertion — a non-certified QNX VM run under
+    // root still genuinely ran under SCHED_FIFO; only `env`/`wcet_status` carry the
+    // certified-vs-indicative verdict.
+    const char *sched  = fifo_granted ? "SCHED_FIFO" : "host-default";
     const char *status = certified ? "QNX-TARGET-MEASURED" : "INDICATIVE-NOT-WCET";
     std::printf("metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status\n");
     std::printf("kirra_judge_assess,%s,%s,%llu,%llu,%llu,%llu,%llu,%llu,%llu,%llu,%s\n",

--- a/tools/qnx-rtm-harness/wcet_measure.cpp
+++ b/tools/qnx-rtm-harness/wcet_measure.cpp
@@ -36,6 +36,18 @@ namespace {
 constexpr std::size_t WARMUP_ITERS  = 10'000;
 constexpr std::size_t MEASURE_ITERS = 1'000'000;
 
+// Compile-time target gate. A certified WCET number requires BOTH the QNX target
+// AND SCHED_FIFO at runtime; FIFO-granted alone is NOT enough (a Linux host /
+// container often grants SCHED_FIFO, yet a host number is INDICATIVE by the
+// methodology). So even a host smoke build refuses to mint a certified row — the
+// `kIsQnxTarget && fifo_granted` conjunction below mirrors
+// `kirra_timing::MeasurementEnv::is_certified_wcet`.
+#if defined(__QNXNTO__) || defined(__QNX__)
+constexpr bool kIsQnxTarget = true;
+#else
+constexpr bool kIsQnxTarget = false;
+#endif
+
 // Build the OK/admissible view — the WCET path (no early short-circuit).
 KirraContractView make_admissible_view(const std::uint8_t *payload, std::uint32_t len) {
     KirraContractView v{};
@@ -63,15 +75,19 @@ std::uint64_t now_ns() {
          + static_cast<std::uint64_t>(ts.tv_nsec);
 }
 
-// Raise to SCHED_FIFO max priority and pin to one isolated core.
+// Raise to SCHED_FIFO max priority and pin to one isolated core. Returns true iff
+// SCHED_FIFO was actually granted — the caller gates the emitted `wcet_status` on
+// this, so a run without privilege is reported INDICATIVE, never certified.
 //   * POSIX form (works on a Linux eval VM; isolate the core with isolcpus=<cpu>).
 //   * On QNX, ALSO set the runmask via
 //       ThreadCtl(_NTO_TCTL_RUNMASK_GET_AND_SET_INHERIT, &mask)
 //     and SchedSet() the FIFO priority. SCHED_FIFO requires privilege.
-void enter_rt(int cpu) {
+bool enter_rt(int cpu) {
     struct sched_param sp{};
     sp.sched_priority = sched_get_priority_max(SCHED_FIFO);
-    if (pthread_setschedparam(pthread_self(), SCHED_FIFO, &sp) != 0) {
+    const bool fifo_granted =
+        pthread_setschedparam(pthread_self(), SCHED_FIFO, &sp) == 0;
+    if (!fifo_granted) {
         std::fprintf(stderr,
             "WARN: SCHED_FIFO not granted (need privilege) — timing is INDICATIVE only\n");
     }
@@ -83,12 +99,13 @@ void enter_rt(int cpu) {
 #else
     (void)cpu;  // QNX: pin via ThreadCtl(_NTO_TCTL_RUNMASK_GET_AND_SET_INHERIT, ...)
 #endif
+    return fifo_granted;
 }
 
 } // namespace
 
 int main() {
-    enter_rt(/*cpu=*/1);
+    const bool fifo_granted = enter_rt(/*cpu=*/1);
 
     static const std::uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
     KirraContractView v = make_admissible_view(payload, sizeof(payload));
@@ -117,20 +134,56 @@ int main() {
 
     std::sort(samples.begin(), samples.end());
     const std::uint64_t mn   = samples.front();
-    const std::uint64_t med  = samples[samples.size() / 2];
+    const std::uint64_t p50  = samples[samples.size() / 2];
+    const std::uint64_t p99  = samples[(samples.size() * 99) / 100];
     const std::uint64_t p999 = samples[(samples.size() * 999) / 1000];
     const std::uint64_t mx   = samples.back();
 
-    std::printf("WCET kirra_judge_assess  n=%zu  min=%lluns  med=%lluns  p99.9=%lluns  MAX=%lluns\n",
-                MEASURE_ITERS,
-                (unsigned long long)mn, (unsigned long long)med,
-                (unsigned long long)p999, (unsigned long long)mx);
+    // Mean + population stddev (integer, matching kirra_timing::ChannelStats: the
+    // exact (n·Σx²−(Σx)²)/n² variance form, floor-rooted). Σx² fits in u128.
+    __uint128_t sum = 0, sum_sq = 0;
+    for (const std::uint64_t s : samples) {
+        sum += s;
+        sum_sq += static_cast<__uint128_t>(s) * s;
+    }
+    const std::uint64_t n    = MEASURE_ITERS;
+    const std::uint64_t mean = static_cast<std::uint64_t>(sum / n);
+    const __uint128_t var = (static_cast<__uint128_t>(n) * sum_sq - sum * sum)
+                          / (static_cast<__uint128_t>(n) * n);
+    std::uint64_t stddev = 0;
+    while ((static_cast<__uint128_t>(stddev) + 1) * (stddev + 1) <= var) ++stddev;
 
-    // CSV row — replaces the harness placeholder `wcet_status = TBD-QNX-TARGET`.
-    // Substitute <TARGET_TRIPLE_TBD> with the confirmed nto-qnx800 tuple.
-    std::printf("metric,target,sched,n,warmup,max_ns,p999_ns,wcet_status\n");
-    std::printf("kirra_judge_assess,<TARGET_TRIPLE_TBD>,SCHED_FIFO,%zu,%zu,%llu,%llu,QNX-TARGET-MEASURED\n",
-                MEASURE_ITERS, WARMUP_ITERS,
-                (unsigned long long)mx, (unsigned long long)p999);
+    // Certified iff on the QNX target AND FIFO actually granted (conjunction —
+    // mirrors MeasurementEnv::is_certified_wcet). Everything else is INDICATIVE.
+    const bool certified = kIsQnxTarget && fifo_granted;
+
+    std::printf("WCET kirra_judge_assess  n=%zu  min=%lluns  med=%lluns  p99.9=%lluns  MAX=%lluns%s\n",
+                MEASURE_ITERS,
+                (unsigned long long)mn, (unsigned long long)p50,
+                (unsigned long long)p999, (unsigned long long)mx,
+                certified ? "" : "  [INDICATIVE — not a WCET claim]");
+
+    // CSV row in the CANONICAL schema — byte-identical to
+    // kirra_timing::report::CSV_HEADER and kirra_timing::MeasurementEnv tokens, so
+    // a host kirra-wcet-bench report and this on-target row union into one table
+    // joinable on (metric, env). `env`/`sched`/`wcet_status` map exactly onto the
+    // MeasurementEnv variants: QNX+FIFO → qnx-target-fifo / QNX-TARGET-MEASURED;
+    // QNX without FIFO → other; a host smoke build → host. Only the certified
+    // conjunction emits QNX-TARGET-MEASURED, never a fabricated figure.
+    const char *env    = certified ? "qnx-target-fifo" : (kIsQnxTarget ? "other" : "host");
+    const char *sched  = certified ? "SCHED_FIFO" : "host-default";
+    const char *status = certified ? "QNX-TARGET-MEASURED" : "INDICATIVE-NOT-WCET";
+    std::printf("metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status\n");
+    std::printf("kirra_judge_assess,%s,%s,%llu,%llu,%llu,%llu,%llu,%llu,%llu,%llu,%s\n",
+                env, sched,
+                (unsigned long long)n,
+                (unsigned long long)mn,
+                (unsigned long long)mean,
+                (unsigned long long)mx,
+                (unsigned long long)stddev,
+                (unsigned long long)p50,
+                (unsigned long long)p99,
+                (unsigned long long)p999,
+                status);
     return 0;
 }


### PR DESCRIPTION
## Why

Next L1 increment for the QNX WCET campaign (#274). The QNX harness's `wcet_measure` already times the judge, but it emitted a **divergent CSV schema** (8 columns vs `kirra-timing`'s canonical 12) — so on-target judge numbers couldn't join with the host `kirra-wcet-bench` output, defeating the point of the shared `stage` labels. It also had a **status-gating hole**: it hardcoded `QNX-TARGET-MEASURED` even when `SCHED_FIFO` was denied. This wires the harness onto `kirra-timing`'s canonical contract, makes the certified/indicative gating structurally honest, and adds the operator runbook for running it on a QNX target.

## Changes

**`kirra-timing`**
- Add `report::CSV_HEADER` (re-exported as `kirra_timing::CSV_HEADER`) — the single source of truth for the machine schema. `Report::write_csv` now emits it, and a test locks the emitted header to the const so the two can't drift.

**`tools/qnx-rtm-harness/wcet_measure.cpp`**
- Emit the **canonical 12-column schema byte-identically** (`metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status`) instead of the old divergent row, so it unions with the host bench output joinable on `(metric, env)`. Adds mean + population stddev (the exact `(n·Σx²−(Σx)²)/n²` form, matching `ChannelStats`) and p50/p99.
- **Honest status gating:** the certified `qnx-target-fifo` / `QNX-TARGET-MEASURED` pair is emitted **only** under the `kIsQnxTarget && fifo_granted` conjunction (mirrors `MeasurementEnv::is_certified_wcet`). Previously it stamped `QNX-TARGET-MEASURED` even on the `SCHED_FIFO`-denied WARN path — and a host smoke build (containers often grant `SCHED_FIFO`) would falsely claim a certified figure. Now a host build self-declares `host` / `INDICATIVE-NOT-WCET`; a QNX run without FIFO declares `other` / `INDICATIVE-NOT-WCET`.
- `enter_rt()` returns whether FIFO was actually granted.

**Docs**
- `QNX_MAPPING.md` §7: record the canonical schema + the gating semantics + the Phase-I-VM-vs-Phase-II-hardware caveat (`AOU-HW-QNX-TARGET-001`).
- **`docs/adr/KIRRA_QNX_RUNBOOK.md` (new):** step-by-step operator runbook — cross-build on a QNX SDP 8.0 dev host → deploy to the QNX target (x86-64 VM for Phase-I) → run the FDIT gate + capture the canonical WCET row. Includes the env/status gating table, the acceptance check (`MAX < 100 µs`), and a troubleshooting matrix. Cross-references the existing QNX docs rather than duplicating them.

The judge (`kirra_judge.rs`) verdict logic is **unchanged**.

## Verification (host)

```
$ ./wcet_measure          # built g++ -Wall -Wextra -Werror, linked vs the real judge staticlib
WCET kirra_judge_assess  n=1000000  min=27ns  med=30ns  p99.9=107ns  MAX=144208ns  [INDICATIVE — not a WCET claim]
metric,env,sched,n,min_ns,mean_ns,max_ns,stddev_ns,p50_ns,p99_ns,p999_ns,wcet_status
kirra_judge_assess,host,host-default,1000000,27,33,144208,261,30,42,107,INDICATIVE-NOT-WCET
```

- The first host run (with FIFO granted in-container) initially mis-stamped `QNX-TARGET-MEASURED` — exactly the hole the compile-time QNX gate now closes; it now self-declares `host` / `INDICATIVE-NOT-WCET`.
- `kirra-timing`: 11/11 tests (incl. the header-lock test).
- Harness host `ctest`: still 2/2 (`rtm_harness`, `kirra_demo`) — judge untouched, no regression.
- Emitted CSV header is **byte-identical** to `kirra_timing::CSV_HEADER`.
- Runbook cross-reference anchors verified to resolve.

The certified path (`qnx-target-fifo` / `QNX-TARGET-MEASURED`) is exercised on the QNX target under FIFO per `WCET_QNX_BRINGUP.md` / the new runbook — runnable on the x86 QNX 8.0 VM once it's up.

## Safety-rule compliance

No determinism reduction, no hidden globals, no new `unsafe`, no alloc on the measured path, no weakened boundaries. The judge verdict logic is unchanged; this only touches the measurement *reporting*, tightens the host-vs-WCET gate, and adds docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6