### PR TITLE
firmware(r2): status-LED heartbeat — probe-free sign of life (#967)

### DIFF
--- a/firmware/rosmaster-r2/CMakeLists.txt
+++ b/firmware/rosmaster-r2/CMakeLists.txt
@@ -82,6 +82,7 @@ if(CMAKE_CROSSCOMPILING)
         add_executable(${target}
             firmware/src/startup_stm32f103.cpp
             firmware/src/main_target.cpp
+            firmware/src/status_led_stm32.cpp
         )
         target_link_libraries(${target} PRIVATE r2_platform_core)
         target_compile_options(${target} PRIVATE

--- a/firmware/rosmaster-r2/docs/MCU_BRINGUP_DRILL.md
+++ b/firmware/rosmaster-r2/docs/MCU_BRINGUP_DRILL.md
@@ -99,6 +99,48 @@ first two flash words — `mdw 0x08000000 2` should read the initial SP
 (`0x2000C000`, top of the 48 KiB SRAM) then the reset-vector address (odd, Thumb
 bit set). Capture the fault and share it.
 
+## 4b. No debug probe? Confirm via the status-LED heartbeat
+
+If you have no ST-Link/J-Link and are flashing over the STM32 serial bootloader
+(below), you can't use GDB — but the image gives a **visible sign of life**: it
+blinks the status LED (PC13, per `hal/include/r2/hal/board_manifest.hpp`) every
+control cycle.
+
+- **LED blinking** → the reset path, runtime init and control loop all ran; the
+  image is alive and looping in the latched-safe state. Boot confirmed.
+- **LED solid or dark** → it never reached the loop (hardfault at reset, or a
+  wrong vector table / SP). Same failure modes as the GDB "faults" note above.
+
+The blink rate is approximate (the loop isn't paced by a real time base yet), so
+judge presence, not precision. If the board's LED isn't on PC13, change the pin
+in `firmware/src/status_led_stm32.cpp` (the single place it's defined).
+
+## 4c. Flashing over the serial bootloader (no probe)
+
+The STM32F103 has a ROM serial bootloader (USART1) entered with **BOOT0 = 1 at
+reset** (jumper/DIP/button on the control board). With `stm32flash`:
+
+```bash
+sudo apt-get install -y stm32flash
+PORT=/dev/ttyUSB0   # the STM32's UART bridge — confirm which one it is first
+
+# 1. BACK UP the existing firmware BEFORE writing anything (reversible!).
+stm32flash -r stock_stm32_backup.bin "$PORT"
+
+# 2. Write the bring-up image and run it.
+stm32flash -w build-target/r2_firmware_bringup.bin -v -g 0x08000000 "$PORT"
+
+# To restore the robot's original firmware later:
+stm32flash -w stock_stm32_backup.bin -v -g 0x08000000 "$PORT"
+```
+
+> **⚠ This erases the factory STM32 firmware** (the bring-up image spans the whole
+> flash). Keep `stock_stm32_backup.bin` safe — it's the only way back. Wheels off
+> the ground, motor bus disconnected.
+
+Identify the STM32's port (vs. e.g. the lidar's) with
+`udevadm info /dev/ttyUSB0 | grep -E "ID_VENDOR|ID_MODEL"`.
+
 ## 5. Next
 
 Once the safe boot is confirmed, drivers land seam-by-seam (#967), non-actuating

--- a/firmware/rosmaster-r2/docs/MCU_BRINGUP_DRILL.md
+++ b/firmware/rosmaster-r2/docs/MCU_BRINGUP_DRILL.md
@@ -103,8 +103,9 @@ bit set). Capture the fault and share it.
 
 If you have no ST-Link/J-Link and are flashing over the STM32 serial bootloader
 (below), you can't use GDB — but the image gives a **visible sign of life**: it
-blinks the status LED (PC13, per `hal/include/r2/hal/board_manifest.hpp`) every
-control cycle.
+drives the status LED (PC13, per `hal/include/r2/hal/board_manifest.hpp`),
+toggling it every `half_period` control cycles so it blinks steadily while the
+loop runs.
 
 - **LED blinking** → the reset path, runtime init and control loop all ran; the
   image is alive and looping in the latched-safe state. Boot confirmed.

--- a/firmware/rosmaster-r2/firmware/include/r2/application/heartbeat.hpp
+++ b/firmware/rosmaster-r2/firmware/include/r2/application/heartbeat.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+// Pure blink-phase for the bring-up "sign of life". A steady blink of the status
+// LED proves the control loop is running (a solid or dark LED means it never
+// reached the loop, or hardfaulted) — the only boot confirmation available when
+// flashing over the serial bootloader with no debug probe attached.
+//
+// This is portable and host-tested; the register-level LED write is the target-
+// only status_led_stm32 driver.
+
+#include <cstdint>
+
+namespace r2::application {
+
+// Square wave: true for the first half_period counts, false for the next
+// half_period, repeating. `counter` increments once per control cycle and
+// `half_period` sets the on/off duration in cycles. A zero half_period yields a
+// constant false (disabled). Because the loop is not yet paced by a real time
+// base, the blink rate is approximate — its purpose is presence, not precision.
+[[nodiscard]] constexpr bool heartbeat_on(std::uint32_t counter,
+                                          std::uint32_t half_period) noexcept {
+    if (half_period == 0U) {
+        return false;
+    }
+    return ((counter / half_period) & 1U) == 0U;
+}
+
+}  // namespace r2::application

--- a/firmware/rosmaster-r2/firmware/include/r2/application/status_led_stm32.hpp
+++ b/firmware/rosmaster-r2/firmware/include/r2/application/status_led_stm32.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+// Minimal STM32F103 status-LED driver — the first concrete #967 HAL seam.
+//
+// Drives PC13 (the status LED per hal/board_manifest.hpp, active-low). It is a
+// safe GPIO output — an LED, no actuation path — used only as the bring-up
+// image's sign of life. Register-level and target-only (compiled into the
+// firmware image targets, not the host build). If the board's LED turns out not
+// to be on PC13, this is the one place to change.
+
+namespace r2::application {
+
+// Enable the GPIOC clock and configure PC13 as a push-pull output. Call once
+// before the control loop.
+void status_led_init() noexcept;
+
+// Set the LED state (active-low is handled here: `on` drives PC13 low).
+void status_led_write(bool on) noexcept;
+
+}  // namespace r2::application

--- a/firmware/rosmaster-r2/firmware/src/main_target.cpp
+++ b/firmware/rosmaster-r2/firmware/src/main_target.cpp
@@ -14,8 +14,12 @@
 
 #include "r2/application/configuration.hpp"
 #include "r2/application/control_loop.hpp"
+#include "r2/application/heartbeat.hpp"
 #include "r2/application/runner.hpp"
 #include "r2/application/safe_hal.hpp"
+#include "r2/application/status_led_stm32.hpp"
+
+#include <cstdint>
 
 namespace {
 
@@ -23,6 +27,11 @@ namespace {
 // frozen, so run_cycle uses this nominal dt); a real image paces the loop from
 // a hardware timer and derives dt from a live monotonic clock.
 constexpr double kNominalDtSeconds = 0.001;  // 1 kHz
+
+// Status-LED blink half-period, in control cycles. Without a real time base the
+// loop free-runs, so this is an approximate rate — the point is a visible blink
+// (loop alive) versus a solid/dark LED (never reached the loop, or hardfaulted).
+constexpr std::uint32_t kHeartbeatHalfPeriodCycles = 250U;
 
 }  // namespace
 
@@ -43,8 +52,18 @@ extern "C" int r2_app_main() {
     static r2::application::Application app{safe_hal.bundle(), config};
     app.initialize();
 
+    // Sign of life: a blinking status LED proves the control loop is running.
+    // This is the only boot confirmation available when flashing over the serial
+    // bootloader with no debug probe attached. The LED is an observability output
+    // only — it does not gate or influence the safety loop.
+    r2::application::status_led_init();
+
     r2::application::RunnerState runner;
+    std::uint32_t heartbeat_counter = 0U;
     for (;;) {
         r2::application::run_cycle(app, safe_hal.clock, runner, kNominalDtSeconds);
+        r2::application::status_led_write(
+            r2::application::heartbeat_on(heartbeat_counter, kHeartbeatHalfPeriodCycles));
+        ++heartbeat_counter;
     }
 }

--- a/firmware/rosmaster-r2/firmware/src/status_led_stm32.cpp
+++ b/firmware/rosmaster-r2/firmware/src/status_led_stm32.cpp
@@ -1,0 +1,43 @@
+#include "r2/application/status_led_stm32.hpp"
+
+#include <cstdint>
+
+namespace r2::application {
+namespace {
+
+// STM32F103 register addresses (RM0008).
+constexpr std::uintptr_t kRccApb2Enr = 0x4002'1018U;  // RCC_APB2ENR
+constexpr std::uintptr_t kGpioCCrh = 0x4001'1004U;    // GPIOC_CRH (pins 8..15)
+constexpr std::uintptr_t kGpioCBsrr = 0x4001'1010U;   // GPIOC_BSRR (atomic set)
+constexpr std::uintptr_t kGpioCBrr = 0x4001'1014U;    // GPIOC_BRR  (atomic reset)
+
+constexpr std::uint32_t kIopcEn = 1U << 4U;  // RCC_APB2ENR IOPCEN
+
+// PC13 config lives in CRH bits [23:20]: MODE13 = 0b10 (output, 2 MHz),
+// CNF13 = 0b00 (general-purpose push-pull).
+constexpr std::uint32_t kPc13CfgShift = 20U;
+constexpr std::uint32_t kPc13CfgMask = 0xFU << kPc13CfgShift;
+constexpr std::uint32_t kPc13Cfg = 0x2U << kPc13CfgShift;
+constexpr std::uint32_t kPc13Bit = 1U << 13U;
+
+[[nodiscard]] volatile std::uint32_t& reg(std::uintptr_t address) noexcept {
+    return *reinterpret_cast<volatile std::uint32_t*>(address);
+}
+
+}  // namespace
+
+void status_led_init() noexcept {
+    reg(kRccApb2Enr) = reg(kRccApb2Enr) | kIopcEn;
+    reg(kGpioCCrh) = (reg(kGpioCCrh) & ~kPc13CfgMask) | kPc13Cfg;
+}
+
+void status_led_write(const bool on) noexcept {
+    // Active-low: LED on = drive PC13 low (BRR), off = drive high (BSRR).
+    if (on) {
+        reg(kGpioCBrr) = kPc13Bit;
+    } else {
+        reg(kGpioCBsrr) = kPc13Bit;
+    }
+}
+
+}  // namespace r2::application

--- a/firmware/rosmaster-r2/firmware/src/status_led_stm32.cpp
+++ b/firmware/rosmaster-r2/firmware/src/status_led_stm32.cpp
@@ -27,8 +27,15 @@ constexpr std::uint32_t kPc13Bit = 1U << 13U;
 }  // namespace
 
 void status_led_init() noexcept {
-    reg(kRccApb2Enr) = reg(kRccApb2Enr) | kIopcEn;
-    reg(kGpioCCrh) = (reg(kGpioCCrh) & ~kPc13CfgMask) | kPc13Cfg;
+    // Read-modify-write each register through a single volatile read and a single
+    // volatile write (no repeated MMIO accesses in one expression).
+    std::uint32_t apb2enr = reg(kRccApb2Enr);
+    apb2enr |= kIopcEn;
+    reg(kRccApb2Enr) = apb2enr;
+
+    std::uint32_t crh = reg(kGpioCCrh);
+    crh = (crh & ~kPc13CfgMask) | kPc13Cfg;
+    reg(kGpioCCrh) = crh;
 }
 
 void status_led_write(const bool on) noexcept {

--- a/firmware/rosmaster-r2/tests/test_main.cpp
+++ b/firmware/rosmaster-r2/tests/test_main.cpp
@@ -1,5 +1,6 @@
 #include "r2/application/configuration.hpp"
 #include "r2/application/control_loop.hpp"
+#include "r2/application/heartbeat.hpp"
 #include "r2/application/runner.hpp"
 #include "r2/application/safe_hal.hpp"
 #include "r2/boot/image_verifier.hpp"
@@ -1426,6 +1427,22 @@ void test_safe_hal_immobilized() {
            r2::safety::bit(r2::safety::Fault::emergency_stop)) != 0U);
 }
 
+// heartbeat_on (#967): square-wave blink phase — on for half_period, off for the
+// next half_period, repeating; zero half_period is disabled (always off).
+void test_heartbeat() {
+    using r2::application::heartbeat_on;
+    constexpr std::uint32_t hp = 250U;
+    CHECK(heartbeat_on(0U, hp));            // start of the ON half
+    CHECK(heartbeat_on(hp - 1U, hp));       // still ON at the edge
+    CHECK(!heartbeat_on(hp, hp));           // first OFF count
+    CHECK(!heartbeat_on((2U * hp) - 1U, hp));
+    CHECK(heartbeat_on(2U * hp, hp));       // back ON after a full period
+    CHECK(!heartbeat_on(3U * hp, hp));
+    // Disabled: a zero half-period never turns the LED on.
+    CHECK(!heartbeat_on(0U, 0U));
+    CHECK(!heartbeat_on(12345U, 0U));
+}
+
 }  // namespace
 
 int main() {
@@ -1446,6 +1463,7 @@ int main() {
     test_control_loop_gating();
     test_application_runner();
     test_safe_hal_immobilized();
+    test_heartbeat();
     if (failures != 0) {
         std::fprintf(stderr, "%d test assertion(s) failed\n", failures);
         return 1;


### PR DESCRIPTION
## Summary

First concrete **#967 driver seam**, and the thing that makes the probe-free bring-up actually verifiable. When flashing over the STM32 serial bootloader with **no debug probe**, the silent `SafeHal` image gave no way to tell whether it booted or hardfaulted (there's no GDB, and the image has no I/O by design). This adds a **visible sign of life** — a blinking status LED.

- **`firmware/src/status_led_stm32.{hpp,cpp}`** — the first real HAL driver: a register-level STM32F103 GPIO output on **PC13** (the status LED per `board_manifest.hpp`, active-low). A *safe* output — an LED, no actuation path.
- **`firmware/include/r2/application/heartbeat.hpp`** — pure, host-tested `heartbeat_on(counter, half_period)` (square wave: on for `half_period` cycles, off for the next, repeating).
- **`main_target.cpp`** — init the LED, drive `heartbeat_on()` each loop iteration. The LED is **observability only** — it never gates or influences the safety loop.
- **CMake** — `status_led_stm32.cpp` builds into both image targets (via the shared `r2_add_firmware_image` function).
- **`docs/MCU_BRINGUP_DRILL.md`** — §4b "confirm via LED" (blink = alive; solid/dark = fault) and §4c the serial-bootloader flash path (`stm32flash`) with a **back-up-first** warning, since flashing erases the factory firmware.

## Semantics

- **LED blinking** → reset path + runtime init + control loop all ran; the image is looping in the latched-safe state. **Boot confirmed.**
- **LED solid/dark** → never reached the loop (hardfault, or wrong vector table / SP).

## Verification

Host build + `ctest` (incl. new `test_heartbeat`), deterministic sim, clang-tidy, cppcheck all green (`check.sh` RC=0). Both target images cross-compile; bring-up image now **~31.6 KiB flash** (of 256 KiB). The register poke is target-only and build/size-verified — not run on silicon here (that's the board owner's LED, next).

Blink rate is approximate (the loop isn't paced by a real time base yet — judge presence, not precision). If a board's LED isn't on PC13, it's a one-line change in `status_led_stm32.cpp`.

Part of #967 — the first of the seam-by-seam driver bring-up (non-actuating seams first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_