### PR TITLE
ADR-0035 Stage 2 (part 2): AvSubsystemStore storage-trait seam

### DIFF
--- a/docs/adr/0035-verifier-crate-decomposition.md
+++ b/docs/adr/0035-verifier-crate-decomposition.md
@@ -147,3 +147,114 @@ replay) gate behaviour preservation.
 Stages land as independent PRs in order (0 → 5); Stage 0 is the gating
 prerequisite and the proof-of-mechanics. Do not begin Stage 1 until Stage 0 is
 merged, and do not begin Stage 3 until Stages 0–2 are merged.
+
+---
+
+## Addendum A (2026-07-14) — Stage 2 execution finding: `verifier_store` is not a clean leaf, and how the hard tier is actually cut
+
+**Status of this addendum:** Accepted (records what execution discovered; revises
+the Stage 2 plan). Stages 0–1 landed as written (#919, #921). Stage 2 is landing
+incrementally as documented below (#922, #923).
+
+### What the plan assumed vs. what execution found
+
+The original Stage 2 line ("move `verifier_store/*` + `StoreHandle` behind the
+existing `EpochFence`/`NodeStore` traits — the least-invasive of the big three
+because the seams exist") **understated the coupling**. Measured against the tree:
+
+- `verifier_store` is ~10.6k LOC across 17 files and is consumed by ~46 files.
+- The `EpochFence` + `NodeStore` trait seams cover **2 of ~8 table families**. The
+  rest (`api_principals`, `operators`, `cert_principals`, `av_subsystem`, `audit`,
+  `federation`, `ota_campaigns`, `posture`, `attestation`, `fabric`) had **no
+  seam** — they marshal domain types and/or append signed audit events directly.
+- So a clean `kirra-persistence` crate **cannot be one mechanical move**: the
+  domain types the store persists (audit-chain records, `FederatedTrustReport`,
+  `Campaign`, causal-log entries, `FabricAsset`, verdict ids, `KeyRegistry`, ~4.7k
+  LOC) currently sit *beside* the store in the root crate, not *below* it, so a
+  persistence crate would not compile independently.
+
+### Decision: trait-seam inversion, family by family (revised Stage 2)
+
+Rather than a big-bang crate move, Stage 2 extends the established storage-trait
+seam program (`EpochFence`, `NodeStore`) one table-family at a time. Each seam is
+a pure ADDITIVE PR: a backend-agnostic trait sharing the inherent method names
+(inherent wins resolution → the SQLite impl delegates without recursion, every
+existing caller untouched), a 2nd in-memory reference backend, and a shared
+`assert_*_store_contract` conformance suite run against both. Once every family is
+behind a trait, consumers depend on traits (not the concrete `VerifierStore`), and
+the eventual crate extraction becomes mechanical.
+
+**Clean tier — DONE (6 of ~8 families).** `PrincipalStore` (#922), `OperatorStore`
+(#922), `CertPrincipalStore` (#922), `AvSubsystemStore` (#923), on top of the
+pre-existing `EpochFence` + `NodeStore`. These are pure CRUD/registry/meta over a
+single table with no audit-chaining. Two of them model a real domain failure mode
+in the in-memory backend's error type rather than `Infallible`
+(`CertPrincipalStore`'s `UNIQUE(cert_sha256)` + `i64::MAX` expiry refusal;
+`PrincipalStore`'s `UNIQUE(token_sha256)`; `AvSubsystemStore`'s increment-on-absent).
+
+### The hard tier — two distinct couplings
+
+The remaining families (`audit`, `federation`, `ota_campaigns`, `posture`,
+`attestation`, `fabric`) cannot be seamed as pure CRUD. They share two *distinct*
+couplings that must be broken first (measured call-site counts in parentheses):
+
+- **C1 — audit-chaining.** The method opens a transaction, writes its table row,
+  AND appends a signed, hash-chained `crate::audit_chain::AuditChainLinker` event
+  **within the same transaction**, using the store's `signing_key` field. Present
+  in `posture` (3), `ota_campaigns` (2), `federation` (2), `operators` clearance
+  grants (4), `fabric` (1), `attestation` (1), and the core `audit` module (7).
+  The atomicity (row + audit append in ONE tx) is load-bearing — the power-loss
+  drill (`audit_chain_prefix_on_kill`) proves the chain never forks — so the audit
+  append **cannot simply move up** to the authority layer without losing it.
+- **C2 — domain-type marshalling.** The method takes/returns a safety-authority
+  domain type: `federation` (`FederatedTrustReport`, `authoritative_posture`),
+  `ota_campaigns` (`Campaign`, `NodeArtifactStatus`), `fabric` (`CausalLogEntry`,
+  `FabricAsset`), `audit` (verdict-id validation, `authoritative_posture`).
+  `posture` and `attestation` are **C1-only** (they marshal primitives/local rows).
+
+The clean-seam recipe doesn't extend here because a portable storage trait for
+these would have to *name* `audit_chain` types, the Ed25519 signing key, AND the
+domain types — none of which can live below persistence in the target DAG today.
+
+### Proposed sequencing for the hard tier (Stage 2.5, before the crate extraction)
+
+1. **Invert the audit-append dependency (breaks C1).** Introduce an injected
+   `AuditAppender` seam: a trait that appends a signed event **into a caller-owned
+   transaction** (`append_within(&tx, event_type, payload, at_ms)`). The store
+   method keeps owning the transaction (atomicity preserved) but calls the injected
+   appender instead of reaching up to `crate::audit_chain` + `self.signing_key`.
+   The `AuditChainLinker` impl and the signing key move to the safety-authority
+   layer and are injected at construction. This is the crux move — it removes the
+   store's dependency on the signing key and the chain-hash logic while keeping the
+   one-transaction guarantee the power-loss drill depends on.
+2. **Relocate the C2 domain types.** Move `FederatedTrustReport{,V2}`, `Campaign` /
+   `NodeArtifactStatus`, `CausalLogEntry` / `FabricAsset`, and the verdict-id
+   predicate into a lower shared crate (candidate: extend `kirra-fleet-types`, or a
+   new `kirra-domain-types` leaf) so a storage trait can name them. `posture` /
+   `attestation` skip this step (C1-only).
+3. **Seam each hard family** as CRUD, exactly like the clean six, now that C1+C2
+   are broken. Then `kirra-persistence` can be extracted mechanically (Stage 2
+   proper), depending only on the domain-types leaf + the injected `AuditAppender`
+   contract.
+
+**Alternative considered — domain-types-first only (no audit inversion):** relocate
+C2 types and move `verifier_store` wholesale into a persistence crate that *keeps*
+depending on `audit_chain`. Rejected as the end state: it drags the signed-audit
+machinery (a safety-authority concern) into the persistence layer, inverting the
+intended DAG (persistence must not know audit semantics). It may still be a useful
+*intermediate* if the `AuditAppender` inversion proves too large for one step.
+
+### Interaction with later stages
+
+The signing key lives on `VerifierStore`/`AppState` today, so step 1 above
+partially overlaps Stage 3 (the `AppState` decomposition) — the `AuditAppender`
+injection is the natural place to relocate signing-key ownership to the
+safety-authority layer. Sequence step 1 as the leading edge of Stage 3 rather than
+duplicating the work.
+
+### Non-goals for the hard tier (unchanged)
+
+No behaviour change: byte-identical verdicts, the SAME audit chain bytes, the same
+fail-closed semantics and one-transaction atomicity. The power-loss, loom, and
+deterministic-replay suites gate this; any tempting semantic change is a separate
+ADR/PR.

--- a/src/verifier_store/av_subsystem.rs
+++ b/src/verifier_store/av_subsystem.rs
@@ -150,3 +150,459 @@ impl VerifierStore {
         )
     }
 }
+
+// ---------------------------------------------------------------------------
+// ADR-0035 Stage 2 (trait-seam inversion) — the AV-subsystem-meta storage trait
+//
+// The AV diagnostic-meta store (per-node confidence floor + last-telemetry stamp
+// + the recovery-streak counters that drive the AV recovery hysteresis and the
+// telemetry watchdog), lifted off `VerifierStore` as another `VerifierStorage`-
+// family seam. All methods are `&self` (matching the inherent signatures and
+// `NodeStore`), so the in-memory backend uses interior mutability and the
+// conformance driver takes `&S`. Inherent methods win resolution → the SQLite
+// impl delegates via `self.method()` without recursion; existing callers
+// (`recovery_hysteresis`, `telemetry_watchdog`, the fleet handler) are untouched.
+//
+// One faithful failure mode: `increment_recovery_streak` on an UNREGISTERED node
+// errors on SQLite (the trailing `SELECT` finds no row → `QueryReturnedNoRows`),
+// so the in-memory backend's `Error` is a real enum ([`InMemAvError`]) returning
+// `NodeNotRegistered` there — the portable contract holds both backends to it.
+// ---------------------------------------------------------------------------
+
+/// The AV-subsystem diagnostic-meta storage contract — upsert a subsystem's meta,
+/// read/update its confidence floor + last-telemetry stamp, and drive its
+/// recovery-streak counters. Backend-agnostic; no secrets.
+pub trait AvSubsystemStore {
+    /// Backend error type (SQLite: `rusqlite::Error`; in-memory: [`InMemAvError`]).
+    type Error;
+
+    /// Upsert an AV subsystem's meta by `node_id` (INSERT-OR-REPLACE — re-registering
+    /// overwrites the row and RESETS the recovery-streak counters to 0, since the
+    /// streak columns are not part of the write and fall back to their DEFAULT 0).
+    fn register_av_subsystem_meta(
+        &self,
+        node_id: &str,
+        subsystem_type: &str,
+        hardware_id: &str,
+        confidence_floor: f64,
+        initial_telemetry_ms: u64,
+    ) -> std::result::Result<(), Self::Error>;
+
+    /// The node's confidence floor, or `None` if unregistered.
+    fn load_av_confidence_floor(
+        &self,
+        node_id: &str,
+    ) -> std::result::Result<Option<f64>, Self::Error>;
+
+    /// Stamp `last_telemetry_ms = now_ms` (no-op if the node is unregistered).
+    fn touch_av_telemetry_timestamp(
+        &self,
+        node_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<(), Self::Error>;
+
+    /// The node's last-telemetry stamp, or `0` if unregistered.
+    fn get_last_telemetry_timestamp(&self, node_id: &str) -> std::result::Result<u64, Self::Error>;
+
+    /// Every registered AV node id.
+    fn load_all_registered_av_node_ids(&self) -> std::result::Result<Vec<String>, Self::Error>;
+
+    /// Every registered AV subsystem's diagnostic-meta record, ordered by `node_id`.
+    fn load_av_subsystems(&self) -> std::result::Result<Vec<AvSubsystemRecord>, Self::Error>;
+
+    /// The node's `(recovery_streak_count, recovery_streak_start_ms)`, or `(0, 0)`
+    /// if unregistered.
+    fn load_recovery_streak(&self, node_id: &str) -> std::result::Result<(u32, u64), Self::Error>;
+
+    /// Reset the streak counters AND stamp `last_telemetry_ms = now_ms` (used on
+    /// receipt of a fault report — the report genuinely arrived "now"). No-op if
+    /// unregistered.
+    fn reset_recovery_streak(
+        &self,
+        node_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<(), Self::Error>;
+
+    /// Reset the streak counters WITHOUT touching `last_telemetry_ms` (used by the
+    /// watchdog on a SILENT node — no report arrived, so the silence clock must not
+    /// be fabricated forward). No-op if unregistered.
+    fn reset_recovery_streak_preserving_telemetry(
+        &self,
+        node_id: &str,
+    ) -> std::result::Result<(), Self::Error>;
+
+    /// Increment the streak (setting `start_ms = now_ms` only on the 0→1 edge) and
+    /// stamp `last_telemetry_ms = now_ms`; returns the NEW count. Errors if the node
+    /// is unregistered (there is no row to increment).
+    fn increment_recovery_streak(
+        &self,
+        node_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<u32, Self::Error>;
+}
+
+/// The production SQLite backend: delegates to the inherent `VerifierStore` methods
+/// over the `av_subsystem_meta` table. `self.method()` resolves to the INHERENT
+/// method (inherent wins), so this is delegation, not recursion.
+impl AvSubsystemStore for VerifierStore {
+    type Error = rusqlite::Error;
+
+    fn register_av_subsystem_meta(
+        &self,
+        node_id: &str,
+        subsystem_type: &str,
+        hardware_id: &str,
+        confidence_floor: f64,
+        initial_telemetry_ms: u64,
+    ) -> Result<()> {
+        self.register_av_subsystem_meta(
+            node_id,
+            subsystem_type,
+            hardware_id,
+            confidence_floor,
+            initial_telemetry_ms,
+        )
+    }
+    fn load_av_confidence_floor(&self, node_id: &str) -> Result<Option<f64>> {
+        self.load_av_confidence_floor(node_id)
+    }
+    fn touch_av_telemetry_timestamp(&self, node_id: &str, now_ms: u64) -> Result<()> {
+        self.touch_av_telemetry_timestamp(node_id, now_ms)
+    }
+    fn get_last_telemetry_timestamp(&self, node_id: &str) -> Result<u64> {
+        self.get_last_telemetry_timestamp(node_id)
+    }
+    fn load_all_registered_av_node_ids(&self) -> Result<Vec<String>> {
+        self.load_all_registered_av_node_ids()
+    }
+    fn load_av_subsystems(&self) -> Result<Vec<AvSubsystemRecord>> {
+        self.load_av_subsystems()
+    }
+    fn load_recovery_streak(&self, node_id: &str) -> Result<(u32, u64)> {
+        self.load_recovery_streak(node_id)
+    }
+    fn reset_recovery_streak(&self, node_id: &str, now_ms: u64) -> Result<()> {
+        self.reset_recovery_streak(node_id, now_ms)
+    }
+    fn reset_recovery_streak_preserving_telemetry(&self, node_id: &str) -> Result<()> {
+        self.reset_recovery_streak_preserving_telemetry(node_id)
+    }
+    fn increment_recovery_streak(&self, node_id: &str, now_ms: u64) -> Result<u32> {
+        self.increment_recovery_streak(node_id, now_ms)
+    }
+}
+
+/// The failure mode of the in-memory [`AvSubsystemStore`] backend — the one the
+/// portable contract preserves across every backend (the SQLite backend surfaces
+/// the same condition as a `rusqlite::Error`).
+#[derive(Debug, PartialEq, Eq)]
+pub enum InMemAvError {
+    /// `increment_recovery_streak` was called on a node with no meta row (nothing
+    /// to increment) — SQLite's trailing `SELECT` returns `QueryReturnedNoRows`.
+    NodeNotRegistered,
+}
+
+#[derive(Debug, Clone)]
+struct InMemoryAvRow {
+    subsystem_type: String,
+    hardware_id: String,
+    confidence_floor: f64,
+    last_telemetry_ms: u64,
+    recovery_streak_count: u32,
+    recovery_streak_start_ms: u64,
+}
+
+/// The in-memory [`AvSubsystemStore`] backend — a portability-proof reference
+/// modelling the `av_subsystem_meta` table as a map keyed by `node_id`. Realizes
+/// the SAME upsert / floor / telemetry-stamp / recovery-streak semantics WITHOUT a
+/// database. `&self` throughout (interior `Mutex`, poison-recovered like
+/// `InMemoryNodeStore`), so the conformance driver takes `&S`. Single-process.
+#[derive(Debug, Default)]
+pub struct InMemoryAvSubsystemStore {
+    rows: std::sync::Mutex<std::collections::HashMap<String, InMemoryAvRow>>,
+}
+
+impl AvSubsystemStore for InMemoryAvSubsystemStore {
+    type Error = InMemAvError;
+
+    fn register_av_subsystem_meta(
+        &self,
+        node_id: &str,
+        subsystem_type: &str,
+        hardware_id: &str,
+        confidence_floor: f64,
+        initial_telemetry_ms: u64,
+    ) -> std::result::Result<(), InMemAvError> {
+        // INSERT OR REPLACE: a re-register overwrites the whole row, so the streak
+        // counters fall back to their DEFAULT 0 (they are not in the write).
+        self.rows.lock().unwrap_or_else(|e| e.into_inner()).insert(
+            node_id.to_string(),
+            InMemoryAvRow {
+                subsystem_type: subsystem_type.to_string(),
+                hardware_id: hardware_id.to_string(),
+                confidence_floor,
+                last_telemetry_ms: initial_telemetry_ms,
+                recovery_streak_count: 0,
+                recovery_streak_start_ms: 0,
+            },
+        );
+        Ok(())
+    }
+
+    fn load_av_confidence_floor(
+        &self,
+        node_id: &str,
+    ) -> std::result::Result<Option<f64>, InMemAvError> {
+        Ok(self
+            .rows
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(node_id)
+            .map(|r| r.confidence_floor))
+    }
+
+    fn touch_av_telemetry_timestamp(
+        &self,
+        node_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<(), InMemAvError> {
+        if let Some(row) = self
+            .rows
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get_mut(node_id)
+        {
+            row.last_telemetry_ms = now_ms;
+        }
+        Ok(())
+    }
+
+    fn get_last_telemetry_timestamp(
+        &self,
+        node_id: &str,
+    ) -> std::result::Result<u64, InMemAvError> {
+        Ok(self
+            .rows
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(node_id)
+            .map(|r| r.last_telemetry_ms)
+            .unwrap_or(0))
+    }
+
+    fn load_all_registered_av_node_ids(&self) -> std::result::Result<Vec<String>, InMemAvError> {
+        Ok(self
+            .rows
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .keys()
+            .cloned()
+            .collect())
+    }
+
+    fn load_av_subsystems(&self) -> std::result::Result<Vec<AvSubsystemRecord>, InMemAvError> {
+        let mut out: Vec<AvSubsystemRecord> = self
+            .rows
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .map(|(id, r)| AvSubsystemRecord {
+                node_id: id.clone(),
+                subsystem_type: r.subsystem_type.clone(),
+                hardware_id: r.hardware_id.clone(),
+                confidence_floor: r.confidence_floor,
+                last_telemetry_ms: r.last_telemetry_ms,
+                recovery_streak_count: r.recovery_streak_count,
+                recovery_streak_start_ms: r.recovery_streak_start_ms,
+            })
+            .collect();
+        out.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+        Ok(out)
+    }
+
+    fn load_recovery_streak(&self, node_id: &str) -> std::result::Result<(u32, u64), InMemAvError> {
+        Ok(self
+            .rows
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(node_id)
+            .map(|r| (r.recovery_streak_count, r.recovery_streak_start_ms))
+            .unwrap_or((0, 0)))
+    }
+
+    fn reset_recovery_streak(
+        &self,
+        node_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<(), InMemAvError> {
+        if let Some(row) = self
+            .rows
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get_mut(node_id)
+        {
+            row.recovery_streak_count = 0;
+            row.recovery_streak_start_ms = 0;
+            row.last_telemetry_ms = now_ms;
+        }
+        Ok(())
+    }
+
+    fn reset_recovery_streak_preserving_telemetry(
+        &self,
+        node_id: &str,
+    ) -> std::result::Result<(), InMemAvError> {
+        if let Some(row) = self
+            .rows
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get_mut(node_id)
+        {
+            row.recovery_streak_count = 0;
+            row.recovery_streak_start_ms = 0;
+        }
+        Ok(())
+    }
+
+    fn increment_recovery_streak(
+        &self,
+        node_id: &str,
+        now_ms: u64,
+    ) -> std::result::Result<u32, InMemAvError> {
+        let mut guard = self.rows.lock().unwrap_or_else(|e| e.into_inner());
+        match guard.get_mut(node_id) {
+            Some(row) => {
+                // `start_ms` is set only on the 0→1 edge (matches the SQL CASE).
+                if row.recovery_streak_count == 0 {
+                    row.recovery_streak_start_ms = now_ms;
+                }
+                row.recovery_streak_count += 1;
+                row.last_telemetry_ms = now_ms;
+                Ok(row.recovery_streak_count)
+            }
+            None => Err(InMemAvError::NodeNotRegistered),
+        }
+    }
+}
+
+/// The AV-subsystem-meta contract, driven through the [`AvSubsystemStore`] trait so
+/// it runs IDENTICALLY against every backend: empty defaults (absent → `None`/`0`/
+/// `(0,0)`), register→read floor + telemetry, telemetry touch, the recovery-streak
+/// lifecycle (increment sets `start` only on the 0→1 edge and advances telemetry;
+/// both resets; the preserving reset keeps telemetry), increment-on-absent errors,
+/// re-register resets the streak, and the ordered listing.
+///
+/// `pub` (not `#[cfg(test)]`) — the shared backend-conformance suite, run below
+/// against the SQLite and in-memory backends. Panics on violation; call from a test.
+/// PRECONDITION: `store` must start empty.
+pub fn assert_av_subsystem_store_contract<S: AvSubsystemStore>(store: &S)
+where
+    S::Error: core::fmt::Debug,
+{
+    // Empty defaults.
+    assert!(store.load_av_confidence_floor("n1").unwrap().is_none());
+    assert_eq!(store.get_last_telemetry_timestamp("n1").unwrap(), 0);
+    assert_eq!(store.load_recovery_streak("n1").unwrap(), (0, 0));
+    assert!(store.load_all_registered_av_node_ids().unwrap().is_empty());
+    assert!(store.load_av_subsystems().unwrap().is_empty());
+
+    // Register + read back floor + telemetry; a fresh node starts with no streak.
+    store
+        .register_av_subsystem_meta("n1", "lidar", "hw-1", 0.8, 100)
+        .unwrap();
+    assert_eq!(store.load_av_confidence_floor("n1").unwrap(), Some(0.8));
+    assert_eq!(store.get_last_telemetry_timestamp("n1").unwrap(), 100);
+    assert_eq!(store.load_recovery_streak("n1").unwrap(), (0, 0));
+
+    // Telemetry touch advances the stamp.
+    store.touch_av_telemetry_timestamp("n1", 200).unwrap();
+    assert_eq!(store.get_last_telemetry_timestamp("n1").unwrap(), 200);
+
+    // Increment: start stamps only on the 0→1 edge; telemetry advances each time.
+    assert_eq!(store.increment_recovery_streak("n1", 300).unwrap(), 1);
+    assert_eq!(store.load_recovery_streak("n1").unwrap(), (1, 300));
+    assert_eq!(store.increment_recovery_streak("n1", 400).unwrap(), 2);
+    assert_eq!(
+        store.load_recovery_streak("n1").unwrap(),
+        (2, 300),
+        "start unchanged after the 0→1 edge"
+    );
+    assert_eq!(store.get_last_telemetry_timestamp("n1").unwrap(), 400);
+
+    // Preserving reset clears the streak but keeps telemetry.
+    store
+        .reset_recovery_streak_preserving_telemetry("n1")
+        .unwrap();
+    assert_eq!(store.load_recovery_streak("n1").unwrap(), (0, 0));
+    assert_eq!(
+        store.get_last_telemetry_timestamp("n1").unwrap(),
+        400,
+        "preserving reset keeps last_telemetry"
+    );
+
+    // Full reset clears the streak AND stamps telemetry = now.
+    assert_eq!(store.increment_recovery_streak("n1", 500).unwrap(), 1);
+    assert_eq!(store.load_recovery_streak("n1").unwrap(), (1, 500));
+    store.reset_recovery_streak("n1", 600).unwrap();
+    assert_eq!(store.load_recovery_streak("n1").unwrap(), (0, 0));
+    assert_eq!(
+        store.get_last_telemetry_timestamp("n1").unwrap(),
+        600,
+        "full reset stamps telemetry"
+    );
+
+    // Increment on an UNREGISTERED node errors (nothing to increment).
+    assert!(
+        store.increment_recovery_streak("ghost", 700).is_err(),
+        "increment on an absent node must error"
+    );
+    assert!(
+        store.load_av_confidence_floor("ghost").unwrap().is_none(),
+        "the failed increment created no row"
+    );
+
+    // A second node; the id listing + record listing are complete and ordered.
+    store
+        .register_av_subsystem_meta("n2", "radar", "hw-2", 0.6, 50)
+        .unwrap();
+    let mut ids = store.load_all_registered_av_node_ids().unwrap();
+    ids.sort();
+    assert_eq!(ids, ["n1", "n2"]);
+    let recs = store.load_av_subsystems().unwrap();
+    assert_eq!(
+        recs.iter().map(|r| r.node_id.as_str()).collect::<Vec<_>>(),
+        ["n1", "n2"],
+        "records ordered by node_id"
+    );
+    assert_eq!(recs[1].subsystem_type, "radar");
+    assert_eq!(recs[1].confidence_floor, 0.6);
+
+    // Re-register n1 (after building a streak) RESETS its streak to (0,0).
+    store.increment_recovery_streak("n1", 800).unwrap();
+    assert_eq!(store.load_recovery_streak("n1").unwrap().0, 1);
+    store
+        .register_av_subsystem_meta("n1", "lidar", "hw-1b", 0.9, 900)
+        .unwrap();
+    assert_eq!(
+        store.load_recovery_streak("n1").unwrap(),
+        (0, 0),
+        "re-register resets the streak (INSERT OR REPLACE)"
+    );
+    assert_eq!(store.load_av_confidence_floor("n1").unwrap(), Some(0.9));
+}
+
+#[cfg(test)]
+mod av_subsystem_store_contract_tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_backend_satisfies_the_av_subsystem_store_contract() {
+        let store = VerifierStore::new(":memory:").expect("in-memory store");
+        assert_av_subsystem_store_contract(&store);
+    }
+
+    #[test]
+    fn in_memory_backend_satisfies_the_av_subsystem_store_contract() {
+        assert_av_subsystem_store_contract(&InMemoryAvSubsystemStore::default());
+    }
+}

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -586,6 +586,12 @@ pub use nodes::{assert_node_store_contract, InMemoryNodeStore, NodeStore};
 mod attestation;
 mod audit;
 mod av_subsystem;
+// ADR-0035 Stage 2 (trait-seam inversion) — the AV-subsystem diagnostic-meta storage
+// trait + its in-memory reference backend (confidence floor + telemetry stamp +
+// recovery-streak counters; models the increment-on-unregistered failure mode).
+pub use av_subsystem::{
+    assert_av_subsystem_store_contract, AvSubsystemStore, InMemAvError, InMemoryAvSubsystemStore,
+};
 mod cert_principals;
 // ADR-0035 Stage 2 (trait-seam inversion) — the cert-principal storage trait + its
 // in-memory reference backend (a richer seam: models the UNIQUE-fingerprint conflict


### PR DESCRIPTION
## Summary

Continues ADR-0035 **Stage 2** (persistence decoupling via trait-seam inversion). Two things:

1. **`AvSubsystemStore`** — the AV diagnostic-meta storage seam, the last of the **clean** (non-audit-chained, non-domain-coupled) `verifier_store` table families.
2. **ADR-0035 Addendum A** — documents the Stage 2 execution finding and the plan for the hard tier (see below).

### `AvSubsystemStore`
Covers the per-node confidence floor, the last-telemetry stamp, and the recovery-streak counters that drive the AV recovery hysteresis and the telemetry watchdog. Same `NodeStore` idiom: the trait shares the inherent method names → **inherent wins resolution → the SQLite impl delegates without recursion and every existing caller (`recovery_hysteresis`, `telemetry_watchdog`, the fleet handler) is untouched** — plus a 2nd in-memory reference backend and a shared conformance suite run against both.

All ten methods are `&self`, so the in-memory backend uses interior mutability and the conformance driver takes `&S` like `NodeStore`. The suite faithfully models the recovery-streak lifecycle (`increment` stamps `start_ms` only on the 0→1 edge and advances telemetry; both resets; the preserving reset keeps telemetry; re-register resets via `INSERT OR REPLACE`) and the one real failure mode — `increment_recovery_streak` on an **unregistered** node errors on SQLite (its trailing `SELECT` finds no row → `QueryReturnedNoRows`), so the in-memory `Error` is a real enum (`InMemAvError::NodeNotRegistered`).

Seam progress: **6 of ~8 table families** now have a storage-trait seam (`EpochFence`, `NodeStore`, `PrincipalStore`, `OperatorStore`, `CertPrincipalStore`, `AvSubsystemStore`). This completes the clean tier.

### ADR-0035 Addendum A — hard-tier plan
Records what executing Stage 2 found (the original "the seams exist" premise held for only 2 of ~8 families; `verifier_store` is not a clean leaf) and the adopted incremental approach. Characterizes the hard tier's two distinct couplings with measured call-site counts — **C1 audit-chaining** (row + signed `AuditChainLinker` append in one transaction, atomicity load-bearing per the power-loss drill) and **C2 domain-type marshalling** (`FederatedTrustReport`/`Campaign`/`CausalLogEntry`/`FabricAsset`/verdict ids); `posture`+`attestation` are C1-only. Proposes the Stage 2.5 sequencing: (1) invert the audit-append dependency via an injected `AuditAppender` seam that appends into a caller-owned transaction; (2) relocate the C2 domain types to a lower shared crate; (3) seam each hard family as CRUD, then extract `kirra-persistence` mechanically. Notes the overlap with Stage 3 (signing-key ownership) and the rejected domain-types-first-only alternative.

## Verification
- Both backends satisfy the `AvSubsystemStore` contract (SQLite + in-memory)
- The existing `av_subsystem` inherent tests + the full **781-test lib suite** green
- fmt-clean · quality-guardrails satisfied · orphan-core gate green
- Additive code + docs only — no new deps, no lockfile change, no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)