### PR TITLE
parko: fail-closed RSS default (RssFeed::NeverFed) + scene-veto gates on the tick seam

### DIFF
--- a/parko/INTEGRATION.md
+++ b/parko/INTEGRATION.md
@@ -212,10 +212,20 @@ banner; do not treat the numbers as a validated safety claim.
 
 ### 3.3 RSS safe-distance
 
-`parko_kirra::KirraGovernor` carries an `RssState { safe: bool, … }`
-updated via `update_rss_state`. An unsafe RSS state applies the MRC
-profile (same path as `SafetyPosture::Degraded`) — a sensor gap is
-recoverable, not a hard stop. Per ADL-001.
+`parko_kirra::KirraGovernor` carries an RSS feed (`RssFeed`) updated via
+`update_rss_state`. An unsafe RSS state applies the MRC profile (same
+path as `SafetyPosture::Degraded`) — a sensor gap is recoverable, not a
+hard stop. Per ADL-001.
+
+**Fail-closed default (WS-0.1 / #G2):** a freshly constructed governor is
+`RssFeed::NeverFed` and gates as UNSAFE — an integrator that never feeds
+an RSS verdict gets a HOLD-at-zero governor, not a silently permissive
+one. The two explicit exits: call `update_rss_state` per control cycle,
+or declare `with_external_rss_gate()` when scene-RSS enforcement happens
+at the publication seam (the parko-ros2 node does this automatically when
+its object-RSS gate is armed) or has been explicitly waived by the
+operator (`PARKO_ALLOW_MOTION_WITHOUT_OBJECT_PERCEPTION=1`, logged
+loudly). A comparator pairing must set the same mode on BOTH arms.
 
 ### 3.4 Posture-driven profile
 

--- a/parko/crates/parko-kirra/src/diverse.rs
+++ b/parko/crates/parko-kirra/src/diverse.rs
@@ -74,6 +74,8 @@ use parko_core::commands::ControlCommand;
 use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
 use parko_core::RssState;
 
+use crate::RssFeed;
+
 use crate::angular_bound::{AngularVelocityBound, PlatformParams};
 use crate::comparator::RssAwareGovernor;
 use crate::{degraded_channel_violation, MRC_VELOCITY_CEILING_MPS, STOP_EPSILON_RAD_S};
@@ -110,7 +112,7 @@ pub struct DiverseKirraGovernor {
     /// `odd_speed_cap_mps`) — the diverse path does NOT call
     /// `validate_vehicle_command`.
     nominal_contract: VehicleKinematicsContract,
-    rss_state: RssState,
+    rss_feed: RssFeed,
     /// SOTIF-derived angular bound for the Nominal posture — same config
     /// object the primary uses. The ω_max(v) derivation is shared SPEC
     /// (see the honest-limit note); the ENFORCEMENT decision around it is
@@ -130,15 +132,14 @@ impl DiverseKirraGovernor {
     /// Construct a diverse governor with defaults identical to
     /// [`crate::KirraGovernor::new`] so the two agree by construction on a
     /// shared config. Mirroring the primary's defaults is what makes the
-    /// comparator's agreement property meaningful.
+    /// comparator's agreement property meaningful — including the
+    /// **fail-closed [`RssFeed::NeverFed`] default** (an unfed shadow gates
+    /// as UNSAFE exactly as the unfed primary does; a mismatched default
+    /// would be a permanent false divergence).
     pub fn new() -> Self {
         Self {
             nominal_contract: VehicleKinematicsContract::nominal_reference_profile(),
-            rss_state: RssState {
-                safe: true,
-                longitudinal_margin: f64::MAX,
-                lateral_margin: f64::MAX,
-            },
+            rss_feed: RssFeed::NeverFed,
             nominal_angular_bound: AngularVelocityBound::nominal(
                 PlatformParams::conservative_default(),
             ),
@@ -201,7 +202,16 @@ impl DiverseKirraGovernor {
     /// `update_rss_state`; the comparator keeps both governors in lockstep
     /// by calling this through its own `update_rss_state`.
     pub fn update_rss_state(&mut self, state: RssState) {
-        self.rss_state = state;
+        self.rss_feed = RssFeed::Fed(state);
+    }
+
+    /// Mirror of [`crate::KirraGovernor::with_external_rss_gate`] — the
+    /// explicit declaration that scene-RSS enforcement happens outside this
+    /// governor. A comparator pairing MUST set this on BOTH arms (or
+    /// neither); a one-sided declaration is a permanent false divergence.
+    pub fn with_external_rss_gate(mut self) -> Self {
+        self.rss_feed = RssFeed::ExternallyGated;
+        self
     }
 
     /// DIFFERENCE #1 — single regime classifier. Folds the primary's
@@ -211,9 +221,17 @@ impl DiverseKirraGovernor {
     /// to the minimum-risk envelope (the primary reaches the same MRC code
     /// from two different branches).
     fn classify(&self, posture: SafetyPosture) -> Regime {
+        // The RSS-safe verdict re-derives the SAME RssFeed semantics as the
+        // primary (NeverFed → unsafe; ExternallyGated → quiescent) through
+        // this governor's own match — the shared item is the SPEC, not code.
+        let rss_safe = match &self.rss_feed {
+            RssFeed::NeverFed => false,
+            RssFeed::Fed(state) => state.safe,
+            RssFeed::ExternallyGated => true,
+        };
         if posture == SafetyPosture::LockedOut {
             Regime::HardStop
-        } else if posture == SafetyPosture::Degraded || !self.rss_state.safe {
+        } else if posture == SafetyPosture::Degraded || !rss_safe {
             Regime::MinimumRisk
         } else {
             Regime::Nominal
@@ -602,7 +620,9 @@ mod tests {
     /// with `&&` a single NaN would slip through to an unbounded command.
     #[test]
     fn diverse_denies_each_nonfinite_input_in_nominal() {
-        let gov = DiverseKirraGovernor::new();
+        // Nominal-tier test: the unfed fail-closed default would route to the
+        // MinimumRisk regime; declare external RSS gating to reach Nominal.
+        let gov = DiverseKirraGovernor::new().with_external_rss_gate();
         let fin = twist(1.0, 0.0);
         // Non-finite linear (current + dt finite).
         for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
@@ -626,7 +646,7 @@ mod tests {
     /// arithmetic to the kinematics contract.
     #[test]
     fn diverse_accel_clamp_equals_spec_value() {
-        let gov = DiverseKirraGovernor::new();
+        let gov = DiverseKirraGovernor::new().with_external_rss_gate();
         let out = gov.evaluate(&twist(20.0, 0.0), Some(&twist(0.0, 0.0)), 0.05, SafetyPosture::Nominal);
         let v = effective_lin(&out, 20.0);
         assert!((v - 0.125).abs() < 1e-6,

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -364,6 +364,56 @@ pub fn compute_occlusion_cap(occlusion: &OcclusionScene, params: &RssParams) -> 
     }
 }
 
+/// Where the pushed-state RSS verdict for `evaluate()` comes from — and,
+/// critically, what "nothing was ever pushed" means.
+///
+/// **Fail-closed default (#G2 / WS-0.1):** a governor that has NEVER been fed
+/// an RSS verdict must not assert one. The prior implementation seeded
+/// `rss_state` with `safe: true`, so a call site that forgot (or didn't know)
+/// to feed the governor got a silently fail-open RSS tier — the exact
+/// "accept by default" class the doer-checker invariants forbid. `NeverFed`
+/// gates as UNSAFE (→ the MRC decel-to-stop-and-HOLD profile: no motion from
+/// standstill), so an unfed governor is immobile, not permissive.
+///
+/// The two ways OUT of `NeverFed` are both explicit and greppable:
+///   - [`KirraGovernor::update_rss_state`] → `Fed(state)`: a control loop
+///     pushes a per-cycle verdict (the comparator/shadow + test path).
+///   - [`KirraGovernor::with_external_rss_gate`] → `ExternallyGated`: the
+///     integrator DECLARES that the scene-RSS verdict is enforced OUTSIDE this
+///     governor instance — e.g. parko-ros2's publication-seam
+///     `apply_object_rss_gate` (ADR-0029 Phase 3b), which bounds the exact
+///     twist about to be published — or that the operator has explicitly
+///     accepted motion without a scene-RSS producer (logged loudly by the
+///     node). The RSS tier inside `evaluate()` is then intentionally
+///     quiescent; every OTHER tier (non-finite reject, LockedOut, Degraded
+///     MRC, kinematic envelope, angular bound) still enforces.
+///
+/// The authoritative `evaluate_scene*` family bypasses this state entirely —
+/// it computes the verdict from the scene per call and never trusts a pushed
+/// value.
+#[derive(Debug, Clone)]
+pub enum RssFeed {
+    /// No RSS verdict has ever been supplied. Gates as UNSAFE (fail-closed).
+    NeverFed,
+    /// The most recent verdict pushed via `update_rss_state`.
+    Fed(RssState),
+    /// The integrator explicitly declared that scene-RSS enforcement happens
+    /// outside this governor (publication-seam gate) or was explicitly
+    /// waived. The pushed-state RSS tier does not gate.
+    ExternallyGated,
+}
+
+impl RssFeed {
+    /// The RSS-safe verdict this feed contributes to the three-tier gate.
+    fn rss_safe(&self) -> bool {
+        match self {
+            RssFeed::NeverFed => false,
+            RssFeed::Fed(state) => state.safe,
+            RssFeed::ExternallyGated => true,
+        }
+    }
+}
+
 /// A safety governor backed by the Kirra runtime SDK's vehicle kinematics
 /// contract.
 ///
@@ -373,7 +423,7 @@ pub struct KirraGovernor {
     nominal_contract: VehicleKinematicsContract,
     #[allow(dead_code)]
     fallback_contract: VehicleKinematicsContract,
-    rss_state: RssState,
+    rss_feed: RssFeed,
     /// SOTIF-derived angular-velocity bound for the Nominal posture.
     /// Default = `AngularVelocityBound::nominal(PlatformParams::conservative_default())`.
     /// Override per platform via `with_platform_params` or
@@ -405,11 +455,16 @@ impl KirraGovernor {
     /// See `crate::angular_bound` for the derivation;
     /// `docs/safety/ANGULAR_VELOCITY_SOTIF.md` is the safety case
     /// (DRAFT — pending formal safety-engineer review).
+    /// **Fail-closed RSS default:** the constructed governor starts
+    /// [`RssFeed::NeverFed`] — its pushed-state RSS tier gates as UNSAFE (MRC
+    /// decel-to-stop-and-HOLD; no motion from standstill) until either a
+    /// verdict is fed (`update_rss_state`) or external gating is explicitly
+    /// declared (`with_external_rss_gate`). See [`RssFeed`].
     pub fn new() -> Self {
         Self {
             nominal_contract: VehicleKinematicsContract::nominal_reference_profile(),
             fallback_contract: VehicleKinematicsContract::mrc_fallback_profile(),
-            rss_state: RssState { safe: true, longitudinal_margin: f64::MAX, lateral_margin: f64::MAX },
+            rss_feed: RssFeed::NeverFed,
             nominal_angular_bound: AngularVelocityBound::nominal(PlatformParams::conservative_default()),
             mrc_angular_bound:     AngularVelocityBound::mrc    (PlatformParams::conservative_default()),
         }
@@ -479,18 +534,36 @@ impl KirraGovernor {
     /// Updates the RSS safe-distance state.
     /// Called by the control loop after each RSS evaluation cycle.
     pub fn update_rss_state(&mut self, state: RssState) {
-        self.rss_state = state;
+        self.rss_feed = RssFeed::Fed(state);
+    }
+
+    /// EXPLICITLY declare that the scene-RSS verdict is enforced OUTSIDE this
+    /// governor instance — at the publication seam (parko-ros2's
+    /// `apply_object_rss_gate` bounds the exact twist about to publish,
+    /// ADR-0029 Phase 3b) — or that the operator has explicitly accepted
+    /// motion without a scene-RSS producer. The pushed-state RSS tier inside
+    /// `evaluate()` is then intentionally quiescent; all other tiers
+    /// (non-finite reject, LockedOut, Degraded MRC, kinematic envelope,
+    /// angular bound) still enforce.
+    ///
+    /// This is the ONLY way to get pre-#G2 pass-through behaviour from a
+    /// governor that is never fed — and it is intent-visible at the call
+    /// site, unlike the removed `safe: true` construction default.
+    pub fn with_external_rss_gate(mut self) -> Self {
+        self.rss_feed = RssFeed::ExternallyGated;
+        self
     }
 
     /// Construct a governor that uses the nominal profile regardless of
     /// the posture passed to evaluate(). Kept for convenience and
     /// backward compatibility.
+    /// Starts [`RssFeed::NeverFed`] like `new()` — feed or explicitly gate.
     pub fn nominal() -> Self {
         let profile = VehicleKinematicsContract::nominal_reference_profile();
         Self {
             nominal_contract: profile,
             fallback_contract: profile,
-            rss_state: RssState { safe: true, longitudinal_margin: f64::MAX, lateral_margin: f64::MAX },
+            rss_feed: RssFeed::NeverFed,
             nominal_angular_bound: AngularVelocityBound::nominal(PlatformParams::conservative_default()),
             mrc_angular_bound:     AngularVelocityBound::mrc    (PlatformParams::conservative_default()),
         }
@@ -499,12 +572,13 @@ impl KirraGovernor {
     /// Construct a governor that uses the MRC fallback profile regardless
     /// of the posture passed to evaluate(). Kept for convenience and
     /// backward compatibility.
+    /// Starts [`RssFeed::NeverFed`] like `new()` — feed or explicitly gate.
     pub fn mrc_fallback() -> Self {
         let profile = VehicleKinematicsContract::mrc_fallback_profile();
         Self {
             nominal_contract: profile,
             fallback_contract: profile,
-            rss_state: RssState { safe: true, longitudinal_margin: f64::MAX, lateral_margin: f64::MAX },
+            rss_feed: RssFeed::NeverFed,
             nominal_angular_bound: AngularVelocityBound::nominal(PlatformParams::conservative_default()),
             mrc_angular_bound:     AngularVelocityBound::mrc    (PlatformParams::conservative_default()),
         }
@@ -1016,8 +1090,11 @@ impl SafetyGovernor for KirraGovernor {
     ) -> EnforcementAction {
         // Pushed-state path (comparator/shadow + tests): the gate runs on the
         // RSS verdict last set via `update_rss_state`. The production verdict
-        // comes from `evaluate_scene`, which computes RSS pairwise.
-        self.gate(proposed, previous, delta_time_s, posture, self.rss_state.safe)
+        // comes from `evaluate_scene`, which computes RSS pairwise — or from
+        // the publication-seam gate when `with_external_rss_gate` was
+        // declared. A governor that was NEVER fed gates as UNSAFE
+        // (RssFeed::NeverFed → MRC/HOLD): "no RSS input" is never "safe".
+        self.gate(proposed, previous, delta_time_s, posture, self.rss_feed.rss_safe())
     }
 }
 
@@ -1270,6 +1347,98 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
+    // #G2 / WS-0.1 — the fail-closed RssFeed default. These pin the semantic
+    // change: an UNFED governor never asserts RSS-safe; the pre-fix
+    // `safe: true` construction default (silent fail-open) is gone.
+    // -------------------------------------------------------------------------
+
+    /// THE DoD TEST — "default posture without RSS input is not-safe": a
+    /// freshly constructed governor (never fed an RSS verdict) must not admit
+    /// motion from standstill in Nominal. The RSS tier gates UNSAFE →
+    /// MRC/HOLD → re-initiation from stop is denied.
+    #[test]
+    fn unfed_governor_is_immobile_from_standstill_fail_closed() {
+        let gov = KirraGovernor::new();
+        let action = gov.evaluate(&cmd(2.0), None, 0.05, SafetyPosture::Nominal);
+        assert!(
+            matches!(action, EnforcementAction::Deny { .. }),
+            "an unfed governor must HOLD at zero (deny re-initiation), got {action:?}"
+        );
+    }
+
+    /// An unfed governor bounds an already-moving platform by the MRC
+    /// decel-to-stop profile: a speed INCREASE is denied (never authored),
+    /// while a converging (non-increasing) command within the MRC envelope
+    /// is admitted — a controlled stop, not a slammed one.
+    #[test]
+    fn unfed_governor_applies_mrc_decel_profile_when_moving() {
+        let gov = KirraGovernor::new();
+        let prev = cmd(4.0);
+        let increase = gov.evaluate(&cmd(6.0), Some(&prev), 0.05, SafetyPosture::Nominal);
+        assert!(
+            matches!(increase, EnforcementAction::Deny { .. }),
+            "an unfed governor must deny a speed increase, got {increase:?}"
+        );
+        let converge = gov.evaluate(&cmd(3.9), Some(&prev), 0.05, SafetyPosture::Nominal);
+        assert!(
+            !matches!(converge, EnforcementAction::Deny { .. }),
+            "a converging command within the MRC envelope decelerates under control, got {converge:?}"
+        );
+    }
+
+    /// The explicit opt-out restores envelope pass-through — and is the ONLY
+    /// way to get it without feeding a verdict.
+    #[test]
+    fn externally_gated_governor_restores_envelope_passthrough() {
+        let gov = KirraGovernor::new().with_external_rss_gate();
+        let prev = cmd(3.0);
+        let action = gov.evaluate(&cmd(3.0), Some(&prev), 0.05, SafetyPosture::Nominal);
+        assert!(
+            matches!(action, EnforcementAction::Allow),
+            "externally-gated governor passes an in-envelope command, got {action:?}"
+        );
+    }
+
+    /// Feeding a safe verdict exits NeverFed; feeding an unsafe one after a
+    /// safe one re-gates — the feed is live state, not a one-shot unlock.
+    #[test]
+    fn feeding_transitions_never_fed_to_live_verdicts() {
+        let mut gov = KirraGovernor::new();
+        gov.update_rss_state(safe_rss());
+        let prev = cmd(3.0);
+        assert!(matches!(
+            gov.evaluate(&cmd(3.0), Some(&prev), 0.05, SafetyPosture::Nominal),
+            EnforcementAction::Allow
+        ));
+        gov.update_rss_state(unsafe_rss());
+        let after_unsafe = gov.evaluate(&cmd(6.0), Some(&cmd(4.0)), 0.05, SafetyPosture::Nominal);
+        assert!(
+            matches!(after_unsafe, EnforcementAction::Deny { .. }),
+            "an unsafe feed after a safe one must re-gate, got {after_unsafe:?}"
+        );
+    }
+
+    /// Lockstep: an unfed primary and an unfed diverse shadow reach the SAME
+    /// physical verdict (both MRC/HOLD) — the fail-closed default cannot be a
+    /// source of false divergence.
+    #[test]
+    fn unfed_primary_and_diverse_agree_fail_closed() {
+        let primary = KirraGovernor::new();
+        let diverse = crate::DiverseKirraGovernor::new();
+        let proposed = cmd(2.0);
+        let pa = primary.evaluate(&proposed, None, 0.05, SafetyPosture::Nominal);
+        let da = diverse.evaluate(&proposed, None, 0.05, SafetyPosture::Nominal);
+        assert!(
+            matches!(pa, EnforcementAction::Deny { .. }),
+            "unfed primary holds, got {pa:?}"
+        );
+        assert!(
+            matches!(da, EnforcementAction::Deny { .. }),
+            "unfed diverse holds, got {da:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
     // Tests for H1 — angular-velocity enforcement (Approach A)
     // -------------------------------------------------------------------------
     //
@@ -1309,7 +1478,12 @@ mod tests {
     /// of the SOTIF derivation itself construct their own governors
     /// via `with_platform_params`.
     fn legacy_scalar_gov() -> KirraGovernor {
-        KirraGovernor::new().with_angular_bounds(H1_NOMINAL_RAD_S, H1_MRC_RAD_S)
+        // These tests exercise the ANGULAR/kinematic tier; the RSS tier is out
+        // of scope, so declare it externally gated (the unfed default would
+        // route every command to the MRC/HOLD profile — see `RssFeed`).
+        KirraGovernor::new()
+            .with_angular_bounds(H1_NOMINAL_RAD_S, H1_MRC_RAD_S)
+            .with_external_rss_gate()
     }
 
     fn cmd_twist(linear: f64, angular: f64) -> ControlCommand {
@@ -1490,7 +1664,7 @@ mod tests {
     fn with_angular_bounds_override_changes_verdict() {
         // Tighter platform: 0.3 rad/s nominal cap. A command at 0.5 rad/s
         // that would be Allow under the placeholder default now clamps.
-        let gov = KirraGovernor::new().with_angular_bounds(0.3, 0.1);
+        let gov = KirraGovernor::new().with_angular_bounds(0.3, 0.1).with_external_rss_gate();
         let prev = cmd_twist(2.0, 0.0);
         let proposed = cmd_twist(2.0, 0.5);
         let action = gov.evaluate(&proposed, Some(&prev), 0.05, SafetyPosture::Nominal);
@@ -1529,12 +1703,13 @@ mod tests {
     fn derived_bound_changes_verdict_between_platforms() {
         let proposed = cmd_twist(1.0, 0.5);
         let urban = KirraGovernor::new()
-            .with_platform_params(PlatformParams::urban_service_robot_reference());
+            .with_platform_params(PlatformParams::urban_service_robot_reference())
+            .with_external_rss_gate();
         let action_urban = urban.evaluate(
             &proposed, Some(&cmd_twist(1.0, 0.0)), 0.05, SafetyPosture::Nominal);
         assert!(matches!(action_urban, EnforcementAction::Allow),
             "urban-reference: 0.5 rad/s at v=1 m/s must Allow; got {action_urban:?}");
-        let cons = KirraGovernor::new();
+        let cons = KirraGovernor::new().with_external_rss_gate();
         let action_cons = cons.evaluate(
             &proposed, Some(&cmd_twist(1.0, 0.0)), 0.05, SafetyPosture::Nominal);
         match action_cons {
@@ -1551,7 +1726,8 @@ mod tests {
     #[test]
     fn derived_in_place_rotation_clamps_to_sweep_bound() {
         let gov = KirraGovernor::new()
-            .with_platform_params(PlatformParams::urban_service_robot_reference());
+            .with_platform_params(PlatformParams::urban_service_robot_reference())
+            .with_external_rss_gate();
         let proposed = cmd_twist(0.0, 1.0);
         let action = gov.evaluate(&proposed, None, 0.05, SafetyPosture::Nominal);
         match action {
@@ -1589,7 +1765,7 @@ mod tests {
     /// confirmation for the H1 enforcement-logic tests.
     #[test]
     fn with_angular_bounds_scalar_back_compat_is_v_independent() {
-        let gov = KirraGovernor::new().with_angular_bounds(0.7, 0.3);
+        let gov = KirraGovernor::new().with_angular_bounds(0.7, 0.3).with_external_rss_gate();
         for v in [0.0_f64, 1.0, 5.0] {
             let proposed = cmd_twist(v, 0.8);
             let action = gov.evaluate(
@@ -2189,7 +2365,7 @@ mod scene_rss_tests {
     /// immobilize (Deny) — regardless of the planner's Nominal verdict.
     #[test]
     fn impact_latch_overrides_pushed_safe_to_immobilize() {
-        let gov = KirraGovernor::new();
+        let gov = KirraGovernor::new().with_external_rss_gate();
         let action = gov.evaluate_with_impact_latch(
             &cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal, &latched());
         assert!(matches!(action, EnforcementAction::Deny { .. }),
@@ -2199,7 +2375,7 @@ mod scene_rss_tests {
     /// Not latched → motion passes through (normal evaluation).
     #[test]
     fn impact_not_latched_passes_through() {
-        let gov = KirraGovernor::new();
+        let gov = KirraGovernor::new().with_external_rss_gate();
         let action = gov.evaluate_with_impact_latch(
             &cmd(8.0), Some(&cmd(8.0)), 0.05, SafetyPosture::Nominal, &ImpactLatch::new());
         assert!(matches!(action, EnforcementAction::Allow),
@@ -2211,7 +2387,7 @@ mod scene_rss_tests {
     /// only an explicit clearance releases it.
     #[test]
     fn impact_no_resume_without_clearance() {
-        let gov = KirraGovernor::new();
+        let gov = KirraGovernor::new().with_external_rss_gate();
         let mut l = latched();
         // More clean ticks must NOT release the latch (sticky-toward-safe).
         l.observe(
@@ -2238,7 +2414,7 @@ mod scene_rss_tests {
     /// the SS-003 structural no-resume at the governor boundary.
     #[test]
     fn clearance_loop_vetoes_in_both_states_and_releases_only_on_grant() {
-        let gov = KirraGovernor::new();
+        let gov = KirraGovernor::new().with_external_rss_gate();
         let mut l = ClearanceLoop::new();
         let contact = ImpactEvidence { imu_accel_spike_mps2: 0.5, contact_sensor: true, vanished_object: false };
         let clean = ImpactEvidence { imu_accel_spike_mps2: 0.5, contact_sensor: false, vanished_object: false };

--- a/parko/crates/parko-kirra/tests/test_kirra_governor.rs
+++ b/parko/crates/parko-kirra/tests/test_kirra_governor.rs
@@ -4,7 +4,9 @@ use parko_core::safety::{EnforcementAction, SafetyGovernor, SafetyPosture};
 
 #[test]
 fn nominal_governor_allows_low_velocity_command() {
-    let governor = KirraGovernor::nominal();
+    // Envelope-tier test; RSS is out of scope → declare external gating
+    // (the fail-closed unfed default would HOLD at zero — see RssFeed).
+    let governor = KirraGovernor::nominal().with_external_rss_gate();
     let cmd = ControlCommand {
         linear_velocity: 0.1,
         angular_velocity: 0.0,

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -219,6 +219,7 @@ fn build_loop<B>(
     model_path: &str,
     tick_period_s: f64,
     platform_profile: Option<&CourierPlatformProfile>,
+    external_rss_gate: bool,
 ) -> Arc<Mutex<InferenceLoop<B>>>
 where
     B: InferenceBackend + 'static,
@@ -269,15 +270,26 @@ where
     // rotation between the two bounds and escalate the posture). With no
     // profile, both keep KirraGovernor/DiverseKirraGovernor `::new()` — the
     // conservative default, byte-identical to pre-Phase-2.
+    // WS-0.1 (#G2): the governors start RssFeed::NeverFed (fail-closed — an
+    // unfed governor HOLDs at zero). `external_rss_gate` is set by main()
+    // ONLY when the publication-seam object-RSS gate is armed, or the
+    // operator explicitly accepted motion without object perception; it is
+    // applied to BOTH comparator arms (a one-sided declaration would be a
+    // permanent false divergence).
+    let gate_arm = |g: KirraGovernor| if external_rss_gate { g.with_external_rss_gate() } else { g };
+    let gate_arm_diverse =
+        |g: DiverseKirraGovernor| if external_rss_gate { g.with_external_rss_gate() } else { g };
     let comparator = match platform_profile {
         Some(profile) => GovernorComparator::with_sink(
-            profile.angular_governor(),
-            DiverseKirraGovernor::new().with_platform_params(profile.angular_params.clone()),
+            gate_arm(profile.angular_governor()),
+            gate_arm_diverse(
+                DiverseKirraGovernor::new().with_platform_params(profile.angular_params.clone()),
+            ),
             build_divergence_sink(),
         ),
         None => GovernorComparator::with_sink(
-            KirraGovernor::new(),
-            DiverseKirraGovernor::new(),
+            gate_arm(KirraGovernor::new()),
+            gate_arm_diverse(DiverseKirraGovernor::new()),
             build_divergence_sink(),
         ),
     };
@@ -369,7 +381,24 @@ fn build_config() -> ParkoNodeConfig {
             ),
         }
     }
+    // WS-0.1 (#G2) opt-in flags. `1`/`true` (case-insensitive) enable; anything
+    // else keeps the fail-closed default.
+    config.allow_motion_without_object_perception =
+        env_flag("PARKO_ALLOW_MOTION_WITHOUT_OBJECT_PERCEPTION");
+    config.occlusion_gate_enabled = env_flag("PARKO_OCCLUSION_GATE_ENABLED");
+    config.water_gate_enabled = env_flag("PARKO_WATER_GATE_ENABLED");
+    config.commit_zone_gate_enabled = env_flag("PARKO_COMMIT_ZONE_GATE_ENABLED");
     config
+}
+
+/// `1` / `true` (case-insensitive, trimmed) → `true`; everything else → `false`.
+fn env_flag(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true"
+        })
+        .unwrap_or(false)
 }
 
 #[tokio::main]
@@ -400,11 +429,39 @@ async fn main() {
             );
             std::process::exit(2);
         });
+    // WS-0.1 (#G2): decide the governors' RSS mode. Fail-closed default: with
+    // no armed object gate and no explicit waiver, the governors stay UNFED
+    // and the node HOLDs at zero.
+    let object_gate_armed = config.object_rss_enabled
+        && config.lidar_topic.is_some()
+        && config.platform_profile.is_some();
+    let external_rss_gate = object_gate_armed || config.allow_motion_without_object_perception;
+    if object_gate_armed {
+        tracing::info!(
+            "parko-ros2: scene-RSS enforced at the publication seam (object gate ARMED); \
+             in-loop governors declare external gating"
+        );
+    } else if config.allow_motion_without_object_perception {
+        tracing::warn!(
+            "parko-ros2: MOTION WITHOUT OBJECT PERCEPTION explicitly enabled \
+             (PARKO_ALLOW_MOTION_WITHOUT_OBJECT_PERCEPTION) — the governors' scene-RSS tier is \
+             WAIVED by operator acknowledgment; kinematic/angular/posture tiers still enforce"
+        );
+    } else {
+        tracing::error!(
+            "parko-ros2: NO scene-RSS source — the object gate is not armed (needs \
+             `lidar_topic` + `platform_profile` + `object_rss_enabled` in ParkoNodeConfig) and \
+             no explicit waiver. FAIL-CLOSED: the governors are UNFED and every tick will \
+             publish a STOP. Arm the object gate or set \
+             PARKO_ALLOW_MOTION_WITHOUT_OBJECT_PERCEPTION=1 to accept driving blind."
+        );
+    }
     let infer = build_loop(
         backend,
         &model_path,
         config.tick_period_s,
         config.platform_profile.as_ref(),
+        external_rss_gate,
     );
 
     // M2 posture: static, defaults to Nominal. M1b's `PostureTracker`

--- a/parko/crates/parko-ros2/src/clearance_gate.rs
+++ b/parko/crates/parko-ros2/src/clearance_gate.rs
@@ -731,7 +731,12 @@ mod tests {
         let backend = Arc::new(MockBackend::new(outputs, BackendDescriptor::Cpu));
         let model = backend.load_model("test.onnx").expect("mock model loads");
         let (tx, _rx) = mpsc::channel::<ControlCommand>(8);
-        let comparator = GovernorComparator::new(KirraGovernor::new(), KirraGovernor::new());
+        // See tick_pipeline tests: enforcement lives at the publication seam;
+        // the in-loop governors declare external gating (unfed = HOLD).
+        let comparator = GovernorComparator::new(
+            KirraGovernor::new().with_external_rss_gate(),
+            KirraGovernor::new().with_external_rss_gate(),
+        );
         let infer = InferenceLoop::new(backend, model, tx)
             .with_governor(ComparatorAsGovernor(comparator))
             .with_tick_period(0.05);

--- a/parko/crates/parko-ros2/src/config.rs
+++ b/parko/crates/parko-ros2/src/config.rs
@@ -142,20 +142,23 @@ pub struct ParkoNodeConfig {
     /// WS-0.1 — arm the RSS rule-iv occlusion gate
     /// (`scene_vetoes::apply_occlusion_gate`) at the publication seam. Armed
     /// only when a `platform_profile` is also configured (the RSS params).
-    /// While armed, a missing/stale sightline scene fails CLOSED
+    /// While armed, a missing/stale sightline scene (staleness budget:
+    /// `corridor_max_age_ms`) fails CLOSED
     /// (`OcclusionScene::Absent` → cap 0.0 → stop): arm this only when a
     /// sightline producer feeds the node's occlusion slot. **Default `false`.**
     pub occlusion_gate_enabled: bool,
 
     /// WS-0.1 — arm the SG4 water-veto gate (`scene_vetoes::apply_water_gate`).
-    /// While armed, a missing/stale water scene fails CLOSED
+    /// While armed, a missing/stale water scene (staleness budget:
+    /// `corridor_max_age_ms`) fails CLOSED
     /// (`WaterScene::Unknown` → veto): arm only with a water-detector producer.
     /// **Default `false`.**
     pub water_gate_enabled: bool,
 
     /// WS-0.1 — arm the SG5 commit-zone gate
     /// (`scene_vetoes::apply_commit_zone_gate`). While armed, a missing/stale
-    /// zone scene fails CLOSED (`CommitZoneScene::Unknown` → veto): arm only
+    /// zone scene (staleness budget: `corridor_max_age_ms`) fails CLOSED
+    /// (`CommitZoneScene::Unknown` → veto): arm only
     /// with a map-anchored zone producer. **Default `false`.**
     pub commit_zone_gate_enabled: bool,
 }

--- a/parko/crates/parko-ros2/src/config.rs
+++ b/parko/crates/parko-ros2/src/config.rs
@@ -128,6 +128,36 @@ pub struct ParkoNodeConfig {
     /// silently enabled by `object_rss_enabled`. Missing/stale object perception →
     /// `AgentScene::Absent` (a gap — never a fabricated latch). **Default `false`.**
     pub vanished_detection_enabled: bool,
+
+    /// WS-0.1 (#G2) — EXPLICIT operator acknowledgment that this deployment
+    /// may MOVE without a scene-RSS producer. **Default `false` — fail-closed:**
+    /// when the object-RSS gate is NOT armed (no lidar/profile or
+    /// `object_rss_enabled = false`) and this is `false`, the node builds
+    /// UNFED governors ([`parko_kirra::RssFeed::NeverFed`]) and the tick HOLDs
+    /// at zero. Setting `true` builds externally-gated governors and is logged
+    /// loudly at startup: the operator — not a silent construction default —
+    /// owns the decision to drive blind.
+    pub allow_motion_without_object_perception: bool,
+
+    /// WS-0.1 — arm the RSS rule-iv occlusion gate
+    /// (`scene_vetoes::apply_occlusion_gate`) at the publication seam. Armed
+    /// only when a `platform_profile` is also configured (the RSS params).
+    /// While armed, a missing/stale sightline scene fails CLOSED
+    /// (`OcclusionScene::Absent` → cap 0.0 → stop): arm this only when a
+    /// sightline producer feeds the node's occlusion slot. **Default `false`.**
+    pub occlusion_gate_enabled: bool,
+
+    /// WS-0.1 — arm the SG4 water-veto gate (`scene_vetoes::apply_water_gate`).
+    /// While armed, a missing/stale water scene fails CLOSED
+    /// (`WaterScene::Unknown` → veto): arm only with a water-detector producer.
+    /// **Default `false`.**
+    pub water_gate_enabled: bool,
+
+    /// WS-0.1 — arm the SG5 commit-zone gate
+    /// (`scene_vetoes::apply_commit_zone_gate`). While armed, a missing/stale
+    /// zone scene fails CLOSED (`CommitZoneScene::Unknown` → veto): arm only
+    /// with a map-anchored zone producer. **Default `false`.**
+    pub commit_zone_gate_enabled: bool,
 }
 
 /// Placeholder for an MRC fallback override. Today's MRC is always
@@ -168,6 +198,14 @@ impl Default for ParkoNodeConfig {
             // #309: SG6 vanished-object detection off by default — a latching
             // auto-immobilizer is opt-in, never silently enabled.
             vanished_detection_enabled: false,
+            // WS-0.1 (#G2): fail-closed — motion without a scene-RSS producer
+            // requires the operator's explicit acknowledgment.
+            allow_motion_without_object_perception: false,
+            // WS-0.1 scene-veto gates: armed-when-configured, off by default
+            // (an armed gate with no producer fails closed to a stop).
+            occlusion_gate_enabled: false,
+            water_gate_enabled: false,
+            commit_zone_gate_enabled: false,
         }
     }
 }

--- a/parko/crates/parko-ros2/src/lib.rs
+++ b/parko/crates/parko-ros2/src/lib.rs
@@ -37,6 +37,7 @@ pub mod odometry_shim;
 pub mod platform_profile;
 pub mod posture_state;
 pub mod radar_shim;
+pub mod scene_vetoes;
 pub mod sensor_mapping;
 pub mod taj_corridor;
 pub mod taj_objects;
@@ -66,6 +67,9 @@ pub use crate::sensor_mapping::{
     CameraConfig, CameraEncoding, CameraLayout, CameraMapping, CameraMappingError,
     CameraNormalization, CameraResize, CameraSample, OdomConfig, OdomMapping,
     OdomMappingError, OdomOrientation, OdomSample, OwnedCameraSample, SensorInputMapping,
+};
+pub use crate::scene_vetoes::{
+    apply_commit_zone_gate, apply_occlusion_gate, apply_water_gate, StampedScene,
 };
 pub use crate::tick_pipeline::{run_pipeline_tick, TickError, TickOutcome};
 pub use crate::clearance_gate::{

--- a/parko/crates/parko-ros2/src/node.rs
+++ b/parko/crates/parko-ros2/src/node.rs
@@ -289,21 +289,25 @@ where
     if config.occlusion_gate_enabled {
         match &drain_occlusion_params {
             Some(_) => tracing::warn!(
-                "parko-ros2: WS-0.1 occlusion gate ARMED — a missing/stale sightline scene                  fails closed to a STOP; ensure a producer feeds the occlusion slot"
+                "parko-ros2: WS-0.1 occlusion gate ARMED — a missing/stale sightline scene \
+                 fails closed to a STOP; ensure a producer feeds the occlusion slot"
             ),
             None => tracing::warn!(
-                "parko-ros2: occlusion_gate_enabled but no platform_profile (no RSS params) —                  occlusion gate NOT armed"
+                "parko-ros2: occlusion_gate_enabled but no platform_profile (no RSS params) — \
+                 occlusion gate NOT armed"
             ),
         }
     }
     if config.water_gate_enabled {
         tracing::warn!(
-            "parko-ros2: WS-0.1 SG4 water gate ARMED — a missing/stale water scene fails              closed to a STOP; ensure a producer feeds the water slot"
+            "parko-ros2: WS-0.1 SG4 water gate ARMED — a missing/stale water scene fails \
+                 closed to a STOP; ensure a producer feeds the water slot"
         );
     }
     if config.commit_zone_gate_enabled {
         tracing::warn!(
-            "parko-ros2: WS-0.1 SG5 commit-zone gate ARMED — a missing/stale zone scene fails              closed to a STOP; ensure a producer feeds the commit-zone slot"
+            "parko-ros2: WS-0.1 SG5 commit-zone gate ARMED — a missing/stale zone scene fails \
+                 closed to a STOP; ensure a producer feeds the commit-zone slot"
         );
     }
 

--- a/parko/crates/parko-ros2/src/node.rs
+++ b/parko/crates/parko-ros2/src/node.rs
@@ -37,10 +37,16 @@ use crate::containment_gate::{apply_containment_gate, CONTAINMENT_HORIZON_S, CON
 use crate::imu_shim::imu_msg_to_sample;
 use crate::sensor_mapping::{ImuSample, SensorInputMapping};
 use crate::taj_corridor::{laserscan_msg_to_taj, CorridorSnapshot, EGO_REAR_COVER_M};
+use crate::scene_vetoes::{
+    apply_commit_zone_gate, apply_occlusion_gate, apply_water_gate, StampedScene,
+};
 use crate::taj_objects::{
     apply_object_rss_gate, courier_rss_params, object_snapshot_to_vanished_scene, ObjectSnapshot,
 };
 use crate::tick_pipeline::{current_time_ms, TickError};
+use parko_core::commit_zone::{CommitZoneCfg, CommitZoneScene};
+use parko_core::rss::OcclusionScene;
+use parko_core::water::{WaterScene, WaterVetoConfig};
 use parko_kirra::clearance_delivery::DeliveryOutcome;
 
 /// Run the Parko ROS 2 node. Owns the r2r context for the lifetime of
@@ -262,6 +268,45 @@ where
         ),
     }
 
+    // WS-0.1 scene-veto channels (occlusion / water / commit-zone). Each slot
+    // is where a future producer subscription publishes its latest stamped
+    // scene (the `latest_objects` pattern). The gates are ARMED by config;
+    // while armed, an empty/stale slot fails CLOSED inside the gate (stop) —
+    // the enabled-but-silent rule. Not armed → the gate is never called.
+    let latest_occlusion: Arc<StdMutex<Option<StampedScene<OcclusionScene>>>> =
+        Arc::new(StdMutex::new(None));
+    let latest_water: Arc<StdMutex<Option<StampedScene<WaterScene>>>> =
+        Arc::new(StdMutex::new(None));
+    let latest_commit_zone: Arc<StdMutex<Option<StampedScene<CommitZoneScene>>>> =
+        Arc::new(StdMutex::new(None));
+    // Occlusion needs the RSS params → armed only with a platform_profile
+    // (same precedent as the object gate). Enabled without a profile → warn.
+    let drain_occlusion_params = config
+        .platform_profile
+        .as_ref()
+        .filter(|_| config.occlusion_gate_enabled)
+        .map(courier_rss_params);
+    if config.occlusion_gate_enabled {
+        match &drain_occlusion_params {
+            Some(_) => tracing::warn!(
+                "parko-ros2: WS-0.1 occlusion gate ARMED — a missing/stale sightline scene                  fails closed to a STOP; ensure a producer feeds the occlusion slot"
+            ),
+            None => tracing::warn!(
+                "parko-ros2: occlusion_gate_enabled but no platform_profile (no RSS params) —                  occlusion gate NOT armed"
+            ),
+        }
+    }
+    if config.water_gate_enabled {
+        tracing::warn!(
+            "parko-ros2: WS-0.1 SG4 water gate ARMED — a missing/stale water scene fails              closed to a STOP; ensure a producer feeds the water slot"
+        );
+    }
+    if config.commit_zone_gate_enabled {
+        tracing::warn!(
+            "parko-ros2: WS-0.1 SG5 commit-zone gate ARMED — a missing/stale zone scene fails              closed to a STOP; ensure a producer feeds the commit-zone slot"
+        );
+    }
+
     // --- Drain task: consume the sensor stream, tick, publish ---------
     let drain_config  = Arc::clone(&config);
     let drain_infer   = Arc::clone(&infer);
@@ -286,6 +331,11 @@ where
     let drain_vanished_armed = config.vanished_detection_enabled
         && config.platform_profile.is_some()
         && config.lidar_topic.is_some();
+    let drain_occlusion = Arc::clone(&latest_occlusion);
+    let drain_water = Arc::clone(&latest_water);
+    let drain_commit_zone = Arc::clone(&latest_commit_zone);
+    let drain_water_armed = config.water_gate_enabled;
+    let drain_commit_zone_armed = config.commit_zone_gate_enabled;
 
     let drain_task = tokio::spawn(async move {
         use futures::StreamExt;
@@ -393,6 +443,44 @@ where
                 None => outcome,
             };
 
+            // WS-0.1 scene-veto gates (occlusion / water / commit-zone),
+            // composed after the object gate on the same publication seam.
+            // Armed-when-configured; inside an armed gate a missing/stale
+            // scene fails closed (stop). The brief std-mutex locks release
+            // before any `.await`.
+            let outcome = match &drain_occlusion_params {
+                Some(params) => apply_occlusion_gate(
+                    outcome,
+                    drain_occlusion.lock().ok().and_then(|g| g.clone()).as_ref(),
+                    params,
+                    drain_config.corridor_max_age_ms,
+                    current_time_ms(),
+                ),
+                None => outcome,
+            };
+            let outcome = if drain_water_armed {
+                apply_water_gate(
+                    outcome,
+                    drain_water.lock().ok().and_then(|g| g.clone()).as_ref(),
+                    &WaterVetoConfig::default(),
+                    drain_config.corridor_max_age_ms,
+                    current_time_ms(),
+                )
+            } else {
+                outcome
+            };
+            let outcome = if drain_commit_zone_armed {
+                apply_commit_zone_gate(
+                    outcome,
+                    drain_commit_zone.lock().ok().and_then(|g| g.clone()).as_ref(),
+                    &CommitZoneCfg::default(),
+                    drain_config.corridor_max_age_ms,
+                    current_time_ms(),
+                )
+            } else {
+                outcome
+            };
+
             // Surface the per-tick clearance delivery (a console-recorded grant
             // arriving on this node's own tick). A `NoGrant` no-op is silent.
             match &cleared.delivery {
@@ -429,6 +517,19 @@ where
                         tracing::warn!(frame_id,
                             "parko-ros2: SG1 object-RSS breach (a perceived object made the command \
                              unsafe, or object perception was absent/stale); publishing MRC"),
+                    TickError::OcclusionBreach =>
+                        tracing::warn!(frame_id,
+                            "parko-ros2: RSS rule-iv occlusion breach (command speed above the \
+                             assured-clear-distance cap, or the sightline scene was absent/stale); \
+                             publishing MRC"),
+                    TickError::WaterVeto =>
+                        tracing::warn!(frame_id,
+                            "parko-ros2: SG4 water veto (untraversable signature, or the water \
+                             scene was absent/stale); publishing MRC (stop short of water)"),
+                    TickError::CommitZoneVeto =>
+                        tracing::warn!(frame_id,
+                            "parko-ros2: SG5 commit-zone veto (entry blocked, or the zone scene / \
+                             map was absent/stale); publishing MRC (stop short of the zone)"),
                 }
             }
 

--- a/parko/crates/parko-ros2/src/platform_profile.rs
+++ b/parko/crates/parko-ros2/src/platform_profile.rs
@@ -105,8 +105,18 @@ impl CourierPlatformProfile {
     /// `evaluate` both bind the courier.
     #[must_use]
     pub fn platform(&self) -> DiffDrivePlatform<KirraGovernor> {
+        self.platform_with(self.angular_governor())
+    }
+
+    /// [`Self::platform`] with a caller-supplied governor — the seam for
+    /// choosing the governor's [`parko_kirra::RssFeed`] mode. `platform()`
+    /// keeps the fail-closed unfed default (no motion until the integrator
+    /// feeds an RSS verdict or explicitly declares external gating on the
+    /// governor it passes here).
+    #[must_use]
+    pub fn platform_with(&self, governor: KirraGovernor) -> DiffDrivePlatform<KirraGovernor> {
         DiffDrivePlatform::new(
-            self.angular_governor(),
+            governor,
             self.footprint(),
             self.max_speed_mps,
             self.max_brake_mps2,
@@ -176,7 +186,9 @@ mod tests {
     /// a sane rate through.
     #[test]
     fn courier_admits_in_place_rotation_within_the_bound() {
-        let platform = CourierPlatformProfile::courier_reference().platform();
+        // Angular-envelope test; RSS is out of scope → externally-gated governor.
+        let profile = CourierPlatformProfile::courier_reference();
+        let platform = profile.platform_with(profile.angular_governor().with_external_rss_gate());
         let cmd = ControlCommand { linear_velocity: 0.0, angular_velocity: 0.5, timestamp_ms: 0 };
         let verdict = platform.evaluate(&cmd, &nominal_state());
         assert!(verdict.is_admitted(), "in-place yaw within the bound must be admitted");
@@ -192,7 +204,8 @@ mod tests {
     /// bounds it.
     #[test]
     fn courier_clamps_excessive_in_place_rotation() {
-        let platform = CourierPlatformProfile::courier_reference().platform();
+        let profile = CourierPlatformProfile::courier_reference();
+        let platform = profile.platform_with(profile.angular_governor().with_external_rss_gate());
         let cmd = ControlCommand { linear_velocity: 0.0, angular_velocity: 1.5, timestamp_ms: 0 };
         let verdict = platform.evaluate(&cmd, &nominal_state());
         match verdict.0 {

--- a/parko/crates/parko-ros2/src/scene_vetoes.rs
+++ b/parko/crates/parko-ros2/src/scene_vetoes.rs
@@ -1,0 +1,305 @@
+// parko/crates/parko-ros2/src/scene_vetoes.rs
+//
+// WS-0.1 (#G2 closure, occlusion/water/commit-zone axis) — publication-seam
+// veto gates for the three scene checks that were built + tested in
+// parko-core/parko-kirra but reachable from NO live path: RSS rule iv
+// occlusion (`compute_occlusion_cap`), the SG4 WATER_UNTRAVERSABLE veto
+// (`water_untraversable_veto`), and the SG5 COMMIT_ZONE_BLOCKED veto
+// (`commit_zone_blocked`).
+//
+// Same seam and same discipline as `taj_objects::apply_object_rss_gate`
+// (ADR-0029 Phase 3b): each gate composes ONTO a `TickOutcome` after the tick,
+// bounding the exact twist about to be published. The node calls a gate ONLY
+// when the corresponding scene channel is CONFIGURED (armed); an armed gate
+// with a missing or stale scene fails CLOSED to the check's worst-case scene
+// variant (`OcclusionScene::Absent` / `WaterScene::Unknown` /
+// `CommitZoneScene::Unknown` — each of which the underlying primitive already
+// treats as unsafe/veto). Not-configured → the gate is never called →
+// byte-identical prior behaviour. This is the enabled-but-silent → fail-closed
+// house rule: "the detector did not look" is never "clear".
+//
+// An already-stopped twist passes through every gate unchanged (a stop is the
+// MRC itself — there is nothing stronger to impose) and preserves any upstream
+// `TickError`.
+
+use parko_core::commit_zone::{commit_zone_blocked, CommitZoneCfg, CommitZoneScene};
+use parko_core::rss::{OcclusionScene, RssParams};
+use parko_core::water::{water_untraversable_veto, WaterScene, WaterVetoConfig};
+use parko_kirra::compute_occlusion_cap;
+
+use crate::command_mapping::OutgoingTwist;
+use crate::tick_pipeline::{TickError, TickOutcome};
+
+/// A scene sample stamped with its production time, so the gates can apply
+/// the same fail-closed freshness rule as the object-RSS gate (a stale scene
+/// is a perception gap, never a verdict).
+#[derive(Debug, Clone, PartialEq)]
+pub struct StampedScene<T> {
+    /// The scene the producer emitted.
+    pub scene: T,
+    /// Producer timestamp, ms (same clock as `now_ms` at the call site).
+    pub stamp_ms: u64,
+}
+
+impl<T> StampedScene<T> {
+    /// Age relative to `now_ms`; saturating (a future-stamped scene reads 0).
+    #[must_use]
+    pub fn age_ms(&self, now_ms: u64) -> u64 {
+        now_ms.saturating_sub(self.stamp_ms)
+    }
+}
+
+/// Resolve an armed channel's slot to the scene the check runs on:
+/// fresh → the producer's scene; missing or stale → the supplied fail-closed
+/// worst-case variant.
+fn resolve_scene<T: Clone>(
+    slot: Option<&StampedScene<T>>,
+    max_age_ms: u64,
+    now_ms: u64,
+    fail_closed: T,
+) -> T {
+    match slot {
+        Some(stamped) if stamped.age_ms(now_ms) <= max_age_ms => stamped.scene.clone(),
+        _ => fail_closed,
+    }
+}
+
+/// True when this outcome needs no further gating: the twist is already a
+/// full stop (the MRC), so every veto is already satisfied — and gating it
+/// again would only overwrite the upstream `TickError` provenance.
+fn already_stopped(outcome: &TickOutcome) -> bool {
+    outcome.twist.linear_x_mps == 0.0 && outcome.twist.angular_z_rads == 0.0
+}
+
+/// RSS rule iv — occlusion / assured-clear-distance gate. The ego speed about
+/// to be published must not exceed the occlusion speed cap for the sightline
+/// scene: `Absent` (or missing/stale when armed) caps at 0.0 (any motion
+/// stops), `KnownClear` never binds, `Limited` binds via
+/// `occlusion_limited_speed` (fail-closed to 0.0 on invalid inputs).
+// SAFETY: SG1 | REQ: parko-ros2-occlusion-gate | TEST: occlusion_known_clear_passes,occlusion_limited_caps_overspeed,occlusion_limited_admits_slow_ego,occlusion_missing_scene_fails_closed,occlusion_stale_scene_fails_closed,already_stopped_outcome_passes_all_gates
+pub fn apply_occlusion_gate(
+    outcome: TickOutcome,
+    occlusion: Option<&StampedScene<OcclusionScene>>,
+    params: &RssParams,
+    max_age_ms: u64,
+    now_ms: u64,
+) -> TickOutcome {
+    if already_stopped(&outcome) {
+        return outcome;
+    }
+    let scene = resolve_scene(occlusion, max_age_ms, now_ms, OcclusionScene::Absent);
+    let cap = compute_occlusion_cap(&scene, params);
+    // `<=` is NaN-safe: a non-finite speed fails the comparison → stop. (The
+    // twist is already finiteness-enforced upstream; this is defence-in-depth.)
+    if outcome.twist.linear_x_mps.abs() <= cap {
+        outcome
+    } else {
+        TickOutcome {
+            twist: OutgoingTwist::stopped(outcome.twist.stamp_ms),
+            error: Some(TickError::OcclusionBreach),
+            degraded: outcome.degraded,
+        }
+    }
+}
+
+/// SG4 — WATER_UNTRAVERSABLE veto gate. A missing/stale scene when armed is
+/// `WaterScene::Unknown` → veto (the detector did not look). A bounded-safe
+/// puddle is NOT vetoed (no over-stop in rain); the unbounded signature stops.
+// SAFETY: SG4 | REQ: parko-ros2-water-gate | TEST: water_clear_passes,water_unbounded_signature_stops,water_missing_scene_fails_closed,already_stopped_outcome_passes_all_gates
+pub fn apply_water_gate(
+    outcome: TickOutcome,
+    water: Option<&StampedScene<WaterScene>>,
+    cfg: &WaterVetoConfig,
+    max_age_ms: u64,
+    now_ms: u64,
+) -> TickOutcome {
+    if already_stopped(&outcome) {
+        return outcome;
+    }
+    let scene = resolve_scene(water, max_age_ms, now_ms, WaterScene::Unknown);
+    if water_untraversable_veto(&scene, cfg) {
+        TickOutcome {
+            twist: OutgoingTwist::stopped(outcome.twist.stamp_ms),
+            error: Some(TickError::WaterVeto),
+            degraded: outcome.degraded,
+        }
+    } else {
+        outcome
+    }
+}
+
+/// SG5 — COMMIT_ZONE_BLOCKED veto gate. A missing/stale scene when armed is
+/// `CommitZoneScene::Unknown` → veto ("reject fires from MAP ALONE"). A
+/// healthy `NoZone` or a confirmed, exit-verified zone passes.
+// SAFETY: SG5 | REQ: parko-ros2-commit-zone-gate | TEST: commit_zone_no_zone_passes,commit_zone_unknown_map_stops,commit_zone_missing_scene_fails_closed,already_stopped_outcome_passes_all_gates
+pub fn apply_commit_zone_gate(
+    outcome: TickOutcome,
+    commit_zone: Option<&StampedScene<CommitZoneScene>>,
+    cfg: &CommitZoneCfg,
+    max_age_ms: u64,
+    now_ms: u64,
+) -> TickOutcome {
+    if already_stopped(&outcome) {
+        return outcome;
+    }
+    let scene = resolve_scene(commit_zone, max_age_ms, now_ms, CommitZoneScene::Unknown);
+    if commit_zone_blocked(&scene, cfg) {
+        TickOutcome {
+            twist: OutgoingTwist::stopped(outcome.twist.stamp_ms),
+            error: Some(TickError::CommitZoneVeto),
+            degraded: outcome.degraded,
+        }
+    } else {
+        outcome
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn outcome(linear: f64) -> TickOutcome {
+        TickOutcome {
+            twist: OutgoingTwist { linear_x_mps: linear, angular_z_rads: 0.0, stamp_ms: 7 },
+            error: None,
+            degraded: false,
+        }
+    }
+
+    fn params() -> RssParams {
+        // Courier-class numbers (mirrors taj_objects::courier_rss_params
+        // magnitudes; exact values are irrelevant to the gate logic).
+        RssParams {
+            reaction_time: 0.5,
+            accel_max: 1.0,
+            brake_min: 1.0,
+            brake_max: 4.0,
+            lat_accel_max: 0.5,
+        }
+    }
+
+    fn stamped<T>(scene: T, stamp_ms: u64) -> StampedScene<T> {
+        StampedScene { scene, stamp_ms }
+    }
+
+    // ---- occlusion ---------------------------------------------------------
+
+    #[test]
+    fn occlusion_known_clear_passes() {
+        let s = stamped(OcclusionScene::KnownClear, 100);
+        let out = apply_occlusion_gate(outcome(1.0), Some(&s), &params(), 500, 100);
+        assert!(out.error.is_none());
+        assert!((out.twist.linear_x_mps - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn occlusion_limited_caps_overspeed() {
+        // A short sightline yields a small cap; a 5 m/s ego must stop.
+        let s = stamped(
+            OcclusionScene::Limited { d_sight_m: 2.0, v_emerge_max_mps: 1.5 },
+            100,
+        );
+        let out = apply_occlusion_gate(outcome(5.0), Some(&s), &params(), 500, 100);
+        assert_eq!(out.twist.linear_x_mps, 0.0, "overspeed past the occlusion cap must stop");
+        assert_eq!(out.error, Some(TickError::OcclusionBreach));
+    }
+
+    #[test]
+    fn occlusion_limited_admits_slow_ego() {
+        // A generous sightline admits a slow ego (the creep-into-blind-junction
+        // behaviour: the cap binds speed, it does not forbid motion).
+        let s = stamped(
+            OcclusionScene::Limited { d_sight_m: 50.0, v_emerge_max_mps: 1.0 },
+            100,
+        );
+        let out = apply_occlusion_gate(outcome(0.3), Some(&s), &params(), 500, 100);
+        assert!(out.error.is_none(), "slow ego under a long sightline passes; got {:?}", out.error);
+    }
+
+    #[test]
+    fn occlusion_missing_scene_fails_closed() {
+        // Armed gate, no scene → Absent → cap 0.0 → any motion stops.
+        let out = apply_occlusion_gate(outcome(0.2), None, &params(), 500, 100);
+        assert_eq!(out.twist.linear_x_mps, 0.0);
+        assert_eq!(out.error, Some(TickError::OcclusionBreach));
+    }
+
+    #[test]
+    fn occlusion_stale_scene_fails_closed() {
+        // A KnownClear scene older than the budget is a gap, not a verdict.
+        let s = stamped(OcclusionScene::KnownClear, 100);
+        let out = apply_occlusion_gate(outcome(0.2), Some(&s), &params(), 500, 2_000);
+        assert_eq!(out.twist.linear_x_mps, 0.0, "stale sightline must fail closed");
+        assert_eq!(out.error, Some(TickError::OcclusionBreach));
+    }
+
+    // ---- water --------------------------------------------------------------
+
+    #[test]
+    fn water_clear_passes() {
+        let s = stamped(WaterScene::Clear, 100);
+        let out = apply_water_gate(outcome(1.0), Some(&s), &WaterVetoConfig::default(), 500, 100);
+        assert!(out.error.is_none());
+        assert!((out.twist.linear_x_mps - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn water_unknown_scene_stops() {
+        let s = stamped(WaterScene::Unknown, 100);
+        let out = apply_water_gate(outcome(1.0), Some(&s), &WaterVetoConfig::default(), 500, 100);
+        assert_eq!(out.twist.linear_x_mps, 0.0, "Unknown water must veto (stop short of water)");
+        assert_eq!(out.error, Some(TickError::WaterVeto));
+    }
+
+    #[test]
+    fn water_missing_scene_fails_closed() {
+        let out = apply_water_gate(outcome(1.0), None, &WaterVetoConfig::default(), 500, 100);
+        assert_eq!(out.twist.linear_x_mps, 0.0, "armed-but-silent water channel must veto");
+        assert_eq!(out.error, Some(TickError::WaterVeto));
+    }
+
+    // ---- commit zone ---------------------------------------------------------
+
+    #[test]
+    fn commit_zone_no_zone_passes() {
+        let s = stamped(CommitZoneScene::NoZone, 100);
+        let out =
+            apply_commit_zone_gate(outcome(1.0), Some(&s), &CommitZoneCfg::default(), 500, 100);
+        assert!(out.error.is_none());
+        assert!((out.twist.linear_x_mps - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn commit_zone_unknown_map_stops() {
+        let s = stamped(CommitZoneScene::Unknown, 100);
+        let out =
+            apply_commit_zone_gate(outcome(1.0), Some(&s), &CommitZoneCfg::default(), 500, 100);
+        assert_eq!(out.twist.linear_x_mps, 0.0, "an Unknown map must veto (reject from map alone)");
+        assert_eq!(out.error, Some(TickError::CommitZoneVeto));
+    }
+
+    #[test]
+    fn commit_zone_missing_scene_fails_closed() {
+        let out = apply_commit_zone_gate(outcome(1.0), None, &CommitZoneCfg::default(), 500, 100);
+        assert_eq!(out.twist.linear_x_mps, 0.0);
+        assert_eq!(out.error, Some(TickError::CommitZoneVeto));
+    }
+
+    // ---- composition ---------------------------------------------------------
+
+    #[test]
+    fn already_stopped_outcome_passes_all_gates() {
+        // A stop is the MRC — gating it again must not run the checks or
+        // overwrite the upstream error provenance.
+        let stopped = TickOutcome {
+            twist: OutgoingTwist::stopped(7),
+            error: Some(TickError::ObjectRssBreach),
+            degraded: false,
+        };
+        let out = apply_occlusion_gate(stopped.clone(), None, &params(), 500, 100);
+        let out = apply_water_gate(out, None, &WaterVetoConfig::default(), 500, 100);
+        let out = apply_commit_zone_gate(out, None, &CommitZoneCfg::default(), 500, 100);
+        assert_eq!(out.error, Some(TickError::ObjectRssBreach), "upstream provenance preserved");
+        assert_eq!(out.twist, OutgoingTwist::stopped(7));
+    }
+}

--- a/parko/crates/parko-ros2/src/tick_pipeline.rs
+++ b/parko/crates/parko-ros2/src/tick_pipeline.rs
@@ -62,6 +62,21 @@ pub enum TickError {
     /// absent/stale. The tick MRCs (stopped twist). Set by
     /// `taj_objects::apply_object_rss_gate`.
     ObjectRssBreach,
+    /// WS-0.1 (RSS rule iv) — the command's speed exceeded the occlusion /
+    /// assured-clear-distance cap for the sightline scene, or the armed
+    /// occlusion channel was missing/stale (fail-closed `Absent` → cap 0.0).
+    /// Set by `scene_vetoes::apply_occlusion_gate`.
+    OcclusionBreach,
+    /// WS-0.1 (SG4) — the water scene carried the untraversable / fail-closed
+    /// signature (or the armed channel was missing/stale → `Unknown` → veto).
+    /// The tick MRCs (stop short of water). Set by
+    /// `scene_vetoes::apply_water_gate`.
+    WaterVeto,
+    /// WS-0.1 (SG5) — commit-zone entry is blocked (or the armed channel /
+    /// map was missing/stale → `Unknown` → veto; reject fires from map
+    /// alone). The tick MRCs (stop short of the zone). Set by
+    /// `scene_vetoes::apply_commit_zone_gate`.
+    CommitZoneVeto,
 }
 
 /// What a single `run_pipeline_tick` produced. Always carries a safe
@@ -235,7 +250,14 @@ mod tick_pipeline_tests {
         let model = backend.load_model("test.onnx").expect("mock model loads");
 
         let (tx, rx) = mpsc::channel::<ControlCommand>(8);
-        let comparator = GovernorComparator::new(KirraGovernor::new(), KirraGovernor::new());
+        // Pipeline-mechanics tests: scene-RSS enforcement lives at the node's
+        // publication seam (`apply_object_rss_gate`, ADR-0029 Phase 3b), so the
+        // in-loop governors declare external gating. The unfed fail-closed
+        // default is pinned separately by `unfed_governor_tick_holds_at_zero`.
+        let comparator = GovernorComparator::new(
+            KirraGovernor::new().with_external_rss_gate(),
+            KirraGovernor::new().with_external_rss_gate(),
+        );
 
         let infer = InferenceLoop::new(backend, model, tx)
             .with_governor(ComparatorAsGovernor(comparator))
@@ -502,7 +524,10 @@ mod tick_pipeline_tests {
     ) -> Arc<Mutex<InferenceLoop<B>>> {
         let model = backend.load_model("test.onnx").expect("mock model loads");
         let (tx, _rx) = mpsc::channel::<ControlCommand>(8);
-        let comparator = GovernorComparator::new(KirraGovernor::new(), KirraGovernor::new());
+        let comparator = GovernorComparator::new(
+            KirraGovernor::new().with_external_rss_gate(),
+            KirraGovernor::new().with_external_rss_gate(),
+        );
         let infer = InferenceLoop::new(backend, model, tx)
             .with_governor(ComparatorAsGovernor(comparator))
             .with_tick_period(0.05);
@@ -657,5 +682,87 @@ mod tick_pipeline_tests {
         assert!((outcome.twist.linear_x_mps - 0.1).abs() < 1e-4,
             "Nominal observation must release the Degraded seed; got {}",
             outcome.twist.linear_x_mps);
+    }
+
+    // =======================================================================
+    // WS-0.1 / #G2 — the fail-closed RSS default and the live scene→RSS→gate
+    // edge, proven at the TICK level (the same composition the node runs).
+    // =======================================================================
+
+    /// THE DoD TEST (default axis) — "default posture without RSS input is
+    /// not-safe", proven THROUGH `run_pipeline_tick`: a loop whose governors
+    /// were never fed an RSS verdict and never declared external gating
+    /// publishes a STOPPED twist for a command the envelope would admit.
+    /// (Before #G2, the `safe: true` construction default let this through.)
+    #[tokio::test(start_paused = true)]
+    async fn unfed_governor_tick_holds_at_zero() {
+        let mut outputs: HashMap<String, Vec<f32>> = HashMap::new();
+        outputs.insert("cmd_vel_linear".to_string(),  vec![0.1]);
+        outputs.insert("cmd_vel_angular".to_string(), vec![0.0]);
+        let backend = Arc::new(MockBackend::new(outputs, BackendDescriptor::Cpu));
+        let model = backend.load_model("test.onnx").expect("mock model loads");
+        let (tx, _rx) = mpsc::channel::<ControlCommand>(8);
+        // UNFED governors — no update_rss_state, no with_external_rss_gate.
+        let comparator = GovernorComparator::new(KirraGovernor::new(), KirraGovernor::new());
+        let infer = Arc::new(Mutex::new(
+            InferenceLoop::new(backend, model, tx)
+                .with_governor(ComparatorAsGovernor(comparator))
+                .with_tick_period(0.05),
+        ));
+        let outcome =
+            run_pipeline_tick(&default_config(), infer, make_frame(201, 0), SafetyPosture::Nominal)
+                .await;
+        assert_eq!(outcome.twist.linear_x_mps, 0.0,
+            "an unfed governor must HOLD at zero through the live tick (fail-closed default)");
+        assert_eq!(outcome.twist.angular_z_rads, 0.0);
+    }
+
+    /// THE DoD TEST (scene axis) — "injected unsafe scene MRCs the live
+    /// tick": the node's exact live composition (`run_pipeline_tick` →
+    /// `apply_object_rss_gate`) with an object dead ahead stops the tick and
+    /// tags `ObjectRssBreach`; the same composition with a verified-clear
+    /// scene publishes the governed command.
+    #[tokio::test(start_paused = true)]
+    async fn injected_unsafe_scene_mrcs_the_live_tick() {
+        use crate::taj_objects::{apply_object_rss_gate, courier_rss_params, ObjectSnapshot};
+        use kirra_core::corridor::Point;
+        use kirra_core::trajectory::PerceivedObject;
+
+        let params = courier_rss_params(&crate::CourierPlatformProfile::courier_reference());
+        let now = current_time_ms();
+
+        // Unsafe scene: an ONCOMING object 0.5 m dead ahead closing at 2 m/s —
+        // far inside the head-on RSS bound for any moving ego (the first-tick
+        // accel clamp bounds the ego to ~0.125 m/s; a stationary far object
+        // would be longitudinally SAFE at that speed, which is correct RSS,
+        // not a gate miss).
+        let blocker = PerceivedObject {
+            id: 1,
+            pos: Point { x_m: 0.5, y_m: 0.0 },
+            velocity_mps: 2.0,
+            heading_rad: 0.0,
+            vel: Point { x_m: -2.0, y_m: 0.0 },
+        };
+        let unsafe_snapshot = ObjectSnapshot::from_objects(&[blocker], now);
+
+        let (infer, _rx) = build_loop(1.0, 0.0);
+        let tick =
+            run_pipeline_tick(&default_config(), infer, make_frame(202, 0), SafetyPosture::Nominal)
+                .await;
+        assert!(tick.twist.linear_x_mps > 0.0, "precondition: the tick admits motion");
+        let gated = apply_object_rss_gate(tick, Some(&unsafe_snapshot), &params, 500, now);
+        assert_eq!(gated.twist.linear_x_mps, 0.0,
+            "an injected unsafe scene must MRC the live tick");
+        assert_eq!(gated.error, Some(TickError::ObjectRssBreach));
+
+        // Control: a fresh verified-clear scene admits the governed command.
+        let clear_snapshot = ObjectSnapshot::from_objects(&[], now);
+        let (infer2, _rx2) = build_loop(0.1, 0.0);
+        let tick2 =
+            run_pipeline_tick(&default_config(), infer2, make_frame(203, 0), SafetyPosture::Nominal)
+                .await;
+        let gated2 = apply_object_rss_gate(tick2, Some(&clear_snapshot), &params, 500, now);
+        assert!(gated2.error.is_none(), "a verified-clear scene passes; got {:?}", gated2.error);
+        assert!(gated2.twist.linear_x_mps > 0.0);
     }
 }


### PR DESCRIPTION
**PR 1 of the product execution plan (WS-0.1) — closes gap-analysis G2**, the highest-ROI item in `docs/analysis/INDUSTRY_BENCHMARK_GAP_ANALYSIS.md`: the best RSS math in the repo was dead on the running path, behind a silently fail-open `safe: true` construction default.

## The defect

`KirraGovernor` / `DiverseKirraGovernor` seeded their pushed-state RSS verdict with `safe: true`, and the production tick never called `update_rss_state` — so the in-loop RSS tier was a no-op that *asserted* safety by default. Meanwhile the occlusion (RSS rule iv), water (SG4), and commit-zone (SG5) checks — built and tested in parko-core/parko-kirra — were invoked by **no live path**.

## The fix

### 1. Fail-closed default — `RssFeed` (parko-kirra, both comparator arms in lockstep)
- `NeverFed` (construction default): gates **UNSAFE** → the MRC decel-to-stop-and-HOLD profile. An unfed governor is immobile, not permissive. "No RSS input" is never "safe".
- `Fed(RssState)` via `update_rss_state` (unchanged API).
- `ExternallyGated` via the new `with_external_rss_gate()` — the explicit, greppable declaration that scene-RSS enforcement lives at the publication seam (ADR-0029 Phase 3b `apply_object_rss_gate` bounds the exact twist about to publish) or was explicitly waived. Every other tier (non-finite reject, LockedOut, Degraded MRC, kinematic envelope, angular bound) still enforces.
- Mirrored identically in the diverse shadow — the fail-closed default cannot be a source of false divergence (test-pinned).

### 2. Scene-veto gates — new `scene_vetoes` module (parko-ros2)
`apply_occlusion_gate` / `apply_water_gate` / `apply_commit_zone_gate` compose onto the `TickOutcome` after the object gate, same seam and discipline as ADR-0029 Phase 3b: **armed-when-configured; while armed, a missing/stale scene fails CLOSED** to the check's worst-case variant (`Absent` → cap 0.0 / `Unknown` → veto). New `TickError::{OcclusionBreach, WaterVeto, CommitZoneVeto}` with node log arms. Node carries stamped scene slots (producer subscriptions land behind them) and config flags (default off) with armed-gate startup warnings.

### 3. Node governor-mode selection (fail-closed default + explicit enable)
- Object gate armed (lidar + profile + `object_rss_enabled`) → both arms declare external gating; behaviour unchanged.
- Not armed + `PARKO_ALLOW_MOTION_WITHOUT_OBJECT_PERCEPTION=1` → external gating with a loud operator-waiver warning.
- Not armed + no waiver → **UNFED governors: every tick publishes a STOP.** This is the intended breaking change for perception-less deployments; the startup error names the two ways out.

## DoD (from the plan, both proven by test)
- *"default posture without RSS input is not-safe"* → `unfed_governor_is_immobile_from_standstill_fail_closed`, `unfed_governor_tick_holds_at_zero` (through the live `run_pipeline_tick`), `unfed_primary_and_diverse_agree_fail_closed`.
- *"injected unsafe scene MRCs the live tick in a test"* → `injected_unsafe_scene_mrcs_the_live_tick` (the node's exact live gate composition; an oncoming object stops the tick with `ObjectRssBreach`, a verified-clear scene admits the governed command).
- Plus 12 scene-veto gate tests (fresh-clear passes / hazard stops / missing/stale fails closed / already-stopped preserves upstream error provenance).

## Test fallout (intentional and intent-visible)
Tests that exercised the envelope/angular/SG6 tiers without feeding RSS relied on the fail-open default; each now declares `with_external_rss_gate()` at its call site. `platform_with()` added to `CourierPlatformProfile` as the governor-mode seam. `INTEGRATION.md` §3.3 documents the new contract.

Note for review: `node.rs` / `parko_ros2_node.rs` changes are `ros2`-feature-gated — validated by CI's ros2 adapter/backends jobs, not the default build. All stable-lane suites pass locally (parko-kirra 169+3+3, parko-ros2 221; parko-core 232 untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_