### PR TITLE
feat(r2): opt-in closed-loop debug log — observable over SSH

### DIFF
--- a/robot/install/env.template
+++ b/robot/install/env.template
@@ -124,3 +124,6 @@ KIRRA_R2_V_PER_PWM_RIGHT=0.0194     # MEASURED — RR feedforward slope (m/s)/PW
                                     # filter. Smooths aliased encoder reads before
                                     # the P-term (the raw per-cycle speed sawtooths
                                     # because the MCU auto-report isn't loop-locked).
+#KIRRA_R2_CLOSED_LOOP_DEBUG=1       # log-only: throttled per-cycle closed-loop line
+                                    # (target, filtered L/R speed, PWMs) so the loop
+                                    # is observable over SSH. No actuation change.

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -166,6 +166,13 @@ def main() -> int:
                 print(f"FATAL: KIRRA_R2_CLOSED_LOOP is on but its params are "
                       f"incomplete: {e}", file=sys.stderr)
                 return 2
+    # Opt-in closed-loop diagnostics: throttled per-cycle log of target + filtered
+    # L/R speed + commanded PWMs, so the loop is OBSERVABLE over SSH (accepted
+    # frames are otherwise silent). Off by default; log-only, no actuation change.
+    r2_cl_debug = (
+        r2_matcher is not None
+        and (os.environ.get("KIRRA_R2_CLOSED_LOOP_DEBUG") or "").strip().lower() in ("1", "true", "yes", "on")
+    )
     topic = os.environ.get("KIRRA_RELEASE_TOPIC", "/kirra/release")
 
     # The verify core (fail-closed: raises on a NULL handle).
@@ -281,6 +288,7 @@ def main() -> int:
         )
 
     alarm_announced = False
+    cl_debug_ctr = [0]  # throttle counter for the closed-loop debug log
 
     def actuate(linear: float, angular: float) -> None:
         if drive_mode == DRIVE_MODE_R2:
@@ -313,6 +321,17 @@ def main() -> int:
                 return
             bot.set_akm_steering_angle(act.steer_cmd)
             bot.set_motor(pwm_left, 0, 0, pwm_right)
+            if r2_cl_debug:
+                # Throttled (~every 5th cycle) so the loop is observable over SSH
+                # without flooding: target, filtered L/R speed, commanded PWMs, steer.
+                cl_debug_ctr[0] += 1
+                if cl_debug_ctr[0] % 5 == 0:
+                    fl, fr = r2_matcher.last_filtered_speeds()
+                    node.get_logger().info(
+                        f"cl tgt={linear:.3f} ema_L={0.0 if fl is None else fl:.3f} "
+                        f"ema_R={0.0 if fr is None else fr:.3f} "
+                        f"pwm_L={pwm_left} pwm_R={pwm_right} steer={act.steer_cmd}"
+                    )
         else:
             # x3: v_y = 0 (skid-steer demo; no lateral). linear→v_x, angular→v_z,
             # both already clamped by the Rust capture seam.

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -288,9 +288,10 @@ def main() -> int:
         )
 
     alarm_announced = False
-    cl_debug_ctr = [0]  # throttle counter for the closed-loop debug log
+    cl_debug_ctr = 0  # throttle counter for the closed-loop debug log
 
     def actuate(linear: float, angular: float) -> None:
+        nonlocal cl_debug_ctr
         if drive_mode == DRIVE_MODE_R2:
             # Path B: the Ackermann last-hop runs AFTER verify (the same place
             # the x3 firmware mixing runs after verify). translate() is
@@ -324,12 +325,15 @@ def main() -> int:
             if r2_cl_debug:
                 # Throttled (~every 5th cycle) so the loop is observable over SSH
                 # without flooding: target, filtered L/R speed, commanded PWMs, steer.
-                cl_debug_ctr[0] += 1
-                if cl_debug_ctr[0] % 5 == 0:
+                cl_debug_ctr += 1
+                if cl_debug_ctr % 5 == 0:
                     fl, fr = r2_matcher.last_filtered_speeds()
+                    # NaN (not 0.0) before the first measured cycle — 0.0 would read
+                    # as a real "wheel stopped" sample and mislead debugging.
+                    fl = float("nan") if fl is None else fl
+                    fr = float("nan") if fr is None else fr
                     node.get_logger().info(
-                        f"cl tgt={linear:.3f} ema_L={0.0 if fl is None else fl:.3f} "
-                        f"ema_R={0.0 if fr is None else fr:.3f} "
+                        f"cl tgt={linear:.3f} ema_L={fl:.3f} ema_R={fr:.3f} "
                         f"pwm_L={pwm_left} pwm_R={pwm_right} steer={act.steer_cmd}"
                     )
         else:

--- a/robot/r2_drive.py
+++ b/robot/r2_drive.py
@@ -505,6 +505,12 @@ class ClosedLoopSpeedMatcher:
         a = self.params.ema_alpha
         return meas if prev_ema is None else a * meas + (1.0 - a) * prev_ema
 
+    def last_filtered_speeds(self):
+        """The most recent EMA-filtered (left, right) speeds the P-term acted on,
+        or (None, None) before the first measured cycle. Read-only, for
+        diagnostics/telemetry (the tune bench + the consumer's debug log)."""
+        return (self._ema_left, self._ema_right)
+
     def _feedforward(self, target_v: float):
         p = self.params
         pl = _clamp(target_v / p.v_per_pwm_left, -p.pwm_max, p.pwm_max)

--- a/robot/r2_drive_test.py
+++ b/robot/r2_drive_test.py
@@ -524,6 +524,18 @@ def test_matcher_ema_smooths_alternating_speed() -> None:
     assert (max(tail) - min(tail)) < (raw_high - raw_low) * 0.6, f"EMA not smoothing enough: {tail}"
 
 
+def test_matcher_last_filtered_speeds_accessor() -> None:
+    p = _valid_params(ema_alpha=1.0)
+    m = ClosedLoopSpeedMatcher(p)
+    assert m.last_filtered_speeds() == (None, None)  # before any measured cycle
+    m.step(0.30, 0, 0, 0.0)      # feedforward seed — still no measured speed
+    assert m.last_filtered_speeds() == (None, None)
+    m.step(0.30, 120, 120, 0.1)  # 120 ticks / 0.1s * m_per_tick
+    fl, fr = m.last_filtered_speeds()
+    expected = 120 * p.m_per_tick / 0.1
+    assert fl is not None and abs(fl - expected) < 1e-9 and abs(fr - expected) < 1e-9
+
+
 def test_speed_match_params_from_env_rejects_nonnumeric() -> None:
     cal = _valid_cal()
     env = {"KIRRA_R2_M_PER_TICK": "abc", "KIRRA_R2_V_PER_PWM_RIGHT": "0.0194"}

--- a/robot/r2_drive_test.py
+++ b/robot/r2_drive_test.py
@@ -533,7 +533,8 @@ def test_matcher_last_filtered_speeds_accessor() -> None:
     m.step(0.30, 120, 120, 0.1)  # 120 ticks / 0.1s * m_per_tick
     fl, fr = m.last_filtered_speeds()
     expected = 120 * p.m_per_tick / 0.1
-    assert fl is not None and abs(fl - expected) < 1e-9 and abs(fr - expected) < 1e-9
+    assert fl is not None and fr is not None
+    assert abs(fl - expected) < 1e-9 and abs(fr - expected) < 1e-9
 
 
 def test_speed_match_params_from_env_rejects_nonnumeric() -> None:


### PR DESCRIPTION
## Summary

The closed-loop drive is invisible without line-of-sight — accepted release frames actuate the motors silently, so you can't tell smooth-from-jittery over SSH. Adds an **opt-in, log-only** per-cycle diagnostic so the loop is observable remotely.

- **`KIRRA_R2_CLOSED_LOOP_DEBUG`** (off by default): a throttled (~every 5th cycle) INFO line — `cl tgt=… ema_L=… ema_R=… pwm_L=… pwm_R=… steer=…` — target, EMA-filtered L/R speed, commanded PWMs, steer command. No actuation change; only logs.
- **`ClosedLoopSpeedMatcher.last_filtered_speeds()`** — read-only accessor for the EMA state, used by the consumer log (and available to the tune bench).

## Tests

New host test for the accessor (None before the first measured cycle, then the filtered value). **41/41** `r2_drive` host tests, teardown smoke **6/6**. `env.template` documents the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_