### PR TITLE
feat(l3): wire the guest producer into the ROS node fast loop (ADR-0030 incr. 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,6 +2164,7 @@ dependencies = [
  "futures",
  "kirra-contract-channel",
  "kirra-core",
+ "kirra-hv-carrier",
  "kirra-trajectory",
  "parko-core",
  "r2r",

--- a/crates/kirra-ros2-adapter/Cargo.toml
+++ b/crates/kirra-ros2-adapter/Cargo.toml
@@ -51,7 +51,7 @@ default = []
 # This feature pulls NO C++ / no cxx / no lanelet2 — that is the separate
 # `lanelet2` feature below (the perception governance path is independent of
 # the map/corridor layer). See README.
-ros2 = ["dep:tokio", "dep:r2r", "dep:tracing-subscriber", "dep:futures", "dep:reqwest", "dep:bytes", "kirra-core/capture"]
+ros2 = ["dep:tokio", "dep:r2r", "dep:tracing-subscriber", "dep:futures", "dep:reqwest", "dep:bytes", "dep:kirra-hv-carrier", "kirra-core/capture"]
 
 # Enable the real Lanelet2CorridorSource — a cxx/C++ wrap of `lanelet2_core`'s
 # boost::serialization deserializer (`fromBinMsg`). Implies `ros2` (the only
@@ -99,6 +99,10 @@ parko-core        = { path = "../../parko/crates/parko-core" }
 # forbid-unsafe, so it adds nothing heavy to the default (non-ros2) adapter build.
 # The guest-side producer (`contract_producer.rs`) publishes proposals over it.
 kirra-contract-channel = { path = "../kirra-contract-channel" }
+# L3 incr. 2 — the POSIX-SHM cross-partition carrier (ADR-0030). Only the
+# ros2-gated node.rs guest producer uses it, so it's optional + pulled by the
+# `ros2` feature; the default (non-ros2) adapter build never links it.
+kirra-hv-carrier = { path = "../kirra-hv-carrier", optional = true }
 # R1: the lean trajectory CHECKER (validation / prediction / perception_redundancy /
 # config / AcceptedTrajectory+EgoOdom). The adapter re-exports its modules so the
 # ros2/lanelet2 node code keeps using `crate::{validation,prediction,...}` unchanged.

--- a/crates/kirra-ros2-adapter/src/contract_producer.rs
+++ b/crates/kirra-ros2-adapter/src/contract_producer.rs
@@ -19,11 +19,13 @@
 // — without a sourced ROS 2 / r2r toolchain. The ros2-gated `node.rs` fast-loop
 // call-site and the hypervisor-mapped `ContractWriter` binding land in L3.3.
 
-// Allowed unconditionally for now: the only non-test caller is the ros2-gated
-// node.rs fast loop, which lands in L3.3, so the module is dead under BOTH the
-// default AND the `--features ros2` build until then (a `cfg_attr(not(feature = "ros2"), …)`
-// would leave the ros2 build unsilenced). L3.3 tightens this to
-// `cfg_attr(not(feature = "ros2"), allow(dead_code))` once the caller exists.
+// Allowed unconditionally: under the default (non-ros2) build the ONLY consumer
+// is the ros2-gated node.rs fast loop (incr. 2 wired it), so the whole module is
+// dead there; and even under `--features ros2` the node exercises
+// `proposal_payload` + `ProposalSequencer::{new, publish_to}` but not the
+// introspection accessors (`committed_generation` / `next_sequence`, used only by
+// tests). A `cfg_attr(not(feature = "ros2"), …)` would therefore leave those two
+// accessors unsilenced under ros2, so the blanket allow stays.
 #![allow(dead_code)]
 
 use kirra_contract_channel::{publish, ContractWriter, VehicleCommandPayload};

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -38,7 +38,10 @@ use std::time::Duration;
 
 use tokio::sync::mpsc;
 
+use kirra_hv_carrier::PosixShmRegion;
+
 pub use crate::control_ingress::IngressControlCommand;
+use crate::contract_producer::{proposal_payload, ProposalSequencer};
 use crate::control_ingress::{fail_closed_control_command, parse_control_command_json};
 use crate::corridor::CorridorSource;
 use crate::state::{
@@ -160,6 +163,23 @@ fn wall_clock_ms() -> u64 {
 /// audit/correlation record timestamps ONLY. Hot path — inlined.
 #[inline]
 fn now_ms_fresh() -> u64 { crate::state::monotonic_now_ms() }
+
+/// Nominal fast-loop control cycle (100 Hz → 10 ms) as seconds — the
+/// `delta_time_s` stamped on a published cross-partition proposal's kinematic
+/// command (ADR-0030 incr. 2).
+const CONTROL_CYCLE_S: f64 = 0.01;
+
+/// Freshness budget added to a published proposal's boundary-clock publication
+/// time to form its `deadline_nanos` (2 control cycles). The governor rejects a
+/// snapshot whose deadline has passed (HVCHAN §3); a host stand-in pending the
+/// #274 FTTI budget.
+const CONTRACT_DEADLINE_BUDGET_NS: u64 = 20_000_000;
+
+/// Monotonic nanoseconds — a HOST stand-in for the boundary clock domain
+/// (AOU-TIMESYNC-001), derived from the same monotonic ms source as the freshness
+/// checks. The real boundary-clock primitive is QNX target work (#274/#278).
+#[inline]
+fn now_ns_fresh() -> u64 { now_ms_fresh().saturating_mul(1_000_000) }
 
 /// Trajectory ingress payload. The subscription callback (Phase 2B —
 /// when Lanelet2 wiring lands) deserializes
@@ -815,6 +835,26 @@ pub async fn run_adapter(
         mpsc::channel::<OutgoingControlCommand>(CONTROL_CHANNEL_CAPACITY);
     let fast_state = Arc::clone(&state);
     let staleness_timeout_ms = subscription_staleness_timeout_ms();
+    // ADR-0030 Clause C (incr. 2) — OPT-IN guest producer. When
+    // KIRRA_CONTRACT_SHM_NAME is set, additively publish each incoming proposal
+    // across the frozen cross-partition contract for the L3.3 governor consumer to
+    // bound. Unset → no contract publishing, byte-identical to prior behavior.
+    // Best-effort: a publish issue NEVER affects the gated ~/output/control_cmd
+    // path. (Host PosixShmRegion carrier; the QNX HvRegion binds the same seam.)
+    let mut contract_writer: Option<PosixShmRegion> = None;
+    let mut contract_seq: Option<ProposalSequencer> = None;
+    if let Ok(name) = std::env::var("KIRRA_CONTRACT_SHM_NAME") {
+        match PosixShmRegion::create(&name).or_else(|_| PosixShmRegion::open(&name)) {
+            Ok(w) => {
+                tracing::info!(shm = %name, "contract producer: publishing proposals to the cross-partition channel");
+                contract_writer = Some(w);
+                contract_seq = Some(ProposalSequencer::new());
+            }
+            Err(e) => {
+                tracing::error!(shm = %name, error = %e, "contract producer: shm map failed; proposals NOT published (gated output unaffected)");
+            }
+        }
+    }
     tokio::spawn(async move {
         let mut rx = control_rx;
         while let Some(in_cmd) = rx.recv().await {
@@ -888,6 +928,33 @@ pub async fn run_adapter(
                     asset_id = %in_cmd.asset_id,
                     elapsed_us = elapsed_us,
                     "fast_loop_wcet_exceeded"
+                );
+            }
+
+            // ADR-0030 Clause C — additively publish the DOER's proposal across
+            // the frozen contract for the governor to bound (L3.3). Placed AFTER
+            // the conformance WCET window above so it never perturbs that metric;
+            // best-effort — it can't affect the gated ~/output/control_cmd path.
+            if let (Some(writer), Some(sequencer)) =
+                (contract_writer.as_ref(), contract_seq.as_mut())
+            {
+                // Current velocity from ego odom. The guest has NO steering
+                // measurement (EgoOdom carries yaw rate, not steering angle), so
+                // the steering-rate baseline is the desired angle (rate 0) — the
+                // AUTHORITATIVE current state is governor-measured on the real path
+                // (HVCHAN R-HV-3); this guest field is untrusted regardless.
+                let payload = proposal_payload(
+                    &in_cmd,
+                    odom.linear_x_mps,
+                    in_cmd.steering_angle_rad.to_degrees(),
+                    CONTROL_CYCLE_S,
+                );
+                let pub_ns = now_ns_fresh();
+                let _ = sequencer.publish_to(
+                    writer,
+                    &payload,
+                    pub_ns,
+                    pub_ns.saturating_add(CONTRACT_DEADLINE_BUDGET_NS),
                 );
             }
         }

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -844,14 +844,21 @@ pub async fn run_adapter(
     let mut contract_writer: Option<PosixShmRegion> = None;
     let mut contract_seq: Option<ProposalSequencer> = None;
     if let Ok(name) = std::env::var("KIRRA_CONTRACT_SHM_NAME") {
-        match PosixShmRegion::create(&name).or_else(|_| PosixShmRegion::open(&name)) {
+        // OPEN an existing region — the guest never CREATES/OWNS it. The region is
+        // provided by the platform (the QNX hypervisor for HvRegion; a host setup
+        // step / the governor side for PosixShmRegion). If the guest owned it, a
+        // node restart would shm_unlink the object out from under a long-lived
+        // governor still mapped to it, silently disconnecting the reader from new
+        // publishes. Absent region → log + don't publish (fail-safe; the gated
+        // ~/output/control_cmd path is unaffected).
+        match PosixShmRegion::open(&name) {
             Ok(w) => {
                 tracing::info!(shm = %name, "contract producer: publishing proposals to the cross-partition channel");
                 contract_writer = Some(w);
                 contract_seq = Some(ProposalSequencer::new());
             }
             Err(e) => {
-                tracing::error!(shm = %name, error = %e, "contract producer: shm map failed; proposals NOT published (gated output unaffected)");
+                tracing::warn!(shm = %name, error = %e, "contract producer: region not available; proposals NOT published (gated output unaffected)");
             }
         }
     }


### PR DESCRIPTION
## Why

L3 last-mile **increment 2** (ADR-0030 Clause C): the ros2-gated `node.rs` fast loop now drives the L3.2 guest producer over the real cross-partition carrier (incr. 1's `kirra-hv-carrier`), so the guest publishes each proposal for the L3.3 governor consumer to bound. This is the guest-side call-site the whole L3 chain was building toward.

## Design — opt-in and fail-safe

- **Gated on `KIRRA_CONTRACT_SHM_NAME`.** Unset → **no contract publishing; build and runtime behavior byte-identical to before** (the producer isn't instantiated). Set → map a `PosixShmRegion` (create-or-open) + hold a `ProposalSequencer`.
- **Additive + best-effort.** The publish is placed **after** the conformance WCET window (never perturbs that metric), and a map/publish issue **never** affects the gated `~/output/control_cmd` path.
- Per `IngressControlCommand`: `proposal_payload(in_cmd, current velocity from EgoOdom, steering baseline, control-cycle Δt)` → `ProposalSequencer::publish_to` with boundary-domain timestamps.

## Honesty notes (documented inline)

- `EgoOdom` carries **yaw rate, not steering angle**, so the steering-**rate** baseline is the desired angle (rate 0). The *authoritative* current state is **governor-measured** on the real path (HVCHAN R-HV-3) — the guest field is untrusted regardless.
- Timestamps are a **host monotonic stand-in** for the boundary clock domain (AOU-TIMESYNC-001); the real primitive is QNX target work (#274/#278).

## Scope / build

- `kirra-hv-carrier` is an **optional** adapter dep pulled only by the `ros2` feature — the default (non-ros2) build never links it.
- `contract_producer` keeps its blanket `allow(dead_code)` (its introspection accessors remain test-only, so a `cfg_attr(not(ros2))` form would warn under ros2) — comment updated to explain.
- **Default (non-ros2) build: 47 tests + clippy clean** locally. The **ros2 path (`node.rs`) is compiled by the `ros2 adapter build` CI job** (now de-flaked to ~5 min via #745) — that job is the compile validator for this PR, since node.rs needs a sourced ROS toolchain not available locally.

## Remaining L3 last-mile (ADR-0030)

- incr. 3 — governor poll-loop + `is_actuatable` gate + the digest/release bridge
- incr. 4 — the QNX `HvRegion` binding + #279 hypervisor-layer faults (target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_