### PR TITLE
feat(robot): R2 Path-B Ackermann last-hop as a pure, host-tested module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1073,6 +1073,13 @@ jobs:
           # harness drives the REAL publisher/consumer main() through the
           # signal-shutdown paths; an unguarded second rclpy.shutdown() fails it.
           python3 robot/teardown_smoke_test.py
+          # R2 Path-B Ackermann last-hop (pure translation, no hardware): the
+          # verify-gated set_car_motion swap becomes set_motor + AKM steering,
+          # doing the Ackermann kinematics + measured calibration in our code.
+          # Fail-closed calibration validation (no path starts on a guessed
+          # profile), geometry/sign/clamps, MRC on non-finite/spin-in-place.
+          # See robot/r2_drive.py + docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md.
+          python3 robot/r2_drive_test.py
           # Detecting-installer contract (R2 golden build): detect/verify/install
           # are fail-closed (wrong car-type mode, unknown platform, missing
           # devices all refuse with remediation) and SELECT-NOT-INFER holds (the

--- a/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
+++ b/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
@@ -1,4 +1,4 @@
-# R2 Path-B Ackermann drive — proposal (review before any code / robot testing)
+# R2 Path-B Ackermann drive — proposal (pure core landed + host-tested; INERT — review before consumer wiring / robot testing)
 
 > **Status: PROPOSAL. The pure translation core is implemented + host-tested;
 > it is INERT — no consumer wiring, no calibration, nothing has driven the

--- a/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
+++ b/docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md
@@ -1,11 +1,24 @@
 # R2 Path-B Ackermann drive — proposal (review before any code / robot testing)
 
-> **Status: PROPOSAL. No code is wired and nothing here has driven the robot.**
-> This is the design for an open-source R2 drive that bypasses the (broken, on
-> this cross-labeled X3 image) firmware `set_car_motion` kinematics and instead
-> drives the two rear motors directly + steers the servo, doing the Ackermann
-> math in KIRRA-governed code. Written for review; the calibration gaps in §5
-> MUST be measured on the bench before this can drive correctly.
+> **Status: PROPOSAL. The pure translation core is implemented + host-tested;
+> it is INERT — no consumer wiring, no calibration, nothing has driven the
+> robot.** This is the design for an open-source R2 drive that bypasses the
+> (broken, on this cross-labeled X3 image) firmware `set_car_motion` kinematics
+> and instead drives the two rear motors directly + steers the servo, doing the
+> Ackermann math in KIRRA-governed code. Written for review; the calibration
+> gaps in §5 MUST be measured on the bench before this can drive correctly.
+>
+> **Slice 1 landed (this is now real code, still inert):** the L1 Ackermann
+> geometry + L2 calibration + fail-closed last-hop of §§3-7 is implemented as a
+> PURE module, `robot/r2_drive.py` (`translate(v, omega, cal) -> R2Actuation`),
+> with exhaustive host tests (`robot/r2_drive_test.py`, in the CI robot smoke
+> step). It does NO serial I/O and imports no ROS/vendor lib, so it is
+> host-verified without a robot. It is NOT called by the consumer yet, and
+> `R2DriveCalibration` REFUSES construction on any missing/invalid field — so
+> with the §5 measurements still open, no profile can be built and the path
+> cannot run. What remains before it drives: the §5 bench calibration, the §6
+> consumer wiring (swap the verify-gated last hop + set car-type 5 at init),
+> and the §9 sign-offs.
 
 ## 1. Why Path B
 
@@ -157,10 +170,13 @@ but in our code.** It does NOT relax the safety architecture:
   profile (`robot/install/PLATFORM_R2_PENDING.md`). The interceptor wheelbase cross-check
   (`ros2_ws/.../cmd_vel_interceptor.py`) uses `L` from that profile.
 
-## 7. Reference algorithm (illustrative — NOT wired)
+## 7. Reference algorithm (now realized as a pure module)
 
-Pseudocode for review only; not committed as runnable code, and inert until §5 is
-measured and §6 re-validated.
+Slice 1 committed this as real, host-tested code: `robot/r2_drive.py`
+(`translate(v, omega, cal) -> R2Actuation`) + `robot/r2_drive_test.py`. It is
+still INERT — the consumer does not call it (§6 wiring pending) and no
+`R2DriveCalibration` can be built until §5 is measured (the dataclass fails
+closed on any missing field). The pseudocode below matches the module 1:1.
 
 ```
 # Inputs: v (m/s), omega (rad/s) — ALREADY governed/bounded by KIRRA upstream.
@@ -206,9 +222,11 @@ def mrc_stop():
 - **Open-loop vs encoder-closed-loop** speed (m/s tracking vs PWM proportional).
   Open-loop v0 will not perfectly track a `m/s` command (§ probe: ~12% wheel
   mismatch at equal PWM) — acceptable for low-speed v0, or close the loop.
-- **Where the Ackermann translation lives** — in `kirra_motor_consumer.py` (one
-  swapped last-hop, simplest) vs a small dedicated `r2_drive` module the consumer
-  calls. Either keeps the verify gate ahead of it.
+- **Where the Ackermann translation lives** — RESOLVED (slice 1): a small
+  dedicated pure module, `robot/r2_drive.py`, that the consumer will call after
+  verify. Chosen over inlining in `kirra_motor_consumer.py` so the translation
+  is host-testable in isolation (the ADR-0033 chokepoint stays thin). The verify
+  gate remains ahead of it. The remaining §9 items below are still open.
 - **`v=0, ω≠0` policy** — confirmed as an upstream KIRRA refusal + last-hop MRC
   (Ackermann cannot execute it).
 

--- a/robot/r2_drive.py
+++ b/robot/r2_drive.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""R2 Path-B Ackermann last-hop translation (PURE, no hardware).
+
+This is the R2 *doer* last-hop from the Path-B proposal
+(`docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md` §§3-7): it turns an
+already-governed twist `(v, omega)` into the raw vendor actuation for the
+Yahboom R2 chassis — two rear motors via `set_motor(pwm,0,0,pwm)` plus the
+front servo via `set_akm_steering_angle(cmd)` — doing the Ackermann kinematics
+(L1) and the measured calibration (L2) in verifiable code instead of the
+firmware mixer (which this cross-labeled X3 image does not implement for R2).
+
+WHY THIS MODULE IS PURE. It performs NO serial I/O and imports NO ROS / vendor
+library. It takes a twist and a calibration profile and returns a typed
+`R2Actuation` decision; the caller (`kirra_motor_consumer.py`, the ADR-0033
+verify chokepoint) applies that decision to the motor board AFTER the Rust
+verify core has released the command. The verify gate stays ahead of this — the
+same place the X3 firmware mixing runs after verify. Keeping the translation
+pure is what lets it be host-tested exhaustively (`robot/r2_drive_test.py`)
+without a robot.
+
+NO INVENTED CONSTANTS. Every physical value (wheelbase, PWM↔speed slope,
+command-units per radian, max road-wheel angle, steering sign, centre trim) is a
+field of `R2DriveCalibration`, which the operator populates from bench
+measurements (`robot/r2_drive_calibration_results.txt`). The dataclass validates
+every field and REFUSES construction (raises `R2CalibrationError`) if any is
+missing / non-finite / out of range — so the R2 drive path cannot start on
+guessed numbers. Until the §5 calibration gaps are measured, no profile can be
+built and the path stays inert. This is the "measure, do not invent" discipline
+of the proposal made structural.
+
+FAIL-CLOSED. A non-finite command, or a `v≈0 & |omega|>eps` command (spin in
+place — not Ackermann-achievable), yields an MRC stop
+(`set_motor(0,0,0,0)` + centre), never an unbounded actuation. A legitimate
+commanded zero (`v≈0 & omega≈0`) yields a plain stop (wheels 0, steer centred),
+distinct from an MRC fault.
+
+Scope of v0 (per proposal §4/§9, the reviewed defaults):
+- Equal-PWM rear drive (no Ackermann rear-speed differential; that needs the
+  rear track `t`, a later refinement). Both rear channels get the same PWM.
+- Open-loop PWM (no encoder speed-matching). The two rear wheels differ ~28% in
+  ticks/s at equal PWM (calibration Phase A), so v0 does not perfectly track a
+  `m/s` command — acceptable for low-speed v0; closing the loop is §9.
+- Proportional PWM (`pwm = v / v_per_pwm`); the measured deadband is a later
+  refinement (`drive_deadband_pwm`, default 0 → the reviewed §7 form).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+# Stopped-speed epsilon. Mirrors the codebase-wide Degraded STOP_EPSILON_MPS
+# (0.05 m/s) used by the decel-to-stop gate — the same "is the vehicle at rest"
+# threshold, not a new tuned value.
+STOP_EPS_MPS = 0.05
+
+# Rotation-while-stopped detection tolerance (rad/s). A NUMERICAL guard for the
+# not-Ackermann-achievable case (v≈0, omega≠0), not a physical calibration: any
+# commanded yaw above this while stopped is a fault → MRC. KIRRA also refuses
+# such a command upstream (proposal §4); this is the last-hop backstop.
+OMEGA_EPS_RPS = 1e-3
+
+# The vendor steering command envelope: set_akm_steering_angle takes [-45, +45]
+# command units about the servo centre (proposal §2/§4). Fixed by the vendor
+# library, not a calibration.
+STEER_CMD_LIMIT = 45
+
+
+class R2CalibrationError(ValueError):
+    """A calibration profile field is missing, non-finite, or out of range.
+
+    Raised by `R2DriveCalibration` construction — fail-closed: the R2 drive
+    path must abort rather than run on an incomplete/guessed profile.
+    """
+
+
+def _finite(x: object) -> bool:
+    return isinstance(x, (int, float)) and math.isfinite(float(x))
+
+
+def _iround(x: float) -> int:
+    """Round to nearest int, ties away from zero (sign-symmetric for reverse)."""
+    return int(math.floor(abs(x) + 0.5)) * (1 if x >= 0.0 else -1)
+
+
+def _clamp(x: float, lo: float, hi: float) -> float:
+    return lo if x < lo else hi if x > hi else x
+
+
+@dataclass(frozen=True)
+class R2DriveCalibration:
+    """Measured Path-B calibration (proposal §5). Every field is bench-measured;
+    none is invented. Construction fails closed on any invalid field.
+
+    Fields:
+        wheelbase_m:          L, rear-to-front axle distance (m). > 0.
+        v_per_pwm:            PWM↔speed slope, (m/s) per PWM unit. > 0.
+        pwm_max:              max |PWM| this deployment commands. (0, 100].
+        steer_units_per_rad:  K, servo command-units per radian of road-wheel
+                              angle. > 0.
+        delta_max_rad:        max road-wheel angle at full lock (rad). (0, pi/2).
+        steer_sign:           +1 or -1 — which command sign steers LEFT (omega>0).
+                              Bench-verified (proposal §4 sign check).
+        center_trim:          set_akm_default_angle value for physical straight
+                              ahead. [60, 120]. Applied ONCE by the consumer at
+                              init (not per-command); carried here for the profile.
+        drive_deadband_pwm:   optional PWM offset added to |pwm| when moving, to
+                              cross the motor deadband. >= 0. Default 0.0 → the
+                              reviewed §7 proportional form.
+    """
+
+    wheelbase_m: float
+    v_per_pwm: float
+    pwm_max: float
+    steer_units_per_rad: float
+    delta_max_rad: float
+    steer_sign: float
+    center_trim: float
+    drive_deadband_pwm: float = 0.0
+
+    def __post_init__(self) -> None:
+        for name in (
+            "wheelbase_m",
+            "v_per_pwm",
+            "pwm_max",
+            "steer_units_per_rad",
+            "delta_max_rad",
+            "steer_sign",
+            "center_trim",
+            "drive_deadband_pwm",
+        ):
+            if not _finite(getattr(self, name)):
+                raise R2CalibrationError(f"{name} must be a finite number")
+        if self.wheelbase_m <= 0.0:
+            raise R2CalibrationError("wheelbase_m must be > 0")
+        if self.v_per_pwm <= 0.0:
+            raise R2CalibrationError("v_per_pwm must be > 0")
+        if not (0.0 < self.pwm_max <= 100.0):
+            raise R2CalibrationError("pwm_max must be in (0, 100]")
+        if self.steer_units_per_rad <= 0.0:
+            raise R2CalibrationError("steer_units_per_rad must be > 0")
+        if not (0.0 < self.delta_max_rad < math.pi / 2.0):
+            raise R2CalibrationError("delta_max_rad must be in (0, pi/2)")
+        if self.steer_sign not in (-1.0, 1.0):
+            raise R2CalibrationError("steer_sign must be exactly +1.0 or -1.0")
+        if not (60.0 <= self.center_trim <= 120.0):
+            raise R2CalibrationError("center_trim must be in [60, 120]")
+        if self.drive_deadband_pwm < 0.0:
+            raise R2CalibrationError("drive_deadband_pwm must be >= 0")
+
+
+@dataclass(frozen=True)
+class R2Actuation:
+    """The raw actuation decision the consumer applies after verify.
+
+    is_mrc:    True → a fail-closed minimum-risk-condition stop (a FAULT).
+               False → a normal actuation (which may itself be a commanded zero).
+    reason:    short tag: "ok", "stopped", or the MRC fault cause.
+    pwm_left:  set_motor s1 (M1 = rear-left), signed PWM %.
+    pwm_right: set_motor s4 (M4 = rear-right), signed PWM %.
+    steer_cmd: set_akm_steering_angle argument, [-45, +45] command units.
+    """
+
+    is_mrc: bool
+    reason: str
+    pwm_left: int
+    pwm_right: int
+    steer_cmd: int
+
+
+def mrc_stop(reason: str) -> R2Actuation:
+    """A fail-closed stop: both rear motors 0, steering centred."""
+    return R2Actuation(is_mrc=True, reason=reason, pwm_left=0, pwm_right=0, steer_cmd=0)
+
+
+def translate(v: float, omega: float, cal: R2DriveCalibration) -> R2Actuation:
+    """Turn a governed twist (v m/s, omega rad/s) into R2 raw actuation.
+
+    Inputs are ALREADY bounded by KIRRA upstream. This layer is the exact
+    Ackermann geometry + measured calibration + a fail-closed backstop; it does
+    NOT re-open the safety envelope. See proposal §§3-7.
+    """
+    # Fail-closed: reject non-finite before any arithmetic.
+    if not (_finite(v) and _finite(omega)):
+        return mrc_stop("non_finite_command")
+
+    at_rest = abs(v) <= STOP_EPS_MPS
+
+    # Spin-in-place is not Ackermann-achievable → MRC (a car cannot rotate about
+    # its own centre). KIRRA refuses this upstream; this is the last-hop backstop.
+    if at_rest and abs(omega) > OMEGA_EPS_RPS:
+        return mrc_stop("spin_in_place_not_achievable")
+
+    # A legitimate commanded zero: wheels stopped, steering centred. Distinct
+    # from an MRC fault (is_mrc=False) so the caller/telemetry can tell a
+    # commanded halt from a fault stop.
+    if at_rest:
+        return R2Actuation(is_mrc=False, reason="stopped", pwm_left=0, pwm_right=0, steer_cmd=0)
+
+    # L1 — steering geometry. Bicycle model: tan(delta) = L * (omega / v).
+    # Using the curvature ratio makes the sign correct for either travel
+    # direction. Clamp to the measured full-lock angle.
+    delta = math.atan(cal.wheelbase_m * omega / v)
+    delta = _clamp(delta, -cal.delta_max_rad, cal.delta_max_rad)
+
+    # L2 — steering calibration: radians → servo command units, apply the
+    # bench-verified sign, clamp to the vendor [-45, +45] envelope.
+    steer_cmd = _iround(cal.steer_sign * cal.steer_units_per_rad * delta)
+    steer_cmd = int(_clamp(float(steer_cmd), -STEER_CMD_LIMIT, STEER_CMD_LIMIT))
+
+    # L2 — drive calibration: m/s → PWM (proportional v0 + optional measured
+    # deadband). Equal PWM on both rear channels (no differential in v0).
+    pwm_mag = abs(v) / cal.v_per_pwm + cal.drive_deadband_pwm
+    pwm = _iround(math.copysign(pwm_mag, v))
+    pwm = int(_clamp(float(pwm), -cal.pwm_max, cal.pwm_max))
+
+    return R2Actuation(is_mrc=False, reason="ok", pwm_left=pwm, pwm_right=pwm, steer_cmd=steer_cmd)

--- a/robot/r2_drive.py
+++ b/robot/r2_drive.py
@@ -75,6 +75,11 @@ class R2CalibrationError(ValueError):
 
 
 def _finite(x: object) -> bool:
+    # Reject bool explicitly: it subclasses int, so without this a YAML/JSON
+    # mistake like `wheelbase_m: true` would pass as 1.0 and slip through the
+    # range checks — weakening the fail-closed calibration validation.
+    if isinstance(x, bool):
+        return False
     return isinstance(x, (int, float)) and math.isfinite(float(x))
 
 

--- a/robot/r2_drive_test.py
+++ b/robot/r2_drive_test.py
@@ -79,6 +79,11 @@ def test_calibration_rejects_bad_fields() -> None:
         dict(center_trim=121.0),
         dict(drive_deadband_pwm=-0.1),
         dict(drive_deadband_pwm=float("nan")),
+        # bool subclasses int — a YAML/JSON `true` must NOT pass as 1.0.
+        dict(wheelbase_m=True),
+        dict(v_per_pwm=True),
+        dict(steer_sign=True),
+        dict(pwm_max=False),
     ]
     for override in bad_cases:
         try:

--- a/robot/r2_drive_test.py
+++ b/robot/r2_drive_test.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Host tests for the R2 Path-B Ackermann last-hop (`robot/r2_drive.py`).
+
+Pure and hardware-free by construction — the module does no serial I/O and
+imports no ROS/vendor library, so its geometry, calibration and fail-closed
+behaviour are exercised exhaustively on a plain host (this is why the
+translation was kept out of the consumer). Runs as a standalone script like the
+other robot smoke tests (`python3 robot/r2_drive_test.py`, exit 1 on any
+failure); also importable under pytest (each `test_*` asserts).
+
+Covers: fail-closed calibration validation (no path starts on a bad/guessed
+profile), Ackermann geometry + sign, all clamps, equal-PWM v0, reverse, and the
+MRC / commanded-stop split.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from r2_drive import (  # noqa: E402
+    STEER_CMD_LIMIT,
+    R2CalibrationError,
+    R2DriveCalibration,
+    mrc_stop,
+    translate,
+)
+
+
+def _valid_cal(**overrides) -> R2DriveCalibration:
+    """A structurally-valid profile for tests. The NUMBERS ARE TEST FIXTURES,
+    not measured hardware values — the real profile comes from the bench
+    (`r2_drive_calibration_results.txt`); these just exercise the math."""
+    base = dict(
+        wheelbase_m=1.0,
+        v_per_pwm=0.02,
+        pwm_max=100.0,
+        steer_units_per_rad=40.0,
+        delta_max_rad=1.0,  # > pi/4 so the exact case below does not clamp
+        steer_sign=1.0,
+        center_trim=90.0,
+        drive_deadband_pwm=0.0,
+    )
+    base.update(overrides)
+    return R2DriveCalibration(**base)
+
+
+# --------------------------------------------------------------------------
+# Calibration validation — fail-closed on any missing/invalid field.
+# --------------------------------------------------------------------------
+
+def test_calibration_accepts_valid() -> None:
+    cal = _valid_cal()
+    assert cal.wheelbase_m == 1.0
+
+
+def test_calibration_rejects_bad_fields() -> None:
+    bad_cases = [
+        dict(wheelbase_m=0.0),
+        dict(wheelbase_m=-1.0),
+        dict(wheelbase_m=float("nan")),
+        dict(v_per_pwm=0.0),
+        dict(v_per_pwm=-0.01),
+        dict(v_per_pwm=float("inf")),
+        dict(pwm_max=0.0),
+        dict(pwm_max=100.1),
+        dict(pwm_max=-5.0),
+        dict(steer_units_per_rad=0.0),
+        dict(steer_units_per_rad=-1.0),
+        dict(delta_max_rad=0.0),
+        dict(delta_max_rad=math.pi / 2.0),  # not strictly less than pi/2
+        dict(delta_max_rad=2.0),
+        dict(steer_sign=0.0),
+        dict(steer_sign=2.0),
+        dict(steer_sign=0.5),
+        dict(center_trim=59.0),
+        dict(center_trim=121.0),
+        dict(drive_deadband_pwm=-0.1),
+        dict(drive_deadband_pwm=float("nan")),
+    ]
+    for override in bad_cases:
+        try:
+            _valid_cal(**override)
+        except R2CalibrationError:
+            continue
+        raise AssertionError(f"calibration accepted invalid field: {override}")
+
+
+# --------------------------------------------------------------------------
+# Geometry + calibration — the happy path.
+# --------------------------------------------------------------------------
+
+def test_straight_is_centered_and_equal_pwm() -> None:
+    cal = _valid_cal()
+    out = translate(0.5, 0.0, cal)
+    assert not out.is_mrc and out.reason == "ok"
+    assert out.steer_cmd == 0
+    assert out.pwm_left == out.pwm_right
+    assert out.pwm_left > 0
+
+
+def test_exact_hand_computed_case() -> None:
+    # L=1, v=1, omega=1 -> delta=atan(1)=pi/4; K=40 -> 40*pi/4=31.4159 -> 31.
+    # v_per_pwm=0.02 -> pwm=1/0.02=50.
+    cal = _valid_cal()
+    out = translate(1.0, 1.0, cal)
+    assert out.pwm_left == 50 and out.pwm_right == 50
+    assert out.steer_cmd == 31, out.steer_cmd
+
+
+def test_steer_sign_selects_left_direction() -> None:
+    # omega>0 (left / CCW). steer_sign flips which command sign is "left".
+    left_neg = translate(1.0, 1.0, _valid_cal(steer_sign=-1.0))
+    left_pos = translate(1.0, 1.0, _valid_cal(steer_sign=1.0))
+    assert left_neg.steer_cmd == -31
+    assert left_pos.steer_cmd == 31
+    # Right turn (omega<0) is the mirror.
+    right_pos = translate(1.0, -1.0, _valid_cal(steer_sign=-1.0))
+    assert right_pos.steer_cmd == 31
+
+
+def test_delta_clamped_to_full_lock() -> None:
+    # Huge omega saturates delta to delta_max before the unit conversion.
+    cal = _valid_cal(delta_max_rad=0.5, steer_units_per_rad=50.0)  # 50*0.5=25 < 45
+    out = translate(0.5, 1000.0, cal)
+    assert out.steer_cmd == 25, out.steer_cmd
+
+
+def test_steer_cmd_clamped_to_envelope() -> None:
+    # K*delta_max exceeds the vendor [-45,45] envelope -> clamp.
+    cal = _valid_cal(delta_max_rad=0.5, steer_units_per_rad=200.0)  # 200*0.5=100
+    out = translate(0.5, 1000.0, cal)
+    assert out.steer_cmd == STEER_CMD_LIMIT == 45
+    out_r = translate(0.5, -1000.0, cal)
+    assert out_r.steer_cmd == -45
+
+
+def test_pwm_clamped_to_max() -> None:
+    cal = _valid_cal(v_per_pwm=0.02, pwm_max=100.0)  # 5.0/0.02 = 250 -> 100
+    out = translate(5.0, 0.0, cal)
+    assert out.pwm_left == 100 and out.pwm_right == 100
+
+
+def test_reverse_is_symmetric() -> None:
+    cal = _valid_cal()
+    fwd = translate(1.0, 0.0, cal)
+    rev = translate(-1.0, 0.0, cal)
+    assert rev.pwm_left == -fwd.pwm_left
+    assert rev.pwm_right == -fwd.pwm_right
+
+
+def test_deadband_offsets_pwm() -> None:
+    # Same speed, a measured deadband adds to |pwm|.
+    plain = translate(1.0, 0.0, _valid_cal(drive_deadband_pwm=0.0))
+    dead = translate(1.0, 0.0, _valid_cal(drive_deadband_pwm=5.0))
+    assert dead.pwm_left == plain.pwm_left + 5
+
+
+# --------------------------------------------------------------------------
+# Fail-closed.
+# --------------------------------------------------------------------------
+
+def test_non_finite_is_mrc() -> None:
+    cal = _valid_cal()
+    for v, w in ((float("nan"), 0.0), (0.5, float("inf")), (float("inf"), float("nan"))):
+        out = translate(v, w, cal)
+        assert out.is_mrc and out.reason == "non_finite_command"
+        assert out.pwm_left == 0 and out.pwm_right == 0 and out.steer_cmd == 0
+
+
+def test_spin_in_place_is_mrc() -> None:
+    cal = _valid_cal()
+    out = translate(0.0, 1.0, cal)
+    assert out.is_mrc and out.reason == "spin_in_place_not_achievable"
+    out2 = translate(0.01, -0.5, cal)  # within STOP_EPS, real yaw commanded
+    assert out2.is_mrc and out2.reason == "spin_in_place_not_achievable"
+
+
+def test_commanded_zero_is_plain_stop_not_mrc() -> None:
+    cal = _valid_cal()
+    out = translate(0.0, 0.0, cal)
+    assert not out.is_mrc and out.reason == "stopped"
+    assert out.pwm_left == 0 and out.pwm_right == 0 and out.steer_cmd == 0
+
+
+def test_mrc_stop_helper() -> None:
+    out = mrc_stop("whatever")
+    assert out.is_mrc and out.pwm_left == 0 and out.pwm_right == 0 and out.steer_cmd == 0
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok   {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"  FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failures += 1
+            print(f"  ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    print("r2_drive host tests (pure, no hardware):")
+    sys.exit(_run_all())


### PR DESCRIPTION
## Summary

Slice 1 of **Path B** (`docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md`): the R2 drive path that bypasses the broken firmware `set_car_motion` mixer (this unit runs the cross-labeled X3 image, which never implements the type-5 Ackermann drive) and instead drives the two rear motors directly + steers the servo, doing the Ackermann kinematics in KIRRA-governed code.

This slice realizes the **L1 geometry + L2 calibration + fail-closed last-hop** of the proposal (§§3–7) as a **pure, host-tested module**. It is **inert**: no consumer wiring, no calibration profile, nothing drives the robot.

## What's in this PR

- **`robot/r2_drive.py`** — `translate(v, omega, cal) -> R2Actuation`. Turns an already-governed twist into the raw vendor actuation: `set_motor(pwm,0,0,pwm)` (M1=rear-left, M4=rear-right, both `+`=forward per the PR #911 bench probe) + `set_akm_steering_angle(cmd)`. Bicycle model `δ = atan(L·ω/v)`, m/s→PWM and rad→command-unit conversions, clamped to the vendor `[-45,+45]` / PWM envelopes.
- **`robot/r2_drive_test.py`** — 14 host tests (calibration validation, geometry + sign, all clamps, equal-PWM v0, reverse, MRC / commanded-stop split). Added to the robot smoke-test CI step; runs as a standalone script and under pytest.
- **`docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md`** — status updated to record slice 1 landed (still inert); §7 now points at the real module; the §9 "where the translation lives" decision resolved to a dedicated module.

## Safety properties held

1. **No invented constants.** Every physical value (wheelbase, PWM↔speed slope, command-units/rad, full-lock angle, steering sign, centre trim) is a required field of `R2DriveCalibration`, which fails closed (`R2CalibrationError`) on any missing/non-finite/out-of-range field. With the §5 bench calibration still open, no profile can be built and the path cannot run — the "measure, don't invent" rule is now structural.
2. **Verify chokepoint unchanged (ADR-0033).** The module does no serial I/O and imports no ROS/vendor lib; the consumer will apply its output only *after* the Rust verify core releases the command. This PR does **not** modify the live consumer, so the X3 path is byte-identical.
3. **Fail-closed.** Non-finite command or a spin-in-place (`v≈0, |ω|>eps`, not Ackermann-achievable) → MRC stop; a legitimate commanded zero → plain stop, distinguished from an MRC fault.

## Not in this PR (still gated)

- §5 bench calibration (both rear wheels' PWM↔m/s, steering protractor sweep + sign check under car-type 5, centre trim, wheelbase re-confirm).
- §6 consumer wiring (swap the verify-gated last hop + set car-type 5 at init). This touches the ADR-0033 chokepoint and the proposal marks it for human review — deliberately a separate, reviewed slice, not auto-merged.
- The remaining §9 sign-offs (equal-PWM vs differential, open- vs closed-loop).

## Test

```
python3 robot/r2_drive_test.py   # 14/14 passed
python3 -m pytest robot/r2_drive_test.py -q   # 14 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_