### PR TITLE
docs: sync CLAUDE.md + roadmap README; ci: durable ros2 apt-source fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@
 - **Primary binary**: `kirra_verifier_service` (`src/bin/kirra_verifier_service.rs`)
 - **Secondary binary**: `kirra_carla_client` (`src/bin/kirra_carla_client.rs`)
 - **Test suite**: `cargo test` (root). For a scoped crate use `cargo test -p <crate>`. `parko/` is its own workspace: `cd parko && cargo test`. The `kirra-ros2-adapter` `node.rs` is `#[cfg(feature = "ros2")]` and needs a sourced ROS 2 toolchain (`r2r`) — it is built ONLY by CI's `ros2 adapter build (--features ros2)` job, never by a default build.
+- **Build toolchain**: pinned to **1.94.1** via `rust-toolchain.toml` (reproducible builds); **MSRV is 1.88**, enforced on every PR by the `msrv` CI lane (`cargo +1.88.0 check --workspace --locked` on both lockfiles). Build on the pin; support down to the MSRV. See `docs/VERSIONING_POLICY.md` §3.
+- **Hardening harnesses** (workspace-detached, own CI lanes): **loom** concurrency models — `crates/kirra-loom-models`, run `RUSTFLAGS="--cfg loom" cargo test -p kirra-loom-models --release` (models the posture-generation + #688 sticky-lockout protocols). **cargo-fuzz** targets — `fuzz/`, run `cargo +nightly fuzz run <target>` (decoders: `decode_verdict`, `dnp3_analog_setpoint`, `scalar_decode_le`, `llm_json_intent`). Both compile to nothing in a normal build.
 - **Remote**: `kirra-systems/kirra-runtime-sdk`
 - **Repo root in prompts**: use `~/kirra-runtime-sdk` (not `/home/user/...` or `/home/user/aegis`)
 
@@ -197,6 +199,9 @@ CURRENT position; the predictive pass rolls each `PredictedMode` forward in TIME
 time-matched ego pose — catching a cut-in / turn-in the snapshot filtered as laterally clear.
 Worst-case over modes (one dangerous hypothesis refuses). Producer: `predicted_modes_from_objects`
 (CV always; CTRV when the tracker yaw feed is fresh — stale yaw degrades to CV-only, not a fault).
+Fail-closed is **per mode**, not per mode-SET: a mode with inter-sample windows that evaluates
+none of them (samples out of the ego trajectory's time span, all non-monotonic, …) → MRC, so one
+object's evaluable mode can never mask another object's unevaluable one (#824).
 
 **Perception-divergence monitor** (gap #2b, True-Redundancy, LIVE): `cross_check` requires two
 independent perception channels to AGREE; a divergence (phantom / miss / speed mismatch) OR a

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -17,35 +17,17 @@ For the full task-level roadmap (PARK-001 through PARK-040), see
 
 ## Current Execution Order
 
-**Now (actively in progress — see /work/active.md):**
-- [~] PARK-001 — Attach `SafetyGovernor` to `ControlLoop` (GitHub Issue #6)
-- [~] PARK-002 — Add `set_state_for_test` test seam (GitHub Issue #7)
-- [~] PARK-003 — Posture divergence proptest (GitHub Issue #16)
-
-**Increment 1 completion (v0.1):**
-- PARK-004 NaN/Inf guard, PARK-005 Clock abstraction, PARK-006 release tag
-
-**TIME-SENSITIVE parallel tracks:**
-- PARK-020–023 TensorRT spike (Jetson arriving — highest leverage)
-- PARK-024–026 QNX deployment (30-day license — do not let this expire)
-
-**Increment 2 — HAL (v0.2):**
-- PARK-007 through PARK-012 (backend trait, CPU ONNX validation, MockBackend, stubs)
-
-**Increment 3 — Behavioral Safety / IEEE 2846 (v0.3):**
-- PARK-013–019: RSS safe-distance, posture engine wiring, audit chain, 10k-scenario sim
-- RSS_KIRRA_INTEGRATION.md is the detailed specification for this increment
-
-**Increment 4 — Silicon Matrix Expansion (v0.4):**
-- QNN, TIDL, OpenVINO, AMD backends (most blocked on hardware)
-
-**Increment 5 — Packaging (v1.2):**
-- PARK-031–035 Docker/Helm/installer/systemd/QNX artifact
-
-**Increment 6 — Robot Stack + Certification (v2.0):**
-- PARK-036–038 ROS2 + Hiwonder (BLOCKED on hardware delivery)
-- PARK-039–040 IEC 61508 SIL 3 / ASTM F3269 mappings
-- Apollo integration (APOLLO_KIRRA_INTEGRATION.md) follows ROS2 demo
+> **Live status is not tracked in this file.** This directory holds pre-execution
+> architecture sketches (the Documents table above) — those don't go stale. The
+> authoritative, current task-level roadmap + work-in-progress status lives in
+> [`/work/roadmap.md`](/work/roadmap.md) and [`/work/active.md`](/work/active.md),
+> with GitHub issue state as the other source of truth. An increment snapshot used
+> to be duplicated here and had drifted badly (it listed long-completed
+> Increment-1 tasks — attach-governor, test seam, divergence proptest — as
+> "in progress," while the tree is well past that: parko backends, the RSS/IEEE-2846
+> behavioral-safety layer, and the QNX governor-judge harness all exist). It was
+> removed in favor of the single source above. The stable design constraints that
+> govern any sequencing are kept below.
 
 ## Sequencing Rules
 


### PR DESCRIPTION
## Summary

Two independent changes on this branch.

### 1. Docs sync (verifiable facts only)
- **`CLAUDE.md`**: toolchain pin + MSRV lane (M4), the loom/fuzz hardening crates + how to run them (M5), and the predictive-RSS per-mode fail-closed (#824).
- **`docs/roadmap/README.md`**: the "Current Execution Order" snapshot had drifted badly (Increment-1 tasks marked in-progress though the tree is at Increment 3+). Replaced the stale duplicate with a pointer to the maintained source of truth (`/work/roadmap.md`, `/work/active.md`, issue state); kept the stable Documents table + Sequencing Rules.

*(Forward priorities / root-README positioning left to the owner — #298.)*

### 2. Durable ROS2 CI fix
The `ros2-adapter-build` job installed ROS via `ros-tooling/setup-ros`, whose `ros2-apt-source` version lookup is an **unauthenticated** api.github.com call (60/hr per shared runner IP). On rate-limit → empty version → deb URL 404 → `curl --fail` exit 22 → job dies (the symptom reported). The single 90 s retry only covers a brief transient.

**Fix** (the job comment already named it): run the job **inside the prebuilt `ros:jazzy-ros-base` image**. ROS + colcon + build-essential + git are baked in → **no ROS apt install at all** → the rate-limit (and the slow-mirror stalls) can't happen. Only extra install is `libclang` (r2r's bindgen) + curl/ca-certs (rustup); `defaults.run.shell: bash` so the `source setup.bash` steps work. `setup-ros` + its retry/delay + apt-hardening are removed; the colcon msgs build, rust toolchain, and `cargo --features ros2` builds are unchanged.

> ⚠️ **This CI change is validatable only in CI** (no ROS/Docker locally). The `ros2 adapter build` lane on this PR is the check. If it reds on a container-specific gotcha (libclang path, colcon variant, JS-action-in-container), I'll iterate. The doc changes above are independent and safe regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)