### PR TITLE
fix(persistence): fail-closed negative-timestamp reads across both backends

### DIFF
--- a/crates/kirra-persistence/src/cert_principals.rs
+++ b/crates/kirra-persistence/src/cert_principals.rs
@@ -135,8 +135,8 @@ impl VerifierStore {
         Ok(CertPrincipalRecord {
             principal_id: row.get(0)?,
             role: row.get(1)?,
-            created_at_ms: row.get::<_, i64>(2)? as u64,
-            revoked_at_ms: row.get::<_, Option<i64>>(3)?.map(|v| v as u64),
+            created_at_ms: row.get::<_, i64>(2)?.max(0) as u64,
+            revoked_at_ms: row.get::<_, Option<i64>>(3)?.map(|v| v.max(0) as u64),
             // FAIL-CLOSED read (Copilot #857): a NEGATIVE stored `not_after_ms` (only
             // reachable via corruption/tamper — the write path refuses > i64::MAX)
             // maps to `Some(0)` = "expired at epoch", so `is_expired(now)` is true for

--- a/crates/kirra-persistence/src/nodes.rs
+++ b/crates/kirra-persistence/src/nodes.rs
@@ -4,6 +4,21 @@
 use super::*;
 
 impl VerifierStore {
+    /// TEST-ONLY: overwrite a node's stored `registered_at_ms` BIGINT with an
+    /// arbitrary raw value (e.g. a NEGATIVE one that the type-safe `u64` API can
+    /// never produce) to exercise the fail-closed read heal — a corrupt/tampered
+    /// negative timestamp must read back as `0`, never a wrapped huge `u64`.
+    /// Never compiled into production builds.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn force_node_registered_at_ms_for_test(&self, node_id: &str, raw: i64) {
+        self.conn
+            .execute(
+                "UPDATE nodes SET registered_at_ms = ?1 WHERE node_id = ?2",
+                params![raw, node_id],
+            )
+            .expect("test seam: force node registered_at_ms");
+    }
+
     pub fn save_node(&self, node: &RegisteredNode) -> Result<()> {
         let status_json =
             serde_json::to_string(&node.status).map_err(|_| rusqlite::Error::InvalidQuery)?;
@@ -43,8 +58,8 @@ impl VerifierStore {
             Ok(RegisteredNode {
                 node_id: row.get(0)?,
                 status,
-                registered_at_ms: row.get::<_, i64>(2)? as u64,
-                last_trust_update_ms: row.get::<_, i64>(3)? as u64,
+                registered_at_ms: row.get::<_, i64>(2)?.max(0) as u64,
+                last_trust_update_ms: row.get::<_, i64>(3)?.max(0) as u64,
                 ak_public_pem: row.get(4)?,
                 expected_pcr16_digest_hex: row.get(5)?,
                 site: row.get(6)?,
@@ -74,8 +89,8 @@ impl VerifierStore {
                     Ok(RegisteredNode {
                         node_id: row.get(0)?,
                         status,
-                        registered_at_ms: row.get::<_, i64>(2)? as u64,
-                        last_trust_update_ms: row.get::<_, i64>(3)? as u64,
+                        registered_at_ms: row.get::<_, i64>(2)?.max(0) as u64,
+                        last_trust_update_ms: row.get::<_, i64>(3)?.max(0) as u64,
                         ak_public_pem: row.get(4)?,
                         expected_pcr16_digest_hex: row.get(5)?,
                         site: row.get(6)?,

--- a/crates/kirra-persistence/src/operators.rs
+++ b/crates/kirra-persistence/src/operators.rs
@@ -126,8 +126,8 @@ impl VerifierStore {
                     Ok(OperatorRecord {
                         operator_id: row.get(0)?,
                         pubkey_pem: row.get(1)?,
-                        registered_at_ms: row.get::<_, i64>(2)? as u64,
-                        revoked_at_ms: row.get::<_, Option<i64>>(3)?.map(|v| v as u64),
+                        registered_at_ms: row.get::<_, i64>(2)?.max(0) as u64,
+                        revoked_at_ms: row.get::<_, Option<i64>>(3)?.map(|v| v.max(0) as u64),
                     })
                 },
             )
@@ -145,8 +145,8 @@ impl VerifierStore {
             Ok(OperatorRecord {
                 operator_id: row.get(0)?,
                 pubkey_pem: row.get(1)?,
-                registered_at_ms: row.get::<_, i64>(2)? as u64,
-                revoked_at_ms: row.get::<_, Option<i64>>(3)?.map(|v| v as u64),
+                registered_at_ms: row.get::<_, i64>(2)?.max(0) as u64,
+                revoked_at_ms: row.get::<_, Option<i64>>(3)?.map(|v| v.max(0) as u64),
             })
         })?;
         rows.collect()
@@ -201,7 +201,7 @@ impl VerifierStore {
                         rowid: row.get(0)?,
                         node_id: row.get(1)?,
                         operator_id: row.get(2)?,
-                        granted_at_ms: row.get::<_, i64>(3)? as u64,
+                        granted_at_ms: row.get::<_, i64>(3)?.max(0) as u64,
                     })
                 },
             )
@@ -255,8 +255,8 @@ impl VerifierStore {
                 params![node_id],
                 |row| {
                     Ok(ClearanceGrantState {
-                        granted_at_ms: row.get::<_, i64>(0)? as u64,
-                        consumed_at_ms: row.get::<_, Option<i64>>(1)?.map(|v| v as u64),
+                        granted_at_ms: row.get::<_, i64>(0)?.max(0) as u64,
+                        consumed_at_ms: row.get::<_, Option<i64>>(1)?.map(|v| v.max(0) as u64),
                         outcome: row.get(2)?,
                         outcome_detail: row.get(3)?,
                     })

--- a/crates/kirra-persistence/src/principals.rs
+++ b/crates/kirra-persistence/src/principals.rs
@@ -76,8 +76,8 @@ impl VerifierStore {
         Ok(ApiPrincipalRecord {
             principal_id: row.get(0)?,
             role: row.get(1)?,
-            created_at_ms: row.get::<_, i64>(2)? as u64,
-            revoked_at_ms: row.get::<_, Option<i64>>(3)?.map(|v| v as u64),
+            created_at_ms: row.get::<_, i64>(2)?.max(0) as u64,
+            revoked_at_ms: row.get::<_, Option<i64>>(3)?.map(|v| v.max(0) as u64),
         })
     }
 }

--- a/crates/kirra-persistence/src/tests.rs
+++ b/crates/kirra-persistence/src/tests.rs
@@ -410,6 +410,36 @@ mod standby_store_tests {
     }
 
     #[test]
+    fn test_negative_stored_timestamp_heals_to_zero() {
+        // Fail-closed read discipline: a corrupt/tampered NEGATIVE BIGINT
+        // timestamp (impossible via the u64 API, only via direct SQL) must read
+        // back as 0 — never wrap to a huge u64. The `.max(0)` guard on the
+        // registered_at_ms read path. The live-Postgres backend applies the
+        // byte-identical `.max(0)` guard (PgVerifierStore::row_to_node), kept in
+        // lock-step so both backends heal negative timestamps the same way.
+        let store = in_memory();
+        store
+            .save_node(&RegisteredNode {
+                node_id: "n1".into(),
+                status: NodeTrustState::Trusted,
+                registered_at_ms: 1_000,
+                last_trust_update_ms: 1_000,
+                ak_public_pem: None,
+                expected_pcr16_digest_hex: None,
+                site: None,
+                firmware_version: None,
+            })
+            .unwrap();
+        // Corrupt the stored timestamp to a negative BIGINT.
+        store.force_node_registered_at_ms_for_test("n1", -5);
+        let loaded = store.load_node("n1").unwrap().expect("node present");
+        assert_eq!(
+            loaded.registered_at_ms, 0,
+            "a negative stored timestamp must heal to 0, not wrap to a huge u64"
+        );
+    }
+
+    #[test]
     fn test_posture_event_analytics_queries() {
         // #396: window/group queries return the expected rows.
         let store = in_memory();

--- a/crates/kirra-verifier-pg/src/cert_principals.rs
+++ b/crates/kirra-verifier-pg/src/cert_principals.rs
@@ -10,8 +10,8 @@ impl PgVerifierStore {
         CertPrincipalRecord {
             principal_id: row.get(0),
             role: row.get(1),
-            created_at_ms: row.get::<_, i64>(2) as u64,
-            revoked_at_ms: row.get::<_, Option<i64>>(3).map(|v| v as u64),
+            created_at_ms: row.get::<_, i64>(2).max(0) as u64,
+            revoked_at_ms: row.get::<_, Option<i64>>(3).map(|v| v.max(0) as u64),
             // FAIL-CLOSED read (matches the SQLite backend, Copilot #857): a NEGATIVE
             // stored `not_after_ms` — only reachable via corruption, since the write
             // path refuses `> i64::MAX` — maps to `Some(0)` ("expired at epoch"), so a

--- a/crates/kirra-verifier-pg/src/lib.rs
+++ b/crates/kirra-verifier-pg/src/lib.rs
@@ -453,8 +453,8 @@ impl PgVerifierStore {
         RegisteredNode {
             node_id: row.get(0),
             status,
-            registered_at_ms: row.get::<_, i64>(2) as u64,
-            last_trust_update_ms: row.get::<_, i64>(3) as u64,
+            registered_at_ms: row.get::<_, i64>(2).max(0) as u64,
+            last_trust_update_ms: row.get::<_, i64>(3).max(0) as u64,
             ak_public_pem: row.get(4),
             expected_pcr16_digest_hex: row.get(5),
             site: row.get(6),

--- a/crates/kirra-verifier-pg/src/operators.rs
+++ b/crates/kirra-verifier-pg/src/operators.rs
@@ -10,8 +10,8 @@ impl PgVerifierStore {
         OperatorRecord {
             operator_id: row.get(0),
             pubkey_pem: row.get(1),
-            registered_at_ms: row.get::<_, i64>(2) as u64,
-            revoked_at_ms: row.get::<_, Option<i64>>(3).map(|v| v as u64),
+            registered_at_ms: row.get::<_, i64>(2).max(0) as u64,
+            revoked_at_ms: row.get::<_, Option<i64>>(3).map(|v| v.max(0) as u64),
         }
     }
 }

--- a/crates/kirra-verifier-pg/src/principals.rs
+++ b/crates/kirra-verifier-pg/src/principals.rs
@@ -10,8 +10,8 @@ impl PgVerifierStore {
         ApiPrincipalRecord {
             principal_id: row.get(0),
             role: row.get(1),
-            created_at_ms: row.get::<_, i64>(2) as u64,
-            revoked_at_ms: row.get::<_, Option<i64>>(3).map(|v| v as u64),
+            created_at_ms: row.get::<_, i64>(2).max(0) as u64,
+            revoked_at_ms: row.get::<_, Option<i64>>(3).map(|v| v.max(0) as u64),
         }
     }
 }

--- a/crates/kirra-verifier-pg/tests/live_pg.rs
+++ b/crates/kirra-verifier-pg/tests/live_pg.rs
@@ -287,6 +287,33 @@ fn a_corrupt_status_json_loads_as_unknown_not_a_panic() {
 }
 
 #[test]
+fn a_negative_stored_timestamp_heals_to_zero() {
+    let Some((url, schema, store)) = isolated_store("negts") else {
+        return;
+    };
+    let mut c = raw_client_in_schema(&url, &schema);
+    // A corrupt/tampered NEGATIVE BIGINT timestamp (the type-safe u64 API can
+    // never write one) must read back as 0 — never wrap to a huge u64. This is
+    // the byte-identical `.max(0)` guard the SQLite backend applies
+    // (test_negative_stored_timestamp_heals_to_zero there), kept in lock-step.
+    c.execute(
+        "INSERT INTO nodes (node_id, status_json, registered_at_ms, last_trust_update_ms) \
+         VALUES ('negts', '\"Trusted\"', -5, -9)",
+        &[],
+    )
+    .unwrap();
+    let n = store.load_node("negts").unwrap().unwrap();
+    assert_eq!(
+        n.registered_at_ms, 0,
+        "negative registered_at_ms must heal to 0"
+    );
+    assert_eq!(
+        n.last_trust_update_ms, 0,
+        "negative last_trust_update_ms must heal to 0"
+    );
+}
+
+#[test]
 fn two_connections_racing_the_cas_produce_exactly_one_winner() {
     // The drill only a LIVE server can run honestly: two independent
     // connections (two OS-level sessions) observe epoch 0 and claim


### PR DESCRIPTION
## Summary

Follow-up to the #980 review (the `u64`↔`i64` timestamp-cast discipline Copilot flagged). A corrupt/tampered **negative** `BIGINT` timestamp — which the type-safe `u64` API can never write, only direct SQL / corruption can — was read back via `as u64`, **wrapping to a huge `u64`** instead of failing closed. This guards every such read with `.max(0)` (the idiom already used in `fabric.rs`) so a negative stored timestamp **heals to 0**.

## Applied symmetrically (parity preserved)

Only to the seams where **both** backends use the identical inline `row.get::<_, i64>(N) as u64` form — the node/operator/principal/cert-principal row-mappers — so the two backends stay byte-parity identical:

- **SQLite** (`kirra-persistence`): `nodes`, `operators`, `principals`, `cert_principals`
- **PG** (`kirra-verifier-pg`): `row_to_node` (`lib.rs`), `operators`, `principals`, `cert_principals`

## Deliberate scope boundaries

- The `epoch` / `ota_campaigns` / `av_subsystem` / `posture` seams read these values through **heterogeneous forms** (local-var vs inline) that differ between the two backends. Hardening them on one side only would introduce the very PG↔SQLite asymmetry this is meant to prevent, so they're **left untouched** here for a dedicated symmetric pass. (This was caught during implementation — an initial blanket sweep hardened SQLite's epoch/ota/av/posture but not PG's, and was reverted.)
- The **write** side (`u64 > i64::MAX`) is left as-is: unreachable for real timestamps, and the read guard already heals any wrapped value to 0.

## Non-vacuity — a negative-timestamp test on **each** backend

- **SQLite** — `tests.rs::test_negative_stored_timestamp_heals_to_zero`, plus a `test-support`-gated `force_node_registered_at_ms_for_test` seam (mirroring `break_audit_chain_table_for_test`).
- **PG** — `live_pg.rs::a_negative_stored_timestamp_heals_to_zero` (runs in the `postgres-conformance` lane).

Both store a negative `BIGINT` via raw SQL and assert it reads back as `0`.

## Verification

SQLite: 166 tests pass (incl. the new one); PG tests compile (skip without `KIRRA_PG_URL`); root crate (`kirra-verifier`, via the `verifier_store` shim) builds; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_