### PR TITLE
ADR-0035: kirra-persistence enabling slices 1–2 (relocate RegisteredNode; split audit_chain pure core)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1087,7 +1087,11 @@ jobs:
           python3 -m pip install --quiet pytest
           python3 -m pytest ros2_ws/src/kirra_safety/test/ -q
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        # `--locked` pins cargo-audit's OWN committed lockfile so a transitive dep
+        # that later bumps its MSRV above our pinned toolchain (e.g. kstring 2.0.3
+        # requiring rustc 1.96 while we pin 1.94) cannot break this install. Without
+        # it cargo resolves deps to latest-compatible and the tool fails to build.
+        run: cargo install cargo-audit --locked
       - name: Clippy
         # --all-targets lints tests/benches/examples too — test-code lint debt
         # had been slipping past the lib+bins-only default (review follow-up).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,6 +2120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-audit-hash"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "hex",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "kirra-capture-schema"
 version = "0.1.0"
 dependencies = [
@@ -2457,6 +2466,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "kirra-audit-hash",
  "kirra-capture-schema",
  "kirra-contract-channel",
  "kirra-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@
 # runtime (ORT etc.) is absent, strict-fail only in the CI lane that installs
 # it (see parko-onnx's PARKO_ONNX_REQUIRE_ORT).
 [workspace]
-members = [".", "crates/kirra-core", "crates/kirra-policy-types", "crates/kirra-industrial", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-inline-governor", "crates/kirra-l3-e2e", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval", "crates/kirra-kpi-gate", "crates/kirra-ota-installer", "crates/kirra-ota-campaign", "crates/kirra-fabric-types", "crates/kirra-replay", "crates/kirra-actuation-consumer", "crates/kirra-sidecars", "crates/kirra-consumer-ffi"]
+members = [".", "crates/kirra-core", "crates/kirra-policy-types", "crates/kirra-industrial", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-inline-governor", "crates/kirra-l3-e2e", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval", "crates/kirra-kpi-gate", "crates/kirra-ota-installer", "crates/kirra-ota-campaign", "crates/kirra-fabric-types", "crates/kirra-audit-hash", "crates/kirra-replay", "crates/kirra-actuation-consumer", "crates/kirra-sidecars", "crates/kirra-consumer-ffi"]
 resolver = "2"
 
 [package]
@@ -113,6 +113,7 @@ kirra-contract-channel = { path = "crates/kirra-contract-channel" }
 kirra-release-token = { path = "crates/kirra-release-token", features = ["serde"] }
 kirra-ota-campaign = { path = "crates/kirra-ota-campaign" }
 kirra-fabric-types = { path = "crates/kirra-fabric-types" }
+kirra-audit-hash = { path = "crates/kirra-audit-hash" }
 parko-core = { path = "parko/crates/parko-core" }
 # Governor-free wire schema for capture records, shared verbatim with the offline
 # collector (docs/COLLECTOR_DESIGN.md [C1]). Re-exported by `crate::capture`.

--- a/crates/kirra-audit-hash/Cargo.toml
+++ b/crates/kirra-audit-hash/Cargo.toml
@@ -1,0 +1,34 @@
+# crates/kirra-audit-hash/Cargo.toml
+#
+# ADR-0035 — the kirra-persistence enabling work (slice 2). The PURE audit/causal
+# chain primitives — the SHA-256 record-hash computations, the domain-separated
+# canonical signing/anchor-head payload encoders, the content-addressed
+# `verifying_key_id`, and `CausalRecordHashInput` — extracted from the heavy
+# `src/audit_chain.rs` (which also holds the rusqlite-backed `AuditChainLinker`
+# append machinery) so the persistence layer (`verifier_store`) can compute + verify
+# hashes WITHOUT depending on the root crate's audit module. No rusqlite, no state.
+#
+# The STATEFUL `AuditChainLinker` (append-into-a-transaction) stays in the root crate
+# (the safety-authority layer) and calls these functions; root's `audit_chain`
+# re-exports this crate so every existing `crate::audit_chain::<fn>` path is unchanged.
+#
+# Byte-exactness is load-bearing: these encoders define the on-disk audit-chain
+# format. The functions were moved VERBATIM — same domain tags, same length-prefixing,
+# same little-endian field order — so every stored signature/hash verifies identically.
+
+[package]
+name = "kirra-audit-hash"
+version = "0.1.0"
+edition = "2021"
+description = "Pure audit/causal hash-chain primitives for Kirra — SHA-256 record hashes, domain-separated canonical signing/anchor-head payloads, content-addressed key ids. No DB, no state."
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+license-file = "../../COPYRIGHT"
+publish = false  # proprietary (see COPYRIGHT) — not for crates.io
+
+[dependencies]
+# The vetted SHA-256 — the digest primitive (same crate+version the root uses).
+sha2 = "0.10"
+# Hex encoding of digests (matches the on-disk `*_hex` columns).
+hex = "0.4"
+# `verifying_key_id` hashes the raw 32-byte Ed25519 verifying key.
+ed25519-dalek = { version = "2", features = ["rand_core"] }

--- a/crates/kirra-audit-hash/Cargo.toml
+++ b/crates/kirra-audit-hash/Cargo.toml
@@ -30,5 +30,7 @@ publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 sha2 = "0.10"
 # Hex encoding of digests (matches the on-disk `*_hex` columns).
 hex = "0.4"
-# `verifying_key_id` hashes the raw 32-byte Ed25519 verifying key.
-ed25519-dalek = { version = "2", features = ["rand_core"] }
+# `verifying_key_id` hashes the raw 32-byte Ed25519 verifying key. VerifyingKey +
+# `as_bytes()` only — no key generation, so the `rand_core` feature is not needed
+# (keeping this leaf's feature surface minimal under feature unification).
+ed25519-dalek = "2"

--- a/crates/kirra-audit-hash/src/lib.rs
+++ b/crates/kirra-audit-hash/src/lib.rs
@@ -1,0 +1,197 @@
+//! Pure audit/causal hash-chain primitives (ADR-0035 — the `kirra-persistence`
+//! enabling work, slice 2).
+//!
+//! The SHA-256 record-hash computations and the domain-separated canonical
+//! signing/anchor-head payload encoders that define the on-disk audit-chain and
+//! fabric causal-log formats, plus the content-addressed [`verifying_key_id`].
+//! Moved VERBATIM from the root crate's `audit_chain` module so the persistence
+//! layer can compute + verify hashes without depending on the root — the stateful
+//! `AuditChainLinker` (append-into-a-transaction, rusqlite) stays in root and calls
+//! these. No DB, no state.
+//!
+//! **Byte-exactness is load-bearing.** These encoders ARE the wire/on-disk format:
+//! same domain tags (`KIRRA-AUDIT-V2`, `KIRRA-CAUSAL-V1`, `kirra-*:v1`), same
+//! length-prefixing, same little-endian field order. Any change re-defines the
+//! format and invalidates every stored signature/hash.
+
+use sha2::{Digest, Sha256};
+
+/// V1 canonical signing payload — kept ONLY for verifying pre-migration
+/// rows. Format: `{prev_hash}:{entry_hash}:{event_type}:{timestamp_ms}`.
+pub fn canonical_signing_payload(
+    prev_hash: &str,
+    entry_hash: &str,
+    event_type: &str,
+    timestamp_ms: i64,
+) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        prev_hash, entry_hash, event_type, timestamp_ms
+    )
+}
+
+/// V2 canonical signing payload. Binds `sequence` and explicit version
+/// tag so a v2 signature cannot be confused with a v1 signature over the
+/// same prev/entry/event_type/ts. Used for all new rows.
+pub fn canonical_signing_payload_v2(
+    prev_hash: &str,
+    entry_hash: &str,
+    event_type: &str,
+    timestamp_ms: i64,
+    sequence: u64,
+) -> String {
+    format!("v2:{prev_hash}:{entry_hash}:{event_type}:{timestamp_ms}:{sequence}")
+}
+
+/// Canonical signing payload for the audit anchor-HEAD high-water mark (#77).
+///
+/// Binds the highest committed chain position `(sequence, record_hash)`.
+/// Domain-separated (`kirra-audit-head:v1` prefix) so a head signature can never
+/// be replayed as a row signature — or vice versa — under the same key.
+pub fn canonical_anchor_head_payload(sequence: u64, record_hash: &str) -> String {
+    format!("kirra-audit-head:v1:{sequence}:{record_hash}")
+}
+
+// --- Fabric causal-log forensic chain primitives (issue #87) ---------------
+//
+// The fabric causal log is a hash-chained, signed, persisted forensic ledger
+// that MIRRORS the audit chain machinery, but is domain-separated so a causal
+// signature/hash can never be confused with an audit one. The record hash binds
+// the CAUSALITY EDGES (`caused_by`, `affects_assets`, `fabric_generation`) plus
+// `previous_hash` and `sequence` — tampering an edge changes the record hash.
+
+/// Bundled inputs for [`compute_causal_record_hash`].
+#[derive(Debug, Clone)]
+pub struct CausalRecordHashInput<'a> {
+    pub previous_hash: &'a str,
+    pub entry_id: &'a str,
+    pub asset_id: &'a str,
+    pub event_type: &'a str,
+    pub payload: &'a str,
+    pub caused_by: &'a [String],
+    pub affects_assets: &'a [String],
+    pub timestamp_ms: u64,
+    pub fabric_generation: u64,
+    pub sequence: u64,
+}
+
+/// Causal record hash (issue #87). SHA-256 over a domain-separated,
+/// length-prefixed encoding that BINDS the causality edges.
+///
+/// Domain tag `KIRRA-CAUSAL-V1` (distinct from `KIRRA-AUDIT-V2`). Every
+/// variable-length scalar field is preceded by its 8-byte LE length; each edge
+/// VECTOR is preceded by its element count (8-byte LE) and every element by its
+/// own 8-byte LE length. Fixed-width integers are appended as LE bytes.
+pub fn compute_causal_record_hash(input: &CausalRecordHashInput<'_>) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"KIRRA-CAUSAL-V1");
+    for field in [
+        input.previous_hash.as_bytes(),
+        input.entry_id.as_bytes(),
+        input.asset_id.as_bytes(),
+        input.event_type.as_bytes(),
+        input.payload.as_bytes(),
+    ] {
+        hasher.update((field.len() as u64).to_le_bytes());
+        hasher.update(field);
+    }
+    // Edge vectors: count-prefixed, each element length-prefixed. This is what
+    // binds the causality edges into the record hash.
+    for vec in [input.caused_by, input.affects_assets] {
+        hasher.update((vec.len() as u64).to_le_bytes());
+        for elem in vec {
+            hasher.update((elem.len() as u64).to_le_bytes());
+            hasher.update(elem.as_bytes());
+        }
+    }
+    hasher.update(input.timestamp_ms.to_le_bytes());
+    hasher.update(input.fabric_generation.to_le_bytes());
+    hasher.update(input.sequence.to_le_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// Canonical signing payload for a causal-log row (issue #87).
+///
+/// The Ed25519 signature is over `record_hash`, which TRANSITIVELY binds the
+/// causality edges. `previous_hash` and `sequence` also appear explicitly so the
+/// row's chain position is signed directly. Domain prefix `kirra-causal:v1`.
+pub fn canonical_causal_signing_payload(
+    previous_hash: &str,
+    record_hash: &str,
+    event_type: &str,
+    timestamp_ms: u64,
+    sequence: u64,
+) -> String {
+    format!("kirra-causal:v1:{previous_hash}:{record_hash}:{event_type}:{timestamp_ms}:{sequence}")
+}
+
+/// Canonical signing payload for the causal anchor-HEAD high-water mark (#87).
+/// Domain-separated (`kirra-causal-head:v1`) from BOTH the audit head and the
+/// causal row payload, so no signature can be replayed across the three roles.
+pub fn canonical_causal_anchor_head_payload(sequence: u64, record_hash: &str) -> String {
+    format!("kirra-causal-head:v1:{sequence}:{record_hash}")
+}
+
+/// Content-addressed key id for an audit signing key: hex SHA-256 of the
+/// 32-byte Ed25519 verifying-key bytes. No DER/SPKI round-trip — matches how
+/// the chain already stores pubkeys (raw 32-byte values), needs no allocator.
+/// A row's `key_id` is derivable from the key that signed it, so the verifier
+/// can select the correct verifying key PER ROW (issue #76).
+#[must_use]
+pub fn verifying_key_id(vk: &ed25519_dalek::VerifyingKey) -> String {
+    let mut h = Sha256::new();
+    h.update(vk.as_bytes());
+    hex::encode(h.finalize())
+}
+
+/// V1 (legacy) record hash: prev || event_json || created_at_ms.
+/// Does NOT bind `event_type` — retained ONLY to verify pre-migration rows.
+pub fn compute_record_hash_v1(
+    previous_hash: &str,
+    canonical_json: &str,
+    created_at_ms: i64,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(previous_hash.as_bytes());
+    hasher.update(canonical_json.as_bytes());
+    hasher.update(created_at_ms.to_string().as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// Back-compat alias for [`compute_record_hash_v1`].
+pub fn compute_record_hash(
+    previous_hash: &str,
+    canonical_json: &str,
+    created_at_ms: i64,
+) -> String {
+    compute_record_hash_v1(previous_hash, canonical_json, created_at_ms)
+}
+
+/// V2 record hash. Binds `event_type` and `sequence` into the hash so
+/// event_type relabeling and row reordering are caught by the cheap hash-only
+/// integrity check — without needing signatures.
+///
+/// Domain-separated (`KIRRA-AUDIT-V2` prefix) and length-prefixed (each
+/// variable-length field is preceded by its 8-byte LE length) so field-splicing
+/// ambiguities (`"AB"+"C"` vs `"A"+"BC"`) cannot collide.
+pub fn compute_record_hash_v2(
+    previous_hash: &str,
+    event_type: &str,
+    event_json: &str,
+    created_at_ms: i64,
+    sequence: u64,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"KIRRA-AUDIT-V2");
+    for field in [
+        previous_hash.as_bytes(),
+        event_type.as_bytes(),
+        event_json.as_bytes(),
+    ] {
+        hasher.update((field.len() as u64).to_le_bytes());
+        hasher.update(field);
+    }
+    hasher.update(created_at_ms.to_le_bytes());
+    hasher.update(sequence.to_le_bytes());
+    hex::encode(hasher.finalize())
+}

--- a/crates/kirra-core/src/lib.rs
+++ b/crates/kirra-core/src/lib.rs
@@ -119,6 +119,32 @@ pub enum NodeTrustState {
     Unknown,
 }
 
+/// A node in the fleet registry — its identity, trust state, and the attestation
+/// material captured at registration. Plain persisted data (the `nodes` table);
+/// carries no behaviour. Relocated to the lean foundation (ADR-0035 — the
+/// `kirra-persistence` enabling work) alongside [`NodeTrustState`] so the
+/// persistence layer can name it without the verifier service tree; re-exported as
+/// `crate::verifier::RegisteredNode` in the root crate so existing paths are unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisteredNode {
+    pub node_id: String,
+    pub status: NodeTrustState,
+    pub registered_at_ms: u64,
+    /// Timestamp of the most recent trust-state change (0 if never attested).
+    pub last_trust_update_ms: u64,
+    /// AK public key in PEM format. Populated on registration when provided;
+    /// reserved for future TPM quote verification.
+    pub ak_public_pem: Option<String>,
+    /// Expected SHA-256 hex digest of PCR16 at attestation time.
+    pub expected_pcr16_digest_hex: Option<String>,
+    /// #397 console — optional site/location label for fleet rollups. NULLABLE;
+    /// captured at registration. Never gates trust/posture.
+    pub site: Option<String>,
+    /// #398 console — optional firmware version label for version rollups.
+    /// NULLABLE; captured at registration. Never gates trust/posture.
+    pub firmware_version: Option<String>,
+}
+
 /// The fleet's safety posture — the spine the whole governor hangs on. `Nominal` →
 /// full operation; `Degraded` → controlled decel-to-stop-and-hold envelope; `LockedOut`
 /// → MRC, human reset required.

--- a/crates/kirra-core/src/lib.rs
+++ b/crates/kirra-core/src/lib.rs
@@ -123,8 +123,9 @@ pub enum NodeTrustState {
 /// material captured at registration. Plain persisted data (the `nodes` table);
 /// carries no behaviour. Relocated to the lean foundation (ADR-0035 — the
 /// `kirra-persistence` enabling work) alongside [`NodeTrustState`] so the
-/// persistence layer can name it without the verifier service tree; re-exported as
-/// `crate::verifier::RegisteredNode` in the root crate so existing paths are unchanged.
+/// persistence layer can name it without the verifier service tree. The root
+/// `kirra-verifier` crate re-exports it (as `kirra_verifier::verifier::RegisteredNode`)
+/// so its existing `crate::verifier::RegisteredNode` paths are unchanged.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegisteredNode {
     pub node_id: String,

--- a/crates/kirra-verifier-pg/Cargo.lock
+++ b/crates/kirra-verifier-pg/Cargo.lock
@@ -827,6 +827,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-audit-hash"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "hex",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "kirra-capture-schema"
 version = "0.1.0"
 dependencies = [
@@ -924,6 +933,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "kirra-audit-hash",
  "kirra-capture-schema",
  "kirra-contract-channel",
  "kirra-core",

--- a/docs/adr/0035-verifier-crate-decomposition.md
+++ b/docs/adr/0035-verifier-crate-decomposition.md
@@ -297,11 +297,19 @@ domain types — none of which can live below persistence in the target DAG toda
    mechanical:
    1. **`RegisteredNode` → `kirra-core`** (DONE — alongside `NodeTrustState`; re-exported
       as `crate::verifier::RegisteredNode`, byte-identical).
-   2. **Split `audit_chain`'s PURE core** (the hash + canonical-payload functions +
-      `verifying_key_id` + `CausalRecordHashInput`) into a lean crate; keep the stateful
-      `AuditChainLinker`/keyring in root (authority). The `AuditAppender` TRAIT moves down
-      with persistence; the `ChainedAuditAppender` IMPL stays in root and is injected. This
-      is the crux enabling slice.
+   2. **Split `audit_chain`'s PURE core** into a lean crate — DONE for the hash side:
+      `kirra-audit-hash` now holds the SHA-256 record-hash computations
+      (`compute_record_hash_v1/v2`, `compute_causal_record_hash`), the domain-separated
+      canonical signing/anchor-head encoders, `verifying_key_id`, and
+      `CausalRecordHashInput` — moved VERBATIM (byte-identical on-disk format; power-loss
+      drill + tamper tests green). The stateful `AuditChainLinker` (append-into-a-tx) stays
+      in root and delegates its `compute_record_hash*` methods to the crate; root's
+      `audit_chain` re-exports the crate so `crate::audit_chain::<fn>` paths are unchanged,
+      and `verifier_store`'s verify/read path now names `kirra_audit_hash::*` directly.
+      REMAINDER (slice 2b): the WRITE seam — `ChainedAuditAppender` (in `verifier_store`)
+      still names `crate::audit_chain::AuditChainLinker::append_audit_event_tx`. Invert it:
+      the `AuditAppender` TRAIT moves down with persistence; the `ChainedAuditAppender` IMPL
+      stays in root and is injected at store construction.
    3. **Relocate/invert** the smaller couplings (`ShippedAuditRecord`, `is_valid_verdict_id`,
       `KeyRegistry`).
    4. **Then** move `verifier_store` wholesale into `kirra-persistence`, depending only on the

--- a/docs/adr/0035-verifier-crate-decomposition.md
+++ b/docs/adr/0035-verifier-crate-decomposition.md
@@ -280,10 +280,32 @@ domain types — none of which can live below persistence in the target DAG toda
    chained data, so it is the authority tier, out of the storage seam. **With both
    hard families seamed, every `verifier_store` domain now has a backend-portable
    storage-trait contract** (the clean six + these two), and the audit-authority
-   surface is cleanly the inherent-only residue. `kirra-persistence` can now be
-   extracted mechanically: move `verifier_store` wholesale, depending only on the
-   domain-types leaves (`kirra-fleet-types` / `kirra-ota-campaign` /
-   `kirra-fabric-types`) + the injected `AuditAppender` contract.
+   surface is cleanly the inherent-only residue.
+
+   **Correction (2026-07-14) — the extraction is NOT yet mechanical.** A dependency
+   audit of `verifier_store` after the seam step found it still names several ROOT-crate
+   items that would cycle if the module moved to its own crate:
+   - `crate::audit_chain::*` (~30 refs) — `verifying_key_id`, `AuditChainLinker`,
+     `compute_{record,causal_record}_hash`, `canonical_*_payload`, `CausalRecordHashInput`.
+     The `AuditAppender` seam broke the WRITE path, but the verify/read path + the
+     `ChainedAuditAppender` impl + the pure hash/canonical helpers still live in root.
+   - `crate::verifier::RegisteredNode` (root data struct); `crate::audit_shipper::ShippedAuditRecord`;
+     `crate::verdicts::is_valid_verdict_id`; `crate::key_registry::KeyRegistry`.
+
+   So `kirra-persistence` needs a few ENABLING slices first, each the familiar
+   relocate-to-a-leaf + re-export-shim move, before the wholesale move is truly
+   mechanical:
+   1. **`RegisteredNode` → `kirra-core`** (DONE — alongside `NodeTrustState`; re-exported
+      as `crate::verifier::RegisteredNode`, byte-identical).
+   2. **Split `audit_chain`'s PURE core** (the hash + canonical-payload functions +
+      `verifying_key_id` + `CausalRecordHashInput`) into a lean crate; keep the stateful
+      `AuditChainLinker`/keyring in root (authority). The `AuditAppender` TRAIT moves down
+      with persistence; the `ChainedAuditAppender` IMPL stays in root and is injected. This
+      is the crux enabling slice.
+   3. **Relocate/invert** the smaller couplings (`ShippedAuditRecord`, `is_valid_verdict_id`,
+      `KeyRegistry`).
+   4. **Then** move `verifier_store` wholesale into `kirra-persistence`, depending only on the
+      domain-type leaves + the pure-audit leaf + the injected `AuditAppender` contract.
 
 **Alternative considered — domain-types-first only (no audit inversion):** relocate
 C2 types and move `verifier_store` wholesale into a persistence crate that *keeps*

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -842,6 +842,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-audit-hash"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "hex",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "kirra-capture-schema"
 version = "0.1.0"
 dependencies = [
@@ -948,6 +957,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "kirra-audit-hash",
  "kirra-capture-schema",
  "kirra-contract-channel",
  "kirra-core",

--- a/parko/Cargo.lock
+++ b/parko/Cargo.lock
@@ -1101,6 +1101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-audit-hash"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "hex",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "kirra-capture-schema"
 version = "0.1.0"
 dependencies = [
@@ -1205,6 +1214,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "kirra-audit-hash",
  "kirra-capture-schema",
  "kirra-contract-channel",
  "kirra-core",

--- a/src/audit_chain.rs
+++ b/src/audit_chain.rs
@@ -2,7 +2,6 @@
 
 use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
 use rusqlite::{params, Result, Transaction};
-use sha2::{Digest, Sha256};
 
 /// Event payload written to the audit chain when an RSS safe-distance
 /// violation is detected. All fields are included in the SHA-256 hash.
@@ -29,179 +28,48 @@ pub enum AuditEntry {
     PerceptionDerate(PerceptionDerateEvent),
 }
 
-/// V1 canonical signing payload — kept ONLY for verifying pre-migration
-/// rows. Format: `{prev_hash}:{entry_hash}:{event_type}:{timestamp_ms}`.
-pub fn canonical_signing_payload(
-    prev_hash: &str,
-    entry_hash: &str,
-    event_type: &str,
-    timestamp_ms: i64,
-) -> String {
-    format!(
-        "{}:{}:{}:{}",
-        prev_hash, entry_hash, event_type, timestamp_ms
-    )
-}
+// The PURE hash/canonical-payload primitives + `verifying_key_id` +
+// `CausalRecordHashInput` were extracted to the lean `kirra-audit-hash` crate
+// (ADR-0035 — kirra-persistence enabling slice 2) so the persistence layer can
+// compute/verify hashes WITHOUT this rusqlite-backed module. Re-exported here so
+// every existing `crate::audit_chain::<fn>` path (service bin, store, tests)
+// resolves unchanged. Byte-identical: the encoders moved verbatim (they ARE the
+// on-disk audit/causal-chain format — same domain tags, length-prefixing, LE order).
+pub use kirra_audit_hash::{
+    canonical_anchor_head_payload, canonical_causal_anchor_head_payload,
+    canonical_causal_signing_payload, canonical_signing_payload, canonical_signing_payload_v2,
+    compute_causal_record_hash, verifying_key_id, CausalRecordHashInput,
+};
 
-/// V2 canonical signing payload. Binds `sequence` and explicit version
-/// tag so a v2 signature cannot be confused with a v1 signature over the
-/// same prev/entry/event_type/ts. Used for all new rows.
-pub fn canonical_signing_payload_v2(
-    prev_hash: &str,
-    entry_hash: &str,
-    event_type: &str,
-    timestamp_ms: i64,
-    sequence: u64,
-) -> String {
-    format!("v2:{prev_hash}:{entry_hash}:{event_type}:{timestamp_ms}:{sequence}")
-}
-
-/// Canonical signing payload for the audit anchor-HEAD high-water mark (#77).
-///
-/// Binds the highest committed chain position `(sequence, record_hash)`.
-/// Domain-separated (`kirra-audit-head:v1` prefix) so a head signature can never
-/// be replayed as a row signature — or vice versa — under the same key.
-pub fn canonical_anchor_head_payload(sequence: u64, record_hash: &str) -> String {
-    format!("kirra-audit-head:v1:{sequence}:{record_hash}")
-}
-
-// --- Fabric causal-log forensic chain primitives (issue #87) ---------------
-//
-// The fabric causal log is a hash-chained, signed, persisted forensic ledger
-// that MIRRORS the audit chain machinery above, but is domain-separated so a
-// causal signature/hash can never be confused with an audit one. The KEY WIN
-// over the prior in-memory log is that the record hash binds the CAUSALITY
-// EDGES (`caused_by`, `affects_assets`, `fabric_generation`) plus `previous_hash`
-// and `sequence` — tampering an edge changes the record hash and is DETECTED.
-
-/// Causal record hash (issue #87). SHA-256 over a domain-separated,
-/// length-prefixed encoding that BINDS the causality edges.
-///
-/// Domain tag `KIRRA-CAUSAL-V1` (distinct from `KIRRA-AUDIT-V2`). Every
-/// variable-length scalar field is preceded by its 8-byte LE length; each edge
-/// VECTOR is preceded by its element count (8-byte LE) and every element by its
-/// own 8-byte LE length. Fixed-width integers (`timestamp_ms`,
-/// `fabric_generation`, `sequence`) are appended as LE bytes. Length-prefixing
-/// closes field-splicing ambiguities (`"AB"+"C"` vs `"A"+"BC"`) so neither a
-/// scalar nor an edge element can be silently relabeled or moved between fields.
-/// Bundled inputs for [`compute_causal_record_hash`].
-#[derive(Debug, Clone)]
-pub struct CausalRecordHashInput<'a> {
-    pub previous_hash: &'a str,
-    pub entry_id: &'a str,
-    pub asset_id: &'a str,
-    pub event_type: &'a str,
-    pub payload: &'a str,
-    pub caused_by: &'a [String],
-    pub affects_assets: &'a [String],
-    pub timestamp_ms: u64,
-    pub fabric_generation: u64,
-    pub sequence: u64,
-}
-
-pub fn compute_causal_record_hash(input: &CausalRecordHashInput<'_>) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(b"KIRRA-CAUSAL-V1");
-    for field in [
-        input.previous_hash.as_bytes(),
-        input.entry_id.as_bytes(),
-        input.asset_id.as_bytes(),
-        input.event_type.as_bytes(),
-        input.payload.as_bytes(),
-    ] {
-        hasher.update((field.len() as u64).to_le_bytes());
-        hasher.update(field);
-    }
-    // Edge vectors: count-prefixed, each element length-prefixed. This is what
-    // binds the causality edges into the record hash.
-    for vec in [input.caused_by, input.affects_assets] {
-        hasher.update((vec.len() as u64).to_le_bytes());
-        for elem in vec {
-            hasher.update((elem.len() as u64).to_le_bytes());
-            hasher.update(elem.as_bytes());
-        }
-    }
-    hasher.update(input.timestamp_ms.to_le_bytes());
-    hasher.update(input.fabric_generation.to_le_bytes());
-    hasher.update(input.sequence.to_le_bytes());
-    hex::encode(hasher.finalize())
-}
-
-/// Canonical signing payload for a causal-log row (issue #87).
-///
-/// The Ed25519 signature is over `record_hash`, which TRANSITIVELY binds the
-/// causality edges (because `compute_causal_record_hash` binds them into
-/// `record_hash`). `previous_hash` and `sequence` also appear explicitly so the
-/// row's chain position is signed directly. Domain prefix `kirra-causal:v1`
-/// keeps it distinct from the audit row payload.
-pub fn canonical_causal_signing_payload(
-    previous_hash: &str,
-    record_hash: &str,
-    event_type: &str,
-    timestamp_ms: u64,
-    sequence: u64,
-) -> String {
-    format!("kirra-causal:v1:{previous_hash}:{record_hash}:{event_type}:{timestamp_ms}:{sequence}")
-}
-
-/// Canonical signing payload for the causal anchor-HEAD high-water mark (#87).
-/// Domain-separated (`kirra-causal-head:v1`) from BOTH the audit head and the
-/// causal row payload, so no signature can be replayed across the three roles.
-pub fn canonical_causal_anchor_head_payload(sequence: u64, record_hash: &str) -> String {
-    format!("kirra-causal-head:v1:{sequence}:{record_hash}")
-}
-
+/// The audit-chain append machinery — the STATEFUL half: it writes rows and
+/// advances the signed anchor-head into a caller-owned rusqlite transaction. The
+/// PURE hash computations it uses now live in `kirra-audit-hash`; the
+/// `compute_record_hash*` associated functions below DELEGATE to them so existing
+/// `AuditChainLinker::compute_record_hash_v2` callers are unchanged.
 pub struct AuditChainLinker;
 
-/// Content-addressed key id for an audit signing key: hex SHA-256 of the
-/// 32-byte Ed25519 verifying-key bytes. No DER/SPKI round-trip — matches how
-/// the chain already stores pubkeys (raw 32-byte values), needs no allocator.
-/// A row's `key_id` is derivable from the key that signed it, so the verifier
-/// can select the correct verifying key PER ROW (issue #76).
-#[must_use]
-pub fn verifying_key_id(vk: &ed25519_dalek::VerifyingKey) -> String {
-    let mut h = Sha256::new();
-    h.update(vk.as_bytes());
-    hex::encode(h.finalize())
-}
-
 impl AuditChainLinker {
-    /// V1 (legacy) record hash: prev || event_json || created_at_ms.
-    /// Does NOT bind `event_type` — retained ONLY to verify pre-migration
-    /// rows. New rows use `compute_record_hash_v2` which closes the
-    /// event_type relabeling hole and the field-splicing ambiguity.
+    /// V1 (legacy) record hash — delegates to [`kirra_audit_hash::compute_record_hash_v1`].
+    /// Retained ONLY to verify pre-migration rows.
     pub fn compute_record_hash_v1(
         previous_hash: &str,
         canonical_json: &str,
         created_at_ms: i64,
     ) -> String {
-        let mut hasher = Sha256::new();
-        hasher.update(previous_hash.as_bytes());
-        hasher.update(canonical_json.as_bytes());
-        hasher.update(created_at_ms.to_string().as_bytes());
-        hex::encode(hasher.finalize())
+        kirra_audit_hash::compute_record_hash_v1(previous_hash, canonical_json, created_at_ms)
     }
 
-    /// Back-compat alias for `compute_record_hash_v1`. Existing callers
-    /// (verifier_store::verify_audit_chain_integrity for legacy rows,
-    /// tests) keep compiling.
+    /// Back-compat alias for `compute_record_hash_v1`.
     pub fn compute_record_hash(
         previous_hash: &str,
         canonical_json: &str,
         created_at_ms: i64,
     ) -> String {
-        Self::compute_record_hash_v1(previous_hash, canonical_json, created_at_ms)
+        kirra_audit_hash::compute_record_hash(previous_hash, canonical_json, created_at_ms)
     }
 
-    /// V2 record hash. Binds `event_type` and `sequence` into the hash so
-    /// event_type relabeling and row reordering are caught by the
-    /// cheap hash-only `verify_audit_chain_integrity` — without needing
-    /// signatures.
-    ///
-    /// Domain-separated (`KIRRA-AUDIT-V2` prefix) and length-prefixed
-    /// (each variable-length field is preceded by its 8-byte LE length)
-    /// so field-splicing ambiguities (`"AB"+"C"` vs `"A"+"BC"`) cannot
-    /// collide.
+    /// V2 record hash — delegates to [`kirra_audit_hash::compute_record_hash_v2`]
+    /// (binds `event_type` + `sequence`, domain-separated, length-prefixed).
     pub fn compute_record_hash_v2(
         previous_hash: &str,
         event_type: &str,
@@ -209,19 +77,13 @@ impl AuditChainLinker {
         created_at_ms: i64,
         sequence: u64,
     ) -> String {
-        let mut hasher = Sha256::new();
-        hasher.update(b"KIRRA-AUDIT-V2");
-        for field in [
-            previous_hash.as_bytes(),
-            event_type.as_bytes(),
-            event_json.as_bytes(),
-        ] {
-            hasher.update((field.len() as u64).to_le_bytes());
-            hasher.update(field);
-        }
-        hasher.update(created_at_ms.to_le_bytes());
-        hasher.update(sequence.to_le_bytes());
-        hex::encode(hasher.finalize())
+        kirra_audit_hash::compute_record_hash_v2(
+            previous_hash,
+            event_type,
+            event_json,
+            created_at_ms,
+            sequence,
+        )
     }
 
     /// Appends an RSS violation event to the hash-chained audit ledger.

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -20,27 +20,11 @@ const CHALLENGE_TTL_MS: u64 = 30_000;
 // `FleetPosture` / `NodeTrustState` moved to the lean `kirra-core` crate (de-monolith
 // Stage 1) so the governor/contract surface need not pull this heavy module. Re-exported
 // here so every existing `crate::verifier::FleetPosture` path keeps the same type.
-pub use kirra_core::{FleetPosture, NodeTrustState};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RegisteredNode {
-    pub node_id: String,
-    pub status: NodeTrustState,
-    pub registered_at_ms: u64,
-    /// Timestamp of the most recent trust-state change (0 if never attested).
-    pub last_trust_update_ms: u64,
-    /// AK public key in PEM format. Populated on registration when provided;
-    /// reserved for future TPM quote verification.
-    pub ak_public_pem: Option<String>,
-    /// Expected SHA-256 hex digest of PCR16 at attestation time.
-    pub expected_pcr16_digest_hex: Option<String>,
-    /// #397 console — optional site/location label for fleet rollups. NULLABLE;
-    /// captured at registration. Never gates trust/posture.
-    pub site: Option<String>,
-    /// #398 console — optional firmware version label for version rollups.
-    /// NULLABLE; captured at registration. Never gates trust/posture.
-    pub firmware_version: Option<String>,
-}
+// `RegisteredNode` moved to `kirra-core` alongside `NodeTrustState` (ADR-0035 — the
+// `kirra-persistence` enabling work: the persistence layer must name it without the
+// verifier service tree). Re-exported here so every existing
+// `crate::verifier::RegisteredNode` path keeps the same type.
+pub use kirra_core::{FleetPosture, NodeTrustState, RegisteredNode};
 
 #[derive(Debug, Clone)]
 pub struct ChallengeEntry {

--- a/src/verifier_store/audit.rs
+++ b/src/verifier_store/audit.rs
@@ -91,7 +91,7 @@ impl VerifierStore {
         for r in self.audit_key_ledger_rows()? {
             if r.key_id == genesis_id {
                 if let Some(vk) = audit_decode_vk(&r.pubkey_b64) {
-                    if crate::audit_chain::verifying_key_id(&vk) == genesis_id {
+                    if kirra_audit_hash::verifying_key_id(&vk) == genesis_id {
                         return Ok(Some(vk));
                     }
                 }
@@ -117,13 +117,13 @@ impl VerifierStore {
         let genesis_id = match (&durable_genesis, fallback_vk) {
             // Durable anchor wins — a mutated env key can never re-root trust.
             (Some(gvk), _) => {
-                let gid = crate::audit_chain::verifying_key_id(gvk);
+                let gid = kirra_audit_hash::verifying_key_id(gvk);
                 keyring.insert(gid.clone(), *gvk);
                 Some(gid)
             }
             // Pre-#165 fallback: the passed-in (env) key is the genesis.
             (None, Some(fvk)) => {
-                let gid = crate::audit_chain::verifying_key_id(fvk);
+                let gid = kirra_audit_hash::verifying_key_id(fvk);
                 keyring.insert(gid.clone(), *fvk);
                 Some(gid)
             }
@@ -162,7 +162,7 @@ impl VerifierStore {
                     // Content-addressed sanity: only carry rows whose announced
                     // id matches the announced pubkey.
                     if let Some(vk) = audit_decode_vk(pk) {
-                        if crate::audit_chain::verifying_key_id(&vk) == kid {
+                        if kirra_audit_hash::verifying_key_id(&vk) == kid {
                             out.push((kid.to_string(), pk.to_string()));
                         }
                     }
@@ -223,7 +223,7 @@ impl VerifierStore {
         // via `assert_epoch_held`. Do not broaden this exemption.
         use ed25519_dalek::Signer;
         let env_vk = env_key.verifying_key();
-        let k_env = crate::audit_chain::verifying_key_id(&env_vk);
+        let k_env = kirra_audit_hash::verifying_key_id(&env_vk);
         let env_pub_b64 = b64e.encode(env_vk.as_bytes());
 
         // Optional operator-pinned genesis check (only meaningful once an anchor
@@ -679,7 +679,7 @@ impl VerifierStore {
         // included); the passed-in `genesis_vk` is only the pre-#165 fallback.
         let (mut keyring, genesis_id_opt) = self.audit_keyring_seed(Some(genesis_vk))?;
         let genesis_id =
-            genesis_id_opt.unwrap_or_else(|| crate::audit_chain::verifying_key_id(genesis_vk));
+            genesis_id_opt.unwrap_or_else(|| kirra_audit_hash::verifying_key_id(genesis_vk));
 
         let mut stmt = self.conn.prepare(
             "SELECT event_json, previous_hash_hex, record_hash_hex, created_at_ms, \
@@ -769,7 +769,7 @@ impl VerifierStore {
             // weakness retained for legacy rows); v2 binds event_type and
             // sequence so this same cheap check catches relabeling/reorder.
             let recalc = match hash_version {
-                1 => crate::audit_chain::AuditChainLinker::compute_record_hash_v1(
+                1 => kirra_audit_hash::compute_record_hash_v1(
                     &previous_hash_hex,
                     &event_json,
                     created_at_ms,
@@ -788,7 +788,7 @@ impl VerifierStore {
                         }
                     }
                     prev_v2_seq = sequence_opt;
-                    crate::audit_chain::AuditChainLinker::compute_record_hash_v2(
+                    kirra_audit_hash::compute_record_hash_v2(
                         &previous_hash_hex,
                         &event_type,
                         &event_json,
@@ -920,7 +920,7 @@ impl VerifierStore {
                                     None => (false, "HEAD_KEY_UNKNOWN".to_string()),
                                     Some(vk) => {
                                         let payload =
-                                            crate::audit_chain::canonical_anchor_head_payload(
+                                            kirra_audit_hash::canonical_anchor_head_payload(
                                                 h_seq.max(0) as u64,
                                                 &h_hash,
                                             );
@@ -974,7 +974,7 @@ impl VerifierStore {
         // Reconstruct the full keyring once (the page is DESC/paginated, so we
         // can't replay rotations within a page) — then annotate each row's
         // signature status under the key its key_id names (#76).
-        let genesis_id = verifying_key.map(crate::audit_chain::verifying_key_id);
+        let genesis_id = verifying_key.map(kirra_audit_hash::verifying_key_id);
         let keyring = match verifying_key {
             Some(g) => self.build_audit_keyring(g)?,
             None => std::collections::HashMap::new(),
@@ -1107,7 +1107,7 @@ impl VerifierStore {
         use ed25519_dalek::Signer;
         let new_vk = new_signing_key.verifying_key();
         let new_public_key_b64 = b64e.encode(new_vk.as_bytes());
-        let new_key_id = crate::audit_chain::verifying_key_id(&new_vk);
+        let new_key_id = kirra_audit_hash::verifying_key_id(&new_vk);
 
         // The OLD key signs the in-chain KEY_ROTATION row (so it verifies under a
         // key already trusted). Clone it out before borrowing self mutably for
@@ -1115,7 +1115,7 @@ impl VerifierStore {
         let old_key = self.signing_key.clone();
         let old_key_id = old_key
             .as_ref()
-            .map(|k| crate::audit_chain::verifying_key_id(&k.verifying_key()));
+            .map(|k| kirra_audit_hash::verifying_key_id(&k.verifying_key()));
 
         let payload = serde_json::json!({
             "new_public_key_b64": new_public_key_b64,
@@ -1196,7 +1196,7 @@ impl VerifierStore {
         // Genesis id from the current signing key (the only key the chain has
         // ever been signed under, pre-rotation). No signing key → nothing to do.
         let genesis_id = match self.signing_key.as_ref() {
-            Some(sk) => crate::audit_chain::verifying_key_id(&sk.verifying_key()),
+            Some(sk) => kirra_audit_hash::verifying_key_id(&sk.verifying_key()),
             None => return Ok(()),
         };
         // Idempotent: already anchored?
@@ -1263,7 +1263,7 @@ impl VerifierStore {
                 return Ok(false);
             }
             let recalc = match hash_version {
-                1 => crate::audit_chain::AuditChainLinker::compute_record_hash_v1(
+                1 => kirra_audit_hash::compute_record_hash_v1(
                     &previous_hash_hex,
                     &event_json,
                     created_at_ms,
@@ -1278,7 +1278,7 @@ impl VerifierStore {
                         return Ok(false);
                     }
                     prev_v2_seq = sequence_opt;
-                    crate::audit_chain::AuditChainLinker::compute_record_hash_v2(
+                    kirra_audit_hash::compute_record_hash_v2(
                         &previous_hash_hex,
                         &event_type,
                         &event_json,
@@ -1386,9 +1386,9 @@ impl VerifierStore {
                 Some(key) => {
                     use ed25519_dalek::Signer;
                     let payload =
-                        crate::audit_chain::canonical_anchor_head_payload(seq, &record_hash);
+                        kirra_audit_hash::canonical_anchor_head_payload(seq, &record_hash);
                     let sig = b64e.encode(key.sign(payload.as_bytes()).to_bytes());
-                    let kid = crate::audit_chain::verifying_key_id(&key.verifying_key());
+                    let kid = kirra_audit_hash::verifying_key_id(&key.verifying_key());
                     (Some(sig), Some(kid))
                 }
                 None => (None, None),

--- a/src/verifier_store/fabric.rs
+++ b/src/verifier_store/fabric.rs
@@ -83,11 +83,11 @@ impl VerifierStore {
             fabric_generation,
             timestamp_ms,
         } = *event;
-        use crate::audit_chain::{
+        use ed25519_dalek::Signer;
+        use kirra_audit_hash::{
             canonical_causal_anchor_head_payload, canonical_causal_signing_payload,
             compute_causal_record_hash, verifying_key_id,
         };
-        use ed25519_dalek::Signer;
 
         let tx = self.conn.unchecked_transaction()?;
 
@@ -106,7 +106,7 @@ impl VerifierStore {
         };
         let sequence: u64 = (prev_seq + 1) as u64;
 
-        let record_hash = compute_causal_record_hash(&crate::audit_chain::CausalRecordHashInput {
+        let record_hash = compute_causal_record_hash(&kirra_audit_hash::CausalRecordHashInput {
             previous_hash: &previous_hash,
             entry_id,
             asset_id,
@@ -294,7 +294,7 @@ impl VerifierStore {
         &self,
         verifying_key: Option<&ed25519_dalek::VerifyingKey>,
     ) -> Result<CausalChainVerifyResult> {
-        use crate::audit_chain::{
+        use kirra_audit_hash::{
             canonical_causal_anchor_head_payload, canonical_causal_signing_payload,
             compute_causal_record_hash,
         };
@@ -365,7 +365,7 @@ impl VerifierStore {
             let caused_by: Vec<String> = serde_json::from_str(&caused_by_json).unwrap_or_default();
             let affects_assets: Vec<String> =
                 serde_json::from_str(&affects_json).unwrap_or_default();
-            let recalc = compute_causal_record_hash(&crate::audit_chain::CausalRecordHashInput {
+            let recalc = compute_causal_record_hash(&kirra_audit_hash::CausalRecordHashInput {
                 previous_hash: &previous_hash_hex,
                 entry_id: &entry_id,
                 asset_id: &asset_id,

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -414,7 +414,7 @@ fn audit_signing_payload(
     created_at_ms: i64,
     sequence: Option<i64>,
 ) -> String {
-    use crate::audit_chain::{canonical_signing_payload, canonical_signing_payload_v2};
+    use kirra_audit_hash::{canonical_signing_payload, canonical_signing_payload_v2};
     match hash_version {
         2 => canonical_signing_payload_v2(
             prev,
@@ -461,7 +461,7 @@ fn extend_keyring_from_rotation(
     let Some(nvk) = audit_decode_vk(npk) else {
         return;
     };
-    if crate::audit_chain::verifying_key_id(&nvk) == nkid {
+    if kirra_audit_hash::verifying_key_id(&nvk) == nkid {
         keyring.insert(nkid.to_string(), nvk);
     }
 }
@@ -545,7 +545,7 @@ fn ledger_row_is_self_attested(r: &LedgerRow) -> bool {
     let Some(vk) = audit_decode_vk(&r.pubkey_b64) else {
         return false;
     };
-    if crate::audit_chain::verifying_key_id(&vk) != r.key_id {
+    if kirra_audit_hash::verifying_key_id(&vk) != r.key_id {
         return false; // content-addressing violated
     }
     let payload = ledger_signing_payload(


### PR DESCRIPTION
## Summary

Continues the ADR-0035 verifier de-monolith toward the `kirra-persistence` extraction. A dependency audit after the Stage 2.5 seam step found the ADR's "mechanical extraction" claim was optimistic — `verifier_store` still names several root-crate items that would cycle if the module moved to its own crate. This PR lands the two lowest-risk **enabling slices** that clear the largest of those couplings, each the familiar relocate-to-a-leaf + re-export-shim move.

Two behaviour-preserving commits:

1. **`5b7478f` — relocate `RegisteredNode` → `kirra-core` (slice 1).** A plain data struct (no impls; only non-std field is `NodeTrustState`, already in kirra-core), re-exported as `crate::verifier::RegisteredNode`. No new crate, no Cargo.toml change → no lockfile churn.
2. **`83a8705` — split `audit_chain`'s pure core → `kirra-audit-hash` (slice 2, the crux).** `verifier_store`'s ~30 references to `crate::audit_chain` were the biggest blocker. The pure primitives — the SHA-256 record-hash computations (`compute_record_hash_v1/v2`, `compute_causal_record_hash`), the domain-separated canonical signing/anchor-head encoders, `verifying_key_id`, `CausalRecordHashInput` — move **verbatim** into a lean leaf crate (deps: sha2, hex, ed25519-dalek; no rusqlite, no state). Root `audit_chain.rs` keeps the **stateful** `AuditChainLinker` (append-into-a-transaction); its `compute_*` methods delegate to the crate, and it re-exports the crate so every `crate::audit_chain::<fn>` path is unchanged. `verifier_store`'s verify/read path now names `kirra_audit_hash::*` directly.

## Design notes

- **Byte-exactness is load-bearing** in slice 2: the moved encoders *are* the on-disk audit-chain and fabric causal-log format (domain tags, length-prefixing, LE field order). They were copied verbatim, so every stored signature/hash verifies identically.
- **Authority stays in root.** Only the pure, stateless hash/encode functions moved; the rusqlite-backed append machinery + keyring remain in the root crate (the safety-authority layer).
- **Not the whole extraction.** `kirra-persistence` still needs: slice 2b (invert the `ChainedAuditAppender` write seam — the one remaining `crate::audit_chain::…::append_audit_event_tx` reference), the small couplings (`ShippedAuditRecord`, `is_valid_verdict_id`, `KeyRegistry`), then the wholesale module move. ADR-0035 (Addendum A) records the corrected inventory and slice sequence.

## Testing

Verified green on the tip:
- workspace build (no warnings)
- `cargo test --lib` — **760** (includes the audit-chain verify path and the `break_audit_chain` tamper-detection tests)
- power-loss audit drill `cargo test --test audit_chain_prefix_on_kill` — **3** (reopens the WAL DB and re-verifies the chain end-to-end — the non-vacuous check that the hash format survived the crate boundary)
- EP-13 audit-anchored rollout `cargo test --test two_node_rollout` — **4**
- kirra-core — **184**
- `cargo fmt --check`, `ci/check_quality_guardrails.py`, `ci/check_orphan_cores.py`
- detached lockfiles (`fuzz`, `crates/kirra-verifier-pg`, `parko`) refreshed for the new crate and validated under `--locked`

No behaviour change: byte-identical audit chain, same fail-closed semantics, no inherent method altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_