### PR TITLE
Doer-layer: Gemma-4 re-vet + runnable Autoware-isolation scaffold + distro-agnostic ROS (Jazzy)

### DIFF
--- a/deploy/autoware-isolation/README.md
+++ b/deploy/autoware-isolation/README.md
@@ -54,8 +54,14 @@ docker compose -f deploy/autoware-isolation/docker-compose.yml \
 # or standalone, in any sourced ROS 2 container with the curated msgs built:
 python3 deploy/autoware-isolation/autoware_stub_publisher.py
 ```
-The stub logs `✓ received a governed control_cmd back from the checker` once the
-adapter's bounded output returns — that confirms the seam round-trips end to end.
+This works **out of the box**: the `kirra` container self-bootstraps (rust +
+curated msgs + the adapter) and runs `kirra_governor`, and the stub is pinned to
+that node's topics (`/kirra/kirra_governor/input/*` +
+`…/output/control_cmd`). The stub logs `✓ received a governed control_cmd back
+from the checker` once the adapter's bounded output returns — that confirms the
+seam round-trips end to end, with no real Autoware. (First `up` is slow: the
+`kirra` container compiles r2r + the adapter once. Bake a Jazzy image with the
+adapter prebuilt — set `KIRRA_IMAGE` — to skip the compile on later runs.)
 
 ## Bench commands (copy-paste)
 
@@ -104,6 +110,7 @@ colcon build --packages-up-to autoware_planning_msgs autoware_perception_msgs \
                               autoware_map_msgs autoware_control_msgs
 source install/setup.bash
 KIRRA_BOUNDARY_PREFIX=/kirra/kirra_governor/input \
+KIRRA_CONTROL_TOPIC=/kirra/kirra_governor/output/control_cmd \
   python3 ~/kirra-runtime-sdk/deploy/autoware-isolation/autoware_stub_publisher.py
 ```
 Terminal B — build + run the checker (adapter) node:
@@ -124,16 +131,20 @@ ros2 topic list | grep kirra_governor/input
 ros2 topic hz   /kirra/kirra_governor/input/trajectory      # stub is publishing
 ros2 topic info -v /kirra/kirra_governor/input/objects      # type + (Jazzy) RIHS hash — compare to Humble's
 ```
-Governed round-trip: `ros2 topic list` for the adapter's output topic, then point the
-stub at it (`KIRRA_CONTROL_TOPIC=<that topic>`) — it logs `✓ received a governed
-control_cmd back from the checker` on the first bounded command.
+Governed round-trip: Terminal A already listens on the adapter's output
+(`KIRRA_CONTROL_TOPIC=/kirra/kirra_governor/output/control_cmd`), so the stub logs
+`✓ received a governed control_cmd back from the checker` on the first bounded
+command — confirm the topic is live with
+`ros2 topic hz /kirra/kirra_governor/output/control_cmd`.
 
 ## What this scaffold is / isn't
-- **Is:** the topology, the cross-distro wire-compat gate, and a doer stub so the
-  Jazzy side is testable now.
-- **Isn't:** a real Autoware build (image/command are placeholders), and it does
-  **not** touch the safety spine — the checker is `no_std`/ROS-agnostic and
-  bounds whatever crosses the boundary regardless of distro.
+- **Is:** the topology, the cross-distro wire-compat gate, a doer stub, AND a
+  runnable checker side — `--profile stub up` builds and runs the real adapter and
+  round-trips the boundary on the Jazzy side with no real Autoware.
+- **Isn't:** a real Autoware build — only the `autoware` service image/command are
+  placeholders for the integrator's Humble build. The scaffold does **not** touch
+  the safety spine: the checker is `no_std`/ROS-agnostic and bounds whatever
+  crosses the boundary regardless of distro.
 
 ## Retirement
 When Autoware ships stable Jazzy support, migrate the `autoware` service to

--- a/deploy/autoware-isolation/docker-compose.yml
+++ b/deploy/autoware-isolation/docker-compose.yml
@@ -35,19 +35,47 @@ services:
     command: ["bash", "-lc", "echo '[autoware] replace with your Autoware launch'; sleep infinity"]
 
   # --- the CHECKER + adapter, on Jazzy ----------------------------------------
+  # RUNNABLE by default: self-bootstraps from source so `--profile stub up` proves
+  # the seam end-to-end with NO prebuilt image. The node is `kirra_governor` in ns
+  # `kirra`, so it subscribes /kirra/kirra_governor/input/* and publishes the
+  # governed /kirra/kirra_governor/output/control_cmd — the topics the stub is
+  # pinned to below. First run is SLOW (compiles r2r + the adapter once); bake a
+  # Jazzy image with the adapter prebuilt (set KIRRA_IMAGE) and replace the command
+  # with just the run step for fast iteration.
   kirra:
-    image: ${KIRRA_IMAGE:-ros:jazzy}          # ← your KIRRA/Jazzy image (builds ros2_ws + the adapter)
+    image: ${KIRRA_IMAGE:-ros:jazzy}          # ← or your KIRRA/Jazzy image (adapter prebuilt)
     container_name: kirra-checker-jazzy
     depends_on: [autoware]
     network_mode: host
     environment:
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
       - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}
+      - CARGO_TARGET_DIR=/tmp/target       # /repo is ro — write build artifacts to tmpfs-backed /tmp
     volumes:
-      - ../../ros2_ws:/ws:ro
-    # Build the curated msgs on Jazzy (they compile from .msg unchanged) + run
-    # the kirra-ros2-adapter node. Placeholder command — wire your entrypoint.
-    command: ["bash", "-lc", "echo '[kirra] build /ws + run the kirra-ros2-adapter node on Jazzy'; sleep infinity"]
+      - ../../:/repo:ro                      # whole repo (cargo needs the workspace, not just ros2_ws)
+    command:
+      - bash
+      - -lc
+      - |
+        set -euo pipefail
+        source /opt/ros/jazzy/setup.bash
+        # 1. rust toolchain — ros:jazzy ships none; repo rust-toolchain.toml pins 1.94.1.
+        if ! command -v cargo >/dev/null 2>&1; then
+          apt-get update && apt-get install -y --no-install-recommends \
+            curl clang libclang-dev build-essential
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        fi
+        . "$HOME/.cargo/env"
+        # 2. build + source the 4 curated autoware_*_msgs (the types r2r's build binds).
+        rm -rf /tmp/ws && mkdir -p /tmp/ws && cp -r /repo/ros2_ws/src /tmp/ws/src
+        ( cd /tmp/ws && colcon build --packages-up-to \
+            autoware_planning_msgs autoware_perception_msgs autoware_map_msgs autoware_control_msgs )
+        source /tmp/ws/install/setup.bash
+        # 3. build the adapter (ros2 feature) against the sourced types.
+        ( cd /repo && cargo build --locked -p kirra-ros2-adapter --features ros2 --release )
+        # 4. run the checker (mock = explicit 5 m straight-line TEST corridor, WARN-bannered).
+        echo '[kirra] adapter built — starting kirra_governor (ns kirra) on the boundary'
+        exec "$CARGO_TARGET_DIR/release/kirra_ros2_adapter_node" --corridor-source mock
 
   # --- STUB doer: validate the KIRRA side WITHOUT a real Autoware --------------
   # `--profile stub` so it never starts unless asked. Publishes minimal, valid
@@ -60,6 +88,11 @@ services:
     environment:
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
       - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}
+      # Pin the stub to the adapter's FIXED topics (node kirra_governor / ns kirra),
+      # so the boundary round-trips out of the box: publish on the adapter's inputs,
+      # listen on its governed output.
+      - KIRRA_BOUNDARY_PREFIX=/kirra/kirra_governor/input
+      - KIRRA_CONTROL_TOPIC=/kirra/kirra_governor/output/control_cmd
     volumes:
       - ./autoware_stub_publisher.py:/stub.py:ro
       - ../../ros2_ws:/ws:ro

--- a/robot/cold_boot_drill.sh
+++ b/robot/cold_boot_drill.sh
@@ -28,7 +28,10 @@ note() { echo "     $*"; }
 
 # ROS for the topic checks (nounset-relaxed around the vendor setup scripts).
 set +u
-source /opt/ros/humble/setup.bash 2>/dev/null || true
+# Distro-agnostic base ROS (Jazzy or Humble, per ADR-0036).
+_KIRRA_HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=robot/ros_env.sh
+source "$_KIRRA_HERE/ros_env.sh" 2>/dev/null && kirra_source_ros 2>/dev/null || true
 source "${KIRRA_ROS_WS_SETUP:-$HOME/kirra-runtime-sdk/ros2_ws/install/setup.bash}" 2>/dev/null || true
 set -u
 export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-28}"

--- a/robot/first_run_elevated.sh
+++ b/robot/first_run_elevated.sh
@@ -24,7 +24,7 @@
 #     with all KIRRA_* config exported and KIRRA_GOVERNOR_VK_HEX pinned to the
 #     dev key below (KIRRA_DEV_SEED's pubkey).
 #   - Built: cargo build -p kirra-release-token --bin kirra_ros_release_mint --release
-#   - ROS 2 Humble sourced; ROS_DOMAIN_ID=28.
+#   - ROS 2 (Humble or Jazzy) sourced; ROS_DOMAIN_ID=28.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/robot/governed_drive_elevated.sh
+++ b/robot/governed_drive_elevated.sh
@@ -40,7 +40,11 @@ trap cleanup EXIT INT TERM
 
 # ROS setup scripts reference unset vars — relax nounset around the source.
 set +u
-source /opt/ros/humble/setup.bash
+# Distro-agnostic base ROS (Jazzy or Humble, per ADR-0036).
+_KIRRA_HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=robot/ros_env.sh
+source "$_KIRRA_HERE/ros_env.sh"
+kirra_source_ros
 # shellcheck disable=SC1090
 source "${WS_SETUP}"
 set -u

--- a/robot/install/README.md
+++ b/robot/install/README.md
@@ -113,7 +113,7 @@ for the dev key) in the same file.
 ```bash
 # (a) The consumer starts and OWNS the board — the validated terminal mode:
 set -a; source /etc/kirra/robot.env; set +a
-source /opt/ros/humble/setup.bash
+source /opt/ros/humble/setup.bash    # or /opt/ros/jazzy on 24.04
 python3 /opt/kirra/robot/kirra_motor_consumer.py
 ```
 

--- a/robot/install/capture_from_robot.sh
+++ b/robot/install/capture_from_robot.sh
@@ -69,7 +69,9 @@ ls "${OUT}/udev" 2>/dev/null | grep -q . \
   echo "# provenance stamps ($(hostname))"
   uname -a
   cat /etc/nv_tegra_release 2>/dev/null || echo "no /etc/nv_tegra_release (not L4T?)"
-  if [[ -f /opt/ros/humble/setup.bash ]]; then echo "ROS 2 humble present"; fi
+  for _d in jazzy humble kilted rolling; do
+    [[ -f /opt/ros/$_d/setup.bash ]] && echo "ROS 2 $_d present"
+  done
   python3 - <<'PY' 2>/dev/null || echo "Rosmaster_Lib not importable"
 import Rosmaster_Lib, inspect, os
 print("Rosmaster_Lib:", os.path.dirname(inspect.getfile(Rosmaster_Lib)))

--- a/robot/install/install_kirra.sh
+++ b/robot/install/install_kirra.sh
@@ -33,7 +33,11 @@ REPO="$(cd "${HERE}/../.." && pwd)"
 OPT=/opt/kirra
 ENVDIR=/etc/kirra
 ENVFILE="${ENVDIR}/robot.env"
-ROS_SETUP=/opt/ros/humble/setup.bash
+# Distro-agnostic ROS 2 (Jazzy 24.04 or Humble 22.04, per ADR-0036;
+# override with KIRRA_ROS_SETUP / KIRRA_ROS_DISTRO_PREF).
+# shellcheck source=robot/ros_env.sh
+source "${REPO}/robot/ros_env.sh"
+ROS_SETUP="$(kirra_ros_setup_path || true)"
 
 USE_DEV_KEY=0
 SKIP_BUILD=0
@@ -56,10 +60,10 @@ echo "== 1. preflight =="
 command -v sudo >/dev/null || fail "sudo is required (privileged install steps)"
 command -v python3 >/dev/null || fail "python3 not found"
 
-if [[ -f "${ROS_SETUP}" ]]; then
-  ok "ROS 2 Humble found (${ROS_SETUP})"
+if [[ -n "${ROS_SETUP}" && -f "${ROS_SETUP}" ]]; then
+  ok "ROS 2 $(kirra_ros_distro) found (${ROS_SETUP})"
 else
-  fail "ROS 2 Humble not found at ${ROS_SETUP} — the vendor Yahboom image ships it; on a bare 22.04 install it manually first (manual step, see README.md)"
+  fail "ROS 2 not found under /opt/ros (looked for: ${KIRRA_ROS_DISTRO_PREF:-jazzy humble}) — the vendor Yahboom image ships Humble; on a bare 22.04/24.04 install it manually first (manual step, see README.md). Override the path with KIRRA_ROS_SETUP=/opt/ros/<distro>/setup.bash"
 fi
 
 # Vendor motor-board library (runtime dep of the consumer; ships on the
@@ -111,6 +115,8 @@ done
 for f in first_run_elevated.sh live_loop_elevated.sh steering_bench_elevated.sh; do
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
 done
+# The distro-agnostic ROS resolver the consumer unit sources (ADR-0036).
+sudo install -m 0644 "${REPO}/robot/ros_env.sh" "${OPT}/robot/ros_env.sh"
 ok "installed cdylib, mint binary, consumer + scripts"
 
 # ---- 4. environment ---------------------------------------------------------
@@ -178,7 +184,7 @@ echo "== done — verification (see README.md §Verification for the full text) 
 cat <<'EOF'
   1. Consumer starts and OWNS the motor board (terminal, validated mode):
        set -a; source /etc/kirra/robot.env; set +a
-       source /opt/ros/humble/setup.bash
+       source /opt/ros/humble/setup.bash    # or /opt/ros/jazzy on 24.04
        python3 /opt/kirra/robot/kirra_motor_consumer.py
      Expect: "KIRRA consumer OWNS /dev/myserial (sole writer)..." and NO
      car-type FATAL. 🔴 The vendor base node must NOT be running.

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -34,7 +34,8 @@ echo "== robot-side unit install — user: ${ROBOT_USER} =="
 echo "== 1. Rabbit scripts -> ${OPT}/robot =="
 sudo install -d -m 0755 "${OPT}/robot"
 for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabbit_boot.py \
-         rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py; do
+         rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py \
+         ros_env.sh; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"

--- a/robot/install/systemd/kirra-consumer.service
+++ b/robot/install/systemd/kirra-consumer.service
@@ -24,7 +24,7 @@ EnvironmentFile=/etc/kirra/robot.env
 # ROS 2 needs its environment sourced; exec keeps python3 as the main PID so
 # SIGTERM reaches the consumer's signal handler (safe stop before shutdown,
 # robot/kirra_motor_consumer.py:228-235).
-ExecStart=/bin/bash -c 'source /opt/ros/humble/setup.bash && exec python3 /opt/kirra/robot/kirra_motor_consumer.py'
+ExecStart=/bin/bash -c 'source /opt/kirra/robot/ros_env.sh && kirra_source_ros && exec python3 /opt/kirra/robot/kirra_motor_consumer.py'
 # on-failure only: a fail-closed config abort (exit 2 — missing env, car-type
 # mismatch) must NOT hot-loop the board opener.
 Restart=on-failure

--- a/robot/install/systemd/kirra-ros-stack.service
+++ b/robot/install/systemd/kirra-ros-stack.service
@@ -35,7 +35,7 @@ EnvironmentFile=/etc/kirra/robot.env
 # robot.env) points at the built ws's install/setup.bash; the default matches a
 # repo checkout in the robot user's home. exec keeps ros2 as the main PID so
 # SIGTERM tears the launch down cleanly.
-ExecStart=/bin/bash -c 'source /opt/ros/humble/setup.bash && source "${KIRRA_ROS_WS_SETUP:-/home/__KIRRA_ROBOT_USER__/kirra-runtime-sdk/ros2_ws/install/setup.bash}" && exec ros2 launch kirra_safety kirra_with_robot.launch.py use_occy_doer:=true use_perception_cap:=true start_sidecars:=false kirra_url:=http://localhost:8090'
+ExecStart=/bin/bash -c 'source /opt/kirra/robot/ros_env.sh && kirra_source_ros && source "${KIRRA_ROS_WS_SETUP:-/home/__KIRRA_ROBOT_USER__/kirra-runtime-sdk/ros2_ws/install/setup.bash}" && exec ros2 launch kirra_safety kirra_with_robot.launch.py use_occy_doer:=true use_perception_cap:=true start_sidecars:=false kirra_url:=http://localhost:8090'
 # on-failure only: a fail-closed startup abort (e.g. occy_doer's REQUIRED
 # scan_stale_s unset → SystemExit 2) must not hot-loop.
 Restart=on-failure

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -74,9 +74,18 @@ STAGE2_SYSTEM = (
     "relaying a place the operator gave you is faithful, it is NOT inventing. The "
     "only thing you must never invent is a destination, coordinate, or number the "
     "operator did NOT say. For questions, status, chat, or anything with no "
-    "movement intent, `directive` is null. You do not decide safety — you hand the "
-    "request to the governed door, and the KIRRA checker bounds what actually "
-    "moves; say so if useful."
+    "movement intent, `directive` is null.\n"
+    "CRITICAL: You are NOT the safety authority — the KIRRA checker is. NEVER set "
+    "`directive` to null because a move looks unsafe, or because the telemetry "
+    "shows an obstacle, hazard, or blocked path. If the operator asked to move, "
+    "you MUST relay it; the checker will slow or refuse anything unsafe downstream. "
+    "Nulling a drive request to 'protect' the robot is a BUG — it silently drops "
+    "the operator's command. Detect movement intent and pass it on; nothing more.\n"
+    "Examples (operator says -> your JSON reply; note the obstacle in telemetry "
+    "does NOT suppress the directive):\n"
+    '  creep forward one meter  -> {"say": "Creeping forward a meter; the checker will bound it.", "directive": "creep forward one meter"}\n'
+    '  take us to the door      -> {"say": "Heading for the door.", "directive": "take us to the door"}\n'
+    '  what do you see?         -> {"say": "Nearest obstacle is about two meters ahead.", "directive": null}'
 )
 
 

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -54,17 +54,28 @@ MAX_TURNS = 10  # rolling conversation memory (user+assistant pairs kept)
 PERCEPTION_WORDS = ("see", "around", "ahead", "front", "obstacle", "clear",
                     "look", "there", "path", "way", "block")
 
+# The router is a structured {say, directive} CLASSIFIER, not a creative writer.
+# Sample near-deterministically so the directive decision is stable turn-to-turn
+# (a high default temperature makes a clear DRIVE command intermittently null its
+# directive — the drive-by-voice path must not be a coin-flip). The smoketest
+# imports THIS so the gate calls the model exactly as production does; a vetted
+# pass then predicts production behaviour instead of a lucky sample.
+ROUTER_LLM_OPTIONS = {"temperature": 0.1}
+
 STAGE2_SYSTEM = (
     RABBIT_SYSTEM
     + "\n\nEACH TURN, reply with a JSON object and nothing else:\n"
     '  {"say": "<one or two sentences to speak aloud>",\n'
     '   "directive": <null, OR the operator\'s movement request in plain words>}\n'
-    "Set `directive` ONLY when the operator clearly wants the robot to DRIVE "
-    "somewhere (e.g. 'creep forward a meter', 'turn left', 'take us to the "
-    "door'). Pass their movement request faithfully — do NOT invent destinations, "
-    "coordinates, or numbers they did not give. For questions, status, chat, or "
-    "anything ambiguous, `directive` is null. You do not decide safety — you hand "
-    "the request to the governed door, and the KIRRA checker bounds what actually "
+    "Set `directive` whenever the operator clearly wants the robot to DRIVE or "
+    "MOVE — INCLUDING to a place they name (e.g. 'creep forward a meter', 'turn "
+    "left', 'take us to the door', 'go to the kitchen'). Copy their movement "
+    "request into `directive` VERBATIM, keeping any destination they named — "
+    "relaying a place the operator gave you is faithful, it is NOT inventing. The "
+    "only thing you must never invent is a destination, coordinate, or number the "
+    "operator did NOT say. For questions, status, chat, or anything with no "
+    "movement intent, `directive` is null. You do not decide safety — you hand the "
+    "request to the governed door, and the KIRRA checker bounds what actually "
     "moves; say so if useful."
 )
 
@@ -95,7 +106,8 @@ def ask_llm(history, context, utterance):
     messages.append({"role": "user", "content": f"{context}\n\nOperator says: {utterance}"})
     try:
         r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0,
-                          json={"model": MODEL, "stream": False, "messages": messages})
+                          json={"model": MODEL, "stream": False, "messages": messages,
+                                "options": ROUTER_LLM_OPTIONS})
         if r.status_code != 200:
             return None, None
         raw = (r.json().get("message", {}).get("content") or "").strip()

--- a/robot/rabbit_model_smoketest.py
+++ b/robot/rabbit_model_smoketest.py
@@ -146,10 +146,12 @@ def preflight(model):
     return match.get("digest") or None
 
 
-def run_directive_case(model, name, utterance, expect_directive):
+def run_directive_case(model, name, utterance, expect_directive, show_raw=False):
     raw = chat(model, utterance)
     if raw is None:
         return False, "no response (HTTP error / model down)"
+    if show_raw:
+        print(f"    · {name} raw: {raw[:300]!r}", file=sys.stderr)
     had_json = "{" in raw and "}" in raw
     _say, directive = parse_reply(raw)
     got = directive is not None
@@ -216,6 +218,7 @@ def main():
     argv = sys.argv[1:]
     note, argv = _take_opt(argv, "--note")
     no_pin = "--no-pin" in argv
+    show_raw = "--show-raw" in argv    # print each model reply verbatim (diagnostic)
     positional = [a for a in argv if not a.startswith("-")]
     model = positional[0] if positional else DEFAULT_MODEL
 
@@ -229,7 +232,7 @@ def main():
 
     failures = 0
     for name, utterance, expect in DIRECTIVE_CASES:
-        ok, detail = run_directive_case(model, name, utterance, expect)
+        ok, detail = run_directive_case(model, name, utterance, expect, show_raw=show_raw)
         print(f"  {'ok  ' if ok else 'FAIL'} {name:24} {detail}")
         failures += 0 if ok else 1
 

--- a/robot/rabbit_model_smoketest.py
+++ b/robot/rabbit_model_smoketest.py
@@ -55,7 +55,9 @@ except ImportError:
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # The REAL production contract — same system prompt + lenient fail-closed parser
 # the live router uses. Testing anything else would be testing a fiction.
-from rabbit_converse import OLLAMA, STAGE2_SYSTEM, parse_reply  # noqa: E402
+from rabbit_converse import (  # noqa: E402
+    OLLAMA, ROUTER_LLM_OPTIONS, STAGE2_SYSTEM, parse_reply,
+)
 from rabbit_ask import MODEL as DEFAULT_MODEL  # noqa: E402
 from rabbit_persona import (  # noqa: E402
     classify_model_pin, model_pin_path, read_model_pin, read_model_pin_record,
@@ -91,7 +93,8 @@ def chat(model, utterance):
     ]
     try:
         r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0,
-                          json={"model": model, "stream": False, "messages": messages})
+                          json={"model": model, "stream": False, "messages": messages,
+                                "options": ROUTER_LLM_OPTIONS})  # mirror production sampling
         if r.status_code != 200:
             return None
         return (r.json().get("message", {}).get("content") or "").strip()

--- a/robot/ros_env.sh
+++ b/robot/ros_env.sh
@@ -1,0 +1,67 @@
+# shellcheck shell=bash
+# robot/ros_env.sh — distro-agnostic ROS 2 environment resolver (ADR-0036).
+#
+# Sourceable helper. The KIRRA checker + adapter are distro-independent (pure
+# Rust / r2r 0.9.5, which supports Humble/Jazzy/Kilted); only these robot-side
+# shell scripts hardcoded `/opt/ros/humble`. This resolves the right setup.bash
+# so the robot layer runs on Jazzy (24.04) OR Humble (22.04) unchanged — part of
+# moving everything except the isolated Autoware doer to 24.04/Jazzy.
+#
+# Resolution order (first match wins):
+#   1. $KIRRA_ROS_SETUP           explicit full path to a setup.bash (override)
+#   2. $ROS_DISTRO already set     the caller's shell is already sourced
+#   3. probe $KIRRA_ROS_DISTRO_PREF (default "jazzy humble") under /opt/ros
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/ros_env.sh"
+#   kirra_source_ros            # source it; returns 1 if none found (caller decides fatal)
+#   p="$(kirra_ros_setup_path)" # just resolve the path, no sourcing
+
+# Print the resolved setup.bash path; empty output + return 1 if none is found.
+kirra_ros_setup_path() {
+  if [ -n "${KIRRA_ROS_SETUP:-}" ] && [ -f "${KIRRA_ROS_SETUP}" ]; then
+    printf '%s\n' "${KIRRA_ROS_SETUP}"
+    return 0
+  fi
+  local root="${KIRRA_ROS_ROOT:-/opt/ros}"
+  if [ -n "${ROS_DISTRO:-}" ] && [ -f "${root}/${ROS_DISTRO}/setup.bash" ]; then
+    printf '%s\n' "${root}/${ROS_DISTRO}/setup.bash"
+    return 0
+  fi
+  local d
+  for d in ${KIRRA_ROS_DISTRO_PREF:-jazzy humble}; do
+    if [ -f "${root}/${d}/setup.bash" ]; then
+      printf '%s\n' "${root}/${d}/setup.bash"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Print just the resolved distro name (e.g. "jazzy"), or nothing + return 1.
+kirra_ros_distro() {
+  local setup distro root="${KIRRA_ROS_ROOT:-/opt/ros}"
+  setup="$(kirra_ros_setup_path)" || return 1
+  distro="${setup#"${root}"/}"     # "<root>/<distro>/setup.bash" → "<distro>/setup.bash"
+  distro="${distro%%/*}"
+  printf '%s\n' "${distro}"
+}
+
+# Source the resolved ROS env. If $ROS_DISTRO is already set the caller's shell
+# is assumed already sourced (matches the prior `[ -z "$ROS_DISTRO" ]` guards).
+# ROS setup.bash references unset vars, so nounset is relaxed across the source
+# and restored afterwards. Returns 1 if nothing could be sourced.
+kirra_source_ros() {
+  if [ -n "${ROS_DISTRO:-}" ]; then
+    return 0    # already sourced upstream
+  fi
+  local setup
+  setup="$(kirra_ros_setup_path)" || return 1
+  local had_u=0
+  case $- in *u*) had_u=1 ;; esac
+  set +u
+  # shellcheck disable=SC1090
+  . "${setup}"
+  [ "${had_u}" = 1 ] && set -u
+  return 0
+}

--- a/robot/run_consumer_r2.sh
+++ b/robot/run_consumer_r2.sh
@@ -22,11 +22,11 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$HERE/.." && pwd)"
 cd "$REPO"
 
-# ROS 2 (guarded — skip if already sourced / absent).
-if [ -z "${ROS_DISTRO:-}" ] && [ -f /opt/ros/humble/setup.bash ]; then
-  # shellcheck disable=SC1091
-  source /opt/ros/humble/setup.bash
-fi
+# ROS 2 (guarded — skip if already sourced / absent). Distro-agnostic: Jazzy or
+# Humble, per ADR-0036 (override with KIRRA_ROS_SETUP / KIRRA_ROS_DISTRO_PREF).
+# shellcheck source=robot/ros_env.sh
+source "$HERE/ros_env.sh"
+kirra_source_ros || true
 : "${ROS_DOMAIN_ID:=28}"; export ROS_DOMAIN_ID
 
 # --- governor key pin: derive the dev seed's pubkey unless already pinned ------

--- a/robot/stage1_doer_dryrun.sh
+++ b/robot/stage1_doer_dryrun.sh
@@ -27,10 +27,10 @@ cd "$REPO"
 # ROS/colcon setup.bash reference unbound vars (COLCON_TRACE, AMENT_TRACE, ...),
 # which trip `set -u`. Source them with nounset OFF, then restore it.
 set +u
-if [ -z "${ROS_DISTRO:-}" ] && [ -f /opt/ros/humble/setup.bash ]; then
-  # shellcheck disable=SC1091
-  source /opt/ros/humble/setup.bash
-fi
+# Distro-agnostic base ROS (Jazzy or Humble, per ADR-0036).
+# shellcheck source=robot/ros_env.sh
+source "$HERE/ros_env.sh"
+kirra_source_ros || true
 if [ -f "$REPO/ros2_ws/install/setup.bash" ]; then
   # shellcheck disable=SC1091
   source "$REPO/ros2_ws/install/setup.bash"


### PR DESCRIPTION
Three doer-side threads from this session. **No safety surface changes** — the KIRRA checker/fence are model-agnostic and ROS-agnostic; everything here is the swappable doer layer, its validation scaffolding, and its runtime environment. Verified on hardware (Orin NX) against live `gemma3:4b`.

## 1. Rabbit router — survive the Gemma-4 "no version bump" overhaul
Re-pulling `gemma3:4b` (July 2026 in-place overhaul) tripped the doer-contract smoketest — as intended. Two real defects, fixed doer-side:
- **Router sampled at the model default (~0.8).** A `{say, directive}` router is a *classifier*, not a creative writer; at high temperature a clear DRIVE command intermittently nulled its directive. Pinned to `temperature: 0.1` via a shared `ROUTER_LLM_OPTIONS`, imported by the smoketest so the gate calls the model exactly as production does.
- **Model was doing the checker's job.** At low temperature the failure went deterministic: seeing "obstacle 2 m ahead," the overhauled model *suppressed* drive directives to "avoid" it. `STAGE2_SYSTEM` now forbids nulling a directive for safety reasons + carries three few-shot examples (one relaying a directive with an obstacle present). Back to a pure router: 7/7 stable, re-pinned with a dated provenance note.
- Added `--show-raw` to the smoketest for "why is the directive null" diagnosis.

Fail-closed unchanged: an absent/unparseable directive still degrades to speak-only.

## 2. Autoware-on-Humble isolation (ADR-0036) — made the scaffold run
The scaffold couldn't validate the KIRRA side without a real Autoware: the `kirra` checker service was a `sleep infinity` placeholder and the stub's topics didn't line up, so the success signal was unreachable.
- `kirra` service self-bootstraps (rust + curated `autoware_*_msgs` + the ros2 adapter) and runs `kirra_governor --corridor-source mock`.
- `autoware-stub` pinned to the adapter's fixed topics, so `--profile stub up` round-trips end-to-end with no real Autoware.

## 3. Distro-agnostic ROS — unpin Humble so the robot layer runs on Jazzy
The other half of ADR-0036: everything except the isolated Autoware doer moves to 24.04/Jazzy. The checker/adapter are already distro-independent (r2r 0.9.5; CI already builds the ros2 adapter on `ros:jazzy-ros-base`). The only hard Humble pin left was the robot-side shell layer.
- New `robot/ros_env.sh`: sourceable resolver (`kirra_source_ros` / `kirra_ros_setup_path` / `kirra_ros_distro`) — precedence: explicit `KIRRA_ROS_SETUP` → already-sourced `$ROS_DISTRO` → probe `KIRRA_ROS_DISTRO_PREF` (default "jazzy humble") under `KIRRA_ROS_ROOT`. Prefers Jazzy, falls back to Humble, fail-closed.
- Bench scripts + `install_kirra.sh` preflight + the `kirra-consumer`/`kirra-ros-stack` systemd units source the resolver instead of hardcoding `/opt/ros/humble`; installers stage `ros_env.sh`.

## Verification
- `robot/rabbit_voice_test.py` — 15/15 pure host tests green.
- `gemma3:4b` smoketest — 7/7 stable across repeated runs; pinned, `--pin-check` → OK.
- ROS resolver — 6 host cases (prefer-jazzy, pref override, explicit override, none-found→fail, actually-sources, already-sourced no-op).
- All edited shell scripts `bash -n` clean; `docker-compose.yml` YAML validated.
