### PR TITLE
feat(l3): on-target E2E harness — two-process doer→checker→release (incr. 4 Phase-I)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,6 +2126,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-l3-e2e"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "kirra-contract-channel",
+ "kirra-core",
+ "kirra-hv-carrier",
+ "kirra-release-token",
+ "libc",
+]
+
+[[package]]
 name = "kirra-map"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@
 # runtime (ORT etc.) is absent, strict-fail only in the CI lane that installs
 # it (see parko-onnx's PARKO_ONNX_REQUIRE_ORT).
 [workspace]
-members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval"]
+members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-l3-e2e", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval"]
 resolver = "2"
 
 [package]

--- a/crates/kirra-l3-e2e/Cargo.toml
+++ b/crates/kirra-l3-e2e/Cargo.toml
@@ -1,0 +1,31 @@
+# crates/kirra-l3-e2e/Cargo.toml
+#
+# The L3 ON-TARGET end-to-end harness (ADR-0030 incr. 4 Phase-I, #279 subset).
+# One self-contained binary that proves the ENTIRE L3 doer→checker→release chain
+# across two real OS processes over the POSIX-SHM carrier, then measures the
+# governor read/decide/sign/verify path — designed to cross-compile for
+# `x86_64-pc-nto-qnx800` and run on the QNX 8.0 VM/target, but it runs on host
+# Linux too (that's how it is verified before hardware day).
+#
+# Self-spawning (`current_exe()` + `--guest`) so it carries NO cargo-test
+# machinery or host paths onto the target. This is a HARNESS crate (evidence
+# tooling), not TCB: it may depend on kirra-core + the release token.
+[package]
+name = "kirra-l3-e2e"
+version = "0.1.0"
+edition = "2021"
+description = "On-target L3 end-to-end harness — two-process doer→checker→release over POSIX SHM (QNX/host)"
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+
+[dependencies]
+kirra-contract-channel = { path = "../kirra-contract-channel" }
+kirra-hv-carrier = { path = "../kirra-hv-carrier" }
+kirra-core = { path = "../kirra-core" }
+kirra-release-token = { path = "../kirra-release-token" }
+# The governor signing key for the harness rows (a fixed TEST key — provenance
+# is the harness, never production identity). Same vetted crate as the seam.
+ed25519-dalek = "2"
+# SCHED_FIFO via pthread_setschedparam (POSIX — Linux and QNX/nto both have it).
+libc = "0.2"

--- a/crates/kirra-l3-e2e/results/qnx800-x86_64-vm-kvm.txt
+++ b/crates/kirra-l3-e2e/results/qnx800-x86_64-vm-kvm.txt
@@ -1,0 +1,78 @@
+KIRRA L3 incr. 4 Phase-I — on-target E2E + timing, QNX 8.0 (ADR-0030 / #279 subset)
+====================================================================================
+Target : QNX SDP 8.0, x86_64, mkqnximage/QEMU VM (KVM: --enable-kvm --cpu host,
+         2 vCPU, 1G). QNX OS — NOT QNX Hypervisor: no guest partitions, so the
+         hypervisor HvRegion + R-HV-1/R-HV-4 enforcement remain Phase-II.
+Build  : cargo +nightly -Zbuild-std=std,panic_abort --target x86_64-pc-nto-qnx800
+         --release -p kirra-l3-e2e (first QNX std binary in this repo; the only
+         fix needed vs host was naming panic_abort — the workspace release
+         profile is panic="abort"). Linker qcc 12.2.0 via the committed
+         .cargo/config.toml stanza. Dynamically linked (ldqnx-64.so.2); ran on
+         the stock image without extra libraries.
+Run    : scp to root's home, executed over ssh as root. Two runs verbatim below.
+Date   : 2026-07-02
+
+STATUS : INDICATIVE-KVM — a KVM VM on an x86_64 laptop is near-native but NOT the
+         deployment ISA; the row gate is VERDICT CORRECTNESS (the #274 harness
+         discipline), which virtualization does not affect. Timing is never a
+         WCET claim; the certified figure is Phase-II hardware under FIFO.
+
+WHAT RAN (each row = two real QNX processes over QNX POSIX shared memory; the
+guest OPENS the governor-owned region and publishes; the governor reads via a
+READ-ONLY mapping, then decide_cycle -> view_to_sign -> issue/verify token):
+  L3-01 in-envelope         -> Actuate(10.0), release token verifies
+  L3-02 over-envelope 50    -> clamped to 35.0; token binds the ENFORCED bytes
+                               and REFUSES the raw proposal (DigestMismatch)
+  L3-03 expired deadline    -> SafeStop, nothing signable
+  L3-04 replay (same seq)   -> SafeStop (fresh guest process re-published)
+  L3-05 unwritten region    -> SafeStop (cold start fail-closed)
+
+--- run 1 (default sched, 100k iters) — verbatim -------------------------------
+platform: os=nto arch=x86_64  (row gate = verdict correctness; timing INDICATIVE)
+L3-01   in-envelope: Actuate(10.0) + token verifies          PASS
+L3-02   over-envelope 50: clamped <=35; token binds enforced bytes PASS
+L3-03   expired deadline: SafeStop, nothing signable         PASS
+L3-04   replay (same seq re-published): SafeStop             PASS
+L3-05   unwritten region (cold start): SafeStop              PASS
+GATE (verdict correctness): PASS
+path                                  p50_ns    p99_ns   p999_ns      max_ns
+shm read_coherent_snapshot                97       112       114       19606
+decide_cycle (read+val+bound)            688       782      5322       27093
+issue_release_token (sign)             31794     49456     61961       82563
+verify_release (actuator)              59617     80830    109222      138624
+
+--- run 2 (SCHED_FIFO granted, 1M iters) — verbatim ----------------------------
+GATE (verdict correctness): PASS  (all five rows, as run 1)
+path                                  p50_ns    p99_ns   p999_ns      max_ns
+shm read_coherent_snapshot                97       112       162       71635
+decide_cycle (read+val+bound)            688       772      1115      342815
+issue_release_token (sign)             31629     42482     63455      465424
+verify_release (actuator)              59626     73822     88333      361312
+
+READING (the takeaways):
+1. GATE PASS on the target OS. The ENTIRE L3 chain — frozen contract, seqlock
+   carrier, governor validate/decode/bound, enforced-bytes release token —
+   executed across two real QNX processes. This is the incr. 4 Phase-I claim.
+2. FIFO collapses the pipeline tail: decide_cycle p99.9 went 5322 -> 1115 ns.
+   On QNX under FIFO the WHOLE transport+validate+decode+bound step is ~1.1 us
+   at p99.9 — roughly 1% of the 100 us governor-verdict budget. The QNX seqlock
+   read tail is also tighter than host Linux (p99.9 114-162 ns vs 244 ns).
+3. THE CRYPTO DOMINATES — the load-bearing finding. Ed25519 sign (~32 us p50)
+   + verify (~60 us p50) ~= 91 us combined, ~99% of the release path and nearly
+   the whole 100 us verdict budget; p99 exceeds it. Conclusion for ADR-0030
+   Clause F / ADR-0013 integration: the release token must be BUDGETED APART
+   from the verdict path (pipelined/overlapped with actuation latency, issued at
+   a lower rate, or hardware-assisted) — it cannot ride inline per-cycle inside
+   the verdict WCET target on this class of CPU. Follow-up design decision.
+4. The few-hundred-us maxes (runs 2) are KVM/vCPU jitter (host preemption, VM
+   exits) — the residual the INDICATIVE-KVM label exists for. Bounding the max
+   is Phase-II bare hardware (QNX Hypervisor, isolated cores, boundary clock).
+
+Reproduce:
+  source /opt/qnx800/sdp2/qnxsdp-env.sh
+  cargo +nightly build -Zbuild-std=std,panic_abort \
+    --target x86_64-pc-nto-qnx800 --release -p kirra-l3-e2e
+  scp target/x86_64-pc-nto-qnx800/release/kirra-l3-e2e root@172.31.1.10:
+  ssh root@172.31.1.10 './kirra-l3-e2e'                                # run 1
+  ssh root@172.31.1.10 'KIRRA_E2E_FIFO=1 KIRRA_LAT_ITERS=1000000 ./kirra-l3-e2e'  # run 2
+  # VM bring-up: tools/qnx-rtm-harness/QNX_VM_RELAUNCH.md

--- a/crates/kirra-l3-e2e/src/main.rs
+++ b/crates/kirra-l3-e2e/src/main.rs
@@ -195,7 +195,9 @@ fn governor_main() -> ExitCode {
             GovernorOutcome::Actuate(c) => Some(c.linear_velocity_mps),
             GovernorOutcome::SafeStop => None,
         };
-        let clamped = clamped_vel.is_some_and(|v| v <= 35.0);
+        // Assert against the contract's own effective ceiling (not a hardcoded
+        // copy of it), so this row tracks the profile / any future ODD cap.
+        let clamped = clamped_vel.is_some_and(|v| v <= contract.effective_max_speed_mps());
         let enforced_bound = match cycle.view_to_sign() {
             Some(view) => {
                 let token = issue_release_token(view, &gov_key);
@@ -209,7 +211,7 @@ fn governor_main() -> ExitCode {
         };
         rows.push(row(
             "L3-02",
-            "over-envelope 50: clamped <=35; token binds enforced bytes",
+            "over-envelope 50: clamped to envelope; token binds enforced bytes",
             published && clamped && enforced_bound,
             format!("published={published} clamped_vel={clamped_vel:?} enforced_bound={enforced_bound}"),
         ));

--- a/crates/kirra-l3-e2e/src/main.rs
+++ b/crates/kirra-l3-e2e/src/main.rs
@@ -1,0 +1,383 @@
+//! kirra_l3_e2e — the on-target L3 end-to-end harness (ADR-0030 incr. 4 Phase-I).
+//!
+//! Runs the ENTIRE L3 doer→checker→release chain across two real OS processes
+//! over the POSIX-SHM carrier, then measures the governor path. Cross-compiles
+//! for `x86_64-pc-nto-qnx800` (QNX 8.0) and runs identically on host Linux —
+//! host runs verify the harness; the QNX run supplies the target evidence.
+//!
+//! Row gate = VERDICT CORRECTNESS only (the #274 harness discipline). Timing is
+//! printed with the honesty banner: host/VM numbers are INDICATIVE, never WCET;
+//! the results-file label (e.g. INDICATIVE-KVM) is applied when recording.
+//!
+//! Roles:
+//!   kirra_l3_e2e                                     — governor/orchestrator (the matrix + timing)
+//!   kirra_l3_e2e --guest <shm> <linvel> <seq> <deadline_ns>   — guest publisher (spawned per row)
+//!
+//! Env: KIRRA_LAT_ITERS (default 100_000), KIRRA_E2E_FIFO=1 (attempt SCHED_FIFO).
+
+use std::process::{Command, ExitCode};
+use std::time::{Duration, Instant};
+
+use ed25519_dalek::SigningKey;
+
+use kirra_contract_channel::{
+    publish, read_coherent_snapshot, AcceptedWatermark, ContractReader, VehicleCommandPayload,
+    MAX_SNAPSHOT_RETRIES,
+};
+use kirra_core::contract_consumer::{decide_cycle, GovernorOutcome};
+use kirra_core::kinematics_contract::VehicleKinematicsContract;
+use kirra_hv_carrier::{PosixShmReader, PosixShmRegion};
+use kirra_release_token::{issue_release_token, verify_release, ReleaseDenied};
+
+const FUTURE_DEADLINE: u64 = u64::MAX / 2;
+
+/// The harness governor signing key — a FIXED TEST key (deterministic, no RNG on
+/// target). Provenance is this harness; never a production identity.
+fn governor_key() -> SigningKey {
+    SigningKey::from_bytes(&[7u8; 32])
+}
+
+fn payload(linear: f64) -> VehicleCommandPayload {
+    VehicleCommandPayload {
+        linear_velocity_mps: linear,
+        current_velocity_mps: linear, // == desired → accel 0; the speed bound decides
+        delta_time_s: 0.1,
+        steering_angle_deg: 1.0,
+        current_steering_angle_deg: 1.0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Guest role — a separate PROCESS that opens (never creates) the region and
+// publishes one proposal. Mirrors the node.rs open-only ownership discipline.
+// ---------------------------------------------------------------------------
+fn guest_main(args: &[String]) -> ExitCode {
+    if args.len() != 4 {
+        eprintln!("usage: kirra_l3_e2e --guest <shm> <linvel> <seq> <deadline_ns>");
+        return ExitCode::from(2);
+    }
+    let (name, linvel, seq, deadline) = (&args[0], &args[1], &args[2], &args[3]);
+    let (Ok(linvel), Ok(seq), Ok(deadline)) =
+        (linvel.parse::<f64>(), seq.parse::<u64>(), deadline.parse::<u64>())
+    else {
+        return ExitCode::from(2);
+    };
+    let region = match PosixShmRegion::open(name) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("guest: open {name} failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    // Publish on top of the region's current committed (even) generation so a
+    // re-spawned guest advances the seqlock like a live producer would.
+    let committed = region.load_generation();
+    if committed % 2 != 0 {
+        eprintln!("guest: region generation is odd (writer died mid-publish?)");
+        return ExitCode::from(1);
+    }
+    let body = payload(linvel).to_view(committed, seq, 0, deadline);
+    publish(&region, committed, &body);
+    ExitCode::SUCCESS
+}
+
+// ---------------------------------------------------------------------------
+// Governor role — the matrix + timing.
+// ---------------------------------------------------------------------------
+
+/// Spawn ourselves as the guest for `name` and wait for the publish to complete.
+fn spawn_guest(name: &str, linvel: f64, seq: u64, deadline: u64) -> bool {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    Command::new(exe)
+        .arg("--guest")
+        .arg(name)
+        .arg(linvel.to_string())
+        .arg(seq.to_string())
+        .arg(deadline.to_string())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Print one matrix row and return its pass/fail (the only thing the gate needs).
+fn row(id: &str, what: &str, pass: bool, detail: String) -> bool {
+    println!("{id:<7} {what:<52} {}  {detail}", if pass { "PASS" } else { "FAIL" });
+    pass
+}
+
+/// Attempt SCHED_FIFO at max priority on the calling thread (POSIX
+/// `pthread_setschedparam` — present on both Linux and QNX/nto). Returns whether
+/// it was granted (needs privilege; without it the run is time-shared).
+fn try_fifo() -> bool {
+    // SAFETY: a zeroed sched_param is valid; we set only sched_priority and pass
+    // SCHED_FIFO for the calling thread. Pure FFI, no invariants touched.
+    unsafe {
+        let mut p: libc::sched_param = std::mem::zeroed();
+        p.sched_priority = libc::sched_get_priority_max(libc::SCHED_FIFO);
+        libc::pthread_setschedparam(libc::pthread_self(), libc::SCHED_FIFO, &p) == 0
+    }
+}
+
+fn percentile(sorted: &[Duration], pct: f64) -> u128 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let n = sorted.len();
+    let rank = (((pct / 100.0) * n as f64).ceil() as usize).clamp(1, n);
+    sorted[rank - 1].as_nanos()
+}
+
+fn print_timing(name: &str, mut samples: Vec<Duration>) {
+    samples.sort_unstable();
+    println!(
+        "{name:<34} {:>9} {:>9} {:>9} {:>11}",
+        percentile(&samples, 50.0),
+        percentile(&samples, 99.0),
+        percentile(&samples, 99.9),
+        samples.last().copied().unwrap_or(Duration::ZERO).as_nanos(),
+    );
+}
+
+fn governor_main() -> ExitCode {
+    let contract = VehicleKinematicsContract::nominal_reference_profile();
+    let gov_key = governor_key();
+    let gov_pub = gov_key.verifying_key();
+    let pid = std::process::id();
+    let mut rows: Vec<bool> = Vec::new();
+
+    println!("===== KIRRA-L3E2E START =====");
+    println!(
+        "platform: os={} arch={}  (row gate = verdict correctness; timing INDICATIVE)",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    );
+    println!();
+
+    // ---- L3-01: in-envelope proposal → Actuate unchanged + token verifies ----
+    {
+        let name = format!("/kirra-l3e2e-01-{pid}");
+        let region = PosixShmRegion::create(&name).expect("create region");
+        let published = spawn_guest(&name, 10.0, 1, FUTURE_DEADLINE);
+        let reader = PosixShmReader::open(&name).expect("governor RO mapping");
+        let mut wm = AcceptedWatermark::new();
+        let cycle = decide_cycle(&reader, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES);
+        let actuated = matches!(&cycle.outcome, GovernorOutcome::Actuate(c) if c.linear_velocity_mps == 10.0);
+        let (signed, verified) = match cycle.view_to_sign() {
+            Some(view) => {
+                let token = issue_release_token(view, &gov_key);
+                (true, verify_release(&token, view, &gov_pub).is_ok())
+            }
+            None => (false, false),
+        };
+        rows.push(row(
+            "L3-01",
+            "in-envelope: Actuate(10.0) + token verifies",
+            published && actuated && signed && verified,
+            format!("published={published} actuated={actuated} signed={signed} verified={verified}"),
+        ));
+        drop(region);
+    }
+
+    // ---- L3-02: over-envelope → clamped; token binds the ENFORCED bytes ----
+    {
+        let name = format!("/kirra-l3e2e-02-{pid}");
+        let region = PosixShmRegion::create(&name).expect("create region");
+        let published = spawn_guest(&name, 50.0, 1, FUTURE_DEADLINE);
+        let reader = PosixShmReader::open(&name).expect("governor RO mapping");
+        // The raw proposal view, for the must-NOT-release check below.
+        let proposal_view = read_coherent_snapshot(&reader, MAX_SNAPSHOT_RETRIES).expect("snapshot");
+        let mut wm = AcceptedWatermark::new();
+        let cycle = decide_cycle(&reader, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES);
+        let clamped_vel = match &cycle.outcome {
+            GovernorOutcome::Actuate(c) => Some(c.linear_velocity_mps),
+            GovernorOutcome::SafeStop => None,
+        };
+        let clamped = clamped_vel.is_some_and(|v| v <= 35.0);
+        let enforced_bound = match cycle.view_to_sign() {
+            Some(view) => {
+                let token = issue_release_token(view, &gov_key);
+                let enforced_ok = verify_release(&token, view, &gov_pub).is_ok();
+                // The token for the CLAMPED bytes must not release the raw proposal.
+                let proposal_refused = verify_release(&token, &proposal_view, &gov_pub)
+                    == Err(ReleaseDenied::DigestMismatch);
+                enforced_ok && proposal_refused
+            }
+            None => false,
+        };
+        rows.push(row(
+            "L3-02",
+            "over-envelope 50: clamped <=35; token binds enforced bytes",
+            published && clamped && enforced_bound,
+            format!("published={published} clamped_vel={clamped_vel:?} enforced_bound={enforced_bound}"),
+        ));
+        drop(region);
+    }
+
+    // ---- L3-03: expired deadline → SafeStop, nothing signable ----
+    {
+        let name = format!("/kirra-l3e2e-03-{pid}");
+        let region = PosixShmRegion::create(&name).expect("create region");
+        let published = spawn_guest(&name, 10.0, 1, 1_000); // deadline 1_000, now 5_000
+        let reader = PosixShmReader::open(&name).expect("governor RO mapping");
+        let mut wm = AcceptedWatermark::new();
+        let cycle = decide_cycle(&reader, &mut wm, 5_000, &contract, MAX_SNAPSHOT_RETRIES);
+        let safe = cycle.outcome == GovernorOutcome::SafeStop && cycle.view_to_sign().is_none();
+        rows.push(row(
+            "L3-03",
+            "expired deadline: SafeStop, nothing signable",
+            published && safe,
+            format!("published={published} outcome={:?} signable={}", cycle.outcome, cycle.view_to_sign().is_some()),
+        ));
+        drop(region);
+    }
+
+    // ---- L3-04: replay (same sequence re-published) → SafeStop ----
+    {
+        let name = format!("/kirra-l3e2e-04-{pid}");
+        let region = PosixShmRegion::create(&name).expect("create region");
+        let reader = PosixShmReader::open(&name).expect("governor RO mapping");
+        let mut wm = AcceptedWatermark::new();
+        let first_pub = spawn_guest(&name, 10.0, 7, FUTURE_DEADLINE);
+        let first = decide_cycle(&reader, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES);
+        let first_ok = matches!(first.outcome, GovernorOutcome::Actuate(_));
+        // The guest re-publishes the SAME sequence (generation advances) — replay.
+        let second_pub = spawn_guest(&name, 10.0, 7, FUTURE_DEADLINE);
+        let second = decide_cycle(&reader, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES);
+        let replay_refused =
+            second.outcome == GovernorOutcome::SafeStop && second.view_to_sign().is_none();
+        rows.push(row(
+            "L3-04",
+            "replay (same seq re-published): SafeStop",
+            first_pub && first_ok && second_pub && replay_refused,
+            format!("first_ok={first_ok} replay_refused={replay_refused}"),
+        ));
+        drop(region);
+    }
+
+    // ---- L3-05: zero/unwritten region → SafeStop (fail-closed cold start) ----
+    {
+        let name = format!("/kirra-l3e2e-05-{pid}");
+        let region = PosixShmRegion::create(&name).expect("create region");
+        let reader = PosixShmReader::open(&name).expect("governor RO mapping");
+        let mut wm = AcceptedWatermark::new();
+        let cycle = decide_cycle(&reader, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES);
+        let safe = cycle.outcome == GovernorOutcome::SafeStop && cycle.view.is_none();
+        rows.push(row(
+            "L3-05",
+            "unwritten region (cold start): SafeStop",
+            safe,
+            format!("outcome={:?}", cycle.outcome),
+        ));
+        drop(region);
+    }
+
+    let gate_pass = rows.iter().all(|&p| p);
+    println!("\nGATE (verdict correctness): {}", if gate_pass { "PASS" } else { "FAIL" });
+
+    // ---- Timing (INDICATIVE) — the governor path over the SHM carrier ----
+    let iters: usize = std::env::var("KIRRA_LAT_ITERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(100_000);
+    let warmup = (iters / 10).max(1_000);
+    let want_fifo = matches!(std::env::var("KIRRA_E2E_FIFO").as_deref(), Ok("1") | Ok("true"));
+    let fifo = want_fifo && try_fifo();
+    if want_fifo && !fifo {
+        eprintln!("[l3e2e] WARN: SCHED_FIFO not granted (need privilege) — timing is time-shared");
+    }
+
+    let name = format!("/kirra-l3e2e-lat-{pid}");
+    let region = PosixShmRegion::create(&name).expect("create region");
+    let _ = spawn_guest(&name, 10.0, 1, FUTURE_DEADLINE);
+    let reader = PosixShmReader::open(&name).expect("governor RO mapping");
+
+    println!(
+        "\n=== timing — INDICATIVE (sched={}, iters={iters}) — never a WCET claim ===",
+        if fifo { "SCHED_FIFO" } else { "default" }
+    );
+    println!("{:<34} {:>9} {:>9} {:>9} {:>11}", "path", "p50_ns", "p99_ns", "p999_ns", "max_ns");
+    println!("{}", "-".repeat(78));
+
+    // (a) the seqlock read alone
+    let mut s = Vec::with_capacity(iters);
+    for i in 0..(iters + warmup) {
+        let t0 = Instant::now();
+        let snap = read_coherent_snapshot(&reader, MAX_SNAPSHOT_RETRIES).unwrap();
+        let dt = t0.elapsed();
+        std::hint::black_box(snap.sequence);
+        if i >= warmup {
+            s.push(dt);
+        }
+    }
+    print_timing("shm read_coherent_snapshot", s);
+
+    // (b) the full per-cycle governor step (fresh watermark each iter so the
+    //     monotonic gate never rejects — we time the pipeline, not replay logic)
+    let mut s = Vec::with_capacity(iters);
+    for i in 0..(iters + warmup) {
+        let mut wm = AcceptedWatermark::new();
+        let t0 = Instant::now();
+        let cycle = decide_cycle(&reader, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES);
+        let dt = t0.elapsed();
+        std::hint::black_box(matches!(cycle.outcome, GovernorOutcome::Actuate(_)));
+        if i >= warmup {
+            s.push(dt);
+        }
+    }
+    print_timing("decide_cycle (read+val+bound)", s);
+
+    // (c)+(d) the release-token crypto (Ed25519) — fewer iters, it is µs-scale
+    let crypto_iters = (iters / 10).max(1_000);
+    let view = {
+        let mut wm = AcceptedWatermark::new();
+        *decide_cycle(&reader, &mut wm, 0, &contract, MAX_SNAPSHOT_RETRIES)
+            .view_to_sign()
+            .expect("valid region → signable view")
+    };
+    let mut s = Vec::with_capacity(crypto_iters);
+    let mut last_token = None;
+    for i in 0..(crypto_iters + crypto_iters / 10) {
+        let t0 = Instant::now();
+        let token = issue_release_token(&view, &gov_key);
+        let dt = t0.elapsed();
+        last_token = Some(token);
+        if i >= crypto_iters / 10 {
+            s.push(dt);
+        }
+    }
+    print_timing("issue_release_token (sign)", s);
+
+    let token = last_token.expect("signed at least once");
+    let mut s = Vec::with_capacity(crypto_iters);
+    for i in 0..(crypto_iters + crypto_iters / 10) {
+        let t0 = Instant::now();
+        let ok = verify_release(&token, &view, &gov_pub).is_ok();
+        let dt = t0.elapsed();
+        std::hint::black_box(ok);
+        if i >= crypto_iters / 10 {
+            s.push(dt);
+        }
+    }
+    print_timing("verify_release (actuator)", s);
+    drop(region);
+
+    println!("\n===== KIRRA-L3E2E DONE (gate={}) =====", if gate_pass { "PASS" } else { "FAIL" });
+    if gate_pass {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() >= 2 && args[1] == "--guest" {
+        guest_main(&args[2..])
+    } else {
+        governor_main()
+    }
+}

--- a/docs/adr/0030-l3-cross-partition-carrier-and-node-wiring.md
+++ b/docs/adr/0030-l3-cross-partition-carrier-and-node-wiring.md
@@ -103,10 +103,37 @@ These are **not** discharged by this ADR; they are the hypervisor-config checkli
 
 ## Implementation order (recommended, each a bounded increment)
 
-1. **`kirra-hv-carrier` + `PosixShmRegion` + a two-process host integration test** (host-testable; proves the cross-process seqlock).
-2. **Guest call-site** — wire `contract_producer` into `node.rs` (ros2-gated; tighten the `dead_code` allow).
-3. **Governor call-site** — the poll loop + `is_actuatable` actuation gate + the Clause-F digest/release bridge.
-4. **`HvRegion` (QNX binding)** + the R-HV config checklist + #279 hypervisor-layer fault injection (target).
+1. **`kirra-hv-carrier` + `PosixShmRegion` + a two-process host integration test** (host-testable; proves the cross-process seqlock). *DONE — PR #744.*
+2. **Guest call-site** — wire `contract_producer` into `node.rs` (ros2-gated; tighten the `dead_code` allow). *DONE — PR #746.*
+3. **Governor call-site** — the poll loop + `is_actuatable` actuation gate + the Clause-F digest/release bridge. *DONE — PRs #747/#748 (`decide`/`decide_cycle`/`view_to_sign` + `kirra-release-token`).*
+4. **`HvRegion` (QNX binding)** + the R-HV config checklist + #279 hypervisor-layer fault injection (target). *Phase-I DONE (see the update below); the hypervisor half remains.*
+
+## Update 2026-07-02 — incr. 4 Phase-I evidence (QNX 8.0 target OS, KVM VM)
+
+The `kirra-l3-e2e` harness ran the **entire L3 chain on QNX 8.0** (`x86_64-pc-nto-qnx800`,
+mkqnximage/QEMU under KVM) — two real QNX processes over QNX POSIX shared memory, the
+governor on a read-only mapping: **GATE PASS on all five verdict rows** (in-envelope
+actuate + token; over-envelope clamped with the token binding the ENFORCED bytes and
+refusing the raw proposal; expired deadline, replay, and cold start all SafeStop).
+Verbatim runs + provenance: `crates/kirra-l3-e2e/results/qnx800-x86_64-vm-kvm.txt`.
+
+Two findings feed forward (timing INDICATIVE-KVM, never WCET):
+
+- **Under SCHED_FIFO the whole transport+validate+decode+bound step is ~1.1 µs at
+  p99.9** (`decide_cycle`; FIFO collapsed the tail 5322 → 1115 ns) — ~1% of the 100 µs
+  governor-verdict budget. The carrier is not the cost.
+- **The Clause-F crypto DOMINATES:** Ed25519 sign (~32 µs) + verify (~60 µs) ≈ 91 µs
+  p50 — nearly the whole verdict budget, p99 over it. **The release token must be
+  budgeted APART from the verdict path** (pipelined/overlapped with actuation latency,
+  issued below cycle rate, or hardware-assisted); it cannot ride inline per-cycle
+  within the verdict WCET target on this CPU class. This is a follow-up design
+  decision for the ADR-0013 integration, recorded here so it is not lost.
+
+**What Phase-I is NOT:** the VM runs QNX **OS**, not QNX **Hypervisor** — no guest
+partitions, so the true `HvRegion` mapping, R-HV-1 read-only enforcement at hypervisor
+config, R-HV-4 partition scheduling, the boundary-clock primitive, and #279's
+hypervisor-layer fault rows remain **Phase-II hardware** (unchanged reopening
+conditions above).
 
 ## Cross-references
 


### PR DESCRIPTION
## Why

**L3 incr. 4 Phase-I prep** (ADR-0030 Clause B / #279 subset). The honest scope for the QNX 8.0 KVM VM: it runs **QNX OS, not QNX Hypervisor** — no guest partitions, so the true `HvRegion` + R-HV-1/R-HV-4 enforcement stays Phase-II hardware. What the VM *can* give is the entire L3 stack running on the **QNX target OS**: POSIX-SHM carrier (QNX is POSIX-native), two real QNX processes, the full doer→checker→release trust chain, the contract-discipline fault rows, and the first QNX-target timing for the carrier + release-token crypto.

The existing two-process tests can't be shipped to a target (they embed `CARGO_BIN_EXE_*` host paths), so this adds the one self-contained binary the QNX day needs — **host-verified first**, per the standing pattern.

## What

New crate **`kirra-l3-e2e`** — one self-spawning binary (`current_exe()` + `--guest`), no cargo-test machinery:

**Matrix (gate = verdict correctness, the #274 discipline):**
| Row | Scenario | Expected |
|---|---|---|
| L3-01 | in-envelope proposal | `Actuate(10.0)` + token verifies |
| L3-02 | over-envelope 50 m/s | clamped ≤35; **token binds the enforced bytes, refuses the raw proposal** |
| L3-03 | expired deadline | SafeStop, nothing signable |
| L3-04 | replay (same seq, fresh guest process) | SafeStop |
| L3-05 | unwritten region (cold start) | SafeStop |

Guest role **opens** (never creates/owns) the region — the node.rs ownership rule.

**Timing section** (INDICATIVE banner; `KIRRA_E2E_FIFO=1` attempts SCHED_FIFO via POSIX `pthread_setschedparam`, which works on both Linux and QNX): seqlock read, `decide_cycle`, `issue_release_token`, `verify_release`.

## Host verification (this container)

```
GATE (verdict correctness): PASS   (all 5 rows)

path                                  p50_ns    p99_ns   p999_ns
shm read_coherent_snapshot                53       183       244
decide_cycle (read+val+bound)            521       672      4546
issue_release_token (sign)             19992     40374     61951
verify_release (actuator)              41415     69283    101805
```

**Finding worth flagging:** the Ed25519 release-token crypto **dominates** the governor cycle — sign ~20 µs / verify ~41 µs p50 vs ~0.5 µs for the entire read+validate+decode+bound pipeline. The release token, not the transport, is the FTTI budget consumer on this path (sign+verify p99 ≈ 109 µs vs the 100 µs governor verdict target). The QNX run will give the target-side numbers; mitigation (rate, amortization, hardware crypto) is a follow-up decision, not this PR.

## Scope

Harness crate (evidence tooling, **not TCB** — it may depend on kirra-core + the release token). One small `unsafe` (the FIFO FFI call) with a SAFETY comment. Clippy clean. Next step after merge: cross-build for `x86_64-pc-nto-qnx800` on the dev laptop, scp to the QNX VM, run, record results (INDICATIVE-KVM labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_