### PR TITLE
refactor(safety-authority): ADR-0035 Stage 3c — move the escalation/hysteresis state onto EscalationState

### DIFF
--- a/crates/kirra-safety-authority/src/lib.rs
+++ b/crates/kirra-safety-authority/src/lib.rs
@@ -8,13 +8,19 @@
 //! slice moves only the **pure, `AppState`-free safety-DECISION surface** so the
 //! crate / shim / MSRV / guardrail mechanics are proven first:
 //!
-//! - [`FleetNodePosture`] — the per-node posture record the DAG emits;
-//! - [`derive_fleet_posture`] — the pure fleet-fold (LockedOut > Degraded > Nominal);
-//! - [`RssRecoveryStreak`] — the in-memory RSS recovery-streak counter;
-//! - [`LockoutReason`] — the structured fail-closed reason codes.
+//! - [`FleetNodePosture`] — the per-node posture record the DAG emits (3a);
+//! - [`derive_fleet_posture`] — the pure fleet-fold (LockedOut > Degraded > Nominal) (3a);
+//! - [`RssRecoveryStreak`] — the in-memory RSS recovery-streak counter (3a);
+//! - [`LockoutReason`] — the structured fail-closed reason codes (3a);
+//! - [`attestation`] — issue #73's per-node Ed25519 challenge-response + PCR16
+//!   measured-boot binding (INVARIANT #3's real crypto) (3b);
+//! - [`EscalationState`] — the fleet-escalation / hysteresis flags + streaks the
+//!   posture engine / supervisor / watchdog read, embedded on `AppState` as
+//!   `app.escalation` (3c — the first `AppState` FIELD migration).
 //!
-//! `kirra-verifier` re-exports every item from its original module path (a
-//! `pub use` shim), so no consumer is touched by this extraction.
+//! `kirra-verifier` re-exports the pure-decision items and the attestation module
+//! from their original module paths (a `pub use` shim) and embeds `EscalationState`
+//! as one `AppState` field, so consumers reach a flag as `app.escalation.<field>`.
 
 use std::sync::Arc;
 
@@ -51,6 +57,72 @@ pub struct FleetNodePosture {
 pub struct RssRecoveryStreak {
     pub count: u32,
     pub start_ms: u64,
+}
+
+/// ADR-0035 Stage 3 (slice 3c) — the fleet-escalation / hysteresis state the
+/// posture engine, supervisor, and telemetry watchdog read to escalate or force
+/// posture, lifted verbatim off the `AppState` god-object into the safety-authority
+/// crate. Every field is `Arc<…>` interior-mutable (shared-ref access only — no
+/// `&mut self`), so `AppState` embeds this as one field and callers reach a flag as
+/// `app.escalation.<field>` (the field-façade step of the decomposition).
+///
+/// Field semantics are UNCHANGED from their prior `AppState` definitions:
+/// - `rss_active_violation` / `flood_condition_active` — Nominal→Degraded escalators;
+/// - `supervisor_tripped` — sticky, forces LockedOut when a critical loop wedges;
+/// - `rss_recovery_streak` — clears an active RSS violation;
+/// - `frame_degraded_active` (escalator) / `frame_lockout_active` (sticky) +
+///   `frame_recovery_streak` / `frame_untrusted_streak` (S-FI1d localization integrity);
+/// - `divergence_degraded_active` (escalator) / `divergence_lockout_active` (sticky) +
+///   `divergence_recovery_streak` (S-DG1 diverse-governor disagreement);
+/// - `av_registry_dirty` — H-3 watchdog watched-node-list refresh flag.
+pub struct EscalationState {
+    pub rss_active_violation: Arc<std::sync::atomic::AtomicBool>,
+    pub flood_condition_active: Arc<std::sync::atomic::AtomicBool>,
+    pub supervisor_tripped: Arc<std::sync::atomic::AtomicBool>,
+    pub rss_recovery_streak: Arc<std::sync::Mutex<RssRecoveryStreak>>,
+    pub frame_degraded_active: Arc<std::sync::atomic::AtomicBool>,
+    pub frame_lockout_active: Arc<std::sync::atomic::AtomicBool>,
+    pub frame_recovery_streak: Arc<std::sync::Mutex<RssRecoveryStreak>>,
+    pub frame_untrusted_streak: Arc<std::sync::Mutex<RssRecoveryStreak>>,
+    pub divergence_degraded_active: Arc<std::sync::atomic::AtomicBool>,
+    pub divergence_lockout_active: Arc<std::sync::atomic::AtomicBool>,
+    pub divergence_recovery_streak: Arc<std::sync::Mutex<RssRecoveryStreak>>,
+    pub av_registry_dirty: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl EscalationState {
+    /// All flags cleared, all streaks at `(0, 0)` — the exact defaults the prior
+    /// `AppState::new` set inline (byte-identical initial state).
+    pub fn new() -> Self {
+        use std::sync::atomic::AtomicBool;
+        use std::sync::Mutex;
+        let streak = || {
+            Arc::new(Mutex::new(RssRecoveryStreak {
+                count: 0,
+                start_ms: 0,
+            }))
+        };
+        Self {
+            rss_active_violation: Arc::new(AtomicBool::new(false)),
+            flood_condition_active: Arc::new(AtomicBool::new(false)),
+            supervisor_tripped: Arc::new(AtomicBool::new(false)),
+            rss_recovery_streak: streak(),
+            frame_degraded_active: Arc::new(AtomicBool::new(false)),
+            frame_lockout_active: Arc::new(AtomicBool::new(false)),
+            frame_recovery_streak: streak(),
+            frame_untrusted_streak: streak(),
+            divergence_degraded_active: Arc::new(AtomicBool::new(false)),
+            divergence_lockout_active: Arc::new(AtomicBool::new(false)),
+            divergence_recovery_streak: streak(),
+            av_registry_dirty: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl Default for EscalationState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Folds per-node postures into the single fleet posture, fail-closed:

--- a/crates/kirra-safety-authority/src/lib.rs
+++ b/crates/kirra-safety-authority/src/lib.rs
@@ -61,32 +61,78 @@ pub struct RssRecoveryStreak {
 
 /// ADR-0035 Stage 3 (slice 3c) — the fleet-escalation / hysteresis state the
 /// posture engine, supervisor, and telemetry watchdog read to escalate or force
-/// posture, lifted verbatim off the `AppState` god-object into the safety-authority
-/// crate. Every field is `Arc<…>` interior-mutable (shared-ref access only — no
-/// `&mut self`), so `AppState` embeds this as one field and callers reach a flag as
+/// posture, lifted VERBATIM off the `AppState` god-object into the safety-authority
+/// crate (per-field semantics preserved on each field below). Every field is
+/// `Arc<…>` interior-mutable (shared-ref access only — no `&mut self`), so
+/// `AppState` embeds this as one field and callers reach a flag as
 /// `app.escalation.<field>` (the field-façade step of the decomposition).
-///
-/// Field semantics are UNCHANGED from their prior `AppState` definitions:
-/// - `rss_active_violation` / `flood_condition_active` — Nominal→Degraded escalators;
-/// - `supervisor_tripped` — sticky, forces LockedOut when a critical loop wedges;
-/// - `rss_recovery_streak` — clears an active RSS violation;
-/// - `frame_degraded_active` (escalator) / `frame_lockout_active` (sticky) +
-///   `frame_recovery_streak` / `frame_untrusted_streak` (S-FI1d localization integrity);
-/// - `divergence_degraded_active` (escalator) / `divergence_lockout_active` (sticky) +
-///   `divergence_recovery_streak` (S-DG1 diverse-governor disagreement);
-/// - `av_registry_dirty` — H-3 watchdog watched-node-list refresh flag.
 pub struct EscalationState {
+    /// True while an RSS safe-distance violation is active (recalculate elevates to Degraded).
     pub rss_active_violation: Arc<std::sync::atomic::AtomicBool>,
+    /// #99 — true while flood conditions are present. Read by the posture engine
+    /// to escalate Nominal → Degraded (SG4 operational layer), exactly like
+    /// `rss_active_violation`. The SETTER (a flood detector, or a bridge from
+    /// sustained #98 WATER_UNTRAVERSABLE vetoes) is a deferred cross-subsystem
+    /// follow-up; this flag is read-only in the current code (defaults false).
     pub flood_condition_active: Arc<std::sync::atomic::AtomicBool>,
+    /// C2 supervisor trip flag (review finding C2). Set by `supervisor::spawn_supervised`
+    /// when a CRITICAL background safety loop (the telemetry watchdog, the posture
+    /// engine worker, the HA heartbeat writer / promotion monitor) crashes past its
+    /// restart budget. The posture engine reads it and forces `FleetPosture::LockedOut`
+    /// unconditionally (highest priority, overriding the DAG), so a wedged safety loop
+    /// fails the whole fleet closed instead of silently leaving actuators live. Sticky:
+    /// once tripped it stays tripped until process restart (a recovered loop within the
+    /// restart window clears the supervisor's local counter but NOT this flag — recovery
+    /// from a forced fleet lockout is an explicit human/HA action, matching LockedOut's
+    /// human-reset semantics). Defaults false.
     pub supervisor_tripped: Arc<std::sync::atomic::AtomicBool>,
+    /// Recovery streak for clearing an active RSS violation.
     pub rss_recovery_streak: Arc<std::sync::Mutex<RssRecoveryStreak>>,
+    /// S-FI1d — true while frame/localization integrity is below full `Trusted`
+    /// (a `Degraded` *or* `Untrusted` verdict). Read by the posture engine to
+    /// escalate Nominal → Degraded, exactly like `rss_active_violation`. Set
+    /// IMMEDIATELY on the first sub-trusted tick (fail-closed-immediately, no
+    /// grace period); cleared by an `AV_RECOVERY_STREAK_THRESHOLD`-long run of
+    /// `Trusted` ticks (auto-recovery). Defaults false. (AOU-LOCALIZATION-001.)
     pub frame_degraded_active: Arc<std::sync::atomic::AtomicBool>,
+    /// S-FI1d — true once frame integrity has been `Untrusted` for a SUSTAINED
+    /// run (an inverted streak): a transient localization loss is the
+    /// frame-trust-minimal Degraded MRC (decel-to-stop, auto-recovering), but a
+    /// sustained / repeated fault is a genuine failure (sensor death, possible
+    /// GNSS spoofing) and escalates to `LockedOut`. STICKY like
+    /// `supervisor_tripped` — recovery is an explicit human/HA reset, matching
+    /// LockedOut semantics. Defaults false.
     pub frame_lockout_active: Arc<std::sync::atomic::AtomicBool>,
+    /// Recovery streak for clearing `frame_degraded_active` (consecutive
+    /// `Trusted` ticks within the recovery window).
     pub frame_recovery_streak: Arc<std::sync::Mutex<RssRecoveryStreak>>,
+    /// Inverted streak counting consecutive `Untrusted` ticks toward the
+    /// `frame_lockout_active` escalation (sustained-fault detection).
     pub frame_untrusted_streak: Arc<std::sync::Mutex<RssRecoveryStreak>>,
+    /// S-DG1 — a posture-significant governor divergence is ACTIVE (the parko
+    /// comparator's leaky-bucket accumulator crossed its significance
+    /// threshold): two independently-derived safety governors disagree and we
+    /// cannot tell which is wrong. Escalates Nominal → Degraded
+    /// (decel-to-stop MRC) immediately; auto-recovers via the recovery
+    /// streak once agreeing ticks resume. Defaults false (inert until the
+    /// comparator's `PostureSignalSink` is wired).
     pub divergence_degraded_active: Arc<std::sync::atomic::AtomicBool>,
+    /// S-DG1 — the comparator's own sustained-divergence escalation
+    /// (`escalated_to_lockout`) was reported: a persistent disagreement is a
+    /// genuine fault (a real governor bug or corrupted input), not a
+    /// transient. STICKY like `supervisor_tripped` / `frame_lockout_active` —
+    /// recovery is an explicit human/HA reset. Defaults false.
     pub divergence_lockout_active: Arc<std::sync::atomic::AtomicBool>,
+    /// Recovery streak for clearing `divergence_degraded_active` (consecutive
+    /// agreeing ticks within the recovery window).
     pub divergence_recovery_streak: Arc<std::sync::Mutex<RssRecoveryStreak>>,
+    /// H-3 — set when an AV subsystem is (de)registered, so the telemetry watchdog
+    /// refreshes its watched-node list on the NEXT sweep instead of waiting up to
+    /// `AV_WATCHDOG_NODE_REFRESH_MS` (30 s). Without this a node registered just
+    /// after a refresh was unmonitored for ~28 s — a fail-OPEN window where a
+    /// freshly-registered sensor could go silent/faulty undetected, breaking the
+    /// SG-003 detection-latency bound (TIMEOUT + one sweep). The watchdog swaps it
+    /// back to false when it refreshes. Defaults false.
     pub av_registry_dirty: Arc<std::sync::atomic::AtomicBool>,
 }
 

--- a/src/bin/kirra_verifier_service/console_phase_a_tests.rs
+++ b/src/bin/kirra_verifier_service/console_phase_a_tests.rs
@@ -1037,6 +1037,7 @@ async fn estop_request_commands_mrc_and_chains_both_events() {
     // The governor commanded the sticky MRC under its own authority.
     assert!(
         svc.app
+            .escalation
             .supervisor_tripped
             .load(std::sync::atomic::Ordering::SeqCst),
         "an accepted e-stop must set the sticky supervisor_tripped flag (force_lockout)"
@@ -1085,6 +1086,7 @@ async fn clearance_signature_is_not_accepted_as_an_estop() {
     );
     assert!(
         !svc.app
+            .escalation
             .supervisor_tripped
             .load(std::sync::atomic::Ordering::SeqCst),
         "a rejected e-stop must NOT command the MRC"
@@ -1109,6 +1111,7 @@ async fn estop_unknown_operator_rejected_403() {
     );
     assert!(!svc
         .app
+        .escalation
         .supervisor_tripped
         .load(std::sync::atomic::Ordering::SeqCst));
     let (_s, ab) = get(svc.clone(), "/console/audit?limit=50").await;
@@ -1161,6 +1164,7 @@ async fn standby_instance_rejects_estop_request() {
     );
     assert!(!svc
         .app
+        .escalation
         .supervisor_tripped
         .load(std::sync::atomic::Ordering::SeqCst));
 }

--- a/src/bin/kirra_verifier_service/fleet.rs
+++ b/src/bin/kirra_verifier_service/fleet.rs
@@ -897,6 +897,7 @@ pub(crate) async fn handle_register_av_asset(
     // fail-OPEN window in which a silent/faulty fresh sensor would go undetected
     // (breaking the SG-003 detection-latency bound).
     svc.app
+        .escalation
         .av_registry_dirty
         .store(true, std::sync::atomic::Ordering::Release);
 

--- a/src/bin/kirra_verifier_service/operators.rs
+++ b/src/bin/kirra_verifier_service/operators.rs
@@ -693,6 +693,7 @@ pub(crate) async fn console_estop_request(
     //     watchdog): set the sticky flag THEN force the cache, so any surviving
     //     recalc keeps producing LockedOut. The console asks; the governor acts.
     svc.app
+        .escalation
         .supervisor_tripped
         .store(true, std::sync::atomic::Ordering::SeqCst);
     kirra_verifier::posture_engine::force_lockout(&svc.posture_cache, now);

--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -183,15 +183,19 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     // ticks clear the flag.
     // SAFETY: SG9 | REQ: governor-divergence-posture-coupling | TEST: test_divergence_degraded_active_escalates_nominal,test_divergence_lockout_active_forces_locked_out,test_divergence_flags_default_inert
     let escalate = (app
+        .escalation
         .rss_active_violation
         .load(std::sync::atomic::Ordering::SeqCst)
         || app
+            .escalation
             .flood_condition_active
             .load(std::sync::atomic::Ordering::SeqCst)
         || app
+            .escalation
             .frame_degraded_active
             .load(std::sync::atomic::Ordering::SeqCst)
         || app
+            .escalation
             .divergence_degraded_active
             .load(std::sync::atomic::Ordering::SeqCst))
         && dag_posture == FleetPosture::Nominal;
@@ -206,12 +210,15 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     // absolute LockedOut priority with `supervisor_tripped`: both are sticky
     // human-reset conditions that override the DAG and the operational escalation.
     let new_posture = if app
+        .escalation
         .supervisor_tripped
         .load(std::sync::atomic::Ordering::SeqCst)
         || app
+            .escalation
             .frame_lockout_active
             .load(std::sync::atomic::Ordering::SeqCst)
         || app
+            .escalation
             .divergence_lockout_active
             .load(std::sync::atomic::Ordering::SeqCst)
     {
@@ -407,12 +414,15 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     // (`crates/kirra-loom-models`) fails (finds a downgrade interleaving) if this
     // read is moved BEFORE the generation grab. Do not reorder.
     let sticky_lockout = app
+        .escalation
         .supervisor_tripped
         .load(std::sync::atomic::Ordering::SeqCst)
         || app
+            .escalation
             .frame_lockout_active
             .load(std::sync::atomic::Ordering::SeqCst)
         || app
+            .escalation
             .divergence_lockout_active
             .load(std::sync::atomic::Ordering::SeqCst);
     let cache_written = replace_cache_if_newer(cache, new_cached, sticky_lockout);
@@ -784,7 +794,9 @@ mod posture_engine_tests {
 
         // Healthy empty DAG would normally be Nominal (see the test above).
         // Trip the C2 supervisor flag: recalc must force LockedOut regardless.
-        app.supervisor_tripped.store(true, Ordering::SeqCst);
+        app.escalation
+            .supervisor_tripped
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         {
             let guard = cache.read().unwrap();
@@ -1067,7 +1079,9 @@ mod posture_engine_tests {
     fn test_flood_active_nominal_escalates_to_degraded() {
         let app = active_app();
         let cache = empty_cache();
-        app.flood_condition_active.store(true, Ordering::SeqCst);
+        app.escalation
+            .flood_condition_active
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(
             cache_posture(&cache),
@@ -1082,7 +1096,9 @@ mod posture_engine_tests {
         let app = active_app();
         let cache = empty_cache();
         insert_node(&app, "n", NodeTrustState::Untrusted("test".to_string())); // DAG → LockedOut
-        app.flood_condition_active.store(true, Ordering::SeqCst);
+        app.escalation
+            .flood_condition_active
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(
             cache_posture(&cache),
@@ -1096,7 +1112,9 @@ mod posture_engine_tests {
         let app = active_app();
         let cache = empty_cache();
         insert_node(&app, "n", NodeTrustState::Unknown); // DAG → Degraded
-        app.flood_condition_active.store(true, Ordering::SeqCst);
+        app.escalation
+            .flood_condition_active
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(
             cache_posture(&cache),
@@ -1115,7 +1133,9 @@ mod posture_engine_tests {
     fn test_divergence_degraded_active_escalates_nominal() {
         let app = active_app();
         let cache = empty_cache();
-        app.divergence_degraded_active.store(true, Ordering::SeqCst);
+        app.escalation
+            .divergence_degraded_active
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(
             cache_posture(&cache),
@@ -1131,7 +1151,9 @@ mod posture_engine_tests {
     fn test_divergence_lockout_active_forces_locked_out() {
         let app = active_app();
         let cache = empty_cache();
-        app.divergence_lockout_active.store(true, Ordering::SeqCst);
+        app.escalation
+            .divergence_lockout_active
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(
             cache_posture(&cache),
@@ -1161,7 +1183,9 @@ mod posture_engine_tests {
     fn test_frame_degraded_active_escalates_nominal() {
         let app = active_app();
         let cache = empty_cache();
-        app.frame_degraded_active.store(true, Ordering::SeqCst);
+        app.escalation
+            .frame_degraded_active
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(
             cache_posture(&cache),
@@ -1176,7 +1200,9 @@ mod posture_engine_tests {
     fn test_frame_degraded_active_locked_out_stays_locked_out() {
         let app = active_app();
         let cache = empty_cache();
-        app.frame_lockout_active.store(true, Ordering::SeqCst);
+        app.escalation
+            .frame_lockout_active
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(
             cache_posture(&cache),
@@ -1190,8 +1216,12 @@ mod posture_engine_tests {
     fn test_frame_and_rss_compose() {
         let app = active_app();
         let cache = empty_cache();
-        app.frame_degraded_active.store(true, Ordering::SeqCst);
-        app.rss_active_violation.store(true, Ordering::SeqCst);
+        app.escalation
+            .frame_degraded_active
+            .store(true, Ordering::SeqCst);
+        app.escalation
+            .rss_active_violation
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(
             cache_posture(&cache),
@@ -1205,11 +1235,15 @@ mod posture_engine_tests {
     fn test_frame_degraded_clears_auto_recovers_to_nominal() {
         let app = active_app();
         let cache = empty_cache();
-        app.frame_degraded_active.store(true, Ordering::SeqCst);
+        app.escalation
+            .frame_degraded_active
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded));
 
-        app.frame_degraded_active.store(false, Ordering::SeqCst);
+        app.escalation
+            .frame_degraded_active
+            .store(false, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(
             cache_posture(&cache),
@@ -1223,8 +1257,12 @@ mod posture_engine_tests {
     fn test_flood_and_rss_compose() {
         let app = active_app();
         let cache = empty_cache();
-        app.flood_condition_active.store(true, Ordering::SeqCst);
-        app.rss_active_violation.store(true, Ordering::SeqCst);
+        app.escalation
+            .flood_condition_active
+            .store(true, Ordering::SeqCst);
+        app.escalation
+            .rss_active_violation
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(
             cache_posture(&cache),
@@ -1239,11 +1277,15 @@ mod posture_engine_tests {
     fn test_flood_clears_auto_recovers_to_nominal() {
         let app = active_app();
         let cache = empty_cache();
-        app.flood_condition_active.store(true, Ordering::SeqCst);
+        app.escalation
+            .flood_condition_active
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded));
 
-        app.flood_condition_active.store(false, Ordering::SeqCst);
+        app.escalation
+            .flood_condition_active
+            .store(false, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(
             cache_posture(&cache),
@@ -1258,7 +1300,7 @@ mod posture_engine_tests {
         let app = active_app();
         let cache = empty_cache();
         assert!(
-            !app.flood_condition_active.load(Ordering::SeqCst),
+            !app.escalation.flood_condition_active.load(Ordering::SeqCst),
             "the flag defaults false"
         );
         recalculate_and_broadcast(&app, &cache);
@@ -1276,7 +1318,9 @@ mod posture_engine_tests {
     fn test_flood_transition_flows_through_audit_gated_path() {
         let app = active_app();
         let cache = empty_cache();
-        app.flood_condition_active.store(true, Ordering::SeqCst);
+        app.escalation
+            .flood_condition_active
+            .store(true, Ordering::SeqCst);
         recalculate_and_broadcast(&app, &cache);
         assert_eq!(cache_posture(&cache), Some(FleetPosture::Degraded));
 

--- a/src/posture_engine_v2.rs
+++ b/src/posture_engine_v2.rs
@@ -273,8 +273,10 @@ pub type PostureEngineSender = mpsc::Sender<PostureRecalcTrigger>;
 //  hysteresis defined in recovery_hysteresis.)
 pub fn apply_rss_state(app: &Arc<AppState>, rss: &RssState, now_ms: u64) {
     if !rss.safe {
-        app.rss_active_violation.store(true, Ordering::SeqCst);
-        if let Ok(mut streak) = app.rss_recovery_streak.lock() {
+        app.escalation
+            .rss_active_violation
+            .store(true, Ordering::SeqCst);
+        if let Ok(mut streak) = app.escalation.rss_recovery_streak.lock() {
             streak.count = 0;
             streak.start_ms = 0;
         }
@@ -283,8 +285,8 @@ pub fn apply_rss_state(app: &Arc<AppState>, rss: &RssState, now_ms: u64) {
             lat_margin = rss.lateral_margin,
             "RSS violation active — fleet posture will be escalated to Degraded"
         );
-    } else if app.rss_active_violation.load(Ordering::SeqCst) {
-        if let Ok(mut streak) = app.rss_recovery_streak.lock() {
+    } else if app.escalation.rss_active_violation.load(Ordering::SeqCst) {
+        if let Ok(mut streak) = app.escalation.rss_recovery_streak.lock() {
             // Window expiry: discard streak and start fresh from this tick.
             if streak.start_ms > 0
                 && now_ms.saturating_sub(streak.start_ms) >= AV_RECOVERY_WINDOW_MS
@@ -297,7 +299,9 @@ pub fn apply_rss_state(app: &Arc<AppState>, rss: &RssState, now_ms: u64) {
             }
             streak.count += 1;
             if streak.count >= AV_RECOVERY_STREAK_THRESHOLD {
-                app.rss_active_violation.store(false, Ordering::SeqCst);
+                app.escalation
+                    .rss_active_violation
+                    .store(false, Ordering::SeqCst);
                 streak.count = 0;
                 streak.start_ms = 0;
                 tracing::info!(
@@ -336,8 +340,8 @@ pub fn apply_frame_integrity_state(app: &Arc<AppState>, trust: FrameTrust, now_m
     match trust {
         FrameTrust::Trusted => {
             // Recovery: only meaningful while a frame degradation is active.
-            if app.frame_degraded_active.load(Ordering::SeqCst) {
-                if let Ok(mut streak) = app.frame_recovery_streak.lock() {
+            if app.escalation.frame_degraded_active.load(Ordering::SeqCst) {
+                if let Ok(mut streak) = app.escalation.frame_recovery_streak.lock() {
                     if streak.start_ms > 0
                         && now_ms.saturating_sub(streak.start_ms) >= AV_RECOVERY_WINDOW_MS
                     {
@@ -349,7 +353,9 @@ pub fn apply_frame_integrity_state(app: &Arc<AppState>, trust: FrameTrust, now_m
                     }
                     streak.count += 1;
                     if streak.count >= AV_RECOVERY_STREAK_THRESHOLD {
-                        app.frame_degraded_active.store(false, Ordering::SeqCst);
+                        app.escalation
+                            .frame_degraded_active
+                            .store(false, Ordering::SeqCst);
                         streak.count = 0;
                         streak.start_ms = 0;
                         tracing::info!(
@@ -360,7 +366,7 @@ pub fn apply_frame_integrity_state(app: &Arc<AppState>, trust: FrameTrust, now_m
                 }
             }
             // A trusted tick breaks any sustained-untrusted run.
-            if let Ok(mut s) = app.frame_untrusted_streak.lock() {
+            if let Ok(mut s) = app.escalation.frame_untrusted_streak.lock() {
                 s.count = 0;
                 s.start_ms = 0;
             }
@@ -370,25 +376,29 @@ pub fn apply_frame_integrity_state(app: &Arc<AppState>, trust: FrameTrust, now_m
         FrameTrust::Degraded => {
             // Immediate Degraded; reset both streaks (not a recovery, not a
             // sustained-untrusted tick).
-            app.frame_degraded_active.store(true, Ordering::SeqCst);
-            if let Ok(mut s) = app.frame_recovery_streak.lock() {
+            app.escalation
+                .frame_degraded_active
+                .store(true, Ordering::SeqCst);
+            if let Ok(mut s) = app.escalation.frame_recovery_streak.lock() {
                 s.count = 0;
                 s.start_ms = 0;
             }
-            if let Ok(mut s) = app.frame_untrusted_streak.lock() {
+            if let Ok(mut s) = app.escalation.frame_untrusted_streak.lock() {
                 s.count = 0;
                 s.start_ms = 0;
             }
         }
         FrameTrust::Untrusted => {
             // Immediate Degraded MRC; a trusted recovery must restart from scratch.
-            app.frame_degraded_active.store(true, Ordering::SeqCst);
-            if let Ok(mut s) = app.frame_recovery_streak.lock() {
+            app.escalation
+                .frame_degraded_active
+                .store(true, Ordering::SeqCst);
+            if let Ok(mut s) = app.escalation.frame_recovery_streak.lock() {
                 s.count = 0;
                 s.start_ms = 0;
             }
             // Inverted streak toward the sticky LockedOut escalation.
-            if let Ok(mut streak) = app.frame_untrusted_streak.lock() {
+            if let Ok(mut streak) = app.escalation.frame_untrusted_streak.lock() {
                 if streak.start_ms > 0
                     && now_ms.saturating_sub(streak.start_ms) >= AV_RECOVERY_WINDOW_MS
                 {
@@ -400,7 +410,9 @@ pub fn apply_frame_integrity_state(app: &Arc<AppState>, trust: FrameTrust, now_m
                 }
                 streak.count += 1;
                 if streak.count >= AV_RECOVERY_STREAK_THRESHOLD {
-                    app.frame_lockout_active.store(true, Ordering::SeqCst);
+                    app.escalation
+                        .frame_lockout_active
+                        .store(true, Ordering::SeqCst);
                     tracing::error!(
                         reason = %LockoutReason::FrameIntegrityUntrusted,
                         streak = streak.count,
@@ -445,13 +457,17 @@ pub fn apply_governor_divergence_state(
 ) {
     if significant {
         // Immediate Degraded; any in-progress recovery restarts from scratch.
-        app.divergence_degraded_active.store(true, Ordering::SeqCst);
-        if let Ok(mut s) = app.divergence_recovery_streak.lock() {
+        app.escalation
+            .divergence_degraded_active
+            .store(true, Ordering::SeqCst);
+        if let Ok(mut s) = app.escalation.divergence_recovery_streak.lock() {
             s.count = 0;
             s.start_ms = 0;
         }
         if escalated {
-            app.divergence_lockout_active.store(true, Ordering::SeqCst);
+            app.escalation
+                .divergence_lockout_active
+                .store(true, Ordering::SeqCst);
             tracing::error!(
                 reason = %LockoutReason::GovernorDivergence,
                 "Sustained diverse-governor disagreement (comparator escalation) — \
@@ -460,8 +476,12 @@ pub fn apply_governor_divergence_state(
         }
     } else {
         // Agreement tick: only meaningful while a divergence is active.
-        if app.divergence_degraded_active.load(Ordering::SeqCst) {
-            if let Ok(mut streak) = app.divergence_recovery_streak.lock() {
+        if app
+            .escalation
+            .divergence_degraded_active
+            .load(Ordering::SeqCst)
+        {
+            if let Ok(mut streak) = app.escalation.divergence_recovery_streak.lock() {
                 if streak.start_ms > 0
                     && now_ms.saturating_sub(streak.start_ms) >= AV_RECOVERY_WINDOW_MS
                 {
@@ -473,7 +493,8 @@ pub fn apply_governor_divergence_state(
                 }
                 streak.count += 1;
                 if streak.count >= AV_RECOVERY_STREAK_THRESHOLD {
-                    app.divergence_degraded_active
+                    app.escalation
+                        .divergence_degraded_active
                         .store(false, Ordering::SeqCst);
                     streak.count = 0;
                     streak.start_ms = 0;
@@ -509,7 +530,8 @@ pub fn start_posture_engine_worker(
         let app = Arc::clone(&app);
         let cache = cache.clone();
         Arc::new(move || {
-            app.supervisor_tripped
+            app.escalation
+                .supervisor_tripped
                 .store(true, std::sync::atomic::Ordering::SeqCst);
             crate::posture_engine::force_lockout(&cache, now_ms_engine());
         })
@@ -748,8 +770,11 @@ mod posture_engine_v2_tests {
     fn test_divergence_significant_escalates_immediately() {
         let app = frame_app();
         apply_governor_divergence_state(&app, true, false, 1_000);
-        assert!(app.divergence_degraded_active.load(Ordering::SeqCst));
-        assert!(!app.divergence_lockout_active.load(Ordering::SeqCst),
+        assert!(app
+            .escalation
+            .divergence_degraded_active
+            .load(Ordering::SeqCst));
+        assert!(!app.escalation.divergence_lockout_active.load(Ordering::SeqCst),
             "a significant-but-not-escalated tick is the transient decel-to-stop MRC, not LockedOut");
     }
 
@@ -759,8 +784,14 @@ mod posture_engine_v2_tests {
     fn test_divergence_escalated_sets_sticky_lockout() {
         let app = frame_app();
         apply_governor_divergence_state(&app, true, true, 1_000);
-        assert!(app.divergence_degraded_active.load(Ordering::SeqCst));
-        assert!(app.divergence_lockout_active.load(Ordering::SeqCst));
+        assert!(app
+            .escalation
+            .divergence_degraded_active
+            .load(Ordering::SeqCst));
+        assert!(app
+            .escalation
+            .divergence_lockout_active
+            .load(Ordering::SeqCst));
     }
 
     /// A full agreeing streak within the window clears the degradation
@@ -769,12 +800,17 @@ mod posture_engine_v2_tests {
     fn test_divergence_agreement_recovery_clears_degraded() {
         let app = frame_app();
         apply_governor_divergence_state(&app, true, false, 1_000);
-        assert!(app.divergence_degraded_active.load(Ordering::SeqCst));
+        assert!(app
+            .escalation
+            .divergence_degraded_active
+            .load(Ordering::SeqCst));
         for i in 0..AV_RECOVERY_STREAK_THRESHOLD {
             apply_governor_divergence_state(&app, false, false, 1_010 + i as u64 * 10);
         }
         assert!(
-            !app.divergence_degraded_active.load(Ordering::SeqCst),
+            !app.escalation
+                .divergence_degraded_active
+                .load(Ordering::SeqCst),
             "a full agreeing recovery streak must clear divergence_degraded_active"
         );
     }
@@ -795,7 +831,9 @@ mod posture_engine_v2_tests {
             );
         }
         assert!(
-            app.divergence_degraded_active.load(Ordering::SeqCst),
+            app.escalation
+                .divergence_degraded_active
+                .load(Ordering::SeqCst),
             "agreeing ticks spread past the window must never clear the degradation"
         );
     }
@@ -810,11 +848,15 @@ mod posture_engine_v2_tests {
             apply_governor_divergence_state(&app, false, false, 1_010 + i as u64 * 10);
         }
         assert!(
-            !app.divergence_degraded_active.load(Ordering::SeqCst),
+            !app.escalation
+                .divergence_degraded_active
+                .load(Ordering::SeqCst),
             "the degraded flag earn-back still works under a sticky lockout"
         );
         assert!(
-            app.divergence_lockout_active.load(Ordering::SeqCst),
+            app.escalation
+                .divergence_lockout_active
+                .load(Ordering::SeqCst),
             "agreement must never clear the sticky divergence lockout"
         );
     }
@@ -824,9 +866,9 @@ mod posture_engine_v2_tests {
         let app = frame_app();
         // A SINGLE Degraded tick sets the flag — no grace period.
         apply_frame_integrity_state(&app, FrameTrust::Degraded, 1_000);
-        assert!(app.frame_degraded_active.load(Ordering::SeqCst));
+        assert!(app.escalation.frame_degraded_active.load(Ordering::SeqCst));
         assert!(
-            !app.frame_lockout_active.load(Ordering::SeqCst),
+            !app.escalation.frame_lockout_active.load(Ordering::SeqCst),
             "Degraded must not by itself lock out"
         );
     }
@@ -836,9 +878,9 @@ mod posture_engine_v2_tests {
         let app = frame_app();
         // First Untrusted tick → immediate Degraded, not yet LockedOut.
         apply_frame_integrity_state(&app, FrameTrust::Untrusted, 1_000);
-        assert!(app.frame_degraded_active.load(Ordering::SeqCst));
+        assert!(app.escalation.frame_degraded_active.load(Ordering::SeqCst));
         assert!(
-            !app.frame_lockout_active.load(Ordering::SeqCst),
+            !app.escalation.frame_lockout_active.load(Ordering::SeqCst),
             "a single Untrusted tick is the transient decel-to-stop MRC, not LockedOut"
         );
         // Sustained Untrusted within the window → sticky LockedOut.
@@ -846,7 +888,7 @@ mod posture_engine_v2_tests {
             apply_frame_integrity_state(&app, FrameTrust::Untrusted, 1_000 + i as u64 * 10);
         }
         assert!(
-            app.frame_lockout_active.load(Ordering::SeqCst),
+            app.escalation.frame_lockout_active.load(Ordering::SeqCst),
             "sustained Untrusted ({AV_RECOVERY_STREAK_THRESHOLD} ticks) must escalate to LockedOut"
         );
     }
@@ -855,13 +897,13 @@ mod posture_engine_v2_tests {
     fn test_frame_trusted_recovery_clears_degraded() {
         let app = frame_app();
         apply_frame_integrity_state(&app, FrameTrust::Degraded, 1_000);
-        assert!(app.frame_degraded_active.load(Ordering::SeqCst));
+        assert!(app.escalation.frame_degraded_active.load(Ordering::SeqCst));
         // A full streak of Trusted ticks within the window clears the degradation.
         for i in 0..AV_RECOVERY_STREAK_THRESHOLD {
             apply_frame_integrity_state(&app, FrameTrust::Trusted, 1_010 + i as u64 * 10);
         }
         assert!(
-            !app.frame_degraded_active.load(Ordering::SeqCst),
+            !app.escalation.frame_degraded_active.load(Ordering::SeqCst),
             "a full Trusted recovery streak must clear frame_degraded_active"
         );
     }
@@ -873,7 +915,7 @@ mod posture_engine_v2_tests {
             apply_frame_integrity_state(&app, FrameTrust::Untrusted, 1_000 + i as u64 * 10);
         }
         assert!(
-            app.frame_lockout_active.load(Ordering::SeqCst),
+            app.escalation.frame_lockout_active.load(Ordering::SeqCst),
             "precondition: locked out"
         );
         // Trusted recovery does NOT clear a sustained-fault lockout (human reset only).
@@ -881,7 +923,7 @@ mod posture_engine_v2_tests {
             apply_frame_integrity_state(&app, FrameTrust::Trusted, 2_000 + i as u64 * 10);
         }
         assert!(
-            app.frame_lockout_active.load(Ordering::SeqCst),
+            app.escalation.frame_lockout_active.load(Ordering::SeqCst),
             "frame_lockout_active must be sticky — only a human/HA reset clears it"
         );
     }

--- a/src/telemetry_watchdog.rs
+++ b/src/telemetry_watchdog.rs
@@ -170,7 +170,8 @@ pub fn spawn_telemetry_watchdog_with_clock(
         let app = Arc::clone(&app);
         let tx = posture_engine_tx.clone();
         Arc::new(move || {
-            app.supervisor_tripped
+            app.escalation
+                .supervisor_tripped
                 .store(true, std::sync::atomic::Ordering::SeqCst);
             let _ = tx.try_send(PostureRecalcTrigger::PeriodicRefresh);
         })
@@ -349,6 +350,7 @@ fn watchdog_sweep_once_inner(
     // up by this load (it reads the committed DB), and if it lands after the load
     // the flag is set again → caught on the next sweep (≤ one AV_WATCHDOG_SWEEP_MS).
     let registry_dirty = app
+        .escalation
         .av_registry_dirty
         .swap(false, std::sync::atomic::Ordering::AcqRel);
     if registry_dirty
@@ -418,7 +420,8 @@ fn watchdog_sweep_once_inner(
                 // periodic refresh is unaffected (it re-fires on the 30 s timer),
                 // and a redundant set just triggers one extra refresh attempt.
                 if registry_dirty {
-                    app.av_registry_dirty
+                    app.escalation
+                        .av_registry_dirty
                         .store(true, std::sync::atomic::Ordering::Release);
                 }
                 tracing::error!(
@@ -642,7 +645,8 @@ fn force_watchdog_lockout(
     reason: &'static str,
 ) {
     if sticky {
-        app.supervisor_tripped
+        app.escalation
+            .supervisor_tripped
             .store(true, std::sync::atomic::Ordering::SeqCst);
     }
     if let Some(cache) = posture_cache {
@@ -687,7 +691,8 @@ pub(crate) fn escalate_on_sustained_overrun(
             "telemetry watchdog SUSTAINED deadline overrun — the dead-man's switch cannot \
              hold its detection-latency bound; escalating fleet to LockedOut (C2 fail-closed)"
         );
-        app.supervisor_tripped
+        app.escalation
+            .supervisor_tripped
             .store(true, std::sync::atomic::Ordering::SeqCst);
         let _ = posture_engine_tx.try_send(PostureRecalcTrigger::PeriodicRefresh);
     }
@@ -1229,7 +1234,7 @@ mod watchdog_di_tests {
             "a FULL channel must force the shared cache to LockedOut immediately"
         );
         assert!(
-            !app.supervisor_tripped.load(Ordering::SeqCst),
+            !app.escalation.supervisor_tripped.load(Ordering::SeqCst),
             "a transient FULL channel must NOT trip the sticky supervisor lockout (auto-recoverable)"
         );
     }
@@ -1278,7 +1283,7 @@ mod watchdog_di_tests {
             "a CLOSED channel must force the shared cache to LockedOut immediately"
         );
         assert!(
-            app.supervisor_tripped.load(Ordering::SeqCst),
+            app.escalation.supervisor_tripped.load(Ordering::SeqCst),
             "a CLOSED channel (dead engine) must trip the sticky supervisor lockout"
         );
     }
@@ -1457,7 +1462,8 @@ mod watchdog_di_tests {
         );
 
         // H-3: registration sets the dirty flag → the next sweep refreshes promptly.
-        app.av_registry_dirty
+        app.escalation
+            .av_registry_dirty
             .store(true, std::sync::atomic::Ordering::Release);
         watchdog_sweep_once(
             &app,
@@ -1471,7 +1477,8 @@ mod watchdog_di_tests {
             "H-3: a dirty registry must force a prompt refresh so the fresh node is monitored within one sweep"
         );
         assert!(
-            !app.av_registry_dirty
+            !app.escalation
+                .av_registry_dirty
                 .load(std::sync::atomic::Ordering::Acquire),
             "the watchdog must clear av_registry_dirty after refreshing"
         );
@@ -1664,7 +1671,8 @@ mod sustained_overrun_tests {
         }
 
         assert!(
-            app.supervisor_tripped
+            app.escalation
+                .supervisor_tripped
                 .load(std::sync::atomic::Ordering::SeqCst),
             "a sustained sweep overrun must set the sticky supervisor_tripped flag (C2)"
         );
@@ -1697,7 +1705,8 @@ mod sustained_overrun_tests {
         }
 
         assert!(
-            !app.supervisor_tripped
+            !app.escalation
+                .supervisor_tripped
                 .load(std::sync::atomic::Ordering::SeqCst),
             "isolated slow sweeps (nominal jitter) must never trip the supervisor"
         );
@@ -1718,6 +1727,7 @@ mod sustained_overrun_tests {
             escalate_on_sustained_overrun(&app, &tx, &mut tracker, 1_000 + i * 100, true);
         }
         assert!(!app
+            .escalation
             .supervisor_tripped
             .load(std::sync::atomic::Ordering::SeqCst));
         assert!(rx.try_recv().is_err());

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -231,7 +231,7 @@ pub fn request_transport_is_secure(
 
 // ADR-0035 Stage 3 (slice 3a): `RssRecoveryStreak` moved to
 // `kirra-safety-authority`; re-exported so `crate::verifier::RssRecoveryStreak`
-// (the `AppState.rss_recovery_streak` field type) resolves unchanged.
+// (the `AppState.escalation.rss_recovery_streak` field type) resolves unchanged.
 pub use kirra_safety_authority::RssRecoveryStreak;
 
 pub struct AppState {
@@ -297,65 +297,15 @@ pub struct AppState {
     /// at startup. When enabled, the `require_secure_transport` middleware
     /// fail-closes a request not asserted to have arrived over TLS.
     pub transport_security: TransportSecurityConfig,
-    /// True while an RSS safe-distance violation is active (recalculate elevates to Degraded).
-    pub rss_active_violation: Arc<AtomicBool>,
-    /// #99 — true while flood conditions are present. Read by the posture engine
-    /// to escalate Nominal → Degraded (SG4 operational layer), exactly like
-    /// `rss_active_violation`. The SETTER (a flood detector, or a bridge from
-    /// sustained #98 WATER_UNTRAVERSABLE vetoes) is a deferred cross-subsystem
-    /// follow-up; this flag is read-only in the current code (defaults false).
-    pub flood_condition_active: Arc<AtomicBool>,
-    /// C2 supervisor trip flag (review finding C2). Set by `supervisor::spawn_supervised`
-    /// when a CRITICAL background safety loop (the telemetry watchdog, the posture
-    /// engine worker, the HA heartbeat writer / promotion monitor) crashes past its
-    /// restart budget. The posture engine reads it and forces `FleetPosture::LockedOut`
-    /// unconditionally (highest priority, overriding the DAG), so a wedged safety loop
-    /// fails the whole fleet closed instead of silently leaving actuators live. Sticky:
-    /// once tripped it stays tripped until process restart (a recovered loop within the
-    /// restart window clears the supervisor's local counter but NOT this flag — recovery
-    /// from a forced fleet lockout is an explicit human/HA action, matching LockedOut's
-    /// human-reset semantics). Defaults false.
-    pub supervisor_tripped: Arc<AtomicBool>,
-    /// Recovery streak for clearing an active RSS violation.
-    pub rss_recovery_streak: Arc<Mutex<RssRecoveryStreak>>,
-    /// S-FI1d — true while frame/localization integrity is below full `Trusted`
-    /// (a `Degraded` *or* `Untrusted` verdict). Read by the posture engine to
-    /// escalate Nominal → Degraded, exactly like `rss_active_violation`. Set
-    /// IMMEDIATELY on the first sub-trusted tick (fail-closed-immediately, no
-    /// grace period); cleared by an `AV_RECOVERY_STREAK_THRESHOLD`-long run of
-    /// `Trusted` ticks (auto-recovery). Defaults false. (AOU-LOCALIZATION-001.)
-    pub frame_degraded_active: Arc<AtomicBool>,
-    /// S-FI1d — true once frame integrity has been `Untrusted` for a SUSTAINED
-    /// run (an inverted streak): a transient localization loss is the
-    /// frame-trust-minimal Degraded MRC (decel-to-stop, auto-recovering), but a
-    /// sustained / repeated fault is a genuine failure (sensor death, possible
-    /// GNSS spoofing) and escalates to `LockedOut`. STICKY like
-    /// `supervisor_tripped` — recovery is an explicit human/HA reset, matching
-    /// LockedOut semantics. Defaults false.
-    pub frame_lockout_active: Arc<AtomicBool>,
-    /// Recovery streak for clearing `frame_degraded_active` (consecutive
-    /// `Trusted` ticks within the recovery window).
-    pub frame_recovery_streak: Arc<Mutex<RssRecoveryStreak>>,
-    /// Inverted streak counting consecutive `Untrusted` ticks toward the
-    /// `frame_lockout_active` escalation (sustained-fault detection).
-    pub frame_untrusted_streak: Arc<Mutex<RssRecoveryStreak>>,
-    /// S-DG1 — a posture-significant governor divergence is ACTIVE (the parko
-    /// comparator's leaky-bucket accumulator crossed its significance
-    /// threshold): two independently-derived safety governors disagree and we
-    /// cannot tell which is wrong. Escalates Nominal → Degraded
-    /// (decel-to-stop MRC) immediately; auto-recovers via the recovery
-    /// streak once agreeing ticks resume. Defaults false (inert until the
-    /// comparator's `PostureSignalSink` is wired).
-    pub divergence_degraded_active: Arc<AtomicBool>,
-    /// S-DG1 — the comparator's own sustained-divergence escalation
-    /// (`escalated_to_lockout`) was reported: a persistent disagreement is a
-    /// genuine fault (a real governor bug or corrupted input), not a
-    /// transient. STICKY like `supervisor_tripped` / `frame_lockout_active` —
-    /// recovery is an explicit human/HA reset. Defaults false.
-    pub divergence_lockout_active: Arc<AtomicBool>,
-    /// Recovery streak for clearing `divergence_degraded_active` (consecutive
-    /// agreeing ticks within the recovery window).
-    pub divergence_recovery_streak: Arc<Mutex<RssRecoveryStreak>>,
+    /// ADR-0035 Stage 3 (slice 3c): the fleet-escalation / hysteresis state —
+    /// the RSS / flood / supervisor-trip / frame-integrity (S-FI1d) / governor-
+    /// divergence (S-DG1) flags + their recovery/untrusted streaks, plus the H-3
+    /// `av_registry_dirty` watchdog flag — lifted VERBATIM onto
+    /// `kirra_safety_authority::EscalationState`. Reached as
+    /// `app.escalation.<field>`; each field's semantics are UNCHANGED (documented
+    /// on the struct in the safety-authority crate). All are `Arc<…>` interior-
+    /// mutable, so the move is pure relocation — no `&mut self`, no behaviour change.
+    pub escalation: kirra_safety_authority::EscalationState,
     /// #104 — the currently-open post-incident forensic sequence (correlation id
     /// + ordinal), or `None` when no incident is open. Volatile; the durable
     /// forensic record lives in the signed audit chain.
@@ -388,14 +338,6 @@ pub struct AppState {
     /// side channel); surfaced so an integrator can see how much training data the
     /// channel sizing is shedding.
     pub capture_drops: Arc<AtomicU64>,
-    /// H-3 — set when an AV subsystem is (de)registered, so the telemetry watchdog
-    /// refreshes its watched-node list on the NEXT sweep instead of waiting up to
-    /// `AV_WATCHDOG_NODE_REFRESH_MS` (30 s). Without this a node registered just
-    /// after a refresh was unmonitored for ~28 s — a fail-OPEN window where a
-    /// freshly-registered sensor could go silent/faulty undetected, breaking the
-    /// SG-003 detection-latency bound (TIMEOUT + one sweep). The watchdog swaps it
-    /// back to false when it refreshes. Defaults false.
-    pub av_registry_dirty: Arc<AtomicBool>,
     /// WS-0.5 — fleet-safety Prometheus counters (posture transitions, gate
     /// denials, HA promotions), exported by `GET /metrics` on the verifier
     /// binary. Lock-free; incremented on the observed paths, never gating
@@ -442,36 +384,15 @@ impl AppState {
             posture_tx,
             transport_identity: TransportIdentityConfig::from_env(),
             transport_security: TransportSecurityConfig::from_env(),
-            rss_active_violation: Arc::new(AtomicBool::new(false)),
-            flood_condition_active: Arc::new(AtomicBool::new(false)),
-            supervisor_tripped: Arc::new(AtomicBool::new(false)),
-            rss_recovery_streak: Arc::new(Mutex::new(RssRecoveryStreak {
-                count: 0,
-                start_ms: 0,
-            })),
-            frame_degraded_active: Arc::new(AtomicBool::new(false)),
-            frame_lockout_active: Arc::new(AtomicBool::new(false)),
-            frame_recovery_streak: Arc::new(Mutex::new(RssRecoveryStreak {
-                count: 0,
-                start_ms: 0,
-            })),
-            frame_untrusted_streak: Arc::new(Mutex::new(RssRecoveryStreak {
-                count: 0,
-                start_ms: 0,
-            })),
-            divergence_degraded_active: Arc::new(AtomicBool::new(false)),
-            divergence_lockout_active: Arc::new(AtomicBool::new(false)),
-            divergence_recovery_streak: Arc::new(Mutex::new(RssRecoveryStreak {
-                count: 0,
-                start_ms: 0,
-            })),
+            // ADR-0035 Stage 3c: the escalation/hysteresis flags + streaks (incl.
+            // av_registry_dirty) now live on EscalationState; identical initial state.
+            escalation: kirra_safety_authority::EscalationState::new(),
             current_incident: Arc::new(Mutex::new(None)),
             post_incident_write_failures: Arc::new(AtomicU64::new(0)),
             incident_durability_failures: Arc::new(AtomicU64::new(0)),
             command_source_write_failures: Arc::new(AtomicU64::new(0)),
             audit_write_drops: Arc::new(AtomicU64::new(0)),
             capture_drops: Arc::new(AtomicU64::new(0)),
-            av_registry_dirty: Arc::new(AtomicBool::new(false)),
             fleet_metrics: crate::metrics::FleetSafetyMetrics::new(),
             deadline_registry: Arc::new(crate::execution_manager::DeadlineRegistry::from_manifest(
                 crate::execution_manager::TASK_MANIFEST,

--- a/tests/rss_simulation.rs
+++ b/tests/rss_simulation.rs
@@ -59,9 +59,9 @@ fn build_app() -> (Arc<AppState>, SharedPostureCache) {
 }
 
 fn reset_rss_state(app: &Arc<AppState>) {
-    app.rss_active_violation
+    app.escalation.rss_active_violation
         .store(false, std::sync::atomic::Ordering::SeqCst);
-    if let Ok(mut streak) = app.rss_recovery_streak.lock() {
+    if let Ok(mut streak) = app.escalation.rss_recovery_streak.lock() {
         streak.count = 0;
         streak.start_ms = 0;
     }

--- a/tests/rss_simulation.rs
+++ b/tests/rss_simulation.rs
@@ -59,7 +59,8 @@ fn build_app() -> (Arc<AppState>, SharedPostureCache) {
 }
 
 fn reset_rss_state(app: &Arc<AppState>) {
-    app.escalation.rss_active_violation
+    app.escalation
+        .rss_active_violation
         .store(false, std::sync::atomic::Ordering::SeqCst);
     if let Ok(mut streak) = app.escalation.rss_recovery_streak.lock() {
         streak.count = 0;


### PR DESCRIPTION
## Summary

The **first `AppState` field migration** of Stage 3 (3a/3b relocated free functions + a pure module; this moves actual god-object *fields*). The 12 fleet-escalation / hysteresis fields move **verbatim** onto a new `kirra_safety_authority::EscalationState`, embedded on `AppState` as one field (`app.escalation`):

`rss_active_violation`, `flood_condition_active`, `supervisor_tripped`, `rss_recovery_streak`, `frame_degraded_active`, `frame_lockout_active`, `frame_recovery_streak`, `frame_untrusted_streak`, `divergence_degraded_active`, `divergence_lockout_active`, `divergence_recovery_streak`, `av_registry_dirty`.

## Why a mechanical rewrite (not a shim)

Rust field access can't hide behind a `pub use` shim, so the **~88 call sites are rewritten** `app.<field>` → `app.escalation.<field>` (across `posture_engine`, `posture_engine_v2`, `supervisor`, `telemetry_watchdog`, `execution_manager`, `verifier`, and the fleet/operator/console bin handlers). **Deref-forwarding was rejected**: it's an anti-pattern and dead-ends 3d/3e (AppState can't `Deref` to two targets). Every field is `Arc<…>` interior-mutable (shared-ref access only, no `&mut self`), so this is pure relocation.

## What changed

- **`crates/kirra-safety-authority`**: new `EscalationState` (+ `new()` / `Default`), each field's semantics + docs preserved on the struct.
- **`AppState`**: the 12 fields replaced by one `pub escalation: EscalationState`; `AppState::new` constructs `EscalationState::new()` — **byte-identical initial state** (all flags `false`, streaks `(0, 0)`).
- Call sites rewritten mechanically; the **compiler is the completeness check** (a missed site won't build).
- No new dependency → no lockfile churn.

## Behaviour preservation

Pure relocation of interior-mutable state. The **sticky-lockout (#688)**, RSS-violation, frame-integrity (S-FI1d), governor-divergence (S-DG1), supervisor-trip, and telemetry-watchdog behaviour tests exercise the fields through the new `app.escalation.<field>` path.

## Verification (local)

- Root build clean → all ~88 rewritten call sites resolve (the type system guarantees completeness).
- Root lib tests **580 passed / 0 failed** (posture-engine escalation, sticky-lockout, supervisor, watchdog).
- New crate **21/21**; orphan-core + quality guardrails + `cargo fmt --check` green.

Scoped to the escalation-state relocation + the mechanical call-site rewrite. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_