### PR TITLE
ADR-0035: fully decouple verifier_store from the root crate (kirra-persistence enabling slices 2b–3.5)

### DIFF
--- a/crates/kirra-audit-hash/src/lib.rs
+++ b/crates/kirra-audit-hash/src/lib.rs
@@ -15,6 +15,37 @@
 //! format and invalidates every stored signature/hash.
 
 use sha2::{Digest, Sha256};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Monotonic per-process discriminator folded into each minted verdict id so two
+/// denials of the SAME payload in the SAME millisecond still get distinct ids.
+static VERDICT_MINT_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Mint a verdict id: 32 lowercase hex chars (the first 16 bytes of a SHA-256
+/// over the event time, a monotonic counter, and the payload bytes).
+/// Collision-resistant across concurrent denials and restarts for any realistic
+/// denial volume; the id is a HANDLE (retrieval key), not a secret. (EP-17 — a
+/// content-addressed audit id, so it lives with the audit hash primitives.)
+#[must_use]
+pub fn mint_verdict_id(now_ms: u64, payload_json: &str) -> String {
+    let n = VERDICT_MINT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut h = Sha256::new();
+    h.update(now_ms.to_be_bytes());
+    h.update(n.to_be_bytes());
+    h.update(payload_json.as_bytes());
+    let digest = h.finalize();
+    hex::encode(&digest[..16])
+}
+
+/// Is `s` a well-formed verdict id (exactly 32 lowercase hex chars)? The retrieval
+/// handler validates BEFORE the id is interpolated into a SQL LIKE pattern, so
+/// `%`/`_` metacharacters can never widen the match.
+#[must_use]
+pub fn is_valid_verdict_id(s: &str) -> bool {
+    s.len() == 32
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
 
 /// V1 canonical signing payload — kept ONLY for verifying pre-migration
 /// rows. Format: `{prev_hash}:{entry_hash}:{event_type}:{timestamp_ms}`.

--- a/crates/kirra-core/src/lib.rs
+++ b/crates/kirra-core/src/lib.rs
@@ -146,6 +146,26 @@ pub struct RegisteredNode {
     pub firmware_version: Option<String>,
 }
 
+/// One audit-chain record in its off-box SHIPPED form — the raw chain fields
+/// needed to INDEPENDENTLY re-verify the hash chain without the source database.
+/// A wire type (serde-serialized off-box), relocated to the lean foundation
+/// (ADR-0035 — the kirra-persistence enabling work) so BOTH the persistence layer
+/// that produces it and the off-box shipper that re-verifies it can name it without
+/// either depending on the other. (Deliberately distinct from the DESC-paginated
+/// human/API export view, which omits `sequence`/`hash_version`.)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShippedAuditRecord {
+    pub sequence: u64,
+    pub event_type: String,
+    pub event_json: String,
+    pub previous_hash_hex: String,
+    pub record_hash_hex: String,
+    pub created_at_ms: i64,
+    pub hash_version: i64,
+    pub signature_b64: Option<String>,
+    pub key_id: Option<String>,
+}
+
 /// The fleet's safety posture — the spine the whole governor hangs on. `Nominal` →
 /// full operation; `Degraded` → controlled decel-to-stop-and-hold envelope; `LockedOut`
 /// → MRC, human reset required.

--- a/docs/adr/0035-verifier-crate-decomposition.md
+++ b/docs/adr/0035-verifier-crate-decomposition.md
@@ -316,8 +316,19 @@ domain types — none of which can live below persistence in the target DAG toda
       no cycle (persistence → `kirra_audit_hash`; root → persistence). Result:
       `verifier_store` has ZERO `crate::audit_chain` code references (production + tests);
       only a prose comment names it. Byte-identical (power-loss drill + tamper tests green).
-   3. **Relocate/invert** the smaller couplings (`ShippedAuditRecord`, `is_valid_verdict_id`,
-      `KeyRegistry`).
+   3. **Relocate the smaller couplings** — DONE. `ShippedAuditRecord` (the off-box
+      shipped-record WIRE type — must stay DB-free for the independent re-verifier) →
+      `kirra-core`; `mint_verdict_id` / `is_valid_verdict_id` (content-addressed SHA-256
+      audit ids) → `kirra-audit-hash`; `KeyRegistry` was only doc-links (no code coupling).
+      `verdicts` / `audit_shipper` re-export from the leaves so root paths are unchanged;
+      `audit_shipper`'s `recompute_hash` became a free fn (calls `kirra_audit_hash`) since
+      the record type is now external — which also freed `audit_shipper` of `audit_chain`.
+   3.5. **Repoint the shim paths (pre-slice-4 mechanical cleanup).** `verifier_store` still
+      NAMES already-relocated types via their ROOT re-export shims (`crate::verifier::*` →
+      `kirra_core`, `crate::federation*` → `kirra_fleet_types`, `crate::ota_campaign::*` →
+      `kirra_ota_campaign`, `crate::fabric::{asset,causal_log}` → `kirra_fabric_types`).
+      After extraction `crate::` is the persistence crate, so these must name the leaves
+      directly. Plus one test-only `crate::gateway::kinematics_contract` use to resolve.
    4. **Then** move `verifier_store` wholesale into `kirra-persistence`, depending only on the
       domain-type leaves + the pure-audit leaf + the injected `AuditAppender` contract.
 

--- a/docs/adr/0035-verifier-crate-decomposition.md
+++ b/docs/adr/0035-verifier-crate-decomposition.md
@@ -323,12 +323,16 @@ domain types — none of which can live below persistence in the target DAG toda
       `verdicts` / `audit_shipper` re-export from the leaves so root paths are unchanged;
       `audit_shipper`'s `recompute_hash` became a free fn (calls `kirra_audit_hash`) since
       the record type is now external — which also freed `audit_shipper` of `audit_chain`.
-   3.5. **Repoint the shim paths (pre-slice-4 mechanical cleanup).** `verifier_store` still
-      NAMES already-relocated types via their ROOT re-export shims (`crate::verifier::*` →
-      `kirra_core`, `crate::federation*` → `kirra_fleet_types`, `crate::ota_campaign::*` →
-      `kirra_ota_campaign`, `crate::fabric::{asset,causal_log}` → `kirra_fabric_types`).
-      After extraction `crate::` is the persistence crate, so these must name the leaves
-      directly. Plus one test-only `crate::gateway::kinematics_contract` use to resolve.
+   3.5. **Repoint the shim paths — DONE.** `verifier_store` named already-relocated types via
+      their ROOT re-export shims; all repointed to the leaves directly: `crate::verifier::{FleetPosture,
+      NodeTrustState, RegisteredNode}` → `kirra_core`, `crate::federation{,_reconciliation}::*` →
+      `kirra_fleet_types`, `crate::ota_campaign::*` → `kirra_ota_campaign`,
+      `crate::fabric::{asset,causal_log}::*` → `kirra_fabric_types`, and the test-only
+      `crate::gateway::kinematics_contract::*` → `kirra_core::kinematics_contract` (also a shim).
+      Two residual doc-links (`KeyRegistry`, `StoreHandle`) demoted to plain spans. RESULT:
+      `verifier_store` now names ZERO root-crate items — only its own `crate::verifier_store::*`
+      submodules, the leaf crates, and external crates. Byte-identical (repointing to the same
+      types via re-export); 760 lib + power-loss + rollout green.
    4. **Then** move `verifier_store` wholesale into `kirra-persistence`, depending only on the
       domain-type leaves + the pure-audit leaf + the injected `AuditAppender` contract.
 

--- a/docs/adr/0035-verifier-crate-decomposition.md
+++ b/docs/adr/0035-verifier-crate-decomposition.md
@@ -306,10 +306,16 @@ domain types — none of which can live below persistence in the target DAG toda
       in root and delegates its `compute_record_hash*` methods to the crate; root's
       `audit_chain` re-exports the crate so `crate::audit_chain::<fn>` paths are unchanged,
       and `verifier_store`'s verify/read path now names `kirra_audit_hash::*` directly.
-      REMAINDER (slice 2b): the WRITE seam — `ChainedAuditAppender` (in `verifier_store`)
-      still names `crate::audit_chain::AuditChainLinker::append_audit_event_tx`. Invert it:
-      the `AuditAppender` TRAIT moves down with persistence; the `ChainedAuditAppender` IMPL
-      stays in root and is injected at store construction.
+      SLICE 2b (DONE — the write seam): rather than injecting the impl up, the append
+      MECHANICS moved DOWN. `append_audit_event_tx` writes the persistence-owned
+      `audit_log_chain` / `audit_anchor_head` tables using only `kirra_audit_hash` +
+      Ed25519, so it was relocated INTO `verifier_store::audit_appender` (as a free fn);
+      `ChainedAuditAppender` calls it locally, and root's
+      `AuditChainLinker::append_audit_event_tx` now DELEGATES down to it (its typed
+      wrappers + external callers unchanged). This needed no store-construction churn and
+      no cycle (persistence → `kirra_audit_hash`; root → persistence). Result:
+      `verifier_store` has ZERO `crate::audit_chain` code references (production + tests);
+      only a prose comment names it. Byte-identical (power-loss drill + tamper tests green).
    3. **Relocate/invert** the smaller couplings (`ShippedAuditRecord`, `is_valid_verdict_id`,
       `KeyRegistry`).
    4. **Then** move `verifier_store` wholesale into `kirra-persistence`, depending only on the

--- a/src/audit_chain.rs
+++ b/src/audit_chain.rs
@@ -1,7 +1,6 @@
 // src/audit_chain.rs
 
-use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
-use rusqlite::{params, Result, Transaction};
+use rusqlite::{Result, Transaction};
 
 /// Event payload written to the audit chain when an RSS safe-distance
 /// violation is detected. All fields are included in the SHA-256 hash.
@@ -129,6 +128,15 @@ impl AuditChainLinker {
         )
     }
 
+    /// Append one event to the hash-chained, signed audit ledger, into a
+    /// caller-owned transaction.
+    ///
+    /// ADR-0035 slice 2b: the write mechanics were relocated to the persistence
+    /// layer ([`crate::verifier_store::append_audit_event_tx`]) — the write touches
+    /// only the persistence-owned `audit_log_chain` / `audit_anchor_head` tables and
+    /// the pure `kirra_audit_hash` primitives. This associated function DELEGATES to
+    /// it so `AuditChainLinker::append_audit_event_tx` callers (the typed wrappers
+    /// above, tests, external callers) are unchanged and the chain bytes identical.
     pub fn append_audit_event_tx(
         tx: &Transaction,
         event_type: &str,
@@ -136,103 +144,25 @@ impl AuditChainLinker {
         created_at_ms: i64,
         signing_key: Option<&ed25519_dalek::SigningKey>,
     ) -> Result<()> {
-        // Read previous (record_hash, sequence). Distinguish empty-table
-        // (legitimate genesis) from real read errors — the pre-v2 code
-        // silently forked to genesis on any error, hiding a corrupted
-        // store behind a brand-new chain. Now: real errors propagate.
-        let prev = tx.query_row(
-            "SELECT record_hash_hex, sequence FROM audit_log_chain \
-             ORDER BY id DESC LIMIT 1",
-            [],
-            |r| Ok((r.get::<_, String>(0)?, r.get::<_, Option<i64>>(1)?)),
-        );
-        let (previous_hash, prev_seq) = match prev {
-            Ok((h, seq)) => (h, seq.unwrap_or(-1)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => ("0".repeat(64), -1),
-            Err(e) => return Err(e), // FAIL CLOSED — never fork-to-genesis on read error
-        };
-        // Genesis -> 0; first v2 row after a v1 tail (prev_seq NULL -> -1) -> 0.
-        let sequence: u64 = (prev_seq + 1) as u64;
-
-        let record_hash = Self::compute_record_hash_v2(
-            &previous_hash,
+        crate::verifier_store::append_audit_event_tx(
+            tx,
             event_type,
             event_json_payload,
             created_at_ms,
-            sequence,
-        );
-
-        let signature_b64: Option<String> = signing_key.map(|key| {
-            use ed25519_dalek::Signer;
-            let payload = canonical_signing_payload_v2(
-                &previous_hash,
-                &record_hash,
-                event_type,
-                created_at_ms,
-                sequence,
-            );
-            let sig = key.sign(payload.as_bytes());
-            b64e.encode(sig.to_bytes())
-        });
-
-        // Record the content-addressed id of the SIGNING key (#76). The
-        // verifier selects the verifying key per row by this id, so rows signed
-        // under a prior key still verify after rotation. `key_id` is unsigned
-        // metadata: tampering it makes the row verify under the WRONG key and
-        // fail (no need to bind it into the existing signed payload, which keeps
-        // v1/v2 signatures unchanged).
-        let key_id: Option<String> = signing_key.map(|key| verifying_key_id(&key.verifying_key()));
-
-        tx.execute(
-            "INSERT INTO audit_log_chain
-             (event_type, event_json, previous_hash_hex, record_hash_hex,
-              created_at_ms, signature_b64, hash_version, sequence, key_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 2, ?7, ?8)",
-            params![
-                event_type,
-                event_json_payload,
-                previous_hash,
-                record_hash,
-                created_at_ms,
-                signature_b64,
-                sequence as i64,
-                key_id,
-            ],
-        )?;
-
-        // #77: advance the signed anchor-HEAD high-water mark to this new tail,
-        // IN THE SAME TRANSACTION as the row above. This is the whole point: the
-        // head and the row it points to commit atomically on the same connection,
-        // so the head can never be more (or less) durable than the chain tail.
-        // #74 INTERACTION: the chain is synchronous=NORMAL and its last rows may
-        // be lost on an ungraceful power cut — but because the head update rides
-        // the SAME commit as each row, a lost tail row takes its head update with
-        // it, leaving head == the recovered tail. No false truncation alarm.
-        let head_sig: Option<String> = signing_key.map(|key| {
-            use ed25519_dalek::Signer;
-            let payload = canonical_anchor_head_payload(sequence, &record_hash);
-            b64e.encode(key.sign(payload.as_bytes()).to_bytes())
-        });
-        tx.execute(
-            "INSERT INTO audit_anchor_head (id, sequence, record_hash_hex, signature_b64, key_id)
-             VALUES (1, ?1, ?2, ?3, ?4)
-             ON CONFLICT(id) DO UPDATE SET
-                 sequence        = excluded.sequence,
-                 record_hash_hex = excluded.record_hash_hex,
-                 signature_b64   = excluded.signature_b64,
-                 key_id          = excluded.key_id",
-            params![sequence as i64, record_hash, head_sig, key_id],
-        )?;
-
-        Ok(())
+            signing_key,
+        )
     }
 }
 
 #[cfg(test)]
 mod audit_signing_tests {
     use super::*;
+    // `params!` + base64 encoding are used only by these tests now that the write
+    // mechanics moved to `verifier_store` (slice 2b); import them locally so the
+    // production module carries no unused import.
+    use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
     use ed25519_dalek::{Signature, SigningKey, Verifier};
-    use rusqlite::Connection;
+    use rusqlite::{params, Connection};
 
     fn setup_db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();

--- a/src/audit_shipper.rs
+++ b/src/audit_shipper.rs
@@ -9,7 +9,7 @@
 //!
 //! **The WORM guarantee.** [`verify_shipped_chain`] recomputes every record hash
 //! from the record's own content (the same domain-separated construction the
-//! store uses — [`AuditChainLinker::compute_record_hash_v2`]) and checks
+//! store uses — [`kirra_audit_hash::compute_record_hash_v2`]) and checks
 //! (a) the recomputed hash matches, (b) each record's `previous_hash` links to
 //! the prior record's hash, and (c) sequences are contiguous ascending. Any
 //! single-field mutation breaks the hash; a dropped record breaks contiguity; a
@@ -21,48 +21,34 @@
 
 use std::io::Write as _;
 
-use serde::{Deserialize, Serialize};
+// `ShippedAuditRecord` (the off-box shipped-record wire type) moved to the lean
+// `kirra-core` crate (ADR-0035 — the kirra-persistence enabling work) so the
+// persistence layer that PRODUCES it and this off-box re-verifier that CONSUMES it
+// can both name it without depending on each other. Re-exported so every existing
+// `crate::audit_shipper::ShippedAuditRecord` path is unchanged.
+pub use kirra_core::ShippedAuditRecord;
 
-use crate::audit_chain::AuditChainLinker;
-
-/// One audit-chain record in its off-box shipped form — the raw chain fields
-/// needed to INDEPENDENTLY re-verify the hash chain without the source database.
-/// (Deliberately distinct from `AuditExportEntry`, which is the DESC-paginated
-/// human/API export view and omits `sequence`/`hash_version`.)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ShippedAuditRecord {
-    pub sequence: u64,
-    pub event_type: String,
-    pub event_json: String,
-    pub previous_hash_hex: String,
-    pub record_hash_hex: String,
-    pub created_at_ms: i64,
-    pub hash_version: i64,
-    pub signature_b64: Option<String>,
-    pub key_id: Option<String>,
-}
-
-impl ShippedAuditRecord {
-    /// Recompute this record's hash from its own content, dispatching on
-    /// `hash_version` exactly as the store does (v2 binds `event_type` + `sequence`
-    /// and is domain-separated; v1 is the legacy `prev || json || ts` form).
-    fn recompute_hash(&self) -> String {
-        match self.hash_version {
-            2 => AuditChainLinker::compute_record_hash_v2(
-                &self.previous_hash_hex,
-                &self.event_type,
-                &self.event_json,
-                self.created_at_ms,
-                self.sequence,
-            ),
-            // hash_version 1 (and any pre-v2 legacy row): the original
-            // `prev || canonical_json || created_at_ms` construction.
-            _ => AuditChainLinker::compute_record_hash_v1(
-                &self.previous_hash_hex,
-                &self.event_json,
-                self.created_at_ms,
-            ),
-        }
+/// Recompute a shipped record's hash from its own content, dispatching on
+/// `hash_version` exactly as the store does (v2 binds `event_type` + `sequence`
+/// and is domain-separated; v1 is the legacy `prev || json || ts` form). A free
+/// function (not an inherent impl) because `ShippedAuditRecord` now lives in
+/// another crate; it calls the pure `kirra_audit_hash` primitives directly.
+fn recompute_hash(rec: &ShippedAuditRecord) -> String {
+    match rec.hash_version {
+        2 => kirra_audit_hash::compute_record_hash_v2(
+            &rec.previous_hash_hex,
+            &rec.event_type,
+            &rec.event_json,
+            rec.created_at_ms,
+            rec.sequence,
+        ),
+        // hash_version 1 (and any pre-v2 legacy row): the original
+        // `prev || canonical_json || created_at_ms` construction.
+        _ => kirra_audit_hash::compute_record_hash_v1(
+            &rec.previous_hash_hex,
+            &rec.event_json,
+            rec.created_at_ms,
+        ),
     }
 }
 
@@ -121,7 +107,7 @@ pub fn verify_shipped_chain(records: &[ShippedAuditRecord]) -> ShippedChainVerdi
                 };
             }
         }
-        if r.recompute_hash() != r.record_hash_hex {
+        if recompute_hash(r) != r.record_hash_hex {
             return ShippedChainVerdict::HashMismatch {
                 sequence: r.sequence,
             };
@@ -442,7 +428,7 @@ mod tests {
         ts: i64,
     ) -> ShippedAuditRecord {
         let record_hash =
-            AuditChainLinker::compute_record_hash_v2(prev_hash, event_type, json, ts, sequence);
+            kirra_audit_hash::compute_record_hash_v2(prev_hash, event_type, json, ts, sequence);
         ShippedAuditRecord {
             sequence,
             event_type: event_type.to_string(),

--- a/src/verdicts.rs
+++ b/src/verdicts.rs
@@ -17,38 +17,12 @@
 // its pin is a git blob hash) — mapping tokens here keeps the talisman
 // untouched while every variant still gets a reviewed operator sentence.
 
-use std::sync::atomic::{AtomicU64, Ordering};
-
-use sha2::{Digest, Sha256};
-
-/// Monotonic per-process discriminator folded into each minted id so two
-/// denials of the SAME payload in the SAME millisecond still get distinct ids.
-static VERDICT_MINT_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Mint a verdict id: 32 lowercase hex chars (the first 16 bytes of a SHA-256
-/// over the event time, a monotonic counter, and the payload bytes).
-/// Collision-resistant across concurrent denials and restarts for any
-/// realistic denial volume; the id is a HANDLE (retrieval key), not a secret.
-#[must_use]
-pub fn mint_verdict_id(now_ms: u64, payload_json: &str) -> String {
-    let n = VERDICT_MINT_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let mut h = Sha256::new();
-    h.update(now_ms.to_be_bytes());
-    h.update(n.to_be_bytes());
-    h.update(payload_json.as_bytes());
-    let digest = h.finalize();
-    hex::encode(&digest[..16])
-}
-
-/// Is `s` a well-formed verdict id (exactly 32 lowercase hex chars)? The
-/// retrieval handler validates BEFORE the id is interpolated into a SQL LIKE
-/// pattern, so `%`/`_` metacharacters can never widen the match.
-#[must_use]
-pub fn is_valid_verdict_id(s: &str) -> bool {
-    s.len() == 32
-        && s.bytes()
-            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
-}
+// The verdict-id codec (`mint_verdict_id` / `is_valid_verdict_id`) is a
+// content-addressed SHA-256 audit id — it moved to the lean `kirra-audit-hash`
+// crate (ADR-0035 — the kirra-persistence enabling work) so the persistence layer
+// can validate ids without naming this module. Re-exported so every existing
+// `crate::verdicts::{mint,is_valid}_verdict_id` path (deny arm, handler) is unchanged.
+pub use kirra_audit_hash::{is_valid_verdict_id, mint_verdict_id};
 
 /// Fallback explanation for a token this build does not recognize (a NEWER
 /// verifier wrote the record). Deliberately loud about being generic.

--- a/src/verifier_store/audit.rs
+++ b/src/verifier_store/audit.rs
@@ -404,7 +404,7 @@ impl VerifierStore {
     }
 
     /// Load audit records with `sequence >= from_sequence` in ASCENDING sequence
-    /// order (up to `limit`) as [`ShippedAuditRecord`](crate::audit_shipper::ShippedAuditRecord)s — the WORM off-box shipper
+    /// order (up to `limit`) as [`ShippedAuditRecord`](kirra_core::ShippedAuditRecord)s — the WORM off-box shipper
     /// source (`crate::audit_shipper`). `from_sequence` is the INCLUSIVE next
     /// sequence to ship (the chain is 0-based — the genesis row is sequence 0 — so
     /// an inclusive lower bound is required to ship it). Rows without a `sequence`
@@ -413,7 +413,7 @@ impl VerifierStore {
         &self,
         from_sequence: u64,
         limit: u64,
-    ) -> Result<Vec<crate::audit_shipper::ShippedAuditRecord>> {
+    ) -> Result<Vec<kirra_core::ShippedAuditRecord>> {
         // CHECKED domain conversions to the SQLite INTEGER (i64) space. A
         // `from_sequence`/`limit` beyond `i64::MAX` (only reachable from a
         // corrupted persisted cursor) SATURATES to `i64::MAX` rather than wrapping
@@ -444,7 +444,7 @@ impl VerifierStore {
                     )),
                 )
             })?;
-            Ok(crate::audit_shipper::ShippedAuditRecord {
+            Ok(kirra_core::ShippedAuditRecord {
                 sequence,
                 event_type: row.get(1)?,
                 event_json: row.get(2)?,
@@ -463,7 +463,7 @@ impl VerifierStore {
     /// retrievable-verdict handle the deny arm binds into the
     /// `KINEMATIC_CONTRACT_VIOLATION` payload). `None` when no such record.
     ///
-    /// The id shape is validated HERE (`crate::verdicts::is_valid_verdict_id`
+    /// The id shape is validated HERE (`kirra_audit_hash::is_valid_verdict_id`
     /// — 32 lowercase hex chars; invalid → `Ok(None)`) so LIKE metacharacters
     /// can never widen the pattern, regardless of caller discipline (the
     /// retrieval handler also pre-validates, for its 400-vs-404 split); this
@@ -472,8 +472,8 @@ impl VerifierStore {
     pub fn load_audit_record_by_verdict_id(
         &self,
         verdict_id: &str,
-    ) -> Result<Option<crate::audit_shipper::ShippedAuditRecord>> {
-        if !crate::verdicts::is_valid_verdict_id(verdict_id) {
+    ) -> Result<Option<kirra_core::ShippedAuditRecord>> {
+        if !kirra_audit_hash::is_valid_verdict_id(verdict_id) {
             return Ok(None);
         }
         let like = format!("%\"verdict_id\":\"{verdict_id}\"%");
@@ -496,7 +496,7 @@ impl VerifierStore {
                     )),
                 )
             })?;
-            Ok(crate::audit_shipper::ShippedAuditRecord {
+            Ok(kirra_core::ShippedAuditRecord {
                 sequence,
                 event_type: row.get(1)?,
                 event_json: row.get(2)?,

--- a/src/verifier_store/audit_appender.rs
+++ b/src/verifier_store/audit_appender.rs
@@ -1,28 +1,28 @@
 // src/verifier_store/audit_appender.rs
 //
-// ADR-0035 Addendum A, Stage 2.5 step 1 (PROTOTYPE) — the injected audit-append seam.
+// ADR-0035 Addendum A — the injected audit-append seam + the audit-chain WRITE
+// mechanics (persistence enabling slice 2b).
 //
-// The hard-tier `verifier_store` families couple to the safety-authority layer by
-// appending a signed, hash-chained `AuditChainLinker` event *inside the same
-// transaction* as their table write (coupling "C1"). That atomicity is load-bearing
-// (the power-loss drill proves the chain never forks), so the append cannot simply
-// move up to the authority layer. This trait inverts the dependency WITHOUT losing
-// atomicity: the store still owns the transaction and calls `append_within` on an
-// injected appender, so a future `kirra-persistence` crate depends only on THIS
-// contract — not on `crate::audit_chain` or the Ed25519 signing key.
-//
-// This is the proof-of-mechanics on the `posture` family (the smallest C1-only
-// family). Behaviour is byte-identical: the production `ChainedAuditAppender`
-// delegates to the exact same `AuditChainLinker::append_audit_event_tx` with the
-// exact same key, so the audit-chain bytes are unchanged (a chained-write test
-// re-verifies the chain, and an atomicity test proves a failing appender rolls the
-// whole caller-owned transaction back).
+// The hard-tier `verifier_store` families couple to the audit chain by appending a
+// signed, hash-chained event *inside the same transaction* as their table write
+// (coupling "C1"). Slice 1 inverted that behind the `AuditAppender` trait so callers
+// no longer name the append function directly. Slice 2b removes the LAST
+// `crate::audit_chain` reference from persistence: the append MECHANICS —
+// `append_audit_event_tx` — write the `audit_log_chain` / `audit_anchor_head` tables
+// that persistence OWNS, using only the pure `kirra_audit_hash` primitives + Ed25519,
+// so they belong in this layer, not the root `audit_chain` module. The root
+// `AuditChainLinker::append_audit_event_tx` now DELEGATES down to the function here
+// (for its own typed wrappers + callers), so the byte-for-byte chain format is
+// unchanged (power-loss drill + tamper tests re-verify it).
+
+use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
+use rusqlite::{params, Transaction};
 
 /// Appends an audit event INTO a caller-owned transaction. The implementation
 /// supplies whatever signing material the chain needs (the production impl below
 /// borrows the store's key; the trait imposes no ownership); the persistence layer
 /// depends only on this trait, so the append happens atomically with the caller's
-/// table write while the store stays ignorant of `audit_chain` internals and the key.
+/// table write while the store stays ignorant of the key.
 ///
 /// `append_within` MUST NOT commit or roll back `tx` — it only stages its rows so
 /// the CALLER's `tx.commit()` makes the table write and the audit append all-or-
@@ -37,11 +37,10 @@ pub trait AuditAppender {
     ) -> rusqlite::Result<()>;
 }
 
-/// The production appender: the hash-chained, Ed25519-signed audit append, delegating
-/// to [`crate::audit_chain::AuditChainLinker::append_audit_event_tx`]. Holds a borrow
-/// of the store's signing key. This is the ONE type that knows both the chain logic
-/// and the key; at the eventual crate split it lives in the safety-authority layer and
-/// is injected into persistence, so persistence itself carries neither dependency.
+/// The production appender: the hash-chained, Ed25519-signed audit append. Holds a
+/// borrow of the store's signing key and delegates to [`append_audit_event_tx`] (the
+/// persistence-local write mechanics), so this type carries NO dependency on the
+/// root `audit_chain` module — the seam a future `kirra-persistence` crate needs.
 pub struct ChainedAuditAppender<'k> {
     pub signing_key: Option<&'k ed25519_dalek::SigningKey>,
 }
@@ -54,12 +53,112 @@ impl AuditAppender for ChainedAuditAppender<'_> {
         payload: &str,
         created_at_ms: i64,
     ) -> rusqlite::Result<()> {
-        crate::audit_chain::AuditChainLinker::append_audit_event_tx(
-            tx,
-            event_type,
-            payload,
-            created_at_ms,
-            self.signing_key,
-        )
+        append_audit_event_tx(tx, event_type, payload, created_at_ms, self.signing_key)
     }
+}
+
+/// Append one event to the hash-chained, signed audit ledger, into a caller-owned
+/// transaction (the row + the anchor-head advance commit atomically with the
+/// caller's write — the #77 / power-loss invariant).
+///
+/// Relocated from the root `audit_chain` module (ADR-0035 slice 2b): the write
+/// touches only the persistence-owned `audit_log_chain` / `audit_anchor_head`
+/// tables and the pure `kirra_audit_hash` hash/canonical primitives, so it belongs
+/// in the persistence layer. Byte-for-byte identical to the prior implementation —
+/// same v2 record hash, same canonical signing payloads, same key-id derivation.
+pub fn append_audit_event_tx(
+    tx: &Transaction,
+    event_type: &str,
+    event_json_payload: &str,
+    created_at_ms: i64,
+    signing_key: Option<&ed25519_dalek::SigningKey>,
+) -> rusqlite::Result<()> {
+    // Read previous (record_hash, sequence). Distinguish empty-table
+    // (legitimate genesis) from real read errors — a real error must NOT
+    // silently fork to genesis (which would hide a corrupted store behind a
+    // brand-new chain). Real errors propagate; only an empty table is genesis.
+    let prev = tx.query_row(
+        "SELECT record_hash_hex, sequence FROM audit_log_chain \
+         ORDER BY id DESC LIMIT 1",
+        [],
+        |r| Ok((r.get::<_, String>(0)?, r.get::<_, Option<i64>>(1)?)),
+    );
+    let (previous_hash, prev_seq) = match prev {
+        Ok((h, seq)) => (h, seq.unwrap_or(-1)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => ("0".repeat(64), -1),
+        Err(e) => return Err(e), // FAIL CLOSED — never fork-to-genesis on read error
+    };
+    // Genesis -> 0; first v2 row after a v1 tail (prev_seq NULL -> -1) -> 0.
+    let sequence: u64 = (prev_seq + 1) as u64;
+
+    let record_hash = kirra_audit_hash::compute_record_hash_v2(
+        &previous_hash,
+        event_type,
+        event_json_payload,
+        created_at_ms,
+        sequence,
+    );
+
+    let signature_b64: Option<String> = signing_key.map(|key| {
+        use ed25519_dalek::Signer;
+        let payload = kirra_audit_hash::canonical_signing_payload_v2(
+            &previous_hash,
+            &record_hash,
+            event_type,
+            created_at_ms,
+            sequence,
+        );
+        let sig = key.sign(payload.as_bytes());
+        b64e.encode(sig.to_bytes())
+    });
+
+    // Record the content-addressed id of the SIGNING key (#76). The verifier
+    // selects the verifying key per row by this id, so rows signed under a prior
+    // key still verify after rotation. `key_id` is unsigned metadata: tampering it
+    // makes the row verify under the WRONG key and fail (no need to bind it into
+    // the existing signed payload, which keeps v1/v2 signatures unchanged).
+    let key_id: Option<String> =
+        signing_key.map(|key| kirra_audit_hash::verifying_key_id(&key.verifying_key()));
+
+    tx.execute(
+        "INSERT INTO audit_log_chain
+         (event_type, event_json, previous_hash_hex, record_hash_hex,
+          created_at_ms, signature_b64, hash_version, sequence, key_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 2, ?7, ?8)",
+        params![
+            event_type,
+            event_json_payload,
+            previous_hash,
+            record_hash,
+            created_at_ms,
+            signature_b64,
+            sequence as i64,
+            key_id,
+        ],
+    )?;
+
+    // #77: advance the signed anchor-HEAD high-water mark to this new tail, IN THE
+    // SAME TRANSACTION as the row above. The head and the row it points to commit
+    // atomically on the same connection, so the head can never be more (or less)
+    // durable than the chain tail. #74 INTERACTION: the chain is synchronous=NORMAL
+    // and its last rows may be lost on an ungraceful power cut — but because the
+    // head update rides the SAME commit as each row, a lost tail row takes its head
+    // update with it, leaving head == the recovered tail. No false truncation alarm.
+    let head_sig: Option<String> = signing_key.map(|key| {
+        use ed25519_dalek::Signer;
+        let payload = kirra_audit_hash::canonical_anchor_head_payload(sequence, &record_hash);
+        b64e.encode(key.sign(payload.as_bytes()).to_bytes())
+    });
+    tx.execute(
+        "INSERT INTO audit_anchor_head (id, sequence, record_hash_hex, signature_b64, key_id)
+         VALUES (1, ?1, ?2, ?3, ?4)
+         ON CONFLICT(id) DO UPDATE SET
+             sequence        = excluded.sequence,
+             record_hash_hex = excluded.record_hash_hex,
+             signature_b64   = excluded.signature_b64,
+             key_id          = excluded.key_id",
+        params![sequence as i64, record_hash, head_sig, key_id],
+    )?;
+
+    Ok(())
 }

--- a/src/verifier_store/fabric.rs
+++ b/src/verifier_store/fabric.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 impl VerifierStore {
-    pub fn save_fabric_asset(&self, asset: &crate::fabric::asset::FabricAsset) -> Result<()> {
+    pub fn save_fabric_asset(&self, asset: &kirra_fabric_types::asset::FabricAsset) -> Result<()> {
         self.conn.execute(
             "INSERT OR REPLACE INTO fabric_assets
              (asset_id, asset_type, display_name, kinematic_profile, registered_at_ms, last_seen_ms, metadata_json)
@@ -22,7 +22,7 @@ impl VerifierStore {
         Ok(())
     }
 
-    pub fn load_fabric_assets(&self) -> Result<Vec<crate::fabric::asset::FabricAsset>> {
+    pub fn load_fabric_assets(&self) -> Result<Vec<kirra_fabric_types::asset::FabricAsset>> {
         let mut stmt = self.conn.prepare(
             "SELECT asset_id, asset_type, display_name, kinematic_profile, registered_at_ms, last_seen_ms, metadata_json
              FROM fabric_assets ORDER BY registered_at_ms"
@@ -42,11 +42,11 @@ impl VerifierStore {
         for row in rows {
             let (asset_id, asset_type_s, display_name, profile_s, reg_ms, last_ms, meta_s) = row?;
             let asset_type = serde_json::from_str(&asset_type_s)
-                .unwrap_or(crate::fabric::asset::AssetType::Unknown);
+                .unwrap_or(kirra_fabric_types::asset::AssetType::Unknown);
             let kinematic_profile = serde_json::from_str(&profile_s)
-                .unwrap_or(crate::fabric::asset::KinematicProfileType::Custom);
+                .unwrap_or(kirra_fabric_types::asset::KinematicProfileType::Custom);
             let metadata = serde_json::from_str(&meta_s).unwrap_or_default();
-            assets.push(crate::fabric::asset::FabricAsset {
+            assets.push(kirra_fabric_types::asset::FabricAsset {
                 asset_id,
                 asset_type,
                 display_name,
@@ -72,7 +72,7 @@ impl VerifierStore {
         &mut self,
         event: &CausalEventInput<'_>,
         signing_key: Option<&ed25519_dalek::SigningKey>,
-    ) -> Result<crate::fabric::causal_log::CausalLogEntry> {
+    ) -> Result<kirra_fabric_types::CausalLogEntry> {
         let CausalEventInput {
             entry_id,
             asset_id,
@@ -176,7 +176,7 @@ impl VerifierStore {
 
         tx.commit()?;
 
-        Ok(crate::fabric::causal_log::CausalLogEntry {
+        Ok(kirra_fabric_types::CausalLogEntry {
             entry_id: entry_id.to_string(),
             sequence,
             timestamp_ms,
@@ -195,9 +195,7 @@ impl VerifierStore {
 
     /// Decode one `fabric_causal_log` row from a query row. Column order must
     /// match the SELECT in the loaders below.
-    fn causal_entry_from_row(
-        row: &rusqlite::Row,
-    ) -> Result<crate::fabric::causal_log::CausalLogEntry> {
+    fn causal_entry_from_row(row: &rusqlite::Row) -> Result<kirra_fabric_types::CausalLogEntry> {
         let entry_id: String = row.get(0)?;
         let sequence: i64 = row.get(1)?;
         let timestamp_ms: i64 = row.get(2)?;
@@ -211,7 +209,7 @@ impl VerifierStore {
         let record_hash: String = row.get(10)?;
         let signature_b64: Option<String> = row.get(11)?;
         let key_id: Option<String> = row.get(12)?;
-        Ok(crate::fabric::causal_log::CausalLogEntry {
+        Ok(kirra_fabric_types::CausalLogEntry {
             entry_id,
             sequence: sequence.max(0) as u64,
             timestamp_ms: timestamp_ms.max(0) as u64,
@@ -229,7 +227,7 @@ impl VerifierStore {
     }
 
     /// Load every causal-log entry in chain (id ASC) order.
-    pub fn load_causal_entries(&self) -> Result<Vec<crate::fabric::causal_log::CausalLogEntry>> {
+    pub fn load_causal_entries(&self) -> Result<Vec<kirra_fabric_types::CausalLogEntry>> {
         let mut stmt = self.conn.prepare(
             "SELECT entry_id, sequence, timestamp_ms, asset_id, event_type, payload, \
              caused_by, affects_assets, fabric_generation, previous_hash_hex, \
@@ -252,7 +250,7 @@ impl VerifierStore {
         to_ms: u64,
         limit: u32,
         offset: u32,
-    ) -> Result<Vec<crate::fabric::causal_log::CausalLogEntry>> {
+    ) -> Result<Vec<kirra_fabric_types::CausalLogEntry>> {
         let mut stmt = self.conn.prepare(
             "SELECT entry_id, sequence, timestamp_ms, asset_id, event_type, payload, \
              caused_by, affects_assets, fabric_generation, previous_hash_hex, \
@@ -532,13 +530,13 @@ pub trait FabricAssetStore {
     /// overwrites, never duplicates).
     fn save_fabric_asset(
         &self,
-        asset: &crate::fabric::asset::FabricAsset,
+        asset: &kirra_fabric_types::asset::FabricAsset,
     ) -> std::result::Result<(), Self::Error>;
 
     /// Load every registered asset, ordered by `registered_at_ms` (ascending).
     fn load_fabric_assets(
         &self,
-    ) -> std::result::Result<Vec<crate::fabric::asset::FabricAsset>, Self::Error>;
+    ) -> std::result::Result<Vec<kirra_fabric_types::asset::FabricAsset>, Self::Error>;
 }
 
 /// The production SQLite backend: delegates to the inherent `VerifierStore` methods
@@ -547,10 +545,10 @@ pub trait FabricAssetStore {
 impl FabricAssetStore for VerifierStore {
     type Error = rusqlite::Error;
 
-    fn save_fabric_asset(&self, asset: &crate::fabric::asset::FabricAsset) -> Result<()> {
+    fn save_fabric_asset(&self, asset: &kirra_fabric_types::asset::FabricAsset) -> Result<()> {
         self.save_fabric_asset(asset)
     }
-    fn load_fabric_assets(&self) -> Result<Vec<crate::fabric::asset::FabricAsset>> {
+    fn load_fabric_assets(&self) -> Result<Vec<kirra_fabric_types::asset::FabricAsset>> {
         self.load_fabric_assets()
     }
 }
@@ -566,7 +564,8 @@ impl FabricAssetStore for VerifierStore {
 /// another thread can never make a `FabricAssetStore` op panic.
 #[derive(Debug, Default)]
 pub struct InMemoryFabricAssetStore {
-    assets: std::sync::Mutex<std::collections::HashMap<String, crate::fabric::asset::FabricAsset>>,
+    assets:
+        std::sync::Mutex<std::collections::HashMap<String, kirra_fabric_types::asset::FabricAsset>>,
 }
 
 impl FabricAssetStore for InMemoryFabricAssetStore {
@@ -574,7 +573,7 @@ impl FabricAssetStore for InMemoryFabricAssetStore {
 
     fn save_fabric_asset(
         &self,
-        asset: &crate::fabric::asset::FabricAsset,
+        asset: &kirra_fabric_types::asset::FabricAsset,
     ) -> std::result::Result<(), std::convert::Infallible> {
         self.assets
             .lock()
@@ -585,8 +584,9 @@ impl FabricAssetStore for InMemoryFabricAssetStore {
 
     fn load_fabric_assets(
         &self,
-    ) -> std::result::Result<Vec<crate::fabric::asset::FabricAsset>, std::convert::Infallible> {
-        let mut all: Vec<crate::fabric::asset::FabricAsset> = self
+    ) -> std::result::Result<Vec<kirra_fabric_types::asset::FabricAsset>, std::convert::Infallible>
+    {
+        let mut all: Vec<kirra_fabric_types::asset::FabricAsset> = self
             .assets
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -616,7 +616,7 @@ pub fn assert_fabric_asset_store_contract<S: FabricAssetStore>(store: &S)
 where
     S::Error: core::fmt::Debug,
 {
-    use crate::fabric::asset::{AssetType, FabricAsset, KinematicProfileType};
+    use kirra_fabric_types::asset::{AssetType, FabricAsset, KinematicProfileType};
     fn asset(id: &str, at: u64, atype: AssetType, profile: KinematicProfileType) -> FabricAsset {
         let mut metadata = std::collections::HashMap::new();
         metadata.insert("site".to_string(), "dock-7".to_string());

--- a/src/verifier_store/fabric.rs
+++ b/src/verifier_store/fabric.rs
@@ -61,7 +61,7 @@ impl VerifierStore {
 
     /// Append a causal-log event to the hash-chained, signed, persisted ledger.
     ///
-    /// Mirrors [`crate::audit_chain::AuditChainLinker::append_audit_event_tx`]:
+    /// Mirrors the audit ledger's [`super::append_audit_event_tx`]:
     /// reads the prev `(record_hash, sequence)` (fail-closed on real read
     /// errors; only `QueryReturnedNoRows` is genesis), computes the record hash
     /// (binding the causality edges), signs the canonical causal payload, records

--- a/src/verifier_store/federation.rs
+++ b/src/verifier_store/federation.rs
@@ -319,7 +319,7 @@ impl VerifierStore {
     pub fn load_federated_report_v2s_for_asset(
         &self,
         asset_id: &str,
-    ) -> Result<Vec<crate::federation_reconciliation::FederatedTrustReportV2>> {
+    ) -> Result<Vec<kirra_fleet_types::federation_reconciliation::FederatedTrustReportV2>> {
         let mut stmt = self.conn.prepare(
             "SELECT source_controller_id, asset_id, posture_json, issued_at_ms, expires_at_ms, source_generation
              FROM federated_trust_reports
@@ -347,20 +347,22 @@ impl VerifierStore {
         for row in rows {
             let (source, aid, posture_json, issued, expires, generation) = row?;
             // Fail-closed: a corrupt posture is skipped, never coerced to Nominal.
-            let Ok(posture) = serde_json::from_str::<crate::verifier::FleetPosture>(&posture_json)
+            let Ok(posture) = serde_json::from_str::<kirra_core::FleetPosture>(&posture_json)
             else {
                 continue;
             };
-            out.push(crate::federation_reconciliation::FederatedTrustReportV2 {
-                source_controller_id: source,
-                asset_id: aid,
-                posture,
-                issued_at_ms: issued,
-                expires_at_ms: expires,
-                nonce_hex: String::new(),
-                signature_b64: String::new(),
-                source_generation: generation,
-            });
+            out.push(
+                kirra_fleet_types::federation_reconciliation::FederatedTrustReportV2 {
+                    source_controller_id: source,
+                    asset_id: aid,
+                    posture,
+                    issued_at_ms: issued,
+                    expires_at_ms: expires,
+                    nonce_hex: String::new(),
+                    signature_b64: String::new(),
+                    source_generation: generation,
+                },
+            );
         }
         Ok(out)
     }

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -7,9 +7,9 @@
 // descendant-module visibility, so the split is a pure move (no new public
 // surface beyond a few `pub(crate)` helpers needed across domains).
 
-use crate::federation::FederatedTrustReport;
-use crate::verifier::{NodeTrustState, RegisteredNode};
 use base64::{engine::general_purpose::STANDARD as b64e, Engine as _};
+use kirra_core::{NodeTrustState, RegisteredNode};
+use kirra_fleet_types::federation::FederatedTrustReport;
 use rusqlite::{params, Connection, Result};
 use std::collections::HashMap;
 
@@ -376,7 +376,7 @@ pub struct VerifierStore {
     durable_conn: Option<Connection>,
     pub signing_key: Option<ed25519_dalek::SigningKey>,
     /// The database path this store was opened from (`":memory:"` for in-memory).
-    /// Retained so a [`StoreHandle`](crate::store_handle::StoreHandle) can open
+    /// Retained so a `StoreHandle` (root crate) can open
     /// independent READ-ONLY replica connections to the same WAL file.
     db_path: String,
     /// #772 F6 — TEST-ONLY invocation counter for the incident-class durable
@@ -1197,7 +1197,7 @@ impl VerifierStore {
 
     /// The PUBLIC half of the in-memory audit signing key, or `None` if no key is
     /// installed. Read-only exposure (#329 residual): lets the
-    /// [`crate::key_registry::KeyRegistry`] resolve the chain's verifying key through
+    /// `KeyRegistry` (root crate) resolve the chain's verifying key through
     /// the unified registry. There is exactly ONE audit signer and it is volatile
     /// (no rotation, no persisted history) — that wider residual is still deferred.
     pub fn audit_verifying_key(&self) -> Option<ed25519_dalek::VerifyingKey> {

--- a/src/verifier_store/mod.rs
+++ b/src/verifier_store/mod.rs
@@ -589,7 +589,7 @@ mod audit;
 // audit-append seam that inverts the C1 audit-chaining coupling while preserving
 // the row+append one-transaction atomicity.
 mod audit_appender;
-pub use audit_appender::{AuditAppender, ChainedAuditAppender};
+pub use audit_appender::{append_audit_event_tx, AuditAppender, ChainedAuditAppender};
 mod av_subsystem;
 // ADR-0035 Stage 2 (trait-seam inversion) — the AV-subsystem diagnostic-meta storage
 // trait + its in-memory reference backend (confidence floor + telemetry stamp +

--- a/src/verifier_store/nodes.rs
+++ b/src/verifier_store/nodes.rs
@@ -57,7 +57,7 @@ impl VerifierStore {
 
     /// Load a single registered node by id, or `None` if unregistered. Additive
     /// single-row loader (mirrors `load_operator` / `load_trusted_federation_controller_key`)
-    /// — the targeted lookup [`crate::key_registry::KeyRegistry`] uses to resolve a
+    /// — the targeted lookup `KeyRegistry` (root crate) uses to resolve a
     /// node's `ak_public_pem` without scanning the whole registry.
     pub fn load_node(&self, node_id: &str) -> Result<Option<RegisteredNode>> {
         use rusqlite::OptionalExtension;

--- a/src/verifier_store/ota_campaigns.rs
+++ b/src/verifier_store/ota_campaigns.rs
@@ -2,7 +2,7 @@
 // OTA governor-artifact campaigns (WS-4 · Track 3 · Fleet Plane) — persistence for
 // the `crate::ota_campaign` control-plane state machine.
 //
-// The engine (`crate::ota_campaign::Campaign`) owns all transition logic and the
+// The engine (`kirra_ota_campaign::Campaign`) owns all transition logic and the
 // fail-closed halt-on-regression rule; this module only persists a campaign and,
 // on every lifecycle mutation, appends an R156-shaped audit-chain entry IN THE
 // SAME atomic tx (the `record_grant_outcome` template — a forked chain is
@@ -11,7 +11,7 @@
 // restart (a halted rollout must never silently resume).
 
 use super::*;
-use crate::ota_campaign::{Campaign, CampaignState, HaltReason, NodeArtifactStatus};
+use kirra_ota_campaign::{Campaign, CampaignState, HaltReason, NodeArtifactStatus};
 
 impl VerifierStore {
     /// Persist a freshly-authored campaign (`Draft`) and append the
@@ -678,9 +678,9 @@ mod ota_campaign_store_contract_tests {
 
 #[cfg(test)]
 mod tests {
-    use crate::ota_campaign::{AdvanceOutcome, Campaign, CampaignState, HaltReason};
-    use crate::verifier::FleetPosture;
     use crate::verifier_store::VerifierStore;
+    use kirra_core::FleetPosture;
+    use kirra_ota_campaign::{AdvanceOutcome, Campaign, CampaignState, HaltReason};
 
     const DIGEST: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
@@ -905,7 +905,7 @@ mod tests {
 
     #[test]
     fn node_artifact_status_upserts_latest_wins() {
-        use crate::ota_campaign::NodeArtifactStatus;
+        use kirra_ota_campaign::NodeArtifactStatus;
         let mut s = store();
         let st = |digest: &str, at: u64| NodeArtifactStatus {
             node_id: "robot-01".into(),
@@ -953,7 +953,7 @@ mod tests {
 
     #[test]
     fn attested_flag_is_monotonic_per_digest() {
-        use crate::ota_campaign::NodeArtifactStatus;
+        use kirra_ota_campaign::NodeArtifactStatus;
         let other = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         let mut s = store();
         let mk = |digest: &str, at: u64, attested: bool| NodeArtifactStatus {

--- a/src/verifier_store/tests.rs
+++ b/src/verifier_store/tests.rs
@@ -562,7 +562,6 @@ mod audit_chain_bypass_tests {
 /// signatures. Pre-v2 these were undetected by the hash-only check.
 #[cfg(test)]
 mod audit_hash_v2_tests {
-    use crate::audit_chain::AuditChainLinker;
     use crate::verifier_store::*;
 
     fn in_memory() -> VerifierStore {
@@ -637,8 +636,8 @@ mod audit_hash_v2_tests {
         let prev = "0".repeat(64);
         let ts = 1_000;
         let seq = 0;
-        let h_ab_c = AuditChainLinker::compute_record_hash_v2(&prev, "AB", "C", ts, seq);
-        let h_a_bc = AuditChainLinker::compute_record_hash_v2(&prev, "A", "BC", ts, seq);
+        let h_ab_c = kirra_audit_hash::compute_record_hash_v2(&prev, "AB", "C", ts, seq);
+        let h_a_bc = kirra_audit_hash::compute_record_hash_v2(&prev, "A", "BC", ts, seq);
         assert_ne!(
             h_ab_c, h_a_bc,
             "v2 must not collide on field-boundary slides — length-prefixing prevents this"
@@ -658,7 +657,7 @@ mod audit_hash_v2_tests {
         let prev_v1 = "0".repeat(64);
         let v1_ts: i64 = 1_000;
         let v1_payload = "{\"legacy\":true}";
-        let v1_hash = AuditChainLinker::compute_record_hash_v1(&prev_v1, v1_payload, v1_ts);
+        let v1_hash = kirra_audit_hash::compute_record_hash_v1(&prev_v1, v1_payload, v1_ts);
         store
             .conn
             .execute(
@@ -721,7 +720,7 @@ mod audit_hash_v2_tests {
         assert_eq!(count, 0, "no v1 rows → no migration marker needed");
 
         // Simulate an upgraded DB: one v1 row, then run the anchor.
-        let h = AuditChainLinker::compute_record_hash_v1(&"0".repeat(64), "{}", 100);
+        let h = kirra_audit_hash::compute_record_hash_v1(&"0".repeat(64), "{}", 100);
         store
             .conn
             .execute(
@@ -762,9 +761,9 @@ mod audit_hash_v2_tests {
 /// fail-closed unknown-key-id case.
 #[cfg(test)]
 mod audit_key_rotation_tests {
-    use crate::audit_chain::{verifying_key_id, AuditChainLinker};
     use crate::verifier_store::*;
     use ed25519_dalek::SigningKey;
+    use kirra_audit_hash::verifying_key_id;
 
     fn store_with_key(seed: u8) -> (VerifierStore, SigningKey) {
         let mut s = VerifierStore::new(":memory:").expect("store");
@@ -786,7 +785,8 @@ mod audit_key_rotation_tests {
     fn append(s: &mut VerifierStore, event_type: &str, ts: i64) {
         let sk = s.signing_key.clone();
         let tx = s.conn.transaction().unwrap();
-        AuditChainLinker::append_audit_event_tx(&tx, event_type, "{}", ts, sk.as_ref()).unwrap();
+        crate::verifier_store::append_audit_event_tx(&tx, event_type, "{}", ts, sk.as_ref())
+            .unwrap();
         tx.commit().unwrap();
     }
 
@@ -1395,9 +1395,9 @@ mod durability_tests {
 
 #[cfg(test)]
 mod key_durability_165_tests {
-    use crate::audit_chain::{verifying_key_id, AuditChainLinker};
     use crate::verifier_store::*;
     use ed25519_dalek::SigningKey;
+    use kirra_audit_hash::verifying_key_id;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static CTR: AtomicU64 = AtomicU64::new(0);
@@ -1536,7 +1536,8 @@ mod key_durability_165_tests {
         {
             let sk = s.signing_key.clone();
             let tx = s.conn.transaction().unwrap();
-            AuditChainLinker::append_audit_event_tx(&tx, "TEST", "{}", 1_500, sk.as_ref()).unwrap();
+            crate::verifier_store::append_audit_event_tx(&tx, "TEST", "{}", 1_500, sk.as_ref())
+                .unwrap();
             tx.commit().unwrap();
         }
         // Verify while passing a MUTATED key: genesis must resolve from the
@@ -1601,7 +1602,7 @@ mod key_durability_165_tests {
         })
         .to_string();
         let tx = s.conn.transaction().unwrap();
-        AuditChainLinker::append_audit_event_tx(&tx, "KEY_ROTATION", &payload, ts, Some(old))
+        crate::verifier_store::append_audit_event_tx(&tx, "KEY_ROTATION", &payload, ts, Some(old))
             .unwrap();
         tx.commit().unwrap();
     }
@@ -1706,7 +1707,8 @@ mod key_durability_165_tests {
         {
             let sk = s.signing_key.clone();
             let tx = s.conn.transaction().unwrap();
-            AuditChainLinker::append_audit_event_tx(&tx, "TEST", "{}", 10, sk.as_ref()).unwrap();
+            crate::verifier_store::append_audit_event_tx(&tx, "TEST", "{}", 10, sk.as_ref())
+                .unwrap();
             tx.commit().unwrap();
         }
         assert_eq!(
@@ -1773,14 +1775,16 @@ mod key_durability_165_tests {
         {
             let sk = s.signing_key.clone();
             let tx = s.conn.transaction().unwrap();
-            AuditChainLinker::append_audit_event_tx(&tx, "TEST", "{}", 10, sk.as_ref()).unwrap();
+            crate::verifier_store::append_audit_event_tx(&tx, "TEST", "{}", 10, sk.as_ref())
+                .unwrap();
             tx.commit().unwrap();
         }
         s.record_key_rotation(b.clone(), "r", 20, held).unwrap();
         {
             let sk = s.signing_key.clone();
             let tx = s.conn.transaction().unwrap();
-            AuditChainLinker::append_audit_event_tx(&tx, "TEST", "{}", 30, sk.as_ref()).unwrap();
+            crate::verifier_store::append_audit_event_tx(&tx, "TEST", "{}", 30, sk.as_ref())
+                .unwrap();
             tx.commit().unwrap();
         }
         let r = s.verify_audit_chain_full(Some(&a.verifying_key())).unwrap();

--- a/src/verifier_store/tests.rs
+++ b/src/verifier_store/tests.rs
@@ -413,8 +413,8 @@ mod standby_store_tests {
     fn test_posture_event_analytics_queries() {
         // #396: window/group queries return the expected rows.
         let store = in_memory();
-        let nominal = serde_json::to_string(&crate::verifier::FleetPosture::Nominal).unwrap();
-        let degraded = serde_json::to_string(&crate::verifier::FleetPosture::Degraded).unwrap();
+        let nominal = serde_json::to_string(&kirra_core::FleetPosture::Nominal).unwrap();
+        let degraded = serde_json::to_string(&kirra_core::FleetPosture::Degraded).unwrap();
         store
             .save_posture_event("a", "E", &nominal, None, 1_000)
             .unwrap();
@@ -1038,11 +1038,11 @@ mod durability_tests {
         c.query_row("PRAGMA synchronous", [], |r| r.get(0)).unwrap()
     }
 
-    fn report(nonce: &str) -> crate::federation::FederatedTrustReport {
-        crate::federation::FederatedTrustReport {
+    fn report(nonce: &str) -> kirra_fleet_types::federation::FederatedTrustReport {
+        kirra_fleet_types::federation::FederatedTrustReport {
             source_controller_id: "ctrl-A".to_string(),
             asset_id: "asset-1".to_string(),
-            posture: crate::verifier::FleetPosture::Nominal,
+            posture: kirra_core::FleetPosture::Nominal,
             issued_at_ms: 1_000,
             expires_at_ms: 9_000,
             nonce_hex: nonce.to_string(),
@@ -1872,7 +1872,7 @@ mod key_durability_165_tests {
         // #165 work is entirely boot-time (admit_signing_key) + rotation-time
         // (record_key_rotation), off the hot path. This compiles & runs with no
         // VerifierStore in scope, demonstrating the independence.
-        use crate::gateway::kinematics_contract::{
+        use kirra_core::kinematics_contract::{
             validate_vehicle_command, EnforceAction, ProposedVehicleCommand,
             VehicleKinematicsContract,
         };
@@ -2077,7 +2077,7 @@ mod epoch_fence_79_tests {
         FederatedTrustReport {
             source_controller_id: "ctrl-A".to_string(),
             asset_id: "asset-1".to_string(),
-            posture: crate::verifier::FleetPosture::Nominal,
+            posture: kirra_core::FleetPosture::Nominal,
             issued_at_ms: 1_000,
             expires_at_ms: 9_000,
             nonce_hex: nonce.to_string(),
@@ -2785,9 +2785,9 @@ mod causal_chain_87_tests {
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 mod federation_v2_wiring_tests {
-    use crate::federation_reconciliation::authoritative_posture;
-    use crate::verifier::FleetPosture;
     use crate::verifier_store::*;
+    use kirra_core::FleetPosture;
+    use kirra_fleet_types::federation_reconciliation::authoritative_posture;
 
     fn rep(
         nonce: &str,


### PR DESCRIPTION
## Summary

Completes the `kirra-persistence` **enabling work**: after these three commits, `verifier_store` names **zero root-crate items** — only its own `crate::verifier_store::*` submodules, the lean leaf crates, and external crates. The wholesale `verifier_store` → `kirra-persistence` extraction (a separate follow-up PR) is now a mechanical move.

Three behaviour-preserving commits (relocations behind re-export shims + import repointing; no functional change, byte-identical audit chain):

1. **`d2f29c0` — invert the audit-append write seam (slice 2b).** The last `crate::audit_chain` coupling was the write path (`ChainedAuditAppender` → `AuditChainLinker::append_audit_event_tx`). Rather than inject the impl up from root (which would churn every `VerifierStore::new` caller), the append **mechanics** moved **down**: `append_audit_event_tx` writes the persistence-owned `audit_log_chain` / `audit_anchor_head` tables using only the pure `kirra_audit_hash` primitives + Ed25519, so it's storage mechanics. Relocated (verbatim) into `verifier_store::audit_appender`; `ChainedAuditAppender` calls it locally, and root's `AuditChainLinker::append_audit_event_tx` now delegates *down* to it (typed wrappers, tests, external callers unchanged). No cycle, no construction churn.
2. **`7895d87` — relocate `ShippedAuditRecord` + verdict-id fns (slice 3).** `ShippedAuditRecord` (the off-box shipped-record wire type — `verify_shipped_chain` is the *DB-free* independent re-verifier, so it must not live in the rusqlite-heavy persistence crate) → `kirra-core`; `mint_verdict_id`/`is_valid_verdict_id` (content-addressed SHA-256 ids) → `kirra-audit-hash`. `audit_shipper`'s `recompute_hash` became a free fn (the record type is now external) — which as a bonus freed `audit_shipper` of its own `crate::audit_chain` dependency. (`KeyRegistry`, the third item in the plan, turned out to be doc-links only.)
3. **`dbbdcf7` — repoint shim paths to leaf crates (slice 3.5).** `verifier_store` still *named* already-relocated types via their root re-export shims (`crate::verifier`, `crate::federation*`, `crate::ota_campaign`, `crate::fabric::*`). All repointed to the leaves directly (`kirra_core` / `kirra_fleet_types` / `kirra_ota_campaign` / `kirra_fabric_types`), plus one test-only `gateway::kinematics_contract` → `kirra_core::kinematics_contract`. Two residual doc-links demoted to plain spans.

## Design notes

- **Layering:** persistence owns the audit-chain **tables**, so the table-write mechanics (`append_audit_event_tx`) belong there; the pure hash/encode primitives live in `kirra-audit-hash`; the authority concern (key management/rotation) stays in the root crate. Root's `audit_chain` re-exports/delegates so every existing `crate::audit_chain::*` path is unchanged.
- **Byte-exactness is load-bearing** (2b touches the on-disk audit-chain write). The encoders moved verbatim; the power-loss drill reopens the WAL and re-verifies the chain end-to-end, and the `break_audit_chain` tamper tests confirm detection — both would fail if the format shifted.
- No new crates; no `Cargo.toml`/lockfile change in any of these three commits (all relocations land in existing leaf crates).

## Testing

Green on the tip (`dbbdcf7`):
- workspace build (no warnings)
- `cargo test --lib` — **760** (incl. the audit-chain verify path + `break_audit_chain` tamper-detection tests)
- power-loss audit drill `cargo test --test audit_chain_prefix_on_kill` — **3** (reopens the WAL DB, re-verifies the chain — the non-vacuous check that the write mechanics survived relocation)
- EP-13 audit-anchored rollout `cargo test --test two_node_rollout` — **4**
- `audit_shipper` module — **16** (verify_shipped_chain / sinks / ship_and_advance — confirms the `recompute_hash` free-fn + `ShippedAuditRecord` relocation are behaviour-preserving)
- `kirra-core` — **184**
- `cargo fmt --check`, `ci/check_quality_guardrails.py`, `ci/check_orphan_cores.py`

No behaviour change: byte-identical audit chain, same fail-closed semantics, no inherent method altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_