### PR TITLE
fix(x3): rclpy double-shutdown guard (hardware finding) + lidar bringup step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1057,6 +1057,10 @@ jobs:
           cargo build --locked -p kirra-consumer-ffi
           cargo build --locked -p kirra-release-token --bin kirra_ros_release_mint
           python3 robot/ffi_smoke_test.py
+          # Teardown exactly-once guard (hardware first-run finding): stub-rclpy
+          # harness drives the REAL publisher/consumer main() through the
+          # signal-shutdown paths; an unguarded second rclpy.shutdown() fails it.
+          python3 robot/teardown_smoke_test.py
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Clippy

--- a/docs/hardware/ROSMASTER_X3_BRINGUP.md
+++ b/docs/hardware/ROSMASTER_X3_BRINGUP.md
@@ -206,15 +206,63 @@ ramp — through the same FFI, minus the wheels. It runs in CI.
 
 Kept a **separate launch step** from the motor consumer. This is the input
 Taj→Occy→Kirra needs so the governed loop is real, not synthetic.
+🔴 **Perception bringup only** — this step publishes and verifies `/scan`;
+wiring `/scan` → Taj → Occy → Kirra → the (fenced) motor consumer is the
+*next* milestone, done deliberately with its own elevated re-test. The motor
+consumer is untouched by this step.
+
+### Which launch file (and why)
+
+`sllidar_ros2` ships per-model launch files that differ mainly by **baud**:
+`sllidar_a2m12_launch.py` / `sllidar_a3_launch.py` / `sllidar_s1_launch.py`
+(256000), `sllidar_s2_launch.py` (1000000), `sllidar_c1_launch.py` (460800) —
+all for faster units this robot does not have. The **4ROS is an A-class
+RPLIDAR** (`RPLIDAR_TYPE=4ROS`, SLAMTEC driver), so the right profile is the
+generic **`sllidar_launch.py`** — the A-series default: serial channel,
+**115200 baud**, `frame_id:=laser`, `angle_compensate:=true`. If `/scan` does
+not appear at 115200 (wrong-baud symptom: driver reports a timeout / no
+device health), the unit is not A-class-clocked — try the 256000 profiles
+before anything else.
+
+### The two-symlink wrinkle (rplidar vs ydlidar)
+
+`/dev/rplidar` **and** `/dev/ydlidar` both symlink to `ttyUSB0` on this image.
+`RPLIDAR_TYPE=4ROS` settles it: the unit is an RPLIDAR, so the driver is
+**`sllidar_ros2`** — never the ydlidar driver. Before launching, confirm no
+ydlidar node is holding the port:
+
+```bash
+ros2 node list          # must show NO ydlidar node
+fuser -v /dev/ttyUSB0   # must show no other process on the port
+```
+
+### Launch + verify (robot stationary)
 
 ```bash
 export RPLIDAR_TYPE=4ROS
 ros2 launch sllidar_ros2 sllidar_launch.py \
-    serial_port:=/dev/rplidar
-# Confirm real scans:
-ros2 topic hz /scan
-ros2 topic echo /scan --once
+    serial_port:=/dev/rplidar \
+    serial_baudrate:=115200 \
+    frame_id:=laser
+
+# In a second terminal — BOTH checks must pass:
+ros2 topic hz /scan          # steady rate, ~5–10 Hz for an A-series unit
+ros2 topic echo /scan --once # real ranges, not all 0.0 / inf
 ```
+
+Acceptance (stationary sanity):
+
+- `ros2 topic hz` reports a **steady** rate (A-series scan rate is ~5.5–10 Hz;
+  a wildly jittering or ~0 rate means a serial/baud problem, not a real scan).
+- The `ranges` array holds mostly **finite values plausible for the room**
+  (indoors: roughly 0.15–12 m for an A-class unit). All-`inf`/all-zero means
+  the motor isn't spinning or the wrong driver/baud is talking to the port.
+- `angle_min`/`angle_max` span ≈ ±π and `range_min`/`range_max` are sane
+  (≈0.15 / ≈12 m for A-series).
+
+Record the observed rate in the bringup log; it becomes the freshness budget
+input when the live loop is wired (`KIRRA_SUBSCRIPTION_STALENESS_MS` must
+exceed one real scan period with margin).
 
 ---
 

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -185,16 +185,27 @@ def main() -> int:
     node.create_timer(control_period_ms / 1000.0, on_timer)
 
     # Guaranteed stop on any exit path (SIGINT / SIGTERM / exception / normal).
+    # Same double-shutdown class as the publisher's hardware finding: shutdown
+    # must be GUARDED (a second signal, or a race with teardown, must not call
+    # rcl_shutdown twice), and spin's ExternalShutdownException — which rclpy
+    # raises once the context is shut down from a signal handler — must be
+    # caught, not tracebacked. Teardown-only; the safe_stop ordering (stop the
+    # wheels BEFORE shutting down) is unchanged.
+    from rclpy.executors import ExternalShutdownException
+
     def handle_signal(signum, _frame):  # noqa: ANN001
         node.get_logger().warn(f"signal {signum} → safe stop + shutdown")
         safe_stop()
-        rclpy.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
 
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)
 
     try:
         rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass  # clean signal-driven exit; the finally below stops the wheels
     finally:
         # Belt-and-braces: even a panic/spin-exit stops the wheels.
         safe_stop()
@@ -203,6 +214,8 @@ def main() -> int:
         except Exception:  # noqa: BLE001
             pass
         consumer.close()
+        if rclpy.ok():
+            rclpy.shutdown()
     return 0
 
 

--- a/robot/kirra_release_publisher.py
+++ b/robot/kirra_release_publisher.py
@@ -105,7 +105,14 @@ def main() -> int:
         pass
     finally:
         node.destroy_node()
-        rclpy.shutdown()
+        # GUARDED shutdown (hardware first-run finding): rclpy.init() installs
+        # its own SIGINT/SIGTERM handlers, so on Ctrl-C / `timeout`'s SIGTERM
+        # the context is ALREADY shut down by the time this finally runs — an
+        # unconditional shutdown() here was a guaranteed second call
+        # (RCLError: rcl_shutdown already called) after every publish window.
+        # Exactly-once teardown: shutdown only if the context is still up.
+        if rclpy.ok():
+            rclpy.shutdown()
     return 0
 
 

--- a/robot/teardown_smoke_test.py
+++ b/robot/teardown_smoke_test.py
@@ -25,6 +25,7 @@ behavior change (frames not published / safe stop not written).
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -211,14 +212,19 @@ def main() -> int:
         rc = -1
     check(rc == 0, f"(1) publisher must exit 0 on the signal path, got {rc}")
     node = StubNode.last
-    check(node is not None and len(node.pub.published) == 3,
-          "(1) publisher must still publish its frames (behavior unchanged)")
-    check(node is not None and node.destroyed == 1, "(1) node destroyed exactly once")
+    # Guard the dereferences (Copilot #903): if main() bailed before creating
+    # the node, this must report a clean check failure, not an AttributeError.
+    check(node is not None, "(1) publisher must have created its node")
+    if node is not None:
+        check(len(node.pub.published) == 3,
+              "(1) publisher must still publish its frames (behavior unchanged)")
+        check(node.destroyed == 1, "(1) node destroyed exactly once")
+        check(all(len(f) == 128 for f in node.pub.published),
+              "(1) valid mode still emits 128-byte signed frames")
+        print(f"(1) publisher/SIGTERM → exit 0, {len(node.pub.published)} frames, "
+              f"no double shutdown")
     check(ctx.shutdown_calls == 0,
           "(1) context was signal-shutdown; the guard must SKIP the second call")
-    check(all(len(f) == 128 for f in node.pub.published),
-          "(1) valid mode still emits 128-byte signed frames")
-    print(f"(1) publisher/SIGTERM → exit 0, {len(node.pub.published)} frames, no double shutdown")
 
     # ------------------------------------------------------------------
     # 2. Publisher, KeyboardInterrupt with the context still up: shutdown
@@ -252,9 +258,12 @@ def main() -> int:
     #    signal handler downed the context (the Humble behavior). Must exit
     #    cleanly, write the (0,0,0) safe stop, and not double-shutdown.
     # ------------------------------------------------------------------
-    vk = os.popen(
-        f"{mint} --seed {'2a' * 32} pubkey"
-    ).read().strip()
+    # subprocess (not os.popen — Copilot #903): no shell, and check=True makes
+    # a mint failure fail THIS test loudly instead of feeding an empty key on.
+    vk = subprocess.run(
+        [mint, "--seed", "2a" * 32, "pubkey"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
     os.environ.update({
         "KIRRA_GOVERNOR_VK_HEX": vk,
         "KIRRA_FRESHNESS_WINDOW_MS": "200",

--- a/robot/teardown_smoke_test.py
+++ b/robot/teardown_smoke_test.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Host teardown test for the robot scripts' shutdown paths (no ROS needed).
+
+The hardware first-run test surfaced a double-shutdown crash: `rclpy.init()`
+installs its own SIGINT/SIGTERM handlers, so on Ctrl-C / `timeout`'s SIGTERM
+the context is ALREADY shut down when the script's `finally` runs — an
+unconditional `rclpy.shutdown()` there was a guaranteed second call
+(`RCLError: rcl_shutdown already called`) after every publish window.
+
+This harness injects a stub `rclpy` whose `shutdown()` raises on a second call
+— exactly like real rcl — then drives the REAL `main()` of the publisher and
+the motor consumer through the signal-shutdown scenarios. Remove the
+`if rclpy.ok():` guards and this test goes red (non-vacuity). The motor
+consumer runs against the REAL libkirra_consumer_ffi and a recording Rosmaster
+stub, so "safe_stop still writes (0,0,0) before teardown" is asserted too.
+
+Prereqs (same as ffi_smoke_test.py):
+    cargo build -p kirra-consumer-ffi
+    cargo build -p kirra-release-token --bin kirra_ros_release_mint
+
+Exit 0 = teardown exactly-once everywhere; exit 1 = a double-shutdown or a
+behavior change (frames not published / safe stop not written).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent
+sys.path.insert(0, str(HERE))
+
+failures: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        failures.append(msg)
+
+
+# ---------------------------------------------------------------------------
+# Stub rclpy — mimics the real teardown semantics that produced the bug:
+#   * ok() reflects context liveness;
+#   * a "signal" (real rclpy's own handler) shuts the context down out-of-band;
+#   * shutdown() on an already-down context RAISES, like rcl_shutdown.
+# ---------------------------------------------------------------------------
+
+class StubContext:
+    def __init__(self) -> None:
+        self.up = False
+        self.shutdown_calls = 0
+        self.ok_calls_until_signal: int | None = None
+        self._ok_calls = 0
+        self.spin_raises: BaseException | None = None
+        self.spin_downs_context = False
+
+    def init(self, *a, **k) -> None:
+        self.up = True
+        self._ok_calls = 0
+        self.shutdown_calls = 0
+
+    def ok(self) -> bool:
+        self._ok_calls += 1
+        if (self.ok_calls_until_signal is not None
+                and self._ok_calls > self.ok_calls_until_signal):
+            self.up = False  # rclpy's own signal handler shut the context down
+        return self.up
+
+    def shutdown(self, *a, **k) -> None:
+        if not self.up:
+            # Real rcl behavior — the exact crash from the hardware run.
+            raise RuntimeError("failed to shutdown: rcl_shutdown already called")
+        self.up = False
+        self.shutdown_calls += 1
+
+    def spin(self, _node) -> None:
+        if self.spin_downs_context:
+            self.up = False
+        if self.spin_raises is not None:
+            raise self.spin_raises
+
+
+class StubLogger:
+    def info(self, *_a) -> None: ...
+    def warn(self, *_a) -> None: ...
+    def error(self, *_a) -> None: ...
+
+
+class StubPublisher:
+    def __init__(self) -> None:
+        self.published: list[bytes] = []
+
+    def publish(self, msg) -> None:
+        self.published.append(bytes(msg.data))
+
+
+class StubNode:
+    last: "StubNode | None" = None
+
+    def __init__(self, _name: str) -> None:
+        StubNode.last = self
+        self.pub = StubPublisher()
+        self.destroyed = 0
+
+    def create_publisher(self, _t, _topic, _qos):
+        return self.pub
+
+    def create_subscription(self, _t, _topic, _cb, _qos):
+        return object()
+
+    def create_timer(self, _period, _cb):
+        return object()
+
+    def get_logger(self):
+        return StubLogger()
+
+    def destroy_node(self) -> None:
+        self.destroyed += 1
+
+
+class ExternalShutdownException(Exception):
+    pass
+
+
+class UInt8MultiArray:
+    def __init__(self) -> None:
+        self.data: list[int] = []
+
+
+def install_stubs(ctx: StubContext) -> None:
+    rclpy = types.ModuleType("rclpy")
+    rclpy.init = ctx.init
+    rclpy.ok = ctx.ok
+    rclpy.shutdown = ctx.shutdown
+    rclpy.spin = ctx.spin
+
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_node.Node = StubNode
+    rclpy_execs = types.ModuleType("rclpy.executors")
+    rclpy_execs.ExternalShutdownException = ExternalShutdownException
+    rclpy.node = rclpy_node
+    rclpy.executors = rclpy_execs
+
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.UInt8MultiArray = UInt8MultiArray
+    std_msgs.msg = std_msgs_msg
+
+    rosmaster_lib = types.ModuleType("Rosmaster_Lib")
+
+    class Rosmaster:
+        last: "Rosmaster | None" = None
+
+        def __init__(self, com: str = "") -> None:
+            Rosmaster.last = self
+            self.com = com
+            self.motions: list[tuple[float, float, float]] = []
+
+        def create_receive_threading(self) -> None: ...
+
+        def set_car_motion(self, vx: float, vy: float, vz: float) -> None:
+            self.motions.append((vx, vy, vz))
+
+    rosmaster_lib.Rosmaster = Rosmaster
+
+    for name, mod in {
+        "rclpy": rclpy,
+        "rclpy.node": rclpy_node,
+        "rclpy.executors": rclpy_execs,
+        "std_msgs": std_msgs,
+        "std_msgs.msg": std_msgs_msg,
+        "Rosmaster_Lib": rosmaster_lib,
+    }.items():
+        sys.modules[name] = mod
+
+
+def find_mint() -> str:
+    for prof in ("release", "debug"):
+        cand = REPO / "target" / prof / "kirra_ros_release_mint"
+        if cand.is_file():
+            return str(cand)
+    print("FAIL: kirra_ros_release_mint not built")
+    sys.exit(1)
+
+
+def main() -> int:
+    mint = find_mint()
+    ctx = StubContext()
+    install_stubs(ctx)
+
+    import kirra_release_publisher
+    import kirra_motor_consumer
+
+    # ------------------------------------------------------------------
+    # 1. Publisher, signal path (the hardware crash): rclpy's own handler
+    #    downs the context mid-loop; the finally must NOT shutdown again.
+    # ------------------------------------------------------------------
+    os.environ.update({
+        "KIRRA_MINT_BIN": mint,
+        "KIRRA_PUB_RATE_HZ": "500",  # fast loop; content/timing logic unchanged
+    })
+    ctx.ok_calls_until_signal = 3  # 3 loop iterations, then "SIGTERM arrived"
+    sys.argv = ["kirra_release_publisher.py", "--valid"]
+    try:
+        rc = kirra_release_publisher.main()
+    except BaseException as e:  # noqa: BLE001 — any traceback is THE bug
+        failures.append(f"(1) publisher signal path raised: {e!r}")
+        rc = -1
+    check(rc == 0, f"(1) publisher must exit 0 on the signal path, got {rc}")
+    node = StubNode.last
+    check(node is not None and len(node.pub.published) == 3,
+          "(1) publisher must still publish its frames (behavior unchanged)")
+    check(node is not None and node.destroyed == 1, "(1) node destroyed exactly once")
+    check(ctx.shutdown_calls == 0,
+          "(1) context was signal-shutdown; the guard must SKIP the second call")
+    check(all(len(f) == 128 for f in node.pub.published),
+          "(1) valid mode still emits 128-byte signed frames")
+    print(f"(1) publisher/SIGTERM → exit 0, {len(node.pub.published)} frames, no double shutdown")
+
+    # ------------------------------------------------------------------
+    # 2. Publisher, KeyboardInterrupt with the context still up: shutdown
+    #    must run EXACTLY once (the guard must not skip a needed teardown).
+    # ------------------------------------------------------------------
+    ctx.ok_calls_until_signal = None
+    calls = {"n": 0}
+    real_mint_frame = kirra_release_publisher.mint_frame
+
+    def interrupting_mint(*a, **k):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            raise KeyboardInterrupt  # Ctrl-C before rclpy's handler ran
+        return real_mint_frame(*a, **k)
+
+    kirra_release_publisher.mint_frame = interrupting_mint
+    try:
+        rc = kirra_release_publisher.main()
+    except BaseException as e:  # noqa: BLE001
+        failures.append(f"(2) publisher KeyboardInterrupt path raised: {e!r}")
+        rc = -1
+    finally:
+        kirra_release_publisher.mint_frame = real_mint_frame
+    check(rc == 0, f"(2) publisher must exit 0 on Ctrl-C, got {rc}")
+    check(ctx.shutdown_calls == 1,
+          f"(2) context still up → shutdown must run exactly once, got {ctx.shutdown_calls}")
+    print("(2) publisher/Ctrl-C (context up) → exit 0, shutdown exactly once")
+
+    # ------------------------------------------------------------------
+    # 3. Motor consumer: spin raises ExternalShutdownException after the
+    #    signal handler downed the context (the Humble behavior). Must exit
+    #    cleanly, write the (0,0,0) safe stop, and not double-shutdown.
+    # ------------------------------------------------------------------
+    vk = os.popen(
+        f"{mint} --seed {'2a' * 32} pubkey"
+    ).read().strip()
+    os.environ.update({
+        "KIRRA_GOVERNOR_VK_HEX": vk,
+        "KIRRA_FRESHNESS_WINDOW_MS": "200",
+        "KIRRA_CONTROL_PERIOD_MS": "100",
+        "KIRRA_MISSED_PERIODS": "3",
+        "KIRRA_STOP_DECEL_MPS2": "0.5",
+        "KIRRA_DEMO_VX_MAX": "0.15",
+        "KIRRA_DEMO_VZ_MAX": "0.4",
+        "KIRRA_MOTOR_PORT": "/dev/stub-serial",
+    })
+    ctx.spin_downs_context = True  # our handler already shut it down...
+    ctx.spin_raises = ExternalShutdownException()  # ...and spin surfaces it
+    try:
+        rc = kirra_motor_consumer.main()
+    except BaseException as e:  # noqa: BLE001 — the pre-fix behavior tracebacked here
+        failures.append(f"(3) consumer external-shutdown path raised: {e!r}")
+        rc = -1
+    check(rc == 0, f"(3) consumer must exit 0 on external shutdown, got {rc}")
+    bot = sys.modules["Rosmaster_Lib"].Rosmaster.last
+    check(bot is not None and bot.motions and bot.motions[-1] == (0.0, 0.0, 0.0),
+          "(3) the shutdown path must still command the (0,0,0) safe stop")
+    check(ctx.shutdown_calls == 0,
+          "(3) context already down → the guarded finally must not re-shutdown")
+    print("(3) consumer/ExternalShutdown → exit 0, safe stop written, no double shutdown")
+
+    # ------------------------------------------------------------------
+    # 4. Motor consumer, spin returns normally (context up): teardown must
+    #    still safe-stop AND shut down exactly once.
+    # ------------------------------------------------------------------
+    ctx.spin_downs_context = False
+    ctx.spin_raises = None
+    try:
+        rc = kirra_motor_consumer.main()
+    except BaseException as e:  # noqa: BLE001
+        failures.append(f"(4) consumer normal-exit path raised: {e!r}")
+        rc = -1
+    check(rc == 0, f"(4) consumer must exit 0 on normal spin exit, got {rc}")
+    bot = sys.modules["Rosmaster_Lib"].Rosmaster.last
+    check(bot is not None and bot.motions and bot.motions[-1] == (0.0, 0.0, 0.0),
+          "(4) normal exit still commands the safe stop")
+    check(ctx.shutdown_calls == 1,
+          f"(4) context up → shutdown exactly once, got {ctx.shutdown_calls}")
+    print("(4) consumer/normal exit → exit 0, safe stop written, shutdown exactly once")
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"FAIL {f}")
+        print(f"\nteardown smoke test FAILED ({len(failures)} mismatch(es))")
+        return 1
+    print("teardown smoke test: OK — shutdown is exactly-once on every exit path, "
+          "behavior (frames / safe stop) unchanged.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Do not merge without human review.** Robot stays stationary for everything here; the motor consumer's safety/verify logic and the verdict core (`ed00f4da…`) are untouched.

## Part 1 — publisher double-shutdown, fixed and regression-guarded

**Root cause** (`robot/kirra_release_publisher.py:86,106-108` pre-fix): `rclpy.init()` installs rclpy's **own** SIGINT/SIGTERM handlers. On Ctrl-C or the elevated script's `timeout` SIGTERM, rclpy's handler shuts the context down first; the `while rclpy.ok()` loop then exits normally and the unconditional `finally: rclpy.shutdown()` was a guaranteed **second** call → `RCLError: rcl_shutdown already called`, after the publish window — exactly the hardware observation (frames all sent, result valid, traceback every phase).

**Fix** — teardown only, publish content/timing untouched: `node.destroy_node()` then `if rclpy.ok(): rclpy.shutdown()` (exactly-once on every exit path).

**Same-pattern sweep:**
- `kirra_motor_consumer.py` — **had the sibling shape**: its custom signal handler called `shutdown()` unguarded (a second signal would double-call), and `rclpy.spin`'s `ExternalShutdownException` (raised once the handler downs the context) was uncaught → traceback on every Ctrl-C. Guarded both, caught the exception, added a guarded shutdown on the normal-exit path. **safe_stop ordering unchanged** — wheels stop *before* teardown, on every path.
- `first_run_elevated.sh` — pure bash, no rclpy, **no pattern**.

**Verification (runs here + in CI, no ROS):** `robot/teardown_smoke_test.py` — a stub-rclpy harness whose `shutdown()` raises on a second call exactly like real rcl, driving the **real `main()`** of both scripts through four paths:

```
(1) publisher/SIGTERM → exit 0, 3 frames, no double shutdown
(2) publisher/Ctrl-C (context up) → exit 0, shutdown exactly once
(3) consumer/ExternalShutdown → exit 0, safe stop written, no double shutdown
(4) consumer/normal exit → exit 0, safe stop written, shutdown exactly once
```

Behavior-unchanged is asserted, not assumed: valid frames still publish (128-byte signed), the `(0,0,0)` safe stop still lands. **Negative control:** reverting the guard turns the harness red with the exact hardware error (`rcl_shutdown already called`). Wired into the CI smoke-test step. On-robot confirmation (clean exit during a real publish window) is the operator's one-liner re-run of the publisher.

## Part 2 — lidar bringup step (perception only)

Documented in `docs/hardware/ROSMASTER_X3_BRINGUP.md` §6:

- **Launch file: `sllidar_launch.py`** — the 4ROS is an A-class RPLIDAR (`RPLIDAR_TYPE=4ROS`, SLAMTEC driver), and the generic launch *is* the A-series profile: serial, **115200 baud**, `frame_id:=laser`. The model-specific alternates are all faster-baud units (a2m12/a3/s1 = 256000, s2 = 1M, c1 = 460800), so they're the fallback ladder only if 115200 shows the wrong-baud symptom.
- **Exact command:** `ros2 launch sllidar_ros2 sllidar_launch.py serial_port:=/dev/rplidar serial_baudrate:=115200 frame_id:=laser`.
- **Two-symlink disambiguation:** `/dev/rplidar` and `/dev/ydlidar` both → `ttyUSB0`; `RPLIDAR_TYPE=4ROS` settles the driver as `sllidar_ros2` — the doc adds a pre-launch check (`ros2 node list` shows no ydlidar node; `fuser` shows nothing else on the port).
- **Stationary `/scan` acceptance:** steady `ros2 topic hz` (~5.5–10 Hz for A-series), mostly-finite room-plausible ranges (≈0.15–12 m indoors, not all 0/inf), sane angle/range bounds — plus a note to log the observed rate as the future `KIRRA_SUBSCRIPTION_STALENESS_MS` input.
- **Honesty note:** the observed rate/ranges can only be read on the robot; this PR provides the command + acceptance criteria, not a fabricated observation.

🔴 **Not wired into the motor path.** `/scan` bringup only; live-loop integration (with its own elevated re-test) is the next milestone. The motor consumer's gate/liveness/safety logic has zero changes beyond the teardown guard.

## Explicitly not here

No floor/untethered driving, no `/scan`→Taj→Occy→Kirra wiring, no motor motion, no verdict-core or verify-logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_