### PR TITLE
R2 bench bring-up: posture-gate bootstrap fix + r2 contract class + KITT/autostart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,8 +354,19 @@ Admin token or an `integrator`-role principal.
 - `POST /fleet/campaigns/report` — WS-4 node adoption report (a node reports the governor digest it is now running → the fleet summary's `applied_nodes`; a write, so identity-gated, unlike the open read-only assignment GET; upsert by node_id, monotonic on `reported_at_ms`, not audit-chained). Optionally attestation-SIGNED: a base64 Ed25519 signature over `attestation::adoption_report_signing_payload(node_id, applied_digest, reported_at_ms)` verified against the node's registered `ak_public_pem` → `attested=true` (unforgeable attribution; `summary.attested_nodes`); invalid sig / no AK → 401 fail-closed; unsigned → accepted but `attested=false`
 - `POST /industrial/evaluate` — Evaluate Modbus/OPC-UA industrial event
 
+**Trust-BOOTSTRAP posture exemption:** the node-onboarding + attestation-handshake
+routes below — `POST /attestation/register`, `/attestation/identity/register`,
+`/attestation/challenge/:node_id`, `/attestation/verify` — are POSTURE-EXEMPT
+(`is_posture_exempt`, `src/gateway/policy_layer.rs`). They establish/prove a node's
+trust identity and cannot actuate, so the posture gate (which blocks COMMANDS) must
+not gate them. This is load-bearing for the M-9 empty-fleet policy: a fresh Active
+verifier with zero nodes is forced LockedOut and auto-recovers "the instant a node
+is registered" — which requires those routes to be reachable UNDER LockedOut (else
+the only way out of the lockout is blocked by the lockout — a bootstrap deadlock).
+Each keeps its own guarantee independent of posture (admin token / challenge-response).
+
 ### Tier 2 — Admin (`SCOPE_ADMIN`; Bearer `KIRRA_ADMIN_TOKEN` or `admin`-role principal)
-- `POST /attestation/register` — Register a node
+- `POST /attestation/register` — Register a node (posture-exempt — trust bootstrap)
 - `POST /fleet/dependencies` — Register dependency graph edges
 - `POST /system/backup/export` — Full state dump (admin-only; NOT in the auditor tier)
 - `POST /system/audit/rotate-signing-key` — Rotate the audit signing key

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -63,7 +63,11 @@ install -d -m 0750 -o kirra -g kirra "$ENVDIR"
 if [[ -f "$ENVFILE" ]]; then
   echo "  $ENVFILE exists — leaving it untouched (your secrets are preserved)"
 else
-  gen() { LC_ALL=C tr -dc 'a-f0-9' < /dev/urandom | head -c "$1"; }
+  # Read from a process-substitution FD so `head` closing the pipe SIGPIPEs the
+  # `tr` in the SUBSHELL, not a member of head's own pipeline — otherwise
+  # `set -o pipefail` sees the SIGPIPE'd tr and `set -e` aborts before any
+  # secret is written (and before the units install). head itself exits 0.
+  gen() { head -c "$1" < <(LC_ALL=C tr -dc 'a-f0-9' < /dev/urandom); }
   admin="$(gen 64)"          # admin bearer token (64 hex chars)
   reset="$(gen 48)"          # supervisor reset key (48 bytes, <= 64)
   umask 077

--- a/deploy/systemd/kirra.target
+++ b/deploy/systemd/kirra.target
@@ -13,9 +13,9 @@
 # Enabling it (install.sh does) also brings the stack up on boot.
 
 [Unit]
-Description=Kirra governor stack (verifier + Occy planner + Taj perception)
+Description=Kirra governor stack (verifier + Occy planner + Taj perception + Mick intent)
 Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
-Wants=kirra-verifier.service kirra-planner.service kirra-taj.service
+Wants=kirra-verifier.service kirra-planner.service kirra-taj.service kirra-mick.service
 After=network-online.target
 
 [Install]

--- a/docs/CONTRACT_PROFILES.md
+++ b/docs/CONTRACT_PROFILES.md
@@ -90,7 +90,8 @@ These relations are asserted as structural invariants (see the validation gate).
 ### Ordering sanity (asserted)
 `r2.effective_cap (1.0) < courier.effective_cap (2.5) < delivery-av (11.0) <
 robotaxi (35.0)` and
-`courier.impact_spike (2.5) < delivery-av (8.0) < robotaxi (22.0)` (deviation units).
+`r2.impact_spike (1.5) < courier.impact_spike (2.5) < delivery-av (8.0) <
+robotaxi (22.0)` (deviation units).
 
 ---
 
@@ -115,6 +116,8 @@ geometry items remain to be bench-captured (see below).
 | `r2.lat_accel` | 1.0 | VALIDATION-PENDING — gentle |
 | `r2.wheelbase` | **0.229** | **MEASURED** ~9 in (front-to-rear CONFIRM owed); `KIRRA_R2_WHEELBASE_M` |
 | `r2.footprint` (w×l, overhangs) | **0.203 × 0.330** (0.05/0.05) | **MEASURED** body 8 in × 13 in (bench tape); **overhang split ESTIMATED** ((len−wb)/2) |
+| `r2.impact_spike` (SG6, parko; **deviation** `\|‖a‖−G\|`) | **1.5** | VALIDATION-PENDING — smallest deviation of the family, above the validate() 1.0 noise floor |
+| `r2.impact_confirm` (M / N consecutive) | **2 / 3** | VALIDATION-PENDING — debounce the bumps a small robot takes |
 
 **Remaining bench captures to firm up `r2` (the 4 items in PLATFORM_R2_PENDING):**
 front-to-rear wheelbase confirmation, servo slew rate (→ `r2.steering_rate`), the

--- a/docs/CONTRACT_PROFILES.md
+++ b/docs/CONTRACT_PROFILES.md
@@ -88,8 +88,44 @@ These relations are asserted as structural invariants (see the validation gate).
 > projection is the named future improvement, gated on a reliable quaternion.
 
 ### Ordering sanity (asserted)
-`courier.effective_cap (2.5) < delivery-av (11.0) < robotaxi (35.0)` and
+`r2.effective_cap (1.0) < courier.effective_cap (2.5) < delivery-av (11.0) <
+robotaxi (35.0)` and
 `courier.impact_spike (2.5) < delivery-av (8.0) < robotaxi (22.0)` (deviation units).
+
+---
+
+## R2 (Yahboom Rosmaster R2 bench robot) — the first MEASURED-geometry class
+
+Unlike courier / delivery-av (every number VALIDATION-PENDING) and robotaxi
+(INHERITED-FROZEN), the `r2` class carries **MEASURED** geometry — it is the small
+Ackermann bench robot (~1/10 RC scale) the R2 hardware work drives. It **retires the
+interim `courier` borrow** for that platform (`robot/install/PLATFORM_R2_PENDING.md`,
+Track-A A2). Its dynamic limits are still VALIDATION-PENDING estimates, and four
+geometry items remain to be bench-captured (see below).
+
+| Param id | R2 value | Status / provenance |
+|---|---|---|
+| `r2.max_speed` | 1.5 | VALIDATION-PENDING — conservative small-robot mechanical max; bench max not measured |
+| `r2.odd_cap` | **1.0** | VALIDATION-PENDING — indoor/tethered ceiling above the `KIRRA_DEMO_VX_MAX` 0.15 demo, below courier 2.5 |
+| `r2.accel` | 0.5 | VALIDATION-PENDING — gentle low-speed |
+| `r2.brake` | 1.5 | VALIDATION-PENDING — brake ≥ accel |
+| `r2.steering` | **39.0** | **MEASURED** — full-lock ~39° (0.68 rad) @ cmd ±45, `r2_drive_calibration_results.txt` Phase C 2026-07-17 |
+| `r2.steering_rate` | 30.0 | VALIDATION-PENDING — **servo slew UNMEASURED** (time a full −45→+45 sweep) |
+| `r2.follow` | 0.5 | VALIDATION-PENDING — short follow at ≤1 m/s |
+| `r2.lat_accel` | 1.0 | VALIDATION-PENDING — gentle |
+| `r2.wheelbase` | **0.229** | **MEASURED** ~9 in (front-to-rear CONFIRM owed); `KIRRA_R2_WHEELBASE_M` |
+| `r2.footprint` (w×l, overhangs) | **0.203 × 0.330** (0.05/0.05) | **MEASURED** body 8 in × 13 in (bench tape); **overhang split ESTIMATED** ((len−wb)/2) |
+
+**Remaining bench captures to firm up `r2` (the 4 items in PLATFORM_R2_PENDING):**
+front-to-rear wheelbase confirmation, servo slew rate (→ `r2.steering_rate`), the
+front/rear overhang split, and track width. MEASURED values are pinned by a unit
+test (`r2_carries_measured_geometry_and_is_slowest`) so they cannot silently drift.
+
+> **Doer-side vs actuation-side.** This `r2` class is the **actuation** envelope
+> (the verifier's per-class contract, Stage 2). The **doer-side** clearance the
+> planner uses each tick (`kirra_params.yaml` occy_doer footprint + lateral
+> clearance) is a separate surface, already set to the same measured geometry — see
+> the "two space surfaces" note there.
 
 ---
 
@@ -141,7 +177,7 @@ instance is the zero-drift proof.
 ## Selection rule — FAIL-CLOSED
 
 `VehicleClass::from_str` accepts case-insensitive `"courier"` / `"delivery-av"` /
-`"robotaxi"`. **Any other string is an `Err`** (the `KIRRA_BACKEND` pattern): a
+`"robotaxi"` / `"r2"`. **Any other string is an `Err`** (the `KIRRA_BACKEND` pattern): a
 typo'd class must **never** silently select another class's (e.g. faster) envelope.
 There is no default class.
 

--- a/docs/hardware/KITT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/KITT_BRINGUP_RUNBOOK.md
@@ -1,0 +1,149 @@
+# KITT bring-up runbook — talk to the R2, start to finish
+
+> One start-to-finish sheet that ties the four KITT scripts + the audio engines +
+> the governed loop together. Every KITT layer is **Channel A (SPEAK) or the ONE
+> fenced door** — none can drive unsafely (see
+> `docs/hardware/KITT_CONVERSATION_DESIGN.md`). Do the safety item (§0) first.
+
+## The pieces (what talks to what)
+
+```
+  🎤 mic ─► whisper (STT) ─► TEXT ─┬─► kitt_converse.py ─(SPEAK)─► Piper (TTS) ─► 🔊
+   (PTT button / Enter)            │      persona + memory + router
+                                   └─(directive TEXT)─► mick POST /intent ─► Occy
+                                        the ONE fail-closed door ─► KIRRA checker ─► wheels
+
+  kitt_watch.py ─(reads /metrics + /narration/last)─(SPEAK on events)─► Piper ─► 🔊
+```
+
+| Script | Role | Channel |
+|---|---|---|
+| `robot/kitt_ask.py` | one-shot grounded Q&A | SPEAK only |
+| `robot/kitt_converse.py` | multi-turn dialogue + persona + router | SPEAK + the fenced door |
+| `robot/kitt_watch.py` | proactive event speech | SPEAK only |
+| `robot/kitt_voice.sh` | voice glue: trigger→record→STT→`kitt_converse` | (drives the above) |
+| `robot/ptt_button.py` | GPIO push-to-talk trigger | trigger only |
+
+---
+
+## 0. Safety first (do NOT skip)
+
+- 🔴 **Hardware e-stop present and tested** if the wheels can turn — a physical
+  kill in the motor-power line (`R2_UNTETHERED_BRINGUP.md` §3). The PTT button is
+  a MIC trigger, never the e-stop.
+- For first voice tests, keep it **on the bench, wheels up** (KITT is doer-side;
+  the checker bounds motion, but you're validating a new front-end).
+
+## 1. Prerequisites (once)
+
+- **Audio hardware:** USB mic + speaker on the Orin. Verify ALSA sees them:
+  `arecord -l` (capture) and `aplay -l` (playback).
+- **Offline speech engines:**
+  - whisper.cpp — build `whisper-cli`, fetch a model (`ggml-base.en.bin`).
+  - Piper — fetch a voice (`en_US-lessac-medium.onnx`), wrap playback in
+    `speak.sh` (text on stdin → `piper … --output-raw | aplay -r 22050 -f S16_LE -t raw -`).
+- **LLM:** Ollama running + the model pulled: `ollama pull gemma3:4b`.
+- **Built binaries:** `cargo build -p kirra-sidecars --release`
+  (mick_service, planner_service, taj_service, speech_shell) and the verifier.
+- **Python:** `pip3 install requests`; for the PTT button `pip3 install Jetson.GPIO`
+  (+ gpio group / udev). For the perception answer, a ROS-sourced shell.
+
+## 2. One env file
+
+Copy `robot/install/kitt.env.example` → fill it in → make the KITT scripts read
+it (they source `/etc/kirra/robot.env`):
+
+```bash
+cp robot/install/kitt.env.example /tmp/kitt.env      # edit STT/TTS/RECORD paths
+set -a; . /tmp/kitt.env; set +a                       # or append into /etc/kirra/robot.env
+```
+
+Key ones: `KIRRA_STT_CMD` (required), `KIRRA_TTS_CMD` (speak.sh), `KIRRA_RECORD_CMD`,
+`KIRRA_KITT_MODEL`. For **"why did we stop"** + proactive **deny** events, also set
+`KIRRA_MICK_AUDITOR_TOKEN` (an auditor-role principal, NOT the admin token) so
+mick's `/narration/last` relay works.
+
+## 3. Bring up the governed loop
+
+Per `docs/hardware/R2_LIVE_LOOP_BRINGUP.md`:
+- **Stage-1 (doer dry run, no actuation):** `./robot/stage1_doer_dryrun.sh` +
+  your lidar (`ydlidar_ros2_driver`). Enough for KITT to **see, answer, and
+  route** — nothing moves.
+- **Stage-2 (elevated, wheels up):** add the verifier (2a key) + interceptor +
+  consumer for real motion. **Physically present.**
+
+Health check: `curl -s localhost:{8090,8100,8101,8102}/health` and
+`curl -s localhost:11434/api/tags`.
+
+## 4. Talk to KITT
+
+Pick your entry point.
+
+### A. Type to it (no audio needed — prove the brain first)
+```bash
+./robot/kitt_converse.py
+> what do you see?
+> are we OK?
+> creep forward one meter          # ← a directive: goes to the fenced door
+```
+
+### B. One-shot questions
+```bash
+./robot/kitt_ask.py "why did we stop?"
+```
+
+### C. Voice — keyboard trigger (press Enter to talk)
+```bash
+./robot/kitt_voice.sh                 # Enter → record → whisper → kitt_converse → speak
+```
+
+### D. Voice — GPIO push-to-talk button
+```bash
+python3 robot/ptt_button.py | ./robot/kitt_voice.sh
+```
+
+### E. Command-only voice (Stage 0, straight to the door — no dialogue)
+```bash
+./robot/run_voice_ptt.sh              # ptt_button | speech_shell → POST /intent
+```
+
+## 5. Proactive voice (KITT talks first)
+
+In its own terminal, alongside any of the above:
+```bash
+./robot/kitt_watch.py                 # speaks on posture / checker-deny transitions
+```
+Put an obstacle in front → the checker refuses → KITT: *"I've had to refuse a
+command. …"*. Force a lockout → *"I'm locking out and holding a safe stop."*
+
+## 6. The KITT experience (all together)
+
+Three terminals + the loop:
+1. the loop (§3) + lidar
+2. `./robot/kitt_watch.py`            (proactive)
+3. `python3 robot/ptt_button.py | ./robot/kitt_voice.sh`   (converse by voice)
+
+Press the button, ask *"what's ahead?"* → it looks and answers. Say *"take us
+that way"* → it routes the directive through the door; the checker bounds it;
+KITT confirms. Approach an obstacle → it warns, unprompted. That's KITT.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| KITT prints but never speaks | `KIRRA_TTS_CMD` unset / speak.sh broken | set it; test `echo hi \| ./speak.sh` |
+| "my voice module is offline" | Ollama down / model not pulled | `ollama serve`; `ollama pull gemma3:4b` |
+| "why did we stop" → "unavailable" | mick has no auditor token | set `KIRRA_MICK_AUDITOR_TOKEN`, restart mick |
+| "what do you see" → "perception unavailable" | no ROS / no `/scan` | source ROS; bring up the lidar |
+| voice records silence / garbage | wrong ALSA device / gain | check `arecord -l`; set the card in `KIRRA_RECORD_CMD` |
+| button does nothing | Jetson.GPIO / wrong pin | `pip3 install Jetson.GPIO` + gpio group; set `KIRRA_PTT_GPIO_PIN` |
+| a spoken command didn't drive | checker refused (correct!) or door 422 | ask "why did we stop"; check the loop + verifier |
+
+## References
+- `docs/hardware/KITT_CONVERSATION_DESIGN.md` — the architecture + the safety fence
+- `docs/hardware/R2_LIVE_LOOP_BRINGUP.md` — the governed loop (Stages 1–2)
+- `docs/hardware/R2_UNTETHERED_BRINGUP.md` — off-network + the hardware e-stop
+- `docs/testing/SPEECH_KITT_DEMO.md` — the built STT→intent→TTS loop + engines
+- `robot/install/kitt.env.example` — the single env template

--- a/docs/hardware/KITT_CONVERSATION_DESIGN.md
+++ b/docs/hardware/KITT_CONVERSATION_DESIGN.md
@@ -115,7 +115,7 @@ audio-engineering effort, and the last mile, not the first.
 | Stage | Capability | Build |
 |---|---|---|
 | **0** ✅ | Speak one command; it drives (bounded) or explains the refusal | *done* — `speech_shell` + PTT button |
-| **1** | **Grounded Q&A** — "what's around us / why did we stop / are we OK" answered from real telemetry (SPEAK only) | read-only telemetry reader + a Q&A prompt; no motion path touched |
+| **1** ✅ | **Grounded Q&A** — "what's around us / why did we stop / are we OK" answered from real telemetry (SPEAK only) | *done* — `robot/kitt_ask.py` (read-only telemetry reader + KITT prompt; no motion path) |
 | **2** | **Multi-turn + persona** — conversation memory + KITT character; router splits chat vs directive; directive still goes through the ONE door | `kitt_service` dialogue manager |
 | **3** | **Proactive voice** — event subscriptions (MRC/arrival/posture) → spoken lines | event→speech bridge |
 | **4** | **Voice + polish** — the KITT Piper voice, listening chirp, arrival tones | audio assets |
@@ -124,6 +124,26 @@ audio-engineering effort, and the last mile, not the first.
 Stage 1 is the natural next step and is **almost free**: the telemetry it needs is
 already exposed (posture GETs, `/narration/last`, the corridor snapshot), and it's
 pure SPEAK — it cannot affect safety, so it needs no new review of the spine.
+
+### Stage 1 — how to run (`robot/kitt_ask.py`)
+
+```bash
+./robot/kitt_ask.py "what do you see?"       # answers from a live /scan → Taj
+./robot/kitt_ask.py "why did we stop?"       # answers from the #893 verdict relay
+./robot/kitt_ask.py "are we OK?"             # answers from /fleet/posture
+echo "what's around us" | ./robot/kitt_ask.py   # stdin form (e.g. from whisper-cli)
+export KIRRA_TTS_CMD="./speak.sh"            # optional → KITT speaks the answer aloud
+```
+
+Structural safety (why Stage 1 needs no spine review): `kitt_ask.py` makes only
+**read-only GETs** (posture, narration) + a Taj `/perception` **analysis** POST +
+an Ollama chat POST — there is **no `/intent` POST, no ROS publisher, no serial,
+no release token**. It is Channel A by construction: it can talk about the robot,
+never move it. Each telemetry source is fetched **fail-soft** — a missing source
+becomes "unavailable" in KITT's answer (proven: with everything offline it says
+"my voice module is offline, here is what I have" + the unavailable list, and
+never invents a fact). Grounding: the LLM is instructed to answer ONLY from the
+supplied telemetry; the persona phrases, the numbers are ground truth.
 
 ---
 

--- a/docs/hardware/KITT_CONVERSATION_DESIGN.md
+++ b/docs/hardware/KITT_CONVERSATION_DESIGN.md
@@ -116,7 +116,7 @@ audio-engineering effort, and the last mile, not the first.
 |---|---|---|
 | **0** ✅ | Speak one command; it drives (bounded) or explains the refusal | *done* — `speech_shell` + PTT button |
 | **1** ✅ | **Grounded Q&A** — "what's around us / why did we stop / are we OK" answered from real telemetry (SPEAK only) | *done* — `robot/kitt_ask.py` (read-only telemetry reader + KITT prompt; no motion path) |
-| **2** | **Multi-turn + persona** — conversation memory + KITT character; router splits chat vs directive; directive still goes through the ONE door | `kitt_service` dialogue manager |
+| **2** ✅ | **Multi-turn + persona** — conversation memory + KITT character; router splits chat vs directive; directive still goes through the ONE door | *done* — `robot/kitt_converse.py` (memory + persona + fail-closed router → mick `POST /intent`) |
 | **3** | **Proactive voice** — event subscriptions (MRC/arrival/posture) → spoken lines | event→speech bridge |
 | **4** | **Voice + polish** — the KITT Piper voice, listening chirp, arrival tones | audio assets |
 | **5** | **Full-duplex / barge-in** | streaming STT + duplex audio |
@@ -124,6 +124,28 @@ audio-engineering effort, and the last mile, not the first.
 Stage 1 is the natural next step and is **almost free**: the telemetry it needs is
 already exposed (posture GETs, `/narration/last`, the corridor snapshot), and it's
 pure SPEAK — it cannot affect safety, so it needs no new review of the spine.
+
+### Stage 2 — how to run (`robot/kitt_converse.py`)
+
+```bash
+./robot/kitt_converse.py                 # interactive: one utterance per line (Ctrl-D quits)
+echo "take us to the door" | ./robot/kitt_converse.py --once
+whisper-cli … | ./robot/kitt_converse.py # voice: pipe the transcript per line (PTT + STT)
+```
+
+One dialogue, two channels, with memory + persona. Per turn KITT emits a JSON
+`{say, directive}`; it speaks `say`, and **only if** `directive` is a clear
+movement request does it hand that TEXT to `mick_service POST /intent` — the
+same fail-closed door a human types into. **The door is the router:** KITT never
+builds an intent; mick's `MickIntent::parse_llm_json` is the authority, occy +
+the checker bound the result.
+
+Fail-closed routing (unit-checked in `parse_reply`): anything KITT can't parse as
+an unambiguous directive — prose, a `null`/`"none"`/empty directive, a question —
+resolves to **no directive → SPEAK only → no motion**. A misheard or hallucinated
+directive at worst becomes a checker-APPROVED bounded motion; an unparseable turn
+drives nothing. The only actuation-adjacent call in the whole script is the
+text-to-`/intent` POST — no publisher, no serial, no release token.
 
 ### Stage 1 — how to run (`robot/kitt_ask.py`)
 

--- a/docs/hardware/KITT_CONVERSATION_DESIGN.md
+++ b/docs/hardware/KITT_CONVERSATION_DESIGN.md
@@ -117,7 +117,7 @@ audio-engineering effort, and the last mile, not the first.
 | **0** ✅ | Speak one command; it drives (bounded) or explains the refusal | *done* — `speech_shell` + PTT button |
 | **1** ✅ | **Grounded Q&A** — "what's around us / why did we stop / are we OK" answered from real telemetry (SPEAK only) | *done* — `robot/kitt_ask.py` (read-only telemetry reader + KITT prompt; no motion path) |
 | **2** ✅ | **Multi-turn + persona** — conversation memory + KITT character; router splits chat vs directive; directive still goes through the ONE door | *done* — `robot/kitt_converse.py` (memory + persona + fail-closed router → mick `POST /intent`) |
-| **3** | **Proactive voice** — event subscriptions (MRC/arrival/posture) → spoken lines | event→speech bridge |
+| **3** ✅ | **Proactive voice** — event transitions (posture / checker deny / cache-stale) → spoken lines | *done* — `robot/kitt_watch.py` (read-only `/metrics` + `/narration/last` poll → transition-gated speech) |
 | **4** | **Voice + polish** — the KITT Piper voice, listening chirp, arrival tones | audio assets |
 | **5** | **Full-duplex / barge-in** | streaming STT + duplex audio |
 
@@ -146,6 +146,31 @@ resolves to **no directive → SPEAK only → no motion**. A misheard or halluci
 directive at worst becomes a checker-APPROVED bounded motion; an unparseable turn
 drives nothing. The only actuation-adjacent call in the whole script is the
 text-to-`/intent` POST — no publisher, no serial, no release token.
+
+### Stage 3 — how to run (`robot/kitt_watch.py`)
+
+```bash
+./robot/kitt_watch.py    # run alongside the loop; KITT speaks on events (Ctrl-C quits)
+```
+
+KITT talks to *you*, unprompted. A read-only watcher polls two signals and speaks
+only on a **state transition**:
+
+- **posture** (`GET /metrics` `kirra_fleet_posture` 0/1/2 + cache-stale) →
+  "I've dropped into a degraded mode," "I'm locking out and holding a safe stop,"
+  "all systems nominal," "I've lost a fresh read on my safety state."
+- **the checker's last verdict** (`GET /narration/last`, the #893 relay) → on a
+  NEW deny, "I've had to refuse a command. \<the checker's real reason\>."
+
+Discipline (unit-checked): announces ONLY on change (steady state is silent),
+establishes a baseline on the first poll without speaking (no boot chatter),
+rate-limits flaps, and stays silent for any signal that's unreachable (never a
+false "recovered" from missing data). Channel A only — read-only GETs + TTS, no
+`/intent`, no publisher, no serial: proactive **speech**, never proactive motion.
+
+> **Natural extension (Stage 3b):** a perception-driven "obstacle ahead" warning
+> — needs a light perception feed (a ROS subscribe to `/kirra/perception_health`
+> or `/cmd_vel_raw`), vs. today's HTTP-only posture+verdict events.
 
 ### Stage 1 — how to run (`robot/kitt_ask.py`)
 

--- a/docs/hardware/KITT_CONVERSATION_DESIGN.md
+++ b/docs/hardware/KITT_CONVERSATION_DESIGN.md
@@ -1,0 +1,151 @@
+# KITT-mode — a conversational R2, and why it stays safe
+
+> **Vision:** you talk to the R2 like Michael talks to KITT — free dialogue,
+> personality, situational awareness, proactive commentary — and it talks back.
+> **Thesis:** this is the *cleanest possible demonstration* of the doer/checker
+> split. KITT is a **doer**: it can say anything, be charming, even be wrong. The
+> only thing that ever reaches the wheels is a typed intent that survives
+> `MickIntent::parse_llm_json` → Occy → the KIRRA checker. A conversational LLM
+> is therefore **exactly as safe as a silent one** — the fence and the checker
+> bound it identically. "It can be KITT and it *cannot* drive you into a wall."
+
+This doc is the target architecture and an incremental path. It changes **nothing**
+on the safety spine — every addition lives on the untrusted Mick/doer side of
+`ci/check_mick_actuation_fence.py`.
+
+---
+
+## The one rule that makes this legal
+
+A conversational agent has **two output channels, and they are not equal:**
+
+```
+                        ┌───────────────────────────────────────────────┐
+  you speak ─► STT ─►   │  KITT dialogue agent (LLM + persona + memory)  │
+                        └───────────────┬───────────────────┬───────────┘
+                                        │                    │
+                        (A) SPEAK       │                    │  (B) ACT
+                        anything ───────┘                    └─── a typed intent ONLY,
+                        → TTS → audio out                        through the EXISTING door:
+                        (say it; it never moves)                 POST /intent →
+                                                                 MickIntent::parse_llm_json →
+                                                                 Occy plan → KIRRA checker → wheels
+```
+
+- **Channel A (SPEAK)** is unrestricted: banter, answers, warnings, status, jokes
+  — it renders to TTS and **can never move the robot**. Words are not commands.
+- **Channel B (ACT)** is the *only* path to motion, and it is the **same
+  fail-closed door typed text already uses**. The agent cannot emit a
+  `Twist`, a release token, or a serial byte — it is structurally fenced
+  (`ci/check_mick_actuation_fence.py` covers the whole Mick side, speech
+  included). A hallucinated "sure, flooring it!" in channel A is just *sound*;
+  unless it also produces a well-formed intent in channel B that the **checker**
+  then admits, nothing happens.
+
+This is the whole safety story: **make the personality as rich as you like — it
+has zero actuation authority.** The checker doesn't care how eloquent the doer is.
+
+---
+
+## What's already built (you're further than it looks)
+
+| KITT capability | Status | Where |
+|---|---|---|
+| Voice in (STT) → text | ✅ built | `speech_shell` + `speech.rs` (whisper.cpp) |
+| Text → **one** typed driving intent, fail-closed | ✅ built | `mick_service` `POST /intent` → `MickIntent::parse_llm_json` |
+| Speaks the reason it stopped (narration) | ✅ built | #893 side-channel: verifier `GET /system/verdicts/last` → mick `GET /narration/last` → TTS |
+| A named persona | ✅ partial | mick persona (chauffeur, gemma3:4b) — a label + system prompt, not yet a character |
+| The fence that makes it all safe | ✅ built | `ci/check_mick_actuation_fence.py` |
+
+So today's R2 is a **single-turn command taker that can explain a refusal**. KITT
+is the same spine plus a **dialogue layer** and **proactive voice**.
+
+---
+
+## What "conversational KITT" adds (the gaps)
+
+### 1. A dialogue manager (multi-turn + memory + persona)
+Today `/intent` is one-shot: text → one intent or reject. KITT needs a turn loop
+that holds **conversation context** and decides, per turn, which channel to use:
+
+- *"KITT, what's around us?"* → **SPEAK** (answer from telemetry; no motion).
+- *"Head for the kitchen."* → **ACT** (emit `go_to`/`route_to` through the door).
+- *"Nice weather."* → **SPEAK** (banter; no intent at all).
+
+Design: a new sidecar (`kitt_service`, or an evolved `mick_service`) that wraps
+the LLM with (a) a **KITT system prompt** (dry wit, protective, addresses you by
+name), (b) a **rolling conversation buffer**, and (c) a **router** that classifies
+each turn as chat / question / directive. A directive is handed to the EXISTING
+`MickIntent` parse — the router never bypasses it. Chat/questions never touch it.
+
+### 2. Situational grounding (so it answers *truthfully*, not plausibly)
+KITT should answer "why did we stop?" with the *real* reason, not a guess. Feed
+the agent **read-only** context each turn:
+
+- **fleet posture / node posture** — the posture-exempt observability GETs
+  (`GET /fleet/posture`), so "are we OK?" is grounded.
+- **the last verdict + narration** — the #893 relay already wired
+  (`GET /narration/last`), so "why did you stop?" speaks the checker's actual
+  DenyCode sentence, phrased conversationally.
+- **a perception summary** — the Taj corridor / nearest-obstacle snapshot
+  (`robot/inspect_corridor.py` is exactly this data), so "what do you see?" is
+  real. **Read-only** — grounding inputs are GETs; none is an actuation path.
+
+The persona *phrases*; the numbers are ground truth. KITT never invents telemetry.
+
+### 3. Proactive speech (KITT talks unprompted)
+KITT comments without being asked — "Michael, I'm detecting an obstacle," "we've
+arrived," "returning to a safe stop." This is an **event → speech** path (new):
+the agent SUBSCRIBES to loop events (an MRC stop, goal reached, a posture change,
+a perception cap) and renders a spoken line. Still channel A only — proactive
+*speech*, never proactive *motion*.
+
+### 4. Persona + a voice
+A distinctive Piper voice + the KITT system prompt (the character). Cosmetic to
+the architecture, load-bearing to the experience.
+
+### 5. (Stretch) full-duplex / barge-in
+Talk while it talks, interrupt it. Needs streaming STT + duplex audio — a real
+audio-engineering effort, and the last mile, not the first.
+
+---
+
+## Incremental path (each stage ships + demos on its own)
+
+| Stage | Capability | Build |
+|---|---|---|
+| **0** ✅ | Speak one command; it drives (bounded) or explains the refusal | *done* — `speech_shell` + PTT button |
+| **1** | **Grounded Q&A** — "what's around us / why did we stop / are we OK" answered from real telemetry (SPEAK only) | read-only telemetry reader + a Q&A prompt; no motion path touched |
+| **2** | **Multi-turn + persona** — conversation memory + KITT character; router splits chat vs directive; directive still goes through the ONE door | `kitt_service` dialogue manager |
+| **3** | **Proactive voice** — event subscriptions (MRC/arrival/posture) → spoken lines | event→speech bridge |
+| **4** | **Voice + polish** — the KITT Piper voice, listening chirp, arrival tones | audio assets |
+| **5** | **Full-duplex / barge-in** | streaming STT + duplex audio |
+
+Stage 1 is the natural next step and is **almost free**: the telemetry it needs is
+already exposed (posture GETs, `/narration/last`, the corridor snapshot), and it's
+pure SPEAK — it cannot affect safety, so it needs no new review of the spine.
+
+---
+
+## Honest caveats
+
+- **Latency.** A local LLM on the Orin (gemma3:4b) is a few seconds per turn.
+  Fine for "take me to the kitchen"; a snappier model or a smaller router model
+  for the chat/directive split helps the conversational feel.
+- **The persona has no authority.** Say it in every prompt and every review: KITT
+  *advises and narrates*; it does not decide safety. The checker does. A jailbreak
+  that makes KITT *say* something reckless still produces, at most, a channel-B
+  intent that the checker refuses.
+- **Grounding must stay read-only.** The temptation will be to give KITT a "just
+  do it" backdoor. There is no such door — every directive is a typed intent
+  through `MickIntent::parse_llm_json`, and the fence CI fails the build if the
+  conversational crate ever links an actuation symbol. That constraint is the
+  feature, not a limitation.
+
+## References
+- `docs/hardware/R2_UNTETHERED_BRINGUP.md` — voice UX + the PTT button + e-stop
+- `docs/testing/SPEECH_KITT_DEMO.md` — the built STT→intent→TTS loop
+- `crates/kirra-sidecars/src/mick.rs` — `handle_text` → `LlmBrain` → the intent parse
+- `ci/check_mick_actuation_fence.py` — why a conversational LLM still can't drive
+- `robot/inspect_corridor.py` — the perception snapshot KITT answers "what do you see" from
+- the #893 narration side-channel — how KITT speaks the checker's real reason

--- a/docs/hardware/R2_AUTOSTART_CHECKLIST.md
+++ b/docs/hardware/R2_AUTOSTART_CHECKLIST.md
@@ -1,0 +1,116 @@
+# R2 autostart — the boot-service enablement checklist
+
+> How the R2 comes up on power-on with no laptop (the untethered Layer 1,
+> `R2_UNTETHERED_BRINGUP.md` §1). The unit files exist; this is the ordered,
+> **validate-then-enable** procedure. The rule throughout: **enable a service
+> only after it passes its acceptance wheels-up as a service** — a boot stack
+> that was only ever validated by hand is an unproven configuration.
+>
+> 🔴 **Cannot fail open.** Every unit is fail-closed: a service that doesn't come
+> up leaves the robot **stationary**, never running away. A missing verifier →
+> no releases minted → the consumer decel-to-stops (`503 → 0.0`, SS-002). Boot
+> order below is for *smoothness*, not safety.
+
+## The full unit inventory
+
+| Unit | What | User | Source |
+|---|---|---|---|
+| `kirra.target` (verifier + planner + taj + mick) | governor stack (mint + sidecars) | `kirra` (service acct, sandboxed) | `deploy/systemd/` (via `install.sh`) |
+| `kirra-consumer.service` | verifying motor consumer (ADR-0033 chokepoint) | robot user (`dialout`) | `robot/install/` (staged by `install_kirra.sh`) |
+| `kirra-ros-stack.service` | occy_doer + cmd_vel_interceptor + perception_governor | robot user (ROS + ws) | `robot/install/systemd/` |
+| `kirra-kitt-watch.service` | proactive event speech (Channel A) | robot user (`audio`) | `robot/install/systemd/` |
+| *(external)* `ollama.service` | the local LLM (mick's brain) | its own | the Ollama installer |
+| *(external)* lidar (`ydlidar_ros2_driver`) | `/scan` | robot user | vendor / your launch |
+
+`kitt_voice.sh` / `speech_shell` / `ptt_button.py` are **interactive** (a person
+talks) — they are NOT boot services; run them in a session when you want to talk.
+
+## Boot / dependency order
+
+```
+  network-online.target
+        │
+        ├─► ollama.service ─────────────┐  (mick needs it; else /intent 422s, fail-closed)
+        │                               ▼
+        └─► kirra.target ──────────────► verifier(8090) + planner(8100) + taj(8101) + mick(8102)
+                    │
+                    ├─► kirra-ros-stack ─► occy_doer + interceptor  (holds if a sidecar is down)
+                    ├─► kirra-consumer ──► wheels (decel-to-stops if no releases)
+                    └─► kirra-kitt-watch ► narration (silent if a source is down)
+        (external)  lidar ─► /scan       (occy holds 'stale-scan' without it)
+```
+
+None of these is a HARD requirement of another — every consumer of a missing
+producer **fail-soft holds**. Order is `After=` (best-effort), never `Requires=`.
+
+## Install the units
+
+```bash
+# governor stack (service account, sandboxed) — one command:
+sudo deploy/systemd/install.sh                      # installs + enables kirra.target
+
+# robot-side units (rendered to YOUR user; needs the placeholders filled):
+#   __KIRRA_ROBOT_USER__  → your login user (in dialout + audio groups)
+#   copy binaries/scripts to /opt/kirra (install_kirra.sh does the consumer bits)
+sudo install_kirra.sh                               # stages kirra-consumer (not enabled)
+# render + install the ros-stack + kitt-watch units the same way (fill User=,
+# set KIRRA_ROS_WS_SETUP in /etc/kirra/robot.env), then daemon-reload.
+sudo systemctl daemon-reload
+```
+
+## Enable — ONE service at a time, validate first
+
+For **each** unit: start it, confirm it does its job wheels-up, THEN enable for boot.
+
+```bash
+# 1. governor stack (no wheels involved) — kirra.target install.sh already enabled it.
+systemctl status kirra.target
+curl -s localhost:8090/health   # verifier
+
+# 2. consumer — wheels UP, e-stop in hand. Prove it holds, drives a governed
+#    command, and safe-stops on a killed verifier BEFORE enabling.
+sudo systemctl start kirra-consumer && journalctl -u kirra-consumer -f
+#    …acceptance passes…            → sudo systemctl enable kirra-consumer
+
+# 3. ros-stack — prove occy_doer holds/plans, interceptor relays.
+sudo systemctl start kirra-ros-stack && journalctl -u kirra-ros-stack -f
+#    …acceptance passes…            → sudo systemctl enable kirra-ros-stack
+
+# 4. kitt-watch — confirm it SPEAKS on a posture/deny event (audio-in-service
+#    caveat: needs an ALSA-direct KIRRA_TTS_CMD + the audio group).
+sudo systemctl start kirra-kitt-watch && journalctl -u kirra-kitt-watch -f
+#    …speaks on an event…           → sudo systemctl enable kirra-kitt-watch
+```
+
+## The cold-boot test (the acceptance for Layer 1)
+
+Only after all four are enabled AND individually validated:
+
+1. **Hardware e-stop in hand** (`R2_ESTOP_SPEC.md`), wheels-up first.
+2. Power the robot with **no laptop attached**.
+3. Confirm the stack comes up: `systemctl is-active kirra.target kirra-consumer
+   kirra-ros-stack kirra-kitt-watch` → all `active`; `curl localhost:8090/health`.
+4. Give a goal (voice via a session, or a pre-loaded mission) → governed motion.
+5. **Fail-closed drill:** `systemctl stop kirra-verifier` mid-run → the consumer
+   decel-to-stops (no runaway). Restart → recovers.
+
+Record results in the bring-up log. Then, and only then, is unattended cold-boot
+operation in scope.
+
+## Status (honest)
+
+- ✅ Governor stack units + one-command install (`deploy/systemd/`).
+- ✅ Consumer unit staged (`install_kirra.sh`).
+- ✅ **ROS-stack + KITT-watch units authored** (`robot/install/systemd/`, this
+  change) — `start_sidecars:=false` so they don't double-bind `kirra.target`'s.
+- ⬜ **Per-service wheels-up validation + `enable`** — hardware, not yet done.
+- ⬜ **Audio-in-a-system-service** proven for `kirra-kitt-watch` (ALSA-direct) —
+  until then, run the narrator in a login session.
+- ⬜ An installer step that renders the two new units' `User=` +
+  `KIRRA_ROS_WS_SETUP` (today: fill the placeholders by hand).
+
+## References
+- `docs/hardware/R2_UNTETHERED_BRINGUP.md` §1 — the autostart layer
+- `docs/hardware/R2_ESTOP_SPEC.md` — the hardware e-stop (do first)
+- `deploy/systemd/README.md` + `install.sh` — the governor stack lifecycle
+- `robot/install/install_kirra.sh` — the consumer staging

--- a/docs/hardware/R2_ESTOP_SPEC.md
+++ b/docs/hardware/R2_ESTOP_SPEC.md
@@ -1,0 +1,151 @@
+# R2 hardware e-stop — specification
+
+> **Status: design spec (buildable). This is the ONE prerequisite for driving the
+> R2 untethered** (`R2_UNTETHERED_BRINGUP.md` §3). Your SSH Ctrl-C soft-stop
+> vanishes off-network; the software safe-state (SS-002 decel, ADR-0013 request)
+> is necessary but **not sufficient** — a wedged process, a hung SBC, or a lost
+> link must STILL be stoppable by a human. That requires a **software-independent
+> hardware kill in the motor-power line.** The build is electrical; this spec is
+> the engineering, parameterized where the R2's exact power topology must be
+> confirmed on the unit.
+
+## 1. Requirements (what "correct" means)
+
+| # | Requirement | Rationale |
+|---|---|---|
+| R1 | **Software-independent.** The kill removes motor power through hardware; it works with the Jetson hung, the consumer crashed, or the code in any state. | The whole point — software can't stop software that's wedged. |
+| R2 | **Fail-safe / energize-to-run.** De-energized = stopped. Any fault (button pressed, RF lost, coil power lost, wire cut) opens the circuit → motors dead. | Loss of anything defaults to STOP, never to run. |
+| R3 | **Latching.** A hit stays stopped until a human deliberately resets (twist-release), never auto-clears. | Mirrors LockedOut's human-reset semantics. |
+| R4 | **Cuts DRIVE power, keeps COMPUTE alive** (if the topology allows). | The Jetson stays up to log the event + hold the software safe-state + let KITT announce it. A blunt whole-robot kill is the acceptable fallback if the rails can't be split. |
+| R5 | **Deliberate two-part re-arm.** Hardware twist-release restores power, but motion does NOT resume until a software clearance (ADR-0013 grant). | Prevents a post-reset lurch; defense in depth. |
+| R6 | **Sense line (advisory).** The e-stop state is readable by software (a GPIO input) so the consumer latches a hold + KITT says "emergency stop engaged." | Observability only — NEVER the stopping mechanism (R1 stands alone). |
+| R7 | **Reachable.** A mushroom head on the robot AND an RF fob for range. | You must be able to hit it from where you watch. |
+
+## 2. Where it cuts (relative to the existing safety spine)
+
+Three nested layers, outermost wins:
+
+```
+  planner (doer) ─► KIRRA checker ─► verifier mint ─► consumer FFI verify (ADR-0033)
+                                                            │  set_motor over /dev/myserial
+       (1) software MRC: SS-002 decel-to-stop, ADR-0013     ▼
+       (2) sense line → consumer latches hold          [ Rosmaster motor driver ]
+                                                            │  motor + steering power
+       (3) HARDWARE E-STOP  ── the SAFETY RELAY ──────────►╳  ← opens here (R1, software-independent)
+                                                            ▼
+                                                          wheels
+```
+
+- **(1)** is the graceful, software stop (already built).
+- **(2)** is advisory — the consumer reads the sense line and behaves consistently.
+- **(3)** is this spec: a relay in the **motor-drive power feed** that opens on any
+  fault, independent of (1)/(2). **Cut the motor-driver supply, not the Jetson
+  rail** (R4) — confirm on the unit which conductor that is (see §5 unknowns).
+
+## 3. The circuit — an energize-to-run safety relay (primary design)
+
+The classic e-stop pattern. One **safety relay** sits in series with the motor
+supply; its coil is held energized (relay closed → motors powered) ONLY while the
+whole safety chain is intact:
+
+```
+   motor supply (+) ──►[ SAFETY RELAY contacts (NO, held closed) ]──► Rosmaster motor-driver (+)
+
+   coil drive (+V) ──►[ NC mushroom E-stop ]──►[ RF-receiver run contact ]──► RELAY COIL ──► GND
+                        (open when pressed)      (open on RF loss/low batt)
+```
+
+- **Mushroom pressed** → coil circuit open → relay drops out → motors dead. Latched
+  (mushroom stays in until twisted).
+- **RF fob kill** (or RF signal lost, or fob battery dead) → receiver run-contact
+  opens → relay drops out → motors dead. **Fail-safe on link loss** (R2).
+- **Coil power lost / wire cut** → relay drops out → dead (R2).
+- Relay **energizes to run**, so the *default* everywhere is STOP.
+
+**Minimal version (no RF, bench first):** the NC mushroom **directly in series**
+with the motor supply (no relay) if the switch is rated for the motor current.
+Simpler, but no remote kill and the switch carries full motor current — the relay
+version is preferred (the switch then only carries coil current) and is required
+once you add RF.
+
+## 4. The sense line + two-part re-arm (R5/R6)
+
+- **Sense (advisory):** a spare relay contact (or a voltage divider off the motor
+  feed) into a Jetson **GPIO input**. A small watcher (mirror of `ptt_button.py`)
+  reads it; on "engaged" the **consumer latches a hold** like LockedOut and KITT
+  (`kitt_watch.py`) announces *"Emergency stop engaged."* This is observability —
+  the hardware already cut power; software just stays consistent.
+- **Re-arm (deliberate, two-part):**
+  1. **Hardware:** twist-release the mushroom (and/or RF re-arm) → motor power
+     restored.
+  2. **Software:** the consumer STAYS held (no releases minted) until an explicit
+     **ADR-0013 clearance grant** (`ClearanceLoop::try_clear`, `OperatorClearance
+     Grant`) — the same operator-authenticated path that clears a post-collision
+     latch. Only then may motion resume. **No lurch on reset.**
+
+## 5. What to confirm on the unit (the honest unknowns)
+
+Parameterize these before buying parts — they are R2-specific and not yet measured:
+
+- **Motor supply voltage + stall current** — sizes the relay/contactor contacts and
+  the mushroom rating. (Small robot: likely ~7–12 V, a few A per motor; **measure
+  the stall current**, don't assume.)
+- **Power topology** — which conductor feeds the Rosmaster **motor driver** vs. the
+  Jetson/compute rail, so the kill cuts drive-only (R4). If they can't be split on
+  this board, fall back to a **master kill of the whole robot** (blunter — you lose
+  logging, but wheels definitely stop; R4 becomes best-effort).
+- **Steering servo behavior on cut** — cutting drive power leaves the Ackermann
+  servo either unpowered (wheels hold last angle, limp) or also cut. Decide whether
+  to also cut/center the servo; for a low-speed stop, drive-cut alone is acceptable
+  (the robot decelerates roughly straight).
+- **The battery main switch is separate** — the e-stop is NOT the on/off switch; it
+  is an always-in-circuit safety element.
+
+## 6. Test procedure (before the first untethered meter)
+
+Wheels-up first, then tethered floor:
+
+1. **Kill under drive:** command slow motion; hit the mushroom → wheels stop
+   **immediately** (verify < ~250 ms by eye/scope). Latched: stays stopped.
+2. **RF loss = stop:** with the RF kill armed, power off the fob (or walk out of
+   range) → motors drop out (fail-safe, R2).
+3. **Compute survives (R4):** during a kill, confirm the Jetson stays up — `curl
+   localhost:8090/health` still answers, and `kitt_watch` announced the sense event.
+4. **No-lurch re-arm (R5):** twist-release → confirm the robot does NOT move until
+   you issue the software clearance; then it resumes.
+5. **Software-independent (R1):** kill the consumer process (`pkill`), then hit the
+   e-stop mid-coast → wheels still cut (proves the hardware path doesn't need code).
+
+Record results in the bring-up log; only after all five pass is untethered driving
+in scope.
+
+## 7. Bill of materials (indicative — size per §5)
+
+- 1× **latching mushroom E-stop**, NC contacts, rated ≥ motor supply V and (if
+  used in-series) ≥ stall current.
+- 1× **safety relay / contactor**, coil at the drive voltage, contacts rated ≥
+  stall current, **energize-to-run** wiring (NO contacts held closed).
+- 1× **RF relay kit** (receiver + fob) with an **energize-to-run** run-contact
+  (signal present = closed), for the remote kill (R7). Confirm its fail-open-on-
+  signal-loss behavior.
+- Wiring, fuse on the motor feed, a spare relay contact (or divider) + a resistor
+  for the Jetson GPIO **sense** input (level-shift to 3.3 V — do NOT feed motor
+  voltage into the Orin).
+
+## 8. Scope + honesty
+
+- This is a **functional safety element added by the integrator**; it is not
+  certified and its rating must match the measured R2 electricals (§5).
+- It composes with, and does not replace, the software safe-state — SS-002 decel
+  and the ADR-0013 clearance path stay live; the e-stop is the outermost,
+  software-independent layer and the re-arm gate.
+- The GPIO sense line is **advisory only** — the hardware kill (R1) never depends
+  on the Jetson reading it.
+
+## References
+- `docs/hardware/R2_UNTETHERED_BRINGUP.md` §3 — why the e-stop is the prerequisite
+- ADR-0013 / SS-002 — the software e-stop request + decel-to-stop safe state
+- ADR-0033 — the on-device verify chokepoint (the software actuation gate the
+  e-stop sits OUTSIDE of)
+- `parko/crates/parko-core/src/impact.rs` — `OperatorClearanceGrant` /
+  `ClearanceLoop` (the authenticated clearance the two-part re-arm reuses)

--- a/docs/hardware/R2_UNTETHERED_BRINGUP.md
+++ b/docs/hardware/R2_UNTETHERED_BRINGUP.md
@@ -192,7 +192,10 @@ decel-to-stop) *independently of software*.
   dead SBC must still be stoppable by a human reaching the robot or a fob.
 
 This is the one item where "it worked on wifi" does **not** carry over — plan the
-e-stop before the first untethered meter.
+e-stop before the first untethered meter. **Concrete design + BOM + test
+procedure: `docs/hardware/R2_ESTOP_SPEC.md`** (an energize-to-run safety relay in
+the motor feed, fail-safe on any fault, latching, with a two-part re-arm that
+reuses the ADR-0013 clearance grant so there's no post-reset lurch).
 
 ---
 

--- a/docs/hardware/R2_UNTETHERED_BRINGUP.md
+++ b/docs/hardware/R2_UNTETHERED_BRINGUP.md
@@ -1,0 +1,209 @@
+# R2 untethered bring-up — driving off the network, voice-directed
+
+> **Status: architecture + procedure.** The load-bearing claim of this doc is
+> that **your home wifi is not in the robot's control loop** — everything that
+> drives the R2 runs on the Jetson Orin as localhost services. "Untethered" is
+> therefore not a re-architecture; it is replacing the three jobs your SSH
+> session currently stands in for. Each layer below cites the real code; where a
+> piece is not yet hardware-validated it says so.
+
+## 0. Why this is not a re-architecture
+
+Cut the wifi mid-drive and the robot does not notice. The whole governed loop is
+on-box:
+
+```
+  voice / goal ─► mick_service (LLM: Ollama gemma3:4b, LOCAL) ─► /intent/last ┐
+  lidar /scan ─► taj_service (corridor) ─────────────────────┼─► planner_service
+                                                              │    (Occy plan, KIRRA
+                                                              ▼     slow-loop checker)
+                                                         /cmd_vel_raw
+                                                              │  cmd_vel_interceptor
+                                                              ▼  → verifier /actuator…
+                                                    verifier MINTS signed release
+                                                              │  (relay, not mint)
+                                                              ▼
+                                          kirra_motor_consumer (FFI Ed25519 verify,
+                                          ADR-0033 chokepoint) ─► wheels
+```
+
+Every box is a **localhost** process on the Orin — Ollama included. Wifi/SSH give
+you exactly two things, **neither in the control path**: a *terminal* (start /
+stop / observe) and *dev convenience* (`git pull`, editing). Going off-network
+means replacing those two jobs with three onboard capabilities:
+
+| Layer | Replaces (today) | Section |
+|---|---|---|
+| **1. Autostart** | "you type the launch commands over SSH" | §1 |
+| **2. Voice goal source** | "you `curl POST /intent` / publish `/goal_pose`" | §2 |
+| **3. Hardware e-stop** | "you press Ctrl-C over SSH" | §3 |
+
+Comms (own hotspot / RF / Zenoh) is **§4 — optional, for you to monitor, not for
+the robot to drive.**
+
+---
+
+## 1. Autostart — the stack comes up on power-on
+
+The mechanism exists: `robot/install/install_kirra.sh` step 6 **stages** a
+`/etc/systemd/system/kirra-consumer.service` unit (rendered with the robot user),
+reading `/etc/kirra/robot.env` via `EnvironmentFile`. It is deliberately **NOT
+enabled** — the install script warns that consumer-as-a-service has not been
+hardware-validated (the validated path is a terminal run).
+
+**To go headless you enable, per service, AFTER an elevated re-test of each:**
+
+```bash
+# after validating each as a service, wheels-up, one at a time:
+sudo systemctl enable --now kirra-consumer       # the verifying motor consumer
+# + equivalent units for: the verifier, the ros2 launch stack (occy/taj/planner/
+#   interceptor), Ollama, and the voice shell (§2). These units are NOT all
+#   written yet — the consumer one is staged; the rest are the untethered TODO.
+```
+
+🔴 **Gate:** each service must pass its wheels-up acceptance *as a service*
+before `enable`. A boot-time stack that was only ever validated by hand is an
+unproven configuration. Bring them up in dependency order (verifier + Ollama →
+sidecars/launch → consumer → voice shell); a consumer that starts before the
+verifier simply starves into decel-to-stop (fail-safe), so ordering is a
+smoothness concern, not a safety one.
+
+**Boot-order safety note:** none of this can fail *open*. If the verifier isn't
+up when the consumer starts, no releases are minted → the consumer holds its
+minimal-risk stop (the `503 → 0.0` floor, SS-002). Power-on with a missing
+service is a stationary robot, never a runaway.
+
+---
+
+## 2. Voice goal source — you speak, KIRRA still disposes
+
+This is **already built and CI-covered** — `speech_shell`
+(`crates/kirra-sidecars/src/bin/speech_shell.rs` + `speech.rs`), documented in
+`docs/testing/SPEECH_KITT_DEMO.md`. You are wiring hardware to an existing seam,
+not adding a code path.
+
+```
+audio in → STT (whisper.cpp, external OS process) → text
+         → POST /intent   (the SAME fail-closed door typed text uses:
+                            MickIntent::parse_llm_json)
+         → …the governed loop, unchanged…
+verdict + #893 narration → TTS (Piper, external OS process) → audio out ("the car says why")
+```
+
+### The safety guarantee that makes voice legal
+`speech.rs` imports **nothing** from `kirra_planner` or the checker. Its only
+output toward the loop is a `String` handed to the intent door. So a misheard
+command, a garbled transcript, or ambient noise parsed as words **dead-ends
+exactly where typed garbage does** — `MickIntent::parse_llm_json` returns a parse
+failure → no intent latched → no motion. There is no audio→goal path that skips
+that parser, and the Mick actuation fence (`ci/check_mick_actuation_fence.py`)
+covers the speech module too. Voice is as safe as typing, by construction.
+
+### Push-to-talk, never open-mic
+Each turn records ONE bounded clip (`KIRRA_RECORD_CMD`, e.g. `arecord -d 4 …`)
+after you trigger it — no wake word, no always-on microphone. On an untethered
+robot the trigger is a **physical button** (a GPIO push-to-talk), not the Enter
+key.
+
+### Your hardware (mic + speaker)
+- **USB mic + USB/3.5mm speaker** into the Orin. Confirm ALSA sees them:
+  `arecord -l` (capture) / `aplay -l` (playback); set the default device or pass
+  the card in the record/play commands.
+- **STT engine** — build whisper.cpp `whisper-cli` + fetch a model
+  (`ggml-base.en.bin` is a good Orin starting point). Fully offline.
+- **TTS engine** — Piper + a voice (`en_US-lessac-medium.onnx`), wrapped in a
+  one-line `speak.sh` (`piper … --output-raw | aplay -r 22050 -f S16_LE -t raw -`).
+  Fully offline. Unset `KIRRA_TTS_CMD` → narration prints instead of speaks.
+
+### Env (fail-closed on malformed — see SPEECH_KITT_DEMO.md §setup)
+```bash
+export KIRRA_STT_CMD="whisper-cli -m models/ggml-base.en.bin -np -nt -f"  # required
+export KIRRA_TTS_CMD="./speak.sh"          # optional; unset → print-only
+export KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"  # push-to-talk
+# KIRRA_MICK_URL default http://127.0.0.1:8102
+```
+
+Untethered, `speech_shell` becomes a boot service (§1) driven by the PTT button —
+the operator interface with zero network dependency. Everything it needs (whisper,
+Piper, Ollama) is on the box.
+
+> **Remaining for a robot-grade voice UX (beyond the demo):** the GPIO push-to-talk
+> button + audio-feedback tones, and mic placement/gain for a moving platform. The
+> transcription→intent→loop path itself is done and tested.
+
+---
+
+## 3. Hardware e-stop — the real prerequisite (do this FIRST)
+
+Today your e-stop is **Ctrl-C over SSH**. That vanishes the moment you leave the
+network. **Do not drive the R2 untethered until it has a physical/RF hardware
+e-stop** — a switch that removes motor power (or forces the consumer's
+decel-to-stop) *independently of software*.
+
+- The **software half exists**: the operator-console e-stop request (ADR-0013),
+  the LockoutReason path, and the always-available MRC decel-to-stop (SS-002).
+- The **physical half is a hardware addition you must make**: a normally-closed
+  kill switch in the motor-power line and/or an RF kill fob. Software e-stops are
+  necessary but not sufficient for an untethered vehicle — a wedged process or a
+  dead SBC must still be stoppable by a human reaching the robot or a fob.
+
+This is the one item where "it worked on wifi" does **not** carry over — plan the
+e-stop before the first untethered meter.
+
+---
+
+## 4. Comms (optional — monitoring, not control)
+
+Because driving needs no link, comms is purely so *you* can observe/command
+remotely. Ordered by how quickly you can stand each up:
+
+| Option | What it buys | Notes |
+|---|---|---|
+| **Robot's own Wi-Fi AP / your phone hotspot** | SSH + terminal anywhere near the robot | Simplest interim; "carry the network with you." No infra. |
+| **Low-bandwidth RF** (LoRa / telemetry radio) | e-stop + status when you don't need video | Pairs well with the §3 RF kill fob. |
+| **Cellular (LTE/5G modem)** | true remote monitoring, anywhere with coverage | For telemetry/observability, still not the control path. |
+| **Zenoh fleet transport** (`kirra-fleet-transport`, ADR-0007) — **the end goal** | node reports trust/posture to a governor; multi-robot fleet | Untrusted carrier: Ed25519 verify-before-use on every ingest + rate-limit; **fails closed locally when the link drops**. This is the fleet story, not a single-robot requirement. |
+
+**Interim recommendation:** stand up the robot's own AP (or a phone hotspot) so
+you keep your SSH/observability while the voice + autostart + e-stop layers mature;
+move to Zenoh when you go multi-robot. Neither is on the driving path, so you can
+swap them freely without touching the safety loop.
+
+---
+
+## 5. The safety punchline
+
+- **Loss of network is safe by design, not a hazard.** If releases stop flowing
+  the consumer decel-to-stops (`503 → 0.0`, SS-002). Nothing about going
+  off-wifi can make the governor fail *open* — the verify chokepoint (ADR-0033)
+  and the checker are local and fail-closed.
+- **The single thing that genuinely changes off-tether is your soft e-stop** —
+  which is why §3 (a hardware e-stop) is the real prerequisite, ahead of any
+  comms or autostart work.
+- Voice, autostart, and comms are all **operator-interface** changes; the
+  doer→checker→verifier→consumer safety spine is byte-identical whether you're on
+  wifi, on a hotspot, on cellular, or on nothing.
+
+---
+
+## Bring-up order (recommended)
+
+1. **Hardware e-stop** (§3) — before the first untethered meter. Test it: drive a
+   little (tethered/on wifi), hit the physical stop, confirm wheels cut.
+2. **Voice on wifi** (§2) — wire the mic/speaker, run `speech_shell` by hand per
+   `SPEECH_KITT_DEMO.md`, prove "creep forward" → intent → bounded proposal (the
+   Stage-1 loop you already validated), with narration spoken back.
+3. **Autostart, one service at a time** (§1) — validate each as a service
+   wheels-up, then `enable`.
+4. **Cut the cord** — power-on cold, no laptop: stack autostarts, PTT button
+   drives voice, hardware e-stop in hand. Own-AP/hotspot for observability.
+5. **Fleet (later)** — Zenoh transport when you go multi-robot.
+
+## References
+- `docs/hardware/R2_LIVE_LOOP_BRINGUP.md` — the tethered governed loop (Stages 1–2)
+- `docs/testing/SPEECH_KITT_DEMO.md` — the voice UX (whisper.cpp / Piper, env, CI)
+- `robot/install/install_kirra.sh` — installer + the staged `kirra-consumer.service`
+- `ci/check_mick_actuation_fence.py` — why the LLM (and voice) can't drive directly
+- ADR-0033 — the on-device verify chokepoint (local, fail-closed)
+- ADR-0007 / `crates/kirra-fleet-transport` — the Zenoh fleet carrier (verify-before-use)
+- ADR-0013 / SS-002 — the operator e-stop request + the decel-to-stop safe state

--- a/docs/hardware/R2_UNTETHERED_BRINGUP.md
+++ b/docs/hardware/R2_UNTETHERED_BRINGUP.md
@@ -127,9 +127,53 @@ Untethered, `speech_shell` becomes a boot service (§1) driven by the PTT button
 the operator interface with zero network dependency. Everything it needs (whisper,
 Piper, Ollama) is on the box.
 
-> **Remaining for a robot-grade voice UX (beyond the demo):** the GPIO push-to-talk
-> button + audio-feedback tones, and mic placement/gain for a moving platform. The
-> transcription→intent→loop path itself is done and tested.
+### The GPIO push-to-talk button (`robot/ptt_button.py`)
+
+`speech_shell`'s interactive loop fires ONE bounded recording turn per stdin line
+("press Enter"). `robot/ptt_button.py` is a GPIO watcher that emits exactly one
+newline per button press, so a hardware button **becomes** the Enter key —
+**no change to the Rust binary**; the button is just another external OS process,
+like the STT/TTS/record commands.
+
+```
+  [ momentary button ]
+     pin ●───────────┐         one command:
+                     │           ./robot/run_voice_ptt.sh
+     GND ●───────────┘         (= python3 robot/ptt_button.py | speech_shell)
+   internal pull-up idles HIGH; press pulls LOW (falling edge = press)
+```
+
+**Wiring:** a normally-open momentary button between a free GPIO pin and GND. The
+script enables the internal pull-up — **no external resistor**. Confirm the pin is
+a real, unmuxed GPIO on your 40-pin header first.
+
+**Env** (all optional; the button pin is INPUT-only, so a wrong value cannot drive
+anything):
+
+| var | default | meaning |
+|---|---|---|
+| `KIRRA_PTT_GPIO_PIN` | `18` | button pin |
+| `KIRRA_PTT_PIN_MODE` | `BOARD` | `BOARD` (physical pin #) or `BCM` |
+| `KIRRA_PTT_ACTIVE` | `low` | `low` = button→GND (pull-up); `high` = button→3V3 (pull-down) |
+| `KIRRA_PTT_DEBOUNCE_MS` | `200` | press debounce |
+| `KIRRA_PTT_LED_PIN` | — | optional OUTPUT pin lit while pressed (recording feedback) |
+
+**Deps:** `sudo pip3 install Jetson.GPIO` + the running user in the `gpio` group
+with the Jetson udev rules (or run as root). The script fails closed with an
+install hint if `Jetson.GPIO` is unavailable.
+
+🔴 **The PTT button is a MIC trigger, NOT the e-stop.** A press starts one voice
+clip; a misheard/silent press dead-ends in `MickIntent::parse_llm_json` → no
+intent → no motion. It cannot inject a goal or bypass the checker — as safe as
+pressing Enter. The **e-stop is a separate hardware kill** in the motor-power line
+(§3); do not conflate the two circuits (losing the button = can't talk; losing
+the e-stop = can't stop — different criticality).
+
+> **Remaining for a robot-grade voice UX (beyond this button):** audio-feedback
+> tones (a "listening" chirp on press, distinct from the spoken narration), and
+> mic placement/gain for a moving platform. A **hold-to-talk** variant (record
+> only while held, vs. today's press → one bounded `-d 4` clip) is a follow-up —
+> it needs the recorder driven by button *state* rather than a fixed duration.
 
 ---
 

--- a/docs/hardware/R2_UNTETHERED_BRINGUP.md
+++ b/docs/hardware/R2_UNTETHERED_BRINGUP.md
@@ -56,9 +56,12 @@ hardware-validated (the validated path is a terminal run).
 ```bash
 # after validating each as a service, wheels-up, one at a time:
 sudo systemctl enable --now kirra-consumer       # the verifying motor consumer
-# + equivalent units for: the verifier, the ros2 launch stack (occy/taj/planner/
-#   interceptor), Ollama, and the voice shell (§2). These units are NOT all
-#   written yet — the consumer one is staged; the rest are the untethered TODO.
+# The full unit set now EXISTS: kirra.target (verifier + planner + taj + mick,
+# deploy/systemd/), kirra-consumer (robot/install/), and the ROS doer stack +
+# KITT watcher (robot/install/systemd/kirra-ros-stack.service /
+# kirra-kitt-watch.service). The ordered validate-then-enable procedure + the
+# cold-boot acceptance test are in docs/hardware/R2_AUTOSTART_CHECKLIST.md.
+# What remains is per-service wheels-up validation, not authoring.
 ```
 
 🔴 **Gate:** each service must pass its wheels-up acceptance *as a service*

--- a/installer/platform_map.toml
+++ b/installer/platform_map.toml
@@ -27,6 +27,16 @@ base_image = "yahboom-r2 (vendor artifact — operator-flashed; see docs/hardwar
 # INTERIM until the measurement-gated `r2` contract profile lands (Track-A A2):
 # courier is the closest reviewed class; the demo envelope stays the backstop.
 profile_class = "courier"
+# ── R2-CLASS FLIP (draft, GATED — 1 of 3 uncomment sites) ─────────────────────
+# The `r2` kinematic + SG6 classes now EXIST (src/gateway/contract_profiles.rs +
+# parko impact.rs; measured footprint + full-lock steering). To retire the
+# courier interim: comment the `profile_class = "courier"` line above and
+# uncomment the line below — but ONLY AFTER the 4 remaining bench captures land
+# (front-to-rear wheelbase confirm, servo slew rate, overhang split, track width)
+# AND the r2 DYNAMIC limits are benched. Flip all THREE sites together (see
+# robot/install/PLATFORM_R2_PENDING.md "THE FLIP"): this, the verifier's
+# KIRRA_VEHICLE_CLASS, and the interceptor wheelbase_m (→ 0.229).
+# profile_class = "r2"
 motor_port = "/dev/myserial"
 [platform.r2.lidar]
 model = "ydlidar-tg30"

--- a/parko/crates/parko-core/src/impact.rs
+++ b/parko/crates/parko-core/src/impact.rs
@@ -114,6 +114,10 @@ pub enum VehicleClass {
     DeliveryAv,
     /// Robotaxi — full-speed. The frozen reference; uses [`ImpactCfg::default`].
     Robotaxi,
+    /// R2 — the Yahboom Rosmaster R2 bench robot (~1/10 RC scale, ≤1 m/s). A
+    /// collision at that scale/speed is the SMALLEST decel deviation of the
+    /// family. Mirror of the SDK `contract_profiles::VehicleClass::R2`.
+    R2,
 }
 
 impl core::str::FromStr for VehicleClass {
@@ -129,9 +133,10 @@ impl core::str::FromStr for VehicleClass {
             "courier" => Ok(VehicleClass::Courier),
             "delivery-av" => Ok(VehicleClass::DeliveryAv),
             "robotaxi" => Ok(VehicleClass::Robotaxi),
+            "r2" => Ok(VehicleClass::R2),
             other => Err(format!(
                 "unknown vehicle class {other:?}; expected one of \
-                 courier | delivery-av | robotaxi (fail-closed — no default)"
+                 courier | delivery-av | robotaxi | r2 (fail-closed — no default)"
             )),
         }
     }
@@ -145,6 +150,7 @@ impl VehicleClass {
             VehicleClass::Courier => "courier",
             VehicleClass::DeliveryAv => "delivery-av",
             VehicleClass::Robotaxi => "robotaxi",
+            VehicleClass::R2 => "r2",
         }
     }
 }
@@ -188,6 +194,15 @@ pub fn impact_cfg_for_class(class: VehicleClass) -> ImpactCfg {
         // characterization. (CONTRACT_PROFILES.md courier.impact_spike)
         VehicleClass::Courier => ImpactCfg {
             spike_threshold_mps2: 2.5,
+            confirmation_m: 2,
+            confirmation_n: 3,
+        },
+        // VALIDATION-PENDING: the bench R2 (~1/10 scale, ≤1 m/s) — a collision is
+        // the SMALLEST decel deviation of the family, yet still ABOVE sensor noise
+        // (validate() floor 1.0); debounced 2-of-3 against the bumps a small robot
+        // takes. Needs bench characterization. (CONTRACT_PROFILES.md r2.impact_spike)
+        VehicleClass::R2 => ImpactCfg {
+            spike_threshold_mps2: 1.5,
             confirmation_m: 2,
             confirmation_n: 3,
         },
@@ -684,9 +699,11 @@ mod tests {
             VehicleClass::Courier,
             VehicleClass::DeliveryAv,
             VehicleClass::Robotaxi,
+            VehicleClass::R2,
         ] {
             assert_eq!(VehicleClass::from_str(c.as_str()), Ok(c));
         }
+        assert_eq!(VehicleClass::from_str("R2"), Ok(VehicleClass::R2));
         // typos / empty / unknown → Err (never a silent fallback)
         assert!(VehicleClass::from_str("").is_err());
         assert!(VehicleClass::from_str("robotax").is_err());
@@ -700,6 +717,7 @@ mod tests {
             VehicleClass::Courier,
             VehicleClass::DeliveryAv,
             VehicleClass::Robotaxi,
+            VehicleClass::R2,
         ] {
             let c = impact_cfg_for_class(class);
             assert!(
@@ -717,6 +735,10 @@ mod tests {
         let courier = impact_cfg_for_class(VehicleClass::Courier).spike_threshold_mps2;
         let delivery = impact_cfg_for_class(VehicleClass::DeliveryAv).spike_threshold_mps2;
         let robotaxi = impact_cfg_for_class(VehicleClass::Robotaxi).spike_threshold_mps2;
+        let r2 = impact_cfg_for_class(VehicleClass::R2).spike_threshold_mps2;
+        // R2 is the smallest deviation of the family, still above sensor noise.
+        assert!(r2 < courier, "r2 {r2} < courier {courier}");
+        assert!(r2 > 1.0, "r2 threshold {r2} above sensor noise");
         assert!(
             courier < delivery && delivery < robotaxi,
             "threshold ordering courier {courier} < delivery-av {delivery} < robotaxi {robotaxi}"
@@ -786,6 +808,7 @@ mod tests {
             VehicleClass::Courier,
             VehicleClass::DeliveryAv,
             VehicleClass::Robotaxi,
+            VehicleClass::R2,
         ] {
             let cfg = impact_cfg_for_class(class);
             assert!(

--- a/robot/attest_bench_node.py
+++ b/robot/attest_bench_node.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""attest_bench_node.py — bring a fresh single-robot verifier out of the M-9
+empty-fleet LockedOut by registering + ATTESTING one Trusted node.
+
+WHY THIS EXISTS
+---------------
+A freshly-booted verifier with an empty node registry reports fleet posture
+`LockedOut` (code 2) — BY DESIGN, not a bug. See src/posture_engine.rs (M-9):
+
+    An EMPTY live-node set on an Active verifier is "no positive trust
+    evidence", NOT "the fleet is healthy". Caching Nominal there would be
+    fail-OPEN (should_route_command reads Nominal as "admit everything"), so
+    the engine overrides the pure aggregate and forces LockedOut.
+
+The empty-set LockedOut is NOT sticky: it auto-recovers to Nominal the moment
+ONE Trusted node is registered (test: empty-set LockedOut must auto-recover).
+A merely-*registered* node is `Unknown` → the DAG derives Degraded, and under
+Degraded the actuator gate DENIES re-initiation from a standstill
+(DegradedReinitiationDenied) — so the robot still can't start driving. Only a
+`Trusted` node yields Nominal. Trusted requires the real Ed25519 challenge/
+response handshake (INVARIANT #3 — trust is never mocked).
+
+This script runs that handshake honestly for a bench node:
+
+  1. POST /attestation/register        (admin-gated)  -> node Unknown
+  2. POST /attestation/challenge/<id>  (open)         -> nonce (u64)
+  3. sign attestation_signing_payload(node_id, nonce) with the node's AK
+  4. POST /attestation/verify          (open)         -> node Trusted
+  5. GET  /fleet/posture                              -> expect Nominal
+
+The AK private seed is persisted (default /etc/kirra/bench_ak.seed) so re-runs
+reuse the same key and are idempotent across verifier restarts.
+
+  🔴 BENCH/DEMO ONLY. A production node proves possession of a hardware-rooted
+  AK (measured boot + TPM quote, kirra-ota-ctl enroll). This generates a
+  software AK on the box — never provision it on a golden unit.
+
+USAGE
+-----
+  set -a; source /etc/kirra/kirra.env; set +a   # for KIRRA_ADMIN_TOKEN
+  python3 robot/attest_bench_node.py
+
+ENV (all optional except the admin token):
+  KIRRA_URL         verifier base URL         (default http://localhost:8090)
+  KIRRA_ADMIN_TOKEN admin bearer token        (REQUIRED; register is admin-gated)
+  KIRRA_BENCH_NODE_ID  node id to attest      (default "r2-bench")
+  KIRRA_BENCH_AK_SEED_FILE  AK seed path      (default /etc/kirra/bench_ak.seed,
+                            falls back to ~/.kirra_bench_ak.seed if unwritable)
+"""
+import os
+import struct
+import sys
+
+# Domain-separation tag — MUST byte-match ATTESTATION_DOMAIN in
+# crates/kirra-safety-authority/src/attestation.rs.
+ATTESTATION_DOMAIN = b"kirra-attestation-challenge-v1"
+
+
+def die(msg, code=1):
+    print(f"attest_bench_node: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+try:
+    import requests
+except ImportError:
+    die("python3 'requests' not found — pip3 install requests")
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives import serialization
+except ImportError:
+    die("python3 'cryptography' not found — pip3 install cryptography")
+
+
+def signing_payload(node_id: str, nonce: int) -> bytes:
+    """Byte-identical to attestation_signing_payload(node_id, nonce):
+        DOMAIN || u64_le(len(node_id)) || node_id || u64_le(nonce)
+    """
+    idb = node_id.encode("utf-8")
+    return (
+        ATTESTATION_DOMAIN
+        + struct.pack("<Q", len(idb))
+        + idb
+        + struct.pack("<Q", nonce)
+    )
+
+
+def load_or_make_ak(seed_file: str) -> Ed25519PrivateKey:
+    """Persist a raw 32-byte Ed25519 seed so re-runs reuse the same AK."""
+    if os.path.exists(seed_file):
+        with open(seed_file, "rb") as f:
+            seed = f.read(32)
+        if len(seed) != 32:
+            die(f"{seed_file} is not a 32-byte seed (len={len(seed)})")
+        return Ed25519PrivateKey.from_private_bytes(seed)
+    sk = Ed25519PrivateKey.generate()
+    seed = sk.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    try:
+        # Try the requested (privileged) location first, mode 600.
+        fd = os.open(seed_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "wb") as f:
+            f.write(seed)
+        print(f"  generated a fresh bench AK, saved -> {seed_file}")
+    except (PermissionError, FileExistsError, OSError) as e:
+        fallback = os.path.expanduser("~/.kirra_bench_ak.seed")
+        if seed_file != fallback:
+            print(f"  ⚠ could not write {seed_file} ({e}); using {fallback}")
+            # Recurse ONCE against the fallback path.
+            return load_or_make_ak(fallback)
+        raise
+    return sk
+
+
+def public_pem(sk: Ed25519PrivateKey) -> str:
+    return (
+        sk.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+    )
+
+
+def main():
+    base = os.environ.get("KIRRA_URL", "http://localhost:8090").rstrip("/")
+    token = os.environ.get("KIRRA_ADMIN_TOKEN", "").strip()
+    node_id = os.environ.get("KIRRA_BENCH_NODE_ID", "r2-bench").strip()
+    seed_file = os.environ.get("KIRRA_BENCH_AK_SEED_FILE", "/etc/kirra/bench_ak.seed")
+    if not token:
+        die("KIRRA_ADMIN_TOKEN is empty — register is admin-gated. "
+            "Source the verifier env: set -a; source /etc/kirra/kirra.env; set +a")
+
+    print(f"== bench-attest node '{node_id}' at {base} ==")
+    sk = load_or_make_ak(seed_file)
+    pem = public_pem(sk)
+    auth = {"Authorization": f"Bearer {token}"}
+
+    # 1. register (idempotent: a re-register just refreshes the Unknown record).
+    r = requests.post(
+        f"{base}/attestation/register",
+        json={"node_id": node_id, "ak_public_pem": pem},
+        headers=auth,
+        timeout=5,
+    )
+    if r.status_code not in (200, 201):
+        die(f"register failed: HTTP {r.status_code} {r.text}")
+    print(f"  1. register     -> {r.status_code}")
+
+    # 2. challenge.
+    r = requests.post(f"{base}/attestation/challenge/{node_id}", timeout=5)
+    if r.status_code != 200:
+        die(f"challenge failed: HTTP {r.status_code} {r.text}")
+    nonce = int(r.json()["nonce"])
+    print(f"  2. challenge    -> nonce={nonce}")
+
+    # 3. sign the domain-separated challenge payload with the node's AK.
+    sig = sk.sign(signing_payload(node_id, nonce))
+    proof_hex = sig.hex()
+
+    # 4. verify -> Trusted.
+    r = requests.post(
+        f"{base}/attestation/verify",
+        json={"node_id": node_id, "nonce": nonce, "proof_hex": proof_hex},
+        timeout=5,
+    )
+    if r.status_code != 200:
+        die(f"verify failed: HTTP {r.status_code} {r.text}")
+    print(f"  3. verify       -> {r.status_code} {r.json()}")
+
+    # 5. confirm the fleet recovered to Nominal.
+    r = requests.get(f"{base}/fleet/posture", timeout=5)
+    print(f"  4. fleet/posture-> {r.status_code} {r.text}")
+    print()
+    print("✔ node attested Trusted. If fleet posture is now Nominal the actuator "
+          "gate will admit /actuator/motion/command; if still LockedOut, give the "
+          "posture engine a moment to recalc and re-GET /fleet/posture.")
+
+
+if __name__ == "__main__":
+    main()

--- a/robot/inspect_corridor.py
+++ b/robot/inspect_corridor.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""inspect_corridor.py — snapshot WHY occy_doer holds, from the live lidar.
+
+Replicates occy_doer's exact per-tick pipeline ONCE — grab one /scan, POST it to
+the Taj sidecar (/perception), extend the corridor back like occy does, then POST
+{ego, goal, corridor, objects, vehicle} to the Occy planner (/plan) — and prints:
+
+  * the nearest lidar return overall + in the forward ±15° cone (is the robot
+    boxed in? → a real obstacle within ~1 m explains a correct MRC refusal),
+  * the Taj corridor (point counts + half-width ahead) + detected objects,
+  * the planner's kind / verdict / #893 NARRATION reason — the operator sentence
+    that says exactly why the checker refused.
+
+Read-only, zero actuation. Run while the Stage-1 stack is up (taj 8101, planner
+8100) and the lidar is publishing /scan. Domain-28 shell, ws sourced.
+
+  ros2 run is not needed — just:  python3 robot/inspect_corridor.py
+"""
+import math
+import sys
+import time
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+from sensor_msgs.msg import LaserScan
+
+try:
+    import requests
+except ImportError:
+    sys.exit("python3-requests missing (pip3 install requests)")
+
+# Faithful to occy_doer: same back-extension of the Taj corridor.
+from kirra_safety.doer_core import extend_corridor_back
+
+TAJ = "http://localhost:8101"
+PLANNER = "http://localhost:8100"
+FORWARD_EXTENT_M = 8.0     # occy_doer forward_extent_m default
+BACK_M = 0.5               # occy_doer corridor_back_m default
+CRUISE = 1.2               # occy_doer cruise_speed_mps default
+GOAL = (1.0, 0.0)          # 1 m dead ahead (the go_to (1,0) intent)
+FORWARD_CONE_RAD = math.radians(15.0)
+# Robot-scale footprint occy sends (kirra_params.yaml / CONTRACT_PROFILES courier).
+VEHICLE = {
+    "class": "courier", "wheelbase_m": 0.2, "half_length_m": 0.18,
+    "half_width_m": 0.15, "max_speed_mps": 1.2, "max_steering_deg": 30.0,
+    "rss_lateral_alignment_tolerance_m": 0.6, "lateral_clearance_target_m": 0.6,
+}
+
+SCAN_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST, depth=1,
+)
+
+
+class Grab(Node):
+    def __init__(self):
+        super().__init__("inspect_corridor")
+        self.scan = None
+        self.create_subscription(LaserScan, "/scan", self._on, SCAN_QOS)
+
+    def _on(self, msg):
+        self.scan = msg
+
+
+def _half_width_at(left, right, x):
+    """Corridor half-widths (|y|) at the boundary point nearest x, for a sense of
+    how wide Taj thinks the free lane is ahead."""
+    def near(poly):
+        if not poly:
+            return None
+        best = min(poly, key=lambda p: abs(p[0] - x))
+        return best[1]
+    return near(left), near(right)
+
+
+def main():
+    rclpy.init()
+    node = Grab()
+    print("waiting for one /scan (BEST_EFFORT)...")
+    t0 = time.monotonic()
+    while node.scan is None and time.monotonic() - t0 < 5.0:
+        rclpy.spin_once(node, timeout_sec=0.2)
+    scan = node.scan
+    if scan is None:
+        node.destroy_node(); rclpy.shutdown()
+        sys.exit("NO /scan in 5 s — is the lidar publishing on domain 28?")
+
+    ranges = [float(r) for r in scan.ranges]
+    n = len(ranges)
+    finite = [(i, r) for i, r in enumerate(ranges)
+              if math.isfinite(r) and r > scan.range_min]
+    nearest = min((r for _, r in finite), default=float("inf"))
+    # forward cone: angle = angle_min + i*inc, |angle| < cone
+    fwd = [r for i, r in finite
+           if abs(scan.angle_min + i * scan.angle_increment) < FORWARD_CONE_RAD]
+    nearest_fwd = min(fwd, default=float("inf"))
+
+    print("\n=== LIDAR /scan ===")
+    print(f"  points={n}  angle=[{scan.angle_min:.2f},{scan.angle_max:.2f}]rad  "
+          f"range=[{scan.range_min:.2f},{scan.range_max:.2f}]m")
+    print(f"  nearest return (any dir): {nearest:.3f} m")
+    print(f"  nearest in FORWARD ±15°:  {nearest_fwd:.3f} m   "
+          f"{'<-- obstacle within 1 m ahead (MRC is CORRECT)' if nearest_fwd < 1.0 else ''}")
+
+    # --- Taj ---
+    try:
+        taj = requests.post(f"{TAJ}/perception", timeout=2.0, json={
+            "angle_min_rad": float(scan.angle_min),
+            "angle_increment_rad": float(scan.angle_increment),
+            "range_min_m": float(scan.range_min),
+            "range_max_m": float(scan.range_max),
+            "ranges": ranges, "stamp_ms": 0, "forward_extent_m": FORWARD_EXTENT_M,
+        }).json()
+    except Exception as e:
+        node.destroy_node(); rclpy.shutdown()
+        sys.exit(f"Taj /perception failed: {e}")
+
+    left, right = taj.get("left", []), taj.get("right", [])
+    objects = taj.get("objects", [])
+    print("\n=== TAJ corridor ===")
+    print(f"  left pts={len(left)}  right pts={len(right)}  objects={len(objects)}")
+    for x in (0.3, 0.5, 1.0):
+        lw, rw = _half_width_at(left, right, x)
+        print(f"  at x~{x:.1f} m:  left y={lw}  right y={rw}")
+    if objects:
+        near_obj = min(objects, key=lambda o: math.hypot(o.get("x", 9e9), o.get("y", 9e9)))
+        print(f"  nearest object: x={near_obj.get('x')} y={near_obj.get('y')} "
+              f"(dist {math.hypot(near_obj.get('x', 0), near_obj.get('y', 0)):.2f} m)")
+    if not left or not right:
+        print("  ** corridor is EMPTY on a side → planner cannot fit → MRC "
+              "(Taj found no forward free space)")
+
+    # --- planner (occy's exact call) ---
+    lext, rext = extend_corridor_back(left, right, BACK_M)
+    try:
+        plan = requests.post(f"{PLANNER}/plan", timeout=2.0, json={
+            "ego": {"x": 0.0, "y": 0.0, "heading": 0.0, "speed": 0.0},
+            "goal": {"x": GOAL[0], "y": GOAL[1]}, "cruise": CRUISE,
+            "left": lext, "right": rext, "objects": objects, "vehicle": VEHICLE,
+        }).json()
+    except Exception as e:
+        node.destroy_node(); rclpy.shutdown()
+        sys.exit(f"planner /plan failed: {e}")
+
+    print("\n=== OCCY planner verdict ===")
+    print(f"  kind={plan.get('kind')}  verdict={plan.get('verdict')}  "
+          f"traj_pts={len(plan.get('trajectory', []))}")
+    for k in ("narration", "reason", "deny_code", "explanation", "detail"):
+        if k in plan:
+            print(f"  {k}: {plan[k]}")
+    verdict = plan.get("verdict")
+    if plan.get("kind") == "Motion" and verdict in ("Accept", "Clamp"):
+        print("  => WOULD DRIVE. If the live occy still holds, its corridor differs "
+              "(the robot moved / scan changed since).")
+    else:
+        print("  => REFUSED. Cause is above: a forward obstacle, an empty/"
+              "one-sided corridor, or a footprint that won't fit.")
+
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/robot/install/PLATFORM_R2_PENDING.md
+++ b/robot/install/PLATFORM_R2_PENDING.md
@@ -50,14 +50,30 @@ Each item lands only after on-hardware validation on the R2 image:
   `installer/kirra_install.py verify --platform r2` passing (mode-5 check,
   `installer/platform_map.toml:18-39`).
 - **Steering calibration measurements** (`robot/steering_bench_elevated.sh`,
-  Track-A A1/A5 — wheels elevated, protractor + tape):
-  - physical road-wheel angle at full lock (the future profile's
-    `max_steering_deg` — the vendor command envelope is `[-45,+45]` command
-    units about a 90 default, and command units ≠ road-wheel degrees until
-    measured);
-  - wheelbase confirmation (≈0.229 m measured on the bench — confirm on the
-    R2 image before it becomes a profile value);
-  - footprint (half-length / half-width), servo slew, `v_z` sign convention.
+  Track-A A1/A5 — wheels elevated, protractor + tape). **Status as of
+  2026-07-18 (partly MEASURED):**
+  - ✅ **road-wheel angle at full lock — MEASURED**: ~39° (0.68 rad) at
+    command ±45 (protractor sweep, `r2_drive_calibration_results.txt` Phase C,
+    2026-07-17). This is the future profile's `max_steering_deg`; command
+    units ≠ road-wheel degrees was the open question and it is now answered.
+    (Supersedes any earlier note that full-lock was unmeasured.)
+  - ✅ **footprint — MEASURED**: body 13 in × 8 in = 0.330 × 0.203 m →
+    half-length 0.165 m, half-width 0.102 m (bench tape). Now carried on the
+    doer side (`kirra_params.yaml` occy_doer, +small margin).
+  - ✅ **`v_z` / steering sign convention — MEASURED**: a NEGATIVE command
+    steers LEFT (`KIRRA_R2_STEER_SIGN=-1`, bench-verified).
+  - 🔶 **wheelbase — MEASURED ≈0.229 m (~9 in), front-to-rear CONFIRM owed**:
+    confirm the 9 in is true front-axle→rear-axle (not e.g. body/hub span)
+    before it becomes a profile value.
+  - ⬜ **STILL UNMEASURED (the one-pass bench list to unblock the `r2`
+    profile, task #85)**:
+    - front-to-rear wheelbase confirmation (tape, axle-center to axle-center);
+    - servo slew rate (steering-angle change per second at full command step —
+      time a full −45→+45 sweep; feeds the profile's `steering_rate`);
+    - front & rear overhang from the ego origin (base_link/lidar) — fixes
+      whether the footprint is front-, center-, or rear-biased (half_length
+      currently assumes a roughly-front origin);
+    - track width (left-wheel-center to right-wheel-center).
 - **The `r2` contract profile** (Track-A A2): a NEW compiled class named `r2`
   (not `x3`, not the interim `courier`) in the contract-profiles registry,
   with wheelbase / steering / envelope values **from the measurements above —

--- a/robot/install/PLATFORM_R2_PENDING.md
+++ b/robot/install/PLATFORM_R2_PENDING.md
@@ -94,6 +94,31 @@ Each item lands only after on-hardware validation on the R2 image:
   mismatch, so a wrong value fails safe — but Layer B is where it becomes
   *correct*, derived from the profile, not a loose default).
 
+## THE FLIP — retire the `courier` interim (3 gated uncomment sites)
+
+The `r2` classes now **exist and compile** (SDK `contract_profiles.rs` kinematic
+envelope + parko `impact.rs` SG6 threshold; measured footprint + full-lock
+steering, dynamic limits VALIDATION-PENDING). The deployment switch is drafted as
+**three commented-out blocks** — when the gate below is met, the flip is exactly
+**three uncomments** (no new plumbing):
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `installer/platform_map.toml` | `profile_class = "courier"` → `"r2"` |
+| 2 | `ros2_ws/src/kirra_safety/config/kirra_params.yaml` | interceptor `wheelbase_m: 0.2` → `0.229` (r2 contract == physical) |
+| 3 | `robot/install/env.template` (verifier env) | uncomment `KIRRA_VEHICLE_CLASS=r2`; on the R2 image also `KIRRA_EXPECTED_CAR_TYPE=5` |
+
+**🔴 GATE — do NOT uncomment until ALL hold:**
+1. The 4 remaining bench captures recorded (front-to-rear wheelbase confirm,
+   servo slew rate, overhang split, track width) — the ⬜ items above.
+2. The r2 **dynamic** limits benched (max speed / accel / brake), replacing the
+   conservative VALIDATION-PENDING estimates in `contract_profiles.rs`.
+3. Human review of the measurement-derived numbers.
+
+All three sites cross-reference each other; flipping only one **fails safe** (the
+interceptor's wheelbase cross-check latches a stop on a class/param mismatch), so
+a partial flip stops the robot rather than mis-driving it.
+
 ## Definition of done for Layer B
 
 1. Vendor R2 image flashed; drive + steering verified together (elevated).

--- a/robot/install/env.template
+++ b/robot/install/env.template
@@ -55,6 +55,24 @@ KIRRA_MOTOR_PORT=/dev/myserial
 # See robot/install/PLATFORM_R2_PENDING.md. Do NOT set 5 on the current image.
 KIRRA_EXPECTED_CAR_TYPE=1
 
+# ---------------------------------------------------------------------------
+# R2 CONTRACT-CLASS FLIP (draft, GATED — 3 of 3 uncomment sites).
+#
+# The `r2` kinematic + SG6 classes now EXIST (src/gateway/contract_profiles.rs +
+# parko impact.rs; measured footprint 0.203×0.330 m, wheelbase 0.229 m, full-lock
+# steering 39°). To retire the interim `courier` borrow, uncomment
+# KIRRA_VEHICLE_CLASS below — but ONLY AFTER the 4 remaining bench captures land
+# AND the r2 dynamic limits are benched (PLATFORM_R2_PENDING.md "THE FLIP").
+# Flip all THREE sites together: this, installer/platform_map.toml
+# profile_class="r2", and the interceptor wheelbase_m=0.229. On the R2 image also
+# set KIRRA_EXPECTED_CAR_TYPE=5 (the =1 above).
+#
+# ⚠ KIRRA_VEHICLE_CLASS is a VERIFIER-side var (also the parko node) — it selects
+# the ACTUATOR envelope + SG6 class and is NOT read by this motor consumer. It is
+# documented here so the R2 flip lives in one place; set it wherever the verifier
+# reads its env (the Stage-2 verifier launch / its EnvironmentFile).
+#KIRRA_VEHICLE_CLASS=r2
+
 # ROS
 ROS_DOMAIN_ID=28
 

--- a/robot/install/env.template
+++ b/robot/install/env.template
@@ -100,18 +100,31 @@ KIRRA_CONSUMER_LIB=/opt/kirra/lib/libkirra_consumer_ffi.so
 # governed consumer. Uncomment KIRRA_DRIVE_MODE only after that passes.
 #KIRRA_DRIVE_MODE=r2_ackermann
 #
-# R2 profile (fail-closed: a missing/invalid value aborts startup). Provenance is
-# per-value below — most are MEASURED (robot/r2_drive_calibration_results.txt,
-# never guessed); a few are deliberate operational CHOICES, called out as such.
-KIRRA_R2_WHEELBASE_M=0.229          # CHOSEN/expected (Phase D not tape-measured yet; ~0.229 nominal)
-KIRRA_R2_V_PER_PWM=0.0145           # MEASURED — (m/s) per PWM (LEFT-channel slope; equal-PWM v0)
-KIRRA_R2_PWM_MAX=40                 # CHOSEN — low-speed v0 cap (below the anomalous +40 drive row)
-KIRRA_R2_STEER_UNITS_PER_RAD=66     # MEASURED — K, servo command-units per radian
-KIRRA_R2_DELTA_MAX_RAD=0.68         # MEASURED — road-wheel angle at full lock (~39°)
-KIRRA_R2_STEER_SIGN=-1              # MEASURED — a NEGATIVE command steers LEFT (bench-verified)
-KIRRA_R2_CENTER_TRIM=90             # MEASURED — set_akm_default_angle for physical straight
-KIRRA_R2_DRIVE_DEADBAND_PWM=0       # CHOSEN — 0 = proportional (reviewed v0). (Bench saw a physical
-                                    # deadband ~5 PWM; this configured 0 is the v0 choice, not that measurement.)
+# R2 profile (fail-closed: a missing/invalid value aborts startup).
+#
+# 🔴 systemd EnvironmentFile SAFETY: NO inline `# comments` on the value lines
+# below. This file is consumed BOTH by a shell `source` (which strips inline
+# comments) AND by systemd `EnvironmentFile=` (which does NOT — the comment would
+# become part of the value and the consumer fail-closes with "must be a number,
+# got '0.229          # ...'"). Keep every value BARE; provenance goes here.
+#
+# Provenance (r2_drive_calibration_results.txt; MEASURED unless noted CHOSEN):
+#   WHEELBASE_M 0.229      CHOSEN/expected (~0.229 nominal; tape-confirm pending)
+#   V_PER_PWM 0.0145       MEASURED (m/s per PWM; LEFT/RL slope, equal-PWM v0)
+#   PWM_MAX 40             CHOSEN low-speed v0 cap
+#   STEER_UNITS_PER_RAD 66 MEASURED servo command-units per radian
+#   DELTA_MAX_RAD 0.68     MEASURED full-lock road-wheel angle (~39°)
+#   STEER_SIGN -1          MEASURED (a NEGATIVE command steers LEFT)
+#   CENTER_TRIM 90         MEASURED set_akm_default_angle for physical straight
+#   DRIVE_DEADBAND_PWM 0   CHOSEN proportional v0 (bench saw ~5 PWM physical deadband)
+KIRRA_R2_WHEELBASE_M=0.229
+KIRRA_R2_V_PER_PWM=0.0145
+KIRRA_R2_PWM_MAX=40
+KIRRA_R2_STEER_UNITS_PER_RAD=66
+KIRRA_R2_DELTA_MAX_RAD=0.68
+KIRRA_R2_STEER_SIGN=-1
+KIRRA_R2_CENTER_TRIM=90
+KIRRA_R2_DRIVE_DEADBAND_PWM=0
 
 # ---------------------------------------------------------------------------
 # R2 Path-B CLOSED-LOOP speed matching (proposal §9) — OFF by default.
@@ -129,9 +142,12 @@ KIRRA_R2_DRIVE_DEADBAND_PWM=0       # CHOSEN — 0 = proportional (reviewed v0).
 # wiring is the NEXT slice and the gains are NOT yet hardware-tuned. Leave OFF
 # until closed-loop is validated on the bench (elevated first).
 #KIRRA_R2_CLOSED_LOOP=1
-# Measured (from the RR confirm); required when the flag is on:
-KIRRA_R2_M_PER_TICK=0.00025101      # MEASURED — encoder scale (m/tick); RL 66.675mm wheel / 834.5 t/rev
-KIRRA_R2_V_PER_PWM_RIGHT=0.0194     # MEASURED — RR feedforward slope (m/s)/PWM (RL slope is KIRRA_R2_V_PER_PWM)
+# Measured (from the RR confirm); required when the flag is on. Values BARE
+# (systemd EnvironmentFile safety — see the R2-profile note above):
+#   M_PER_TICK 0.00025101 = encoder scale m/tick (RL 66.675mm wheel / 834.5 t/rev)
+#   V_PER_PWM_RIGHT 0.0194 = RR feedforward slope (m/s)/PWM (RL slope = KIRRA_R2_V_PER_PWM)
+KIRRA_R2_M_PER_TICK=0.00025101
+KIRRA_R2_V_PER_PWM_RIGHT=0.0194
 # Controller gains — CONSERVATIVE DEFAULTS, not yet hardware-tuned (optional):
 #KIRRA_R2_SPEED_KP=20               # PWM per (m/s error)
 #KIRRA_R2_SPEED_MAX_PWM_STEP=5      # per-cycle slew cap on each wheel's PWM

--- a/robot/install/install_kirra.sh
+++ b/robot/install/install_kirra.sh
@@ -105,7 +105,7 @@ echo "== 3. install -> ${OPT} =="
 sudo install -d -m 0755 "${OPT}/lib" "${OPT}/bin" "${OPT}/robot"
 sudo install -m 0644 "${SO}"   "${OPT}/lib/libkirra_consumer_ffi.so"
 sudo install -m 0755 "${MINT}" "${OPT}/bin/kirra_ros_release_mint"
-for f in kirra_motor_consumer.py kirra_ffi.py kirra_release_publisher.py; do
+for f in kirra_motor_consumer.py kirra_ffi.py kirra_release_publisher.py r2_drive.py; do
   sudo install -m 0644 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
 done
 for f in first_run_elevated.sh live_loop_elevated.sh steering_bench_elevated.sh; do

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# install_robot_units.sh — stage the robot-side DOER units (ROS stack + KITT
+# watcher) as systemd services, rendered to the invoking user. Companion to
+# install_kirra.sh (which stages the consumer) and deploy/systemd/install.sh
+# (the governor stack). Does NOT enable — validate each as a service, wheels-up,
+# BEFORE enabling (docs/hardware/R2_AUTOSTART_CHECKLIST.md).
+#
+#   robot/install/install_robot_units.sh
+#
+# What it does (idempotent):
+#   1. copies the KITT scripts the watcher runs to /opt/kirra/robot (install_kirra.sh
+#      stages the consumer scripts; these are the KITT/voice ones on top),
+#   2. renders __KIRRA_ROBOT_USER__ → the invoking user in both units + installs
+#      them to /etc/systemd/system,
+#   3. daemon-reload.
+#
+# Enable deliberately after validation:
+#   sudo systemctl enable --now kirra-ros-stack        # occy_doer + interceptor + perception_governor
+#   sudo systemctl enable --now kirra-kitt-watch       # Channel-A narration (see the audio-in-service caveat)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "${HERE}/../.." && pwd)"
+UNITS="${HERE}/systemd"
+OPT=/opt/kirra
+# The invoking user (works whether or not the script itself is run under sudo).
+ROBOT_USER="${SUDO_USER:-${USER}}"
+
+echo "== robot-side unit install — user: ${ROBOT_USER} =="
+
+# ---- 1. KITT scripts -> /opt/kirra/robot -----------------------------------
+# The kitt-watch unit runs /opt/kirra/robot/kitt_watch.py, which imports kitt_ask;
+# ship the whole KITT/voice set so the interactive tools are staged too.
+echo "== 1. KITT scripts -> ${OPT}/robot =="
+sudo install -d -m 0755 "${OPT}/robot"
+for f in kitt_watch.py kitt_ask.py kitt_converse.py kitt_voice.sh ptt_button.py \
+         run_voice_ptt.sh inspect_corridor.py; do
+  [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
+  sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
+  echo "  installed ${OPT}/robot/${f}"
+done
+
+# ---- 2. render + install the units -----------------------------------------
+echo "== 2. units -> /etc/systemd/system =="
+for u in kirra-ros-stack.service kirra-kitt-watch.service; do
+  [[ -f "${UNITS}/${u}" ]] || { echo "❌ missing ${UNITS}/${u}"; exit 1; }
+  sed "s/__KIRRA_ROBOT_USER__/${ROBOT_USER}/g" "${UNITS}/${u}" \
+    | sudo tee "/etc/systemd/system/${u}" >/dev/null
+  echo "  installed /etc/systemd/system/${u} (User=${ROBOT_USER})"
+done
+
+# ---- 3. reload -------------------------------------------------------------
+sudo systemctl daemon-reload
+echo "== done — STAGED, not enabled =="
+echo "  the ROS stack default ws overlay is /home/${ROBOT_USER}/kirra-runtime-sdk/ros2_ws/install/setup.bash"
+echo "  (override with KIRRA_ROS_WS_SETUP in /etc/kirra/robot.env if the ws is elsewhere)."
+echo
+echo "  validate then enable, one at a time:"
+echo "    sudo systemctl start kirra-ros-stack   && journalctl -u kirra-ros-stack -f"
+echo "    sudo systemctl start kirra-kitt-watch  && journalctl -u kirra-kitt-watch -f"

--- a/robot/install/kitt.env.example
+++ b/robot/install/kitt.env.example
@@ -1,0 +1,47 @@
+# kitt.env.example — the KITT voice/conversation environment, in one place.
+#
+# Copy the vars you want into /etc/kirra/robot.env (the KITT scripts + kitt_voice.sh
+# source it), or `set -a; . this-file; set +a` in your shell. Every KITT script
+# (kitt_ask / kitt_converse / kitt_watch / kitt_voice.sh) reads these; nothing
+# here is safety-critical — it is the operator UX layer (Channel A + the fenced
+# /intent door). See docs/hardware/KITT_BRINGUP_RUNBOOK.md.
+
+# ── Speech engines (external OS processes — never crate deps) ────────────────
+# STT: receives the WAV path APPENDED as its last arg; prints the transcript.
+# Build whisper.cpp `whisper-cli` + fetch a model (offline).
+KIRRA_STT_CMD="whisper-cli -m models/ggml-base.en.bin -np -nt -f"
+# TTS: receives text on STDIN and plays it. Wrap Piper in a one-line speak.sh:
+#   #!/usr/bin/env bash
+#   exec piper --model en_US-lessac-medium.onnx --output-raw | aplay -r 22050 -f S16_LE -t raw -
+# Unset → KITT PRINTS instead of speaks (still works, just silent).
+KIRRA_TTS_CMD="./speak.sh"
+# Bounded push-to-talk recorder (the -d bound = no open mic). WAV path appended.
+KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
+
+# ── The persona LLM (local, offline) ─────────────────────────────────────────
+KIRRA_OLLAMA_URL="http://localhost:11434"
+KIRRA_KITT_MODEL="gemma3:4b"
+
+# ── Loop endpoints (localhost defaults; override only if you moved a service) ─
+KIRRA_VERIFIER_URL="http://localhost:8090"   # posture (/metrics), narration source
+KIRRA_MICK_URL="http://localhost:8102"        # POST /intent (the door), /narration/last
+KIRRA_TAJ_URL="http://localhost:8101"         # perception snapshot ("what do you see")
+
+# ── "Why did we stop" + proactive deny events need the #893 narration relay ──
+# mick_service must be started with KIRRA_VERIFIER_URL + an AUDITOR-role token so
+# GET /narration/last can relay the verifier's GET /system/verdicts/last. Mint an
+# auditor principal (POST /system/principals, role=auditor) and put it here — NOT
+# the admin token. Absent → KITT truthfully says the stop reason is "unavailable".
+#KIRRA_MICK_AUDITOR_TOKEN=
+
+# ── GPIO push-to-talk button (robot/ptt_button.py) — optional ────────────────
+# Normally-open momentary button between the pin and GND (internal pull-up).
+#KIRRA_PTT_GPIO_PIN=18
+#KIRRA_PTT_PIN_MODE=BOARD          # BOARD (physical pin #) | BCM
+#KIRRA_PTT_ACTIVE=low             # low = button→GND (pull-up) | high = button→3V3
+#KIRRA_PTT_DEBOUNCE_MS=200
+#KIRRA_PTT_LED_PIN=               # optional: OUTPUT pin lit while pressed
+
+# ── Proactive watcher (robot/kitt_watch.py) — optional tuning ────────────────
+#KIRRA_KITT_WATCH_MS=1500          # poll interval
+#KIRRA_KITT_WATCH_MIN_GAP_MS=2500  # min gap between spoken lines

--- a/robot/install/systemd/kirra-kitt-watch.service
+++ b/robot/install/systemd/kirra-kitt-watch.service
@@ -1,0 +1,40 @@
+# kirra-kitt-watch.service — KITT proactive event speech as a service.
+#
+# Runs robot/kitt_watch.py: a READ-ONLY watcher that speaks on posture / checker-
+# deny transitions (docs/hardware/KITT_CONVERSATION_DESIGN.md Stage 3). CHANNEL A
+# ONLY — GETs + TTS, no /intent, no publisher, no serial. It cannot move the robot;
+# it narrates. Safe to autostart.
+#
+# ⚠ AUDIO-FROM-A-SYSTEM-SERVICE caveat: a system service has no login session, so
+# a Pulse/PipeWire-based KIRRA_TTS_CMD may have no sink. Use an ALSA-DIRECT speak
+# command (e.g. `piper … --output-raw | aplay -D hw:0 …`) and put the rendered
+# User in the `audio` group. If TTS can't reach the device, KITT degrades to
+# PRINTING (harmless) — validate audio in-service before relying on it. Until
+# then, running kitt_watch in a login shell is the honest interim.
+#
+# ⚠ NOT YET HARDWARE-VALIDATED as a service. Enable deliberately:
+# `sudo systemctl enable --now kirra-kitt-watch`. See R2_AUTOSTART_CHECKLIST.md.
+#
+# User= is rendered by the installer to the invoking user (needs the `audio` group).
+
+[Unit]
+Description=KIRRA KITT proactive event speech (read-only; posture + verdict narration)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+# Best-effort: it polls the verifier + mick, but is fail-soft — an unreachable
+# source is silently skipped (never a false "recovered"), so no hard dependency.
+After=network-online.target kirra.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=__KIRRA_ROBOT_USER__
+EnvironmentFile=/etc/kirra/robot.env
+# HTTP-only (no ROS). KIRRA_TTS_CMD (ALSA-direct, see caveat above) + the loop
+# URLs come from robot.env. exec keeps python3 as the main PID for clean SIGTERM.
+ExecStart=/bin/bash -c 'exec python3 /opt/kirra/robot/kitt_watch.py'
+# always: a transient network/LLM blip should not stop the narrator; it self-heals.
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/robot/install/systemd/kirra-ros-stack.service
+++ b/robot/install/systemd/kirra-ros-stack.service
@@ -1,0 +1,45 @@
+# kirra-ros-stack.service — the ROS doer/interceptor stack as a service.
+#
+# Runs `ros2 launch kirra_safety kirra_with_robot.launch.py` — the occy_doer
+# bridge + cmd_vel_interceptor (the release relay) + perception_governor +
+# sensor_monitor + posture_subscriber. This is the DOER + interceptor side; the
+# governor stack (verifier + planner + taj + mick) is deploy/systemd/kirra.target,
+# and the motor consumer is kirra-consumer.service.
+#
+# ⚠ PROVIDED, NOT YET HARDWARE-VALIDATED as a service (the validated mode is a
+# terminal run — R2_LIVE_LOOP_BRINGUP.md). Enable deliberately after a wheels-up
+# re-test: `sudo systemctl enable --now kirra-ros-stack`. See
+# docs/hardware/R2_AUTOSTART_CHECKLIST.md.
+#
+# start_sidecars:=false — the planner + Taj sidecars are owned by kirra.target;
+# this unit must NOT also start them (double bind on :8100/:8101). It assumes
+# they are reachable (fail-soft: occy_doer HOLDS if a sidecar is down, never drives).
+#
+# User= is rendered by the installer to the invoking user (same idiom as
+# kirra-consumer.service). That user needs the ROS 2 toolchain + the built ws.
+
+[Unit]
+Description=Kirra ROS doer stack (occy_doer + cmd_vel_interceptor + perception_governor)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+# Best-effort ordering only — the loop is fail-soft (occy holds if a service is
+# down), so this is for boot smoothness, not correctness. Not a hard Requires:
+# a missing governor stack must leave the doer HOLDING, never blocked-from-starting.
+After=network-online.target kirra.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=__KIRRA_ROBOT_USER__
+EnvironmentFile=/etc/kirra/robot.env
+# ROS 2 + the workspace overlay must be sourced. KIRRA_ROS_WS_SETUP (from
+# robot.env) points at the built ws's install/setup.bash; the default matches a
+# repo checkout in the robot user's home. exec keeps ros2 as the main PID so
+# SIGTERM tears the launch down cleanly.
+ExecStart=/bin/bash -c 'source /opt/ros/humble/setup.bash && source "${KIRRA_ROS_WS_SETUP:-/home/__KIRRA_ROBOT_USER__/kirra-runtime-sdk/ros2_ws/install/setup.bash}" && exec ros2 launch kirra_safety kirra_with_robot.launch.py use_occy_doer:=true use_perception_cap:=true start_sidecars:=false kirra_url:=http://localhost:8090'
+# on-failure only: a fail-closed startup abort (e.g. occy_doer's REQUIRED
+# scan_stale_s unset → SystemExit 2) must not hot-loop.
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/robot/kitt_ask.py
+++ b/robot/kitt_ask.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""kitt_ask.py — Stage 1 KITT: grounded, spoken Q&A. **SPEAK-ONLY.**
+
+Ask the R2 a question — "what do you see", "why did we stop", "are we OK" — and
+it answers OUT LOUD, truthfully, from live telemetry, in the KITT persona.
+
+  question (argv or stdin) ─► gather READ-ONLY telemetry ─► local LLM phrases it
+                                                          ─► print + (optional) TTS
+
+🔴 THIS IS CHANNEL A (SPEAK) ONLY — see docs/hardware/KITT_CONVERSATION_DESIGN.md.
+   It makes read-only HTTP GETs and prints/speaks text. It has NO /intent POST,
+   NO ROS publisher, NO serial write, NO release token — there is NO code path
+   from this script to motion. It cannot move the robot; it can only talk about
+   it. Driving stays Channel B: a typed intent through mick_service's fail-closed
+   POST /intent door → Occy → the KIRRA checker (a SEPARATE tool, speech_shell).
+
+GROUNDING is read-only and FAIL-SOFT: every source (posture / stop-reason /
+perception) is fetched independently; if one is unreachable KITT says so ("I
+can't reach my perception right now") rather than inventing an answer. The LLM is
+instructed to state ONLY what the telemetry shows — the persona phrases; the
+numbers are ground truth. If the LLM itself is down, KITT falls back to a plain
+factual read (no personality, still truthful).
+
+Usage:
+  ./robot/kitt_ask.py "what do you see?"
+  echo "why did we stop" | ./robot/kitt_ask.py           # e.g. from whisper-cli
+Env (all optional; sensible localhost defaults):
+  KIRRA_VERIFIER_URL  http://localhost:8090   (posture, narration relay source)
+  KIRRA_MICK_URL      http://localhost:8102   (GET /narration/last — the #893 reason)
+  KIRRA_TAJ_URL       http://localhost:8101   (perception snapshot)
+  KIRRA_OLLAMA_URL    http://localhost:11434  (the local LLM)
+  KIRRA_KITT_MODEL    gemma3:4b               (persona model)
+  KIRRA_TTS_CMD       (unset → print only; e.g. "./speak.sh" to speak the answer)
+"""
+import math
+import os
+import subprocess
+import sys
+import time
+
+try:
+    import requests
+except ImportError:
+    sys.exit("kitt_ask: python3-requests missing (pip3 install requests)")
+
+VERIFIER = os.environ.get("KIRRA_VERIFIER_URL", "http://localhost:8090").rstrip("/")
+MICK = os.environ.get("KIRRA_MICK_URL", "http://localhost:8102").rstrip("/")
+TAJ = os.environ.get("KIRRA_TAJ_URL", "http://localhost:8101").rstrip("/")
+OLLAMA = os.environ.get("KIRRA_OLLAMA_URL", "http://localhost:11434").rstrip("/")
+MODEL = os.environ.get("KIRRA_KITT_MODEL", "gemma3:4b")
+TTS_CMD = os.environ.get("KIRRA_TTS_CMD", "").strip()
+FORWARD_CONE_RAD = math.radians(15.0)
+
+KITT_SYSTEM = (
+    "You are KITT, the voice of a small self-driving robot. You are composed, "
+    "articulate, dryly witty, and protective of your operator. Speak in the "
+    "first person about yourself and the robot ('I', 'we'). Keep answers to one "
+    "or two spoken sentences — this is read aloud.\n"
+    "STRICT RULES:\n"
+    "1. Answer ONLY from the TELEMETRY provided below. State nothing the "
+    "telemetry does not support. If the needed telemetry is missing or says "
+    "'unavailable', say plainly that you can't determine it right now.\n"
+    "2. You ADVISE and NARRATE; you do NOT control safety and you never claim to "
+    "have driven or to be about to drive. If asked to go somewhere, say the "
+    "operator should give that as a driving command (you don't act on it here).\n"
+    "3. Never invent distances, objects, or status. The numbers are ground truth."
+)
+
+
+def _get_json(url, timeout=2.0, headers=None):
+    """Read-only GET, fail-soft → None."""
+    try:
+        r = requests.get(url, timeout=timeout, headers=headers or {})
+        if r.status_code != 200:
+            return None
+        return r.json()
+    except Exception:  # noqa: BLE001 — any fault degrades to "unavailable"
+        return None
+
+
+def gather_posture():
+    # GET /fleet/posture → {"fleet": <per-node postures>} (posture-exempt, no auth).
+    j = _get_json(f"{VERIFIER}/fleet/posture")
+    if j is None:
+        return "posture: unavailable (cannot reach the governor)"
+    fleet = j.get("fleet") if isinstance(j, dict) else None
+    if not fleet:
+        return "fleet posture: no nodes registered in the fleet view (no reported faults)"
+    return f"fleet posture (per node): {str(fleet)[:300]}"
+
+
+def gather_stop_reason():
+    # The #893 narration relay (mick_service GET /narration/last) — the checker's
+    # actual last verdict. Shape: {"last": null | {action, deny_code, explanation}}.
+    # Needs mick started with the auditor token; else fail-soft to unavailable.
+    j = _get_json(f"{MICK}/narration/last")
+    if not isinstance(j, dict):
+        return "last stop reason: unavailable (narration relay off or governor unreachable)"
+    if "last" not in j:
+        return "last stop reason: unavailable"
+    last = j.get("last")
+    if last is None:
+        return "last verdict: no actuator command has been judged yet"
+    action = last.get("action", "?") if isinstance(last, dict) else "?"
+    code = last.get("deny_code") if isinstance(last, dict) else None
+    expl = last.get("explanation") if isinstance(last, dict) else None
+    if code and expl:
+        return f"last verdict: {action} ({code}) — {expl}"
+    if code:
+        return f"last verdict: {action} ({code})"
+    return f"last verdict: {action}"
+
+
+def gather_perception():
+    """One live /scan → Taj corridor → a truthful nearest-obstacle summary.
+    Lazy ROS import: if ROS isn't up this degrades to 'unavailable'."""
+    try:
+        import rclpy
+        from rclpy.node import Node
+        from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+        from sensor_msgs.msg import LaserScan
+    except Exception:  # noqa: BLE001
+        return "perception: unavailable (ROS not reachable)"
+
+    qos = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,
+                     history=HistoryPolicy.KEEP_LAST, depth=1)
+
+    class Grab(Node):
+        def __init__(self):
+            super().__init__("kitt_ask_scan")
+            self.scan = None
+            self.create_subscription(LaserScan, "/scan", self._on, qos)
+
+        def _on(self, m):
+            self.scan = m
+
+    started = False
+    try:
+        rclpy.init()
+        started = True
+        node = Grab()
+        t0 = time.monotonic()
+        while node.scan is None and time.monotonic() - t0 < 3.0:
+            rclpy.spin_once(node, timeout_sec=0.2)
+        scan = node.scan
+        node.destroy_node()
+        if scan is None:
+            return "perception: unavailable (no lidar scan)"
+        ranges = [float(r) for r in scan.ranges]
+        fwd = [r for i, r in enumerate(ranges)
+               if math.isfinite(r) and r > scan.range_min
+               and abs(scan.angle_min + i * scan.angle_increment) < FORWARD_CONE_RAD]
+        nearest_fwd = min(fwd, default=float("inf"))
+        taj = requests.post(f"{TAJ}/perception", timeout=2.0, json={
+            "angle_min_rad": float(scan.angle_min),
+            "angle_increment_rad": float(scan.angle_increment),
+            "range_min_m": float(scan.range_min),
+            "range_max_m": float(scan.range_max),
+            "ranges": ranges, "stamp_ms": 0, "forward_extent_m": 8.0,
+        }).json()
+        objs = taj.get("objects", [])
+        left, right = taj.get("left", []), taj.get("right", [])
+        clear = "unknown"
+        if left and right:
+            hw = min(abs(left[len(left) // 2][1]), abs(right[len(right) // 2][1]))
+            clear = f"~{2 * hw:.2f} m wide lane" if hw > 0.001 else "no clear lane (boxed in)"
+        fwd_txt = (f"{nearest_fwd:.2f} m ahead" if math.isfinite(nearest_fwd)
+                   else "nothing within range ahead")
+        return (f"perception: nearest obstacle straight ahead {fwd_txt}; "
+                f"{len(objs)} objects detected; drivable corridor {clear}")
+    except Exception as e:  # noqa: BLE001
+        return f"perception: unavailable ({e})"
+    finally:
+        if started:
+            try:
+                rclpy.shutdown()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def build_context():
+    return "TELEMETRY (ground truth — answer only from this):\n- " + "\n- ".join([
+        gather_posture(), gather_stop_reason(), gather_perception(),
+    ])
+
+
+def ask_ollama(question, context):
+    """Phrase the answer with the persona LLM. Fail-soft → None (caller falls
+    back to a plain factual read)."""
+    try:
+        r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0, json={
+            "model": MODEL, "stream": False,
+            "messages": [
+                {"role": "system", "content": KITT_SYSTEM},
+                {"role": "user", "content": f"{context}\n\nOperator asks: {question}"},
+            ],
+        })
+        if r.status_code != 200:
+            return None
+        return (r.json().get("message", {}).get("content") or "").strip() or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def speak(text):
+    print(text)
+    if not TTS_CMD:
+        return
+    try:
+        parts = TTS_CMD.split()
+        subprocess.run(parts, input=text.encode(), check=False)
+    except Exception as e:  # noqa: BLE001
+        print(f"(tts failed: {e})", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) > 1:
+        question = " ".join(sys.argv[1:]).strip()
+    else:
+        question = sys.stdin.read().strip()
+    if not question:
+        sys.exit("kitt_ask: no question (pass as args or on stdin)")
+
+    context = build_context()
+    answer = ask_ollama(question, context)
+    if answer is None:
+        # LLM offline → plain, still-truthful factual read (no persona).
+        answer = "My voice module is offline, but here is what I have:\n" + context
+    speak(answer)
+
+
+if __name__ == "__main__":
+    main()

--- a/robot/kitt_converse.py
+++ b/robot/kitt_converse.py
@@ -36,7 +36,10 @@ import os
 import re
 import sys
 
-import requests
+try:
+    import requests
+except ImportError:
+    sys.exit("kitt_converse: python3-requests missing (pip3 install requests)")
 
 # Reuse Stage 1's read-only grounding + persona + speak (robot/ is on sys.path[0]).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/robot/kitt_converse.py
+++ b/robot/kitt_converse.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""kitt_converse.py — Stage 2 KITT: multi-turn conversation, persona, router.
+
+Unifies ASKING (Stage 1 Q&A) and COMMANDING into ONE dialogue with memory and
+character. Each turn, KITT decides between its two channels
+(docs/hardware/KITT_CONVERSATION_DESIGN.md):
+
+  * SPEAK  — chat / questions / status → answered in persona from live telemetry
+             (reuses robot/kitt_ask.py's read-only grounding). Never moves.
+  * ACT    — a driving directive → the operator's movement words are handed to
+             mick_service POST /intent, the ONE fail-closed door. occy_doer then
+             drives it and the KIRRA checker BOUNDS it. KITT speaks a confirmation.
+
+🔴 THE SINGLE-DOOR INVARIANT: KITT NEVER constructs an intent, a Twist, a release
+   token, or a serial byte. The ONLY actuation-adjacent call in this process is
+   POSTing the operator's directive TEXT to /intent — exactly what a human typing
+   does. mick's fail-closed parse (MickIntent::parse_llm_json) is the final
+   authority on whether text is a valid directive; occy + the checker bound the
+   result. A misheard or hallucinated directive at worst becomes a checker-
+   APPROVED, bounded motion — never an unsafe one — and an unparseable turn
+   drives NOTHING (fail-closed: uncertain → no directive → SPEAK only).
+
+Routing is fail-closed: KITT emits a directive ONLY when it is confident the
+operator asked to DRIVE. Questions, chat, and any turn it can't parse → SPEAK,
+directive null, no motion.
+
+Usage:
+  ./robot/kitt_converse.py            # interactive: one utterance per line (Ctrl-D quits)
+  echo "take us to the door" | ./robot/kitt_converse.py --once
+Env: inherits robot/kitt_ask.py's (KIRRA_VERIFIER_URL / _MICK_URL / _TAJ_URL /
+     _OLLAMA_URL / KIRRA_KITT_MODEL / KIRRA_TTS_CMD). Wire STT in by piping the
+     transcript per line (e.g. the PTT button + whisper) — same as speech_shell.
+"""
+import json
+import os
+import re
+import sys
+
+import requests
+
+# Reuse Stage 1's read-only grounding + persona + speak (robot/ is on sys.path[0]).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from kitt_ask import (  # noqa: E402
+    KITT_SYSTEM, MICK, MODEL, OLLAMA, gather_perception, gather_posture,
+    gather_stop_reason, speak,
+)
+
+MAX_TURNS = 10  # rolling conversation memory (user+assistant pairs kept)
+PERCEPTION_WORDS = ("see", "around", "ahead", "front", "obstacle", "clear",
+                    "look", "there", "path", "way", "block")
+
+STAGE2_SYSTEM = (
+    KITT_SYSTEM
+    + "\n\nEACH TURN, reply with a JSON object and nothing else:\n"
+    '  {"say": "<one or two sentences to speak aloud>",\n'
+    '   "directive": <null, OR the operator\'s movement request in plain words>}\n'
+    "Set `directive` ONLY when the operator clearly wants the robot to DRIVE "
+    "somewhere (e.g. 'creep forward a meter', 'turn left', 'take us to the "
+    "door'). Pass their movement request faithfully — do NOT invent destinations, "
+    "coordinates, or numbers they did not give. For questions, status, chat, or "
+    "anything ambiguous, `directive` is null. You do not decide safety — you hand "
+    "the request to the governed door, and the KIRRA checker bounds what actually "
+    "moves; say so if useful."
+)
+
+
+def perception_relevant(text):
+    t = text.lower()
+    return any(w in t for w in PERCEPTION_WORDS)
+
+
+def context_for(utterance):
+    """Fresh live telemetry each turn (posture + last verdict always; the costly
+    perception grab only when the utterance is about seeing)."""
+    parts = [gather_posture(), gather_stop_reason()]
+    if perception_relevant(utterance):
+        parts.append(gather_perception())
+    return "TELEMETRY (ground truth — answer only from this):\n- " + "\n- ".join(parts)
+
+
+def ask_llm(history, context, utterance):
+    """One persona call with memory. Returns (say, directive|None); fail-soft."""
+    messages = [{"role": "system", "content": STAGE2_SYSTEM}]
+    messages += history
+    messages.append({"role": "user", "content": f"{context}\n\nOperator says: {utterance}"})
+    try:
+        r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0,
+                          json={"model": MODEL, "stream": False, "messages": messages})
+        if r.status_code != 200:
+            return None, None
+        raw = (r.json().get("message", {}).get("content") or "").strip()
+    except Exception:  # noqa: BLE001
+        return None, None
+    return parse_reply(raw)
+
+
+def parse_reply(raw):
+    """Lenient JSON extraction. FAIL-CLOSED: anything we can't parse as a clear
+    directive → (text, None) — no directive, no motion."""
+    m = re.search(r"\{.*\}", raw, re.DOTALL)
+    if m:
+        try:
+            j = json.loads(m.group(0))
+            say = (j.get("say") or "").strip()
+            directive = j.get("directive")
+            if isinstance(directive, str):
+                directive = directive.strip()
+                if directive.lower() in ("", "null", "none"):
+                    directive = None
+            else:
+                directive = None
+            return (say or raw.strip()), directive
+        except Exception:  # noqa: BLE001
+            pass
+    return raw.strip(), None  # fail-closed: no directive
+
+
+def offer_to_door(directive_text):
+    """Hand the directive TEXT to the ONE fail-closed door (mick POST /intent).
+    Returns 'ok' | 'reject' | 'error'. This is the sole actuation-adjacent call —
+    it is text-to-the-door, exactly what a human typing does."""
+    try:
+        r = requests.post(f"{MICK}/intent", timeout=60.0, json={"text": directive_text})
+        j = r.json() if r.content else {}
+        if r.status_code == 200 and isinstance(j, dict) and j.get("ok"):
+            return "ok"
+        return "reject"
+    except Exception:  # noqa: BLE001
+        return "error"
+
+
+def handle_turn(history, utterance):
+    context = context_for(utterance)
+    say, directive = ask_llm(history, context, utterance)
+    if say is None:
+        say = "My voice module is offline for a moment."
+        directive = None
+
+    if directive:
+        result = offer_to_door(directive)
+        if result == "ok":
+            spoken = say or "On my way — the governor will keep us safe."
+        elif result == "reject":
+            spoken = ("I heard a movement request, but I couldn't pin down a "
+                      "safe destination — could you say it another way?")
+        else:  # error
+            spoken = "I can't reach my driving control right now, so I'm staying put."
+    else:
+        spoken = say
+
+    speak(spoken)
+    # rolling memory (store the spoken reply, not the raw grounding)
+    history.append({"role": "user", "content": utterance})
+    history.append({"role": "assistant", "content": spoken})
+    del history[: max(0, len(history) - 2 * MAX_TURNS)]
+
+
+def main():
+    once = "--once" in sys.argv[1:]
+    history = []
+    if once:
+        utterance = sys.stdin.read().strip()
+        if utterance:
+            handle_turn(history, utterance)
+        return
+    print("kitt_converse: talk to KITT — one line per turn (Ctrl-D quits).",
+          file=sys.stderr)
+    for line in sys.stdin:
+        utterance = line.strip()
+        if utterance:
+            handle_turn(history, utterance)
+
+
+if __name__ == "__main__":
+    main()

--- a/robot/kitt_voice.sh
+++ b/robot/kitt_voice.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# kitt_voice.sh — TALK to KITT by voice: trigger → record → STT → kitt_converse.
+#
+# The missing glue between the mic and the conversation. Each TRIGGER (a line on
+# this script's stdin) records one bounded clip, transcribes it, and feeds the
+# TEXT to robot/kitt_converse.py — which answers in persona (SPEAK) or hands a
+# driving directive to the ONE fail-closed door (mick POST /intent → Occy → the
+# KIRRA checker). speech_shell goes straight to /intent (command-only, Stage 0);
+# THIS routes voice through the full KITT dialogue (Stages 2-3).
+#
+# The trigger source is whatever feeds stdin — pick one:
+#   with a GPIO button:   python3 robot/ptt_button.py | ./robot/kitt_voice.sh
+#   with the keyboard:     ./robot/kitt_voice.sh        # press Enter to talk
+#
+# 🔴 Voice cannot bypass the fence: a transcript is TEXT handed to the door, the
+# same as typing. A misheard clip dead-ends in MickIntent::parse_llm_json (no
+# intent, no motion). This is the mic, NOT the e-stop (a separate hardware kill).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Optional shared env (STT/TTS/RECORD live here — see robot/install/kitt.env.example)
+if [ -f /etc/kirra/robot.env ]; then set -a; . /etc/kirra/robot.env; set +a; fi
+
+if [ -z "${KIRRA_STT_CMD:-}" ]; then
+  echo "FATAL: KIRRA_STT_CMD required (e.g. \"whisper-cli -m models/ggml-base.en.bin -np -nt -f\")" >&2
+  exit 1
+fi
+: "${KIRRA_RECORD_CMD:=arecord -d 4 -f S16_LE -r 16000 -c 1}"
+
+# Producer: one transcript line per trigger. STT/RECORD are word-split command
+# lists (the house convention: the WAV path is APPENDED as the last argument).
+transcribe() {
+  local wav text
+  while IFS= read -r _; do
+    wav="$(mktemp --suffix=.wav)"
+    # shellcheck disable=SC2086
+    if $KIRRA_RECORD_CMD "$wav" >/dev/null 2>&1; then
+      # shellcheck disable=SC2086
+      text="$($KIRRA_STT_CMD "$wav" 2>/dev/null | tr '\r\n' '  ' | sed 's/  */ /g;s/^ //;s/ $//')"
+      [ -n "${text// /}" ] && printf '%s\n' "$text"
+    else
+      echo "kitt_voice: recorder failed — nothing captured" >&2
+    fi
+    rm -f "$wav"
+  done
+}
+
+echo "kitt_voice: trigger to talk (button press or Enter). Ctrl-C / Ctrl-D quits." >&2
+transcribe | python3 "$HERE/kitt_converse.py"

--- a/robot/kitt_watch.py
+++ b/robot/kitt_watch.py
@@ -30,7 +30,10 @@ import re
 import sys
 import time
 
-import requests
+try:
+    import requests
+except ImportError:
+    sys.exit("kitt_watch: python3-requests missing (pip3 install requests)")
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from kitt_ask import MICK, VERIFIER, speak  # noqa: E402

--- a/robot/kitt_watch.py
+++ b/robot/kitt_watch.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""kitt_watch.py — Stage 3 KITT: proactive event speech. **SPEAK-ONLY.**
+
+KITT talks to YOU, unprompted — "I'm holding a safe stop," "all systems nominal,"
+"I've had to refuse that." A read-only watcher that polls two signals, detects
+state TRANSITIONS, and speaks in persona on a change (never on steady state).
+
+  poll (read-only):                        announce on TRANSITION only:
+    GET /metrics  kirra_fleet_posture ─►   Nominal↔Degraded↔LockedOut, cache-stale
+    GET /narration/last (the #893 relay) ─► a NEW checker DENY (with its reason)
+
+🔴 CHANNEL A ONLY (docs/hardware/KITT_CONVERSATION_DESIGN.md). This process makes
+   read-only GETs and prints/speaks text — NO /intent POST, NO publisher, NO
+   serial, NO release token. It observes and narrates; it cannot move the robot.
+   Proactive SPEECH, never proactive MOTION.
+
+Discipline: announces ONLY on a state change (steady state is silent), establishes
+a baseline on the first poll WITHOUT speaking (no boot-time chatter), and rate-
+limits so a flap can't spam. If a signal is unreachable it stays silent for that
+signal (never false-announces "recovered" from missing data).
+
+Usage:
+  ./robot/kitt_watch.py                 # run alongside the loop; speaks on events
+Env: KIRRA_VERIFIER_URL / KIRRA_MICK_URL / KIRRA_TTS_CMD (inherited from kitt_ask);
+     KIRRA_KITT_WATCH_MS  poll interval (default 1500)
+     KIRRA_KITT_WATCH_MIN_GAP_MS  min ms between spoken lines (default 2500)
+"""
+import os
+import re
+import sys
+import time
+
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from kitt_ask import MICK, VERIFIER, speak  # noqa: E402
+
+POLL_S = int(os.environ.get("KIRRA_KITT_WATCH_MS", "1500")) / 1000.0
+MIN_GAP_S = int(os.environ.get("KIRRA_KITT_WATCH_MIN_GAP_MS", "2500")) / 1000.0
+POSTURE_NAME = {0: "nominal", 1: "degraded", 2: "locked out"}
+
+_FLEET_RE = re.compile(r"kirra_fleet_posture\{[^}]*\}\s+(\d+)")
+_STALE_RE = re.compile(r"kirra_posture_cache_stale\{[^}]*\}\s+1\b")
+
+
+def poll_posture():
+    """Worst-case posture code across nodes + cache-stale, from /metrics.
+    Returns (code|None, stale_bool). code None = no posture data (stay silent)."""
+    try:
+        r = requests.get(f"{VERIFIER}/metrics", timeout=2.0)
+        if r.status_code != 200:
+            return None, False
+        text = r.text
+    except Exception:  # noqa: BLE001
+        return None, False
+    codes = [int(m) for m in _FLEET_RE.findall(text)]
+    stale = bool(_STALE_RE.search(text))
+    return (max(codes) if codes else None), stale
+
+
+def poll_verdict():
+    """The checker's last verdict tuple from the #893 relay, or None if
+    unavailable. ('none',) = relay up but nothing judged yet."""
+    try:
+        r = requests.get(f"{MICK}/narration/last", timeout=2.0)
+        if r.status_code != 200:
+            return None
+        j = r.json()
+    except Exception:  # noqa: BLE001
+        return None
+    if not isinstance(j, dict) or "last" not in j:
+        return None
+    last = j["last"]
+    if not isinstance(last, dict):
+        return ("none",)
+    return ("verdict", last.get("action"), last.get("deny_code"), last.get("explanation"))
+
+
+def posture_line(old, new, stale_now, stale_before):
+    if stale_now and not stale_before:
+        return "I've lost a fresh read on my safety state — I'm holding until it clears."
+    if old is None or new is None or new == old:
+        return None
+    if new > old:  # escalation
+        if new == 2:
+            return ("I'm locking out and holding a safe stop. "
+                    "I'll need a manual reset before we continue.")
+        return ("Heads up — I've dropped into a degraded mode. "
+                "I'll slow and stop as needed to keep us safe.")
+    # recovery
+    if new == 0:
+        return "All systems nominal. We're clear to move again."
+    return "Recovering — back to a degraded mode."
+
+
+def verdict_line(v):
+    # v = ('verdict', action, deny_code, explanation)
+    _, _action, code, expl = v
+    if not code:
+        return None  # not a deny → not noteworthy
+    if expl:
+        return f"I've had to refuse a command. {expl}"
+    return f"I've had to refuse a command ({code})."
+
+
+def main():
+    print("kitt_watch: proactive event speech — announces on change (Ctrl-C quits).",
+          file=sys.stderr)
+    # baseline WITHOUT speaking
+    posture, stale = poll_posture()
+    verdict = poll_verdict()
+    last_spoke = 0.0
+
+    def announce(line):
+        nonlocal last_spoke
+        if not line:
+            return
+        now = time.monotonic()
+        if now - last_spoke < MIN_GAP_S:
+            return  # coalesce flaps
+        last_spoke = now
+        speak(line)
+
+    while True:
+        time.sleep(POLL_S)
+        new_posture, new_stale = poll_posture()
+        announce(posture_line(posture, new_posture, new_stale, stale))
+        # only overwrite known state (don't lose baseline on a transient outage)
+        if new_posture is not None:
+            posture = new_posture
+        stale = new_stale
+
+        new_verdict = poll_verdict()
+        if (new_verdict is not None and new_verdict != verdict
+                and new_verdict[0] == "verdict"):
+            announce(verdict_line(new_verdict))
+        if new_verdict is not None:
+            verdict = new_verdict
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nkitt_watch: stopped", file=sys.stderr)

--- a/robot/ptt_button.py
+++ b/robot/ptt_button.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""ptt_button.py — a GPIO push-to-talk button for the voice shell.
+
+The R2's untethered voice UX needs a physical trigger to replace "press Enter"
+in `speech_shell`'s interactive push-to-talk loop (crates/kirra-sidecars/src/bin/
+speech_shell.rs: `loop { read_line(stdin) }` — ONE bounded recording turn per
+line). This watcher emits exactly ONE newline on stdout per button press, so:
+
+    python3 robot/ptt_button.py | speech_shell
+
+makes a hardware button = the Enter key. Zero change to the Rust binary; the
+button is just another external OS process, like the STT/TTS/record commands.
+
+🔴 SAFETY — WHAT THIS BUTTON IS (and is NOT):
+  * It is a MICROPHONE trigger. A press starts ONE bounded voice clip; the
+    transcript enters the loop ONLY through the existing fail-closed intent door
+    (MickIntent::parse_llm_json). A press with silence / noise / a misheard word
+    → empty-or-garbage transcript → parse failure → NO intent latched → NO
+    motion. The button cannot inject a goal or a command; it cannot bypass the
+    checker. It is exactly as safe as pressing Enter.
+  * It is NOT the e-stop. The e-stop is a SEPARATE hardware kill in the motor
+    power line (docs/hardware/R2_UNTETHERED_BRINGUP.md §3). Do not wire this
+    button as, or in place of, the e-stop. Losing this button = you can't talk
+    to the robot; losing the e-stop = you can't stop it. They are different
+    circuits with different criticality.
+
+STDOUT DISCIPLINE: ONLY the trigger newline goes to stdout (it is speech_shell's
+stdin). Every log/banner/error goes to STDERR — otherwise a log line would be
+read as a turn and fire a spurious recording (harmless, but noisy).
+
+Wiring (default): a normally-open momentary button between the configured pin and
+GND. The internal pull-up idles the pin HIGH; a press pulls it LOW (falling
+edge = press). No external resistor needed.
+
+Env (all optional; the button pin is INPUT-only so a wrong value cannot drive
+anything — but confirm the pin is a free GPIO on your header, not muxed):
+  KIRRA_PTT_GPIO_PIN    button pin (default 18)         — see KIRRA_PTT_PIN_MODE
+  KIRRA_PTT_PIN_MODE    BOARD | BCM  (default BOARD = physical pin numbers)
+  KIRRA_PTT_ACTIVE      low | high   (default low: button→GND, internal pull-up)
+  KIRRA_PTT_DEBOUNCE_MS debounce (default 200)
+  KIRRA_PTT_LED_PIN     optional OUTPUT pin lit while pressed (recording feedback)
+
+Requires Jetson.GPIO (`sudo pip3 install Jetson.GPIO`) + the running user in the
+`gpio` group with the Jetson udev rules installed, or run as root.
+"""
+import os
+import signal
+import sys
+import time
+
+
+def log(msg):
+    """Everything human-facing goes to STDERR — stdout is the trigger channel."""
+    print(f"ptt_button: {msg}", file=sys.stderr, flush=True)
+
+
+def env_int(key, default):
+    raw = os.environ.get(key, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw, 0)
+    except ValueError:
+        log(f"FATAL: {key}={raw!r} is not an integer")
+        sys.exit(2)
+
+
+def main():
+    try:
+        import Jetson.GPIO as GPIO
+    except Exception as e:  # noqa: BLE001
+        log(f"Jetson.GPIO unavailable ({e}). Install: sudo pip3 install Jetson.GPIO "
+            "(+ gpio group / udev), or run as root.")
+        sys.exit(2)
+
+    pin = env_int("KIRRA_PTT_GPIO_PIN", 18)
+    led_pin = env_int("KIRRA_PTT_LED_PIN", 0)  # 0 = no LED
+    debounce_s = env_int("KIRRA_PTT_DEBOUNCE_MS", 200) / 1000.0
+    mode = os.environ.get("KIRRA_PTT_PIN_MODE", "BOARD").strip().upper()
+    active = os.environ.get("KIRRA_PTT_ACTIVE", "low").strip().lower()
+    if mode not in ("BOARD", "BCM"):
+        log(f"FATAL: KIRRA_PTT_PIN_MODE={mode!r} — expected BOARD or BCM")
+        sys.exit(2)
+    if active not in ("low", "high"):
+        log(f"FATAL: KIRRA_PTT_ACTIVE={active!r} — expected low or high")
+        sys.exit(2)
+
+    # active-low (button→GND) → internal PULL-UP, pressed reads LOW.
+    # active-high (button→3V3) → internal PULL-DOWN, pressed reads HIGH.
+    GPIO.setmode(getattr(GPIO, mode))
+    if active == "low":
+        GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+        pressed_level = GPIO.LOW
+    else:
+        GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+        pressed_level = GPIO.HIGH
+    if led_pin:
+        GPIO.setup(led_pin, GPIO.OUT, initial=GPIO.LOW)
+
+    def cleanup(*_):
+        try:
+            GPIO.cleanup()
+        finally:
+            log("stopped")
+            sys.exit(0)
+
+    signal.signal(signal.SIGINT, cleanup)
+    signal.signal(signal.SIGTERM, cleanup)
+
+    log(f"push-to-talk ready on {mode} pin {pin} (active {active}); "
+        f"press = one voice clip. Pipe into speech_shell. Ctrl-C quits.")
+
+    POLL_S = 0.02
+    is_pressed = False
+    try:
+        while True:
+            down = GPIO.input(pin) == pressed_level
+            if down and not is_pressed:
+                # debounce: confirm still held after the settle window
+                time.sleep(debounce_s)
+                if GPIO.input(pin) == pressed_level:
+                    is_pressed = True
+                    if led_pin:
+                        GPIO.output(led_pin, GPIO.HIGH)
+                    # THE TRIGGER — the only thing that ever touches stdout.
+                    sys.stdout.write("\n")
+                    sys.stdout.flush()
+                    log("press -> record one clip")
+            elif not down and is_pressed:
+                is_pressed = False
+                if led_pin:
+                    GPIO.output(led_pin, GPIO.LOW)
+            time.sleep(POLL_S)
+    finally:
+        cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/robot/run_voice_ptt.sh
+++ b/robot/run_voice_ptt.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# run_voice_ptt.sh — voice push-to-talk in ONE command: a GPIO button drives the
+# governed voice shell. Wires robot/ptt_button.py (the hardware trigger) into
+# speech_shell (STT -> the fail-closed POST /intent door -> Occy -> KIRRA -> TTS).
+#
+#   ./robot/run_voice_ptt.sh
+#
+# The loop it talks to (mick_service + Ollama, planner_service, taj_service,
+# occy_doer, interceptor) must already be up — see docs/hardware/
+# R2_LIVE_LOOP_BRINGUP.md. This script only stands up the VOICE FRONT-END.
+#
+# 🔴 The button is a MIC trigger, not the e-stop (a separate hardware kill —
+# R2_UNTETHERED_BRINGUP.md §3). A misheard press dead-ends in the intent parser:
+# no intent, no motion.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+cd "$REPO"
+
+# Optional shared env (put KIRRA_STT_CMD / KIRRA_TTS_CMD / KIRRA_PTT_* here):
+if [ -f /etc/kirra/robot.env ]; then
+  set -a; . /etc/kirra/robot.env; set +a
+fi
+
+# STT is REQUIRED (speech_shell refuses to start without an ear). No default path
+# is invented — point it at your built whisper-cli + model.
+if [ -z "${KIRRA_STT_CMD:-}" ]; then
+  echo "FATAL: KIRRA_STT_CMD is required, e.g.:" >&2
+  echo '  export KIRRA_STT_CMD="whisper-cli -m models/ggml-base.en.bin -np -nt -f"' >&2
+  echo "(build whisper.cpp; see docs/testing/SPEECH_KITT_DEMO.md)" >&2
+  exit 1
+fi
+# Bounded push-to-talk recorder (the -d bound = no open mic). Overridable.
+: "${KIRRA_RECORD_CMD:=arecord -d 4 -f S16_LE -r 16000 -c 1}"; export KIRRA_RECORD_CMD
+# TTS optional: unset -> narration prints instead of speaks.
+: "${KIRRA_MICK_URL:=http://127.0.0.1:8102}"; export KIRRA_MICK_URL
+
+# Resolve the speech_shell binary (release then debug, like run_consumer_r2.sh).
+SHELL_BIN="${KIRRA_SPEECH_SHELL_BIN:-}"
+if [ -z "$SHELL_BIN" ]; then
+  for prof in release debug; do
+    [ -x "$REPO/target/$prof/speech_shell" ] && { SHELL_BIN="$REPO/target/$prof/speech_shell"; break; }
+  done
+fi
+[ -n "$SHELL_BIN" ] && [ -x "$SHELL_BIN" ] || {
+  echo "FATAL: speech_shell not built (cargo build -p kirra-sidecars --bin speech_shell --release)" >&2
+  exit 1
+}
+
+echo "voice PTT: GPIO ${KIRRA_PTT_PIN_MODE:-BOARD} pin ${KIRRA_PTT_GPIO_PIN:-18} -> $SHELL_BIN" >&2
+# The button's newline-per-press IS the interactive trigger. Ctrl-C stops both.
+python3 "$HERE/ptt_button.py" | "$SHELL_BIN"

--- a/robot/stage1_doer_dryrun.sh
+++ b/robot/stage1_doer_dryrun.sh
@@ -111,10 +111,13 @@ ros2 service call /occy_doer/set_logger_levels rcl_interfaces/srv/SetLoggerLevel
      "{levels: [{name: 'occy_doer', level: 10}]}" >/dev/null 2>&1 \
      && echo "  occy_doer log level -> DEBUG" || echo "  ⚠ could not set occy DEBUG (non-fatal)"
 
-# fire the LLM intent (go_to becomes the goal, grounded ego->odom at receipt)
+# fire the LLM intent (go_to becomes the goal, grounded ego->odom at receipt).
+# JSON-encode the body via python so quotes/backslashes/newlines in INTENT_TEXT
+# can't produce invalid JSON (shell string interpolation would break here).
 echo "  POST /intent  text=\"$INTENT_TEXT\""
+INTENT_JSON="$(python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1]}))' "$INTENT_TEXT")"
 curl -s "$MICK_URL/intent" -XPOST -H 'content-type: application/json' \
-     -d "{\"text\":\"$INTENT_TEXT\"}" ; echo
+     -d "$INTENT_JSON" ; echo
 echo -n "  /intent/last -> "; curl -s "$MICK_URL/intent/last" ; echo
 
 # --- 5. live view: occy decision + the bounded proposal -------------------------

--- a/robot/stage1_doer_dryrun.sh
+++ b/robot/stage1_doer_dryrun.sh
@@ -24,6 +24,9 @@ REPO="$(cd "$HERE/.." && pwd)"
 cd "$REPO"
 
 # --- env: ROS + domain (guarded; matches run_consumer_r2.sh discipline) --------
+# ROS/colcon setup.bash reference unbound vars (COLCON_TRACE, AMENT_TRACE, ...),
+# which trip `set -u`. Source them with nounset OFF, then restore it.
+set +u
 if [ -z "${ROS_DISTRO:-}" ] && [ -f /opt/ros/humble/setup.bash ]; then
   # shellcheck disable=SC1091
   source /opt/ros/humble/setup.bash
@@ -32,6 +35,7 @@ if [ -f "$REPO/ros2_ws/install/setup.bash" ]; then
   # shellcheck disable=SC1091
   source "$REPO/ros2_ws/install/setup.bash"
 fi
+set -u
 : "${ROS_DOMAIN_ID:=28}"; export ROS_DOMAIN_ID
 
 MICK_URL="${KIRRA_MICK_URL:-http://127.0.0.1:8102}"

--- a/robot/stage1_doer_dryrun.sh
+++ b/robot/stage1_doer_dryrun.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# stage1_doer_dryrun.sh — stand up the WHOLE Stage-1 doer dry run in ONE window.
+#
+# Stage 1 proves Mick (LLM) + Taj (perception) + Occy (planner) produce a sane
+# /cmd_vel_raw proposal WITHOUT the verifier/interceptor-mint/consumer, so nothing
+# can actuate — safe to run over SSH. See docs/hardware/R2_LIVE_LOOP_BRINGUP.md §1.
+#
+# WHY THIS EXISTS: juggling five SSH shells (mick, launch, odom, intent, echo) on a
+# phone keyboard is the actual failure mode — a half-typed export or a Ctrl-C on the
+# wrong window and the pipeline looks broken when it isn't. This script owns every
+# piece EXCEPT your lidar driver, backgrounds them with logs, then foregrounds a live
+# tail of occy's decision + the proposal. One Ctrl-C tears down everything it started
+# (never your lidar).
+#
+#   Window 1 (your usual way):  the 4ROS lidar driver  -> /scan
+#   Window 2:                   ./robot/stage1_doer_dryrun.sh
+#
+# NO verifier, NO consumer, NO wheels. Actuation is Stage 2 (live_loop_elevated.sh),
+# physically present only.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+cd "$REPO"
+
+# --- env: ROS + domain (guarded; matches run_consumer_r2.sh discipline) --------
+if [ -z "${ROS_DISTRO:-}" ] && [ -f /opt/ros/humble/setup.bash ]; then
+  # shellcheck disable=SC1091
+  source /opt/ros/humble/setup.bash
+fi
+if [ -f "$REPO/ros2_ws/install/setup.bash" ]; then
+  # shellcheck disable=SC1091
+  source "$REPO/ros2_ws/install/setup.bash"
+fi
+: "${ROS_DOMAIN_ID:=28}"; export ROS_DOMAIN_ID
+
+MICK_URL="${KIRRA_MICK_URL:-http://127.0.0.1:8102}"
+OLLAMA_URL="${KIRRA_OLLAMA_URL:-http://127.0.0.1:11434}"
+INTENT_TEXT="${1:-creep forward one meter}"
+LOGDIR="${KIRRA_STAGE1_LOGDIR:-/tmp/kirra_stage1}"
+mkdir -p "$LOGDIR"
+
+# --- teardown: one Ctrl-C kills only what THIS script started -------------------
+PIDS=()
+cleanup() {
+  echo; echo "── tearing down Stage-1 (lidar untouched) ──"
+  for pid in "${PIDS[@]:-}"; do
+    [ -n "${pid:-}" ] && kill "$pid" 2>/dev/null || true
+  done
+  wait 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+banner() { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
+
+# --- 0. Ollama reachability (Mick's brain) — warn only, Mick fail-closes anyway -
+banner "0/5  Ollama"
+if curl -sf "$OLLAMA_URL/api/tags" >/dev/null 2>&1; then
+  echo "  ollama up ($OLLAMA_URL)"
+else
+  echo "  ⚠ ollama NOT reachable at $OLLAMA_URL — start it (ollama serve) + pull the model."
+  echo "    Mick will 422 on /intent until it's up; the rest of the stack still runs."
+fi
+
+# --- 1. mick_service (text -> typed intent); start if down ----------------------
+banner "1/5  mick_service"
+if curl -sf "$MICK_URL/health" >/dev/null 2>&1; then
+  echo "  mick_service already up ($MICK_URL) — reusing it"
+else
+  MICK_BIN=""
+  for prof in release debug; do
+    [ -x "$REPO/target/$prof/mick_service" ] && { MICK_BIN="$REPO/target/$prof/mick_service"; break; }
+  done
+  [ -n "$MICK_BIN" ] || { echo "FATAL: mick_service not built (cargo build -p kirra-sidecars --bin mick_service --release)"; exit 1; }
+  echo "  starting $MICK_BIN -> $LOGDIR/mick.log"
+  "$MICK_BIN" >"$LOGDIR/mick.log" 2>&1 &
+  PIDS+=("$!")
+  for _ in $(seq 1 30); do curl -sf "$MICK_URL/health" >/dev/null 2>&1 && break; sleep 0.3; done
+  curl -sf "$MICK_URL/health" >/dev/null 2>&1 && echo "  mick_service up" || { echo "FATAL: mick_service did not come up — see $LOGDIR/mick.log"; exit 1; }
+fi
+
+# --- 2. the launch stack (planner + taj sidecars + occy_doer + interceptor) -----
+banner "2/5  ros2 launch (occy doer + perception cap)"
+echo "  -> $LOGDIR/launch.log  (Cannot-reach-Kirra errors here are EXPECTED — no verifier in Stage 1)"
+ros2 launch kirra_safety kirra_with_robot.launch.py \
+     use_occy_doer:=true use_perception_cap:=true \
+     >"$LOGDIR/launch.log" 2>&1 &
+PIDS+=("$!")
+
+echo -n "  waiting for /occy_doer to appear"
+for _ in $(seq 1 40); do
+  if ros2 node list 2>/dev/null | grep -q '/occy_doer'; then echo " — up"; break; fi
+  echo -n "."; sleep 0.5
+done
+ros2 node list 2>/dev/null | grep -q '/occy_doer' || { echo; echo "FATAL: /occy_doer never appeared — see $LOGDIR/launch.log"; exit 1; }
+
+# --- 3. static /odom at origin (dry run: the motor node is OFF) ------------------
+banner "3/5  /odom static ego (10 Hz, origin)"
+ros2 topic pub -r 10 /odom nav_msgs/msg/Odometry '{header: {frame_id: odom}}' \
+     >"$LOGDIR/odom.log" 2>&1 &
+PIDS+=("$!")
+echo "  publishing /odom"
+
+# --- 4. occy DEBUG on (so it prints its hold reason each tick) -------------------
+banner "4/5  occy DEBUG + goal via Mick"
+ros2 service call /occy_doer/set_logger_levels rcl_interfaces/srv/SetLoggerLevels \
+     "{levels: [{name: 'occy_doer', level: 10}]}" >/dev/null 2>&1 \
+     && echo "  occy_doer log level -> DEBUG" || echo "  ⚠ could not set occy DEBUG (non-fatal)"
+
+# fire the LLM intent (go_to becomes the goal, grounded ego->odom at receipt)
+echo "  POST /intent  text=\"$INTENT_TEXT\""
+curl -s "$MICK_URL/intent" -XPOST -H 'content-type: application/json' \
+     -d "{\"text\":\"$INTENT_TEXT\"}" ; echo
+echo -n "  /intent/last -> "; curl -s "$MICK_URL/intent/last" ; echo
+
+# --- 5. live view: occy decision + the bounded proposal -------------------------
+banner "5/5  LIVE  (Ctrl-C to tear it all down)"
+echo "  Left: occy_doer hold/plan lines (from the launch log)."
+echo "  Right: /cmd_vel_raw — Occy's KIRRA-bounded proposal (want a small linear.x)."
+echo "  Obstacle ~0.5 m in front of the lidar -> proposal should collapse to ~0 (Taj cap)."
+echo
+# occy's per-tick line, filtered out of the launch log
+( stdbuf -oL tail -n0 -F "$LOGDIR/launch.log" 2>/dev/null \
+    | grep --line-buffered -E 'occy_doer|hold:|v=|new goal|mick intent' \
+    | sed -u 's/^/[occy] /' ) &
+PIDS+=("$!")
+# the proposal itself
+ros2 topic echo /cmd_vel_raw

--- a/ros2_ws/src/kirra_safety/config/kirra_params.yaml
+++ b/ros2_ws/src/kirra_safety/config/kirra_params.yaml
@@ -25,6 +25,30 @@ occy_doer:
     # a different lidar rate needs a deployment-review update here.
     scan_stale_s: 0.25
 
+    # --- R2-SIZED footprint + clearance (doer-side; sent to the planner's
+    # CHECKER each tick). WITHOUT these the node falls back to occy_doer.py's
+    # courier-sized defaults (half 0.15/0.18, clearance 0.6/0.6) and judges a
+    # ~0.2 m robot as if it needed a courier's lane -> the corridor pinches
+    # shut and KIRRA MRCs even passable gaps. Setting the robot's REAL size is
+    # accurate modelling, NOT a safety relaxation.
+    #
+    # NOTE the two distinct "space" surfaces (docs/CONTRACT_PROFILES.md):
+    #   * footprint (half_*): the robot's BODY. Keep it >= the real robot --
+    #     these are CONSERVATIVE estimates pending a tape-measure (see
+    #     R2_PATH_B / PLATFORM_R2_PENDING). NEVER shrink below reality.
+    #   * clearance TARGETS (lateral_clearance_target_m /
+    #     rss_lateral_alignment_tolerance_m): extra room DEMANDED beyond the
+    #     body. A 0.2 m robot honestly needs far less than an AV's 0.6 m.
+    # This is the doer dry-run envelope only; the ACTUATION envelope (Stage 2)
+    # is the verifier's per-class contract (courier interim until a measured
+    # `r2` class lands).
+    vehicle_class: "courier"                    # doer RSS-band label; numbers below win
+    wheelbase_m: 0.229                          # R2 physical wheelbase (matches KIRRA_R2_WHEELBASE_M)
+    half_length_m: 0.16                         # CONSERVATIVE (~0.30 m body); tape-measure to firm up
+    half_width_m: 0.12                          # CONSERVATIVE (~0.20 m body); tape-measure to firm up
+    lateral_clearance_target_m: 0.15            # robot-scale (was courier 0.6)
+    rss_lateral_alignment_tolerance_m: 0.15     # robot-scale (was courier 0.6)
+
 perception_governor:
   ros__parameters:
     taj_url: "http://localhost:8101"   # the Taj perception sidecar (kirra-mick example taj_service)

--- a/ros2_ws/src/kirra_safety/config/kirra_params.yaml
+++ b/ros2_ws/src/kirra_safety/config/kirra_params.yaml
@@ -4,6 +4,19 @@ cmd_vel_interceptor:
     kirra_token: ""              # Set via environment variable KIRRA_ADMIN_TOKEN or launch arg
     kirra_client_id: "ros2-interceptor-01"
     wheelbase_m: 0.2             # Hiwonder ROSOrin wheelbase (meters)
+    # ── R2-CLASS FLIP (draft, GATED — 2 of 3 uncomment sites) ─────────────────
+    # The interceptor cross-checks wheelbase_m against the wheelbase the verifier
+    # reports for its ACTIVE class contract; a mismatch (>1e-6) latches a
+    # PERMANENT stop (enforcement_decision.py WHEELBASE_TOLERANCE_M). The active
+    # class's contract wheelbase must be matched EXACTLY:
+    #   • courier interim → 0.5   • r2 class → 0.229 (== the physical, measured)
+    # When you flip to r2 (KIRRA_VEHICLE_CLASS=r2 + platform_map profile_class="r2"),
+    # comment the 0.2 line above and uncomment the r2 line below. Flip all THREE
+    # sites together — robot/install/PLATFORM_R2_PENDING.md "THE FLIP".
+    # NOTE: the current 0.2 matches NEITHER class — it is safe only while no
+    # verifier is in the loop (Stage-1 doer dry run); a Stage-2 courier run needs
+    # 0.5, a Stage-2 r2 run needs 0.229.
+    # wheelbase_m: 0.229         # r2 contract wheelbase (== physical, measured)
     max_speed_mps: 1.8           # ROSOrin spec max speed (m/s)
     input_topic: "/cmd_vel"
     output_topic: "/cmd_vel_safe"

--- a/ros2_ws/src/kirra_safety/config/kirra_params.yaml
+++ b/ros2_ws/src/kirra_safety/config/kirra_params.yaml
@@ -33,19 +33,27 @@ occy_doer:
     # accurate modelling, NOT a safety relaxation.
     #
     # NOTE the two distinct "space" surfaces (docs/CONTRACT_PROFILES.md):
-    #   * footprint (half_*): the robot's BODY. Keep it >= the real robot --
-    #     these are CONSERVATIVE estimates pending a tape-measure (see
-    #     R2_PATH_B / PLATFORM_R2_PENDING). NEVER shrink below reality.
+    #   * footprint (half_*): the robot's BODY. Keep it >= the real robot.
+    #     NEVER shrink below reality.
     #   * clearance TARGETS (lateral_clearance_target_m /
     #     rss_lateral_alignment_tolerance_m): extra room DEMANDED beyond the
     #     body. A 0.2 m robot honestly needs far less than an AV's 0.6 m.
     # This is the doer dry-run envelope only; the ACTUATION envelope (Stage 2)
     # is the verifier's per-class contract (courier interim until a measured
-    # `r2` class lands).
+    # `r2` class lands -- see robot/install/PLATFORM_R2_PENDING.md).
+    #
+    # PROVENANCE: footprint MEASURED (body 13 in x 8 in = 0.330 x 0.203 m ->
+    # half 0.165 x 0.102, +small margin); steering MEASURED (full lock ~39 deg
+    # / 0.68 rad @ cmd +/-45, r2_drive_calibration_results.txt Phase C
+    # 2026-07-17); wheelbase MEASURED ~0.229 m (front-to-rear CONFIRM still
+    # owed). Origin-offset / overhangs unmeasured -> the corridor_back
+    # extension (0.5 m) covers the rear; half_length assumes a roughly-front
+    # origin (lidar at base). Firm both up per PLATFORM_R2_PENDING.
     vehicle_class: "courier"                    # doer RSS-band label; numbers below win
-    wheelbase_m: 0.229                          # R2 physical wheelbase (matches KIRRA_R2_WHEELBASE_M)
-    half_length_m: 0.16                         # CONSERVATIVE (~0.30 m body); tape-measure to firm up
-    half_width_m: 0.12                          # CONSERVATIVE (~0.20 m body); tape-measure to firm up
+    wheelbase_m: 0.229                          # MEASURED ~9 in (front-to-rear CONFIRM pending)
+    half_length_m: 0.17                         # MEASURED body 13 in=0.330 m -> half 0.165 + margin
+    half_width_m: 0.11                          # MEASURED body 8 in=0.203 m -> half 0.102 + margin
+    max_steering_deg: 39.0                      # MEASURED full lock ~39 deg (0.68 rad) @ cmd +/-45 (calib Phase C)
     lateral_clearance_target_m: 0.15            # robot-scale (was courier 0.6)
     rss_lateral_alignment_tolerance_m: 0.15     # robot-scale (was courier 0.6)
 

--- a/ros2_ws/src/kirra_safety/config/kirra_params.yaml
+++ b/ros2_ws/src/kirra_safety/config/kirra_params.yaml
@@ -38,6 +38,12 @@ occy_doer:
     # a different lidar rate needs a deployment-review update here.
     scan_stale_s: 0.25
 
+    # Mick typed-intent sidecar (kirra-sidecars mick_service). Empty = off
+    # (goals come from /goal_pose only). Set here so occy_doer polls GET
+    # /intent/last each tick and grounds NEW positional intents as its goal —
+    # the R2 voice/LLM goal path. Mick publishes INTENTS, never commands.
+    mick_url: "http://127.0.0.1:8102"
+
     # --- R2-SIZED footprint + clearance (doer-side; sent to the planner's
     # CHECKER each tick). WITHOUT these the node falls back to occy_doer.py's
     # courier-sized defaults (half 0.15/0.18, clearance 0.6/0.6) and judges a

--- a/src/gateway/contract_profiles.rs
+++ b/src/gateway/contract_profiles.rs
@@ -88,9 +88,20 @@ pub const DELIVERY_AV_ODD_SPEED_CAP_MPS: f64 = 11.0;
 /// None` — the deployment applies the cap, per the frozen instance's own doc).
 pub const ROBOTAXI_ODD_SPEED_CAP_MPS: f64 = URBAN_ODD_SPEED_CAP_MPS;
 
-// The ODD-cap ordering is a family invariant, pinned at COMPILE time: a sidewalk
-// robot's ceiling is below a road pod's is below a robotaxi's. (Compile-time
-// assertions are the clippy-approved way to assert on constants.)
+/// R2 (Yahboom Rosmaster R2 bench robot, ~1/10 RC scale) ODD operational speed
+/// cap (m/s). **VALIDATION-PENDING.**
+///
+/// Basis: a small indoor/tethered Ackermann robot operated well below walking
+/// pace; the tethered demo backstop is `KIRRA_DEMO_VX_MAX` = 0.15 m/s, and
+/// 1.0 m/s is a conservative operational ceiling above the demo yet below the
+/// courier sidewalk cap. NOT a certified value — see `docs/CONTRACT_PROFILES.md`
+/// (param `r2.odd_cap`). Below every other class's cap (compile-time asserted).
+pub const R2_ODD_SPEED_CAP_MPS: f64 = 1.0;
+
+// The ODD-cap ordering is a family invariant, pinned at COMPILE time: the bench
+// R2 is below a sidewalk courier is below a road pod is below a robotaxi.
+// (Compile-time assertions are the clippy-approved way to assert on constants.)
+const _: () = assert!(R2_ODD_SPEED_CAP_MPS < COURIER_ODD_SPEED_CAP_MPS);
 const _: () = assert!(COURIER_ODD_SPEED_CAP_MPS < DELIVERY_AV_ODD_SPEED_CAP_MPS);
 const _: () = assert!(DELIVERY_AV_ODD_SPEED_CAP_MPS < ROBOTAXI_ODD_SPEED_CAP_MPS);
 
@@ -108,6 +119,11 @@ pub enum VehicleClass {
     DeliveryAv,
     /// Robotaxi — full-speed mixed-traffic. The frozen reference instance.
     Robotaxi,
+    /// R2 — the Yahboom Rosmaster R2 bench robot (Ackermann, ~1/10 RC scale).
+    /// The first profile with MEASURED geometry (footprint + full-lock steering);
+    /// its dynamic limits are still VALIDATION-PENDING. Retires the interim
+    /// `courier` borrow once selected (`robot/install/PLATFORM_R2_PENDING.md`).
+    R2,
 }
 
 impl FromStr for VehicleClass {
@@ -124,9 +140,10 @@ impl FromStr for VehicleClass {
             "courier" => Ok(VehicleClass::Courier),
             "delivery-av" => Ok(VehicleClass::DeliveryAv),
             "robotaxi" => Ok(VehicleClass::Robotaxi),
+            "r2" => Ok(VehicleClass::R2),
             other => Err(format!(
                 "unknown vehicle class {other:?}; expected one of \
-                 courier | delivery-av | robotaxi (fail-closed — no default)"
+                 courier | delivery-av | robotaxi | r2 (fail-closed — no default)"
             )),
         }
     }
@@ -140,6 +157,7 @@ impl VehicleClass {
             VehicleClass::Courier => "courier",
             VehicleClass::DeliveryAv => "delivery-av",
             VehicleClass::Robotaxi => "robotaxi",
+            VehicleClass::R2 => "r2",
         }
     }
 }
@@ -158,6 +176,7 @@ pub fn contract_for(class: VehicleClass) -> VehicleKinematicsContract {
         VehicleClass::Robotaxi => VehicleKinematicsContract::nominal_reference_profile(),
         VehicleClass::DeliveryAv => delivery_av_nominal(),
         VehicleClass::Courier => courier_nominal(),
+        VehicleClass::R2 => r2_nominal(),
     }
 }
 
@@ -172,6 +191,7 @@ pub fn mrc_fallback_for(class: VehicleClass) -> VehicleKinematicsContract {
         VehicleClass::Robotaxi => VehicleKinematicsContract::mrc_fallback_profile(),
         VehicleClass::DeliveryAv => delivery_av_mrc(),
         VehicleClass::Courier => courier_mrc(),
+        VehicleClass::R2 => r2_mrc(),
     }
 }
 
@@ -346,6 +366,75 @@ fn delivery_av_mrc() -> VehicleKinematicsContract {
     }
 }
 
+// --- R2 (Yahboom Rosmaster R2 bench robot, Ackermann, ~1/10 RC scale) -------
+//
+// The FIRST profile with MEASURED geometry. Footprint + full-lock steering are
+// bench numbers; the DYNAMIC limits (speed / accel / brake / lateral / steering-
+// rate) and the overhang split are still VALIDATION-PENDING estimates — the four
+// remaining bench items in `robot/install/PLATFORM_R2_PENDING.md`. Retires the
+// interim `courier` borrow for the R2 (Track-A A2). Provenance below is per-field
+// (MEASURED vs VALIDATION-PENDING); every non-inherited number cites
+// `docs/CONTRACT_PROFILES.md` param `r2.*`.
+
+fn r2_nominal() -> VehicleKinematicsContract {
+    VehicleKinematicsContract {
+        // VALIDATION-PENDING: conservative mechanical max for a small robot; the
+        // ODD cap (1.0) sits below it so the effective ceiling is the cap. Bench
+        // max-speed NOT yet measured. (r2.max_speed)
+        max_speed_mps: 1.5,
+        // VALIDATION-PENDING: gentle low-speed acceleration. (r2.accel)
+        max_accel_mps2: 0.5,
+        // VALIDATION-PENDING: firm brake ≥ accel; short stop at ≤1 m/s. (r2.brake)
+        max_brake_mps2: 1.5,
+        // MEASURED: full-lock road-wheel angle ~39° (0.68 rad) at command ±45
+        // (robot/r2_drive_calibration_results.txt Phase C 2026-07-17;
+        // KIRRA_R2_DELTA_MAX_RAD=0.68). (r2.steering)
+        max_steering_deg: 39.0,
+        // VALIDATION-PENDING: servo slew NOT yet measured (time a full −45→+45
+        // sweep — one of the 4 remaining bench items). (r2.steering_rate)
+        max_steering_rate_deg_s: 30.0,
+        // VALIDATION-PENDING: short follow at ≤1 m/s indoor speeds. (r2.follow)
+        min_follow_distance_m: 0.5,
+        // VALIDATION-PENDING: gentle lateral comfort. (r2.lat_accel)
+        max_lateral_accel_mps2: 1.0,
+        // MEASURED ~9 in = 0.229 m (front-to-rear CONFIRM owed;
+        // KIRRA_R2_WHEELBASE_M). (r2.wheelbase)
+        wheelbase_m: 0.229,
+        // MEASURED body (bench tape): width 8 in = 0.203 m, length 13 in = 0.330 m.
+        // (r2.footprint)
+        width_m: 0.203,
+        length_m: 0.330,
+        // ESTIMATE (overhang split UNMEASURED): (length − wheelbase)/2 ≈ 0.05 m
+        // each → front+rear+wheelbase ≈ length. Firm up per PLATFORM_R2_PENDING.
+        // (r2.overhangs)
+        overhang_front_m: 0.05,
+        overhang_rear_m: 0.05,
+        // The bench-robot ODD ceiling (sibling of COURIER_ODD_SPEED_CAP_MPS).
+        odd_speed_cap_mps: Some(R2_ODD_SPEED_CAP_MPS),
+    }
+}
+
+fn r2_mrc() -> VehicleKinematicsContract {
+    VehicleKinematicsContract {
+        max_speed_mps: 0.5,     // VALIDATION-PENDING: degraded crawl (r2.mrc.max_speed)
+        max_accel_mps2: 0.3,    // VALIDATION-PENDING (r2.mrc.accel)
+        max_brake_mps2: 1.0,    // VALIDATION-PENDING: brake ≥ accel (r2.mrc.brake)
+        max_steering_deg: 20.0, // VALIDATION-PENDING: ≤ nominal 39 (r2.mrc.steering)
+        max_steering_rate_deg_s: 15.0, // VALIDATION-PENDING (r2.mrc.steering_rate)
+        min_follow_distance_m: 0.75, // VALIDATION-PENDING: ≥ nominal follow (r2.mrc.follow)
+        max_lateral_accel_mps2: 0.5, // VALIDATION-PENDING (r2.mrc.lat_accel)
+        // Footprint IDENTICAL to r2 nominal (the vehicle does not shrink).
+        wheelbase_m: 0.229,
+        width_m: 0.203,
+        length_m: 0.330,
+        overhang_front_m: 0.05,
+        overhang_rear_m: 0.05,
+        // MRC crawl (0.5) is already below the R2 ODD cap; leave None so min()
+        // selects 0.5 (the frozen-MRC idiom).
+        odd_speed_cap_mps: None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -364,6 +453,7 @@ mod tests {
             VehicleClass::Courier,
             VehicleClass::DeliveryAv,
             VehicleClass::Robotaxi,
+            VehicleClass::R2,
         ]
         .into_iter()
         .map(|c| (c, contract_for(c), mrc_fallback_for(c)))
@@ -387,11 +477,13 @@ mod tests {
             VehicleClass::from_str("ROBOTAXI").unwrap(),
             VehicleClass::Robotaxi
         );
+        assert_eq!(VehicleClass::from_str("R2").unwrap(), VehicleClass::R2);
         // round-trip through as_str
         for c in [
             VehicleClass::Courier,
             VehicleClass::DeliveryAv,
             VehicleClass::Robotaxi,
+            VehicleClass::R2,
         ] {
             assert_eq!(VehicleClass::from_str(c.as_str()).unwrap(), c);
         }
@@ -460,6 +552,28 @@ mod tests {
         );
         // (The documented ODD-cap consts agree with this ordering — pinned at
         // compile time via the `const _: () = assert!(...)` checks beside the consts.)
+    }
+
+    #[test]
+    fn r2_carries_measured_geometry_and_is_slowest() {
+        // The MEASURED values are pinned so a future edit that silently changes
+        // the bench footprint / full-lock steering fails loudly (they are facts,
+        // not tuning knobs). Provenance: r2_drive_calibration_results.txt Phase C
+        // + bench tape (body 13x8 in, wheelbase ~9 in).
+        let n = contract_for(VehicleClass::R2);
+        assert_eq!(n.width_m, 0.203, "R2 measured width (8 in)");
+        assert_eq!(n.length_m, 0.330, "R2 measured length (13 in)");
+        assert_eq!(n.wheelbase_m, 0.229, "R2 measured wheelbase (~9 in)");
+        assert_eq!(n.max_steering_deg, 39.0, "R2 measured full-lock steering");
+        // R2 is the slowest class: effective ceiling below the courier's.
+        let r2 = n.effective_max_speed_mps();
+        let courier = contract_for(VehicleClass::Courier).effective_max_speed_mps();
+        assert!(r2 < courier, "R2 {r2} !< courier {courier}");
+        // The MRC footprint is identical (the robot does not shrink degraded).
+        let m = mrc_fallback_for(VehicleClass::R2);
+        assert_eq!(m.width_m, n.width_m);
+        assert_eq!(m.length_m, n.length_m);
+        assert_eq!(m.wheelbase_m, n.wheelbase_m);
     }
 
     #[test]

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -659,6 +659,31 @@ fn is_posture_exempt(method: &axum::http::Method, path: &str) -> bool {
         return true;
     }
 
+    // Trust-BOOTSTRAP plane (node registration + attestation handshake). These
+    // establish or PROVE a node's trust identity; none can reach an actuator, so
+    // the posture gate — which exists to block COMMANDS — must not gate them.
+    //
+    // This is load-bearing for the M-9 empty-fleet fail-closed policy: a fresh
+    // Active verifier with zero live nodes is forced LockedOut ("no positive
+    // trust evidence"), which auto-recovers to the DAG posture "the instant a
+    // node is registered" — the posture-engine comment explicitly relies on
+    // "registration routes are not posture-gated" (src/posture_engine.rs, M-9).
+    // Without this exemption those routes classify as `WriteState` and LockedOut
+    // 503s them, so the ONLY path out of the empty-fleet lockout (register +
+    // attest the first node) is itself blocked BY the lockout — an
+    // un-bootstrappable deadlock. Each route keeps its own guarantee independent
+    // of fleet posture: `/attestation/register` + `/attestation/identity/register`
+    // are admin-token gated; `/attestation/challenge/*` + `/attestation/verify`
+    // are the CSPRNG-nonce challenge-response (which "provides its own
+    // guarantee", #73). Same recovery-affordance rationale as the `/console`
+    // plane above — reachable regardless of posture BECAUSE it is the way out.
+    if matches!(path,
+        "/attestation/register" | "/attestation/verify" | "/attestation/identity/register")
+        || path.starts_with("/attestation/challenge/")
+    {
+        return true;
+    }
+
     // Bug 2 — the documented "public read-only" fleet-observability endpoints.
     // A GET/HEAD cannot reach an actuator (the posture gate exists to block
     // COMMANDS, not reads), and `/metrics` already exposes fleet posture during
@@ -1193,6 +1218,34 @@ mod actuator_middleware_tests {
             !is_posture_exempt(&Method::POST, "/federation/reports/submit"),
             "the report-submit write must stay posture-gated"
         );
+        // Trust-BOOTSTRAP plane — EXEMPT for the handshake methods (POST) so the
+        // M-9 empty-fleet LockedOut can auto-recover: register + attest the first
+        // node is the ONLY way out and must not be blocked BY the lockout. None
+        // can actuate; each keeps its own gate (admin token / challenge-response).
+        for p in [
+            "/attestation/register",
+            "/attestation/verify",
+            "/attestation/identity/register",
+            "/attestation/challenge/node-1",
+        ] {
+            assert!(
+                is_posture_exempt(&Method::POST, p),
+                "{p} MUST be posture-exempt (trust bootstrap out of empty-fleet LockedOut)"
+            );
+        }
+        // Prefix-confusion guard — a near-miss on a bootstrap route must NOT ride
+        // in on a loose prefix (challenge exempts only on the trailing-slash form).
+        for p in [
+            "/attestation/registerX",
+            "/attestation/challenge",
+            "/attestation/challengeX",
+            "/attestation/verifyX",
+        ] {
+            assert!(
+                !is_posture_exempt(&Method::POST, p),
+                "{p} must NOT be posture-exempt (prefix-confusion near-miss)"
+            );
+        }
         // Still gated even for GET (not in the documented public-read-only set /
         // intentionally denied under LockedOut): the campaign assignment feed and
         // the fabric reads.
@@ -1213,7 +1266,7 @@ mod actuator_middleware_tests {
             "/console-x",
             "/consol",
             "/con",
-            "/attestation/register",
+            "/fleet/dependencies",
             "/",
         ] {
             assert!(

--- a/src/gateway/policy_layer.rs
+++ b/src/gateway/policy_layer.rs
@@ -677,9 +677,14 @@ fn is_posture_exempt(method: &axum::http::Method, path: &str) -> bool {
     // are the CSPRNG-nonce challenge-response (which "provides its own
     // guarantee", #73). Same recovery-affordance rationale as the `/console`
     // plane above — reachable regardless of posture BECAUSE it is the way out.
-    if matches!(path,
-        "/attestation/register" | "/attestation/verify" | "/attestation/identity/register")
-        || path.starts_with("/attestation/challenge/")
+    // POST-only (the sole methods routed on these paths today): scope the
+    // exemption to the write verb so a future GET/HEAD sibling on one of these
+    // paths cannot inherit the exemption unintentionally — matching the GET/HEAD
+    // discipline of the Bug 2 observability block below.
+    if method == axum::http::Method::POST
+        && (matches!(path,
+            "/attestation/register" | "/attestation/verify" | "/attestation/identity/register")
+            || path.starts_with("/attestation/challenge/"))
     {
         return true;
     }
@@ -1231,6 +1236,12 @@ mod actuator_middleware_tests {
             assert!(
                 is_posture_exempt(&Method::POST, p),
                 "{p} MUST be posture-exempt (trust bootstrap out of empty-fleet LockedOut)"
+            );
+            // POST-only: a GET/HEAD sibling on the same path must NOT inherit the
+            // exemption (no such route today; pins the method constraint).
+            assert!(
+                !is_posture_exempt(&Method::GET, p),
+                "{p} must NOT be posture-exempt for GET (bootstrap exemption is POST-only)"
             );
         }
         // Prefix-confusion guard — a near-miss on a bootstrap route must NOT ride


### PR DESCRIPTION
## Summary

The R2 (Rosmaster R2 on Jetson Orin NX) governed-safety bring-up, standing the doer→checker→actuation loop up under systemd. The one load-bearing **verifier-core change** is a bootstrap-deadlock fix in the posture gate; the rest is the r2 contract class, the KITT conversational (SPEAK-only) stack, autostart units, and bench fixes found while standing the robot up.

## Verifier core (the important review target)

**`posture-gate: exempt trust-bootstrap routes` — fixes an M-9 empty-fleet deadlock.**
The M-9 policy forces a fresh Active verifier with zero live nodes to `LockedOut` ("no positive trust evidence"), and its own code comment states it auto-recovers *"the instant a node is registered (registration routes are not posture-gated)."* But they **were** gated: `classify_http_command` maps `/attestation/register` + `/attestation/verify` to `WriteState`, which `LockedOut` 503s — so the only way out of the empty-fleet lockout (register + attest the first node) was itself blocked **by** the lockout. A fresh single-box verifier could never onboard its first node.

The fix restores the documented invariant: `is_posture_exempt` now allowlists the trust-bootstrap plane — `/attestation/register`, `/attestation/identity/register`, `/attestation/verify`, `/attestation/challenge/*` (trailing-slash prefix). These establish/prove a node's trust identity and **cannot actuate**, so the posture gate (which blocks COMMANDS) must not gate them — same recovery-affordance rationale as the already-exempt `/console` plane. Each keeps its own guarantee independent of fleet posture (admin token / CSPRNG challenge-response). Reproduced and confirmed live on the Orin: after the fix, register→challenge→verify succeeds and `kirra_fleet_posture` flips `2 → 0` (Nominal).

- `console_exemption_set_is_pinned` extended: the four bootstrap routes MUST be exempt (POST); prefix-confusion near-misses (`/attestation/registerX`, `/attestation/challenge` without trailing slash) MUST NOT; sibling admin write `/fleet/dependencies` stays gated.
- Tests: 13 policy_layer + 17 real-router posture-gate tests green.

**`r2` vehicle contract class** (`src/gateway/contract_profiles.rs` + parko `impact.rs` SG6 sibling): a measured R2 kinematic envelope + SG6 impact config to retire the interim `courier` borrow. Measured footprint 0.203 × 0.330 m, wheelbase 0.229 m, full-lock steering 39°; compile-assert `R2_ODD_SPEED_CAP_MPS < courier`. Gated behind the 3-site `KIRRA_VEHICLE_CLASS=r2` flip (still commented pending the remaining bench captures).

## Robot side (scripts / docs — no verifier behaviour change)

- **`robot/attest_bench_node.py`** — bench helper that runs the real Ed25519 register→challenge→verify handshake to bring a fresh single-robot verifier out of the M-9 empty-fleet LockedOut (byte-matches `attestation_signing_payload`; persists the AK seed for idempotent reruns). Bench/demo only — documented as such.
- **Autostart**: `deploy/systemd` + `robot/install` unit files (ROS stack + KITT watcher), `install_robot_units.sh`, `kirra.target` `Wants=` fix (was omitting `kirra-mick`), and the `install.sh` secret-gen SIGPIPE fix.
- **KITT conversational stack** (SPEAK-only, fenced from actuation): grounded Q&A → multi-turn persona + fail-closed router → proactive event speech, plus GPIO push-to-talk + voice glue and the bring-up runbook.
- **Path-B R2 fixes**: `env.template` inline-comment strip (systemd `EnvironmentFile=` does not strip `#`), `install_kirra.sh` missing `r2_drive.py`, `occy_doer` `mick_url` param.
- **Docs**: untethered bring-up, hardware e-stop spec, autostart checklist, KITT design + runbook, CONTRACT_PROFILES r2 rows.

## Test

- `cargo test --lib policy_layer` (13) + `cargo test --bin kirra_verifier_service posture_gate` (17) green.
- Live on the Orin: empty-fleet bootstrap now recovers to Nominal; the actuator gate admits `/actuator/motion/command` once a node is Trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_