### PR TITLE
r2/kitt: closed-loop tuning guide + KITT scanner protocol + autostart preflight gate

### DIFF
--- a/docs/hardware/R2_AUTOSTART_CHECKLIST.md
+++ b/docs/hardware/R2_AUTOSTART_CHECKLIST.md
@@ -60,6 +60,13 @@ sudo systemctl daemon-reload
 
 ## Enable — ONE service at a time, validate first
 
+**First, the readiness gate** (read-only — checks every prerequisite below and
+names the fix for each; run until it's green before enabling anything):
+
+```bash
+robot/install/preflight_autostart.sh      # exit 0 = ready to enable
+```
+
 For **each** unit: start it, confirm it does its job wheels-up, THEN enable for boot.
 
 ```bash
@@ -111,8 +118,14 @@ operation in scope.
 
 ## Bench tooling (automates the steps above)
 
-Three scripts turn the manual checklist into runnable commands:
+Four scripts turn the manual checklist into runnable commands:
 
+- **`robot/install/preflight_autostart.sh`** — the READINESS GATE (read-only):
+  verifies every prerequisite for a clean governed boot (units installed, key
+  pinned, `KIRRA_VEHICLE_CLASS` set, `robot.env` clean, dialout/audio groups,
+  device symlinks, vendor autostart cleared, ROS ws overlay) and names the fix
+  for each gap. Run until green BEFORE the one-service-at-a-time enable. Exit 0 =
+  ready.
 - **`robot/install/lint_robot_env.sh`** — validate `/etc/kirra/robot.env` for the
   two systemd-`EnvironmentFile` traps: inline `# comments` on value lines (systemd
   keeps them IN the value → the consumer fail-closes) and duplicate keys (last
@@ -129,8 +142,10 @@ Three scripts turn the manual checklist into runnable commands:
   stop the verifier → prove the consumer decel-stops (SS-002) + the interceptor
   denies → restart → prove recovery. 🔴 wheels elevated for Phase B.
 
-Order at the bench: `lint_robot_env.sh` → `disable_vendor_autostart.sh --disable`
-→ power-cycle → `cold_boot_drill.sh` → (wheels up) `cold_boot_drill.sh --fail-closed`.
+Order at the bench: `lint_robot_env.sh --fix` → `disable_vendor_autostart.sh
+--disable` → `preflight_autostart.sh` (until green) → enable services one at a
+time (above) → power-cycle → `cold_boot_drill.sh` → (wheels up)
+`cold_boot_drill.sh --fail-closed`.
 
 ## References
 - `docs/hardware/R2_UNTETHERED_BRINGUP.md` §1 — the autostart layer

--- a/docs/hardware/R2_CLOSED_LOOP_TUNING.md
+++ b/docs/hardware/R2_CLOSED_LOOP_TUNING.md
@@ -1,0 +1,136 @@
+# R2 closed-loop speed matching — bench tuning guide
+
+> Task #84. The pure controller (`robot/r2_drive.py`: `ClosedLoopSpeedMatcher` /
+> `speed_match_step`) and its consumer wiring are done and host-tested; the gains
+> are conservative defaults, **not hardware-tuned**. This is the turnkey procedure
+> to tune them on the R2. Do it AFTER the odom is validated (it reuses the same
+> encoder feed) and the first open-loop governed drive works.
+
+## Why closed-loop (what problem it solves)
+
+The R2's two rear wheels are **independently driven with no shared axle**, and at
+equal PWM they differ **~34%** in speed (measured, `r2_drive_calibration_results.txt`).
+Open-loop equal-PWM therefore drives an **arc**, not a straight line. Closed-loop
+speed matching trims each rear wheel's PWM so both track the **same governed
+target speed** → the robot drives straight.
+
+It does NOT touch safety: `translate()` is still the fail-closed front (non-finite
+/ spin-in-place / at-rest → MRC or stop with zeros), the KIRRA checker still bounds
+the command upstream, and closed-loop only REPLACES the two drive PWMs when
+`translate` returns `ok` — the steering command and every MRC/stop path are
+unchanged. A stalled wheel → MRC stop.
+
+### The control law (per wheel, each cycle)
+```
+ff   = target_v / v_per_pwm_side          # feedforward from the wheel's own slope
+raw  = ff + KP * (target_v - meas_v)      # proportional trim on the speed error
+raw  = clamp(raw, prev_pwm ± MAX_PWM_STEP)# slew limit (no jerk)
+pwm  = clamp(raw, ±pwm_max)               # hard envelope
+```
+`meas_v` is the EMA-filtered per-wheel ground speed (Δticks·m_per_tick / dt). No
+integral term → the setpoint `|target_v|` is a ceiling P can't wind past.
+
+## Prerequisites (all already done)
+- Encoder feed proven (odom hand-spin / roll test — `encL/encR` change under motion).
+- Measured constants present in `/etc/kirra/robot.env`:
+  - `KIRRA_R2_M_PER_TICK` (encoder scale, m/tick),
+  - `KIRRA_R2_V_PER_PWM` (LEFT/RL slope, reused for the left wheel),
+  - `KIRRA_R2_V_PER_PWM_RIGHT` (RR slope).
+- `KIRRA_DRIVE_MODE=r2_ackermann`, a pinned governor key, posture Nominal.
+
+## Enable it (with the debug log)
+
+Add to `/etc/kirra/robot.env` (then `sudo robot/install/lint_robot_env.sh --fix`
+if you hand-edit, and `sudo systemctl restart kirra-consumer`):
+```
+KIRRA_R2_CLOSED_LOOP=1
+KIRRA_R2_CLOSED_LOOP_DEBUG=1        # throttled per-cycle log, tuning only
+```
+On start the consumer logs `r2_ackermann drive: CLOSED-LOOP speed matching`.
+
+## Reading the debug line
+
+Throttled ~every 5th control cycle:
+```
+cl tgt=0.120 ema_L=0.098 ema_R=0.131 pwm_L=41 pwm_R=33 steer=0
+```
+| field | meaning | what you want |
+|---|---|---|
+| `tgt` | governed target speed (m/s), the setpoint | > 0 while driving |
+| `ema_L` / `ema_R` | filtered measured speed of each rear wheel | **both converge to `tgt`** |
+| `pwm_L` / `pwm_R` | commanded PWM per wheel | **differ** (that's the imbalance being corrected) |
+| `steer` | AKM steering command units | ~0 on a straight goal |
+
+- **Good (converged):** `ema_L ≈ ema_R ≈ tgt`, `pwm_L ≠ pwm_R` and steady. The
+  slower wheel (lower slope) carries the higher PWM.
+- **Under-corrected (still curves):** `ema_L` and `ema_R` stay apart, PWMs nearly
+  equal → KP too low.
+- **Oscillating (hunts):** `ema_L`/`ema_R` and PWMs swing above/below `tgt` cycle
+  to cycle → KP too high or EMA too fast (alpha too high).
+- **`NaN` before the first measured cycle** is normal (feedforward-only seed).
+
+## Gain reference
+
+| Env var | Default | Effect | Tune |
+|---|---|---|---|
+| `KIRRA_R2_SPEED_KP` | 20 | PWM per (m/s error). The main knob. | ↑ until wheels match; ↓ if it hunts |
+| `KIRRA_R2_SPEED_MAX_PWM_STEP` | 5 | per-cycle slew cap | ↑ if correction is sluggish; ↓ if jerky |
+| `KIRRA_R2_SPEED_EMA_ALPHA` | 0.4 | measured-speed smoothing (0,1]; 1=raw | ↓ to smooth a noisy `ema_*`; ↑ if lag hurts |
+| `KIRRA_R2_SPEED_STALL_CYCLES` | 5 | under-response cycles → MRC fault | ↑ if false stalls on start; ↓ for faster fault |
+| `KIRRA_R2_SPEED_STALL_MIN_PWM` | 10 | "commanding real effort" threshold | set just above the physical deadband PWM |
+| `KIRRA_R2_SPEED_STALL_MIN_MPS` | 0.02 | "not moving" threshold | just above encoder noise at rest |
+
+Change a value → `sudo systemctl restart kirra-consumer` (params are read at
+startup) → re-observe. (A future slice could hot-reload; today it's a restart.)
+
+## Procedure
+
+### Step 1 — 🔴 WHEELS ELEVATED: converge the wheel speeds
+Goal: both `ema_*` track `tgt` with no oscillation.
+1. Enable closed-loop + debug (above), wheels up.
+2. Drive a steady low goal (`bash robot/governed_drive_elevated.sh "go forward one meter"`
+   — elevated it just spins the wheels) and watch `journalctl -u kirra-consumer -f | grep '^.*cl tgt'`.
+3. Read `ema_L`/`ema_R`:
+   - apart + equal PWMs → raise `KIRRA_R2_SPEED_KP` (try 30, 40), restart, re-check.
+   - swinging → lower KP (try 12, 8) and/or lower `KIRRA_R2_SPEED_EMA_ALPHA` (0.3, 0.2).
+4. Converged when `|ema_L − ema_R|` is small and steady and both ≈ `tgt`.
+
+### Step 2 — floor: verify it drives straight
+1. Wheels down, clear ~1.5 m straight lane, e-stop in hand, cables clear of the lidar.
+2. `bash robot/governed_drive_elevated.sh "go forward one meter"`.
+3. Measure **heading drift** over the run (tape a start line; eyeball or measure
+   lateral deviation at 1 m):
+   - drifts to one side → KP still too low (slower wheel not catching up) → ↑ KP.
+   - snakes / weaves → KP too high or EMA too fast → ↓ KP / ↓ alpha.
+4. Cross-check with odom: `journalctl -u kirra-consumer -f | grep 'odom raw'` — `x`
+   should climb smoothly to the goal; large per-cycle jumps in the debug `ema_*`
+   mean the EMA is too fast.
+
+### Step 3 — lock the gains
+Write the converged values into `robot/install/env.template` (and the deployed
+`robot.env`), turn `KIRRA_R2_CLOSED_LOOP_DEBUG` off, restart, and re-run the floor
+drive once to confirm it holds without the debug spam.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `wheel_stall_left/right` fault → MRC on start | stall thresholds too tight for the start transient | ↑ `KIRRA_R2_SPEED_STALL_CYCLES`, or ↑ `KIRRA_R2_SPEED_STALL_MIN_PWM` above the deadband |
+| Still curves, PWMs ≈ equal | KP too low | ↑ `KIRRA_R2_SPEED_KP` |
+| Weaves/hunts | KP too high or alpha too high | ↓ KP; ↓ `KIRRA_R2_SPEED_EMA_ALPHA` |
+| `ema_*` very noisy | raw aliasing (auto-report not loop-locked) | ↓ alpha (more smoothing) |
+| One wheel always pins to `pwm_max` | its slope const wrong | re-confirm `KIRRA_R2_V_PER_PWM` / `_RIGHT` |
+| MRC on a legit slow crawl | `STALL_MIN_MPS` above the crawl speed | ↓ `KIRRA_R2_SPEED_STALL_MIN_MPS` |
+
+## Safety notes
+- Elevated first (Step 1) before any floor run. E-stop in hand on the floor.
+- Closed-loop never relaxes the envelope: `translate` + the KIRRA checker bound
+  the command first; closed-loop only redistributes the two drive PWMs toward the
+  already-governed target. A non-finite feedback or a stalled wheel → MRC stop.
+- The Nominal WCET-critical checker path is unchanged (closed-loop is doer-side,
+  after verify).
+
+## References
+- `robot/r2_drive.py` — `ClosedLoopSpeedMatcher`, `speed_match_step`, `SpeedMatchParams`.
+- `robot/r2_drive_calibration_results.txt` — the measured slopes + the RR confirm.
+- `docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md` §9 — the closed-loop proposal.

--- a/docs/kitt/scanner_protocol.md
+++ b/docs/kitt/scanner_protocol.md
@@ -1,0 +1,220 @@
+# KITT Scanner — Jetson ↔ MCU serial protocol (v1)
+
+> **Single source of truth** for the KITT LED scanner wire contract. BOTH halves
+> cite this doc:
+> - the **MCU firmware** (XIAO/QT Py driving the WS2812B strip) implements the
+>   *receiver* side, and
+> - the **Jetson-side hooks** (Phase-3: the TTS amplitude streamer + the
+>   `/kirra/enforcement_action`→mode bridge) implement the *sender* side.
+>
+> The two halves are built in different sessions, weeks apart. Freeze this
+> contract BEFORE either is written (same discipline as freezing the KIRRA
+> trajectory contract) so they cannot diverge. Any change bumps `PROTO_VERSION`
+> and updates this doc in the same commit.
+
+## 0. Design goals
+
+- **Unambiguous:** amplitude payload bytes can never be mistaken for a mode
+  command (the classic "T then raw bytes vs framed" failure). Every message is a
+  framed packet with a start-of-frame anchor and a CRC.
+- **Low-latency:** small fixed framing; amplitude streams at 50 Hz, trivial at
+  115200 baud (~600 B/s peak).
+- **Fail-safe (KIRRA ethos):** if the MCU hears nothing for `LINK_TIMEOUT_MS` it
+  reverts to IDLE — a dead Jetson link → the calm idle sweep, never a frozen bar.
+- **Trivially implementable** on an Arduino/CircuitPython MCU (~40 lines) and in
+  Python on the Jetson.
+
+## 1. Physical layer
+
+| Parameter | Value |
+|---|---|
+| Transport | USB CDC serial (the MCU's native USB) |
+| Baud | **115200**, 8N1, no flow control |
+| Direction | Jetson → MCU (commands) primary; MCU → Jetson (HELLO only) optional |
+| Byte order | little-endian for multi-byte fields |
+
+The MCU port appears on the Jetson as `/dev/ttyACM*` (or a udev symlink, e.g.
+`/dev/kitt_scanner` — recommended, add a rule so it's stable).
+
+## 2. Frame format
+
+Every message — command or amplitude — is ONE frame:
+
+```
++------+------+------+---------------+-------+
+| SOF  | CMD  | LEN  | PAYLOAD[LEN]  | CRC8  |
+| 0xAA | 1 B  | 1 B  | LEN bytes     | 1 B   |
++------+------+------+---------------+-------+
+```
+
+- `SOF = 0xAA` — start-of-frame / resync anchor. If the receiver is mid-garbage
+  it scans for `0xAA` and restarts.
+- `CMD` — an ASCII command letter (table below).
+- `LEN` — payload length, 0–255.
+- `PAYLOAD` — `LEN` bytes (may be 0).
+- `CRC8` — over `CMD | LEN | PAYLOAD` (NOT the SOF). Polynomial **0x07** (CRC-8/SMBUS),
+  init 0x00, no reflection, no final xor. A frame with a bad CRC is DROPPED
+  silently (the sender will send another within 20 ms in TALK mode).
+
+Max frame = 1 + 1 + 1 + 255 + 1 = 259 bytes. In practice payloads are 0–2 bytes.
+
+## 3. Commands
+
+| CMD | Name | Payload | Meaning |
+|---|---|---|---|
+| `'I'` (0x49) | IDLE | none (LEN 0) | Slow Larson sweep. **Default power-on state.** Persistent. |
+| `'S'` (0x53) | DRIVE | none (LEN 0) | Fast Larson sweep — robot is actively driving. Persistent. |
+| `'T'` (0x54) | TALK | none (LEN 0) | Enter amplitude-reactive mode. Persistent until another mode. |
+| `'V'` (0x56) | AMPL | 1 byte, `0–255` | One amplitude sample. **Rendered only while the persistent mode is TALK**; ignored otherwise. |
+| `'A'` (0x41) | ALERT | 2 bytes, `uint16 LE` `duration_ms` | Momentary red full-bar flash OVERLAY for `duration_ms`, then auto-revert to the current persistent mode. Non-persistent (see §5). |
+| `'H'` (0x48) | HELLO | 1 byte, `PROTO_VERSION` | Handshake / version check (§6). Bi-directional. |
+| `'C'` (0x43) | CONFIG | see §7 | Optional runtime config (brightness, speeds). |
+
+"Persistent mode" = the last of `IDLE`/`DRIVE`/`TALK` received. `AMPL` and `ALERT`
+do not change the persistent mode.
+
+## 4. Amplitude semantics (the TALK sync)
+
+- The Jetson computes a **rolling RMS envelope** of the audio it is *generating*
+  (not a mic) over a ~20 ms window, normalizes to the speech's dynamic range, and
+  maps to a byte `0–255`.
+- **Stream rate: 50 Hz** (one `'V'` frame every 20 ms) while KITT speaks. This is
+  smooth to the eye and ~300 B/s.
+- MCU mapping (firmware-owned, tune to taste): amplitude → the lit bar's
+  **width AND brightness** — louder syllables = wider/brighter, gaps = a dim
+  narrow core. A reasonable default: `width = 1 + round(ampl/255 * (N-1))`,
+  `brightness = 40 + round(ampl/255 * 215)`.
+- **End of speech:** the Jetson sends `'I'` (or `'S'` if driving) to leave TALK.
+  It does NOT need to send a final `'V' 0` — the mode change ends the pulse.
+- If TALK is set but no `'V'` arrives for `TALK_SILENCE_MS` (default 300 ms), the
+  MCU shows a dim static core (speech paused) — it does NOT revert mode (the
+  Jetson owns mode).
+
+## 5. ALERT semantics (the KIRRA-state hook)
+
+The high-value tie-in: the scanner reflects the *actual* safety-governor verdict.
+
+- The Jetson-side bridge subscribes to `/kirra/enforcement_action` (already
+  published every command cycle: `PASS:v=…` / `BLOCKED:<reason>` / `SafeStop`).
+- On a **rising edge into `BLOCKED`/`SafeStop`** (a refusal the checker just made),
+  the bridge sends `'A'` with `duration_ms` (e.g. 400).
+- The MCU **overlays** a red full-bar flash for that duration, then returns to
+  whatever persistent mode was active (IDLE/DRIVE/TALK) — so a momentary refusal
+  produces a visible flash without the Jetson tracking a clear.
+- Repeated refusals re-trigger `'A'` (the flash restarts). The bridge should
+  debounce so a sustained refusal doesn't strobe (e.g. min 250 ms between `'A'`).
+
+This makes the cosmetic and the thesis the same event: **KITT refuses an unsafe
+command → the scanner flashes red at that instant.**
+
+## 6. Version handshake
+
+- `PROTO_VERSION = 1` (this doc).
+- On boot the MCU MAY send `H | 0x01 | PROTO_VERSION | CRC` to the Jetson.
+- The Jetson SHOULD send `'H'` with its version once on connect; if the MCU's
+  reply (or its unsolicited HELLO) is a different major version, the Jetson logs a
+  mismatch and refuses to stream (fail-loud, don't drive a bar with the wrong
+  contract). Absent a HELLO, assume v1 (back-compat for a bare firmware).
+
+## 7. CONFIG (optional, forward-compatible)
+
+`'C'` payload is a list of `[key, value]` byte pairs (LEN even). Unknown keys are
+ignored (forward-compat). Reserved keys:
+
+| key | value | meaning |
+|---|---|---|
+| 0x01 | 0–255 | master brightness |
+| 0x02 | 0–255 | idle sweep period (×10 ms) |
+| 0x03 | 0–255 | drive sweep period (×10 ms) |
+| 0x04 | 0–255 | base hue (0=red; KITT is red — default 0) |
+
+CONFIG is a nice-to-have; v1 firmware may ignore it entirely.
+
+## 8. Reference: CRC8 (both sides use this exact function)
+
+```python
+def crc8(data: bytes) -> int:          # CRC-8/SMBUS, poly 0x07
+    c = 0
+    for b in data:
+        c ^= b
+        for _ in range(8):
+            c = ((c << 1) ^ 0x07) & 0xFF if (c & 0x80) else (c << 1) & 0xFF
+    return c
+```
+
+## 9. Reference: Jetson sender (Python, Phase-3)
+
+```python
+import struct, serial
+SOF = 0xAA
+def _frame(cmd: str, payload: bytes = b"") -> bytes:
+    body = bytes([ord(cmd), len(payload)]) + payload
+    return bytes([SOF]) + body + bytes([crc8(body)])
+
+class Scanner:
+    def __init__(self, port="/dev/kitt_scanner", baud=115200):
+        self.s = serial.Serial(port, baud, timeout=0)
+        self.s.write(_frame("H", bytes([1])))          # announce v1
+    def idle(self):   self.s.write(_frame("I"))
+    def drive(self):  self.s.write(_frame("S"))
+    def talk(self):   self.s.write(_frame("T"))
+    def ampl(self, a: int):  self.s.write(_frame("V", bytes([a & 0xFF])))   # 50 Hz in TALK
+    def alert(self, ms=400): self.s.write(_frame("A", struct.pack("<H", ms)))
+```
+
+## 10. Reference: MCU receiver (pseudocode)
+
+```
+state = { mode: IDLE, ampl: 0, alert_until: 0, last_rx_ms: now }
+loop forever:
+    # --- parse (non-blocking) ---
+    while serial.available():
+        b = serial.read()
+        feed(b) into a small state machine: [SOF][CMD][LEN][PAYLOAD..][CRC]
+        on a COMPLETE, CRC-valid frame:
+            last_rx_ms = now
+            switch CMD:
+              'I','S','T': mode = that
+              'V': if mode == TALK: ampl = payload[0]
+              'A': alert_until = now + u16le(payload)
+              'H': (optionally reply H|version); check version
+              'C': apply config pairs
+    # --- render (fixed tick, e.g. every 10–20 ms) ---
+    if now - last_rx_ms > LINK_TIMEOUT_MS: mode = IDLE      # fail-safe
+    if now < alert_until: render_alert_red_flash()          # overlay wins
+    elif mode == IDLE:  render_larson(period_idle)
+    elif mode == DRIVE: render_larson(period_drive)
+    elif mode == TALK:  render_pulse(ampl)                  # width+brightness ~ ampl
+    show()
+```
+
+## 11. Constants (pin these)
+
+| Name | Value | Owner |
+|---|---|---|
+| `PROTO_VERSION` | 1 | this doc |
+| Baud | 115200 | this doc |
+| `SOF` | 0xAA | this doc |
+| CRC | CRC-8/SMBUS (poly 0x07) | this doc |
+| Amplitude range | 0–255 (RMS-mapped) | this doc |
+| Amplitude rate | 50 Hz | this doc |
+| `LINK_TIMEOUT_MS` | 1000 | this doc |
+| `TALK_SILENCE_MS` | 300 | this doc |
+| ALERT default duration | 400 ms | Jetson bridge |
+| LED count / data pin / strip type | firmware-owned | MCU firmware |
+| RMS window, normalization curve | Jetson-owned | Jetson streamer |
+
+## 12. Build/test order (contract-first)
+
+1. **MCU firmware now** (other session) — implement §2/§3/§10 + the Larson sweep,
+   testable with a serial terminal (`printf '\xAAI\x00…'`) and fake `'V'`
+   amplitude (a sine) before the strip or Jetson exist.
+2. **Phase 3 — Jetson hooks** (this repo, later) — the §9 sender wired to (a) the
+   TTS RMS envelope → `ampl()` at 50 Hz, and (b) `/kirra/enforcement_action` →
+   `alert()`/mode. Built against THIS doc, so they meet the firmware exactly.
+
+## Status
+- ⬜ MCU firmware (other session) — write against this contract.
+- ⬜ Jetson TTS amplitude streamer — Phase 3 (needs the voice stack).
+- ⬜ Jetson `/kirra/enforcement_action`→mode bridge — Phase 3.
+- ✅ Protocol frozen at v1 (this doc).

--- a/robot/install/env.template
+++ b/robot/install/env.template
@@ -148,7 +148,8 @@ KIRRA_R2_DRIVE_DEADBAND_PWM=0
 #   V_PER_PWM_RIGHT 0.0194 = RR feedforward slope (m/s)/PWM (RL slope = KIRRA_R2_V_PER_PWM)
 KIRRA_R2_M_PER_TICK=0.00025101
 KIRRA_R2_V_PER_PWM_RIGHT=0.0194
-# Controller gains — CONSERVATIVE DEFAULTS, not yet hardware-tuned (optional):
+# Controller gains — CONSERVATIVE DEFAULTS, not yet hardware-tuned (optional).
+# Tuning procedure + debug-log interpretation: docs/hardware/R2_CLOSED_LOOP_TUNING.md
 #KIRRA_R2_SPEED_KP=20               # PWM per (m/s error)
 #KIRRA_R2_SPEED_MAX_PWM_STEP=5      # per-cycle slew cap on each wheel's PWM
 #KIRRA_R2_SPEED_STALL_CYCLES=5      # under-response cycles before an MRC fault

--- a/robot/install/preflight_autostart.sh
+++ b/robot/install/preflight_autostart.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# preflight_autostart.sh — is the R2 READY to enable autostart? (read-only gate)
+#
+# The green light BEFORE the one-service-at-a-time enable dance in
+# docs/hardware/R2_AUTOSTART_CHECKLIST.md. Checks every prerequisite for a clean
+# governed boot and names the fix for each gap. Changes NOTHING — it only reads
+# state (safe to run anytime). Companion to:
+#   - disable_vendor_autostart.sh (fix a vendor-autostart FAIL here)
+#   - lint_robot_env.sh          (fix a robot.env FAIL here)
+#   - cold_boot_drill.sh         (the POST-boot acceptance, after enabling)
+#
+#   robot/install/preflight_autostart.sh
+#
+# Exit 0 iff every checked prerequisite passes (ready to enable).
+set -uo pipefail
+
+PASS=0; FAIL=0; WARN=0
+ok()   { echo "  ✔ $*"; PASS=$((PASS + 1)); }
+bad()  { echo "  ❌ $*"; FAIL=$((FAIL + 1)); }
+warn() { echo "  ⚠ $*"; WARN=$((WARN + 1)); }
+fix()  { echo "       ↳ fix: $*"; }
+
+ROBOT_USER="${SUDO_USER:-${USER:-$(id -un)}}"
+KENV=/etc/kirra/kirra.env
+RENV=/etc/kirra/robot.env
+
+# sudo-read helper (kirra.env is 600 root/kirra). Returns "" if unreadable.
+sread() { sudo cat "$1" 2>/dev/null || true; }
+
+echo "== R2 autostart preflight — user: ${ROBOT_USER} =="
+
+# ---- 1. unit files installed ----------------------------------------------
+echo "-- unit files (/etc/systemd/system) --"
+for u in kirra.target kirra-verifier.service kirra-planner.service kirra-taj.service \
+         kirra-mick.service kirra-consumer.service kirra-ros-stack.service; do
+  if systemctl cat "$u" >/dev/null 2>&1; then ok "$u installed"; else
+    bad "$u NOT installed"
+    case "$u" in
+      kirra-*consumer*) fix "sudo robot/install/install_kirra.sh" ;;
+      kirra-ros-stack*) fix "sudo robot/install/install_robot_units.sh" ;;
+      *)                fix "sudo deploy/systemd/install.sh" ;;
+    esac
+  fi
+done
+# kitt-watch is optional (interactive narration) — warn, don't fail.
+systemctl cat kirra-kitt-watch.service >/dev/null 2>&1 \
+  && ok "kirra-kitt-watch installed (optional)" \
+  || warn "kirra-kitt-watch not installed (optional — narration only)"
+
+# ---- 2. binaries + consumer scripts staged --------------------------------
+echo "-- /opt/kirra artifacts --"
+for f in /opt/kirra/kirra_verifier_service /opt/kirra/planner_service \
+         /opt/kirra/taj_service /opt/kirra/mick_service; do
+  [[ -x "$f" ]] && ok "$(basename "$f")" || { bad "missing $f"; fix "sudo deploy/systemd/install.sh"; }
+done
+for f in /opt/kirra/robot/kirra_motor_consumer.py /opt/kirra/robot/r2_drive.py \
+         /opt/kirra/robot/kirra_ffi.py /opt/kirra/lib/libkirra_consumer_ffi.so; do
+  [[ -e "$f" ]] && ok "$(basename "$f")" || { bad "missing $f"; fix "sudo robot/install/install_kirra.sh"; }
+done
+
+# ---- 3. governor-stack secrets (kirra.env) --------------------------------
+echo "-- /etc/kirra/kirra.env (governor stack) --"
+kenv="$(sread "$KENV")"
+if [[ -z "$kenv" ]]; then
+  bad "$KENV unreadable/missing"; fix "sudo deploy/systemd/install.sh (generates secrets)"
+else
+  grep -qE '^KIRRA_ADMIN_TOKEN=.+' <<<"$kenv" && ok "KIRRA_ADMIN_TOKEN set" || { bad "KIRRA_ADMIN_TOKEN empty (verifier 503s)"; fix "re-run deploy/systemd/install.sh"; }
+  grep -qE '^KIRRA_SUPERVISOR_RESET_KEY=.+' <<<"$kenv" && ok "KIRRA_SUPERVISOR_RESET_KEY set" || bad "KIRRA_SUPERVISOR_RESET_KEY empty"
+  if grep -qE '^KIRRA_VEHICLE_CLASS=(courier|delivery-av|robotaxi|r2)$' <<<"$kenv"; then
+    ok "KIRRA_VEHICLE_CLASS = $(grep -oE '^KIRRA_VEHICLE_CLASS=.*' <<<"$kenv" | cut -d= -f2)"
+  else
+    bad "KIRRA_VEHICLE_CLASS unset/invalid (verifier + parko fail-closed abort)"
+    fix "set KIRRA_VEHICLE_CLASS=courier (interim) or r2 in $KENV"
+  fi
+  if grep -qE '^KIRRA_GOVERNOR_SIGNING_KEY_SOURCE=.+' <<<"$kenv"; then
+    ok "KIRRA_GOVERNOR_SIGNING_KEY_SOURCE set"
+  else
+    warn "KIRRA_GOVERNOR_SIGNING_KEY_SOURCE unset — verifier won't mint release tokens"
+    fix "file:/etc/kirra/gov_2a.seed (bench) — robot/install/make_gov_seed.sh"
+  fi
+fi
+
+# ---- 4. consumer env (robot.env) ------------------------------------------
+echo "-- /etc/kirra/robot.env (consumer) --"
+renv="$(sread "$RENV")"
+if [[ -z "$renv" ]]; then
+  bad "$RENV unreadable/missing"; fix "sudo robot/install/install_kirra.sh --dev-key"
+else
+  if grep -qE '^KIRRA_GOVERNOR_VK_HEX=[0-9a-fA-F]{64}$' <<<"$renv"; then ok "governor VK pinned (64 hex)"; else
+    bad "KIRRA_GOVERNOR_VK_HEX not pinned (placeholder) — consumer refuses to start"
+    fix "install_kirra.sh --dev-key (bench) or enroll a real key"
+  fi
+  grep -qE '^KIRRA_MOTOR_PORT=' <<<"$renv" && ok "KIRRA_MOTOR_PORT set" || bad "KIRRA_MOTOR_PORT unset"
+  dm="$(grep -oE '^KIRRA_DRIVE_MODE=.*' <<<"$renv" | cut -d= -f2)"
+  [[ "$dm" == "r2_ackermann" ]] && ok "KIRRA_DRIVE_MODE=r2_ackermann" || warn "KIRRA_DRIVE_MODE='${dm:-unset}' (R2 wants r2_ackermann)"
+  # env hygiene (the systemd EnvironmentFile traps) — delegate to the linter.
+  if robot/install/lint_robot_env.sh "$RENV" >/dev/null 2>&1; then
+    ok "robot.env clean (no inline-comment/dup traps)"
+  else
+    bad "robot.env has inline-comment or duplicate-key traps"
+    fix "sudo robot/install/lint_robot_env.sh --fix"
+  fi
+fi
+
+# ---- 5. user groups (serial + audio) --------------------------------------
+echo "-- user groups --"
+groups_u="$(id -nG "$ROBOT_USER" 2>/dev/null || true)"
+grep -qw dialout <<<"$groups_u" && ok "$ROBOT_USER in dialout (serial)" || { bad "$ROBOT_USER NOT in dialout — consumer can't open /dev/myserial"; fix "sudo usermod -aG dialout $ROBOT_USER (re-login)"; }
+grep -qw audio <<<"$groups_u" && ok "$ROBOT_USER in audio (kitt narration)" || warn "$ROBOT_USER not in audio (only needed for kitt-watch)"
+
+# ---- 6. device symlinks ---------------------------------------------------
+echo "-- devices --"
+for d in /dev/myserial /dev/ydlidar; do
+  [[ -e "$d" ]] && ok "$d -> $(readlink -f "$d")" || { bad "$d ABSENT"; fix "restore vendor udev rules (capture_from_robot.sh / REFLASH.md)"; }
+done
+
+# ---- 7. vendor autostart cleared ------------------------------------------
+echo "-- vendor autostart --"
+VPAT='rosmaster_main|Rosmaster_Lib|yahboom'
+vhit=0
+while IFS= read -r u; do
+  frag="$(systemctl cat "$u" 2>/dev/null || true)"
+  grep -qiE "$VPAT" <<<"$frag" && { [[ "$(systemctl is-enabled "$u" 2>/dev/null)" == "enabled" ]] && { bad "vendor unit enabled: $u"; vhit=1; }; }
+done < <(systemctl list-unit-files --type=service --no-legend 2>/dev/null | awk '{print $1}' | grep -viE '^kirra')
+[[ $vhit -eq 0 ]] && ok "no enabled vendor base unit" || fix "robot/install/disable_vendor_autostart.sh --disable"
+
+# ---- 8. mick's LLM (ollama) + ROS ws --------------------------------------
+echo "-- dependencies --"
+if command -v ollama >/dev/null 2>&1 || systemctl is-active ollama >/dev/null 2>&1; then
+  ok "ollama present (mick /intent)"
+else
+  warn "ollama not found — mick /intent 422s fail-closed (typed goals still work)"
+fi
+WS="$(grep -oE '^KIRRA_ROS_WS_SETUP=.*' <<<"$renv" 2>/dev/null | cut -d= -f2)"
+WS="${WS:-/home/${ROBOT_USER}/kirra-runtime-sdk/ros2_ws/install/setup.bash}"
+[[ -f "$WS" ]] && ok "ROS ws overlay present ($WS)" || { bad "ROS ws overlay missing: $WS"; fix "colcon build in ros2_ws, or set KIRRA_ROS_WS_SETUP"; }
+
+# ---- verdict --------------------------------------------------------------
+echo
+echo "preflight: ${PASS} ok, ${WARN} warn, ${FAIL} fail"
+if [[ $FAIL -eq 0 ]]; then
+  echo "✔ READY to enable autostart. Proceed with the one-service-at-a-time enable"
+  echo "  in docs/hardware/R2_AUTOSTART_CHECKLIST.md (validate wheels-up, then enable)."
+  exit 0
+else
+  echo "❌ ${FAIL} blocker(s) above — fix them before enabling autostart."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Off-bench bench-support artifacts — docs and read-only scripts only, no runtime/verifier/checker code touched. Prepares the next few R2 bring-up steps so the bench sessions are turnkey.

## Changes

**Closed-loop speed-matching tuning guide** (`docs/hardware/R2_CLOSED_LOOP_TUNING.md`, task #84 prep)
The `ClosedLoopSpeedMatcher` + consumer wiring are done and host-tested; the gains are conservative untuned defaults. This is the turnkey procedure to tune them: why (the ~34% rear-wheel imbalance drives an arc), the control law + safety framing (translate/checker still bound the command; closed-loop only redistributes the two drive PWMs toward the already-governed target), a full debug-log interpretation guide (`cl tgt / ema_L / ema_R / pwm_L / pwm_R` — converged vs under-corrected vs oscillating), a gain reference table with tune directions, an elevated→floor procedure, and troubleshooting. `env.template` points at it. Review of the matcher: clean, nothing to harden (41 host tests cover it).

**KITT LED-scanner serial protocol, frozen v1** (`docs/kitt/scanner_protocol.md`)
Single-source-of-truth wire contract for the KITT scanner, frozen BEFORE either half is written so the MCU firmware (built in a separate session) and the Phase-3 Jetson hooks can't diverge. Framed packets `[SOF 0xAA | CMD | LEN | PAYLOAD | CRC8]` (CRC-8/SMBUS) so amplitude bytes can never be mistaken for a mode command; modes I/S/T + V (amplitude @ 50 Hz) + A (alert) + H (version); fail-safe link-timeout → idle. The ALERT hook is wired to the real governor signal (`/kirra/enforcement_action` BLOCKED/SafeStop edges) so the bar flashes red the instant the checker refuses. CRC verified against the 0xF4 known-answer; framing round-trips.

**Autostart readiness-gate preflight** (`robot/install/preflight_autostart.sh`, Phase 2)
Read-only green light before the one-service-at-a-time enable dance: verifies units installed, `/opt/kirra` artifacts, kirra.env secrets + `KIRRA_VEHICLE_CLASS` + signing-key source, robot.env VK pinned + drive mode + no EnvironmentFile traps, dialout/audio groups, device symlinks, no enabled vendor unit, ollama, ROS ws overlay — naming the fix for each gap. Exit 0 = ready. Wired into `R2_AUTOSTART_CHECKLIST.md` with the full bench order (lint → disable-vendor → preflight → enable → cold-boot drill).

## Test
- All three shell scripts touched are `bash -n` clean and dry-run cleanly here.
- CRC8 + framing verified against the standard known-answer.
- No Rust / no runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_