### PR TITLE
audit: incident-class rows are power-loss durable at write time (WS-0.3)

### DIFF
--- a/src/post_incident.rs
+++ b/src/post_incident.rs
@@ -109,7 +109,13 @@ fn emit(app: &AppState, event_type: &str, body: &serde_json::Value, ts: u64) {
             &body.to_string(),
             Some("post-incident forensic sequence (#104)"),
             ts,
-        )
+        )?;
+        // WS-0.3: every post-incident sequence event is incident-class by
+        // definition — fsync the WAL so the forensic row survives a hard
+        // power loss (the incident record must not be the least durable
+        // write in the system). Same best-effort contract as the rest of
+        // this module: a failure is counted, never propagated.
+        store.fsync_wal_durable(ts)
     });
     if let Err(e) = outcome {
         note_failure(app, event_type, &e.to_string());

--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -288,6 +288,23 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
                     ),
                     Err(e) => tracing::error!(error = %e, generation, "Failed to persist last generation (high-water self-heals on next recalc; live transition not suppressed) — #695"),
                 }
+                // WS-0.3: a posture TRANSITION is incident-class — make its
+                // just-committed audit row hard-power-loss durable NOW (one
+                // FULL-sync marker commit fsyncs the shared WAL). The periodic
+                // POSTURE_CACHE_REFRESHED traffic is NOT fsync'd (INV-12
+                // throughput rationale). Best-effort by the same reasoning as
+                // the generation persist above: the row IS committed and the
+                // live (possibly escalating) transition must not be suppressed
+                // over a degraded durability guarantee — log loudly instead.
+                if is_transition {
+                    if let Err(e) = store.fsync_wal_durable(ts) {
+                        tracing::error!(
+                            error = %e,
+                            generation,
+                            "INCIDENT-DURABILITY DEGRADED: WAL fsync after posture transition failed — the transition row is committed but not yet power-loss durable (WS-0.3)"
+                        );
+                    }
+                }
                 true
             }
             // SAFETY: SG-HA-4 — DB errors demote node to safe state (fail-closed).
@@ -1110,6 +1127,52 @@ mod posture_engine_tests {
             next > high_water,
             "the first generation after init must exceed the persisted high-water \
              (got {next}, high-water {high_water}) — otherwise restarts time-reverse"
+        );
+    }
+
+    /// WS-0.3 — the incident-durability fsync is gated on TRANSITIONS: a
+    /// posture change fsyncs the WAL (marker advances); the periodic
+    /// POSTURE_CACHE_REFRESHED traffic does not (INV-12 throughput rationale
+    /// — no 20 Hz per-row fsync re-introduced through the back door).
+    #[test]
+    fn test_incident_fsync_fires_on_transition_not_on_refresh() {
+        let app = active_app();
+        let cache = empty_cache();
+
+        // First recalc: None → Nominal is a transition → marker committed.
+        recalculate_and_broadcast(&app, &cache);
+        let after_transition = app
+            .store
+            .with(|s| s.load_engine_state("last_incident_durable_ms").unwrap());
+        assert!(
+            after_transition.is_some(),
+            "a posture transition must fsync the WAL (marker present)"
+        );
+
+        // Poison the marker, then recalc with NO posture change: the refresh
+        // path must NOT re-fsync (marker stays poisoned).
+        app.store
+            .with(|s| s.save_engine_state("last_incident_durable_ms", "sentinel").unwrap());
+        recalculate_and_broadcast(&app, &cache);
+        let after_refresh = app
+            .store
+            .with(|s| s.load_engine_state("last_incident_durable_ms").unwrap());
+        assert_eq!(
+            after_refresh.as_deref(),
+            Some("sentinel"),
+            "a no-change refresh must not fsync (INV-12: transitions only)"
+        );
+
+        // Force a real transition (trust the DAG down): marker advances again.
+        insert_node(&app, "faulty", NodeTrustState::Untrusted("test".into()));
+        recalculate_and_broadcast(&app, &cache);
+        let after_second_transition = app
+            .store
+            .with(|s| s.load_engine_state("last_incident_durable_ms").unwrap());
+        assert_ne!(
+            after_second_transition.as_deref(),
+            Some("sentinel"),
+            "a real transition must fsync again (marker overwritten)"
         );
     }
 

--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -1130,10 +1130,12 @@ mod posture_engine_tests {
         );
     }
 
-    /// WS-0.3 — the incident-durability fsync is gated on TRANSITIONS: a
-    /// posture change fsyncs the WAL (marker advances); the periodic
-    /// POSTURE_CACHE_REFRESHED traffic does not (INV-12 throughput rationale
-    /// — no 20 Hz per-row fsync re-introduced through the back door).
+    /// WS-0.3 — the incident-durability marker write is gated on TRANSITIONS:
+    /// a posture change commits the marker (and on a file-backed store, that
+    /// commit fsyncs the shared WAL — this test's in-memory store exercises
+    /// only the gating); the periodic POSTURE_CACHE_REFRESHED traffic does
+    /// not (INV-12 throughput rationale — no 20 Hz per-row fsync
+    /// re-introduced through the back door).
     #[test]
     fn test_incident_fsync_fires_on_transition_not_on_refresh() {
         let app = active_app();

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -887,13 +887,46 @@ impl VerifierStore {
     /// safe-stop/shutdown + SQLite auto-checkpoint). So the final audit rows
     /// before an UNGRACEFUL power cut may be lost — a forensic gap, never a
     /// safety-state gap (the verdict path is store-free). Do NOT assume the audit
-    /// tail is hard-power-loss-durable. Tighter durability (a periodic fsync'd
-    /// checkpoint) is an available future knob, off by default. See
+    /// tail is hard-power-loss-durable — EXCEPT incident-class rows: since
+    /// WS-0.3, a posture TRANSITION and every post-incident sequence event are
+    /// followed by `fsync_wal_durable`, so the record of the incident preceding
+    /// a power cut is fsync-durable at write time. The periodic refresh tail
+    /// keeps the checkpoint-bounded window. See
     /// docs/safety/CODING_GUIDELINES.md INV-12.
     pub fn durable_checkpoint(&self) -> Result<()> {
         if let Some(dc) = &self.durable_conn {
             dc.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
         }
+        Ok(())
+    }
+
+    /// WS-0.3 (#G10 audit axis) — make everything committed so far on the
+    /// shared WAL **hard-power-loss durable**, by committing one tiny marker
+    /// row on the `synchronous=FULL` connection. A FULL commit fsyncs the WAL
+    /// file, and fsync flushes the file's dirty pages wholesale — including
+    /// every frame previously committed by the NORMAL connection. So the
+    /// incident row committed immediately before this call survives an
+    /// ungraceful power cut, without per-row fsync on the 20 Hz+ audit path
+    /// and without a checkpoint's reader/writer coordination.
+    ///
+    /// Call AFTER committing an INCIDENT-CLASS audit row (a posture
+    /// TRANSITION, a post-incident sequence event) — never on the periodic
+    /// `POSTURE_CACHE_REFRESHED` traffic, which keeps the INV-12 throughput
+    /// rationale intact (transitions are rare state changes, not steady-state
+    /// load). The marker itself (`last_incident_durable_ms`) doubles as a
+    /// forensic breadcrumb: the last instant the audit tail was known
+    /// fsync-durable.
+    ///
+    /// In-memory stores have no durable connection (and nothing to make
+    /// durable); the marker then rides the main connection — semantics
+    /// preserved for tests.
+    pub fn fsync_wal_durable(&self, now_ms: u64) -> Result<()> {
+        self.durable_ref().execute(
+            "INSERT INTO posture_engine_state (key, value)
+             VALUES ('last_incident_durable_ms', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = ?1",
+            params![now_ms.to_string()],
+        )?;
         Ok(())
     }
 

--- a/src/verifier_store/tests.rs
+++ b/src/verifier_store/tests.rs
@@ -792,6 +792,38 @@ mod durability_tests {
         assert_eq!(pragma_synchronous(dc), 2, "durable conn is FULL (2)");
     }
 
+    /// WS-0.3 — `fsync_wal_durable` commits the durability marker (and, on a
+    /// file-backed store, rides the `synchronous=FULL` connection whose pragma
+    /// `durable_connection_is_full_main_is_normal` pins — a FULL commit fsyncs
+    /// the shared WAL, carrying every previously committed audit frame).
+    #[test]
+    fn test_fsync_wal_durable_writes_marker_on_file_and_memory_stores() {
+        // File-backed: the marker rides the durable (FULL) connection.
+        let db = TmpDb::new("fsync_marker");
+        let s = VerifierStore::new(db.path()).unwrap();
+        s.fsync_wal_durable(1_234).unwrap();
+        assert_eq!(
+            s.load_engine_state("last_incident_durable_ms").unwrap().as_deref(),
+            Some("1234"),
+            "marker must be committed and readable"
+        );
+        // Marker is an upsert — the latest incident instant wins.
+        s.fsync_wal_durable(5_678).unwrap();
+        assert_eq!(
+            s.load_engine_state("last_incident_durable_ms").unwrap().as_deref(),
+            Some("5678")
+        );
+
+        // In-memory fallback: no durable conn, semantics preserved on main.
+        let m = VerifierStore::new(":memory:").unwrap();
+        m.fsync_wal_durable(9).unwrap();
+        assert_eq!(
+            m.load_engine_state("last_incident_durable_ms").unwrap().as_deref(),
+            Some("9")
+        );
+    }
+
+
     /// IN-MEMORY FALLBACK: no separate durable conn (a 2nd :memory: open would be
     /// a distinct db), and epoch/nonce still work via the main connection.
     #[test]

--- a/tests/audit_power_loss.rs
+++ b/tests/audit_power_loss.rs
@@ -1,0 +1,114 @@
+// tests/audit_power_loss.rs
+//
+// WS-0.3 (#G10 audit axis) — incident-class audit rows survive an ungraceful
+// process death, proven by a REAL kill: a child process commits a posture
+// TRANSITION (which triggers the WS-0.3 `fsync_wal_durable` marker commit on
+// the `synchronous=FULL` connection) and then `std::process::abort()`s —
+// no destructors, no shutdown `durable_checkpoint`, no SIGTERM path. The
+// parent reopens the SQLite file and must find the transition row, the
+// durability marker, and an intact audit chain.
+//
+// HONESTY NOTE on what this can and cannot prove: a userspace test can kill a
+// PROCESS, not the power. WAL-committed data survives a process kill even at
+// `synchronous=NORMAL` (the OS page cache persists), so process death alone
+// cannot distinguish NORMAL from FULL. The hard-power-loss half of the WS-0.3
+// claim therefore rests on the asserted MECHANISM — the marker commit rides
+// the FULL connection (`durable_connection_is_full_main_is_normal` pins the
+// pragma; `fsync_wal_durable` rides `durable_ref()`), and a FULL commit
+// fsyncs the shared WAL file, carrying every previously committed frame with
+// it. This test pins the abort-path end-to-end behaviour AND the presence of
+// the fsync marker at the moment of death.
+
+use std::process::Command;
+
+use kirra_verifier::posture_cache::SharedPostureCache;
+use kirra_verifier::posture_engine::recalculate_and_broadcast;
+use kirra_verifier::verifier::{AppState, VerifierOperationMode};
+use kirra_verifier::verifier_store::VerifierStore;
+
+const CHILD_ENV: &str = "KIRRA_AUDIT_POWER_LOSS_CHILD_DB";
+
+fn empty_cache() -> SharedPostureCache {
+    std::sync::Arc::new(std::sync::RwLock::new(None))
+}
+
+/// CHILD half: open the store at the given path, commit exactly one posture
+/// TRANSITION (an empty Active fleet forces the M-9 None→LockedOut transition
+/// on the first recalc — incident-class by construction), then die without
+/// any graceful path.
+fn child_write_incident_and_abort(db_path: &str) -> ! {
+    let store = VerifierStore::new(db_path).expect("child: file store");
+    let app = std::sync::Arc::new(AppState::new(store, VerifierOperationMode::Active));
+    let cache = empty_cache();
+    recalculate_and_broadcast(&app, &cache);
+    assert!(
+        cache.read().unwrap().is_some(),
+        "child: recalc must have populated the cache before the kill"
+    );
+    // Ungraceful death: no Drop, no shutdown checkpoint, no WAL truncate.
+    std::process::abort();
+}
+
+#[test]
+fn incident_row_survives_ungraceful_process_death() {
+    // ---- child mode (re-exec'd below) ------------------------------------
+    if let Ok(db_path) = std::env::var(CHILD_ENV) {
+        child_write_incident_and_abort(&db_path);
+    }
+
+    // ---- parent mode -------------------------------------------------------
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("audit_power_loss.sqlite");
+    let db_str = db.to_str().expect("utf8 temp path").to_string();
+
+    let exe = std::env::current_exe().expect("test binary path");
+    let output = Command::new(&exe)
+        .arg("incident_row_survives_ungraceful_process_death")
+        .arg("--exact")
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .env(CHILD_ENV, &db_str)
+        .output()
+        .expect("spawn child test process");
+
+    assert!(
+        !output.status.success(),
+        "the child must die by abort, not exit cleanly (stdout: {})",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    // Reopen the store the way a restarted service would.
+    let store = VerifierStore::new(&db_str).expect("parent: reopen after kill");
+
+    // DoD: the incident row is present on reopen.
+    let events = store
+        .load_all_posture_events()
+        .expect("parent: events readable after kill");
+    assert!(
+        events
+            .iter()
+            .any(|e| e["event_type"] == "SYSTEM_POSTURE_TRANSITION"),
+        "the posture-transition row committed immediately before the kill must \
+         be present on reopen; got events: {events:?}"
+    );
+
+    // The WS-0.3 durability marker was committed on the FULL connection at the
+    // moment of the incident — its presence pins that the fsync path ran
+    // before the death.
+    let marker = store
+        .load_engine_state("last_incident_durable_ms")
+        .expect("parent: engine state readable");
+    assert!(
+        marker.is_some(),
+        "the incident-durability fsync marker must exist — the WS-0.3 fsync \
+         path did not run before the kill"
+    );
+
+    // The chain the incident row landed on is intact after the kill.
+    assert!(
+        store
+            .verify_audit_chain_integrity()
+            .expect("parent: chain verifiable"),
+        "audit-chain hash linkage must verify after an ungraceful death"
+    );
+}

--- a/tests/audit_power_loss.rs
+++ b/tests/audit_power_loss.rs
@@ -73,8 +73,10 @@ fn incident_row_survives_ungraceful_process_death() {
 
     assert!(
         !output.status.success(),
-        "the child must die by abort, not exit cleanly (stdout: {})",
-        String::from_utf8_lossy(&output.stdout)
+        "the child must die by abort, not exit cleanly (status: {:?}, stdout: {}, stderr: {})",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
     );
 
     // Reopen the store the way a restarted service would.


### PR DESCRIPTION
**PR 3 of the product execution plan (WS-0.3) — closes gap-analysis G10, audit axis.**

## The defect

The audit chain rides the `synchronous=NORMAL` connection: rows are durable only to the last WAL checkpoint (graceful shutdown / auto-checkpoint). On an *ungraceful* power cut, the last rows before the cut may be lost — and those are precisely the record of the incident that preceded the crash. The most forensically important write in the system was its least durable. (This boundary was deliberate — INV-12 chose it over a 20 Hz per-row fsync, and named "tighter durability" as an available future knob. This PR is that knob, scoped to incident-class events only.)

## The fix

**`VerifierStore::fsync_wal_durable(now_ms)`** — commits one tiny marker row (`posture_engine_state['last_incident_durable_ms']`) on the `synchronous=FULL` durable connection. A FULL commit fsyncs the shared WAL file, and fsync carries **every previously committed frame** with it — so the incident row committed immediately before the call becomes hard-power-loss durable:
- no per-row fsync on the steady-state audit path (INV-12 throughput rationale intact),
- no `wal_checkpoint` reader/writer coordination,
- the marker doubles as a forensic breadcrumb: the last instant the audit tail was known fsync-durable,
- in-memory stores fall back to the main connection (test semantics preserved).

**Call sites (incident-class only):**
- posture **transitions** in `recalculate_and_broadcast` — the periodic `POSTURE_CACHE_REFRESHED` traffic is deliberately *not* fsync'd,
- every `post_incident` forensic sequence event.

Both are best-effort with loud `INCIDENT-DURABILITY DEGRADED` error logs: the row *is* committed, and a live (possibly escalating) transition must never be suppressed over a degraded durability guarantee — the same trade the adjacent #695 generation-persist comment documents.

Docs: `durable_checkpoint`'s DURABILITY BOUNDARY note updated to reflect the tightened boundary.

## DoD ("Kill -9 after incident write → row present on reopen")

- **`tests/audit_power_loss.rs`** — a real ungraceful death: a re-exec'd child process commits a posture transition (M-9 `None→LockedOut` on an empty Active fleet — incident-class by construction) and `std::process::abort()`s with no destructors, no shutdown checkpoint. The parent reopens the SQLite file and asserts the transition row is present, the durability marker exists, and the audit chain verifies.
- **Honesty note (in the test header):** userspace can kill a process, not the power; WAL data survives process death even at NORMAL. The hard-power-loss half of the claim rests on the pinned mechanism — the marker rides the FULL connection (pragma pinned by the existing `durable_connection_is_full_main_is_normal`) and a FULL commit fsyncs the shared WAL.
- **`test_incident_fsync_fires_on_transition_not_on_refresh`** — transition-gating proven via a poisoned-marker technique: a no-change refresh does not re-fsync; a forced trust-degradation transition does.
- **`test_fsync_wal_durable_writes_marker_on_file_and_memory_stores`** — marker upsert semantics on both store shapes.

Full workspace tests pass locally (645 lib tests + all integration suites), clippy clean, quality guardrails satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_