### PR TITLE
robot: record R2 calibration + confirm car-type-5 steering (Path-B)

### DIFF
--- a/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
+++ b/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
@@ -39,6 +39,29 @@ From `robot/motor_channel_probe_results.txt` (PR #911 probe, elevated):
   four pulses.
 - Encoder cross-check agreed with the visual on both driven channels.
 
+### 2a. Steering requires car-type 5 (bench-confirmed, PR #913 follow-up)
+
+The first calibration run saw **no servo motion** during the Phase C steering
+sweep. Cause (confirmed on the bench, `r2_drive_calibration_results.txt`): the
+AKM steering servo **only actuates when the board is in car-type 5**. Under the
+default cross-labeled X3 image (car-type 1) `set_akm_steering_angle` is silently
+ignored. After `set_car_type(5)` the front wheels swing as commanded.
+
+- This is **not** a Path-B problem — it's the reason Path B works. Type 5 is
+  known to *break* `set_car_motion` drive (`PLATFORM_R2_PENDING.md`), but Path B
+  **never uses `set_car_motion`**; it drives with `set_motor`, which is car-type
+  **independent** (the Phase A drive sweep ran fine without ever touching
+  car-type). So the Path-B trio is: `set_car_type(5)` (servo on) +
+  `set_motor(+v,0,0,+v)` (drive, any type) + `set_akm_steering_angle(cmd)` (steer).
+- `get_akm_default_angle()` returns the sentinel **−1** on this image **even with
+  the servo actuating** — it is an unimplemented getter, **not** an
+  "AKM-inactive" flag. The physical centre trim must therefore be read from the
+  protractor sweep, never from this call.
+- `set_car_type` is **RAM-volatile** (reverts on reboot). Because the *currently
+  live* consumer still uses `set_car_motion`, any bench tool that sets type 5
+  must **restore type 1 on exit** (or reboot) so the live drive path is not left
+  broken. The calibration script does this in its `finally`.
+
 ## 3. The drive stack (three layers)
 
 ```
@@ -95,7 +118,9 @@ guessed:
    is physically straight. The library initialises this default to **100**;
    `PLATFORM_R2_PENDING.md` earlier noted the `[60,120]` **midpoint (90)** — both
    are provisional. The physical straight-ahead centre is the value MEASURED here
-   (read the live value with `get_akm_default_angle`), not assumed.
+   from the protractor sweep — **not** `get_akm_default_angle`, which returns the
+   sentinel **−1** (unimplemented) on this image even with the servo actuating
+   (see §2a).
 4. **Max road-wheel angle at full lock** → `δ_max`.
 5. **Rear track `t`** — only if the Ackermann rear differential (§4) is chosen.
 6. **Wheelbase `L`** ≈0.229 m — re-confirm on this platform.
@@ -115,6 +140,12 @@ but in our code.** It does NOT relax the safety architecture:
   the Ackermann pair `set_motor(pwm,0,0,pwm)` + `set_akm_steering_angle(cmd)`.
   The translation runs **after** verify — the same place the X3 firmware mixing
   runs after verify. The token still gates the enforced bytes.
+- **The consumer must set car-type 5 once at init** (§2a) so the AKM servo
+  actuates, and it MUST NOT call `set_car_motion` thereafter (type 5 breaks it —
+  which is fine, Path B does not use it). This replaces the current
+  `KIRRA_EXPECTED_CAR_TYPE` type-1 assertion for the R2 platform. Because type 5
+  is RAM-volatile, the consumer re-asserts it on every start (it does not rely on
+  a persisted board setting).
 - **`safe_stop` becomes** `set_motor(0,0,0,0)` **+** `set_akm_steering_angle(0)`
   (replacing `set_car_motion(0,0,0)` at `:160`), preserving SS-002 stop-on-fault.
 - **Fail-closed at the last hop**: any non-finite `(v, ω)` or `δ`, a `v=0,ω≠0`
@@ -135,6 +166,9 @@ measured and §6 re-validated.
 # Inputs: v (m/s), omega (rad/s) — ALREADY governed/bounded by KIRRA upstream.
 # Calibrations (measured, from the r2 profile): L, V_PER_PWM, K, delta_max,
 # center_trim, PWM_MAX.
+# ONCE at consumer init (NOT per command): bot.set_car_type(5)  # enables the AKM
+#   servo (§2a); drive via set_motor is car-type independent. Never call
+#   set_car_motion after this.
 def r2_ackermann_last_hop(v, omega):
     if not (isfinite(v) and isfinite(omega)):     return mrc_stop()
     if abs(v) <= STOP_EPS and abs(omega) > W_EPS: return mrc_stop()  # not Ackermann-achievable

--- a/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
+++ b/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
@@ -14,7 +14,7 @@ vy, vz)` to the MCU and the **firmware** does the car-type kinematics (analyzed
 in the read-only investigation; confirmed against the installed Rosmaster_Lib
 3.3.9). The X3 image on this R2 does not implement the type-5 (Ackermann) drive
 path, so `set_car_motion(v, 0, 0)` moves only one wheel. Path A (flash Yahboom's
-R2 firmware) remains the low-effort route (`PLATFORM_R2_PENDING.md`). **Path B**
+R2 firmware) remains the low-effort route (`robot/install/PLATFORM_R2_PENDING.md`). **Path B**
 needs no vendor firmware: `set_motor` (FUNC `0x10`) carries **no car-type byte**
 and addresses the four motor channels directly, bypassing the mixer entirely;
 `set_akm_steering_angle` (FUNC `0x31`) drives the steering servo independently.
@@ -48,7 +48,7 @@ default cross-labeled X3 image (car-type 1) `set_akm_steering_angle` is silently
 ignored. After `set_car_type(5)` the front wheels swing as commanded.
 
 - This is **not** a Path-B problem — it's the reason Path B works. Type 5 is
-  known to *break* `set_car_motion` drive (`PLATFORM_R2_PENDING.md`), but Path B
+  known to *break* `set_car_motion` drive (`robot/install/PLATFORM_R2_PENDING.md`), but Path B
   **never uses `set_car_motion`**; it drives with `set_motor`, which is car-type
   **independent** (the Phase A drive sweep ran fine without ever touching
   car-type). So the Path-B trio is: `set_car_type(5)` (servo on) +
@@ -116,7 +116,7 @@ guessed:
    for turns.
 3. **Steering centre trim** (`set_akm_default_angle`, range `[60,120]`) so `δ = 0`
    is physically straight. The library initialises this default to **100**;
-   `PLATFORM_R2_PENDING.md` earlier noted the `[60,120]` **midpoint (90)** — both
+   `robot/install/PLATFORM_R2_PENDING.md` earlier noted the `[60,120]` **midpoint (90)** — both
    are provisional. The physical straight-ahead centre is the value MEASURED here
    from the protractor sweep — **not** `get_akm_default_angle`, which returns the
    sentinel **−1** (unimplemented) on this image even with the servo actuating
@@ -126,7 +126,7 @@ guessed:
 6. **Wheelbase `L`** ≈0.229 m — re-confirm on this platform.
 
 These become the measured fields of the `r2` contract profile
-(`PLATFORM_R2_PENDING.md` Track-A A2), never invented defaults.
+(`robot/install/PLATFORM_R2_PENDING.md` Track-A A2), never invented defaults.
 
 ## 6. KIRRA integration & fail-closed
 
@@ -154,7 +154,7 @@ but in our code.** It does NOT relax the safety architecture:
 - **KIRRA class re-validation.** The checker's envelope/WCET reasoning currently
   assumes the X3 `(linear, angular)` → `set_car_motion` semantics. For R2 it must
   be re-validated under `KIRRA_VEHICLE_CLASS=r2` with the measured contract
-  profile (`PLATFORM_R2_PENDING.md`). The interceptor wheelbase cross-check
+  profile (`robot/install/PLATFORM_R2_PENDING.md`). The interceptor wheelbase cross-check
   (`ros2_ws/.../cmd_vel_interceptor.py`) uses `L` from that profile.
 
 ## 7. Reference algorithm (illustrative — NOT wired)
@@ -175,7 +175,7 @@ def r2_ackermann_last_hop(v, omega):
     # steering
     delta = 0.0 if abs(v) <= STOP_EPS else atan(L * omega / v)
     delta = clamp(delta, -delta_max, +delta_max)
-    steer_cmd = clamp(round(-K * delta), -45, +45)   # sign VERIFIED on bench
+    steer_cmd = clamp(round(-K * delta), -45, +45)   # sign STILL TO VERIFY on bench (Phase C sign-check pending)
     # drive (equal-PWM v0)
     pwm = clamp(round(v / V_PER_PWM), -PWM_MAX, +PWM_MAX)
     # actuate (order: steer, then drive; both fail-closed on raise)

--- a/robot/r2_drive_calibration_elevated.py
+++ b/robot/r2_drive_calibration_elevated.py
@@ -20,10 +20,13 @@ Four phases (each optional; skip any you cannot do this bench):
   B  encoder scale                — hand-rotate ONE rear wheel a known number of
                                      turns → ticks/rev; with the measured wheel
                                      diameter this converts ticks/s → m/s.
-  C  steering command ↔ road-wheel angle — sweep set_akm_steering_angle over
-                                     [-45..+45]; operator reads the physical
-                                     road-wheel angle per command → K, linearity,
-                                     δ_max, sign check; records the live centre.
+  C  steering command ↔ road-wheel angle — enables car-type 5 (REQUIRED for the
+                                     AKM servo to actuate — type 1 ignores it),
+                                     sweeps set_akm_steering_angle over [-45..+45];
+                                     operator reads the physical road-wheel angle
+                                     per command → K, linearity, δ_max, sign check.
+                                     Restores car-type 1 on exit (the live
+                                     set_car_motion consumer needs it).
   D  geometry                      — tape-measured wheelbase L (re-confirm ~0.229 m)
                                      and rear track t.
 
@@ -221,15 +224,34 @@ def phase_c(bot, lines):
         lines.append("PHASE C (steering↔angle): SKIPPED")
         return
 
-    # Record the live centre default (the physical straight-ahead trim).
+    # BENCH FINDING (PR #913 follow-up): the AKM steering servo only actuates when
+    # the board is in car-type 5. The default X3 image (type 1) silently ignores
+    # set_akm_steering_angle — which is why the first calibration run saw no servo
+    # motion. set_motor drive is car-type INDEPENDENT, so enabling type 5 here does
+    # not disturb Phase A. It IS restored to type 1 in main()'s finally, because the
+    # currently-live consumer still uses set_car_motion (which type 5 breaks).
+    print("   Enabling car-type 5 (Ackermann) so the AKM servo actuates ...")
+    try:
+        bot.set_car_type(5)
+        time.sleep(0.3)
+    except Exception as exc:  # noqa: BLE001 - record and continue; the sweep will show no motion
+        print(f"   (set_car_type(5) failed: {exc})")
+        lines.append(f"PHASE C: set_car_type(5) FAILED: {exc} — steering will not actuate")
+
+    # Record the live centre default IF the getter is implemented. On this image
+    # get_akm_default_angle returns the sentinel -1 (unimplemented) even with the
+    # servo actuating — so -1 means "not readable", NOT "steering inactive"; the
+    # physical centre trim is established from the sweep below, not this value.
     live_center = None
     try:
         live_center = bot.get_akm_default_angle()
     except Exception as exc:  # noqa: BLE001 - not fatal; just record that we couldn't
         print(f"   (get_akm_default_angle unavailable: {exc})")
+    center_note = " (-1 = getter unimplemented on this image; use the sweep)" if live_center == -1 else ""
     lines.append("PHASE C (steering↔angle): set_akm_steering_angle sweep, command units [-45,+45], neg=left")
-    lines.append(f"  live_default_angle (get_akm_default_angle) = {live_center}")
-    print(f"   live steering default (centre trim) = {live_center}")
+    lines.append("  REQUIRES car-type 5 (set_car_type(5)); type 1 ignores the AKM servo.")
+    lines.append(f"  live_default_angle (get_akm_default_angle) = {live_center}{center_note}")
+    print(f"   live steering default (centre trim) = {live_center}{center_note}")
 
     cmds = _parse_int_list(os.environ.get("CALIB_STEER_CMDS", DEFAULT_STEER_CMDS), "CALIB_STEER_CMDS")
     over = [c for c in cmds if abs(c) > 45]
@@ -355,7 +377,11 @@ def main():
             bot.set_akm_steering_angle(0)
         except Exception:  # noqa: BLE001 - best-effort centre
             pass
-        print("\n\nInterrupted - motors stopped, steering centred.")
+        try:
+            bot.set_car_type(1)  # restore X3/type-1 so the live set_car_motion consumer still drives
+        except Exception:  # noqa: BLE001 - best-effort restore (reboot also restores it)
+            pass
+        print("\n\nInterrupted - motors stopped, steering centred, car-type restored to 1.")
         if lines:
             _write_results(lines)  # persist whatever was captured before the interrupt
     finally:
@@ -367,7 +393,14 @@ def main():
             bot.set_akm_steering_angle(0)
         except Exception:  # noqa: BLE001 - best-effort centre
             pass
-        print("\nAll channels commanded to 0, steering centred. Calibration complete.")
+        # Phase C may have set car-type 5 for the servo; restore type 1 so the live
+        # set_car_motion consumer still drives until Path B is wired (RAM-volatile,
+        # so a reboot also restores it — this just avoids requiring one).
+        try:
+            bot.set_car_type(1)
+        except Exception:  # noqa: BLE001 - best-effort restore
+            pass
+        print("\nAll channels commanded to 0, steering centred, car-type restored to 1. Calibration complete.")
 
 
 if __name__ == "__main__":

--- a/robot/r2_drive_calibration_elevated.py
+++ b/robot/r2_drive_calibration_elevated.py
@@ -234,9 +234,11 @@ def phase_c(bot, lines):
     try:
         bot.set_car_type(5)
         time.sleep(0.3)
-    except Exception as exc:  # noqa: BLE001 - record and continue; the sweep will show no motion
-        print(f"   (set_car_type(5) failed: {exc})")
-        lines.append(f"PHASE C: set_car_type(5) FAILED: {exc} — steering will not actuate")
+    except Exception as exc:  # noqa: BLE001 - without type 5 the servo can't move; abort the phase
+        print(f"   set_car_type(5) FAILED: {exc} — the servo will not actuate; skipping phase C.")
+        lines.append(f"PHASE C (steering↔angle): ABORTED — set_car_type(5) FAILED: {exc}")
+        lines.append("  (no sweep recorded; the AKM servo cannot actuate without car-type 5)")
+        return
 
     # Record the live centre default IF the getter is implemented. On this image
     # get_akm_default_angle returns the sentinel -1 (unimplemented) even with the

--- a/robot/r2_drive_calibration_results.txt
+++ b/robot/r2_drive_calibration_results.txt
@@ -1,0 +1,87 @@
+R2 DRIVE CALIBRATION RESULTS — Path-B Step 2 (measured, not invented)
+======================================================================
+
+Provenance: robot/r2_drive_calibration_elevated.py, run ELEVATED on the Yahboom
+R2 (Jetson Orin, hostname `yahboom`, cross-labeled X3 image / car-type 1).
+Channel map assumed (robot/motor_channel_probe_results.txt, PR #911):
+  set_motor s1=M1=REAR-LEFT(+fwd), s4=M4=REAR-RIGHT(+fwd); steering on AKM path.
+These feed the §5 gaps in docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md.
+
+STATUS: PARTIAL. Phase A captured in full; Phase B partial (ticks/rev only, no
+diameter); Phase C's servo-actuation MECHANISM confirmed but its protractor
+angles not yet measured; Phase D not measured. The floor-blocking gaps that
+remain are called out at the bottom.
+
+------------------------------------------------------------------
+PHASE A (PWM↔speed): both rear wheels driven together (M1=RL, M4=RR = +PWM)
+------------------------------------------------------------------
+  hold_per_rung_s = 1.5   (dt≈1.506 s each)
+
+  pwm   d_m1(ticks)  d_m4(ticks)  ticks/s_m1  ticks/s_m4  L/R_ratio(m1/m4)
+  15    892          1240         592.2       823.3       0.719
+  20    1222         1721         811.4       1142.8      0.710
+  25    1612         2242         1070.3      1488.6      0.719
+  30    2076         2853         1378.5      1894.4      0.728
+  35    2631         3479         1747.0      2310.0      0.756
+  40    4085         4115         2712.3      2732.2      0.993   <-- ANOMALOUS
+
+  Derived (least-squares intent, endpoints 15..35 — the +40 row is excluded as
+  a suspected encoder glitch / stiction release, see note):
+    M4 (rear-right): ticks/s ≈ 74.3 * PWM - 293   (deadband ~PWM 4)
+    M1 (rear-left):  ticks/s ≈ 57.7 * PWM - 274   (deadband ~PWM 5)
+    left/right slope ratio ≈ 0.78
+
+  NOTE: set_motor bypasses the firmware speed PID — this is an OPEN-LOOP map.
+  NOTE: the left rear reads ~28% fewer ticks/s than the right at equal PWM,
+        consistently across 15..35. The +40 row (M1 jumps 2631->4085 while M4
+        rises proportionately, ratio snaps to 0.99) is anomalous — discard it;
+        do not operate there.
+  CAVEAT: this ticks/s ratio conflates a TRUE speed mismatch with any difference
+        in the two encoders' ticks/rev. Only RL's ticks/rev was measured (Phase
+        B) — RR's is unknown, so the "28%" cannot yet be split into real drift
+        vs encoder-scale. Measure RR ticks/rev to resolve it. Either way, equal
+        PWM is NOT guaranteed straight → informs the §9 open-loop-vs-closed-loop
+        decision (v0 needs per-wheel trim or encoder speed-matching, not naive
+        equal PWM).
+
+------------------------------------------------------------------
+PHASE B (encoder scale): wheel=RL
+------------------------------------------------------------------
+  full_turns          = 2.0
+  delta_ticks (RL/m1) = 1669
+  ticks_per_rev       = 834.5   (single 2-turn sample)
+  wheel_diameter_m    = (NOT measured — m/s conversion pending)
+  => with a measured diameter D: m_per_tick = pi*D / 834.5, then Phase A ticks/s
+     becomes m/s and yields V_PER_PWM. STILL OPEN: RR ticks/rev + diameter.
+
+------------------------------------------------------------------
+PHASE C (steering↔angle): MECHANISM CONFIRMED, angles NOT yet measured
+------------------------------------------------------------------
+  REQUIRES car-type 5. The first run (type 1, default X3 image) saw NO servo
+  motion. After set_car_type(5) the front wheels swing as commanded — confirmed
+  on the bench (steering_cartype5_check.py). set_motor drive is car-type
+  independent, so type 5 is enabled only for the servo and restored to type 1 on
+  exit (the live set_car_motion consumer needs it). See §2a of the proposal.
+
+  get_akm_default_angle() = -1 BEFORE and AFTER set_car_type(5), WITH the servo
+  actuating → the getter is UNIMPLEMENTED on this image (a sentinel), NOT an
+  "AKM inactive" flag. The centre trim must come from the protractor sweep.
+
+  STILL OPEN (floor-blocking for turns): road-wheel angle at each command
+  [-45..+45] → K (command-units per radian), linearity, delta_max, and the
+  LEFT/RIGHT sign check (does a NEGATIVE command steer LEFT?).
+
+------------------------------------------------------------------
+PHASE D (geometry): NOT measured
+------------------------------------------------------------------
+  wheelbase_L_m  = (not measured; ~0.229 expected, re-confirm)
+  rear_track_t_m = (not measured; only needed if the Ackermann rear differential
+                    is chosen over equal-PWM v0)
+
+==================================================================
+REMAINING FLOOR-BLOCKING CAPTURES (next bench pass, elevated):
+  1. Phase B on RR (+ wheel diameter) — closes m/s AND resolves the real-vs-
+     encoder-scale question behind the ~28% L/R imbalance.
+  2. Phase C protractor sweep under car-type 5 — K, delta_max, sign check.
+  3. Phase D — tape-measured L and (if differential chosen) t.
+==================================================================

--- a/robot/r2_drive_calibration_results.txt
+++ b/robot/r2_drive_calibration_results.txt
@@ -50,9 +50,27 @@ PHASE B (encoder scale): wheel=RL
   full_turns          = 2.0
   delta_ticks (RL/m1) = 1669
   ticks_per_rev       = 834.5   (single 2-turn sample)
-  wheel_diameter_m    = (NOT measured — m/s conversion pending)
-  => with a measured diameter D: m_per_tick = pi*D / 834.5, then Phase A ticks/s
-     becomes m/s and yields V_PER_PWM. STILL OPEN: RR ticks/rev + diameter.
+  wheel_diameter      = 2 5/8 in = 66.675 mm = 0.066675 m  (measured with calipers)
+  wheel_circumf_m     = pi*D     = 0.209465 m
+  m_per_tick (RL)     = C/834.5  = 0.00025101 m/tick
+
+  DERIVED — left-channel (M1) ground speed = ticks/s * m_per_tick:
+    pwm   m/s (rear-left)
+    15    0.149
+    20    0.204
+    25    0.269
+    30    0.346
+    35    0.439
+    40    0.681   (anomalous row, excluded from the fit)
+    V_PER_PWM (left) ≈ 0.0145 (m/s)/PWM,  offset -0.069 m/s,  deadband ~PWM 4.7
+    (i.e. m/s ≈ 0.0145*PWM - 0.069 over 15..35; a governed 0.3 m/s -> ~27 PWM)
+
+  SCOPE: this m/s map is valid for the LEFT channel only — it uses RL's own
+  encoder scale. RR's m/s still needs RR's ticks/rev (Phase B on RR). Measuring
+  RR ALSO resolves whether the ~28% Phase-A L/R gap is real speed drift or an
+  encoder-scale difference — one capture closes both. If the two encoders prove
+  identical (same ticks/rev), the same m_per_tick applies to RR and the gap is
+  real motor drift (→ per-wheel PWM trim or closed loop, §9).
 
 ------------------------------------------------------------------
 PHASE C (steering↔angle): MECHANISM CONFIRMED, angles NOT yet measured

--- a/robot/steering_cartype5_check.py
+++ b/robot/steering_cartype5_check.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""steering_cartype5_check.py — confirm the R2 AKM servo actuates only under car-type 5.
+
+🔴 RUN ELEVATED — wheels off the ground, e-stop in hand. 🔴
+
+Path-B bench finding (PR #913 follow-up): set_akm_steering_angle drives the
+steering servo ONLY when the board is in car-type 5. The default cross-labeled X3
+image (car-type 1) silently ignores it — which is why the first drive-calibration
+run saw no servo motion. set_motor drive is car-type INDEPENDENT, so Path B sets
+car-type 5 for the servo and still drives via set_motor. (Car-type 5 breaks
+set_car_motion — which Path B never uses.)
+
+set_car_type(5) is RAM-volatile (reverts on reboot). The currently-live consumer
+still uses set_car_motion, so this restores car-type 1 on exit to avoid leaving
+the live drive path broken.
+
+Sole-writer discipline: STOP the KIRRA consumer first (it owns /dev/myserial):
+    sudo systemctl stop kirra-consumer   # or kill the consumer node
+    KIRRA_MOTOR_PORT=/dev/myserial python3 robot/steering_cartype5_check.py
+
+This ONLY confirms the servo mechanism + sign. It writes no kinematics and does
+not touch the consumer. Observe: do the front wheels swing, and does a NEGATIVE
+command steer LEFT?
+"""
+
+import os
+import sys
+import time
+
+
+def confirm(q):
+    return input(q + " [y/N] ").strip().lower() == "y"
+
+
+def main():
+    try:
+        from Rosmaster_Lib import Rosmaster
+    except Exception as exc:  # noqa: BLE001 - report and abort, never proceed
+        sys.exit(f"Rosmaster_Lib not importable: {exc}")
+
+    port = os.environ.get("KIRRA_MOTOR_PORT", "/dev/myserial")
+    if not confirm("Robot ELEVATED, wheels free, e-stop in hand?"):
+        sys.exit("Elevate first.")
+    if not confirm("KIRRA consumer STOPPED (it owns /dev/myserial)?"):
+        sys.exit("Stop the consumer first.")
+
+    try:
+        bot = Rosmaster(com=port)
+    except Exception as exc:  # noqa: BLE001
+        sys.exit(f"Could not open {port}: {exc} (device busy = consumer still holds it)")
+
+    try:
+        # -1 here is the unimplemented-getter sentinel on this image, NOT an
+        # AKM-inactive flag — the servo actuates under type 5 regardless.
+        print("AKM default angle BEFORE set_car_type(5):", bot.get_akm_default_angle())
+        bot.set_car_type(5)          # 5 = R2 / Ackermann — enables the AKM servo path
+        time.sleep(0.3)
+        print("AKM default angle AFTER  set_car_type(5):", bot.get_akm_default_angle())
+        bot.set_akm_steering_angle(0)
+        time.sleep(0.6)
+        for cmd in (-30, 0, 30, 0, -45, 0, 45, 0):
+            print(f"  set_akm_steering_angle({cmd:+d}) -- WATCH the front wheels")
+            bot.set_akm_steering_angle(cmd)
+            time.sleep(1.3)
+    finally:
+        try:
+            bot.set_akm_steering_angle(0)
+        except Exception:  # noqa: BLE001 - best-effort centre
+            pass
+        try:
+            bot.set_car_type(1)      # restore X3/type-1 so set_car_motion drive still works
+        except Exception:  # noqa: BLE001 - best-effort restore (reboot also restores it)
+            pass
+        print("\nSteering centred, car-type restored to 1 (reboot also restores it).")
+
+
+if __name__ == "__main__":
+    main()

--- a/robot/steering_cartype5_check.py
+++ b/robot/steering_cartype5_check.py
@@ -50,6 +50,15 @@ def main():
         sys.exit(f"Could not open {port}: {exc} (device busy = consumer still holds it)")
 
     try:
+        # Board reads (get_*) only reflect MCU report frames once the vendor
+        # receive thread + auto-report are running; without them a getter can
+        # read stale/None. Start them before any read so the -1 observation is
+        # a real board response, not an unstarted-thread artifact.
+        bot.create_receive_threading()
+        time.sleep(0.1)
+        bot.set_auto_report_state(True)
+        time.sleep(0.2)
+
         # -1 here is the unimplemented-getter sentinel on this image, NOT an
         # AKM-inactive flag — the servo actuates under type 5 regardless.
         print("AKM default angle BEFORE set_car_type(5):", bot.get_akm_default_angle())


### PR DESCRIPTION
## What

Records the first on-bench R2 drive-calibration numbers and a decisive steering finding, and folds both into the tooling and the Path-B proposal. **No drive code is wired; no safety claim; talisman untouched.**

## The steering finding (the headline)

The first calibration run reported *"steering wheels did not move."* Cause, confirmed on the bench: **the AKM steering servo only actuates under car-type 5.** The default cross-labeled X3 image (car-type 1) silently ignores `set_akm_steering_angle`. After `set_car_type(5)` the front wheels swing as commanded.

This is not a Path-B problem — it's *why Path B works*:
- `set_motor` drive is **car-type independent** (the +15…+40 sweep ran fine under type 1).
- Type 5 is known to break `set_car_motion` — which **Path B never uses**.
- So the Path-B trio is: `set_car_type(5)` (servo on) + `set_motor(+v,0,0,+v)` (drive, any type) + `set_akm_steering_angle(cmd)` (steer).
- `get_akm_default_angle()` returns the sentinel **−1** *even with the servo actuating* → it's an unimplemented getter, **not** an inactive flag. Centre trim must come from the protractor sweep.
- `set_car_type` is RAM-volatile, and the *live* consumer still uses `set_car_motion`, so any bench tool that sets type 5 **restores type 1 on exit**.

## Captured data (`r2_drive_calibration_results.txt`, partial)

- **Phase A — PWM↔ticks/s** captured in full. Both channels affine in PWM (deadband ~PWM 4–5): M4 ≈ 74.3·PWM−293, M1 ≈ 57.7·PWM−274. **Consistent ~28% left/right imbalance** (ratio ~0.72 across 15–35) → equal PWM is *not* guaranteed straight. Caveat recorded: that ratio conflates true drift with the **unmeasured RR encoder scale**, so it can't yet be split. The **+40 row is flagged anomalous** (M1 jumps disproportionately) and excluded.
- **Phase B** — rear-left = **834.5 ticks/rev** (one 2-turn sample); wheel diameter pending.
- **Phase C** — mechanism confirmed (above); protractor angles / K / δ_max / sign still to measure.
- **Phase D** — geometry not yet measured.

## Changes

- `robot/r2_drive_calibration_elevated.py` — Phase C now enables car-type 5 before the sweep and restores type 1 on every exit path; the −1 default is recorded as "getter unimplemented", not treated as state.
- `robot/steering_cartype5_check.py` — the small elevated diagnostic that confirmed the mechanism; also the sign-check tool (does a negative command steer left?).
- `robot/r2_drive_calibration_results.txt` — the captured record + remaining floor-blocking gaps.
- `docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md` — new §2a (car-type-5 requirement); §5/§6/§7 updated (centre trim from the sweep not the −1 getter; consumer sets type 5 once at init, never calls `set_car_motion`).

## Still open (next bench pass, informs §9 sign-off)

1. Phase B on **RR** + wheel **diameter** — closes m/s *and* resolves the real-drift-vs-encoder-scale question behind the 28% imbalance.
2. Phase C **protractor sweep under car-type 5** — K, δ_max, and the left/right sign.
3. Phase D — tape-measured L (+ track t if the Ackermann differential is chosen).

🔴 **Human review; do not merge.** Robot-only + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_