### PR TITLE
firmware(r2): control-loop runner + fail-closed safe-boot HAL (#968)

### DIFF
--- a/.github/workflows/rosmaster-r2-firmware.yml
+++ b/.github/workflows/rosmaster-r2-firmware.yml
@@ -42,7 +42,9 @@ jobs:
             firmware/rosmaster-r2/protocol/src/wire.cpp \
             firmware/rosmaster-r2/safety/src/safety_manager.cpp \
             firmware/rosmaster-r2/firmware/src/configuration.cpp \
-            firmware/rosmaster-r2/firmware/src/control_loop.cpp; do
+            firmware/rosmaster-r2/firmware/src/control_loop.cpp \
+            firmware/rosmaster-r2/firmware/src/runner.cpp \
+            firmware/rosmaster-r2/firmware/src/safe_hal.cpp; do
             clang-tidy-18 -p /tmp/r2-build "$source"
           done
       - name: cppcheck

--- a/firmware/rosmaster-r2/CMakeLists.txt
+++ b/firmware/rosmaster-r2/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(r2_platform_core STATIC
     safety/src/safety_manager.cpp
     firmware/src/configuration.cpp
     firmware/src/control_loop.cpp
+    firmware/src/runner.cpp
+    firmware/src/safe_hal.cpp
 )
 
 target_include_directories(r2_platform_core PUBLIC

--- a/firmware/rosmaster-r2/docs/SAFETY_AND_PRODUCTION.md
+++ b/firmware/rosmaster-r2/docs/SAFETY_AND_PRODUCTION.md
@@ -74,6 +74,19 @@ or a dedicated brownout/PVD comparator seam, so `steering_plausible` and
 is serviced every tick). ACKNOWLEDGE_FAULT is not honored from the network — a
 packet is never physical acknowledgement.
 
+The platform drives the loop through `run_cycle` (`r2/application/runner.hpp`),
+which derives `dt` from the monotonic clock and ticks the `Application` once per
+cycle; the loop and the idle between cycles are the platform's (a timer ISR or
+superloop on the MCU). A genuine overrun is passed through as a large `dt` so the
+control-deadline check catches the stall rather than the runner masking it.
+
+Before the concrete STM32 drivers (#967) exist, the bring-up image boots the
+`Application` against `SafeHal` (`r2/application/safe_hal.hpp`) — fail-closed HAL
+seams (asserted e-stop, invalid battery/IMU samples, a silent transport, disabled
+actuators). A driverless boot therefore lands directly in a latched-safe,
+bridge-disabled state: the platform is immobilized until real, healthy peripherals
+are wired in one seam at a time. This is asserted by the host tests.
+
 ## Fault policy
 
 | Detection | Reaction | Latch / recovery |

--- a/firmware/rosmaster-r2/firmware/include/r2/application/runner.hpp
+++ b/firmware/rosmaster-r2/firmware/include/r2/application/runner.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+// Portable control-loop runner. run_cycle() drives exactly one Application tick,
+// deriving dt from the monotonic clock, so the same cadence logic serves both
+// the host superloop and the target timer ISR / superloop. The PLATFORM owns
+// the loop and the idle between cycles (e.g. WFI on the MCU); this function is
+// the per-cycle body only, allocation-free and noexcept.
+
+#include "r2/application/control_loop.hpp"
+#include "r2/hal/interfaces.hpp"
+
+#include <cstdint>
+
+namespace r2::application {
+
+// Per-cycle timing state owned by the caller (statically allocated on target).
+struct RunnerState {
+    std::uint64_t last_us{0U};
+    bool initialized{false};
+};
+
+// Drive one control cycle:
+//   * read the monotonic clock;
+//   * the first cycle (and any non-advancing or backwards clock reading — a
+//     glitch or same-microsecond re-entry) uses nominal_dt_s and reseeds;
+//   * otherwise dt is the real elapsed time since the previous cycle. A genuine
+//     overrun is passed through as a large dt (NOT clamped) so the Application's
+//     control-deadline check catches the stall and fails closed, rather than
+//     the runner hiding it.
+// nominal_dt_s should be the loop's design period; a non-positive value is
+// itself guarded downstream by the Application/MotionController.
+void run_cycle(Application& app,
+               const hal::MonotonicClock& clock,
+               RunnerState& state,
+               double nominal_dt_s) noexcept;
+
+}  // namespace r2::application

--- a/firmware/rosmaster-r2/firmware/include/r2/application/safe_hal.hpp
+++ b/firmware/rosmaster-r2/firmware/include/r2/application/safe_hal.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+// Fail-closed HAL seams for a boot with no concrete drivers present (#967).
+//
+// Every seam reports the safe / no-device state so the SafetyManager
+// immobilizes the platform: the emergency stop reads asserted, the battery and
+// IMU samples read invalid, the transport is silent, and the actuators stay
+// disabled. Wiring the Application against a SafeHal therefore boots straight
+// into a latched-safe, bridge-disabled state — the correct default before the
+// real STM32 drivers exist.
+//
+// Uses: the target bring-up image can boot against SafeHal to prove a safe
+// power-on; the host tests assert the driverless-boot immobilization property;
+// and each concrete driver from #967 replaces its Safe* counterpart one seam at
+// a time without touching the control loop.
+
+#include "r2/application/control_loop.hpp"
+#include "r2/hal/interfaces.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace r2::application {
+
+// A monotonic clock with no real time base (returns 0). run_cycle() then falls
+// back to the nominal loop period; nothing actuates in the safe boot, so a
+// frozen clock is harmless. A concrete driver replaces this with a real timer.
+class SafeClock final : public hal::MonotonicClock {
+public:
+    [[nodiscard]] std::uint64_t now_us() const noexcept override;
+};
+
+class SafeMotorBridge final : public hal::MotorBridge {
+public:
+    void set_duty_q15(std::int16_t left, std::int16_t right) noexcept override;
+    void disable() noexcept override;
+    [[nodiscard]] bool output_enabled() const noexcept override;
+};
+
+class SafeSteeringActuator final : public hal::SteeringActuator {
+public:
+    void set_pulse_us(std::uint16_t pulse_us) noexcept override;
+    void disable() noexcept override;
+};
+
+// Reports zero motion (no encoders wired).
+class SafeEncoderBank final : public hal::EncoderBank {
+public:
+    [[nodiscard]] hal::EncoderSnapshot snapshot() noexcept override;
+};
+
+// Reports an invalid sample so imu_sane is false.
+class SafeImuDevice final : public hal::ImuDevice {
+public:
+    [[nodiscard]] hal::ImuSample sample() noexcept override;
+};
+
+// Reports all channels invalid so no battery input reads safe.
+class SafeBatteryMonitor final : public hal::BatteryMonitor {
+public:
+    [[nodiscard]] hal::BatterySample sample() noexcept override;
+};
+
+// Reads asserted: with no real e-stop wired, the platform stays e-stopped.
+class SafeEmergencyStopInput final : public hal::EmergencyStopInput {
+public:
+    [[nodiscard]] bool asserted() const noexcept override;
+};
+
+class SafeIndependentWatchdog final : public hal::IndependentWatchdog {
+public:
+    void service() noexcept override;
+};
+
+// Silent: no frames are ever delivered.
+class SafeTransport final : public hal::Transport {
+public:
+    [[nodiscard]] std::size_t read(std::uint8_t* destination,
+                                   std::size_t capacity) noexcept override;
+    [[nodiscard]] bool write(const std::uint8_t* source,
+                             std::size_t length) noexcept override;
+};
+
+// Owns one instance of each fail-closed seam and hands out a HalBundle wired to
+// them. Statically allocate one SafeHal and pass bundle() to the Application.
+struct SafeHal {
+    SafeClock clock;
+    SafeMotorBridge motors;
+    SafeSteeringActuator steering;
+    SafeEncoderBank encoders;
+    SafeImuDevice imu;
+    SafeBatteryMonitor battery;
+    SafeEmergencyStopInput emergency_stop;
+    SafeIndependentWatchdog watchdog;
+    SafeTransport transport;
+
+    [[nodiscard]] HalBundle bundle() noexcept;
+};
+
+}  // namespace r2::application

--- a/firmware/rosmaster-r2/firmware/src/runner.cpp
+++ b/firmware/rosmaster-r2/firmware/src/runner.cpp
@@ -1,0 +1,24 @@
+#include "r2/application/runner.hpp"
+
+#include "r2/application/control_loop.hpp"
+#include "r2/hal/interfaces.hpp"
+
+#include <cstdint>
+
+namespace r2::application {
+
+void run_cycle(Application& app,
+               const hal::MonotonicClock& clock,
+               RunnerState& state,
+               const double nominal_dt_s) noexcept {
+    const std::uint64_t now_us = clock.now_us();
+    double dt_s = nominal_dt_s;
+    if (state.initialized && now_us > state.last_us) {
+        dt_s = static_cast<double>(now_us - state.last_us) / 1'000'000.0;
+    }
+    state.last_us = now_us;
+    state.initialized = true;
+    app.tick(dt_s);
+}
+
+}  // namespace r2::application

--- a/firmware/rosmaster-r2/firmware/src/safe_hal.cpp
+++ b/firmware/rosmaster-r2/firmware/src/safe_hal.cpp
@@ -1,0 +1,66 @@
+#include "r2/application/safe_hal.hpp"
+
+#include "r2/application/control_loop.hpp"
+#include "r2/hal/interfaces.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace r2::application {
+
+std::uint64_t SafeClock::now_us() const noexcept {
+    return 0U;
+}
+
+void SafeMotorBridge::set_duty_q15(std::int16_t, std::int16_t) noexcept {
+    // No H-bridge present: ignore any drive request.
+}
+
+void SafeMotorBridge::disable() noexcept {}
+
+bool SafeMotorBridge::output_enabled() const noexcept {
+    return false;
+}
+
+void SafeSteeringActuator::set_pulse_us(std::uint16_t) noexcept {}
+
+void SafeSteeringActuator::disable() noexcept {}
+
+hal::EncoderSnapshot SafeEncoderBank::snapshot() noexcept {
+    return hal::EncoderSnapshot{};
+}
+
+hal::ImuSample SafeImuDevice::sample() noexcept {
+    hal::ImuSample sample{};
+    sample.valid = false;
+    return sample;
+}
+
+hal::BatterySample SafeBatteryMonitor::sample() noexcept {
+    hal::BatterySample sample{};
+    sample.voltage_valid = false;
+    sample.current_valid = false;
+    sample.temperature_valid = false;
+    return sample;
+}
+
+bool SafeEmergencyStopInput::asserted() const noexcept {
+    return true;
+}
+
+void SafeIndependentWatchdog::service() noexcept {}
+
+std::size_t SafeTransport::read(std::uint8_t*, std::size_t) noexcept {
+    return 0U;
+}
+
+bool SafeTransport::write(const std::uint8_t*, std::size_t) noexcept {
+    return false;
+}
+
+HalBundle SafeHal::bundle() noexcept {
+    return HalBundle{clock,   motors,         steering, encoders, imu,
+                     battery, emergency_stop, watchdog, transport};
+}
+
+}  // namespace r2::application

--- a/firmware/rosmaster-r2/tests/test_main.cpp
+++ b/firmware/rosmaster-r2/tests/test_main.cpp
@@ -1,5 +1,7 @@
 #include "r2/application/configuration.hpp"
 #include "r2/application/control_loop.hpp"
+#include "r2/application/runner.hpp"
+#include "r2/application/safe_hal.hpp"
 #include "r2/boot/image_verifier.hpp"
 #include "r2/control/motion_controller.hpp"
 #include "r2/diagnostics/metrics.hpp"
@@ -1338,6 +1340,92 @@ void test_control_loop_gating() {
     }
 }
 
+// ── Application runner (#968) ───────────────────────────────────────────────
+// run_cycle() derives dt from the monotonic clock and drives one Application
+// tick. Driven end-to-end it reproduces the happy path (arm → activate → motion
+// actuates), proving the dt derivation and per-cycle wiring.
+void test_application_runner() {
+    std::array<std::uint8_t, r2::protocol::kMacKeySize> key{};
+    for (std::size_t i = 0U; i < key.size(); ++i) {
+        key[i] = static_cast<std::uint8_t>(i + 1U);
+    }
+    constexpr double kNominalDt = 0.01;
+    constexpr std::uint64_t kDtUs = 10'000U;
+
+    app_test::TestClock clock{};
+    app_test::TestMotors motors{};
+    app_test::TestSteering steering{};
+    app_test::TestEncoders encoders{};
+    app_test::TestImu imu{};
+    app_test::TestBattery battery{};
+    app_test::TestEstop estop{};
+    app_test::TestWatchdog watchdog{};
+    app_test::TestTransport transport{};
+    battery.sample_ = app_test::healthy_battery();
+    imu.sample_ = app_test::healthy_imu();
+
+    const r2::application::HalBundle hal{clock,  motors,  steering, encoders, imu,
+                                         battery, estop,  watchdog, transport};
+    r2::application::Application app{
+        hal, app_test::make_config(app_test::calibrated_platform(), key)};
+    app.initialize();
+
+    r2::application::RunnerState runner{};
+    CHECK(!runner.initialized);
+
+    transport.push(app_test::make_control_frame(key, r2::protocol::MessageType::arm, 1U));
+    r2::application::run_cycle(app, clock, runner, kNominalDt);
+    CHECK(runner.initialized);
+    CHECK(app.safety_state() == r2::safety::SafetyState::armed);
+    CHECK(watchdog.services_ == 1U);
+
+    clock.advance(kDtUs);
+    transport.clear();
+    transport.push(app_test::make_control_frame(key, r2::protocol::MessageType::activate, 2U));
+    transport.push(app_test::make_motion_frame(key, 3U, 1.0F, 0.0F, 1U, true));
+    r2::application::run_cycle(app, clock, runner, kNominalDt);
+    CHECK(app.safety_state() == r2::safety::SafetyState::active);
+    CHECK(runner.last_us == clock.now_);
+
+    for (int cycle = 0; cycle < 4; ++cycle) {
+        clock.advance(kDtUs);
+        r2::application::run_cycle(app, clock, runner, kNominalDt);
+    }
+    CHECK(app.safety_state() == r2::safety::SafetyState::active);
+    CHECK(motors.output_enabled());
+    CHECK(motors.left_ > 0);
+    CHECK(motors.right_ > 0);
+}
+
+// A boot with no concrete drivers present (SafeHal) must immobilize: the
+// fail-closed seams (asserted e-stop, invalid battery/IMU, silent transport,
+// disabled actuators) drive the SafetyManager to a latched-safe, bridge-
+// disabled state and never permit motion, no matter how long it runs.
+void test_safe_hal_immobilized() {
+    std::array<std::uint8_t, r2::protocol::kMacKeySize> key{};
+    for (std::size_t i = 0U; i < key.size(); ++i) {
+        key[i] = static_cast<std::uint8_t>(i + 1U);
+    }
+
+    r2::application::SafeHal safe{};
+    r2::application::Application app{
+        safe.bundle(), app_test::make_config(app_test::calibrated_platform(), key)};
+    app.initialize();
+
+    r2::application::RunnerState runner{};
+    for (int cycle = 0; cycle < 64; ++cycle) {
+        r2::application::run_cycle(app, safe.clock, runner, 0.01);
+        CHECK(app.bridge_disabled());
+        CHECK(!safe.motors.output_enabled());
+        CHECK(app.last_left_duty_q15() == 0);
+        CHECK(app.last_right_duty_q15() == 0);
+    }
+    // The asserted e-stop latches the platform into the safe state.
+    CHECK(app.safety_state() == r2::safety::SafetyState::fault_latched);
+    CHECK((app.latched_faults() &
+           r2::safety::bit(r2::safety::Fault::emergency_stop)) != 0U);
+}
+
 }  // namespace
 
 int main() {
@@ -1356,6 +1444,8 @@ int main() {
     test_decode_fuzz();
     test_control_loop_decode();
     test_control_loop_gating();
+    test_application_runner();
+    test_safe_hal_immobilized();
     if (failures != 0) {
         std::fprintf(stderr, "%d test assertion(s) failed\n", failures);
         return 1;

--- a/firmware/rosmaster-r2/tools/check.sh
+++ b/firmware/rosmaster-r2/tools/check.sh
@@ -21,7 +21,9 @@ if command -v clang-tidy >/dev/null 2>&1; then
     "$root/protocol/src/wire.cpp" \
     "$root/safety/src/safety_manager.cpp" \
     "$root/firmware/src/configuration.cpp" \
-    "$root/firmware/src/control_loop.cpp")
+    "$root/firmware/src/control_loop.cpp" \
+    "$root/firmware/src/runner.cpp" \
+    "$root/firmware/src/safe_hal.cpp")
 else
   printf 'warning: clang-tidy is not installed; static analysis skipped\n' >&2
 fi


### PR DESCRIPTION
## Summary

The **portable half of #968's application entry**, fully host-tested (no un-runnable silicon code in this PR):

- **`run_cycle`** (`r2/application/runner.hpp`) — derives `dt` from the monotonic clock and drives one `Application` tick. The platform owns the loop + idle (timer ISR / superloop on the MCU). The first cycle and any non-advancing/backwards clock reading use the nominal period; a genuine overrun is passed through as a large `dt` so the control-deadline check catches the stall rather than the runner masking it.
- **`SafeHal`** (`r2/application/safe_hal.hpp`) — fail-closed HAL seams for a boot with **no concrete drivers (#967) present**: asserted e-stop, invalid battery/IMU samples, silent transport, disabled actuators. Wiring the `Application` against `SafeHal` boots straight into a **latched-safe, bridge-disabled** state; each real driver replaces its `Safe*` counterpart one seam at a time without touching the loop.

## Why this shape

`main` can't wire real drivers yet (#967), and a linker/startup image is only link-checkable, not runnable, here. This slice instead lands the parts of the "application entry" that are **fully verifiable on the host** and establishes a concrete safety property — *a driverless boot is immobilized* — that the eventual bring-up image inherits.

## Tests (host)

- `run_cycle` reproduces the `arm → activate → motion` happy path end-to-end (exercises the `dt` derivation and per-cycle wiring; drive ramps up, steering holds center).
- A **64-cycle `SafeHal` boot** is asserted to stay immobilized every cycle — bridge disabled, zero duty — and to latch `emergency_stop` into `fault_latched`.

Both new sources cross-compile for the Cortex-M3 target (the #971 lane), are added to the CI clang-tidy list + `check.sh`, and the full `check.sh` (ASAN/UBSAN build + ctest + deterministic sim + clang-tidy + cppcheck) is green. Documented in `docs/SAFETY_AND_PRODUCTION.md`.

## Remaining for a flashable image (build-only follow-ups)

Linker script / flash map (A/B-slot consistent), startup + vector table + fault→safe-state, and the target `main.cpp` that swaps `SafeHal` for the concrete STM32 drivers (#967) and runs `run_cycle` on the timer tick.

Part of #968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_