### PR TITLE
stop-gate cleanup: bound prediction step_count (L2) + fix CLAUDE.md verifier_store drift (L5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ These have been blocked or reverted multiple times. Any submission that violates
 | `NodeTrustState` | `src/verifier.rs` | `Trusted` / `Untrusted(String)` / `Unknown` |
 | `OperationalCommand` | `src/posture_cache.rs` | `ReadTelemetry` / `WriteState` / `SystemMutation` / `Unknown` |
 | `VerifierOperationMode` | `src/verifier.rs` | `Active` / `PassiveStandby`; runtime state held in `mode_active: Arc<AtomicBool>` |
-| `VerifierStore` | `src/verifier_store.rs` | rusqlite WAL-mode SQLite; wrapped in `Arc<Mutex<VerifierStore>>` in AppState |
+| `VerifierStore` | `src/verifier_store/` (module dir: `mod.rs` + per-table submodules) | rusqlite WAL-mode SQLite; wrapped in `Arc<Mutex<VerifierStore>>` in AppState |
 | `PostureStreamEvent` | `src/verifier.rs` | Broadcast channel payload for SSE stream |
 | `TransportIdentityConfig` | `src/verifier.rs` | `trusted_ingress_mode` + `client_id_header` from env |
 | `FederatedTrustReport` | `src/federation.rs` | Ed25519-signed cross-controller trust report |
@@ -90,7 +90,9 @@ These have been blocked or reverted multiple times. Any submission that violates
 ```
 src/
 ├── verifier.rs               — AppState, FleetPosture, DAG traversal, TransportIdentityConfig
-├── verifier_store.rs         — SQLite persistence (all tables; WAL mode)
+├── verifier_store/           — SQLite persistence (all tables; WAL mode); module dir:
+│                               mod.rs + per-table submodules (nodes, attestation, audit,
+│                               federation, epoch, principals, ota_campaigns, …)
 ├── posture_cache.rs          — SharedPostureCache, CachedFleetPosture, ServiceState,
 │                               OperationalCommand, should_route_command, POSTURE_CACHE_TTL_MS
 ├── posture_engine.rs         — recalculate_and_broadcast, derive_fleet_posture,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/kirra-trajectory/src/prediction.rs
+++ b/crates/kirra-trajectory/src/prediction.rs
@@ -75,8 +75,10 @@ pub const MAX_PREDICTION_STEPS: usize = 512;
 /// realized `SampleVec` length is bounded by `MAX_PREDICTION_STEPS + 1`.
 fn step_count(horizon_s: f64, dt_s: f64) -> usize {
     let raw = (horizon_s.max(0.0) / dt_s).ceil().max(1.0);
-    // `dt_s <= 0` or a non-finite ratio yields NaN/∞; the `as usize` cast of a non-finite or
-    // out-of-range f64 saturates, but clamp explicitly so the bound is obvious and total.
+    // Guard the non-finite cases explicitly (rather than lean on `as usize` saturation): `dt_s
+    // == 0.0` makes the ratio ±∞, and a NaN input makes it NaN. A *negative* `dt_s` is NOT
+    // non-finite — it yields a finite negative ratio that `.max(1.0)` already floors to 1 — so
+    // it flows through the finite branch. Clamping here keeps the upper bound obvious and total.
     if raw.is_finite() {
         (raw as usize).min(MAX_PREDICTION_STEPS)
     } else {
@@ -344,9 +346,10 @@ mod tests {
         // A pathological caller (huge horizon / near-zero dt) is CLAMPED, not unbounded.
         assert_eq!(step_count(1.0e9, 1.0e-9), MAX_PREDICTION_STEPS, "huge ratio clamps to the ceiling");
         assert_eq!(step_count(10.0, 1.0e-6), MAX_PREDICTION_STEPS, "tiny dt clamps to the ceiling");
-        // A non-finite ratio (dt_s <= 0 → division by zero) also clamps, never panics/UB-casts.
+        // dt_s == 0 makes the ratio +inf (non-finite) → clamps to the ceiling, never panics/UB-casts.
         assert_eq!(step_count(5.0, 0.0), MAX_PREDICTION_STEPS, "dt=0 → +inf ratio clamps");
-        assert_eq!(step_count(5.0, -1.0), 1, "negative dt → negative ratio floors at 1");
+        // A negative dt_s is FINITE (negative ratio), so it takes the ordinary floor, not the cap.
+        assert_eq!(step_count(5.0, -1.0), 1, "negative dt → finite negative ratio floors at 1");
     }
 
     #[test]

--- a/crates/kirra-trajectory/src/prediction.rs
+++ b/crates/kirra-trajectory/src/prediction.rs
@@ -59,9 +59,29 @@ impl OwnedPredictedMode {
     }
 }
 
-/// Number of sample steps over `[0, horizon_s]` at `dt_s` (≥ 1).
+/// Hard ceiling on the number of prediction sample steps a single mode may roll out, so the
+/// per-mode `SampleVec` allocation is BOUNDED by a `MAX_*` constant regardless of the
+/// `(horizon_s, dt_s)` a caller supplies — mirroring the verdict path's `MAX_TRAJECTORY_HORIZON`
+/// discipline (`kirra_core::containment`). The live slow-loop config is a 3 s / 0.5 s horizon
+/// (`SLOW_PRED_HORIZON_S` / `SLOW_PRED_DT_S` → 6 steps), so this ceiling has ~85× headroom over
+/// any legitimate use and only ever bites a misconfigured caller (a huge horizon or a
+/// near-zero `dt_s`), where a bounded rollout is strictly better than an unbounded `Vec`. It is
+/// NOT on the pinned per-pose `validate_vehicle_command` path (that stays byte-identical).
+pub const MAX_PREDICTION_STEPS: usize = 512;
+
+/// Number of sample steps over `[0, horizon_s]` at `dt_s` (≥ 1), capped at
+/// [`MAX_PREDICTION_STEPS`] so a pathological `(horizon_s, dt_s)` can never drive an unbounded
+/// allocation. Each `*_samples` producer emits `n + 1` samples (the `0` step plus `n`), so the
+/// realized `SampleVec` length is bounded by `MAX_PREDICTION_STEPS + 1`.
 fn step_count(horizon_s: f64, dt_s: f64) -> usize {
-    (horizon_s.max(0.0) / dt_s).ceil().max(1.0) as usize
+    let raw = (horizon_s.max(0.0) / dt_s).ceil().max(1.0);
+    // `dt_s <= 0` or a non-finite ratio yields NaN/∞; the `as usize` cast of a non-finite or
+    // out-of-range f64 saturates, but clamp explicitly so the bound is obvious and total.
+    if raw.is_finite() {
+        (raw as usize).min(MAX_PREDICTION_STEPS)
+    } else {
+        MAX_PREDICTION_STEPS
+    }
 }
 
 /// Roll `obj` forward on CONSTANT VELOCITY (its reported velocity vector) — a straight-line
@@ -312,5 +332,42 @@ mod tests {
         let path = [Point { x_m: 0.0, y_m: 0.0 }, Point { x_m: 10.0, y_m: 0.0 }];
         let modes = predicted_modes_from_objects(&[o], &[], &[(1, &path[..])], 2.0, 0.5);
         assert_eq!(modes.len(), 1, "a stationary object's lane-follow degenerates to CV → omitted");
+    }
+
+    #[test]
+    fn step_count_is_bounded_by_the_max_constant() {
+        // The nominal slow-loop config produces a handful of steps...
+        assert_eq!(step_count(3.0, 0.5), 6, "nominal 3 s / 0.5 s horizon");
+        assert_eq!(step_count(2.0, 1.0), 2);
+        // ...and step_count never drops below 1 for a degenerate-but-finite horizon.
+        assert_eq!(step_count(0.0, 0.5), 1, "a zero horizon still yields the t=0 step");
+        // A pathological caller (huge horizon / near-zero dt) is CLAMPED, not unbounded.
+        assert_eq!(step_count(1.0e9, 1.0e-9), MAX_PREDICTION_STEPS, "huge ratio clamps to the ceiling");
+        assert_eq!(step_count(10.0, 1.0e-6), MAX_PREDICTION_STEPS, "tiny dt clamps to the ceiling");
+        // A non-finite ratio (dt_s <= 0 → division by zero) also clamps, never panics/UB-casts.
+        assert_eq!(step_count(5.0, 0.0), MAX_PREDICTION_STEPS, "dt=0 → +inf ratio clamps");
+        assert_eq!(step_count(5.0, -1.0), 1, "negative dt → negative ratio floors at 1");
+    }
+
+    #[test]
+    fn a_pathological_horizon_produces_a_bounded_sample_run() {
+        // BEFORE the L2 fix this allocated an ~unbounded Vec; now every producer's SampleVec is
+        // capped at MAX_PREDICTION_STEPS + 1 (the +1 is the t=0 sample) no matter the inputs.
+        let o = obj(1, 0.0, 0.0, 3.0, 0.0);
+        let cv = predicted_modes_from_objects(&[o], &[], &[], 1.0e6, 1.0e-6);
+        assert_eq!(cv.len(), 1, "CV mode only");
+        assert!(
+            cv[0].samples.len() <= MAX_PREDICTION_STEPS + 1,
+            "CV rollout bounded, got {}",
+            cv[0].samples.len()
+        );
+        // The CTRV producer (a separate `with_capacity`/push loop) is bounded the same way.
+        let mm = predicted_modes_from_objects(&[o], &[(1, 0.4)], &[], 1.0e6, 1.0e-6);
+        assert_eq!(mm.len(), 2, "CV + CTRV");
+        assert!(
+            mm[1].samples.len() <= MAX_PREDICTION_STEPS + 1,
+            "CTRV rollout bounded, got {}",
+            mm[1].samples.len()
+        );
     }
 }

--- a/parko/Cargo.lock
+++ b/parko/Cargo.lock
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Closes the two remaining **Low** findings from the Track-2 → Track-3 stop-gate review. All High (H1/H2/H3) and Medium (M1–M5) findings were already fixed and merged; these were the last two open items, both trivial and neither an entry blocker.

## L2 — bound the slow-loop predictor's `step_count`

`crates/kirra-trajectory/src/prediction.rs` — the multi-modal predictive-RSS mode producer computed `step_count = (horizon_s / dt_s).ceil()` with **no upper cap**, so a misconfigured caller (a huge horizon or a near-zero `dt_s`) could drive an unbounded per-mode `SampleVec` allocation. It is off the pinned per-pose `validate_vehicle_command` verdict path (~10 Hz slow loop), but it was the one prediction rollout **not** hard-bounded by a `MAX_*` constant the way the verdict path is bounded by `MAX_TRAJECTORY_HORIZON`.

- Add `pub const MAX_PREDICTION_STEPS: usize = 512` — ~85× headroom over the live `SLOW_PRED_HORIZON_S` / `SLOW_PRED_DT_S` (3 s / 0.5 s → 6 steps), so the cap only ever bites a misconfiguration.
- Clamp `step_count` to it, and handle a **non-finite** ratio (`dt_s <= 0` → `+inf`/`NaN`) explicitly so the `as usize` cast never relies on saturation behaviour.
- Every `*_samples` producer emits `n + 1` samples, so the realized `SampleVec` length is now bounded by `MAX_PREDICTION_STEPS + 1` regardless of inputs.

**Tests (discriminating):**
- `step_count_is_bounded_by_the_max_constant` — nominal (6), zero-horizon floor (1), huge ratio → cap, tiny `dt` → cap, `dt=0` (`+inf`) → cap, negative `dt` → floors at 1.
- `a_pathological_horizon_produces_a_bounded_sample_run` — a `1e6 s / 1e-6 s` input keeps both the CV (`map`/`collect`) and CTRV (`with_capacity`/push) producers `<= MAX_PREDICTION_STEPS + 1`.

The pinned `validate_vehicle_command` path is **unchanged** (byte-identical Nominal WCET path).

## L5 — fix CLAUDE.md `verifier_store` doc drift

`CLAUDE.md`'s type table and module map listed `src/verifier_store.rs` as a **file**; it is now a **directory module** (`mod.rs` + per-table submodules: `nodes`, `attestation`, `audit`, `federation`, `epoch`, `principals`, `ota_campaigns`, …). Both references updated to match the tree. (The `judge.rs` references the original review flagged are accurate-in-context — they point at the real `tools/iceoryx2-spike/src/judge.rs` / `tools/qnx-rtm-harness/kirra_judge.rs`, not a stale `src/judge.rs`.)

## Verification

- `cargo test -p kirra-trajectory --lib prediction` → 10 passed
- `cargo clippy -p kirra-trajectory --lib --all-targets` → clean
- `python3 ci/check_quality_guardrails.py` → all guardrails satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_