### PR TITLE
refactor(safety-authority): ADR-0035 Stage 3a — extract the pure posture-decision surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-safety-authority"
+version = "0.1.0"
+dependencies = [
+ "kirra-core",
+ "serde",
+]
+
+[[package]]
 name = "kirra-sidecars"
 version = "0.1.0"
 dependencies = [
@@ -2498,6 +2506,7 @@ dependencies = [
  "kirra-persistence",
  "kirra-policy-types",
  "kirra-release-token",
+ "kirra-safety-authority",
  "parko-core",
  "parko-kirra",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@
 # runtime (ORT etc.) is absent, strict-fail only in the CI lane that installs
 # it (see parko-onnx's PARKO_ONNX_REQUIRE_ORT).
 [workspace]
-members = [".", "crates/kirra-core", "crates/kirra-policy-types", "crates/kirra-industrial", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-inline-governor", "crates/kirra-l3-e2e", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval", "crates/kirra-kpi-gate", "crates/kirra-ota-installer", "crates/kirra-ota-campaign", "crates/kirra-fabric-types", "crates/kirra-audit-hash", "crates/kirra-persistence", "crates/kirra-replay", "crates/kirra-actuation-consumer", "crates/kirra-sidecars", "crates/kirra-consumer-ffi"]
+members = [".", "crates/kirra-core", "crates/kirra-policy-types", "crates/kirra-industrial", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-inline-governor", "crates/kirra-l3-e2e", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval", "crates/kirra-kpi-gate", "crates/kirra-ota-installer", "crates/kirra-ota-campaign", "crates/kirra-fabric-types", "crates/kirra-audit-hash", "crates/kirra-persistence", "crates/kirra-safety-authority", "crates/kirra-replay", "crates/kirra-actuation-consumer", "crates/kirra-sidecars", "crates/kirra-consumer-ffi"]
 resolver = "2"
 
 [package]
@@ -115,6 +115,9 @@ kirra-ota-campaign = { path = "crates/kirra-ota-campaign" }
 kirra-fabric-types = { path = "crates/kirra-fabric-types" }
 kirra-audit-hash = { path = "crates/kirra-audit-hash" }
 kirra-persistence = { path = "crates/kirra-persistence" }
+# ADR-0035 Stage 3 (slice 3a) — the pure safety-decision surface (FleetNodePosture,
+# derive_fleet_posture, RssRecoveryStreak, LockoutReason); re-exported via shims.
+kirra-safety-authority = { path = "crates/kirra-safety-authority" }
 parko-core = { path = "parko/crates/parko-core" }
 # Governor-free wire schema for capture records, shared verbatim with the offline
 # collector (docs/COLLECTOR_DESIGN.md [C1]). Re-exported by `crate::capture`.

--- a/crates/kirra-safety-authority/Cargo.toml
+++ b/crates/kirra-safety-authority/Cargo.toml
@@ -1,0 +1,37 @@
+# crates/kirra-safety-authority/Cargo.toml
+#
+# ADR-0035 Stage 3 (slice 3a — the leading edge) — the first extraction toward a
+# `SafetyAuthority` crate that will eventually own the posture engine + gray/black
+# DAG + actuator gate + attestation lifted off the `AppState` god-object.
+#
+# This FIRST slice moves only the PURE, AppState-free safety-DECISION surface, to
+# prove the crate/shim/MSRV/guardrail mechanics before anything touches the DAG or
+# actuator core (see the Stage-3 risk register):
+#   - `FleetNodePosture`      — the per-node posture record the DAG emits
+#   - `derive_fleet_posture`  — the pure fleet-fold (LockedOut > Degraded > Nominal)
+#   - `RssRecoveryStreak`     — the in-memory RSS recovery streak counter
+#   - `LockoutReason`         — the structured fail-closed reason codes
+#
+# `kirra-verifier` depends on this crate and RE-EXPORTS it (each original location
+# keeps a `pub use kirra_safety_authority::…` shim) so every existing
+# `crate::verifier::FleetNodePosture` / `crate::posture_engine::derive_fleet_posture`
+# / `crate::posture_engine_v2::LockoutReason` path resolves unchanged. No consumer
+# is edited in this slice.
+[package]
+name = "kirra-safety-authority"
+version = "0.1.0"
+edition = "2021"
+description = "Kirra safety-authority core (ADR-0035 Stage 3) — the pure, AppState-free posture-decision surface: FleetNodePosture, the fleet-fold, the RSS recovery streak, and the fail-closed LockoutReason codes. No service/DB deps."
+repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
+license-file = "../../COPYRIGHT"
+publish = false # proprietary (see COPYRIGHT) — not for crates.io
+
+[dependencies]
+# FleetPosture + NodeTrustState (the posture record's fields, and the fleet-fold's
+# lattice) live in the lean foundation crate.
+kirra-core = { path = "../kirra-core" }
+# The posture record + reason codes serialize exactly as they did in the root
+# (SSE payloads, verdict bodies) — same derives, byte-identical. The `rc` feature
+# is REQUIRED: `FleetNodePosture` interns its ids as `Arc<str>` (review P5), and
+# serde only implements `Serialize`/`Deserialize` for `Arc`/`Rc` under `rc`.
+serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/kirra-safety-authority/src/lib.rs
+++ b/crates/kirra-safety-authority/src/lib.rs
@@ -1,0 +1,149 @@
+//! Kirra **safety-authority** core (ADR-0035 Stage 3, slice 3a — the leading edge).
+//!
+//! This crate is the first extraction toward a `SafetyAuthority` aggregate that
+//! will eventually own the posture engine, the gray/black DAG traversal, the
+//! actuator gate, and attestation — lifted off the `AppState` god-object
+//! (referenced across ~42 files). Per the Stage-3 risk register, the DAG and
+//! actuator core move LAST, behind the full Kani/loom/power-loss/replay net; this
+//! slice moves only the **pure, `AppState`-free safety-DECISION surface** so the
+//! crate / shim / MSRV / guardrail mechanics are proven first:
+//!
+//! - [`FleetNodePosture`] — the per-node posture record the DAG emits;
+//! - [`derive_fleet_posture`] — the pure fleet-fold (LockedOut > Degraded > Nominal);
+//! - [`RssRecoveryStreak`] — the in-memory RSS recovery-streak counter;
+//! - [`LockoutReason`] — the structured fail-closed reason codes.
+//!
+//! `kirra-verifier` re-exports every item from its original module path (a
+//! `pub use` shim), so no consumer is touched by this extraction.
+
+use std::sync::Arc;
+
+use kirra_core::{FleetPosture, NodeTrustState};
+use serde::{Deserialize, Serialize};
+
+/// One node's contribution to the fleet posture: its local trust state, the
+/// posture propagated to it through the dependency DAG, and the interned ids of
+/// the dependencies that blocked it (if any).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetNodePosture {
+    /// Interned node id (review P5). One `Arc<str>` per distinct id is minted
+    /// per whole-fleet recalc (in `recursive_calculate`) and shared by
+    /// `Arc::clone` into the gray set, the `black` memo key, this field, and
+    /// every parent's `blocked_by` — so a node depended on by K others costs one
+    /// id allocation, not K+. Serializes/compares exactly like the prior
+    /// `String` (it derefs to `str`).
+    pub node_id: Arc<str>,
+    pub local_status: NodeTrustState,
+    pub propagated_status: FleetPosture,
+    /// Interned blocking-dependency ids — each is an `Arc::clone` of that dep's
+    /// own `node_id`, not a fresh allocation (review P5).
+    pub blocked_by: Vec<Arc<str>>,
+}
+
+/// In-memory streak counter for RSS recovery hysteresis.
+/// Tracks consecutive safe RSS reports and the streak start timestamp.
+pub struct RssRecoveryStreak {
+    pub count: u32,
+    pub start_ms: u64,
+}
+
+/// Folds per-node postures into the single fleet posture, fail-closed:
+/// any `LockedOut` wins outright; else any `Degraded` yields `Degraded`;
+/// else `Nominal`.
+pub fn derive_fleet_posture(node_postures: &[FleetNodePosture]) -> FleetPosture {
+    let mut any_degraded = false;
+    for np in node_postures {
+        match np.propagated_status {
+            FleetPosture::LockedOut => return FleetPosture::LockedOut,
+            FleetPosture::Degraded => any_degraded = true,
+            FleetPosture::Nominal => {}
+        }
+    }
+    if any_degraded {
+        FleetPosture::Degraded
+    } else {
+        FleetPosture::Nominal
+    }
+}
+
+/// Structured reason code for any fail-closed LockedOut condition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LockoutReason {
+    /// Gray/black DAG traversal produced LockedOut (cycle or depth exceeded).
+    DagLockedOut,
+    /// Posture cache entry has aged beyond POSTURE_CACHE_TTL_MS.
+    PostureCacheStale,
+    /// Posture cache contains None (cold start or operator reset).
+    PostureCacheEmpty,
+    /// Posture cache RwLock was poisoned. Requires process restart.
+    PostureCachePoisoned,
+    /// Posture engine failed to complete a recalculation cycle.
+    PostureEngineFailure,
+    /// Watchdog task determined a node's telemetry has timed out.
+    WatchdogTimeout,
+    /// An operator or administrative action explicitly locked out the fleet.
+    ManualLockout,
+    /// S-FI1d — frame/localization integrity was `Untrusted` for a sustained
+    /// run (sensor failure / possible GNSS spoofing). Sticky human-reset lockout.
+    FrameIntegrityUntrusted,
+    /// S-DG1 — the two diverse governors sustained a significant disagreement
+    /// (the parko comparator's own `escalated_to_lockout`). One of the two
+    /// safety authorities is wrong and we cannot tell which — a genuine fault,
+    /// not a transient. Sticky human-reset lockout.
+    GovernorDivergence,
+}
+
+impl std::fmt::Display for LockoutReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let code = match self {
+            Self::DagLockedOut => "DAG_LOCKED_OUT",
+            Self::PostureCacheStale => "POSTURE_CACHE_STALE",
+            Self::PostureCacheEmpty => "POSTURE_CACHE_EMPTY",
+            Self::PostureCachePoisoned => "POSTURE_CACHE_POISONED",
+            Self::PostureEngineFailure => "POSTURE_ENGINE_FAILURE",
+            Self::WatchdogTimeout => "WATCHDOG_TIMEOUT",
+            Self::ManualLockout => "MANUAL_LOCKOUT",
+            Self::FrameIntegrityUntrusted => "FRAME_INTEGRITY_UNTRUSTED",
+            Self::GovernorDivergence => "GOVERNOR_DIVERGENCE",
+        };
+        write!(f, "{code}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_fold_is_fail_closed_lockedout_wins() {
+        let mk = |p: FleetPosture| FleetNodePosture {
+            node_id: Arc::from("n"),
+            local_status: NodeTrustState::Trusted,
+            propagated_status: p,
+            blocked_by: vec![],
+        };
+        assert_eq!(derive_fleet_posture(&[]), FleetPosture::Nominal);
+        assert_eq!(
+            derive_fleet_posture(&[mk(FleetPosture::Nominal), mk(FleetPosture::Degraded)]),
+            FleetPosture::Degraded
+        );
+        assert_eq!(
+            derive_fleet_posture(&[
+                mk(FleetPosture::Degraded),
+                mk(FleetPosture::LockedOut),
+                mk(FleetPosture::Nominal)
+            ]),
+            FleetPosture::LockedOut,
+            "any LockedOut wins outright"
+        );
+    }
+
+    #[test]
+    fn lockout_reason_codes_are_stable() {
+        assert_eq!(LockoutReason::DagLockedOut.to_string(), "DAG_LOCKED_OUT");
+        assert_eq!(
+            LockoutReason::GovernorDivergence.to_string(),
+            "GOVERNOR_DIVERGENCE"
+        );
+    }
+}

--- a/crates/kirra-verifier-pg/Cargo.lock
+++ b/crates/kirra-verifier-pg/Cargo.lock
@@ -938,6 +938,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-safety-authority"
+version = "0.1.0"
+dependencies = [
+ "kirra-core",
+ "serde",
+]
+
+[[package]]
 name = "kirra-verifier"
 version = "1.1.2"
 dependencies = [
@@ -962,6 +970,7 @@ dependencies = [
  "kirra-persistence",
  "kirra-policy-types",
  "kirra-release-token",
+ "kirra-safety-authority",
  "parko-core",
  "reqwest",
  "rusqlite",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -962,6 +962,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-safety-authority"
+version = "0.1.0"
+dependencies = [
+ "kirra-core",
+ "serde",
+]
+
+[[package]]
 name = "kirra-verifier"
 version = "1.1.2"
 dependencies = [
@@ -986,6 +994,7 @@ dependencies = [
  "kirra-persistence",
  "kirra-policy-types",
  "kirra-release-token",
+ "kirra-safety-authority",
  "parko-core",
  "reqwest",
  "rusqlite",

--- a/parko/Cargo.lock
+++ b/parko/Cargo.lock
@@ -1212,6 +1212,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kirra-safety-authority"
+version = "0.1.0"
+dependencies = [
+ "kirra-core",
+ "serde",
+]
+
+[[package]]
 name = "kirra-taj"
 version = "0.1.0"
 dependencies = [
@@ -1243,6 +1251,7 @@ dependencies = [
  "kirra-persistence",
  "kirra-policy-types",
  "kirra-release-token",
+ "kirra-safety-authority",
  "parko-core",
  "reqwest",
  "rusqlite",

--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -81,21 +81,10 @@ pub fn next_generation() -> u64 {
 /// `recalculate_and_broadcast` (M-9), which overrides this to LockedOut.
 ///
 /// Pure function — no I/O, no side effects.
-pub fn derive_fleet_posture(node_postures: &[FleetNodePosture]) -> FleetPosture {
-    let mut any_degraded = false;
-    for np in node_postures {
-        match np.propagated_status {
-            FleetPosture::LockedOut => return FleetPosture::LockedOut,
-            FleetPosture::Degraded => any_degraded = true,
-            FleetPosture::Nominal => {}
-        }
-    }
-    if any_degraded {
-        FleetPosture::Degraded
-    } else {
-        FleetPosture::Nominal
-    }
-}
+// ADR-0035 Stage 3 (slice 3a): the pure fleet-fold moved to the lean
+// `kirra-safety-authority` crate; re-exported so `crate::posture_engine::derive_fleet_posture`
+// (and the `derive_fleet_posture` tests below) resolve unchanged.
+pub use kirra_safety_authority::derive_fleet_posture;
 
 // ---------------------------------------------------------------------------
 // Core engine — single authoritative write path to SharedPostureCache

--- a/src/posture_engine_v2.rs
+++ b/src/posture_engine_v2.rs
@@ -16,49 +16,11 @@
 
 use std::fmt;
 
-/// Structured reason code for any fail-closed LockedOut condition.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum LockoutReason {
-    /// Gray/black DAG traversal produced LockedOut (cycle or depth exceeded).
-    DagLockedOut,
-    /// Posture cache entry has aged beyond POSTURE_CACHE_TTL_MS.
-    PostureCacheStale,
-    /// Posture cache contains None (cold start or operator reset).
-    PostureCacheEmpty,
-    /// Posture cache RwLock was poisoned. Requires process restart.
-    PostureCachePoisoned,
-    /// Posture engine failed to complete a recalculation cycle.
-    PostureEngineFailure,
-    /// Watchdog task determined a node's telemetry has timed out.
-    WatchdogTimeout,
-    /// An operator or administrative action explicitly locked out the fleet.
-    ManualLockout,
-    /// S-FI1d — frame/localization integrity was `Untrusted` for a sustained
-    /// run (sensor failure / possible GNSS spoofing). Sticky human-reset lockout.
-    FrameIntegrityUntrusted,
-    /// S-DG1 — the two diverse governors sustained a significant disagreement
-    /// (the parko comparator's own `escalated_to_lockout`). One of the two
-    /// safety authorities is wrong and we cannot tell which — a genuine fault,
-    /// not a transient. Sticky human-reset lockout.
-    GovernorDivergence,
-}
-
-impl fmt::Display for LockoutReason {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let code = match self {
-            Self::DagLockedOut => "DAG_LOCKED_OUT",
-            Self::PostureCacheStale => "POSTURE_CACHE_STALE",
-            Self::PostureCacheEmpty => "POSTURE_CACHE_EMPTY",
-            Self::PostureCachePoisoned => "POSTURE_CACHE_POISONED",
-            Self::PostureEngineFailure => "POSTURE_ENGINE_FAILURE",
-            Self::WatchdogTimeout => "WATCHDOG_TIMEOUT",
-            Self::ManualLockout => "MANUAL_LOCKOUT",
-            Self::FrameIntegrityUntrusted => "FRAME_INTEGRITY_UNTRUSTED",
-            Self::GovernorDivergence => "GOVERNOR_DIVERGENCE",
-        };
-        write!(f, "{code}")
-    }
-}
+// ADR-0035 Stage 3 (slice 3a): `LockoutReason` (the structured fail-closed reason
+// codes + its `Display` string mapping) moved to the lean `kirra-safety-authority`
+// crate; re-exported so every `crate::posture_engine_v2::LockoutReason` path
+// (this module's `resolve_posture_with_reason`, the handlers, tests) is unchanged.
+pub use kirra_safety_authority::LockoutReason;
 
 use crate::posture_cache::SharedPostureCache;
 use crate::verifier::FleetPosture;

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -98,21 +98,11 @@ pub struct BackupExport {
     pub posture_events: Vec<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FleetNodePosture {
-    /// Interned node id (review P5). One `Arc<str>` per distinct id is minted
-    /// per whole-fleet recalc (in `recursive_calculate`) and shared by
-    /// `Arc::clone` into the gray set, the `black` memo key, this field, and
-    /// every parent's `blocked_by` — so a node depended on by K others costs one
-    /// id allocation, not K+. Serializes/compares exactly like the prior
-    /// `String` (it derefs to `str`).
-    pub node_id: Arc<str>,
-    pub local_status: NodeTrustState,
-    pub propagated_status: FleetPosture,
-    /// Interned blocking-dependency ids — each is an `Arc::clone` of that dep's
-    /// own `node_id`, not a fresh allocation (review P5).
-    pub blocked_by: Vec<Arc<str>>,
-}
+// ADR-0035 Stage 3 (slice 3a): `FleetNodePosture` moved to the lean
+// `kirra-safety-authority` crate (the pure safety-decision surface). Re-exported
+// here so every `crate::verifier::FleetNodePosture` path (the DAG traversal that
+// mints it, SSE payloads, tests) resolves unchanged.
+pub use kirra_safety_authority::FleetNodePosture;
 
 /// Capacity of the bounded broadcast channel for posture stream events.
 /// A slow subscriber that falls this many events behind is dropped rather than
@@ -239,12 +229,10 @@ pub fn request_transport_is_secure(
     }
 }
 
-/// In-memory streak counter for RSS recovery hysteresis.
-/// Tracks consecutive safe RSS reports and the streak start timestamp.
-pub struct RssRecoveryStreak {
-    pub count: u32,
-    pub start_ms: u64,
-}
+// ADR-0035 Stage 3 (slice 3a): `RssRecoveryStreak` moved to
+// `kirra-safety-authority`; re-exported so `crate::verifier::RssRecoveryStreak`
+// (the `AppState.rss_recovery_streak` field type) resolves unchanged.
+pub use kirra_safety_authority::RssRecoveryStreak;
 
 pub struct AppState {
     pub nodes: DashMap<String, RegisteredNode>,


### PR DESCRIPTION
## Summary

The **leading-edge slice of ADR-0035 Stage 3** — decomposing the `AppState` god-object (referenced across ~42 files) into a `kirra-safety-authority` crate. Per the Stage-3 risk register, the gray/black DAG traversal and the actuator core move **last**, behind the full Kani/loom/power-loss/replay net. This first slice moves **only the pure, `AppState`-free safety-DECISION surface**, to prove the crate / shim / MSRV / guardrail mechanics before anything touches the DAG.

## What changed

- **New `crates/kirra-safety-authority`** (deps: `kirra-core` + `serde`) holding:
  - `FleetNodePosture` — the per-node posture record the DAG emits;
  - `derive_fleet_posture` — the fail-closed fleet-fold (LockedOut > Degraded > Nominal);
  - `RssRecoveryStreak` — the in-memory RSS recovery-streak counter;
  - `LockoutReason` — the structured fail-closed reason codes + its `Display` code mapping.
- **Shims left at every original location** (`pub use kirra_safety_authority::…`), so every `crate::verifier::FleetNodePosture` / `crate::posture_engine::derive_fleet_posture` / `crate::posture_engine_v2::LockoutReason` path resolves unchanged. **No consumer is edited; INVARIANT #11 (`State<Arc<ServiceState>>`, `svc.app.*`) is untouched.**
- serde `rc` feature enabled on the new crate: `FleetNodePosture` interns its ids as `Arc<str>` (review P5), and serde only implements `Serialize`/`Deserialize` for `Arc`/`Rc` under `rc` (invisible in the feature-unified root build, required explicitly on the isolated crate).

## Behaviour preservation

Pure relocation — the moved items are byte-identical. The root's own `derive_fleet_posture` / DAG / lockout / verifier unit tests exercise the moved code **through the shims**, which is the regression proof.

## Verification (local)

- Root lib tests **599 passed / 0 failed**.
- New crate: unit tests + clippy clean; `cargo fmt --check` clean.
- CI guards green locally: orphan-core gate (`ci/check_orphan_cores.py`), quality guardrails (`ci/check_quality_guardrails.py`), rustfmt.

Scoped to the new crate + the three shimmed modules (`verifier.rs`, `posture_engine.rs`, `posture_engine_v2.rs`) + workspace wiring. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_