### PR TITLE
feat(l3): release-token bridge — governor signs, actuator verifies (ADR-0030 Clause F)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,6 +2226,7 @@ dependencies = [
  "kirra-contract-channel",
  "kirra-core",
  "kirra-fleet-types",
+ "kirra-release-token",
  "parko-core",
  "parko-kirra",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,6 +2155,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-release-token"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "kirra-contract-channel",
+ "kirra-core",
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "kirra-ros2-adapter"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # That separation keeps the ML inference pipeline (parko-core / parko-onnx /
 # parko-kirra) independent of the safety-kernel build.
 [workspace]
-members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
+members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport"]
 resolver = "2"
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,10 @@ kirra-fleet-types = { path = "crates/kirra-fleet-types" }
 # binding (src/governor_release.rs) reuses THIS crate's canonical image plus the
 # verifier's EXISTING Ed25519/SHA-256 machinery (no new crypto).
 kirra-contract-channel = { path = "crates/kirra-contract-channel" }
+# The single canonical governor→actuator release-token format (HVCHAN §3.5-7).
+# `src/governor_release.rs` re-exports it (adding only the root-local key-id
+# helper) so there is one digest/sign/verify implementation, not two.
+kirra-release-token = { path = "crates/kirra-release-token" }
 parko-core = { path = "parko/crates/parko-core" }
 # Governor-free wire schema for capture records, shared verbatim with the offline
 # collector (docs/COLLECTOR_DESIGN.md [C1]). Re-exported by `crate::capture`.

--- a/crates/kirra-core/src/contract_consumer.rs
+++ b/crates/kirra-core/src/contract_consumer.rs
@@ -23,7 +23,7 @@
 
 use kirra_contract_channel::{
     read_coherent_snapshot, validate, AcceptedWatermark, CommandCodecError, ContractFault,
-    ContractReader, SnapshotFault, VehicleCommandPayload,
+    ContractReader, GovernorContractView, SnapshotFault, VehicleCommandPayload,
 };
 
 use crate::kinematics_contract::{
@@ -103,7 +103,9 @@ pub fn consume_and_bound<R: ContractReader>(
     max_retries: u32,
 ) -> GovernorVerdict {
     match receive(reader, watermark, now_nanos, max_retries) {
-        Received::Command(cmd) => GovernorVerdict::Bounded(validate_vehicle_command(&cmd, contract)),
+        Received::Command { command, .. } => {
+            GovernorVerdict::Bounded(validate_vehicle_command(&command, contract))
+        }
         Received::Snapshot(f) => GovernorVerdict::Snapshot(f),
         Received::Contract(f) => GovernorVerdict::Contract(f),
         Received::Codec(e) => GovernorVerdict::Codec(e),
@@ -117,7 +119,10 @@ pub fn consume_and_bound<R: ContractReader>(
 /// actuation) governs sequence advancement. A fault leaves the watermark
 /// untouched. Kept private so there is ONE transport pipeline, never two to drift.
 enum Received {
-    Command(ProposedVehicleCommand),
+    /// The decoded command AND the exact validated snapshot it came from — the
+    /// snapshot is the release-token signing input (HVCHAN §3.5-6), carried so the
+    /// governor signs the same bytes it validated.
+    Command { command: ProposedVehicleCommand, view: GovernorContractView },
     Snapshot(SnapshotFault),
     Contract(ContractFault),
     Codec(CommandCodecError),
@@ -141,7 +146,27 @@ fn receive<R: ContractReader>(
         Err(err) => return Received::Codec(err),
     };
     watermark.record(&snapshot);
-    Received::Command(payload.into())
+    Received::Command { command: payload.into(), view: snapshot }
+}
+
+/// Apply a kinematic verdict to the decoded command: `Allow`/`Clamp*` become
+/// [`GovernorOutcome::Actuate`] (the clamp folded in), a `DenyBreach` becomes
+/// [`GovernorOutcome::SafeStop`]. Shared by [`decide`] and [`decide_cycle`].
+fn apply(action: EnforceAction, command: ProposedVehicleCommand) -> GovernorOutcome {
+    match action {
+        EnforceAction::Allow => GovernorOutcome::Actuate(command),
+        EnforceAction::ClampLinear(v) => {
+            let mut c = command;
+            c.linear_velocity_mps = v;
+            GovernorOutcome::Actuate(c)
+        }
+        EnforceAction::ClampSteering(s) => {
+            let mut c = command;
+            c.steering_angle_deg = s;
+            GovernorOutcome::Actuate(c)
+        }
+        EnforceAction::DenyBreach(_) => GovernorOutcome::SafeStop,
+    }
 }
 
 /// The governor's actuation decision for one cycle — the fail-closed reduction of
@@ -172,26 +197,47 @@ pub fn decide<R: ContractReader>(
     contract: &VehicleKinematicsContract,
     max_retries: u32,
 ) -> GovernorOutcome {
-    let cmd = match receive(reader, watermark, now_nanos, max_retries) {
-        Received::Command(cmd) => cmd,
+    match receive(reader, watermark, now_nanos, max_retries) {
+        Received::Command { command, .. } => apply(validate_vehicle_command(&command, contract), command),
         // Any transport/codec fault → fail closed to the safe stop.
+        Received::Snapshot(_) | Received::Contract(_) | Received::Codec(_) => GovernorOutcome::SafeStop,
+    }
+}
+
+/// The result of one governor cycle: the actuation [`outcome`](Self::outcome) plus
+/// the exact validated snapshot [`view`](Self::view) — the release-token signing
+/// input (HVCHAN §3.5-6). `view` is `Some` iff a command was received (transport +
+/// codec passed), regardless of the kinematic outcome, and `None` on a snapshot/
+/// contract/codec fault. The governor signs `view` (with `kirra-release-token`)
+/// ONLY when `outcome` is [`GovernorOutcome::Actuate`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct GovernorCycle {
+    pub outcome: GovernorOutcome,
+    pub view: Option<GovernorContractView>,
+}
+
+/// Like [`decide`], but also returns the validated [`GovernorContractView`] so the
+/// integration seam can sign it for the release token (HVCHAN §3.5-6 / ADR-0013).
+/// Same pipeline, same watermark advancement, same fail-closed reduction — this
+/// only additionally surfaces the exact bytes that were validated.
+///
+/// `#[must_use]`: the outcome gates actuation vs. MRC — dropping it is a safety bug.
+#[must_use]
+pub fn decide_cycle<R: ContractReader>(
+    reader: &R,
+    watermark: &mut AcceptedWatermark,
+    now_nanos: u64,
+    contract: &VehicleKinematicsContract,
+    max_retries: u32,
+) -> GovernorCycle {
+    match receive(reader, watermark, now_nanos, max_retries) {
+        Received::Command { command, view } => GovernorCycle {
+            outcome: apply(validate_vehicle_command(&command, contract), command),
+            view: Some(view),
+        },
         Received::Snapshot(_) | Received::Contract(_) | Received::Codec(_) => {
-            return GovernorOutcome::SafeStop
+            GovernorCycle { outcome: GovernorOutcome::SafeStop, view: None }
         }
-    };
-    match validate_vehicle_command(&cmd, contract) {
-        EnforceAction::Allow => GovernorOutcome::Actuate(cmd),
-        EnforceAction::ClampLinear(v) => {
-            let mut c = cmd;
-            c.linear_velocity_mps = v;
-            GovernorOutcome::Actuate(c)
-        }
-        EnforceAction::ClampSteering(s) => {
-            let mut c = cmd;
-            c.steering_angle_deg = s;
-            GovernorOutcome::Actuate(c)
-        }
-        EnforceAction::DenyBreach(_) => GovernorOutcome::SafeStop,
     }
 }
 
@@ -428,5 +474,37 @@ mod tests {
         let outcome = decide(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES);
         assert_eq!(outcome, GovernorOutcome::SafeStop); // codec fail-closed
         assert_eq!(wm.last(), None);
+    }
+
+    // ---- decide_cycle() — outcome + the validated view for the release token --
+
+    #[test]
+    fn decide_cycle_surfaces_the_validated_view_when_actuatable() {
+        let region = InProcessRegion::new();
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let mut wm = AcceptedWatermark::new();
+
+        publish_payload(&region, 0, 1, 10_000, &in_envelope());
+        let cycle = decide_cycle(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES);
+        assert_eq!(cycle.outcome, GovernorOutcome::Actuate(in_envelope().into()));
+        // The view is present and IS the exact validated snapshot (the sign input).
+        let view = cycle.view.expect("actuatable → view present for the release token");
+        assert_eq!(view.sequence, 1);
+        assert_eq!(
+            VehicleCommandPayload::from_validated_view(&view),
+            Ok(in_envelope())
+        );
+    }
+
+    #[test]
+    fn decide_cycle_has_no_view_on_a_fault() {
+        let region = InProcessRegion::new();
+        let contract = VehicleKinematicsContract::nominal_reference_profile();
+        let mut wm = AcceptedWatermark::new();
+
+        publish_payload(&region, 0, 1, 1_000, &in_envelope()); // deadline 1_000
+        let cycle = decide_cycle(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES);
+        assert_eq!(cycle.outcome, GovernorOutcome::SafeStop);
+        assert_eq!(cycle.view, None); // nothing to sign — a fault never releases
     }
 }

--- a/crates/kirra-core/src/contract_consumer.rs
+++ b/crates/kirra-core/src/contract_consumer.rs
@@ -213,9 +213,16 @@ pub fn decide<R: ContractReader>(
 /// [`Actuate`](GovernorOutcome::Actuate) outcome the view is rebuilt over the
 /// post-enforcement command (see [`decide_cycle`]), so a `Clamp*` verdict's folded
 /// bound is reflected in the bytes that get signed — the governor signs *exactly*
-/// what the actuator will release. `Allow` leaves it byte-identical to the received
-/// snapshot. On a received-but-denied `SafeStop` the field carries the raw received
-/// view (never signable — see [`view_to_sign`](Self::view_to_sign)).
+/// what the actuator will release. The rebuild also **canonicalizes the whole
+/// command array**: transport `validate` only CRCs `command[..command_len]`, so the
+/// bytes beyond `command_len` are unconstrained in the received snapshot, yet the
+/// digest is over `canonical_image()` (the full array). Rebuilding via
+/// [`decide_cycle`] zero-fills that tail, so the signed bytes are deterministic and
+/// free of attacker-controlled padding. For `Allow` the meaningful command is
+/// unchanged (only the unconstrained padding is canonicalized), so the view is not
+/// necessarily byte-identical to the raw received snapshot. On a received-but-denied
+/// `SafeStop` the field carries the raw received view (never signable — see
+/// [`view_to_sign`](Self::view_to_sign)).
 #[derive(Clone, Debug, PartialEq)]
 pub struct GovernorCycle {
     pub outcome: GovernorOutcome,

--- a/crates/kirra-core/src/contract_consumer.rs
+++ b/crates/kirra-core/src/contract_consumer.rs
@@ -216,6 +216,23 @@ pub struct GovernorCycle {
     pub view: Option<GovernorContractView>,
 }
 
+impl GovernorCycle {
+    /// The view to sign for the release token — `Some` **only** when the outcome
+    /// is [`GovernorOutcome::Actuate`]. This is the correct gate for the release
+    /// seam: `view` is populated whenever a command was *received* (transport +
+    /// codec passed), so it is `Some` even on a kinematic `DenyBreach → SafeStop`.
+    /// Signing on `view.is_some()` would therefore sign a DENIED command; signing
+    /// on `view_to_sign()` cannot. "Sign only when actuatable" enforced at the type.
+    #[must_use]
+    pub fn view_to_sign(&self) -> Option<&GovernorContractView> {
+        if matches!(self.outcome, GovernorOutcome::Actuate(_)) {
+            self.view.as_ref()
+        } else {
+            None
+        }
+    }
+}
+
 /// Like [`decide`], but also returns the validated [`GovernorContractView`] so the
 /// integration seam can sign it for the release token (HVCHAN §3.5-6 / ADR-0013).
 /// Same pipeline, same watermark advancement, same fail-closed reduction — this

--- a/crates/kirra-core/src/contract_consumer.rs
+++ b/crates/kirra-core/src/contract_consumer.rs
@@ -205,11 +205,17 @@ pub fn decide<R: ContractReader>(
 }
 
 /// The result of one governor cycle: the actuation [`outcome`](Self::outcome) plus
-/// the exact validated snapshot [`view`](Self::view) — the release-token signing
-/// input (HVCHAN §3.5-6). `view` is `Some` iff a command was received (transport +
-/// codec passed), regardless of the kinematic outcome, and `None` on a snapshot/
-/// contract/codec fault. The governor signs `view` (with `kirra-release-token`)
-/// ONLY when `outcome` is [`GovernorOutcome::Actuate`].
+/// the signable [`view`](Self::view) — the release-token signing input (HVCHAN
+/// §3.5-6). `view` is `Some` iff a command was received (transport + codec passed)
+/// and `None` on a snapshot/contract/codec fault.
+///
+/// **The view binds the ENFORCED command, not the guest's raw proposal.** On an
+/// [`Actuate`](GovernorOutcome::Actuate) outcome the view is rebuilt over the
+/// post-enforcement command (see [`decide_cycle`]), so a `Clamp*` verdict's folded
+/// bound is reflected in the bytes that get signed — the governor signs *exactly*
+/// what the actuator will release. `Allow` leaves it byte-identical to the received
+/// snapshot. On a received-but-denied `SafeStop` the field carries the raw received
+/// view (never signable — see [`view_to_sign`](Self::view_to_sign)).
 #[derive(Clone, Debug, PartialEq)]
 pub struct GovernorCycle {
     pub outcome: GovernorOutcome,
@@ -218,11 +224,13 @@ pub struct GovernorCycle {
 
 impl GovernorCycle {
     /// The view to sign for the release token — `Some` **only** when the outcome
-    /// is [`GovernorOutcome::Actuate`]. This is the correct gate for the release
-    /// seam: `view` is populated whenever a command was *received* (transport +
-    /// codec passed), so it is `Some` even on a kinematic `DenyBreach → SafeStop`.
-    /// Signing on `view.is_some()` would therefore sign a DENIED command; signing
-    /// on `view_to_sign()` cannot. "Sign only when actuatable" enforced at the type.
+    /// is [`GovernorOutcome::Actuate`], and then it is the ENFORCED view (the
+    /// post-clamp command). This is the correct gate for the release seam: `view`
+    /// is populated whenever a command was *received* (transport + codec passed),
+    /// so it is `Some` even on a kinematic `DenyBreach → SafeStop`. Signing on
+    /// `view.is_some()` would therefore sign a DENIED command; signing on
+    /// `view_to_sign()` cannot, and it signs the actuated (clamped) bytes rather
+    /// than the guest's proposal. "Sign only what is actuatable" at the type.
     #[must_use]
     pub fn view_to_sign(&self) -> Option<&GovernorContractView> {
         if matches!(self.outcome, GovernorOutcome::Actuate(_)) {
@@ -233,10 +241,16 @@ impl GovernorCycle {
     }
 }
 
-/// Like [`decide`], but also returns the validated [`GovernorContractView`] so the
-/// integration seam can sign it for the release token (HVCHAN §3.5-6 / ADR-0013).
-/// Same pipeline, same watermark advancement, same fail-closed reduction — this
-/// only additionally surfaces the exact bytes that were validated.
+/// Like [`decide`], but also surfaces the signable [`GovernorContractView`] for the
+/// release token (HVCHAN §3.5-6 / ADR-0013). Same pipeline, same watermark
+/// advancement, same fail-closed reduction.
+///
+/// On an actuatable verdict the returned `view` is the **enforced** view — the
+/// received snapshot's header with the *post-enforcement* command (a `Clamp*`
+/// verdict folds its bound in). This closes the integrity gap where the governor
+/// would otherwise sign the guest's raw proposal while the actuator drives the
+/// clamped command: here the signed bytes are exactly the actuated bytes. `Allow`
+/// is byte-identical to the received snapshot (enforced command == received).
 ///
 /// `#[must_use]`: the outcome gates actuation vs. MRC — dropping it is a safety bug.
 #[must_use]
@@ -248,14 +262,47 @@ pub fn decide_cycle<R: ContractReader>(
     max_retries: u32,
 ) -> GovernorCycle {
     match receive(reader, watermark, now_nanos, max_retries) {
-        Received::Command { command, view } => GovernorCycle {
-            outcome: apply(validate_vehicle_command(&command, contract), command),
-            view: Some(view),
-        },
+        Received::Command { command, view } => {
+            let outcome = apply(validate_vehicle_command(&command, contract), command);
+            // Bind the token to the bytes the actuator will ACTUALLY drive. On a
+            // Clamp verdict `apply` folded the bound into the command, so the raw
+            // received `view` no longer matches it — rebuild the enforced view. A
+            // denied command keeps the raw received view (never signable).
+            let view = match &outcome {
+                GovernorOutcome::Actuate(actuated) => enforced_view(actuated, &view),
+                GovernorOutcome::SafeStop => view,
+            };
+            GovernorCycle { outcome, view: Some(view) }
+        }
         Received::Snapshot(_) | Received::Contract(_) | Received::Codec(_) => {
             GovernorCycle { outcome: GovernorOutcome::SafeStop, view: None }
         }
     }
+}
+
+/// Rebuild the contract view over the POST-ENFORCEMENT `command`, reusing the
+/// received snapshot's header (generation / sequence / timestamps / deadline) and
+/// a freshly computed CRC. The release token is signed over this view's canonical
+/// image, so on a `Clamp*` verdict the signed bytes are the clamped (actuated)
+/// bytes, not the guest's proposal. Byte-identical to `received` when the verdict
+/// was `Allow` (the command is unchanged).
+fn enforced_view(
+    command: &ProposedVehicleCommand,
+    received: &GovernorContractView,
+) -> GovernorContractView {
+    let payload = VehicleCommandPayload {
+        linear_velocity_mps: command.linear_velocity_mps,
+        current_velocity_mps: command.current_velocity_mps,
+        delta_time_s: command.delta_time_s,
+        steering_angle_deg: command.steering_angle_deg,
+        current_steering_angle_deg: command.current_steering_angle_deg,
+    };
+    payload.to_view(
+        received.generation,
+        received.sequence,
+        received.publication_nanos,
+        received.deadline_nanos,
+    )
 }
 
 #[cfg(test)]

--- a/crates/kirra-release-token/Cargo.toml
+++ b/crates/kirra-release-token/Cargo.toml
@@ -1,0 +1,36 @@
+# crates/kirra-release-token/Cargo.toml
+#
+# The HVCHAN §3 steps 5-6 release-token bridge (ADR-0013 / ADR-0030 Clause F):
+# on an ACTUATABLE governor verdict, the governor signs the digest of the exact
+# validated GovernorContractView so the actuator can verify "the governor
+# approved EXACTLY these bytes" before it releases the command.
+#
+# "No new crypto primitives" (HVCHAN §3): this uses the SAME ed25519-dalek +
+# sha2 the verifier's attestation path already uses (`src/attestation.rs`) — it
+# only applies them at this seam. `#![forbid(unsafe_code)]`; no allocator beyond
+# the digest. Kept a small, focused crate (not folded into kirra-core, which
+# stays crypto-free, nor the heavy kirra-verifier).
+[package]
+name = "kirra-release-token"
+version = "0.1.0"
+edition = "2021"
+description = "Governor→actuator release-token bridge — sign/verify the validated contract digest (HVCHAN §3.5-6, ADR-0013)"
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+
+[dependencies]
+# The frozen contract — the canonical little-endian image the digest is computed
+# over (GovernorContractView::canonical_image). Lean, no_std, zero-dep.
+kirra-contract-channel = { path = "../kirra-contract-channel" }
+# The vetted Ed25519 (verify_strict / Signer) — the SAME crate + version the
+# attestation path uses. No hand-rolled primitives.
+ed25519-dalek = "2"
+# The vetted SHA-256 — the digest primitive (matches the audit chain + the root).
+sha2 = "0.11"
+
+[dev-dependencies]
+# The governor decision step, for the end-to-end governor→actuator release-flow
+# integration test. Dev-only — kirra-core does NOT enter this crate's real tree,
+# and this crate does NOT enter kirra-core's (kirra-core stays crypto-free).
+kirra-core = { path = "../kirra-core" }

--- a/crates/kirra-release-token/src/lib.rs
+++ b/crates/kirra-release-token/src/lib.rs
@@ -49,8 +49,15 @@ pub fn digest_image(canonical_image: &[u8]) -> [u8; 32] {
 /// Sign the digest of `canonical_image` with the governor's key (HVCHAN §3
 /// steps 5-6). The image is [`GovernorContractView::canonical_image`] of the
 /// exact validated snapshot; see [`sign_view`] for the typed convenience.
+///
+/// The image is a **fixed-length** `&[u8; CANONICAL_IMAGE_LEN]` so signing a
+/// wrong-length / non-canonical image is a COMPILE error, not a runtime footgun —
+/// reinforcing the "sign exactly the validated bytes" invariant at the type level.
 #[must_use]
-pub fn sign_release(canonical_image: &[u8], signing_key: &SigningKey) -> ReleaseToken {
+pub fn sign_release(
+    canonical_image: &[u8; kirra_contract_channel::CANONICAL_IMAGE_LEN],
+    signing_key: &SigningKey,
+) -> ReleaseToken {
     let digest = digest_image(canonical_image);
     ReleaseToken { signature: signing_key.sign(&digest).to_bytes() }
 }
@@ -58,9 +65,13 @@ pub fn sign_release(canonical_image: &[u8], signing_key: &SigningKey) -> Release
 /// Verify a release token against `canonical_image` and the governor's public
 /// key — the actuator's pre-release gate. **Fail-closed:** `false` on any
 /// mismatch (tampered image → different digest; wrong key; bad signature).
+///
+/// Fixed-length image (`&[u8; CANONICAL_IMAGE_LEN]`) for the same reason as
+/// [`sign_release`]: the actuator cannot accidentally verify over a non-canonical
+/// slice.
 #[must_use]
 pub fn verify_release(
-    canonical_image: &[u8],
+    canonical_image: &[u8; kirra_contract_channel::CANONICAL_IMAGE_LEN],
     token: &ReleaseToken,
     verifying_key: &VerifyingKey,
 ) -> bool {

--- a/crates/kirra-release-token/src/lib.rs
+++ b/crates/kirra-release-token/src/lib.rs
@@ -70,31 +70,21 @@ pub enum ReleaseDenied {
     SignatureInvalid,
 }
 
-/// The digest payload (step 5): domain tag, then the length-prefixed canonical
-/// image. The image is fixed-size, but the length prefix keeps the encoding
-/// injective and consistent with the audit-chain discipline.
-fn digest_payload(view: &GovernorContractView) -> ([u8; 32 + 1024], usize) {
-    // Stack buffer sized to comfortably hold the domain tag + 8-byte length +
-    // the canonical image (176 bytes today). Returned with its used length.
-    let image = view.canonical_image();
-    let mut buf = [0u8; 32 + 1024];
-    let mut n = 0;
-    buf[n..n + DIGEST_DOMAIN.len()].copy_from_slice(DIGEST_DOMAIN);
-    n += DIGEST_DOMAIN.len();
-    buf[n..n + 8].copy_from_slice(&(image.len() as u64).to_le_bytes());
-    n += 8;
-    buf[n..n + image.len()].copy_from_slice(&image);
-    n += image.len();
-    (buf, n)
-}
-
 /// Step 5: the digest over the exact validated snapshot bytes. Deterministic;
 /// independent of the live shared region.
+///
+/// The digest input is the domain tag, then the length-prefixed canonical image
+/// (the audit-chain house style — the length prefix keeps the encoding injective).
+/// It is **streamed directly into the hasher** rather than assembled in a buffer,
+/// so there is no fixed-size assumption to overflow if `canonical_image()` ever
+/// grows: `SHA-256(domain || len || image)` is identical fed in one slice or three.
 #[must_use]
 pub fn contract_digest(view: &GovernorContractView) -> [u8; 32] {
-    let (buf, n) = digest_payload(view);
+    let image = view.canonical_image();
     let mut hasher = Sha256::new();
-    hasher.update(&buf[..n]);
+    hasher.update(DIGEST_DOMAIN);
+    hasher.update((image.len() as u64).to_le_bytes());
+    hasher.update(image);
     hasher.finalize().into()
 }
 

--- a/crates/kirra-release-token/src/lib.rs
+++ b/crates/kirra-release-token/src/lib.rs
@@ -1,0 +1,153 @@
+//! # kirra-release-token — the governor→actuator release bridge (HVCHAN §3.5-6)
+//!
+//! The last link of the L3 trust chain (ADR-0030 Clause F, ADR-0013): once the
+//! governor has validated a [`GovernorContractView`] and decided it is
+//! **actuatable**, it **signs the digest of that exact view** so the actuator can
+//! verify — before it releases the command — that *"the governor approved exactly
+//! these bytes."* A guest cannot forge it; a single flipped byte between governor
+//! and actuator invalidates it.
+//!
+//! Two steps, matching HVCHAN §3:
+//! - **step 5 — digest.** SHA-256 over the canonical little-endian image
+//!   ([`GovernorContractView::canonical_image`]).
+//! - **step 6 — sign.** Ed25519 over that digest, with the governor's key.
+//!
+//! **No new crypto primitives** (HVCHAN §3): the SAME `ed25519-dalek` +
+//! `sha2` the verifier's attestation path already uses (`src/attestation.rs`),
+//! applied at this seam. `#![forbid(unsafe_code)]`.
+//!
+//! Fail-closed: [`verify_release`] returns `false` on ANY mismatch — a tampered
+//! image, a wrong key, or a malformed/altered signature. The actuator releases
+//! ONLY on `true`.
+
+#![forbid(unsafe_code)]
+
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+use kirra_contract_channel::GovernorContractView;
+
+/// A governor release token: the Ed25519 signature (64 bytes) over the SHA-256
+/// digest of the validated contract image. The bytes an actuator checks before
+/// releasing a command.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReleaseToken {
+    /// The raw Ed25519 signature over the image digest.
+    pub signature: [u8; 64],
+}
+
+/// SHA-256 over the canonical contract image (HVCHAN §3 step 5). Deterministic;
+/// the actuator recomputes it from the image it holds, so a tampered image
+/// yields a different digest and fails verification.
+#[must_use]
+pub fn digest_image(canonical_image: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(canonical_image);
+    hasher.finalize().into()
+}
+
+/// Sign the digest of `canonical_image` with the governor's key (HVCHAN §3
+/// steps 5-6). The image is [`GovernorContractView::canonical_image`] of the
+/// exact validated snapshot; see [`sign_view`] for the typed convenience.
+#[must_use]
+pub fn sign_release(canonical_image: &[u8], signing_key: &SigningKey) -> ReleaseToken {
+    let digest = digest_image(canonical_image);
+    ReleaseToken { signature: signing_key.sign(&digest).to_bytes() }
+}
+
+/// Verify a release token against `canonical_image` and the governor's public
+/// key — the actuator's pre-release gate. **Fail-closed:** `false` on any
+/// mismatch (tampered image → different digest; wrong key; bad signature).
+#[must_use]
+pub fn verify_release(
+    canonical_image: &[u8],
+    token: &ReleaseToken,
+    verifying_key: &VerifyingKey,
+) -> bool {
+    let digest = digest_image(canonical_image);
+    verifying_key
+        .verify_strict(&digest, &Signature::from_bytes(&token.signature))
+        .is_ok()
+}
+
+/// Sign the validated [`GovernorContractView`] (its canonical image). The
+/// governor calls this on an actuatable verdict, over the exact snapshot it
+/// validated (e.g. `kirra_core::contract_consumer::GovernorCycle::view`).
+#[must_use]
+pub fn sign_view(view: &GovernorContractView, signing_key: &SigningKey) -> ReleaseToken {
+    sign_release(&view.canonical_image(), signing_key)
+}
+
+/// Verify a release token against a [`GovernorContractView`] — the actuator's
+/// gate over the typed view. Fail-closed, as [`verify_release`].
+#[must_use]
+pub fn verify_view(
+    view: &GovernorContractView,
+    token: &ReleaseToken,
+    verifying_key: &VerifyingKey,
+) -> bool {
+    verify_release(&view.canonical_image(), token, verifying_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keypair(seed: u8) -> (SigningKey, VerifyingKey) {
+        // Deterministic (no RNG) — same pattern as the attestation tests.
+        let sk = SigningKey::from_bytes(&[seed; 32]);
+        let vk = sk.verifying_key();
+        (sk, vk)
+    }
+
+    fn image() -> [u8; kirra_contract_channel::CANONICAL_IMAGE_LEN] {
+        GovernorContractView::new_command(2, 1, 0, u64::MAX / 2, b"steer:1.0")
+            .unwrap()
+            .canonical_image()
+    }
+
+    #[test]
+    fn sign_then_verify_accepts() {
+        let (sk, vk) = keypair(1);
+        let img = image();
+        let token = sign_release(&img, &sk);
+        assert!(verify_release(&img, &token, &vk));
+    }
+
+    #[test]
+    fn a_tampered_image_is_rejected() {
+        let (sk, vk) = keypair(1);
+        let mut img = image();
+        let token = sign_release(&img, &sk);
+        img[48] ^= 0xFF; // flip a command byte AFTER signing
+        assert!(!verify_release(&img, &token, &vk));
+    }
+
+    #[test]
+    fn a_wrong_public_key_is_rejected() {
+        let (sk, _) = keypair(1);
+        let (_, other_vk) = keypair(2);
+        let img = image();
+        let token = sign_release(&img, &sk);
+        assert!(!verify_release(&img, &token, &other_vk));
+    }
+
+    #[test]
+    fn a_tampered_token_is_rejected() {
+        let (sk, vk) = keypair(1);
+        let img = image();
+        let mut token = sign_release(&img, &sk);
+        token.signature[0] ^= 0xFF;
+        assert!(!verify_release(&img, &token, &vk));
+    }
+
+    #[test]
+    fn sign_view_agrees_with_sign_release_over_the_canonical_image() {
+        let (sk, vk) = keypair(3);
+        let view = GovernorContractView::new_command(4, 2, 0, u64::MAX / 2, b"steer:2.0").unwrap();
+        let token = sign_view(&view, &sk);
+        assert!(verify_view(&view, &token, &vk));
+        // Same as signing the raw canonical image.
+        assert_eq!(token, sign_release(&view.canonical_image(), &sk));
+    }
+}

--- a/crates/kirra-release-token/src/lib.rs
+++ b/crates/kirra-release-token/src/lib.rs
@@ -1,4 +1,4 @@
-//! # kirra-release-token — the governor→actuator release bridge (HVCHAN §3.5-6)
+//! # kirra-release-token — the governor→actuator release bridge (HVCHAN §3 steps 5-7)
 //!
 //! The last link of the L3 trust chain (ADR-0030 Clause F, ADR-0013): once the
 //! governor has validated a [`GovernorContractView`] and decided it is
@@ -7,18 +7,31 @@
 //! these bytes."* A guest cannot forge it; a single flipped byte between governor
 //! and actuator invalidates it.
 //!
-//! Two steps, matching HVCHAN §3:
-//! - **step 5 — digest.** SHA-256 over the canonical little-endian image
-//!   ([`GovernorContractView::canonical_image`]).
-//! - **step 6 — sign.** Ed25519 over that digest, with the governor's key.
+//! Steps 1-4 (the frozen layout, the seqlock coherent read, and validation) live
+//! in [`kirra_contract_channel`]. This crate closes the chain:
 //!
-//! **No new crypto primitives** (HVCHAN §3): the SAME `ed25519-dalek` +
-//! `sha2` the verifier's attestation path already uses (`src/attestation.rs`),
-//! applied at this seam. `#![forbid(unsafe_code)]`.
+//! - **Step 5 — digest.** [`contract_digest`] hashes the **exact validated
+//!   snapshot bytes** ([`GovernorContractView::canonical_image`]) — the bytes the
+//!   judge approved, not the live region which may already have moved on.
+//! - **Step 6 — release token.** [`issue_release_token`] signs that digest with
+//!   the governor's Ed25519 key.
+//! - **Step 7 — actuator verify-before-release.** [`verify_release`] re-derives
+//!   the digest over the command the actuator is **about to actuate** and checks
+//!   (a) the token's digest matches it **and** (b) the signature verifies against
+//!   the governor key. Either failure ⇒ **no release** (fail-closed).
 //!
-//! Fail-closed: [`verify_release`] returns `false` on ANY mismatch — a tampered
-//! image, a wrong key, or a malformed/altered signature. The actuator releases
-//! ONLY on `true`.
+//! **No new crypto primitives** (HVCHAN §3): the SAME `ed25519-dalek` + `sha2`
+//! the verifier's attestation / audit-chain paths already use, applied at this
+//! seam. `#![forbid(unsafe_code)]`.
+//!
+//! **One canonical token format.** Both the digest and the token signature use
+//! **domain-separated, length-prefixed** payloads (the `audit_chain` /
+//! `compute_causal_record_hash` house style), so a governor-release digest or
+//! signature can never collide with — or be replayed as — an audit-chain or causal
+//! hash/signature. This crate is the SINGLE source of the release-token format:
+//! the heavy `kirra-verifier` root crate re-exports it from
+//! `src/governor_release.rs` (which adds only the root-local `governor_key_id`
+//! forensic helper), so there is exactly one digest/sign/verify implementation.
 
 #![forbid(unsafe_code)]
 
@@ -27,138 +40,244 @@ use sha2::{Digest, Sha256};
 
 use kirra_contract_channel::GovernorContractView;
 
-/// A governor release token: the Ed25519 signature (64 bytes) over the SHA-256
-/// digest of the validated contract image. The bytes an actuator checks before
-/// releasing a command.
+/// Domain tag for the contract digest (step 5). Distinct from every audit-chain
+/// / causal tag so the two hash spaces never collide.
+const DIGEST_DOMAIN: &[u8] = b"KIRRA-GOVERNOR-CONTRACT-DIGEST-V1";
+
+/// Domain tag for the release-token signing payload (step 6). Distinct again, so
+/// a release signature can never be reused as an audit signature and vice versa.
+const RELEASE_DOMAIN: &[u8] = b"KIRRA-GOVERNOR-RELEASE-V1";
+
+/// The release token: a digest of the approved command plus the governor's
+/// Ed25519 signature over it. Minimal and fixed-size (96 bytes on the wire); the
+/// actuator is supplied the governor verifying key out-of-band.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ReleaseToken {
-    /// The raw Ed25519 signature over the image digest.
+    /// SHA-256 digest over the validated snapshot's canonical image (step 5).
+    pub digest: [u8; 32],
+    /// Ed25519 signature over the domain-separated digest payload (step 6).
     pub signature: [u8; 64],
 }
 
-/// SHA-256 over the canonical contract image (HVCHAN §3 step 5). Deterministic;
-/// the actuator recomputes it from the image it holds, so a tampered image
-/// yields a different digest and fails verification.
+/// Why the actuator refused to release (step 7). Both are fail-closed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReleaseDenied {
+    /// The token's digest does not match the command about to be actuated — the
+    /// approval was for *different* bytes. (Substitution / stale token.)
+    DigestMismatch,
+    /// The signature does not verify against the governor key — forged or
+    /// tampered token, or wrong signer.
+    SignatureInvalid,
+}
+
+/// The digest payload (step 5): domain tag, then the length-prefixed canonical
+/// image. The image is fixed-size, but the length prefix keeps the encoding
+/// injective and consistent with the audit-chain discipline.
+fn digest_payload(view: &GovernorContractView) -> ([u8; 32 + 1024], usize) {
+    // Stack buffer sized to comfortably hold the domain tag + 8-byte length +
+    // the canonical image (176 bytes today). Returned with its used length.
+    let image = view.canonical_image();
+    let mut buf = [0u8; 32 + 1024];
+    let mut n = 0;
+    buf[n..n + DIGEST_DOMAIN.len()].copy_from_slice(DIGEST_DOMAIN);
+    n += DIGEST_DOMAIN.len();
+    buf[n..n + 8].copy_from_slice(&(image.len() as u64).to_le_bytes());
+    n += 8;
+    buf[n..n + image.len()].copy_from_slice(&image);
+    n += image.len();
+    (buf, n)
+}
+
+/// Step 5: the digest over the exact validated snapshot bytes. Deterministic;
+/// independent of the live shared region.
 #[must_use]
-pub fn digest_image(canonical_image: &[u8]) -> [u8; 32] {
+pub fn contract_digest(view: &GovernorContractView) -> [u8; 32] {
+    let (buf, n) = digest_payload(view);
     let mut hasher = Sha256::new();
-    hasher.update(canonical_image);
+    hasher.update(&buf[..n]);
     hasher.finalize().into()
 }
 
-/// Sign the digest of `canonical_image` with the governor's key (HVCHAN §3
-/// steps 5-6). The image is [`GovernorContractView::canonical_image`] of the
-/// exact validated snapshot; see [`sign_view`] for the typed convenience.
-///
-/// The image is a **fixed-length** `&[u8; CANONICAL_IMAGE_LEN]` so signing a
-/// wrong-length / non-canonical image is a COMPILE error, not a runtime footgun —
-/// reinforcing the "sign exactly the validated bytes" invariant at the type level.
-#[must_use]
-pub fn sign_release(
-    canonical_image: &[u8; kirra_contract_channel::CANONICAL_IMAGE_LEN],
-    signing_key: &SigningKey,
-) -> ReleaseToken {
-    let digest = digest_image(canonical_image);
-    ReleaseToken { signature: signing_key.sign(&digest).to_bytes() }
+/// The signing payload over a digest (step 6): domain tag, then the 32-byte
+/// digest length-prefixed. Domain separation prevents cross-protocol reuse.
+fn release_signing_payload(digest: &[u8; 32]) -> [u8; RELEASE_DOMAIN.len() + 8 + 32] {
+    let mut out = [0u8; RELEASE_DOMAIN.len() + 8 + 32];
+    let mut n = 0;
+    out[n..n + RELEASE_DOMAIN.len()].copy_from_slice(RELEASE_DOMAIN);
+    n += RELEASE_DOMAIN.len();
+    out[n..n + 8].copy_from_slice(&(32u64).to_le_bytes());
+    n += 8;
+    out[n..n + 32].copy_from_slice(digest);
+    out
 }
 
-/// Verify a release token against `canonical_image` and the governor's public
-/// key — the actuator's pre-release gate. **Fail-closed:** `false` on any
-/// mismatch (tampered image → different digest; wrong key; bad signature).
-///
-/// Fixed-length image (`&[u8; CANONICAL_IMAGE_LEN]`) for the same reason as
-/// [`sign_release`]: the actuator cannot accidentally verify over a non-canonical
-/// slice.
+/// Step 6: issue a release token binding `view` to the governor's approval, by
+/// signing its digest with `signing_key`. The governor calls this on an
+/// actuatable verdict, over the exact snapshot it validated (e.g.
+/// `kirra_core::contract_consumer::GovernorCycle::view_to_sign`).
 #[must_use]
+pub fn issue_release_token(view: &GovernorContractView, signing_key: &SigningKey) -> ReleaseToken {
+    let digest = contract_digest(view);
+    let signature = signing_key.sign(&release_signing_payload(&digest));
+    ReleaseToken { digest, signature: signature.to_bytes() }
+}
+
+/// Step 7: the actuator's verify-before-release gate. `actuating_view` is the
+/// command the actuator is about to drive; `governor_vk` is the trusted governor
+/// key. Returns `Ok(())` only if the token's digest matches the actuating command
+/// **and** the signature verifies — otherwise a fail-closed [`ReleaseDenied`].
 pub fn verify_release(
-    canonical_image: &[u8; kirra_contract_channel::CANONICAL_IMAGE_LEN],
     token: &ReleaseToken,
-    verifying_key: &VerifyingKey,
-) -> bool {
-    let digest = digest_image(canonical_image);
-    verifying_key
-        .verify_strict(&digest, &Signature::from_bytes(&token.signature))
-        .is_ok()
+    actuating_view: &GovernorContractView,
+    governor_vk: &VerifyingKey,
+) -> Result<(), ReleaseDenied> {
+    // (a) The token must approve exactly the bytes about to be actuated.
+    let expected = contract_digest(actuating_view);
+    if token.digest != expected {
+        return Err(ReleaseDenied::DigestMismatch);
+    }
+    // (b) The signature must verify against the governor key, over the same
+    // digest. `verify_strict` is the attestation path (rejects malleable / small-
+    // order points). A tampered digest field fails here even if (a) somehow passed.
+    let sig = Signature::from_bytes(&token.signature);
+    if governor_vk
+        .verify_strict(&release_signing_payload(&token.digest), &sig)
+        .is_err()
+    {
+        return Err(ReleaseDenied::SignatureInvalid);
+    }
+    Ok(())
 }
 
-/// Sign the validated [`GovernorContractView`] (its canonical image). The
-/// governor calls this on an actuatable verdict, over the exact snapshot it
-/// validated (e.g. `kirra_core::contract_consumer::GovernorCycle::view`).
-#[must_use]
-pub fn sign_view(view: &GovernorContractView, signing_key: &SigningKey) -> ReleaseToken {
-    sign_release(&view.canonical_image(), signing_key)
-}
+impl ReleaseToken {
+    /// Canonical 96-byte wire form: `digest(32) || signature(64)`.
+    #[must_use]
+    pub fn to_bytes(&self) -> [u8; 96] {
+        let mut out = [0u8; 96];
+        out[..32].copy_from_slice(&self.digest);
+        out[32..].copy_from_slice(&self.signature);
+        out
+    }
 
-/// Verify a release token against a [`GovernorContractView`] — the actuator's
-/// gate over the typed view. Fail-closed, as [`verify_release`].
-#[must_use]
-pub fn verify_view(
-    view: &GovernorContractView,
-    token: &ReleaseToken,
-    verifying_key: &VerifyingKey,
-) -> bool {
-    verify_release(&view.canonical_image(), token, verifying_key)
+    /// Parse the canonical wire form. (No verification — that is [`verify_release`].)
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8; 96]) -> Self {
+        let mut digest = [0u8; 32];
+        let mut signature = [0u8; 64];
+        digest.copy_from_slice(&bytes[..32]);
+        signature.copy_from_slice(&bytes[32..]);
+        Self { digest, signature }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn keypair(seed: u8) -> (SigningKey, VerifyingKey) {
-        // Deterministic (no RNG) — same pattern as the attestation tests.
-        let sk = SigningKey::from_bytes(&[seed; 32]);
-        let vk = sk.verifying_key();
-        (sk, vk)
+    fn governor_key() -> SigningKey {
+        SigningKey::from_bytes(&[42u8; 32])
     }
 
-    fn image() -> [u8; kirra_contract_channel::CANONICAL_IMAGE_LEN] {
-        GovernorContractView::new_command(2, 1, 0, u64::MAX / 2, b"steer:1.0")
-            .unwrap()
-            .canonical_image()
+    fn view(seq: u64, cmd: &[u8]) -> GovernorContractView {
+        GovernorContractView::new_command(2, seq, 100, 10_000, cmd).unwrap()
     }
 
     #[test]
-    fn sign_then_verify_accepts() {
-        let (sk, vk) = keypair(1);
-        let img = image();
-        let token = sign_release(&img, &sk);
-        assert!(verify_release(&img, &token, &vk));
+    fn honest_token_releases() {
+        let sk = governor_key();
+        let v = view(1, b"steer:1.5");
+        let token = issue_release_token(&v, &sk);
+        assert_eq!(verify_release(&token, &v, &sk.verifying_key()), Ok(()));
     }
 
     #[test]
-    fn a_tampered_image_is_rejected() {
-        let (sk, vk) = keypair(1);
-        let mut img = image();
-        let token = sign_release(&img, &sk);
-        img[48] ^= 0xFF; // flip a command byte AFTER signing
-        assert!(!verify_release(&img, &token, &vk));
+    fn digest_binds_the_exact_command_bytes() {
+        // A token issued for one command must NOT release a different command,
+        // even a one-byte change — the digest mismatch is caught.
+        let sk = governor_key();
+        let approved = view(1, b"steer:1.5");
+        let token = issue_release_token(&approved, &sk);
+
+        let tampered = view(1, b"steer:9.9");
+        assert_eq!(
+            verify_release(&token, &tampered, &sk.verifying_key()),
+            Err(ReleaseDenied::DigestMismatch)
+        );
     }
 
     #[test]
-    fn a_wrong_public_key_is_rejected() {
-        let (sk, _) = keypair(1);
-        let (_, other_vk) = keypair(2);
-        let img = image();
-        let token = sign_release(&img, &sk);
-        assert!(!verify_release(&img, &token, &other_vk));
+    fn any_header_field_change_changes_the_digest() {
+        // The digest covers the whole canonical image, not just the payload: a
+        // changed sequence (replay number) or deadline yields a different digest.
+        let sk = governor_key();
+        let token = issue_release_token(&view(1, b"go"), &sk);
+        assert_eq!(
+            verify_release(&token, &view(2, b"go"), &sk.verifying_key()),
+            Err(ReleaseDenied::DigestMismatch),
+            "a different sequence is a different approved command"
+        );
     }
 
     #[test]
-    fn a_tampered_token_is_rejected() {
-        let (sk, vk) = keypair(1);
-        let img = image();
-        let mut token = sign_release(&img, &sk);
-        token.signature[0] ^= 0xFF;
-        assert!(!verify_release(&img, &token, &vk));
+    fn wrong_governor_key_is_rejected() {
+        let real = governor_key();
+        let imposter = SigningKey::from_bytes(&[7u8; 32]);
+        let v = view(1, b"go");
+        // Token signed by the imposter; actuator trusts the real governor key.
+        let token = issue_release_token(&v, &imposter);
+        assert_eq!(
+            verify_release(&token, &v, &real.verifying_key()),
+            Err(ReleaseDenied::SignatureInvalid)
+        );
     }
 
     #[test]
-    fn sign_view_agrees_with_sign_release_over_the_canonical_image() {
-        let (sk, vk) = keypair(3);
-        let view = GovernorContractView::new_command(4, 2, 0, u64::MAX / 2, b"steer:2.0").unwrap();
-        let token = sign_view(&view, &sk);
-        assert!(verify_view(&view, &token, &vk));
-        // Same as signing the raw canonical image.
-        assert_eq!(token, sign_release(&view.canonical_image(), &sk));
+    fn tampered_signature_is_rejected() {
+        let sk = governor_key();
+        let v = view(1, b"go");
+        let mut token = issue_release_token(&v, &sk);
+        token.signature[0] ^= 0x01;
+        assert_eq!(
+            verify_release(&token, &v, &sk.verifying_key()),
+            Err(ReleaseDenied::SignatureInvalid)
+        );
+    }
+
+    #[test]
+    fn tampered_digest_field_is_rejected() {
+        // Flipping the token's digest to match a substituted command does not
+        // help: the signature was over the original digest, so verify fails.
+        let sk = governor_key();
+        let v = view(1, b"go");
+        let mut token = issue_release_token(&v, &sk);
+        let substitute = view(1, b"no");
+        token.digest = contract_digest(&substitute); // now matches `substitute`
+        assert_eq!(
+            verify_release(&token, &substitute, &sk.verifying_key()),
+            Err(ReleaseDenied::SignatureInvalid),
+            "digest matches the substitute, but the signature does not cover it"
+        );
+    }
+
+    #[test]
+    fn wire_roundtrip_preserves_the_token() {
+        let sk = governor_key();
+        let token = issue_release_token(&view(3, b"abc"), &sk);
+        assert_eq!(ReleaseToken::from_bytes(&token.to_bytes()), token);
+    }
+
+    #[test]
+    fn release_payload_is_domain_separated_from_a_bare_digest() {
+        // The signed payload is NOT the bare digest; a signature is bound to the
+        // release domain and cannot be reused where a bare-digest signature is
+        // expected. (Guards against cross-protocol signature reuse.)
+        let sk = governor_key();
+        let v = view(1, b"go");
+        let token = issue_release_token(&v, &sk);
+        let bare = Signature::from_bytes(&token.signature);
+        assert!(
+            sk.verifying_key().verify_strict(&token.digest, &bare).is_err(),
+            "the signature must not verify over the bare digest (no domain tag)"
+        );
     }
 }

--- a/crates/kirra-release-token/src/lib.rs
+++ b/crates/kirra-release-token/src/lib.rs
@@ -10,9 +10,14 @@
 //! Steps 1-4 (the frozen layout, the seqlock coherent read, and validation) live
 //! in [`kirra_contract_channel`]. This crate closes the chain:
 //!
-//! - **Step 5 — digest.** [`contract_digest`] hashes the **exact validated
-//!   snapshot bytes** ([`GovernorContractView::canonical_image`]) — the bytes the
-//!   judge approved, not the live region which may already have moved on.
+//! - **Step 5 — digest.** [`contract_digest`] hashes the **signable view's**
+//!   [`GovernorContractView::canonical_image`] — the bytes the governor approved,
+//!   not the live region which may already have moved on. Note transport `validate`
+//!   only CRCs `command[..command_len]`, whereas `canonical_image` covers the
+//!   *full* command array; callers must therefore pass a canonicalized / **enforced**
+//!   view (e.g. `kirra_core::contract_consumer::GovernorCycle::view_to_sign`, which
+//!   zero-fills the tail) so the digest is over deterministic bytes rather than
+//!   attacker-controlled padding.
 //! - **Step 6 — release token.** [`issue_release_token`] signs that digest with
 //!   the governor's Ed25519 key.
 //! - **Step 7 — actuator verify-before-release.** [`verify_release`] re-derives

--- a/crates/kirra-release-token/tests/governor_release_flow.rs
+++ b/crates/kirra-release-token/tests/governor_release_flow.rs
@@ -10,7 +10,7 @@ use kirra_contract_channel::reference::InProcessRegion;
 use kirra_contract_channel::{publish, AcceptedWatermark, VehicleCommandPayload, MAX_SNAPSHOT_RETRIES};
 use kirra_core::contract_consumer::{decide_cycle, GovernorOutcome};
 use kirra_core::kinematics_contract::VehicleKinematicsContract;
-use kirra_release_token::{sign_view, verify_view};
+use kirra_release_token::{issue_release_token, verify_release, ReleaseDenied};
 
 fn in_envelope() -> VehicleCommandPayload {
     VehicleCommandPayload {
@@ -37,18 +37,24 @@ fn actuator_releases_only_the_governor_signed_command() {
     let mut wm = AcceptedWatermark::new();
     let cycle = decide_cycle(&region, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES);
     assert!(matches!(cycle.outcome, GovernorOutcome::Actuate(_)), "in-envelope must actuate");
-    let view = cycle.view.expect("actuatable → a view to sign");
-    let token = sign_view(&view, &gov_key);
+    // `view_to_sign()` is the correct gate: Some only because the outcome is Actuate.
+    let view = *cycle.view_to_sign().expect("actuatable → a view to sign");
+    let token = issue_release_token(&view, &gov_key);
 
     // Actuator: verify BEFORE releasing. The governor-signed view passes.
-    assert!(verify_view(&view, &token, &gov_pub), "actuator releases the governor-signed command");
+    assert_eq!(
+        verify_release(&token, &view, &gov_pub),
+        Ok(()),
+        "actuator releases the governor-signed command"
+    );
 
     // Tamper: a command the governor did NOT sign (one flipped byte) is refused —
-    // the actuator will not release it (fail-closed).
+    // the actuator will not release it (fail-closed, digest mismatch).
     let mut forged = view;
     forged.command[0] ^= 0xFF;
-    assert!(
-        !verify_view(&forged, &token, &gov_pub),
+    assert_eq!(
+        verify_release(&token, &forged, &gov_pub),
+        Err(ReleaseDenied::DigestMismatch),
         "actuator must refuse a command the governor did not sign"
     );
 }
@@ -64,4 +70,32 @@ fn a_faulted_cycle_has_no_view_so_nothing_can_be_released() {
     let cycle = decide_cycle(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES);
     assert_eq!(cycle.outcome, GovernorOutcome::SafeStop);
     assert!(cycle.view.is_none(), "a fault yields no view → there is nothing to sign or release");
+    // And the correct gate agrees: no actuatable view to sign.
+    assert!(cycle.view_to_sign().is_none(), "SafeStop → view_to_sign() is None");
+}
+
+#[test]
+fn a_denied_command_is_received_but_never_signable() {
+    // A command that PASSES transport/codec but FAILS the kinematic envelope:
+    // `view` is populated (a command was received) yet the outcome is SafeStop.
+    // This is the footgun `view_to_sign()` closes — `view.is_some()` but the
+    // command must NEVER be signed for release.
+    let region = InProcessRegion::new();
+    let mut denied = in_envelope();
+    // A zero time-step is FINITE (transport/codec pass — NaN/Inf would be rejected
+    // earlier and yield no view) but the kinematic check DENIES it as
+    // `InvalidTimeDelta` → DenyBreach → SafeStop. (An over-SPEED command would
+    // merely clamp and actuate, so it is not a deny.)
+    denied.delta_time_s = 0.0;
+    publish(&region, 0, &denied.to_view(0, 1, 0, u64::MAX / 2));
+
+    let contract = VehicleKinematicsContract::nominal_reference_profile();
+    let mut wm = AcceptedWatermark::new();
+    let cycle = decide_cycle(&region, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES);
+    assert_eq!(cycle.outcome, GovernorOutcome::SafeStop, "over-envelope → SafeStop");
+    assert!(cycle.view.is_some(), "a command WAS received (transport/codec passed)");
+    assert!(
+        cycle.view_to_sign().is_none(),
+        "…but a denied command is never signable for release"
+    );
 }

--- a/crates/kirra-release-token/tests/governor_release_flow.rs
+++ b/crates/kirra-release-token/tests/governor_release_flow.rs
@@ -99,3 +99,54 @@ fn a_denied_command_is_received_but_never_signable() {
         "…but a denied command is never signable for release"
     );
 }
+
+#[test]
+fn a_clamped_command_signs_the_enforced_bytes_not_the_proposal() {
+    // The integrity claim under a Clamp: the governor must sign the ACTUATED
+    // (clamped) bytes, not the guest's raw proposal — otherwise the bytes released
+    // differ from the bytes signed. This is the regression test for that gap.
+    let gov_key = SigningKey::from_bytes(&[9u8; 32]);
+    let gov_pub = gov_key.verifying_key();
+
+    // A command far over the speed cap → the governor CLAMPS it (Actuate with a
+    // reduced velocity), so the actuated command differs from the proposal.
+    let region = InProcessRegion::new();
+    let mut over = in_envelope();
+    over.linear_velocity_mps = 1_000.0;
+    over.current_velocity_mps = 0.0;
+    let proposal_view = over.to_view(0, 1, 0, u64::MAX / 2);
+    publish(&region, 0, &proposal_view);
+
+    let contract = VehicleKinematicsContract::nominal_reference_profile();
+    let mut wm = AcceptedWatermark::new();
+    let cycle = decide_cycle(&region, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES);
+
+    // It actuated a CLAMPED command — velocity reduced from the 1000 proposal.
+    let actuated_velocity = match &cycle.outcome {
+        GovernorOutcome::Actuate(c) => c.linear_velocity_mps,
+        other => panic!("expected a clamp → Actuate, got {other:?}"),
+    };
+    assert!(actuated_velocity < 1_000.0, "velocity must have been clamped");
+
+    // The signable view is the ENFORCED view: it decodes to the clamped command,
+    // NOT the guest's 1000 m/s proposal.
+    let signed_view = *cycle.view_to_sign().expect("a clamp is actuatable");
+    let signed_cmd =
+        VehicleCommandPayload::from_validated_view(&signed_view).expect("enforced view decodes");
+    assert_eq!(
+        signed_cmd.linear_velocity_mps, actuated_velocity,
+        "the signed bytes must be the CLAMPED (actuated) bytes, not the proposal"
+    );
+
+    // Sign + verify closes over the enforced bytes.
+    let token = issue_release_token(&signed_view, &gov_key);
+    assert_eq!(verify_release(&token, &signed_view, &gov_pub), Ok(()));
+
+    // Critically: a token for the enforced command must NOT authorize the guest's
+    // original, un-clamped proposal — proving we bound the actuated bytes.
+    assert_eq!(
+        verify_release(&token, &proposal_view, &gov_pub),
+        Err(ReleaseDenied::DigestMismatch),
+        "a token for the clamped command must not release the raw proposal"
+    );
+}

--- a/crates/kirra-release-token/tests/governor_release_flow.rs
+++ b/crates/kirra-release-token/tests/governor_release_flow.rs
@@ -1,0 +1,67 @@
+// End-to-end governor → actuator release flow (HVCHAN §3 / ADR-0030 Clause F):
+// a proposal is published, the GOVERNOR validates + bounds it (`decide_cycle`),
+// signs the exact validated view, and the ACTUATOR verifies the token before it
+// would release — refusing anything the governor did not sign. Ties the L3
+// consumer (kirra-core) to the release bridge (this crate).
+
+use ed25519_dalek::SigningKey;
+
+use kirra_contract_channel::reference::InProcessRegion;
+use kirra_contract_channel::{publish, AcceptedWatermark, VehicleCommandPayload, MAX_SNAPSHOT_RETRIES};
+use kirra_core::contract_consumer::{decide_cycle, GovernorOutcome};
+use kirra_core::kinematics_contract::VehicleKinematicsContract;
+use kirra_release_token::{sign_view, verify_view};
+
+fn in_envelope() -> VehicleCommandPayload {
+    VehicleCommandPayload {
+        linear_velocity_mps: 10.0,
+        current_velocity_mps: 10.0, // accel 0
+        delta_time_s: 0.1,
+        steering_angle_deg: 1.0,
+        current_steering_angle_deg: 1.0,
+    }
+}
+
+#[test]
+fn actuator_releases_only_the_governor_signed_command() {
+    // The governor's signing identity (deterministic seed — no RNG in the test).
+    let gov_key = SigningKey::from_bytes(&[7u8; 32]);
+    let gov_pub = gov_key.verifying_key();
+
+    // Guest publishes an in-envelope proposal.
+    let region = InProcessRegion::new();
+    publish(&region, 0, &in_envelope().to_view(0, 1, 0, u64::MAX / 2));
+
+    // Governor: validate + bound, and get the exact validated view to sign.
+    let contract = VehicleKinematicsContract::nominal_reference_profile();
+    let mut wm = AcceptedWatermark::new();
+    let cycle = decide_cycle(&region, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES);
+    assert!(matches!(cycle.outcome, GovernorOutcome::Actuate(_)), "in-envelope must actuate");
+    let view = cycle.view.expect("actuatable → a view to sign");
+    let token = sign_view(&view, &gov_key);
+
+    // Actuator: verify BEFORE releasing. The governor-signed view passes.
+    assert!(verify_view(&view, &token, &gov_pub), "actuator releases the governor-signed command");
+
+    // Tamper: a command the governor did NOT sign (one flipped byte) is refused —
+    // the actuator will not release it (fail-closed).
+    let mut forged = view;
+    forged.command[0] ^= 0xFF;
+    assert!(
+        !verify_view(&forged, &token, &gov_pub),
+        "actuator must refuse a command the governor did not sign"
+    );
+}
+
+#[test]
+fn a_faulted_cycle_has_no_view_so_nothing_can_be_released() {
+    let region = InProcessRegion::new();
+    // Publish with an already-past deadline → the governor faults, no view.
+    publish(&region, 0, &in_envelope().to_view(0, 1, 0, 1_000));
+
+    let contract = VehicleKinematicsContract::nominal_reference_profile();
+    let mut wm = AcceptedWatermark::new();
+    let cycle = decide_cycle(&region, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES);
+    assert_eq!(cycle.outcome, GovernorOutcome::SafeStop);
+    assert!(cycle.view.is_none(), "a fault yields no view → there is nothing to sign or release");
+}

--- a/src/governor_release.rs
+++ b/src/governor_release.rs
@@ -1,278 +1,49 @@
 //! Governor release token — the cryptographic binding from an approved contract
 //! snapshot to an actuator release (HVCHAN-001 §3 steps 5-7).
 //!
-//! Steps 1-4 (the frozen layout, the seqlock coherent read, and validation) live
-//! in the `kirra-contract-channel` crate. This module closes the chain:
+//! **The binding logic now lives in the lean [`kirra_release_token`] crate** —
+//! ONE canonical release-token format (domain-separated, length-prefixed digest +
+//! signature), shared by both the heavy `kirra-verifier` root crate (here) and
+//! the lean L3 integration seam (`kirra-core` + `kirra-release-token`). This
+//! module re-exports that single implementation and adds only the root-local
+//! [`governor_key_id`] forensic helper, which needs the `audit_chain` key-id
+//! discipline (a root-crate dependency the lean crate deliberately does not pull).
 //!
-//! - **Step 5 — digest.** [`contract_digest`] hashes the **exact validated
-//!   snapshot bytes** ([`GovernorContractView::canonical_image`]) — the bytes the
-//!   judge approved, not the live region which may already have moved on.
-//! - **Step 6 — release token.** [`issue_release_token`] signs that digest with
-//!   the governor's Ed25519 key, **reusing the existing machinery** (`SigningKey`
-//!   / `verify_strict`, the `audit_chain` SHA-256 + domain-separation discipline).
-//!   **No new crypto primitive is introduced** (HVCHAN-001 §3 step 6).
-//! - **Step 7 — actuator verify-before-release.** [`verify_release`] re-derives
-//!   the digest over the command the actuator is **about to actuate** and checks
-//!   (a) the token's digest matches it **and** (b) the signature verifies against
-//!   the governor key. Either failure ⇒ **no release** (fail-closed).
-//!
-//! Both the digest and the token signature use **domain-separated,
-//! length-prefixed** payloads (the `compute_causal_record_hash` house style), so
-//! a governor-release digest or signature can never collide with — or be replayed
-//! as — an audit-chain or causal hash/signature.
-//!
-//! Out of scope here (deployment / integration): where the governor's signing key
-//! comes from, key rotation/selection, and the wire/SHM carriage of the token
-//! alongside the command. This module is the pure binding logic; it takes keys as
-//! parameters and is exercised end-to-end in tests.
+//! - **Step 5 — digest** ([`contract_digest`]): SHA-256 over the domain-separated,
+//!   length-prefixed [`kirra_contract_channel::GovernorContractView::canonical_image`]
+//!   — the exact validated snapshot bytes, not the live region.
+//! - **Step 6 — release token** ([`issue_release_token`]): Ed25519 over the
+//!   domain-separated digest payload. No new crypto primitive.
+//! - **Step 7 — verify-before-release** ([`verify_release`]): re-derive the digest
+//!   over the command about to be actuated; a digest mismatch OR bad signature ⇒
+//!   fail-closed [`ReleaseDenied`], no release.
 
-use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
-use sha2::{Digest, Sha256};
+// The single canonical release-token implementation. Re-exported so existing
+// callers (`kirra_verifier::governor_release::*`) are unchanged after the
+// consolidation.
+pub use kirra_release_token::{
+    contract_digest, issue_release_token, verify_release, ReleaseDenied, ReleaseToken,
+};
 
-use kirra_contract_channel::GovernorContractView;
-
-/// Domain tag for the contract digest (step 5). Distinct from every audit-chain
-/// / causal tag so the two hash spaces never collide.
-const DIGEST_DOMAIN: &[u8] = b"KIRRA-GOVERNOR-CONTRACT-DIGEST-V1";
-
-/// Domain tag for the release-token signing payload (step 6). Distinct again, so
-/// a release signature can never be reused as an audit signature and vice versa.
-const RELEASE_DOMAIN: &[u8] = b"KIRRA-GOVERNOR-RELEASE-V1";
-
-/// The release token: a digest of the approved command plus the governor's
-/// Ed25519 signature over it. Minimal and fixed-size (96 bytes on the wire); the
-/// actuator is supplied the governor verifying key out-of-band.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ReleaseToken {
-    /// SHA-256 digest over the validated snapshot's canonical image (step 5).
-    pub digest: [u8; 32],
-    /// Ed25519 signature over the domain-separated digest payload (step 6).
-    pub signature: [u8; 64],
-}
-
-/// Why the actuator refused to release (step 7). Both are fail-closed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ReleaseDenied {
-    /// The token's digest does not match the command about to be actuated — the
-    /// approval was for *different* bytes. (Substitution / stale token.)
-    DigestMismatch,
-    /// The signature does not verify against the governor key — forged or
-    /// tampered token, or wrong signer.
-    SignatureInvalid,
-}
-
-/// The digest payload (step 5): domain tag, then the length-prefixed canonical
-/// image. The image is fixed-size, but the length prefix keeps the encoding
-/// injective and consistent with the audit-chain discipline.
-fn digest_payload(view: &GovernorContractView) -> ([u8; 32 + 1024], usize) {
-    // Stack buffer sized to comfortably hold the domain tag + 8-byte length +
-    // the canonical image (176 bytes today). Returned with its used length.
-    let image = view.canonical_image();
-    let mut buf = [0u8; 32 + 1024];
-    let mut n = 0;
-    buf[n..n + DIGEST_DOMAIN.len()].copy_from_slice(DIGEST_DOMAIN);
-    n += DIGEST_DOMAIN.len();
-    buf[n..n + 8].copy_from_slice(&(image.len() as u64).to_le_bytes());
-    n += 8;
-    buf[n..n + image.len()].copy_from_slice(&image);
-    n += image.len();
-    (buf, n)
-}
-
-/// Step 5: the digest over the exact validated snapshot bytes. Deterministic;
-/// independent of the live shared region.
-pub fn contract_digest(view: &GovernorContractView) -> [u8; 32] {
-    let (buf, n) = digest_payload(view);
-    let mut hasher = Sha256::new();
-    hasher.update(&buf[..n]);
-    hasher.finalize().into()
-}
-
-/// The signing payload over a digest (step 6): domain tag, then the 32-byte
-/// digest length-prefixed. Domain separation prevents cross-protocol reuse.
-fn release_signing_payload(digest: &[u8; 32]) -> [u8; RELEASE_DOMAIN.len() + 8 + 32] {
-    let mut out = [0u8; RELEASE_DOMAIN.len() + 8 + 32];
-    let mut n = 0;
-    out[n..n + RELEASE_DOMAIN.len()].copy_from_slice(RELEASE_DOMAIN);
-    n += RELEASE_DOMAIN.len();
-    out[n..n + 8].copy_from_slice(&(32u64).to_le_bytes());
-    n += 8;
-    out[n..n + 32].copy_from_slice(digest);
-    out
-}
-
-/// Step 6: issue a release token binding `view` to the governor's approval, by
-/// signing its digest with `signing_key`.
-pub fn issue_release_token(view: &GovernorContractView, signing_key: &SigningKey) -> ReleaseToken {
-    let digest = contract_digest(view);
-    let signature = signing_key.sign(&release_signing_payload(&digest));
-    ReleaseToken { digest, signature: signature.to_bytes() }
-}
-
-/// Step 7: the actuator's verify-before-release gate. `actuating_view` is the
-/// command the actuator is about to drive; `governor_vk` is the trusted governor
-/// key. Returns `Ok(())` only if the token's digest matches the actuating command
-/// **and** the signature verifies — otherwise a fail-closed [`ReleaseDenied`].
-pub fn verify_release(
-    token: &ReleaseToken,
-    actuating_view: &GovernorContractView,
-    governor_vk: &VerifyingKey,
-) -> Result<(), ReleaseDenied> {
-    // (a) The token must approve exactly the bytes about to be actuated.
-    let expected = contract_digest(actuating_view);
-    if token.digest != expected {
-        return Err(ReleaseDenied::DigestMismatch);
-    }
-    // (b) The signature must verify against the governor key, over the same
-    // digest. `verify_strict` is the attestation path (rejects malleable / small-
-    // order points). A tampered digest field fails here even if (a) somehow passed.
-    let sig = Signature::from_bytes(&token.signature);
-    if governor_vk.verify_strict(&release_signing_payload(&token.digest), &sig).is_err() {
-        return Err(ReleaseDenied::SignatureInvalid);
-    }
-    Ok(())
-}
+use ed25519_dalek::VerifyingKey;
 
 /// Forensic key id of the governor signing key — the `audit_chain` key-id
 /// discipline (hex SHA-256 of the public key), for logging which key signed a
-/// release without storing it in the wire token.
+/// release without storing it in the wire token. Root-local (the lean release
+/// crate does not depend on `audit_chain`).
+#[must_use]
 pub fn governor_key_id(vk: &VerifyingKey) -> String {
     crate::audit_chain::verifying_key_id(vk)
-}
-
-impl ReleaseToken {
-    /// Canonical 96-byte wire form: `digest(32) || signature(64)`.
-    pub fn to_bytes(&self) -> [u8; 96] {
-        let mut out = [0u8; 96];
-        out[..32].copy_from_slice(&self.digest);
-        out[32..].copy_from_slice(&self.signature);
-        out
-    }
-
-    /// Parse the canonical wire form. (No verification — that is [`verify_release`].)
-    pub fn from_bytes(bytes: &[u8; 96]) -> Self {
-        let mut digest = [0u8; 32];
-        let mut signature = [0u8; 64];
-        digest.copy_from_slice(&bytes[..32]);
-        signature.copy_from_slice(&bytes[32..]);
-        Self { digest, signature }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn governor_key() -> SigningKey {
-        SigningKey::from_bytes(&[42u8; 32])
-    }
-
-    fn view(seq: u64, cmd: &[u8]) -> GovernorContractView {
-        GovernorContractView::new_command(2, seq, 100, 10_000, cmd).unwrap()
-    }
-
-    #[test]
-    fn honest_token_releases() {
-        let sk = governor_key();
-        let v = view(1, b"steer:1.5");
-        let token = issue_release_token(&v, &sk);
-        assert_eq!(verify_release(&token, &v, &sk.verifying_key()), Ok(()));
-    }
-
-    #[test]
-    fn digest_binds_the_exact_command_bytes() {
-        // A token issued for one command must NOT release a different command,
-        // even a one-byte change — the digest mismatch is caught.
-        let sk = governor_key();
-        let approved = view(1, b"steer:1.5");
-        let token = issue_release_token(&approved, &sk);
-
-        let tampered = view(1, b"steer:9.9");
-        assert_eq!(
-            verify_release(&token, &tampered, &sk.verifying_key()),
-            Err(ReleaseDenied::DigestMismatch)
-        );
-    }
-
-    #[test]
-    fn any_header_field_change_changes_the_digest() {
-        // The digest covers the whole canonical image, not just the payload: a
-        // changed sequence (replay number) or deadline yields a different digest.
-        let sk = governor_key();
-        let token = issue_release_token(&view(1, b"go"), &sk);
-        assert_eq!(
-            verify_release(&token, &view(2, b"go"), &sk.verifying_key()),
-            Err(ReleaseDenied::DigestMismatch),
-            "a different sequence is a different approved command"
-        );
-    }
-
-    #[test]
-    fn wrong_governor_key_is_rejected() {
-        let real = governor_key();
-        let imposter = SigningKey::from_bytes(&[7u8; 32]);
-        let v = view(1, b"go");
-        // Token signed by the imposter; actuator trusts the real governor key.
-        let token = issue_release_token(&v, &imposter);
-        assert_eq!(
-            verify_release(&token, &v, &real.verifying_key()),
-            Err(ReleaseDenied::SignatureInvalid)
-        );
-    }
-
-    #[test]
-    fn tampered_signature_is_rejected() {
-        let sk = governor_key();
-        let v = view(1, b"go");
-        let mut token = issue_release_token(&v, &sk);
-        token.signature[0] ^= 0x01;
-        assert_eq!(
-            verify_release(&token, &v, &sk.verifying_key()),
-            Err(ReleaseDenied::SignatureInvalid)
-        );
-    }
-
-    #[test]
-    fn tampered_digest_field_is_rejected() {
-        // Flipping the token's digest to match a substituted command does not
-        // help: the signature was over the original digest, so verify fails.
-        let sk = governor_key();
-        let v = view(1, b"go");
-        let mut token = issue_release_token(&v, &sk);
-        let substitute = view(1, b"no");
-        token.digest = contract_digest(&substitute); // now matches `substitute`
-        assert_eq!(
-            verify_release(&token, &substitute, &sk.verifying_key()),
-            Err(ReleaseDenied::SignatureInvalid),
-            "digest matches the substitute, but the signature does not cover it"
-        );
-    }
-
-    #[test]
-    fn wire_roundtrip_preserves_the_token() {
-        let sk = governor_key();
-        let token = issue_release_token(&view(3, b"abc"), &sk);
-        assert_eq!(ReleaseToken::from_bytes(&token.to_bytes()), token);
-    }
-
-    #[test]
-    fn release_payload_is_domain_separated_from_a_bare_digest() {
-        // The signed payload is NOT the bare digest; a signature is bound to the
-        // release domain and cannot be reused where a bare-digest signature is
-        // expected. (Guards against cross-protocol signature reuse.)
-        let sk = governor_key();
-        let v = view(1, b"go");
-        let token = issue_release_token(&v, &sk);
-        let bare = Signature::from_bytes(&token.signature);
-        assert!(
-            sk.verifying_key().verify_strict(&token.digest, &bare).is_err(),
-            "the signature must not verify over the bare digest (no domain tag)"
-        );
-    }
+    use ed25519_dalek::SigningKey;
 
     #[test]
     fn key_id_is_stable_hex_sha256() {
-        let sk = governor_key();
+        let sk = SigningKey::from_bytes(&[42u8; 32]);
         let id = governor_key_id(&sk.verifying_key());
         assert_eq!(id.len(), 64); // hex SHA-256
         assert_eq!(id, governor_key_id(&sk.verifying_key()));

--- a/src/governor_release.rs
+++ b/src/governor_release.rs
@@ -11,7 +11,9 @@
 //!
 //! - **Step 5 — digest** ([`contract_digest`]): SHA-256 over the domain-separated,
 //!   length-prefixed [`kirra_contract_channel::GovernorContractView::canonical_image`]
-//!   — the exact validated snapshot bytes, not the live region.
+//!   of the **signable** view, not the live region. (Transport `validate` CRCs only
+//!   `command[..command_len]`; `canonical_image` covers the full command array, so
+//!   sign a canonicalized/enforced view — see the `kirra-release-token` crate docs.)
 //! - **Step 6 — release token** ([`issue_release_token`]): Ed25519 over the
 //!   domain-separated digest payload. No new crypto primitive.
 //! - **Step 7 — verify-before-release** ([`verify_release`]): re-derive the digest


### PR DESCRIPTION
## Why

The last link of the L3 trust chain (HVCHAN §3 steps 5–6 / ADR-0013 / ADR-0030 Clause F): once the governor validates + bounds a proposal and decides it is **actuatable**, it **signs the digest of that exact validated `GovernorContractView`**; the actuator **verifies the token before releasing**. A guest cannot forge a command, and a single flipped byte between governor and actuator invalidates the release.

## What

**New crate `kirra-release-token`** (lean, `#[forbid(unsafe_code)]`):
- `digest_image` (SHA-256 over `canonical_image`, step 5) + `sign_release`/`verify_release` (Ed25519 over the digest, step 6) + `sign_view`/`verify_view` over `GovernorContractView`.
- **"No new crypto primitives"** (HVCHAN §3): the *same* `ed25519-dalek` + `sha2` the verifier's attestation path already uses, applied at this seam.
- `verify_*` is **fail-closed** — `false` on a tampered image / wrong key / altered signature.
- 5 unit tests (round-trip; tampered image; wrong key; tampered token; `sign_view` == `sign_release` over the canonical image).

**`kirra-core` (`contract_consumer`):**
- `receive()` now carries the validated **view** alongside the command (shared refactor — `consume_and_bound`/`decide` behavior unchanged, all prior tests pass).
- Add **`decide_cycle` → `GovernorCycle { outcome, view: Option<GovernorContractView> }`** so the seam can sign the **exact** bytes the governor validated. `view` is `Some` iff a command was received; `None` on a fault (nothing to sign → nothing releases). **kirra-core stays crypto-free** — the release crate is a *dev-dep only*, for the integration test.
- Factor `apply()` (enforce-action → outcome), shared by `decide` + `decide_cycle`.
- 2 new `decide_cycle` unit tests.

**End-to-end integration test** (`kirra-release-token/tests`): publish → `decide_cycle` → sign the view → actuator `verify_view` **accepts**; a forged (one-byte-flipped) command is **refused**; a faulted cycle yields **no view** so nothing can be released.

## Verification

kirra-core 179 tests + kirra-release-token 7 (5 unit + 2 integration); clippy clean. All host-testable — no ros2/QNX.

## Scope

Adds `crates/kirra-release-token` to the workspace. No boundary weakened; `validate_vehicle_command`, `consume_and_bound`, `decide`, and the frozen contract are unchanged.

This completes **ADR-0030 Clause F**. The only remaining L3 last-mile is **incr. 4** — the QNX `HvRegion` binding + #279 hypervisor-layer fault injection (pure target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_