### PR TITLE
docs(kitt): copy-paste Gemma update commands in the runbook

### DIFF
--- a/docs/hardware/KITT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/KITT_BRINGUP_RUNBOOK.md
@@ -174,6 +174,38 @@ specifically the tool-calling/truncation fixes are *welcome* — they harden the
 `{say, directive}` JSON contract; the smoketest confirms it. The FA4/vision gains
 don't reach the Orin — Ampere, text-only router.)
 
+### Update commands (copy-paste)
+
+**A — re-pull the same tag** (stealth in-place update, e.g. the Gemma-4 case):
+```bash
+cd ~/kirra-runtime-sdk
+ollama pull gemma3:4b                                              # new weights, same tag
+python3 robot/kitt_model_smoketest.py gemma3:4b --note "re-pull $(date -I)"   # RE-VET + re-pin
+sudo systemctl restart kirra-kitt-watch kirra-kitt-greet          # load them
+```
+No `robot.env` edit — the tag is unchanged. Boot speaks warning A5 if a re-pull
+ever slipped in unvetted.
+
+**B — switch to a different / bigger model:**
+```bash
+cd ~/kirra-runtime-sdk
+ollama pull gemma4:8b
+python3 robot/kitt_model_smoketest.py gemma4:8b --note "eval $(date -I)"      # gate the candidate
+sudo sed -i 's/^KIRRA_KITT_MODEL=.*/KIRRA_KITT_MODEL="gemma4:8b"/' /etc/kirra/robot.env
+sudo systemctl restart kirra-kitt-watch kirra-kitt-greet
+```
+Then measure end-to-end latency (`KITT_AUDIO_STACK.md` §5) — bigger = slower/more VRAM.
+
+**C — check anytime (no LLM call, no change):**
+```bash
+python3 robot/kitt_model_smoketest.py --pin-check
+#   OK → running digest == vetted pin | CHANGED → stealth update, re-run A | UNPINNED → vet once
+```
+Needs Ollama up (`ollama serve`) + `python3-requests`. Doer-quality gate only —
+the checker is untouched by any model change. The unattended OTA timer checks for
+a governed *software* update (`kirra-ota-ctl pull`); it never touches LLM weights
+— updating Gemma is always this deliberate pull + re-vet.
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |


### PR DESCRIPTION
## What

Adds a **"Update commands (copy-paste)"** block to `KITT_BRINGUP_RUNBOOK.md` →
"Swapping the LLM", covering the three real scenarios for updating Gemma (or any
model), grounded in `robot/kitt_model_smoketest.py` + the digest pin:

- **A — re-pull the same tag** (the Gemma-4 "no version bump" stealth update):
  `ollama pull` → re-vet with the smoketest (re-pins the new digest) → restart
  the KITT units. No `robot.env` edit; boot warns (A5) if a re-pull ever slipped
  in unvetted.
- **B — switch to a different/bigger model:** pull → gate the candidate → flip
  `KIRRA_KITT_MODEL` → restart → measure latency/VRAM.
- **C — `--pin-check`:** verify the running digest vs the vetted pin with no LLM
  call.

Restates the invariant: it's a **doer-quality** gate (the checker is untouched by
any model change), and the unattended OTA timer checks for a governed *software*
update — never LLM weights.

## Safety

Docs only. No code, no safety-spine impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_