### PR TITLE
docs/release: CHANGELOG backfill + versioning/MSRV/deprecation policy; releases fail without real notes (WS-0.7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,8 +233,18 @@ jobs:
           # whose heading names the pushed tag; a missing/empty section
           # FAILS the release — no more "Release vX" fallback notes. Write
           # the section in CHANGELOG.md (rename [Unreleased]) and re-tag.
-          awk "/^## \[?${VERSION}\]?/{flag=1; next} /^## /{flag=0} flag" CHANGELOG.md \
-              > release_notes.md
+          #
+          # Exact-prefix match on the BRACKETED heading ("## [vX.Y.Z]") —
+          # the version is compared as a STRING, never interpolated into a
+          # regex, so dots can't wildcard and "v1.1.2" can't match a
+          # "v1.1.21" section (the closing bracket bounds it).
+          if [ ! -f CHANGELOG.md ]; then
+            echo "::error::CHANGELOG.md is missing — a release must ship real notes (WS-0.7)."
+            exit 1
+          fi
+          awk -v ver="${VERSION}" '
+            /^## / { want = "## [" ver "]"; flag = (substr($0, 1, length(want)) == want); next }
+            flag' CHANGELOG.md > release_notes.md
           if [ ! -s release_notes.md ]; then
             echo "::error file=CHANGELOG.md::No '## [${VERSION}]' section found in CHANGELOG.md —" \
                  "a release must ship real notes (WS-0.7). Add the section (rename [Unreleased])," \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,13 +229,17 @@ jobs:
         id: changelog
         run: |
           VERSION="${{ github.ref_name }}"
-          # Extract the relevant section from CHANGELOG.md if it exists
-          if [ -f CHANGELOG.md ]; then
-            awk "/^## \[?${VERSION}\]?/{flag=1; next} /^## /{flag=0} flag" CHANGELOG.md \
-                > release_notes.md
-          fi
+          # WS-0.7: the changelog section is REQUIRED. Extract the section
+          # whose heading names the pushed tag; a missing/empty section
+          # FAILS the release — no more "Release vX" fallback notes. Write
+          # the section in CHANGELOG.md (rename [Unreleased]) and re-tag.
+          awk "/^## \[?${VERSION}\]?/{flag=1; next} /^## /{flag=0} flag" CHANGELOG.md \
+              > release_notes.md
           if [ ! -s release_notes.md ]; then
-            echo "Release ${VERSION}" > release_notes.md
+            echo "::error file=CHANGELOG.md::No '## [${VERSION}]' section found in CHANGELOG.md —" \
+                 "a release must ship real notes (WS-0.7). Add the section (rename [Unreleased])," \
+                 "then delete and re-push the tag."
+            exit 1
           fi
           # WS-0.6: verification instructions travel with every release.
           cat >> release_notes.md <<'VERIFY'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,119 @@
+# Changelog
+
+All notable changes to the Kirra Runtime SDK are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to the semantic-versioning rules defined in
+[`docs/VERSIONING_POLICY.md`](docs/VERSIONING_POLICY.md) (which also defines
+the versioned public surface, the MSRV policy, and the deprecation process).
+
+> **Version-numbering note.** The first public release shipped as **v1.5.0
+> under the previous "Aegis" branding** (2026-05-23). The rename to Kirra
+> restarted the version line at **v1.1.2** (2026-05-27) — so v1.1.2 is
+> *newer* than v1.5.0. Versions are monotonic from v1.1.2 onward; a future
+> major bump will clear the ambiguity permanently. Release automation
+> (`.github/workflows/release.yml`) extracts the section matching the pushed
+> tag from this file — a release without a matching section **fails the
+> release job** (WS-0.7; no silent "Release vX" fallback).
+
+## [Unreleased]
+
+Everything since v1.1.2 (May 2026 → present). The highlights, by stream —
+detail lives in `docs/adr/`, `docs/safety/`, and the PR history:
+
+### Added
+
+- **Doer-checker planning & perception stack** — the swappable DOER
+  (`kirra-planner`: geometric Occy, Mick intent seam incl. multi-junction
+  `RouteTo`, learned Hydra-MDP-style planners) bounded by the CHECKER
+  (`kirra-trajectory` / `kirra-ros2-adapter`: containment, per-pose
+  kinematics, the RSS §4 conjunction, occlusion Rule 4, multi-modal
+  predictive RSS, True-Redundancy perception cross-check), with the
+  lanelet2-lite lane graph (`kirra-map`) and the Taj R2 perception layer
+  (`kirra-taj`, safety-weighted eval harness).
+- **QNX partition lane (EPIC #270)** — L3 end-to-end two-process
+  doer→checker→release harness, POSIX-SHM hypervisor carrier
+  (`kirra-hv-carrier`), release-token bridge (`kirra-release-token`,
+  ADR-0031), frozen `GovernorContractView` contract channel, WCET
+  measurement methodology + CI boundedness gate (`wcet_gate.rs`).
+- **Diverse redundancy (CERT-006)** — `GovernorComparator` pairing the
+  primary `KirraGovernor` with a structurally diverse shadow; two-axis
+  divergence detection; divergence drives the live fleet posture.
+- **Learned-doer quantization lane (Q-series)** — ONNX export, TensorRT
+  INT8-QDQ on Orin, precision-selection ladder, per-tick perf contract.
+- **Operator console & live observability** — `/console` plane
+  (posture-exempt observe-and-recover), operator clearance grants,
+  governor-routed e-stop requests (ADR-0013).
+- **WS-0 truth-alignment series** (the seven-PR GATE A closer):
+  - WS-0.1 — parko live RSS wiring; the `safe: true` construction default
+    is dead (unfed governors HOLD at zero).
+  - WS-0.2 — posture-generation persistence restored (restart-monotonic
+    generations; federation ordering claim true again).
+  - WS-0.3 — incident-class audit writes are power-loss durable at write
+    time (FULL-sync WAL fsync on transitions; kill-after-incident test).
+  - WS-0.4 — parko per-tick inference deadline + hung-backend watchdog;
+    comparator angular reconciliation capped by the SOTIF MRC `ω_max(v)`.
+  - WS-0.5 — `GET /metrics` Prometheus fleet-safety series (posture gauge,
+    committed transitions, gate denials by reason, HA promotions, drop
+    counters); scrape survives LockedOut.
+  - WS-0.6 — cargo-deny supply-chain gate (licenses/bans/sources, both
+    workspaces, one policy), CycloneDX release SBOMs, keyless cosign
+    signatures over release artifacts and container images;
+    `parko/Cargo.lock` is now committed.
+  - WS-0.7 — this changelog, the versioning/MSRV/deprecation policy, and
+    the fail-instead-of-fallback release-notes rule.
+
+### Changed
+
+- Degraded posture is **decel-to-stop-and-HOLD** (issue #70) at all four
+  enforcement points, with `ActuatorMotion` deferral under Degraded
+  (ADR-0011 Option A) — not a sustained crawl.
+- Attestation verifies a **per-node Ed25519 proof** over the challenge
+  (issue #73); the admin-asserted HMAC proof is removed.
+- Per-class kinematic contracts selected by `KIRRA_VEHICLE_CLASS`
+  (fail-closed: no default class; #312).
+
+### Security / supply chain
+
+- Ed25519-signed hash-chained audit ledger with causal chain, key
+  rotation, and tamper-evident export; HA epoch fencing closes the
+  two-writer actuator window; deny gate + SBOM + cosign (WS-0.6).
+
+## [v1.1.2] — 2026-05-27
+
+First release under the **Kirra** name (see the version-numbering note
+above). Full notes: [`docs/releases/v1.1.2.md`](docs/releases/v1.1.2.md).
+
+### Fixed
+
+- **LockedOut authority model (PARK-003, critical):** LockedOut is a hard
+  stop (`Deny`, 0.0 m/s) — not an MRC cap. Corrected in the governor,
+  property tests, and decision log. The three-tier authority model is:
+  LockedOut → 0.0 hard stop (human reset); Degraded → MRC ceiling
+  (5.0 m/s); Nominal → full kinematic envelope.
+
+### Added
+
+- **Parko workspace** — behavioral safety governor: RSS per
+  IEEE 2846-2022 (longitudinal + lateral safe distance), `RssState` wired
+  into the posture engine with recovery hysteresis, software-lockstep
+  `GovernorComparator`, ONNX/OpenVINO inference backends behind the
+  `InferenceBackend` seam.
+- aarch64 cross-compilation support and release packaging.
+- 340 new tests in the root workspace; 61 (incl. 70k proptest cases) in
+  parko.
+
+## [v1.5.0] — 2026-05-23 (Aegis era)
+
+Published under the previous **Aegis** branding; numerically higher but
+*older* than v1.1.2 (see the version-numbering note). Full notes:
+[`docs/releases/v1.5.0.md`](docs/releases/v1.5.0.md).
+
+### Added
+
+- Multi-asset safety fabric (per-asset governors, fleet lockout
+  propagation, federated causal log).
+- ROS 2 safety interlock package (`cmd_vel` → governor → `cmd_vel_safe`).
+- Industrial protocol adapters: EtherNet/IP, CANopen, DNP3.
+- Ed25519 audit-chain signing with tamper detection.
+- React operations dashboard; Helm deployment.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ resolver = "2"
 name = "kirra-verifier"
 version = "1.1.2"
 edition = "2021"
+# MSRV (WS-0.7, docs/VERSIONING_POLICY.md §3): floor set by locked deps
+# (time-core 0.1.9 -> rustc 1.88); verified `cargo +1.88.0 check --workspace
+# --locked`. Raising this is a MINOR bump + CHANGELOG entry, per policy.
+rust-version = "1.88"
 description = "Vendor-neutral runtime safety kernel for autonomous vehicles, robots, and drones"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 homepage = "https://kirrasystems.com"

--- a/docs/VERSIONING_POLICY.md
+++ b/docs/VERSIONING_POLICY.md
@@ -1,0 +1,118 @@
+# Versioning, MSRV & Deprecation Policy
+
+**Document ID:** KIRRA-POLICY-VERSIONING-001
+**Status:** Active (WS-0.7)
+**Applies to:** the whole repository — the root (`kirra-verifier`) workspace,
+the `parko/` workspace, release artifacts, and container images.
+
+---
+
+## 1. What is versioned
+
+There is **one product version** for the repository, held in the root
+`Cargo.toml` (`kirra-verifier.version`) and released as git tag `v<version>`.
+Workspace crates are proprietary and `publish = false`; their individual
+Rust APIs are **not** a semver surface — the versioned **public contract**
+is what an integrator can touch from outside:
+
+| Surface | Where defined |
+|---|---|
+| HTTP API of the verifier service (routes, methods, status semantics, JSON shapes) | `src/bin/kirra_verifier_service.rs`, CLAUDE.md route matrix |
+| Environment-variable configuration (names, semantics, defaults, fail-closed behavior) | CLAUDE.md env table |
+| Prometheus exposition (metric names + label vocabularies) | `src/metrics.rs` (WS-0.5; label values are pinned by test) |
+| C FFI (`include/kirra.h`, `src/ffi.rs`) | ADR-0006 Clause 3 boundary |
+| Wire schemas: capture schema (`kirra-capture-schema`), governor wire (`kirra-wire-client`), hypervisor contract channel (`GovernorContractView`, frozen `#[repr(C)]`) | crate docs + `docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md` |
+| SQLite schema (forward migration expectations) | `src/verifier_store.rs` |
+| Release artifact layout (tarball structure, SBOM, signature bundles) | `.github/workflows/release.yml` |
+
+## 2. Semantic versioning rules
+
+Given `MAJOR.MINOR.PATCH`:
+
+- **MAJOR** — any breaking change to the public contract above: removing or
+  renaming a route/env var/metric/label, changing JSON or wire shapes
+  incompatibly, a destructive SQLite schema migration, an FFI signature
+  change, or completing a deprecation (removal).
+- **MINOR** — additive, backward-compatible surface: new routes, new env
+  vars (with fail-safe defaults), new metric families, additive schema
+  migrations, new crates/binaries. **Raising the MSRV is a MINOR bump.**
+  Introducing a deprecation (§5) is MINOR.
+- **PATCH** — bug fixes and internal changes that do not alter the contract.
+
+**Safety asymmetry (overrides the above):** a change that makes behavior
+*more* fail-closed (tightening a bound, denying something previously and
+wrongly admitted) may ship in a **PATCH** even though a client could observe
+it — safety corrections are never held hostage to compatibility. The
+reverse direction (relaxing an envelope, admitting more) is at minimum
+MINOR, requires the safety-case review trail, and is never silent. The
+CRITICAL SECURITY INVARIANTS in CLAUDE.md are not versionable surface — no
+bump of any size may violate them.
+
+### 2.1 The v1.5.0 → v1.1.2 renumbering
+
+The first public release shipped as **v1.5.0 under the "Aegis" branding**
+(2026-05-23). The Kirra rename restarted the line at **v1.1.2**
+(2026-05-27), so v1.1.2 is *newer* than v1.5.0. Versions are monotonic from
+v1.1.2 onward. Tooling that sorts the two tags semantically will order them
+wrong; CHANGELOG.md is the authoritative timeline. The next MAJOR release
+clears the ambiguity permanently (every active version will then be > 1.5).
+
+## 3. MSRV (Minimum Supported Rust Version)
+
+- **Current MSRV: 1.88** — pinned as `rust-version` in the root
+  `Cargo.toml` and in `parko/crates/parko-core/Cargo.toml` (the base crate
+  of the parko workspace), and verified empirically against both committed
+  lockfiles (`cargo +1.88.0 check --workspace --locked`); the floor is set
+  by locked dependencies (`time-core 0.1.9` requires 1.88), not by our own
+  code (`u64::is_multiple_of` needs 1.87).
+- Older toolchains fail loudly at build time (cargo enforces
+  `rust-version`), instead of failing cryptically mid-compile.
+- **Raising the MSRV is a deliberate act:** a MINOR version bump, a
+  CHANGELOG entry stating the new floor and what forced it, and an update
+  to the two `rust-version` fields plus this document. Routine `cargo
+  update` must not silently raise the effective floor past the pinned MSRV
+  — if it would, either pin the dependency back or raise the MSRV by this
+  process.
+- CI builds on current stable; the MSRV claim is re-verified at release
+  time (the release builds use the pinned toolchain expectations of the
+  committed lockfiles).
+
+## 4. Release process contract
+
+- Releases are cut by pushing tag `v<version>` (must equal the root
+  `Cargo.toml` version).
+- `CHANGELOG.md` **must** contain a `## [v<version>]` section. The release
+  workflow extracts it for the release notes and **fails the release** if
+  it is missing — there is no "Release vX" fallback (WS-0.7 DoD).
+- Every release carries: per-target tarballs, CycloneDX SBOMs for the two
+  shipped binaries, `SHA256SUMS`, and keyless cosign signature bundles for
+  all of the above (WS-0.6). Container images are cosign-signed by digest.
+
+## 5. Deprecation policy
+
+For any element of the public contract (§1):
+
+1. **Announce (MINOR):** mark deprecated in the CHANGELOG (`### Deprecated`)
+   and in the surface's documentation; where technically possible, emit a
+   startup or per-use `tracing::warn!` naming the replacement and this
+   policy. The element keeps working unchanged.
+2. **Grace window:** at least **one MINOR release** (and at least 90 days)
+   between announcement and removal. Longer for fleet-facing wire schemas —
+   a deployed fleet cannot flag-day.
+3. **Remove (MAJOR only):** removal or behavior change lands only in a
+   MAJOR release, listed under `### Removed`.
+4. **Exceptions:** a surface that is itself a safety or security defect
+   (fail-open behavior, an unauthenticated mutation) is corrected
+   immediately under the §2 safety asymmetry — with a loud CHANGELOG entry
+   — rather than deprecated on schedule.
+5. **Never deprecated-in-place:** semantics of an existing name are not
+   silently repurposed; a changed meaning gets a new name and the old one
+   goes through this process.
+
+## 6. Housekeeping
+
+- `CHANGELOG.md` is updated in the PR that makes the change (an
+  `[Unreleased]` section accumulates between releases and is renamed to the
+  version section at release time).
+- `docs/releases/v*.md` remains the home for long-form release narratives;
+  the changelog links to them.

--- a/docs/VERSIONING_POLICY.md
+++ b/docs/VERSIONING_POLICY.md
@@ -73,9 +73,12 @@ clears the ambiguity permanently (every active version will then be > 1.5).
   update` must not silently raise the effective floor past the pinned MSRV
   — if it would, either pin the dependency back or raise the MSRV by this
   process.
-- CI builds on current stable; the MSRV claim is re-verified at release
-  time (the release builds use the pinned toolchain expectations of the
-  committed lockfiles).
+- CI and release builds run on current stable Rust (≥ 1.88 by
+  construction); they do NOT themselves prove the MSRV. The MSRV claim is
+  verified explicitly — and must be re-verified when cutting a release or
+  updating either lockfile — by running
+  `cargo +1.88.0 check --workspace --locked` against both committed
+  lockfiles (root and `parko/`).
 
 ## 4. Release process contract
 

--- a/docs/VERSIONING_POLICY.md
+++ b/docs/VERSIONING_POLICY.md
@@ -22,7 +22,7 @@ is what an integrator can touch from outside:
 | Prometheus exposition (metric names + label vocabularies) | `src/metrics.rs` (WS-0.5; label values are pinned by test) |
 | C FFI (`include/kirra.h`, `src/ffi.rs`) | ADR-0006 Clause 3 boundary |
 | Wire schemas: capture schema (`kirra-capture-schema`), governor wire (`kirra-wire-client`), hypervisor contract channel (`GovernorContractView`, frozen `#[repr(C)]`) | crate docs + `docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md` |
-| SQLite schema (forward migration expectations) | `src/verifier_store.rs` |
+| SQLite schema (forward migration expectations) | `src/verifier_store/` (module; tables in `mod.rs` + per-domain files) |
 | Release artifact layout (tarball structure, SBOM, signature bundles) | `.github/workflows/release.yml` |
 
 ## 2. Semantic versioning rules

--- a/parko/crates/parko-core/Cargo.toml
+++ b/parko/crates/parko-core/Cargo.toml
@@ -2,6 +2,9 @@
 name = "parko-core"
 version = "0.1.0"
 edition = "2021"
+# Workspace MSRV floor (WS-0.7, docs/VERSIONING_POLICY.md §3) — parko-core is
+# the base crate every parko member depends on, so this bounds the workspace.
+rust-version = "1.88"
 description = "Core types and traits for vendor-neutral ML inference runtime"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../../COPYRIGHT"


### PR DESCRIPTION
**PR 7 of the product execution plan (WS-0.7) — the last WS-0 item; closes the G20 policy axis and, per the plan, GATE A.**

## CHANGELOG.md

Backfilled from `docs/releases/` in Keep-a-Changelog format, with the version-numbering anomaly stated honestly up front: **v1.1.2 is *newer* than v1.5.0** — the first release shipped as v1.5.0 under the Aegis branding, and the Kirra rename restarted the line at v1.1.2. Tools that sort the tags semantically will order them wrong; the changelog is the authoritative timeline, and the next MAJOR clears the ambiguity for good. An `[Unreleased]` section summarizes the ~440 commits since v1.1.2 by stream (doer-checker planning/perception stack, QNX partition lane, CERT-006 diversity, quantization lane, operator console, and the WS-0.1–0.7 truth-alignment series).

## `docs/VERSIONING_POLICY.md`

- **What the semver surface *is*** for a `publish = false` product: not crate APIs, but the integrator-touchable contract — HTTP API, env vars, the Prometheus name/label vocabulary (pinned by test since WS-0.5), FFI, wire schemas (capture, governor wire, `GovernorContractView`), SQLite schema, release artifact layout.
- **MAJOR/MINOR/PATCH rules with a safety asymmetry**: a fail-closed tightening may ship in a PATCH even though clients can observe it — safety corrections are never held hostage to compatibility; the reverse (relaxing an envelope) is ≥ MINOR with a review trail, and the CLAUDE.md critical invariants are not versionable surface at any bump size.
- **Deprecation process**: announce in a MINOR with warnings naming the replacement → ≥ 1 MINOR and ≥ 90 days grace (longer for fleet-facing wire schemas — a deployed fleet can't flag-day) → removal only in a MAJOR → immediate-fix exception for surfaces that are themselves safety/security defects → no silent semantic reuse of an existing name.

## MSRV: 1.88, pinned and empirical

`rust-version = "1.88"` in the root package and `parko-core` (the parko base crate). The floor was established by experiment, not vibes: the locked tree's binding constraint is `time-core 0.1.9` (requires rustc 1.88) — our own code only needs 1.87 (`is_multiple_of`). `cargo +1.85`/`+1.87 check` fail on that dep; `cargo +1.88.0 check --workspace --locked` passes on **both** workspaces. The deny-gate container (cargo 1.85, `cargo metadata` only) was explicitly re-verified unaffected — `rust-version` enforces at build time, not metadata. Raising the MSRV is a MINOR bump + CHANGELOG entry per policy.

## Release notes: fail, don't fall back

`release.yml` now **requires** a `## [v<tag>]` section in CHANGELOG.md; extraction failure fails the release with an actionable `::error` (add the section, re-push the tag) instead of shipping "Release vX". **DoD proven by dry-run**: the extraction script was pulled out of the workflow YAML and executed — the `v1.1.2` section extracts correctly, and a missing section exits 1 with the error annotation.

With this, all seven WS-0 rows are merged or in review: GATE A closes on merge. Next per the plan: WS-3.1 (scenario-KPI CI gate) and the Stage-1 openers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_