### PR TITLE
safety(r2): document + debounce-escalate the momentary faults (#953)

### DIFF
--- a/firmware/rosmaster-r2/docs/SAFETY_AND_PRODUCTION.md
+++ b/firmware/rosmaster-r2/docs/SAFETY_AND_PRODUCTION.md
@@ -55,6 +55,27 @@ already debounce/hysteresis-filtered monitor verdicts; their monitor services
 own the documented healthy streaks. A single raw healthy sample is not passed
 as recovery.
 
+### Momentary-fault latch policy
+
+`SafetyManager::evaluate()` raises four faults momentarily (they clear as soon
+as their input recovers) rather than latching on the first sample; this section
+records why, and the consecutive-tick escalation that backstops three of them
+(`SafetyManager::raise_persistent`, `kPersistentFaultLatchThreshold`).
+
+| Fault | On the boundary going bad | Sustained (≥ `kPersistentFaultLatchThreshold` consecutive ticks) | Rationale |
+|---|---|---|---|
+| `command_timeout` | drives controlled-stop | **stays momentary — never latches** | The vehicle is already halted safely; a link that returns must let motion resume without a physical reset. |
+| `battery_undervoltage` | active, controlled-stop | **escalates to latched** (acknowledgement-clearable) | A single sag under load is normal; a *sustained* undervoltage is a real power fault an operator must clear. |
+| `imu_invalid` | active, controlled-stop | **escalates to latched** (acknowledgement-clearable) | One bad sample is noise; a *sustained* invalid IMU is a real sensor fault. |
+| `communication_corrupt` | active, controlled-stop | **escalates to latched** (acknowledgement-clearable) | A burst of line noise is transient; *sustained* corruption is a real link fault (or an attacker). |
+
+The debounce counter resets on any tick the condition is not active, so only a
+continuously-held fault escalates. The escalated latched faults are *recoverable*
+— cleared by `clear_recoverable_faults(true)` (operator acknowledgement) — unlike
+`self_test_failed` / `configuration_invalid`, which require a reset + POST.
+`kPersistentFaultLatchThreshold` is expressed in `evaluate()` ticks; tune it to
+the control-loop cadence so it represents a meaningful sustained interval.
+
 ## Dual watchdog and deadline supervision
 
 1. A high-priority software supervisor expects independent alive counters from

--- a/firmware/rosmaster-r2/safety/include/r2/safety/safety_manager.hpp
+++ b/firmware/rosmaster-r2/safety/include/r2/safety/safety_manager.hpp
@@ -61,6 +61,16 @@ struct SafetyInputs {
     bool configuration_valid;
 };
 
+// Consecutive-tick debounce for the "sustained = hard fault" momentary faults
+// (battery_undervoltage, imu_invalid, communication_corrupt). A transient (a
+// single voltage sag, a bad IMU sample, a burst of line noise) is momentary and
+// auto-clears; the same condition held for this many CONSECUTIVE evaluate()
+// ticks is not noise but a real fault, and escalates to a latched fault that
+// requires operator acknowledgement. Expressed in control-loop ticks — tune to
+// the deployment's evaluate() cadence so it represents a meaningful sustained
+// interval (e.g. at a 100 Hz control loop this is ~0.5 s).
+inline constexpr std::uint32_t kPersistentFaultLatchThreshold = 50U;
+
 class SafetyManager {
 public:
     void begin_self_test() noexcept;
@@ -81,11 +91,21 @@ public:
 
 private:
     void raise(Fault fault, bool latch) noexcept;
+    // Raises `fault` momentarily while `active`, and escalates it to a latched
+    // fault once it has been continuously active for kPersistentFaultLatchThreshold
+    // ticks. `streak` is the caller-owned consecutive-active counter; it resets
+    // to zero on any tick the condition is not active (so only a *sustained*
+    // fault latches, never an intermittent one).
+    void raise_persistent(Fault fault, bool active, std::uint32_t& streak) noexcept;
     void transition_to_safe_state() noexcept;
 
     SafetyState state_{SafetyState::boot};
     std::uint64_t active_faults_{0U};
     std::uint64_t latched_faults_{0U};
+    // Per-fault consecutive-active tick counters backing raise_persistent().
+    std::uint32_t undervoltage_streak_{0U};
+    std::uint32_t imu_invalid_streak_{0U};
+    std::uint32_t communication_streak_{0U};
 };
 
 [[nodiscard]] constexpr std::uint64_t bit(const Fault fault) noexcept {

--- a/firmware/rosmaster-r2/safety/src/safety_manager.cpp
+++ b/firmware/rosmaster-r2/safety/src/safety_manager.cpp
@@ -70,13 +70,25 @@ void SafetyManager::evaluate(const SafetyInputs& inputs) noexcept {
     if (inputs.emergency_stop_asserted) {
         raise(Fault::emergency_stop, true);
     }
+    // Fault-latch policy (see docs/SAFETY_AND_PRODUCTION.md §"Fault policy" →
+    // "Momentary-fault latch policy"):
+    //
+    // command_timeout — MOMENTARY (never latches). A stale command drives the
+    //   controlled-stop below; the vehicle halts safely. It must auto-recover
+    //   when fresh commands resume — a transient link dropout, with the vehicle
+    //   already stopped, must not demand a physical reset to move again.
     if (!inputs.command_fresh &&
         (state_ == SafetyState::active || state_ == SafetyState::controlled_stop)) {
         raise(Fault::command_timeout, false);
     }
-    if (!inputs.battery_voltage_safe) {
-        raise(Fault::battery_undervoltage, false);
-    }
+    // battery_undervoltage / imu_invalid / communication_corrupt — MOMENTARY
+    //   while transient (a single voltage sag, one bad IMU sample, a burst of
+    //   line noise auto-clears), but ESCALATE to a latched fault after
+    //   kPersistentFaultLatchThreshold consecutive ticks: a *sustained*
+    //   undervoltage / invalid IMU / corrupt link is a hard fault, not noise,
+    //   and must require operator acknowledgement (clear_recoverable_faults).
+    raise_persistent(Fault::battery_undervoltage, !inputs.battery_voltage_safe,
+                     undervoltage_streak_);
     if (!inputs.supply_stable) {
         raise(Fault::brownout, true);
     }
@@ -95,18 +107,15 @@ void SafetyManager::evaluate(const SafetyInputs& inputs) noexcept {
     if (!inputs.steering_plausible) {
         raise(Fault::steering_implausible, true);
     }
-    if (!inputs.imu_sane) {
-        raise(Fault::imu_invalid, false);
-    }
+    raise_persistent(Fault::imu_invalid, !inputs.imu_sane, imu_invalid_streak_);
     if (inputs.motor_runaway) {
         raise(Fault::motor_runaway, true);
     }
     if (!inputs.control_deadline_met) {
         raise(Fault::control_deadline_missed, true);
     }
-    if (!inputs.communication_healthy) {
-        raise(Fault::communication_corrupt, false);
-    }
+    raise_persistent(Fault::communication_corrupt, !inputs.communication_healthy,
+                     communication_streak_);
     if (!inputs.configuration_valid) {
         raise(Fault::configuration_invalid, true);
     }
@@ -188,6 +197,26 @@ bool SafetyManager::bridge_must_be_disabled() const noexcept {
 void SafetyManager::raise(const Fault fault, const bool latch) noexcept {
     active_faults_ |= bit(fault);
     if (latch) {
+        latched_faults_ |= bit(fault);
+    }
+}
+
+void SafetyManager::raise_persistent(const Fault fault,
+                                     const bool active,
+                                     std::uint32_t& streak) noexcept {
+    if (!active) {
+        // Transient: the condition cleared, so the debounce restarts. An already
+        // latched escalation is unaffected (latched_faults_ only clears via
+        // clear_recoverable_faults) — this only governs whether it re-escalates.
+        streak = 0U;
+        return;
+    }
+    raise(fault, false);
+    if (streak < kPersistentFaultLatchThreshold) {
+        ++streak;
+    }
+    if (streak >= kPersistentFaultLatchThreshold) {
+        // Sustained: escalate to a latched (acknowledgement-clearable) fault.
         latched_faults_ |= bit(fault);
     }
 }

--- a/firmware/rosmaster-r2/tests/test_main.cpp
+++ b/firmware/rosmaster-r2/tests/test_main.cpp
@@ -771,6 +771,119 @@ void test_decode_fuzz() {
           r2::protocol::DecodeStatus::ok);
 }
 
+void test_fault_latch_debounce() {
+    // #953: the four momentary faults' latch policy.
+    //   • battery_undervoltage / imu_invalid / communication_corrupt escalate to
+    //     a latched (ack-clearable) fault after kPersistentFaultLatchThreshold
+    //     CONSECUTIVE active ticks — transient noise auto-clears, sustained
+    //     faults latch.
+    //   • command_timeout stays momentary forever (controlled-stop covers it and
+    //     it must auto-recover on fresh commands).
+    const auto make_healthy = []() noexcept {
+        r2::safety::SafetyInputs in{};
+        in.command_fresh = true;
+        in.battery_voltage_safe = true;
+        in.battery_current_safe = true;
+        in.thermal_safe = true;
+        in.encoder_plausible = true;
+        in.steering_plausible = true;
+        in.imu_sane = true;
+        in.control_deadline_met = true;
+        in.communication_healthy = true;
+        in.supply_stable = true;
+        in.watchdog_healthy = true;
+        in.configuration_valid = true;
+        return in;
+    };
+    const std::uint32_t threshold = r2::safety::kPersistentFaultLatchThreshold;
+    const std::uint64_t undervoltage_bit =
+        r2::safety::bit(r2::safety::Fault::battery_undervoltage);
+
+    // battery_undervoltage: a single transient tick is active but NOT latched,
+    // and recovers cleanly; a sustained run escalates to latched.
+    {
+        r2::safety::SafetyManager mgr{};
+        mgr.begin_self_test();
+        mgr.complete_self_test(true);
+        r2::safety::SafetyInputs sag = make_healthy();
+        sag.battery_voltage_safe = false;
+
+        mgr.evaluate(sag);
+        CHECK((mgr.active_faults() & undervoltage_bit) != 0U);
+        CHECK((mgr.latched_faults() & undervoltage_bit) == 0U);
+        mgr.evaluate(make_healthy());  // debounce resets on the healthy tick
+        CHECK(mgr.latched_faults() == 0U);
+
+        for (std::uint32_t i = 0U; i < threshold - 1U; ++i) {
+            mgr.evaluate(sag);
+            CHECK((mgr.latched_faults() & undervoltage_bit) == 0U);  // not yet
+        }
+        mgr.evaluate(sag);  // the threshold-th consecutive tick escalates
+        CHECK((mgr.latched_faults() & undervoltage_bit) != 0U);
+        CHECK(mgr.state() == r2::safety::SafetyState::fault_latched);
+
+        // The latch survives a healthy tick and is acknowledgement-clearable
+        // (a recoverable fault — not reset+POST like self_test/configuration).
+        mgr.evaluate(make_healthy());
+        CHECK((mgr.latched_faults() & undervoltage_bit) != 0U);
+        CHECK(mgr.clear_recoverable_faults(true));
+        CHECK(mgr.state() == r2::safety::SafetyState::standby);
+    }
+
+    // imu_invalid: sustained run latches.
+    {
+        r2::safety::SafetyManager mgr{};
+        mgr.begin_self_test();
+        mgr.complete_self_test(true);
+        r2::safety::SafetyInputs bad = make_healthy();
+        bad.imu_sane = false;
+        for (std::uint32_t i = 0U; i < threshold; ++i) {
+            mgr.evaluate(bad);
+        }
+        CHECK((mgr.latched_faults() & r2::safety::bit(r2::safety::Fault::imu_invalid)) != 0U);
+        CHECK(mgr.state() == r2::safety::SafetyState::fault_latched);
+    }
+
+    // communication_corrupt: sustained run latches.
+    {
+        r2::safety::SafetyManager mgr{};
+        mgr.begin_self_test();
+        mgr.complete_self_test(true);
+        r2::safety::SafetyInputs bad = make_healthy();
+        bad.communication_healthy = false;
+        for (std::uint32_t i = 0U; i < threshold; ++i) {
+            mgr.evaluate(bad);
+        }
+        CHECK((mgr.latched_faults() & r2::safety::bit(r2::safety::Fault::communication_corrupt)) != 0U);
+        CHECK(mgr.state() == r2::safety::SafetyState::fault_latched);
+    }
+
+    // command_timeout: intentionally momentary — never latches, even when the
+    // command stays stale far past the threshold, and auto-recovers on resume.
+    {
+        r2::safety::SafetyManager mgr{};
+        mgr.begin_self_test();
+        mgr.complete_self_test(true);
+        mgr.evaluate(make_healthy());
+        CHECK(mgr.arm());
+        CHECK(mgr.activate());
+        r2::safety::SafetyInputs stale = make_healthy();
+        stale.command_fresh = false;
+        for (std::uint32_t i = 0U; i < threshold + 10U; ++i) {
+            mgr.evaluate(stale);
+            CHECK((mgr.latched_faults() &
+                   r2::safety::bit(r2::safety::Fault::command_timeout)) == 0U);
+        }
+        CHECK(mgr.latched_faults() == 0U);
+        CHECK(mgr.state() == r2::safety::SafetyState::controlled_stop);
+
+        r2::safety::SafetyInputs resumed = make_healthy();
+        resumed.motion_stopped = true;
+        mgr.evaluate(resumed);
+        CHECK(mgr.state() == r2::safety::SafetyState::standby);
+    }
+}
+
 }  // namespace
 
 int main() {
@@ -780,6 +893,7 @@ int main() {
     test_motion_controller_composition();
     test_safety();
     test_safety_configuration_invalid();
+    test_fault_latch_debounce();
     test_configuration_rollback();
     test_diagnostics();
     test_image_verifier_failclosed();


### PR DESCRIPTION
## What

`SafetyManager::evaluate()` raised four faults **non-latching** — `command_timeout`, `battery_undervoltage`, `imu_invalid`, `communication_corrupt` — so a *persistent* one flapped active→clear every tick with no durable record. This documents the policy per fault and adds a consecutive-tick debounce escalation. Closes #953.

## ⚠️ Design decision (please sanity-check)

This changes safety-state-machine behavior, so the call is called out explicitly:

| Fault | Sustained (≥ threshold consecutive ticks) | Why |
|---|---|---|
| `command_timeout` | **stays momentary — never latches** | Controlled-stop already halts the vehicle; a link that returns must let motion resume without a physical reset. |
| `battery_undervoltage` | **escalates to latched** (ack-clearable) | A single sag under load is normal; sustained undervoltage is a real power fault. |
| `imu_invalid` | **escalates to latched** (ack-clearable) | One bad sample is noise; sustained invalid IMU is a real sensor fault. |
| `communication_corrupt` | **escalates to latched** (ack-clearable) | A noise burst is transient; sustained corruption is a real link fault (or an attacker). |

If you'd rather `command_timeout` also escalate, or want a different threshold, say so and I'll adjust — it's a one-line change.

## How

- New `raise_persistent(fault, active, streak)` helper + three per-fault streak counters. The counter resets on any non-active tick, so **only a continuously-held fault escalates**; the escalated form is a **recoverable** latched fault (cleared by `clear_recoverable_faults(true)`), not reset+POST like `self_test_failed`/`configuration_invalid`.
- `kPersistentFaultLatchThreshold = 50` ticks (documented as tunable to the control-loop cadence).
- Policy table added to `docs/SAFETY_AND_PRODUCTION.md` §"Fault policy".
- `test_fault_latch_debounce` covers: transient-stays-momentary + clean recovery; sustained-escalates for all three; latch survives a healthy tick and is ack-clearable; `command_timeout` never latches past threshold and auto-recovers on resume.

## Verification (local)

`cmake -DR2_ENABLE_SANITIZERS=ON` + `ctest` → **100% pass** (ASAN/UBSAN clean); `clang-tidy-18` clean on `safety_manager.cpp`; Doxygen flags checked (`EXTRACT_PRIVATE=NO`, `WARN_IF_UNDOCUMENTED=NO` — additions are private + plain `//` comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_