### PR TITLE
ADR-0035 Stage 2.5: complete the C1 audit-append inversion (all verifier_store families)

### DIFF
--- a/src/verifier_store/attestation.rs
+++ b/src/verifier_store/attestation.rs
@@ -26,12 +26,19 @@ impl VerifierStore {
             "registration_source": source,
             "registered_at_ms": registered_at_ms,
         });
-        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
+        // ADR-0035 Addendum A, Stage 2.5 step 1: the audit append goes through the
+        // injected `AuditAppender` seam (into this tx), not a direct
+        // `AuditChainLinker` + signing-key call — the row + append stay atomic on
+        // `tx.commit()`. `ChainedAuditAppender` delegates to the same appender, so
+        // the audit-chain bytes are byte-identical to the prior call.
+        ChainedAuditAppender {
+            signing_key: self.signing_key.as_ref(),
+        }
+        .append_within(
             &tx,
             "NODE_IDENTITY_REGISTERED",
             &audit_payload.to_string(),
             registered_at_ms as i64,
-            self.signing_key.as_ref(),
         )?;
 
         tx.commit()
@@ -47,5 +54,38 @@ impl VerifierStore {
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(e),
         }
+    }
+}
+
+#[cfg(test)]
+mod attestation_appender_seam_tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    /// ADR-0035 Addendum A: identity registration now appends its
+    /// `NODE_IDENTITY_REGISTERED` audit event through the injected `AuditAppender`
+    /// seam. Behaviour-preserving: the row persists AND the resulting signed chain
+    /// fully verifies (byte-identical to the prior direct `AuditChainLinker` call).
+    #[test]
+    fn identity_registration_through_the_seam_produces_a_verifiable_chain() {
+        let mut store = VerifierStore::new(":memory:").expect("store");
+        let sk = SigningKey::from_bytes(&[9u8; 32]);
+        store.set_signing_key(sk.clone());
+
+        store
+            .register_attestation_identity("node-1", "fp-abc", "self-report", 1_000)
+            .unwrap();
+
+        assert_eq!(
+            store.load_registered_fingerprint("node-1").unwrap(),
+            Some("fp-abc".to_string())
+        );
+        assert!(
+            store
+                .verify_audit_chain_full(Some(&sk.verifying_key()))
+                .unwrap()
+                .verified(),
+            "the chain built through the injected appender must fully verify"
+        );
     }
 }

--- a/src/verifier_store/audit.rs
+++ b/src/verifier_store/audit.rs
@@ -1155,13 +1155,14 @@ impl VerifierStore {
             // #79 HA epoch fence — FIRST statement, before any mutation. A node
             // fenced after the request-path gate cannot land a stale rotation.
             Self::assert_epoch_held(&tx, held_epoch)?;
-            crate::audit_chain::AuditChainLinker::append_audit_event_tx(
-                &tx,
-                "KEY_ROTATION",
-                &payload.to_string(),
-                now_ms as i64,
-                old_key.as_ref(),
-            )?;
+            // The KEY_ROTATION row is signed by the OUTGOING key (`old_key`) so the
+            // chain verifies up to the rotation boundary under the old key. The
+            // injected appender simply HOLDS that key — byte-identical to the prior
+            // direct call.
+            ChainedAuditAppender {
+                signing_key: old_key.as_ref(),
+            }
+            .append_within(&tx, "KEY_ROTATION", &payload.to_string(), now_ms as i64)?;
             tx.execute(
                 "INSERT INTO audit_key_ledger \
                  (key_id, prev_key_id, role, pubkey_b64, signature_b64, created_at_ms) \
@@ -1224,13 +1225,10 @@ impl VerifierStore {
         let payload = format!(
             "{{\"genesis_key_id\":\"{genesis_id}\",\"backfilled_rows\":{null_count},\"migrated_at_ms\":{now_ms}}}"
         );
-        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
-            &tx,
-            "KEY_ID_BACKFILL",
-            &payload,
-            now_ms as i64,
-            self.signing_key.as_ref(),
-        )?;
+        ChainedAuditAppender {
+            signing_key: self.signing_key.as_ref(),
+        }
+        .append_within(&tx, "KEY_ID_BACKFILL", &payload, now_ms as i64)?;
         tx.commit()?;
         Ok(())
     }
@@ -1340,13 +1338,10 @@ impl VerifierStore {
             "{{\"v1_head_record_hash\":\"{v1_head}\",\"v1_total_count\":{v1_total},\"migrated_at_ms\":{now_ms}}}"
         );
         let tx = Self::audit_tx(&mut self.conn)?; // #685: Immediate — non-forking audit append
-        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
-            &tx,
-            "HASH_V2_MIGRATION",
-            &payload,
-            now_ms as i64,
-            self.signing_key.as_ref(),
-        )?;
+        ChainedAuditAppender {
+            signing_key: self.signing_key.as_ref(),
+        }
+        .append_within(&tx, "HASH_V2_MIGRATION", &payload, now_ms as i64)?;
         tx.commit()
     }
 

--- a/src/verifier_store/federation.rs
+++ b/src/verifier_store/federation.rs
@@ -128,12 +128,14 @@ impl VerifierStore {
             "nonce_hex": report.nonce_hex,
             "received_at_ms": received_at_ms,
         });
-        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
+        ChainedAuditAppender {
+            signing_key: signing_key.as_ref(),
+        }
+        .append_within(
             &tx,
             "FEDERATED_TRUST_REPORT_ACCEPTED",
             &audit.to_string(),
             received_at_ms as i64,
-            signing_key.as_ref(),
         )?;
 
         // Item 20 — in-chain AUDIT_GAP marker. A forward generation jump means this
@@ -152,12 +154,14 @@ impl VerifierStore {
                 "missing_through_generation": gen - 1,
                 "skipped_generations": gen - hw - 1,
             });
-            crate::audit_chain::AuditChainLinker::append_audit_event_tx(
+            ChainedAuditAppender {
+                signing_key: signing_key.as_ref(),
+            }
+            .append_within(
                 &tx,
                 "FEDERATION_GENERATION_GAP",
                 &gap.to_string(),
                 received_at_ms as i64,
-                signing_key.as_ref(),
             )?;
         }
 

--- a/src/verifier_store/operators.rs
+++ b/src/verifier_store/operators.rs
@@ -69,12 +69,14 @@ impl VerifierStore {
             ],
         )?;
         let id = tx.last_insert_rowid();
-        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
+        ChainedAuditAppender {
+            signing_key: self.signing_key.as_ref(),
+        }
+        .append_within(
             &tx,
             "OperatorClearanceGrantIssued",
             &payload,
             granted_at_ms as i64,
-            self.signing_key.as_ref(),
         )?;
         tx.commit()?;
         Ok(id)
@@ -161,13 +163,10 @@ impl VerifierStore {
         created_at_ms: u64,
     ) -> Result<()> {
         let tx = Self::audit_tx(&mut self.conn)?; // #685: Immediate — non-forking audit append
-        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
-            &tx,
-            event_type,
-            payload_json,
-            created_at_ms as i64,
-            self.signing_key.as_ref(),
-        )?;
+        ChainedAuditAppender {
+            signing_key: self.signing_key.as_ref(),
+        }
+        .append_within(&tx, event_type, payload_json, created_at_ms as i64)?;
         tx.commit()
     }
 
@@ -238,13 +237,10 @@ impl VerifierStore {
             "UPDATE clearance_grants SET outcome = ?2, outcome_detail = ?3 WHERE id = ?1",
             params![grant_rowid, outcome, detail],
         )?;
-        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
-            &tx,
-            event_type,
-            &payload,
-            now_ms as i64,
-            self.signing_key.as_ref(),
-        )?;
+        ChainedAuditAppender {
+            signing_key: self.signing_key.as_ref(),
+        }
+        .append_within(&tx, event_type, &payload, now_ms as i64)?;
         tx.commit()
     }
 

--- a/src/verifier_store/ota_campaigns.rs
+++ b/src/verifier_store/ota_campaigns.rs
@@ -49,12 +49,14 @@ impl VerifierStore {
                 campaign.uptane_metadata_json,
             ],
         )?;
-        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
+        ChainedAuditAppender {
+            signing_key: self.signing_key.as_ref(),
+        }
+        .append_within(
             &tx,
             "OtaCampaignCreated",
             &payload,
             campaign.updated_at_ms as i64,
-            self.signing_key.as_ref(),
         )?;
         tx.commit()
     }
@@ -89,13 +91,10 @@ impl VerifierStore {
             // No such campaign — do NOT write an audit entry for a phantom mutation.
             return Err(rusqlite::Error::QueryReturnedNoRows);
         }
-        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
-            &tx,
-            event_type,
-            &payload,
-            campaign.updated_at_ms as i64,
-            self.signing_key.as_ref(),
-        )?;
+        ChainedAuditAppender {
+            signing_key: self.signing_key.as_ref(),
+        }
+        .append_within(&tx, event_type, &payload, campaign.updated_at_ms as i64)?;
         tx.commit()
     }
 


### PR DESCRIPTION
## Summary

Completes ADR-0035 Addendum A **Stage 2.5 step 1** — inverting the **C1 audit-chaining coupling** across **all** hard-tier `verifier_store` families, using the `AuditAppender` seam whose design was proven and merged on `posture` in #924.

**Every production audit-append in `verifier_store` now goes through `ChainedAuditAppender.append_within(&tx, …)` inside the store-owned transaction** — instead of a direct `crate::audit_chain::AuditChainLinker::append_audit_event_tx(…, signing_key)` call. The store still owns the transaction, so the table write + audit append stay atomic on `tx.commit()`; `ChainedAuditAppender` delegates to the same appender, so the **audit-chain bytes are byte-identical**.

| Family | Events moved onto the seam |
| :-- | :-- |
| `attestation` | `NODE_IDENTITY_REGISTERED` |
| `federation` | `FEDERATED_TRUST_REPORT_ACCEPTED`, `FEDERATION_GENERATION_GAP` (signs with the fenced-write **local** key) |
| `ota_campaigns` | `OtaCampaignCreated` + the lifecycle-transition event |
| `operators` | `OperatorClearanceGrantIssued`, the delivery-outcome event, the rejected-attempt console event |
| `audit` | `KEY_ID_BACKFILL`, `HASH_V2_MIGRATION`, and `KEY_ROTATION` (signs its ledger row with the **outgoing** key `old_key`) |

**The seam is validated across all the key-provenance variants** — `self.signing_key`, a fenced-write local key (federation), and the *outgoing* key on rotation (audit). The appender simply holds whatever key the site used, so no special-casing and byte-identical output.

### Honest scope note
This inverts the audit-**append** coupling (the atomicity-critical write path). `audit.rs`'s **verify** path still calls `AuditChainLinker::compute_record_hash_v1/v2` for read-side hash recomputation — a separate, non-atomicity concern left as-is. The one intended remaining reference to `append_audit_event_tx` is inside `ChainedAuditAppender` itself (the single delegation point). `fabric` had no append call site (its earlier count was a doc-comment reference).

## Why this matters
A future `kirra-persistence` crate now depends only on the `AuditAppender` trait for its writes — not on `crate::audit_chain` or the Ed25519 signing key (which relocate to the safety-authority layer and are injected, overlapping Stage 3's signing-key ownership move). C1 is the load-bearing coupling; **it is now fully broken.**

## Verification
- Full **785-test lib suite** (incl. key-rotation, clearance-grant, federation chained-report, campaign-lifecycle, and audit chain-verify tests) green
- The **power-loss drill** (`cargo test --test audit_chain_prefix_on_kill`) green
- fmt-clean · quality-guardrails satisfied · orphan-core gate green
- No new deps, no lockfile change, **no behaviour change** (byte-identical audit chain)

## What's next (Stage 2.5 step 2)
The **C2 domain-type relocation** — move `FederatedTrustReport` / `Campaign` / `CausalLogEntry` / `FabricAsset` / verdict ids to a lower shared crate — after which `kirra-persistence` can extract mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)