### PR TITLE
G20 (WS-2): SDK quickstart examples + rustdoc gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,27 @@ jobs:
         # never silently rot if the unification path changes.
         run: cargo test -p kirra-core --features capture --locked
 
+  docs-and-sdk:
+    name: SDK docs + examples (G20)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - name: rustdoc build gate (public API docs; broken intra-doc links fail)
+        # -D warnings turns any rustdoc warning (broken intra-doc link, unclosed
+        # HTML tag, private-item link from public docs) into a hard error, so the
+        # published SDK docs stay clean.
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps --lib --locked
+      - name: Rust SDK example (governor_quickstart) builds + runs
+        run: cargo run --example governor_quickstart --locked
+      - name: C SDK example builds + runs against the cdylib
+        # Compiles examples/c/kirra_ffi_demo.c against include/kirra.h + the
+        # libkirra_verifier cdylib and runs it — keeps the C ABI examples from rotting.
+        run: ./examples/c/build_and_run.sh
+
   coverage:
     name: Branch Coverage (MC/DC pending — issue #65)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ detail lives in `docs/adr/`, `docs/safety/`, and the PR history:
 
 ### Added
 
+- **SDK quickstart examples + rustdoc gate (G20, WS-2).** A runnable Rust example
+  (`examples/governor_quickstart.rs` — the checker bounding a doer's proposals,
+  fail-closed) and a C example (`examples/c/kirra_ffi_demo.c` + `build_and_run.sh`)
+  that links the `libkirra_verifier` cdylib over the now-documented `include/kirra.h`
+  ABI. Crate-level rustdoc landing page + documented FFI surface; the whole public
+  lib is rustdoc-clean under `-D warnings` (14 pre-existing broken intra-doc links /
+  unclosed-HTML doc tags fixed). New CI job **SDK docs + examples** gates the doc
+  build and builds+runs both examples so they never rot.
 - **Doer-checker planning & perception stack** — the swappable DOER
   (`kirra-planner`: geometric Occy, Mick intent seam incl. multi-junction
   `RouteTo`, learned Hydra-MDP-style planners) bounded by the CHECKER

--- a/docs/analysis/GAP_CLOSURE_STATUS.md
+++ b/docs/analysis/GAP_CLOSURE_STATUS.md
@@ -58,8 +58,13 @@ registry — see the CHANGELOG Unification note.
    `LEARNING_LOOP_ARCHITECTURE.md`; verdict-emit machinery exists. Effort M.
 4. **G18 config governance** — `KirraRuntimeConfig` exists; no schema/versioning;
    env sprawl remains. Effort M.
-5. **G20 SDK remainder** — 2 Python examples only; `kirra.h` is a 20-line stub;
-   no Rust/C examples or published rustdoc. Effort S–M.
+5. **G20 SDK remainder** — ✅ **first slice landed:** a runnable Rust example
+   (`governor_quickstart`) + a C example linking the cdylib over a now-documented
+   `include/kirra.h`, a crate-level rustdoc landing page + documented FFI surface
+   (public lib rustdoc-clean under `-D warnings`), and a CI `SDK docs + examples`
+   job gating the doc build + both examples. **Remaining:** publishing rustdoc to
+   a hosted location (Pages) and, if desired, broadening `deny(missing_docs)`
+   beyond the FFI surface + enriching the C ABI beyond the 4 scalar functions.
 
 ### Track 3 — WS-4 fleet plane (Stage 2, blocks Gate C)
 6. **G6 secure/measured boot** — TPM feature off-by-default; needs a reference

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,39 @@
+# Kirra SDK examples
+
+Runnable consumers of the Kirra safety governor — the CHECKER that bounds a doer's
+proposed commands, fail-closed. All are exercised in CI (`SDK docs + examples`), so
+they never rot.
+
+| Example | Language | Run |
+|---|---|---|
+| `governor_quickstart.rs` | Rust | `cargo run --example governor_quickstart` |
+| `c/kirra_ffi_demo.c` | C (over the `include/kirra.h` ABI) | `./examples/c/build_and_run.sh` |
+| `langchain_action_filter.py` | Python | see file header |
+| `openai_action_filter.py` | Python | see file header |
+
+## Rust — in-process governor
+
+`governor_quickstart.rs` constructs a `KirraKernelGovernor` over a
+`KinematicContract` (the hard envelope) and feeds it a sequence of proposed
+velocities — safe, over-envelope, and a corrupt `NaN` — printing what the checker
+actually emits. It asserts the two invariants the checker guarantees: the emitted
+command is **always finite** and **always inside the envelope**.
+
+## C — the same over the C ABI
+
+The root crate builds a `cdylib` (`libkirra_verifier`), so a C program links it and
+calls the stable ABI in [`include/kirra.h`](../include/kirra.h). `build_and_run.sh`
+builds the library, compiles the demo against it, and runs it:
+
+```sh
+./examples/c/build_and_run.sh            # release
+PROFILE=debug ./examples/c/build_and_run.sh
+```
+
+## API docs
+
+Build the SDK's rustdoc locally:
+
+```sh
+cargo doc --no-deps --open
+```

--- a/examples/c/build_and_run.sh
+++ b/examples/c/build_and_run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Build and run the Kirra C quickstart against the cdylib (libkirra_verifier).
+#
+# Kirra's root crate builds a `cdylib` (Cargo.toml: crate-type = ["rlib","cdylib"]),
+# so a C program links it directly and calls the C ABI declared in include/kirra.h.
+#
+#   ./examples/c/build_and_run.sh              # release cdylib
+#   PROFILE=debug ./examples/c/build_and_run.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROFILE="${PROFILE:-release}"
+CC="${CC:-cc}"
+
+case "$PROFILE" in
+  release) CARGO_FLAGS="--release" ;;
+  debug)   CARGO_FLAGS="" ;;
+  *) echo "PROFILE must be 'release' or 'debug' (got '$PROFILE')" >&2; exit 2 ;;
+esac
+
+# 1. Build the shared library the C program links against.
+( cd "$REPO_ROOT" && cargo build --lib --locked $CARGO_FLAGS )
+
+LIB_DIR="$REPO_ROOT/target/$PROFILE"
+OUT="$(mktemp -d)/kirra_ffi_demo"
+
+# 2. Compile the C demo against include/kirra.h + the cdylib.
+"$CC" -std=c11 -Wall -Wextra \
+  -I "$REPO_ROOT/include" \
+  "$REPO_ROOT/examples/c/kirra_ffi_demo.c" \
+  -L "$LIB_DIR" -lkirra_verifier -lm \
+  -o "$OUT"
+
+# 3. Run it, pointing the loader at the freshly built cdylib.
+echo "--- running $OUT (LD_LIBRARY_PATH=$LIB_DIR) ---"
+LD_LIBRARY_PATH="$LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$OUT"

--- a/examples/c/kirra_ffi_demo.c
+++ b/examples/c/kirra_ffi_demo.c
@@ -1,0 +1,39 @@
+/*
+ * Kirra SDK quickstart (C) — the CHECKER bounding a DOER's proposals over the C ABI.
+ *
+ * The C integration boundary (ADR-0006 Clause 3) exposes the same safety-governor
+ * behaviour as the Rust `governor_quickstart` example, through `include/kirra.h`.
+ * A doer PROPOSES a velocity; `kirra_filter_move_velocity` BOUNDS it, fail-closed,
+ * against a hard kinematic envelope compiled into `libkirra_verifier`.
+ *
+ * Build + run: see `examples/c/build_and_run.sh` (compiles against the cdylib).
+ */
+
+#include <stdio.h>
+#include <math.h>
+#include "kirra.h"
+
+int main(void) {
+    /* The doer's proposed linear velocities over 50 ms ticks. The last is a
+     * corrupt NaN to exercise the fail-closed path. */
+    const double dt = 0.05;
+    const double proposals[] = {1.0, 1.8, 5.0 /* over-envelope */, NAN /* corrupt */};
+    const size_t n = sizeof(proposals) / sizeof(proposals[0]);
+
+    printf("proposed -> emitted   (trust score after tick)\n");
+    printf("----------------------------------------------\n");
+    for (size_t i = 0; i < n; ++i) {
+        /* The returned scalar is what reaches the actuator: never non-finite,
+         * never outside the envelope compiled into the governor. */
+        double emitted = kirra_filter_move_velocity(proposals[i], dt);
+        uint32_t trust = kirra_get_trust_score();
+
+        if (!isfinite(emitted)) {
+            fprintf(stderr, "FATAL: checker emitted a non-finite command\n");
+            return 1;
+        }
+        printf("%8.2f -> %7.2f   (trust=%u)\n", proposals[i], emitted, trust);
+    }
+
+    return 0;
+}

--- a/examples/governor_quickstart.rs
+++ b/examples/governor_quickstart.rs
@@ -28,6 +28,10 @@ fn main() {
         fallback_linear_speed: 0.0,    // the fail-closed safe-stop scalar
     };
 
+    // Capture the envelope ceiling before `contract` is moved into the governor, so
+    // the assertion below tracks the configured value rather than a magic number.
+    let max_speed = contract.max_linear_velocity;
+
     // KirraKernelGovernor<C>::new(contract, initial_scalar, cap_min, cap_max).
     let mut governor = KirraKernelGovernor::new(contract, 0.0, -2.0, 2.0);
 
@@ -52,7 +56,7 @@ fn main() {
             "the checker must never emit a non-finite command"
         );
         assert!(
-            verdict.sanitized_scalar.abs() <= 2.0,
+            verdict.sanitized_scalar.abs() <= max_speed,
             "the checker must never emit outside the hard envelope"
         );
     }

--- a/examples/governor_quickstart.rs
+++ b/examples/governor_quickstart.rs
@@ -1,0 +1,63 @@
+//! Kirra SDK quickstart (Rust) — the CHECKER bounding a DOER's proposals.
+//!
+//! Kirra's load-bearing thesis: a planner (the DOER) PROPOSES a scalar command;
+//! the safety governor (the CHECKER) BOUNDS it, fail-closed, against a hard
+//! kinematic envelope. The doer is never trusted for safety — the checker is the
+//! invariant. This example feeds a governor a sequence of proposed velocities
+//! (some safe, some out-of-envelope, one corrupt `NaN`) and prints what the
+//! checker actually emits to the actuator.
+//!
+//! Run it:
+//! ```text
+//! cargo run --example governor_quickstart
+//! ```
+//!
+//! The C-ABI equivalent of this path is in `examples/c/` (linking `libkirra_verifier`).
+
+use kirra_verifier::kinematics_contract::KinematicContract;
+use kirra_verifier::kirra_core::KirraKernelGovernor;
+use kirra_verifier::SafetyGovernor;
+
+fn main() {
+    // The hard envelope the checker enforces. A proposal outside this is clamped;
+    // a corrupt (non-finite) proposal fails closed to `fallback_linear_speed`.
+    let contract = KinematicContract {
+        max_linear_velocity: 2.0,      // m/s — the absolute speed ceiling
+        max_angular_velocity: 1.0,     // rad/s
+        max_linear_acceleration: 10.0, // m/s² — rate-of-change bound
+        fallback_linear_speed: 0.0,    // the fail-closed safe-stop scalar
+    };
+
+    // KirraKernelGovernor<C>::new(contract, initial_scalar, cap_min, cap_max).
+    let mut governor = KirraKernelGovernor::new(contract, 0.0, -2.0, 2.0);
+
+    // A doer's proposed linear velocities over successive 50 ms ticks. The last is
+    // deliberately corrupt to show the fail-closed path.
+    let dt = 0.05;
+    let proposals = [1.0_f64, 1.8, 5.0 /* over-envelope */, f64::NAN /* corrupt */];
+
+    println!("proposed -> emitted   (why)");
+    println!("---------------------------");
+    for demand in proposals {
+        let verdict = governor.evaluate(demand, dt);
+        // `sanitized_scalar` is what reaches the actuator — NEVER non-finite, NEVER
+        // outside the envelope. `mitigation` is the structured, `Copy` reason code
+        // for the verdict (shown here via `Debug`).
+        println!(
+            "{:>8.2} -> {:>7.2}   ({:?})",
+            demand, verdict.sanitized_scalar, verdict.mitigation
+        );
+        assert!(
+            verdict.sanitized_scalar.is_finite(),
+            "the checker must never emit a non-finite command"
+        );
+        assert!(
+            verdict.sanitized_scalar.abs() <= 2.0,
+            "the checker must never emit outside the hard envelope"
+        );
+    }
+
+    // The governor also exposes its trust posture and last emitted output.
+    println!("\ntrust mode after the corrupt tick: {:?}", governor.trust_mode());
+    println!("last emitted output: {:.2} m/s", governor.last_output());
+}

--- a/include/kirra.h
+++ b/include/kirra.h
@@ -1,3 +1,19 @@
+/*
+ * kirra.h — Kirra safety-governor C ABI (ADR-0006 Clause 3).
+ *
+ * The C/C++ integration boundary for the Kirra runtime safety governor. A caller
+ * PROPOSES a scalar actuator command; the governor BOUNDS it, fail-closed, against
+ * a hard kinematic envelope and rate-of-change limits compiled into the library.
+ * The doer is never trusted for safety — these functions are the invariant.
+ *
+ * All functions operate on ONE process-wide governor and are thread-safe (an
+ * internal mutex serialises access). Every function fails CLOSED: any error path
+ * (non-finite input, invalid timestep, poisoned lock) yields the safe value
+ * (0.0 / 0), never an unclamped or non-finite command.
+ *
+ * Link against the cdylib `libkirra_verifier` (Cargo crate-type includes cdylib);
+ * see examples/c/ for a runnable demo.
+ */
 #ifndef KIRRA_H
 #define KIRRA_H
 
@@ -8,9 +24,49 @@
 extern "C" {
 #endif
 
+/**
+ * Bound a proposed LINEAR velocity against the envelope + rate limits.
+ *
+ * @param demand  proposed linear velocity (m/s).
+ * @param dt      timestep since the previous command (seconds); must be > 0.
+ * @return the sanitized velocity to actuate — ALWAYS finite and within the
+ *         envelope. A non-finite @p demand, a non-positive @p dt, or an internal
+ *         lock failure returns the fail-closed fallback (0.0).
+ */
 double kirra_filter_move_velocity(double demand, double dt);
+
+/**
+ * Bound a proposed ANGULAR velocity to the governor's maximum angular rate.
+ *
+ * @param angular_demand  proposed angular velocity (rad/s).
+ * @param dt              timestep (seconds); currently unused by the angular clamp.
+ * @return the clamped angular rate — ALWAYS finite. A non-finite input (or lock
+ *         failure) returns 0.0; an over-limit input is clamped to the bound. Both
+ *         off-nominal cases decay the trust score.
+ */
 double kirra_filter_rotate_velocity(double angular_demand, double dt);
+
+/**
+ * @return the governor's current trust score, 0–100. Safe ticks raise it; clamps
+ *         and fail-closed rejections decay it. An internal lock failure reads 0.
+ */
 uint32_t kirra_get_trust_score(void);
+
+/**
+ * Authenticated supervisor reset of the governor's trust state.
+ *
+ * Requires the KIRRA_SUPERVISOR_RESET_KEY environment variable to be set and the
+ * presented @p token_ptr to match it. Rate-limited: repeated failures arm a
+ * brute-force cooldown. The token bytes are never logged.
+ *
+ * @param token_ptr  pointer to @p token_len readable bytes (the reset token).
+ * @param token_len  token length in bytes; must be in [1, 64].
+ * @return 1 on a successful reset, 0 on ANY rejection (bad/oversized token,
+ *         null pointer, unset key, active cooldown) — fail-closed.
+ *
+ * @warning The caller owns pointer validity: @p token_ptr must address
+ *          @p token_len valid, non-aliased bytes that outlive the call.
+ */
 int kirra_reset_state(const uint8_t *token_ptr, size_t token_len);
 
 #ifdef __cplusplus

--- a/include/kirra.h
+++ b/include/kirra.h
@@ -40,9 +40,10 @@ double kirra_filter_move_velocity(double demand, double dt);
  *
  * @param angular_demand  proposed angular velocity (rad/s).
  * @param dt              timestep (seconds); currently unused by the angular clamp.
- * @return the clamped angular rate — ALWAYS finite. A non-finite input (or lock
- *         failure) returns 0.0; an over-limit input is clamped to the bound. Both
- *         off-nominal cases decay the trust score.
+ * @return the clamped angular rate — ALWAYS finite. A non-finite input returns 0.0
+ *         and decays the trust score; an over-limit input is clamped to the bound and
+ *         decays trust. If the internal lock cannot be acquired it returns 0.0
+ *         WITHOUT touching trust (fail-closed).
  */
 double kirra_filter_rotate_velocity(double angular_demand, double dt);
 

--- a/src/adapters/dnp3.rs
+++ b/src/adapters/dnp3.rs
@@ -89,7 +89,7 @@ impl Dnp3Adapter {
     ///     fail-closed default),
     ///   - a value outside `[min, max]` → `Err(DNP3_ANALOG_OUTPUT_ENVELOPE_BREACH)`.
     ///
-    /// Only the control function codes (Select / Operate / Direct_Operate[_NR],
+    /// Only the control function codes (Select / Operate / `Direct_Operate[_NR]`,
     /// 0x03–0x06) carry a commanded setpoint; reads/responses are not bounded.
     /// A control with no g41 object (e.g. a CROB-only relay op) is `Ok` here —
     /// CROB is a relay control block, not a scalar magnitude.

--- a/src/attestation.rs
+++ b/src/attestation.rs
@@ -208,7 +208,7 @@ pub fn parse_ed25519_public_pem(pem: &str) -> Option<VerifyingKey> {
 // ---------------------------------------------------------------------------
 
 /// Domain tag for an operator clearance-grant signature. Distinct from
-/// [`ATTESTATION_DOMAIN`] so an operator signature can never be cross-replayed as
+/// `ATTESTATION_DOMAIN` so an operator signature can never be cross-replayed as
 /// a node attestation (or vice versa).
 pub const OPERATOR_GRANT_DOMAIN: &[u8] = b"KIRRA-OPERATOR-GRANT-v1";
 

--- a/src/fabric/router.rs
+++ b/src/fabric/router.rs
@@ -218,7 +218,7 @@ impl FabricRouter {
     /// Cross-asset trust propagation rules.
     /// Returns a list of (asset_id, forced_posture) pairs to apply.
     ///
-    /// Thin map over [`FabricRouter::evaluate_cross_asset_trust`] — the returned
+    /// Thin map over `FabricRouter::evaluate_cross_asset_trust` — the returned
     /// `(follower, posture)` pairs (and their order) are byte-identical to the
     /// pre-SG-007-recording behavior. The richer trigger-tagged result is used
     /// only by [`FabricRouter::propagate_and_record`] for causal-log recording.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,3 +1,14 @@
+//! # C ABI — the safety-governor integration boundary (ADR-0006 Clause 3)
+//!
+//! The stable C entry points declared in [`include/kirra.h`](https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/include/kirra.h).
+//! A C/C++ integrator PROPOSES a scalar command; the governor BOUNDS it,
+//! fail-closed, against a hard kinematic envelope. All functions operate on one
+//! process-wide governor (`GLOBAL_GOVERNOR`) and are safe to call from any thread
+//! (an internal mutex serialises access); a poisoned lock fails closed to `0.0`.
+//!
+//! See `examples/c/kirra_ffi_demo.c` for a linked, runnable consumer, and the Rust
+//! `governor_quickstart` example for the equivalent in-process path.
+
 use std::sync::{Mutex, LazyLock};
 use crate::kirra_core::{KirraKernelGovernor, RuntimeTrustEngine};
 use crate::kinematics_contract::KinematicContract;
@@ -11,11 +22,20 @@ static GLOBAL_GOVERNOR: LazyLock<Mutex<KirraKernelGovernor<KinematicContract>>> 
     Mutex::new(KirraKernelGovernor::new(contract, 0.0, -2.0, 2.0))
 });
 
+/// Bound a proposed LINEAR velocity (m/s) against the governor's envelope and
+/// rate-of-change limits, over a timestep `dt` (seconds). Returns the sanitized
+/// scalar to send to the actuator — ALWAYS finite and inside the envelope. A
+/// non-finite proposal, a non-positive `dt`, or a poisoned lock fails closed to the
+/// contract fallback (`0.0`).
 #[no_mangle]
 pub extern "C" fn kirra_filter_move_velocity(proposed_velocity: f64, dt: f64) -> f64 {
     GLOBAL_GOVERNOR.lock().map(|mut g| g.evaluate(proposed_velocity, dt).sanitized_scalar).unwrap_or(0.0)
 }
 
+/// Bound a proposed ANGULAR velocity (rad/s) to the governor's `max_angular_rate`.
+/// Returns the clamped rate — ALWAYS finite. A non-finite proposal (or a poisoned
+/// lock) fails closed to `0.0` and decays trust; an over-limit proposal is clamped
+/// to the bound and decays trust; an in-bound proposal passes through.
 #[no_mangle]
 pub extern "C" fn kirra_filter_rotate_velocity(proposed_angular: f64, _dt: f64) -> f64 {
     if let Ok(mut g) = GLOBAL_GOVERNOR.lock() {
@@ -39,6 +59,8 @@ pub extern "C" fn kirra_filter_rotate_velocity(proposed_angular: f64, _dt: f64) 
     } else { 0.0 }
 }
 
+/// The governor's current trust score (0–100). Safe ticks raise it; clamps and
+/// fail-closed rejections decay it. A poisoned lock reads as `0` (fail-closed).
 #[no_mangle]
 pub extern "C" fn kirra_get_trust_score() -> u32 {
     GLOBAL_GOVERNOR.lock().map(|g| g.trust_engine.current_score).unwrap_or(0)

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -33,9 +33,10 @@ pub extern "C" fn kirra_filter_move_velocity(proposed_velocity: f64, dt: f64) ->
 }
 
 /// Bound a proposed ANGULAR velocity (rad/s) to the governor's `max_angular_rate`.
-/// Returns the clamped rate — ALWAYS finite. A non-finite proposal (or a poisoned
-/// lock) fails closed to `0.0` and decays trust; an over-limit proposal is clamped
-/// to the bound and decays trust; an in-bound proposal passes through.
+/// Returns the clamped rate — ALWAYS finite. A non-finite proposal fails closed to
+/// `0.0` and decays trust; an over-limit proposal is clamped to the bound and decays
+/// trust; an in-bound proposal passes through. If the lock is poisoned it returns
+/// `0.0` WITHOUT touching trust (the engine was never acquired) — fail-closed.
 #[no_mangle]
 pub extern "C" fn kirra_filter_rotate_velocity(proposed_angular: f64, _dt: f64) -> f64 {
     if let Ok(mut g) = GLOBAL_GOVERNOR.lock() {

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -237,7 +237,7 @@ impl EnforcementOutcome {
 ///   LockedOut → immediate 403 FORBIDDEN     — fail-closed, no physics evaluation
 ///
 /// # Invariants
-/// - Uses State<Arc<ServiceState>> (invariant #11)
+/// - Uses `State<Arc<ServiceState>>` (invariant #11)
 /// - FleetPosture from crate::verifier
 /// - SharedPostureCache accessed via svc.posture_cache
 /// - LockedOut is always fail-closed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,32 @@
 // pedantry.
 #![allow(clippy::doc_lazy_continuation, clippy::doc_overindented_list_items)]
 
+//! # Kirra — runtime legitimacy engine & safety governor
+//!
+//! Kirra is a fail-closed safety governor for AI-driven robotic and edge systems.
+//! Its load-bearing thesis is **doer / checker**: a planner (the DOER) PROPOSES a
+//! command; Kirra (the CHECKER) BOUNDS it against hard invariants, regardless of
+//! what an AI model, LLM output, or upstream orchestrator instructs. The doer is
+//! swappable and never trusted for safety — the checker is the invariant.
+//!
+//! ## Where to start
+//!
+//! - [`kirra_core::KirraKernelGovernor`] — the scalar governor: clamp a proposed
+//!   command to a [`kinematics_contract::KinematicContract`] envelope + rate limit,
+//!   fail-closed on non-finite input. Implements the [`SafetyGovernor`] trait.
+//! - [`GovernorInterceptResult`] / [`MitigationCode`] — a governor verdict and the
+//!   structured, zero-alloc reason it mitigated.
+//! - [`ffi`] — the C ABI (`include/kirra.h`) exposing the same governor to C/C++.
+//! - `authz`, `verifier`, `federation`, `audit_chain` — the fleet-legitimacy /
+//!   verifier-service side (trust attestation, scoped RBAC, hash-chained audit).
+//!
+//! ## Examples
+//!
+//! - `examples/governor_quickstart.rs` — the checker bounding a doer's proposals
+//!   (`cargo run --example governor_quickstart`).
+//! - `examples/c/kirra_ffi_demo.c` — the same over the C ABI
+//!   (`examples/c/build_and_run.sh`).
+
 pub mod kirra_core;
 pub mod governor_guard;
 pub mod modbus_adapter;

--- a/src/posture_cache.rs
+++ b/src/posture_cache.rs
@@ -182,7 +182,7 @@ pub struct ServiceState {
     pub fabric_causal_log: Arc<FabricCausalLog>,
     /// Channel to the serialized posture-engine worker. Populated by the
     /// Active startup path via `OnceLock::set` AFTER the `ServiceState` is
-    /// already wrapped in `Arc` (the worker spawn needs Arc<AppState>).
+    /// already wrapped in `Arc` (the worker spawn needs `Arc<AppState>`).
     /// `get() == None` on PassiveStandby (no worker is spawned until the
     /// standby promotes). Handlers that mutate trust state, dependency
     /// graph, or other recalc-relevant state call `.get()` and `try_send`

--- a/src/scenario_runner.rs
+++ b/src/scenario_runner.rs
@@ -221,7 +221,7 @@ impl ScenarioRunner {
     /// Processes all events and evaluates all assertions in timestamp order.
     /// Events and assertions at the same timestamp: events first, then assertions.
     ///
-    /// Returns a Vec<AssertionResult> for programmatic inspection.
+    /// Returns a `Vec<AssertionResult>` for programmatic inspection.
     /// Also panics on the first failed assertion with a descriptive message
     /// including the virtual timestamp. Set `panic_on_failure = false` via
     /// `run_collecting()` if you want to collect all results without panicking.

--- a/src/tpm_quote.rs
+++ b/src/tpm_quote.rs
@@ -18,7 +18,7 @@
 //!   6. the quoted `pcrDigest` equals the registered expectation.
 //!
 //! This module is the PURE, hardware-free verification engine (parser + checks),
-//! testable with synthetic quotes (see [`tests::marshal_quote`]). Generating a
+//! testable with synthetic quotes (see `tests::marshal_quote`). Generating a
 //! real quote on a node is a TPM/`tss-esapi` concern (the `tpm` feature).
 //!
 //! LIVE WIRING: [`verify_tpm_quote`] is enforced on `/attestation/verify` for a

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -272,7 +272,7 @@ pub struct AppState {
     /// `pending_challenges` (INVARIANT #5): never persisted, TTL-bounded, single-use.
     pub pending_clearance_challenges: DashMap<String, ClearanceChallengeEntry>,
     /// Durable store for nodes and dependency graph (write-through, read on boot).
-    /// Accessed through the [`StoreHandle`] seam (`with` / `call`) — never a raw
+    /// Accessed through the `StoreHandle` seam (`with` / `call`) — never a raw
     /// lock. Phase 2 of the DB-actor migration swaps the handle's internals for a
     /// dedicated-thread connection owner.
     pub store: crate::store_handle::StoreHandle,
@@ -553,7 +553,7 @@ impl AppState {
         self.calculate_posture_memoized(node_id, &mut black)
     }
 
-    /// As [`calculate_posture`], but reuses a CALLER-OWNED `black` memo across
+    /// As `calculate_posture`, but reuses a CALLER-OWNED `black` memo across
     /// many roots (review P3). A node's fully-evaluated posture is
     /// root-INDEPENDENT (it is a property of the node + its dependency subgraph,
     /// not of which root reached it), so the whole-fleet recalc can share ONE

--- a/src/verifier_store/audit.rs
+++ b/src/verifier_store/audit.rs
@@ -60,7 +60,7 @@ impl VerifierStore {
     /// Returns the verifying key for the FIRST **self-attested** ledger row whose
     /// `key_id` matches — i.e. a `genesis` / `rotation` / `reanchor` row whose
     /// content-addressing holds and whose self-signature verifies
-    /// ([`ledger_row_is_self_attested`]). A forensic `backfill` row (empty
+    /// (`ledger_row_is_self_attested`). A forensic `backfill` row (empty
     /// signature, lost-private-key history) is NOT trusted as a verification key
     /// — `None`, never a key. This is what lets a ROTATED-OUT key still verify
     /// the audit-chain rows it signed, across a key rotation.

--- a/src/verifier_store/epoch.rs
+++ b/src/verifier_store/epoch.rs
@@ -49,7 +49,7 @@ impl VerifierStore {
     ///
     /// Unlike federation/key-rotation writes, the actuator command path does not
     /// naturally own a durable SQLite mutation whose transaction can carry
-    /// [`Self::assert_epoch_held`]. This helper creates a bounded
+    /// `Self::assert_epoch_held`. This helper creates a bounded
     /// `BEGIN IMMEDIATE` assertion transaction solely for the actuator authority
     /// check: while it is open, a competing epoch claim serializes behind it; if
     /// a competing claim already landed, the assertion observes the newer epoch

--- a/src/verifier_store/federation.rs
+++ b/src/verifier_store/federation.rs
@@ -296,7 +296,7 @@ impl VerifierStore {
     }
 
     /// Typed loader for generation-ordered reconciliation (#329 v2 wiring). Returns
-    /// the stored reports for an asset as [`FederatedTrustReportV2`] so the caller can
+    /// the stored reports for an asset as `FederatedTrustReportV2` so the caller can
     /// run `authoritative_posture`. `nonce_hex` / `signature_b64` are NOT persisted in
     /// this table (they are consumed/verified at ingest), so they are left empty here —
     /// the reconciliation API (`reconcile_reports` / `authoritative_posture`) reads only

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -193,7 +193,7 @@ pub struct ClearanceGrantState {
 
 /// Why the in-transaction HA epoch fence rejected a top-tier durable write.
 ///
-/// Returned by [`VerifierStore::assert_epoch_held`], which re-reads the durable
+/// Returned by `VerifierStore::assert_epoch_held`, which re-reads the durable
 /// `ha_state.epoch` INSIDE the write transaction and compares it to the
 /// instance's in-memory `held_epoch`. Every variant is fail-closed: the
 /// enclosing transaction is dropped WITHOUT commit, so no partial write lands.

--- a/src/verifier_store/nodes.rs
+++ b/src/verifier_store/nodes.rs
@@ -56,7 +56,7 @@ impl VerifierStore {
     }
 
     /// Load a single registered node by id, or `None` if unregistered. Additive
-    /// single-row loader (mirrors [`load_operator`] / `load_trusted_federation_controller_key`)
+    /// single-row loader (mirrors `load_operator` / `load_trusted_federation_controller_key`)
     /// — the targeted lookup [`crate::key_registry::KeyRegistry`] uses to resolve a
     /// node's `ak_public_pem` without scanning the whole registry.
     pub fn load_node(&self, node_id: &str) -> Result<Option<RegisteredNode>> {


### PR DESCRIPTION
Closes the first slice of the **G20 SDK remainder** (`GAP_CLOSURE_STATUS.md`): *"2 Python examples only; `kirra.h` a 20-line stub; no Rust/C examples or published rustdoc."*

## Examples (both run in CI, so they never rot)

- **`examples/governor_quickstart.rs`** — the CHECKER bounding a DOER's proposals: feed a `KirraKernelGovernor` safe / over-envelope / corrupt-`NaN` velocities and print what it emits, asserting the output is **always finite and inside the envelope**. `cargo run --example governor_quickstart`.
- **`examples/c/kirra_ffi_demo.c`** + `build_and_run.sh` — the same over the **C ABI**, linking the `libkirra_verifier` cdylib against `include/kirra.h`.
- `examples/README.md` — index + run instructions.

## Docs

- **`include/kirra.h`** rewritten from a bare 4-line stub into a documented ABI header (Doxygen contracts: fail-closed semantics, return values, pointer-safety).
- **`src/ffi.rs`** — module header + per-function docs; **`src/lib.rs`** — a crate-level rustdoc landing page (doer/checker thesis, where-to-start, examples).
- Fixed **14 pre-existing rustdoc defects** across the crate (broken intra-doc links to unresolved/private items; unclosed-HTML `Vec<T>`/`Arc<T>` tags) so the public lib is **rustdoc-clean under `-D warnings`**. All are in-place doc-comment edits — no code/line changes to ratchet-tracked files.

## CI

New **`SDK docs + examples`** job: `cargo doc --no-deps --lib` under `RUSTDOCFLAGS=-D warnings` (broken-intra-doc-link gate), then builds + runs both examples.

## Verification

Both examples build + run (Rust and C-against-cdylib); rustdoc clean under `-D warnings`; 692 lib tests green; clippy clean (lib + examples); quality guardrails pass.

## Flagged separately (out of scope)

`MitigationCode::RateClampEnforced`'s `Display` prints **"GPM/s"** (a flow unit) for the generic scalar governor — a latent unit bug with a test + likely log/audit consumers, so not touched here. The Rust example prints the structured `Debug` instead of surfacing it.

## Remaining G20

Publishing rustdoc to a hosted location (Pages); optionally broadening `deny(missing_docs)` beyond the FFI surface and enriching the C ABI beyond the 4 scalar functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_