### PR TITLE
traceability-gate: reconcile the manual RTM ✓/✗ markers (WS-5)

### DIFF
--- a/docs/safety/REQUIREMENTS_TRACEABILITY.md
+++ b/docs/safety/REQUIREMENTS_TRACEABILITY.md
@@ -16,6 +16,20 @@ Traceability flows in both directions:
 - **Forward:** Safety Goal -> Technical Requirement -> Implementation -> Test
 - **Backward:** Test -> Implementation -> Technical Requirement -> Safety Goal
 
+### 1.1 Test-status markers (machine-gated)
+
+Each named test in the Test(s) column carries a status marker:
+
+- **✓** — the named test **exists** and demonstrates compliance.
+- **✗** — a **gap**: no test of that name exists yet.
+
+These markers are **reconciled against reality in CI** by
+`kirra_verifier::traceability_gate::ci_gate_tests::rtm_markers_match_test_existence`:
+a **✓ whose test does not exist** (a false coverage claim) and a **✗ whose test
+now exists** (stale pessimism — the coverage landed) both **fail the gate**. So a
+marker can no longer silently diverge from the code — when a gap test is written,
+its marker must flip to ✓, and a claimed test must actually exist.
+
 ---
 
 ## 2. Traceability Matrix
@@ -44,9 +58,9 @@ Traceability flows in both directions:
 
 | TR ID | Technical Requirement | Implementation | Test(s) |
 |-------|-----------------------|----------------|---------|
-| TR-003 | `spawn_telemetry_watchdog` shall detect absence of telemetry for any registered AV sensor node when the elapsed time since last telemetry exceeds `AV_TELEMETRY_TIMEOUT_MS = 2000` ms and shall transition that node to `Untrusted` | `src/telemetry_watchdog.rs:spawn_telemetry_watchdog` | `test_watchdog_marks_node_untrusted_after_timeout` ✗ |
-| TR-003a | The watchdog sweep interval shall be `AV_WATCHDOG_SWEEP_MS = 100` ms; the maximum detection latency shall not exceed `AV_TELEMETRY_TIMEOUT_MS + AV_WATCHDOG_SWEEP_MS = 2100` ms | `src/telemetry_watchdog.rs` — constant `AV_WATCHDOG_SWEEP_MS` | `test_watchdog_detection_latency_within_bound` ✗ |
-| TR-003b | After the watchdog transitions a node to `Untrusted`, it shall send a `PostureRecalcTrigger` to the posture engine worker channel within the same sweep cycle | `src/telemetry_watchdog.rs` trigger send | `test_watchdog_triggers_posture_recalculation` ✗ |
+| TR-003 | `spawn_telemetry_watchdog` shall detect absence of telemetry for any registered AV sensor node when the elapsed time since last telemetry exceeds `AV_TELEMETRY_TIMEOUT_MS = 2000` ms and shall transition that node to `Untrusted` | `src/telemetry_watchdog.rs:spawn_telemetry_watchdog` | `test_watchdog_marks_node_untrusted_after_timeout` ✓ |
+| TR-003a | The watchdog sweep interval shall be `AV_WATCHDOG_SWEEP_MS = 100` ms; the maximum detection latency shall not exceed `AV_TELEMETRY_TIMEOUT_MS + AV_WATCHDOG_SWEEP_MS = 2100` ms | `src/telemetry_watchdog.rs` — constant `AV_WATCHDOG_SWEEP_MS` | `test_watchdog_detection_latency_within_bound` ✓ |
+| TR-003b | After the watchdog transitions a node to `Untrusted`, it shall send a `PostureRecalcTrigger` to the posture engine worker channel within the same sweep cycle | `src/telemetry_watchdog.rs` trigger send | `test_watchdog_triggers_posture_recalculation` ✓ |
 
 ---
 
@@ -94,7 +108,7 @@ Traceability flows in both directions:
 
 | TR ID | Technical Requirement | Implementation | Test(s) |
 |-------|-----------------------|----------------|---------|
-| TR-008 | `startup_sentinel` shall verify all safety invariants (admin token present, watchdog spawned, posture engine running, SQLite WAL mode active) before the TCP listener binds; on any invariant failure, the process shall abort | `src/startup_sentinel.rs`, `src/bin/kirra_verifier_service.rs` | Integration smoke test, `test_startup_aborts_without_admin_token` ✗ |
+| TR-008 | `startup_sentinel` shall verify all safety invariants (admin token present, watchdog spawned, posture engine running, SQLite WAL mode active) before the TCP listener binds; on any invariant failure, the process shall abort | `src/startup_sentinel.rs`, `src/bin/kirra_verifier_service.rs` | Integration smoke test, `test_startup_aborts_without_admin_token` ✓ |
 | TR-008a | The `kirra_verifier_service` binary shall bind the TCP listener only after `startup_sentinel` succeeds; no route shall be served before all invariants pass | `src/bin/kirra_verifier_service.rs` — listener bind ordering | Integration test confirming no response before startup_sentinel completes |
 | TR-008b | The `KirraPolicyLayer` Tower middleware shall be applied to the router at construction time; there shall be no code path that serves a request without passing through the middleware | `src/gateway/policy_layer.rs:KirraPolicyLayer`, `src/bin/kirra_verifier_service.rs` | Integration test confirming all routes pass through middleware |
 
@@ -135,8 +149,8 @@ Traceability flows in both directions:
 | TR ID | Technical Requirement | Implementation | Test(s) |
 |-------|-----------------------|----------------|---------|
 | TR-012 | The DNP3 protocol adapter and verifier service shall write an audit chain entry for every DNP3 message with `dest_address == DNP3_BROADCAST_ADDRESS` before returning the verdict (Kirra classifies; physical actuation ordering is an integrator AoU) | `src/bin/kirra_verifier_service.rs:evaluate_dnp3_adapter` (+ unified `evaluate_unified_industrial_request`) → `save_posture_event_chained` | `test_dnp3_broadcast_always_audited` ✓ |
-| TR-012a | If the audit chain write fails for a DNP3 broadcast command, the control output shall be blocked and an error shall be returned to the caller | `src/bin/kirra_verifier_service.rs:evaluate_dnp3_adapter` — audit-then-verdict; broadcast audit failure ⇒ `allowed:false` / `DNP3_BROADCAST_AUDIT_UNAVAILABLE` / 503 | `test_dnp3_broadcast_blocked_on_audit_write_failure` ✓ |
-| TR-012b | Non-broadcast DNP3 commands (unicast) shall also be audited, but an audit write failure for a non-broadcast command shall not block the control output | `src/bin/kirra_verifier_service.rs:evaluate_dnp3_adapter` — unicast control audited, audit failure non-fatal | `test_dnp3_unicast_audit_failure_non_fatal` ✓ |
+| TR-012a | If the audit chain write fails for a DNP3 broadcast command, the control output shall be blocked and an error shall be returned to the caller | `src/bin/kirra_verifier_service.rs:evaluate_dnp3_adapter` — audit-then-verdict; broadcast audit failure ⇒ `allowed:false` / `DNP3_BROADCAST_AUDIT_UNAVAILABLE` / 503 | `test_dnp3_broadcast_blocked_on_audit_write_failure` ✗ |
+| TR-012b | Non-broadcast DNP3 commands (unicast) shall also be audited, but an audit write failure for a non-broadcast command shall not block the control output | `src/bin/kirra_verifier_service.rs:evaluate_dnp3_adapter` — unicast control audited, audit failure non-fatal | `test_dnp3_unicast_audit_failure_non_fatal` ✗ |
 
 ---
 

--- a/src/traceability_gate.rs
+++ b/src/traceability_gate.rs
@@ -10,6 +10,12 @@
 // real `fn` in the workspace (a renamed/deleted test can no longer leave the RTM
 // claim dangling; prose entries like `see §7` are a documented escape).
 //
+// It ALSO reconciles the MANUAL RTM (`REQUIREMENTS_TRACEABILITY.md`, TR-NNN) with
+// reality: each named test's ✓ (verified) / ✗ (gap) marker must match whether the
+// test actually exists — a ✓ with no such fn is a false coverage claim, a ✗ whose
+// test now exists is stale pessimism; both fail the gate. So both the generated
+// SG/REQ matrix AND the hand-maintained TR matrix are drift-proof.
+//
 // Tag format (defined in docs/safety/TRACEABILITY.md §1):
 //
 //     // SAFETY: SG3 SG9 | REQ: <kebab-id> | TEST: test_a,test_b
@@ -185,6 +191,49 @@ fn is_test_identifier(s: &str) -> bool {
         && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
+/// Parse the `(test-name, is_verified)` markers from the manual RTM
+/// (`REQUIREMENTS_TRACEABILITY.md`): each TR row's Test column marks a named test
+/// `` `test_x` ✓ `` (verified — the test exists) or `` `test_x` ✗ `` (a gap — no
+/// such test). Only identifier-shaped, marker-followed backtick tokens are
+/// captured (implementation refs like `` `src/x.rs:f` `` carry no marker).
+#[cfg(test)]
+fn parse_rtm_markers(md: &str) -> Vec<(String, bool)> {
+    let mut out = Vec::new();
+    for line in md.lines() {
+        if !line.trim_start().starts_with("| TR-") {
+            continue;
+        }
+        let chars: Vec<char> = line.chars().collect();
+        let mut i = 0;
+        while i < chars.len() {
+            if chars[i] == '`' {
+                let mut j = i + 1;
+                let mut tok = String::new();
+                while j < chars.len() && chars[j] != '`' {
+                    tok.push(chars[j]);
+                    j += 1;
+                }
+                if j < chars.len() {
+                    let mut k = j + 1;
+                    while k < chars.len() && chars[k].is_whitespace() {
+                        k += 1;
+                    }
+                    if k < chars.len()
+                        && (chars[k] == '✓' || chars[k] == '✗')
+                        && is_test_identifier(&tok)
+                    {
+                        out.push((tok, chars[k] == '✓'));
+                    }
+                    i = j + 1;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+    }
+    out
+}
+
 fn parse_file(path: &Path, content: &str, tags: &mut Vec<SafetyTag>) {
     for (idx, line) in content.lines().enumerate() {
         if let Some((sgs, req, tests)) = parse_safety_line(line) {
@@ -324,6 +373,55 @@ mod ci_gate_tests {
              tag or restore the test:\n{}",
             dangling.join("\n")
         );
+    }
+
+    #[test]
+    fn rtm_markers_match_test_existence() {
+        // The manual RTM (`REQUIREMENTS_TRACEABILITY.md`) marks each named test ✓
+        // (verified — the test exists) or ✗ (a gap — no such test). Reconcile the
+        // markers with reality so the safety matrix cannot silently lie: a ✓ whose
+        // test does NOT exist is a FALSE coverage claim; a ✗ whose test NOW exists
+        // is stale pessimism (the coverage landed — flip it to ✓).
+        let root = std::env::var("CARGO_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("."));
+        let md_path = root.join("docs/safety/REQUIREMENTS_TRACEABILITY.md");
+        let md = std::fs::read_to_string(&md_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", md_path.display()));
+        let fns = walk_test_fn_names();
+
+        let mut false_check = Vec::new();
+        let mut stale_cross = Vec::new();
+        for (name, verified) in parse_rtm_markers(&md) {
+            let exists = fns.contains(&name);
+            if verified && !exists {
+                false_check.push(name);
+            } else if !verified && exists {
+                stale_cross.push(name);
+            }
+        }
+        assert!(
+            false_check.is_empty(),
+            "RTM marks these tests ✓ (verified) but no such fn exists — a FALSE \
+             coverage claim; write the test or flip the marker to ✗:\n  {}",
+            false_check.join("\n  ")
+        );
+        assert!(
+            stale_cross.is_empty(),
+            "RTM marks these tests ✗ (a gap) but the test NOW EXISTS — stale; flip \
+             the marker to ✓:\n  {}",
+            stale_cross.join("\n  ")
+        );
+    }
+
+    #[test]
+    fn rtm_marker_parser_reads_ticks_and_crosses() {
+        let md = "| TR-001 | req | `src/x.rs:f` | `test_alpha` ✓, `test_beta` ✗ |\n\
+                  not a tr row `test_gamma` ✓\n";
+        let m = parse_rtm_markers(md);
+        assert_eq!(m, vec![("test_alpha".to_string(), true), ("test_beta".to_string(), false)]);
+        // An implementation ref (path/colon token) carries no marker → not captured.
+        assert!(!m.iter().any(|(n, _)| n.contains('/')));
     }
 
     #[test]

--- a/src/traceability_gate.rs
+++ b/src/traceability_gate.rs
@@ -191,11 +191,42 @@ fn is_test_identifier(s: &str) -> bool {
         && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
+/// Extract the test-fn identifier(s) from a marker-bearing backtick token. Handles
+/// the qualified forms the RTM uses, not just a bare `test_x`:
+/// - bare:          `test_x`                          → `test_x`
+/// - path/mod:      `tests/f.rs::test_x`, `m::test_x`  → `test_x` (last `::` segment)
+/// - brace group:   `m::{test_a, test_b}`             → `test_a`, `test_b`
+///
+/// An abbreviating `...` inside a brace group (the doc's "and others") is not an
+/// identifier and is dropped. Anything that still isn't identifier-shaped after
+/// stripping the qualifier is ignored.
+#[cfg(test)]
+fn tests_in_token(tok: &str) -> Vec<String> {
+    let last_segment = |s: &str| s.rsplit("::").next().unwrap_or(s).trim().to_string();
+    // Brace group: names live inside `{ ... }`; the part before `{` is the module.
+    if let (Some(open), Some(close)) = (tok.find('{'), tok.rfind('}')) {
+        if open < close {
+            return tok[open + 1..close]
+                .split(',')
+                .map(|s| last_segment(s.trim()))
+                .filter(|s| is_test_identifier(s))
+                .collect();
+        }
+    }
+    let name = last_segment(tok.trim());
+    if is_test_identifier(&name) {
+        vec![name]
+    } else {
+        vec![]
+    }
+}
+
 /// Parse the `(test-name, is_verified)` markers from the manual RTM
 /// (`REQUIREMENTS_TRACEABILITY.md`): each TR row's Test column marks a named test
 /// `` `test_x` ✓ `` (verified — the test exists) or `` `test_x` ✗ `` (a gap — no
-/// such test). Only identifier-shaped, marker-followed backtick tokens are
-/// captured (implementation refs like `` `src/x.rs:f` `` carry no marker).
+/// such test). The marker follows a backtick token, which may be bare, path/mod-
+/// qualified, or a brace group ([`tests_in_token`]); implementation refs carry no
+/// marker and so are never captured.
 #[cfg(test)]
 fn parse_rtm_markers(md: &str) -> Vec<(String, bool)> {
     let mut out = Vec::new();
@@ -218,11 +249,11 @@ fn parse_rtm_markers(md: &str) -> Vec<(String, bool)> {
                     while k < chars.len() && chars[k].is_whitespace() {
                         k += 1;
                     }
-                    if k < chars.len()
-                        && (chars[k] == '✓' || chars[k] == '✗')
-                        && is_test_identifier(&tok)
-                    {
-                        out.push((tok, chars[k] == '✓'));
+                    if k < chars.len() && (chars[k] == '✓' || chars[k] == '✗') {
+                        let verified = chars[k] == '✓';
+                        for name in tests_in_token(&tok) {
+                            out.push((name, verified));
+                        }
                     }
                     i = j + 1;
                     continue;
@@ -422,6 +453,27 @@ mod ci_gate_tests {
         assert_eq!(m, vec![("test_alpha".to_string(), true), ("test_beta".to_string(), false)]);
         // An implementation ref (path/colon token) carries no marker → not captured.
         assert!(!m.iter().any(|(n, _)| n.contains('/')));
+    }
+
+    #[test]
+    fn rtm_marker_parser_handles_qualified_and_brace_forms() {
+        // path::test, mod::test, and mod::{a, b, ...} all reduce to bare fn names,
+        // carrying the row's marker (Copilot #852) — so the gate reconciles every
+        // marked test, not only bare-identifier ones.
+        let md = "| TR-9 | r | i | `tests/f.rs::test_path_qualified` ✓ |\n\
+                  | TR-9a | r | i | `m::sub::test_mod_qualified` ✗ |\n\
+                  | TR-9b | r | i | `admin_tests::{test_a, test_b, ...}` ✓ |\n";
+        let m = parse_rtm_markers(md);
+        assert_eq!(
+            m,
+            vec![
+                ("test_path_qualified".to_string(), true),
+                ("test_mod_qualified".to_string(), false),
+                ("test_a".to_string(), true),
+                ("test_b".to_string(), true),
+            ],
+            "qualified/brace tokens must reduce to bare fn names with the marker; `...` is dropped"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the other half of WS-5 item 4 ("merge manual RTM with the tag gate"). The hand-maintained `TR-NNN` matrix in `docs/safety/REQUIREMENTS_TRACEABILITY.md` marks each named test **✓** (verified — the test exists) or **✗** (a gap — no such test), but nothing checked those markers against reality — so the safety matrix could over-claim (✓ on a test that doesn't exist) or under-claim (✗ on a test that landed). This adds a machine gate and fixes the drift it found. It complements #851 (which drift-proofed the *generated* SG/REQ matrix).

## What changed

- **New gate `rtm_markers_match_test_existence`**: every ✓ test must resolve to a real `fn` (no false coverage claim), and every ✗ test must NOT resolve (a ✗ whose test now exists is stale — flip to ✓). Reuses `walk_test_fn_names`; `parse_rtm_markers` reads the backtick + ✓/✗ tokens (implementation refs carry no marker). Plus a parser unit test.
- **Real drift found and fixed in the doc:**
  - **2 false ✓ → ✗** (TR-012a/b): `test_dnp3_broadcast_blocked_on_audit_write_failure`, `test_dnp3_unicast_audit_failure_non_fatal` — named tests that do **not exist under any name** (the requirement's code path exists; `test_dnp3_broadcast_always_audited` covers "is audited", not "blocked on audit failure").
  - **4 stale ✗ → ✓** (TR-003/003a/003b watchdog + TR-008 startup): implemented in the CERT-003 work but the markers were never updated.
- **§1.1 legend** added, documenting the ✓/✗ meaning and that the markers are machine-gated — so the convention is explicit and self-describing.

## Verification

- `cargo test -p kirra-verifier --lib traceability_gate` — 8 pass (incl. the RTM reconciliation gate + its parser unit test)
- `cargo clippy -p kirra-verifier --lib --tests` — clean
- `python3 ci/check_quality_guardrails.py` — satisfied

With #851, **both RTM vocabularies (generated SG/REQ + hand-maintained TR-NNN) are now drift-proof** — neither can silently misclaim which tests verify a safety requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_