### PR TITLE
docs(parko): record Q-1b measured results from the Orin NX bench

### DIFF
--- a/parko/QUANTIZATION_Q1_SCOPE.md
+++ b/parko/QUANTIZATION_Q1_SCOPE.md
@@ -1,6 +1,8 @@
 # Q-1 — PTQ INT8 on one backend + the metric producers (detailed scope)
 
-Status: **scoping / design** (not yet implemented). Elaborates phase **Q-1** of
+Status: **COMPLETE — measured on target** (Q-1a: #755/#756; Q-1b: #757; Orin
+exit criteria met 2026-07-02, results in
+`crates/parko-tensorrt/Q1B_ORIN.md` §"Measured results"). Elaborates phase **Q-1** of
 `QUANTIZATION_DESIGN.md` §9. Q-0 landed the measuring stick
 (`parko_core::perf_contract` — the contract + latency harness, with `quality`
 and `admissibility` as *inputs*). Q-1 turns those two inputs into **real
@@ -102,7 +104,11 @@ Runnable on your Jetson Orin NX; skipped where the GPU/EP is absent.
    `PARKO_TRT_REQUIRE_EP=1` (see `parko/crates/parko-tensorrt/tests/*_probe.rs`). A Q-1b row is
    `SKIPPED` where the silicon/SDK is absent — **never silently passed**.
 
-**Q-1b exit criteria (on the Orin, strict lane):**
+**Q-1b exit criteria (on the Orin, strict lane):** ✅ **MET 2026-07-02** — see
+`crates/parko-tensorrt/Q1B_ORIN.md` §"Measured results" (fp32 + int8-qdq PASS,
+fp16 latency-only; INT8 zero admissibility regression; notable finding: INT8 is
+*slower* than FP32 at this model size — the contract measured it, selection
+verdict for this model on Orin is FP32).
 - FP32, FP16, and INT8 rows for the exported planner, each meeting or explicitly
   failing the §4 contract; INT8 within the admissibility-regression budget of FP32.
 - Cross-precision comparison is **quality-based, not bit-based** (design-note §7.4:

--- a/parko/crates/parko-tensorrt/Q1B_ORIN.md
+++ b/parko/crates/parko-tensorrt/Q1B_ORIN.md
@@ -71,3 +71,48 @@ KIRRA_DOER_EVAL_REQUIRE_ORT=1 cargo test -p kirra-doer-eval --test onnx_roundtri
   numbers land (design note §11).
 - All of this tunes the **untrusted doer**; the checker is unchanged and bounds
   the INT8 planner's proposals exactly as it bounds FP32 ones.
+
+---
+
+## Measured results — Jetson Orin NX 16GB (2026-07-02)
+
+Q-1b exit criteria: **MET**. Bench: Orin NX 16GB, JetPack 6 (`jp6/cu126`),
+onnxruntime-gpu **1.23.0** (venv, `load-dynamic`), `ort` rc.11, strict lane
+(`PARKO_TRT_REQUIRE_EP=1`), artifacts as checked in at `artifacts/doer-eval/`.
+
+### Probe (step 2)
+
+`INT8-QDQ PROBE PASSED` — cold INT8 engine build **48 ms**, engine SHA
+`2fbc1a6f…9052e5f1`, scores `[0.0448861, -0.4265421, -1.3937072, -3.0795364]`,
+argmax `0`, stable across runs.
+
+### Contract matrix (step 3; iters=1000, warmup=100)
+
+| row | engine build | p50 | p99 | max | contract |
+|---|---|---|---|---|---|
+| fp32 | 19 ms | 97 µs | 115 µs | 157 µs | **PASS** (quality 1.000, admissibility 1.000) |
+| fp16 | 1 ms | 97 µs | 134 µs | 175 µs | informational (latency-only by design) |
+| int8-qdq | 1 ms | 146 µs | 163 µs | 185 µs | **PASS** (quality 1.000, admissibility 1.000) |
+
+All rows are ~60–90× under the placeholder 10 ms p99 budget
+(`PerfContract::illustrative()` — real per-class budgets are design-note §11).
+
+### Findings
+
+1. **The calibration is consistent across silicon (design note §6, measured).**
+   The TensorRT INT8 engine's scores agree with the same QDQ artifact run
+   through CPU ONNX Runtime to ~1e-7, identical argmax — one calibration
+   artifact, two very different backends, the same decision. Engine SHA matched
+   between the probe and the eval run (deterministic build).
+2. **FP16 is a no-op at this model size.** The fp16 row produced a
+   byte-identical engine to fp32 (same SHA): TensorRT judged reduced precision
+   pointless for a 4→8→4 MLP. Expected; recorded so nobody reads the fp16 row
+   as a win.
+3. **INT8 is SLOWER than FP32 on this model (146 µs vs 97 µs p50)** — the Q/DQ
+   overhead dominates a net with almost no compute. This is the contract
+   framework doing its job: "closed the gap" is measured, not assumed, and for
+   THIS model on THIS chip the selection verdict is **FP32**. INT8 earns its row
+   when a real-sized net goes through the same pipeline (Q-2+ / larger doer).
+
+Honesty: all latency figures are on-target-indicative (pinning/isolation not
+controlled), NOT a WCET/FTTI claim.


### PR DESCRIPTION
## What

Doc-only: records the Q-1b bench run (Jetson Orin NX 16GB, JetPack 6, onnxruntime-gpu 1.23.0, strict lane) that closes the Q-1 phase.

- **`Q1B_ORIN.md`** gains a "Measured results" section: the probe result (INT8 engine built in 48 ms, deterministic SHA), the full contract matrix (fp32 97 µs p50 / int8-qdq 146 µs p50, both PASS; fp16 latency-only as designed), and the three findings.
- **`QUANTIZATION_Q1_SCOPE.md`** status flipped to **COMPLETE — measured on target**, exit criteria marked met with a pointer to the results.

## The findings worth recording

1. **Calibration consistent across silicon (design note §6, now measured):** the TensorRT INT8 engine's scores match the same QDQ artifact through CPU ONNX Runtime to ~1e-7, identical argmax — one calibration artifact, two very different backends, same decision.
2. **FP16 is a no-op at this model size** — byte-identical engine SHA to fp32; recorded so the fp16 row isn't misread as a win.
3. **INT8 is *slower* than FP32 on this model** (146 µs vs 97 µs p50) — Q/DQ overhead dominates a 4→8→4 MLP. This is the contract framework working as designed: "closed the gap" is measured, not assumed; the selection verdict for this model on the Orin is FP32, and INT8 earns its row when a real-sized net goes through the same pipeline.

All latency figures are flagged on-target-indicative, not WCET/FTTI; budgets remain the documented illustrative placeholder pending §11 per-class numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_