### PR TITLE
governor verdict: make the rate-clamp narrative unit-neutral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,12 @@ detail lives in `docs/adr/`, `docs/safety/`, and the PR history:
   (issue #73); the admin-asserted HMAC proof is removed.
 - Per-class kinematic contracts selected by `KIRRA_VEHICLE_CLASS`
   (fail-closed: no default class; #312).
+- `MitigationCode::RateClampEnforced`'s narrative is now **unit-neutral**
+  (`RATE_CLAMP_ENFORCED: Max {max_rate}`, was `… GPM/s`). The generic scalar
+  verdict serves both kinematic (m/s²) and flow (GPM/s) governors, so the
+  formatter cannot assert a domain unit — the contract owns it, matching every
+  other variant's bare-number style. Cosmetic/narrative only (nothing parses it);
+  new gateway `kirra_replay.json` records read without the unit suffix.
 
 ### Security / supply chain
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,14 @@ impl std::fmt::Display for MitigationCode {
             }
             MitigationCode::EnvelopeClampTakesPriority => f.write_str("ENVELOPE_CLAMP_TAKES_PRIORITY"),
             MitigationCode::RateClampEnforced { max_rate } => {
-                write!(f, "RATE_CLAMP_ENFORCED: Max {max_rate} GPM/s")
+                // Unit-NEUTRAL: this generic verdict serves every scalar governor —
+                // kinematic (m/s²) AND flow (GPM/s, e.g. the water-flow Modbus
+                // gateway) — so the formatter cannot know the domain's unit. The
+                // contract owns the unit; a record sink that knows its domain adds
+                // it. Every other variant already prints a bare number, so this
+                // matches the prevailing style (was a hardcoded "GPM/s", correct
+                // only for the flow path and wrong for every kinematic caller).
+                write!(f, "RATE_CLAMP_ENFORCED: Max {max_rate}")
             }
             MitigationCode::PassthroughUnrestrictedNormal => {
                 f.write_str("PASSTHROUGH_UNRESTRICTED_NORMAL")
@@ -188,8 +195,10 @@ mod mitigation_code_tests {
             "ENVELOPE_CLAMP_TAKES_PRIORITY"
         );
         assert_eq!(
+            // Unit-neutral: the generic scalar verdict names no domain unit (the
+            // contract owns it) — was "Max 1.5 GPM/s", wrong for kinematic callers.
             MitigationCode::RateClampEnforced { max_rate: 1.5 }.to_string(),
-            "RATE_CLAMP_ENFORCED: Max 1.5 GPM/s"
+            "RATE_CLAMP_ENFORCED: Max 1.5"
         );
         assert_eq!(
             MitigationCode::PassthroughUnrestrictedNormal.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,11 +177,13 @@ impl std::fmt::Display for MitigationCode {
 mod mitigation_code_tests {
     use super::MitigationCode;
 
-    /// `Display` must reproduce the EXACT prior narrative strings — these are
-    /// recorded into the audit/governor-verdict narrative, so a change here is a
-    /// content change. Numeric detail formats lazily (and only when recorded).
+    /// `Display` PINS the exact narrative strings — they are recorded into the
+    /// audit / governor-verdict narrative (e.g. the gateway `kirra_replay.json`),
+    /// so any change to one is a deliberate recorded-content change and MUST be made
+    /// here on purpose (as the unit-neutral `RateClampEnforced` change was). Numeric
+    /// detail formats lazily (and only when recorded).
     #[test]
-    fn display_reproduces_the_exact_prior_narratives() {
+    fn display_pins_the_recorded_narratives() {
         assert_eq!(
             MitigationCode::NonfiniteInputRejectedFailsafe.to_string(),
             "NONFINITE_INPUT_REJECTED_FAILSAFE"


### PR DESCRIPTION
`MitigationCode::RateClampEnforced`'s `Display` hardcoded **`GPM/s`** (gallons-per-minute per second). But `MitigationCode` is the **generic** verdict for every scalar governor:

- velocity / kinematic callers — `KirraKernelGovernor<KinematicContract>`, where `max_rate` is `max_linear_acceleration` (m/s²) — GPM is **wrong**;
- the water-flow Modbus gateway — `KirraKernelGovernor<ContractProfile>` from `config/asset_profile.json`, genuinely in **GPM** — where the unit was actually correct.

One shared `Display` can't know the domain, so the hardcoded unit was right for the flow path and wrong for every kinematic caller. This is a unit-locality bug, not a typo.

## The fix

Make it **unit-neutral** — `RATE_CLAMP_ENFORCED: Max {max_rate}` — so the generic verdict names no domain unit. The *contract* owns the unit; a record sink that knows its domain can add it. This matches the prevailing style: **every other `MitigationCode` variant already prints a bare number** (`RateClampEnforced` was the lone unit-bearing one).

## Blast radius (narrative-only)

Traced across `src`/`tests`/`crates`/`parko`/fixtures: **nothing parses or wire-depends on the string** — it's display/record-only. Specifically:
- The one unit test asserting the exact text (`mitigation_code_tests`) is updated.
- The narrative flows into the gateway's `kirra_replay.json` (serialized `JournalEntry.operator_narrative`); new records read without the `GPM/s` suffix. The numeric setpoints are recorded separately, and `tests/hil_replay_proof.py` asserts **Modbus response bytes**, not the narrative — so it's unaffected.

## Verification

692 lib tests + 65 gateway tests green; clippy clean; quality guardrails pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_