### PR TITLE
posture/HA: re-seed generations at promotion, atomic stamp+high-water, bound corrupt high-water (review fix-C: #771 F1/F2/F4)

### DIFF
--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -43,7 +43,18 @@ pub fn init_generation_from_store(app: &Arc<AppState>) -> Result<u64, String> {
         // monotonicity invariant that federation peers rely on for report ordering.
         // `fetch_max` only ever raises it, so the counter is monotone regardless of
         // init/recalc ordering.
-        POSTURE_GENERATION.fetch_max(last + 1, Ordering::SeqCst);
+        //
+        // #771 F4: `checked_add`, not `last + 1`. `load_last_generation` already
+        // rejects a stored high-water `>= i64::MAX`, so `last + 1` cannot overflow
+        // in practice — but the release profile builds with overflow-checks OFF, so
+        // a bare `+ 1` on a `u64::MAX` that slipped past the store guard would wrap
+        // to 0 and fail OPEN (fetch_max(0) is a no-op → counter stays 1 → the exact
+        // restart time-reversal). Belt-and-suspenders: overflow is corruption, fail
+        // closed.
+        let next = last.checked_add(1).ok_or_else(|| {
+            format!("generation high-water {last} at u64::MAX — refusing to overflow the counter (corruption)")
+        })?;
+        POSTURE_GENERATION.fetch_max(next, Ordering::SeqCst);
     }
     Ok(last)
 }
@@ -252,41 +263,36 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     // SAFETY: SG-HA-3 — durable writes must not execute on Tokio workers.
     // `recalculate_and_broadcast` is run on blocking/offline paths when called from async workers.
     let audit_committed = app.store.with(|store| {
-        match store.save_posture_event_chained(
+        // #771 F2: the posture event, its audit-chain link, AND the generation
+        // high-water now commit in ONE transaction (see
+        // `save_posture_event_chained_with_generation`). Previously the high-water
+        // was a SEPARATE write whose `Err` was deliberately tolerated — which left
+        // a cross-restart crash window: a hard kill after the audit event committed
+        // at generation G but before the high-water reached G re-seeded stale on
+        // restart, so the durable chain could hold two events at the same
+        // generation or re-issue an already-broadcast one. Folding them removes the
+        // window: either both land (proceed) or neither lands (fail closed here,
+        // exactly like the audit-chain write did).
+        match store.save_posture_event_chained_with_generation(
             "posture_engine",
             event_type,
             &audit_payload.to_string(),
             Some("Fleet posture recomputed from DAG traversal"),
             ts,
+            generation,
         ) {
-            Ok(()) => {
-                // #695: a `false` here means the generation high-water rejected this
-                // write as stale. In normal operation that's a benign concurrent-
-                // recalc race (another recalc already persisted a higher generation),
-                // so it is logged at debug; a PERSISTENT rejection of the latest
-                // generation would indicate a regression/time-reversal worth
-                // investigating. An Err is a real DB failure.
-                //
-                // We deliberately DO NOT fail the transition closed on this Err
-                // (unlike the audit-chain write below, SG-HA-4). Failing closed
-                // here would not restore the cross-restart monotonicity invariant
-                // anyway: the in-memory `generation` was already claimed by
-                // `next_generation()` (an irreversible `fetch_add`) AND the audit
-                // chain above already committed durably AT this generation. So the
-                // persisted high-water is equally behind whether we proceed or
-                // suppress — suppressing only drops a live, already-audited posture
-                // transition (possibly a safety ESCALATION), which is the wrong
-                // trade. The high-water is a self-healing monotonic max-write (the
-                // next successful recalc re-persists it), and a SYSTEMIC DB failure
-                // is still caught fail-closed by the audit-chain write on the next
-                // cycle. So: log loudly and let the live broadcast proceed.
-                match store.save_last_generation(generation) {
-                    Ok(true) => {}
-                    Ok(false) => tracing::debug!(
+            Ok(high_water_advanced) => {
+                // #695: a `false` means the in-tx monotonic guard rejected this
+                // generation as stale — a benign concurrent-recalc race (another
+                // recalc already persisted a higher generation); logged at debug.
+                // A PERSISTENT rejection of the latest generation would indicate a
+                // regression worth investigating. The posture event still committed
+                // in the same tx, so the live transition proceeds.
+                if !high_water_advanced {
+                    tracing::debug!(
                         generation,
-                        "Generation high-water rejected a stale persist (benign race unless persistent) — #695"
-                    ),
-                    Err(e) => tracing::error!(error = %e, generation, "Failed to persist last generation (high-water self-heals on next recalc; live transition not suppressed) — #695"),
+                        "Generation high-water rejected a stale persist in-tx (benign race unless persistent) — #695/#771"
+                    );
                 }
                 // WS-0.3: a posture TRANSITION is incident-class — make its
                 // just-committed audit row hard-power-loss durable NOW (one

--- a/src/standby_monitor.rs
+++ b/src/standby_monitor.rs
@@ -55,7 +55,7 @@ use tokio::time::{interval, Duration};
 
 use crate::verifier::AppState;
 use crate::posture_cache::{SharedPostureCache, now_ms};
-use crate::posture_engine::recalculate_and_broadcast;
+use crate::posture_engine::{init_generation_from_store, recalculate_and_broadcast};
 use crate::posture_engine_v2::resolve_post_promotion_posture;
 
 // ---------------------------------------------------------------------------
@@ -892,6 +892,53 @@ async fn perform_promotion(
         ts,
     );
 
+    // Step 4d (#771 F1): RE-SEED the generation counter from the SHARED store
+    // before the first Active recalc. HA pairs share one SQLite file; the dead
+    // primary advanced the durable generation high-water for its ENTIRE uptime
+    // (~34,560 generations/day at the recalc cadence), while THIS node's in-memory
+    // `POSTURE_GENERATION` was seeded once — at its own boot — and is now far
+    // behind. Without this re-seed the first post-promotion recalc (Step 5) emits
+    // a generation BELOW the dead primary's last, time-reversing the sequence that
+    // federation peers hard-reject (`GenerationRegress`, fail-closed) and SSE
+    // consumers order by — roughly a day of cross-fleet trust blindness per day of
+    // prior primary uptime, on the exact event (primary death) where fresh posture
+    // matters most. `init_generation_from_store` is idempotent (`fetch_max` only
+    // ever RAISES the counter), so re-running it at promotion cannot regress a
+    // counter another racing recalc already advanced. Runs AFTER the epoch claim /
+    // promotion records so a fenced loser (which returned early above) never
+    // touches it. Fail-closed: a store read error aborts promotion and self-demotes
+    // — a promoted Active that would time-reverse generations is worse than staying
+    // PassiveStandby for another instance / a later retry to handle.
+    // SAFETY: SG-HA-3 — durable read offloaded off the async runtime.
+    // SAFETY: SG-HA-4 — DB/offload failure fails closed (self-demote, return false).
+    let app_for_seed = Arc::clone(app);
+    match tokio::task::spawn_blocking(move || init_generation_from_store(&app_for_seed)).await {
+        Ok(Ok(seeded_high_water)) => {
+            tracing::info!(
+                instance_id = %id,
+                epoch = new_epoch,
+                seeded_high_water,
+                "promotion: re-seeded generation counter from shared store (#771 F1) — first Active recalc will emit above the dead primary's last generation"
+            );
+        }
+        Ok(Err(e)) => {
+            tracing::error!(
+                error = %e, instance_id = %id, epoch = new_epoch,
+                "promotion ABORTED — cannot re-seed generation high-water from shared store; staying PassiveStandby (fail-closed) to avoid time-reversing generations"
+            );
+            app.mode_active.store(false, std::sync::atomic::Ordering::SeqCst);
+            return false;
+        }
+        Err(e) => {
+            tracing::error!(
+                error = %e, instance_id = %id, epoch = new_epoch,
+                "promotion ABORTED — generation re-seed offload failed; staying PassiveStandby (fail-closed)"
+            );
+            app.mode_active.store(false, std::sync::atomic::Ordering::SeqCst);
+            return false;
+        }
+    }
+
     // Step 5: Initial recalculation as Active instance.
     // is_active() now returns true, so recalculate_and_broadcast will write
     // to the cache and emit broadcasts instead of returning early.
@@ -1466,6 +1513,52 @@ mod sg_009_promotion_act_tests {
             .with(|store| store.verify_audit_chain_full(None)).unwrap();
         assert!(audit.total_entries >= 1,
             "promotion must append a STANDBY_PROMOTED_TO_ACTIVE audit event");
+    }
+
+    /// #771 F1 — a promoted standby must RE-SEED the generation counter from the
+    /// SHARED store before its first Active recalc, so its first emitted
+    /// generation is ABOVE the dead primary's last (which advanced the durable
+    /// high-water for the primary's whole uptime). Before the fix `perform_promotion`
+    /// recalculated with THIS node's stale boot counter, time-reversing the sequence
+    /// federation peers hard-reject.
+    ///
+    /// The store carries a high-water `H` well ABOVE the current live counter
+    /// (offset like the other generation tests to survive the process-global
+    /// `POSTURE_GENERATION` that concurrent tests also mutate — #771 F7 debt). After
+    /// promotion the persisted high-water — bumped by the first Active recalc — must
+    /// exceed `H`. Without the re-seed the recalc stamps a generation BELOW `H`, the
+    /// monotonic guard rejects the persist, and the high-water stays exactly `H`
+    /// (assertion fails). Verified to fail on the pre-fix code.
+    #[test]
+    fn test_promotion_reseeds_generation_above_dead_primary_highwater() {
+        use crate::posture_engine::POSTURE_GENERATION;
+
+        let store = VerifierStore::new(":memory:").expect("store");
+        // The dead primary's durable high-water: far above any value concurrent
+        // tests could have pushed the shared counter to.
+        let h = POSTURE_GENERATION.load(Ordering::SeqCst) + 1_000_000;
+        assert!(
+            store.save_last_generation(h).expect("seed high-water"),
+            "seeding the dead-primary high-water must persist"
+        );
+
+        let app = Arc::new(AppState::new(store, VerifierOperationMode::PassiveStandby));
+        let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
+        assert!(!app.is_active(), "must start as PassiveStandby");
+
+        run_promotion(&app, &cache, "standby-f1", "HEARTBEAT_TIMEOUT");
+        assert!(app.is_active(), "promotion must complete");
+
+        let persisted = app
+            .store
+            .with(|s| s.load_last_generation())
+            .expect("load high-water");
+        assert!(
+            persisted > h,
+            "post-promotion high-water {persisted} must EXCEED the dead primary's {h} \
+             (re-seed at promotion, #771 F1); without the re-seed the recalc stamps below {h} \
+             and the monotonic guard leaves it unchanged"
+        );
     }
 
     /// Drives the real async promotion on a deterministic current-thread runtime.

--- a/src/verifier_store/posture.rs
+++ b/src/verifier_store/posture.rs
@@ -155,6 +155,60 @@ impl VerifierStore {
         tx.commit()
     }
 
+    /// Like [`Self::save_posture_event_chained`], but ALSO advances the
+    /// generation high-water in the SAME transaction (#771 F2). Folding the
+    /// stamp and its high-water into one commit closes the cross-restart crash
+    /// window the separate two-write path left open: a hard kill between the
+    /// audit-event commit and the high-water UPSERT re-seeded from a STALE
+    /// high-water on restart, so the durable audit chain could hold two events
+    /// stamped with the same generation, or an already-broadcast generation
+    /// could be re-issued. With one transaction the event and its high-water
+    /// are all-or-nothing: a failed commit lands neither, and the caller (which
+    /// gates cache/broadcast on success) fails closed.
+    ///
+    /// Returns whether the high-water ADVANCED (`true`) or the monotonic guard
+    /// rejected `generation` as stale/equal (`false`, a benign concurrent-recalc
+    /// race); either way the posture event + audit append committed.
+    ///
+    /// FAIL-CLOSED (#771 F4): a `generation` outside the storable INTEGER domain
+    /// (`>= i64::MAX`) is rejected BEFORE the transaction — SQLite's
+    /// `CAST(value AS INTEGER)` saturates at `i64::MAX`, so storing such a value
+    /// would silently corrupt the monotonic guard itself. The whole write errors.
+    pub fn save_posture_event_chained_with_generation(
+        &mut self,
+        node_id: &str,
+        event_type: &str,
+        posture_json: &str,
+        reason: Option<&str>,
+        created_at_ms: u64,
+        generation: u64,
+    ) -> Result<bool> {
+        if generation >= i64::MAX as u64 {
+            return Err(rusqlite::Error::IntegralValueOutOfRange(0, i64::MAX));
+        }
+        let tx = Self::audit_tx(&mut self.conn)?; // #685: Immediate — non-forking audit append
+        tx.execute(
+            "INSERT INTO posture_events
+             (node_id, event_type, posture_json, reason, created_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![node_id, event_type, posture_json, reason, created_at_ms as i64],
+        )?;
+        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
+            &tx, event_type, posture_json, created_at_ms as i64, self.signing_key.as_ref(),
+        )?;
+        // Monotonic max-write — identical guard to `save_last_generation`, but
+        // in THIS transaction so the stamp and its high-water commit together.
+        let changed = tx.execute(
+            "INSERT INTO posture_engine_state (key, value)
+             VALUES ('last_generation', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = ?1
+             WHERE CAST(?1 AS INTEGER) > CAST(value AS INTEGER)",
+            params![generation.to_string()],
+        )?;
+        tx.commit()?;
+        Ok(changed > 0)
+    }
+
     pub fn load_last_generation(&self) -> Result<u64> {
         match self.conn.query_row(
             "SELECT value FROM posture_engine_state WHERE key = 'last_generation'",
@@ -165,13 +219,27 @@ impl VerifierStore {
             // CORRUPTION, not a fresh store. The prior `unwrap_or(0)` read it as
             // "no history", silently reintroducing the restart time-reversal the
             // boot init exists to prevent. Only a genuinely absent row is 0.
-            Ok(s) => s.parse::<u64>().map_err(|e| {
-                rusqlite::Error::FromSqlConversionFailure(
-                    0,
-                    rusqlite::types::Type::Text,
-                    Box::new(e),
-                )
-            }),
+            Ok(s) => {
+                let parsed = s.parse::<u64>().map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })?;
+                // #771 F4: a numeric-but-out-of-domain value (`>= i64::MAX`) is
+                // ALSO corruption, not a valid high-water. It parses cleanly but
+                // (a) `init_generation_from_store` would compute `last + 1` — a
+                // release-build wraparound to 0 with overflow-checks off, silently
+                // failing OPEN to the very restart time-reversal this guard exists
+                // to prevent; and (b) it breaks the store's own `CAST(value AS
+                // INTEGER)` monotonic guard (SQLite saturates at i64::MAX). Reject
+                // it fail-closed, exactly like the non-numeric case.
+                if parsed >= i64::MAX as u64 {
+                    return Err(rusqlite::Error::IntegralValueOutOfRange(0, i64::MAX));
+                }
+                Ok(parsed)
+            }
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(0),
             Err(e) => Err(e),
         }

--- a/src/verifier_store/tests.rs
+++ b/src/verifier_store/tests.rs
@@ -155,6 +155,108 @@ mod attestation_registry_tests {
             "a non-numeric persisted generation must be a load ERROR, not 0"
         );
     }
+
+    /// #771 F4 — a NUMERIC-but-out-of-domain high-water (`>= i64::MAX`) is also
+    /// corruption. It parses cleanly, so the prior guard let it through — but
+    /// `init_generation_from_store` would then compute `last + 1`, a release-build
+    /// wraparound to 0 that silently fails OPEN to the restart time-reversal; and
+    /// it breaks the store's own `CAST(value AS INTEGER)` monotonic guard (SQLite
+    /// saturates at i64::MAX). It must fail closed exactly like the non-numeric case.
+    #[test]
+    fn test_numeric_but_out_of_domain_last_generation_fails_closed() {
+        let store = in_memory();
+        // u64::MAX — the exact value the review flagged.
+        store
+            .save_engine_state("last_generation", "18446744073709551615")
+            .unwrap();
+        assert!(
+            store.load_last_generation().is_err(),
+            "u64::MAX high-water must fail closed (corruption), not load as a value"
+        );
+        // i64::MAX is the inclusive boundary of the rejected range.
+        store
+            .save_engine_state("last_generation", &(i64::MAX as u64).to_string())
+            .unwrap();
+        assert!(
+            store.load_last_generation().is_err(),
+            "i64::MAX high-water is at the CAST-saturation boundary and must be rejected"
+        );
+        // A large but in-domain value still loads normally (no false positives).
+        store
+            .save_engine_state("last_generation", "1000000000")
+            .unwrap();
+        assert_eq!(
+            store.load_last_generation().unwrap(),
+            1_000_000_000,
+            "a large in-domain high-water must still load"
+        );
+    }
+
+    /// #771 F2 — the posture event, its audit-chain link, AND the generation
+    /// high-water must commit in ONE transaction. Folding the stamp and its
+    /// high-water removes the cross-restart crash window the separate two-write
+    /// path left open (an event durable at generation G while the high-water lagged
+    /// < G). This pins: (a) the happy path advances both; (b) a stale generation
+    /// still commits the event but leaves the high-water untouched; (c) a failed
+    /// audit append rolls back BOTH — neither the event nor the high-water lands.
+    #[test]
+    fn test_posture_event_and_generation_commit_atomically() {
+        let mut store = in_memory();
+
+        // (a) Happy path — event row lands AND high-water advances, one tx.
+        let advanced = store
+            .save_posture_event_chained_with_generation(
+                "posture_engine",
+                "SYSTEM_POSTURE_TRANSITION",
+                "{}",
+                None,
+                1_000,
+                42,
+            )
+            .unwrap();
+        assert!(advanced, "first write must advance the high-water");
+        assert_eq!(store.load_last_generation().unwrap(), 42);
+        assert_eq!(store.load_all_posture_events().unwrap().len(), 1, "event must commit");
+
+        // (b) Stale generation — the monotonic guard rejects the high-water bump,
+        // but the event still commits (matches the old separate-write semantics).
+        let advanced2 = store
+            .save_posture_event_chained_with_generation(
+                "posture_engine",
+                "POSTURE_CACHE_REFRESHED",
+                "{}",
+                None,
+                2_000,
+                10,
+            )
+            .unwrap();
+        assert!(!advanced2, "a stale generation must not advance the high-water");
+        assert_eq!(store.load_last_generation().unwrap(), 42, "high-water unchanged by stale write");
+        assert_eq!(store.load_all_posture_events().unwrap().len(), 2, "the event still commits");
+
+        // (c) Atomicity on failure — break the audit-chain append so the tx must
+        // roll back; NEITHER the event NOR the high-water may land.
+        store.break_audit_chain_table_for_test();
+        let r = store.save_posture_event_chained_with_generation(
+            "posture_engine",
+            "SYSTEM_POSTURE_TRANSITION",
+            "{}",
+            None,
+            3_000,
+            99,
+        );
+        assert!(r.is_err(), "a failed audit append must error the whole write");
+        assert_eq!(
+            store.load_last_generation().unwrap(),
+            42,
+            "a rolled-back tx must NOT advance the high-water (atomicity)"
+        );
+        assert_eq!(
+            store.load_all_posture_events().unwrap().len(),
+            2,
+            "a rolled-back tx must NOT leave the posture-event row behind (atomicity)"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**Fix-PR C of the 10-PR review follow-up — the three generation-persistence gaps from #771.** #771 fixed the single-process restart time-reversal; these close the paths it stopped one layer short of. Each fix ships a regression test; F1's is **proven to fail on the pre-fix code**.

## F1 — HIGH — promoted standby still time-reverses generations (`standby_monitor.rs`)

HA pairs share one SQLite file. `perform_promotion` claimed the durable epoch, flipped `mode_active`, and recalculated — but never re-seeded `POSTURE_GENERATION` from the shared store. The dead primary advanced the durable high-water for its **entire uptime** (~34,560 generations/day at the recalc cadence) while the standby's in-memory counter was seeded once, at its own boot. So the first post-promotion recalc emitted a generation far *below* the primary's last, and every v2 federation report this controller sources was then **hard-rejected by every peer** (`GenerationRegress`, fail-closed) until the counter ground past the old high-water — roughly **a day of cross-fleet trust blindness per day of prior primary uptime**, on the exact event (primary death) where fresh posture matters most. The PR's own boot comment documented this path as *solved*.

**Fix:** re-seed via the idempotent `init_generation_from_store` (`fetch_max`, only ever raises) after the epoch/promotion records and **before** the first Active recalc. Fail-closed — a store read error aborts promotion and self-demotes.

**Regression:** `test_promotion_reseeds_generation_above_dead_primary_highwater` drives the real `perform_promotion` over a store carrying a high-water `H`; the post-promotion high-water must exceed `H`. **Verified to fail** without the re-seed (the recalc stamps below `H`, the monotonic guard leaves it unchanged).

## F2 — MEDIUM — audit event and generation high-water were separate transactions (`posture_engine.rs` / `posture.rs`)

`recalculate_and_broadcast` committed the audit event (with the generation embedded in its payload) in one transaction, then persisted the high-water in a *separate, tolerated-`Err`* write. A hard kill in between re-seeded stale on restart: the durable audit chain could hold **two events stamped with the same generation**, or an already-broadcast generation could be re-issued — a live time reversal.

**Fix:** new `save_posture_event_chained_with_generation` folds the posture row, its audit-chain link, and the monotonic high-water UPSERT into **one transaction**. A failed commit now lands neither, and the caller (which already gates cache/broadcast on success) fails closed — the crash window vanishes. The 30+ other `save_posture_event_chained` callers are untouched.

**Regression:** `test_posture_event_and_generation_commit_atomically` — happy path advances both; a stale generation still commits the event but leaves the high-water; a broken audit append rolls back **both**.

## F4 — MEDIUM — numeric-but-huge corrupt high-water failed OPEN (`posture.rs`)

`load_last_generation` only rejected non-numeric text. A row of `u64::MAX` parsed cleanly, then `init_generation_from_store` computed `last + 1` — a **release-build wraparound to 0** (the workspace profile has `overflow-checks` off) → `fetch_max(0)` no-op → counter stays 1, the exact restart time-reversal the guard exists to prevent; and it broke the store's own `CAST(value AS INTEGER)` monotonic guard (SQLite saturates at `i64::MAX`).

**Fix:** reject a loaded high-water `>= i64::MAX` as corruption (fail-closed, like the non-numeric case); `checked_add(1)` in the init as belt-and-suspenders; and the same domain guard on the write side of the combined method.

**Regression:** `test_numeric_but_out_of_domain_last_generation_fails_closed`.

## Verification

657 lib tests + the `generation_persistence` integration test + clippy all green. F1 independently confirmed to fail on the pre-fix code. No hot-path change; the Nominal WCET path is untouched. Quality-guardrail ratchet unaffected (none of the tracked files changed).

## Not in scope (tracked for later fix-PRs)

#771 F3 (binary-level boot-wiring guard / two-process restart test) and the epoch-fenced `(epoch, generation)` ordering (I1) are larger structural items; F5/F6/F7/F8 are LOW/INFO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_