### PR TITLE
Autoware distro migration: ADR-0036 + Occy gap analysis + "only Autoware on Humble" isolation scaffold

### DIFF
--- a/deploy/autoware-isolation/README.md
+++ b/deploy/autoware-isolation/README.md
@@ -1,0 +1,70 @@
+# Autoware-on-Humble isolation (ADR-0036)
+
+Scaffold for the "**only Autoware on 22.04/Humble**" topology: the Autoware
+*doer* stays on Humble in its own container; the KIRRA checker + adapter and the
+rest of the stack move to 24.04/Jazzy. They meet **only** on the 5 curated
+boundary topics. See `docs/adr/0036-autoware-distro-migration-occy-gap.md`.
+
+```
+ ┌─────────────────────────────┐        5 curated topics over DDS        ┌────────────────────────────┐
+ │ Autoware  (doer)            │  trajectory / objects(+2nd) / map /     │ KIRRA checker + adapter    │
+ │ ros:humble  (the ONLY 22.04)│  odometry  ───────────────────────────► │ ros:jazzy                  │
+ │                             │  ◄─────────────  governed control_cmd   │ (Occy/Taj/robot on Jazzy)  │
+ └─────────────────────────────┘                                         └────────────────────────────┘
+```
+
+The checker does **not** depend on Autoware — only on the 4 curated
+`autoware_*_msgs` packages vendored in `ros2_ws/src/` (they build from `.msg` on
+any distro). So the only thing pinned to Humble is Autoware itself.
+
+## Step 1 — prove the boundary is wire-safe across distros (do this FIRST)
+
+Direct cross-distro DDS is only safe if the 5 curated interfaces are
+byte-identical on both distros (⇒ identical RIHS type hash). Verify:
+
+```bash
+bash scripts/curated_interface/crossdistro_hash_check.sh \
+     /opt/ros/humble/share  /opt/ros/jazzy/share
+```
+- **PASS** → every curated interface is identical Humble==Jazzy → **direct DDS**, no bridge.
+- **DRIFT** → the named interface(s) differ across distros → route those through
+  `kirra_bridge_cpp` / `domain_bridge`; record the drift in the MSGSYNC SRAC
+  (`docs/safety/MSG_INTERFACE_VERSION_SYNC.md`).
+
+## Step 2 — bring up the two containers
+
+```bash
+# real (placeholder) Autoware on Humble + KIRRA on Jazzy:
+docker compose -f deploy/autoware-isolation/docker-compose.yml up
+```
+Replace the `autoware` service image/command with your real Autoware-on-Humble
+build. Both sides share `ROS_DOMAIN_ID` + the same `RMW_IMPLEMENTATION`
+(Fast DDS is the most interop-tested Humble↔Jazzy pairing) over host networking.
+
+## Step 3 — validate the KIRRA side WITHOUT a real Autoware (if it isn't built out)
+
+If Autoware isn't fully implemented yet, use the **stub doer** — it publishes
+minimal, valid messages on the 5 boundary topics so you can bring up and validate
+the whole Jazzy checker path (topic discovery, type match, message flow, and the
+governed-control round-trip) independent of Autoware:
+
+```bash
+docker compose -f deploy/autoware-isolation/docker-compose.yml \
+  --profile stub up autoware-stub kirra
+# or standalone, in any sourced ROS 2 container with the curated msgs built:
+python3 deploy/autoware-isolation/autoware_stub_publisher.py
+```
+The stub logs `✓ received a governed control_cmd back from the checker` once the
+adapter's bounded output returns — that confirms the seam round-trips end to end.
+
+## What this scaffold is / isn't
+- **Is:** the topology, the cross-distro wire-compat gate, and a doer stub so the
+  Jazzy side is testable now.
+- **Isn't:** a real Autoware build (image/command are placeholders), and it does
+  **not** touch the safety spine — the checker is `no_std`/ROS-agnostic and
+  bounds whatever crosses the boundary regardless of distro.
+
+## Retirement
+When Autoware ships stable Jazzy support, migrate the `autoware` service to
+Jazzy, re-run step 1 (now Jazzy↔Jazzy, trivially PASS), and delete the Humble
+container — the isolation was only ever a bridge across the EOL gap.

--- a/deploy/autoware-isolation/autoware_stub_publisher.py
+++ b/deploy/autoware-isolation/autoware_stub_publisher.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""autoware_stub_publisher.py — a stand-in Autoware DOER for the isolation
+scaffold (ADR-0036).
+
+Publishes minimal, structurally-valid messages on the 5 curated boundary topics
+so the KIRRA checker+adapter (Jazzy) can be validated **end-to-end without a real
+Autoware** — proving the wire (topic discovery, type match, message flow across
+the Humble↔Jazzy DDS boundary) independent of whether the Autoware doer is fully
+built out. It is NOT Autoware: it drives nothing meaningful, it exercises the
+seam.
+
+Boundary (subscribed by kirra-ros2-adapter/src/node.rs), published here:
+  <prefix>/trajectory         autoware_planning_msgs/Trajectory
+  <prefix>/objects            autoware_perception_msgs/PredictedObjects
+  <prefix>/objects_secondary  autoware_perception_msgs/PredictedObjects  (channel-B)
+  <prefix>/map                autoware_map_msgs/LaneletMapBin
+  <prefix>/odometry           nav_msgs/Odometry
+It also *subscribes* the governed control topic to show the checker's bounded
+output comes back (logs on receipt).
+
+Robust by construction: each message type is imported LAZILY; a type that isn't
+built (or whose field names differ on a distro) degrades to a logged warning and
+that one topic is skipped — the rest keep flowing. Empty-but-valid payloads are
+the point (wire proof), not behaviour.
+
+Env:
+  KIRRA_BOUNDARY_PREFIX   topic prefix (default /input) — remap to your adapter ns
+  KIRRA_CONTROL_TOPIC     governed control topic to listen on (default /output/control_cmd)
+  KIRRA_STUB_HZ           publish rate (default 10)
+Run (inside a Jazzy/Humble container with the curated msgs built + sourced):
+  python3 autoware_stub_publisher.py
+"""
+import os
+import sys
+
+try:
+    import rclpy
+    from rclpy.node import Node
+except Exception as e:  # noqa: BLE001
+    sys.exit(f"autoware_stub_publisher: rclpy unavailable ({e}). Source a ROS 2 setup.bash first.")
+
+PREFIX = os.environ.get("KIRRA_BOUNDARY_PREFIX", "/input").rstrip("/")
+CONTROL_TOPIC = os.environ.get("KIRRA_CONTROL_TOPIC", "/output/control_cmd")
+HZ = float(os.environ.get("KIRRA_STUB_HZ", "10"))
+
+
+def _try_import(modpath, name):
+    """Import a message class, or return None with a warning (never crash)."""
+    try:
+        mod = __import__(modpath, fromlist=[name])
+        return getattr(mod, name)
+    except Exception as e:  # noqa: BLE001
+        print(f"  [skip] {modpath}.{name} unavailable ({type(e).__name__}) — topic disabled", file=sys.stderr)
+        return None
+
+
+class AutowareStub(Node):
+    def __init__(self):
+        super().__init__("autoware_stub_publisher")
+        # Lazy type imports — each independent.
+        self.Trajectory = _try_import("autoware_planning_msgs.msg", "Trajectory")
+        self.PredictedObjects = _try_import("autoware_perception_msgs.msg", "PredictedObjects")
+        self.LaneletMapBin = _try_import("autoware_map_msgs.msg", "LaneletMapBin")
+        self.Odometry = _try_import("nav_msgs.msg", "Odometry")
+        self.Control = _try_import("autoware_control_msgs.msg", "Control")
+
+        self.pubs = {}
+        if self.Trajectory:
+            self.pubs["trajectory"] = self.create_publisher(self.Trajectory, f"{PREFIX}/trajectory", 1)
+        if self.PredictedObjects:
+            self.pubs["objects"] = self.create_publisher(self.PredictedObjects, f"{PREFIX}/objects", 1)
+            self.pubs["objects_secondary"] = self.create_publisher(
+                self.PredictedObjects, f"{PREFIX}/objects_secondary", 1)
+        if self.LaneletMapBin:
+            self.pubs["map"] = self.create_publisher(self.LaneletMapBin, f"{PREFIX}/map", 1)
+        if self.Odometry:
+            self.pubs["odometry"] = self.create_publisher(self.Odometry, f"{PREFIX}/odometry", 1)
+
+        # Round-trip: hear the checker's governed output come back.
+        if self.Control:
+            self.create_subscription(self.Control, CONTROL_TOPIC, self._on_control, 1)
+
+        self._control_seen = 0
+        self._ticks = 0
+        self.create_timer(1.0 / max(HZ, 0.1), self._tick)
+        self.get_logger().info(
+            f"stub doer up — publishing {sorted(self.pubs)} on '{PREFIX}/*' at {HZ} Hz; "
+            f"listening for governed control on '{CONTROL_TOPIC}'")
+
+    def _stamp(self, msg):
+        """Set header.stamp/frame_id when the message has a header."""
+        try:
+            msg.header.stamp = self.get_clock().now().to_msg()
+            msg.header.frame_id = "map"
+        except Exception:  # noqa: BLE001 — not all msgs have a header
+            pass
+        return msg
+
+    def _tick(self):
+        self._ticks += 1
+        for key, pub in self.pubs.items():
+            try:
+                cls = pub.msg_type
+                pub.publish(self._stamp(cls()))   # empty-but-valid: exercises the wire
+            except Exception as e:  # noqa: BLE001
+                self.get_logger().warn(f"publish {key} failed ({type(e).__name__}: {e})")
+        if self._ticks % int(max(HZ, 1)) == 0:  # ~once/sec
+            self.get_logger().info(
+                f"heartbeat: published {sorted(self.pubs)}; governed-control msgs seen={self._control_seen}")
+
+    def _on_control(self, _msg):
+        self._control_seen += 1
+        if self._control_seen == 1:
+            self.get_logger().info("✓ received a governed control_cmd back from the checker — boundary round-trips")
+
+
+def main():
+    rclpy.init()
+    node = AutowareStub()
+    if not node.pubs:
+        node.get_logger().error("no boundary types available — build the curated autoware_*_msgs first")
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        try:
+            rclpy.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/autoware-isolation/docker-compose.yml
+++ b/deploy/autoware-isolation/docker-compose.yml
@@ -1,0 +1,75 @@
+# Autoware-on-Humble isolation topology (ADR-0036).
+#
+# Autoware (the DOER) stays on Ubuntu 22.04 / ROS 2 Humble in its OWN container;
+# the KIRRA checker + adapter (and the rest of the stack) run on 24.04 / Jazzy.
+# They meet ONLY on the 5 curated boundary topics over DDS
+# (autoware_{planning,perception,map,control}_msgs + nav_msgs/Odometry).
+#
+# 🔴 VERIFY WIRE-COMPAT FIRST — before trusting direct cross-distro DDS, run:
+#     bash scripts/curated_interface/crossdistro_hash_check.sh
+#   PASS  → the 5 interfaces are byte-identical Humble==Jazzy → direct DDS (below).
+#   DRIFT → the drifted interface needs kirra_bridge_cpp / domain_bridge instead.
+#
+# This is a TOPOLOGY SCAFFOLD: the `autoware` image + command are PLACEHOLDERS for
+# the integrator's real Autoware-on-Humble build. If Autoware isn't fully built
+# out yet, use the `stub` profile to validate the KIRRA/Jazzy side end-to-end
+# WITHOUT a real Autoware (it publishes the 5 boundary topics).
+#
+#   docker compose -f deploy/autoware-isolation/docker-compose.yml up            # real (placeholder) Autoware + KIRRA
+#   docker compose -f deploy/autoware-isolation/docker-compose.yml --profile stub up autoware-stub kirra   # stub doer + KIRRA
+#
+# DDS discovery uses host networking + a shared ROS_DOMAIN_ID. Pin the SAME
+# RMW on both sides (Fast DDS is the most interop-tested Humble↔Jazzy pairing).
+
+services:
+  # --- the DOER, pinned to Humble (the ONLY thing left on 22.04) --------------
+  autoware:
+    image: ${AUTOWARE_IMAGE:-ros:humble}      # ← replace with your real Autoware/Humble image
+    container_name: kirra-autoware-humble
+    network_mode: host
+    environment:
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
+      - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}
+    # Replace the command with the Autoware launch that publishes trajectory /
+    # objects / map and subscribes the governed control_cmd.
+    command: ["bash", "-lc", "echo '[autoware] replace with your Autoware launch'; sleep infinity"]
+
+  # --- the CHECKER + adapter, on Jazzy ----------------------------------------
+  kirra:
+    image: ${KIRRA_IMAGE:-ros:jazzy}          # ← your KIRRA/Jazzy image (builds ros2_ws + the adapter)
+    container_name: kirra-checker-jazzy
+    depends_on: [autoware]
+    network_mode: host
+    environment:
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
+      - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}
+    volumes:
+      - ../../ros2_ws:/ws:ro
+    # Build the curated msgs on Jazzy (they compile from .msg unchanged) + run
+    # the kirra-ros2-adapter node. Placeholder command — wire your entrypoint.
+    command: ["bash", "-lc", "echo '[kirra] build /ws + run the kirra-ros2-adapter node on Jazzy'; sleep infinity"]
+
+  # --- STUB doer: validate the KIRRA side WITHOUT a real Autoware --------------
+  # `--profile stub` so it never starts unless asked. Publishes minimal, valid
+  # messages on the 5 boundary topics at a fixed rate.
+  autoware-stub:
+    profiles: ["stub"]
+    image: ${KIRRA_IMAGE:-ros:jazzy}
+    container_name: kirra-autoware-stub
+    network_mode: host
+    environment:
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
+      - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}
+    volumes:
+      - ./autoware_stub_publisher.py:/stub.py:ro
+      - ../../ros2_ws:/ws:ro
+    command:
+      - bash
+      - -lc
+      - |
+        source /opt/ros/jazzy/setup.bash
+        cd /tmp && cp -r /ws/src ./src && colcon build --packages-up-to \
+          autoware_planning_msgs autoware_perception_msgs autoware_map_msgs autoware_control_msgs \
+          >/tmp/build.log 2>&1 || { echo 'msg build failed — see /tmp/build.log'; tail -20 /tmp/build.log; }
+        source install/setup.bash 2>/dev/null || true
+        python3 /stub.py

--- a/docs/adr/0036-autoware-distro-migration-occy-gap.md
+++ b/docs/adr/0036-autoware-distro-migration-occy-gap.md
@@ -1,0 +1,114 @@
+# ADR-0036 — Autoware Distro Migration & Occy/KIRRA Gap Analysis
+
+**Status:** Accepted
+**Date:** 2026-07-19
+**Owner:** Kirra Systems, LLC
+**Scope:** How the KIRRA stack crosses the Ubuntu 22.04 / ROS 2 Humble → Ubuntu 24.04 / ROS 2 Jazzy boundary, given that the **Autoware** AV-stack doer is the one component pinned to Humble. Records the doer-vs-doer gap analysis (Occy/KIRRA vs Autoware) that decides "keep vs replace," and the migration/isolation decision that follows. This is a *doer-side* decision — it does not touch the safety spine or any certification claim (ADR-0032).
+
+---
+
+## Decision
+
+1. **Autoware stays.** It remains the AV-stack **doer**; KIRRA does **not** reimplement it. Occy/KIRRA is a *lean doer + heavy checker* and does not cover Autoware's L4 breadth (localization, closed-loop control, mature fused perception, full HD maps). Reimplementing those would dilute the thesis — KIRRA's value is the **checker that bounds any doer**, not a second Autoware.
+
+2. **Autoware becomes the *only* thing on 22.04 / Humble, isolated in its own container.** Everything else — `kirra-ros2-adapter`, the checker/governor, the robot `rclpy` nodes, the Occy/planner/Taj crates — targets **24.04 / Jazzy**. The rest of the stack's Jazzy move is therefore **unblocked now** and does not wait on Autoware.
+
+3. **Interop crosses at the frozen contract, not at raw cross-distro ROS topics.** The Humble-Autoware container and the Jazzy world are bridged at the distro-agnostic `#[repr(C)]` governed-command / doer↔checker boundary (ADR-0006 Clause 2, ADR-0032), or through a **narrow, version-matched** message set via `domain_bridge`. Naive Humble↔Jazzy DDS is **not** relied upon (RIHS type-hash / message-version mismatch risk).
+
+4. **The Humble container is retired when Autoware ships stable Jazzy support.** Autoware tracks the ROS LTS; a 24.04/Jazzy Autoware is the expected successor. That external release — not anything in this repo — is the trigger. Confirm current Autoware roadmap status before committing a date.
+
+The **safety spine is unaffected** by any of this: the checker is `no_std` and ROS-agnostic, and ADR-0032 already names the doer guest as "ROS 2 Jazzy."
+
+---
+
+## Context
+
+- **Humble + Ubuntu 22.04 Jammy** reach end-of-support **~May 2027** (tied together). **Jazzy + 24.04 Noble** is the LTS successor (Jazzy EOL 2029).
+- In the KIRRA doer/checker split (`docs/hardware/TARGET_PLATFORM_MATRIX.md`), the ROS/Ubuntu box is the **swappable, never-trusted doer**. Its distro coupling is a **contained, non-safety** concern.
+- Audit of the workspace: **the only component structurally tied to Humble is the Autoware AV-stack doer.** The Rust binding (`r2r = "=0.9.5"`) already lists Humble / Jazzy / Kilted support; the `kirra-ros2-adapter` and robot `rclpy` nodes are source-mostly-portable Humble→Jazzy (the sharp edge is Python 3.10→3.12 native deps). Message interfaces are tracked in `docs/safety/MSG_INTERFACE_VERSION_SYNC.md`.
+- The open question was whether Occy/KIRRA could **replace** Autoware and delete the dependency. Answer: only for narrow uses — see the gap analysis.
+
+---
+
+## Gap analysis — Occy/KIRRA doer vs Autoware
+
+**One line:** Occy/KIRRA is a lean *doer* attached to a heavy *checker*; Autoware is a full production AV autonomy stack. They overlap on "propose a trajectory along a lane corridor" and diverge at the edges.
+
+### What Occy/KIRRA's doer actually is
+- **`kirra-map`** — Lanelet2-**lite**: route Dijkstra, multi-junction `route_corridor`, right-of-way / junction context, occlusion sight-distance. A subset of Lanelet2, not the full HD-map spec.
+- **`kirra-planner` (Occy)** — geometric planner + Mick intent grounding (`GoTo`/`LaneChange`/`Cruise`/`Overtake`/`PullOver`/`TurnAt`/`RouteTo`) + learned planners (Hydra-MDP speed; 2-D lateral×speed route-around) + `behavior.rs` (traffic-control + occluded-approach creep).
+- **`kirra-taj`** — lidar perception: geometric corridor + semantic hazard fusion (Phase-A/B).
+- **`parko`** — ML inference backends (ONNX / OpenVINO / TensorRT) + detector.
+- **The checker** (`kirra-ros2-adapter` validation: RSS, occlusion bound, multi-modal predictive RSS, perception redundancy) — where KIRRA is *ahead*; Autoware has **no** equivalent formal bounding layer.
+
+### Coverage table
+
+| Autoware subsystem | Occy/KIRRA coverage | Verdict |
+|---|---|---|
+| **Localization** (NDT lidar + EKF pose fusion, GNSS) | *none* | 🔴 **Major gap** — no map-relative localization |
+| **Control** (trajectory follower: MPC / pure-pursuit) | *none* — R2 uses the Ackermann last-hop + governor clamp | 🔴 **Major gap** — no closed-loop path tracker |
+| **Perception** (3-D detection + MOT tracking + map-based prediction + traffic lights) | parko ML detectors + Taj corridor/hazard + predictive-RSS (in the *checker*) | 🟠 **Partial** — detection + bounding, not a mature fused doer pipeline |
+| **HD maps** (full Lanelet2 + pointcloud maps + projection) | Lanelet2-**lite** | 🟠 **Partial** — subset |
+| **Behavior planning** (intersection, crosswalk, blind-spot, stop-line, traffic-light) | traffic-control + occluded-approach | 🟠 **Partial** — a slice of the suite |
+| **Motion planning** (obstacle avoidance, path optimization, freespace/parking) | geometric + learned 2-D route-around, `PullOver` | 🟠 **Partial** — vocabulary-based, not optimization-based |
+| **Sensor drivers** (lidar/cam/radar/GNSS/IMU) | ydlidar + off-the-shelf | 🟠 mostly distro-independent |
+| **Route / mission planning** | Occy `RouteTo` (Dijkstra) | 🟢 **Covered** (for the lite map) |
+| **Vehicle interface** | R2 governed consumer (Ackermann) | 🟢 **Covered** for R2; not general AV |
+| **Formal command bounding** (RSS / occlusion / decel envelope) | the KIRRA checker | 🟢 **KIRRA-only** — Autoware has no equivalent |
+
+### What the gaps imply
+The red/orange cells cluster in the "**full L4 AV autonomy on real roads**" columns — localization, control, mature fused perception/HD-maps. Those are multi-year to close **and are not what KIRRA is trying to be.** So the decision maps by *usage*:
+
+- **Autoware as the real AV autonomy stack** (localize on an HD map → perceive/track → follow trajectories) → Occy does **not** replace it → **keep + isolate** (this ADR).
+- **Autoware as a *reference doer*** feeding trajectories to the checker for the doer/checker demonstration → Occy already fills that role on scoped scenarios → droppable for that purpose.
+- **Specific Autoware modules** (e.g. just localization or just perception) → those are exactly the red cells → keep those, drop the rest.
+
+---
+
+## Options considered
+
+1. **Isolate + track (CHOSEN).** Autoware pinned to Humble in its own container; the rest of the stack moves to Jazzy; bridge at the frozen contract; adopt Autoware's Jazzy release when it ships. Unblocks everything else now; plays to the thesis; the only cost is running EOL Humble for one isolated, non-safety box.
+2. **Replace Autoware with Occy.** Rejected for full-AV use — the red-cell gaps (localization, control, mature perception) are prohibitive and off-thesis. Viable only if the actual Autoware use was narrow.
+3. **Freeze the whole stack on Humble.** Rejected — drags the entire stack past EOL to accommodate one component, and forfeits the Jazzy security/support horizon for no benefit.
+4. **Naive cross-distro DDS bridge at ROS topics.** Rejected as the *primary* boundary — Humble↔Jazzy interface hashes can mismatch silently; used only for a narrow version-matched set via `domain_bridge` if needed.
+
+---
+
+## Migration & isolation plan ("only Autoware on 22.04/Humble")
+
+1. **Inventory the Autoware boundary.** Enumerate exactly which topics/services cross between Autoware and the rest of the stack, and which of those are safety-relevant (must go through the checker) vs observability. This is the input to the bridge design.
+2. **Containerize Autoware**, pinned: a `ros:humble` + Autoware image, versions locked. Nothing else runs in that container.
+3. **Move the rest to Jazzy**: `kirra-ros2-adapter` (rebuild against `/opt/ros/jazzy`; `r2r =0.9.5` already supports it), robot `rclpy` nodes (mind Python 3.10→3.12 native deps — Jetson.GPIO, numpy), Occy/Taj crates.
+4. **Bridge at the frozen contract.** Route safety-relevant Autoware output through the doer↔checker boundary (distro-agnostic), not raw cross-distro topics. Where a ROS-topic bridge is unavoidable, use `domain_bridge` over a **narrow, version-matched** interface set and record the matched versions.
+5. **Record an environment lock** (Ubuntu + ROS distro + rmw + `r2r` + Python + key apt/pip versions) per side — the reproducibility pin, mirroring the LLM digest-pin discipline. Add a Jazzy row to `TARGET_PLATFORM_MATRIX.md`.
+6. **Add a Jazzy CI build lane** (`--features ros2` against a `ros:jazzy` container, in parallel with Humble) — the analog of the MSRV lane: validate the next target continuously so an EOL cutover is a non-event.
+7. **Retire on Autoware-Jazzy.** When Autoware ships stable Jazzy, migrate the container, run the governed-loop bring-up smoke, drop Humble.
+
+**Orin note:** on the Jetson the host OS is JetPack/L4T (NVIDIA-controlled; JetPack 6 = 22.04), not something you `do-release-upgrade`. Containerizing ROS is what lets the ROS distro move ahead of the JetPack-bound host. (Per ADR-0032, the Orin is a *doer*, never the governor cert target.)
+
+---
+
+## Consequences
+
+**Positive**
+- The rest of the stack's Jazzy migration is unblocked immediately; no dependency on Autoware's timeline.
+- Autoware stays a swappable, checker-bounded doer — the thesis holds, and the "we complement, not compete with Autoware" positioning is documented (proposal-relevant).
+- The safety spine is untouched (`no_std`, ROS-agnostic checker) — no re-certification.
+
+**Negative / risks**
+- One isolated box runs EOL Humble until Autoware-Jazzy lands. Mitigated: it carries **no safety claim**, is network-isolated, and is behind the checker.
+- Cross-distro interop needs care; the frozen-contract boundary is the mitigation, `domain_bridge` the fallback.
+- Autoware's Jazzy timeline is **external** — track it; do not commit a repo date to it.
+
+## Follow-ups
+- Autoware boundary inventory (step 1) — the immediate next work item.
+- Jazzy CI build lane (step 6).
+- Governed-loop bring-up smoke checklist (Jazzy), analogous to `robot/kitt_model_smoketest.py`.
+
+## References
+- ADR-0032 — Governor Deployment Platform (doer guest = "ROS 2 Jazzy"; Jetson is a doer, not the cert target)
+- ADR-0006 — Governor transport / the frozen `#[repr(C)]` contract (Clause 2)
+- ADR-0033 — Actuation-authority ROS/R2 topology
+- `docs/hardware/TARGET_PLATFORM_MATRIX.md` — doer/checker hardware homes
+- `docs/safety/MSG_INTERFACE_VERSION_SYNC.md` — message interface versioning
+- `crates/kirra-ros2-adapter/Cargo.toml` — `r2r =0.9.5` distro support (Humble/Jazzy/Kilted)

--- a/docs/adr/0036-autoware-distro-migration-occy-gap.md
+++ b/docs/adr/0036-autoware-distro-migration-occy-gap.md
@@ -65,6 +65,51 @@ The red/orange cells cluster in the "**full L4 AV autonomy on real roads**" colu
 
 ---
 
+## The Autoware boundary (as inventoried)
+
+The handoff between Autoware and the KIRRA stack is **already curated to a small,
+hash-verified interface** — the checker does not depend on Autoware, only on a
+pinned subset of its message packages. This makes the Humble isolation far
+smaller than a generic Autoware container.
+
+**The seam = 5 topics into the checker node (`kirra-ros2-adapter/src/node.rs`):**
+
+| Topic | Type | Direction | Role |
+|---|---|---|---|
+| `~/input/trajectory` | `autoware_planning_msgs/Trajectory` | Autoware → checker | the proposed path being **bounded** |
+| `~/input/objects` (+ `~/input/objects_secondary`) | `autoware_perception_msgs/PredictedObjects` | Autoware → checker | perception (+ redundant channel-B) |
+| `~/input/map` | `autoware_map_msgs/LaneletMapBin` | Autoware → checker | lanelet map |
+| `~/input/odometry` | `nav_msgs/Odometry` | (standard ROS) | ego odom |
+| `~/input/control_cmd` | `autoware_control_msgs/Control` | Autoware → checker | control command being **gated** |
+| *(output)* | `autoware_control_msgs/Control` | checker → actuation | the **governed** (bounded) command |
+
+**Already decoupled.** The four `autoware_*_msgs` packages are **vendored +
+curated** in `ros2_ws/src/` — only the verbatim message closures the governor
+consumes (`Trajectory`/`TrajectoryPoint`; the `PredictedObjects` family;
+`LaneletMapBin`; `Control`/`Lateral`/`Longitudinal`), **not a full Autoware
+install.** The checker builds these from their `.msg` on any distro. A
+`kirra_bridge_cpp` node already exists at the governor FFI boundary.
+
+**Already governed.** `docs/safety/MSG_INTERFACE_VERSION_SYNC.md`
+(KIRRA-OCCY-MSGSYNC-001) is a hash-verified **version-sync SRAC** that keeps the
+curated subset wire-compatible with the deployed Autoware.
+
+**So the cross-distro crux reduces to one check:** do these 5 message definitions
+have identical **RIHS type-hashes** on Humble and Jazzy? The curated `.msg` files
+are pinned in-repo, so:
+- **If byte-identical → Autoware (Humble) ↔ adapter (Jazzy) talk directly over
+  DDS** for these interfaces, no bridge needed.
+- **If an upstream `.msg` drifts between distros** → the MSGSYNC SRAC catches it,
+  and `kirra_bridge_cpp` / `domain_bridge` translates that one interface.
+
+**Net shape of "only Autoware on Humble":**
+1. **Container A (Humble):** Autoware only — publishes the 4 inputs, subscribes the governed `Control`.
+2. **Container/host B (Jazzy):** the adapter + checker + Occy/Taj + robot nodes, building the 4 curated msg packages unchanged.
+3. **Extend the MSGSYNC SRAC** to hash-verify the 5 interfaces across the **Humble↔Jazzy** pair — the one *new* safety-relevant check this migration introduces.
+4. **Env-lock both sides.**
+
+---
+
 ## Options considered
 
 1. **Isolate + track (CHOSEN).** Autoware pinned to Humble in its own container; the rest of the stack moves to Jazzy; bridge at the frozen contract; adopt Autoware's Jazzy release when it ships. Unblocks everything else now; plays to the thesis; the only cost is running EOL Humble for one isolated, non-safety box.
@@ -76,7 +121,7 @@ The red/orange cells cluster in the "**full L4 AV autonomy on real roads**" colu
 
 ## Migration & isolation plan ("only Autoware on 22.04/Humble")
 
-1. **Inventory the Autoware boundary.** Enumerate exactly which topics/services cross between Autoware and the rest of the stack, and which of those are safety-relevant (must go through the checker) vs observability. This is the input to the bridge design.
+1. **Inventory the Autoware boundary.** ✅ Done — see "The Autoware boundary (as inventoried)" above: 5 topics into the checker node, backed by 4 curated (already-vendored, hash-verified) `autoware_*_msgs` packages. The design input is settled.
 2. **Containerize Autoware**, pinned: a `ros:humble` + Autoware image, versions locked. Nothing else runs in that container.
 3. **Move the rest to Jazzy**: `kirra-ros2-adapter` (rebuild against `/opt/ros/jazzy`; `r2r =0.9.5` already supports it), robot `rclpy` nodes (mind Python 3.10→3.12 native deps — Jetson.GPIO, numpy), Occy/Taj crates.
 4. **Bridge at the frozen contract.** Route safety-relevant Autoware output through the doer↔checker boundary (distro-agnostic), not raw cross-distro topics. Where a ROS-topic bridge is unavoidable, use `domain_bridge` over a **narrow, version-matched** interface set and record the matched versions.
@@ -110,5 +155,8 @@ The red/orange cells cluster in the "**full L4 AV autonomy on real roads**" colu
 - ADR-0006 — Governor transport / the frozen `#[repr(C)]` contract (Clause 2)
 - ADR-0033 — Actuation-authority ROS/R2 topology
 - `docs/hardware/TARGET_PLATFORM_MATRIX.md` — doer/checker hardware homes
-- `docs/safety/MSG_INTERFACE_VERSION_SYNC.md` — message interface versioning
+- `docs/safety/MSG_INTERFACE_VERSION_SYNC.md` (KIRRA-OCCY-MSGSYNC-001) — the hash-verified curated-interface version-sync SRAC (extend to the Humble↔Jazzy pair)
+- `crates/kirra-ros2-adapter/src/node.rs` — the checker node + the 5-topic Autoware seam
+- `ros2_ws/src/autoware_{planning,perception,map,control}_msgs/` — the curated, vendored message packages (the boundary)
+- `ros2_ws/src/kirra_bridge_cpp/` — the existing C++ bridge node at the governor FFI boundary
 - `crates/kirra-ros2-adapter/Cargo.toml` — `r2r =0.9.5` distro support (Humble/Jazzy/Kilted)

--- a/scripts/curated_interface/crossdistro_hash_check.sh
+++ b/scripts/curated_interface/crossdistro_hash_check.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# crossdistro_hash_check.sh — the Humble↔Jazzy wire-compatibility gate for the
+# curated Autoware interface (ADR-0036; extends KIRRA-OCCY-MSGSYNC-001 to the
+# distro pair).
+#
+# The "only Autoware on Humble" split (ADR-0036) runs the Autoware *doer* on
+# 22.04/Humble and the KIRRA checker+adapter on 24.04/Jazzy, meeting ONLY on the
+# 5 curated boundary topics over DDS. That direct cross-distro DDS is wire-safe
+# iff the curated `.msg` closures are BYTE-IDENTICAL on both distros: identical
+# closure + identical base messages ⇒ identical RIHS type hash ⇒ genuine
+# messages cross the boundary. This script proves (or refutes) exactly that:
+#
+#   1. curated == Humble reference       (reuses verify_hashes.sh)
+#   2. curated == Jazzy  reference       (reuses verify_hashes.sh)
+#   3. Humble reference == Jazzy reference, per curated .msg  (the cross-distro diff)
+#
+# A DRIFT in step 3 names the exact interface that must go through
+# kirra_bridge_cpp / domain_bridge instead of direct DDS.
+#
+# Bench tool — needs BOTH a Humble and a Jazzy Autoware msg reference available
+# (sourced installs or mounted `share/` trees). Not a CI gate.
+#
+# Usage:
+#   bash scripts/curated_interface/crossdistro_hash_check.sh \
+#        [REF_HUMBLE=/opt/ros/humble/share] [REF_JAZZY=/opt/ros/jazzy/share]
+set -euo pipefail
+
+REF_HUMBLE="${1:-/opt/ros/humble/share}"
+REF_JAZZY="${2:-/opt/ros/jazzy/share}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+WS_SRC="$REPO_ROOT/ros2_ws/src"
+
+echo "== cross-distro curated-interface wire-compat check (ADR-0036) =="
+echo "  Humble ref: $REF_HUMBLE"
+echo "  Jazzy  ref: $REF_JAZZY"
+echo
+
+missing=0
+
+# --- 1 + 2: curated is byte-identical to EACH reference (the existing gate) ---
+for ref in "$REF_HUMBLE" "$REF_JAZZY"; do
+  if [ ! -d "$ref" ]; then
+    echo "SKIP: reference share not found: $ref (source that distro, or mount its share/ tree)"
+    missing=1
+    continue
+  fi
+  echo "-- curated vs ${ref} --"
+  bash "$HERE/verify_hashes.sh" "$ref"
+  echo
+done
+
+# --- 3: the cross-distro per-interface diff (are the upstream .msg identical?) ---
+echo "== per-interface Humble↔Jazzy diff =="
+mapfile -t CURATED_PKGS < <(
+  find "$WS_SRC" -maxdepth 1 -type d -name 'autoware_*_msgs' -printf '%f\n' | sort
+)
+drift=0
+checked=0
+for pkg in "${CURATED_PKGS[@]}"; do
+  shopt -s nullglob
+  msgs=("$WS_SRC/$pkg/msg"/*.msg)
+  shopt -u nullglob
+  for m in "${msgs[@]}"; do
+    name="$(basename "$m")"
+    h="$REF_HUMBLE/$pkg/msg/$name"
+    j="$REF_JAZZY/$pkg/msg/$name"
+    if [ ! -f "$h" ] || [ ! -f "$j" ]; then
+      echo "SKIP  $pkg/$name (missing on a reference)"
+      missing=1
+      continue
+    fi
+    checked=$((checked + 1))
+    if cmp -s "$h" "$j"; then
+      echo "MATCH $pkg/$name  (Humble == Jazzy → direct DDS ok)"
+    else
+      echo "DRIFT $pkg/$name  (Humble != Jazzy → bridge THIS interface):"
+      diff -u "$h" "$j" | sed 's/^/      /' || true
+      drift=1
+    fi
+  done
+done
+
+echo
+if [ "$missing" -ne 0 ]; then
+  echo "RESULT: INCOMPLETE — a reference (or a per-interface file) was missing."
+  echo "        Re-run with BOTH distros' Autoware msg shares available."
+  exit 2
+fi
+if [ "$checked" -eq 0 ]; then
+  echo "ERROR: no curated .msg to compare — run extract_closures.sh first." >&2
+  exit 4
+fi
+if [ "$drift" -ne 0 ]; then
+  echo "RESULT: DRIFT — some curated interfaces differ across Humble/Jazzy."
+  echo "        Those interfaces need kirra_bridge_cpp / domain_bridge translation,"
+  echo "        NOT direct cross-distro DDS. Record the drift in the MSGSYNC SRAC."
+  exit 1
+fi
+echo "RESULT: PASS — all $checked curated interfaces are byte-identical Humble == Jazzy."
+echo "        Direct cross-distro DDS is wire-safe for the whole boundary; no bridge needed."


### PR DESCRIPTION
## What

Two coupled things: **ADR-0036** (the gap analysis + decision) and the
**buildable isolation scaffold** it calls for.

### ADR-0036 — Occy/KIRRA vs Autoware gap analysis + distro decision
- Grounded coverage table (per Autoware subsystem → Occy/KIRRA → 🔴/🟠/🟢). Gaps
  cluster in **localization, closed-loop control, mature fused perception/HD-maps**
  — multi-year and off-thesis. KIRRA's value is the **checker that bounds any
  doer**, not a second Autoware.
- **Decision:** keep Autoware; make it the **only** thing on 22.04/Humble
  (isolated container); move everything else (adapter, checker, Occy/Taj, robot
  nodes) to Jazzy now; bridge at the frozen `#[repr(C)]` contract, not naive
  cross-distro ROS topics; retire the Humble container when Autoware ships Jazzy.
- **Inventoried boundary:** the seam is 5 topics into `kirra-ros2-adapter/node.rs`,
  backed by 4 curated, already-vendored, hash-verified `autoware_*_msgs` packages
  (`ros2_ws/src/`) governed by the MSGSYNC SRAC. The checker does not depend on
  Autoware — only on those `.msg`.

### The isolation scaffold (`deploy/autoware-isolation/` + a script)
- `scripts/curated_interface/crossdistro_hash_check.sh` — the one *new*
  safety-relevant check: curated interfaces byte-identical to **both** Humble and
  Jazzy refs + per-interface cross-distro diff. **PASS** → direct DDS is
  wire-safe; **DRIFT** → names the interface needing `kirra_bridge_cpp` /
  `domain_bridge`. Reuses the existing `verify_hashes.sh`.
- `docker-compose.yml` — Autoware on `ros:humble` (the only 22.04 box) ⟷ KIRRA on
  `ros:jazzy`, over a shared DDS domain.
- `autoware_stub_publisher.py` — a stub doer publishing the 5 boundary topics so
  the **Jazzy checker path validates end-to-end without a real Autoware** (for
  when Autoware isn't fully built out); logs the governed-control round-trip.
- `README.md` — the runbook (verify wire-compat → two containers → stub-validate → retire).

## Safety

Docs + doer-side infra only. The checker is `no_std`/ROS-agnostic (ADR-0032
already names the doer guest as Jazzy). No safety spine or certification impact.
The scaffold is bench-run (needs real ROS envs) — no CI dependency; `bash -n` /
`py_compile` / `docker compose config` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr