### PR TITLE
posture: wire generation persistence at boot — restarts no longer time-reverse generations

### DIFF
--- a/ci/quality_guardrails_baseline.json
+++ b/ci/quality_guardrails_baseline.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Quality-guardrail ratchet baseline. Metrics may only DECREASE without review; an INCREASE fails CI (see ci/check_quality_guardrails.py). #721 (startup.rs extraction) then merged, removing ~227 lines from the bin — bin line ceiling tightened 4186→3959 to lock that gain, and the new SG-008 startup.rs is now tracked (line ceiling + panic_budget 0, keeping the fail-closed predicate panic-free) and added to ownership_scope. When a refactor legitimately raises a ceiling, bump it with a justification in the PR; when it lowers one, tighten it here.",
   "max_lines": {
-    "src/bin/kirra_verifier_service.rs": 3959,
+    "src/bin/kirra_verifier_service.rs": 3997,
     "src/bin/kirra_verifier_service/startup.rs": 248,
     "src/gateway/mod.rs": 538,
     "src/verifier.rs": 1092,

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -868,6 +868,44 @@ async fn main() {
         }
     }
 
+    // WS-0.2 / #G10: initialize the posture-generation counter from the
+    // persisted high-water BEFORE any recalculation claims a generation (the
+    // Active path's initial recalc and the standby promotion recalc both run
+    // after this point). Without this call — missing from the binary until
+    // now — every restart reset the live counter to 1: emitted generations
+    // regressed across restarts (breaking the ordering federation peers and
+    // SSE consumers rely on) and `save_last_generation`'s high-water guard
+    // rejected every persist until the counter caught back up.
+    // SAFETY: SG-HA-3 — store read runs off the tokio worker threads.
+    {
+        let app_gen = Arc::clone(&app_state);
+        match tokio::task::spawn_blocking(move || {
+            kirra_verifier::posture_engine::init_generation_from_store(&app_gen)
+        })
+        .await
+        {
+            Ok(Ok(last)) => tracing::info!(
+                persisted_high_water = last,
+                "posture: generation counter initialized from store (0 = fresh store)"
+            ),
+            Ok(Err(err)) => {
+                tracing::error!(
+                    error = %err,
+                    "startup failed: unable to load the persisted posture-generation \
+                     high-water (fail-closed — serving would time-reverse generations)"
+                );
+                std::process::exit(1);
+            }
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    "startup failed: generation-init task panicked (fail-closed)"
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+
     let signing_key = audit_signing_key.clone();
     // #87: the causal log persists to the SAME store the rest of the service
     // uses, so forensic causal rows land in the production DB and chain there.

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -899,8 +899,7 @@ async fn main() {
             Err(err) => {
                 tracing::error!(
                     error = %err,
-                    "startup failed: generation-init task failed to join (panic or \
-                     cancellation) (fail-closed)"
+                    "startup failed: generation-init task failed to join (panic or cancellation) (fail-closed)"
                 );
                 std::process::exit(1);
             }

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -899,7 +899,8 @@ async fn main() {
             Err(err) => {
                 tracing::error!(
                     error = %err,
-                    "startup failed: generation-init task panicked (fail-closed)"
+                    "startup failed: generation-init task failed to join (panic or \
+                     cancellation) (fail-closed)"
                 );
                 std::process::exit(1);
             }

--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -17,9 +17,25 @@ pub use crate::posture_cache::POSTURE_CACHE_TTL_MS;
 pub static POSTURE_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 /// Initialize the generation counter from the last persisted value.
-/// Call once at service startup after VerifierStore is opened.
-pub fn init_generation_from_store(app: &Arc<AppState>) {
-    let last = app.store.with(|store| store.load_last_generation().unwrap_or(0));
+/// Call once at service startup after VerifierStore is opened, BEFORE the
+/// first recalculation claims a generation — the service binary does this
+/// right after the initial node/dependency load (WS-0.2 / #G10: the call was
+/// previously missing from the binary entirely, so every restart reset the
+/// live counter to 1 while the store held the high-water mark; emitted
+/// generations regressed across restarts and `save_last_generation` rejected
+/// every persist until the counter caught up).
+///
+/// Returns the persisted high-water that was loaded (0 = fresh store).
+/// FAIL-CLOSED: a store read error is returned as `Err` — the caller must
+/// treat an unreadable generation high-water like any other unreadable
+/// startup state (refuse to serve), because proceeding would silently
+/// re-introduce the cross-restart time-reversal this function exists to
+/// prevent. (The prior signature swallowed the error via `unwrap_or(0)`.)
+pub fn init_generation_from_store(app: &Arc<AppState>) -> Result<u64, String> {
+    let last = app
+        .store
+        .with(|store| store.load_last_generation())
+        .map_err(|e| e.to_string())?;
     if last > 0 {
         // B6: `fetch_max`, not `store`. If any recalc already advanced the counter
         // past `last + 1` before this init runs (e.g. a cold-start recalc), a bare
@@ -29,6 +45,7 @@ pub fn init_generation_from_store(app: &Arc<AppState>) {
         // init/recalc ordering.
         POSTURE_GENERATION.fetch_max(last + 1, Ordering::SeqCst);
     }
+    Ok(last)
 }
 
 /// Returns the next generation number, strictly monotonically increasing.
@@ -1053,13 +1070,46 @@ mod posture_engine_tests {
         let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
         app.store.with(|s| s.save_last_generation(5).unwrap());
 
-        init_generation_from_store(&app);
+        let loaded = init_generation_from_store(&app).expect("readable store");
+        assert_eq!(loaded, 5, "init reports the persisted high-water it loaded");
 
         // With the old `store(last + 1)` this would have dropped the counter to 6;
         // `fetch_max(6)` cannot lower a counter already at/above `before`.
         assert!(
             POSTURE_GENERATION.load(Ordering::SeqCst) >= before,
             "init_generation_from_store must never move the generation counter backwards"
+        );
+    }
+
+    /// WS-0.2 / #G10 — the RAISE case: when the persisted high-water is AHEAD
+    /// of the live counter (the restart scenario: a prior process advanced the
+    /// store, this process booted fresh), init must lift the counter above it
+    /// so every generation emitted after a restart is strictly greater than
+    /// every generation emitted before it (the ordering federation peers and
+    /// SSE consumers rely on).
+    #[test]
+    fn test_init_generation_raises_counter_above_persisted_high_water() {
+        use std::sync::Arc;
+        use crate::verifier::{AppState, VerifierOperationMode};
+        use crate::verifier_store::VerifierStore;
+
+        let store = VerifierStore::new(":memory:").unwrap();
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+
+        // Simulate a prior process having persisted a high-water far ahead of
+        // this process's live counter (offset keeps the test robust to the
+        // shared global being bumped concurrently by other tests).
+        let high_water = POSTURE_GENERATION.load(Ordering::SeqCst) + 10_000;
+        app.store.with(|s| s.save_last_generation(high_water).unwrap());
+
+        let loaded = init_generation_from_store(&app).expect("readable store");
+        assert_eq!(loaded, high_water);
+
+        let next = next_generation();
+        assert!(
+            next > high_water,
+            "the first generation after init must exceed the persisted high-water \
+             (got {next}, high-water {high_water}) — otherwise restarts time-reverse"
         );
     }
 

--- a/src/posture_engine_v2.rs
+++ b/src/posture_engine_v2.rs
@@ -135,30 +135,20 @@ pub fn resolve_post_promotion_posture(
 // ============================================================================
 // SECTION 2: Generation persistence across restarts
 // ============================================================================
-
-/*
-pub fn load_last_generation(&self) -> rusqlite::Result<u64> {
-    let result = self.conn.query_row(
-        "SELECT value FROM posture_engine_state WHERE key = 'last_generation'",
-        [],
-        |row| row.get::<_, String>(0),
-    );
-    match result {
-        Ok(s)  => Ok(s.parse::<u64>().unwrap_or(0)),
-        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(0),
-        Err(e) => Err(e),
-    }
-}
-
-pub fn save_last_generation(&self, generation: u64) -> rusqlite::Result<()> {
-    self.conn.execute(
-        "INSERT OR REPLACE INTO posture_engine_state (key, value)
-         VALUES ('last_generation', ?1)",
-        rusqlite::params![generation.to_string()],
-    )?;
-    Ok(())
-}
-*/
+//
+// IMPLEMENTED ELSEWHERE — this section used to hold a commented-out draft of
+// the persistence pair, which read as "the mechanism does not exist" (it was
+// flagged exactly that way in the 2026-07 architecture review, #G10). The
+// LIVE implementations are:
+//   - `VerifierStore::load_last_generation` / `save_last_generation`
+//     (src/verifier_store/posture.rs — monotonic high-water UPSERT, #695),
+//   - `posture_engine::init_generation_from_store` (B6 `fetch_max` init),
+//     called by the service binary at startup BEFORE the first recalc
+//     (WS-0.2 wired it; it was previously missing from the binary), and
+//   - the per-recalc persist inside `recalculate_and_broadcast`.
+// Restart contract test: `test_init_generation_raises_counter_above_
+// persisted_high_water` (unit) + tests/generation_persistence.rs (restart
+// simulation over one SQLite file).
 
 // ============================================================================
 // SECTION 3: PostureEngineTask — serialized recalculation with coalescing

--- a/src/verifier_store/posture.rs
+++ b/src/verifier_store/posture.rs
@@ -161,7 +161,17 @@ impl VerifierStore {
             [],
             |row| row.get::<_, String>(0),
         ) {
-            Ok(s)  => Ok(s.parse::<u64>().unwrap_or(0)),
+            // FAIL-CLOSED parse (#771 review): a present-but-non-numeric value is
+            // CORRUPTION, not a fresh store. The prior `unwrap_or(0)` read it as
+            // "no history", silently reintroducing the restart time-reversal the
+            // boot init exists to prevent. Only a genuinely absent row is 0.
+            Ok(s) => s.parse::<u64>().map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            }),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(0),
             Err(e) => Err(e),
         }

--- a/src/verifier_store/tests.rs
+++ b/src/verifier_store/tests.rs
@@ -139,6 +139,22 @@ mod attestation_registry_tests {
         assert!(!store.save_last_generation(11).unwrap(), "an equal generation is rejected (strict >)");
         assert_eq!(store.load_last_generation().unwrap(), 11);
     }
+
+    /// #771 review — a present-but-non-numeric `last_generation` value is
+    /// CORRUPTION and must surface as `Err`, never read as 0/"fresh store"
+    /// (which would silently reintroduce the restart time-reversal the boot
+    /// init exists to prevent; the binary exits fail-closed on the Err).
+    #[test]
+    fn test_corrupted_last_generation_fails_closed_not_zero() {
+        let store = in_memory();
+        store
+            .save_engine_state("last_generation", "not-a-number")
+            .unwrap();
+        assert!(
+            store.load_last_generation().is_err(),
+            "a non-numeric persisted generation must be a load ERROR, not 0"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/tests/generation_persistence.rs
+++ b/tests/generation_persistence.rs
@@ -1,0 +1,138 @@
+// tests/generation_persistence.rs
+//
+// WS-0.2 / #G10 — posture-generation persistence across restarts, proven as a
+// RESTART SIMULATION over one file-backed SQLite store.
+//
+// The invariant (CLAUDE.md "Generation Persistence"): every generation emitted
+// after a restart is strictly greater than every generation emitted before it.
+// Federation peers and SSE consumers order posture reports by generation, so a
+// reset-to-1 after restart is a time-reversal, not a cosmetic blip.
+//
+// Why a simulation and not two literal processes: `POSTURE_GENERATION` is a
+// process-global atomic, so an in-process test cannot observe the pre-fix
+// reset itself. What it CAN prove — and what this file pins — is the boot
+// CONTRACT the binary now follows (init from the persisted high-water BEFORE
+// the first recalc): given a store whose high-water is ahead of the live
+// counter (exactly the state a fresh process finds after a predecessor died),
+// the init+recalc sequence emits generations strictly above the high-water
+// and re-persists the new maximum.
+
+use std::sync::Arc;
+
+use kirra_verifier::posture_cache::SharedPostureCache;
+use kirra_verifier::posture_engine::{init_generation_from_store, recalculate_and_broadcast};
+use kirra_verifier::verifier::{
+    AppState, NodeTrustState, RegisteredNode, VerifierOperationMode,
+};
+use kirra_verifier::verifier_store::VerifierStore;
+
+fn app_on(path: &std::path::Path) -> Arc<AppState> {
+    let store = VerifierStore::new(path.to_str().expect("utf8 temp path")).expect("file store");
+    let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
+    let node = RegisteredNode {
+        node_id: "gen-node".to_string(),
+        status: NodeTrustState::Trusted,
+        registered_at_ms: 1,
+        last_trust_update_ms: 1,
+        ak_public_pem: None,
+        expected_pcr16_digest_hex: None,
+        site: None,
+        firmware_version: None,
+    };
+    app.nodes.insert(node.node_id.clone(), node);
+    app
+}
+
+fn empty_cache() -> SharedPostureCache {
+    Arc::new(std::sync::RwLock::new(None))
+}
+
+fn cache_generation(cache: &SharedPostureCache) -> u64 {
+    cache
+        .read()
+        .unwrap()
+        .as_ref()
+        .expect("cache populated by recalc")
+        .generation
+}
+
+/// The restart contract, end to end over one SQLite file:
+///
+/// "Process #1": recalc against a file-backed store → the emitted generation
+/// is persisted as the high-water. Simulated death: everything but the file is
+/// dropped, and the high-water is pushed far AHEAD of the live counter (the
+/// state a fresh process finds — its counter is behind the store).
+///
+/// "Process #2": a NEW AppState on the SAME file runs the binary's boot order
+/// (`init_generation_from_store`, then the first recalc). The emitted
+/// generation must be strictly above the persisted high-water, and the store
+/// must now hold the new maximum.
+#[test]
+fn generation_survives_restart_and_never_time_reverses() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("gen_restart.sqlite");
+
+    // ---- "process #1": live service, emits + persists generations --------
+    let persisted_high_water = {
+        let app1 = app_on(&db);
+        let cache1 = empty_cache();
+        recalculate_and_broadcast(&app1, &cache1);
+        recalculate_and_broadcast(&app1, &cache1);
+        let last_emitted = cache_generation(&cache1);
+
+        let stored = app1
+            .store
+            .with(|s| s.load_last_generation())
+            .expect("readable store");
+        assert!(
+            stored >= last_emitted,
+            "recalc must persist its generation (stored {stored} < emitted {last_emitted})"
+        );
+
+        // Simulate the predecessor having run far ahead of THIS process's
+        // live counter before dying — the exact restart state (a fresh
+        // process's counter is behind the store's high-water). The offset
+        // also makes the test robust to other tests bumping the shared
+        // global counter concurrently.
+        let ahead = kirra_verifier::posture_engine::POSTURE_GENERATION
+            .load(std::sync::atomic::Ordering::SeqCst)
+            + 50_000;
+        assert!(
+            app1.store
+                .with(|s| s.save_last_generation(ahead))
+                .expect("writable store"),
+            "pushing the high-water ahead must be accepted"
+        );
+        ahead
+    }; // app1 + cache1 dropped — only the SQLite file survives the "crash".
+
+    // ---- "process #2": fresh state on the same file, binary's boot order --
+    let app2 = app_on(&db);
+    let loaded = init_generation_from_store(&app2).expect("readable store at boot");
+    assert_eq!(
+        loaded, persisted_high_water,
+        "boot init must load the predecessor's high-water"
+    );
+
+    let cache2 = empty_cache();
+    recalculate_and_broadcast(&app2, &cache2);
+    let post_restart = cache_generation(&cache2);
+    assert!(
+        post_restart > persisted_high_water,
+        "the first post-restart generation must be strictly above the persisted \
+         high-water (got {post_restart}, high-water {persisted_high_water}) — \
+         anything else is the pre-fix time-reversal"
+    );
+
+    // The store's high-water must have advanced to the new maximum (the #695
+    // monotonic UPSERT accepted the strictly-greater post-restart write).
+    let stored_after = app2
+        .store
+        .with(|s| s.load_last_generation())
+        .expect("readable store");
+    assert!(
+        stored_after >= post_restart,
+        "the post-restart generation must be re-persisted (stored {stored_after}, \
+         emitted {post_restart})"
+    );
+}


### PR DESCRIPTION
**PR 2 of the product execution plan (WS-0.2) — closes gap-analysis G10, generation axis.**

## The defect (sharper than the review stated)

The architecture review flagged generation persistence as "commented-out dead code." Investigation showed the mechanism was never missing: `VerifierStore::load/save_last_generation` (monotonic high-water UPSERT, #695) and `posture_engine::init_generation_from_store` (B6 `fetch_max`) exist and were unit-tested. The commented block in `posture_engine_v2.rs` SECTION 2 was a superseded draft.

The real gap: **no code in the service binary ever called `init_generation_from_store` at boot.** Every restart reset the live `POSTURE_GENERATION` counter to 1 while the store held the high-water mark — emitted generations regressed across restarts (breaking the ordering federation peers and SSE consumers rely on), and `save_last_generation`'s strict-greater guard silently rejected every persist until the counter caught back up. CLAUDE.md's "survives restarts" claim was false in the binary.

## The fix

- **Boot wiring** (`kirra_verifier_service`): `init_generation_from_store` runs right after the initial node/dependency load, **before any recalculation claims a generation** — covering both the Active path's initial recalc and the standby promotion recalc. Runs off the tokio workers (SG-HA-3); a store read error is `process::exit(1)` fail-closed, matching every other fallible startup step.
- **Fail-closed hardening**: `init_generation_from_store` now returns `Result<u64>` (the loaded high-water) instead of swallowing store errors via `unwrap_or(0)` — an unreadable high-water at boot refuses to serve rather than silently reintroducing the time-reversal it exists to prevent.
- **Dead draft removed**: `posture_engine_v2.rs` SECTION 2 now points at the live implementations and the boot wiring instead of a commented-out sketch that read as "not implemented."

## DoD (from the plan: "Generation survives restart in test; federation ordering claim true")

- Unit raise-case `test_init_generation_raises_counter_above_persisted_high_water`: init lifts the counter above a persisted high-water that is *ahead* of it — the exact state a fresh process finds.
- `tests/generation_persistence.rs` — restart simulation over one file-backed SQLite store: "process #1" emits + persists and dies with the high-water ahead; "process #2" on the same file runs the binary's boot order and must emit strictly above the predecessor's high-water and re-persist the new maximum. (An in-process test cannot observe the pre-fix reset itself — `POSTURE_GENERATION` is process-global — so the test pins the boot *contract*; the file header documents this honestly.)

## Ratchet note

`ci/quality_guardrails_baseline.json`: bin line ceiling 3959 → 3997 for the fail-closed init block, per the ratchet's own raise-with-justification protocol. Panic budget unchanged.

Full workspace tests pass locally; clippy clean; quality guardrails satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_