### PR TITLE
parko: per-tick inference deadline + hung-backend watchdog; MRC-bound angular reconciliation (WS-0.4)

### DIFF
--- a/parko/crates/parko-core/src/scheduler.rs
+++ b/parko/crates/parko-core/src/scheduler.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::task;
 
-use crate::backend::{BackendCapabilities, BackendDescriptor, InferenceBackend, ModelHandle, PrecisionMode, TensorBatch};
+use crate::backend::{BackendCapabilities, BackendDescriptor, BackendError, InferenceBackend, ModelHandle, PrecisionMode, TensorBatch};
 use crate::commands::ControlCommand;
 use crate::sensor::SensorFrame;
 use crate::telemetry::{CumulativeJitterEvaluator, PostureSnapshot, RuntimeTelemetry, ThermalState};
@@ -23,6 +23,26 @@ fn override_reason(action: &EnforcementAction) -> Option<&'static str> {
         EnforcementAction::Deny { .. } => Some("deny"),
     }
 }
+
+/// WS-0.4 — default per-tick inference deadline, ms. The HARD bound on how
+/// long `tick` waits for the backend before failing closed to a stopped
+/// command; distinct from `DegradationThresholds::max_inference_latency_ms`
+/// (150 ms), which only FLAGS a slow-but-completed inference as degraded.
+/// A backend that never returns (wedged driver, deadlocked EP) previously
+/// stalled `tick` — and therefore the node's whole drain loop — forever;
+/// the deadline turns that hang into an MRC within a bounded time.
+/// Deliberately generous (20× the tick period @ 20 Hz) so it only fires on
+/// a genuine hang, never on ordinary latency jitter; deployments tighten it
+/// via `with_inference_deadline_ms` / `PARKO_INFERENCE_DEADLINE_MS`.
+pub const DEFAULT_INFERENCE_DEADLINE_MS: u64 = 1_000;
+
+/// The join handle of an in-flight (possibly hung) inference task. The
+/// blocking task cannot be cancelled — `spawn_blocking` work holds an OS
+/// thread until it returns — so on deadline breach the handle is parked
+/// here and polled for completion on later ticks instead of being dropped
+/// (a dropped handle would leave the straggler untracked and let every
+/// subsequent tick stack a fresh blocking task onto a wedged backend).
+type InFlightInference = task::JoinHandle<(Result<TensorBatch<'static>, BackendError>, u64)>;
 
 /// Thresholds for degraded-mode detection.
 ///
@@ -68,6 +88,16 @@ pub struct InferenceLoop<B: InferenceBackend> {
     /// overrides and non-finite faults through the `AuditClient` trait, keeping
     /// it independent of any concrete (e.g. SDK-backed) audit implementation.
     audit: Option<Arc<dyn AuditClient>>,
+    /// WS-0.4 — per-tick inference deadline, ms (always on; default
+    /// `DEFAULT_INFERENCE_DEADLINE_MS`). Exceeding it fails the tick closed
+    /// to a stopped command instead of stalling the loop.
+    inference_deadline_ms: u64,
+    /// WS-0.4 — the watchdog state for a backend that blew its deadline:
+    /// the still-running straggler task. While `Some` and unfinished, ticks
+    /// fail fast to MRC without spawning more inference; once it finishes,
+    /// its (stale) result is reaped and discarded and normal operation
+    /// resumes.
+    hung_inference: Option<InFlightInference>,
 }
 
 fn capabilities_precision(caps: &BackendCapabilities) -> PrecisionMode {
@@ -114,7 +144,19 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
             governor: None,
             tick_period_s: 0.05,
             audit: None,
+            inference_deadline_ms: DEFAULT_INFERENCE_DEADLINE_MS,
+            hung_inference: None,
         }
+    }
+
+    /// WS-0.4 — set the per-tick inference deadline (ms). Must be positive;
+    /// zero is coerced to 1 ms (a zero deadline would MRC every tick, which
+    /// is fail-closed but certainly a misconfiguration). The deadline cannot
+    /// be disabled: a backend hang must never stall the loop indefinitely.
+    #[must_use]
+    pub fn with_inference_deadline_ms(mut self, deadline_ms: u64) -> Self {
+        self.inference_deadline_ms = deadline_ms.max(1);
+        self
     }
 
     /// Attach an [`AuditClient`] so the decision path records governor overrides
@@ -184,19 +226,83 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
             .map(|s| std::mem::size_of_val(s.as_slice()))
             .sum();
 
+        // WS-0.4 watchdog — a previous inference that blew its deadline may
+        // still be running (a blocking task cannot be cancelled). While it
+        // is, fail fast to MRC WITHOUT spawning more inference: each extra
+        // spawn onto a wedged backend would leak another blocking-pool
+        // thread, and its answer would be for a stale frame anyway. Once the
+        // straggler finishes, reap and DISCARD its output (it answers a
+        // frame that is no longer current) and resume normal inference.
+        if let Some(straggler) = self.hung_inference.take() {
+            if straggler.is_finished() {
+                let _ = straggler.await;
+            } else {
+                self.hung_inference = Some(straggler);
+                self.last_validated_command =
+                    Some(ControlCommand::stopped(loop_start_ms));
+                // The onset was audited on the deadline tick; while-hung
+                // ticks stay quiet (a 20 Hz loop would flood the ledger) —
+                // the degraded MRC snapshots are the ongoing record.
+                return Ok(self.deadline_mrc_snapshot(
+                    current_frame.frame_id,
+                    loop_start_ms,
+                    frame_age_ms,
+                    tensor_payload_bytes,
+                ));
+            }
+        }
+
         let backend_ref = Arc::clone(&self.backend);
         let model_handle = Arc::clone(&self.model);
         let payload = current_frame.payload;
 
-        // Inference on blocking thread.
-        let (output_tensors, inference_latency_ms) = task::spawn_blocking(move || {
+        // Inference on blocking thread, bounded by the WS-0.4 per-tick
+        // deadline. On breach the handle is parked in `hung_inference` (see
+        // the watchdog above) and the tick fails closed to a stopped command
+        // — the loop keeps ticking and publishing MRC instead of stalling.
+        let mut in_flight: InFlightInference = task::spawn_blocking(move || {
             let start = std::time::Instant::now();
             let out = backend_ref.run(&model_handle, &payload);
             let elapsed = start.elapsed().as_millis() as u64;
             (out, elapsed)
-        })
+        });
+        let joined = match tokio::time::timeout(
+            std::time::Duration::from_millis(self.inference_deadline_ms),
+            &mut in_flight,
+        )
         .await
-        .map_err(|e| format!("inference worker join failure: {}", e))?;
+        {
+            Ok(join_result) => join_result,
+            Err(_elapsed) => {
+                if let Some(a) = &self.audit {
+                    a.record_fault(FaultRecord {
+                        tick_ms: loop_start_ms,
+                        code: "inference_deadline_exceeded",
+                        detail: format!(
+                            "backend did not return within the {} ms per-tick \
+                             inference deadline; failing closed to MRC and \
+                             watchdogging the straggler",
+                            self.inference_deadline_ms
+                        ),
+                        posture,
+                    });
+                }
+                self.hung_inference = Some(in_flight);
+                // The next flush must carry a STOP, not the pre-hang command
+                // (fail-closed: after a hang the governor's `previous` is a
+                // stop, so Degraded's no-re-initiation gate holds at zero).
+                self.last_validated_command =
+                    Some(ControlCommand::stopped(loop_start_ms));
+                return Ok(self.deadline_mrc_snapshot(
+                    current_frame.frame_id,
+                    loop_start_ms,
+                    frame_age_ms,
+                    tensor_payload_bytes,
+                ));
+            }
+        };
+        let (output_tensors, inference_latency_ms) =
+            joined.map_err(|e| format!("inference worker join failure: {}", e))?;
 
         let processed_outputs =
             output_tensors.map_err(|e| format!("backend inference error: {}", e))?;
@@ -372,6 +478,38 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
             telemetry,
             active_state_degraded: degraded,
         })
+    }
+
+    /// WS-0.4 — the fail-closed snapshot for a tick whose inference blew the
+    /// deadline (or was skipped because a straggler is still hung): a stopped
+    /// command, degraded. `inference_latency_ms` reports the DEADLINE — no
+    /// true measurement exists (the work never finished), and the exhausted
+    /// budget is the honest lower bound; it also keeps the value above
+    /// `max_inference_latency_ms` so downstream latency triage agrees with
+    /// the degraded flag. The jitter tracker is NOT updated (no measurement).
+    fn deadline_mrc_snapshot(
+        &self,
+        frame_id: u64,
+        loop_start_ms: u64,
+        frame_age_ms: u64,
+        tensor_payload_bytes: usize,
+    ) -> PostureSnapshot {
+        let telemetry = RuntimeTelemetry {
+            inference_latency_ms: self.inference_deadline_ms,
+            rolling_jitter_ms: self.jitter_tracker.std_dev_ms(),
+            dropped_frames: self.dropped_frame_counter,
+            thermal_state: self.probe_platform_thermals().unwrap_or(ThermalState::Normal),
+            frame_age_ms,
+            tensor_payload_bytes,
+            backend_precision: capabilities_precision(&self.cached_capabilities),
+            backend_vendor: std::borrow::Cow::Borrowed(descriptor_vendor(&self.cached_descriptor)),
+        };
+        PostureSnapshot {
+            frame_id,
+            active_command: ControlCommand::stopped(loop_start_ms),
+            telemetry,
+            active_state_degraded: true,
+        }
     }
 
     fn parse_inference_to_command(
@@ -760,6 +898,138 @@ mod tests {
         assert!(flushed.linear_velocity <= 1.5);
     }
 
+    // ── WS-0.4: per-tick inference deadline + hung-backend watchdog ──────────
+
+    /// Backend whose FIRST run hangs for `hang_ms` (real time) and returns a
+    /// normal 0.5 m/s command on every later run. Models a wedged driver /
+    /// EP stall that eventually clears. The hang is a BOUNDED sleep so the
+    /// runtime's shutdown (which waits for blocking-pool threads) always
+    /// completes.
+    struct HangOnceBackend {
+        hang_ms: u64,
+        runs: std::sync::atomic::AtomicU32,
+    }
+
+    impl InferenceBackend for HangOnceBackend {
+        fn load_model(&self, _: &str) -> Result<ModelHandle, BackendError> {
+            Ok(ModelHandle {
+                model_id: "hang-once".to_string(),
+                input_shapes: HashMap::new(),
+                output_shapes: HashMap::new(),
+                expected_precision: PrecisionMode::FP32,
+            })
+        }
+        fn run(&self, _: &ModelHandle, _: &TensorBatch) -> Result<TensorBatch<'static>, BackendError> {
+            let n = self.runs.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n == 0 {
+                std::thread::sleep(std::time::Duration::from_millis(self.hang_ms));
+            }
+            let mut map = HashMap::new();
+            map.insert("cmd_vel_linear".to_string(), TensorStorage::Owned(vec![0.5_f32]));
+            map.insert("cmd_vel_angular".to_string(), TensorStorage::Owned(vec![0.0_f32]));
+            Ok(TensorBatch { named_tensors: map, metadata: HashMap::new() })
+        }
+    }
+
+    /// THE WS-0.4 DoD TEST — "hung-backend test MRCs within budget":
+    ///   tick 1: the backend hangs → the deadline MRCs the tick well before
+    ///           the backend would have returned, audited as a fault;
+    ///   tick 2: the straggler is still running → the watchdog fails fast to
+    ///           MRC WITHOUT spawning another blocking task onto the wedged
+    ///           backend (run count stays 1);
+    ///   tick 3 (after the straggler clears): its stale result is discarded,
+    ///           inference resumes, the loop is healthy again.
+    #[tokio::test]
+    async fn hung_backend_mrcs_within_budget_then_recovers() {
+        use crate::audit::MockAuditClient;
+        let backend = Arc::new(HangOnceBackend {
+            hang_ms: 800,
+            runs: std::sync::atomic::AtomicU32::new(0),
+        });
+        let model = backend.load_model("").unwrap();
+        let (tx, _rx) = mpsc::channel(8);
+        let mock = Arc::new(MockAuditClient::new());
+        let mut loop_engine = InferenceLoop::new(Arc::clone(&backend), model, tx)
+            .with_inference_deadline_ms(50)
+            .with_audit_client(mock.clone());
+        let mut stream = SimpleStream { next_id: 0 };
+
+        // Tick 1 — deadline breach. Must return WITHIN BUDGET (long before
+        // the 800 ms hang clears; the generous 500 ms assertion bound is
+        // slack for a loaded CI host, not the deadline itself).
+        let started = std::time::Instant::now();
+        let snap = loop_engine
+            .tick(stream.next_frame().unwrap(), SafetyPosture::Nominal)
+            .await
+            .unwrap();
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "the deadline must cut the hung backend off within budget; tick took {elapsed:?}"
+        );
+        assert_eq!(snap.active_command.linear_velocity, 0.0, "deadline breach → MRC stop");
+        assert!(snap.active_state_degraded, "deadline breach → degraded snapshot");
+        let faults = mock.faults();
+        assert_eq!(faults.len(), 1, "the breach must be audited exactly once");
+        assert_eq!(faults[0].code, "inference_deadline_exceeded");
+
+        // Tick 2 — straggler still hung: MRC again, and NO new inference is
+        // spawned (the watchdog half of WS-0.4: no blocking-thread pile-up).
+        let snap2 = loop_engine
+            .tick(stream.next_frame().unwrap(), SafetyPosture::Nominal)
+            .await
+            .unwrap();
+        assert_eq!(snap2.active_command.linear_velocity, 0.0);
+        assert!(snap2.active_state_degraded);
+        assert_eq!(
+            backend.runs.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "while hung, ticks must NOT stack more blocking tasks onto the wedged backend"
+        );
+        assert_eq!(mock.faults().len(), 1, "while-hung ticks do not re-audit the onset");
+
+        // Let the straggler finish, then tick 3 — the stale result is reaped
+        // and DISCARDED; fresh inference runs and the loop publishes it.
+        tokio::time::sleep(std::time::Duration::from_millis(900)).await;
+        let snap3 = loop_engine
+            .tick(stream.next_frame().unwrap(), SafetyPosture::Nominal)
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.runs.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "after the straggler clears, inference must resume"
+        );
+        assert_eq!(
+            snap3.active_command.linear_velocity, 0.5,
+            "recovery tick publishes the fresh backend output, not the stale straggler result"
+        );
+        assert!(!snap3.active_state_degraded, "recovered loop is healthy again");
+    }
+
+    /// The deadline must not fire on a slow-but-completing backend: the
+    /// existing `TestBackend` (200 ms) under the DEFAULT deadline (1000 ms)
+    /// completes normally — degraded by the latency THRESHOLD, but with the
+    /// real command, not an MRC stop. Pins the threshold/deadline separation.
+    #[tokio::test]
+    async fn slow_but_completing_backend_is_degraded_not_deadlined() {
+        let backend = Arc::new(TestBackend);
+        let model = backend.load_model("").unwrap();
+        let (tx, _rx) = mpsc::channel(4);
+        let mut loop_engine = InferenceLoop::new(backend, model, tx); // default deadline
+        let mut stream = SimpleStream { next_id: 0 };
+        let snap = loop_engine
+            .tick(stream.next_frame().unwrap(), SafetyPosture::Nominal)
+            .await
+            .unwrap();
+        assert!(snap.active_state_degraded, "200 ms latency trips the degraded THRESHOLD");
+        assert_eq!(
+            snap.active_command.linear_velocity, 1.5,
+            "a completed inference is clamped (1.5), not deadline-MRC'd to 0.0 — \
+             the 1000 ms deadline must not fire at 200 ms"
+        );
+    }
+
     // ── PARK-004 test helpers ────────────────────────────────────────────────
 
     /// Backend that returns a configurable linear velocity; no sleep.
@@ -817,7 +1087,7 @@ mod tests {
                 Just(f32::NEG_INFINITY),
             ]
         ) {
-            let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+            let rt = tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap();
             let (linear_vel, degraded) = rt.block_on(async {
                 let backend = Arc::new(ConfigurableBackend { linear: val });
                 let model = backend.load_model("").unwrap();
@@ -846,7 +1116,7 @@ mod tests {
         fn subnormal_model_output_does_not_panic(
             val in prop::num::f32::SUBNORMAL
         ) {
-            let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+            let rt = tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap();
             rt.block_on(async {
                 let backend = Arc::new(ConfigurableBackend { linear: val });
                 let model = backend.load_model("").unwrap();

--- a/parko/crates/parko-core/src/scheduler.rs
+++ b/parko/crates/parko-core/src/scheduler.rs
@@ -235,7 +235,22 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
         // frame that is no longer current) and resume normal inference.
         if let Some(straggler) = self.hung_inference.take() {
             if straggler.is_finished() {
-                let _ = straggler.await;
+                // A clean straggler result is discarded (stale frame); a
+                // JoinError means the blocking task PANICKED or was aborted
+                // — a backend-health signal worth auditing, not swallowing.
+                if let Err(e) = straggler.await {
+                    if let Some(a) = &self.audit {
+                        a.record_fault(FaultRecord {
+                            tick_ms: loop_start_ms,
+                            code: "inference_worker_join_failure",
+                            detail: format!(
+                                "deadline straggler died instead of returning \
+                                 (panic/abort in the blocking inference task): {e}"
+                            ),
+                            posture,
+                        });
+                    }
+                }
             } else {
                 self.hung_inference = Some(straggler);
                 self.last_validated_command =
@@ -904,7 +919,8 @@ mod tests {
     /// normal 0.5 m/s command on every later run. Models a wedged driver /
     /// EP stall that eventually clears. The hang is a BOUNDED sleep so the
     /// runtime's shutdown (which waits for blocking-pool threads) always
-    /// completes.
+    /// completes — sized to dwarf the 50 ms test deadline (anti-flake slack)
+    /// while keeping the suite fast.
     struct HangOnceBackend {
         hang_ms: u64,
         runs: std::sync::atomic::AtomicU32,
@@ -943,7 +959,7 @@ mod tests {
     async fn hung_backend_mrcs_within_budget_then_recovers() {
         use crate::audit::MockAuditClient;
         let backend = Arc::new(HangOnceBackend {
-            hang_ms: 800,
+            hang_ms: 400,
             runs: std::sync::atomic::AtomicU32::new(0),
         });
         let model = backend.load_model("").unwrap();
@@ -954,9 +970,10 @@ mod tests {
             .with_audit_client(mock.clone());
         let mut stream = SimpleStream { next_id: 0 };
 
-        // Tick 1 — deadline breach. Must return WITHIN BUDGET (long before
-        // the 800 ms hang clears; the generous 500 ms assertion bound is
-        // slack for a loaded CI host, not the deadline itself).
+        // Tick 1 — deadline breach. Must return WITHIN BUDGET — strictly
+        // before the 400 ms hang clears, so the timing itself proves the
+        // DEADLINE cut the tick off, not the backend completing. (The 300 ms
+        // assertion bound is slack for a loaded CI host, not the deadline.)
         let started = std::time::Instant::now();
         let snap = loop_engine
             .tick(stream.next_frame().unwrap(), SafetyPosture::Nominal)
@@ -964,7 +981,7 @@ mod tests {
             .unwrap();
         let elapsed = started.elapsed();
         assert!(
-            elapsed < std::time::Duration::from_millis(500),
+            elapsed < std::time::Duration::from_millis(300),
             "the deadline must cut the hung backend off within budget; tick took {elapsed:?}"
         );
         assert_eq!(snap.active_command.linear_velocity, 0.0, "deadline breach → MRC stop");
@@ -990,7 +1007,7 @@ mod tests {
 
         // Let the straggler finish, then tick 3 — the stale result is reaped
         // and DISCARDED; fresh inference runs and the loop publishes it.
-        tokio::time::sleep(std::time::Duration::from_millis(900)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         let snap3 = loop_engine
             .tick(stream.next_frame().unwrap(), SafetyPosture::Nominal)
             .await

--- a/parko/crates/parko-kirra/src/comparator.rs
+++ b/parko/crates/parko-kirra/src/comparator.rs
@@ -235,7 +235,8 @@ impl Default for DivState {
 /// On divergence beyond `COMPARATOR_TOLERANCE` on **either** axis (linear
 /// or angular — CERT-006 v3), the comparator commands a most-restrictive
 /// reconciliation of the two outputs as an `EnforcementAction::ClampMotion`
-/// (MRC-capped on linear, pure most-restrictive on angular). It escalates
+/// (MRC-capped on BOTH axes — WS-0.4: `MRC_VELOCITY_CEILING_MPS` on linear,
+/// the SOTIF-derived MRC `ω_max(v)` on angular). It escalates
 /// to LockedOut **only** when the divergence is persistent **AND** the
 /// vehicle is already at a safe speed — never as a hard stop at speed.
 ///
@@ -427,13 +428,19 @@ impl<S: SafetyGovernor> GovernorComparator<S> {
         // ---------------- Divergence path ----------------
 
         let reconciled_lin = reconcile(primary_lin, shadow_lin, MRC_VELOCITY_CEILING_MPS);
-        // Angular cap: no `MRC_ANGULAR_CEILING_RAD_S` exists in the
-        // codebase today, so use `f64::INFINITY` — pure most-restrictive
-        // min-of-magnitudes (sign and direction-disagreement handling are
-        // identical to the linear case via `reconcile`). FOLLOW-UP:
-        // introduce a proper MRC_ANGULAR_CEILING_RAD_S in parko-kirra and
-        // pass it here instead of INFINITY.
-        let angular_cap = f64::INFINITY;
+        // WS-0.4 — the angular reconciliation is capped by the SOTIF-derived
+        // MRC angular ceiling `ω_max(v)` (#136), evaluated at the RECONCILED
+        // linear velocity (matching `apply_mrc_profile`, which evaluates the
+        // bound at the post-clamp linear command). Divergence is a lost-trust
+        // condition, so the MRC (posture-derated) bound — not the Nominal one
+        // — is the envelope. The bound is read from the PRIMARY arm: the
+        // production wiring configures both arms with identical platform
+        // params by construction (a mismatched shadow would spuriously
+        // diverge on every tick anyway). Replaces the interim
+        // `f64::INFINITY` pure min-of-magnitudes, which left the reconciled
+        // yaw rate unbounded whenever both governors admitted a
+        // large-but-differing angular command.
+        let angular_cap = self.primary.mrc_omega_max(reconciled_lin);
         let reconciled_ang = reconcile(primary_ang, shadow_ang, angular_cap);
 
         // Best-available current-speed proxy. There is no measured-speed
@@ -666,6 +673,106 @@ mod tests {
         assert!(
             v.abs() <= MRC_VELOCITY_CEILING_MPS + COMPARATOR_TOLERANCE,
             "Reconciled linear magnitude must be at or below MRC ceiling. Got {v}"
+        );
+    }
+
+    /// WS-0.4 DoD — "angular divergence bounded": when both arms admit a
+    /// large but DIFFERING yaw rate, the reconciled angular command is
+    /// capped at the primary's MRC angular ceiling `ω_max(v)`, not merely
+    /// the smaller of the two outputs. (Pre-WS-0.4 the cap was
+    /// `f64::INFINITY` — pure min-of-magnitudes — so a 3-vs-2 rad/s
+    /// divergence commanded a 2 rad/s yaw under lost trust.)
+    #[test]
+    fn angular_divergence_is_capped_at_the_mrc_angular_ceiling() {
+        /// Shadow that agrees on the linear axis (passes the proposal
+        /// through) but clamps yaw to a fixed large value — forcing an
+        /// angular-only divergence with BOTH effective yaw rates far above
+        /// the MRC angular ceiling.
+        struct FixedAngularClamp(f64);
+        impl parko_core::safety::SafetyGovernor for FixedAngularClamp {
+            fn evaluate(
+                &self,
+                _proposed: &ControlCommand,
+                _previous: Option<&ControlCommand>,
+                _delta_time_s: f64,
+                _posture: SafetyPosture,
+            ) -> EnforcementAction {
+                EnforcementAction::ClampAngularVelocity(self.0)
+            }
+        }
+
+        // Scalar bounds make the numbers exact: Nominal ω ≤ 5.0 (admits the
+        // 3.0 rad/s proposal), MRC ω ceiling 0.4.
+        let mut primary = KirraGovernor::new().with_angular_bounds(5.0, 0.4);
+        primary.update_rss_state(safe_rss());
+        let comparator = GovernorComparator::new(primary, FixedAngularClamp(2.0));
+
+        let proposed = ControlCommand {
+            linear_velocity: 1.0,
+            angular_velocity: 3.0,
+            timestamp_ms: 0,
+        };
+        let prev = proposed.clone();
+        let out = comparator.evaluate(&proposed, Some(&prev), 0.05, SafetyPosture::Nominal);
+
+        assert!(
+            matches!(out, EnforcementAction::ClampMotion { .. }),
+            "an angular-only divergence must reconcile to ClampMotion, got {out:?}"
+        );
+        let ang = effective_angular_velocity(&out, proposed.angular_velocity);
+        assert!(
+            ang.abs() <= 0.4 + COMPARATOR_TOLERANCE,
+            "reconciled yaw must be capped at the MRC angular ceiling (0.4 rad/s); \
+             got {ang} — min-of-magnitudes alone would have commanded 2.0"
+        );
+        assert!(ang > 0.0, "the cap must preserve the agreed yaw direction");
+        // The agreed linear axis passes through the reconciliation unharmed.
+        let lin = effective_linear_velocity(&out, proposed.linear_velocity);
+        assert!(
+            (lin - 1.0).abs() <= COMPARATOR_TOLERANCE,
+            "the agreed linear axis must survive an angular-only divergence; got {lin}"
+        );
+    }
+
+    /// WS-0.4 — with the default (derived) bounds, the reconciled yaw under
+    /// divergence never exceeds `AngularVelocityBound::mrc(...)`'s ω_max at
+    /// the reconciled linear velocity — pinning that the comparator uses the
+    /// POSTURE-DERATED bound, not the looser Nominal one.
+    #[test]
+    fn angular_divergence_cap_uses_the_derated_mrc_bound() {
+        struct FixedAngularClamp(f64);
+        impl parko_core::safety::SafetyGovernor for FixedAngularClamp {
+            fn evaluate(
+                &self,
+                _proposed: &ControlCommand,
+                _previous: Option<&ControlCommand>,
+                _delta_time_s: f64,
+                _posture: SafetyPosture,
+            ) -> EnforcementAction {
+                EnforcementAction::ClampAngularVelocity(self.0)
+            }
+        }
+        use crate::angular_bound::{AngularVelocityBound, PlatformParams};
+
+        let mut primary = KirraGovernor::new(); // conservative-default derived bounds
+        primary.update_rss_state(safe_rss());
+        let comparator = GovernorComparator::new(primary, FixedAngularClamp(10.0));
+
+        // In-place rotation request far above every bound.
+        let proposed = ControlCommand {
+            linear_velocity: 0.0,
+            angular_velocity: 12.0,
+            timestamp_ms: 0,
+        };
+        let prev = proposed.clone();
+        let out = comparator.evaluate(&proposed, Some(&prev), 0.05, SafetyPosture::Nominal);
+
+        let ang = effective_angular_velocity(&out, proposed.angular_velocity);
+        let mrc_ceiling =
+            AngularVelocityBound::mrc(PlatformParams::conservative_default()).omega_max(0.0);
+        assert!(
+            ang.abs() <= mrc_ceiling + COMPARATOR_TOLERANCE,
+            "reconciled yaw {ang} must be ≤ the derated MRC ω_max(0) = {mrc_ceiling}"
         );
     }
 

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -675,6 +675,16 @@ impl KirraGovernor {
         }
     }
 
+    /// WS-0.4 — the MRC angular-velocity ceiling `ω_max(v)` (rad/s) at a
+    /// given linear velocity: the SAME SOTIF-derived bound
+    /// `apply_mrc_profile` enforces (#136), exposed for the comparator's
+    /// divergence reconciliation, which caps the reconciled yaw rate with
+    /// the primary arm's MRC envelope. Always non-negative and finite
+    /// (`AngularVelocityBound::omega_max` masks the v→0 singularity).
+    pub(crate) fn mrc_omega_max(&self, linear_velocity_mps: f64) -> f64 {
+        self.mrc_angular_bound.omega_max(linear_velocity_mps.abs())
+    }
+
     /// Applies the Nominal angular-velocity ceiling to a proposed command,
     /// returning the clamped magnitude (sign-preserved) when the bound is
     /// exceeded, else `None`.

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -218,6 +218,7 @@ fn build_loop<B>(
     backend: Arc<B>,
     model_path: &str,
     tick_period_s: f64,
+    inference_deadline_ms: u64,
     platform_profile: Option<&CourierPlatformProfile>,
     external_rss_gate: bool,
 ) -> Arc<Mutex<InferenceLoop<B>>>
@@ -295,7 +296,10 @@ where
     };
     let infer = InferenceLoop::new(backend, model, actuator_tx)
         .with_governor(ComparatorAsGovernor(comparator))
-        .with_tick_period(tick_period_s);
+        .with_tick_period(tick_period_s)
+        // WS-0.4: a backend that never returns MRCs the tick within this
+        // bound instead of stalling the drain loop forever.
+        .with_inference_deadline_ms(inference_deadline_ms);
     Arc::new(Mutex::new(infer))
 }
 
@@ -381,6 +385,19 @@ fn build_config() -> ParkoNodeConfig {
             ),
         }
     }
+    // WS-0.4: per-tick inference deadline override. Always on (the default is
+    // hang-scale, 1000 ms); a non-positive / unparsable value keeps the default.
+    if let Ok(raw) = std::env::var("PARKO_INFERENCE_DEADLINE_MS") {
+        match raw.trim().parse::<u64>() {
+            Ok(v) if v > 0 => config.inference_deadline_ms = v,
+            _ => tracing::warn!(
+                value = %raw,
+                "parko-ros2: PARKO_INFERENCE_DEADLINE_MS is not a positive integer — keeping the \
+                 default {} ms",
+                config.inference_deadline_ms
+            ),
+        }
+    }
     // WS-0.1 (#G2) opt-in flags. `1`/`true` (case-insensitive) enable; anything
     // else keeps the fail-closed default.
     config.allow_motion_without_object_perception =
@@ -460,6 +477,7 @@ async fn main() {
         backend,
         &model_path,
         config.tick_period_s,
+        config.inference_deadline_ms,
         config.platform_profile.as_ref(),
         external_rss_gate,
     );

--- a/parko/crates/parko-ros2/src/config.rs
+++ b/parko/crates/parko-ros2/src/config.rs
@@ -38,6 +38,17 @@ pub struct ParkoNodeConfig {
     /// `POSTURE_STALENESS_TIMEOUT_MS` in M1b.
     pub sensor_staleness_budget_ms: u64,
 
+    /// WS-0.4 — per-tick inference deadline, ms (threaded into
+    /// `InferenceLoop::with_inference_deadline_ms`). The HARD bound on how
+    /// long a tick waits for the backend before failing closed to a stopped
+    /// command; a backend that never returns (wedged driver / EP stall)
+    /// previously stalled the drain loop forever. Always on; default
+    /// `parko_core::scheduler::DEFAULT_INFERENCE_DEADLINE_MS` (1000 ms —
+    /// generous, so it fires only on a genuine hang, never on latency
+    /// jitter; the 150 ms latency THRESHOLD handles slow-but-completing
+    /// ticks). Env: `PARKO_INFERENCE_DEADLINE_MS` (positive integer).
+    pub inference_deadline_ms: u64,
+
     /// MRC fallback published when a sensor input is stale or
     /// inference fails. Always a stopped twist (linear = angular = 0)
     /// per the M1 / parko-kirra discipline. Stored as a field so the
@@ -177,6 +188,8 @@ impl Default for ParkoNodeConfig {
             command_topic: "~/output/cmd_vel".to_string(),
             tick_period_s: 0.05,
             sensor_staleness_budget_ms: 200,
+            // WS-0.4: hung-backend deadline — always on, hang-scale default.
+            inference_deadline_ms: parko_core::scheduler::DEFAULT_INFERENCE_DEADLINE_MS,
             mrc_command: OutgoingTwistDefaults,
             num_threads: 1,
             // SG6 detection sources default OFF — a missing sensor is reduced

--- a/parko/crates/parko-ros2/src/tick_pipeline.rs
+++ b/parko/crates/parko-ros2/src/tick_pipeline.rs
@@ -579,9 +579,11 @@ mod tick_pipeline_tests {
             "1000 m/s must be CLAMPED by the governor envelope, never admitted as-is; got {v}");
     }
 
-    /// A backend that hangs (bounded 800 ms real sleep — the runtime's
+    /// A backend that hangs (bounded 400 ms real sleep — the runtime's
     /// shutdown waits for blocking threads, so an unbounded hang would wedge
-    /// the test itself) and would emit a moving command if ever awaited.
+    /// the test itself; 400 ms dwarfs the 50 ms deadline for anti-flake
+    /// slack without slowing the suite) and would emit a moving command if
+    /// ever awaited.
     #[derive(Debug)]
     struct HangingBackend;
     impl parko_core::backend::InferenceBackend for HangingBackend {
@@ -601,7 +603,7 @@ mod tick_pipeline_tests {
             _model: &parko_core::backend::ModelHandle,
             _inputs: &TensorBatch,
         ) -> Result<TensorBatch<'static>, parko_core::backend::BackendError> {
-            std::thread::sleep(std::time::Duration::from_millis(800));
+            std::thread::sleep(std::time::Duration::from_millis(400));
             let mut map = HashMap::new();
             map.insert(
                 "cmd_vel_linear".to_string(),
@@ -645,8 +647,10 @@ mod tick_pipeline_tests {
                 .await;
         let elapsed = started.elapsed();
 
+        // Strictly below the 400 ms hang: the timing proves the DEADLINE cut
+        // the tick off, not the backend completing.
         assert!(
-            elapsed < std::time::Duration::from_millis(500),
+            elapsed < std::time::Duration::from_millis(300),
             "a hung backend must not stall the tick; took {elapsed:?}"
         );
         assert_eq!(outcome.twist.linear_x_mps, 0.0,

--- a/parko/crates/parko-ros2/src/tick_pipeline.rs
+++ b/parko/crates/parko-ros2/src/tick_pipeline.rs
@@ -105,7 +105,7 @@ pub struct TickOutcome {
 /// uncontended in practice (one drain task drives the loop) but the
 /// `&mut`-receiver shape requires interior mutability.
 ///
-// SAFETY: SG8 SG9 | REQ: parko-ros2-tick-fail-closed | TEST: tick_with_finite_inference_publishes_governed_command,tick_with_stale_sensor_input_publishes_stopped_twist,tick_with_zero_inference_publishes_stopped_twist,tick_with_locked_out_posture_publishes_stopped_twist
+// SAFETY: SG8 SG9 | REQ: parko-ros2-tick-fail-closed | TEST: tick_with_finite_inference_publishes_governed_command,tick_with_stale_sensor_input_publishes_stopped_twist,tick_with_zero_inference_publishes_stopped_twist,tick_with_locked_out_posture_publishes_stopped_twist,fault_hung_backend_mrcs_the_tick_within_budget
 pub async fn run_pipeline_tick<B>(
     config:      &ParkoNodeConfig,
     loop_mutex:  Arc<Mutex<InferenceLoop<B>>>,
@@ -577,6 +577,84 @@ mod tick_pipeline_tests {
         assert!(v >= 0.0, "must not flip sign, got {v}");
         assert!(v < 1000.0,
             "1000 m/s must be CLAMPED by the governor envelope, never admitted as-is; got {v}");
+    }
+
+    /// A backend that hangs (bounded 800 ms real sleep — the runtime's
+    /// shutdown waits for blocking threads, so an unbounded hang would wedge
+    /// the test itself) and would emit a moving command if ever awaited.
+    #[derive(Debug)]
+    struct HangingBackend;
+    impl parko_core::backend::InferenceBackend for HangingBackend {
+        fn load_model(
+            &self,
+            path: &str,
+        ) -> Result<parko_core::backend::ModelHandle, parko_core::backend::BackendError> {
+            Ok(parko_core::backend::ModelHandle {
+                model_id: format!("hanging::{path}"),
+                input_shapes: HashMap::new(),
+                output_shapes: HashMap::new(),
+                expected_precision: parko_core::backend::PrecisionMode::FP32,
+            })
+        }
+        fn run(
+            &self,
+            _model: &parko_core::backend::ModelHandle,
+            _inputs: &TensorBatch,
+        ) -> Result<TensorBatch<'static>, parko_core::backend::BackendError> {
+            std::thread::sleep(std::time::Duration::from_millis(800));
+            let mut map = HashMap::new();
+            map.insert(
+                "cmd_vel_linear".to_string(),
+                parko_core::backend::TensorStorage::Owned(vec![2.0_f32]),
+            );
+            map.insert(
+                "cmd_vel_angular".to_string(),
+                parko_core::backend::TensorStorage::Owned(vec![0.0_f32]),
+            );
+            Ok(TensorBatch { named_tensors: map, metadata: HashMap::new() })
+        }
+        fn descriptor(&self) -> BackendDescriptor {
+            BackendDescriptor::Cpu
+        }
+    }
+
+    /// WS-0.4 DoD at the TICK level — "hung-backend test MRCs within budget":
+    /// a wedged backend must not stall `run_pipeline_tick`; the deadline MRCs
+    /// the tick (stopped twist, degraded) well before the backend would have
+    /// answered. REAL time (not `start_paused`) — the deadline race against a
+    /// blocking thread is exactly what is under test.
+    #[tokio::test]
+    async fn fault_hung_backend_mrcs_the_tick_within_budget() {
+        let backend = Arc::new(HangingBackend);
+        let model = backend.load_model("test.onnx").expect("model loads");
+        let (tx, _rx) = mpsc::channel::<ControlCommand>(8);
+        let comparator = GovernorComparator::new(
+            KirraGovernor::new().with_external_rss_gate(),
+            KirraGovernor::new().with_external_rss_gate(),
+        );
+        let infer = Arc::new(Mutex::new(
+            InferenceLoop::new(backend, model, tx)
+                .with_governor(ComparatorAsGovernor(comparator))
+                .with_tick_period(0.05)
+                .with_inference_deadline_ms(50),
+        ));
+
+        let started = std::time::Instant::now();
+        let outcome =
+            run_pipeline_tick(&default_config(), infer, make_frame(105, 0), SafetyPosture::Nominal)
+                .await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "a hung backend must not stall the tick; took {elapsed:?}"
+        );
+        assert_eq!(outcome.twist.linear_x_mps, 0.0,
+            "deadline breach must publish a stopped twist (linear=0)");
+        assert_eq!(outcome.twist.angular_z_rads, 0.0,
+            "deadline breach must publish a stopped twist (angular=0)");
+        assert!(outcome.degraded,
+            "the deadline-MRC snapshot must be flagged degraded for the audit ledger");
     }
 
     /// FAULT: the inference backend itself errors. ASSERT fail-closed — the


### PR DESCRIPTION
**PR 4 of the product execution plan (WS-0.4) — closes gap-analysis G8 (deadline axis) and the G20 angular-cap item.**

## Defect 1 — a hung backend stalled the loop forever

`InferenceLoop::tick` awaited the `spawn_blocking` inference join with **no bound**: a wedged driver / EP stall froze the tick — and with it the node's entire drain loop — so no command (not even MRC) was ever published again. The 150 ms latency *threshold* only flags a slow-but-**completed** inference; nothing bounded one that never completes.

**The deadline.** `tick` now bounds the join with `tokio::time::timeout` (`DEFAULT_INFERENCE_DEADLINE_MS = 1000` — hang-scale, 20× the tick period, so it fires on a genuine hang, never latency jitter; tune via `with_inference_deadline_ms` / `PARKO_INFERENCE_DEADLINE_MS`; always on, floor 1 ms). On breach: an audited `inference_deadline_exceeded` fault, `last_validated_command` set to a **stop** (the next flush carries a stop, and Degraded's no-re-initiation gate then holds at zero), and a stopped, degraded snapshot.

**The watchdog.** A blocking task can't be cancelled, so the straggler's handle is parked in `hung_inference`. While it runs, subsequent ticks fail fast to MRC **without spawning more inference** — no blocking-thread pile-up on a wedged backend. When it finishes, its stale result is reaped and **discarded** and normal inference resumes automatically. While-hung ticks don't re-audit (a 20 Hz loop would flood the ledger); the onset fault plus the degraded MRC snapshots are the record.

**Plumbing:** `ParkoNodeConfig.inference_deadline_ms` → `build_loop`, env parsing matching the adjacent knobs (invalid → warn + keep default). Harness fix: two proptest runtimes needed `.enable_time()` (the deadline requires a timer driver).

## Defect 2 — unbounded yaw under lost trust

`GovernorComparator`'s divergence reconciliation capped the linear axis at `MRC_VELOCITY_CEILING_MPS` but the angular axis at `f64::INFINITY` — its own comment named the missing ceiling as a follow-up. Two governors admitting a large-but-differing yaw (9 vs 8 rad/s) commanded 8 rad/s *while trust was already lost*.

The cap is now the **SOTIF-derived MRC angular ceiling `ω_max(v)`** (#136) from the primary arm's `mrc_angular_bound`, evaluated at the *reconciled* linear velocity — the same posture-derated bound `apply_mrc_profile` enforces — rather than resurrecting the removed scalar placeholder. Divergence is a lost-trust condition, so the derated MRC bound (not Nominal) is the envelope. Direction-disagreement → 0 is unchanged; the agreed linear axis passes through unharmed.

## DoD

- **"Hung-backend test MRCs within budget"** — `hung_backend_mrcs_within_budget_then_recovers` (scheduler level: the deadline cuts an 800 ms hang off within budget; while-hung ticks spawn **no** new inference, pinned via run count; recovery discards the stale straggler result and resumes) and `fault_hung_backend_mrcs_the_tick_within_budget` (tick level, **real time not `start_paused`** — the deadline race against a blocking thread is what's under test; stopped twist, degraded, wall-clock bounded). Plus `slow_but_completing_backend_is_degraded_not_deadlined` pinning the threshold/deadline separation (200 ms latency → degraded-but-clamped, never deadline-MRC'd).
- **"Angular divergence bounded"** — `angular_divergence_is_capped_at_the_mrc_angular_ceiling` (exact scalar numbers: min-of-magnitudes alone would command 2.0 rad/s, the cap yields 0.4) and `angular_divergence_cap_uses_the_derated_mrc_bound` (derived conservative-default bounds; reconciled yaw ≤ MRC `ω_max(0)`, not the looser Nominal bound).

Note: paused-clock safety was verified empirically — tokio 1.52 inhibits auto-advance while a `spawn_blocking` task is in flight, so the existing `start_paused` tick tests can't spuriously trip the deadline.

parko workspace: 24 suites green; the 4 `parko-openvino` failures are pre-existing environment gaps (missing OpenVINO/ORT runtime — identical on clean main). Clippy: no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_