### PR TITLE
ADR-0033 follow-up: consumer key enrollment, rotation order, loud key-mismatch alarm + Addendum A (clock coupling named)

### DIFF
--- a/crates/kirra-actuation-consumer/src/bin/kirra_consumer_ctl.rs
+++ b/crates/kirra-actuation-consumer/src/bin/kirra_consumer_ctl.rs
@@ -1,0 +1,113 @@
+//! kirra-consumer-ctl — operator CLI for the motor consumer's pinned
+//! governor verifying key (ADR-0033; the #891 key-distribution gap).
+//!
+//!   kirra-consumer-ctl enroll --key-hex <64-hex> --path <pin-file> [--rotate]
+//!   kirra-consumer-ctl show   --path <pin-file>
+//!
+//! `enroll` is idempotent (re-enrolling the same key succeeds without
+//! touching the file) and REFUSES to overwrite a different pin unless
+//! `--rotate` is explicit — changing which governor a consumer obeys must
+//! never happen silently. Rotation ORDER matters: re-enroll the consumer
+//! BEFORE the verifier signs under the new key, or the platform enters a
+//! permanent safe stop (loud, via the key-mismatch alarm) until re-enrolled.
+//! See docs/safety/GOVERNOR_KEY_PROVISIONING.md §7.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use kirra_actuation_consumer::enrollment::{
+    enroll_verifying_key, load_pinned_verifying_key, EnrollError, EnrollOutcome,
+};
+use kirra_release_token::ros_twist::verifying_key_id_hex;
+
+fn usage() -> &'static str {
+    "usage:\n  kirra-consumer-ctl enroll --key-hex <64-hex> --path <pin-file> [--rotate]\n  kirra-consumer-ctl show   --path <pin-file>"
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let result = match args.first().map(String::as_str) {
+        Some("enroll") => cmd_enroll(&args[1..]),
+        Some("show") => cmd_show(&args[1..]),
+        _ => Err(usage().to_string()),
+    };
+    match result {
+        Ok(msg) => {
+            println!("{msg}");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn flag_value(args: &[String], name: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == name)
+        .and_then(|i| args.get(i + 1).cloned())
+}
+
+fn cmd_enroll(args: &[String]) -> Result<String, String> {
+    let key_hex = flag_value(args, "--key-hex").ok_or_else(|| usage().to_string())?;
+    let path = PathBuf::from(flag_value(args, "--path").ok_or_else(|| usage().to_string())?);
+    let rotate = args.iter().any(|a| a == "--rotate");
+
+    match enroll_verifying_key(&path, &key_hex, rotate) {
+        Ok(EnrollOutcome::Enrolled { key_id }) => {
+            Ok(format!("ENROLLED key_id={key_id} path={}", path.display()))
+        }
+        Ok(EnrollOutcome::AlreadyEnrolled { key_id }) => Ok(format!(
+            "ALREADY-ENROLLED key_id={key_id} (idempotent; pin untouched)"
+        )),
+        Ok(EnrollOutcome::Rotated {
+            previous_key_id,
+            key_id,
+        }) => Ok(format!(
+            "ROTATED previous_key_id={previous_key_id} -> key_id={key_id}\n\
+             REMINDER: the verifier must not sign under the OLD key from here on; if the \
+             verifier is still on the old key, this consumer will refuse everything \
+             (loudly) until the verifier rotates too."
+        )),
+        Err(EnrollError::DifferentKeyPinned {
+            pinned_key_id,
+            offered_key_id,
+        }) => Err(format!(
+            "a DIFFERENT key is already pinned (pinned key_id={pinned_key_id}, offered \
+             key_id={offered_key_id}). Refusing to overwrite silently — if this is an \
+             intentional rotation, re-run with --rotate AND follow the rotation order in \
+             GOVERNOR_KEY_PROVISIONING.md §7 (consumer first, verifier second)."
+        )),
+        Err(EnrollError::ExistingPinUnreadable) => Err(
+            "the existing pin file does not parse as a key (tampering or corruption?). \
+             Investigate before replacing it; --rotate may overwrite it once you have."
+                .to_string(),
+        ),
+        Err(EnrollError::MalformedKey) => Err(
+            "--key-hex must be exactly 64 hex chars (the 32 Ed25519 public-key bytes) \
+             and a valid curve point"
+                .to_string(),
+        ),
+        Err(EnrollError::Io(e)) => Err(format!("filesystem: {e}")),
+    }
+}
+
+fn cmd_show(args: &[String]) -> Result<String, String> {
+    let path = PathBuf::from(flag_value(args, "--path").ok_or_else(|| usage().to_string())?);
+    match load_pinned_verifying_key(&path) {
+        Ok(vk) => Ok(format!(
+            "PINNED key_id={} path={}",
+            verifying_key_id_hex(&vk),
+            path.display()
+        )),
+        Err(EnrollError::Io(e)) => Err(format!(
+            "no readable pin at {} ({e}) — an unpinned consumer refuses every command",
+            path.display()
+        )),
+        Err(_) => Err(format!(
+            "pin at {} does not parse as a key — the consumer will refuse to start",
+            path.display()
+        )),
+    }
+}

--- a/crates/kirra-actuation-consumer/src/enrollment.rs
+++ b/crates/kirra-actuation-consumer/src/enrollment.rs
@@ -1,0 +1,284 @@
+//! Consumer verifying-key enrollment — closing the #891 key-distribution gap.
+//!
+//! The consumer admits only a **pinned** governor verifying key
+//! (`ADR-0033`; `RosReleaseGate::new` takes it by argument). This module is
+//! the ONE place that decides where that pin lives on a consumer and how it
+//! changes — the consumer-side sibling of
+//! `kirra_release_token::provisioning` (which owns the VERIFIER's signing
+//! key) and of `kirra-ota-ctl enroll` (which enrolls a node's attestation
+//! identity with the verifier).
+//!
+//! ## The rotation-order hazard this exists to manage
+//!
+//! Rotation must re-provision the consumer **before** the verifier signs
+//! under the new key. Done out of order, every command becomes
+//! `SignatureInvalid` → the liveness supervisor starves into the safe stop
+//! and stays there — a **permanent safe stop**. That outcome is fail-closed
+//! and safe; the paired defect would be muteness, which the consumer's
+//! key-mismatch alarm (`MotorConsumer::health`) exists to prevent. The
+//! documented order and the recovery procedure live in
+//! `docs/safety/GOVERNOR_KEY_PROVISIONING.md` §7.
+//!
+//! ## Pin file format and integrity model
+//!
+//! The pin is the PUBLIC key: exactly 64 lowercase hex chars (the 32
+//! Ed25519 public-key bytes) plus optional trailing newline. No secrecy is
+//! required — INTEGRITY is: whoever can write the pin decides which governor
+//! this consumer obeys. The file therefore belongs inside the same
+//! OS-ownership boundary as the serial device (ADR-0033 layer 2: dedicated
+//! user/group; the Tier-3 startup sentinel asserts the device node, and the
+//! pin should live in that user's config dir). Writes are atomic
+//! (temp file + rename in the same directory) so a torn write can never
+//! half-pin.
+//!
+//! ## First-provisioning assumption (reported per the task)
+//!
+//! `enroll` assumes an OPERATOR-AUTHENTICATED channel already exists to the
+//! consumer host (the same assumption `kirra-ota-ctl enroll` makes: you can
+//! run a CLI as the right user on the right machine). It does NOT bootstrap
+//! trust from nothing — a consumer with no pin refuses everything, and the
+//! first pin is only as trustworthy as the channel that delivered the key
+//! hex. Closing that (signed enrollment bundles / attested first-boot) is a
+//! tracked follow-up, not silently assumed away.
+
+use std::io::Write as _;
+use std::path::Path;
+
+use ed25519_dalek::VerifyingKey;
+use kirra_release_token::ros_twist::verifying_key_id_hex;
+
+/// What an enrollment attempt did. Every variant is explicit — there is no
+/// silent overwrite path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EnrollOutcome {
+    /// No pin existed; the key is now pinned.
+    Enrolled { key_id: String },
+    /// The exact same key was already pinned — idempotent success, file
+    /// untouched.
+    AlreadyEnrolled { key_id: String },
+    /// A DIFFERENT key was pinned and rotation was explicitly requested:
+    /// the pin now names the new key. `previous_key_id` is logged for the
+    /// audit trail.
+    Rotated {
+        previous_key_id: String,
+        key_id: String,
+    },
+}
+
+/// Why enrollment refused. Fail-closed: on any error the existing pin (if
+/// any) is untouched.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EnrollError {
+    /// The offered key hex is malformed (not 64 hex chars / not a valid
+    /// Ed25519 point).
+    MalformedKey,
+    /// A DIFFERENT key is already pinned and rotation was NOT requested.
+    /// This is the refuses-to-overwrite-silently arm: changing which
+    /// governor a consumer obeys must be an explicit act.
+    DifferentKeyPinned {
+        pinned_key_id: String,
+        offered_key_id: String,
+    },
+    /// A pin file exists but does not parse as a key. Refused without
+    /// `rotate` — an unreadable pin is evidence of tampering or corruption,
+    /// and silently replacing evidence is wrong. `rotate` may overwrite it.
+    ExistingPinUnreadable,
+    /// Filesystem failure (io error text attached for the operator).
+    Io(String),
+}
+
+fn parse_key_hex(key_hex: &str) -> Result<VerifyingKey, EnrollError> {
+    let t = key_hex.trim();
+    if t.len() != 64 || !t.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(EnrollError::MalformedKey);
+    }
+    let mut bytes = [0u8; 32];
+    for (i, chunk) in t.as_bytes().chunks(2).enumerate() {
+        let hi = (chunk[0] as char)
+            .to_digit(16)
+            .ok_or(EnrollError::MalformedKey)?;
+        let lo = (chunk[1] as char)
+            .to_digit(16)
+            .ok_or(EnrollError::MalformedKey)?;
+        bytes[i] = ((hi << 4) | lo) as u8;
+    }
+    VerifyingKey::from_bytes(&bytes).map_err(|_| EnrollError::MalformedKey)
+}
+
+fn key_to_hex(vk: &VerifyingKey) -> String {
+    let mut out = String::with_capacity(64);
+    for b in vk.as_bytes() {
+        use core::fmt::Write as _;
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+/// Load the pinned governor verifying key a consumer starts from.
+/// Fail-closed: missing or malformed pin → error → the consumer must refuse
+/// to start (no pin means no fence).
+pub fn load_pinned_verifying_key(path: &Path) -> Result<VerifyingKey, EnrollError> {
+    let content = std::fs::read_to_string(path).map_err(|e| EnrollError::Io(e.to_string()))?;
+    parse_key_hex(&content)
+}
+
+/// Pin `key_hex` at `path`. Idempotent (same key → `AlreadyEnrolled`);
+/// refuses to overwrite a different or unreadable pin unless `rotate` is
+/// explicitly set. The write is atomic (temp + rename, same directory).
+pub fn enroll_verifying_key(
+    path: &Path,
+    key_hex: &str,
+    rotate: bool,
+) -> Result<EnrollOutcome, EnrollError> {
+    let offered = parse_key_hex(key_hex)?;
+    let offered_id = verifying_key_id_hex(&offered);
+
+    let previous = match std::fs::read_to_string(path) {
+        Ok(existing) => match parse_key_hex(&existing) {
+            Ok(pinned) => {
+                if pinned == offered {
+                    return Ok(EnrollOutcome::AlreadyEnrolled { key_id: offered_id });
+                }
+                if !rotate {
+                    return Err(EnrollError::DifferentKeyPinned {
+                        pinned_key_id: verifying_key_id_hex(&pinned),
+                        offered_key_id: offered_id,
+                    });
+                }
+                Some(verifying_key_id_hex(&pinned))
+            }
+            Err(_) if !rotate => return Err(EnrollError::ExistingPinUnreadable),
+            Err(_) => None,
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => return Err(EnrollError::Io(e.to_string())),
+    };
+
+    // Atomic pin: write a sibling temp file, fsync, rename over the target.
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let tmp = dir.join(format!(
+        ".{}.enroll-tmp",
+        path.file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "governor_vk".to_string())
+    ));
+    let write = (|| -> std::io::Result<()> {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(key_to_hex(&offered).as_bytes())?;
+        f.write_all(b"\n")?;
+        f.sync_all()?;
+        std::fs::rename(&tmp, path)
+    })();
+    if let Err(e) = write {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(EnrollError::Io(e.to_string()));
+    }
+
+    Ok(match previous {
+        Some(previous_key_id) => EnrollOutcome::Rotated {
+            previous_key_id,
+            key_id: offered_id,
+        },
+        None => EnrollOutcome::Enrolled { key_id: offered_id },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn key_hex(seed: u8) -> String {
+        key_to_hex(&SigningKey::from_bytes(&[seed; 32]).verifying_key())
+    }
+
+    /// Per-test unique path under the system temp dir (the provisioning-test
+    /// pattern: no tempfile dev-dep, no env mutation).
+    fn pin_path(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "kirra-enroll-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ))
+    }
+
+    #[test]
+    fn first_enroll_then_idempotent_then_loadable() {
+        let p = pin_path("first");
+        let _ = std::fs::remove_file(&p);
+        let out = enroll_verifying_key(&p, &key_hex(1), false).unwrap();
+        assert!(matches!(out, EnrollOutcome::Enrolled { .. }));
+        // Idempotent: same key again is success, not an overwrite refusal.
+        let again = enroll_verifying_key(&p, &key_hex(1), false).unwrap();
+        assert!(matches!(again, EnrollOutcome::AlreadyEnrolled { .. }));
+        // The consumer can start from it.
+        let loaded = load_pinned_verifying_key(&p).unwrap();
+        assert_eq!(loaded, SigningKey::from_bytes(&[1; 32]).verifying_key());
+        let _ = std::fs::remove_file(&p);
+    }
+
+    /// The refuses-to-overwrite-silently arm: a different key needs `rotate`.
+    #[test]
+    fn different_key_is_refused_without_explicit_rotate() {
+        let p = pin_path("rotate");
+        let _ = std::fs::remove_file(&p);
+        enroll_verifying_key(&p, &key_hex(1), false).unwrap();
+        let refused = enroll_verifying_key(&p, &key_hex(2), false);
+        assert!(matches!(
+            refused,
+            Err(EnrollError::DifferentKeyPinned { .. })
+        ));
+        // Pin unchanged after the refusal.
+        assert_eq!(
+            load_pinned_verifying_key(&p).unwrap(),
+            SigningKey::from_bytes(&[1; 32]).verifying_key()
+        );
+        // Explicit rotation succeeds and reports the previous key id.
+        let rotated = enroll_verifying_key(&p, &key_hex(2), true).unwrap();
+        match rotated {
+            EnrollOutcome::Rotated {
+                previous_key_id, ..
+            } => assert_eq!(
+                previous_key_id,
+                verifying_key_id_hex(&SigningKey::from_bytes(&[1; 32]).verifying_key())
+            ),
+            other => panic!("expected Rotated, got {other:?}"),
+        }
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn malformed_and_corrupt_pins_fail_closed() {
+        let p = pin_path("corrupt");
+        let _ = std::fs::remove_file(&p);
+        // Malformed offered key.
+        assert_eq!(
+            enroll_verifying_key(&p, "not-hex", false),
+            Err(EnrollError::MalformedKey)
+        );
+        assert_eq!(
+            enroll_verifying_key(&p, &"ab".repeat(31), false),
+            Err(EnrollError::MalformedKey)
+        );
+        // Corrupt existing pin: load refuses; enroll refuses without rotate.
+        std::fs::write(&p, "garbage").unwrap();
+        assert!(load_pinned_verifying_key(&p).is_err());
+        assert_eq!(
+            enroll_verifying_key(&p, &key_hex(1), false),
+            Err(EnrollError::ExistingPinUnreadable)
+        );
+        // rotate may replace the corrupt pin.
+        assert!(matches!(
+            enroll_verifying_key(&p, &key_hex(1), true),
+            Ok(EnrollOutcome::Enrolled { .. })
+        ));
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn missing_pin_fails_closed_on_load() {
+        let p = pin_path("missing");
+        let _ = std::fs::remove_file(&p);
+        assert!(load_pinned_verifying_key(&p).is_err());
+    }
+}

--- a/crates/kirra-actuation-consumer/src/enrollment.rs
+++ b/crates/kirra-actuation-consumer/src/enrollment.rs
@@ -89,7 +89,14 @@ pub enum EnrollError {
 
 fn parse_key_hex(key_hex: &str) -> Result<VerifyingKey, EnrollError> {
     let t = key_hex.trim();
-    if t.len() != 64 || !t.bytes().all(|b| b.is_ascii_hexdigit()) {
+    // LOWERCASE hex only, exactly as the module docs pin the format: a
+    // manually edited pin (e.g. uppercase) is treated as tamper/corruption
+    // evidence rather than silently normalized (Copilot review on #892).
+    if t.len() != 64
+        || !t
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
         return Err(EnrollError::MalformedKey);
     }
     let mut bytes = [0u8; 32];
@@ -154,20 +161,46 @@ pub fn enroll_verifying_key(
         Err(e) => return Err(EnrollError::Io(e.to_string())),
     };
 
-    // Atomic pin: write a sibling temp file, fsync, rename over the target.
+    // Atomic pin: write a sibling temp file (unique name — concurrent
+    // enrollments or a leftover tmp must not collide), 0600 (the pin is
+    // integrity-critical; do not let a permissive umask make it
+    // group-writable), fsync the file, rename over the target, then fsync
+    // the DIRECTORY so the rename itself is durable (Copilot review, #892).
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let unique = {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        format!("{}-{nanos}", std::process::id())
+    };
     let tmp = dir.join(format!(
-        ".{}.enroll-tmp",
+        ".{}.enroll-tmp.{unique}",
         path.file_name()
             .map(|n| n.to_string_lossy().into_owned())
             .unwrap_or_else(|| "governor_vk".to_string())
     ));
     let write = (|| -> std::io::Result<()> {
-        let mut f = std::fs::File::create(&tmp)?;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            opts.mode(0o600);
+        }
+        let mut f = opts.open(&tmp)?;
         f.write_all(key_to_hex(&offered).as_bytes())?;
         f.write_all(b"\n")?;
         f.sync_all()?;
-        std::fs::rename(&tmp, path)
+        std::fs::rename(&tmp, path)?;
+        // Durability of the rename: fsync the containing directory (Unix).
+        #[cfg(unix)]
+        {
+            if let Ok(d) = std::fs::File::open(dir) {
+                let _ = d.sync_all();
+            }
+        }
+        Ok(())
     })();
     if let Err(e) = write {
         let _ = std::fs::remove_file(&tmp);
@@ -272,6 +305,31 @@ mod tests {
             enroll_verifying_key(&p, &key_hex(1), true),
             Ok(EnrollOutcome::Enrolled { .. })
         ));
+        let _ = std::fs::remove_file(&p);
+    }
+
+    /// Copilot (#892): uppercase hex is refused (the documented format is
+    /// lowercase; a hand-edited pin reads as tamper evidence, not silently
+    /// normalized), and the written pin is 0600 regardless of umask.
+    #[test]
+    fn uppercase_hex_is_refused_and_pin_mode_is_0600() {
+        let p = pin_path("case-mode");
+        let _ = std::fs::remove_file(&p);
+        let upper = key_hex(1).to_uppercase();
+        assert_eq!(
+            enroll_verifying_key(&p, &upper, false),
+            Err(EnrollError::MalformedKey)
+        );
+        enroll_verifying_key(&p, &key_hex(1), false).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&p).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "pin must be 0600, got {mode:o}");
+        }
+        // An uppercase pin on disk is unreadable = tamper evidence.
+        std::fs::write(&p, key_hex(1).to_uppercase()).unwrap();
+        assert!(load_pinned_verifying_key(&p).is_err());
         let _ = std::fs::remove_file(&p);
     }
 

--- a/crates/kirra-actuation-consumer/src/lib.rs
+++ b/crates/kirra-actuation-consumer/src/lib.rs
@@ -25,15 +25,42 @@
 
 #![forbid(unsafe_code)]
 
+/// Consumer verifying-key enrollment + rotation (the #891 key-distribution
+/// gap): pin/load/rotate the governor verifying key on a consumer host. See
+/// [`enrollment`].
+pub mod enrollment;
+
 pub use kirra_release_token::ros_twist::{
     RosReleaseGate, RosReleaseRefusal, RosTwistPayload, ROS_TWIST_PAYLOAD_LEN,
 };
-pub use kirra_release_token::ReleaseToken;
+pub use kirra_release_token::{ReleaseDenied, ReleaseToken};
 
 use ed25519_dalek::VerifyingKey;
 
 /// ADR-0033: the liveness deadline is ≈ 3 missed control periods.
 pub const DEFAULT_MISSED_PERIODS: u32 = 3;
+
+/// Consecutive `SignatureInvalid` refusals before the key-mismatch alarm
+/// latches. An OPERABILITY threshold, not a safety number: refusals already
+/// fail closed regardless; this only decides when the consumer starts saying
+/// "my pinned key doesn't match the signer" out loud. At the R2's 10–20 Hz
+/// command rate, 10 consecutive failures ≈ ½–1 s of uniform signature
+/// failure — long enough to rule out a stray corrupt frame, short enough
+/// that the diagnosis is up before anyone starts reading logs.
+pub const DEFAULT_SIGNATURE_INVALID_ALARM_STREAK: u32 = 10;
+
+/// The operator sentence the key-mismatch alarm carries. Fail-closed is
+/// correct; fail-closed-and-MUTE is a defect — a robot in a permanent safe
+/// stop must say why. This names the likely cause (rotation misorder) and
+/// the recovery.
+pub const KEY_MISMATCH_ALARM_EXPLANATION: &str =
+    "KEY MISMATCH: every release token is failing Ed25519 verification against this \
+     consumer's pinned governor verifying key. Likely cause: key rotation done out of \
+     order (the verifier is signing under a new key but this consumer was not re-enrolled \
+     first), or a wrong/stale consumer pin. The platform is holding its safe stop and will \
+     not move until this is fixed. Recovery: re-enroll the pin with the CURRENT governor \
+     verifying key (kirra-consumer-ctl enroll --rotate), restart the consumer. See \
+     docs/safety/GOVERNOR_KEY_PROVISIONING.md §7.";
 
 /// The one hardware seam. The real implementation owns the Rosmaster
 /// expansion-board serial device (dedicated user/group, mode 0600 — the
@@ -111,6 +138,75 @@ enum DriveState {
     Silent,
 }
 
+/// Per-class refusal counters — the distinguishable diagnostic surface
+/// (Tier-2's rogue-flood test watches `no_token`; the key-rotation drill
+/// watches `signature_invalid`). A refusal is never just "refused".
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RefusalBreakdown {
+    pub no_token: u64,
+    pub digest_mismatch: u64,
+    pub signature_invalid: u64,
+    pub undecodable: u64,
+    pub stale: u64,
+    pub sequence_not_advanced: u64,
+}
+
+impl RefusalBreakdown {
+    fn count(&mut self, refusal: &RosReleaseRefusal) {
+        match refusal {
+            RosReleaseRefusal::NoToken => self.no_token += 1,
+            RosReleaseRefusal::Denied(ReleaseDenied::DigestMismatch) => self.digest_mismatch += 1,
+            RosReleaseRefusal::Denied(ReleaseDenied::SignatureInvalid) => {
+                self.signature_invalid += 1
+            }
+            RosReleaseRefusal::Undecodable(_) => self.undecodable += 1,
+            RosReleaseRefusal::Stale { .. } => self.stale += 1,
+            RosReleaseRefusal::SequenceNotAdvanced { .. } => self.sequence_not_advanced += 1,
+        }
+    }
+
+    #[must_use]
+    pub fn total(&self) -> u64 {
+        self.no_token
+            + self.digest_mismatch
+            + self.signature_invalid
+            + self.undecodable
+            + self.stale
+            + self.sequence_not_advanced
+    }
+}
+
+/// The consumer's health surface — what a supervisor/monitor reads and what
+/// the field engineer sees. Read-only telemetry; nothing here gates the
+/// fence (the gate already failed closed before any of this is consulted).
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConsumerHealth {
+    pub releases: u64,
+    pub refusals: RefusalBreakdown,
+    pub serial_errors: u64,
+    /// Consecutive `SignatureInvalid` refusals with no intervening release
+    /// or other-class refusal (uniform signature failure is the rotation-
+    /// misorder signature; a mixed stream is not).
+    pub consecutive_signature_invalid: u32,
+    /// LATCHED once `consecutive_signature_invalid` crosses the alarm
+    /// streak; cleared only by a VALID release (proof the pin works again).
+    /// While true, [`ConsumerHealth::alarm_explanation`] returns the loud
+    /// operator sentence.
+    pub key_mismatch_alarm: bool,
+    /// The starve path finished its ramp — the platform is in output
+    /// silence.
+    pub silent: bool,
+}
+
+impl ConsumerHealth {
+    /// The operator sentence for the latched alarm, if any.
+    #[must_use]
+    pub fn alarm_explanation(&self) -> Option<&'static str> {
+        self.key_mismatch_alarm
+            .then_some(KEY_MISMATCH_ALARM_EXPLANATION)
+    }
+}
+
 /// The consumer: gate + liveness + serial seam. Single-owner, single-thread —
 /// exactly one instance per actuation path (the same discipline as the gate).
 pub struct MotorConsumer<S: MotorSerial> {
@@ -121,7 +217,9 @@ pub struct MotorConsumer<S: MotorSerial> {
     /// Wall-clock (ms) of the last VALID release. Refusals never touch this.
     last_valid_at_ms: Option<u64>,
     releases: u64,
-    refusals: u64,
+    refusal_breakdown: RefusalBreakdown,
+    consecutive_signature_invalid: u32,
+    key_mismatch_alarm: bool,
     serial_errors: u64,
 }
 
@@ -144,7 +242,9 @@ impl<S: MotorSerial> MotorConsumer<S> {
             state: DriveState::NeverReleased,
             last_valid_at_ms: None,
             releases: 0,
-            refusals: 0,
+            refusal_breakdown: RefusalBreakdown::default(),
+            consecutive_signature_invalid: 0,
+            key_mismatch_alarm: false,
             serial_errors: 0,
         })
     }
@@ -167,6 +267,10 @@ impl<S: MotorSerial> MotorConsumer<S> {
                     last_linear: released.linear_mps,
                 };
                 self.releases += 1;
+                // A valid release proves the pinned key matches the signer:
+                // the uniform-signature-failure evidence is void — clear it.
+                self.consecutive_signature_invalid = 0;
+                self.key_mismatch_alarm = false;
                 match self
                     .serial
                     .write_twist(released.linear_mps, released.angular_rad_s)
@@ -182,9 +286,44 @@ impl<S: MotorSerial> MotorConsumer<S> {
             }
             Err(refusal) => {
                 // 🔴 Refusals are NOT liveness: last_valid_at_ms untouched.
-                self.refusals += 1;
+                self.refusal_breakdown.count(&refusal);
+                // Key-mismatch detection: only an UNBROKEN run of
+                // SignatureInvalid is the rotation-misorder signature. Any
+                // other refusal class breaks the run (tokens that fail for
+                // other reasons still parsed/verified structure under the
+                // pinned key path, or carry no signature at all).
+                if matches!(
+                    refusal,
+                    RosReleaseRefusal::Denied(ReleaseDenied::SignatureInvalid)
+                ) {
+                    self.consecutive_signature_invalid =
+                        self.consecutive_signature_invalid.saturating_add(1);
+                    if self.consecutive_signature_invalid >= DEFAULT_SIGNATURE_INVALID_ALARM_STREAK
+                    {
+                        // LATCHED (until a valid release): the loud, distinct
+                        // diagnostic — see KEY_MISMATCH_ALARM_EXPLANATION.
+                        self.key_mismatch_alarm = true;
+                    }
+                } else {
+                    self.consecutive_signature_invalid = 0;
+                }
                 FrameOutcome::Refused(refusal)
             }
+        }
+    }
+
+    /// The read-only health surface (the Part-1 loud diagnostic): per-class
+    /// refusal counters, the consecutive-`SignatureInvalid` streak, and the
+    /// latched key-mismatch alarm with its operator sentence.
+    #[must_use]
+    pub fn health(&self) -> ConsumerHealth {
+        ConsumerHealth {
+            releases: self.releases,
+            refusals: self.refusal_breakdown,
+            serial_errors: self.serial_errors,
+            consecutive_signature_invalid: self.consecutive_signature_invalid,
+            key_mismatch_alarm: self.key_mismatch_alarm,
+            silent: self.state == DriveState::Silent,
         }
     }
 
@@ -244,10 +383,11 @@ impl<S: MotorSerial> MotorConsumer<S> {
         self.releases
     }
 
-    /// Gate refusals — the counter the Tier-2 rogue-flood test watches.
+    /// Total gate refusals — the counter the Tier-2 rogue-flood test
+    /// watches. Per-class detail is on [`MotorConsumer::health`].
     #[must_use]
     pub fn refusal_count(&self) -> u64 {
-        self.refusals
+        self.refusal_breakdown.total()
     }
 
     /// Serial write failures on legitimately released frames.
@@ -409,6 +549,80 @@ mod tests {
         );
         assert_eq!(m.release_count(), 1);
         assert!(m.refusal_count() >= 1);
+    }
+
+    /// Part 1.3 — fail-closed-and-mute is a defect: a sustained run of
+    /// SignatureInvalid (the rotation-misorder signature) must latch the
+    /// DISTINCT key-mismatch alarm with its operator sentence; mixed
+    /// refusals must not; a valid release clears it.
+    #[test]
+    fn sustained_signature_invalid_latches_the_loud_key_mismatch_alarm() {
+        let mut m = consumer();
+        // Tokens signed by a DIFFERENT governor key — exactly what a
+        // rotation done out of order produces.
+        let wrong = SigningKey::from_bytes(&[9u8; 32]);
+        for k in 0..DEFAULT_SIGNATURE_INVALID_ALARM_STREAK as u64 {
+            let p = RosTwistPayload {
+                sequence: k + 1,
+                issued_at_ms: 10_000 + k,
+                linear_mps: 0.2,
+                angular_rad_s: 0.0,
+            };
+            let t = kirra_release_token::ros_twist::issue_ros_release(&p, &wrong);
+            let out = m.on_frame(&p.encode(), Some(&t), 10_000 + k);
+            assert!(matches!(
+                out,
+                FrameOutcome::Refused(RosReleaseRefusal::Denied(ReleaseDenied::SignatureInvalid))
+            ));
+        }
+        let h = m.health();
+        assert!(h.key_mismatch_alarm, "alarm must latch at the streak");
+        assert_eq!(
+            h.alarm_explanation(),
+            Some(KEY_MISMATCH_ALARM_EXPLANATION),
+            "the alarm must carry the operator sentence"
+        );
+        assert_eq!(
+            h.refusals.signature_invalid,
+            u64::from(DEFAULT_SIGNATURE_INVALID_ALARM_STREAK),
+            "per-class counter must be distinguishable from other refusals"
+        );
+        // Nothing was actuated and the fence is intact.
+        assert!(m.serial.writes.is_empty());
+
+        // A VALID release (correct key again) clears the alarm.
+        let (p_ok, t_ok) = frame(100, 11_000, 0.2);
+        assert!(matches!(
+            m.on_frame(&p_ok, Some(&t_ok), 11_000),
+            FrameOutcome::Released { .. }
+        ));
+        assert!(!m.health().key_mismatch_alarm);
+        assert_eq!(m.health().consecutive_signature_invalid, 0);
+    }
+
+    /// A MIXED refusal stream (unsigned frames interleaved with wrong-key
+    /// tokens) is not the rotation-misorder signature and must not alarm.
+    #[test]
+    fn mixed_refusals_do_not_latch_the_key_mismatch_alarm() {
+        let mut m = consumer();
+        let wrong = SigningKey::from_bytes(&[9u8; 32]);
+        for k in 0..(2 * DEFAULT_SIGNATURE_INVALID_ALARM_STREAK as u64) {
+            let p = RosTwistPayload {
+                sequence: k + 1,
+                issued_at_ms: 10_000 + k,
+                linear_mps: 0.2,
+                angular_rad_s: 0.0,
+            };
+            if k % 2 == 0 {
+                let t = kirra_release_token::ros_twist::issue_ros_release(&p, &wrong);
+                m.on_frame(&p.encode(), Some(&t), 10_000 + k);
+            } else {
+                m.on_frame(&p.encode(), None, 10_000 + k); // NoToken breaks the run
+            }
+        }
+        let h = m.health();
+        assert!(!h.key_mismatch_alarm);
+        assert!(h.refusals.signature_invalid > 0 && h.refusals.no_token > 0);
     }
 
     #[test]

--- a/crates/kirra-release-token/src/ros_twist.rs
+++ b/crates/kirra-release-token/src/ros_twist.rs
@@ -543,3 +543,130 @@ mod tests {
         assert_eq!(ReleaseToken::from_bytes(&token.to_bytes()), token);
     }
 }
+
+/// Forensic key id for a pinned/offered verifying key: lowercase hex SHA-256
+/// of the raw 32 public-key bytes — byte-identical to the root crate's
+/// `audit_chain::verifying_key_id` discipline (asserted there by
+/// `governor_release` tests), reproduced here so the lean consumer side can
+/// name keys in diagnostics without pulling the heavy crate.
+#[must_use]
+pub fn verifying_key_id_hex(vk: &VerifyingKey) -> String {
+    let mut h = Sha256::new();
+    h.update(vk.as_bytes());
+    let digest = h.finalize();
+    let mut out = String::with_capacity(64);
+    for b in digest {
+        use core::fmt::Write as _;
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+impl RosReleaseRefusal {
+    /// Stable machine code for this refusal (SCREAMING_SNAKE, the capture /
+    /// metrics vocabulary style). Wire-stable: consumers may key on these.
+    #[must_use]
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::NoToken => "ROS_RELEASE_NO_TOKEN",
+            Self::Denied(ReleaseDenied::DigestMismatch) => "ROS_RELEASE_DIGEST_MISMATCH",
+            Self::Denied(ReleaseDenied::SignatureInvalid) => "ROS_RELEASE_SIGNATURE_INVALID",
+            Self::Undecodable(_) => "ROS_RELEASE_UNDECODABLE",
+            Self::Stale { .. } => "ROS_RELEASE_STALE",
+            Self::SequenceNotAdvanced { .. } => "ROS_RELEASE_SEQUENCE_NOT_ADVANCED",
+        }
+    }
+
+    /// The operator sentence for this refusal — what a field engineer reads
+    /// on the consumer's health surface. Same discipline as the verifier's
+    /// `explain_deny_token` table: every variant gets a SPECIFIC sentence
+    /// (never a generic fallback), pinned by the exhaustive match here plus
+    /// the lock-step test below. Fail-closed is correct; fail-closed-and-mute
+    /// is a defect — these sentences are how the fence says why it refused.
+    #[must_use]
+    pub fn explain(&self) -> &'static str {
+        match self {
+            Self::NoToken => {
+                "The command arrived without a release token. Either the checker denied it \
+                 (denials never carry a token) or the publisher is not the checker at all — \
+                 the command was refused and nothing was actuated."
+            }
+            Self::Denied(ReleaseDenied::DigestMismatch) => {
+                "The release token does not approve these exact command bytes — the bytes were \
+                 substituted or reordered after signing. The command was refused."
+            }
+            Self::Denied(ReleaseDenied::SignatureInvalid) => {
+                "The release token's signature does not verify against the pinned governor \
+                 verifying key. If this is sustained, the likely cause is a key rotation done \
+                 out of order (verifier signing under a new key before this consumer was \
+                 re-enrolled) or a wrong consumer pin — re-enroll the pin (see \
+                 GOVERNOR_KEY_PROVISIONING.md, consumer rotation order)."
+            }
+            Self::Undecodable(_) => {
+                "The token verified but the command bytes do not decode to a finite twist \
+                 (NaN/Inf). The command was refused — the checker never signs non-finite \
+                 commands, so this indicates corruption."
+            }
+            Self::Stale { .. } => {
+                "The release token is outside the freshness window (too old or future-dated). \
+                 A replayed pre-restart token, a stalled bus, or clock skew between verifier \
+                 and consumer produces this."
+            }
+            Self::SequenceNotAdvanced { .. } => {
+                "The release sequence does not advance past the last released command — a \
+                 replayed or reordered release. The original command already actuated; this \
+                 copy was refused."
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod refusal_explanation_tests {
+    use super::*;
+
+    /// Lock-step coverage (the `every_deny_code_has_a_specific_explanation`
+    /// pattern): every refusal variant has a SPECIFIC, distinct operator
+    /// sentence and a distinct stable code. The exhaustive `match` in
+    /// `explain`/`code` makes a NEW variant a compile error; this test pins
+    /// that no two variants share a sentence and none is empty/generic.
+    #[test]
+    fn every_refusal_variant_has_a_specific_distinct_explanation() {
+        let all: [RosReleaseRefusal; 6] = [
+            RosReleaseRefusal::NoToken,
+            RosReleaseRefusal::Denied(ReleaseDenied::DigestMismatch),
+            RosReleaseRefusal::Denied(ReleaseDenied::SignatureInvalid),
+            RosReleaseRefusal::Undecodable(RosTwistDecodeError::NonFiniteValue),
+            RosReleaseRefusal::Stale {
+                issued_at_ms: 0,
+                now_ms: 1,
+                window_ms: 0,
+            },
+            RosReleaseRefusal::SequenceNotAdvanced {
+                presented: 0,
+                last_released: 0,
+            },
+        ];
+        let mut sentences = std::collections::HashSet::new();
+        let mut codes = std::collections::HashSet::new();
+        for r in &all {
+            let s = r.explain();
+            let c = r.code();
+            assert!(s.len() > 40, "explanation must be a real sentence: {c}");
+            assert!(sentences.insert(s), "duplicate explanation for {c}");
+            assert!(codes.insert(c), "duplicate code {c}");
+            assert!(c.starts_with("ROS_RELEASE_"), "code vocabulary: {c}");
+        }
+    }
+
+    #[test]
+    fn key_id_matches_the_audit_chain_discipline_shape() {
+        let vk = SigningKey::from_bytes(&[42u8; 32]).verifying_key();
+        let id = verifying_key_id_hex(&vk);
+        assert_eq!(id.len(), 64);
+        assert!(id
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()));
+        assert_eq!(id, verifying_key_id_hex(&vk), "deterministic");
+    }
+}

--- a/docs/adr/0033-actuation-authority-ros-r2-topology.md
+++ b/docs/adr/0033-actuation-authority-ros-r2-topology.md
@@ -248,3 +248,57 @@ a component from bypassing it on the bus or the serial port.* `OCCY_DFA.md` PO-2
 carries a scoping note to that effect; `ASSUMPTIONS_OF_USE.md` carries the
 serial-port-exclusivity assumption (`AOU-ACTUATION-SERIAL-001`) until the Tier-3
 sentinel enforces it.
+
+---
+
+## Addendum A (2026-07-10) — verifier-restart sequence continuity
+
+**Context.** Settled decision 3 (restart semantics) covers CONSUMER restarts:
+resync-from-zero plus the freshness window. Implementation (#891) surfaced the
+mirror case this ADR did not settle: a VERIFIER restart. A verifier whose
+sequence counter restarted from zero would mint sequences BELOW a live
+consumer's watermark; every release would refuse `SequenceNotAdvanced` and the
+path would deadlock until the consumer itself restarted (its empty watermark
+resyncing the baseline).
+
+**Decision (ratifying the #891 implementation).** The verifier's mint counter
+is seeded from the boot wall clock (milliseconds since epoch) and incremented
+by one per mint (`src/governor_release.rs`, `RosReleaseSigner`). Sequences
+stay monotonic across verifier restarts whenever (a) the wall clock is
+monotonic across those restarts and (b) the long-run mint rate stays under
+one command per millisecond — the R2 control rate of 10–20 Hz gives ~50×
+headroom on (b).
+
+**The coupling this introduces — named, not buried.** The release-token
+watermark's monotonicity now rests on **clock monotonicity**. This is a new
+edge in the system's clock-dependency graph, and it is the same shape of
+common-mode clock concern raised as **B4 in the stop-gate review** and
+reflected in the clock-diversity gap against `docs/safety/OCCY_DFA.md` §3's
+common-cause table (which today carries no explicit shared-clock row; the
+freshness window of decision 3 already depends on verifier/consumer clock
+agreement, and this addendum adds the sequence dependency on the verifier's
+own clock across reboots). An assessor tracing clock dependencies must find
+all three in one place:
+
+1. **Freshness window** (decision 3) — verifier↔consumer clock agreement
+   within the window; skew beyond it refuses (fail-closed).
+2. **Sequence continuity** (this addendum) — verifier boot-clock
+   monotonicity across restarts; a backwards step at reboot mints
+   non-advancing sequences, the consumer refuses, motion stops
+   (fail-closed), recovery = consumer restart (resync) or clock repair.
+3. **The boundary timing rule** — `AOU-TIMESYNC-001`
+   (`ASSUMPTIONS_OF_USE.md`) and the two-clock-domain non-mixing rule
+   (`docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md` §5) govern timestamp
+   provenance on the enforced path generally.
+
+Every failure mode in this list degrades to refusal → safe stop, never to a
+release — which is why the coupling is acceptable — but it is a shared-cause
+dependency on time and belongs in the DFA's field of view. **Follow-up
+recorded:** add a shared-clock common-cause row to the `OCCY_DFA.md` §3 table
+citing this addendum, rather than editing that ratified analysis silently
+here.
+
+**Rejected alternative.** A durable mint counter (SQLite write per mint) was
+rejected for the same reasons decision 3 rejected the durable consumer
+watermark: a write on the actuation response path and a corruptible file, in
+exchange for closing a window that fail-closed refusal already bounds.

--- a/docs/safety/GOVERNOR_KEY_PROVISIONING.md
+++ b/docs/safety/GOVERNOR_KEY_PROVISIONING.md
@@ -82,3 +82,64 @@ key's own zeroize-on-drop storage.
 (`tss-esapi`, the `tpm` feature) + hardware. The seam already routes `tpm:<handle>` to
 a single refusal point (`provision_signing_key` → `TpmUnsealUnsupported`), so landing
 it is an additive change at one call site — no consumer rewiring.
+
+## 7. Consumer verifying-key enrollment and rotation order (ADR-0033)
+
+The sections above provision the **signing** key on the verifier. The other
+half of the pair — the **verifying** key pinned on the ROS/R2 motor consumer
+(ADR-0033; `RosReleaseGate::new` admits only a pinned key) — is provisioned by
+`kirra-consumer-ctl` (`crates/kirra-actuation-consumer/src/enrollment.rs`):
+
+```
+kirra-consumer-ctl enroll --key-hex <64-hex-vk> --path /etc/kirra/governor_vk.pin
+kirra-consumer-ctl show   --path /etc/kirra/governor_vk.pin
+```
+
+Properties: **idempotent** (re-enrolling the identical key succeeds without a
+write); **refuses to overwrite silently** (a different key needs an explicit
+`--rotate`, and a corrupt pin is refused as tamper evidence rather than
+replaced); writes are **atomic** (temp + rename — no torn pin). The pin is a
+PUBLIC key: the requirement is integrity, not secrecy — keep the pin file
+inside the same OS-ownership boundary as the serial device (the ADR-0033
+layer-2 dedicated user; whoever can write the pin decides which governor the
+consumer obeys).
+
+### Rotation order — this order is load-bearing
+
+1. **Re-enroll the consumer** with the NEW verifying key
+   (`kirra-consumer-ctl enroll --rotate …`) and restart the consumer. The
+   consumer now trusts the new key; the verifier is still signing under the
+   old one, so every token is refused `SignatureInvalid` and the platform
+   holds its safe stop — **expected and bounded** by how long step 2 takes.
+2. **Rotate the verifier's signing key** (`KIRRA_GOVERNOR_SIGNING_KEY_SOURCE`
+   → the new seed; restart the verifier). Tokens verify again; motion
+   resumes on the next valid release (the key-mismatch alarm self-clears).
+
+Consumer-first is deliberate: the safe-stop window sits between the two
+steps either way, but consumer-first bounds it to an operator-controlled
+moment with both hands already on the system.
+
+### Done out of order — the failure mode, loudly
+
+If the verifier signs under the new key while any consumer still pins the
+old one, that consumer refuses **everything**: `SignatureInvalid` on every
+frame → liveness starves → decel-to-stop → output silence. **Permanent safe
+stop** until re-enrolled. Fail-closed and safe — and NOT mute: after
+`DEFAULT_SIGNATURE_INVALID_ALARM_STREAK` (10) consecutive signature failures
+the consumer latches the **key-mismatch alarm**
+(`MotorConsumer::health().key_mismatch_alarm` +
+`KEY_MISMATCH_ALARM_EXPLANATION`), a diagnostic DISTINCT from staleness or a
+dead link, naming the likely cause and this recovery:
+
+**Recovery:** `kirra-consumer-ctl enroll --rotate` with the CURRENT governor
+verifying key → restart the consumer → the next valid release clears the
+alarm and resumes motion. (A mixed refusal stream does not latch the alarm —
+only the uniform signature-failure signature of a key mismatch does.)
+
+### First-provisioning assumption (stated, not assumed away)
+
+`enroll` presumes an operator-authenticated channel to the consumer host
+(the same trust `kirra-ota-ctl enroll` presumes): the first pin is only as
+trustworthy as the channel that delivered the key hex. Bootstrapping that
+first pin from a signed enrollment bundle / attested first boot is a tracked
+follow-up, not something this procedure claims to solve.

--- a/src/governor_release.rs
+++ b/src/governor_release.rs
@@ -130,6 +130,19 @@ mod tests {
         assert_eq!(id, governor_key_id(&sk.verifying_key()));
     }
 
+    /// The lean crate's `verifying_key_id_hex` (used by consumer enrollment
+    /// diagnostics) must stay byte-identical to the root `audit_chain`
+    /// key-id discipline `governor_key_id` wraps — one key names ONE id
+    /// everywhere it appears in logs.
+    #[test]
+    fn lean_key_id_matches_the_audit_chain_discipline() {
+        let vk = SigningKey::from_bytes(&[42u8; 32]).verifying_key();
+        assert_eq!(
+            governor_key_id(&vk),
+            kirra_release_token::ros_twist::verifying_key_id_hex(&vk)
+        );
+    }
+
     #[test]
     fn signer_mints_strictly_advancing_gate_accepted_tokens() {
         let sk = SigningKey::from_bytes(&[42u8; 32]);


### PR DESCRIPTION
Parts 1 + 2 of the post-#891 sequence — closes both #891 findings. **Human review before merge; do not merge without it.**

## Part 1 — the key-distribution gap

- **Enrollment** (`crates/kirra-actuation-consumer/src/enrollment.rs` + new `kirra-consumer-ctl` bin): pin the governor verifying key on a consumer. Idempotent (same key → success, file untouched); **refuses to overwrite a different or corrupt pin without explicit `--rotate`** (a corrupt pin is treated as tamper evidence, not silently replaced); atomic write (temp + rename); fail-closed load (no pin → the consumer must refuse to start). The pin is the *public* key — the integrity boundary is the ADR-0033 layer-2 OS ownership (same dedicated user as the serial device).
- **Rotation order** (`GOVERNOR_KEY_PROVISIONING.md` §7): consumer re-enrolled **first**, verifier rotated second — the safe-stop window between the steps becomes an operator-controlled moment. Out-of-order consequence documented (permanent safe stop) with recovery.
- 🔴 **The operability fix, treated as its own requirement**: per-class `RefusalBreakdown` counters plus a consecutive-`SignatureInvalid` detector that **latches a key-mismatch alarm** (`MotorConsumer::health()`), carrying an operator sentence that names the likely cause (rotation misorder) and the exact recovery. Distinct from staleness or a dead link; a **mixed** refusal stream does not latch (only uniform signature failure is the misorder signature) — both behaviors tested. Cleared only by a valid release (proof the pin works again). The 10-frame streak threshold is documented as an operability count (~½–1 s at the R2 rate), **not** a safety number — refusals fail closed regardless.
- `RosReleaseRefusal::code()/explain()`: stable machine codes + specific operator sentences for **every** refusal variant, pinned by a lock-step test (the `every_deny_code_has_a_specific_explanation` pattern; the exhaustive match makes a new variant a compile error). This also pre-builds Part 3's ReleaseRefusal narration.
- `verifying_key_id_hex` in the lean crate, with a root-crate test asserting byte-identity with the `audit_chain` key-id discipline — one key names one id in every log.

**First-provisioning assumption (reported, per the task):** `enroll` presumes an operator-authenticated channel to the consumer host — the same trust `kirra-ota-ctl enroll` presumes. It does not bootstrap trust from nothing: the first pin is only as trustworthy as the channel that delivered the key hex. Signed enrollment bundles / attested first boot are a tracked follow-up, stated in the module docs and §7 rather than assumed away.

## Part 2 — ADR-0033 Addendum A

Ratifies the #891 boot-clock sequence seeding and **names the coupling explicitly**: *the release-token watermark's monotonicity now rests on clock monotonicity.* Cross-referenced, so an assessor tracing clock dependencies finds all three in one place: the decision-3 freshness window (verifier↔consumer clock agreement), this addendum's sequence continuity (verifier boot-clock monotonicity across restarts), and `AOU-TIMESYNC-001` + the HVCHAN §5 two-clock-domain rule. Tied to the stop-gate review's **B4** common-mode clock concern and the clock-diversity gap against `OCCY_DFA.md` §3's common-cause table — with a recorded follow-up to add a shared-clock row to that table rather than editing the ratified analysis silently. Every listed failure mode degrades to refusal → safe stop, never a release. The rejected durable-counter alternative is documented with the same rationale as decision 3's rejected durable watermark.

## Verification

- `kirra-actuation-consumer`: 12 tests (alarm latch/clear, mixed-stream no-latch, enrollment idempotence/refusal/rotation/corrupt-pin, Tier-1 cross-process guard still green)
- `kirra-release-token`: 59 tests (lock-step refusal explanations, key-id shape)
- Root `governor_release`: key-id byte-identity with `audit_chain`
- `cargo fmt --all -- --check` clean

No fail-closed invariant loosened; the verdict core (`ed00f4da…`) untouched; no new env vars; no new command surface (everything added is read-only telemetry or an operator CLI acting on a local file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_