### PR TITLE
refactor(safety-authority): ADR-0035 Stage 3d — move the gray/black DAG traversal into kirra-safety-authority

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,7 +441,10 @@ AUDIT_SHIP_INTERVAL_MS      = 5_000      // WORM off-box audit-ship cycle interv
 **Gray/Black DAG Traversal** (`kirra_safety_authority::dag::recursive_calculate`, ADR-0035 Stage 3d; `AppState::calculate_posture*` delegate to it):
 - Gray set = nodes currently on the active call stack (cycle detection)
 - Black set = nodes fully evaluated (memoization, handles diamond DAGs)
-- Cycle or depth ≥ 10 → `FleetPosture::LockedOut` with `CYCLE_DETECTED` tag
+- Cycle (gray-set back-edge) → `FleetPosture::LockedOut` tagged `CYCLE_DETECTED`
+- Depth backstop is a DYNAMIC bound `max(nodes+edges, MAX_DEPENDENCY_DEPTH)` (10 is
+  a floor, not a fixed cap): exceeding it → `LockedOut` tagged `MAX_DEPTH_EXCEEDED`
+  (distinct from the cycle tag; unreachable on a valid acyclic graph)
 - LockedOut dep propagates LockedOut (not Degraded) upward
 
 **`should_route_command(cache, now_ms, command)`**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ These have been blocked or reverted multiple times. Any submission that violates
 
 3. **`verify_attestation` must never mock trust** (`let status = NodeTrustState::Trusted` without verification). It MUST cryptographically verify a per-node proof: the node's Ed25519 signature over the `(node_id, nonce)` challenge payload, checked against the registered per-node `ak_public_pem` via `attestation::verify_attestation_proof` (issue #73). Fail-closed — no registered AK / malformed key / malformed proof / bad signature → reject; never accept by default. (The prior `HMAC(KIRRA_ADMIN_TOKEN, nonce)` proof was admin-asserted, not node-proven, and is removed. PCR16 measured-boot: BOTH paths are LIVE — the self-report binding (`verify_attestation_proof_with_pcr16`) and the genuine TPM2 **quote**. `tpm_quote::verify_tpm_quote` (`src/tpm_quote.rs`) is wired into `/attestation/verify` under a per-node `require_tpm_quote` policy: a node required to quote must present one whose TPM-signed `pcrDigest` equals `SHA256(registered_pcr16_value)` (`expected_single_pcr_digest_hex`) over a bounded PCR16 selection, bound to the challenge nonce — `verify_strict`, fail-closed (401 auth / 403 boot-state), and nonce-preserving (runs before `consume_challenge`, so a failed quote is retryable). What remains for Gate C #3 is the on-device rooting only: Orin Secure Boot + dm-verity + a provisioned TPM AK (the quote sig is Ed25519 today → RSA/ECC on a real TPM).)
 
-4. **`FleetNodePosture` and the gray/black two-set DAG algorithm must never be replaced with a mock**. The real traversal in `AppState::recursive_calculate` must remain intact.
+4. **`FleetNodePosture` and the gray/black two-set DAG algorithm must never be replaced with a mock**. The real traversal was moved VERBATIM to `kirra_safety_authority::dag::recursive_calculate` (ADR-0035 Stage 3d) and is invoked via the `AppState::calculate_posture*` / `calculate_fleet_posture` delegators — the algorithm is byte-identical and must remain intact (proven by `shared_memo_equivalence_tests`).
 
 5. **`pending_challenges: DashMap<String, ChallengeEntry>` must never be removed**. Nonces are volatile, never persisted, and expire after `CHALLENGE_TTL_MS = 30_000` ms.
 
@@ -438,7 +438,7 @@ AUDIT_SHIP_INTERVAL_MS      = 5_000      // WORM off-box audit-ship cycle interv
 
 ## Key Algorithms
 
-**Gray/Black DAG Traversal** (`AppState::recursive_calculate`):
+**Gray/Black DAG Traversal** (`kirra_safety_authority::dag::recursive_calculate`, ADR-0035 Stage 3d; `AppState::calculate_posture*` delegate to it):
 - Gray set = nodes currently on the active call stack (cycle detection)
 - Black set = nodes fully evaluated (memoization, handles diamond DAGs)
 - Cycle or depth ≥ 10 → `FleetPosture::LockedOut` with `CYCLE_DETECTED` tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,6 +2438,7 @@ name = "kirra-safety-authority"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "dashmap",
  "ed25519-dalek",
  "hex",
  "hmac 0.13.0",

--- a/crates/kirra-safety-authority/Cargo.toml
+++ b/crates/kirra-safety-authority/Cargo.toml
@@ -28,8 +28,11 @@ publish = false # proprietary (see COPYRIGHT) — not for crates.io
 
 [dependencies]
 # FleetPosture + NodeTrustState (the posture record's fields, and the fleet-fold's
-# lattice) live in the lean foundation crate.
+# lattice) + RegisteredNode (the DAG's node registry value) live in the foundation.
 kirra-core = { path = "../kirra-core" }
+# The gray/black DAG traversal (slice 3d) reads the node/edge maps directly; they
+# are `DashMap`s on `AppState`, passed by reference into the pure traversal.
+dashmap = "6"
 # The posture record + reason codes serialize exactly as they did in the root
 # (SSE payloads, verdict bodies) — same derives, byte-identical. The `rc` feature
 # is REQUIRED: `FleetNodePosture` interns its ids as `Arc<str>` (review P5), and

--- a/crates/kirra-safety-authority/src/dag.rs
+++ b/crates/kirra-safety-authority/src/dag.rs
@@ -20,8 +20,14 @@ use kirra_core::{FleetPosture, NodeTrustState, RegisteredNode};
 
 use crate::FleetNodePosture;
 
-/// Maximum recursion depth for dependency graph traversal.
-/// Prevents stack overflow on pathologically deep (but acyclic) graphs.
+/// FLOOR on the dependency-graph traversal's stack-overflow backstop — NOT a fixed
+/// cap. The effective bound is dynamic:
+/// `max(nodes.len() + dependency_graph.len(), MAX_DEPENDENCY_DEPTH)` (see
+/// [`calculate_posture_memoized`]), so it covers the whole distinct-id universe and
+/// CANNOT fire on a valid acyclic graph (a cycle is always caught first). This
+/// constant only ensures a tiny fleet still carries a documented guard. A graph
+/// that exceeds the dynamic bound degrades to fail-closed `LockedOut` tagged
+/// `MAX_DEPTH_EXCEEDED` — DISTINCT from the `CYCLE_DETECTED` cycle verdict.
 pub const MAX_DEPENDENCY_DEPTH: usize = 10;
 
 /// Single-root posture with a fresh memo.
@@ -113,9 +119,11 @@ pub fn calculate_fleet_posture(
 
 /// The gray/black two-set DFS (INVARIANT #4). BYTE-IDENTICAL to the prior
 /// `AppState::recursive_calculate` — self-recursive, reads only `nodes` +
-/// `dependency_graph`.
+/// `dependency_graph`. `pub(crate)` (not `pub`): external callers use the stable
+/// `calculate_posture*` / `calculate_fleet_posture` entry points; the recursion
+/// helper is not part of the crate's public API.
 #[allow(clippy::too_many_arguments)]
-pub fn recursive_calculate(
+pub(crate) fn recursive_calculate(
     nodes: &DashMap<String, RegisteredNode>,
     dependency_graph: &DashMap<String, Vec<String>>,
     node_id: &str,

--- a/crates/kirra-safety-authority/src/dag.rs
+++ b/crates/kirra-safety-authority/src/dag.rs
@@ -1,0 +1,232 @@
+//! ADR-0035 Stage 3 (slice 3d) — the gray/black two-set dependency-DAG posture
+//! traversal (INVARIANT #4), lifted VERBATIM out of `AppState` into the reviewable
+//! safety-authority crate.
+//!
+//! The algorithm is BYTE-IDENTICAL to its prior `AppState` form — it is never
+//! mocked (INVARIANT #4). It was already pure with respect to `AppState`: it reads
+//! only the node registry (`nodes`) and the dependency edges (`dependency_graph`),
+//! so the extraction takes those two maps as parameters and `AppState` keeps the
+//! `calculate_posture*` / `calculate_fleet_posture` methods as thin delegators
+//! (every existing `app.calculate_*` caller is unchanged). The fields themselves
+//! stay on `AppState` for now — this slice moves the ALGORITHM (the safety-critical
+//! core, and the thing the Kani proofs + `shared_memo_equivalence_tests` pin), not
+//! the storage.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use kirra_core::{FleetPosture, NodeTrustState, RegisteredNode};
+
+use crate::FleetNodePosture;
+
+/// Maximum recursion depth for dependency graph traversal.
+/// Prevents stack overflow on pathologically deep (but acyclic) graphs.
+pub const MAX_DEPENDENCY_DEPTH: usize = 10;
+
+/// Single-root posture with a fresh memo.
+pub fn calculate_posture(
+    nodes: &DashMap<String, RegisteredNode>,
+    dependency_graph: &DashMap<String, Vec<String>>,
+    node_id: &str,
+) -> FleetNodePosture {
+    let mut black: HashMap<Arc<str>, Arc<FleetNodePosture>> = HashMap::new();
+    calculate_posture_memoized(nodes, dependency_graph, node_id, &mut black)
+}
+
+/// As [`calculate_posture`], but reuses a CALLER-OWNED `black` memo across
+/// many roots (review P3). A node's fully-evaluated posture is
+/// root-INDEPENDENT (it is a property of the node + its dependency subgraph,
+/// not of which root reached it), so the whole-fleet recalc can share ONE
+/// memo: a node depended on by K others is traversed ONCE (the first root to
+/// reach it) and then black-hit by the rest — turning the fleet recalc from
+/// O(N·(N+E)) into ~O(N+E). The gray (cycle-detection) set is still FRESH per
+/// call: it tracks the CURRENT root's active call stack, and the cycle /
+/// depth sentinels are deliberately NOT memoized (never inserted into
+/// `black`), so sharing `black` only ever reuses fully-resolved verdicts.
+/// The memo stores `Arc<FleetNodePosture>` so a hit is an `Arc::clone`
+/// (refcount bump) rather than a deep clone of the node id + `blocked_by`
+/// vector. Node ids are interned as `Arc<str>` (review P5): the memo key, the
+/// gray set, every `node_id` field and every `blocked_by` entry share one
+/// allocation per distinct id, so a hot dependency referenced by K parents
+/// costs one id allocation rather than K+ `String`s. `Arc<str>: Borrow<str>`
+/// lets both maps be probed with a plain `&str` (no allocation on a lookup).
+pub fn calculate_posture_memoized(
+    nodes: &DashMap<String, RegisteredNode>,
+    dependency_graph: &DashMap<String, Vec<String>>,
+    node_id: &str,
+    black: &mut HashMap<Arc<str>, Arc<FleetNodePosture>>,
+) -> FleetNodePosture {
+    let mut gray: HashSet<Arc<str>> = HashSet::new();
+    // Recursion bound for the stack-overflow backstop below. The gray set
+    // already makes a repeated node on the active path impossible without a
+    // cycle, so the longest *acyclic* path visits at most as many DISTINCT
+    // ids as exist in the graph. That universe is NOT just `nodes` (B8):
+    // `dependency_graph` may carry edges to ids never registered as nodes (a
+    // dangling/forward dependency), and the traversal recurses into them
+    // (they resolve to `Unknown`). A chain of such unregistered ids can be
+    // LONGER than `nodes.len()`, so the old `nodes.len()` bound could fire on
+    // a perfectly acyclic graph and spuriously report LockedOut. Bound by the
+    // full id universe instead: `nodes.len() + dependency_graph.len()`
+    // over-approximates the distinct-id count (every id with an outgoing edge
+    // is a dependency_graph key; a leaf id has no edge and cannot extend a
+    // path), so the depth check CANNOT fire on a valid acyclic graph,
+    // registered or not — keeping it a pure stack-safety guard rather than a
+    // (traversal-order-dependent) semantic verdict. Floored at
+    // MAX_DEPENDENCY_DEPTH so a tiny fleet still carries the documented guard.
+    let max_depth = (nodes.len() + dependency_graph.len()).max(MAX_DEPENDENCY_DEPTH);
+    let posture = recursive_calculate(
+        nodes,
+        dependency_graph,
+        node_id,
+        &mut gray,
+        black,
+        0,
+        max_depth,
+    );
+    (*posture).clone()
+}
+
+/// Whole-fleet per-node posture in ONE pass with a SHARED `black` memo
+/// (review P3): O(N+E) instead of the O(N·(N+E)) of calling
+/// [`calculate_posture`] once per node (each with a fresh memo). Result is
+/// IDENTICAL to mapping `calculate_posture` over every registered node — the
+/// per-node verdict is root-independent, so one shared memo only ever reuses
+/// fully-resolved verdicts (proven in `shared_memo_equivalence_tests`).
+///
+/// The node-id set is snapshotted FIRST (the `nodes` shard guards are dropped
+/// before any traversal), so the re-entrant `nodes.get(...)` inside the DAG
+/// walk cannot deadlock against a held `nodes.iter()` guard — the same B1
+/// hazard the posture-engine recalc already avoids.
+pub fn calculate_fleet_posture(
+    nodes: &DashMap<String, RegisteredNode>,
+    dependency_graph: &DashMap<String, Vec<String>>,
+) -> Vec<FleetNodePosture> {
+    // SAFETY: SG-RED-2 — snapshot iteration prevents nested DashMap locks.
+    // SAFETY: SG-RED-3 — posture DAG recalculation must be deadlock-free.
+    let ids: Vec<String> = nodes.iter().map(|e| e.key().clone()).collect();
+    let mut black: HashMap<Arc<str>, Arc<FleetNodePosture>> = HashMap::new();
+    ids.iter()
+        .map(|id| calculate_posture_memoized(nodes, dependency_graph, id.as_str(), &mut black))
+        .collect()
+}
+
+/// The gray/black two-set DFS (INVARIANT #4). BYTE-IDENTICAL to the prior
+/// `AppState::recursive_calculate` — self-recursive, reads only `nodes` +
+/// `dependency_graph`.
+#[allow(clippy::too_many_arguments)]
+pub fn recursive_calculate(
+    nodes: &DashMap<String, RegisteredNode>,
+    dependency_graph: &DashMap<String, Vec<String>>,
+    node_id: &str,
+    gray: &mut HashSet<Arc<str>>,
+    black: &mut HashMap<Arc<str>, Arc<FleetNodePosture>>,
+    depth: usize,
+    max_depth: usize,
+) -> Arc<FleetNodePosture> {
+    // Black: node already fully evaluated in this pass — reuse without
+    // re-traversal. `Arc::clone` is a refcount bump, not a deep copy (P5).
+    if let Some(cached) = black.get(node_id) {
+        return Arc::clone(cached);
+    }
+
+    // Gray: node is currently on the active call stack — a back-edge, i.e. a
+    // genuine cycle. A circular dependency has no well-defined posture →
+    // fail-closed LockedOut (tagged CYCLE_DETECTED). Deterministic: any
+    // traversal that re-enters the cycle hits a gray node regardless of the
+    // entry path, so this is a true property of the graph, not the walk order.
+    // NOT memoized (not inserted into `black`) — a transient per-DFS sentinel,
+    // which is what makes sharing `black` across roots sound (P3).
+    if gray.contains(node_id) {
+        return Arc::new(FleetNodePosture {
+            node_id: Arc::from(node_id),
+            local_status: NodeTrustState::Unknown,
+            propagated_status: FleetPosture::LockedOut,
+            blocked_by: vec![Arc::from("CYCLE_DETECTED")],
+        });
+    }
+
+    // Depth backstop — a stack-overflow guard, NOT a semantic verdict. Because
+    // the gray set bounds any acyclic path to the number of distinct ids in the
+    // graph and `max_depth` covers that whole id universe (registered nodes +
+    // dependency-graph edges, see above), this branch is unreachable on a valid
+    // acyclic graph (a cycle is always caught above first). It exists only so a
+    // pathological graph degrades to fail-closed LockedOut instead of
+    // overflowing the stack. The prior `depth >= MAX_DEPENDENCY_DEPTH` fixed cap
+    // conflated this with graph validity: because the sentinel was not memoized,
+    // a node reachable both within and beyond 10 hops resolved to LockedOut or
+    // Nominal depending on which path the DFS reached it by FIRST — so the whole
+    // fleet's posture depended on dependency *insertion order* rather than the
+    // graph's trust state. Bounding by the id-universe count removes that flip
+    // entirely, including for chains of unregistered dependency ids (B8).
+    if depth >= max_depth {
+        return Arc::new(FleetNodePosture {
+            node_id: Arc::from(node_id),
+            local_status: NodeTrustState::Unknown,
+            propagated_status: FleetPosture::LockedOut,
+            blocked_by: vec![Arc::from("MAX_DEPTH_EXCEEDED")],
+        });
+    }
+
+    // Mint the interned id ONCE for this node; every subsequent use (gray
+    // set, the result's `node_id`, the `black` key, and each parent's
+    // `blocked_by`) is an `Arc::clone` refcount bump, not a new allocation.
+    let id: Arc<str> = Arc::from(node_id);
+    gray.insert(Arc::clone(&id));
+
+    let local_status = nodes
+        .get(node_id)
+        .map(|n| n.status.clone())
+        .unwrap_or(NodeTrustState::Unknown);
+
+    let deps = dependency_graph
+        .get(node_id)
+        .map(|d| d.value().clone())
+        .unwrap_or_default();
+
+    let mut blocked_by: Vec<Arc<str>> = Vec::new();
+    let mut has_locked_out_dep = false;
+
+    for dep_id in &deps {
+        let dep_posture = recursive_calculate(
+            nodes,
+            dependency_graph,
+            dep_id,
+            gray,
+            black,
+            depth + 1,
+            max_depth,
+        );
+        match &dep_posture.propagated_status {
+            FleetPosture::LockedOut => {
+                // Share the dep's interned id rather than re-allocating it.
+                blocked_by.push(Arc::clone(&dep_posture.node_id));
+                has_locked_out_dep = true;
+            }
+            FleetPosture::Degraded => {
+                blocked_by.push(Arc::clone(&dep_posture.node_id));
+            }
+            FleetPosture::Nominal => {}
+        }
+    }
+
+    let propagated_status = match &local_status {
+        NodeTrustState::Untrusted(_) => FleetPosture::LockedOut,
+        _ if has_locked_out_dep => FleetPosture::LockedOut,
+        _ if !blocked_by.is_empty() => FleetPosture::Degraded,
+        NodeTrustState::Unknown => FleetPosture::Degraded,
+        NodeTrustState::Trusted => FleetPosture::Nominal,
+    };
+
+    let posture = Arc::new(FleetNodePosture {
+        node_id: Arc::clone(&id),
+        local_status,
+        propagated_status,
+        blocked_by,
+    });
+
+    gray.remove(node_id);
+    black.insert(id, Arc::clone(&posture));
+
+    posture
+}

--- a/crates/kirra-safety-authority/src/lib.rs
+++ b/crates/kirra-safety-authority/src/lib.rs
@@ -33,6 +33,12 @@ use serde::{Deserialize, Serialize};
 // shim. Its own test suite (moved with it) is the behaviour-preservation proof.
 pub mod attestation;
 
+// ADR-0035 Stage 3 (slice 3d): the gray/black two-set dependency-DAG posture
+// traversal (INVARIANT #4), moved VERBATIM out of `AppState`. It reads only the
+// node/edge maps (passed as params), so `AppState` keeps its `calculate_*` methods
+// as thin delegators — every caller unchanged, the algorithm never mocked.
+pub mod dag;
+
 /// One node's contribution to the fleet posture: its local trust state, the
 /// posture propagated to it through the dependency DAG, and the interned ids of
 /// the dependencies that blocked it (if any).

--- a/crates/kirra-verifier-pg/Cargo.lock
+++ b/crates/kirra-verifier-pg/Cargo.lock
@@ -941,6 +941,7 @@ dependencies = [
 name = "kirra-safety-authority"
 version = "0.1.0"
 dependencies = [
+ "dashmap",
  "ed25519-dalek",
  "hex",
  "kirra-audit-hash",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -965,6 +965,7 @@ dependencies = [
 name = "kirra-safety-authority"
 version = "0.1.0"
 dependencies = [
+ "dashmap",
  "ed25519-dalek",
  "hex",
  "kirra-audit-hash",

--- a/parko/Cargo.lock
+++ b/parko/Cargo.lock
@@ -1215,6 +1215,7 @@ dependencies = [
 name = "kirra-safety-authority"
 version = "0.1.0"
 dependencies = [
+ "dashmap",
  "ed25519-dalek",
  "hex",
  "kirra-audit-hash",

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -4,14 +4,15 @@ use crate::security::constant_time_compare;
 use crate::verifier_store::VerifierStore;
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 
-/// Maximum recursion depth for dependency graph traversal.
-/// Prevents stack overflow on pathologically deep (but acyclic) graphs.
-pub const MAX_DEPENDENCY_DEPTH: usize = 10;
+// ADR-0035 Stage 3 (slice 3d): the gray/black DAG traversal + its depth bound
+// moved to `kirra_safety_authority::dag`; re-exported so every
+// `crate::verifier::MAX_DEPENDENCY_DEPTH` path resolves unchanged.
+pub use kirra_safety_authority::dag::MAX_DEPENDENCY_DEPTH;
 
 /// Nonces expire after 30 seconds — long enough for a challenged node to respond,
 /// short enough to limit the replay window if a response is intercepted.
@@ -494,188 +495,32 @@ impl AppState {
         Ok(())
     }
 
+    /// Single-root posture with a fresh memo. Delegates to the gray/black DAG
+    /// traversal in `kirra_safety_authority::dag` (ADR-0035 slice 3d) — the
+    /// algorithm is byte-identical and never mocked (INVARIANT #4).
     pub fn calculate_posture(&self, node_id: &str) -> FleetNodePosture {
-        let mut black: HashMap<Arc<str>, Arc<FleetNodePosture>> = HashMap::new();
-        self.calculate_posture_memoized(node_id, &mut black)
+        kirra_safety_authority::dag::calculate_posture(&self.nodes, &self.dependency_graph, node_id)
     }
 
-    /// As `calculate_posture`, but reuses a CALLER-OWNED `black` memo across
-    /// many roots (review P3). A node's fully-evaluated posture is
-    /// root-INDEPENDENT (it is a property of the node + its dependency subgraph,
-    /// not of which root reached it), so the whole-fleet recalc can share ONE
-    /// memo: a node depended on by K others is traversed ONCE (the first root to
-    /// reach it) and then black-hit by the rest — turning the fleet recalc from
-    /// O(N·(N+E)) into ~O(N+E). The gray (cycle-detection) set is still FRESH per
-    /// call: it tracks the CURRENT root's active call stack, and the cycle /
-    /// depth sentinels are deliberately NOT memoized (never inserted into
-    /// `black`), so sharing `black` only ever reuses fully-resolved verdicts.
-    /// The memo stores `Arc<FleetNodePosture>` so a hit is an `Arc::clone`
-    /// (refcount bump) rather than a deep clone of the node id + `blocked_by`
-    /// vector. Node ids are interned as `Arc<str>` (review P5): the memo key, the
-    /// gray set, every `node_id` field and every `blocked_by` entry share one
-    /// allocation per distinct id, so a hot dependency referenced by K parents
-    /// costs one id allocation rather than K+ `String`s. `Arc<str>: Borrow<str>`
-    /// lets both maps be probed with a plain `&str` (no allocation on a lookup).
+    /// Whole-fleet-shared-memo posture (see `dag::calculate_posture_memoized`).
     pub fn calculate_posture_memoized(
         &self,
         node_id: &str,
         black: &mut HashMap<Arc<str>, Arc<FleetNodePosture>>,
     ) -> FleetNodePosture {
-        let mut gray: HashSet<Arc<str>> = HashSet::new();
-        // Recursion bound for the stack-overflow backstop below. The gray set
-        // already makes a repeated node on the active path impossible without a
-        // cycle, so the longest *acyclic* path visits at most as many DISTINCT
-        // ids as exist in the graph. That universe is NOT just `nodes` (B8):
-        // `dependency_graph` may carry edges to ids never registered as nodes (a
-        // dangling/forward dependency), and the traversal recurses into them
-        // (they resolve to `Unknown`). A chain of such unregistered ids can be
-        // LONGER than `nodes.len()`, so the old `nodes.len()` bound could fire on
-        // a perfectly acyclic graph and spuriously report LockedOut. Bound by the
-        // full id universe instead: `nodes.len() + dependency_graph.len()`
-        // over-approximates the distinct-id count (every id with an outgoing edge
-        // is a dependency_graph key; a leaf id has no edge and cannot extend a
-        // path), so the depth check CANNOT fire on a valid acyclic graph,
-        // registered or not — keeping it a pure stack-safety guard rather than a
-        // (traversal-order-dependent) semantic verdict. Floored at
-        // MAX_DEPENDENCY_DEPTH so a tiny fleet still carries the documented guard.
-        let max_depth = (self.nodes.len() + self.dependency_graph.len()).max(MAX_DEPENDENCY_DEPTH);
-        let posture = self.recursive_calculate(node_id, &mut gray, black, 0, max_depth);
-        (*posture).clone()
+        kirra_safety_authority::dag::calculate_posture_memoized(
+            &self.nodes,
+            &self.dependency_graph,
+            node_id,
+            black,
+        )
     }
 
-    /// Whole-fleet per-node posture in ONE pass with a SHARED `black` memo
-    /// (review P3): O(N+E) instead of the O(N·(N+E)) of calling
-    /// [`calculate_posture`](Self::calculate_posture) once per node (each with a
-    /// fresh memo). Result is IDENTICAL to mapping `calculate_posture` over every
-    /// registered node — the per-node verdict is root-independent, so one shared
-    /// memo only ever reuses fully-resolved verdicts (proven in
-    /// `shared_memo_equivalence_tests`).
-    ///
-    /// The node-id set is snapshotted FIRST (the `nodes` shard guards are dropped
-    /// before any traversal), so the re-entrant `nodes.get(...)` inside the DAG
-    /// walk cannot deadlock against a held `nodes.iter()` guard — the same B1
-    /// hazard the posture-engine recalc already avoids. (The previous
-    /// `/fleet/posture` handler iterated `nodes` while calling `calculate_posture`
-    /// per entry, holding the iter guard across re-entrant gets.)
+    /// Whole-fleet per-node posture in ONE pass with a shared memo
+    /// (see `dag::calculate_fleet_posture`). Snapshot-then-traverse, deadlock-free.
     pub fn calculate_fleet_posture(&self) -> Vec<FleetNodePosture> {
-        // SAFETY: SG-RED-2 — snapshot iteration prevents nested DashMap locks.
-        // SAFETY: SG-RED-3 — posture DAG recalculation must be deadlock-free.
-        let ids: Vec<String> = self.nodes.iter().map(|e| e.key().clone()).collect();
-        let mut black: HashMap<Arc<str>, Arc<FleetNodePosture>> = HashMap::new();
-        ids.iter()
-            .map(|id| self.calculate_posture_memoized(id.as_str(), &mut black))
-            .collect()
+        kirra_safety_authority::dag::calculate_fleet_posture(&self.nodes, &self.dependency_graph)
     }
-
-    fn recursive_calculate(
-        &self,
-        node_id: &str,
-        gray: &mut HashSet<Arc<str>>,
-        black: &mut HashMap<Arc<str>, Arc<FleetNodePosture>>,
-        depth: usize,
-        max_depth: usize,
-    ) -> Arc<FleetNodePosture> {
-        // Black: node already fully evaluated in this pass — reuse without
-        // re-traversal. `Arc::clone` is a refcount bump, not a deep copy (P5).
-        if let Some(cached) = black.get(node_id) {
-            return Arc::clone(cached);
-        }
-
-        // Gray: node is currently on the active call stack — a back-edge, i.e. a
-        // genuine cycle. A circular dependency has no well-defined posture →
-        // fail-closed LockedOut (tagged CYCLE_DETECTED). Deterministic: any
-        // traversal that re-enters the cycle hits a gray node regardless of the
-        // entry path, so this is a true property of the graph, not the walk order.
-        // NOT memoized (not inserted into `black`) — a transient per-DFS sentinel,
-        // which is what makes sharing `black` across roots sound (P3).
-        if gray.contains(node_id) {
-            return Arc::new(FleetNodePosture {
-                node_id: Arc::from(node_id),
-                local_status: NodeTrustState::Unknown,
-                propagated_status: FleetPosture::LockedOut,
-                blocked_by: vec![Arc::from("CYCLE_DETECTED")],
-            });
-        }
-
-        // Depth backstop — a stack-overflow guard, NOT a semantic verdict. Because
-        // the gray set bounds any acyclic path to the number of distinct ids in the
-        // graph and `max_depth` covers that whole id universe (registered nodes +
-        // dependency-graph edges, see above), this branch is unreachable on a valid
-        // acyclic graph (a cycle is always caught above first). It exists only so a
-        // pathological graph degrades to fail-closed LockedOut instead of
-        // overflowing the stack. The prior `depth >= MAX_DEPENDENCY_DEPTH` fixed cap
-        // conflated this with graph validity: because the sentinel was not memoized,
-        // a node reachable both within and beyond 10 hops resolved to LockedOut or
-        // Nominal depending on which path the DFS reached it by FIRST — so the whole
-        // fleet's posture depended on dependency *insertion order* rather than the
-        // graph's trust state. Bounding by the id-universe count removes that flip
-        // entirely, including for chains of unregistered dependency ids (B8).
-        if depth >= max_depth {
-            return Arc::new(FleetNodePosture {
-                node_id: Arc::from(node_id),
-                local_status: NodeTrustState::Unknown,
-                propagated_status: FleetPosture::LockedOut,
-                blocked_by: vec![Arc::from("MAX_DEPTH_EXCEEDED")],
-            });
-        }
-
-        // Mint the interned id ONCE for this node; every subsequent use (gray
-        // set, the result's `node_id`, the `black` key, and each parent's
-        // `blocked_by`) is an `Arc::clone` refcount bump, not a new allocation.
-        let id: Arc<str> = Arc::from(node_id);
-        gray.insert(Arc::clone(&id));
-
-        let local_status = self
-            .nodes
-            .get(node_id)
-            .map(|n| n.status.clone())
-            .unwrap_or(NodeTrustState::Unknown);
-
-        let deps = self
-            .dependency_graph
-            .get(node_id)
-            .map(|d| d.value().clone())
-            .unwrap_or_default();
-
-        let mut blocked_by: Vec<Arc<str>> = Vec::new();
-        let mut has_locked_out_dep = false;
-
-        for dep_id in &deps {
-            let dep_posture = self.recursive_calculate(dep_id, gray, black, depth + 1, max_depth);
-            match &dep_posture.propagated_status {
-                FleetPosture::LockedOut => {
-                    // Share the dep's interned id rather than re-allocating it.
-                    blocked_by.push(Arc::clone(&dep_posture.node_id));
-                    has_locked_out_dep = true;
-                }
-                FleetPosture::Degraded => {
-                    blocked_by.push(Arc::clone(&dep_posture.node_id));
-                }
-                FleetPosture::Nominal => {}
-            }
-        }
-
-        let propagated_status = match &local_status {
-            NodeTrustState::Untrusted(_) => FleetPosture::LockedOut,
-            _ if has_locked_out_dep => FleetPosture::LockedOut,
-            _ if !blocked_by.is_empty() => FleetPosture::Degraded,
-            NodeTrustState::Unknown => FleetPosture::Degraded,
-            NodeTrustState::Trusted => FleetPosture::Nominal,
-        };
-
-        let posture = Arc::new(FleetNodePosture {
-            node_id: Arc::clone(&id),
-            local_status,
-            propagated_status,
-            blocked_by,
-        });
-
-        gray.remove(node_id);
-        black.insert(id, Arc::clone(&posture));
-
-        posture
-    }
-
     /// Consume a challenge nonce. Returns false if nonce is absent, expired, or mismatched.
     pub fn consume_challenge(&self, node_id: &str, nonce: u64, now_ms: u64) -> bool {
         let entry = match self.pending_challenges.remove(node_id) {


### PR DESCRIPTION
## Summary

Lifts the fleet-posture dependency-DAG traversal — **INVARIANT #4, the gray/black two-set DFS** — **verbatim** out of `AppState` into a reviewable `dag` module in the safety-authority crate. This is the safety-critical core the Stage-3 target names, and the algorithm the Kani mirror + `shared_memo_equivalence_tests` pin. It's the highest-risk slice of Stage 3, so it's isolated behind the full regression net.

## Why this is lower-risk than the Plan's 3d

`recursive_calculate` was **already pure** with respect to `AppState`: it reads only `nodes` + `dependency_graph`. So the traversal moves as **free functions** taking those two `DashMap`s by reference, and `AppState` keeps `calculate_posture` / `calculate_posture_memoized` / `calculate_fleet_posture` as **thin delegators** — every `app.calculate_*` caller is unchanged, **zero call-site rewrite**. The **fields stay on `AppState`**; only the ALGORITHM moves. This deliberately defers the field migration, decoupling the slice from the `store` / INVARIANT-#12 work (that's 3e).

## What changed

- **New `kirra_safety_authority::dag`**: `recursive_calculate` (self-recursive) + `calculate_posture{,_memoized}` + `calculate_fleet_posture` + `MAX_DEPENDENCY_DEPTH` — **byte-identical** to the prior `AppState` code (comments and interning discipline preserved). Crate gains a `dashmap` dependency (already in the workspace tree; the detached lockfiles are refreshed for the new edge only — no package added).
- **`AppState` methods delegate** to `dag::*`; `MAX_DEPENDENCY_DEPTH` is re-exported so `crate::verifier::MAX_DEPENDENCY_DEPTH` resolves unchanged. Dropped the now-unused `HashSet` import.
- **CLAUDE.md** INVARIANT #4 + the Gray/Black algorithm note repointed to the new home.

## INVARIANT #4 preservation

The real traversal is never mocked, byte-identical, and **proven equivalent**: `shared_memo_equivalence_tests` (fleet-matches-per-node, cycle memo-equivalence, diamond-dag, deep-unregistered-chain) + the cycle→LockedOut-tag, diamond-not-cycle, deep-acyclic, and supervisor-forces-lockout tests all pass through the delegators.

## Verification (local)

- **Root lib tests 580 / 0** (all DAG equivalence + behaviour tests).
- New crate **21/21** + clippy; **`cargo test --no-run` compiles the entire test tree** (incl. `tests/`); detached lockfiles edge-only; `cargo fmt --check`, orphan-core, and quality guardrails all green.

Scoped to the traversal relocation + delegators + docs + the four lockfiles. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_