### PR TITLE
fix(governor): supervisor-reset cooldown must re-open, not lock out forever (M2)

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -162,8 +162,8 @@ fn reset_engine_at(
 mod reset_clock_tests {
     use super::*;
 
-    /// DELTA 1: the injected clock flows into the cooldown computation — after a
-    /// brute-force lockout the cooldown end is set RELATIVE to the real
+    /// DELTA 1: the injected clock flows into the cooldown computation — the
+    /// threshold-th failed attempt arms the cooldown RELATIVE to the real
     /// timestamp (`T + 60_000`), not to a frozen `0`. With the old `now = 0`,
     /// `reset_cooldown_end_ms` would be `60_000` (a 1970 instant) and a probe at
     /// a real timestamp would NOT read as cooldown-active — the timer was inert.
@@ -172,16 +172,13 @@ mod reset_clock_tests {
         let mut engine = RuntimeTrustEngine::new();
         let key = b"supervisor-key";
 
-        // Five wrong tokens arm the brute-force counter.
-        for _ in 0..5 {
-            assert_eq!(reset_engine_at(&mut engine, b"wrong", key, 1_000), 0);
-        }
-        assert_eq!(engine.failed_reset_attempts, 5);
-
         // A real-ish wall-clock timestamp (~2024 in ms).
         let t: u64 = 1_700_000_000_000;
-        // failed >= 5 → brute-force branch arms the cooldown RELATIVE to `t`.
-        assert_eq!(reset_engine_at(&mut engine, key, key, t), 0);
+        // Five wrong tokens at `t`: the threshold-th arms the cooldown at `t + 60s`.
+        for _ in 0..5 {
+            assert_eq!(reset_engine_at(&mut engine, b"wrong", key, t), 0);
+        }
+        assert_eq!(engine.failed_reset_attempts, 5);
         assert_eq!(
             engine.reset_cooldown_end_ms,
             t + 60_000,
@@ -194,6 +191,57 @@ mod reset_clock_tests {
         // and this branch would never be reached.
         assert!(t + 59_999 < engine.reset_cooldown_end_ms);
         assert_eq!(reset_engine_at(&mut engine, key, key, t + 59_999), 0);
+    }
+
+    /// M2 (permanent-lockout fix): once the brute-force cooldown has been SERVED,
+    /// the CORRECT token must succeed. The pre-fix code cleared the failed-attempt
+    /// counter only on a successful compare — which was unreachable, because
+    /// `failed >= threshold` returned BRUTE_FORCE (re-arming the cooldown) before
+    /// the compare, forever. The counter is persisted across restarts, so this was
+    /// an unrecoverable lockout of a legitimate supervisor.
+    #[test]
+    fn served_cooldown_admits_correct_token() {
+        let mut engine = RuntimeTrustEngine::new();
+        let key = b"supervisor-key";
+        let t: u64 = 1_700_000_000_000;
+
+        // Trip the brute-force cooldown.
+        for _ in 0..5 {
+            assert_eq!(reset_engine_at(&mut engine, b"wrong", key, t), 0);
+        }
+        assert_eq!(engine.reset_cooldown_end_ms, t + 60_000);
+
+        // Correct token DURING the window is still blocked (throttle intact).
+        assert_eq!(reset_engine_at(&mut engine, key, key, t + 30_000), 0);
+
+        // Correct token AFTER the window succeeds — the lockout is recoverable.
+        assert_eq!(
+            reset_engine_at(&mut engine, key, key, t + 60_001),
+            1,
+            "a served cooldown must admit the correct token (no permanent lockout)"
+        );
+        assert_eq!(engine.failed_reset_attempts, 0, "success clears the counter");
+        assert_eq!(engine.reset_cooldown_end_ms, 0, "success clears the cooldown");
+        assert_eq!(engine.mode, crate::TrustMode::FullAutonomy);
+    }
+
+    /// A served cooldown grants a FRESH attempt budget, not a single try: after the
+    /// window, wrong tokens count from zero again and only re-arm the cooldown once
+    /// the threshold is hit anew.
+    #[test]
+    fn served_cooldown_grants_fresh_attempt_window() {
+        let mut engine = RuntimeTrustEngine::new();
+        let key = b"supervisor-key";
+        let t: u64 = 1_700_000_000_000;
+
+        for _ in 0..5 {
+            assert_eq!(reset_engine_at(&mut engine, b"wrong", key, t), 0);
+        }
+        let after = t + 60_001;
+        // First wrong attempt after the window: counter restarts at 1, no re-arm.
+        assert_eq!(reset_engine_at(&mut engine, b"wrong", key, after), 0);
+        assert_eq!(engine.failed_reset_attempts, 1);
+        assert_eq!(engine.reset_cooldown_end_ms, 0, "one failure must not re-arm the cooldown");
     }
 
     /// The clock the production FFI path supplies is a real current wall clock,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -244,6 +244,39 @@ mod reset_clock_tests {
         assert_eq!(engine.reset_cooldown_end_ms, 0, "one failure must not re-arm the cooldown");
     }
 
+    /// A restart must NOT bypass the throttle (Copilot #819). The gateway persists
+    /// `failed_reset_attempts` but NOT the in-memory `reset_cooldown_end_ms`, so a
+    /// reboot presents `failed == threshold` with `cooldown_end == 0`. That state
+    /// must ARM a fresh cooldown and reject — not clear the counter and grant an
+    /// immediate fresh window — otherwise an attacker who can force restarts skips
+    /// the wait. Recovery is still possible once the armed window is served.
+    #[test]
+    fn restart_persisted_lockout_arms_cooldown_not_bypass() {
+        let mut engine = RuntimeTrustEngine::new();
+        let key = b"supervisor-key";
+        let t: u64 = 1_700_000_000_000;
+
+        // Simulate the post-restart load: counter restored from disk, cooldown lost.
+        engine.failed_reset_attempts = 5;
+        engine.reset_cooldown_end_ms = 0;
+
+        // Correct token immediately after restart: throttle must NOT be skipped.
+        assert_eq!(reset_engine_at(&mut engine, key, key, t), 0);
+        assert_eq!(
+            engine.reset_cooldown_end_ms,
+            t + 60_000,
+            "a restart at threshold must ARM a cooldown, not clear the counter"
+        );
+        assert_eq!(engine.failed_reset_attempts, 5, "counter held until the cooldown is served");
+
+        // Within the window: still blocked.
+        assert_eq!(reset_engine_at(&mut engine, key, key, t + 59_999), 0);
+
+        // Once served: the correct token recovers (no permanent lockout).
+        assert_eq!(reset_engine_at(&mut engine, key, key, t + 60_001), 1);
+        assert_eq!(engine.failed_reset_attempts, 0);
+    }
+
     /// The clock the production FFI path supplies is a real current wall clock,
     /// not the old hardcoded `0`.
     #[test]

--- a/src/kirra_core.rs
+++ b/src/kirra_core.rs
@@ -48,6 +48,11 @@ impl SafetyContract for ContractProfile {
     #[inline] fn scale_factor(&self) -> f64 { self.engineering_scale_factor }
 }
 
+/// Consecutive failed supervisor-reset attempts that trip the brute-force cooldown.
+pub const RESET_MAX_FAILED_ATTEMPTS: u32 = 5;
+/// Brute-force cooldown window (ms) armed once the failed-attempt threshold is hit.
+pub const RESET_BRUTE_FORCE_COOLDOWN_MS: u64 = 60_000;
+
 pub struct RuntimeTrustEngine {
     pub current_score: u32,
     pub mode: TrustMode,
@@ -103,13 +108,30 @@ impl RuntimeTrustEngine {
     }
 
     pub fn authenticated_manual_reset(&mut self, raw_token: &[u8], system_auth_key: &[u8], current_time_ms: u64) -> Result<(), &'static str> {
-        if current_time_ms < self.reset_cooldown_end_ms { return Err("RESET_REJECTED_COOLDOWN_ACTIVE"); }
-        if self.failed_reset_attempts >= 5 {
-            self.reset_cooldown_end_ms = current_time_ms + 60000;
-            return Err("RESET_DISABLED_BRUTE_FORCE_SUSPECTED");
+        // An armed cooldown window blocks every attempt outright.
+        if current_time_ms < self.reset_cooldown_end_ms {
+            return Err("RESET_REJECTED_COOLDOWN_ACTIVE");
+        }
+        // The cooldown (if one was armed) has now been SERVED, so a prior
+        // brute-force lockout grants a FRESH attempt window here. Without this,
+        // `failed_reset_attempts` — cleared only on a successful compare below —
+        // would stay ≥ threshold forever: every post-cooldown attempt would
+        // re-hit this guard, re-arm a new cooldown, and reject even the CORRECT
+        // token, permanently locking out a legitimate supervisor (the counter is
+        // persisted across restarts, so the lockout survived a reboot too).
+        if self.failed_reset_attempts >= RESET_MAX_FAILED_ATTEMPTS {
+            self.failed_reset_attempts = 0;
+            self.reset_cooldown_end_ms = 0; // served — clear the stale (past) window
         }
         if !constant_time_compare(raw_token, system_auth_key) {
             self.failed_reset_attempts = self.failed_reset_attempts.saturating_add(1);
+            // Hitting the threshold arms the cooldown; the window is re-openable
+            // (served → fresh attempts above), so this throttles brute force
+            // without becoming a permanent lockout.
+            if self.failed_reset_attempts >= RESET_MAX_FAILED_ATTEMPTS {
+                self.reset_cooldown_end_ms = current_time_ms + RESET_BRUTE_FORCE_COOLDOWN_MS;
+                return Err("RESET_DISABLED_BRUTE_FORCE_SUSPECTED");
+            }
             return Err("RESET_REJECTED_INVALID_TOKEN");
         }
         self.current_score = 100;

--- a/src/kirra_core.rs
+++ b/src/kirra_core.rs
@@ -112,16 +112,27 @@ impl RuntimeTrustEngine {
         if current_time_ms < self.reset_cooldown_end_ms {
             return Err("RESET_REJECTED_COOLDOWN_ACTIVE");
         }
-        // The cooldown (if one was armed) has now been SERVED, so a prior
-        // brute-force lockout grants a FRESH attempt window here. Without this,
-        // `failed_reset_attempts` — cleared only on a successful compare below —
-        // would stay ≥ threshold forever: every post-cooldown attempt would
-        // re-hit this guard, re-arm a new cooldown, and reject even the CORRECT
-        // token, permanently locking out a legitimate supervisor (the counter is
-        // persisted across restarts, so the lockout survived a reboot too).
+        // At the threshold, the counter is cleared ONLY once a cooldown has been
+        // armed and SERVED. Clearing it unconditionally would let a legitimate
+        // supervisor recover (the counter is cleared only on a successful compare
+        // below, which the `>= threshold` guard returns before ever reaching — the
+        // permanent-lockout bug), BUT it would also let a restart bypass the
+        // throttle: the gateway persists `failed_reset_attempts` and NOT the
+        // (in-memory) `reset_cooldown_end_ms`, so after a reboot the counter is at
+        // threshold with `reset_cooldown_end_ms == 0` and no wait has been served.
         if self.failed_reset_attempts >= RESET_MAX_FAILED_ATTEMPTS {
+            if self.reset_cooldown_end_ms == 0 {
+                // Threshold reached with NO cooldown on record — the cross-restart /
+                // pre-fix-persisted signature. Arm a cooldown and reject so a
+                // restart cannot skip the wait; it becomes SERVED (and recoverable)
+                // once this window elapses.
+                self.reset_cooldown_end_ms = current_time_ms + RESET_BRUTE_FORCE_COOLDOWN_MS;
+                return Err("RESET_DISABLED_BRUTE_FORCE_SUSPECTED");
+            }
+            // A cooldown was armed and (per the guard above) has now elapsed —
+            // reopen a fresh attempt window so the correct token recovers.
             self.failed_reset_attempts = 0;
-            self.reset_cooldown_end_ms = 0; // served — clear the stale (past) window
+            self.reset_cooldown_end_ms = 0;
         }
         if !constant_time_compare(raw_token, system_auth_key) {
             self.failed_reset_attempts = self.failed_reset_attempts.saturating_add(1);


### PR DESCRIPTION
## Summary

Stop-gate review **M2**: the authenticated supervisor-reset had a **permanent-lockout** bug — once the brute-force counter reached the threshold, a legitimate supervisor could **never** recover the governor, even with the correct token, even after the cooldown elapsed, even across a restart.

## The bug

In `RuntimeTrustEngine::authenticated_manual_reset` (`src/kirra_core.rs`):

- `failed_reset_attempts` was cleared **only** on a successful token compare.
- But once `failed_reset_attempts >= 5`, the guard returned `RESET_DISABLED_BRUTE_FORCE_SUSPECTED` (re-arming a fresh 60 s cooldown) **before** reaching the compare.
- So after the cooldown expired, every subsequent call — including one with the **correct** token — re-hit the `>= 5` guard, re-armed the cooldown, and rejected. Forever.
- The gateway (`src/gateway/mod.rs`) persists the counter to a file (`save_brute_force_counter`), so the lockout **survived a process restart** too — only manual deletion of the counter file could recover it.

## The fix

Once the cooldown window has been **served** (`now >= reset_cooldown_end_ms`), grant a **fresh attempt budget**: clear the counter (and the stale, now-past window) *before* the compare. The cooldown is armed exactly when the threshold is hit anew, so brute-force throttling stays intact but is **re-openable** rather than terminal. Magic numbers extracted to `RESET_MAX_FAILED_ATTEMPTS` / `RESET_BRUTE_FORCE_COOLDOWN_MS`.

Behavior after the fix:
- ≥5 wrong tokens in a window → arm a 60 s cooldown.
- Any attempt during the window → `RESET_REJECTED_COOLDOWN_ACTIVE`.
- After the window → counter resets; the correct token **succeeds**, wrong tokens count from zero again.

## Tests

- `served_cooldown_admits_correct_token` — the permanent-lockout regression (correct token after a served cooldown must succeed).
- `served_cooldown_grants_fresh_attempt_window` — a served cooldown grants a full fresh budget, and one failure does not re-arm.
- `reset_threads_real_clock_into_cooldown_window` — updated; it had encoded the buggy "correct token still rejected at threshold" path while verifying the #103 clock-threading.

## Verification

verifier lib **703 passed**; clippy clean; quality guardrails satisfied. Single-path change (the FFI reset delegates to the same `authenticated_manual_reset`, so there is one source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_