### PR TITLE
robot(r2): governed OTA check — startup timer + voice "check for update" (stage-and-ask)

### DIFF
--- a/docs/hardware/R2_OTA_VOICE_CHECK.md
+++ b/docs/hardware/R2_OTA_VOICE_CHECK.md
@@ -1,0 +1,69 @@
+# R2 — "check for update" (startup timer + voice), stage-and-ask
+
+Two ways to check for a governed software update, both built on the existing OTA
+machinery (`kirra-ota-ctl` + the verifier campaign plane). **Policy: stage and
+ask** — a check only ever STAGES a verified update; applying is always a
+deliberate, health-gated step. Nothing auto-installs, ever.
+
+## What a "check" actually does
+
+`kirra-ota-ctl pull` → GET the node's assignment from the verifier
+(`/fleet/campaigns/assignment/{node_id}`) → if a new governor artifact is
+assigned, **download + verify** (SHA-256 + Uptane signed metadata: root-keyed
+role signatures, freshness, rollback floors) → **stage** it into the inactive A/B
+slot. A staged slot is inert until applied.
+
+**Security:** a check only TRIGGERS this. The artifact is cryptographically
+verified and health-gated by `kirra-ota-ctl` regardless of who asked — a voice
+command (or a timer) is a convenience, never an authorization bypass. An
+unsigned/rolled-back/unauthorized artifact is refused at the verify step.
+
+## 1. On startup + periodically (unattended)
+
+```bash
+sudo cp robot/install/systemd/kirra-ota-check.{service,timer} /etc/systemd/system/
+sudo sed -i "s/__KIRRA_ROBOT_USER__/$USER/" /etc/systemd/system/kirra-ota-check.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now kirra-ota-check.timer   # ~2 min after boot, then every 6 h
+```
+`Persistent=true` catches a missed window. Stage-only → it can never change the
+running governor unattended.
+
+## 2. By voice ("check for update")
+
+Runs through the KITT conversational router (`robot/kitt_converse.py`), matched
+**deterministically** by keyword in `robot/kitt_ota.py` — NOT the LLM, and NOT
+the fenced Mick `/intent` movement door (an OTA check is a system command, not a
+movement; the two can never be confused).
+
+| you say | it does | it says |
+|---|---|---|
+| "check for update" / "any updates?" | `pull` (stage-only) | "…staged, ready — say 'apply update' to install" / "you're up to date" |
+| "update status" | `status` | whether an update is staged |
+| "apply update" / "install update" | `probe` (HEALTH-GATED commit-or-rollback) | "applied and health-checked" / "didn't pass — rolled back" |
+
+"apply update" is the **ask**: a distinct, deliberate command. It runs the
+health-gated probe — an unhealthy new artifact **auto-rolls-back** to the safe
+version; it is never a blind commit.
+
+Standalone (for the timer log, or testing):
+```bash
+python3 robot/kitt_ota.py check     # or status | apply
+```
+
+## Caveats
+- **Needs an upstream campaign.** A check only finds something if a release is
+  published on the verifier/fleet this node points at. Standalone bench robot,
+  no campaign → "you're up to date" (the plumbing is ready for when you push one).
+- **Governs the safety-critical governor artifact** — the OTA-managed binary,
+  with the full verify/rollback discipline. App-level bits (KITT scripts,
+  planner) are a separate `git pull` + rebuild if you want those too.
+- **Config:** `kirra-ota-ctl` reads node id / verifier URL / slot paths from its
+  env — set them in `/etc/kirra/robot.env`. `KIRRA_OTA_CTL` overrides the binary
+  path (default `/opt/kirra/bin/kirra-ota-ctl`).
+
+## Follow-up (bench-validated)
+The voice "apply" runs `probe` (health-gates a trial). Wiring the full A/B trial
+lifecycle — restart the governor into the staged slot, then probe — is the
+reboot-spanning flow in `docs/ota/ORIN_APP_LEVEL_AB_DRILL.md`; validate that at
+the bench before relying on voice-apply for a live governor swap.

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -34,7 +34,7 @@ echo "== robot-side unit install — user: ${ROBOT_USER} =="
 echo "== 1. KITT scripts -> ${OPT}/robot =="
 sudo install -d -m 0755 "${OPT}/robot"
 for f in kitt_watch.py kitt_ask.py kitt_converse.py kitt_voice.sh ptt_button.py \
-         run_voice_ptt.sh inspect_corridor.py; do
+         run_voice_ptt.sh inspect_corridor.py kitt_ota.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"
@@ -42,7 +42,8 @@ done
 
 # ---- 2. render + install the units -----------------------------------------
 echo "== 2. units -> /etc/systemd/system =="
-for u in kirra-ros-stack.service kirra-kitt-watch.service; do
+for u in kirra-ros-stack.service kirra-kitt-watch.service \
+         kirra-ota-check.service kirra-ota-check.timer; do
   [[ -f "${UNITS}/${u}" ]] || { echo "❌ missing ${UNITS}/${u}"; exit 1; }
   sed "s/__KIRRA_ROBOT_USER__/${ROBOT_USER}/g" "${UNITS}/${u}" \
     | sudo tee "/etc/systemd/system/${u}" >/dev/null

--- a/robot/install/systemd/kirra-ota-check.service
+++ b/robot/install/systemd/kirra-ota-check.service
@@ -1,0 +1,29 @@
+# kirra-ota-check.service — STAGE-ONLY governed OTA check (boot + periodic).
+#
+# Runs `kirra-ota-ctl pull`: polls the verifier's assignment endpoint and, if a
+# new governor artifact is assigned, downloads + VERIFIES (SHA-256 + Uptane
+# signed metadata) + STAGES it into the inactive A/B slot. It NEVER commits —
+# "stage and ask": applying is a deliberate step (voice "apply update", or a
+# health-gated `kirra-ota-ctl probe`). A staged-but-uncommitted update is inert
+# until then, so this timer can never change the running governor unattended.
+#
+# Config (node id / verifier URL / slot paths) is read by kirra-ota-ctl from its
+# environment — set those in /etc/kirra/robot.env. `pull` hits the OPEN
+# assignment GET (no admin token); it is posture-gated at the verifier.
+#
+# Triggered by kirra-ota-check.timer. Staged, NOT enabled by install — enable
+# deliberately: sudo systemctl enable --now kirra-ota-check.timer
+[Unit]
+Description=KIRRA governed OTA check (stage-only; never auto-commits)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+After=network-online.target kirra-verifier.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=__KIRRA_ROBOT_USER__
+EnvironmentFile=/etc/kirra/robot.env
+ExecStart=/opt/kirra/bin/kirra-ota-ctl pull
+# Never fail the unit on "up to date"/transient — the timer just retries later.
+SuccessExitStatus=0 1
+Nice=10

--- a/robot/install/systemd/kirra-ota-check.timer
+++ b/robot/install/systemd/kirra-ota-check.timer
@@ -1,0 +1,19 @@
+# kirra-ota-check.timer — when to run the STAGE-ONLY OTA check.
+#
+#   sudo systemctl enable --now kirra-ota-check.timer
+#
+# Fires ~2 min after boot (so the robot is up and the verifier reachable) and
+# every 6 h thereafter. `Persistent=true` catches a missed window (robot was off).
+# The service only STAGES — applying stays a deliberate, health-gated step.
+[Unit]
+Description=Schedule the KIRRA stage-only OTA check
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=6h
+Persistent=true
+Unit=kirra-ota-check.service
+
+[Install]
+WantedBy=timers.target

--- a/robot/kitt_converse.py
+++ b/robot/kitt_converse.py
@@ -47,6 +47,7 @@ from kitt_ask import (  # noqa: E402
     KITT_SYSTEM, MICK, MODEL, OLLAMA, gather_perception, gather_posture,
     gather_stop_reason, speak,
 )
+import kitt_ota  # noqa: E402 — deterministic OTA voice commands (NOT the movement door)
 
 MAX_TURNS = 10  # rolling conversation memory (user+assistant pairs kept)
 PERCEPTION_WORDS = ("see", "around", "ahead", "front", "obstacle", "clear",
@@ -133,6 +134,17 @@ def offer_to_door(directive_text):
 
 
 def handle_turn(history, utterance):
+    # System commands (OTA "check/apply update") are matched DETERMINISTICALLY and
+    # handled BEFORE the LLM/movement path — they run local kirra-ota-ctl, never
+    # the fenced mick /intent door, and a movement utterance never reaches here.
+    ota_reply = kitt_ota.handle(utterance)
+    if ota_reply is not None:
+        speak(ota_reply)
+        history.append({"role": "user", "content": utterance})
+        history.append({"role": "assistant", "content": ota_reply})
+        del history[: max(0, len(history) - 2 * MAX_TURNS)]
+        return
+
     context = context_for(utterance)
     say, directive = ask_llm(history, context, utterance)
     if say is None:

--- a/robot/kitt_ota.py
+++ b/robot/kitt_ota.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""kitt_ota.py — the KITT "check for update" / "apply update" voice actions.
+
+WHY this is a SEPARATE path from the KITT movement router: an OTA check is a
+SYSTEM command, not a movement. KITT's conversational router only ever hands
+*movement* directives to the ONE fenced door (mick POST /intent). OTA must NOT
+ride that door — it runs the local `kirra-ota-ctl` instead, matched
+DETERMINISTICALLY (keyword, not LLM) so an ambiguous utterance can never be
+mistaken for "install software", and vice-versa.
+
+SECURITY: this only TRIGGERS the governed OTA flow. The artifact is still
+SHA-256 + Uptane verified and health-gated by `kirra-ota-ctl` regardless of who
+asked — voice is a convenience, never an authorization bypass. "Stage and ask":
+`check` only STAGES (never commits); `apply` runs the HEALTH-GATED probe
+(auto-rollback on an unhealthy trial) — never a blind commit.
+
+Importable (the router calls `handle(text)`), or runnable standalone:
+    python3 robot/kitt_ota.py check     # stage-only pull
+    python3 robot/kitt_ota.py status
+    python3 robot/kitt_ota.py apply      # health-gated commit/rollback of a trial
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+# The ota-ctl binary reads its OWN config from env (verifier URL, node id, slot
+# paths) — we do NOT duplicate that here, we just invoke it.
+OTA_CTL = os.environ.get("KIRRA_OTA_CTL") or shutil.which("kirra-ota-ctl") or "/opt/kirra/bin/kirra-ota-ctl"
+_TIMEOUT_S = float(os.environ.get("KIRRA_OTA_CTL_TIMEOUT_S", "120"))
+
+
+def _run(*args: str) -> tuple[int, str]:
+    """Invoke kirra-ota-ctl; return (rc, combined_output). rc=127 if absent."""
+    if not (os.path.isfile(OTA_CTL) or shutil.which(OTA_CTL)):
+        return 127, f"{OTA_CTL} not found"
+    try:
+        p = subprocess.run(
+            [OTA_CTL, *args], capture_output=True, text=True, timeout=_TIMEOUT_S
+        )
+        return p.returncode, (p.stdout + p.stderr).strip()
+    except subprocess.TimeoutExpired:
+        return 124, "timed out"
+    except Exception as e:  # noqa: BLE001 — never crash the voice loop
+        return 1, f"{type(e).__name__}: {e}"
+
+
+# --- classification (heuristic on rc + output; conservative) ----------------
+_STAGED_RX = re.compile(r"\b(stag|download|new digest|trying|armed|pending)\b", re.I)
+_CURRENT_RX = re.compile(r"\b(up[- ]to[- ]date|no assignment|unchanged|already|current|no update)\b", re.I)
+
+
+def check() -> tuple[str, str]:
+    """Stage-only `pull`. Returns (state, spoken). state in
+    {'staged','current','error'}. NEVER commits."""
+    rc, out = _run("pull")
+    if rc == 127:
+        return "error", "My update tool isn't installed, so I can't check right now."
+    if rc != 0:
+        return "error", "I couldn't reach the update service just now — I'll stay on my current version."
+    if _STAGED_RX.search(out) and not _CURRENT_RX.search(out):
+        return "staged", ("There's a new version. I've downloaded and verified it and it's "
+                          "staged, ready to go. Say 'apply update' when you want me to install it.")
+    if _CURRENT_RX.search(out):
+        return "current", "I checked — you're on the latest version, nothing to update."
+    # Unknown-but-success: fall back to the authoritative slot state.
+    st, _ = _run("status")
+    return ("staged" if _STAGED_RX.search(st) else "current"), (
+        "Update check complete. Say 'update status' if you'd like the details.")
+
+
+def status() -> tuple[str, str]:
+    rc, out = _run("status")
+    if rc == 127:
+        return "error", "My update tool isn't installed."
+    if rc != 0:
+        return "error", "I couldn't read my update status."
+    staged = bool(_STAGED_RX.search(out))
+    return ("staged" if staged else "current",
+            "An update is staged and waiting — say 'apply update' to install." if staged
+            else "No update is staged; you're current.")
+
+
+def apply() -> tuple[str, str]:
+    """HEALTH-GATED apply: `probe` runs the consecutive-success gate and auto
+    commit-or-rollback. Never a blind commit — a bad artifact rolls back."""
+    rc, out = _run("probe")
+    if rc == 127:
+        return "error", "My update tool isn't installed, so I can't apply anything."
+    if rc != 0:
+        # probe fails/rolls back an unhealthy trial, or there's no trial to apply.
+        if re.search(r"\b(no trial|not in a trial|nothing to|idle)\b", out, re.I):
+            return "none", "There's nothing staged to apply right now. Say 'check for update' first."
+        return "error", "The update didn't pass its health check, so I rolled back to the safe version."
+    return "ok", "Update applied and health-checked — I'm running the new version now."
+
+
+# --- deterministic command matcher (NOT the LLM / NOT the movement door) -----
+_CHECK_RX = re.compile(r"\b(check\s+for\s+(an?\s+)?updates?|any\s+updates?|are\s+you\s+up\s+to\s+date)\b", re.I)
+_APPLY_RX = re.compile(r"\b(apply|install|confirm)\s+(the\s+)?updates?\b", re.I)
+_STATUS_RX = re.compile(r"\bupdate\s+status\b", re.I)
+
+
+def match_command(text: str):
+    """Return 'apply' | 'status' | 'check' | None. Apply/status matched before
+    check so 'apply the update' isn't caught by a loose 'update' in check."""
+    if _APPLY_RX.search(text):
+        return "apply"
+    if _STATUS_RX.search(text):
+        return "status"
+    if _CHECK_RX.search(text):
+        return "check"
+    return None
+
+
+def handle(text: str) -> "str | None":
+    """If `text` is an OTA voice command, run it and return the spoken reply;
+    else None (the caller falls through to the normal conversation path)."""
+    cmd = match_command(text)
+    if cmd is None:
+        return None
+    if cmd == "check":
+        return check()[1]
+    if cmd == "status":
+        return status()[1]
+    if cmd == "apply":
+        return apply()[1]
+    return None
+
+
+if __name__ == "__main__":
+    action = sys.argv[1] if len(sys.argv) > 1 else "check"
+    fn = {"check": check, "status": status, "apply": apply}.get(action)
+    if fn is None:
+        sys.exit("usage: kitt_ota.py [check|status|apply]")
+    state, spoken = fn()
+    print(f"[{state}] {spoken}")
+    sys.exit(0 if state in ("staged", "current", "ok", "none") else 1)


### PR DESCRIPTION
## Summary

Two triggers for a **governed** software-update check, both built on the existing `kirra-ota-ctl` + verifier campaign machinery — no new update mechanism, just two ways to invoke the one that already verifies + health-gates. Robot-side only; no verifier/checker code touched.

**Policy: stage and ask.** A check only ever *stages* a verified update; applying is always a deliberate, health-gated step. Nothing auto-installs.

## What it adds

- **`robot/kitt_ota.py`** — `check()` = `kirra-ota-ctl pull` (stage-only), `status()`, `apply()` = `kirra-ota-ctl probe` (health-gated commit-or-rollback — never a blind commit). A **deterministic keyword matcher** (`check`/`apply`/`status`) so an OTA command is matched by keyword, NOT the LLM, and **never rides the fenced Mick `/intent` movement door** — an update is a system command, not a movement, and the two can never be confused. Fail-closed: a missing binary / transport error → a calm spoken message, never a crash.
- **`robot/kitt_converse.py`** — intercepts OTA commands at the top of `handle_turn`, before the LLM/movement path.
- **`kirra-ota-check.{service,timer}`** — unattended stage-only `pull` ~2 min after boot + every 6 h (`Persistent=true`). Staged, not enabled by install.
- **`install_robot_units.sh`** stages `kitt_ota.py` + the two units.
- **`docs/hardware/R2_OTA_VOICE_CHECK.md`** — enable steps, the voice-command table, and the security rationale.

## Security posture (unchanged)

The voice command / timer only *triggers* the check. The artifact is still SHA-256 + Uptane verified (root-keyed role sigs, freshness, rollback floors) and health-gated by `kirra-ota-ctl` regardless of who asked — voice is a convenience, never an authorization bypass. Same "the trigger is untrusted, the verification is the gate" ethos as the rest of KIRRA. `apply` runs the health-gated probe, so an unhealthy new artifact auto-rolls-back.

## Test

- `kitt_ota.py` + `kitt_converse.py` compile; the command matcher is unit-checked (OTA phrases match `check`/`apply`/`status`; "go forward one meter" / general chat fall through to `None`); the no-binary path returns a graceful spoken string.
- `install_robot_units.sh` `bash -n` clean.
- No Rust / no runtime code changed.

## Caveats (documented)
- Only *finds* an update if a campaign is published upstream (standalone bench → "you're up to date").
- Governs the safety-critical **governor artifact**; app code (KITT scripts, planner) is a separate `git pull` + rebuild.
- Voice-`apply` runs `probe`; wiring the full A/B trial-restart lifecycle is a bench-validated follow-up (`ORIN_APP_LEVEL_AB_DRILL.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_