### PR TITLE
robot(r2): consumer-published wheel /odom (stop-at-goal) + odom hardening + bench turnkey scripts

### DIFF
--- a/docs/hardware/R2_AUTOSTART_CHECKLIST.md
+++ b/docs/hardware/R2_AUTOSTART_CHECKLIST.md
@@ -109,6 +109,29 @@ operation in scope.
 - ⬜ An installer step that renders the two new units' `User=` +
   `KIRRA_ROS_WS_SETUP` (today: fill the placeholders by hand).
 
+## Bench tooling (automates the steps above)
+
+Three scripts turn the manual checklist into runnable commands:
+
+- **`robot/install/lint_robot_env.sh`** — validate `/etc/kirra/robot.env` for the
+  two systemd-`EnvironmentFile` traps: inline `# comments` on value lines (systemd
+  keeps them IN the value → the consumer fail-closes) and duplicate keys (last
+  wins — a trap on reorder/delete). `--fix` normalizes to one bare `KEY=VALUE` per
+  key (backs up first). Run after any hand-edit of `robot.env`.
+- **`robot/install/disable_vendor_autostart.sh`** — find whatever autostarts the
+  Yahboom vendor base node (systemd unit / cron `@reboot` / `rc.local` /
+  autostart) — it opens `/dev/myserial` and fights the consumer. Report-only by
+  default; `--disable` acts on confident hits (never touches `kirra-*`). **Must be
+  clean before the cold-boot drill.**
+- **`robot/cold_boot_drill.sh`** — after a physical power cycle: Phase A verifies
+  every KIRRA service is up, posture is readable, a node is Trusted, the board is
+  KIRRA-owned, and no vendor node runs (read-only). `--fail-closed` runs Phase B:
+  stop the verifier → prove the consumer decel-stops (SS-002) + the interceptor
+  denies → restart → prove recovery. 🔴 wheels elevated for Phase B.
+
+Order at the bench: `lint_robot_env.sh` → `disable_vendor_autostart.sh --disable`
+→ power-cycle → `cold_boot_drill.sh` → (wheels up) `cold_boot_drill.sh --fail-closed`.
+
 ## References
 - `docs/hardware/R2_UNTETHERED_BRINGUP.md` §1 — the autostart layer
 - `docs/hardware/R2_ESTOP_SPEC.md` — the hardware e-stop (do first)

--- a/robot/cold_boot_drill.sh
+++ b/robot/cold_boot_drill.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# cold_boot_drill.sh — verify the R2 comes up SAFE on a clean power-on, and that
+# it FAILS CLOSED when the verifier dies. Run after a physical power cycle.
+#
+# Two phases:
+#   (default)      Phase A — post-boot health: every KIRRA service up, posture
+#                  readable, the fleet node attested, the board owned by KIRRA,
+#                  the vendor autostart gone. READ-ONLY; safe with wheels down.
+#   --fail-closed  Phase B — kill the verifier and prove the consumer decel-stops
+#                  (503 → 0.0, SS-002) + the interceptor denies, then restart and
+#                  prove recovery. 🔴 WHEELS ELEVATED (it exercises the stop path).
+#
+#   robot/cold_boot_drill.sh
+#   robot/cold_boot_drill.sh --fail-closed
+#
+# Companion to docs/hardware/R2_AUTOSTART_CHECKLIST.md. Exit 0 iff every checked
+# item passes.
+set -uo pipefail
+
+FAILCLOSED=0
+[[ "${1:-}" == "--fail-closed" ]] && FAILCLOSED=1
+
+VERIFIER="${KIRRA_URL:-http://localhost:8090}"
+PASS=0; FAIL=0
+ok()   { echo "  ✔ $*"; PASS=$((PASS + 1)); }
+bad()  { echo "  ❌ $*"; FAIL=$((FAIL + 1)); }
+note() { echo "     $*"; }
+
+# ROS for the topic checks (nounset-relaxed around the vendor setup scripts).
+set +u
+source /opt/ros/humble/setup.bash 2>/dev/null || true
+source "${KIRRA_ROS_WS_SETUP:-$HOME/kirra-runtime-sdk/ros2_ws/install/setup.bash}" 2>/dev/null || true
+set -u
+export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-28}"
+
+echo "== Phase A — post-boot health (ROS_DOMAIN_ID=${ROS_DOMAIN_ID}) =="
+
+# 1. services active.
+echo "-- services --"
+for svc in kirra-verifier kirra-planner kirra-taj kirra-mick kirra-consumer kirra-ros-stack; do
+  st="$(systemctl is-active "$svc" 2>/dev/null || echo missing)"
+  [[ "$st" == "active" ]] && ok "$svc active" || bad "$svc is '$st' (expected active)"
+done
+
+# 2. verifier reachable + posture.
+echo "-- verifier posture --"
+if curl -fsS "${VERIFIER}/health" >/dev/null 2>&1; then
+  ok "verifier /health reachable"
+  pm="$(curl -fsS "${VERIFIER}/metrics" 2>/dev/null | grep -m1 '^kirra_fleet_posture{' | awk '{print $NF}')"
+  case "$pm" in
+    0) ok "fleet posture = Nominal (0)" ;;
+    1) bad "fleet posture = Degraded (1)"; note "an actuator START from rest is denied under Degraded" ;;
+    2) bad "fleet posture = LockedOut (2)"; note "attest a node: python3 robot/attest_bench_node.py" ;;
+    *) bad "fleet posture unreadable ('$pm')" ;;
+  esac
+  # 3. fleet has an attested/Trusted node.
+  fleet="$(curl -fsS "${VERIFIER}/fleet/posture" 2>/dev/null || echo '')"
+  if grep -q '"local_status":"Trusted"' <<<"$fleet"; then
+    ok "at least one Trusted node in the fleet"
+  else
+    bad "no Trusted node — empty/untrusted fleet"
+    note "fleet was: ${fleet:0:120}"
+  fi
+else
+  bad "verifier /health unreachable at ${VERIFIER}"
+fi
+
+# 4. consumer owns the board, no car-type FATAL.
+echo "-- consumer / board ownership --"
+clog="$(journalctl -u kirra-consumer -n 60 --no-pager 2>/dev/null || true)"
+grep -q 'OWNS /dev/myserial' <<<"$clog" && ok "consumer OWNS /dev/myserial" || bad "no 'OWNS /dev/myserial' in recent consumer log"
+if grep -qE 'FATAL' <<<"$clog"; then bad "consumer logged a FATAL"; grep -E 'FATAL' <<<"$clog" | tail -1 | sed 's/^/     /'; else ok "no consumer FATAL"; fi
+
+# 5. vendor autostart gone.
+echo "-- vendor node absent --"
+if pgrep -af 'rosmaster_main|Rosmaster_Lib|yahboom' 2>/dev/null | grep -viE 'grep|cold_boot|disable_vendor' >/dev/null; then
+  bad "a vendor base process is RUNNING (will fight the consumer for /dev/myserial)"
+  note "disable it: robot/install/disable_vendor_autostart.sh --disable"
+else
+  ok "no vendor base process running"
+fi
+
+# 6. sensor topics (advisory — lidar is a separate launch, may be off at boot).
+echo "-- sensor topics (advisory) --"
+scan_pub="$(ros2 topic info /scan 2>/dev/null | awk -F': ' '/Publisher count/{print $2}')"
+odom_pub="$(ros2 topic info /odom 2>/dev/null | awk -F': ' '/Publisher count/{print $2}')"
+[[ "${scan_pub:-0}" -gt 0 ]] && ok "/scan has a publisher" || note "⚠ /scan has no publisher (start the lidar: ros2 launch ydlidar_ros2_driver ydlidar_launch.py)"
+[[ "${odom_pub:-0}" -gt 0 ]] && ok "/odom has a publisher" || note "⚠ /odom has no publisher (KIRRA_R2_ODOM_ENABLED=1 for consumer odom)"
+
+echo
+echo "Phase A: ${PASS} passed, ${FAIL} failed."
+
+if [[ $FAILCLOSED -eq 0 ]]; then
+  [[ $FAIL -eq 0 ]] && echo "✔ cold-boot health OK. Add --fail-closed to run the kill-verifier drill (wheels up)."
+  exit $(( FAIL > 0 ? 1 : 0 ))
+fi
+
+# ---- Phase B — fail-closed drill ------------------------------------------
+echo
+echo "== Phase B — fail-closed drill =="
+echo "🔴 WHEELS ELEVATED. This STOPS the verifier to prove the consumer decel-stops."
+read -r -p "   Wheels up and clear? type 'yes' to proceed: " ans
+[[ "$ans" == "yes" ]] || { echo "aborted."; exit 1; }
+
+echo "-- stopping kirra-verifier --"
+sudo systemctl stop kirra-verifier
+# Consumer liveness period is KIRRA_CONTROL_PERIOD_MS × KIRRA_MISSED_PERIODS (default
+# 100 ms × 3 = 300 ms) → decel-to-zero. Give it a comfortable margin.
+sleep 3
+ilog="$(journalctl -u kirra-ros-stack --since '6 seconds ago' --no-pager 2>/dev/null || true)"
+if grep -qiE 'POSTURE_|Cannot reach Kirra|BLOCKED|fail-closed' <<<"$ilog"; then
+  ok "interceptor denied / failed closed while the verifier was down"
+  grep -iE 'POSTURE_|Cannot reach|BLOCKED' <<<"$ilog" | tail -1 | sed 's/^/     /'
+else
+  note "⚠ no explicit interceptor denial in the window (it may just be publishing nothing → consumer starves to 0, also fail-closed)"
+fi
+echo "-- restarting kirra-verifier --"
+sudo systemctl start kirra-verifier
+sleep 4
+pm="$(curl -fsS "${VERIFIER}/metrics" 2>/dev/null | grep -m1 '^kirra_fleet_posture{' | awk '{print $NF}')"
+[[ "$pm" == "0" ]] && ok "verifier recovered to Nominal after restart" \
+  || bad "posture is '$pm' after restart (a fresh DB needs re-attest: robot/attest_bench_node.py)"
+
+echo
+echo "Drill total: ${PASS} passed, ${FAIL} failed."
+exit $(( FAIL > 0 ? 1 : 0 ))

--- a/robot/governed_drive_elevated.sh
+++ b/robot/governed_drive_elevated.sh
@@ -65,6 +65,11 @@ fi
 
 # ---- 2. /odom --------------------------------------------------------------
 banner "2/4  /odom"
+# Remove any stale static crutch left by a PRIOR run (a `ros2 topic pub … /odom`
+# process) BEFORE counting publishers — otherwise an orphaned crutch would be
+# mistaken for the consumer's real wheel-odometry below. The consumer's real
+# /odom is a python process, not `ros2 topic pub`, so it survives this.
+pkill -f "topic pub.*[/]odom" 2>/dev/null && sleep 1 || true
 if [[ "$(pub_count /odom)" != "0" && -n "$(pub_count /odom)" ]]; then
   # The consumer's real wheel-odometry (KIRRA_R2_ODOM_ENABLED) is publishing —
   # do NOT add a static crutch (two publishers would fight). This is the path

--- a/robot/governed_drive_elevated.sh
+++ b/robot/governed_drive_elevated.sh
@@ -63,16 +63,26 @@ else
   echo "  ❌ /scan STILL has no publisher — check ${LOGDIR}/lidar.log (is /dev/ydlidar present?)"
 fi
 
-# ---- 2. /odom (static origin crutch) ---------------------------------------
-banner "2/4  /odom (static origin, 10 Hz — bench crutch, wheels up)"
-pkill -f "topic pub.*[/]odom" 2>/dev/null || true
-setsid ros2 topic pub -r 10 /odom nav_msgs/msg/Odometry '{header: {frame_id: odom}}' \
-  >"${LOGDIR}/odom.log" 2>&1 &
-ODOM_PID=$!
-sleep 1
-[[ "$(pub_count /odom)" != "0" && -n "$(pub_count /odom)" ]] \
-  && echo "  ✔ /odom publishing (pid ${ODOM_PID})" \
-  || echo "  ❌ /odom not publishing — see ${LOGDIR}/odom.log"
+# ---- 2. /odom --------------------------------------------------------------
+banner "2/4  /odom"
+if [[ "$(pub_count /odom)" != "0" && -n "$(pub_count /odom)" ]]; then
+  # The consumer's real wheel-odometry (KIRRA_R2_ODOM_ENABLED) is publishing —
+  # do NOT add a static crutch (two publishers would fight). This is the path
+  # that lets the drive STOP at the goal.
+  echo "  ✔ /odom already published (real wheel-odometry) — no static crutch"
+else
+  echo "  no /odom publisher — starting static origin crutch (10 Hz)."
+  echo "  🔴 static odom has NO feedback: occy never sees the goal approach, so it"
+  echo "     drives forward FOREVER — wheels-up proof only. For a floor drive that"
+  echo "     STOPS at the goal, run the consumer with KIRRA_R2_ODOM_ENABLED=1."
+  setsid ros2 topic pub -r 10 /odom nav_msgs/msg/Odometry '{header: {frame_id: odom}}' \
+    >"${LOGDIR}/odom.log" 2>&1 &
+  ODOM_PID=$!
+  sleep 1
+  [[ "$(pub_count /odom)" != "0" && -n "$(pub_count /odom)" ]] \
+    && echo "  ✔ static /odom publishing (pid ${ODOM_PID})" \
+    || echo "  ❌ /odom not publishing — see ${LOGDIR}/odom.log"
+fi
 
 # ---- 3. occy DEBUG + goal --------------------------------------------------
 banner "3/4  occy DEBUG + goal via Mick"

--- a/robot/install/disable_vendor_autostart.sh
+++ b/robot/install/disable_vendor_autostart.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# disable_vendor_autostart.sh — find (and optionally disable) whatever autostarts
+# the Yahboom vendor base node on boot.
+#
+# WHY: the vendor image auto-launches its own ROS bringup (rosmaster_main.py / a
+# Rosmaster_Lib driver node) at boot, and that node OPENS /dev/myserial. The KIRRA
+# consumer is the ADR-0033 sole-writer of that port and will FATAL (or fight the
+# vendor node for the board) if the vendor node is also running. Before the
+# cold-boot drill, the vendor autostart must be OFF so KIRRA owns the board on a
+# clean power-on. Killing it by hand (pkill) does not survive a reboot — this
+# finds the persistent mechanism and disables it.
+#
+#   robot/install/disable_vendor_autostart.sh            # REPORT only (default)
+#   robot/install/disable_vendor_autostart.sh --disable  # act on confident hits
+#
+# Fail-safe: default is report-only. --disable acts ONLY on entries this script
+# is confident are the vendor bringup (matching the patterns below); it backs up
+# any file it edits and never touches a kirra-* unit.
+set -uo pipefail
+
+DISABLE=0
+[[ "${1:-}" == "--disable" ]] && DISABLE=1
+[[ "${1:-}" == "--report" || -z "${1:-}" ]] || { [[ $DISABLE -eq 1 ]] || { echo "usage: $0 [--disable]"; exit 2; }; }
+
+# Vendor signatures — what a Yahboom base autostart looks like. Deliberately does
+# NOT match 'kirra' (our own units must never be caught).
+PAT='rosmaster_main|Rosmaster_Lib|yahboom|Yahboom|ros_robot_controller|handsfree|bringup.*rosmaster|start_ros\.sh'
+found=0
+acted=0
+
+hr() { printf '%s\n' "-----------------------------------------------"; }
+
+# ---- 1. systemd services --------------------------------------------------
+echo "== 1. systemd units referencing the vendor base =="
+# Scan enabled/loaded unit files for the signature, excluding our kirra-* units.
+mapfile -t UNITS < <(
+  systemctl list-unit-files --type=service --no-legend 2>/dev/null | awk '{print $1}' \
+    | grep -viE '^kirra' || true
+)
+for u in "${UNITS[@]}"; do
+  frag="$(systemctl cat "$u" 2>/dev/null || true)"
+  [[ -z "$frag" ]] && continue
+  if grep -qiE "$PAT" <<<"$frag"; then
+    state="$(systemctl is-enabled "$u" 2>/dev/null || echo '?')"
+    active="$(systemctl is-active "$u" 2>/dev/null || echo '?')"
+    echo "  ⚠ ${u}  (enabled=${state} active=${active})"
+    grep -iE "ExecStart|$PAT" <<<"$frag" | sed 's/^/       /' | head -3
+    found=$((found + 1))
+    if [[ $DISABLE -eq 1 ]]; then
+      sudo systemctl disable --now "$u" 2>/dev/null \
+        && { echo "       ✔ disabled --now $u"; acted=$((acted + 1)); } \
+        || echo "       ❌ could not disable $u"
+    fi
+  fi
+done
+[[ $found -eq 0 ]] && echo "  (none found)"
+
+# ---- 2. cron @reboot ------------------------------------------------------
+echo "== 2. cron @reboot =="
+c=0
+for cronsrc in "crontab -l" "sudo crontab -l"; do
+  out="$($cronsrc 2>/dev/null | grep -iE "@reboot.*($PAT)" || true)"
+  [[ -n "$out" ]] && { echo "  ⚠ ($cronsrc):"; sed 's/^/       /' <<<"$out"; c=$((c + 1)); found=$((found + 1)); }
+done
+[[ $c -eq 0 ]] && echo "  (none found)"
+[[ $c -gt 0 && $DISABLE -eq 1 ]] && echo "  → edit the crontab by hand (comment the @reboot line); not auto-edited."
+
+# ---- 3. rc.local + profile/autostart scripts ------------------------------
+echo "== 3. rc.local / autostart scripts =="
+r=0
+for f in /etc/rc.local "$HOME/.bashrc" "$HOME/.profile" "$HOME/.config/autostart"/*.desktop; do
+  [[ -e "$f" ]] || continue
+  if grep -qiE "$PAT" "$f" 2>/dev/null; then
+    echo "  ⚠ $f references the vendor bringup:"
+    grep -niE "$PAT" "$f" | sed 's/^/       /' | head -3
+    r=$((r + 1)); found=$((found + 1))
+    if [[ $DISABLE -eq 1 ]]; then
+      bak="${f}.bak.$(od -An -N4 -tx1 /dev/urandom | tr -d ' ')"
+      sudo cp -a "$f" "$bak"
+      sudo sed -i -E "s@^(.*($PAT).*)@# DISABLED by disable_vendor_autostart.sh: \1@I" "$f"
+      echo "       ✔ commented matching lines in $f (backup $bak)"
+      acted=$((acted + 1))
+    fi
+  fi
+done
+[[ $r -eq 0 ]] && echo "  (none found)"
+
+# ---- 4. currently-running process (advisory) ------------------------------
+echo "== 4. running now? =="
+if pgrep -af "$PAT" 2>/dev/null | grep -viE 'disable_vendor_autostart|grep'; then
+  echo "  ⚠ a vendor process is running NOW."
+  [[ $DISABLE -eq 1 ]] && { sudo pkill -f "$PAT" 2>/dev/null && echo "  ✔ pkill sent" || true; }
+  echo "  (a running process is separate from the boot autostart above — disable both.)"
+else
+  echo "  (no vendor process running)"
+fi
+
+hr
+if [[ $found -eq 0 ]]; then
+  echo "✔ no vendor autostart found — the board is KIRRA's on boot."
+elif [[ $DISABLE -eq 0 ]]; then
+  echo "Found $found autostart reference(s). Re-run with --disable to act on the"
+  echo "systemd/rc.local/autostart hits (cron is reported, edit by hand)."
+  exit 1
+else
+  echo "Acted on $acted item(s). Re-run WITHOUT --disable to confirm it's clean,"
+  echo "then reboot and check: pgrep -af '$PAT' should be empty and"
+  echo "the consumer should log 'OWNS /dev/myserial' with no car-type FATAL."
+fi

--- a/robot/install/env.template
+++ b/robot/install/env.template
@@ -161,3 +161,22 @@ KIRRA_R2_V_PER_PWM_RIGHT=0.0194
 #KIRRA_R2_CLOSED_LOOP_DEBUG=1       # log-only: throttled per-cycle closed-loop line
                                     # (target, filtered L/R speed, PWMs) so the loop
                                     # is observable over SSH. No actuation change.
+
+# ---------------------------------------------------------------------------
+# R2 wheel-ODOMETRY (proposal follow-up) — OFF by default.
+#
+# Publishes nav_msgs/Odometry on /odom from the rear-wheel encoders so the Occy
+# planner sees the ego ADVANCE and STOPS at the goal. Without it the doer runs on
+# a static-origin /odom crutch (governed_drive_elevated.sh) that never sees the
+# goal approach, so a floor drive would command forward indefinitely — fine
+# wheels-up, unsafe on the floor. Ackermann dead-reckoning: forward travel from
+# the MEAN rear-wheel distance, heading from the STEERING angle (never the
+# per-wheel encoder difference — the R2's independent rear motors differ ~34% at
+# equal PWM and would fabricate phantom yaw). r2_ackermann mode only; reuses
+# KIRRA_R2_M_PER_TICK (above). Turn on for a governed FLOOR drive that terminates.
+#KIRRA_R2_ODOM_ENABLED=1
+# Optional (defaults shown):
+#KIRRA_R2_ODOM_PERIOD_MS=50         # publish period (50 = 20 Hz)
+#KIRRA_R2_ODOM_TOPIC=/odom
+#KIRRA_R2_ODOM_FRAME=odom
+#KIRRA_R2_ODOM_CHILD_FRAME=base_link

--- a/robot/install/lint_robot_env.sh
+++ b/robot/install/lint_robot_env.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# lint_robot_env.sh — validate (and optionally normalize) /etc/kirra/robot.env.
+#
+# WHY: robot.env is consumed by systemd `EnvironmentFile=`, which — unlike a
+# shell `source` — does NOT strip inline `# comments` and does NOT dedup repeated
+# keys (it takes the LAST). A value line like
+#     KIRRA_R2_WHEELBASE_M=0.229   # CHOSEN ~0.229 nominal
+# is read by systemd as the value `0.229   # CHOSEN ...`, and the consumer
+# fail-closes: "must be a number, got '0.229   # ...'". Bench edits that append a
+# clean duplicate below the commented one work by last-wins, but leave a trap:
+# reorder or delete the clean line and the commented one silently wins.
+#
+# This script FLAGS both hazards (inline comments on value lines, duplicate keys)
+# and, with --fix, rewrites the file to one bare `KEY=VALUE` per key (last value
+# wins, inline comments stripped), backing up the original first. Full-line
+# comments and blanks are dropped in --fix (the rich provenance lives in
+# robot/install/env.template, not the deployed copy).
+#
+#   robot/install/lint_robot_env.sh            # validate only (exit 1 on issues)
+#   robot/install/lint_robot_env.sh --fix      # normalize in place (backs up)
+#   robot/install/lint_robot_env.sh /path/to/env [--fix]
+set -euo pipefail
+
+FILE=/etc/kirra/robot.env
+FIX=0
+for arg in "$@"; do
+  case "$arg" in
+    --fix) FIX=1 ;;
+    -*) echo "unknown flag: $arg (known: --fix)"; exit 2 ;;
+    *)  FILE="$arg" ;;
+  esac
+done
+
+[[ -r "$FILE" ]] || { echo "❌ cannot read $FILE (need sudo?)"; exit 2; }
+echo "== lint $FILE =="
+
+# A "value line" is KEY=... (KEY = leading [A-Za-z_][A-Za-z0-9_]*). Everything
+# else (blank / full-line comment starting with optional ws then #) is structure.
+issues=0
+
+# 1. inline comments on value lines (systemd keeps them in the value).
+while IFS= read -r line; do
+  [[ "$line" =~ ^[[:space:]]*# ]] && continue
+  [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+  if [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]] && [[ "$line" =~ [[:space:]]# ]]; then
+    key="${line%%=*}"
+    echo "  ⚠ inline comment on value line for ${key} — systemd keeps it IN the value"
+    issues=$((issues + 1))
+  fi
+done < "$FILE"
+
+# 2. duplicate keys (systemd takes the last; a trap on reorder/delete).
+dups="$(grep -oE '^[A-Za-z_][A-Za-z0-9_]*=' "$FILE" | sed 's/=$//' | sort | uniq -d || true)"
+if [[ -n "$dups" ]]; then
+  while IFS= read -r k; do
+    n="$(grep -cE "^${k}=" "$FILE" || true)"
+    echo "  ⚠ duplicate key ${k} appears ${n}× (systemd uses the LAST)"
+    issues=$((issues + 1))
+  done <<< "$dups"
+fi
+
+if [[ "$issues" -eq 0 ]]; then
+  echo "  ✔ clean — no inline-comment value lines, no duplicate keys"
+  exit 0
+fi
+
+if [[ "$FIX" -eq 0 ]]; then
+  echo
+  echo "  $issues issue(s). Re-run with --fix to normalize (backs up first):"
+  echo "    sudo robot/install/lint_robot_env.sh $FILE --fix"
+  exit 1
+fi
+
+# --fix: normalize to bare KEY=VALUE, last value wins, inline comments stripped.
+BACKUP="${FILE}.bak.$(od -An -N4 -tx1 /dev/urandom | tr -d ' ')"
+cp -a "$FILE" "$BACKUP"
+echo "  backed up → $BACKUP"
+
+# Emit in first-appearance order, using each key's LAST value (inline comment
+# stripped: cut from the first ' #' or tab-#; then trim trailing whitespace).
+python3 - "$FILE" > "${FILE}.tmp" <<'PY'
+import re, sys
+path = sys.argv[1]
+order, last = [], {}
+for raw in open(path):
+    line = raw.rstrip("\n")
+    if re.match(r'^\s*#', line) or re.match(r'^\s*$', line):
+        continue
+    m = re.match(r'^([A-Za-z_][A-Za-z0-9_]*)=(.*)$', line)
+    if not m:
+        continue
+    key, val = m.group(1), m.group(2)
+    # Strip an inline comment: first ' #' or '\t#'. (KIRRA_* values are numbers/
+    # paths/hex/topics and never legitimately contain '#'.)
+    val = re.split(r'[ \t]#', val, 1)[0].rstrip()
+    if key not in last:
+        order.append(key)
+    last[key] = val
+print("# /etc/kirra/robot.env — normalized by lint_robot_env.sh --fix.")
+print("# One bare KEY=VALUE per key (systemd-safe: no inline comments, no dups).")
+print("# Provenance for each var lives in robot/install/env.template.")
+for k in order:
+    print(f"{k}={last[k]}")
+PY
+# Preserve mode/owner of the original, then swap in.
+chmod --reference="$FILE" "${FILE}.tmp" 2>/dev/null || true
+chown --reference="$FILE" "${FILE}.tmp" 2>/dev/null || true
+mv "${FILE}.tmp" "$FILE"
+echo "  ✔ normalized $FILE ($(grep -cE '^[A-Za-z_]' "$FILE") keys). Original at $BACKUP."
+echo "  restart the consumer to pick it up: sudo systemctl restart kirra-consumer"

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -51,6 +51,7 @@ servo, §2a) and NEVER calls set_car_motion.
 
 from __future__ import annotations
 
+import math
 import os
 import signal
 import sys
@@ -65,9 +66,12 @@ from r2_drive import (  # noqa: E402
     apply_actuation,
     calibration_from_env,
     closed_loop_enabled,
+    odom_step,
+    odom_zero,
     r2_safe_stop,
     speed_match_params_from_env,
     translate,
+    yaw_to_quaternion_zw,
 )
 
 # Actuation last-hop selector (R2 Path B). Default = the existing X3 path
@@ -173,6 +177,28 @@ def main() -> int:
         r2_matcher is not None
         and (os.environ.get("KIRRA_R2_CLOSED_LOOP_DEBUG") or "").strip().lower() in ("1", "true", "yes", "on")
     )
+
+    # R2 wheel-odometry — OPT-IN (default OFF → byte-identical, no /odom publish).
+    # Publishes nav_msgs/Odometry from the rear-wheel encoders so the PLANNER sees
+    # the ego advance and STOPS at the goal. Without it the doer runs on a static-
+    # origin /odom crutch (never sees the goal approach) and a floor drive would
+    # command forward indefinitely. Ackermann dead-reckoning: forward travel from
+    # the mean rear-wheel distance, heading from the STEERING angle (never the
+    # per-wheel encoder difference — the R2's independent rear motors differ ~34%
+    # at equal PWM and would fabricate phantom yaw). r2 mode only.
+    odom_enabled = (
+        drive_mode == DRIVE_MODE_R2
+        and (os.environ.get("KIRRA_R2_ODOM_ENABLED") or "").strip().lower() in ("1", "true", "yes", "on")
+    )
+    odom_m_per_tick = _req_float("KIRRA_R2_M_PER_TICK") if odom_enabled else 0.0
+    odom_period_ms = _req_int("KIRRA_R2_ODOM_PERIOD_MS") if os.environ.get("KIRRA_R2_ODOM_PERIOD_MS") else 50
+    odom_topic = os.environ.get("KIRRA_R2_ODOM_TOPIC", "/odom")
+    odom_frame = os.environ.get("KIRRA_R2_ODOM_FRAME", "odom")
+    odom_child_frame = os.environ.get("KIRRA_R2_ODOM_CHILD_FRAME", "base_link")
+    if odom_enabled and odom_period_ms <= 0:
+        print("FATAL: KIRRA_R2_ODOM_PERIOD_MS must be > 0", file=sys.stderr)
+        return 2
+
     topic = os.environ.get("KIRRA_RELEASE_TOPIC", "/kirra/release")
 
     # The verify core (fail-closed: raises on a NULL handle).
@@ -190,17 +216,17 @@ def main() -> int:
     bot = Rosmaster(com=motor_port)
     bot.create_receive_threading()
 
-    # Closed-loop speed matching reads the wheel encoders (get_motor_encoder),
-    # which ONLY update from the MCU's auto-report frames. Enable auto-report once
-    # here, fail-closed — without it every encoder read is a stale 0, so the
-    # matcher would see a dead wheel and immediately trip a stall→MRC fault (or
-    # never converge). Open-loop paths never read encoders, so this is scoped to
-    # the closed-loop consumer only (byte-identical otherwise).
-    if r2_matcher is not None:
+    # Closed-loop speed matching AND wheel-odometry read the encoders
+    # (get_motor_encoder), which ONLY update from the MCU's auto-report frames.
+    # Enable auto-report once here, fail-closed — without it every encoder read is
+    # a stale 0, so the matcher would trip a stall→MRC fault (or never converge)
+    # and odom would never advance. Open-loop-without-odom paths never read
+    # encoders, so this is scoped to those consumers only (byte-identical otherwise).
+    if r2_matcher is not None or odom_enabled:
         try:
             bot.set_auto_report_state(True)
         except Exception as e:  # noqa: BLE001 — no encoder feed → refuse to start
-            print(f"FATAL: closed-loop drive needs encoder auto-report, but "
+            print(f"FATAL: encoder auto-report is required (closed-loop or odom) but "
                   f"set_auto_report_state(True) failed: {e}", file=sys.stderr)
             return 2
 
@@ -289,15 +315,19 @@ def main() -> int:
 
     alarm_announced = False
     cl_debug_ctr = 0  # throttle counter for the closed-loop debug log
+    last_delta_rad = 0.0  # steering angle of the last actuation (odom heading source)
 
     def actuate(linear: float, angular: float) -> None:
-        nonlocal cl_debug_ctr
+        nonlocal cl_debug_ctr, last_delta_rad
         if drive_mode == DRIVE_MODE_R2:
             # Path B: the Ackermann last-hop runs AFTER verify (the same place
             # the x3 firmware mixing runs after verify). translate() is
             # fail-closed; an MRC/stop decision carries zeros, so this same call
             # stops the platform.
             act = translate(linear, angular, r2_cal)
+            # The odom integrator's heading source: the kinematic road-wheel angle
+            # this actuation applied (0.0 for a stop/MRC). Latched for the odom timer.
+            last_delta_rad = act.delta_rad
             if r2_matcher is None:
                 apply_actuation(bot, act)  # open-loop equal-PWM (default)
                 return
@@ -380,6 +410,56 @@ def main() -> int:
             actuate(t.linear, t.angular)
 
     node.create_timer(control_period_ms / 1000.0, on_timer)
+
+    # R2 wheel-odometry publisher (opt-in). Reads the rear-wheel encoders each
+    # period and publishes an Ackermann dead-reckoning pose so the planner sees
+    # the ego advance and stops at the goal. Read-only w.r.t. actuation — never
+    # writes a motor; a transient encoder-read fault skips the tick (fail-soft).
+    if odom_enabled:
+        from nav_msgs.msg import Odometry  # robot-only dep; imported under the gate
+
+        odom_pub = node.create_publisher(Odometry, odom_topic, 10)
+        odom_state = odom_zero()
+
+        def on_odom_timer() -> None:
+            nonlocal odom_state
+            try:
+                enc = bot.get_motor_encoder()  # [m1(RL), m2, m3, m4(RR)]
+                left, right = int(enc[0]), int(enc[3])
+            except Exception:  # noqa: BLE001 — transient read fault → skip this tick
+                return
+            prev = odom_state.pose
+            odom_state = odom_step(
+                odom_state, left, right, last_delta_rad, odom_m_per_tick, r2_cal.wheelbase_m
+            )
+            cur = odom_state.pose
+            dt = odom_period_ms / 1000.0
+            dx, dy = cur.x_m - prev.x_m, cur.y_m - prev.y_m
+            dist = math.hypot(dx, dy)
+            # Signed forward speed: project the step onto the entry heading.
+            forward = dist if (dx * math.cos(prev.yaw_rad) + dy * math.sin(prev.yaw_rad)) >= 0.0 else -dist
+            dyaw = math.atan2(
+                math.sin(cur.yaw_rad - prev.yaw_rad), math.cos(cur.yaw_rad - prev.yaw_rad)
+            )
+            msg = Odometry()
+            msg.header.stamp = node.get_clock().now().to_msg()
+            msg.header.frame_id = odom_frame
+            msg.child_frame_id = odom_child_frame
+            msg.pose.pose.position.x = cur.x_m
+            msg.pose.pose.position.y = cur.y_m
+            qz, qw = yaw_to_quaternion_zw(cur.yaw_rad)
+            msg.pose.pose.orientation.z = qz
+            msg.pose.pose.orientation.w = qw
+            msg.twist.twist.linear.x = forward / dt
+            msg.twist.twist.angular.z = dyaw / dt
+            odom_pub.publish(msg)
+
+        node.create_timer(odom_period_ms / 1000.0, on_odom_timer)
+        node.get_logger().info(
+            f"R2 wheel-odometry ON → {odom_topic} @ {1000.0 / odom_period_ms:.0f} Hz "
+            f"(m/tick={odom_m_per_tick}, wheelbase={r2_cal.wheelbase_m} m; Ackermann "
+            f"dead-reckoning: heading from steering, distance from mean rear encoder)."
+        )
 
     # Guaranteed stop on any exit path (SIGINT / SIGTERM / exception / normal).
     # Same double-shutdown class as the publisher's hardware finding: shutdown

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -192,7 +192,13 @@ def main() -> int:
         and (os.environ.get("KIRRA_R2_ODOM_ENABLED") or "").strip().lower() in ("1", "true", "yes", "on")
     )
     odom_m_per_tick = _req_float("KIRRA_R2_M_PER_TICK") if odom_enabled else 0.0
-    odom_period_ms = _req_int("KIRRA_R2_ODOM_PERIOD_MS") if os.environ.get("KIRRA_R2_ODOM_PERIOD_MS") else 50
+    # Parse the period ONLY when odom is enabled — a stray/invalid
+    # KIRRA_R2_ODOM_PERIOD_MS must never fail-close a run that isn't using odom.
+    odom_period_ms = (
+        _req_int("KIRRA_R2_ODOM_PERIOD_MS")
+        if (odom_enabled and os.environ.get("KIRRA_R2_ODOM_PERIOD_MS"))
+        else 50
+    )
     odom_topic = os.environ.get("KIRRA_R2_ODOM_TOPIC", "/odom")
     odom_frame = os.environ.get("KIRRA_R2_ODOM_FRAME", "odom")
     odom_child_frame = os.environ.get("KIRRA_R2_ODOM_CHILD_FRAME", "base_link")

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -63,6 +63,7 @@ from kirra_ffi import KirraConsumer, REFUSAL_NAMES, split_frame  # noqa: E402
 from r2_drive import (  # noqa: E402
     ClosedLoopSpeedMatcher,
     R2CalibrationError,
+    _wrap_angle,
     apply_actuation,
     calibration_from_env,
     closed_loop_enabled,
@@ -195,6 +196,12 @@ def main() -> int:
     odom_topic = os.environ.get("KIRRA_R2_ODOM_TOPIC", "/odom")
     odom_frame = os.environ.get("KIRRA_R2_ODOM_FRAME", "odom")
     odom_child_frame = os.environ.get("KIRRA_R2_ODOM_CHILD_FRAME", "base_link")
+    if odom_enabled and odom_m_per_tick <= 0.0:
+        # A 0/negative scale silently yields a never-advancing (or reversed) odom
+        # → the planner never sees the goal approach → the robot drives forever.
+        # It is a measured physical constant like the others: fail closed.
+        print("FATAL: KIRRA_R2_M_PER_TICK must be > 0 (odom)", file=sys.stderr)
+        return 2
     if odom_enabled and odom_period_ms <= 0:
         print("FATAL: KIRRA_R2_ODOM_PERIOD_MS must be > 0", file=sys.stderr)
         return 2
@@ -453,9 +460,7 @@ def main() -> int:
             dist = math.hypot(dx, dy)
             # Signed forward speed: project the step onto the entry heading.
             forward = dist if (dx * math.cos(prev.yaw_rad) + dy * math.sin(prev.yaw_rad)) >= 0.0 else -dist
-            dyaw = math.atan2(
-                math.sin(cur.yaw_rad - prev.yaw_rad), math.cos(cur.yaw_rad - prev.yaw_rad)
-            )
+            dyaw = _wrap_angle(cur.yaw_rad - prev.yaw_rad)  # correct across the ±pi seam
             msg = Odometry()
             msg.header.stamp = node.get_clock().now().to_msg()
             msg.header.frame_id = odom_frame
@@ -467,6 +472,15 @@ def main() -> int:
             msg.pose.pose.orientation.w = qw
             msg.twist.twist.linear.x = forward / dt
             msg.twist.twist.angular.z = dyaw / dt
+            # Honest covariance: this is UN-fused wheel dead-reckoning, loosely
+            # trusted. A modest diagonal (x,y,yaw / vx,wz) tells a downstream
+            # estimator not to treat it as ground truth; occy ignores it. The
+            # unset DOF rows stay 0 (planar robot). Indices: 6x6 row-major.
+            msg.pose.covariance[0] = 0.02   # x
+            msg.pose.covariance[7] = 0.02   # y
+            msg.pose.covariance[35] = 0.05  # yaw
+            msg.twist.covariance[0] = 0.05  # vx
+            msg.twist.covariance[35] = 0.10  # wz
             odom_pub.publish(msg)
 
         node.create_timer(odom_period_ms / 1000.0, on_odom_timer)

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -420,14 +420,29 @@ def main() -> int:
 
         odom_pub = node.create_publisher(Odometry, odom_topic, 10)
         odom_state = odom_zero()
+        odom_debug = (os.environ.get("KIRRA_R2_ODOM_DEBUG") or "").strip().lower() in (
+            "1", "true", "yes", "on"
+        )
+        odom_dbg_ctr = 0
 
         def on_odom_timer() -> None:
-            nonlocal odom_state
+            nonlocal odom_state, odom_dbg_ctr
             try:
                 enc = bot.get_motor_encoder()  # [m1(RL), m2, m3, m4(RR)]
                 left, right = int(enc[0]), int(enc[3])
-            except Exception:  # noqa: BLE001 — transient read fault → skip this tick
+            except Exception as e:  # noqa: BLE001 — transient read fault → skip this tick
+                if odom_debug:
+                    node.get_logger().warn(f"odom: get_motor_encoder failed: {e}")
                 return
+            if odom_debug:
+                # ~1 Hz: raw rear encoder counts + integrated x, so a hand-spin
+                # (wheels up) shows whether the MCU auto-report is delivering.
+                odom_dbg_ctr += 1
+                if odom_dbg_ctr % max(1, int(round(1000.0 / odom_period_ms))) == 0:
+                    node.get_logger().info(
+                        f"odom raw: encL={left} encR={right} x={odom_state.pose.x_m:.3f} "
+                        f"yaw={odom_state.pose.yaw_rad:.3f} delta={last_delta_rad:.3f}"
+                    )
             prev = odom_state.pose
             odom_state = odom_step(
                 odom_state, left, right, last_delta_rad, odom_m_per_tick, r2_cal.wheelbase_m

--- a/robot/r2_drive.py
+++ b/robot/r2_drive.py
@@ -168,6 +168,10 @@ class R2Actuation:
     pwm_left:  set_motor s1 (M1 = rear-left), signed PWM %.
     pwm_right: set_motor s4 (M4 = rear-right), signed PWM %.
     steer_cmd: set_akm_steering_angle argument, [-45, +45] command units.
+    delta_rad: the kinematic road-wheel steering angle this actuation implies
+               (bicycle model), BEFORE the servo-unit calibration/rounding. 0.0
+               for a stop/MRC. Used by the odometry integrator as the heading
+               source (never the corrupted per-wheel encoder difference).
     """
 
     is_mrc: bool
@@ -175,6 +179,8 @@ class R2Actuation:
     pwm_left: int
     pwm_right: int
     steer_cmd: int
+    # Default keeps every existing positional/keyword constructor valid.
+    delta_rad: float = 0.0
 
 
 def mrc_stop(reason: str) -> R2Actuation:
@@ -223,7 +229,110 @@ def translate(v: float, omega: float, cal: R2DriveCalibration) -> R2Actuation:
     pwm = _iround(math.copysign(pwm_mag, v))
     pwm = int(_clamp(float(pwm), -cal.pwm_max, cal.pwm_max))
 
-    return R2Actuation(is_mrc=False, reason="ok", pwm_left=pwm, pwm_right=pwm, steer_cmd=steer_cmd)
+    return R2Actuation(
+        is_mrc=False, reason="ok", pwm_left=pwm, pwm_right=pwm, steer_cmd=steer_cmd, delta_rad=delta
+    )
+
+
+# --------------------------------------------------------------------------
+# Ackermann wheel-odometry (pure; the consumer feeds it encoder ticks).
+#
+# WHY a bicycle model, not differential-drive: the R2's two rear wheels are
+# INDEPENDENTLY driven (no fixed axle / no differential) and differ ~34% in
+# speed at equal PWM, so the per-wheel encoder DIFFERENCE does not measure body
+# rotation — it would fabricate a phantom yaw. Heading therefore comes from the
+# STEERING angle (`delta_rad`, the same bicycle geometry `translate` uses);
+# forward travel is the MEAN of the two rear-wheel distances (the body follows
+# the rear-axle centre). Dead-reckoning only — no slip model, no IMU fusion; it
+# exists so the planner sees the ego advance and stops at the goal.
+
+
+@dataclass(frozen=True)
+class OdomPose:
+    """Planar dead-reckoning pose in the odom frame (metres, radians)."""
+
+    x_m: float = 0.0
+    y_m: float = 0.0
+    yaw_rad: float = 0.0
+
+
+@dataclass(frozen=True)
+class OdomState:
+    """Accumulator: the current pose + the last raw encoder tick counts.
+
+    `last_*_ticks is None` marks the pre-first-sample state (no delta yet).
+    """
+
+    pose: OdomPose = OdomPose()
+    last_left_ticks: "int | None" = None
+    last_right_ticks: "int | None" = None
+
+
+def odom_zero() -> OdomState:
+    """A fresh accumulator at the origin, awaiting its first encoder sample."""
+    return OdomState()
+
+
+def _wrap_angle(a: float) -> float:
+    """Normalise a yaw to (-pi, pi]."""
+    return math.atan2(math.sin(a), math.cos(a))
+
+
+def integrate_ackermann_odom(
+    pose: OdomPose, d_left_m: float, d_right_m: float, delta_rad: float, wheelbase_m: float
+) -> OdomPose:
+    """Advance `pose` by one step given the two rear-wheel distances + steering.
+
+    Forward travel is the mean of the wheel distances; heading change is the
+    bicycle model `dyaw = d * tan(delta) / L`. Midpoint (2nd-order) integration
+    so a step taken mid-turn lands between the entry and exit headings.
+    Non-finite inputs are treated as no motion (fail-soft: never poison the pose).
+    """
+    if not (_finite(d_left_m) and _finite(d_right_m) and _finite(delta_rad) and wheelbase_m > 0.0):
+        return pose
+    d = 0.5 * (d_left_m + d_right_m)
+    dyaw = d * math.tan(delta_rad) / wheelbase_m
+    yaw_mid = pose.yaw_rad + 0.5 * dyaw
+    return OdomPose(
+        x_m=pose.x_m + d * math.cos(yaw_mid),
+        y_m=pose.y_m + d * math.sin(yaw_mid),
+        yaw_rad=_wrap_angle(pose.yaw_rad + dyaw),
+    )
+
+
+def odom_step(
+    state: OdomState,
+    left_ticks: int,
+    right_ticks: int,
+    delta_rad: float,
+    m_per_tick: float,
+    wheelbase_m: float,
+    max_tick_jump: int = 100_000,
+) -> OdomState:
+    """Fold one encoder sample into the accumulator (pure).
+
+    The FIRST sample only anchors the tick baseline (no motion — there is no
+    prior count to difference against). A per-step tick delta whose magnitude
+    exceeds `max_tick_jump` is treated as a counter wrap / garbage frame: the
+    baseline is re-anchored and NO motion is integrated (a wrap must never
+    teleport the pose). Otherwise ticks → distance → `integrate_ackermann_odom`.
+    """
+    if state.last_left_ticks is None or state.last_right_ticks is None:
+        return OdomState(pose=state.pose, last_left_ticks=left_ticks, last_right_ticks=right_ticks)
+    dl = left_ticks - state.last_left_ticks
+    dr = right_ticks - state.last_right_ticks
+    if abs(dl) > max_tick_jump or abs(dr) > max_tick_jump:
+        # Re-anchor on a suspicious jump; hold the pose.
+        return OdomState(pose=state.pose, last_left_ticks=left_ticks, last_right_ticks=right_ticks)
+    new_pose = integrate_ackermann_odom(
+        state.pose, dl * m_per_tick, dr * m_per_tick, delta_rad, wheelbase_m
+    )
+    return OdomState(pose=new_pose, last_left_ticks=left_ticks, last_right_ticks=right_ticks)
+
+
+def yaw_to_quaternion_zw(yaw_rad: float) -> "tuple[float, float]":
+    """The (z, w) of the planar-yaw quaternion (x=y=0). For nav_msgs/Odometry."""
+    return (math.sin(yaw_rad * 0.5), math.cos(yaw_rad * 0.5))
 
 
 # --------------------------------------------------------------------------

--- a/robot/r2_drive.py
+++ b/robot/r2_drive.py
@@ -307,26 +307,29 @@ def odom_step(
     delta_rad: float,
     m_per_tick: float,
     wheelbase_m: float,
-    max_tick_jump: int = 100_000,
+    max_step_m: float = 1.0,
 ) -> OdomState:
     """Fold one encoder sample into the accumulator (pure).
 
     The FIRST sample only anchors the tick baseline (no motion — there is no
-    prior count to difference against). A per-step tick delta whose magnitude
-    exceeds `max_tick_jump` is treated as a counter wrap / garbage frame: the
-    baseline is re-anchored and NO motion is integrated (a wrap must never
-    teleport the pose). Otherwise ticks → distance → `integrate_ackermann_odom`.
+    prior count to difference against). A per-step wheel travel whose magnitude
+    exceeds `max_step_m` is PHYSICALLY IMPOSSIBLE for this robot in one odom
+    period (<0.2 m/s → <~0.01 m/step) and is treated as an encoder-counter WRAP
+    or garbage frame: the baseline is re-anchored and NO motion is integrated (a
+    wrap must never teleport the pose). This bound is on DISTANCE, not tick
+    magnitude, so it is independent of the encoder counter's width — a 16- or
+    32-bit wrap (metres of implied travel) is caught the same way, unlike a raw
+    tick threshold that a 16-bit wrap (~65 k ticks) could slip under. Otherwise
+    ticks → distance → `integrate_ackermann_odom`.
     """
     if state.last_left_ticks is None or state.last_right_ticks is None:
         return OdomState(pose=state.pose, last_left_ticks=left_ticks, last_right_ticks=right_ticks)
-    dl = left_ticks - state.last_left_ticks
-    dr = right_ticks - state.last_right_ticks
-    if abs(dl) > max_tick_jump or abs(dr) > max_tick_jump:
-        # Re-anchor on a suspicious jump; hold the pose.
+    d_left = (left_ticks - state.last_left_ticks) * m_per_tick
+    d_right = (right_ticks - state.last_right_ticks) * m_per_tick
+    if abs(d_left) > max_step_m or abs(d_right) > max_step_m:
+        # Re-anchor on a non-physical jump; hold the pose.
         return OdomState(pose=state.pose, last_left_ticks=left_ticks, last_right_ticks=right_ticks)
-    new_pose = integrate_ackermann_odom(
-        state.pose, dl * m_per_tick, dr * m_per_tick, delta_rad, wheelbase_m
-    )
+    new_pose = integrate_ackermann_odom(state.pose, d_left, d_right, delta_rad, wheelbase_m)
     return OdomState(pose=new_pose, last_left_ticks=left_ticks, last_right_ticks=right_ticks)
 
 

--- a/robot/r2_drive_test.py
+++ b/robot/r2_drive_test.py
@@ -32,11 +32,15 @@ from r2_drive import (  # noqa: E402
     apply_actuation,
     calibration_from_env,
     closed_loop_enabled,
+    integrate_ackermann_odom,
     mrc_stop,
+    odom_step,
+    odom_zero,
     r2_safe_stop,
     speed_match_params_from_env,
     speed_match_step,
     translate,
+    yaw_to_quaternion_zw,
 )
 
 
@@ -545,6 +549,103 @@ def test_speed_match_params_from_env_rejects_nonnumeric() -> None:
     except R2CalibrationError:
         return
     raise AssertionError("expected R2CalibrationError for non-numeric m_per_tick")
+
+
+# --------------------------------------------------------------------------
+# Ackermann wheel-odometry (pure integrator)
+# --------------------------------------------------------------------------
+_MPT = 0.00025101  # KIRRA_R2_M_PER_TICK (RL 66.675 mm wheel / 834.5 t/rev)
+_WB = 0.229  # KIRRA_R2_WHEELBASE_M
+
+
+def test_odom_first_sample_only_anchors_no_motion() -> None:
+    st = odom_step(odom_zero(), 1000, 1000, 0.0, _MPT, _WB)
+    assert st.pose.x_m == 0.0 and st.pose.y_m == 0.0 and st.pose.yaw_rad == 0.0
+    assert st.last_left_ticks == 1000 and st.last_right_ticks == 1000
+
+
+def test_odom_straight_advances_x_by_mean_distance() -> None:
+    # delta=0 → pure forward. 4000 ticks both wheels → 4000*_MPT metres.
+    st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
+    st = odom_step(st, 4000, 4000, 0.0, _MPT, _WB)
+    assert abs(st.pose.x_m - 4000 * _MPT) < 1e-9
+    assert abs(st.pose.y_m) < 1e-12
+    assert abs(st.pose.yaw_rad) < 1e-12
+
+
+def test_odom_reaches_one_metre_and_would_trip_goal() -> None:
+    # Accumulate ~1 m in equal steps; the planner's goal-reached fires when the
+    # ego x crosses the goal distance. Prove x converges to ~1.0 m.
+    st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
+    ticks = int(round(1.0 / _MPT))
+    st = odom_step(st, ticks, ticks, 0.0, _MPT, _WB)
+    assert abs(st.pose.x_m - 1.0) < 1e-3
+
+
+def test_odom_heading_from_steering_not_wheel_difference() -> None:
+    # The R2's rear wheels differ at equal PWM. Feed a LARGE wheel difference but
+    # delta=0: a differential model would spin; the bicycle model must NOT — yaw
+    # stays 0 and x advances by the mean.
+    st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
+    st = odom_step(st, 5000, 3000, 0.0, _MPT, _WB)  # 34%-ish imbalance
+    assert abs(st.pose.yaw_rad) < 1e-12, "wheel diff must not create yaw at delta=0"
+    assert abs(st.pose.x_m - 4000 * _MPT) < 1e-9  # mean of 5000,3000
+
+
+def test_odom_positive_delta_turns_left() -> None:
+    st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
+    st = odom_step(st, 4000, 4000, 0.30, _MPT, _WB)  # steering left
+    assert st.pose.yaw_rad > 0.0, "a positive road-wheel angle must yaw left (+)"
+    # dyaw = d*tan(delta)/L with d=4000*_MPT
+    d = 4000 * _MPT
+    assert abs(st.pose.yaw_rad - d * math.tan(0.30) / _WB) < 1e-9
+
+
+def test_odom_backward_decrements_x() -> None:
+    st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
+    st = odom_step(st, -2000, -2000, 0.0, _MPT, _WB)
+    assert st.pose.x_m < 0.0 and abs(st.pose.x_m + 2000 * _MPT) < 1e-9
+
+
+def test_odom_tick_wrap_re_anchors_without_teleport() -> None:
+    st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
+    st = odom_step(st, 4000, 4000, 0.0, _MPT, _WB)
+    x_before = st.pose.x_m
+    # A garbage jump beyond max_tick_jump must hold the pose but re-anchor ticks.
+    st = odom_step(st, 4000 + 10_000_000, 4000, 0.0, _MPT, _WB, max_tick_jump=100_000)
+    assert st.pose.x_m == x_before, "a counter wrap must not teleport the pose"
+    assert st.last_left_ticks == 4000 + 10_000_000  # re-anchored
+    # A subsequent normal step integrates from the new baseline.
+    st = odom_step(st, 4000 + 10_000_000 + 4000, 8000, 0.0, _MPT, _WB)
+    assert abs(st.pose.x_m - (x_before + 4000 * _MPT)) < 1e-9
+
+
+def test_odom_nonfinite_distance_holds_pose() -> None:
+    st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
+    p = st.pose
+    p2 = integrate_ackermann_odom(p, float("nan"), 0.0, 0.0, _WB)
+    assert p2 == p, "non-finite input must not poison the pose"
+
+
+def test_yaw_to_quaternion_zw_matches_planar_convention() -> None:
+    z, w = yaw_to_quaternion_zw(0.0)
+    assert abs(z) < 1e-12 and abs(w - 1.0) < 1e-12
+    z, w = yaw_to_quaternion_zw(math.pi / 2)
+    assert abs(z - math.sin(math.pi / 4)) < 1e-12 and abs(w - math.cos(math.pi / 4)) < 1e-12
+
+
+def test_odom_delta_rad_flows_from_translate() -> None:
+    # The heading source the consumer feeds odom is translate().delta_rad — prove
+    # it is populated on an "ok" actuation and zero on a stop.
+    cal = R2DriveCalibration(
+        wheelbase_m=_WB, v_per_pwm=0.0145, pwm_max=40, steer_units_per_rad=66,
+        delta_max_rad=0.68, steer_sign=-1.0, center_trim=90, drive_deadband_pwm=0,
+    )
+    turning = translate(0.1, 0.2, cal)
+    assert turning.reason == "ok" and abs(turning.delta_rad) > 0.0
+    assert abs(turning.delta_rad - math.atan(_WB * 0.2 / 0.1)) < 1e-9
+    assert translate(0.0, 0.0, cal).delta_rad == 0.0  # stopped
+    assert mrc_stop("x").delta_rad == 0.0
 
 
 def _run_all() -> int:

--- a/robot/r2_drive_test.py
+++ b/robot/r2_drive_test.py
@@ -567,7 +567,7 @@ def test_odom_first_sample_only_anchors_no_motion() -> None:
 def test_odom_straight_advances_x_by_mean_distance() -> None:
     # delta=0 → pure forward. 4000 ticks both wheels → 4000*_MPT metres.
     st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
-    st = odom_step(st, 4000, 4000, 0.0, _MPT, _WB)
+    st = odom_step(st, 4000, 4000, 0.0, _MPT, _WB, max_step_m=100.0)
     assert abs(st.pose.x_m - 4000 * _MPT) < 1e-9
     assert abs(st.pose.y_m) < 1e-12
     assert abs(st.pose.yaw_rad) < 1e-12
@@ -578,7 +578,7 @@ def test_odom_reaches_one_metre_and_would_trip_goal() -> None:
     # ego x crosses the goal distance. Prove x converges to ~1.0 m.
     st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
     ticks = int(round(1.0 / _MPT))
-    st = odom_step(st, ticks, ticks, 0.0, _MPT, _WB)
+    st = odom_step(st, ticks, ticks, 0.0, _MPT, _WB, max_step_m=100.0)
     assert abs(st.pose.x_m - 1.0) < 1e-3
 
 
@@ -587,14 +587,14 @@ def test_odom_heading_from_steering_not_wheel_difference() -> None:
     # delta=0: a differential model would spin; the bicycle model must NOT — yaw
     # stays 0 and x advances by the mean.
     st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
-    st = odom_step(st, 5000, 3000, 0.0, _MPT, _WB)  # 34%-ish imbalance
+    st = odom_step(st, 5000, 3000, 0.0, _MPT, _WB, max_step_m=100.0)  # 34%-ish imbalance
     assert abs(st.pose.yaw_rad) < 1e-12, "wheel diff must not create yaw at delta=0"
     assert abs(st.pose.x_m - 4000 * _MPT) < 1e-9  # mean of 5000,3000
 
 
 def test_odom_positive_delta_turns_left() -> None:
     st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
-    st = odom_step(st, 4000, 4000, 0.30, _MPT, _WB)  # steering left
+    st = odom_step(st, 4000, 4000, 0.30, _MPT, _WB, max_step_m=100.0)  # steering left
     assert st.pose.yaw_rad > 0.0, "a positive road-wheel angle must yaw left (+)"
     # dyaw = d*tan(delta)/L with d=4000*_MPT
     d = 4000 * _MPT
@@ -607,17 +607,38 @@ def test_odom_backward_decrements_x() -> None:
     assert st.pose.x_m < 0.0 and abs(st.pose.x_m + 2000 * _MPT) < 1e-9
 
 
-def test_odom_tick_wrap_re_anchors_without_teleport() -> None:
+def test_odom_wrap_re_anchors_without_teleport() -> None:
     st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
-    st = odom_step(st, 4000, 4000, 0.0, _MPT, _WB)
+    st = odom_step(st, 4000, 4000, 0.0, _MPT, _WB, max_step_m=100.0)
     x_before = st.pose.x_m
-    # A garbage jump beyond max_tick_jump must hold the pose but re-anchor ticks.
-    st = odom_step(st, 4000 + 10_000_000, 4000, 0.0, _MPT, _WB, max_tick_jump=100_000)
+    # A non-physical jump (2500 m of implied travel) must hold the pose + re-anchor.
+    st = odom_step(st, 4000 + 10_000_000, 4000, 0.0, _MPT, _WB, max_step_m=100.0)
     assert st.pose.x_m == x_before, "a counter wrap must not teleport the pose"
     assert st.last_left_ticks == 4000 + 10_000_000  # re-anchored
     # A subsequent normal step integrates from the new baseline.
-    st = odom_step(st, 4000 + 10_000_000 + 4000, 8000, 0.0, _MPT, _WB)
+    st = odom_step(st, 4000 + 10_000_000 + 4000, 8000, 0.0, _MPT, _WB, max_step_m=100.0)
     assert abs(st.pose.x_m - (x_before + 4000 * _MPT)) < 1e-9
+
+
+def test_odom_16bit_wrap_is_caught_by_distance_bound() -> None:
+    # THE realistic case a tick-magnitude threshold would miss: a signed 16-bit
+    # counter wrap (~65536 ticks) implies ~16.4 m of travel in one step — a raw
+    # 100k-tick threshold would let it through, but the DISTANCE bound (default
+    # 1.0 m) rejects it. Guards finding: a 16-bit wrap must not teleport the pose.
+    st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
+    st = odom_step(st, 100, 100, 0.0, _MPT, _WB)
+    x_before = st.pose.x_m
+    st = odom_step(st, 100 - 65536, 100, 0.0, _MPT, _WB)  # 16-bit wrap on the left wheel
+    assert st.pose.x_m == x_before, "a 16-bit wrap (~65536 ticks) must be rejected, not integrated"
+
+
+def test_odom_large_but_physical_step_is_kept() -> None:
+    # A vigorous hand-spin (~0.2 m in one 50 ms step) is physical (< 1.0 m bound)
+    # and MUST be integrated, not mistaken for a wrap.
+    st = odom_step(odom_zero(), 0, 0, 0.0, _MPT, _WB)
+    ticks = int(round(0.2 / _MPT))
+    st = odom_step(st, ticks, ticks, 0.0, _MPT, _WB)
+    assert abs(st.pose.x_m - ticks * _MPT) < 1e-9, "a physical step must not be rejected"
 
 
 def test_odom_nonfinite_distance_holds_pose() -> None:


### PR DESCRIPTION
## ⚠️ Hold merge — for CI signal

This PR is opened to get CI (mutation gate, checker-diff gate, consumer compile) on the odom slice. **Do not merge until the encoder→odom path is confirmed on the R2 hardware** — the pure math is host-tested but the live encoder feed hasn't been verified end-to-end yet (a hand-spin left `x` at 0.0; the `KIRRA_R2_ODOM_DEBUG` hook here is how we'll confirm whether the MCU auto-report delivers counts, and reveal the counter width).

## Summary

Robot-side only — no verifier/checker code touched. Gives the R2 a real `/odom` source so a governed floor drive **stops at the goal** instead of driving forever on a static-origin crutch, plus off-bench hardening and three bench turnkey scripts.

## Consumer-published wheel `/odom` (`bffcf38`)

The R2 has no odom source (the vendor base node that publishes it is killed to free `/dev/myserial` for the KIRRA consumer). The consumer — the sole serial owner, already reading the encoders — now publishes `nav_msgs/Odometry` so occy sees the ego advance and holds at the goal.

- Pure core in `r2_drive.py`: `integrate_ackermann_odom` / `odom_step`. **Ackermann dead-reckoning** — forward travel from the *mean* rear-wheel distance, heading from the *steering angle* (`translate().delta_rad`), **not** the per-wheel encoder difference (the R2's independent rear motors differ ~34% at equal PWM → a differential model would fabricate phantom yaw). Midpoint integration; first-sample anchors only; non-finite holds the pose.
- Consumer wiring (opt-in `KIRRA_R2_ODOM_ENABLED`, r2 mode, default OFF → byte-identical): enables encoder auto-report, latches the actuation's `delta_rad`, a timer folds one `odom_step` and publishes pose + yaw-quaternion + twist. Read-only w.r.t. actuation; a transient read fault skips the tick.
- Sim-verified: ~1 m of encoder ticks → ego `x` = 1.004 m → occy's `goal_reached` fires.

## Odom hardening from a self-review (`ab83a12`)

- **Wrap guard on DISTANCE, not tick magnitude** (`max_step_m`, 1.0 m). A raw 100 k-tick threshold would let a 16-bit counter wrap (~65536 ticks ≈ 16.4 m) through and integrate a phantom jump → the robot never reaches the goal. A physical distance bound catches 16- and 32-bit wraps identically, independent of the (unconfirmed) counter width. New tests: 16-bit wrap rejected, physical hand-spin step kept.
- **Fail-closed on `KIRRA_R2_M_PER_TICK ≤ 0`** — a 0/negative scale was a silent never-advancing odom.
- Honest `/odom` covariance + `_wrap_angle` reuse.
- `KIRRA_R2_ODOM_DEBUG` (`0a775f5`) — throttled raw-encoder log for the hardware diagnosis.
- **53/53 host tests green.**

## Bench turnkey scripts (`ff6a379`)

- `robot/install/lint_robot_env.sh` — validate/normalize `robot.env` (inline-comment + duplicate-key systemd `EnvironmentFile` traps).
- `robot/install/disable_vendor_autostart.sh` — find/disable the vendor base autostart that grabs `/dev/myserial`.
- `robot/cold_boot_drill.sh` — post-power-cycle health + fail-closed (kill-verifier → decel-stop) drill.
- Wired into `docs/hardware/R2_AUTOSTART_CHECKLIST.md`.

## Test

- `python3 robot/r2_drive_test.py` → 53/53.
- `py_compile` clean on the consumer.
- The three shell scripts `bash -n` clean; linter + vendor-detector exercised locally.

## Deferred (needs bench hardware data)
- Confirm the encoder counter width (via `KIRRA_R2_ODOM_DEBUG`) to add a modular wrap-diff + width-matched test.
- `twist.linear.x` aliases when auto-report rate < odom rate (pose integral correct; occy tolerates noisy speed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_