### PR TITLE
feat(l3): kirra-hv-carrier — POSIX-SHM cross-partition carrier (ADR-0030 incr. 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,6 +2104,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-hv-carrier"
+version = "0.1.0"
+dependencies = [
+ "kirra-contract-channel",
+ "libc",
+]
+
+[[package]]
 name = "kirra-map"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
+members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
 resolver = "2"
 
 [package]

--- a/crates/kirra-hv-carrier/Cargo.toml
+++ b/crates/kirra-hv-carrier/Cargo.toml
@@ -1,0 +1,27 @@
+# crates/kirra-hv-carrier/Cargo.toml
+#
+# L3 last-mile carrier (ADR-0030). THE single crate in the L3 path that is NOT
+# `#![forbid(unsafe_code)]`: it binds the carrier-agnostic ContractReader /
+# ContractWriter seam to a memory-MAPPED shared region, which requires the mmap
+# `unsafe` (ADR-0006 Clause 3 integration boundary). The contract + trust chain
+# above it (kirra-contract-channel, kirra-core) stay forbid-unsafe.
+#
+# Deps are deliberately minimal — the cross-partition TCB is the frozen layout
+# plus this thin mapping shim, nothing more (Clause 2). Only:
+#   - kirra-contract-channel: the frozen GovernorContractView + seqlock + validate
+#   - libc: shm_open / mmap / ftruncate / munmap / shm_unlink (POSIX host binding)
+[package]
+name = "kirra-hv-carrier"
+version = "0.1.0"
+edition = "2021"
+description = "L3 cross-partition contract carrier — POSIX-SHM (host) binding of the ContractReader/Writer seam (ADR-0030)"
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+
+[dependencies]
+kirra-contract-channel = { path = "../kirra-contract-channel" }
+# POSIX shared-memory + mmap for the host `PosixShmRegion` binding. Unix-only;
+# this crate is a host (Linux/QNX) integration shim, never built for a bare
+# no_std target.
+libc = "0.2"

--- a/crates/kirra-hv-carrier/README.md
+++ b/crates/kirra-hv-carrier/README.md
@@ -1,0 +1,69 @@
+# kirra-hv-carrier — L3 cross-partition contract carrier (ADR-0030)
+
+Binds the carrier-agnostic `ContractReader` / `ContractWriter` seam
+(`kirra-contract-channel`) to a **memory-mapped shared region**, so the frozen
+`GovernorContractView` + seqlock trust chain runs across a **real** address-space
+boundary — not just host-in-process over `InProcessRegion`.
+
+This is **the only crate in the L3 path that is NOT `#![forbid(unsafe_code)]`** —
+the ADR-0006 **Clause 3** integration boundary. The `unsafe` budget is bounded
+and enumerated (ADR-0030 Clause A): the `shm_open`/`mmap` map, the atomic field
+accesses over the mapped bytes (reproducing `InProcessRegion`'s memory model
+exactly — `generation` Acquire/Release, body Relaxed), and the `Send`/`Sync`
+assertions. The `#[repr(C)]` overlay is byte-identical to the frozen
+`GovernorContractView` (compile-time asserted against its frozen offsets).
+
+## Bindings
+
+- **`PosixShmRegion`** — the host **guest** handle (read-write; `create` /
+  `open`). Implements `ContractReader` + `ContractWriter`.
+- **`PosixShmReader`** — the host **governor** handle (read-only; `open`). The
+  R-HV-1 shape: no `ContractWriter` impl (type-level) **and** a `PROT_READ`
+  mapping (OS-level), so the governor cannot write the region.
+
+Both are the testable stand-in for the QNX `HvRegion` (a hypervisor-mapped
+region), which binds the *same* traits with the *same* trust chain and only swaps
+the map primitive (ADR-0030 Clause B).
+
+## Run
+
+```sh
+cargo test -p kirra-hv-carrier          # unit + two-process integration test
+cargo run --release -p kirra-hv-carrier --bin shm_latency   # raw-SHM latency
+```
+
+The two-process test (`tests/two_process.rs`) has a guest process publish into a
+POSIX shared region and a **separate** governor process (`shm_peer`) map it
+read-only and validate+decode — the real cross-address-space proof the
+in-process reference carrier cannot give.
+
+## Latency — raw SHM is at the floor (host-INDICATIVE)
+
+`shm_latency` times the governor read path over `MAP_SHARED` (176-byte
+`GovernorContractView`, same nearest-rank percentiles as the iceoryx2
+`latency_bench`). Representative host run (shared dev box, no core isolation /
+FIFO — the comparative **ratio** is the takeaway, not the absolute ns):
+
+```
+path                            p50_ns    p99_ns   p999_ns
+shm read_coherent_snapshot          60       187      2569
+shm read+validate+decode           297       485      3797
+```
+
+Compared to the `latency_bench` rows on the same class of host:
+
+| path | p50 |
+|---|---|
+| in-process floor (by-value) | ~28 ns |
+| **shm read_coherent_snapshot** | **~60 ns** |
+| iceoryx2 zero-copy (pub/sub) | ~309 ns |
+| socket+serde (UDP proxy) | ~976 ns |
+
+The raw-SHM seqlock read sits at the **in-process-floor class — ~5× tighter than
+iceoryx2's pub/sub handoff** — because for a single latest-value slot it is the
+minimal mechanism: no queue, no loan, no discovery. (And note the ~60 ns is
+transport-only; the ~297 ns row already *includes* CRC + validate + decode, which
+iceoryx2's 309 ns does not.) This is the measured evidence behind ADR-0006's
+choice of a frozen layout over SHM — **not** iceoryx2 — for the Clause 2
+cross-partition boundary. The ms-scale `max` (not shown) is host jitter; the
+certified figure is a QNX-target-under-FIFO measurement (#274).

--- a/crates/kirra-hv-carrier/src/bin/shm_latency.rs
+++ b/crates/kirra-hv-carrier/src/bin/shm_latency.rs
@@ -112,8 +112,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for i in 0..(iters + warmup) {
         let t0 = Instant::now();
         let snap = read_coherent_snapshot(&governor, MAX_SNAPSHOT_RETRIES).unwrap();
-        // A fresh watermark each iter so validate always accepts (we are timing
-        // the read+validate+decode cost, not the monotonic gate).
+        // Fresh watermark (created once, never recorded) so the monotonic gate is
+        // disabled and validate always accepts — we are timing the
+        // read+validate+decode cost, not sequence-advancement behavior.
         validate(&snap, 0, &wm).unwrap();
         let cmd = VehicleCommandPayload::from_validated_view(&snap).unwrap();
         let dt = t0.elapsed();

--- a/crates/kirra-hv-carrier/src/bin/shm_latency.rs
+++ b/crates/kirra-hv-carrier/src/bin/shm_latency.rs
@@ -1,0 +1,135 @@
+// shm_latency — raw POSIX-SHM seqlock read latency (ADR-0030 evidence).
+//
+// Times the GOVERNOR read path over a real shared-memory mapping — the carrier's
+// actual cost on the validation path — so the "raw SHM + seqlock beats iceoryx2
+// for this single-latest-value pattern" claim has a measured number instead of
+// the in-process-floor proxy. Same 176-byte GovernorContractView payload, same
+// nearest-rank percentile method as `tools/iceoryx2-spike/.../latency_bench.rs`,
+// so the rows are directly comparable.
+//
+// HONESTY: absolute ns are host-INDICATIVE (shared dev box, no core isolation /
+// FIFO). The comparative RATIO vs the iceoryx2 / socket rows is the takeaway; the
+// certified figure is a QNX-target-under-FIFO measurement (#274).
+//
+// Run:  KIRRA_LAT_ITERS=1000000 cargo run --release -p kirra-hv-carrier --bin shm_latency
+
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use kirra_contract_channel::{
+    publish, read_coherent_snapshot, validate, AcceptedWatermark, VehicleCommandPayload,
+    MAX_SNAPSHOT_RETRIES,
+};
+use kirra_hv_carrier::{PosixShmReader, PosixShmRegion};
+
+fn parse_iters() -> usize {
+    std::env::var("KIRRA_LAT_ITERS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(200_000)
+}
+
+fn percentile(sorted: &[Duration], pct: f64) -> u128 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let n = sorted.len();
+    let mut rank = ((pct / 100.0) * n as f64).ceil() as usize;
+    rank = rank.clamp(1, n);
+    sorted[rank - 1].as_nanos()
+}
+
+fn row(name: &str, mut s: Vec<Duration>) {
+    s.sort_unstable();
+    println!(
+        "{name:<28} {:>9} {:>9} {:>9} {:>9}",
+        percentile(&s, 50.0),
+        percentile(&s, 99.0),
+        percentile(&s, 99.9),
+        s.last().copied().unwrap_or(Duration::ZERO).as_nanos(),
+    );
+}
+
+fn well_formed(seq: u64) -> VehicleCommandPayload {
+    VehicleCommandPayload {
+        linear_velocity_mps: 3.0,
+        current_velocity_mps: 2.9,
+        delta_time_s: 0.1,
+        steering_angle_deg: 1.5,
+        current_steering_angle_deg: 1.2,
+    }
+    .with_seq_noise(seq)
+}
+
+// tiny helper so successive publishes differ (defeat any constant-folding)
+trait SeqNoise {
+    fn with_seq_noise(self, seq: u64) -> Self;
+}
+impl SeqNoise for VehicleCommandPayload {
+    fn with_seq_noise(mut self, seq: u64) -> Self {
+        self.linear_velocity_mps = 3.0 + (seq % 7) as f64 * 0.01;
+        self
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let iters = parse_iters();
+    let warmup = (iters / 10).max(1_000);
+
+    let name = format!("/kirra-hv-lat-{}", std::process::id());
+    let guest = PosixShmRegion::create(&name)?;
+    let governor = PosixShmReader::open(&name)?; // read-only, the governor mapping
+
+    // Publish a committed command so the region holds a valid latest value.
+    let committed = publish(&guest, 0, &well_formed(1).to_view(0, 1, 0, u64::MAX / 2));
+
+    eprintln!(
+        "=== raw POSIX-SHM seqlock read latency — INDICATIVE (host, no isolation/FIFO) ===\n\
+         payload = frozen GovernorContractView (176 B) over MAP_SHARED; iters={iters} warmup={warmup}\n\
+         governor mapping = PROT_READ (R-HV-1). Compare against the latency_bench\n\
+         iceoryx2 / socket rows (same payload + percentile method)."
+    );
+    println!("\n{:<28} {:>9} {:>9} {:>9} {:>9}", "path", "p50_ns", "p99_ns", "p999_ns", "max_ns");
+    println!("{}", "-".repeat(70));
+
+    // (1) read_coherent_snapshot alone — the seqlock read the governor pays.
+    let mut read_samples = Vec::with_capacity(iters);
+    for i in 0..(iters + warmup) {
+        let t0 = Instant::now();
+        let snap = read_coherent_snapshot(&governor, MAX_SNAPSHOT_RETRIES).unwrap();
+        let dt = t0.elapsed();
+        black_box(snap.sequence);
+        if i >= warmup {
+            read_samples.push(dt);
+        }
+    }
+    row("shm read_coherent_snapshot", read_samples);
+
+    // (2) read + validate + decode — the full governor receive (minus kinematics).
+    let wm = AcceptedWatermark::new();
+    let mut full_samples = Vec::with_capacity(iters);
+    for i in 0..(iters + warmup) {
+        let t0 = Instant::now();
+        let snap = read_coherent_snapshot(&governor, MAX_SNAPSHOT_RETRIES).unwrap();
+        // A fresh watermark each iter so validate always accepts (we are timing
+        // the read+validate+decode cost, not the monotonic gate).
+        validate(&snap, 0, &wm).unwrap();
+        let cmd = VehicleCommandPayload::from_validated_view(&snap).unwrap();
+        let dt = t0.elapsed();
+        black_box(cmd.linear_velocity_mps);
+        if i >= warmup {
+            full_samples.push(dt);
+        }
+    }
+    row("shm read+validate+decode", full_samples);
+
+    let _ = committed;
+    eprintln!(
+        "\nNote: the seqlock read is a handful of atomic loads + a 176 B copy over\n\
+         shared pages — the same class as the latency_bench in-process floor, and\n\
+         well below the iceoryx2 pub/sub rows: raw SHM is the minimal carrier for a\n\
+         single latest-value slot (no queue, no loan, no discovery)."
+    );
+    Ok(())
+}

--- a/crates/kirra-hv-carrier/src/bin/shm_peer.rs
+++ b/crates/kirra-hv-carrier/src/bin/shm_peer.rs
@@ -1,0 +1,72 @@
+// shm_peer — the GOVERNOR-side reader peer for the two-process host test
+// (tests/two_process.rs). A separate OS process that maps the same POSIX shared
+// region READ-ONLY (the R-HV-1 governor shape) and validates+decodes the command
+// the guest process published, proving the frozen contract crosses a real
+// address-space boundary.
+//
+// Args: <shm_name> <expected_sequence> <expected_linear_velocity_mps>
+// Exit:  0 = a coherent snapshot validated, decoded, and matched the expected
+//            sequence + linear velocity;  1 = any mismatch/fault (fail-closed).
+
+use std::process::ExitCode;
+
+use kirra_contract_channel::{
+    read_coherent_snapshot, validate, AcceptedWatermark, VehicleCommandPayload, MAX_SNAPSHOT_RETRIES,
+};
+use kirra_hv_carrier::PosixShmReader;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 4 {
+        eprintln!("usage: shm_peer <shm_name> <expected_seq> <expected_linvel>");
+        return ExitCode::from(2);
+    }
+    let name = &args[1];
+    let expected_seq: u64 = match args[2].parse() {
+        Ok(v) => v,
+        Err(_) => return ExitCode::from(2),
+    };
+    let expected_linvel: f64 = match args[3].parse() {
+        Ok(v) => v,
+        Err(_) => return ExitCode::from(2),
+    };
+
+    let reader = match PosixShmReader::open(name) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("shm_peer: open {name} failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let snapshot = match read_coherent_snapshot(&reader, MAX_SNAPSHOT_RETRIES) {
+        Ok(s) => s,
+        Err(f) => {
+            eprintln!("shm_peer: snapshot fault: {f:?}");
+            return ExitCode::from(1);
+        }
+    };
+    // now = 0: the guest publishes a far-future deadline, so the freshness check
+    // passes regardless of wall time (this test is about cross-process fidelity,
+    // not the boundary clock).
+    let wm = AcceptedWatermark::new();
+    if let Err(fault) = validate(&snapshot, 0, &wm) {
+        eprintln!("shm_peer: contract fault: {fault:?}");
+        return ExitCode::from(1);
+    }
+    let cmd = match VehicleCommandPayload::from_validated_view(&snapshot) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("shm_peer: decode fault: {e:?}");
+            return ExitCode::from(1);
+        }
+    };
+    if snapshot.sequence != expected_seq || (cmd.linear_velocity_mps - expected_linvel).abs() > 1e-9 {
+        eprintln!(
+            "shm_peer: mismatch: seq {} (want {expected_seq}), linvel {} (want {expected_linvel})",
+            snapshot.sequence, cmd.linear_velocity_mps
+        );
+        return ExitCode::from(1);
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/kirra-hv-carrier/src/lib.rs
+++ b/crates/kirra-hv-carrier/src/lib.rs
@@ -1,0 +1,380 @@
+//! # kirra-hv-carrier — the L3 last-mile cross-partition carrier (ADR-0030)
+//!
+//! Binds the carrier-agnostic [`ContractReader`] / [`ContractWriter`] seam
+//! (`kirra-contract-channel`) to a **memory-mapped shared region**, so the same
+//! frozen `GovernorContractView` + seqlock trust chain that runs host-in-process
+//! over `InProcessRegion` runs across a **real** address-space boundary.
+//!
+//! This is **the only crate in the L3 path that is NOT `#![forbid(unsafe_code)]`**
+//! — it is the ADR-0006 **Clause 3** integration boundary. The `unsafe` budget is
+//! bounded and enumerated (ADR-0030 Clause A):
+//!
+//! 1. the **map** (`shm_open` + `mmap`, and `ftruncate` on create) producing a
+//!    pointer to exactly `size_of::<GovernorContractView>()` bytes (R-HV-2);
+//! 2. viewing those mapped bytes as [`AtomicView`] and doing **atomic** field
+//!    accesses that reproduce `InProcessRegion`'s memory model **exactly** —
+//!    `generation` Acquire/Release, body fields Relaxed; the generation counter
+//!    fences the body. The trust chain's torn-read freedom holds across the
+//!    boundary **only** because these orderings are preserved (ADR-0030 Clause A);
+//! 3. the `Send`/`Sync` assertions (the backing is atomics over a stable mapping).
+//!
+//! No other `unsafe`. The `#[repr(C)]` layout the shim overlays is **byte-identical
+//! to the frozen `GovernorContractView`** — pinned by the compile-time assertions
+//! below against `kirra_contract_channel`'s own frozen offsets — so the mapped
+//! region *is* the canonical contract image; the shim maps and atomically accesses
+//! it, it never re-derives the layout.
+//!
+//! ## Host binding vs. target
+//!
+//! This crate ships the **host** binding, `PosixShmRegion` (`shm_open`/`mmap`,
+//! `MAP_SHARED`) — the testable stand-in for the QNX `HvRegion` (a hypervisor-
+//! mapped region), which binds the *same* traits with the same trust chain and
+//! only swaps the map primitive (ADR-0030 Clause B). [`PosixShmRegion`] is the
+//! read-write handle (guest); [`PosixShmReader`] is the **read-only** handle
+//! (governor) — read-only is enforced both by the `PROT_READ` mapping and at the
+//! type level (it has no [`ContractWriter`] impl), the R-HV-1 shape.
+
+use core::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::ffi::CString;
+use std::io;
+
+use kirra_contract_channel::{
+    ContractReader, ContractWriter, GovernorContractView, CANONICAL_IMAGE_LEN, MAX_COMMAND_BYTES,
+};
+
+/// The mapped region viewed as atomics. `#[repr(C)]`, field order + widths
+/// **identical to [`GovernorContractView`]**, so the mapped bytes are the frozen
+/// contract image and a peer that maps the same region interprets it identically.
+/// Atomics have the same size/alignment as their underlying integers, so the
+/// layout matches byte-for-byte (asserted below).
+#[repr(C)]
+struct AtomicView {
+    layout_version: AtomicU32,
+    magic: AtomicU32,
+    generation: AtomicU64,
+    sequence: AtomicU64,
+    publication_nanos: AtomicU64,
+    deadline_nanos: AtomicU64,
+    crc32: AtomicU32,
+    command_len: AtomicU32,
+    command: [AtomicU8; MAX_COMMAND_BYTES],
+}
+
+// The mapped-region layout IS the frozen contract layout — assert every offset
+// against GovernorContractView's own (themselves frozen in kirra-contract-channel).
+use core::mem::{align_of, offset_of, size_of};
+const _: () = assert!(offset_of!(AtomicView, layout_version) == offset_of!(GovernorContractView, layout_version));
+const _: () = assert!(offset_of!(AtomicView, magic) == offset_of!(GovernorContractView, magic));
+const _: () = assert!(offset_of!(AtomicView, generation) == offset_of!(GovernorContractView, generation));
+const _: () = assert!(offset_of!(AtomicView, sequence) == offset_of!(GovernorContractView, sequence));
+const _: () = assert!(offset_of!(AtomicView, publication_nanos) == offset_of!(GovernorContractView, publication_nanos));
+const _: () = assert!(offset_of!(AtomicView, deadline_nanos) == offset_of!(GovernorContractView, deadline_nanos));
+const _: () = assert!(offset_of!(AtomicView, crc32) == offset_of!(GovernorContractView, crc32));
+const _: () = assert!(offset_of!(AtomicView, command_len) == offset_of!(GovernorContractView, command_len));
+const _: () = assert!(offset_of!(AtomicView, command) == offset_of!(GovernorContractView, command));
+const _: () = assert!(size_of::<AtomicView>() == size_of::<GovernorContractView>());
+const _: () = assert!(size_of::<AtomicView>() == CANONICAL_IMAGE_LEN);
+const _: () = assert!(align_of::<AtomicView>() == align_of::<GovernorContractView>());
+
+/// Copy the region into an owned [`GovernorContractView`] — the reader side of
+/// the seqlock. Body fields Relaxed; the caller's Acquire load of `generation`
+/// (in `read_coherent_snapshot`) fences them. **Mirrors `InProcessRegion::copy_view`
+/// exactly** — the two carriers MUST share the memory model.
+fn read_view(v: &AtomicView) -> GovernorContractView {
+    let mut command = [0u8; MAX_COMMAND_BYTES];
+    for (i, slot) in command.iter_mut().enumerate() {
+        *slot = v.command[i].load(Ordering::Relaxed);
+    }
+    GovernorContractView {
+        layout_version: v.layout_version.load(Ordering::Relaxed),
+        magic: v.magic.load(Ordering::Relaxed),
+        generation: v.generation.load(Ordering::Relaxed),
+        sequence: v.sequence.load(Ordering::Relaxed),
+        publication_nanos: v.publication_nanos.load(Ordering::Relaxed),
+        deadline_nanos: v.deadline_nanos.load(Ordering::Relaxed),
+        crc32: v.crc32.load(Ordering::Relaxed),
+        command_len: v.command_len.load(Ordering::Relaxed),
+        command,
+    }
+}
+
+/// Write every field EXCEPT `generation` (the `publish` driver owns the counter).
+/// Relaxed; the Release store of `generation` publishes them. **Mirrors
+/// `InProcessRegion::store_body` exactly.**
+fn write_body(v: &AtomicView, view: &GovernorContractView) {
+    v.layout_version.store(view.layout_version, Ordering::Relaxed);
+    v.magic.store(view.magic, Ordering::Relaxed);
+    v.sequence.store(view.sequence, Ordering::Relaxed);
+    v.publication_nanos.store(view.publication_nanos, Ordering::Relaxed);
+    v.deadline_nanos.store(view.deadline_nanos, Ordering::Relaxed);
+    v.crc32.store(view.crc32, Ordering::Relaxed);
+    v.command_len.store(view.command_len, Ordering::Relaxed);
+    for (i, b) in view.command.iter().enumerate() {
+        v.command[i].store(*b, Ordering::Relaxed);
+    }
+}
+
+// --- the map primitive (the enumerated `unsafe`) --------------------------------
+
+/// Build a NUL-terminated POSIX shared-memory name. Callers pass a leading-slash
+/// name (e.g. `"/kirra-gov"`); an interior NUL is rejected.
+fn shm_name(name: &str) -> io::Result<CString> {
+    CString::new(name).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "shm name has interior NUL"))
+}
+
+/// `mmap` the named shared region and return the base pointer. `create` adds
+/// `O_CREAT | O_EXCL` + `ftruncate` to `CANONICAL_IMAGE_LEN` (a fresh, zeroed
+/// region). The fd is closed after mapping (the mapping persists).
+///
+/// SAFETY: pure FFI. On any failure we translate `errno` and (on create) unlink
+/// the partially-created object. The returned pointer is page-aligned (satisfies
+/// `AtomicView`'s 8-byte alignment) and spans exactly `CANONICAL_IMAGE_LEN` bytes.
+fn map_region(name: &CString, prot: libc::c_int, create: bool) -> io::Result<*mut AtomicView> {
+    let oflag = if create {
+        libc::O_CREAT | libc::O_EXCL | libc::O_RDWR
+    } else if prot & libc::PROT_WRITE != 0 {
+        libc::O_RDWR
+    } else {
+        libc::O_RDONLY
+    };
+    // SAFETY: FFI. name is a valid NUL-terminated C string for the call's duration.
+    let fd = unsafe { libc::shm_open(name.as_ptr(), oflag, 0o600) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if create {
+        // SAFETY: fd is a valid open descriptor from shm_open above.
+        if unsafe { libc::ftruncate(fd, CANONICAL_IMAGE_LEN as libc::off_t) } < 0 {
+            let e = io::Error::last_os_error();
+            // SAFETY: fd valid; name valid. Best-effort cleanup of the new object.
+            unsafe {
+                libc::close(fd);
+                libc::shm_unlink(name.as_ptr());
+            }
+            return Err(e);
+        }
+    }
+    // SAFETY: fd valid; length is the fixed region size; MAP_SHARED so writes are
+    // visible to every peer mapping the same object.
+    let addr = unsafe {
+        libc::mmap(core::ptr::null_mut(), CANONICAL_IMAGE_LEN, prot, libc::MAP_SHARED, fd, 0)
+    };
+    // SAFETY: fd valid; the mapping outlives the fd, so closing it now is correct.
+    unsafe { libc::close(fd) };
+    if addr == libc::MAP_FAILED {
+        let e = io::Error::last_os_error();
+        if create {
+            // SAFETY: name valid; drop the object we created but couldn't map.
+            unsafe { libc::shm_unlink(name.as_ptr()) };
+        }
+        return Err(e);
+    }
+    Ok(addr as *mut AtomicView)
+}
+
+/// The read-write carrier handle (the **guest** side): maps the region
+/// `PROT_READ | PROT_WRITE` and implements both [`ContractReader`] and
+/// [`ContractWriter`]. The creator (`create`) owns the object and `shm_unlink`s
+/// it on drop; a `open`ed handle does not.
+pub struct PosixShmRegion {
+    ptr: *mut AtomicView,
+    name: CString,
+    is_creator: bool,
+}
+
+// SAFETY: the only shared state is the `AtomicView` over the mapping, which is
+// `Sync` (all fields are atomics); the pointer is stable for the handle's life
+// and the mapping is `MAP_SHARED`. Moving/​sharing the handle across threads only
+// ever performs atomic accesses. Same rationale for `PosixShmReader`.
+unsafe impl Send for PosixShmRegion {}
+unsafe impl Sync for PosixShmRegion {}
+
+impl PosixShmRegion {
+    /// Create a fresh, zeroed region (fails if `name` already exists — `O_EXCL`).
+    /// The returned handle owns the object (unlinked on drop).
+    pub fn create(name: &str) -> io::Result<Self> {
+        let name = shm_name(name)?;
+        let ptr = map_region(&name, libc::PROT_READ | libc::PROT_WRITE, true)?;
+        Ok(Self { ptr, name, is_creator: true })
+    }
+
+    /// Open an existing region read-write (a second guest-side mapping). Does not
+    /// own the object.
+    pub fn open(name: &str) -> io::Result<Self> {
+        let name = shm_name(name)?;
+        let ptr = map_region(&name, libc::PROT_READ | libc::PROT_WRITE, false)?;
+        Ok(Self { ptr, name, is_creator: false })
+    }
+
+    /// SAFETY: `ptr` is a valid, aligned mapping of `size_of::<AtomicView>()`
+    /// bytes for the handle's lifetime, so the shared reference is sound.
+    fn view(&self) -> &AtomicView {
+        unsafe { &*self.ptr }
+    }
+}
+
+impl ContractReader for PosixShmRegion {
+    fn load_generation(&self) -> u64 {
+        self.view().generation.load(Ordering::Acquire)
+    }
+    fn copy_view(&self) -> GovernorContractView {
+        read_view(self.view())
+    }
+}
+
+impl ContractWriter for PosixShmRegion {
+    fn store_generation(&self, generation: u64) {
+        self.view().generation.store(generation, Ordering::Release);
+    }
+    fn store_body(&self, view: &GovernorContractView) {
+        write_body(self.view(), view);
+    }
+}
+
+impl Drop for PosixShmRegion {
+    fn drop(&mut self) {
+        // SAFETY: ptr is our mapping of CANONICAL_IMAGE_LEN bytes; name is valid.
+        unsafe {
+            libc::munmap(self.ptr as *mut libc::c_void, CANONICAL_IMAGE_LEN);
+            if self.is_creator {
+                libc::shm_unlink(self.name.as_ptr());
+            }
+        }
+    }
+}
+
+/// The **read-only** carrier handle (the **governor** side, R-HV-1): maps the
+/// region `PROT_READ` only and implements [`ContractReader`] **only** — it has no
+/// [`ContractWriter`] impl, so a governor cannot write the region at the type
+/// level, and the `PROT_READ` mapping enforces it at the OS level too.
+pub struct PosixShmReader {
+    ptr: *mut AtomicView,
+}
+
+// SAFETY: see `PosixShmRegion` — atomics over a stable `MAP_SHARED` mapping.
+unsafe impl Send for PosixShmReader {}
+unsafe impl Sync for PosixShmReader {}
+
+impl PosixShmReader {
+    /// Map an existing region read-only. The creator must already have created it.
+    pub fn open(name: &str) -> io::Result<Self> {
+        let name = shm_name(name)?;
+        let ptr = map_region(&name, libc::PROT_READ, false)?;
+        Ok(Self { ptr })
+    }
+
+    /// SAFETY: as `PosixShmRegion::view`.
+    fn view(&self) -> &AtomicView {
+        unsafe { &*self.ptr }
+    }
+}
+
+impl ContractReader for PosixShmReader {
+    fn load_generation(&self) -> u64 {
+        self.view().generation.load(Ordering::Acquire)
+    }
+    fn copy_view(&self) -> GovernorContractView {
+        read_view(self.view())
+    }
+}
+
+impl Drop for PosixShmReader {
+    fn drop(&mut self) {
+        // SAFETY: our own read-only mapping; readers never unlink the object.
+        unsafe { libc::munmap(self.ptr as *mut libc::c_void, CANONICAL_IMAGE_LEN) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kirra_contract_channel::{
+        publish, read_coherent_snapshot, validate, AcceptedWatermark, VehicleCommandPayload,
+        MAX_SNAPSHOT_RETRIES,
+    };
+    use std::sync::atomic::AtomicU32 as Counter;
+
+    // Unique shm name per test (process id + a counter) so parallel tests and
+    // reruns don't collide on a leftover object.
+    static SEQ: Counter = Counter::new(0);
+    fn unique_name(tag: &str) -> String {
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        format!("/kirra-hv-{}-{}-{}", tag, std::process::id(), n)
+    }
+
+    fn demo(seq: u64) -> VehicleCommandPayload {
+        VehicleCommandPayload {
+            linear_velocity_mps: 3.0 + seq as f64,
+            current_velocity_mps: 2.5,
+            delta_time_s: 0.1,
+            steering_angle_deg: -4.0,
+            current_steering_angle_deg: -3.5,
+        }
+    }
+
+    #[test]
+    fn two_rw_mappings_of_one_region_round_trip_a_command() {
+        let name = unique_name("rw");
+        let writer = PosixShmRegion::create(&name).expect("create");
+        let reader = PosixShmRegion::open(&name).expect("open"); // a SECOND mmap
+
+        let payload = demo(1);
+        let body = payload.to_view(0, 1, 0, u64::MAX / 2);
+        let committed = publish(&writer, 0, &body);
+        assert_eq!(committed, 2);
+
+        // Read through the independent mapping — real shared pages.
+        let snap = read_coherent_snapshot(&reader, MAX_SNAPSHOT_RETRIES).unwrap();
+        let mut wm = AcceptedWatermark::new();
+        validate(&snap, 0, &wm).expect("valid");
+        wm.record(&snap);
+        assert_eq!(VehicleCommandPayload::from_validated_view(&snap), Ok(payload));
+    }
+
+    #[test]
+    fn read_only_mapping_sees_what_the_guest_published() {
+        let name = unique_name("ro");
+        let guest = PosixShmRegion::create(&name).expect("create");
+        let governor = PosixShmReader::open(&name).expect("open ro"); // governor, R-HV-1
+
+        let payload = demo(7);
+        let body = payload.to_view(0, 42, 0, u64::MAX / 2);
+        publish(&guest, 0, &body);
+
+        let snap = read_coherent_snapshot(&governor, MAX_SNAPSHOT_RETRIES).unwrap();
+        let wm = AcceptedWatermark::new();
+        validate(&snap, 0, &wm).expect("valid");
+        assert_eq!(snap.sequence, 42);
+        assert_eq!(VehicleCommandPayload::from_validated_view(&snap), Ok(payload));
+    }
+
+    #[test]
+    fn a_monotonic_stream_is_accepted_in_order_over_shared_memory() {
+        let name = unique_name("stream");
+        let guest = PosixShmRegion::create(&name).expect("create");
+        let governor = PosixShmReader::open(&name).expect("open ro");
+        let mut wm = AcceptedWatermark::new();
+
+        let mut committed = 0u64;
+        for seq in 1..=4u64 {
+            let body = demo(seq).to_view(committed, seq, 0, u64::MAX / 2);
+            committed = publish(&guest, committed, &body);
+            let snap = read_coherent_snapshot(&governor, MAX_SNAPSHOT_RETRIES).unwrap();
+            validate(&snap, 0, &wm).expect("in order");
+            wm.record(&snap);
+            assert_eq!(snap.sequence, seq);
+            assert_eq!(VehicleCommandPayload::from_validated_view(&snap), Ok(demo(seq)));
+        }
+        assert_eq!(wm.last(), Some((8, 4)));
+    }
+
+    #[test]
+    fn creator_unlinks_on_drop() {
+        let name = unique_name("unlink");
+        {
+            let _guest = PosixShmRegion::create(&name).expect("create");
+        } // dropped → shm_unlink
+        // A fresh create with the same name must succeed (O_EXCL) → proves unlink.
+        let _again = PosixShmRegion::create(&name).expect("recreate after unlink");
+    }
+}

--- a/crates/kirra-hv-carrier/src/lib.rs
+++ b/crates/kirra-hv-carrier/src/lib.rs
@@ -142,6 +142,25 @@ fn map_region(name: &CString, prot: libc::c_int, create: bool) -> io::Result<*mu
     if fd < 0 {
         return Err(io::Error::last_os_error());
     }
+    if !create {
+        // Fail-closed size guard: mapping CANONICAL_IMAGE_LEN over a stale/smaller
+        // object of the same name would map fine and then SIGBUS on first access
+        // (a crash, not a reject). Verify the object is large enough BEFORE mmap.
+        // SAFETY: fd is a valid descriptor; fstat writes `st`.
+        let mut st: libc::stat = unsafe { core::mem::zeroed() };
+        if unsafe { libc::fstat(fd, &mut st) } < 0 {
+            let e = io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(e);
+        }
+        if (st.st_size as u64) < CANONICAL_IMAGE_LEN as u64 {
+            unsafe { libc::close(fd) };
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "shm region smaller than the frozen contract layout",
+            ));
+        }
+    }
     if create {
         // SAFETY: fd is a valid open descriptor from shm_open above.
         if unsafe { libc::ftruncate(fd, CANONICAL_IMAGE_LEN as libc::off_t) } < 0 {
@@ -159,10 +178,15 @@ fn map_region(name: &CString, prot: libc::c_int, create: bool) -> io::Result<*mu
     let addr = unsafe {
         libc::mmap(core::ptr::null_mut(), CANONICAL_IMAGE_LEN, prot, libc::MAP_SHARED, fd, 0)
     };
+    // Capture the mmap errno BEFORE close() can overwrite it.
+    let map_err = if addr == libc::MAP_FAILED {
+        Some(io::Error::last_os_error())
+    } else {
+        None
+    };
     // SAFETY: fd valid; the mapping outlives the fd, so closing it now is correct.
     unsafe { libc::close(fd) };
-    if addr == libc::MAP_FAILED {
-        let e = io::Error::last_os_error();
+    if let Some(e) = map_err {
         if create {
             // SAFETY: name valid; drop the object we created but couldn't map.
             unsafe { libc::shm_unlink(name.as_ptr()) };
@@ -366,6 +390,30 @@ mod tests {
             assert_eq!(VehicleCommandPayload::from_validated_view(&snap), Ok(demo(seq)));
         }
         assert_eq!(wm.last(), Some((8, 4)));
+    }
+
+    #[test]
+    fn open_rejects_a_too_small_region_fail_closed() {
+        // A stale/malformed object one byte too small must be REFUSED before mmap
+        // (else CANONICAL_IMAGE_LEN accesses would SIGBUS). Create it raw.
+        let name = unique_name("small");
+        let cname = std::ffi::CString::new(name.clone()).unwrap();
+        // SAFETY: FFI; fd is checked and closed.
+        unsafe {
+            let fd = libc::shm_open(cname.as_ptr(), libc::O_CREAT | libc::O_EXCL | libc::O_RDWR, 0o600);
+            assert!(fd >= 0, "raw shm_open");
+            assert_eq!(
+                libc::ftruncate(fd, (CANONICAL_IMAGE_LEN - 1) as libc::off_t),
+                0,
+                "ftruncate too-small"
+            );
+            libc::close(fd);
+        }
+        // Both handles fail closed rather than map a SIGBUS-prone region.
+        assert!(PosixShmRegion::open(&name).is_err(), "RW open must reject too-small");
+        assert!(PosixShmReader::open(&name).is_err(), "RO open must reject too-small");
+        // SAFETY: cleanup the raw object.
+        unsafe { libc::shm_unlink(cname.as_ptr()) };
     }
 
     #[test]

--- a/crates/kirra-hv-carrier/tests/two_process.rs
+++ b/crates/kirra-hv-carrier/tests/two_process.rs
@@ -1,0 +1,70 @@
+// Two-process host integration test (ADR-0030 Clause B): a guest process (this
+// test) creates + publishes into a POSIX shared region; a SEPARATE governor
+// process (the `shm_peer` bin) maps it READ-ONLY and validates+decodes the
+// command. This is the real cross-address-space proof the in-process reference
+// carrier (InProcessRegion) cannot give — the step the QNX HvRegion then only
+// swaps the map primitive on.
+
+use std::process::Command;
+
+use kirra_contract_channel::{publish, VehicleCommandPayload};
+use kirra_hv_carrier::PosixShmRegion;
+
+fn demo(seq: u64) -> VehicleCommandPayload {
+    VehicleCommandPayload {
+        linear_velocity_mps: 3.0 + seq as f64,
+        current_velocity_mps: 2.5,
+        delta_time_s: 0.1,
+        steering_angle_deg: -4.0,
+        current_steering_angle_deg: -3.5,
+    }
+}
+
+fn shm_peer() -> Command {
+    // Cargo exposes the peer bin's path to integration tests.
+    Command::new(env!("CARGO_BIN_EXE_shm_peer"))
+}
+
+#[test]
+fn governor_process_reads_the_guest_process_command() {
+    let name = format!("/kirra-hv-2p-{}", std::process::id());
+    // Guest: create the region and publish a known command BEFORE spawning the
+    // reader (latest-value-wins; the value persists in the mapping).
+    let guest = PosixShmRegion::create(&name).expect("create");
+    let payload = demo(5); // linear_velocity_mps = 8.0, sequence 5
+    let body = payload.to_view(0, 5, 0, u64::MAX / 2);
+    publish(&guest, 0, &body);
+
+    // Governor process maps read-only and must validate/decode/match.
+    let status = shm_peer()
+        .arg(&name)
+        .arg("5")
+        .arg(format!("{}", payload.linear_velocity_mps))
+        .status()
+        .expect("spawn shm_peer");
+    assert!(status.success(), "peer should accept the published command: {status:?}");
+
+    // `guest` still owns the region here; it unlinks on drop after the peer ran.
+    drop(guest);
+}
+
+#[test]
+fn governor_process_rejects_a_sequence_mismatch() {
+    // Negative control: the peer expecting the WRONG sequence must fail closed,
+    // proving the test genuinely reads across the boundary (not a vacuous pass).
+    let name = format!("/kirra-hv-2p-neg-{}", std::process::id());
+    let guest = PosixShmRegion::create(&name).expect("create");
+    let payload = demo(1);
+    let body = payload.to_view(0, 1, 0, u64::MAX / 2);
+    publish(&guest, 0, &body);
+
+    let status = shm_peer()
+        .arg(&name)
+        .arg("999") // wrong sequence
+        .arg(format!("{}", payload.linear_velocity_mps))
+        .status()
+        .expect("spawn shm_peer");
+    assert!(!status.success(), "peer must reject a sequence mismatch");
+
+    drop(guest);
+}


### PR DESCRIPTION
## Why

First **L3 last-mile increment** (ADR-0030 Clause A/B). The L3 software path (L3.1–L3.3) runs the frozen contract host-in-process over `InProcessRegion`; this adds the **real cross-partition carrier** — the seam bound to a memory-mapped shared region — so the same `GovernorContractView` + seqlock trust chain runs across a real address-space boundary.

## What

New crate **`kirra-hv-carrier`** — **the only crate in the L3 path that is NOT `#[forbid(unsafe_code)]`** (the ADR-0006 **Clause 3** integration boundary), with a bounded, enumerated `unsafe` budget:
1. the map (`shm_open`/`mmap`, `ftruncate` on create) — exactly `size_of::<GovernorContractView>()` bytes (R-HV-2);
2. atomic field accesses over the mapped bytes reproducing `InProcessRegion`'s memory model **exactly** (`generation` Acquire/Release, body Relaxed — the seqlock ordering that keeps torn-read freedom across the boundary);
3. `Send`/`Sync` (atomics over a stable `MAP_SHARED` mapping).

The `#[repr(C)] AtomicView` overlay is **byte-identical to `GovernorContractView`** — compile-time asserted against its frozen offsets — so the mapped region *is* the canonical contract image; the shim maps + atomically accesses it, never re-derives the layout.

- **`PosixShmRegion`** (guest, read-write) — `ContractReader` + `ContractWriter`.
- **`PosixShmReader`** (governor, read-only) — `ContractReader` **only**: the R-HV-1 shape, enforced at the **type** level (no writer impl) *and* the **OS** level (`PROT_READ`).

The QNX `HvRegion` binds the same traits / same trust chain, only swapping the map primitive (ADR-0030 Clause B, follow-up).

## Tests (host — no QNX needed)

- **4 unit**: two RW mappings of one region round-trip a command; the RO governor mapping reads what the guest published; a monotonic stream is accepted in order over shared memory; the creator `shm_unlink`s on drop.
- **2 two-PROCESS integration** (`tests/two_process.rs` + the `shm_peer` bin): a guest process publishes into a POSIX shared region, a **separate** governor process maps it read-only and validates+decodes — the real cross-address-space proof `InProcessRegion` can't give — plus a sequence-mismatch negative control.

## Latency evidence — closes the measurement gap

`shm_latency` times the governor read path over `MAP_SHARED` (same 176 B payload + percentile method as the iceoryx2 `latency_bench`). Host-INDICATIVE run:

```
path                            p50_ns    p99_ns   p999_ns
shm read_coherent_snapshot          60       187      2569
shm read+validate+decode           297       485      3797
```

| path | p50 |
|---|---|
| in-process floor | ~28 ns |
| **shm read_coherent_snapshot** | **~60 ns** |
| iceoryx2 zero-copy | ~309 ns |
| socket+serde (UDP proxy) | ~976 ns |

The raw-SHM seqlock read is at the **in-process-floor class — ~5× tighter than iceoryx2's pub/sub handoff** — because for a single latest-value slot it's the minimal carrier (no queue/loan/discovery). And the ~60 ns is transport-only, whereas the ~297 ns row already *includes* CRC+validate+decode (iceoryx2's 309 ns does not). This is the **measured evidence** behind ADR-0006's Clause-2 choice of a frozen layout over SHM rather than iceoryx2. (The ms-scale `max` is host jitter; certified = QNX/FIFO, #274.)

## Verification

`cargo test -p kirra-hv-carrier` (4 unit + 2 two-process) pass; `cargo clippy -p kirra-hv-carrier --all-targets -- -D warnings` clean. Adds the crate to the workspace members. (`cargo check --workspace` didn't finish in the local 2-min window — big tree — but the crate builds standalone and is purely additive; CI runs the full workspace.)

## Scope

The one audited `unsafe` unit; everything above stays `forbid-unsafe`. No boundary weakened. Follow-ups (ADR-0030): guest `node.rs` call-site, governor poll-loop + release-token bridge, and the QNX `HvRegion` binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_