### PR TITLE
planner: percentile activation calibrator — the PTQ graduation rung off absmax (#3)

### DIFF
--- a/crates/kirra-doer-eval/src/lib.rs
+++ b/crates/kirra-doer-eval/src/lib.rs
@@ -760,6 +760,25 @@ mod tests {
         }
     }
 
+    /// The percentile calibrator (#3) is wired through and back-compatible: over the
+    /// real corpus, `Percentile(1.0)` (clip at the max) reproduces `AbsMax`, which in
+    /// turn equals the default `quantize_int8` — so the shipped-artifact path is
+    /// byte-identical and only an explicit sub-1.0 fraction changes the scales.
+    #[test]
+    fn percentile_1_0_equals_absmax_and_is_backcompat() {
+        use kirra_planner::CalibrationMethod;
+        let corpus = demo_corpus();
+        let fp32 = LearnedPlanner::trained(SEED, Teacher::SafetyAware);
+        let inputs: Vec<PlanInput<'_>> = corpus.iter().map(EvalScenario::plan_input).collect();
+
+        let default = fp32.quantize_int8(&inputs);
+        let absmax = fp32.quantize_int8_with(&inputs, CalibrationMethod::AbsMax);
+        let p100 = fp32.quantize_int8_with(&inputs, CalibrationMethod::Percentile(1.0));
+
+        assert_eq!(default.scales(), absmax.scales(), "default == explicit AbsMax");
+        assert_eq!(absmax.scales(), p100.scales(), "Percentile(1.0) == AbsMax");
+    }
+
     /// Quantization is a pure function of `(planner, calibration set)` — same inputs,
     /// byte-identical artifact and eval. (Reproducibility is a scorecard-provenance
     /// requirement; see Q1 scope §5.)

--- a/crates/kirra-planner/src/learned.rs
+++ b/crates/kirra-planner/src/learned.rs
@@ -614,9 +614,10 @@ pub enum CalibrationMethod {
     /// coarsening the resolution of the in-distribution bulk.
     #[default]
     AbsMax,
-    /// Clip at the given quantile of |activation| in `(0.0, 1.0]` (nearest-rank). A
-    /// rare outlier SATURATES gracefully to `±127` while the bulk keeps tight bins
-    /// (and precision). `Percentile(1.0)` is exactly [`AbsMax`](Self::AbsMax). The
+    /// Clip at the given quantile of |activation| in `[0.0, 1.0]` (nearest-rank; the
+    /// value is clamped into that range). A rare outlier SATURATES gracefully to
+    /// `±127` while the bulk keeps tight bins (and precision). `Percentile(1.0)` is
+    /// exactly [`AbsMax`](Self::AbsMax) and `Percentile(0.0)` is the min. The
     /// pre-emptive graduation path for when the scorer moves off tanh / grows
     /// (design-note §9/§11); absmax remains the default until a model fails the PTQ
     /// quality gate.
@@ -624,14 +625,16 @@ pub enum CalibrationMethod {
 }
 
 /// Nearest-rank quantile of the |activation| magnitudes `xs` at fraction `frac`
-/// (sorts in place). `frac >= 1.0` returns the max, so `Percentile(1.0)` coincides
-/// with `AbsMax`; an empty set returns `0.0` (→ the degenerate unit scale, guarded
-/// by [`int8_scale`]). NaNs sort last but a finite calibration set has none.
+/// (sorts in place). `frac` is clamped to `[0.0, 1.0]`: `>= 1.0` returns the max
+/// (so `Percentile(1.0)` coincides with `AbsMax`), `0.0` the min; an empty set
+/// returns `0.0` (→ the degenerate unit scale, guarded by [`int8_scale`]). Sorted
+/// by [`f64::total_cmp`] for a genuine total order — NaNs sort last, though a
+/// finite calibration set (the only caller) has none.
 pub(crate) fn percentile_nearest_rank(xs: &mut [f64], frac: f64) -> f64 {
     if xs.is_empty() {
         return 0.0;
     }
-    xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    xs.sort_by(f64::total_cmp);
     let n = xs.len();
     let frac = frac.clamp(0.0, 1.0);
     // 1-based nearest rank = ceil(frac * n), clamped to [1, n]; index = rank - 1.
@@ -681,8 +684,10 @@ impl LearnedPlanner {
                 (ax, ah)
             }
             CalibrationMethod::Percentile(frac) => {
-                let mut xs = Vec::new();
-                let mut hs = Vec::new();
+                // Sizes are predictable: one magnitude per input feature / hidden
+                // unit per calibration scenario — reserve up front, no re-growth.
+                let mut xs = Vec::with_capacity(calibration.len() * IN);
+                let mut hs = Vec::with_capacity(calibration.len() * H);
                 for input in calibration {
                     let x = featurize(&scene_of(input));
                     for &xi in &x {

--- a/crates/kirra-planner/src/learned.rs
+++ b/crates/kirra-planner/src/learned.rs
@@ -602,34 +602,99 @@ impl ScoredPlanner for QuantizedLearnedPlanner {
     }
 }
 
+/// The activation-scale calibration estimator (PTQ). Governs how the per-tensor
+/// *activation* clip threshold (→ `s_x` on the inputs, `s_h` on the hidden layer)
+/// is derived from the observed |activation| distribution over the calibration
+/// corpus. Weights are always per-tensor absmax — they are static and
+/// corpus-independent, so they carry no outlier risk.
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub enum CalibrationMethod {
+    /// The largest observed |activation|. Simple and the historical default, but a
+    /// single outlier scenario stretches the int8 bins for the WHOLE corpus,
+    /// coarsening the resolution of the in-distribution bulk.
+    #[default]
+    AbsMax,
+    /// Clip at the given quantile of |activation| in `(0.0, 1.0]` (nearest-rank). A
+    /// rare outlier SATURATES gracefully to `±127` while the bulk keeps tight bins
+    /// (and precision). `Percentile(1.0)` is exactly [`AbsMax`](Self::AbsMax). The
+    /// pre-emptive graduation path for when the scorer moves off tanh / grows
+    /// (design-note §9/§11); absmax remains the default until a model fails the PTQ
+    /// quality gate.
+    Percentile(f64),
+}
+
+/// Nearest-rank quantile of the |activation| magnitudes `xs` at fraction `frac`
+/// (sorts in place). `frac >= 1.0` returns the max, so `Percentile(1.0)` coincides
+/// with `AbsMax`; an empty set returns `0.0` (→ the degenerate unit scale, guarded
+/// by [`int8_scale`]). NaNs sort last but a finite calibration set has none.
+pub(crate) fn percentile_nearest_rank(xs: &mut [f64], frac: f64) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let n = xs.len();
+    let frac = frac.clamp(0.0, 1.0);
+    // 1-based nearest rank = ceil(frac * n), clamped to [1, n]; index = rank - 1.
+    let rank = ((frac * n as f64).ceil() as usize).clamp(1, n);
+    xs[rank - 1]
+}
+
 impl LearnedPlanner {
     /// **Post-training int8 quantization** (PTQ) of this planner's scorer, calibrated
-    /// over `calibration` inputs. Weights are quantized per-tensor (symmetric int8);
-    /// the activation scales — `s_x` on the input features, `s_h` on the hidden layer
-    /// — are the absmax observed across the calibration corpus (a real PTQ
-    /// calibration pass). Returns an int8 [`QuantizedLearnedPlanner`] with the same
-    /// vocabulary + teacher.
+    /// over `calibration` inputs with the default [`CalibrationMethod::AbsMax`].
+    /// Byte-identical to the historical behaviour — the shipped artifact path.
     ///
     /// PTQ is a QUALITY operation, not a safety one (see the section header): the int8
     /// scorer's proposal is still bounded by the unchanged checker.
     pub fn quantize_int8(&self, calibration: &[PlanInput]) -> QuantizedLearnedPlanner {
+        self.quantize_int8_with(calibration, CalibrationMethod::AbsMax)
+    }
+
+    /// [`quantize_int8`](Self::quantize_int8) with an explicit activation-calibration
+    /// `method`. Weights are per-tensor symmetric int8 (absmax); the activation
+    /// scales `s_x` / `s_h` are derived from the calibration corpus per `method`.
+    pub fn quantize_int8_with(
+        &self,
+        calibration: &[PlanInput],
+        method: CalibrationMethod,
+    ) -> QuantizedLearnedPlanner {
         // Weight scales: per-tensor absmax over the (static) trained weights.
         let s_w1 = int8_scale(absmax2(&self.scorer.w1));
         let s_w2 = int8_scale(absmax2(&self.scorer.w2));
 
-        // Activation scales: absmax of the input features and the hidden activations
-        // observed over the calibration corpus.
-        let mut ax = 0.0_f64;
-        let mut ah = 0.0_f64;
-        for input in calibration {
-            let x = featurize(&scene_of(input));
-            for &xi in &x {
-                ax = ax.max(xi.abs());
+        // Activation clip thresholds over the calibration corpus, per `method`.
+        // AbsMax streams a running max (zero-alloc, byte-identical to the historical
+        // path); Percentile collects the magnitudes and takes the nearest-rank quantile.
+        let (ax, ah) = match method {
+            CalibrationMethod::AbsMax => {
+                let mut ax = 0.0_f64;
+                let mut ah = 0.0_f64;
+                for input in calibration {
+                    let x = featurize(&scene_of(input));
+                    for &xi in &x {
+                        ax = ax.max(xi.abs());
+                    }
+                    for hj in self.scorer.hidden(&x) {
+                        ah = ah.max(hj.abs());
+                    }
+                }
+                (ax, ah)
             }
-            for hj in self.scorer.hidden(&x) {
-                ah = ah.max(hj.abs());
+            CalibrationMethod::Percentile(frac) => {
+                let mut xs = Vec::new();
+                let mut hs = Vec::new();
+                for input in calibration {
+                    let x = featurize(&scene_of(input));
+                    for &xi in &x {
+                        xs.push(xi.abs());
+                    }
+                    for hj in self.scorer.hidden(&x) {
+                        hs.push(hj.abs());
+                    }
+                }
+                (percentile_nearest_rank(&mut xs, frac), percentile_nearest_rank(&mut hs, frac))
             }
-        }
+        };
         let s_x = int8_scale(ax);
         let s_h = int8_scale(ah);
 
@@ -849,5 +914,65 @@ mod ptq_tests {
         assert!(moved, "int8 forward must differ from fp32 — quantization is non-trivial");
         let maxdiff = yf.iter().zip(yq.iter()).map(|(a, b)| (a - b).abs()).fold(0.0, f64::max);
         assert!(maxdiff < 0.5, "int8 perturbation should be small, got {maxdiff}");
+    }
+
+    // ---- Percentile calibrator (#3: the graduation path off absmax) ----
+
+    #[test]
+    fn percentile_nearest_rank_math() {
+        // frac = 1.0 is the max → Percentile(1.0) == AbsMax.
+        let mut v = vec![0.3, 0.1, 0.2, 0.5, 0.4];
+        assert!((percentile_nearest_rank(&mut v, 1.0) - 0.5).abs() < 1e-12);
+        // A mid quantile picks the nearest-rank element.
+        let mut v = vec![0.1, 0.2, 0.3, 0.4, 0.5];
+        // rank = ceil(0.6 * 5) = 3 → the 3rd smallest = 0.3.
+        assert!((percentile_nearest_rank(&mut v, 0.6) - 0.3).abs() < 1e-12);
+        // Degenerate inputs are guarded.
+        assert_eq!(percentile_nearest_rank(&mut [], 0.99), 0.0);
+        let mut one = vec![7.0];
+        assert_eq!(percentile_nearest_rank(&mut one, 0.5), 7.0);
+        // frac clamps into [0,1]; a huge frac is still the max, a tiny one the min.
+        let mut v = vec![1.0, 2.0, 3.0, 4.0];
+        assert_eq!(percentile_nearest_rank(&mut v, 5.0), 4.0);
+        assert_eq!(percentile_nearest_rank(&mut v, 0.0), 1.0);
+    }
+
+    /// The load-bearing #3 test — the two halves of the Gap-2 claim, deterministically:
+    /// with one extreme outlier in the calibration magnitudes, (a) the percentile clip
+    /// threshold is FAR below absmax (the outlier is clipped, not allowed to stretch the
+    /// bins), and (b) as a direct consequence the in-distribution BULK reconstructs with
+    /// FINER resolution under the percentile scale — while the outlier merely saturates.
+    #[test]
+    fn percentile_clips_outlier_and_keeps_finer_bulk_resolution() {
+        // 99 tightly-clustered bulk magnitudes + 1 blow-out outlier.
+        let mut mags: Vec<f64> = (0..99).map(|i| 0.20 + 0.001 * f64::from(i)).collect();
+        let outlier = 100.0;
+        mags.push(outlier);
+
+        let s_absmax = int8_scale(mags.iter().fold(0.0_f64, |a, &v| a.max(v)));
+        let s_pct = int8_scale(percentile_nearest_rank(&mut mags.clone(), 0.99));
+
+        // (a) The outlier stretches absmax; the 99th-percentile clip ignores it.
+        assert!(
+            s_pct < s_absmax / 10.0,
+            "percentile clip must be far tighter than absmax: s_pct={s_pct}, s_absmax={s_absmax}"
+        );
+
+        // (b) Finer bulk resolution: mean fake-quant reconstruction error over the bulk
+        // is strictly smaller under the tighter percentile scale.
+        let bulk: Vec<f64> = (0..99).map(|i| 0.20 + 0.001 * f64::from(i)).collect();
+        let mean_err = |scale: f64| -> f64 {
+            bulk.iter().map(|&v| (fake_quant(v, scale) - v).abs()).sum::<f64>() / bulk.len() as f64
+        };
+        assert!(
+            mean_err(s_pct) < mean_err(s_absmax),
+            "percentile scale must reconstruct the bulk more precisely: pct={}, absmax={}",
+            mean_err(s_pct),
+            mean_err(s_absmax)
+        );
+
+        // The outlier merely saturates (graceful), never a panic / out-of-range code.
+        assert_eq!(quantize_i8(outlier, s_pct), 127);
+        assert_eq!(quantize_i8(-outlier, s_pct), -127);
     }
 }

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -85,8 +85,8 @@ pub use mick_llm::{
 
 pub mod learned;
 pub use learned::{
-    LearnedManeuverPlanner, LearnedPlanner, QuantizedLearnedPlanner, QuantizedScorerWeights,
-    ScoredPlanner, ScorerWeights, Teacher,
+    CalibrationMethod, LearnedManeuverPlanner, LearnedPlanner, QuantizedLearnedPlanner,
+    QuantizedScorerWeights, ScoredPlanner, ScorerWeights, Teacher,
 };
 
 // M-1 (parko/DOER_MODEL_SCALEUP.md): the real-sized doer scorer — offset×speed

--- a/parko/QUANTIZATION_DESIGN.md
+++ b/parko/QUANTIZATION_DESIGN.md
@@ -173,7 +173,17 @@ is absent, never silently passed). Reuses the existing bench scaffolding.
   (PARK-027/028/030).
 - **Q-4 — FP8/INT4** (extend `PrecisionMode`) where hardware supports it, if the
   contract shows headroom.
-- **QAT** — only spun up for a specific model that fails PTQ's quality gate.
+- **Calibrator graduation (available, opt-in).** Before QAT, the PTQ activation
+  calibrator can graduate from absmax to a **percentile clip**:
+  `LearnedPlanner::quantize_int8_with(_, CalibrationMethod::Percentile(frac))` clips
+  at the `frac` quantile of |activation| so a rare outlier saturates gracefully
+  instead of stretching the int8 bins (keeping precision for the bulk).
+  `Percentile(1.0)` == `AbsMax`, and **absmax stays the default** — evidence-gated:
+  at the current tanh scale the held-out gap is ~0 (nothing has failed the gate), so
+  the percentile rung is armed for the M-lane scale-up / off-tanh activations, not
+  switched on speculatively.
+- **QAT** — the last rung, only spun up for a specific model that fails PTQ's quality
+  gate even after the percentile calibrator.
 
 ## 10. Risks & mitigations
 


### PR DESCRIPTION
Lands the calibrator-graduation rung raised in review (Gap 2, "saturation cliff") — a percentile activation calibrator behind an opt-in seam, with absmax kept as the byte-identical default.

## The gap
The absmax activation calibrator (`absmax / 127`) sets the int8 clip threshold from the single largest observed activation. A rare outlier scenario therefore stretches the bins for the *whole* corpus, coarsening resolution for the in-distribution bulk and risking argmax drift → constant MRC. Safe (the checker bounds it) but functionally degraded. This bites once the scorer moves off tanh / grows (design-note §11).

## What this lands (`kirra-planner`, opt-in, default byte-identical)
- **`CalibrationMethod { AbsMax (default), Percentile(frac) }`** — governs how the per-tensor **activation** clip threshold (`s_x`/`s_h`) is derived. Weights stay per-tensor absmax (static → no outlier risk).
- **`LearnedPlanner::quantize_int8_with(calibration, method)`** — `quantize_int8` now delegates to `AbsMax`, so the shipped-artifact path is unchanged (drift tests green).
- **`percentile_nearest_rank`** — nearest-rank quantile; `Percentile(1.0) == AbsMax`; empty → `0.0` (guarded degenerate scale).

## Tests (discriminating)
- `percentile_nearest_rank_math` — rank arithmetic, `frac` clamping, degenerate inputs.
- **`percentile_clips_outlier_and_keeps_finer_bulk_resolution`** — the two halves of the Gap-2 claim, deterministically: with one blow-out outlier, the percentile clip is far below absmax **and** the in-distribution bulk reconstructs with strictly finer resolution under the tighter scale, while the outlier merely saturates to `±127`.
- doer-eval **`percentile_1_0_equals_absmax_and_is_backcompat`** — over the real corpus, `Percentile(1.0) == AbsMax == default quantize_int8`.

## Honesty / scope
- **Absmax stays the default — evidence-gated.** At the current tanh scale the held-out gap (from #858's `generalization_report`) is ~0; nothing has failed the PTQ quality gate. The percentile rung is *armed* for the M-lane scale-up / off-tanh activations, not switched on speculatively (matches the design-note rule: graduate the calibrator only when a model fails the gate).
- v2 (N-layer) calibrator graduation is a mechanical follow-up.
- Checker untouched — doer-side only, no safety authority. Documented in `parko/QUANTIZATION_DESIGN.md §9` as the rung between PTQ-absmax and QAT.

## Verification
- `cargo test -p kirra-planner --lib ptq_tests` → 5 passed
- `cargo test -p kirra-doer-eval` → 18 passed (incl. `artifact_drift` — no artifact churn — and the back-compat test)
- `cargo clippy -p kirra-planner -p kirra-doer-eval --all-targets` → clean
- `python3 ci/check_quality_guardrails.py` → satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8UD3ajLiTY7QtnNE7oJ6)_