### PR TITLE
R2 §9 closed-loop slice 2: consumer wiring + elevated tuning script

### DIFF
--- a/robot/install/env.template
+++ b/robot/install/env.template
@@ -120,3 +120,7 @@ KIRRA_R2_V_PER_PWM_RIGHT=0.0194     # MEASURED — RR feedforward slope (m/s)/PW
 #KIRRA_R2_SPEED_STALL_CYCLES=5      # under-response cycles before an MRC fault
 #KIRRA_R2_SPEED_STALL_MIN_PWM=10    # "commanding real effort" threshold
 #KIRRA_R2_SPEED_STALL_MIN_MPS=0.02  # "not moving" threshold
+#KIRRA_R2_SPEED_EMA_ALPHA=0.4       # EMA weight on new measured speed (0,1]; 1=no
+                                    # filter. Smooths aliased encoder reads before
+                                    # the P-term (the raw per-cycle speed sawtooths
+                                    # because the MCU auto-report isn't loop-locked).

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -183,6 +183,20 @@ def main() -> int:
     bot = Rosmaster(com=motor_port)
     bot.create_receive_threading()
 
+    # Closed-loop speed matching reads the wheel encoders (get_motor_encoder),
+    # which ONLY update from the MCU's auto-report frames. Enable auto-report once
+    # here, fail-closed — without it every encoder read is a stale 0, so the
+    # matcher would see a dead wheel and immediately trip a stall→MRC fault (or
+    # never converge). Open-loop paths never read encoders, so this is scoped to
+    # the closed-loop consumer only (byte-identical otherwise).
+    if r2_matcher is not None:
+        try:
+            bot.set_auto_report_state(True)
+        except Exception as e:  # noqa: BLE001 — no encoder feed → refuse to start
+            print(f"FATAL: closed-loop drive needs encoder auto-report, but "
+                  f"set_auto_report_state(True) failed: {e}", file=sys.stderr)
+            return 2
+
     def _settle_car_type() -> "int | None":
         # Read the board's car-type register with settle retries (~3 s total; the
         # register needs receive-thread settle after a car-type write). The valid

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -60,10 +60,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from kirra_ffi import KirraConsumer, REFUSAL_NAMES, split_frame  # noqa: E402
 from r2_drive import (  # noqa: E402
+    ClosedLoopSpeedMatcher,
     R2CalibrationError,
     apply_actuation,
     calibration_from_env,
+    closed_loop_enabled,
     r2_safe_stop,
+    speed_match_params_from_env,
     translate,
 )
 
@@ -144,6 +147,7 @@ def main() -> int:
     # calibration instead — fail-closed if any measured value is missing.
     expected_car_type = _req_int("KIRRA_EXPECTED_CAR_TYPE") if drive_mode == DRIVE_MODE_X3 else None
     r2_cal = None
+    r2_matcher = None  # closed-loop speed matcher (r2 mode + KIRRA_R2_CLOSED_LOOP)
     if drive_mode == DRIVE_MODE_R2:
         try:
             r2_cal = calibration_from_env(os.environ)
@@ -151,6 +155,17 @@ def main() -> int:
             print(f"FATAL: R2 drive mode requires a measured calibration "
                   f"profile: {e}", file=sys.stderr)
             return 2
+        # §9 closed-loop per-wheel speed matching — OPT-IN (default off → open-loop
+        # equal-PWM, byte-identical). Fail-closed: if the flag is on but the
+        # controller params are incomplete, refuse to start (never silently fall
+        # back to open-loop when closed-loop was requested).
+        if closed_loop_enabled(os.environ):
+            try:
+                r2_matcher = ClosedLoopSpeedMatcher(speed_match_params_from_env(os.environ, r2_cal))
+            except R2CalibrationError as e:
+                print(f"FATAL: KIRRA_R2_CLOSED_LOOP is on but its params are "
+                      f"incomplete: {e}", file=sys.stderr)
+                return 2
     topic = os.environ.get("KIRRA_RELEASE_TOPIC", "/kirra/release")
 
     # The verify core (fail-closed: raises on a NULL handle).
@@ -246,6 +261,10 @@ def main() -> int:
         f"envelope: vx_max={vx_max} m/s vz_max={vz_max} rad/s (DEMO backstop; "
         f"Kirra's checker is the authority). Vendor base node must NOT be running."
     )
+    if drive_mode == DRIVE_MODE_R2:
+        node.get_logger().info(
+            f"r2_ackermann drive: {'CLOSED-LOOP speed matching' if r2_matcher else 'open-loop equal-PWM'}"
+        )
 
     alarm_announced = False
 
@@ -255,7 +274,31 @@ def main() -> int:
             # the x3 firmware mixing runs after verify). translate() is
             # fail-closed; an MRC/stop decision carries zeros, so this same call
             # stops the platform.
-            apply_actuation(bot, translate(linear, angular, r2_cal))
+            act = translate(linear, angular, r2_cal)
+            if r2_matcher is None:
+                apply_actuation(bot, act)  # open-loop equal-PWM (default)
+                return
+            # §9 closed loop: translate() stays the safety front (non-finite /
+            # spin-in-place / at-rest all yield is_mrc or reason=="stopped" with
+            # zeros). Only when translate says "ok" do we KEEP its steer command
+            # and REPLACE the two drive PWMs with the per-wheel speed-matched ones.
+            if act.is_mrc or act.reason == "stopped":
+                apply_actuation(bot, act)  # zeros → stop; drop the loop's history
+                r2_matcher.reset()
+                return
+            enc = bot.get_motor_encoder()  # [m1(RL), m2, m3, m4(RR)]
+            pwm_left, pwm_right, fault = r2_matcher.step(
+                linear, enc[0], enc[3], time.monotonic()
+            )
+            if fault is not None:
+                # A stalled wheel / non-finite feedback → MRC stop (never keep
+                # driving a faulted loop). Reset so a stale delta can't resume it.
+                r2_safe_stop(bot)
+                r2_matcher.reset()
+                node.get_logger().warn(f"closed-loop MRC ({fault}) — motors stopped")
+                return
+            bot.set_akm_steering_angle(act.steer_cmd)
+            bot.set_motor(pwm_left, 0, 0, pwm_right)
         else:
             # x3: v_y = 0 (skid-steer demo; no lateral). linear→v_x, angular→v_z,
             # both already clamped by the Rust capture seam.

--- a/robot/r2_closed_loop_tune_elevated.py
+++ b/robot/r2_closed_loop_tune_elevated.py
@@ -80,10 +80,12 @@ def _run_pass(bot, matcher, params, target_v: float, seconds: float, rate_hz: fl
     """
     period = 1.0 / rate_hz
     m_per_tick = params.m_per_tick
-    prev = None  # (enc_left, enc_right, t) for the DISPLAY speed (matcher keeps its own)
+    prev = None  # (enc_left, enc_right, t) for the RAW display speed
     print(f"\n  target={target_v:.3f} m/s  for {seconds:.1f}s @ {rate_hz:.0f}Hz  "
-          f"(KP={params.kp_pwm_per_mps}, slew={params.max_pwm_step}, pwm_max={params.pwm_max})")
-    print("   t(s)   meas_L   meas_R   pwm_L  pwm_R   note")
+          f"(KP={params.kp_pwm_per_mps}, slew={params.max_pwm_step}, "
+          f"ema={params.ema_alpha}, pwm_max={params.pwm_max})")
+    print("  filt_* = the EMA-filtered speed the controller ACTS on; raw_* = unfiltered.")
+    print("   t(s)   filt_L   filt_R   raw_L   raw_R   pwm_L  pwm_R   note")
     t0 = time.monotonic()
     matcher.reset()
     try:
@@ -96,15 +98,19 @@ def _run_pass(bot, matcher, params, target_v: float, seconds: float, rate_hz: fl
             pwm_left, pwm_right, fault = matcher.step(target_v, enc[0], enc[3], now)
             if fault is not None:
                 bot.set_motor(0, 0, 0, 0)
-                print(f"  {elapsed:6.2f}   ----     ----     0      0     FAULT: {fault} → motors STOPPED")
+                print(f"  {elapsed:6.2f}   -----    -----    -----   -----     0      0   FAULT: {fault} → STOPPED")
                 return f"fault:{fault}"
             bot.set_motor(pwm_left, 0, 0, pwm_right)
-            # Display speed from our own delta (independent of the matcher's).
+            # filt_* is the matcher's own EMA (what the P-term saw); raw_* is our
+            # independent unfiltered delta — the gap shows the aliasing the filter removes.
             if prev is not None:
                 dt = now - prev[2]
-                mvl = (enc[0] - prev[0]) * m_per_tick / dt if dt > 0 else 0.0
-                mvr = (enc[3] - prev[1]) * m_per_tick / dt if dt > 0 else 0.0
-                print(f"  {elapsed:6.2f}  {mvl:7.3f}  {mvr:7.3f}  {pwm_left:5d}  {pwm_right:5d}")
+                rvl = (enc[0] - prev[0]) * m_per_tick / dt if dt > 0 else 0.0
+                rvr = (enc[3] - prev[1]) * m_per_tick / dt if dt > 0 else 0.0
+                fvl = matcher._ema_left if matcher._ema_left is not None else rvl
+                fvr = matcher._ema_right if matcher._ema_right is not None else rvr
+                print(f"  {elapsed:6.2f}  {fvl:7.3f}  {fvr:7.3f}  {rvl:6.3f}  {rvr:6.3f}  "
+                      f"{pwm_left:5d}  {pwm_right:5d}")
             prev = (enc[0], enc[3], now)
             # pace to the next tick
             sleep_left = period - (time.monotonic() - now)

--- a/robot/r2_closed_loop_tune_elevated.py
+++ b/robot/r2_closed_loop_tune_elevated.py
@@ -70,16 +70,26 @@ def _env_float(name: str, default: float) -> float:
     return v
 
 
-def _run_pass(bot, matcher, params, target_v: float, seconds: float, rate_hz: float) -> str:
+def _run_pass(bot, matcher, params, target_v: float, seconds: float, rate_hz: float,
+              inject_wheel=None, inject_after_s: float = 1.5) -> str:
     """Drive the closed loop for one window. Returns a short outcome tag.
 
     Prints per-cycle: measured L/R ground speed vs target and the commanded PWMs,
     so the operator can judge convergence + oscillation and watch for a runaway
     (there must be none — PWM is capped + slew-limited). A matcher fault (stall /
     non-finite) stops the motors immediately and ends the pass.
+
+    inject_wheel (0=RL, 3=RR or None): SOFTWARE stall injection. After
+    inject_after_s, the chosen wheel's encoder value fed to the matcher is FROZEN
+    (its computed speed → 0, as if the wheel jammed), so the matcher must trip a
+    stall fault and cut BOTH motors — a repeatable end-to-end proof of the
+    fault→MRC path without needing to physically hold a spinning wheel. The REAL
+    motors keep being commanded until the fault fires, so the operator still sees
+    the wheels actually STOP.
     """
     period = 1.0 / rate_hz
     m_per_tick = params.m_per_tick
+    frozen = None  # captured encoder value for the injected wheel
     prev = None  # (enc_left, enc_right, t) for the RAW display speed
     print(f"\n  target={target_v:.3f} m/s  for {seconds:.1f}s @ {rate_hz:.0f}Hz  "
           f"(KP={params.kp_pwm_per_mps}, slew={params.max_pwm_step}, "
@@ -95,6 +105,14 @@ def _run_pass(bot, matcher, params, target_v: float, seconds: float, rate_hz: fl
             if elapsed >= seconds:
                 break
             enc = bot.get_motor_encoder()  # [m1(RL), m2, m3, m4(RR)]
+            # Software stall injection: freeze the chosen wheel's encoder so the
+            # matcher sees it as stopped (Δticks → 0) while the real motor is still
+            # commanded — proves fault→motor-cut without a physical hold.
+            if inject_wheel is not None and elapsed >= inject_after_s:
+                if frozen is None:
+                    frozen = enc[inject_wheel]
+                enc = list(enc)
+                enc[inject_wheel] = frozen
             pwm_left, pwm_right, fault = matcher.step(target_v, enc[0], enc[3], now)
             if fault is not None:
                 bot.set_motor(0, 0, 0, 0)
@@ -180,18 +198,32 @@ def main() -> int:
         conv = _confirm("Did BOTH wheels converge to ~target with BOUNDED PWM (no runaway)?")
 
         stall_seconds = min(max(seconds, 6.0), SECONDS_HARD_CAP)
+        inject = os.environ.get("KIRRA_TUNE_INJECT_STALL", "").strip().lower()
+        inject_wheel = 0 if inject in ("left", "l", "rl") else 3 if inject in ("right", "r", "rr") else None
         print("\n── PASS 2: stall → MRC fault ──")
-        print("  As soon as it starts, FIRMLY grip ONE rear wheel (gloved) to a COMPLETE")
-        print(f"  STOP and HOLD it there (~2 s) — you have {stall_seconds:.0f}s. That wheel's")
-        print("  pwm will climb a little as the controller tries; that is expected + safe")
-        print("  (it is capped). KEEP HOLDING until you see 'FAULT: wheel_stall_...' and")
-        print("  BOTH motors stop. A light touch that only SLOWS the wheel will NOT trip")
-        print("  it — its filt_ column must reach ~0 and stay there for ~1 s.")
-        if _confirm("Ready to run the stall test (grip one wheel to a FULL stop)?"):
-            outcome2 = _run_pass(bot, matcher, params, target, stall_seconds, rate_hz)
+        if inject_wheel is not None:
+            side = "LEFT (RL)" if inject_wheel == 0 else "RIGHT (RR)"
+            print(f"  INJECTION MODE (KIRRA_TUNE_INJECT_STALL={inject}): after ~1.5 s the {side}")
+            print("  wheel's ENCODER is frozen in software (the controller sees it as jammed).")
+            print("  Expected: the matcher trips a stall fault and BOTH real motors STOP —")
+            print("  you'll SEE the wheels cut. This is the repeatable fault→MRC proof.")
+            ready = _confirm("Ready to run the injected stall test?")
+        else:
+            print("  As soon as it starts, FIRMLY grip ONE rear wheel (gloved) to a COMPLETE")
+            print(f"  STOP and HOLD it there (~2 s) — you have {stall_seconds:.0f}s. That wheel's")
+            print("  pwm will climb a little as the controller tries; that is expected + safe")
+            print("  (it is capped). KEEP HOLDING until you see 'FAULT: wheel_stall_...' and")
+            print("  BOTH motors stop. A light touch that only SLOWS the wheel will NOT trip")
+            print("  it — its filt_ column must reach ~0 and stay there for ~1 s.")
+            print("  (Hard to do by hand? Re-run with KIRRA_TUNE_INJECT_STALL=left for a")
+            print("   reliable software-injected stall instead.)")
+            ready = _confirm("Ready to run the stall test (grip one wheel to a FULL stop)?")
+        if ready:
+            outcome2 = _run_pass(bot, matcher, params, target, stall_seconds, rate_hz,
+                                 inject_wheel=inject_wheel)
             print(f"  pass 2: {outcome2}")
             stalled = outcome2.startswith("fault:") and _confirm(
-                "Did holding a wheel trip a FAULT and STOP both motors (no ramp-to-cap)?"
+                "Did the stall trip a FAULT and STOP both motors (no ramp-to-cap)?"
             )
         else:
             stalled = False

--- a/robot/r2_closed_loop_tune_elevated.py
+++ b/robot/r2_closed_loop_tune_elevated.py
@@ -179,12 +179,16 @@ def main() -> int:
         print(f"  pass 1: {outcome}")
         conv = _confirm("Did BOTH wheels converge to ~target with BOUNDED PWM (no runaway)?")
 
+        stall_seconds = min(max(seconds, 6.0), SECONDS_HARD_CAP)
         print("\n── PASS 2: stall → MRC fault ──")
-        print("  During this pass, GENTLY hold/brake ONE rear wheel (gloved hand) so it")
-        print("  stops while commanded. Expected: the matcher trips a stall fault and")
-        print("  BOTH motors STOP (it must NOT ramp that wheel to the cap).")
-        if _confirm("Ready to run the stall test (you will hold one wheel)?"):
-            outcome2 = _run_pass(bot, matcher, params, target, seconds, rate_hz)
+        print("  As soon as it starts, FIRMLY grip ONE rear wheel (gloved) to a COMPLETE")
+        print(f"  STOP and HOLD it there (~2 s) — you have {stall_seconds:.0f}s. That wheel's")
+        print("  pwm will climb a little as the controller tries; that is expected + safe")
+        print("  (it is capped). KEEP HOLDING until you see 'FAULT: wheel_stall_...' and")
+        print("  BOTH motors stop. A light touch that only SLOWS the wheel will NOT trip")
+        print("  it — its filt_ column must reach ~0 and stay there for ~1 s.")
+        if _confirm("Ready to run the stall test (grip one wheel to a FULL stop)?"):
+            outcome2 = _run_pass(bot, matcher, params, target, stall_seconds, rate_hz)
             print(f"  pass 2: {outcome2}")
             stalled = outcome2.startswith("fault:") and _confirm(
                 "Did holding a wheel trip a FAULT and STOP both motors (no ramp-to-cap)?"

--- a/robot/r2_closed_loop_tune_elevated.py
+++ b/robot/r2_closed_loop_tune_elevated.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""r2_closed_loop_tune_elevated.py — bench-tune + validate the R2 §9 closed-loop
+per-wheel speed matcher against the REAL motors + encoders, ELEVATED.
+
+🔴🔴🔴 RUN ELEVATED — ALL WHEELS OFF THE GROUND, E-STOP IN HAND. 🔴🔴🔴
+
+WHY THIS EXISTS. The closed-loop controller (`r2_drive.ClosedLoopSpeedMatcher`)
+is host-tested for correctness + fail-closed behaviour, but its GAINS
+(KIRRA_R2_SPEED_*) are conservative PLACEHOLDERS — they must be tuned against the
+real drivetrain, and the no-runaway / stall→MRC behaviour must be seen on
+hardware, BEFORE the loop is ever wired into the actuation consumer. This script
+drives the matcher directly (NO governed consumer, NO ROS) so you can:
+  1. watch both wheels converge to the SAME target speed (tune KP / slew),
+  2. confirm PWM stays BOUNDED (no runaway) as it converges,
+  3. prove a STALLED wheel (grab/hold one) trips the MRC fault → motors stop.
+
+This is the closed-loop analogue of r2_drive_calibration_elevated.py: it opens
+the board directly, so the KIRRA consumer must be STOPPED first (it owns
+/dev/myserial). It writes NOTHING into the consumer and makes no safety claim; it
+is a tuning bench. Steering is not used (straight-line tuning, wheels up).
+
+SOLE-WRITER: stop the consumer first, else the port open fails "device busy"
+(the intended interlock):
+    (stop the kirra consumer)
+    set -a; source /etc/kirra/robot.env; set +a
+    export KIRRA_R2_M_PER_TICK=0.00025101 KIRRA_R2_V_PER_PWM_RIGHT=0.0194
+    python3 robot/r2_closed_loop_tune_elevated.py
+
+Knobs (env; the matcher gains are the ones you are here to tune):
+    KIRRA_TUNE_TARGET_MPS   target ground speed for the run (default 0.20; HARD-
+                            capped at 0.30 — this is a low-speed elevated bench).
+    KIRRA_TUNE_SECONDS      run-window length per pass (default 4.0; capped 10).
+    KIRRA_TUNE_RATE_HZ      control rate (default 10).
+    KIRRA_R2_SPEED_KP, KIRRA_R2_SPEED_MAX_PWM_STEP, KIRRA_R2_SPEED_STALL_* —
+                            the controller gains (see r2_drive.py / env.template).
+"""
+
+import math
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from r2_drive import (  # noqa: E402
+    ClosedLoopSpeedMatcher,
+    R2CalibrationError,
+    calibration_from_env,
+    speed_match_params_from_env,
+)
+
+TARGET_HARD_CAP_MPS = 0.30  # refuse a higher elevated-bench target (fat-finger guard)
+SECONDS_HARD_CAP = 10.0
+
+
+def _confirm(q: str) -> bool:
+    return input(q + " [y/N] ").strip().lower() == "y"
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        v = float(raw)
+    except ValueError:
+        sys.exit(f"{name}: '{raw}' is not a number.")
+    if not math.isfinite(v):
+        sys.exit(f"{name}: must be finite.")
+    return v
+
+
+def _run_pass(bot, matcher, params, target_v: float, seconds: float, rate_hz: float) -> str:
+    """Drive the closed loop for one window. Returns a short outcome tag.
+
+    Prints per-cycle: measured L/R ground speed vs target and the commanded PWMs,
+    so the operator can judge convergence + oscillation and watch for a runaway
+    (there must be none — PWM is capped + slew-limited). A matcher fault (stall /
+    non-finite) stops the motors immediately and ends the pass.
+    """
+    period = 1.0 / rate_hz
+    m_per_tick = params.m_per_tick
+    prev = None  # (enc_left, enc_right, t) for the DISPLAY speed (matcher keeps its own)
+    print(f"\n  target={target_v:.3f} m/s  for {seconds:.1f}s @ {rate_hz:.0f}Hz  "
+          f"(KP={params.kp_pwm_per_mps}, slew={params.max_pwm_step}, pwm_max={params.pwm_max})")
+    print("   t(s)   meas_L   meas_R   pwm_L  pwm_R   note")
+    t0 = time.monotonic()
+    matcher.reset()
+    try:
+        while True:
+            now = time.monotonic()
+            elapsed = now - t0
+            if elapsed >= seconds:
+                break
+            enc = bot.get_motor_encoder()  # [m1(RL), m2, m3, m4(RR)]
+            pwm_left, pwm_right, fault = matcher.step(target_v, enc[0], enc[3], now)
+            if fault is not None:
+                bot.set_motor(0, 0, 0, 0)
+                print(f"  {elapsed:6.2f}   ----     ----     0      0     FAULT: {fault} → motors STOPPED")
+                return f"fault:{fault}"
+            bot.set_motor(pwm_left, 0, 0, pwm_right)
+            # Display speed from our own delta (independent of the matcher's).
+            if prev is not None:
+                dt = now - prev[2]
+                mvl = (enc[0] - prev[0]) * m_per_tick / dt if dt > 0 else 0.0
+                mvr = (enc[3] - prev[1]) * m_per_tick / dt if dt > 0 else 0.0
+                print(f"  {elapsed:6.2f}  {mvl:7.3f}  {mvr:7.3f}  {pwm_left:5d}  {pwm_right:5d}")
+            prev = (enc[0], enc[3], now)
+            # pace to the next tick
+            sleep_left = period - (time.monotonic() - now)
+            if sleep_left > 0:
+                time.sleep(sleep_left)
+    finally:
+        bot.set_motor(0, 0, 0, 0)
+    return "completed"
+
+
+def main() -> int:
+    try:
+        from Rosmaster_Lib import Rosmaster
+    except Exception as exc:  # noqa: BLE001
+        sys.exit(f"Rosmaster_Lib not importable: {exc}")
+
+    # Build the controller params from env, fail-closed (needs the measured R2
+    # profile + KIRRA_R2_M_PER_TICK + KIRRA_R2_V_PER_PWM_RIGHT).
+    try:
+        cal = calibration_from_env(os.environ)
+        params = speed_match_params_from_env(os.environ, cal)
+    except R2CalibrationError as exc:
+        sys.exit(f"closed-loop params incomplete: {exc}\n"
+                 "(source /etc/kirra/robot.env and export KIRRA_R2_M_PER_TICK + "
+                 "KIRRA_R2_V_PER_PWM_RIGHT — see env.template.)")
+
+    target = _env_float("KIRRA_TUNE_TARGET_MPS", 0.20)
+    if not (0.0 < target <= TARGET_HARD_CAP_MPS):
+        sys.exit(f"KIRRA_TUNE_TARGET_MPS must be in (0, {TARGET_HARD_CAP_MPS}] — got {target}.")
+    seconds = min(_env_float("KIRRA_TUNE_SECONDS", 4.0), SECONDS_HARD_CAP)
+    rate_hz = _env_float("KIRRA_TUNE_RATE_HZ", 10.0)
+    if not (rate_hz > 0.0):
+        sys.exit("KIRRA_TUNE_RATE_HZ must be > 0.")
+    port = os.environ.get("KIRRA_MOTOR_PORT", "/dev/myserial")
+
+    print("=" * 66)
+    print("  R2 CLOSED-LOOP TUNE — 🔴 WHEELS MUST BE OFF THE GROUND 🔴")
+    print("=" * 66)
+    if not _confirm("Robot ELEVATED, all wheels free to spin, e-stop in hand?"):
+        sys.exit("Elevate the robot first. Aborting.")
+    if not _confirm("Is the KIRRA consumer / vendor motor node STOPPED? (it owns /dev/myserial)"):
+        sys.exit("Stop the consumer first. Aborting.")
+
+    print(f"\nOpening motor board on {port} ...")
+    try:
+        bot = Rosmaster(com=port)
+    except Exception as exc:  # noqa: BLE001
+        sys.exit(f"Could not open {port}: {exc}\n(If 'device busy', the consumer still holds it — stop it.)")
+
+    try:
+        # Encoders only update from the MCU auto-report — REQUIRED or every read is 0.
+        bot.create_receive_threading()
+        time.sleep(0.1)
+        bot.set_auto_report_state(True)
+        time.sleep(0.2)
+        bot.set_motor(0, 0, 0, 0)
+
+        matcher = ClosedLoopSpeedMatcher(params)
+
+        print("\n── PASS 1: convergence + no-runaway ──")
+        print("  WATCH: both meas_L and meas_R should climb to ~target and hold; the")
+        print("  PWMs must stay BOUNDED (no ramp to the cap). If either wheel races or")
+        print("  the PWM pins to the cap and stays, Ctrl-C and lower KP / raise slew.")
+        _confirm("Ready to drive (elevated)?") or sys.exit("Aborted before drive.")
+        outcome = _run_pass(bot, matcher, params, target, seconds, rate_hz)
+        print(f"  pass 1: {outcome}")
+        conv = _confirm("Did BOTH wheels converge to ~target with BOUNDED PWM (no runaway)?")
+
+        print("\n── PASS 2: stall → MRC fault ──")
+        print("  During this pass, GENTLY hold/brake ONE rear wheel (gloved hand) so it")
+        print("  stops while commanded. Expected: the matcher trips a stall fault and")
+        print("  BOTH motors STOP (it must NOT ramp that wheel to the cap).")
+        if _confirm("Ready to run the stall test (you will hold one wheel)?"):
+            outcome2 = _run_pass(bot, matcher, params, target, seconds, rate_hz)
+            print(f"  pass 2: {outcome2}")
+            stalled = outcome2.startswith("fault:") and _confirm(
+                "Did holding a wheel trip a FAULT and STOP both motors (no ramp-to-cap)?"
+            )
+        else:
+            stalled = False
+            print("  pass 2: SKIPPED")
+
+        print("\n" + "=" * 66)
+        if conv and stalled:
+            print("  ✅ CLOSED-LOOP TUNE PASSED (elevated): converged + bounded + stall→MRC.")
+            print("     Record the working KIRRA_R2_SPEED_* gains; they are the ones the")
+            print("     consumer will use once wired (KIRRA_R2_CLOSED_LOOP=1). Next: the")
+            print("     governed-consumer elevated run, then tethered floor.")
+        else:
+            print("  ⚠  NOT signed off. Adjust gains (KP / slew) or re-run the stall test;")
+            print("     do NOT enable closed-loop on the consumer until BOTH pass.")
+        print("=" * 66)
+    except KeyboardInterrupt:
+        try:
+            bot.set_motor(0, 0, 0, 0)
+        except Exception:  # noqa: BLE001
+            pass
+        print("\n\nInterrupted - motors stopped.")
+    finally:
+        try:
+            bot.set_motor(0, 0, 0, 0)
+        except Exception:  # noqa: BLE001
+            pass
+        print("\nMotors commanded to 0. Tune session complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/r2_drive.py
+++ b/robot/r2_drive.py
@@ -343,6 +343,12 @@ DEFAULT_MAX_PWM_STEP = 5.0         # per-cycle slew cap on each wheel's PWM
 DEFAULT_STALL_CYCLES = 5           # consecutive under-response cycles → fault
 DEFAULT_STALL_MIN_PWM = 10.0       # "commanding real effort" threshold
 DEFAULT_STALL_MIN_MPS = 0.02       # "not moving" threshold
+# EMA low-pass on the measured wheel speed. The MCU encoder auto-report cadence is
+# not phase-locked to the control loop, so raw per-cycle Δticks/dt ALIASES (a
+# high/low sawtooth every other cycle — seen on the bench). A first-order EMA
+# smooths that so the P-term acts on the real speed, not the sampling artifact.
+# alpha in (0, 1]: 1.0 = no filter (raw); smaller = smoother + more lag.
+DEFAULT_SPEED_EMA_ALPHA = 0.4
 
 
 @dataclass(frozen=True)
@@ -358,6 +364,10 @@ class SpeedMatchParams:
     stall_cycles:      consecutive under-response cycles before a fault, int >= 1.
     stall_min_pwm:     |PWM| at/above which a non-moving wheel counts as stalled, >= 0.
     stall_min_mps:     |speed| below which a wheel counts as "not moving", >= 0.
+    ema_alpha:         EMA weight on the NEW measured speed, in (0, 1]. 1.0 = no
+                       filter. Applied in ClosedLoopSpeedMatcher before the P-term
+                       to smooth aliased encoder reads. Default 1.0 (back-compat);
+                       the env loader defaults it to DEFAULT_SPEED_EMA_ALPHA.
     """
 
     m_per_tick: float
@@ -369,6 +379,7 @@ class SpeedMatchParams:
     stall_cycles: int
     stall_min_pwm: float
     stall_min_mps: float
+    ema_alpha: float = 1.0
 
     def __post_init__(self) -> None:
         for name in (
@@ -380,6 +391,7 @@ class SpeedMatchParams:
             "max_pwm_step",
             "stall_min_pwm",
             "stall_min_mps",
+            "ema_alpha",
         ):
             if not _finite(getattr(self, name)):
                 raise R2CalibrationError(f"{name} must be a finite number")
@@ -398,6 +410,8 @@ class SpeedMatchParams:
             raise R2CalibrationError("stall_cycles must be an int >= 1")
         if self.stall_min_pwm < 0.0 or self.stall_min_mps < 0.0:
             raise R2CalibrationError("stall_min_pwm/stall_min_mps must be >= 0")
+        if not (0.0 < self.ema_alpha <= 1.0):
+            raise R2CalibrationError("ema_alpha must be in (0, 1]")
 
 
 @dataclass
@@ -475,11 +489,21 @@ class ClosedLoopSpeedMatcher:
         self.params = params
         self.state = SpeedMatchState()
         self._prev = None  # (enc_left, enc_right, now_s) or None
+        self._ema_left = None  # filtered measured speed (None until first sample)
+        self._ema_right = None
 
     def reset(self) -> None:
         """Drop the prior sample + zero the controller (call on stop / MRC / fault)."""
         self.state = SpeedMatchState()
         self._prev = None
+        self._ema_left = None
+        self._ema_right = None
+
+    def _filter(self, meas: float, prev_ema) -> float:
+        # First-order EMA: seed on the first sample, else blend. Smooths the
+        # aliased per-cycle encoder speed (see DEFAULT_SPEED_EMA_ALPHA).
+        a = self.params.ema_alpha
+        return meas if prev_ema is None else a * meas + (1.0 - a) * prev_ema
 
     def _feedforward(self, target_v: float):
         p = self.params
@@ -507,7 +531,10 @@ class ClosedLoopSpeedMatcher:
             return self._feedforward(target_v)
         meas_v_left = (enc_left - prev[0]) * self.params.m_per_tick / dt
         meas_v_right = (enc_right - prev[1]) * self.params.m_per_tick / dt
-        return speed_match_step(target_v, meas_v_left, meas_v_right, self.params, self.state)
+        # Low-pass the aliased raw speed before the P-term / stall check.
+        self._ema_left = self._filter(meas_v_left, self._ema_left)
+        self._ema_right = self._filter(meas_v_right, self._ema_right)
+        return speed_match_step(target_v, self._ema_left, self._ema_right, self.params, self.state)
 
 
 # Closed-loop env vars. The enable flag is read by the consumer; the params come
@@ -520,6 +547,7 @@ _ENV_CL_MAX_STEP = "KIRRA_R2_SPEED_MAX_PWM_STEP"
 _ENV_CL_STALL_CYCLES = "KIRRA_R2_SPEED_STALL_CYCLES"
 _ENV_CL_STALL_MIN_PWM = "KIRRA_R2_SPEED_STALL_MIN_PWM"
 _ENV_CL_STALL_MIN_MPS = "KIRRA_R2_SPEED_STALL_MIN_MPS"
+_ENV_CL_EMA_ALPHA = "KIRRA_R2_SPEED_EMA_ALPHA"
 
 
 def closed_loop_enabled(env) -> bool:
@@ -573,4 +601,5 @@ def speed_match_params_from_env(env, cal: R2DriveCalibration) -> SpeedMatchParam
         stall_cycles=_opt_int(_ENV_CL_STALL_CYCLES, DEFAULT_STALL_CYCLES),
         stall_min_pwm=_opt_float(_ENV_CL_STALL_MIN_PWM, DEFAULT_STALL_MIN_PWM),
         stall_min_mps=_opt_float(_ENV_CL_STALL_MIN_MPS, DEFAULT_STALL_MIN_MPS),
+        ema_alpha=_opt_float(_ENV_CL_EMA_ALPHA, DEFAULT_SPEED_EMA_ALPHA),
     )

--- a/robot/r2_drive_calibration_results.txt
+++ b/robot/r2_drive_calibration_results.txt
@@ -132,6 +132,37 @@ RR-CHANNEL CONFIRM (Phase A re-sweep + Phase B on RR): MEASURED 2026-07-17
       sign-offs; the flag is OFF, so nothing changes until then.
 
 ------------------------------------------------------------------
+CLOSED-LOOP TUNE — ELEVATED BENCH SIGN-OFF: PASSED 2026-07-17
+------------------------------------------------------------------
+  (robot/r2_closed_loop_tune_elevated.py, wheels up; the per-wheel EMA-filtered
+  speed matcher, r2_drive.ClosedLoopSpeedMatcher.)
+
+  WORKING GAINS (elevated starting point): KP=40, EMA_ALPHA=0.3, slew=5,
+  stall_cycles=5, stall_min_pwm=10, stall_min_mps=0.02, at target 0.15 m/s.
+
+  BENCH CRITERIA — all met:
+    * STABLE + BOUNDED (no runaway): with the EMA filter the filt_* speeds are
+      steady (the raw per-cycle reads alias ±, the filter removes it); PWMs stayed
+      12-16 / 7-9, far below the pwm_max 40 cap.
+    * STALL → MRC: proven via software encoder-freeze injection
+      (KIRRA_TUNE_INJECT_STALL=left). At freeze, filt_L decayed 0.07→0.006 over
+      ~0.9 s, pwm_L climbed 12→16 (BOUNDED, not to the cap), and after 5 sub-0.02
+      cycles the matcher tripped FAULT: wheel_stall_left → BOTH motors cut to 0.
+      (Physical hand-stop was tried first but unreliable at pwm ~13 — the injected
+      stall is the repeatable end-to-end proof; the pure stall LOGIC is also
+      host-tested in r2_drive_test.py.)
+
+  UNLOADED CAVEAT — L/R equalization is NOT signed off on the bench: filt_L ~0.10
+  vs filt_R ~0.15 (RL ~2/3 of RR), the same unloaded stiction imbalance. Forcing
+  them equal in the air would demand an extreme PWM ratio that would over-correct
+  under load. Equalization/straightness is a FLOOR task (tethered, loaded) — the
+  §8.2 open-loop creep already ran straight under load. The bench proves the loop
+  is SAFE (bounded + stall→MRC); the floor proves it's STRAIGHT.
+
+  NEXT: governed-consumer elevated run with KIRRA_R2_CLOSED_LOOP=1 (through the
+  ADR-0033 verify chokepoint), then the tethered floor to tune straightness.
+
+------------------------------------------------------------------
 PHASE C (steering↔angle): MEASURED (protractor sweep, 2026-07-17)
 ------------------------------------------------------------------
   REQUIRES car-type 5. The first run (type 1, default X3 image) saw NO servo

--- a/robot/r2_drive_test.py
+++ b/robot/r2_drive_test.py
@@ -489,6 +489,41 @@ def test_speed_match_params_from_env_fail_closed_on_missing() -> None:
         raise AssertionError(f"expected fail-closed for {env}")
 
 
+def test_speed_match_params_ema_validation() -> None:
+    for bad in (0.0, -0.1, 1.5, float("nan")):
+        try:
+            _valid_params(ema_alpha=bad)
+        except R2CalibrationError:
+            continue
+        raise AssertionError(f"expected R2CalibrationError for ema_alpha={bad}")
+    # 1.0 (no filter) and a mid value are valid.
+    _valid_params(ema_alpha=1.0)
+    _valid_params(ema_alpha=0.4)
+
+
+def test_matcher_ema_smooths_alternating_speed() -> None:
+    # Feed an ALTERNATING encoder delta (aliasing-like): +100 then +300 ticks per
+    # 0.1s. With alpha<1 the filtered speed the matcher acts on must sit BETWEEN
+    # the two raw samples (smoothed), not swing fully to each.
+    p = _valid_params(ema_alpha=0.3)
+    m = ClosedLoopSpeedMatcher(p)
+    m.step(0.30, 0, 0, 0.0)  # seed
+    enc = 0
+    t = 0.0
+    filtered = []
+    for i in range(8):
+        enc += 100 if i % 2 == 0 else 300
+        t += 0.1
+        m.step(0.30, enc, enc, t)
+        filtered.append(m._ema_left)
+    raw_low = 100 * p.m_per_tick / 0.1   # 0.25
+    raw_high = 300 * p.m_per_tick / 0.1  # 0.75
+    tail = filtered[-4:]
+    assert all(raw_low < f < raw_high for f in tail), f"EMA should sit between raw extremes: {tail}"
+    # And it should be far less jumpy than the raw sawtooth (spread << raw spread).
+    assert (max(tail) - min(tail)) < (raw_high - raw_low) * 0.6, f"EMA not smoothing enough: {tail}"
+
+
 def test_speed_match_params_from_env_rejects_nonnumeric() -> None:
     cal = _valid_cal()
     env = {"KIRRA_R2_M_PER_TICK": "abc", "KIRRA_R2_V_PER_PWM_RIGHT": "0.0194"}

--- a/robot/run_consumer_r2.sh
+++ b/robot/run_consumer_r2.sh
@@ -59,6 +59,13 @@ export KIRRA_GOVERNOR_VK_HEX
 : "${KIRRA_R2_CENTER_TRIM:=90}";              export KIRRA_R2_CENTER_TRIM
 : "${KIRRA_R2_DRIVE_DEADBAND_PWM:=0}";        export KIRRA_R2_DRIVE_DEADBAND_PWM
 
+# §9 closed-loop calibration (only READ when KIRRA_R2_CLOSED_LOOP is set truthy;
+# harmless otherwise). Measured from the RR confirm. Export KIRRA_R2_CLOSED_LOOP=1
+# yourself (after the elevated tune) to enable per-wheel speed matching; the gains
+# (KIRRA_R2_SPEED_*) fall back to r2_drive's conservative defaults unless set.
+: "${KIRRA_R2_M_PER_TICK:=0.00025101}";       export KIRRA_R2_M_PER_TICK
+: "${KIRRA_R2_V_PER_PWM_RIGHT:=0.0194}";      export KIRRA_R2_V_PER_PWM_RIGHT
+
 # --- ADR-0033 timing + demo caps + hardware (validated first-run values) -------
 : "${KIRRA_FRESHNESS_WINDOW_MS:=200}";        export KIRRA_FRESHNESS_WINDOW_MS
 : "${KIRRA_CONTROL_PERIOD_MS:=100}";          export KIRRA_CONTROL_PERIOD_MS

--- a/robot/teardown_smoke_test.py
+++ b/robot/teardown_smoke_test.py
@@ -168,6 +168,12 @@ def install_stubs(ctx: StubContext) -> None:
 
         def create_receive_threading(self) -> None: ...
 
+        def set_auto_report_state(self, enable: bool, forever: bool = False) -> None:
+            # Closed-loop init enables MCU encoder auto-report before reading
+            # encoders; the stub records nothing but must accept the call so the
+            # closed-loop init path stays runnable under stubs.
+            self.auto_report = bool(enable)
+
         def get_motor_encoder(self) -> "list[int]":
             # Advance each channel a little per read so a closed-loop actuate()
             # sees a non-zero speed (the no-op spin here does not call it, but the

--- a/robot/teardown_smoke_test.py
+++ b/robot/teardown_smoke_test.py
@@ -164,8 +164,16 @@ def install_stubs(ctx: StubContext) -> None:
             self.steer_writes: list[int] = []
             self.default_angle: "int | None" = None
             self._car_type = 1  # default X3; set_car_type(5) flips it for r2
+            self._enc = [0, 0, 0, 0]  # cumulative encoder counts (closed-loop reads)
 
         def create_receive_threading(self) -> None: ...
+
+        def get_motor_encoder(self) -> "list[int]":
+            # Advance each channel a little per read so a closed-loop actuate()
+            # sees a non-zero speed (the no-op spin here does not call it, but the
+            # method must exist for the closed-loop path to be importable/runnable).
+            self._enc = [c + 10 for c in self._enc]
+            return list(self._enc)
 
         def get_car_type_from_machine(self) -> int:
             # Reflects set_car_type — x3 cases never call it, so this stays 1
@@ -380,6 +388,60 @@ def main() -> int:
               "(5) r2 safe stop must centre the steering")
     print("(5) consumer/r2 mode → exit 0, car-type 5 + trim set, "
           "no set_car_motion, safe stop zeros motors + centre (init + teardown)")
+
+    # ------------------------------------------------------------------
+    # 6. R2 closed-loop (§9) init: with KIRRA_R2_CLOSED_LOOP on, the consumer
+    #    must build the speed matcher (needs KIRRA_R2_M_PER_TICK +
+    #    KIRRA_R2_V_PER_PWM_RIGHT) and start; and fail-closed (rc != 0) when the
+    #    flag is on but those params are MISSING — never silently fall back to
+    #    open-loop. The no-op spin covers INIT; the loop math is r2_drive_test.py.
+    # ------------------------------------------------------------------
+    r2_env = {
+        "KIRRA_DRIVE_MODE": "r2_ackermann",
+        "KIRRA_R2_WHEELBASE_M": "0.229",
+        "KIRRA_R2_V_PER_PWM": "0.0145",
+        "KIRRA_R2_PWM_MAX": "60",
+        "KIRRA_R2_STEER_UNITS_PER_RAD": "140",
+        "KIRRA_R2_DELTA_MAX_RAD": "0.5",
+        "KIRRA_R2_STEER_SIGN": "-1",
+        "KIRRA_R2_CENTER_TRIM": "90",
+    }
+    cl_keys = list(r2_env) + ["KIRRA_R2_CLOSED_LOOP", "KIRRA_R2_M_PER_TICK", "KIRRA_R2_V_PER_PWM_RIGHT"]
+
+    # 6a. flag ON but params MISSING → fail closed.
+    os.environ.update(r2_env)
+    os.environ["KIRRA_R2_CLOSED_LOOP"] = "1"
+    os.environ.pop("KIRRA_R2_M_PER_TICK", None)
+    os.environ.pop("KIRRA_R2_V_PER_PWM_RIGHT", None)
+    try:
+        rc_missing = kirra_motor_consumer.main()
+    except BaseException:  # noqa: BLE001
+        rc_missing = -1
+    check(rc_missing != 0, "(6a) closed-loop ON with missing params must fail closed (rc != 0)")
+
+    # 6b. flag ON + params present → inits + exits 0 + safe-stops.
+    os.environ.update(r2_env)
+    os.environ.update({
+        "KIRRA_R2_CLOSED_LOOP": "1",
+        "KIRRA_R2_M_PER_TICK": "0.00025101",
+        "KIRRA_R2_V_PER_PWM_RIGHT": "0.0194",
+    })
+    try:
+        rc_cl = kirra_motor_consumer.main()
+    except BaseException as e:  # noqa: BLE001
+        failures.append(f"(6b) closed-loop consumer raised: {e!r}")
+        rc_cl = -1
+    finally:
+        for k in cl_keys:
+            os.environ.pop(k, None)
+    check(rc_cl == 0, f"(6b) closed-loop consumer must exit 0, got {rc_cl}")
+    bot_cl = sys.modules["Rosmaster_Lib"].Rosmaster.last
+    if bot_cl is not None:
+        check(bot_cl._car_type == 5, "(6b) closed-loop r2 mode must still set car-type 5")
+        check(bot_cl.motor_writes and bot_cl.motor_writes[-1] == (0, 0, 0, 0),
+              "(6b) closed-loop safe stop must zero both rear motors")
+    print("(6) consumer/r2 closed-loop → fail-closed on missing params; "
+          "inits + exits 0 + safe stop when params present")
 
     print()
     if failures:

--- a/robot/tune_r2.sh
+++ b/robot/tune_r2.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# tune_r2.sh — one-command launcher for the R2 closed-loop ELEVATED tune, so a
+# fresh shell doesn't need the KIRRA_R2_* exports re-pasted every time.
+#
+#   ./robot/tune_r2.sh
+#
+# 🔴 RUN ELEVATED — wheels off the ground, e-stop in hand. Stop the KIRRA
+# consumer first (it owns /dev/myserial). This sets the measured R2 profile +
+# closed-loop calibration (env.template / r2_drive_calibration_results.txt) and
+# runs r2_closed_loop_tune_elevated.py. Every value is override-friendly (:=), so
+# to sweep a gain just export it first, e.g.:
+#   KIRRA_R2_SPEED_KP=60 ./robot/tune_r2.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+cd "$REPO"
+
+# --- measured R2 drive/steer profile (only the drive values are used by the
+#     tuner, but the shared calibration loader wants the full set) ---
+: "${KIRRA_R2_WHEELBASE_M:=0.229}";           export KIRRA_R2_WHEELBASE_M
+: "${KIRRA_R2_V_PER_PWM:=0.0145}";            export KIRRA_R2_V_PER_PWM
+: "${KIRRA_R2_PWM_MAX:=40}";                  export KIRRA_R2_PWM_MAX
+: "${KIRRA_R2_STEER_UNITS_PER_RAD:=66}";      export KIRRA_R2_STEER_UNITS_PER_RAD
+: "${KIRRA_R2_DELTA_MAX_RAD:=0.68}";          export KIRRA_R2_DELTA_MAX_RAD
+: "${KIRRA_R2_STEER_SIGN:=-1}";               export KIRRA_R2_STEER_SIGN
+: "${KIRRA_R2_CENTER_TRIM:=90}";              export KIRRA_R2_CENTER_TRIM
+# --- closed-loop calibration (measured, RR confirm) ---
+: "${KIRRA_R2_M_PER_TICK:=0.00025101}";       export KIRRA_R2_M_PER_TICK
+: "${KIRRA_R2_V_PER_PWM_RIGHT:=0.0194}";      export KIRRA_R2_V_PER_PWM_RIGHT
+# --- controller gains — CONSERVATIVE starting points; sweep via env to tune ---
+: "${KIRRA_R2_SPEED_KP:=40}";                 export KIRRA_R2_SPEED_KP
+: "${KIRRA_R2_SPEED_EMA_ALPHA:=0.3}";         export KIRRA_R2_SPEED_EMA_ALPHA
+: "${KIRRA_MOTOR_PORT:=/dev/myserial}";       export KIRRA_MOTOR_PORT
+
+echo "── R2 closed-loop tune: KP=$KIRRA_R2_SPEED_KP ema=$KIRRA_R2_SPEED_EMA_ALPHA "\
+"target=${KIRRA_TUNE_TARGET_MPS:-0.20} port=$KIRRA_MOTOR_PORT"
+exec python3 "$REPO/robot/r2_closed_loop_tune_elevated.py"


### PR DESCRIPTION
## Summary

Wires the closed-loop speed matcher (landed in #987) into the governed consumer behind `KIRRA_R2_CLOSED_LOOP` (default **OFF** → open-loop equal-PWM, byte-identical), and adds the elevated bench script to tune the gains + prove the fail-closed behaviour **before** the loop ever drives through the consumer.

## Consumer wiring (`kirra_motor_consumer.py`)

In r2 mode + flag on, `actuate()` keeps `translate()` as the **safety front** — non-finite / spin-in-place / at-rest all still yield an MRC or commanded-stop with zeros — and only when `translate()` returns `ok` does it **replace the two drive PWMs** with the per-wheel speed-matched ones (keeping `translate`'s steer command). It reads `get_motor_encoder()` (`RL=0, RR=3`) + `time.monotonic()`, steps the matcher, and applies steer + the matched PWMs. A stall / non-finite fault → `r2_safe_stop` + `matcher.reset()` + a warn. **Fail-closed at init:** flag on but params incomplete → FATAL (never a silent fallback to open-loop). Startup logs open-loop vs closed-loop.

## Elevated tuning bench (`robot/r2_closed_loop_tune_elevated.py`)

Drives the matcher directly against the real motors + encoders (no ROS, no governed consumer), so the operator can, **wheels-up**:
1. watch both wheels converge to the same target speed (tune `KP` / slew),
2. confirm PWM stays **bounded** (no runaway),
3. prove a **stalled wheel → MRC fault → motors stop** (a guided stall-test pass).

Target hard-capped at 0.30 m/s; `set_motor(0,0,0,0)` on every exit path; sole-writer interlock (consumer must be stopped).

## Tests

`teardown_smoke_test` case (6): closed-loop **fail-closed on missing params** + **inits / exits-0 / safe-stops** when present (stub gains `get_motor_encoder`). **38/38** `r2_drive` host tests, smoke **6/6**. `run_consumer_r2.sh` now carries the measured `m_per_tick` + RR slope (read only when the flag is on).

## Explicitly remaining (task #84)

**Hardware tuning + validation** — the gains shipped are conservative placeholders. Run `r2_closed_loop_tune_elevated.py` elevated to tune + sign off (converge / bounded / stall→MRC), then the governed-consumer elevated run with `KIRRA_R2_CLOSED_LOOP=1`, then tethered floor. `KIRRA_R2_CLOSED_LOOP` and `KIRRA_DRIVE_MODE` both stay OFF in `env.template` until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_