### PR TITLE
G16: model-integrity allow-list — reject substituted ML artifacts

### DIFF
--- a/parko/Cargo.lock
+++ b/parko/Cargo.lock
@@ -1450,10 +1450,12 @@ dependencies = [
 name = "parko-core"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "parko-kirra",
  "proptest",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/parko/MODEL_INTEGRITY.md
+++ b/parko/MODEL_INTEGRITY.md
@@ -1,0 +1,78 @@
+# Model-Integrity Allow-List (#G16)
+
+**Status:** LIVE for the source-model path (CPU + TensorRT backends). Compiled-
+engine fingerprint verification and the accelerator watchdog are tracked
+remainders (§4).
+
+## 1. The gap
+
+A backend loaded whatever model file it was pointed at. `parko-tensorrt`
+*computed* a SHA-256 of its cached engine but only **logged** it;
+`parko-onnx` computed **nothing**. So a substituted or corrupted ML artifact
+loaded and ran undetected — a fail-**open** in an otherwise fail-closed stack
+(`INDUSTRY_BENCHMARK_GAP_ANALYSIS.md` G16, ROI shortlist #—).
+
+## 2. The primitive
+
+`parko_core::model_integrity` (pure, no logging, no globals — fully unit-tested):
+
+- `sha256_file(path)` — streaming SHA-256 (bounded memory), fail-closed `Io` on
+  an unreadable file.
+- `ModelAllowList` — the operator policy: a set of allowed lowercase-hex SHA-256
+  digests plus a strict flag. `from_env()` / `parse()` / `from_parts()`.
+- `verify_model_file(path, &allow) -> Result<VerifiedModel, BackendError>` — the
+  gate. Hashes the file and applies the fail-closed table below.
+
+## 3. Fail-closed policy
+
+| `KIRRA_MODEL_ALLOWLIST` | `KIRRA_MODEL_ALLOWLIST_STRICT` | model digest | result |
+|---|---|---|---|
+| has entries | any | in the list | `Ok { verified: true }` |
+| has entries | any | NOT in the list | **`Err(IntegrityRejected)`** |
+| empty / unset | `1`/`true`/`yes`/`on` | (nothing allowed) | **`Err(IntegrityRejected)`** — deny-by-default |
+| empty / unset | off | — | `Ok { verified: false }` — enforcement OFF; digest computed for audit, acceptance byte-identical to pre-#G16 |
+| (either) | — | file unreadable | **`Err(Io)`** — a model that cannot be hashed cannot be proven |
+
+Enforcement is **opt-in**: configuring an allow-list turns it on (matching the
+repo's other env-gated safety gates), so absent config never rejects a
+previously-accepted model, but a configured operator gets hard substitution
+detection and `STRICT` gives the deny-by-default posture.
+
+### Env vars
+
+| Var | Meaning |
+|---|---|
+| `KIRRA_MODEL_ALLOWLIST` | Comma/space/`;`-separated SHA-256 hex digests. Each entry may be a bare `<64-hex>` or `name=<64-hex>` (only the digest is compared). Case-insensitive; malformed entries are ignored (never match). |
+| `KIRRA_MODEL_ALLOWLIST_STRICT` | `1`/`true`/`yes`/`on` → deny any model whose digest is not explicitly listed, even when the list is empty. Off by default. |
+
+## 4. Wiring & coverage
+
+The gate lives in `parko_onnx::session_core::OrtRunCore::load_model` — the
+**single-sourced** inference core. Because **both** `parko-onnx` (`OrtBackend`,
+CPU) and `parko-tensorrt` (`TrtBackend`, TensorRT EP) route `load_model` through
+`OrtRunCore`, the source-model substitution defense covers both backends from one
+call site. A rejected model returns `Err` from `load_model` and never yields a
+runnable `ModelHandle`.
+
+**Tracked remainders (not in this slice):**
+1. **Compiled-engine fingerprint verification** — `parko-tensorrt` computes an
+   `engine_sha256` of the *compiled* TRT engine (deployment/driver-specific).
+   Verifying it against an engine allow-list is a follow-up; the *source* model
+   (what gets substituted upstream) is already gated here.
+2. **Accelerator watchdog** — a hung inference call. Partially covered already by
+   the scheduler's per-tick inference deadline (`parko_core::scheduler`,
+   `with_inference_deadline_ms`); a dedicated per-call accelerator watchdog is a
+   separate follow-up.
+
+## 5. Test traceability
+
+| Property | Test (`parko-core::model_integrity`) |
+|---|---|
+| Known SHA-256 vector ("abc") | `digest_is_stable_and_matches_known_vector` |
+| Matching digest verified | `matching_digest_is_verified` |
+| Substituted model rejected (fail-closed) | `substituted_model_is_rejected_fail_closed` |
+| Enforcement off → accept + unverified | `enforcement_off_accepts_but_reports_unverified` |
+| Strict + empty list → deny-by-default | `strict_mode_rejects_when_allowlist_empty` |
+| Unreadable file fails closed | `unreadable_file_fails_closed_even_when_enforcement_off` |
+| Env parse (forms/case/junk/strict) | `parse_reads_env_forms`, `parse_unset_is_not_enforcing` |
+| Real mnist artifact reject/accept (backend seam) | `parko-onnx::model_integrity_allowlist_gates_the_real_mnist_artifact` |

--- a/parko/MODEL_INTEGRITY.md
+++ b/parko/MODEL_INTEGRITY.md
@@ -10,7 +10,7 @@ A backend loaded whatever model file it was pointed at. `parko-tensorrt`
 *computed* a SHA-256 of its cached engine but only **logged** it;
 `parko-onnx` computed **nothing**. So a substituted or corrupted ML artifact
 loaded and ran undetected — a fail-**open** in an otherwise fail-closed stack
-(`INDUSTRY_BENCHMARK_GAP_ANALYSIS.md` G16, ROI shortlist #—).
+(`INDUSTRY_BENCHMARK_GAP_ANALYSIS.md` G16).
 
 ## 2. The primitive
 

--- a/parko/crates/parko-core/Cargo.toml
+++ b/parko/crates/parko-core/Cargo.toml
@@ -29,6 +29,10 @@ backend-amd      = []
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1", features = ["sync", "time", "rt-multi-thread", "macros"] }
+# Model-integrity allow-list (#G16): SHA-256 the model file and compare against
+# the operator allow-list. Same versions parko-tensorrt already depends on.
+sha2 = "0.11"
+hex = "0.4"
 
 [dev-dependencies]
 parko-kirra = { path = "../parko-kirra" }

--- a/parko/crates/parko-core/src/backend.rs
+++ b/parko/crates/parko-core/src/backend.rs
@@ -27,6 +27,12 @@ pub enum BackendError {
     #[error("I/O error: {0}")]
     Io(String),
 
+    /// Model-integrity allow-list rejection (#G16): the loaded model's SHA-256
+    /// digest is not in the operator's allow-list (or strict mode is on and no
+    /// entry matches). Fail-closed — the model MUST NOT run.
+    #[error("model integrity rejected: {path} has sha256 {sha256} (not in the allow-list)")]
+    IntegrityRejected { path: String, sha256: String },
+
     #[error("Operation not supported by this backend")]
     Unsupported,
 }

--- a/parko/crates/parko-core/src/lib.rs
+++ b/parko/crates/parko-core/src/lib.rs
@@ -27,6 +27,9 @@ pub mod detector;
 pub mod impact;
 // SG2/SG5 — localization-integrity gate over the map-anchored checks (#123).
 pub mod localization;
+// #G16 — model-integrity allow-list: SHA-256 the model file and reject a
+// substituted artifact against the operator allow-list before it can run.
+pub mod model_integrity;
 pub mod rss;
 pub mod runtime;
 // SG4 — WATER_UNTRAVERSABLE governor veto (depth-free, bounded-worst-case, #98).
@@ -57,6 +60,11 @@ pub use backend::{
     PrecisionMode,
     TensorBatch,
     TensorStorage,
+};
+
+pub use model_integrity::{
+    sha256_file, verify_model_file, ModelAllowList, VerifiedModel, MODEL_ALLOWLIST_ENV,
+    MODEL_ALLOWLIST_STRICT_ENV,
 };
 
 pub use backend_selector::{

--- a/parko/crates/parko-core/src/model_integrity.rs
+++ b/parko/crates/parko-core/src/model_integrity.rs
@@ -1,0 +1,290 @@
+//! **Model-integrity allow-list (#G16).**
+//!
+//! The gap: a backend loads whatever model file it is pointed at. parko-tensorrt
+//! *computes* a SHA-256 of its cached engine but only logs it; parko-onnx computes
+//! nothing. So a substituted or corrupted ML artifact loads and runs undetected —
+//! a fail-OPEN in an otherwise fail-closed stack.
+//!
+//! This module is the shared, backend-agnostic primitive: hash the model file and
+//! compare it to an operator-configured allow-list before the model is allowed to
+//! run. It is PURE (no logging, no globals) so it is fully unit-testable; the
+//! backends call [`verify_model_file`] from their `load_model` and surface the
+//! [`BackendError::IntegrityRejected`] verdict.
+//!
+//! **Fail-closed policy.**
+//!
+//! | `KIRRA_MODEL_ALLOWLIST` | `KIRRA_MODEL_ALLOWLIST_STRICT` | model digest | result |
+//! |---|---|---|---|
+//! | has entries | any | in the list | `Ok { verified: true }` |
+//! | has entries | any | NOT in the list | **`Err(IntegrityRejected)`** |
+//! | empty / unset | `1`/`true` | (nothing allowed) | **`Err(IntegrityRejected)`** — high-assurance: no model may load without an explicit entry |
+//! | empty / unset | off | — | `Ok { verified: false }` — enforcement OFF; the digest is still computed for audit, acceptance is byte-identical to today (a warn is the caller's job) |
+//! | (enforcing or not) | — | file unreadable | **`Err(Io)`** — a model that cannot be hashed cannot be proven, and cannot be loaded anyway |
+//!
+//! Enforcement is therefore OPT-IN (configuring an allow-list turns it on),
+//! matching the repo's other env-gated safety gates — absent config never rejects
+//! a previously-accepted model, but a configured operator gets hard substitution
+//! detection, and `STRICT` gives the deny-by-default posture.
+
+use std::collections::BTreeSet;
+use std::io::Read;
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use crate::backend::BackendError;
+
+/// Env var naming the allowed model digests: comma/space-separated lowercase
+/// SHA-256 hex strings. Each entry may be a bare `<64-hex>` digest or a
+/// `name=<64-hex>` pair (only the digest is compared). Non-hex / wrong-length
+/// entries are ignored (they simply never match — safe).
+pub const MODEL_ALLOWLIST_ENV: &str = "KIRRA_MODEL_ALLOWLIST";
+
+/// Env var enabling strict (deny-by-default) mode: `1`/`true` → a model whose
+/// digest is not explicitly allow-listed is rejected even when the allow-list is
+/// empty. Off by default so existing deployments/tests are unaffected.
+pub const MODEL_ALLOWLIST_STRICT_ENV: &str = "KIRRA_MODEL_ALLOWLIST_STRICT";
+
+/// Streaming read buffer — bounded memory regardless of model size.
+const HASH_BUF_BYTES: usize = 64 * 1024;
+
+/// An operator's model-integrity policy: the set of allowed SHA-256 digests plus
+/// the strict flag. Construct from the environment ([`ModelAllowList::from_env`])
+/// or explicitly ([`ModelAllowList::from_parts`], used by tests).
+#[derive(Debug, Clone, Default)]
+pub struct ModelAllowList {
+    allowed: BTreeSet<String>,
+    strict: bool,
+}
+
+/// The outcome of a successful integrity check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedModel {
+    /// Lowercase hex SHA-256 of the model file.
+    pub sha256_hex: String,
+    /// `true` iff enforcement was on and the digest matched the allow-list.
+    /// `false` means enforcement was OFF (the digest is informational only).
+    pub verified: bool,
+}
+
+impl ModelAllowList {
+    /// Read the policy from the process environment.
+    pub fn from_env() -> Self {
+        let allow = std::env::var(MODEL_ALLOWLIST_ENV).ok();
+        let strict = std::env::var(MODEL_ALLOWLIST_STRICT_ENV).ok();
+        Self::parse(allow.as_deref(), strict.as_deref())
+    }
+
+    /// Pure parser (the testable core of [`from_env`]). Splits on commas and
+    /// whitespace, lowercases, strips an optional `name=` prefix, and keeps only
+    /// well-formed 64-char hex digests.
+    pub fn parse(allowlist: Option<&str>, strict: Option<&str>) -> Self {
+        let mut allowed = BTreeSet::new();
+        if let Some(list) = allowlist {
+            for tok in list.split([',', ' ', '\t', '\n', ';']) {
+                let tok = tok.trim();
+                if tok.is_empty() {
+                    continue;
+                }
+                // Accept `name=digest`; keep only the digest half.
+                let digest = tok.rsplit('=').next().unwrap_or(tok).trim().to_ascii_lowercase();
+                if is_sha256_hex(&digest) {
+                    allowed.insert(digest);
+                }
+            }
+        }
+        let strict = matches!(strict.map(|s| s.trim().to_ascii_lowercase()).as_deref(), Some("1" | "true" | "yes" | "on"));
+        Self { allowed, strict }
+    }
+
+    /// Explicit constructor for tests / programmatic policies.
+    pub fn from_parts<I, S>(digests: I, strict: bool) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let allowed = digests
+            .into_iter()
+            .filter_map(|d| {
+                let d = d.as_ref().trim().to_ascii_lowercase();
+                is_sha256_hex(&d).then_some(d)
+            })
+            .collect();
+        Self { allowed, strict }
+    }
+
+    /// Is integrity enforcement active? True when any digest is allow-listed OR
+    /// strict mode is on. When false, [`verify_model_file`] computes the digest
+    /// for audit but does not reject.
+    #[must_use]
+    pub fn is_enforcing(&self) -> bool {
+        !self.allowed.is_empty() || self.strict
+    }
+
+    fn contains(&self, digest_hex: &str) -> bool {
+        self.allowed.contains(&digest_hex.to_ascii_lowercase())
+    }
+}
+
+/// Is `s` a well-formed lowercase-or-mixed 64-char SHA-256 hex digest?
+fn is_sha256_hex(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Stream a file through SHA-256, returning the lowercase hex digest. Bounded
+/// memory ([`HASH_BUF_BYTES`]). An unreadable file is a fail-closed `Io` error.
+pub fn sha256_file(path: &Path) -> Result<String, BackendError> {
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| BackendError::Io(format!("cannot open model '{}': {e}", path.display())))?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; HASH_BUF_BYTES];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| BackendError::Io(format!("cannot read model '{}': {e}", path.display())))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// **The #G16 primitive.** Hash the model at `path` and check it against `allow`.
+///
+/// Fail-closed per the module table: a digest not in a non-empty (or strict)
+/// allow-list is [`BackendError::IntegrityRejected`]; an unreadable file is
+/// [`BackendError::Io`]; enforcement-off returns `Ok { verified: false }` with the
+/// computed digest (the caller may log it). Never runs the model on rejection.
+pub fn verify_model_file(path: &str, allow: &ModelAllowList) -> Result<VerifiedModel, BackendError> {
+    let sha256_hex = sha256_file(Path::new(path))?;
+    if allow.is_enforcing() {
+        if allow.contains(&sha256_hex) {
+            Ok(VerifiedModel { sha256_hex, verified: true })
+        } else {
+            Err(BackendError::IntegrityRejected { path: path.to_string(), sha256: sha256_hex })
+        }
+    } else {
+        // Enforcement OFF: compute-and-accept (byte-identical to prior behaviour);
+        // the digest is returned so the backend can log it for audit.
+        Ok(VerifiedModel { sha256_hex, verified: false })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    // Unique temp path per call (tests run in parallel; no env mutation, no RNG).
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    fn write_temp(content: &[u8]) -> std::path::PathBuf {
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        let p = std::env::temp_dir().join(format!("parko_g16_{}_{n}.bin", std::process::id()));
+        std::fs::File::create(&p).unwrap().write_all(content).unwrap();
+        p
+    }
+
+    #[test]
+    fn digest_is_stable_and_matches_known_vector() {
+        // SHA-256("abc") — the canonical NIST test vector.
+        let p = write_temp(b"abc");
+        let d = sha256_file(&p).unwrap();
+        assert_eq!(d, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+        std::fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn matching_digest_is_verified() {
+        let p = write_temp(b"model-bytes-v1");
+        let digest = sha256_file(&p).unwrap();
+        let allow = ModelAllowList::from_parts([digest.clone()], false);
+        assert!(allow.is_enforcing());
+        let v = verify_model_file(p.to_str().unwrap(), &allow).unwrap();
+        assert_eq!(v.sha256_hex, digest);
+        assert!(v.verified);
+        std::fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn substituted_model_is_rejected_fail_closed() {
+        // Allow-list pins v1's digest; then the file is SUBSTITUTED with v2.
+        let p = write_temp(b"model-bytes-v1");
+        let v1 = sha256_file(&p).unwrap();
+        let allow = ModelAllowList::from_parts([v1], false);
+        std::fs::File::create(&p).unwrap().write_all(b"model-bytes-v2-EVIL").unwrap();
+        let err = verify_model_file(p.to_str().unwrap(), &allow).unwrap_err();
+        assert!(
+            matches!(err, BackendError::IntegrityRejected { .. }),
+            "a substituted model must be rejected, got {err:?}"
+        );
+        std::fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn enforcement_off_accepts_but_reports_unverified() {
+        let p = write_temp(b"anything");
+        let allow = ModelAllowList::from_parts(Vec::<String>::new(), false); // empty, not strict
+        assert!(!allow.is_enforcing());
+        let v = verify_model_file(p.to_str().unwrap(), &allow).unwrap();
+        assert!(!v.verified, "enforcement off → unverified");
+        assert_eq!(v.sha256_hex, sha256_file(&p).unwrap(), "digest still computed for audit");
+        std::fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn strict_mode_rejects_when_allowlist_empty() {
+        // Deny-by-default: strict + no entries → nothing may load.
+        let p = write_temp(b"unlisted-model");
+        let allow = ModelAllowList::from_parts(Vec::<String>::new(), true);
+        assert!(allow.is_enforcing(), "strict is enforcing even with an empty list");
+        let err = verify_model_file(p.to_str().unwrap(), &allow).unwrap_err();
+        assert!(matches!(err, BackendError::IntegrityRejected { .. }));
+        std::fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn unreadable_file_fails_closed_even_when_enforcement_off() {
+        let allow = ModelAllowList::from_parts(Vec::<String>::new(), false);
+        let err = verify_model_file("/no/such/parko/model.onnx", &allow).unwrap_err();
+        assert!(matches!(err, BackendError::Io(_)), "a model that cannot be hashed cannot be proven");
+    }
+
+    #[test]
+    fn parse_reads_env_forms() {
+        let d1 = "a".repeat(64);
+        let d2 = "b".repeat(64);
+        // mixed separators, a name= form, an UPPERCASE digest, and junk that must be dropped.
+        let list = format!("{d1} , primary={}  ; not-a-digest ,", d2.to_ascii_uppercase());
+        let allow = ModelAllowList::parse(Some(&list), Some("true"));
+        assert!(allow.is_enforcing());
+        assert!(allow.strict);
+        assert!(allow.contains(&d1));
+        assert!(allow.contains(&d2), "name= form and case are normalized");
+        assert!(!allow.contains(&"c".repeat(64)));
+        // junk token was not admitted as a digest
+        assert_eq!(allow.allowed.len(), 2);
+    }
+
+    #[test]
+    fn parse_unset_is_not_enforcing() {
+        let allow = ModelAllowList::parse(None, None);
+        assert!(!allow.is_enforcing());
+        // strict parsing is exact: only 1/true/yes/on enable it.
+        assert!(!ModelAllowList::parse(None, Some("0")).strict);
+        assert!(!ModelAllowList::parse(None, Some("")).strict);
+        assert!(ModelAllowList::parse(None, Some("ON")).strict);
+    }
+
+    #[test]
+    fn is_sha256_hex_validates() {
+        assert!(is_sha256_hex(&"0".repeat(64)));
+        // exactly 64 mixed-case hex chars ("aAbBcCdDeEfF" is 12; ×6 = 72; take 64).
+        let mixed: String = "aAbBcCdDeEfF".repeat(6).chars().take(64).collect();
+        assert_eq!(mixed.len(), 64);
+        assert!(is_sha256_hex(&mixed));
+        assert!(!is_sha256_hex(&"0".repeat(63)), "wrong length");
+        assert!(!is_sha256_hex(&"g".repeat(64)), "non-hex");
+    }
+}

--- a/parko/crates/parko-core/src/model_integrity.rs
+++ b/parko/crates/parko-core/src/model_integrity.rs
@@ -7,8 +7,11 @@
 //!
 //! This module is the shared, backend-agnostic primitive: hash the model file and
 //! compare it to an operator-configured allow-list before the model is allowed to
-//! run. It is PURE (no logging, no globals) so it is fully unit-testable; the
-//! backends call [`verify_model_file`] from their `load_model` and surface the
+//! run. The hashing/parsing/verification core ([`sha256_file`], [`ModelAllowList::parse`],
+//! [`verify_model_file`]) is pure — no logging and no retained global state — so it
+//! is fully unit-testable; [`ModelAllowList::from_env`] is the small
+//! environment-reading wrapper backends use to obtain the policy. Backends call
+//! [`verify_model_file`] from their `load_model` and surface the
 //! [`BackendError::IntegrityRejected`] verdict.
 //!
 //! **Fail-closed policy.**
@@ -17,7 +20,7 @@
 //! |---|---|---|---|
 //! | has entries | any | in the list | `Ok { verified: true }` |
 //! | has entries | any | NOT in the list | **`Err(IntegrityRejected)`** |
-//! | empty / unset | `1`/`true` | (nothing allowed) | **`Err(IntegrityRejected)`** — high-assurance: no model may load without an explicit entry |
+//! | empty / unset | `1`/`true`/`yes`/`on` | (nothing allowed) | **`Err(IntegrityRejected)`** — high-assurance: no model may load without an explicit entry |
 //! | empty / unset | off | — | `Ok { verified: false }` — enforcement OFF; the digest is still computed for audit, acceptance is byte-identical to today (a warn is the caller's job) |
 //! | (enforcing or not) | — | file unreadable | **`Err(Io)`** — a model that cannot be hashed cannot be proven, and cannot be loaded anyway |
 //!

--- a/parko/crates/parko-onnx/src/session_core.rs
+++ b/parko/crates/parko-onnx/src/session_core.rs
@@ -47,8 +47,23 @@ impl OrtRunCore {
     }
 
     /// Read input/output shapes off the session into a `ModelHandle`. Relocated
-    /// verbatim from `OrtBackend::load_model`.
+    /// verbatim from `OrtBackend::load_model`, plus the #G16 integrity gate below.
     pub fn load_model(&self, path: &str) -> Result<ModelHandle, BackendError> {
+        // #G16 — model-integrity allow-list: SHA-256 the model file and reject a
+        // substituted / corrupt artifact BEFORE handing back a runnable handle.
+        // Enforcement is opt-in (KIRRA_MODEL_ALLOWLIST); when off this only
+        // computes+logs the digest and acceptance is byte-identical to before.
+        let integrity = parko_core::model_integrity::verify_model_file(
+            path,
+            &parko_core::model_integrity::ModelAllowList::from_env(),
+        )?;
+        tracing::info!(
+            model_path = path,
+            sha256 = integrity.sha256_hex,
+            verified = integrity.verified,
+            "ort load_model integrity check"
+        );
+
         let session = self.session.lock()
             .map_err(|e| BackendError::InitializationError(format!("session lock poisoned: {}", e)))?;
 

--- a/parko/crates/parko-onnx/tests/test_onnx_backend.rs
+++ b/parko/crates/parko-onnx/tests/test_onnx_backend.rs
@@ -38,6 +38,36 @@ fn ort_available() -> Option<()> {
     Some(())
 }
 
+/// #G16 — the model-integrity allow-list rejects a SUBSTITUTED model and accepts
+/// the pinned one, exercised against the REAL mnist artifact. No ORT and no env
+/// mutation: `verify_model_file` (which `OrtRunCore::load_model` now calls for both
+/// the CPU and TensorRT backends) is driven directly with explicit policies.
+#[test]
+fn model_integrity_allowlist_gates_the_real_mnist_artifact() {
+    use parko_core::model_integrity::{sha256_file, verify_model_file, ModelAllowList};
+    let model_path = "tests/data/mnist-12.onnx";
+
+    let real_digest = sha256_file(std::path::Path::new(model_path)).expect("hash mnist");
+
+    // (a) Enforcing with a WRONG digest → the real model is rejected (fail-closed).
+    let wrong = ModelAllowList::from_parts(["0".repeat(64)], false);
+    let err = verify_model_file(model_path, &wrong).unwrap_err();
+    assert!(
+        matches!(err, parko_core::backend::BackendError::IntegrityRejected { .. }),
+        "an unlisted (substituted) model must be rejected, got {err:?}"
+    );
+
+    // (b) Enforcing with the CORRECT digest → accepted and marked verified.
+    let right = ModelAllowList::from_parts([real_digest.clone()], false);
+    let v = verify_model_file(model_path, &right).expect("pinned model accepted");
+    assert!(v.verified && v.sha256_hex == real_digest);
+
+    // (c) No allow-list configured → accepted but unverified (byte-identical to
+    //     the pre-#G16 behaviour; the digest is still computed for audit).
+    let off = ModelAllowList::from_parts(Vec::<String>::new(), false);
+    assert!(!verify_model_file(model_path, &off).unwrap().verified);
+}
+
 #[test]
 fn mnist_end_to_end_inference() {
     if ort_available().is_none() {


### PR DESCRIPTION
Closes the highest-value **still-open** item from the industry gap analysis (`INDUSTRY_BENCHMARK_GAP_ANALYSIS.md` **G16 — model integrity**). The plan's "Next 2 weeks" tier was already closed by the recent campaign (G2/G4/G8/G9/G10/G11/G12/G17/G20); G16 is the clean next fail-closed win.

## The gap
A backend loaded whatever model file it was pointed at. `parko-tensorrt` *computed* an engine SHA-256 but only **logged** it; `parko-onnx` computed **nothing**. A substituted or corrupt ML artifact loaded and ran **undetected** — a fail-**open** in an otherwise fail-closed stack.

## The primitive — `parko_core::model_integrity` (pure, fully unit-tested)
- `sha256_file` — streaming SHA-256, bounded memory, fail-closed `Io` on an unreadable file.
- `ModelAllowList` — operator policy (allowed digests + strict flag) from `KIRRA_MODEL_ALLOWLIST` / `KIRRA_MODEL_ALLOWLIST_STRICT` (`from_env`/`parse`/`from_parts`).
- `verify_model_file` — the fail-closed gate:

| allow-list | strict | model digest | result |
|---|---|---|---|
| has entries | any | listed | `Ok { verified }` |
| has entries | any | **not** listed | **`Err(IntegrityRejected)`** (substitution) |
| empty/unset | on | (nothing allowed) | **`Err(IntegrityRejected)`** (deny-by-default) |
| empty/unset | off | — | `Ok { verified: false }` — enforcement OFF, digest computed for audit, acceptance byte-identical to before |
| (either) | — | unreadable | **`Err(Io)`** — can't hash ⇒ can't prove |

Enforcement is **opt-in** (configuring an allow-list turns it on), matching the repo's other env-gated safety gates — absent config never rejects a previously-accepted model; `STRICT` gives deny-by-default.

## Wiring — one call site covers both backends
The gate lives in the **single-sourced** `OrtRunCore::load_model`. Because both `parko-onnx` (CPU) **and** `parko-tensorrt` (TRT EP) route `load_model` through `OrtRunCore`, the source-model substitution defense covers both from one place. A rejected model returns `Err` and never yields a runnable `ModelHandle`. New `BackendError::IntegrityRejected` variant.

## Tests
- **9 parko-core unit tests**: substitution rejected, strict deny-by-default, enforcement-off accept, unreadable fail-closed, env parse (forms/case/junk/strict), NIST `"abc"` vector.
- **parko-onnx** `model_integrity_allowlist_gates_the_real_mnist_artifact`: drives the **real** mnist model through reject (wrong digest) / accept (correct digest) / unverified (no list) — no ORT, no env mutation.
- parko-core 239→**248** lib tests; parko-onnx / parko-kirra (147) / parko-ros2 (224) green; clippy clean on the touched crates; full parko workspace builds.

## Out of scope (tracked in `parko/MODEL_INTEGRITY.md` §4)
- **Compiled-engine fingerprint verification** — the *source* model (what gets substituted upstream) is now gated; verifying the deployment-specific compiled TRT engine hash is a follow-up.
- **Dedicated accelerator watchdog** — partially covered already by the scheduler's per-tick inference deadline (`with_inference_deadline_ms`, #773).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_