### PR TITLE
kpi: scenario-KPI CI gate — unsafe_miss_rate / admissibility / hazard_recall over a generated corpus (WS-3.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,22 @@ jobs:
           command: check advisories
           arguments: --locked
 
+  # WS-3.1 — the scenario-KPI gate: thresholds unsafe_miss_rate /
+  # admissibility / hazard_recall over the generated deterministic corpus
+  # (248 doer scenarios + 71 perception frames) against the reviewed policy
+  # in ci/scenario_kpi_thresholds.json. Red = a fleet-safety KPI regressed
+  # (the corpus and planners are deterministic — never flake). The WS-3 DoD:
+  # no safety-relevant PR merges without this gate.
+  scenario-kpi-gate:
+    name: scenario-KPI gate (WS-3.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: KPI gate (unsafe_miss_rate / admissibility / hazard_recall)
+        run: cargo run --locked -p kirra-kpi-gate --bin scenario_kpi_gate
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,6 +2126,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-kpi-gate"
+version = "0.1.0"
+dependencies = [
+ "kirra-core",
+ "kirra-doer-eval",
+ "kirra-planner",
+ "kirra-taj",
+ "kirra-trajectory",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kirra-l3-e2e"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@
 # runtime (ORT etc.) is absent, strict-fail only in the CI lane that installs
 # it (see parko-onnx's PARKO_ONNX_REQUIRE_ORT).
 [workspace]
-members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-l3-e2e", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval"]
+members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-l3-e2e", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval", "crates/kirra-kpi-gate"]
 resolver = "2"
 
 [package]

--- a/ci/scenario_kpi_thresholds.json
+++ b/ci/scenario_kpi_thresholds.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "WS-3.1 scenario-KPI gate thresholds (see crates/kirra-kpi-gate). The corpus is deterministic (closed-form generators, seeded planner), so measured values are exact rationals and these bounds sit AT the current floor: geometric admissibility 240/248 = 0.96774..., learned (SafetyAware, seed 7) 224/248 = 0.90322...; perception runs through the scripted MockSemanticDetector seam and pins perfection (unsafe_miss_rate 0, hazard_recall 1) — the real detector inherits these bars behind the same trait. A KPI may only move DOWN past its bound with a reviewed justification in the PR that changes this file; improvements should tighten the bound here (ratchet).",
+  "geometric_admissibility_min": 0.9677,
+  "learned_admissibility_min": 0.9032,
+  "unsafe_miss_rate_max": 0.0,
+  "hazard_recall_min": 1.0
+}

--- a/crates/kirra-doer-eval/src/lib.rs
+++ b/crates/kirra-doer-eval/src/lib.rs
@@ -190,7 +190,9 @@ pub struct DoerEvalSummary {
 /// [`PlanInput`] and the same corridor/objects to the checker within one call —
 /// the self-referential-borrow shape the planner tests build by hand.
 pub struct EvalScenario {
-    pub name: &'static str,
+    /// Scenario label. `String` so parameterized generators (WS-3.1) can mint
+    /// names like `hazard_x24_v4.0_g60`; the hand-written corpus uses literals.
+    pub name: String,
     corridor: MockCorridorSource,
     objects: Vec<PerceivedObject>,
     ego: EgoState,
@@ -205,7 +207,7 @@ impl EvalScenario {
     /// around and the checker runs RSS against.
     #[must_use]
     pub fn new(
-        name: &'static str,
+        name: impl Into<String>,
         corridor: MockCorridorSource,
         objects: Vec<PerceivedObject>,
         ego_x: f64,
@@ -213,7 +215,7 @@ impl EvalScenario {
         goal_x: f64,
     ) -> Self {
         Self {
-            name,
+            name: name.into(),
             corridor,
             objects,
             ego: EgoState {
@@ -233,6 +235,27 @@ impl EvalScenario {
     pub fn with_posture(mut self, posture: FleetPosture) -> Self {
         self.posture = posture;
         self
+    }
+
+    // Read-only world accessors (WS-3.1): the KPI gate scores planners other
+    // than the `ScoredPlanner` pair `evaluate_corpus` takes, so it needs the
+    // same world handles `verdict_of` wants. Borrowed, never mutable — a
+    // scenario stays immutable once built.
+    #[must_use]
+    pub fn corridor(&self) -> &MockCorridorSource {
+        &self.corridor
+    }
+    #[must_use]
+    pub fn objects(&self) -> &[PerceivedObject] {
+        &self.objects
+    }
+    #[must_use]
+    pub fn config(&self) -> &VehicleConfig {
+        &self.config
+    }
+    #[must_use]
+    pub fn posture(&self) -> FleetPosture {
+        self.posture
     }
 
     /// Build the borrowed [`PlanInput`] the planner sees. Every optional/behavioral

--- a/crates/kirra-kpi-gate/Cargo.toml
+++ b/crates/kirra-kpi-gate/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "kirra-kpi-gate"
+version = "0.1.0"
+edition = "2021"
+description = "WS-3.1 scenario-KPI CI gate: thresholds unsafe_miss_rate / admissibility / hazard_recall over the generated scenario corpus"
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+
+[dependencies]
+kirra-core = { path = "../kirra-core" }
+kirra-planner = { path = "../kirra-planner" }
+kirra-trajectory = { path = "../kirra-trajectory" }
+kirra-doer-eval = { path = "../kirra-doer-eval" }
+kirra-taj = { path = "../kirra-taj" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[[bin]]
+name = "scenario_kpi_gate"
+path = "src/bin/scenario_kpi_gate.rs"

--- a/crates/kirra-kpi-gate/src/bin/scenario_kpi_gate.rs
+++ b/crates/kirra-kpi-gate/src/bin/scenario_kpi_gate.rs
@@ -1,0 +1,59 @@
+//! WS-3.1 — the scenario-KPI CI gate binary.
+//!
+//! Loads the reviewed thresholds (`ci/scenario_kpi_thresholds.json`, or the
+//! path given as the first argument), runs the generated corpora through the
+//! existing metric harnesses, prints the scorecard, and exits non-zero on
+//! any KPI breach. Deterministic: a red run is a real KPI regression.
+
+use kirra_kpi_gate::{run_gate, KpiThresholds};
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "ci/scenario_kpi_thresholds.json".to_string());
+
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("scenario_kpi_gate: cannot read thresholds at {path}: {e}");
+            eprintln!("  (run from the repo root, or pass the thresholds path as the first argument)");
+            std::process::exit(2);
+        }
+    };
+    let thresholds: KpiThresholds = match serde_json::from_str(&raw) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("scenario_kpi_gate: thresholds at {path} do not parse: {e}");
+            std::process::exit(2);
+        }
+    };
+
+    let report = run_gate(&thresholds);
+
+    println!("=== Scenario-KPI gate (WS-3.1) ===");
+    println!(
+        "corpus: {} doer scenarios, {} perception frames",
+        report.doer_scenarios, report.perception_frames
+    );
+    for row in &report.rows {
+        println!(
+            "  [{}] {:<26} {:.4} (must be {} {:.4})",
+            if row.pass { "PASS" } else { "FAIL" },
+            row.name,
+            row.measured,
+            row.direction,
+            row.bound,
+        );
+    }
+
+    if report.passed() {
+        println!("KPI gate: PASS");
+    } else {
+        eprintln!(
+            "KPI gate: FAIL — a fleet-safety KPI regressed past its reviewed threshold. \
+             Fix the regression; if the change is intentional and reviewed, update {path} \
+             with a justification in the PR."
+        );
+        std::process::exit(1);
+    }
+}

--- a/crates/kirra-kpi-gate/src/lib.rs
+++ b/crates/kirra-kpi-gate/src/lib.rs
@@ -1,0 +1,399 @@
+//! # Scenario-KPI CI gate (WS-3.1)
+//!
+//! Thresholds the three fleet-safety KPIs the execution plan names —
+//! **`unsafe_miss_rate`**, **admissibility**, **`hazard_recall`** — over a
+//! parameterized, deterministic scenario corpus in the low hundreds, so that
+//! *no safety-relevant PR merges without the KPI gate* (WS-3 DoD).
+//!
+//! Three deliberate properties:
+//!
+//! - **The gate consumes the EXISTING metric harnesses** — the doer-eval
+//!   admissibility producer (`kirra_doer_eval::AdmissibilityTally` over the
+//!   real checker `validate_trajectory_slow`) and the taj safety-weighted
+//!   perception scorecard (`kirra_taj::SemanticEvalSummary`). It adds corpus
+//!   + thresholds + an exit code; it never re-implements a metric.
+//! - **Deterministic.** Generators are closed-form parameter sweeps (no RNG,
+//!   no time); the learned planner is seeded. A red gate is a real change in
+//!   doer/checker/perception behavior, never flake.
+//! - **The bar predates the model** (the taj crate's own discipline): today's
+//!   perception rows are produced through the scripted `MockSemanticDetector`
+//!   seam and pin perfection (`unsafe_miss_rate = 0`, `hazard_recall = 1`);
+//!   when the real RGB→TensorRT detector lands behind the same seam, it
+//!   inherits this gate on day one and the thresholds become a negotiation
+//!   with evidence, not a wish.
+//!
+//! Thresholds live in `ci/scenario_kpi_thresholds.json` (repo root) — the
+//! reviewed, versioned policy. The binary exits non-zero on any breach and
+//! prints the scorecard either way.
+
+use kirra_core::corridor::{MockCorridorSource, Point};
+use kirra_core::trajectory::PerceivedObject;
+use kirra_doer_eval::{verdict_of, AdmissibilityTally, EvalScenario};
+use kirra_planner::{GeometricPlanner, GeometricPlannerConfig, LearnedPlanner, Planner, Teacher};
+use kirra_taj::{
+    LaserScan, SemanticClass, SemanticDetection, SemanticDetector, MockSemanticDetector,
+    SemanticEvalFrame, SemanticEvalSummary, TajConfig, TajCorridor, TajPhaseA,
+};
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Doer corpus — parameterized sweep (WS-3.1: "corpus to low hundreds")
+// ---------------------------------------------------------------------------
+
+/// Hazard kind axis for the doer sweep. All are checker-visible
+/// `PerceivedObject`s; the kinds differ in longitudinal motion so the RSS
+/// terms (stationary lead / slower lead / oncoming closer) are all exercised.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HazardKind {
+    /// Stationary object on the centerline (the stopped-queue case).
+    Stopped,
+    /// Lead vehicle moving away slowly (+1.0 m/s along +x).
+    LeadMoving,
+    /// Oncoming vehicle closing at 2.0 m/s (−x velocity).
+    Oncoming,
+}
+
+fn hazard(kind: HazardKind, id: u64, x_m: f64) -> PerceivedObject {
+    let (v, heading) = match kind {
+        HazardKind::Stopped => (0.0, 0.0),
+        HazardKind::LeadMoving => (1.0, 0.0),
+        HazardKind::Oncoming => (2.0, std::f64::consts::PI),
+    };
+    let vx = match kind {
+        HazardKind::Stopped => 0.0,
+        HazardKind::LeadMoving => 1.0,
+        HazardKind::Oncoming => -2.0,
+    };
+    PerceivedObject {
+        id,
+        pos: Point { x_m, y_m: 0.0 },
+        velocity_mps: v,
+        heading_rad: heading,
+        vel: Point { x_m: vx, y_m: 0.0 },
+    }
+}
+
+/// The WS-3.1 doer corpus: a deterministic closed-form sweep over
+/// hazard kind × hazard distance × ego speed × goal distance, plus a
+/// clear-road row per (speed, goal). No RNG — the corpus is identical on
+/// every run and every machine.
+///
+/// Size: 3 kinds × 10 distances × 4 speeds × 2 goals + 4×2 clear-road
+/// = **248 scenarios** (pinned by test).
+#[must_use]
+pub fn generated_doer_corpus() -> Vec<EvalScenario> {
+    let road = || MockCorridorSource::straight_5m_half_width(100.0);
+    let speeds = [1.0, 2.0, 4.0, 6.0];
+    let goals = [40.0, 60.0];
+    let distances = [12.0, 16.0, 20.0, 24.0, 28.0, 32.0, 36.0, 40.0, 44.0, 48.0];
+    let kinds = [HazardKind::Stopped, HazardKind::LeadMoving, HazardKind::Oncoming];
+
+    let mut corpus = Vec::new();
+    for &speed in &speeds {
+        for &goal in &goals {
+            corpus.push(EvalScenario::new(
+                format!("clear_v{speed}_g{goal}"),
+                road(),
+                vec![],
+                5.0,
+                speed,
+                goal,
+            ));
+            for &kind in &kinds {
+                for &dist in &distances {
+                    corpus.push(EvalScenario::new(
+                        format!("{kind:?}_x{dist}_v{speed}_g{goal}"),
+                        road(),
+                        vec![hazard(kind, 1, dist)],
+                        5.0,
+                        speed,
+                        goal,
+                    ));
+                }
+            }
+        }
+    }
+    corpus
+}
+
+/// Admissibility of a planner over the corpus: every proposal is run through
+/// the REAL checker (`validate_trajectory_slow` via `verdict_of`); the rate
+/// is `kirra_doer_eval::AdmissibilityTally::admissibility_rate` (fail-closed:
+/// an empty corpus scores 0.0, not 1.0).
+fn admissibility_over(corpus: &[EvalScenario], mut plan: impl FnMut(&EvalScenario) -> kirra_planner::PlanOutput) -> (f64, AdmissibilityTally) {
+    let mut tally = AdmissibilityTally::default();
+    for sc in corpus {
+        let out = plan(sc);
+        tally.record(verdict_of(&out, sc.corridor(), sc.objects(), sc.config(), sc.posture()));
+    }
+    (tally.admissibility_rate(), tally)
+}
+
+// ---------------------------------------------------------------------------
+// Perception corpus — parameterized frames through the fusion oracle
+// ---------------------------------------------------------------------------
+
+/// One owned perception case (the borrowed `SemanticEvalFrame` shape needs an
+/// owner for corridor + detection sets).
+pub struct PerceptionCase {
+    pub name: String,
+    pub corridor: TajCorridor,
+    pub truth: Vec<SemanticDetection>,
+    pub detected: Vec<SemanticDetection>,
+}
+
+/// A wide-open ~20 m corridor built through the real Phase-A geometric
+/// pipeline (the same substrate the taj fusion tests use), so the binding
+/// hazard in each frame is the semantic one, never geometry.
+fn open_corridor() -> TajCorridor {
+    let taj = TajPhaseA::new(TajConfig { forward_extent_m: 20.0, ..Default::default() });
+    let n = 180usize;
+    let mut ranges = vec![f32::INFINITY; n];
+    ranges[10] = 30.0;
+    ranges[170] = 30.0;
+    let scan = LaserScan {
+        angle_min_rad: -std::f64::consts::FRAC_PI_2,
+        angle_increment_rad: std::f64::consts::PI / (n as f64 - 1.0),
+        range_min_m: 0.1,
+        range_max_m: 40.0,
+        ranges,
+        stamp_ms: 0,
+    };
+    taj.process(&scan, 0).corridor
+}
+
+/// The WS-3.1 perception corpus: hazard class × near distance × lateral
+/// span, plus hazard-free frames. The detector under test is the shipped
+/// seam — today the scripted [`MockSemanticDetector`] fed the same scene, so
+/// the corpus pins perfection; the real detector inherits the corpus (and
+/// the thresholds) unchanged behind the same trait.
+///
+/// Size: 2 classes × 11 distances × 3 spans + 5 clear = **71 frames**
+/// (pinned by test).
+#[must_use]
+pub fn generated_perception_corpus() -> Vec<PerceptionCase> {
+    let classes = [SemanticClass::Water, SemanticClass::StaticObstacle];
+    let spans: [(f64, f64); 3] = [(-5.0, 5.0), (-2.0, 1.0), (0.5, 4.0)];
+    let mut cases = Vec::new();
+
+    for i in 0..5u32 {
+        cases.push(PerceptionCase {
+            name: format!("clear_{i}"),
+            corridor: open_corridor(),
+            truth: vec![],
+            detected: MockSemanticDetector::default().detect(),
+        });
+    }
+    for &class in &classes {
+        for step in 0..11u32 {
+            let near_x = 3.0 + 1.5 * f64::from(step);
+            for (si, &(lo, hi)) in spans.iter().enumerate() {
+                let det = SemanticDetection {
+                    class,
+                    near_x_m: near_x,
+                    lateral_min_m: lo,
+                    lateral_max_m: hi,
+                };
+                // The shipped detector seam: a scripted mock carrying the
+                // scene's hazards — `detect()` is the trait the real model
+                // will implement.
+                let detector = MockSemanticDetector { detections: vec![det] };
+                cases.push(PerceptionCase {
+                    name: format!("{class:?}_x{near_x}_span{si}"),
+                    corridor: open_corridor(),
+                    truth: vec![det],
+                    detected: detector.detect(),
+                });
+            }
+        }
+    }
+    cases
+}
+
+/// Score the perception corpus through the taj safety-weighted harness.
+#[must_use]
+pub fn score_perception(cases: &[PerceptionCase]) -> SemanticEvalSummary {
+    SemanticEvalSummary::from_frames(cases.iter().map(|c| SemanticEvalFrame {
+        corridor: &c.corridor,
+        truth: &c.truth,
+        detected: &c.detected,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Thresholds + gate verdict
+// ---------------------------------------------------------------------------
+
+/// The reviewed KPI policy (`ci/scenario_kpi_thresholds.json`). Every field
+/// is required — a threshold that silently defaults is not a policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KpiThresholds {
+    /// Free-text rationale — travels with the numbers.
+    #[serde(rename = "_comment")]
+    pub comment: String,
+    /// Min fraction of GEOMETRIC-planner proposals the checker admits
+    /// without an MRC (`Accept | Clamp`) over the doer corpus.
+    pub geometric_admissibility_min: f64,
+    /// Min admissibility for the seeded SafetyAware learned planner.
+    pub learned_admissibility_min: f64,
+    /// Max fraction of perception frames where the detector's drivable
+    /// extent runs PAST ground truth (the catastrophic direction).
+    pub unsafe_miss_rate_max: f64,
+    /// Min fraction of true binding hazards the detector catches.
+    pub hazard_recall_min: f64,
+}
+
+/// One evaluated KPI row: measured value vs its bound.
+#[derive(Debug, Clone, Serialize)]
+pub struct KpiRow {
+    pub name: &'static str,
+    pub measured: f64,
+    /// `">="` or `"<="` — which side of `bound` passes.
+    pub direction: &'static str,
+    pub bound: f64,
+    pub pass: bool,
+}
+
+impl KpiRow {
+    fn at_least(name: &'static str, measured: f64, bound: f64) -> Self {
+        Self { name, measured, direction: ">=", bound, pass: measured >= bound }
+    }
+    fn at_most(name: &'static str, measured: f64, bound: f64) -> Self {
+        Self { name, measured, direction: "<=", bound, pass: measured <= bound }
+    }
+}
+
+/// The full gate outcome: every row, plus corpus sizes for the report.
+#[derive(Debug, Clone, Serialize)]
+pub struct GateReport {
+    pub doer_scenarios: usize,
+    pub perception_frames: usize,
+    pub rows: Vec<KpiRow>,
+}
+
+impl GateReport {
+    #[must_use]
+    pub fn passed(&self) -> bool {
+        self.rows.iter().all(|r| r.pass)
+    }
+}
+
+/// Run the whole gate: generate both corpora, produce the three KPIs through
+/// the existing harnesses, and threshold them.
+#[must_use]
+pub fn run_gate(t: &KpiThresholds) -> GateReport {
+    let corpus = generated_doer_corpus();
+
+    // Geometric doer (the shipped default proposer). `Planner::plan` takes
+    // &mut self; a fresh planner per scenario keeps scenarios independent.
+    let (geo_rate, _) = admissibility_over(&corpus, |sc| {
+        GeometricPlanner::new(GeometricPlannerConfig::default()).plan(&sc.plan_input())
+    });
+
+    // Seeded SafetyAware learned doer (the ScoredPlanner path — same seam the
+    // quantization scorecard uses).
+    let learned = LearnedPlanner::trained(7, Teacher::SafetyAware);
+    let (learned_rate, _) = admissibility_over(&corpus, |sc| {
+        learned.plan_with_chosen_index(&sc.plan_input()).1
+    });
+
+    let cases = generated_perception_corpus();
+    let perception = score_perception(&cases);
+
+    GateReport {
+        doer_scenarios: corpus.len(),
+        perception_frames: cases.len(),
+        rows: vec![
+            KpiRow::at_least("geometric_admissibility", geo_rate, t.geometric_admissibility_min),
+            KpiRow::at_least("learned_admissibility", learned_rate, t.learned_admissibility_min),
+            KpiRow::at_most("unsafe_miss_rate", perception.unsafe_miss_rate(), t.unsafe_miss_rate_max),
+            KpiRow::at_least("hazard_recall", perception.hazard_recall(), t.hazard_recall_min),
+        ],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Corpus sizes are pinned: a silent shrink would weaken the gate while
+    /// it kept reporting green.
+    #[test]
+    fn corpus_sizes_are_pinned_at_low_hundreds() {
+        assert_eq!(generated_doer_corpus().len(), 248);
+        assert_eq!(generated_perception_corpus().len(), 71);
+    }
+
+    /// The generators are deterministic: two invocations produce identical
+    /// scenario names in identical order (no RNG, no time).
+    #[test]
+    fn generators_are_deterministic() {
+        let a: Vec<String> = generated_doer_corpus().into_iter().map(|s| s.name).collect();
+        let b: Vec<String> = generated_doer_corpus().into_iter().map(|s| s.name).collect();
+        assert_eq!(a, b);
+        let pa: Vec<String> = generated_perception_corpus().into_iter().map(|c| c.name).collect();
+        let pb: Vec<String> = generated_perception_corpus().into_iter().map(|c| c.name).collect();
+        assert_eq!(pa, pb);
+    }
+
+    fn committed_thresholds() -> KpiThresholds {
+        // The gate tests run from the crate dir; the binary defaults to the
+        // repo-root path. Resolve relative to the manifest.
+        let p = concat!(env!("CARGO_MANIFEST_DIR"), "/../../ci/scenario_kpi_thresholds.json");
+        serde_json::from_str(&std::fs::read_to_string(p).expect("committed thresholds exist"))
+            .expect("thresholds parse")
+    }
+
+    /// THE WS-3.1 DoD (green half): the gate PASSES against the committed
+    /// thresholds — the numbers in ci/ are honest for the current tree.
+    #[test]
+    fn gate_passes_against_committed_thresholds() {
+        let report = run_gate(&committed_thresholds());
+        assert!(
+            report.passed(),
+            "the committed thresholds must hold on the current tree: {report:#?}"
+        );
+    }
+
+    /// THE WS-3.1 DoD (red half): a KPI regression turns the gate red. An
+    /// impossible bound stands in for the regression — the wiring from
+    /// measured value to verdict is what is under test.
+    #[test]
+    fn gate_goes_red_on_a_kpi_breach() {
+        let mut t = committed_thresholds();
+        t.geometric_admissibility_min = 1.01; // unreachable: rate is ≤ 1.0
+        let report = run_gate(&t);
+        assert!(!report.passed(), "an unreachable bound must red the gate");
+        assert!(
+            report.rows.iter().any(|r| r.name == "geometric_admissibility" && !r.pass),
+            "the breach must be attributed to the right row: {report:#?}"
+        );
+    }
+
+    /// The perception axis detects a real unsafe miss: a detector that drops
+    /// a true hazard breaches unsafe_miss_rate/hazard_recall — the metric is
+    /// live, not vacuously green.
+    #[test]
+    fn blind_detector_breaches_the_perception_kpis() {
+        let mut cases = generated_perception_corpus();
+        for c in &mut cases {
+            c.detected.clear(); // a detector that sees nothing
+        }
+        let s = score_perception(&cases);
+        assert!(s.unsafe_miss_rate() > 0.5, "a blind detector must unsafe-miss most hazard frames");
+        assert_eq!(s.hazard_recall(), 0.0, "a blind detector catches nothing");
+    }
+
+    /// An empty corpus fails closed through the underlying tally (0.0 ≠ 1.0).
+    #[test]
+    fn empty_corpus_scores_zero_admissibility() {
+        let (rate, tally) = admissibility_over(&[], |_| unreachable!("no scenarios"));
+        assert_eq!(rate, 0.0);
+        assert_eq!(tally.total(), 0);
+    }
+}


### PR DESCRIPTION
**PR 8 — the first post-GATE-A item: WS-3 Phase 1 (scenario & evidence engine), closing the Stage-1 slice of G9.**

## What it is

A new `crates/kirra-kpi-gate` crate + CI job that thresholds the three fleet-safety KPIs the plan names — **`unsafe_miss_rate`**, **admissibility**, **`hazard_recall`** — over a parameterized scenario corpus in the low hundreds. Red = a fleet-safety KPI regressed past the reviewed policy; the WS-3 DoD ("no safety-relevant PR merges without the KPI gate") starts here.

Three design properties:

- **It consumes the existing metric harnesses, never re-implements one.** Admissibility runs every proposal through the *real checker* (`validate_trajectory_slow` via `kirra_doer_eval::verdict_of`) into the existing `AdmissibilityTally` (fail-closed: an empty corpus scores 0.0). Perception scores through `kirra_taj::SemanticEvalSummary` at the fusion oracle. Two doers are scored: the shipped `GeometricPlanner` and the seeded SafetyAware `LearnedPlanner` (the quantization-scorecard seam).
- **Deterministic.** Closed-form generators (no RNG, no time), seeded planner — a red gate is a real behavior change, never flake. Corpus sizes are **pinned by test** (248 doer scenarios: hazard kind {stopped, lead-moving, oncoming} × 10 distances × 4 ego speeds × 2 goals + clear-road rows; 71 perception frames: class {Water, StaticObstacle} × 11 distances × 3 lateral spans + clear frames) — a silent shrink can't weaken the gate while reporting green.
- **The bar predates the model** (the taj crate's own discipline): today's perception frames run through the scripted `MockSemanticDetector` **seam** and pin perfection; when the real RGB→TensorRT detector lands behind the same trait, it inherits corpus and thresholds on day one.

## The policy

`ci/scenario_kpi_thresholds.json` — bounds set **at the measured floor** (exact rationals, since everything is deterministic): geometric admissibility 240/248 = 0.9677, learned 224/248 = 0.9032, `unsafe_miss_rate` ≤ 0.0, `hazard_recall` ≥ 1.0. Moving a bound down requires a justified change to the file in the PR; improvements tighten it (ratchet). `deny_unknown_fields` so a typo'd threshold can't silently default.

## DoD proven both ways

- **Green:** the gate passes against the committed thresholds — also pinned as a unit test, so plain `cargo test` catches a KPI regression even without the CI job.
- **Red:** `gate_goes_red_on_a_kpi_breach` (unreachable bound → red, attributed to the right row); `blind_detector_breaches_the_perception_kpis` (a detector that sees nothing: `unsafe_miss_rate` > 0.5, recall 0 — the metric is live, not vacuously green); binary-level runs (breach → exit 1 with the failing row named; missing/unparsable policy → exit 2).

Supporting changes: `EvalScenario.name` `&'static str` → `String` (generated names) and read-only world accessors on `EvalScenario`; the new CI job runs `cargo run --locked -p kirra-kpi-gate` on every push/PR.

118 workspace suites green; clippy zero warnings; guardrails + deny gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_