### PR TITLE
parko: deadline-breach → posture escalation w/ hysteresis; monotonic scene freshness; deadline hardening (review fix-F: #773 + #770 F4)

### DIFF
--- a/docs/safety/ASSUMPTIONS_OF_USE.md
+++ b/docs/safety/ASSUMPTIONS_OF_USE.md
@@ -47,6 +47,7 @@ the verification passes for the target deployment.
 | AOU-PERCEPTION-CLASS-001 | Reliable detection of the worst-case object classes (pedestrian / cyclist / child / low-contrast debris) at ≥ R_reliable | Integrator (perception) | **AoU-GAP** (base) → D1 IDC omission coverage | the speed cap (SPEED-VAL-001 row 4); the SG1/SG6 worst-case-object basis |
 | AOU-VEHICLE-FRICTION-001 | Effective deceleration ≥ 3.0 m/s² over the deployment ODD (else sub-ODD weather-derate) | Integrator (vehicle / road) | **OK-ANALYTICAL** (vehicle) + **AoU-GAP** (road friction) | the speed cap's SSD braking term (SPEED-VAL-001 row 3) |
 | AOU-ACTUATION-LATENCY-001 | Actuation completes safe-stop initiation ≤ 499 ms of the MRC verdict, and safe-stops on loss of a valid verdict | Integrator (actuation) | **OK-PROVEN** (Governor) + **AoU-GAP** (actuator residual) | the speed cap's t_react budget (SPEED-VAL-001 row 2); SS-003 MRC fallback |
+| AOU-ACTUATION-DEADMAN-001 | The base controller consuming the parko node's `cmd_vel` stream treats stream SILENCE beyond a dead-man budget (≤ the parko inference deadline) as STOP — it must not hold the last twist live indefinitely | Integrator (actuation / base controller) | **AoU-GAP** — integrator obligation; parko side fails closed to per-tick STOP + posture escalation (#773 F2) | the parko WS-0.4 inference deadline (`DEFAULT_INFERENCE_DEADLINE_MS`): on a backend hang the node publishes STOP, but a base controller that latches the last command would keep a pre-hang MOVING twist live across the hang window |
 | AOU-HW-POWER-001 (DR-1) | Governor D3 compute on an ASIL-D-class redundant / supervised power supply | Integrator (hardware / platform) | **AoU-GAP** — pre-production HW gate | the ASIL-D PMHF target for the Governor element (KIRRA-OCCY-QUANT-001) |
 | AOU-HW-COMMBUS-001 (DR-2) | Governor comm path (Auto-Ethernet PHY+MAC) achieves LFM ≥ 90 % | Integrator (hardware / platform) | **AoU-GAP** — pre-production HW gate | the ASIL-D LFM target for the Governor element (KIRRA-OCCY-QUANT-001) |
 | AOU-LOCALIZATION-001 | Integrator localization ≤ 0.10 m 95th-pct lateral (cross-track) error over the ODD; else the documented 0.75 m conservative-fallback margin | Integrator (localization) | **AoU-GAP** (base) — integrator-characterized; runtime gate live (#123 / PR #264) | `CONTAINMENT_LATERAL_MARGIN_M = 0.40 m` (SG2 ASIL D); all map-anchored SG5 commit-zone enforcement (#260–#262) + the SG4 `MapKnownSafe` earn-back |
@@ -1268,3 +1269,61 @@ OS is not a partition guarantee). Discharged by hypervisor scheduling
 configuration + the HV-S1/HV-S2 campaign rows measuring governor-path latency
 percentiles UNDER guest flood/starve-burst, against the same budgets the
 Phase-I baseline established unloaded.
+
+---
+
+## AOU-ACTUATION-DEADMAN-001 — Base controller dead-mans a silent `cmd_vel` stream
+
+### Assumption
+
+The base controller (or motor driver) that consumes the parko node's `cmd_vel`
+command stream treats **stream silence** — no fresh command within a dead-man
+budget — as an immediate **STOP**, rather than latching the last-received twist
+live. The dead-man budget SHALL be no larger than the parko per-tick inference
+deadline (`DEFAULT_INFERENCE_DEADLINE_MS`, default 1000 ms; deployments tighten
+it via `PARKO_INFERENCE_DEADLINE_MS`).
+
+### Why it is load-bearing
+
+On a backend hang (wedged driver / deadlocked execution provider) the parko
+inference loop fails closed **at its own boundary**: the WS-0.4 deadline cuts the
+tick off, the loop publishes STOP, and the deadline-breach posture escalator
+(#773 F2) drives the fleet toward Degraded/LockedOut with recovery hysteresis.
+But that protection covers only the commands parko **emits**. A base controller
+that holds the last twist live on stream silence would keep a **pre-hang MOVING
+command** actuating across the hang window regardless — the parko STOP never
+reaches the wheels if the transport stalls, and even a delivered STOP is
+undermined if the controller ignores subsequent silence. The dead-man closes
+that residual, mirroring the SDK's own `503 → 0.0` consumer safe-stop discipline
+(the HTTP command consumer treats a fail-closed 503 as zero).
+
+### Pairs with
+
+- **AOU-ACTUATION-LATENCY-001** — safe-stop on loss of a valid *verdict* (the
+  MRC path). This entry is the finer-grained cmd_vel-stream analogue for the
+  parko doer path: loss of a valid *command stream* is also a stop.
+- **AOU-TIMESYNC-001** — the timestamps the dead-man ages must be in the
+  boundary clock domain (a non-monotonic stamp would mis-age the stream; cf. the
+  #770 F4 future-stamp-is-stale fix on the scene freshness gates).
+
+### Verification status — **AoU-GAP** (integrator obligation)
+
+The parko side is DISCHARGED: `InferenceLoop::tick` publishes STOP on every fault
+exit (deadline / non-finite / backend-error / join-error, WS-0.4 F3) and
+escalates the recommended posture on deadline breaches (F2), both regression-
+tested. The consumer-side dead-man is the integrator's obligation — parko cannot
+enforce what a downstream controller does with a silent topic.
+
+### Consequence if violated
+
+A base controller that latches the last `cmd_vel` and ignores stream silence
+converts a bounded, fail-closed parko hang into an **unbounded moving command**
+at the pre-hang velocity for the duration of the stall — defeating the WS-0.4
+deadline's entire purpose at the actuator.
+
+### Cross-references
+
+- `parko/crates/parko-core/src/scheduler.rs` — `DEFAULT_INFERENCE_DEADLINE_MS`,
+  the deadline watchdog, and the F2 breach→posture escalator.
+- `SAFE_STATE_SPECIFICATION.md` SS-003 (MRC fallback); the SDK `503 → 0.0`
+  consumer safe-stop (#405 / ADR-0011).

--- a/parko/crates/parko-core/src/scheduler.rs
+++ b/parko/crates/parko-core/src/scheduler.rs
@@ -34,7 +34,49 @@ fn override_reason(action: &EnforcementAction) -> Option<&'static str> {
 /// Deliberately generous (20× the tick period @ 20 Hz) so it only fires on
 /// a genuine hang, never on ordinary latency jitter; deployments tighten it
 /// via `with_inference_deadline_ms` / `PARKO_INFERENCE_DEADLINE_MS`.
+///
+/// NOTE (#773 F1): this bounds only the command parko EMITS — on breach the loop
+/// publishes STOP and escalates posture (F2). The base controller consuming
+/// `cmd_vel` MUST additionally dead-man a silent command stream to STOP within
+/// this budget (else it would hold a pre-hang MOVING twist live across the hang).
+/// See `AOU-ACTUATION-DEADMAN-001` in `docs/safety/ASSUMPTIONS_OF_USE.md`.
+/// Budget-deriving this default from the FTTI decomposition (vs the current
+/// "generous" rationale) is a tracked safety-case item.
 pub const DEFAULT_INFERENCE_DEADLINE_MS: u64 = 1_000;
+
+/// WS-0.4 F6 — sanity CEILING on the per-tick inference deadline, ms. The
+/// deadline is the loop's only defence against an indefinite backend hang, so a
+/// value large enough to be a de-facto disable (`u64::MAX`, a 10-year timeout)
+/// silently defeats the "cannot be disabled" contract. `with_inference_deadline_ms`
+/// clamps to `[1, DEADLINE_CEILING_MS]` (60 s — comfortably above any legitimate
+/// backend warm-up, far below "never").
+pub const DEADLINE_CEILING_MS: u64 = 60_000;
+
+// --- WS-0.4 F2: deadline-breach → posture escalation, with hysteresis --------
+//
+// A backend hang is a serious platform-health event (wedged driver / deadlocked
+// EP). Per-tick it already fails closed to a stopped command, but before this
+// the fault never reached the POSTURE layer: the fleet stayed Nominal, no
+// watchdog counted repeated breaches toward LockedOut, and the instant the
+// straggler cleared the vehicle re-accelerated with zero confirmation. This is a
+// leaky-bucket escalator (mirroring the comparator's divergence accumulator so
+// the two fault-escalators read the same): each breach adds `INC`, each healthy
+// tick drains `DECAY`. Any non-zero accumulator recommends `Degraded`; reaching
+// `LOCKOUT_LEVEL` (three consecutive breaches) recommends `LockedOut`. The drain
+// is the recovery hysteresis — a single breach holds `Degraded` for
+// `INC / DECAY` = 3 healthy ticks (the same confirmation-streak discipline
+// `ControlLoop` uses), so a backend flapping at ~deadline period stays escalated
+// instead of oscillating move/stop/move at Nominal.
+
+/// Accumulator increment per deadline breach (or while-hung tick).
+const DEADLINE_BREACH_INC: u32 = 3;
+/// Accumulator decrement per healthy (within-deadline) tick.
+const DEADLINE_BREACH_DECAY: u32 = 1;
+/// Accumulator saturation ceiling (bounds the drain time after a breach storm).
+const DEADLINE_BREACH_CEILING: u32 = 12;
+/// Accumulator level at/above which the loop recommends `LockedOut`
+/// (= three consecutive breaches with no intervening recovery).
+const DEADLINE_LOCKOUT_LEVEL: u32 = 9;
 
 /// The join handle of an in-flight (possibly hung) inference task. The
 /// blocking task cannot be cancelled — `spawn_blocking` work holds an OS
@@ -98,6 +140,11 @@ pub struct InferenceLoop<B: InferenceBackend> {
     /// its (stale) result is reaped and discarded and normal operation
     /// resumes.
     hung_inference: Option<InFlightInference>,
+    /// WS-0.4 F2 — leaky-bucket accumulator of recent inference-deadline breaches.
+    /// Drives `recommended_posture` (Degraded while non-zero, LockedOut at
+    /// `DEADLINE_LOCKOUT_LEVEL`), so a hang escalates the FLEET posture with
+    /// recovery hysteresis, not just this tick's command.
+    deadline_breach_acc: u32,
 }
 
 fn capabilities_precision(caps: &BackendCapabilities) -> PrecisionMode {
@@ -146,17 +193,54 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
             audit: None,
             inference_deadline_ms: DEFAULT_INFERENCE_DEADLINE_MS,
             hung_inference: None,
+            deadline_breach_acc: 0,
         }
     }
 
-    /// WS-0.4 — set the per-tick inference deadline (ms). Must be positive;
-    /// zero is coerced to 1 ms (a zero deadline would MRC every tick, which
-    /// is fail-closed but certainly a misconfiguration). The deadline cannot
-    /// be disabled: a backend hang must never stall the loop indefinitely.
+    /// WS-0.4 — set the per-tick inference deadline (ms). Clamped to
+    /// `[1, DEADLINE_CEILING_MS]`: zero would MRC every tick (fail-closed but a
+    /// misconfiguration), and a value large enough to be a de-facto disable
+    /// (`u64::MAX`) would silently defeat the "cannot be disabled" contract — a
+    /// backend hang must never stall the loop indefinitely (#773 F6).
+    ///
+    /// RUNTIME REQUIREMENT (#773 F4): `tick` arms a `tokio::time::timeout`, so it
+    /// must run on a Tokio runtime with the TIME DRIVER enabled (`enable_time()` /
+    /// `enable_all()`). On a time-less `current_thread` runtime the first tick
+    /// panics ("time driver not enabled"); under a `start_paused` runtime the
+    /// clock auto-advances while a `spawn_blocking` worker runs, firing the
+    /// deadline spuriously every tick. Drive it on a real-time runtime.
     #[must_use]
     pub fn with_inference_deadline_ms(mut self, deadline_ms: u64) -> Self {
-        self.inference_deadline_ms = deadline_ms.max(1);
+        self.inference_deadline_ms = deadline_ms.clamp(1, DEADLINE_CEILING_MS);
         self
+    }
+
+    /// WS-0.4 F2 — record a deadline breach (or a while-hung tick): charge the
+    /// leaky-bucket accumulator that drives `recommended_posture`.
+    fn record_deadline_breach(&mut self) {
+        self.deadline_breach_acc =
+            (self.deadline_breach_acc + DEADLINE_BREACH_INC).min(DEADLINE_BREACH_CEILING);
+    }
+
+    /// WS-0.4 F2 — record a healthy (within-deadline) tick: drain the
+    /// accumulator by `DECAY`. The drain IS the recovery hysteresis — the
+    /// posture recommendation stays escalated until the bucket empties.
+    fn record_deadline_healthy(&mut self) {
+        self.deadline_breach_acc = self.deadline_breach_acc.saturating_sub(DEADLINE_BREACH_DECAY);
+    }
+
+    /// WS-0.4 F2 — the posture the deadline watchdog recommends from its breach
+    /// history: `LockedOut` once persistent (`>= DEADLINE_LOCKOUT_LEVEL`),
+    /// `Degraded` while any recent breach is still draining, else `Nominal`.
+    #[must_use]
+    fn deadline_health_posture(&self) -> SafetyPosture {
+        if self.deadline_breach_acc >= DEADLINE_LOCKOUT_LEVEL {
+            SafetyPosture::LockedOut
+        } else if self.deadline_breach_acc > 0 {
+            SafetyPosture::Degraded
+        } else {
+            SafetyPosture::Nominal
+        }
     }
 
     /// Attach an [`AuditClient`] so the decision path records governor overrides
@@ -177,16 +261,25 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
         self
     }
 
-    /// The posture the attached governor RECOMMENDS from its internal state (e.g. a redundancy
-    /// comparator escalating to `Degraded` / `LockedOut` on persistent divergence); `Nominal`
-    /// when no governor is attached. The tick driver reads this each cycle and escalates the
-    /// effective posture with it — closing the divergence→posture loop so a governor
-    /// disagreement actually drives the fleet posture, not just this tick's clamp.
+    /// The posture this loop RECOMMENDS to the fleet, the MORE RESTRICTIVE of two
+    /// independent fault-escalators (#773 F2): the attached governor's own
+    /// recommendation (e.g. a redundancy comparator escalating on persistent
+    /// divergence; `Nominal` when no governor is set), and the DEADLINE watchdog's
+    /// breach history (`Degraded` while a recent hang is still draining,
+    /// `LockedOut` once persistent — see `deadline_health_posture`).
+    ///
+    /// The tick driver reads this each cycle and escalates the effective posture
+    /// with it, so BOTH a governor disagreement AND a backend hang drive the fleet
+    /// posture, not just this tick's clamp. Before F2 the deadline breach fed only
+    /// this tick's stopped command; the fleet stayed Nominal and re-accelerated the
+    /// instant the straggler cleared.
     #[must_use]
     pub fn recommended_posture(&self) -> SafetyPosture {
-        self.governor
+        let governor = self
+            .governor
             .as_ref()
-            .map_or(SafetyPosture::Nominal, |g| g.recommended_posture())
+            .map_or(SafetyPosture::Nominal, |g| g.recommended_posture());
+        governor.escalate(self.deadline_health_posture())
     }
 
     /// Set the tick period (used for time-delta calculations passed to
@@ -255,6 +348,9 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
                 self.hung_inference = Some(straggler);
                 self.last_validated_command =
                     Some(ControlCommand::stopped(loop_start_ms));
+                // WS-0.4 F2: a while-hung tick is a continuing breach — keep the
+                // posture escalated (and drive it toward LockedOut on persistence).
+                self.record_deadline_breach();
                 // The onset was audited on the deadline tick; while-hung
                 // ticks stay quiet (a 20 Hz loop would flood the ledger) —
                 // the degraded MRC snapshots are the ongoing record.
@@ -303,6 +399,9 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
                     });
                 }
                 self.hung_inference = Some(in_flight);
+                // WS-0.4 F2: escalate the fleet posture on the breach, with
+                // recovery hysteresis (the accumulator drains over healthy ticks).
+                self.record_deadline_breach();
                 // The next flush must carry a STOP, not the pre-hang command
                 // (fail-closed: after a hang the governor's `previous` is a
                 // stop, so Degraded's no-re-initiation gate holds at zero).
@@ -316,6 +415,14 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
                 ));
             }
         };
+        // WS-0.4 F2: the inference returned WITHIN the deadline (it did not hang) —
+        // drain the breach accumulator one step. This is the recovery hysteresis:
+        // after a hang, several consecutive healthy ticks are required before the
+        // posture recommendation relaxes from Degraded back to Nominal. A
+        // non-finite / backend-error result still counts as "not a hang" (it
+        // returned): the deadline watchdog governs stalls, not output validity.
+        self.record_deadline_healthy();
+
         // WS-0.4 F3: EVERY fault exit must leave `last_validated_command` a STOP,
         // not the pre-fault MOVING command. `tick` flushes `last_validated_command`
         // at the START of the next tick (one-tick-delayed publication), so a fault
@@ -1043,6 +1150,101 @@ mod tests {
             "recovery tick publishes the fresh backend output, not the stale straggler result"
         );
         assert!(!snap3.active_state_degraded, "recovered loop is healthy again");
+    }
+
+    /// WS-0.4 F2 — the deadline-breach posture escalator (leaky bucket) drives
+    /// `recommended_posture` with recovery hysteresis and a persistent-breach
+    /// LockedOut. Exercised directly (no real hangs) so the exact accumulator
+    /// contract is pinned: one breach → Degraded, held for `INC/DECAY` = 3
+    /// healthy ticks; three consecutive breaches → LockedOut.
+    #[test]
+    fn deadline_breach_accumulator_escalates_and_recovers_with_hysteresis() {
+        let backend = Arc::new(ConfigurableBackend { linear: 1.0 });
+        let model = backend.load_model("").unwrap();
+        let (tx, _rx) = mpsc::channel(4);
+        let mut engine = InferenceLoop::new(backend, model, tx);
+
+        // Fresh loop: no breach history → Nominal.
+        assert_eq!(engine.recommended_posture(), SafetyPosture::Nominal);
+
+        // One breach → Degraded (acc = INC = 3).
+        engine.record_deadline_breach();
+        assert_eq!(engine.recommended_posture(), SafetyPosture::Degraded,
+            "a single deadline breach must recommend Degraded");
+
+        // Recovery hysteresis: it stays Degraded for INC/DECAY = 3 healthy ticks,
+        // clearing only when the bucket drains to 0.
+        engine.record_deadline_healthy(); // 3 → 2
+        assert_eq!(engine.recommended_posture(), SafetyPosture::Degraded, "still draining (2)");
+        engine.record_deadline_healthy(); // 2 → 1
+        assert_eq!(engine.recommended_posture(), SafetyPosture::Degraded, "still draining (1)");
+        engine.record_deadline_healthy(); // 1 → 0
+        assert_eq!(engine.recommended_posture(), SafetyPosture::Nominal,
+            "recovered to Nominal only after the confirmation streak drained the bucket");
+
+        // Three consecutive breaches (no intervening recovery) → LockedOut.
+        engine.record_deadline_breach(); // 3
+        engine.record_deadline_breach(); // 6
+        assert_eq!(engine.recommended_posture(), SafetyPosture::Degraded, "two breaches: still Degraded");
+        engine.record_deadline_breach(); // 9 == DEADLINE_LOCKOUT_LEVEL
+        assert_eq!(engine.recommended_posture(), SafetyPosture::LockedOut,
+            "three consecutive breaches must escalate to LockedOut");
+    }
+
+    /// WS-0.4 F2 — the escalation is LIVE through the real tick path: a backend
+    /// hang not only MRCs the tick's command but escalates `recommended_posture`
+    /// to Degraded (the signal the tick driver feeds to the fleet posture),
+    /// then relaxes back to Nominal after a recovery streak of healthy ticks.
+    /// Before F2 a hang left the posture Nominal and re-accelerated instantly.
+    #[tokio::test]
+    async fn deadline_breach_escalates_recommended_posture_through_tick() {
+        let backend = Arc::new(HangOnceBackend {
+            hang_ms: 250,
+            runs: std::sync::atomic::AtomicU32::new(0),
+        });
+        let model = backend.load_model("").unwrap();
+        let (tx, _rx) = mpsc::channel(8);
+        let mut engine = InferenceLoop::new(Arc::clone(&backend), model, tx)
+            .with_inference_deadline_ms(30);
+        let mut stream = SimpleStream { next_id: 0 };
+
+        assert_eq!(engine.recommended_posture(), SafetyPosture::Nominal, "healthy at start");
+
+        // Tick 1: the backend hangs → deadline breach → posture escalates.
+        let _ = engine.tick(stream.next_frame().unwrap(), SafetyPosture::Nominal).await.unwrap();
+        assert_eq!(
+            engine.recommended_posture(),
+            SafetyPosture::Degraded,
+            "a deadline breach must escalate the RECOMMENDED posture, not just the command"
+        );
+
+        // Let the straggler clear, then drive healthy ticks until the bucket
+        // drains. The posture must NOT snap back on the first healthy tick
+        // (hysteresis); it relaxes to Nominal only after the streak.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        let mut recovered = false;
+        for _ in 0..6 {
+            let _ = engine.tick(stream.next_frame().unwrap(), SafetyPosture::Nominal).await.unwrap();
+            if engine.recommended_posture() == SafetyPosture::Nominal {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(recovered, "the posture must relax to Nominal after a recovery streak of healthy ticks");
+    }
+
+    /// #773 F6 — the deadline is clamped to a sanity ceiling so a `u64::MAX`
+    /// (de-facto "disable") value can't silently defeat the always-on contract.
+    #[test]
+    fn deadline_is_clamped_to_sanity_ceiling() {
+        let backend = Arc::new(ConfigurableBackend { linear: 1.0 });
+        let model = backend.load_model("").unwrap();
+        let (tx, _rx) = mpsc::channel(1);
+        let engine = InferenceLoop::new(backend, model, tx).with_inference_deadline_ms(u64::MAX);
+        assert_eq!(
+            engine.inference_deadline_ms, DEADLINE_CEILING_MS,
+            "an absurd deadline must clamp to the ceiling, never act as a disable"
+        );
     }
 
     /// The deadline must not fire on a slow-but-completing backend: the

--- a/parko/crates/parko-core/src/scheduler.rs
+++ b/parko/crates/parko-core/src/scheduler.rs
@@ -205,10 +205,13 @@ impl<B: InferenceBackend + 'static> InferenceLoop<B> {
     ///
     /// RUNTIME REQUIREMENT (#773 F4): `tick` arms a `tokio::time::timeout`, so it
     /// must run on a Tokio runtime with the TIME DRIVER enabled (`enable_time()` /
-    /// `enable_all()`). On a time-less `current_thread` runtime the first tick
-    /// panics ("time driver not enabled"); under a `start_paused` runtime the
-    /// clock auto-advances while a `spawn_blocking` worker runs, firing the
-    /// deadline spuriously every tick. Drive it on a real-time runtime.
+    /// `enable_all()`) — on a time-less `current_thread` runtime the first tick
+    /// panics ("time driver not enabled"). Note also that `start_paused` changes
+    /// timeout semantics: the paused clock auto-advances while the runtime is idle,
+    /// but the inference runs on a real-time `spawn_blocking` thread, so whether
+    /// the join or the auto-advanced timer wins is timing-dependent. Tests that
+    /// need real wall-clock deadline behaviour should use real time
+    /// (`start_paused = false`), as the WS-0.4 tick tests do.
     #[must_use]
     pub fn with_inference_deadline_ms(mut self, deadline_ms: u64) -> Self {
         self.inference_deadline_ms = deadline_ms.clamp(1, DEADLINE_CEILING_MS);

--- a/parko/crates/parko-ros2/src/scene_vetoes.rs
+++ b/parko/crates/parko-ros2/src/scene_vetoes.rs
@@ -41,17 +41,43 @@ pub struct StampedScene<T> {
     pub stamp_ms: u64,
 }
 
+/// #770 F4 — tolerated future-stamp skew, ms. `now_ms` comes from a
+/// NON-MONOTONIC wall clock (`SystemTime`), so a backward NTP step or a
+/// producer whose clock runs ahead can stamp a scene in the future relative to
+/// `now_ms`. A producer stamp up to this far ahead is tolerated as ordinary
+/// clock jitter; beyond it the stamp is IMPLAUSIBLE and the scene is treated as
+/// STALE (fail-closed), never age-0.
+pub const SCENE_FUTURE_SKEW_BUDGET_MS: u64 = 50;
+
 impl<T> StampedScene<T> {
     /// Age relative to `now_ms`; saturating (a future-stamped scene reads 0).
     #[must_use]
     pub fn age_ms(&self, now_ms: u64) -> u64 {
         now_ms.saturating_sub(self.stamp_ms)
     }
+
+    /// Fresh iff the stamp is neither too OLD (`age > max_age_ms`) nor
+    /// implausibly in the FUTURE (#770 F4). The naive `age_ms <= max_age_ms`
+    /// alone fails OPEN on a non-monotonic clock: `saturating_sub` reads any
+    /// future stamp as age 0, so a backward clock step (every cached scene now
+    /// "in the future") or a skewed-ahead producer keeps a STALE scene passing
+    /// the freshness gate indefinitely — silently disarming the interlock whose
+    /// whole purpose is "a stale scene is a perception gap, never a verdict."
+    /// Treating a beyond-skew future stamp as stale closes both holes fail-closed.
+    /// (A monotonic gate-clock domain is the fuller fix; this bounds the wall-clock
+    /// exposure now.)
+    #[must_use]
+    pub fn is_fresh(&self, now_ms: u64, max_age_ms: u64) -> bool {
+        if self.stamp_ms > now_ms.saturating_add(SCENE_FUTURE_SKEW_BUDGET_MS) {
+            return false; // implausible future stamp → fail closed (stale)
+        }
+        self.age_ms(now_ms) <= max_age_ms
+    }
 }
 
 /// Resolve an armed channel's slot to the scene the check runs on:
-/// fresh → the producer's scene; missing or stale → the supplied fail-closed
-/// worst-case variant.
+/// fresh → the producer's scene; missing, stale, OR implausibly-future-stamped
+/// → the supplied fail-closed worst-case variant (#770 F4).
 fn resolve_scene<T: Clone>(
     slot: Option<&StampedScene<T>>,
     max_age_ms: u64,
@@ -59,7 +85,7 @@ fn resolve_scene<T: Clone>(
     fail_closed: T,
 ) -> T {
     match slot {
-        Some(stamped) if stamped.age_ms(now_ms) <= max_age_ms => stamped.scene.clone(),
+        Some(stamped) if stamped.is_fresh(now_ms, max_age_ms) => stamped.scene.clone(),
         _ => fail_closed,
     }
 }
@@ -231,6 +257,27 @@ mod tests {
         let out = apply_occlusion_gate(outcome(0.2), Some(&s), &params(), 500, 2_000);
         assert_eq!(out.twist.linear_x_mps, 0.0, "stale sightline must fail closed");
         assert_eq!(out.error, Some(TickError::OcclusionBreach));
+    }
+
+    #[test]
+    fn occlusion_future_stamped_scene_fails_closed() {
+        // #770 F4 — a KnownClear scene stamped implausibly in the FUTURE
+        // (backward clock step / skewed-ahead producer) must NOT read as age-0
+        // fresh: beyond the skew budget it is treated as stale → fail closed.
+        let s = stamped(OcclusionScene::KnownClear, 100_000);
+        let out = apply_occlusion_gate(outcome(0.2), Some(&s), &params(), 500, 100);
+        assert_eq!(out.twist.linear_x_mps, 0.0, "future-stamped sightline must fail closed, not read fresh");
+        assert_eq!(out.error, Some(TickError::OcclusionBreach));
+    }
+
+    #[test]
+    fn scene_within_skew_budget_is_still_fresh() {
+        // #770 F4 — a stamp a few ms ahead (ordinary jitter, within the skew
+        // budget) is tolerated as fresh, so the fix doesn't over-reject.
+        let s = stamped(OcclusionScene::KnownClear, 110);
+        assert!(s.is_fresh(100, 500), "a stamp within the skew budget must stay fresh");
+        let out = apply_occlusion_gate(outcome(0.2), Some(&s), &params(), 500, 100);
+        assert!(out.error.is_none(), "within-skew-budget KnownClear must pass");
     }
 
     // ---- water --------------------------------------------------------------


### PR DESCRIPTION
**Fix-PR F of the 10-PR review follow-up — parko fault-chain hardening from two reviews.** (#773 F3/F5 already shipped in Fix-PR B; F1/F2/F4/F6 here. #770 F1/F2 shipped in Fix-PR A; F4 here.)

## #773 F2 — a backend hang now escalates the FLEET posture, with recovery hysteresis (the centerpiece)

Before, a deadline breach fail-closed only **this tick's** command (STOP); the fleet posture stayed Nominal, no watchdog counted repeated breaches toward LockedOut, and the instant the straggler cleared the vehicle re-accelerated with zero confirmation.

Added a **leaky-bucket breach accumulator** on `InferenceLoop` (mirroring the comparator's divergence accumulator so the two fault-escalators read the same): each breach `+3`, each healthy within-deadline tick `-1`. Any non-zero level → `Degraded`; three consecutive breaches (level 9) → `LockedOut`. `recommended_posture()` now returns the **more restrictive** of the governor's recommendation and this deadline health — and since `tick_pipeline.rs:185` already escalates the effective posture with `recommended_posture()`, the breach signal reaches the production posture path with **no wiring change**. The bucket drain **is** the recovery hysteresis (a single breach holds `Degraded` for 3 healthy ticks — the same discipline `ControlLoop` uses), so a backend flapping at ~deadline period stays escalated instead of oscillating move/stop/move at Nominal.

Tests: `deadline_breach_accumulator_escalates_and_recovers_with_hysteresis` (direct, precise) + `deadline_breach_escalates_recommended_posture_through_tick` (live through the real tick path with a real hang).

## #773 F6 — deadline clamped to a sanity ceiling

`with_inference_deadline_ms` now clamps to `[1, DEADLINE_CEILING_MS]` (60 s), so a `u64::MAX` value can't silently defeat the "cannot be disabled" contract. Test: `deadline_is_clamped_to_sanity_ceiling`.

## #773 F4 — time-driver requirement documented

`with_inference_deadline_ms` rustdoc now states the Tokio time-driver requirement (a time-less `current_thread` runtime panics; a `start_paused` runtime fires the deadline spuriously). Doc-only.

## #773 F1 — actuator dead-man AOU

Added `AOU-ACTUATION-DEADMAN-001`: the base controller consuming the parko `cmd_vel` stream MUST dead-man stream silence to STOP within the deadline budget, else it would hold a pre-hang MOVING twist live across the hang. The deadline default's doc references it. Budget-deriving the default value from the FTTI decomposition is left as a tracked **safety-case** item (a value change is a safety-case decision, not a code cleanup).

## #770 F4 — monotonic / future-stamp scene freshness

`StampedScene` freshness used `saturating_sub`, so a future-stamped scene read age-0 = fresh forever — a backward NTP step (cached scenes now "in the future") or a skewed-ahead producer silently disarmed the staleness interlock. New skew-bounded `is_fresh`: a stamp beyond `SCENE_FUTURE_SKEW_BUDGET_MS` (50 ms) in the future is treated as **stale** (fail-closed); `resolve_scene` routes through it. Tests: `occlusion_future_stamped_scene_fails_closed`, `scene_within_skew_budget_is_still_fresh`. (A monotonic gate-clock domain is the fuller fix; this bounds the wall-clock exposure now.)

## Verification

parko-core 239 + parko-ros2 224 + parko-kirra 147 lib tests green; clippy clean. No new dependencies; verdict/WCET-critical paths untouched.

## Not in scope (tracked follow-ups)

#773 F7 (runtime `shutdown_timeout` on a wedged straggler), F8/F9 (occlusion clamp-to-cap "proper response"), #770 F5–F11 (waiver-state split, real scene producers, per-channel staleness budgets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_