### PR TITLE
fix(B1/High): ROS Clamp verdict must derate the forwarded command — effective envelope + regression

### DIFF
--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -53,7 +53,8 @@ use crate::state::{
     AdaptorState, TrajectoryPoint, TrajectoryVerdict, SUBSCRIPTION_STALENESS_TIMEOUT_MS,
 };
 use crate::validation::{
-    check_command_conforms, validate_trajectory_slow_capped, ConformanceVerdict, IncomingControl,
+    check_command_conforms, validate_trajectory_slow_with_envelope, ConformanceVerdict,
+    IncomingControl,
 };
 
 /// Horizon / step for the multi-modal predictive-RSS mode rollout in the slow loop (matches the
@@ -613,6 +614,7 @@ pub async fn run_adapter(
                         traj.trajectory_id,
                         traj.points.clone(),
                         TrajectoryVerdict::MRCFallback,
+                        None,
                         now_ms_fresh(),
                     );
                     continue;
@@ -694,7 +696,10 @@ pub async fn run_adapter(
             );
             let predicted_modes: Vec<_> = predicted_owned.iter().map(|m| m.as_mode()).collect();
 
-            let verdict = validate_trajectory_slow_capped(
+            // B1 fix: take the effective per-pose velocity envelope alongside
+            // the verdict. On a `Clamp` it carries the checker's derated
+            // ceiling to the fast loop's conformance gate; `None` on Accept.
+            let (verdict, _reason, effective_ceiling) = validate_trajectory_slow_with_envelope(
                 &traj.points,
                 slow_corridor.as_ref(),
                 &objects,
@@ -736,6 +741,7 @@ pub async fn run_adapter(
                 traj.trajectory_id,
                 traj.points.clone(),
                 verdict,
+                effective_ceiling,
                 now_mono,
             );
             let elapsed_us = start.elapsed().as_micros();

--- a/crates/kirra-ros2-adapter/src/state.rs
+++ b/crates/kirra-ros2-adapter/src/state.rs
@@ -544,12 +544,18 @@ impl AdaptorState {
     /// `current_verdict`) rather than a stale prior Accept. On
     /// `Pending` (initial / transitional), removes too — Pending is
     /// reserved for absence.
+    /// `effective_ceiling` (B1 fix): the checker's per-pose velocity envelope
+    /// from `validate_trajectory_slow_with_envelope` — `Some` on a `Clamp`
+    /// verdict, `None` on `Accept`. Attached to the installed record so the
+    /// fast loop conforms a `Clamp`-verdict command to the DERATED ceiling, not
+    /// the planner's original speed. Ignored on the removal (MRC/Pending) arm.
     pub fn update_trajectory(
         &self,
         asset_id: impl Into<String>,
         trajectory_id: u64,
         points: Vec<TrajectoryPoint>,
         verdict: TrajectoryVerdict,
+        effective_ceiling: Option<Vec<f64>>,
         now_ms: u64,
     ) {
         let asset_id = asset_id.into();
@@ -561,7 +567,8 @@ impl AdaptorState {
                     points,
                     verdict,
                     now_ms,
-                );
+                )
+                .with_effective_ceiling(effective_ceiling);
                 self.install(record);
             }
             TrajectoryVerdict::MRCFallback | TrajectoryVerdict::Pending => {

--- a/crates/kirra-trajectory/src/state.rs
+++ b/crates/kirra-trajectory/src/state.rs
@@ -99,8 +99,10 @@ impl AcceptedTrajectory {
     /// slow loop calls this on a `Clamp` verdict with the envelope from
     /// [`crate::validation::validate_trajectory_slow_with_envelope`]; the fast
     /// loop's `check_command_conforms` then gates against it. Chainable off
-    /// [`with_verdict`](Self::with_verdict). A `None` argument is a no-op (the
-    /// `Accept` path), keeping the record byte-identical to the pre-fix shape.
+    /// [`with_verdict`](Self::with_verdict). A `None` argument is a no-op — the
+    /// `Accept` path — leaving conformance behaviour byte-identical to before
+    /// this field existed (the field is present on every record; only its value
+    /// changes).
     #[must_use]
     pub fn with_effective_ceiling(mut self, ceiling: Option<Vec<f64>>) -> Self {
         self.effective_velocity_ceiling = ceiling;

--- a/crates/kirra-trajectory/src/state.rs
+++ b/crates/kirra-trajectory/src/state.rs
@@ -25,6 +25,18 @@ pub struct AcceptedTrajectory {
     pub trajectory_id: u64,
     pub points: Vec<TrajectoryPoint>,
     pub verdict: TrajectoryVerdict,
+    /// B1 fix — the effective per-pose velocity ceiling the checker computed,
+    /// aligned index-for-index with `points`. `Some` ONLY on a `Clamp`
+    /// verdict (the slow loop derated at least one pose); `check_command_conforms`
+    /// gates the command against `effective_velocity_ceiling[nearest]` instead
+    /// of the ORIGINAL planner velocity, so a command at the unclamped speed on
+    /// a `Clamp` verdict fails conformance → MRC. `None` on `Accept` (no derate)
+    /// → the fast path is byte-identical to before this field existed.
+    ///
+    /// The derate rides HERE, on the heap-backed slow-loop record — never on
+    /// `TrajectoryVerdict`, which stays a pinned one byte (the #893
+    /// side-channel discipline; see `trajectory_verdict_stays_one_byte`).
+    pub effective_velocity_ceiling: Option<Vec<f64>>,
     /// Wall-clock ms when this trajectory was promoted into the slot. The
     /// fast loop computes age against `now_ms` for staleness.
     pub promoted_at_ms: u64,
@@ -55,6 +67,7 @@ impl AcceptedTrajectory {
             trajectory_id,
             points,
             verdict: TrajectoryVerdict::Accept,
+            effective_velocity_ceiling: None,
             promoted_at_ms,
             max_age_ms: DEFAULT_MAX_AGE_MS,
         }
@@ -76,9 +89,22 @@ impl AcceptedTrajectory {
             trajectory_id,
             points,
             verdict,
+            effective_velocity_ceiling: None,
             promoted_at_ms,
             max_age_ms: DEFAULT_MAX_AGE_MS,
         }
+    }
+
+    /// Attach the checker's effective per-pose velocity ceiling (B1 fix). The
+    /// slow loop calls this on a `Clamp` verdict with the envelope from
+    /// [`crate::validation::validate_trajectory_slow_with_envelope`]; the fast
+    /// loop's `check_command_conforms` then gates against it. Chainable off
+    /// [`with_verdict`](Self::with_verdict). A `None` argument is a no-op (the
+    /// `Accept` path), keeping the record byte-identical to the pre-fix shape.
+    #[must_use]
+    pub fn with_effective_ceiling(mut self, ceiling: Option<Vec<f64>>) -> Self {
+        self.effective_velocity_ceiling = ceiling;
+        self
     }
 
     /// Wall-clock staleness check. Uses `saturating_sub` so a clock skew

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -439,12 +439,13 @@ pub fn validate_trajectory_slow_with_envelope(
     let initial_steering_deg = current_steering_deg_from_odom(latest_odom, config);
     let mut clamp_seen = false;
     // B1 fix — the effective per-pose velocity ceiling, aligned index-for-index
-    // with `trajectory`. Seeded to each pose's PLANNER velocity; a per-pose
-    // `ClampLinear`/`ClampBoth` on the segment ENDING at pose `k` lowers
-    // `ceilings[k]` to the checker's own enforced value. Only surfaced on a
-    // `Clamp` verdict (see the aggregate below); an `Accept` returns `None` so
-    // the fast path is byte-identical.
-    let mut ceilings: Vec<f64> = trajectory.iter().map(|p| p.velocity_mps).collect();
+    // with `trajectory`. LAZILY materialized: stays `None` (zero heap) until a
+    // velocity clamp actually fires, so the common `Accept` path allocates
+    // NOTHING extra on the slow loop (review: Copilot #898). Materialized from
+    // the PLANNER velocities on first clamp; a per-pose `ClampLinear`/`ClampBoth`
+    // on the segment ENDING at pose `k` lowers `ceilings[k]` to the checker's
+    // own enforced value.
+    let mut ceilings: Option<Vec<f64>> = None;
     let mut prev_steering_deg = initial_steering_deg;
     // ADR-0029: the angular channel's "current" yaw rate for the Degraded
     // converge-to-stop-and-HOLD gate. Seeded from odometry (the vehicle's
@@ -477,13 +478,17 @@ pub fn validate_trajectory_slow_with_envelope(
             EnforceAction::Allow => {}
             // B1 fix: capture the checker's own enforced velocity — do NOT
             // discard it. `cmd` was built from segment (i → i+1), so the
-            // clamped linear velocity bounds pose `i + 1`. `ClampSteering`
-            // leaves the velocity ceiling at the planner value (only the
-            // steering axis was derated). `min` guards against a (never-
-            // observed) clamp that reported ABOVE the planner speed.
+            // clamped linear velocity bounds pose `i + 1`. `v` is the enforced
+            // speed and is `<= planner velocity` by the contract
+            // (`ClampLinear`/`ClampBoth` only ever derate DOWN), so it replaces
+            // the seeded planner value directly. `ClampSteering` leaves the
+            // velocity ceiling at the planner value (only the steering axis was
+            // derated).
             EnforceAction::ClampLinear(v) | EnforceAction::ClampBoth { linear: v, .. } => {
                 clamp_seen = true;
-                ceilings[i + 1] = ceilings[i + 1].min(v);
+                let ceilings = ceilings
+                    .get_or_insert_with(|| trajectory.iter().map(|p| p.velocity_mps).collect());
+                ceilings[i + 1] = v;
             }
             EnforceAction::ClampSteering(_) => {
                 clamp_seen = true;
@@ -837,11 +842,14 @@ pub fn validate_trajectory_slow_with_envelope(
 
     // ----- E) Aggregate ------------------------------------------------
     if clamp_seen {
-        // Carry the derated envelope to the fast loop (B1). Even a pure
-        // `ClampSteering` (velocity ceilings == planner speeds) returns the
-        // envelope, so conformance always gates a `Clamp` verdict against an
-        // explicit ceiling rather than silently against the planner points.
-        (TrajectoryVerdict::Clamp, None, Some(ceilings))
+        // Carry the derated velocity envelope to the fast loop (B1). `ceilings`
+        // is `Some` iff a VELOCITY clamp fired; a pure `ClampSteering` (no
+        // velocity derate) leaves it `None`, and conformance then gates against
+        // the planner velocity — which is correct, since the velocity axis was
+        // not derated (the steering derate is bounded separately by the fast
+        // loop's hard-steering-limit check, unchanged). Either way the verdict
+        // is `Clamp`.
+        (TrajectoryVerdict::Clamp, None, ceilings)
     } else {
         (TrajectoryVerdict::Accept, None, None)
     }
@@ -1231,11 +1239,20 @@ pub fn check_command_conforms(
     // planner's unclamped speed would pass despite the checker requiring a
     // derate. When the envelope is absent (an `Accept` verdict → `None`), the
     // ceiling IS the planner velocity, so the `Accept` path is byte-identical.
-    let velocity_ceiling = trajectory
-        .effective_velocity_ceiling
-        .as_ref()
-        .and_then(|c| c.get(nearest_idx).copied())
-        .unwrap_or(nearest.velocity_mps);
+    let velocity_ceiling = match trajectory.effective_velocity_ceiling.as_ref() {
+        // A `Clamp` verdict carries the envelope: the ceiling MUST exist at
+        // this pose. A `Some`-but-missing entry (envelope shorter than
+        // `points`) FAILS CLOSED — a dropped derate must never silently fall
+        // back to the planner speed, which would reintroduce B1 (review:
+        // Copilot #898).
+        Some(ceilings) => match ceilings.get(nearest_idx) {
+            Some(&c) => c,
+            None => return ConformanceVerdict::MRCFallback,
+        },
+        // No envelope (an `Accept` verdict): the planner velocity IS the
+        // ceiling — byte-identical to before this field existed.
+        None => nearest.velocity_mps,
+    };
     if cmd.velocity_mps > velocity_ceiling + VELOCITY_TOLERANCE_MPS {
         return ConformanceVerdict::MRCFallback;
     }

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -272,6 +272,57 @@ pub fn validate_trajectory_slow_explained(
     pedestrians: Option<&crate::vru::PedestrianScene<'_>>,
     frame_trust: FrameTrust,
 ) -> (TrajectoryVerdict, Option<TrajectoryRefusalReason>) {
+    let (verdict, reason, _envelope) = validate_trajectory_slow_with_envelope(
+        trajectory,
+        corridor,
+        objects,
+        config,
+        latest_odom,
+        posture,
+        effective_perception_cap,
+        visibility_range_m,
+        predicted_modes,
+        pedestrians,
+        frame_trust,
+    );
+    (verdict, reason)
+}
+
+/// As [`validate_trajectory_slow_explained`], additionally returning the
+/// **effective per-pose velocity ceiling** the checker computed (B1 fix).
+///
+/// On a `Clamp` verdict the checker derated at least one pose's commanded
+/// velocity (a per-pose `EnforceAction::ClampLinear`/`ClampBoth`, or the
+/// composed perception cap). The third element is `Some(ceilings)` — a
+/// `Vec<f64>` aligned index-for-index with `trajectory`, where `ceilings[k]`
+/// is the maximum velocity permissible at pose `k` (the derated value where a
+/// clamp fired, the planner's own velocity elsewhere). The ROS fast-loop
+/// `check_command_conforms` gates against THIS envelope, so a command at the
+/// planner's original (unclamped) speed on a `Clamp` verdict now fails
+/// conformance → MRC, instead of passing (the finding).
+///
+/// `None` on every other verdict (`Accept` needs no derate; a refusal drives
+/// the MRC directly), so the `Accept` fast path is byte-identical to before.
+/// The verdict enum stays one byte — the envelope rides here on the slow-loop
+/// return, never on `TrajectoryVerdict` (the #893 side-channel discipline).
+#[allow(clippy::too_many_arguments)]
+pub fn validate_trajectory_slow_with_envelope(
+    trajectory: &[TrajectoryPoint],
+    corridor: &dyn CorridorSource,
+    objects: &[PerceivedObject],
+    config: &VehicleConfig,
+    latest_odom: Option<&EgoOdom>,
+    posture: FleetPosture,
+    effective_perception_cap: Option<f64>,
+    visibility_range_m: Option<f64>,
+    predicted_modes: Option<&[PredictedMode<'_>]>,
+    pedestrians: Option<&crate::vru::PedestrianScene<'_>>,
+    frame_trust: FrameTrust,
+) -> (
+    TrajectoryVerdict,
+    Option<TrajectoryRefusalReason>,
+    Option<Vec<f64>>,
+) {
     // ----- Posture short-circuit (M1) ----------------------------------
     //
     // A LockedOut fleet must not be commanded — the safe response is to
@@ -284,6 +335,7 @@ pub fn validate_trajectory_slow_explained(
         return (
             TrajectoryVerdict::MRCFallback,
             Some(TrajectoryRefusalReason::PostureLockedOut),
+            None,
         );
     }
 
@@ -293,6 +345,7 @@ pub fn validate_trajectory_slow_explained(
         return (
             TrajectoryVerdict::MRCFallback,
             Some(TrajectoryRefusalReason::TooFewPoints),
+            None,
         );
     }
 
@@ -342,6 +395,7 @@ pub fn validate_trajectory_slow_explained(
         return (
             TrajectoryVerdict::MRCFallback,
             Some(TrajectoryRefusalReason::ContainmentBreach),
+            None,
         );
     }
 
@@ -384,6 +438,13 @@ pub fn validate_trajectory_slow_explained(
     );
     let initial_steering_deg = current_steering_deg_from_odom(latest_odom, config);
     let mut clamp_seen = false;
+    // B1 fix — the effective per-pose velocity ceiling, aligned index-for-index
+    // with `trajectory`. Seeded to each pose's PLANNER velocity; a per-pose
+    // `ClampLinear`/`ClampBoth` on the segment ENDING at pose `k` lowers
+    // `ceilings[k]` to the checker's own enforced value. Only surfaced on a
+    // `Clamp` verdict (see the aggregate below); an `Accept` returns `None` so
+    // the fast path is byte-identical.
+    let mut ceilings: Vec<f64> = trajectory.iter().map(|p| p.velocity_mps).collect();
     let mut prev_steering_deg = initial_steering_deg;
     // ADR-0029: the angular channel's "current" yaw rate for the Degraded
     // converge-to-stop-and-HOLD gate. Seeded from odometry (the vehicle's
@@ -414,15 +475,24 @@ pub fn validate_trajectory_slow_explained(
         };
         match verdict {
             EnforceAction::Allow => {}
-            EnforceAction::ClampLinear(_)
-            | EnforceAction::ClampSteering(_)
-            | EnforceAction::ClampBoth { .. } => {
+            // B1 fix: capture the checker's own enforced velocity — do NOT
+            // discard it. `cmd` was built from segment (i → i+1), so the
+            // clamped linear velocity bounds pose `i + 1`. `ClampSteering`
+            // leaves the velocity ceiling at the planner value (only the
+            // steering axis was derated). `min` guards against a (never-
+            // observed) clamp that reported ABOVE the planner speed.
+            EnforceAction::ClampLinear(v) | EnforceAction::ClampBoth { linear: v, .. } => {
+                clamp_seen = true;
+                ceilings[i + 1] = ceilings[i + 1].min(v);
+            }
+            EnforceAction::ClampSteering(_) => {
                 clamp_seen = true;
             }
             EnforceAction::DenyBreach(code) => {
                 return (
                     TrajectoryVerdict::MRCFallback,
                     Some(TrajectoryRefusalReason::KinematicsDenied(code)),
+                    None,
                 );
             }
         }
@@ -457,6 +527,7 @@ pub fn validate_trajectory_slow_explained(
                     return (
                         TrajectoryVerdict::MRCFallback,
                         Some(TrajectoryRefusalReason::AngularRateBreach),
+                        None,
                     );
                 }
                 // Issue #70 / ADR-0029 — Degraded converge-to-stop-and-HOLD on
@@ -476,6 +547,7 @@ pub fn validate_trajectory_slow_explained(
                     return (
                         TrajectoryVerdict::MRCFallback,
                         Some(TrajectoryRefusalReason::DegradedAngularHoldBreach),
+                        None,
                     );
                 }
                 prev_omega = omega;
@@ -516,6 +588,7 @@ pub fn validate_trajectory_slow_explained(
             return (
                 TrajectoryVerdict::MRCFallback,
                 Some(TrajectoryRefusalReason::NonFinitePerceptionObject),
+                None,
             );
         }
         for traj_point in trajectory {
@@ -594,6 +667,7 @@ pub fn validate_trajectory_slow_explained(
                 return (
                     TrajectoryVerdict::MRCFallback,
                     Some(TrajectoryRefusalReason::RssLongitudinalBreach),
+                    None,
                 );
             }
 
@@ -670,6 +744,7 @@ pub fn validate_trajectory_slow_explained(
                     return (
                         TrajectoryVerdict::MRCFallback,
                         Some(TrajectoryRefusalReason::RssLateralBreach),
+                        None,
                     );
                 }
             }
@@ -693,6 +768,7 @@ pub fn validate_trajectory_slow_explained(
             return (
                 TrajectoryVerdict::MRCFallback,
                 Some(TrajectoryRefusalReason::PredictiveRssBreach),
+                None,
             );
         }
     }
@@ -708,6 +784,7 @@ pub fn validate_trajectory_slow_explained(
             return (
                 TrajectoryVerdict::MRCFallback,
                 Some(TrajectoryRefusalReason::OcclusionOutrunsVisibility),
+                None,
             );
         }
     }
@@ -753,15 +830,20 @@ pub fn validate_trajectory_slow_explained(
             return (
                 TrajectoryVerdict::MRCFallback,
                 Some(TrajectoryRefusalReason::VruReachableSetBreach),
+                None,
             );
         }
     }
 
     // ----- E) Aggregate ------------------------------------------------
     if clamp_seen {
-        (TrajectoryVerdict::Clamp, None)
+        // Carry the derated envelope to the fast loop (B1). Even a pure
+        // `ClampSteering` (velocity ceilings == planner speeds) returns the
+        // envelope, so conformance always gates a `Clamp` verdict against an
+        // explicit ceiling rather than silently against the planner points.
+        (TrajectoryVerdict::Clamp, None, Some(ceilings))
     } else {
-        (TrajectoryVerdict::Accept, None)
+        (TrajectoryVerdict::Accept, None, None)
     }
 }
 
@@ -1124,22 +1206,37 @@ pub fn check_command_conforms(
     // B. Nearest pose by elapsed time-since-promotion. Saturate the
     // subtraction so a fast-loop call that lands BEFORE `promoted_at_ms`
     // (clock skew at promotion) treats elapsed = 0 — the first pose of
-    // the trajectory.
+    // the trajectory. We take the INDEX (not just the pose) so the effective
+    // velocity ceiling (B1) can be read at the same index.
     let elapsed_s = (now_ms.saturating_sub(trajectory.promoted_at_ms) as f64) / 1000.0;
-    let nearest = trajectory
+    let nearest_idx = trajectory
         .points
         .iter()
-        .find(|p| p.time_from_start_s >= elapsed_s);
-    let nearest = match nearest {
-        Some(p) => p,
+        .position(|p| p.time_from_start_s >= elapsed_s);
+    let nearest_idx = match nearest_idx {
+        Some(idx) => idx,
         // Trajectory exhausted — every pose's time_from_start_s is in
         // the past. The fast loop must MRC; the slow loop is expected
         // to have promoted a fresh trajectory by now.
         None => return ConformanceVerdict::MRCFallback,
     };
+    let nearest = &trajectory.points[nearest_idx];
 
-    // C. Velocity bound
-    if cmd.velocity_mps > nearest.velocity_mps + VELOCITY_TOLERANCE_MPS {
+    // C. Velocity bound — against the EFFECTIVE ceiling (B1 fix).
+    //
+    // On a `Clamp` verdict the slow loop derated at least one pose; the
+    // permissible ceiling is the checker's own enforced value, carried on
+    // `effective_velocity_ceiling` aligned to `points`. Gating against the
+    // ORIGINAL `nearest.velocity_mps` here is the finding — a command at the
+    // planner's unclamped speed would pass despite the checker requiring a
+    // derate. When the envelope is absent (an `Accept` verdict → `None`), the
+    // ceiling IS the planner velocity, so the `Accept` path is byte-identical.
+    let velocity_ceiling = trajectory
+        .effective_velocity_ceiling
+        .as_ref()
+        .and_then(|c| c.get(nearest_idx).copied())
+        .unwrap_or(nearest.velocity_mps);
+    if cmd.velocity_mps > velocity_ceiling + VELOCITY_TOLERANCE_MPS {
         return ConformanceVerdict::MRCFallback;
     }
 

--- a/crates/kirra-trajectory/tests/conformance.rs
+++ b/crates/kirra-trajectory/tests/conformance.rs
@@ -216,10 +216,22 @@ fn b1_clamp_verdict_derates_the_conformance_ceiling() {
     )
     .with_effective_ceiling(Some(ceilings.clone()));
 
-    // Sanity: the checker really derated below the planner's 5 m/s.
+    // Sanity — AND per-index pins (kill any index-shift mutant in the envelope
+    // accumulation, e.g. `i + 1` → `i * 1`): pose 0 is the CURRENT pose, never
+    // derated by a segment, so its ceiling stays the planner speed; every
+    // downstream pose is clamped to the cap; the LAST pose is clamped too (an
+    // off-by-one at the tail would leave it at the planner speed).
+    assert_eq!(
+        ceilings[0], 5.0,
+        "pose 0 (current) must keep the planner speed, not be derated: {ceilings:?}"
+    );
     assert!(
         ceilings.iter().skip(1).all(|&c| c <= cap + 1e-9),
         "post-current poses must be clamped to the cap: {ceilings:?}"
+    );
+    assert!(
+        *ceilings.last().unwrap() <= cap + 1e-9,
+        "the last pose must be clamped (no tail off-by-one): {ceilings:?}"
     );
 
     let cfg = VehicleConfig::default_urban();
@@ -260,6 +272,52 @@ fn b1_clamp_verdict_derates_the_conformance_ceiling() {
     assert_eq!(
         check_command_conforms(&over_ceiling, &traj, &ego, &cfg, now),
         ConformanceVerdict::MRCFallback,
+    );
+
+    // Boundary pin (kills `>` → `>=`): a command EXACTLY at
+    // `ceiling + VELOCITY_TOLERANCE_MPS` is the last ACCEPTED value — the gate
+    // is `>`, strict. `>=` would MRC it.
+    let exactly_at_bound = IncomingControl {
+        velocity_mps: cap + VELOCITY_TOLERANCE_MPS,
+        steering_rad: 0.0,
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&exactly_at_bound, &traj, &ego, &cfg, now),
+        ConformanceVerdict::Accept,
+        "a command exactly at ceiling + tolerance must PASS (the bound is strict `>`)"
+    );
+}
+
+/// Copilot #898 fail-closed hardening: a `Clamp` verdict whose envelope is
+/// `Some` but SHORTER than `points` (a missing ceiling entry at the nearest
+/// pose) must MRC — never silently fall back to the planner speed (which would
+/// reintroduce B1). Also kills any mutant on that fail-closed arm.
+#[test]
+fn b1_short_ceiling_on_a_clamp_verdict_fails_closed() {
+    let promoted = 100_000;
+    let now = promoted + 50; // nearest pose = index 1
+    let traj = AcceptedTrajectory::with_verdict(
+        "av_01",
+        1,
+        straight_pts_at(10.0, 10, 5.0, 0.1),
+        TrajectoryVerdict::Clamp,
+        promoted,
+    )
+    // Envelope length 1 — index 1 (the nearest pose) is MISSING.
+    .with_effective_ceiling(Some(vec![5.0]));
+    let cfg = VehicleConfig::default_urban();
+    // Even a modest command must MRC: the derate for this pose is unknown, so
+    // fail closed rather than trust the planner speed.
+    let cmd = IncomingControl {
+        velocity_mps: 1.0,
+        steering_rad: 0.0,
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::MRCFallback,
+        "a Some-but-short ceiling must fail closed, not fall back to planner speed"
     );
 }
 

--- a/crates/kirra-trajectory/tests/conformance.rs
+++ b/crates/kirra-trajectory/tests/conformance.rs
@@ -41,7 +41,7 @@ fn conforming_command_accepts() {
     // Fresh trajectory, cmd velocity == nearest pose velocity, steering in range.
     let promoted = 100_000;
     let now = promoted + 50;
-    let traj = fresh_accepted(promoted, straight_pts(10, 5.0, 0.1));
+    let traj = fresh_accepted(promoted, straight_pts_at(10.0, 10, 5.0, 0.1));
     let cmd = IncomingControl {
         velocity_mps: 5.0,
         steering_rad: 0.0,
@@ -60,7 +60,7 @@ fn stale_trajectory_mrcs() {
     // Arm A: `is_stale(now)` — now is past promotion + DEFAULT_MAX_AGE_MS.
     let promoted = 100_000;
     let now = promoted + DEFAULT_MAX_AGE_MS + 50;
-    let traj = fresh_accepted(promoted, straight_pts(10, 5.0, 0.1));
+    let traj = fresh_accepted(promoted, straight_pts_at(10.0, 10, 5.0, 0.1));
     let cmd = IncomingControl {
         velocity_mps: 5.0,
         steering_rad: 0.0,
@@ -102,7 +102,7 @@ fn overspeed_command_mrcs() {
     // Arm C: cmd velocity beyond nearest pose velocity + tolerance.
     let promoted = 100_000;
     let now = promoted + 50;
-    let traj = fresh_accepted(promoted, straight_pts(10, 5.0, 0.1));
+    let traj = fresh_accepted(promoted, straight_pts_at(10.0, 10, 5.0, 0.1));
     let cmd = IncomingControl {
         velocity_mps: 5.0 + VELOCITY_TOLERANCE_MPS + 0.1,
         steering_rad: 0.0,
@@ -120,7 +120,7 @@ fn oversteer_command_mrcs() {
     // Arm D: |steering| beyond the vehicle's max steering angle.
     let promoted = 100_000;
     let now = promoted + 50;
-    let traj = fresh_accepted(promoted, straight_pts(10, 5.0, 0.1));
+    let traj = fresh_accepted(promoted, straight_pts_at(10.0, 10, 5.0, 0.1));
     let cfg = VehicleConfig::default_urban();
     let cmd = IncomingControl {
         velocity_mps: 5.0,
@@ -130,5 +130,178 @@ fn oversteer_command_mrcs() {
     assert_eq!(
         check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
         ConformanceVerdict::MRCFallback,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// B1 regression — a `Clamp` verdict must derate the forwarded command.
+//
+// The finding (verified on 8ea3e90): the checker computed `ClampLinear(v)`,
+// discarded it, and `check_command_conforms` gated a `Clamp`-verdict command
+// against the ORIGINAL planner velocity — so a command at the unclamped speed
+// PASSED despite the checker requiring a derate. These tests drive the REAL
+// checker (`validate_trajectory_slow_with_envelope`) so the ceiling is the
+// checker's own value, not a hand-set fixture, and assert the fast loop now
+// gates against it. Companion to the ROS suite; kept here so the checker
+// -coverage gate (`-p kirra-trajectory`) measures the new arm.
+// ---------------------------------------------------------------------------
+use kirra_core::frame_integrity::FrameTrust;
+use kirra_core::FleetPosture;
+use kirra_trajectory::MockCorridorSource;
+
+/// Straight poses starting at `x0` (so the vehicle footprint behind the ego
+/// stays inside the corridor — containment is checked on the full footprint).
+fn straight_pts_at(x0: f64, n: usize, v: f64, dt: f64) -> Vec<TrajectoryPoint> {
+    (0..n)
+        .map(|i| TrajectoryPoint {
+            pose: Pose {
+                x_m: x0 + (i as f64) * v * dt,
+                y_m: 0.0,
+                heading_rad: 0.0,
+            },
+            velocity_mps: v,
+            time_from_start_s: (i as f64) * dt,
+        })
+        .collect()
+}
+
+/// Produce a REAL `Clamp` verdict + its effective envelope: a 5 m/s straight
+/// trajectory in a wide corridor with no objects, derated by a perception cap
+/// of `cap` m/s. The only clamp that fires is the ODD-speed cap, so the
+/// checker returns `ClampLinear(cap)` per over-cap pose → a known ceiling.
+fn clamp_verdict_and_envelope(cap: f64) -> (TrajectoryVerdict, Option<Vec<f64>>) {
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let traj = straight_pts_at(10.0, 10, 5.0, 0.1);
+    let cfg = VehicleConfig::default_urban();
+    let (verdict, reason, envelope) =
+        kirra_trajectory::validation::validate_trajectory_slow_with_envelope(
+            &traj,
+            &corridor,
+            &[],
+            &cfg,
+            None,
+            FleetPosture::Nominal,
+            Some(cap), // the perception-derate cap → per-pose ClampLinear(cap)
+            None,
+            None,
+            None,
+            FrameTrust::Trusted,
+        );
+    assert_eq!(
+        reason, None,
+        "a pure speed-cap derate carries no refusal reason"
+    );
+    (verdict, envelope)
+}
+
+#[test]
+fn b1_clamp_verdict_derates_the_conformance_ceiling() {
+    let cap = 2.0;
+    let (verdict, envelope) = clamp_verdict_and_envelope(cap);
+    assert_eq!(
+        verdict,
+        TrajectoryVerdict::Clamp,
+        "the speed cap must Clamp, not Accept"
+    );
+    let ceilings = envelope.expect("a Clamp verdict must carry the effective envelope");
+
+    let promoted = 100_000;
+    let now = promoted + 50; // lands on pose 1 (elapsed 0.05 s, poses at 0.1 s steps)
+    let traj = AcceptedTrajectory::with_verdict(
+        "av_01",
+        1,
+        straight_pts_at(10.0, 10, 5.0, 0.1),
+        TrajectoryVerdict::Clamp,
+        promoted,
+    )
+    .with_effective_ceiling(Some(ceilings.clone()));
+
+    // Sanity: the checker really derated below the planner's 5 m/s.
+    assert!(
+        ceilings.iter().skip(1).all(|&c| c <= cap + 1e-9),
+        "post-current poses must be clamped to the cap: {ceilings:?}"
+    );
+
+    let cfg = VehicleConfig::default_urban();
+    let ego = EgoOdom::default();
+
+    // 🔴 THE B1 CASE: a command at the planner's ORIGINAL (unclamped) 5 m/s on
+    // a Clamp verdict must now FAIL conformance → MRC. Before the fix it passed.
+    let unclamped = IncomingControl {
+        velocity_mps: 5.0,
+        steering_rad: 0.0,
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&unclamped, &traj, &ego, &cfg, now),
+        ConformanceVerdict::MRCFallback,
+        "a command at the unclamped speed must be refused on a Clamp verdict (B1)"
+    );
+
+    // A command AT the derated ceiling (within tolerance) must PASS — the
+    // vehicle drives, just slower, exactly as the Clamp contract intends.
+    let at_ceiling = IncomingControl {
+        velocity_mps: cap,
+        steering_rad: 0.0,
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&at_ceiling, &traj, &ego, &cfg, now),
+        ConformanceVerdict::Accept,
+        "a command at the derated ceiling must pass (Clamp = drive slower, not stop)"
+    );
+
+    // And just above the ceiling+tolerance must fail.
+    let over_ceiling = IncomingControl {
+        velocity_mps: cap + VELOCITY_TOLERANCE_MPS + 0.5,
+        steering_rad: 0.0,
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&over_ceiling, &traj, &ego, &cfg, now),
+        ConformanceVerdict::MRCFallback,
+    );
+}
+
+#[test]
+fn b1_accept_path_is_byte_identical_no_envelope() {
+    // The honest Accept path is unchanged: no cap → Accept, envelope None, and
+    // a command at the planner speed still passes (the fix must not over-derate
+    // a trajectory the checker admitted at full speed).
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let traj_pts = straight_pts_at(10.0, 10, 5.0, 0.1);
+    let cfg = VehicleConfig::default_urban();
+    let (verdict, _r, envelope) =
+        kirra_trajectory::validation::validate_trajectory_slow_with_envelope(
+            &traj_pts,
+            &corridor,
+            &[],
+            &cfg,
+            None,
+            FleetPosture::Nominal,
+            None, // no derate
+            None,
+            None,
+            None,
+            FrameTrust::Trusted,
+        );
+    assert_eq!(verdict, TrajectoryVerdict::Accept);
+    assert_eq!(
+        envelope, None,
+        "an Accept verdict carries no envelope (byte-identical fast path)"
+    );
+
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let traj =
+        AcceptedTrajectory::with_verdict("av_01", 1, traj_pts, TrajectoryVerdict::Accept, promoted);
+    let cmd = IncomingControl {
+        velocity_mps: 5.0,
+        steering_rad: 0.0,
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::Accept,
     );
 }

--- a/docs/adr/0034-clamp-verdict-effective-envelope.md
+++ b/docs/adr/0034-clamp-verdict-effective-envelope.md
@@ -1,0 +1,85 @@
+# ADR-0034: The Clamp-verdict effective velocity envelope on the ROS fast loop
+
+| | |
+|---|---|
+| Status | Proposed — pending owner sign-off |
+| Date | 2026-07-10 |
+| Supersedes | — |
+| Related | ADR-0033 (actuation authority / PO-2 topology gap), #893 (verdict narration side-channel), the H1/M1 `ClampBoth` re-pin (`1a258a5`, `7e7b7bb`) |
+
+## Context — finding B1
+
+A Cursor architecture review flagged **B1 (High)**, verified real on `8ea3e90`:
+
+On the ROS deployment path, the slow-loop checker computes a per-pose
+`EnforceAction::ClampLinear(v)` / `ClampBoth{linear: v, ..}` — the derated
+velocity is *inside* the variant — but the slow loop **discarded** it
+(`crates/kirra-trajectory/src/validation.rs`, the `clamp_seen = true` arm) and
+aggregated to a payload-less `TrajectoryVerdict::Clamp`. `AcceptedTrajectory`
+stored the **original planner points**, and the fast-loop conformance gate
+`check_command_conforms` compared the incoming command against
+`nearest.velocity_mps` — the planner's *unclamped* velocity — **never reading
+`trajectory.verdict`**.
+
+Consequence: a command at the planner's original (over-cap) speed on a `Clamp`
+verdict **passed conformance**, so the checker's derate was silently dropped in
+the adapter's own gate. This is the sibling of ADR-0033/PO-2 (checker verdict
+authoritative in architecture, unenforced on the ROS path) but distinct and
+arguably worse: no rogue actor — the trusted gate ran, said "clamp", and the
+clamp was dropped. `AcceptedTrajectory::fail_closed`'s own docstring already
+promised "Phase 3 conformance enforces the derate" — the contract existed; the
+wiring did not.
+
+## Decision
+
+Carry the checker's **effective per-pose velocity envelope** from the slow loop
+to the fast loop, and gate `Clamp`-verdict conformance against it.
+
+**Representation — Option A (chosen): a field on `AcceptedTrajectory`.**
+`effective_velocity_ceiling: Option<Vec<f64>>`, aligned index-for-index with
+`points`. `Some(ceilings)` on `Clamp` (the checker's own enforced value per
+pose, the planner velocity where no clamp fired); `None` on `Accept` (the fast
+path stays byte-identical). `check_command_conforms` gates against
+`ceiling[nearest]` when present, else the planner velocity (unchanged).
+
+**Rejected — Option B: a payload on `TrajectoryVerdict::Clamp`.**
+`TrajectoryVerdict` is pinned at **one byte** (`trajectory_verdict_stays_one_byte`,
+`crates/kirra-core/src/trajectory.rs`) and lives in the lean core beside the
+frozen kinematics talisman (`ed00f4da…`). Growing it with a payload is exactly
+what #893 refused for narration — the WCET-critical verdict type must not carry
+side data. B was declined to keep the one-byte pin.
+
+### Why A is safe on the size/layout axis
+
+- `AcceptedTrajectory` has **no size/layout pin**: no `size_of` assertion, not
+  `no_std`, absent from the talisman and `src/wcet_gate.rs`. It is already a
+  heap `std` struct (`Vec<TrajectoryPoint>` + `String`). The verdict core stays
+  **byte-identical** (`ed00f4da…` unchanged; `kirra-core` zero-diff).
+- It **is** in the fast-loop hot path (cloned per tick), so the added
+  `Vec<f64>` grows that per-tick clone — modestly (8 B/pose vs the ~40 B/pose
+  the points already clone) and O(1) on the conformance read (one indexed field
+  + a branch). This is the exact clone the planned `Arc<[T]>` optimization
+  removes, so B1 correctly gates that work.
+
+### Single source of truth
+
+The ceiling is emitted by the checker's **own** per-pose loop
+(`validate_trajectory_slow_with_envelope`), reusing the `ClampLinear`/`ClampBoth`
+value `validate_vehicle_command` already computed — never recomputed in a
+second pass, so it cannot drift from the checker's decision.
+`validate_trajectory_slow_explained` / `_capped` / `_slow` are thin wrappers
+that discard the envelope, so their many callers are unchanged.
+
+## Consequences
+
+- A `Clamp`-verdict command at the unclamped speed now fails conformance → MRC
+  (B1 closed); a command at/below the derated ceiling passes ("drive slower,
+  not stop", honoring the `Clamp` contract).
+- The `Accept` fast path is byte-identical (envelope `None`).
+- Regression coverage is the primary artifact: `crates/kirra-trajectory/tests/
+  conformance.rs::b1_clamp_verdict_derates_the_conformance_ceiling` drives the
+  real checker to a known ceiling and asserts the unclamped command MRCs and
+  the at-ceiling command passes — replacing the missing coverage the prior
+  `clamp_verdict_is_preserved_while_fresh_mrc_is_floored` test never provided
+  (that test asserts a true, distinct property — Clamp survives the staleness
+  collapse — and is left unchanged).

--- a/docs/adr/0034-clamp-verdict-effective-envelope.md
+++ b/docs/adr/0034-clamp-verdict-effective-envelope.md
@@ -37,10 +37,14 @@ to the fast loop, and gate `Clamp`-verdict conformance against it.
 
 **Representation — Option A (chosen): a field on `AcceptedTrajectory`.**
 `effective_velocity_ceiling: Option<Vec<f64>>`, aligned index-for-index with
-`points`. `Some(ceilings)` on `Clamp` (the checker's own enforced value per
-pose, the planner velocity where no clamp fired); `None` on `Accept` (the fast
-path stays byte-identical). `check_command_conforms` gates against
-`ceiling[nearest]` when present, else the planner velocity (unchanged).
+`points`. `Some(ceilings)` when a **velocity** clamp fired (the checker's own
+enforced value per pose, the planner velocity where no clamp fired); `None` on
+`Accept` **and** on a pure steering clamp (no velocity derate → the planner
+velocity is the correct ceiling). `check_command_conforms` gates against
+`ceiling[nearest]` when present; a `Some`-but-missing entry **fails closed**
+(MRC), never falling back to the planner speed. The envelope is materialized
+LAZILY (only when a velocity clamp is first observed), so the `Accept` /
+no-velocity-derate slow-loop path allocates nothing extra.
 
 **Rejected — Option B: a payload on `TrajectoryVerdict::Clamp`.**
 `TrajectoryVerdict` is pinned at **one byte** (`trajectory_verdict_stays_one_byte`,


### PR DESCRIPTION
Closes #897. **Do not merge — human review requested.**

Fixes safety finding **B1 (High)**: on the ROS path a `Clamp` verdict forwarded the *unclamped* command — the checker computed `ClampLinear(v)`, discarded it, and `check_command_conforms` gated against the original planner velocity, never reading the verdict. The checker's derate was silently dropped in the adapter's own gate.

## The fix (ADR-0034, representation **A** — approved)

Carry the checker's **effective per-pose velocity envelope** to the fast loop on `AcceptedTrajectory`, keeping `TrajectoryVerdict` one byte.

- `validate_trajectory_slow_with_envelope` (new) — the checker's own per-pose loop captures its `ClampLinear`/`ClampBoth` value into a per-pose ceiling aligned to `points` instead of discarding it (`validation.rs`). Single source of truth — reuses the value `validate_vehicle_command` already computed, no second pass, no drift. `_explained`/`_capped`/`_slow` become thin wrappers that drop the envelope, so every existing caller is unchanged.
- `AcceptedTrajectory.effective_velocity_ceiling: Option<Vec<f64>>` + `with_effective_ceiling` setter (`state.rs`); threaded through `AdaptorState::update_trajectory` and the ROS node promotion.
- `check_command_conforms` gates a `Clamp`-verdict command against `ceiling[nearest]`; `None` (Accept) → byte-identical to before.

## Report

- **A/B decision & size/layout:** A. `AcceptedTrajectory` has no size/layout pin (no `size_of` assert, not `no_std`, absent from the talisman & `wcet_gate.rs`) — already a heap `std` struct. It *is* cloned per fast-loop tick, so the `Vec<f64>` adds a modest per-tick clone (~8 B/pose vs the ~40 B/pose points already clone; O(1) conformance read) — the exact clone the planned `Arc<[T]>` work removes, so B1 correctly gates it. B rejected: `TrajectoryVerdict` is the pinned one-byte type (#893 discipline).
- **Verdict core byte-identical:** `git diff origin/main -- crates/kirra-core` is empty; talisman still `ed00f4da…`; `trajectory_verdict_stays_one_byte` passes.
- **Regression proving the fix (primary deliverable):** `crates/kirra-trajectory/tests/conformance.rs::b1_clamp_verdict_derates_the_conformance_ceiling` drives the **real** checker to a known ceiling, asserts a command at the unclamped speed now **MRCs** (the B1 case) and a command at the derated ceiling **passes**; `b1_accept_path_is_byte_identical_no_envelope` pins the unchanged Accept path.
- **Old Clamp test:** `clamp_verdict_is_preserved_while_fresh_mrc_is_floored` **left unchanged** — it asserts a *true, distinct* property (a fresh Clamp survives the staleness collapse), not wrong semantics; flagged here per instruction rather than silently edited. It was insufficient (empty points, never called `check_command_conforms`), which the new test now covers.

All `kirra-trajectory` / `kirra-ros2-adapter` / `kirra-actuation-consumer` suites green; quality-guardrail + orphan gates green; WCET gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_