### PR TITLE
docs: sync CLAUDE.md + READMEs with the robot/KITT + Autoware-isolation code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -655,6 +655,70 @@ the harness CSV carries `wcet_status = TBD-QNX-TARGET`).
 
 ---
 
+## Robot Side — R2 / KITT operator & doer layer (`robot/`)
+
+`robot/` is the **doer-side operator layer** for the Rosmaster R2 on Jetson Orin
+NX — Python scripts + install tooling, NOT a Cargo crate. It holds no safety
+authority: every actuation goes through the ADR-0033 verify-token chokepoint, and
+every conversational path is fenced.
+
+**Governed drive chokepoint (ADR-0033):** `kirra_motor_consumer.py` (verifying
+consumer — reads the Ed25519 release token, verifies via `kirra_ffi.py` ctypes →
+`libkirra_consumer_ffi.so`, NO crypto in Python, then drives) + `r2_drive.py`
+(the pure R2 Path-B Ackermann last-hop — `translate`/`odom_step`, host-tested in
+`r2_drive_test.py`; `KIRRA_DRIVE_MODE=r2_ackermann` = set_motor + AKM steering,
+bypassing the broken X3 firmware mixer). Consumer `/odom` gated by
+`KIRRA_R2_ODOM_ENABLED`.
+
+**KITT — the conversational operator layer** (`docs/hardware/KITT_CONVERSATION_DESIGN.md`).
+Two output channels, only one reaches the wheels:
+- **Channel A (SPEAK)** — pure speech, zero actuation authority: `kitt_ask.py`
+  (grounded Q&A), `kitt_converse.py` (multi-turn persona + router), `kitt_watch.py`
+  (proactive posture/deny narration), `kitt_boot.py` (posture-gated boot greeting
+  + shutdown).
+- **Channel B (ACT)** — the ONLY motion path: a movement directive's TEXT → mick
+  `POST /intent` → `MickIntent::parse_llm_json` → Occy → the KIRRA checker. KITT
+  never builds an intent, a Twist, or a token. 🔴 Single-door invariant: system
+  commands (OTA) do NOT ride the movement door.
+- `kitt_persona.py` — shared stdlib-only helpers: the `{name}` slot
+  (`operator_name`/`name_slot`), `speak()`, and the LLM model pin
+  (`read/write_model_pin`, `classify_model_pin`).
+- The doer LLM is local Ollama (`KIRRA_KITT_MODEL`, default `gemma3:4b`);
+  STT = whisper.cpp, TTS = piper (`docs/hardware/KITT_AUDIO_STACK.md`, incl. the
+  systemd-audio caveat). Deterministic (NON-LLM) speech — OTA (`kitt_ota.py`),
+  proactive (`kitt_watch.py`), boot (`kitt_boot.py`) — are templates fired by real
+  events. Every spoken line is catalogued in `docs/kitt/KITT_VOICE_LINES.md`.
+
+**Model-swap discipline** (the doer LLM is swappable with ZERO safety re-review —
+the checker is model-agnostic): `kitt_model_smoketest.py` is the doer-contract
+gate — fires canned utterances through the REAL router contract (`STAGE2_SYSTEM` +
+`parse_reply`) and asserts JSON / drive→directive / chat→null / no-fabrication.
+On PASS it pins the model's Ollama **digest + vetted-at timestamp**
+(`~/.kirra_kitt_model.pin`) — the "no version bump" stealth-update guard;
+`--pin-check` compares, boot warns (voice line A5) on drift. Commands:
+`KITT_BRINGUP_RUNBOOK.md` → "Swapping the LLM". Pure logic host-tested in
+`kitt_voice_test.py`.
+
+**OTA voice check** (`kitt_ota.py` + `kirra-ota-check.timer`): "stage and ask" —
+`kirra-ota-ctl pull` stages only; applying is a deliberate health-gated `probe`
+(`docs/hardware/R2_OTA_VOICE_CHECK.md`). Never touches LLM weights.
+
+**Install** (`robot/install/`): `install_robot_units.sh` stages the KITT scripts +
+systemd units (`kirra-ros-stack`, `kirra-kitt-watch`, `kirra-kitt-greet`,
+`kirra-ota-check`) — STAGED, not enabled (validate wheels-up first:
+`R2_AUTOSTART_CHECKLIST.md`). Base-image install (verifying consumer + FFI +
+lidar): `robot/install/README.md`. Bring-up: `docs/hardware/KITT_BRINGUP_RUNBOOK.md`.
+
+**Autoware distro isolation (ADR-0036):** the Autoware AV-stack doer stays pinned
+to Ubuntu 22.04/Humble in its own container while the rest of the stack (ros2
+adapter, checker, Occy/Taj) moves to 24.04/Jazzy; they meet only on 5 curated,
+hash-verified boundary topics (`ros2_ws/src/autoware_*_msgs`). Occy does NOT
+replace Autoware's L4 breadth (localization / control / mature fused perception /
+HD-maps) — KIRRA is the checker that bounds it. Scaffold: `deploy/autoware-isolation/`
++ `scripts/curated_interface/crossdistro_hash_check.sh`.
+
+---
+
 ## Common Mistakes to Reject
 
 - Using `State<Arc<AppState>>` in handlers — correct type is `State<Arc<ServiceState>>`

--- a/README.md
+++ b/README.md
@@ -172,6 +172,16 @@ companions `KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md`, `KIRRA_BRINGUP_RUNBOOK.md`,
 and `KIRRA_QNX_CROSSCOMPILE.md`. (That file's `ADR-0001` prefix is independent of
 the numbered ODD-cap ADRs in the table above — a known naming overlap.)
 
+[`0036-autoware-distro-migration-occy-gap.md`](docs/adr/0036-autoware-distro-migration-occy-gap.md)
+records the Occy-vs-Autoware gap analysis and the decision for the Ubuntu
+22.04/Humble → 24.04/Jazzy transition: **keep Autoware** as the AV-stack doer
+(Occy does not cover its L4 breadth — localization, control, mature fused
+perception), **isolate it as the only component on Humble** in its own container,
+and move the rest of the stack (ros2 adapter, checker, Occy/Taj) to Jazzy now —
+meeting only on 5 curated, hash-verified boundary topics. The safety spine is
+`no_std`/ROS-agnostic, so this is a doer-side migration with no re-certification.
+Isolation scaffold: [`deploy/autoware-isolation/`](deploy/autoware-isolation/).
+
 ### Governor transport / QNX partition lane (EPIC #270)
 
 The governor command path is moving to **Rust end-to-end** on a QNX-resident

--- a/robot/install/README.md
+++ b/robot/install/README.md
@@ -6,6 +6,17 @@ during the 2026-07 bringup (first governed motion + TG30 lidar). This is the
 seed of the golden-image product and the backup that makes a reflash
 non-destructive (see `REFLASH.md`).
 
+> **Companion installer — the KITT / voice operator layer.** This README covers
+> the base-image install (the fenced verifying consumer + FFI + lidar). The
+> conversational **KITT** layer (voice, persona, proactive narration, OTA voice
+> check) is staged separately by `install_robot_units.sh`, which installs the
+> `kitt_*` scripts + the `kirra-ros-stack` / `kirra-kitt-watch` /
+> `kirra-kitt-greet` / `kirra-ota-check` units (STAGED, not enabled). See
+> `docs/hardware/KITT_BRINGUP_RUNBOOK.md` (bring-up), `KITT_AUDIO_STACK.md`
+> (STT/TTS + the systemd-audio caveat), and `docs/kitt/KITT_VOICE_LINES.md`
+> (every spoken line). KITT is Channel-A speech + the one fenced `/intent` door —
+> it carries no actuation authority.
+
 **Layer split (the honesty constraint):**
 
 - **Layer A (this directory, scripted)** — everything base-agnostic and


### PR DESCRIPTION
## What

Brings the top-level context docs in sync with code that had accumulated with no
mention in CLAUDE.md (which had **zero** coverage of the `robot/` operator layer).

- **`CLAUDE.md`** — new **"Robot Side — R2 / KITT operator & doer layer"** section
  documenting what's actually in the tree:
  - the ADR-0033 governed drive chokepoint (`kirra_motor_consumer` → `kirra_ffi`
    → the FFI verify core; `r2_drive` Path-B Ackermann last-hop);
  - the KITT conversational layer — Channel A (SPEAK, zero authority) vs the one
    fenced Channel-B `/intent` door; `kitt_ask`/`converse`/`watch`/`boot` + the
    shared `kitt_persona` helpers; the single-door invariant;
  - the **model-swap discipline** — `kitt_model_smoketest` + the digest+vetted-at
    pin (stealth-update guard, voice line A5);
  - the OTA voice check, the install units, and the ADR-0036 Autoware-on-Humble
    isolation.
- **`README.md`** — records **ADR-0036** next to the platform ADRs (keep Autoware,
  isolate it on Humble, move the rest to Jazzy; Occy doesn't cover Autoware's L4
  breadth; doer-side migration, no re-certification).
- **`robot/install/README.md`** — points to the companion KITT/voice unit
  installer (`install_robot_units.sh`) + the KITT bring-up / audio / voice-lines
  docs.

## Verification

Docs only. Every referenced file, script, unit, env var, and helper was checked
to exist in the current tree before writing (no aspirational claims).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_