### PR TITLE
firmware(r2): wire SafetyManager into a portable control loop (#962)

### DIFF
--- a/.github/workflows/rosmaster-r2-firmware.yml
+++ b/.github/workflows/rosmaster-r2-firmware.yml
@@ -41,7 +41,8 @@ jobs:
             firmware/rosmaster-r2/control/src/motion_controller.cpp \
             firmware/rosmaster-r2/protocol/src/wire.cpp \
             firmware/rosmaster-r2/safety/src/safety_manager.cpp \
-            firmware/rosmaster-r2/firmware/src/configuration.cpp; do
+            firmware/rosmaster-r2/firmware/src/configuration.cpp \
+            firmware/rosmaster-r2/firmware/src/control_loop.cpp; do
             clang-tidy-18 -p /tmp/r2-build "$source"
           done
       - name: cppcheck

--- a/firmware/rosmaster-r2/CMakeLists.txt
+++ b/firmware/rosmaster-r2/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(r2_platform_core STATIC
     protocol/src/wire.cpp
     safety/src/safety_manager.cpp
     firmware/src/configuration.cpp
+    firmware/src/control_loop.cpp
 )
 
 target_include_directories(r2_platform_core PUBLIC

--- a/firmware/rosmaster-r2/docs/SAFETY_AND_PRODUCTION.md
+++ b/firmware/rosmaster-r2/docs/SAFETY_AND_PRODUCTION.md
@@ -31,6 +31,49 @@ never holds the last command. E-stop, runaway, overcurrent, overtemperature, enc
 plausibility and missed control deadline disable immediately. Configuration and
 updates require standby and disabled outputs.
 
+## Control-loop orchestration
+
+`r2::application::Application` (`firmware/include/r2/application/control_loop.hpp`)
+wires the abstract HAL seams (`r2/hal/interfaces.hpp`) to the `SafetyManager`,
+the `MotionController` and the authenticated R2CP decoder. It is portable and
+device-agnostic — it holds only references to the pure-virtual peripheral
+interfaces, so the same object runs against real silicon on the target and
+against mock seams in the host tests. One `tick(dt_s)` is the whole per-cycle
+pipeline:
+
+1. Service the independent watchdog.
+2. Drain the transport and run every inbound frame through
+   `decode_authenticated`. A frame that fails the HMAC check is dropped (no
+   positive trust); a structurally corrupt frame also degrades link health.
+   Only surviving frames reach the state machine (`arm`/`activate`/`disarm`) or
+   update the held motion command (`decode_motion_command`).
+3. Sample the sensors and build `SafetyInputs`, including
+   `configuration_valid = valid_configuration(cfg) && cfg.calibrated` and
+   `command_fresh` from the held command's age against the calibrated
+   `command_timeout_ms` (bounded further by the command's `valid_for_us`).
+4. `evaluate(inputs)`.
+5. Actuate, fail-closed: `bridge_must_be_disabled()` hard-cuts the H-bridge and
+   servo before any drive decision; motion is issued only while
+   `motion_permitted()` AND a fresh TRACK command is held; every other reachable
+   state drives the body command to zero so the jerk-limited controller
+   decelerates to rest with the bridge still braking. The steering angle maps to
+   the servo pulse through the calibrated `servo_minimum/center/maximum_us`.
+
+Consequently an uncalibrated or invalid configuration raises
+`configuration_invalid` and immobilizes the platform (arming is refused, the
+bridge stays disabled), and a command reaches an actuator only after passing
+both authentication and the safety gate.
+
+Assumptions of use / deferred hardware seams for this portable slice: the
+transport delivers one COBS-framed datagram per `read()`; `SafetyThresholds`
+(battery/thermal/IMU limits, plausibility factors) are calibration-owned and
+their `default_thresholds()` values are conservative placeholders, not a
+production calibration; and there is not yet a steering-position feedback sensor
+or a dedicated brownout/PVD comparator seam, so `steering_plausible` and
+`supply_stable` report nominal until those seams are wired (`watchdog_healthy`
+is serviced every tick). ACKNOWLEDGE_FAULT is not honored from the network — a
+packet is never physical acknowledgement.
+
 ## Fault policy
 
 | Detection | Reaction | Latch / recovery |

--- a/firmware/rosmaster-r2/firmware/include/r2/application/control_loop.hpp
+++ b/firmware/rosmaster-r2/firmware/include/r2/application/control_loop.hpp
@@ -1,0 +1,184 @@
+#pragma once
+
+// Portable control-loop orchestrator for the ROSMASTER R2 MCU.
+//
+// The Application wires the abstract HAL seams (r2/hal/interfaces.hpp) to the
+// SafetyManager, the MotionController and the authenticated R2CP decoder so
+// that a single tick(dt_s) is the whole per-cycle safety/actuation pipeline.
+// It is device-agnostic: it holds only references to the pure-virtual HAL
+// interfaces, so the same object is driven by real silicon peripherals on the
+// target and by mock seams in the host tests. No allocation, no exceptions.
+//
+// Fail-closed invariants enforced here (see docs/SAFETY_AND_PRODUCTION.md):
+//   * A command reaches the state machine ONLY through decode_authenticated —
+//     an unauthenticated or tampered frame is dropped and never actuates.
+//   * Every actuation is gated on the SafetyManager: bridge_must_be_disabled()
+//     hard-cuts the H-bridge and servo before any drive decision; motion is
+//     issued only while motion_permitted() AND a fresh command is held.
+//   * An uncalibrated / invalid configuration raises configuration_invalid and
+//     immobilizes the platform (arming is refused, the bridge stays disabled).
+
+#include "r2/application/configuration.hpp"
+#include "r2/control/motion_controller.hpp"
+#include "r2/hal/interfaces.hpp"
+#include "r2/kinematics/ackermann.hpp"
+#include "r2/protocol/wire.hpp"
+#include "r2/safety/safety_manager.hpp"
+
+#include <array>
+#include <cstdint>
+
+namespace r2::application {
+
+// MOTION_COMMAND payload mode (docs/PROTOCOL.md §MOTION_COMMAND). STOP and
+// HOLD_ZERO both request zero body velocity; TRACK requests the carried
+// velocity/curvature pair. Any other raw value is rejected by the decoder.
+enum class MotionMode : std::uint8_t {
+    stop = 0U,
+    track = 1U,
+    hold_zero = 2U,
+};
+
+// Decoded MOTION_COMMAND payload. Mirrors the on-wire layout AFTER
+// decode_authenticated() has stripped the trailing authentication tag:
+//   command_id:u32, valid_for_us:u32, velocity_mps:f32, curvature_per_m:f32,
+//   acceleration_limit_mps2:f32, jerk_limit_mps3:f32, mode:u8, reserved[3].
+struct MotionCommand {
+    std::uint32_t command_id{0U};
+    std::uint32_t valid_for_us{0U};
+    float velocity_mps{0.0F};
+    float curvature_per_m{0.0F};
+    float acceleration_limit_mps2{0.0F};
+    float jerk_limit_mps3{0.0F};
+    MotionMode mode{MotionMode::stop};
+};
+
+// Minimum decoded (tag-stripped) MOTION_COMMAND payload length in bytes.
+inline constexpr std::size_t kMotionCommandPayloadBytes = 28U;
+
+// Faithfully decode a verified MOTION_COMMAND frame. Returns false (leaving
+// `out` untouched) for a wrong message type, a short payload, an unknown mode
+// byte, or a non-finite scalar — fail-closed: a frame that cannot be decoded
+// exactly is never turned into motion.
+[[nodiscard]] bool decode_motion_command(const protocol::Frame& frame,
+                                         MotionCommand& out) noexcept;
+
+// Deployment safety thresholds that the SafetyInputs mapping needs but the
+// PlatformConfiguration does not carry. These are calibration-owned; the
+// default_thresholds() values are conservative placeholders and MUST be set
+// per deployment. The *_v / *_a / *_c / *_rad_s fields are compared against the
+// float HAL sample fields directly (kept float to avoid double-promotion); the
+// factor/epsilon/budget fields participate in the double-precision speed math.
+struct SafetyThresholds {
+    float minimum_battery_voltage_v{0.0F};
+    float maximum_battery_current_a{0.0F};
+    float maximum_temperature_c{0.0F};
+    float maximum_angular_rate_rad_s{0.0F};
+    float maximum_linear_acceleration_mps2{0.0F};
+    // Encoder-implied wheel speed above maximum_speed_mps * this factor is
+    // treated as implausible (a sensor/gearing fault).
+    double encoder_plausibility_factor{0.0};
+    // Encoder-implied wheel speed above maximum_speed_mps * this factor is
+    // treated as motor runaway (bridge hard-disable).
+    double runaway_factor{0.0};
+    // |wheel speed| at or below this is "stopped" (lets controlled_stop settle
+    // back to standby).
+    double motion_stopped_epsilon_mps{0.0};
+    // A tick whose dt exceeds this budget missed its control deadline.
+    double maximum_tick_s{0.0};
+};
+
+// Conservative default thresholds. NOT a production calibration — a deployment
+// must override these with values validated against its own hardware.
+[[nodiscard]] SafetyThresholds default_thresholds() noexcept;
+
+// A pair of measured rear-wheel ground speeds derived from the encoder deltas.
+// Bundled so it travels as one value through the tick, rather than as two
+// adjacent doubles that a caller could transpose.
+struct WheelSpeeds {
+    double left_mps{0.0};
+    double right_mps{0.0};
+};
+
+// The HAL seams the control loop drives. Held by reference; every peripheral
+// must outlive the Application (statically allocated on the target).
+struct HalBundle {
+    hal::MonotonicClock& clock;
+    hal::MotorBridge& motors;
+    hal::SteeringActuator& steering;
+    hal::EncoderBank& encoders;
+    hal::ImuDevice& imu;
+    hal::BatteryMonitor& battery;
+    hal::EmergencyStopInput& emergency_stop;
+    hal::IndependentWatchdog& watchdog;
+    hal::Transport& transport;
+};
+
+// Boot-time configuration for the Application. PlatformConfiguration carries the
+// kinematics/envelope; wheel_gains and thresholds are calibration; link_key is
+// the per-link HMAC-SHA-256 key that authenticates every inbound command.
+struct ApplicationConfig {
+    PlatformConfiguration platform{};
+    control::WheelPidGains wheel_gains{};
+    SafetyThresholds thresholds{};
+    std::array<std::uint8_t, protocol::kMacKeySize> link_key{};
+};
+
+class Application {
+public:
+    Application(const HalBundle& hal, const ApplicationConfig& config) noexcept;
+
+    // Run power-on self-test and settle to standby. Must be called once before
+    // ticking. A future slice will drive a real hardware POST here; today it
+    // asserts firmware self-consistency and lets evaluate() gate on the live
+    // configuration/fault inputs.
+    void initialize() noexcept;
+
+    // One control cycle: service the watchdog, drain and authenticate inbound
+    // frames, sample the sensors, evaluate the safety state, and actuate (or
+    // fail-closed disable). dt_s is the elapsed time since the previous tick.
+    void tick(double dt_s) noexcept;
+
+    // Observability accessors (used by the host tests and by a future telemetry
+    // path). None of these mutate the loop.
+    [[nodiscard]] safety::SafetyState safety_state() const noexcept;
+    [[nodiscard]] std::uint64_t active_faults() const noexcept;
+    [[nodiscard]] std::uint64_t latched_faults() const noexcept;
+    [[nodiscard]] bool bridge_disabled() const noexcept;
+    [[nodiscard]] std::int16_t last_left_duty_q15() const noexcept;
+    [[nodiscard]] std::int16_t last_right_duty_q15() const noexcept;
+    [[nodiscard]] std::uint16_t last_steering_pulse_us() const noexcept;
+    [[nodiscard]] bool command_held() const noexcept;
+
+private:
+    void drain_transport(bool& link_corrupt) noexcept;
+    void handle_frame(const protocol::Frame& frame) noexcept;
+    [[nodiscard]] safety::SafetyInputs build_inputs(double dt_s,
+                                                    const WheelSpeeds& speeds,
+                                                    bool link_corrupt) noexcept;
+    void actuate(const WheelSpeeds& speeds, double dt_s) noexcept;
+    void disable_actuators() noexcept;
+    void apply_output(const control::MotionOutput& output) noexcept;
+    [[nodiscard]] double wheel_speed_mps(std::int32_t delta_counts,
+                                         std::uint32_t counts_per_rev,
+                                         double dt_s) const noexcept;
+    [[nodiscard]] std::uint16_t steering_pulse_us(double angle_rad) const noexcept;
+    [[nodiscard]] bool command_fresh() const noexcept;
+
+    HalBundle hal_;
+    PlatformConfiguration platform_;
+    SafetyThresholds thresholds_;
+    std::array<std::uint8_t, protocol::kMacKeySize> link_key_;
+    safety::SafetyManager safety_{};
+    control::MotionController controller_;
+    MotionCommand command_{};
+    bool command_valid_{false};
+    std::uint64_t last_command_us_{0U};
+    std::uint64_t now_us_{0U};
+    std::int16_t last_left_duty_q15_{0};
+    std::int16_t last_right_duty_q15_{0};
+    std::uint16_t last_steering_pulse_us_{0U};
+    bool bridge_disabled_{true};
+};
+
+}  // namespace r2::application

--- a/firmware/rosmaster-r2/firmware/src/control_loop.cpp
+++ b/firmware/rosmaster-r2/firmware/src/control_loop.cpp
@@ -1,0 +1,408 @@
+#include "r2/application/control_loop.hpp"
+
+#include "r2/application/configuration.hpp"
+#include "r2/control/motion_controller.hpp"
+#include "r2/hal/interfaces.hpp"
+#include "r2/kinematics/ackermann.hpp"
+#include "r2/protocol/wire.hpp"
+#include "r2/safety/safety_manager.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace r2::application {
+namespace {
+
+// Freshness bounds for MOTION_COMMAND.valid_for_us (docs/PROTOCOL.md: 20–1000 ms).
+constexpr std::uint32_t kMinValidForUs = 20'000U;
+constexpr std::uint32_t kMaxValidForUs = 1'000'000U;
+
+constexpr double kTwoPi = 6.283185307179586;
+
+[[nodiscard]] std::uint32_t read_u32_le(const std::uint8_t* bytes) noexcept {
+    return static_cast<std::uint32_t>(bytes[0]) |
+           (static_cast<std::uint32_t>(bytes[1]) << 8U) |
+           (static_cast<std::uint32_t>(bytes[2]) << 16U) |
+           (static_cast<std::uint32_t>(bytes[3]) << 24U);
+}
+
+[[nodiscard]] float read_f32_le(const std::uint8_t* bytes) noexcept {
+    const std::uint32_t raw = read_u32_le(bytes);
+    float value = 0.0F;
+    std::memcpy(&value, &raw, sizeof(value));
+    return value;
+}
+
+[[nodiscard]] kinematics::VehicleGeometry geometry_from(
+    const PlatformConfiguration& configuration) noexcept {
+    kinematics::VehicleGeometry geometry{};
+    geometry.wheelbase_m = static_cast<double>(configuration.wheelbase_m);
+    geometry.rear_track_m = static_cast<double>(configuration.rear_track_m);
+    geometry.wheel_radius_m = static_cast<double>(configuration.wheel_radius_m);
+    geometry.maximum_road_wheel_angle_rad =
+        static_cast<double>(configuration.maximum_steering_angle_rad);
+    return geometry;
+}
+
+[[nodiscard]] control::MotionLimits limits_from(
+    const PlatformConfiguration& configuration) noexcept {
+    control::MotionLimits limits{};
+    limits.maximum_speed_mps = static_cast<double>(configuration.maximum_speed_mps);
+    limits.maximum_acceleration_mps2 =
+        static_cast<double>(configuration.maximum_acceleration_mps2);
+    limits.maximum_deceleration_mps2 =
+        static_cast<double>(configuration.maximum_deceleration_mps2);
+    limits.maximum_jerk_mps3 = static_cast<double>(configuration.maximum_jerk_mps3);
+    limits.maximum_steering_rate_rad_s =
+        static_cast<double>(configuration.maximum_steering_rate_rad_s);
+    return limits;
+}
+
+[[nodiscard]] std::int16_t to_duty_q15(const double command) noexcept {
+    const double clamped = std::clamp(command, -1.0, 1.0);
+    const double scaled = std::round(clamped * 32'767.0);
+    return static_cast<std::int16_t>(scaled);
+}
+
+}  // namespace
+
+bool decode_motion_command(const protocol::Frame& frame, MotionCommand& out) noexcept {
+    if (frame.type != protocol::MessageType::motion_command) {
+        return false;
+    }
+    if (frame.payload_length < kMotionCommandPayloadBytes) {
+        return false;
+    }
+    const std::uint8_t* const payload = frame.payload.data();
+    const std::uint8_t raw_mode = payload[24];
+    if (raw_mode > static_cast<std::uint8_t>(MotionMode::hold_zero)) {
+        return false;
+    }
+    MotionCommand decoded{};
+    decoded.command_id = read_u32_le(payload + 0);
+    decoded.valid_for_us = read_u32_le(payload + 4);
+    decoded.velocity_mps = read_f32_le(payload + 8);
+    decoded.curvature_per_m = read_f32_le(payload + 12);
+    decoded.acceleration_limit_mps2 = read_f32_le(payload + 16);
+    decoded.jerk_limit_mps3 = read_f32_le(payload + 20);
+    decoded.mode = static_cast<MotionMode>(raw_mode);
+    if (!std::isfinite(decoded.velocity_mps) ||
+        !std::isfinite(decoded.curvature_per_m) ||
+        !std::isfinite(decoded.acceleration_limit_mps2) ||
+        !std::isfinite(decoded.jerk_limit_mps3)) {
+        return false;
+    }
+    out = decoded;
+    return true;
+}
+
+SafetyThresholds default_thresholds() noexcept {
+    SafetyThresholds thresholds{};
+    thresholds.minimum_battery_voltage_v = 10.0F;
+    thresholds.maximum_battery_current_a = 20.0F;
+    thresholds.maximum_temperature_c = 70.0F;
+    thresholds.maximum_angular_rate_rad_s = 20.0F;
+    thresholds.maximum_linear_acceleration_mps2 = 80.0F;
+    thresholds.encoder_plausibility_factor = 1.5;
+    thresholds.runaway_factor = 2.0;
+    thresholds.motion_stopped_epsilon_mps = 0.02;
+    thresholds.maximum_tick_s = 0.02;
+    return thresholds;
+}
+
+Application::Application(const HalBundle& hal, const ApplicationConfig& config) noexcept
+    : hal_(hal),
+      platform_(config.platform),
+      thresholds_(config.thresholds),
+      link_key_(config.link_key),
+      controller_(geometry_from(config.platform),
+                  limits_from(config.platform),
+                  config.wheel_gains) {}
+
+void Application::initialize() noexcept {
+    safety_.begin_self_test();
+    // Firmware self-consistency POST. The live configuration and sensor inputs
+    // are gated on each tick by evaluate(); an invalid/uncalibrated record
+    // raises configuration_invalid there and blocks arming.
+    safety_.complete_self_test(true);
+}
+
+void Application::tick(const double dt_s) noexcept {
+    hal_.watchdog.service();
+    now_us_ = hal_.clock.now_us();
+
+    bool link_corrupt = false;
+    drain_transport(link_corrupt);
+
+    const hal::EncoderSnapshot encoders = hal_.encoders.snapshot();
+    WheelSpeeds speeds{};
+    speeds.left_mps = wheel_speed_mps(
+        encoders.left_delta, platform_.left_encoder_counts_per_revolution, dt_s);
+    speeds.right_mps = wheel_speed_mps(
+        encoders.right_delta, platform_.right_encoder_counts_per_revolution, dt_s);
+
+    const safety::SafetyInputs inputs = build_inputs(dt_s, speeds, link_corrupt);
+    safety_.evaluate(inputs);
+
+    actuate(speeds, dt_s);
+}
+
+void Application::drain_transport(bool& link_corrupt) noexcept {
+    // Bound the per-tick work: at most kMaxFramesPerTick frames are processed so
+    // a flood cannot stall the control cycle. The transport delivers at most one
+    // COBS-framed datagram per read() (AOU: the link layer is frame-delimited).
+    constexpr std::size_t kMaxFramesPerTick = 16U;
+    std::array<std::uint8_t, protocol::kMaximumEncodedFrame> buffer{};
+    for (std::size_t frame_index = 0U; frame_index < kMaxFramesPerTick; ++frame_index) {
+        const std::size_t length = hal_.transport.read(buffer.data(), buffer.size());
+        if (length == 0U) {
+            return;
+        }
+        protocol::Frame frame{};
+        const protocol::DecodeStatus status = protocol::decode_authenticated(
+            buffer.data(), length, link_key_, frame);
+        if (status != protocol::DecodeStatus::ok) {
+            // A structurally corrupt frame degrades link health; an
+            // authentication failure is simply dropped (fail-closed, no trust).
+            if (status == protocol::DecodeStatus::crc_mismatch ||
+                status == protocol::DecodeStatus::malformed_cobs ||
+                status == protocol::DecodeStatus::bad_magic ||
+                status == protocol::DecodeStatus::unsupported_version) {
+                link_corrupt = true;
+            }
+            continue;
+        }
+        handle_frame(frame);
+    }
+}
+
+void Application::handle_frame(const protocol::Frame& frame) noexcept {
+    switch (frame.type) {
+        case protocol::MessageType::motion_command: {
+            MotionCommand decoded{};
+            if (decode_motion_command(frame, decoded)) {
+                command_ = decoded;
+                command_valid_ = true;
+                last_command_us_ = now_us_;
+            }
+            break;
+        }
+        case protocol::MessageType::arm:
+            (void)safety_.arm();
+            break;
+        case protocol::MessageType::activate:
+            (void)safety_.activate();
+            break;
+        case protocol::MessageType::disarm:
+            (void)safety_.disarm();
+            break;
+        // ACKNOWLEDGE_FAULT is intentionally NOT honored here: a network packet
+        // is never physical acknowledgement (docs/PROTOCOL.md). Clearing a
+        // latched fault additionally requires a separately-wired local
+        // acknowledgement input, which this portable slice does not model.
+        case protocol::MessageType::acknowledge_fault:
+        default:
+            break;
+    }
+}
+
+safety::SafetyInputs Application::build_inputs(const double dt_s,
+                                              const WheelSpeeds& speeds,
+                                              const bool link_corrupt) noexcept {
+    const double left_mps = speeds.left_mps;
+    const double right_mps = speeds.right_mps;
+    const hal::BatterySample battery = hal_.battery.sample();
+    const hal::ImuSample imu = hal_.imu.sample();
+
+    const bool battery_voltage_safe =
+        battery.voltage_valid && std::isfinite(battery.voltage_v) &&
+        battery.voltage_v >= thresholds_.minimum_battery_voltage_v;
+    // An absent current channel cannot indict the battery (the SBC only reports
+    // current where the hardware proves that channel).
+    const bool battery_current_safe =
+        !battery.current_valid ||
+        (std::isfinite(battery.current_a) &&
+         std::fabs(battery.current_a) <= thresholds_.maximum_battery_current_a);
+    const bool battery_thermal_safe =
+        !battery.temperature_valid ||
+        (std::isfinite(battery.temperature_c) &&
+         battery.temperature_c <= thresholds_.maximum_temperature_c);
+    const bool imu_thermal_safe =
+        !imu.valid ||
+        (std::isfinite(imu.temperature_c) &&
+         imu.temperature_c <= thresholds_.maximum_temperature_c);
+
+    bool imu_finite = true;
+    bool imu_in_bounds = true;
+    for (std::size_t axis = 0U; axis < 3U; ++axis) {
+        const float rate = imu.angular_velocity_rad_s[axis];
+        const float accel = imu.acceleration_mps2[axis];
+        imu_finite = imu_finite && std::isfinite(rate) && std::isfinite(accel);
+        imu_in_bounds = imu_in_bounds &&
+                        std::fabs(rate) <= thresholds_.maximum_angular_rate_rad_s &&
+                        std::fabs(accel) <= thresholds_.maximum_linear_acceleration_mps2;
+    }
+
+    const double max_speed = static_cast<double>(platform_.maximum_speed_mps);
+    const double plausible_limit = max_speed * thresholds_.encoder_plausibility_factor;
+    const double runaway_limit = max_speed * thresholds_.runaway_factor;
+
+    safety::SafetyInputs inputs{};
+    inputs.emergency_stop_asserted = hal_.emergency_stop.asserted();
+    inputs.command_fresh = command_fresh();
+    inputs.battery_voltage_safe = battery_voltage_safe;
+    inputs.battery_current_safe = battery_current_safe;
+    inputs.thermal_safe = battery_thermal_safe && imu_thermal_safe;
+    inputs.encoder_plausible = std::isfinite(left_mps) && std::isfinite(right_mps) &&
+                               std::fabs(left_mps) <= plausible_limit &&
+                               std::fabs(right_mps) <= plausible_limit;
+    // No steering-position feedback seam exists yet; a real potentiometer/encoder
+    // would populate this. Absent the sensor there is nothing to contradict, so
+    // it reports plausible (the commanded angle is already envelope-bounded).
+    inputs.steering_plausible = true;
+    inputs.imu_sane = imu.valid && imu_finite && imu_in_bounds;
+    inputs.motor_runaway =
+        std::fabs(left_mps) > runaway_limit || std::fabs(right_mps) > runaway_limit;
+    inputs.control_deadline_met = dt_s > 0.0 && dt_s <= thresholds_.maximum_tick_s;
+    inputs.communication_healthy = !link_corrupt;
+    // No dedicated brownout/PVD comparator seam yet; the target must wire the
+    // supply-rail monitor here. Reported stable until that seam exists.
+    inputs.supply_stable = true;
+    // The independent watchdog is serviced at the head of every tick.
+    inputs.watchdog_healthy = true;
+    inputs.motion_stopped =
+        std::fabs(left_mps) <= thresholds_.motion_stopped_epsilon_mps &&
+        std::fabs(right_mps) <= thresholds_.motion_stopped_epsilon_mps;
+    inputs.configuration_valid =
+        valid_configuration(platform_) && platform_.calibrated;
+    return inputs;
+}
+
+void Application::actuate(const WheelSpeeds& speeds, const double dt_s) noexcept {
+    if (safety_.bridge_must_be_disabled()) {
+        disable_actuators();
+        return;
+    }
+
+    kinematics::BodyCommand requested{};
+    requested.longitudinal_velocity_mps = 0.0;
+    requested.yaw_rate_rad_s = 0.0;
+    if (safety_.motion_permitted() && command_fresh() &&
+        command_.mode == MotionMode::track) {
+        const double velocity = static_cast<double>(command_.velocity_mps);
+        const double curvature = static_cast<double>(command_.curvature_per_m);
+        requested.longitudinal_velocity_mps = velocity;
+        requested.yaw_rate_rad_s = velocity * curvature;
+    }
+    // Every other reachable state (armed hold, controlled-stop deceleration,
+    // STOP/HOLD_ZERO, or a stale command) drives the requested body command to
+    // zero so the jerk-limited controller decelerates to rest with the bridge
+    // still braking.
+    const control::MotionOutput output =
+        controller_.update(requested, speeds.left_mps, speeds.right_mps, dt_s);
+    apply_output(output);
+    bridge_disabled_ = false;
+}
+
+void Application::disable_actuators() noexcept {
+    hal_.motors.disable();
+    hal_.steering.disable();
+    controller_.reset();
+    last_left_duty_q15_ = 0;
+    last_right_duty_q15_ = 0;
+    last_steering_pulse_us_ = platform_.servo_center_us;
+    bridge_disabled_ = true;
+}
+
+void Application::apply_output(const control::MotionOutput& output) noexcept {
+    const std::int16_t left_duty = to_duty_q15(output.left_motor_command);
+    const std::int16_t right_duty = to_duty_q15(output.right_motor_command);
+    hal_.motors.set_duty_q15(left_duty, right_duty);
+    const std::uint16_t pulse = steering_pulse_us(output.steering_angle_rad);
+    hal_.steering.set_pulse_us(pulse);
+    last_left_duty_q15_ = left_duty;
+    last_right_duty_q15_ = right_duty;
+    last_steering_pulse_us_ = pulse;
+}
+
+double Application::wheel_speed_mps(const std::int32_t delta_counts,
+                                    const std::uint32_t counts_per_rev,
+                                    const double dt_s) const noexcept {
+    if (counts_per_rev == 0U || dt_s <= 0.0) {
+        return 0.0;
+    }
+    const double revolutions =
+        static_cast<double>(delta_counts) / static_cast<double>(counts_per_rev);
+    const double distance =
+        revolutions * kTwoPi * static_cast<double>(platform_.wheel_radius_m);
+    return distance / dt_s;
+}
+
+std::uint16_t Application::steering_pulse_us(const double angle_rad) const noexcept {
+    const double center = static_cast<double>(platform_.servo_center_us);
+    const double minimum = static_cast<double>(platform_.servo_minimum_us);
+    const double maximum = static_cast<double>(platform_.servo_maximum_us);
+    const double max_angle = static_cast<double>(platform_.maximum_steering_angle_rad);
+    if (!(max_angle > 0.0) || !(minimum <= center && center <= maximum)) {
+        // Degenerate servo calibration: hold the center pulse (fail-safe).
+        return platform_.servo_center_us;
+    }
+    const double bounded = std::clamp(angle_rad, -max_angle, max_angle);
+    const double fraction = bounded / max_angle;
+    const double half_span = fraction >= 0.0 ? (maximum - center) : (center - minimum);
+    const double pulse = std::clamp(center + fraction * half_span, minimum, maximum);
+    return static_cast<std::uint16_t>(std::lround(pulse));
+}
+
+bool Application::command_fresh() const noexcept {
+    if (!command_valid_) {
+        return false;
+    }
+    const std::uint32_t bounded_valid =
+        std::clamp(command_.valid_for_us, kMinValidForUs, kMaxValidForUs);
+    const std::uint64_t configured_budget =
+        static_cast<std::uint64_t>(platform_.command_timeout_ms) * 1'000ULL;
+    const std::uint64_t budget =
+        std::min(configured_budget, static_cast<std::uint64_t>(bounded_valid));
+    const std::uint64_t age =
+        now_us_ >= last_command_us_ ? now_us_ - last_command_us_ : 0ULL;
+    return age <= budget;
+}
+
+safety::SafetyState Application::safety_state() const noexcept {
+    return safety_.state();
+}
+
+std::uint64_t Application::active_faults() const noexcept {
+    return safety_.active_faults();
+}
+
+std::uint64_t Application::latched_faults() const noexcept {
+    return safety_.latched_faults();
+}
+
+bool Application::bridge_disabled() const noexcept {
+    return bridge_disabled_;
+}
+
+std::int16_t Application::last_left_duty_q15() const noexcept {
+    return last_left_duty_q15_;
+}
+
+std::int16_t Application::last_right_duty_q15() const noexcept {
+    return last_right_duty_q15_;
+}
+
+std::uint16_t Application::last_steering_pulse_us() const noexcept {
+    return last_steering_pulse_us_;
+}
+
+bool Application::command_held() const noexcept {
+    return command_valid_;
+}
+
+}  // namespace r2::application

--- a/firmware/rosmaster-r2/tests/test_main.cpp
+++ b/firmware/rosmaster-r2/tests/test_main.cpp
@@ -1,4 +1,5 @@
 #include "r2/application/configuration.hpp"
+#include "r2/application/control_loop.hpp"
 #include "r2/boot/image_verifier.hpp"
 #include "r2/control/motion_controller.hpp"
 #include "r2/diagnostics/metrics.hpp"
@@ -884,6 +885,459 @@ void test_fault_latch_debounce() {
     }
 }
 
+// ── Application control-loop tests (#962) ───────────────────────────────────
+// Mock HAL seams + the real Application/SafetyManager/MotionController wiring,
+// proving the fail-closed gating: authenticated command → actuation, fault →
+// bridge disabled, unauthenticated frame ignored, uncalibrated → immobilize.
+
+namespace app_test {
+
+class TestClock final : public r2::hal::MonotonicClock {
+public:
+    std::uint64_t now_us() const noexcept override { return now_; }
+    void advance(const std::uint64_t delta_us) noexcept { now_ += delta_us; }
+    std::uint64_t now_{1'000'000U};
+};
+
+class TestMotors final : public r2::hal::MotorBridge {
+public:
+    void set_duty_q15(const std::int16_t left, const std::int16_t right) noexcept override {
+        left_ = left;
+        right_ = right;
+        enabled_ = true;
+    }
+    void disable() noexcept override {
+        enabled_ = false;
+        left_ = 0;
+        right_ = 0;
+        ++disable_calls_;
+    }
+    bool output_enabled() const noexcept override { return enabled_; }
+    std::int16_t left_{0};
+    std::int16_t right_{0};
+    bool enabled_{false};
+    std::uint32_t disable_calls_{0U};
+};
+
+class TestSteering final : public r2::hal::SteeringActuator {
+public:
+    void set_pulse_us(const std::uint16_t pulse_us) noexcept override {
+        pulse_us_ = pulse_us;
+        disabled_ = false;
+    }
+    void disable() noexcept override { disabled_ = true; }
+    std::uint16_t pulse_us_{0U};
+    bool disabled_{false};
+};
+
+class TestEncoders final : public r2::hal::EncoderBank {
+public:
+    r2::hal::EncoderSnapshot snapshot() noexcept override { return sample_; }
+    r2::hal::EncoderSnapshot sample_{};
+};
+
+class TestImu final : public r2::hal::ImuDevice {
+public:
+    r2::hal::ImuSample sample() noexcept override { return sample_; }
+    r2::hal::ImuSample sample_{};
+};
+
+class TestBattery final : public r2::hal::BatteryMonitor {
+public:
+    r2::hal::BatterySample sample() noexcept override { return sample_; }
+    r2::hal::BatterySample sample_{};
+};
+
+class TestEstop final : public r2::hal::EmergencyStopInput {
+public:
+    bool asserted() const noexcept override { return asserted_; }
+    bool asserted_{false};
+};
+
+class TestWatchdog final : public r2::hal::IndependentWatchdog {
+public:
+    void service() noexcept override { ++services_; }
+    std::uint32_t services_{0U};
+};
+
+class TestTransport final : public r2::hal::Transport {
+public:
+    void push(const r2::protocol::EncodedFrame& frame) noexcept {
+        if (count_ < queue_.size()) {
+            queue_[count_++] = frame;
+        }
+    }
+    void clear() noexcept {
+        count_ = 0U;
+        read_index_ = 0U;
+    }
+    std::size_t read(std::uint8_t* destination, const std::size_t capacity) noexcept override {
+        if (read_index_ >= count_) {
+            return 0U;
+        }
+        const r2::protocol::EncodedFrame& frame = queue_[read_index_++];
+        if (frame.length == 0U || frame.length > capacity) {
+            return 0U;
+        }
+        std::memcpy(destination, frame.bytes.data(), frame.length);
+        return frame.length;
+    }
+    bool write(const std::uint8_t*, const std::size_t) noexcept override { return true; }
+    std::array<r2::protocol::EncodedFrame, 8> queue_{};
+    std::size_t count_{0U};
+    std::size_t read_index_{0U};
+};
+
+[[nodiscard]] r2::hal::BatterySample healthy_battery() noexcept {
+    r2::hal::BatterySample battery{};
+    battery.voltage_v = 12.0F;
+    battery.current_a = 1.0F;
+    battery.temperature_c = 25.0F;
+    battery.captured_at_us = 0U;
+    battery.voltage_valid = true;
+    battery.current_valid = true;
+    battery.temperature_valid = true;
+    return battery;
+}
+
+[[nodiscard]] r2::hal::ImuSample healthy_imu() noexcept {
+    r2::hal::ImuSample imu{};
+    imu.acceleration_mps2[2] = 9.81F;
+    imu.temperature_c = 25.0F;
+    imu.valid = true;
+    return imu;
+}
+
+[[nodiscard]] r2::application::PlatformConfiguration calibrated_platform() noexcept {
+    r2::application::PlatformConfiguration platform{};
+    platform.schema = r2::application::kConfigurationSchema;
+    platform.calibrated = true;
+    platform.generation = 1U;
+    platform.wheelbase_m = 0.25F;
+    platform.rear_track_m = 0.20F;
+    platform.wheel_radius_m = 0.05F;
+    platform.maximum_steering_angle_rad = 0.5F;
+    platform.maximum_speed_mps = 2.0F;
+    platform.maximum_acceleration_mps2 = 2.0F;
+    platform.maximum_deceleration_mps2 = 3.0F;
+    platform.maximum_jerk_mps3 = 10.0F;
+    platform.maximum_steering_rate_rad_s = 5.0F;
+    platform.battery_divider_ratio = 2.0F;
+    platform.servo_minimum_us = 1'000U;
+    platform.servo_center_us = 1'500U;
+    platform.servo_maximum_us = 2'000U;
+    platform.left_encoder_counts_per_revolution = 1'000U;
+    platform.right_encoder_counts_per_revolution = 1'000U;
+    platform.command_timeout_ms = 100U;
+    return platform;
+}
+
+[[nodiscard]] r2::application::ApplicationConfig make_config(
+    const r2::application::PlatformConfiguration& platform,
+    const std::array<std::uint8_t, r2::protocol::kMacKeySize>& key) noexcept {
+    r2::application::ApplicationConfig config{};
+    config.platform = platform;
+    config.thresholds = r2::application::default_thresholds();
+    config.link_key = key;
+    // Simple proportional + feed-forward wheel gains so a nonzero body command
+    // yields a nonzero duty in the happy-path assertion.
+    const r2::control::PidGains gains{1.0, 0.0, 0.0, 1.0, 0.0};
+    config.wheel_gains.left = gains;
+    config.wheel_gains.right = gains;
+    return config;
+}
+
+void put_u32_le(std::uint8_t* out, const std::uint32_t value) noexcept {
+    for (std::size_t index = 0U; index < 4U; ++index) {
+        out[index] = static_cast<std::uint8_t>(value >> (index * 8U));
+    }
+}
+
+void put_f32_le(std::uint8_t* out, const float value) noexcept {
+    std::uint32_t raw = 0U;
+    std::memcpy(&raw, &value, sizeof(raw));
+    put_u32_le(out, raw);
+}
+
+[[nodiscard]] r2::protocol::EncodedFrame make_motion_frame(
+    const std::array<std::uint8_t, r2::protocol::kMacKeySize>& key,
+    const std::uint32_t sequence,
+    const float velocity,
+    const float curvature,
+    const std::uint8_t mode,
+    const bool authenticate) noexcept {
+    r2::protocol::Frame frame{};
+    frame.type = r2::protocol::MessageType::motion_command;
+    frame.sequence = sequence;
+    frame.source_time_us = 0U;
+    std::array<std::uint8_t, r2::application::kMotionCommandPayloadBytes> payload{};
+    put_u32_le(&payload[0], sequence);       // command_id
+    put_u32_le(&payload[4], 100'000U);       // valid_for_us (100 ms)
+    put_f32_le(&payload[8], velocity);
+    put_f32_le(&payload[12], curvature);
+    put_f32_le(&payload[16], 2.0F);          // acceleration_limit_mps2
+    put_f32_le(&payload[20], 10.0F);         // jerk_limit_mps3
+    payload[24] = mode;
+    frame.payload_length = static_cast<std::uint16_t>(payload.size());
+    std::memcpy(frame.payload.data(), payload.data(), payload.size());
+    r2::protocol::EncodedFrame encoded{};
+    if (authenticate) {
+        (void)r2::protocol::encode_authenticated(frame, key, encoded);
+    } else {
+        (void)r2::protocol::encode(frame, encoded);
+    }
+    return encoded;
+}
+
+[[nodiscard]] r2::protocol::EncodedFrame make_control_frame(
+    const std::array<std::uint8_t, r2::protocol::kMacKeySize>& key,
+    const r2::protocol::MessageType type,
+    const std::uint32_t sequence) noexcept {
+    r2::protocol::Frame frame{};
+    frame.type = type;
+    frame.sequence = sequence;
+    frame.payload_length = 0U;
+    r2::protocol::EncodedFrame encoded{};
+    (void)r2::protocol::encode_authenticated(frame, key, encoded);
+    return encoded;
+}
+
+}  // namespace app_test
+
+void test_control_loop_decode() {
+    using r2::application::decode_motion_command;
+    using r2::application::MotionCommand;
+    using r2::application::MotionMode;
+
+    std::array<std::uint8_t, r2::protocol::kMacKeySize> key{};
+    for (std::size_t i = 0U; i < key.size(); ++i) {
+        key[i] = static_cast<std::uint8_t>(i + 3U);
+    }
+
+    // Well-formed TRACK command decodes with faithful fields.
+    {
+        const r2::protocol::EncodedFrame enc =
+            app_test::make_motion_frame(key, 7U, 1.25F, 0.5F, 1U, true);
+        r2::protocol::Frame frame{};
+        CHECK(r2::protocol::decode_authenticated(enc.bytes.data(), enc.length, key,
+                                                 frame) == r2::protocol::DecodeStatus::ok);
+        MotionCommand command{};
+        CHECK(decode_motion_command(frame, command));
+        CHECK(command.command_id == 7U);
+        CHECK(command.mode == MotionMode::track);
+        CHECK(near(static_cast<double>(command.velocity_mps), 1.25, 1.0e-6));
+        CHECK(near(static_cast<double>(command.curvature_per_m), 0.5, 1.0e-6));
+    }
+
+    // Unknown mode byte is rejected.
+    {
+        const r2::protocol::EncodedFrame enc =
+            app_test::make_motion_frame(key, 8U, 1.0F, 0.0F, 3U, true);
+        r2::protocol::Frame frame{};
+        CHECK(r2::protocol::decode_authenticated(enc.bytes.data(), enc.length, key,
+                                                 frame) == r2::protocol::DecodeStatus::ok);
+        MotionCommand command{};
+        CHECK(!decode_motion_command(frame, command));
+    }
+
+    // Non-finite velocity is rejected.
+    {
+        const r2::protocol::EncodedFrame enc = app_test::make_motion_frame(
+            key, 9U, std::numeric_limits<float>::quiet_NaN(), 0.0F, 1U, true);
+        r2::protocol::Frame frame{};
+        CHECK(r2::protocol::decode_authenticated(enc.bytes.data(), enc.length, key,
+                                                 frame) == r2::protocol::DecodeStatus::ok);
+        MotionCommand command{};
+        CHECK(!decode_motion_command(frame, command));
+    }
+
+    // Wrong message type / short payload rejected.
+    {
+        r2::protocol::Frame frame{};
+        frame.type = r2::protocol::MessageType::arm;
+        frame.payload_length = r2::application::kMotionCommandPayloadBytes;
+        MotionCommand command{};
+        CHECK(!decode_motion_command(frame, command));
+        frame.type = r2::protocol::MessageType::motion_command;
+        frame.payload_length = 4U;
+        CHECK(!decode_motion_command(frame, command));
+    }
+}
+
+void test_control_loop_gating() {
+    std::array<std::uint8_t, r2::protocol::kMacKeySize> key{};
+    for (std::size_t i = 0U; i < key.size(); ++i) {
+        key[i] = static_cast<std::uint8_t>(i + 1U);
+    }
+    constexpr double kDt = 0.01;
+    constexpr std::uint64_t kDtUs = 10'000U;
+
+    // ── Happy path: authenticated arm → activate → motion actuates ──────────
+    {
+        app_test::TestClock clock{};
+        app_test::TestMotors motors{};
+        app_test::TestSteering steering{};
+        app_test::TestEncoders encoders{};
+        app_test::TestImu imu{};
+        app_test::TestBattery battery{};
+        app_test::TestEstop estop{};
+        app_test::TestWatchdog watchdog{};
+        app_test::TestTransport transport{};
+        battery.sample_ = app_test::healthy_battery();
+        imu.sample_ = app_test::healthy_imu();
+
+        const r2::application::HalBundle hal{clock,  motors,  steering, encoders, imu,
+                                             battery, estop,  watchdog, transport};
+        r2::application::Application app{
+            hal, app_test::make_config(app_test::calibrated_platform(), key)};
+        app.initialize();
+        CHECK(app.safety_state() == r2::safety::SafetyState::standby);
+
+        transport.clear();
+        transport.push(app_test::make_control_frame(key, r2::protocol::MessageType::arm, 1U));
+        app.tick(kDt);
+        CHECK(app.safety_state() == r2::safety::SafetyState::armed);
+        CHECK(watchdog.services_ == 1U);
+
+        clock.advance(kDtUs);
+        transport.clear();
+        transport.push(app_test::make_control_frame(key, r2::protocol::MessageType::activate, 2U));
+        transport.push(app_test::make_motion_frame(key, 3U, 1.0F, 0.0F, 1U, true));
+        app.tick(kDt);
+        CHECK(app.safety_state() == r2::safety::SafetyState::active);
+        CHECK(app.command_held());
+        CHECK(!app.bridge_disabled());
+        CHECK(motors.output_enabled());
+        // The jerk-limited controller ramps from rest, so drive is issued over
+        // the next few cycles. The single held command stays fresh (age < the
+        // 100 ms budget) without re-transmission.
+        for (int cycle = 0; cycle < 4; ++cycle) {
+            clock.advance(kDtUs);
+            app.tick(kDt);
+        }
+        CHECK(app.safety_state() == r2::safety::SafetyState::active);
+        CHECK(motors.output_enabled());
+        CHECK(motors.left_ > 0);
+        CHECK(motors.right_ > 0);
+        // Straight-line command → steering holds servo center.
+        CHECK(app.last_steering_pulse_us() == 1'500U);
+    }
+
+    // ── Emergency stop hard-disables the bridge ─────────────────────────────
+    {
+        app_test::TestClock clock{};
+        app_test::TestMotors motors{};
+        app_test::TestSteering steering{};
+        app_test::TestEncoders encoders{};
+        app_test::TestImu imu{};
+        app_test::TestBattery battery{};
+        app_test::TestEstop estop{};
+        app_test::TestWatchdog watchdog{};
+        app_test::TestTransport transport{};
+        battery.sample_ = app_test::healthy_battery();
+        imu.sample_ = app_test::healthy_imu();
+
+        const r2::application::HalBundle hal{clock,  motors,  steering, encoders, imu,
+                                             battery, estop,  watchdog, transport};
+        r2::application::Application app{
+            hal, app_test::make_config(app_test::calibrated_platform(), key)};
+        app.initialize();
+        transport.push(app_test::make_control_frame(key, r2::protocol::MessageType::arm, 1U));
+        app.tick(kDt);
+        CHECK(app.safety_state() == r2::safety::SafetyState::armed);
+
+        clock.advance(kDtUs);
+        estop.asserted_ = true;
+        transport.clear();
+        transport.push(app_test::make_motion_frame(key, 2U, 1.0F, 0.0F, 1U, true));
+        app.tick(kDt);
+        CHECK(app.safety_state() == r2::safety::SafetyState::fault_latched);
+        CHECK(app.bridge_disabled());
+        CHECK(!motors.output_enabled());
+        CHECK(motors.disable_calls_ > 0U);
+        CHECK(steering.disabled_);
+        CHECK((app.latched_faults() &
+               r2::safety::bit(r2::safety::Fault::emergency_stop)) != 0U);
+    }
+
+    // ── Unauthenticated / wrong-key frames are ignored ──────────────────────
+    {
+        app_test::TestClock clock{};
+        app_test::TestMotors motors{};
+        app_test::TestSteering steering{};
+        app_test::TestEncoders encoders{};
+        app_test::TestImu imu{};
+        app_test::TestBattery battery{};
+        app_test::TestEstop estop{};
+        app_test::TestWatchdog watchdog{};
+        app_test::TestTransport transport{};
+        battery.sample_ = app_test::healthy_battery();
+        imu.sample_ = app_test::healthy_imu();
+
+        std::array<std::uint8_t, r2::protocol::kMacKeySize> wrong_key{};
+        for (std::size_t i = 0U; i < wrong_key.size(); ++i) {
+            wrong_key[i] = static_cast<std::uint8_t>(0xF0U ^ i);
+        }
+
+        const r2::application::HalBundle hal{clock,  motors,  steering, encoders, imu,
+                                             battery, estop,  watchdog, transport};
+        r2::application::Application app{
+            hal, app_test::make_config(app_test::calibrated_platform(), key)};
+        app.initialize();
+
+        // One tick carrying an authenticated arm (accepted) alongside a plaintext
+        // high-velocity motion command and a wrong-key motion command (both
+        // dropped). Only commands that survive decode_authenticated reach the
+        // state machine, so arm takes effect while neither forged command is held.
+        transport.push(app_test::make_control_frame(key, r2::protocol::MessageType::arm, 1U));
+        transport.push(app_test::make_motion_frame(key, 2U, 5.0F, 0.0F, 1U, false));
+        transport.push(app_test::make_motion_frame(wrong_key, 3U, 5.0F, 0.0F, 1U, true));
+        app.tick(kDt);
+        CHECK(app.safety_state() == r2::safety::SafetyState::armed);
+        CHECK(!app.command_held());
+        CHECK(app.last_left_duty_q15() == 0);
+        CHECK(app.last_right_duty_q15() == 0);
+    }
+
+    // ── Uncalibrated configuration immobilizes the platform ─────────────────
+    {
+        app_test::TestClock clock{};
+        app_test::TestMotors motors{};
+        app_test::TestSteering steering{};
+        app_test::TestEncoders encoders{};
+        app_test::TestImu imu{};
+        app_test::TestBattery battery{};
+        app_test::TestEstop estop{};
+        app_test::TestWatchdog watchdog{};
+        app_test::TestTransport transport{};
+        battery.sample_ = app_test::healthy_battery();
+        imu.sample_ = app_test::healthy_imu();
+
+        r2::application::PlatformConfiguration uncalibrated = app_test::calibrated_platform();
+        uncalibrated.calibrated = false;
+
+        const r2::application::HalBundle hal{clock,  motors,  steering, encoders, imu,
+                                             battery, estop,  watchdog, transport};
+        r2::application::Application app{hal, app_test::make_config(uncalibrated, key)};
+        app.initialize();
+        transport.push(app_test::make_control_frame(key, r2::protocol::MessageType::arm, 1U));
+        app.tick(kDt);
+        CHECK(app.safety_state() == r2::safety::SafetyState::fault_latched);
+        CHECK(app.bridge_disabled());
+        CHECK(!motors.output_enabled());
+        CHECK((app.latched_faults() &
+               r2::safety::bit(r2::safety::Fault::configuration_invalid)) != 0U);
+
+        // A subsequent activate cannot lift the latch.
+        clock.advance(kDtUs);
+        transport.clear();
+        transport.push(app_test::make_control_frame(key, r2::protocol::MessageType::activate, 2U));
+        app.tick(kDt);
+        CHECK(app.safety_state() == r2::safety::SafetyState::fault_latched);
+        CHECK(app.bridge_disabled());
+    }
+}
+
 }  // namespace
 
 int main() {
@@ -900,6 +1354,8 @@ int main() {
     test_mac_known_answer_vectors();
     test_mac_authentication();
     test_decode_fuzz();
+    test_control_loop_decode();
+    test_control_loop_gating();
     if (failures != 0) {
         std::fprintf(stderr, "%d test assertion(s) failed\n", failures);
         return 1;

--- a/firmware/rosmaster-r2/tools/check.sh
+++ b/firmware/rosmaster-r2/tools/check.sh
@@ -20,7 +20,8 @@ if command -v clang-tidy >/dev/null 2>&1; then
     "$root/control/src/motion_controller.cpp" \
     "$root/protocol/src/wire.cpp" \
     "$root/safety/src/safety_manager.cpp" \
-    "$root/firmware/src/configuration.cpp")
+    "$root/firmware/src/configuration.cpp" \
+    "$root/firmware/src/control_loop.cpp")
 else
   printf 'warning: clang-tidy is not installed; static analysis skipped\n' >&2
 fi


### PR DESCRIPTION
## Summary

Closes #962 — the keystone the rest of the flash-readiness work hangs off.

Adds `r2::application::Application` (`firmware/include/r2/application/control_loop.hpp` + `firmware/src/control_loop.cpp`): the per-tick orchestrator that wires the abstract HAL seams (`r2/hal/interfaces.hpp`) to the `SafetyManager`, the `MotionController`, and the authenticated R2CP decoder. It is **portable and device-agnostic** — it holds only references to the pure-virtual peripheral interfaces, so the same object runs against real silicon on the target and against mock seams in the host tests. No allocation, `noexcept`, `-fno-exceptions/-fno-rtti`.

## `tick(dt_s)` pipeline — fail-closed at every step

1. Service the independent watchdog.
2. Drain the transport; run **every** inbound frame through `decode_authenticated`. A frame failing the HMAC check is dropped (no positive trust); a structurally corrupt frame degrades link health; only survivors reach the state machine (`arm`/`activate`/`disarm`) or update the held motion command via `decode_motion_command` (faithful to `docs/PROTOCOL.md §MOTION_COMMAND`).
3. Sample sensors → build `SafetyInputs` (`configuration_valid = valid_configuration && calibrated`; `command_fresh` from the held command's age vs the calibrated `command_timeout_ms`, bounded by `valid_for_us`).
4. `evaluate(inputs)`.
5. Actuate: `bridge_must_be_disabled()` hard-cuts the H-bridge + servo **before** any drive decision; motion is issued only while `motion_permitted()` **and** a fresh TRACK command is held; every other reachable state drives the body command to zero so the jerk-limited controller decelerates to rest with the bridge still braking. Steering angle → servo pulse via the calibrated `servo_minimum/center/maximum_us`.

Net effect: an uncalibrated/invalid configuration immobilizes the platform, and a command reaches an actuator only after passing **both** authentication and the safety gate.

## Tests (mock HAL, host)

- **Codec**: faithful TRACK decode; unknown mode byte / short payload / non-finite scalar / wrong type all rejected.
- **Gating**: authenticated `arm → activate → motion` actuates (duty ramps up under the jerk limiter, steering holds center on a straight command); E-stop hard-disables the bridge and latches `emergency_stop`; a plaintext and a wrong-key motion command are both ignored while an authenticated `arm` in the same tick takes effect; an uncalibrated config latches `configuration_invalid` and immobilizes (a later `activate` cannot lift it).

Builds under the strict warning set + ASAN/UBSAN; `ctest`, the deterministic sim, **clang-tidy** and **cppcheck** all clean. The new `.cpp` is added to the CI clang-tidy list and to `tools/check.sh`.

## Design decisions worth a look before merge

This is the first code to put the safety state machine on the live actuation path, so flagging the judgment calls:

- **`active` requires a continuous fresh-command stream.** A freshly-activated node with no held command immediately drops to `controlled_stop` (the `command_timeout` momentary fault). This is the intended safety behavior, not a bug — surfacing it because it shapes how the SBC must drive the link (100–250 Hz per `docs/PROTOCOL.md`).
- **Deferred hardware seams** (reported nominal until wired, documented in `docs/SAFETY_AND_PRODUCTION.md`): no steering-position feedback sensor (`steering_plausible = true`) and no dedicated brownout/PVD comparator (`supply_stable = true`). The target rooting adds these.
- **`SafetyThresholds` are calibration-owned**; `default_thresholds()` are conservative placeholders, **not** a production calibration.
- **`ACKNOWLEDGE_FAULT` is not honored from the network** — a packet is never physical acknowledgement (matches the protocol doc).
- Command `acceleration_limit`/`jerk_limit` are decoded and validated but not yet applied to tighten the envelope (the configured hard limits already bound everything; command limits can only tighten, so ignoring them is conservative). Straightforward follow-up.

Holding merge for review given the safety-orchestration surface — happy to adjust any of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_