### PR TITLE
docs(adr): ADR-0006 (#275) — production carrier + latency evidence

### DIFF
--- a/docs/adr/0006-governor-transport-iceoryx2.md
+++ b/docs/adr/0006-governor-transport-iceoryx2.md
@@ -6,7 +6,7 @@
 | Date | 2026-06-11 (updated 2026-06-30 — see §*Update 2026-06-30*) |
 | Deciders | Project owner |
 | Issues | #275 (this ADR); EPIC #270; evidence #273 / PR #277; **production carrier + latency PR #736**; validating condition #274; support posture #276; boundary design #278 |
-| Doc | `tools/iceoryx2-spike/README.md` (the #273 host spike + the #736 frozen-contract carrier & latency bench); `docs/adr/KIRRA_QNX_CROSSCOMPILE.md` (toolchain notes) |
+| Doc | `tools/iceoryx2-spike/README.md` (the #273 host spike; **PR #736 adds** the frozen-contract carrier & latency bench); `docs/adr/KIRRA_QNX_CROSSCOMPILE.md` (toolchain notes) |
 | Builds on | ADR-0004 (independent safety channel / doer–checker) |
 
 ## Context
@@ -93,8 +93,9 @@ toolchain-gated), so the Status stays *Accepted (direction)*.
 
 ### 1. The carrier now rides the PRODUCTION frozen contract (PR #736)
 
-The #273 spike carried an ad-hoc `CommandFrame`. `tools/iceoryx2-spike/src/frozen.rs`
-now publishes the **production** `kirra_contract_channel::GovernorContractView` (the
+The #273 spike carried an ad-hoc `CommandFrame`. **In PR #736**, the new
+`tools/iceoryx2-spike/src/frozen.rs` publishes the **production**
+`kirra_contract_channel::GovernorContractView` (the
 frozen 176-byte `#[repr(C)]`, by-value image — Clause 2's layout) over a real
 iceoryx2 zero-copy channel and validates every received owned sample with the
 **production** `kirra_contract_channel::validate()`. All nine transport-contract
@@ -115,8 +116,9 @@ layout is library-independent).
 The driving requirement is the **lowest-latency way to cross the mandatory
 doer↔checker isolation boundary** (freedom-from-interference forbids co-locating
 them — so the boundary cannot be deleted to save latency).
-`tools/iceoryx2-spike/src/bin/latency_bench.rs` times the 176-byte contract handoff
-three ways (host-**INDICATIVE** — shared dev box, no core isolation / FIFO; 100k iters):
+**In PR #736**, `tools/iceoryx2-spike/src/bin/latency_bench.rs` times the 176-byte
+contract handoff three ways (host-**INDICATIVE** — shared dev box, no core isolation /
+FIFO; 100k iters):
 
 ```
 transport                  p50_ns     p99_ns    p999_ns     max_ns
@@ -144,7 +146,7 @@ stay network transport. This bounds Clause 1's reach:
 
 | Class | Boundaries | Verdict |
 |---|---|---|
-| iceoryx2 (cross-partition, same SoC) | governor contract channel (Clause 2 layout) | the carrier (this ADR) |
+| iceoryx2 (intra-partition, cross-process) | governor-side contract handoff reusing the Clause 2 frozen layout (`GovernorContractView`) as payload | the carrier (this ADR) |
 | iceoryx2 candidate (intra-host) | local actuator / sensor DDS hops | bypass DDS → the latency win |
 | already in-process (no gain) | parko inference loop, posture engine, capture/audit mpsc, impact latch, Taj corridor, RSS gates | leave as-is |
 | cross-host (NOT iceoryx2) | fleet transport (Zenoh, ADR-0007), two-box UDP governor | network — stays Zenoh/DDS |
@@ -152,12 +154,12 @@ stay network transport. This bounds Clause 1's reach:
 
 ### 4. Dependency / condition progress
 
-- **Pin moved `=0.9.1` → `=0.9.2`.** The `0.9.1` umbrella no longer composes with its
-  `0.9.2` sub-crates on a fresh resolve (`ZeroCopySendError::NoConnectedReceiver`
+- **PR #736 moves the pin `=0.9.1` → `=0.9.2`.** The `0.9.1` umbrella no longer composes
+  with its `0.9.2` sub-crates on a fresh resolve (`ZeroCopySendError::NoConnectedReceiver`
   missing); the spike code compiles unchanged at `0.9.2`. (`Cargo.lock` is gitignored
-  in the isolated spike, so the pin is the control.) A **dedicated CI lane** now gates
-  the spike + carrier (full + minimal configs + clippy) — previously nothing ran it,
-  which is exactly how the `0.9.1` breakage went unnoticed.
+  in the isolated spike, so the pin is the control.) PR #736 also adds a **dedicated CI
+  lane** to gate the spike + carrier (full + minimal configs + clippy) — previously
+  nothing ran it, which is exactly how the `0.9.1` breakage went unnoticed.
 - **#274 advanced (judge, not iceoryx2 yet).** The QNX 8.0 cross-build + FDIT
   **verdict-correctness gate now PASSES on a `mkqnximage`/QEMU QNX 8.0 KVM VM**
   (`max ≈ 20 µs < 100 µs`, KVM-indicative; `tools/qnx-rtm-harness/results/`). This

--- a/docs/adr/0006-governor-transport-iceoryx2.md
+++ b/docs/adr/0006-governor-transport-iceoryx2.md
@@ -2,11 +2,11 @@
 
 | Field | Value |
 |---|---|
-| Status | **Accepted (direction)** — see *Conditions that reopen this decision* |
-| Date | 2026-06-11 |
+| Status | **Accepted (direction)** — see *Conditions that reopen this decision* (evidence strengthened 2026-06-30; reopening conditions remain open) |
+| Date | 2026-06-11 (updated 2026-06-30 — see §*Update 2026-06-30*) |
 | Deciders | Project owner |
-| Issues | #275 (this ADR); EPIC #270; evidence #273 / PR #277; validating condition #274; support posture #276; boundary design #278 |
-| Doc | `tools/iceoryx2-spike/README.md` (the #273 host spike); `docs/adr/KIRRA_QNX_CROSSCOMPILE.md` (toolchain notes) |
+| Issues | #275 (this ADR); EPIC #270; evidence #273 / PR #277; **production carrier + latency PR #736**; validating condition #274; support posture #276; boundary design #278 |
+| Doc | `tools/iceoryx2-spike/README.md` (the #273 host spike + the #736 frozen-contract carrier & latency bench); `docs/adr/KIRRA_QNX_CROSSCOMPILE.md` (toolchain notes) |
 | Builds on | ADR-0004 (independent safety channel / doer–checker) |
 
 ## Context
@@ -85,11 +85,92 @@ path**.
   **generation rule** for the #278 cross-partition channel, and aligns with the
   durable **epoch fence (#79)** used elsewhere in the system.
 
+## Update 2026-06-30 — production frozen-contract carrier, latency evidence, QNX-KVM progress
+
+Three developments since the original decision **strengthen the evidence base**.
+They do **not** discharge the reopening conditions below (which remain target- and
+toolchain-gated), so the Status stays *Accepted (direction)*.
+
+### 1. The carrier now rides the PRODUCTION frozen contract (PR #736)
+
+The #273 spike carried an ad-hoc `CommandFrame`. `tools/iceoryx2-spike/src/frozen.rs`
+now publishes the **production** `kirra_contract_channel::GovernorContractView` (the
+frozen 176-byte `#[repr(C)]`, by-value image — Clause 2's layout) over a real
+iceoryx2 zero-copy channel and validates every received owned sample with the
+**production** `kirra_contract_channel::validate()`. All nine transport-contract
+fault classes (layout-version, magic, bounds, CRC, sequence-regress, replay,
+generation-regress, deadline, valid) are green over the live channel, on the full
+**and** minimal (`--no-default-features`) iceoryx2 configs. This demonstrates Clause 1
+with the real contract, not a spike-local copy.
+
+**Isolation held (the #275 gate, reaffirmed):** the dependency direction is
+spike → `kirra-contract-channel` (a path dep on the lean, `no_std`, zero-dep,
+`#![forbid(unsafe_code)]` core), never the reverse — iceoryx2 still **never** enters
+the SDK/parko dependency tree. "Accepted (direction)" is the *architecture*; it is
+**not** an SDK adoption of iceoryx2 (the core stays transport-agnostic, and Clause 2's
+layout is library-independent).
+
+### 2. Latency evidence — the quantitative rationale
+
+The driving requirement is the **lowest-latency way to cross the mandatory
+doer↔checker isolation boundary** (freedom-from-interference forbids co-locating
+them — so the boundary cannot be deleted to save latency).
+`tools/iceoryx2-spike/src/bin/latency_bench.rs` times the 176-byte contract handoff
+three ways (host-**INDICATIVE** — shared dev box, no core isolation / FIFO; 100k iters):
+
+```
+transport                  p50_ns     p99_ns    p999_ns     max_ns
+in-process (floor)             28         37         60      69069
+socket+serde (UDP loopback)   976       1901      13934      83820
+iceoryx2 (zero-copy)          309        424        995      46083
+```
+
+iceoryx2 keeps the crossing **sub-microsecond** (~3× the median of a bare
+UDP+serialize hop) and — the part that matters for a jitter-bounded safety path —
+the **tail is ~14× tighter (p99.9 of 995 ns vs 13.9 µs)**. `socket+serde` is a
+*conservative* proxy; a real DDS hop adds RTPS/discovery/typed-CDR overhead (tens of
+µs–ms → 100–1000×; external refs in the spike README). The 28 ns in-process floor is
+what the mandatory isolation costs; iceoryx2 holds the crossing near it. The deployment
+**lowest-latency mode** pairs iceoryx2 with **busy-wait polling on an isolated core
+under `SCHED_FIFO`** → toward iceoryx2's published ~100 ns; the certified figure is a
+QNX-target-under-FIFO measurement (#274).
+
+### 3. Where iceoryx2 applies (utilization scope)
+
+A whole-system boundary map (every IPC / serialization / FFI hop) shows the
+opportunity is **targeted, not universal** — most internal hops are already
+in-process (Tokio / atomics) where iceoryx2 would *add* overhead, and cross-host hops
+stay network transport. This bounds Clause 1's reach:
+
+| Class | Boundaries | Verdict |
+|---|---|---|
+| iceoryx2 (cross-partition, same SoC) | governor contract channel (Clause 2 layout) | the carrier (this ADR) |
+| iceoryx2 candidate (intra-host) | local actuator / sensor DDS hops | bypass DDS → the latency win |
+| already in-process (no gain) | parko inference loop, posture engine, capture/audit mpsc, impact latch, Taj corridor, RSS gates | leave as-is |
+| cross-host (NOT iceoryx2) | fleet transport (Zenoh, ADR-0007), two-box UDP governor | network — stays Zenoh/DDS |
+| integration boundary (not hot path) | C FFI (`src/ffi.rs`), supervisor reset | Clause 3 (FFI demoted) |
+
+### 4. Dependency / condition progress
+
+- **Pin moved `=0.9.1` → `=0.9.2`.** The `0.9.1` umbrella no longer composes with its
+  `0.9.2` sub-crates on a fresh resolve (`ZeroCopySendError::NoConnectedReceiver`
+  missing); the spike code compiles unchanged at `0.9.2`. (`Cargo.lock` is gitignored
+  in the isolated spike, so the pin is the control.) A **dedicated CI lane** now gates
+  the spike + carrier (full + minimal configs + clippy) — previously nothing ran it,
+  which is exactly how the `0.9.1` breakage went unnoticed.
+- **#274 advanced (judge, not iceoryx2 yet).** The QNX 8.0 cross-build + FDIT
+  **verdict-correctness gate now PASSES on a `mkqnximage`/QEMU QNX 8.0 KVM VM**
+  (`max ≈ 20 µs < 100 µs`, KVM-indicative; `tools/qnx-rtm-harness/results/`). This
+  validates the *judge* on a real QNX target. It does **not** yet measure **iceoryx2**
+  on QNX, nor discharge the **edition-2024 / Ferrocene** toolchain gate — both remain
+  open conditions. Running `latency_bench` on the QNX KVM VM under `SCHED_FIFO` is the
+  next step.
+
 ## Constraints and risks (honest section — none softened)
 
-- **Edition-2024 toolchain gate.** iceoryx2 0.9.1 and its entire
+- **Edition-2024 toolchain gate.** iceoryx2 0.9.1/0.9.2 and its entire
   `iceoryx2-*` / `iceoryx2-bb-*` / `iceoryx2-pal-*` dependency family declare
-  `edition = "2024"` (verified across the 0.9.1 lock tree). Edition 2024
+  `edition = "2024"` (verified across the lock tree; unchanged by the 0.9.2 bump). Edition 2024
   stabilized in **Rust 1.85**, so an older toolchain (e.g. cargo 1.75) refuses
   the tree outright. The **QNX cross-toolchain AND the qualified Ferrocene
   `rustc` must support edition 2024**, or the iceoryx2 pin must move to an older
@@ -126,10 +207,16 @@ this decision.
 ## Cross-references
 
 - **EPIC #270** — iceoryx2 transport adoption for the QNX governor lane.
-- **#273 / PR #277** — the host-side spike supplying the evidence above
+- **#273 / PR #277** — the host-side spike supplying the original evidence
   (`tools/iceoryx2-spike/README.md`).
+- **PR #736** — the production frozen-contract carrier (`frozen.rs`) + the latency
+  benchmark (`src/bin/latency_bench.rs`) + the dedicated CI lane; the
+  §*Update 2026-06-30* evidence.
 - **#274** — QNX 8.0 cross-compile + feature-subset + toolchain validation (the
-  reopening condition).
+  reopening condition; the judge's FDIT gate now passes on a QNX KVM VM —
+  `tools/qnx-rtm-harness/results/`).
+- **`crates/kirra-contract-channel/`** — the frozen `GovernorContractView` +
+  `validate()` the carrier now rides (Clause 2's layout, library-independent).
 - **#276** — ekxide tier-1 / commercial support posture.
 - **#278** — the hypervisor-shared-memory frozen-layout contract channel (Clause
   2's design).


### PR DESCRIPTION
## Why

You asked me to "write ADR #275." Honesty check: **ADR #275 already exists** — it's `docs/adr/0006-governor-transport-iceoryx2.md` (its Issues field says "#275 (this ADR)"), already **Accepted (direction)**. Writing a second ADR for the same decision would be wrong, so this **updates 0006** with everything this session produced, advancing its evidence base. The reopening conditions remain open, so the Status is unchanged.

## What's added (a dated `Update 2026-06-30` section)

1. **Production frozen-contract carrier (PR #736)** — iceoryx2 now carries the *production* `GovernorContractView` + `validate()` (not the spike's ad-hoc `CommandFrame`); all 9 transport-contract fault classes green over the live channel on full + minimal configs. Isolation held — the dep direction is spike → `kirra-contract-channel` (lean core), so iceoryx2 still never enters the SDK/parko tree.

2. **Latency evidence** — the host-indicative `latency_bench` table (the quantitative rationale 0006 lacked):

   ```
   transport                  p50_ns     p99_ns    p999_ns     max_ns
   in-process (floor)             28         37         60      69069
   socket+serde (UDP loopback)   976       1901      13934      83820
   iceoryx2 (zero-copy)          309        424        995      46083
   ```

   iceoryx2 holds the **mandatory** doer↔checker isolation crossing **sub-microsecond** (~3× a UDP+serialize hop at the median, **~14× tighter at p99.9** — the jitter that bounds FTTI). Lowest-latency mode = iceoryx2 + busy-wait on an isolated core under `SCHED_FIFO` → toward the published ~100 ns.

3. **Utilization scope** — a whole-system boundary-map table: the opportunity is **targeted, not universal** (cross-partition contract + intra-host DDS-bypass hops), since most internal hops are already in-process and cross-host stays Zenoh/DDS.

4. **Condition progress** — pin `0.9.1`→`0.9.2` (upstream skew) + a dedicated CI lane; #274 judge FDIT now passes on a QNX KVM VM. iceoryx2-on-QNX and the edition-2024/Ferrocene gate remain open conditions.

Also: updated the Status/Issues/Doc/cross-reference rows and a minor edition-2024 accuracy tweak (`0.9.1`→`0.9.1/0.9.2`).

## Notes
- Docs-only.
- References PR #736 (the carrier + bench) as the evidence source — that PR is open; this ADR documents its significance.
- All cited paths verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_