### PR TITLE
feat(x3): governed motor consumer for the Yahboom Rosmaster X3 (ADR-0033 chokepoint, physical)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1054,8 +1054,8 @@ jobs:
         # — the same (a)/(b)/(c) the elevated first-run test checks, minus the
         # wheels. See robot/ffi_smoke_test.py + docs/hardware/ROSMASTER_X3_BRINGUP.md.
         run: |
-          cargo build -p kirra-consumer-ffi
-          cargo build -p kirra-release-token --bin kirra_ros_release_mint
+          cargo build --locked -p kirra-consumer-ffi
+          cargo build --locked -p kirra-release-token --bin kirra_ros_release_mint
           python3 robot/ffi_smoke_test.py
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1046,6 +1046,17 @@ jobs:
         run: |
           python3 ci/check_verdict_core_purity.py --self-test
           python3 ci/check_verdict_core_purity.py
+      - name: Consumer FFI boundary smoke test (ADR-0033 Python↔Rust)
+        # Proves the Yahboom X3 verifying-consumer boundary WITHOUT hardware:
+        # loads libkirra_consumer_ffi via ctypes, mints frames with the governor
+        # stand-in, and asserts the Rust core's decisions across the FFI
+        # (valid+clamp / unsigned refuse / wrong-key alarm / replay / decel ramp)
+        # — the same (a)/(b)/(c) the elevated first-run test checks, minus the
+        # wheels. See robot/ffi_smoke_test.py + docs/hardware/ROSMASTER_X3_BRINGUP.md.
+        run: |
+          cargo build -p kirra-consumer-ffi
+          cargo build -p kirra-release-token --bin kirra_ros_release_mint
+          python3 robot/ffi_smoke_test.py
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,6 +2142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-consumer-ffi"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "kirra-actuation-consumer",
+ "kirra-release-token",
+]
+
+[[package]]
 name = "kirra-contract-channel"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@
 # runtime (ORT etc.) is absent, strict-fail only in the CI lane that installs
 # it (see parko-onnx's PARKO_ONNX_REQUIRE_ORT).
 [workspace]
-members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-inline-governor", "crates/kirra-l3-e2e", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval", "crates/kirra-kpi-gate", "crates/kirra-ota-installer", "crates/kirra-replay", "crates/kirra-actuation-consumer", "crates/kirra-sidecars"]
+members = [".", "crates/kirra-core", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-inline-governor", "crates/kirra-l3-e2e", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval", "crates/kirra-kpi-gate", "crates/kirra-ota-installer", "crates/kirra-replay", "crates/kirra-actuation-consumer", "crates/kirra-sidecars", "crates/kirra-consumer-ffi"]
 resolver = "2"
 
 [package]

--- a/ci/check_mick_actuation_fence.py
+++ b/ci/check_mick_actuation_fence.py
@@ -64,6 +64,7 @@ FORBIDDEN_WORKSPACE = {
     "kirra-inline-governor":    "the EP-01 in-line SHM enforcement path",
     "kirra-ros2-adapter":       "the ROS 2 node (cmd_vel / actuator topics)",
     "kirra-hv-carrier":         "the hypervisor shared-memory command carrier",
+    "kirra-consumer-ffi":       "the C-ABI motor consumer (drives set_car_motion on the X3)",
 }
 
 # External crates that would give a fenced crate transport to an actuator:

--- a/crates/kirra-actuation-consumer/src/lib.rs
+++ b/crates/kirra-actuation-consumer/src/lib.rs
@@ -402,6 +402,16 @@ impl<S: MotorSerial> MotorConsumer<S> {
     pub fn serial(&self) -> &S {
         &self.serial
     }
+
+    /// Mutably borrow the serial seam. Used by the C-ABI surface
+    /// (`kirra-consumer-ffi`) to reset its one-slot capture record between
+    /// `on_frame`/`on_tick` calls so it can tell whether the core wrote this
+    /// call. This lends the seam ONLY — it cannot reach the gate, the
+    /// watermark, or the liveness state (those stay private), so it grants no
+    /// path to bypass verification.
+    pub fn serial_mut(&mut self) -> &mut S {
+        &mut self.serial
+    }
 }
 
 #[cfg(test)]

--- a/crates/kirra-consumer-ffi/Cargo.toml
+++ b/crates/kirra-consumer-ffi/Cargo.toml
@@ -1,0 +1,41 @@
+# crates/kirra-consumer-ffi/Cargo.toml
+#
+# ADR-0033 decision (c): the Rust verify core exposed over a C ABI so the
+# Python motor consumer (Rosmaster_Lib on the Yahboom X3) can drive the ONE
+# verify-before-release gate WITHOUT reimplementing any crypto / watermark /
+# freshness / liveness semantics in Python (the two-sources-of-truth risk).
+#
+# This crate adds NO verification logic. It instantiates the existing
+# `MotorConsumer<S>` (kirra-actuation-consumer) with a *capture* serial seam and
+# marshals its decisions across the C boundary; Python performs the actual
+# `set_car_motion` on whatever twist the Rust core decides. The demo-envelope
+# clamp is a config-injected output saturation applied in the capture seam
+# (defense-in-depth; Kirra's checker remains the authority).
+[package]
+name = "kirra-consumer-ffi"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.88"
+description = "C-ABI surface over the ADR-0033 verifying motor consumer (kirra-actuation-consumer) for the Python Rosmaster consumer."
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+
+[lib]
+name = "kirra_consumer_ffi"
+# cdylib = the .so Python ctypes loads; rlib = so the in-crate #[test] FFI
+# self-tests and any Rust consumer can link it too.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# The verify core — reused verbatim, NOT reimplemented. The gate, the refusal
+# taxonomy, the SS-002 liveness/decel ramp, and the #892 key-mismatch alarm all
+# live here; this crate only marshals them.
+kirra-actuation-consumer = { path = "../kirra-actuation-consumer" }
+# The token/payload wire types (ReleaseToken 96B, RosTwistPayload 32B) the C
+# boundary marshals. Same crate the consumer's gate is built from.
+kirra-release-token = { path = "../kirra-release-token" }
+# Only to reconstruct a VerifyingKey from the 32 pinned public-key bytes handed
+# across the boundary. No signing happens here — this is the actuation path,
+# past the verdict (ADR-0031 separation is upheld: the checker signed upstream).
+ed25519-dalek = { version = "2" }

--- a/crates/kirra-consumer-ffi/src/lib.rs
+++ b/crates/kirra-consumer-ffi/src/lib.rs
@@ -273,8 +273,26 @@ pub unsafe extern "C" fn kirra_consumer_on_frame(
     now_ms: u64,
     out: *mut KirraFrameResult,
 ) {
-    if h.is_null() || payload.is_null() || out.is_null() {
+    if out.is_null() {
         return;
+    }
+    // Fail-closed default FIRST (Copilot #901): a caller that reuses an output
+    // struct must never observe a stale `write=1` from a previous call when
+    // this call bails on a NULL handle/payload. Refused, no write, no motion.
+    // SAFETY: caller guarantees `out` is a writable KirraFrameResult.
+    core::ptr::write(
+        out,
+        KirraFrameResult {
+            kind: 2,
+            refusal_code: -1,
+            write: 0,
+            sequence: 0,
+            linear: 0.0,
+            angular: 0.0,
+        },
+    );
+    if h.is_null() || payload.is_null() {
+        return; // *out already says "refused / do not actuate".
     }
     // SAFETY: caller guarantees `h` is a live handle.
     let consumer = &mut *h;
@@ -345,8 +363,22 @@ pub unsafe extern "C" fn kirra_consumer_on_tick(
     now_ms: u64,
     out: *mut KirraTickResult,
 ) {
-    if h.is_null() || out.is_null() {
+    if out.is_null() {
         return;
+    }
+    // Fail-closed default first (Copilot #901): stale-struct reuse must read
+    // as "no write", never a leftover ramp step.
+    // SAFETY: caller guarantees `out` is a writable KirraTickResult.
+    core::ptr::write(
+        out,
+        KirraTickResult {
+            write: 0,
+            linear: 0.0,
+            angular: 0.0,
+        },
+    );
+    if h.is_null() {
+        return; // *out already says "no write".
     }
     // SAFETY: caller guarantees `h` is a live handle.
     let consumer = &mut *h;
@@ -374,8 +406,30 @@ pub unsafe extern "C" fn kirra_consumer_on_tick(
 /// - `h` is a live handle; `out` points to a writable [`KirraHealth`].
 #[no_mangle]
 pub unsafe extern "C" fn kirra_consumer_health(h: *const KirraConsumer, out: *mut KirraHealth) {
-    if h.is_null() || out.is_null() {
+    if out.is_null() {
         return;
+    }
+    // Zeroed snapshot first (Copilot #901): a NULL handle must not leave stale
+    // counters/alarm state visible in a reused struct.
+    // SAFETY: caller guarantees `out` is a writable KirraHealth.
+    core::ptr::write(
+        out,
+        KirraHealth {
+            releases: 0,
+            refusals_total: 0,
+            no_token: 0,
+            digest_mismatch: 0,
+            signature_invalid: 0,
+            undecodable: 0,
+            stale: 0,
+            sequence_not_advanced: 0,
+            consecutive_signature_invalid: 0,
+            key_mismatch_alarm: 0,
+            silent: 0,
+        },
+    );
+    if h.is_null() {
+        return; // *out is the zeroed snapshot.
     }
     // SAFETY: caller guarantees `h` is a live handle.
     let health = (*h).inner.health();
@@ -593,6 +647,64 @@ mod tests {
             let mut hp = std::mem::zeroed::<KirraHealth>();
             kirra_consumer_health(h, &mut hp);
             assert_eq!(hp.silent, 1, "after the ramp, the consumer is silent");
+            kirra_consumer_free(h);
+        }
+    }
+
+    /// Copilot #901: an early bail (NULL handle/payload) must OVERWRITE `*out`
+    /// with a fail-closed "do not actuate" result — a caller reusing an output
+    /// struct must never observe a stale `write=1` / stale health from the
+    /// previous call.
+    #[test]
+    fn null_inputs_overwrite_out_with_fail_closed_defaults() {
+        unsafe {
+            let h = new_consumer(sk().verifying_key().to_bytes());
+            // Seed `out` with a stale RELEASED decision, then call with a NULL
+            // handle: the stale write=1 must be clobbered to refused/no-write.
+            let (p, t) = frame(1, 10_000, 0.1, 0.0);
+            let mut out = std::mem::zeroed::<KirraFrameResult>();
+            kirra_consumer_on_frame(h, p.as_ptr(), t.as_ptr(), 96, 10_000, &mut out);
+            assert_eq!(out.write, 1, "precondition: stale struct holds write=1");
+            kirra_consumer_on_frame(
+                core::ptr::null_mut(),
+                p.as_ptr(),
+                t.as_ptr(),
+                96,
+                10_000,
+                &mut out,
+            );
+            assert_eq!(
+                out.write, 0,
+                "NULL handle must fail closed, not leak stale write=1"
+            );
+            assert_eq!(out.kind, 2, "NULL handle reads as Refused");
+
+            // Same for a NULL payload.
+            kirra_consumer_on_frame(h, core::ptr::null(), t.as_ptr(), 96, 10_000, &mut out);
+            assert_eq!(out.write, 0, "NULL payload must fail closed");
+
+            // on_tick with NULL handle: stale ramp step must read as no-write.
+            let mut tk = KirraTickResult {
+                write: 1,
+                linear: 0.15,
+                angular: 0.0,
+            };
+            kirra_consumer_on_tick(core::ptr::null_mut(), 10_000, &mut tk);
+            assert_eq!(
+                tk.write, 0,
+                "NULL handle tick must not leak a stale ramp step"
+            );
+
+            // health with NULL handle: zeroed snapshot, no stale alarm.
+            let mut hp = std::mem::zeroed::<KirraHealth>();
+            hp.key_mismatch_alarm = 1; // stale
+            hp.releases = 99;
+            kirra_consumer_health(core::ptr::null(), &mut hp);
+            assert_eq!(
+                hp.key_mismatch_alarm, 0,
+                "NULL handle must zero the snapshot"
+            );
+            assert_eq!(hp.releases, 0);
             kirra_consumer_free(h);
         }
     }

--- a/crates/kirra-consumer-ffi/src/lib.rs
+++ b/crates/kirra-consumer-ffi/src/lib.rs
@@ -1,0 +1,619 @@
+//! ADR-0033 decision (c) — the C-ABI surface over the ONE verifying motor
+//! consumer (`kirra-actuation-consumer::MotorConsumer`), for the Python
+//! Rosmaster consumer on the Yahboom X3.
+//!
+//! # Why this crate exists
+//!
+//! The verify core is Rust (`RosReleaseGate` + `MotorConsumer`), the motor
+//! driver is Python (`Rosmaster_Lib.set_car_motion`). ADR-0033 settled that the
+//! token verification, the sequence watermark, the freshness rule, the refusal
+//! taxonomy, and the SS-002 liveness/decel-to-stop must live in **one Rust
+//! implementation** — never re-implemented in Python (two-sources-of-truth is
+//! the failure this rule exists to prevent). So the Python node NEVER sees a
+//! key, a signature, a watermark, or a ramp: it hands raw wire bytes to this
+//! ABI and is told, per frame and per tick, *whether* and *what* to actuate.
+//!
+//! This crate adds **no verification logic**. It instantiates `MotorConsumer<S>`
+//! with a [`CaptureSerial`] seam that records the twist the core decided to
+//! write (and applies the demo-envelope clamp), then marshals the outcome across
+//! the boundary. `unsafe` lives ONLY here, at the C boundary — the verify core
+//! stays `#![forbid(unsafe_code)]`.
+//!
+//! # The wire frame Python passes in
+//!
+//! - `payload`: the 32-byte [`RosTwistPayload`] image (`ROS_TWIST_PAYLOAD_LEN`).
+//! - `token`: the 96-byte [`ReleaseToken`] image, or absent (`NULL`, len 0) for
+//!   an unsigned command → refused `NoToken`, no motor write.
+//!
+//! # Decision, not action
+//!
+//! On a full gate pass the core writes the (clamped) twist into `CaptureSerial`;
+//! this ABI copies it into the out-struct with `write = 1`. Python then calls
+//! `set_car_motion(linear, 0.0, angular)`. On any refusal `write = 0` and the
+//! motor is not touched. The starve path ([`kirra_consumer_on_tick`]) likewise
+//! returns the next decel-ramp twist to write (or `write = 0` for silence /
+//! never-released).
+
+// The verify core is `forbid(unsafe_code)`; this is the C boundary, so unsafe is
+// unavoidable and DELIBERATELY isolated here. Same discipline as `src/ffi.rs`
+// and the QNX judge: every `unsafe fn` documents its caller contract.
+#![allow(clippy::missing_safety_doc)] // each fn has a prose `# Safety` section.
+
+use std::os::raw::c_char;
+
+use ed25519_dalek::VerifyingKey;
+use kirra_actuation_consumer::{
+    ConsumerConfig, FrameOutcome, MotorConsumer, MotorSerial, RosReleaseRefusal,
+    KEY_MISMATCH_ALARM_EXPLANATION,
+};
+use kirra_release_token::ros_twist::ROS_TWIST_PAYLOAD_LEN;
+use kirra_release_token::{ReleaseDenied, ReleaseToken};
+
+/// Wire lengths the Python side must present (re-exported as constants so the
+/// ctypes binding and any C consumer agree with the Rust truth).
+pub const KIRRA_PAYLOAD_LEN: usize = ROS_TWIST_PAYLOAD_LEN; // 32
+pub const KIRRA_TOKEN_LEN: usize = 96;
+pub const KIRRA_VK_LEN: usize = 32;
+
+// ---------------------------------------------------------------------------
+// The capture serial seam: the demo-envelope clamp + a one-slot record of the
+// twist the core decided to write on the LAST call. NOT the motor — the motor
+// is Python. `Infallible` error type (a record never fails), so the core's
+// `SerialError` outcome is structurally unreachable here (documented at the ABI).
+// ---------------------------------------------------------------------------
+
+/// Records the (clamped) twist the core wrote on the most recent
+/// `on_frame`/`on_tick`, and applies the demo-envelope magnitude clamp.
+///
+/// The clamp is a **backstop**, not the safety mechanism (Kirra's checker is the
+/// authority). Its bounds are config-injected with NO default — a caller must
+/// supply `vx_max`/`vz_max`; the constructor fails closed (returns NULL) if they
+/// are not finite and > 0. `v_y` has no channel here (skid-steer demo): the
+/// consumer core carries only (linear, angular), and Python passes `v_y = 0`.
+struct CaptureSerial {
+    vx_max: f64,
+    vz_max: f64,
+    /// The twist written on the last core call, already clamped. `None` = the
+    /// last call wrote nothing (refusal / silence / never-released).
+    pending: Option<(f64, f64)>,
+}
+
+impl CaptureSerial {
+    fn clamp_mag(v: f64, max: f64) -> f64 {
+        // max is validated finite & > 0 at construction. A finite v is clamped
+        // to [-max, max]; a non-finite v cannot arrive (the gate refuses
+        // non-finite payloads before any write), but clamp defensively to 0.
+        if !v.is_finite() {
+            0.0
+        } else if v > max {
+            max
+        } else if v < -max {
+            -max
+        } else {
+            v
+        }
+    }
+}
+
+impl MotorSerial for CaptureSerial {
+    type Error = core::convert::Infallible;
+    fn write_twist(&mut self, linear_mps: f64, angular_rad_s: f64) -> Result<(), Self::Error> {
+        self.pending = Some((
+            Self::clamp_mag(linear_mps, self.vx_max),
+            Self::clamp_mag(angular_rad_s, self.vz_max),
+        ));
+        Ok(())
+    }
+}
+
+/// The opaque handle Python holds. One consumer = one actuation path (the same
+/// single-owner discipline as the gate); not thread-safe by design.
+pub struct KirraConsumer {
+    inner: MotorConsumer<CaptureSerial>,
+}
+
+// ---------------------------------------------------------------------------
+// C ABI result structs — `#[repr(C)]`, scalar-only, no pointers into Rust state.
+// ---------------------------------------------------------------------------
+
+/// The outcome of one `on_frame`. `kind`: 0 = Released, 1 = SerialError
+/// (unreachable with the capture seam; mapped for completeness), 2 = Refused.
+/// `refusal_code` is meaningful iff `kind == 2`.
+#[repr(C)]
+pub struct KirraFrameResult {
+    pub kind: i32,
+    pub refusal_code: i32,
+    /// 1 → Python must actuate `(linear, angular)`; 0 → do not touch the motor.
+    pub write: u8,
+    pub sequence: u64,
+    pub linear: f64,
+    pub angular: f64,
+}
+
+/// The outcome of one `on_tick` (the liveness clock / decel-to-stop ramp).
+#[repr(C)]
+pub struct KirraTickResult {
+    /// 1 → Python must actuate `(linear, angular)` (the next ramp step); 0 →
+    /// output silence (nothing to write this tick).
+    pub write: u8,
+    pub linear: f64,
+    pub angular: f64,
+}
+
+/// A snapshot of the consumer's health surface (the #892 loud-diagnostic data).
+#[repr(C)]
+pub struct KirraHealth {
+    pub releases: u64,
+    pub refusals_total: u64,
+    pub no_token: u64,
+    pub digest_mismatch: u64,
+    pub signature_invalid: u64,
+    pub undecodable: u64,
+    pub stale: u64,
+    pub sequence_not_advanced: u64,
+    pub consecutive_signature_invalid: u32,
+    /// 1 → the DISTINCT key-mismatch alarm is latched (sustained
+    /// SignatureInvalid). Python must surface [`kirra_consumer_alarm_explanation`]
+    /// loudly and keep the safe stop.
+    pub key_mismatch_alarm: u8,
+    pub silent: u8,
+}
+
+// Refusal-class codes (wire-stable; mirror `RosReleaseRefusal`).
+const REF_NO_TOKEN: i32 = 0;
+const REF_DIGEST_MISMATCH: i32 = 1;
+const REF_SIGNATURE_INVALID: i32 = 2;
+const REF_UNDECODABLE: i32 = 3;
+const REF_STALE: i32 = 4;
+const REF_SEQUENCE_NOT_ADVANCED: i32 = 5;
+
+fn refusal_code(r: &RosReleaseRefusal) -> i32 {
+    match r {
+        RosReleaseRefusal::NoToken => REF_NO_TOKEN,
+        RosReleaseRefusal::Denied(ReleaseDenied::DigestMismatch) => REF_DIGEST_MISMATCH,
+        RosReleaseRefusal::Denied(ReleaseDenied::SignatureInvalid) => REF_SIGNATURE_INVALID,
+        RosReleaseRefusal::Undecodable(_) => REF_UNDECODABLE,
+        RosReleaseRefusal::Stale { .. } => REF_STALE,
+        RosReleaseRefusal::SequenceNotAdvanced { .. } => REF_SEQUENCE_NOT_ADVANCED,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constructor / destructor
+// ---------------------------------------------------------------------------
+
+/// Construct a consumer. FAIL-CLOSED: returns NULL (never a half-configured
+/// handle) if the pinned key is malformed, the liveness/decel config is invalid
+/// (see `ConsumerConfig`), or the demo-envelope bounds are not finite and > 0.
+/// There is deliberately NO default for any physical number — the caller
+/// (deployment) must supply them.
+///
+/// # Safety
+/// - `vk` must point to exactly [`KIRRA_VK_LEN`] readable bytes (the raw
+///   Ed25519 public key). The pointer is only read for the duration of the call.
+#[no_mangle]
+pub unsafe extern "C" fn kirra_consumer_new(
+    vk: *const u8,
+    freshness_window_ms: u64,
+    control_period_ms: u64,
+    missed_periods: u32,
+    stop_decel_mps2: f64,
+    vx_max: f64,
+    vz_max: f64,
+) -> *mut KirraConsumer {
+    if vk.is_null() {
+        return core::ptr::null_mut();
+    }
+    // Demo-envelope bounds are required and fail-closed (no silent default).
+    if !(vx_max.is_finite() && vx_max > 0.0 && vz_max.is_finite() && vz_max > 0.0) {
+        return core::ptr::null_mut();
+    }
+    // SAFETY: caller guarantees `vk` points to KIRRA_VK_LEN readable bytes.
+    let vk_bytes: [u8; KIRRA_VK_LEN] = {
+        let mut b = [0u8; KIRRA_VK_LEN];
+        core::ptr::copy_nonoverlapping(vk, b.as_mut_ptr(), KIRRA_VK_LEN);
+        b
+    };
+    let Ok(governor_vk) = VerifyingKey::from_bytes(&vk_bytes) else {
+        // A non-canonical / invalid public key → refuse (never pin garbage).
+        return core::ptr::null_mut();
+    };
+    let cfg = ConsumerConfig {
+        freshness_window_ms,
+        control_period_ms,
+        missed_periods,
+        stop_decel_mps2,
+    };
+    let serial = CaptureSerial {
+        vx_max,
+        vz_max,
+        pending: None,
+    };
+    match MotorConsumer::new(governor_vk, cfg, serial) {
+        Ok(inner) => Box::into_raw(Box::new(KirraConsumer { inner })),
+        // ConfigError (bad decel / deadline) → fail closed, NULL.
+        Err(_) => core::ptr::null_mut(),
+    }
+}
+
+/// Free a consumer handle. Safe to call with NULL (no-op).
+///
+/// # Safety
+/// - `h` must be a pointer returned by [`kirra_consumer_new`] and not already
+///   freed. After this call `h` is dangling; the caller must not reuse it.
+#[no_mangle]
+pub unsafe extern "C" fn kirra_consumer_free(h: *mut KirraConsumer) {
+    if !h.is_null() {
+        // SAFETY: caller guarantees `h` came from Box::into_raw and is live.
+        drop(Box::from_raw(h));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The chokepoint: on_frame / on_tick
+// ---------------------------------------------------------------------------
+
+/// Ingest one wire frame. Writes the decision into `*out`. `token` may be NULL
+/// (with `token_len == 0`) for an unsigned command → refused `NoToken`.
+///
+/// # Safety
+/// - `h` is a live handle from [`kirra_consumer_new`].
+/// - `payload` points to exactly [`KIRRA_PAYLOAD_LEN`] readable bytes.
+/// - `token` is either NULL, or points to exactly [`KIRRA_TOKEN_LEN`] readable
+///   bytes; `token_len` must be `KIRRA_TOKEN_LEN` when `token` is non-NULL.
+/// - `out` points to a writable [`KirraFrameResult`].
+///
+/// All pointers are used only for the duration of the call.
+#[no_mangle]
+pub unsafe extern "C" fn kirra_consumer_on_frame(
+    h: *mut KirraConsumer,
+    payload: *const u8,
+    token: *const u8,
+    token_len: usize,
+    now_ms: u64,
+    out: *mut KirraFrameResult,
+) {
+    if h.is_null() || payload.is_null() || out.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees `h` is a live handle.
+    let consumer = &mut *h;
+
+    // SAFETY: caller guarantees KIRRA_PAYLOAD_LEN readable bytes at `payload`.
+    let mut payload_bytes = [0u8; KIRRA_PAYLOAD_LEN];
+    core::ptr::copy_nonoverlapping(payload, payload_bytes.as_mut_ptr(), KIRRA_PAYLOAD_LEN);
+
+    // Reconstruct the optional token. A malformed length is treated as "no
+    // usable token" → NoToken refusal (fail-closed; never a partial read).
+    let token_obj: Option<ReleaseToken> = if token.is_null() || token_len != KIRRA_TOKEN_LEN {
+        None
+    } else {
+        // SAFETY: caller guarantees KIRRA_TOKEN_LEN readable bytes at `token`.
+        let mut tb = [0u8; KIRRA_TOKEN_LEN];
+        core::ptr::copy_nonoverlapping(token, tb.as_mut_ptr(), KIRRA_TOKEN_LEN);
+        Some(ReleaseToken::from_bytes(&tb))
+    };
+
+    // Clear the capture slot so we can tell whether THIS call wrote.
+    consumer.reset_capture();
+    let outcome = consumer
+        .inner
+        .on_frame(&payload_bytes, token_obj.as_ref(), now_ms);
+
+    let result = match outcome {
+        FrameOutcome::Released { sequence } => {
+            let (linear, angular) = consumer.pending().unwrap_or((0.0, 0.0));
+            KirraFrameResult {
+                kind: 0,
+                refusal_code: -1,
+                write: 1,
+                sequence,
+                linear,
+                angular,
+            }
+        }
+        FrameOutcome::SerialError => KirraFrameResult {
+            kind: 1,
+            refusal_code: -1,
+            write: 0,
+            sequence: 0,
+            linear: 0.0,
+            angular: 0.0,
+        },
+        FrameOutcome::Refused(r) => KirraFrameResult {
+            kind: 2,
+            refusal_code: refusal_code(&r),
+            write: 0,
+            sequence: 0,
+            linear: 0.0,
+            angular: 0.0,
+        },
+    };
+    // SAFETY: caller guarantees `out` is a writable KirraFrameResult.
+    core::ptr::write(out, result);
+}
+
+/// The liveness clock — call once per control period. Drives SS-002: past the
+/// deadline with no valid release → an ACTIVE decel-to-zero ramp (never
+/// hold-last), then silence. Writes the next ramp step (or "no write") to `*out`.
+///
+/// # Safety
+/// - `h` is a live handle; `out` points to a writable [`KirraTickResult`].
+#[no_mangle]
+pub unsafe extern "C" fn kirra_consumer_on_tick(
+    h: *mut KirraConsumer,
+    now_ms: u64,
+    out: *mut KirraTickResult,
+) {
+    if h.is_null() || out.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees `h` is a live handle.
+    let consumer = &mut *h;
+    consumer.reset_capture();
+    consumer.inner.on_tick(now_ms);
+    let result = match consumer.pending() {
+        Some((linear, angular)) => KirraTickResult {
+            write: 1,
+            linear,
+            angular,
+        },
+        None => KirraTickResult {
+            write: 0,
+            linear: 0.0,
+            angular: 0.0,
+        },
+    };
+    // SAFETY: caller guarantees `out` is a writable KirraTickResult.
+    core::ptr::write(out, result);
+}
+
+/// Snapshot the health surface into `*out`.
+///
+/// # Safety
+/// - `h` is a live handle; `out` points to a writable [`KirraHealth`].
+#[no_mangle]
+pub unsafe extern "C" fn kirra_consumer_health(h: *const KirraConsumer, out: *mut KirraHealth) {
+    if h.is_null() || out.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees `h` is a live handle.
+    let health = (*h).inner.health();
+    let refusals = health.refusals;
+    let result = KirraHealth {
+        releases: health.releases,
+        refusals_total: refusals.total(),
+        no_token: refusals.no_token,
+        digest_mismatch: refusals.digest_mismatch,
+        signature_invalid: refusals.signature_invalid,
+        undecodable: refusals.undecodable,
+        stale: refusals.stale,
+        sequence_not_advanced: refusals.sequence_not_advanced,
+        consecutive_signature_invalid: health.consecutive_signature_invalid,
+        key_mismatch_alarm: u8::from(health.key_mismatch_alarm),
+        silent: u8::from(health.silent),
+    };
+    // SAFETY: caller guarantees `out` is a writable KirraHealth.
+    core::ptr::write(out, result);
+}
+
+/// The latched key-mismatch alarm's operator sentence, as a static
+/// NUL-terminated C string (valid for the program lifetime; never freed by the
+/// caller). Returned regardless of latch state so callers can display it; check
+/// `KirraHealth::key_mismatch_alarm` to know WHEN to display it.
+#[no_mangle]
+pub extern "C" fn kirra_consumer_alarm_explanation() -> *const c_char {
+    // A 'static &str with an appended NUL, built once.
+    ALARM_EXPLANATION_CSTR.as_ptr().cast::<c_char>()
+}
+
+// KEY_MISMATCH_ALARM_EXPLANATION with a trailing NUL, as a byte slice usable as
+// a C string. A const check below pins that the source sentence has no interior
+// NUL (which would truncate it at the boundary).
+const fn _no_interior_nul() {
+    let bytes = KEY_MISMATCH_ALARM_EXPLANATION.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        assert!(bytes[i] != 0, "alarm sentence must have no interior NUL");
+        i += 1;
+    }
+}
+const _: () = _no_interior_nul();
+
+// Build the NUL-terminated image at compile time.
+const ALARM_LEN: usize = KEY_MISMATCH_ALARM_EXPLANATION.len();
+static ALARM_EXPLANATION_CSTR: [u8; ALARM_LEN + 1] = {
+    let src = KEY_MISMATCH_ALARM_EXPLANATION.as_bytes();
+    let mut buf = [0u8; ALARM_LEN + 1];
+    let mut i = 0;
+    while i < ALARM_LEN {
+        buf[i] = src[i];
+        i += 1;
+    }
+    // buf[ALARM_LEN] stays 0 → the terminator.
+    buf
+};
+
+impl CaptureSerial {
+    fn pending(&self) -> Option<(f64, f64)> {
+        self.pending
+    }
+}
+
+impl KirraConsumer {
+    /// Clear the capture slot before a core call, so a subsequent `pending()`
+    /// read reflects ONLY what this call wrote. Reaches the seam through
+    /// `MotorConsumer::serial_mut` — the seam only, never the gate/watermark.
+    fn reset_capture(&mut self) {
+        self.inner.serial_mut().pending = None;
+    }
+    fn pending(&self) -> Option<(f64, f64)> {
+        self.inner.serial().pending()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use kirra_release_token::ros_twist::{issue_ros_release, RosTwistPayload};
+
+    fn sk() -> SigningKey {
+        SigningKey::from_bytes(&[42u8; 32])
+    }
+
+    unsafe fn new_consumer(vk: [u8; 32]) -> *mut KirraConsumer {
+        kirra_consumer_new(
+            vk.as_ptr(),
+            /* freshness_window_ms */ 200,
+            /* control_period_ms   */ 100,
+            /* missed_periods      */ 3,
+            /* stop_decel_mps2     */ 1.0,
+            /* vx_max              */ 0.15,
+            /* vz_max              */ 0.4,
+        )
+    }
+
+    fn frame(seq: u64, issued: u64, lin: f64, ang: f64) -> ([u8; 32], [u8; 96]) {
+        let p = RosTwistPayload {
+            sequence: seq,
+            issued_at_ms: issued,
+            linear_mps: lin,
+            angular_rad_s: ang,
+        };
+        (p.encode(), issue_ros_release(&p, &sk()).to_bytes())
+    }
+
+    #[test]
+    fn valid_frame_releases_and_clamps_to_the_demo_envelope() {
+        unsafe {
+            let h = new_consumer(sk().verifying_key().to_bytes());
+            assert!(!h.is_null());
+            // Command ABOVE the demo envelope (0.5 m/s, 2.0 rad/s) — the clamp
+            // must saturate it to (0.15, 0.4). (The checker is authority; this
+            // is the defense-in-depth backstop.)
+            let (p, t) = frame(1, 10_000, 0.5, 2.0);
+            let mut out = std::mem::zeroed::<KirraFrameResult>();
+            kirra_consumer_on_frame(h, p.as_ptr(), t.as_ptr(), 96, 10_050, &mut out);
+            assert_eq!(out.kind, 0, "valid frame must Release");
+            assert_eq!(out.write, 1);
+            assert_eq!(out.sequence, 1);
+            assert!(
+                (out.linear - 0.15).abs() < 1e-12,
+                "linear clamped to vx_max"
+            );
+            assert!(
+                (out.angular - 0.4).abs() < 1e-12,
+                "angular clamped to vz_max"
+            );
+            kirra_consumer_free(h);
+        }
+    }
+
+    #[test]
+    fn unsigned_frame_is_refused_no_write() {
+        unsafe {
+            let h = new_consumer(sk().verifying_key().to_bytes());
+            let (p, _t) = frame(1, 10_000, 0.1, 0.1);
+            let mut out = std::mem::zeroed::<KirraFrameResult>();
+            // token NULL, len 0 → NoToken.
+            kirra_consumer_on_frame(h, p.as_ptr(), core::ptr::null(), 0, 10_000, &mut out);
+            assert_eq!(out.kind, 2, "unsigned → Refused");
+            assert_eq!(out.refusal_code, REF_NO_TOKEN);
+            assert_eq!(out.write, 0, "refusal must not actuate");
+            kirra_consumer_free(h);
+        }
+    }
+
+    #[test]
+    fn wrong_key_latches_the_key_mismatch_alarm() {
+        unsafe {
+            let h = new_consumer(sk().verifying_key().to_bytes());
+            let wrong = SigningKey::from_bytes(&[9u8; 32]);
+            for k in 0..10u64 {
+                let p = RosTwistPayload {
+                    sequence: k + 1,
+                    issued_at_ms: 10_000 + k,
+                    linear_mps: 0.1,
+                    angular_rad_s: 0.0,
+                };
+                let t = issue_ros_release(&p, &wrong).to_bytes();
+                let mut out = std::mem::zeroed::<KirraFrameResult>();
+                kirra_consumer_on_frame(
+                    h,
+                    p.encode().as_ptr(),
+                    t.as_ptr(),
+                    96,
+                    10_000 + k,
+                    &mut out,
+                );
+                assert_eq!(out.refusal_code, REF_SIGNATURE_INVALID);
+                assert_eq!(out.write, 0);
+            }
+            let mut hp = std::mem::zeroed::<KirraHealth>();
+            kirra_consumer_health(h, &mut hp);
+            assert_eq!(hp.key_mismatch_alarm, 1, "sustained bad-sig must latch");
+            assert_eq!(hp.signature_invalid, 10);
+            // The alarm sentence is reachable and non-empty.
+            let s = kirra_consumer_alarm_explanation();
+            let cstr = std::ffi::CStr::from_ptr(s);
+            assert!(cstr.to_bytes().len() > 40);
+            kirra_consumer_free(h);
+        }
+    }
+
+    #[test]
+    fn starvation_ramps_to_zero_then_goes_silent() {
+        unsafe {
+            let h = new_consumer(sk().verifying_key().to_bytes());
+            let (p, t) = frame(1, 10_000, 0.15, 0.0);
+            let mut out = std::mem::zeroed::<KirraFrameResult>();
+            kirra_consumer_on_frame(h, p.as_ptr(), t.as_ptr(), 96, 10_000, &mut out);
+            assert_eq!(out.kind, 0);
+
+            // Tick past the 300 ms deadline: expect a strictly decreasing ramp
+            // to zero, then silence (write=0).
+            let mut saw_ramp = false;
+            let mut last = 0.15f64;
+            let mut reached_zero = false;
+            for k in 1..=20u64 {
+                let mut tk = std::mem::zeroed::<KirraTickResult>();
+                kirra_consumer_on_tick(h, 10_000 + 300 + k * 100, &mut tk);
+                if tk.write == 1 {
+                    saw_ramp = true;
+                    assert!(tk.linear.abs() <= last + 1e-12, "ramp must not increase");
+                    last = tk.linear;
+                    if tk.linear == 0.0 {
+                        reached_zero = true;
+                    }
+                }
+            }
+            assert!(saw_ramp, "starvation must produce an active stop ramp");
+            assert!(reached_zero, "ramp must reach zero");
+            let mut hp = std::mem::zeroed::<KirraHealth>();
+            kirra_consumer_health(h, &mut hp);
+            assert_eq!(hp.silent, 1, "after the ramp, the consumer is silent");
+            kirra_consumer_free(h);
+        }
+    }
+
+    #[test]
+    fn bad_config_and_bad_key_fail_closed_null() {
+        unsafe {
+            // Bad vx_max (0.0) → NULL.
+            let vk = sk().verifying_key().to_bytes();
+            let h = kirra_consumer_new(vk.as_ptr(), 200, 100, 3, 1.0, 0.0, 0.4);
+            assert!(h.is_null(), "zero vx_max must fail closed");
+            // Bad decel → NULL.
+            let h2 = kirra_consumer_new(vk.as_ptr(), 200, 100, 3, -1.0, 0.15, 0.4);
+            assert!(h2.is_null(), "negative decel must fail closed");
+            // Bad control period (0) → NULL (ConsumerConfig::InvalidDeadline).
+            let h3 = kirra_consumer_new(vk.as_ptr(), 200, 0, 3, 1.0, 0.15, 0.4);
+            assert!(h3.is_null(), "zero control period must fail closed");
+            // NULL key pointer → NULL (never dereferenced). A malformed key
+            // encoding likewise returns NULL via the `from_bytes` Err arm.
+            let h4 = kirra_consumer_new(core::ptr::null(), 200, 100, 3, 1.0, 0.15, 0.4);
+            assert!(h4.is_null(), "null key pointer must fail closed");
+        }
+    }
+}

--- a/crates/kirra-release-token/src/bin/kirra_ros_release_mint.rs
+++ b/crates/kirra-release-token/src/bin/kirra_ros_release_mint.rs
@@ -1,0 +1,120 @@
+//! `kirra_ros_release_mint` — the GOVERNOR STAND-IN minter for the ROS release
+//! path. Emits a signed `payload(32) || token(96)` frame (or an unsigned
+//! payload) for demos, the elevated first-run test, and the FFI smoke test.
+//!
+//! Why this exists: the Python consumer must NEVER hold a signing key or
+//! re-implement the domain-separated signing (two-sources-of-truth). In
+//! production the verifier/governor signs. For a bench demo we still need a
+//! signer — so this tiny CLI wraps the SAME `issue_ros_release` the governor
+//! uses (`kirra-release-token::ros_twist`). No crypto is re-implemented here or
+//! in Python; the Python side only ever consumes these bytes.
+//!
+//! ⚠️ DEV/DEMO ONLY. The `--seed` is a well-known test key, not a provisioned
+//! governor key. A real deployment mints frames from the verifier's provisioned
+//! signing key (see docs/safety/GOVERNOR_KEY_PROVISIONING.md), never from a CLI
+//! seed on the robot.
+//!
+//! Usage:
+//!   kirra_ros_release_mint --seed <hex32> pubkey
+//!       → prints the 64-hex Ed25519 public key to pin in the consumer.
+//!   kirra_ros_release_mint --seed <hex32> frame \
+//!       --seq N --issued-ms M --linear X --angular Y [--corrupt-sig | --no-token]
+//!       → prints the frame as one hex line to stdout
+//!         (128 bytes signed, or 32 bytes with --no-token).
+
+use ed25519_dalek::SigningKey;
+use kirra_release_token::ros_twist::{issue_ros_release, RosTwistPayload};
+
+fn die(msg: &str) -> ! {
+    eprintln!("kirra_ros_release_mint: {msg}");
+    std::process::exit(2);
+}
+
+fn arg_val(args: &[String], flag: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1).cloned())
+}
+
+fn has_flag(args: &[String], flag: &str) -> bool {
+    args.iter().any(|a| a == flag)
+}
+
+fn hex_to_32(s: &str) -> [u8; 32] {
+    let s = s.trim();
+    if s.len() != 64 {
+        die("--seed must be 64 hex chars (32 bytes)");
+    }
+    let mut out = [0u8; 32];
+    for (i, b) in out.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16)
+            .unwrap_or_else(|_| die("--seed is not valid hex"));
+    }
+    out
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let seed = arg_val(&args, "--seed").unwrap_or_else(|| die("--seed <hex32> is required"));
+    let sk = SigningKey::from_bytes(&hex_to_32(&seed));
+
+    match args
+        .iter()
+        .find(|a| !a.starts_with("--") && a.as_str() != seed)
+        .map(String::as_str)
+    {
+        Some("pubkey") => {
+            let pk = sk.verifying_key().to_bytes();
+            let mut s = String::with_capacity(64);
+            for b in pk {
+                use std::fmt::Write as _;
+                let _ = write!(s, "{b:02x}");
+            }
+            println!("{s}");
+        }
+        Some("frame") => {
+            let parse = |flag: &str| -> String {
+                arg_val(&args, flag).unwrap_or_else(|| die(&format!("{flag} is required")))
+            };
+            let seq: u64 = parse("--seq")
+                .parse()
+                .unwrap_or_else(|_| die("--seq must be u64"));
+            let issued_ms: u64 = parse("--issued-ms")
+                .parse()
+                .unwrap_or_else(|_| die("--issued-ms must be u64"));
+            let linear: f64 = parse("--linear")
+                .parse()
+                .unwrap_or_else(|_| die("--linear must be f64"));
+            let angular: f64 = parse("--angular")
+                .parse()
+                .unwrap_or_else(|_| die("--angular must be f64"));
+
+            let payload = RosTwistPayload {
+                sequence: seq,
+                issued_at_ms: issued_ms,
+                linear_mps: linear,
+                angular_rad_s: angular,
+            };
+            let payload_bytes = payload.encode();
+
+            let mut frame: Vec<u8> = payload_bytes.to_vec();
+            if !has_flag(&args, "--no-token") {
+                let mut token = issue_ros_release(&payload, &sk).to_bytes();
+                if has_flag(&args, "--corrupt-sig") {
+                    // Flip a signature bit → a token that fails Ed25519 verify
+                    // (the wrong-key / tamper case, without a second key).
+                    token[64] ^= 0x01;
+                }
+                frame.extend_from_slice(&token);
+            }
+
+            let mut s = String::with_capacity(frame.len() * 2);
+            for b in &frame {
+                use std::fmt::Write as _;
+                let _ = write!(s, "{b:02x}");
+            }
+            println!("{s}");
+        }
+        _ => die("expected a subcommand: `pubkey` or `frame`"),
+    }
+}

--- a/docs/hardware/ROSMASTER_X3_BRINGUP.md
+++ b/docs/hardware/ROSMASTER_X3_BRINGUP.md
@@ -1,0 +1,247 @@
+# KIRRA on the Yahboom Rosmaster X3 — Governed Motor Bringup
+
+**The ADR-0033 chokepoint, made physical.** The verifying consumer owns the
+motor serial port and drives the wheels **only** for commands carrying a valid
+ADR-0033 release token. This is the software fence (#891) made hardware: the
+consumer *is* the motor bringup — we do **not** stand up the vendor `/cmd_vel`
+driver and retrofit a fence onto it.
+
+> 🔴 **The very first drive test runs with the robot ELEVATED — wheels off the
+> ground.** See [§5](#5-first-run-acceptance-test--wheels-off-the-ground).
+
+---
+
+## 0. Confirmed hardware facts
+
+| Thing | Value |
+|---|---|
+| Motor board | `/dev/myserial` → `ttyUSB1`, driven by `Rosmaster_Lib` |
+| Motor API | `Rosmaster.set_car_motion(v_x, v_y, v_z)` |
+| X3 hardware range | `v_x, v_y ∈ [-1.0, 1.0]` m/s, `v_z ∈ [-5, 5]` rad/s |
+| Lidar | `/dev/rplidar` → `ttyUSB0`, `RPLIDAR_TYPE=4ROS`, `sllidar_ros2` |
+| ROS | Humble, `ROBOT_TYPE=x3`, `ROS_DOMAIN_ID=28` |
+
+---
+
+## 1. Architecture — one verify core, in Rust, over FFI
+
+The verify core is Rust; the motor driver is Python. Per **ADR-0033 decision
+(c)** we bridge with a **C-ABI over the existing Rust core**, never a Python
+re-implementation of the crypto/watermark/freshness/liveness (that would be two
+sources of truth):
+
+```
+ signed frame (topic)                     Rust: libkirra_consumer_ffi
+ payload(32)||token(96)   ──ctypes──▶  MotorConsumer<CaptureSerial>
+        │                                 = RosReleaseGate (verify→decode→
+        │                                   freshness→watermark) + SS-002
+        │                                   liveness/decel + #892 alarm
+        ▼                                        │ decides a twist (or refuses)
+ kirra_motor_consumer.py  ◀──decision──────────┘
+        │ set_car_motion(v_x, 0, v_z)   (only if the core said "write")
+        ▼
+   /dev/myserial  (Rosmaster_Lib)   ← this node is the SOLE writer
+```
+
+**No verification logic lives in Python.** `robot/kirra_ffi.py` marshals bytes in
+and a decision out; every gate decision is made by the reused
+`kirra-actuation-consumer::MotorConsumer` (`crates/kirra-actuation-consumer/src/lib.rs`),
+whose gate is `RosReleaseGate` (`crates/kirra-release-token/src/ros_twist.rs`).
+
+### The FFI surface (reused from #891, and how it was extended)
+
+The **verify core is reused verbatim** — no crypto, no watermark, no freshness,
+no liveness, no refusal taxonomy was reimplemented. What this PR **adds** is the
+C-ABI marshalling layer that #891 named as future work (ros_twist.rs module
+docs: *"the C-ABI surface for the Python node"*), because none existed yet:
+
+- **New crate `crates/kirra-consumer-ffi`** (`cdylib` + `rlib`): instantiates
+  `MotorConsumer<CaptureSerial>` and exposes six `extern "C"` functions —
+  `kirra_consumer_new` (fail-closed: NULL on bad key / decel / deadline /
+  envelope), `_on_frame`, `_on_tick`, `_health`, `_alarm_explanation`, `_free`.
+  `unsafe` is isolated **here only**; the verify core keeps
+  `#![forbid(unsafe_code)]`.
+- **One added accessor** on the reused consumer: `MotorConsumer::serial_mut`
+  (`kirra-actuation-consumer/src/lib.rs`) — lends the serial seam so the FFI can
+  reset its one-slot capture between calls. It reaches the seam **only**, never
+  the gate/watermark/liveness.
+- **`CaptureSerial`** (in the FFI crate) is the `MotorSerial` seam: it records
+  the twist the core decided to write and applies the **demo-envelope clamp**.
+  The core owns the *decision*; Python performs the *actuation*.
+- **Governor stand-in minter** `kirra_ros_release_mint`
+  (`crates/kirra-release-token/src/bin/`) wraps the existing `issue_ros_release`
+  for demos/tests — so even the *signing* side of the bench stays the Rust
+  implementation, never Python.
+
+---
+
+## 2. Verify-before-drive (ADR-0033)
+
+Every actuated command passes the five-step gate (`RosReleaseGate::release`):
+token exists → Ed25519 over the exact bytes (ROS domain) → finite decode →
+freshness window → strictly-advancing sequence. Refusal taxonomy (wire-stable
+codes) and the failure that produced each:
+
+| Refusal | Meaning |
+|---|---|
+| `NO_TOKEN` | unsigned command / rogue publisher → **no motor write** |
+| `DIGEST_MISMATCH` | bytes substituted after signing |
+| `SIGNATURE_INVALID` | wrong/rotated key or tamper |
+| `UNDECODABLE` | non-finite twist (never actuate NaN/Inf) |
+| `STALE` | outside freshness window (replay / clock skew) |
+| `SEQUENCE_NOT_ADVANCED` | replay / reorder |
+
+🔴 **Loud key-mismatch diagnostic (#892).** A *sustained* run of
+`SIGNATURE_INVALID` (≥10 consecutive, ~½–1 s at 10–20 Hz) **latches** a distinct
+alarm — visibly different from ordinary staleness, never a silent safe-stop. The
+node logs `KEY_MISMATCH_ALARM_EXPLANATION` (the operator sentence naming the
+likely cause — rotation done out of order — and the recovery). A valid release
+clears it.
+
+---
+
+## 3. The demo velocity envelope (backstop, not the safety mechanism)
+
+The consumer clamps the actuated twist to a demo envelope **far below** the X3
+hardware max. **Chosen demo values (demo-scoped, NOT the hardware limit):**
+
+| Knob | Demo value | X3 hardware max |
+|---|---|---|
+| `KIRRA_DEMO_VX_MAX` (linear) | **0.15 m/s** | 1.0 m/s |
+| `KIRRA_DEMO_VZ_MAX` (angular) | **0.4 rad/s** | 5 rad/s |
+| lateral `v_y` | **0** (skid-steer demo; no lateral) | 1.0 m/s |
+
+These are **required config with no default** — `kirra_consumer_new` returns a
+fail-closed NULL (and the node aborts) if they are unset or not finite > 0. The
+clamp is **defense-in-depth**: Kirra's checker is the safety authority; the clamp
+only guarantees a bug can't command 1.0 m/s. It lives in the Rust `CaptureSerial`
+seam so it is tested and cannot be forgotten by the Python layer.
+
+---
+
+## 4. Fail-closed liveness + guaranteed stop (SS-002)
+
+- **No valid release within ≈3 control periods** → the core drives an **active
+  decel-to-zero ramp** via `set_car_motion`, then output silence. **Never
+  hold-last** (the Cruise-drag failure SS-002 exists to prevent).
+- **A refusal does NOT reset the liveness window** — a flood of invalid tokens
+  starves into the safe stop exactly as silence does.
+- **Consumer exit / SIGINT / SIGTERM / exception / panic** → `set_car_motion(0,
+  0, 0)` in the shutdown path, guaranteed (signal handlers + a `finally` belt).
+  The robot stops if the consumer dies.
+
+---
+
+## 5. First-run acceptance test — WHEELS OFF THE GROUND
+
+> 🔴 **Run `robot/first_run_elevated.sh` with the robot ELEVATED, all wheels
+> free to spin.** This is the first time governed commands drive real motors; a
+> wiring/clamp/verify bug elevated is a wheel spinning in the air, not a robot
+> lunging off the bench. **Only after all three phases pass elevated does the
+> robot touch the floor.**
+
+### Build + pin the key
+
+```bash
+# Build the verify-core .so and the governor stand-in minter.
+cargo build -p kirra-consumer-ffi --release
+cargo build -p kirra-release-token --bin kirra_ros_release_mint --release
+
+# The dev signing seed for the bench (DEV ONLY). Pin its public key.
+export KIRRA_DEV_SEED=2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a
+export KIRRA_GOVERNOR_VK_HEX=$(target/release/kirra_ros_release_mint --seed $KIRRA_DEV_SEED pubkey)
+```
+
+### Start the consumer (it OWNS the motor board)
+
+```bash
+export KIRRA_FRESHNESS_WINDOW_MS=200
+export KIRRA_CONTROL_PERIOD_MS=100
+export KIRRA_MISSED_PERIODS=3
+export KIRRA_STOP_DECEL_MPS2=0.5      # from the deployed class MRC profile
+export KIRRA_DEMO_VX_MAX=0.15
+export KIRRA_DEMO_VZ_MAX=0.4
+export KIRRA_MOTOR_PORT=/dev/myserial
+export ROS_DOMAIN_ID=28
+python3 robot/kirra_motor_consumer.py
+```
+
+🔴 **Do NOT launch `yahboomcar_bringup` (the vendor base node).** It would be a
+second, unfenced writer to `/dev/myserial`. This consumer holding the port is the
+structural guarantee; the script prints the active `ros2 node list` so you can
+confirm it is absent.
+
+### Run the elevated acceptance
+
+In a second terminal:
+
+```bash
+robot/first_run_elevated.sh
+```
+
+It guides three phases and asks you to confirm each (you are the acceptance
+sensor — it cannot see the wheels):
+
+- **(a)** valid governed command → wheels spin at the **clamped** demo speed;
+- **(b)** unsigned command → **zero** wheel motion + `REFUSED (NO_TOKEN)` in the
+  consumer log;
+- **(c)** kill the consumer (Ctrl-C) → wheels **stop immediately**.
+
+### Host pre-check (no robot required)
+
+Before touching hardware, prove the Python↔Rust boundary on any host:
+
+```bash
+cargo build -p kirra-consumer-ffi
+cargo build -p kirra-release-token --bin kirra_ros_release_mint
+python3 robot/ffi_smoke_test.py
+```
+
+This mirrors the elevated (a)/(b)/(c) — plus replay, wrong-key, and the decel
+ramp — through the same FFI, minus the wheels. It runs in CI.
+
+---
+
+## 6. Lidar — separately (real perception for the governed loop)
+
+Kept a **separate launch step** from the motor consumer. This is the input
+Taj→Occy→Kirra needs so the governed loop is real, not synthetic.
+
+```bash
+export RPLIDAR_TYPE=4ROS
+ros2 launch sllidar_ros2 sllidar_launch.py \
+    serial_port:=/dev/rplidar
+# Confirm real scans:
+ros2 topic hz /scan
+ros2 topic echo /scan --once
+```
+
+---
+
+## 7. Explicitly NOT in this bringup
+
+- **Speech / mic / TTS** — no audio hardware yet; voice is the last layer, on top
+  of a robot that already drives and refuses.
+- **sros2** — Tier-2.
+- **Autonomous navigation / SLAM / nav2** — the demo is *governed command →
+  checker → wheels*, and a refusal. Not nav.
+- **Any second writer to `/dev/myserial`** — the vendor base node stays off.
+
+---
+
+## 8. Report summary (per the deliverable)
+
+- **FFI surface:** reused the #891 verify core verbatim (`RosReleaseGate` /
+  `MotorConsumer`); **extended** it with the previously-absent C-ABI marshalling
+  layer (`kirra-consumer-ffi`) that ADR-0033 decision (c) called for, plus one
+  seam accessor (`serial_mut`) and the governor stand-in minter. No crypto /
+  watermark / freshness / liveness reimplemented anywhere.
+- **Demo envelope:** `vx_max = 0.15 m/s`, `vz_max = 0.4 rad/s`, `v_y = 0` —
+  demo-scoped backstop, required config with no default, far below the X3
+  hardware max (1.0 m/s / 5 rad/s).
+- **No vendor motor node co-runs:** the consumer is the sole opener/writer of
+  `/dev/myserial`; the bringup and the elevated script both assert the vendor
+  base node is absent.
+- **Shutdown-stop guarantee:** `set_car_motion(0,0,0)` on SIGINT/SIGTERM/
+  exception/normal exit (signal handlers + `finally`), plus the SS-002 liveness
+  decel-to-zero when releases stop arriving.

--- a/robot/ffi_smoke_test.py
+++ b/robot/ffi_smoke_test.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Host smoke test for the ADR-0033 Python↔Rust consumer boundary.
+
+Runs WITHOUT ROS or a motor: it loads libkirra_consumer_ffi via ctypes, mints
+frames with the governor stand-in (`kirra_ros_release_mint`), and asserts the
+decisions the Rust core returns across the boundary. This is the non-vacuity
+proof that the FFI marshalling matches the verify core's semantics — the same
+(a)/(b)/(c) behaviours the elevated first-run test checks, minus the wheels.
+
+Prereqs (both built by this script's CI step):
+    cargo build -p kirra-consumer-ffi
+    cargo build -p kirra-release-token --bin kirra_ros_release_mint
+
+Exit 0 = boundary behaves; exit 1 = a mismatch (fail the gate).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from kirra_ffi import KirraConsumer  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+# The dev/demo governor key (well-known [42u8;32]) — DEV ONLY, matches the Rust
+# fixtures. A real deployment pins the verifier's provisioned key.
+DEV_SEED = "2a" * 32
+MINT = None  # resolved in main()
+
+# Demo envelope (Step 3) — the SAME values the node/docs use.
+VX_MAX = 0.15
+VZ_MAX = 0.4
+
+
+def mint(*args: str) -> bytes:
+    out = subprocess.run(
+        [str(MINT), "--seed", DEV_SEED, *args],
+        capture_output=True, text=True, check=True,
+    )
+    return bytes.fromhex(out.stdout.strip())
+
+
+def pubkey(seed: str = DEV_SEED) -> bytes:
+    out = subprocess.run(
+        [str(MINT), "--seed", seed, "pubkey"],
+        capture_output=True, text=True, check=True,
+    )
+    return bytes.fromhex(out.stdout.strip())
+
+
+def split(frame: bytes) -> tuple[bytes, bytes | None]:
+    """payload(32) [|| token(96)] → (payload, token|None)."""
+    payload = frame[:32]
+    token = frame[32:] if len(frame) > 32 else None
+    return payload, token
+
+
+def new_consumer(vk: bytes) -> KirraConsumer:
+    return KirraConsumer(
+        vk,
+        freshness_window_ms=200,
+        control_period_ms=100,
+        missed_periods=3,
+        stop_decel_mps2=1.0,
+        vx_max=VX_MAX,
+        vz_max=VZ_MAX,
+    )
+
+
+def main() -> int:
+    global MINT
+    for prof in ("release", "debug"):
+        cand = REPO / "target" / prof / "kirra_ros_release_mint"
+        if cand.is_file():
+            MINT = cand
+            break
+    if MINT is None:
+        print("FAIL: kirra_ros_release_mint not built "
+              "(cargo build -p kirra-release-token --bin kirra_ros_release_mint)")
+        return 1
+
+    vk = pubkey()
+    failures: list[str] = []
+
+    def check(cond: bool, msg: str) -> None:
+        if not cond:
+            failures.append(msg)
+
+    # (a) A valid governed command ABOVE the demo envelope → Released + clamped.
+    c = new_consumer(vk)
+    payload, token = split(mint("frame", "--seq", "1", "--issued-ms", "10000",
+                                "--linear", "0.5", "--angular", "2.0"))
+    r = c.on_frame(payload, token, 10_050)
+    check(r.kind == 0, f"(a) valid frame must Release, got kind={r.kind}")
+    check(r.write == 1, "(a) release must actuate")
+    check(abs(r.linear - VX_MAX) < 1e-9, f"(a) linear must clamp to {VX_MAX}, got {r.linear}")
+    check(abs(r.angular - VZ_MAX) < 1e-9, f"(a) angular must clamp to {VZ_MAX}, got {r.angular}")
+    print(f"(a) valid  → kind=Released write={r.write} twist=({r.linear:.3f},{r.angular:.3f}) [clamped]")
+
+    # (b) An unsigned command → Refused NO_TOKEN, no write.
+    c = new_consumer(vk)
+    payload, token = split(mint("frame", "--seq", "1", "--issued-ms", "10000",
+                                "--linear", "0.1", "--angular", "0.0", "--no-token"))
+    check(token is None, "(b) --no-token frame must carry no token")
+    r = c.on_frame(payload, token, 10_000)
+    check(r.kind == 2 and r.refusal_code == 0, f"(b) unsigned must be NO_TOKEN, got kind={r.kind} code={r.refusal_code}")
+    check(r.write == 0, "(b) refusal must NOT actuate")
+    print(f"(b) unsigned → kind=Refused code=NO_TOKEN write={r.write}")
+
+    # (c) Sustained wrong-key (corrupt signature) → SIGNATURE_INVALID + latched alarm.
+    c = new_consumer(vk)
+    for k in range(10):
+        payload, token = split(mint("frame", "--seq", str(k + 1), "--issued-ms", str(10_000 + k),
+                                    "--linear", "0.1", "--angular", "0.0", "--corrupt-sig"))
+        r = c.on_frame(payload, token, 10_000 + k)
+        check(r.kind == 2 and r.refusal_code == 2, f"(c) must be SIGNATURE_INVALID, got code={r.refusal_code}")
+        check(r.write == 0, "(c) bad-sig must not actuate")
+    h = c.health()
+    check(h.key_mismatch_alarm == 1, "(c) sustained bad-sig must LATCH the key-mismatch alarm")
+    check(h.signature_invalid == 10, f"(c) per-class counter must read 10, got {h.signature_invalid}")
+    expl = c.alarm_explanation()
+    check("KEY MISMATCH" in expl, "(c) alarm must carry the loud operator sentence")
+    print(f"(c) 10× bad-sig → alarm_latched={h.key_mismatch_alarm} sig_invalid={h.signature_invalid}")
+    print(f"    alarm: {expl[:72]}...")
+
+    # (d) Replay (same sequence) → SEQUENCE_NOT_ADVANCED after the first release.
+    c = new_consumer(vk)
+    payload, token = split(mint("frame", "--seq", "5", "--issued-ms", "10000",
+                                "--linear", "0.1", "--angular", "0.0"))
+    r1 = c.on_frame(payload, token, 10_000)
+    r2 = c.on_frame(payload, token, 10_010)  # exact replay
+    check(r1.kind == 0, "(d) first release must pass")
+    check(r2.kind == 2 and r2.refusal_code == 5, f"(d) replay must be SEQUENCE_NOT_ADVANCED, got code={r2.refusal_code}")
+    print(f"(d) replay → first=Released replay=code=SEQUENCE_NOT_ADVANCED write={r2.write}")
+
+    # (e) Starvation → active decel ramp to zero, then silence (write=0).
+    c = new_consumer(vk)
+    payload, token = split(mint("frame", "--seq", "1", "--issued-ms", "10000",
+                                "--linear", "0.15", "--angular", "0.0"))
+    c.on_frame(payload, token, 10_000)
+    ramp = []
+    silent = False
+    for k in range(1, 21):
+        t = c.on_tick(10_000 + 300 + k * 100)
+        if t.write == 1:
+            ramp.append(t.linear)
+    check(len(ramp) >= 1, "(e) starvation must produce an active stop ramp")
+    check(ramp and ramp[-1] == 0.0, f"(e) ramp must reach zero, got {ramp}")
+    check(all(a >= b - 1e-12 for a, b in zip(ramp, ramp[1:])), f"(e) ramp must not increase: {ramp}")
+    silent = c.health().silent == 1
+    check(silent, "(e) after the ramp the consumer must be silent")
+    print(f"(e) starvation → ramp={[round(x,3) for x in ramp]} silent={silent}")
+
+    # (f) A frame signed by a DIFFERENT key entirely → SIGNATURE_INVALID.
+    c = new_consumer(vk)
+    other_seed = "09" * 32
+    other = subprocess.run([str(MINT), "--seed", other_seed, "frame", "--seq", "1",
+                            "--issued-ms", "10000", "--linear", "0.1", "--angular", "0.0"],
+                           capture_output=True, text=True, check=True)
+    payload, token = split(bytes.fromhex(other.stdout.strip()))
+    r = c.on_frame(payload, token, 10_000)
+    check(r.kind == 2 and r.refusal_code == 2, f"(f) wrong-key must be SIGNATURE_INVALID, got code={r.refusal_code}")
+    print(f"(f) wrong-key → kind=Refused code=SIGNATURE_INVALID write={r.write}")
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"FAIL {f}")
+        print(f"\nffi smoke test FAILED ({len(failures)} mismatch(es)) — the Python↔Rust boundary diverges.")
+        return 1
+    print("ffi smoke test: OK — the Python↔Rust consumer boundary matches the verify core.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/ffi_smoke_test.py
+++ b/robot/ffi_smoke_test.py
@@ -21,7 +21,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from kirra_ffi import KirraConsumer  # noqa: E402
+from kirra_ffi import KirraConsumer, split_frame  # noqa: E402
 
 REPO = Path(__file__).resolve().parent.parent
 # The dev/demo governor key (well-known [42u8;32]) — DEV ONLY, matches the Rust
@@ -51,10 +51,11 @@ def pubkey(seed: str = DEV_SEED) -> bytes:
 
 
 def split(frame: bytes) -> tuple[bytes, bytes | None]:
-    """payload(32) [|| token(96)] → (payload, token|None)."""
-    payload = frame[:32]
-    token = frame[32:] if len(frame) > 32 else None
-    return payload, token
+    """The strict wire parse the motor consumer uses (kirra_ffi.split_frame);
+    minted frames are always well-formed, so None here is a test bug."""
+    parsed = split_frame(frame)
+    assert parsed is not None, f"minted frame has malformed length {len(frame)}"
+    return parsed
 
 
 def new_consumer(vk: bytes) -> KirraConsumer:
@@ -163,6 +164,16 @@ def main() -> int:
     r = c.on_frame(payload, token, 10_000)
     check(r.kind == 2 and r.refusal_code == 2, f"(f) wrong-key must be SIGNATURE_INVALID, got code={r.refusal_code}")
     print(f"(f) wrong-key → kind=Refused code=SIGNATURE_INVALID write={r.write}")
+
+    # (g) Malformed wire lengths are rejected by the strict parse the motor
+    # consumer uses (Copilot #901): never sliced into an oversized token, never
+    # a crash — the frame is simply not a frame.
+    for n in (0, 31, 33, 127, 129, 256):
+        check(split_frame(b"\x00" * n) is None, f"(g) length {n} must parse as malformed")
+    check(split_frame(b"\x00" * 32) == (b"\x00" * 32, None), "(g) exact 32 → unsigned")
+    p128 = split_frame(b"\x01" * 128)
+    check(p128 is not None and len(p128[1]) == 96, "(g) exact 128 → token of exactly 96")
+    print("(g) malformed lengths (0/31/33/127/129/256) → rejected by the strict parse")
 
     print()
     if failures:

--- a/robot/first_run_elevated.sh
+++ b/robot/first_run_elevated.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# first_run_elevated.sh — the FIRST-RUN acceptance test for the KIRRA verifying
+# motor consumer on the Yahboom Rosmaster X3.
+#
+# 🔴🔴🔴 RUN THIS WITH THE ROBOT ELEVATED — WHEELS OFF THE GROUND. 🔴🔴🔴
+#
+# WHY ELEVATED: this is the first time governed commands drive real motors. A
+# wiring/clamp/verify bug could spin the wheels unexpectedly. Elevated, a wrong
+# motion is a spinning wheel in the air, not a robot lunging off a bench. Only
+# AFTER all three phases pass elevated does the robot touch the floor.
+#
+# The three phases (ADR-0033 Step 4 acceptance):
+#   (a) a VALID governed command  → wheels spin at the CLAMPED demo speed
+#   (b) an UNSIGNED command        → ZERO wheel motion, loud REFUSED in the log
+#   (c) kill the consumer          → wheels STOP immediately (SS-002)
+#
+# This is a GUIDED script: it drives the publisher and prompts YOU to observe the
+# wheels. It cannot see the wheels — you are the acceptance sensor. Answer
+# honestly; a "no" fails the run.
+#
+# Prereqs:
+#   - The consumer node is running in ANOTHER terminal (see the bringup doc):
+#       ros2 run ... kirra_motor_consumer.py   (or: python3 robot/kirra_motor_consumer.py)
+#     with all KIRRA_* config exported and KIRRA_GOVERNOR_VK_HEX pinned to the
+#     dev key below (KIRRA_DEV_SEED's pubkey).
+#   - Built: cargo build -p kirra-release-token --bin kirra_ros_release_mint --release
+#   - ROS 2 Humble sourced; ROS_DOMAIN_ID=28.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PUB="python3 ${HERE}/kirra_release_publisher.py"
+
+confirm() {  # confirm "question" -> exits non-zero on anything but y/Y
+  read -r -p "$1 [y/N] " ans
+  case "$ans" in
+    y|Y) return 0 ;;
+    *) echo "✗ operator reported failure — FIRST-RUN TEST FAILED"; exit 1 ;;
+  esac
+}
+
+echo "=================================================================="
+echo "  KIRRA X3 FIRST-RUN TEST — 🔴 WHEELS MUST BE OFF THE GROUND 🔴"
+echo "=================================================================="
+read -r -p "Is the robot ELEVATED with all wheels free to spin? [y/N] " ans
+[ "$ans" = "y" ] || [ "$ans" = "Y" ] || { echo "Elevate the robot first. Aborting."; exit 1; }
+
+echo
+echo "Confirm the vendor base node is NOT running (it would be a second, unfenced"
+echo "writer to the motor board):"
+if command -v ros2 >/dev/null 2>&1; then
+  echo "  active nodes:"; ros2 node list 2>/dev/null | sed 's/^/    /' || true
+fi
+confirm "Is 'yahboomcar_bringup' / any vendor /cmd_vel motor node ABSENT?"
+
+# ---- Phase (a): valid governed command → clamped motion --------------------
+echo
+echo "── Phase (a): VALID governed command (expect wheels spinning at the CLAMPED demo speed) ──"
+echo "Publishing valid frames for 5 s..."
+timeout 5s ${PUB} --valid || true
+confirm "Did the wheels SPIN (slowly, at the clamped demo speed)?"
+
+# ---- Phase (b): unsigned command → no motion + loud refusal ----------------
+echo
+echo "── Phase (b): UNSIGNED command (expect ZERO motion + REFUSED in the consumer log) ──"
+echo "Publishing UNSIGNED frames for 5 s... watch the consumer terminal for 'REFUSED (NO_TOKEN)'."
+timeout 5s ${PUB} --unsigned || true
+confirm "Did the wheels stay COMPLETELY STILL?"
+confirm "Did the consumer log 'REFUSED (NO_TOKEN)' (no motor write)?"
+
+# ---- Phase (c): kill the consumer → wheels stop ----------------------------
+echo
+echo "── Phase (c): consumer death → wheels STOP (SS-002 shutdown guarantee) ──"
+echo "First, re-establish motion so a stop is observable:"
+echo "Publishing valid frames for 3 s (wheels should spin again)..."
+timeout 3s ${PUB} --valid || true
+echo
+echo "NOW: in the consumer terminal, press Ctrl-C (or: kill the consumer process)."
+confirm "After killing the consumer, did the wheels STOP immediately?"
+
+echo
+echo "=================================================================="
+echo "  ✅ FIRST-RUN TEST PASSED (elevated). All three phases confirmed:"
+echo "     (a) governed → clamped motion, (b) unsigned → refused + still,"
+echo "     (c) consumer death → wheels stop."
+echo "  Only NOW may the robot be placed on the floor for further testing."
+echo "=================================================================="

--- a/robot/kirra_ffi.py
+++ b/robot/kirra_ffi.py
@@ -35,6 +35,23 @@ REFUSAL_NAMES = {
 }
 
 
+def split_frame(data: bytes) -> "tuple[bytes, bytes | None] | None":
+    """Strict wire parse of a release frame (Copilot #901 review).
+
+    Exactly 32 bytes → (payload, None)          — an unsigned command.
+    Exactly 128 bytes → (payload, token[96])    — a signed command.
+    ANY other length → None                     — malformed; the caller must
+    ignore it (never actuate, never crash). A >128-byte frame must NOT be
+    sliced into an oversized token: that raised ValueError inside the ROS
+    callback and let hostile input take down the consumer.
+    """
+    if len(data) == PAYLOAD_LEN:
+        return data, None
+    if len(data) == PAYLOAD_LEN + TOKEN_LEN:
+        return data[:PAYLOAD_LEN], data[PAYLOAD_LEN:]
+    return None
+
+
 class KirraFrameResult(ctypes.Structure):
     _fields_ = [
         ("kind", ctypes.c_int32),          # 0 Released, 1 SerialError, 2 Refused

--- a/robot/kirra_ffi.py
+++ b/robot/kirra_ffi.py
@@ -1,0 +1,201 @@
+"""ctypes binding to libkirra_consumer_ffi (ADR-0033 decision (c)).
+
+This is the ONLY place Python talks to the verify core. It exposes the C ABI of
+`crates/kirra-consumer-ffi` as a small Pythonic `KirraConsumer` wrapper. There is
+NO verification logic here: every gate/watermark/freshness/liveness/alarm
+decision is made in Rust and returned across this boundary. Python's job is to
+present wire bytes and actuate whatever twist the core decides.
+
+Build the shared library first (host or on the robot):
+    cargo build -p kirra-consumer-ffi           # target/debug/libkirra_consumer_ffi.so
+    cargo build -p kirra-consumer-ffi --release # target/release/... (deploy this)
+
+Point KIRRA_CONSUMER_LIB at the .so, or let this module find it under target/.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from pathlib import Path
+
+# Wire lengths — MUST match kirra-consumer-ffi (KIRRA_PAYLOAD_LEN / TOKEN / VK).
+PAYLOAD_LEN = 32
+TOKEN_LEN = 96
+VK_LEN = 32
+
+# Refusal-class codes — MUST match the REF_* constants in the Rust FFI.
+REFUSAL_NAMES = {
+    0: "NO_TOKEN",
+    1: "DIGEST_MISMATCH",
+    2: "SIGNATURE_INVALID",
+    3: "UNDECODABLE",
+    4: "STALE",
+    5: "SEQUENCE_NOT_ADVANCED",
+}
+
+
+class KirraFrameResult(ctypes.Structure):
+    _fields_ = [
+        ("kind", ctypes.c_int32),          # 0 Released, 1 SerialError, 2 Refused
+        ("refusal_code", ctypes.c_int32),  # meaningful iff kind==2
+        ("write", ctypes.c_uint8),         # 1 → actuate (linear, angular)
+        ("sequence", ctypes.c_uint64),
+        ("linear", ctypes.c_double),
+        ("angular", ctypes.c_double),
+    ]
+
+
+class KirraTickResult(ctypes.Structure):
+    _fields_ = [
+        ("write", ctypes.c_uint8),
+        ("linear", ctypes.c_double),
+        ("angular", ctypes.c_double),
+    ]
+
+
+class KirraHealth(ctypes.Structure):
+    _fields_ = [
+        ("releases", ctypes.c_uint64),
+        ("refusals_total", ctypes.c_uint64),
+        ("no_token", ctypes.c_uint64),
+        ("digest_mismatch", ctypes.c_uint64),
+        ("signature_invalid", ctypes.c_uint64),
+        ("undecodable", ctypes.c_uint64),
+        ("stale", ctypes.c_uint64),
+        ("sequence_not_advanced", ctypes.c_uint64),
+        ("consecutive_signature_invalid", ctypes.c_uint32),
+        ("key_mismatch_alarm", ctypes.c_uint8),
+        ("silent", ctypes.c_uint8),
+    ]
+
+
+def _find_lib() -> str:
+    env = os.environ.get("KIRRA_CONSUMER_LIB")
+    if env:
+        if not Path(env).is_file():
+            raise FileNotFoundError(f"KIRRA_CONSUMER_LIB={env} does not exist")
+        return env
+    # Search the workspace target dirs (release preferred for deployment).
+    here = Path(__file__).resolve().parent.parent
+    for prof in ("release", "debug"):
+        cand = here / "target" / prof / "libkirra_consumer_ffi.so"
+        if cand.is_file():
+            return str(cand)
+    raise FileNotFoundError(
+        "libkirra_consumer_ffi.so not found. Build it "
+        "(`cargo build -p kirra-consumer-ffi --release`) or set KIRRA_CONSUMER_LIB."
+    )
+
+
+def _load(lib_path: str) -> ctypes.CDLL:
+    lib = ctypes.CDLL(lib_path)
+    lib.kirra_consumer_new.restype = ctypes.c_void_p
+    lib.kirra_consumer_new.argtypes = [
+        ctypes.c_char_p,   # vk (32 bytes)
+        ctypes.c_uint64,   # freshness_window_ms
+        ctypes.c_uint64,   # control_period_ms
+        ctypes.c_uint32,   # missed_periods
+        ctypes.c_double,   # stop_decel_mps2
+        ctypes.c_double,   # vx_max
+        ctypes.c_double,   # vz_max
+    ]
+    lib.kirra_consumer_free.restype = None
+    lib.kirra_consumer_free.argtypes = [ctypes.c_void_p]
+
+    lib.kirra_consumer_on_frame.restype = None
+    lib.kirra_consumer_on_frame.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,   # payload (32)
+        ctypes.c_char_p,   # token (96) or None
+        ctypes.c_size_t,   # token_len
+        ctypes.c_uint64,   # now_ms
+        ctypes.POINTER(KirraFrameResult),
+    ]
+    lib.kirra_consumer_on_tick.restype = None
+    lib.kirra_consumer_on_tick.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint64,
+        ctypes.POINTER(KirraTickResult),
+    ]
+    lib.kirra_consumer_health.restype = None
+    lib.kirra_consumer_health.argtypes = [ctypes.c_void_p, ctypes.POINTER(KirraHealth)]
+
+    lib.kirra_consumer_alarm_explanation.restype = ctypes.c_char_p
+    lib.kirra_consumer_alarm_explanation.argtypes = []
+    return lib
+
+
+class KirraConsumer:
+    """The verifying motor consumer, driven from Python. Fail-closed: the
+    constructor raises if the core refuses the config (a NULL handle) — the node
+    must abort rather than run unverified."""
+
+    def __init__(
+        self,
+        governor_vk: bytes,
+        *,
+        freshness_window_ms: int,
+        control_period_ms: int,
+        missed_periods: int,
+        stop_decel_mps2: float,
+        vx_max: float,
+        vz_max: float,
+        lib_path: str | None = None,
+    ) -> None:
+        if len(governor_vk) != VK_LEN:
+            raise ValueError(f"governor_vk must be {VK_LEN} bytes, got {len(governor_vk)}")
+        self._lib = _load(lib_path or _find_lib())
+        self._h = self._lib.kirra_consumer_new(
+            governor_vk,
+            ctypes.c_uint64(freshness_window_ms),
+            ctypes.c_uint64(control_period_ms),
+            ctypes.c_uint32(missed_periods),
+            ctypes.c_double(stop_decel_mps2),
+            ctypes.c_double(vx_max),
+            ctypes.c_double(vz_max),
+        )
+        if not self._h:
+            # NULL = fail-closed: bad key, bad decel/deadline, or bad envelope.
+            raise ValueError(
+                "kirra_consumer_new refused the configuration (fail-closed NULL handle): "
+                "check the pinned key, stop_decel_mps2 (finite > 0), control_period_ms/"
+                "missed_periods (non-zero), and vx_max/vz_max (finite > 0)."
+            )
+
+    def on_frame(self, payload: bytes, token: bytes | None, now_ms: int) -> KirraFrameResult:
+        if len(payload) != PAYLOAD_LEN:
+            raise ValueError(f"payload must be {PAYLOAD_LEN} bytes")
+        out = KirraFrameResult()
+        if token is None:
+            self._lib.kirra_consumer_on_frame(
+                self._h, payload, None, 0, ctypes.c_uint64(now_ms), ctypes.byref(out)
+            )
+        else:
+            if len(token) != TOKEN_LEN:
+                raise ValueError(f"token must be {TOKEN_LEN} bytes")
+            self._lib.kirra_consumer_on_frame(
+                self._h, payload, token, TOKEN_LEN, ctypes.c_uint64(now_ms), ctypes.byref(out)
+            )
+        return out
+
+    def on_tick(self, now_ms: int) -> KirraTickResult:
+        out = KirraTickResult()
+        self._lib.kirra_consumer_on_tick(self._h, ctypes.c_uint64(now_ms), ctypes.byref(out))
+        return out
+
+    def health(self) -> KirraHealth:
+        out = KirraHealth()
+        self._lib.kirra_consumer_health(self._h, ctypes.byref(out))
+        return out
+
+    def alarm_explanation(self) -> str:
+        return self._lib.kirra_consumer_alarm_explanation().decode("utf-8", "replace")
+
+    def close(self) -> None:
+        if getattr(self, "_h", None):
+            self._lib.kirra_consumer_free(self._h)
+            self._h = None
+
+    def __del__(self) -> None:
+        self.close()

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""KIRRA verifying motor consumer — Yahboom Rosmaster X3 (ADR-0033 chokepoint, physical).
+
+This node IS the motor bringup. Per ADR-0033 we do NOT stand up the vendor
+`/cmd_vel` driver and retrofit a fence — the verifying consumer is the ONLY
+thing that opens the motor board (`/dev/myserial`) and the ONLY thing that calls
+`Rosmaster.set_car_motion`. A command is actuated ONLY if the Rust verify core
+(libkirra_consumer_ffi, ADR-0033 decision (c)) releases it: token → Ed25519 over
+the exact bytes → freshness → strictly-advancing sequence. No token / stale /
+replayed / bad-signature → refused, no motor write.
+
+🔴 Nothing here re-implements verification. Every gate/watermark/freshness/
+liveness/decel/alarm decision is made in Rust and returned across the FFI; this
+node presents wire bytes and actuates whatever twist the core decides.
+
+🔴 No vendor base node. Do NOT launch `yahboomcar_bringup` alongside this — it
+would be a second, UNFENCED writer to the motor board. This node owning
+`/dev/myserial` (exclusive) is the structural guarantee.
+
+Wire input: topic KIRRA_RELEASE_TOPIC (default /kirra/release),
+`std_msgs/UInt8MultiArray`, data = payload(32) || token(96) for a governed
+command, or payload(32) alone for an unsigned one (→ refused).
+
+Config — ALL required, NO defaults (fail-closed; a missing var aborts):
+    KIRRA_GOVERNOR_VK_HEX      64-hex Ed25519 public key this consumer pins
+    KIRRA_FRESHNESS_WINDOW_MS  freshness window (ADR-0033 decision 3; e.g. 200)
+    KIRRA_CONTROL_PERIOD_MS    control period (e.g. 100 at 10 Hz)
+    KIRRA_MISSED_PERIODS       liveness deadline in periods (ADR-0033: 3)
+    KIRRA_STOP_DECEL_MPS2      MRC decel for the safe stop (class MRC profile)
+    KIRRA_DEMO_VX_MAX          demo linear cap (m/s) — Step 3 backstop
+    KIRRA_DEMO_VZ_MAX          demo angular cap (rad/s) — Step 3 backstop
+    KIRRA_MOTOR_PORT           motor serial device (e.g. /dev/myserial)
+Optional:
+    KIRRA_RELEASE_TOPIC        (default /kirra/release)
+    KIRRA_CONSUMER_LIB         explicit path to libkirra_consumer_ffi.so
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from kirra_ffi import KirraConsumer, REFUSAL_NAMES  # noqa: E402
+
+
+def _req(name: str) -> str:
+    v = os.environ.get(name)
+    if v is None or v == "":
+        # Fail-closed: no invented "safe" numbers. A missing knob is an abort,
+        # not a default.
+        print(f"FATAL: required env var {name} is unset — refusing to start "
+              f"(no defaults for physical/safety numbers).", file=sys.stderr)
+        sys.exit(2)
+    return v
+
+
+def _req_float(name: str) -> float:
+    try:
+        return float(_req(name))
+    except ValueError:
+        print(f"FATAL: {name} must be a number", file=sys.stderr)
+        sys.exit(2)
+
+
+def _req_int(name: str) -> int:
+    try:
+        return int(_req(name))
+    except ValueError:
+        print(f"FATAL: {name} must be an integer", file=sys.stderr)
+        sys.exit(2)
+
+
+def now_ms() -> int:
+    # UNIX epoch ms — MUST share a synchronized clock with the signer
+    # (AOU-TIMESYNC-001): freshness compares this to the token's issued_at_ms.
+    return int(time.time() * 1000)
+
+
+def main() -> int:
+    # ROS + vendor lib imported inside main so the file parses/syntax-checks on a
+    # host without them (CI py_compile); they are required on the robot.
+    import rclpy
+    from rclpy.node import Node
+    from std_msgs.msg import UInt8MultiArray
+    from Rosmaster_Lib import Rosmaster
+
+    vk_hex = _req("KIRRA_GOVERNOR_VK_HEX").strip()
+    try:
+        governor_vk = bytes.fromhex(vk_hex)
+    except ValueError:
+        print("FATAL: KIRRA_GOVERNOR_VK_HEX is not valid hex", file=sys.stderr)
+        return 2
+    if len(governor_vk) != 32:
+        print("FATAL: KIRRA_GOVERNOR_VK_HEX must be 32 bytes (64 hex)", file=sys.stderr)
+        return 2
+
+    freshness_window_ms = _req_int("KIRRA_FRESHNESS_WINDOW_MS")
+    control_period_ms = _req_int("KIRRA_CONTROL_PERIOD_MS")
+    missed_periods = _req_int("KIRRA_MISSED_PERIODS")
+    stop_decel_mps2 = _req_float("KIRRA_STOP_DECEL_MPS2")
+    vx_max = _req_float("KIRRA_DEMO_VX_MAX")
+    vz_max = _req_float("KIRRA_DEMO_VZ_MAX")
+    motor_port = _req("KIRRA_MOTOR_PORT")
+    topic = os.environ.get("KIRRA_RELEASE_TOPIC", "/kirra/release")
+
+    # The verify core (fail-closed: raises on a NULL handle).
+    consumer = KirraConsumer(
+        governor_vk,
+        freshness_window_ms=freshness_window_ms,
+        control_period_ms=control_period_ms,
+        missed_periods=missed_periods,
+        stop_decel_mps2=stop_decel_mps2,
+        vx_max=vx_max,
+        vz_max=vz_max,
+    )
+
+    # 🔴 OWN the motor board. This is the sole opener/writer of /dev/myserial.
+    bot = Rosmaster(com=motor_port)
+    bot.create_receive_threading()
+
+    def safe_stop() -> None:
+        # SS-002 shutdown guarantee: command zero, best-effort, idempotent.
+        try:
+            bot.set_car_motion(0.0, 0.0, 0.0)
+        except Exception as e:  # noqa: BLE001 — shutdown must not raise past here.
+            print(f"safe_stop: set_car_motion(0,0,0) raised: {e}", file=sys.stderr)
+
+    rclpy.init()
+    node = Node("kirra_motor_consumer")
+    node.get_logger().info(
+        f"KIRRA consumer OWNS {motor_port} (sole writer). topic={topic} "
+        f"envelope: vx_max={vx_max} m/s vz_max={vz_max} rad/s (DEMO backstop; "
+        f"Kirra's checker is the authority). Vendor base node must NOT be running."
+    )
+
+    alarm_announced = False
+
+    def actuate(linear: float, angular: float) -> None:
+        # v_y = 0 (skid-steer demo; no lateral). linear→v_x, angular→v_z, both
+        # already clamped by the Rust capture seam.
+        bot.set_car_motion(linear, 0.0, angular)
+
+    def on_msg(msg: UInt8MultiArray) -> None:
+        nonlocal alarm_announced
+        data = bytes(msg.data)
+        # payload(32) [|| token(96)]. Any other length → no usable token.
+        payload = data[:32]
+        if len(payload) < 32:
+            node.get_logger().warn("release frame shorter than 32 bytes — ignored")
+            return
+        token = data[32:] if len(data) >= 128 else None
+        res = consumer.on_frame(payload, token, now_ms())
+        if res.write == 1:
+            actuate(res.linear, res.angular)
+        else:
+            name = REFUSAL_NAMES.get(res.refusal_code, f"code{res.refusal_code}")
+            node.get_logger().warn(f"REFUSED ({name}) — no motor write")
+        # 🔴 #892 loud, DISTINCT key-mismatch diagnostic (latched once).
+        h = consumer.health()
+        if h.key_mismatch_alarm == 1 and not alarm_announced:
+            alarm_announced = True
+            node.get_logger().error("🔴 " + consumer.alarm_explanation())
+        elif h.key_mismatch_alarm == 0:
+            alarm_announced = False
+
+    node.create_subscription(UInt8MultiArray, topic, on_msg, 10)
+
+    # Liveness clock: on_tick every control period drives the SS-002 decel-to-zero
+    # ramp when releases stop arriving (never hold-last). A refusal does NOT feed
+    # liveness — a flood starves into the stop exactly as silence does.
+    def on_timer() -> None:
+        t = consumer.on_tick(now_ms())
+        if t.write == 1:
+            actuate(t.linear, t.angular)
+
+    node.create_timer(control_period_ms / 1000.0, on_timer)
+
+    # Guaranteed stop on any exit path (SIGINT / SIGTERM / exception / normal).
+    def handle_signal(signum, _frame):  # noqa: ANN001
+        node.get_logger().warn(f"signal {signum} → safe stop + shutdown")
+        safe_stop()
+        rclpy.shutdown()
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    try:
+        rclpy.spin(node)
+    finally:
+        # Belt-and-braces: even a panic/spin-exit stops the wheels.
+        safe_stop()
+        try:
+            node.destroy_node()
+        except Exception:  # noqa: BLE001
+            pass
+        consumer.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -44,7 +44,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from kirra_ffi import KirraConsumer, REFUSAL_NAMES  # noqa: E402
+from kirra_ffi import KirraConsumer, REFUSAL_NAMES, split_frame  # noqa: E402
 
 
 def _req(name: str) -> str:
@@ -147,12 +147,17 @@ def main() -> int:
     def on_msg(msg: UInt8MultiArray) -> None:
         nonlocal alarm_announced
         data = bytes(msg.data)
-        # payload(32) [|| token(96)]. Any other length → no usable token.
-        payload = data[:32]
-        if len(payload) < 32:
-            node.get_logger().warn("release frame shorter than 32 bytes — ignored")
+        # STRICT wire parse (Copilot #901): exactly 32 (unsigned) or exactly
+        # 128 (signed). Anything else is malformed — ignored with a warn, never
+        # sliced into an oversized token (which raised ValueError in the
+        # callback and let hostile input take down the consumer).
+        parsed = split_frame(data)
+        if parsed is None:
+            node.get_logger().warn(
+                f"malformed release frame ({len(data)} bytes; expected 32 or 128) — ignored"
+            )
             return
-        token = data[32:] if len(data) >= 128 else None
+        payload, token = parsed
         res = consumer.on_frame(payload, token, now_ms())
         if res.write == 1:
             actuate(res.linear, res.angular)

--- a/robot/kirra_release_publisher.py
+++ b/robot/kirra_release_publisher.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Governor stand-in publisher for the elevated first-run test (DEV/DEMO only).
+
+Publishes release frames on KIRRA_RELEASE_TOPIC for the consumer to verify. It
+mints frames with `kirra_ros_release_mint` (the SAME Rust `issue_ros_release` the
+governor uses — no Python crypto), then publishes them as std_msgs/UInt8MultiArray.
+
+⚠️ DEV/DEMO ONLY. The signing seed is a well-known test key; a real deployment's
+frames come from the verifier's provisioned key, not this script.
+
+Modes:
+    --valid     publish signed, freshly-stamped, strictly-advancing frames
+    --unsigned  publish the 32-byte payload with NO token (→ consumer refuses)
+
+Env:
+    KIRRA_MINT_BIN     path to kirra_ros_release_mint (else searched under target/)
+    KIRRA_DEV_SEED     64-hex signing seed (default 2a*32, matching the fixtures)
+    KIRRA_RELEASE_TOPIC (default /kirra/release)
+    KIRRA_PUB_LINEAR   commanded linear m/s (default 0.15)
+    KIRRA_PUB_ANGULAR  commanded angular rad/s (default 0.0)
+    KIRRA_PUB_RATE_HZ  publish rate (default 10)
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_SEED = "2a" * 32
+
+
+def find_mint() -> str:
+    env = os.environ.get("KIRRA_MINT_BIN")
+    if env:
+        return env
+    for prof in ("release", "debug"):
+        cand = REPO / "target" / prof / "kirra_ros_release_mint"
+        if cand.is_file():
+            return str(cand)
+    print("FATAL: kirra_ros_release_mint not found "
+          "(cargo build -p kirra-release-token --bin kirra_ros_release_mint) "
+          "or set KIRRA_MINT_BIN", file=sys.stderr)
+    sys.exit(2)
+
+
+def mint_frame(mint: str, seed: str, seq: int, issued_ms: int,
+               linear: float, angular: float, unsigned: bool) -> bytes:
+    args = [mint, "--seed", seed, "frame", "--seq", str(seq),
+            "--issued-ms", str(issued_ms), "--linear", str(linear),
+            "--angular", str(angular)]
+    if unsigned:
+        args.append("--no-token")
+    out = subprocess.run(args, capture_output=True, text=True, check=True)
+    return bytes.fromhex(out.stdout.strip())
+
+
+def main() -> int:
+    unsigned = "--unsigned" in sys.argv
+    valid = "--valid" in sys.argv
+    if unsigned == valid:
+        print("usage: kirra_release_publisher.py (--valid | --unsigned)", file=sys.stderr)
+        return 2
+
+    mint = find_mint()
+    seed = os.environ.get("KIRRA_DEV_SEED", DEFAULT_SEED)
+    topic = os.environ.get("KIRRA_RELEASE_TOPIC", "/kirra/release")
+    linear = float(os.environ.get("KIRRA_PUB_LINEAR", "0.15"))
+    angular = float(os.environ.get("KIRRA_PUB_ANGULAR", "0.0"))
+    rate_hz = float(os.environ.get("KIRRA_PUB_RATE_HZ", "10"))
+
+    import rclpy
+    from rclpy.node import Node
+    from std_msgs.msg import UInt8MultiArray
+
+    rclpy.init()
+    node = Node("kirra_release_publisher")
+    pub = node.create_publisher(UInt8MultiArray, topic, 10)
+    mode = "UNSIGNED (expect REFUSED)" if unsigned else "VALID governed"
+    node.get_logger().info(f"publishing {mode} frames on {topic} at {rate_hz} Hz "
+                           f"linear={linear} angular={angular}")
+
+    seq = 1
+    period = 1.0 / rate_hz
+    try:
+        while rclpy.ok():
+            issued_ms = int(time.time() * 1000)  # fresh each frame
+            frame = mint_frame(mint, seed, seq, issued_ms, linear, angular, unsigned)
+            msg = UInt8MultiArray()
+            msg.data = list(frame)
+            pub.publish(msg)
+            seq += 1
+            time.sleep(period)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/kirra_release_publisher.py
+++ b/robot/kirra_release_publisher.py
@@ -71,6 +71,13 @@ def main() -> int:
     linear = float(os.environ.get("KIRRA_PUB_LINEAR", "0.15"))
     angular = float(os.environ.get("KIRRA_PUB_ANGULAR", "0.0"))
     rate_hz = float(os.environ.get("KIRRA_PUB_RATE_HZ", "10"))
+    # Fail fast on a nonsensical rate (Copilot #901): 0 divides, NaN/Inf breaks
+    # sleep(). This script drives the guided first-run test — a bad knob must be
+    # a clear error, not a crash mid-procedure.
+    import math
+    if not (math.isfinite(rate_hz) and rate_hz > 0):
+        print(f"FATAL: KIRRA_PUB_RATE_HZ must be finite and > 0, got {rate_hz}", file=sys.stderr)
+        return 2
 
     import rclpy
     from rclpy.node import Node


### PR DESCRIPTION
**Do not merge without human review.** The first real drive test runs **WHEELS OFF THE GROUND** (`robot/first_run_elevated.sh`).

## What

The ADR-0033 chokepoint made physical on the X3: the verifying consumer **owns `/dev/myserial`** and drives `set_car_motion` **only** for commands carrying a valid release token. Per ADR-0033 we do **not** stand up the vendor `/cmd_vel` driver and retrofit a fence — the consumer **is** the motor bringup.

Per ADR-0033 **decision (c)**, the Rust verify core is **reused verbatim over a new C ABI**, never reimplemented in Python.

## The verify-before-drive path

```
signed frame (topic)  ──ctypes──▶  libkirra_consumer_ffi: MotorConsumer<CaptureSerial>
payload(32)||token(96)               = RosReleaseGate (verify→decode→freshness→watermark)
                                       + SS-002 liveness/decel + #892 key-mismatch alarm
kirra_motor_consumer.py ◀─decision─┘  → set_car_motion(v_x,0,v_z) iff the core said "write"
        │
     /dev/myserial (Rosmaster_Lib)  ← sole writer
```

Every gate/watermark/freshness/liveness/alarm decision is made in Rust; Python presents bytes and actuates the decided twist. **No crypto in Python.**

## Report (per the deliverable)

- **FFI surface — reused from #891, extended.** The verify core (`RosReleaseGate` / `MotorConsumer`, `crates/kirra-actuation-consumer` + `kirra-release-token`) is reused with **zero** crypto/watermark/freshness/liveness reimplemented. This PR **adds** the C-ABI marshalling layer that #891 explicitly named as future work (`ros_twist.rs`: *"the C-ABI surface for the Python node"*) and which did not exist:
  - **`crates/kirra-consumer-ffi`** (cdylib+rlib): 6 `extern "C"` fns — `kirra_consumer_new` (fail-closed NULL on bad key/decel/deadline/envelope), `_on_frame`, `_on_tick`, `_health`, `_alarm_explanation`, `_free`. `unsafe` isolated **here only**; the verify core keeps `#[forbid(unsafe_code)]`.
  - One additive accessor `MotorConsumer::serial_mut` (lends the serial seam only — no path to gate/watermark/liveness).
  - `CaptureSerial` = the `MotorSerial` seam: records the decided twist + applies the demo clamp.
  - Governor stand-in minter `kirra_ros_release_mint` (wraps the existing `issue_ros_release` — keeps *signing* in Rust too; DEV/DEMO only).
- **Demo envelope (required config, no default; backstop, not the safety mechanism):** `vx_max = 0.15 m/s`, `vz_max = 0.4 rad/s`, `v_y = 0` (skid-steer, no lateral) — far below the X3 hardware max (1.0 m/s / 5 rad/s). `kirra_consumer_new` returns fail-closed NULL if unset/non-finite; the node aborts.
- **No vendor motor node co-runs:** the consumer is the sole opener/writer of `/dev/myserial`; the bringup + elevated script both assert `yahboomcar_bringup` is absent.
- **Shutdown-stop guarantee:** `set_car_motion(0,0,0)` on SIGINT/SIGTERM/exception/normal exit (signal handlers + `finally`), plus SS-002 liveness decel-to-zero (never hold-last) when releases stop. A refusal does **not** feed liveness — a flood starves into the safe stop like silence.

## Loud diagnostic (#892)

Sustained `SIGNATURE_INVALID` (≥10 consecutive) **latches** a distinct key-mismatch alarm with the operator sentence (rotation-misorder cause + recovery) — visibly different from staleness, never a silent safe-stop. A valid release clears it.

## Verification (runs here / in CI — no hardware)

`robot/ffi_smoke_test.py` loads the `.so` via ctypes, mints frames with the governor stand-in, and asserts the core's decisions across the FFI — the same (a)/(b)/(c) the elevated test checks, plus replay/wrong-key/decel-ramp, minus the wheels:

```
(a) valid  → kind=Released write=1 twist=(0.150,0.400) [clamped]
(b) unsigned → kind=Refused code=NO_TOKEN write=0
(c) 10× bad-sig → alarm_latched=1 sig_invalid=10
(d) replay → replay=code=SEQUENCE_NOT_ADVANCED write=0
(e) starvation → ramp=[0.05, 0.0] silent=True
(f) wrong-key → kind=Refused code=SIGNATURE_INVALID write=0
ffi smoke test: OK
```

Also: `kirra-consumer-ffi` 5 FFI tests + `kirra-actuation-consumer` 12 + clippy clean + `cargo check --workspace` green. Wired as a blocking CI step (`static-analysis`).

## Fences

- **Mick actuation fence:** `kirra-consumer-ffi` added to the forbidden set (Mick must not reach the motor `.so`) — fence stays INTACT.
- **Verdict-core purity fence (#900):** stays INTACT — this is the actuation path, where crypto legitimately lives *after* the verdict (ADR-0031 separation upheld).

## First-run acceptance — WHEELS OFF THE GROUND

`robot/first_run_elevated.sh` guides three phases with the robot elevated: (a) governed → clamped spin, (b) unsigned → zero motion + loud refusal, (c) kill consumer → wheels stop. Only after all three pass elevated does the robot touch the floor. Full procedure (incl. the separate lidar step): `docs/hardware/ROSMASTER_X3_BRINGUP.md`.

## Explicitly NOT in this PR

Speech/mic/TTS (last layer, hardware on order); sros2 (Tier-2); nav2/SLAM; any second writer to `/dev/myserial`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_