### PR TITLE
deploy/orin-jazzy: containerize the Jazzy safety spine for a JetPack-6 Orin host (ADR-0036 Step 3)

### DIFF
--- a/deploy/orin-jazzy/Dockerfile
+++ b/deploy/orin-jazzy/Dockerfile
@@ -1,0 +1,75 @@
+# Orin Jazzy runtime (ADR-0036, Step 3) — the robot-side KIRRA stack on ROS 2
+# Jazzy, built to run INSIDE a container on a JetPack-6 / Ubuntu-22.04 / Humble
+# Orin host. This decouples the stack from L4T: the host stays on whatever
+# JetPack ships (Humble), while the checker/adapter/governed-consumer speak Jazzy
+# in the container. They meet the host's Humble ROS graph (and the isolated
+# Autoware doer) only over DDS — same cross-distro wire story as the Autoware
+# isolation, inverted (here Jazzy is the guest).
+#
+# SCOPE — the CPU-only safety spine: the ros2 adapter (checker), the ADR-0033
+# governed motor consumer + its verify-core FFI, the curated autoware_*_msgs, and
+# the robot Channel-A layer. GPU doers (parko TensorRT/camera perception) are NOT
+# here — they need an nvcr.io/nvidia/l4t-jetpack-based Jazzy image and are a
+# follow-up; the safety path needs no CUDA, so a plain ros:jazzy base runs on the
+# Orin's aarch64 today.
+#
+# ros:jazzy-ros-base is multi-arch (arm64 present) → builds/runs natively on Orin.
+# Digest-pinned by Dependabot (`docker` ecosystem); tag kept for readability.
+FROM ros:jazzy-ros-base
+
+SHELL ["/bin/bash", "-c"]
+
+# Toolchain: rust (r2r's bindgen needs libclang), colcon, rosdep, build-essential.
+# rustup installs the repo-pinned toolchain from rust-toolchain.toml at build.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential clang libclang-dev curl git pkg-config \
+      python3-colcon-common-extensions python3-rosdep python3-pip python3-serial \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /opt/kirra/src
+COPY . .
+# Honor the repo toolchain pin (rust-toolchain.toml) for a reproducible build.
+RUN rustup show
+
+# 1. Build + install the curated autoware_*_msgs + kirra_safety into a ROS overlay.
+#    rosdep resolves kirra_safety's deps; the 4 curated msgs build from .msg alone.
+RUN source /opt/ros/jazzy/setup.bash \
+    && (rosdep update || true) \
+    && cd ros2_ws \
+    && (rosdep install --from-paths src --ignore-src -r -y || \
+        echo '[warn] rosdep partial — curated msgs still build from .msg') \
+    && colcon build --packages-up-to \
+         autoware_planning_msgs autoware_perception_msgs \
+         autoware_map_msgs autoware_control_msgs kirra_safety \
+    && cp -a install /opt/kirra/ros2_ws_install
+
+# 2. Build the ros2 adapter (checker), the governed-consumer verify core (cdylib),
+#    and the dev release-token minter — against the sourced curated types.
+RUN source /opt/ros/jazzy/setup.bash \
+    && source /opt/kirra/ros2_ws_install/setup.bash \
+    && cargo build --locked --release \
+         -p kirra-ros2-adapter --features ros2 \
+    && cargo build --locked --release \
+         -p kirra-consumer-ffi -p kirra-release-token --bin kirra_ros_release_mint
+RUN install -d /opt/kirra/bin /opt/kirra/lib /opt/kirra/robot \
+    && install -m0755 target/release/kirra_ros2_adapter_node /opt/kirra/bin/ \
+    && install -m0755 target/release/kirra_ros_release_mint  /opt/kirra/bin/ \
+    && install -m0644 target/release/libkirra_consumer_ffi.so /opt/kirra/lib/
+
+# 3. Stage the robot-side Python layer + the distro-agnostic ROS resolver.
+RUN for f in kirra_motor_consumer.py kirra_ffi.py r2_drive.py kirra_release_publisher.py \
+             ros_env.sh rabbit_persona.py rabbit_ask.py rabbit_converse.py rabbit_watch.py; do \
+      [ -f "robot/$f" ] && install -m0755 "robot/$f" "/opt/kirra/robot/$f" || true; \
+    done
+RUN install -m0755 deploy/orin-jazzy/entrypoint.sh /opt/kirra/entrypoint.sh
+
+ENV KIRRA_CONSUMER_LIB=/opt/kirra/lib/libkirra_consumer_ffi.so \
+    KIRRA_ROS_WS_SETUP=/opt/kirra/ros2_ws_install/setup.bash \
+    ROS_DOMAIN_ID=28
+
+WORKDIR /opt/kirra
+ENTRYPOINT ["/opt/kirra/entrypoint.sh"]
+# Default role = the checker/adapter node. Override with `command: [consumer]` etc.
+CMD ["adapter"]

--- a/deploy/orin-jazzy/README.md
+++ b/deploy/orin-jazzy/README.md
@@ -1,0 +1,101 @@
+# Orin Jazzy runtime — containerize the Jazzy stack on a JetPack-6 host (ADR-0036, Step 3)
+
+The last thing pinning the robot to 22.04/Humble isn't the code — it's **L4T**.
+The Jetson Orin NX runs NVIDIA's L4T, and **JetPack 6 = Ubuntu 22.04 / ROS 2
+Humble**. You can't `apt` your way to 24.04; you're gated on what NVIDIA ships.
+This directory runs the **Jazzy stack in a container on the unchanged JetPack-6
+host**, so you move to Jazzy today instead of waiting for a JetPack-7 (24.04)
+native flash.
+
+```
+ ┌──────────────────────────── Orin NX host (JetPack 6 / 22.04 / Humble) ────────────────────────────┐
+ │  kernel + devices (/dev/myserial, /dev/ydlidar) + the DDS network (host mode)                      │
+ │                                                                                                    │
+ │   ┌─────────────────────────────┐   DDS over host net    ┌──────────────────────────────────────┐ │
+ │   │ (optional) Humble bits /    │  (shared DOMAIN_ID)    │  container: ros:jazzy                  │ │
+ │   │  Autoware doer, if present  │◄─────────────────────► │  kirra_governor (checker/adapter)      │ │
+ │   └─────────────────────────────┘                        │  + governed consumer (ADR-0033)        │ │
+ │                                                           └──────────────────────────────────────┘ │
+ └────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+This is the **inverse** of `deploy/autoware-isolation/`: there, Autoware is the
+odd-one-out Humble *guest* alongside a native Jazzy host; here (on the robot),
+Jazzy is the *guest* on a Humble host. Same cross-distro DDS wire; the checker is
+distro-independent and bounds whatever crosses the boundary.
+
+## Scope — the CPU-only safety spine (honest boundary)
+The image builds and runs, on a plain `ros:jazzy` arm64 base (no CUDA needed):
+- **the ros2 adapter** (`kirra_ros2_adapter_node`, the checker),
+- **the ADR-0033 governed motor consumer** + its verify-core `libkirra_consumer_ffi.so`,
+- **the 4 curated `autoware_*_msgs`** + `kirra_safety`,
+- **the robot Channel-A layer** (`rabbit_*`) + the distro resolver `ros_env.sh`.
+
+**Not here (follow-up):** GPU doers — parko TensorRT/ONNX inference and camera
+perception. Those need an `nvcr.io/nvidia/l4t-jetpack`-based Jazzy image with the
+CUDA/cuDNN/TensorRT runtime and `--runtime nvidia`. The safety path needs none of
+that, so it's deliberately split out; the checker bounds a GPU doer the same way
+whether the doer is native, in another container, or on Humble.
+
+## Prerequisites on the host
+- Docker with the default runtime (Buildx/BuildKit). For the GPU follow-up:
+  `nvidia-container-toolkit` + `--runtime nvidia`.
+- The udev symlinks the robot already relies on: `/dev/myserial` (motor board),
+  `/dev/ydlidar` (TG30 lidar). Confirm with `robot/install/capture_from_robot.sh`.
+- The vendor **`Rosmaster_Lib`** Python package on the host — it is NOT
+  redistributable in the image, so the consumer mounts it read-only (see below).
+
+## Bring-up
+```bash
+cd ~/kirra-runtime-sdk
+
+# 1. env: copy the robot env template and fill it (governor key, R2 calib, ports).
+cp robot/install/env.template deploy/orin-jazzy/robot.env
+$EDITOR deploy/orin-jazzy/robot.env        # KIRRA_GOVERNOR_VK_HEX, KIRRA_R2_*, ROS_DOMAIN_ID, ...
+
+# 2. build the image (first build compiles r2r + the adapter + the ws — slow once).
+docker compose -f deploy/orin-jazzy/docker-compose.yml build
+
+# 3. the checker/adapter (CPU-only, no devices) — validate the wire first:
+docker compose -f deploy/orin-jazzy/docker-compose.yml up kirra-adapter
+
+# 4. the governed wheels (🔴 moves the robot — elevate/tether first):
+#    point ROSMASTER_LIB_DIR at the host's Rosmaster_Lib, then:
+ROSMASTER_LIB_DIR=/usr/local/lib/python3.10/dist-packages/Rosmaster_Lib \
+  docker compose -f deploy/orin-jazzy/docker-compose.yml --profile drive up kirra-consumer
+```
+
+`kirra-adapter` is safe to run anytime (it only reads/publishes topics and bounds
+them). `kirra-consumer` is behind `--profile drive` because it owns the motor
+board and moves the robot — the ADR-0033 verify-token chokepoint still gates every
+command inside the container, exactly as on bare metal.
+
+## Why host networking + shared DOMAIN_ID
+DDS discovery is multicast/shared-memory based; `network_mode: host` puts the
+container's ROS graph on the host's network so it discovers (and is discovered by)
+any Humble nodes on the box and the isolated Autoware doer — no bridge, provided
+the curated boundary interfaces are byte-identical across distros (run the
+`scripts/curated_interface/crossdistro_hash_check.sh` gate; ADR-0036 Step 1).
+
+## Device + vendor notes (the parts that are hardware-specific)
+- **Motor / lidar**: passed via `devices:` as the udev symlinks. If your host
+  exposes the raw `ttyUSB*` instead, set `KIRRA_MOTOR_DEV` / `KIRRA_LIDAR_DEV`.
+- **`Rosmaster_Lib`**: mounted read-only from the host into `/opt/vendor` and put
+  on `PYTHONPATH`. Adjust `ROSMASTER_LIB_DIR` to the host path (it varies by
+  Python minor version). If your consumer runs in `KIRRA_DRIVE_MODE=r2_ackermann`,
+  the Path-B last-hop still calls the vendor lib for `set_motor`/steering.
+- **Real-time**: for the FIFO-scheduled loops add `cap_add: [SYS_NICE]` (and, if
+  you pin CPUs, `cpuset`). Not enabled by default — validate wheels-up first.
+
+## What this is / isn't
+- **Is:** the topology + a buildable image + a compose that runs the Jazzy safety
+  spine on a Humble Orin host, and the honest device/vendor/GPU boundaries.
+- **Isn't:** validated on-Orin here (build it on the Orin or an arm64 builder),
+  and it does **not** include the GPU doers — those are the l4t-jetpack follow-up.
+  The checker/fence are unchanged; only the runtime environment moved.
+
+## Retirement
+When JetPack 7 (24.04/Noble, Jazzy-native) ships, flash the Orin and run the
+stack on the host directly — this container was only ever the bridge across the
+L4T gap. The Autoware-Humble isolation (`deploy/autoware-isolation/`) retires the
+same way when Autoware ships stable Jazzy support.

--- a/deploy/orin-jazzy/docker-compose.yml
+++ b/deploy/orin-jazzy/docker-compose.yml
@@ -1,0 +1,53 @@
+# Orin Jazzy runtime (ADR-0036, Step 3).
+#
+# Runs the robot-side KIRRA stack on ROS 2 Jazzy INSIDE a container on a
+# JetPack-6 / 22.04 / Humble Orin host — so you move to Jazzy today without
+# waiting for a JetPack-7 (24.04) native flash. host networking + a shared
+# ROS_DOMAIN_ID let the containerized Jazzy nodes meet the host's Humble ROS
+# graph (and the isolated Autoware doer) over DDS.
+#
+#   # provide the filled env first (see README):
+#   cp ../../robot/install/env.template robot.env   # then fill KIRRA_* + governor key
+#   docker compose -f deploy/orin-jazzy/docker-compose.yml build
+#   docker compose -f deploy/orin-jazzy/docker-compose.yml up kirra-adapter        # the checker
+#   docker compose -f deploy/orin-jazzy/docker-compose.yml --profile drive up kirra-consumer  # governed wheels
+#
+# 🔴 device + vendor caveats are in README.md (Rosmaster_Lib, udev symlinks, GPU).
+
+x-common: &common
+  build:
+    context: ../..
+    dockerfile: deploy/orin-jazzy/Dockerfile
+  image: kirra-orin-jazzy:local
+  network_mode: host          # DDS discovery + Humble<->Jazzy on the wire
+  environment:
+    - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-28}
+    - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}
+  env_file:
+    - robot.env               # copy from ../../robot/install/env.template and fill
+  restart: unless-stopped
+
+services:
+  # The checker/adapter — bounds whatever the doer proposes. CPU-only, no devices.
+  kirra-adapter:
+    <<: *common
+    container_name: kirra-adapter-jazzy
+    command: ["adapter"]
+
+  # The ADR-0033 governed motor consumer — owns the motor board, verify-before-drive.
+  # `--profile drive` so it never starts unless asked (it moves wheels). Needs the
+  # motor + lidar device symlinks and the vendor Rosmaster_Lib (see README).
+  kirra-consumer:
+    <<: *common
+    container_name: kirra-consumer-jazzy
+    profiles: ["drive"]
+    command: ["consumer"]
+    devices:
+      - "${KIRRA_MOTOR_DEV:-/dev/myserial}:/dev/myserial"
+      - "${KIRRA_LIDAR_DEV:-/dev/ydlidar}:/dev/ydlidar"
+    volumes:
+      # Vendor motor lib (not redistributable in the image) — mount from the host.
+      - "${ROSMASTER_LIB_DIR:-/usr/local/lib/python3.10/dist-packages/Rosmaster_Lib}:/opt/vendor/Rosmaster_Lib:ro"
+    environment:
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-28}
+      - PYTHONPATH=/opt/vendor

--- a/deploy/orin-jazzy/entrypoint.sh
+++ b/deploy/orin-jazzy/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# entrypoint.sh — Orin Jazzy runtime dispatcher (ADR-0036, Step 3).
+# Sources the Jazzy base + the curated-msgs overlay, then execs the requested
+# role. ROS setup.bash references unset vars, so nounset is off during sourcing.
+set -eo pipefail
+
+# Base ROS (distro-agnostic resolver, though this image is Jazzy) + the ws overlay.
+# shellcheck source=robot/ros_env.sh
+source /opt/kirra/robot/ros_env.sh 2>/dev/null && kirra_source_ros || source /opt/ros/jazzy/setup.bash
+# shellcheck disable=SC1090
+source "${KIRRA_ROS_WS_SETUP:-/opt/kirra/ros2_ws_install/setup.bash}"
+
+ROLE="${1:-adapter}"; shift || true
+echo "[orin-jazzy] role=${ROLE}  ROS_DISTRO=${ROS_DISTRO:-?}  ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-?}"
+
+case "${ROLE}" in
+  adapter)
+    # The checker: bounds whatever the doer proposes on the boundary topics.
+    exec /opt/kirra/bin/kirra_ros2_adapter_node --corridor-source "${KIRRA_CORRIDOR_SOURCE:-mock}" "$@"
+    ;;
+  consumer)
+    # The ADR-0033 governed motor consumer (owns the motor board, verify-before-drive).
+    exec python3 /opt/kirra/robot/kirra_motor_consumer.py "$@"
+    ;;
+  mint)
+    exec /opt/kirra/bin/kirra_ros_release_mint "$@"
+    ;;
+  bash|shell)
+    exec bash "$@"
+    ;;
+  *)
+    echo "[orin-jazzy] unknown role '${ROLE}' (adapter|consumer|mint|bash)" >&2
+    exit 2
+    ;;
+esac

--- a/docs/adr/0036-autoware-distro-migration-occy-gap.md
+++ b/docs/adr/0036-autoware-distro-migration-occy-gap.md
@@ -129,7 +129,7 @@ are pinned in-repo, so:
 6. **Add a Jazzy CI build lane** (`--features ros2` against a `ros:jazzy` container, in parallel with Humble) — the analog of the MSRV lane: validate the next target continuously so an EOL cutover is a non-event.
 7. **Retire on Autoware-Jazzy.** When Autoware ships stable Jazzy, migrate the container, run the governed-loop bring-up smoke, drop Humble.
 
-**Orin note:** on the Jetson the host OS is JetPack/L4T (NVIDIA-controlled; JetPack 6 = 22.04), not something you `do-release-upgrade`. Containerizing ROS is what lets the ROS distro move ahead of the JetPack-bound host. (Per ADR-0032, the Orin is a *doer*, never the governor cert target.)
+**Orin note:** on the Jetson the host OS is JetPack/L4T (NVIDIA-controlled; JetPack 6 = 22.04), not something you `do-release-upgrade`. Containerizing ROS is what lets the ROS distro move ahead of the JetPack-bound host. (Per ADR-0032, the Orin is a *doer*, never the governor cert target.) The concrete scaffold for this — the Jazzy safety-spine image + compose that runs on the unchanged JetPack-6 host — is `deploy/orin-jazzy/` (the inverse of `deploy/autoware-isolation/`: Jazzy as the container guest on a Humble host). GPU doers (parko TensorRT / camera perception) stay a follow-up on an `l4t-jetpack`-based Jazzy image; the CPU-only checker/adapter/consumer need no CUDA.
 
 ---
 


### PR DESCRIPTION
ADR-0036 Step 3 — the last thing pinning the robot to Humble isn't code, it's **L4T**: JetPack 6 = Ubuntu 22.04. This runs the Jazzy stack in a container **on the unchanged JetPack-6 host**, so we move to Jazzy today instead of waiting for a JetPack-7 native flash. It's the **inverse** of `deploy/autoware-isolation/` — there Autoware is the Humble guest on a Jazzy host; here Jazzy is the guest on a Humble host. Same cross-distro DDS wire; the checker is distro-independent and bounds whatever crosses the boundary.

**No safety surface changes** — only the runtime *environment* moves. The ADR-0033 verify-token chokepoint and the checker are byte-identical.

## What's here (`deploy/orin-jazzy/`)
- **`Dockerfile`** — `ros:jazzy-ros-base` (arm64, runs natively on Orin) builds the CPU-only safety spine: the curated `autoware_*_msgs` + `kirra_safety` (colcon), the ros2 adapter (checker), the governed-consumer verify core (`kirra-consumer-ffi` cdylib) + the dev release-token minter, and stages the robot Python layer + the `ros_env.sh` resolver from Step 1.
- **`entrypoint.sh`** — sources base ROS (via the `ros_env.sh` resolver) + the ws overlay, dispatches by role (`adapter | consumer | mint | bash`).
- **`docker-compose.yml`** — `network_mode: host` + shared `ROS_DOMAIN_ID` (DDS discovery across the Humble↔Jazzy boundary). `kirra-adapter` (CPU-only, no devices, safe anytime); `kirra-consumer` behind a `drive` profile with `/dev/myserial` + `/dev/ydlidar` passthrough and the vendor `Rosmaster_Lib` mounted read-only.
- **`README.md`** + an ADR-0036 pointer — rationale, the honest device/vendor/GPU boundaries, bring-up, and retire-on-JetPack-7.

## Scope / honesty
- **CPU-only safety spine** by design — GPU doers (parko TensorRT / camera perception) are a follow-up on an `nvcr.io/nvidia/l4t-jetpack`-based Jazzy image with `--runtime nvidia`. The safety path needs no CUDA, so a plain `ros:jazzy` base runs on the Orin's aarch64 today.
- **Not validated on-Orin here** (build it on the Orin or an arm64 builder) — this is the buildable scaffold + recipe, in the same honest style as `deploy/autoware-isolation/`.
- Vendor `Rosmaster_Lib` is mounted, not redistributed in the image.

## Verification
- `entrypoint.sh` `bash -n` clean; `docker-compose.yml` YAML validated (anchors/merge resolve).
- Referenced crate/bin names verified against the workspace (`kirra-consumer-ffi`, `kirra-ros2-adapter` → `kirra_ros2_adapter_node`, `kirra-release-token` → `kirra_ros_release_mint`).
- `.dockerignore` confirmed not to exclude `ros2_ws/` / `robot/` / `crates/` from the build context (`target/` is excluded → clean in-container rebuild).

Closes the ADR-0036 migration arc: Step 1 (unpin the robot layer — merged in #1007), Step 2 (verify the two `ros2_ws` nodes on Jazzy — CI already sources Jazzy), Step 3 (this — containerize the runtime).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_