### PR TITLE
fix(ci): self-skip parko-onnx tests without an ORT dylib; strict in the ORT lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,11 @@ jobs:
           # to reference HOME in an Actions expression (${{ env.HOME }}) yields
           # an empty string → a "/.local/..." dlopen failure.
           RUST_BACKTRACE: "1"
+          # STRICT: this is THE ORT-provisioned lane, so a would-be self-skip
+          # (dylib missing/unloadable) is a hard failure here — the tests
+          # self-skip everywhere else (the root --workspace lanes absorb
+          # parko-onnx as an implicit member and install no ORT runtime).
+          PARKO_ONNX_REQUIRE_ORT: "1"
         run: cargo test -p parko-onnx -- --nocapture
 
       - name: parko-tensorrt fail-closed test (PARK-021, GATING)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,16 @@
 #                                     wiring). ROS deps gated behind `ros2`
 #                                     feature; default build does not pull them.
 #
-# `parko/` is intentionally NOT included — it is a self-contained sub-workspace
-# with its own resolver and is consumed by this crate via a `path =` dependency.
-# That separation keeps the ML inference pipeline (parko-core / parko-onnx /
-# parko-kirra) independent of the safety-kernel build.
+# `parko/` is intentionally NOT listed — it is a self-contained sub-workspace
+# with its own resolver, consumed via `path =` dependencies. CAVEAT (learned the
+# hard way): cargo FORCE-ABSORBS a path dependency living under the workspace
+# directory as an implicit member — `exclude` does not prevent it — so the
+# path-depped parko crates (parko-core, parko-kirra, and parko-onnx via
+# kirra-doer-eval's dev-deps) ARE members here and `cargo test --workspace`
+# runs their tests. Consequently any parko crate reachable by path from this
+# workspace must keep its tests sandbox-safe: self-skip when the native
+# runtime (ORT etc.) is absent, strict-fail only in the CI lane that installs
+# it (see parko-onnx's PARKO_ONNX_REQUIRE_ORT).
 [workspace]
 members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval"]
 resolver = "2"

--- a/parko/crates/parko-onnx/tests/test_onnx_backend.rs
+++ b/parko/crates/parko-onnx/tests/test_onnx_backend.rs
@@ -3,8 +3,43 @@ use std::collections::HashMap;
 use parko_core::backend::{BackendCapabilities, BackendDescriptor, InferenceBackend, TensorBatch, TensorStorage};
 use parko_onnx::OrtBackend;
 
+/// `PARKO_ONNX_REQUIRE_ORT` truthy → a loadable ORT runtime is REQUIRED: a
+/// would-be skip becomes a hard failure. Set in the dedicated ORT-provisioned
+/// CI job so these tests keep gating with teeth there; unset everywhere else
+/// (self-skip). Mirrors `PARKO_TRT_REQUIRE_EP` / `KIRRA_DOER_EVAL_REQUIRE_ORT`.
+fn require_ort() -> bool {
+    std::env::var("PARKO_ONNX_REQUIRE_ORT")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// `Some(())` iff a loadable ORT runtime is present (`ORT_DYLIB_PATH` names an
+/// existing file); `None` → skip (or panic in strict mode). ort PANICS on a
+/// missing dylib — and since `ort = { default-features = false }` dropped the
+/// build-time `download-binaries` provisioning, NO lane gets a dylib implicitly
+/// any more. The guard matters beyond the dedicated job because cargo absorbs
+/// path-depped parko crates as implicit ROOT-workspace members (a path dep under
+/// the workspace directory is force-absorbed; `exclude` cannot prevent it), so
+/// root `cargo test --workspace` runs THESE tests in lanes with no ORT installed.
+fn ort_available() -> Option<()> {
+    let dylib = std::env::var("ORT_DYLIB_PATH").unwrap_or_default();
+    if dylib.is_empty() || !std::path::Path::new(&dylib).exists() {
+        assert!(
+            !require_ort(),
+            "STRICT (PARKO_ONNX_REQUIRE_ORT): no loadable ORT runtime at ORT_DYLIB_PATH \
+             ({dylib:?}) — refusing to skip (the ORT-provisioned job must install it)."
+        );
+        eprintln!("SKIP: no ORT runtime ({dylib:?}) — parko-onnx tests need a real ORT lib.");
+        return None;
+    }
+    Some(())
+}
+
 #[test]
 fn mnist_end_to_end_inference() {
+    if ort_available().is_none() {
+        return;
+    }
     let model_path = "tests/data/mnist-12.onnx";
 
     let backend = OrtBackend::new(model_path)
@@ -92,6 +127,9 @@ fn mnist_end_to_end_inference() {
 
 #[test]
 fn test_ort_backend_descriptor_is_cpu() {
+    if ort_available().is_none() {
+        return;
+    }
     let model_path = "tests/data/mnist-12.onnx";
     let backend = OrtBackend::new(model_path).expect("failed to construct OrtBackend");
     assert_eq!(backend.descriptor(), BackendDescriptor::Cpu);
@@ -99,6 +137,9 @@ fn test_ort_backend_descriptor_is_cpu() {
 
 #[test]
 fn test_ort_backend_capabilities() {
+    if ort_available().is_none() {
+        return;
+    }
     let model_path = "tests/data/mnist-12.onnx";
     let backend = OrtBackend::new(model_path).expect("failed to construct OrtBackend");
     let caps = backend.capabilities();

--- a/parko/crates/parko-onnx/tests/test_onnx_backend.rs
+++ b/parko/crates/parko-onnx/tests/test_onnx_backend.rs
@@ -14,7 +14,8 @@ fn require_ort() -> bool {
 }
 
 /// `Some(())` iff a loadable ORT runtime is present (`ORT_DYLIB_PATH` names an
-/// existing file); `None` → skip (or panic in strict mode). ort PANICS on a
+/// existing regular file — symlinks resolve); `None` → skip (or panic in strict
+/// mode). ort PANICS on a
 /// missing dylib — and since `ort = { default-features = false }` dropped the
 /// build-time `download-binaries` provisioning, NO lane gets a dylib implicitly
 /// any more. The guard matters beyond the dedicated job because cargo absorbs
@@ -23,7 +24,9 @@ fn require_ort() -> bool {
 /// root `cargo test --workspace` runs THESE tests in lanes with no ORT installed.
 fn ort_available() -> Option<()> {
     let dylib = std::env::var("ORT_DYLIB_PATH").unwrap_or_default();
-    if dylib.is_empty() || !std::path::Path::new(&dylib).exists() {
+    // `is_file()` (not `exists()`): a directory here is a misconfiguration that
+    // would sail past the guard straight into ort's panicking dlopen.
+    if dylib.is_empty() || !std::path::Path::new(&dylib).is_file() {
         assert!(
             !require_ort(),
             "STRICT (PARKO_ONNX_REQUIRE_ORT): no loadable ORT runtime at ORT_DYLIB_PATH \


### PR DESCRIPTION
## What / why (main is red — merge first)

Main's root `Test` job (and the coverage job) went red at the #757 merge. Two facts combined:

1. **#757's ort feature trim removed the implicit dylib.** `default-features = false` dropped ort's `download-binaries`, which had been silently provisioning an ONNX Runtime at build time. That trim was right (it removed the dead `ureq → native-tls → openssl-sys` stack) — but a lane was depending on the side effect.
2. **Cargo force-absorbs path-depped parko crates as implicit root-workspace members.** The root manifest's comment claimed *"parko/ is intentionally NOT included"*, but `cargo metadata` shows parko-core / parko-kirra / **parko-onnx** (newly reachable via kirra-doer-eval's dev-deps) are members — so root `cargo test --workspace` runs **their** tests. `[workspace] exclude` cannot prevent this for path dependencies (verified empirically: both directory-prefix and exact-package excludes left them members). It never mattered before because the absorbed crates needed no runtime; parko-onnx is the first that hard-requires one.

Result: `OrtBackend::new` panicked on a bare-name dlopen in the runtime-less root lane, poisoning ort's init mutex for the sibling tests.

## The fix (the repo's own probe idiom)

- **`test_onnx_backend.rs`** — self-skips when `ORT_DYLIB_PATH` is unset or the file is missing; `PARKO_ONNX_REQUIRE_ORT=1` turns a would-be skip into a hard refusal. Identical pattern to `positive_probe.rs` / `onnx_roundtrip.rs`.
- **`ci.yml`** — the dedicated ORT-provisioned `parko-onnx` job sets `PARKO_ONNX_REQUIRE_ORT: "1"`, so the real-inference coverage keeps gating **with teeth** exactly where ORT is installed. No lane silently loses coverage: the tests move from "accidentally ran in two lanes, one unprovisioned" to "run strictly in the provisioned lane, skip visibly elsewhere."
- **Root `Cargo.toml` header comment** — replaces the stale "not included" claim with the force-absorption caveat and the resulting rule: any parko crate reachable by path from the root workspace must keep its tests sandbox-safe.

## Verified locally

| Scenario | Result |
|---|---|
| No dylib (the broken CI case) | green, 0.00s (self-skip with visible `SKIP:` lines) |
| Real ORT dylib (dedicated-job case) | green, 1.65s (real MNIST inference, golden logits) |
| `PARKO_ONNX_REQUIRE_ORT=1`, no dylib | hard failure with a clear refusal message |

## Note for the open PRs

#759/#760 CI runs will go green once this merges (PR checks build against the merge commit with main) — their failures are inherited from main, not their own diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY1ndGdaAnttiBamxuuUs4)_