### PR TITLE
ci: harden the ros2 adapter build against slow/stalling apt mirrors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,9 +510,25 @@ jobs:
     # Jazzy targets Ubuntu 24.04 (Noble), so pin the runner (the rest of the
     # workflow runs on ubuntu-latest, which is fine for the non-ROS jobs).
     runs-on: ubuntu-24.04
-    timeout-minutes: 40
+    # 60 (was 40): the 40-min cancellations on this job were setup-ros's apt
+    # install crawling on a degraded mirror, hitting the wall exactly. With the
+    # apt hardening below (bounded per-connection timeouts + IPv4) a slow-but-
+    # progressing install now has headroom instead of timing out.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
+      - name: Harden apt for slow/stalling mirrors (flaky ros2 build)
+        # The timeouts on this job were setup-ros's apt install crawling on a
+        # degraded azure.archive.ubuntu.com mirror (kB/s, per-connection stalls) —
+        # NOT the ros2-apt-source rate-limit the retry below covers. Drop an apt
+        # config BEFORE setup-ros so its apt-get honors it: bounded per-connection
+        # timeouts + retries turn a wedged socket into a fast reconnect, and
+        # ForceIPv4 avoids the slow/blackholed IPv6 path that commonly causes slow
+        # apt on GitHub runners. If this still recurs, the durable fix is a
+        # prebuilt ros:jazzy container (avoids the ROS apt install entirely).
+        run: |
+          printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::ForceIPv4 "true";\n' \
+            | sudo tee /etc/apt/apt.conf.d/99-kirra-ci-mirror
       - id: setup_ros
         uses: ros-tooling/setup-ros@v0.7
         with:


### PR DESCRIPTION
## Why

The `ros2 adapter build (--features ros2)` job has been intermittently cancelled after ~40 minutes. The logs show the cause: **setup-ros's apt install crawling on a degraded `azure.archive.ubuntu.com` mirror** (kB/s throughput, ~7 s per small package, per-connection stalls) until it hit `timeout-minutes: 40` exactly. That's a *different* failure mode than the `ros2-apt-source` version rate-limit the existing `continue-on-error` retry already handles — retrying a fast-failing action doesn't help a slow-but-progressing download.

## What

- **Drop an apt config before setup-ros** (so its `apt-get` honors it):
  - `Acquire::Retries "5"` + `Acquire::http/https::Timeout "30"` — a wedged socket times out after 30 s and reconnects (often to a healthier endpoint) instead of hanging for minutes.
  - `Acquire::ForceIPv4 "true"` — avoids the slow/blackholed IPv6 route that is a common root cause of slow apt on GitHub/Azure runners.
- **Bump `timeout-minutes` 40 → 60** so a slow-but-progressing install has headroom rather than dying at the wall.

## Notes

- CI-only; no source change. YAML validated (`yaml.safe_load`).
- Because this is a same-repo PR, the hardened job **runs on this PR** — so this is a live test of the fix.
- If the flake recurs even with this, the durable fix (noted inline) is running the job in a **prebuilt `ros:jazzy` container**, which avoids the ROS apt install entirely — a bigger change deferred until proven necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_