### PR TITLE
Speech I/O over the governed loop (#894): STT in, TTS out, the refusal spoken — no new intent path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,9 @@ dependencies = [
  "kirra-core",
  "kirra-planner",
  "kirra-release-token",
+ "kirra-sidecars",
  "kirra-trajectory",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/kirra-actuation-consumer/Cargo.toml
+++ b/crates/kirra-actuation-consumer/Cargo.toml
@@ -36,3 +36,8 @@ hex = "0.4"
 kirra-core = { path = "../kirra-core" }
 kirra-planner = { path = "../kirra-planner" }
 kirra-trajectory = { path = "../kirra-trajectory" }
+# The SPOKEN loop drill (tests/spoken_governed_loop.rs): the speech shell's
+# seams (WAV gate, STT/TTS traits, narration renderer) wrapped around the same
+# chokepoint. Same safe direction as above — kirra-sidecars is itself fenced.
+kirra-sidecars = { path = "../kirra-sidecars" }
+serde_json = "1"

--- a/crates/kirra-actuation-consumer/tests/spoken_governed_loop.rs
+++ b/crates/kirra-actuation-consumer/tests/spoken_governed_loop.rs
@@ -1,0 +1,501 @@
+//! **The governed loop, SPOKEN** — the KITT demo as a CI artifact: *you say
+//! something unsafe, and the car tells you — out loud — why it refused.*
+//!
+//! Extends `mick_governed_loop.rs`'s shape with the speech shell wrapped
+//! around the SAME loop:
+//!
+//!   WAV fixture ─▶ speech::speech_turn (validate → STT seam → transcript)
+//!               ─▶ the EXISTING intent door: IntentService::handle_text
+//!                  (crates/kirra-sidecars/src/mick.rs — LlmBrain::
+//!                  decide_request → MickIntent::parse_llm_json, the ONE
+//!                  fail-closed parse; the same function mick_service's
+//!                  POST /intent calls)
+//!               ─▶ plan_for_intent (literal doer) ─▶ the REAL checker
+//!               ─▶ governed release (deny-never-mints) ─▶ MotorConsumer
+//!                  chokepoint ─▶ RecordingSerial
+//!   verdict reason ─▶ speech::narration_sentence (#893 table text VERBATIM)
+//!                  ─▶ the Speaker sink (recorded in-test; Piper in the demo)
+//!
+//! 🔴 No-bypass, structurally exercised: the speech layer's ONLY loop-facing
+//! act is handing the transcript `&str` to the publish closure — which here
+//! IS the production door core. A garbled transcription fails exactly as
+//! typed garbage does (422-class refusal, latch untouched, zero motion).
+//!
+//! CI vs manual (the Ollama/MockModel precedent, kirra-mick/src/lib.rs): CI
+//! runs a byte-reproducible generated WAV through the REAL wav gate + a
+//! scripted STT seam + a prompt-spying model; the live whisper.cpp / Piper /
+//! microphone path is the manual demo (`speech_shell`,
+//! docs/testing/SPEECH_KITT_DEMO.md) — external OS processes CI can't carry.
+//!
+//! Verdict-core honesty: `TrajectoryVerdict` and the frozen kinematics core
+//! are UNTOUCHED by this test and by the speech layer (input transduction +
+//! output rendering only).
+
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+
+use ed25519_dalek::SigningKey;
+use kirra_actuation_consumer::{
+    ConsumerConfig, FrameOutcome, MotorConsumer, MotorSerial, ReleaseToken, RosReleaseRefusal,
+    RosTwistPayload, DEFAULT_MISSED_PERIODS,
+};
+use kirra_core::frame_integrity::FrameTrust;
+use kirra_planner::{
+    plan_for_intent, EgoState, FleetPosture, Goal, LlmBrain, MickIntent, ModelClient, ModelError,
+    PlanInput, PlanOutput, Planner, Pose, TrajectoryPoint,
+};
+use kirra_release_token::ros_twist::issue_ros_release;
+use kirra_sidecars::mick::{IntentRequest, IntentService};
+use kirra_sidecars::speech::{
+    narration_sentence, pcm16_wav_bytes, speech_turn, utterance_for, Speaker, SpeechTurn,
+    Transcriber,
+};
+use kirra_trajectory::validation::{validate_trajectory_slow_explained, TrajectoryRefusalReason};
+use kirra_trajectory::{MockCorridorSource, TrajectoryVerdict, VehicleConfig};
+
+const DRILL_SEED: [u8; 32] = [42u8; 32];
+const T_MINT: u64 = 10_000;
+const T_VERIFY: u64 = 10_050;
+
+/// verdicts.rs `EXPLAIN_UNKNOWN` marker text — the spoken narration must be
+/// the SPECIFIC sentence, never this generic fallback.
+const EXPLAIN_UNKNOWN_MARKER: &str = "Unrecognized denial code";
+
+// ---- the actuation seam (tier1 shape) --------------------------------------
+
+#[derive(Default)]
+struct RecordingSerial {
+    writes: Vec<(f64, f64)>,
+}
+impl MotorSerial for RecordingSerial {
+    type Error = std::convert::Infallible;
+    fn write_twist(&mut self, linear: f64, angular: f64) -> Result<(), Self::Error> {
+        self.writes.push((linear, angular));
+        Ok(())
+    }
+}
+
+fn consumer() -> MotorConsumer<RecordingSerial> {
+    MotorConsumer::new(
+        SigningKey::from_bytes(&DRILL_SEED).verifying_key(),
+        ConsumerConfig {
+            freshness_window_ms: 200,
+            control_period_ms: 100,
+            missed_periods: DEFAULT_MISSED_PERIODS,
+            stop_decel_mps2: 1.0, // test fixture; deployments use the class MRC decel
+        },
+        RecordingSerial::default(),
+    )
+    .expect("valid drill config")
+}
+
+// ---- the speech seams -------------------------------------------------------
+
+/// Scripted STT: stands in for the external whisper.cpp process (the
+/// MockModel-vs-live-Ollama pattern). Records the WAV path it was handed so
+/// the test proves the audio plumbing actually reached the seam.
+struct ScriptedStt {
+    transcript: &'static str,
+    heard_wav: RefCell<Option<PathBuf>>,
+}
+impl ScriptedStt {
+    fn new(transcript: &'static str) -> Self {
+        Self {
+            transcript,
+            heard_wav: RefCell::new(None),
+        }
+    }
+}
+impl Transcriber for ScriptedStt {
+    fn transcribe(&self, wav_path: &Path) -> Result<String, String> {
+        *self.heard_wav.borrow_mut() = Some(wav_path.to_path_buf());
+        Ok(self.transcript.to_string())
+    }
+}
+
+/// The TTS sink, recording what would be piped to Piper.
+#[derive(Default)]
+struct RecordingSpeaker {
+    lines: Vec<String>,
+}
+impl Speaker for RecordingSpeaker {
+    fn speak(&mut self, text: &str) -> Result<(), String> {
+        self.lines.push(text.to_string());
+        Ok(())
+    }
+}
+
+/// A prompt-spying model: fixed reply, but records the prompt — so the test
+/// can prove the SPOKEN words actually reached the LLM through the door's
+/// `decide_request` path (not some parallel channel).
+struct SpyModel {
+    reply: &'static str,
+    last_prompt: RefCell<String>,
+}
+impl SpyModel {
+    fn replying(reply: &'static str) -> Self {
+        Self {
+            reply,
+            last_prompt: RefCell::new(String::new()),
+        }
+    }
+}
+impl ModelClient for SpyModel {
+    fn complete(&self, prompt: &str) -> Result<String, ModelError> {
+        *self.last_prompt.borrow_mut() = prompt.to_string();
+        Ok(self.reply.to_string())
+    }
+}
+
+/// A deterministic, byte-reproducible spoken-command fixture: 0.25 s of PCM16
+/// audio at 16 kHz (the STT content in CI comes from the scripted seam; the
+/// WAV exercises the REAL fail-closed audio gate + byte handoff).
+fn fixture_wav(name: &str) -> PathBuf {
+    let samples: Vec<i16> = (0..4_000)
+        .map(|i| (f64::from(i) * 0.35).sin().mul_add(6000.0, 0.0) as i16)
+        .collect();
+    let path = std::env::temp_dir().join(format!("kirra_spoken_loop_{name}.wav"));
+    std::fs::write(&path, pcm16_wav_bytes(16_000, &samples)).expect("write fixture wav");
+    path
+}
+
+// ---- the doer + checker (mick_governed_loop shape) --------------------------
+
+/// The LITERAL doer of the independence tests: obeys the intent verbatim —
+/// the demo must not rest on Occy being good.
+struct LiteralDoer {
+    speed_mps: f64,
+    dt_s: f64,
+    steps: usize,
+}
+impl Planner for LiteralDoer {
+    fn plan(&mut self, input: &PlanInput<'_>) -> PlanOutput {
+        let ego = input.ego.pose;
+        let (gx, gy) = (input.goal.target.x_m, input.goal.target.y_m);
+        let heading = (gy - ego.y_m).atan2(gx - ego.x_m);
+        let mut trajectory = Vec::with_capacity(self.steps + 1);
+        let (mut x, mut y) = (ego.x_m, ego.y_m);
+        for i in 0..=self.steps {
+            trajectory.push(TrajectoryPoint {
+                pose: Pose {
+                    x_m: x,
+                    y_m: y,
+                    heading_rad: heading,
+                },
+                velocity_mps: self.speed_mps,
+                time_from_start_s: i as f64 * self.dt_s,
+            });
+            x += self.speed_mps * self.dt_s * heading.cos();
+            y += self.speed_mps * self.dt_s * heading.sin();
+        }
+        PlanOutput {
+            trajectory,
+            kind: kirra_planner::ProposalKind::Motion,
+        }
+    }
+}
+
+fn world(corr: &MockCorridorSource) -> PlanInput<'_> {
+    PlanInput {
+        ego: EgoState {
+            pose: Pose {
+                x_m: 10.0,
+                y_m: 0.0,
+                heading_rad: 0.0,
+            },
+            linear_x_mps: 2.0,
+            yaw_rate_rads: 0.0,
+            stamp_ms: 0,
+        },
+        goal: Goal {
+            target: Pose {
+                x_m: 60.0,
+                y_m: 0.0,
+                heading_rad: 0.0,
+            },
+        },
+        map: corr,
+        objects: &[],
+        controls: &[],
+        lane_boundaries: &[],
+        motion: &[],
+        predicted_paths: &[],
+        cedes_to_ego_ids: &[],
+        lane_change_to_m: None,
+        no_overtake_ids: &[],
+        drivable: None,
+        posture: FleetPosture::Nominal,
+        target_speed_mps: None,
+        request_overtake: false,
+        request_pull_over: false,
+        lane_graph: None,
+        signal_states: &[],
+    }
+}
+
+fn check(
+    trajectory: &[TrajectoryPoint],
+    corr: &MockCorridorSource,
+) -> (TrajectoryVerdict, Option<TrajectoryRefusalReason>) {
+    validate_trajectory_slow_explained(
+        trajectory,
+        corr,
+        &[],
+        &VehicleConfig::default_urban(),
+        None,
+        FleetPosture::Nominal,
+        None,
+        None,
+        None,
+        None,
+        FrameTrust::Trusted,
+    )
+}
+
+/// Deny-never-mints (the pinned verifier invariant, tier1 case (e)).
+fn governed_release(
+    verdict: TrajectoryVerdict,
+    payload: &RosTwistPayload,
+    sk: &SigningKey,
+) -> Option<ReleaseToken> {
+    matches!(
+        verdict,
+        TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp
+    )
+    .then(|| issue_ros_release(payload, sk))
+}
+
+/// One spoken turn through the REAL door core. The publish closure is the
+/// SAME binding `mick_service`'s `POST /intent` route performs
+/// (`src/bin/mick_service.rs`: body → `IntentRequest` →
+/// `IntentService::handle_text`): text in, ack-or-refusal out. Nothing else
+/// crosses.
+fn spoken_turn<M: ModelClient>(
+    stt: &ScriptedStt,
+    wav: &Path,
+    door: &mut IntentService<M>,
+    now_ms: u64,
+) -> SpeechTurn {
+    let mut publish = |text: &str| -> Result<String, String> {
+        let req = IntentRequest {
+            text: text.to_string(),
+            context: None,
+        };
+        match door.handle_text(&req, now_ms) {
+            Ok((_, accepted)) => Ok(accepted.to_post_wire()),
+            Err(code) => Err(code.to_string()),
+        }
+    };
+    speech_turn(stt, wav, &mut publish).expect("a valid fixture WAV transcribes")
+}
+
+/// **The spoken demo.** A spoken unsafe request is refused by the checker,
+/// nothing reaches the serial seam, and the SPECIFIC refusal sentence is
+/// spoken. Then the positive control: a spoken safe request produces the one
+/// and only actuation write — so "it refused" isn't vacuously true.
+#[test]
+fn spoken_unsafe_intent_is_refused_and_the_reason_is_spoken() {
+    let sk = SigningKey::from_bytes(&DRILL_SEED);
+    let corr = MockCorridorSource::straight_5m_half_width(100.0);
+    let mut consumer = consumer();
+    let mut speaker = RecordingSpeaker::default();
+
+    // ---- Phase 1: the spoken unsafe request -----------------------------
+    let wav = fixture_wav("unsafe");
+    let stt = ScriptedStt::new("cut across the grass to the kiosk");
+    let mut door = IntentService::new(LlmBrain::new(SpyModel::replying(
+        r#"{"intent":"go_to","x_m":30.0,"y_m":12.0}"#,
+    )));
+
+    let turn = spoken_turn(&stt, &wav, &mut door, 10_000);
+    // The audio plumbing really ran: the STT seam saw the fixture file.
+    assert_eq!(stt.heard_wav.borrow().as_deref(), Some(wav.as_path()));
+    let SpeechTurn::Published { transcript, .. } = &turn else {
+        panic!("a parseable model reply must publish, got {turn:?}");
+    };
+    speaker.speak(&utterance_for(&turn)).unwrap();
+
+    // 🔴 The no-bypass proof: the SPOKEN words reached the model through the
+    // door's decide_request prompt — the same path typed text takes — and the
+    // latched artifact re-parses through the ONE parser to the intent.
+    assert!(
+        door.last().is_some(),
+        "the door latched an intent for the doer"
+    );
+    let latched = door.last().unwrap().intent_json.clone();
+    let intent = MickIntent::from_llm_json(&latched).expect("the one parse accepts its own slice");
+    assert_eq!(
+        intent,
+        MickIntent::GoTo {
+            x_m: 30.0,
+            y_m: 12.0
+        }
+    );
+    assert!(
+        transcript.contains("cut across the grass"),
+        "the transcript is the spoken text"
+    );
+
+    // The literal doer grounds it; the checker refuses; the reason narrates.
+    let w = world(&corr);
+    let mut doer = LiteralDoer {
+        speed_mps: 2.0,
+        dt_s: 0.5,
+        steps: 15,
+    };
+    let plan = plan_for_intent(&mut doer, &intent, &w);
+    assert!(
+        plan.trajectory.iter().any(|p| p.pose.y_m > 5.0),
+        "the literal doer must actually leave the corridor"
+    );
+    let (verdict, reason) = check(&plan.trajectory, &corr);
+    assert_eq!(verdict, TrajectoryVerdict::MRCFallback);
+    let reason = reason.expect("a refusal carries its reason (#893)");
+    assert_eq!(reason, TrajectoryRefusalReason::ContainmentBreach);
+
+    // Deny path never mints; the token-less frame dies at the chokepoint.
+    let refused_payload = RosTwistPayload {
+        sequence: 1,
+        issued_at_ms: T_MINT,
+        linear_mps: 2.0,
+        angular_rad_s: 0.0,
+    };
+    assert!(governed_release(verdict, &refused_payload, &sk).is_none());
+    assert!(matches!(
+        consumer.on_frame(&refused_payload.encode(), None, T_VERIFY),
+        FrameOutcome::Refused(RosReleaseRefusal::NoToken)
+    ));
+    assert!(
+        consumer.serial().writes.is_empty(),
+        "the spoken refused command must not reach the serial seam"
+    );
+
+    // The refusal is SPOKEN: the #893-shaped narration (deny code + the
+    // reviewed table sentence, verbatim) goes to the TTS sink.
+    let narration_wire = serde_json::json!({"last": {
+        "at_ms": T_VERIFY,
+        "action": "DenyBreach",
+        "deny_code": reason.code(),
+        "explanation": reason.explain(),
+    }});
+    let spoken = narration_sentence(&narration_wire);
+    speaker.speak(&spoken).unwrap();
+    assert!(
+        spoken.contains("TRAJECTORY_CONTAINMENT_BREACH") && spoken.contains("corridor"),
+        "the spoken reason must be the SPECIFIC explanation: {spoken}"
+    );
+    assert!(
+        !spoken.contains(EXPLAIN_UNKNOWN_MARKER),
+        "never the generic fallback"
+    );
+    assert!(
+        spoken.contains(reason.explain()),
+        "the table sentence is spoken VERBATIM, not paraphrased"
+    );
+
+    // ---- Phase 2: the positive control, spoken ---------------------------
+    let wav_ok = fixture_wav("safe");
+    let stt_ok = ScriptedStt::new("ease forward down the corridor");
+    let mut door_ok = IntentService::new(LlmBrain::new(SpyModel::replying(
+        r#"{"intent":"go_to","x_m":60.0,"y_m":0.0}"#,
+    )));
+    let turn_ok = spoken_turn(&stt_ok, &wav_ok, &mut door_ok, 20_000);
+    assert!(matches!(turn_ok, SpeechTurn::Published { .. }));
+    let intent_ok =
+        MickIntent::from_llm_json(&door_ok.last().unwrap().intent_json).expect("parses");
+
+    let mut doer_ok = LiteralDoer {
+        speed_mps: 2.0,
+        dt_s: 0.5,
+        steps: 15,
+    };
+    let plan_ok = plan_for_intent(&mut doer_ok, &intent_ok, &w);
+    let (verdict_ok, reason_ok) = check(&plan_ok.trajectory, &corr);
+    assert_eq!(verdict_ok, TrajectoryVerdict::Accept, "the control admits");
+    assert_eq!(reason_ok, None);
+
+    let admitted = RosTwistPayload {
+        sequence: 2,
+        issued_at_ms: T_MINT,
+        linear_mps: 2.0,
+        angular_rad_s: 0.0,
+    };
+    let token = governed_release(verdict_ok, &admitted, &sk).expect("admitted verdict mints");
+    assert!(matches!(
+        consumer.on_frame(&admitted.encode(), Some(&token), T_VERIFY),
+        FrameOutcome::Released { sequence: 2 }
+    ));
+
+    // THE assertion: exactly one write ever — the spoken ADMITTED command;
+    // the spoken refused one contributed zero bytes.
+    assert_eq!(
+        consumer.serial().writes.as_slice(),
+        &[(admitted.linear_mps, 0.0)]
+    );
+
+    // And the demo's transcript, for -- --nocapture:
+    println!("YOU said: \"cut across the grass to the kiosk\"");
+    for line in &speaker.lines {
+        println!("CAR said: \"{line}\"");
+    }
+    let _ = std::fs::remove_file(&wav);
+    let _ = std::fs::remove_file(&wav_ok);
+}
+
+/// A GARBLED transcription — noise the STT heard as words — dead-ends at the
+/// same fail-closed parser typed garbage does: the door refuses, no intent
+/// latches, nothing is planned, nothing reaches the motors, and the shell
+/// says it is holding. (The prompt's hardest-to-verify case, verified.)
+#[test]
+fn garbled_transcription_fails_exactly_like_typed_garbage() {
+    let wav = fixture_wav("garbled");
+    let stt = ScriptedStt::new("krrshh uh the the wind noise");
+    // The model, fed nonsense, replies prose — which parse_llm_json refuses.
+    let mut door = IntentService::new(LlmBrain::new(SpyModel::replying("just floor it, trust me")));
+    let mut speaker = RecordingSpeaker::default();
+
+    let turn = spoken_turn(&stt, &wav, &mut door, 10_000);
+    let SpeechTurn::Refused { error, .. } = &turn else {
+        panic!("a garbled turn must be Refused, got {turn:?}");
+    };
+    assert_eq!(error, "MICK_JSON_PARSE_ERROR", "the ONE parser refused");
+    assert!(
+        door.last().is_none(),
+        "no intent latched — the doer has nothing to ground"
+    );
+    speaker.speak(&utterance_for(&turn)).unwrap();
+    assert!(
+        speaker.lines[0].contains("Holding"),
+        "the hold is spoken: {}",
+        speaker.lines[0]
+    );
+
+    // Nothing to plan → nothing minted → the never-released consumer stays
+    // silent through the liveness sweep.
+    let mut consumer = consumer();
+    for k in 0..40u64 {
+        consumer.on_tick(T_VERIFY + k * 100);
+    }
+    assert!(consumer.serial().writes.is_empty());
+    assert_eq!(consumer.release_count(), 0);
+    let _ = std::fs::remove_file(&wav);
+}
+
+/// A corrupt/empty audio clip is refused BEFORE any STT or door call — the
+/// first gate of the fail-closed chain.
+#[test]
+fn corrupt_audio_never_reaches_the_intent_door() {
+    let bad = std::env::temp_dir().join("kirra_spoken_loop_corrupt.wav");
+    std::fs::write(&bad, b"this is not audio").expect("write");
+    let stt = ScriptedStt::new("should never be asked");
+    let mut called = 0u32;
+    let mut publish = |_t: &str| -> Result<String, String> {
+        called += 1;
+        Ok("{}".into())
+    };
+    let err = speech_turn(&stt, &bad, &mut publish).expect_err("garbage bytes are refused");
+    assert!(err.contains("SPEECH_WAV"), "{err}");
+    assert!(stt.heard_wav.borrow().is_none(), "STT was never invoked");
+    assert_eq!(called, 0, "the intent door was never called");
+    let _ = std::fs::remove_file(&bad);
+}

--- a/crates/kirra-sidecars/Cargo.toml
+++ b/crates/kirra-sidecars/Cargo.toml
@@ -11,6 +11,11 @@
 #   * `mick_service`    — Mick `POST /intent`: typed text → LlmBrain (Ollama) →
 #     fail-closed typed intent, published read-only on `GET /intent/last` for
 #     the DOER (occy_doer) to consume. Never a command.
+#   * `speech_shell`    — the voice UX shell (push-to-talk): external STT/TTS
+#     OS processes (whisper.cpp / Piper — never crate deps); the transcript
+#     enters the loop ONLY as text through mick_service's POST /intent, and
+#     TTS speaks the #893 narration verbatim. Input transduction + output
+#     rendering; no new intent path (docs/testing/SPEECH_KITT_DEMO.md).
 #
 # 🔴 FENCED (ci/check_mick_actuation_fence.py): this crate must have NO path to
 # actuation — no release-token mint, no serial consumer, no ROS/DDS transport.

--- a/crates/kirra-sidecars/src/bin/speech_shell.rs
+++ b/crates/kirra-sidecars/src/bin/speech_shell.rs
@@ -1,0 +1,170 @@
+//! **speech_shell** — the voice UX shell around the governed loop. You speak;
+//! Mick proposes; Occy plans; KIRRA bounds; the car says why — out loud.
+//!
+//! A THIN wrapper, by construction (see `speech.rs` module docs): STT and TTS
+//! are external OS processes (whisper.cpp / Piper — never crate deps of the
+//! safety workspace), and the transcript enters the loop ONLY as text through
+//! the EXISTING `mick_service` `POST /intent` door — the same fail-closed
+//! `MickIntent::parse_llm_json` path typed text uses. A misheard command
+//! fails exactly as typed garbage does: 422, no intent latched, no motion.
+//! This binary constructs no intent, no goal, no command — grep it.
+//!
+//! Push-to-talk, never always-on: in interactive mode each turn records ONE
+//! bounded clip via `KIRRA_RECORD_CMD` (e.g. `arecord -d 4 …`) after you
+//! press Enter. No wake word, no open mic.
+//!
+//! Usage:
+//!   speech_shell --wav clip.wav      # one turn from a recorded/synthesized WAV
+//!   speech_shell                     # interactive push-to-talk (needs KIRRA_RECORD_CMD)
+//!
+//! Env (fail-closed on malformed; see docs/testing/SPEECH_KITT_DEMO.md):
+//!   KIRRA_STT_CMD     required   e.g. "whisper-cli -m models/ggml-base.en.bin -np -nt -f"
+//!   KIRRA_TTS_CMD     optional   e.g. "./speak.sh"  (text on stdin; unset → print only)
+//!   KIRRA_RECORD_CMD  optional   e.g. "arecord -d 4 -f S16_LE -r 16000 -c 1"
+//!   KIRRA_MICK_URL    optional   default http://127.0.0.1:8102 (the mick_service)
+
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use kirra_sidecars::speech::{
+    narration_sentence, parse_cmd, speech_turn, utterance_for, PrintSpeaker, ProcessSpeaker,
+    ProcessTranscriber, Speaker, SpeechTurn, RECORD_CMD_ENV, STT_CMD_ENV, TTS_CMD_ENV,
+};
+
+fn env_cmd(key: &'static str) -> Option<(String, Vec<String>)> {
+    match parse_cmd(key, std::env::var(key).ok().as_deref()) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("speech_shell: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// POST the transcript — as text, nothing else — to the existing intent door.
+fn publish_to_mick(
+    http: &reqwest::blocking::Client,
+    mick_url: &str,
+    text: &str,
+) -> Result<String, String> {
+    let resp = http
+        .post(format!("{mick_url}/intent"))
+        .json(&serde_json::json!({ "text": text }))
+        .send()
+        .map_err(|e| format!("mick_service unreachable: {e}"))?;
+    let status = resp.status();
+    let body = resp.text().unwrap_or_default();
+    if status.is_success() {
+        Ok(body)
+    } else {
+        Err(body)
+    }
+}
+
+/// Fetch and render the #893 narration (mick_service's read-only relay of the
+/// verifier's auditor-tier `GET /system/verdicts/last`).
+fn narrate(http: &reqwest::blocking::Client, mick_url: &str) -> String {
+    match http
+        .get(format!("{mick_url}/narration/last"))
+        .send()
+        .and_then(reqwest::blocking::Response::error_for_status)
+    {
+        Ok(resp) => match resp.json::<serde_json::Value>() {
+            Ok(v) => narration_sentence(&v),
+            Err(e) => format!("The narration channel returned unreadable data ({e})."),
+        },
+        Err(e) => format!("The narration channel is not available ({e})."),
+    }
+}
+
+fn one_turn(
+    stt: &ProcessTranscriber,
+    speaker: &mut dyn Speaker,
+    http: &reqwest::blocking::Client,
+    mick_url: &str,
+    wav: &Path,
+) {
+    let mut publish = |text: &str| publish_to_mick(http, mick_url, text);
+    match speech_turn(stt, wav, &mut publish) {
+        Ok(turn) => {
+            let line = utterance_for(&turn);
+            println!("mick: {line}");
+            if let Err(e) = speaker.speak(&line) {
+                eprintln!("speech_shell: TTS failed ({e}) — continuing print-only");
+            }
+            // The governor's word, spoken from the EXISTING narration
+            // side-channel — only when a proposal was actually published.
+            if matches!(turn, SpeechTurn::Published { .. }) {
+                let verdict_line = narrate(http, mick_url);
+                println!("governor: {verdict_line}");
+                if let Err(e) = speaker.speak(&verdict_line) {
+                    eprintln!("speech_shell: TTS failed ({e})");
+                }
+            }
+        }
+        // A bad clip / dead STT process: nothing was published, say so.
+        Err(e) => eprintln!("speech_shell: turn failed fail-closed ({e}) — nothing proposed"),
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mick_url =
+        std::env::var("KIRRA_MICK_URL").unwrap_or_else(|_| "http://127.0.0.1:8102".to_string());
+
+    let Some((stt_prog, stt_args)) = env_cmd(STT_CMD_ENV) else {
+        eprintln!("speech_shell: {STT_CMD_ENV} is required (the external STT command — see docs/testing/SPEECH_KITT_DEMO.md)");
+        std::process::exit(1);
+    };
+    let stt = ProcessTranscriber::new(stt_prog, stt_args);
+
+    let mut speaker: Box<dyn Speaker> = match env_cmd(TTS_CMD_ENV) {
+        Some((prog, tts_args)) => Box::new(ProcessSpeaker::new(prog, tts_args)),
+        None => {
+            eprintln!("speech_shell: {TTS_CMD_ENV} unset — narration will be printed, not spoken");
+            Box::new(PrintSpeaker)
+        }
+    };
+    let http = reqwest::blocking::Client::new();
+
+    // --wav mode: one turn from a file (also what the CI-adjacent smoke uses).
+    if let [flag, path] = args.as_slice() {
+        if flag == "--wav" {
+            one_turn(&stt, speaker.as_mut(), &http, &mick_url, Path::new(path));
+            return;
+        }
+    }
+    if !args.is_empty() {
+        eprintln!("usage: speech_shell [--wav clip.wav]");
+        std::process::exit(2);
+    }
+
+    // Interactive push-to-talk.
+    let Some((rec_prog, rec_args)) = env_cmd(RECORD_CMD_ENV) else {
+        eprintln!(
+            "speech_shell: interactive mode needs {RECORD_CMD_ENV} (a bounded push-to-talk \
+             recorder, e.g. \"arecord -d 4 -f S16_LE -r 16000 -c 1\"); or use --wav <file>"
+        );
+        std::process::exit(1);
+    };
+    println!("speech_shell: push-to-talk — press Enter to record one clip (Ctrl-D quits).");
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match stdin.lock().read_line(&mut line) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {}
+        }
+        let wav: PathBuf =
+            std::env::temp_dir().join(format!("kirra_speech_{}.wav", std::process::id()));
+        println!("(recording…)");
+        match Command::new(&rec_prog).args(&rec_args).arg(&wav).status() {
+            Ok(s) if s.success() => one_turn(&stt, speaker.as_mut(), &http, &mick_url, &wav),
+            Ok(s) => eprintln!("speech_shell: recorder exited {s} — nothing proposed"),
+            Err(e) => eprintln!("speech_shell: recorder failed ({e}) — nothing proposed"),
+        }
+        let _ = std::fs::remove_file(&wav);
+    }
+}

--- a/crates/kirra-sidecars/src/lib.rs
+++ b/crates/kirra-sidecars/src/lib.rs
@@ -26,4 +26,5 @@ pub mod mick;
 pub mod narrator;
 pub mod net;
 pub mod planner;
+pub mod speech;
 pub mod taj;

--- a/crates/kirra-sidecars/src/speech.rs
+++ b/crates/kirra-sidecars/src/speech.rs
@@ -1,0 +1,516 @@
+//! Speech I/O for the governed loop — **input transduction and output
+//! rendering ONLY.**
+//!
+//! ```text
+//! audio in → STT (external OS process) → text ──▶ POST /intent  (the EXISTING
+//!                                                  fail-closed door: mick.rs
+//!                                                  handle_text → LlmBrain::
+//!                                                  decide_request →
+//!                                                  MickIntent::parse_llm_json)
+//! …the governed loop, unchanged…
+//! verdict + reason (the #893 narration side-channel) ──▶ TTS (external OS
+//!                                                          process) → audio out
+//! ```
+//!
+//! 🔴 **The structural no-bypass guarantee**: this module imports NOTHING from
+//! `kirra_planner` (no `MickIntent`, no `Goal`, no plan types) and NOTHING
+//! from the checker. Its only output toward the loop is a `String` handed to
+//! a text publisher — the same `POST /intent` door typed text uses. A
+//! misheard command, a garbled transcription, or ambient noise parsed as
+//! words therefore dead-ends exactly where typed garbage does: in
+//! `MickIntent::parse_llm_json` returning a parse failure → no latched
+//! intent → no motion. There is no path from audio to a goal that does not
+//! pass through that parser.
+//!
+//! **TTS is a pure sink.** [`Speaker`] consumes strings — the intent door's
+//! ack/refusal line and the #893 narration sentence (the `explain_deny_token`
+//! / trajectory-reason table text, spoken VERBATIM via
+//! [`narration_sentence`]) — and renders audio. It exposes no route, accepts
+//! no input from the loop's consumers, and returns nothing the loop reads.
+//!
+//! STT/TTS engines are **external OS processes** (whisper.cpp, Piper), like
+//! `taj_service` is a sidecar — never crate dependencies of the safety
+//! workspace. This module only spawns and pipes them.
+
+use std::io::Write as _;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// External STT command (env). Convention: the command receives the WAV path
+/// APPENDED as its last argument and prints the transcript to stdout — e.g.
+/// `whisper-cli -m models/ggml-base.en.bin -np -nt -f` (whisper.cpp). Unset →
+/// the speech shell refuses to start (it has no purpose without an ear).
+pub const STT_CMD_ENV: &str = "KIRRA_STT_CMD";
+
+/// External TTS command (env). Convention: the command receives the text to
+/// speak on STDIN and renders/plays it — e.g. a one-line wrapper around
+/// `piper --model en_US-….onnx --output-raw | aplay -r 22050 -f S16_LE`.
+/// Unset → narration is PRINTED, not spoken (the sink degrades to stdout;
+/// nothing else changes).
+pub const TTS_CMD_ENV: &str = "KIRRA_TTS_CMD";
+
+/// External push-to-talk record command (env). Convention: the command
+/// receives the output WAV path appended as its last argument and records a
+/// bounded clip — e.g. `arecord -d 4 -f S16_LE -r 16000 -c 1` (the `-d`
+/// bound is the push-to-talk discipline: no always-on mic). Unset → the
+/// shell runs in `--wav <file>` mode only.
+pub const RECORD_CMD_ENV: &str = "KIRRA_RECORD_CMD";
+
+/// Parse an external-command env value into (program, args). Fail-closed on
+/// a SET-but-blank value (the env_config convention: malformed config is a
+/// startup error, never a silent default); `None` in → `None` out (feature
+/// off / caller decides).
+pub fn parse_cmd(
+    env_key: &str,
+    raw: Option<&str>,
+) -> Result<Option<(String, Vec<String>)>, String> {
+    match raw {
+        None => Ok(None),
+        Some(s) => {
+            let mut parts = s.split_whitespace().map(str::to_string);
+            match parts.next() {
+                Some(program) => Ok(Some((program, parts.collect()))),
+                None => Err(format!(
+                    "{env_key}: set but blank — refusing to start (unset it or give a command)"
+                )),
+            }
+        }
+    }
+}
+
+/// Minimal WAV facts, from a fail-closed header parse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WavInfo {
+    pub channels: u16,
+    pub sample_rate: u32,
+    pub data_len: u32,
+}
+
+/// Fail-closed validation of a WAV byte stream BEFORE it is handed to the
+/// external STT process: RIFF/WAVE framing, a PCM (1) or IEEE-float (3)
+/// `fmt ` chunk, sane channel/rate fields, and a non-empty `data` chunk.
+/// Anything else — a truncated file, a random blob, an empty recording — is
+/// refused here, producing NO transcript and therefore no intent-door call.
+pub fn validate_wav(bytes: &[u8]) -> Result<WavInfo, &'static str> {
+    if bytes.len() < 44 {
+        return Err("SPEECH_WAV_TRUNCATED");
+    }
+    if &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
+        return Err("SPEECH_WAV_NOT_RIFF_WAVE");
+    }
+    let mut pos = 12usize;
+    let mut fmt: Option<(u16, u16, u32)> = None; // (audio_format, channels, sample_rate)
+    let mut data_len: Option<u32> = None;
+    while pos + 8 <= bytes.len() {
+        let id = &bytes[pos..pos + 4];
+        let len = u32::from_le_bytes([
+            bytes[pos + 4],
+            bytes[pos + 5],
+            bytes[pos + 6],
+            bytes[pos + 7],
+        ]) as usize;
+        let body = pos + 8;
+        match id {
+            b"fmt " => {
+                if body + 8 > bytes.len() || len < 16 {
+                    return Err("SPEECH_WAV_BAD_FMT");
+                }
+                let audio_format = u16::from_le_bytes([bytes[body], bytes[body + 1]]);
+                let channels = u16::from_le_bytes([bytes[body + 2], bytes[body + 3]]);
+                let sample_rate = u32::from_le_bytes([
+                    bytes[body + 4],
+                    bytes[body + 5],
+                    bytes[body + 6],
+                    bytes[body + 7],
+                ]);
+                fmt = Some((audio_format, channels, sample_rate));
+            }
+            b"data" => {
+                data_len = Some(len as u32);
+            }
+            _ => {}
+        }
+        // Chunks are word-aligned (pad byte on odd lengths).
+        pos = body + len + (len & 1);
+    }
+    let (audio_format, channels, sample_rate) = fmt.ok_or("SPEECH_WAV_NO_FMT")?;
+    if audio_format != 1 && audio_format != 3 {
+        return Err("SPEECH_WAV_NOT_PCM");
+    }
+    if channels == 0 || sample_rate == 0 {
+        return Err("SPEECH_WAV_BAD_FMT");
+    }
+    let data_len = data_len.ok_or("SPEECH_WAV_NO_DATA")?;
+    if data_len == 0 {
+        return Err("SPEECH_WAV_EMPTY_DATA");
+    }
+    Ok(WavInfo {
+        channels,
+        sample_rate,
+        data_len,
+    })
+}
+
+/// The STT seam: WAV file → transcript text. The production impl is
+/// [`ProcessTranscriber`] (an external whisper.cpp-class OS process); tests
+/// use a scripted stand-in — the same pattern as `kirra-mick`'s
+/// `MockModel`-vs-live-Ollama split.
+pub trait Transcriber {
+    fn transcribe(&self, wav_path: &Path) -> Result<String, String>;
+}
+
+/// STT as an external OS process: `program args… <wav_path>` → stdout.
+pub struct ProcessTranscriber {
+    program: String,
+    args: Vec<String>,
+}
+
+impl ProcessTranscriber {
+    #[must_use]
+    pub fn new(program: impl Into<String>, args: Vec<String>) -> Self {
+        Self {
+            program: program.into(),
+            args,
+        }
+    }
+}
+
+impl Transcriber for ProcessTranscriber {
+    fn transcribe(&self, wav_path: &Path) -> Result<String, String> {
+        let out = Command::new(&self.program)
+            .args(&self.args)
+            .arg(wav_path)
+            .stdin(Stdio::null())
+            .output()
+            .map_err(|e| format!("SPEECH_STT_SPAWN_FAILED: {} ({e})", self.program))?;
+        if !out.status.success() {
+            return Err(format!("SPEECH_STT_EXIT: {}", out.status));
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+}
+
+/// The TTS sink: text → audio (or stdout). Write-only by construction —
+/// `speak` returns no data the loop could consume.
+pub trait Speaker {
+    fn speak(&mut self, text: &str) -> Result<(), String>;
+}
+
+/// TTS as an external OS process: the text is written to the child's STDIN.
+pub struct ProcessSpeaker {
+    program: String,
+    args: Vec<String>,
+}
+
+impl ProcessSpeaker {
+    #[must_use]
+    pub fn new(program: impl Into<String>, args: Vec<String>) -> Self {
+        Self {
+            program: program.into(),
+            args,
+        }
+    }
+}
+
+impl Speaker for ProcessSpeaker {
+    fn speak(&mut self, text: &str) -> Result<(), String> {
+        let mut child = Command::new(&self.program)
+            .args(&self.args)
+            .stdin(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("SPEECH_TTS_SPAWN_FAILED: {} ({e})", self.program))?;
+        if let Some(stdin) = child.stdin.as_mut() {
+            stdin
+                .write_all(text.as_bytes())
+                .and_then(|()| stdin.write_all(b"\n"))
+                .map_err(|e| format!("SPEECH_TTS_WRITE_FAILED: {e}"))?;
+        }
+        drop(child.stdin.take());
+        let status = child
+            .wait()
+            .map_err(|e| format!("SPEECH_TTS_WAIT_FAILED: {e}"))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("SPEECH_TTS_EXIT: {status}"))
+        }
+    }
+}
+
+/// The degraded sink when `KIRRA_TTS_CMD` is unset: narration goes to stdout.
+pub struct PrintSpeaker;
+
+impl Speaker for PrintSpeaker {
+    fn speak(&mut self, text: &str) -> Result<(), String> {
+        println!("🔊 {text}");
+        Ok(())
+    }
+}
+
+/// One speech turn's outcome, for the caller's logging/tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpeechTurn {
+    /// The clip validated but transcribed to nothing (silence / pure noise):
+    /// nothing was published — the intent door was never called.
+    NothingHeard,
+    /// The transcript was handed to the intent door, which ACCEPTED it (the
+    /// fail-closed parse produced a typed intent). Carries the door's ack.
+    Published { transcript: String, ack: String },
+    /// The transcript was handed to the intent door, which REFUSED it (parse
+    /// failure / rate limit / bad context). Fail-closed: no intent latched,
+    /// no motion — identical to typed garbage. Carries the door's error.
+    Refused { transcript: String, error: String },
+}
+
+/// Drive one turn: WAV file → validate → external STT → transcript →
+/// `publish_text` (the caller's binding to the EXISTING `POST /intent`
+/// door — nothing else). This function never constructs an intent, a goal,
+/// or a command; its only loop-facing act is handing `&str` to the closure.
+///
+/// `publish_text` contract: `Ok(ack_body)` when the door accepted (200),
+/// `Err(error_body)` when it refused (4xx) — transport failures are also
+/// `Err` (fail-closed: indistinguishable from refusal, nothing moves).
+pub fn speech_turn(
+    transcriber: &dyn Transcriber,
+    wav_path: &Path,
+    publish_text: &mut dyn FnMut(&str) -> Result<String, String>,
+) -> Result<SpeechTurn, String> {
+    let bytes = std::fs::read(wav_path).map_err(|e| format!("SPEECH_WAV_READ: {e}"))?;
+    validate_wav(&bytes).map_err(str::to_string)?;
+    let transcript = transcriber.transcribe(wav_path)?;
+    if transcript.trim().is_empty() {
+        return Ok(SpeechTurn::NothingHeard);
+    }
+    match publish_text(transcript.trim()) {
+        Ok(ack) => Ok(SpeechTurn::Published {
+            transcript: transcript.trim().to_string(),
+            ack,
+        }),
+        Err(error) => Ok(SpeechTurn::Refused {
+            transcript: transcript.trim().to_string(),
+            error,
+        }),
+    }
+}
+
+/// Mick's own spoken line for a turn outcome — UX strings only, NOT safety
+/// narration (the safety sentence is the #893 table text spoken verbatim by
+/// [`narration_sentence`]). The refusal line never speculates about what was
+/// meant: fail-closed means holding, and saying so.
+#[must_use]
+pub fn utterance_for(turn: &SpeechTurn) -> String {
+    match turn {
+        SpeechTurn::NothingHeard => "I didn't catch anything.".to_string(),
+        SpeechTurn::Published { transcript, .. } => {
+            format!("Heard: \"{transcript}\". Proposing it to the planner — the governor has the final word.")
+        }
+        SpeechTurn::Refused { transcript, .. } => {
+            format!("Heard: \"{transcript}\", but I couldn't turn that into a safe instruction. Holding.")
+        }
+    }
+}
+
+/// Render the #893 narration relay body (`GET /narration/last` →
+/// `{"last": null | {at_ms, action, deny_code, explanation}}`) as the spoken
+/// sentence. The `explanation` string — the reviewed `explain_deny_token` /
+/// trajectory-reason table text — is spoken VERBATIM; this function composes
+/// framing around it and generates no new safety-relevant text. A body that
+/// is not that shape fails closed to a said-so ("nothing to narrate" is
+/// never fabricated from an unrecognized payload).
+#[must_use]
+pub fn narration_sentence(body: &serde_json::Value) -> String {
+    let Some(last) = body.get("last") else {
+        return "The narration channel returned something I don't recognize.".to_string();
+    };
+    if last.is_null() {
+        return "No actuator command has been judged since the verifier started.".to_string();
+    }
+    let action = last.get("action").and_then(|v| v.as_str()).unwrap_or("?");
+    match (
+        last.get("deny_code").and_then(|v| v.as_str()),
+        last.get("explanation").and_then(|v| v.as_str()),
+    ) {
+        (Some(code), Some(sentence)) => {
+            format!("The governor's last verdict was {action} ({code}). {sentence}")
+        }
+        (Some(code), None) => format!("The governor's last verdict was {action} ({code})."),
+        _ => format!("The governor's last command verdict was {action}."),
+    }
+}
+
+/// Serialize PCM16 mono samples as a minimal valid WAV byte stream. Used to
+/// GENERATE the deterministic audio fixtures the CI tests transcribe-from
+/// (no binary blob committed; the fixture is byte-reproducible from code) —
+/// and handy for any harness that needs a synthetic clip. Pure encoder; it
+/// never touches audio hardware.
+#[must_use]
+pub fn pcm16_wav_bytes(sample_rate: u32, samples: &[i16]) -> Vec<u8> {
+    let data_len = (samples.len() * 2) as u32;
+    let mut out = Vec::with_capacity(44 + data_len as usize);
+    out.extend_from_slice(b"RIFF");
+    out.extend_from_slice(&(36 + data_len).to_le_bytes());
+    out.extend_from_slice(b"WAVE");
+    out.extend_from_slice(b"fmt ");
+    out.extend_from_slice(&16u32.to_le_bytes());
+    out.extend_from_slice(&1u16.to_le_bytes()); // PCM
+    out.extend_from_slice(&1u16.to_le_bytes()); // mono
+    out.extend_from_slice(&sample_rate.to_le_bytes());
+    out.extend_from_slice(&(sample_rate * 2).to_le_bytes()); // byte rate
+    out.extend_from_slice(&2u16.to_le_bytes()); // block align
+    out.extend_from_slice(&16u16.to_le_bytes()); // bits/sample
+    out.extend_from_slice(b"data");
+    out.extend_from_slice(&data_len.to_le_bytes());
+    for s in samples {
+        out.extend_from_slice(&s.to_le_bytes());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wav_bytes(sample_rate: u32, samples: &[i16]) -> Vec<u8> {
+        pcm16_wav_bytes(sample_rate, samples)
+    }
+
+    #[test]
+    fn wav_validation_accepts_a_real_pcm_clip() {
+        let bytes = wav_bytes(16_000, &[0, 1000, -1000, 500]);
+        let info = validate_wav(&bytes).expect("valid PCM WAV");
+        assert_eq!(
+            info,
+            WavInfo {
+                channels: 1,
+                sample_rate: 16_000,
+                data_len: 8
+            }
+        );
+    }
+
+    /// 🔴 Fail-closed at the first gate: garbage audio input produces NO
+    /// transcript and therefore no intent-door call at all.
+    #[test]
+    fn wav_validation_refuses_garbage_fail_closed() {
+        for (bytes, why) in [
+            (Vec::new(), "empty file"),
+            (vec![0u8; 20], "truncated"),
+            (
+                b"NOT A WAVE FILE AT ALL......................".to_vec(),
+                "not RIFF",
+            ),
+            (wav_bytes(16_000, &[]), "empty data chunk"),
+            (wav_bytes(0, &[1, 2]), "zero sample rate"),
+        ] {
+            assert!(validate_wav(&bytes).is_err(), "{why} must be refused");
+        }
+        // A non-PCM format tag is refused too.
+        let mut bytes = wav_bytes(16_000, &[1, 2]);
+        bytes[20] = 7; // audio_format = 7 (µ-law)
+        assert_eq!(validate_wav(&bytes), Err("SPEECH_WAV_NOT_PCM"));
+    }
+
+    #[test]
+    fn parse_cmd_is_fail_closed_on_blank_and_off_on_unset() {
+        assert_eq!(parse_cmd("K", None), Ok(None));
+        let (prog, args) = parse_cmd("K", Some("whisper-cli -m model.bin -f"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(prog, "whisper-cli");
+        assert_eq!(args, vec!["-m", "model.bin", "-f"]);
+        assert!(parse_cmd("K", Some("   ")).is_err(), "blank-but-set aborts");
+    }
+
+    struct Scripted(&'static str);
+    impl Transcriber for Scripted {
+        fn transcribe(&self, _wav: &Path) -> Result<String, String> {
+            Ok(self.0.to_string())
+        }
+    }
+
+    fn temp_wav(name: &str) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!("kirra_speech_test_{name}.wav"));
+        std::fs::write(&p, wav_bytes(16_000, &[0, 200, -200, 100])).expect("write wav");
+        p
+    }
+
+    /// The no-bypass property, at this layer: an empty transcription ends the
+    /// turn BEFORE the publish closure — and a non-empty one reaches the loop
+    /// ONLY as text through that closure.
+    #[test]
+    fn silence_publishes_nothing_and_text_goes_only_through_the_door() {
+        let wav = temp_wav("silence");
+        let mut called = 0u32;
+        let mut publish = |_t: &str| -> Result<String, String> {
+            called += 1;
+            Ok("{\"ok\":true}".into())
+        };
+        let turn = speech_turn(&Scripted("   "), &wav, &mut publish).unwrap();
+        assert_eq!(turn, SpeechTurn::NothingHeard);
+        assert_eq!(called, 0, "silence must never call the intent door");
+
+        let mut seen = String::new();
+        let mut publish = |t: &str| -> Result<String, String> {
+            seen = t.to_string();
+            Ok("{\"ok\":true}".into())
+        };
+        let turn = speech_turn(&Scripted("take me to the dock"), &wav, &mut publish).unwrap();
+        assert!(matches!(turn, SpeechTurn::Published { .. }));
+        assert_eq!(seen, "take me to the dock");
+        let _ = std::fs::remove_file(&wav);
+    }
+
+    /// A refused publish (the door's fail-closed parse) is a REFUSED turn —
+    /// surfaced, spoken as a hold, never retried into something else.
+    #[test]
+    fn a_door_refusal_is_a_held_turn() {
+        let wav = temp_wav("refusal");
+        let mut publish =
+            |_t: &str| -> Result<String, String> { Err("MICK_JSON_PARSE_ERROR".into()) };
+        let turn = speech_turn(&Scripted("krrrshh mumble"), &wav, &mut publish).unwrap();
+        assert!(matches!(turn, SpeechTurn::Refused { .. }));
+        let line = utterance_for(&turn);
+        assert!(line.contains("Holding"), "{line}");
+        let _ = std::fs::remove_file(&wav);
+    }
+
+    #[test]
+    fn narration_sentence_speaks_the_table_text_verbatim() {
+        let body = serde_json::json!({"last": {
+            "at_ms": 123, "action": "DenyBreach",
+            "deny_code": "INVALID_TIME_DELTA",
+            "explanation": "The command reported a zero or negative time step."
+        }});
+        let line = narration_sentence(&body);
+        assert!(
+            line.contains("INVALID_TIME_DELTA")
+                && line.contains("The command reported a zero or negative time step."),
+            "{line}"
+        );
+        assert_eq!(
+            narration_sentence(&serde_json::json!({"last": null})),
+            "No actuator command has been judged since the verifier started."
+        );
+        // Not the endpoint's shape → said so, never fabricated.
+        let odd = narration_sentence(&serde_json::json!({"posture": "Nominal"}));
+        assert!(odd.contains("don't recognize"), "{odd}");
+    }
+
+    /// The process seams, driven by real OS processes (Unix coreutils).
+    #[cfg(unix)]
+    #[test]
+    fn process_transcriber_and_speaker_run_external_commands() {
+        let wav = temp_wav("process");
+        // `echo hello <wav>` → stdout starts with "hello".
+        let t = ProcessTranscriber::new("echo", vec!["hello".into()]);
+        let text = t.transcribe(&wav).expect("echo runs");
+        assert!(text.starts_with("hello"), "{text}");
+        // `cat` consumes stdin and exits 0 — the sink contract.
+        let mut s = ProcessSpeaker::new("cat", vec![]);
+        assert!(s.speak("narration line").is_ok());
+        // A missing binary fails loudly, not silently.
+        let missing = ProcessTranscriber::new("definitely-not-a-real-binary-kirra", vec![]);
+        assert!(missing.transcribe(&wav).is_err());
+        let _ = std::fs::remove_file(&wav);
+    }
+}

--- a/docs/testing/SPEECH_KITT_DEMO.md
+++ b/docs/testing/SPEECH_KITT_DEMO.md
@@ -1,0 +1,76 @@
+# The spoken governed loop — KITT demo (speech I/O over #894)
+
+You speak; Mick proposes; Occy plans; KIRRA bounds; **the car says why — out
+loud.** Speech is a thin UX shell around the governed loop: input transduction
+and output rendering only. Nothing inside the loop changed.
+
+```
+audio in → STT (whisper.cpp, OS process) → text
+        → mick_service POST /intent            ← the EXISTING fail-closed door
+          (LlmBrain::decide_request → MickIntent::parse_llm_json)
+        → GET /intent/last → occy_doer → planner_service → checker → …
+verdict + reason (#893) → GET /narration/last → TTS (Piper, OS process) → audio out
+```
+
+🔴 **The one rule:** speech text becomes an intent ONLY through
+`MickIntent::parse_llm_json` — the same parser typed text uses
+(`crates/kirra-sidecars/src/mick.rs` `handle_text`). A misheard command, a
+garbled transcription, or noise-as-words fails exactly like typed garbage:
+422, no intent latched, no motion. The speech layer
+(`crates/kirra-sidecars/src/speech.rs`) imports nothing from the planner and
+can only hand a `String` to that door. TTS is a pure sink: it consumes the
+door's ack line and the #893 narration sentence (spoken **verbatim** from the
+reviewed explanation tables) and produces audio — no route, no command
+surface.
+
+STT and TTS engines are **external OS processes**, never crate dependencies of
+the safety workspace — the `taj_service`-sidecar discipline. The Mick
+actuation fence (`ci/check_mick_actuation_fence.py`) covers the speech module
+and shell like everything else in `kirra-sidecars`.
+
+## What runs in CI vs what's manual
+
+| Layer | CI (deterministic, every push) | Manual demo only |
+|---|---|---|
+| Audio gate | `speech.rs` WAV validation over generated PCM fixtures (fail-closed on garbage/empty/non-PCM) | live `arecord` clips |
+| STT | scripted `Transcriber` seam (the `MockModel`-vs-live-Ollama precedent) driving the REAL door + loop: `crates/kirra-actuation-consumer/tests/spoken_governed_loop.rs` | whisper.cpp on the Orin |
+| The loop | real parse → real grounding → real checker → real chokepoint; refused-spoken + admitted-positive-control + garbled-fails-closed | same binaries, live |
+| TTS | recording `Speaker` sink asserting the SPECIFIC refusal sentence (never `EXPLAIN_UNKNOWN`) is what gets spoken | Piper voices it |
+
+## Manual demo setup (Orin / any Linux box)
+
+1. **Engines** (outside the workspace):
+   - [whisper.cpp](https://github.com/ggml-org/whisper.cpp): build `whisper-cli`,
+     fetch a model (`ggml-base.en.bin` is plenty for command phrases).
+   - [Piper](https://github.com/rhasspy/piper): fetch a voice, wrap playback in
+     a one-line script, e.g. `speak.sh`:
+     ```sh
+     #!/bin/sh
+     exec piper --model en_US-lessac-medium.onnx --output-raw | aplay -r 22050 -f S16_LE -t raw -
+     ```
+2. **The loop** (from #894): `mick_service` (+ Ollama), `planner_service`,
+   `taj_service`, the `occy_doer` bridge — per `deploy/systemd/README.md` and
+   `docs/testing/OCCY_DOER_BRIDGE.md`. Narration needs `mick_service` started
+   with `KIRRA_VERIFIER_URL` + `KIRRA_MICK_AUDITOR_TOKEN` (an **auditor-role
+   principal token — never the admin token**).
+3. **The shell** (push-to-talk; no wake word, no open mic — each turn records
+   one bounded clip):
+   ```sh
+   export KIRRA_STT_CMD="whisper-cli -m models/ggml-base.en.bin -np -nt -f"
+   export KIRRA_TTS_CMD="./speak.sh"                       # unset → print-only
+   export KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
+   cargo run -p kirra-sidecars --bin speech_shell           # Enter = talk
+   # or, from a recorded clip:
+   cargo run -p kirra-sidecars --bin speech_shell -- --wav clip.wav
+   ```
+
+Say something the corridor won't allow. The planner will try; the checker will
+refuse; and the car will tell you which invariant you asked it to break —
+in the exact reviewed sentence from the explanation tables, through a speaker.
+
+## Explicitly out of scope
+
+Serial protocol / motor bringup (hardware-gated; ADR-0033: the verifying
+consumer *is* the motor bringup) · sros2 (Tier-2) · any change inside the loop
+(verdict core, fence, parser, `TrajectoryVerdict` — all frozen) · wake-word /
+always-listening.


### PR DESCRIPTION
**Do not merge — human review requested.**

Voice as a **thin UX shell** around the #894 loop: `audio → STT → text → [the EXISTING fail-closed parse] → intent → …loop… → verdict+reason → TTS → audio`. Nothing inside the loop changed.

## Report (the five asked-for confirmations)

1. **STT reaches a goal ONLY through the existing parser — no bypass.** The speech module (`crates/kirra-sidecars/src/speech.rs`) imports nothing from `kirra_planner` or the checker; its only loop-facing act is handing the transcript `&str` to a text publisher (`speech_turn`, speech.rs). The shell binds that publisher to `POST /intent` on `mick_service` (`src/bin/speech_shell.rs` `publish_to_mick`) — the same route typed text uses, backed by `IntentService::handle_text` → `LlmBrain::decide_request` → `MickIntent::parse_llm_json` (`crates/kirra-sidecars/src/mick.rs:148-180`, `crates/kirra-planner/src/mick_llm.rs:321-336`). The e2e test drives the REAL door core and proves a garbled transcription fails identically to typed garbage (`tests/spoken_governed_loop.rs::garbled_transcription_fails_exactly_like_typed_garbage`: `MICK_JSON_PARSE_ERROR`, latch untouched, zero writes). Upstream of the door there's a second fail-closed gate: corrupt/empty audio is refused before STT is even invoked (`corrupt_audio_never_reaches_the_intent_door`).
2. **Fence still passes and covers the new components.** `ci/check_mick_actuation_fence.py`: INTACT — `kirra-sidecars` closure unchanged (speech.rs is std-only; STT/TTS are external OS processes, not deps), symbol scan covers the new sources. Orphan-core + quality-guardrail gates green.
3. **Verdict core, `TrajectoryVerdict`, intent parser byte-unchanged.** `git diff origin/main -- crates/kirra-core crates/kirra-trajectory crates/kirra-planner src/verdicts.rs` is empty; talisman blob still `ed00f4da…`.
4. **TTS is a pure sink.** `Speaker::speak(&str) -> Result<(), _>` returns nothing the loop reads; `ProcessSpeaker` writes text to the child's stdin and exits. It consumes only the door's ack line and the #893 narration sentence — `narration_sentence` speaks the reviewed explanation-table text **verbatim** (pinned by test: `spoken.contains(reason.explain())`). No route, no command surface.
5. **CI vs manual.** CI: generated byte-reproducible PCM fixtures through the REAL WAV gate + scripted STT seam + prompt-spying model + the real door/doer/checker/chokepoint (3 e2e tests + 7 speech unit tests, deterministic, no engines needed). Manual: whisper.cpp + Piper + push-to-talk mic via `speech_shell` (`docs/testing/SPEECH_KITT_DEMO.md`). No wake word, no always-on mic — each turn records one bounded clip.

## The demo, in CI

`spoken_unsafe_intent_is_refused_and_the_reason_is_spoken`: "cut across the grass to the kiosk" → intent → literal doer leaves the corridor → checker refuses `TRAJECTORY_CONTAINMENT_BREACH` → deny-never-mints → chokepoint refuses → **zero serial writes** → the TTS sink receives the specific corridor sentence (asserted ≠ `EXPLAIN_UNKNOWN`, verbatim from the table). Positive control in the same test: "ease forward down the corridor" → admitted → the single actuation write ever seen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_