### PR TITLE
ADR-0035 Stage 3h — group the transport-enforcement configs as app.transport

### DIFF
--- a/src/bin/kirra_verifier_service/auth.rs
+++ b/src/bin/kirra_verifier_service/auth.rs
@@ -336,7 +336,7 @@ pub(crate) async fn require_client_identity(
     request: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
-    let cfg = &svc.app.transport_identity;
+    let cfg = &svc.app.transport.identity;
     if !validate_client_identity_headers(
         cfg.trusted_ingress_mode,
         &cfg.client_id_header,
@@ -358,7 +358,7 @@ pub(crate) async fn require_secure_transport(
     request: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
-    let cfg = &svc.app.transport_security;
+    let cfg = &svc.app.transport.security;
     if !request_transport_is_secure(
         cfg.require_secure_transport,
         &cfg.forwarded_proto_header,
@@ -426,7 +426,7 @@ mod g7_transport_security_router_tests {
     fn state_requiring_secure_transport(require: bool) -> Arc<ServiceState> {
         let store = VerifierStore::new(":memory:").expect("in-memory store");
         let mut app = AppState::new(store, VerifierOperationMode::Active);
-        app.transport_security = TransportSecurityConfig {
+        app.transport.security = TransportSecurityConfig {
             require_secure_transport: require,
             forwarded_proto_header: "x-forwarded-proto".to_string(),
         };

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -229,6 +229,33 @@ pub fn request_transport_is_secure(
     }
 }
 
+/// ADR-0035 Stage 3 (slice 3h) — the two transport-layer enforcement configs
+/// grouped into one `AppState` field façade (`app.transport`), the same shape as
+/// the earlier slices. Both are read from env at startup and consulted by the
+/// request middleware (`identity` gates the `x-kirra-client-id` header; `security`
+/// fail-closes a request not asserted to have arrived over TLS). A root-crate
+/// config grouping (not a safety-decision surface). Per-field semantics UNCHANGED.
+#[derive(Debug, Clone)]
+pub struct TransportConfig {
+    /// Transport identity enforcement config — reads from env at startup.
+    pub identity: TransportIdentityConfig,
+    /// Transport SECURITY (TLS-required) enforcement config (#G7) — reads from env
+    /// at startup. When enabled, the `require_secure_transport` middleware
+    /// fail-closes a request not asserted to have arrived over TLS.
+    pub security: TransportSecurityConfig,
+}
+
+impl TransportConfig {
+    /// Read both transport configs from env — byte-identical to the prior two
+    /// inline `*::from_env()` calls in `AppState::new`.
+    pub fn from_env() -> Self {
+        Self {
+            identity: TransportIdentityConfig::from_env(),
+            security: TransportSecurityConfig::from_env(),
+        }
+    }
+}
+
 // ADR-0035 Stage 3 (slice 3a): `RssRecoveryStreak` moved to
 // `kirra-safety-authority`; re-exported so `crate::verifier::RssRecoveryStreak`
 // (the `AppState.escalation.rss_recovery_streak` field type) resolves unchanged.
@@ -268,12 +295,11 @@ pub struct AppState {
     pub writers: crate::writer_handles::WriterHandles,
     /// Bounded broadcast channel for real-time posture stream subscribers.
     pub posture_tx: broadcast::Sender<PostureStreamEvent>,
-    /// Transport identity enforcement config — reads from env at startup.
-    pub transport_identity: TransportIdentityConfig,
-    /// Transport SECURITY (TLS-required) enforcement config (#G7) — reads from env
-    /// at startup. When enabled, the `require_secure_transport` middleware
-    /// fail-closes a request not asserted to have arrived over TLS.
-    pub transport_security: TransportSecurityConfig,
+    /// ADR-0035 Stage 3 (slice 3h): the two transport-layer enforcement configs
+    /// (`identity` + `security`) grouped onto `TransportConfig`. Reached as
+    /// `app.transport.identity` / `app.transport.security`; per-field semantics
+    /// UNCHANGED (documented on the struct). A root-crate config grouping.
+    pub transport: TransportConfig,
     /// ADR-0035 Stage 3 (slice 3c): the fleet-escalation / hysteresis state —
     /// the RSS / flood / supervisor-trip / frame-integrity (S-FI1d) / governor-
     /// divergence (S-DG1) flags + their recovery/untrusted streaks, plus the H-3
@@ -346,8 +372,9 @@ impl AppState {
             // (both writers uninstalled, capture sequence at 0).
             writers: crate::writer_handles::WriterHandles::new(),
             posture_tx,
-            transport_identity: TransportIdentityConfig::from_env(),
-            transport_security: TransportSecurityConfig::from_env(),
+            // ADR-0035 Stage 3h: the two transport configs now live on
+            // TransportConfig; identical initial state (both read from env).
+            transport: TransportConfig::from_env(),
             // ADR-0035 Stage 3c: the escalation/hysteresis flags + streaks (incl.
             // av_registry_dirty) now live on EscalationState; identical initial state.
             escalation: kirra_safety_authority::EscalationState::new(),


### PR DESCRIPTION
## Summary

The final `AppState` field-façade slice of ADR-0035 Stage 3: group the two transport-layer enforcement configs into one field.

```
transport_identity: TransportIdentityConfig  ┐
transport_security: TransportSecurityConfig  ┘ → transport: TransportConfig { identity, security }
```

`TransportConfig` (+ `from_env()`) wraps the two existing config structs — both are read from env at startup and consulted by the request middleware (`identity` gates the `x-kirra-client-id` header; `security` fail-closes a request not asserted to have arrived over TLS). It's defined in `verifier.rs` beside the two structs it groups — a root-crate config grouping, not a safety-decision surface (so not `kirra-safety-authority`, consistent with the 3g decision).

## Why it is byte-identical

- The two config structs are unchanged; `TransportConfig::from_env()` calls them in the same order.
- The 3 call-sites become `app.transport.identity` / `app.transport.security` (two reads in `auth.rs` + one test-side mutation in the g7 router tests). No behaviour change.
- No new dependency edge (root-internal grouping).

## Bookkeeping

- `verifier.rs` nets **+27 lines** (the wrapper struct + impl live in-file) but the `AppState` field list drops 2→1; ceiling 1441 unchanged (1141→1168). No baseline edit.
- No detached-lockfile churn (no new dep edge). Traceability matrix unchanged (the config carries no `SAFETY:` tag).

## This concludes ADR-0035 Stage 3

The `AppState` god-object is decomposed into a thin owner of what genuinely can't move — the durable `store` (persistence, deferred to a later DB-actor phase), the volatile nonce maps + rate limiter (INVARIANT #5), the node/edge maps (INVARIANT #12), the heavy `fleet_metrics` / `deadline_registry` structs — plus grouped sub-structs: `escalation` / `ha_fence` (safety-authority crate, 3c/3f), `off_path_writes` (3e), `writers` (3g), and now `transport` (3h). The safety-decision surfaces (posture fold, DAG traversal, attestation, `LockoutReason`) live in the reviewable, Kani/loom-amenable `kirra-safety-authority` crate.

## Verification

- root `cargo build`; `cargo test --lib` — **579/0** (incl. `transport_identity_tests` + `transport_security_tests`)
- `cargo test --no-run` — all integration tests compile
- bin tests — **129/0** (incl. `g7_transport_security_router_tests`, which exercises the `app.transport.security` mutation site)
- `cargo clippy --workspace --all-targets` clean; `cargo fmt --all --check` clean; quality guardrails satisfied; no detached-lockfile churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_