### PR TITLE
authz: per-principal API tokens & scoped RBAC (WS-1 #G7, first PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,20 @@ detail lives in `docs/adr/`, `docs/safety/`, and the PR history:
     `parko/Cargo.lock` is now committed.
   - WS-0.7 — this changelog, the versioning/MSRV/deprecation policy, and
     the fail-instead-of-fallback release-notes rule.
+- **WS-1 (#G7) — per-principal API tokens & scoped RBAC (first PR).** A new
+  `api_principals` registry (`POST/GET /system/principals`,
+  `POST /system/principals/{id}/revoke`, admin-scoped) mints least-privilege
+  bearer tokens across four roles (`admin` / `integrator` / `auditor` /
+  `operator`). The gated route groups now terminate in a scope layer
+  (`src/authz.rs`, `authorize_request`): the identity/integration surface,
+  the actuator command, and a NEW read-only `auditor_routes` carve-out
+  (audit verify / causal-verify / export) each admit their scoped role in
+  addition to the admin token. Tokens are stored ONLY as their SHA-256 (looked
+  up by hash, never plaintext); the plaintext is shown once at mint.
+  `KIRRA_ADMIN_TOKEN` is RETAINED as the break-glass superuser and its
+  fail-closed 503-when-absent root gate is unchanged (INVARIANT #1/#6), so an
+  admin-token-only deployment is byte-compatible. (TLS/mTLS and TPM-bound
+  signing-key rotation are the follow-up WS-1 PRs.)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,8 @@ src/
 ├── action_filter.rs          — ActionFilter<C>, ActionClaim, evaluate_action_claim
 ├── action_policy.rs          — UnstructuredTextParser (LLM JSON → typed AgentAction)
 ├── security.rs               — constant_time_compare
+├── authz.rs                  — WS-1 (#G7) RBAC: ApiRole, scopes, authorize_request
+│                               (pure fail-closed decision; store/env lifted out)
 ├── protocol_adapter.rs       — Modbus/OPC-UA industrial event mapping
 ├── kirra_core.rs             — KirraKernelGovernor (scalar clamping, rate limiting)
 ├── ros2_adapter.rs           — NaN/Inf rejection before ROS2 publish
@@ -158,6 +160,7 @@ src/
 | `trusted_federation_controllers` | Ed25519 public key registry |
 | `federation_report_nonces` | Burned nonces (replay prevention) |
 | `attestation_identity_registry` | Hardware fingerprint (AK public key digest) per node |
+| `api_principals` | WS-1 (#G7) per-principal scoped API tokens (SHA-256 hash + role; plaintext never stored) |
 
 ---
 
@@ -229,19 +232,39 @@ pass that fits the corridor, rejects one that doesn't or a misaligned straight-t
 
 ## Route Authorization Matrix
 
-### Tier 1 — Identity-gated (admin token + `x-kirra-client-id` header)
+**WS-1 (#G7) scoped RBAC.** Each gated group requires a SCOPE, satisfied by EITHER
+the break-glass `KIRRA_ADMIN_TOKEN` (Admin holds every scope — the tiers below are
+back-compatible) OR a per-principal API token (`api_principals`; role ∈
+{`admin`,`integrator`,`auditor`,`operator`}) whose role holds that scope. The gate
+is `authz::authorize_request` (`src/authz.rs`); `require_admin_token` is preserved as
+the `SCOPE_ADMIN` specialization (INVARIANT #1/#6 unchanged: absent/empty root → 503).
+Mint/manage principals via the admin-scoped `POST/GET /system/principals` +
+`POST /system/principals/{id}/revoke` (token returned once at mint; stored only as
+its SHA-256).
+
+### Tier 1 — Identity-gated (`SCOPE_INTEGRATION_EVALUATE` + `x-kirra-client-id` header)
+Admin token or an `integrator`-role principal.
 - `GET  /system/posture/stream` — SSE broadcast of posture events
 - `POST /federation/reports/submit` — Submit signed federated trust report
 - `POST /action_filter/evaluate` — Evaluate action claim against posture
 - `POST /industrial/evaluate` — Evaluate Modbus/OPC-UA industrial event
 
-### Tier 2 — Admin-only (Bearer `KIRRA_ADMIN_TOKEN`)
+### Tier 2 — Admin (`SCOPE_ADMIN`; Bearer `KIRRA_ADMIN_TOKEN` or `admin`-role principal)
 - `POST /attestation/register` — Register a node
 - `POST /fleet/dependencies` — Register dependency graph edges
-- `POST /system/backup/export` — Full state dump
-- `GET  /system/audit/verify` — Verify audit chain integrity
+- `POST /system/backup/export` — Full state dump (admin-only; NOT in the auditor tier)
+- `POST /system/audit/rotate-signing-key` — Rotate the audit signing key
+- `POST/GET /system/principals`, `POST /system/principals/{id}/revoke` — API principal registry
 - `POST /federation/controllers/register` — Register trusted peer controller
 - `POST /attestation/identity/register` — Register hardware fingerprint
+
+### Tier 2a — Auditor read-only (`SCOPE_AUDIT_READ`; admin token or `auditor`-role principal)
+- `GET  /system/audit/verify` — Verify audit chain integrity
+- `GET  /system/audit/causal/verify` — Verify the fabric causal chain
+- `GET  /system/audit/export` — Export the audit chain (read-only; no mutation rights)
+
+### Tier 2b — Actuator (`SCOPE_ACTUATOR_COMMAND`; admin token or `operator`-role principal)
+- `POST /actuator/motion/command` — behind the decel safety envelope + posture gate
 
 ### Unauthenticated (challenge-response provides its own guarantee)
 - `POST /attestation/challenge/:node_id`

--- a/docs/safety/SECURITY_BOUNDARIES.md
+++ b/docs/safety/SECURITY_BOUNDARIES.md
@@ -16,25 +16,53 @@ CLAUDE.md "Route Authorization Matrix".
 `constant_time_compare` (never `==`). The check is the pure predicate
 `security::admin_token_ok`, unit-tested in `src/security.rs` mod `sg_015_admin_token_tests`.
 
+> **WS-1 (#G7) update — scoped RBAC layered on top, admin root preserved.** The
+> gate is now the unified `authorize_scope` predicate (`src/authz.rs`,
+> `authorize_request`). `require_admin_token` is PRESERVED by name and role as the
+> `SCOPE_ADMIN` specialization (INVARIANT #1/#6 verbatim: absent/empty root →
+> 503; the admin token is compared constant-time). It is only ever a STRICT
+> SUPERSET: a per-principal API token (`api_principals` table; role ∈
+> {`admin`,`integrator`,`auditor`,`operator`}) may ADDITIONALLY authorize a route
+> whose scope its role holds. Absent/empty `KIRRA_ADMIN_TOKEN` still fail-closes
+> the WHOLE surface to 503 regardless of principals — principals never substitute
+> for the root. Decision truth-table: `authz::tests`; store↔authz composition:
+> `tests/authz_rbac.rs`; router wiring fail-closed: `posture_gate_real_router_tests
+> ::ws1_scope_gated_routes_fail_closed_on_real_router`.
+
 ### Gated mutation routes
 
-Each of the following route groups applies `middleware::from_fn(require_admin_token)`
-(verified on `cert/rtm-gap-closure`, `src/bin/kirra_verifier_service.rs`):
+Each route group terminates in a scope layer (WS-1: `middleware::from_fn_with_state
+(svc, require_<scope>)`; the admin group keeps `require_admin_token`). Every scope
+is satisfied by the break-glass admin token (Admin holds all scopes), so an
+admin-token-only deployment is unchanged:
 
-- **identity/industrial group** (`identity_gated_routes`, layered at the `.layer(...require_admin_token)`
-  after the route list; additionally gated by `require_client_identity`):
+- **identity/industrial group** (`identity_gated_routes`, `SCOPE_INTEGRATION_EVALUATE`
+  via `require_integration_scope`; additionally gated by `require_client_identity`):
   `/federation/reports/submit`, `/action_filter/evaluate`, `/industrial/evaluate`,
   `/industrial/ethernet-ip/evaluate`, `/industrial/canopen/evaluate`,
-  `/industrial/dnp3/evaluate` (and the `/system/posture/stream` SSE).
-- **admin group** (`admin_routes`): `/attestation/register`, `/fleet/dependencies`,
-  `/fleet/diagnostics/report`, `/fleet/assets/register`, `/system/backup/export`,
+  `/industrial/dnp3/evaluate` (and the `/system/posture/stream` SSE). Admin token or
+  an `integrator`-role principal.
+- **admin group** (`admin_routes`, `SCOPE_ADMIN` via `require_admin_token`):
+  `/attestation/register`, `/fleet/dependencies`, `/fleet/diagnostics/report`,
+  `/fleet/assets/register`, `/system/backup/export`,
   `/system/audit/rotate-signing-key`, `/federation/controllers/register`,
   `/attestation/identity/register`, `/fabric/assets/register`,
-  `/fabric/command/{asset_id}`. (The same layer additionally gates the admin GET
-  reads — `/system/audit/verify`, `/system/audit/export`, `/fabric/assets`,
-  `/fabric/state`, `/fabric/telemetry[/{asset_id}]`, `/fabric/causal-log[/{entry_id}]`
-  — so they are admin-only too, beyond the mutation set this claim is about.)
-- **actuator group** (`actuator_routes`): `/actuator/motion/command`.
+  `/fabric/command/{asset_id}`, and the WS-1 API-principal registry
+  (`POST/GET /system/principals`, `POST /system/principals/{principal_id}/revoke`).
+  (The same layer additionally gates the admin GET reads — `/fabric/assets`,
+  `/fabric/state`, `/fabric/telemetry[/{asset_id}]`, `/fabric/causal-log[/{entry_id}]`,
+  `/fleet/av-subsystems` — so they are admin-only too.) Admin token or an
+  `admin`-role principal.
+- **auditor group** (`auditor_routes`, `SCOPE_AUDIT_READ` via `require_audit_scope`) —
+  WS-1 carve-out of the read-only audit surface for a least-privilege auditor:
+  `/system/audit/verify`, `/system/audit/causal/verify`, `/system/audit/export`.
+  Admin token or an `auditor`-role principal (NO mutation rights). The full-state
+  `/system/backup/export` dump and the `rotate-signing-key` mutation deliberately
+  stay in the admin group.
+- **actuator group** (`actuator_routes`, `SCOPE_ACTUATOR_COMMAND` via
+  `require_actuator_scope`; auth outermost, then the inner safety envelope):
+  `/actuator/motion/command`. Admin token or an `operator`-role principal — the
+  envelope and the posture gate independently bound WHAT command is accepted.
 
 ### Deliberate carve-out — the attestation handshake (NOT a bypass)
 
@@ -74,12 +102,15 @@ handlers, this carve-out must be re-evaluated.**
 ### Verification (this branch)
 
 Router wiring confirmed in `src/bin/kirra_verifier_service.rs`: `identity_gated_routes`,
-`admin_routes`, and `actuator_routes` each terminate in
-`.layer(middleware::from_fn(require_admin_token))`; `attestation_routes` (the two handshake
-POSTs) is constructed and merged with **no** such layer. The gate predicate
-`security::admin_token_ok` uses `constant_time_compare` (never `==`) and is unit-tested in
-`src/security.rs` mod `sg_015_admin_token_tests` (absent/empty configured → deny;
-absent/mismatched provided → deny; exact token → allow).
+`admin_routes`, `auditor_routes`, and `actuator_routes` each terminate in a
+`.layer(middleware::from_fn_with_state(svc, require_<scope>))` scope layer (the admin
+group's is `require_admin_token`, the `SCOPE_ADMIN` specialization); `attestation_routes`
+(the two handshake POSTs) is constructed and merged with **no** such layer. The root
+predicate `security::admin_token_ok` still uses `constant_time_compare` (never `==`) and is
+unit-tested in `src/security.rs` mod `sg_015_admin_token_tests`; the RBAC layer above it is
+the pure `authz::authorize_request` (`src/authz.rs`), unit-tested in `authz::tests` and
+composed against a real store in `tests/authz_rbac.rs`. Per-principal tokens are stored ONLY
+as their SHA-256 (`api_principals.token_sha256`, UNIQUE), resolved by hash — never plaintext.
 
 ---
 

--- a/src/authz.rs
+++ b/src/authz.rs
@@ -1,0 +1,389 @@
+// src/authz.rs
+//
+// WS-1 · G7 — per-principal API tokens, roles, and scoped authorization.
+//
+// This module is the PURE authorization core: role→scope RBAC and the single
+// fail-closed decision predicate `authorize_request`. It reads NO process env and
+// touches NO store — exactly like `security::admin_token_ok`, the env (the
+// `KIRRA_ADMIN_TOKEN` root) and the store (the per-principal token lookup) are
+// lifted out to the calling middleware, so the decision truth-table is unit-tested
+// without `set_var` (CRITICAL SECURITY INVARIANT #13 forbids it in the parallel
+// test runner).
+//
+// Trust model (invariants preserved):
+//   * The shared `KIRRA_ADMIN_TOKEN` is the ROOT of the mutation gate and is
+//     RETAINED as a break-glass superuser (all scopes). Absent/empty → 503,
+//     unconditionally, regardless of principals (INVARIANT #1/#6, verbatim). A
+//     per-principal token only ADDS least-privilege capability on top of a
+//     configured admin root; it never substitutes for it.
+//   * A per-principal token is compared by HASHED lookup (SHA-256), never `==` on
+//     the raw secret; the root admin token still goes through the constant-time
+//     `admin_token_ok` (INVARIANT #2).
+
+use crate::security::admin_token_ok;
+
+/// API principal roles (least-privilege RBAC). Each role holds a fixed scope set;
+/// a scoped principal token replaces sharing the root admin token for a whole
+/// class of callers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiRole {
+    /// Superuser — every scope. The break-glass `KIRRA_ADMIN_TOKEN` resolves to
+    /// this role.
+    Admin,
+    /// The integration surface: action-filter / industrial / federation-submit /
+    /// posture-stream (`identity_gated_routes`).
+    Integrator,
+    /// Read-only audit access: audit-chain verify / causal-verify / export.
+    Auditor,
+    /// Actuator command submission (`/actuator/motion/command`).
+    Operator,
+}
+
+// --- Scope constants — one per gated route GROUP in `build_app`. -------------
+/// Full admin mutation surface (`admin_routes`). Only [`ApiRole::Admin`] holds it.
+pub const SCOPE_ADMIN: &str = "admin";
+/// The identity-gated integration surface (`identity_gated_routes`).
+pub const SCOPE_INTEGRATION_EVALUATE: &str = "integration:evaluate";
+/// Actuator motion command submission (`actuator_routes`).
+pub const SCOPE_ACTUATOR_COMMAND: &str = "actuator:command";
+/// Read-only audit-chain verification / export (`auditor_routes`).
+pub const SCOPE_AUDIT_READ: &str = "audit:read";
+
+impl ApiRole {
+    /// The wire/DB string for this role.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ApiRole::Admin => "admin",
+            ApiRole::Integrator => "integrator",
+            ApiRole::Auditor => "auditor",
+            ApiRole::Operator => "operator",
+        }
+    }
+
+    /// Parse a role string, fail-closed: an unknown/corrupt value yields `None`
+    /// (the caller then denies — a garbled DB role never authorizes).
+    #[must_use]
+    pub fn parse_role(s: &str) -> Option<ApiRole> {
+        match s {
+            "admin" => Some(ApiRole::Admin),
+            "integrator" => Some(ApiRole::Integrator),
+            "auditor" => Some(ApiRole::Auditor),
+            "operator" => Some(ApiRole::Operator),
+            _ => None,
+        }
+    }
+
+    /// The fixed scope set this role holds.
+    #[must_use]
+    pub fn scopes(self) -> &'static [&'static str] {
+        match self {
+            ApiRole::Admin => &[
+                SCOPE_ADMIN,
+                SCOPE_INTEGRATION_EVALUATE,
+                SCOPE_ACTUATOR_COMMAND,
+                SCOPE_AUDIT_READ,
+            ],
+            ApiRole::Integrator => &[SCOPE_INTEGRATION_EVALUATE],
+            ApiRole::Auditor => &[SCOPE_AUDIT_READ],
+            ApiRole::Operator => &[SCOPE_ACTUATOR_COMMAND],
+        }
+    }
+
+    /// True iff this role holds `scope`.
+    #[must_use]
+    pub fn has_scope(self, scope: &str) -> bool {
+        self.scopes().contains(&scope)
+    }
+}
+
+/// The store lookup result for a presented API token (resolved by its hash).
+/// Lifted out of [`authorize_request`] so the decision needs no store — the
+/// middleware does the `load_api_principal_by_token_hash` and fills this in.
+#[derive(Debug, Clone)]
+pub struct ResolvedPrincipal {
+    pub principal_id: String,
+    /// `None` = the stored role string did not parse (corrupt) → fail-closed deny.
+    pub role: Option<ApiRole>,
+    /// `true` = a revoked credential; treated as unauthenticated (not a valid token).
+    pub revoked: bool,
+}
+
+/// The authorization outcome; the middleware maps each to an HTTP status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthzOutcome {
+    /// Authorized — continue.
+    Allow,
+    /// `KIRRA_ADMIN_TOKEN` absent/empty → server unconfigured. HTTP 503
+    /// (INVARIANT #1/#6, verbatim — never fail-open).
+    Unconfigured,
+    /// No / unknown / revoked credential. HTTP 401.
+    Unauthenticated,
+    /// Authenticated principal that lacks the required scope. HTTP 403.
+    Forbidden,
+}
+
+/// The full decision, carrying the attribution the middleware logs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthzDecision {
+    pub outcome: AuthzOutcome,
+    /// `"admin-token"` (break-glass root) | `"api-principal"` | `"none"`.
+    pub auth_method: &'static str,
+    pub principal_id: Option<String>,
+    pub role: Option<ApiRole>,
+}
+
+impl AuthzDecision {
+    fn deny(outcome: AuthzOutcome, auth_method: &'static str) -> Self {
+        AuthzDecision { outcome, auth_method, principal_id: None, role: None }
+    }
+}
+
+/// THE fail-closed authorization predicate. Pure: no env, no store.
+///
+/// Precedence (each step denies unless it can positively authorize):
+/// 1. `admin_configured` absent/empty → `Unconfigured` (503), regardless of
+///    everything else — the admin token is the gate's root (INVARIANT #1/#6).
+/// 2. no bearer token → `Unauthenticated` (401).
+/// 3. bearer equals the root admin token (constant-time) → `Allow` as
+///    [`ApiRole::Admin`] (break-glass; back-compat: an admin-token-only deployment
+///    is byte-identical).
+/// 4. otherwise the `principal` (resolved by token hash) decides:
+///    revoked → 401; role holds `required_scope` → `Allow`; role lacks it → 403
+///    (Forbidden); unknown token / corrupt role → 401.
+#[must_use]
+pub fn authorize_request(
+    required_scope: &str,
+    admin_configured: Option<&str>,
+    provided_token: Option<&str>,
+    principal: Option<&ResolvedPrincipal>,
+) -> AuthzDecision {
+    // 1. Fail-closed root check — the admin token gates the whole surface.
+    let admin = match admin_configured {
+        Some(c) if !c.is_empty() => c,
+        _ => return AuthzDecision::deny(AuthzOutcome::Unconfigured, "none"),
+    };
+
+    // 2. A configured server with no presented credential → 401.
+    let provided = match provided_token {
+        Some(p) => p,
+        None => return AuthzDecision::deny(AuthzOutcome::Unauthenticated, "none"),
+    };
+
+    // 3. Break-glass root admin token → Admin (all scopes). Constant-time (#2).
+    if admin_token_ok(Some(provided), Some(admin)) {
+        return AuthzDecision {
+            outcome: AuthzOutcome::Allow,
+            auth_method: "admin-token",
+            principal_id: None,
+            role: Some(ApiRole::Admin),
+        };
+    }
+
+    // 4. Scoped per-principal token (looked up by hash by the caller).
+    match principal {
+        // A revoked credential is not a valid token.
+        Some(p) if p.revoked => AuthzDecision {
+            outcome: AuthzOutcome::Unauthenticated,
+            auth_method: "api-principal",
+            principal_id: Some(p.principal_id.clone()),
+            role: p.role,
+        },
+        Some(p) => match p.role {
+            Some(role) if role.has_scope(required_scope) => AuthzDecision {
+                outcome: AuthzOutcome::Allow,
+                auth_method: "api-principal",
+                principal_id: Some(p.principal_id.clone()),
+                role: Some(role),
+            },
+            // Authenticated but under-scoped → 403 (distinct from 401 so an
+            // operator can tell "wrong token" from "insufficient privilege").
+            Some(role) => AuthzDecision {
+                outcome: AuthzOutcome::Forbidden,
+                auth_method: "api-principal",
+                principal_id: Some(p.principal_id.clone()),
+                role: Some(role),
+            },
+            // Corrupt/unknown stored role → fail-closed deny.
+            None => AuthzDecision {
+                outcome: AuthzOutcome::Unauthenticated,
+                auth_method: "api-principal",
+                principal_id: Some(p.principal_id.clone()),
+                role: None,
+            },
+        },
+        // Bearer present, not the admin token, and no principal holds its hash.
+        None => AuthzDecision::deny(AuthzOutcome::Unauthenticated, "none"),
+    }
+}
+
+/// SHA-256 hex of an API token — the value STORED and looked up. The plaintext
+/// token is shown once at mint and never persisted.
+#[must_use]
+pub fn token_sha256_hex(token: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(token.as_bytes());
+    hex::encode(h.finalize())
+}
+
+/// A short, stable fingerprint of a token for audit/log attribution WITHOUT
+/// recording the token — the first 8 bytes of its SHA-256 (matches the
+/// `admin_token_fingerprint` shape used elsewhere).
+#[must_use]
+pub fn token_fingerprint(token: &str) -> String {
+    token_sha256_hex(token)[..16].to_string()
+}
+
+/// Mint a fresh 256-bit API token, hex-encoded (64 chars), from the OS CSPRNG.
+#[must_use]
+pub fn generate_api_token() -> String {
+    let mut bytes = [0u8; 32];
+    getrandom::fill(&mut bytes)
+        .expect("OS CSPRNG (getrandom) unavailable — cannot mint a secure API token");
+    hex::encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn principal(id: &str, role: ApiRole, revoked: bool) -> ResolvedPrincipal {
+        ResolvedPrincipal { principal_id: id.into(), role: Some(role), revoked }
+    }
+
+    // --- RBAC matrix ---------------------------------------------------------
+
+    #[test]
+    fn admin_holds_every_scope() {
+        for s in [
+            SCOPE_ADMIN,
+            SCOPE_INTEGRATION_EVALUATE,
+            SCOPE_ACTUATOR_COMMAND,
+            SCOPE_AUDIT_READ,
+        ] {
+            assert!(ApiRole::Admin.has_scope(s), "admin must hold {s}");
+        }
+    }
+
+    #[test]
+    fn non_admin_roles_are_least_privilege() {
+        assert!(ApiRole::Integrator.has_scope(SCOPE_INTEGRATION_EVALUATE));
+        assert!(!ApiRole::Integrator.has_scope(SCOPE_ADMIN));
+        assert!(!ApiRole::Integrator.has_scope(SCOPE_ACTUATOR_COMMAND));
+        assert!(!ApiRole::Integrator.has_scope(SCOPE_AUDIT_READ));
+
+        assert!(ApiRole::Auditor.has_scope(SCOPE_AUDIT_READ));
+        assert!(!ApiRole::Auditor.has_scope(SCOPE_ADMIN));
+
+        assert!(ApiRole::Operator.has_scope(SCOPE_ACTUATOR_COMMAND));
+        assert!(!ApiRole::Operator.has_scope(SCOPE_ADMIN));
+    }
+
+    #[test]
+    fn role_string_round_trips_and_rejects_unknown() {
+        for r in [ApiRole::Admin, ApiRole::Integrator, ApiRole::Auditor, ApiRole::Operator] {
+            assert_eq!(ApiRole::parse_role(r.as_str()), Some(r));
+        }
+        assert_eq!(ApiRole::parse_role("superuser"), None);
+        assert_eq!(ApiRole::parse_role(""), None);
+        assert_eq!(ApiRole::parse_role("Admin"), None, "role match is case-sensitive");
+    }
+
+    // --- authorize_request truth table --------------------------------------
+
+    #[test]
+    fn unconfigured_admin_token_is_503_regardless_of_principal() {
+        // INVARIANT #1/#6 — absent/empty admin root → Unconfigured, even with a
+        // valid scoped principal presenting a good token.
+        let p = principal("svc-a", ApiRole::Integrator, false);
+        for admin in [None, Some("")] {
+            let d = authorize_request(SCOPE_INTEGRATION_EVALUATE, admin, Some("tok"), Some(&p));
+            assert_eq!(d.outcome, AuthzOutcome::Unconfigured);
+        }
+    }
+
+    #[test]
+    fn configured_but_no_bearer_is_401() {
+        let d = authorize_request(SCOPE_ADMIN, Some("root"), None, None);
+        assert_eq!(d.outcome, AuthzOutcome::Unauthenticated);
+        assert_eq!(d.auth_method, "none");
+    }
+
+    #[test]
+    fn root_admin_token_allows_every_scope_as_break_glass() {
+        for s in [SCOPE_ADMIN, SCOPE_INTEGRATION_EVALUATE, SCOPE_ACTUATOR_COMMAND, SCOPE_AUDIT_READ] {
+            let d = authorize_request(s, Some("root-token"), Some("root-token"), None);
+            assert_eq!(d.outcome, AuthzOutcome::Allow, "admin token must satisfy {s}");
+            assert_eq!(d.auth_method, "admin-token");
+            assert_eq!(d.role, Some(ApiRole::Admin));
+        }
+    }
+
+    #[test]
+    fn integrator_reaches_integration_but_not_admin_or_actuator() {
+        let p = principal("svc-integ", ApiRole::Integrator, false);
+        let allow = authorize_request(SCOPE_INTEGRATION_EVALUATE, Some("root"), Some("scoped"), Some(&p));
+        assert_eq!(allow.outcome, AuthzOutcome::Allow);
+        assert_eq!(allow.auth_method, "api-principal");
+        assert_eq!(allow.principal_id.as_deref(), Some("svc-integ"));
+
+        for s in [SCOPE_ADMIN, SCOPE_ACTUATOR_COMMAND, SCOPE_AUDIT_READ] {
+            let d = authorize_request(s, Some("root"), Some("scoped"), Some(&p));
+            assert_eq!(d.outcome, AuthzOutcome::Forbidden, "integrator must be 403 on {s}");
+        }
+    }
+
+    #[test]
+    fn auditor_reaches_audit_read_only() {
+        let p = principal("svc-audit", ApiRole::Auditor, false);
+        assert_eq!(
+            authorize_request(SCOPE_AUDIT_READ, Some("root"), Some("scoped"), Some(&p)).outcome,
+            AuthzOutcome::Allow
+        );
+        assert_eq!(
+            authorize_request(SCOPE_ADMIN, Some("root"), Some("scoped"), Some(&p)).outcome,
+            AuthzOutcome::Forbidden
+        );
+    }
+
+    #[test]
+    fn revoked_principal_is_401() {
+        let p = principal("svc-old", ApiRole::Integrator, true);
+        let d = authorize_request(SCOPE_INTEGRATION_EVALUATE, Some("root"), Some("scoped"), Some(&p));
+        assert_eq!(d.outcome, AuthzOutcome::Unauthenticated);
+    }
+
+    #[test]
+    fn unknown_token_is_401() {
+        // Bearer present, not the admin token, no principal holds its hash.
+        let d = authorize_request(SCOPE_INTEGRATION_EVALUATE, Some("root"), Some("mystery"), None);
+        assert_eq!(d.outcome, AuthzOutcome::Unauthenticated);
+    }
+
+    #[test]
+    fn corrupt_stored_role_fails_closed() {
+        let p = ResolvedPrincipal { principal_id: "svc-x".into(), role: None, revoked: false };
+        let d = authorize_request(SCOPE_INTEGRATION_EVALUATE, Some("root"), Some("scoped"), Some(&p));
+        assert_eq!(d.outcome, AuthzOutcome::Unauthenticated);
+    }
+
+    // --- token helpers -------------------------------------------------------
+
+    #[test]
+    fn token_hash_is_stable_deterministic_and_distinct() {
+        let a = token_sha256_hex("alpha");
+        assert_eq!(a, token_sha256_hex("alpha"));
+        assert_ne!(a, token_sha256_hex("beta"));
+        assert_eq!(a.len(), 64, "sha-256 hex is 64 chars");
+        assert_eq!(token_fingerprint("alpha"), a[..16]);
+    }
+
+    #[test]
+    fn generated_tokens_are_unique_256_bit_hex() {
+        let a = generate_api_token();
+        let b = generate_api_token();
+        assert_eq!(a.len(), 64);
+        assert_ne!(a, b, "two mints must not collide");
+    }
+}

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -28,6 +28,11 @@ use kirra_verifier::posture_engine_v2::{
     resolve_posture_snapshot_silent, resolve_posture_with_reason, LockoutReason,
 };
 use kirra_verifier::security::{admin_token_ok, constant_time_compare};
+use kirra_verifier::authz::{
+    authorize_request, generate_api_token, token_fingerprint, token_sha256_hex, ApiRole,
+    AuthzOutcome, ResolvedPrincipal, SCOPE_ACTUATOR_COMMAND, SCOPE_ADMIN, SCOPE_AUDIT_READ,
+    SCOPE_INTEGRATION_EVALUATE,
+};
 use kirra_verifier::action_filter::{evaluate_action_claim, ActionClaim};
 use kirra_verifier::protocol_adapter::{
     evaluate_unified_industrial_request, UnifiedIndustrialRequest,
@@ -81,6 +86,8 @@ mod fabric;
 mod console;
 #[path = "kirra_verifier_service/operators.rs"]
 mod operators;
+#[path = "kirra_verifier_service/principals.rs"]
+mod principals;
 // SG-008 (ASIL D) startup sentinel — pure invariant predicate + its CERT-003
 // RTM coverage tests; extracted from this file to keep the entry point lean.
 #[path = "kirra_verifier_service/startup.rs"]
@@ -95,37 +102,154 @@ use actuator::*;
 use fabric::*;
 use console::*;
 use operators::*;
+use principals::*;
 use startup::*;
 
 
 // --- Auth middleware ---------------------------------------------------------
 
-async fn require_admin_token(request: Request, next: Next) -> Result<Response, StatusCode> {
-    let expected = std::env::var("KIRRA_ADMIN_TOKEN")
-        .unwrap_or_default();
+/// INVARIANT #1/#6 — the admin mutation gate, PRESERVED by name and role. WS-1
+/// (#G7) reimplements it as the `SCOPE_ADMIN` specialization of the unified
+/// [`authorize_scope`] gate: the break-glass `KIRRA_ADMIN_TOKEN` still authorizes
+/// under `constant_time_compare` and an absent/empty token is still a fail-closed
+/// 503 — it is only ever a STRICT SUPERSET (an `admin`-role API principal
+/// additionally qualifies; only that role holds `SCOPE_ADMIN`). NEVER commented
+/// out, bypassed, or removed from any mutation route.
+async fn require_admin_token(
+    State(svc): State<Arc<ServiceState>>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    authorize_scope(&svc, SCOPE_ADMIN, request, next).await
+}
 
-    // Fail-closed: absent or empty admin token → 503 (CRITICAL INVARIANT #1/#6).
-    // Kept distinct from the 401 below so an unconfigured server is never
-    // mistaken for a bad credential.
-    if expected.is_empty() {
-        return Err(StatusCode::SERVICE_UNAVAILABLE);
-    }
+/// WS-1 (#G7) — the identity-gated integration surface (`SCOPE_INTEGRATION_EVALUATE`).
+/// Admin token or an `integrator`-role principal qualifies.
+async fn require_integration_scope(
+    State(svc): State<Arc<ServiceState>>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    authorize_scope(&svc, SCOPE_INTEGRATION_EVALUATE, request, next).await
+}
 
-    let provided = request
+/// WS-1 (#G7) — actuator command submission (`SCOPE_ACTUATOR_COMMAND`). Admin token
+/// or an `operator`-role principal qualifies (the inner safety envelope + the outer
+/// posture gate independently bound WHAT command is accepted).
+async fn require_actuator_scope(
+    State(svc): State<Arc<ServiceState>>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    authorize_scope(&svc, SCOPE_ACTUATOR_COMMAND, request, next).await
+}
+
+/// WS-1 (#G7) — read-only audit-chain verification/export (`SCOPE_AUDIT_READ`).
+/// Admin token or an `auditor`-role principal qualifies.
+async fn require_audit_scope(
+    State(svc): State<Arc<ServiceState>>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    authorize_scope(&svc, SCOPE_AUDIT_READ, request, next).await
+}
+
+/// The unified fail-closed authorization gate (WS-1 · #G7). Resolves the bearer to
+/// EITHER the break-glass root admin token OR a scoped API principal (by token
+/// hash), then delegates the verdict to the pure [`authorize_request`] predicate.
+///
+/// Store/env are lifted out of the predicate (INVARIANT #13-friendly): this thin
+/// wrapper reads `KIRRA_ADMIN_TOKEN`, does the hashed principal lookup ONLY when
+/// needed (admin configured, a non-admin bearer present), and fail-closes to
+/// "no principal" (→ 401) on any store error — never an authorized default.
+///
+/// Auditing (this PR): decisions are OBSERVED via structured `tracing` (denials
+/// warn; api-principal allows info; admin-token allows debug). They are NOT written
+/// to the tamper-evident audit chain here — an unauthenticated caller must not be
+/// able to append unboundedly (denial-flood DoS), and privileged MUTATIONS are
+/// already chained by their own handlers. Promoting scoped-principal ALLOWS into
+/// the chain (rate-limited) is a named follow-up.
+async fn authorize_scope(
+    svc: &Arc<ServiceState>,
+    required_scope: &'static str,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let admin_env = std::env::var("KIRRA_ADMIN_TOKEN").unwrap_or_default();
+    let bearer = request
         .headers()
         .get(header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.strip_prefix("Bearer "))
-        .ok_or(StatusCode::UNAUTHORIZED)?;
+        .map(str::to_string);
 
-    // Single constant-time authorization decision (SG-015). `expected` is
-    // non-empty here, so this reduces to a constant_time_compare of the two
-    // tokens — behavior identical to the prior inline check, never `==`.
-    if !admin_token_ok(Some(provided), Some(&expected)) {
-        return Err(StatusCode::UNAUTHORIZED);
+    // Resolve a scoped principal ONLY when it could matter: admin configured, a
+    // bearer present, and it is NOT the root admin token (the admin token
+    // short-circuits to Admin in the predicate, so no store hit is needed).
+    let principal: Option<ResolvedPrincipal> = match (admin_env.is_empty(), bearer.as_deref()) {
+        (false, Some(tok)) if !admin_token_ok(Some(tok), Some(&admin_env)) => {
+            let hash = token_sha256_hex(tok);
+            match svc
+                .app
+                .store
+                .call_read(move |s| s.load_api_principal_by_token_hash(&hash))
+                .await
+            {
+                Ok(Ok(Some(rec))) => Some(ResolvedPrincipal {
+                    role: ApiRole::parse_role(&rec.role),
+                    revoked: rec.revoked_at_ms.is_some(),
+                    principal_id: rec.principal_id,
+                }),
+                // No such token, OR a store/read failure → fail-closed as "no
+                // principal" (the predicate then denies with 401).
+                _ => None,
+            }
+        }
+        _ => None,
+    };
+
+    let decision = authorize_request(
+        required_scope,
+        Some(admin_env.as_str()),
+        bearer.as_deref(),
+        principal.as_ref(),
+    );
+
+    let fp = bearer.as_deref().map(token_fingerprint);
+    match decision.outcome {
+        AuthzOutcome::Allow => {
+            if decision.auth_method == "api-principal" {
+                tracing::info!(
+                    scope = required_scope,
+                    principal_id = decision.principal_id.as_deref().unwrap_or("?"),
+                    role = decision.role.map(ApiRole::as_str).unwrap_or("?"),
+                    "authz allow (api-principal)"
+                );
+            } else {
+                tracing::debug!(scope = required_scope, "authz allow (admin-token)");
+            }
+            Ok(next.run(request).await)
+        }
+        AuthzOutcome::Unconfigured => {
+            tracing::warn!(scope = required_scope,
+                "authz denied: KIRRA_ADMIN_TOKEN absent/empty → 503 (fail-closed)");
+            Err(StatusCode::SERVICE_UNAVAILABLE)
+        }
+        AuthzOutcome::Unauthenticated => {
+            tracing::warn!(scope = required_scope, token_fp = fp.as_deref().unwrap_or("none"),
+                "authz denied: no/unknown/revoked credential → 401");
+            Err(StatusCode::UNAUTHORIZED)
+        }
+        AuthzOutcome::Forbidden => {
+            tracing::warn!(
+                scope = required_scope,
+                principal_id = decision.principal_id.as_deref().unwrap_or("?"),
+                role = decision.role.map(ApiRole::as_str).unwrap_or("?"),
+                "authz denied: principal lacks required scope → 403"
+            );
+            Err(StatusCode::FORBIDDEN)
+        }
     }
-
-    Ok(next.run(request).await)
 }
 
 // SG-008 (ASIL D) process fail-closed startup sentinel — `StartupContext`,
@@ -1524,7 +1648,9 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
         .route("/industrial/canopen/evaluate", post(evaluate_canopen_adapter))
         .route("/industrial/dnp3/evaluate", post(evaluate_dnp3_adapter))
         .layer(middleware::from_fn_with_state(svc_state.clone(), require_client_identity))
-        .layer(middleware::from_fn(require_admin_token));
+        // WS-1 (#G7): SCOPE_INTEGRATION_EVALUATE — the admin token (break-glass) OR
+        // an `integrator`-role principal. Previously admin-token-only.
+        .layer(middleware::from_fn_with_state(svc_state.clone(), require_integration_scope));
 
     let admin_routes = Router::new()
         .route("/attestation/register", post(register_node))
@@ -1533,10 +1659,11 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
         .route("/fleet/assets/register", post(handle_register_av_asset))
         .route("/fleet/av-subsystems", get(list_av_subsystems))
         .route("/system/backup/export", post(export_backup))
-        .route("/system/audit/verify", get(verify_audit_chain))
-        .route("/system/audit/causal/verify", get(verify_causal_chain))
-        .route("/system/audit/export", get(handle_audit_export))
         .route("/system/audit/rotate-signing-key", post(handle_audit_rotate_key))
+        // WS-1 (#G7) — API principal registry. SCOPE_ADMIN (admin-only); the mint
+        // returns the plaintext token exactly once.
+        .route("/system/principals", post(register_api_principal_handler).get(list_api_principals_handler))
+        .route("/system/principals/{principal_id}/revoke", post(revoke_api_principal_handler))
         .route("/federation/controllers/register", post(register_federation_controller))
         .route("/attestation/identity/register", post(register_node_identity))
         // #314 Phase 1 — operator registry. ADMIN-gated (separate power from the
@@ -1551,7 +1678,18 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
         .route("/fabric/command/{asset_id}", post(handle_fabric_command))
         .route("/fabric/causal-log", get(handle_fabric_causal_log))
         .route("/fabric/causal-log/{entry_id}", get(handle_fabric_causal_chain))
-        .layer(middleware::from_fn(require_admin_token));
+        .layer(middleware::from_fn_with_state(svc_state.clone(), require_admin_token));
+
+    // WS-1 (#G7) — read-only audit-chain verification/export, carved out of the
+    // admin group so an `auditor`-role principal (least privilege — NO mutation
+    // rights) can reach them. SCOPE_AUDIT_READ; the admin token still qualifies
+    // (Admin holds every scope). The full-state `/system/backup/export` and the
+    // `rotate-signing-key` mutation stay admin-only above.
+    let auditor_routes = Router::new()
+        .route("/system/audit/verify", get(verify_audit_chain))
+        .route("/system/audit/causal/verify", get(verify_causal_chain))
+        .route("/system/audit/export", get(handle_audit_export))
+        .layer(middleware::from_fn_with_state(svc_state.clone(), require_audit_scope));
 
     let actuator_routes = Router::new()
         .route("/actuator/motion/command", post(handle_actuator_motion_command))
@@ -1559,7 +1697,9 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
             Arc::clone(&svc_state),
             enforce_actuator_safety_envelope,
         ))
-        .layer(middleware::from_fn(require_admin_token));
+        // WS-1 (#G7): SCOPE_ACTUATOR_COMMAND — the admin token OR an `operator`-role
+        // principal. Auth is outermost (runs before the envelope), order preserved.
+        .layer(middleware::from_fn_with_state(Arc::clone(&svc_state), require_actuator_scope));
 
     let attestation_routes = Router::new()
         .route("/attestation/challenge/{node_id}", post(issue_challenge))
@@ -1657,6 +1797,7 @@ fn build_app(svc_state: Arc<ServiceState>) -> Router {
         .merge(probe_routes)
         .merge(identity_gated_routes)
         .merge(admin_routes)
+        .merge(auditor_routes)
         .merge(actuator_routes)
         .merge(attestation_routes)
         .merge(read_routes)
@@ -1886,6 +2027,40 @@ mod posture_gate_real_router_tests {
             StatusCode::SERVICE_UNAVAILABLE,
             "LockedOut must still 503 at the posture gate even authenticated; got {locked}"
         );
+    }
+
+    /// WS-1 (#G7) — the new/rewired scope-gated groups are WIRED behind the authz
+    /// gate on the REAL assembled router and fail closed WITHOUT a credential. Under
+    /// Nominal the outer posture gate lets each request through to the scope layer,
+    /// which denies (503 when `KIRRA_ADMIN_TOKEN` is unset — INV-13 forbids setting
+    /// it here — or 401 if the CI env happens to configure one). Either way the
+    /// invariant is the same: NEVER 2xx without a valid credential. The positive
+    /// RBAC paths (integrator/auditor/operator reach exactly their surface) are
+    /// proven by `authz::tests` (pure truth table) + `tests/authz_rbac.rs`
+    /// (store↔authz composition), which need neither env nor router.
+    #[tokio::test]
+    async fn ws1_scope_gated_routes_fail_closed_on_real_router() {
+        // (method, path) for one route in each newly scope-gated group.
+        let cases = [
+            // admin group — the new principal-mint route (SCOPE_ADMIN).
+            ("POST", "/system/principals"),
+            // carved auditor group (SCOPE_AUDIT_READ) — must NOT be accidentally open.
+            ("GET", "/system/audit/verify"),
+            // integration group, switched admin-token → SCOPE_INTEGRATION_EVALUATE.
+            ("POST", "/action_filter/evaluate"),
+        ];
+        for (method, path) in cases {
+            let status =
+                status_through_real_app(state_with(FleetPosture::Nominal), method, path).await;
+            assert!(
+                status == StatusCode::SERVICE_UNAVAILABLE || status == StatusCode::UNAUTHORIZED,
+                "{method} {path} must fail closed (503/401) without a credential; got {status}"
+            );
+            assert!(
+                !status.is_success(),
+                "{method} {path} must never reach the handler unauthenticated; got {status}"
+            );
+        }
     }
 
     /// WS-0.5 DoD — "Prometheus scrape returns fleet-safety series", proven

--- a/src/bin/kirra_verifier_service/principals.rs
+++ b/src/bin/kirra_verifier_service/principals.rs
@@ -1,0 +1,140 @@
+// src/bin/kirra_verifier_service/principals.rs
+// WS-1 (#G7) — API principal registry handlers (mint / list / revoke).
+//
+// `use super::*` pulls the binary root's helpers, DTOs and `use` imports (the
+// authz helpers, `ServiceState`, `now_ms`, `valid_identifier`, `admin_token_
+// fingerprint`, axum extractors). These routes are ADMIN-scoped at the router
+// layer (`require_admin_token` / SCOPE_ADMIN) — only an admin may mint or revoke.
+
+use super::*;
+
+#[derive(Deserialize)]
+pub(crate) struct RegisterApiPrincipalRequest {
+    principal_id: String,
+    /// One of `admin` | `integrator` | `auditor` | `operator`.
+    role: String,
+}
+
+/// POST /system/principals — mint (or rotate) a scoped API principal. ADMIN-scoped.
+/// The server generates a 256-bit token, stores ONLY its SHA-256 hex, and returns
+/// the plaintext token EXACTLY ONCE (it can never be recovered later). Re-minting an
+/// existing `principal_id` rotates its token and clears any revocation.
+pub(crate) async fn register_api_principal_handler(
+    State(svc): State<Arc<ServiceState>>,
+    headers: HeaderMap,
+    Json(req): Json<RegisterApiPrincipalRequest>,
+) -> impl IntoResponse {
+    let principal_id = req.principal_id.trim();
+    if principal_id.is_empty() {
+        return (StatusCode::UNPROCESSABLE_ENTITY,
+                Json(json!({ "error": "principal_id must be non-empty" }))).into_response();
+    }
+    // Same identifier hygiene as the operator registry (#326): no `|` / control chars.
+    if !valid_identifier(principal_id) {
+        return (StatusCode::BAD_REQUEST, Json(json!({
+            "error": "principal_id must not contain '|' or control characters"
+        }))).into_response();
+    }
+    // Fail-closed: the role must be one of the known RBAC roles.
+    let role = match ApiRole::parse_role(req.role.trim()) {
+        Some(r) => r,
+        None => return (StatusCode::UNPROCESSABLE_ENTITY, Json(json!({
+            "error": "role must be one of: admin, integrator, auditor, operator"
+        }))).into_response(),
+    };
+
+    // Generate the token and derive its stored hash + short fingerprint. The
+    // plaintext exists ONLY in this response; the store sees only the hash.
+    let token = generate_api_token();
+    let token_hash = token_sha256_hex(&token);
+    let token_fp = token_fingerprint(&token);
+    let admin_fp = admin_token_fingerprint(&headers);
+    let now = now_ms();
+
+    let id = principal_id.to_string();
+    let role_str = role.as_str().to_string();
+    let fp_for_audit = token_fp.clone();
+    let persisted = svc.app.store.call(move |store| {
+        if store.register_api_principal(&id, &token_hash, &role_str, now).is_err() {
+            return false;
+        }
+        // Attributed, non-repudiable registration event (never records the token).
+        let _ = store.append_clearance_audit_event(
+            "ApiPrincipalRegistered",
+            &json!({
+                "principal_id": id,
+                "role": role_str,
+                "token_fingerprint": fp_for_audit,
+                "registered_by_admin_fingerprint": admin_fp,
+            }).to_string(),
+            now,
+        );
+        true
+    }).await;
+
+    match persisted {
+        Ok(true) => (StatusCode::CREATED, Json(json!({
+            "principal_id": principal_id,
+            "role": role.as_str(),
+            // Shown ONCE — store it now; it cannot be retrieved again.
+            "token": token,
+            "token_fingerprint": token_fp,
+            "note": "the token is shown only once; store it securely — it cannot be recovered later",
+        }))).into_response(),
+        Ok(false) => (StatusCode::INTERNAL_SERVER_ERROR,
+                      Json(json!({ "error": "persist failed" }))).into_response(),
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
+                   Json(json!({ "error": "store task failed" }))).into_response(),
+    }
+}
+
+/// GET /system/principals — list registered principals. ADMIN-scoped. Never
+/// returns the token or its hash — only id / role / status.
+pub(crate) async fn list_api_principals_handler(
+    State(svc): State<Arc<ServiceState>>,
+) -> impl IntoResponse {
+    match svc.app.store.call_read(|store| store.load_api_principals()).await {
+        Ok(Ok(list)) => {
+            let out: Vec<_> = list.into_iter().map(|p| json!({
+                "principal_id": p.principal_id,
+                "role": p.role,
+                "created_at_ms": p.created_at_ms,
+                "active": p.is_active(),
+                "revoked_at_ms": p.revoked_at_ms,
+            })).collect();
+            (StatusCode::OK, Json(json!({ "principals": out }))).into_response()
+        }
+        _ => (StatusCode::INTERNAL_SERVER_ERROR,
+              Json(json!({ "error": "query failed" }))).into_response(),
+    }
+}
+
+/// POST /system/principals/{principal_id}/revoke — revoke a principal. ADMIN-scoped.
+/// A revoked principal's token no longer authorizes (resolves to 401).
+pub(crate) async fn revoke_api_principal_handler(
+    State(svc): State<Arc<ServiceState>>,
+    headers: HeaderMap,
+    Path(principal_id): Path<String>,
+) -> impl IntoResponse {
+    let now = now_ms();
+    let admin_fp = admin_token_fingerprint(&headers);
+    let id = principal_id.clone();
+    match svc.app.store.call(move |store| match store.revoke_api_principal(&id, now) {
+        Ok(true) => {
+            let _ = store.append_clearance_audit_event(
+                "ApiPrincipalRevoked",
+                &json!({ "principal_id": id, "revoked_by_admin_fingerprint": admin_fp }).to_string(),
+                now,
+            );
+            (StatusCode::OK, Json(json!({ "principal_id": id, "status": "revoked" }))).into_response()
+        }
+        Ok(false) => (StatusCode::NOT_FOUND,
+                      Json(json!({ "error": "principal not found or already revoked" }))).into_response(),
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
+                   Json(json!({ "error": "persist failed" }))).into_response(),
+    }).await {
+        Ok(r) => r,
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,
+                   Json(json!({ "error": "store task failed" }))).into_response(),
+    }
+}

--- a/src/gateway/policy.rs
+++ b/src/gateway/policy.rs
@@ -92,8 +92,12 @@ fn is_write_state_path(path: &str) -> bool {
         return true;
     }
     // Path-parameterised control-plane writes (prefix is fixed; the trailing
-    // segment is the {node_id} / {asset_id} parameter).
-    if path.starts_with("/attestation/challenge/") || path.starts_with("/fabric/command/") {
+    // segment is the {node_id} / {asset_id} / {principal_id} parameter).
+    if path.starts_with("/attestation/challenge/")
+        || path.starts_with("/fabric/command/")
+        // WS-1 (#G7) — `/system/principals/{principal_id}/revoke`.
+        || path.starts_with("/system/principals/")
+    {
         return true;
     }
     // Exact control-plane state-write endpoints.
@@ -115,6 +119,9 @@ fn is_write_state_path(path: &str) -> bool {
             | "/industrial/ethernet-ip/evaluate"
             | "/system/backup/export"
             | "/system/audit/rotate-signing-key"
+            // WS-1 (#G7) — mint an API principal (POST). The parameterised revoke
+            // is matched by the `/system/principals/` prefix above.
+            | "/system/principals"
     )
 }
 
@@ -180,6 +187,20 @@ mod tests {
             classify_http_command("POST", "/actuator/servo"),
             OperationalCommand::WriteState
         );
+    }
+
+    #[test]
+    fn test_classifies_api_principal_writes() {
+        // WS-1 (#G7): the principal mint (exact) and the parameterised revoke must
+        // classify as WriteState — NOT Unknown (which the outer posture gate denies
+        // in every posture, incl. Nominal — that would brick the routes).
+        assert_eq!(classify_http_command("POST", "/system/principals"), OperationalCommand::WriteState);
+        assert_eq!(
+            classify_http_command("POST", "/system/principals/svc-a/revoke"),
+            OperationalCommand::WriteState
+        );
+        // The GET list is a read.
+        assert_eq!(classify_http_command("GET", "/system/principals"), OperationalCommand::ReadTelemetry);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod ros2_adapter;
 pub mod action_filter;
 pub mod action_policy;
 pub mod security;
+pub mod authz;
 pub mod telemetry;
 pub mod metrics;
 pub mod health;

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -157,6 +157,26 @@ impl OperatorRecord {
     }
 }
 
+/// A registered API principal (WS-1 · G7). The bearer token is stored ONLY as its
+/// SHA-256 hex (`token_sha256`); the plaintext is shown once at mint and never
+/// persisted. `role` is the wire role string (parsed fail-closed by
+/// `authz::ApiRole::parse_role`). `revoked_at_ms` NULL = active.
+#[derive(Debug, Clone)]
+pub struct ApiPrincipalRecord {
+    pub principal_id: String,
+    pub role: String,
+    pub created_at_ms: u64,
+    pub revoked_at_ms: Option<u64>,
+}
+
+impl ApiPrincipalRecord {
+    /// True iff the principal is registered and not revoked.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        self.revoked_at_ms.is_none()
+    }
+}
+
 /// The latest clearance grant's delivery state for a node (console read surface).
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ClearanceGrantState {
@@ -485,6 +505,7 @@ mod nodes;
 mod posture;
 mod audit;
 mod operators;
+mod principals;
 mod federation;
 mod attestation;
 mod av_subsystem;
@@ -623,6 +644,22 @@ impl VerifierStore {
                 pubkey_pem        TEXT    NOT NULL,
                 registered_at_ms  INTEGER NOT NULL,
                 revoked_at_ms     INTEGER
+            )",
+            [],
+        )?;
+
+        // WS-1 (#G7) — API principals: per-principal scoped bearer tokens. Only the
+        // SHA-256 hex of the token is stored (UNIQUE, looked up by hash — never
+        // plaintext). `role` is the wire role string; `revoked_at_ms` NULL = active.
+        // Layers ON TOP of the `KIRRA_ADMIN_TOKEN` root (which stays the break-glass
+        // superuser); this table only ADDS least-privilege sub-credentials.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS api_principals (
+                principal_id   TEXT    PRIMARY KEY,
+                token_sha256   TEXT    NOT NULL UNIQUE,
+                role           TEXT    NOT NULL,
+                created_at_ms  INTEGER NOT NULL,
+                revoked_at_ms  INTEGER
             )",
             [],
         )?;

--- a/src/verifier_store/principals.rs
+++ b/src/verifier_store/principals.rs
@@ -1,0 +1,137 @@
+// src/verifier_store/principals.rs
+// api_principals domain (WS-1 · G7) — per-principal scoped bearer tokens.
+//
+// Only the SHA-256 hex of a token is ever stored; resolution is by hash, never
+// plaintext. Mirrors the `operators` registry shape.
+
+use super::*;
+
+impl VerifierStore {
+    /// Register (or rotate) an API principal. Re-registration overwrites the token
+    /// hash + role and CLEARS any prior revocation (a fresh token for a principal
+    /// is an active principal). `token_sha256` is the SHA-256 hex of the bearer
+    /// token — the plaintext never reaches the store.
+    pub fn register_api_principal(
+        &mut self,
+        principal_id: &str,
+        token_sha256: &str,
+        role: &str,
+        now_ms: u64,
+    ) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO api_principals
+                 (principal_id, token_sha256, role, created_at_ms, revoked_at_ms)
+             VALUES (?1, ?2, ?3, ?4, NULL)
+             ON CONFLICT(principal_id) DO UPDATE SET
+                 token_sha256  = excluded.token_sha256,
+                 role          = excluded.role,
+                 created_at_ms = excluded.created_at_ms,
+                 revoked_at_ms = NULL",
+            params![principal_id, token_sha256, role, now_ms as i64],
+        )?;
+        Ok(())
+    }
+
+    /// Revoke an API principal (sets `revoked_at_ms`). Returns `true` if an ACTIVE
+    /// principal was revoked, `false` if absent or already revoked.
+    pub fn revoke_api_principal(&mut self, principal_id: &str, now_ms: u64) -> Result<bool> {
+        let n = self.conn.execute(
+            "UPDATE api_principals SET revoked_at_ms = ?2
+             WHERE principal_id = ?1 AND revoked_at_ms IS NULL",
+            params![principal_id, now_ms as i64],
+        )?;
+        Ok(n > 0)
+    }
+
+    /// Resolve an API principal by the SHA-256 hex of its presented token. Returns
+    /// the record (active OR revoked — the caller fail-closes on revoked), or
+    /// `None` if no principal holds that token hash. Lookup is by hash only.
+    pub fn load_api_principal_by_token_hash(
+        &self,
+        token_sha256: &str,
+    ) -> Result<Option<ApiPrincipalRecord>> {
+        use rusqlite::OptionalExtension;
+        self.conn
+            .query_row(
+                "SELECT principal_id, role, created_at_ms, revoked_at_ms
+                 FROM api_principals WHERE token_sha256 = ?1",
+                params![token_sha256],
+                Self::map_api_principal_row,
+            )
+            .optional()
+    }
+
+    /// Read-only listing of every registered API principal. Never returns the
+    /// token hash — the handler exposes only id / role / status.
+    pub fn load_api_principals(&self) -> Result<Vec<ApiPrincipalRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT principal_id, role, created_at_ms, revoked_at_ms
+             FROM api_principals ORDER BY principal_id",
+        )?;
+        let rows = stmt.query_map([], Self::map_api_principal_row)?;
+        rows.collect()
+    }
+
+    fn map_api_principal_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ApiPrincipalRecord> {
+        Ok(ApiPrincipalRecord {
+            principal_id: row.get(0)?,
+            role: row.get(1)?,
+            created_at_ms: row.get::<_, i64>(2)? as u64,
+            revoked_at_ms: row.get::<_, Option<i64>>(3)?.map(|v| v as u64),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::verifier_store::VerifierStore;
+
+    fn store() -> VerifierStore {
+        VerifierStore::new(":memory:").expect("in-memory store")
+    }
+
+    #[test]
+    fn register_then_resolve_by_hash() {
+        let mut s = store();
+        s.register_api_principal("svc-a", "hash-a", "integrator", 1_000).unwrap();
+        let rec = s.load_api_principal_by_token_hash("hash-a").unwrap().expect("present");
+        assert_eq!(rec.principal_id, "svc-a");
+        assert_eq!(rec.role, "integrator");
+        assert!(rec.is_active());
+        assert!(s.load_api_principal_by_token_hash("nope").unwrap().is_none());
+    }
+
+    #[test]
+    fn rotation_overwrites_hash_and_clears_revocation() {
+        let mut s = store();
+        s.register_api_principal("svc-a", "hash-old", "integrator", 1_000).unwrap();
+        assert!(s.revoke_api_principal("svc-a", 2_000).unwrap());
+        // The old hash still resolves the (now revoked) record.
+        assert!(s.load_api_principal_by_token_hash("hash-old").unwrap().unwrap().revoked_at_ms.is_some());
+        // Re-register rotates the token and reactivates.
+        s.register_api_principal("svc-a", "hash-new", "auditor", 3_000).unwrap();
+        assert!(s.load_api_principal_by_token_hash("hash-old").unwrap().is_none(),
+            "the rotated-out hash no longer resolves");
+        let rec = s.load_api_principal_by_token_hash("hash-new").unwrap().unwrap();
+        assert_eq!(rec.role, "auditor");
+        assert!(rec.is_active());
+    }
+
+    #[test]
+    fn revoke_is_idempotent_and_reports_transition() {
+        let mut s = store();
+        s.register_api_principal("svc-a", "h", "operator", 1_000).unwrap();
+        assert!(s.revoke_api_principal("svc-a", 2_000).unwrap(), "first revoke transitions");
+        assert!(!s.revoke_api_principal("svc-a", 3_000).unwrap(), "second revoke is a no-op");
+        assert!(!s.revoke_api_principal("absent", 3_000).unwrap(), "absent principal → false");
+    }
+
+    #[test]
+    fn list_orders_by_id_and_hides_no_secret() {
+        let mut s = store();
+        s.register_api_principal("svc-b", "hb", "auditor", 1_000).unwrap();
+        s.register_api_principal("svc-a", "ha", "integrator", 1_000).unwrap();
+        let all = s.load_api_principals().unwrap();
+        assert_eq!(all.iter().map(|p| p.principal_id.as_str()).collect::<Vec<_>>(), ["svc-a", "svc-b"]);
+    }
+}

--- a/tests/authz_rbac.rs
+++ b/tests/authz_rbac.rs
@@ -1,0 +1,141 @@
+//! WS-1 (#G7) — RBAC authorization, proven through the EXACT store↔authz
+//! composition the `authorize_scope` middleware performs, WITHOUT process env or a
+//! live router (INVARIANT #13 forbids `set_var` in the parallel runner).
+//!
+//! The middleware's real work is: mint/resolve a principal by token hash in the
+//! store, map its role, then call the pure `authorize_request` predicate against a
+//! configured admin root. This test drives that same composition against a real
+//! in-memory `VerifierStore`, so it proves the seam the pure-function unit tests
+//! (`authz::tests`) and the router-gating tests each cover only half of.
+
+use kirra_verifier::authz::{
+    authorize_request, token_sha256_hex, ApiRole, AuthzOutcome, ResolvedPrincipal,
+    SCOPE_ACTUATOR_COMMAND, SCOPE_ADMIN, SCOPE_AUDIT_READ, SCOPE_INTEGRATION_EVALUATE,
+};
+use kirra_verifier::verifier_store::VerifierStore;
+
+const ADMIN_ROOT: &str = "root-admin-token";
+
+/// Mint a principal in the store (as the mint handler does: store the token HASH),
+/// then resolve it back by hash exactly as the middleware does, into the
+/// `ResolvedPrincipal` the pure predicate consumes.
+fn mint_and_resolve(
+    store: &mut VerifierStore,
+    principal_id: &str,
+    role: ApiRole,
+    token: &str,
+    revoke: bool,
+) -> ResolvedPrincipal {
+    let hash = token_sha256_hex(token);
+    store
+        .register_api_principal(principal_id, &hash, role.as_str(), 1_000)
+        .expect("register");
+    if revoke {
+        assert!(store.revoke_api_principal(principal_id, 2_000).expect("revoke"));
+    }
+    let rec = store
+        .load_api_principal_by_token_hash(&hash)
+        .expect("query")
+        .expect("principal present");
+    ResolvedPrincipal {
+        role: ApiRole::parse_role(&rec.role),
+        revoked: rec.revoked_at_ms.is_some(),
+        principal_id: rec.principal_id,
+    }
+}
+
+/// Resolve a presented token against the store the way the middleware does: the
+/// admin root short-circuits (no lookup); otherwise look up by hash (miss → None).
+fn resolve(store: &VerifierStore, token: &str) -> Option<ResolvedPrincipal> {
+    if token == ADMIN_ROOT {
+        return None; // admin path never consults the principal store
+    }
+    let hash = token_sha256_hex(token);
+    store
+        .load_api_principal_by_token_hash(&hash)
+        .expect("query")
+        .map(|rec| ResolvedPrincipal {
+            role: ApiRole::parse_role(&rec.role),
+            revoked: rec.revoked_at_ms.is_some(),
+            principal_id: rec.principal_id,
+        })
+}
+
+fn decide(store: &VerifierStore, scope: &str, token: &str) -> AuthzOutcome {
+    let principal = resolve(store, token);
+    authorize_request(scope, Some(ADMIN_ROOT), Some(token), principal.as_ref())
+        .outcome
+}
+
+#[test]
+fn integrator_principal_reaches_only_the_integration_surface() {
+    let mut store = VerifierStore::new(":memory:").unwrap();
+    mint_and_resolve(&mut store, "svc-integ", ApiRole::Integrator, "integ-tok", false);
+
+    assert_eq!(decide(&store, SCOPE_INTEGRATION_EVALUATE, "integ-tok"), AuthzOutcome::Allow);
+    // Least privilege: 403 on every other surface.
+    for scope in [SCOPE_ADMIN, SCOPE_ACTUATOR_COMMAND, SCOPE_AUDIT_READ] {
+        assert_eq!(decide(&store, scope, "integ-tok"), AuthzOutcome::Forbidden,
+            "integrator must be forbidden on {scope}");
+    }
+}
+
+#[test]
+fn auditor_principal_reaches_only_audit_read() {
+    let mut store = VerifierStore::new(":memory:").unwrap();
+    mint_and_resolve(&mut store, "svc-audit", ApiRole::Auditor, "audit-tok", false);
+
+    assert_eq!(decide(&store, SCOPE_AUDIT_READ, "audit-tok"), AuthzOutcome::Allow);
+    for scope in [SCOPE_ADMIN, SCOPE_INTEGRATION_EVALUATE, SCOPE_ACTUATOR_COMMAND] {
+        assert_eq!(decide(&store, scope, "audit-tok"), AuthzOutcome::Forbidden);
+    }
+}
+
+#[test]
+fn operator_principal_reaches_only_actuator_command() {
+    let mut store = VerifierStore::new(":memory:").unwrap();
+    mint_and_resolve(&mut store, "svc-op", ApiRole::Operator, "op-tok", false);
+
+    assert_eq!(decide(&store, SCOPE_ACTUATOR_COMMAND, "op-tok"), AuthzOutcome::Allow);
+    assert_eq!(decide(&store, SCOPE_ADMIN, "op-tok"), AuthzOutcome::Forbidden);
+    assert_eq!(decide(&store, SCOPE_INTEGRATION_EVALUATE, "op-tok"), AuthzOutcome::Forbidden);
+}
+
+#[test]
+fn break_glass_admin_token_still_satisfies_every_group() {
+    // Back-compat: an admin-token-only deployment (no principals minted) reaches
+    // every gated group exactly as before this change.
+    let store = VerifierStore::new(":memory:").unwrap();
+    for scope in [SCOPE_ADMIN, SCOPE_INTEGRATION_EVALUATE, SCOPE_ACTUATOR_COMMAND, SCOPE_AUDIT_READ] {
+        assert_eq!(decide(&store, scope, ADMIN_ROOT), AuthzOutcome::Allow,
+            "admin token must satisfy {scope}");
+    }
+}
+
+#[test]
+fn revoked_principal_token_is_unauthenticated_after_store_round_trip() {
+    let mut store = VerifierStore::new(":memory:").unwrap();
+    mint_and_resolve(&mut store, "svc-old", ApiRole::Integrator, "old-tok", true);
+    // Even on its own scope, a revoked credential no longer authorizes.
+    assert_eq!(decide(&store, SCOPE_INTEGRATION_EVALUATE, "old-tok"), AuthzOutcome::Unauthenticated);
+}
+
+#[test]
+fn unknown_token_is_unauthenticated() {
+    let store = VerifierStore::new(":memory:").unwrap();
+    assert_eq!(decide(&store, SCOPE_INTEGRATION_EVALUATE, "never-minted"), AuthzOutcome::Unauthenticated);
+}
+
+#[test]
+fn rotated_token_supersedes_the_old_one() {
+    let mut store = VerifierStore::new(":memory:").unwrap();
+    mint_and_resolve(&mut store, "svc-rot", ApiRole::Integrator, "tok-v1", false);
+    // Rotate: same principal, new token, new role.
+    mint_and_resolve(&mut store, "svc-rot", ApiRole::Auditor, "tok-v2", false);
+
+    // The old token no longer resolves → unauthenticated.
+    assert_eq!(decide(&store, SCOPE_INTEGRATION_EVALUATE, "tok-v1"), AuthzOutcome::Unauthenticated);
+    // The new token carries the new role's scope.
+    assert_eq!(decide(&store, SCOPE_AUDIT_READ, "tok-v2"), AuthzOutcome::Allow);
+    assert_eq!(decide(&store, SCOPE_INTEGRATION_EVALUATE, "tok-v2"), AuthzOutcome::Forbidden);
+}


### PR DESCRIPTION
Layer least-privilege scoped authorization on top of the KIRRA_ADMIN_TOKEN
root, closing the "single shared admin token" gap (G7) toward the GATE-B
security review — no shared-token-only surface.

- `src/authz.rs` (new): the pure fail-closed RBAC core. `ApiRole`
  {admin,integrator,auditor,operator} → scope sets; `authorize_request`
  decides Allow / Unconfigured(503) / Unauthenticated(401) / Forbidden(403).
  Store+env are lifted out (like `admin_token_ok`) so the truth table is
  unit-tested without `set_var` (INVARIANT #13).
- `api_principals` table + store methods: tokens stored ONLY as SHA-256
  (UNIQUE, resolved by hash — plaintext never persisted).
- Service: `authorize_scope` gate resolves a bearer to the break-glass admin
  token OR a scoped principal (hashed lookup, fail-closed on store error).
  `require_admin_token` is PRESERVED by name/role as the SCOPE_ADMIN
  specialization (INVARIANT #1/#6 verbatim: absent/empty root → 503). Route
  groups now terminate in scope layers; a NEW `auditor_routes` carve-out
  gives an auditor least-privilege read of audit verify/causal-verify/export.
- Admin-scoped API-principal registry: POST/GET /system/principals,
  POST /system/principals/{id}/revoke (token shown once at mint). Added to the
  WriteState classifier allowlist so the outer posture gate admits them.

Back-compat: the admin token satisfies every scope, so an admin-token-only
deployment is byte-identical. TLS/mTLS and TPM-bound signing-key rotation are
the follow-up WS-1 PRs.

Tests: authz truth table (`authz::tests`); store↔authz composition
(`tests/authz_rbac.rs`); real-router fail-closed wiring
(`ws1_scope_gated_routes_fail_closed_on_real_router`); classifier + store
round-trips. Docs: SG-015 (SECURITY_BOUNDARIES), CHANGELOG, route matrix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GmYCVzTaidSMJvdSAubyj7