### PR TITLE
feat(parko): Q-2 — precision-aware selection (evidence ladder, visible degradation)

### DIFF
--- a/parko/QUANTIZATION_DESIGN.md
+++ b/parko/QUANTIZATION_DESIGN.md
@@ -165,7 +165,10 @@ is absent, never silently passed). Reuses the existing bench scaffolding.
   Detailed scope: `QUANTIZATION_Q1_SCOPE.md` (metric producers + in-Rust PTQ on
   CI; real TensorRT INT8 gated to the Orin lane).
 - **Q-2 — precision-aware selection.** Extend `BackendSelector` with the per-chip
-  allow-list + fail-closed fallback.
+  allow-list + fail-closed fallback. Implemented: `parko_core::precision`
+  (`PrecisionLadder` from `KIRRA_PRECISION_LADDER` + `select_by_ladder`, walked by
+  operational proof, degrading visibly per §5 — composes with `BackendSelector`
+  rather than replacing it) and the `parko-tensorrt` `precision_select` Orin demo.
 - **Q-3 — fan out** INT8 to QNN / TIDL / Vitis as those backends land
   (PARK-027/028/030).
 - **Q-4 — FP8/INT4** (extend `PrecisionMode`) where hardware supports it, if the

--- a/parko/crates/parko-core/src/lib.rs
+++ b/parko/crates/parko-core/src/lib.rs
@@ -38,6 +38,9 @@ pub mod telemetry;
 // Q-0 (doer chipset tuning): the performance contract + eval harness — the
 // pass/fail measuring stick for per-silicon inference (parko/QUANTIZATION_DESIGN.md).
 pub mod perf_contract;
+// Q-2: precision-aware selection — the evidence-derived precision ladder walked
+// by operational proof, degrading visibly (parko/QUANTIZATION_DESIGN.md §5).
+pub mod precision;
 
 pub use audit::{
     AuditClient, DecisionRecord, FaultRecord, HealthRecord, MockAuditClient, NoopAuditClient,
@@ -63,6 +66,10 @@ pub use backend_selector::{
 
 pub use perf_contract::{
     evaluate, run_latency, ContractFailure, ContractVerdict, EvalRow, LatencyStats, PerfContract,
+};
+
+pub use precision::{
+    select_by_ladder, LadderSelection, PrecisionLadder, KIRRA_PRECISION_LADDER_ENV,
 };
 
 pub use backends::mock::MockBackend;

--- a/parko/crates/parko-core/src/precision.rs
+++ b/parko/crates/parko-core/src/precision.rs
@@ -123,10 +123,25 @@ impl PrecisionLadder {
         }
     }
 
-    /// Build the ladder from [`KIRRA_PRECISION_LADDER_ENV`].
+    /// Build the ladder from [`KIRRA_PRECISION_LADDER_ENV`]. Fail-closed on a
+    /// present-but-non-UTF-8 value: `.ok()` would silently collapse it to the
+    /// fp32 default, which is exactly the "malformed config selects something
+    /// else" hazard the parse refuses everywhere else.
     pub fn from_env() -> Result<Self, BackendError> {
-        let raw = std::env::var(KIRRA_PRECISION_LADDER_ENV).ok();
-        Self::from_env_value(raw.as_deref())
+        Self::from_env_lookup(std::env::var(KIRRA_PRECISION_LADDER_ENV))
+    }
+
+    /// The env-lookup routing, separated from the env read for testability
+    /// (a non-UTF-8 value cannot be injected without `set_var`, which the
+    /// workspace forbids in tests).
+    fn from_env_lookup(raw: Result<String, std::env::VarError>) -> Result<Self, BackendError> {
+        match raw {
+            Ok(s) => Self::from_env_value(Some(s.as_str())),
+            Err(std::env::VarError::NotPresent) => Self::from_env_value(None),
+            Err(std::env::VarError::NotUnicode(_)) => Err(BackendError::InitializationError(
+                format!("{KIRRA_PRECISION_LADDER_ENV} contains non-UTF-8 data (fail-closed)"),
+            )),
+        }
     }
 
     /// The rungs, in walk order (including the appended FP32 anchor, if any).
@@ -244,6 +259,21 @@ mod tests {
             assert_eq!(l.rungs(), &[PrecisionMode::FP32]);
             assert!(!l.fp32_anchored());
         }
+    }
+
+    #[test]
+    fn non_utf8_env_value_fails_closed_not_default() {
+        use std::os::unix::ffi::OsStringExt;
+        let bad = std::ffi::OsString::from_vec(vec![0xFF, 0xFE]);
+        let err = PrecisionLadder::from_env_lookup(Err(std::env::VarError::NotUnicode(bad)))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("non-UTF-8"),
+            "a present-but-non-UTF-8 ladder must be a typed error, never the fp32 default"
+        );
+        // NotPresent still routes to the default (unset ≠ malformed).
+        let l = PrecisionLadder::from_env_lookup(Err(std::env::VarError::NotPresent)).unwrap();
+        assert_eq!(l.rungs(), &[PrecisionMode::FP32]);
     }
 
     #[test]

--- a/parko/crates/parko-core/src/precision.rs
+++ b/parko/crates/parko-core/src/precision.rs
@@ -1,0 +1,300 @@
+//! # Precision-aware backend selection (Q-2; `parko/QUANTIZATION_DESIGN.md` §5/§9)
+//!
+//! Q-0/Q-1 built the measuring stick and produced the first per-chip evidence
+//! (`parko/QUANTIZATION_Q1_SCOPE.md`; measured results in
+//! `parko/crates/parko-tensorrt/Q1B_ORIN.md`). This module turns that evidence
+//! into a runtime choice: a **precision ladder** — the operator's ORDERED list of
+//! the `(chip, model)` precision rows that **passed the performance contract** —
+//! walked at startup to pick the artifact actually run.
+//!
+//! ## Semantics (design note §5, exactly)
+//!
+//! - **The ladder is evidence, not preference.** Its entries are the rows that
+//!   passed the §4 contract on THIS chip, ordered by measured merit. The Q-1b Orin
+//!   result is the canonical example of why order is measured, not assumed: INT8
+//!   was *slower* than FP32 on the planner scorer, so that deployment's ladder is
+//!   just `fp32`.
+//! - **A rung is "supported" by OPERATIONAL PROOF, not a static flag.**
+//!   `BackendCapabilities` are deliberately conservative (`supports_int8` stays
+//!   `false` until hardware-measured), so selection would be inert if it gated on
+//!   them. Instead [`select_by_ladder`] attempts each rung via the caller's
+//!   `try_build` (construct + fail-closed `warm_up` — the same proof the Q-1b
+//!   probe uses) and takes the first that actually works.
+//! - **Failure degrades, visibly — it does not fail closed.** The checker, not
+//!   the selector, is the fail-closed safety authority; the doer is
+//!   availability-preserving. A rung that will not build is recorded in
+//!   [`LadderSelection::rejected`] (the no-silent-caps rule) and the walk
+//!   continues. To guarantee the doer keeps running, [`PrecisionLadder::parse`]
+//!   **anchors the ladder with FP32** if the operator omitted it (flagged in
+//!   [`PrecisionLadder::fp32_anchored`], never silent) — the always-available
+//!   reference artifact, the selection analogue of `PlanOutput::safe_stop`.
+//! - **Nothing outside the ladder is ever chosen.** Exhausting every rung is an
+//!   `Err` — the existing `BackendSelector` fail-closed posture; no silent
+//!   substitution of an unlisted precision.
+//!
+//! Selection composes with (does not replace) [`crate::BackendSelector`]: the
+//! descriptor→backend axis stays PARK-022's; this module adds the precision axis
+//! via a caller-supplied constructor closure, because only the integrator knows
+//! the per-precision artifact paths and backend config (e.g. the TensorRT
+//! `Int8Qdq` posture + per-precision engine cache).
+//!
+//! Safety framing: selection tunes the UNTRUSTED doer's inference only. Whatever
+//! rung wins, the KIRRA checker bounds its proposals exactly as it bounds FP32.
+
+use crate::backend::{BackendError, PrecisionMode};
+
+/// Env var carrying the deployment's precision ladder — a comma-separated,
+/// highest-merit-first list of contract-passing precisions, e.g. `fp16,fp32`.
+/// Unset/blank → the `fp32`-only default. Unknown tokens are an `Err`
+/// (fail-closed parse — never a silently different precision), mirroring
+/// [`crate::KIRRA_BACKEND_ENV`].
+pub const KIRRA_PRECISION_LADDER_ENV: &str = "KIRRA_PRECISION_LADDER";
+
+/// The operator's ordered precision allow-list for this deployment (see the
+/// module docs for the semantics — entries must come from contract evidence).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrecisionLadder {
+    rungs: Vec<PrecisionMode>,
+    fp32_anchored: bool,
+}
+
+impl PrecisionLadder {
+    /// The unconfigured default: FP32 only (the reference artifact). Absent an
+    /// explicit operator choice, no reduced-precision artifact is engaged —
+    /// engaging one must be a deliberate, evidence-backed act.
+    #[must_use]
+    pub fn default_fp32() -> Self {
+        Self { rungs: vec![PrecisionMode::FP32], fp32_anchored: false }
+    }
+
+    /// Parse a comma-separated ladder (`"int8,fp16,fp32"`; case-insensitive,
+    /// whitespace-tolerant). Fail-closed: an unknown or duplicate token, or an
+    /// empty list, is an `Err` — a config typo must never select something else.
+    /// If `fp32` is absent it is APPENDED as the availability anchor and
+    /// [`Self::fp32_anchored`] reports it (visible, per the no-silent-caps rule).
+    pub fn parse(s: &str) -> Result<Self, BackendError> {
+        let mut rungs = Vec::new();
+        for raw in s.split(',') {
+            let tok = raw.trim();
+            if tok.is_empty() {
+                return Err(BackendError::InitializationError(format!(
+                    "empty precision token in ladder {s:?} (fail-closed)"
+                )));
+            }
+            let mode = match tok.to_ascii_lowercase().as_str() {
+                "fp32" => PrecisionMode::FP32,
+                "fp16" => PrecisionMode::FP16,
+                "int8" => PrecisionMode::INT8,
+                other => {
+                    return Err(BackendError::InitializationError(format!(
+                        "unknown precision {other:?} in ladder {s:?} (fail-closed; \
+                         expected fp32|fp16|int8)"
+                    )));
+                }
+            };
+            if rungs.contains(&mode) {
+                return Err(BackendError::InitializationError(format!(
+                    "duplicate precision {tok:?} in ladder {s:?} (fail-closed; \
+                     a repeated rung is a config error)"
+                )));
+            }
+            rungs.push(mode);
+        }
+        if rungs.is_empty() {
+            return Err(BackendError::InitializationError(
+                "empty precision ladder (fail-closed)".to_string(),
+            ));
+        }
+        let fp32_anchored = !rungs.contains(&PrecisionMode::FP32);
+        if fp32_anchored {
+            rungs.push(PrecisionMode::FP32);
+        }
+        Ok(Self { rungs, fp32_anchored })
+    }
+
+    /// The env-routing logic, separated from the env read for testability
+    /// (the workspace invariant: no `set_var` in tests). `None`/blank → the
+    /// FP32-only default; otherwise [`Self::parse`].
+    pub fn from_env_value(value: Option<&str>) -> Result<Self, BackendError> {
+        match value {
+            None => Ok(Self::default_fp32()),
+            Some(s) if s.trim().is_empty() => Ok(Self::default_fp32()),
+            Some(s) => Self::parse(s),
+        }
+    }
+
+    /// Build the ladder from [`KIRRA_PRECISION_LADDER_ENV`].
+    pub fn from_env() -> Result<Self, BackendError> {
+        let raw = std::env::var(KIRRA_PRECISION_LADDER_ENV).ok();
+        Self::from_env_value(raw.as_deref())
+    }
+
+    /// The rungs, in walk order (including the appended FP32 anchor, if any).
+    #[must_use]
+    pub fn rungs(&self) -> &[PrecisionMode] {
+        &self.rungs
+    }
+
+    /// `true` iff FP32 was absent from the operator's list and appended as the
+    /// availability anchor. Callers should log this — the anchor is deliberate
+    /// and visible, never silent.
+    #[must_use]
+    pub fn fp32_anchored(&self) -> bool {
+        self.fp32_anchored
+    }
+}
+
+/// The outcome of a ladder walk: the backend that won, at which precision, and
+/// every higher rung that was rejected on the way down (with its error) — the
+/// caller logs these so a degradation is never silent.
+#[derive(Debug)]
+pub struct LadderSelection<B> {
+    pub backend: B,
+    pub precision: PrecisionMode,
+    /// Higher-preference rungs that failed to build, in walk order.
+    pub rejected: Vec<(PrecisionMode, BackendError)>,
+    /// Mirrors [`PrecisionLadder::fp32_anchored`] for the caller's log line.
+    pub fp32_anchored: bool,
+}
+
+impl<B> LadderSelection<B> {
+    /// `true` iff the winning rung was not the operator's first choice.
+    #[must_use]
+    pub fn degraded(&self) -> bool {
+        !self.rejected.is_empty()
+    }
+}
+
+/// Walk `ladder` in order, attempting `try_build` per rung; the first rung that
+/// builds wins. `try_build` should carry the FULL operational proof for a rung —
+/// construct the backend at that precision AND run its fail-closed `warm_up`
+/// (engine build) — so "supported" means demonstrated, not assumed.
+///
+/// Every rejected rung is returned in the selection (visibility); exhausting the
+/// ladder is an `Err` naming each rung's failure (fail-closed — nothing outside
+/// the ladder is substituted).
+pub fn select_by_ladder<B>(
+    ladder: &PrecisionLadder,
+    mut try_build: impl FnMut(PrecisionMode) -> Result<B, BackendError>,
+) -> Result<LadderSelection<B>, BackendError> {
+    let mut rejected: Vec<(PrecisionMode, BackendError)> = Vec::new();
+    for &rung in ladder.rungs() {
+        match try_build(rung) {
+            Ok(backend) => {
+                return Ok(LadderSelection {
+                    backend,
+                    precision: rung,
+                    rejected,
+                    fp32_anchored: ladder.fp32_anchored(),
+                });
+            }
+            Err(e) => rejected.push((rung, e)),
+        }
+    }
+    let detail: Vec<String> =
+        rejected.iter().map(|(p, e)| format!("{p:?}: {e}")).collect();
+    Err(BackendError::InitializationError(format!(
+        "no rung of the precision ladder could be built (fail-closed; nothing \
+         outside the ladder is substituted): [{}]",
+        detail.join("; ")
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fails(msg: &str) -> BackendError {
+        BackendError::InitializationError(msg.to_string())
+    }
+
+    #[test]
+    fn parse_preserves_order_and_is_case_insensitive() {
+        let l = PrecisionLadder::parse("INT8, fp16 ,Fp32").unwrap();
+        assert_eq!(
+            l.rungs(),
+            &[PrecisionMode::INT8, PrecisionMode::FP16, PrecisionMode::FP32]
+        );
+        assert!(!l.fp32_anchored(), "fp32 was explicit — no anchor appended");
+    }
+
+    #[test]
+    fn parse_appends_fp32_anchor_visibly_when_absent() {
+        let l = PrecisionLadder::parse("int8,fp16").unwrap();
+        assert_eq!(
+            l.rungs(),
+            &[PrecisionMode::INT8, PrecisionMode::FP16, PrecisionMode::FP32],
+            "fp32 availability anchor appended last"
+        );
+        assert!(l.fp32_anchored(), "the append is flagged, never silent");
+    }
+
+    #[test]
+    fn parse_fails_closed_on_garbage() {
+        assert!(PrecisionLadder::parse("").is_err(), "empty ladder");
+        assert!(PrecisionLadder::parse("int4").is_err(), "unknown precision");
+        assert!(PrecisionLadder::parse("fp32,,int8").is_err(), "empty token");
+        assert!(PrecisionLadder::parse("int8,int8").is_err(), "duplicate rung");
+    }
+
+    #[test]
+    fn env_default_is_fp32_only() {
+        for v in [None, Some(""), Some("   ")] {
+            let l = PrecisionLadder::from_env_value(v).unwrap();
+            assert_eq!(l.rungs(), &[PrecisionMode::FP32]);
+            assert!(!l.fp32_anchored());
+        }
+    }
+
+    #[test]
+    fn first_buildable_rung_wins_without_degradation() {
+        let ladder = PrecisionLadder::parse("int8,fp32").unwrap();
+        let sel = select_by_ladder(&ladder, Ok::<_, BackendError>).unwrap();
+        assert_eq!(sel.precision, PrecisionMode::INT8);
+        assert!(!sel.degraded());
+        assert!(sel.rejected.is_empty());
+    }
+
+    #[test]
+    fn failed_rung_degrades_visibly_to_the_next() {
+        let ladder = PrecisionLadder::parse("int8,fp16,fp32").unwrap();
+        let sel = select_by_ladder(&ladder, |p| match p {
+            PrecisionMode::INT8 => Err(fails("no int8 engine")),
+            other => Ok(other),
+        })
+        .unwrap();
+        assert_eq!(sel.precision, PrecisionMode::FP16);
+        assert!(sel.degraded(), "a skipped rung is a degradation");
+        assert_eq!(sel.rejected.len(), 1);
+        assert_eq!(sel.rejected[0].0, PrecisionMode::INT8);
+    }
+
+    #[test]
+    fn anchored_fp32_keeps_the_doer_running_when_the_whole_list_fails() {
+        // Operator configured int8-only; int8 won't build; the appended anchor
+        // lands the selection on FP32 — availability-preserving, and both the
+        // anchor and the rejection are visible.
+        let ladder = PrecisionLadder::parse("int8").unwrap();
+        let sel = select_by_ladder(&ladder, |p| match p {
+            PrecisionMode::FP32 => Ok(p),
+            _ => Err(fails("unavailable")),
+        })
+        .unwrap();
+        assert_eq!(sel.precision, PrecisionMode::FP32);
+        assert!(sel.degraded());
+        assert!(sel.fp32_anchored);
+    }
+
+    #[test]
+    fn exhausted_ladder_is_a_typed_error_naming_every_rung() {
+        let ladder = PrecisionLadder::parse("int8,fp32").unwrap();
+        let err = select_by_ladder::<()>(&ladder, |p| Err(fails(match p {
+            PrecisionMode::INT8 => "engine build failed",
+            _ => "model file missing",
+        })))
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("INT8") && msg.contains("engine build failed"));
+        assert!(msg.contains("FP32") && msg.contains("model file missing"));
+    }
+}

--- a/parko/crates/parko-tensorrt/examples/precision_select.rs
+++ b/parko/crates/parko-tensorrt/examples/precision_select.rs
@@ -1,0 +1,106 @@
+//! Q-2 PRECISION SELECTION DEMO — walk the evidence-derived precision ladder
+//! against the real TensorRT backend (`parko_core::precision`; design note §5).
+//!
+//! Reads `KIRRA_PRECISION_LADDER` (e.g. `int8,fp32`; default `fp32` — engaging a
+//! reduced-precision artifact must be a deliberate, evidence-backed act), then
+//! walks the ladder with the FULL operational proof per rung: construct
+//! `TrtBackend` at that precision, introspect the artifact, and run the
+//! fail-closed `warm_up` (engine build). The first rung that proves out wins;
+//! rejected rungs are printed (a degradation is never silent).
+//!
+//! EVIDENCE NOTE (Q1B_ORIN.md "Measured results"): on the Orin NX, INT8 measured
+//! *slower* than FP32 for this planner scorer, so the evidence-derived ladder for
+//! THIS deployment is plain `fp32`. Running with `KIRRA_PRECISION_LADDER=int8,fp32`
+//! demonstrates the mechanism (int8 builds and wins the walk) — it is a mechanism
+//! demo, not the recommended config for this model.
+//!
+//! GATING: prints SKIPPED and exits 0 where the TensorRT EP is unavailable;
+//! `PARKO_TRT_REQUIRE_EP=1` makes that a nonzero exit (the Orin strict lane).
+//!
+//! Run on the Orin:
+//!   ORT_DYLIB_PATH=<...>/libonnxruntime.so KIRRA_PRECISION_LADDER=int8,fp32 \
+//!     PARKO_TRT_REQUIRE_EP=1 cargo run -p parko-tensorrt --example precision_select
+
+use parko_core::backend::{InferenceBackend, PrecisionMode};
+use parko_core::precision::{select_by_ladder, PrecisionLadder};
+use parko_tensorrt::{TrtBackend, TrtConfig, TrtPrecision};
+
+fn require_ep() -> bool {
+    std::env::var("PARKO_TRT_REQUIRE_EP")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn skip_or_refuse(reason: &str) -> ! {
+    if require_ep() {
+        eprintln!("REFUSED (PARKO_TRT_REQUIRE_EP): {reason}");
+        std::process::exit(1);
+    }
+    println!("SKIPPED: {reason}");
+    std::process::exit(0);
+}
+
+fn main() {
+    let dylib = std::env::var("ORT_DYLIB_PATH").unwrap_or_default();
+    if dylib.is_empty() || !std::path::Path::new(&dylib).exists() {
+        skip_or_refuse(&format!("no loadable ORT runtime at ORT_DYLIB_PATH ({dylib:?})"));
+    }
+
+    let artifacts = std::env::var("KIRRA_DOER_ARTIFACTS").unwrap_or_else(|_| {
+        format!("{}/../../../artifacts/doer-eval", env!("CARGO_MANIFEST_DIR"))
+    });
+
+    let ladder = PrecisionLadder::from_env().expect("valid KIRRA_PRECISION_LADDER");
+    if ladder.fp32_anchored() {
+        println!(
+            "note: fp32 was absent from the configured ladder — appended as the \
+             availability anchor (visible, per design note §5)"
+        );
+    }
+    println!("ladder: {:?}", ladder.rungs());
+
+    // The per-rung operational proof: artifact + posture for the precision,
+    // construct, introspect, fail-closed warm-up (engine build). Only rungs the
+    // Q-1 pipeline produced artifacts for are constructible; FP16 shares the
+    // fp32 artifact (precision is an engine posture, not a different file).
+    let selection = select_by_ladder(&ladder, |rung| {
+        let (model_path, trt_precision) = match rung {
+            PrecisionMode::FP32 => (format!("{artifacts}/planner_fp32.onnx"), TrtPrecision::Full),
+            PrecisionMode::FP16 => (format!("{artifacts}/planner_fp32.onnx"), TrtPrecision::Fp16),
+            PrecisionMode::INT8 => {
+                (format!("{artifacts}/planner_int8_qdq.onnx"), TrtPrecision::Int8Qdq)
+            }
+            // PrecisionMode is #[non_exhaustive]; a future mode with no artifact
+            // mapping here must fail the rung, not the process.
+            other => {
+                return Err(parko_core::backend::BackendError::InitializationError(
+                    format!("no artifact mapping for precision {other:?}"),
+                ))
+            }
+        };
+        // Distinct engine cache per precision — engines are precision-specific.
+        let cache = std::env::temp_dir().join(format!("kirra_precision_select_{rung:?}"));
+        let cfg = TrtConfig { engine_cache_path: cache.to_string_lossy().into_owned() };
+        let backend = TrtBackend::with_precision(&model_path, &cfg, trt_precision)?;
+        let model = backend.load_model(&model_path)?;
+        backend.warm_up(&model)?; // fail-closed engine build = the proof
+        Ok((backend, model))
+    });
+
+    match selection {
+        Ok(sel) => {
+            for (rung, err) in &sel.rejected {
+                println!("rejected {rung:?}: {err}");
+            }
+            let (backend, model) = &sel.backend;
+            println!(
+                "SELECTED {:?} (degraded={}) — model {}, engine_sha={}",
+                sel.precision,
+                sel.degraded(),
+                model.model_id,
+                backend.engine_sha().unwrap_or("-"),
+            );
+        }
+        Err(e) => skip_or_refuse(&format!("ladder exhausted: {e}")),
+    }
+}

--- a/parko/crates/parko-tensorrt/examples/precision_select.rs
+++ b/parko/crates/parko-tensorrt/examples/precision_select.rs
@@ -42,7 +42,9 @@ fn skip_or_refuse(reason: &str) -> ! {
 
 fn main() {
     let dylib = std::env::var("ORT_DYLIB_PATH").unwrap_or_default();
-    if dylib.is_empty() || !std::path::Path::new(&dylib).exists() {
+    // `is_file()` (not `exists()`): a directory here is a misconfiguration that
+    // would sail past the guard into ort's panicking dlopen.
+    if dylib.is_empty() || !std::path::Path::new(&dylib).is_file() {
         skip_or_refuse(&format!("no loadable ORT runtime at ORT_DYLIB_PATH ({dylib:?})"));
     }
 
@@ -87,6 +89,15 @@ fn main() {
                 ))
             }
         };
+        // A missing artifact is a MISCONFIGURATION, not absent hardware — give it
+        // a distinguishable error so the exhausted-ladder path refuses instead of
+        // skipping (the run-the-export remedy is in the message).
+        if !std::path::Path::new(&model_path).is_file() {
+            return Err(parko_core::backend::BackendError::InitializationError(format!(
+                "artifact missing: {model_path} — run \
+                 `cargo run -p kirra-doer-eval --example export_artifacts` (root workspace)"
+            )));
+        }
         // Distinct engine cache per precision — engines are precision-specific.
         let cache = std::env::temp_dir().join(format!("kirra_precision_select_{rung:?}"));
         let cfg = TrtConfig { engine_cache_path: cache.to_string_lossy().into_owned() };
@@ -110,6 +121,18 @@ fn main() {
                 backend.engine_sha().unwrap_or("-"),
             );
         }
-        Err(e) => skip_or_refuse(&format!("ladder exhausted: {e}")),
+        Err(e) => {
+            // Only ABSENT HARDWARE is skippable: every rung failing with the TRT
+            // EP's fail-closed registration error (our own marker string from
+            // `TrtBackend::with_config`) means a CPU-only ORT / no GPU — the
+            // documented skip case. Any other exhaustion (missing artifacts, bad
+            // paths) is a misconfiguration and must refuse, never read as skipped.
+            let msg = e.to_string();
+            if msg.contains("TensorRT EP registration failed") {
+                skip_or_refuse(&format!("ladder exhausted — TensorRT EP unavailable: {msg}"));
+            }
+            eprintln!("REFUSED: ladder exhausted for non-EP reasons (misconfiguration): {msg}");
+            std::process::exit(1);
+        }
     }
 }

--- a/parko/crates/parko-tensorrt/examples/precision_select.rs
+++ b/parko/crates/parko-tensorrt/examples/precision_select.rs
@@ -50,7 +50,16 @@ fn main() {
         format!("{}/../../../artifacts/doer-eval", env!("CARGO_MANIFEST_DIR"))
     });
 
-    let ladder = PrecisionLadder::from_env().expect("valid KIRRA_PRECISION_LADDER");
+    // A malformed ladder is a MISCONFIGURATION → a controlled nonzero-exit
+    // refusal, unconditionally (this is not the hardware skip lane — a config
+    // error must never read as "skipped").
+    let ladder = match PrecisionLadder::from_env() {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("REFUSED: invalid KIRRA_PRECISION_LADDER: {e}");
+            std::process::exit(1);
+        }
+    };
     if ladder.fp32_anchored() {
         println!(
             "note: fp32 was absent from the configured ladder — appended as the \


### PR DESCRIPTION
## What

**Q-2** of the doer quantization plan (`parko/QUANTIZATION_DESIGN.md` §5/§9): precision-aware selection. Q-1 produced the per-chip evidence (the contract matrix, measured on the Orin in #757/#758); this PR turns that evidence into the runtime choice of which precision artifact actually runs.

### `parko_core::precision` (new module)

- **`PrecisionLadder`** — the operator's **ordered allow-list of contract-passing precisions** for this deployment, from `KIRRA_PRECISION_LADDER` (e.g. `fp16,fp32`). Fail-closed parse: unknown/duplicate/empty tokens are `Err` (a config typo never selects something else, mirroring `KIRRA_BACKEND`); unset → the fp32-only default (engaging reduced precision must be a deliberate, evidence-backed act). If `fp32` is absent it is appended as the **availability anchor** — flagged via `fp32_anchored()`, never silent — the selection analogue of `PlanOutput::safe_stop`.
- **`select_by_ladder`** — walks the ladder by **operational proof**: a rung is "supported" iff the caller's `try_build` closure (construct the backend at that precision + fail-closed `warm_up`) succeeds. Static `BackendCapabilities` are deliberately **not** consulted — they're conservative-false everywhere by design, so gating on them would nullify selection; the Q-1b probe's construct+warm-up proof is the real support test.
- **Degradation is visible, not silent**: every rejected rung is returned in `LadderSelection::rejected` with its error (the no-silent-caps rule); `degraded()` says whether the winner was the first choice. An exhausted ladder is a typed `Err` — nothing outside the ladder is ever substituted.
- Composes with (does not replace) `BackendSelector`: the descriptor→backend axis stays PARK-022's; the closure injection is because only the integrator knows per-precision artifact paths and backend config.

### `parko-tensorrt` `examples/precision_select.rs`

The Orin-runnable wiring demo: rung → (artifact, `TrtPrecision`, per-precision engine cache) → construct + `warm_up` proof; prints rejected rungs and the selection. Skip-gated with the standard `PARKO_TRT_REQUIRE_EP` lane.

## The design-note semantics, honored exactly

§5: selection **degrades gracefully** (availability-preserving — the checker, not the selector, is the fail-closed safety authority), and the allow-list is **the rows that passed the contract**, not a precision preference. The doc note in the demo records the Q-1b evidence: for this planner scorer on the Orin, INT8 measured *slower* than FP32, so the evidence-derived ladder for that deployment is plain `fp32` — running `int8,fp32` demonstrates the mechanism, and the docs say so rather than implying INT8 is recommended.

## Safety framing

Selection tunes the untrusted doer's inference only; whichever rung wins, the checker bounds its proposals exactly as it bounds FP32. Checker untouched.

## Verification

8 new unit tests (parse order/case/fail-closed/anchor; first-rung win; visible degradation; anchored-fp32 availability; exhausted-ladder error naming every rung); full parko-core + parko-tensorrt suites pass; clippy clean; the example builds (real run is Orin-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_