### PR TITLE
build: source-identical `dist` profile + opt-in per-chipset tuning (target-cpu / PGO)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,23 @@ crate-type = ["rlib", "cdylib"]
 [profile.release]
 panic = "abort"
 
+# Production-artifact profile for the control-plane binaries. SOURCE-IDENTICAL to
+# `release` (inherits it, so `panic = "abort"` and the fail-closed rationale above
+# still hold) — it only turns UP codegen quality: thin LTO + a single codegen unit
+# + symbol strip. These are portable, chipset-AGNOSTIC wins; they do not fragment
+# source and do not reduce portability. Per-chipset `target-cpu` and PGO are opt-in
+# at the build invocation (see docs/PERFORMANCE_BUILD_TUNING.md), never a committed
+# global default. NOTE: this profile is for the HOST/edge Linux service build only.
+# The QNX safety-checker (`tools/qnx-rtm-harness/run_qnx_fdit.sh`) builds the judge
+# with its OWN fixed flags (`-C opt-level=2 -C panic=abort`, no LTO/PGO/target-cpu)
+# so the WCET evidence stays deterministic and reproducible — do not route the cert
+# build through this profile.
+[profile.dist]
+inherits = "release"
+lto = "thin"
+codegen-units = 1
+strip = true
+
 [features]
 ros2 = []
 tpm = ["dep:tss-esapi"]

--- a/docs/PERFORMANCE_BUILD_TUNING.md
+++ b/docs/PERFORMANCE_BUILD_TUNING.md
@@ -1,0 +1,131 @@
+# Performance Build Tuning — control-plane binaries
+
+Cheap, **safe** per-chipset performance for the host/edge Linux control-plane
+binaries (`kirra_verifier_service`, `kirra_carla_client`) via **build flags, not
+source forks**. Same code everywhere; only codegen is tuned.
+
+## The one hard rule (read first)
+
+**None of this touches the safety element.** The WCET-critical governor / checker
+evidence is produced by the QNX cross-build (`tools/qnx-rtm-harness/run_qnx_fdit.sh`),
+which builds the `no_std` judge with its own **fixed** flags
+(`-C opt-level=2 -C panic=abort`, **no** LTO / PGO / `target-cpu`). That build must
+stay deterministic and reproducible so the FDIT/WCET row is trustworthy. Do **not**
+route the cert build through the `dist` profile or apply any tuning below to it.
+Build-time tuning is for the *untrusted* control plane and the *untrusted* doer —
+never the trusted kernel.
+
+Three tiers, cheapest/safest first:
+
+| Tier | What | Portable? | Fragments source? | Where |
+|---|---|---|---|---|
+| **A. `dist` profile** | thin-LTO + `codegen-units=1` + `strip` | ✅ yes | ✅ no | committed (`Cargo.toml`) |
+| **B. `target-cpu`** | pin the ISA baseline / `native` | ⚠️ per-target | ✅ no | opt-in at invocation |
+| **C. PGO** | profile-guided optimization | ⚠️ workload-specific | ✅ no | opt-in (`scripts/pgo-build.sh`) |
+
+---
+
+## Tier A — the `dist` profile (always on for shipped artifacts)
+
+`Cargo.toml` defines `[profile.dist]` inheriting `release` (so `panic = "abort"`
+and its fail-closed rationale still hold) and turning up codegen quality only:
+
+```toml
+[profile.dist]
+inherits = "release"
+lto = "thin"          # ~most of fat-LTO's win, a fraction of the build time
+codegen-units = 1     # better cross-function optimization
+strip = true          # smaller binary
+```
+
+Build:
+
+```bash
+cargo build --profile dist --bin kirra_verifier_service
+# artifact: target/dist/kirra_verifier_service
+```
+
+`scripts/build_release.sh` already uses `--profile dist` for the portable musl
+release artifacts. This tier is chipset-agnostic — keep it in the portable build.
+
+**Want fat LTO?** For a final shipped artifact where build time doesn't matter,
+`lto = "fat"` squeezes a little more. Thin is the default because it keeps CI and
+local dist builds fast.
+
+---
+
+## Tier B — `target-cpu` (opt-in, per deployment)
+
+`target-cpu` lets the compiler use instructions your deployment CPU actually has
+(AVX2/AVX-512/BMI2 on x86, the right feature level on aarch64). It is **not**
+committed globally because it would break the portable musl release and cross-arch
+builds. Set it at the build invocation for a build you know the target of:
+
+```bash
+# Portable-but-modern x86-64 baseline (AVX2/BMI2; ~any server since ~2015).
+# Big win for ed25519 (MULX/ADX) and sha2 (SHA-NI is runtime-detected anyway).
+RUSTFLAGS="-C target-cpu=x86-64-v3" cargo build --profile dist --bin kirra_verifier_service
+
+# Newer server baseline (AVX-512): Intel Ice Lake+/Sapphire Rapids, AMD Zen4+.
+RUSTFLAGS="-C target-cpu=x86-64-v4" cargo build --profile dist --bin kirra_verifier_service
+
+# Exact host (only when the build machine == the deploy machine; NON-portable):
+RUSTFLAGS="-C target-cpu=native"    cargo build --profile dist --bin kirra_verifier_service
+
+# aarch64 edge SoC — pin the actual core (example; use your SoC's value):
+RUSTFLAGS="-C target-cpu=neoverse-n1" \
+  cargo build --profile dist --target aarch64-unknown-linux-gnu --bin kirra_verifier_service
+```
+
+Choosing a baseline:
+- `x86-64-v2` — universally safe on server hardware (~2010+). Minimal win.
+- `x86-64-v3` — **recommended default** for a modern-server deployment (AVX2 + BMI2/`MULX`/`ADX`). This is where the Ed25519 field arithmetic gets faster.
+- `x86-64-v4` — AVX-512; only if every node has it (Ice Lake+/Zen4+).
+- `native` — fastest, **not portable**; only for build-on-target or a pinned SKU.
+
+Note: `sha2` (SHA-NI) and `curve25519-dalek` already do **runtime** CPU-feature
+detection, so a chunk of the crypto win is free even without `target-cpu`. Tier B
+mainly helps the non-dispatched integer/vector paths.
+
+Prefer setting it per-invocation (as above) or in a **per-target** stanza of a
+build-host-local `.cargo/config.toml` — do **not** add a global `[build] rustflags`
+`target-cpu` (it would poison cross-arch and the portable release).
+
+---
+
+## Tier C — PGO (opt-in, per deployment)
+
+Profile-Guided Optimization compiles an instrumented binary, runs a
+**representative workload** against it, then rebuilds using the collected profile
+so the compiler lays out hot paths optimally. Worth it for a long-lived server
+binary with a stable traffic shape.
+
+```bash
+# 1) provide a workload driver that exercises the RUNNING service with
+#    representative traffic (register/attest/posture/federation routes), then:
+scripts/pgo-build.sh ./scripts/pgo-workload.sh
+# → target/dist/kirra_verifier_service, PGO-optimized
+```
+
+`scripts/pgo-build.sh` does: instrument → run your workload → `llvm-profdata
+merge` → rebuild with `-C profile-use`. It uses the **rustc-bundled**
+`llvm-profdata` (via `rustup component add llvm-tools-preview`) to avoid an
+LLVM-version mismatch with a system `llvm-profdata`.
+
+PGO composes with Tier B — pass `EXTRA_RUSTFLAGS="-C target-cpu=x86-64-v3"` to
+`pgo-build.sh` to stack them.
+
+The workload MUST be representative: PGO optimizes for what it sees, so a bad
+workload can pessimize real traffic. Capture a realistic mix, not a microbench.
+
+---
+
+## What NOT to do
+
+- ❌ A global `target-cpu` / `[build] rustflags` in the committed `.cargo/config.toml`
+  (breaks cross-arch + the portable release).
+- ❌ Any of A/B/C on the QNX judge / safety-checker cert build.
+- ❌ Source-level SIMD intrinsics or vendor forks in the control plane to chase the
+  last few percent — that fragments source and is not worth the maintenance. If a
+  hot loop truly needs it, put it in the *doer*, not here (and never in the checker).
+- ❌ Shipping a `native` build as the portable release artifact.

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -66,12 +66,14 @@ for i in "${!TARGETS[@]}"; do
     # are opt-in overlays — see docs/PERFORMANCE_BUILD_TUNING.md. These are the
     # PORTABLE musl artifacts, so target-cpu is intentionally NOT set here.
     cross build \
+        --locked \
         --profile dist \
         --target "${TARGET}" \
         --bin "${BINARY}"
 
     # Build CARLA client
     cross build \
+        --locked \
         --profile dist \
         --target "${TARGET}" \
         --bin "${CARLA_BINARY}"

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -60,15 +60,19 @@ for i in "${!TARGETS[@]}"; do
 
     echo "Building ${TARGET_NAME}..."
 
-    # Build main verifier service
+    # Build main verifier service.
+    # `--profile dist` = release + thin-LTO + single codegen unit + strip
+    # (source-identical, portable, chipset-agnostic). Per-chipset target-cpu / PGO
+    # are opt-in overlays — see docs/PERFORMANCE_BUILD_TUNING.md. These are the
+    # PORTABLE musl artifacts, so target-cpu is intentionally NOT set here.
     cross build \
-        --release \
+        --profile dist \
         --target "${TARGET}" \
         --bin "${BINARY}"
 
     # Build CARLA client
     cross build \
-        --release \
+        --profile dist \
         --target "${TARGET}" \
         --bin "${CARLA_BINARY}"
 
@@ -78,8 +82,8 @@ for i in "${!TARGETS[@]}"; do
     mkdir -p "${STAGING_BIN}"
 
     # Copy binaries
-    cp "target/${TARGET}/release/${BINARY}"       "${STAGING_BIN}/"
-    cp "target/${TARGET}/release/${CARLA_BINARY}" "${STAGING_BIN}/"
+    cp "target/${TARGET}/dist/${BINARY}"       "${STAGING_BIN}/"
+    cp "target/${TARGET}/dist/${CARLA_BINARY}" "${STAGING_BIN}/"
 
     # Copy supporting files
     cp install.sh                    "${STAGING}/"

--- a/scripts/pgo-build.sh
+++ b/scripts/pgo-build.sh
@@ -42,7 +42,11 @@ WORKLOAD="${WORKLOAD_DIR}/$(basename "$WORKLOAD_ARG")"
 [[ -n "$WORKLOAD_DIR" && -x "$WORKLOAD" ]] || { echo "ERROR: workload driver not found or not executable: $WORKLOAD_ARG" >&2; exit 1; }
 EXTRA_RUSTFLAGS="${EXTRA_RUSTFLAGS:-}"
 ADDR="${KIRRA_VERIFIER_ADDR:-127.0.0.1:8099}"
-PGO_DIR="${REPO_ROOT}/target/pgo-data"
+# Honor CARGO_TARGET_DIR so the profile data AND the built artifact land where
+# cargo actually emits them (defaults to the repo's target/). Covers the common
+# env-var relocation; a `.cargo/config.toml` target-dir override is out of scope.
+TARGET_DIR="${CARGO_TARGET_DIR:-${REPO_ROOT}/target}"
+PGO_DIR="${TARGET_DIR}/pgo-data"
 
 # The service fails closed at startup without a non-empty admin token (SG-008);
 # the phase-2 instrumented run must actually boot, so require it up front.
@@ -71,10 +75,10 @@ fi
 echo "== PGO phase 1/3: build instrumented $BIN"
 rm -rf "$PGO_DIR"
 RUSTFLAGS="-C profile-generate=${PGO_DIR} ${EXTRA_RUSTFLAGS}" \
-    cargo build --profile dist --bin "$BIN"
+    cargo build --locked --profile dist --bin "$BIN"
 
 echo "== PGO phase 2/3: run representative workload against the instrumented binary"
-KIRRA_VERIFIER_ADDR="$ADDR" "${REPO_ROOT}/target/dist/${BIN}" &
+KIRRA_VERIFIER_ADDR="$ADDR" "${TARGET_DIR}/dist/${BIN}" &
 SVC_PID=$!
 # Arm the teardown BEFORE anything that can fail/interrupt (the sleep, the
 # workload), so the background service is never left running on an abort.
@@ -99,9 +103,9 @@ if (( ${#PROFRAWS[@]} == 0 )); then
 fi
 "$PROFDATA" merge -o "${PGO_DIR}/merged.profdata" "${PROFRAWS[@]}"
 RUSTFLAGS="-C profile-use=${PGO_DIR}/merged.profdata -C llvm-args=-pgo-warn-missing-function ${EXTRA_RUSTFLAGS}" \
-    cargo build --profile dist --bin "$BIN"
+    cargo build --locked --profile dist --bin "$BIN"
 
 echo
-echo "PGO build complete: target/dist/${BIN}"
+echo "PGO build complete: ${TARGET_DIR}/dist/${BIN}"
 echo "  profile data: ${PGO_DIR}/merged.profdata"
 [[ -n "$EXTRA_RUSTFLAGS" ]] && echo "  stacked flags: ${EXTRA_RUSTFLAGS}"

--- a/scripts/pgo-build.sh
+++ b/scripts/pgo-build.sh
@@ -34,8 +34,12 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 BIN="${BIN:-kirra_verifier_service}"
 WORKLOAD_ARG="${1:?usage: scripts/pgo-build.sh <workload-driver-script>}"
-WORKLOAD="$(cd "$(dirname "$WORKLOAD_ARG")" 2>/dev/null && pwd)/$(basename "$WORKLOAD_ARG")"
-[[ -x "$WORKLOAD" ]] || { echo "ERROR: workload driver not found or not executable: $WORKLOAD_ARG" >&2; exit 1; }
+# `|| true` so a non-existent workload dir doesn't trip `set -e` inside the
+# command substitution (which would exit silently, with cd's stderr suppressed,
+# before the explicit check below). A failed cd leaves WORKLOAD_DIR empty.
+WORKLOAD_DIR="$(cd "$(dirname "$WORKLOAD_ARG")" 2>/dev/null && pwd || true)"
+WORKLOAD="${WORKLOAD_DIR}/$(basename "$WORKLOAD_ARG")"
+[[ -n "$WORKLOAD_DIR" && -x "$WORKLOAD" ]] || { echo "ERROR: workload driver not found or not executable: $WORKLOAD_ARG" >&2; exit 1; }
 EXTRA_RUSTFLAGS="${EXTRA_RUSTFLAGS:-}"
 ADDR="${KIRRA_VERIFIER_ADDR:-127.0.0.1:8099}"
 PGO_DIR="${REPO_ROOT}/target/pgo-data"

--- a/scripts/pgo-build.sh
+++ b/scripts/pgo-build.sh
@@ -22,13 +22,30 @@
 #   BIN               binary name (default: kirra_verifier_service)
 #   EXTRA_RUSTFLAGS   stacked onto both phases, e.g. "-C target-cpu=x86-64-v3"
 #   KIRRA_VERIFIER_ADDR   listen addr for the instrumented run (default 127.0.0.1:8099)
+#   KIRRA_ADMIN_TOKEN     REQUIRED — the service fails closed at startup without a
+#                         non-empty admin token (SG-008), so the instrumented run
+#                         below cannot start without it.
 set -euo pipefail
 
+# Resolve paths from the script location, not the caller's cwd, so this works from
+# anywhere. The workload arg is resolved to absolute BEFORE we cd into the repo.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 BIN="${BIN:-kirra_verifier_service}"
-WORKLOAD="${1:?usage: scripts/pgo-build.sh <workload-driver-script>}"
+WORKLOAD_ARG="${1:?usage: scripts/pgo-build.sh <workload-driver-script>}"
+WORKLOAD="$(cd "$(dirname "$WORKLOAD_ARG")" 2>/dev/null && pwd)/$(basename "$WORKLOAD_ARG")"
+[[ -x "$WORKLOAD" ]] || { echo "ERROR: workload driver not found or not executable: $WORKLOAD_ARG" >&2; exit 1; }
 EXTRA_RUSTFLAGS="${EXTRA_RUSTFLAGS:-}"
 ADDR="${KIRRA_VERIFIER_ADDR:-127.0.0.1:8099}"
-PGO_DIR="$(pwd)/target/pgo-data"
+PGO_DIR="${REPO_ROOT}/target/pgo-data"
+
+# The service fails closed at startup without a non-empty admin token (SG-008);
+# the phase-2 instrumented run must actually boot, so require it up front.
+: "${KIRRA_ADMIN_TOKEN:?ERROR: set KIRRA_ADMIN_TOKEN (non-empty) — the service fails closed at startup without it (SG-008)}"
+
+# Run everything from the repo root so target/dist paths resolve regardless of cwd.
+cd "$REPO_ROOT"
 
 # Use the rustc-BUNDLED llvm-profdata so its LLVM version matches rustc's (a
 # system llvm-profdata will refuse a version-mismatched raw profile).
@@ -46,7 +63,7 @@ RUSTFLAGS="-C profile-generate=${PGO_DIR} ${EXTRA_RUSTFLAGS}" \
     cargo build --profile dist --bin "$BIN"
 
 echo "== PGO phase 2/3: run representative workload against the instrumented binary"
-KIRRA_VERIFIER_ADDR="$ADDR" ./target/dist/"$BIN" &
+KIRRA_VERIFIER_ADDR="$ADDR" "${REPO_ROOT}/target/dist/${BIN}" &
 SVC_PID=$!
 # give it a moment to bind, then drive it; always tear the service down.
 sleep 2
@@ -57,7 +74,17 @@ wait "$SVC_PID" 2>/dev/null || true
 trap - EXIT
 
 echo "== PGO phase 3/3: merge profile + rebuild with -C profile-use"
-"$PROFDATA" merge -o "${PGO_DIR}/merged.profdata" "${PGO_DIR}"
+# `llvm-profdata merge` expects .profraw files (not a directory). Expand them and
+# fail clearly if the instrumented run produced none (e.g. the workload didn't
+# actually exercise the binary, or it never started).
+shopt -s nullglob
+PROFRAWS=("${PGO_DIR}"/*.profraw)
+shopt -u nullglob
+if (( ${#PROFRAWS[@]} == 0 )); then
+    echo "ERROR: no .profraw files in ${PGO_DIR} — did the instrumented run exercise ${BIN}?" >&2
+    exit 1
+fi
+"$PROFDATA" merge -o "${PGO_DIR}/merged.profdata" "${PROFRAWS[@]}"
 RUSTFLAGS="-C profile-use=${PGO_DIR}/merged.profdata -C llvm-args=-pgo-warn-missing-function ${EXTRA_RUSTFLAGS}" \
     cargo build --profile dist --bin "$BIN"
 

--- a/scripts/pgo-build.sh
+++ b/scripts/pgo-build.sh
@@ -52,12 +52,19 @@ PGO_DIR="${REPO_ROOT}/target/pgo-data"
 cd "$REPO_ROOT"
 
 # Use the rustc-BUNDLED llvm-profdata so its LLVM version matches rustc's (a
-# system llvm-profdata will refuse a version-mismatched raw profile).
+# system llvm-profdata will refuse a version-mismatched raw profile). It lives
+# under the sysroot's per-host rustlib bin, NOT the toolchain's top-level bin, so
+# `rustup which llvm-profdata` cannot resolve it — address it by exact path first,
+# then fall back to a search for an EXECUTABLE match.
 SYSROOT="$(rustc --print sysroot)"
-PROFDATA="$(find "$SYSROOT" -name 'llvm-profdata' -type f 2>/dev/null | head -1 || true)"
-if [[ -z "$PROFDATA" ]]; then
-    echo "ERROR: rustc-bundled llvm-profdata not found."
-    echo "       Install it:  rustup component add llvm-tools-preview"
+HOST_TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
+PROFDATA="${SYSROOT}/lib/rustlib/${HOST_TRIPLE}/bin/llvm-profdata"
+if [[ ! -x "$PROFDATA" ]]; then
+    PROFDATA="$(find "$SYSROOT" -name 'llvm-profdata' -type f -perm -u+x 2>/dev/null | head -1 || true)"
+fi
+if [[ -z "$PROFDATA" || ! -x "$PROFDATA" ]]; then
+    echo "ERROR: rustc-bundled llvm-profdata not found or not executable." >&2
+    echo "       Install it:  rustup component add llvm-tools-preview" >&2
     exit 1
 fi
 
@@ -69,9 +76,11 @@ RUSTFLAGS="-C profile-generate=${PGO_DIR} ${EXTRA_RUSTFLAGS}" \
 echo "== PGO phase 2/3: run representative workload against the instrumented binary"
 KIRRA_VERIFIER_ADDR="$ADDR" "${REPO_ROOT}/target/dist/${BIN}" &
 SVC_PID=$!
-# give it a moment to bind, then drive it; always tear the service down.
-sleep 2
+# Arm the teardown BEFORE anything that can fail/interrupt (the sleep, the
+# workload), so the background service is never left running on an abort.
 trap 'kill "$SVC_PID" 2>/dev/null || true' EXIT
+# give it a moment to bind, then drive it.
+sleep 2
 KIRRA_VERIFIER_ADDR="$ADDR" "$WORKLOAD"
 kill "$SVC_PID" 2>/dev/null || true
 wait "$SVC_PID" 2>/dev/null || true

--- a/scripts/pgo-build.sh
+++ b/scripts/pgo-build.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# scripts/pgo-build.sh — Profile-Guided Optimization for the control-plane binary.
+#
+# OPT-IN, per-deployment tuning of the UNTRUSTED control plane. It does NOT touch
+# the safety element: the QNX judge / checker WCET evidence is built separately by
+# tools/qnx-rtm-harness/run_qnx_fdit.sh with fixed, PGO-free flags. Never PGO the
+# cert build. See docs/PERFORMANCE_BUILD_TUNING.md.
+#
+# Three phases: instrument -> run a representative workload -> rebuild with the
+# collected profile.
+#
+# Usage:
+#   scripts/pgo-build.sh <workload-driver>
+#
+#   <workload-driver> is a script YOU provide that drives the RUNNING instrumented
+#   service with representative traffic and then returns. This script starts the
+#   instrumented binary, runs the driver against it (KIRRA_VERIFIER_ADDR is
+#   exported), stops it, then rebuilds. PGO optimizes for what the workload
+#   exercises, so make it representative (a realistic route mix, not a microbench).
+#
+# Env:
+#   BIN               binary name (default: kirra_verifier_service)
+#   EXTRA_RUSTFLAGS   stacked onto both phases, e.g. "-C target-cpu=x86-64-v3"
+#   KIRRA_VERIFIER_ADDR   listen addr for the instrumented run (default 127.0.0.1:8099)
+set -euo pipefail
+
+BIN="${BIN:-kirra_verifier_service}"
+WORKLOAD="${1:?usage: scripts/pgo-build.sh <workload-driver-script>}"
+EXTRA_RUSTFLAGS="${EXTRA_RUSTFLAGS:-}"
+ADDR="${KIRRA_VERIFIER_ADDR:-127.0.0.1:8099}"
+PGO_DIR="$(pwd)/target/pgo-data"
+
+# Use the rustc-BUNDLED llvm-profdata so its LLVM version matches rustc's (a
+# system llvm-profdata will refuse a version-mismatched raw profile).
+SYSROOT="$(rustc --print sysroot)"
+PROFDATA="$(find "$SYSROOT" -name 'llvm-profdata' -type f 2>/dev/null | head -1 || true)"
+if [[ -z "$PROFDATA" ]]; then
+    echo "ERROR: rustc-bundled llvm-profdata not found."
+    echo "       Install it:  rustup component add llvm-tools-preview"
+    exit 1
+fi
+
+echo "== PGO phase 1/3: build instrumented $BIN"
+rm -rf "$PGO_DIR"
+RUSTFLAGS="-C profile-generate=${PGO_DIR} ${EXTRA_RUSTFLAGS}" \
+    cargo build --profile dist --bin "$BIN"
+
+echo "== PGO phase 2/3: run representative workload against the instrumented binary"
+KIRRA_VERIFIER_ADDR="$ADDR" ./target/dist/"$BIN" &
+SVC_PID=$!
+# give it a moment to bind, then drive it; always tear the service down.
+sleep 2
+trap 'kill "$SVC_PID" 2>/dev/null || true' EXIT
+KIRRA_VERIFIER_ADDR="$ADDR" "$WORKLOAD"
+kill "$SVC_PID" 2>/dev/null || true
+wait "$SVC_PID" 2>/dev/null || true
+trap - EXIT
+
+echo "== PGO phase 3/3: merge profile + rebuild with -C profile-use"
+"$PROFDATA" merge -o "${PGO_DIR}/merged.profdata" "${PGO_DIR}"
+RUSTFLAGS="-C profile-use=${PGO_DIR}/merged.profdata -C llvm-args=-pgo-warn-missing-function ${EXTRA_RUSTFLAGS}" \
+    cargo build --profile dist --bin "$BIN"
+
+echo
+echo "PGO build complete: target/dist/${BIN}"
+echo "  profile data: ${PGO_DIR}/merged.profdata"
+[[ -n "$EXTRA_RUSTFLAGS" ]] && echo "  stacked flags: ${EXTRA_RUSTFLAGS}"


### PR DESCRIPTION
## Summary

Cheap, **safe** per-chipset performance for the control-plane binaries (`kirra_verifier_service`, `kirra_carla_client`) via **build flags, not source forks** — same code everywhere, only codegen is tuned. The one hard rule, enforced throughout: **none of this touches the safety element.** The WCET-critical QNX judge/checker build (`tools/qnx-rtm-harness/run_qnx_fdit.sh`) keeps its own fixed flags (`-C opt-level=2 -C panic=abort`, no LTO/PGO/target-cpu) so the timing evidence stays deterministic and reproducible.

Three tiers, cheapest/safest first.

### 1. `[profile.dist]` — always-on, source-identical, portable
Inherits `release` (so `panic = "abort"` and its fail-closed rationale carry over) and only turns up codegen quality:
- `lto = "thin"` + `codegen-units = 1` + `strip = true`.
- Chipset-agnostic; does not fragment source or reduce portability.
- `scripts/build_release.sh` now builds the portable musl artifacts with `--profile dist` (target-cpu intentionally **not** set — these stay portable).
- Verified: builds `kirra_verifier_service` in ~2m35s, 5.0 MB stripped.

### 2. `target-cpu` — opt-in, per deployment
Documented in `docs/PERFORMANCE_BUILD_TUNING.md`, set per build invocation (never a committed global, which would break cross-arch + the portable release):
- `x86-64-v3` recommended modern-server baseline (AVX2 + BMI2/`MULX`/`ADX` — where the Ed25519 field arithmetic speeds up; SHA-NI is already runtime-detected via `sha2`).
- `x86-64-v4` / `native` / per-SoC aarch64 documented with the portability trade-offs.

### 3. PGO — opt-in helper
`scripts/pgo-build.sh`: instrument → run a representative workload → `llvm-profdata merge` → `profile-use` rebuild. Uses the **rustc-bundled** `llvm-profdata` (avoids the classic LLVM-version mismatch) and composes with tier 2 via `EXTRA_RUSTFLAGS`.

## The safety carve-out (load-bearing)
`docs/PERFORMANCE_BUILD_TUNING.md` leads with, and the `Cargo.toml`/scripts repeat, the rule that none of this applies to the QNX judge / checker cert build. Build-time tuning is for the **untrusted** control plane (and, separately, the doer) — never the trusted kernel. This matches the doer/checker discipline: push chipset-specific performance into layers where a wrong result is bounded, keep the safety kernel uniform and boring.

## Also included
- `tools/qnx-rtm-harness/QNX_VM_RELAUNCH.md` — a QNX SDP 8.0 x86_64 VM relaunch runbook (#274): quick path, KVM-vs-TCG note, and the bake-in/auto-run recipe recovered from the on-target bring-up. Docs-only; unrelated to the build-tuning change but on the same branch.

## Scope / what this does NOT do
- No source-level SIMD/intrinsics or vendor forks (that fragments source; reserved for the doer).
- No change to any runtime behavior — build configuration + docs only.
- `Cargo.toml` diff is limited to the new `[profile.dist]` block.

## Testing
- `cargo build --profile dist --bin kirra_verifier_service` — green (stripped 5.0 MB).
- `Cargo.toml` parses; both scripts `bash -n`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_