### PR TITLE
test(audit): de-flake the power-loss drill — poll-until-ready instead of a fixed sleep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,11 @@ kirra-ota-installer = { path = "crates/kirra-ota-installer" }
 # per-connection, so tampering a row written by one connection from a second
 # connection (the audit-chain tamper scenario, SG-010) requires an on-disk file.
 tempfile = "3"
+# Already a normal dependency (bundled); declared here too so the power-loss
+# drill (tests/audit_chain_prefix_on_kill.rs) can classify a BUSY/LOCKED
+# `rusqlite::Error` on its readiness-poll `COUNT(*)` as transient. Same version
+# → no new locked package.
+rusqlite = { version = "0.31", features = ["bundled"] }
 # R5: the demo-seed test exercises parko-kirra's `VerifierStore`-backed clearance
 # delivery, so it needs the opt-in `verifier-sink` feature.
 parko-kirra = { path = "parko/crates/parko-kirra", features = ["verifier-sink"] }

--- a/tests/audit_chain_prefix_on_kill.rs
+++ b/tests/audit_chain_prefix_on_kill.rs
@@ -42,6 +42,21 @@ const MAX_READY_POLLS: u32 = 600;
 
 static UNIQ: AtomicU64 = AtomicU64::new(0);
 
+/// A transient SQLite BUSY/LOCKED — expected when the readiness poll's
+/// `COUNT(*)` races the crash-writer's `Immediate` write transactions (rare in
+/// WAL mode, but possible during a checkpoint). Treated as "retry", distinct
+/// from a real query error (which must fail loudly, not be swallowed as 0).
+fn is_transient_lock(e: &rusqlite::Error) -> bool {
+    matches!(
+        e,
+        rusqlite::Error::SqliteFailure(err, _)
+            if matches!(
+                err.code,
+                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+            )
+    )
+}
+
 fn temp_db(tag: &str) -> std::path::PathBuf {
     // Wall-clock-free unique name: pid + a process-local counter.
     let n = UNIQ.fetch_add(1, Ordering::Relaxed);
@@ -131,10 +146,18 @@ fn audit_chain_survives_sigkill_mid_append() {
                  ({committed} seen after {polls} polls) — writer not making progress"
             );
             std::thread::sleep(READY_POLL_STEP);
-            committed = observer
-                .verify_audit_chain_full(None)
-                .map(|f| f.total_entries)
-                .unwrap_or(0); // a transient SQLITE_BUSY under the write load → retry
+            // `audit_chain_len` is the light `COUNT(*)` — we only need the row
+            // count, NOT the full chain re-verification (signature/keyring walk)
+            // `verify_audit_chain_full` runs (review: Copilot #899). A transient
+            // BUSY/LOCKED under the writer's load is expected → keep the last
+            // count and retry; ANY OTHER error is a real failure and must NOT be
+            // masked as "0 committed" (which would loop to the misleading
+            // "writer not making progress" assertion) — surface it loudly.
+            committed = match observer.audit_chain_len() {
+                Ok(n) => n,
+                Err(e) if is_transient_lock(&e) => committed,
+                Err(e) => panic!("trial {trial}: audit_chain_len query failed unexpectedly: {e}"),
+            };
             polls += 1;
         }
         // Small per-trial jitter so the kill lands at varied offsets PAST the

--- a/tests/audit_chain_prefix_on_kill.rs
+++ b/tests/audit_chain_prefix_on_kill.rs
@@ -26,6 +26,20 @@ use kirra_verifier::verifier_store::VerifierStore;
 const DIGEST: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 const WRITER_ENV: &str = "KIRRA_AUDIT_POWERLOSS_DB";
 
+/// The crash-writer must have committed at least this many chained entries
+/// before we SIGKILL it, so the kill is guaranteed to land WHILE it is actively
+/// appending — regardless of how long the reexec child takes to start. Well
+/// within a healthy burst (the writer commits hundreds per 100 ms when warm).
+/// This replaces a fixed pre-kill `sleep`, which raced the reexec-child startup
+/// and flaked to 0 committed entries on a loaded runner (#894 CI).
+const READY_THRESHOLD: u64 = 50;
+/// Poll cadence while waiting for that burst, and its ceiling. `5 ms × 600 ≈ 3 s`
+/// — generous headroom on any real runner; exceeding it means the writer is
+/// genuinely not progressing (a real regression), which fails LOUDLY rather
+/// than hanging.
+const READY_POLL_STEP: Duration = Duration::from_millis(5);
+const MAX_READY_POLLS: u32 = 600;
+
 static UNIQ: AtomicU64 = AtomicU64::new(0);
 
 fn temp_db(tag: &str) -> std::path::PathBuf {
@@ -75,10 +89,12 @@ fn powerloss_writer_child() {
     }
 }
 
-/// Spawn the crash-writer, let it append for a (jittered) interval, SIGKILL it
-/// mid-append, then reopen the DB from the file and assert the chain verifies INTACT
-/// with entries that survived. Repeated across several kill timings so the kill lands
-/// at different points relative to a commit boundary.
+/// Spawn the crash-writer, WAIT until it has committed a healthy burst (polled via
+/// an observer connection — not a fixed sleep, so the kill can't race the reexec
+/// child's startup), add a small per-trial jitter, SIGKILL it mid-append, then
+/// reopen the DB from the file and assert the chain verifies INTACT with entries
+/// that survived. Repeated across several jitter offsets so the kill lands at
+/// different points relative to a commit boundary.
 #[test]
 fn audit_chain_survives_sigkill_mid_append() {
     let self_exe = std::env::current_exe().expect("current exe");
@@ -86,6 +102,12 @@ fn audit_chain_survives_sigkill_mid_append() {
     for trial in 0..6u64 {
         let db = temp_db(&format!("kill{trial}"));
         cleanup(&db); // fresh
+
+        // Pre-create the schema via an OBSERVER connection BEFORE spawning the
+        // child: the child then opens an already-schema'd DB (no schema-creation
+        // race), and this read connection can poll the child's commit progress.
+        // WAL mode admits one writer + concurrent readers, so it sees the commits.
+        let observer = VerifierStore::new(db.to_str().unwrap()).expect("open observer");
 
         let mut child = Command::new(&self_exe)
             .args(["--exact", "--nocapture", "powerloss_writer_child"])
@@ -95,9 +117,31 @@ fn audit_chain_survives_sigkill_mid_append() {
             .spawn()
             .expect("spawn crash-writer");
 
-        // Let it commit a healthy burst (each insert is sub-ms → hundreds land), with
-        // jitter so the SIGKILL lands at varied points in the write stream.
-        std::thread::sleep(Duration::from_millis(180 + trial * 35));
+        // Wait until the child has committed a healthy burst, THEN kill — so the
+        // SIGKILL is guaranteed to land mid-append INDEPENDENT of reexec-startup
+        // latency (the old fixed `sleep` raced it and flaked to 0 committed under
+        // load). Bounded by MAX_READY_POLLS so a genuinely stuck writer fails
+        // LOUDLY rather than hanging.
+        let mut committed = 0u64;
+        let mut polls = 0u32;
+        while committed < READY_THRESHOLD {
+            assert!(
+                polls < MAX_READY_POLLS,
+                "trial {trial}: the crash-writer never committed {READY_THRESHOLD} entries \
+                 ({committed} seen after {polls} polls) — writer not making progress"
+            );
+            std::thread::sleep(READY_POLL_STEP);
+            committed = observer
+                .verify_audit_chain_full(None)
+                .map(|f| f.total_entries)
+                .unwrap_or(0); // a transient SQLITE_BUSY under the write load → retry
+            polls += 1;
+        }
+        // Small per-trial jitter so the kill lands at varied offsets PAST the
+        // readiness point (preserving the original "different points relative to a
+        // commit boundary" coverage), without depending on absolute startup time.
+        std::thread::sleep(Duration::from_millis(trial * 7));
+        drop(observer); // release the reader before the crash-reopen (cold-boot analogue)
 
         child.kill().expect("SIGKILL the writer"); // abrupt termination == power loss
         let _ = child.wait();


### PR DESCRIPTION
**Do not merge — human review requested.**

Fixes the environmental flake in the Gate C #2 power-loss drill (`tests/audit_chain_prefix_on_kill.rs::audit_chain_survives_sigkill_mid_append`) that failed in **#894's** CI.

## Root cause (diagnosed, not guessed)

The drill spawned the crash-writer as a **re-exec of the test binary**, slept a fixed **180 ms**, then SIGKILLed it — expecting hundreds of sub-ms commits to have landed. Under load the re-exec'd child's process + libtest **startup** consumed the whole 180 ms *before it reached the write loop*, so **0 entries committed** and the "committed entries must survive" assertion failed. Verified: the writer itself commits ~600 entries per 180 ms when warm — the race is purely startup-latency vs. the fixed sleep, not anything about the audit chain.

## Fix — remove the timing race

Open an **observer** connection first (pre-creating the schema so the child never races schema creation), spawn the child, then **poll the observer until the child has committed `READY_THRESHOLD` (50) chained entries** — guaranteeing the SIGKILL lands mid-append regardless of startup latency — then a small per-trial jitter + kill. Bounded by `MAX_READY_POLLS` (~3 s) so a genuinely stuck writer fails **loudly**, not hangs. WAL admits the reader alongside the writer; the observer is dropped before the crash-reopen, so the cold-boot recovery analogue is unchanged.

**The safety property under test is identical** — the chain is always a valid prefix after an abrupt kill. Only the kill *timing* is now deterministic instead of racing process startup.

## Verification

- Passes cleanly (3/3).
- **6/6 passes under sustained CPU load** — the exact condition that flaked the old fixed-sleep version to 0 committed.

Test-only, single file, root crate. Independent of B1 (#898) — different crate, branched off clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_