### PR TITLE
firmware(r2): standalone bring-up image + on-target boot drill (#968)

### DIFF
--- a/firmware/rosmaster-r2/CMakeLists.txt
+++ b/firmware/rosmaster-r2/CMakeLists.txt
@@ -64,94 +64,68 @@ if(R2_ENABLE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
     target_link_options(r2_platform_core PUBLIC --coverage)
 endif()
 
-# Flashable target image (cross-compile only). Links the whole safety core plus
-# the startup/vector table and the SafeHal safe-boot entry against the slot-A
-# linker script, producing r2_firmware_image.elf + .bin. Build/link + size
-# verification only (the target-build CI lane size-checks it against the 104 KiB
-# slot); it is not run on silicon here. Host builds skip this entirely.
+# Flashable target images (cross-compile only). Both link the whole safety core
+# plus the startup/vector table and the SafeHal safe-boot entry — identical in
+# every respect EXCEPT the linker script (slot-A behind the bootloader vs. the
+# standalone bring-up image at the reset base). The shared compile/link flags are
+# factored into one function so the two images cannot drift (a future
+# warning/ABI/GC change lands on both). Build/link + size verification only (the
+# target-build CI lane size-checks r2_firmware_image against the 104 KiB slot);
+# not run on silicon here. Host builds skip this entirely.
 if(CMAKE_CROSSCOMPILING)
-    set(R2_TARGET_LINKER_SCRIPT
-        "${CMAKE_CURRENT_SOURCE_DIR}/firmware/link/stm32f103rc_app_a.ld")
-    add_executable(r2_firmware_image
-        firmware/src/startup_stm32f103.cpp
-        firmware/src/main_target.cpp
-    )
-    target_link_libraries(r2_firmware_image PRIVATE r2_platform_core)
-    target_compile_options(r2_firmware_image PRIVATE
-        -Wall -Wextra -Wpedantic -Werror -Wconversion -Wsign-conversion
-        -Wshadow -Wdouble-promotion -Wformat=2 -Wundef
-        -fno-exceptions -fno-rtti
-        # Single-core MCU, no hosted atexit: drop the thread-safe-static guards
-        # and the __cxa_atexit/__dso_handle destructor registration (main never
-        # returns, so local-static destructors never run anyway).
-        -fno-threadsafe-statics -fno-use-cxa-atexit
-    )
-    target_link_options(r2_firmware_image PRIVATE
-        "-T${R2_TARGET_LINKER_SCRIPT}"
-        -nostartfiles
-        --specs=nano.specs
-        --specs=nosys.specs
-        -Wl,--gc-sections
-        -Wl,-Map=r2_firmware_image.map
-    )
-    set_target_properties(r2_firmware_image PROPERTIES
-        SUFFIX ".elf"
-        LINK_DEPENDS "${R2_TARGET_LINKER_SCRIPT}")
-
-    # Emit a raw .bin next to the .elf for flashing/inspection and report size.
     find_program(R2_OBJCOPY arm-none-eabi-objcopy)
     find_program(R2_SIZE arm-none-eabi-size)
-    if(R2_OBJCOPY)
-        add_custom_command(TARGET r2_firmware_image POST_BUILD
-            COMMAND ${R2_OBJCOPY} -O binary
-                    $<TARGET_FILE:r2_firmware_image> r2_firmware_image.bin
-            VERBATIM)
-    endif()
-    if(R2_SIZE)
-        add_custom_command(TARGET r2_firmware_image POST_BUILD
-            COMMAND ${R2_SIZE} $<TARGET_FILE:r2_firmware_image>
-            VERBATIM)
-    endif()
 
-    # Standalone bring-up image: the same startup + SafeHal entry linked at the
-    # reset base (0x08000000, whole flash) so it boots on bare silicon with no
-    # bootloader. For first hardware bring-up only (flash + halt/inspect); see
-    # docs/MCU_BRINGUP_DRILL.md.
-    set(R2_BRINGUP_LINKER_SCRIPT
+    # r2_add_firmware_image(<target> <linker_script>): assemble one image target
+    # from the common sources + flags, differing only in the linker script.
+    function(r2_add_firmware_image target linker_script)
+        add_executable(${target}
+            firmware/src/startup_stm32f103.cpp
+            firmware/src/main_target.cpp
+        )
+        target_link_libraries(${target} PRIVATE r2_platform_core)
+        target_compile_options(${target} PRIVATE
+            -Wall -Wextra -Wpedantic -Werror -Wconversion -Wsign-conversion
+            -Wshadow -Wdouble-promotion -Wformat=2 -Wundef
+            -fno-exceptions -fno-rtti
+            # Single-core MCU, no hosted atexit: drop the thread-safe-static
+            # guards and the __cxa_atexit/__dso_handle destructor registration
+            # (main never returns, so local-static destructors never run anyway).
+            -fno-threadsafe-statics -fno-use-cxa-atexit
+        )
+        target_link_options(${target} PRIVATE
+            "-T${linker_script}"
+            -nostartfiles
+            --specs=nano.specs
+            --specs=nosys.specs
+            -Wl,--gc-sections
+            "-Wl,-Map=${target}.map"
+        )
+        set_target_properties(${target} PROPERTIES
+            SUFFIX ".elf"
+            LINK_DEPENDS "${linker_script}")
+        # Emit a raw .bin next to the .elf for flashing/inspection and report size.
+        if(R2_OBJCOPY)
+            add_custom_command(TARGET ${target} POST_BUILD
+                COMMAND ${R2_OBJCOPY} -O binary
+                        $<TARGET_FILE:${target}> ${target}.bin
+                VERBATIM)
+        endif()
+        if(R2_SIZE)
+            add_custom_command(TARGET ${target} POST_BUILD
+                COMMAND ${R2_SIZE} $<TARGET_FILE:${target}>
+                VERBATIM)
+        endif()
+    endfunction()
+
+    # Slot-A production image (0x08006000, behind the bootloader).
+    r2_add_firmware_image(r2_firmware_image
+        "${CMAKE_CURRENT_SOURCE_DIR}/firmware/link/stm32f103rc_app_a.ld")
+
+    # Standalone bring-up image (0x08000000, whole flash) — boots on bare silicon
+    # with no bootloader; for first hardware bring-up (see docs/MCU_BRINGUP_DRILL.md).
+    r2_add_firmware_image(r2_firmware_bringup
         "${CMAKE_CURRENT_SOURCE_DIR}/firmware/link/stm32f103rc_bringup.ld")
-    add_executable(r2_firmware_bringup
-        firmware/src/startup_stm32f103.cpp
-        firmware/src/main_target.cpp
-    )
-    target_link_libraries(r2_firmware_bringup PRIVATE r2_platform_core)
-    target_compile_options(r2_firmware_bringup PRIVATE
-        -Wall -Wextra -Wpedantic -Werror -Wconversion -Wsign-conversion
-        -Wshadow -Wdouble-promotion -Wformat=2 -Wundef
-        -fno-exceptions -fno-rtti
-        -fno-threadsafe-statics -fno-use-cxa-atexit
-    )
-    target_link_options(r2_firmware_bringup PRIVATE
-        "-T${R2_BRINGUP_LINKER_SCRIPT}"
-        -nostartfiles
-        --specs=nano.specs
-        --specs=nosys.specs
-        -Wl,--gc-sections
-        -Wl,-Map=r2_firmware_bringup.map
-    )
-    set_target_properties(r2_firmware_bringup PROPERTIES
-        SUFFIX ".elf"
-        LINK_DEPENDS "${R2_BRINGUP_LINKER_SCRIPT}")
-    if(R2_OBJCOPY)
-        add_custom_command(TARGET r2_firmware_bringup POST_BUILD
-            COMMAND ${R2_OBJCOPY} -O binary
-                    $<TARGET_FILE:r2_firmware_bringup> r2_firmware_bringup.bin
-            VERBATIM)
-    endif()
-    if(R2_SIZE)
-        add_custom_command(TARGET r2_firmware_bringup POST_BUILD
-            COMMAND ${R2_SIZE} $<TARGET_FILE:r2_firmware_bringup>
-            VERBATIM)
-    endif()
 endif()
 
 if(R2_BUILD_TESTS)

--- a/firmware/rosmaster-r2/CMakeLists.txt
+++ b/firmware/rosmaster-r2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16...3.27)
 project(kirra_rosmaster_r2_firmware VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/firmware/rosmaster-r2/CMakeLists.txt
+++ b/firmware/rosmaster-r2/CMakeLists.txt
@@ -112,6 +112,46 @@ if(CMAKE_CROSSCOMPILING)
             COMMAND ${R2_SIZE} $<TARGET_FILE:r2_firmware_image>
             VERBATIM)
     endif()
+
+    # Standalone bring-up image: the same startup + SafeHal entry linked at the
+    # reset base (0x08000000, whole flash) so it boots on bare silicon with no
+    # bootloader. For first hardware bring-up only (flash + halt/inspect); see
+    # docs/MCU_BRINGUP_DRILL.md.
+    set(R2_BRINGUP_LINKER_SCRIPT
+        "${CMAKE_CURRENT_SOURCE_DIR}/firmware/link/stm32f103rc_bringup.ld")
+    add_executable(r2_firmware_bringup
+        firmware/src/startup_stm32f103.cpp
+        firmware/src/main_target.cpp
+    )
+    target_link_libraries(r2_firmware_bringup PRIVATE r2_platform_core)
+    target_compile_options(r2_firmware_bringup PRIVATE
+        -Wall -Wextra -Wpedantic -Werror -Wconversion -Wsign-conversion
+        -Wshadow -Wdouble-promotion -Wformat=2 -Wundef
+        -fno-exceptions -fno-rtti
+        -fno-threadsafe-statics -fno-use-cxa-atexit
+    )
+    target_link_options(r2_firmware_bringup PRIVATE
+        "-T${R2_BRINGUP_LINKER_SCRIPT}"
+        -nostartfiles
+        --specs=nano.specs
+        --specs=nosys.specs
+        -Wl,--gc-sections
+        -Wl,-Map=r2_firmware_bringup.map
+    )
+    set_target_properties(r2_firmware_bringup PROPERTIES
+        SUFFIX ".elf"
+        LINK_DEPENDS "${R2_BRINGUP_LINKER_SCRIPT}")
+    if(R2_OBJCOPY)
+        add_custom_command(TARGET r2_firmware_bringup POST_BUILD
+            COMMAND ${R2_OBJCOPY} -O binary
+                    $<TARGET_FILE:r2_firmware_bringup> r2_firmware_bringup.bin
+            VERBATIM)
+    endif()
+    if(R2_SIZE)
+        add_custom_command(TARGET r2_firmware_bringup POST_BUILD
+            COMMAND ${R2_SIZE} $<TARGET_FILE:r2_firmware_bringup>
+            VERBATIM)
+    endif()
 endif()
 
 if(R2_BUILD_TESTS)

--- a/firmware/rosmaster-r2/docs/MCU_BRINGUP_DRILL.md
+++ b/firmware/rosmaster-r2/docs/MCU_BRINGUP_DRILL.md
@@ -14,7 +14,8 @@ image boots and reaches the safe state. **Nothing actuates.**
 
 ## What you need
 
-- ST-Link V2 (or clone), or a J-Link.
+- ST-Link V2 (or clone). The OpenOCD commands below use `interface/stlink.cfg`;
+  for a J-Link, substitute `interface/jlink.cfg` (everything else is the same).
 - OpenOCD ≥ 0.11 and `arm-none-eabi-gdb`.
 - This repo, with `gcc-arm-none-eabi` installed.
 
@@ -37,10 +38,18 @@ openocd -f interface/stlink.cfg -f target/stm32f1x.cfg \
 
 `0xE0042000` is `DBGMCU_IDCODE`; the low 12 bits are the device ID. **0x414 =
 high-density F103 (STM32F103xC/D/E)**, which the RCT6 is. If you see a different
-ID, stop and reconcile the part against `hal/board_manifest.hpp`
+ID, stop and reconcile the part against `hal/include/r2/hal/board_manifest.hpp`
 (`kExpectedSharedBoardMcu = "STM32F103RCT6"`) before flashing.
 
 ## 3. Flash
+
+> **⚠ This image is linked at `0x08000000` and spans the whole 256 KiB flash.**
+> Flashing it **erases everything**, including any preinstalled bootloader +
+> public key (`0x08000000`) and both application slots. Only flash the bring-up
+> image to a blank or development part. On a board that already carries the
+> bootloader, flash the **slot-A** image (`r2_firmware_image.bin` at
+> `0x08006000`) through the bootloader instead, so the boot + key region is
+> preserved.
 
 ```bash
 openocd -f interface/stlink.cfg -f target/stm32f1x.cfg \

--- a/firmware/rosmaster-r2/docs/MCU_BRINGUP_DRILL.md
+++ b/firmware/rosmaster-r2/docs/MCU_BRINGUP_DRILL.md
@@ -1,0 +1,100 @@
+# MCU first-boot bring-up drill (STM32F103RCT6)
+
+The **standalone bring-up image** (`r2_firmware_bringup.bin`) boots on bare
+silicon with no bootloader and no peripheral I/O — it wires the `Application`
+against `SafeHal` and holds the platform in the latched-safe, bridge-disabled
+state. This drill flashes it and confirms, with a debug probe only, that the
+image boots and reaches the safe state. **Nothing actuates.**
+
+## Safety preconditions
+
+- **Wheels off the ground and the motor power bus disconnected.** Even though
+  this image commands no motion, treat every on-target session as if it could.
+- Power the board from a current-limited bench supply for the first boots.
+
+## What you need
+
+- ST-Link V2 (or clone), or a J-Link.
+- OpenOCD ≥ 0.11 and `arm-none-eabi-gdb`.
+- This repo, with `gcc-arm-none-eabi` installed.
+
+## 1. Build the image
+
+```bash
+cmake -S firmware/rosmaster-r2 -B build-target \
+  -DCMAKE_TOOLCHAIN_FILE="$PWD/firmware/rosmaster-r2/cmake/arm-none-eabi-cortex-m3.cmake"
+cmake --build build-target --parallel
+# Produces build-target/r2_firmware_bringup.elf + .bin (and the slot-A image).
+arm-none-eabi-size build-target/r2_firmware_bringup.elf   # ~31 KiB flash, well under 256 KiB
+```
+
+## 2. Confirm the part before writing flash
+
+```bash
+openocd -f interface/stlink.cfg -f target/stm32f1x.cfg \
+  -c "init; mdw 0xE0042000 1; exit"
+```
+
+`0xE0042000` is `DBGMCU_IDCODE`; the low 12 bits are the device ID. **0x414 =
+high-density F103 (STM32F103xC/D/E)**, which the RCT6 is. If you see a different
+ID, stop and reconcile the part against `hal/board_manifest.hpp`
+(`kExpectedSharedBoardMcu = "STM32F103RCT6"`) before flashing.
+
+## 3. Flash
+
+```bash
+openocd -f interface/stlink.cfg -f target/stm32f1x.cfg \
+  -c "program build-target/r2_firmware_bringup.elf verify reset exit"
+```
+
+`verify` reads flash back and compares; a mismatch fails the command.
+
+## 4. Confirm boot + safe state with GDB (no I/O)
+
+Terminal A:
+
+```bash
+openocd -f interface/stlink.cfg -f target/stm32f1x.cfg
+```
+
+Terminal B:
+
+```bash
+arm-none-eabi-gdb build-target/r2_firmware_bringup.elf
+(gdb) target extended-remote :3333
+(gdb) monitor reset halt
+# 4a. The reset vector must be reached (not stuck in a fault handler):
+(gdb) break Reset_Handler
+(gdb) continue          # should hit Reset_Handler
+# 4b. The application entry must be reached:
+(gdb) break r2_app_main
+(gdb) continue          # should hit r2_app_main
+# 4c. Let it run a moment, then halt inside the loop and confirm it is NOT in a
+#     fault handler and IS ticking the control loop:
+(gdb) continue
+# ...wait ~1 s, Ctrl-C...
+(gdb) backtrace         # expect run_cycle / Application::tick, NOT *_Handler
+```
+
+**Expected result:** the image reaches `r2_app_main`, enters the superloop, and
+stays there (no `HardFault_Handler`). Because `SafeHal` reports an asserted
+e-stop, the `SafetyManager` latches into `fault_latched` and the motor-bridge
+`disable()` path runs every cycle. You can confirm the latched-safe state by
+reading the live `SafetyManager` (its address is the static `app` inside
+`r2_app_main`); the exact offset depends on the build, so the simplest proof is
+4c: the loop runs and never actuates.
+
+**If it faults** (PC parks in `HardFault_Handler`/`Default_Handler` right after
+reset): most often a stack-pointer or vector-table mismatch. Sanity-check the
+first two flash words — `mdw 0x08000000 2` should read the initial SP
+(`0x2000C000`, top of the 48 KiB SRAM) then the reset-vector address (odd, Thumb
+bit set). Capture the fault and share it.
+
+## 5. Next
+
+Once the safe boot is confirmed, drivers land seam-by-seam (#967), non-actuating
+first (clock/PLL, watchdog, UART, ADC, encoders), each replacing its `Safe*`
+seam and validated on the board before the motor/steering outputs — which come
+last, wheels still off the ground. The production image is the slot-A build
+(`r2_firmware_image.bin`, behind the bootloader); this standalone image is a
+bring-up aid only.

--- a/firmware/rosmaster-r2/firmware/link/stm32f103rc_bringup.ld
+++ b/firmware/rosmaster-r2/firmware/link/stm32f103rc_bringup.ld
@@ -1,0 +1,126 @@
+/*
+ * Linker script — ROSMASTER R2 STANDALONE BRING-UP image (STM32F103RCT6).
+ *
+ * Identical to stm32f103rc_app_a.ld except the image is linked at the reset
+ * base 0x08000000 and spans the whole 256 KiB flash, so it boots on bare
+ * silicon with NO bootloader present: at power-on the core loads SP + the reset
+ * vector from 0x08000000, which is exactly where this image's vector table
+ * sits. Use this for first hardware bring-up (flash + halt/inspect with a debug
+ * probe); the production image is the slot-A script behind the bootloader.
+ *
+ * The startup code points VTOR at the vector table's own linked address, so the
+ * same startup_stm32f103.cpp is correct for both scripts.
+ */
+
+ENTRY(Reset_Handler)
+
+MEMORY
+{
+    FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 256K
+    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 48K
+}
+
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+_Min_Heap_Size  = 0x400;   /* 1 KiB */
+_Min_Stack_Size = 0x800;   /* 2 KiB */
+
+SECTIONS
+{
+    .isr_vector :
+    {
+        . = ALIGN(4);
+        KEEP(*(.isr_vector))
+        . = ALIGN(4);
+    } >FLASH
+
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)
+        *(.text*)
+        *(.glue_7)
+        *(.glue_7t)
+        *(.eh_frame)
+        KEEP(*(.init))
+        KEEP(*(.fini))
+        . = ALIGN(4);
+        _etext = .;
+    } >FLASH
+
+    .rodata :
+    {
+        . = ALIGN(4);
+        *(.rodata)
+        *(.rodata*)
+        . = ALIGN(4);
+    } >FLASH
+
+    .ARM.extab : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+    .ARM :
+    {
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        __exidx_end = .;
+    } >FLASH
+
+    .preinit_array :
+    {
+        . = ALIGN(4);
+        PROVIDE_HIDDEN(__preinit_array_start = .);
+        KEEP(*(.preinit_array*))
+        PROVIDE_HIDDEN(__preinit_array_end = .);
+    } >FLASH
+    .init_array :
+    {
+        . = ALIGN(4);
+        PROVIDE_HIDDEN(__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array*))
+        PROVIDE_HIDDEN(__init_array_end = .);
+    } >FLASH
+    .fini_array :
+    {
+        . = ALIGN(4);
+        PROVIDE_HIDDEN(__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array*))
+        PROVIDE_HIDDEN(__fini_array_end = .);
+    } >FLASH
+
+    _sidata = LOADADDR(.data);
+    .data :
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data)
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } >RAM AT>FLASH
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        __bss_start__ = _sbss;
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+        __bss_end__ = _ebss;
+    } >RAM
+
+    ._user_heap_stack :
+    {
+        . = ALIGN(8);
+        PROVIDE(end = .);
+        PROVIDE(_end = .);
+        . = . + _Min_Heap_Size;
+        . = . + _Min_Stack_Size;
+        . = ALIGN(8);
+    } >RAM
+
+    /DISCARD/ : { *(.ARM.attributes) }
+}


### PR DESCRIPTION
## Summary

The slot-A image (#973, now on main) links at `0x08006000` behind the bootloader, so it can't boot on bare silicon. This adds a **standalone bring-up image** for first hardware validation, plus the drill to flash and confirm it — the first concrete step of the seam-by-seam #967 driver bring-up now that the board is in hand.

- **`firmware/link/stm32f103rc_bringup.ld`** — the same layout linked at the reset base (`0x08000000`, whole 256 KiB flash), so the core loads SP + the reset vector directly at power-on with **no bootloader**.
- **CMake** — cross-compile also builds `r2_firmware_bringup.elf`/`.bin` (same startup + `SafeHal` entry, bring-up linker script). The startup already self-locates `VTOR` at `&g_vector_table` (from #973's review hardening), so one startup is correct at both link bases.
- **`docs/MCU_BRINGUP_DRILL.md`** — flash (OpenOCD + ST-Link) and confirm-boot (GDB) procedure: ID-code check → flash+verify → confirm the image reaches `r2_app_main` and spins in `run_cycle`/`tick` **without faulting**, holding the latched-safe, bridge-disabled state. **Wheels off the ground, no I/O — nothing actuates.**

## Verification

Both images link (`arm-none-eabi-g++` 13.2), ~31 KiB flash each. Bring-up vector table confirmed at `0x08000000`: SP `0x2000C000` (RAM top), reset vector Thumb-set. Build/link + size only; **on-silicon boot is the drill's job** (board owner runs it).

## Follow-up

Once the safe boot is confirmed on the board, drivers land seam-by-seam (#967) — non-actuating (clock/PLL, watchdog, UART, ADC, encoders) before the motor/steering outputs, each replacing its `Safe*` seam and validated on hardware.

Part of #968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_