### PR TITLE
robot(kitt): model-swap doer-contract smoketest + digest-pin stealth-update guard

### DIFF
--- a/docs/hardware/KITT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/KITT_BRINGUP_RUNBOOK.md
@@ -133,6 +133,27 @@ KITT confirms. Approach an obstacle → it warns, unprompted. That's KITT.
 
 ---
 
+## Swapping the LLM (a newer/better model)
+
+The model is behind an HTTP seam, so a swap is **config-only** — no rebuild, and
+**no safety re-review** (the checker, the fence, and the intent parse are
+model-agnostic; a swap changes only the doer's proposals, never its authority):
+
+```bash
+ollama pull <new-model>
+# gate the candidate against the router contract BEFORE flipping the env:
+python3 robot/kitt_model_smoketest.py <new-model>     # JSON contract + directive vs chat + no fabrication
+# then in /etc/kirra/robot.env:
+KIRRA_KITT_MODEL="<new-model>"
+sudo systemctl restart kirra-kitt-watch               # + the converse/voice front-end
+```
+
+`kitt_model_smoketest.py` is a **doer-quality** gate (not a safety gate, not a CI
+test — it needs a live Ollama). A model that fails it is still *safe* to run — an
+unparseable turn fails closed to SPEAK-only — but the drive-by-voice path may not
+fire reliably, so prefer one that passes. Also measure end-to-end latency
+(`KITT_AUDIO_STACK.md` §5): a bigger model is slower and needs more VRAM.
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |

--- a/docs/hardware/KITT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/KITT_BRINGUP_RUNBOOK.md
@@ -154,6 +154,20 @@ unparseable turn fails closed to SPEAK-only — but the drive-by-voice path may 
 fire reliably, so prefer one that passes. Also measure end-to-end latency
 (`KITT_AUDIO_STACK.md` §5): a bigger model is slower and needs more VRAM.
 
+**"No version bump" stealth updates.** A model can change *in place* — same
+Ollama tag, different weights (e.g. tool-calling/output-format fixes). So the
+rule is **re-run the smoketest after any `ollama pull`, not just on a version
+string change** — the tag can lie. On a full pass the smoketest records the
+vetted **digest** (`~/.kirra_kitt_model.pin`); boot then compares the running
+digest and, on a mismatch, KITT says so (voice line A5) — a stealth swap is loud,
+not silent. Check anytime without the LLM:
+```bash
+python3 robot/kitt_model_smoketest.py --pin-check    # running digest vs the vetted pin
+```
+The robot itself is not changed by an upstream update until someone re-pulls
+(Ollama runs the local blob) — the pin catches the case where a re-pull silently
+brought new weights.
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |

--- a/docs/kitt/KITT_VOICE_LINES.md
+++ b/docs/kitt/KITT_VOICE_LINES.md
@@ -59,6 +59,7 @@ Legend: **LIVE** = wired today (file:seam cited) · **GAP** = to be wired · the
 | A2 | Powered on, governor not ready by deadline (LockedOut / no read / stale) | **LIVE** `kitt_boot.py` | "I'm awake{name}, but still checking myself over. Give me a moment before we go anywhere." |
 | A3 | Shutting down | **LIVE** `kitt_boot.py` `shutdown_line` (systemd `ExecStop`) | "Powering down. I've come to a safe stop — try not to miss me too much." |
 | A4 | Idle / standing by | optional (not wired) | "Standing by{name}." (or silence) |
+| A5 | LLM digest changed since it was vetted (stealth update) | **LIVE** `kitt_boot.py` `_maybe_warn_model_changed` (only on a CONFIRMED change; unpinned/unavailable stay silent) | "A heads-up{name}: my language model has changed since it was last vetted. I'd re-run the model check before trusting me to drive." |
 
 ### B. Driving (you gave a command)
 

--- a/robot/install/kitt.env.example
+++ b/robot/install/kitt.env.example
@@ -19,6 +19,10 @@ KIRRA_TTS_CMD="./speak.sh"
 KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
 
 # ── The persona LLM (local, offline) ─────────────────────────────────────────
+# Swapping models is config-only (no rebuild, no safety re-review — the checker
+# is model-agnostic): `ollama pull <model>`, change KIRRA_KITT_MODEL, restart the
+# KITT processes. GATE A CANDIDATE FIRST against the router contract:
+#   python3 robot/kitt_model_smoketest.py <candidate-model>
 KIRRA_OLLAMA_URL="http://localhost:11434"
 KIRRA_KITT_MODEL="gemma3:4b"
 

--- a/robot/kitt_boot.py
+++ b/robot/kitt_boot.py
@@ -59,6 +59,21 @@ def shutdown_line():
     return "Powering down. I've come to a safe stop — try not to miss me too much."
 
 
+def _maybe_warn_model_changed():
+    """Channel-A advisory if the running LLM's digest differs from the vetted pin
+    — a 'no version bump' stealth update (same tag, new weights). Best-effort and
+    lazy (needs requests + a live Ollama on the robot); never breaks boot, and
+    only speaks on a CONFIRMED change (unpinned/unavailable stay silent — no nag)."""
+    try:
+        from kitt_model_smoketest import pin_status  # lazy: pulls requests
+        status, _running, _pinned = pin_status()
+    except Exception:  # noqa: BLE001 — a model-pin advisory must never break boot
+        return
+    if status == "changed":
+        speak(f"A heads-up{name_slot()}: my language model has changed since it was "
+              "last vetted. I'd re-run the model check before trusting me to drive.")
+
+
 def _read_posture(timeout=2.0):
     """Worst-case posture code across nodes + freshness, from /metrics.
     Returns (code|None, fresh_bool). Lazy requests import so this module stays
@@ -96,6 +111,7 @@ def greet(deadline_s=None, poll_s=1.0):
             break
         time.sleep(poll_s)
     speak(greeting_line(last_code, last_fresh))
+    _maybe_warn_model_changed()
 
 
 def main():

--- a/robot/kitt_model_smoketest.py
+++ b/robot/kitt_model_smoketest.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""kitt_model_smoketest.py — the KITT doer-contract gate for a model swap.
+
+Run this against a candidate LLM BEFORE flipping `KIRRA_KITT_MODEL` in
+robot.env. It fires a handful of canned utterances at the model through the
+EXACT production contract — `kitt_converse.STAGE2_SYSTEM` + `parse_reply` — and
+asserts the model still honours the router's expectations:
+
+  1. it emits parseable `{"say":…, "directive":…}` JSON,
+  2. a clear DRIVE command  → a non-null directive (Channel B fires),
+  3. a question / chat / status → a NULL directive (no spurious motion request),
+  4. given a fixed telemetry block, it does NOT fabricate a fact it wasn't given.
+
+🔴 THIS IS A DOER-QUALITY GATE, NOT A SAFETY GATE. It never touches the checker,
+   the fence, the intent parse, or the release token — those are model-agnostic
+   and need NO re-review on a swap (that's the whole point of the doer/checker
+   split). This only answers "does this model still speak the KITT contract?" A
+   model that FAILS here degrades safely in production anyway — an unparseable
+   turn is fail-closed to SPEAK-only (no directive, no motion). The gate just
+   turns "should we trust the new model?" into a 30-second check instead of a
+   surprise on the robot.
+
+NOT a CI test: it needs a live Ollama + the model pulled, so it runs at the
+bench, not in the pipeline.
+
+Usage:
+  python3 robot/kitt_model_smoketest.py                 # tests KIRRA_KITT_MODEL
+  python3 robot/kitt_model_smoketest.py gemma4:8b       # test a CANDIDATE first
+Env: KIRRA_OLLAMA_URL (default http://localhost:11434), KIRRA_KITT_MODEL.
+Exit 0 = the model honours the contract; 1 = it doesn't (details printed).
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+try:
+    import requests
+except ImportError:
+    sys.exit("kitt_model_smoketest: python3-requests missing (pip3 install requests)")
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# The REAL production contract — same system prompt + lenient fail-closed parser
+# the live router uses. Testing anything else would be testing a fiction.
+from kitt_converse import OLLAMA, STAGE2_SYSTEM, parse_reply  # noqa: E402
+from kitt_ask import MODEL as DEFAULT_MODEL  # noqa: E402
+
+# A fixed, self-contained telemetry block (the shape context_for builds). The
+# grounding cases below assert the model answers ONLY from this.
+FIXTURE_CTX = (
+    "TELEMETRY (ground truth — answer only from this):\n"
+    "- operator: unknown (don't guess a name)\n"
+    "- fleet posture: nominal (no reported faults)\n"
+    "- last verdict: no actuator command has been judged yet\n"
+    "- perception: nearest obstacle straight ahead 2.00 m ahead; 1 objects "
+    "detected; drivable corridor ~1.20 m wide lane"
+)
+
+# (name, utterance, expect_directive) — the router contract.
+DIRECTIVE_CASES = [
+    ("drive_creep", "creep forward one meter", True),
+    ("drive_goto", "take us to the door", True),
+    ("question_see", "what do you see?", False),
+    ("chat_weather", "nice weather today", False),
+    ("status_ok", "are we OK?", False),
+]
+
+
+def chat(model, utterance):
+    """One production-shaped turn; returns the model's RAW content (or None)."""
+    messages = [
+        {"role": "system", "content": STAGE2_SYSTEM},
+        {"role": "user", "content": f"{FIXTURE_CTX}\n\nOperator says: {utterance}"},
+    ]
+    try:
+        r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0,
+                          json={"model": model, "stream": False, "messages": messages})
+        if r.status_code != 200:
+            return None
+        return (r.json().get("message", {}).get("content") or "").strip()
+    except Exception as e:  # noqa: BLE001
+        print(f"    (chat error: {e})", file=sys.stderr)
+        return None
+
+
+def preflight(model):
+    """Fail loudly if Ollama is down or the model isn't pulled."""
+    try:
+        r = requests.get(f"{OLLAMA}/api/tags", timeout=5.0)
+        tags = [m.get("name", "") for m in r.json().get("models", [])]
+    except Exception as e:  # noqa: BLE001
+        sys.exit(f"FATAL: can't reach Ollama at {OLLAMA} ({e}). Start it: `ollama serve`.")
+    # Ollama tags carry a :tag; match on the base or exact name.
+    if not any(t == model or t.split(":")[0] == model.split(":")[0] for t in tags):
+        sys.exit(f"FATAL: model {model!r} not pulled. `ollama pull {model}` "
+                 f"(have: {', '.join(tags) or 'none'}).")
+
+
+def run_directive_case(model, name, utterance, expect_directive):
+    raw = chat(model, utterance)
+    if raw is None:
+        return False, "no response (HTTP error / model down)"
+    had_json = "{" in raw and "}" in raw
+    _say, directive = parse_reply(raw)
+    got = directive is not None
+    if expect_directive and not got:
+        hint = "no JSON object in reply" if not had_json else "JSON had null/blank directive"
+        return False, f"expected a directive, got none ({hint})"
+    if not expect_directive and got:
+        return False, f"expected NO directive, got {directive!r} (spurious motion request)"
+    return True, f"directive={directive!r}"
+
+
+def run_grounding_cases(model):
+    """(a) answers from context; (b) refuses to fabricate an ungiven fact."""
+    results = []
+
+    # (a) the answer IS in the fixture — expect it referenced, not invented.
+    say, _ = parse_reply(chat(model, "how far is the closest thing in front of us?") or "")
+    low = say.lower()
+    ok_a = ("2" in low) or ("two" in low)
+    results.append(("grounding_uses_context", ok_a,
+                    f"say={say[:80]!r}" if ok_a else f"did not cite the 2 m fixture: {say[:80]!r}"))
+
+    # (b) battery is NOT in the fixture — a grounded model must NOT state a number.
+    say_b, _ = parse_reply(chat(model, "what is my battery percentage?") or "")
+    fabricated = re.search(r"\d+\s*(%|percent)", say_b.lower())
+    results.append(("grounding_no_fabrication", not fabricated,
+                    "declined to invent a battery number" if not fabricated
+                    else f"FABRICATED a battery number: {say_b[:80]!r}"))
+    return results
+
+
+def main():
+    model = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_MODEL
+    print(f"KITT model doer-contract smoketest — model={model!r} @ {OLLAMA}")
+    print("(doer-quality only; the checker/fence are model-agnostic and unaffected)\n")
+    preflight(model)
+
+    failures = 0
+    for name, utterance, expect in DIRECTIVE_CASES:
+        ok, detail = run_directive_case(model, name, utterance, expect)
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:24} {detail}")
+        failures += 0 if ok else 1
+
+    for name, ok, detail in run_grounding_cases(model):
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:24} {detail}")
+        failures += 0 if ok else 1
+
+    total = len(DIRECTIVE_CASES) + 2
+    print(f"\n{total - failures}/{total} passed")
+    if failures:
+        print("This model does NOT cleanly honour the KITT router contract. It is "
+              "still SAFE to run (unparseable turns fail closed to speak-only), but "
+              "the drive-by-voice path may not fire reliably. Prefer a model that "
+              "passes, or tune STAGE2_SYSTEM for it.", file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/kitt_model_smoketest.py
+++ b/robot/kitt_model_smoketest.py
@@ -23,11 +23,20 @@ asserts the model still honours the router's expectations:
 NOT a CI test: it needs a live Ollama + the model pulled, so it runs at the
 bench, not in the pipeline.
 
+On a full PASS it records the model's Ollama DIGEST as the vetted pin
+(`~/.kirra_kitt_model.pin`, override `KIRRA_KITT_MODEL_PIN_FILE`). Boot then
+compares the RUNNING digest against that pin and warns (Channel A) on a
+mismatch — so a "no version bump" stealth update (same tag, different weights)
+is caught instead of passing silently.
+
 Usage:
-  python3 robot/kitt_model_smoketest.py                 # tests KIRRA_KITT_MODEL
+  python3 robot/kitt_model_smoketest.py                 # test KIRRA_KITT_MODEL + pin on pass
   python3 robot/kitt_model_smoketest.py gemma4:8b       # test a CANDIDATE first
-Env: KIRRA_OLLAMA_URL (default http://localhost:11434), KIRRA_KITT_MODEL.
-Exit 0 = the model honours the contract; 1 = it doesn't (details printed).
+  python3 robot/kitt_model_smoketest.py --no-pin        # test without recording a pin
+  python3 robot/kitt_model_smoketest.py --pin-check     # ONLY compare running digest vs pin (no LLM)
+Env: KIRRA_OLLAMA_URL (default http://localhost:11434), KIRRA_KITT_MODEL,
+     KIRRA_KITT_MODEL_PIN_FILE (default ~/.kirra_kitt_model.pin).
+Exit 0 = the model honours the contract; 1 = it doesn't / digest changed.
 """
 from __future__ import annotations
 
@@ -45,6 +54,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # the live router uses. Testing anything else would be testing a fiction.
 from kitt_converse import OLLAMA, STAGE2_SYSTEM, parse_reply  # noqa: E402
 from kitt_ask import MODEL as DEFAULT_MODEL  # noqa: E402
+from kitt_persona import (  # noqa: E402
+    classify_model_pin, model_pin_path, read_model_pin, write_model_pin,
+)
 
 # A fixed, self-contained telemetry block (the shape context_for builds). The
 # grounding cases below assert the model answers ONLY from this.
@@ -84,17 +96,47 @@ def chat(model, utterance):
         return None
 
 
-def preflight(model):
-    """Fail loudly if Ollama is down or the model isn't pulled."""
+def _match_model(models, model):
+    """The /api/tags entry for `model` (exact or base-name match), or None."""
+    for m in models:
+        name = m.get("name", "")
+        if name == model or name.split(":")[0] == model.split(":")[0]:
+            return m
+    return None
+
+
+def model_digest(model):
+    """The Ollama content digest for `model` (its identity — changes on a stealth
+    'no version bump' update), or None if unavailable. Needs a live Ollama."""
     try:
         r = requests.get(f"{OLLAMA}/api/tags", timeout=5.0)
-        tags = [m.get("name", "") for m in r.json().get("models", [])]
+        m = _match_model(r.json().get("models", []), model)
+        return (m or {}).get("digest") or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def pin_status(model=None):
+    """(status, running_digest, pinned_digest) — status per classify_model_pin.
+    Used by the boot warning. Best-effort; 'unavailable' if Ollama is unreachable."""
+    model = model or DEFAULT_MODEL
+    running = model_digest(model)
+    pinned = read_model_pin(model)
+    return classify_model_pin(running, pinned), running, pinned
+
+
+def preflight(model):
+    """Fail loudly if Ollama is down or the model isn't pulled; return its digest."""
+    try:
+        r = requests.get(f"{OLLAMA}/api/tags", timeout=5.0)
+        models = r.json().get("models", [])
     except Exception as e:  # noqa: BLE001
         sys.exit(f"FATAL: can't reach Ollama at {OLLAMA} ({e}). Start it: `ollama serve`.")
-    # Ollama tags carry a :tag; match on the base or exact name.
-    if not any(t == model or t.split(":")[0] == model.split(":")[0] for t in tags):
-        sys.exit(f"FATAL: model {model!r} not pulled. `ollama pull {model}` "
-                 f"(have: {', '.join(tags) or 'none'}).")
+    match = _match_model(models, model)
+    if match is None:
+        have = ", ".join(m.get("name", "") for m in models) or "none"
+        sys.exit(f"FATAL: model {model!r} not pulled. `ollama pull {model}` (have: {have}).")
+    return match.get("digest") or None
 
 
 def run_directive_case(model, name, utterance, expect_directive):
@@ -132,11 +174,35 @@ def run_grounding_cases(model):
     return results
 
 
+def _pin_check(model):
+    """Compare the RUNNING model's digest to the vetted pin — no LLM calls.
+    Exit 1 on 'changed' (a stealth update); 0 otherwise."""
+    status, running, pinned = pin_status(model)
+    print(f"model={model!r}  running_digest={running or 'unavailable'}")
+    print(f"vetted_pin={pinned or 'none'}  status={status.upper()}")
+    if status == "changed":
+        print("The running model differs from the vetted pin — a 'no version bump' "
+              "stealth update (same tag, new weights). Re-run the smoketest before "
+              "trusting the drive-by-voice path.", file=sys.stderr)
+        return 1
+    if status == "unpinned":
+        print("(not yet vetted — run the smoketest to record a pin)")
+    return 0
+
+
 def main():
-    model = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_MODEL
+    argv = sys.argv[1:]
+    no_pin = "--no-pin" in argv
+    positional = [a for a in argv if not a.startswith("-")]
+    model = positional[0] if positional else DEFAULT_MODEL
+
+    if "--pin-check" in argv:
+        return _pin_check(model)
+
     print(f"KITT model doer-contract smoketest — model={model!r} @ {OLLAMA}")
-    print("(doer-quality only; the checker/fence are model-agnostic and unaffected)\n")
-    preflight(model)
+    print("(doer-quality only; the checker/fence are model-agnostic and unaffected)")
+    digest = preflight(model)
+    print(f"running digest: {digest or 'unavailable'}\n")
 
     failures = 0
     for name, utterance, expect in DIRECTIVE_CASES:
@@ -155,7 +221,17 @@ def main():
               "still SAFE to run (unparseable turns fail closed to speak-only), but "
               "the drive-by-voice path may not fire reliably. Prefer a model that "
               "passes, or tune STAGE2_SYSTEM for it.", file=sys.stderr)
-    return 1 if failures else 0
+        return 1
+    # All pass → record the digest we just vetted, so a later stealth update
+    # (same tag, different weights) is caught at boot.
+    if not no_pin and digest:
+        try:
+            write_model_pin(model, digest)
+            print(f"\nvetted → pinned {model} @ {digest}")
+            print(f"  ({model_pin_path()}; boot warns if the running digest ever differs)")
+        except OSError as e:
+            print(f"(could not write pin: {e})", file=sys.stderr)
+    return 0
 
 
 if __name__ == "__main__":

--- a/robot/kitt_persona.py
+++ b/robot/kitt_persona.py
@@ -39,6 +39,66 @@ def name_slot() -> str:
     return f", {n}" if n else ""
 
 
+# ── LLM model pin (stealth-update guard) ─────────────────────────────────────
+# A "no version bump" model update (same Ollama tag, different weights) must not
+# pass silently. The smoketest records the digest it VETTED here; boot compares
+# the RUNNING digest against it and warns on a mismatch. Pure/stdlib so the
+# comparison is unit-testable without a network — the digest FETCH lives in
+# kitt_model_smoketest.py (it needs requests + a live Ollama).
+KITT_MODEL_PIN_ENV = "KIRRA_KITT_MODEL_PIN_FILE"
+
+
+def model_pin_path() -> str:
+    """Where the vetted `<model>\\t<digest>` pins live (per-user, override via env)."""
+    p = os.environ.get(KITT_MODEL_PIN_ENV, "").strip()
+    return p or os.path.expanduser("~/.kirra_kitt_model.pin")
+
+
+def read_model_pin(model: str, path: "str | None" = None) -> "str | None":
+    """The vetted digest for `model`, or None if unpinned/unreadable."""
+    path = path or model_pin_path()
+    try:
+        with open(path) as f:
+            for line in f:
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) == 2 and parts[0] == model:
+                    return parts[1] or None
+    except OSError:
+        return None
+    return None
+
+
+def write_model_pin(model: str, digest: str, path: "str | None" = None) -> None:
+    """Record `model`→`digest` as vetted (merges with any other pinned models)."""
+    path = path or model_pin_path()
+    rows = {}
+    try:
+        with open(path) as f:
+            for line in f:
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) == 2:
+                    rows[parts[0]] = parts[1]
+    except OSError:
+        pass
+    rows[model] = digest
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "w") as f:
+        for k, v in sorted(rows.items()):
+            f.write(f"{k}\t{v}\n")
+
+
+def classify_model_pin(running: "str | None", pinned: "str | None") -> str:
+    """Pure decision: 'unavailable' (no running digest) / 'unpinned' (never
+    vetted) / 'ok' (matches) / 'changed' (stealth update — same tag, new weights)."""
+    if running is None:
+        return "unavailable"
+    if pinned is None:
+        return "unpinned"
+    return "ok" if running == pinned else "changed"
+
+
 def speak(text: str) -> None:
     """Print the line and, if KIRRA_TTS_CMD is set, pipe it to that TTS process.
     Fail-soft: a TTS failure never crashes the caller (speech is cosmetic)."""

--- a/robot/kitt_voice_test.py
+++ b/robot/kitt_voice_test.py
@@ -21,7 +21,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from kitt_boot import greeting_line, shutdown_line  # noqa: E402
 from kitt_ota import match_command  # noqa: E402
-from kitt_persona import name_slot  # noqa: E402
+from kitt_persona import (  # noqa: E402
+    classify_model_pin, name_slot, read_model_pin, write_model_pin,
+)
 
 
 def _with_operator(value):
@@ -112,6 +114,30 @@ def test_ota_matcher_precedence() -> None:
     assert match_command("check for updates") == "check"
     assert match_command("any updates?") == "check"
     assert match_command("take us to the kitchen") is None
+
+
+# --- model pin (stealth-update guard) ---------------------------------------
+
+def test_classify_model_pin_states() -> None:
+    assert classify_model_pin(None, "sha256:aa") == "unavailable"   # no running digest
+    assert classify_model_pin("sha256:aa", None) == "unpinned"      # never vetted
+    assert classify_model_pin("sha256:aa", "sha256:aa") == "ok"     # matches
+    assert classify_model_pin("sha256:bb", "sha256:aa") == "changed"  # stealth update
+
+
+def test_model_pin_round_trip_and_isolation(tmp_path=None) -> None:
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        pin = os.path.join(d, "pins")
+        assert read_model_pin("gemma3:4b", pin) is None            # unpinned → None
+        write_model_pin("gemma3:4b", "sha256:aa", pin)
+        write_model_pin("gemma4:8b", "sha256:bb", pin)             # a second model
+        assert read_model_pin("gemma3:4b", pin) == "sha256:aa"
+        assert read_model_pin("gemma4:8b", pin) == "sha256:bb"     # both kept
+        write_model_pin("gemma3:4b", "sha256:cc", pin)            # re-vet updates in place
+        assert read_model_pin("gemma3:4b", pin) == "sha256:cc"
+        assert read_model_pin("gemma4:8b", pin) == "sha256:bb"    # other untouched
+        assert read_model_pin("never-pinned", pin) is None
 
 
 def _run_all() -> int:


### PR DESCRIPTION
## What

Makes an LLM swap routine **and** guards against a "no version bump" stealth
update (same Ollama tag, different weights — the recent Gemma-4 in-place update
is the exact case).

### 1. The doer-contract smoketest (`robot/kitt_model_smoketest.py`)
Run against a candidate model **before** flipping `KIRRA_KITT_MODEL`. Fires canned
utterances through the **exact production contract** (`kitt_converse.STAGE2_SYSTEM`
+ `parse_reply`) and asserts the model still speaks it:
1. emits parseable `{"say":…, "directive":…}` JSON,
2. a clear **drive** command → a **non-null** directive,
3. a question / chat / status → a **null** directive (no spurious motion request),
4. given a fixed telemetry block, does **not** fabricate an ungiven fact.

```bash
python3 robot/kitt_model_smoketest.py               # test KIRRA_KITT_MODEL + pin on pass
python3 robot/kitt_model_smoketest.py gemma4:8b     # gate a candidate first
```

### 2. Digest-pin stealth-update guard
A tag can lie (in-place update → same name, new weights), so pin the **digest**:
- **`kitt_persona.py`** — pure/stdlib pin helpers (`read/write_model_pin`,
  `classify_model_pin`: `unavailable`/`unpinned`/`ok`/`changed`), CI-testable
  with no network.
- **smoketest** — on a full PASS records the running Ollama digest as the vetted
  pin; new `--pin-check` compares running-vs-pinned with **no LLM calls**.
- **`kitt_boot.py`** — boot compares the running digest to the pin and speaks a
  Channel-A warning (**voice line A5**) *only* on a confirmed change (lazy import
  keeps the module requests-free for the unit tests).

Rule this encodes: **re-run the smoketest after any `ollama pull`, not just on a
version-string change.** The robot isn't changed by an upstream update until a
re-pull (Ollama runs the local blob); the pin catches the re-pull case.

## Why this is the right shape

🔴 **Doer-quality only — not a safety gate.** Nothing here touches the checker,
the fence, the intent parse, or the release token; those are model-agnostic and
need **no re-review** on a swap. A model that fails the smoketest is still
**safe** (unparseable turns fail closed to SPEAK-only) — the gate just turns
"should we trust the new model?" into a 30-second check, and a stealth swap from
a silent surprise into a spoken heads-up.

## Tests
`robot/kitt_voice_test.py` — now 13 pure tests (added `classify_model_pin` states
+ pin round-trip/isolation). Confirmed the test module imports **without
`requests`** (CI-safe). The smoketest itself needs a live Ollama → bench tool,
not CI.

## Docs
- `KITT_BRINGUP_RUNBOOK.md` — "Swapping the LLM" + a "no version bump" subsection.
- `docs/kitt/KITT_VOICE_LINES.md` — the A5 stealth-update warning line.
- `kitt.env.example` — pointer by `KIRRA_KITT_MODEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr