### PR TITLE
fix(rss): predictive RSS must fail closed per object, not just per mode-set

### DIFF
--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -1017,6 +1017,47 @@ fn predictive_rss_fails_closed_on_modes_with_no_evaluable_window_b3() {
         "a non-empty mode set with no evaluable window must fail closed; got {verdict:?}");
 }
 
+#[test]
+fn predictive_rss_fails_closed_per_object_when_one_mode_is_unevaluable() {
+    // PER-OBJECT fail-closed: the multi-modal pass must evaluate EVERY object's
+    // mode or fail closed. The B3 guard was set-level — a single "did we evaluate
+    // anything?" flag — so one object's evaluable mode MASKED another object's
+    // fully-unevaluable one, silently letting that object's predicted threat
+    // through (a per-object fail-OPEN reachable via the public `predicted_modes`
+    // arg). Here object 1's mode is evaluable + safe (far to the side, beyond the
+    // lateral-alignment tolerance, so it is evaluated then skipped), while object
+    // 2's mode has proper inter-sample windows but timestamps FAR outside the ego
+    // trajectory's span ([0, 1.9 s]) — so `nearest_in_time` matches nothing and it
+    // is never checked. Pre-fix this returned Accept (object 1 satisfied the
+    // set-level flag); it must now MRC on object 2.
+    let trajectory = straight_trajectory(20, 6.0, 0.1); // ego times [0, 1.9 s], x from 5.0
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+
+    // Object 1 — evaluable and safe (far off to the side; evaluated then skipped
+    // by the lateral-alignment gate). Satisfies the set-level flag on its own.
+    let evaluable_safe = [
+        PredictedSample { pos: Point { x_m: 50.0, y_m: -10.0 }, time_from_start_s: 0.0 },
+        PredictedSample { pos: Point { x_m: 50.0, y_m: -10.0 }, time_from_start_s: 0.1 },
+    ];
+    // Object 2 — has windows (dt > 0) but every sample's time is outside the ego
+    // span, so no ego pose matches within tolerance: unevaluable.
+    let windowed_unevaluable = [
+        PredictedSample { pos: Point { x_m: 9.0, y_m: -3.5 }, time_from_start_s: 100.0 },
+        PredictedSample { pos: Point { x_m: 6.0, y_m: 0.0 }, time_from_start_s: 100.1 },
+    ];
+    let modes = [
+        PredictedMode { object_id: 1, samples: &evaluable_safe },
+        PredictedMode { object_id: 2, samples: &windowed_unevaluable },
+    ];
+
+    let verdict = validate_trajectory_slow_capped(
+        &trajectory, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&modes), None, FrameTrust::Trusted,
+    );
+    assert_eq!(verdict, TrajectoryVerdict::MRCFallback,
+        "one object's unevaluable mode must fail closed even when another object's mode is evaluable; got {verdict:?}");
+}
+
 // ---------------------------------------------------------------------------
 // RSS conjunction (§4): a safe stationary queue is admitted; genuine danger
 // (driving in, or a lateral cut-in) is still rejected. A deterministic SWEEP —

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -688,7 +688,7 @@ fn object_fields_finite(obj: &PerceivedObject) -> bool {
         && obj.heading_rad.is_finite()
 }
 
-// SAFETY: SG1 | REQ: multi-modal-predictive-rss-bound | TEST: predictive_rss_catches_a_predicted_cut_in,predictive_rss_does_not_regress_a_lane_keeping_neighbor,predictive_rss_is_a_no_op_when_no_modes_are_supplied,rss_conjunction_still_rejects_a_lateral_cut_in_at_a_safe_longitudinal_distance,predictive_rss_catches_a_mid_band_lateral_cut_in,predictive_rss_fails_closed_on_modes_supplied_but_all_unevaluable_b3,predictive_rss_fails_closed_on_modes_with_no_evaluable_window_b3
+// SAFETY: SG1 | REQ: multi-modal-predictive-rss-bound | TEST: predictive_rss_catches_a_predicted_cut_in,predictive_rss_does_not_regress_a_lane_keeping_neighbor,predictive_rss_is_a_no_op_when_no_modes_are_supplied,rss_conjunction_still_rejects_a_lateral_cut_in_at_a_safe_longitudinal_distance,predictive_rss_catches_a_mid_band_lateral_cut_in,predictive_rss_fails_closed_on_modes_supplied_but_all_unevaluable_b3,predictive_rss_fails_closed_on_modes_with_no_evaluable_window_b3,predictive_rss_fails_closed_per_object_when_one_mode_is_unevaluable
 fn predictive_rss_breach(
     trajectory: &[TrajectoryPoint],
     modes: &[PredictedMode<'_>],
@@ -701,9 +701,19 @@ fn predictive_rss_breach(
     // ("evaluated → not a threat"). If a non-empty mode set produces NOT ONE
     // evaluable window, the cut-in detector checked nothing; see the fail-closed
     // guard after the loop.
-    let mut evaluated_any = false;
+    // Per-MODE evaluability, not just per mode-SET: each object's mode must be
+    // evaluated or fail closed. A single set-level flag let one object's evaluable
+    // mode MASK another object's fully-unevaluable one (e.g. samples whose times
+    // fall outside the ego trajectory's span, so `nearest_in_time` returns `None`
+    // for every window) — a silent per-object fail-open. `any_windows` preserves
+    // the original set-level guard for the "no windows anywhere" case.
+    let mut any_windows = false;
     for mode in modes {
+        let mut mode_evaluated = false;
+        let mut mode_has_windows = false;
         for pair in mode.samples.windows(2) {
+            mode_has_windows = true;
+            any_windows = true;
             let (a, b) = (pair[0], pair[1]);
             // H-2 (fail-closed predictive RSS): a non-finite predicted-mode
             // sample position poisons the closing-rate (`ov*`) and gap math the
@@ -730,7 +740,7 @@ fn predictive_rss_breach(
             };
             // Past both unevaluable gates: this window WAS evaluated (whatever the
             // geometric verdict below).
-            evaluated_any = true;
+            mode_evaluated = true;
             let dx = a.pos.x_m - ego.pose.x_m;
             let dy = a.pos.y_m - ego.pose.y_m;
             let cos_h = ego.pose.heading_rad.cos();
@@ -800,21 +810,25 @@ fn predictive_rss_breach(
                 }
             }
         }
+        // Per-mode fail-closed: a mode that HAS inter-sample windows but evaluated
+        // NONE of them — every window non-monotonic in time, or none within the ego
+        // trajectory's span — means THIS object's predicted threat was checked
+        // against nothing. Fail closed here rather than let another object's
+        // evaluable mode mask it (the per-object fail-open the set-level flag had).
+        if mode_has_windows && !mode_evaluated {
+            return true;
+        }
     }
 
-    // B3 (fail-closed): the caller already treats `predicted_modes == None` /
-    // an EMPTY slice as the legitimate "no prediction supplied" no-op. But a
-    // NON-EMPTY mode set that produced ZERO evaluable windows — every sample
-    // non-monotonic in time, or none within the ego trajectory's time span, or
-    // no inter-sample window at all (a sub-`dt` horizon) — means the multi-modal
-    // predictive pass, the ONLY layer catching a mid-band cut-in the snapshot
-    // filters out, evaluated nothing. Returning `false` here would be a SILENT
-    // FAIL-OPEN that a producer can trigger with equal timestamps or a too-short
-    // horizon. Fail closed instead: derate to the MRC floor (the caller maps
-    // `true` → `TrajectoryVerdict::MRCFallback`). Well-formed modes always have
-    // at least one evaluable window (the t≈0 sample matches the ego start pose),
-    // so the Nominal path is unaffected.
-    if !modes.is_empty() && !evaluated_any {
+    // B3 (fail-closed, set level): a NON-EMPTY mode set that produced NOT ONE
+    // inter-sample window at all (every mode one-sample / a sub-`dt` horizon)
+    // evaluated nothing — the multi-modal pass, the only layer catching a mid-band
+    // cut-in the snapshot filters out, ran on nothing. Returning `false` would be a
+    // SILENT FAIL-OPEN a producer triggers with a too-short horizon. Fail closed;
+    // the caller maps `true` → `TrajectoryVerdict::MRCFallback`. Well-formed modes
+    // always have ≥1 window (the t≈0 sample matches the ego start pose), so the
+    // Nominal path is unaffected.
+    if !modes.is_empty() && !any_windows {
         return true;
     }
 


### PR DESCRIPTION
## Summary

A review of the multi-modal predictive RSS pass (`predictive_rss_breach`, gap #3) turned up a **per-object fail-open** in its fail-closed guard.

## The bug

The pass already guards against a silent fail-open: if a non-empty predicted-mode set produces **zero** evaluable windows (every sample non-monotonic in time, or none within the ego trajectory's span), it fails closed → `MRCFallback`. But that guard used a single **set-level** flag (`evaluated_any`) shared across *all* objects' modes.

So with two objects — object 1's mode evaluable, object 2's mode fully **unevaluable** — object 1 alone satisfied the flag, and object 2's predicted threat was checked against **nothing** while the pass still returned "safe." That object silently fell through.

This is **reachable via the public checker API**: `validate_trajectory_slow[_capped]` takes an integrator-supplied `predicted_modes` slice, so a mode whose sample timestamps fall outside the ego trajectory's time span (→ `nearest_in_time` matches nothing for every window) triggers it.

## The fix

Track evaluability **per mode**. A mode that *has* inter-sample windows but evaluated *none* of them fails closed immediately, instead of deferring to another object's evaluable mode. The original set-level guard is preserved (renamed `any_windows`) for the "no windows anywhere" case (all one-sample / sub-`dt` modes).

The **Nominal path is unchanged** — well-formed modes always have ≥1 evaluable window (the t≈0 sample matches the ego start pose), so no real prediction is affected. This strictly *adds* fail-closed coverage; it can never admit a previously-rejected trajectory.

## Test + negative control

`predictive_rss_fails_closed_per_object_when_one_mode_is_unevaluable`: object 1 evaluable + safe (far to the side), object 2 windowed but out-of-span (unevaluable) → asserts `MRCFallback`. Verified **discriminating**: disabling the per-mode guard makes the test fail-open to `Accept` (confirming it exercises the exact gap, not a trivially-green assertion).

## Verification

`kirra-trajectory` + `kirra-ros2-adapter` suites green (54 validation tests incl. the new one, all existing B3/predictive/RSS-conjunction tests unchanged); clippy clean; quality guardrails satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_