### PR TITLE
verifier: mount /metrics — Prometheus fleet-safety series (WS-0.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,7 @@ pass that fits the corridor, rejects one that doesn't or a misaligned straight-t
 
 ### Public read-only
 - `GET /health`, `GET /ready`
+- `GET /metrics` — Prometheus fleet-safety series (WS-0.5); posture-exempt so the scrape survives LockedOut
 - `GET /attestation/status/:node_id`
 - `GET /fleet/posture`, `GET /fleet/posture/:node_id`
 - `GET /fleet/history/:node_id`, `GET /fleet/flapping/:node_id`

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -1565,7 +1565,11 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
 
     let probe_routes = Router::new()
         .route("/health", get(health))
-        .route("/ready", get(ready));
+        .route("/ready", get(ready))
+        // WS-0.5 — Prometheus fleet-safety series. Public read-only;
+        // posture-exempt (pre-allowlisted in `is_posture_exempt`) so the
+        // scrape survives LockedOut.
+        .route("/metrics", get(metrics_endpoint));
 
     let read_routes = Router::new()
         .route("/attestation/status/{node_id}", get(get_node_status))
@@ -1879,6 +1883,92 @@ mod posture_gate_real_router_tests {
             locked,
             StatusCode::SERVICE_UNAVAILABLE,
             "LockedOut must still 503 at the posture gate even authenticated; got {locked}"
+        );
+    }
+
+    /// WS-0.5 DoD — "Prometheus scrape returns fleet-safety series", proven
+    /// on the REAL assembled router UNDER LockedOut (the scrape must survive
+    /// exactly the posture it exists to observe). Asserts reachability, the
+    /// exposition content type, every fleet-safety family, the fail-closed
+    /// posture gauge value, and that a denial that just happened is visible
+    /// on the labeled counter — the series are live, not just present.
+    #[tokio::test]
+    async fn metrics_scrape_returns_fleet_safety_series_under_lockedout() {
+        let svc = state_with(FleetPosture::LockedOut);
+
+        // A functional read denied by the gate first, so the scrape can show
+        // a non-zero locked_out denial.
+        let denied =
+            status_through_real_app(Arc::clone(&svc), "GET", "/fleet/posture").await;
+        assert_eq!(
+            denied,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "precondition: LockedOut denies the functional read"
+        );
+
+        let resp = build_app(Arc::clone(&svc))
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router service should not panic");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "/metrics must remain reachable under LockedOut (posture-exempt)"
+        );
+        let content_type = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        assert!(
+            content_type.starts_with("text/plain"),
+            "Prometheus text exposition content type expected; got {content_type:?}"
+        );
+
+        let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+            .await
+            .expect("read body");
+        let text = String::from_utf8(bytes.to_vec()).expect("utf8 exposition");
+
+        for family in [
+            "kirra_fleet_posture{",
+            "kirra_posture_cache_stale{",
+            "kirra_posture_generation{",
+            "kirra_mode_active{",
+            "kirra_posture_transitions_total{",
+            "kirra_gate_denials_total{",
+            "kirra_ha_promotions_total{",
+            "kirra_audit_write_drops_total{",
+            "kirra_capture_drops_total{",
+            "kirra_post_incident_write_failures_total{",
+            "kirra_command_source_write_failures_total{",
+        ] {
+            assert!(
+                text.contains(family),
+                "the scrape must contain the {family} series; got:\n{text}"
+            );
+        }
+
+        // The live LockedOut posture reads 2 on the gauge (fresh cache → not
+        // the stale-synthetic flavor).
+        assert!(
+            text.lines()
+                .any(|l| l.starts_with("kirra_fleet_posture{") && l.ends_with(" 2")),
+            "the posture gauge must read 2 (LockedOut); got:\n{text}"
+        );
+        // The denied read above is visible on the labeled denial counter.
+        assert!(
+            text.lines().any(|l| l.starts_with("kirra_gate_denials_total{")
+                && l.contains("reason=\"locked_out\"")
+                && l.ends_with(" 1")),
+            "the LockedOut denial must be counted on the labeled series; got:\n{text}"
         );
     }
 

--- a/src/bin/kirra_verifier_service/fleet.rs
+++ b/src/bin/kirra_verifier_service/fleet.rs
@@ -40,6 +40,50 @@ pub(crate) async fn ready(State(svc): State<Arc<ServiceState>>) -> impl IntoResp
     }
 }
 
+/// WS-0.5 — `GET /metrics`: Prometheus text exposition (0.0.4) of the
+/// fleet-safety series (posture gauge, committed transitions, gate denials
+/// by reason, HA promotions, audit/capture drop counters). Public read-only
+/// and posture-exempt (pre-allowlisted in `is_posture_exempt`): the scrape
+/// must survive LockedOut — that is exactly when an operator needs it. No
+/// secrets: counters and posture state only.
+pub(crate) async fn metrics_endpoint(State(svc): State<Arc<ServiceState>>) -> impl IntoResponse {
+    use std::sync::atomic::Ordering;
+
+    // Effective fail-closed posture via the single TTL authority — the gauge
+    // reports what the ROUTING GATE would enforce (cold/stale/poisoned →
+    // LockedOut), not a possibly-stale cached optimism.
+    let (effective_posture, stale_reason) =
+        resolve_posture_with_reason(&svc.posture_cache, POSTURE_CACHE_TTL_MS);
+    let posture_generation = svc
+        .posture_cache
+        .read()
+        .ok()
+        .and_then(|g| g.as_ref().map(|c| c.generation))
+        .unwrap_or(0);
+
+    let snap = kirra_verifier::metrics::FleetMetricsSnapshot {
+        effective_posture,
+        posture_cache_stale: stale_reason.is_some(),
+        posture_generation,
+        mode_active: svc.app.is_active(),
+        audit_write_drops: svc.app.audit_write_drops.load(Ordering::SeqCst),
+        capture_drops: svc.app.capture_drops.load(Ordering::SeqCst),
+        post_incident_write_failures: svc.app.post_incident_write_failures.load(Ordering::SeqCst),
+        command_source_write_failures: svc
+            .app
+            .command_source_write_failures
+            .load(Ordering::SeqCst),
+    };
+    let body = svc
+        .app
+        .fleet_metrics
+        .format_prometheus(&kirra_verifier::standby_monitor::instance_id(), &snap);
+    (
+        [(axum::http::header::CONTENT_TYPE, "text/plain; version=0.0.4")],
+        body,
+    )
+}
+
 pub(crate) async fn export_backup(State(svc): State<Arc<ServiceState>>) -> impl IntoResponse {
     let exported_at_ms = now_ms();
     // Three full-table loads (nodes + dependencies + all posture events) — the

--- a/src/bin/kirra_verifier_service/fleet.rs
+++ b/src/bin/kirra_verifier_service/fleet.rs
@@ -66,13 +66,16 @@ pub(crate) async fn metrics_endpoint(State(svc): State<Arc<ServiceState>>) -> im
         posture_cache_stale: stale_reason.is_some(),
         posture_generation,
         mode_active: svc.app.is_active(),
-        audit_write_drops: svc.app.audit_write_drops.load(Ordering::SeqCst),
-        capture_drops: svc.app.capture_drops.load(Ordering::SeqCst),
-        post_incident_write_failures: svc.app.post_incident_write_failures.load(Ordering::SeqCst),
+        // Relaxed: monotonic observability counters — a best-effort snapshot
+        // needs no ordering with other memory, and the scrape path should not
+        // pay SeqCst fences.
+        audit_write_drops: svc.app.audit_write_drops.load(Ordering::Relaxed),
+        capture_drops: svc.app.capture_drops.load(Ordering::Relaxed),
+        post_incident_write_failures: svc.app.post_incident_write_failures.load(Ordering::Relaxed),
         command_source_write_failures: svc
             .app
             .command_source_write_failures
-            .load(Ordering::SeqCst),
+            .load(Ordering::Relaxed),
     };
     let body = svc
         .app

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -605,7 +605,14 @@ pub async fn enforce_posture_routing(
         // and any audit work, so an epoch change during the actuator write is
         // caught at the final authority boundary too.
         OperationalCommand::ActuatorMotion => {
-            assert_actuator_epoch_or_demote(&svc, "POST", "/actuator/motion/command").await?;
+            assert_actuator_epoch_or_demote(&svc, "POST", "/actuator/motion/command")
+                .await
+                .inspect_err(|_| {
+                    // WS-0.5: count the authority-fence denial for /metrics.
+                    svc.app
+                        .fleet_metrics
+                        .record_gate_denial(crate::metrics::GateDenialReason::HaFenced);
+                })?;
         }
         // Other mutations keep the fast CACHED epoch check (Pass B1): they ARE
         // backstopped by the in-transaction `assert_epoch_held` on their durable
@@ -628,6 +635,10 @@ pub async fn enforce_posture_routing(
                     db     = db,
                     "FENCED — held epoch stale; self-demoting and rejecting mutation (HA split-brain prevention)"
                 );
+                // WS-0.5: count the fence denial for /metrics.
+                svc.app
+                    .fleet_metrics
+                    .record_gate_denial(crate::metrics::GateDenialReason::HaFenced);
                 return Err(StatusCode::SERVICE_UNAVAILABLE);
             }
         }
@@ -644,16 +655,123 @@ pub async fn enforce_posture_routing(
         Err(_) => None,
     };
 
-    if !should_route_command(&snapshot, posture_now_ms(), cmd) {
+    let gate_now_ms = posture_now_ms();
+    if !should_route_command(&snapshot, gate_now_ms, cmd) {
+        let reason = classify_gate_denial(&snapshot, gate_now_ms, cmd);
+        // WS-0.5: count the dropped command for /metrics, labeled by reason.
+        svc.app.fleet_metrics.record_gate_denial(reason);
         tracing::warn!(
             method = %method,
             path = %path,
             command = ?cmd,
+            deny_reason = reason.as_label(),
             "posture-routing gate denied command (fail-closed)"
         );
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     }
     Ok(next.run(req).await)
+}
+
+/// WS-0.5 — derive the metrics label for a `should_route_command` denial.
+/// OBSERVABILITY ONLY: this mirrors `should_route_command`'s decision order
+/// (Unknown first, then cache presence, then staleness, then posture) but
+/// never influences it — the gate's verdict is already made when this runs.
+fn classify_gate_denial(
+    snapshot: &Option<CachedFleetPosture>,
+    now_ms: u64,
+    cmd: OperationalCommand,
+) -> crate::metrics::GateDenialReason {
+    use crate::metrics::GateDenialReason as R;
+    if cmd == OperationalCommand::Unknown {
+        return R::UnknownCommand;
+    }
+    match snapshot {
+        None => R::PostureCacheEmpty,
+        Some(c) if c.is_stale(now_ms) => R::PostureCacheStale,
+        Some(c) => match c.posture {
+            crate::verifier::FleetPosture::LockedOut => R::LockedOut,
+            // A denial with a fresh cache and a non-Unknown command can only
+            // be a Degraded write (`should_route_command` admits everything
+            // else under Nominal, and ReadTelemetry / the ActuatorMotion
+            // deferral under Degraded).
+            _ => R::DegradedWriteDenied,
+        },
+    }
+}
+
+#[cfg(test)]
+mod gate_denial_metrics_tests {
+    use super::*;
+    use crate::metrics::GateDenialReason as R;
+    use crate::posture_cache::POSTURE_CACHE_TTL_MS;
+    use crate::verifier::FleetPosture;
+
+    fn fresh(posture: FleetPosture, now: u64) -> Option<CachedFleetPosture> {
+        Some(CachedFleetPosture {
+            posture,
+            generated_at_ms: now,
+            ttl_ms: POSTURE_CACHE_TTL_MS,
+            generation: 1,
+        })
+    }
+
+    /// WS-0.5 — the denial classifier mirrors `should_route_command`'s
+    /// decision order: Unknown before the cache is consulted, then cache
+    /// presence, then staleness, then posture.
+    #[test]
+    fn classifier_mirrors_the_gate_decision_order() {
+        let now = 1_000_000u64;
+        // Unknown wins even with a fresh Nominal cache.
+        assert_eq!(
+            classify_gate_denial(&fresh(FleetPosture::Nominal, now), now, OperationalCommand::Unknown),
+            R::UnknownCommand
+        );
+        // Cold cache.
+        assert_eq!(
+            classify_gate_denial(&None, now, OperationalCommand::ReadTelemetry),
+            R::PostureCacheEmpty
+        );
+        // Stale cache (aged past TTL) beats its recorded posture.
+        let stale = fresh(FleetPosture::Nominal, now);
+        assert_eq!(
+            classify_gate_denial(&stale, now + POSTURE_CACHE_TTL_MS + 1, OperationalCommand::ReadTelemetry),
+            R::PostureCacheStale
+        );
+        // Fresh LockedOut.
+        assert_eq!(
+            classify_gate_denial(&fresh(FleetPosture::LockedOut, now), now, OperationalCommand::ReadTelemetry),
+            R::LockedOut
+        );
+        // Fresh Degraded + a denied write.
+        assert_eq!(
+            classify_gate_denial(&fresh(FleetPosture::Degraded, now), now, OperationalCommand::SystemMutation),
+            R::DegradedWriteDenied
+        );
+    }
+
+    /// The classifier agrees with `should_route_command` on every denied
+    /// combination it labels: whenever the gate denies, the classifier's
+    /// reason is consistent with the input that caused the denial (and the
+    /// classifier is never consulted on admitted commands).
+    #[test]
+    fn classifier_is_only_meaningful_where_the_gate_denies() {
+        let now = 1_000_000u64;
+        let cases = [
+            (fresh(FleetPosture::Nominal, now), OperationalCommand::Unknown),
+            (None, OperationalCommand::WriteState),
+            (fresh(FleetPosture::LockedOut, now), OperationalCommand::ReadTelemetry),
+            (fresh(FleetPosture::Degraded, now), OperationalCommand::WriteState),
+        ];
+        for (snapshot, cmd) in cases {
+            assert!(
+                !should_route_command(&snapshot, now, cmd),
+                "test premise: the gate denies ({snapshot:?}, {cmd:?})"
+            );
+            // Classification must not panic and must produce a stable label.
+            let label = classify_gate_denial(&snapshot, now, cmd).as_label();
+            assert!(!label.is_empty());
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,6 +2,289 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use crate::verifier::FleetPosture;
+
+/// WS-0.5 — why the posture-routing gate denied a request. Mirrors
+/// `should_route_command`'s decision order exactly (see
+/// `classify_gate_denial` in `gateway::policy_layer`), plus the HA
+/// authority fence. A FIXED label set — Prometheus label cardinality
+/// must stay bounded, so new deny causes get new variants here, never
+/// free-form strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateDenialReason {
+    /// The request classified as `OperationalCommand::Unknown` (denied in
+    /// every posture, before the cache is even consulted).
+    UnknownCommand,
+    /// Posture cache held `None` (cold start / reset) or its lock was
+    /// poisoned — no posture evidence, fail closed.
+    PostureCacheEmpty,
+    /// Posture cache entry aged past its TTL — stale evidence, fail closed.
+    PostureCacheStale,
+    /// Fleet posture is `LockedOut` — everything is denied.
+    LockedOut,
+    /// Fleet posture is `Degraded` and the command is a write that is not
+    /// the decel-gated `ActuatorMotion` deferral (ADR-0011 Option A).
+    DegradedWriteDenied,
+    /// The HA authority fence rejected a mutation: this instance's held
+    /// epoch is stale (another instance promoted) or actuator authority
+    /// could not be verified — self-demote + deny.
+    HaFenced,
+}
+
+impl GateDenialReason {
+    /// The stable Prometheus label value.
+    pub fn as_label(self) -> &'static str {
+        match self {
+            Self::UnknownCommand      => "unknown_command",
+            Self::PostureCacheEmpty   => "posture_cache_empty",
+            Self::PostureCacheStale   => "posture_cache_stale",
+            Self::LockedOut           => "locked_out",
+            Self::DegradedWriteDenied => "degraded_write_denied",
+            Self::HaFenced            => "ha_fenced",
+        }
+    }
+}
+
+/// WS-0.5 — point-in-time gauge values the `/metrics` handler reads from
+/// live service state at scrape time (they are not accumulated counters).
+/// Constructed by the binary's handler; passed to
+/// [`FleetSafetyMetrics::format_prometheus`].
+#[derive(Debug, Clone, Copy)]
+pub struct FleetMetricsSnapshot {
+    /// The EFFECTIVE routing posture (fail-closed: a cold / stale /
+    /// poisoned cache reads as `LockedOut`, exactly as the gate treats it).
+    pub effective_posture: FleetPosture,
+    /// True when the effective posture is fail-closed synthetic (cold /
+    /// stale / poisoned cache) rather than a live DAG verdict.
+    pub posture_cache_stale: bool,
+    /// The posture generation from the cache (0 when the cache is cold).
+    pub posture_generation: u64,
+    /// True when this instance is Active (accepting mutations), false for
+    /// PassiveStandby.
+    pub mode_active: bool,
+    /// `AppState::audit_write_drops` — kinematic-deny audit records dropped
+    /// on a Full/Closed audit-writer channel (A3). MUST be 0 when healthy.
+    pub audit_write_drops: u64,
+    /// `AppState::capture_drops` — learning-capture records dropped on a
+    /// Full/Closed capture channel (non-safety).
+    pub capture_drops: u64,
+    /// `AppState::post_incident_write_failures` — post-incident forensic
+    /// audit writes that could not be durably recorded (#104).
+    pub post_incident_write_failures: u64,
+    /// `AppState::command_source_write_failures` — command-source handoff
+    /// audit writes that could not be durably recorded (#112).
+    pub command_source_write_failures: u64,
+}
+
+/// WS-0.5 — the fleet-safety counter set behind `GET /metrics` on the
+/// verifier binary. Lock-free atomics, incremented on the paths they
+/// observe; formatted with [`format_prometheus`](Self::format_prometheus).
+/// Lives on `AppState` so the posture engine, the routing gate, and the
+/// HA promotion path can all reach it.
+#[derive(Debug, Default)]
+pub struct FleetSafetyMetrics {
+    /// Committed posture TRANSITIONS by target posture (the periodic
+    /// refresh traffic is not counted). Indexed: [Nominal, Degraded, LockedOut].
+    transitions_nominal: AtomicU64,
+    transitions_degraded: AtomicU64,
+    transitions_locked_out: AtomicU64,
+    /// Posture-routing gate denials (dropped commands) by reason.
+    denials_unknown_command: AtomicU64,
+    denials_posture_cache_empty: AtomicU64,
+    denials_posture_cache_stale: AtomicU64,
+    denials_locked_out: AtomicU64,
+    denials_degraded_write: AtomicU64,
+    denials_ha_fenced: AtomicU64,
+    /// Completed standby→Active promotions (HA failover).
+    ha_promotions: AtomicU64,
+}
+
+impl FleetSafetyMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Count a COMMITTED posture transition (called by the posture engine
+    /// after the audit-chain write succeeds — a suppressed transition is
+    /// not counted, matching what subscribers observe).
+    pub fn record_transition(&self, to: &FleetPosture) {
+        let c = match to {
+            FleetPosture::Nominal => &self.transitions_nominal,
+            FleetPosture::Degraded => &self.transitions_degraded,
+            FleetPosture::LockedOut => &self.transitions_locked_out,
+        };
+        c.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Count a posture-routing gate denial (a dropped command).
+    pub fn record_gate_denial(&self, reason: GateDenialReason) {
+        let c = match reason {
+            GateDenialReason::UnknownCommand      => &self.denials_unknown_command,
+            GateDenialReason::PostureCacheEmpty   => &self.denials_posture_cache_empty,
+            GateDenialReason::PostureCacheStale   => &self.denials_posture_cache_stale,
+            GateDenialReason::LockedOut           => &self.denials_locked_out,
+            GateDenialReason::DegradedWriteDenied => &self.denials_degraded_write,
+            GateDenialReason::HaFenced            => &self.denials_ha_fenced,
+        };
+        c.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Count a completed standby→Active promotion (HA failover).
+    pub fn record_ha_promotion(&self) {
+        self.ha_promotions.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn transition_count(&self, to: &FleetPosture) -> u64 {
+        match to {
+            FleetPosture::Nominal => &self.transitions_nominal,
+            FleetPosture::Degraded => &self.transitions_degraded,
+            FleetPosture::LockedOut => &self.transitions_locked_out,
+        }
+        .load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn ha_promotion_count(&self) -> u64 {
+        self.ha_promotions.load(Ordering::Relaxed)
+    }
+
+    /// Render the Prometheus text exposition (format 0.0.4) for the fleet-
+    /// safety series: the accumulated counters in `self` plus the
+    /// scrape-time gauges in `snap`. Same `kirra_` prefix and style as
+    /// `LockFreeMetricsAggregator::format_prometheus_metrics`.
+    pub fn format_prometheus(&self, node_id: &str, snap: &FleetMetricsSnapshot) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::with_capacity(4096);
+
+        // One HELP/TYPE block, then one sample line per label value.
+        let family = |out: &mut String,
+                          name: &str,
+                          mtype: &str,
+                          desc: &str,
+                          samples: &[(&str, u64)]| {
+            let _ = writeln!(out, "# HELP kirra_{name} {desc}");
+            let _ = writeln!(out, "# TYPE kirra_{name} {mtype}");
+            for (labels, val) in samples {
+                if labels.is_empty() {
+                    let _ = writeln!(out, "kirra_{name}{{node_id=\"{node_id}\"}} {val}");
+                } else {
+                    let _ = writeln!(
+                        out,
+                        "kirra_{name}{{node_id=\"{node_id}\",{labels}}} {val}"
+                    );
+                }
+            }
+        };
+
+        // --- gauges (scrape-time state) ---
+        family(
+            &mut out,
+            "fleet_posture",
+            "gauge",
+            "Effective fleet routing posture (0=Nominal 1=Degraded 2=LockedOut; \
+             fail-closed: a cold/stale/poisoned posture cache reads as LockedOut)",
+            &[("", match snap.effective_posture {
+                FleetPosture::Nominal => 0,
+                FleetPosture::Degraded => 1,
+                FleetPosture::LockedOut => 2,
+            })],
+        );
+        family(
+            &mut out,
+            "posture_cache_stale",
+            "gauge",
+            "1 when the effective posture is the fail-closed synthetic LockedOut \
+             (cold/stale/poisoned posture cache) rather than a live DAG verdict",
+            &[("", u64::from(snap.posture_cache_stale))],
+        );
+        family(
+            &mut out,
+            "posture_generation",
+            "gauge",
+            "Monotonic posture generation from the cache (0 when cold)",
+            &[("", snap.posture_generation)],
+        );
+        family(
+            &mut out,
+            "mode_active",
+            "gauge",
+            "1 when this instance is Active (accepting mutations), 0 for PassiveStandby",
+            &[("", u64::from(snap.mode_active))],
+        );
+
+        // --- counters (accumulated events) ---
+        family(
+            &mut out,
+            "posture_transitions_total",
+            "counter",
+            "Committed fleet posture transitions by target posture \
+             (periodic cache refreshes are not transitions)",
+            &[
+                ("posture=\"nominal\"", self.transitions_nominal.load(Ordering::Relaxed)),
+                ("posture=\"degraded\"", self.transitions_degraded.load(Ordering::Relaxed)),
+                ("posture=\"locked_out\"", self.transitions_locked_out.load(Ordering::Relaxed)),
+            ],
+        );
+        family(
+            &mut out,
+            "gate_denials_total",
+            "counter",
+            "Commands dropped by the posture-routing gate (HTTP 503) by fail-closed reason",
+            &[
+                ("reason=\"unknown_command\"", self.denials_unknown_command.load(Ordering::Relaxed)),
+                ("reason=\"posture_cache_empty\"", self.denials_posture_cache_empty.load(Ordering::Relaxed)),
+                ("reason=\"posture_cache_stale\"", self.denials_posture_cache_stale.load(Ordering::Relaxed)),
+                ("reason=\"locked_out\"", self.denials_locked_out.load(Ordering::Relaxed)),
+                ("reason=\"degraded_write_denied\"", self.denials_degraded_write.load(Ordering::Relaxed)),
+                ("reason=\"ha_fenced\"", self.denials_ha_fenced.load(Ordering::Relaxed)),
+            ],
+        );
+        family(
+            &mut out,
+            "ha_promotions_total",
+            "counter",
+            "Completed standby-to-Active promotions (HA failover) performed by this instance",
+            &[("", self.ha_promotions.load(Ordering::Relaxed))],
+        );
+
+        // --- drop / write-failure counters already accumulated on AppState ---
+        family(
+            &mut out,
+            "audit_write_drops_total",
+            "counter",
+            "Kinematic-deny audit records dropped on a full/closed audit-writer \
+             channel (A3) — MUST be 0 in a healthy deployment",
+            &[("", snap.audit_write_drops)],
+        );
+        family(
+            &mut out,
+            "capture_drops_total",
+            "counter",
+            "Learning-capture records dropped on a full/closed capture channel (non-safety)",
+            &[("", snap.capture_drops)],
+        );
+        family(
+            &mut out,
+            "post_incident_write_failures_total",
+            "counter",
+            "Post-incident forensic audit writes that could not be durably recorded (#104) \
+             — MUST be 0 in a healthy deployment",
+            &[("", snap.post_incident_write_failures)],
+        );
+        family(
+            &mut out,
+            "command_source_write_failures_total",
+            "counter",
+            "Command-source handoff audit writes that could not be durably recorded (#112) \
+             — MUST be 0 in a healthy deployment",
+            &[("", snap.command_source_write_failures)],
+        );
+
+        out
+    }
+}
+
 pub struct LockFreeMetricsAggregator {
     pub total_processed_frames: AtomicU64,
     pub envelope_clamping_events: AtomicU64,
@@ -48,5 +331,123 @@ impl LockFreeMetricsAggregator {
         write_metric(&mut out, "active_worker_threads", "gauge", "Concurrent thread saturation within worker pools", self.active_worker_threads.load(Ordering::Relaxed));
 
         out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WS-0.5 tests — the fleet-safety exposition.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod fleet_metrics_tests {
+    use super::*;
+
+    fn snap(posture: FleetPosture, stale: bool) -> FleetMetricsSnapshot {
+        FleetMetricsSnapshot {
+            effective_posture: posture,
+            posture_cache_stale: stale,
+            posture_generation: 7,
+            mode_active: true,
+            audit_write_drops: 11,
+            capture_drops: 12,
+            post_incident_write_failures: 13,
+            command_source_write_failures: 14,
+        }
+    }
+
+    /// Every fleet-safety family is present with a HELP + TYPE block and a
+    /// node_id label — the shape a Prometheus scraper parses.
+    #[test]
+    fn exposition_contains_every_family_with_help_and_type() {
+        let m = FleetSafetyMetrics::new();
+        let text = m.format_prometheus("node-a", &snap(FleetPosture::Nominal, false));
+        for family in [
+            "fleet_posture",
+            "posture_cache_stale",
+            "posture_generation",
+            "mode_active",
+            "posture_transitions_total",
+            "gate_denials_total",
+            "ha_promotions_total",
+            "audit_write_drops_total",
+            "capture_drops_total",
+            "post_incident_write_failures_total",
+            "command_source_write_failures_total",
+        ] {
+            assert!(
+                text.contains(&format!("# HELP kirra_{family} ")),
+                "missing HELP for kirra_{family}:\n{text}"
+            );
+            assert!(
+                text.contains(&format!("# TYPE kirra_{family} ")),
+                "missing TYPE for kirra_{family}:\n{text}"
+            );
+            assert!(
+                text.contains(&format!("kirra_{family}{{node_id=\"node-a\"")),
+                "missing sample line for kirra_{family}:\n{text}"
+            );
+        }
+    }
+
+    /// The posture gauge encodes 0/1/2 and the stale flag is independent.
+    #[test]
+    fn posture_gauge_encodes_the_fail_closed_mapping() {
+        let m = FleetSafetyMetrics::new();
+        for (posture, code) in [
+            (FleetPosture::Nominal, 0),
+            (FleetPosture::Degraded, 1),
+            (FleetPosture::LockedOut, 2),
+        ] {
+            let text = m.format_prometheus("n", &snap(posture, false));
+            assert!(
+                text.contains(&format!("kirra_fleet_posture{{node_id=\"n\"}} {code}\n")),
+                "posture {posture:?} must encode as {code}:\n{text}"
+            );
+        }
+        let stale = m.format_prometheus("n", &snap(FleetPosture::LockedOut, true));
+        assert!(stale.contains("kirra_posture_cache_stale{node_id=\"n\"} 1\n"));
+    }
+
+    /// Recorded events land on exactly the right labeled sample.
+    #[test]
+    fn recorded_events_render_on_the_right_labels() {
+        let m = FleetSafetyMetrics::new();
+        m.record_transition(&FleetPosture::Degraded);
+        m.record_transition(&FleetPosture::Degraded);
+        m.record_transition(&FleetPosture::LockedOut);
+        m.record_gate_denial(GateDenialReason::PostureCacheStale);
+        m.record_gate_denial(GateDenialReason::LockedOut);
+        m.record_gate_denial(GateDenialReason::LockedOut);
+        m.record_gate_denial(GateDenialReason::LockedOut);
+        m.record_ha_promotion();
+
+        let text = m.format_prometheus("n", &snap(FleetPosture::Nominal, false));
+        for expected in [
+            "kirra_posture_transitions_total{node_id=\"n\",posture=\"nominal\"} 0\n",
+            "kirra_posture_transitions_total{node_id=\"n\",posture=\"degraded\"} 2\n",
+            "kirra_posture_transitions_total{node_id=\"n\",posture=\"locked_out\"} 1\n",
+            "kirra_gate_denials_total{node_id=\"n\",reason=\"posture_cache_stale\"} 1\n",
+            "kirra_gate_denials_total{node_id=\"n\",reason=\"locked_out\"} 3\n",
+            "kirra_gate_denials_total{node_id=\"n\",reason=\"unknown_command\"} 0\n",
+            "kirra_ha_promotions_total{node_id=\"n\"} 1\n",
+            "kirra_audit_write_drops_total{node_id=\"n\"} 11\n",
+            "kirra_capture_drops_total{node_id=\"n\"} 12\n",
+            "kirra_post_incident_write_failures_total{node_id=\"n\"} 13\n",
+            "kirra_command_source_write_failures_total{node_id=\"n\"} 14\n",
+        ] {
+            assert!(text.contains(expected), "missing exact sample {expected:?} in:\n{text}");
+        }
+    }
+
+    /// Label values are the stable snake_case codes (renaming one breaks
+    /// every dashboard/alert built on it — pin the vocabulary).
+    #[test]
+    fn gate_denial_labels_are_pinned() {
+        assert_eq!(GateDenialReason::UnknownCommand.as_label(), "unknown_command");
+        assert_eq!(GateDenialReason::PostureCacheEmpty.as_label(), "posture_cache_empty");
+        assert_eq!(GateDenialReason::PostureCacheStale.as_label(), "posture_cache_stale");
+        assert_eq!(GateDenialReason::LockedOut.as_label(), "locked_out");
+        assert_eq!(GateDenialReason::DegradedWriteDenied.as_label(), "degraded_write_denied");
+        assert_eq!(GateDenialReason::HaFenced.as_label(), "ha_fenced");
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,6 +31,21 @@ pub enum GateDenialReason {
     HaFenced,
 }
 
+/// Escape a string for use inside a quoted Prometheus label value
+/// (text exposition format 0.0.4): `\` → `\\`, `"` → `\"`, newline → `\n`.
+fn escape_label_value(raw: &str) -> String {
+    let mut escaped = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}
+
 impl GateDenialReason {
     /// The stable Prometheus label value.
     pub fn as_label(self) -> &'static str {
@@ -155,6 +170,11 @@ impl FleetSafetyMetrics {
     /// `LockFreeMetricsAggregator::format_prometheus_metrics`.
     pub fn format_prometheus(&self, node_id: &str, snap: &FleetMetricsSnapshot) -> String {
         use std::fmt::Write as _;
+        // node_id comes from env/hostname — escape it per the Prometheus
+        // text-format rules for quoted label values (`\` → `\\`, `"` → `\"`,
+        // newline → `\n`), or a hostile/odd instance id breaks every scrape.
+        let node_id = escape_label_value(node_id);
+        let node_id = node_id.as_str();
         let mut out = String::with_capacity(4096);
 
         // One HELP/TYPE block, then one sample line per label value.
@@ -437,6 +457,28 @@ mod fleet_metrics_tests {
         ] {
             assert!(text.contains(expected), "missing exact sample {expected:?} in:\n{text}");
         }
+    }
+
+    /// A node_id carrying label-breaking characters (`"`, `\`, newline) is
+    /// escaped per the text-format rules, so an odd/hostile instance id can
+    /// neither corrupt the exposition nor inject extra samples.
+    #[test]
+    fn node_id_is_escaped_in_label_values() {
+        let m = FleetSafetyMetrics::new();
+        let text = m.format_prometheus(
+            "bad\"id\\with\nnewline",
+            &snap(FleetPosture::Nominal, false),
+        );
+        assert!(
+            text.contains("kirra_fleet_posture{node_id=\"bad\\\"id\\\\with\\nnewline\"} 0\n"),
+            "node_id must be escaped for the quoted label value; got:\n{text}"
+        );
+        // No raw newline may survive inside a sample line (it would split
+        // the sample and inject a bogus line).
+        assert!(
+            !text.lines().any(|l| l.starts_with("newline")),
+            "a raw newline in node_id must not split a sample line:\n{text}"
+        );
     }
 
     /// Label values are the stable snake_case codes (renaming one breaks

--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -323,6 +323,13 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
         return;
     }
 
+    // WS-0.5 — count the COMMITTED transition for /metrics (a suppressed
+    // transition above is not counted, matching what subscribers observe;
+    // refresh traffic is not a transition). Observability only.
+    if is_transition {
+        app.fleet_metrics.record_transition(&new_posture);
+    }
+
     // #104: post-incident forensic sequence — OBSERVABILITY ONLY. Runs only
     // after the posture transition is committed to the chain (above); it never
     // perturbs or blocks the cache/broadcast path below. A failed forensic write
@@ -1127,6 +1134,51 @@ mod posture_engine_tests {
             next > high_water,
             "the first generation after init must exceed the persisted high-water \
              (got {next}, high-water {high_water}) — otherwise restarts time-reverse"
+        );
+    }
+
+    /// WS-0.5 — a COMMITTED posture transition increments the /metrics
+    /// transition counter for its TARGET posture; the periodic no-change
+    /// refresh does not count (it is not a transition).
+    #[test]
+    fn test_transition_counts_for_metrics_but_refresh_does_not() {
+        let app = active_app();
+        let cache = empty_cache();
+
+        // First recalc: None → Nominal is a transition.
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(
+            app.fleet_metrics.transition_count(&FleetPosture::Nominal),
+            1,
+            "the None→Nominal transition must be counted"
+        );
+
+        // No-change refresh: nothing moves.
+        recalculate_and_broadcast(&app, &cache);
+        assert_eq!(
+            app.fleet_metrics.transition_count(&FleetPosture::Nominal),
+            1,
+            "a no-change refresh is not a transition and must not count"
+        );
+
+        // Trust the DAG down: the new posture's counter increments once.
+        insert_node(&app, "faulty", NodeTrustState::Untrusted("test".into()));
+        recalculate_and_broadcast(&app, &cache);
+        let new_posture = cache
+            .read()
+            .unwrap()
+            .expect("cache populated")
+            .posture;
+        assert_ne!(new_posture, FleetPosture::Nominal, "precondition: the fault degrades the fleet");
+        assert_eq!(
+            app.fleet_metrics.transition_count(&new_posture),
+            1,
+            "the degradation transition must be counted under its target posture"
+        );
+        assert_eq!(
+            app.fleet_metrics.transition_count(&FleetPosture::Nominal),
+            1,
+            "the earlier Nominal count is untouched"
         );
     }
 

--- a/src/standby_monitor.rs
+++ b/src/standby_monitor.rs
@@ -938,6 +938,9 @@ async fn perform_promotion(
     }
 
     // Promotion succeeded (durable epoch claimed, audit anchored, mode flipped).
+    // WS-0.5 — count the completed failover for /metrics (aborted promotions
+    // above returned false and are not counted). Observability only.
+    app.fleet_metrics.record_ha_promotion();
     true
 }
 
@@ -1478,6 +1481,40 @@ mod sg_009_promotion_act_tests {
     // #78 — hash-v2 audit anchor is ENSURED before any Active write, and its
     // failure FAILS CLOSED (promotion aborts, no Active state written).
     // -----------------------------------------------------------------------
+
+    /// WS-0.5 — a COMPLETED promotion increments the /metrics failover
+    /// counter; an ABORTED one (here: the hash-v2 anchor cannot be ensured,
+    /// the same deterministic abort `test_promotion_aborts_when_anchor_
+    /// cannot_be_ensured` pins) does not — the counter reports failovers
+    /// that actually transferred authority, not attempts.
+    #[test]
+    fn test_promotion_counts_for_metrics_only_when_completed() {
+        // Completed promotion → counted once.
+        let store = VerifierStore::new(":memory:").expect("store");
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::PassiveStandby));
+        let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
+        run_promotion(&app, &cache, "standby-metrics", "HEARTBEAT_TIMEOUT");
+        assert!(app.is_active(), "healthy promotion completes");
+        assert_eq!(
+            app.fleet_metrics.ha_promotion_count(),
+            1,
+            "a completed failover must be counted"
+        );
+
+        // Aborted promotion (broken audit-chain table → anchor failure,
+        // fail-closed early return) → NOT counted.
+        let store2 = VerifierStore::new(":memory:").expect("store");
+        store2.break_audit_chain_table_for_test();
+        let app2 = Arc::new(AppState::new(store2, VerifierOperationMode::PassiveStandby));
+        let cache2: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
+        run_promotion(&app2, &cache2, "standby-abort", "HEARTBEAT_TIMEOUT");
+        assert!(!app2.is_active(), "precondition: the promotion aborted");
+        assert_eq!(
+            app2.fleet_metrics.ha_promotion_count(),
+            0,
+            "an aborted promotion is not a failover and must not be counted"
+        );
+    }
 
     /// Happy path: a store carrying legacy v1 audit rows has its
     /// `HASH_V2_MIGRATION` anchor ensured DURING promotion (proof the anchor

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -324,6 +324,12 @@ pub struct AppState {
     /// SG-003 detection-latency bound (TIMEOUT + one sweep). The watchdog swaps it
     /// back to false when it refreshes. Defaults false.
     pub av_registry_dirty: Arc<AtomicBool>,
+    /// WS-0.5 — fleet-safety Prometheus counters (posture transitions, gate
+    /// denials, HA promotions), exported by `GET /metrics` on the verifier
+    /// binary. Lock-free; incremented on the observed paths, never gating
+    /// them. Lives here (not on `ServiceState`) so the posture engine, the
+    /// routing gate, and the HA promotion path can all reach it.
+    pub fleet_metrics: crate::metrics::FleetSafetyMetrics,
 }
 
 impl AppState {
@@ -361,6 +367,7 @@ impl AppState {
             audit_write_drops: Arc::new(AtomicU64::new(0)),
             capture_drops: Arc::new(AtomicU64::new(0)),
             av_registry_dirty: Arc::new(AtomicBool::new(false)),
+            fleet_metrics: crate::metrics::FleetSafetyMetrics::new(),
         }
     }
 


### PR DESCRIPTION
**PR 5 of the product execution plan (WS-0.5) — closes the S0 slice of gap-analysis G17 (observability).**

## The gap

The exemption allowlist (`is_posture_exempt`) and `SECURITY_BOUNDARIES.md` both already promised a `/metrics` observability surface, and `AppState` carried four "operator-observable" drop counters (`audit_write_drops`, `capture_drops`, `post_incident_write_failures`, `command_source_write_failures`) — but **no `/metrics` route existed and nothing exported any of it**. The fleet's safety state was invisible to standard monitoring exactly when it mattered: a LockedOut fleet emitted no scrape-able signal at all.

## The change

**`FleetSafetyMetrics`** (`src/metrics.rs`) — lock-free counters plus the Prometheus text exposition (0.0.4, `kirra_` prefix, `node_id` label, same style as the existing `format_prometheus_metrics`):

- **`kirra_fleet_posture`** gauge — the *effective* routing posture via the single TTL authority (`resolve_posture_with_reason`): a cold/stale/poisoned cache reads as LockedOut, exactly what the gate enforces — the gauge never reports stale optimism. Plus `posture_cache_stale`, `posture_generation`, `mode_active`.
- **`kirra_posture_transitions_total{posture}`** — committed transitions only: counted after the audit-chain write succeeds, so suppressed transitions and the periodic refresh traffic are not counted — the counter matches what SSE subscribers observe.
- **`kirra_gate_denials_total{reason}`** — dropped commands by fail-closed reason (`unknown_command` / `posture_cache_empty` / `posture_cache_stale` / `locked_out` / `degraded_write_denied` / `ha_fenced`). A **fixed** label vocabulary (bounded cardinality), derived by `classify_gate_denial`, which mirrors `should_route_command`'s decision order and never influences the verdict — observability only, wired into all three deny arms (posture deny, epoch fence, actuator authority assert).
- **`kirra_ha_promotions_total`** — completed standby→Active failovers; aborted promotions are not failovers and are not counted.
- The four pre-existing `AppState` drop/write-failure counters, exported at last as `*_total` series.

**Route**: `GET /metrics` in `probe_routes` — public read-only, posture-exempt (the allowlist entry existed; now the route does). The scrape survives LockedOut — that is precisely when an operator needs it. CLAUDE.md's route matrix updated; the security-boundaries doc already documented the tier.

`FleetSafetyMetrics` lives on `AppState` (not `ServiceState`) so the posture engine, the routing gate, and the HA promotion path all reach it without constructor churn.

## DoD ("Prometheus scrape returns fleet-safety series")

- **`metrics_scrape_returns_fleet_safety_series_under_lockedout`** — on the *real assembled router* under LockedOut: 200, `text/plain; version=0.0.4`, every family present, the posture gauge reads the fail-closed `2`, and a denial that just happened is visible on the labeled counter — the series are live, not just present.
- **Live boot check** — ran the actual binary and scraped it: the boot `None→LockedOut` transition appears on the transition counter, and a real denied `POST` moved `gate_denials_total{reason="locked_out"}` 0→1 between scrapes.
- **Unit coverage** — exposition shape (HELP/TYPE per family), gauge encoding, exact labeled samples, pinned label vocabulary (renaming a label breaks every dashboard built on it); transition-vs-refresh counting in the posture engine; completed-vs-aborted promotion counting in the standby monitor; the denial classifier mirrors the gate's decision order.

115 workspace test suites green; clippy zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_