### PR TITLE
docs(adr): ADR-0031 — release-token crypto rides the actuation path, not the verdict WCET

### DIFF
--- a/docs/adr/0031-release-token-on-the-actuation-path.md
+++ b/docs/adr/0031-release-token-on-the-actuation-path.md
@@ -6,7 +6,7 @@
 | Date | 2026-07-02 |
 | Deciders | Project / safety-case owner |
 | Safety goals | **SG3** (per-command kinematic envelope — the release token is the authenticated *proof* of the bounded command, ADR-0013); FTTI budget integrity (the verdict gate stays crypto-free and bounded) |
-| Cross-refs | ADR-0030 (Clause F + the *Update 2026-07-02* Phase-I evidence); ADR-0013 (authenticated actuation gate); `docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md` §3 steps 5–7; `crates/kirra-release-token` (the canonical token); `kirra_core::contract_consumer::{decide_cycle, GovernorCycle::view_to_sign}`; `src/wcet_gate.rs` (`GOVERNOR_VERDICT_WCET_TARGET_MICROS = 100`, p99.9 gate); the measurements: **PR #766** (`crates/kirra-l3-e2e`, results `qnx800-x86_64-vm-kvm.txt`, INDICATIVE-KVM) |
+| Cross-refs | ADR-0030 (Clause F; its *Update 2026-07-02* Phase-I evidence section **lands in PR #766**); ADR-0013 (authenticated actuation gate); `docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md` §3 steps 5–7; `crates/kirra-release-token` (the canonical token); `kirra_core::contract_consumer::decide_cycle`; `kirra_core::contract_consumer::GovernorCycle::view_to_sign()`; `src/wcet_gate.rs` (`GOVERNOR_VERDICT_WCET_TARGET_MICROS = 100`, p99.9 gate); the measurements: **PR #766** (`crates/kirra-l3-e2e`, results `qnx800-x86_64-vm-kvm.txt`, INDICATIVE-KVM) |
 
 ## Context — the measured problem
 
@@ -51,9 +51,10 @@ The FTTI decomposition is `verdict_WCET + actuation_latency < control_cycle (≪
 
 ### Clause B — per-command tokens are retained (and are affordable)
 
-At the 100 Hz control cycle (10 ms), the measured pair costs ~91 µs p50 / ~150 µs at
-p99-sum — **~1–2 % of the cycle**; even the VM's worst-case outliers (340–465 µs, KVM
-jitter) are <5 %. Per-command, per-cycle tokens therefore fit with an order-of-magnitude
+At the 100 Hz control cycle (10 ms), the measured pair costs ~91 µs p50 / ~116 µs at
+p99-sum (42+74) / ~151 µs at p99.9-sum (63+88) — **~1–2 % of the cycle**; even the VM's
+worst-case outliers (340–465 µs, KVM jitter) are <5 %. Per-command, per-cycle tokens
+therefore fit with an order-of-magnitude
 margin on this CPU class. **No weakening of the per-command binding is needed or taken**:
 every actuated command carries a token over its exact enforced bytes
 (`view_to_sign` → `issue_release_token` → `verify_release`).

--- a/docs/adr/0031-release-token-on-the-actuation-path.md
+++ b/docs/adr/0031-release-token-on-the-actuation-path.md
@@ -1,0 +1,126 @@
+# ADR-0031: The release-token crypto rides the actuation path — never inside the verdict WCET
+
+| Field | Value |
+|---|---|
+| Status | **Proposed (design note)** — ratified on merge. |
+| Date | 2026-07-02 |
+| Deciders | Project / safety-case owner |
+| Safety goals | **SG3** (per-command kinematic envelope — the release token is the authenticated *proof* of the bounded command, ADR-0013); FTTI budget integrity (the verdict gate stays crypto-free and bounded) |
+| Cross-refs | ADR-0030 (Clause F + the *Update 2026-07-02* Phase-I evidence); ADR-0013 (authenticated actuation gate); `docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md` §3 steps 5–7; `crates/kirra-release-token` (the canonical token); `kirra_core::contract_consumer::{decide_cycle, GovernorCycle::view_to_sign}`; `src/wcet_gate.rs` (`GOVERNOR_VERDICT_WCET_TARGET_MICROS = 100`, p99.9 gate); the measurements: **PR #766** (`crates/kirra-l3-e2e`, results `qnx800-x86_64-vm-kvm.txt`, INDICATIVE-KVM) |
+
+## Context — the measured problem
+
+ADR-0030's Phase-I run (PR #766) put target-side numbers on the L3 release path, on QNX 8.0
+(`x86_64-pc-nto-qnx800`, KVM VM, INDICATIVE — the *ratios* are the takeaway):
+
+| path | p50 | p99 | p99.9 |
+|---|---|---|---|
+| `decide_cycle` (read+validate+decode+bound), FIFO | 0.69 µs | 0.77 µs | **1.1 µs** |
+| `issue_release_token` (Ed25519 sign, governor) | 31.6 µs | 42 µs | 63 µs |
+| `verify_release` (Ed25519 verify, actuator) | 59.6 µs | 74 µs | 88 µs |
+
+Two facts follow:
+
+1. **The verdict pipeline is ~1% of its budget.** The whole transport+validate+decode+bound
+   step sits at ~1.1 µs p99.9 against the 100 µs `GOVERNOR_VERDICT_WCET_TARGET_MICROS`.
+   The carrier and the checker are not the cost.
+2. **The token pair (~91 µs p50, sign+verify) is ~99% of the release path and cannot ride
+   inside the verdict target** — at p99 (42+74 ≈ 116 µs) it alone exceeds 100 µs. Any
+   accounting that folds the crypto into the verdict WCET breaks the gate on this CPU class.
+
+The question this ADR decides: **where is the release-token crypto budgeted, and what
+changes if it ever stops fitting?**
+
+## Decision
+
+Five clauses.
+
+### Clause A — budget split (NORMATIVE)
+
+The FTTI decomposition is `verdict_WCET + actuation_latency < control_cycle (≪ FTTI)`.
+
+- **The verdict budget (`GOVERNOR_VERDICT_WCET_TARGET_MICROS = 100`, p99.9) covers the
+  verdict pipeline ONLY** — `consume_and_bound` / `decide` / `decide_cycle`
+  (snapshot → validate → decode → kinematic bound). It is and stays **crypto-free**.
+  The WCET gate (`src/wcet_gate.rs`) and any future on-target verdict-WCET claim must
+  never include token issuance.
+- **The release token (sign governor-side, verify actuator-side) is accounted to the
+  actuation-latency leg.** It executes strictly AFTER the verdict returns and before
+  physical release — it can delay actuation of an *approved* command, but it can never
+  delay the *decision* (and therefore never delays an MRC: a SafeStop needs no token).
+
+### Clause B — per-command tokens are retained (and are affordable)
+
+At the 100 Hz control cycle (10 ms), the measured pair costs ~91 µs p50 / ~150 µs at
+p99-sum — **~1–2 % of the cycle**; even the VM's worst-case outliers (340–465 µs, KVM
+jitter) are <5 %. Per-command, per-cycle tokens therefore fit with an order-of-magnitude
+margin on this CPU class. **No weakening of the per-command binding is needed or taken**:
+every actuated command carries a token over its exact enforced bytes
+(`view_to_sign` → `issue_release_token` → `verify_release`).
+
+### Clause C — rejected alternatives (and why)
+
+- **Folding the token into the verdict WCET** — arithmetic above; also conceptually wrong:
+  the token is an *authorization artifact* of an already-made decision, not part of making it.
+- **Reduced-rate / epoch tokens** (sign every Kth cycle or per time window) — rejected.
+  A token that covers a window re-opens a substitution surface inside that window, and the
+  claim degrades from "the governor approved exactly these bytes" to "…some bytes this
+  epoch." That claim is the whole point of HVCHAN §3.5–7.
+- **Dropping authentication on the release hop** (CRC-only) — rejected outright; the CRC
+  is integrity against corruption, not authenticity against a compromised guest.
+
+### Clause D — the designed escalation: Ed25519-bootstrapped session MAC (specified now, built on trigger)
+
+If the token pair ever stops fitting, the escalation is **not** rate reduction — it is a
+cheaper per-command primitive with the same binding:
+
+- **At boot / re-key**: the governor generates a session key and signs it (plus epoch +
+  identities) with its **existing Ed25519 identity**; the actuator verifies once. Asymmetric
+  crypto stays where it is cheap — identity and bootstrap.
+- **Per command**: the token's signature field carries an **HMAC-SHA256** (already in the
+  tree; no new primitive) over the SAME domain-separated contract digest, keyed by the
+  session key. Measured HMAC cost on this class of hardware is ~1–2 µs — two orders under
+  Ed25519 — restoring the ~99 % headroom.
+- **The trade, stated honestly**: a symmetric MAC keeps *integrity + authenticity* inside
+  the vehicle TCB but loses per-command *non-repudiation* (either key-holder could mint).
+  Forensic non-repudiation is retained at the session level (the Ed25519-signed key
+  attestation) and via the audit chain. Acceptable for the governor→actuator hop, whose
+  threat is the compromised guest, not a dishonest governor.
+
+**Triggers** (any one): the control rate rises to ≥ 1 kHz; measured token p99 exceeds 10 %
+of the control cycle on deployment hardware; or the deployment CPU class measures
+materially slower than this reference. Until a trigger fires, Clause B stands.
+
+### Clause E — hardware crypto is NOT the default answer
+
+TPM / secure-element offload (Phase-II) is noted and deliberately not selected: discrete
+secure elements typically cost *milliseconds* per operation on 96-byte payloads — worse
+than software Ed25519, far worse than the Clause-D MAC. It becomes interesting only for
+key custody (the governor signing key living in hardware), which composes with Clause D
+(the session-key signature is the rare, offloadable operation). Adopt only with measured
+numbers on the deployment SoC.
+
+## Measurement standing
+
+`crates/kirra-l3-e2e` (PR #766) is the standing measurement harness — its
+`issue_release_token` / `verify_release` timing rows re-validate this ADR's arithmetic on
+every future target (Orin, QNX Hypervisor hardware). The budgets above are re-checked, not
+assumed, per target class; the recorded run is INDICATIVE-KVM and the certified figures
+are Phase-II hardware under FIFO (#274 discipline).
+
+## Consequences
+
+- The verdict gate keeps its clean, crypto-free 100 µs claim; no change to `wcet_gate.rs`.
+- The governor call-site (ADR-0030 Clause D) orders its cycle: `decide_cycle` → (if
+  actuatable) `issue_release_token` → hand off; the actuator orders `verify_release` →
+  physical release. A SafeStop bypasses the token entirely — fail-closed costs nothing extra.
+- Integrators get a stated, measurable feasibility envelope (Clause B) and a pre-designed
+  escalation (Clause D) instead of an ad-hoc redesign under schedule pressure.
+
+## Conditions that reopen this decision
+
+- A Clause-D trigger fires (rate/cycle-share/CPU-class) → implement the session MAC.
+- Deployment hardware measurements contradict Clause B's arithmetic (e.g. the p99.9 token
+  cost exceeding ~10 % of the cycle even at 100 Hz).
+- A certification requirement demands per-command non-repudiation → Clause D's MAC is
+  insufficient; revisit with hardware key custody (Clause E) in the loop.


### PR DESCRIPTION
## Why

The release-token bridge (#748) and the QNX Phase-I run (#766) deferred one decision: *where is the Ed25519 sign/verify cost budgeted, and what changes if it stops fitting?* We now have the target-side numbers, so this ADR makes that call — it changes how FTTI is allocated, which is ADR material, not code.

**The measured problem** (PR #766, QNX 8.0 KVM, INDICATIVE): the whole verdict pipeline (`decide_cycle`) is **~1.1 µs p99.9 under FIFO** — ~1% of the 100 µs `GOVERNOR_VERDICT_WCET_TARGET`. The token pair (sign ~32 µs + verify ~60 µs ≈ **91 µs p50**) is ~99% of the release path and **exceeds the verdict target on its own at p99**.

## The decision (five clauses)

- **A (normative)** — the 100 µs verdict WCET target covers the verdict pipeline **only** and stays crypto-free (no change to `wcet_gate.rs`). The token is accounted to the **actuation-latency leg** of FTTI, strictly after the verdict. A SafeStop needs no token — fail-closed costs nothing extra.
- **B** — **per-command tokens retained**: at the 100 Hz cycle the pair is ~1–2% of 10 ms (even the VM's worst KVM-jitter outliers are <5%). No weakening of the "governor approved exactly these bytes" binding is needed or taken.
- **C — rejected**: folding the token into the verdict WCET (arithmetic + conceptually wrong); reduced-rate/epoch tokens (re-opens a substitution window inside the epoch); CRC-only (integrity ≠ authenticity).
- **D — the designed escalation** (specified now, built on trigger): Ed25519-bootstrapped **per-boot session key** + per-command **HMAC-SHA256** over the same domain-separated digest (~1–2 µs; `hmac`/`sha2` already in the tree — no new primitive). Trade stated honestly: session-level rather than per-command non-repudiation. **Triggers**: ≥1 kHz control rate, token p99 >10% of the cycle on deployment hardware, or a materially slower CPU class.
- **E** — hardware crypto is **not** the default answer (discrete SEs are ms-class on 96-byte ops — worse than software); interesting only for governor-key custody, composing with D, and only with measured numbers on the deployment SoC.

## Measurement standing

`kirra-l3-e2e` (PR #766) is the standing harness — its sign/verify timing rows re-validate this arithmetic on every future target (Orin, QNX Hypervisor hardware). Budgets are re-checked per target class, never assumed.

## Notes

- Docs-only. References PR #766 for the results file (not yet on `main` — same attribution discipline as before).
- Cross-refs: ADR-0030 Clause F + Update 2026-07-02, ADR-0013, HVCHAN §3.5–7, `src/wcet_gate.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_