### PR TITLE
docs(safety): Phase-II Track B — file the three R-HV AoUs + the #279 hypervisor fault campaign spec

### DIFF
--- a/docs/safety/ASSUMPTIONS_OF_USE.md
+++ b/docs/safety/ASSUMPTIONS_OF_USE.md
@@ -55,6 +55,9 @@ the verification passes for the target deployment.
 | AOU-HW-QNX-TARGET-001 | The QNX-resident safety partition and its **certified-WCET** evidence run on an NVIDIA **DRIVE** platform (DRIVE AGX Orin / DRIVE AGX Thor) running DRIVE OS + QNX OS for Safety — **NOT** a Jetson module (Orin NX / AGX Orin / Jetson Thor), which runs L4T/Linux and which NVIDIA does **not** support QNX on | Integrator (hardware / platform) | **AoU-GAP** — pre-production HW gate; vendor-fixed (informational) | the QNX-target WCET / FTTI claim (`TBD-QNX-TARGET`, #274); the EPIC #270 QNX safety-partition lane; ADR `KIRRA_QNX_CROSSCOMPILE` aarch64 path |
 | AOU-PLATFORM-GEOMETRY-001 | A non-Ackermann platform deployed behind the `PlatformKinematics` abstraction supplies a footprint and kinematic limits (via its impl) that MATCH the physical platform; for a platform using the center-convention `VehicleFootprint` (`wheelbase_m = 0`, symmetric overhangs), the supplied pose is the **geometric center** | Integrator (platform) | **AoU** (by design) — abstraction + SG2 seam IMPLEMENTED and dual-platform-PROVEN (S-PK1a/b/c, ADR-0027); a live non-Ackermann **deployment** is **DEPLOYMENT-PENDING** (integrator wires a node consuming `validate_platform_containment` + supplies verified geometry/limits). The Ackermann path is unchanged/ENFORCED | SG2 drivable-space containment for any platform via `validate_platform_containment` (`crates/kirra-core/src/platform_kinematics.rs`); the per-platform envelope (`evaluate`) + RSS stay platform-specific |
 | AOU-TRANSPORT-TLS-001 | The verifier HTTP API (admin token + mutation routes) is reached only over a TLS-terminated / encrypted transport; plaintext exposure beyond a trusted cluster-internal path is prohibited | Integrator (deployment / platform) | **AoU** (by design) — chart fail-closed guard + TLS Ingress live (H-1); cert/issuer integrator-supplied | the confidentiality of `KIRRA_ADMIN_TOKEN` (Tier-2 Bearer auth) and the integrity of all mutation routes — `constant_time_compare` defends the comparison, not the wire |
+| AOU-HV-CLOCK-001 | The hypervisor provides the **boundary clock domain** (HVCHAN §5, R-HV-3): one shared, monotonic time source readable identically from the guest and governor partitions, with a **bounded max cross-partition skew** (bound: **VALIDATION-PENDING**, set with the FTTI budget on hypervisor hardware) | Integrator (hypervisor / platform) | **AoU-GAP** — Phase-II hypervisor gate; the concrete QNX primitive + skew figure are #274/#278 target work | every governor deadline/staleness verdict (`validate` `now > deadline`, HVCHAN §3); the §4 `clock skew beyond bound` fail-closed backstop. Distinct from AOU-TIMESYNC-001 (that binds the integrator's *timestamps*; this binds the *clock source*) |
+| AOU-HV-ROMAP-001 | The hypervisor maps the contract region **read-only into the governor partition** (HVCHAN R-HV-1): the governor cannot write it, and no guest action can induce a governor-side write; verified at hypervisor-configuration level | Integrator (hypervisor / platform) | **AoU-GAP** — Phase-II hypervisor gate; the software mirrors (`PosixShmReader` `PROT_READ` + no-`ContractWriter`-impl) are defense-in-depth, **not** the discharge | the one-way trust direction of the whole Clause-2 channel; `HV_FAULT_CAMPAIGN.md` row HV-R1 |
+| AOU-HV-SCHED-001 | The hypervisor grants the governor partition a **CPU scheduling guarantee independent of guest behavior** (HVCHAN R-HV-4): a guest CPU flood or starve-then-burst cannot delay the governor's bounded snapshot→validate→decide path beyond its FTTI allocation | Integrator (hypervisor / platform) | **AoU-GAP** — Phase-II hypervisor gate; tested by the `HV_FAULT_CAMPAIGN.md` HV-S* rows (a flood absorbed only by judge speed is a FINDING, per the #279 attribution rule) | the `publisher silent` liveness row (§4) and the verdict-latency half of FTTI — without it, guest misbehavior converts into governor latency, the interference FFI forbids |
 
 ---
 
@@ -1130,3 +1133,138 @@ control plane, not a single route.
 - `docs/ros2_interlock.md` (interceptor token-over-TLS note).
 - Route auth matrix: `CLAUDE.md` / `docs/v1_route_authorization_matrix.md`
   (Tier-1 / Tier-2 routes that carry the token).
+
+---
+
+## AOU-HV-CLOCK-001 — Hypervisor boundary-clock provision (shared monotonic source, bounded skew)
+
+### Assumption
+> *The hypervisor shall provide the boundary clock domain (HVCHAN §5, R-HV-3): a
+> single shared, monotonic time source readable identically from the guest and
+> governor partitions, with a bounded maximum cross-partition skew (bound:
+> **VALIDATION-PENDING** — fixed with the FTTI budget on hypervisor hardware,
+> #274/#278).*
+
+### Why it is load-bearing
+Every deadline/staleness verdict the governor issues is `now > deadline ⇒ reject`
+(HVCHAN §3 step 4; `kirra_contract_channel::validate`). `deadline_nanos` is
+written by the guest, `now` is read by the governor — the comparison is only
+meaningful if **both partitions read the same monotonic clock** within a known
+skew. A skew beyond bound silently converts into deadline error: stale commands
+admitted as fresh (skew one way) or fresh commands spuriously rejected into MRC
+(the other way). This is the **provision half** of the two-clock-domain model;
+the **conversion half** (integrator timestamps) is AOU-TIMESYNC-001, filed
+separately — the two discharge different obligations by different owners.
+
+### Evidence / consuming mechanisms
+- `HYPERVISOR_CONTRACT_CHANNEL.md` §5 **R-HV-3** — the domain model (decided) and
+  the primitive (target work); §4 `clock skew beyond bound` — the fail-closed
+  backstop for gross violations.
+- `kirra_contract_channel::validate` — the deadline check that consumes it.
+- ADR-0031 Clause A — the verdict/actuation budget split this clock underpins.
+
+### Scope
+- **In scope:** the shared monotonic source itself — its existence, guest
+  visibility mechanism, monotonicity, and bounded cross-partition skew; the
+  measured **read cost** (it sits on the governor validation path's WCET, #274).
+- **Owner:** Integrator (hypervisor / platform). KIRRA consumes the clock; it
+  cannot create it.
+- **Out of scope:** integrator sensor-timestamp synchronization/conversion
+  (AOU-TIMESYNC-001); system-timing (PTP/wall) uses off the validation path.
+
+### Verification status — **AoU-GAP** (Phase-II hypervisor gate)
+Not dischargeable on the Phase-I evidence platform (QNX OS VM — no partitions,
+one kernel clock). Discharged on hypervisor hardware by (a) identifying the
+concrete QNX Hypervisor clock primitive, (b) demonstrating identical guest/
+governor readability, (c) measuring the skew bound and the read cost, and (d)
+folding both into the FTTI budget (#274/#278). Until then the §4 skew/deadline
+rows are the runtime backstops (gross, not subtle — same honesty note as
+AOU-TIMESYNC-001).
+
+---
+
+## AOU-HV-ROMAP-001 — Read-only governor mapping of the contract region (R-HV-1)
+
+### Assumption
+> *The hypervisor configuration shall map the contract region **read-only** into
+> the governor partition: the governor cannot write the region, and no guest
+> action can induce a governor-side write. Verified at the hypervisor-
+> configuration level, not assumed from software behavior.*
+
+### Why it is load-bearing
+The Clause-2 channel's trust argument is **one-directional**: the guest writes,
+the governor validates a local snapshot and never trusts — or touches — the
+shared bytes. A writable governor mapping breaks that direction: a fault (or
+compromise) on the governor side could fabricate "guest" input, corrupt the
+region mid-read for its own snapshot loop, or mask a guest fault — undermining
+both the validation claim and the #279 attribution taxonomy (which layer owns
+which fault).
+
+### Evidence / consuming mechanisms
+- `HYPERVISOR_CONTRACT_CHANNEL.md` §5 **R-HV-1**; §2.3 (writer/checker roles).
+- **Software mirrors (defense-in-depth, NOT the discharge):** the host carrier
+  already enforces the shape twice — `kirra_hv_carrier::PosixShmReader` maps
+  `PROT_READ` (OS level) and implements no `ContractWriter` (type level); the
+  Phase-I harness ran the governor exclusively on that read-only mapping. These
+  demonstrate the *software* never needs a writable mapping; only the hypervisor
+  config makes it *impossible*.
+- `HV_FAULT_CAMPAIGN.md` row **HV-R1** — the config-violation probe.
+
+### Scope
+- **In scope:** the hypervisor memory-map configuration for the contract region
+  (guest RW, governor RO), and its verification as a checkable precondition.
+- **Owner:** Integrator (hypervisor / platform).
+- **Out of scope:** in-partition memory protection (the guest's own hygiene) and
+  the region's size/alignment (R-HV-2, enforced by the carrier's fstat guard +
+  freeze assertions).
+
+### Verification status — **AoU-GAP** (Phase-II hypervisor gate)
+Not dischargeable on Phase-I (POSIX SHM offers `PROT_READ`, but a same-kernel
+process with credentials could remap; only a hypervisor makes the RO mapping a
+partition-level invariant). Discharged by hypervisor-config review + the
+HV-R1 campaign row (an attempted governor-side write must fault at the
+hypervisor, not merely be absent from the software).
+
+---
+
+## AOU-HV-SCHED-001 — Governor-partition scheduling guarantee independent of guest behavior (R-HV-4)
+
+### Assumption
+> *The hypervisor shall grant the governor partition a CPU scheduling guarantee
+> sufficient to complete its bounded snapshot → validate → decide (and, when
+> actuatable, token-issue) path within its FTTI allocation **regardless of guest
+> CPU behavior** — a guest flood or starve-then-burst shall not delay it.*
+
+### Why it is load-bearing
+The FTTI decomposition (`verdict_WCET + actuation_latency < control_cycle`,
+ADR-0031 Clause A) presumes the governor actually gets scheduled. Without a
+partition-level guarantee, a compromised or merely busy guest converts its CPU
+consumption into governor latency — the precise interference that
+freedom-from-interference (ADR-0004/0020) forbids, arriving through the
+scheduler rather than through memory. The §4 `publisher silent` row catches a
+guest that stops *publishing*; only R-HV-4 catches a guest that keeps publishing
+while starving the *governor*.
+
+### Evidence / consuming mechanisms
+- `HYPERVISOR_CONTRACT_CHANNEL.md` §5 **R-HV-4**; §4 `publisher silent` row
+  (SG-003 liveness posture) — the complementary barrier.
+- The Phase-I timing baseline (PR #766 results): the governor path is ~1.1 µs
+  p99.9 under FIFO **when scheduled** — R-HV-4 is what makes "when scheduled" a
+  guarantee rather than a hope.
+- `HV_FAULT_CAMPAIGN.md` rows **HV-S1/HV-S2** — flood and starve-then-burst.
+- **Attribution rule (#279, normative here):** a flood absorbed only because the
+  judge is fast is a **finding against the hypervisor config**, not a pass.
+
+### Scope
+- **In scope:** the hypervisor's CPU budget/priority configuration for the
+  governor partition and its independence from guest load.
+- **Owner:** Integrator (hypervisor / platform).
+- **Out of scope:** in-partition thread scheduling (the governor's own FIFO
+  discipline — measured in Phase-I) and the guest's internal QoS.
+
+### Verification status — **AoU-GAP** (Phase-II hypervisor gate)
+Not dischargeable on Phase-I (one kernel, no partitions — SCHED_FIFO inside one
+OS is not a partition guarantee). Discharged by hypervisor scheduling
+configuration + the HV-S1/HV-S2 campaign rows measuring governor-path latency
+percentiles UNDER guest flood/starve-burst, against the same budgets the
+Phase-I baseline established unloaded.

--- a/docs/safety/HV_FAULT_CAMPAIGN.md
+++ b/docs/safety/HV_FAULT_CAMPAIGN.md
@@ -1,0 +1,80 @@
+# KIRRA-OCCY-HVFAULT-001 — The #279 hypervisor-layer fault-injection campaign (Phase-II execution spec)
+
+| Field | Value |
+|---|---|
+| Status | **Specified** — executable when the Phase-II preconditions (below) are met |
+| Date | 2026-07-02 |
+| Scope | The **hypervisor-owned rows** of the HVCHAN §4 failure-semantics table, plus re-validation of the discipline/judge rows over the real `HvRegion` carrier. Maps **1:1** onto §4's "owning barrier" column (#279's attribution taxonomy) |
+| Cross-refs | `HYPERVISOR_CONTRACT_CHANNEL.md` (HVCHAN-001 §4/§5); ADR-0030 (Clause B `HvRegion`; the *Update 2026-07-02* Phase-I evidence); ADR-0031 (budget split the latency rows verify); `AOU-HV-CLOCK-001` / `AOU-HV-ROMAP-001` / `AOU-HV-SCHED-001` (the register entries these rows discharge); `crates/kirra-l3-e2e` (the harness the campaign extends); #279, #274, #278 |
+
+## 1. Purpose and the attribution rule
+
+HVCHAN §4 assigns every fault a **detection point**, a **fail-closed verdict**, and an
+**owning barrier** (hypervisor / contract-discipline / judge). Phase-I (PR #766) proved
+the *contract-discipline* and *judge* rows on the QNX target OS. This campaign is the
+remaining half: the rows only a real hypervisor deployment can exercise — and the
+**attribution rule is normative**: *a fault absorbed by the wrong layer is a FINDING,
+not a pass.* A guest flood survived only because the judge is fast means the hypervisor
+scheduling config failed, even though nothing unsafe was actuated.
+
+## 2. Preconditions (the honest gate — recorded 2026-07-02)
+
+1. **QNX Hypervisor 8.0 product.** Probed on the dev laptop: the SDP 8.0 install
+   carries hypervisor *documentation* and the `mkqnximage/qvm` image **template**, but
+   **no `qvm` binary / vdev modules** — the hypervisor package is not present under the
+   current (non-commercial) license. QNX Hypervisor for Safety is a commercial product
+   (see `KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md`). **The campaign is blocked on
+   obtaining the hypervisor package**; the `mkqnximage --type=qvm` path means the
+   tooling flow exists the day the package installs.
+2. **A hypervisor image** with two partitions: a guest (publisher; eventually the ROS
+   adapter's host) and the governor partition, sharing one `shmem` vdev region of
+   exactly `CANONICAL_IMAGE_LEN` bytes — guest RW, governor **RO** (R-HV-1).
+3. **The `HvRegion` binding** (ADR-0030 Clause B): `ContractReader`/`ContractWriter`
+   over the vdev region — the same traits, trust chain, and freeze assertions as
+   `PosixShmRegion`; only the map primitive differs. The `kirra-l3-e2e` harness then
+   runs UNCHANGED over it (the carrier is behind the seam).
+4. **The boundary-clock primitive** identified and readable from both partitions
+   (AOU-HV-CLOCK-001) — required by the HV-C1 row; the campaign can start without it
+   (rows HV-R1/HV-S1/HV-S2 do not need it) but cannot **complete**.
+
+## 3. Row matrix
+
+**Already discharged (Phase-I, PR #766, QNX OS)** — re-run over `HvRegion` as
+regression, expecting byte-identical verdicts:
+
+| Row | §4 fault | Phase-I evidence |
+|---|---|---|
+| CD-1..5 | layout-version / magic / retry-exhaustion / CRC / bounds | `kirra-l3-e2e` L3-05 (cold start) + the carrier/consumer test suites |
+| J-1..2 | judge rejects (deadline, kinematic, replay/regress) | `kirra-l3-e2e` L3-02/03/04 |
+
+**Hypervisor-owned rows (this campaign — need the real hypervisor):**
+
+| Row | Fault injected | Injection method | Observation point | PASS criterion (attribution-correct) |
+|---|---|---|---|---|
+| **HV-R1** | Governor-side write attempt on the contract region (R-HV-1 violation probe) | A deliberate test-only write through the governor partition's mapping (page poke at a known offset) | Hypervisor fault handling; region bytes | The write **faults at the hypervisor** (partition exception / denied), region bytes unchanged. Absence-of-write-in-software is NOT a pass — the mapping must make it impossible (`AOU-HV-ROMAP-001`) |
+| **HV-S1** | Guest CPU **flood**: guest spins all its vCPUs at max while publishing at max rate | Guest-side busy loops (N threads) + tight publish loop | Governor-path latency percentiles (`kirra-l3-e2e` timing section) under load | Governor `decide_cycle` percentiles stay within the FTTI allocation and within a stated factor of the Phase-I unloaded baseline (~1.1 µs p99.9 FIFO). Degradation traced to the scheduler = **hypervisor-config FINDING** even if verdicts stay correct (`AOU-HV-SCHED-001`) |
+| **HV-S2** | Guest **starve-then-burst**: guest goes silent past the liveness window, then floods | Guest publisher pause (> watchdog window) followed by max-rate burst | (a) liveness posture during silence; (b) governor latency + watermark behavior during the burst | (a) `publisher silent` row fires → the SG-003 Degraded/MRC posture (never a stale-data accept); (b) the burst neither starves the governor nor replays past the watermark |
+| **HV-C1** | **Clock skew beyond bound** between partitions (R-HV-3) | Skew the guest's view of the boundary clock beyond the AOU-HV-CLOCK-001 bound (test hook or vdev manipulation) | Governor deadline verdicts | Deadlines mis-signed by skew are **rejected** (the §4 skew row) — never a stale command admitted as fresh. Requires the measured skew bound; completes AOU-HV-CLOCK-001 |
+| **HV-T1** | Torn/churning writer across the **real** partition boundary | Guest publishes at max rate while the governor snapshots continuously (the Phase-I seqlock test, now over the vdev + hypervisor memory model) | Snapshot loop outcomes | Zero torn snapshots accepted; persistent churn → `RetryExhausted` reject. Re-proves the Clause-A atomics assumption on the hypervisor's actual shared-memory semantics |
+
+**Timing evidence taken alongside** (not pass/fail rows): the `kirra-l3-e2e` timing
+section on the governor partition — unloaded, under HV-S1, and under HV-S2 — labelled
+per the #274 discipline (only genuine hypervisor-hardware-under-FIFO numbers may feed a
+WCET/FTTI claim; `KIRRA_WCET_CERTIFIED` stays reserved for certified hardware).
+
+## 4. Instruments
+
+- `kirra-l3-e2e` (PR #766) — the verdict matrix + timing, unchanged over `HvRegion`.
+- A small guest-side **load generator** (flood threads + publish-rate control + the
+  silence/burst sequencer) — to be added to the harness crate when the campaign
+  unblocks (`--load` role beside `--guest`).
+- The HV-R1 **write probe** — a test-only governor-partition poke, kept OUT of the
+  carrier crate (it violates the discipline on purpose; it lives with the campaign).
+
+## 5. Exit criteria
+
+The campaign is complete when: every HV-* row passes **with correct attribution**;
+the CD/J regression rows are byte-identical over `HvRegion`; the three `AOU-HV-*`
+register entries move from **AoU-GAP** to discharged-with-evidence (config review +
+row results + the measured skew bound); and the timing set (unloaded / HV-S1 / HV-S2)
+is recorded with honest labels in `crates/kirra-l3-e2e/results/`.

--- a/docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md
+++ b/docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md
@@ -344,14 +344,16 @@ safety argument leans on. They become the **hypervisor-config checklist** that
     drift-bounded against the boundary domain, and **converted to it before
     publication** (the §5 R-HV-3 non-mixing rule). This is the integrator half of
     the resolved two-domain model.
-  - **Integrator / hypervisor clock provision — *NOT filed yet*.** The boundary
-    domain *itself*: a hypervisor-provided shared monotonic source with a bounded
-    max skew across partitions (R-HV-3). The domain model is decided (§5); the
-    concrete clock **primitive** + its bounded-skew figure are **target work
-    (#274/#278)**, to be filed as its own register entry when resolved on target.
-    Distinct from `AOU-TIMESYNC-001`: that one binds the integrator's *timestamps*;
-    this one binds the hypervisor's *clock source*.
-  - **Hypervisor partition-scheduling guarantee** — the governor-partition CPU
-    guarantee independent of guest behavior (R-HV-4). *(NOT filed yet.)*
-  - **Read-only-mapping enforcement** — the hypervisor config that makes R-HV-1
-    a checkable precondition. *(NOT filed yet.)*
+  - **Integrator / hypervisor clock provision — FILED as `AOU-HV-CLOCK-001`**
+    (`ASSUMPTIONS_OF_USE.md`). The boundary domain *itself*: a hypervisor-provided
+    shared monotonic source with a bounded max skew across partitions (R-HV-3).
+    The domain model is decided (§5); the concrete clock **primitive** + its
+    bounded-skew figure remain **target work (#274/#278)** — the entry carries the
+    bound as VALIDATION-PENDING. Distinct from `AOU-TIMESYNC-001`: that one binds
+    the integrator's *timestamps*; this one binds the hypervisor's *clock source*.
+  - **Hypervisor partition-scheduling guarantee — FILED as `AOU-HV-SCHED-001`** —
+    the governor-partition CPU guarantee independent of guest behavior (R-HV-4);
+    tested by the `HV_FAULT_CAMPAIGN.md` HV-S1/HV-S2 rows.
+  - **Read-only-mapping enforcement — FILED as `AOU-HV-ROMAP-001`** — the
+    hypervisor config that makes R-HV-1 a checkable precondition; probed by the
+    `HV_FAULT_CAMPAIGN.md` HV-R1 row.


### PR DESCRIPTION
## Why

Phase-II (the QNX **Hypervisor** half of L3) splits on a licensing gate we probed today on the dev laptop: SDP 8.0 carries hypervisor *documentation* and the `mkqnximage/qvm` image **template**, but **no `qvm` binary / vdev modules** — the QNX Hypervisor package is not present under the current non-commercial license (it's a commercial product, per `KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md`).

- **Track A** (real `HvRegion`, R-HV enforcement, the fault rows) → **blocked on the package**; the `mkqnximage --type=qvm` template means the tooling flow exists the day it installs.
- **Track B** (this PR) → the Phase-II paperwork that must exist regardless, and that HVCHAN §6 explicitly flagged as *"NOT filed yet"* three times.

## What

**`ASSUMPTIONS_OF_USE.md` — three new register entries** (table rows + full sections, house format):
- **AOU-HV-CLOCK-001** (R-HV-3, provision half) — the hypervisor boundary clock: shared monotonic source, bounded cross-partition skew (VALIDATION-PENDING, fixed with the FTTI budget on hypervisor hardware). Explicitly distinct from AOU-TIMESYNC-001 (*timestamps* vs *clock source*) — closing the split TIMESYNC's own Scope section carved out.
- **AOU-HV-ROMAP-001** (R-HV-1) — the read-only governor mapping, verified at **hypervisor config**; the software mirrors (`PosixShmReader` `PROT_READ` + no-`ContractWriter`-impl, proven in Phase-I) are documented as defense-in-depth, **not** the discharge.
- **AOU-HV-SCHED-001** (R-HV-4) — the governor-partition CPU guarantee independent of guest behavior, carrying the #279 attribution rule (a flood absorbed only by judge speed is a hypervisor-config **finding**).

**`HYPERVISOR_CONTRACT_CHANNEL.md` §6** — the three *"NOT filed yet"* markers now point at the filed entries and the campaign rows that test them.

**`HV_FAULT_CAMPAIGN.md`** (KIRRA-OCCY-HVFAULT-001, new) — the #279 hypervisor-layer campaign as an **executable spec**:
- the honest licensing precondition recorded (today's probe);
- the Phase-I-discharged contract-discipline/judge rows listed for `HvRegion` regression;
- five **HV-\*** rows — RO-mapping write probe (HV-R1), guest CPU flood (HV-S1), starve-then-burst (HV-S2), clock skew (HV-C1), torn writer over the real boundary (HV-T1) — each with injection method, observation point, and an **attribution-correct** PASS criterion;
- instruments (`kirra-l3-e2e` unchanged over `HvRegion` + a guest load-generator role + the write probe kept OUT of the carrier crate);
- exit criteria that move the three `AOU-HV-*` entries from AoU-GAP to discharged-with-evidence.

## Notes

Docs-only. With this merged, Phase-II's remaining work is purely **Track A execution** — obtain the hypervisor package, build the qvm image, bind `HvRegion`, run the campaign — with nothing left unspecified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_