### PR TITLE
VRU RSS go-live soundness prerequisites (#789 F4/F5/F8/F9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,6 +2244,7 @@ version = "0.1.0"
 dependencies = [
  "kirra-core",
  "parko-core",
+ "proptest",
  "smallvec",
  "tracing",
 ]

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -1343,6 +1343,8 @@ fn walker(id: u64, x: f64, y: f64) -> PerceivedPedestrian {
         id,
         pos: Point { x_m: x, y_m: y },
         vel: Point { x_m: 0.0, y_m: 0.0 },
+        // #789 F8 — fresh synchronous measurement (no additional disc growth).
+        age_s: 0.0,
     }
 }
 

--- a/crates/kirra-trajectory/Cargo.toml
+++ b/crates/kirra-trajectory/Cargo.toml
@@ -41,3 +41,8 @@ parko-core = { path = "../../parko/crates/parko-core" }
 smallvec = { version = "1", features = ["const_generics"] }
 # `config` logs a one-time warning when no ODD speed cap is configured.
 tracing = "0.1"
+
+[dev-dependencies]
+# Property-based cross-check of the VRU bound (#789): the F9-hoisted
+# `pedestrian_breach` vs an independent per-pair reference (vru.rs tests).
+proptest = "1"

--- a/crates/kirra-trajectory/src/vru.rs
+++ b/crates/kirra-trajectory/src/vru.rs
@@ -31,9 +31,51 @@
 //! perception fault → breach (MRC), mirroring the vehicle-object rule.
 //! Absent input (`None` scene) is a no-op — the Nominal path without a VRU
 //! channel is byte-identical (the derate-only invariant).
+//!
+//! **Go-live hardening (#789).** Before any producer feeds live
+//! `PerceivedPedestrian`s the bound also (F4) refuses to trust a doer-declared
+//! `velocity_mps` alone — the stop-epsilon skip uses the MAX of the declared and
+//! the displacement-implied speed of the adjacent pose pair, so a planner emitting
+//! translating poses that DECLARE `v = 0` cannot bypass the check; (F5) sanitizes
+//! the caller-supplied [`VruRssParams`] at the single choke point so a loose param
+//! set can never WEAKEN the bound (`v_ped_max` floored at [`V_PED_MAX_FLOOR_MPS`],
+//! `stop_epsilon` clamped to the kernel [`VRU_STOP_EPSILON_CEILING_MPS`]); (F8)
+//! grows the reachable disc by `v_ped_max · age` for a stale measurement
+//! ([`PerceivedPedestrian::age_s`], fail-closed on negative/non-finite age); and
+//! (F9) bounds the pedestrian count at [`MAX_PEDESTRIANS`] (fail-closed above it)
+//! and hoists the per-pose `required` out of the pedestrian loop.
+//!
+//! **WCET (F9).** With `T` poses (`T ≤ MAX_TRAJECTORY_HORIZON`) and `P`
+//! pedestrians (`P ≤ MAX_PEDESTRIANS`), [`pedestrian_breach`] is `O(T·P)`
+//! comparisons with exactly ONE `required` evaluation per pose (the heavy term is
+//! pose-only, not per-pedestrian) — a bounded, allocation-free per-tick cost.
 
 use kirra_core::corridor::Point;
+use kirra_core::kinematics_contract::STOP_EPSILON_MPS;
 use kirra_core::trajectory::TrajectoryPoint;
+
+/// Fail-closed input bound on pedestrians per scene (#789 F9, WCET). Mirrors
+/// `MAX_TRAJECTORY_HORIZON`'s role for the trajectory: a scene carrying more
+/// than this is a malformed / over-bound perception input → breach, never an
+/// unbounded loop on the slow-loop path.
+pub const MAX_PEDESTRIANS: usize = 64;
+
+/// Floor on the assumed max pedestrian speed (#789 F5), the validated 2.0 m/s
+/// brisk walk. A caller cannot supply a smaller `v_ped_max` — that would silently
+/// SHRINK the reachable-disc growth. ODDs may only RAISE it (doc §5.1).
+pub const V_PED_MAX_FLOOR_MPS: f64 = 2.0;
+
+/// Ceiling on the VRU stop-epsilon (#789 F5): the kernel stop-and-hold epsilon
+/// (`STOP_EPSILON_MPS`). A larger VRU `stop_epsilon` would let a still-rolling ego
+/// (up to the looser value) SKIP the bound; clamping to the kernel epsilon keeps
+/// one stop semantics across the checker.
+pub const VRU_STOP_EPSILON_CEILING_MPS: f64 = STOP_EPSILON_MPS;
+
+/// Displacement below which a zero/negative-`dt` segment is treated as a
+/// stationary dwell rather than a malformed teleport (#789 F4). A nonzero
+/// displacement over a non-positive/non-finite `dt` is a time-inconsistent
+/// trajectory and fails closed.
+const SEG_DEGENERATE_EPS_M: f64 = 1e-9;
 
 /// A perceived pedestrian / VRU. Deliberately minimal for v0: the
 /// omnidirectional model needs only a position (velocity is accepted for
@@ -47,6 +89,14 @@ pub struct PerceivedPedestrian {
     /// Tracked velocity vector, m/s (informational in v0 — the reachable
     /// disc assumes `v_ped_max` in every direction regardless).
     pub vel: Point,
+    /// Age of this measurement at evaluation time, s (#789 F8): how long ago the
+    /// pedestrian was observed. The reachable disc has ALREADY been growing for
+    /// `age_s` before the trajectory's `t = 0`, so the bound adds `v_ped_max ·
+    /// age_s` to the required clearance. Frozen into the wire shape NOW, before a
+    /// producer exists, so the age term never has to be retrofitted. A fresh
+    /// synchronous measurement passes `0.0`; a negative or non-finite age is a
+    /// perception fault and fails closed (breach).
+    pub age_s: f64,
 }
 
 /// Parameters of the VRU bound. Every default is CONSERVATIVE-FIRST and
@@ -82,6 +132,36 @@ impl Default for VruRssParams {
     }
 }
 
+impl VruRssParams {
+    /// Safety sanitization (#789 F5), applied at the single choke point
+    /// ([`pedestrian_breach`]) so a caller-supplied param set can never WEAKEN the
+    /// bound however it was constructed: `v_ped_max` is floored at
+    /// [`V_PED_MAX_FLOOR_MPS`] and `stop_epsilon` is clamped to
+    /// [`VRU_STOP_EPSILON_CEILING_MPS`] (the kernel stop-and-hold epsilon). Both
+    /// clamps are MONOTONE-TIGHTENING — a caller may raise `v_ped_max` or lower
+    /// `stop_epsilon`, never the reverse. Non-finite fields are left untouched for
+    /// [`params_valid`] to fail closed (an infinite requirement), never clamped
+    /// into a finite value that would admit a trajectory. (A full per-ODD
+    /// derivation of `v_ped_max` — runners, children, cyclists-as-VRUs — remains a
+    /// deployment tuning obligation on top of this floor; doc §5.)
+    #[must_use]
+    pub fn sanitized(&self) -> VruRssParams {
+        VruRssParams {
+            v_ped_max_mps: if self.v_ped_max_mps.is_finite() {
+                self.v_ped_max_mps.max(V_PED_MAX_FLOOR_MPS)
+            } else {
+                self.v_ped_max_mps
+            },
+            stop_epsilon_mps: if self.stop_epsilon_mps.is_finite() {
+                self.stop_epsilon_mps.min(VRU_STOP_EPSILON_CEILING_MPS)
+            } else {
+                self.stop_epsilon_mps
+            },
+            ..*self
+        }
+    }
+}
+
 /// The pedestrian input to the slow checker: the perceived VRUs plus the
 /// bound's parameters, carried together so the checker call site stays a
 /// single optional argument (absent → no-op).
@@ -95,8 +175,32 @@ fn finite_point(p: &Point) -> bool {
     p.x_m.is_finite() && p.y_m.is_finite()
 }
 
-fn pedestrian_fields_finite(p: &PerceivedPedestrian) -> bool {
-    finite_point(&p.pos) && finite_point(&p.vel)
+/// A pedestrian is usable iff its position/velocity are finite AND its
+/// measurement age is finite and non-negative (#789 F8). A negative or non-finite
+/// age is a perception fault → fail closed (the caller treats `false` as breach).
+fn pedestrian_fields_valid(p: &PerceivedPedestrian) -> bool {
+    finite_point(&p.pos) && finite_point(&p.vel) && p.age_s.is_finite() && p.age_s >= 0.0
+}
+
+/// Displacement-implied speed of a trajectory segment (#789 F4). `Ok(v)` is the
+/// segment's average speed for a well-formed segment (`dt` finite and positive);
+/// a stationary dwell (`dt ≤ 0` with no displacement) is `Ok(0.0)`; a MALFORMED
+/// segment — nonzero displacement over a non-positive/non-finite `dt` (a teleport
+/// or a time reversal) — is `Err(())`, which the caller fails closed on. The point
+/// is that a doer cannot DECLARE `v = 0` while its poses translate: the geometry
+/// betrays the motion regardless of the declared scalar.
+fn segment_implied_speed(a: &TrajectoryPoint, b: &TrajectoryPoint) -> Result<f64, ()> {
+    let dt = b.time_from_start_s - a.time_from_start_s;
+    let dx = b.pose.x_m - a.pose.x_m;
+    let dy = b.pose.y_m - a.pose.y_m;
+    let disp = (dx * dx + dy * dy).sqrt();
+    if dt.is_finite() && dt > 0.0 {
+        Ok(disp / dt)
+    } else if disp > SEG_DEGENERATE_EPS_M {
+        Err(()) // teleport / time reversal → fail closed
+    } else {
+        Ok(0.0) // coincident-time dwell, no motion
+    }
 }
 
 /// Params are usable iff every field is finite and non-negative. A corrupt
@@ -208,14 +312,21 @@ pub fn required_pedestrian_clearance_m(
 /// **The WS-2 primitive**: does `trajectory` breach the omnidirectional
 /// pedestrian bound for any (pose, pedestrian) pair?
 ///
-/// Per pose with `|v| > stop_epsilon`, per pedestrian: breach if the
-/// euclidean pose→pedestrian distance is below
-/// [`required_pedestrian_clearance_m`]. No lateral filter and no
-/// behind-ego filter — omnidirectionality is the point (a VRU beside or
-/// behind the path can enter it; distance + the disc's time growth keep
-/// far pedestrians from binding). A non-finite pedestrian or a non-finite
-/// pose time/speed is a breach (fail closed).
-// SAFETY: SG1 | REQ: vru-pedestrian-reachable-set-bound | TEST: pedestrian_ahead_within_stopping_envelope_breaches,pedestrian_far_ahead_is_clear,safe_stop_next_to_pedestrian_is_admitted,kerbside_pedestrian_outside_lateral_band_still_binds,non_finite_pedestrian_breaches,empty_scene_is_noop
+/// Per pose with effective speed `> stop_epsilon`, per pedestrian: breach if the
+/// euclidean pose→pedestrian distance is below the pose's
+/// [`required_pedestrian_clearance_m`] plus the pedestrian's measurement-age disc
+/// growth (`v_ped_max · age_s`, #789 F8). No lateral filter and no behind-ego
+/// filter — omnidirectionality is the point (a VRU beside or behind the path can
+/// enter it; distance + the disc's time growth keep far pedestrians from binding).
+///
+/// **Effective speed (#789 F4).** The stop-epsilon skip and the `d_stop` term use
+/// `max(|v_declared|, displacement-implied speed of the adjacent pose pair)`, so a
+/// doer emitting translating poses that DECLARE `v = 0` cannot skip the bound.
+/// **Params (#789 F5)** are sanitized once here; **the pedestrian count (#789 F9)**
+/// is bounded at [`MAX_PEDESTRIANS`] and the per-pose `required` is hoisted out of
+/// the pedestrian loop. A non-finite pedestrian / pose, a negative-or-non-finite
+/// age, an over-bound scene, or a malformed segment is a breach (fail closed).
+// SAFETY: SG1 | REQ: vru-pedestrian-reachable-set-bound | TEST: pedestrian_ahead_within_stopping_envelope_breaches,pedestrian_far_ahead_is_clear,safe_stop_next_to_pedestrian_is_admitted,kerbside_pedestrian_outside_lateral_band_still_binds,non_finite_pedestrian_breaches,empty_scene_is_noop,declared_zero_velocity_but_translating_pose_still_binds,loose_params_cannot_weaken_the_bound,measurement_age_grows_the_reachable_disc,too_many_pedestrians_fails_closed
 #[must_use]
 pub fn pedestrian_breach(
     trajectory: &[TrajectoryPoint],
@@ -224,30 +335,74 @@ pub fn pedestrian_breach(
     a_max_mps2: f64,
     ego_reach_m: f64,
 ) -> bool {
+    // Absent pedestrians → no-op (byte-identical to the empty double-loop).
+    if scene.pedestrians.is_empty() {
+        return false;
+    }
+    // F9 — fail-closed input bound: an over-bound scene is a malformed perception
+    // input, never an unbounded per-tick loop.
+    if scene.pedestrians.len() > MAX_PEDESTRIANS {
+        return true;
+    }
+    // F5 — sanitize the caller-supplied params ONCE, at this single choke point, so
+    // a loose param set can never weaken the bound regardless of how it was built.
+    let params = scene.params.sanitized();
+    // Validate every pedestrian up front (fail closed on non-finite fields or a
+    // negative / non-finite measurement age, #789 F8).
     for ped in scene.pedestrians {
-        if !pedestrian_fields_finite(ped) {
+        if !pedestrian_fields_valid(ped) {
             return true;
         }
-        for tp in trajectory {
-            let v = tp.velocity_mps;
-            let t = tp.time_from_start_s;
-            // Self-contained fail-closed: a non-finite pose would NaN the
-            // distance and fail OPEN in the comparison below. The validator's
-            // containment pass rejects such poses first, but this helper is
-            // public and must not depend on that ordering.
-            if !(v.is_finite()
-                && t.is_finite()
-                && tp.pose.x_m.is_finite()
-                && tp.pose.y_m.is_finite()
-                && tp.pose.heading_rad.is_finite())
-            {
-                return true;
+    }
+    // F9 hoist — `required_base` depends only on the POSE (effective speed, time),
+    // not on the pedestrian, so evaluate it ONCE per pose in the outer loop; the
+    // inner pedestrian loop is a distance comparison plus the cheap per-pedestrian
+    // age term. One `required` evaluation per pose, not per (pose, pedestrian).
+    for (i, tp) in trajectory.iter().enumerate() {
+        // Self-contained fail-closed: a non-finite pose would NaN the distance and
+        // fail OPEN below. The validator's containment pass rejects such poses
+        // first, but this helper is public and must not depend on that ordering.
+        if !(tp.velocity_mps.is_finite()
+            && tp.time_from_start_s.is_finite()
+            && tp.pose.x_m.is_finite()
+            && tp.pose.y_m.is_finite()
+            && tp.pose.heading_rad.is_finite())
+        {
+            return true;
+        }
+        // F4 — the EFFECTIVE speed: the max of the declared speed and the
+        // displacement-implied speed of the adjacent segments. A malformed segment
+        // (teleport / time reversal) fails closed. This is used for BOTH the
+        // stop-epsilon skip and the `d_stop` term, so a translating pose that
+        // declares `v = 0` neither skips the bound nor understates the stop distance.
+        let mut v_eff = tp.velocity_mps.abs();
+        if i > 0 {
+            match segment_implied_speed(&trajectory[i - 1], tp) {
+                Ok(s) => v_eff = v_eff.max(s),
+                Err(()) => return true,
             }
-            if v.abs() <= scene.params.stop_epsilon_mps {
-                continue;
+        }
+        if i + 1 < trajectory.len() {
+            match segment_implied_speed(tp, &trajectory[i + 1]) {
+                Ok(s) => v_eff = v_eff.max(s),
+                Err(()) => return true,
             }
-            let required =
-                required_pedestrian_clearance_m(v, t, a_brake_mps2, a_max_mps2, ego_reach_m, &scene.params);
+        }
+        if v_eff <= params.stop_epsilon_mps {
+            continue;
+        }
+        let required_base = required_pedestrian_clearance_m(
+            v_eff,
+            tp.time_from_start_s,
+            a_brake_mps2,
+            a_max_mps2,
+            ego_reach_m,
+            &params,
+        );
+        for ped in scene.pedestrians {
+            // F8 — the disc has already been growing for `age_s` since the
+            // measurement was taken; extend the required clearance accordingly.
+            let required = required_base + params.v_ped_max_mps * ped.age_s;
             let dx = ped.pos.x_m - tp.pose.x_m;
             let dy = ped.pos.y_m - tp.pose.y_m;
             let dist = (dx * dx + dy * dy).sqrt();
@@ -279,7 +434,16 @@ mod tests {
     }
 
     fn ped(x: f64, y: f64) -> PerceivedPedestrian {
-        PerceivedPedestrian { id: 1, pos: Point { x_m: x, y_m: y }, vel: Point { x_m: 0.0, y_m: 0.0 } }
+        ped_age(x, y, 0.0)
+    }
+
+    fn ped_age(x: f64, y: f64, age_s: f64) -> PerceivedPedestrian {
+        PerceivedPedestrian {
+            id: 1,
+            pos: Point { x_m: x, y_m: y },
+            vel: Point { x_m: 0.0, y_m: 0.0 },
+            age_s,
+        }
     }
 
     const BRAKE: f64 = 4.5; // default_urban service brake (Nominal)
@@ -508,5 +672,180 @@ mod tests {
         let early = required(3.0, 0.5, &p);
         let late = required(3.0, 4.0, &p);
         assert!(late > early, "a later pose faces a larger reachable disc");
+    }
+
+    /// #789 F4 — the stop-epsilon skip must NOT trust the declared `velocity_mps`.
+    /// A trajectory whose poses TRANSLATE (x: 0 → 2 → 4 over t 0,1,2) while
+    /// declaring `v = 0` is really moving at 2 m/s; pre-fix every pose was
+    /// stop-epsilon-skipped and a pedestrian in the path was missed. The
+    /// displacement-implied speed must bind it.
+    #[test]
+    fn declared_zero_velocity_but_translating_pose_still_binds() {
+        let traj = [pt(0.0, 0.0, 0.0), pt(2.0, 0.0, 1.0), pt(4.0, 0.0, 2.0)];
+        assert!(
+            breaches(&traj, &scene(&[ped(3.0, 0.0)])),
+            "a translating trajectory declaring v=0 must not bypass the VRU bound (F4)"
+        );
+        // Control: a genuinely stationary trajectory (no translation, v=0) is still
+        // admitted next to the same pedestrian — the stop-proposal invariant holds.
+        let stopped = [pt(0.0, 0.0, 0.0), pt(0.0, 0.0, 1.0)];
+        assert!(!breaches(&stopped, &scene(&[ped(3.0, 0.0)])));
+    }
+
+    /// #789 F4 — a teleport / time-reversal (nonzero displacement over a
+    /// non-positive `dt`) is a malformed trajectory and fails closed.
+    #[test]
+    fn malformed_segment_fails_closed() {
+        // Two poses at the SAME time but different positions → instantaneous
+        // translation. No finite implied speed is definable → breach.
+        let teleport = [pt(0.0, 0.0, 0.0), pt(5.0, 0.0, 0.0)];
+        assert!(breaches(&teleport, &scene(&[ped(1000.0, 0.0)])));
+    }
+
+    /// #789 F5 — caller-supplied params cannot WEAKEN the bound. A params set with
+    /// `stop_epsilon = 5.0` (would skip a 2 m/s pose) and `v_ped_max = 0.0` (would
+    /// zero the disc growth) is sanitized: the epsilon is clamped to the kernel
+    /// stop-and-hold value and `v_ped_max` is floored at 2.0, so the pedestrian
+    /// still binds. Pre-fix the loose epsilon skipped the pose and it admitted.
+    #[test]
+    fn loose_params_cannot_weaken_the_bound() {
+        let loose =
+            VruRssParams { v_ped_max_mps: 0.0, stop_epsilon_mps: 5.0, ..VruRssParams::default() };
+        // The sanitizer floors/clamps both fields (monotone-tightening).
+        let s = loose.sanitized();
+        assert_eq!(s.v_ped_max_mps, V_PED_MAX_FLOOR_MPS);
+        assert!(s.stop_epsilon_mps <= VRU_STOP_EPSILON_CEILING_MPS);
+        // And through the predicate: the 2 m/s pose is NOT skipped despite eps=5.0.
+        let traj = [pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
+        let sc = PedestrianScene { pedestrians: &[ped(3.0, 0.0)], params: loose };
+        assert!(
+            pedestrian_breach(&traj, &sc, BRAKE, A_MAX, ego_reach()),
+            "a loose stop_epsilon must be clamped so the pose is not skipped (F5)"
+        );
+    }
+
+    /// #789 F8 — a stale measurement grows the reachable disc by `v_ped_max · age`.
+    /// A pedestrian just OUTSIDE the fresh (age 0) requirement is admitted; the same
+    /// pedestrian measured 2 s ago (disc grown by 2·2 = 4 m) now binds. A negative
+    /// or non-finite age fails closed.
+    #[test]
+    fn measurement_age_grows_the_reachable_disc() {
+        let p = VruRssParams::default();
+        // Single distinct pose (duplicated at t=0 so the implied speed is 0 and the
+        // required is the age-free base at v=2).
+        let traj = [pt(0.0, 2.0, 0.0), pt(0.0, 2.0, 0.0)];
+        let req = required(2.0, 0.0, &p);
+        assert!(!breaches(&traj, &scene(&[ped_age(req + 1.0, 0.0, 0.0)])), "fresh: admits");
+        assert!(
+            breaches(&traj, &scene(&[ped_age(req + 1.0, 0.0, 2.0)])),
+            "a 2 s stale measurement grows the disc by v_ped_max·age = 4 m → binds (F8)"
+        );
+        // Fail-closed on a bad age even for a distant pedestrian.
+        assert!(breaches(&traj, &scene(&[ped_age(1000.0, 0.0, -0.1)])));
+        assert!(breaches(&traj, &scene(&[ped_age(1000.0, 0.0, f64::NAN)])));
+    }
+
+    /// #789 F9 — the pedestrian count is a fail-closed input bound: a scene AT the
+    /// bound with all pedestrians far is admitted; one OVER the bound breaches
+    /// regardless of placement (a malformed / over-bound perception input).
+    #[test]
+    fn too_many_pedestrians_fails_closed() {
+        let traj = [pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
+        let ok: Vec<_> = (0..MAX_PEDESTRIANS).map(|i| ped(1000.0 + i as f64, 0.0)).collect();
+        assert!(!breaches(&traj, &scene(&ok)), "a scene at the bound with far VRUs admits");
+        let over: Vec<_> = (0..=MAX_PEDESTRIANS).map(|i| ped(1000.0 + i as f64, 0.0)).collect();
+        assert!(breaches(&traj, &scene(&over)), "an over-bound scene must fail closed (F9)");
+    }
+
+    /// An INDEPENDENT reference for the breach predicate: pedestrian-outer /
+    /// pose-inner, recomputing `required` per (pedestrian, pose) pair — the
+    /// structure the F9 hoist replaced. Used by the proptest to prove the hoisted
+    /// implementation is verdict-identical to the per-pair spec.
+    fn naive_reference_breach(
+        traj: &[TrajectoryPoint],
+        scene: &PedestrianScene<'_>,
+        brake: f64,
+        amax: f64,
+        reach: f64,
+    ) -> bool {
+        if scene.pedestrians.is_empty() {
+            return false;
+        }
+        if scene.pedestrians.len() > MAX_PEDESTRIANS {
+            return true;
+        }
+        let params = scene.params.sanitized();
+        for ped in scene.pedestrians {
+            if !pedestrian_fields_valid(ped) {
+                return true;
+            }
+        }
+        for ped in scene.pedestrians {
+            for (i, tp) in traj.iter().enumerate() {
+                if !(tp.velocity_mps.is_finite()
+                    && tp.time_from_start_s.is_finite()
+                    && tp.pose.x_m.is_finite()
+                    && tp.pose.y_m.is_finite()
+                    && tp.pose.heading_rad.is_finite())
+                {
+                    return true;
+                }
+                let mut v_eff = tp.velocity_mps.abs();
+                if i > 0 {
+                    match segment_implied_speed(&traj[i - 1], tp) {
+                        Ok(s) => v_eff = v_eff.max(s),
+                        Err(()) => return true,
+                    }
+                }
+                if i + 1 < traj.len() {
+                    match segment_implied_speed(tp, &traj[i + 1]) {
+                        Ok(s) => v_eff = v_eff.max(s),
+                        Err(()) => return true,
+                    }
+                }
+                if v_eff <= params.stop_epsilon_mps {
+                    continue;
+                }
+                let required = required_pedestrian_clearance_m(
+                    v_eff,
+                    tp.time_from_start_s,
+                    brake,
+                    amax,
+                    reach,
+                    &params,
+                ) + params.v_ped_max_mps * ped.age_s;
+                let dx = ped.pos.x_m - tp.pose.x_m;
+                let dy = ped.pos.y_m - tp.pose.y_m;
+                let dist = (dx * dx + dy * dy).sqrt();
+                if dist < required {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    proptest::proptest! {
+        /// #789 — the F9-hoisted [`pedestrian_breach`] is verdict-identical to the
+        /// independent per-pair reference over random finite trajectories and
+        /// scenes (the review-recommended `breach ⟺ disc/envelope overlap` cross
+        /// check, phrased as hoisted-vs-naive equivalence so it also guards F4/F8).
+        #[test]
+        fn hoisted_breach_matches_naive_reference(
+            xs in proptest::collection::vec(-5.0f64..50.0, 2..6),
+            vs in proptest::collection::vec(0.0f64..12.0, 2..6),
+            pxs in proptest::collection::vec(-5.0f64..60.0, 0..5),
+            pys in proptest::collection::vec(-5.0f64..5.0, 0..5),
+            ages in proptest::collection::vec(0.0f64..3.0, 0..5),
+        ) {
+            let n = xs.len().min(vs.len());
+            let traj: Vec<_> = (0..n).map(|i| pt(xs[i], vs[i], i as f64)).collect();
+            let m = pxs.len().min(pys.len()).min(ages.len());
+            let peds: Vec<_> = (0..m).map(|i| ped_age(pxs[i], pys[i], ages[i])).collect();
+            let sc = scene(&peds);
+            let got = pedestrian_breach(&traj, &sc, BRAKE, A_MAX, ego_reach());
+            let want = naive_reference_breach(&traj, &sc, BRAKE, A_MAX, ego_reach());
+            proptest::prop_assert_eq!(got, want);
+        }
     }
 }

--- a/crates/kirra-trajectory/src/vru.rs
+++ b/crates/kirra-trajectory/src/vru.rs
@@ -147,12 +147,20 @@ impl VruRssParams {
     #[must_use]
     pub fn sanitized(&self) -> VruRssParams {
         VruRssParams {
-            v_ped_max_mps: if self.v_ped_max_mps.is_finite() {
+            // Only floor a VALID (finite AND non-negative) value. A negative
+            // v_ped_max is corrupt — `max(-1.0, 2.0)` would LAUNDER it into a valid
+            // 2.0 and defeat the design-doc §4 fail-closed rule (a corrupt param →
+            // ∞ requirement → breach). Leave it untouched so `params_valid` fails
+            // closed. (Copilot #799.)
+            v_ped_max_mps: if self.v_ped_max_mps.is_finite() && self.v_ped_max_mps >= 0.0 {
                 self.v_ped_max_mps.max(V_PED_MAX_FLOOR_MPS)
             } else {
                 self.v_ped_max_mps
             },
-            stop_epsilon_mps: if self.stop_epsilon_mps.is_finite() {
+            // Same discipline for the epsilon clamp: `min(neg, 0.05)` already keeps a
+            // negative (so `params_valid` still fails), but guard explicitly so the
+            // fail-closed intent does not depend on `min`'s sign behavior.
+            stop_epsilon_mps: if self.stop_epsilon_mps.is_finite() && self.stop_epsilon_mps >= 0.0 {
                 self.stop_epsilon_mps.min(VRU_STOP_EPSILON_CEILING_MPS)
             } else {
                 self.stop_epsilon_mps
@@ -326,7 +334,7 @@ pub fn required_pedestrian_clearance_m(
 /// is bounded at [`MAX_PEDESTRIANS`] and the per-pose `required` is hoisted out of
 /// the pedestrian loop. A non-finite pedestrian / pose, a negative-or-non-finite
 /// age, an over-bound scene, or a malformed segment is a breach (fail closed).
-// SAFETY: SG1 | REQ: vru-pedestrian-reachable-set-bound | TEST: pedestrian_ahead_within_stopping_envelope_breaches,pedestrian_far_ahead_is_clear,safe_stop_next_to_pedestrian_is_admitted,kerbside_pedestrian_outside_lateral_band_still_binds,non_finite_pedestrian_breaches,empty_scene_is_noop,declared_zero_velocity_but_translating_pose_still_binds,loose_params_cannot_weaken_the_bound,measurement_age_grows_the_reachable_disc,too_many_pedestrians_fails_closed
+// SAFETY: SG1 | REQ: vru-pedestrian-reachable-set-bound | TEST: pedestrian_ahead_within_stopping_envelope_breaches,pedestrian_far_ahead_is_clear,safe_stop_next_to_pedestrian_is_admitted,kerbside_pedestrian_outside_lateral_band_still_binds,non_finite_pedestrian_breaches,empty_scene_is_noop,declared_zero_velocity_but_translating_pose_still_binds,loose_params_cannot_weaken_the_bound,measurement_age_grows_the_reachable_disc,too_many_pedestrians_fails_closed,corrupt_v_ped_max_is_not_laundered_and_fails_closed
 #[must_use]
 pub fn pedestrian_breach(
     trajectory: &[TrajectoryPoint],
@@ -399,6 +407,15 @@ pub fn pedestrian_breach(
             ego_reach_m,
             &params,
         );
+        // Fail closed on a non-finite base BEFORE adding the age term (Copilot #799):
+        // `required_base` is ∞ on any fault (invalid params / brake / accel / geometry),
+        // and `∞ + v_ped_max·age_s` becomes NaN when `v_ped_max` is non-finite and
+        // `age_s = 0` (NaN·0 = NaN) — then `dist < NaN` is false and the check would
+        // FAIL OPEN. A moving pose with an infinite requirement is an unconditional
+        // breach.
+        if !required_base.is_finite() {
+            return true;
+        }
         for ped in scene.pedestrians {
             // F8 — the disc has already been growing for `age_s` since the
             // measurement was taken; extend the required clearance accordingly.
@@ -745,6 +762,33 @@ mod tests {
         assert!(breaches(&traj, &scene(&[ped_age(1000.0, 0.0, f64::NAN)])));
     }
 
+    /// #789 (Copilot #799) — a corrupt `v_ped_max` must fail closed, not be
+    /// LAUNDERED by `sanitized()` into a valid 2.0, and the split age term must not
+    /// NaN-poison the requirement into failing OPEN. A negative value stays negative
+    /// (→ `params_valid` breach); a non-finite value forces `required_base = ∞`,
+    /// whose `∞ + v_ped_max·age` (NaN at age 0) is caught by the finite guard.
+    #[test]
+    fn corrupt_v_ped_max_is_not_laundered_and_fails_closed() {
+        // A negative v_ped_max is NOT floored to 2.0.
+        let neg = VruRssParams { v_ped_max_mps: -1.0, ..VruRssParams::default() };
+        assert!(neg.sanitized().v_ped_max_mps < 0.0, "a negative v_ped_max must NOT be floored");
+        // Through the predicate: a moving pose with a corrupt v_ped_max breaches even
+        // a FRESH (age 0) pedestrian placed arbitrarily far — no NaN fail-open. Each
+        // of these silently ADMITTED before the fix (negative → laundered to 2.0 with
+        // a finite requirement; NaN/∞ → `∞ + NaN` → `dist < NaN` false).
+        let traj = [pt(0.0, 2.0, 0.0), pt(2.0, 2.0, 1.0)];
+        for bad in [-1.0, f64::NAN, f64::INFINITY] {
+            let sc = PedestrianScene {
+                pedestrians: &[ped_age(1000.0, 0.0, 0.0)],
+                params: VruRssParams { v_ped_max_mps: bad, ..VruRssParams::default() },
+            };
+            assert!(
+                pedestrian_breach(&traj, &sc, BRAKE, A_MAX, ego_reach()),
+                "corrupt v_ped_max={bad} must fail closed, not NaN-poison to fail open"
+            );
+        }
+    }
+
     /// #789 F9 — the pedestrian count is a fail-closed input bound: a scene AT the
     /// bound with all pedestrians far is admitted; one OVER the bound breaches
     /// regardless of placement (a malformed / over-bound perception input).
@@ -806,14 +850,20 @@ mod tests {
                 if v_eff <= params.stop_epsilon_mps {
                     continue;
                 }
-                let required = required_pedestrian_clearance_m(
+                // Mirror the fail-closed guard in `pedestrian_breach` (Copilot #799):
+                // an infinite base must breach before the age term can NaN-poison it.
+                let required_base = required_pedestrian_clearance_m(
                     v_eff,
                     tp.time_from_start_s,
                     brake,
                     amax,
                     reach,
                     &params,
-                ) + params.v_ped_max_mps * ped.age_s;
+                );
+                if !required_base.is_finite() {
+                    return true;
+                }
+                let required = required_base + params.v_ped_max_mps * ped.age_s;
                 let dx = ped.pos.x_m - tp.pose.x_m;
                 let dy = ped.pos.y_m - tp.pose.y_m;
                 let dist = (dx * dx + dy * dy).sqrt();

--- a/docs/safety/PEDESTRIAN_RSS.md
+++ b/docs/safety/PEDESTRIAN_RSS.md
@@ -50,14 +50,24 @@ stopping envelope meeting the disc as it grows over the whole stopping
 interval:
 
 ```text
-v_after  = v + a_max · ρ                          — worst-case speed AFTER the response phase (F2)
+v_eff    = max(|v_declared|, displacement / dt)   — effective ego speed (F4, #789): the
+                                                    declared scalar is NOT trusted alone
+v_after  = v_eff + a_max · ρ                       — worst-case speed AFTER the response phase (F2)
 t_stop   = ρ + v_after / a_brake                  — time to full stop
-d_stop   = v·ρ + ½·a_max·ρ² + v_after² / (2·a_brake)   — RSS stopping distance
-required = d_stop + r_ped + v_ped_max · (t + t_stop) + clearance + ego_reach
+d_stop   = v_eff·ρ + ½·a_max·ρ² + v_after² / (2·a_brake)   — RSS stopping distance
+required = d_stop + r_ped + v_ped_max · (age + t + t_stop) + clearance + ego_reach
 UNSAFE   ⟺ dist(pose, ped) < required
 ```
 
 where:
+- **`v_eff`** (F4, #789) is `max(|v_declared|, displacement/dt)` over the adjacent
+  pose pair — the checker does not trust a doer-declared `velocity_mps` in isolation,
+  so a planner emitting translating poses that DECLARE `v = 0` cannot skip the bound
+  (or understate `d_stop`). A nonzero displacement over a non-positive/non-finite `dt`
+  (teleport / time reversal) fails closed.
+- **`age`** (F8, #789) is the pedestrian measurement age (`PerceivedPedestrian.age_s`):
+  the reachable disc has already been growing since the observation, so the growth window
+  is `age + t + t_stop`. A negative or non-finite age is a perception fault → breach.
 - **`a_max`** is the ego's max acceleration: during the reaction time ρ the
   plan/actuator may still be executing acceleration, so the ego brakes from
   `v_after`, not `v` (Shalev-Shwartz Def. 1 / Lemma 2; IEEE 2846). This is the
@@ -132,17 +142,31 @@ is exactly the sidewalk-courier posture.
 | Non-positive / non-finite `a_brake`, or non-finite/negative `a_max` / `ego_reach` | `required = ∞` → any moving pose breaches (an unbrakeable ego, or corrupt ego geometry, cannot prove VRU safety) |
 | Non-finite speed/time input or ANY corrupt `VruRssParams` field (non-finite or negative) | `required = ∞` → breach (a NaN would otherwise poison `dist < required` into failing OPEN) |
 | Non-finite trajectory pose field | Breach → MRC (self-contained — not dependent on containment rejecting it first) |
-| Absent VRU channel (`None` scene) | **No-op** — byte-identical path (the derate-only invariant: absent input never relaxes, never fabricates) |
+| Negative / non-finite pedestrian measurement `age_s` (F8, #789) | Breach → MRC (a stale-age fault must not silently reduce the disc growth) |
+| Malformed segment — nonzero displacement over non-positive/non-finite `dt` (F4, #789) | Breach → MRC (teleport / time reversal: no finite implied speed is definable) |
+| More than `MAX_PEDESTRIANS` (64) in a scene (F9, #789) | Breach → MRC (over-bound perception input; bounds the per-tick WCET) |
+| Absent VRU channel (`None` scene) OR empty pedestrian list | **No-op** — byte-identical path (the derate-only invariant: absent input never relaxes, never fabricates) |
 
 ## 5. Parameters (`VruRssParams`, plus the ego brake from `VehicleConfig`) — all VALIDATION-PENDING
 
 | Param | Default | Rationale / tuning obligation |
 |---|---|---|
-| `v_ped_max_mps` | 2.0 | Brisk walk (~1.4 typical walking; 2.0 covers hurried). **ODDs with expected runners, children darting, or cyclists-as-VRUs must raise it** — a raise only tightens the bound. Lowering below 2.0 needs ODD evidence + review. |
+| `v_ped_max_mps` | 2.0 | Brisk walk (~1.4 typical walking; 2.0 covers hurried). **ODDs with expected runners, children darting, or cyclists-as-VRUs must raise it** — a raise only tightens the bound. **Floored at 2.0 (F5, #789): a caller cannot supply a smaller value** — `sanitized()` enforces `max(v_ped_max, V_PED_MAX_FLOOR_MPS)`. |
 | `ped_radius_m` | 0.3 | Body half-width; not a point target. |
 | `clearance_m` | 0.5 | Comfort/robustness margin beyond the geometric envelopes. |
 | `reaction_time_s` | 0.5 | Matches the vehicle-RSS `RSS_REACTION_TIME_S` — one reaction model per checker. |
-| `stop_epsilon_mps` | 0.05 | Matches `STOP_EPSILON_MPS` (the Degraded stop-and-hold epsilon). |
+| `stop_epsilon_mps` | 0.05 | Matches `STOP_EPSILON_MPS` (the Degraded stop-and-hold epsilon). **Clamped ≤ the kernel `STOP_EPSILON_MPS` (F5, #789): a caller cannot loosen it** — a larger value would let a still-rolling ego skip the bound. `sanitized()` enforces `min(stop_epsilon, VRU_STOP_EPSILON_CEILING_MPS)`. |
+
+**Params authority (F5, #789).** `VruRssParams` are caller-supplied per call. The
+`params_valid` finiteness/non-negativity check is not sufficient on its own — a
+`stop_epsilon = 5.0` or `v_ped_max = 0.0` is finite and non-negative yet WEAKENS the
+bound. `VruRssParams::sanitized()`, applied once at the single choke point
+(`pedestrian_breach`), floors `v_ped_max` at `V_PED_MAX_FLOOR_MPS` (2.0) and clamps
+`stop_epsilon` to `VRU_STOP_EPSILON_CEILING_MPS` (the kernel `STOP_EPSILON_MPS`); both
+clamps are monotone-tightening, and non-finite fields are left for `params_valid` to
+fail closed rather than clamped into an admitting value. A full per-ODD derivation of
+`v_ped_max` (mirroring `KIRRA_VEHICLE_CLASS` / `contract_for`) remains a deployment
+tuning obligation ON TOP of this floor.
 | `a_brake_mps2` (not a `VruRssParams` field — the validator passes the **posture-composed** `kinematics.max_brake_mps2`, #779 F3) | per-class contract | The ego's assured braking: the Nominal service brake under Nominal, the weaker MRC brake under Degraded (so a faulted-posture ego is held to its actual stopping power). Derating it further (e.g. wet-surface factor) is a tracked refinement. |
 | `a_max_mps2` (not a `VruRssParams` field — the validator passes `VehicleConfig::max_accel_mps2`, #779 F2) | per-class contract | The ego's max acceleration, for the RSS response-phase term (`v_after = v + a_max·ρ`). |
 | `ego_reach_m` (derived from the footprint by the validator, #779 F1) | per-class geometry | `max(wheelbase+overhang_front, overhang_rear).hypot(half_width)` — the ego body extent from the rear-axle pose. |
@@ -165,7 +189,25 @@ argument (absent → no-op). The WCET-critical per-pose
 `validate_vehicle_command` path is untouched; the Nominal path without a
 VRU channel is byte-identical.
 
+**Go-live soundness hardening (#789), landed — the prerequisites for feeding a
+live producer:**
+- **F4 — velocity-declaration trust.** The stop-epsilon skip and `d_stop` use
+  `v_eff = max(|v_declared|, displacement/dt)`; a translating pose declaring `v = 0`
+  can no longer bypass the bound. Malformed segments fail closed.
+- **F5 — params authority.** `VruRssParams::sanitized()` floors `v_ped_max` and
+  clamps `stop_epsilon` at the single choke point (§5).
+- **F8 — measurement age.** `PerceivedPedestrian.age_s` grows the disc by
+  `v_ped_max · age`; the wire shape is frozen now, before a producer exists.
+- **F9 — WCET.** `MAX_PEDESTRIANS` fail-closed input bound; per-pose `required`
+  hoisted out of the pedestrian loop; `O(T·P)` with one `required` per pose (module
+  doc). Cross-checked by the `hoisted_breach_matches_naive_reference` proptest.
+
 **Follow-ups (in dependency order):**
+0. **Road-structure / right-of-way (F6, #789, availability).** The pure disc makes
+   the robotaxi ODD over-conservative (§5) and can bind a pedestrian behind a receding
+   ego. Corridor-clipped disc growth (a distance-to-path term) and/or per-zone
+   `v_ped_max`, keeping the pure disc for the sidewalk-courier ODD. **Availability,
+   strictly after soundness** — a relaxation, never a silent default; own review.
 1. **Node VRU channel** — a `~/input/pedestrians` subscription on the ros2
    adapter (staleness-budgeted like the object channels: an ARMED but
    silent/stale channel fails closed to `Some(empty…)`→cap, never silently
@@ -195,3 +237,7 @@ VRU channel is byte-identical.
 | Absent-channel byte-identity | `vru_absent_channel_is_byte_identical` |
 | Fail-closed non-finite / unbrakeable / bad geometry | `vru_non_finite_pedestrian_mrcs`, unit `non_positive_brake_and_bad_geometry_fail_closed`, `non_finite_pedestrian_breaches` |
 | Ego-body term (F1) / response-phase term (F2) / posture brake (F3) | unit `ego_footprint_term_binds_the_body_not_the_axle`, `response_phase_accel_term_raises_the_requirement`, `weaker_degraded_brake_demands_more_clearance` |
+| Velocity-declaration trust (F4, #789) | unit `declared_zero_velocity_but_translating_pose_still_binds`, `malformed_segment_fails_closed` |
+| Params authority — loose params cannot weaken (F5, #789) | unit `loose_params_cannot_weaken_the_bound` |
+| Measurement-age disc growth (F8, #789) | unit `measurement_age_grows_the_reachable_disc` |
+| WCET input bound + hoist equivalence (F9, #789) | unit `too_many_pedestrians_fails_closed`, `hoisted_breach_matches_naive_reference` (proptest) |

--- a/docs/safety/PEDESTRIAN_RSS.md
+++ b/docs/safety/PEDESTRIAN_RSS.md
@@ -163,8 +163,9 @@ is exactly the sidewalk-courier posture.
 bound. `VruRssParams::sanitized()`, applied once at the single choke point
 (`pedestrian_breach`), floors `v_ped_max` at `V_PED_MAX_FLOOR_MPS` (2.0) and clamps
 `stop_epsilon` to `VRU_STOP_EPSILON_CEILING_MPS` (the kernel `STOP_EPSILON_MPS`); both
-clamps are monotone-tightening, and non-finite fields are left for `params_valid` to
-fail closed rather than clamped into an admitting value. A full per-ODD derivation of
+clamps are monotone-tightening, and non-finite OR negative fields are left untouched for
+`params_valid` to fail closed rather than clamped/laundered into an admitting value (a
+negative `v_ped_max` is not floored to 2.0 — Copilot #799). A full per-ODD derivation of
 `v_ped_max` (mirroring `KIRRA_VEHICLE_CLASS` / `contract_for`) remains a deployment
 tuning obligation ON TOP of this floor.
 | `a_brake_mps2` (not a `VruRssParams` field — the validator passes the **posture-composed** `kinematics.max_brake_mps2`, #779 F3) | per-class contract | The ego's assured braking: the Nominal service brake under Nominal, the weaker MRC brake under Degraded (so a faulted-posture ego is held to its actual stopping power). Derating it further (e.g. wet-surface factor) is a tracked refinement. |


### PR DESCRIPTION
Closes the fail-closed soundness prerequisites from the #779 deep review (issue #789) that **must land before any producer feeds live `PerceivedPedestrian`s**. The geometric soundness fixes (F1 ego footprint, F2 RSS response phase, F3 posture brake, F7 doc) landed in #788; the bound is still armed-but-unfed. This PR hardens the primitive so a producer can be wired safely.

All changes are confined to `crates/kirra-trajectory/src/vru.rs` (+ its `Cargo.toml`, one adapter test constructor, and the design doc). The WCET-critical per-pose `validate_vehicle_command` path is untouched, and the absent-channel / empty-list path stays byte-identical (derate-only invariant).

### F4 (Medium) — velocity-declaration trust
The stop-epsilon skip no longer trusts the doer-declared `velocity_mps` alone. It now uses the **effective speed** `max(|v_declared|, displacement/dt)` over the adjacent pose pair — for **both** the skip decision **and** the `d_stop` term. A planner emitting translating poses that DECLARE `v = 0` can no longer bypass the bound or understate the stopping distance. A malformed segment (nonzero displacement over a non-positive/non-finite `dt` — a teleport / time reversal) fails closed.

### F5 (Medium) — params authority
`VruRssParams::sanitized()`, applied once at the single choke point (`pedestrian_breach`), floors `v_ped_max` at `V_PED_MAX_FLOOR_MPS` (2.0) and clamps `stop_epsilon` to the kernel `STOP_EPSILON_MPS`. Both clamps are monotone-tightening, so a caller-supplied loose param set (`stop_epsilon = 5.0`, `v_ped_max = 0.0`) can never weaken the bound; non-finite fields are left for `params_valid` to fail closed. A full per-ODD derivation of `v_ped_max` remains a documented tuning obligation on top of this floor.

### F8 (Low) — measurement age
`PerceivedPedestrian` gains `age_s`; the reachable disc grows by `v_ped_max · age_s` (the disc has been growing since the observation). The wire shape is **frozen now, before a producer exists**. A negative or non-finite age fails closed.

### F9 (Low, WCET) — unbounded pedestrian count
`MAX_PEDESTRIANS` (64) fail-closed input bound; the per-pose `required` clearance is hoisted out of the pedestrian loop (it is pose-only, not per-pedestrian), giving `O(T·P)` with one `required` evaluation per pose. One `O()` sentence added to the module doc.

### Out of scope — F6 (availability)
Road-structure / right-of-way corridor clipping is explicitly **after soundness** — a relaxation, never a silent default — and remains tracked on #789.

## Tests
- **5 new unit tests**, two of which are proven to fail on pre-fix code: `declared_zero_velocity_but_translating_pose_still_binds` (the translating-pose-declaring-v=0 previously admitted) and `loose_params_cannot_weaken_the_bound` (the loose `stop_epsilon` previously skipped the pose). Plus `malformed_segment_fails_closed`, `measurement_age_grows_the_reachable_disc`, `too_many_pedestrians_fails_closed`.
- **`hoisted_breach_matches_naive_reference` proptest** — the review-recommended cross-check, phrased as hoisted-vs-independent-per-pair equivalence over random finite trajectories/scenes (also guards F4/F8).
- Full `kirra-trajectory` suite (116) green; adapter D2 integration tests green; clippy clean.

Design doc `docs/safety/PEDESTRIAN_RSS.md` updated: formula (`v_eff` + `age` terms), fail-closed table, params-authority section, follow-ups, and traceability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_