### PR TITLE
build(parko): dist profile + doer build-tuning note (doer-side chipset tuning)

### DIFF
--- a/parko/BUILD_TUNING.md
+++ b/parko/BUILD_TUNING.md
@@ -59,8 +59,8 @@ SDK ships a ready-made helper for this shape in PR #749.)
 Build flags (A–C) are the *cheap* win. The **large** per-silicon gains on the
 doer are not build flags — they live in the inference backend:
 
-- `parko-core/src/backend_selector.rs` + `backends/` (`openvino_stub`, `qnn_stub`,
-  `amd_stub`) — the per-chip dispatch surface.
+- `crates/parko-core/src/backend_selector.rs` + `crates/parko-core/src/backends/`
+  (`openvino_stub`, `qnn_stub`, `amd_stub`) — the per-chip dispatch surface.
 - `parko-onnx`, `parko-openvino`, `parko-tensorrt` — the vendor backends (all
   runtime-linked, so they build without the native SDK present).
 

--- a/parko/BUILD_TUNING.md
+++ b/parko/BUILD_TUNING.md
@@ -1,0 +1,69 @@
+# Doer (parko) build tuning
+
+Per-chipset performance for the **doer** — the untrusted planning/inference side
+(`parko-*`). The doer is the sanctioned place to chase chipset-specific speed:
+it is bounded by the KIRRA checker, so a wrong or slow output is clamped, never
+actuated unbounded. The **safety kernel** (the SDK workspace) is the opposite —
+it stays uniform and keeps its own fixed-flag QNX build; never apply any of this
+to it. See `../docs/PERFORMANCE_BUILD_TUNING.md` for the control-plane side.
+
+Tiers, cheapest first.
+
+## Tier A — the `dist` profile (source-identical, portable)
+
+parko's `[profile.release]` is already aggressively tuned (`opt-level = 3`, fat
+LTO, `codegen-units = 1`). `[profile.dist]` inherits it and adds a symbol strip,
+mirroring the SDK so the shipping command is the same in both workspaces:
+
+```bash
+cd parko
+cargo build --profile dist -p parko-ros2   # the doer node binary
+```
+
+Chipset-agnostic; keep it in the portable build.
+
+## Tier B — `target-cpu` (opt-in, per deployment)
+
+Set at the build invocation for a known target — never a committed global (it
+breaks cross-arch + portable artifacts). The doer's geometric half (planning,
+routing, RSS math) is CPU-bound and benefits directly:
+
+```bash
+# modern x86_64 baseline (AVX2/BMI2)
+RUSTFLAGS="-C target-cpu=x86-64-v3" cargo build --profile dist -p parko-ros2
+
+# aarch64 edge SoC — pin the actual core (example)
+RUSTFLAGS="-C target-cpu=neoverse-n1" \
+  cargo build --profile dist --target aarch64-unknown-linux-gnu -p parko-ros2
+```
+
+The deployment ISA for the doer is typically aarch64 (Orin/Thor-class) — pin the
+SoC's core there.
+
+## Tier C — PGO (opt-in)
+
+Same shape as the SDK helper (`../scripts/pgo-build.sh`): instrument → run a
+representative planning/perception workload → `llvm-profdata merge` → rebuild with
+`-C profile-use`. Worth it for the doer's steady inner loop; use the rustc-bundled
+`llvm-profdata`. Composes with Tier B via `EXTRA_RUSTFLAGS`.
+
+## Tier D — the real per-silicon lever (backend + quantization)
+
+Build flags (A–C) are the *cheap* win. The **large** per-silicon gains on the
+doer are not build flags — they live in the inference backend:
+
+- `parko-core/src/backend_selector.rs` + `backends/` (`openvino_stub`, `qnn_stub`,
+  `amd_stub`) — the per-chip dispatch surface.
+- `parko-onnx`, `parko-openvino`, `parko-tensorrt` — the vendor backends (all
+  runtime-linked, so they build without the native SDK present).
+
+The wins there: **quantization** (FP16 → INT8/FP8 on the bounded-vocabulary MLP),
+**per-backend graph compilation** (TensorRT / OpenVINO / QNN / MIGraphX from one
+ONNX IR), and **DLA / NPU / Hexagon offload**. This is a separate project (a doer
+performance contract + calibration), tracked apart from this build-flag change.
+
+## What NOT to do
+
+- No global `target-cpu` / `[build] rustflags` (breaks cross-arch + portable builds).
+- None of A–D on the SDK's safety-kernel / QNX judge build.
+- Don't ship a `target-cpu=native` build as a portable artifact.

--- a/parko/BUILD_TUNING.md
+++ b/parko/BUILD_TUNING.md
@@ -5,7 +5,8 @@ Per-chipset performance for the **doer** — the untrusted planning/inference si
 it is bounded by the KIRRA checker, so a wrong or slow output is clamped, never
 actuated unbounded. The **safety kernel** (the SDK workspace) is the opposite —
 it stays uniform and keeps its own fixed-flag QNX build; never apply any of this
-to it. See `../docs/PERFORMANCE_BUILD_TUNING.md` for the control-plane side.
+to it. See **PR #749** (the SDK-side build-tuning notes) for the control-plane
+counterpart.
 
 Tiers, cheapest first.
 
@@ -13,14 +14,18 @@ Tiers, cheapest first.
 
 parko's `[profile.release]` is already aggressively tuned (`opt-level = 3`, fat
 LTO, `codegen-units = 1`). `[profile.dist]` inherits it and adds a symbol strip,
-mirroring the SDK so the shipping command is the same in both workspaces:
+keeping the shipping profile source-identical, portable, and chipset-agnostic:
 
 ```bash
 cd parko
-cargo build --profile dist -p parko-ros2   # the doer node binary
+cargo build --profile dist               # applies to every doer crate
 ```
 
-Chipset-agnostic; keep it in the portable build.
+> **The `parko_ros2_node` binary is `ros2`-feature-gated** (`required-features =
+> ["ros2"]`) and links `r2r`, so it builds ONLY on a sourced ROS 2 host — add
+> `--features ros2`: `cargo build --profile dist -p parko-ros2 --features ros2`.
+> The plain build above (and the `target-cpu` / PGO examples below) covers every
+> other doer crate; the same `--features ros2` on a ROS host adds the node binary.
 
 ## Tier B — `target-cpu` (opt-in, per deployment)
 
@@ -30,22 +35,24 @@ routing, RSS math) is CPU-bound and benefits directly:
 
 ```bash
 # modern x86_64 baseline (AVX2/BMI2)
-RUSTFLAGS="-C target-cpu=x86-64-v3" cargo build --profile dist -p parko-ros2
+RUSTFLAGS="-C target-cpu=x86-64-v3" cargo build --profile dist
 
 # aarch64 edge SoC — pin the actual core (example)
 RUSTFLAGS="-C target-cpu=neoverse-n1" \
-  cargo build --profile dist --target aarch64-unknown-linux-gnu -p parko-ros2
+  cargo build --profile dist --target aarch64-unknown-linux-gnu
 ```
 
 The deployment ISA for the doer is typically aarch64 (Orin/Thor-class) — pin the
-SoC's core there.
+SoC's core there. (Add `--features ros2` on a sourced ROS host to include the
+`parko_ros2_node` binary in either build.)
 
 ## Tier C — PGO (opt-in)
 
-Same shape as the SDK helper (`../scripts/pgo-build.sh`): instrument → run a
-representative planning/perception workload → `llvm-profdata merge` → rebuild with
-`-C profile-use`. Worth it for the doer's steady inner loop; use the rustc-bundled
-`llvm-profdata`. Composes with Tier B via `EXTRA_RUSTFLAGS`.
+Standard three-phase PGO: build instrumented (`-C profile-generate=<dir>`) → run a
+representative planning/perception workload → `llvm-profdata merge` the `*.profraw`
+→ rebuild with `-C profile-use=<merged>`. Use the **rustc-bundled** `llvm-profdata`
+(match rustc's LLVM version). Composes with Tier B by combining `RUSTFLAGS`. (The
+SDK ships a ready-made helper for this shape in PR #749.)
 
 ## Tier D — the real per-silicon lever (backend + quantization)
 

--- a/parko/Cargo.toml
+++ b/parko/Cargo.toml
@@ -9,10 +9,12 @@ codegen-units = 1
 
 # Production-artifact profile for the DOER (parko) binaries — the untrusted
 # planning/inference side. Inherits parko's already-tuned `release` (opt-level 3 +
-# fat LTO + single codegen unit) and adds a symbol strip, mirroring the SDK's
-# `--profile dist` so `cargo build --profile dist` is the shipping command in BOTH
-# workspaces. Source-identical + chipset-agnostic. Per-chipset `target-cpu` / PGO
-# and the (bigger) per-backend quantization lever are opt-in — see BUILD_TUNING.md.
+# fat LTO + single codegen unit) and adds a symbol strip, so `cargo build
+# --profile dist` is the shipping command for this workspace. Source-identical +
+# chipset-agnostic. Per-chipset `target-cpu` / PGO and the (bigger) per-backend
+# quantization lever are opt-in — see BUILD_TUNING.md. (The SDK workspace gains a
+# matching `dist` profile in a sibling PR; this one stands on its own regardless
+# of merge order.)
 #
 # Tuning the doer aggressively is SAFE: it is bounded by the KIRRA checker (a wrong
 # doer output is clamped, never actuated unbounded), so it is the sanctioned place

--- a/parko/Cargo.toml
+++ b/parko/Cargo.toml
@@ -6,3 +6,18 @@ resolver = "2"
 opt-level = 3
 lto = true
 codegen-units = 1
+
+# Production-artifact profile for the DOER (parko) binaries — the untrusted
+# planning/inference side. Inherits parko's already-tuned `release` (opt-level 3 +
+# fat LTO + single codegen unit) and adds a symbol strip, mirroring the SDK's
+# `--profile dist` so `cargo build --profile dist` is the shipping command in BOTH
+# workspaces. Source-identical + chipset-agnostic. Per-chipset `target-cpu` / PGO
+# and the (bigger) per-backend quantization lever are opt-in — see BUILD_TUNING.md.
+#
+# Tuning the doer aggressively is SAFE: it is bounded by the KIRRA checker (a wrong
+# doer output is clamped, never actuated unbounded), so it is the sanctioned place
+# for chipset-specific performance. This is NOT the safety kernel — that lives in
+# the SDK workspace and keeps its own fixed-flag QNX build (no LTO/PGO/target-cpu).
+[profile.dist]
+inherits = "release"
+strip = true


### PR DESCRIPTION
## Summary

The **doer-side** analog of the control-plane chipset tuning (#749). The doer (`parko-*` — planning + inference) is the sanctioned place to chase chipset-specific speed: it is **bounded by the KIRRA checker**, so a wrong or slow output is clamped, never actuated unbounded. The safety kernel is the opposite and keeps its own fixed-flag QNX build — none of this touches it.

## What

- **`parko/Cargo.toml` — `[profile.dist]`.** parko's `[profile.release]` is *already* aggressively tuned (`opt-level = 3`, fat LTO, `codegen-units = 1`), so the delta is small and honest: `dist` inherits release and adds `strip = true`, mirroring the SDK so `cargo build --profile dist` is the shipping command in **both** workspaces. Source-identical, chipset-agnostic.
- **`parko/BUILD_TUNING.md`** — the doer tuning tiers:
  - **A. `dist` profile** (above).
  - **B. `target-cpu`** — opt-in per invocation; the doer's geometric half (planning/routing/RSS) is CPU-bound and benefits; aarch64 SoC pin for the deployment ISA.
  - **C. PGO** — same shape as the SDK helper.
  - **D. the real per-silicon lever** — backend quantization (FP16→INT8/FP8) + per-backend graph compilation (`parko-onnx`/`parko-openvino`/`parko-tensorrt` + `backend_selector`) + DLA/NPU/Hexagon offload. Not a build flag; tracked as a separate project.

## Scope / what this does NOT do

- No runtime behavior change — build configuration + a doc, only.
- No source-level SIMD/intrinsics or vendor forks.
- Nothing applied to the SDK safety-kernel / QNX judge build.
- The doc is kept **parko-local** (not folded into the SDK's `docs/PERFORMANCE_BUILD_TUNING.md`) since that doc lives in the still-open #749; cross-referenced instead.

## Testing

- `parko/Cargo.toml` parses (`cargo metadata`).
- `cargo build --profile dist -p parko-core` — green.

## Relationship to #749

#749 is the control-plane (`kirra_verifier_service`) chipset tuning; this is the doer (`parko`) counterpart. Independent branches/PRs; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_