### PR TITLE
firmware(r2): linker script + startup + flashable safe-boot image (#968)

### DIFF
--- a/.github/workflows/rosmaster-r2-firmware.yml
+++ b/.github/workflows/rosmaster-r2-firmware.yml
@@ -137,10 +137,22 @@ jobs:
         run: >
           cmake -S firmware/rosmaster-r2 -B /tmp/r2-target
           -DCMAKE_TOOLCHAIN_FILE=$PWD/firmware/rosmaster-r2/cmake/arm-none-eabi-cortex-m3.cmake
-      - name: Cross-compile the safety core
+      - name: Cross-compile the safety core + link the target image
         run: cmake --build /tmp/r2-target --parallel
       - name: Confirm ARM object output
         run: |
           arm-none-eabi-objdump -f /tmp/r2-target/libr2_platform_core.a \
             | grep -q 'architecture: armv7'
           arm-none-eabi-size /tmp/r2-target/libr2_platform_core.a
+      - name: Size-check the flashable image against slot A
+        run: |
+          test -f /tmp/r2-target/r2_firmware_image.elf
+          test -f /tmp/r2-target/r2_firmware_image.bin
+          arm-none-eabi-size /tmp/r2-target/r2_firmware_image.elf
+          read text data bss _ _ < <(arm-none-eabi-size /tmp/r2-target/r2_firmware_image.elf | tail -1)
+          flash=$((text + data)); ram=$((data + bss))
+          echo "flash=${flash} B (slot 106496) ram=${ram} B (SRAM 49152)"
+          # Application slot A is 104 KiB; SRAM is 48 KiB. Fail closed if either
+          # is exceeded — the 104 KiB slot is a hard exit criterion.
+          test "${flash}" -le 106496
+          test "${ram}" -le 49152

--- a/firmware/rosmaster-r2/CMakeLists.txt
+++ b/firmware/rosmaster-r2/CMakeLists.txt
@@ -64,6 +64,56 @@ if(R2_ENABLE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
     target_link_options(r2_platform_core PUBLIC --coverage)
 endif()
 
+# Flashable target image (cross-compile only). Links the whole safety core plus
+# the startup/vector table and the SafeHal safe-boot entry against the slot-A
+# linker script, producing r2_firmware_image.elf + .bin. Build/link + size
+# verification only (the target-build CI lane size-checks it against the 104 KiB
+# slot); it is not run on silicon here. Host builds skip this entirely.
+if(CMAKE_CROSSCOMPILING)
+    set(R2_TARGET_LINKER_SCRIPT
+        "${CMAKE_CURRENT_SOURCE_DIR}/firmware/link/stm32f103rc_app_a.ld")
+    add_executable(r2_firmware_image
+        firmware/src/startup_stm32f103.cpp
+        firmware/src/main_target.cpp
+    )
+    target_link_libraries(r2_firmware_image PRIVATE r2_platform_core)
+    target_compile_options(r2_firmware_image PRIVATE
+        -Wall -Wextra -Wpedantic -Werror -Wconversion -Wsign-conversion
+        -Wshadow -Wdouble-promotion -Wformat=2 -Wundef
+        -fno-exceptions -fno-rtti
+        # Single-core MCU, no hosted atexit: drop the thread-safe-static guards
+        # and the __cxa_atexit/__dso_handle destructor registration (main never
+        # returns, so local-static destructors never run anyway).
+        -fno-threadsafe-statics -fno-use-cxa-atexit
+    )
+    target_link_options(r2_firmware_image PRIVATE
+        "-T${R2_TARGET_LINKER_SCRIPT}"
+        -nostartfiles
+        --specs=nano.specs
+        --specs=nosys.specs
+        -Wl,--gc-sections
+        -Wl,-Map=r2_firmware_image.map
+    )
+    set_target_properties(r2_firmware_image PROPERTIES
+        SUFFIX ".elf"
+        LINK_DEPENDS "${R2_TARGET_LINKER_SCRIPT}")
+
+    # Emit a raw .bin next to the .elf for flashing/inspection and report size.
+    find_program(R2_OBJCOPY arm-none-eabi-objcopy)
+    find_program(R2_SIZE arm-none-eabi-size)
+    if(R2_OBJCOPY)
+        add_custom_command(TARGET r2_firmware_image POST_BUILD
+            COMMAND ${R2_OBJCOPY} -O binary
+                    $<TARGET_FILE:r2_firmware_image> r2_firmware_image.bin
+            VERBATIM)
+    endif()
+    if(R2_SIZE)
+        add_custom_command(TARGET r2_firmware_image POST_BUILD
+            COMMAND ${R2_SIZE} $<TARGET_FILE:r2_firmware_image>
+            VERBATIM)
+    endif()
+endif()
+
 if(R2_BUILD_TESTS)
     include(CTest)
     add_executable(r2_platform_tests tests/test_main.cpp)

--- a/firmware/rosmaster-r2/docs/DEVELOPER_GUIDE.md
+++ b/firmware/rosmaster-r2/docs/DEVELOPER_GUIDE.md
@@ -29,12 +29,22 @@ cmake -S firmware/rosmaster-r2 -B /tmp/r2-target \
 cmake --build /tmp/r2-target --parallel   # builds libr2_platform_core.a (armv7-m)
 ```
 
-Cross-compiling disables the host tests, simulation and fuzzer automatically
-(they are host-only). This is a build-only lane — a static library needs no
-linker script. The linker script / flash map, startup + vector table, the
-concrete HAL drivers (#967) and the flashable application image (#968) are the
-remaining follow-ups after the BSP closure gates in `drivers/README.md`; the
-host target is not flashable.
+Cross-compiling also links the flashable **safe-boot image** for application
+slot A (`r2_firmware_image.elf` + `.bin`): startup/vector table
+(`firmware/src/startup_stm32f103.cpp`) + the `SafeHal` entry
+(`firmware/src/main_target.cpp`) against `firmware/link/stm32f103rc_app_a.ld`.
+It links the whole safety core and boots into a latched-safe, bridge-disabled
+state. The `target-build` CI lane size-checks it against the 104 KiB slot / 48
+KiB SRAM (currently ~31 KiB flash, ~4 KiB static RAM). Cross-compiling disables
+the host tests, simulation and fuzzer automatically (they are host-only).
+
+This is a build/link + size lane only — the image is **not** run on silicon
+here. Before it drives hardware: the concrete STM32 HAL drivers (#967), a real
+time base (SysTick/timer feeding the clock + loop cadence; `SafeClock` is frozen
+at 0), the 72 MHz PLL clock tree, and a per-link HMAC key in place of the zero
+placeholder. Slot B / configuration / metadata regions and a hardware root of
+trust are separate phase gates (see `drivers/README.md` and the flash map in
+`docs/SAFETY_AND_PRODUCTION.md`).
 
 ## Coding rules
 

--- a/firmware/rosmaster-r2/firmware/link/stm32f103rc_app_a.ld
+++ b/firmware/rosmaster-r2/firmware/link/stm32f103rc_app_a.ld
@@ -1,0 +1,136 @@
+/*
+ * Linker script — ROSMASTER R2 application slot A (STM32F103RCT6, Cortex-M3).
+ *
+ * Memory map per docs/SAFETY_AND_PRODUCTION.md "Preliminary flash map":
+ *   0x08000000  24 KiB  bootloader + public key (not owned by this script)
+ *   0x08006000 104 KiB  application A   <-- this image
+ *   0x08020000 104 KiB  application B
+ *   0x0803A000   8 KiB  configuration A/B + calibration
+ *   0x0803C000  16 KiB  event log / boot metadata
+ *
+ * The 104 KiB application slot is a hard exit criterion (do not grow the image
+ * by removing rollback or diagnostics). The vector table is placed first in the
+ * slot; startup points VTOR at the slot base so the bootloader can hand off.
+ *
+ * NOTE: build/link + size verification only. Slot B / config / metadata regions
+ * and a real dm-verity-style root of trust are separate phase gates.
+ */
+
+ENTRY(Reset_Handler)
+
+MEMORY
+{
+    FLASH (rx)  : ORIGIN = 0x08006000, LENGTH = 104K
+    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 48K
+}
+
+/* Top of stack = end of RAM (full-descending stack). */
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+/* Minimum heap/stack the image reserves; the link fails if RAM cannot hold it
+ * on top of .data/.bss, catching an over-large static footprint. */
+_Min_Heap_Size  = 0x400;   /* 1 KiB */
+_Min_Stack_Size = 0x800;   /* 2 KiB */
+
+SECTIONS
+{
+    .isr_vector :
+    {
+        . = ALIGN(4);
+        KEEP(*(.isr_vector))
+        . = ALIGN(4);
+    } >FLASH
+
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)
+        *(.text*)
+        *(.glue_7)
+        *(.glue_7t)
+        *(.eh_frame)
+        KEEP(*(.init))
+        KEEP(*(.fini))
+        . = ALIGN(4);
+        _etext = .;
+    } >FLASH
+
+    .rodata :
+    {
+        . = ALIGN(4);
+        *(.rodata)
+        *(.rodata*)
+        . = ALIGN(4);
+    } >FLASH
+
+    .ARM.extab : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+    .ARM :
+    {
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        __exidx_end = .;
+    } >FLASH
+
+    /* C++ static constructors / init arrays (run by __libc_init_array). */
+    .preinit_array :
+    {
+        . = ALIGN(4);
+        PROVIDE_HIDDEN(__preinit_array_start = .);
+        KEEP(*(.preinit_array*))
+        PROVIDE_HIDDEN(__preinit_array_end = .);
+    } >FLASH
+    .init_array :
+    {
+        . = ALIGN(4);
+        PROVIDE_HIDDEN(__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array*))
+        PROVIDE_HIDDEN(__init_array_end = .);
+    } >FLASH
+    .fini_array :
+    {
+        . = ALIGN(4);
+        PROVIDE_HIDDEN(__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array*))
+        PROVIDE_HIDDEN(__fini_array_end = .);
+    } >FLASH
+
+    /* Initialised data: load address in FLASH, run address in RAM. */
+    _sidata = LOADADDR(.data);
+    .data :
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data)
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } >RAM AT>FLASH
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        __bss_start__ = _sbss;
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+        __bss_end__ = _ebss;
+    } >RAM
+
+    /* Reserve, and range-check, heap + stack. */
+    ._user_heap_stack :
+    {
+        . = ALIGN(8);
+        PROVIDE(end = .);
+        PROVIDE(_end = .);
+        . = . + _Min_Heap_Size;
+        . = . + _Min_Stack_Size;
+        . = ALIGN(8);
+    } >RAM
+
+    /DISCARD/ : { *(.ARM.attributes) }
+}

--- a/firmware/rosmaster-r2/firmware/link/stm32f103rc_app_a.ld
+++ b/firmware/rosmaster-r2/firmware/link/stm32f103rc_app_a.ld
@@ -71,7 +71,10 @@ SECTIONS
         __exidx_end = .;
     } >FLASH
 
-    /* C++ static constructors / init arrays (run by __libc_init_array). */
+    /* C++ static constructors / init arrays. Run manually by Reset_Handler
+       (startup_stm32f103.cpp) over __init_array_start.._end — NOT via newlib's
+       __libc_init_array, so the image needs no crti/crtn _init under
+       -nostartfiles. */
     .preinit_array :
     {
         . = ALIGN(4);

--- a/firmware/rosmaster-r2/firmware/src/main_target.cpp
+++ b/firmware/rosmaster-r2/firmware/src/main_target.cpp
@@ -1,0 +1,50 @@
+// Target application entry — ROSMASTER R2 safe-boot image (STM32F103RCT6).
+//
+// This is the first flashable image: it wires the Application against SafeHal
+// (the fail-closed seams) and runs the control loop, so a freshly-flashed board
+// powers on into a latched-safe, bridge-disabled state. As the concrete STM32
+// drivers land (#967), each Safe* seam is replaced by its real driver one at a
+// time — the loop body here does not change.
+//
+// Build/link + size verification only. What remains before this drives motors:
+// the concrete HAL drivers (#967), a real time base (SysTick/timer feeding the
+// clock and the loop cadence — SafeClock is frozen at 0 here), the 72 MHz PLL
+// clock tree, and the per-link HMAC key provisioned in place of the zero
+// placeholder below. None of these are exercised in the safe boot.
+
+#include "r2/application/configuration.hpp"
+#include "r2/application/control_loop.hpp"
+#include "r2/application/runner.hpp"
+#include "r2/application/safe_hal.hpp"
+
+namespace {
+
+// Design control-loop period. The safe boot spins the superloop (SafeClock is
+// frozen, so run_cycle uses this nominal dt); a real image paces the loop from
+// a hardware timer and derives dt from a live monotonic clock.
+constexpr double kNominalDtSeconds = 0.001;  // 1 kHz
+
+}  // namespace
+
+// Called from Reset_Handler (startup_stm32f103.cpp). Named r2_app_main rather
+// than main so the freestanding startup can call it without tripping the ISO
+// C++ rule against a program calling ::main. Never returns.
+extern "C" int r2_app_main() {
+    // Statically allocated: no heap on the target.
+    static r2::application::SafeHal safe_hal;
+
+    static r2::application::ApplicationConfig config;
+    config.platform = r2::application::factory_defaults();
+    config.thresholds = r2::application::default_thresholds();
+    // config.link_key stays zero here: a production image provisions the per-link
+    // HMAC key. With SafeHal the platform never actuates regardless, so the
+    // placeholder key cannot authorise motion.
+
+    static r2::application::Application app{safe_hal.bundle(), config};
+    app.initialize();
+
+    r2::application::RunnerState runner;
+    for (;;) {
+        r2::application::run_cycle(app, safe_hal.clock, runner, kNominalDtSeconds);
+    }
+}

--- a/firmware/rosmaster-r2/firmware/src/startup_stm32f103.cpp
+++ b/firmware/rosmaster-r2/firmware/src/startup_stm32f103.cpp
@@ -1,0 +1,141 @@
+// Startup + vector table for the ROSMASTER R2 application (STM32F103RCT6,
+// Cortex-M3), application slot A.
+//
+// Reset_Handler initialises the C/C++ runtime (copy .data, zero .bss, run the
+// static constructors via __libc_init_array) and calls main(). The fault
+// handlers enter a safe halt — with the H-bridge already de-energised by
+// hardware/POR, a spin is the safe state until the independent watchdog resets
+// the part. This is the standard bare-metal reset path; peripheral IRQ vectors
+// are added alongside the concrete drivers (#967) that enable those interrupts.
+//
+// Build/link + size verification only: this image links the whole safety core
+// and fits the 104 KiB slot; it is NOT validated on silicon, and the PLL/clock
+// tree beyond the reset-default HSI is a follow-up (see main_target.cpp).
+
+#include <cstdint>
+
+extern "C" {
+
+// Provided by the linker script (stm32f103rc_app_a.ld).
+extern std::uint32_t _sidata;  // .data init image (in FLASH)
+extern std::uint32_t _sdata;   // .data start (in RAM)
+extern std::uint32_t _edata;   // .data end (in RAM)
+extern std::uint32_t _sbss;    // .bss start
+extern std::uint32_t _ebss;    // .bss end
+extern std::uint32_t _estack;  // top of stack
+
+// C++ static constructor table (from the linker script). Run manually so the
+// image needs no crti/crtn `_init` (we link -nostartfiles).
+extern void (*const __init_array_start[])();
+extern void (*const __init_array_end[])();
+
+// Application entry.
+int r2_app_main();  // application entry (named to avoid the ISO ::main restriction)
+
+void Reset_Handler();
+void Default_Handler();
+void SystemInit();
+
+// Cortex-M3 core exception handlers. Weakly aliased to Default_Handler so a
+// driver can override any of them; the fault handlers spin in the safe state.
+void NMI_Handler() __attribute__((weak, alias("Default_Handler")));
+void HardFault_Handler();
+void MemManage_Handler();
+void BusFault_Handler();
+void UsageFault_Handler();
+void SVC_Handler() __attribute__((weak, alias("Default_Handler")));
+void DebugMon_Handler() __attribute__((weak, alias("Default_Handler")));
+void PendSV_Handler() __attribute__((weak, alias("Default_Handler")));
+void SysTick_Handler() __attribute__((weak, alias("Default_Handler")));
+
+using VectorEntry = void (*)();
+
+// Cortex-M3 core vector table. The first word is the initial stack pointer; the
+// bootloader hands off by loading this slot's SP and jumping to Reset_Handler.
+// Placed first in FLASH by the linker script; SystemInit points VTOR here.
+__attribute__((section(".isr_vector"), used))
+const VectorEntry g_vector_table[16] = {
+    reinterpret_cast<VectorEntry>(&_estack),
+    Reset_Handler,
+    NMI_Handler,
+    HardFault_Handler,
+    MemManage_Handler,
+    BusFault_Handler,
+    UsageFault_Handler,
+    nullptr,  // reserved
+    nullptr,  // reserved
+    nullptr,  // reserved
+    nullptr,  // reserved
+    SVC_Handler,
+    DebugMon_Handler,
+    nullptr,  // reserved
+    PendSV_Handler,
+    SysTick_Handler,
+};
+
+// Application slot base — the vector table lives here (see the linker script).
+constexpr std::uint32_t kVectorTableBase = 0x0800'6000U;
+// SCB->VTOR (vector table offset register).
+constexpr std::uint32_t kScbVtorAddress = 0xE000'ED08U;
+
+void SystemInit() {
+    // Point the core at this slot's vector table. Clock configuration beyond the
+    // reset-default HSI (the 72 MHz PLL tree) is a follow-up; nothing in the
+    // safe-boot image depends on the bus frequency.
+    *reinterpret_cast<volatile std::uint32_t*>(kScbVtorAddress) = kVectorTableBase;
+}
+
+void Reset_Handler() {
+    // Copy the .data initialisers from FLASH to RAM. _sdata/_edata are linker
+    // region-boundary symbols, not one object — comparing them walks the region.
+    const std::uint32_t* source = &_sidata;
+    // cppcheck-suppress comparePointers
+    for (std::uint32_t* destination = &_sdata; destination < &_edata;) {
+        *destination++ = *source++;
+    }
+    // Zero .bss (likewise bounded by the _sbss/_ebss linker symbols).
+    // cppcheck-suppress comparePointers
+    for (std::uint32_t* bss = &_sbss; bss < &_ebss;) {
+        *bss++ = 0U;
+    }
+
+    SystemInit();
+    // Run C++ static constructors (the .init_array). Empty in the current
+    // image, but correct as global-scope constructors are added.
+    for (void (*const* ctor)() = __init_array_start; ctor < __init_array_end; ++ctor) {
+        (*ctor)();
+    }
+    static_cast<void>(r2_app_main());
+
+    // main() owns the control loop and must not return; if it ever does, halt
+    // in the safe state (bridge de-energised) until the watchdog resets us.
+    for (;;) {
+    }
+}
+
+void Default_Handler() {
+    for (;;) {
+    }
+}
+
+void HardFault_Handler() {
+    for (;;) {
+    }
+}
+
+void MemManage_Handler() {
+    for (;;) {
+    }
+}
+
+void BusFault_Handler() {
+    for (;;) {
+    }
+}
+
+void UsageFault_Handler() {
+    for (;;) {
+    }
+}
+
+}  // extern "C"

--- a/firmware/rosmaster-r2/firmware/src/startup_stm32f103.cpp
+++ b/firmware/rosmaster-r2/firmware/src/startup_stm32f103.cpp
@@ -1,12 +1,14 @@
 // Startup + vector table for the ROSMASTER R2 application (STM32F103RCT6,
 // Cortex-M3), application slot A.
 //
-// Reset_Handler initialises the C/C++ runtime (copy .data, zero .bss, run the
-// static constructors via __libc_init_array) and calls main(). The fault
-// handlers enter a safe halt — with the H-bridge already de-energised by
-// hardware/POR, a spin is the safe state until the independent watchdog resets
-// the part. This is the standard bare-metal reset path; peripheral IRQ vectors
-// are added alongside the concrete drivers (#967) that enable those interrupts.
+// Reset_Handler repoints the vector table (fail-closed, before anything else),
+// initialises the C/C++ runtime (copy .data, zero .bss, run the .init_array
+// constructors manually — no crti/crtn `_init` under -nostartfiles) and calls
+// the application entry r2_app_main(). The fault handlers enter a safe halt —
+// with the H-bridge already de-energised by hardware/POR, a spin is the safe
+// state until the independent watchdog resets the part. This is the standard
+// bare-metal reset path; peripheral IRQ vectors are added alongside the concrete
+// drivers (#967) that enable those interrupts.
 //
 // Build/link + size verification only: this image links the whole safety core
 // and fits the 104 KiB slot; it is NOT validated on silicon, and the PLL/clock
@@ -29,8 +31,9 @@ extern std::uint32_t _estack;  // top of stack
 extern void (*const __init_array_start[])();
 extern void (*const __init_array_end[])();
 
-// Application entry.
-int r2_app_main();  // application entry (named to avoid the ISO ::main restriction)
+// Application entry. Named r2_app_main (not main) so the freestanding startup
+// can call it without tripping the ISO C++ rule against a program calling ::main.
+int r2_app_main();
 
 void Reset_Handler();
 void Default_Handler();
@@ -48,44 +51,52 @@ void DebugMon_Handler() __attribute__((weak, alias("Default_Handler")));
 void PendSV_Handler() __attribute__((weak, alias("Default_Handler")));
 void SysTick_Handler() __attribute__((weak, alias("Default_Handler")));
 
-using VectorEntry = void (*)();
-
-// Cortex-M3 core vector table. The first word is the initial stack pointer; the
-// bootloader hands off by loading this slot's SP and jumping to Reset_Handler.
-// Placed first in FLASH by the linker script; SystemInit points VTOR here.
+// Cortex-M3 core vector table as an array of 32-bit words: word 0 is the initial
+// stack pointer, words 1.. are exception-entry addresses. It is an integer-word
+// table (not a function-pointer array) so the initial-SP entry is a well-defined
+// object-pointer-to-integer cast, rather than an object-pointer-to-function-
+// pointer reinterpret (which is only conditionally-supported in C++). The
+// hardware reads raw words, so the handler-address entries are identical bytes.
+// Placed first in FLASH by the linker script; Reset_Handler points VTOR at it.
 __attribute__((section(".isr_vector"), used))
-const VectorEntry g_vector_table[16] = {
-    reinterpret_cast<VectorEntry>(&_estack),
-    Reset_Handler,
-    NMI_Handler,
-    HardFault_Handler,
-    MemManage_Handler,
-    BusFault_Handler,
-    UsageFault_Handler,
-    nullptr,  // reserved
-    nullptr,  // reserved
-    nullptr,  // reserved
-    nullptr,  // reserved
-    SVC_Handler,
-    DebugMon_Handler,
-    nullptr,  // reserved
-    PendSV_Handler,
-    SysTick_Handler,
+const std::uintptr_t g_vector_table[16] = {
+    reinterpret_cast<std::uintptr_t>(&_estack),
+    reinterpret_cast<std::uintptr_t>(&Reset_Handler),
+    reinterpret_cast<std::uintptr_t>(&NMI_Handler),
+    reinterpret_cast<std::uintptr_t>(&HardFault_Handler),
+    reinterpret_cast<std::uintptr_t>(&MemManage_Handler),
+    reinterpret_cast<std::uintptr_t>(&BusFault_Handler),
+    reinterpret_cast<std::uintptr_t>(&UsageFault_Handler),
+    0U,  // reserved
+    0U,  // reserved
+    0U,  // reserved
+    0U,  // reserved
+    reinterpret_cast<std::uintptr_t>(&SVC_Handler),
+    reinterpret_cast<std::uintptr_t>(&DebugMon_Handler),
+    0U,  // reserved
+    reinterpret_cast<std::uintptr_t>(&PendSV_Handler),
+    reinterpret_cast<std::uintptr_t>(&SysTick_Handler),
 };
 
-// Application slot base — the vector table lives here (see the linker script).
-constexpr std::uint32_t kVectorTableBase = 0x0800'6000U;
 // SCB->VTOR (vector table offset register).
 constexpr std::uint32_t kScbVtorAddress = 0xE000'ED08U;
 
 void SystemInit() {
-    // Point the core at this slot's vector table. Clock configuration beyond the
-    // reset-default HSI (the 72 MHz PLL tree) is a follow-up; nothing in the
-    // safe-boot image depends on the bus frequency.
-    *reinterpret_cast<volatile std::uint32_t*>(kScbVtorAddress) = kVectorTableBase;
+    // Point the core at the vector table by its own linked address, so the same
+    // startup is correct at any link base (the slot-A image at 0x08006000 behind
+    // the bootloader, or a standalone bring-up image at 0x08000000). Clock
+    // configuration beyond the reset-default HSI (the 72 MHz PLL tree) is a
+    // follow-up; nothing in the safe-boot image depends on the bus frequency.
+    *reinterpret_cast<volatile std::uint32_t*>(kScbVtorAddress) =
+        static_cast<std::uint32_t>(reinterpret_cast<std::uintptr_t>(&g_vector_table));
 }
 
 void Reset_Handler() {
+    // Fail-closed: repoint the vector table to THIS image's handlers before any
+    // other work, so a fault during early memory init (or a stale VTOR a
+    // bootloader may have left) vectors into our table, not someone else's.
+    SystemInit();
+
     // Copy the .data initialisers from FLASH to RAM. _sdata/_edata are linker
     // region-boundary symbols, not one object — comparing them walks the region.
     const std::uint32_t* source = &_sidata;
@@ -99,16 +110,15 @@ void Reset_Handler() {
         *bss++ = 0U;
     }
 
-    SystemInit();
-    // Run C++ static constructors (the .init_array). Empty in the current
-    // image, but correct as global-scope constructors are added.
+    // Run C++ static constructors (the .init_array). Empty in the current image,
+    // but correct as global-scope constructors are added.
     for (void (*const* ctor)() = __init_array_start; ctor < __init_array_end; ++ctor) {
         (*ctor)();
     }
     static_cast<void>(r2_app_main());
 
-    // main() owns the control loop and must not return; if it ever does, halt
-    // in the safe state (bridge de-energised) until the watchdog resets us.
+    // r2_app_main() owns the control loop and must not return; if it ever does,
+    // halt in the safe state (bridge de-energised) until the watchdog resets us.
     for (;;) {
     }
 }


### PR DESCRIPTION
## Summary

Turns the safety core into a **linkable, size-checkable target image** for application slot A (STM32F103RCT6, Cortex-M3) — the last structural piece of #968's boot path. A freshly-flashed board would power on into a latched-safe, bridge-disabled state via `SafeHal`.

- **`firmware/link/stm32f103rc_app_a.ld`** — slot-A linker script per the flash map (FLASH `0x08006000` len 104 KiB, SRAM 48 KiB): `.isr_vector` first, `.data` load-in-FLASH/run-in-RAM, reserved + range-checked heap/stack, `_estack` at RAM top.
- **`firmware/src/startup_stm32f103.cpp`** — Cortex-M3 core vector table + `Reset_Handler` (copy `.data`, zero `.bss`, run `.init_array` manually so no crti `_init` is needed under `-nostartfiles`, then call the app entry). `SystemInit` points `VTOR` at the slot base; fault handlers spin in the safe state until the watchdog resets the part.
- **`firmware/src/main_target.cpp`** — the safe-boot entry (`r2_app_main`) wires the `Application` against `SafeHal` and runs the loop via `run_cycle`. Real drivers (#967) replace each `Safe*` seam without changing this loop.
- **CMake** — cross-compile builds `r2_firmware_image.elf` + `.bin` (nano+nosys specs, `--gc-sections`, `-fno-threadsafe-statics`/`-fno-use-cxa-atexit` for bare metal).
- **CI** — the `target-build` lane now size-checks the image against the 104 KiB slot / 48 KiB SRAM (a hard exit criterion).

## Verification (build/link + size only)

Links with `arm-none-eabi-g++` 13.2. `arm-none-eabi-size`: **flash ~31 KiB / 104 KiB slot, static RAM ~4 KiB / 48 KiB** + 3 KiB reserved heap/stack. Vector table checked: word 0 = `0x2000C000` (SP at RAM top), word 1 = `Reset_Handler` in slot A with the Thumb bit, distinct fault handlers, reserved slots zeroed. Host lanes (ASAN/UBSAN + ctest + clang-tidy + cppcheck) unchanged and green; the `.data`/`.bss` linker-boundary loops carry documented `cppcheck-suppress comparePointers`.

## ⚠️ Not run on silicon

This is the honest limit of what's verifiable without the board: it **links and fits**, it is **not executed**. Before it drives hardware:
- concrete STM32 HAL drivers (#967),
- a real time base (SysTick/timer feeding the clock + loop cadence — `SafeClock` is frozen at 0),
- the 72 MHz PLL clock tree (currently reset-default HSI),
- a per-link HMAC key in place of the zero placeholder.

Slot B / configuration / metadata regions and a hardware root of trust are separate phase gates.

Part of #968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_