### PR TITLE
docs(parko): upgrade #749 forward-refs to real links (post-merge cleanup)

### DIFF
--- a/parko/BUILD_TUNING.md
+++ b/parko/BUILD_TUNING.md
@@ -5,8 +5,8 @@ Per-chipset performance for the **doer** — the untrusted planning/inference si
 it is bounded by the KIRRA checker, so a wrong or slow output is clamped, never
 actuated unbounded. The **safety kernel** (the SDK workspace) is the opposite —
 it stays uniform and keeps its own fixed-flag QNX build; never apply any of this
-to it. See **PR #749** (the SDK-side build-tuning notes) for the control-plane
-counterpart.
+to it. See [`../docs/PERFORMANCE_BUILD_TUNING.md`](../docs/PERFORMANCE_BUILD_TUNING.md)
+for the control-plane counterpart.
 
 Tiers, cheapest first.
 
@@ -51,8 +51,9 @@ SoC's core there. (Add `--features ros2` on a sourced ROS host to include the
 Standard three-phase PGO: build instrumented (`-C profile-generate=<dir>`) → run a
 representative planning/perception workload → `llvm-profdata merge` the `*.profraw`
 → rebuild with `-C profile-use=<merged>`. Use the **rustc-bundled** `llvm-profdata`
-(match rustc's LLVM version). Composes with Tier B by combining `RUSTFLAGS`. (The
-SDK ships a ready-made helper for this shape in PR #749.)
+(match rustc's LLVM version). Composes with Tier B by combining `RUSTFLAGS`. The
+SDK ships a ready-made helper for this shape:
+[`../scripts/pgo-build.sh`](../scripts/pgo-build.sh).
 
 ## Tier D — the real per-silicon lever (backend + quantization)
 

--- a/parko/Cargo.toml
+++ b/parko/Cargo.toml
@@ -12,9 +12,9 @@ codegen-units = 1
 # fat LTO + single codegen unit) and adds a symbol strip, so `cargo build
 # --profile dist` is the shipping command for this workspace. Source-identical +
 # chipset-agnostic. Per-chipset `target-cpu` / PGO and the (bigger) per-backend
-# quantization lever are opt-in — see BUILD_TUNING.md. (The SDK workspace gains a
-# matching `dist` profile in a sibling PR; this one stands on its own regardless
-# of merge order.)
+# quantization lever are opt-in — see BUILD_TUNING.md. (The SDK workspace has a
+# matching `dist` profile, so `cargo build --profile dist` is the shipping command
+# in both workspaces.)
 #
 # Tuning the doer aggressively is SAFE: it is bounded by the KIRRA checker (a wrong
 # doer output is clamped, never actuated unbounded), so it is the sanctioned place


### PR DESCRIPTION
## Summary

Small post-merge doc cleanup. While #749 (SDK-side build tuning) was open, #750's parko docs deliberately referenced it as *"PR #749"* / *"sibling PR"* and described the PGO steps inline — to avoid dangling links that would break if #750 merged first. Both are now merged, so those targets exist on `main` and the forward-references can become real links.

## Changes (docs only)

- `parko/BUILD_TUNING.md` intro → links [`../docs/PERFORMANCE_BUILD_TUNING.md`](../docs/PERFORMANCE_BUILD_TUNING.md) instead of "PR #749".
- `parko/BUILD_TUNING.md` Tier C → links the real helper [`../scripts/pgo-build.sh`](../scripts/pgo-build.sh) instead of "the SDK ships a helper … in PR #749".
- `parko/Cargo.toml` comment → drops the merge-order hedge; the SDK now has a matching `dist` profile, so `cargo build --profile dist` is the shipping command in both workspaces.

## Testing

- `parko` manifest parses (`cargo metadata`).
- Both new relative links resolve to files present on `main`.
- No `PR #749` / `sibling PR` / merge-order references remain.

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_