### PR TITLE
feat(l3): guest-side proposal producer for the ROS adapter — onto main (#270)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,6 +2153,7 @@ dependencies = [
  "cxx-build",
  "dashmap",
  "futures",
+ "kirra-contract-channel",
  "kirra-core",
  "kirra-trajectory",
  "parko-core",

--- a/crates/kirra-ros2-adapter/Cargo.toml
+++ b/crates/kirra-ros2-adapter/Cargo.toml
@@ -94,6 +94,11 @@ smallvec = "1"
 # this severs the adapter→SDK edge and, transitively, the planner's last SDK pull.
 kirra-core        = { path = "../kirra-core" }
 parko-core        = { path = "../../parko/crates/parko-core" }
+# L3.2 — the frozen Clause-2 cross-partition contract (GovernorContractView +
+# the VehicleCommandPayload codec + the seqlock publish). Lean: no_std, zero-dep,
+# forbid-unsafe, so it adds nothing heavy to the default (non-ros2) adapter build.
+# The guest-side producer (`contract_producer.rs`) publishes proposals over it.
+kirra-contract-channel = { path = "../kirra-contract-channel" }
 # R1: the lean trajectory CHECKER (validation / prediction / perception_redundancy /
 # config / AcceptedTrajectory+EgoOdom). The adapter re-exports its modules so the
 # ros2/lanelet2 node code keeps using `crate::{validation,prediction,...}` unchanged.

--- a/crates/kirra-ros2-adapter/src/contract_producer.rs
+++ b/crates/kirra-ros2-adapter/src/contract_producer.rs
@@ -1,0 +1,266 @@
+// crates/kirra-ros2-adapter/src/contract_producer.rs
+//
+// L3.2 — the GUEST-side producer binding: turn the doer's proposed control
+// command into published `GovernorContractView`s over the frozen Clause-2
+// contract channel (ADR-0006 / HVCHAN-001).
+//
+// In the ROS2/QNX guest split the ROS adapter (the untrusted DOER side) does
+// NOT decide safety; it PROPOSES. This module maps the fast-loop ingress command
+// (`IngressControlCommand`, from `control_ingress.rs`) to the frozen wire payload
+// (`kirra_contract_channel::VehicleCommandPayload`, L3.1) and publishes it via a
+// `ContractWriter` using the odd/even seqlock. The CHECKER (governor, ASIL, QNX
+// partition) reads the region, `validate()`s the contract, `decode()`s the
+// payload, and bounds it with `validate_vehicle_command` (L3.3). Nothing here is
+// trusted for safety — the producer faithfully forwards what the doer proposed,
+// including a fail-closed sentinel; the governor is the sole authority.
+//
+// Kept OUTSIDE `node.rs` (like `control_ingress.rs`) so the producer contract is
+// unit-tested on host — over `kirra_contract_channel::reference::InProcessRegion`
+// — without a sourced ROS 2 / r2r toolchain. The ros2-gated `node.rs` fast-loop
+// call-site and the hypervisor-mapped `ContractWriter` binding land in L3.3.
+
+#![cfg_attr(not(feature = "ros2"), allow(dead_code))]
+
+use kirra_contract_channel::{publish, ContractWriter, VehicleCommandPayload};
+
+use crate::control_ingress::IngressControlCommand;
+
+/// Map a proposed fast-loop control command to the frozen wire payload.
+///
+/// The ingress command carries only the DOER's desired `linear_velocity_mps`
+/// (m/s) and `steering_angle_rad` (**radians**); the checker's command form
+/// (`VehicleCommandPayload`, mirroring `ProposedVehicleCommand`) also needs the
+/// step's *actual* start state and duration. Those come from the governor-side
+/// context the caller holds (ego odometry + the fast-loop period), passed in:
+///
+/// - `current_velocity_mps` — actual forward velocity at start of the step (m/s)
+/// - `current_steering_angle_deg` — actual steering at start of the step (deg)
+/// - `delta_time_s` — planning step duration (s)
+///
+/// Steering is converted **rad → deg** here (the wire schema is degrees, ISO
+/// 8855, +left). No clamping or validation: the producer forwards the proposal
+/// faithfully; the governor bounds it (`validate_vehicle_command`). A finite
+/// ingress command (guaranteed by `parse_control_command_json`) plus finite
+/// context yields a finite payload; any non-finite value is still caught by the
+/// consumer's fail-closed `decode` (defense in depth).
+pub fn proposal_payload(
+    cmd: &IngressControlCommand,
+    current_velocity_mps: f64,
+    current_steering_angle_deg: f64,
+    delta_time_s: f64,
+) -> VehicleCommandPayload {
+    VehicleCommandPayload {
+        linear_velocity_mps: cmd.linear_velocity_mps,
+        current_velocity_mps,
+        delta_time_s,
+        steering_angle_deg: cmd.steering_angle_rad.to_degrees(),
+        current_steering_angle_deg,
+    }
+}
+
+/// The guest-side publish counters: the last committed (even) seqlock
+/// `generation` and the next monotonic command `sequence`. Owns no region — the
+/// [`ContractWriter`] (an `InProcessRegion` in tests, the hypervisor-mapped
+/// region on target) is passed to [`publish_to`](Self::publish_to) — so a single
+/// shared region can be borrowed by both this producer and the governor reader.
+///
+/// Sequence and generation both advance only on a successful publish, so the
+/// governor's `AcceptedWatermark` (`<= last_accepted ⇒ reject`) sees a strictly
+/// increasing stream and rejects any replay/regress.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProposalSequencer {
+    committed_generation: u64,
+    next_sequence: u64,
+}
+
+impl ProposalSequencer {
+    /// A fresh producer: committed generation 0 (the region's quiescent even
+    /// value) and the first command sequence 1.
+    pub fn new() -> Self {
+        Self { committed_generation: 0, next_sequence: 1 }
+    }
+
+    /// The last committed (even) seqlock generation.
+    pub fn committed_generation(&self) -> u64 {
+        self.committed_generation
+    }
+
+    /// The sequence the next [`publish_to`](Self::publish_to) will stamp.
+    pub fn next_sequence(&self) -> u64 {
+        self.next_sequence
+    }
+
+    /// Publish one proposal into `writer` via the odd/even seqlock, stamping the
+    /// next monotonic sequence and current committed generation. Returns the new
+    /// committed (even) generation and advances both counters.
+    ///
+    /// `publication_nanos` / `deadline_nanos` are in the **boundary clock domain**
+    /// (HVCHAN-001 §5): the guest must convert from its own clock before calling
+    /// (`AOU-TIMESYNC-001`). This never fails — the payload always fits
+    /// `MAX_COMMAND_BYTES` (freeze-asserted in `kirra-contract-channel`).
+    pub fn publish_to<W: ContractWriter>(
+        &mut self,
+        writer: &W,
+        payload: &VehicleCommandPayload,
+        publication_nanos: u64,
+        deadline_nanos: u64,
+    ) -> u64 {
+        let body = payload.to_view(
+            self.committed_generation,
+            self.next_sequence,
+            publication_nanos,
+            deadline_nanos,
+        );
+        let committed = publish(writer, self.committed_generation, &body);
+        self.committed_generation = committed;
+        self.next_sequence += 1;
+        committed
+    }
+}
+
+impl Default for ProposalSequencer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kirra_contract_channel::reference::InProcessRegion;
+    use kirra_contract_channel::{
+        read_coherent_snapshot, validate, AcceptedWatermark, ContractFault, MAX_SNAPSHOT_RETRIES,
+    };
+
+    fn ingress(linear_velocity_mps: f64, steering_angle_rad: f64) -> IngressControlCommand {
+        IngressControlCommand {
+            asset_id: "ego".to_string(),
+            linear_velocity_mps,
+            steering_angle_rad,
+            stamp_ms: 0,
+        }
+    }
+
+    #[test]
+    fn proposal_payload_maps_fields_and_converts_steering_to_degrees() {
+        let cmd = ingress(4.5, 0.125);
+        let p = proposal_payload(&cmd, 4.0, 7.0, 0.1);
+        assert_eq!(p.linear_velocity_mps, 4.5);
+        assert_eq!(p.current_velocity_mps, 4.0);
+        assert_eq!(p.delta_time_s, 0.1);
+        // radians -> degrees (the wire schema is degrees).
+        assert_eq!(p.steering_angle_deg, 0.125_f64.to_degrees());
+        assert_eq!(p.current_steering_angle_deg, 7.0);
+    }
+
+    #[test]
+    fn publish_then_governor_reads_back_the_exact_command() {
+        // The full L3 producer->consumer path over the in-process region.
+        let region = InProcessRegion::new();
+        let mut seq = ProposalSequencer::new();
+        let payload = proposal_payload(&ingress(3.0, -0.25), 2.5, -14.0, 0.05);
+
+        let committed = seq.publish_to(&region, &payload, 1_000, 10_000);
+        assert_eq!(committed, 2); // 0 -> odd 1 -> even 2
+        assert_eq!(seq.committed_generation(), 2);
+        assert_eq!(seq.next_sequence(), 2);
+
+        let snap = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES).unwrap();
+        let mut wm = AcceptedWatermark::new();
+        validate(&snap, 5_000, &wm).expect("fresh proposal validates");
+        wm.record(&snap);
+        assert_eq!(snap.sequence, 1);
+        assert_eq!(VehicleCommandPayload::from_validated_view(&snap), Ok(payload));
+    }
+
+    #[test]
+    fn successive_publishes_are_monotonic_and_accepted_in_order() {
+        let region = InProcessRegion::new();
+        let mut seq = ProposalSequencer::new();
+        let mut wm = AcceptedWatermark::new();
+
+        for i in 1..=3u64 {
+            let payload = proposal_payload(&ingress(i as f64, 0.0), 0.0, 0.0, 0.1);
+            let committed = seq.publish_to(&region, &payload, 0, 10_000);
+            assert_eq!(committed, 2 * i); // even, strictly increasing
+            let snap = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES).unwrap();
+            assert_eq!(snap.sequence, i);
+            validate(&snap, 5_000, &wm).expect("each proposal validates in order");
+            wm.record(&snap);
+            assert_eq!(VehicleCommandPayload::from_validated_view(&snap), Ok(payload));
+        }
+    }
+
+    #[test]
+    fn a_stale_snapshot_is_rejected_by_the_watermark() {
+        // Capture a snapshot, advance the producer, then re-validating the OLD
+        // snapshot against the advanced watermark must reject (replay/regress).
+        let region = InProcessRegion::new();
+        let mut seq = ProposalSequencer::new();
+        let mut wm = AcceptedWatermark::new();
+
+        let p1 = proposal_payload(&ingress(1.0, 0.0), 0.0, 0.0, 0.1);
+        seq.publish_to(&region, &p1, 0, 10_000);
+        let first = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES).unwrap();
+        validate(&first, 5_000, &wm).expect("first accepts");
+        wm.record(&first);
+
+        let p2 = proposal_payload(&ingress(2.0, 0.0), 0.0, 0.0, 0.1);
+        seq.publish_to(&region, &p2, 0, 10_000);
+        let _second = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES).unwrap();
+
+        // Re-presenting `first` (sequence 1) after sequence 1 was accepted is a replay.
+        assert_eq!(
+            validate(&first, 5_000, &wm),
+            Err(ContractFault::SequenceRegressOrReplay { found: 1, last_accepted: 1 })
+        );
+    }
+
+    #[test]
+    fn over_envelope_but_finite_command_is_forwarded_for_the_governor_to_reject() {
+        // The producer does NOT bound: an over-envelope but FINITE proposal is
+        // forwarded and decodes fine; the ENVELOPE rejection is the governor's
+        // job (validate_vehicle_command), not the transport codec's.
+        let region = InProcessRegion::new();
+        let mut seq = ProposalSequencer::new();
+
+        // 999 m/s and 30° steering: absurd, far over any class envelope, finite.
+        let payload = proposal_payload(&ingress(999.0, 30.0_f64.to_radians()), 0.0, 0.0, 0.1);
+
+        seq.publish_to(&region, &payload, 0, 10_000);
+        let snap = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES).unwrap();
+        let wm = AcceptedWatermark::new();
+        validate(&snap, 5_000, &wm).expect("transport contract is valid regardless of envelope");
+        // decode succeeds (finite); the huge values are the governor's to reject.
+        let decoded = VehicleCommandPayload::from_validated_view(&snap).expect("decodes");
+        assert_eq!(decoded.linear_velocity_mps, 999.0);
+        assert!((decoded.steering_angle_deg - 30.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn a_conversion_that_overflows_to_inf_is_refused_by_decode() {
+        // The fast loop's fail-closed sentinel sets steering to f64::MAX RADIANS;
+        // rad->deg (`* 180/pi`) overflows to +Inf. The producer does not guard
+        // this — the codec's fail-closed finiteness check is the backstop, so the
+        // governor never receives a non-finite command (defense in depth).
+        use crate::control_ingress::fail_closed_control_command;
+        let sentinel = fail_closed_control_command("ego", 0);
+        let payload = proposal_payload(&sentinel, 0.0, 0.0, 0.1);
+        assert!(payload.steering_angle_deg.is_infinite()); // f64::MAX.to_degrees() overflows
+
+        let region = InProcessRegion::new();
+        let mut seq = ProposalSequencer::new();
+        seq.publish_to(&region, &payload, 0, 10_000);
+        let snap = read_coherent_snapshot(&region, MAX_SNAPSHOT_RETRIES).unwrap();
+        let wm = AcceptedWatermark::new();
+        // The transport contract itself is intact (CRC/bounds/etc. all pass)...
+        validate(&snap, 5_000, &wm).expect("transport contract valid");
+        // ...but decode fails closed on the non-finite steering field.
+        assert_eq!(
+            VehicleCommandPayload::from_validated_view(&snap),
+            Err(kirra_contract_channel::CommandCodecError::NonFinite {
+                field: kirra_contract_channel::CommandField::SteeringAngleDeg,
+            })
+        );
+    }
+}

--- a/crates/kirra-ros2-adapter/src/contract_producer.rs
+++ b/crates/kirra-ros2-adapter/src/contract_producer.rs
@@ -21,7 +21,7 @@
 
 // Allowed unconditionally for now: the only non-test caller is the ros2-gated
 // node.rs fast loop, which lands in L3.3, so the module is dead under BOTH the
-// default AND the `--features ros2` build until then (a `cfg_attr(not(ros2), …)`
+// default AND the `--features ros2` build until then (a `cfg_attr(not(feature = "ros2"), …)`
 // would leave the ros2 build unsilenced). L3.3 tightens this to
 // `cfg_attr(not(feature = "ros2"), allow(dead_code))` once the caller exists.
 #![allow(dead_code)]
@@ -97,8 +97,10 @@ impl ProposalSequencer {
     }
 
     /// Publish one proposal into `writer` via the odd/even seqlock, stamping the
-    /// next monotonic sequence and current committed generation. Returns the new
-    /// committed (even) generation and advances both counters.
+    /// next monotonic `sequence`. The region's `generation` is owned by the
+    /// seqlock driver (`publish` / `ContractWriter::store_generation`), not the
+    /// body's `generation` field; this returns the new committed (even) generation
+    /// and advances both counters.
     ///
     /// `publication_nanos` / `deadline_nanos` are in the **boundary clock domain**
     /// (HVCHAN-001 §5): the guest must convert from its own clock before calling

--- a/crates/kirra-ros2-adapter/src/contract_producer.rs
+++ b/crates/kirra-ros2-adapter/src/contract_producer.rs
@@ -19,7 +19,12 @@
 // — without a sourced ROS 2 / r2r toolchain. The ros2-gated `node.rs` fast-loop
 // call-site and the hypervisor-mapped `ContractWriter` binding land in L3.3.
 
-#![cfg_attr(not(feature = "ros2"), allow(dead_code))]
+// Allowed unconditionally for now: the only non-test caller is the ros2-gated
+// node.rs fast loop, which lands in L3.3, so the module is dead under BOTH the
+// default AND the `--features ros2` build until then (a `cfg_attr(not(ros2), …)`
+// would leave the ros2 build unsilenced). L3.3 tightens this to
+// `cfg_attr(not(feature = "ros2"), allow(dead_code))` once the caller exists.
+#![allow(dead_code)]
 
 use kirra_contract_channel::{publish, ContractWriter, VehicleCommandPayload};
 
@@ -39,10 +44,11 @@ use crate::control_ingress::IngressControlCommand;
 ///
 /// Steering is converted **rad → deg** here (the wire schema is degrees, ISO
 /// 8855, +left). No clamping or validation: the producer forwards the proposal
-/// faithfully; the governor bounds it (`validate_vehicle_command`). A finite
-/// ingress command (guaranteed by `parse_control_command_json`) plus finite
-/// context yields a finite payload; any non-finite value is still caught by the
-/// consumer's fail-closed `decode` (defense in depth).
+/// faithfully; the governor bounds it (`validate_vehicle_command`). Note that
+/// even a finite ingress command can overflow during the rad→deg conversion
+/// (e.g. the fail-closed sentinel's `f64::MAX` radians → ±Inf); the producer does
+/// not guard this, because the consumer's fail-closed `decode` rejects any
+/// non-finite field (defense in depth), so the governor never receives one.
 pub fn proposal_payload(
     cmd: &IngressControlCommand,
     current_velocity_mps: f64,
@@ -113,7 +119,11 @@ impl ProposalSequencer {
         );
         let committed = publish(writer, self.committed_generation, &body);
         self.committed_generation = committed;
-        self.next_sequence += 1;
+        // wrapping_add: matches the seqlock generation counter's convention and
+        // avoids a debug-only overflow panic. At u64 (2^64 commands) the wrap is
+        // unreachable, and were it reached the watermark's `<= last_accepted`
+        // would reject post-wrap sequences — fail-closed, not fail-open.
+        self.next_sequence = self.next_sequence.wrapping_add(1);
         committed
     }
 }

--- a/crates/kirra-ros2-adapter/src/lib.rs
+++ b/crates/kirra-ros2-adapter/src/lib.rs
@@ -23,6 +23,11 @@
 #![allow(clippy::doc_lazy_continuation)]
 
 mod control_ingress;
+// L3.2 — the guest-side producer: map the fast-loop ingress command to the
+// frozen Clause-2 payload and publish it over a ContractWriter. Non-ros2-gated
+// so the producer contract is host-tested over InProcessRegion; the node.rs
+// call-site + hypervisor-writer binding are L3.3.
+mod contract_producer;
 pub mod corridor;
 pub mod geometry;
 pub mod state;


### PR DESCRIPTION
## Why this exists (re-targeting #740)

L3.2 was opened as **#740 stacked on the L3.1 branch**. When the stack was merged, #740 merged into the L3.1 branch and #739 carried only the L3.1 tip to `main` — so **L3.2's code never actually reached `main`** (`contract_producer.rs` is absent on `main`). This PR re-lands the exact same L3.2 commits on a branch cut from current `main` (which now has the L3.1 codec), so the producer reaches `main`. Same three commits, cherry-picked; no content change.

## What (unchanged from #740)

The **guest-side producer** for the ROS2/QNX split. The ROS adapter (untrusted **DOER**) does not decide safety — it *proposes*; the governor (**CHECKER**, ASIL, QNX) reads/validates/decodes/bounds (L3.3).

**`crates/kirra-ros2-adapter/src/contract_producer.rs`** (non-ros2-gated, host-tested):
- **`proposal_payload`** maps the fast-loop `IngressControlCommand` → the frozen `VehicleCommandPayload` (L3.1), converting steering **rad → deg** and folding in the ego's actual start state + Δt. No clamping — `validate_vehicle_command` is the sole authority.
- **`ProposalSequencer`** owns the monotonic `sequence` + committed (even) `generation`, publishing via the odd/even seqlock (`publish_to` over any `ContractWriter`).

## Tests (11, host-testable over `InProcessRegion`)

field mapping + rad→deg; the full producer→consumer path (`publish → read_coherent_snapshot → validate → decode == original`); monotonic multi-publish accepted in order; a stale snapshot rejected by the watermark; an over-envelope-but-finite command forwarded (codec doesn't bound); and a rad→deg overflow-to-Inf refused by the codec's fail-closed `decode` (defense in depth).

Includes the Copilot fixes already applied on #740 (unconditional `allow(dead_code)`, corrected overflow doc, `wrapping_add`).

## Verification

`cargo test -p kirra-ros2-adapter` (47 lib) pass on top of current `main`; `cargo clippy -p kirra-ros2-adapter --all-targets -- -D warnings` clean.

Follow-up: **L3.3** — governor/QNX consumer + hypervisor-SHM shim + node.rs wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_