### PR TITLE
G18 (WS-2): config schema versioning + effective-config digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ detail lives in `docs/adr/`, `docs/safety/`, and the PR history:
 
 ### Added
 
+- **Config schema versioning + effective-config digest (G18, WS-2).** The
+  industrial Modbus gateway's `KirraRuntimeConfig` (`src/config.rs`,
+  `config/asset_profile.json`) now carries a `config_version` (default
+  `CONFIG_SCHEMA_VERSION`; an unversioned pre-governance file still loads) that is
+  validated **fail-closed** — `0` or a version NEWER than the binary understands is
+  refused, so a config from an unknown future schema is never mis-interpreted
+  against renamed fields. `effective_digest()` computes a stable SHA-256 fingerprint
+  of the loaded config, and the gateway prints `schema vN · sha256:…` at boot — the
+  "which config is this process running?" answer for audit/attestation. First slice
+  of G18; broad env-sprawl absorption for the verifier service remains.
 - **SDK quickstart examples + rustdoc gate (G20, WS-2).** A runnable Rust example
   (`examples/governor_quickstart.rs` — the checker bounding a doer's proposals,
   fail-closed) and a C example (`examples/c/kirra_ffi_demo.c` + `build_and_run.sh`)

--- a/config/asset_profile.json
+++ b/config/asset_profile.json
@@ -1,4 +1,5 @@
 {
+  "config_version": 1,
   "network": {
     "proxy_listen_port": 5502,
     "plc_target_port": 5503,

--- a/docs/analysis/GAP_CLOSURE_STATUS.md
+++ b/docs/analysis/GAP_CLOSURE_STATUS.md
@@ -56,8 +56,12 @@ registry — see the CHANGELOG Unification note.
 ### Track 2 — WS-2 P1 surface remainders (Stage 1, blocks Gate B)
 3. **G15 learning-loop capture** — §3 capture-point decision still OPEN in
    `LEARNING_LOOP_ARCHITECTURE.md`; verdict-emit machinery exists. Effort M.
-4. **G18 config governance** — `KirraRuntimeConfig` exists; no schema/versioning;
-   env sprawl remains. Effort M.
+4. **G18 config governance** — ✅ **first slice landed:** `KirraRuntimeConfig` now
+   has `config_version` + `CONFIG_SCHEMA_VERSION` (fail-closed on `0` / an unknown
+   future schema) and `effective_digest()` (SHA-256 fingerprint printed at boot,
+   `schema vN · sha256:…`). **Remaining:** absorbing the verifier-service env sprawl
+   (~66 `KIRRA_*` sites) into a typed/validated surface — deferred as broad + risky
+   (the `KIRRA_ADMIN_TOKEN` / reset-key env-only carve-outs must be preserved).
 5. **G20 SDK remainder** — ✅ **first slice landed:** a runnable Rust example
    (`governor_quickstart`) + a C example linking the cdylib over a now-documented
    `include/kirra.h`, a crate-level rustdoc landing page + documented FFI surface

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,29 @@
 // src/config.rs
+//
+// G18 config governance (WS-2): the industrial Modbus gateway's runtime config
+// (`src/main.rs` → the water-flow PLC deployment). This surface is now VERSIONED
+// (fail-closed on a schema newer than the binary understands) and carries an
+// effective-config DIGEST — a stable fingerprint answering "which config is this
+// process running?" for audit/attestation (docs/roadmap/PRODUCT_EXECUTION_PLAN.md).
 
 use crate::kirra_core::ContractProfile;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+
+/// The config-schema version THIS binary understands. A config declaring a HIGHER
+/// version is refused: the binary cannot be sure it interprets a newer schema, so
+/// it fails closed rather than mis-reading fields (e.g. a renamed safety bound).
+/// Bump this — and document the migration — whenever the config shape changes.
+pub const CONFIG_SCHEMA_VERSION: u32 = 1;
+
+/// An unversioned config (pre-governance file) is treated as the CURRENT schema, so
+/// existing `config/asset_profile.json`-style files still load. New configs SHOULD
+/// declare `config_version` explicitly.
+fn default_config_version() -> u32 {
+    CONFIG_SCHEMA_VERSION
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NetworkConfig {
@@ -22,13 +41,40 @@ pub struct TelemetryConfig {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KirraRuntimeConfig {
+    /// Config-schema version. Absent → the current schema (back-compat). Validated
+    /// fail-closed: `0`, or a version NEWER than [`CONFIG_SCHEMA_VERSION`], is refused.
+    #[serde(default = "default_config_version")]
+    pub config_version: u32,
     pub network: NetworkConfig,
     pub telemetry: TelemetryConfig,
     pub contract: ContractProfile,
 }
 
 impl KirraRuntimeConfig {
+    /// SHA-256 (hex) of the canonical serialization of the effective config — a
+    /// stable fingerprint for audit/attestation ("which config is this process
+    /// running?"). Structs serialize in declaration order, so the encoding is
+    /// deterministic; a serialization failure (never expected for this struct)
+    /// yields the digest of the empty string rather than panicking.
+    #[must_use]
+    pub fn effective_digest(&self) -> String {
+        use sha2::{Digest, Sha256};
+        let canonical = serde_json::to_string(self).unwrap_or_default();
+        let mut hasher = Sha256::new();
+        hasher.update(canonical.as_bytes());
+        hex::encode(hasher.finalize())
+    }
+
     pub fn validate_safety_invariants(&self) -> Result<(), &'static str> {
+        // Schema-version gate FIRST (fail-closed): a config from an unknown future
+        // schema must never be interpreted against this binary's field meanings.
+        if self.config_version == 0 {
+            return Err("CONFIG_INVALID: config_version must be >= 1 (0 is not a valid schema version).");
+        }
+        if self.config_version > CONFIG_SCHEMA_VERSION {
+            return Err("CONFIG_INVALID: config_version is newer than this binary supports — refusing a config from an unknown future schema (fail-closed).");
+        }
+
         let n = &self.network;
         let c = &self.contract;
 
@@ -76,5 +122,79 @@ impl KirraRuntimeConfig {
         let parsed: Self = serde_json::from_str(&contents).map_err(|e| format!("JSON_DESERIALIZE_ERROR: {}", e))?;
         parsed.validate_safety_invariants().map_err(|e| e.to_string())?;
         Ok(parsed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A valid reference config (mirrors config/asset_profile.json's shape).
+    fn valid_json(version_field: &str) -> String {
+        format!(
+            r#"{{
+                {version_field}
+                "network": {{
+                    "proxy_listen_port": 5502, "plc_target_port": 5503,
+                    "admin_reset_port": 5504, "metrics_http_port": 8080,
+                    "max_concurrent_connections": 32
+                }},
+                "telemetry": {{ "log_directory": "/var/log/kirra" }},
+                "contract": {{
+                    "asset_register_offset": 10,
+                    "min_permissible_ceiling": 1000.0, "max_permissible_ceiling": 3000.0,
+                    "max_angular_velocity_ceiling": 1.5, "max_rate_of_change_dt": 100.0,
+                    "fallback_safe_setpoint": 1200.0,
+                    "constraint_cap_min": 1100.0, "constraint_cap_max": 2000.0,
+                    "engineering_scale_factor": 10.0
+                }}
+            }}"#
+        )
+    }
+
+    fn parse(json: &str) -> KirraRuntimeConfig {
+        serde_json::from_str(json).expect("valid json")
+    }
+
+    #[test]
+    fn absent_version_defaults_to_current_schema() {
+        // Back-compat: a pre-governance (unversioned) config loads as the current schema.
+        let cfg = parse(&valid_json(""));
+        assert_eq!(cfg.config_version, CONFIG_SCHEMA_VERSION);
+        assert!(cfg.validate_safety_invariants().is_ok());
+    }
+
+    #[test]
+    fn explicit_current_version_is_accepted() {
+        let cfg = parse(&valid_json(r#""config_version": 1,"#));
+        assert_eq!(cfg.config_version, 1);
+        assert!(cfg.validate_safety_invariants().is_ok());
+    }
+
+    #[test]
+    fn zero_version_is_refused() {
+        let cfg = parse(&valid_json(r#""config_version": 0,"#));
+        assert!(cfg.validate_safety_invariants().is_err());
+    }
+
+    #[test]
+    fn future_version_is_refused_fail_closed() {
+        // A config from a newer schema than this binary understands must not run.
+        let cfg = parse(&valid_json(&format!(r#""config_version": {},"#, CONFIG_SCHEMA_VERSION + 1)));
+        let err = cfg.validate_safety_invariants().unwrap_err();
+        assert!(err.contains("newer than this binary supports"), "got: {err}");
+    }
+
+    #[test]
+    fn digest_is_deterministic_and_change_sensitive() {
+        let a = parse(&valid_json(r#""config_version": 1,"#));
+        let b = parse(&valid_json(r#""config_version": 1,"#));
+        assert_eq!(a.effective_digest(), b.effective_digest(), "same config → same digest");
+        assert_eq!(a.effective_digest().len(), 64, "sha-256 hex is 64 chars");
+
+        // A changed safety bound changes the digest — the fingerprint tracks content.
+        let mut c = a.clone();
+        c.contract.max_permissible_ceiling = 3001.0;
+        assert_ne!(a.effective_digest(), c.effective_digest());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,15 +54,20 @@ impl KirraRuntimeConfig {
     /// SHA-256 (hex) of the canonical serialization of the effective config — a
     /// stable fingerprint for audit/attestation ("which config is this process
     /// running?"). Structs serialize in declaration order, so the encoding is
-    /// deterministic; a serialization failure (never expected for this struct)
-    /// yields the digest of the empty string rather than panicking.
-    #[must_use]
-    pub fn effective_digest(&self) -> String {
+    /// deterministic.
+    ///
+    /// **Fail-closed:** a serialization failure returns `Err` rather than a
+    /// valid-looking-but-wrong digest. `serde_json` refuses non-finite floats
+    /// (`NaN`/`Inf`), so this can only fire on a config that never passed
+    /// [`validate_safety_invariants`](Self::validate_safety_invariants) (which now
+    /// rejects non-finite contract fields) — the caller treats it as a boot halt.
+    pub fn effective_digest(&self) -> Result<String, String> {
         use sha2::{Digest, Sha256};
-        let canonical = serde_json::to_string(self).unwrap_or_default();
+        let canonical = serde_json::to_string(self)
+            .map_err(|e| format!("CONFIG_DIGEST_SERIALIZE_FAILED: {e}"))?;
         let mut hasher = Sha256::new();
         hasher.update(canonical.as_bytes());
-        hex::encode(hasher.finalize())
+        Ok(hex::encode(hasher.finalize()))
     }
 
     pub fn validate_safety_invariants(&self) -> Result<(), &'static str> {
@@ -77,6 +82,20 @@ impl KirraRuntimeConfig {
 
         let n = &self.network;
         let c = &self.contract;
+
+        // Non-finite (NaN/Inf) safety bounds are meaningless AND slip past the
+        // ordering checks below (every comparison with NaN is false), so reject them
+        // explicitly. This also guarantees the config is JSON-serializable, so
+        // `effective_digest` cannot fail on a validated config.
+        let finite = [
+            c.min_permissible_ceiling, c.max_permissible_ceiling,
+            c.max_angular_velocity_ceiling, c.max_rate_of_change_dt,
+            c.fallback_safe_setpoint, c.constraint_cap_min, c.constraint_cap_max,
+            c.engineering_scale_factor,
+        ];
+        if finite.iter().any(|v| !v.is_finite()) {
+            return Err("CONFIG_INVALID: contract safety bounds must all be finite (no NaN/Inf).");
+        }
 
         let ports = [n.proxy_listen_port, n.plc_target_port, n.admin_reset_port, n.metrics_http_port];
         for i in 0..ports.len() {
@@ -166,8 +185,9 @@ mod tests {
 
     #[test]
     fn explicit_current_version_is_accepted() {
-        let cfg = parse(&valid_json(r#""config_version": 1,"#));
-        assert_eq!(cfg.config_version, 1);
+        // Track CONFIG_SCHEMA_VERSION so this keeps testing "current version" after a bump.
+        let cfg = parse(&valid_json(&format!(r#""config_version": {CONFIG_SCHEMA_VERSION},"#)));
+        assert_eq!(cfg.config_version, CONFIG_SCHEMA_VERSION);
         assert!(cfg.validate_safety_invariants().is_ok());
     }
 
@@ -189,12 +209,24 @@ mod tests {
     fn digest_is_deterministic_and_change_sensitive() {
         let a = parse(&valid_json(r#""config_version": 1,"#));
         let b = parse(&valid_json(r#""config_version": 1,"#));
-        assert_eq!(a.effective_digest(), b.effective_digest(), "same config → same digest");
-        assert_eq!(a.effective_digest().len(), 64, "sha-256 hex is 64 chars");
+        let da = a.effective_digest().expect("digest");
+        assert_eq!(da, b.effective_digest().expect("digest"), "same config → same digest");
+        assert_eq!(da.len(), 64, "sha-256 hex is 64 chars");
 
         // A changed safety bound changes the digest — the fingerprint tracks content.
         let mut c = a.clone();
         c.contract.max_permissible_ceiling = 3001.0;
-        assert_ne!(a.effective_digest(), c.effective_digest());
+        assert_ne!(da, c.effective_digest().expect("digest"));
+    }
+
+    #[test]
+    fn non_finite_contract_bound_is_refused() {
+        // A NaN safety bound is meaningless and slips past ordering checks (NaN
+        // comparisons are all false) — validation must reject it explicitly, which
+        // also keeps effective_digest serializable.
+        let mut cfg = parse(&valid_json(r#""config_version": 1,"#));
+        cfg.contract.max_permissible_ceiling = f64::NAN;
+        let err = cfg.validate_safety_invariants().unwrap_err();
+        assert!(err.contains("finite"), "got: {err}");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,13 @@ fn main() {
 
     // G18: announce the effective config's schema version + content digest at boot
     // — the "which config is this process running?" fingerprint for audit/attestation.
+    // Fail-closed: a digest failure halts boot rather than running unfingerprinted.
+    let config_digest = runtime_config
+        .effective_digest()
+        .expect("BOOT_HALTED_CONFIG_DIGEST");
     println!(
         "[CONFIG] schema v{} · sha256:{}",
-        runtime_config.config_version,
-        runtime_config.effective_digest()
+        runtime_config.config_version, config_digest
     );
 
     let raw_key_string = env::var("KIRRA_SUPERVISOR_RESET_KEY").expect("SECURITY_FAILURE_ENV_KEY_MISSING");

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,14 @@ fn main() {
     let config_path = args.get(2).map(|s| s.as_str()).unwrap_or("config/asset_profile.json");
     let runtime_config = KirraRuntimeConfig::load_and_validate(config_path).expect("BOOT_HALTED_INVALID_CONFIG");
 
+    // G18: announce the effective config's schema version + content digest at boot
+    // — the "which config is this process running?" fingerprint for audit/attestation.
+    println!(
+        "[CONFIG] schema v{} · sha256:{}",
+        runtime_config.config_version,
+        runtime_config.effective_digest()
+    );
+
     let raw_key_string = env::var("KIRRA_SUPERVISOR_RESET_KEY").expect("SECURITY_FAILURE_ENV_KEY_MISSING");
 
     if raw_key_string.is_empty() {


### PR DESCRIPTION
First slice of **G18 config governance** (`GAP_CLOSURE_STATUS.md`: *"`KirraRuntimeConfig` exists; no schema/versioning"*), on the industrial Modbus gateway's config (`src/main.rs` → the water-flow PLC deployment).

## What this adds

- **Schema versioning, fail-closed.** `config_version` + `CONFIG_SCHEMA_VERSION`. Validated: `0` is refused, and a version **newer than the binary understands** is refused — a config from an unknown future schema must never be interpreted against this binary's (possibly renamed) field meanings. An unversioned pre-governance file still loads (serde default = current schema), so it's **back-compatible**.
- **Effective-config digest.** `effective_digest()` — a stable SHA-256 fingerprint of the loaded config (deterministic; structs serialize in declaration order). The gateway prints `schema vN · sha256:…` at boot: the *"which config is this process running?"* answer for audit/attestation, as the execution plan calls for.
- `config/asset_profile.json` now declares `config_version: 1` explicitly.

## Tests

`config::tests` — absent-version back-compat default, explicit current version accepted, **version 0 and future-version refused (fail-closed)**, digest determinism + change-sensitivity. Verified end-to-end: the built gateway boots and prints `[CONFIG] schema v1 · sha256:7b2bcc3f…`.

## Verification

697 lib tests green (5 new); `kirra-verifier` gateway bin builds + boots; clippy clean; quality guardrails pass. No new deps (`sha2`/`hex` already in tree). `config.rs` is not ratchet-tracked.

## Scope / remaining

This is the bounded, low-risk slice that closes the *"no schema/versioning"* gap. The broader G18 remainder — absorbing the verifier-service env sprawl (~66 `KIRRA_*` sites) into a typed/validated surface — is deferred: it's broad and risky, and must preserve the deliberate `KIRRA_ADMIN_TOKEN` / reset-key **env-only** carve-outs (no config fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_