### PR TITLE
checker: pedestrian/VRU RSS — omnidirectional reachable-set bound wired into the slow validator (WS-2)

### DIFF
--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -705,6 +705,12 @@ pub async fn run_adapter(
                 // worst-cases over them, refusing a trajectory a predicted cut-in / turn-in
                 // breaches even though the snapshot showed the object laterally clear.
                 Some(&predicted_modes),
+                // WS-2 pedestrian/VRU RSS: no VRU perception channel is wired on the
+                // node yet -> None (no-op, byte-identical). The `~/input/pedestrians`
+                // subscription + classification ingest is the tracked follow-up
+                // (docs/safety/PEDESTRIAN_RSS.md par.6); once wired, the live scene
+                // arms the omnidirectional reachable-set bound in the checker.
+                None,
                 // Frame/localization integrity (S-FI1): the LIVE frame trust resolved from the
                 // integrator's per-tick `update_frame_integrity` report. With no source wired
                 // this returns `Trusted` — the AOU-LOCALIZATION-001 seam (byte-for-byte the

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -687,7 +687,7 @@ fn occlusion_rejects_a_trajectory_that_outruns_assured_clear_distance() {
     let cfg = VehicleConfig::default_urban();
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(5.0), None, FrameTrust::Trusted,
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(5.0), None, None, FrameTrust::Trusted,
     );
     assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
         "10 m/s into 5 m of visibility outruns the assured clear distance; got {verdict:?}");
@@ -703,7 +703,7 @@ fn occlusion_bound_is_gated_off_when_no_visibility_is_supplied() {
     let cfg = VehicleConfig::default_urban();
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None, None, FrameTrust::Trusted,
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None, None, None, FrameTrust::Trusted,
     );
     assert_ne!(verdict, TrajectoryVerdict::MRCFallback,
         "with no visibility input the occlusion bound is a no-op; got {verdict:?}");
@@ -720,13 +720,13 @@ fn untrusted_frame_mrcs_an_otherwise_clean_trajectory() {
     let cfg = VehicleConfig::default_urban();
 
     let trusted = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None, None, FrameTrust::Trusted,
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None, None, None, FrameTrust::Trusted,
     );
     assert_ne!(trusted, TrajectoryVerdict::MRCFallback,
         "a clean trajectory under a Trusted frame must not MRC; got {trusted:?}");
 
     let untrusted = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None, None, FrameTrust::Untrusted,
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, None, None, None, FrameTrust::Untrusted,
     );
     assert_eq!(untrusted, TrajectoryVerdict::MRCFallback,
         "the SAME clean trajectory must MRC under an Untrusted frame; got {untrusted:?}");
@@ -742,7 +742,7 @@ fn occlusion_admits_a_decel_to_stop_within_visibility() {
     let cfg = VehicleConfig::default_urban();
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(20.0), None, FrameTrust::Trusted,
+        &trajectory, &corridor, &objects, &cfg, None, FleetPosture::Nominal, None, Some(20.0), None, None, FrameTrust::Trusted,
     );
     assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
         "a decel-to-stop within the assured clear distance is admissible; got {verdict:?}");
@@ -782,7 +782,7 @@ fn predictive_rss_does_not_regress_a_lane_keeping_neighbor() {
     let modes = [PredictedMode { object_id: 1, samples: &samples }];
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), FrameTrust::Trusted,
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), None, FrameTrust::Trusted,
     );
     assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
         "a neighbor predicted to keep its lane must not be rejected; got {verdict:?}");
@@ -809,7 +809,7 @@ fn predictive_rss_catches_a_predicted_cut_in() {
     let modes = [PredictedMode { object_id: 1, samples: &samples }];
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), FrameTrust::Trusted,
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), None, FrameTrust::Trusted,
     );
     assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
         "a predicted cut-in into the ego's path must be refused; got {verdict:?}");
@@ -839,7 +839,7 @@ fn predictive_rss_catches_a_mid_band_lateral_cut_in() {
     let modes = [PredictedMode { object_id: 1, samples: &samples }];
 
     let verdict = validate_trajectory_slow_capped(
-        &ego, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), FrameTrust::Trusted,
+        &ego, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), None, FrameTrust::Trusted,
     );
     assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
         "a mid-band predicted lateral cut-in at a safe longitudinal distance must be refused; got {verdict:?}");
@@ -875,7 +875,7 @@ fn produced_cv_mode_catches_a_cut_in_the_snapshot_rss_misses() {
 
     // Snapshot-only (object passed, no produced modes): laterally clear now → admitted.
     let snapshot_only = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, None, FrameTrust::Trusted,
+        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, None, None, FrameTrust::Trusted,
     );
     assert!(matches!(snapshot_only, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
         "snapshot RSS alone sees the object as out-of-lane → admits; got {snapshot_only:?}");
@@ -884,7 +884,7 @@ fn produced_cv_mode_catches_a_cut_in_the_snapshot_rss_misses() {
     let owned = predicted_modes_from_objects(&[obj], &[], &[], 3.0, 0.5);
     let modes: Vec<_> = owned.iter().map(|m| m.as_mode()).collect();
     let with_modes = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), FrameTrust::Trusted,
+        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), None, FrameTrust::Trusted,
     );
     assert_eq!(with_modes, TrajectoryVerdict::MRCFallback,
         "the produced CV mode catches the cut-in the snapshot missed; got {with_modes:?}");
@@ -905,7 +905,7 @@ fn produced_ctrv_mode_catches_a_turn_in_that_cv_misses_multimodal_payoff() {
     let cv_owned = predicted_modes_from_objects(&[obj], &[], &[], 3.0, 0.5);
     let cv_modes: Vec<_> = cv_owned.iter().map(|m| m.as_mode()).collect();
     let cv = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&cv_modes), FrameTrust::Trusted,
+        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&cv_modes), None, FrameTrust::Trusted,
     );
     assert!(matches!(cv, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
         "CV alone: a lane-parallel object is admitted; got {cv:?}");
@@ -915,7 +915,7 @@ fn produced_ctrv_mode_catches_a_turn_in_that_cv_misses_multimodal_payoff() {
     assert_eq!(mm_owned.len(), 2, "the turning object yields BOTH a CV and a CTRV mode");
     let mm_modes: Vec<_> = mm_owned.iter().map(|m| m.as_mode()).collect();
     let mm = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&mm_modes), FrameTrust::Trusted,
+        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&mm_modes), None, FrameTrust::Trusted,
     );
     assert_eq!(mm, TrajectoryVerdict::MRCFallback,
         "the produced CTRV turn-in mode catches what CV missed; got {mm:?}");
@@ -940,7 +940,7 @@ fn produced_lane_follow_mode_catches_a_curving_in_object_that_cv_misses() {
     let cv_owned = predicted_modes_from_objects(&[obj], &[], &[], 3.0, 0.3);
     let cv_modes: Vec<_> = cv_owned.iter().map(|m| m.as_mode()).collect();
     let cv = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&cv_modes), FrameTrust::Trusted,
+        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&cv_modes), None, FrameTrust::Trusted,
     );
     assert!(matches!(cv, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
         "CV alone: a lane-parallel object is admitted; got {cv:?}");
@@ -950,7 +950,7 @@ fn produced_lane_follow_mode_catches_a_curving_in_object_that_cv_misses() {
     assert_eq!(lf_owned.len(), 2, "the object yields BOTH a CV and a lane-follow mode");
     let lf_modes: Vec<_> = lf_owned.iter().map(|m| m.as_mode()).collect();
     let lf = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&lf_modes), FrameTrust::Trusted,
+        &trajectory, &corridor, &[obj], &cfg, None, FleetPosture::Nominal, None, None, Some(&lf_modes), None, FrameTrust::Trusted,
     );
     assert_eq!(lf, TrajectoryVerdict::MRCFallback,
         "the produced lane-follow mode catches the curving-in object CV missed; got {lf:?}");
@@ -965,7 +965,7 @@ fn predictive_rss_is_a_no_op_when_no_modes_are_supplied() {
     let cfg = VehicleConfig::default_urban();
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, None, FrameTrust::Trusted,
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, None, None, FrameTrust::Trusted,
     );
     assert_ne!(verdict, TrajectoryVerdict::MRCFallback,
         "with no predicted modes the predictive pass is a no-op; got {verdict:?}");
@@ -992,7 +992,7 @@ fn predictive_rss_fails_closed_on_modes_supplied_but_all_unevaluable_b3() {
     let modes = [PredictedMode { object_id: 1, samples: &samples }];
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), FrameTrust::Trusted,
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), None, FrameTrust::Trusted,
     );
     assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
         "modes supplied but all unevaluable (equal timestamps) must fail closed; got {verdict:?}");
@@ -1011,7 +1011,7 @@ fn predictive_rss_fails_closed_on_modes_with_no_evaluable_window_b3() {
     let modes = [PredictedMode { object_id: 1, samples: &samples }];
 
     let verdict = validate_trajectory_slow_capped(
-        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), FrameTrust::Trusted,
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), None, FrameTrust::Trusted,
     );
     assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
         "a non-empty mode set with no evaluable window must fail closed; got {verdict:?}");
@@ -1324,4 +1324,109 @@ fn stationary_side_object_in_band_beyond_8m_stays_admitted_683() {
     );
     assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
         "a stationary object 3 m to the side stays admitted inside the widened window; got {verdict:?}");
+}
+
+// ---------------------------------------------------------------------------
+// WS-2 — Pedestrian / VRU RSS (KIRRA-VRU-RSS-001), end-to-end through the
+// slow checker. Design: docs/safety/PEDESTRIAN_RSS.md; primitive:
+// kirra_trajectory::vru.
+// ---------------------------------------------------------------------------
+
+use kirra_trajectory::vru::{PedestrianScene, PerceivedPedestrian, VruRssParams};
+
+fn vru_scene(peds: &[PerceivedPedestrian]) -> PedestrianScene<'_> {
+    PedestrianScene { pedestrians: peds, params: VruRssParams::default() }
+}
+
+fn walker(id: u64, x: f64, y: f64) -> PerceivedPedestrian {
+    PerceivedPedestrian {
+        id,
+        pos: Point { x_m: x, y_m: y },
+        vel: Point { x_m: 0.0, y_m: 0.0 },
+    }
+}
+
+fn vru_verdict(
+    trajectory: &[TrajectoryPoint],
+    peds: &[PerceivedPedestrian],
+) -> TrajectoryVerdict {
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let scene = vru_scene(peds);
+    validate_trajectory_slow_capped(
+        trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal,
+        None, None, None, Some(&scene), FrameTrust::Trusted,
+    )
+}
+
+/// A pedestrian inside the moving ego's stopping+reachable envelope → MRC.
+#[test]
+fn vru_pedestrian_in_path_mrcs() {
+    let trajectory = straight_trajectory(10, 5.0, 0.1); // 5 m/s from x=5
+    let verdict = vru_verdict(&trajectory, &[walker(1, 12.0, 0.0)]);
+    assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
+        "a pedestrian 7 m ahead of a 5 m/s ego is inside the reachable-set bound");
+}
+
+/// A pedestrian far beyond the envelope → the trajectory is admitted.
+#[test]
+fn vru_far_pedestrian_admits() {
+    let trajectory = straight_trajectory(10, 5.0, 0.1);
+    let verdict = vru_verdict(&trajectory, &[walker(1, 60.0, 0.0)]);
+    assert_eq!(verdict, TrajectoryVerdict::Accept,
+        "a pedestrian ~50 m ahead must not bind a 1 s, 5 m/s trajectory");
+}
+
+/// THE STOP-PROPOSAL INVARIANT at the checker level: a stopped trajectory
+/// next to a pedestrian is admitted — the VRU gate can never make the
+/// always-available safe_stop proposal inadmissible (doer↔checker deadlock).
+#[test]
+fn vru_safe_stop_next_to_pedestrian_admits() {
+    let stop: Vec<TrajectoryPoint> = (0..5)
+        .map(|i| TrajectoryPoint {
+            pose: Pose { x_m: 5.0, y_m: 0.0, heading_rad: 0.0 },
+            velocity_mps: 0.0,
+            time_from_start_s: f64::from(i) * 0.1,
+        })
+        .collect();
+    let verdict = vru_verdict(&stop, &[walker(1, 5.6, 0.4)]);
+    assert!(matches!(verdict, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "a stationary trajectory imposes no VRU requirement (responsibility rule); got {verdict:?}");
+}
+
+/// Omnidirectionality: a kerbside pedestrian laterally OUTSIDE the
+/// vehicle-RSS alignment band still binds a moving ego — VRUs step in.
+#[test]
+fn vru_kerbside_pedestrian_binds_despite_lateral_clearance() {
+    let trajectory = straight_trajectory(10, 5.0, 0.1);
+    let cfg = VehicleConfig::default_urban();
+    let lateral = cfg.rss_lateral_alignment_tolerance_m + 0.5; // outside the vehicle band
+    let verdict = vru_verdict(&trajectory, &[walker(1, 9.0, lateral)]);
+    assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
+        "a kerbside pedestrian outside the vehicle lateral band must still bind (they can step in)");
+}
+
+/// Derate-only invariant: absent VRU input is byte-identical to the
+/// pre-WS-2 path (None and an empty scene both admit the clean trajectory).
+#[test]
+fn vru_absent_channel_is_byte_identical() {
+    let trajectory = straight_trajectory(10, 5.0, 0.1);
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let without = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal,
+        None, None, None, None, FrameTrust::Trusted,
+    );
+    let empty = vru_verdict(&trajectory, &[]);
+    assert_eq!(without, TrajectoryVerdict::Accept);
+    assert_eq!(empty, without, "an empty scene must not change the verdict");
+}
+
+/// Fail-closed: a non-finite pedestrian is a perception fault → MRC.
+#[test]
+fn vru_non_finite_pedestrian_mrcs() {
+    let trajectory = straight_trajectory(10, 5.0, 0.1);
+    let verdict = vru_verdict(&trajectory, &[walker(1, f64::NAN, 0.0)]);
+    assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
+        "an unlocalizable pedestrian must fail closed");
 }

--- a/crates/kirra-trajectory/src/lib.rs
+++ b/crates/kirra-trajectory/src/lib.rs
@@ -18,6 +18,8 @@ pub mod config;
 pub mod corridor;
 pub mod state;
 pub mod validation;
+// WS-2 — pedestrian / VRU RSS primitive (KIRRA-VRU-RSS-001).
+pub mod vru;
 // Multi-modal predictive-RSS mode producer (gap #3) — rolls live perceived objects
 // into CV/CTRV `PredictedMode` hypotheses so the checker's multi-modal pass runs
 // against real perception. Pure, no ROS.

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -136,6 +136,9 @@ pub fn validate_trajectory_slow(
     // (KIRRA-OCCY-PMON-003 slice-1).
     validate_trajectory_slow_capped(
         trajectory, corridor, objects, config, latest_odom, posture, None, None, None,
+        // WS-2: no VRU channel on the convenience wrapper → no-op (the node
+        // passes the live pedestrian scene once its subscription lands).
+        None,
         // Convenience/doer-side wrapper: assert AOU-LOCALIZATION-001 (Trusted →
         // primary 0.40 m containment margin). The production slow loop passes a
         // resolved FrameTrust; see `validate_trajectory_slow_capped`.
@@ -177,6 +180,7 @@ pub fn validate_trajectory_slow_capped(
     effective_perception_cap: Option<f64>,
     visibility_range_m: Option<f64>,
     predicted_modes: Option<&[PredictedMode<'_>]>,
+    pedestrians: Option<&crate::vru::PedestrianScene<'_>>,
     frame_trust: FrameTrust,
 ) -> TrajectoryVerdict {
     // ----- Posture short-circuit (M1) ----------------------------------
@@ -525,6 +529,25 @@ pub fn validate_trajectory_slow_capped(
     // stopped hazard. Absent input → skipped, so the Nominal path is unchanged.
     if let Some(vis) = visibility_range_m {
         if outruns_assured_clear_distance(trajectory, vis, config.max_decel_mps2) {
+            return TrajectoryVerdict::MRCFallback;
+        }
+    }
+
+    // ----- D2) Pedestrian / VRU RSS (WS-2, KIRRA-VRU-RSS-001) -----------
+    //
+    // The omnidirectional reachable-set bound (`crate::vru`): at each
+    // time-matched pose the pedestrian may move ANY direction at v_ped_max;
+    // a moving ego must be able to stop before its envelope meets the grown
+    // reachable disc. Deliberately NO lateral filter (a kerbside VRU can
+    // step in — the vehicle-object lateral band above is unsound for VRUs)
+    // and NO requirement on stopped/stopping poses (RSS responsibility +
+    // the safe_stop admissibility invariant: this gate can never deadlock
+    // the doer↔checker loop). Absent input → skipped: the path without a
+    // VRU channel is byte-identical (derate-only invariant). Fail-closed:
+    // a non-finite pedestrian is a perception fault → MRC.
+    // SAFETY: SG1 | REQ: vru-pedestrian-reachable-set-bound | TEST: vru_pedestrian_in_path_mrcs,vru_far_pedestrian_admits,vru_safe_stop_next_to_pedestrian_admits,vru_kerbside_pedestrian_binds_despite_lateral_clearance,vru_absent_channel_is_byte_identical,vru_non_finite_pedestrian_mrcs
+    if let Some(scene) = pedestrians {
+        if crate::vru::pedestrian_breach(trajectory, scene, config.max_decel_mps2) {
             return TrajectoryVerdict::MRCFallback;
         }
     }

--- a/crates/kirra-trajectory/src/vru.rs
+++ b/crates/kirra-trajectory/src/vru.rs
@@ -99,6 +99,18 @@ fn pedestrian_fields_finite(p: &PerceivedPedestrian) -> bool {
     finite_point(&p.pos) && finite_point(&p.vel)
 }
 
+/// Params are usable iff every field is finite and non-negative. A corrupt
+/// parameter set must FAIL CLOSED (an infinite requirement → guaranteed
+/// breach), never NaN-poison a comparison into admitting a trajectory.
+fn params_valid(p: &VruRssParams) -> bool {
+    let ok = |x: f64| x.is_finite() && x >= 0.0;
+    ok(p.v_ped_max_mps)
+        && ok(p.ped_radius_m)
+        && ok(p.clearance_m)
+        && ok(p.reaction_time_s)
+        && ok(p.stop_epsilon_mps)
+}
+
 /// The required center-to-center distance between a trajectory pose and a
 /// pedestrian for the pose to be VRU-safe (doc §4):
 ///
@@ -110,9 +122,11 @@ fn pedestrian_fields_finite(p: &PerceivedPedestrian) -> bool {
 /// ```
 ///
 /// `a_brake_mps2` is the ego's assured service braking (the per-class
-/// `VehicleConfig::max_decel_mps2`). Returns `f64::INFINITY` for a
-/// non-positive/non-finite brake (an unbrakeable ego can never prove VRU
-/// safety — fail closed).
+/// `VehicleConfig::max_decel_mps2`). Returns `f64::INFINITY` — a guaranteed
+/// breach once applied — for ANY invalid input: a non-positive/non-finite
+/// brake (an unbrakeable ego can never prove VRU safety), a non-finite
+/// speed/time, or a corrupt parameter set (fail closed; a NaN here would
+/// otherwise poison `dist < required` into admitting an unsafe trajectory).
 #[must_use]
 pub fn required_pedestrian_clearance_m(
     ego_speed_mps: f64,
@@ -120,7 +134,11 @@ pub fn required_pedestrian_clearance_m(
     a_brake_mps2: f64,
     params: &VruRssParams,
 ) -> f64 {
-    if !(a_brake_mps2.is_finite() && a_brake_mps2 > 0.0) {
+    if !(a_brake_mps2.is_finite() && a_brake_mps2 > 0.0)
+        || !ego_speed_mps.is_finite()
+        || !pose_time_s.is_finite()
+        || !params_valid(params)
+    {
         return f64::INFINITY;
     }
     let v = ego_speed_mps.abs();
@@ -155,7 +173,16 @@ pub fn pedestrian_breach(
         for tp in trajectory {
             let v = tp.velocity_mps;
             let t = tp.time_from_start_s;
-            if !(v.is_finite() && t.is_finite()) {
+            // Self-contained fail-closed: a non-finite pose would NaN the
+            // distance and fail OPEN in the comparison below. The validator's
+            // containment pass rejects such poses first, but this helper is
+            // public and must not depend on that ordering.
+            if !(v.is_finite()
+                && t.is_finite()
+                && tp.pose.x_m.is_finite()
+                && tp.pose.y_m.is_finite()
+                && tp.pose.heading_rad.is_finite())
+            {
                 return true;
             }
             if v.abs() <= scene.params.stop_epsilon_mps {
@@ -266,6 +293,43 @@ mod tests {
             required_pedestrian_clearance_m(1.0, 0.0, f64::NAN, &VruRssParams::default()),
             f64::INFINITY
         );
+    }
+
+    /// Fail-closed on corrupt inputs/params: a NaN speed, time, or ANY
+    /// parameter field yields an infinite requirement — never a NaN that
+    /// would fail OPEN in `dist < required`.
+    #[test]
+    fn corrupt_inputs_and_params_fail_closed_not_open() {
+        let p = VruRssParams::default();
+        assert_eq!(required_pedestrian_clearance_m(f64::NAN, 0.0, BRAKE, &p), f64::INFINITY);
+        assert_eq!(required_pedestrian_clearance_m(1.0, f64::NAN, BRAKE, &p), f64::INFINITY);
+        for corrupt in [
+            VruRssParams { v_ped_max_mps: f64::NAN, ..p },
+            VruRssParams { ped_radius_m: -1.0, ..p },
+            VruRssParams { clearance_m: f64::INFINITY, ..p },
+            VruRssParams { reaction_time_s: -0.5, ..p },
+            VruRssParams { stop_epsilon_mps: f64::NAN, ..p },
+        ] {
+            let r = required_pedestrian_clearance_m(1.0, 0.0, BRAKE, &corrupt);
+            assert_eq!(r, f64::INFINITY, "corrupt {corrupt:?} must fail closed");
+        }
+        // And through the breach predicate: corrupt params → a moving pose
+        // near ANY pedestrian breaches (never admits).
+        let traj = [pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
+        let scene = PedestrianScene {
+            pedestrians: &[ped(1000.0, 0.0)],
+            params: VruRssParams { reaction_time_s: f64::NAN, ..p },
+        };
+        assert!(pedestrian_breach(&traj, &scene, BRAKE));
+    }
+
+    /// Fail-closed on a non-finite trajectory POSE (the distance would NaN
+    /// and fail open) — self-contained, not dependent on containment order.
+    #[test]
+    fn non_finite_pose_breaches() {
+        let mut traj = vec![pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
+        traj[1].pose.x_m = f64::NAN;
+        assert!(pedestrian_breach(&traj, &scene(&[ped(50.0, 0.0)]), BRAKE));
     }
 
     /// Monotonicity (the safety shape): the requirement never DECREASES

--- a/crates/kirra-trajectory/src/vru.rs
+++ b/crates/kirra-trajectory/src/vru.rs
@@ -1,0 +1,287 @@
+//! **Pedestrian / VRU RSS primitive (WS-2, KIRRA-VRU-RSS-001).**
+//!
+//! The vehicle-vehicle RSS in `validation.rs` models road users with a
+//! defined direction of travel (the §5 longitudinal/lateral conjunction).
+//! A pedestrian breaks that model's core assumption: a VRU can change
+//! direction and speed essentially instantly relative to vehicle dynamics,
+//! so lateral-alignment filtering and directional closing-speed bounds are
+//! unsound for them — a pedestrian standing laterally "clear" on the kerb
+//! can step into the corridor within the ego's stopping time.
+//!
+//! This module implements the **omnidirectional reachable-set bound**
+//! (design: `docs/safety/PEDESTRIAN_RSS.md`): at each time-matched
+//! trajectory pose, the pedestrian is assumed able to move in ANY direction
+//! at `v_ped_max`; the ego must be able to come to a full stop (reaction +
+//! braking, the same RSS stopping model as the vehicle case) WITHOUT its
+//! stopping envelope intersecting the pedestrian's grown reachable disc
+//! plus a clearance margin. The disc model deliberately SUBSUMES a directed
+//! "crossing model" — every crossing trajectory of speed ≤ `v_ped_max` lies
+//! inside the disc — trading availability for soundness in v0; the directed
+//! refinement is a tracked follow-up, allowed only to RELAX this bound with
+//! validated tracking evidence, never to weaken it silently.
+//!
+//! **Responsibility semantics / the stop-proposal invariant.** A pose with
+//! ego speed ≤ `stop_epsilon_mps` imposes NO requirement: a stationary ego
+//! strikes nothing (a pedestrian contacting a stopped vehicle is not an
+//! ego-caused collision under RSS responsibility), and — load-bearing —
+//! this keeps `PlanOutput::safe_stop` admissible next to any pedestrian, so
+//! the pedestrian gate can never deadlock the doer↔checker loop.
+//!
+//! **Fail-closed:** a non-finite pedestrian field is an unlocalizable
+//! perception fault → breach (MRC), mirroring the vehicle-object rule.
+//! Absent input (`None` scene) is a no-op — the Nominal path without a VRU
+//! channel is byte-identical (the derate-only invariant).
+
+use kirra_core::corridor::Point;
+use kirra_core::trajectory::TrajectoryPoint;
+
+/// A perceived pedestrian / VRU. Deliberately minimal for v0: the
+/// omnidirectional model needs only a position (velocity is accepted for
+/// forward-compatibility with the directed refinement but does not weaken
+/// the v0 bound).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PerceivedPedestrian {
+    pub id: u64,
+    /// Position, ego-world frame (same frame as `PerceivedObject.pos`).
+    pub pos: Point,
+    /// Tracked velocity vector, m/s (informational in v0 — the reachable
+    /// disc assumes `v_ped_max` in every direction regardless).
+    pub vel: Point,
+}
+
+/// Parameters of the VRU bound. Every default is CONSERVATIVE-FIRST and
+/// **VALIDATION-PENDING** (deployment-tunable per ODD; see the design doc
+/// §5 for the rationale and the tuning obligations).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VruRssParams {
+    /// Assumed max pedestrian speed, m/s (any direction). Default 2.0 —
+    /// a brisk walk; ODDs with expected runners/cyclists-as-VRUs must
+    /// raise it (doc §5.1).
+    pub v_ped_max_mps: f64,
+    /// Pedestrian body radius, m (their footprint is not a point).
+    pub ped_radius_m: f64,
+    /// Additional clearance margin, m, beyond the geometric envelopes.
+    pub clearance_m: f64,
+    /// Ego reaction time, s — the delay before assured braking begins.
+    /// Default matches the vehicle-RSS `RSS_REACTION_TIME_S` (0.5 s).
+    pub reaction_time_s: f64,
+    /// Ego speed at/below which a pose imposes no VRU requirement, m/s
+    /// (the stationary-ego responsibility rule + safe-stop admissibility).
+    pub stop_epsilon_mps: f64,
+}
+
+impl Default for VruRssParams {
+    fn default() -> Self {
+        Self {
+            v_ped_max_mps: 2.0,
+            ped_radius_m: 0.3,
+            clearance_m: 0.5,
+            reaction_time_s: 0.5,
+            stop_epsilon_mps: 0.05,
+        }
+    }
+}
+
+/// The pedestrian input to the slow checker: the perceived VRUs plus the
+/// bound's parameters, carried together so the checker call site stays a
+/// single optional argument (absent → no-op).
+#[derive(Debug, Clone, Copy)]
+pub struct PedestrianScene<'a> {
+    pub pedestrians: &'a [PerceivedPedestrian],
+    pub params: VruRssParams,
+}
+
+fn finite_point(p: &Point) -> bool {
+    p.x_m.is_finite() && p.y_m.is_finite()
+}
+
+fn pedestrian_fields_finite(p: &PerceivedPedestrian) -> bool {
+    finite_point(&p.pos) && finite_point(&p.vel)
+}
+
+/// The required center-to-center distance between a trajectory pose and a
+/// pedestrian for the pose to be VRU-safe (doc §4):
+///
+/// ```text
+/// t_stop  = ρ + v / a_brake                     (time to full stop)
+/// d_stop  = v·ρ + v² / (2·a_brake)              (ego stopping distance)
+/// reach   = r_ped + v_ped_max · (t_pose + t_stop)  (grown reachable disc)
+/// required = d_stop + reach + clearance
+/// ```
+///
+/// `a_brake_mps2` is the ego's assured service braking (the per-class
+/// `VehicleConfig::max_decel_mps2`). Returns `f64::INFINITY` for a
+/// non-positive/non-finite brake (an unbrakeable ego can never prove VRU
+/// safety — fail closed).
+#[must_use]
+pub fn required_pedestrian_clearance_m(
+    ego_speed_mps: f64,
+    pose_time_s: f64,
+    a_brake_mps2: f64,
+    params: &VruRssParams,
+) -> f64 {
+    if !(a_brake_mps2.is_finite() && a_brake_mps2 > 0.0) {
+        return f64::INFINITY;
+    }
+    let v = ego_speed_mps.abs();
+    let rho = params.reaction_time_s;
+    let t_stop = rho + v / a_brake_mps2;
+    let d_stop = v * rho + v * v / (2.0 * a_brake_mps2);
+    let reach = params.ped_radius_m + params.v_ped_max_mps * (pose_time_s.max(0.0) + t_stop);
+    d_stop + reach + params.clearance_m
+}
+
+/// **The WS-2 primitive**: does `trajectory` breach the omnidirectional
+/// pedestrian bound for any (pose, pedestrian) pair?
+///
+/// Per pose with `|v| > stop_epsilon`, per pedestrian: breach if the
+/// euclidean pose→pedestrian distance is below
+/// [`required_pedestrian_clearance_m`]. No lateral filter and no
+/// behind-ego filter — omnidirectionality is the point (a VRU beside or
+/// behind the path can enter it; distance + the disc's time growth keep
+/// far pedestrians from binding). A non-finite pedestrian or a non-finite
+/// pose time/speed is a breach (fail closed).
+// SAFETY: SG1 | REQ: vru-pedestrian-reachable-set-bound | TEST: pedestrian_ahead_within_stopping_envelope_breaches,pedestrian_far_ahead_is_clear,safe_stop_next_to_pedestrian_is_admitted,kerbside_pedestrian_outside_lateral_band_still_binds,non_finite_pedestrian_breaches,empty_scene_is_noop
+#[must_use]
+pub fn pedestrian_breach(
+    trajectory: &[TrajectoryPoint],
+    scene: &PedestrianScene<'_>,
+    a_brake_mps2: f64,
+) -> bool {
+    for ped in scene.pedestrians {
+        if !pedestrian_fields_finite(ped) {
+            return true;
+        }
+        for tp in trajectory {
+            let v = tp.velocity_mps;
+            let t = tp.time_from_start_s;
+            if !(v.is_finite() && t.is_finite()) {
+                return true;
+            }
+            if v.abs() <= scene.params.stop_epsilon_mps {
+                continue;
+            }
+            let required = required_pedestrian_clearance_m(v, t, a_brake_mps2, &scene.params);
+            let dx = ped.pos.x_m - tp.pose.x_m;
+            let dy = ped.pos.y_m - tp.pose.y_m;
+            let dist = (dx * dx + dy * dy).sqrt();
+            if dist < required {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the primitive in isolation (integration tests live in
+// kirra-ros2-adapter/tests/validation_tests.rs with the rest of the
+// slow-checker suite).
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kirra_core::trajectory::Pose;
+
+    fn pt(x: f64, v: f64, t: f64) -> TrajectoryPoint {
+        TrajectoryPoint {
+            pose: Pose { x_m: x, y_m: 0.0, heading_rad: 0.0 },
+            velocity_mps: v,
+            time_from_start_s: t,
+        }
+    }
+
+    fn ped(x: f64, y: f64) -> PerceivedPedestrian {
+        PerceivedPedestrian { id: 1, pos: Point { x_m: x, y_m: y }, vel: Point { x_m: 0.0, y_m: 0.0 } }
+    }
+
+    const BRAKE: f64 = 4.5; // default_urban service brake
+
+    fn scene(peds: &[PerceivedPedestrian]) -> PedestrianScene<'_> {
+        PedestrianScene { pedestrians: peds, params: VruRssParams::default() }
+    }
+
+    /// The formula at a worked point (doc §4.1): v=2, t=0, ρ=0.5, a=4.5 →
+    /// t_stop = 0.5 + 0.444 = 0.944s; d_stop = 1.0 + 0.444 = 1.444m;
+    /// reach = 0.3 + 2.0·0.944 = 2.189m; required = 1.444+2.189+0.5 = 4.133m.
+    #[test]
+    fn worked_reference_point_matches_the_doc() {
+        let r = required_pedestrian_clearance_m(2.0, 0.0, BRAKE, &VruRssParams::default());
+        assert!((r - 4.1333).abs() < 1e-3, "got {r}");
+    }
+
+    #[test]
+    fn pedestrian_ahead_within_stopping_envelope_breaches() {
+        let traj = [pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
+        assert!(pedestrian_breach(&traj, &scene(&[ped(3.0, 0.0)]), BRAKE));
+    }
+
+    #[test]
+    fn pedestrian_far_ahead_is_clear() {
+        let traj = [pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
+        assert!(!pedestrian_breach(&traj, &scene(&[ped(40.0, 0.0)]), BRAKE));
+    }
+
+    /// THE STOP-PROPOSAL INVARIANT: a stopped/stopping trajectory next to a
+    /// pedestrian is admitted — the gate must never make `safe_stop`
+    /// inadmissible (that would deadlock the doer↔checker loop).
+    #[test]
+    fn safe_stop_next_to_pedestrian_is_admitted() {
+        let stop = [pt(0.0, 0.0, 0.0), pt(0.0, 0.0, 1.0)];
+        assert!(!pedestrian_breach(&stop, &scene(&[ped(0.5, 0.5)]), BRAKE));
+    }
+
+    /// Omnidirectionality: a kerbside pedestrian OUTSIDE the vehicle-RSS
+    /// lateral band still binds — they can step in. (The vehicle-object RSS
+    /// would lateral-filter this away; the VRU bound must not.)
+    #[test]
+    fn kerbside_pedestrian_outside_lateral_band_still_binds() {
+        let traj = [pt(0.0, 4.0, 0.0), pt(4.0, 4.0, 1.0)];
+        // 2.5 m lateral, 4 m ahead: inside required (~8.9 m at v=4).
+        assert!(pedestrian_breach(&traj, &scene(&[ped(4.0, 2.5)]), BRAKE));
+    }
+
+    #[test]
+    fn non_finite_pedestrian_breaches() {
+        let traj = [pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
+        assert!(pedestrian_breach(&traj, &scene(&[ped(f64::NAN, 0.0)]), BRAKE));
+    }
+
+    #[test]
+    fn empty_scene_is_noop() {
+        let traj = [pt(0.0, 10.0, 0.0), pt(10.0, 10.0, 1.0)];
+        assert!(!pedestrian_breach(&traj, &scene(&[]), BRAKE));
+    }
+
+    /// Fail-closed on an unbrakeable ego: zero/negative/non-finite brake →
+    /// infinite requirement → any moving pose near any pedestrian breaches.
+    #[test]
+    fn non_positive_brake_fails_closed() {
+        assert_eq!(
+            required_pedestrian_clearance_m(1.0, 0.0, 0.0, &VruRssParams::default()),
+            f64::INFINITY
+        );
+        assert_eq!(
+            required_pedestrian_clearance_m(1.0, 0.0, f64::NAN, &VruRssParams::default()),
+            f64::INFINITY
+        );
+    }
+
+    /// Monotonicity (the safety shape): the requirement never DECREASES
+    /// with ego speed or pose time — faster/later can only demand more room.
+    #[test]
+    fn requirement_is_monotone_in_speed_and_time() {
+        let p = VruRssParams::default();
+        let mut prev = 0.0;
+        for i in 0..50 {
+            let v = f64::from(i) * 0.5;
+            let r = required_pedestrian_clearance_m(v, 0.0, BRAKE, &p);
+            assert!(r >= prev, "requirement must not decrease with speed");
+            prev = r;
+        }
+        let early = required_pedestrian_clearance_m(3.0, 0.5, BRAKE, &p);
+        let late = required_pedestrian_clearance_m(3.0, 4.0, BRAKE, &p);
+        assert!(late > early, "a later pose faces a larger reachable disc");
+    }
+}

--- a/docs/safety/PEDESTRIAN_RSS.md
+++ b/docs/safety/PEDESTRIAN_RSS.md
@@ -111,9 +111,11 @@ is exactly the sidewalk-courier posture.
 | Non-finite pedestrian field | Breach → MRC (unlocalizable perception fault; mirrors the vehicle-object rule) |
 | Non-finite pose speed/time | Breach → MRC |
 | Non-positive / non-finite `a_brake` | `required = ∞` → any moving pose breaches (an unbrakeable ego cannot prove VRU safety) |
+| Non-finite speed/time input or ANY corrupt `VruRssParams` field (non-finite or negative) | `required = ∞` → breach (a NaN would otherwise poison `dist < required` into failing OPEN) |
+| Non-finite trajectory pose field | Breach → MRC (self-contained — not dependent on containment rejecting it first) |
 | Absent VRU channel (`None` scene) | **No-op** — byte-identical path (the derate-only invariant: absent input never relaxes, never fabricates) |
 
-## 5. Parameters (`VruRssParams`) — all VALIDATION-PENDING
+## 5. Parameters (`VruRssParams`, plus the ego brake from `VehicleConfig`) — all VALIDATION-PENDING
 
 | Param | Default | Rationale / tuning obligation |
 |---|---|---|
@@ -122,7 +124,7 @@ is exactly the sidewalk-courier posture.
 | `clearance_m` | 0.5 | Comfort/robustness margin beyond the geometric envelopes. |
 | `reaction_time_s` | 0.5 | Matches the vehicle-RSS `RSS_REACTION_TIME_S` — one reaction model per checker. |
 | `stop_epsilon_mps` | 0.05 | Matches `STOP_EPSILON_MPS` (the Degraded stop-and-hold epsilon). |
-| `a_brake` | per-class `VehicleConfig::max_decel_mps2` | The ego's assured service braking from the per-class contract (`KIRRA_VEHICLE_CLASS`). Using full service braking is the *least* conservative element here; derating it (e.g. wet-surface factor) is a tracked refinement. |
+| `a_brake_mps2` (not a `VruRssParams` field — the validator passes `VehicleConfig::max_decel_mps2`) | per-class contract | The ego's assured service braking from the per-class contract (`KIRRA_VEHICLE_CLASS`). Using full service braking is the *least* conservative element here; derating it (e.g. wet-surface factor) is a tracked refinement. |
 
 Availability envelope at the defaults (euclidean `required`, pose `t = 0`):
 ego 1 m/s → 3.0 m; 2 m/s → 4.1 m; 4 m/s → 7.1 m; 6 m/s → 10.7 m. The

--- a/docs/safety/PEDESTRIAN_RSS.md
+++ b/docs/safety/PEDESTRIAN_RSS.md
@@ -1,0 +1,169 @@
+# Pedestrian / VRU RSS — the omnidirectional reachable-set bound
+
+**Document ID:** KIRRA-VRU-RSS-001
+**Status:** DRAFT — pending formal safety-engineer review (the reasoning and
+implementation are real and tested; treating the parameter values as a
+validated safety claim requires sign-off — same discipline as
+`ANGULAR_VELOCITY_SOTIF.md`).
+**Implements:** WS-2 "Pedestrian RSS primitive … wired into
+`validate_trajectory_slow` — the courier/sidewalk persona is P1's flagship."
+**Code:** `crates/kirra-trajectory/src/vru.rs` (primitive) +
+`validation.rs` section D2 (wiring). Traceability tag:
+`REQ: vru-pedestrian-reachable-set-bound`.
+
+---
+
+## 1. Why the vehicle RSS is unsound for pedestrians
+
+The checker's vehicle-object RSS (validation.rs section C) implements the
+IEEE 2846 / Shalev-Shwartz §5 model for road users **with a defined
+direction of travel**: a longitudinal safe-distance bound gated by a
+**lateral-alignment filter** (an object laterally outside
+`rss_lateral_alignment_tolerance_m` is "another lane's problem" — handled
+by containment, skipped by RSS).
+
+Both halves break for a VRU:
+
+1. **The lateral filter is a hole, not an optimization.** A pedestrian
+   standing on the kerb 2.5 m laterally "clear" can step into the corridor
+   within the ego's stopping time. For vehicles, lane discipline justifies
+   the filter; a pedestrian has no lane discipline.
+2. **Directional closing-speed bounds assume inertia.** RSS's
+   longitudinal/lateral decomposition leans on vehicles being unable to
+   change velocity direction instantly. Relative to vehicle dynamics, a
+   pedestrian *can*: walking → turning → stepping sideways happens inside
+   one reaction time.
+
+## 2. The model: omnidirectional reachable set
+
+At trajectory time `t`, assume the pedestrian may be anywhere in a disc
+around their perceived position:
+
+```text
+reach(t_eval) = r_ped + v_ped_max · t_eval
+```
+
+The ego is safe with respect to that pedestrian iff, from every
+time-matched trajectory pose with speed `v > ε`, it could come to a
+**complete stop** (reaction ρ, then assured braking `a_brake`) without its
+stopping envelope meeting the disc as it grows over the whole stopping
+interval:
+
+```text
+t_stop   = ρ + v / a_brake                       — time to full stop
+d_stop   = v·ρ + v² / (2·a_brake)                — RSS stopping distance
+required = d_stop + r_ped + v_ped_max · (t + t_stop) + clearance
+UNSAFE   ⟺ dist(pose, ped) < required
+```
+
+Distance is **euclidean** — deliberately no lateral filter and no
+behind-ego filter (§1; a VRU beside or behind the path can enter it — the
+disc's time growth keeps genuinely distant pedestrians from binding).
+Verdict on breach: `MRCFallback`, exactly like a containment or RSS breach.
+
+### 2.1 The crossing model is subsumed
+
+WS-2 names "longitudinal/lateral bounds + crossing model". A directed
+crossing model (pedestrian heading toward the path at up to `v_cross`)
+traces a cone of positions; for any crossing speed ≤ `v_ped_max` that cone
+is a **subset of the omnidirectional disc**. v0 therefore ships the disc
+and gets the crossing model for free, at an availability (not safety)
+cost. The directed refinement — using tracked heading/velocity to shrink
+the disc toward a cone — is a tracked follow-up (§6) and is only ever a
+RELAXATION of this bound: it requires validated tracking evidence and its
+own review, and it can never be introduced as a silent default.
+
+### 2.2 Worked reference point
+
+`v = 2 m/s`, pose `t = 0`, defaults (ρ = 0.5 s, a_brake = 4.5 m/s²,
+v_ped_max = 2.0, r_ped = 0.3, clearance = 0.5):
+
+```text
+t_stop   = 0.5 + 2/4.5            = 0.944 s
+d_stop   = 2·0.5 + 4/(2·4.5)      = 1.444 m
+reach    = 0.3 + 2.0 · 0.944      = 2.189 m
+required = 1.444 + 2.189 + 0.5    = 4.133 m
+```
+
+(pinned by `vru::tests::worked_reference_point_matches_the_doc`).
+
+## 3. Responsibility semantics & the stop-proposal invariant
+
+A pose with `|v| ≤ stop_epsilon_mps` imposes **no requirement**:
+
+- **RSS responsibility:** a stationary ego strikes nothing; a pedestrian
+  contacting a stopped vehicle is not an ego-caused collision.
+- **Deadlock freedom (load-bearing):** the architecture requires
+  `PlanOutput::safe_stop` to always exist and be admissible ("a planner
+  with no stop output deadlocks the loop"). A VRU bound that refused
+  stopped trajectories near pedestrians would make the MRC itself
+  inadmissible — the gate must converge on stopping, never forbid it.
+  Pinned end-to-end by `vru_safe_stop_next_to_pedestrian_admits`.
+
+The consequence is intentionally asymmetric: near a pedestrian the checker
+admits *stopping and staying stopped* and refuses *moving through* — which
+is exactly the sidewalk-courier posture.
+
+## 4. Fail-closed rules
+
+| Condition | Treatment |
+|---|---|
+| Non-finite pedestrian field | Breach → MRC (unlocalizable perception fault; mirrors the vehicle-object rule) |
+| Non-finite pose speed/time | Breach → MRC |
+| Non-positive / non-finite `a_brake` | `required = ∞` → any moving pose breaches (an unbrakeable ego cannot prove VRU safety) |
+| Absent VRU channel (`None` scene) | **No-op** — byte-identical path (the derate-only invariant: absent input never relaxes, never fabricates) |
+
+## 5. Parameters (`VruRssParams`) — all VALIDATION-PENDING
+
+| Param | Default | Rationale / tuning obligation |
+|---|---|---|
+| `v_ped_max_mps` | 2.0 | Brisk walk (~1.4 typical walking; 2.0 covers hurried). **ODDs with expected runners, children darting, or cyclists-as-VRUs must raise it** — a raise only tightens the bound. Lowering below 2.0 needs ODD evidence + review. |
+| `ped_radius_m` | 0.3 | Body half-width; not a point target. |
+| `clearance_m` | 0.5 | Comfort/robustness margin beyond the geometric envelopes. |
+| `reaction_time_s` | 0.5 | Matches the vehicle-RSS `RSS_REACTION_TIME_S` — one reaction model per checker. |
+| `stop_epsilon_mps` | 0.05 | Matches `STOP_EPSILON_MPS` (the Degraded stop-and-hold epsilon). |
+| `a_brake` | per-class `VehicleConfig::max_decel_mps2` | The ego's assured service braking from the per-class contract (`KIRRA_VEHICLE_CLASS`). Using full service braking is the *least* conservative element here; derating it (e.g. wet-surface factor) is a tracked refinement. |
+
+Availability envelope at the defaults (euclidean `required`, pose `t = 0`):
+ego 1 m/s → 3.0 m; 2 m/s → 4.1 m; 4 m/s → 7.1 m; 6 m/s → 10.7 m. The
+courier persona (≤ ~2 m/s on sidewalks) keeps a ~4 m bubble around
+pedestrians — conservative but operable; a robotaxi at speed must rely on
+pedestrians being genuinely distant, which is correct.
+
+## 6. Integration status & tracked follow-ups
+
+**Live now:** the primitive (`vru.rs`) and its wiring as section D2 of
+`validate_trajectory_slow_capped` behind an optional `PedestrianScene`
+argument (absent → no-op). The WCET-critical per-pose
+`validate_vehicle_command` path is untouched; the Nominal path without a
+VRU channel is byte-identical.
+
+**Follow-ups (in dependency order):**
+1. **Node VRU channel** — a `~/input/pedestrians` subscription on the ros2
+   adapter (staleness-budgeted like the object channels: an ARMED but
+   silent/stale channel fails closed to `Some(empty…)`→cap, never silently
+   disarms), feeding the live scene into the D2 argument.
+2. **Classification ingest** — today nothing produces
+   `PerceivedPedestrian`s; Taj Phase-B semantic classes (the detector seam)
+   or an integrator-supplied VRU topic must classify. Until then the gate
+   is armed-but-unfed by construction, and *that is stated here rather than
+   papered over*.
+3. **KPI corpus rows** — pedestrian scenarios in the WS-3.1 gate corpus
+   (admissibility of stop-near-VRU proposals; refusal of drive-through
+   proposals) once the seam has a producer.
+4. **Directed refinement** (§2.1) — cone-shrunk reachable sets from
+   validated tracking; relaxation-only, review-gated.
+5. **Brake derating** (§5) — surface-condition factor on `a_brake`.
+
+## 7. Test traceability
+
+| Property | Test |
+|---|---|
+| Formula reference point | `vru::tests::worked_reference_point_matches_the_doc` |
+| Monotonicity in speed & time | `vru::tests::requirement_is_monotone_in_speed_and_time` |
+| In-path pedestrian → MRC (end-to-end) | `vru_pedestrian_in_path_mrcs` |
+| Distant pedestrian admits | `vru_far_pedestrian_admits` |
+| Stop-proposal invariant | `vru_safe_stop_next_to_pedestrian_admits` (+ unit `safe_stop_next_to_pedestrian_is_admitted`) |
+| Omnidirectionality vs the lateral band | `vru_kerbside_pedestrian_binds_despite_lateral_clearance` (+ unit) |
+| Absent-channel byte-identity | `vru_absent_channel_is_byte_identical` |
+| Fail-closed non-finite / unbrakeable | `vru_non_finite_pedestrian_mrcs`, unit `non_positive_brake_fails_closed`, `non_finite_pedestrian_breaches` |


### PR DESCRIPTION
**PR 10 — the WS-2 pedestrian-RSS primitive (design doc + first implementation): the foundation of the P1 courier/sidewalk launch blocker (G12 slice). Completes the plan's ten-PR "Now" list.**

## Design (`docs/safety/PEDESTRIAN_RSS.md`, KIRRA-VRU-RSS-001, DRAFT pending safety-engineer review)

**Why the vehicle RSS is unsound for VRUs.** Section C's lateral-alignment filter is a *hole* for pedestrians — a kerbside pedestrian laterally "clear" of the band can step into the corridor within the ego's stopping time — and directional closing-speed bounds assume inertia a pedestrian doesn't have.

**The model.** Omnidirectional reachable set, checked at every time-matched pose with `|v| > ε`:

```
required = d_stop(v) + r_ped + v_ped_max·(t_pose + t_stop) + clearance
UNSAFE  ⟺ dist(pose, ped) < required        (euclidean — no lateral, no behind-ego filter)
```

The plan's "crossing model" is **subsumed**: every crossing trajectory at ≤ `v_ped_max` lies inside the disc, so v0 gets it for free at an availability (not safety) cost; the cone-shrunk directed refinement is a relaxation-only, review-gated follow-up.

**Responsibility + deadlock freedom (load-bearing).** Stopped/stopping poses impose no requirement — a stationary ego strikes nothing (RSS responsibility), and the always-available `PlanOutput::safe_stop` stays admissible next to any pedestrian, so this gate can never deadlock the doer↔checker loop. Pinned end-to-end by test. The resulting asymmetry is the sidewalk-courier posture: near a VRU the checker admits *stopping*, refuses *driving through*.

**Parameters** are conservative-first and VALIDATION-PENDING (v_ped_max 2.0 = brisk walk with the raise-for-runners obligation stated; reaction 0.5 s = the vehicle `RSS_REACTION_TIME_S`; `a_brake` = the per-class `max_decel_mps2`), with the availability envelope worked out (a courier at ≤ 2 m/s keeps a ~4 m bubble — operable).

## Implementation

- **`crates/kirra-trajectory/src/vru.rs`** — the primitive: `pedestrian_breach` / `required_pedestrian_clearance_m` + `PerceivedPedestrian` / `VruRssParams` / `PedestrianScene`. Fail-closed: non-finite pedestrian/pose fields breach; a non-positive/non-finite brake yields an infinite requirement (an unbrakeable ego can't prove VRU safety). 9 unit tests including the doc's worked reference point and the monotonicity shape.
- **`validation.rs` section D2** — wired into `validate_trajectory_slow_capped` behind an optional `PedestrianScene` argument: **absent input → no-op, byte-identical** (the derate-only invariant; the WCET-critical `validate_vehicle_command` path is untouched). Breach → `MRCFallback`, exactly like containment/RSS.
- **6 end-to-end tests** in the slow-checker suite: in-path pedestrian MRCs, distant pedestrian admits, the stop-proposal invariant, kerbside-binds-despite-lateral-clearance (the exact hole the vehicle RSS has), absent-channel byte-identity, non-finite fail-closed.
- **Honesty about integration status**: nothing produces `PerceivedPedestrian`s yet — the node passes `None` with the follow-up note, and the doc §6 says "armed-but-unfed by construction" outright, listing the follow-ups in dependency order (node VRU subscription with fail-closed staleness, Taj Phase-B classification ingest, KPI corpus rows, directed refinement, brake derating).

118 workspace suites green; clippy zero; guardrails pass; the WS-3.1 KPI gate still passes — which doubles as confirmation the no-channel path is genuinely unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_