### PR TITLE
ADR-0035 Stage 2 (part 1): credential/identity-registry storage-trait seams

### DIFF
--- a/src/verifier_store/cert_principals.rs
+++ b/src/verifier_store/cert_principals.rs
@@ -150,6 +150,362 @@ impl VerifierStore {
     }
 }
 
+// ---------------------------------------------------------------------------
+// ADR-0035 Stage 2 (trait-seam inversion) — the cert-principal storage trait
+//
+// The mTLS cert-principal registry CRUD, lifted off `VerifierStore` as another
+// `VerifierStorage`-family seam. Richer than `PrincipalStore`/`OperatorStore`
+// because a cert carries an EXPIRY and the registry enforces two domain failure
+// modes the portable contract must preserve on EVERY backend:
+//   1. one fingerprint pins to at most one principal (the `UNIQUE(cert_sha256)`
+//      column — pinning a fingerprint under a DIFFERENT id must ERROR);
+//   2. an expiry beyond `i64::MAX` is REFUSED, never truncated (Copilot #857 —
+//      a signed-64-bit store would wrap it to a fail-OPEN "never expires").
+// So the in-memory backend's `Error` is a real enum (not `Infallible`), and the
+// conformance suite exercises both failure modes against both backends. Inherent
+// methods win resolution → the SQLite impl delegates without recursion.
+// ---------------------------------------------------------------------------
+
+/// The cert-principal registry storage contract — register/rotate/renew a cert pin
+/// (SHA-256 leaf fingerprint + role + optional X.509 notAfter), revoke it, resolve
+/// by fingerprint, and list. Only the fingerprint is stored, never the cert bytes.
+pub trait CertPrincipalStore {
+    /// Backend error type (SQLite: `rusqlite::Error`; in-memory: [`InMemCertError`]).
+    type Error;
+
+    /// Register / rotate / renew a cert principal by `principal_id`: overwrite the
+    /// fingerprint + role + expiry and CLEAR revocation. Errors if `cert_sha256` is
+    /// already pinned to a DIFFERENT principal, or if `not_after_ms` exceeds
+    /// `i64::MAX` (refused, not truncated — fail-closed expiry).
+    fn register_cert_principal(
+        &mut self,
+        principal_id: &str,
+        cert_sha256: &str,
+        role: &str,
+        not_after_ms: Option<u64>,
+        now_ms: u64,
+    ) -> std::result::Result<(), Self::Error>;
+
+    /// Revoke a cert principal. Returns `true` iff an ACTIVE principal transitioned;
+    /// `false` if absent or already revoked.
+    fn revoke_cert_principal(
+        &mut self,
+        principal_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<bool, Self::Error>;
+
+    /// Resolve the record whose CURRENT fingerprint equals `cert_sha256` (active OR
+    /// revoked OR expired — the caller fail-closes via `is_valid_at`), or `None`.
+    fn load_cert_principal_by_fingerprint(
+        &self,
+        cert_sha256: &str,
+    ) -> std::result::Result<Option<CertPrincipalRecord>, Self::Error>;
+
+    /// List every registered cert principal, ordered by `principal_id`.
+    fn load_cert_principals(&self) -> std::result::Result<Vec<CertPrincipalRecord>, Self::Error>;
+}
+
+/// The production SQLite backend: delegates to the inherent `VerifierStore` methods
+/// over the `cert_principals` table (which enforce the same two failure modes — the
+/// `UNIQUE(cert_sha256)` constraint and the checked `i64::try_from` on the expiry).
+impl CertPrincipalStore for VerifierStore {
+    type Error = rusqlite::Error;
+
+    fn register_cert_principal(
+        &mut self,
+        principal_id: &str,
+        cert_sha256: &str,
+        role: &str,
+        not_after_ms: Option<u64>,
+        now_ms: u64,
+    ) -> Result<()> {
+        self.register_cert_principal(principal_id, cert_sha256, role, not_after_ms, now_ms)
+    }
+    fn revoke_cert_principal(&mut self, principal_id: &str, now_ms: u64) -> Result<bool> {
+        self.revoke_cert_principal(principal_id, now_ms)
+    }
+    fn load_cert_principal_by_fingerprint(
+        &self,
+        cert_sha256: &str,
+    ) -> Result<Option<CertPrincipalRecord>> {
+        self.load_cert_principal_by_fingerprint(cert_sha256)
+    }
+    fn load_cert_principals(&self) -> Result<Vec<CertPrincipalRecord>> {
+        self.load_cert_principals()
+    }
+}
+
+/// The failure modes of the in-memory [`CertPrincipalStore`] backend — the two the
+/// portable contract preserves across every backend (the SQLite backend surfaces
+/// the same conditions as a `rusqlite::Error`).
+#[derive(Debug, PartialEq, Eq)]
+pub enum InMemCertError {
+    /// `cert_sha256` is already pinned to a DIFFERENT principal (the `UNIQUE`
+    /// column) — one certificate authorizes at most one principal.
+    FingerprintConflict,
+    /// `not_after_ms` exceeds `i64::MAX`; refused rather than truncated to a
+    /// fail-OPEN "never expires" (Copilot #857).
+    ExpiryOverflow,
+}
+
+/// The in-memory [`CertPrincipalStore`] backend — a portability-proof reference
+/// modelling the `cert_principals` table as a map keyed by `principal_id`, each row
+/// carrying the CURRENT fingerprint + role + timestamps + optional expiry. Realizes
+/// the SAME register/rotate/renew/revoke/resolve semantics — INCLUDING the unique-
+/// fingerprint and expiry-overflow refusals — WITHOUT a database. Single-process.
+#[derive(Debug, Default)]
+pub struct InMemoryCertPrincipalStore {
+    rows: std::collections::HashMap<String, InMemoryCertRow>,
+}
+
+#[derive(Debug, Clone)]
+struct InMemoryCertRow {
+    cert_sha256: String,
+    role: String,
+    created_at_ms: u64,
+    revoked_at_ms: Option<u64>,
+    not_after_ms: Option<u64>,
+}
+
+impl InMemoryCertRow {
+    fn to_record(&self, principal_id: &str) -> CertPrincipalRecord {
+        CertPrincipalRecord {
+            principal_id: principal_id.to_string(),
+            role: self.role.clone(),
+            created_at_ms: self.created_at_ms,
+            revoked_at_ms: self.revoked_at_ms,
+            not_after_ms: self.not_after_ms,
+        }
+    }
+}
+
+impl CertPrincipalStore for InMemoryCertPrincipalStore {
+    type Error = InMemCertError;
+
+    fn register_cert_principal(
+        &mut self,
+        principal_id: &str,
+        cert_sha256: &str,
+        role: &str,
+        not_after_ms: Option<u64>,
+        now_ms: u64,
+    ) -> std::result::Result<(), InMemCertError> {
+        // (2) Expiry beyond i64::MAX is refused (mirrors the checked SQLite write) —
+        // BEFORE any mutation, so a refused registration persists nothing.
+        if let Some(v) = not_after_ms {
+            if i64::try_from(v).is_err() {
+                return Err(InMemCertError::ExpiryOverflow);
+            }
+        }
+        // (1) UNIQUE(cert_sha256): the fingerprint may already be pinned only to the
+        // SAME principal (an idempotent rotate); a DIFFERENT id is a conflict.
+        if let Some((holder, _)) = self.rows.iter().find(|(_, r)| r.cert_sha256 == cert_sha256) {
+            if holder != principal_id {
+                return Err(InMemCertError::FingerprintConflict);
+            }
+        }
+        // Upsert by principal_id; rotation overwrites fp/role/expiry and CLEARS
+        // revocation — matching the SQLite `ON CONFLICT … SET … revoked_at_ms = NULL`.
+        self.rows.insert(
+            principal_id.to_string(),
+            InMemoryCertRow {
+                cert_sha256: cert_sha256.to_string(),
+                role: role.to_string(),
+                created_at_ms: now_ms,
+                revoked_at_ms: None,
+                not_after_ms,
+            },
+        );
+        Ok(())
+    }
+
+    fn revoke_cert_principal(
+        &mut self,
+        principal_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<bool, InMemCertError> {
+        match self.rows.get_mut(principal_id) {
+            Some(row) if row.revoked_at_ms.is_none() => {
+                row.revoked_at_ms = Some(now_ms);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn load_cert_principal_by_fingerprint(
+        &self,
+        cert_sha256: &str,
+    ) -> std::result::Result<Option<CertPrincipalRecord>, InMemCertError> {
+        Ok(self
+            .rows
+            .iter()
+            .find(|(_, row)| row.cert_sha256 == cert_sha256)
+            .map(|(id, row)| row.to_record(id)))
+    }
+
+    fn load_cert_principals(
+        &self,
+    ) -> std::result::Result<Vec<CertPrincipalRecord>, InMemCertError> {
+        let mut out: Vec<CertPrincipalRecord> = self
+            .rows
+            .iter()
+            .map(|(id, row)| row.to_record(id))
+            .collect();
+        out.sort_by(|a, b| a.principal_id.cmp(&b.principal_id));
+        Ok(out)
+    }
+}
+
+/// The cert-principal registry contract, driven through the [`CertPrincipalStore`]
+/// trait so it runs IDENTICALLY against every backend: empty read, register→resolve,
+/// expiry validity boundaries (inclusive notAfter) + untracked-never-expires,
+/// rotation (old fp stops resolving, revocation clears), revoke idempotence +
+/// resolves-while-revoked, the UNIQUE-fingerprint conflict (same fp / different id
+/// errors; same id re-pins), the expiry-overflow refusal (persists nothing), and
+/// the ordered listing.
+///
+/// `pub` (not `#[cfg(test)]`) — the shared backend-conformance suite, run below
+/// against the SQLite and in-memory backends. Panics on violation; call from a test.
+/// PRECONDITION: `store` must start empty.
+pub fn assert_cert_principal_store_contract<S: CertPrincipalStore>(store: &mut S)
+where
+    S::Error: core::fmt::Debug,
+{
+    // Empty registry.
+    assert!(store
+        .load_cert_principal_by_fingerprint("nope")
+        .unwrap()
+        .is_none());
+    assert!(store.load_cert_principals().unwrap().is_empty());
+
+    // Register + resolve (id + role, active).
+    store
+        .register_cert_principal("svc-a", "fp-a", "integrator", None, 1_000)
+        .unwrap();
+    let rec = store
+        .load_cert_principal_by_fingerprint("fp-a")
+        .unwrap()
+        .expect("svc-a present");
+    assert_eq!(rec.principal_id, "svc-a");
+    assert_eq!(rec.role, "integrator");
+    assert!(rec.is_active());
+    assert!(!rec.is_expired(u64::MAX), "untracked expiry never ages out");
+
+    // Expiry validity boundaries (inclusive notAfter).
+    store
+        .register_cert_principal("svc-exp", "fp-exp", "integrator", Some(5_000), 1_000)
+        .unwrap();
+    let exp = store
+        .load_cert_principal_by_fingerprint("fp-exp")
+        .unwrap()
+        .unwrap();
+    assert_eq!(exp.not_after_ms, Some(5_000));
+    assert!(exp.is_valid_at(4_999), "before notAfter → valid");
+    assert!(!exp.is_valid_at(5_000), "notAfter is inclusive → expired");
+    assert!(exp.is_expired(5_000) && !exp.is_expired(4_999));
+
+    // Revoke transitions once then no-op; the OLD fp still resolves the revoked row.
+    assert!(
+        store.revoke_cert_principal("svc-a", 2_000).unwrap(),
+        "first revoke transitions"
+    );
+    assert!(
+        !store.revoke_cert_principal("svc-a", 3_000).unwrap(),
+        "second revoke is a no-op"
+    );
+    assert!(
+        !store.revoke_cert_principal("absent", 3_000).unwrap(),
+        "absent → false"
+    );
+    assert!(store
+        .load_cert_principal_by_fingerprint("fp-a")
+        .unwrap()
+        .expect("resolves while revoked")
+        .revoked_at_ms
+        .is_some());
+
+    // Rotation overwrites the fingerprint + role and reactivates; old fp drops.
+    store
+        .register_cert_principal("svc-a", "fp-a2", "auditor", None, 4_000)
+        .unwrap();
+    assert!(
+        store
+            .load_cert_principal_by_fingerprint("fp-a")
+            .unwrap()
+            .is_none(),
+        "the rotated-out fingerprint no longer resolves"
+    );
+    let rotated = store
+        .load_cert_principal_by_fingerprint("fp-a2")
+        .unwrap()
+        .unwrap();
+    assert_eq!(rotated.role, "auditor");
+    assert!(rotated.is_active());
+
+    // (1) UNIQUE fingerprint: the same fp under a DIFFERENT principal errors; the
+    // SAME principal re-pinning it is an idempotent rotate.
+    assert!(
+        store
+            .register_cert_principal("svc-other", "fp-a2", "operator", None, 5_000)
+            .is_err(),
+        "a second principal on the same fingerprint must conflict"
+    );
+    assert!(
+        store
+            .load_cert_principal_by_fingerprint("fp-a2")
+            .unwrap()
+            .expect("still the original holder")
+            .principal_id
+            == "svc-a",
+        "the conflicting registration persisted nothing"
+    );
+    assert!(
+        store
+            .register_cert_principal("svc-a", "fp-a2", "operator", None, 6_000)
+            .is_ok(),
+        "same principal re-pinning the same fingerprint is fine"
+    );
+
+    // (2) Expiry beyond i64::MAX is refused, not truncated; nothing persists.
+    assert!(
+        store
+            .register_cert_principal("svc-of", "fp-of", "integrator", Some(u64::MAX), 7_000)
+            .is_err(),
+        "expiry beyond i64::MAX must be refused"
+    );
+    assert!(
+        store
+            .load_cert_principal_by_fingerprint("fp-of")
+            .unwrap()
+            .is_none(),
+        "the refused registration persisted nothing"
+    );
+    // The largest representable value is accepted.
+    store
+        .register_cert_principal(
+            "svc-max",
+            "fp-max",
+            "integrator",
+            Some(i64::MAX as u64),
+            7_000,
+        )
+        .unwrap();
+
+    // Ordered listing by principal_id.
+    let ids: Vec<String> = store
+        .load_cert_principals()
+        .unwrap()
+        .into_iter()
+        .map(|p| p.principal_id)
+        .collect();
+    assert_eq!(
+        ids,
+        ["svc-a", "svc-exp", "svc-max"],
+        "listing ordered by principal_id"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use crate::verifier_store::VerifierStore;
@@ -425,5 +781,21 @@ mod tests {
             "only 'soon' is inside the 1s warn window"
         );
         assert_eq!(sum.no_expiry, 1, "'forever' has no tracked expiry");
+    }
+}
+
+#[cfg(test)]
+mod cert_principal_store_contract_tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_backend_satisfies_the_cert_principal_store_contract() {
+        let mut store = VerifierStore::new(":memory:").expect("in-memory store");
+        assert_cert_principal_store_contract(&mut store);
+    }
+
+    #[test]
+    fn in_memory_backend_satisfies_the_cert_principal_store_contract() {
+        assert_cert_principal_store_contract(&mut InMemoryCertPrincipalStore::default());
     }
 }

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -593,6 +593,10 @@ mod operators;
 mod ota_campaigns;
 mod posture;
 mod principals;
+// ADR-0035 Stage 2 (trait-seam inversion) — the API-principal storage trait + its
+// in-memory reference backend (the 3rd VerifierStorage-family seam after EpochFence
+// and NodeStore), extending the seam program toward the persistence/authority split.
+pub use principals::{assert_principal_store_contract, InMemoryPrincipalStore, PrincipalStore};
 // WP-18 3/3 (G-9 store half) — the backend-portable HA epoch-fence trait + its
 // in-memory reference backend (SQLite realizes it via `ha_state` + BEGIN IMMEDIATE,
 // a future Postgres backend via SELECT … FOR UPDATE).

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -607,7 +607,9 @@ mod principals;
 // ADR-0035 Stage 2 (trait-seam inversion) — the API-principal storage trait + its
 // in-memory reference backend (the 3rd VerifierStorage-family seam after EpochFence
 // and NodeStore), extending the seam program toward the persistence/authority split.
-pub use principals::{assert_principal_store_contract, InMemoryPrincipalStore, PrincipalStore};
+pub use principals::{
+    assert_principal_store_contract, InMemPrincipalError, InMemoryPrincipalStore, PrincipalStore,
+};
 // WP-18 3/3 (G-9 store half) — the backend-portable HA epoch-fence trait + its
 // in-memory reference backend (SQLite realizes it via `ha_state` + BEGIN IMMEDIATE,
 // a future Postgres backend via SELECT … FOR UPDATE).

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -587,9 +587,20 @@ mod attestation;
 mod audit;
 mod av_subsystem;
 mod cert_principals;
+// ADR-0035 Stage 2 (trait-seam inversion) — the cert-principal storage trait + its
+// in-memory reference backend (a richer seam: models the UNIQUE-fingerprint conflict
+// and the fail-closed expiry-overflow refusal as portable contract failure modes).
+pub use cert_principals::{
+    assert_cert_principal_store_contract, CertPrincipalStore, InMemCertError,
+    InMemoryCertPrincipalStore,
+};
 mod epoch;
 mod federation;
 mod operators;
+// ADR-0035 Stage 2 (trait-seam inversion) — the operator-registry storage trait + its
+// in-memory reference backend (registry CRUD only; the audit-chained clearance-grant
+// methods stay inherent, belonging to the harder persistence tier).
+pub use operators::{assert_operator_store_contract, InMemoryOperatorStore, OperatorStore};
 mod ota_campaigns;
 mod posture;
 mod principals;

--- a/src/verifier_store/operators.rs
+++ b/src/verifier_store/operators.rs
@@ -269,3 +269,234 @@ impl VerifierStore {
             .optional()
     }
 }
+
+// ---------------------------------------------------------------------------
+// ADR-0035 Stage 2 (trait-seam inversion) — the operator-registry storage trait
+//
+// The operator IDENTITY registry CRUD (register/rotate the Ed25519 PUBLIC key,
+// revoke, load, list), lifted off `VerifierStore` as a `VerifierStorage`-family
+// seam like `NodeStore` / `PrincipalStore`. Scope is deliberately JUST the
+// operator registry — the clearance-GRANT methods above stay inherent-only
+// because they are audit-chained (they append signed `AuditChainLinker` events),
+// a coupling that belongs to the harder persistence tier, not a portable CRUD
+// seam. Inherent methods win resolution, so the SQLite impl delegates via
+// `self.method()` without recursion and every existing caller is untouched.
+// ---------------------------------------------------------------------------
+
+/// The operator-registry storage contract — register/rotate an operator's Ed25519
+/// PUBLIC key, revoke it, load one by id / list all. Backend-agnostic identity CRUD
+/// (only the PUBLIC key is ever stored). Mirrors [`super::NodeStore`].
+pub trait OperatorStore {
+    /// Backend error type (SQLite: `rusqlite::Error`; in-memory: [`std::convert::Infallible`]).
+    type Error;
+
+    /// Register or rotate an operator by `operator_id`: overwrite the public key and
+    /// CLEAR any prior revocation (a fresh key reactivates an operator).
+    fn register_operator(
+        &mut self,
+        operator_id: &str,
+        pubkey_pem: &str,
+        now_ms: u64,
+    ) -> std::result::Result<(), Self::Error>;
+
+    /// Revoke an operator. Returns `true` iff an ACTIVE operator transitioned to
+    /// revoked; `false` if absent or already revoked.
+    fn revoke_operator(
+        &mut self,
+        operator_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<bool, Self::Error>;
+
+    /// Load one operator by id (active or revoked), or `None` if unregistered.
+    fn load_operator(
+        &self,
+        operator_id: &str,
+    ) -> std::result::Result<Option<OperatorRecord>, Self::Error>;
+
+    /// List every registered operator, ordered by `operator_id`.
+    fn load_operators(&self) -> std::result::Result<Vec<OperatorRecord>, Self::Error>;
+}
+
+/// The production SQLite backend: delegates to the inherent `VerifierStore` methods
+/// over the `operators` table. `self.method()` resolves to the INHERENT method
+/// (inherent wins), so this is delegation, not recursion.
+impl OperatorStore for VerifierStore {
+    type Error = rusqlite::Error;
+
+    fn register_operator(
+        &mut self,
+        operator_id: &str,
+        pubkey_pem: &str,
+        now_ms: u64,
+    ) -> Result<()> {
+        self.register_operator(operator_id, pubkey_pem, now_ms)
+    }
+    fn revoke_operator(&mut self, operator_id: &str, now_ms: u64) -> Result<bool> {
+        self.revoke_operator(operator_id, now_ms)
+    }
+    fn load_operator(&self, operator_id: &str) -> Result<Option<OperatorRecord>> {
+        self.load_operator(operator_id)
+    }
+    fn load_operators(&self) -> Result<Vec<OperatorRecord>> {
+        self.load_operators()
+    }
+}
+
+/// The in-memory [`OperatorStore`] backend — a portability-proof reference modelling
+/// the `operators` table as a map keyed by `operator_id`. Realizes the SAME
+/// register/rotate/revoke/load semantics WITHOUT a database. Single-process.
+#[derive(Debug, Default)]
+pub struct InMemoryOperatorStore {
+    rows: std::collections::HashMap<String, InMemoryOperatorRow>,
+}
+
+#[derive(Debug, Clone)]
+struct InMemoryOperatorRow {
+    pubkey_pem: String,
+    registered_at_ms: u64,
+    revoked_at_ms: Option<u64>,
+}
+
+impl InMemoryOperatorRow {
+    fn to_record(&self, operator_id: &str) -> OperatorRecord {
+        OperatorRecord {
+            operator_id: operator_id.to_string(),
+            pubkey_pem: self.pubkey_pem.clone(),
+            registered_at_ms: self.registered_at_ms,
+            revoked_at_ms: self.revoked_at_ms,
+        }
+    }
+}
+
+impl OperatorStore for InMemoryOperatorStore {
+    type Error = std::convert::Infallible;
+
+    fn register_operator(
+        &mut self,
+        operator_id: &str,
+        pubkey_pem: &str,
+        now_ms: u64,
+    ) -> std::result::Result<(), std::convert::Infallible> {
+        // Upsert by id; rotation overwrites the key and CLEARS revocation —
+        // matching the SQLite `ON CONFLICT … SET … revoked_at_ms = NULL`.
+        self.rows.insert(
+            operator_id.to_string(),
+            InMemoryOperatorRow {
+                pubkey_pem: pubkey_pem.to_string(),
+                registered_at_ms: now_ms,
+                revoked_at_ms: None,
+            },
+        );
+        Ok(())
+    }
+
+    fn revoke_operator(
+        &mut self,
+        operator_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<bool, std::convert::Infallible> {
+        match self.rows.get_mut(operator_id) {
+            Some(row) if row.revoked_at_ms.is_none() => {
+                row.revoked_at_ms = Some(now_ms);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn load_operator(
+        &self,
+        operator_id: &str,
+    ) -> std::result::Result<Option<OperatorRecord>, std::convert::Infallible> {
+        Ok(self
+            .rows
+            .get(operator_id)
+            .map(|row| row.to_record(operator_id)))
+    }
+
+    fn load_operators(&self) -> std::result::Result<Vec<OperatorRecord>, std::convert::Infallible> {
+        let mut out: Vec<OperatorRecord> = self
+            .rows
+            .iter()
+            .map(|(id, row)| row.to_record(id))
+            .collect();
+        out.sort_by(|a, b| a.operator_id.cmp(&b.operator_id));
+        Ok(out)
+    }
+}
+
+/// The operator-registry contract, driven through the [`OperatorStore`] trait so it
+/// runs IDENTICALLY against every backend: empty read, register→load roundtrip (id +
+/// key + active), rotation (key overwrites, revocation clears), revoke idempotence +
+/// reports the transition + loads-while-revoked, and the ordered listing.
+///
+/// `pub` (not `#[cfg(test)]`) by design — the shared backend-conformance suite, run
+/// below against the SQLite and in-memory backends. Panics on violation; call from a
+/// test. PRECONDITION: `store` must start empty.
+pub fn assert_operator_store_contract<S: OperatorStore>(store: &mut S)
+where
+    S::Error: core::fmt::Debug,
+{
+    // Empty registry.
+    assert!(store.load_operator("op-a").unwrap().is_none());
+    assert!(store.load_operators().unwrap().is_empty());
+
+    // Register + load (id + key preserved, active).
+    store.register_operator("op-a", "PEM-A", 1_000).unwrap();
+    let rec = store.load_operator("op-a").unwrap().expect("op-a present");
+    assert_eq!(rec.operator_id, "op-a");
+    assert_eq!(rec.pubkey_pem, "PEM-A");
+    assert!(rec.is_active());
+
+    // Revoke transitions once, then no-op; the record still loads while revoked.
+    assert!(
+        store.revoke_operator("op-a", 2_000).unwrap(),
+        "first revoke transitions"
+    );
+    assert!(
+        !store.revoke_operator("op-a", 3_000).unwrap(),
+        "second revoke is a no-op"
+    );
+    assert!(
+        !store.revoke_operator("absent", 3_000).unwrap(),
+        "absent operator → false"
+    );
+    assert!(store
+        .load_operator("op-a")
+        .unwrap()
+        .expect("loads while revoked")
+        .revoked_at_ms
+        .is_some());
+
+    // Rotation overwrites the key and reactivates.
+    store.register_operator("op-a", "PEM-A2", 4_000).unwrap();
+    let rotated = store.load_operator("op-a").unwrap().unwrap();
+    assert_eq!(rotated.pubkey_pem, "PEM-A2");
+    assert!(rotated.is_active(), "rotation clears revocation");
+
+    // A second operator; listing is ordered by id.
+    store.register_operator("op-b", "PEM-B", 5_000).unwrap();
+    let ids: Vec<String> = store
+        .load_operators()
+        .unwrap()
+        .into_iter()
+        .map(|o| o.operator_id)
+        .collect();
+    assert_eq!(ids, ["op-a", "op-b"], "listing ordered by operator_id");
+}
+
+#[cfg(test)]
+mod operator_store_contract_tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_backend_satisfies_the_operator_store_contract() {
+        let mut store = VerifierStore::new(":memory:").expect("in-memory store");
+        assert_operator_store_contract(&mut store);
+    }
+
+    #[test]
+    fn in_memory_backend_satisfies_the_operator_store_contract() {
+        assert_operator_store_contract(&mut InMemoryOperatorStore::default());
+    }
+}

--- a/src/verifier_store/principals.rs
+++ b/src/verifier_store/principals.rs
@@ -95,9 +95,13 @@ impl VerifierStore {
 // the contract is genuinely backend-portable.
 //
 // The two writers are `&mut self` (mirroring the inherent signatures verbatim —
-// this is a pure ADDITIVE seam, no inherent change), so the in-memory backend
-// needs no interior mutability and the conformance driver takes `&mut S`. That's
-// the one honest shape difference from `NodeStore` (whose `save_node` is `&self`).
+// this is a pure ADDITIVE seam, no inherent change), so the conformance driver
+// takes `&mut S` (the one honest shape difference from `NodeStore`'s `&self`
+// `save_node`). The registry also enforces one domain failure mode the portable
+// contract must preserve on EVERY backend: `token_sha256` is `UNIQUE` (one token
+// hash pins to at most one principal), so registering a hash already held by a
+// DIFFERENT principal must ERROR — hence the in-memory backend's `Error` is a
+// real enum ([`InMemPrincipalError`]), not `Infallible` (matching `CertPrincipalStore`).
 // ---------------------------------------------------------------------------
 
 /// The API-principal registry storage contract — register/rotate a per-principal
@@ -105,11 +109,13 @@ impl VerifierStore {
 /// by token hash, and list all principals. Backend-agnostic; only ever holds the
 /// token HASH, never plaintext.
 pub trait PrincipalStore {
-    /// Backend error type (SQLite: `rusqlite::Error`; in-memory: [`std::convert::Infallible`]).
+    /// Backend error type (SQLite: `rusqlite::Error`; in-memory: [`InMemPrincipalError`]).
     type Error;
 
     /// Register or rotate a principal by `principal_id`: overwrite the token hash +
     /// role and CLEAR any prior revocation (a fresh token reactivates a principal).
+    /// Errors if `token_sha256` is already held by a DIFFERENT principal (the
+    /// `UNIQUE(token_sha256)` constraint — one token authorizes one principal).
     fn register_api_principal(
         &mut self,
         principal_id: &str,
@@ -166,10 +172,22 @@ impl PrincipalStore for VerifierStore {
     }
 }
 
+/// The failure mode of the in-memory [`PrincipalStore`] backend — the one the
+/// portable contract preserves across every backend (the SQLite backend surfaces
+/// the same condition as a `rusqlite::Error` from the `UNIQUE(token_sha256)`
+/// constraint).
+#[derive(Debug, PartialEq, Eq)]
+pub enum InMemPrincipalError {
+    /// `token_sha256` is already held by a DIFFERENT principal (the `UNIQUE`
+    /// column) — one token hash authorizes at most one principal.
+    TokenHashConflict,
+}
+
 /// The in-memory [`PrincipalStore`] backend — a portability-proof reference
 /// modelling the `api_principals` table as a map keyed by `principal_id`, each
 /// row carrying the CURRENT token hash + role + timestamps. Realizes the SAME
-/// register/rotate/revoke/resolve semantics WITHOUT a database. Single-process.
+/// register/rotate/revoke/resolve semantics — INCLUDING the unique-token-hash
+/// refusal — WITHOUT a database. Single-process.
 #[derive(Debug, Default)]
 pub struct InMemoryPrincipalStore {
     rows: std::collections::HashMap<String, InMemoryPrincipalRow>,
@@ -195,7 +213,7 @@ impl InMemoryPrincipalRow {
 }
 
 impl PrincipalStore for InMemoryPrincipalStore {
-    type Error = std::convert::Infallible;
+    type Error = InMemPrincipalError;
 
     fn register_api_principal(
         &mut self,
@@ -203,7 +221,19 @@ impl PrincipalStore for InMemoryPrincipalStore {
         token_sha256: &str,
         role: &str,
         now_ms: u64,
-    ) -> std::result::Result<(), std::convert::Infallible> {
+    ) -> std::result::Result<(), InMemPrincipalError> {
+        // UNIQUE(token_sha256): the hash may already be held only by the SAME
+        // principal (an idempotent re-register); a DIFFERENT id is a conflict, and
+        // is rejected BEFORE any mutation so a refused registration persists nothing.
+        if let Some((holder, _)) = self
+            .rows
+            .iter()
+            .find(|(_, r)| r.token_sha256 == token_sha256)
+        {
+            if holder != principal_id {
+                return Err(InMemPrincipalError::TokenHashConflict);
+            }
+        }
         // Upsert by principal_id; rotation overwrites the hash/role and CLEARS
         // revocation — matching the SQLite `ON CONFLICT … SET … revoked_at_ms = NULL`.
         self.rows.insert(
@@ -222,7 +252,7 @@ impl PrincipalStore for InMemoryPrincipalStore {
         &mut self,
         principal_id: &str,
         now_ms: u64,
-    ) -> std::result::Result<bool, std::convert::Infallible> {
+    ) -> std::result::Result<bool, InMemPrincipalError> {
         match self.rows.get_mut(principal_id) {
             Some(row) if row.revoked_at_ms.is_none() => {
                 row.revoked_at_ms = Some(now_ms);
@@ -236,7 +266,7 @@ impl PrincipalStore for InMemoryPrincipalStore {
     fn load_api_principal_by_token_hash(
         &self,
         token_sha256: &str,
-    ) -> std::result::Result<Option<ApiPrincipalRecord>, std::convert::Infallible> {
+    ) -> std::result::Result<Option<ApiPrincipalRecord>, InMemPrincipalError> {
         Ok(self
             .rows
             .iter()
@@ -246,7 +276,7 @@ impl PrincipalStore for InMemoryPrincipalStore {
 
     fn load_api_principals(
         &self,
-    ) -> std::result::Result<Vec<ApiPrincipalRecord>, std::convert::Infallible> {
+    ) -> std::result::Result<Vec<ApiPrincipalRecord>, InMemPrincipalError> {
         let mut out: Vec<ApiPrincipalRecord> = self
             .rows
             .iter()
@@ -336,6 +366,38 @@ where
     store
         .register_api_principal("svc-b", "hash-b", "operator", 5_000)
         .unwrap();
+
+    // UNIQUE(token_sha256): the same hash under a DIFFERENT principal errors and
+    // persists nothing; the SAME principal re-registering its own hash is fine.
+    assert!(
+        store
+            .register_api_principal("svc-c", "hash-b", "operator", 6_000)
+            .is_err(),
+        "a second principal on the same token hash must conflict"
+    );
+    assert!(
+        store
+            .load_api_principal_by_token_hash("hash-b")
+            .unwrap()
+            .expect("still the original holder")
+            .principal_id
+            == "svc-b",
+        "the conflicting registration persisted nothing"
+    );
+    assert!(
+        store
+            .load_api_principal_by_token_hash("hash-a2")
+            .unwrap()
+            .is_some(),
+        "svc-c must not have been created"
+    );
+    assert!(
+        store
+            .register_api_principal("svc-b", "hash-b", "auditor", 7_000)
+            .is_ok(),
+        "same principal re-registering its own hash is fine"
+    );
+
     let ids: Vec<String> = store
         .load_api_principals()
         .unwrap()

--- a/src/verifier_store/principals.rs
+++ b/src/verifier_store/principals.rs
@@ -82,6 +82,269 @@ impl VerifierStore {
     }
 }
 
+// ---------------------------------------------------------------------------
+// ADR-0035 Stage 2 (trait-seam inversion) — the API-principal storage trait
+//
+// The THIRD `VerifierStorage`-family seam lifted off `VerifierStore` (after
+// `EpochFence` and `NodeStore`), extending the same seam program toward the
+// clean persistence/authority split. Same discipline as `NodeStore`: the trait
+// shares the inherent method NAMES, inherent methods win resolution (so every
+// existing `store.register_api_principal(...)` / `load_api_principal_by_token_hash(...)`
+// caller is untouched and the SQLite impl delegates via `self.method()` WITHOUT
+// recursion), and a second in-memory backend + a shared conformance suite prove
+// the contract is genuinely backend-portable.
+//
+// The two writers are `&mut self` (mirroring the inherent signatures verbatim —
+// this is a pure ADDITIVE seam, no inherent change), so the in-memory backend
+// needs no interior mutability and the conformance driver takes `&mut S`. That's
+// the one honest shape difference from `NodeStore` (whose `save_node` is `&self`).
+// ---------------------------------------------------------------------------
+
+/// The API-principal registry storage contract — register/rotate a per-principal
+/// scoped bearer token (stored only as its SHA-256), revoke it, resolve a record
+/// by token hash, and list all principals. Backend-agnostic; only ever holds the
+/// token HASH, never plaintext.
+pub trait PrincipalStore {
+    /// Backend error type (SQLite: `rusqlite::Error`; in-memory: [`std::convert::Infallible`]).
+    type Error;
+
+    /// Register or rotate a principal by `principal_id`: overwrite the token hash +
+    /// role and CLEAR any prior revocation (a fresh token reactivates a principal).
+    fn register_api_principal(
+        &mut self,
+        principal_id: &str,
+        token_sha256: &str,
+        role: &str,
+        now_ms: u64,
+    ) -> std::result::Result<(), Self::Error>;
+
+    /// Revoke a principal. Returns `true` iff an ACTIVE principal transitioned to
+    /// revoked; `false` if absent or already revoked.
+    fn revoke_api_principal(
+        &mut self,
+        principal_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<bool, Self::Error>;
+
+    /// Resolve the record whose CURRENT token hash equals `token_sha256` (active OR
+    /// revoked — the caller fail-closes on revoked), or `None`. Lookup by hash only.
+    fn load_api_principal_by_token_hash(
+        &self,
+        token_sha256: &str,
+    ) -> std::result::Result<Option<ApiPrincipalRecord>, Self::Error>;
+
+    /// List every registered principal, ordered by `principal_id`. Never the hash.
+    fn load_api_principals(&self) -> std::result::Result<Vec<ApiPrincipalRecord>, Self::Error>;
+}
+
+/// The production SQLite backend: delegates to the inherent `VerifierStore` methods
+/// over the `api_principals` table. `self.method()` resolves to the INHERENT method
+/// (inherent wins over the trait), so this is delegation, not recursion.
+impl PrincipalStore for VerifierStore {
+    type Error = rusqlite::Error;
+
+    fn register_api_principal(
+        &mut self,
+        principal_id: &str,
+        token_sha256: &str,
+        role: &str,
+        now_ms: u64,
+    ) -> Result<()> {
+        self.register_api_principal(principal_id, token_sha256, role, now_ms)
+    }
+    fn revoke_api_principal(&mut self, principal_id: &str, now_ms: u64) -> Result<bool> {
+        self.revoke_api_principal(principal_id, now_ms)
+    }
+    fn load_api_principal_by_token_hash(
+        &self,
+        token_sha256: &str,
+    ) -> Result<Option<ApiPrincipalRecord>> {
+        self.load_api_principal_by_token_hash(token_sha256)
+    }
+    fn load_api_principals(&self) -> Result<Vec<ApiPrincipalRecord>> {
+        self.load_api_principals()
+    }
+}
+
+/// The in-memory [`PrincipalStore`] backend — a portability-proof reference
+/// modelling the `api_principals` table as a map keyed by `principal_id`, each
+/// row carrying the CURRENT token hash + role + timestamps. Realizes the SAME
+/// register/rotate/revoke/resolve semantics WITHOUT a database. Single-process.
+#[derive(Debug, Default)]
+pub struct InMemoryPrincipalStore {
+    rows: std::collections::HashMap<String, InMemoryPrincipalRow>,
+}
+
+#[derive(Debug, Clone)]
+struct InMemoryPrincipalRow {
+    token_sha256: String,
+    role: String,
+    created_at_ms: u64,
+    revoked_at_ms: Option<u64>,
+}
+
+impl InMemoryPrincipalRow {
+    fn to_record(&self, principal_id: &str) -> ApiPrincipalRecord {
+        ApiPrincipalRecord {
+            principal_id: principal_id.to_string(),
+            role: self.role.clone(),
+            created_at_ms: self.created_at_ms,
+            revoked_at_ms: self.revoked_at_ms,
+        }
+    }
+}
+
+impl PrincipalStore for InMemoryPrincipalStore {
+    type Error = std::convert::Infallible;
+
+    fn register_api_principal(
+        &mut self,
+        principal_id: &str,
+        token_sha256: &str,
+        role: &str,
+        now_ms: u64,
+    ) -> std::result::Result<(), std::convert::Infallible> {
+        // Upsert by principal_id; rotation overwrites the hash/role and CLEARS
+        // revocation — matching the SQLite `ON CONFLICT … SET … revoked_at_ms = NULL`.
+        self.rows.insert(
+            principal_id.to_string(),
+            InMemoryPrincipalRow {
+                token_sha256: token_sha256.to_string(),
+                role: role.to_string(),
+                created_at_ms: now_ms,
+                revoked_at_ms: None,
+            },
+        );
+        Ok(())
+    }
+
+    fn revoke_api_principal(
+        &mut self,
+        principal_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<bool, std::convert::Infallible> {
+        match self.rows.get_mut(principal_id) {
+            Some(row) if row.revoked_at_ms.is_none() => {
+                row.revoked_at_ms = Some(now_ms);
+                Ok(true)
+            }
+            // Absent or already revoked → no transition.
+            _ => Ok(false),
+        }
+    }
+
+    fn load_api_principal_by_token_hash(
+        &self,
+        token_sha256: &str,
+    ) -> std::result::Result<Option<ApiPrincipalRecord>, std::convert::Infallible> {
+        Ok(self
+            .rows
+            .iter()
+            .find(|(_, row)| row.token_sha256 == token_sha256)
+            .map(|(id, row)| row.to_record(id)))
+    }
+
+    fn load_api_principals(
+        &self,
+    ) -> std::result::Result<Vec<ApiPrincipalRecord>, std::convert::Infallible> {
+        let mut out: Vec<ApiPrincipalRecord> = self
+            .rows
+            .iter()
+            .map(|(id, row)| row.to_record(id))
+            .collect();
+        out.sort_by(|a, b| a.principal_id.cmp(&b.principal_id));
+        Ok(out)
+    }
+}
+
+/// The API-principal registry contract, driven through the [`PrincipalStore`] trait
+/// so it runs IDENTICALLY against every backend: empty read, register→resolve-by-hash
+/// roundtrip (id + role preserved, active), rotation (the rotated-out hash stops
+/// resolving; role + activation update), revoke-is-idempotent + reports the
+/// transition + resolves-while-revoked, and the ordered listing.
+///
+/// `pub` (not `#[cfg(test)]`) by design: the shared backend-conformance suite, run
+/// below against the SQLite and in-memory backends (and available to an external
+/// backend crate, exactly as `assert_node_store_contract` is). Panics on any
+/// violation (assert-based) — call it from a test.
+///
+/// PRECONDITION: `store` must start empty.
+pub fn assert_principal_store_contract<S: PrincipalStore>(store: &mut S)
+where
+    S::Error: core::fmt::Debug,
+{
+    // Empty registry.
+    assert!(store
+        .load_api_principal_by_token_hash("nope")
+        .unwrap()
+        .is_none());
+    assert!(store.load_api_principals().unwrap().is_empty());
+
+    // Register + resolve by hash (id + role preserved, active).
+    store
+        .register_api_principal("svc-a", "hash-a", "integrator", 1_000)
+        .unwrap();
+    let rec = store
+        .load_api_principal_by_token_hash("hash-a")
+        .unwrap()
+        .expect("svc-a present");
+    assert_eq!(rec.principal_id, "svc-a");
+    assert_eq!(rec.role, "integrator");
+    assert!(rec.is_active());
+
+    // Revoke transitions once, then is a no-op; the OLD hash still resolves the
+    // now-revoked record.
+    assert!(
+        store.revoke_api_principal("svc-a", 2_000).unwrap(),
+        "first revoke transitions"
+    );
+    assert!(
+        !store.revoke_api_principal("svc-a", 3_000).unwrap(),
+        "second revoke is a no-op"
+    );
+    assert!(
+        !store.revoke_api_principal("absent", 3_000).unwrap(),
+        "absent principal → false"
+    );
+    assert!(store
+        .load_api_principal_by_token_hash("hash-a")
+        .unwrap()
+        .expect("still resolvable while revoked")
+        .revoked_at_ms
+        .is_some());
+
+    // Rotation overwrites the hash + role and reactivates; the rotated-out hash
+    // no longer resolves.
+    store
+        .register_api_principal("svc-a", "hash-a2", "auditor", 4_000)
+        .unwrap();
+    assert!(
+        store
+            .load_api_principal_by_token_hash("hash-a")
+            .unwrap()
+            .is_none(),
+        "the rotated-out hash no longer resolves"
+    );
+    let rotated = store
+        .load_api_principal_by_token_hash("hash-a2")
+        .unwrap()
+        .expect("rotated token resolves");
+    assert_eq!(rotated.role, "auditor");
+    assert!(rotated.is_active());
+
+    // A second principal; the listing is ordered by id and hides no secret shape.
+    store
+        .register_api_principal("svc-b", "hash-b", "operator", 5_000)
+        .unwrap();
+    let ids: Vec<String> = store
+        .load_api_principals()
+        .unwrap()
+        .into_iter()
+        .map(|p| p.principal_id)
+        .collect();
+    assert_eq!(ids, ["svc-a", "svc-b"], "listing ordered by principal_id");
+}
+
 #[cfg(test)]
 mod tests {
     use crate::verifier_store::VerifierStore;
@@ -171,5 +434,21 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["svc-a", "svc-b"]
         );
+    }
+}
+
+#[cfg(test)]
+mod principal_store_contract_tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_backend_satisfies_the_principal_store_contract() {
+        let mut store = VerifierStore::new(":memory:").expect("in-memory store");
+        assert_principal_store_contract(&mut store);
+    }
+
+    #[test]
+    fn in_memory_backend_satisfies_the_principal_store_contract() {
+        assert_principal_store_contract(&mut InMemoryPrincipalStore::default());
     }
 }


### PR DESCRIPTION
## Summary

First installment of ADR-0035 **Stage 2** (persistence decoupling), delivered as **trait-seam inversion** rather than a single crate move.

### Why not a clean `kirra-persistence` crate in one PR
Unlike Stages 0/1, `verifier_store` (~10.6k LOC) is **not a clean leaf** — it's coupled to ~4.7k LOC of domain modules it persists (`audit_chain`, `ota_campaign`, `federation`, `verdicts`, `key_registry`, `fabric`, `audit_shipper`). The `EpochFence`/`NodeStore` trait seams the ADR cited as "already existing" cover only **2 of ~8 table families**. So a clean extraction can't be one mechanical move; the tractable path is to keep extending the storage-trait seam family-by-family (consumers depend on backend-agnostic traits) until a later extraction is mechanical.

### What this PR adds
Three more `VerifierStorage`-family seams — the credential/identity registries — each following the established `NodeStore` idiom verbatim: the trait shares the inherent method names (inherent wins resolution → **the SQLite impl delegates without recursion and every existing caller is untouched**), plus a 2nd in-memory reference backend and a shared `assert_*_store_contract` conformance suite run against both backends.

| Family | Trait | Notes |
| :-- | :-- | :-- |
| `api_principals` | `PrincipalStore` | register/rotate/revoke/resolve-by-hash/list; `Infallible` in-memory |
| `operators` | `OperatorStore` | registry CRUD only — the audit-chained clearance-**grant** methods stay inherent (a coupling for the harder tier) |
| `cert_principals` | `CertPrincipalStore` | richer: models the two real failure modes as a proper error enum (`InMemCertError { FingerprintConflict, ExpiryOverflow }`) — the `UNIQUE(cert_sha256)` one-cert-one-principal constraint and the fail-closed `i64::MAX` expiry refusal (Copilot #857) — plus inclusive-notAfter expiry boundaries, exercised against both backends |

This brings the seam count to **5 of ~8 families** (after the pre-existing `EpochFence` + `NodeStore`).

## Verification
- All store-contract tests green (each family × SQLite + in-memory backends)
- The existing inherent tests (13 cert + 2 operator + 6 principals) + the full **779-test lib suite** green
- fmt-clean · quality-guardrails satisfied · orphan-core gate green
- Purely additive — no new deps, no lockfile change, no modification to existing code paths

## Not in this PR
`av_subsystem` (one more clean registry-ish family) and the **hard tier** — `audit` / `federation` / `ota_campaigns` / `posture` / `attestation` / `fabric` — which are audit-chained / domain-coupled and need the domain-type relocation before they can be seamed. Those are a genuinely different unit of work (the "keep-slicing vs. domain-types-first" fork) worth its own planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_