### PR TITLE
robot(kitt): pin the vetted-at date + provenance note (reproducibility)

### DIFF
--- a/docs/hardware/KITT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/KITT_BRINGUP_RUNBOOK.md
@@ -155,18 +155,24 @@ fire reliably, so prefer one that passes. Also measure end-to-end latency
 (`KITT_AUDIO_STACK.md` §5): a bigger model is slower and needs more VRAM.
 
 **"No version bump" stealth updates.** A model can change *in place* — same
-Ollama tag, different weights (e.g. tool-calling/output-format fixes). So the
-rule is **re-run the smoketest after any `ollama pull`, not just on a version
-string change** — the tag can lie. On a full pass the smoketest records the
-vetted **digest** (`~/.kirra_kitt_model.pin`); boot then compares the running
-digest and, on a mismatch, KITT says so (voice line A5) — a stealth swap is loud,
-not silent. Check anytime without the LLM:
+Ollama tag, different weights (e.g. the July 2026 Gemma-4 overhaul: tool-calling
+patches + reduced truncation, no version label change). So the rule is **re-run
+the smoketest after any `ollama pull`, not just on a version string change** — the
+tag can lie. On a full pass the smoketest records the vetted **digest** *and the
+vetted-at timestamp* (`~/.kirra_kitt_model.pin`) — the "which weights, verified
+when" trail researchers recommend logging for reproducibility; add provenance
+with `--note`:
 ```bash
-python3 robot/kitt_model_smoketest.py --pin-check    # running digest vs the vetted pin
+python3 robot/kitt_model_smoketest.py --note "hf re-pull 2026-07-16"   # test + pin with a dated note
+python3 robot/kitt_model_smoketest.py --pin-check                       # running digest vs pin (+ vetted-at), no LLM
 ```
-The robot itself is not changed by an upstream update until someone re-pulls
-(Ollama runs the local blob) — the pin catches the case where a re-pull silently
-brought new weights.
+Boot compares the running digest to the pin and, on a mismatch, KITT says so
+(voice line A5) — a stealth swap is loud, not silent. The robot itself is not
+changed by an upstream update until someone re-pulls (Ollama runs the local
+blob); the pin catches the re-pull that silently brought new weights. (For KITT
+specifically the tool-calling/truncation fixes are *welcome* — they harden the
+`{say, directive}` JSON contract; the smoketest confirms it. The FA4/vision gains
+don't reach the Orin — Ampere, text-only router.)
 
 ## Troubleshooting
 

--- a/robot/kitt_model_smoketest.py
+++ b/robot/kitt_model_smoketest.py
@@ -23,15 +23,17 @@ asserts the model still honours the router's expectations:
 NOT a CI test: it needs a live Ollama + the model pulled, so it runs at the
 bench, not in the pipeline.
 
-On a full PASS it records the model's Ollama DIGEST as the vetted pin
-(`~/.kirra_kitt_model.pin`, override `KIRRA_KITT_MODEL_PIN_FILE`). Boot then
-compares the RUNNING digest against that pin and warns (Channel A) on a
-mismatch — so a "no version bump" stealth update (same tag, different weights)
-is caught instead of passing silently.
+On a full PASS it records the model's Ollama DIGEST + the VETTED-AT timestamp
+(the reproducibility trail ML researchers recommend logging — "which weights,
+verified when") as the vetted pin (`~/.kirra_kitt_model.pin`, override
+`KIRRA_KITT_MODEL_PIN_FILE`). Boot then compares the RUNNING digest against that
+pin and warns (Channel A) on a mismatch — so a "no version bump" stealth update
+(same tag, different weights) is caught instead of passing silently.
 
 Usage:
   python3 robot/kitt_model_smoketest.py                 # test KIRRA_KITT_MODEL + pin on pass
   python3 robot/kitt_model_smoketest.py gemma4:8b       # test a CANDIDATE first
+  python3 robot/kitt_model_smoketest.py --note "hf re-pull 2026-07-16"  # provenance note in the pin
   python3 robot/kitt_model_smoketest.py --no-pin        # test without recording a pin
   python3 robot/kitt_model_smoketest.py --pin-check     # ONLY compare running digest vs pin (no LLM)
 Env: KIRRA_OLLAMA_URL (default http://localhost:11434), KIRRA_KITT_MODEL,
@@ -43,6 +45,7 @@ from __future__ import annotations
 import os
 import re
 import sys
+from datetime import datetime, timezone
 
 try:
     import requests
@@ -55,7 +58,8 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from kitt_converse import OLLAMA, STAGE2_SYSTEM, parse_reply  # noqa: E402
 from kitt_ask import MODEL as DEFAULT_MODEL  # noqa: E402
 from kitt_persona import (  # noqa: E402
-    classify_model_pin, model_pin_path, read_model_pin, write_model_pin,
+    classify_model_pin, model_pin_path, read_model_pin, read_model_pin_record,
+    write_model_pin,
 )
 
 # A fixed, self-contained telemetry block (the shape context_for builds). The
@@ -176,10 +180,16 @@ def run_grounding_cases(model):
 
 def _pin_check(model):
     """Compare the RUNNING model's digest to the vetted pin — no LLM calls.
+    Also prints the reproducibility trail (vetted-when + note).
     Exit 1 on 'changed' (a stealth update); 0 otherwise."""
-    status, running, pinned = pin_status(model)
+    running = model_digest(model)
+    rec = read_model_pin_record(model)
+    pinned = rec[0] if rec else None
+    status = classify_model_pin(running, pinned)
     print(f"model={model!r}  running_digest={running or 'unavailable'}")
     print(f"vetted_pin={pinned or 'none'}  status={status.upper()}")
+    if rec:
+        print(f"  vetted_at={rec[1] or 'unknown'}  note={rec[2] or '-'}")
     if status == "changed":
         print("The running model differs from the vetted pin — a 'no version bump' "
               "stealth update (same tag, new weights). Re-run the smoketest before "
@@ -190,8 +200,18 @@ def _pin_check(model):
     return 0
 
 
+def _take_opt(argv, flag):
+    """Pull `--flag VALUE` out of argv; return (value|None, remaining argv)."""
+    if flag in argv:
+        i = argv.index(flag)
+        value = argv[i + 1] if i + 1 < len(argv) else ""
+        return value, argv[:i] + argv[i + 2:]
+    return None, argv
+
+
 def main():
     argv = sys.argv[1:]
+    note, argv = _take_opt(argv, "--note")
     no_pin = "--no-pin" in argv
     positional = [a for a in argv if not a.startswith("-")]
     model = positional[0] if positional else DEFAULT_MODEL
@@ -222,12 +242,17 @@ def main():
               "the drive-by-voice path may not fire reliably. Prefer a model that "
               "passes, or tune STAGE2_SYSTEM for it.", file=sys.stderr)
         return 1
-    # All pass → record the digest we just vetted, so a later stealth update
-    # (same tag, different weights) is caught at boot.
+    # All pass → record the digest + WHEN we vetted it (the reproducibility trail
+    # ML researchers recommend logging), so a later stealth update (same tag,
+    # different weights) is caught at boot and "which weights, verified when" is
+    # answerable from the pin file itself.
     if not no_pin and digest:
+        vetted_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
         try:
-            write_model_pin(model, digest)
-            print(f"\nvetted → pinned {model} @ {digest}")
+            write_model_pin(model, digest, vetted_at=vetted_at, note=note or "")
+            print(f"\nvetted {vetted_at} → pinned {model} @ {digest}")
+            if note:
+                print(f"  note: {note}")
             print(f"  ({model_pin_path()}; boot warns if the running digest ever differs)")
         except OSError as e:
             print(f"(could not write pin: {e})", file=sys.stderr)

--- a/robot/kitt_persona.py
+++ b/robot/kitt_persona.py
@@ -54,39 +54,57 @@ def model_pin_path() -> str:
     return p or os.path.expanduser("~/.kirra_kitt_model.pin")
 
 
-def read_model_pin(model: str, path: "str | None" = None) -> "str | None":
-    """The vetted digest for `model`, or None if unpinned/unreadable."""
-    path = path or model_pin_path()
-    try:
-        with open(path) as f:
-            for line in f:
-                parts = line.rstrip("\n").split("\t")
-                if len(parts) == 2 and parts[0] == model:
-                    return parts[1] or None
-    except OSError:
-        return None
-    return None
+def _pin_clean(s: "str | None") -> str:
+    """Strip tabs/newlines so a field can't corrupt the TSV record."""
+    return (s or "").replace("\t", " ").replace("\n", " ").strip()
 
 
-def write_model_pin(model: str, digest: str, path: "str | None" = None) -> None:
-    """Record `model`→`digest` as vetted (merges with any other pinned models)."""
-    path = path or model_pin_path()
+def _load_pins(path: str) -> dict:
+    """model → (digest, vetted_at, note). Back-compat: legacy 2-field lines
+    (`model\\tdigest`) read with empty vetted_at/note."""
     rows = {}
     try:
         with open(path) as f:
             for line in f:
                 parts = line.rstrip("\n").split("\t")
-                if len(parts) == 2:
-                    rows[parts[0]] = parts[1]
+                if len(parts) >= 2 and parts[0]:
+                    rows[parts[0]] = (
+                        parts[1],
+                        parts[2] if len(parts) >= 3 else "",
+                        parts[3] if len(parts) >= 4 else "",
+                    )
     except OSError:
         pass
-    rows[model] = digest
+    return rows
+
+
+def read_model_pin_record(model: str, path: "str | None" = None):
+    """(digest, vetted_at, note) for `model`, or None if unpinned — the
+    reproducibility trail: WHICH weights, verified WHEN, and a provenance note."""
+    return _load_pins(path or model_pin_path()).get(model)
+
+
+def read_model_pin(model: str, path: "str | None" = None) -> "str | None":
+    """The vetted digest for `model`, or None if unpinned/unreadable."""
+    rec = read_model_pin_record(model, path)
+    return (rec[0] or None) if rec else None
+
+
+def write_model_pin(model: str, digest: str, path: "str | None" = None,
+                    vetted_at: str = "", note: str = "") -> None:
+    """Record `model`→(digest, vetted_at, note) as vetted (merges with any other
+    pinned models; preserves their fields). `vetted_at` is an ISO timestamp the
+    caller supplies (kept out of here so the write stays clock-free/testable)."""
+    path = path or model_pin_path()
+    rows = _load_pins(path)
+    rows[model] = (digest, _pin_clean(vetted_at), _pin_clean(note))
     parent = os.path.dirname(path)
     if parent:
         os.makedirs(parent, exist_ok=True)
     with open(path, "w") as f:
-        for k, v in sorted(rows.items()):
-            f.write(f"{k}\t{v}\n")
+        for k in sorted(rows):
+            d, v, n = rows[k]
+            f.write(f"{k}\t{d}\t{v}\t{n}\n")
 
 
 def classify_model_pin(running: "str | None", pinned: "str | None") -> str:

--- a/robot/kitt_voice_test.py
+++ b/robot/kitt_voice_test.py
@@ -22,7 +22,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from kitt_boot import greeting_line, shutdown_line  # noqa: E402
 from kitt_ota import match_command  # noqa: E402
 from kitt_persona import (  # noqa: E402
-    classify_model_pin, name_slot, read_model_pin, write_model_pin,
+    classify_model_pin, name_slot, read_model_pin, read_model_pin_record,
+    write_model_pin,
 )
 
 
@@ -138,6 +139,30 @@ def test_model_pin_round_trip_and_isolation(tmp_path=None) -> None:
         assert read_model_pin("gemma3:4b", pin) == "sha256:cc"
         assert read_model_pin("gemma4:8b", pin) == "sha256:bb"    # other untouched
         assert read_model_pin("never-pinned", pin) is None
+
+
+def test_model_pin_records_timestamp_and_note() -> None:
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        pin = os.path.join(d, "pins")
+        write_model_pin("gemma4:8b", "sha256:aa", pin,
+                        vetted_at="2026-07-19T00:00:00+00:00", note="hf re-pull")
+        assert read_model_pin_record("gemma4:8b", pin) == (
+            "sha256:aa", "2026-07-19T00:00:00+00:00", "hf re-pull")
+        assert read_model_pin("gemma4:8b", pin) == "sha256:aa"   # digest accessor still works
+        # a tab in the note must not corrupt the record
+        write_model_pin("m2", "sha256:bb", pin, vetted_at="t", note="a\tb")
+        assert read_model_pin_record("m2", pin) == ("sha256:bb", "t", "a b")
+
+
+def test_model_pin_legacy_two_field_line_reads() -> None:
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        pin = os.path.join(d, "pins")
+        with open(pin, "w") as f:
+            f.write("gemma3:4b\tsha256:cc\n")                    # legacy 2-field line
+        assert read_model_pin("gemma3:4b", pin) == "sha256:cc"   # still reads the digest
+        assert read_model_pin_record("gemma3:4b", pin) == ("sha256:cc", "", "")  # empty ts/note
 
 
 def _run_all() -> int:


### PR DESCRIPTION
## What

Implements the reproducibility recommendation from the July 2026 Gemma-4 stealth
update: **log the exact weight vet/download date**, because unversioned in-place
updates change how identical names/tags score. Extends the model pin from
digest-only to a full record: `model ⇥ digest ⇥ vetted_at ⇥ note`.

- **`kitt_persona.py`** — 4-field TSV pin. `read_model_pin_record()` returns
  `(digest, vetted_at, note)`; `read_model_pin()` still returns the digest
  (back-compat). **Legacy 2-field lines still read** (empty ts/note). Fields are
  tab/newline-sanitized so a note can't corrupt the record. The write stays
  clock-free (caller supplies the ISO timestamp) → deterministic + unit-testable.
- **`kitt_model_smoketest.py`** — stamps `datetime.now(UTC)` on a passing pin;
  `--note "<text>"` records provenance (e.g. `"hf re-pull 2026-07-16"`);
  `--pin-check` prints `vetted_at` + `note` alongside the digest comparison.

## Why (matched to the article)

The Gemma-4 overhaul shipped unversioned — same tag, new weights. For KITT the
**tool-calling patches + reduced truncation are welcome**: they harden exactly
the `{say, directive}` JSON contract the router depends on, and the smoketest
confirms it. The **FA4 throughput / vision-budget gains don't reach the Orin**
(Ampere-class, text-only router). Either way, the pin now answers "which weights,
verified when" from the file itself, and boot still warns (voice line A5) if the
running digest ever drifts from the vetted one.

## Tests

`robot/kitt_voice_test.py` — now **15 pure tests** (added timestamp/note
round-trip + tab-sanitize, and legacy 2-field back-compat). Confirmed the test
module still imports **without `requests`** (CI-safe). The smoketest itself needs
a live Ollama → bench tool, not CI.

## Safety

Doer-only. The pin is a reproducibility/quality record; nothing here touches the
checker, the fence, or the intent parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_