### PR TITLE
rss: NaN-production-free longitudinal_safe_distance — fixes the blocking kani lane (main is red)

### DIFF
--- a/parko/crates/parko-core/src/rss.rs
+++ b/parko/crates/parko-core/src/rss.rs
@@ -334,12 +334,46 @@ pub fn longitudinal_safe_distance(
         return RSS_FAILSAFE_DISTANCE_M;
     }
 
-    let d_response = ego_vel * reaction_time + 0.5 * accel_max * reaction_time.powi(2);
-    let v_after = ego_vel + accel_max * reaction_time;
+    // NO-TRANSIENT-NAN DISCIPLINE. Extreme-but-finite inputs can overflow an
+    // intermediate term to ±Inf, and `Inf + -Inf` / `Inf - Inf` would transit
+    // through NaN before a final finiteness check caught it. The previous
+    // shape was still fail-closed (a NaN `raw` is non-finite → failsafe), but
+    // the NaN *production* itself is now guarded away: every addition or
+    // subtraction below happens only after its operands are proven finite
+    // (products/divisions of finite operands — with the divisors guarded
+    // finite-positive above — yield ±Inf at worst, never NaN). Output is
+    // identical for every input; the property "this function never forms a
+    // NaN" is what the Kani R1/R2 harnesses machine-check.
+    let rt2 = reaction_time.powi(2);
+    if !rt2.is_finite() {
+        // finite² can overflow to +Inf; guarded here so the products below
+        // are finite×finite (0 × Inf would be the one product-formed NaN).
+        return RSS_FAILSAFE_DISTANCE_M;
+    }
+    let d_react = ego_vel * reaction_time;
+    let d_accel = 0.5 * accel_max * rt2;
+    if !(d_react.is_finite() && d_accel.is_finite()) {
+        return RSS_FAILSAFE_DISTANCE_M;
+    }
+    let d_response = d_react + d_accel;
+
+    let v_gain = accel_max * reaction_time;
+    if !(v_gain.is_finite() && d_response.is_finite()) {
+        return RSS_FAILSAFE_DISTANCE_M;
+    }
+    let v_after = ego_vel + v_gain;
     let d_brake_ego = v_after.powi(2) / (2.0 * brake_min);
     let d_brake_lead = lead_vel.powi(2) / (2.0 * brake_max);
+    if !(d_brake_ego.is_finite() && d_brake_lead.is_finite()) {
+        return RSS_FAILSAFE_DISTANCE_M;
+    }
 
-    let raw = d_response + d_brake_ego - d_brake_lead;
+    let sum = d_response + d_brake_ego;
+    if !sum.is_finite() {
+        // finite + finite can still overflow to ±Inf (never NaN); fail closed.
+        return RSS_FAILSAFE_DISTANCE_M;
+    }
+    let raw = sum - d_brake_lead;
     if !raw.is_finite() {
         return RSS_FAILSAFE_DISTANCE_M;
     }

--- a/parko/crates/parko-core/src/rss.rs
+++ b/parko/crates/parko-core/src/rss.rs
@@ -344,7 +344,12 @@ pub fn longitudinal_safe_distance(
     // finite-positive above — yield ±Inf at worst, never NaN). Output is
     // identical for every input; the property "this function never forms a
     // NaN" is what the Kani R1/R2 harnesses machine-check.
-    let rt2 = reaction_time.powi(2);
+    // Spelled `x * x` (not `.powi(2)`) so the Kani/CBMC proof of this
+    // function models a plain IEEE multiplication instead of the loop-based
+    // `__builtin_powi` over-approximation, whose under-constrained result
+    // admits spurious monotonicity counterexamples (R2). Bit-identical on
+    // hardware: LLVM lowers `powi(2)` to a single `fmul`.
+    let rt2 = reaction_time * reaction_time;
     if !rt2.is_finite() {
         // finite² can overflow to +Inf; guarded here so the products below
         // are finite×finite (0 × Inf would be the one product-formed NaN).
@@ -371,8 +376,8 @@ pub fn longitudinal_safe_distance(
     // `raw` was NaN → failsafe — fails closed directly. Divisors are
     // finite-positive-nonzero when used, so 0/0 is impossible and a finite
     // division never forms NaN.
-    let v_after_sq = v_after.powi(2); // ±Inf² → +Inf; never NaN
-    let lead_sq = lead_vel.powi(2); // finite² → +Inf at worst; never NaN
+    let v_after_sq = v_after * v_after; // ±Inf² → +Inf; never NaN
+    let lead_sq = lead_vel * lead_vel; // finite² → +Inf at worst; never NaN
     let twice_brake_min = 2.0 * brake_min;
     let twice_brake_max = 2.0 * brake_max;
     let d_brake_ego = if twice_brake_min.is_finite() {

--- a/parko/crates/parko-core/src/rss.rs
+++ b/parko/crates/parko-core/src/rss.rs
@@ -362,8 +362,33 @@ pub fn longitudinal_safe_distance(
         return RSS_FAILSAFE_DISTANCE_M;
     }
     let v_after = ego_vel + v_gain;
-    let d_brake_ego = v_after.powi(2) / (2.0 * brake_min);
-    let d_brake_lead = lead_vel.powi(2) / (2.0 * brake_max);
+
+    // The one NaN a division can form here is Inf/Inf: the squared numerator
+    // AND the doubled denominator can each overflow to +Inf independently
+    // (review catch on the first cut of this restructure). Divide only when
+    // the divisor is finite; a divisor that overflowed (an absurdly strong
+    // brake) keeps the old finite/Inf → 0 flush, and Inf/Inf — whose old
+    // `raw` was NaN → failsafe — fails closed directly. Divisors are
+    // finite-positive-nonzero when used, so 0/0 is impossible and a finite
+    // division never forms NaN.
+    let v_after_sq = v_after.powi(2); // ±Inf² → +Inf; never NaN
+    let lead_sq = lead_vel.powi(2); // finite² → +Inf at worst; never NaN
+    let twice_brake_min = 2.0 * brake_min;
+    let twice_brake_max = 2.0 * brake_max;
+    let d_brake_ego = if twice_brake_min.is_finite() {
+        v_after_sq / twice_brake_min
+    } else if v_after_sq.is_finite() {
+        0.0
+    } else {
+        return RSS_FAILSAFE_DISTANCE_M;
+    };
+    let d_brake_lead = if twice_brake_max.is_finite() {
+        lead_sq / twice_brake_max
+    } else if lead_sq.is_finite() {
+        0.0
+    } else {
+        return RSS_FAILSAFE_DISTANCE_M;
+    };
     if !(d_brake_ego.is_finite() && d_brake_lead.is_finite()) {
         return RSS_FAILSAFE_DISTANCE_M;
     }

--- a/verification/kani/src/proofs_rss.rs
+++ b/verification/kani/src/proofs_rss.rs
@@ -65,6 +65,12 @@ mod proofs {
     /// is the precondition `occlusion_limited_speed`'s bisection relies on
     /// (`lead_vel = 0`, exactly its call shape).
     #[kani::proof]
+    // kissat: with the squares now spelled as exact IEEE multiplications
+    // (rss.rs dropped `__builtin_powi`, whose cheap over-approximation both
+    // admitted a spurious counterexample AND made this relational two-
+    // evaluation proof artificially easy), the default CaDiCaL run exceeds
+    // the CI job timeout. Kissat solves this instance class far faster.
+    #[kani::solver(kissat)]
     fn r2_longitudinal_monotone_in_closing_speed_on_grid() {
         let v1_raw: u16 = kani::any();
         let v2_raw: u16 = kani::any();


### PR DESCRIPTION
**`main` is currently red** on exactly one job — `Kani proofs (EP-15, blocking; install-flake tolerated)` — since #885 merged (run 29057553064). This PR fixes it forward.

## What failed

`r1_longitudinal_totality_full_domain` and `r2_longitudinal_monotone_in_closing_speed_on_grid` fail on kani 0.67.0 with **"NaN on subtraction"** at `parko/crates/parko-core/src/rss.rs:342`:

```
let raw = d_response + d_brake_ego - d_brake_lead;
```

Extreme-but-finite inputs (R1 is full-domain) overflow an intermediate term to ±Inf, and `Inf − Inf` transits through NaN before the next line's `raw.is_finite()` failsafe catches it. The **shipped behavior was fail-closed** — a NaN `raw` returned `RSS_FAILSAFE_DISTANCE_M` — but CBMC flags the NaN *production*, not just its escape.

## Why it surfaced now (two compounding facts)

1. The lane flipped to **blocking** in #885 (L5).
2. The L5 flip's run-history evidence was weaker than claimed: a `continue-on-error` step reports `conclusion: success` in the jobs API **even when it failed**, so the "proofs passed on main" verification read the post-override conclusion. The proofs may have been failing under the non-blocking mask for some time (the CI install is also unpinned — `cargo install kani-verifier` takes latest — so a kani-strictness bump is a possible trigger). Either way: the finding is real and worth keeping, so **fix the code, don't unflip the lane**.

## The fix

Restructure the arithmetic so **no operation can form a NaN** (audited op-by-op):
- `reaction_time²` guarded finite before any product — kills the one `0 × Inf` product case;
- every addition/subtraction's operands guarded finite first (finite arithmetic yields ±Inf at worst, never NaN);
- the overflow-to-Inf failsafe checks stay.

**Output-identical for every input**: each new early-failsafe path corresponds to an input whose `raw` was already non-finite → failsafe under the old shape. Fail-closed semantics, `SAFETY: SG1 SG9` traceability tags, and test names unchanged.

## Verification

- parko-core: **284 tests green** (47 rss unit tests + 3 rss proptests among them), fmt clean.
- Kani **mirror tier: 113 green** (the blocking concrete mirrors of every property).
- The CBMC proofs could not be run in the dev container (the egress proxy 403s the kani release-bundle download — the same tolerated-install failure mode the CI lane anticipates). **This PR's kani-proofs job is the authoritative proof run** — please check it shows `12 successfully verified harnesses, 0 failures` before merging.

Unblocks #886 (and every open PR — the lane is blocking for all of them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_