### PR TITLE
Live-loop wiring: /scan QoS fix, ADR-0033 release relay, required scan-staleness budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1067,6 +1067,13 @@ jobs:
           # rendered config carries names + mapping values, never a computed
           # safety parameter). See installer/ + docs/hardware/R2_GOLDEN_BUILD.md.
           python3 installer/test_installer.py
+          # kirra_safety pure-decision suites (no ROS needed — the nodes'
+          # fail-closed cores are deliberately rclpy-free): enforcement
+          # decision, the A3 wheelbase cross-check, the ADR-0033 release-frame
+          # carriage (strict 32/96 parse, never slice/pad), perception cap,
+          # and the doer geometry + staleness-budget validation.
+          python3 -m pip install --quiet pytest
+          python3 -m pytest ros2_ws/src/kirra_safety/test/ -q
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Clippy

--- a/docs/hardware/ROSMASTER_X3_BRINGUP.md
+++ b/docs/hardware/ROSMASTER_X3_BRINGUP.md
@@ -266,6 +266,39 @@ exceed one real scan period with margin).
 
 ---
 
+## 6b. The live loop — lidar → Taj → Occy → interceptor → signed release → consumer
+
+With the consumer (§1–5) and lidar (§6) proven separately, three wiring fixes
+close the perception-to-wheels chain:
+
+1. **`/scan` ingress QoS** — the TG30 driver publishes BEST_EFFORT; the three
+   kirra_safety subscribers (`occy_doer`, `perception_governor`,
+   `sensor_monitor`) previously used the default RELIABLE profile, which
+   silently matches **zero messages** (no error — just an eternally stale
+   scan, a dead cap topic, and a false lidar fault). All three now subscribe
+   BestEffort + KeepLast(1), the house sensor-ingress discipline
+   (`kirra-ros2-adapter::ingress_sensor_qos`).
+2. **The release relay** — the verifier's actuator 200 carries the ADR-0033
+   `release` object (signed payload+token), but nothing republished it for
+   the consumer. The `cmd_vel_interceptor` now relays it as the 128-byte
+   `payload(32)‖token(96)` frame on `release_topic` (default
+   `/kirra/release`) — strict pure-carriage (`release_frame`): a malformed
+   release publishes **nothing** and the consumer starves into its
+   decel-to-zero. Relay happens ONLY on a Forward decision; a wheelbase
+   mismatch or contract-violating 200 relays nothing.
+3. **`scan_stale_s` is now REQUIRED** on `occy_doer` (0.0 unset-sentinel →
+   refuse to start), replacing the silent 0.5 s default: the staleness budget
+   is a safety number and is operator-set per deployment
+   (`ros2_ws/src/kirra_safety/config/kirra_params.yaml` carries 0.25 s = 2.5
+   scan periods of the TG30 at ~10 Hz).
+
+Acceptance: `robot/live_loop_elevated.sh` — four phases, WHEELS ELEVATED:
+(a) nominal governed motion through the full chain, (b) obstacle →
+**perception-driven refusal** (Taj cap collapses → stop, then recovery),
+(c) dead lidar → hold, (d) dead verifier → consumer liveness decel-to-zero.
+
+---
+
 ## 7. Explicitly NOT in this bringup
 
 - **Speech / mic / TTS** — no audio hardware yet; voice is the last layer, on top

--- a/robot/live_loop_elevated.sh
+++ b/robot/live_loop_elevated.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# live_loop_elevated.sh — the LIVE-LOOP acceptance test: lidar → Taj → Occy →
+# interceptor → verifier → signed release → verifying motor consumer → wheels.
+#
+# 🔴🔴🔴 RUN THIS WITH THE ROBOT ELEVATED — WHEELS OFF THE GROUND. 🔴🔴🔴
+#
+# WHY ELEVATED: this is the first time the FULL perception-driven chain moves
+# real motors (first_run_elevated.sh only proved the consumer against a
+# hand-driven publisher). A wiring bug anywhere in the chain could spin the
+# wheels unexpectedly. Elevated, that is a spinning wheel in the air.
+#
+# The chain under test (every hop live):
+#   /scan (lidar, BEST_EFFORT) ──> perception_governor ──> /kirra/perception_speed_cap
+#                              └─> occy_doer (+Taj corridor +Occy plan) ──> /cmd_vel_raw
+#   /cmd_vel_raw ──> cmd_vel_interceptor [Taj cap → KIRRA verifier → mint]
+#                       └──> /kirra/release (payload‖token, 128-byte signed frames)
+#   /kirra/release ──> kirra_motor_consumer [Rust FFI verify] ──> /dev/myserial
+#
+# The four phases:
+#   (a) NOMINAL           clear corridor + goal ahead → wheels spin (governed)
+#   (b) PERCEPTION REFUSAL obstacle in front of lidar → Taj caps → STOP
+#                          — the perception-driven-refusal proof
+#   (c) STALE PERCEPTION  lidar driver killed → doer holds + cap stale → STILL
+#   (d) VERIFIER DEATH    verifier killed → no releases → consumer decels → STOP
+#
+# This is a GUIDED script: you are the acceptance sensor. Answer honestly; a
+# "no" fails the run.
+#
+# Prereqs (each in its own terminal, ROS 2 sourced, ROS_DOMAIN_ID consistent):
+#   1. verifier: KIRRA_GOVERNOR_SIGNING_KEY_SOURCE configured (dev key needs
+#      KIRRA_GOVERNOR_SIGNING_KEY_ALLOW_DEV=1) + KIRRA_VEHICLE_CLASS set —
+#      minting MUST be on or phase (a) has no frames to relay.
+#   2. sidecars + nodes: ros2 launch kirra_safety kirra_with_robot.launch.py \
+#        use_perception_cap:=true use_occy_doer:=true kirra_token:=$KIRRA_ADMIN_TOKEN
+#      (interceptor wheelbase_m MUST equal the active class contract's — a
+#      mismatch latches every command to stop, by design.)
+#   3. lidar driver publishing /scan (e.g. ydlidar_ros2_driver, TG30).
+#   4. the verifying consumer: python3 robot/kirra_motor_consumer.py with all
+#      KIRRA_* config exported, KIRRA_RELEASE_TOPIC=/kirra/release, and
+#      KIRRA_GOVERNOR_VK_HEX pinned to the verifier's key.
+#   5. NO vendor /cmd_vel motor node running (the consumer owns /dev/myserial).
+set -euo pipefail
+
+confirm() {  # confirm "question" -> exits non-zero on anything but y/Y
+  read -r -p "$1 [y/N] " ans
+  case "$ans" in
+    y|Y) return 0 ;;
+    *) echo "✗ operator reported failure — LIVE-LOOP TEST FAILED"; exit 1 ;;
+  esac
+}
+
+echo "=================================================================="
+echo "  KIRRA LIVE-LOOP TEST — 🔴 WHEELS MUST BE OFF THE GROUND 🔴"
+echo "=================================================================="
+read -r -p "Is the robot ELEVATED with all wheels free to spin? [y/N] " ans
+[ "$ans" = "y" ] || [ "$ans" = "Y" ] || { echo "Elevate the robot first. Aborting."; exit 1; }
+
+echo
+echo "Pre-flight (watch these in spare terminals for the proofs below):"
+echo "  ros2 topic echo /kirra/enforcement_action     # interceptor verdicts"
+echo "  ros2 topic echo /kirra/perception_health      # Taj corridor health"
+echo "  ros2 topic hz   /kirra/release                # signed-frame flow"
+if command -v ros2 >/dev/null 2>&1; then
+  echo "  active nodes:"; ros2 node list 2>/dev/null | sed 's/^/    /' || true
+fi
+confirm "Are the verifier (minting ON), launch stack, lidar, and consumer all up?"
+confirm "Is every vendor /cmd_vel motor node ABSENT (consumer is the sole /dev/myserial writer)?"
+
+# ---- Phase (a): nominal — perception-driven governed motion -----------------
+echo
+echo "── Phase (a): NOMINAL — clear corridor, goal ahead ──"
+echo "Clear ~2 m in front of the lidar, then send a goal ~1.5 m ahead, e.g.:"
+echo "  ros2 topic pub -1 /goal_pose geometry_msgs/msg/PoseStamped \\"
+echo "    '{header: {frame_id: odom}, pose: {position: {x: 1.5}, orientation: {w: 1.0}}}'"
+echo "Expected: interceptor logs 'release relay ACTIVE', /kirra/release shows"
+echo "frames flowing, and the wheels SPIN under governed (clamped) commands."
+confirm "Did the wheels SPIN, with 'release relay ACTIVE' in the interceptor log?"
+
+# ---- Phase (b): perception-driven refusal (the load-bearing proof) ----------
+echo
+echo "── Phase (b): PERCEPTION-DRIVEN REFUSAL — obstacle in the corridor ──"
+echo "With the goal still active, place a large obstacle (box/board) ~0.5 m in"
+echo "front of the lidar. Expected: Taj's clear-distance collapses, the cap"
+echo "drops (watch /kirra/perception_health), the enforcement log shows the"
+echo "capped/stopped verdict, and the wheels STOP while the goal is still set."
+confirm "Did the wheels STOP with the obstacle in place (goal still active)?"
+confirm "Does /kirra/perception_health (or the interceptor log) show the collapsed clear-distance/cap as the cause?"
+echo "Remove the obstacle. Expected: motion RESUMES (governed) within ~1 s."
+confirm "Did motion resume after removing the obstacle?"
+
+# ---- Phase (c): stale perception → hold --------------------------------------
+echo
+echo "── Phase (c): STALE PERCEPTION — kill the lidar driver ──"
+echo "Stop the lidar driver process (Ctrl-C its terminal). Expected: the doer"
+echo "holds ('stale-scan'), the perception cap goes stale → the interceptor"
+echo "fails closed, and the wheels are STILL. Nothing may keep driving on the"
+echo "last scan."
+confirm "Did the wheels stop/stay STILL after the lidar died?"
+echo "Restart the lidar driver before the next phase."
+confirm "Is the lidar back up (/scan publishing) and motion restored?"
+
+# ---- Phase (d): verifier death → consumer starves → decel-to-zero -----------
+echo
+echo "── Phase (d): VERIFIER DEATH — kill the verifier process ──"
+echo "Kill the verifier (Ctrl-C its terminal). The doer keeps proposing, but no"
+echo "releases are minted → the consumer's liveness deadline starves → SS-002"
+echo "decel-to-zero. Expected: wheels STOP within the configured liveness"
+echo "window, and the interceptor logs CONNECTION_ERROR:STOP (defense in depth:"
+echo "both layers fail closed independently)."
+confirm "Did the wheels STOP after the verifier was killed?"
+
+echo
+echo "=================================================================="
+echo "  ✅ LIVE-LOOP TEST PASSED (elevated). All four phases confirmed:"
+echo "     (a) nominal governed motion, (b) obstacle → perception-driven"
+echo "     refusal + recovery, (c) dead lidar → hold, (d) dead verifier →"
+echo "     consumer decel-to-zero."
+echo "  Save the terminal logs (interceptor + consumer) as the acceptance"
+echo "  record. Only NOW may floor testing be considered."
+echo "=================================================================="

--- a/ros2_ws/src/kirra_safety/README.md
+++ b/ros2_ws/src/kirra_safety/README.md
@@ -4,9 +4,9 @@ ROS2 safety interlock package for the Kirra runtime legitimacy engine.
 
 Provides the nodes that enforce kinematic contracts, derive a perception speed cap, drive the robot to a goal, monitor sensor health, and gate motion commands based on fleet posture:
 
-- **cmd_vel_interceptor** — intercepts `/cmd_vel`, enforces via Kirra, publishes to `/cmd_vel_safe`
+- **cmd_vel_interceptor** — intercepts `/cmd_vel`, enforces via Kirra, publishes to `/cmd_vel_safe`; when the verifier mints ADR-0033 release tokens, it also relays each signed frame (`payload(32)‖token(96)`, 128 bytes) on `/kirra/release` for the verifying motor consumer (`robot/kirra_motor_consumer.py`) — pure carriage, strict parse, malformed release → nothing published (the consumer decels to zero)
 - **perception_governor** — turns `/scan` into Taj's corridor and an assured-clear-distance (ACD) speed cap on `/kirra/perception_speed_cap` (see below)
-- **occy_doer** — the DOER: drives the robot to a `/goal_pose` using Occy + Taj + KIRRA, publishing proposals to `/cmd_vel_raw` (see [`docs/testing/OCCY_DOER_BRIDGE.md`](../../../../docs/testing/OCCY_DOER_BRIDGE.md))
+- **occy_doer** — the DOER: drives the robot to a `/goal_pose` using Occy + Taj + KIRRA, publishing proposals to `/cmd_vel_raw` (see [`docs/testing/OCCY_DOER_BRIDGE.md`](../../../../docs/testing/OCCY_DOER_BRIDGE.md)). `scan_stale_s` is REQUIRED (no default — a safety number; `config/kirra_params.yaml` carries the deployment value): perception older than the budget holds the robot
 - **sensor_monitor** — reports LiDAR, IMU, camera, and odometry health to Kirra
 - **posture_subscriber** — bridges the Kirra SSE posture stream to ROS2 topics and triggers emergency stops on `LockedOut` transitions
 

--- a/ros2_ws/src/kirra_safety/config/kirra_params.yaml
+++ b/ros2_ws/src/kirra_safety/config/kirra_params.yaml
@@ -14,6 +14,16 @@ cmd_vel_interceptor:
     use_perception_cap: false    # opt-in: apply Taj's assured-clear-distance cap before the governor
     perception_cap_topic: "/kirra/perception_speed_cap"
     perception_cap_stale_ms: 300 # cap older than this is a perception fault -> fail-closed stop
+    release_topic: "/kirra/release"  # ADR-0033 relay: verifier-minted signed frames -> motor consumer
+
+occy_doer:
+  ros__parameters:
+    # REQUIRED (the node refuses to start without it): newest-scan staleness
+    # budget in seconds -- perception older than this and the doer HOLDS
+    # instead of proposing motion. 0.25 s = 2.5 scan periods of the
+    # bench-verified TG30 at ~10 Hz (HARDWARE_FINDINGS_R2X3.md deployment);
+    # a different lidar rate needs a deployment-review update here.
+    scan_stale_s: 0.25
 
 perception_governor:
   ros__parameters:

--- a/ros2_ws/src/kirra_safety/kirra_safety/cmd_vel_interceptor.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/cmd_vel_interceptor.py
@@ -133,6 +133,7 @@ class CmdVelInterceptor(Node):
                        history=HistoryPolicy.KEEP_LAST, depth=1),
         )
         self._release_relay_announced = False
+        self._release_malformed_announced = False
 
         # Subscriber
         self._sub = self.create_subscription(
@@ -375,11 +376,18 @@ class CmdVelInterceptor(Node):
             return  # no signer provisioned upstream — nothing to relay
         frame = release_frame(release)
         if frame is None:
-            self.get_logger().warn(
-                'release object present but malformed — no frame relayed '
-                '(consumer starves into decel-to-zero, fail-closed)'
-            )
+            # Latched (review #905): commands arrive at rate, so an unfixed
+            # malformed release would otherwise warn every cycle. Re-armed by
+            # the next VALID frame, so a fresh malformed episode logs again.
+            if not self._release_malformed_announced:
+                self._release_malformed_announced = True
+                self.get_logger().warn(
+                    'release object present but malformed — no frame relayed '
+                    '(consumer starves into decel-to-zero, fail-closed); '
+                    'latched until a valid release flows'
+                )
             return
+        self._release_malformed_announced = False
         out = UInt8MultiArray()
         out.data = list(frame)
         self._pub_release.publish(out)

--- a/ros2_ws/src/kirra_safety/kirra_safety/cmd_vel_interceptor.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/cmd_vel_interceptor.py
@@ -23,10 +23,10 @@ import threading
 import rclpy
 from rclpy.node import Node
 from geometry_msgs.msg import Twist
-from std_msgs.msg import String, Float64
+from std_msgs.msg import String, Float64, UInt8MultiArray
 
 from kirra_safety.enforcement_decision import (
-    decide_enforcement, Forward, wheelbase_consistent,
+    decide_enforcement, Forward, wheelbase_consistent, release_frame,
 )
 from kirra_safety.perception_cap import apply_perception_cap, DISABLED
 
@@ -66,6 +66,12 @@ class CmdVelInterceptor(Node):
         self.declare_parameter('use_perception_cap', False)
         self.declare_parameter('perception_cap_topic', '/kirra/perception_speed_cap')
         self.declare_parameter('perception_cap_stale_ms', 300)
+        # ADR-0033 live-loop relay: when the verifier's 200 carries a `release`
+        # object (signer provisioned), its payload_hex||token_hex bytes are
+        # republished as one 128-byte frame on this topic for the verifying
+        # motor consumer (robot/kirra_motor_consumer.py). Pure carriage — the
+        # consumer's Ed25519 verify over exactly these bytes is the trust path.
+        self.declare_parameter('release_topic', '/kirra/release')
 
         self._kirra_url = self.get_parameter('kirra_url').value
         self._kirra_token = self.get_parameter('kirra_token').value
@@ -113,6 +119,20 @@ class CmdVelInterceptor(Node):
         # Publishers
         self._pub_safe = self.create_publisher(Twist, output_topic, 10)
         self._pub_action = self.create_publisher(String, enforcement_topic, 10)
+        # The governed-frame relay to the verifying motor consumer. Reliable +
+        # depth 1 (the output-side freshness discipline: a gated command must
+        # not be silently dropped, but an OLDER queued frame must never reach
+        # the consumer after a newer verdict — mirrors the ros2-adapter's
+        # actuator_output_qos, node.rs). Logged-once when the first frame
+        # flows / when a release is malformed.
+        from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+        self._pub_release = self.create_publisher(
+            UInt8MultiArray,
+            self.get_parameter('release_topic').value,
+            QoSProfile(reliability=ReliabilityPolicy.RELIABLE,
+                       history=HistoryPolicy.KEEP_LAST, depth=1),
+        )
+        self._release_relay_announced = False
 
         # Subscriber
         self._sub = self.create_subscription(
@@ -279,6 +299,14 @@ class CmdVelInterceptor(Node):
                     self._pub_safe.publish(safe_twist)
                     self._publish_action(f'{decision.action}:v={decision.enforced_v:.2f}{cap_suffix}')
 
+                    # ADR-0033 live-loop relay: republish the verifier-minted
+                    # signed frame (payload||token, 128 bytes) for the verifying
+                    # motor consumer. ONLY on a Forward decision — a wheelbase
+                    # mismatch or contract-violating 200 returned above and
+                    # relays nothing. No/malformed release → nothing published;
+                    # the consumer starves into its decel-to-zero (fail-closed).
+                    self._relay_release(release)
+
                     with self._lock:
                         self._current_velocity_mps = decision.enforced_v
                         self._current_steering_deg = decision.enforced_s
@@ -336,6 +364,32 @@ class CmdVelInterceptor(Node):
         else:
             self._publish_stop('CONNECTION_ERROR')
             self._publish_action('CONNECTION_ERROR:STOP')
+
+    def _relay_release(self, release):
+        """Republish the gateway 200's release object as the 128-byte wire
+        frame the verifying motor consumer parses (`split_frame`). Strictness
+        lives in the pure `release_frame`; a None (absent OR malformed release)
+        publishes nothing — starving the consumer into decel is the fail-closed
+        outcome, never a guessed frame."""
+        if release is None:
+            return  # no signer provisioned upstream — nothing to relay
+        frame = release_frame(release)
+        if frame is None:
+            self.get_logger().warn(
+                'release object present but malformed — no frame relayed '
+                '(consumer starves into decel-to-zero, fail-closed)'
+            )
+            return
+        out = UInt8MultiArray()
+        out.data = list(frame)
+        self._pub_release.publish(out)
+        if not self._release_relay_announced:
+            self._release_relay_announced = True
+            self.get_logger().info(
+                f'release relay ACTIVE: signed frames flowing to '
+                f'{self.get_parameter("release_topic").value} '
+                f'(key_id={release.get("key_id", "?")!r})'
+            )
 
     def _publish_stop(self, reason: str):
         self._pub_safe.publish(ZERO_TWIST)

--- a/ros2_ws/src/kirra_safety/kirra_safety/doer_core.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/doer_core.py
@@ -36,6 +36,21 @@ def goal_reached(goal_base_x, goal_base_y, tolerance_m):
     return math.hypot(goal_base_x, goal_base_y) <= tolerance_m
 
 
+def staleness_budget_valid(value_s):
+    """True only for a finite number > 0 — a usable scan-staleness budget.
+
+    The staleness budget is a SAFETY number (how old perception may be and
+    still produce motion), so it follows the no-default convention: the node
+    declares a 0.0 unset-sentinel and refuses to start unless the operator set
+    a real value. bool is rejected explicitly (an int subclass: `true` in a
+    params YAML would otherwise pass as a 1-second budget — the #904
+    wheelbase lesson).
+    """
+    if isinstance(value_s, bool) or not isinstance(value_s, (int, float)):
+        return False
+    return math.isfinite(value_s) and value_s > 0.0
+
+
 def extend_corridor_back(left, right, back_m):
     """Prepend a straight back-extension to each corridor polyline.
 

--- a/ros2_ws/src/kirra_safety/kirra_safety/enforcement_decision.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/enforcement_decision.py
@@ -102,3 +102,46 @@ def wheelbase_consistent(param_m, reported_m):
     if not _is_finite_number(param_m) or not _is_finite_number(reported_m):
         return False
     return abs(float(param_m) - float(reported_m)) <= WHEELBASE_TOLERANCE_M
+
+
+# ---------------------------------------------------------------------------
+# Live-loop relay — gateway `release` object -> /kirra/release wire frame
+# ---------------------------------------------------------------------------
+
+# ADR-0033 wire shape (mirrors robot/kirra_ffi.py::split_frame, the consumer's
+# strict parse): payload(32) || token(96) = one 128-byte governed frame.
+RELEASE_PAYLOAD_LEN = 32
+RELEASE_TOKEN_LEN = 96
+
+
+def release_frame(release):
+    """Build the 128-byte `payload(32) || token(96)` wire frame from a gateway
+    200's `release` object, or return None when no valid frame exists.
+
+    STRICT: `release` must be a dict whose `payload_hex` / `token_hex` are hex
+    strings decoding to EXACTLY 32 and 96 bytes. Anything else -> None, and the
+    relay publishes NOTHING — the verifying motor consumer then starves into
+    its decel-to-zero, the same fail-closed outcome as a verifier with no
+    signer provisioned. Never publish a "best effort" frame: the consumer's
+    strict parser would discard a malformed one anyway, but a sliced/padded
+    frame must not even be offered (review #901's oversized-token lesson).
+
+    This is pure CARRIAGE: the bytes are relayed exactly as the verifier
+    hex-encoded them. The trust path is the consumer's Ed25519 verify over
+    exactly these bytes — this function never re-encodes floats or
+    reinterprets the payload.
+    """
+    if not isinstance(release, dict):
+        return None
+    payload_hex = release.get("payload_hex")
+    token_hex = release.get("token_hex")
+    if not isinstance(payload_hex, str) or not isinstance(token_hex, str):
+        return None
+    try:
+        payload = bytes.fromhex(payload_hex)
+        token = bytes.fromhex(token_hex)
+    except ValueError:
+        return None
+    if len(payload) != RELEASE_PAYLOAD_LEN or len(token) != RELEASE_TOKEN_LEN:
+        return None
+    return payload + token

--- a/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
@@ -31,12 +31,14 @@ import time
 
 import rclpy
 from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
 from geometry_msgs.msg import Twist, PoseStamped
 from nav_msgs.msg import Odometry
 from sensor_msgs.msg import LaserScan
 
 from kirra_safety.doer_core import (
     yaw_from_quaternion, goal_to_base, goal_reached, decide, extend_corridor_back,
+    staleness_budget_valid,
 )
 
 try:
@@ -46,6 +48,19 @@ except ImportError:
     REQUESTS_AVAILABLE = False
 
 ZERO = Twist()
+
+# Lidar-ingress QoS (hardware finding: the TG30 driver publishes /scan
+# BEST_EFFORT; a default RELIABLE subscription silently matches ZERO messages —
+# no error, just an eternally stale scan). BestEffort + KeepLast(1) is the
+# house sensor-ingress discipline (kirra-ros2-adapter ingress_sensor_qos,
+# node.rs: freshness over buffering — no stale backlog after a stall), and a
+# BestEffort subscription is compatible with BOTH BestEffort and Reliable
+# publishers, so this never regresses a Reliable lidar.
+SCAN_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+)
 
 # Mick intents this bridge grounds. Positional intents become the goal;
 # `hold` clears it. Anything else is ignored (logged once) — the doer stays
@@ -77,7 +92,14 @@ class OccyDoer(Node):
         self.declare_parameter('lookahead_m', 0.8)
         self.declare_parameter('goal_tolerance_m', 0.25)
         self.declare_parameter('forward_extent_m', 8.0)
-        self.declare_parameter('scan_stale_s', 0.5)
+        # REQUIRED, no default — 0.0 is the unset sentinel. How old the newest
+        # scan may be before this node stops proposing motion (holds). A
+        # safety number: it bounds how blind the doer can be while still
+        # moving, so it is operator-set per deployment (lidar rate dependent —
+        # e.g. ~0.25 s for a 10 Hz TG30), never silently defaulted. Mirrors
+        # the ros2-adapter's KIRRA_SUBSCRIPTION_STALENESS_MS discipline and
+        # the interceptor's required wheelbase_m.
+        self.declare_parameter('scan_stale_s', 0.0)
         self.declare_parameter('http_timeout_ms', 60)
         # The robot's footprint/kinematics for the CHECKER. A small differential robot MUST
         # pass these, or the planner's default urban-car (4.8 m) footprint can't fit a
@@ -107,6 +129,16 @@ class OccyDoer(Node):
         self._goal_tol = self.get_parameter('goal_tolerance_m').value
         self._extent = self.get_parameter('forward_extent_m').value
         self._scan_stale_s = self.get_parameter('scan_stale_s').value
+        if not staleness_budget_valid(self._scan_stale_s):
+            # Fail-closed: an unset/invalid staleness budget would either let
+            # the doer plan on arbitrarily old perception or come from a typo
+            # the operator believes is in effect. Refuse to start.
+            self.get_logger().fatal(
+                'scan_stale_s parameter is REQUIRED (finite, > 0 seconds) — '
+                f'refusing to start (got {self._scan_stale_s!r}). Set it to the '
+                'deployment lidar staleness budget (e.g. 0.25 for a 10 Hz scan).'
+            )
+            raise SystemExit(2)
         self._timeout_s = self.get_parameter('http_timeout_ms').value / 1000.0
         self._back_m = self.get_parameter('corridor_back_m').value
         self._vehicle = {
@@ -128,7 +160,7 @@ class OccyDoer(Node):
         self._pub = self.create_publisher(Twist, self.get_parameter('cmd_topic').value, 10)
         self.create_subscription(Odometry, self.get_parameter('odom_topic').value, self._on_odom, 20)
         self.create_subscription(PoseStamped, self.get_parameter('goal_topic').value, self._on_goal, 10)
-        self.create_subscription(LaserScan, self.get_parameter('scan_topic').value, self._on_scan, 10)
+        self.create_subscription(LaserScan, self.get_parameter('scan_topic').value, self._on_scan, SCAN_QOS)
         self.create_timer(1.0 / self.get_parameter('plan_hz').value, self._tick)
 
         if not REQUESTS_AVAILABLE:

--- a/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
@@ -24,8 +24,21 @@ robot rather than freezing the last cap.
 
 import rclpy
 from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
 from sensor_msgs.msg import LaserScan
 from std_msgs.msg import Float64, String
+
+# Lidar-ingress QoS (hardware finding: the TG30 driver publishes /scan
+# BEST_EFFORT; a default RELIABLE subscription silently matches ZERO messages —
+# the cap topic then goes stale and the interceptor fail-closes, but the cause
+# is invisible). BestEffort + KeepLast(1) mirrors the house sensor-ingress
+# discipline (kirra-ros2-adapter ingress_sensor_qos); depth 1 also stops a
+# post-stall backlog of stale scans from queueing Taj POSTs.
+SCAN_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+)
 
 try:
     import requests
@@ -61,7 +74,7 @@ class PerceptionGovernor(Node):
         scan_topic = self.get_parameter('scan_topic').value
         self._pub_cap = self.create_publisher(Float64, self.get_parameter('cap_topic').value, 10)
         self._pub_health = self.create_publisher(String, self.get_parameter('health_topic').value, 10)
-        self.create_subscription(LaserScan, scan_topic, self._on_scan, 10)
+        self.create_subscription(LaserScan, scan_topic, self._on_scan, SCAN_QOS)
 
         if not REQUESTS_AVAILABLE:
             self.get_logger().error(

--- a/ros2_ws/src/kirra_safety/kirra_safety/sensor_monitor.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/sensor_monitor.py
@@ -14,10 +14,23 @@ import json
 
 import rclpy
 from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
 from sensor_msgs.msg import LaserScan, Imu, Image
 from nav_msgs.msg import Odometry
 from diagnostic_msgs.msg import DiagnosticArray
 from std_msgs.msg import String
+
+# Lidar-ingress QoS (hardware finding: the TG30 driver publishes /scan
+# BEST_EFFORT; a default RELIABLE subscription silently matches ZERO messages —
+# this monitor would then report the lidar FAULTED while the driver is healthy,
+# degrading the fleet for a QoS mismatch). BestEffort subscriptions match both
+# BestEffort and Reliable publishers. Depth 1: this callback only counts
+# arrivals, a backlog adds nothing.
+SCAN_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+)
 
 try:
     import requests
@@ -83,7 +96,7 @@ class SensorMonitor(Node):
         }
 
         # Subscriptions
-        self.create_subscription(LaserScan, '/scan', self._on_scan, 10)
+        self.create_subscription(LaserScan, '/scan', self._on_scan, SCAN_QOS)
         self.create_subscription(Image, '/camera/depth/image_raw', self._on_depth, 10)
         self.create_subscription(Imu, '/imu/data', self._on_imu, 10)
         self.create_subscription(Odometry, '/odom', self._on_odom, 10)

--- a/ros2_ws/src/kirra_safety/test/test_doer_core.py
+++ b/ros2_ws/src/kirra_safety/test/test_doer_core.py
@@ -87,3 +87,33 @@ def test_decide_holds_on_refused_verdict():
             "trajectory": [{"x": 1.0, "y": 0.0, "v": 1.0}]}
     v, w, reason = decide(plan, 1.0, 1.2, 2.0)
     assert (v, w) == (0.0, 0.0) and reason.startswith("HOLD")
+
+
+# ---------------------------------------------------------------------------
+# scan_stale_s required-config validation (staleness_budget_valid)
+# ---------------------------------------------------------------------------
+
+from doer_core import staleness_budget_valid  # noqa: E402
+
+
+def test_staleness_budget_accepts_real_positive_seconds():
+    for good in (0.25, 0.5, 1, 2.0):
+        assert staleness_budget_valid(good), good
+
+
+def test_staleness_budget_rejects_unset_sentinel_and_nonpositive():
+    # 0.0 is the declared unset sentinel; negatives are config errors.
+    for bad in (0.0, 0, -0.25, -1):
+        assert not staleness_budget_valid(bad), bad
+
+
+def test_staleness_budget_rejects_nonfinite_and_nonnumeric():
+    for bad in (float("nan"), float("inf"), float("-inf"), None, "0.25", [0.25]):
+        assert not staleness_budget_valid(bad), bad
+
+
+def test_staleness_budget_rejects_bool():
+    # bool is an int subclass: `scan_stale_s: true` in a params YAML would
+    # otherwise pass as a 1-second budget (the #904 wheelbase lesson).
+    assert not staleness_budget_valid(True)
+    assert not staleness_budget_valid(False)

--- a/ros2_ws/src/kirra_safety/test/test_enforcement_decision.py
+++ b/ros2_ws/src/kirra_safety/test/test_enforcement_decision.py
@@ -152,3 +152,60 @@ def test_wheelbase_missing_or_nonfinite_reported_fails_closed():
 def test_wheelbase_bad_param_fails_closed():
     for bad in (None, float("nan"), "0.229"):
         assert not wheelbase_consistent(bad, 0.229), bad
+
+
+# ---------------------------------------------------------------------------
+# Live-loop relay — release_frame (release object -> 128-byte wire frame)
+# ---------------------------------------------------------------------------
+
+from enforcement_decision import (  # noqa: E402
+    release_frame, RELEASE_PAYLOAD_LEN, RELEASE_TOKEN_LEN,
+)
+
+PAYLOAD = bytes(range(RELEASE_PAYLOAD_LEN))            # 32 distinct bytes
+TOKEN = bytes(255 - (i % 256) for i in range(RELEASE_TOKEN_LEN))  # 96 bytes
+
+
+def _release(payload=PAYLOAD, token=TOKEN, **extra):
+    r = {"payload_hex": payload.hex(), "token_hex": token.hex()}
+    r.update(extra)
+    return r
+
+
+def test_release_frame_valid_is_exact_carriage():
+    frame = release_frame(_release())
+    assert frame == PAYLOAD + TOKEN            # byte-exact, payload first
+    assert len(frame) == 128                    # the consumer's strict length
+
+
+def test_release_frame_extra_keys_ignored():
+    # sequence/issued_at_ms/key_id/wheelbase_m ride alongside — carriage only
+    # cares about the two hex fields.
+    assert release_frame(_release(sequence=7, key_id="ab" * 32)) == PAYLOAD + TOKEN
+
+
+def test_release_frame_absent_or_non_dict_is_none():
+    for bad in (None, [], "release", 42, True):
+        assert release_frame(bad) is None, bad
+
+
+def test_release_frame_missing_or_non_string_hex_is_none():
+    assert release_frame({"payload_hex": PAYLOAD.hex()}) is None      # no token
+    assert release_frame({"token_hex": TOKEN.hex()}) is None          # no payload
+    assert release_frame(_release() | {"payload_hex": None}) is None
+    assert release_frame(_release() | {"token_hex": 123}) is None
+    assert release_frame(_release() | {"payload_hex": list(PAYLOAD)}) is None
+
+
+def test_release_frame_undecodable_hex_is_none():
+    assert release_frame(_release() | {"payload_hex": "zz" * 32}) is None
+    assert release_frame(_release() | {"token_hex": TOKEN.hex()[:-1]}) is None  # odd length
+
+
+def test_release_frame_wrong_lengths_are_none():
+    # The #901 lesson made structural: never slice/pad — off-by-one either
+    # side of both fields is refused, no frame offered at all.
+    for n in (0, RELEASE_PAYLOAD_LEN - 1, RELEASE_PAYLOAD_LEN + 1):
+        assert release_frame(_release(payload=bytes(n))) is None, n
+    for n in (0, RELEASE_TOKEN_LEN - 1, RELEASE_TOKEN_LEN + 1):
+        assert release_frame(_release(token=bytes(n))) is None, n


### PR DESCRIPTION
Closes the perception-to-wheels chain — the three planned live-loop fixes plus the elevated acceptance harness. Every hop now exists:

```
/scan (BEST_EFFORT) → perception_governor → /kirra/perception_speed_cap
                    → occy_doer (+Taj +Occy) → /cmd_vel_raw
/cmd_vel_raw → cmd_vel_interceptor [Taj cap → KIRRA verifier → mint]
                    → /kirra/release (payload(32)‖token(96), 128-byte signed frames)
/kirra/release → kirra_motor_consumer [Rust FFI Ed25519 verify] → /dev/myserial
```

## 1. `/scan` ingress QoS (hardware finding)

The TG30's driver publishes `/scan` **BEST_EFFORT**; the three `kirra_safety` subscribers (`occy_doer.py`, `perception_governor.py`, `sensor_monitor.py`) used the default RELIABLE profile, which silently matches **zero messages** — an eternally stale scan, a dead cap topic, and a false lidar fault, with no error anywhere. All three now subscribe BestEffort + KeepLast(1), the house sensor-ingress discipline (`kirra-ros2-adapter::ingress_sensor_qos`, node.rs — freshness over buffering). A BestEffort subscription matches both BestEffort and Reliable publishers, so no existing deployment regresses.

## 2. ADR-0033 release relay (the missing hop)

The verifier's actuator 200 has carried the signed `release` object since the mint landed, but nothing republished it for the verifying consumer. `cmd_vel_interceptor` now relays it as the 128-byte wire frame on `release_topic` (default `/kirra/release`):

- **Pure carriage**: the new `enforcement_decision.release_frame` decodes `payload_hex`/`token_hex` strictly (exactly 32 + 96 bytes, never slice/pad — the #901 oversized-token lesson made structural) and the node publishes the bytes untouched. The trust path stays the consumer's Ed25519 verify over exactly these bytes.
- **Fail-closed**: absent or malformed release → nothing published → the consumer starves into its SS-002 decel-to-zero, identical to a verifier with no signer. Relay happens ONLY on a `Forward` decision — a wheelbase mismatch or contract-violating 200 relays nothing.
- Relay QoS is Reliable + KeepLast(1) (the `actuator_output_qos` mirror: never drop a gated command silently, never queue a stale one).

## 3. `scan_stale_s` becomes REQUIRED config on `occy_doer`

The staleness budget bounds how blind the doer may be while still proposing motion — a safety number, so the silent `0.5` default is gone. The node declares a `0.0` unset-sentinel and refuses to start unless the operator set a real value (finite, > 0, bool rejected — the #904 wheelbase lesson). The deployment value lives in `kirra_params.yaml` as reviewed config: `0.25 s` = 2.5 scan periods of the bench-verified ~10 Hz TG30, with provenance comment.

## Acceptance + CI

- **`robot/live_loop_elevated.sh`** — four-phase, WHEELS-ELEVATED, guided: (a) nominal governed motion through the full chain, (b) obstacle → **perception-driven refusal** (Taj clear-distance collapses → stop, then recovery on removal), (c) dead lidar → hold, (d) dead verifier → consumer liveness decel-to-zero.
- **10 new pure tests** (49 total in the package): `release_frame` carriage/strictness (byte-exact, wrong-length/bad-hex/non-string → None) + `staleness_budget_valid` (sentinel/NaN/Inf/bool rejection). Pass from repo root and package dir.
- **CI gap closed**: the `kirra_safety` pure suites were never run in CI — now wired into the smoke step (`python3 -m pytest ros2_ws/src/kirra_safety/test/ -q`).
- Docs: bringup §6b (the live loop), package README.

Verdict core untouched (talisman `ed00f4da…` verified). No Rust changes. Human review before merge, as always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_