### PR TITLE
docs(r2): record Path-B channel map + Ackermann drive proposal

### DIFF
--- a/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
+++ b/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
@@ -87,11 +87,15 @@ guessed:
    *Without this the drive cannot honor a `m/s` command* — only a normalized
    fraction of full PWM. Floor-blocking.
 2. **Road-wheel angle ↔ servo command-units.** `set_akm_steering_angle` is
-   `[-45,+45]` **command units** about a 90 default — command units ≠ road-wheel
-   degrees. Measure road-wheel angle (protractor) at several commands → `K`
-   (command-units per radian) + linearity. Floor-blocking for turns.
-3. **Steering centre trim** (`set_akm_default_angle`, `[60,120]`, default 100) so
-   `δ = 0` is physically straight.
+   `[-45,+45]` **command units** about the servo centre default (see 3) —
+   command units ≠ road-wheel degrees. Measure road-wheel angle (protractor) at
+   several commands → `K` (command-units per radian) + linearity. Floor-blocking
+   for turns.
+3. **Steering centre trim** (`set_akm_default_angle`, range `[60,120]`) so `δ = 0`
+   is physically straight. The library initialises this default to **100**;
+   `PLATFORM_R2_PENDING.md` earlier noted the `[60,120]` **midpoint (90)** — both
+   are provisional. The physical straight-ahead centre is the value MEASURED here
+   (read the live value with `get_akm_default_angle`), not assumed.
 4. **Max road-wheel angle at full lock** → `δ_max`.
 5. **Rear track `t`** — only if the Ackermann rear differential (§4) is chosen.
 6. **Wheelbase `L`** ≈0.229 m — re-confirm on this platform.

--- a/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
+++ b/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
@@ -1,0 +1,182 @@
+# R2 Path-B Ackermann drive — proposal (review before any code / robot testing)
+
+> **Status: PROPOSAL. No code is wired and nothing here has driven the robot.**
+> This is the design for an open-source R2 drive that bypasses the (broken, on
+> this cross-labeled X3 image) firmware `set_car_motion` kinematics and instead
+> drives the two rear motors directly + steers the servo, doing the Ackermann
+> math in KIRRA-governed code. Written for review; the calibration gaps in §5
+> MUST be measured on the bench before this can drive correctly.
+
+## 1. Why Path B
+
+`Rosmaster.set_car_motion` is a pure pass-through: it forwards `(car_type, vx,
+vy, vz)` to the MCU and the **firmware** does the car-type kinematics (analyzed
+in the read-only investigation; confirmed against the installed Rosmaster_Lib
+3.3.9). The X3 image on this R2 does not implement the type-5 (Ackermann) drive
+path, so `set_car_motion(v, 0, 0)` moves only one wheel. Path A (flash Yahboom's
+R2 firmware) remains the low-effort route (`PLATFORM_R2_PENDING.md`). **Path B**
+needs no vendor firmware: `set_motor` (FUNC `0x10`) carries **no car-type byte**
+and addresses the four motor channels directly, bypassing the mixer entirely;
+`set_akm_steering_angle` (FUNC `0x31`) drives the steering servo independently.
+The Ackermann kinematics then live in our verifiable code, which is arguably a
+*better* safety story than closed vendor firmware.
+
+## 2. Confirmed hardware facts (bench probe)
+
+From `robot/motor_channel_probe_results.txt` (PR #911 probe, elevated):
+
+| `set_motor` arg | Channel | Wheel | Forward sign |
+|---|---|---|---|
+| `s1` | M1 | rear-left | **+** |
+| `s2` | M2 | (unpopulated) | — |
+| `s3` | M3 | (unpopulated) | — |
+| `s4` | M4 | rear-right | **+** |
+
+- **Straight-ahead forward drive = `set_motor(+v, 0, 0, +v)`.** Both rear channels
+  take POSITIVE for robot-forward — no mirror-sign flip (motor polarity is
+  already matched).
+- Steering is **not** a motor channel (AKM path); it stayed centered through all
+  four pulses.
+- Encoder cross-check agreed with the visual on both driven channels.
+
+## 3. The drive stack (three layers)
+
+```
+  (governed cmd_vel: v [m/s], ω [rad/s])   ← KIRRA has ALREADY bounded this
+        │
+  L1 Ackermann kinematics  ── δ = atan(L·ω / v) ;  rear speeds
+        │
+  L2 calibration           ── m/s → PWM% ;  road-wheel rad → servo command-units
+        │
+  L0 raw actuation         ── set_motor(pwm,0,0,pwm) + set_akm_steering_angle(cmd)
+```
+
+L1 is exact geometry. **L2 is the gap** — until the two calibrations in §5 are
+measured, L0 cannot honor a physical `m/s` / `rad` command.
+
+## 4. Ackermann kinematics (L1)
+
+Inputs are the **already-governed** command `(v, ω)` = `(linear.x, angular.z)`.
+`L` = wheelbase (≈0.229 m measured, to re-confirm). Bicycle model:
+
+- **Turn radius** of the rear-axle centre: `R = v / ω` (ω ≠ 0).
+- **Front road-wheel steering angle**: `δ = atan(L · ω / v)` (from `tan δ = L/R`).
+  - `ω = 0` → `δ = 0` (straight).
+  - `v = 0, ω ≠ 0` is **not Ackermann-achievable** (a car cannot spin in place):
+    KIRRA must refuse/clamp such a command *upstream*; this layer treats it as a
+    fault → MRC stop (§6), never an unbounded steer.
+- **Sign**: `ω > 0` (left / CCW) → `δ > 0` → steer **left**. The servo command is
+  `[-45,+45]` with **negative = left**, so `steer_cmd ≈ −K·δ`. The sign **must be
+  verified on the bench** (drive slow, confirm a left command turns left) before
+  any floor run.
+- **Clamp** `δ` to `±δ_max` (max road-wheel angle at full lock, measured).
+- **Rear-wheel speeds**: rear-axle centre moves at `v`. Optional true Ackermann
+  differential `v_{L,R} = v ∓ t·ω/2` (`t` = rear track). **v0 proposal: equal PWM
+  on both rear wheels** (`t` not needed); the differential is small at low `ω`
+  and is a later refinement (needs `t`, and — to be exact in m/s — the speed
+  calibration).
+
+## 5. Calibration gaps — MEASURE, do not invent
+
+These are the values that stand between this design and correct driving. Each is
+a bench measurement (elevated), recorded like `steering_bench_results.txt`, never
+guessed:
+
+1. **PWM ↔ ground speed.** Sweep `set_motor` %; measure wheel surface speed (or
+   encoder ticks/s → m/s using the wheel radius). Yields `pwm = v / V_PER_PWM`.
+   *Without this the drive cannot honor a `m/s` command* — only a normalized
+   fraction of full PWM. Floor-blocking.
+2. **Road-wheel angle ↔ servo command-units.** `set_akm_steering_angle` is
+   `[-45,+45]` **command units** about a 90 default — command units ≠ road-wheel
+   degrees. Measure road-wheel angle (protractor) at several commands → `K`
+   (command-units per radian) + linearity. Floor-blocking for turns.
+3. **Steering centre trim** (`set_akm_default_angle`, `[60,120]`, default 100) so
+   `δ = 0` is physically straight.
+4. **Max road-wheel angle at full lock** → `δ_max`.
+5. **Rear track `t`** — only if the Ackermann rear differential (§4) is chosen.
+6. **Wheelbase `L`** ≈0.229 m — re-confirm on this platform.
+
+These become the measured fields of the `r2` contract profile
+(`PLATFORM_R2_PENDING.md` Track-A A2), never invented defaults.
+
+## 6. KIRRA integration & fail-closed
+
+**This module is the R2 *doer* last-hop — the analog of the X3 firmware mixer,
+but in our code.** It does NOT relax the safety architecture:
+
+- **The verify chokepoint is unchanged.** In `kirra_motor_consumer.py`, actuation
+  happens only after the Rust verify core releases the token (ADR-0033). Path B
+  swaps exactly one call: the released last-hop
+  `set_car_motion(linear, 0.0, angular)` (`kirra_motor_consumer.py:177`) becomes
+  the Ackermann pair `set_motor(pwm,0,0,pwm)` + `set_akm_steering_angle(cmd)`.
+  The translation runs **after** verify — the same place the X3 firmware mixing
+  runs after verify. The token still gates the enforced bytes.
+- **`safe_stop` becomes** `set_motor(0,0,0,0)` **+** `set_akm_steering_angle(0)`
+  (replacing `set_car_motion(0,0,0)` at `:160`), preserving SS-002 stop-on-fault.
+- **Fail-closed at the last hop**: any non-finite `(v, ω)` or `δ`, a `v=0,ω≠0`
+  command, or an out-of-range clamp saturating → MRC (`set_motor(0,0,0,0)` +
+  centre). Never a bare unbounded actuation.
+- **KIRRA class re-validation.** The checker's envelope/WCET reasoning currently
+  assumes the X3 `(linear, angular)` → `set_car_motion` semantics. For R2 it must
+  be re-validated under `KIRRA_VEHICLE_CLASS=r2` with the measured contract
+  profile (`PLATFORM_R2_PENDING.md`). The interceptor wheelbase cross-check
+  (`ros2_ws/.../cmd_vel_interceptor.py`) uses `L` from that profile.
+
+## 7. Reference algorithm (illustrative — NOT wired)
+
+Pseudocode for review only; not committed as runnable code, and inert until §5 is
+measured and §6 re-validated.
+
+```
+# Inputs: v (m/s), omega (rad/s) — ALREADY governed/bounded by KIRRA upstream.
+# Calibrations (measured, from the r2 profile): L, V_PER_PWM, K, delta_max,
+# center_trim, PWM_MAX.
+def r2_ackermann_last_hop(v, omega):
+    if not (isfinite(v) and isfinite(omega)):     return mrc_stop()
+    if abs(v) <= STOP_EPS and abs(omega) > W_EPS: return mrc_stop()  # not Ackermann-achievable
+    # steering
+    delta = 0.0 if abs(v) <= STOP_EPS else atan(L * omega / v)
+    delta = clamp(delta, -delta_max, +delta_max)
+    steer_cmd = clamp(round(-K * delta), -45, +45)   # sign VERIFIED on bench
+    # drive (equal-PWM v0)
+    pwm = clamp(round(v / V_PER_PWM), -PWM_MAX, +PWM_MAX)
+    # actuate (order: steer, then drive; both fail-closed on raise)
+    bot.set_akm_steering_angle(steer_cmd)
+    bot.set_motor(pwm, 0, 0, pwm)          # M1=rear-left, M4=rear-right, both +fwd
+
+def mrc_stop():
+    bot.set_motor(0, 0, 0, 0)
+    bot.set_akm_steering_angle(0)
+```
+
+## 8. Validation plan (staged, elevated → floor)
+
+0. **Calibrate (elevated)** — measure every §5 value; record to
+   `r2_drive_calibration_results.txt`. Verify the steering sign (§4).
+1. **Elevated drive** — feed governed commands through the last-hop; confirm:
+   straight = both rear wheels same direction/speed; left/right steer sign;
+   fail-closed on injected NaN / `v=0,ω≠0`; `safe_stop` zeros both.
+2. **Floor, tethered, low speed** — straight + gentle turns; confirm KIRRA bounds
+   and the verify gate hold end-to-end (a `first_run_elevated.sh`-style guided
+   acceptance, adapted for R2).
+3. Only then: promote to the standing R2 config (`KIRRA_VEHICLE_CLASS=r2`,
+   `KIRRA_EXPECTED_CAR_TYPE` per platform, interceptor wheelbase = profile `L`).
+
+## 9. Open decisions (need sign-off before implementation)
+
+- **Equal-PWM vs Ackermann rear differential** for v0 (differential needs `t`).
+- **Open-loop vs encoder-closed-loop** speed (m/s tracking vs PWM proportional).
+  Open-loop v0 will not perfectly track a `m/s` command (§ probe: ~12% wheel
+  mismatch at equal PWM) — acceptable for low-speed v0, or close the loop.
+- **Where the Ackermann translation lives** — in `kirra_motor_consumer.py` (one
+  swapped last-hop, simplest) vs a small dedicated `r2_drive` module the consumer
+  calls. Either keeps the verify gate ahead of it.
+- **`v=0, ω≠0` policy** — confirmed as an upstream KIRRA refusal + last-hop MRC
+  (Ackermann cannot execute it).
+
+---
+
+Cross-refs: `robot/motor_channel_probe_results.txt` (the map),
+`robot/install/PLATFORM_R2_PENDING.md` (Path A / the `r2` profile),
+`robot/kirra_motor_consumer.py:157,177` (the verify-gated actuation last-hop).
+Human review; do not merge.

--- a/robot/install/PLATFORM_R2_PENDING.md
+++ b/robot/install/PLATFORM_R2_PENDING.md
@@ -23,7 +23,19 @@ down — the difference between "the image mysteriously doesn't steer" and
 3. **Therefore the blocking dependency is external**: Yahboom's
    **Ultimate-Orin NX R2 image** (drive AND steering wired together).
    **Not yet obtained — emailing Yahboom is the critical path.** Only that
-   image unblocks this layer.
+   image unblocks this layer via `set_car_motion` (Path A).
+
+> **Path B (no vendor firmware) — proposal, in review.** The read-only
+> investigation confirmed `set_car_motion` is a pure pass-through and the
+> car-type kinematics are firmware-side; `set_motor` (no car-type byte) drives
+> the motor channels directly, bypassing the broken mixer. A bench probe mapped
+> the channels (`robot/motor_channel_probe_results.txt`: M1=rear-left, M4=rear-right,
+> both `+`=forward; steering on the AKM path). The open-source Ackermann drive
+> that uses this — rear wheels via `set_motor`, steering via
+> `set_akm_steering_angle`, KIRRA-governed — is proposed in
+> `docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md` (calibration measurements pending
+> before it can drive). Path B and Path A are alternatives; either unblocks R2
+> drive+steer.
 
 ## What Layer B WILL contain (once unblocked)
 

--- a/robot/motor_channel_probe_results.txt
+++ b/robot/motor_channel_probe_results.txt
@@ -65,9 +65,11 @@ Values still to CAPTURE on the bench (do NOT invent — see the drive proposal,
 docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md):
   - PWM ↔ ground-speed calibration (map set_motor % → m/s).
   - Road-wheel angle ↔ servo command-units (set_akm_steering_angle is [-45,+45]
-    command units about a 90 default; command units ≠ road-wheel degrees).
-  - Steering center trim (set_akm_default_angle) and max road-wheel angle at
-    full lock.
+    command units about the servo centre default; command units ≠ road-wheel
+    degrees).
+  - Steering center trim (set_akm_default_angle; library-initialised default 100,
+    range [60,120] — the physical centre is the measured value) and max
+    road-wheel angle at full lock.
   - Rear track width (only if the Ackermann rear-wheel speed differential is
     implemented; equal-PWM v0 does not need it).
   - Wheelbase L: ≈0.229 m measured previously (PLATFORM_R2_PENDING.md), to be

--- a/robot/motor_channel_probe_results.txt
+++ b/robot/motor_channel_probe_results.txt
@@ -1,0 +1,74 @@
+R2 MOTOR-CHANNEL PROBE RESULTS — Path-B Step 1 (channel → wheel → forward-sign)
+==============================================================================
+
+Provenance
+----------
+Robot     : Yahboom R2 (Ackermann) on Jetson Orin, hostname `yahboom`
+            (banner reports my_robot_type: x3 — the cross-labeled X3 image; this
+            is irrelevant to set_motor, which is car-type independent).
+Tool      : robot/motor_channel_probe_elevated.py (merged in PR #911)
+Library   : Rosmaster_Lib 3.3.9 (installed egg; set_motor confirmed byte-identical
+            to the analyzed source — packet [0xFF,0xFC,len,0x10,s1,s2,s3,s4,ck],
+            NO car-type byte, i.e. the firmware kinematics mixer is bypassed).
+Condition : robot ELEVATED, wheels free, +20 PWM per channel, 1.5 s each,
+            steering centered (set_akm_steering_angle(0)) and held.
+Method    : one channel pulsed at a time, explicit 0 on the other three; the
+            moving wheel recorded visually AND cross-checked against the
+            per-channel encoder delta (get_motor_encoder m1..m4).
+
+Verbatim probe output
+---------------------
+  -- Pulse channel M1 now? [y/N] y
+     encoder delta (m1..m4): [1371, 0, 0, 0]   moved-index: [1]
+     Which WHEEL turned for M1? RL   Direction at +20? forward
+  -- Pulse channel M2 now? [y/N] y
+     encoder delta (m1..m4): [0, 0, 0, 0]      moved-index: []
+     Which WHEEL turned for M2? none
+  -- Pulse channel M3 now? [y/N] y
+     encoder delta (m1..m4): [0, 0, 0, 0]      moved-index: []
+     Which WHEEL turned for M3? none
+  -- Pulse channel M4 now? [y/N] y
+     encoder delta (m1..m4): [0, 0, 0, 1554]   moved-index: [4]
+     Which WHEEL turned for M4? RR   Direction at +20? forward
+  (M4 wheel answer was typed "aaRR"; the "aa" is an input typo — the wheel is RR,
+   confirmed by the m4 encoder delta. The auto-summary's rear-drive list dropped
+   M4 only because "AARR" != "RR"; the mapping below is the corrected record.)
+
+CONFIRMED MAP
+-------------
+  set_motor(s1, s2, s3, s4)   # signed PWM %, [-100, 100]; car-type independent
+
+  s1 = M1 = REAR-LEFT  drive   forward-sign = +   (encoder m1, Δ +1371 @ +20)
+  s2 = M2 = (unpopulated)      —                  (encoder flat)
+  s3 = M3 = (unpopulated)      —                  (encoder flat)
+  s4 = M4 = REAR-RIGHT drive   forward-sign = +   (encoder m4, Δ +1554 @ +20)
+
+  => STRAIGHT-AHEAD FORWARD DRIVE:  set_motor(+v, 0, 0, +v)
+
+  Steering: NOT a motor channel — no servo motion observed during any pulse,
+  consistent with the AKM path (set_akm_steering_angle, FUNC 0x31). Steering
+  stayed centered throughout.
+
+Key findings
+------------
+1. Both rear-drive channels take POSITIVE for robot-forward (NO mirror-sign flip
+   needed). The motor polarity/gearing is already matched, so straight drive is
+   `+v` on both M1 and M4 — simpler than a mirror-mounted differential pair.
+2. Visual observation and encoder cross-check AGREE on both driven channels
+   (M1→m1, M4→m4) and both dead channels have flat encoders — unambiguous.
+3. Open-loop note (not a fault): at the same +20 PWM the two encoder deltas
+   differ ~12% (1371 vs 1554). `set_motor` bypasses the firmware speed PID, so a
+   naive equal-PWM command may drift slightly rather than track perfectly
+   straight. Encoder-closed-loop speed matching is a later refinement.
+
+Values still to CAPTURE on the bench (do NOT invent — see the drive proposal,
+docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md):
+  - PWM ↔ ground-speed calibration (map set_motor % → m/s).
+  - Road-wheel angle ↔ servo command-units (set_akm_steering_angle is [-45,+45]
+    command units about a 90 default; command units ≠ road-wheel degrees).
+  - Steering center trim (set_akm_default_angle) and max road-wheel angle at
+    full lock.
+  - Rear track width (only if the Ackermann rear-wheel speed differential is
+    implemented; equal-PWM v0 does not need it).
+  - Wheelbase L: ≈0.229 m measured previously (PLATFORM_R2_PENDING.md), to be
+    re-confirmed on this platform before it becomes a profile value.


### PR DESCRIPTION
## What

Records the bench-validated `set_motor` channel→wheel map and proposes the open-source R2 Ackermann drive that uses it — no Yahboom firmware, KIRRA-governed.

**Proposal only.** No drive code is wired, nothing has driven the robot, and every calibration value is explicitly flagged pending measurement (never invented).

## The validated map (`robot/motor_channel_probe_results.txt`)

From the PR #911 probe, robot elevated, `set_motor` bypassing the firmware mixer:

| `set_motor` arg | Channel | Wheel | Forward sign |
|---|---|---|---|
| `s1` | M1 | rear-left | **+** |
| `s2`/`s3` | M2/M3 | unpopulated | — |
| `s4` | M4 | rear-right | **+** |

**Straight forward = `set_motor(+v, 0, 0, +v)`** — both rear channels positive (no mirror-sign flip). Steering is on the AKM path (not a motor channel). Encoder cross-check agreed with the visual; ~12% open-loop wheel-speed mismatch at equal PWM is noted.

## The proposal (`docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md`)

- **Ackermann kinematics**: `δ = atan(L·ω/v)` from the governed `(v, ω)`; `v=0,ω≠0` is not Ackermann-achievable → upstream refusal + last-hop MRC.
- **The L2 calibration gaps that MUST be measured before floor driving** (never invented): PWM↔m/s, road-wheel-angle↔servo-command-units, center trim, `δ_max`, rear track, wheelbase re-confirm.
- **KIRRA integration**: the ADR-0033 verify chokepoint is unchanged — Path B swaps exactly one *post-verify* last-hop (`kirra_motor_consumer.py:177` `set_car_motion(...)` → `set_motor(+v,0,0,+v)` + `set_akm_steering_angle`); `safe_stop` → `set_motor(0,0,0,0)` + center.
- Staged elevated→floor validation plan + open decisions for sign-off (equal-PWM vs Ackermann differential, open- vs closed-loop, where the translation lives).
- `PLATFORM_R2_PENDING.md` cross-referenced: Path B (no firmware) alongside Path A (vendor image).

## Scope / safety

Docs only — no Rust, no runnable drive module, frozen kinematics talisman untouched. The next step (writing/validating the drive) is gated on this review + the bench calibrations.

**Human review; do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_