### PR TITLE
parko/ort: hold rc.12 (deadlock #144) + fix stale INTEGRATION doc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,3 +79,10 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # ort 2.0.0-rc.12 (+ ONNX Runtime 1.24.2) DEADLOCKS at OrtBackend::new even
+      # single-threaded (#144) — a genuine init hang, not a version-pair mismatch.
+      # The workspace is pinned to rc.11 / ORT 1.23.2 ON PURPOSE. Hold rc.12 until
+      # an upstream ort / ONNX-Runtime release fixes the hang (then drop this and
+      # bump the CI + Dockerfile native-lib pin in lockstep). See PR #667.
+      - dependency-name: "ort"
+        versions: ["2.0.0-rc.12"]

--- a/parko/INTEGRATION.md
+++ b/parko/INTEGRATION.md
@@ -137,7 +137,7 @@ Today the supported model format on every shipped backend is **ONNX**.
 
 | Backend crate | Type name | Hardware | Status |
 |---|---|---|---|
-| `parko-onnx` | `OrtBackend` | any x86 CPU | ✅ shipping — uses `ort 2.0.0-rc.12` + ONNX Runtime v1.24.2 dlopen'd at runtime |
+| `parko-onnx` | `OrtBackend` | any x86 CPU | ✅ shipping — uses `ort 2.0.0-rc.11` + ONNX Runtime v1.23.2 dlopen'd at runtime (pinned in lockstep; rc.12/1.24.2 deadlocks at init, #144) |
 | `parko-openvino` | `OvBackend` | any x86 Intel CPU | ✅ shipping — uses `openvino = 0.11` with the `runtime-linking` feature; OpenVINO 2024.x |
 | TensorRT (NVIDIA) | — | NVIDIA GPU | **planned** (PARK-020); not built |
 | Qualcomm QNN | — | Qualcomm NPU | **planned** (PARK-027); not built |


### PR DESCRIPTION
Outcome of investigating Dependabot **#667** (`ort =2.0.0-rc.11 → =2.0.0-rc.12` in `/parko`). **The bump is not viable and should not be merged — here's the evidence, plus the two fixes that actually resolve the situation.**

## Why rc.12 can't ship
- rc.12 is **exactly matched** to ONNX Runtime 1.24.2 (ORT_API_VERSION 24). The docs are explicit that this *matched* pair **deadlocks at `OrtBackend::new` even single-threaded** — `--test-threads=1` hung at the first init before printing anything (`#144`, documented in `parko/README.md`, `ci.yml`, `parko-onnx/Cargo.toml`). That's a genuine init hang, **not** an `ORT_API_VERSION` mismatch.
- So "aligning" CI's native lib to 1.24.2 **reproduces** the deadlock rather than fixing it — alignment was never the missing piece.
- There is **no `ort` release past rc.12** to move to, and the fix must come from upstream `ort`/ONNX-Runtime.
- Forcing it would reintroduce a **validated deadlock into a safety-adjacent inference path** (parko's scheduler treats a wedged backend as a platform-health hazard) with no way to prove liveness. (It also couldn't be validated in the authoring sandbox — the proxy blocks the ONNX-Runtime release download, so `OrtBackend::new` can't be exercised here.)

## What this PR does instead
1. **`.github/dependabot.yml`** — ignore `ort 2.0.0-rc.12` in the `/parko` cargo group. It slipped past the `semver-major` ignore as a *pre-release patch* bump, which is why #667 kept reopening. The ignore is **version-specific**: a future rc that fixes #144 is still proposed.
2. **`parko/INTEGRATION.md`** — fix a stale row that claimed `parko-onnx` ships `rc.12 / ORT 1.24.2`. It ships **rc.11 / ORT 1.23.2** (the row contradicted the real, deliberate pin).

## To lift the hold later (when upstream fixes #144)
Drop the dependabot ignore **and** bump the ONNX-Runtime native-lib pin (`ci.yml` ×2 install steps + `Dockerfile.parko-ort-cpu` + `Dockerfile.parko-trt-jetson` wheel) to the fixed 1.24.x **in lockstep** with the `ort` crate — then the parko ONNX/adapter lanes prove it doesn't hang.

**Recommendation:** close #667. No safety surface changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_