### PR TITLE
robot(kitt): voice-lines catalog + wire Channel-A gaps (name slot, boot greeting)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1080,6 +1080,11 @@ jobs:
           # profile), geometry/sign/clamps, MRC on non-finite/spin-in-place.
           # See robot/r2_drive.py + docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md.
           python3 robot/r2_drive_test.py
+          # KITT voice logic (pure, no hardware): the {name} slot, the posture-
+          # GATED boot greeting (only claims "governor nominal" on a fresh code-0
+          # read; stale/degraded/lockout → "still checking myself over"), and the
+          # OTA voice-matcher precedence. See docs/kitt/KITT_VOICE_LINES.md.
+          python3 robot/kitt_voice_test.py
           # Detecting-installer contract (R2 golden build): detect/verify/install
           # are fail-closed (wrong car-type mode, unknown platform, missing
           # devices all refuse with remediation) and SELECT-NOT-INFER holds (the

--- a/docs/kitt/KITT_VOICE_LINES.md
+++ b/docs/kitt/KITT_VOICE_LINES.md
@@ -54,10 +54,11 @@ Legend: **LIVE** = wired today (file:seam cited) · **GAP** = to be wired · the
 
 | # | Trigger | Status | Line |
 |---|---|---|---|
-| A1 | Powered on, safety systems confirmed up | **GAP** (new boot hook; NOT `kitt_watch`, which stays silent on boot by design) | "Good morning{name}. All systems online, governor nominal — I'm at your disposal." |
-| A2 | Powered on, services still coming up | **GAP** | "I'm awake{name}, but still checking myself over. Give me a moment before we go anywhere." |
-| A3 | Shutting down | **GAP** | "Powering down. I've come to a safe stop — try not to miss me too much." |
-| A4 | Idle / standing by | optional | "Standing by{name}." (or silence) |
+| A1 | Powered on, **fresh nominal** posture confirmed | **LIVE** `kitt_boot.py` `greeting_line` (posture-gated: claims "governor nominal" only on a real fresh code-0 read) | "Good morning{name}. All systems online, governor nominal — I'm at your disposal." |
+| A1b | Powered on, fresh but **degraded** | **LIVE** `kitt_boot.py` | "Good morning{name}. I'm online, but starting in a degraded mode — I'll be cautious until it clears." |
+| A2 | Powered on, governor not ready by deadline (LockedOut / no read / stale) | **LIVE** `kitt_boot.py` | "I'm awake{name}, but still checking myself over. Give me a moment before we go anywhere." |
+| A3 | Shutting down | **LIVE** `kitt_boot.py` `shutdown_line` (systemd `ExecStop`) | "Powering down. I've come to a safe stop — try not to miss me too much." |
+| A4 | Idle / standing by | optional (not wired) | "Standing by{name}." (or silence) |
 
 ### B. Driving (you gave a command)
 
@@ -66,7 +67,7 @@ Legend: **LIVE** = wired today (file:seam cited) · **GAP** = to be wired · the
 | B1 | Directive accepted by the door | **LIVE** `kitt_converse.py` `handle_turn` (fallback line; the LLM usually phrases this) | "On our way{name} — the governor will keep us honest." |
 | B2 | Door couldn't pin a safe destination | **LIVE** `kitt_converse.py` | "I heard a movement request, but I couldn't pin down a safe destination — could you say it another way?" |
 | B3 | Drive control unreachable | **LIVE** `kitt_converse.py` | "I can't reach my driving control right now, so I'm staying put." |
-| B4 | Arrived / goal reached | **GAP** (no arrival event wired) | "We've arrived{name}. Holding position — and I didn't scratch a thing." |
+| B4 | Arrived / goal reached | **FOLLOW-UP** — needs a real *goal-reached* event from the planner/loop; KITT must never announce an arrival it can't confirm (persona rule 2) | "We've arrived{name}. Holding position — and I didn't scratch a thing." |
 
 ### C. Safety — refusals & obstacles
 
@@ -102,7 +103,7 @@ Legend: **LIVE** = wired today (file:seam cited) · **GAP** = to be wired · the
 | # | Trigger | Status | Line |
 |---|---|---|---|
 | F1 | Voice module / LLM offline | **LIVE** `kitt_converse.py` | "My voice module is offline for a moment." |
-| F2 | Didn't understand / empty transcript | **GAP** (STT-empty currently does nothing) | "I didn't quite catch that{name}." |
+| F2 | Didn't understand / empty transcript | **LIVE** `kitt_converse.py` (`--once` empty stdin → the PTT-released-with-nothing case) | "I didn't quite catch that{name}." |
 
 ---
 
@@ -137,13 +138,18 @@ recognizer node ─► publishes {operator: "Justin" | null, confidence}
 
 ## Wiring status summary
 
-- **~16 lines LIVE** across `kitt_converse.py`, `kitt_watch.py`, `kitt_ota.py`.
-- **Easy Channel-A gaps to wire:** A1–A3 (boot greeting/not-ready/shutdown), B4
-  (arrival), F2 (didn't-catch-that), plus threading the `{name}` slot through the
-  live lines.
-- **Engineering gap:** C3 proactive obstacle (needs a perception subscribe —
-  Stage 3b in the conversation design doc).
-- **Follow-up feature:** the recognition feed that fills `{name}` per person.
+- **LIVE:** the boot greeting/not-ready/shutdown (A1–A3, `kitt_boot.py`, posture-
+  gated), the conversation lines (B1–B3, F1–F2, `kitt_converse.py`), the proactive
+  posture + refusal lines (C1–C2, D1–D4, `kitt_watch.py`), and the OTA lines
+  (E1–E6, `kitt_ota.py`). The `{name}` slot is threaded through all of them via
+  `kitt_persona.py` and, for the LLM-phrased turns, via the operator line in the
+  grounding context.
+- **Follow-up (needs a real event source, so it can't be a template):**
+  - **C3** proactive obstacle — needs a perception subscribe (Stage 3b in the
+    conversation design doc).
+  - **B4** arrival — needs a goal-reached event from the planner/loop.
+- **Follow-up feature:** the recognition feed (face/voice) that fills `{name}`
+  per person — see below.
 
-Any change to a line bumps nothing but should update this doc in the same commit —
-this file is the script the robot reads from.
+Any change to a line should update this doc in the same commit — this file is the
+script the robot reads from.

--- a/docs/kitt/KITT_VOICE_LINES.md
+++ b/docs/kitt/KITT_VOICE_LINES.md
@@ -1,0 +1,149 @@
+# KITT Voice Lines (v1)
+
+> **Single source of truth** for everything the R2 says out loud. Every spoken
+> line the robot produces should trace to a row in this doc, and every row traces
+> to the code seam that fires it. Freeze the *words* here; wire the seams to match.
+>
+> This is **Channel A only** (`docs/hardware/KITT_CONVERSATION_DESIGN.md`). Nothing
+> in this document moves the robot. Speech has **zero actuation authority** — a
+> line can be witty, wrong, or hallucinated and the KIRRA checker still bounds
+> every motion identically. The words are theatre; the checker is the safety.
+
+## Persona
+
+KITT is **composed, articulate, dryly witty, and protective of the operator.**
+First person ("I", "we"). One or two spoken sentences — this is read aloud, not
+printed. Source prompt: `KITT_SYSTEM` in `robot/kitt_ask.py`.
+
+Two hard rules the wit never overrides:
+
+1. **Safety lines stay legible.** On a refusal, a posture drop, or an obstacle,
+   the *real reason* comes first and intact; wit is a garnish after it, never a
+   substitute for it. "I've had to refuse that — corridor departure. I'd rather be
+   dull than dented" is fine; "Nope!" is not.
+2. **Never invent telemetry.** The persona *phrases*; the numbers are ground
+   truth (posture, distances, deny codes come from live reads). An unavailable
+   source becomes an honest "I can't tell right now," never a guess.
+
+## The `{name}` slot — how KITT uses your name
+
+Every line may contain a `{name}` slot. It renders to:
+
+- `", Justin"` (leading comma + space) when the operator is known, or
+- `""` (nothing) when unknown — the line reads naturally either way.
+
+The name comes, in priority order, from:
+
+1. the **operator recognizer** (face/voice — see "Recognition feed" below), when
+   it has a confident identity, else
+2. `KIRRA_KITT_OPERATOR` (a configured default name), else
+3. nothing (`{name}` → empty).
+
+So the lines below are written **once**, with `{name}` where a greeting or a
+direct address is natural. Recognition, when it lands, fills the slot per person —
+no line is rewritten.
+
+---
+
+## The lines
+
+Legend: **LIVE** = wired today (file:seam cited) · **GAP** = to be wired · the
+`{name}` slot renders per the rule above.
+
+### A. Power & lifecycle
+
+| # | Trigger | Status | Line |
+|---|---|---|---|
+| A1 | Powered on, safety systems confirmed up | **GAP** (new boot hook; NOT `kitt_watch`, which stays silent on boot by design) | "Good morning{name}. All systems online, governor nominal — I'm at your disposal." |
+| A2 | Powered on, services still coming up | **GAP** | "I'm awake{name}, but still checking myself over. Give me a moment before we go anywhere." |
+| A3 | Shutting down | **GAP** | "Powering down. I've come to a safe stop — try not to miss me too much." |
+| A4 | Idle / standing by | optional | "Standing by{name}." (or silence) |
+
+### B. Driving (you gave a command)
+
+| # | Trigger | Status | Line |
+|---|---|---|---|
+| B1 | Directive accepted by the door | **LIVE** `kitt_converse.py` `handle_turn` (fallback line; the LLM usually phrases this) | "On our way{name} — the governor will keep us honest." |
+| B2 | Door couldn't pin a safe destination | **LIVE** `kitt_converse.py` | "I heard a movement request, but I couldn't pin down a safe destination — could you say it another way?" |
+| B3 | Drive control unreachable | **LIVE** `kitt_converse.py` | "I can't reach my driving control right now, so I'm staying put." |
+| B4 | Arrived / goal reached | **GAP** (no arrival event wired) | "We've arrived{name}. Holding position — and I didn't scratch a thing." |
+
+### C. Safety — refusals & obstacles
+
+| # | Trigger | Status | Line |
+|---|---|---|---|
+| C1 | Checker refused a command (real reason available) | **LIVE** `kitt_watch.py` `verdict_line` | "I've had to refuse that{name}. {reason}. I'd rather be dull than dented." |
+| C2 | Refused, reason code only | **LIVE** `kitt_watch.py` | "I've had to refuse a command ({code}). I'm holding until it's safe." |
+| C3 | Something in the way (proactive, before/without a command) | **GAP** (Stage 3b — needs a perception subscribe) | "There's something ahead{name} — I'm not driving us into it." |
+| C4 | Holding a safe stop | covered by posture rows | "I'm holding a safe stop until it's clear." |
+
+### D. Posture state changes (proactive, on transition only)
+
+| # | Trigger | Status | Line |
+|---|---|---|---|
+| D1 | → Degraded | **LIVE** `kitt_watch.py` `posture_line` | "Heads up{name} — I've dropped into a degraded mode. I'll slow and stop as needed to keep us safe." |
+| D2 | → LockedOut | **LIVE** `kitt_watch.py` | "I'm locking out and holding a safe stop. I'll need a manual reset before we continue." |
+| D3 | → Nominal (recovered) | **LIVE** `kitt_watch.py` | "All systems nominal{name}. We're clear to move again." |
+| D4 | Lost a fresh safety read (cache stale) | **LIVE** `kitt_watch.py` | "I've lost a fresh read on my safety state — I'm holding until it clears." |
+
+### E. Updates (voice + boot/periodic timer)
+
+| # | Trigger | Status | Line |
+|---|---|---|---|
+| E1 | "check for update" → new one staged | **LIVE** `kitt_ota.py` `check` | "There's a new version{name}. I've downloaded and verified it and it's staged, ready to go. Say 'apply update' when you want me to install it." |
+| E2 | Already current | **LIVE** `kitt_ota.py` | "I checked — you're on the latest version, nothing to update." |
+| E3 | "update status" | **LIVE** `kitt_ota.py` `status` | "An update is staged and waiting — say 'apply update' to install." / "No update is staged; you're current." |
+| E4 | "apply update" → applied | **LIVE** `kitt_ota.py` `apply` | "Update applied and health-checked — I'm running the new version now." |
+| E5 | Apply failed → rolled back | **LIVE** `kitt_ota.py` | "The update didn't pass its health check, so I rolled back to the safe version." |
+| E6 | Update tool missing / unreachable | **LIVE** `kitt_ota.py` | "My update tool isn't installed, so I can't check right now." / "I couldn't reach the update service — I'll stay on my current version." |
+
+### F. Conversation edge cases
+
+| # | Trigger | Status | Line |
+|---|---|---|---|
+| F1 | Voice module / LLM offline | **LIVE** `kitt_converse.py` | "My voice module is offline for a moment." |
+| F2 | Didn't understand / empty transcript | **GAP** (STT-empty currently does nothing) | "I didn't quite catch that{name}." |
+
+---
+
+## Recognition feed (follow-up — how `{name}` gets filled per person)
+
+Face and/or voice recognition run **on-device** on the Orin and publish the
+current operator identity as a **read-only Channel-A grounding source** — the same
+shape as posture and perception. The KITT scripts read it via a new
+`gather_operator()` and render `{name}` from it.
+
+**Invariant: recognition personalizes speech only. It is NOT an actuation
+authority.** Recognizing the operator never authorizes a command; the checker
+bounds every motion identically whether the operator is known, unknown, or
+mis-identified. (Promoting identity to a *drive-door* auth signal is a separate,
+deliberate decision and does not change the safety spine.)
+
+- **Face:** camera → detector (SCRFD/MediaPipe) → embedding (ArcFace/`insightface`)
+  → cosine-match against a small enrolled gallery. Real-time on the Orin GPU.
+- **Voice:** the PTT audio already captured for STT → speaker embedding
+  (SpeechBrain ECAPA-TDNN) → match enrolled voiceprints. No extra hardware.
+- **Privacy:** local embeddings only — no cloud, no retained raw images/audio.
+- **Enrollment:** one-time "this is Justin" capture per person → a local gallery
+  entry; unknown faces/voices → `{name}` empty (KITT stays polite, just nameless).
+
+Seam sketch (nothing here touches motion):
+
+```
+recognizer node ─► publishes {operator: "Justin" | null, confidence}
+                        │  (read-only, like /fleet/posture)
+  kitt_ask / kitt_converse / kitt_watch ─► gather_operator() ─► render {name}
+```
+
+## Wiring status summary
+
+- **~16 lines LIVE** across `kitt_converse.py`, `kitt_watch.py`, `kitt_ota.py`.
+- **Easy Channel-A gaps to wire:** A1–A3 (boot greeting/not-ready/shutdown), B4
+  (arrival), F2 (didn't-catch-that), plus threading the `{name}` slot through the
+  live lines.
+- **Engineering gap:** C3 proactive obstacle (needs a perception subscribe —
+  Stage 3b in the conversation design doc).
+- **Follow-up feature:** the recognition feed that fills `{name}` per person.
+
+Any change to a line bumps nothing but should update this doc in the same commit —
+this file is the script the robot reads from.

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -33,8 +33,8 @@ echo "== robot-side unit install — user: ${ROBOT_USER} =="
 # ship the whole KITT/voice set so the interactive tools are staged too.
 echo "== 1. KITT scripts -> ${OPT}/robot =="
 sudo install -d -m 0755 "${OPT}/robot"
-for f in kitt_watch.py kitt_ask.py kitt_converse.py kitt_voice.sh ptt_button.py \
-         run_voice_ptt.sh inspect_corridor.py kitt_ota.py; do
+for f in kitt_persona.py kitt_watch.py kitt_ask.py kitt_converse.py kitt_boot.py \
+         kitt_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py kitt_ota.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"
@@ -42,7 +42,7 @@ done
 
 # ---- 2. render + install the units -----------------------------------------
 echo "== 2. units -> /etc/systemd/system =="
-for u in kirra-ros-stack.service kirra-kitt-watch.service \
+for u in kirra-ros-stack.service kirra-kitt-watch.service kirra-kitt-greet.service \
          kirra-ota-check.service kirra-ota-check.timer; do
   [[ -f "${UNITS}/${u}" ]] || { echo "❌ missing ${UNITS}/${u}"; exit 1; }
   sed "s/__KIRRA_ROBOT_USER__/${ROBOT_USER}/g" "${UNITS}/${u}" \

--- a/robot/install/systemd/kirra-kitt-greet.service
+++ b/robot/install/systemd/kirra-kitt-greet.service
@@ -1,0 +1,36 @@
+# kirra-kitt-greet.service — KITT power-on greeting + shutdown line.
+#
+# Runs robot/kitt_boot.py: a one-shot that speaks a HONEST boot greeting once the
+# governor is actually up (it polls /metrics for a fresh, non-LockedOut posture
+# before claiming "governor nominal"), and speaks a power-down line on stop.
+# CHANNEL A ONLY (docs/kitt/KITT_VOICE_LINES.md rows A1–A3) — a read-only GET +
+# TTS, no /intent, no publisher, no serial. It cannot move the robot.
+#
+# ⚠ Same AUDIO-FROM-A-SYSTEM-SERVICE caveat as kirra-kitt-watch: use an ALSA-direct
+# KIRRA_TTS_CMD and put the rendered User in the `audio` group, or it degrades to
+# printing (harmless). Validate audio in-service before relying on the greeting.
+#
+# ⚠ NOT YET HARDWARE-VALIDATED as a service. Enable deliberately:
+# `sudo systemctl enable kirra-kitt-greet`. See R2_AUTOSTART_CHECKLIST.md.
+#
+# RemainAfterExit=yes so ExecStop fires the shutdown line on a clean stop/poweroff.
+[Unit]
+Description=KIRRA KITT power-on greeting + shutdown line (speak-only, posture-gated)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+After=network-online.target kirra-verifier.service kirra.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=__KIRRA_ROBOT_USER__
+EnvironmentFile=/etc/kirra/robot.env
+# Greeting is posture-gated + deadline-bounded inside the script (default 20s);
+# cap the unit start a little above that so a wedged verifier can't hang boot.
+ExecStart=/opt/kirra/robot/kitt_boot.py greet
+ExecStop=/opt/kirra/robot/kitt_boot.py shutdown
+TimeoutStartSec=40
+Nice=10
+
+[Install]
+WantedBy=multi-user.target

--- a/robot/kitt_ask.py
+++ b/robot/kitt_ask.py
@@ -34,7 +34,6 @@ Env (all optional; sensible localhost defaults):
 """
 import math
 import os
-import subprocess
 import sys
 import time
 
@@ -43,12 +42,15 @@ try:
 except ImportError:
     sys.exit("kitt_ask: python3-requests missing (pip3 install requests)")
 
+# robot/ is on sys.path when run standalone; importers add it before importing us.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from kitt_persona import name_slot, operator_name, speak  # noqa: E402,F401 (re-export speak)
+
 VERIFIER = os.environ.get("KIRRA_VERIFIER_URL", "http://localhost:8090").rstrip("/")
 MICK = os.environ.get("KIRRA_MICK_URL", "http://localhost:8102").rstrip("/")
 TAJ = os.environ.get("KIRRA_TAJ_URL", "http://localhost:8101").rstrip("/")
 OLLAMA = os.environ.get("KIRRA_OLLAMA_URL", "http://localhost:11434").rstrip("/")
 MODEL = os.environ.get("KIRRA_KITT_MODEL", "gemma3:4b")
-TTS_CMD = os.environ.get("KIRRA_TTS_CMD", "").strip()
 FORWARD_CONE_RAD = math.radians(15.0)
 
 KITT_SYSTEM = (
@@ -178,9 +180,17 @@ def gather_perception():
                 pass
 
 
+def gather_operator():
+    """The current operator, if known — a read-only grounding fact the persona
+    may use to address them by name. Never an actuation authority."""
+    n = operator_name()
+    return f"operator: {n} (address them by name when natural)" if n else \
+        "operator: unknown (don't guess a name)"
+
+
 def build_context():
     return "TELEMETRY (ground truth — answer only from this):\n- " + "\n- ".join([
-        gather_posture(), gather_stop_reason(), gather_perception(),
+        gather_operator(), gather_posture(), gather_stop_reason(), gather_perception(),
     ])
 
 
@@ -200,17 +210,6 @@ def ask_ollama(question, context):
         return (r.json().get("message", {}).get("content") or "").strip() or None
     except Exception:  # noqa: BLE001
         return None
-
-
-def speak(text):
-    print(text)
-    if not TTS_CMD:
-        return
-    try:
-        parts = TTS_CMD.split()
-        subprocess.run(parts, input=text.encode(), check=False)
-    except Exception as e:  # noqa: BLE001
-        print(f"(tts failed: {e})", file=sys.stderr)
 
 
 def main():

--- a/robot/kitt_boot.py
+++ b/robot/kitt_boot.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""kitt_boot.py — KITT's power-on greeting and shutdown line. **SPEAK-ONLY.**
+
+The boot greeting is deliberately NOT in kitt_watch.py (which stays silent on
+boot by design — no false "recovered" chatter). It lives here as a one-shot the
+systemd greet unit runs AFTER the stack is up, and it is HONEST: it only claims
+"governor nominal" when it has actually read a FRESH, non-LockedOut posture from
+the verifier. If the governor isn't ready within the deadline, it says so instead
+of greeting into a lie.
+
+  greet   → poll /metrics for a fresh non-LockedOut posture (up to a deadline),
+            then speak the matching line (nominal / degraded / not-ready-yet).
+  shutdown→ speak the power-down line.
+
+🔴 CHANNEL A ONLY (docs/kitt/KITT_VOICE_LINES.md, rows A1–A3). Read-only GET +
+   TTS. No /intent, no publisher, no serial, no release token — it cannot move
+   the robot. Proactive SPEECH, never proactive motion.
+
+Usage:
+  ./robot/kitt_boot.py greet       # power-on greeting (posture-gated)
+  ./robot/kitt_boot.py shutdown    # power-down line
+Env: KIRRA_VERIFIER_URL (default http://localhost:8090), KIRRA_TTS_CMD,
+     KIRRA_KITT_OPERATOR, KIRRA_KITT_GREET_DEADLINE_MS (default 20000).
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from kitt_persona import name_slot, speak  # noqa: E402
+
+VERIFIER = os.environ.get("KIRRA_VERIFIER_URL", "http://localhost:8090").rstrip("/")
+GREET_DEADLINE_S = int(os.environ.get("KIRRA_KITT_GREET_DEADLINE_MS", "20000")) / 1000.0
+
+_FLEET_RE = re.compile(r"kirra_fleet_posture\{[^}]*\}\s+(\d+)")
+_STALE_RE = re.compile(r"kirra_posture_cache_stale\{[^}]*\}\s+1\b")
+
+
+def greeting_line(posture_code, fresh):
+    """Pure: choose the boot line from a posture read.
+    posture_code: 0 nominal / 1 degraded / 2 lockedout / None (no read).
+    fresh: the read is fresh (posture present AND cache not stale)."""
+    slot = name_slot()
+    if fresh and posture_code == 0:
+        return (f"Good morning{slot}. All systems online, governor nominal — "
+                "I'm at your disposal.")
+    if fresh and posture_code == 1:
+        return (f"Good morning{slot}. I'm online, but starting in a degraded mode — "
+                "I'll be cautious until it clears.")
+    # LockedOut, no read, or stale → do NOT claim ready.
+    return (f"I'm awake{slot}, but still checking myself over. "
+            "Give me a moment before we go anywhere.")
+
+
+def shutdown_line():
+    return "Powering down. I've come to a safe stop — try not to miss me too much."
+
+
+def _read_posture(timeout=2.0):
+    """Worst-case posture code across nodes + freshness, from /metrics.
+    Returns (code|None, fresh_bool). Lazy requests import so this module stays
+    importable (and greeting_line unit-testable) without requests installed."""
+    try:
+        import requests
+    except Exception:  # noqa: BLE001
+        return None, False
+    try:
+        r = requests.get(f"{VERIFIER}/metrics", timeout=timeout)
+        if r.status_code != 200:
+            return None, False
+        text = r.text
+    except Exception:  # noqa: BLE001
+        return None, False
+    codes = [int(m) for m in _FLEET_RE.findall(text)]
+    stale = bool(_STALE_RE.search(text))
+    code = max(codes) if codes else None
+    return code, (code is not None and not stale)
+
+
+def greet(deadline_s=None, poll_s=1.0):
+    """Poll until a fresh nominal posture (greet at once) or the deadline
+    (greet with whatever the last honest read was)."""
+    deadline_s = GREET_DEADLINE_S if deadline_s is None else deadline_s
+    t0 = time.monotonic()
+    last_code, last_fresh = None, False
+    while True:
+        code, fresh = _read_posture()
+        if code is not None:  # keep the last KNOWN read; a transient outage ≠ ready
+            last_code, last_fresh = code, fresh
+        if fresh and code == 0:
+            break
+        if time.monotonic() - t0 >= deadline_s:
+            break
+        time.sleep(poll_s)
+    speak(greeting_line(last_code, last_fresh))
+
+
+def main():
+    action = sys.argv[1] if len(sys.argv) > 1 else "greet"
+    if action == "greet":
+        greet()
+    elif action == "shutdown":
+        speak(shutdown_line())
+    else:
+        sys.exit("usage: kitt_boot.py [greet|shutdown]")
+
+
+if __name__ == "__main__":
+    main()

--- a/robot/kitt_converse.py
+++ b/robot/kitt_converse.py
@@ -48,6 +48,7 @@ from kitt_ask import (  # noqa: E402
     gather_stop_reason, speak,
 )
 import kitt_ota  # noqa: E402 — deterministic OTA voice commands (NOT the movement door)
+from kitt_persona import name_slot, operator_name  # noqa: E402
 
 MAX_TURNS = 10  # rolling conversation memory (user+assistant pairs kept)
 PERCEPTION_WORDS = ("see", "around", "ahead", "front", "obstacle", "clear",
@@ -76,7 +77,12 @@ def perception_relevant(text):
 def context_for(utterance):
     """Fresh live telemetry each turn (posture + last verdict always; the costly
     perception grab only when the utterance is about seeing)."""
-    parts = [gather_posture(), gather_stop_reason()]
+    op = operator_name()
+    parts = [
+        f"operator: {op} (address them by name when natural)" if op
+        else "operator: unknown (don't guess a name)",
+        gather_posture(), gather_stop_reason(),
+    ]
     if perception_relevant(utterance):
         parts.append(gather_perception())
     return "TELEMETRY (ground truth — answer only from this):\n- " + "\n- ".join(parts)
@@ -154,7 +160,7 @@ def handle_turn(history, utterance):
     if directive:
         result = offer_to_door(directive)
         if result == "ok":
-            spoken = say or "On my way — the governor will keep us safe."
+            spoken = say or f"On our way{name_slot()} — the governor will keep us honest."
         elif result == "reject":
             spoken = ("I heard a movement request, but I couldn't pin down a "
                       "safe destination — could you say it another way?")
@@ -177,6 +183,9 @@ def main():
         utterance = sys.stdin.read().strip()
         if utterance:
             handle_turn(history, utterance)
+        else:
+            # Empty transcript (e.g. PTT released with nothing intelligible) → F2.
+            speak(f"I didn't quite catch that{name_slot()}.")
         return
     print("kitt_converse: talk to KITT — one line per turn (Ctrl-D quits).",
           file=sys.stderr)

--- a/robot/kitt_ota.py
+++ b/robot/kitt_ota.py
@@ -27,6 +27,9 @@ import shutil
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from kitt_persona import name_slot  # noqa: E402 — stdlib-only helper, safe for this lean module
+
 # The ota-ctl binary reads its OWN config from env (verifier URL, node id, slot
 # paths) — we do NOT duplicate that here, we just invoke it.
 OTA_CTL = os.environ.get("KIRRA_OTA_CTL") or shutil.which("kirra-ota-ctl") or "/opt/kirra/bin/kirra-ota-ctl"
@@ -62,8 +65,8 @@ def check() -> tuple[str, str]:
     if rc != 0:
         return "error", "I couldn't reach the update service just now — I'll stay on my current version."
     if _STAGED_RX.search(out) and not _CURRENT_RX.search(out):
-        return "staged", ("There's a new version. I've downloaded and verified it and it's "
-                          "staged, ready to go. Say 'apply update' when you want me to install it.")
+        return "staged", (f"There's a new version{name_slot()}. I've downloaded and verified it "
+                          "and it's staged, ready to go. Say 'apply update' when you want me to install it.")
     if _CURRENT_RX.search(out):
         return "current", "I checked — you're on the latest version, nothing to update."
     # Unknown-but-success: fall back to the authoritative slot state.

--- a/robot/kitt_persona.py
+++ b/robot/kitt_persona.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""kitt_persona.py — shared, dependency-free KITT persona helpers.
+
+The one home for (a) how KITT addresses the operator (the `{name}` slot) and
+(b) how it speaks (`speak`). Deliberately stdlib-only so EVERY KITT script can
+import it — including the lean, requests-free ones (kitt_ota.py).
+
+🔴 CHANNEL A ONLY (docs/hardware/KITT_CONVERSATION_DESIGN.md, docs/kitt/KITT_VOICE_LINES.md).
+   These helpers personalize and render SPEECH. They carry ZERO actuation
+   authority: knowing the operator's name never authorizes a command, and
+   `speak` only prints / pipes text to a TTS process. The KIRRA checker bounds
+   every motion identically whether the operator is known, unknown, or misheard.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def operator_name() -> str:
+    """The current operator's name for direct address, or '' if unknown.
+
+    Priority (highest first):
+      1. the operator RECOGNIZER feed (face/voice) — slots in here later; it is
+         a read-only grounding source with NO actuation authority, and
+      2. KIRRA_KITT_OPERATOR (a configured default name), else
+      3. '' (unknown → KITT stays polite, just nameless).
+    """
+    # (recognizer feed reads in here first once it lands — Channel A, read-only.)
+    return os.environ.get("KIRRA_KITT_OPERATOR", "").strip()
+
+
+def name_slot() -> str:
+    """Render the `{name}` slot used throughout docs/kitt/KITT_VOICE_LINES.md:
+    ', Justin' when the operator is known, '' when not — so a line reads
+    naturally either way ("Good morning{name}." → "Good morning, Justin." | "Good morning.")."""
+    n = operator_name()
+    return f", {n}" if n else ""
+
+
+def speak(text: str) -> None:
+    """Print the line and, if KIRRA_TTS_CMD is set, pipe it to that TTS process.
+    Fail-soft: a TTS failure never crashes the caller (speech is cosmetic)."""
+    print(text)
+    tts = os.environ.get("KIRRA_TTS_CMD", "").strip()
+    if not tts:
+        return
+    try:
+        subprocess.run(tts.split(), input=text.encode(), check=False)
+    except Exception as e:  # noqa: BLE001 — speech is never load-bearing
+        print(f"(tts failed: {e})", file=sys.stderr)

--- a/robot/kitt_voice_test.py
+++ b/robot/kitt_voice_test.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Host tests for the pure KITT voice logic (`kitt_persona.py`, `kitt_boot.py`,
+`kitt_ota.py` matcher).
+
+Pure and dependency-light by construction: `kitt_persona` is stdlib-only and
+`kitt_boot` imports `requests` LAZILY (inside `_read_posture`), so the boot
+greeting decision and the `{name}` slot are exercised on a plain host with no
+network, no ROS, and no TTS. Runs standalone (`python3 robot/kitt_voice_test.py`,
+exit 1 on any failure); also importable under pytest.
+
+Covers: the `{name}` slot (known/unknown), the posture-GATED boot greeting
+(nominal vs degraded vs not-ready-yet, and stale-is-not-ready), the shutdown
+line, and the OTA voice-command matcher precedence.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from kitt_boot import greeting_line, shutdown_line  # noqa: E402
+from kitt_ota import match_command  # noqa: E402
+from kitt_persona import name_slot  # noqa: E402
+
+
+def _with_operator(value):
+    """Context helper: set/clear KIRRA_KITT_OPERATOR, restoring the prior value.
+    Single-process test env twiddling (not the Rust INV-13 set_var concern)."""
+    class _Ctx:
+        def __enter__(self):
+            self.prev = os.environ.get("KIRRA_KITT_OPERATOR")
+            if value is None:
+                os.environ.pop("KIRRA_KITT_OPERATOR", None)
+            else:
+                os.environ["KIRRA_KITT_OPERATOR"] = value
+            return self
+
+        def __exit__(self, *a):
+            if self.prev is None:
+                os.environ.pop("KIRRA_KITT_OPERATOR", None)
+            else:
+                os.environ["KIRRA_KITT_OPERATOR"] = self.prev
+    return _Ctx()
+
+
+# --- {name} slot ------------------------------------------------------------
+
+def test_name_slot_known_renders_comma_name() -> None:
+    with _with_operator("Justin"):
+        assert name_slot() == ", Justin"
+
+
+def test_name_slot_unknown_is_empty() -> None:
+    with _with_operator(None):
+        assert name_slot() == ""
+
+
+def test_name_slot_blank_is_treated_as_unknown() -> None:
+    with _with_operator("   "):
+        assert name_slot() == ""
+
+
+# --- boot greeting: HONEST, posture-gated -----------------------------------
+
+def test_greeting_nominal_fresh_claims_governor_nominal() -> None:
+    with _with_operator(None):
+        line = greeting_line(0, True)
+    assert "governor nominal" in line and "online" in line
+
+
+def test_greeting_degraded_fresh_says_degraded_not_nominal() -> None:
+    with _with_operator(None):
+        line = greeting_line(1, True)
+    assert "degraded" in line and "governor nominal" not in line
+
+
+def test_greeting_lockedout_is_not_ready() -> None:
+    with _with_operator(None):
+        line = greeting_line(2, True)
+    assert "checking myself over" in line and "nominal" not in line
+
+
+def test_greeting_no_read_is_not_ready() -> None:
+    with _with_operator(None):
+        assert "checking myself over" in greeting_line(None, False)
+
+
+def test_greeting_stale_nominal_is_not_ready() -> None:
+    # code 0 but NOT fresh (stale cache) must NOT claim ready — freshness gates.
+    with _with_operator(None):
+        line = greeting_line(0, False)
+    assert "checking myself over" in line and "governor nominal" not in line
+
+
+def test_greeting_uses_name_when_known() -> None:
+    with _with_operator("Justin"):
+        assert ", Justin" in greeting_line(0, True)
+
+
+def test_shutdown_line_is_a_safe_stop_message() -> None:
+    line = shutdown_line()
+    assert "safe stop" in line and len(line) > 0
+
+
+# --- OTA matcher precedence (apply/status before check) ----------------------
+
+def test_ota_matcher_precedence() -> None:
+    assert match_command("apply the update") == "apply"
+    assert match_command("install update") == "apply"
+    assert match_command("update status") == "status"
+    assert match_command("check for updates") == "check"
+    assert match_command("any updates?") == "check"
+    assert match_command("take us to the kitchen") is None
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok   {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"  FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failures += 1
+            print(f"  ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    print("KITT voice-logic host tests (pure, no hardware):")
+    sys.exit(_run_all())

--- a/robot/kitt_watch.py
+++ b/robot/kitt_watch.py
@@ -37,6 +37,7 @@ except ImportError:
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from kitt_ask import MICK, VERIFIER, speak  # noqa: E402
+from kitt_persona import name_slot  # noqa: E402
 
 POLL_S = int(os.environ.get("KIRRA_KITT_WATCH_MS", "1500")) / 1000.0
 MIN_GAP_S = int(os.environ.get("KIRRA_KITT_WATCH_MIN_GAP_MS", "2500")) / 1000.0
@@ -86,13 +87,14 @@ def posture_line(old, new, stale_now, stale_before):
         return None
     if new > old:  # escalation
         if new == 2:
+            # LockedOut is the most serious state — kept humor-free, no name.
             return ("I'm locking out and holding a safe stop. "
                     "I'll need a manual reset before we continue.")
-        return ("Heads up — I've dropped into a degraded mode. "
+        return (f"Heads up{name_slot()} — I've dropped into a degraded mode. "
                 "I'll slow and stop as needed to keep us safe.")
     # recovery
     if new == 0:
-        return "All systems nominal. We're clear to move again."
+        return f"All systems nominal{name_slot()}. We're clear to move again."
     return "Recovering — back to a degraded mode."
 
 
@@ -102,8 +104,10 @@ def verdict_line(v):
     if not code:
         return None  # not a deny → not noteworthy
     if expl:
-        return f"I've had to refuse a command. {expl}"
-    return f"I've had to refuse a command ({code})."
+        # Real reason first and intact; the dry garnish trails it (persona rule 1).
+        return (f"I've had to refuse that{name_slot()}. {expl.rstrip('.')}. "
+                "I'd rather be dull than dented.")
+    return f"I've had to refuse a command ({code}). I'm holding until it's safe."
 
 
 def main():


### PR DESCRIPTION
## What

Works through **everything the R2 says out loud** and freezes it as a single
source of truth, then wires the easy Channel-A gaps.

- **`docs/kitt/KITT_VOICE_LINES.md`** — canonical catalog: one row per trigger
  (power-on, driving, refusals, posture changes, updates, conversation edges),
  each traced to its code seam (LIVE) or flagged as a follow-up. Persona:
  composed, dry-witty, protective; two hard rules the wit never overrides
  (safety lines stay legible; never invent telemetry).
- **`kitt_persona.py`** — shared, dependency-free `{name}` slot + `speak()`.
  `operator_name()` resolves (future) recognizer feed → `KIRRA_KITT_OPERATOR` →
  none, rendering `", Justin"` when known and nothing when not.
- **`kitt_boot.py`** — an **honest, posture-gated** power-on greeting: it only
  claims "governor nominal" after reading a fresh code-0 posture from
  `/metrics`; degraded / lockout / stale / no-read → "still checking myself
  over." Plus a shutdown line. `requests` is imported lazily so the pure
  `greeting_line` is unit-testable with no network.
- **`kirra-kitt-greet.service`** — one-shot greet on start, shutdown line on
  `ExecStop` (`RemainAfterExit`). Staged by the installer, **not enabled**.
- Threaded `{name}` + the dry garnish through the live lines
  (`kitt_watch` / `kitt_converse` / `kitt_ota`); **LockedOut kept humor-free**.
  LLM-phrased turns get an operator line in their grounding context.
- **F2** "I didn't quite catch that" on an empty `--once` transcript (PTT
  released with nothing intelligible).

## Safety

All Channel A (`docs/hardware/KITT_CONVERSATION_DESIGN.md`). Nothing here moves
the robot — speech carries zero actuation authority, and the doc restates that
the (planned) face/voice recognition personalizes speech only, never authorizes
a command. The KIRRA checker bounds every motion identically.

## Tests

- `robot/kitt_voice_test.py` — 11 pure tests: the `{name}` slot (known/unknown/
  blank), the posture-gated greeting (nominal vs degraded vs not-ready, and
  stale-nominal-is-not-ready), the shutdown line, and OTA matcher precedence.
  Wired into the CI robot-python job after `r2_drive_test.py`.
- `py_compile` + full import smoke of all KITT modules pass.

## Deferred (need a real event source, so not templatable)

- **C3** proactive obstacle — needs a perception subscribe (Stage 3b).
- **B4** arrival — needs a goal-reached event from the planner/loop.
- The face/voice **recognition feed** that fills `{name}` per person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_