### PR TITLE
ffi: add KirraVerdict struct + kirra_check_move_velocity (WS-2 SDK)

### DIFF
--- a/docs/roadmap/PRODUCT_EXECUTION_PLAN.md
+++ b/docs/roadmap/PRODUCT_EXECUTION_PLAN.md
@@ -61,7 +61,7 @@ The gap analysis found a fail-closed codebase with a handful of fail-open or cla
 - **DoD:** compromise of any single credential no longer grants the full admin+actuator surface; keys never live as raw env seeds in production mode.
 
 ### WS-2 · P1 Product Surface (Stage 1 — closes G20, G16, G18, G12, parts of G15/G17)
-- **SDK:** Rust quickstart + examples (governed cmd_vel loop, action-filter integration, typed-intent planner); C example against an expanded `kirra.h` (envelope config, verdict struct, posture query, release-token verify); Python client polish; published rustdoc + `deny(missing_docs)` on public crates.
+- **SDK:** Rust quickstart + examples (governed cmd_vel loop, action-filter integration, typed-intent planner); C example against an expanded `kirra.h` (verdict struct LANDED — `KirraVerdict` + `kirra_check_move_velocity` returns the bounded scalar + a stable `KIRRA_VERDICT_*` reason code, exercised by the CI C example; still to add: envelope config, posture query, release-token verify); Python client polish; published rustdoc + `deny(missing_docs)` on public crates.
 - **Pedestrian RSS** primitive (VRU longitudinal/lateral bounds + crossing model) wired into `validate_trajectory_slow` — the courier/sidewalk persona is P1's flagship, this is a launch blocker, not an AV-track item.
 - **Model integrity:** SHA allow-list verification at backend load (fingerprint exists, verify it); accelerator health watchdog; measured (not hardcoded) HW capabilities.
 - **Config governance:** one versioned, JSON-Schema'd config surface (`KirraRuntimeConfig` absorbs the env sprawl; env vars become overrides); migration story; startup prints effective config digest to audit chain.

--- a/examples/c/kirra_ffi_demo.c
+++ b/examples/c/kirra_ffi_demo.c
@@ -3,8 +3,9 @@
  *
  * The C integration boundary (ADR-0006 Clause 3) exposes the same safety-governor
  * behaviour as the Rust `governor_quickstart` example, through `include/kirra.h`.
- * A doer PROPOSES a velocity; `kirra_filter_move_velocity` BOUNDS it, fail-closed,
- * against a hard kinematic envelope compiled into `libkirra_verifier`.
+ * A doer PROPOSES a velocity; `kirra_check_move_velocity` BOUNDS it, fail-closed,
+ * against a hard kinematic envelope compiled into `libkirra_verifier`, and reports
+ * WHY it was bounded via a KirraVerdict struct.
  *
  * Build + run: see `examples/c/build_and_run.sh` (compiles against the cdylib).
  */
@@ -13,6 +14,23 @@
 #include <math.h>
 #include "kirra.h"
 
+/* Human label for a KIRRA_VERDICT_* code (integrators would branch on the int). */
+static const char *verdict_label(int32_t code) {
+    switch (code) {
+        case KIRRA_VERDICT_PASSTHROUGH:            return "passthrough";
+        case KIRRA_VERDICT_ENVELOPE_CLAMP:         return "envelope-clamp";
+        case KIRRA_VERDICT_RATE_CLAMP:             return "rate-clamp";
+        case KIRRA_VERDICT_NONFINITE_REJECTED:     return "nonfinite-rejected";
+        case KIRRA_VERDICT_INVALID_DT_REJECTED:    return "invalid-dt-rejected";
+        case KIRRA_VERDICT_DEGRADED_POSTURE_CLAMP: return "degraded-posture-clamp";
+        case KIRRA_VERDICT_DEGRADED_DECEL_HOLD:    return "degraded-decel-hold";
+        case KIRRA_VERDICT_SHADOW_HOLD:            return "shadow-hold";
+        case KIRRA_VERDICT_LOCKOUT_FALLBACK:       return "lockout-fallback";
+        case KIRRA_VERDICT_LOCK_POISONED:          return "lock-poisoned";
+        default:                                   return "unknown";
+    }
+}
+
 int main(void) {
     /* The doer's proposed linear velocities over 50 ms ticks. The last is a
      * corrupt NaN to exercise the fail-closed path. */
@@ -20,19 +38,20 @@ int main(void) {
     const double proposals[] = {1.0, 1.8, 5.0 /* over-envelope */, NAN /* corrupt */};
     const size_t n = sizeof(proposals) / sizeof(proposals[0]);
 
-    printf("proposed -> emitted   (trust score after tick)\n");
-    printf("----------------------------------------------\n");
+    printf("proposed -> emitted   [reason]                (trust score after tick)\n");
+    printf("----------------------------------------------------------------------\n");
     for (size_t i = 0; i < n; ++i) {
-        /* The returned scalar is what reaches the actuator: never non-finite,
-         * never outside the envelope compiled into the governor. */
-        double emitted = kirra_filter_move_velocity(proposals[i], dt);
+        /* The verdict carries both the sanitized scalar (what reaches the actuator:
+         * never non-finite, never outside the envelope) AND the reason code. */
+        KirraVerdict v = kirra_check_move_velocity(proposals[i], dt);
         uint32_t trust = kirra_get_trust_score();
 
-        if (!isfinite(emitted)) {
+        if (!isfinite(v.sanitized_value)) {
             fprintf(stderr, "FATAL: checker emitted a non-finite command\n");
             return 1;
         }
-        printf("%8.2f -> %7.2f   (trust=%u)\n", proposals[i], emitted, trust);
+        printf("%8.2f -> %7.2f   [%-22s] (trust=%u)\n",
+               proposals[i], v.sanitized_value, verdict_label(v.code), trust);
     }
 
     return 0;

--- a/include/kirra.h
+++ b/include/kirra.h
@@ -35,6 +35,44 @@ extern "C" {
  */
 double kirra_filter_move_velocity(double demand, double dt);
 
+/*
+ * Verdict reason codes returned in KirraVerdict.code. Stable wire values — only
+ * appended, never renumbered. A poisoned internal lock yields LOCK_POISONED with
+ * a fail-closed value of 0.0.
+ */
+#define KIRRA_VERDICT_PASSTHROUGH             0  /* in envelope + rate: unchanged */
+#define KIRRA_VERDICT_ENVELOPE_CLAMP          1  /* clamped to the hard envelope  */
+#define KIRRA_VERDICT_RATE_CLAMP              2  /* clamped to the rate-of-change */
+#define KIRRA_VERDICT_NONFINITE_REJECTED      3  /* NaN/Inf demand: fail-closed   */
+#define KIRRA_VERDICT_INVALID_DT_REJECTED     4  /* dt <= 0: fail-closed          */
+#define KIRRA_VERDICT_DEGRADED_POSTURE_CLAMP  5  /* bounded inside a reduced cap  */
+#define KIRRA_VERDICT_DEGRADED_DECEL_HOLD     6  /* decel-to-stop-and-hold        */
+#define KIRRA_VERDICT_SHADOW_HOLD             7  /* shadow mode: last value held  */
+#define KIRRA_VERDICT_LOCKOUT_FALLBACK        8  /* LockedOut: fallback commanded */
+#define KIRRA_VERDICT_LOCK_POISONED           9  /* internal lock poisoned        */
+
+/**
+ * A governed-command verdict: the sanitized scalar to actuate plus WHY it was
+ * bounded. Returned by value from kirra_check_move_velocity.
+ */
+typedef struct KirraVerdict {
+    double sanitized_value; /* what to actuate — ALWAYS finite, inside envelope */
+    int32_t code;           /* one of the KIRRA_VERDICT_* codes                 */
+} KirraVerdict;
+
+/**
+ * Bound a proposed LINEAR velocity AND report the reason.
+ *
+ * Same fail-closed bounding as kirra_filter_move_velocity — sanitized_value is
+ * identical for the same input — but also returns a KIRRA_VERDICT_* code so the
+ * caller can tell a clean passthrough from a clamp or a fail-closed rejection.
+ *
+ * @param demand  proposed linear velocity (m/s).
+ * @param dt      timestep since the previous command (seconds); must be > 0.
+ * @return a KirraVerdict; a poisoned internal lock yields {0.0, LOCK_POISONED}.
+ */
+KirraVerdict kirra_check_move_velocity(double demand, double dt);
+
 /**
  * Bound a proposed ANGULAR velocity to the governor's maximum angular rate.
  *

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -32,6 +32,79 @@ pub extern "C" fn kirra_filter_move_velocity(proposed_velocity: f64, dt: f64) ->
     GLOBAL_GOVERNOR.lock().map(|mut g| g.evaluate(proposed_velocity, dt).sanitized_scalar).unwrap_or(0.0)
 }
 
+// --- Structured verdict (WS-2 SDK: the verdict struct) ---------------------
+//
+// `kirra_filter_move_velocity` returns only the bounded scalar; a C integrator
+// cannot tell WHY it was bounded (a clean passthrough vs an envelope clamp vs a
+// fail-closed rejection). `kirra_check_move_velocity` returns both — the same
+// sanitized scalar plus a stable reason code — as a `#[repr(C)]` struct BY VALUE.
+// No raw pointers, so no `unsafe`: the ABI passes the small {f64,i32} aggregate
+// per the platform C convention, and the fail-closed contract is unchanged.
+
+/// Stable C verdict reason codes (mirror `include/kirra.h`'s `KIRRA_VERDICT_*`).
+/// Frozen wire values — only APPEND new codes, never renumber.
+pub const KIRRA_VERDICT_PASSTHROUGH: i32 = 0;
+pub const KIRRA_VERDICT_ENVELOPE_CLAMP: i32 = 1;
+pub const KIRRA_VERDICT_RATE_CLAMP: i32 = 2;
+pub const KIRRA_VERDICT_NONFINITE_REJECTED: i32 = 3;
+pub const KIRRA_VERDICT_INVALID_DT_REJECTED: i32 = 4;
+pub const KIRRA_VERDICT_DEGRADED_POSTURE_CLAMP: i32 = 5;
+pub const KIRRA_VERDICT_DEGRADED_DECEL_HOLD: i32 = 6;
+pub const KIRRA_VERDICT_SHADOW_HOLD: i32 = 7;
+pub const KIRRA_VERDICT_LOCKOUT_FALLBACK: i32 = 8;
+/// FFI-only sentinel: the process governor lock was poisoned; `sanitized_value`
+/// is the fail-closed `0.0`. Not a `MitigationCode` (no verdict was computed).
+pub const KIRRA_VERDICT_LOCK_POISONED: i32 = 9;
+
+/// A governed-command verdict for the C ABI: the sanitized scalar to actuate plus
+/// the reason it was (or was not) bounded. `#[repr(C)]`, returned by value.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KirraVerdict {
+    /// The scalar to send to the actuator — ALWAYS finite and inside the envelope
+    /// (identical to `kirra_filter_move_velocity` for the same input).
+    pub sanitized_value: f64,
+    /// One of the `KIRRA_VERDICT_*` codes.
+    pub code: i32,
+}
+
+/// The stable C reason code for a `MitigationCode`. Exhaustive (no wildcard): a
+/// new verdict variant will fail to compile here until it is given a code — the
+/// C ABI can never silently drop a new mitigation reason.
+#[must_use]
+fn mitigation_to_code(m: &crate::MitigationCode) -> i32 {
+    use crate::MitigationCode as M;
+    match m {
+        M::PassthroughUnrestrictedNormal => KIRRA_VERDICT_PASSTHROUGH,
+        M::EnvelopeClampTakesPriority => KIRRA_VERDICT_ENVELOPE_CLAMP,
+        M::RateClampEnforced { .. } => KIRRA_VERDICT_RATE_CLAMP,
+        M::NonfiniteInputRejectedFailsafe => KIRRA_VERDICT_NONFINITE_REJECTED,
+        M::InvalidTimeDeltaRejectedFailsafe => KIRRA_VERDICT_INVALID_DT_REJECTED,
+        M::DegradedPostureClamp { .. } => KIRRA_VERDICT_DEGRADED_POSTURE_CLAMP,
+        M::DegradedDecelToStopHold { .. } => KIRRA_VERDICT_DEGRADED_DECEL_HOLD,
+        M::ShadowModeHoldEnforced { .. } => KIRRA_VERDICT_SHADOW_HOLD,
+        M::CriticalLockoutFallback => KIRRA_VERDICT_LOCKOUT_FALLBACK,
+    }
+}
+
+/// Bound a proposed LINEAR velocity (m/s) over `dt` (seconds) and return a
+/// structured [`KirraVerdict`] — the sanitized scalar plus WHY it was bounded.
+/// `sanitized_value` is byte-identical to [`kirra_filter_move_velocity`] for the
+/// same input; a poisoned lock fails closed to `{0.0, KIRRA_VERDICT_LOCK_POISONED}`.
+#[no_mangle]
+pub extern "C" fn kirra_check_move_velocity(proposed_velocity: f64, dt: f64) -> KirraVerdict {
+    match GLOBAL_GOVERNOR.lock() {
+        Ok(mut g) => {
+            let r = g.evaluate(proposed_velocity, dt);
+            KirraVerdict {
+                sanitized_value: r.sanitized_scalar,
+                code: mitigation_to_code(&r.mitigation),
+            }
+        }
+        Err(_) => KirraVerdict { sanitized_value: 0.0, code: KIRRA_VERDICT_LOCK_POISONED },
+    }
+}
+
 /// Bound a proposed ANGULAR velocity (rad/s) to the governor's `max_angular_rate`.
 /// Returns the clamped rate — ALWAYS finite. A non-finite proposal fails closed to
 /// `0.0` and decays trust; an over-limit proposal is clamped to the bound and decays
@@ -286,6 +359,57 @@ mod reset_clock_tests {
             now > 1_600_000_000_000,
             "supervisor reset must use real wall-clock ms (got {now}), never a frozen 0"
         );
+    }
+}
+
+#[cfg(test)]
+mod verdict_tests {
+    use super::*;
+    use crate::MitigationCode as M;
+
+    /// Every `MitigationCode` maps to its stable, DISTINCT C code — exhaustively,
+    /// so a new verdict variant cannot silently collide or default.
+    #[test]
+    fn mitigation_codes_are_stable_and_distinct() {
+        let cases = [
+            (M::PassthroughUnrestrictedNormal, KIRRA_VERDICT_PASSTHROUGH),
+            (M::EnvelopeClampTakesPriority, KIRRA_VERDICT_ENVELOPE_CLAMP),
+            (M::RateClampEnforced { max_rate: 1.0 }, KIRRA_VERDICT_RATE_CLAMP),
+            (M::NonfiniteInputRejectedFailsafe, KIRRA_VERDICT_NONFINITE_REJECTED),
+            (M::InvalidTimeDeltaRejectedFailsafe, KIRRA_VERDICT_INVALID_DT_REJECTED),
+            (M::DegradedPostureClamp { cap_min: -1.0, cap_max: 1.0 }, KIRRA_VERDICT_DEGRADED_POSTURE_CLAMP),
+            (M::DegradedDecelToStopHold { held: 0.5 }, KIRRA_VERDICT_DEGRADED_DECEL_HOLD),
+            (M::ShadowModeHoldEnforced { retained: 0.2 }, KIRRA_VERDICT_SHADOW_HOLD),
+            (M::CriticalLockoutFallback, KIRRA_VERDICT_LOCKOUT_FALLBACK),
+        ];
+        let mut seen = std::collections::BTreeSet::new();
+        for (m, expected) in cases {
+            assert_eq!(mitigation_to_code(&m), expected, "code for {m:?} must be stable");
+            assert!(seen.insert(expected), "code {expected} must be distinct");
+        }
+        // The poisoned-lock sentinel is distinct from every mapped code.
+        assert!(!seen.contains(&KIRRA_VERDICT_LOCK_POISONED));
+    }
+
+    /// The verdict's `sanitized_value` matches the scalar `kirra_filter_move_velocity`
+    /// returns for the same input — the struct adds a reason, never a different value.
+    /// Uses the non-finite input, whose fail-closed result is invariant of the shared
+    /// `GLOBAL_GOVERNOR` state (the P0 guard short-circuits before any trust branch).
+    #[test]
+    fn verdict_value_matches_the_scalar_filter_nonfinite() {
+        let v = kirra_check_move_velocity(f64::NAN, 0.05);
+        assert_eq!(v.code, KIRRA_VERDICT_NONFINITE_REJECTED, "a NaN demand is a fail-closed rejection");
+        assert!(v.sanitized_value.is_finite(), "the verdict value is never non-finite");
+        assert_eq!(v.sanitized_value, kirra_filter_move_velocity(f64::NAN, 0.05));
+    }
+
+    /// A non-positive timestep is a fail-closed rejection with the invalid-dt code
+    /// (also state-invariant — the dt guard runs before any trust branch).
+    #[test]
+    fn verdict_reports_invalid_dt() {
+        let v = kirra_check_move_velocity(1.0, 0.0);
+        assert_eq!(v.code, KIRRA_VERDICT_INVALID_DT_REJECTED);
+        assert!(v.sanitized_value.is_finite());
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the WS-2 SDK "verdict struct" for the C ABI. `kirra_filter_move_velocity` returns only the bounded scalar — a C integrator cannot tell a clean passthrough from an envelope clamp, a rate clamp, or a fail-closed rejection. This exposes *why* a command was bounded.

## What changed

- **`KirraVerdict`** (`#[repr(C)]`, returned **by value** — no raw pointers, so **no `unsafe`**): the sanitized scalar plus a stable `KIRRA_VERDICT_*` reason code.
- **`kirra_check_move_velocity(demand, dt) -> KirraVerdict`**: the same fail-closed bounding as `kirra_filter_move_velocity` (identical `sanitized_value` for the same input), plus the reason. A poisoned internal lock fails closed to `{0.0, KIRRA_VERDICT_LOCK_POISONED}`.
- `mitigation_to_code` is **exhaustive** over `MitigationCode` (no wildcard) — a new verdict variant won't compile until it is given a stable C code, so the ABI can never silently drop a mitigation reason. Codes are frozen / append-only.
- `include/kirra.h`: the `KirraVerdict` typedef + `KIRRA_VERDICT_*` #defines + the function declaration.
- `examples/c/kirra_ffi_demo.c` now calls the verdict API and prints the reason label — so the CI `docs-and-sdk` job (which builds + runs the C example against the cdylib) exercises the new ABI on every PR.

## Verification

- `cargo test -p kirra-verifier --lib ffi::verdict_tests` — 3 pass: stable + distinct code mapping (exhaustive over `MitigationCode`), verdict `sanitized_value` matches `kirra_filter_move_velocity`, invalid-dt reported
- `examples/c/build_and_run.sh` — builds + links + runs against the cdylib; prints real reasons end-to-end:
  ```
      1.00 ->    0.50   [rate-clamp            ] (trust=100)
      1.80 ->    1.00   [rate-clamp            ] (trust=100)
      5.00 ->    2.00   [envelope-clamp        ] (trust=70)
       nan ->    0.00   [nonfinite-rejected    ] (trust=40)
  ```
- `cargo clippy -p kirra-verifier --lib` — clean
- `cargo +1.88.0 check -p kirra-verifier --lib --locked` — MSRV floor
- `python3 ci/check_quality_guardrails.py` — satisfied

Back-compat: `kirra_filter_move_velocity` is unchanged; this is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_