### PR TITLE
website: fix mobile overlap in the "life of one command" timeline

### DIFF
--- a/website/_src/pages/index.mjs
+++ b/website/_src/pages/index.mjs
@@ -249,7 +249,7 @@ export const body = `
     <section id="lifecycle" aria-labelledby="h-life">
       <div class="container">
         <div class="grid grid--2" style="align-items:start;gap:48px">
-          <div class="section-head" style="position:sticky;top:calc(var(--nav-h) + 24px);margin-bottom:0">
+          <div class="section-head sticky-col">
             <p class="eyebrow" data-reveal>Data flow</p>
             <h2 id="h-life" data-reveal>The life of one command</h2>
             <p class="lede" data-reveal>From an AI's proposal to a verified actuator release — every stage is a

--- a/website/css/kirra.css
+++ b/website/css/kirra.css
@@ -516,6 +516,14 @@ table.tbl { width: 100%; border-collapse: collapse; font-size: 0.92rem; min-widt
 .tabs__panel h3 { margin-bottom: 8px; }
 .tabs__panel > p { color: var(--ink-2); }
 
+/* Sticky side column — only when the two-column layout actually exists;
+   on narrow viewports the grid stacks and a pinned heading would sit
+   under the scrolling content. */
+.sticky-col { margin-bottom: 0; }
+@media (min-width: 980px) {
+  .sticky-col { position: sticky; top: calc(var(--nav-h) + 24px); }
+}
+
 /* ---------- Timeline (scrolling data-flow) ---------- */
 .timeline { position: relative; padding-left: 36px; }
 .timeline::before {

--- a/website/index.html
+++ b/website/index.html
@@ -302,7 +302,7 @@
     <section id="lifecycle" aria-labelledby="h-life">
       <div class="container">
         <div class="grid grid--2" style="align-items:start;gap:48px">
-          <div class="section-head" style="position:sticky;top:calc(var(--nav-h) + 24px);margin-bottom:0">
+          <div class="section-head sticky-col">
             <p class="eyebrow" data-reveal>Data flow</p>
             <h2 id="h-life" data-reveal>The life of one command</h2>
             <p class="lede" data-reveal>From an AI's proposal to a verified actuator release — every stage is a


### PR DESCRIPTION
The section heading was `position: sticky` at all viewports; on mobile the grid stacks to one column, so the timeline scrolled up underneath the pinned heading (user-reported on the live site). Sticky now applies only at ≥980px where the two-column layout actually exists.

Verified headlessly: `.sticky-col` computes `static` at 390px (timeline scrolls cleanly, screenshot-checked) and `sticky` at 1440px (desktop behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7)_