### PR TITLE
docs(l2): Orin NX isolated-core iceoryx2 latency evidence (deployment SoC)

### DIFF
--- a/docs/adr/0006-governor-transport-iceoryx2.md
+++ b/docs/adr/0006-governor-transport-iceoryx2.md
@@ -137,8 +137,9 @@ what the mandatory isolation costs; iceoryx2 holds the crossing near it. The dep
 under `SCHED_FIFO`** → toward iceoryx2's published ~100 ns; the certified figure is a
 QNX-target-under-FIFO measurement (#274).
 
-**Isolated-core measurement on the DEPLOYMENT SoC** (PR #736,
-`results/orin-nx-16gb-linux-isolated.txt`). The above is an x86 shared host; the
+**Isolated-core measurement on the DEPLOYMENT SoC**
+([`tools/iceoryx2-spike/results/orin-nx-16gb-linux-isolated.txt`](../../tools/iceoryx2-spike/results/orin-nx-16gb-linux-isolated.txt)).
+The above is an x86 shared host; the
 lowest-latency mode was then measured on the **real robot silicon** — a Jetson
 Orin NX 16GB (aarch64, Tegra234) — with cores 6/7 `isolcpus`-isolated, MAXN +
 `jetson_clocks` (no DVFS), the requester/responder pinned to the isolated cores,

--- a/docs/adr/0006-governor-transport-iceoryx2.md
+++ b/docs/adr/0006-governor-transport-iceoryx2.md
@@ -137,6 +137,30 @@ what the mandatory isolation costs; iceoryx2 holds the crossing near it. The dep
 under `SCHED_FIFO`** → toward iceoryx2's published ~100 ns; the certified figure is a
 QNX-target-under-FIFO measurement (#274).
 
+**Isolated-core measurement on the DEPLOYMENT SoC** (PR #736,
+`results/orin-nx-16gb-linux-isolated.txt`). The above is an x86 shared host; the
+lowest-latency mode was then measured on the **real robot silicon** — a Jetson
+Orin NX 16GB (aarch64, Tegra234) — with cores 6/7 `isolcpus`-isolated, MAXN +
+`jetson_clocks` (no DVFS), the requester/responder pinned to the isolated cores,
+and `SCHED_FIFO` granted (1M iters, reproduced twice):
+
+```
+mode                       p50_ns     p99_ns    p999_ns     max_ns
+iox2 ping-pong (RTT)         1408       1568       2304   ~47–51 ms
+```
+
+The true cross-core doer↔checker hop is a reproducible **~704 ns one-way** (RTT/2)
+with a **p99.9 of 2304 ns RTT (~1.15 µs one-way)** — two runs agreed to the
+nanosecond on p50/p99/p99.9, and isolation collapsed the tail *body* ~6× versus
+the shared host. **The honest caveat is the headline, not a footnote:** the max is
+a *reproducible* ~47–51 ms because the stock L4T kernel has no `CONFIG_NO_HZ_FULL`
+(so `nohz_full` was silently ignored and the timer tick + RCU/IPI housekeeping
+still land on cores 6/7). `isolcpus` tightens the distribution *body* but cannot
+*bound* the tail on non-RT Linux — which is precisely why the certified, FTTI-
+backing WCET must be a **QNX-under-FIFO** number (#274), never a Linux figure
+however clean the body. (The sub-3 µs p99.9 body still sits far under the governor
+verdict WCET target of 100 µs, so the transport is not the bottleneck.)
+
 ### 3. Where iceoryx2 applies (utilization scope)
 
 A whole-system boundary map (every IPC / serialization / FFI hop) shows the

--- a/tools/iceoryx2-spike/README.md
+++ b/tools/iceoryx2-spike/README.md
@@ -106,6 +106,28 @@ system scheduler on a shared core). The published ~100 ns floor needs an
 **isolated core on a low-jitter target**, which is precisely the QNX-under-FIFO
 measurement (#274) — the mechanism is in place; the target supplies the number.
 
+**Isolated-core result on the deployment SoC** (Jetson Orin NX 16GB, aarch64 —
+the real robot silicon, not a VM). With `isolcpus=6,7`, MAXN + `jetson_clocks`
+(no DVFS), the requester/responder pinned to the two isolated cores, and
+`SCHED_FIFO` granted (`sudo env KIRRA_LAT_REQ_CPU=6 KIRRA_LAT_RESP_CPU=7
+KIRRA_LAT_FIFO=1 …`, 1M iters — full provenance + verbatim output in
+[`results/orin-nx-16gb-linux-isolated.txt`](results/orin-nx-16gb-linux-isolated.txt)):
+
+```
+mode                       p50_ns     p99_ns    p999_ns     max_ns
+iox2 ping-pong (RTT)         1408       1568       2304   ~47-51 ms
+```
+
+Two honest reads. (1) **Isolation collapses the tail *body*:** p99.9 RTT is
+**2304 ns** (~1.15 µs one-way) — ~6× tighter than the shared-host ~15 µs above,
+and two runs agreed to the **nanosecond** on p50/p99/p99.9. The true cross-core
+doer↔checker hop on the deployment SoC is a reproducible **~704 ns one-way**.
+(2) **`isolcpus` tightens the body but cannot BOUND the tail:** the max is a
+*reproducible* ~47–51 ms — the stock L4T kernel has no `CONFIG_NO_HZ_FULL`
+(`nohz_full` was silently ignored), so the timer tick + RCU/IPI housekeeping
+still land on cores 6/7. That residual is the point, not a defect: it is why the
+certified WCET is a **QNX-under-FIFO** number (#274), never a non-RT-Linux figure.
+
 ## How to run
 
 ```sh

--- a/tools/iceoryx2-spike/README.md
+++ b/tools/iceoryx2-spike/README.md
@@ -109,8 +109,7 @@ measurement (#274) — the mechanism is in place; the target supplies the number
 **Isolated-core result on the deployment SoC** (Jetson Orin NX 16GB, aarch64 —
 the real robot silicon, not a VM). With `isolcpus=6,7`, MAXN + `jetson_clocks`
 (no DVFS), the requester/responder pinned to the two isolated cores, and
-`SCHED_FIFO` granted (`sudo env KIRRA_LAT_REQ_CPU=6 KIRRA_LAT_RESP_CPU=7
-KIRRA_LAT_FIFO=1 …`, 1M iters — full provenance + verbatim output in
+`SCHED_FIFO` granted (e.g. `sudo env KIRRA_LAT_REQ_CPU=6 KIRRA_LAT_RESP_CPU=7 KIRRA_LAT_FIFO=1 …`, 1M iters — full provenance + verbatim output in
 [`results/orin-nx-16gb-linux-isolated.txt`](results/orin-nx-16gb-linux-isolated.txt)):
 
 ```

--- a/tools/iceoryx2-spike/results/orin-nx-16gb-linux-isolated.txt
+++ b/tools/iceoryx2-spike/results/orin-nx-16gb-linux-isolated.txt
@@ -1,0 +1,71 @@
+KIRRA #275 / L2 — iceoryx2 command-handoff latency on the deployment SoC (isolated-core)
+========================================================================================
+Target : NVIDIA Jetson Orin NX 16GB (Tegra234; 8x Cortex-A78AE @ 1.984 GHz),
+         Yahboom ROSMASTER X3 chassis. THIS is deployment-class silicon (aarch64),
+         not an x86 dev box or a VM.
+OS     : L4T / JetPack, STOCK kernel. CONFIG_NO_HZ_FULL is NOT set
+         (/sys/devices/system/cpu/nohz_full = none), so nohz_full=/rcu_nocbs= in
+         the cmdline are silently ignored — only isolcpus is in force.
+Build  : iceoryx2 0.9.2, cargo 1.96.0 (edition-2024 tree builds clean; 45.8 s cold).
+         latency_bench (feat/l2-iceoryx2-frozen-contract), --release.
+Date   : 2026-07-01
+
+Config (jitter-reduction levers applied):
+  - nvpmodel -m 0 (MAXN) + jetson_clocks  -> all 8 cores pinned @ 1984000 kHz (no DVFS)
+  - isolcpus=6,7  (verified: /sys/devices/system/cpu/isolated = 6-7)
+  - requester core=6, responder core=7 (the two isolated cores)
+  - SCHED_FIFO = GRANTED (run under sudo; banner reported SCHED_FIFO=true)
+  - KIRRA_LAT_ITERS=1000000
+
+STATUS : LINUX-TARGET-ISOLATED — INDICATIVE, *not* a WCET claim.
+         isolcpus tightens the DISTRIBUTION BODY to a reproducible sub-us hop, but
+         non-RT Linux cannot BOUND the tail (see the reproducible tens-of-ms max
+         below). The certified, FTTI-backing WCET number is a QNX-under-FIFO
+         measurement on the RTOS (#274) — a Linux figure, however clean in the
+         body, never mints a WCET.
+
+payload = frozen GovernorContractView (176 B, #[repr(C)], by value) — the same
+production contract kirra_contract_channel::validate() checks.
+
+--- run 1 (verbatim) ------------------------------------------------------------
+transport                  p50_ns     p99_ns    p999_ns     max_ns   p50 vs floor
+--------------------------------------------------------------------------------------
+in-process (floor)             64         64         64      47265     (floor)
+socket+serde (proxy)         3040       3200       6112      98785     47.5x
+iceoryx2 (zero-copy)          672        768        960      18945     10.5x
+mode                       p50_ns     p99_ns    p999_ns     max_ns   p50 vs floor
+--------------------------------------------------------------------------------------
+iox2 ping-pong (RTT)         1408       1568       2304   50941608     22.0x
+
+--- run 2 (verbatim) ------------------------------------------------------------
+transport                  p50_ns     p99_ns    p999_ns     max_ns   p50 vs floor
+--------------------------------------------------------------------------------------
+in-process (floor)             32         64         64       7008     (floor)
+socket+serde (proxy)         3040       3201       4384      80866     95.0x
+iceoryx2 (zero-copy)          672        768        992      18369     21.0x
+mode                       p50_ns     p99_ns    p999_ns     max_ns   p50 vs floor
+--------------------------------------------------------------------------------------
+iox2 ping-pong (RTT)         1408       1568       2304   46941425     44.0x
+
+Reading (the takeaways):
+- CROSS-CORE hop (the real doer<->checker shape, ping-pong RTT): p50 1408 ns,
+  p99 1568 ns, p99.9 2304 ns. Halved -> ~704 ns ONE-WAY at the median, ~1.15 us
+  one-way at p99.9. Both runs agree to the NANOSECOND on p50/p99/p99.9 — the
+  isolation makes the body deterministic and reproducible.
+- iceoryx2 vs the socket+serde DDS-proxy: ~4.5x tighter at p50 (672 vs 3040 ns)
+  and ~6.4x tighter at p99.9 (960 vs 6112 ns) on the single-thread rows. A real
+  DDS hop adds RTPS/discovery/typed-CDR on top of the proxy — the gap only widens.
+- The reproducible ~47-51 ms MAX is the stock-kernel non-RT residual (timer tick
+  on 6/7 since nohz_full is absent, plus RCU/IPI housekeeping isolcpus cannot
+  remove). It is the point, not a defect: it is why the WCET claim needs QNX.
+- FTTI budget sanity: the sub-3-us p99.9 body sits far under the governor verdict
+  WCET target (100 us) and the control-cycle budget; the transport is not the
+  bottleneck. WCET closure remains the RTOS measurement (#274).
+
+Reproduce:
+  cd tools/iceoryx2-spike
+  cargo build --release --bin latency_bench
+  sudo env KIRRA_LAT_ITERS=1000000 KIRRA_LAT_REQ_CPU=6 KIRRA_LAT_RESP_CPU=7 \
+       KIRRA_LAT_FIFO=1 ./target/release/latency_bench
+  # prerequisites: nvpmodel -m 0 && jetson_clocks; isolcpus=6,7 on the kernel
+  # cmdline (/boot/extlinux/extlinux.conf) + reboot; verify /sys/.../isolated = 6-7.

--- a/tools/iceoryx2-spike/results/orin-nx-16gb-linux-isolated.txt
+++ b/tools/iceoryx2-spike/results/orin-nx-16gb-linux-isolated.txt
@@ -4,8 +4,10 @@ Target : NVIDIA Jetson Orin NX 16GB (Tegra234; 8x Cortex-A78AE @ 1.984 GHz),
          Yahboom ROSMASTER X3 chassis. THIS is deployment-class silicon (aarch64),
          not an x86 dev box or a VM.
 OS     : L4T / JetPack, STOCK kernel. CONFIG_NO_HZ_FULL is NOT set
-         (/sys/devices/system/cpu/nohz_full = none), so nohz_full=/rcu_nocbs= in
-         the cmdline are silently ignored — only isolcpus is in force.
+         (/sys/devices/system/cpu/nohz_full = none), so the cmdline nohz_full= is
+         silently ignored. Only isolcpus is VERIFIED in force (/sys/.../isolated
+         = 6-7); rcu_nocbs= state was not checked (CONFIG_RCU_NOCB_CPU unverified),
+         so no claim is made about it either way.
 Build  : iceoryx2 0.9.2, cargo 1.96.0 (edition-2024 tree builds clean; 45.8 s cold).
          latency_bench (feat/l2-iceoryx2-frozen-contract), --release.
 Date   : 2026-07-01


### PR DESCRIPTION
## Why

Follow-up to #736 / #737 (both merged). Those landed the iceoryx2 frozen-contract carrier + latency bench and the ADR-0006 evidence update on an **x86 shared host** — INDICATIVE only, and the ADR explicitly flagged the isolated-core "toward ~100 ns" figure as still-needed and certified-on-QNX. This PR supplies that measurement, taken on the **real deployment silicon**.

Because #736/#737 were already merged, this is a fresh branch off `main` (a merged PR can't track new work), carrying the two follow-up commits.

## What was measured

Jetson Orin NX 16GB (aarch64, Tegra234 — the actual ROSMASTER robot, not a VM or x86 box), with:
- cores 6/7 `isolcpus`-isolated (verified `/sys/devices/system/cpu/isolated = 6-7`)
- MAXN + `jetson_clocks` (all cores pinned @ 1.984 GHz, no DVFS)
- requester/responder pinned to the isolated cores, `SCHED_FIFO` granted
- 1M iterations, reproduced twice

```
mode                       p50_ns     p99_ns    p999_ns     max_ns
iox2 ping-pong (RTT)         1408       1568       2304   ~47–51 ms
```

- **Real cross-core doer↔checker hop: ~704 ns one-way** (RTT/2), **p99.9 = 2304 ns RTT (~1.15 µs one-way)**. Two runs agreed to the **nanosecond** on p50/p99/p99.9 — isolation collapsed the tail *body* ~6× vs the shared host.
- **Honest caveat (the headline, not a footnote):** the max is a *reproducible* ~47–51 ms because the stock L4T kernel has no `CONFIG_NO_HZ_FULL` (so `nohz_full` was silently ignored; the timer tick + RCU/IPI still land on 6/7). `isolcpus` tightens the body but cannot *bound* the tail on non-RT Linux — which is exactly why the certified WCET must be a **QNX-under-FIFO** number (#274), never a Linux figure.
- The sub-3 µs p99.9 body sits far under the governor verdict WCET target (100 µs), so the transport is not the FTTI bottleneck.

## What's added

- `tools/iceoryx2-spike/results/orin-nx-16gb-linux-isolated.txt` — full provenance + verbatim output of both runs, mirroring the `qnx-rtm-harness/results/` convention.
- `tools/iceoryx2-spike/README.md` — "Isolated-core result on the deployment SoC" subsection, advancing the prior "the target supplies the number" note with a real measurement.
- `docs/adr/0006-governor-transport-iceoryx2.md` §2 — the Orin NX isolated-core row folded into the latency evidence.

## Notes

- Docs/data only — no code change, no rebuild. iceoryx2 stays out of the SDK/parko tree (the isolated spike workspace is unchanged).
- The reproduce recipe is in the results file header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_