### PR TITLE
#798: per-target SBOMs, image SBOM+SLSA provenance, exact-identity verification, install.sh cosign dogfooding

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,14 +44,29 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # #798 F6 — the images previously shipped with a signature but NO
+          # SBOM and NO provenance. BuildKit attestations close both: an SBOM
+          # attestation per platform and max-detail SLSA provenance, attached
+          # to the image in the registry (inspect with
+          # `docker buildx imagetools inspect <image>@<digest>`).
+          sbom: true
+          provenance: mode=max
 
       # WS-0.6 — keyless cosign signature over the pushed image, BY DIGEST
       # (a tag is mutable; the digest is the artifact). The signature is
-      # stored in the registry next to the image and recorded in Rekor;
-      # verify with:
+      # stored in the registry next to the image and recorded in Rekor.
+      #
+      # #798 F7 — verify with an EXACT or ANCHORED identity, never `@.*`
+      # (which matched every build of this workflow, including any branch
+      # push). For a release image, pin the exact tag:
       #   cosign verify ghcr.io/<image>@<digest> \
-      #     --certificate-identity-regexp 'https://github.com/kirra-systems/kirra-runtime-sdk/\.github/workflows/docker\.yml@.*' \
+      #     --certificate-identity \
+      #       'https://github.com/kirra-systems/kirra-runtime-sdk/.github/workflows/docker.yml@refs/tags/vX.Y.Z' \
       #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      # For a main-branch image, the identity is
+      #   ...docker.yml@refs/heads/main
+      # If a regexp is unavoidable, ANCHOR it end-to-end:
+      #   --certificate-identity-regexp '^https://github\.com/kirra-systems/kirra-runtime-sdk/\.github/workflows/docker\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)[0-9]*)?$'
       - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign image (keyless, GitHub OIDC)
@@ -91,6 +106,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # #798 F6 — SBOM + max-detail SLSA provenance attestations, same as
+          # the verifier image above.
+          sbom: true
+          provenance: mode=max
 
       # WS-0.6 — same keyless by-digest signature as the verifier image.
       - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,11 +112,34 @@ jobs:
         # OIDC signing token — see the per-job permissions above.)
         run: cd dashboard && npm ci && npm run build
 
+      - name: Generate dashboard npm SBOM (CycloneDX)
+        # #798 F6 — the dashboard/dist bundle ships in EVERY tarball but had
+        # no SBOM. `npm sbom` (built into npm ≥9.5 — no extra unpinned tool)
+        # reads the tree `npm ci` just installed from the committed lockfile;
+        # --omit dev scopes it to what actually ships.
+        env:
+          VERSION: ${{ github.ref_name }}  # #775 F5 — tag as data
+        run: |
+          cd dashboard
+          npm sbom --sbom-format cyclonedx --omit dev \
+            > "../kirra-${VERSION}-dashboard-npm.cdx.json"
+          if [ ! -s "../kirra-${VERSION}-dashboard-npm.cdx.json" ]; then
+            echo "::error::npm sbom produced an empty dashboard SBOM"
+            exit 1
+          fi
+
       - name: Upload dashboard artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: kirra-dashboard-dist
           path: dashboard/dist/
+          retention-days: 1
+
+      - name: Upload dashboard SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: kirra-sbom-npm
+          path: kirra-*.cdx.json
           retention-days: 1
 
   build:
@@ -222,62 +245,53 @@ jobs:
               -cf - -C staging . | gzip -n > "${ARCHIVE_NAME}"
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> "${GITHUB_ENV}"
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: kirra-${{ matrix.target_name }}
-          path: kirra-*.tar.gz
-          retention-days: 1
-
-  # WS-0.6 — CycloneDX SBOM for the shipped binaries. Generated from the
-  # committed lockfile (--locked: the SBOM must describe what the build jobs
-  # actually built, never a re-resolve). One SBOM per release, named with
-  # the version so it travels with the artifacts.
-  sbom:
-    name: Generate SBOM (CycloneDX)
-    needs: preflight
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    env:
-      VERSION: ${{ github.ref_name }}  # #775 F5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-
+      # WS-0.6 / #798 F5 — CycloneDX SBOMs, generated INSIDE the build matrix
+      # with `--target` so each SBOM describes the dependency graph of the
+      # binary actually shipped for that triple. The previous standalone job
+      # resolved on the HOST (no --target): target-conditional dep arms
+      # (getrandom/libc/nix, per-arch crypto backends, gnu-vs-musl) made that
+      # an approximation — verified concretely: the x86_64-musl and
+      # aarch64-musl graphs differ (curve25519-dalek-derive is x86_64-only).
+      # Each SBOM records its triple as the `kirra:cargo:target` property;
+      # the release job asserts count == bins × targets and per-file triple.
       - name: Install cargo-cyclonedx
         # #775 F1/F10 — pin the tool version (was: unpinned; an upstream naming
         # or behaviour change would silently alter the release SBOM).
         run: cargo install cargo-cyclonedx --version 0.5.9 --locked
 
-      - name: Generate SBOM for the release binaries
+      - name: Generate per-target SBOMs (CycloneDX)
         run: |
-          # $VERSION from job env (#775 F5).
-          # `--describe binaries` emits one SBOM per workspace binary; the
-          # release ships exactly two (kirra_verifier_service and
-          # kirra_carla_client, both from the root crate — their SBOMs land
-          # in the repo root). Keep those two, version-prefixed so they are
-          # self-identifying next to the tarballs; the committed Cargo.lock
-          # is what cargo metadata resolves, so the SBOM describes what the
-          # build jobs actually built.
-          cargo cyclonedx --describe binaries --format json --spec-version 1.5 -q
+          # $VERSION from job env (#775 F5); matrix values are workflow-defined.
+          TARGET="${{ matrix.target }}"
+          # `--describe binaries` emits one SBOM per workspace binary from the
+          # committed lockfile (what the build above actually built); the
+          # release ships exactly two, both from the root crate.
+          cargo cyclonedx --describe binaries --format json --spec-version 1.5 \
+            --target "${TARGET}" -q
           for bin in kirra_verifier_service kirra_carla_client; do
-            mv "./${bin}_bin.cdx.json" "kirra-${VERSION}-${bin}.cdx.json"
+            src="./${bin}_bin.cdx.json"
+            if [ ! -s "${src}" ]; then
+              echo "::error::cargo-cyclonedx produced no SBOM for ${bin} (${TARGET})"
+              exit 1
+            fi
+            # Record the triple IN the SBOM (self-identifying beyond the
+            # filename); the release job cross-checks this against the name.
+            jq --arg t "${TARGET}" \
+              '.metadata.properties = ((.metadata.properties // []) + [{"name":"kirra:cargo:target","value":$t}])' \
+              "${src}" > "kirra-${VERSION}-${bin}-${TARGET}.cdx.json"
           done
           # Trial outputs for non-shipped workspace binaries are not release
           # artifacts — drop them so the upload glob can't pick one up.
           find . -name '*_bin.cdx.json' -delete
-          find . -name '*.cdx.json' -not -name "kirra-${VERSION}-*" -delete
-          ls -l ./*.cdx.json
+          ls -l ./kirra-*.cdx.json
 
-      - name: Upload SBOM artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: kirra-sbom
-          path: kirra-*.cdx.json
+          name: kirra-${{ matrix.target_name }}
+          path: |
+            kirra-*.tar.gz
+            kirra-*.cdx.json
           retention-days: 1
 
   # EP-18 — the safety-case-as-code bundle: reviewed evidence manifests +
@@ -378,8 +392,16 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [build, sbom, qnx-artifact, safety-case]
+    needs: [build, build-dashboard, qnx-artifact, safety-case]
     runs-on: ubuntu-latest
+    # #798 F7 — the signing job runs in a GitHub Environment so the OIDC
+    # signing identity can be put behind REQUIRED REVIEWERS: a pushed tag then
+    # builds everything but cannot SIGN or publish until a human approves the
+    # deployment. The protection rules are repo settings (owner action, not
+    # code) — see docs/releases/SUPPLY_CHAIN_OWNER_ACTIONS.md. Referencing the
+    # environment here is safe before that: an unconfigured environment is
+    # created on first run with no rules (current behavior unchanged).
+    environment: release
     # #775 F1 — the ONLY job granted the OIDC signing identity + release-write.
     # It runs no third-party build scripts (checkout, download, checksum, cosign,
     # gh-release), so the token is not exposed to untrusted code.
@@ -400,6 +422,39 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
+      - name: Assert SBOM completeness (#798 F5/F6)
+        # The SBOM set must be ARTIFACT-ACCURATE before anything is signed:
+        # one SBOM per (shipped bin × target), each recording the triple it
+        # was resolved for, plus the dashboard npm bundle. A missing or
+        # mislabeled SBOM fails the release here — before the signing step —
+        # so an approximate SBOM can never enter the trust chain again.
+        run: |
+          cd dist
+          fail=0
+          for target in x86_64-unknown-linux-musl aarch64-unknown-linux-musl armv7-unknown-linux-musleabihf; do
+            for bin in kirra_verifier_service kirra_carla_client; do
+              f="kirra-${VERSION}-${bin}-${target}.cdx.json"
+              if [ ! -s "$f" ]; then
+                echo "::error::missing SBOM: $f"; fail=1; continue
+              fi
+              rec=$(jq -r '.metadata.properties[]? | select(.name=="kirra:cargo:target") | .value' "$f")
+              if [ "$rec" != "$target" ]; then
+                echo "::error::$f records target '$rec' (expected '$target')"; fail=1
+              fi
+            done
+          done
+          if [ ! -s "kirra-${VERSION}-dashboard-npm.cdx.json" ]; then
+            echo "::error::missing dashboard npm SBOM"; fail=1
+          fi
+          count=$(find . -maxdepth 1 -name '*.cdx.json' | wc -l)
+          if [ "$count" -ne 7 ]; then
+            echo "::error::expected exactly 7 SBOMs (2 bins x 3 targets + dashboard), found $count:"
+            ls ./*.cdx.json || true
+            fail=1
+          fi
+          [ "$fail" -eq 0 ] && echo "OK: SBOM set complete and target-accurate (7/7)"
+          exit "$fail"
 
       - name: Generate checksums
         run: |
@@ -451,27 +506,43 @@ jobs:
             exit 1
           fi
           # WS-0.6: verification instructions travel with every release.
+          # #798 F7 — EXACT identity, interpolated per release (the notes are
+          # generated per-release, so nothing is lost by being exact). The old
+          # `@refs/tags/.*` regexp accepted a signature from ANY tag build —
+          # including a malicious tag pushed by any writer — as valid for any
+          # artifact. The heredoc stays quoted (no shell interpolation near
+          # the signing job); the version is substituted as data by sed below.
           cat >> release_notes.md <<'VERIFY'
 
           ---
           ### Verify artifact signatures (cosign, keyless)
 
-          Every artifact (tarballs, SBOM, `SHA256SUMS`) carries a
+          Every artifact (tarballs, SBOMs, `SHA256SUMS`) carries a
           `.cosign.bundle` — signature + signing certificate + transparency-log
-          proof, verifiable offline:
+          proof, verifiable offline. The identity below is EXACT for this
+          release: a signature minted by any other tag, branch, or workflow
+          does not verify.
 
           ```sh
           cosign verify-blob \
             --bundle <artifact>.cosign.bundle \
-            --certificate-identity-regexp \
-              'https://github.com/kirra-systems/kirra-runtime-sdk/\.github/workflows/release\.yml@refs/tags/.*' \
+            --certificate-identity \
+              'https://github.com/kirra-systems/kirra-runtime-sdk/.github/workflows/release.yml@refs/tags/@VERSION@' \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             <artifact>
           ```
 
-          The `kirra-*.cdx.json` files are the CycloneDX SBOM for the shipped
-          binaries, generated from the committed lockfile.
+          The `kirra-@VERSION@-<bin>-<target-triple>.cdx.json` files are
+          per-target CycloneDX SBOMs — one per shipped binary per platform,
+          resolved with `--target` so each describes the dependency graph of
+          the binary it sits next to (the triple is also recorded inside each
+          SBOM as the `kirra:cargo:target` property).
+          `kirra-@VERSION@-dashboard-npm.cdx.json` covers the bundled
+          dashboard's npm runtime dependencies.
           VERIFY
+          # $VERSION is preflight-validated (== the Cargo.toml version), so it
+          # is plain vX.Y.Z[-rc...] data — substituted with a non-/ delimiter.
+          sed -i "s|@VERSION@|${VERSION}|g" release_notes.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3

--- a/docs/releases/SUPPLY_CHAIN_OWNER_ACTIONS.md
+++ b/docs/releases/SUPPLY_CHAIN_OWNER_ACTIONS.md
@@ -1,0 +1,73 @@
+# Release supply-chain — owner actions (repo settings, not code)
+
+Issue #798 (F7) requires two protections that live in GitHub **settings**, not
+in this repository's files. The workflow half is already merged (the `release`
+job runs in the `release` Environment — `.github/workflows/release.yml`); the
+two settings below are what make it bite. Until they are configured, the
+threat F7 names remains open: **any user with push access can push a `v9.9.9`
+tag and mint signatures under the release identity** (the exact-identity
+verify instructions merged with #798 stop such a signature from verifying *as
+a different release*, but not from being minted).
+
+## 1. Protect `v*` tags (ruleset)
+
+Settings → Rules → Rulesets → **New tag ruleset**:
+
+- Name: `release-tags`; Enforcement: **Active**
+- Target tags → Add target → Include by pattern: `v*`
+- Rules: enable **Restrict creations**, **Restrict updates**, **Restrict
+  deletions** (updates/deletions matter doubly here: keyless signing means a
+  deleted-and-re-pushed tag leaves conflicting Rekor entries for one identity
+  — the workflow comments already forbid it as policy; the ruleset makes it
+  mechanical)
+- Bypass list: only the release manager(s)
+
+Equivalent API call (`gh api`):
+
+```sh
+gh api repos/kirra-systems/kirra-runtime-sdk/rulesets -X POST --input - <<'JSON'
+{
+  "name": "release-tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["refs/tags/v*"], "exclude": [] } },
+  "rules": [ { "type": "creation" }, { "type": "update" }, { "type": "deletion" } ]
+}
+JSON
+```
+
+(Then add your bypass actors in the UI — bypass lists take actor IDs.)
+
+## 2. Required reviewers on the `release` Environment
+
+Settings → Environments → `release` (auto-created by the first post-#798
+release run; create it manually if it does not exist yet):
+
+- **Required reviewers**: add the release manager(s). A pushed tag then
+  builds everything, but the `release` job — the ONLY job holding
+  `id-token: write` — waits for human approval before signing or publishing.
+- Optionally **Deployment branches and tags** → restrict to `v*` tags only
+  (defense in depth with the ruleset above).
+
+## 3. Verification quick reference (post-#798)
+
+- Release artifacts: the release notes carry the **exact** identity for that
+  version — `…/release.yml@refs/tags/vX.Y.Z`. No `.*` regexps.
+- Container images: exact identity `…/docker.yml@refs/tags/vX.Y.Z` (releases)
+  or `…@refs/heads/main` (main pushes); if a regexp is unavoidable, anchor it
+  end-to-end (see the comment in `.github/workflows/docker.yml`).
+- `install.sh` verifies `SHA256SUMS` authenticity with cosign automatically
+  when cosign is installed; `KIRRA_REQUIRE_SIGNED=1` makes it mandatory
+  (fail-closed).
+
+## 4. Roadmap remainder (tracked, not yet merged)
+
+- **SLSA L2→L3 provenance for the tarballs**: adopt
+  `actions/attest-build-provenance` (or `slsa-github-generator`) in the
+  release workflow — L3 additionally isolates signing from `npm install` /
+  `build.rs` structurally. Deferred from the #798 PR only because the repo's
+  SHA-pinning rule (#775 F2) requires pinning the new action by commit SHA,
+  and resolving that SHA needs repo access outside this session's scope —
+  a one-line follow-up with the SHA in hand. (Container images already get
+  SLSA provenance via BuildKit `provenance: mode=max`, merged with #798.)
+- QNX judge tarball SBOM: tracked in #790.

--- a/install.sh
+++ b/install.sh
@@ -303,11 +303,13 @@ else
     # SHA256SUMS (see .github/workflows/release.yml), so each of those is now a
     # hard failure, not a skip.
     #
-    # NOTE — integrity, NOT authenticity: SHA256SUMS is fetched over the SAME
-    # channel as the binary, so this defends against corruption and a binary-only
-    # swap, but NOT against an attacker who can replace BOTH artifacts. Signed
-    # releases (cosign keyless over SHA256SUMS, verified against the repo's GitHub
-    # OIDC identity) are the tracked authenticity follow-up — see INSTALL.md.
+    # NOTE — checksum alone is integrity, NOT authenticity: SHA256SUMS is
+    # fetched over the SAME channel as the binary, so it defends against
+    # corruption and a binary-only swap, but NOT against an attacker who can
+    # replace BOTH artifacts. Authenticity comes from the cosign step below
+    # (#798 roadmap — dogfooding the product's own fail-closed-trust pitch):
+    # every release signs SHA256SUMS keyless under the repo's release-workflow
+    # GitHub OIDC identity, pinned EXACTLY to this version's tag.
     if [ -z "${CHECKSUM_URL}" ]; then
         fatal "No SHA256SUMS published for this release — refusing to install an UNVERIFIED binary. Every Kirra release publishes one; its absence indicates a tampered or incomplete release."
     fi
@@ -316,6 +318,49 @@ else
     CHECKSUMS="${TMPDIR}/SHA256SUMS"
     curl -fsSL "${CHECKSUM_URL}" -o "${CHECKSUMS}" || \
         fatal "Could not download SHA256SUMS (${CHECKSUM_URL}) — refusing to install an UNVERIFIED binary."
+
+    # ------------------------------------------------------------------
+    # Authenticity — cosign keyless verification of SHA256SUMS (#798).
+    #
+    # EXACT identity (no regexp): a signature minted by any other tag,
+    # branch, or workflow of this repo — or by any other repo — does not
+    # verify. With cosign installed (or KIRRA_REQUIRE_SIGNED=1) this is
+    # REQUIRED and fail-closed. Without cosign we do NOT silently skip
+    # (that was the H-4 anti-pattern): we warn loudly, print the exact
+    # manual command, and name the flag that makes it mandatory. cosign
+    # is not packaged in Debian/Ubuntu, so hard-requiring it by default
+    # would break every fresh install — the flag is the operator's
+    # fail-closed opt-in until cosign ships preinstalled.
+    # ------------------------------------------------------------------
+    IDENTITY="https://github.com/${GITHUB_REPO}/.github/workflows/release.yml@refs/tags/${VERSION}"
+    if command -v cosign &>/dev/null || [ "${KIRRA_REQUIRE_SIGNED:-0}" = "1" ]; then
+        command -v cosign &>/dev/null || \
+            fatal "KIRRA_REQUIRE_SIGNED=1 but cosign is not installed. Install cosign (https://docs.sigstore.dev/cosign/system_config/installation/) and re-run."
+        BUNDLE_URL=$(echo "${RELEASE_JSON}" | \
+            grep -o '"browser_download_url": "[^"]*SHA256SUMS\.cosign\.bundle"' | \
+            head -1 | \
+            sed 's/"browser_download_url": "//;s/"//')
+        if [ -z "${BUNDLE_URL}" ]; then
+            fatal "No SHA256SUMS.cosign.bundle published for this release — refusing: signed releases always publish one; its absence indicates a tampered or incomplete release."
+        fi
+        curl -fsSL "${BUNDLE_URL}" -o "${CHECKSUMS}.cosign.bundle" || \
+            fatal "Could not download the signature bundle (${BUNDLE_URL}) — refusing to install an UNAUTHENTICATED binary."
+        info "Verifying SHA256SUMS signature (cosign keyless, exact identity)..."
+        cosign verify-blob \
+            --bundle "${CHECKSUMS}.cosign.bundle" \
+            --certificate-identity "${IDENTITY}" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${CHECKSUMS}" || \
+            fatal "cosign verification FAILED for SHA256SUMS — the checksums are not authentically from the ${VERSION} release build. Aborting."
+        success "SHA256SUMS authenticity verified (signed by ${IDENTITY})"
+    else
+        warn "cosign is not installed — SHA256SUMS is verified for INTEGRITY only, not authenticity."
+        warn "To verify authenticity manually:"
+        warn "  cosign verify-blob --bundle SHA256SUMS.cosign.bundle \\"
+        warn "    --certificate-identity '${IDENTITY}' \\"
+        warn "    --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS"
+        warn "Or set KIRRA_REQUIRE_SIGNED=1 to make signature verification mandatory (fail-closed)."
+    fi
 
     # Exact-field match on the SHA256SUMS filename column ($2), not a substring
     # `grep -F` — so a sibling artifact (e.g. a future `…tar.gz.sig`) whose name

--- a/install.sh
+++ b/install.sh
@@ -333,13 +333,13 @@ else
     # fail-closed opt-in until cosign ships preinstalled.
     # ------------------------------------------------------------------
     IDENTITY="https://github.com/${GITHUB_REPO}/.github/workflows/release.yml@refs/tags/${VERSION}"
+    BUNDLE_URL=$(echo "${RELEASE_JSON}" | \
+        grep -o '"browser_download_url": "[^"]*SHA256SUMS\.cosign\.bundle"' | \
+        head -1 | \
+        sed 's/"browser_download_url": "//;s/"//')
     if command -v cosign &>/dev/null || [ "${KIRRA_REQUIRE_SIGNED:-0}" = "1" ]; then
         command -v cosign &>/dev/null || \
             fatal "KIRRA_REQUIRE_SIGNED=1 but cosign is not installed. Install cosign (https://docs.sigstore.dev/cosign/system_config/installation/) and re-run."
-        BUNDLE_URL=$(echo "${RELEASE_JSON}" | \
-            grep -o '"browser_download_url": "[^"]*SHA256SUMS\.cosign\.bundle"' | \
-            head -1 | \
-            sed 's/"browser_download_url": "//;s/"//')
         if [ -z "${BUNDLE_URL}" ]; then
             fatal "No SHA256SUMS.cosign.bundle published for this release — refusing: signed releases always publish one; its absence indicates a tampered or incomplete release."
         fi
@@ -354,12 +354,23 @@ else
             fatal "cosign verification FAILED for SHA256SUMS — the checksums are not authentically from the ${VERSION} release build. Aborting."
         success "SHA256SUMS authenticity verified (signed by ${IDENTITY})"
     else
+        # Review #907: the manual instructions must be SELF-CONTAINED — the
+        # files this installer downloaded live in a temp dir that is removed
+        # on exit, so the commands below fetch their own copies.
         warn "cosign is not installed — SHA256SUMS is verified for INTEGRITY only, not authenticity."
-        warn "To verify authenticity manually:"
-        warn "  cosign verify-blob --bundle SHA256SUMS.cosign.bundle \\"
-        warn "    --certificate-identity '${IDENTITY}' \\"
-        warn "    --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS"
-        warn "Or set KIRRA_REQUIRE_SIGNED=1 to make signature verification mandatory (fail-closed)."
+        warn "Easiest: install cosign (https://docs.sigstore.dev/cosign/system_config/installation/)"
+        warn "and RE-RUN this installer — verification then runs automatically and fail-closed."
+        if [ -n "${BUNDLE_URL}" ]; then
+            warn "Or verify manually (self-contained; run in any empty directory):"
+            warn "  curl -fsSLO '${CHECKSUM_URL}'"
+            warn "  curl -fsSLO '${BUNDLE_URL}'"
+            warn "  cosign verify-blob --bundle SHA256SUMS.cosign.bundle \\"
+            warn "    --certificate-identity '${IDENTITY}' \\"
+            warn "    --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS"
+        else
+            warn "This release publishes no SHA256SUMS.cosign.bundle (pre-signing release) — authenticity cannot be verified for it."
+        fi
+        warn "Set KIRRA_REQUIRE_SIGNED=1 to make signature verification mandatory (fail-closed)."
     fi
 
     # Exact-field match on the SHA256SUMS filename column ($2), not a substring


### PR DESCRIPTION
Closes the in-repo half of #798 (supply-chain review follow-up, siblings of the #787 fixes). Every mechanic was validated locally before being written into the pipeline — including proof that the finding itself is real.

## F5 — SBOMs are now artifact-accurate

SBOM generation moves **into the build matrix** with `--target ${{ matrix.target }}`: one CycloneDX SBOM per (shipped bin × target) = 6, each recording its triple inside the document as the `kirra:cargo:target` property (jq-injected, filename cross-checked). The standalone host-resolve `sbom` job is removed.

**The inaccuracy was verified, not assumed**: resolving the same lockfile for `x86_64-unknown-linux-musl` vs `aarch64-unknown-linux-musl` with cargo-cyclonedx 0.5.9 yields different component sets (`curve25519-dalek-derive` appears only on x86_64) — the old host SBOM genuinely misdescribed the ARM binaries.

A new **`Assert SBOM completeness`** step in the release job runs *before signing*: all 6 rust SBOMs present, each file's recorded triple equals its filename triple, dashboard SBOM present, total exactly 7. Assertion logic exercised with a positive case and two negative controls (mislabeled triple, missing file) — both caught.

## F6 — coverage gaps closed

- **Dashboard npm bundle** (ships in every tarball): `npm sbom --sbom-format cyclonedx --omit dev` in `build-dashboard`, generated from the `npm ci` tree — built into npm ≥9.5, so no new unpinned tool enters the pipeline. Output validated locally (CycloneDX 1.5).
- **Container images**: both `docker/build-push-action` steps now set `sbom: true, provenance: mode=max` — BuildKit SBOM + max-detail SLSA provenance attestations attached in the registry, alongside the existing by-digest cosign signature.
- QNX judge tarball SBOM remains tracked in #790 (named there, not half-done here).

## F7 — verification identity is now exact; signing is gate-able

- Release-notes verify instructions pin the **exact** identity `…/release.yml@refs/tags/<this version>` — interpolated per release via a quoted-heredoc `@VERSION@` placeholder + `sed` (the tag never touches shell interpolation in the signing job; it's preflight-validated data). A signature minted by any other tag — including the review's malicious-`v9.9.9` scenario — no longer verifies.
- `docker.yml` verify guidance: exact identity per ref, or an **end-anchored** regexp; the old `@.*` (which matched every main push) is gone.
- The `release` job now runs in the **`release` GitHub Environment** — the workflow half of required-reviewer gating on the signing identity. The two **settings** halves (a `v*` tag ruleset with restrict create/update/delete, and required reviewers on the environment) cannot live in repo files; they're documented with exact UI steps and the `gh api` call in `docs/releases/SUPPLY_CHAIN_OWNER_ACTIONS.md` — **those two settings are yours to flip**, and until then the F7 threat is only narrowed, not closed.

## Roadmap — dogfooding

`install.sh` now verifies `SHA256SUMS` **authenticity**, not just integrity: cosign keyless verify against the exact release identity, **required and fail-closed** when cosign is installed or `KIRRA_REQUIRE_SIGNED=1`; without cosign it warns loudly with the exact manual command and names the flag — never a silent skip (the H-4 lesson). Hard-requiring cosign unconditionally would break every fresh Debian/Ubuntu install (cosign isn't packaged), so the flag is the operator's fail-closed opt-in — stated honestly in the comment.

`actions/attest-build-provenance` (SLSA L2→L3 for the tarballs) is deferred solely because the repo's SHA-pinning rule (#775 F2) needs the action pinned by commit SHA, and resolving that SHA requires repo access outside this session's scope — documented as a one-line follow-up.

## Validation record

- `cargo cyclonedx 0.5.9 --target` behavior + jq property round-trip run against this repo's real lockfile
- `npm sbom` run against the real dashboard lockfile post-`npm ci`
- both workflow YAMLs machine-parsed and structurally asserted (needs graph, environment, both images' sbom/provenance — the check caught that I'd initially only covered one image)
- `bash -n install.sh`; release-notes sed round-trip
- talisman re-verified (`ed00f4da…`); no Rust/safety code touched

Human review; do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_