### PR TITLE
feat(l3): governor decide() + two-process producer→governor test (ADR-0030 incr. 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,7 @@ name = "kirra-hv-carrier"
 version = "0.1.0"
 dependencies = [
  "kirra-contract-channel",
+ "kirra-core",
  "libc",
 ]
 

--- a/crates/kirra-core/src/contract_consumer.rs
+++ b/crates/kirra-core/src/contract_consumer.rs
@@ -102,22 +102,97 @@ pub fn consume_and_bound<R: ContractReader>(
     contract: &VehicleKinematicsContract,
     max_retries: u32,
 ) -> GovernorVerdict {
+    match receive(reader, watermark, now_nanos, max_retries) {
+        Received::Command(cmd) => GovernorVerdict::Bounded(validate_vehicle_command(&cmd, contract)),
+        Received::Snapshot(f) => GovernorVerdict::Snapshot(f),
+        Received::Contract(f) => GovernorVerdict::Contract(f),
+        Received::Codec(e) => GovernorVerdict::Codec(e),
+    }
+}
+
+/// The receive stage shared by [`consume_and_bound`] and [`decide`]: the
+/// transport half of the pipeline (snapshot → validate → decode), returning the
+/// decoded command or the first fault. On success the monotonic `watermark`
+/// advances (HVCHAN-001 §3.1) — before any kinematic bound, so receipt (not
+/// actuation) governs sequence advancement. A fault leaves the watermark
+/// untouched. Kept private so there is ONE transport pipeline, never two to drift.
+enum Received {
+    Command(ProposedVehicleCommand),
+    Snapshot(SnapshotFault),
+    Contract(ContractFault),
+    Codec(CommandCodecError),
+}
+
+fn receive<R: ContractReader>(
+    reader: &R,
+    watermark: &mut AcceptedWatermark,
+    now_nanos: u64,
+    max_retries: u32,
+) -> Received {
     let snapshot = match read_coherent_snapshot(reader, max_retries) {
         Ok(view) => view,
-        Err(fault) => return GovernorVerdict::Snapshot(fault),
+        Err(fault) => return Received::Snapshot(fault),
     };
     if let Err(fault) = validate(&snapshot, now_nanos, watermark) {
-        return GovernorVerdict::Contract(fault);
+        return Received::Contract(fault);
     }
     let payload = match VehicleCommandPayload::from_validated_view(&snapshot) {
         Ok(p) => p,
-        Err(err) => return GovernorVerdict::Codec(err),
+        Err(err) => return Received::Codec(err),
     };
-    // Transport + codec passed: the command was validly received. Advance the
-    // monotonic watermark now (HVCHAN-001 §3.1), before the kinematic bound —
-    // the bound decides actuation, not receipt.
     watermark.record(&snapshot);
-    GovernorVerdict::Bounded(validate_vehicle_command(&payload.into(), contract))
+    Received::Command(payload.into())
+}
+
+/// The governor's actuation decision for one cycle — the fail-closed reduction of
+/// a [`GovernorVerdict`] to what the actuator does.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GovernorOutcome {
+    /// Actuate this command, with the kinematic bound ALREADY APPLIED (a `Clamp`
+    /// verdict returns the clamped value; `Allow` returns the command as received).
+    Actuate(ProposedVehicleCommand),
+    /// Issue the MRC safe-stop: any transport/codec fault, or a kinematic
+    /// `DenyBreach`. The governor never actuates a guest command in this case.
+    SafeStop,
+}
+
+/// Consume one proposal and reduce it to an actuation decision, fail-closed:
+/// `receive` → `validate_vehicle_command` → apply the verdict. `Allow`/`Clamp*`
+/// become [`GovernorOutcome::Actuate`] (the clamp already folded into the command);
+/// a `DenyBreach` or ANY snapshot/contract/codec fault becomes
+/// [`GovernorOutcome::SafeStop`]. This is the governor loop's per-cycle step; the
+/// watermark advances exactly as in [`consume_and_bound`] (they share `receive`).
+///
+/// `#[must_use]`: the outcome gates actuation vs. MRC — dropping it is a safety bug.
+#[must_use]
+pub fn decide<R: ContractReader>(
+    reader: &R,
+    watermark: &mut AcceptedWatermark,
+    now_nanos: u64,
+    contract: &VehicleKinematicsContract,
+    max_retries: u32,
+) -> GovernorOutcome {
+    let cmd = match receive(reader, watermark, now_nanos, max_retries) {
+        Received::Command(cmd) => cmd,
+        // Any transport/codec fault → fail closed to the safe stop.
+        Received::Snapshot(_) | Received::Contract(_) | Received::Codec(_) => {
+            return GovernorOutcome::SafeStop
+        }
+    };
+    match validate_vehicle_command(&cmd, contract) {
+        EnforceAction::Allow => GovernorOutcome::Actuate(cmd),
+        EnforceAction::ClampLinear(v) => {
+            let mut c = cmd;
+            c.linear_velocity_mps = v;
+            GovernorOutcome::Actuate(c)
+        }
+        EnforceAction::ClampSteering(s) => {
+            let mut c = cmd;
+            c.steering_angle_deg = s;
+            GovernorOutcome::Actuate(c)
+        }
+        EnforceAction::DenyBreach(_) => GovernorOutcome::SafeStop,
+    }
 }
 
 #[cfg(test)]
@@ -285,6 +360,66 @@ mod tests {
         let verdict = consume_and_bound(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES);
         assert!(matches!(verdict, GovernorVerdict::Snapshot(_)));
         assert!(!verdict.is_actuatable());
+        assert_eq!(wm.last(), None);
+    }
+
+    // ---- decide() — the actuate-vs-safe-stop reduction ---------------------
+
+    #[test]
+    fn decide_actuates_an_in_envelope_command_unchanged() {
+        let region = InProcessRegion::new();
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let mut wm = AcceptedWatermark::new();
+
+        publish_payload(&region, 0, 1, 10_000, &in_envelope());
+        let outcome = decide(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES);
+        // Allow → Actuate with the command exactly as received.
+        assert_eq!(outcome, GovernorOutcome::Actuate(in_envelope().into()));
+        assert_eq!(wm.last(), Some((2, 1))); // watermark advanced, like consume_and_bound
+    }
+
+    #[test]
+    fn decide_bounds_an_over_envelope_command_below_the_proposal() {
+        let region = InProcessRegion::new();
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let mut wm = AcceptedWatermark::new();
+
+        // 50 m/s desired, way over the 35 m/s ceiling.
+        let over = VehicleCommandPayload { linear_velocity_mps: 50.0, ..in_envelope() };
+        publish_payload(&region, 0, 1, 10_000, &over);
+        match decide(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES) {
+            // If actuated, the clamp MUST have folded the speed below the proposal.
+            GovernorOutcome::Actuate(c) => {
+                assert!(c.linear_velocity_mps < 50.0, "over-speed must be clamped, got {}", c.linear_velocity_mps)
+            }
+            // A DenyBreach → SafeStop is also an acceptable fail-closed outcome.
+            GovernorOutcome::SafeStop => {}
+        }
+    }
+
+    #[test]
+    fn decide_safe_stops_on_an_expired_deadline() {
+        let region = InProcessRegion::new();
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let mut wm = AcceptedWatermark::new();
+
+        publish_payload(&region, 0, 1, 1_000, &in_envelope()); // deadline 1_000
+        let outcome = decide(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES);
+        assert_eq!(outcome, GovernorOutcome::SafeStop); // now > deadline → fail closed
+        assert_eq!(wm.last(), None);
+    }
+
+    #[test]
+    fn decide_safe_stops_on_a_non_finite_payload() {
+        let region = InProcessRegion::new();
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let mut wm = AcceptedWatermark::new();
+
+        let mut bad = in_envelope();
+        bad.linear_velocity_mps = f64::INFINITY;
+        publish_payload(&region, 0, 1, 10_000, &bad);
+        let outcome = decide(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES);
+        assert_eq!(outcome, GovernorOutcome::SafeStop); // codec fail-closed
         assert_eq!(wm.last(), None);
     }
 }

--- a/crates/kirra-core/src/contract_consumer.rs
+++ b/crates/kirra-core/src/contract_consumer.rs
@@ -384,16 +384,23 @@ mod tests {
         let contract = VehicleKinematicsContract::nominal_reference_profile();
         let mut wm = AcceptedWatermark::new();
 
-        // 50 m/s desired, way over the 35 m/s ceiling.
-        let over = VehicleCommandPayload { linear_velocity_mps: 50.0, ..in_envelope() };
+        // 50 m/s desired over the 35 m/s ceiling, current == desired (accel 0) so
+        // ONLY the absolute speed bound trips → the nominal contract CLAMPS.
+        let over = VehicleCommandPayload {
+            linear_velocity_mps: 50.0,
+            current_velocity_mps: 50.0,
+            ..in_envelope()
+        };
         publish_payload(&region, 0, 1, 10_000, &over);
         match decide(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES) {
-            // If actuated, the clamp MUST have folded the speed below the proposal.
-            GovernorOutcome::Actuate(c) => {
-                assert!(c.linear_velocity_mps < 50.0, "over-speed must be clamped, got {}", c.linear_velocity_mps)
-            }
-            // A DenyBreach → SafeStop is also an acceptable fail-closed outcome.
-            GovernorOutcome::SafeStop => {}
+            // ClampLinear → Actuate the clamped command (asserting Actuate, not
+            // accepting SafeStop, so a clamping regression can't hide here).
+            GovernorOutcome::Actuate(c) => assert!(
+                c.linear_velocity_mps <= 35.0, // clamped into the 35 m/s envelope (< the 50 proposal)
+                "over-speed must be clamped into the envelope, got {}",
+                c.linear_velocity_mps
+            ),
+            GovernorOutcome::SafeStop => panic!("nominal over-speed must clamp (Actuate), not safe-stop"),
         }
     }
 

--- a/crates/kirra-core/src/kinematics_contract.rs
+++ b/crates/kirra-core/src/kinematics_contract.rs
@@ -170,7 +170,7 @@ impl VehicleKinematicsContract {
 
 /// A proposed actuator command from the motion planning stack, with the current
 /// kinematic state required to compute rate-of-change invariants.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ProposedVehicleCommand {
     /// Desired forward velocity at end of this time step (m/s).
     /// Negative values indicate reverse motion.

--- a/crates/kirra-hv-carrier/Cargo.toml
+++ b/crates/kirra-hv-carrier/Cargo.toml
@@ -25,3 +25,11 @@ kirra-contract-channel = { path = "../kirra-contract-channel" }
 # this crate is a host (Linux/QNX) integration shim, never built for a bare
 # no_std target.
 libc = "0.2"
+
+[dev-dependencies]
+# The two-process GOVERNOR test (tests/governor_two_process.rs) runs the L3.3
+# governor `decide` (kirra-core) over a PosixShmReader while a separate guest
+# process publishes. A DEV-dependency only — it does NOT enter the carrier's real
+# dependency tree, so the crate's cross-partition TCB stays the frozen layout +
+# this mapping shim (ADR-0006 Clause 2 / ADR-0030).
+kirra-core = { path = "../kirra-core" }

--- a/crates/kirra-hv-carrier/src/bin/guest_peer.rs
+++ b/crates/kirra-hv-carrier/src/bin/guest_peer.rs
@@ -1,0 +1,53 @@
+// guest_peer — the GUEST-side writer peer for the two-process governor test
+// (tests/governor_two_process.rs). A separate OS process that OPENS the shared
+// region (created by the governor/test process) and publishes one proposal, so
+// the governor process reads + validates + decodes + BOUNDS a command that
+// genuinely crossed an address-space boundary.
+//
+// Args: <shm_name> <linear_velocity_mps> <deadline_nanos>
+// Exit:  0 = published;  1 = open failed;  2 = bad args.
+//
+// The payload fixes current == desired (accel 0) and a small steering (1 deg),
+// so the governor's decision turns ONLY on the absolute speed bound — making the
+// two-process assertions predictable.
+
+use std::process::ExitCode;
+
+use kirra_contract_channel::{publish, VehicleCommandPayload};
+use kirra_hv_carrier::PosixShmRegion;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 4 {
+        eprintln!("usage: guest_peer <shm_name> <linear_velocity_mps> <deadline_nanos>");
+        return ExitCode::from(2);
+    }
+    let name = &args[1];
+    let linear: f64 = match args[2].parse() {
+        Ok(v) => v,
+        Err(_) => return ExitCode::from(2),
+    };
+    let deadline: u64 = match args[3].parse() {
+        Ok(v) => v,
+        Err(_) => return ExitCode::from(2),
+    };
+
+    // The guest OPENS (never creates) the region — the governor/platform owns it.
+    let region = match PosixShmRegion::open(name) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("guest_peer: open {name} failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    let payload = VehicleCommandPayload {
+        linear_velocity_mps: linear,
+        current_velocity_mps: linear, // == desired → accel 0
+        delta_time_s: 0.1,
+        steering_angle_deg: 1.0, // small → never trips the steering bound
+        current_steering_angle_deg: 1.0,
+    };
+    let body = payload.to_view(0, 1, 0, deadline);
+    publish(&region, 0, &body);
+    ExitCode::SUCCESS
+}

--- a/crates/kirra-hv-carrier/tests/governor_two_process.rs
+++ b/crates/kirra-hv-carrier/tests/governor_two_process.rs
@@ -1,0 +1,94 @@
+// Two-process producer→GOVERNOR test (ADR-0030 incr. 3). A guest process
+// (`guest_peer`) publishes a proposal into a POSIX shared region; THIS process is
+// the governor — it reads the region and runs the L3.3 `decide` (snapshot →
+// validate → decode → bound) end-to-end, asserting the actuate-vs-safe-stop
+// outcome. This is the full doer→checker path across a real address-space
+// boundary — the step the in-process `InProcessRegion` tests cannot give — and
+// the host analogue of the QNX guest-partition → governor-partition path.
+
+use std::process::Command;
+
+use kirra_contract_channel::{AcceptedWatermark, MAX_SNAPSHOT_RETRIES};
+use kirra_core::contract_consumer::{decide, GovernorOutcome};
+use kirra_core::kinematics_contract::VehicleKinematicsContract;
+use kirra_hv_carrier::PosixShmRegion;
+
+fn guest_peer() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_guest_peer"))
+}
+
+const FUTURE_DEADLINE: u64 = u64::MAX / 2;
+
+#[test]
+fn governor_process_actuates_a_guest_in_envelope_proposal() {
+    let name = format!("/kirra-hv-gov-{}", std::process::id());
+    // The governor/test owns the region; the guest process opens it to publish.
+    let region = PosixShmRegion::create(&name).expect("create");
+    let contract = VehicleKinematicsContract::nominal_reference_profile();
+
+    let status = guest_peer()
+        .arg(&name)
+        .arg("10.0")
+        .arg(FUTURE_DEADLINE.to_string())
+        .status()
+        .expect("spawn guest_peer");
+    assert!(status.success(), "guest publish failed: {status:?}");
+
+    let mut wm = AcceptedWatermark::new();
+    match decide(&region, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES) {
+        GovernorOutcome::Actuate(c) => assert_eq!(c.linear_velocity_mps, 10.0),
+        GovernorOutcome::SafeStop => panic!("an in-envelope cross-process proposal must actuate"),
+    }
+    assert_eq!(wm.last(), Some((2, 1))); // consumed the guest's seq 1 (gen 2)
+    drop(region);
+}
+
+#[test]
+fn governor_process_bounds_a_guest_over_envelope_proposal() {
+    let name = format!("/kirra-hv-gov-over-{}", std::process::id());
+    let region = PosixShmRegion::create(&name).expect("create");
+    let contract = VehicleKinematicsContract::nominal_reference_profile();
+
+    // 50 m/s, far over the 35 m/s ceiling.
+    let status = guest_peer()
+        .arg(&name)
+        .arg("50.0")
+        .arg(FUTURE_DEADLINE.to_string())
+        .status()
+        .expect("spawn guest_peer");
+    assert!(status.success());
+
+    let mut wm = AcceptedWatermark::new();
+    match decide(&region, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES) {
+        // If actuated, the clamp folded the speed below the guest's proposal.
+        GovernorOutcome::Actuate(c) => {
+            assert!(c.linear_velocity_mps < 50.0, "over-speed must be clamped, got {}", c.linear_velocity_mps)
+        }
+        GovernorOutcome::SafeStop => {} // a deny → safe-stop is also fail-closed-correct
+    }
+    drop(region);
+}
+
+#[test]
+fn governor_process_safe_stops_on_a_guest_expired_deadline() {
+    let name = format!("/kirra-hv-gov-dl-{}", std::process::id());
+    let region = PosixShmRegion::create(&name).expect("create");
+    let contract = VehicleKinematicsContract::nominal_reference_profile();
+
+    // Guest publishes with deadline 1_000; the governor's now is 5_000 → expired.
+    let status = guest_peer()
+        .arg(&name)
+        .arg("10.0")
+        .arg("1000")
+        .status()
+        .expect("spawn guest_peer");
+    assert!(status.success());
+
+    let mut wm = AcceptedWatermark::new();
+    assert_eq!(
+        decide(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES),
+        GovernorOutcome::SafeStop,
+        "an expired-deadline proposal must fail closed across processes"
+    );
+    drop(region);
+}

--- a/crates/kirra-hv-carrier/tests/governor_two_process.rs
+++ b/crates/kirra-hv-carrier/tests/governor_two_process.rs
@@ -11,7 +11,7 @@ use std::process::Command;
 use kirra_contract_channel::{AcceptedWatermark, MAX_SNAPSHOT_RETRIES};
 use kirra_core::contract_consumer::{decide, GovernorOutcome};
 use kirra_core::kinematics_contract::VehicleKinematicsContract;
-use kirra_hv_carrier::PosixShmRegion;
+use kirra_hv_carrier::{PosixShmReader, PosixShmRegion};
 
 fn guest_peer() -> Command {
     Command::new(env!("CARGO_BIN_EXE_guest_peer"))
@@ -34,8 +34,11 @@ fn governor_process_actuates_a_guest_in_envelope_proposal() {
         .expect("spawn guest_peer");
     assert!(status.success(), "guest publish failed: {status:?}");
 
+    // The governor reads via a READ-ONLY mapping (R-HV-1); the region handle
+    // stays alive to keep the object mapped + unlink it on drop.
+    let reader = PosixShmReader::open(&name).expect("governor read-only mapping");
     let mut wm = AcceptedWatermark::new();
-    match decide(&region, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES) {
+    match decide(&reader, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES) {
         GovernorOutcome::Actuate(c) => assert_eq!(c.linear_velocity_mps, 10.0),
         GovernorOutcome::SafeStop => panic!("an in-envelope cross-process proposal must actuate"),
     }
@@ -58,13 +61,19 @@ fn governor_process_bounds_a_guest_over_envelope_proposal() {
         .expect("spawn guest_peer");
     assert!(status.success());
 
+    // guest_peer sets current == desired (accel 0) + small steering, so the ONLY
+    // envelope breach is the absolute speed → the nominal contract CLAMPS
+    // (ClampLinear), and decide() must Actuate the clamped command (not SafeStop —
+    // that would mask a clamping regression).
+    let reader = PosixShmReader::open(&name).expect("governor read-only mapping");
     let mut wm = AcceptedWatermark::new();
-    match decide(&region, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES) {
-        // If actuated, the clamp folded the speed below the guest's proposal.
-        GovernorOutcome::Actuate(c) => {
-            assert!(c.linear_velocity_mps < 50.0, "over-speed must be clamped, got {}", c.linear_velocity_mps)
-        }
-        GovernorOutcome::SafeStop => {} // a deny → safe-stop is also fail-closed-correct
+    match decide(&reader, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES) {
+        GovernorOutcome::Actuate(c) => assert!(
+            c.linear_velocity_mps <= 35.0, // clamped into the 35 m/s envelope (< the 50 proposal)
+            "over-speed must be clamped into the envelope, got {}",
+            c.linear_velocity_mps
+        ),
+        GovernorOutcome::SafeStop => panic!("nominal over-speed must clamp (Actuate), not safe-stop"),
     }
     drop(region);
 }
@@ -84,9 +93,10 @@ fn governor_process_safe_stops_on_a_guest_expired_deadline() {
         .expect("spawn guest_peer");
     assert!(status.success());
 
+    let reader = PosixShmReader::open(&name).expect("governor read-only mapping");
     let mut wm = AcceptedWatermark::new();
     assert_eq!(
-        decide(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES),
+        decide(&reader, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES),
         GovernorOutcome::SafeStop,
         "an expired-deadline proposal must fail closed across processes"
     );


### PR DESCRIPTION
## Why

L3 last-mile **increment 3** — the governor decision layer, plus the first **cross-process** validation of the full doer→checker path (incr. 2 wired the guest producer; L3.3 gave the consumer, but only ever tested single-process over `InProcessRegion`).

## What

**`kirra-core` (`contract_consumer`):**
- **Extract a private `receive()`** (snapshot → validate → decode → advance watermark) shared by `consume_and_bound` **and** the new `decide()` — one transport pipeline, never two to drift. `consume_and_bound` behavior is unchanged (its tests pass as-is).
- **`GovernorOutcome { Actuate(ProposedVehicleCommand), SafeStop }` + `decide()`** — the per-cycle governor step reduced to an actuation decision: `Allow`/`Clamp*` → `Actuate` (the clamp already folded into the returned command); a `DenyBreach` **or any** snapshot/contract/codec fault → `SafeStop`. `#[must_use]`.
- `ProposedVehicleCommand` gains `PartialEq` (additive).
- 4 new `decide` unit tests (actuate-unchanged; over-envelope clamped-below-proposal; expired-deadline → SafeStop; non-finite → SafeStop).

**`kirra-hv-carrier`:**
- **`src/bin/guest_peer.rs`** — a guest writer *process* that opens the region and publishes one proposal (uses only `kirra-contract-channel` + the carrier — **no `kirra-core`**, so the crate's real TCB is unchanged).
- **`tests/governor_two_process.rs`** — this process is the **governor**: it owns the region, spawns `guest_peer` to publish across the boundary, then runs `decide()` and asserts **Actuate** (in-envelope, value preserved), **bounded-below-proposal** (over-envelope 50 m/s), and **SafeStop** (expired deadline) — the doer→checker path end-to-end across a real address-space boundary.
- `kirra-core` added as a **dev-dependency only** — it does not enter the carrier's real dependency tree, so the cross-partition TCB stays the frozen layout + the mapping shim (ADR-0006 Clause 2).

## Verification

- `kirra-core`: 177 tests + clippy clean.
- `kirra-hv-carrier`: 10 tests (5 unit + 3 governor two-process + 2 carrier two-process) + clippy clean.
- All host-testable — no ros2/QNX toolchain needed.

## Remaining (ADR-0030)

- the **digest → Ed25519 → release-token bridge** (ADR-0013) — deferred; it needs the verifier's crypto machinery, more integration glue than host logic.
- **incr. 4** — the QNX `HvRegion` binding + #279 hypervisor-layer fault injection (target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_