### PR TITLE
R2 firmware: fail-closed fixes (bridge polarity, image verdict default, brownout/watchdog) for #946

### DIFF
--- a/firmware/rosmaster-r2/bootloader/include/r2/boot/image_verifier.hpp
+++ b/firmware/rosmaster-r2/bootloader/include/r2/boot/image_verifier.hpp
@@ -14,7 +14,17 @@ struct ImageManifest {
     std::uint8_t signature_ed25519[64];
 };
 
+// NOTE: software integrity + version rollback checks only. On the STM32F103 the
+// verifier key and bootloader live in mutable flash with no hardware root of
+// trust, so this is NOT hardware-backed secure boot / tamper-resistant rollback
+// (see PR scope note). A reviewed crypto backend + a provisioned RoT remain
+// explicit phase gates.
 enum class VerificationResult : std::uint8_t {
+    // Fail-closed: `rejected` is value 0 so a default-constructed / zeroed /
+    // memset verdict reads as a rejection, never as `accepted`. Every `verify`
+    // implementation MUST return an explicit non-`rejected` value only on a
+    // fully-passed check.
+    rejected = 0,
     accepted,
     malformed_manifest,
     wrong_product,
@@ -24,6 +34,10 @@ enum class VerificationResult : std::uint8_t {
     invalid_signature,
     rollback_attempt,
 };
+
+// The zero/default verdict must be the reject state (fail-closed default).
+static_assert(static_cast<std::uint8_t>(VerificationResult::rejected) == 0U,
+              "a default/zero-initialized image verdict must fail closed (reject)");
 
 class ImageReader {
 public:

--- a/firmware/rosmaster-r2/safety/include/r2/safety/safety_manager.hpp
+++ b/firmware/rosmaster-r2/safety/include/r2/safety/safety_manager.hpp
@@ -46,6 +46,12 @@ struct SafetyInputs {
     bool motor_runaway;
     bool control_deadline_met;
     bool communication_healthy;
+    // Power-supply rails within the brownout threshold (true = stable). A false
+    // raises Fault::brownout — the "fail-closed on brownout" safety guarantee.
+    bool supply_stable;
+    // Watchdog serviced within its window (true = healthy). A false raises
+    // Fault::watchdog_precursor — the "fail-closed on watchdog" safety guarantee.
+    bool watchdog_healthy;
     bool motion_stopped;
 };
 

--- a/firmware/rosmaster-r2/safety/src/safety_manager.cpp
+++ b/firmware/rosmaster-r2/safety/src/safety_manager.cpp
@@ -77,6 +77,12 @@ void SafetyManager::evaluate(const SafetyInputs& inputs) noexcept {
     if (!inputs.battery_voltage_safe) {
         raise(Fault::battery_undervoltage, false);
     }
+    if (!inputs.supply_stable) {
+        raise(Fault::brownout, true);
+    }
+    if (!inputs.watchdog_healthy) {
+        raise(Fault::watchdog_precursor, true);
+    }
     if (!inputs.battery_current_safe) {
         raise(Fault::battery_overcurrent, true);
     }
@@ -151,19 +157,29 @@ bool SafetyManager::controlled_stop_required() const noexcept {
 bool SafetyManager::bridge_must_be_disabled() const noexcept {
     constexpr auto immediate_disable_faults =
         bit(Fault::emergency_stop) |
+        bit(Fault::brownout) |
         bit(Fault::battery_overcurrent) |
         bit(Fault::motor_overtemperature) |
         bit(Fault::control_deadline_missed) |
         bit(Fault::encoder_implausible) |
         bit(Fault::motor_runaway) |
         bit(Fault::steering_implausible) |
+        bit(Fault::watchdog_precursor) |
         bit(Fault::self_test_failed);
-    return state_ == SafetyState::boot ||
-           state_ == SafetyState::self_test ||
-           state_ == SafetyState::standby ||
-           state_ == SafetyState::fault_latched ||
-           state_ == SafetyState::firmware_update ||
-           ((active_faults_ | latched_faults_) & immediate_disable_faults) != 0U;
+    // Fail-closed / default-deny: enumerate the states in which the H-bridge MAY
+    // be enabled (armed pre-charge, active drive, controlled-stop deceleration),
+    // and require a clean immediate-disable set. An unknown / corrupt `state_`
+    // value therefore DISABLES the bridge. The prior form allow-listed the *safe*
+    // states, so any unlisted state_ left the bridge enabled by default (a
+    // fail-OPEN default on a bit-flip / out-of-range value). This is behaviour-
+    // identical for every valid state.
+    const bool bridge_permitted_state =
+        state_ == SafetyState::armed ||
+        state_ == SafetyState::active ||
+        state_ == SafetyState::controlled_stop;
+    const bool immediate_disable =
+        ((active_faults_ | latched_faults_) & immediate_disable_faults) != 0U;
+    return !bridge_permitted_state || immediate_disable;
 }
 
 void SafetyManager::raise(const Fault fault, const bool latch) noexcept {

--- a/firmware/rosmaster-r2/tests/test_main.cpp
+++ b/firmware/rosmaster-r2/tests/test_main.cpp
@@ -1,4 +1,5 @@
 #include "r2/application/configuration.hpp"
+#include "r2/boot/image_verifier.hpp"
 #include "r2/control/motion_controller.hpp"
 #include "r2/diagnostics/metrics.hpp"
 #include "r2/kinematics/ackermann.hpp"
@@ -278,7 +279,7 @@ void test_safety() {
     CHECK(manager.motion_permitted());
 
     const r2::safety::SafetyInputs healthy{
-        false, true, true, true, true, true, true, true, false, true, true, false};
+        false, true, true, true, true, true, true, true, false, true, true, true, true, false};
     manager.evaluate(healthy);
     CHECK(manager.motion_permitted());
 
@@ -306,6 +307,30 @@ void test_safety() {
     manager.evaluate(healthy);
     CHECK(manager.clear_recoverable_faults(true));
     CHECK(manager.state() == r2::safety::SafetyState::standby);
+
+    // H3: brownout is wired and fails closed (latched + bridge disabled).
+    r2::safety::SafetyManager brownout_mgr{};
+    brownout_mgr.begin_self_test();
+    brownout_mgr.complete_self_test(true);
+    CHECK(brownout_mgr.arm());
+    CHECK(brownout_mgr.activate());
+    auto brownout = healthy;
+    brownout.supply_stable = false;
+    brownout_mgr.evaluate(brownout);
+    CHECK(brownout_mgr.state() == r2::safety::SafetyState::fault_latched);
+    CHECK(brownout_mgr.bridge_must_be_disabled());
+
+    // H3: watchdog precursor is wired and fails closed (latched + bridge disabled).
+    r2::safety::SafetyManager watchdog_mgr{};
+    watchdog_mgr.begin_self_test();
+    watchdog_mgr.complete_self_test(true);
+    CHECK(watchdog_mgr.arm());
+    CHECK(watchdog_mgr.activate());
+    auto watchdog = healthy;
+    watchdog.watchdog_healthy = false;
+    watchdog_mgr.evaluate(watchdog);
+    CHECK(watchdog_mgr.state() == r2::safety::SafetyState::fault_latched);
+    CHECK(watchdog_mgr.bridge_must_be_disabled());
 
     r2::safety::SafetyManager illegal{};
     CHECK(!illegal.disarm());
@@ -390,6 +415,17 @@ void test_diagnostics() {
     CHECK(histogram.maximum_us() == 11U);
 }
 
+void test_image_verifier_failclosed() {
+    // H4: a default-constructed / zero-initialized image verdict MUST read as a
+    // rejection, never as `accepted`. (The static_assert in the header enforces
+    // this at compile time; this keeps the header in a compiled TU so the guard
+    // stays live, and documents the contract for a future verify() backend.)
+    const r2::boot::VerificationResult defaulted{};
+    CHECK(defaulted == r2::boot::VerificationResult::rejected);
+    CHECK(defaulted != r2::boot::VerificationResult::accepted);
+    CHECK(static_cast<std::uint8_t>(r2::boot::VerificationResult::rejected) == 0U);
+}
+
 }  // namespace
 
 int main() {
@@ -400,6 +436,7 @@ int main() {
     test_safety();
     test_configuration_rollback();
     test_diagnostics();
+    test_image_verifier_failclosed();
     if (failures != 0) {
         std::fprintf(stderr, "%d test assertion(s) failed\n", failures);
         return 1;

--- a/firmware/rosmaster-r2/tests/test_main.cpp
+++ b/firmware/rosmaster-r2/tests/test_main.cpp
@@ -278,8 +278,25 @@ void test_safety() {
     CHECK(manager.activate());
     CHECK(manager.motion_permitted());
 
-    const r2::safety::SafetyInputs healthy{
-        false, true, true, true, true, true, true, true, false, true, true, true, true, false};
+    // Named field assignment (not a positional aggregate list): value-init zeroes
+    // every field to the fault-asserting `false`, then only the healthy signals are
+    // set true by name. Resilient to future SafetyInputs field add/reorder — a new
+    // field defaults to the safe value instead of silently shifting the columns.
+    const r2::safety::SafetyInputs healthy = [] {
+        r2::safety::SafetyInputs in{};
+        in.command_fresh = true;
+        in.battery_voltage_safe = true;
+        in.battery_current_safe = true;
+        in.thermal_safe = true;
+        in.encoder_plausible = true;
+        in.steering_plausible = true;
+        in.imu_sane = true;
+        in.control_deadline_met = true;
+        in.communication_healthy = true;
+        in.supply_stable = true;
+        in.watchdog_healthy = true;
+        return in;
+    }();
     manager.evaluate(healthy);
     CHECK(manager.motion_permitted());
 


### PR DESCRIPTION
Targets **#946's branch** (`cursor/rosmaster-r2-firmware-d1a8`), so merging this lands the three fail-closed fixes onto PR #946. These address the HIGH review findings that are merge-blockers for a safety repo — each makes a *declared* fail-closed guarantee actually hold in code.

## Fixes

**H1 — `bridge_must_be_disabled()` default-deny.** The predicate allow-listed the *safe* states, so any unlisted/corrupt `state_` (a `uint8_t` — a bit-flip / out-of-range value) left the H-bridge **enabled by default** (fail-open, opposite polarity to the deny-by-default `motion_permitted()`). Reworked to enumerate the states where the bridge *may* be enabled (`armed`/`active`/`controlled_stop`) with a clean immediate-disable set, so an unknown state disables the bridge. **Behaviour-identical for every valid state.**

**H4 — `VerificationResult` fail-closed default.** `accepted` was value `0`, so a default-constructed / zeroed / `memset` verdict read as accepted, accepting an unauthenticated image on any stubbed or forgotten-assignment path. Added `rejected = 0` (accepted is now non-zero) + a header `static_assert`, plus a comment stating this seam is software-integrity only, not hardware-backed secure boot on the F103. The enum has no consumers yet, so the reorder is safe; a new test keeps the header in a compiled TU so the guard stays live.

**H3 — brownout / watchdog wired.** `Fault::brownout` and `Fault::watchdog_precursor` were declared but never raised (`SafetyInputs` had no fields), so the "fail-closed on brownout/watchdog" claim was unbacked in this layer. Added `supply_stable` / `watchdog_healthy` inputs + `evaluate()` branches raising the two faults **latched**, and added both to the bridge immediate-disable mask.

## Verification (host)

- `cmake` build + `ctest` pass — incl. new tests: brownout & watchdog-precursor each drive `active → fault_latched` with the bridge disabled, and a default `VerificationResult` asserts as `rejected`.
- ASAN/UBSAN build + `ctest` pass.
- `clang-tidy-18` (the CI-pinned version) clean on the changed files.

## Not addressed here (deferred, per the review)

Phase-2+ items remain phase-gated and out of scope for these merge-blocker fixes: decoder fuzzer, halting UBSAN in CI, latch/hysteresis on the remaining non-latched faults, the `!calibrated` validation gap, a MAC over `firmware_*`/control frames, and the still-dead `Fault::configuration_invalid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_