### PR TITLE
ci/release: QNX governor-judge cross-build — recipe promoted to pipeline (WS-5.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,31 @@ jobs:
       - name: KPI gate (unsafe_miss_rate / admissibility / hazard_recall)
         run: cargo run --locked -p kirra-kpi-gate --bin scenario_kpi_gate
 
+  # WS-5.1 — the QNX governor-judge cross-build: the EPIC-#270 no_std
+  # core-only judge staticlib for both QNX 8.0 tuples (x86_64 + the aarch64
+  # deployment ISA), via stable + -Zbuild-std=core (no proprietary SDP — a
+  # staticlib needs no final link). Proves on every PR that the partition
+  # verdict core still cross-compiles; the release workflow ships the same
+  # artifact into the SHA256SUMS + cosign chain. NO timing claim (see the
+  # script header / PROVENANCE.txt).
+  qnx-governor-artifact:
+    name: QNX governor-judge cross-build (WS-5.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-src
+      - name: Build the judge staticlibs (x86_64 + aarch64 nto-qnx800)
+        run: scripts/build_qnx_judge_artifact.sh dist-qnx
+      - name: Upload artifact (PR inspection; releases ship the signed copy)
+        uses: actions/upload-artifact@v7
+        with:
+          name: kirra-qnx800-judge
+          path: dist-qnx/
+          retention-days: 7
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,9 +188,43 @@ jobs:
           path: kirra-*.cdx.json
           retention-days: 1
 
+  # WS-5.1 — the QNX governor-judge artifact: the no_std core-only verdict
+  # staticlib for both QNX 8.0 tuples, tarred with its ABI header and
+  # provenance manifest. Named kirra-<version>-qnx800-judge.tar.gz so the
+  # release job's existing *.tar.gz handling carries it into SHA256SUMS and
+  # the keyless cosign signing — the artifact enters the supply-chain trust
+  # chain like every platform tarball. Functional artifact only: timing/WCET
+  # evidence is QNX-target-only (PROVENANCE.txt states this).
+  qnx-artifact:
+    name: QNX governor-judge artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain (+rust-src for -Zbuild-std)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-src
+
+      - name: Build the judge staticlibs
+        run: scripts/build_qnx_judge_artifact.sh dist-qnx
+
+      - name: Package
+        run: |
+          VERSION="${{ github.ref_name }}"
+          tar -czf "kirra-${VERSION}-qnx800-judge.tar.gz" -C dist-qnx .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: kirra-qnx800-judge
+          path: kirra-*-qnx800-judge.tar.gz
+          retention-days: 1
+
   release:
     name: Create GitHub Release
-    needs: [build, sbom]
+    needs: [build, sbom, qnx-artifact]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/adr/KIRRA_QNX_RUNBOOK.md
+++ b/docs/adr/KIRRA_QNX_RUNBOOK.md
@@ -60,6 +60,16 @@ rustup component add rust-src --toolchain nightly
 script's first path — a direct `rustc --target` cross-build — is used instead and
 nightly/rust-src are not needed. The script tries direct first, then build-std.)
 
+> **WS-5.1 — this recipe is now a pipeline.** CI cross-builds the judge for
+> BOTH qnx800 tuples on every PR (`qnx-governor-artifact` job), and every
+> release ships `kirra-<version>-qnx800-judge.tar.gz` (staticlibs + the
+> `kirra_ffi.h` ABI + a provenance manifest) through the SHA256SUMS + cosign
+> chain. Entry point: `scripts/build_qnx_judge_artifact.sh` — stable +
+> `RUSTC_BOOTSTRAP=1 -Zbuild-std=core` (no SDP needed for the staticlib), with
+> machine-arch and `kirra_judge_assess` ABI-export acceptance checks. Note the
+> upstream tuple rename in flight (`*-nto-qnx800` → `x86_64-pc-qnx` /
+> `aarch64-unknown-qnx` on 2026 nightlies); the script follows it loudly.
+
 ### 1b. QNX target VM (Phase-I, x86 laptop)
 
 - Enable **Intel VT-x** (and **VT-d** if you'll pass through devices) in BIOS, so

--- a/scripts/build_qnx_judge_artifact.sh
+++ b/scripts/build_qnx_judge_artifact.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# build_qnx_judge_artifact.sh — WS-5.1: the QNX governor-judge artifact build.
+#
+# Cross-compiles the EPIC-#270 governor JUDGE (`tools/qnx-rtm-harness/
+# kirra_judge.rs` — the #![no_std], zero-alloc, core-only contract checker)
+# for the QNX 8.0 targets, producing one staticlib per target plus a
+# provenance manifest. This is the recipe→pipeline promotion of the
+# `-Zbuild-std=core` lane from KIRRA_QNX_RUNBOOK.md / run_qnx_fdit.sh:
+# because the judge is core-only and a STATICLIB needs no final link, the
+# cross-build requires NO proprietary QNX SDP — upstream nightly + rust-src
+# is enough, so it runs in plain CI.
+#
+# What this artifact IS: the portable verdict core (judge) the C++ shim
+# links against on the QNX safety partition (ADR-0006 Clause 3 boundary).
+# What it is NOT: a WCET/timing claim. Host-built artifacts carry no timing
+# evidence — only QNX-target-under-SCHED_FIFO runs do (AOU-HW-QNX-TARGET-001,
+# docs/safety/WCET_MEASUREMENT_METHODOLOGY.md). PROVENANCE.txt states this.
+#
+# Toolchain note: the ACTIVE toolchain is used. On stable, -Zbuild-std is
+# unlocked with RUSTC_BOOTSTRAP=1 — the same documented fallback as
+# run_qnx_fdit.sh, and deliberately so here: current stable (1.94) still
+# ships the `*-nto-qnx800` tuples, while nightly 1.98 has RENAMED them to
+# `aarch64-unknown-qnx` / `x86_64-pc-qnx`. The script prefers the qnx800
+# spelling and falls back to the renamed tuple LOUDLY when stable picks up
+# the rename, so the pipeline degrades with a visible message, never a
+# silent wrong artifact.
+#
+# Usage:
+#   scripts/build_qnx_judge_artifact.sh [out-dir]     # default: dist-qnx
+# Env:
+#   KIRRA_QNX_TARGETS   space-separated tuples
+#                       (default: "x86_64-pc-nto-qnx800 aarch64-unknown-nto-qnx800")
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+JUDGE_SRC="$REPO_ROOT/tools/qnx-rtm-harness/kirra_judge.rs"
+FFI_HEADER="$REPO_ROOT/tools/qnx-rtm-harness/kirra_ffi.h"
+OUT="${1:-dist-qnx}"
+TARGETS="${KIRRA_QNX_TARGETS:-x86_64-pc-nto-qnx800 aarch64-unknown-nto-qnx800}"
+
+mkdir -p "$OUT"
+OUT="$(cd "$OUT" && pwd)"
+
+# rust-src is required for -Zbuild-std (core is compiled from source for the
+# tier-3 nto tuples — rustup ships no prebuilt core/std for them).
+SYSROOT="$(rustc --print sysroot)"
+if [[ ! -d "$SYSROOT/lib/rustlib/src/rust" ]]; then
+    echo "ERROR: rust-src missing — run: rustup component add rust-src" >&2
+    exit 2
+fi
+
+# -Z flags need a nightly compiler OR RUSTC_BOOTSTRAP=1 on stable (the
+# run_qnx_fdit.sh fallback). Detect which we have.
+BOOT=()
+if ! rustc --version | grep -q nightly; then
+    BOOT=(env RUSTC_BOOTSTRAP=1)
+fi
+
+# Resolve a requested tuple against this toolchain, following the upstream
+# rename (nto-qnx800 → version-less qnx tuples on 2026 nightlies).
+resolve_target() {
+    local want="$1" renamed=""
+    rustc --print target-list | grep -qx "$want" && { echo "$want"; return 0; }
+    case "$want" in
+        x86_64-pc-nto-qnx800)       renamed="x86_64-pc-qnx" ;;
+        aarch64-unknown-nto-qnx800) renamed="aarch64-unknown-qnx" ;;
+    esac
+    if [[ -n "$renamed" ]] && rustc --print target-list | grep -qx "$renamed"; then
+        echo "NOTE: tuple '$want' is gone from this toolchain — using its upstream rename '$renamed'" >&2
+        echo "$renamed"
+        return 0
+    fi
+    return 1
+}
+
+# Throwaway cargo wrapper (the judge is a single dependency-free .rs built by
+# rustc in the harness; -Zbuild-std is cargo-level, so wrap it). The leading
+# empty [workspace] detaches it from the repo workspace. Same technique as
+# run_qnx_fdit.sh::build_judge_buildstd — one recipe, two entry points.
+CRATE="$(mktemp -d)"
+trap 'rm -rf "$CRATE"' EXIT
+mkdir -p "$CRATE/src"
+cp "$JUDGE_SRC" "$CRATE/src/lib.rs"
+cat > "$CRATE/Cargo.toml" <<'EOF'
+[workspace]
+
+[package]
+name = "kirra_judge"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["staticlib"]
+
+[profile.release]
+panic = "abort"
+opt-level = 2
+debug = false
+EOF
+
+for want in $TARGETS; do
+    tgt="$(resolve_target "$want")" || { echo "ERROR: no usable tuple for '$want' on $(rustc --version)" >&2; exit 2; }
+    echo "== building judge staticlib for $tgt (-Zbuild-std=core, $(rustc --version | cut -d' ' -f2))"
+    ( cd "$CRATE" && "${BOOT[@]}" cargo build --release -Z build-std=core --target "$tgt" )
+    lib="$CRATE/target/$tgt/release/libkirra_judge.a"
+    [[ -f "$lib" ]] || { echo "ERROR: expected $lib missing" >&2; exit 1; }
+
+    # Acceptance check: the archive's objects must be ELF for the TARGET
+    # machine, not the host (a silent host-arch fallback would ship a wrong
+    # artifact that only fails at partition link time).
+    case "$tgt" in
+        x86_64-*)  mach="Advanced Micro Devices X86-64" ;;
+        aarch64-*) mach="AArch64" ;;
+        *)         mach="" ;;
+    esac
+    if [[ -n "$mach" ]]; then
+        got="$(readelf -h "$lib" 2>/dev/null | grep -m1 'Machine:' || true)"
+        echo "$got" | grep -q "$mach" \
+            || { echo "ERROR: $tgt archive machine check failed: '$got' (want '$mach')" >&2; exit 1; }
+        echo "   machine ok: ${got#*Machine:}"
+    fi
+    # The kirra_ffi.h ABI entry point must be exported, or the shim has
+    # nothing to link against. (nm exits non-zero on the archive's rmeta
+    # member while still printing real symbols — capture first so pipefail
+    # judges the grep, not nm's complaint.)
+    syms="$(nm "$lib" 2>/dev/null || true)"
+    grep -q " T kirra_judge_assess" <<<"$syms" \
+        || { echo "ERROR: $tgt archive does not export kirra_judge_assess (ABI break?)" >&2; exit 1; }
+    echo "   abi ok: kirra_judge_assess exported"
+    cp "$lib" "$OUT/libkirra_judge-$tgt.a"
+done
+
+cp "$FFI_HEADER" "$OUT/kirra_ffi.h"
+
+# Provenance: what built this, from what, and what it does NOT claim.
+cat > "$OUT/PROVENANCE.txt" <<EOF
+kirra QNX governor-judge artifact (WS-5.1)
+==========================================
+source      : tools/qnx-rtm-harness/kirra_judge.rs (+ kirra_ffi.h, the ABI)
+commit      : $(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)
+targets     : $TARGETS
+toolchain   : $(rustc --version)
+build       : cargo -Zbuild-std=core --release (staticlib; panic=abort, opt-level=2)
+dependencies: NONE beyond rust core/compiler_builtins (the judge is
+              #![no_std], zero-alloc, dependency-free by design — its SBOM
+              is this toolchain line).
+
+Integration : link against the C++ shim per tools/qnx-rtm-harness/README.md
+              (ADR-0006 Clause 3 — the shim is the memory/transport DRIVER,
+              this judge is the contract CHECKER).
+NO TIMING CLAIM: this is a host-built functional artifact. WCET/FTTI
+              evidence comes ONLY from QNX-target-under-SCHED_FIFO runs
+              (AOU-HW-QNX-TARGET-001; docs/safety/WCET_MEASUREMENT_METHODOLOGY.md).
+EOF
+
+echo "== artifact contents ($OUT):"
+ls -l "$OUT"

--- a/scripts/build_qnx_judge_artifact.sh
+++ b/scripts/build_qnx_judge_artifact.sh
@@ -98,6 +98,7 @@ opt-level = 2
 debug = false
 EOF
 
+BUILT_TARGETS=""
 for want in $TARGETS; do
     tgt="$(resolve_target "$want")" || { echo "ERROR: no usable tuple for '$want' on $(rustc --version)" >&2; exit 2; }
     echo "== building judge staticlib for $tgt (-Zbuild-std=core, $(rustc --version | cut -d' ' -f2))"
@@ -128,6 +129,7 @@ for want in $TARGETS; do
         || { echo "ERROR: $tgt archive does not export kirra_judge_assess (ABI break?)" >&2; exit 1; }
     echo "   abi ok: kirra_judge_assess exported"
     cp "$lib" "$OUT/libkirra_judge-$tgt.a"
+    BUILT_TARGETS="${BUILT_TARGETS:+$BUILT_TARGETS }$tgt"
 done
 
 cp "$FFI_HEADER" "$OUT/kirra_ffi.h"
@@ -137,8 +139,9 @@ cat > "$OUT/PROVENANCE.txt" <<EOF
 kirra QNX governor-judge artifact (WS-5.1)
 ==========================================
 source      : tools/qnx-rtm-harness/kirra_judge.rs (+ kirra_ffi.h, the ABI)
+requested   : $TARGETS
 commit      : $(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)
-targets     : $TARGETS
+targets     : $BUILT_TARGETS
 toolchain   : $(rustc --version)
 build       : cargo -Zbuild-std=core --release (staticlib; panic=abort, opt-level=2)
 dependencies: NONE beyond rust core/compiler_builtins (the judge is


### PR DESCRIPTION
**PR 9 — WS-5.1, opening the certification leg (WS-5 runs parallel from Stage 1): the QNX cross-build recipe becomes a pipeline, and the governor artifact enters the supply-chain trust chain.**

## The artifact

The EPIC-#270 governor **judge** (`tools/qnx-rtm-harness/kirra_judge.rs` — the `#[no_std]`, zero-alloc, core-only contract checker the C++ shim links against on the QNX safety partition, ADR-0006 Clause 3). Because it's core-only and a **staticlib needs no final link**, the cross-build requires *no proprietary QNX SDP*: stable + `RUSTC_BOOTSTRAP=1` + `rust-src` (`-Zbuild-std=core`) is enough — the same fallback lane `run_qnx_fdit.sh` already documents. Both QNX 8.0 tuples build in ~35 s: `x86_64-pc-nto-qnx800` and the **aarch64 deployment ISA** (`aarch64-unknown-nto-qnx800`).

## `scripts/build_qnx_judge_artifact.sh`

One entry point, with acceptance checks rather than hope:
- **ELF machine assert** per target (a silent host-arch fallback must never ship a wrong artifact that only fails at partition link time) — verified emitting `AArch64` / `X86-64` respectively.
- **ABI export assert**: `kirra_judge_assess` (the `kirra_ffi.h` entry point) must be in the archive, or the shim has nothing to link.
- **Upstream tuple rename handled loudly**: discovered empirically that 2026 nightlies **renamed** the qnx800 tuples to `x86_64-pc-qnx` / `aarch64-unknown-qnx` (nightly 1.98 no longer lists `nto-qnx800`; stable 1.94 still does). The script prefers the qnx800 spelling and falls back to the rename with a visible NOTE when stable follows — a loud degradation, never a silent wrong artifact.
- **`PROVENANCE.txt`** ships inside the artifact: source, commit, toolchain, build flags, and the explicit **no-timing-claim** statement (host-built functional artifact; WCET/FTTI evidence is QNX-target-under-SCHED_FIFO only, AOU-HW-QNX-TARGET-001) — the honesty invariant the harness banners enforce, carried onto the shipped artifact. The judge is dependency-free by design (core + compiler_builtins only), so its SBOM *is* the toolchain line.

## CI + release wiring

- **CI job `qnx-governor-artifact`**: cross-builds both tuples on every push/PR — the partition verdict core can no longer silently rot — and uploads staticlibs + ABI header + provenance for inspection.
- **Release job `qnx-artifact`**: ships `kirra-<version>-qnx800-judge.tar.gz`; the name rides the release job's existing `*.tar.gz` handling, so the artifact enters **`SHA256SUMS` and the keyless cosign chain** exactly like the platform tarballs — the WS-5.1 "artifact enters the cosign/SBOM chain" DoD.

## Verified

End-to-end locally: both staticlibs build, machine + ABI checks pass, the artifact assembles with provenance. Two `set -o pipefail` traps were found and fixed en route (nm's rmeta complaint failing a matching grep; `grep -q` SIGPIPE-ing `echo`) — the checks now judge the grep, not the plumbing. Runbook updated with the recipe→pipeline cross-reference including the tuple-rename note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_