### PR TITLE
checker/qnx: sound VRU RSS bound (ego body + response phase + posture brake) and ABI layout gate (review fix-I: #779 + #778 F1)

### DIFF
--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -547,7 +547,26 @@ pub fn validate_trajectory_slow_capped(
     // a non-finite pedestrian is a perception fault → MRC.
     // SAFETY: SG1 | REQ: vru-pedestrian-reachable-set-bound | TEST: vru_pedestrian_in_path_mrcs,vru_far_pedestrian_admits,vru_safe_stop_next_to_pedestrian_admits,vru_kerbside_pedestrian_binds_despite_lateral_clearance,vru_absent_channel_is_byte_identical,vru_non_finite_pedestrian_mrcs
     if let Some(scene) = pedestrians {
-        if crate::vru::pedestrian_breach(trajectory, scene, config.max_decel_mps2) {
+        // #779 F3 — the POSTURE-COMPOSED brake (`kinematics.max_brake_mps2`), not
+        // the Nominal service brake `config.max_decel_mps2`: under Degraded the
+        // vehicle is commanded to brake no harder than the MRC contract (e.g. 3.0
+        // vs 4.5), so the Nominal value would understate the stopping distance in
+        // exactly the posture where a subsystem is already faulted.
+        // #779 F1 — the ego is a BODY: the pose is the rear axle, so the required
+        // clearance must include the max distance from the axle to any footprint
+        // corner (direction-independent, matching the omnidirectional disc).
+        let ego_reach_m = f64::max(
+            kinematics.wheelbase_m + kinematics.overhang_front_m,
+            kinematics.overhang_rear_m,
+        )
+        .hypot(kinematics.width_m / 2.0);
+        if crate::vru::pedestrian_breach(
+            trajectory,
+            scene,
+            kinematics.max_brake_mps2,   // #779 F3
+            config.max_accel_mps2,       // #779 F2 (RSS response-phase term)
+            ego_reach_m,                 // #779 F1
+        ) {
             return TrajectoryVerdict::MRCFallback;
         }
     }

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -555,11 +555,15 @@ pub fn validate_trajectory_slow_capped(
         // #779 F1 — the ego is a BODY: the pose is the rear axle, so the required
         // clearance must include the max distance from the axle to any footprint
         // corner (direction-independent, matching the omnidirectional disc).
-        let ego_reach_m = f64::max(
-            kinematics.wheelbase_m + kinematics.overhang_front_m,
+        // #779 F1 — the ego-body reach, fail-closed on corrupt geometry (the
+        // helper forces NaN → ∞ → breach; a naive `f64::max` would MASK a NaN
+        // footprint field, Copilot #788).
+        let ego_reach_m = crate::vru::ego_reach_m(
+            kinematics.wheelbase_m,
+            kinematics.overhang_front_m,
             kinematics.overhang_rear_m,
-        )
-        .hypot(kinematics.width_m / 2.0);
+            kinematics.width_m,
+        );
         if crate::vru::pedestrian_breach(
             trajectory,
             scene,

--- a/crates/kirra-trajectory/src/vru.rs
+++ b/crates/kirra-trajectory/src/vru.rs
@@ -111,6 +111,33 @@ fn params_valid(p: &VruRssParams) -> bool {
         && ok(p.stop_epsilon_mps)
 }
 
+/// The ego-body reach term for the VRU bound (#779 F1): the max distance from
+/// the pose (the REAR AXLE) to any point of the ego footprint,
+/// `max(wheelbase+overhang_front, overhang_rear).hypot(half_width)` —
+/// direction-independent, matching the omnidirectional disc model.
+///
+/// FAIL-CLOSED (Copilot #788): returns `f64::NAN` — which makes
+/// [`required_pedestrian_clearance_m`] return `∞`, a guaranteed breach — on ANY
+/// non-finite OR negative geometry input. `f64::max` uses IEEE `maxNum` semantics
+/// (it IGNORES NaN and returns the other argument), so a naive `max` would MASK a
+/// corrupt footprint field (e.g. `overhang_rear = NaN`) into a FINITE reach and
+/// defeat the downstream `is_finite()` check. The explicit validation prevents that.
+#[must_use]
+pub fn ego_reach_m(
+    wheelbase_m: f64,
+    overhang_front_m: f64,
+    overhang_rear_m: f64,
+    width_m: f64,
+) -> f64 {
+    let geom_ok = [wheelbase_m, overhang_front_m, overhang_rear_m, width_m]
+        .iter()
+        .all(|x| x.is_finite() && *x >= 0.0);
+    if !geom_ok {
+        return f64::NAN; // corrupt ego geometry → fail closed downstream
+    }
+    f64::max(wheelbase_m + overhang_front_m, overhang_rear_m).hypot(width_m / 2.0)
+}
+
 /// The required distance between a trajectory pose (the ego REAR AXLE) and a
 /// pedestrian for the pose to be VRU-safe (doc §4):
 ///
@@ -318,6 +345,32 @@ mod tests {
         let with_accel = required_pedestrian_clearance_m(4.0, 0.0, BRAKE, A_MAX, ego_reach(), &p);
         let no_accel = required_pedestrian_clearance_m(4.0, 0.0, BRAKE, 0.0, ego_reach(), &p);
         assert!(with_accel > no_accel, "the a_max·ρ response phase must add distance");
+    }
+
+    /// #779 F1 / Copilot #788 — `ego_reach_m` fails closed (NaN → downstream ∞) on
+    /// ANY non-finite or negative geometry. The `overhang_rear = NaN` case is the
+    /// one a naive `f64::max` would MASK (max ignores NaN, returning the finite
+    /// front reach) — the explicit validation must catch it.
+    #[test]
+    fn ego_reach_fails_closed_on_corrupt_geometry() {
+        // Sound robotaxi geometry → finite, equals the worked-reference reach.
+        let r = ego_reach_m(2.8, 0.9, 1.1, 1.85);
+        assert!((r - ego_reach()).abs() < 1e-9, "sound geometry: got {r}");
+        // A NaN in ANY field → NaN (fail closed).
+        assert!(ego_reach_m(f64::NAN, 0.9, 1.1, 1.85).is_nan());
+        assert!(ego_reach_m(2.8, f64::NAN, 1.1, 1.85).is_nan());
+        assert!(
+            ego_reach_m(2.8, 0.9, f64::NAN, 1.85).is_nan(),
+            "the overhang_rear=NaN case f64::max would MASK must fail closed"
+        );
+        assert!(ego_reach_m(2.8, 0.9, 1.1, f64::NAN).is_nan());
+        // Negative geometry also fails closed.
+        assert!(ego_reach_m(2.8, 0.9, -1.0, 1.85).is_nan());
+        // And the NaN reach makes the requirement ∞ (breach) downstream.
+        assert_eq!(
+            required_pedestrian_clearance_m(2.0, 0.0, BRAKE, A_MAX, f64::NAN, &VruRssParams::default()),
+            f64::INFINITY
+        );
     }
 
     /// #779 F3 — the posture-composed brake matters: the weaker Degraded MRC

--- a/crates/kirra-trajectory/src/vru.rs
+++ b/crates/kirra-trajectory/src/vru.rs
@@ -111,30 +111,53 @@ fn params_valid(p: &VruRssParams) -> bool {
         && ok(p.stop_epsilon_mps)
 }
 
-/// The required center-to-center distance between a trajectory pose and a
+/// The required distance between a trajectory pose (the ego REAR AXLE) and a
 /// pedestrian for the pose to be VRU-safe (doc §4):
 ///
 /// ```text
-/// t_stop  = ρ + v / a_brake                     (time to full stop)
-/// d_stop  = v·ρ + v² / (2·a_brake)              (ego stopping distance)
-/// reach   = r_ped + v_ped_max · (t_pose + t_stop)  (grown reachable disc)
-/// required = d_stop + reach + clearance
+/// v_after = v + a_max · ρ                        (F2: worst-case speed AFTER the
+///                                                 response phase — the plan may
+///                                                 still be accelerating during ρ)
+/// t_stop  = ρ + v_after / a_brake                (time to full stop)
+/// d_stop  = v·ρ + ½·a_max·ρ² + v_after² / (2·a_brake)   (RSS stopping distance)
+/// reach   = r_ped + v_ped_max · (t_pose + t_stop)      (grown reachable disc)
+/// required = d_stop + reach + clearance + ego_reach    (F1: ego is a BODY, not a point)
 /// ```
 ///
-/// `a_brake_mps2` is the ego's assured service braking (the per-class
-/// `VehicleConfig::max_decel_mps2`). Returns `f64::INFINITY` — a guaranteed
-/// breach once applied — for ANY invalid input: a non-positive/non-finite
-/// brake (an unbrakeable ego can never prove VRU safety), a non-finite
-/// speed/time, or a corrupt parameter set (fail closed; a NaN here would
-/// otherwise poison `dist < required` into admitting an unsafe trajectory).
+/// - `a_brake_mps2` is the ego's assured braking. The caller MUST pass the
+///   POSTURE-COMPOSED brake (`kinematics.max_brake_mps2`), not the Nominal
+///   service brake — under Degraded the vehicle is commanded to brake no harder
+///   than the MRC contract, so the Nominal value would understate `d_stop` in
+///   exactly the posture where a subsystem is already faulted (#779 F3).
+/// - `a_max_mps2` is the ego's max acceleration — the RSS response-phase term
+///   (#779 F2): during ρ the plan/actuator may still be executing acceleration,
+///   which is the whole reason RSS's `d_min` carries an `a_max·ρ` term. The prior
+///   constant-speed-during-ρ model understated the boundary by metres at ODD speed.
+/// - `ego_reach_m` is the max distance from the pose (rear axle) to any point of
+///   the ego footprint — `max(wheelbase+overhang_front, overhang_rear).hypot(half_width)`
+///   (#779 F1). Direction-independent, matching the omnidirectional model. Without
+///   it the distance was rear-axle-to-pedestrian and the ~3.8 m robotaxi nose swept
+///   past the pedestrian before the disc growth even counted.
+///
+/// Returns `f64::INFINITY` — a guaranteed breach once applied — for ANY invalid
+/// input: a non-positive/non-finite brake (an unbrakeable ego can never prove VRU
+/// safety), a non-finite/negative accel or ego-reach, a non-finite speed/time, or
+/// a corrupt parameter set (fail closed; a NaN here would otherwise poison
+/// `dist < required` into admitting an unsafe trajectory).
 #[must_use]
 pub fn required_pedestrian_clearance_m(
     ego_speed_mps: f64,
     pose_time_s: f64,
     a_brake_mps2: f64,
+    a_max_mps2: f64,
+    ego_reach_m: f64,
     params: &VruRssParams,
 ) -> f64 {
-    if !(a_brake_mps2.is_finite() && a_brake_mps2 > 0.0)
+    let pos_finite = |x: f64| x.is_finite() && x > 0.0;
+    let nonneg_finite = |x: f64| x.is_finite() && x >= 0.0;
+    if !pos_finite(a_brake_mps2)      // an unbrakeable ego can never prove VRU safety
+        || !nonneg_finite(a_max_mps2) // #779 F2
+        || !nonneg_finite(ego_reach_m) // #779 F1
         || !ego_speed_mps.is_finite()
         || !pose_time_s.is_finite()
         || !params_valid(params)
@@ -143,10 +166,16 @@ pub fn required_pedestrian_clearance_m(
     }
     let v = ego_speed_mps.abs();
     let rho = params.reaction_time_s;
-    let t_stop = rho + v / a_brake_mps2;
-    let d_stop = v * rho + v * v / (2.0 * a_brake_mps2);
+    // F2 — RSS response phase: the ego may still be accelerating during ρ, so it
+    // brakes from `v_after`, not `v` (Shalev-Shwartz Def. 1 / Lemma 2; IEEE 2846).
+    let v_after = v + a_max_mps2 * rho;
+    let t_stop = rho + v_after / a_brake_mps2;
+    let d_stop = v * rho + 0.5 * a_max_mps2 * rho * rho + v_after * v_after / (2.0 * a_brake_mps2);
     let reach = params.ped_radius_m + params.v_ped_max_mps * (pose_time_s.max(0.0) + t_stop);
-    d_stop + reach + params.clearance_m
+    // F1 — the ego is a body: the pose is the rear axle, so the front corner is
+    // `ego_reach_m` ahead; add it so the STOPPING ENVELOPE (not the axle) must
+    // clear the disc.
+    d_stop + reach + params.clearance_m + ego_reach_m
 }
 
 /// **The WS-2 primitive**: does `trajectory` breach the omnidirectional
@@ -165,6 +194,8 @@ pub fn pedestrian_breach(
     trajectory: &[TrajectoryPoint],
     scene: &PedestrianScene<'_>,
     a_brake_mps2: f64,
+    a_max_mps2: f64,
+    ego_reach_m: f64,
 ) -> bool {
     for ped in scene.pedestrians {
         if !pedestrian_fields_finite(ped) {
@@ -188,7 +219,8 @@ pub fn pedestrian_breach(
             if v.abs() <= scene.params.stop_epsilon_mps {
                 continue;
             }
-            let required = required_pedestrian_clearance_m(v, t, a_brake_mps2, &scene.params);
+            let required =
+                required_pedestrian_clearance_m(v, t, a_brake_mps2, a_max_mps2, ego_reach_m, &scene.params);
             let dx = ped.pos.x_m - tp.pose.x_m;
             let dy = ped.pos.y_m - tp.pose.y_m;
             let dist = (dx * dx + dy * dy).sqrt();
@@ -223,31 +255,107 @@ mod tests {
         PerceivedPedestrian { id: 1, pos: Point { x_m: x, y_m: y }, vel: Point { x_m: 0.0, y_m: 0.0 } }
     }
 
-    const BRAKE: f64 = 4.5; // default_urban service brake
+    const BRAKE: f64 = 4.5; // default_urban service brake (Nominal)
+    const A_MAX: f64 = 2.5; // default_urban max accel (#779 F2 response phase)
+
+    /// default_urban (robotaxi) rear-axle→front-corner reach (#779 F1):
+    /// `max(wheelbase+overhang_front, overhang_rear).hypot(half_width)` =
+    /// `max(2.8+0.9, 1.1).hypot(0.925)` = `3.7.hypot(0.925)` ≈ 3.814 m.
+    fn ego_reach() -> f64 {
+        3.7_f64.hypot(0.925)
+    }
+
+    fn required(v: f64, t: f64, p: &VruRssParams) -> f64 {
+        required_pedestrian_clearance_m(v, t, BRAKE, A_MAX, ego_reach(), p)
+    }
+
+    fn breaches(traj: &[TrajectoryPoint], sc: &PedestrianScene<'_>) -> bool {
+        pedestrian_breach(traj, sc, BRAKE, A_MAX, ego_reach())
+    }
 
     fn scene(peds: &[PerceivedPedestrian]) -> PedestrianScene<'_> {
         PedestrianScene { pedestrians: peds, params: VruRssParams::default() }
     }
 
-    /// The formula at a worked point (doc §4.1): v=2, t=0, ρ=0.5, a=4.5 →
-    /// t_stop = 0.5 + 0.444 = 0.944s; d_stop = 1.0 + 0.444 = 1.444m;
-    /// reach = 0.3 + 2.0·0.944 = 2.189m; required = 1.444+2.189+0.5 = 4.133m.
+    /// The formula at a worked point (doc §4.1) with the F1 ego-body + F2
+    /// response-phase terms: v=2, t=0, ρ=0.5, a_brake=4.5, a_max=2.5 →
+    /// v_after = 3.25; t_stop = 0.5 + 3.25/4.5 = 1.2222 s;
+    /// d_stop = 1.0 + 0.3125 + 3.25²/9 = 2.4861 m;
+    /// reach = 0.3 + 2.0·1.2222 = 2.7444 m;
+    /// ego_reach ≈ 3.8139 m; required = 2.4861+2.7444+0.5+3.8139 = 9.5444 m.
     #[test]
     fn worked_reference_point_matches_the_doc() {
-        let r = required_pedestrian_clearance_m(2.0, 0.0, BRAKE, &VruRssParams::default());
-        assert!((r - 4.1333).abs() < 1e-3, "got {r}");
+        let r = required(2.0, 0.0, &VruRssParams::default());
+        assert!((r - 9.5444).abs() < 1e-3, "got {r}");
+    }
+
+    /// #779 F1 — the ego-body (footprint) term is present: the pose is the rear
+    /// axle, so a pedestrian that clears the AXLE-only bound but not the front
+    /// corner must still breach. Before the fix (point ego) it admitted.
+    #[test]
+    fn ego_footprint_term_binds_the_body_not_the_axle() {
+        let p = VruRssParams::default();
+        let req = required(2.0, 0.0, &p);
+        // What the old point-ego formula would have demanded (no ego_reach term).
+        let axle_only = req - ego_reach();
+        let ped_x = axle_only + 0.1; // clears the axle bound, INSIDE the body bound
+        assert!(ped_x < req, "precondition: still inside the full requirement");
+        let traj = [pt(0.0, 2.0, 0.0)];
+        assert!(
+            breaches(&traj, &scene(&[ped(ped_x, 0.0)])),
+            "a pedestrian inside the ego-body envelope must breach (F1)"
+        );
+        // Just OUTSIDE the full requirement still admits (no over-rejection).
+        assert!(!breaches(&[pt(0.0, 2.0, 0.0)], &scene(&[ped(req + 0.1, 0.0)])));
+    }
+
+    /// #779 F2 — the response-phase acceleration term raises the requirement vs a
+    /// constant-speed-during-ρ model: with a_max=0 the ego coasts through ρ and
+    /// the requirement is strictly smaller than with the real a_max.
+    #[test]
+    fn response_phase_accel_term_raises_the_requirement() {
+        let p = VruRssParams::default();
+        let with_accel = required_pedestrian_clearance_m(4.0, 0.0, BRAKE, A_MAX, ego_reach(), &p);
+        let no_accel = required_pedestrian_clearance_m(4.0, 0.0, BRAKE, 0.0, ego_reach(), &p);
+        assert!(with_accel > no_accel, "the a_max·ρ response phase must add distance");
+    }
+
+    /// #779 F3 — the posture-composed brake matters: the weaker Degraded MRC
+    /// brake (3.0) demands MORE clearance than the Nominal service brake (4.5),
+    /// and a pedestrian between the two verdicts admits under Nominal but breaches
+    /// under Degraded. The validator passes `kinematics.max_brake_mps2` (3.0 under
+    /// Degraded) so a faulted-posture ego is held to its actual stopping power.
+    #[test]
+    fn weaker_degraded_brake_demands_more_clearance() {
+        let p = VruRssParams::default();
+        const NOMINAL_BRAKE: f64 = 4.5;
+        const DEGRADED_BRAKE: f64 = 3.0;
+        let nominal = required_pedestrian_clearance_m(5.0, 0.0, NOMINAL_BRAKE, A_MAX, ego_reach(), &p);
+        let degraded = required_pedestrian_clearance_m(5.0, 0.0, DEGRADED_BRAKE, A_MAX, ego_reach(), &p);
+        assert!(degraded > nominal, "the weaker Degraded brake must demand MORE clearance");
+        // A pedestrian between the two boundaries: Nominal admits, Degraded breaches.
+        let d = 0.5 * (nominal + degraded);
+        let traj = [pt(0.0, 5.0, 0.0)];
+        assert!(
+            !pedestrian_breach(&traj, &scene(&[ped(d, 0.0)]), NOMINAL_BRAKE, A_MAX, ego_reach()),
+            "the Nominal brake admits a pedestrian at the mid-distance"
+        );
+        assert!(
+            pedestrian_breach(&traj, &scene(&[ped(d, 0.0)]), DEGRADED_BRAKE, A_MAX, ego_reach()),
+            "the Degraded brake breaches the same pedestrian (F3)"
+        );
     }
 
     #[test]
     fn pedestrian_ahead_within_stopping_envelope_breaches() {
         let traj = [pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
-        assert!(pedestrian_breach(&traj, &scene(&[ped(3.0, 0.0)]), BRAKE));
+        assert!(breaches(&traj, &scene(&[ped(3.0, 0.0)])));
     }
 
     #[test]
     fn pedestrian_far_ahead_is_clear() {
         let traj = [pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
-        assert!(!pedestrian_breach(&traj, &scene(&[ped(40.0, 0.0)]), BRAKE));
+        assert!(!breaches(&traj, &scene(&[ped(40.0, 0.0)])));
     }
 
     /// THE STOP-PROPOSAL INVARIANT: a stopped/stopping trajectory next to a
@@ -256,7 +364,7 @@ mod tests {
     #[test]
     fn safe_stop_next_to_pedestrian_is_admitted() {
         let stop = [pt(0.0, 0.0, 0.0), pt(0.0, 0.0, 1.0)];
-        assert!(!pedestrian_breach(&stop, &scene(&[ped(0.5, 0.5)]), BRAKE));
+        assert!(!breaches(&stop, &scene(&[ped(0.5, 0.5)])));
     }
 
     /// Omnidirectionality: a kerbside pedestrian OUTSIDE the vehicle-RSS
@@ -265,34 +373,34 @@ mod tests {
     #[test]
     fn kerbside_pedestrian_outside_lateral_band_still_binds() {
         let traj = [pt(0.0, 4.0, 0.0), pt(4.0, 4.0, 1.0)];
-        // 2.5 m lateral, 4 m ahead: inside required (~8.9 m at v=4).
-        assert!(pedestrian_breach(&traj, &scene(&[ped(4.0, 2.5)]), BRAKE));
+        // 2.5 m lateral, 4 m ahead: well inside required (~13 m at v=4).
+        assert!(breaches(&traj, &scene(&[ped(4.0, 2.5)])));
     }
 
     #[test]
     fn non_finite_pedestrian_breaches() {
         let traj = [pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
-        assert!(pedestrian_breach(&traj, &scene(&[ped(f64::NAN, 0.0)]), BRAKE));
+        assert!(breaches(&traj, &scene(&[ped(f64::NAN, 0.0)])));
     }
 
     #[test]
     fn empty_scene_is_noop() {
         let traj = [pt(0.0, 10.0, 0.0), pt(10.0, 10.0, 1.0)];
-        assert!(!pedestrian_breach(&traj, &scene(&[]), BRAKE));
+        assert!(!breaches(&traj, &scene(&[])));
     }
 
-    /// Fail-closed on an unbrakeable ego: zero/negative/non-finite brake →
-    /// infinite requirement → any moving pose near any pedestrian breaches.
+    /// Fail-closed on an unbrakeable ego, AND on a corrupt accel / ego-reach
+    /// (the new #779 F1/F2 inputs): zero/negative/non-finite brake, non-finite
+    /// or negative a_max, non-finite or negative ego_reach → infinite requirement.
     #[test]
-    fn non_positive_brake_fails_closed() {
-        assert_eq!(
-            required_pedestrian_clearance_m(1.0, 0.0, 0.0, &VruRssParams::default()),
-            f64::INFINITY
-        );
-        assert_eq!(
-            required_pedestrian_clearance_m(1.0, 0.0, f64::NAN, &VruRssParams::default()),
-            f64::INFINITY
-        );
+    fn non_positive_brake_and_bad_geometry_fail_closed() {
+        let p = VruRssParams::default();
+        assert_eq!(required_pedestrian_clearance_m(1.0, 0.0, 0.0, A_MAX, ego_reach(), &p), f64::INFINITY);
+        assert_eq!(required_pedestrian_clearance_m(1.0, 0.0, f64::NAN, A_MAX, ego_reach(), &p), f64::INFINITY);
+        assert_eq!(required_pedestrian_clearance_m(1.0, 0.0, BRAKE, f64::NAN, ego_reach(), &p), f64::INFINITY);
+        assert_eq!(required_pedestrian_clearance_m(1.0, 0.0, BRAKE, -1.0, ego_reach(), &p), f64::INFINITY);
+        assert_eq!(required_pedestrian_clearance_m(1.0, 0.0, BRAKE, A_MAX, f64::NAN, &p), f64::INFINITY);
+        assert_eq!(required_pedestrian_clearance_m(1.0, 0.0, BRAKE, A_MAX, -1.0, &p), f64::INFINITY);
     }
 
     /// Fail-closed on corrupt inputs/params: a NaN speed, time, or ANY
@@ -301,8 +409,8 @@ mod tests {
     #[test]
     fn corrupt_inputs_and_params_fail_closed_not_open() {
         let p = VruRssParams::default();
-        assert_eq!(required_pedestrian_clearance_m(f64::NAN, 0.0, BRAKE, &p), f64::INFINITY);
-        assert_eq!(required_pedestrian_clearance_m(1.0, f64::NAN, BRAKE, &p), f64::INFINITY);
+        assert_eq!(required(f64::NAN, 0.0, &p), f64::INFINITY);
+        assert_eq!(required(1.0, f64::NAN, &p), f64::INFINITY);
         for corrupt in [
             VruRssParams { v_ped_max_mps: f64::NAN, ..p },
             VruRssParams { ped_radius_m: -1.0, ..p },
@@ -310,17 +418,17 @@ mod tests {
             VruRssParams { reaction_time_s: -0.5, ..p },
             VruRssParams { stop_epsilon_mps: f64::NAN, ..p },
         ] {
-            let r = required_pedestrian_clearance_m(1.0, 0.0, BRAKE, &corrupt);
+            let r = required(1.0, 0.0, &corrupt);
             assert_eq!(r, f64::INFINITY, "corrupt {corrupt:?} must fail closed");
         }
         // And through the breach predicate: corrupt params → a moving pose
         // near ANY pedestrian breaches (never admits).
         let traj = [pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
-        let scene = PedestrianScene {
+        let sc = PedestrianScene {
             pedestrians: &[ped(1000.0, 0.0)],
             params: VruRssParams { reaction_time_s: f64::NAN, ..p },
         };
-        assert!(pedestrian_breach(&traj, &scene, BRAKE));
+        assert!(breaches(&traj, &sc));
     }
 
     /// Fail-closed on a non-finite trajectory POSE (the distance would NaN
@@ -329,7 +437,7 @@ mod tests {
     fn non_finite_pose_breaches() {
         let mut traj = vec![pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
         traj[1].pose.x_m = f64::NAN;
-        assert!(pedestrian_breach(&traj, &scene(&[ped(50.0, 0.0)]), BRAKE));
+        assert!(breaches(&traj, &scene(&[ped(50.0, 0.0)])));
     }
 
     /// Monotonicity (the safety shape): the requirement never DECREASES
@@ -340,12 +448,12 @@ mod tests {
         let mut prev = 0.0;
         for i in 0..50 {
             let v = f64::from(i) * 0.5;
-            let r = required_pedestrian_clearance_m(v, 0.0, BRAKE, &p);
+            let r = required(v, 0.0, &p);
             assert!(r >= prev, "requirement must not decrease with speed");
             prev = r;
         }
-        let early = required_pedestrian_clearance_m(3.0, 0.5, BRAKE, &p);
-        let late = required_pedestrian_clearance_m(3.0, 4.0, BRAKE, &p);
+        let early = required(3.0, 0.5, &p);
+        let late = required(3.0, 4.0, &p);
         assert!(late > early, "a later pose faces a larger reachable disc");
     }
 }

--- a/docs/safety/PEDESTRIAN_RSS.md
+++ b/docs/safety/PEDESTRIAN_RSS.md
@@ -50,11 +50,28 @@ stopping envelope meeting the disc as it grows over the whole stopping
 interval:
 
 ```text
-t_stop   = ρ + v / a_brake                       — time to full stop
-d_stop   = v·ρ + v² / (2·a_brake)                — RSS stopping distance
-required = d_stop + r_ped + v_ped_max · (t + t_stop) + clearance
+v_after  = v + a_max · ρ                          — worst-case speed AFTER the response phase (F2)
+t_stop   = ρ + v_after / a_brake                  — time to full stop
+d_stop   = v·ρ + ½·a_max·ρ² + v_after² / (2·a_brake)   — RSS stopping distance
+required = d_stop + r_ped + v_ped_max · (t + t_stop) + clearance + ego_reach
 UNSAFE   ⟺ dist(pose, ped) < required
 ```
+
+where:
+- **`a_max`** is the ego's max acceleration: during the reaction time ρ the
+  plan/actuator may still be executing acceleration, so the ego brakes from
+  `v_after`, not `v` (Shalev-Shwartz Def. 1 / Lemma 2; IEEE 2846). This is the
+  same response-phase term the vehicle RSS carries (#779 F2).
+- **`ego_reach`** = `max(wheelbase+overhang_front, overhang_rear).hypot(half_width)`
+  — the max distance from the pose (the **rear axle**) to any point of the ego
+  footprint. The ego is a BODY, not a point: without this term the distance was
+  rear-axle-to-pedestrian and the robotaxi's ~3.8 m nose swept past the pedestrian
+  before the disc growth counted (#779 F1). Direction-independent, matching the
+  omnidirectional model.
+- **`a_brake`** is the **posture-composed** brake the validator passes
+  (`kinematics.max_brake_mps2`) — the Nominal service brake under Nominal, the
+  weaker MRC brake under Degraded (#779 F3), so a faulted-posture ego is held to
+  its actual stopping power.
 
 Distance is **euclidean** — deliberately no lateral filter and no
 behind-ego filter (§1; a VRU beside or behind the path can enter it — the
@@ -75,14 +92,16 @@ own review, and it can never be introduced as a silent default.
 
 ### 2.2 Worked reference point
 
-`v = 2 m/s`, pose `t = 0`, defaults (ρ = 0.5 s, a_brake = 4.5 m/s²,
-v_ped_max = 2.0, r_ped = 0.3, clearance = 0.5):
+`v = 2 m/s`, pose `t = 0`, robotaxi (`default_urban`) defaults (ρ = 0.5 s,
+a_brake = 4.5 m/s², a_max = 2.5 m/s², v_ped_max = 2.0, r_ped = 0.3,
+clearance = 0.5, ego_reach = `3.7.hypot(0.925)` ≈ 3.814 m):
 
 ```text
-t_stop   = 0.5 + 2/4.5            = 0.944 s
-d_stop   = 2·0.5 + 4/(2·4.5)      = 1.444 m
-reach    = 0.3 + 2.0 · 0.944      = 2.189 m
-required = 1.444 + 2.189 + 0.5    = 4.133 m
+v_after  = 2 + 2.5·0.5                 = 3.25 m/s
+t_stop   = 0.5 + 3.25/4.5              = 1.2222 s
+d_stop   = 2·0.5 + ½·2.5·0.25 + 3.25²/9 = 2.4861 m
+reach    = 0.3 + 2.0 · 1.2222          = 2.7444 m
+required = 2.4861 + 2.7444 + 0.5 + 3.814 = 9.5444 m
 ```
 
 (pinned by `vru::tests::worked_reference_point_matches_the_doc`).
@@ -110,7 +129,7 @@ is exactly the sidewalk-courier posture.
 |---|---|
 | Non-finite pedestrian field | Breach → MRC (unlocalizable perception fault; mirrors the vehicle-object rule) |
 | Non-finite pose speed/time | Breach → MRC |
-| Non-positive / non-finite `a_brake` | `required = ∞` → any moving pose breaches (an unbrakeable ego cannot prove VRU safety) |
+| Non-positive / non-finite `a_brake`, or non-finite/negative `a_max` / `ego_reach` | `required = ∞` → any moving pose breaches (an unbrakeable ego, or corrupt ego geometry, cannot prove VRU safety) |
 | Non-finite speed/time input or ANY corrupt `VruRssParams` field (non-finite or negative) | `required = ∞` → breach (a NaN would otherwise poison `dist < required` into failing OPEN) |
 | Non-finite trajectory pose field | Breach → MRC (self-contained — not dependent on containment rejecting it first) |
 | Absent VRU channel (`None` scene) | **No-op** — byte-identical path (the derate-only invariant: absent input never relaxes, never fabricates) |
@@ -124,13 +143,19 @@ is exactly the sidewalk-courier posture.
 | `clearance_m` | 0.5 | Comfort/robustness margin beyond the geometric envelopes. |
 | `reaction_time_s` | 0.5 | Matches the vehicle-RSS `RSS_REACTION_TIME_S` — one reaction model per checker. |
 | `stop_epsilon_mps` | 0.05 | Matches `STOP_EPSILON_MPS` (the Degraded stop-and-hold epsilon). |
-| `a_brake_mps2` (not a `VruRssParams` field — the validator passes `VehicleConfig::max_decel_mps2`) | per-class contract | The ego's assured service braking from the per-class contract (`KIRRA_VEHICLE_CLASS`). Using full service braking is the *least* conservative element here; derating it (e.g. wet-surface factor) is a tracked refinement. |
+| `a_brake_mps2` (not a `VruRssParams` field — the validator passes the **posture-composed** `kinematics.max_brake_mps2`, #779 F3) | per-class contract | The ego's assured braking: the Nominal service brake under Nominal, the weaker MRC brake under Degraded (so a faulted-posture ego is held to its actual stopping power). Derating it further (e.g. wet-surface factor) is a tracked refinement. |
+| `a_max_mps2` (not a `VruRssParams` field — the validator passes `VehicleConfig::max_accel_mps2`, #779 F2) | per-class contract | The ego's max acceleration, for the RSS response-phase term (`v_after = v + a_max·ρ`). |
+| `ego_reach_m` (derived from the footprint by the validator, #779 F1) | per-class geometry | `max(wheelbase+overhang_front, overhang_rear).hypot(half_width)` — the ego body extent from the rear-axle pose. |
 
-Availability envelope at the defaults (euclidean `required`, pose `t = 0`):
-ego 1 m/s → 3.0 m; 2 m/s → 4.1 m; 4 m/s → 7.1 m; 6 m/s → 10.7 m. The
-courier persona (≤ ~2 m/s on sidewalks) keeps a ~4 m bubble around
-pedestrians — conservative but operable; a robotaxi at speed must rely on
-pedestrians being genuinely distant, which is correct.
+Availability envelope at the robotaxi (`default_urban`) defaults (euclidean
+`required`, pose `t = 0`, with the F1 ego-body + F2 response-phase terms):
+ego 1 m/s → 8.0 m; 2 m/s → 9.5 m; 4 m/s → 13.3 m; 6 m/s → 18.0 m. These are
+substantially larger than the pre-fix point-ego numbers — the sound bound is
+also a MORE conservative one. The courier persona (smaller footprint, lower
+a_max/speed) keeps a tighter bubble; a robotaxi at speed relies on pedestrians
+being genuinely distant. The over-conservatism at the urban ODD cap — road-
+structure / right-of-way semantics to shrink the disc to the corridor — is
+tracked as a §6 refinement (never a silent relaxation).
 
 ## 6. Integration status & tracked follow-ups
 
@@ -168,4 +193,5 @@ VRU channel is byte-identical.
 | Stop-proposal invariant | `vru_safe_stop_next_to_pedestrian_admits` (+ unit `safe_stop_next_to_pedestrian_is_admitted`) |
 | Omnidirectionality vs the lateral band | `vru_kerbside_pedestrian_binds_despite_lateral_clearance` (+ unit) |
 | Absent-channel byte-identity | `vru_absent_channel_is_byte_identical` |
-| Fail-closed non-finite / unbrakeable | `vru_non_finite_pedestrian_mrcs`, unit `non_positive_brake_fails_closed`, `non_finite_pedestrian_breaches` |
+| Fail-closed non-finite / unbrakeable / bad geometry | `vru_non_finite_pedestrian_mrcs`, unit `non_positive_brake_and_bad_geometry_fail_closed`, `non_finite_pedestrian_breaches` |
+| Ego-body term (F1) / response-phase term (F2) / posture brake (F3) | unit `ego_footprint_term_binds_the_body_not_the_axle`, `response_phase_accel_term_raises_the_requirement`, `weaker_degraded_brake_demands_more_clearance` |

--- a/tools/qnx-rtm-harness/kirra_ffi.h
+++ b/tools/qnx-rtm-harness/kirra_ffi.h
@@ -15,6 +15,19 @@
 #define KIRRA_FFI_H
 
 #include <stdint.h>
+#include <stddef.h>  /* offsetof — for the #778 F1 layout gate below */
+
+/* #778 F1 — portable compile-time assert (C11 `_Static_assert` / C++ `static_assert`). */
+#if defined(__cplusplus)
+#  define KIRRA_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#  define KIRRA_ALIGNOF(t) alignof(t)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#  define KIRRA_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#  define KIRRA_ALIGNOF(t) _Alignof(t)
+#else
+#  define KIRRA_STATIC_ASSERT(cond, msg) /* pre-C11: no static assert available */
+#  define KIRRA_ALIGNOF(t) 8u            /* unused: asserts compile out pre-C11 */
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,6 +84,31 @@ typedef struct KirraContractView {
     uint8_t  integrity_ok;               /* upstream integrity assertion (1 = set) */
     uint8_t  header_torn;                /* explicit upstream tear flag (1 = torn) */
 } KirraContractView;
+
+/*
+ * #778 F1 — ABI LAYOUT GATE (C side). Every TU that includes this header now
+ * pins the documented LP64 layout at COMPILE TIME, independently of the Rust
+ * side (which pins the mirror in `kirra_judge.rs`). Reorder or resize a field on
+ * either side and the build fails here — replacing the old symbol-name `nm` grep,
+ * which passed through any struct-layout drift into the signed release artifact.
+ * Gated on 64-bit (the leading pointer + tail padding make sizeof==72 an LP64
+ * fact); both QNX 8.0 judge tuples are 64-bit.
+ */
+#if UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
+KIRRA_STATIC_ASSERT(sizeof(KirraContractView) == 72, "KirraContractView must be 72 bytes (LP64)");
+KIRRA_STATIC_ASSERT(KIRRA_ALIGNOF(KirraContractView) == 8, "KirraContractView must be 8-byte aligned");
+KIRRA_STATIC_ASSERT(offsetof(KirraContractView, payload) == 0, "payload@0");
+KIRRA_STATIC_ASSERT(offsetof(KirraContractView, generation) == 8, "generation@8");
+KIRRA_STATIC_ASSERT(offsetof(KirraContractView, magic) == 16, "magic@16");
+KIRRA_STATIC_ASSERT(offsetof(KirraContractView, sequence) == 24, "sequence@24");
+KIRRA_STATIC_ASSERT(offsetof(KirraContractView, last_accepted_sequence) == 32, "last_accepted_sequence@32");
+KIRRA_STATIC_ASSERT(offsetof(KirraContractView, now_monotonic_ns) == 40, "now_monotonic_ns@40");
+KIRRA_STATIC_ASSERT(offsetof(KirraContractView, deadline_monotonic_ns) == 48, "deadline_monotonic_ns@48");
+KIRRA_STATIC_ASSERT(offsetof(KirraContractView, payload_len) == 56, "payload_len@56");
+KIRRA_STATIC_ASSERT(offsetof(KirraContractView, commanded_velocity) == 60, "commanded_velocity@60");
+KIRRA_STATIC_ASSERT(offsetof(KirraContractView, integrity_ok) == 64, "integrity_ok@64");
+KIRRA_STATIC_ASSERT(offsetof(KirraContractView, header_torn) == 65, "header_torn@65");
+#endif /* LP64 */
 
 /*
  * The Rust JUDGE entry. Renders the CONTRACT verdict (magic → sequence →

--- a/tools/qnx-rtm-harness/kirra_judge.rs
+++ b/tools/qnx-rtm-harness/kirra_judge.rs
@@ -70,6 +70,32 @@ pub struct KirraContractView {
     pub header_torn: u8,
 }
 
+// #778 F1 — ABI LAYOUT GATE (Rust side). The old CI "ABI assert" was a symbol-name
+// grep (`nm | grep kirra_judge_assess`) that passes even if a field is reordered
+// or resized — a broken-contract judge would then be checksummed, cosign-signed,
+// and shipped as the partition verdict core. These compile-time asserts pin the
+// documented LP64 layout (`kirra_ffi.h`: sizeof == 72, alignof == 8, one offset
+// per field) INDEPENDENTLY of the C side, so drift on EITHER side fails the build.
+// Gated on 64-bit: the layout (leading pointer + tail padding) is defined for LP64,
+// which both QNX 8.0 judge tuples (aarch64 / x86_64) are.
+#[cfg(target_pointer_width = "64")]
+const _: () = {
+    use core::mem::{align_of, offset_of, size_of};
+    assert!(size_of::<KirraContractView>() == 72, "KirraContractView must be 72 bytes (LP64)");
+    assert!(align_of::<KirraContractView>() == 8, "KirraContractView must be 8-byte aligned");
+    assert!(offset_of!(KirraContractView, payload) == 0);
+    assert!(offset_of!(KirraContractView, generation) == 8);
+    assert!(offset_of!(KirraContractView, magic) == 16);
+    assert!(offset_of!(KirraContractView, sequence) == 24);
+    assert!(offset_of!(KirraContractView, last_accepted_sequence) == 32);
+    assert!(offset_of!(KirraContractView, now_monotonic_ns) == 40);
+    assert!(offset_of!(KirraContractView, deadline_monotonic_ns) == 48);
+    assert!(offset_of!(KirraContractView, payload_len) == 56);
+    assert!(offset_of!(KirraContractView, commanded_velocity) == 60);
+    assert!(offset_of!(KirraContractView, integrity_ok) == 64);
+    assert!(offset_of!(KirraContractView, header_torn) == 65);
+};
+
 /// Render the CONTRACT verdict for a stabilized contract view.
 ///
 /// Check ORDER (fixed, documented): magic → sequence → deadline → integrity flag


### PR DESCRIPTION
**Fix-PR I — the final review follow-up.** The two safety-math soundness fixes flagged as *must-fix-before-arming* (#779 VRU RSS) plus the QNX ABI layout gate (#778 F1).

## #779 — the VRU pedestrian RSS bound is now geometrically sound

The omnidirectional reachable-set bound shipped dark (no producer), but its math **under-counted by metres at the admit/deny boundary**. Every fix here must land before a producer feeds it.

- **F1 (High) — ego footprint.** Distance was measured from the trajectory pose, which is the **rear axle** — the ego was a point. The robotaxi's ~3.8 m nose swept past the pedestrian before the disc growth counted. `required` now adds `ego_reach = max(wheelbase+overhang_front, overhang_rear).hypot(half_width)` (the max rear-axle-to-footprint-corner distance, direction-independent, matching the omnidirectional model).
- **F2 (Med-High) — RSS response phase.** `d_stop`/`t_stop` assumed constant speed during the reaction time ρ; RSS (and the checker's own vehicle model) brakes from `v_after = v + a_max·ρ`. Now `d_stop = v·ρ + ½·a_max·ρ² + v_after²/(2·a_brake)`, `t_stop = ρ + v_after/a_brake`.
- **F3 (Med) — posture-composed brake.** The gate was handed the Nominal service brake (4.5) unconditionally; under Degraded the vehicle brakes no harder than the MRC contract (3.0), so the Nominal value understated the stop in exactly the faulted posture. Now passes `kinematics.max_brake_mps2`.
- **F7 — doc.** `PEDESTRIAN_RSS.md` formula, worked example (now **9.54 m** at v=2, was 4.13), and availability table recomputed and re-pinned; fail-closed rows extended to `a_max`/`ego_reach`.

New tests: `ego_footprint_term_binds_the_body_not_the_axle` (a pedestrian clearing the axle-only bound but not the body must breach — pins F1), `response_phase_accel_term_raises_the_requirement` (F2), `weaker_degraded_brake_demands_more_clearance` (F3 — a pedestrian between the two brake boundaries admits under Nominal, breaches under Degraded), worked-reference re-pinned, fail-closed extended to the new inputs. **109 trajectory + 6 VRU e2e tests green.** Also fixed the pre-existing `nonminimal_bool` clippy warning in the fail-closed guard.

## #778 F1 (High) — ABI layout gate replaces the symbol-name grep

The QNX judge "ABI assert" was `nm | grep kirra_judge_assess` — it passed even if a `KirraContractView` field was reordered or resized, shipping a broken-contract judge through the signed release chain. Added compile-time layout asserts on **both sides, independently**:
- `kirra_judge.rs`: `size_of == 72`, `align_of == 8`, one `offset_of!` per field (gated on 64-bit LP64).
- `kirra_ffi.h`: mirror via a portable `static_assert`/`_Static_assert` + `offsetof` macro — fires in every C/C++ TU that includes the header.

Verified both compile against the current layout, and that a deliberate offset drift **fails the build** (`static assertion failed: magic@16`).

## Not in scope (tracked follow-ups)

#779 F4 (velocity-declaration cross-check), F5 (per-class params authority), F6 (road-structure/right-of-way to cut the over-conservatism the sound bound now shows at ODD speed), F8 (pedestrian timestamp), F9 (`MAX_PEDESTRIANS`); #778 F2–F9 (reproducible build, provenance completeness, host-harness ctest CI lane, toolchain pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_