### PR TITLE
G7 (slice 1): per-principal admin tokens — rotation, revocation, attribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,10 +2809,12 @@ dependencies = [
 name = "parko-core"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "parko-kirra",
  "proptest",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/docs/safety/PRINCIPAL_TOKENS.md
+++ b/docs/safety/PRINCIPAL_TOKENS.md
@@ -1,0 +1,75 @@
+# Per-Principal Admin Tokens (#G7, slice 1)
+
+**Status:** LIVE. First slice of gap **G7 — key/identity lifecycle**
+(`INDUSTRY_BENCHMARK_GAP_ANALYSIS.md`). RBAC scoping, TPM key-binding, and
+TLS/mTLS are tracked remainders (§4).
+
+## 1. The gap
+
+The admin+actuator surface was gated by a **single shared bearer token**
+(`KIRRA_ADMIN_TOKEN`). Its compromise exposes the whole surface, it cannot be
+rotated or revoked per-holder, and every mutation is attributed to the same
+anonymous credential. (`INDUSTRY_BENCHMARK_GAP_ANALYSIS.md` G7.)
+
+## 2. What this slice adds
+
+An operator can issue a **named token per principal** — rotate or revoke one
+without disturbing the others, and attribute each admin mutation to a named
+identity — **without sharing** the root `KIRRA_ADMIN_TOKEN`.
+
+- `parko`-free, pure primitive in `src/security.rs`:
+  - `PrincipalRegistry` — the `(principal_id, token)` set, `from_env()` / `parse()`.
+  - `authorize_admin(provided, configured_admin, registry) -> Option<AdminPrincipal>`
+    — the single fail-closed decision the `require_admin_token` middleware gates on.
+  - `AdminPrincipal::{Root, Named(id)}` — the resolved identity, attached to the
+    request extensions and logged for attribution.
+
+### Env vars
+
+| Var | Meaning |
+|---|---|
+| `KIRRA_ADMIN_TOKEN` | **Unchanged.** The root admin token. Absent/empty → **HTTP 503** for every admin route (INVARIANT #1/#6). |
+| `KIRRA_PRINCIPAL_TOKENS` | Optional. `principal_id=token` entries, separated by `,` `;` or newlines. Only the FIRST `=` splits id from token (tokens may contain `=`). Whitespace-trimmed; an entry with no `=`, an empty id, or an empty token is **ignored** (never a credential). |
+
+## 3. Fail-closed & invariant preservation
+
+The extension is **purely additive** and **cannot fail open**:
+
+1. **INVARIANT #1/#6 unchanged.** `require_admin_token` still returns **503**
+   when `KIRRA_ADMIN_TOKEN` is absent/empty, as the FIRST check — before the
+   registry is ever consulted. A per-principal token therefore **never**
+   authorizes without a configured root token
+   (`principal_token_denied_when_root_token_absent_or_empty`).
+2. **INVARIANT #2.** Every token comparison — root and per-principal — goes
+   through `constant_time_compare`. `PrincipalRegistry::resolve` compares against
+   **every** entry with no early-out, so a match does not leak its position by
+   timing.
+3. **Root path unchanged.** With `KIRRA_PRINCIPAL_TOKENS` unset the registry is
+   empty and behavior is byte-identical to before (root-token-only).
+4. **INVARIANT #13.** The decision logic is pure and unit-tested without touching
+   process env (env is read only by the thin `from_env` wrapper), exactly like
+   the sibling `admin_token_ok` (SG-015).
+
+## 4. Tracked remainders (rest of G7)
+
+1. **RBAC scoping.** v1 grants every principal the SAME capability as the root
+   token (admin-equivalent). Per-route capability scoping (read-only vs mutate vs
+   actuator) is the next slice — `AdminPrincipal` already carries the identity to
+   scope on.
+2. **Audit-chain attribution.** The principal is attached to the request
+   extension and logged; recording it on each SHA-256-chained audit row is a
+   follow-up.
+3. **TPM-bind the governor release-token signing key** (`tpm.rs` exists at the
+   fleet layer) — remove the in-process signing key.
+4. **TLS / mTLS on the verifier** — the bind is currently plaintext with
+   header-based identity.
+
+## 5. Test traceability
+
+| Property | Test (`security::g7_principal_token_tests`) |
+|---|---|
+| Parse forms; malformed dropped | `parse_keeps_wellformed_drops_malformed` |
+| Empty provided never matches | `resolve_empty_provided_never_matches` |
+| Root token → `Root` | `authorize_root_token_is_root_principal` |
+| Principal token → `Named(id)`; unknown denies | `authorize_principal_token_is_named_and_attributed` |
+| **Principal denied when root token absent/empty (no fail-open)** | `principal_token_denied_when_root_token_absent_or_empty` |

--- a/docs/safety/PRINCIPAL_TOKENS.md
+++ b/docs/safety/PRINCIPAL_TOKENS.md
@@ -43,7 +43,10 @@ The extension is **purely additive** and **cannot fail open**:
 2. **INVARIANT #2.** Every token comparison — root and per-principal — goes
    through `constant_time_compare`. `PrincipalRegistry::resolve` compares against
    **every** entry with no early-out, so a match does not leak its position by
-   timing.
+   timing. A token that matches the same id twice (overlapping-window rotation)
+   resolves to that id; a token that matches **multiple distinct** ids is an
+   ambiguous misconfiguration and **denies** (fail-closed — never a
+   non-deterministic audit identity).
 3. **Root path unchanged.** With `KIRRA_PRINCIPAL_TOKENS` unset the registry is
    empty and behavior is byte-identical to before (root-token-only).
 4. **INVARIANT #13.** The decision logic is pure and unit-tested without touching

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -27,7 +27,7 @@ use kirra_verifier::posture_cache::{now_ms, ServiceState, POSTURE_CACHE_TTL_MS};
 use kirra_verifier::posture_engine_v2::{
     resolve_posture_snapshot_silent, resolve_posture_with_reason, LockoutReason,
 };
-use kirra_verifier::security::{admin_token_ok, constant_time_compare};
+use kirra_verifier::security::{authorize_admin, constant_time_compare, PrincipalRegistry};
 use kirra_verifier::action_filter::{evaluate_action_claim, ActionClaim};
 use kirra_verifier::protocol_adapter::{
     evaluate_unified_industrial_request, UnifiedIndustrialRequest,
@@ -100,32 +100,58 @@ use startup::*;
 
 // --- Auth middleware ---------------------------------------------------------
 
-async fn require_admin_token(request: Request, next: Next) -> Result<Response, StatusCode> {
+/// Process-wide per-principal admin token registry (#G7), loaded once from
+/// `KIRRA_PRINCIPAL_TOKENS`. Lazy `OnceLock` (env is fixed at process start);
+/// malformed entries are dropped by the parser, so a bad config degrades to
+/// fewer principals, never a fail-open.
+fn principal_registry() -> &'static PrincipalRegistry {
+    static REGISTRY: std::sync::OnceLock<PrincipalRegistry> = std::sync::OnceLock::new();
+    REGISTRY.get_or_init(|| {
+        let reg = PrincipalRegistry::from_env();
+        if !reg.is_empty() {
+            tracing::info!(principals = reg.len(), "loaded per-principal admin tokens (#G7)");
+        }
+        reg
+    })
+}
+
+async fn require_admin_token(mut request: Request, next: Next) -> Result<Response, StatusCode> {
     let expected = std::env::var("KIRRA_ADMIN_TOKEN")
         .unwrap_or_default();
 
     // Fail-closed: absent or empty admin token → 503 (CRITICAL INVARIANT #1/#6).
     // Kept distinct from the 401 below so an unconfigured server is never
-    // mistaken for a bad credential.
+    // mistaken for a bad credential. This gate stays FIRST, so a per-principal
+    // token can never authorize without a configured root token (no fail-open).
     if expected.is_empty() {
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     }
 
+    // Own the token before the mutable borrow below (attaching the principal to
+    // the request extensions). The extra allocation on the admin path is trivial.
     let provided = request
         .headers()
         .get(header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.strip_prefix("Bearer "))
+        .map(str::to_owned)
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
-    // Single constant-time authorization decision (SG-015). `expected` is
-    // non-empty here, so this reduces to a constant_time_compare of the two
-    // tokens — behavior identical to the prior inline check, never `==`.
-    if !admin_token_ok(Some(provided), Some(&expected)) {
-        return Err(StatusCode::UNAUTHORIZED);
+    // Fail-closed authorization (#G7): the root KIRRA_ADMIN_TOKEN (constant-time,
+    // SG-015) OR a registered per-principal token. `expected` is non-empty here,
+    // so `authorize_admin` reduces to the prior admin_token_ok decision plus the
+    // additive principal-registry lookup; a `None` denies (401). The resolved
+    // principal is attached to the request extensions for audit attribution.
+    match authorize_admin(Some(&provided), Some(&expected), principal_registry()) {
+        Some(principal) => {
+            // Attribution (#G7): make the authenticated identity visible now (logs)
+            // and available to downstream handlers/audit via the request extension.
+            tracing::debug!(principal = principal.label(), "admin request authorized (#G7)");
+            request.extensions_mut().insert(principal);
+            Ok(next.run(request).await)
+        }
+        None => Err(StatusCode::UNAUTHORIZED),
     }
-
-    Ok(next.run(request).await)
 }
 
 // SG-008 (ASIL D) process fail-closed startup sentinel — `StartupContext`,

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -109,7 +109,7 @@ fn principal_registry() -> &'static PrincipalRegistry {
     REGISTRY.get_or_init(|| {
         let reg = PrincipalRegistry::from_env();
         if !reg.is_empty() {
-            tracing::info!(principals = reg.len(), "loaded per-principal admin tokens (#G7)");
+            tracing::info!(principal_tokens = reg.len(), "loaded per-principal admin tokens (#G7)");
         }
         reg
     })

--- a/src/security.rs
+++ b/src/security.rs
@@ -74,6 +74,155 @@ pub fn admin_token_ok(provided: Option<&str>, configured: Option<&str>) -> bool 
     constant_time_compare(provided.as_bytes(), configured.as_bytes())
 }
 
+/// Env var naming the per-principal admin tokens (#G7).
+pub const PRINCIPAL_TOKENS_ENV: &str = "KIRRA_PRINCIPAL_TOKENS";
+
+/// The authenticated caller identity resolved by the admin gate (#G7).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdminPrincipal {
+    /// Authenticated with the root `KIRRA_ADMIN_TOKEN`.
+    Root,
+    /// Authenticated with a registered per-principal token (carries its id, for
+    /// audit attribution).
+    Named(String),
+}
+
+impl AdminPrincipal {
+    /// A short, log/audit-safe label for the principal (never the token).
+    #[must_use]
+    pub fn label(&self) -> &str {
+        match self {
+            AdminPrincipal::Root => "root",
+            AdminPrincipal::Named(id) => id.as_str(),
+        }
+    }
+}
+
+/// A registry of per-principal admin-equivalent tokens (#G7 — key/identity
+/// lifecycle). It lets an operator issue, ROTATE, and REVOKE a token per
+/// principal — and attribute each mutation to a named identity — WITHOUT sharing
+/// the single root `KIRRA_ADMIN_TOKEN`, whose compromise otherwise exposes the
+/// whole admin+actuator surface.
+///
+/// **Purely additive & fail-closed.** The root token still authorizes exactly as
+/// before (INVARIANT #1/#6 unchanged), and a principal token NEVER authorizes
+/// unless a non-empty root token is also configured — [`authorize_admin`] denies
+/// before the registry is consulted when the root token is absent/empty, so this
+/// extension cannot fail open. v1 grants every principal the SAME capability as
+/// the root token (admin-equivalent); per-route RBAC scoping is a tracked
+/// follow-up.
+#[derive(Debug, Default, Clone)]
+pub struct PrincipalRegistry {
+    /// `(principal_id, token)` pairs. A `Vec` (not a map) so [`resolve`] compares
+    /// against EVERY entry with no early-out that could leak set membership by
+    /// timing. [`resolve`]: PrincipalRegistry::resolve
+    principals: Vec<(String, String)>,
+}
+
+impl PrincipalRegistry {
+    /// Load from `KIRRA_PRINCIPAL_TOKENS` (the process environment).
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::parse(std::env::var(PRINCIPAL_TOKENS_ENV).ok().as_deref())
+    }
+
+    /// Pure parser (the testable core of [`from_env`]). Entries are
+    /// `principal_id=token`, separated by commas, semicolons, or newlines and
+    /// trimmed of surrounding whitespace. An entry with no `=`, an empty id, or an
+    /// empty token is IGNORED — never a usable credential (fail-closed against
+    /// malformed config). Duplicate ids are allowed (each token is independently
+    /// valid, which supports overlapping-window rotation).
+    #[must_use]
+    pub fn parse(spec: Option<&str>) -> Self {
+        let mut principals = Vec::new();
+        if let Some(spec) = spec {
+            for entry in spec.split([',', ';', '\n']) {
+                let entry = entry.trim();
+                if entry.is_empty() {
+                    continue;
+                }
+                // Split on the FIRST '=' only — tokens may themselves contain '='.
+                let Some((id, token)) = entry.split_once('=') else {
+                    continue; // no '=' → not a principal=token pair
+                };
+                let id = id.trim();
+                let token = token.trim();
+                if id.is_empty() || token.is_empty() {
+                    continue; // empty id or token is never a credential
+                }
+                principals.push((id.to_string(), token.to_string()));
+            }
+        }
+        Self { principals }
+    }
+
+    /// Number of registered principals.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.principals.len()
+    }
+
+    /// Is the registry empty (no per-principal tokens configured)?
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.principals.is_empty()
+    }
+
+    /// Constant-time resolve: return the principal id whose token matches
+    /// `provided`, comparing against EVERY entry via [`constant_time_compare`]
+    /// with NO early-out (so a match does not leak its position by timing).
+    /// `None` if nothing matches. Parse forbids empty tokens, so an empty
+    /// `provided` can never match.
+    #[must_use]
+    pub fn resolve(&self, provided: &str) -> Option<&str> {
+        let mut matched: Option<&str> = None;
+        for (id, token) in &self.principals {
+            // Deliberately no `break` — evaluate all entries in constant work.
+            if constant_time_compare(provided.as_bytes(), token.as_bytes()) {
+                matched = Some(id.as_str());
+            }
+        }
+        matched
+    }
+}
+
+/// Fail-closed admin authorization (#G7) — the single decision the
+/// `require_admin_token` middleware gates on, extending [`admin_token_ok`] with
+/// the per-principal [`PrincipalRegistry`].
+///
+/// Returns `Some(principal)` (allow, with attribution) ONLY when a non-empty root
+/// admin token is configured AND the provided bearer either matches the root
+/// token OR a registered principal token. Every other case denies (`None`):
+///   - configured root token absent/empty → `None` (caller → HTTP 503; INV #1/#6),
+///   - provided absent                    → `None` (401),
+///   - no match in root or registry       → `None` (401).
+///
+/// The root token is authorized via `admin_token_ok` FIRST; the registry is only
+/// consulted when a non-empty root token IS configured, so a principal token can
+/// never authorize without a root token — this extension cannot fail open.
+//
+// Verifies: SG-015 (extended)
+#[must_use]
+pub fn authorize_admin(
+    provided: Option<&str>,
+    configured_admin: Option<&str>,
+    registry: &PrincipalRegistry,
+) -> Option<AdminPrincipal> {
+    // Root token path — the exact fail-closed predicate (INV #1/#2/#6).
+    if admin_token_ok(provided, configured_admin) {
+        return Some(AdminPrincipal::Root);
+    }
+    // Principal tokens are additive and ONLY valid when a non-empty root token is
+    // configured. If the root token is absent/empty, deny here — never fall
+    // through to the registry (that would be a fail-open with no root configured).
+    match configured_admin {
+        Some(c) if !c.is_empty() => {}
+        _ => return None,
+    }
+    let provided = provided?;
+    registry.resolve(provided).map(|id| AdminPrincipal::Named(id.to_string()))
+}
+
 pub struct AdministrativeKeyContainer {
     private_auth_key: Vec<u8>,
 }
@@ -169,5 +318,88 @@ mod sg_015_admin_token_tests {
             "tokens differing only past byte 64 must NOT compare equal");
         assert!(constant_time_compare(a.as_bytes(), a.as_bytes()),
             "an identical >64-byte token must still compare equal");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #G7 — per-principal admin tokens (rotation / revocation / attribution)
+// ---------------------------------------------------------------------------
+//
+// The registry and `authorize_admin` are pure (INVARIANT #13 — no env in the
+// multithreaded test runner; env is read only by the thin `from_env` wrapper).
+// The LOAD-BEARING invariant these pin: a per-principal token can NEVER authorize
+// when the root KIRRA_ADMIN_TOKEN is absent/empty (INV #1/#6 preserved — no
+// fail-open), and the root token still authorizes exactly as before.
+#[cfg(test)]
+mod g7_principal_token_tests {
+    use super::{authorize_admin, AdminPrincipal, PrincipalRegistry};
+
+    fn registry() -> PrincipalRegistry {
+        PrincipalRegistry::parse(Some("alice=alice-token, bob = bob-token ;carol=carol=eq"))
+    }
+
+    #[test]
+    fn parse_keeps_wellformed_drops_malformed() {
+        let r = registry();
+        assert_eq!(r.len(), 3, "alice, bob, carol are well-formed");
+        assert_eq!(r.resolve("alice-token"), Some("alice"));
+        assert_eq!(r.resolve("bob-token"), Some("bob"), "surrounding whitespace trimmed");
+        assert_eq!(r.resolve("carol=eq"), Some("carol"), "only the FIRST '=' splits id from token");
+        assert_eq!(r.resolve("nope"), None);
+
+        // Malformed entries are dropped (never a usable credential).
+        let bad = PrincipalRegistry::parse(Some("no-equals, =empty-id, empty-token=, ,  "));
+        assert!(bad.is_empty(), "no '=', empty id, and empty token are all dropped");
+        assert_eq!(PrincipalRegistry::parse(None).len(), 0);
+    }
+
+    #[test]
+    fn resolve_empty_provided_never_matches() {
+        assert_eq!(registry().resolve(""), None, "parse forbids empty tokens, so '' matches nothing");
+    }
+
+    #[test]
+    fn authorize_root_token_is_root_principal() {
+        let r = registry();
+        assert_eq!(
+            authorize_admin(Some("root-secret"), Some("root-secret"), &r),
+            Some(AdminPrincipal::Root)
+        );
+    }
+
+    #[test]
+    fn authorize_principal_token_is_named_and_attributed() {
+        let r = registry();
+        assert_eq!(
+            authorize_admin(Some("bob-token"), Some("root-secret"), &r),
+            Some(AdminPrincipal::Named("bob".to_string())),
+            "a registered principal token authorizes and is attributed to its id"
+        );
+        assert_eq!(
+            authorize_admin(Some("unknown-token"), Some("root-secret"), &r),
+            None,
+            "an unregistered token denies"
+        );
+        assert_eq!(authorize_admin(None, Some("root-secret"), &r), None, "no bearer denies");
+    }
+
+    /// THE load-bearing #G7 invariant (INV #1/#6): with NO root admin token
+    /// configured, a valid PRINCIPAL token must STILL be denied — the whole admin
+    /// surface is 503 without the root token, and the registry can never fail open.
+    #[test]
+    fn principal_token_denied_when_root_token_absent_or_empty() {
+        let r = registry();
+        assert_eq!(
+            authorize_admin(Some("bob-token"), None, &r),
+            None,
+            "no root token configured → a principal token must NOT authorize (INV #6)"
+        );
+        assert_eq!(
+            authorize_admin(Some("bob-token"), Some(""), &r),
+            None,
+            "empty root token → a principal token must NOT authorize (INV #6)"
+        );
+        // And the root token itself is still denied when unconfigured.
+        assert_eq!(authorize_admin(Some("anything"), None, &r), None);
     }
 }

--- a/src/security.rs
+++ b/src/security.rs
@@ -156,7 +156,8 @@ impl PrincipalRegistry {
         Self { principals }
     }
 
-    /// Number of registered principals.
+    /// Number of registered principal-token ENTRIES (duplicates allowed for
+    /// overlapping-window rotation, so this is a count of tokens, not unique ids).
     #[must_use]
     pub fn len(&self) -> usize {
         self.principals.len()
@@ -171,18 +172,33 @@ impl PrincipalRegistry {
     /// Constant-time resolve: return the principal id whose token matches
     /// `provided`, comparing against EVERY entry via [`constant_time_compare`]
     /// with NO early-out (so a match does not leak its position by timing).
+    ///
     /// `None` if nothing matches. Parse forbids empty tokens, so an empty
-    /// `provided` can never match.
+    /// `provided` can never match. A token that matches the SAME id more than once
+    /// (overlapping-window rotation) resolves to that id; a token that matches
+    /// MULTIPLE DISTINCT ids is a misconfiguration whose attribution would be
+    /// ambiguous, so it is treated as **deny** (`None`) — fail-closed, never a
+    /// non-deterministic audit identity (Copilot #802).
     #[must_use]
     pub fn resolve(&self, provided: &str) -> Option<&str> {
         let mut matched: Option<&str> = None;
+        let mut ambiguous = false;
         for (id, token) in &self.principals {
             // Deliberately no `break` — evaluate all entries in constant work.
             if constant_time_compare(provided.as_bytes(), token.as_bytes()) {
-                matched = Some(id.as_str());
+                match matched {
+                    None => matched = Some(id.as_str()),
+                    // Same id repeated (rotation) is fine; a DISTINCT id is ambiguous.
+                    Some(prev) if prev != id.as_str() => ambiguous = true,
+                    Some(_) => {}
+                }
             }
         }
-        matched
+        if ambiguous {
+            None
+        } else {
+            matched
+        }
     }
 }
 
@@ -356,6 +372,20 @@ mod g7_principal_token_tests {
     #[test]
     fn resolve_empty_provided_never_matches() {
         assert_eq!(registry().resolve(""), None, "parse forbids empty tokens, so '' matches nothing");
+    }
+
+    #[test]
+    fn same_id_rotation_resolves_but_distinct_id_collision_denies() {
+        // Overlapping-window rotation: SAME id, two tokens → both resolve to the id.
+        let rot = PrincipalRegistry::parse(Some("alice=old-tok, alice=new-tok"));
+        assert_eq!(rot.resolve("old-tok"), Some("alice"));
+        assert_eq!(rot.resolve("new-tok"), Some("alice"));
+
+        // Misconfiguration: the SAME token for DISTINCT ids → ambiguous attribution
+        // → deny (fail-closed, Copilot #802). A unique token still resolves.
+        let collide = PrincipalRegistry::parse(Some("alice=shared, bob=shared, carol=carol-tok"));
+        assert_eq!(collide.resolve("shared"), None, "a token mapping to 2 ids must deny");
+        assert_eq!(collide.resolve("carol-tok"), Some("carol"), "unambiguous tokens still resolve");
     }
 
     #[test]


### PR DESCRIPTION
First slice of the highest-ROI remaining gap-analysis item (**G7 — key/identity lifecycle**). Touches the auth path, so it is deliberately **additive and fail-closed**: the critical invariants (INV-1/2/6/13) are preserved exactly.

## The gap
The admin+actuator surface was gated by a **single shared bearer token** (`KIRRA_ADMIN_TOKEN`). Its compromise exposes everything; it can't be rotated/revoked per-holder; every mutation is attributed to one anonymous credential.

## What this slice adds
An operator can issue a **named token per principal** — rotate/revoke one without disturbing the others, and attribute each admin mutation to a named identity — **without sharing** the root token.

Pure primitive in `src/security.rs`:
- `PrincipalRegistry` — `(principal_id, token)` set from `KIRRA_PRINCIPAL_TOKENS` (`from_env`/`parse`). First `=` splits id from token; malformed entries dropped.
- `authorize_admin(provided, configured_admin, registry) -> Option<AdminPrincipal>` — the single fail-closed decision the `require_admin_token` middleware gates on.
- `AdminPrincipal::{Root, Named(id)}` — resolved identity, attached to the request extensions + logged for attribution.

## Cannot fail open — invariants preserved
- **INV-1/6**: `require_admin_token` still **503s** when `KIRRA_ADMIN_TOKEN` is absent/empty, as the **first** check — *before* the registry is consulted. A per-principal token **never** authorizes without a configured root token (pinned by `principal_token_denied_when_root_token_absent_or_empty`).
- **INV-2**: every comparison (root + per-principal) goes through `constant_time_compare`; `resolve()` compares against **every** entry with no early-out (a match doesn't leak its position by timing).
- **INV-13**: the decision logic is pure and unit-tested **without env mutation** (env is read only by the thin `from_env` wrapper), mirroring the sibling `admin_token_ok` (SG-015).
- With `KIRRA_PRINCIPAL_TOKENS` unset the registry is empty → **byte-identical** to prior root-token-only behavior.

## Tests
5 new pure `security` tests: parse/malformed-drop, constant-time resolve, root-vs-named attribution, and the **load-bearing** no-fail-open-without-root-token case. Existing 6 SG-015 admin-token tests + all **79** binary tests green; clippy clean.

## Tracked remainders of G7 (`docs/safety/PRINCIPAL_TOKENS.md` §4)
- Per-route **RBAC scoping** (`AdminPrincipal` already carries the identity to scope on).
- **Audit-chain attribution** (principal is attached + logged now; recording it on each hash-chained row is next).
- **TPM-bind** the governor release-token signing key (`tpm.rs` exists at the fleet layer).
- **TLS/mTLS** on the verifier bind.

*(The `Cargo.lock` delta is the root lockfile catching up to #801's merged `parko-core` `sha2`/`hex` deps — no new root dependencies.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_