### PR TITLE
ADR-0035 Stage 2.5 prototype: inject the audit-append seam (posture)

### DIFF
--- a/src/verifier_store/audit_appender.rs
+++ b/src/verifier_store/audit_appender.rs
@@ -1,0 +1,64 @@
+// src/verifier_store/audit_appender.rs
+//
+// ADR-0035 Addendum A, Stage 2.5 step 1 (PROTOTYPE) — the injected audit-append seam.
+//
+// The hard-tier `verifier_store` families couple to the safety-authority layer by
+// appending a signed, hash-chained `AuditChainLinker` event *inside the same
+// transaction* as their table write (coupling "C1"). That atomicity is load-bearing
+// (the power-loss drill proves the chain never forks), so the append cannot simply
+// move up to the authority layer. This trait inverts the dependency WITHOUT losing
+// atomicity: the store still owns the transaction and calls `append_within` on an
+// injected appender, so a future `kirra-persistence` crate depends only on THIS
+// contract — not on `crate::audit_chain` or the Ed25519 signing key.
+//
+// This is the proof-of-mechanics on the `posture` family (the smallest C1-only
+// family). Behaviour is byte-identical: the production `ChainedAuditAppender`
+// delegates to the exact same `AuditChainLinker::append_audit_event_tx` with the
+// exact same key, so the audit-chain bytes are unchanged (a chained-write test
+// re-verifies the chain, and an atomicity test proves a failing appender rolls the
+// whole caller-owned transaction back).
+
+/// Appends an audit event INTO a caller-owned transaction. The implementation owns
+/// whatever signing material the chain needs; the persistence layer depends only on
+/// this trait, so the append happens atomically with the caller's table write while
+/// the store stays ignorant of `audit_chain` internals and the signing key.
+///
+/// `append_within` MUST NOT commit or roll back `tx` — it only stages its rows so
+/// the CALLER's `tx.commit()` makes the table write and the audit append all-or-
+/// nothing (and any error here propagates to abort the caller's transaction).
+pub trait AuditAppender {
+    fn append_within(
+        &self,
+        tx: &rusqlite::Transaction<'_>,
+        event_type: &str,
+        payload: &str,
+        created_at_ms: i64,
+    ) -> rusqlite::Result<()>;
+}
+
+/// The production appender: the hash-chained, Ed25519-signed audit append, delegating
+/// to [`crate::audit_chain::AuditChainLinker::append_audit_event_tx`]. Holds a borrow
+/// of the store's signing key. This is the ONE type that knows both the chain logic
+/// and the key; at the eventual crate split it lives in the safety-authority layer and
+/// is injected into persistence, so persistence itself carries neither dependency.
+pub struct ChainedAuditAppender<'k> {
+    pub signing_key: Option<&'k ed25519_dalek::SigningKey>,
+}
+
+impl AuditAppender for ChainedAuditAppender<'_> {
+    fn append_within(
+        &self,
+        tx: &rusqlite::Transaction<'_>,
+        event_type: &str,
+        payload: &str,
+        created_at_ms: i64,
+    ) -> rusqlite::Result<()> {
+        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
+            tx,
+            event_type,
+            payload,
+            created_at_ms,
+            self.signing_key,
+        )
+    }
+}

--- a/src/verifier_store/audit_appender.rs
+++ b/src/verifier_store/audit_appender.rs
@@ -18,10 +18,11 @@
 // re-verifies the chain, and an atomicity test proves a failing appender rolls the
 // whole caller-owned transaction back).
 
-/// Appends an audit event INTO a caller-owned transaction. The implementation owns
-/// whatever signing material the chain needs; the persistence layer depends only on
-/// this trait, so the append happens atomically with the caller's table write while
-/// the store stays ignorant of `audit_chain` internals and the signing key.
+/// Appends an audit event INTO a caller-owned transaction. The implementation
+/// supplies whatever signing material the chain needs (the production impl below
+/// borrows the store's key; the trait imposes no ownership); the persistence layer
+/// depends only on this trait, so the append happens atomically with the caller's
+/// table write while the store stays ignorant of `audit_chain` internals and the key.
 ///
 /// `append_within` MUST NOT commit or roll back `tx` — it only stages its rows so
 /// the CALLER's `tx.commit()` makes the table write and the audit append all-or-

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -585,6 +585,11 @@ mod nodes;
 pub use nodes::{assert_node_store_contract, InMemoryNodeStore, NodeStore};
 mod attestation;
 mod audit;
+// ADR-0035 Addendum A, Stage 2.5 step 1 (prototype on `posture`) — the injected
+// audit-append seam that inverts the C1 audit-chaining coupling while preserving
+// the row+append one-transaction atomicity.
+mod audit_appender;
+pub use audit_appender::{AuditAppender, ChainedAuditAppender};
 mod av_subsystem;
 // ADR-0035 Stage 2 (trait-seam inversion) — the AV-subsystem diagnostic-meta storage
 // trait + its in-memory reference backend (confidence floor + telemetry stamp +

--- a/src/verifier_store/posture.rs
+++ b/src/verifier_store/posture.rs
@@ -130,13 +130,13 @@ impl VerifierStore {
     }
 
     /// Shared body of every chained posture-event write. Runs the posture-row
-    /// INSERT, the `AuditChainLinker` append, and (when `generation` is `Some`)
-    /// the monotonic high-water UPSERT in ONE `Immediate` transaction on the
-    /// GIVEN connection. Callers pass either the NORMAL `conn` (checkpoint-bounded
-    /// durability, INV-12 throughput path) or the FULL `durable_conn` (per-commit
-    /// fsync — hard-power-loss durable at write time, #772 F2). Threading the
-    /// connection + signing key as params keeps the durable and normal variants a
-    /// single source of truth so they cannot drift.
+    /// INSERT, the injected audit append (via the `AuditAppender` seam), and (when
+    /// `generation` is `Some`) the monotonic high-water UPSERT in ONE `Immediate`
+    /// transaction on the GIVEN connection. Callers pass either the NORMAL `conn`
+    /// (checkpoint-bounded durability, INV-12 throughput path) or the FULL
+    /// `durable_conn` (per-commit fsync — hard-power-loss durable at write time,
+    /// #772 F2). Threading the connection + appender as params keeps the durable and
+    /// normal variants a single source of truth so they cannot drift.
     ///
     /// Returns whether the high-water ADVANCED (`false` when `generation` is
     /// `None`, or when the monotonic guard rejected a stale/equal generation).

--- a/src/verifier_store/posture.rs
+++ b/src/verifier_store/posture.rs
@@ -143,7 +143,14 @@ impl VerifierStore {
     #[allow(clippy::too_many_arguments)] // faithful pass-through of the write's columns
     fn write_posture_event_chained_tx(
         conn: &mut Connection,
-        signing_key: Option<&ed25519_dalek::SigningKey>,
+        // ADR-0035 Addendum A, Stage 2.5 step 1: the audit append now goes through
+        // an INJECTED `AuditAppender` instead of a direct `AuditChainLinker` +
+        // signing-key call. The store still owns the transaction (`tx` below), so
+        // the posture row and the audit append stay all-or-nothing — the appender
+        // only stages its rows into `tx`; this method's `tx.commit()` is what makes
+        // them atomic. The production caller injects `ChainedAuditAppender`, so the
+        // audit-chain bytes are byte-identical to the prior direct call.
+        appender: &dyn AuditAppender,
         node_id: &str,
         event_type: &str,
         posture_json: &str,
@@ -164,13 +171,7 @@ impl VerifierStore {
                 created_at_ms as i64
             ],
         )?;
-        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
-            &tx,
-            event_type,
-            posture_json,
-            created_at_ms as i64,
-            signing_key,
-        )?;
+        appender.append_within(&tx, event_type, posture_json, created_at_ms as i64)?;
         let advanced = match generation {
             Some(g) => {
                 // Monotonic max-write — identical guard to `save_last_generation`,
@@ -208,7 +209,9 @@ impl VerifierStore {
         // `self.signing_key` — different fields, so both live at once.
         Self::write_posture_event_chained_tx(
             &mut self.conn,
-            self.signing_key.as_ref(),
+            &ChainedAuditAppender {
+                signing_key: self.signing_key.as_ref(),
+            },
             node_id,
             event_type,
             posture_json,
@@ -252,7 +255,9 @@ impl VerifierStore {
         }
         Self::write_posture_event_chained_tx(
             &mut self.conn,
-            self.signing_key.as_ref(),
+            &ChainedAuditAppender {
+                signing_key: self.signing_key.as_ref(),
+            },
             node_id,
             event_type,
             posture_json,
@@ -294,7 +299,9 @@ impl VerifierStore {
         let conn = self.durable_conn.as_mut().unwrap_or(&mut self.conn);
         Self::write_posture_event_chained_tx(
             conn,
-            self.signing_key.as_ref(),
+            &ChainedAuditAppender {
+                signing_key: self.signing_key.as_ref(),
+            },
             node_id,
             event_type,
             posture_json,
@@ -340,7 +347,9 @@ impl VerifierStore {
         let conn = self.durable_conn.as_mut().unwrap_or(&mut self.conn);
         Self::write_posture_event_chained_tx(
             conn,
-            self.signing_key.as_ref(),
+            &ChainedAuditAppender {
+                signing_key: self.signing_key.as_ref(),
+            },
             node_id,
             event_type,
             posture_json,
@@ -459,5 +468,149 @@ impl VerifierStore {
             params![key, value],
         )?;
         Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ADR-0035 Addendum A, Stage 2.5 step 1 (prototype) — proof-of-mechanics that the
+// injected `AuditAppender` seam (a) still produces a byte-identical, verifiable
+// signed chain, (b) participates ATOMICALLY in the store's transaction (a failing
+// appender rolls the posture row back too), and (c) receives the store's event.
+// These drive the private `write_posture_event_chained_tx` with CUSTOM appenders,
+// which is only possible because the append is now injected rather than hardwired.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod audit_appender_seam_tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn count_posture_events(store: &VerifierStore) -> i64 {
+        store
+            .conn
+            .query_row("SELECT COUNT(*) FROM posture_events", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    /// An appender that always fails — to prove the caller-owned transaction rolls
+    /// back the posture row when the injected append errors (atomicity).
+    struct FailingAppender;
+    impl AuditAppender for FailingAppender {
+        fn append_within(
+            &self,
+            _tx: &rusqlite::Transaction<'_>,
+            _event_type: &str,
+            _payload: &str,
+            _created_at_ms: i64,
+        ) -> rusqlite::Result<()> {
+            Err(rusqlite::Error::QueryReturnedNoRows)
+        }
+    }
+
+    /// An appender that records what it was asked to append (and stages no audit
+    /// row) — to prove the store routes its event through the seam verbatim.
+    struct RecordingAppender {
+        seen: std::cell::RefCell<Vec<(String, String, i64)>>,
+    }
+    impl AuditAppender for RecordingAppender {
+        fn append_within(
+            &self,
+            _tx: &rusqlite::Transaction<'_>,
+            event_type: &str,
+            payload: &str,
+            created_at_ms: i64,
+        ) -> rusqlite::Result<()> {
+            self.seen.borrow_mut().push((
+                event_type.to_string(),
+                payload.to_string(),
+                created_at_ms,
+            ));
+            Ok(())
+        }
+    }
+
+    /// (a) The production path (which now injects `ChainedAuditAppender`) produces a
+    /// signed chain that fully verifies — byte-identical to the prior direct call.
+    #[test]
+    fn chained_appender_seam_produces_a_verifiable_chain() {
+        let mut store = VerifierStore::new(":memory:").expect("store");
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        store.set_signing_key(sk.clone());
+
+        store
+            .save_posture_event_chained(
+                "node-1",
+                "POSTURE_TRANSITION",
+                "{\"p\":\"Nominal\"}",
+                None,
+                1_000,
+            )
+            .unwrap();
+
+        let result = store
+            .verify_audit_chain_full(Some(&sk.verifying_key()))
+            .unwrap();
+        assert!(
+            result.verified(),
+            "the chain built through the injected appender must fully verify"
+        );
+        assert_eq!(count_posture_events(&store), 1);
+    }
+
+    /// (b) THE CRUX: the injected append participates in the store's transaction.
+    /// A failing appender aborts the whole write — the posture row is rolled back,
+    /// so atomicity (the power-loss invariant) survives the dependency inversion.
+    #[test]
+    fn injected_appender_failure_rolls_back_the_posture_row_atomically() {
+        let mut store = VerifierStore::new(":memory:").expect("store");
+        assert_eq!(count_posture_events(&store), 0);
+
+        let r = VerifierStore::write_posture_event_chained_tx(
+            &mut store.conn,
+            &FailingAppender,
+            "node-1",
+            "POSTURE_TRANSITION",
+            "{}",
+            None,
+            1_000,
+            None,
+        );
+        assert!(r.is_err(), "a failing appender must abort the write");
+        assert_eq!(
+            count_posture_events(&store),
+            0,
+            "the posture row must roll back with the failed audit append (atomic)"
+        );
+    }
+
+    /// (c) The store routes its event through the seam verbatim (type + payload +
+    /// timestamp), so any injected appender sees exactly what the table row carries.
+    #[test]
+    fn store_delegates_the_event_to_the_injected_appender() {
+        let mut store = VerifierStore::new(":memory:").expect("store");
+        let recorder = RecordingAppender {
+            seen: std::cell::RefCell::new(Vec::new()),
+        };
+        VerifierStore::write_posture_event_chained_tx(
+            &mut store.conn,
+            &recorder,
+            "node-1",
+            "POSTURE_CACHE_REFRESHED",
+            "{\"p\":\"Degraded\"}",
+            None,
+            4_242,
+            None,
+        )
+        .unwrap();
+        let seen = recorder.seen.borrow();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(
+            seen[0],
+            (
+                "POSTURE_CACHE_REFRESHED".to_string(),
+                "{\"p\":\"Degraded\"}".to_string(),
+                4_242
+            ),
+            "the injected appender receives the row's event verbatim"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Proof-of-mechanics for the **hard-tier plan in ADR-0035 Addendum A** — inverting the **C1 audit-chaining coupling** so a future `kirra-persistence` crate no longer depends on `crate::audit_chain` or the Ed25519 signing key, **without losing the row+append one-transaction atomicity** that the power-loss drill guards.

Prototyped on `posture`, the smallest C1-only family. **This PR is for review of the seam shape before I roll it out across the audit-chained families** — please sign off on the design here.

### The problem (C1)
The hard-tier families (`audit`, `federation`, `ota_campaigns`, `posture`, `attestation`, `fabric`) write their table row **and** append a signed `AuditChainLinker` event **in the same transaction**, using the store's `signing_key`. That atomicity is load-bearing (`audit_chain_prefix_on_kill` proves the chain never forks), so the append can't simply move up to the authority layer.

### The seam (`src/verifier_store/audit_appender.rs`)
- **`AuditAppender` trait** — `append_within(&tx, event_type, payload, at_ms)` stages an audit row into a **caller-owned transaction**. It must not commit/roll back; the store's own `tx.commit()` makes the table write + audit append all-or-nothing.
- **`ChainedAuditAppender`** — the production impl, holding the signing key and delegating to the *exact same* `AuditChainLinker::append_audit_event_tx`. **Byte-identical audit-chain bytes.**
- `posture::write_posture_event_chained_tx` now takes `&dyn AuditAppender` instead of `Option<&SigningKey>` and calls `appender.append_within(&tx, …)` inside its own `Immediate` transaction; the four callers inject `ChainedAuditAppender { signing_key: self.signing_key.as_ref() }`. Behaviour-preserving.

At the eventual crate split, `ChainedAuditAppender` (the one type that knows both the chain logic and the key) lives in the safety-authority layer and is injected into persistence — overlapping Stage 3's signing-key-ownership relocation, as the addendum notes.

### The three proofs (drive the private write path with custom appenders — only possible because the append is now injected)
1. `chained_appender_seam_produces_a_verifiable_chain` — the production path produces a fully-verifiable signed chain (byte-identical).
2. `injected_appender_failure_rolls_back_the_posture_row_atomically` — **the crux**: a failing injected appender aborts the whole write, rolling the posture row back. Atomicity survives the inversion.
3. `store_delegates_the_event_to_the_injected_appender` — the store routes its event through the seam verbatim.

## Verification
- The 3 new tests + the existing `posture` / audit-chain suites + the full **784-test lib suite** green
- The **power-loss drill** (`cargo test --test audit_chain_prefix_on_kill`) green
- fmt-clean · quality-guardrails satisfied · orphan-core gate green
- No new deps, no lockfile change, **no behaviour change** (byte-identical audit chain)

## If the design is approved
Roll the seam out to the remaining C1 families: `attestation` (the other C1-only) next, then the C1+C2 families (`federation`, `ota_campaigns`, `fabric`, `audit`) as their domain types are relocated (Addendum A step 2). Then `kirra-persistence` extracts mechanically.

## Design questions for review
- `&dyn AuditAppender` (dynamic dispatch) vs. a generic `A: AuditAppender` on the write path — I chose `&dyn` to avoid threading a generic through every caller; the posture write is a DB path (not the WCET-gated governor path), so the vtable call is negligible. OK?
- Trait method surface: `append_within(&tx, event_type, payload, at_ms)` mirrors `append_audit_event_tx`'s non-key params exactly. Good shape for the C1+C2 families too, or should it carry more context?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_