### PR TITLE
robot: voice-config doctor + boot self-announce (Rabbit says if misconfigured)

### DIFF
--- a/docs/hardware/R2_VOICE_AUDIO_SETUP.md
+++ b/docs/hardware/R2_VOICE_AUDIO_SETUP.md
@@ -110,6 +110,11 @@ sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
 
 ## Verify (in order)
 ```bash
+# 0. one-shot config doctor (read-only; the fastest "am I misconfigured?" check —
+#    catches a drifted ALSA card, a missing engine/model, an unset env key):
+./robot/kirra_voice_doctor.sh          # ✔/❌/⚠ + a fix hint per gap; exit 0 iff no ❌
+#    (rabbit_boot.py runs it --quiet on boot and SPEAKS a warning on a ❌ — voice line A6.)
+
 # 1. engines standalone:
 echo "rabbit online" | ~/kirra-runtime-sdk/speak.sh                 # hear the speaker
 whisper-cli -m ~/whisper.cpp/models/ggml-base.en.bin -np -nt -f /tmp/t.wav   # prints your words

--- a/docs/rabbit/RABBIT_VOICE_LINES.md
+++ b/docs/rabbit/RABBIT_VOICE_LINES.md
@@ -60,6 +60,7 @@ Legend: **LIVE** = wired today (file:seam cited) · **GAP** = to be wired · the
 | A3 | Shutting down | **LIVE** `rabbit_boot.py` `shutdown_line` (systemd `ExecStop`) | "Powering down. I've come to a safe stop — try not to miss me too much." |
 | A4 | Idle / standing by | optional (not wired) | "Standing by{name}." (or silence) |
 | A5 | LLM digest changed since it was vetted (stealth update) | **LIVE** `rabbit_boot.py` `_maybe_warn_model_changed` (only on a CONFIRMED change; unpinned/unavailable stay silent) | "A heads-up{name}: my language model has changed since it was last vetted. I'd re-run the model check before trusting me to drive." |
+| A6 | Voice-config doctor found a ❌ on boot (mic/speaker device drifted, missing engine, …) | **LIVE** `rabbit_boot.py` `_maybe_warn_misconfigured` (runs the read-only `kirra_voice_doctor.sh --quiet`; only on a FAIL, silent when clean or the doctor can't run) | "A heads-up{name}: my self-check found a configuration problem. Run the voice doctor before relying on me — my ears or voice may be off." |
 
 ### B. Driving (you gave a command)
 

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -35,7 +35,7 @@ echo "== 1. Rabbit scripts -> ${OPT}/robot =="
 sudo install -d -m 0755 "${OPT}/robot"
 for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabbit_boot.py \
          rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py \
-         ros_env.sh; do
+         ros_env.sh kirra_voice_doctor.sh; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"

--- a/robot/kirra_voice_doctor.sh
+++ b/robot/kirra_voice_doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# kirra_voice_doctor.sh — read-only voice/audio config doctor for the R2.
+#
+# Checks the voice layer configured in /etc/kirra/robot.env against the actual
+# machine state and names the fix for each gap. Changes NOTHING (safe to run
+# anytime, incl. over SSH). Companion to robot/install/preflight_autostart.sh
+# (autostart readiness) — this one covers the STT/TTS/mic/speaker path that the
+# autostart preflight does not. Concrete setup + fixes: docs/hardware/
+# R2_VOICE_AUDIO_SETUP.md.
+#
+#   robot/kirra_voice_doctor.sh            # human report (✔/❌/⚠ + fix hints)
+#   robot/kirra_voice_doctor.sh --quiet    # one line: "OK" | "FAIL: <first issue>"
+#
+# Exit 0 iff there is no ❌ (a ⚠ still exits 0 — warnings are non-fatal).
+# The killer check: the `-D plughw:N,0` mic/speaker cards actually appear in
+# arecord -l / aplay -l — ALSA card numbers drift across reboots, and a drifted
+# device fails SILENTLY mid-turn otherwise.
+set -uo pipefail
+
+QUIET=0
+[ "${1:-}" = "--quiet" ] && QUIET=1
+
+PASS=0; FAIL=0; WARN=0; FIRST_FAIL=""
+ok()   { [ "$QUIET" = 1 ] || echo "  ✔ $*"; PASS=$((PASS + 1)); }
+bad()  { [ "$QUIET" = 1 ] || echo "  ❌ $*"; FAIL=$((FAIL + 1)); [ -n "$FIRST_FAIL" ] || FIRST_FAIL="$*"; }
+warn() { [ "$QUIET" = 1 ] || echo "  ⚠ $*"; WARN=$((WARN + 1)); }
+fix()  { [ "$QUIET" = 1 ] || echo "       ↳ fix: $*"; }
+
+RENV="${KIRRA_ROBOT_ENV:-/etc/kirra/robot.env}"
+
+# first token of a command string (the binary/script it invokes)
+first_tok() { set -- $1; printf '%s' "${1:-}"; }
+# value following <flag> in a command string, or "" (e.g. opt_val -m "$KIRRA_STT_CMD")
+opt_val() { local f="$1"; shift; set -- $1; while [ "$#" -gt 0 ]; do [ "$1" = "$f" ] && { printf '%s' "${2:-}"; return; }; shift; done; }
+# ALSA card number from a plughw:N,0 / hw:N,0 spec
+card_of() { local d="${1#plughw:}"; d="${d#hw:}"; printf '%s' "${d%%,*}"; }
+
+[ "$QUIET" = 1 ] || echo "== R2 voice/audio doctor =="
+
+# 1. env file present + loadable
+if [ -r "$RENV" ]; then
+  ok "robot.env readable ($RENV)"
+  # shellcheck disable=SC1090
+  set -a; . "$RENV"; set +a
+else
+  bad "robot.env not readable ($RENV)"; fix "create it / check perms — R2_VOICE_AUDIO_SETUP.md §4"
+fi
+
+# 2. STT engine + model
+if [ -n "${KIRRA_STT_CMD:-}" ]; then
+  b="$(first_tok "$KIRRA_STT_CMD")"
+  command -v "$b" >/dev/null 2>&1 && ok "STT binary: $b" || { bad "STT binary not found: $b"; fix "build whisper.cpp + symlink whisper-cli — §1"; }
+  m="$(opt_val -m "$KIRRA_STT_CMD")"
+  [ -z "$m" ] || { [ -f "$m" ] && ok "STT model: $m" || { bad "STT model missing: $m"; fix "download-ggml-model.sh base.en — §1"; }; }
+else
+  bad "KIRRA_STT_CMD unset"; fix "set it in $RENV — §4"
+fi
+
+# 3. TTS wrapper
+if [ -n "${KIRRA_TTS_CMD:-}" ]; then
+  b="$(first_tok "$KIRRA_TTS_CMD")"
+  { [ -x "$b" ] || command -v "$b" >/dev/null 2>&1; } && ok "TTS command: $b" || { bad "TTS command not found/executable: $b"; fix "create speak.sh + chmod +x — §3"; }
+else
+  warn "KIRRA_TTS_CMD unset — Rabbit will PRINT, not speak"
+fi
+
+# 4. MIC device present in arecord -l  (the drift check)
+mc="$(card_of "$(opt_val -D "${KIRRA_RECORD_CMD:-}")")"
+if [ -n "$mc" ]; then
+  if command -v arecord >/dev/null 2>&1 && arecord -l 2>/dev/null | grep -qE "^card ${mc}:"; then
+    ok "mic device present: plughw:${mc},0"
+  else
+    bad "mic device plughw:${mc},0 NOT in arecord -l (card drifted?)"; fix "arecord -l → update KIRRA_RECORD_CMD -D plughw:<N>,0 — §0"
+  fi
+else
+  warn "KIRRA_RECORD_CMD has no -D plughw:N,0 (mic device not pinned)"
+fi
+
+# 5. SPEAKER device present in aplay -l (parse the plughw from the TTS wrapper file)
+tts_src="${KIRRA_TTS_CMD:-}"; tf="$(first_tok "$tts_src")"
+[ -f "$tf" ] && tts_src="$(cat "$tf" 2>/dev/null || true)"
+sc="$(card_of "$(opt_val -D "$tts_src")")"
+if [ -n "$sc" ]; then
+  if command -v aplay >/dev/null 2>&1 && aplay -l 2>/dev/null | grep -qE "^card ${sc}:"; then
+    ok "speaker device present: plughw:${sc},0"
+  else
+    bad "speaker device plughw:${sc},0 NOT in aplay -l (card drifted?)"; fix "aplay -l → update speak.sh aplay -D plughw:<N>,0 — §0"
+  fi
+else
+  warn "no speaker plughw:N,0 found in the TTS path (not pinned)"
+fi
+
+# 6. loop services listening (WARN — may legitimately be off)
+for pair in "8090:verifier" "8102:mick" "11434:ollama"; do
+  p="${pair%%:*}"; n="${pair##*:}"
+  if ss -tlnH 2>/dev/null | grep -qE ":${p}([[:space:]]|$)"; then ok "$n listening (:$p)"; else warn "$n not listening (:$p)"; fix "bring up the loop — R2_LIVE_LOOP_BRINGUP.md"; fi
+done
+
+# 7. Jetson.GPIO (PTT button) — WARN (Enter-key path works without it)
+if python3 -c "import Jetson.GPIO" >/dev/null 2>&1; then
+  ok "Jetson.GPIO importable (PTT ready)"
+else
+  warn "Jetson.GPIO not importable (PTT button off; Enter-key still works)"; fix "pip install >=2.1.12 from GitHub on Super boards — §5"
+fi
+
+# summary + exit code
+if [ "$QUIET" = 1 ]; then
+  [ "$FAIL" -eq 0 ] && echo "OK" || echo "FAIL: $FIRST_FAIL"
+else
+  echo "== ${PASS} ok / ${WARN} warn / ${FAIL} fail =="
+fi
+[ "$FAIL" -eq 0 ]

--- a/robot/rabbit_boot.py
+++ b/robot/rabbit_boot.py
@@ -12,9 +12,10 @@ of greeting into a lie.
             then speak the matching line (nominal / degraded / not-ready-yet).
   shutdown→ speak the power-down line.
 
-🔴 CHANNEL A ONLY (docs/rabbit/RABBIT_VOICE_LINES.md, rows A1–A3). Read-only GET +
-   TTS. No /intent, no publisher, no serial, no release token — it cannot move
-   the robot. Proactive SPEECH, never proactive motion.
+🔴 CHANNEL A ONLY (docs/rabbit/RABBIT_VOICE_LINES.md, rows A1–A3 + A5 model-drift +
+   A6 misconfig self-check). Read-only GET + TTS + a read-only config doctor. No
+   /intent, no publisher, no serial, no release token — it cannot move the robot.
+   Proactive SPEECH, never proactive motion.
 
 Usage:
   ./robot/rabbit_boot.py greet       # power-on greeting (posture-gated)
@@ -57,6 +58,30 @@ def greeting_line(posture_code, fresh):
 
 def shutdown_line():
     return "Powering down. I've come to a safe stop — try not to miss me too much."
+
+
+def misconfig_line():
+    """A6: the voice-config doctor found a ❌ (e.g. a mic/speaker device drifted,
+    a missing engine). Generic advisory — run the doctor for specifics."""
+    return (f"A heads-up{name_slot()}: my self-check found a configuration problem. "
+            "Run the voice doctor before relying on me — my ears or voice may be off.")
+
+
+def _maybe_warn_misconfigured():
+    """Channel-A advisory if the read-only voice-config doctor (kirra_voice_doctor.sh,
+    next to this file) reports a FAIL. Best-effort and lazy; never breaks boot, and
+    stays silent when the doctor passes or can't run (e.g. not staged here)."""
+    import subprocess
+    doctor = os.path.join(os.path.dirname(os.path.abspath(__file__)), "kirra_voice_doctor.sh")
+    if not os.path.exists(doctor):
+        return
+    try:
+        rc = subprocess.run(["bash", doctor, "--quiet"], timeout=15,
+                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode
+    except Exception:  # noqa: BLE001 — a self-check advisory must never break boot
+        return
+    if rc != 0:
+        speak(misconfig_line())
 
 
 def _maybe_warn_model_changed():
@@ -112,6 +137,7 @@ def greet(deadline_s=None, poll_s=1.0):
         time.sleep(poll_s)
     speak(greeting_line(last_code, last_fresh))
     _maybe_warn_model_changed()
+    _maybe_warn_misconfigured()
 
 
 def main():

--- a/robot/rabbit_voice_test.py
+++ b/robot/rabbit_voice_test.py
@@ -19,7 +19,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from rabbit_boot import greeting_line, shutdown_line  # noqa: E402
+from rabbit_boot import greeting_line, misconfig_line, shutdown_line  # noqa: E402
 from rabbit_ota import match_command  # noqa: E402
 from rabbit_persona import (  # noqa: E402
     classify_model_pin, name_slot, read_model_pin, read_model_pin_record,
@@ -104,6 +104,12 @@ def test_greeting_uses_name_when_known() -> None:
 def test_shutdown_line_is_a_safe_stop_message() -> None:
     line = shutdown_line()
     assert "safe stop" in line and len(line) > 0
+
+
+def test_misconfig_line_is_a_nonempty_advisory() -> None:
+    # A6: a Channel-A advisory pointing at the doctor; never claims motion.
+    line = misconfig_line()
+    assert len(line) > 0 and "doctor" in line.lower()
 
 
 # --- OTA matcher precedence (apply/status before check) ----------------------


### PR DESCRIPTION
The config we set up by hand tonight (ALSA device pins, engine paths, env keys) drifts silently — a mic that moves from card 3 → card 4 on reboot fails **mid-turn with no warning**. This makes the robot self-aware of that: a read-only doctor + a boot self-check.

**Read-only + Channel-A only — no actuation surface.**

## `robot/kirra_voice_doctor.sh` — the doctor
Companion to `robot/install/preflight_autostart.sh` (which covers *autostart* readiness but not the voice path). Read-only, safe over SSH. Checks:
- `/etc/kirra/robot.env` keys set; STT/TTS binaries + the whisper model present;
- **the killer check** — the `-D plughw:N,0` mic/speaker cards actually appear in `arecord -l` / `aplay -l` (ALSA card numbers drift across reboots → the silent failure);
- loop services (`:8090`/`:8102`/`:11434`) + Jetson.GPIO as **WARN**s.

`✔/❌/⚠ + fix:` report; `--quiet` → `OK` | `FAIL: <first issue>`; **exit 0 iff no ❌**.

## `rabbit_boot.py` — the self-announce
`_maybe_warn_misconfigured()` runs `kirra_voice_doctor.sh --quiet` on boot and **speaks voice line A6** on a `❌` — a Channel-A advisory that mirrors the existing A5 model-drift warning: best-effort, never breaks boot, silent when clean or the doctor can't run. New pure `misconfig_line()` (unit-tested); A6 catalogued in `RABBIT_VOICE_LINES.md`.

Also: `install_robot_units.sh` stages the doctor to `/opt/kirra/robot`; `R2_VOICE_AUDIO_SETUP.md §Verify` now leads with it.

## Verification
- Doctor logic host-tested with mocked `aplay`/`arecord`: correct card → `OK`/exit 0; **drifted card → `FAIL`/exit 1** with the precise reason.
- `bash -n` clean; `rabbit_boot.py` compiles; voice tests **16/16** (added `test_misconfig_line`).

## The bigger diagnostics picture
This is deliberately **module 1** of a broader "robot diagnostics" story (see the PR discussion): the voice doctor sits alongside the existing read-only checks (`preflight_autostart.sh`, `lint_robot_env.sh`, `cold_boot_drill.sh`) and the verifier's own config self-audit (`env_config.rs` unknown-var sweep + `EffectiveConfig` digest). A future top-level `kirra_doctor` runner + a voice-triggered "run diagnostics" would compose these into one health report — left as a follow-up, not built here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_