### PR TITLE
M3 — certification evidence: Miri lane, gated decision coverage, curved-geometry RSS, safety-constants provenance gate (EP-16/07/08/09)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -2,11 +2,13 @@
 #
 # SCOPE. Mutation runs target the CHECKER crate (`-p kirra-trajectory`,
 # passed on the command line by the CI lane / the baseline scripts). The
-# checker's DEEPEST tests live in `crates/kirra-ros2-adapter/tests/
-# validation_tests.rs` (the Option-B re-export wiring), so the mutation
-# harness MUST run that package's tests too — otherwise it understates kill
-# rates badly (measured 2026-07-07: 318 survivors own-tests-only vs 202 with
-# the adapter suite; see docs/testing/MUTATION_BASELINE.md).
+# checker's slow-loop test battery now lives WITH the checker code
+# (`crates/kirra-trajectory/tests/validation_tests.rs`, relocated from the
+# adapter alongside the code it covers); the adapter crate is kept in scope
+# because its conformance / perception-gate / cited-copy suites still exercise
+# the checker through the Option-B re-export wiring, catching mutants the unit
+# tests alone would not (measured 2026-07-07: 318 survivors own-tests-only vs
+# 202 with the adapter suite; see docs/testing/MUTATION_BASELINE.md).
 #
 # `test_package` is the CORRECT mechanism for this. cargo-mutants defaults to
 # running ONLY the mutated package's own tests; `test_package` (CLI
@@ -21,3 +23,33 @@ test_package = ["kirra-trajectory", "kirra-ros2-adapter"]
 # the suite itself runs in seconds, so 300 s cleanly separates "hung mutant"
 # (caught as timeout) from slow CI I/O.
 minimum_test_timeout = 300
+
+# EQUIVALENT-MUTANT exclusions (EP-08 Frenet / curved-RSS geometry). Each entry
+# below is a mutation that CANNOT be killed by any test because it does not
+# change observable behaviour — cargo-mutants cannot detect equivalence, so it
+# is excluded here with a written justification (mirrors the accept-with-reason
+# policy in docs/testing/MUTATION_BASELINE.md §3/§6). These are precise
+# function+operator patterns, NOT blanket operator excludes: the ONLY `<`/`-`
+# operators remaining in `from_boundaries` after its redundant length guards
+# were removed ARE the duplicate-collapse predicate, and the two RSS gates each
+# have exactly one in-diff `<` (the EP-08 per-class overlap comparison).
+exclude_re = [
+    # Duplicate-midpoint collapse in the centerline builder: a defensive guard
+    # whose only effect is to drop a zero-length centerline segment. Every
+    # downstream traversal (project, tangent_at, total_heading_change_rad)
+    # already skips a zero-length segment, so mutating the collapse predicate or
+    # its coordinate subtraction produces byte-identical projections/tangents for
+    # every corridor the resampler can produce — output-equivalent.
+    "replace < with (==|<=|>) in CenterlineFrenet::from_boundaries",
+    "replace - with (\\+|/) in CenterlineFrenet::from_boundaries",
+    # Nearest-segment retention in `project`: `dist2 < best` vs `<=` differ only
+    # when two segments are EXACTLY equidistant, where either choice yields the
+    # same projected (s, d) — a measure-zero, output-equivalent boundary.
+    "replace < with <= in CenterlineFrenet::project",
+    # EP-08 per-class longitudinal-overlap gate (snapshot :553 + predictive
+    # :911): `|dy| < overlap` vs `|dy| <= overlap` differ only at exact float
+    # equality (|dy| == overlap to the bit) — a measure-zero boundary that is
+    # behaviourally identical for any real perception input.
+    "replace < with <= in validate_trajectory_slow_capped",
+    "replace < with <= in predictive_rss_breach",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,8 +308,61 @@ jobs:
         # libkirra_verifier cdylib and runs it — keeps the C ABI examples from rotting.
         run: ./examples/c/build_and_run.sh
 
+  checker-coverage:
+    name: Checker decision coverage — gated floors (EP-07; true MC/DC toolchain-blocked, #65)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # The certification-relevant CHECKER crates get a GATED decision-coverage
+    # floor (the workspace `coverage` job uploads but does not gate). Each crate
+    # first attempts `--mcdc`: rustc currently rejects `-Zcoverage-options=mcdc`
+    # (block|branch|condition only — the EP-07 spike result recorded in #65), so
+    # the attempt falls back to BRANCH coverage (decision coverage — the
+    # strongest gate the toolchain can express) and ci/check_decision_floor.py
+    # gates on the strongest metric present in the export. The day nightly
+    # restores mcdc, this lane upgrades itself with no workflow change.
+    #
+    # Floors sit ~2 points under the measured baselines (kirra-trajectory
+    # 80.08 %, kirra-core 81.15 %, parko-core 79.82 % branch) — real gates with
+    # anti-flake headroom; RATCHET them up as coverage improves, never down
+    # without reviewer sign-off.
+    env:
+      RUSTUP_TOOLCHAIN: nightly
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@efcb852328a9f50117170cc43094fb6f09eaf1ae # nightly
+        with:
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov
+      - name: Gate the checker crates (root workspace)
+        run: |
+          set -euo pipefail
+          gate () {
+            local crate="$1" floor="$2"
+            if cargo llvm-cov -p "$crate" --mcdc --json --summary-only > "cov-$crate.json" 2> "mcdc-$crate.err"; then
+              echo "[$crate] MC/DC accepted by toolchain — gating on MC/DC."
+            else
+              echo "[$crate] --mcdc rejected by the toolchain (#65) — gating on branch (decision) coverage."
+              cargo llvm-cov -p "$crate" --branch --json --summary-only > "cov-$crate.json"
+            fi
+            python3 ci/check_decision_floor.py "cov-$crate.json" "$floor" "$crate"
+          }
+          gate kirra-trajectory 78.0
+          gate kirra-core 79.0
+      - name: Gate parko-core (parko workspace)
+        working-directory: parko
+        run: |
+          set -euo pipefail
+          if cargo llvm-cov -p parko-core --mcdc --json --summary-only > cov-parko-core.json 2> mcdc.err; then
+            echo "[parko-core] MC/DC accepted by toolchain — gating on MC/DC."
+          else
+            echo "[parko-core] --mcdc rejected by the toolchain (#65) — gating on branch (decision) coverage."
+            cargo llvm-cov -p parko-core --branch --json --summary-only > cov-parko-core.json
+          fi
+          python3 ../ci/check_decision_floor.py cov-parko-core.json 77.0 parko-core
+
   coverage:
-    name: Branch Coverage (MC/DC pending — issue #65)
+    name: Branch Coverage (workspace)
     runs-on: ubuntu-latest
     # Bumped 30→45: when --mcdc is unsupported the instrumented workspace test
     # suite runs TWICE (mcdc attempt, then branch fallback). Instrumented runs
@@ -332,12 +385,13 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
       - name: Run MC/DC coverage
-        # Prefer MC/DC (issue #65 / CERT-001) when the installed cargo-llvm-cov +
-        # nightly support it; fall back to branch coverage only when the toolchain
-        # rejects `--mcdc`. Historically nightly accepted only block|branch|
-        # condition for the coverage-options value and `--mcdc` would not compile,
-        # so branch was the closest substitute; this opportunistically uses MC/DC
-        # once the toolchain realigns, without breaking CI before then.
+        # DECISION (EP-07 / issue #65): true MC/DC is TOOLCHAIN-BLOCKED — current
+        # nightly rejects `-Zcoverage-options=mcdc` (only block|branch|condition
+        # are accepted), so no Rust toolchain can express it today. This job stays
+        # the WORKSPACE-WIDE branch gate (observability via Codecov); the GATED
+        # decision-coverage floors for the certification-relevant checker crates
+        # live in the dedicated `checker-coverage` job below, which attempts
+        # `--mcdc` first every run so it auto-upgrades the day rustc restores it.
         #
         # The `if` swallows a non-zero `--mcdc` exit (set -e is suppressed in an
         # if-condition) and falls back; a genuine deterministic failure also fails

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,41 @@ jobs:
         # libkirra_verifier cdylib and runs it — keeps the C ABI examples from rotting.
         run: ./examples/c/build_and_run.sh
 
+  safety-constants:
+    name: Safety-constants provenance gate (EP-09)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Every VALIDATION-PENDING safety constant (RSS terms, redundancy
+    # tolerances, CTRV bounds, VRU caps, …) is pinned in
+    # ci/safety_constants_manifest.json with its provenance and sign-off
+    # status. This job verifies the declared values still match the manifest —
+    # a silent retune of a safety constant reds CI until the manifest is
+    # re-signed alongside it. The RELEASE path runs the same script with
+    # KIRRA_RELEASE_GATE=1, which additionally FAILS while any entry is still
+    # `pending` — no placeholder can reach a release.
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: declared constants match the signed manifest
+        run: python3 ci/check_safety_constants.py
+      - name: release gate refuses pending constants (red-path self-test)
+        # Prove the release-blocking arm actually fires: with KIRRA_RELEASE_GATE=1
+        # the script must exit non-zero exactly when a `pending` entry exists.
+        # Once every constant is signed off this inverts automatically (release
+        # mode passes and this step asserts that instead).
+        run: |
+          set -euo pipefail
+          pending=$(python3 -c "import json; print(sum(1 for c in json.load(open('ci/safety_constants_manifest.json'))['constants'] if c['status'] == 'pending'))")
+          if [ "$pending" -gt 0 ]; then
+            if KIRRA_RELEASE_GATE=1 python3 ci/check_safety_constants.py; then
+              echo "release gate FAILED TO BLOCK with $pending pending constants" >&2
+              exit 1
+            fi
+            echo "release gate correctly blocks ($pending constants pending sign-off)"
+          else
+            KIRRA_RELEASE_GATE=1 python3 ci/check_safety_constants.py
+            echo "all constants signed off — release gate green"
+          fi
+
   checker-coverage:
     name: Checker decision coverage — gated floors (EP-07; true MC/DC toolchain-blocked, #65)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,40 @@ jobs:
         # never silently rot if the unification path changes.
         run: cargo test -p kirra-core --features capture --locked
 
+  miri:
+    name: Miri — seqlock UB/memory-model check (EP-16)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Miri interprets the program against Rust's memory model, catching UB and
+    # (with many seeds) weak-memory/data-race bugs the type system cannot. The
+    # lane covers the Clause-2 CONTRACT PROTOCOL — the seqlock trust chain in
+    # kirra-contract-channel, including the concurrent writer/reader torn-read
+    # test (iteration count auto-scaled under cfg(miri)).
+    #
+    # kirra-hv-carrier is EXCLUDED, deliberately: Miri cannot interpret the
+    # `shm_open`/`mmap` FFI its mapping needs ("can't call foreign function
+    # `shm_open`"). Its unsafe budget is bounded + enumerated (ADR-0030 Clause
+    # A), its AtomicView layout is compile-time-asserted against the frozen
+    # contract, and its atomic ORDERINGS reproduce InProcessRegion's exactly —
+    # which is what this lane Miri-checks. The mapping itself is exercised by
+    # the cross-process tests in the inline-governor job.
+    env:
+      RUSTUP_TOOLCHAIN: nightly
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@efcb852328a9f50117170cc43094fb6f09eaf1ae # nightly
+        with:
+          components: miri
+      - name: Contract-channel under Miri (lib + integration + doctests)
+        run: cargo miri test -p kirra-contract-channel --locked
+      - name: Seqlock writer/reader race under many seeds
+        # -Zmiri-many-seeds re-runs the nondeterministic schedule with 16
+        # different seeds, exploring distinct interleavings of the concurrent
+        # torn-read test — the closest Miri gets to a schedule sweep.
+        env:
+          MIRIFLAGS: "-Zmiri-many-seeds=0..16"
+        run: cargo miri test -p kirra-contract-channel --lib --locked concurrent
+
   inline-governor:
     name: In-line governor loop (EP-01) — fault matrix + cross-process demo
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,7 +419,7 @@ jobs:
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
-      - name: Run MC/DC coverage
+      - name: Workspace branch coverage (attempts MC/DC, falls back — #65)
         # DECISION (EP-07 / issue #65): true MC/DC is TOOLCHAIN-BLOCKED — current
         # nightly rejects `-Zcoverage-options=mcdc` (only block|branch|condition
         # are accepted), so no Rust toolchain can express it today. This job stays

--- a/ci/check_decision_floor.py
+++ b/ci/check_decision_floor.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""EP-07 — gate a checker crate's DECISION coverage on a floor.
+
+Reads a `cargo llvm-cov --json --summary-only` export and fails (exit 1) when
+the strongest decision metric the toolchain produced is below the floor:
+
+  - if the export carries an MC/DC summary (`totals.mcdc`), gate on it — this
+    is the auto-upgrade path for the day rustc restores `-Zcoverage-options=mcdc`
+    (see issue #65: current nightly accepts only block|branch|condition);
+  - otherwise gate on BRANCH coverage (`totals.branches`) — decision coverage,
+    the strongest gate the toolchain can express today.
+
+Usage: check_decision_floor.py <summary.json> <floor_percent> <label>
+"""
+
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(__doc__, file=sys.stderr)
+        return 2
+    path, floor_s, label = sys.argv[1], sys.argv[2], sys.argv[3]
+    floor = float(floor_s)
+
+    with open(path, encoding="utf-8") as f:
+        export = json.load(f)
+    totals = export["data"][0]["totals"]
+
+    if "mcdc" in totals and totals["mcdc"].get("count", 0) > 0:
+        metric, name = totals["mcdc"], "MC/DC"
+    elif "branches" in totals and totals["branches"].get("count", 0) > 0:
+        metric, name = totals["branches"], "branch"
+    else:
+        print(
+            f"FAIL [{label}]: the coverage export carries neither an MC/DC nor a "
+            "branch summary — the lane is not measuring decision coverage at all "
+            "(instrumentation flag regression?)",
+            file=sys.stderr,
+        )
+        return 1
+
+    pct = float(metric["percent"])
+    covered = metric.get("covered", "?")
+    count = metric.get("count", "?")
+    print(
+        f"[{label}] {name} coverage: {pct:.2f}% ({covered}/{count}) — floor {floor:.2f}%"
+    )
+    if pct < floor:
+        print(
+            f"FAIL [{label}]: {name} coverage {pct:.2f}% is below the gated floor "
+            f"{floor:.2f}%. Either cover the new decisions or (with reviewer sign-off) "
+            "adjust the floor in ci.yml.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/check_safety_constants.py
+++ b/ci/check_safety_constants.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""EP-09 — RSS / checker safety-constant provenance & sign-off gate.
+
+Verifies every constant declared in `ci/safety_constants_manifest.json`:
+
+  1. the `const NAME: ... = VALUE;` declaration still exists in the manifest's
+     file — a moved/renamed constant fails until the manifest is updated
+     (the provenance record must follow the code);
+  2. the declared value matches the manifest value — a silent retune of a
+     safety constant is impossible: any change reds CI until the manifest is
+     re-signed alongside it (a visible, reviewable diff);
+  3. a `validated` entry carries non-empty provenance and owner — a sign-off
+     without recorded evidence is not a sign-off;
+  4. under `KIRRA_RELEASE_GATE=1` (the release path), any `pending` entry
+     FAILS the build — no VALIDATION-PENDING placeholder can reach a release.
+
+Numeric values compare numerically (so `1_000` == `1000`); symbolic values
+(e.g. an inherited `STOP_EPSILON_MPS`) compare as exact identifiers.
+
+Usage: check_safety_constants.py [manifest.json]   (default: the file beside
+this script). Exit 0 = green, 1 = gate failure, 2 = usage/manifest error.
+"""
+
+import json
+import os
+import re
+import sys
+
+VALID_STATUSES = {"validated", "pending"}
+
+
+def parse_declared_value(repo_root: str, rel_path: str, name: str):
+    """Return the right-hand-side expression of `const NAME: T = <expr>;`."""
+    path = os.path.join(repo_root, rel_path)
+    try:
+        with open(path, encoding="utf-8") as f:
+            src = f.read()
+    except OSError as e:
+        return None, f"cannot read {rel_path}: {e}"
+    pattern = re.compile(
+        r"^\s*(?:pub(?:\([^)]*\))?\s+)?const\s+"
+        + re.escape(name)
+        + r"\s*:\s*[^=;]+=\s*(.+?)\s*;",
+        re.MULTILINE,
+    )
+    matches = pattern.findall(src)
+    if not matches:
+        return None, f"`const {name}` not found in {rel_path}"
+    if len(matches) > 1:
+        return None, f"`const {name}` declared {len(matches)} times in {rel_path}"
+    return matches[0], None
+
+
+def values_match(manifest_value: str, declared_value: str) -> bool:
+    m, d = manifest_value.strip(), declared_value.strip()
+    try:
+        return float(m.replace("_", "")) == float(d.replace("_", ""))
+    except ValueError:
+        return m == d
+
+
+def main() -> int:
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    manifest_path = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else os.path.join(script_dir, "safety_constants_manifest.json")
+    )
+    if len(sys.argv) > 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    repo_root = os.path.dirname(script_dir)
+
+    try:
+        with open(manifest_path, encoding="utf-8") as f:
+            manifest = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"FAIL: cannot load manifest {manifest_path}: {e}", file=sys.stderr)
+        return 2
+
+    entries = manifest.get("constants")
+    if not isinstance(entries, list) or not entries:
+        print("FAIL: manifest carries no `constants` entries", file=sys.stderr)
+        return 2
+
+    release_gate = os.environ.get("KIRRA_RELEASE_GATE", "") == "1"
+    errors: list[str] = []
+    pending: list[str] = []
+    seen: set[tuple[str, str]] = set()
+
+    for entry in entries:
+        name = entry.get("name", "<unnamed>")
+        rel_path = entry.get("file", "")
+        label = f"{rel_path}::{name}"
+
+        key = (rel_path, name)
+        if key in seen:
+            errors.append(f"{label}: duplicate manifest entry")
+            continue
+        seen.add(key)
+
+        status = entry.get("status", "")
+        if status not in VALID_STATUSES:
+            errors.append(
+                f"{label}: status {status!r} is not one of {sorted(VALID_STATUSES)}"
+            )
+            continue
+        if status == "validated" and not (
+            str(entry.get("provenance", "")).strip()
+            and str(entry.get("owner", "")).strip()
+        ):
+            errors.append(
+                f"{label}: `validated` without recorded provenance/owner — a "
+                "sign-off must carry its evidence reference and signer"
+            )
+            continue
+
+        declared, err = parse_declared_value(repo_root, rel_path, name)
+        if err:
+            errors.append(f"{label}: {err} (update the manifest alongside the code)")
+            continue
+        if not values_match(str(entry.get("value", "")), declared):
+            errors.append(
+                f"{label}: declared value `{declared}` != manifest value "
+                f"`{entry.get('value')}` — a safety constant changed without "
+                "re-recording its provenance; update BOTH together"
+            )
+            continue
+
+        if status == "pending":
+            pending.append(label)
+        print(f"OK   [{status:>9}] {label} = {declared}")
+
+    if pending:
+        print(f"\n{len(pending)}/{len(entries)} constants are VALIDATION-PENDING:")
+        for label in pending:
+            print(f"  pending  {label}")
+
+    if errors:
+        print("", file=sys.stderr)
+        for e in errors:
+            print(f"FAIL: {e}", file=sys.stderr)
+        return 1
+
+    if release_gate and pending:
+        print(
+            f"\nFAIL: KIRRA_RELEASE_GATE=1 and {len(pending)} safety constant(s) "
+            "are still `pending` — a release is blocked until a safety engineer "
+            "signs each off (status → `validated` with provenance) in "
+            "ci/safety_constants_manifest.json",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"\nsafety-constants gate green ({len(entries)} constants verified"
+        + (", RELEASE mode)" if release_gate else ")")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/safety_constants_manifest.json
+++ b/ci/safety_constants_manifest.json
@@ -1,0 +1,158 @@
+{
+  "version": 1,
+  "description": "EP-09 — RSS / checker safety-constant provenance & sign-off manifest. Every entry is a declared `const` on a safety-relevant checker path. `status` is `pending` until a safety engineer records a sign-off (set `status` to `validated` and fill `provenance` with the evidence reference). ci/check_safety_constants.py verifies each declared value still matches this manifest on every CI run, and FAILS a release build (KIRRA_RELEASE_GATE=1) while any entry is `pending` — no silent placeholder can reach a release.",
+  "constants": [
+    {
+      "name": "RSS_REACTION_TIME_S",
+      "file": "crates/kirra-trajectory/src/validation.rs",
+      "value": "0.5",
+      "status": "pending",
+      "provenance": "IEEE 2846-2022 §5.1 canonical response time for SAE-L4 stacks (conservative end); awaiting #408 safety-case sign-off",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "RSS_LAT_BRAKE_FRACTION",
+      "file": "crates/kirra-trajectory/src/validation.rs",
+      "value": "0.7",
+      "status": "pending",
+      "provenance": "WP-07 (#408 Option A) placeholder; fraction form keeps deratings tightening-or-equal (parko-core test_lat_split_conservative_vs_legacy); deployed value must be safety-case-derived",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "RSS_MU_LATERAL_M",
+      "file": "crates/kirra-trajectory/src/validation.rs",
+      "value": "0.2",
+      "status": "pending",
+      "provenance": "IEEE 2846-2022 §5.2 lateral-fluctuation margin mu; additive so strictly conservative; placeholder pending #408 sign-off",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "RSS_LATERAL_MOTION_EPS_MPS",
+      "file": "crates/kirra-trajectory/src/validation.rs",
+      "value": "0.1",
+      "status": "pending",
+      "provenance": "Cut-in stillness threshold for the RSS §4 conjunction (admits a stationary queue, catches any real lateral closing); value needs track-data confirmation",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "OCCLUSION_SPEED_TOL_MPS",
+      "file": "crates/kirra-trajectory/src/validation.rs",
+      "value": "0.1",
+      "status": "pending",
+      "provenance": "Float-noise slack on the RSS-Rule-4 assured-clear-distance speed bound; sub-decimetre by construction, needs recorded sign-off that the slack is envelope-negligible",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "DEFAULT_RSS_LATERAL_ALIGNMENT_TOLERANCE_M",
+      "file": "crates/kirra-trajectory/src/config.rs",
+      "value": "4.0",
+      "status": "pending",
+      "provenance": "Robotaxi lane-width-scale lateral-alignment band (per-class VehicleConfig field default; docs/CONTRACT_PROFILES.md); VALIDATION-PENDING like the other class numbers",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "DIVERGENCE_DEGRADE_MS",
+      "file": "crates/kirra-trajectory/src/perception_redundancy.rs",
+      "value": "1_000",
+      "status": "pending",
+      "provenance": "True-Redundancy divergence-to-Degraded debounce; balances phantom-flicker tolerance vs detection latency; needs FTTI-budget sign-off",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "DIVERGENCE_LOCKOUT_MS",
+      "file": "crates/kirra-trajectory/src/perception_redundancy.rs",
+      "value": "5_000",
+      "status": "pending",
+      "provenance": "Sustained-divergence-to-MRC escalation window; needs FTTI-budget sign-off",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "CTRV_YAW_EPS_RAD_S",
+      "file": "crates/kirra-trajectory/src/prediction.rs",
+      "value": "0.02",
+      "status": "pending",
+      "provenance": "Yaw-rate floor below which CTRV degrades to CV (numerical conditioning of the turn-radius division); needs tracker-noise-floor confirmation",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "CTRV_MAX_LATERAL_ACCEL_MPS2",
+      "file": "crates/kirra-trajectory/src/prediction.rs",
+      "value": "10.0",
+      "status": "pending",
+      "provenance": "Physical-plausibility cap on a predicted mode's implied lateral acceleration (~1g); needs recorded sign-off vs the object-class dynamics envelope",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "MAX_PREDICTION_STEPS",
+      "file": "crates/kirra-trajectory/src/prediction.rs",
+      "value": "512",
+      "status": "pending",
+      "provenance": "Boundedness cap on mode rollout length (WCET/memory argument, not a tuning value); sign-off = confirm it exceeds every horizon/step-size pairing in the ODD",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "LANE_FOLLOW_MIN_SPEED_MPS",
+      "file": "crates/kirra-trajectory/src/prediction.rs",
+      "value": "0.1",
+      "status": "pending",
+      "provenance": "Speed floor below which a lane-follow mode is not synthesized (heading unreliable at standstill); needs tracker-noise-floor confirmation",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "MAX_PEDESTRIANS",
+      "file": "crates/kirra-trajectory/src/vru.rs",
+      "value": "64",
+      "status": "pending",
+      "provenance": "Boundedness cap on the per-cycle VRU set (WCET argument); sign-off = confirm it exceeds the ODD's worst-case crossing crowd",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "V_PED_MAX_FLOOR_MPS",
+      "file": "crates/kirra-trajectory/src/vru.rs",
+      "value": "2.0",
+      "status": "pending",
+      "provenance": "Pedestrian worst-case-speed floor (brisk walk); deployment-tunable per ODD (vru.rs design note); needs ODD sign-off",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "VRU_STOP_EPSILON_CEILING_MPS",
+      "file": "crates/kirra-trajectory/src/vru.rs",
+      "value": "STOP_EPSILON_MPS",
+      "status": "pending",
+      "provenance": "Inherited by construction from the frozen gateway contract's STOP_EPSILON_MPS; sign-off = record the inheritance argument",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "RSS_FAILSAFE_DISTANCE_M",
+      "file": "parko/crates/parko-core/src/rss.rs",
+      "value": "1.0e6",
+      "status": "pending",
+      "provenance": "Fail-closed sentinel returned on invalid RSS inputs (NaN-division guard); sign-off = confirm it exceeds every finite safe-distance the ODD can produce",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "RSS_LONGITUDINAL_CONFLICT_M",
+      "file": "parko/crates/parko-core/src/rss.rs",
+      "value": "8.0",
+      "status": "pending",
+      "provenance": "FLOOR of the lateral-RSS longitudinal conflict window (#683/#684 — gates use max(floor, lon_required) so the window grows with closing speed); urban-minimum value needs ODD sign-off",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "RSS_LONGITUDINAL_OVERLAP_M",
+      "file": "parko/crates/parko-core/src/rss.rs",
+      "value": "2.5",
+      "status": "pending",
+      "provenance": "Passenger-vehicle footprint overlap (~two half-widths + fluctuation margin) gating longitudinal RSS; per-class values on VehicleConfig::rss_longitudinal_overlap_m (EP-08) derive from it; needs footprint-data sign-off",
+      "owner": "safety-engineering"
+    },
+    {
+      "name": "RSS_LATERAL_MOTION_EPS_MPS",
+      "file": "parko/crates/parko-core/src/rss.rs",
+      "value": "0.1",
+      "status": "pending",
+      "provenance": "Diverse-checker twin of the kirra-trajectory cut-in stillness threshold; must stay in lockstep with it; needs track-data confirmation",
+      "owner": "safety-engineering"
+    }
+  ]
+}

--- a/crates/kirra-contract-channel/src/seqlock.rs
+++ b/crates/kirra-contract-channel/src/seqlock.rs
@@ -215,7 +215,10 @@ mod tests {
         // would break the invariant; the seqlock must guarantee every coherent
         // snapshot the reader accepts is internally consistent.
         let region = Arc::new(InProcessRegion::new());
-        const N: u64 = 20_000;
+        // Miri interprets ~3 orders of magnitude slower; a reduced count still
+        // exercises the same acquire/release protocol (Miri's value is the
+        // memory-model checking, not the iteration volume).
+        const N: u64 = if cfg!(miri) { 200 } else { 20_000 };
 
         let w = Arc::clone(&region);
         let writer = thread::spawn(move || {

--- a/crates/kirra-ros2-adapter/tests/adaptor_state_default.rs
+++ b/crates/kirra-ros2-adapter/tests/adaptor_state_default.rs
@@ -1,0 +1,22 @@
+// crates/kirra-ros2-adapter/tests/adaptor_state_default.rs
+//
+// The one validation_tests.rs pin that could NOT move to `kirra-trajectory`
+// with the rest of the slow-loop battery (EP-07 gate follow-through — the
+// checker tests now live with the checker code): `AdaptorState` is
+// adapter-LOCAL (per the #131 Option-B split, `state.rs` stays here), so its
+// construction-default regression stays here too.
+
+use kirra_core::FleetPosture;
+use kirra_ros2_adapter::state::AdaptorState;
+
+#[test]
+fn nominal_behavior_matches_prior_default() {
+    // Regression: every prior test in the slow-loop battery passed Nominal
+    // explicitly. This test pins the rule that Nominal is the construction
+    // default for `AdaptorState::current_posture` — until M1b wires a
+    // live posture source, the slow-loop verdict is byte-for-byte the
+    // pre-M1 behaviour.
+    let state = AdaptorState::new();
+    assert_eq!(state.current_posture(), FleetPosture::Nominal,
+        "AdaptorState must default to Nominal so pre-M1 callers see no behaviour change");
+}

--- a/crates/kirra-ros2-adapter/tests/validation_tests.rs
+++ b/crates/kirra-ros2-adapter/tests/validation_tests.rs
@@ -1012,12 +1012,16 @@ fn predictive_rss_lateral_brake_parameter_is_load_bearing() {
     );
 }
 
-/// SNAPSHOT lateral brake parameter is load-bearing (validation.rs:518,
-/// `RSS_LAT_BRAKE_FRACTION * kinematics.max_lateral_accel_mps2`, `* → +`
-/// mutant). A moderate cut-in whose lateral gap is UNSAFE under the correct
-/// brake-min (2.45 m/s²) but would be admitted if `*` became `+` (brake-min
-/// 0.7+3.5 = 4.2 m/s² — a STRONGER brake shrinks the required separation).
-/// Correct MRCs, mutant admits. 45° ego heading (rotation exercised).
+/// SNAPSHOT lateral brake parameter is load-bearing
+/// (`RSS_LAT_BRAKE_FRACTION * kinematics.max_lateral_accel_mps2`, `* → +`
+/// mutant). The ego is HELD (stopped poses), so the EP-08 stopped-pose rule
+/// applies the STATIONARY-EGO lateral form — which still charges the object's
+/// braking envelope through this parameter, keeping it load-bearing on the
+/// stopped path too. A moderate cut-in whose lateral gap (2.3 m) is UNSAFE
+/// under the correct brake-min (2.45 m/s² → requires ≈2.68 m) but would be
+/// admitted if `*` became `+` (brake-min 0.7+3.5 = 4.2 m/s² → requires
+/// ≈2.04 m — a STRONGER brake shrinks the required separation). Correct MRCs,
+/// mutant admits. 45° ego heading (rotation exercised).
 #[test]
 fn snapshot_rss_lateral_brake_parameter_is_load_bearing() {
     use std::f64::consts::FRAC_PI_4;
@@ -1031,12 +1035,13 @@ fn snapshot_rss_lateral_brake_parameter_is_load_bearing() {
         .collect();
     let corridor = MockCorridorSource::straight_5m_half_width(200.0);
     let cfg = VehicleConfig::default_urban();
-    // Object at ego-frame (dx=3, dy=3.4), lateral-closing at 1 m/s (ego-frame
-    // velocity (0,-1) → world (s, -c)). obj_lat_vel = -1.0, cut-in fires;
-    // lat_required ≈ 3.74 m (correct) > 3.4 → MRC; ≈ 2.84 m (brake 4.2) < 3.4 → admit.
+    // Object at ego-frame (dx=3, dy=2.3), lateral-closing at 1 m/s (ego-frame
+    // velocity (0,-1) → world (s, -c)). obj_lat_vel = -1.0, cut-in fires; the
+    // stopped ego takes the STATIONARY-EGO form: lat_required ≈ 2.68 m
+    // (correct) > 2.3 → MRC; ≈ 2.04 m (brake 4.2 mutant) < 2.3 → admit.
     let obj = PerceivedObject {
         id: 1,
-        pos: Point { x_m: 10.0 + 3.0 * c - 3.4 * s, y_m: 3.0 * s + 3.4 * c },
+        pos: Point { x_m: 10.0 + 3.0 * c - 2.3 * s, y_m: 3.0 * s + 2.3 * c },
         velocity_mps: 1.0,
         heading_rad: 0.0,
         vel: Point { x_m: s, y_m: -c },

--- a/crates/kirra-trajectory/src/config.rs
+++ b/crates/kirra-trajectory/src/config.rs
@@ -70,6 +70,18 @@ pub struct VehicleConfig {
     /// (see `docs/CONTRACT_PROFILES.md`, the sibling rule).
     pub rss_lateral_alignment_tolerance_m: f64,
 
+    /// **RSS longitudinal-overlap half-window** (m): the lateral offset below which
+    /// the two FOOTPRINTS overlap (one is in the other's path) and the longitudinal
+    /// rear-end/head-on bound is a real conflict. EP-08 makes this **per-class**
+    /// (it was the global `RSS_LONGITUDINAL_OVERLAP_M` = 2.5 m — a car-width-scale
+    /// number a 0.6 m courier has no business using). Values preserve today's
+    /// EFFECTIVE geometry per class: the check nests inside the alignment band, so
+    /// each class gets `min(2.5, its band)` — robotaxi keeps the frozen 2.5 verbatim;
+    /// courier/delivery-AV, whose bands were narrower than 2.5, keep "the whole band
+    /// is overlap". Tuning BELOW the band is a future per-class footprint calibration
+    /// (VALIDATION-PENDING like the other class numbers).
+    pub rss_longitudinal_overlap_m: f64,
+
     /// **Differential-drive angular (yaw-rate) bound** (ADR-0029). `Some` only for a
     /// diff-drive class (`courier()`); the Ackermann profiles (`default_urban`,
     /// `delivery_av`) leave it **`None`**, so the per-pose path is **byte-identical**
@@ -181,12 +193,14 @@ impl VehicleConfig {
             max_steering_rad:   35.0_f64.to_radians(),
             odd_speed_cap_mps:  Some(URBAN_ODD_SPEED_CAP_MPS),
             rss_lateral_alignment_tolerance_m: DEFAULT_RSS_LATERAL_ALIGNMENT_TOLERANCE_M,
+            // The frozen robotaxi footprint-overlap half-window, verbatim.
+            rss_longitudinal_overlap_m: parko_core::rss::RSS_LONGITUDINAL_OVERLAP_M,
             // Ackermann (robotaxi) — NO angular channel; per-pose path byte-identical.
             angular: None,
         }
     }
 
-    /// **Courier / small-robot class** (a sibling of [`default_urban`], per
+    /// **Courier / small-robot class** (a sibling of [`VehicleConfig::default_urban`], per
     /// `docs/CONTRACT_PROFILES.md`). Robot-scale footprint + kinematics + a tight RSS
     /// lateral band so the slow-loop checker judges a sidewalk/indoor robot, not a 4.8 m
     /// car. The checker LOGIC is identical to the robotaxi path — only these numbers differ,
@@ -208,6 +222,9 @@ impl VehicleConfig {
             max_steering_rad:   30.0_f64.to_radians(),
             odd_speed_cap_mps:  Some(2.5),
             rss_lateral_alignment_tolerance_m: 0.6,
+            // Overlap == the band (the courier band is narrower than the old global
+            // 2.5 m constant, so every in-band object was — and stays — overlap).
+            rss_longitudinal_overlap_m: 0.6,
             // Differential-drive courier — the diff-drive yaw bound (ADR-0029),
             // a cited copy of parko's AngularVelocityBound (#136).
             angular: Some(CourierAngularBound::courier_reference()),
@@ -231,6 +248,8 @@ impl VehicleConfig {
             max_steering_rad:   33.0_f64.to_radians(),
             odd_speed_cap_mps:  Some(11.0),
             rss_lateral_alignment_tolerance_m: 2.0,
+            // Overlap == the band (narrower than the old global 2.5 m constant).
+            rss_longitudinal_overlap_m: 2.0,
             // Delivery-AV is Ackermann (road pod) — NO angular channel.
             angular: None,
         }

--- a/crates/kirra-trajectory/src/frenet.rs
+++ b/crates/kirra-trajectory/src/frenet.rs
@@ -342,6 +342,121 @@ mod tests {
     }
 
     #[test]
+    fn every_non_finite_operand_position_yields_none() {
+        // `cumulative_arc` guards all four coordinates of each window; a NaN
+        // or Inf in ANY position must degrade to the tangent frame, so each
+        // operand's failing side is pinned individually (not just one).
+        let good = vec![Point { x_m: 0.0, y_m: -5.0 }, Point { x_m: 10.0, y_m: -5.0 }];
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            for (bx, by, gx, gy) in [
+                (bad, 5.0, 10.0, 5.0), // w[0].x
+                (0.0, bad, 10.0, 5.0), // w[0].y
+                (0.0, 5.0, bad, 5.0),  // w[1].x
+                (0.0, 5.0, 10.0, bad), // w[1].y
+            ] {
+                let poly = vec![Point { x_m: bx, y_m: by }, Point { x_m: gx, y_m: gy }];
+                assert!(
+                    CenterlineFrenet::from_boundaries(&poly, &good).is_none(),
+                    "non-finite left boundary ({bx},{by})→({gx},{gy}) must yield None"
+                );
+                assert!(
+                    CenterlineFrenet::from_boundaries(&good, &poly).is_none(),
+                    "non-finite right boundary ({bx},{by})→({gx},{gy}) must yield None"
+                );
+            }
+        }
+        // The short-boundary guard, each side individually.
+        let one = vec![Point { x_m: 0.0, y_m: 0.0 }];
+        assert!(CenterlineFrenet::from_boundaries(&one, &good).is_none());
+        assert!(CenterlineFrenet::from_boundaries(&good, &one).is_none());
+    }
+
+    #[test]
+    fn duplicate_vertices_are_skipped_not_divided_by() {
+        // A polyline may legally carry consecutive duplicate vertices (its
+        // total length stays positive, so `cumulative_arc` admits it); the
+        // resampler must step over the zero-length segments, never divide by
+        // them. Interior run of duplicates: the binary search lands inside it
+        // and the skip loop walks out.
+        let poly = vec![
+            Point { x_m: 0.0, y_m: 0.0 },
+            Point { x_m: 4.0, y_m: 0.0 },
+            Point { x_m: 4.0, y_m: 0.0 },
+            Point { x_m: 4.0, y_m: 0.0 },
+            Point { x_m: 16.0, y_m: 0.0 },
+        ];
+        let cum = cumulative_arc(&poly).unwrap();
+        assert_eq!(cum, vec![0.0, 4.0, 4.0, 4.0, 16.0]);
+        // frac 0.25 → target arc 4.0, exactly on the duplicate run.
+        let p = sample_at_fraction(&poly, &cum, 0.25);
+        assert!(p.x_m.is_finite() && p.y_m.is_finite());
+        assert!((p.x_m - 4.0).abs() < 1e-9 && p.y_m.abs() < 1e-9);
+        // Trailing duplicate: the skip loop cannot advance past the end, so
+        // the zero-length tail resolves to its start vertex (t = 0), finite.
+        let tail = vec![
+            Point { x_m: 0.0, y_m: 0.0 },
+            Point { x_m: 4.0, y_m: 0.0 },
+            Point { x_m: 4.0, y_m: 0.0 },
+        ];
+        let cum_t = cumulative_arc(&tail).unwrap();
+        let p = sample_at_fraction(&tail, &cum_t, 1.0);
+        assert!((p.x_m - 4.0).abs() < 1e-9 && p.y_m.abs() < 1e-9);
+        // End-to-end: boundaries carrying duplicates still build a frame whose
+        // projection matches the clean-geometry answer.
+        let dup_left: Vec<Point> = poly.iter().map(|p| Point { x_m: p.x_m, y_m: 3.0 }).collect();
+        let clean_right =
+            vec![Point { x_m: 0.0, y_m: -3.0 }, Point { x_m: 16.0, y_m: -3.0 }];
+        let f = CenterlineFrenet::from_boundaries(&dup_left, &clean_right).unwrap();
+        let c = f.project(Point { x_m: 8.0, y_m: 1.0 }).unwrap();
+        assert!((c.s - 8.0).abs() < 1e-9 && (c.d - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn pinched_corridor_whose_midpoints_all_coincide_yields_none() {
+        // Left traced +x, right traced the OPPOSITE way: every matched-fraction
+        // midpoint lands on the same point, the duplicate collapse reduces the
+        // centerline to one vertex, and the constructor refuses (tangent-frame
+        // fallback) rather than emit a degenerate reference line.
+        let left = vec![Point { x_m: 0.0, y_m: 1.0 }, Point { x_m: 10.0, y_m: 1.0 }];
+        let right = vec![Point { x_m: 10.0, y_m: -1.0 }, Point { x_m: 0.0, y_m: -1.0 }];
+        assert!(CenterlineFrenet::from_boundaries(&left, &right).is_none());
+    }
+
+    #[test]
+    fn zero_length_interior_segment_is_stepped_over_defensively() {
+        // `from_boundaries` collapses duplicates, so a zero-length centerline
+        // segment cannot arise through the constructor — but the traversals
+        // (`total_heading_change_rad`, `project`) still guard it. Pin the
+        // defensive arms directly.
+        let f = CenterlineFrenet {
+            pts: vec![
+                Point { x_m: 0.0, y_m: 0.0 },
+                Point { x_m: 5.0, y_m: 0.0 },
+                Point { x_m: 5.0, y_m: 0.0 },
+                Point { x_m: 10.0, y_m: 0.0 },
+            ],
+            cum_s: vec![0.0, 5.0, 5.0, 10.0],
+        };
+        // The zero segment contributes no heading change: still straight.
+        assert!(f.total_heading_change_rad().abs() < 1e-12);
+        assert!(f.is_effectively_straight());
+        // Projection ignores the zero segment and answers from the real ones.
+        let c = f.project(Point { x_m: 7.0, y_m: 1.5 }).unwrap();
+        assert!((c.s - 7.0).abs() < 1e-9 && (c.d - 1.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn projection_keeps_the_nearest_segment_not_the_last() {
+        // A point beside the FIRST segment of a long bent line: later segments
+        // are all farther, so the best-candidate branch must decline them (the
+        // "not better" side), and the answer stays on segment 0.
+        let (l, r) = arc_boundaries(30.0, 2.0, std::f64::consts::FRAC_PI_2, 40);
+        let f = CenterlineFrenet::from_boundaries(&l, &r).unwrap();
+        let c = f.project(Point { x_m: 0.5, y_m: 0.2 }).unwrap();
+        assert!(c.s < 2.0, "nearest the arc start, s = {}", c.s);
+    }
+
+    #[test]
     fn mismatched_vertex_counts_still_center_the_lane() {
         // Left has 2 vertices, right has 7 (same geometry) — matched-fraction
         // resampling must not skew the centerline.

--- a/crates/kirra-trajectory/src/frenet.rs
+++ b/crates/kirra-trajectory/src/frenet.rs
@@ -81,9 +81,10 @@ fn sample_at_fraction(poly: &[Point], cum: &[f64], frac: f64) -> Point {
     let target = frac * cum[cum.len() - 1];
     // Find the segment containing `target` (cum is non-decreasing).
     let i = match cum.binary_search_by(|c| c.partial_cmp(&target).unwrap()) {
-        Ok(idx) => idx.min(poly.len() - 2),
-        Err(idx) => idx.saturating_sub(1).min(poly.len() - 2),
-    };
+        Ok(idx) => idx,
+        Err(idx) => idx.saturating_sub(1),
+    }
+    .min(poly.len() - 2);
     // A zero-length segment (coincident vertices) is handled by the `seg > 0.0`
     // guard below — `t = 0.0` returns `poly[i]`, which equals `poly[i + 1]` for
     // such a segment, so no separate skip loop is needed (and none can divide by
@@ -172,19 +173,25 @@ impl CenterlineFrenet {
         let mut total = 0.0;
         let mut prev: Option<(f64, f64)> = None;
         for w in self.pts.windows(2) {
-            let (dx, dy) = (w[1].x_m - w[0].x_m, w[1].y_m - w[0].y_m);
-            let len = (dx * dx + dy * dy).sqrt();
-            if len <= 0.0 {
+            let v = (w[1].x_m - w[0].x_m, w[1].y_m - w[0].y_m);
+            // A zero-length segment carries no direction — skip it WITHOUT
+            // resetting `prev`, so the turn across it is still measured between
+            // the two real neighbours. (Construction collapses duplicates, so
+            // this only guards a hand-built frame.)
+            if v == (0.0, 0.0) {
                 continue;
             }
-            let t = (dx / len, dy / len);
             if let Some(p) = prev {
-                // Angle between consecutive unit tangents.
-                let cross = p.0 * t.1 - p.1 * t.0;
-                let dot = (p.0 * t.0 + p.1 * t.1).clamp(-1.0, 1.0);
+                // Turn angle between consecutive segment vectors. `atan2(cross,
+                // dot)` is invariant to each vector's magnitude (both scale by
+                // |p|·|v|, which cancels), so the RAW segment vectors give the
+                // exact angle — no per-segment normalization is needed (it was
+                // dead computation the angle never depended on).
+                let cross = p.0 * v.1 - p.1 * v.0;
+                let dot = p.0 * v.0 + p.1 * v.1;
                 total += cross.atan2(dot).abs();
             }
-            prev = Some(t);
+            prev = Some(v);
         }
         total
     }
@@ -236,13 +243,11 @@ impl CenterlineFrenet {
     #[must_use]
     pub fn tangent_at(&self, s: f64) -> (f64, f64) {
         let s = s.clamp(0.0, self.total_length_m());
-        let i = match self
-            .cum_s
-            .binary_search_by(|c| c.partial_cmp(&s).unwrap())
-        {
-            Ok(idx) => idx.min(self.pts.len() - 2),
-            Err(idx) => idx.saturating_sub(1).min(self.pts.len() - 2),
-        };
+        let i = match self.cum_s.binary_search_by(|c| c.partial_cmp(&s).unwrap()) {
+            Ok(idx) => idx,
+            Err(idx) => idx.saturating_sub(1),
+        }
+        .min(self.pts.len() - 2);
         let (dx, dy) = (
             self.pts[i + 1].x_m - self.pts[i].x_m,
             self.pts[i + 1].y_m - self.pts[i].y_m,
@@ -590,4 +595,31 @@ mod tests {
         // seg0's end — the near-vs-far comparison must keep seg1.
         assert!(b.s > 10.0, "must have chosen seg1, s = {}", b.s);
     }
+
+    #[test]
+    fn segment_lookup_clamps_the_final_arc_length_into_the_last_segment() {
+        // A 5-point frame so `.min(len - 2)` is BOTH reachable and distinguishable
+        // from a mangled bound: at s = total the binary search returns the last
+        // index, which must clamp into the last SEGMENT (index len-2) — a `- → +`
+        // bound would index past the end (panic) and a `- → /` bound
+        // (len/2 = 2 ≠ len-2 = 3) would land on the wrong segment.
+        let f = CenterlineFrenet {
+            pts: vec![
+                Point { x_m: 0.0, y_m: 0.0 },
+                Point { x_m: 5.0, y_m: 0.0 },
+                Point { x_m: 10.0, y_m: 0.0 },
+                Point { x_m: 15.0, y_m: 0.0 },
+                Point { x_m: 20.0, y_m: 5.0 }, // last segment turns, so its tangent is distinct
+            ],
+            cum_s: vec![0.0, 5.0, 10.0, 15.0, 15.0 + 29.0_f64.sqrt()],
+        };
+        // tangent_at(total) → last segment (5,5)/√50.
+        let (tx, ty) = f.tangent_at(f.total_length_m());
+        assert!((tx - 5.0 / 50.0_f64.sqrt()).abs() < 1e-12 && (ty - 5.0 / 50.0_f64.sqrt()).abs() < 1e-12, "{tx},{ty}");
+        // sample_at_fraction(frac = 1.0) → the final vertex exactly.
+        let poly: Vec<Point> = f.pts.clone();
+        let end = sample_at_fraction(&poly, &f.cum_s, 1.0);
+        assert!((end.x_m - 20.0).abs() < 1e-12 && (end.y_m - 5.0).abs() < 1e-12, "{end:?}");
+    }
+
 }

--- a/crates/kirra-trajectory/src/frenet.rs
+++ b/crates/kirra-trajectory/src/frenet.rs
@@ -80,14 +80,14 @@ fn arc_fractions(n: usize) -> impl Iterator<Item = f64> {
 fn sample_at_fraction(poly: &[Point], cum: &[f64], frac: f64) -> Point {
     let target = frac * cum[cum.len() - 1];
     // Find the segment containing `target` (cum is non-decreasing).
-    let mut i = match cum.binary_search_by(|c| c.partial_cmp(&target).unwrap()) {
+    let i = match cum.binary_search_by(|c| c.partial_cmp(&target).unwrap()) {
         Ok(idx) => idx.min(poly.len() - 2),
         Err(idx) => idx.saturating_sub(1).min(poly.len() - 2),
     };
-    // Skip zero-length segments (guarded against div-by-zero below).
-    while i + 2 < poly.len() && (cum[i + 1] - cum[i]) <= 0.0 {
-        i += 1;
-    }
+    // A zero-length segment (coincident vertices) is handled by the `seg > 0.0`
+    // guard below — `t = 0.0` returns `poly[i]`, which equals `poly[i + 1]` for
+    // such a segment, so no separate skip loop is needed (and none can divide by
+    // zero).
     let seg = cum[i + 1] - cum[i];
     let t = if seg > 0.0 { ((target - cum[i]) / seg).clamp(0.0, 1.0) } else { 0.0 };
     Point {
@@ -519,29 +519,32 @@ mod tests {
     }
 
     // A hand-built frame with EXACT geometry (bypassing resampling error) so the
-    // projection / tangent / heading arithmetic can be pinned to 1e-12.
+    // projection / tangent / heading arithmetic can be pinned to 1e-12. The two
+    // legs have DIFFERENT lengths (√10 and √26) on purpose: a same-length corner
+    // lets a `dx*dx + dy*dy → dx*dx * dy*dy` length mutant keep the cross/dot
+    // RATIO (hence the angle) unchanged — unequal legs break that proportionality
+    // so the heading mutant is caught.
     fn corner_frame() -> CenterlineFrenet {
-        // Two unit-scaled 3-4-5 legs: seg0 dir (0.8,0.6) len 5, seg1 dir
-        // (0.6,0.8) len 5 — both tangents non-axis-aligned and distinct, so
-        // every operand of the cross/dot/normalize arithmetic is load-bearing.
+        // seg0 (0,0)→(1,3): dir (1,3)/√10; seg1 (1,3)→(6,4): dir (5,1)/√26.
         CenterlineFrenet {
             pts: vec![
                 Point { x_m: 0.0, y_m: 0.0 },
-                Point { x_m: 4.0, y_m: 3.0 },
-                Point { x_m: 7.0, y_m: 7.0 },
+                Point { x_m: 1.0, y_m: 3.0 },
+                Point { x_m: 6.0, y_m: 4.0 },
             ],
-            cum_s: vec![0.0, 5.0, 10.0],
+            cum_s: vec![0.0, 10.0_f64.sqrt(), 10.0_f64.sqrt() + 26.0_f64.sqrt()],
         }
     }
 
     #[test]
     fn tangent_at_pins_the_segment_direction() {
         let f = corner_frame();
-        // Inside seg0 → unit (0.8, 0.6); inside seg1 → unit (0.6, 0.8).
-        let (t0x, t0y) = f.tangent_at(2.5);
-        assert!((t0x - 0.8).abs() < 1e-12 && (t0y - 0.6).abs() < 1e-12, "{t0x},{t0y}");
-        let (t1x, t1y) = f.tangent_at(7.5);
-        assert!((t1x - 0.6).abs() < 1e-12 && (t1y - 0.8).abs() < 1e-12, "{t1x},{t1y}");
+        let (s10, s26) = (10.0_f64.sqrt(), 26.0_f64.sqrt());
+        // Inside seg0 → unit (1,3)/√10; inside seg1 → unit (5,1)/√26.
+        let (t0x, t0y) = f.tangent_at(s10 / 2.0);
+        assert!((t0x - 1.0 / s10).abs() < 1e-12 && (t0y - 3.0 / s10).abs() < 1e-12, "{t0x},{t0y}");
+        let (t1x, t1y) = f.tangent_at(s10 + s26 / 2.0);
+        assert!((t1x - 5.0 / s26).abs() < 1e-12 && (t1y - 1.0 / s26).abs() < 1e-12, "{t1x},{t1y}");
         // Neither is (1,0): kills the whole-function default-return mutant.
         assert!((t0x - 1.0).abs() > 0.1 || t0y.abs() > 0.1);
     }
@@ -549,9 +552,9 @@ mod tests {
     #[test]
     fn total_heading_change_pins_the_corner_angle() {
         let f = corner_frame();
-        // Angle between (0.8,0.6) and (0.6,0.8): cross = .8*.8-.6*.6 = 0.28,
-        // dot = .8*.6+.6*.8 = 0.96 → atan2(0.28, 0.96).
-        let expected = 0.28_f64.atan2(0.96);
+        // Angle between (1,3)/√10 and (5,1)/√26: cross = (1·1 − 3·5)/√260 =
+        // −14/√260, dot = (1·5 + 3·1)/√260 = 8/√260 → |atan2(−14, 8)|.
+        let expected = 14.0_f64.atan2(8.0);
         assert!(
             (f.total_heading_change_rad() - expected).abs() < 1e-12,
             "{} vs {expected}",

--- a/crates/kirra-trajectory/src/frenet.rs
+++ b/crates/kirra-trajectory/src/frenet.rs
@@ -213,7 +213,7 @@ impl CenterlineFrenet {
             let (cx, cy) = (ax + t * ex, ay + t * ey);
             let (dx, dy) = (p.x_m - cx, p.y_m - cy);
             let dist2 = dx * dx + dy * dy;
-            if best.map_or(true, |(b, _)| dist2 < b) {
+            if best.is_none_or(|(b, _)| dist2 < b) {
                 let len = len2.sqrt();
                 // Signed offset: positive on the LEFT of the travel direction
                 // (cross(tangent, delta) z-component).

--- a/crates/kirra-trajectory/src/frenet.rs
+++ b/crates/kirra-trajectory/src/frenet.rs
@@ -98,14 +98,19 @@ fn sample_at_fraction(poly: &[Point], cum: &[f64], frac: f64) -> Point {
 
 /// Cumulative arc length of a polyline; `None` when any coordinate is
 /// non-finite or the total length is not strictly positive.
+///
+/// The single trailing `s.is_finite()` guard is sufficient for BOTH failure
+/// modes: a non-finite input coordinate poisons the running sum (NaN/±∞
+/// propagate through the subtraction, `powi`, `sqrt` and `+`), and a finite
+/// input that overflows to `±∞` is caught the same way — so there is no need
+/// for a redundant per-window finiteness pre-check (it could reject nothing
+/// the trailing guard does not). `s > 0.0` additionally rejects a
+/// zero-length (all-coincident) polyline.
 fn cumulative_arc(poly: &[Point]) -> Option<Vec<f64>> {
     let mut cum = Vec::with_capacity(poly.len());
     let mut s = 0.0;
     cum.push(0.0);
     for w in poly.windows(2) {
-        if !(w[0].x_m.is_finite() && w[0].y_m.is_finite() && w[1].x_m.is_finite() && w[1].y_m.is_finite()) {
-            return None;
-        }
         s += ((w[1].x_m - w[0].x_m).powi(2) + (w[1].y_m - w[0].y_m).powi(2)).sqrt();
         cum.push(s);
     }
@@ -466,5 +471,120 @@ mod tests {
         let f = CenterlineFrenet::from_boundaries(&l, &r).unwrap();
         let c = f.project(Point { x_m: 30.0, y_m: 0.0 }).unwrap();
         assert!(c.d.abs() < 1e-9, "centerline must sit on y=0, d = {}", c.d);
+    }
+
+    #[test]
+    fn cumulative_arc_pins_the_running_length_and_rejects_degenerate() {
+        // Exact per-vertex arc length — a 3-4-5 triangle leg pair pins the
+        // hypotenuse arithmetic (the `-`, `powi`, `+`, `sqrt` chain).
+        let poly = vec![
+            Point { x_m: 0.0, y_m: 0.0 },
+            Point { x_m: 3.0, y_m: 4.0 }, // +5
+            Point { x_m: 3.0, y_m: 4.0 + 12.0 }, // +12
+        ];
+        assert_eq!(cumulative_arc(&poly).unwrap(), vec![0.0, 5.0, 17.0]);
+        // The single trailing guard rejects BOTH failure modes:
+        //   - a zero-length (all-coincident) polyline → s == 0, not > 0.
+        let p = Point { x_m: 2.0, y_m: 7.0 };
+        assert!(cumulative_arc(&[p, p]).is_none(), "s>0 must reject zero length");
+        assert!(cumulative_arc(&[p, p, p]).is_none());
+        //   - a non-finite coordinate → s non-finite (poisoned through the sum).
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(cumulative_arc(&[Point { x_m: bad, y_m: 0.0 }, p]).is_none());
+            assert!(cumulative_arc(&[p, Point { x_m: 0.0, y_m: bad }]).is_none());
+        }
+    }
+
+    #[test]
+    fn sample_at_fraction_pins_the_interpolation() {
+        // L-corner polyline: seg0 (0,0)→(10,0) len 10, seg1 (10,0)→(10,10) len 10.
+        let poly = vec![
+            Point { x_m: 0.0, y_m: 0.0 },
+            Point { x_m: 10.0, y_m: 0.0 },
+            Point { x_m: 10.0, y_m: 10.0 },
+        ];
+        let cum = vec![0.0, 10.0, 20.0];
+        // frac 0.25 → target 5 → seg0, t = 0.5 → (5, 0). Pins the `target-cum[i]`
+        // numerator, the `/seg` division and the two lerp expressions.
+        let a = sample_at_fraction(&poly, &cum, 0.25);
+        assert!((a.x_m - 5.0).abs() < 1e-12 && a.y_m.abs() < 1e-12, "{a:?}");
+        // frac 0.75 → target 15 → seg1, t = 0.5 → (10, 5).
+        let b = sample_at_fraction(&poly, &cum, 0.75);
+        assert!((b.x_m - 10.0).abs() < 1e-12 && (b.y_m - 5.0).abs() < 1e-12, "{b:?}");
+        // Endpoints resolve exactly (frac 0 → start, frac 1 → end).
+        let s0 = sample_at_fraction(&poly, &cum, 0.0);
+        assert!(s0.x_m.abs() < 1e-12 && s0.y_m.abs() < 1e-12);
+        let s1 = sample_at_fraction(&poly, &cum, 1.0);
+        assert!((s1.x_m - 10.0).abs() < 1e-12 && (s1.y_m - 10.0).abs() < 1e-12);
+    }
+
+    // A hand-built frame with EXACT geometry (bypassing resampling error) so the
+    // projection / tangent / heading arithmetic can be pinned to 1e-12.
+    fn corner_frame() -> CenterlineFrenet {
+        // Two unit-scaled 3-4-5 legs: seg0 dir (0.8,0.6) len 5, seg1 dir
+        // (0.6,0.8) len 5 — both tangents non-axis-aligned and distinct, so
+        // every operand of the cross/dot/normalize arithmetic is load-bearing.
+        CenterlineFrenet {
+            pts: vec![
+                Point { x_m: 0.0, y_m: 0.0 },
+                Point { x_m: 4.0, y_m: 3.0 },
+                Point { x_m: 7.0, y_m: 7.0 },
+            ],
+            cum_s: vec![0.0, 5.0, 10.0],
+        }
+    }
+
+    #[test]
+    fn tangent_at_pins_the_segment_direction() {
+        let f = corner_frame();
+        // Inside seg0 → unit (0.8, 0.6); inside seg1 → unit (0.6, 0.8).
+        let (t0x, t0y) = f.tangent_at(2.5);
+        assert!((t0x - 0.8).abs() < 1e-12 && (t0y - 0.6).abs() < 1e-12, "{t0x},{t0y}");
+        let (t1x, t1y) = f.tangent_at(7.5);
+        assert!((t1x - 0.6).abs() < 1e-12 && (t1y - 0.8).abs() < 1e-12, "{t1x},{t1y}");
+        // Neither is (1,0): kills the whole-function default-return mutant.
+        assert!((t0x - 1.0).abs() > 0.1 || t0y.abs() > 0.1);
+    }
+
+    #[test]
+    fn total_heading_change_pins_the_corner_angle() {
+        let f = corner_frame();
+        // Angle between (0.8,0.6) and (0.6,0.8): cross = .8*.8-.6*.6 = 0.28,
+        // dot = .8*.6+.6*.8 = 0.96 → atan2(0.28, 0.96).
+        let expected = 0.28_f64.atan2(0.96);
+        assert!(
+            (f.total_heading_change_rad() - expected).abs() < 1e-12,
+            "{} vs {expected}",
+            f.total_heading_change_rad()
+        );
+        // A single straight segment turns through nothing.
+        let straight = CenterlineFrenet {
+            pts: vec![Point { x_m: 0.0, y_m: 0.0 }, Point { x_m: 3.0, y_m: 4.0 }],
+            cum_s: vec![0.0, 5.0],
+        };
+        assert!(straight.total_heading_change_rad().abs() < 1e-12);
+    }
+
+    #[test]
+    fn project_pins_signed_offset_on_both_sides() {
+        // L-corner: seg0 (0,0)→(10,0), seg1 (10,0)→(10,10).
+        let f = CenterlineFrenet {
+            pts: vec![
+                Point { x_m: 0.0, y_m: 0.0 },
+                Point { x_m: 10.0, y_m: 0.0 },
+                Point { x_m: 10.0, y_m: 10.0 },
+            ],
+            cum_s: vec![0.0, 10.0, 20.0],
+        };
+        // Beside seg0, LEFT of +X travel (y>0) → d = +2, s = 5.
+        let a = f.project(Point { x_m: 5.0, y_m: 2.0 }).unwrap();
+        assert!((a.s - 5.0).abs() < 1e-12 && (a.d - 2.0).abs() < 1e-12, "{a:?}");
+        // Beside seg1 (travel +Y), a point at x=12 is to the RIGHT → d = -2,
+        // s = 10 + 5. The ex=0 branch makes the `ey*dx` sign load-bearing.
+        let b = f.project(Point { x_m: 12.0, y_m: 5.0 }).unwrap();
+        assert!((b.s - 15.0).abs() < 1e-12 && (b.d + 2.0).abs() < 1e-12, "{b:?}");
+        // Nearest-segment retention: (12,5) is 2 m from seg1 but ~5.4 m from
+        // seg0's end — the near-vs-far comparison must keep seg1.
+        assert!(b.s > 10.0, "must have chosen seg1, s = {}", b.s);
     }
 }

--- a/crates/kirra-trajectory/src/frenet.rs
+++ b/crates/kirra-trajectory/src/frenet.rs
@@ -132,9 +132,12 @@ impl CenterlineFrenet {
     /// relaxation; it is exactly today's behaviour.
     #[must_use]
     pub fn from_boundaries(left: &[Point], right: &[Point]) -> Option<Self> {
-        if left.len() < 2 || right.len() < 2 {
-            return None;
-        }
+        // `cumulative_arc` is the fail-closed backstop for a too-short boundary:
+        // a polyline with fewer than two vertices produces no segment, so its
+        // total length is 0 and it returns `None` here — no separate `len < 2`
+        // pre-check is needed (it could reject nothing the arc-length guard does
+        // not), and `sample_at_fraction` below is only reached once both
+        // boundaries are known to have ≥ 2 vertices.
         let cum_l = cumulative_arc(left)?;
         let cum_r = cumulative_arc(right)?;
 
@@ -153,9 +156,9 @@ impl CenterlineFrenet {
             }
             pts.push(mid);
         }
-        if pts.len() < 2 {
-            return None;
-        }
+        // Again `cumulative_arc` is the backstop: a centerline that collapsed to
+        // a single point (a fully pinched corridor) has zero total length and
+        // returns `None` — so no separate `pts.len() < 2` pre-check is needed.
         let cum_s = cumulative_arc(&pts)?;
         Some(Self { pts, cum_s })
     }

--- a/crates/kirra-trajectory/src/frenet.rs
+++ b/crates/kirra-trajectory/src/frenet.rs
@@ -1,0 +1,355 @@
+//! EP-08 (ex-WP-11, G-12 geometry half) — the corridor-centerline **Frenet
+//! frame** for curved-lane RSS.
+//!
+//! ## The unsound simplification this removes
+//!
+//! The snapshot RSS (validation.rs §C) measures each object in the TANGENT
+//! frame of the nearest trajectory pose: `dx_ego` (longitudinal) / `dy_ego`
+//! (lateral) are chord projections along the pose heading. On a straight lane
+//! that is exact. On a CURVED lane it is wrong in the dangerous direction: an
+//! in-lane object ahead *around the bend* acquires a large tangent-frame
+//! lateral offset, escapes the lateral-alignment filter, and is never
+//! longitudinally evaluated — fail-OPEN. (Symmetrically, an object dead ahead
+//! in the tangent direction but OUTSIDE the curving lane was spuriously
+//! rejected — the over-rejection half.)
+//!
+//! ## The Frenet correction
+//!
+//! [`CenterlineFrenet`] derives the corridor **centerline** (matched-fraction
+//! resampling of the left/right boundary polylines, midpointed) and projects
+//! world points onto it: `s` = arc length along the lane, `d` = signed lateral
+//! offset (left of travel positive). "Longitudinal" and "lateral" then follow
+//! the ROAD, not the chord:
+//!
+//! - object–ego longitudinal gap = `s_obj − s_ego` (arc distance),
+//! - lateral offset = `d_obj − d_ego`,
+//! - object velocity resolves against the centerline tangent AT THE OBJECT.
+//!
+//! ## Fail-safe composition (the additive rule)
+//!
+//! The WCET-critical per-pose path and the straight-lane RSS are UNCHANGED:
+//! - a corridor whose centerline is *effectively straight*
+//!   ([`CenterlineFrenet::is_effectively_straight`]) never engages the curved
+//!   path — the existing tangent-frame code runs bit-for-bit;
+//! - a degenerate corridor (too few vertices, non-finite, zero length) or a
+//!   point that fails to project falls back to the tangent frame **for that
+//!   pair** — i.e. exactly today's behaviour, never a skip.
+//!
+//! On a straight corridor the two frames agree (`s = x`, `d = y` for a +X
+//! lane) — pinned by the equivalence property tests in `validation.rs`.
+
+use crate::corridor::Point;
+
+/// Heading change (radians) across the whole centerline below which the
+/// corridor is treated as straight and the curved path never engages —
+/// keeping the straight-lane RSS bit-for-bit. ~0.6° total: an order of
+/// magnitude below any real curve, comfortably above polyline resampling
+/// noise on a genuinely straight lane.
+pub const STRAIGHT_EPS_RAD: f64 = 0.01;
+
+/// Number of matched-fraction samples used to derive the centerline when the
+/// boundaries carry fewer vertices. Curvature between samples is invisible,
+/// so this floor bounds the discretization error on smooth lane geometry.
+const MIN_CENTERLINE_SAMPLES: usize = 16;
+
+/// A point in the lane's Frenet frame: `s` metres of arc length along the
+/// centerline from its start, `d` metres of signed lateral offset (positive =
+/// LEFT of the direction of travel).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FrenetCoord {
+    pub s: f64,
+    pub d: f64,
+}
+
+/// The corridor centerline as a Frenet reference line: resampled vertices +
+/// cumulative arc length. Built once per slow-loop validation call.
+#[derive(Debug, Clone)]
+pub struct CenterlineFrenet {
+    /// Centerline vertices (≥ 2, all finite, consecutive points distinct).
+    pts: Vec<Point>,
+    /// Cumulative arc length at each vertex; `cum_s[0] == 0`.
+    cum_s: Vec<f64>,
+}
+
+/// Arc-length positions (fractions of total) for `n` resample points.
+fn arc_fractions(n: usize) -> impl Iterator<Item = f64> {
+    (0..n).map(move |i| i as f64 / (n - 1) as f64)
+}
+
+/// Sample a polyline at `frac` (∈ [0,1]) of its own total arc length.
+fn sample_at_fraction(poly: &[Point], cum: &[f64], frac: f64) -> Point {
+    let target = frac * cum[cum.len() - 1];
+    // Find the segment containing `target` (cum is non-decreasing).
+    let mut i = match cum.binary_search_by(|c| c.partial_cmp(&target).unwrap()) {
+        Ok(idx) => idx.min(poly.len() - 2),
+        Err(idx) => idx.saturating_sub(1).min(poly.len() - 2),
+    };
+    // Skip zero-length segments (guarded against div-by-zero below).
+    while i + 2 < poly.len() && (cum[i + 1] - cum[i]) <= 0.0 {
+        i += 1;
+    }
+    let seg = cum[i + 1] - cum[i];
+    let t = if seg > 0.0 { ((target - cum[i]) / seg).clamp(0.0, 1.0) } else { 0.0 };
+    Point {
+        x_m: poly[i].x_m + t * (poly[i + 1].x_m - poly[i].x_m),
+        y_m: poly[i].y_m + t * (poly[i + 1].y_m - poly[i].y_m),
+    }
+}
+
+/// Cumulative arc length of a polyline; `None` when any coordinate is
+/// non-finite or the total length is not strictly positive.
+fn cumulative_arc(poly: &[Point]) -> Option<Vec<f64>> {
+    let mut cum = Vec::with_capacity(poly.len());
+    let mut s = 0.0;
+    cum.push(0.0);
+    for w in poly.windows(2) {
+        if !(w[0].x_m.is_finite() && w[0].y_m.is_finite() && w[1].x_m.is_finite() && w[1].y_m.is_finite()) {
+            return None;
+        }
+        s += ((w[1].x_m - w[0].x_m).powi(2) + (w[1].y_m - w[0].y_m).powi(2)).sqrt();
+        cum.push(s);
+    }
+    if !(s.is_finite() && s > 0.0) {
+        return None;
+    }
+    Some(cum)
+}
+
+impl CenterlineFrenet {
+    /// Derive the centerline from the corridor boundaries: both polylines are
+    /// resampled at the same arc-length FRACTIONS (so a vertex-count mismatch
+    /// or uneven spacing cannot skew the midpoints), then midpointed.
+    ///
+    /// Returns `None` — the caller keeps the tangent-frame path — when either
+    /// boundary is degenerate (< 2 vertices, non-finite, zero total length) or
+    /// the derived centerline itself degenerates. Fail-safe: `None` is never a
+    /// relaxation; it is exactly today's behaviour.
+    #[must_use]
+    pub fn from_boundaries(left: &[Point], right: &[Point]) -> Option<Self> {
+        if left.len() < 2 || right.len() < 2 {
+            return None;
+        }
+        let cum_l = cumulative_arc(left)?;
+        let cum_r = cumulative_arc(right)?;
+
+        let n = left.len().max(right.len()).max(MIN_CENTERLINE_SAMPLES);
+        let mut pts: Vec<Point> = Vec::with_capacity(n);
+        for frac in arc_fractions(n) {
+            let l = sample_at_fraction(left, &cum_l, frac);
+            let r = sample_at_fraction(right, &cum_r, frac);
+            let mid = Point { x_m: (l.x_m + r.x_m) / 2.0, y_m: (l.y_m + r.y_m) / 2.0 };
+            // Collapse consecutive duplicates (a pinched corridor) so segment
+            // tangents below are always well-defined.
+            if let Some(prev) = pts.last() {
+                if (mid.x_m - prev.x_m).abs() < 1e-9 && (mid.y_m - prev.y_m).abs() < 1e-9 {
+                    continue;
+                }
+            }
+            pts.push(mid);
+        }
+        if pts.len() < 2 {
+            return None;
+        }
+        let cum_s = cumulative_arc(&pts)?;
+        Some(Self { pts, cum_s })
+    }
+
+    /// Total centerline arc length (m).
+    #[must_use]
+    pub fn total_length_m(&self) -> f64 {
+        self.cum_s[self.cum_s.len() - 1]
+    }
+
+    /// The largest absolute heading change between consecutive centerline
+    /// segments, summed over the line — 0 for a straight lane.
+    #[must_use]
+    pub fn total_heading_change_rad(&self) -> f64 {
+        let mut total = 0.0;
+        let mut prev: Option<(f64, f64)> = None;
+        for w in self.pts.windows(2) {
+            let (dx, dy) = (w[1].x_m - w[0].x_m, w[1].y_m - w[0].y_m);
+            let len = (dx * dx + dy * dy).sqrt();
+            if len <= 0.0 {
+                continue;
+            }
+            let t = (dx / len, dy / len);
+            if let Some(p) = prev {
+                // Angle between consecutive unit tangents.
+                let cross = p.0 * t.1 - p.1 * t.0;
+                let dot = (p.0 * t.0 + p.1 * t.1).clamp(-1.0, 1.0);
+                total += cross.atan2(dot).abs();
+            }
+            prev = Some(t);
+        }
+        total
+    }
+
+    /// Whether the corridor is straight for RSS purposes — the curved path
+    /// must NOT engage (`validation.rs` keeps the tangent frame bit-for-bit).
+    #[must_use]
+    pub fn is_effectively_straight(&self) -> bool {
+        self.total_heading_change_rad() <= STRAIGHT_EPS_RAD
+    }
+
+    /// Project a world point onto the centerline: the nearest point across all
+    /// segments (interior projections clamped to segment ends), returned as
+    /// `(s, d)`. `None` when the input is non-finite — the caller falls back
+    /// to the tangent frame (fail-safe), never skips the object.
+    #[must_use]
+    pub fn project(&self, p: Point) -> Option<FrenetCoord> {
+        if !(p.x_m.is_finite() && p.y_m.is_finite()) {
+            return None;
+        }
+        let mut best: Option<(f64, FrenetCoord)> = None;
+        for (i, w) in self.pts.windows(2).enumerate() {
+            let (ax, ay) = (w[0].x_m, w[0].y_m);
+            let (bx, by) = (w[1].x_m, w[1].y_m);
+            let (ex, ey) = (bx - ax, by - ay);
+            let len2 = ex * ex + ey * ey;
+            if len2 <= 0.0 {
+                continue;
+            }
+            let t = (((p.x_m - ax) * ex + (p.y_m - ay) * ey) / len2).clamp(0.0, 1.0);
+            let (cx, cy) = (ax + t * ex, ay + t * ey);
+            let (dx, dy) = (p.x_m - cx, p.y_m - cy);
+            let dist2 = dx * dx + dy * dy;
+            if best.map_or(true, |(b, _)| dist2 < b) {
+                let len = len2.sqrt();
+                // Signed offset: positive on the LEFT of the travel direction
+                // (cross(tangent, delta) z-component).
+                let d = (ex * dy - ey * dx) / len;
+                let s = self.cum_s[i] + t * len;
+                best = Some((dist2, FrenetCoord { s, d }));
+            }
+        }
+        best.map(|(_, c)| c)
+    }
+
+    /// Unit tangent of the centerline segment containing arc length `s`
+    /// (clamped to the line's span). Well-defined: construction collapses
+    /// zero-length segments.
+    #[must_use]
+    pub fn tangent_at(&self, s: f64) -> (f64, f64) {
+        let s = s.clamp(0.0, self.total_length_m());
+        let i = match self
+            .cum_s
+            .binary_search_by(|c| c.partial_cmp(&s).unwrap())
+        {
+            Ok(idx) => idx.min(self.pts.len() - 2),
+            Err(idx) => idx.saturating_sub(1).min(self.pts.len() - 2),
+        };
+        let (dx, dy) = (
+            self.pts[i + 1].x_m - self.pts[i].x_m,
+            self.pts[i + 1].y_m - self.pts[i].y_m,
+        );
+        let len = (dx * dx + dy * dy).sqrt();
+        (dx / len, dy / len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn straight_boundaries(len: f64, half_w: f64) -> (Vec<Point>, Vec<Point>) {
+        (
+            vec![Point { x_m: 0.0, y_m: half_w }, Point { x_m: len, y_m: half_w }],
+            vec![Point { x_m: 0.0, y_m: -half_w }, Point { x_m: len, y_m: -half_w }],
+        )
+    }
+
+    /// Arc boundaries: a circular lane of centerline radius `r`, sweeping
+    /// `sweep` radians counter-clockwise from the +X axis start (0, 0) with
+    /// the circle center at (0, r). Left boundary radius r - hw, right r + hw.
+    fn arc_boundaries(r: f64, half_w: f64, sweep: f64, n: usize) -> (Vec<Point>, Vec<Point>) {
+        let ring = |radius: f64| -> Vec<Point> {
+            (0..n)
+                .map(|i| {
+                    let a = sweep * (i as f64) / ((n - 1) as f64);
+                    // Circle center (0, r): start angle -pi/2.
+                    Point {
+                        x_m: radius * a.sin(),
+                        y_m: r - radius * a.cos(),
+                    }
+                })
+                .collect()
+        };
+        (ring(r - half_w), ring(r + half_w))
+    }
+
+    #[test]
+    fn straight_lane_frenet_is_the_identity_frame() {
+        let (l, r) = straight_boundaries(100.0, 5.0);
+        let f = CenterlineFrenet::from_boundaries(&l, &r).unwrap();
+        assert!(f.is_effectively_straight());
+        // s = x, d = y (lane along +X, centered on y = 0).
+        for (x, y) in [(0.0, 0.0), (10.0, 1.5), (50.0, -2.0), (99.0, 4.9)] {
+            let c = f.project(Point { x_m: x, y_m: y }).unwrap();
+            assert!((c.s - x).abs() < 1e-9, "s({x},{y}) = {}", c.s);
+            assert!((c.d - y).abs() < 1e-9, "d({x},{y}) = {}", c.d);
+        }
+        let (tx, ty) = f.tangent_at(50.0);
+        assert!((tx - 1.0).abs() < 1e-9 && ty.abs() < 1e-9);
+    }
+
+    #[test]
+    fn curved_lane_is_detected_and_projects_by_arc_length() {
+        // Quarter circle, centerline radius 30 m → arc length ~47.1 m.
+        let (l, r) = arc_boundaries(30.0, 2.0, std::f64::consts::FRAC_PI_2, 40);
+        let f = CenterlineFrenet::from_boundaries(&l, &r).unwrap();
+        assert!(!f.is_effectively_straight());
+        assert!(
+            (f.total_length_m() - 30.0 * std::f64::consts::FRAC_PI_2).abs() < 0.2,
+            "arc length {} vs expected {}",
+            f.total_length_m(),
+            30.0 * std::f64::consts::FRAC_PI_2
+        );
+        // A point ON the centerline halfway around: s ≈ half the arc, d ≈ 0.
+        let a = std::f64::consts::FRAC_PI_4;
+        let p = Point { x_m: 30.0 * a.sin(), y_m: 30.0 - 30.0 * a.cos() };
+        let c = f.project(p).unwrap();
+        assert!((c.s - 30.0 * a).abs() < 0.1, "s = {}", c.s);
+        assert!(c.d.abs() < 0.05, "d = {}", c.d);
+    }
+
+    #[test]
+    fn signed_offset_is_left_positive() {
+        let (l, r) = straight_boundaries(50.0, 5.0);
+        let f = CenterlineFrenet::from_boundaries(&l, &r).unwrap();
+        assert!(f.project(Point { x_m: 10.0, y_m: 2.0 }).unwrap().d > 0.0, "left of travel");
+        assert!(f.project(Point { x_m: 10.0, y_m: -2.0 }).unwrap().d < 0.0, "right of travel");
+    }
+
+    #[test]
+    fn degenerate_boundaries_yield_none() {
+        // Too few vertices.
+        assert!(CenterlineFrenet::from_boundaries(&[Point { x_m: 0.0, y_m: 0.0 }], &[]).is_none());
+        // Zero-length polyline.
+        let p = Point { x_m: 1.0, y_m: 1.0 };
+        assert!(CenterlineFrenet::from_boundaries(&[p, p], &[p, p]).is_none());
+        // Non-finite vertex.
+        let bad = vec![Point { x_m: 0.0, y_m: f64::NAN }, Point { x_m: 10.0, y_m: 0.0 }];
+        let good = vec![Point { x_m: 0.0, y_m: -5.0 }, Point { x_m: 10.0, y_m: -5.0 }];
+        assert!(CenterlineFrenet::from_boundaries(&bad, &good).is_none());
+    }
+
+    #[test]
+    fn non_finite_point_projection_is_none() {
+        let (l, r) = straight_boundaries(50.0, 5.0);
+        let f = CenterlineFrenet::from_boundaries(&l, &r).unwrap();
+        assert!(f.project(Point { x_m: f64::NAN, y_m: 0.0 }).is_none());
+        assert!(f.project(Point { x_m: 1.0, y_m: f64::INFINITY }).is_none());
+    }
+
+    #[test]
+    fn mismatched_vertex_counts_still_center_the_lane() {
+        // Left has 2 vertices, right has 7 (same geometry) — matched-fraction
+        // resampling must not skew the centerline.
+        let l = vec![Point { x_m: 0.0, y_m: 3.0 }, Point { x_m: 60.0, y_m: 3.0 }];
+        let r: Vec<Point> =
+            (0..7).map(|i| Point { x_m: 10.0 * i as f64, y_m: -3.0 }).collect();
+        let f = CenterlineFrenet::from_boundaries(&l, &r).unwrap();
+        let c = f.project(Point { x_m: 30.0, y_m: 0.0 }).unwrap();
+        assert!(c.d.abs() < 1e-9, "centerline must sit on y=0, d = {}", c.d);
+    }
+}

--- a/crates/kirra-trajectory/src/lib.rs
+++ b/crates/kirra-trajectory/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod config;
 pub mod corridor;
+pub mod frenet;
 pub mod state;
 pub mod validation;
 // WS-2 — pedestrian / VRU RSS primitive (KIRRA-VRU-RSS-001).

--- a/crates/kirra-trajectory/src/redundancy_hardening.rs
+++ b/crates/kirra-trajectory/src/redundancy_hardening.rs
@@ -77,7 +77,7 @@ pub enum EquivalenceCheckResult {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```text
 /// heading_difference(3.1, -3.1) ≈ 0.04 (both are ≈ π in opposite directions)
 /// heading_difference(0.0, π) = π (half turn)
 /// ```

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -1457,8 +1457,10 @@ mod rss_frame_tests {
         let right: Vec<Point> = (0..=20).map(|i| off(center(i as f64), -2.0)).collect();
         let frenet = CenterlineFrenet::from_boundaries(&left, &right).unwrap();
 
-        // Ego on the centerline at s = 5; object at s = 12, 1 m to the LEFT.
-        let ego_w = center(5.0);
+        // Ego at s = 5, 0.5 m to the RIGHT of the centerline; object at s = 12,
+        // 1.0 m to the LEFT. A non-zero ego offset makes `o.d - ego.d`
+        // load-bearing (an ego ON the centerline would let a `-`→`+` mutant pass).
+        let ego_w = off(center(5.0), -0.5);
         let obj_w = off(center(12.0), 1.0);
         let (vx, vy) = (2.0_f64, 3.0_f64);
         let f = rss_frenet_frame(
@@ -1467,9 +1469,9 @@ mod rss_frame_tests {
             &obj_at(obj_w.x_m, obj_w.y_m, vx, vy),
         )
         .expect("both points project onto the lane");
-        // Arc gap 12 - 5 = 7; lateral offset +1 (object left of ego).
+        // Arc gap 12 - 5 = 7; lateral offset 1.0 - (-0.5) = 1.5.
         assert!((f.lon_gap - 7.0).abs() < 1e-6, "lon_gap {}", f.lon_gap);
-        assert!((f.lat_off - 1.0).abs() < 1e-6, "lat_off {}", f.lat_off);
+        assert!((f.lat_off - 1.5).abs() < 1e-6, "lat_off {}", f.lat_off);
         // Velocity resolved against the lane tangent at the object.
         assert!((f.obj_lon_v - (tx * vx + ty * vy)).abs() < 1e-6, "obj_lon_v {}", f.obj_lon_v);
         assert!((f.obj_lat_v - (-ty * vx + tx * vy)).abs() < 1e-6, "obj_lat_v {}", f.obj_lat_v);

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -572,22 +572,7 @@ pub fn validate_trajectory_slow_capped(
             // motion here — the orientation-based `sin(heading − ego)` form read it
             // as ~0 and could miss the cut-in. EP-08: from the same frame.
             let obj_lat_vel = frame.obj_lat_v;
-            // EP-08 refinement (RSS responsibility, Shalev-Shwartz §3.4 — the
-            // same principle behind the §4 stopped-queue admission): a pose at
-            // which the ego is STOPPED has completed its proper response on
-            // both axes. A laterally-CLOSING object can no longer be met by
-            // any ego action — the collision, if one occurs, is attributable
-            // to the closer, not the stationary ego — so the cut-in arm does
-            // not fire for a stopped pose. (Without this, a planner's smooth
-            // yield-to-a-stop short of a crossing vehicle is refused at its
-            // final stopped pose and replaced by an MRC stop at essentially
-            // the same spot — over-rejection with no safety gain.) The ABREAST
-            // arm (`lon_unsafe`) is deliberately kept even at v = 0
-            // (conservative: a stopped ego abreast-dangerously close is still
-            // flagged).
-            let lateral_cut_in = obj_lat_vel.abs() > RSS_LATERAL_MOTION_EPS_MPS
-                && traj_point.velocity_mps.abs()
-                    > kirra_core::kinematics_contract::STOP_EPSILON_MPS;
+            let lateral_cut_in = obj_lat_vel.abs() > RSS_LATERAL_MOTION_EPS_MPS;
             // #683/#684: scale the lateral-conflict longitudinal window by closing
             // SPEED (via `lon_required`), floored at the 8 m urban minimum. A FIXED 8 m
             // ceiling clipped (a) a high-speed cut-in originating farther ahead than 8 m — at the
@@ -603,15 +588,41 @@ pub fn validate_trajectory_slow_capped(
             // gate (overtaking) is untouched.
             let lat_conflict_window = RSS_LONGITUDINAL_CONFLICT_M.max(lon_required);
             if dx_ego <= lat_conflict_window && (lon_unsafe || lateral_cut_in) {
-                let ego_lat_vel = 0.0; // straight-following assumption per §3
-                let lat_required = lateral_safe_distance_split(
-                    ego_lat_vel,
-                    obj_lat_vel,
-                    kinematics.max_lateral_accel_mps2,
-                    RSS_LAT_BRAKE_FRACTION * kinematics.max_lateral_accel_mps2,
-                    RSS_REACTION_TIME_S,
-                    RSS_MU_LATERAL_M,
-                );
+                // EP-08 stopped-pose rule (RSS responsibility, Shalev-Shwartz
+                // §3.4 — the same principle behind the §4 stopped-queue
+                // admission): a pose at which the committed trajectory is
+                // STOPPED provably contributes no lateral motion — the split
+                // form's ego response-phase swerve term is a hypothesis the
+                // trajectory itself falsifies. Such a pose is charged the
+                // OBJECT's full closing envelope + mu only
+                // (`lateral_safe_distance_split_stationary_ego`): a cut-in
+                // that can actually reach the stopped ego is still rejected
+                // (the 0.3 m held-ego pins), while a smooth yield-to-a-stop
+                // short of a crossing vehicle is no longer refused at its
+                // final stopped pose (which would merely swap the planner's
+                // yield for an MRC stop at the same spot). Moving poses keep
+                // the full split form unchanged.
+                let ego_stopped = traj_point.velocity_mps.abs()
+                    <= kirra_core::kinematics_contract::STOP_EPSILON_MPS;
+                let lat_required = if ego_stopped {
+                    parko_core::rss::lateral_safe_distance_split_stationary_ego(
+                        obj_lat_vel,
+                        kinematics.max_lateral_accel_mps2,
+                        RSS_LAT_BRAKE_FRACTION * kinematics.max_lateral_accel_mps2,
+                        RSS_REACTION_TIME_S,
+                        RSS_MU_LATERAL_M,
+                    )
+                } else {
+                    let ego_lat_vel = 0.0; // straight-following assumption per §3
+                    lateral_safe_distance_split(
+                        ego_lat_vel,
+                        obj_lat_vel,
+                        kinematics.max_lateral_accel_mps2,
+                        RSS_LAT_BRAKE_FRACTION * kinematics.max_lateral_accel_mps2,
+                        RSS_REACTION_TIME_S,
+                        RSS_MU_LATERAL_M,
+                    )
+                };
                 if dy_ego.abs() < lat_required {
                     return TrajectoryVerdict::MRCFallback;
                 }

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -1390,3 +1390,105 @@ mod degraded_angular_gate_tests {
         assert!(degraded_angular_violation(0.1, f64::INFINITY, EPS));
     }
 }
+
+// EP-08 — the two RSS reference frames pinned to exact values. Both resolve a
+// longitudinal gap, a signed lateral offset, and the object velocity's
+// longitudinal/lateral components; every product/sum/sign in that resolution
+// is load-bearing (a snapshot RSS conjunction rides on the signs), so these
+// tests pin all four outputs of each frame to 1e-9 — the mutation gate's
+// arithmetic mutants in `rss_tangent_frame` / `rss_frenet_frame` each move at
+// least one output well past that tolerance.
+#[cfg(test)]
+mod rss_frame_tests {
+    use super::*;
+    use crate::state::Pose as AdapterPose;
+
+    fn traj_point(x: f64, y: f64, heading: f64) -> TrajectoryPoint {
+        TrajectoryPoint {
+            pose: AdapterPose { x_m: x, y_m: y, heading_rad: heading },
+            velocity_mps: 0.0,
+            time_from_start_s: 0.0,
+        }
+    }
+
+    fn obj_at(px: f64, py: f64, vx: f64, vy: f64) -> PerceivedObject {
+        PerceivedObject {
+            id: 1,
+            pos: Point { x_m: px, y_m: py },
+            velocity_mps: (vx * vx + vy * vy).sqrt(),
+            heading_rad: vy.atan2(vx),
+            vel: Point { x_m: vx, y_m: vy },
+        }
+    }
+
+    #[test]
+    fn tangent_frame_resolves_gap_offset_and_velocity_exactly() {
+        // Heading π/6 → cos = √3/2, sin = 1/2 (both non-trivial and distinct).
+        // Ego at (5, 7); object 2 m +X, 3 m +Y of it; velocity (1, 4).
+        let h = std::f64::consts::FRAC_PI_6;
+        let (cos_h, sin_h) = (h.cos(), h.sin());
+        let (dx, dy) = (2.0_f64, 3.0_f64);
+        let (vx, vy) = (1.0_f64, 4.0_f64);
+        let f = rss_tangent_frame(&traj_point(5.0, 7.0, h), &obj_at(5.0 + dx, 7.0 + dy, vx, vy));
+        assert!((f.lon_gap - (cos_h * dx + sin_h * dy)).abs() < 1e-9, "lon_gap {}", f.lon_gap);
+        assert!((f.lat_off - (-sin_h * dx + cos_h * dy)).abs() < 1e-9, "lat_off {}", f.lat_off);
+        assert!((f.obj_lon_v - (cos_h * vx + sin_h * vy)).abs() < 1e-9, "obj_lon_v {}", f.obj_lon_v);
+        assert!((f.obj_lat_v - (-sin_h * vx + cos_h * vy)).abs() < 1e-9, "obj_lat_v {}", f.obj_lat_v);
+        // Concrete values (independent of the formula above): with these inputs
+        // lon_gap ≈ 3.232, lat_off ≈ 1.598 — a sign flip or product→sum mutant
+        // lands elsewhere.
+        assert!((f.lon_gap - 3.232_050_8).abs() < 1e-6);
+        assert!((f.lat_off - 1.598_076_2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn frenet_frame_resolves_along_a_rotated_lane_exactly() {
+        // A straight lane at 30° (tangent (cos30, sin30) = (0.866, 0.5)) — the
+        // frame BUILDS regardless of straightness (engagement is gated
+        // elsewhere), and a rotated tangent makes the velocity-resolution signs
+        // load-bearing (a +X lane would zero the lateral term and hide mutants).
+        let h = std::f64::consts::FRAC_PI_6;
+        let (tx, ty) = (h.cos(), h.sin());
+        // Left/right boundaries offset ±2 m along the left normal (-sin, cos).
+        let (nx, ny) = (-ty, tx);
+        let center = |s: f64| Point { x_m: tx * s, y_m: ty * s };
+        let off = |p: Point, k: f64| Point { x_m: p.x_m + k * nx, y_m: p.y_m + k * ny };
+        let left: Vec<Point> = (0..=20).map(|i| off(center(i as f64), 2.0)).collect();
+        let right: Vec<Point> = (0..=20).map(|i| off(center(i as f64), -2.0)).collect();
+        let frenet = CenterlineFrenet::from_boundaries(&left, &right).unwrap();
+
+        // Ego on the centerline at s = 5; object at s = 12, 1 m to the LEFT.
+        let ego_w = center(5.0);
+        let obj_w = off(center(12.0), 1.0);
+        let (vx, vy) = (2.0_f64, 3.0_f64);
+        let f = rss_frenet_frame(
+            &frenet,
+            &traj_point(ego_w.x_m, ego_w.y_m, h),
+            &obj_at(obj_w.x_m, obj_w.y_m, vx, vy),
+        )
+        .expect("both points project onto the lane");
+        // Arc gap 12 - 5 = 7; lateral offset +1 (object left of ego).
+        assert!((f.lon_gap - 7.0).abs() < 1e-6, "lon_gap {}", f.lon_gap);
+        assert!((f.lat_off - 1.0).abs() < 1e-6, "lat_off {}", f.lat_off);
+        // Velocity resolved against the lane tangent at the object.
+        assert!((f.obj_lon_v - (tx * vx + ty * vy)).abs() < 1e-6, "obj_lon_v {}", f.obj_lon_v);
+        assert!((f.obj_lat_v - (-ty * vx + tx * vy)).abs() < 1e-6, "obj_lat_v {}", f.obj_lat_v);
+        // The lateral component is non-zero (≈ 1.598) — the sign/product mutants
+        // in the `-ty*vx + tx*vy` resolution cannot hide.
+        assert!(f.obj_lat_v.abs() > 1.0);
+    }
+
+    #[test]
+    fn frenet_frame_falls_back_when_a_point_cannot_project() {
+        // A degenerate (single-point-after-collapse) frame is unbuildable, so
+        // instead pin the None path via a non-finite object position: project
+        // returns None → the caller uses the tangent frame for that pair.
+        let (l, r) = (
+            vec![Point { x_m: 0.0, y_m: 2.0 }, Point { x_m: 40.0, y_m: 2.0 }],
+            vec![Point { x_m: 0.0, y_m: -2.0 }, Point { x_m: 40.0, y_m: -2.0 }],
+        );
+        let frenet = CenterlineFrenet::from_boundaries(&l, &r).unwrap();
+        let bad = obj_at(f64::NAN, 0.0, 1.0, 0.0);
+        assert!(rss_frenet_frame(&frenet, &traj_point(5.0, 0.0, 0.0), &bad).is_none());
+    }
+}

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -29,11 +29,12 @@ use kirra_core::frame_integrity::FrameTrust;
 use kirra_core::FleetPosture;
 use parko_core::rss::{
     lateral_safe_distance_split, longitudinal_safe_distance, opposite_direction_safe_distance,
-    RSS_LONGITUDINAL_CONFLICT_M, RSS_LONGITUDINAL_OVERLAP_M,
+    RSS_LONGITUDINAL_CONFLICT_M,
 };
 
 use crate::config::VehicleConfig;
 use crate::corridor::{CorridorSource, Point};
+use crate::frenet::CenterlineFrenet;
 use crate::state::{
     AcceptedTrajectory, EgoOdom, PerceivedObject, Pose, TrajectoryPoint,
     TrajectoryVerdict,
@@ -141,6 +142,65 @@ pub struct PredictedMode<'a> {
 ///  mapping so the AV slow-loop and the differential-drive bridge stay
 ///  consistent. M1b — wiring `current_posture` to the live verifier
 ///  stream — is tracked at the slow-loop call site in `node.rs`.)
+/// EP-08 — the per-(object, pose) RSS measurement frame: the longitudinal gap,
+/// lateral offset, and the object's velocity resolved into (longitudinal,
+/// lateral) components. Two constructors:
+/// - [`rss_tangent_frame`] — the pose-heading chord frame (the original math,
+///   verbatim; exact on a straight lane);
+/// - [`rss_frenet_frame`] — the corridor-centerline Frenet frame (EP-08):
+///   longitudinal = ARC distance along the lane, lateral = signed-offset
+///   difference, velocity resolved against the centerline tangent AT the
+///   object. Correct on curved lanes, where the chord frame lets an in-lane
+///   object around the bend escape the lateral filter (fail-open) and
+///   spuriously rejects an out-of-lane object dead ahead on the tangent.
+struct RssFrame {
+    /// Longitudinal gap, ego → object (m; ≤ 0 = behind the ego).
+    lon_gap: f64,
+    /// Lateral offset, object relative to ego (m, signed).
+    lat_off: f64,
+    /// Object velocity, longitudinal component (m/s; negative = oncoming).
+    obj_lon_v: f64,
+    /// Object velocity, lateral component (m/s, signed).
+    obj_lat_v: f64,
+}
+
+/// The original pose-tangent (chord) frame — expression-for-expression the
+/// pre-EP-08 math, so the straight-lane path stays bit-for-bit.
+fn rss_tangent_frame(traj_point: &TrajectoryPoint, obj: &PerceivedObject) -> RssFrame {
+    let dx = obj.pos.x_m - traj_point.pose.x_m;
+    let dy = obj.pos.y_m - traj_point.pose.y_m;
+    let cos_h = traj_point.pose.heading_rad.cos();
+    let sin_h = traj_point.pose.heading_rad.sin();
+    RssFrame {
+        lon_gap: cos_h * dx + sin_h * dy,
+        lat_off: -sin_h * dx + cos_h * dy,
+        obj_lon_v: cos_h * obj.vel.x_m + sin_h * obj.vel.y_m,
+        obj_lat_v: -sin_h * obj.vel.x_m + cos_h * obj.vel.y_m,
+    }
+}
+
+/// The corridor-centerline Frenet frame (EP-08). `None` when either point
+/// fails to project — the caller falls back to the tangent frame for that
+/// pair (exactly the pre-EP-08 behaviour, never a skip).
+fn rss_frenet_frame(
+    frenet: &CenterlineFrenet,
+    traj_point: &TrajectoryPoint,
+    obj: &PerceivedObject,
+) -> Option<RssFrame> {
+    let ego = frenet.project(Point { x_m: traj_point.pose.x_m, y_m: traj_point.pose.y_m })?;
+    let o = frenet.project(obj.pos)?;
+    // Velocity resolves against the lane direction AT THE OBJECT — on a curve
+    // the tangent rotates, and it is the object's local lane direction that
+    // decides "closing along the lane" vs "cutting across it".
+    let (tx, ty) = frenet.tangent_at(o.s);
+    Some(RssFrame {
+        lon_gap: o.s - ego.s,
+        lat_off: o.d - ego.d,
+        obj_lon_v: tx * obj.vel.x_m + ty * obj.vel.y_m,
+        obj_lat_v: -ty * obj.vel.x_m + tx * obj.vel.y_m,
+    })
+}
+
 pub fn validate_trajectory_slow(
     trajectory: &[TrajectoryPoint],
     corridor: &dyn CorridorSource,
@@ -167,7 +227,7 @@ pub fn validate_trajectory_slow(
 
 /// As [`validate_trajectory_slow`], plus the Track-C perception-derate cap
 /// (KIRRA-OCCY-PMON-003 D3a). `effective_perception_cap` is the value resolved
-/// by [`resolve_perception_cap`] at the call site (the adapter slow loop):
+/// by `resolve_perception_cap` at the call site (the adapter slow loop):
 /// `None` when the monitor is disabled/absent (state 1 → no-op), `Some(0.0)`
 /// MRC floor when an enabled monitor is stale/silent (state 3).
 ///
@@ -391,6 +451,20 @@ pub fn validate_trajectory_slow_capped(
     // gates the longitudinal check: if the object is far enough off the
     // ego corridor laterally, containment handled it; longitudinal is
     // skipped to avoid spurious violations from objects in another lane.
+    // EP-08: derive the corridor-centerline Frenet reference ONCE per call.
+    // Engaged ONLY when the corridor is genuinely curved — a straight (or
+    // degenerate) corridor leaves `frenet` None and every pair below runs the
+    // original tangent-frame math bit-for-bit. On a curved corridor a pair
+    // whose projection fails also falls back per-pair (fail-safe: exactly the
+    // pre-EP-08 measurement, never a skip). The multi-modal PREDICTIVE pass
+    // (§C2) keeps its tangent frame — extending Frenet to the time-matched
+    // pass is the recorded follow-up.
+    let frenet = CenterlineFrenet::from_boundaries(
+        corridor.left_boundary(),
+        corridor.right_boundary(),
+    )
+    .filter(|f| !f.is_effectively_straight());
+
     for obj in objects {
         // H-2 (fail-closed RSS): a non-finite object field would poison every
         // RSS `<` / `abs()` comparison below — NaN compares false against every
@@ -405,15 +479,16 @@ pub fn validate_trajectory_slow_capped(
             return TrajectoryVerdict::MRCFallback;
         }
         for traj_point in trajectory {
-            let dx = obj.pos.x_m - traj_point.pose.x_m;
-            let dy = obj.pos.y_m - traj_point.pose.y_m;
-
-            // Skip if behind ego pose (objects we've already passed).
-            // Ego-frame: rotate world delta by -heading.
-            let cos_h = traj_point.pose.heading_rad.cos();
-            let sin_h = traj_point.pose.heading_rad.sin();
-            let dx_ego =  cos_h * dx + sin_h * dy;     // longitudinal
-            let dy_ego = -sin_h * dx + cos_h * dy;     // lateral
+            // EP-08: measure the pair in the lane's frame. Curved corridor →
+            // Frenet (arc-length longitudinal, signed-offset lateral, velocity
+            // against the local lane tangent); straight/degenerate corridor or
+            // a failed projection → the original pose-tangent frame, verbatim.
+            let frame = frenet
+                .as_ref()
+                .and_then(|f| rss_frenet_frame(f, traj_point, obj))
+                .unwrap_or_else(|| rss_tangent_frame(traj_point, obj));
+            let dx_ego = frame.lon_gap;
+            let dy_ego = frame.lat_off;
 
             // Behind ego — RSS does not apply (the object is no longer
             // a forward collision risk; containment + posture handle
@@ -444,7 +519,9 @@ pub fn validate_trajectory_slow_capped(
             // object. Reuses the ego-frame rotation already computed for dx/dy_ego;
             // the longitudinal bound now takes the true longitudinal closing
             // component (matching `predictive_rss_breach`), not the full speed.
-            let obj_lon_v = cos_h * obj.vel.x_m + sin_h * obj.vel.y_m;
+            // EP-08: the component comes from the SAME frame as the gaps above
+            // (lane tangent on a curve; pose tangent on a straight).
+            let obj_lon_v = frame.obj_lon_v;
             let lon_required = if obj_lon_v < 0.0 {
                 // Closing magnitudes; symmetric brake_min (both in their lanes).
                 opposite_direction_safe_distance(
@@ -472,7 +549,8 @@ pub fn validate_trajectory_slow_capped(
             // the ego's path). Applying it to an object the ego is laterally CLEAR of — a vehicle
             // being passed, or oncoming traffic safely in the next lane — over-rejected (§4): it
             // was why a car centered in the ego lane could not be overtaken.
-            if dy_ego.abs() < RSS_LONGITUDINAL_OVERLAP_M && lon_unsafe {
+            // EP-08: per-class footprint-overlap gate (was the global 2.5 m).
+            if dy_ego.abs() < config.rss_longitudinal_overlap_m && lon_unsafe {
                 return TrajectoryVerdict::MRCFallback;
             }
 
@@ -492,8 +570,8 @@ pub fn validate_trajectory_slow_capped(
             // normal), mirroring `predictive_rss_breach`'s `obj_lat_v`. A car still
             // FACING forward but MOVING laterally (a cut-in) now registers lateral
             // motion here — the orientation-based `sin(heading − ego)` form read it
-            // as ~0 and could miss the cut-in.
-            let obj_lat_vel = -sin_h * obj.vel.x_m + cos_h * obj.vel.y_m;
+            // as ~0 and could miss the cut-in. EP-08: from the same frame.
+            let obj_lat_vel = frame.obj_lat_v;
             let lateral_cut_in = obj_lat_vel.abs() > RSS_LATERAL_MOTION_EPS_MPS;
             // #683/#684: scale the lateral-conflict longitudinal window by closing
             // SPEED (via `lon_required`), floored at the 8 m urban minimum. A FIXED 8 m
@@ -802,8 +880,9 @@ fn predictive_rss_breach(
             };
             let lon_unsafe = dx_ego < lon_required;
 
-            // Longitudinal RSS — gated on lateral footprint overlap (same as snapshot).
-            if dy_ego.abs() < RSS_LONGITUDINAL_OVERLAP_M && lon_unsafe {
+            // Longitudinal RSS — gated on lateral footprint overlap (same as
+            // snapshot; EP-08: the per-class window).
+            if dy_ego.abs() < config.rss_longitudinal_overlap_m && lon_unsafe {
                 return true;
             }
 

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -572,7 +572,22 @@ pub fn validate_trajectory_slow_capped(
             // motion here — the orientation-based `sin(heading − ego)` form read it
             // as ~0 and could miss the cut-in. EP-08: from the same frame.
             let obj_lat_vel = frame.obj_lat_v;
-            let lateral_cut_in = obj_lat_vel.abs() > RSS_LATERAL_MOTION_EPS_MPS;
+            // EP-08 refinement (RSS responsibility, Shalev-Shwartz §3.4 — the
+            // same principle behind the §4 stopped-queue admission): a pose at
+            // which the ego is STOPPED has completed its proper response on
+            // both axes. A laterally-CLOSING object can no longer be met by
+            // any ego action — the collision, if one occurs, is attributable
+            // to the closer, not the stationary ego — so the cut-in arm does
+            // not fire for a stopped pose. (Without this, a planner's smooth
+            // yield-to-a-stop short of a crossing vehicle is refused at its
+            // final stopped pose and replaced by an MRC stop at essentially
+            // the same spot — over-rejection with no safety gain.) The ABREAST
+            // arm (`lon_unsafe`) is deliberately kept even at v = 0
+            // (conservative: a stopped ego abreast-dangerously close is still
+            // flagged).
+            let lateral_cut_in = obj_lat_vel.abs() > RSS_LATERAL_MOTION_EPS_MPS
+                && traj_point.velocity_mps.abs()
+                    > kirra_core::kinematics_contract::STOP_EPSILON_MPS;
             // #683/#684: scale the lateral-conflict longitudinal window by closing
             // SPEED (via `lon_required`), floored at the 8 m urban minimum. A FIXED 8 m
             // ceiling clipped (a) a high-speed cut-in originating farther ahead than 8 m — at the

--- a/crates/kirra-trajectory/src/validation_hardening.rs
+++ b/crates/kirra-trajectory/src/validation_hardening.rs
@@ -24,7 +24,7 @@ use crate::state::TrajectoryPoint;
 /// # Returns
 ///
 /// `None` if valid (times strictly increasing).
-/// `Some(violation_index)` if non-monotonic (times[i] ≥ times[i+1] at index i).
+/// `Some(violation_index)` if non-monotonic (`times[i] >= times[i+1]` at index i).
 ///
 /// # Example
 ///
@@ -53,7 +53,7 @@ pub fn validate_trajectory_time_monotonicity(trajectory: &[TrajectoryPoint]) -> 
 /// # Returns
 ///
 /// `None` if valid (max spacing ≤ max_spacing_s).
-/// `Some((index, spacing_s))` if violated (spacing[i] > max at segment i).
+/// `Some((index, spacing_s))` if violated (`spacing[i] > max` at segment i).
 ///
 /// # Certification Notes
 ///

--- a/crates/kirra-trajectory/src/vru.rs
+++ b/crates/kirra-trajectory/src/vru.rs
@@ -125,7 +125,7 @@ impl VruRssParams {
     /// [`VRU_STOP_EPSILON_CEILING_MPS`] (the kernel stop-and-hold epsilon). Both
     /// clamps are MONOTONE-TIGHTENING — a caller may raise `v_ped_max` or lower
     /// `stop_epsilon`, never the reverse. Non-finite fields are left untouched for
-    /// [`params_valid`] to fail closed (an infinite requirement), never clamped
+    /// `params_valid` to fail closed (an infinite requirement), never clamped
     /// into a finite value that would admit a trajectory. (A full per-ODD
     /// derivation of `v_ped_max` — runners, children, cyclists-as-VRUs — remains a
     /// deployment tuning obligation on top of this floor; doc §5.)

--- a/crates/kirra-trajectory/tests/conformance.rs
+++ b/crates/kirra-trajectory/tests/conformance.rs
@@ -60,12 +60,14 @@ fn stale_trajectory_mrcs() {
 #[test]
 fn horizon_exhausted_mrcs() {
     // Arm B: no pose with `time_from_start_s >= elapsed` — the trajectory's
-    // whole horizon is in the past (fresh enough to pass staleness, but every
-    // pose's time has elapsed). 3 poses over 0.2 s, elapsed 0.19 s: still fresh
-    // (< 200 ms), but only the last pose (0.2 s) could match — nudge elapsed
-    // just past it so `find` returns None.
+    // whole horizon is in the past while it is still fresh enough to pass
+    // `is_stale(now)`. The accepted trajectory spans 0.04 s (poses at
+    // 0.00/0.02/0.04 s) but elapsed since promotion is 0.15 s, so `find`
+    // returns None → MRCFallback. The exact numbers matter: 150 ms keeps the
+    // trajectory fresh (< DEFAULT_MAX_AGE_MS = 200 ms) yet past the 0.04 s
+    // horizon, so this pins horizon exhaustion WITHOUT tripping staleness.
     let promoted = 100_000;
-    let now = promoted + 150; // < DEFAULT_MAX_AGE_MS (fresh), but past a short horizon
+    let now = promoted + 150; // 0.15 s: < DEFAULT_MAX_AGE_MS (fresh), past the 0.04 s horizon
     let traj = fresh_accepted(promoted, straight_pts(3, 5.0, 0.02)); // poses at 0, 0.02, 0.04 s
     let cmd = IncomingControl { velocity_mps: 5.0, steering_rad: 0.0, stamp_ms: now };
     let cfg = VehicleConfig::default_urban();

--- a/crates/kirra-trajectory/tests/conformance.rs
+++ b/crates/kirra-trajectory/tests/conformance.rs
@@ -1,0 +1,112 @@
+// crates/kirra-trajectory/tests/conformance.rs
+//
+// Native (kirra-trajectory-scoped) coverage of the fast-loop conformance
+// check `validation::check_command_conforms`. The behaviour is also exercised
+// from the adapter's `conformance_tests.rs`, but that suite runs under
+// `-p kirra-ros2-adapter`; the checker-coverage gate measures
+// `-p kirra-trajectory`, so this file drives every conformance decision arm
+// (staleness / horizon-exhaustion / velocity / steering / Accept) from within
+// the checker crate itself. Pure and sync — no ROS, no spawned tasks.
+
+use kirra_trajectory::{
+    config::VehicleConfig,
+    state::{AcceptedTrajectory, EgoOdom, Pose, TrajectoryPoint, TrajectoryVerdict, DEFAULT_MAX_AGE_MS},
+    validation::{check_command_conforms, ConformanceVerdict, IncomingControl, VELOCITY_TOLERANCE_MPS},
+};
+
+fn straight_pts(n: usize, v: f64, dt: f64) -> Vec<TrajectoryPoint> {
+    (0..n)
+        .map(|i| TrajectoryPoint {
+            pose: Pose { x_m: (i as f64) * v * dt, y_m: 0.0, heading_rad: 0.0 },
+            velocity_mps: v,
+            time_from_start_s: (i as f64) * dt,
+        })
+        .collect()
+}
+
+fn fresh_accepted(promoted_at_ms: u64, pts: Vec<TrajectoryPoint>) -> AcceptedTrajectory {
+    AcceptedTrajectory::with_verdict("av_01", 1, pts, TrajectoryVerdict::Accept, promoted_at_ms)
+}
+
+#[test]
+fn conforming_command_accepts() {
+    // Fresh trajectory, cmd velocity == nearest pose velocity, steering in range.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let traj = fresh_accepted(promoted, straight_pts(10, 5.0, 0.1));
+    let cmd = IncomingControl { velocity_mps: 5.0, steering_rad: 0.0, stamp_ms: now };
+    let cfg = VehicleConfig::default_urban();
+    let ego = EgoOdom::default();
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &ego, &cfg, now),
+        ConformanceVerdict::Accept,
+    );
+}
+
+#[test]
+fn stale_trajectory_mrcs() {
+    // Arm A: `is_stale(now)` — now is past promotion + DEFAULT_MAX_AGE_MS.
+    let promoted = 100_000;
+    let now = promoted + DEFAULT_MAX_AGE_MS + 50;
+    let traj = fresh_accepted(promoted, straight_pts(10, 5.0, 0.1));
+    let cmd = IncomingControl { velocity_mps: 5.0, steering_rad: 0.0, stamp_ms: now };
+    let cfg = VehicleConfig::default_urban();
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::MRCFallback,
+    );
+}
+
+#[test]
+fn horizon_exhausted_mrcs() {
+    // Arm B: no pose with `time_from_start_s >= elapsed` — the trajectory's
+    // whole horizon is in the past (fresh enough to pass staleness, but every
+    // pose's time has elapsed). 3 poses over 0.2 s, elapsed 0.19 s: still fresh
+    // (< 200 ms), but only the last pose (0.2 s) could match — nudge elapsed
+    // just past it so `find` returns None.
+    let promoted = 100_000;
+    let now = promoted + 150; // < DEFAULT_MAX_AGE_MS (fresh), but past a short horizon
+    let traj = fresh_accepted(promoted, straight_pts(3, 5.0, 0.02)); // poses at 0, 0.02, 0.04 s
+    let cmd = IncomingControl { velocity_mps: 5.0, steering_rad: 0.0, stamp_ms: now };
+    let cfg = VehicleConfig::default_urban();
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::MRCFallback,
+    );
+}
+
+#[test]
+fn overspeed_command_mrcs() {
+    // Arm C: cmd velocity beyond nearest pose velocity + tolerance.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let traj = fresh_accepted(promoted, straight_pts(10, 5.0, 0.1));
+    let cmd = IncomingControl {
+        velocity_mps: 5.0 + VELOCITY_TOLERANCE_MPS + 0.1,
+        steering_rad: 0.0,
+        stamp_ms: now,
+    };
+    let cfg = VehicleConfig::default_urban();
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::MRCFallback,
+    );
+}
+
+#[test]
+fn oversteer_command_mrcs() {
+    // Arm D: |steering| beyond the vehicle's max steering angle.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let traj = fresh_accepted(promoted, straight_pts(10, 5.0, 0.1));
+    let cfg = VehicleConfig::default_urban();
+    let cmd = IncomingControl {
+        velocity_mps: 5.0,
+        steering_rad: cfg.max_steering_rad + 0.1,
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::MRCFallback,
+    );
+}

--- a/crates/kirra-trajectory/tests/curved_rss.rs
+++ b/crates/kirra-trajectory/tests/curved_rss.rs
@@ -264,6 +264,94 @@ fn tighter_curvature_never_admits_a_higher_speed() {
     }
 }
 
+/// EP-08 refinement pin (RSS responsibility): the lateral CUT-IN arm does not
+/// fire for a STOPPED pose — a planner's yield-to-a-stop short of a crossing
+/// vehicle is admitted; the same scene with the ego still MOVING at that spot
+/// is rejected. (The abreast arm stays live even at v = 0.)
+#[test]
+fn a_stopped_pose_is_not_rejected_for_a_crosser_it_yielded_to() {
+    // Straight lane along +X; a crosser 4 m left at x = 40, closing laterally
+    // at 1.5 m/s (its lateral safe distance ≈ 4.4 m > 4 m — inside the
+    // alignment band, outside the overlap band).
+    let corridor = PolyCorridor {
+        left: vec![Point { x_m: 0.0, y_m: 5.0 }, Point { x_m: 120.0, y_m: 5.0 }],
+        right: vec![Point { x_m: 0.0, y_m: -5.0 }, Point { x_m: 120.0, y_m: -5.0 }],
+    };
+    let crosser = PerceivedObject {
+        id: 9,
+        pos: Point { x_m: 45.0, y_m: 4.0 },
+        velocity_mps: 1.5,
+        heading_rad: -std::f64::consts::FRAC_PI_2,
+        vel: Point { x_m: 0.0, y_m: -1.5 },
+    };
+
+    // Yield: the MOVING poses all stay outside the 8 m lateral-conflict
+    // window (x ≤ 36.9, gap ≥ 8.1); the vehicle comes to rest just inside it
+    // (x = 37.2, gap 7.8) and holds. Exactly the mid-turn shape: only the
+    // STOPPED pose sits inside the window, so the verdict isolates the
+    // stopped-pose rule.
+    let mut yielded: Vec<TrajectoryPoint> = Vec::new();
+    for i in 0..12 {
+        let t = i as f64 * 0.1;
+        let frac = t / 1.2;
+        yielded.push(TrajectoryPoint {
+            pose: Pose {
+                x_m: 28.0 + 8.9 * (1.0 - (1.0 - frac) * (1.0 - frac)),
+                y_m: 0.0,
+                heading_rad: 0.0,
+            },
+            velocity_mps: 3.0 * (1.0 - frac) + 0.2, // still moving at the window edge
+            time_from_start_s: t,
+        });
+    }
+    for i in 12..21 {
+        let t = i as f64 * 0.1;
+        yielded.push(TrajectoryPoint {
+            pose: Pose { x_m: 37.2, y_m: 0.0, heading_rad: 0.0 },
+            velocity_mps: 0.0,
+            time_from_start_s: t,
+        });
+    }
+    let v_yield = validate_trajectory_slow(
+        &yielded,
+        &corridor,
+        std::slice::from_ref(&crosser),
+        &urban(),
+        None,
+        FleetPosture::Nominal,
+    );
+    assert!(
+        admitted(v_yield),
+        "a yield-to-a-stop short of a laterally-closing crosser must be admitted \
+         (the stopped ego has completed its proper response); got {v_yield:?}"
+    );
+
+    // Control: DRIVING through the same window at speed → the cut-in arm fires.
+    let driving: Vec<TrajectoryPoint> = (0..21)
+        .map(|i| {
+            let t = i as f64 * 0.1;
+            TrajectoryPoint {
+                pose: Pose { x_m: 32.0 + 5.0 * t, y_m: 0.0, heading_rad: 0.0 },
+                velocity_mps: 5.0,
+                time_from_start_s: t,
+            }
+        })
+        .collect();
+    let v_drive = validate_trajectory_slow(
+        &driving,
+        &corridor,
+        std::slice::from_ref(&crosser),
+        &urban(),
+        None,
+        FleetPosture::Nominal,
+    );
+    assert_eq!(
+        v_drive,
+        TrajectoryVerdict::MRCFallback,
+        "driving through the crosser's closing path at speed must reject"
+    );
+}
+
 proptest! {
     /// STRAIGHT-LINE EQUIVALENCE (the EP-08 property): on straight corridors —
     /// arbitrary offset, width, length, and small boundary vertex noise below

--- a/crates/kirra-trajectory/tests/curved_rss.rs
+++ b/crates/kirra-trajectory/tests/curved_rss.rs
@@ -1,0 +1,326 @@
+//! EP-08 — curved-geometry RSS: the equivalence + monotonicity properties and
+//! the headline fail-open regression, at the FULL `validate_trajectory_slow`
+//! level (the composition the slow loop runs).
+
+use kirra_core::FleetPosture;
+use kirra_trajectory::config::VehicleConfig;
+use kirra_trajectory::corridor::{CorridorSource, Point};
+use kirra_trajectory::frenet::CenterlineFrenet;
+use kirra_trajectory::state::{PerceivedObject, Pose, TrajectoryPoint, TrajectoryVerdict};
+use kirra_trajectory::validation::validate_trajectory_slow;
+
+use proptest::prelude::*;
+
+/// An owned corridor source over explicit boundary polylines.
+struct PolyCorridor {
+    left: Vec<Point>,
+    right: Vec<Point>,
+}
+
+impl CorridorSource for PolyCorridor {
+    fn left_boundary(&self) -> &[Point] {
+        &self.left
+    }
+    fn right_boundary(&self) -> &[Point] {
+        &self.right
+    }
+    fn confidence(&self) -> f32 {
+        0.95
+    }
+    fn age_ms(&self) -> u64 {
+        10
+    }
+}
+
+/// A circular-arc lane: centerline radius `r`, circle center (0, r), starting
+/// at the origin heading +X and sweeping counter-clockwise. `curvature = 1/r`;
+/// `r = f64::INFINITY` degenerates to the straight +X lane.
+fn arc_point(r: f64, s: f64, d: f64) -> Point {
+    if r.is_finite() {
+        let a = s / r;
+        // Offset d is LEFT of travel = toward the circle center.
+        let radius = r - d;
+        Point { x_m: radius * a.sin(), y_m: r - radius * a.cos() }
+    } else {
+        Point { x_m: s, y_m: d }
+    }
+}
+
+fn arc_heading(r: f64, s: f64) -> f64 {
+    if r.is_finite() {
+        s / r
+    } else {
+        0.0
+    }
+}
+
+/// Corridor length bounded to ≲115° of sweep so the lane is a realistic bend,
+/// not a horseshoe curling back on itself (a 275° ring-sector's far end passes
+/// within the containment margin of its own start — correctly rejected, but
+/// not the geometry under test).
+fn arc_len(r: f64) -> f64 {
+    if r.is_finite() {
+        (2.0 * r).min(120.0)
+    } else {
+        120.0
+    }
+}
+
+fn arc_corridor(r: f64, half_w: f64, len: f64, n: usize) -> PolyCorridor {
+    let ring = |d: f64| -> Vec<Point> {
+        (0..n).map(|i| arc_point(r, len * i as f64 / (n - 1) as f64, d)).collect()
+    };
+    PolyCorridor { left: ring(half_w), right: ring(-half_w) }
+}
+
+/// Arc-length offset of the FIRST trajectory pose from the corridor start —
+/// the vehicle's rear overhang must not protrude past the corridor's start cap
+/// (containment correctly rejects a footprint hanging out the back).
+const EGO_START_S: f64 = 5.0;
+
+/// A constant-speed trajectory following the lane centerline, starting
+/// `EGO_START_S` into the corridor.
+fn lane_following_trajectory(r: f64, v: f64, horizon_s: f64, dt: f64) -> Vec<TrajectoryPoint> {
+    let steps = (horizon_s / dt) as usize + 1;
+    (0..steps)
+        .map(|i| {
+            let t = i as f64 * dt;
+            let s = EGO_START_S + v * t;
+            let p = arc_point(r, s, 0.0);
+            TrajectoryPoint {
+                pose: Pose { x_m: p.x_m, y_m: p.y_m, heading_rad: arc_heading(r, s) },
+                velocity_mps: v,
+                time_from_start_s: t,
+            }
+        })
+        .collect()
+}
+
+/// A stationary object ON the lane centerline at arc distance `ahead_m` from
+/// the ego's starting pose.
+fn stationary_in_lane_object(r: f64, ahead_m: f64) -> PerceivedObject {
+    let s_obj = EGO_START_S + ahead_m;
+    let p = arc_point(r, s_obj, 0.0);
+    PerceivedObject {
+        id: 1,
+        pos: p,
+        velocity_mps: 0.0,
+        heading_rad: arc_heading(r, s_obj),
+        vel: Point { x_m: 0.0, y_m: 0.0 },
+    }
+}
+
+/// "Admitted" = the validator lets the vehicle DRIVE the lane (possibly speed-
+/// derated): `Accept` or `Clamp`. (`Clamp` is routine here: with no odometry
+/// the first segment's steering estimate starts at 0°, so entering a curve
+/// always trips the steering-rate clamp — a derate, not a rejection.)
+fn admitted(v: TrajectoryVerdict) -> bool {
+    matches!(v, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp)
+}
+
+fn urban() -> VehicleConfig {
+    VehicleConfig::default_urban()
+}
+
+/// The largest speed on a fixed grid the validator ADMITS for a lane-following
+/// trajectory against a stationary in-lane object 35 m (arc) ahead.
+fn max_admitted_speed(r: f64) -> f64 {
+    let corridor = arc_corridor(r, 5.0, arc_len(r), 60);
+    let obj = stationary_in_lane_object(r, 35.0);
+    let mut max_ok = 0.0;
+    for i in 1..=18 {
+        let v = i as f64; // 1..=18 m/s (inside the urban ODD cap)
+        // Horizon shortened so the footprint's front stays inside the shortest
+        // corridor in the sweep (r = 25 → 50 m of arc).
+        let traj = lane_following_trajectory(r, v, 2.0_f64.min(38.0 / v), 0.1);
+        let verdict = validate_trajectory_slow(
+            &traj,
+            &corridor,
+            std::slice::from_ref(&obj),
+            &urban(),
+            None,
+            FleetPosture::Nominal,
+        );
+        if admitted(verdict) {
+            max_ok = v;
+        }
+    }
+    max_ok
+}
+
+/// THE HEADLINE REGRESSION (the fail-open this EP removes): on a tight curve,
+/// an in-lane stationary object at an arc distance the ego CANNOT stop within
+/// must be rejected. In the pose-tangent chord frame the object around the
+/// bend acquires a large apparent lateral offset, escapes the alignment band,
+/// and is never longitudinally evaluated — the Frenet frame measures it in
+/// lane coordinates and rejects.
+#[test]
+fn in_lane_object_around_a_bend_is_rejected_not_missed() {
+    let r = 25.0; // tight urban curve
+    let corridor = arc_corridor(r, 5.0, arc_len(r), 60);
+    // 40 m of arc ahead: at 15 m/s with 4.5 m/s² brake + 0.5 s reaction the
+    // required longitudinal gap is ~44 m → unsafe. The CHORD offset of that
+    // point from the start pose's tangent line is ~[large] — the old frame
+    // read it as laterally clear (out of the 4 m band → fail-open skip).
+    let obj = stationary_in_lane_object(r, 40.0);
+    let p = &obj.pos;
+    // Apparent lateral offset in the START POSE's chord frame (pose at arc 5 m,
+    // heading 5/r): rotate the world delta by -heading.
+    let start = arc_point(r, EGO_START_S, 0.0);
+    let h = arc_heading(r, EGO_START_S);
+    let (dx, dy) = (p.x_m - start.x_m, p.y_m - start.y_m);
+    let apparent_lateral_at_start = -h.sin() * dx + h.cos() * dy;
+    assert!(
+        apparent_lateral_at_start.abs() > urban().rss_lateral_alignment_tolerance_m,
+        "precondition (the fail-open shape): the chord frame reads the in-lane object as \
+         {apparent_lateral_at_start:.1} m lateral — outside the {} m band — so the OLD code \
+         skipped it entirely",
+        urban().rss_lateral_alignment_tolerance_m
+    );
+
+    let traj = lane_following_trajectory(r, 15.0, 2.0_f64.min(38.0 / 15.0), 0.1);
+    let verdict = validate_trajectory_slow(
+        &traj,
+        &corridor,
+        std::slice::from_ref(&obj),
+        &urban(),
+        None,
+        FleetPosture::Nominal,
+    );
+    assert_eq!(
+        verdict,
+        TrajectoryVerdict::MRCFallback,
+        "an in-lane object at an unstoppable arc distance around the bend must reject"
+    );
+}
+
+/// Control for the over-rejection half: an object OUTSIDE the curving lane but
+/// dead ahead on the start pose's tangent line (the chord frame read it as
+/// in-path and could spuriously MRC) is admitted at a modest speed — the lane
+/// bends away from it.
+#[test]
+fn out_of_lane_object_on_the_tangent_line_is_not_spuriously_rejected() {
+    let r = 25.0;
+    let corridor = arc_corridor(r, 5.0, arc_len(r), 60);
+    // Dead ahead on the START POSE's tangent line, 30 m out: the lane bends
+    // away, so in LANE coordinates the point is far outside the corridor —
+    // but the chord frame reads it as exactly in-path (lateral 0) at a
+    // longitudinally-unsafe range for a 15 m/s ego.
+    let start = arc_point(r, EGO_START_S, 0.0);
+    let h = arc_heading(r, EGO_START_S);
+    let obj = PerceivedObject {
+        id: 2,
+        pos: Point { x_m: start.x_m + 30.0 * h.cos(), y_m: start.y_m + 30.0 * h.sin() },
+        velocity_mps: 0.0,
+        heading_rad: h,
+        vel: Point { x_m: 0.0, y_m: 0.0 },
+    };
+    // Frenet lateral offset of that point is far beyond the 4 m band.
+    let f = CenterlineFrenet::from_boundaries(corridor.left_boundary(), corridor.right_boundary())
+        .expect("arc corridor is non-degenerate");
+    let c = f.project(obj.pos).expect("projects");
+    assert!(
+        c.d.abs() > urban().rss_lateral_alignment_tolerance_m,
+        "precondition: the object is outside the lane in lane coordinates (d = {:.1})",
+        c.d
+    );
+
+    let traj = lane_following_trajectory(r, 15.0, 2.0_f64.min(38.0 / 15.0), 0.1);
+    let verdict = validate_trajectory_slow(
+        &traj,
+        &corridor,
+        std::slice::from_ref(&obj),
+        &urban(),
+        None,
+        FleetPosture::Nominal,
+    );
+    assert!(
+        admitted(verdict),
+        "a lane-following trajectory must not be rejected for an object the lane bends away \
+         from; got {verdict:?}"
+    );
+}
+
+/// CURVATURE MONOTONICITY (the EP-08 property): for the same in-lane hazard at
+/// the same ARC distance, tightening the curve never ENLARGES the admissible
+/// speed. (The chord frame violated this violently: at high curvature the
+/// object escaped the lateral band and everything was admitted.)
+#[test]
+fn tighter_curvature_never_admits_a_higher_speed() {
+    let radii = [f64::INFINITY, 200.0, 100.0, 50.0, 25.0]; // increasing curvature
+    let mut prev = f64::INFINITY;
+    for r in radii {
+        let max_ok = max_admitted_speed(r);
+        assert!(
+            max_ok <= prev + 1e-9,
+            "admissible speed must be non-increasing in curvature: r={r} admitted {max_ok} \
+             m/s after {prev} m/s at the previous (straighter) radius"
+        );
+        assert!(
+            max_ok > 0.0,
+            "sanity: some speed must be admitted at r={r} (the object is 35 m out)"
+        );
+        prev = max_ok;
+    }
+}
+
+proptest! {
+    /// STRAIGHT-LINE EQUIVALENCE (the EP-08 property): on straight corridors —
+    /// arbitrary offset, width, length, and small boundary vertex noise below
+    /// the straightness epsilon — the curved machinery never engages, and the
+    /// full validator's verdict is IDENTICAL to the tangent-frame result for
+    /// arbitrary scenes. (The curved branch is keyed on `is_effectively_straight`,
+    /// so this pins both the detector and the verdict.)
+    #[test]
+    fn straight_corridors_never_engage_the_curved_path_and_verdicts_match(
+        lane_y in -20.0f64..20.0,
+        half_w in 3.0f64..8.0,
+        len in 60.0f64..150.0,
+        v in 1.0f64..20.0,
+        obj_x in 5.0f64..50.0,
+        obj_y_off in -6.0f64..6.0,
+        obj_vx in -10.0f64..10.0,
+        obj_vy in -3.0f64..3.0,
+    ) {
+        let corridor = PolyCorridor {
+            left:  vec![Point { x_m: 0.0, y_m: lane_y + half_w }, Point { x_m: len, y_m: lane_y + half_w }],
+            right: vec![Point { x_m: 0.0, y_m: lane_y - half_w }, Point { x_m: len, y_m: lane_y - half_w }],
+        };
+        // The detector must classify it straight (the curved path never engages).
+        let f = CenterlineFrenet::from_boundaries(corridor.left_boundary(), corridor.right_boundary())
+            .expect("straight corridor is non-degenerate");
+        prop_assert!(f.is_effectively_straight());
+
+        // Full-validator determinism/equivalence: the verdict on the straight
+        // corridor equals the verdict on a 16-vertex resampling of the SAME
+        // straight geometry (different polyline representation, same lane) —
+        // the representation must not change the result.
+        let dense_ring = |y: f64| -> Vec<Point> {
+            (0..16).map(|i| Point { x_m: len * i as f64 / 15.0, y_m: y }).collect()
+        };
+        let dense = PolyCorridor { left: dense_ring(lane_y + half_w), right: dense_ring(lane_y - half_w) };
+
+        let traj: Vec<TrajectoryPoint> = (0..21)
+            .map(|i| {
+                let t = i as f64 * 0.1;
+                TrajectoryPoint {
+                    // Start 5 m in so the rear overhang stays inside the lane.
+                    pose: Pose { x_m: 5.0 + v * t, y_m: lane_y, heading_rad: 0.0 },
+                    velocity_mps: v,
+                    time_from_start_s: t,
+                }
+            })
+            .collect();
+        let obj = PerceivedObject {
+            id: 3,
+            pos: Point { x_m: obj_x, y_m: lane_y + obj_y_off },
+            velocity_mps: (obj_vx * obj_vx + obj_vy * obj_vy).sqrt(),
+            heading_rad: obj_vy.atan2(obj_vx),
+            vel: Point { x_m: obj_vx, y_m: obj_vy },
+        };
+
+        let v1 = validate_trajectory_slow(&traj, &corridor, std::slice::from_ref(&obj), &urban(), None, FleetPosture::Nominal);
+        let v2 = validate_trajectory_slow(&traj, &dense, std::slice::from_ref(&obj), &urban(), None, FleetPosture::Nominal);
+        prop_assert_eq!(v1, v2, "straight-lane verdict must not depend on the polyline representation");
+    }
+}

--- a/crates/kirra-trajectory/tests/validation_tests.rs
+++ b/crates/kirra-trajectory/tests/validation_tests.rs
@@ -1,4 +1,4 @@
-// crates/kirra-ros2-adapter/tests/validation_tests.rs
+// crates/kirra-trajectory/tests/validation_tests.rs
 //
 // S131 Phase 2A — integration tests for the slow-loop validator.
 //
@@ -8,7 +8,7 @@
 // the corridor seam (Phase 2B replaces it with the real
 // Lanelet2CorridorSource).
 
-use kirra_ros2_adapter::{
+use kirra_trajectory::{
     config::VehicleConfig,
     corridor::{MockCorridorSource, Point},
     state::{PerceivedObject, Pose, TrajectoryPoint, TrajectoryVerdict},
@@ -654,18 +654,9 @@ fn degraded_with_corridor_breach_still_mrcs() {
         "Degraded + corridor breach must still MRC — most-restrictive-wins; got {verdict:?}");
 }
 
-#[test]
-fn nominal_behavior_matches_prior_default() {
-    // Regression: every prior test in this file passed Nominal explicitly
-    // (above). This test pins the rule that Nominal is the construction
-    // default for `AdaptorState::current_posture` — until M1b wires a
-    // live posture source, the slow-loop verdict is byte-for-byte the
-    // pre-M1 behaviour.
-    use kirra_ros2_adapter::state::AdaptorState;
-    let state = AdaptorState::new();
-    assert_eq!(state.current_posture(), FleetPosture::Nominal,
-        "AdaptorState must default to Nominal so pre-M1 callers see no behaviour change");
-}
+// (`nominal_behavior_matches_prior_default` — the AdaptorState construction-
+// default pin — stays in the adapter crate: `AdaptorState` is adapter-LOCAL,
+// so it lives in `kirra-ros2-adapter/tests/adaptor_state_default.rs`.)
 
 // ---------------------------------------------------------------------------
 // 7. H2 + M1 reconciliation — the proof test
@@ -728,7 +719,7 @@ fn nominal_posture_clamps_above_odd_cap_to_22_35() {
 // Limited-visibility / occlusion bound (RSS Rule 4)
 // ---------------------------------------------------------------------------
 
-use kirra_ros2_adapter::validation::validate_trajectory_slow_capped;
+use kirra_trajectory::validation::validate_trajectory_slow_capped;
 
 /// A decel-to-stop straight trajectory: starts at `v0`, brakes at `decel` to 0,
 /// then holds. Stays at y=0 from x=5 (inside the corridor).
@@ -824,7 +815,7 @@ fn occlusion_admits_a_decel_to_stop_within_visibility() {
 // Multi-modal predictive RSS (space-time over predicted modes)
 // ---------------------------------------------------------------------------
 
-use kirra_ros2_adapter::validation::{PredictedMode, PredictedSample};
+use kirra_trajectory::validation::{PredictedMode, PredictedSample};
 
 /// Build a predicted mode: an object moving in a straight line from `(x0,y0)` at
 /// `(vx,vy)` m/s, sampled every 0.5 s over `horizon_s`.
@@ -1167,7 +1158,7 @@ fn predictive_rss_catches_a_mid_band_lateral_cut_in() {
 // perceived objects into modes the checker then acts on — the bridge that makes the multi-modal
 // pass run against real perception instead of dormant `None`.
 
-use kirra_ros2_adapter::prediction::predicted_modes_from_objects;
+use kirra_trajectory::prediction::predicted_modes_from_objects;
 
 fn perceived(id: u64, x: f64, y: f64, vx: f64, vy: f64) -> PerceivedObject {
     PerceivedObject {
@@ -1542,8 +1533,8 @@ fn in_place_rotation_seq(omegas: &[f64], dt: f64) -> Vec<TrajectoryPoint> {
 }
 
 /// Ego odometry snapshot carrying a current yaw rate (linear stopped).
-fn odom_yaw(yaw_rate_rads: f64) -> kirra_ros2_adapter::state::EgoOdom {
-    kirra_ros2_adapter::state::EgoOdom { linear_x_mps: 0.0, yaw_rate_rads, stamp_ms: 0 }
+fn odom_yaw(yaw_rate_rads: f64) -> kirra_trajectory::state::EgoOdom {
+    kirra_trajectory::state::EgoOdom { linear_x_mps: 0.0, yaw_rate_rads, stamp_ms: 0 }
 }
 
 #[test]

--- a/crates/kirra-trajectory/tests/validation_tests.rs
+++ b/crates/kirra-trajectory/tests/validation_tests.rs
@@ -1498,12 +1498,14 @@ fn predictive_overlap_gate_is_the_sole_reason_an_in_band_closing_mode_breaches()
     let corridor = MockCorridorSource::straight_5m_half_width(200.0);
     let cfg = VehicleConfig::default_urban();
     let ego = held_ego(10.0);
-    // Closing head-on: x decreases 13→9 over 1.0 s (≈4 m/s), y fixed at 2.0 →
-    // zero predicted lateral velocity.
+    // Closing head-on: x decreases 13→9 over 1.0 s (≈4 m/s), y fixed at 2.4 →
+    // zero predicted lateral velocity. |dy| = 2.4 sits in (lat_required ≈ 2.325,
+    // overlap 2.5): the predictive lateral branch does NOT fire, so the breach is
+    // the overlap gate's alone (a `< → ==`/`>` mutant on it stops the breach).
     let near_samples = [
-        PredictedSample { pos: Point { x_m: 13.0, y_m: 2.0 }, time_from_start_s: 0.0 },
-        PredictedSample { pos: Point { x_m: 11.0, y_m: 2.0 }, time_from_start_s: 0.5 },
-        PredictedSample { pos: Point { x_m: 9.0, y_m: 2.0 }, time_from_start_s: 1.0 },
+        PredictedSample { pos: Point { x_m: 13.0, y_m: 2.4 }, time_from_start_s: 0.0 },
+        PredictedSample { pos: Point { x_m: 11.0, y_m: 2.4 }, time_from_start_s: 0.5 },
+        PredictedSample { pos: Point { x_m: 9.0, y_m: 2.4 }, time_from_start_s: 1.0 },
     ];
     let near_modes = [PredictedMode { object_id: 1, samples: &near_samples }];
     let near = validate_trajectory_slow_capped(

--- a/crates/kirra-trajectory/tests/validation_tests.rs
+++ b/crates/kirra-trajectory/tests/validation_tests.rs
@@ -1447,6 +1447,85 @@ fn rss_conjunction_still_rejects_a_lateral_cut_in_at_a_safe_longitudinal_distanc
     }
 }
 
+#[test]
+fn snapshot_overlap_gate_is_the_sole_reason_an_in_band_closing_object_mrcs() {
+    // EP-08 per-class longitudinal-overlap gate (validation.rs:553):
+    //   `dy_ego.abs() < rss_longitudinal_overlap_m && lon_unsafe → MRCFallback`.
+    // An object INSIDE the overlap band (|dy| = 2.0 m < 2.5 m) but BEYOND the
+    // lateral safe distance, closing HEAD-ON (purely longitudinal, no lateral
+    // cut-in), against a STOPPED ego (whose stationary-ego lateral required gap
+    // ≈ 1.26 m < 2.0 m, so the lateral branch does not fire) is MRC'd ONLY by
+    // this gate. A `< → ==` / `< → >` comparison mutant stops the MRC. Two
+    // controls make the gate the provable sole cause:
+    //   (a) the SAME object placed longitudinally FAR is admitted — nothing
+    //       else about the geometry MRCs it;
+    //   (b) at the SAME near geometry but NOT closing (stationary object,
+    //       `lon_unsafe` false), it is admitted — proving the lateral branch
+    //       does not fire at 2.0 m offset, so the closing-case MRC is the gate.
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let ego = held_ego(10.0); // stopped ego → stationary-ego lateral form
+    let closing = |x: f64| PerceivedObject {
+        id: 7,
+        pos: Point { x_m: x, y_m: 2.0 },
+        velocity_mps: 6.0,
+        heading_rad: std::f64::consts::PI, // facing −X: head-on, no lateral component
+        vel: Point { x_m: -6.0, y_m: 0.0 },
+    };
+    // NEAR + closing (dx = 3 m, longitudinally unsafe) → MRC via the gate.
+    let near = validate_trajectory_slow(&ego, &corridor, &[closing(13.0)], &cfg, None, FleetPosture::Nominal);
+    assert_eq!(near, TrajectoryVerdict::MRCFallback,
+        "an in-band (2.0<2.5), head-on-closing object must MRC via the overlap gate; got {near:?}");
+    // (a) FAR + closing (dx = 60 m, longitudinally safe) → admitted.
+    let far = validate_trajectory_slow(&ego, &corridor, &[closing(70.0)], &cfg, None, FleetPosture::Nominal);
+    assert!(matches!(far, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "the same object 60 m away must be admitted; got {far:?}");
+    // (b) NEAR but stationary (not closing) → admitted: the lateral branch does
+    // not fire at a 2.0 m offset, so only the closing-case gate MRCs.
+    let near_still = validate_trajectory_slow(&ego, &corridor, &[stopped_object(13.0, 2.0)], &cfg, None, FleetPosture::Nominal);
+    assert!(matches!(near_still, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "a stationary in-band object at 2.0 m offset must be admitted (no lateral MRC); got {near_still:?}");
+}
+
+#[test]
+fn predictive_overlap_gate_is_the_sole_reason_an_in_band_closing_mode_breaches() {
+    // The predictive twin of the snapshot gate (validation.rs:911) — the same
+    // `dy_ego.abs() < rss_longitudinal_overlap_m && lon_unsafe` comparison, over
+    // a predicted MODE. A mode closing HEAD-ON at |dy| = 2.0 m (in-band, beyond
+    // the stopped-ego lateral gap, no predicted lateral motion) breaches ONLY
+    // via this gate; a `< → ==` / `< → >` / `< → <=`-off mutant stops the breach.
+    // Control: the same mode kept longitudinally FAR is admitted.
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let ego = held_ego(10.0);
+    // Closing head-on: x decreases 13→9 over 1.0 s (≈4 m/s), y fixed at 2.0 →
+    // zero predicted lateral velocity.
+    let near_samples = [
+        PredictedSample { pos: Point { x_m: 13.0, y_m: 2.0 }, time_from_start_s: 0.0 },
+        PredictedSample { pos: Point { x_m: 11.0, y_m: 2.0 }, time_from_start_s: 0.5 },
+        PredictedSample { pos: Point { x_m: 9.0, y_m: 2.0 }, time_from_start_s: 1.0 },
+    ];
+    let near_modes = [PredictedMode { object_id: 1, samples: &near_samples }];
+    let near = validate_trajectory_slow_capped(
+        &ego, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&near_modes), None, FrameTrust::Trusted,
+    );
+    assert_eq!(near, TrajectoryVerdict::MRCFallback,
+        "an in-band, head-on-closing predicted mode must breach via the overlap gate; got {near:?}");
+    // Control: same closing motion but far ahead (x 63→59) → longitudinally
+    // safe, admitted.
+    let far_samples = [
+        PredictedSample { pos: Point { x_m: 63.0, y_m: 2.0 }, time_from_start_s: 0.0 },
+        PredictedSample { pos: Point { x_m: 61.0, y_m: 2.0 }, time_from_start_s: 0.5 },
+        PredictedSample { pos: Point { x_m: 59.0, y_m: 2.0 }, time_from_start_s: 1.0 },
+    ];
+    let far_modes = [PredictedMode { object_id: 1, samples: &far_samples }];
+    let far = validate_trajectory_slow_capped(
+        &ego, &corridor, &[], &cfg, None, FleetPosture::Nominal, None, None, Some(&far_modes), None, FrameTrust::Trusted,
+    );
+    assert!(matches!(far, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "the same mode far ahead must be admitted; got {far:?}");
+}
+
 // ---------------------------------------------------------------------------
 // ADR-0029 — courier angular (yaw-rate) channel
 // ---------------------------------------------------------------------------

--- a/docs/testing/MUTATION_BASELINE.md
+++ b/docs/testing/MUTATION_BASELINE.md
@@ -105,3 +105,33 @@ case leans on; they are NOT evidence the code is wrong.
 4. Re-baseline (full run, both scopes recorded) after each wave of kills;
    parko-core's RSS primitives are the next crate to bring under the gate
    (separate workspace — needs its own lane scope).
+
+## 6. Accepted EQUIVALENT mutants — EP-08 curved-RSS geometry (`frenet.rs`)
+
+The EP-08 curved-geometry Frenet frame added `src/frenet.rs` plus the
+per-class longitudinal-overlap gate. Its arithmetic — projection, tangent,
+heading-change, both RSS reference frames, the overlap gate on BOTH the
+snapshot and predictive paths — is pinned by exact value tests
+(`frenet.rs` unit tests + `validation.rs::rss_frame_tests` +
+`validation_tests.rs::{snapshot,predictive}_overlap_gate_*`); the `--in-diff`
+gate confirmed those mutants die. What remains are a small set of **provably
+equivalent** mutants that no test can kill because they do not change
+observable behaviour. Per policy §3.3 (accept-with-reason only when the
+mutation is behaviour-preserving), they are excluded in `.cargo/mutants.toml`
+with a written justification:
+
+| Mutant class | Location | Why equivalent |
+|---|---|---|
+| Duplicate-midpoint collapse predicate (`<`→`==`/`<=`/`>`) and its coordinate subtraction (`-`→`+`/`/`) | `CenterlineFrenet::from_boundaries` | The collapse only drops a zero-length centerline segment; `project`, `tangent_at` and `total_heading_change_rad` all already skip a zero-length segment, so every corridor the resampler can produce yields byte-identical output with or without the collapse. |
+| Nearest-segment retention `dist2 < best` → `<=` | `CenterlineFrenet::project` | Differs only when two segments are exactly equidistant, where both choices return the same `(s, d)`. |
+| Per-class overlap gate `|dy| < overlap` → `<=` | `validate_trajectory_slow_capped` (:553), `predictive_rss_breach` (:911) | Strict-vs-nonstrict on a float comparison differs only at exact bit-equality `|dy| == overlap` — a measure-zero boundary, behaviourally identical for any real input. |
+
+Other EP-08 equivalent mutants were **removed at the source** rather than
+excluded: two redundant length pre-checks (`left.len() < 2 || right.len() < 2`
+and `pts.len() < 2`) whose job `cumulative_arc` already does fail-closed (a
+polyline with < 2 vertices, or a fully-collapsed centerline, has zero total
+length → `None`); the length normalization in `total_heading_change_rad` (the
+`atan2(cross, dot)` turn angle is invariant to the segment-vector magnitudes);
+and the duplicated Err-branch `.min(len - 2)` segment-index clamp in
+`sample_at_fraction` / `tangent_at` (unified to one reachable site). These
+simplifications delete the equivalent mutants instead of masking them.

--- a/parko/crates/parko-core/src/rss.rs
+++ b/parko/crates/parko-core/src/rss.rs
@@ -858,8 +858,6 @@ mod tests {
         }
     }
 
-    /// A negative or non-finite `mu` fails safe (a margin must only ever ADD).
-    #[test]
     /// The stationary-ego form is exactly the split form minus the
     /// zero-velocity ego term (the response-phase swerve + its braking tail).
     #[test]
@@ -897,6 +895,8 @@ mod tests {
         );
     }
 
+    /// A negative or non-finite `mu` fails safe (a margin must only ever ADD).
+    #[test]
     fn test_lat_split_negative_mu_is_failsafe() {
         for bad in [-0.1, f64::NAN, f64::NEG_INFINITY] {
             assert_eq!(

--- a/parko/crates/parko-core/src/rss.rs
+++ b/parko/crates/parko-core/src/rss.rs
@@ -230,6 +230,53 @@ pub fn lateral_safe_distance_split(
     margin.max(0.0)
 }
 
+/// [`lateral_safe_distance_split`] for a **provably stationary ego** — the
+/// object's full worst-case lateral envelope plus the fluctuation margin, with
+/// the ego's hypothetical response-phase swerve term dropped.
+///
+/// Rationale (EP-08, the stopped-pose rule): the split form charges the ego a
+/// response-phase drift (`a·ρ²/2` + its braking tail) even at zero lateral
+/// velocity — the worst case for a vehicle whose future motion is UNKNOWN. A
+/// trajectory checker evaluating a pose at which the committed trajectory is
+/// STOPPED knows that hypothesis is false: a stationary vehicle drifts
+/// nowhere, and per RSS responsibility (Shalev-Shwartz §3.4) it has completed
+/// its proper response — only the OBJECT's closing envelope can create the
+/// conflict. Dropping the ego term is therefore not a relaxation of the
+/// object's bound: a cut-in that can reach the stopped ego is still rejected
+/// (its own reaction + brake envelope and `mu` are charged in full).
+///
+/// Same fail-closed guards as the split form; conservativeness relation:
+/// `stationary_ego(obj, …) <= split(0.0, obj, …)` on every valid input (the
+/// difference is exactly the zero-velocity ego term), property-tested below.
+// SAFETY: SG1 SG9 | REQ: rss-lateral-stationary-ego-failsafe | TEST: test_lat_stationary_ego_is_split_minus_ego_term,test_lat_stationary_ego_invalid_params_failsafe
+pub fn lateral_safe_distance_split_stationary_ego(
+    obj_lat_vel: f64,
+    lat_accel_max: f64,
+    lat_brake_min: f64,
+    reaction_time: f64,
+    mu_lateral_m: f64,
+) -> f64 {
+    if !(finite_positive(lat_accel_max)
+        && finite_positive(lat_brake_min)
+        && obj_lat_vel.is_finite()
+        && reaction_time.is_finite()
+        && reaction_time >= 0.0
+        && mu_lateral_m.is_finite()
+        && mu_lateral_m >= 0.0)
+    {
+        return RSS_FAILSAFE_DISTANCE_M;
+    }
+    let v = obj_lat_vel.abs();
+    let d_reaction = v * reaction_time + 0.5 * lat_accel_max * reaction_time.powi(2);
+    let v_after = v + lat_accel_max * reaction_time;
+    let d_brake = v_after.powi(2) / (2.0 * lat_brake_min);
+    let margin = d_reaction + d_brake + mu_lateral_m;
+    if !margin.is_finite() {
+        return RSS_FAILSAFE_DISTANCE_M;
+    }
+    margin.max(0.0)
+}
+
 /// Computes the longitudinal RSS safe-distance per IEEE 2846-2022 §5.1.
 ///
 /// Returns the minimum required gap (metres) between ego and lead vehicle.
@@ -813,6 +860,43 @@ mod tests {
 
     /// A negative or non-finite `mu` fails safe (a margin must only ever ADD).
     #[test]
+    /// The stationary-ego form is exactly the split form minus the
+    /// zero-velocity ego term (the response-phase swerve + its braking tail).
+    #[test]
+    fn test_lat_stationary_ego_is_split_minus_ego_term() {
+        for obj_v in [0.0, 0.5, 1.5, 4.0] {
+            let (a, b, rho, mu) = (3.5, 2.45, 0.5, 0.2);
+            let split = lateral_safe_distance_split(0.0, obj_v, a, b, rho, mu);
+            let stationary = lateral_safe_distance_split_stationary_ego(obj_v, a, b, rho, mu);
+            let ego_zero_term = 0.5 * a * rho * rho + (a * rho) * (a * rho) / (2.0 * b);
+            assert!(
+                (split - stationary - ego_zero_term).abs() < 1e-12,
+                "obj_v={obj_v}: split {split} - stationary {stationary} != ego term {ego_zero_term}"
+            );
+            assert!(stationary <= split, "never larger than the split form");
+        }
+    }
+
+    #[test]
+    fn test_lat_stationary_ego_invalid_params_failsafe() {
+        assert_eq!(
+            lateral_safe_distance_split_stationary_ego(f64::NAN, 3.5, 2.45, 0.5, 0.2),
+            RSS_FAILSAFE_DISTANCE_M
+        );
+        assert_eq!(
+            lateral_safe_distance_split_stationary_ego(1.0, 0.0, 2.45, 0.5, 0.2),
+            RSS_FAILSAFE_DISTANCE_M
+        );
+        assert_eq!(
+            lateral_safe_distance_split_stationary_ego(1.0, 3.5, 2.45, -0.1, 0.2),
+            RSS_FAILSAFE_DISTANCE_M
+        );
+        assert_eq!(
+            lateral_safe_distance_split_stationary_ego(1.0, 3.5, 2.45, 0.5, -0.2),
+            RSS_FAILSAFE_DISTANCE_M
+        );
+    }
+
     fn test_lat_split_negative_mu_is_failsafe() {
         for bad in [-0.1, f64::NAN, f64::NEG_INFINITY] {
             assert_eq!(


### PR DESCRIPTION
Delivers Milestone 3 of `docs/analysis/ENGINEERING_EXECUTION_PROGRAM.md` — the certification-evidence work packages, one bounded commit per EP.

## EP-16 — Miri lane (`94fd625`)

New `miri` CI job checks the `unsafe` seqlock boundaries against the Rust memory model: `kirra-contract-channel` runs the full suite under Miri plus a `-Zmiri-many-seeds=0..16` sweep of the concurrent torn-read test (iteration count scaled under `cfg(miri)` so the sweep stays fast). `kirra-hv-carrier` is excluded with the reason recorded in the job: Miri cannot interpret the `shm_open` FFI — its unsafety is exercised by the cross-process tests and the EP-01 demo instead.

## EP-07 — gated decision-coverage floors; true MC/DC recorded as toolchain-blocked (`8b76350`, closes the #65 investigation)

The spike result: current nightly rejects `-Zcoverage-options=mcdc` (`block | branch | condition` only) — true MC/DC is blocked on **every** Rust toolchain today, recorded on #65. What ships instead:

- `checker-coverage` CI job: **gated** decision-coverage floors for the certification-relevant checker crates (`kirra-trajectory` 78%, `kirra-core` 79%, `parko-core` 77%) — the workspace `coverage` job uploads but never gated.
- Auto-upgrade path: each run attempts `--mcdc` first and falls back to branch coverage; `ci/check_decision_floor.py` gates on the strongest metric present in the llvm-cov export, so the lane upgrades itself the day rustc restores MC/DC instrumentation.

## EP-08 — curved-geometry RSS (`1ee8890`, `291a9cf`, `94b996c`)

Removes a known unsound simplification: RSS previously evaluated longitudinal/lateral gaps in the trajectory point's **tangent frame**, so an in-lane object around a bend could read as laterally clear (fail-open) and an out-of-lane object on the tangent line as a conflict (over-rejection).

- New `crates/kirra-trajectory/src/frenet.rs`: corridor-centerline arc-length frame (`CenterlineFrenet` — matched-fraction boundary resampling, nearest-segment projection to signed left-positive offset, straightness detector at ≤ 0.01 rad total heading change).
- `validation.rs` §C resolves each ego-pose/object pair in the Frenet frame when the corridor is genuinely curved, with a **per-pair fallback** to the verbatim tangent-frame math (`rss_tangent_frame` is the old expressions expression-for-expression) — the straight-lane WCET-critical path is preserved bit-for-bit, proptest-proven (`straight_corridors_never_engage_the_curved_path_and_verdicts_match`).
- The fixed 2.5 m longitudinal-overlap band becomes per-class: `VehicleConfig::rss_longitudinal_overlap_m` (robotaxi 2.5 verbatim, delivery-AV 2.0, courier 0.6 — behavior-preserving defaults).
- The curved frame surfaced a real over-rejection: a **stopped** pose behind a crosser it had already yielded to was rejected by the ego's hypothetical response-phase swerve term — falsified by the committed zero-velocity trajectory. New `parko_core::rss::lateral_safe_distance_split_stationary_ego` drops only the ego response-phase term (object's full closing envelope + μ retained, same fail-closed guards); the held-ego cut-in pins still reject at 0.3 m.
- New `tests/curved_rss.rs`: the headline fail-open scenario (in-lane object around a bend rejected, with the chord-skip precondition asserted), the tangent-line over-rejection scenario, curvature monotonicity (tighter curve ⇒ never-higher admitted speed across radii ∞→25 m), the stopped-pose yield scenario, and the equivalence proptest.

## EP-09 — RSS constants provenance & sign-off gate (`52b063f`)

Every VALIDATION-PENDING safety constant is now either signed off with recorded provenance or mechanically visible as pending — no silent placeholder can reach a release.

- `ci/safety_constants_manifest.json`: 19 checker safety constants (kirra-trajectory RSS terms incl. the EP-08 additions, redundancy tolerances, CTRV bounds, VRU caps, parko-core RSS windows) pinned as name → file → declared value → status ∈ {validated, pending} → provenance → owner. All `pending` today, per the program.
- `ci/check_safety_constants.py`: fails on a value/manifest mismatch (a retune cannot land without re-signing the manifest in the same diff), a moved/renamed constant, or a `validated` entry without recorded provenance/owner. Under `KIRRA_RELEASE_GATE=1` any `pending` entry fails the build.
- New `safety-constants` CI job: default-mode gate + a red-path self-test proving the release arm actually blocks while pending entries exist (inverts to asserting release-green once all are signed off).

## Verification

- Full root-workspace test sweep: 0 FAILED; `parko` workspace green (OpenVINO job runs in its dedicated CI lane).
- EP-09 gate: all red paths exercised locally (mismatched value / release-with-pending / validated-without-provenance / renamed-away constant → exit 1); green default and all-validated-release → exit 0.
- Clippy + rustdoc (`-D warnings`) clean on touched crates; mutation-gate pins retuned where the refined lateral formula moved thresholds (parameters remain load-bearing).

## Out of scope

- The sign-offs themselves (EP-09 makes the external dependency visible; a safety engineer records each `validated` entry).
- EP-14 (iceoryx2 production path) stays deferred — DoD needs Orin hardware.
- Next per the program: M4 (EP-10 live Postgres, EP-12 Config Slice B, EP-13 Uptane orchestration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_