### PR TITLE
R2 §9: RR-channel confirm + closed-loop speed-matching core

### DIFF
--- a/robot/install/env.template
+++ b/robot/install/env.template
@@ -94,3 +94,29 @@ KIRRA_R2_STEER_SIGN=-1              # MEASURED — a NEGATIVE command steers LEF
 KIRRA_R2_CENTER_TRIM=90             # MEASURED — set_akm_default_angle for physical straight
 KIRRA_R2_DRIVE_DEADBAND_PWM=0       # CHOSEN — 0 = proportional (reviewed v0). (Bench saw a physical
                                     # deadband ~5 PWM; this configured 0 is the v0 choice, not that measurement.)
+
+# ---------------------------------------------------------------------------
+# R2 Path-B CLOSED-LOOP speed matching (proposal §9) — OFF by default.
+#
+# The RR-channel confirm (robot/r2_drive_calibration_results.txt) proved the two
+# rear wheels differ ~34% in speed at equal PWM AND that the imbalance is
+# session-variable — so equal-PWM open-loop drifts and a fixed per-wheel trim
+# won't hold; but both encoders are trustworthy + identically scaled. The opt-in
+# controller (r2_drive.speed_match_step / ClosedLoopSpeedMatcher) trims each rear
+# wheel's PWM toward the SAME governed target speed. Fail-closed + envelope-
+# respecting (setpoint is the governed |v| ceiling; PWM capped + slew-limited; a
+# stalled wheel → MRC).
+#
+# STATUS: the PURE controller + host tests have landed; the consumer encoder-read
+# wiring is the NEXT slice and the gains are NOT yet hardware-tuned. Leave OFF
+# until closed-loop is validated on the bench (elevated first).
+#KIRRA_R2_CLOSED_LOOP=1
+# Measured (from the RR confirm); required when the flag is on:
+KIRRA_R2_M_PER_TICK=0.00025101      # MEASURED — encoder scale (m/tick); RL 66.675mm wheel / 834.5 t/rev
+KIRRA_R2_V_PER_PWM_RIGHT=0.0194     # MEASURED — RR feedforward slope (m/s)/PWM (RL slope is KIRRA_R2_V_PER_PWM)
+# Controller gains — CONSERVATIVE DEFAULTS, not yet hardware-tuned (optional):
+#KIRRA_R2_SPEED_KP=20               # PWM per (m/s error)
+#KIRRA_R2_SPEED_MAX_PWM_STEP=5      # per-cycle slew cap on each wheel's PWM
+#KIRRA_R2_SPEED_STALL_CYCLES=5      # under-response cycles before an MRC fault
+#KIRRA_R2_SPEED_STALL_MIN_PWM=10    # "commanding real effort" threshold
+#KIRRA_R2_SPEED_STALL_MIN_MPS=0.02  # "not moving" threshold

--- a/robot/r2_drive.py
+++ b/robot/r2_drive.py
@@ -37,9 +37,13 @@ distinct from an MRC fault.
 Scope of v0 (per proposal §4/§9, the reviewed defaults):
 - Equal-PWM rear drive (no Ackermann rear-speed differential; that needs the
   rear track `t`, a later refinement). Both rear channels get the same PWM.
-- Open-loop PWM (no encoder speed-matching). The two rear wheels differ ~28% in
-  ticks/s at equal PWM (calibration Phase A), so v0 does not perfectly track a
-  `m/s` command — acceptable for low-speed v0; closing the loop is §9.
+- Open-loop PWM by default (no encoder speed-matching). The two rear wheels
+  differ ~34% in ticks/s at equal PWM (calibration Phase A + RR confirm), so the
+  open-loop path does not perfectly track a `m/s` command — acceptable for the
+  tethered low-speed v0. Closing the loop (§9) is now available as an OPT-IN
+  controller (`speed_match_step` / `ClosedLoopSpeedMatcher`, below): per-wheel
+  encoder speed-matching toward the SAME governed target, fail-closed and
+  envelope-respecting. It is a separate, gated path — `translate` is unchanged.
 - Proportional PWM (`pwm = v / v_per_pwm`); the measured deadband is a later
   refinement (`drive_deadband_pwm`, default 0 → the reviewed §7 form).
 """
@@ -292,3 +296,281 @@ def r2_safe_stop(bot) -> None:
     """
     bot.set_motor(0, 0, 0, 0)
     bot.set_akm_steering_angle(0)
+
+
+# ==========================================================================
+# Closed-loop per-wheel speed matching (proposal §9, the beyond-tethered path).
+#
+# WHY. The RR-channel confirm (r2_drive_calibration_results.txt) proved the two
+# rear wheels differ ~34% in speed at equal PWM AND that the imbalance is
+# session-variable — so equal-PWM open-loop drifts, and a FIXED per-wheel PWM
+# trim would not hold. It also proved both encoders are trustworthy and
+# IDENTICALLY scaled (RR 825.6 vs RL 834.5 ticks/rev), which is exactly what a
+# speed-matching controller needs. This closes the loop: each rear wheel's PWM is
+# trimmed toward the SAME governed target ground speed, so the platform tracks
+# straight regardless of per-wheel drift.
+#
+# FAIL-CLOSED + ENVELOPE-RESPECTING (never re-opens the safety envelope):
+#   * The controlled SETPOINT is the governed target speed |v| — a ceiling KIRRA
+#     already bounds. The loop only redistributes PWM to HIT it, never raises it.
+#   * Each wheel's PWM is hard-capped at pwm_max and slew-limited per cycle.
+#   * Pure P + per-wheel feedforward (no integral) → no windup / no slow ramp to
+#     an unsafe command.
+#   * A wheel commanded real PWM but not moving (encoder ~0) for stall_cycles
+#     consecutive cycles → a FAULT the caller turns into an MRC stop — never
+#     ramp-to-max on a stuck/faulted wheel.
+#   * Non-finite feedback (target / encoder / clock) → fault, and the matcher
+#     resets so a stale delta can never drive the next cycle.
+#
+# STILL PURE where it counts: `speed_match_step` is a pure function of
+# (target, measured speeds, params, state). `ClosedLoopSpeedMatcher` adds only
+# the encoder-delta / dt bookkeeping. Both are host-tested without a robot.
+#
+# GAINS ARE NOT YET HARDWARE-TUNED. The defaults are conservative and every gain
+# is env-tunable; closing the loop on hardware (ELEVATED first) is the validation
+# step. This module lands the algorithm + its fail-closed behaviour; the consumer
+# encoder-read wiring behind KIRRA_R2_CLOSED_LOOP is the next slice.
+# ==========================================================================
+
+# Max control period (s) between encoder samples for a valid speed estimate. A
+# longer gap (a paused loop, or the first cycle) → treat as a fresh start:
+# command feedforward-only that cycle, never trust a stale/huge delta.
+CLOSED_LOOP_MAX_DT_S = 0.5
+
+# Conservative controller defaults (env-overridable). NOT hardware-tuned.
+DEFAULT_SPEED_KP = 20.0            # PWM per (m/s of speed error)
+DEFAULT_MAX_PWM_STEP = 5.0         # per-cycle slew cap on each wheel's PWM
+DEFAULT_STALL_CYCLES = 5           # consecutive under-response cycles → fault
+DEFAULT_STALL_MIN_PWM = 10.0       # "commanding real effort" threshold
+DEFAULT_STALL_MIN_MPS = 0.02       # "not moving" threshold
+
+
+@dataclass(frozen=True)
+class SpeedMatchParams:
+    """Closed-loop controller calibration + gains. Fail-closed on any bad field.
+
+    m_per_tick:        encoder scale (m/tick), > 0 — converts ticks/s → m/s.
+    v_per_pwm_left:    RL feedforward slope, (m/s)/PWM, > 0.
+    v_per_pwm_right:   RR feedforward slope, (m/s)/PWM, > 0.
+    kp_pwm_per_mps:    proportional gain, PWM per (m/s error), >= 0.
+    pwm_max:           per-wheel |PWM| cap, (0, 100].
+    max_pwm_step:      per-cycle slew cap on each wheel's PWM, > 0.
+    stall_cycles:      consecutive under-response cycles before a fault, int >= 1.
+    stall_min_pwm:     |PWM| at/above which a non-moving wheel counts as stalled, >= 0.
+    stall_min_mps:     |speed| below which a wheel counts as "not moving", >= 0.
+    """
+
+    m_per_tick: float
+    v_per_pwm_left: float
+    v_per_pwm_right: float
+    kp_pwm_per_mps: float
+    pwm_max: float
+    max_pwm_step: float
+    stall_cycles: int
+    stall_min_pwm: float
+    stall_min_mps: float
+
+    def __post_init__(self) -> None:
+        for name in (
+            "m_per_tick",
+            "v_per_pwm_left",
+            "v_per_pwm_right",
+            "kp_pwm_per_mps",
+            "pwm_max",
+            "max_pwm_step",
+            "stall_min_pwm",
+            "stall_min_mps",
+        ):
+            if not _finite(getattr(self, name)):
+                raise R2CalibrationError(f"{name} must be a finite number")
+        if self.m_per_tick <= 0.0:
+            raise R2CalibrationError("m_per_tick must be > 0")
+        if self.v_per_pwm_left <= 0.0 or self.v_per_pwm_right <= 0.0:
+            raise R2CalibrationError("v_per_pwm_left/right must be > 0")
+        if self.kp_pwm_per_mps < 0.0:
+            raise R2CalibrationError("kp_pwm_per_mps must be >= 0")
+        if not (0.0 < self.pwm_max <= 100.0):
+            raise R2CalibrationError("pwm_max must be in (0, 100]")
+        if self.max_pwm_step <= 0.0:
+            raise R2CalibrationError("max_pwm_step must be > 0")
+        # stall_cycles is a count — reject bool (subclasses int) and < 1.
+        if isinstance(self.stall_cycles, bool) or not isinstance(self.stall_cycles, int) or self.stall_cycles < 1:
+            raise R2CalibrationError("stall_cycles must be an int >= 1")
+        if self.stall_min_pwm < 0.0 or self.stall_min_mps < 0.0:
+            raise R2CalibrationError("stall_min_pwm/stall_min_mps must be >= 0")
+
+
+@dataclass
+class SpeedMatchState:
+    """Mutable controller state carried between cycles (per-wheel PWM + stall)."""
+
+    pwm_left: float = 0.0
+    pwm_right: float = 0.0
+    stall_left: int = 0
+    stall_right: int = 0
+
+
+def _match_one(target_v: float, meas_v: float, prev_pwm: float, v_per_pwm_side: float, p: SpeedMatchParams) -> float:
+    # Per-wheel feedforward toward the governed target + a proportional trim on
+    # the measured error, slew-limited around the previous command, then hard-
+    # capped at pwm_max. The setpoint is |target_v| (a ceiling); P has no integral
+    # so it cannot wind up past it.
+    ff = target_v / v_per_pwm_side
+    raw = ff + p.kp_pwm_per_mps * (target_v - meas_v)
+    raw = _clamp(raw, prev_pwm - p.max_pwm_step, prev_pwm + p.max_pwm_step)
+    return _clamp(raw, -p.pwm_max, p.pwm_max)
+
+
+def speed_match_step(
+    target_v: float,
+    meas_v_left: float,
+    meas_v_right: float,
+    params: SpeedMatchParams,
+    state: SpeedMatchState,
+):
+    """One closed-loop control step (PURE apart from mutating `state`).
+
+    Returns `(pwm_left:int, pwm_right:int, fault:str|None)`. On a fault the PWMs
+    are `(0, 0)` — the caller applies an MRC stop. Non-finite feedback and a
+    per-wheel stall are the two fault causes. `target_v` is the governed signed
+    speed (the caller has already handled the at-rest / MRC cases via `translate`).
+    """
+    if not (_finite(target_v) and _finite(meas_v_left) and _finite(meas_v_right)):
+        return 0, 0, "non_finite_feedback"
+
+    pl = _match_one(target_v, meas_v_left, state.pwm_left, params.v_per_pwm_left, params)
+    pr = _match_one(target_v, meas_v_right, state.pwm_right, params.v_per_pwm_right, params)
+
+    def _bump(count: int, pwm: float, meas: float) -> int:
+        # A wheel commanding real effort but not moving is stalling — count it;
+        # any real motion (or no real command) resets the counter.
+        if abs(pwm) >= params.stall_min_pwm and abs(meas) < params.stall_min_mps:
+            return count + 1
+        return 0
+
+    state.stall_left = _bump(state.stall_left, pl, meas_v_left)
+    state.stall_right = _bump(state.stall_right, pr, meas_v_right)
+    state.pwm_left = pl
+    state.pwm_right = pr
+
+    if state.stall_left >= params.stall_cycles:
+        return 0, 0, "wheel_stall_left"
+    if state.stall_right >= params.stall_cycles:
+        return 0, 0, "wheel_stall_right"
+    return _iround(pl), _iround(pr), None
+
+
+class ClosedLoopSpeedMatcher:
+    """Encoder-fed wrapper around `speed_match_step`.
+
+    The consumer feeds RAW cumulative encoder counts + a monotonic timestamp each
+    control cycle; this computes per-wheel ground speeds (Δticks · m_per_tick / dt)
+    and runs the pure step. The FIRST valid cycle (or any cycle after a stale/
+    invalid interval) has no trustworthy speed estimate → it commands
+    FEEDFORWARD-ONLY and seeds the state, so the next cycle's slew is relative to
+    the feedforward, not 0. Fail-closed: non-finite input resets and faults.
+    """
+
+    def __init__(self, params: SpeedMatchParams) -> None:
+        self.params = params
+        self.state = SpeedMatchState()
+        self._prev = None  # (enc_left, enc_right, now_s) or None
+
+    def reset(self) -> None:
+        """Drop the prior sample + zero the controller (call on stop / MRC / fault)."""
+        self.state = SpeedMatchState()
+        self._prev = None
+
+    def _feedforward(self, target_v: float):
+        p = self.params
+        pl = _clamp(target_v / p.v_per_pwm_left, -p.pwm_max, p.pwm_max)
+        pr = _clamp(target_v / p.v_per_pwm_right, -p.pwm_max, p.pwm_max)
+        self.state.pwm_left = pl
+        self.state.pwm_right = pr
+        self.state.stall_left = 0
+        self.state.stall_right = 0
+        return _iround(pl), _iround(pr), None
+
+    def step(self, target_v: float, enc_left: float, enc_right: float, now_s: float):
+        """Advance one cycle. Returns `(pwm_left:int, pwm_right:int, fault:str|None)`."""
+        if not (_finite(target_v) and _finite(enc_left) and _finite(enc_right) and _finite(now_s)):
+            self.reset()
+            return 0, 0, "non_finite_feedback"
+        prev = self._prev
+        self._prev = (enc_left, enc_right, now_s)
+        if prev is None:
+            return self._feedforward(target_v)
+        dt = now_s - prev[2]
+        # A non-positive or too-large interval yields no trustworthy speed → treat
+        # as a fresh start (feedforward-only), never divide by / trust it.
+        if not (dt > 0.0) or dt > CLOSED_LOOP_MAX_DT_S:
+            return self._feedforward(target_v)
+        meas_v_left = (enc_left - prev[0]) * self.params.m_per_tick / dt
+        meas_v_right = (enc_right - prev[1]) * self.params.m_per_tick / dt
+        return speed_match_step(target_v, meas_v_left, meas_v_right, self.params, self.state)
+
+
+# Closed-loop env vars. The enable flag is read by the consumer; the params come
+# from the measured RR confirm (left slope reuses the open-loop KIRRA_R2_V_PER_PWM).
+ENV_CLOSED_LOOP_ENABLE = "KIRRA_R2_CLOSED_LOOP"
+_ENV_CL_M_PER_TICK = "KIRRA_R2_M_PER_TICK"
+_ENV_CL_V_PER_PWM_RIGHT = "KIRRA_R2_V_PER_PWM_RIGHT"
+_ENV_CL_KP = "KIRRA_R2_SPEED_KP"
+_ENV_CL_MAX_STEP = "KIRRA_R2_SPEED_MAX_PWM_STEP"
+_ENV_CL_STALL_CYCLES = "KIRRA_R2_SPEED_STALL_CYCLES"
+_ENV_CL_STALL_MIN_PWM = "KIRRA_R2_SPEED_STALL_MIN_PWM"
+_ENV_CL_STALL_MIN_MPS = "KIRRA_R2_SPEED_STALL_MIN_MPS"
+
+
+def closed_loop_enabled(env) -> bool:
+    """True iff KIRRA_R2_CLOSED_LOOP is set truthy (1/true/yes/on)."""
+    raw = env.get(ENV_CLOSED_LOOP_ENABLE)
+    return raw is not None and str(raw).strip().lower() in ("1", "true", "yes", "on")
+
+
+def speed_match_params_from_env(env, cal: R2DriveCalibration) -> SpeedMatchParams:
+    """Build `SpeedMatchParams` from env + the loaded `cal`, fail-closed.
+
+    Required (measured): KIRRA_R2_M_PER_TICK, KIRRA_R2_V_PER_PWM_RIGHT. The LEFT
+    slope reuses `cal.v_per_pwm` (KIRRA_R2_V_PER_PWM) and pwm_max reuses
+    `cal.pwm_max`. Gains are optional (conservative defaults; NOT hardware-tuned).
+    """
+
+    def _req_float(var: str) -> float:
+        raw = env.get(var)
+        if raw is None or str(raw).strip() == "":
+            raise R2CalibrationError(f"{var} is unset — closed-loop drive requires a measured value")
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            raise R2CalibrationError(f"{var} must be a number, got {raw!r}") from None
+
+    def _opt_float(var: str, default: float) -> float:
+        raw = env.get(var)
+        if raw is None or str(raw).strip() == "":
+            return default
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            raise R2CalibrationError(f"{var} must be a number, got {raw!r}") from None
+
+    def _opt_int(var: str, default: int) -> int:
+        raw = env.get(var)
+        if raw is None or str(raw).strip() == "":
+            return default
+        try:
+            return int(str(raw).strip())
+        except (TypeError, ValueError):
+            raise R2CalibrationError(f"{var} must be an integer, got {raw!r}") from None
+
+    return SpeedMatchParams(
+        m_per_tick=_req_float(_ENV_CL_M_PER_TICK),
+        v_per_pwm_left=cal.v_per_pwm,
+        v_per_pwm_right=_req_float(_ENV_CL_V_PER_PWM_RIGHT),
+        kp_pwm_per_mps=_opt_float(_ENV_CL_KP, DEFAULT_SPEED_KP),
+        pwm_max=cal.pwm_max,
+        max_pwm_step=_opt_float(_ENV_CL_MAX_STEP, DEFAULT_MAX_PWM_STEP),
+        stall_cycles=_opt_int(_ENV_CL_STALL_CYCLES, DEFAULT_STALL_CYCLES),
+        stall_min_pwm=_opt_float(_ENV_CL_STALL_MIN_PWM, DEFAULT_STALL_MIN_PWM),
+        stall_min_mps=_opt_float(_ENV_CL_STALL_MIN_MPS, DEFAULT_STALL_MIN_MPS),
+    )

--- a/robot/r2_drive_calibration_results.txt
+++ b/robot/r2_drive_calibration_results.txt
@@ -65,12 +65,66 @@ PHASE B (encoder scale): wheel=RL
     V_PER_PWM (left) ≈ 0.0145 (m/s)/PWM,  offset -0.069 m/s,  deadband ~PWM 4.7
     (i.e. m/s ≈ 0.0145*PWM - 0.069 over 15..35; a governed 0.3 m/s -> ~27 PWM)
 
-  SCOPE: this m/s map is valid for the LEFT channel only — it uses RL's own
-  encoder scale. RR's m/s still needs RR's ticks/rev (Phase B on RR). Measuring
-  RR ALSO resolves whether the ~28% Phase-A L/R gap is real speed drift or an
-  encoder-scale difference — one capture closes both. If the two encoders prove
-  identical (same ticks/rev), the same m_per_tick applies to RR and the gap is
-  real motor drift (→ per-wheel PWM trim or closed loop, §9).
+  SCOPE: this m/s map used RL's own encoder scale. The RR confirm below now
+  closes the RR m/s map AND resolves the L/R-gap question (see "RR-CHANNEL
+  CONFIRM"): RR's ticks/rev proved ~identical to RL's, so the gap is REAL
+  drivetrain drift, not an encoder-scale artifact.
+
+------------------------------------------------------------------
+RR-CHANNEL CONFIRM (Phase A re-sweep + Phase B on RR): MEASURED 2026-07-17
+------------------------------------------------------------------
+  (robot/r2_rr_channel_results.txt; a SECOND elevated session, same script.)
+
+  PHASE B (encoder scale): wheel=RR
+    full_turns          = 5.0                (5-turn sample — finer than RL's 2)
+    delta_ticks (RR/m4) = 4128
+    ticks_per_rev (RR)  = 825.6
+    wheel_diameter      = not re-measured; RR is the SAME wheel model as RL, so
+                          RL's caliper value (0.066675 m) applies (the ticks/rev
+                          match below justifies reusing it).
+    m_per_tick (RR)     = 0.209465 / 825.6 = 0.00025371 m/tick
+
+  >>> DECISIVE RESULT — L/R gap is REAL DRIFT, not encoder scale:
+      RR ticks/rev 825.6  vs  RL ticks/rev 834.5  ->  1.07% apart (identical
+      within hand-rotation error). The encoders share a scale, so the Phase-A
+      ticks/s L/R gap is a REAL wheel-speed difference at equal PWM — NOT an
+      encoder artifact. Equal PWM does NOT drive straight open-loop.
+
+  PHASE A re-sweep (this session, both rear wheels at equal +PWM):
+    pwm   ticks/s M1(RL)  ticks/s M4(RR)   RL/RR ratio
+    15    307.5          904.4            0.34
+    20    567.7          1225.8           0.46
+    25    824.1          1579.1           0.52
+    30    1140.3         1958.3           0.58
+    35    1479.8         2380.7           0.62
+    40    1873.2         2807.2           0.67
+    RR (M4) fit: ticks/s ~= 76.3*PWM - 290   (prior session: 74.3*PWM - 293 —
+      RR is STABLE across sessions, ~75 ticks/s/PWM).
+    RL (M1) this session ran much SLOWER than the prior run (307 vs 592 ticks/s
+      at PWM 15) with a bigger deadband — i.e. the imbalance is not a fixed
+      ratio; it VARIES session-to-session (stiction / battery / load), unloaded.
+
+  DERIVED — RR ground speed = M4 ticks/s * m_per_tick(RR):
+    V_PER_PWM (RR) ~= 76.3 * 0.00025371 = 0.0194 (m/s)/PWM,  offset -0.074 m/s
+    (m/s ~= 0.0194*PWM - 0.074).  Compare RL: 0.0145 (m/s)/PWM.
+    => at equal PWM, RR runs ~34% FASTER than RL → an open-loop equal-PWM drive
+       pulls toward the slower (RL) side.
+
+  INTERPRETATION / §9 recommendation (data-backed):
+    * Elevated/unloaded numbers EXAGGERATE the drift — unloaded stiction
+      dominates (RL barely moving at low PWM). On the FLOOR under load the §8.2
+      creep was operator-confirmed STRAIGHT, so equal-PWM is acceptable for the
+      v0 TETHERED LOW-SPEED use only.
+    * A fixed per-wheel PWM trim is FRAGILE here: the imbalance is real but
+      session-variable, so a static trim won't hold. For anything beyond
+      tethered creep (faster / untethered), CLOSE THE LOOP — per-wheel encoder
+      speed-matching (both encoders are trustworthy and identically scaled,
+      which the RR confirm just established).
+    * KIRRA_R2_V_PER_PWM is currently 0.0145 (RL slope). If we want the
+      commanded m/s to be a true CEILING (neither wheel exceeds it), switch it
+      to the FASTER RR slope 0.0194 so PWM stays low enough that RR <= target
+      (RL then merely undershoots). Operator decision, pending the §8-step-3
+      sign-offs; the flag is OFF, so nothing changes until then.
 
 ------------------------------------------------------------------
 PHASE C (steering↔angle): MEASURED (protractor sweep, 2026-07-17)
@@ -138,11 +192,13 @@ PHASE C (steering↔angle): MEASURED (protractor sweep, 2026-07-17)
       watermark (NOT a hard monotonic guarantee: a backward clock step could still
       collide; a real governor persists its sequence, ADR-0033 PART 2).
 
-  STILL OPEN before the STANDING R2 config (doc §8 step 3 / §9): RR-channel
-  PWM↔m/s confirm (v0 uses the LEFT slope 0.0145 for equal-PWM drive);
+  STILL OPEN before the STANDING R2 config (doc §8 step 3 / §9):
   KIRRA_VEHICLE_CLASS=r2 contract re-validation + interceptor wheelbase=L; and the
-  §9 open decisions (equal-PWM vs rear differential, open- vs closed-loop speed).
+  §9 open decisions (equal-PWM vs rear differential, open- vs closed-loop speed) —
+  now DATA-BACKED by the RR-channel confirm above (equal-PWM acceptable for
+  tethered creep; close the loop for anything faster/untethered).
   KIRRA_DRIVE_MODE stays OFF in env.template until those land.
+  (RR-channel PWM↔m/s confirm — DONE, see "RR-CHANNEL CONFIRM" above.)
 
 ------------------------------------------------------------------
 PHASE D (geometry): NOT measured

--- a/robot/r2_drive_calibration_results.txt
+++ b/robot/r2_drive_calibration_results.txt
@@ -73,7 +73,9 @@ PHASE B (encoder scale): wheel=RL
 ------------------------------------------------------------------
 RR-CHANNEL CONFIRM (Phase A re-sweep + Phase B on RR): MEASURED 2026-07-17
 ------------------------------------------------------------------
-  (robot/r2_rr_channel_results.txt; a SECOND elevated session, same script.)
+  (Source: a SECOND elevated session with the same script, writing its raw output
+  to r2_rr_channel_results.txt ON THE UNIT — that raw file is NOT checked in; the
+  numbers below are transcribed from it into this reviewed record.)
 
   PHASE B (encoder scale): wheel=RR
     full_turns          = 5.0                (5-turn sample — finer than RL's 2)
@@ -85,10 +87,13 @@ RR-CHANNEL CONFIRM (Phase A re-sweep + Phase B on RR): MEASURED 2026-07-17
     m_per_tick (RR)     = 0.209465 / 825.6 = 0.00025371 m/tick
 
   >>> DECISIVE RESULT — L/R gap is REAL DRIFT, not encoder scale:
-      RR ticks/rev 825.6  vs  RL ticks/rev 834.5  ->  1.07% apart (identical
-      within hand-rotation error). The encoders share a scale, so the Phase-A
-      ticks/s L/R gap is a REAL wheel-speed difference at equal PWM — NOT an
-      encoder artifact. Equal PWM does NOT drive straight open-loop.
+      RR ticks/rev 825.6  vs  RL ticks/rev 834.5  ->  1.07% apart. The two
+      encoders share a scale to within ~1% (single hand-rotation samples: RR over
+      5 turns, RL over 2; the per-sample repeatability was not separately
+      quantified, but a ~1% spread is far smaller than the >30% Phase-A ticks/s
+      L/R gap, so that gap cannot be an encoder-scale artifact — it is a REAL
+      wheel-speed difference at equal PWM. Equal PWM does NOT drive straight
+      open-loop.)
 
   PHASE A re-sweep (this session, both rear wheels at equal +PWM):
     pwm   ticks/s M1(RL)  ticks/s M4(RR)   RL/RR ratio

--- a/robot/r2_drive_test.py
+++ b/robot/r2_drive_test.py
@@ -21,14 +21,21 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from r2_drive import (  # noqa: E402
+    CLOSED_LOOP_MAX_DT_S,
     STEER_CMD_LIMIT,
+    ClosedLoopSpeedMatcher,
     R2Actuation,
     R2CalibrationError,
     R2DriveCalibration,
+    SpeedMatchParams,
+    SpeedMatchState,
     apply_actuation,
     calibration_from_env,
+    closed_loop_enabled,
     mrc_stop,
     r2_safe_stop,
+    speed_match_params_from_env,
+    speed_match_step,
     translate,
 )
 
@@ -299,6 +306,197 @@ def test_r2_safe_stop_zeros_motors_and_centers() -> None:
         ("set_motor", 0, 0, 0, 0),
         ("set_akm_steering_angle", 0),
     ]
+
+
+# --------------------------------------------------------------------------
+# Closed-loop speed matcher (§9): pure controller core + fail-closed behaviour.
+# --------------------------------------------------------------------------
+
+def _valid_params(**overrides) -> SpeedMatchParams:
+    """Structurally-valid controller params (TEST FIXTURES, not measured)."""
+    base = dict(
+        m_per_tick=0.00025,
+        v_per_pwm_left=0.0145,
+        v_per_pwm_right=0.0194,
+        kp_pwm_per_mps=20.0,
+        pwm_max=40.0,
+        max_pwm_step=100.0,  # wide by default so tests see the raw control law
+        stall_cycles=5,
+        stall_min_pwm=10.0,
+        stall_min_mps=0.02,
+    )
+    base.update(overrides)
+    return SpeedMatchParams(**base)
+
+
+def test_speed_match_params_reject_bad_fields() -> None:
+    for bad in (
+        dict(m_per_tick=0.0),
+        dict(m_per_tick=-1.0),
+        dict(v_per_pwm_left=0.0),
+        dict(v_per_pwm_right=-0.1),
+        dict(kp_pwm_per_mps=-1.0),
+        dict(pwm_max=0.0),
+        dict(pwm_max=101.0),
+        dict(max_pwm_step=0.0),
+        dict(stall_cycles=0),
+        dict(stall_cycles=True),  # bool must be rejected (subclasses int)
+        dict(stall_min_pwm=-1.0),
+        dict(m_per_tick=float("nan")),
+        dict(max_pwm_step=float("inf")),
+    ):
+        try:
+            _valid_params(**bad)
+        except R2CalibrationError:
+            continue
+        raise AssertionError(f"expected R2CalibrationError for {bad}")
+
+
+def test_speed_match_slow_wheel_gets_more_pwm() -> None:
+    # Both wheels below target; the SLOWER wheel (bigger error) must get more PWM.
+    p = _valid_params()
+    st = SpeedMatchState()
+    pl, pr, fault = speed_match_step(0.30, 0.10, 0.20, p, st)
+    assert fault is None
+    assert pl > pr, f"slower left wheel should get more PWM: {pl} vs {pr}"
+
+
+def test_speed_match_feedforward_when_on_target() -> None:
+    # Zero error → command is exactly the per-wheel feedforward (target/v_per_pwm).
+    p = _valid_params()
+    st = SpeedMatchState()
+    target = 0.30
+    pl, pr, fault = speed_match_step(target, target, target, p, st)
+    assert fault is None
+    assert pl == round(target / p.v_per_pwm_left)   # ~21
+    assert pr == round(target / p.v_per_pwm_right)  # ~15
+
+
+def test_speed_match_pwm_capped() -> None:
+    # A large error cannot push PWM past pwm_max.
+    p = _valid_params(pwm_max=25.0)
+    st = SpeedMatchState()
+    pl, pr, fault = speed_match_step(0.40, 0.0, 0.0, p, st)
+    assert fault is None
+    assert abs(pl) <= 25 and abs(pr) <= 25
+
+
+def test_speed_match_slew_limited() -> None:
+    # From a zero prior command, one cycle can move each wheel at most max_pwm_step.
+    p = _valid_params(max_pwm_step=3.0)
+    st = SpeedMatchState()  # prev pwm 0
+    pl, pr, fault = speed_match_step(0.40, 0.0, 0.0, p, st)
+    assert fault is None
+    assert abs(pl) <= 3 and abs(pr) <= 3
+
+
+def test_speed_match_non_finite_feedback_faults() -> None:
+    p = _valid_params()
+    st = SpeedMatchState()
+    for tv, ml, mr in ((float("nan"), 0.1, 0.1), (0.3, float("inf"), 0.1), (0.3, 0.1, float("nan"))):
+        pl, pr, fault = speed_match_step(tv, ml, mr, p, st)
+        assert fault == "non_finite_feedback"
+        assert (pl, pr) == (0, 0)
+
+
+def test_speed_match_stall_faults_after_threshold() -> None:
+    # A wheel commanded real PWM but not moving trips a fault at stall_cycles.
+    p = _valid_params(stall_cycles=3, max_pwm_step=100.0, pwm_max=40.0)
+    st = SpeedMatchState()
+    faults = []
+    for _ in range(3):
+        _, _, f = speed_match_step(0.30, 0.0, 0.30, p, st)  # left stalled, right on target
+        faults.append(f)
+    assert faults[0] is None and faults[1] is None
+    assert faults[2] == "wheel_stall_left", faults
+
+
+def test_speed_match_motion_resets_stall() -> None:
+    p = _valid_params(stall_cycles=2, max_pwm_step=100.0)
+    st = SpeedMatchState()
+    speed_match_step(0.30, 0.0, 0.30, p, st)      # left stall count -> 1
+    assert st.stall_left == 1
+    speed_match_step(0.30, 0.30, 0.30, p, st)     # left now moving -> reset
+    assert st.stall_left == 0
+
+
+def test_matcher_first_cycle_is_feedforward_only() -> None:
+    p = _valid_params()
+    m = ClosedLoopSpeedMatcher(p)
+    pl, pr, fault = m.step(0.30, enc_left=1000, enc_right=1000, now_s=10.0)
+    assert fault is None
+    assert pl == round(0.30 / p.v_per_pwm_left)
+    assert pr == round(0.30 / p.v_per_pwm_right)
+
+
+def test_matcher_second_cycle_uses_measured_speed() -> None:
+    # RR spun far more ticks than RL over the same dt → RL (slower) gets more PWM.
+    p = _valid_params()
+    m = ClosedLoopSpeedMatcher(p)
+    m.step(0.30, enc_left=0, enc_right=0, now_s=0.0)          # seed
+    pl, pr, fault = m.step(0.30, enc_left=400, enc_right=1200, now_s=0.1)
+    assert fault is None
+    assert pl > pr, f"slower RL should be trimmed up: {pl} vs {pr}"
+
+
+def test_matcher_bad_dt_falls_back_to_feedforward() -> None:
+    p = _valid_params()
+    for now2 in (0.0, -1.0, CLOSED_LOOP_MAX_DT_S + 1.0):  # dt<=0 or too large
+        m = ClosedLoopSpeedMatcher(p)
+        m.step(0.30, 0, 0, 0.0)
+        pl, pr, fault = m.step(0.30, 9999, 9999, now2)
+        assert fault is None
+        assert pl == round(0.30 / p.v_per_pwm_left)   # feedforward, ignored the huge delta
+        assert pr == round(0.30 / p.v_per_pwm_right)
+
+
+def test_matcher_non_finite_resets_and_faults() -> None:
+    p = _valid_params()
+    m = ClosedLoopSpeedMatcher(p)
+    m.step(0.30, 100, 100, 1.0)
+    pl, pr, fault = m.step(float("nan"), 200, 200, 1.1)
+    assert fault == "non_finite_feedback" and (pl, pr) == (0, 0)
+    assert m._prev is None  # reset so a stale delta can't drive the next cycle
+
+
+def test_closed_loop_enabled_parsing() -> None:
+    for v in ("1", "true", "TRUE", "yes", "on", " On "):
+        assert closed_loop_enabled({"KIRRA_R2_CLOSED_LOOP": v}) is True
+    for v in ("0", "false", "no", "off", "", None):
+        env = {} if v is None else {"KIRRA_R2_CLOSED_LOOP": v}
+        assert closed_loop_enabled(env) is False
+    assert closed_loop_enabled({}) is False
+
+
+def test_speed_match_params_from_env_loads_and_defaults() -> None:
+    cal = _valid_cal(v_per_pwm=0.0145, pwm_max=40.0)
+    env = {"KIRRA_R2_M_PER_TICK": "0.00025", "KIRRA_R2_V_PER_PWM_RIGHT": "0.0194"}
+    p = speed_match_params_from_env(env, cal)
+    assert p.v_per_pwm_left == 0.0145   # reuses cal.v_per_pwm (the LEFT slope)
+    assert p.v_per_pwm_right == 0.0194
+    assert p.pwm_max == 40.0            # reuses cal.pwm_max
+    assert p.kp_pwm_per_mps == 20.0     # default
+    assert p.stall_cycles == 5          # default
+
+
+def test_speed_match_params_from_env_fail_closed_on_missing() -> None:
+    cal = _valid_cal()
+    for env in ({}, {"KIRRA_R2_M_PER_TICK": "0.00025"}, {"KIRRA_R2_V_PER_PWM_RIGHT": "0.0194"}):
+        try:
+            speed_match_params_from_env(env, cal)
+        except R2CalibrationError:
+            continue
+        raise AssertionError(f"expected fail-closed for {env}")
+
+
+def test_speed_match_params_from_env_rejects_nonnumeric() -> None:
+    cal = _valid_cal()
+    env = {"KIRRA_R2_M_PER_TICK": "abc", "KIRRA_R2_V_PER_PWM_RIGHT": "0.0194"}
+    try:
+        speed_match_params_from_env(env, cal)
+    except R2CalibrationError:
+        return
+    raise AssertionError("expected R2CalibrationError for non-numeric m_per_tick")
 
 
 def _run_all() -> int:


### PR DESCRIPTION
## Summary

Two tightly-coupled parts of the R2 Path-B §9 work: the RR-channel calibration capture, and the closed-loop speed-matching controller it directly calibrates. `KIRRA_R2_CLOSED_LOOP` is OFF by default — the validated §8.2 equal-PWM path is byte-identical.

## Part 1 — RR-channel confirm (`robot/r2_drive_calibration_results.txt`)

Second elevated bench session. **RR ticks/rev 825.6 vs RL 834.5 — 1.07 % apart**, so the two encoders share a scale. The Phase-A L/R gap is therefore a **real wheel-speed difference at equal PWM, not an encoder artifact** — equal PWM does not drive straight open-loop. Derived `V_PER_PWM(RR) ≈ 0.0194` vs RL `0.0145` (RR ~34 % faster); RR is stable across sessions, RL varies unloaded (stiction) — the imbalance is **session-variable**.

## Part 2 — closed-loop speed-matching core (`robot/r2_drive.py`)

The decision that data drove: for anything beyond the tethered creep, **close the loop** (a static per-wheel trim can't hold a session-variable imbalance; both encoders are proven trustworthy + identically scaled). Lands the **pure** controller:

- `speed_match_step(target_v, meas_v_left, meas_v_right, params, state)` — per-wheel feedforward toward the SAME governed target + a proportional error trim.
- `ClosedLoopSpeedMatcher` — the encoder-Δ / dt wrapper (feeds raw counts + a monotonic timestamp).

**Fail-closed + envelope-respecting:** the setpoint is the governed `|v|` ceiling (the loop redistributes PWM to hit it, never raises it); each wheel is hard-capped at `pwm_max` and slew-limited per cycle; pure-P (no integral) can't wind up; a wheel commanding real PWM but not moving for `stall_cycles` → an **MRC fault** (never ramp-to-max on a stuck wheel); non-finite feedback → fault + reset; the first / stale-dt cycle commands feedforward-only.

Gated behind `KIRRA_R2_CLOSED_LOOP` (default OFF). `env.template` documents the measured `m_per_tick` (0.00025101) + RR slope (0.0194) and the **conservative, not-yet-hardware-tuned** default gains.

## Tests

16 new host tests (feedforward, correction direction, slew, cap, stall fault, dt guards, env loader fail-closed) — **38/38 `r2_drive` tests pass**, teardown smoke **5/5** unchanged.

## Explicitly NOT in this PR (next slice)

The consumer encoder-read wiring in `kirra_motor_consumer.py` and **hardware tuning + validation** (elevated first). This lands the tested algorithm; the gains are placeholders until the bench run. `KIRRA_DRIVE_MODE` and `KIRRA_R2_CLOSED_LOOP` both stay OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr