### PR TITLE
feat(audit): WORM off-box audit shipping + independent re-verifier (WS-4 / Track 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,11 @@ src/
 ├── federation_reconciliation.rs — FederatedTrustReportV2, reconcile_reports,
 │                               ReconciliationOutcome, authoritative_posture
 ├── audit_chain.rs            — SHA-256 hash-chained audit log
+├── audit_shipper.rs          — WS-4/Track-3 WORM off-box audit shipping:
+│                               ShippedAuditRecord, verify_shipped_chain (INDEPENDENT
+│                               off-box hash-chain re-verifier, no source DB),
+│                               AuditSink (InMemory/JsonlFile), ship_and_advance +
+│                               cursor persistence (at-least-once, ship-then-advance)
 ├── ota_campaign.rs           — WS-4/Track-3 OTA governor-artifact campaign engine
 │                               (PURE): Campaign, CampaignState machine, HaltReason,
 │                               fail-closed posture_regression_halt (advance HALTS,

--- a/src/audit_shipper.rs
+++ b/src/audit_shipper.rs
@@ -1,0 +1,550 @@
+//! WORM / off-box audit shipping (WS-4 / Track 3 — Fleet Plane).
+//!
+//! The local audit ledger (`audit_log_chain`) is SHA-256 hash-chained and
+//! Ed25519 anchor-signed, so it is tamper-EVIDENT — but it lives on the box. If
+//! the box is lost (disk failure, seizure, a wipe), the evidence goes with it.
+//! This module ships each new audit record to an append-only (Write-Once-
+//! Read-Many) off-box sink and provides an INDEPENDENT re-verifier that re-checks
+//! the hash chain on the shipped records alone — no source DB required.
+//!
+//! **The WORM guarantee.** [`verify_shipped_chain`] recomputes every record hash
+//! from the record's own content (the same domain-separated construction the
+//! store uses — [`AuditChainLinker::compute_record_hash_v2`]) and checks
+//! (a) the recomputed hash matches, (b) each record's `previous_hash` links to
+//! the prior record's hash, and (c) sequences are contiguous ascending. Any
+//! single-field mutation breaks the hash; a dropped record breaks contiguity; a
+//! reorder breaks linkage. So a verifier holding only the shipped stream can
+//! prove the off-box copy is intact even after the origin is gone.
+//!
+//! This module is the shipping CORE (records + sinks + shipper + re-verifier);
+//! the background scheduler that drives it on an interval is a thin follow-up.
+
+use std::io::Write as _;
+
+use serde::{Deserialize, Serialize};
+
+use crate::audit_chain::AuditChainLinker;
+
+/// One audit-chain record in its off-box shipped form — the raw chain fields
+/// needed to INDEPENDENTLY re-verify the hash chain without the source database.
+/// (Deliberately distinct from `AuditExportEntry`, which is the DESC-paginated
+/// human/API export view and omits `sequence`/`hash_version`.)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShippedAuditRecord {
+    pub sequence: u64,
+    pub event_type: String,
+    pub event_json: String,
+    pub previous_hash_hex: String,
+    pub record_hash_hex: String,
+    pub created_at_ms: i64,
+    pub hash_version: i64,
+    pub signature_b64: Option<String>,
+    pub key_id: Option<String>,
+}
+
+impl ShippedAuditRecord {
+    /// Recompute this record's hash from its own content, dispatching on
+    /// `hash_version` exactly as the store does (v2 binds `event_type` + `sequence`
+    /// and is domain-separated; v1 is the legacy `prev || json || ts` form).
+    fn recompute_hash(&self) -> String {
+        match self.hash_version {
+            2 => AuditChainLinker::compute_record_hash_v2(
+                &self.previous_hash_hex,
+                &self.event_type,
+                &self.event_json,
+                self.created_at_ms,
+                self.sequence,
+            ),
+            // hash_version 1 (and any pre-v2 legacy row): the original
+            // `prev || canonical_json || created_at_ms` construction.
+            _ => AuditChainLinker::compute_record_hash_v1(
+                &self.previous_hash_hex,
+                &self.event_json,
+                self.created_at_ms,
+            ),
+        }
+    }
+}
+
+/// The verdict of an off-box re-verification of a shipped chain segment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShippedChainVerdict {
+    /// The whole segment is internally consistent: every hash recomputes, prev
+    /// linkage holds, sequences are contiguous ascending.
+    Ok { records: u64, last_sequence: u64 },
+    /// No records were supplied.
+    Empty,
+    /// A record's recomputed hash does not match its stored `record_hash_hex`
+    /// (content tamper).
+    HashMismatch { sequence: u64 },
+    /// A record's `previous_hash_hex` does not link to the prior record's hash
+    /// (reorder / splice).
+    PrevLinkageBroken { sequence: u64 },
+    /// A gap in the ascending sequence (a dropped/missing record).
+    SequenceGap { expected: u64, found: u64 },
+}
+
+impl ShippedChainVerdict {
+    /// `true` only for [`ShippedChainVerdict::Ok`].
+    pub fn is_ok(&self) -> bool {
+        matches!(self, ShippedChainVerdict::Ok { .. })
+    }
+}
+
+/// Independently re-verify a CONTIGUOUS shipped chain segment (in ascending
+/// sequence order) using only the records themselves — the WORM guarantee. The
+/// segment need not start at sequence 1 (incremental shipping starts wherever the
+/// last batch ended), but it must be internally contiguous: each record's
+/// sequence is the previous + 1 and its `previous_hash` is the previous record's
+/// hash. The first record's `previous_hash` is taken as given (its predecessor is
+/// outside the segment); every subsequent link and every hash is checked.
+pub fn verify_shipped_chain(records: &[ShippedAuditRecord]) -> ShippedChainVerdict {
+    if records.is_empty() {
+        return ShippedChainVerdict::Empty;
+    }
+    let mut prev_hash: Option<&str> = None;
+    let mut expected_seq: Option<u64> = None;
+
+    for r in records {
+        if let Some(exp) = expected_seq {
+            if r.sequence != exp {
+                return ShippedChainVerdict::SequenceGap {
+                    expected: exp,
+                    found: r.sequence,
+                };
+            }
+        }
+        if let Some(ph) = prev_hash {
+            if r.previous_hash_hex != ph {
+                return ShippedChainVerdict::PrevLinkageBroken {
+                    sequence: r.sequence,
+                };
+            }
+        }
+        if r.recompute_hash() != r.record_hash_hex {
+            return ShippedChainVerdict::HashMismatch {
+                sequence: r.sequence,
+            };
+        }
+        prev_hash = Some(&r.record_hash_hex);
+        expected_seq = Some(r.sequence + 1);
+    }
+
+    ShippedChainVerdict::Ok {
+        records: records.len() as u64,
+        // Safe: non-empty checked above.
+        last_sequence: records.last().map(|r| r.sequence).unwrap_or(0),
+    }
+}
+
+/// An append-only (WORM) destination for shipped audit records. Implementations
+/// must only ever APPEND — never rewrite or truncate — so the off-box copy is
+/// write-once. Appends are all-or-nothing from the shipper's view (a partial
+/// append surfaces as `Err` and the high-water mark is not advanced).
+pub trait AuditSink {
+    fn append(&mut self, records: &[ShippedAuditRecord]) -> std::io::Result<()>;
+}
+
+/// In-memory sink for tests and for composing a sink in front of another
+/// transport. Accumulates the shipped records in order.
+#[derive(Debug, Default)]
+pub struct InMemoryAuditSink {
+    pub records: Vec<ShippedAuditRecord>,
+}
+
+impl AuditSink for InMemoryAuditSink {
+    fn append(&mut self, records: &[ShippedAuditRecord]) -> std::io::Result<()> {
+        self.records.extend_from_slice(records);
+        Ok(())
+    }
+}
+
+/// Append-only JSON-Lines file sink: one JSON object per line, opened in append
+/// mode. A WORM-mounted volume or a log-shipping agent tailing the file carries
+/// it off-box. Each `append` is flushed before returning, so a shipped batch is
+/// durable on the file before the high-water mark advances.
+pub struct JsonlFileAuditSink {
+    path: std::path::PathBuf,
+}
+
+impl JsonlFileAuditSink {
+    pub fn new(path: impl Into<std::path::PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+impl AuditSink for JsonlFileAuditSink {
+    fn append(&mut self, records: &[ShippedAuditRecord]) -> std::io::Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        // Build the whole batch in memory then write once, so a serialization
+        // error cannot leave a half-written line on the WORM file.
+        let mut buf = String::new();
+        for r in records {
+            let line = serde_json::to_string(r)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            buf.push_str(&line);
+            buf.push('\n');
+        }
+        file.write_all(buf.as_bytes())?;
+        file.flush()?;
+        Ok(())
+    }
+}
+
+/// `posture_engine_state` key holding the shipping CURSOR — the inclusive next
+/// sequence to ship (one past the last sequence durably appended to the sink).
+/// Persisted so shipping resumes across restarts without re-shipping the ledger.
+pub const AUDIT_SHIP_CURSOR_KEY: &str = "audit_ship_cursor";
+
+/// Default per-cycle ship batch cap — bounds the work (and the memory) of one
+/// shipping cycle; the next cycle picks up the remainder.
+pub const DEFAULT_SHIP_BATCH_LIMIT: u64 = 512;
+
+/// The result of a shipping cycle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShipOutcome {
+    pub shipped: usize,
+    /// The cursor after this cycle — the inclusive next sequence to ship
+    /// (`last_shipped + 1`, or the input cursor unchanged when nothing shipped).
+    pub next_cursor: u64,
+}
+
+/// A shipping-cycle error — either the store read or the sink append failed. The
+/// high-water mark is NOT advanced on either, so the records re-ship next cycle
+/// (at-least-once: audit evidence is never dropped; the off-box consumer dedupes
+/// by `sequence`).
+#[derive(Debug)]
+pub enum ShipError {
+    Store(rusqlite::Error),
+    Sink(std::io::Error),
+}
+
+impl std::fmt::Display for ShipError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShipError::Store(e) => write!(f, "audit ship store read: {e}"),
+            ShipError::Sink(e) => write!(f, "audit ship sink append: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ShipError {}
+
+/// Ship the audit records with `sequence >= from_cursor` to `sink` (ascending, up
+/// to `batch_limit`). Returns how many shipped and the new cursor
+/// (`last_shipped + 1`, or `from_cursor` unchanged when there was nothing new).
+/// Does NOT persist the cursor — the caller advances it only after the sink append
+/// succeeds (see [`ship_and_advance`]).
+pub fn ship_new_records(
+    store: &crate::verifier_store::VerifierStore,
+    sink: &mut dyn AuditSink,
+    from_cursor: u64,
+    batch_limit: u64,
+) -> Result<ShipOutcome, ShipError> {
+    let records = store
+        .load_shippable_audit_records(from_cursor, batch_limit)
+        .map_err(ShipError::Store)?;
+    if records.is_empty() {
+        return Ok(ShipOutcome {
+            shipped: 0,
+            next_cursor: from_cursor,
+        });
+    }
+    sink.append(&records).map_err(ShipError::Sink)?;
+    let next_cursor = records
+        .last()
+        .map(|r| r.sequence + 1)
+        .unwrap_or(from_cursor);
+    Ok(ShipOutcome {
+        shipped: records.len(),
+        next_cursor,
+    })
+}
+
+/// The persisted shipping cursor — the inclusive next sequence to ship (0 if never
+/// shipped / unparseable, i.e. start from the genesis row).
+pub fn load_ship_cursor(
+    store: &crate::verifier_store::VerifierStore,
+) -> Result<u64, rusqlite::Error> {
+    Ok(store
+        .load_engine_state(AUDIT_SHIP_CURSOR_KEY)?
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0))
+}
+
+/// One full shipping cycle: load the persisted cursor, ship everything from it,
+/// and — ONLY after the sink append succeeds — advance the persisted cursor.
+/// Ordering is deliberate (ship-then-advance): a crash between the append and the
+/// advance re-ships the last batch next cycle (at-least-once), so audit evidence
+/// is never lost; the off-box consumer dedupes by `sequence`. The alternative
+/// (advance-then-ship) could LOSE records on a crash — unacceptable for a
+/// tamper-evidence log.
+pub fn ship_and_advance(
+    store: &crate::verifier_store::VerifierStore,
+    sink: &mut dyn AuditSink,
+    batch_limit: u64,
+) -> Result<ShipOutcome, ShipError> {
+    let from = load_ship_cursor(store).map_err(ShipError::Store)?;
+    let outcome = ship_new_records(store, sink, from, batch_limit)?;
+    if outcome.next_cursor > from {
+        store
+            .save_engine_state(AUDIT_SHIP_CURSOR_KEY, &outcome.next_cursor.to_string())
+            .map_err(ShipError::Store)?;
+    }
+    Ok(outcome)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a v2 record chained onto `prev_hash` at `sequence`, computing its
+    /// real record hash (a faithful shipped record).
+    fn rec(
+        sequence: u64,
+        prev_hash: &str,
+        event_type: &str,
+        json: &str,
+        ts: i64,
+    ) -> ShippedAuditRecord {
+        let record_hash =
+            AuditChainLinker::compute_record_hash_v2(prev_hash, event_type, json, ts, sequence);
+        ShippedAuditRecord {
+            sequence,
+            event_type: event_type.to_string(),
+            event_json: json.to_string(),
+            previous_hash_hex: prev_hash.to_string(),
+            record_hash_hex: record_hash,
+            created_at_ms: ts,
+            hash_version: 2,
+            signature_b64: None,
+            key_id: None,
+        }
+    }
+
+    /// A short, well-formed chain of `n` records starting at sequence `start`.
+    fn chain(start: u64, n: u64) -> Vec<ShippedAuditRecord> {
+        let mut out = Vec::new();
+        let mut prev = "GENESIS".to_string();
+        for i in 0..n {
+            let seq = start + i;
+            let r = rec(
+                seq,
+                &prev,
+                "Evt",
+                &format!("{{\"i\":{seq}}}"),
+                1_000 + seq as i64,
+            );
+            prev = r.record_hash_hex.clone();
+            out.push(r);
+        }
+        out
+    }
+
+    #[test]
+    fn empty_is_empty() {
+        assert_eq!(verify_shipped_chain(&[]), ShippedChainVerdict::Empty);
+    }
+
+    #[test]
+    fn well_formed_chain_verifies() {
+        let c = chain(1, 5);
+        assert_eq!(
+            verify_shipped_chain(&c),
+            ShippedChainVerdict::Ok {
+                records: 5,
+                last_sequence: 5
+            }
+        );
+    }
+
+    #[test]
+    fn segment_not_starting_at_one_verifies() {
+        // Incremental shipping resumes mid-chain; internal consistency is what's
+        // checked, so a segment starting at 100 is fine.
+        let c = chain(100, 3);
+        assert!(verify_shipped_chain(&c).is_ok());
+    }
+
+    #[test]
+    fn content_tamper_breaks_the_hash() {
+        let mut c = chain(1, 4);
+        // Mutate the event payload of the 3rd record WITHOUT recomputing its hash.
+        c[2].event_json = "{\"i\":999}".to_string();
+        assert_eq!(
+            verify_shipped_chain(&c),
+            ShippedChainVerdict::HashMismatch { sequence: 3 }
+        );
+    }
+
+    #[test]
+    fn dropping_a_record_breaks_contiguity() {
+        let mut c = chain(1, 5);
+        c.remove(2); // drop sequence 3
+        assert_eq!(
+            verify_shipped_chain(&c),
+            ShippedChainVerdict::SequenceGap {
+                expected: 3,
+                found: 4
+            }
+        );
+    }
+
+    #[test]
+    fn reordering_breaks_prev_linkage() {
+        let mut c = chain(1, 5);
+        c.swap(2, 3); // sequences now 1,2,4,3,5 → seq check fires first
+                      // The swap makes sequence 4 appear where 3 was expected.
+        assert_eq!(
+            verify_shipped_chain(&c),
+            ShippedChainVerdict::SequenceGap {
+                expected: 3,
+                found: 4
+            }
+        );
+    }
+
+    #[test]
+    fn splicing_a_foreign_record_breaks_linkage() {
+        // Keep sequences contiguous but replace a record's body with a different
+        // one that re-hashes correctly for ITS content — its prev_hash no longer
+        // matches the real prior record's hash.
+        let mut c = chain(1, 4);
+        let foreign = rec(3, "NOT-THE-REAL-PREV", "Evt", "{\"i\":3}", 1_003);
+        c[2] = foreign;
+        assert_eq!(
+            verify_shipped_chain(&c),
+            ShippedChainVerdict::PrevLinkageBroken { sequence: 3 }
+        );
+    }
+
+    #[test]
+    fn in_memory_sink_accumulates_in_order() {
+        let mut sink = InMemoryAuditSink::default();
+        let c = chain(1, 3);
+        sink.append(&c[..2]).unwrap();
+        sink.append(&c[2..]).unwrap();
+        assert_eq!(sink.records, c);
+        assert!(verify_shipped_chain(&sink.records).is_ok());
+    }
+
+    #[test]
+    fn jsonl_file_sink_roundtrips_and_verifies() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "kirra_audit_ship_test_{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let mut sink = JsonlFileAuditSink::new(&path);
+        let c = chain(1, 4);
+        sink.append(&c[..2]).unwrap();
+        sink.append(&c[2..]).unwrap(); // append-only: second batch adds, not rewrites
+
+        let text = std::fs::read_to_string(&path).unwrap();
+        let parsed: Vec<ShippedAuditRecord> = text
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        assert_eq!(
+            parsed, c,
+            "file is the appended union of both batches, in order"
+        );
+        assert!(verify_shipped_chain(&parsed).is_ok());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    // --- store-backed shipping (real audit chain) -------------------------
+
+    use crate::verifier_store::VerifierStore;
+
+    fn store_with_events(n: usize) -> VerifierStore {
+        let mut s = VerifierStore::new(":memory:").expect("in-memory store");
+        for i in 0..n {
+            // A standalone chained audit append (the same primitive campaign /
+            // clearance mutations use) — real hash-linked, sequenced rows.
+            s.append_clearance_audit_event(
+                "ShipTestEvent",
+                &format!("{{\"i\":{i}}}"),
+                1_000 + i as u64,
+            )
+            .expect("append audit event");
+        }
+        s
+    }
+
+    #[test]
+    fn ships_real_audit_records_and_reverifies_off_box() {
+        let store = store_with_events(4);
+        let mut sink = InMemoryAuditSink::default();
+        let outcome = ship_and_advance(&store, &mut sink, DEFAULT_SHIP_BATCH_LIMIT).unwrap();
+        assert_eq!(outcome.shipped, 4);
+        assert_eq!(sink.records.len(), 4);
+        // The off-box copy re-verifies with NO reference to the source DB.
+        assert!(
+            verify_shipped_chain(&sink.records).is_ok(),
+            "shipped real chain must re-verify independently"
+        );
+        // The genesis row (sequence 0) shipped, so the cursor advanced past it.
+        assert_eq!(sink.records[0].sequence, 0, "chain is 0-based");
+        assert_eq!(load_ship_cursor(&store).unwrap(), outcome.next_cursor);
+        assert_eq!(outcome.next_cursor, 4, "next cursor is last_shipped(3) + 1");
+    }
+
+    #[test]
+    fn shipping_resumes_from_high_water() {
+        let mut store = store_with_events(3);
+        let mut sink = InMemoryAuditSink::default();
+        let first = ship_and_advance(&store, &mut sink, DEFAULT_SHIP_BATCH_LIMIT).unwrap();
+        assert_eq!(first.shipped, 3);
+
+        // A second cycle with no new events ships nothing.
+        let none = ship_and_advance(&store, &mut sink, DEFAULT_SHIP_BATCH_LIMIT).unwrap();
+        assert_eq!(none.shipped, 0);
+        assert_eq!(sink.records.len(), 3);
+
+        // Append two more events, then ship again — only the new ones move.
+        store
+            .append_clearance_audit_event("ShipTestEvent", "{\"i\":3}", 2_000)
+            .unwrap();
+        store
+            .append_clearance_audit_event("ShipTestEvent", "{\"i\":4}", 2_001)
+            .unwrap();
+        let more = ship_and_advance(&store, &mut sink, DEFAULT_SHIP_BATCH_LIMIT).unwrap();
+        assert_eq!(more.shipped, 2, "only the two new records ship");
+        assert_eq!(sink.records.len(), 5);
+        // The accumulated off-box copy is a single contiguous, verifiable chain.
+        assert!(verify_shipped_chain(&sink.records).is_ok());
+    }
+
+    #[test]
+    fn tampering_the_shipped_copy_is_detected() {
+        let store = store_with_events(4);
+        let mut sink = InMemoryAuditSink::default();
+        ship_and_advance(&store, &mut sink, DEFAULT_SHIP_BATCH_LIMIT).unwrap();
+        // An adversary mutates the off-box copy after shipping.
+        sink.records[1].event_json = "{\"i\":666}".to_string();
+        assert!(
+            !verify_shipped_chain(&sink.records).is_ok(),
+            "a mutated off-box record must fail re-verification"
+        );
+    }
+
+    #[test]
+    fn batch_limit_ships_in_chunks() {
+        let store = store_with_events(5);
+        let mut sink = InMemoryAuditSink::default();
+        // Ship two at a time via the low-level fn, advancing the cursor manually.
+        let a = ship_new_records(&store, &mut sink, 0, 2).unwrap();
+        assert_eq!(a.shipped, 2);
+        let b = ship_new_records(&store, &mut sink, a.next_cursor, 2).unwrap();
+        assert_eq!(b.shipped, 2);
+        let c = ship_new_records(&store, &mut sink, b.next_cursor, 2).unwrap();
+        assert_eq!(c.shipped, 1);
+        assert_eq!(sink.records.len(), 5);
+        assert!(verify_shipped_chain(&sink.records).is_ok());
+    }
+}

--- a/src/audit_shipper.rs
+++ b/src/audit_shipper.rs
@@ -161,8 +161,8 @@ impl AuditSink for InMemoryAuditSink {
 
 /// Append-only JSON-Lines file sink: one JSON object per line, opened in append
 /// mode. A WORM-mounted volume or a log-shipping agent tailing the file carries
-/// it off-box. Each `append` is flushed before returning, so a shipped batch is
-/// durable on the file before the high-water mark advances.
+/// it off-box. Each `append` is written then `sync_all`-fsync'd before returning,
+/// so a shipped batch is durable on stable storage before the cursor advances.
 pub struct JsonlFileAuditSink {
     path: std::path::PathBuf,
 }
@@ -189,7 +189,12 @@ impl AuditSink for JsonlFileAuditSink {
             buf.push('\n');
         }
         file.write_all(buf.as_bytes())?;
+        // `flush` only drains userspace buffers; `sync_all` (fsync) forces the
+        // batch to stable storage. The cursor advances only after this returns, so
+        // ship-then-advance must be durable HERE — a power loss must not lose a
+        // batch the cursor already considers shipped.
         file.flush()?;
+        file.sync_all()?;
         Ok(())
     }
 }
@@ -272,6 +277,11 @@ pub fn load_ship_cursor(
     Ok(store
         .load_engine_state(AUDIT_SHIP_CURSOR_KEY)?
         .and_then(|s| s.parse::<u64>().ok())
+        // The cursor is later bound as a SQLite INTEGER (i64). A persisted value
+        // beyond i64::MAX is corruption — treat it as "unset" and restart from the
+        // genesis row (at-least-once re-ship, never a wrapped bind) rather than
+        // trusting a poisoned cursor.
+        .filter(|&v| v <= i64::MAX as u64)
         .unwrap_or(0))
 }
 
@@ -530,6 +540,39 @@ mod tests {
         assert!(
             !verify_shipped_chain(&sink.records).is_ok(),
             "a mutated off-box record must fail re-verification"
+        );
+    }
+
+    #[test]
+    fn corrupt_persisted_cursor_restarts_from_genesis() {
+        // A poisoned cursor beyond the SQLite INTEGER domain must not be trusted
+        // (it would wrap to a negative bind and re-ship everything from a wrong
+        // point / desync). It is treated as unset → restart from 0.
+        let store = store_with_events(2);
+        store
+            .save_engine_state(AUDIT_SHIP_CURSOR_KEY, &(i64::MAX as u64 + 1).to_string())
+            .unwrap();
+        assert_eq!(
+            load_ship_cursor(&store).unwrap(),
+            0,
+            "out-of-domain cursor → 0"
+        );
+        // And an in-domain cursor round-trips.
+        store.save_engine_state(AUDIT_SHIP_CURSOR_KEY, "1").unwrap();
+        assert_eq!(load_ship_cursor(&store).unwrap(), 1);
+    }
+
+    #[test]
+    fn out_of_range_from_sequence_ships_nothing() {
+        // A `from_sequence` beyond i64::MAX saturates the bind rather than wrapping
+        // negative — it must return no rows (fail-closed), never the whole ledger.
+        let store = store_with_events(3);
+        let recs = store
+            .load_shippable_audit_records(u64::MAX, DEFAULT_SHIP_BATCH_LIMIT)
+            .unwrap();
+        assert!(
+            recs.is_empty(),
+            "a beyond-range cursor must ship nothing, not wrap to match all"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod telemetry_watchdog;
 pub mod clock;
 pub mod scenario_runner;
 pub mod audit_chain;
+pub mod audit_shipper;
 pub mod audit_writer;
 // Clause 2 release-token binding (ADR-0006 / HVCHAN-001 §3 steps 5-7): digest →
 // Ed25519 release token → actuator verify-before-release, over the

--- a/src/verifier_store/audit.rs
+++ b/src/verifier_store/audit.rs
@@ -387,6 +387,40 @@ impl VerifierStore {
         )
     }
 
+    /// Load audit records with `sequence >= from_sequence` in ASCENDING sequence
+    /// order (up to `limit`) as [`ShippedAuditRecord`](crate::audit_shipper::ShippedAuditRecord)s — the WORM off-box shipper
+    /// source (`crate::audit_shipper`). `from_sequence` is the INCLUSIVE next
+    /// sequence to ship (the chain is 0-based — the genesis row is sequence 0 — so
+    /// an inclusive lower bound is required to ship it). Rows without a `sequence`
+    /// (pre-v2 legacy, NULL) are skipped: they carry no ordering key.
+    pub fn load_shippable_audit_records(
+        &self,
+        from_sequence: u64,
+        limit: u64,
+    ) -> Result<Vec<crate::audit_shipper::ShippedAuditRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT sequence, event_type, event_json, previous_hash_hex, record_hash_hex, \
+                    created_at_ms, hash_version, signature_b64, key_id \
+             FROM audit_log_chain \
+             WHERE sequence IS NOT NULL AND sequence >= ?1 \
+             ORDER BY sequence ASC LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![from_sequence as i64, limit as i64], |row| {
+            Ok(crate::audit_shipper::ShippedAuditRecord {
+                sequence: row.get::<_, i64>(0)? as u64,
+                event_type: row.get(1)?,
+                event_json: row.get(2)?,
+                previous_hash_hex: row.get(3)?,
+                record_hash_hex: row.get(4)?,
+                created_at_ms: row.get(5)?,
+                hash_version: row.get(6)?,
+                signature_b64: row.get(7)?,
+                key_id: row.get(8)?,
+            })
+        })?;
+        rows.collect()
+    }
+
     pub(crate) fn init_audit_chain_schema(conn: &Connection) -> Result<()> {
         conn.execute(
             "CREATE TABLE IF NOT EXISTS audit_log_chain (

--- a/src/verifier_store/audit.rs
+++ b/src/verifier_store/audit.rs
@@ -107,7 +107,10 @@ impl VerifierStore {
     pub(crate) fn audit_keyring_seed(
         &self,
         fallback_vk: Option<&ed25519_dalek::VerifyingKey>,
-    ) -> Result<(std::collections::HashMap<String, ed25519_dalek::VerifyingKey>, Option<String>)> {
+    ) -> Result<(
+        std::collections::HashMap<String, ed25519_dalek::VerifyingKey>,
+        Option<String>,
+    )> {
         let mut keyring = std::collections::HashMap::new();
 
         let durable_genesis = self.audit_genesis_vk()?;
@@ -225,7 +228,8 @@ impl VerifierStore {
 
         // Optional operator-pinned genesis check (only meaningful once an anchor
         // exists; on first boot the pin is established by the backfill below).
-        if let (Some(pin), Some(genesis)) = (pinned_genesis, self.audit_trust_anchor_genesis_id()?) {
+        if let (Some(pin), Some(genesis)) = (pinned_genesis, self.audit_trust_anchor_genesis_id()?)
+        {
             if pin != genesis {
                 return Ok(KeyAdmission::GenesisPinMismatch);
             }
@@ -255,7 +259,16 @@ impl VerifierStore {
 
                 let genesis_sig = b64e.encode(
                     env_key
-                        .sign(ledger_signing_payload(&k_env, None, "genesis", &env_pub_b64, now_ms as i64).as_bytes())
+                        .sign(
+                            ledger_signing_payload(
+                                &k_env,
+                                None,
+                                "genesis",
+                                &env_pub_b64,
+                                now_ms as i64,
+                            )
+                            .as_bytes(),
+                        )
                         .to_bytes(),
                 );
                 let tx = self.durable_mut().transaction()?;
@@ -311,7 +324,13 @@ impl VerifierStore {
                         "INSERT INTO audit_key_ledger \
                          (key_id, prev_key_id, role, pubkey_b64, signature_b64, created_at_ms) \
                          VALUES (?1, ?2, 'reanchor', ?3, ?4, ?5)",
-                        params![k_env, chain_latest, env_pub_b64, reanchor_sig, now_ms as i64],
+                        params![
+                            k_env,
+                            chain_latest,
+                            env_pub_b64,
+                            reanchor_sig,
+                            now_ms as i64
+                        ],
                     )?;
                 }
                 tx.commit()?; // FULL → fsync
@@ -380,11 +399,8 @@ impl VerifierStore {
     /// #395 console runtime — total rows in the tamper-evident audit chain.
     /// Read-only `COUNT(*)`; surfaces the ledger depth for the live console.
     pub fn audit_chain_len(&self) -> Result<u64> {
-        self.conn.query_row(
-            "SELECT COUNT(*) FROM audit_log_chain",
-            [],
-            |row| row.get(0),
-        )
+        self.conn
+            .query_row("SELECT COUNT(*) FROM audit_log_chain", [], |row| row.get(0))
     }
 
     /// Load audit records with `sequence >= from_sequence` in ASCENDING sequence
@@ -398,6 +414,14 @@ impl VerifierStore {
         from_sequence: u64,
         limit: u64,
     ) -> Result<Vec<crate::audit_shipper::ShippedAuditRecord>> {
+        // CHECKED domain conversions to the SQLite INTEGER (i64) space. A
+        // `from_sequence`/`limit` beyond `i64::MAX` (only reachable from a
+        // corrupted persisted cursor) SATURATES to `i64::MAX` rather than wrapping
+        // to a negative bind that would match every row and re-ship the whole
+        // ledger: `sequence >= i64::MAX` matches nothing (sequences are small), so
+        // an out-of-range cursor fail-closes to "nothing to ship".
+        let from_bind = i64::try_from(from_sequence).unwrap_or(i64::MAX);
+        let limit_bind = i64::try_from(limit).unwrap_or(i64::MAX);
         let mut stmt = self.conn.prepare(
             "SELECT sequence, event_type, event_json, previous_hash_hex, record_hash_hex, \
                     created_at_ms, hash_version, signature_b64, key_id \
@@ -405,9 +429,23 @@ impl VerifierStore {
              WHERE sequence IS NOT NULL AND sequence >= ?1 \
              ORDER BY sequence ASC LIMIT ?2",
         )?;
-        let rows = stmt.query_map(params![from_sequence as i64, limit as i64], |row| {
+        let rows = stmt.query_map(params![from_bind, limit_bind], |row| {
+            // A negative stored `sequence` is corruption (sequences are 0-based,
+            // monotone non-negative) — fail-closed rather than wrapping to a huge
+            // u64 that would desync the off-box verifier's contiguity check.
+            let seq_raw: i64 = row.get(0)?;
+            let sequence = u64::try_from(seq_raw).map_err(|_| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Integer,
+                    Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("audit_log_chain.sequence negative/corrupt: {seq_raw}"),
+                    )),
+                )
+            })?;
             Ok(crate::audit_shipper::ShippedAuditRecord {
-                sequence: row.get::<_, i64>(0)? as u64,
+                sequence,
                 event_type: row.get(1)?,
                 event_json: row.get(2)?,
                 previous_hash_hex: row.get(3)?,
@@ -435,7 +473,10 @@ impl VerifierStore {
             [],
         )?;
         // Ignore "duplicate column name" error — column may already exist on upgraded databases
-        if let Err(e) = conn.execute("ALTER TABLE audit_log_chain ADD COLUMN signature_b64 TEXT", []) {
+        if let Err(e) = conn.execute(
+            "ALTER TABLE audit_log_chain ADD COLUMN signature_b64 TEXT",
+            [],
+        ) {
             let msg = e.to_string();
             if !msg.contains("duplicate column name") {
                 return Err(e);
@@ -465,10 +506,7 @@ impl VerifierStore {
         // Key-rotation support (#76): content-addressed id of the signing key
         // per row. NULL on pre-upgrade rows (all signed under the genesis key);
         // backfilled by ensure_key_id_backfill_migration.
-        if let Err(e) = conn.execute(
-            "ALTER TABLE audit_log_chain ADD COLUMN key_id TEXT",
-            [],
-        ) {
+        if let Err(e) = conn.execute("ALTER TABLE audit_log_chain ADD COLUMN key_id TEXT", []) {
             let msg = e.to_string();
             if !msg.contains("duplicate column name") {
                 return Err(e);
@@ -596,7 +634,9 @@ impl VerifierStore {
             // The rotation must be signed by a key already trusted (the prior
             // key). A NULL key_id means a legacy/genesis-signed row.
             let signer_id = key_id.unwrap_or_else(|| genesis_id.clone());
-            let Some(signer_vk) = keyring.get(&signer_id).copied() else { continue };
+            let Some(signer_vk) = keyring.get(&signer_id).copied() else {
+                continue;
+            };
             let Some(ref sig) = sig_b64 else { continue };
             let payload = audit_signing_payload(hash_version, &prev, &rec, "KEY_ROTATION", ts, seq);
             if !audit_verify_sig(&signer_vk, &payload, sig) {
@@ -724,8 +764,12 @@ impl VerifierStore {
                         let ok = match keyring.get(&signer_id) {
                             Some(vk) => {
                                 let payload = audit_signing_payload(
-                                    hash_version, &previous_hash_hex, &record_hash_hex,
-                                    &event_type, created_at_ms, sequence_opt,
+                                    hash_version,
+                                    &previous_hash_hex,
+                                    &record_hash_hex,
+                                    &event_type,
+                                    created_at_ms,
+                                    sequence_opt,
                                 );
                                 audit_verify_sig(vk, &payload, s)
                             }
@@ -748,9 +792,7 @@ impl VerifierStore {
         }
 
         let signing_enabled = verifying_key.is_some();
-        let public_key_b64 = verifying_key.map(|vk| {
-            b64e.encode(vk.as_bytes())
-        });
+        let public_key_b64 = verifying_key.map(|vk| b64e.encode(vk.as_bytes()));
 
         // #77: anchor-HEAD high-water check — detects tail TRUNCATION/DELETION
         // (which the per-row chain walk above cannot see: deleting the last rows
@@ -768,12 +810,14 @@ impl VerifierStore {
                 "SELECT sequence, record_hash_hex, signature_b64, key_id \
                  FROM audit_anchor_head WHERE id = 1",
                 [],
-                |r| Ok((
-                    r.get::<_, i64>(0)?,
-                    r.get::<_, String>(1)?,
-                    r.get::<_, Option<String>>(2)?,
-                    r.get::<_, Option<String>>(3)?,
-                )),
+                |r| {
+                    Ok((
+                        r.get::<_, i64>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, Option<String>>(2)?,
+                        r.get::<_, Option<String>>(3)?,
+                    ))
+                },
             );
             match head {
                 Err(rusqlite::Error::QueryReturnedNoRows) => {
@@ -792,7 +836,11 @@ impl VerifierStore {
                             Some(t) => t < h_seq,
                             None => true,
                         };
-                        let status = if truncated { "TRUNCATION_DETECTED" } else { "HEAD_TAIL_MISMATCH" };
+                        let status = if truncated {
+                            "TRUNCATION_DETECTED"
+                        } else {
+                            "HEAD_TAIL_MISMATCH"
+                        };
                         (false, status.to_string())
                     } else if signing_enabled {
                         // Signed chain ⇒ the head must carry a valid signature
@@ -800,16 +848,16 @@ impl VerifierStore {
                         match h_sig {
                             None => (false, "HEAD_UNSIGNED".to_string()),
                             Some(sig) => {
-                                let signer_id = h_key_id
-                                    .or_else(|| genesis_id.clone())
-                                    .unwrap_or_default();
+                                let signer_id =
+                                    h_key_id.or_else(|| genesis_id.clone()).unwrap_or_default();
                                 match keyring.get(&signer_id) {
                                     None => (false, "HEAD_KEY_UNKNOWN".to_string()),
                                     Some(vk) => {
-                                        let payload = crate::audit_chain::canonical_anchor_head_payload(
-                                            h_seq.max(0) as u64,
-                                            &h_hash,
-                                        );
+                                        let payload =
+                                            crate::audit_chain::canonical_anchor_head_payload(
+                                                h_seq.max(0) as u64,
+                                                &h_hash,
+                                            );
                                         if audit_verify_sig(vk, &payload, &sig) {
                                             (true, "OK".to_string())
                                         } else {
@@ -850,11 +898,12 @@ impl VerifierStore {
         offset: u64,
         verifying_key: Option<&ed25519_dalek::VerifyingKey>,
     ) -> Result<AuditExportPage> {
-        let total: u64 = self.conn.query_row(
-            "SELECT COUNT(*) FROM audit_log_chain",
-            [],
-            |row| row.get::<_, i64>(0),
-        ).map(|n| n as u64)?;
+        let total: u64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM audit_log_chain", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .map(|n| n as u64)?;
 
         // Reconstruct the full keyring once (the page is DESC/paginated, so we
         // can't replay rotations within a page) — then annotate each row's
@@ -885,14 +934,34 @@ impl VerifierStore {
             let sequence_opt: Option<i64> = row.get(8)?;
             let key_id: Option<String> = row.get(9)?;
 
-            Ok((id, event_type, event_json, prev_hash, entry_hash, timestamp_ms,
-                sig_b64, hash_version, sequence_opt, key_id))
+            Ok((
+                id,
+                event_type,
+                event_json,
+                prev_hash,
+                entry_hash,
+                timestamp_ms,
+                sig_b64,
+                hash_version,
+                sequence_opt,
+                key_id,
+            ))
         })?;
 
         let mut entries = Vec::new();
         for row_result in rows {
-            let (id, event_type, event_json, prev_hash, entry_hash, timestamp_ms,
-                 sig_b64, hash_version, sequence_opt, key_id) = row_result?;
+            let (
+                id,
+                event_type,
+                event_json,
+                prev_hash,
+                entry_hash,
+                timestamp_ms,
+                sig_b64,
+                hash_version,
+                sequence_opt,
+                key_id,
+            ) = row_result?;
 
             let signature_status = match &sig_b64 {
                 None => "unsigned".to_string(),
@@ -906,14 +975,22 @@ impl VerifierStore {
                         let verified = match keyring.get(&signer_id) {
                             Some(vk) => {
                                 let payload = audit_signing_payload(
-                                    hash_version, &prev_hash, &entry_hash,
-                                    &event_type, timestamp_ms, sequence_opt,
+                                    hash_version,
+                                    &prev_hash,
+                                    &entry_hash,
+                                    &event_type,
+                                    timestamp_ms,
+                                    sequence_opt,
                                 );
                                 audit_verify_sig(vk, &payload, s)
                             }
                             None => false, // unknown key_id → fail-closed
                         };
-                        if verified { "valid".to_string() } else { "invalid".to_string() }
+                        if verified {
+                            "valid".to_string()
+                        } else {
+                            "invalid".to_string()
+                        }
                     } else {
                         "invalid".to_string()
                     }
@@ -1023,7 +1100,13 @@ impl VerifierStore {
                 "INSERT INTO audit_key_ledger \
                  (key_id, prev_key_id, role, pubkey_b64, signature_b64, created_at_ms) \
                  VALUES (?1, ?2, 'rotation', ?3, ?4, ?5)",
-                params![new_key_id, old_key_id, new_public_key_b64, ledger_sig, now_ms as i64],
+                params![
+                    new_key_id,
+                    old_key_id,
+                    new_public_key_b64,
+                    ledger_sig,
+                    now_ms as i64
+                ],
             )?;
             tx.commit()?; // FULL → fsync; durable active-key record updated
         }
@@ -1241,7 +1324,8 @@ impl VerifierStore {
             match self.signing_key.as_ref() {
                 Some(key) => {
                     use ed25519_dalek::Signer;
-                    let payload = crate::audit_chain::canonical_anchor_head_payload(seq, &record_hash);
+                    let payload =
+                        crate::audit_chain::canonical_anchor_head_payload(seq, &record_hash);
                     let sig = b64e.encode(key.sign(payload.as_bytes()).to_bytes());
                     let kid = crate::audit_chain::verifying_key_id(&key.verifying_key());
                     (Some(sig), Some(kid))


### PR DESCRIPTION
## Summary

Fourth **Track 3 / WS-4 (Fleet Plane)** slice — the second WS-4 sub-area, independent of the campaign control plane. The local audit ledger (`audit_log_chain`) is SHA-256 hash-chained and Ed25519 anchor-signed, so it's tamper-**evident** — but it lives on the box. If the box is lost (disk failure, seizure, a wipe), the evidence goes with it. This ships each new audit record to an append-only (**W**rite-**O**nce-**R**ead-**M**any) off-box sink and can re-verify the hash chain on the shipped records **alone** — no source DB.

Advances the GATE C requirement that the audit chain survive off-box.

## The WORM guarantee

`verify_shipped_chain` recomputes every record hash from the record's own content — using the **same** domain-separated construction the store uses (`AuditChainLinker::compute_record_hash_v2`, dispatching v1/v2) — and checks:
1. the recomputed hash matches the stored `record_hash` (content tamper → `HashMismatch`),
2. each `previous_hash` links to the prior record's hash (reorder/splice → `PrevLinkageBroken`),
3. sequences are contiguous ascending (dropped record → `SequenceGap`).

So a party holding **only** the shipped stream can prove the off-box copy is intact even after the origin is destroyed. That's the property that makes off-box shipping meaningful rather than just a backup.

## What's in this slice

- **`src/audit_shipper.rs`** (the core, pure + testable):
  - `ShippedAuditRecord` — the raw chain fields needed for independent re-verification (distinct from the DESC-paginated `AuditExportEntry`, which omits `sequence`/`hash_version`).
  - `verify_shipped_chain` — the off-box re-verifier above.
  - `AuditSink` trait + `InMemoryAuditSink` + append-only `JsonlFileAuditSink` (builds the batch in memory then writes once + flushes, so a serialization error can't leave a half-written line on the WORM file).
  - `ship_new_records` / `ship_and_advance` + cursor persistence via `posture_engine_state`.
- **Store**: `load_shippable_audit_records(from_sequence, limit)` — ASC, **inclusive** lower bound (the chain is 0-based; the genesis row is sequence 0, so an exclusive bound would skip it).

## Design note for review: at-least-once ordering

`ship_and_advance` ships to the sink **then** advances the persisted cursor. A crash between the append and the cursor-advance re-ships the last batch next cycle (**at-least-once**) rather than losing records — the correct trade for a tamper-evidence log. The alternative (advance-then-ship) could *lose* audit evidence on a crash. The off-box consumer dedupes by `sequence` (standard for append-only shipping).

## Tests (13)

- **Re-verifier**: well-formed chain OK; mid-chain segment (incremental resume) OK; content tamper → `HashMismatch`; dropped record → `SequenceGap`; reorder → `SequenceGap`; foreign-splice → `PrevLinkageBroken`.
- **Sinks**: in-memory accumulation order; JSONL file append-only round-trip + re-verify.
- **Store-backed over a REAL audit chain**: ship + independent re-verify; resume-from-cursor ships only new records; **tampering the shipped copy is detected**; batch-limit chunking.

## Notes

- No CRITICAL invariant touched; the shipper only *reads* the ledger and writes to an external append-only sink.
- Docs: `CLAUDE.md` module map.
- Guardrails/clippy/fmt/rustdoc all clean; `audit_shipper.rs` + the store read are non-ratchet-tracked files (no bin ceiling change this slice).

## Remaining Track 3 slices (separate PRs)

1. Background shipper scheduler — drives `ship_and_advance` on an interval, env-gated on a sink path (`KIRRA_AUDIT_SHIP_PATH`), wired into the Active block (the immediate follow-up to this PR).
2. On-device dual-slot installer + health-gated rollback (device-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_