### PR TITLE
robot: kirra_doctor diagnostics framework — modular, deterministic, read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1085,6 +1085,12 @@ jobs:
           # read; stale/degraded/lockout → "still checking myself over"), and the
           # OTA voice-matcher precedence. See docs/rabbit/RABBIT_VOICE_LINES.md.
           python3 robot/rabbit_voice_test.py
+          # Diagnostics framework (pure, no hardware): schema v1 shape/ordering,
+          # worst-of aggregation + exit codes, module isolation (raise/timeout →
+          # UNKNOWN for that module only), the deterministic "run diagnostics"
+          # voice matcher (no OTA/drive overlap), speech-summary capping, and
+          # the voice-doctor wrapper against a stub. See docs/diagnostics.md.
+          python3 robot/kirra_doctor_test.py
           # Detecting-installer contract (R2 golden build): detect/verify/install
           # are fail-closed (wrong car-type mode, unknown platform, missing
           # devices all refuse with remediation) and SELECT-NOT-INFER holds (the

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,186 @@
+# Robot diagnostics — the `kirra_doctor` framework
+
+The R2's self-diagnostics subsystem: deterministic, modular, **read-only**
+health checks the robot can run itself — from the CLI, by voice ("Rabbit, run
+diagnostics"), at boot, and on a systemd timer — with one stable machine-
+readable report schema.
+
+## Security model (the non-negotiable)
+
+**Diagnostics are observability, never a safety authority.**
+
+- Every module is **read-only**: no writes to robot state, no GPIO actuation,
+  no firmware, no motion, no `/intent`. The one artifact the subsystem writes
+  is its **own report file** (the timer's JSON archive) — never robot state.
+- No diagnostic verdict gates the planner, the governor, RSS, the checker, or
+  the fence. Those **fail closed on their own, independently** — a green
+  doctor is not a permission, and a red doctor is not a stop. Safety stays
+  exclusively with the verifier/checker/fence architecture.
+- The voice trigger is **deterministic** (regex, the `rabbit_ota` pattern) —
+  the LLM can neither decide to run a self-check nor fabricate one; the reply
+  the operator hears comes from the real runner, not from model inference.
+- Reports carry env **key names**, statuses, and device paths — never secrets
+  (tokens, keys, or env *values* beyond non-sensitive config).
+
+## Architecture
+
+```
+ robot/kirra_doctor.py        CLI + programmatic entry (collect())
+ robot/doctor/core.py         schema v1, runner (parallel + isolation), rendering
+ robot/doctor/modules/*.py    one INDEPENDENT file per diagnostic
+ robot/rabbit_diag.py         deterministic voice trigger → speech summary
+ rabbit_boot.py               boot self-check (logs always; speaks only on FAIL)
+ kirra-doctor.service/.timer  periodic run → journal + JSON archive
+```
+
+Composition, not replacement: the pre-existing per-concern checks stay
+independently runnable and are wrapped as modules —
+`kirra_voice_doctor.sh` (→ `voice`), `lint_robot_env.sh` (→ `config`),
+`preflight_autostart.sh` (→ `autostart`, opt-in), `cold_boot_drill.sh`
+(→ `cold_boot`, opt-in), `capture_from_robot.sh` (→ `snapshot`, status-only —
+capture WRITES, so the module reports presence/age and never runs it).
+The verifier's own config self-audit (`env_config.rs` unknown-var sweep +
+`EffectiveConfig` digest, `startup_sentinel.rs`) runs verifier-side at its
+boot; the `governor`/`telemetry` modules observe it from outside via
+`/health` `/ready` `/metrics`.
+
+## Module lifecycle
+
+A module is one file in `robot/doctor/modules/` exposing:
+
+```python
+NAME = "devices"          # stable id (addressable: --module devices)
+DESCRIPTION = "..."
+DEFAULT = True            # False → opt-in only (--module NAME or --all)
+HEAVY = False             # advisory metadata
+TIMEOUT_S = 10            # isolation timeout
+def run(ctx) -> {"details": [core.detail(check, status, info, fix)],
+                 "recommended_action": str | None, "metadata": {...}}
+```
+
+The runner enforces what modules must not be trusted to do themselves:
+- **Isolation** — a raising or hanging module becomes an `UNKNOWN` result for
+  *that module only*; the others always complete.
+- **Status derivation** — module status = worst of its detail statuses;
+  `recommended_action` defaults to the first non-PASS detail's `fix`.
+- **Determinism** — modules run and report sorted by name; the only
+  nondeterminism is the timestamp/timings and the machine's actual state.
+- **Parallelism** — read-only modules share no state, so the default set runs
+  concurrently (~70 ms wall for 9 modules); `--serial` disables it.
+
+**Statuses** (severity order): `PASS < WARN < UNKNOWN < FAIL`. Policy: `FAIL`
+is *configured-but-broken* (a pinned device absent, a placeholder secret);
+"optional thing not running" (staged-not-enabled service, NTP off, offline
+DNS) is `WARN` — the doctor must not cry wolf. `UNKNOWN` = could not verify
+(not healthy: it shares the warning exit code).
+
+## Modules
+
+| Module | Default | Checks |
+|---|---|---|
+| `config` | ✔ | robot.env readable/structured, placeholders, `lint_robot_env.sh` |
+| `devices` | ✔ | motor/lidar serial, camera, `/dev/snd`, gpiochip, group memberships |
+| `governor` | ✔ | verify key pinned, consumer FFI present, verifier `/health` (implies `KIRRA_VEHICLE_CLASS` — startup aborts without one) |
+| `network` | ✔ | interfaces up, DNS (WARN offline), NTP sync |
+| `services` | ✔ | verifier/mick/ollama ports; systemd states (inactive = staged-by-design → PASS; `failed`/restart-looping → FAIL/WARN) |
+| `snapshot` | ✔ | per-robot config capture present + fresh (status only — never captures) |
+| `storage` | ✔ | disk headroom, `/etc/kirra`, root not remounted read-only |
+| `telemetry` | ✔ | `/health` `/ready` `/metrics`, max thermal zone, memory, load |
+| `voice` | ✔ | wraps `kirra_voice_doctor.sh` (engines, models, ALSA plughw drift) |
+| `autostart` | opt-in | wraps `preflight_autostart.sh` (sudo reads can prompt → never in the timer path) |
+| `cold_boot` | opt-in | wraps `cold_boot_drill.sh` (slow, needs ROS + the stack up) |
+
+## CLI
+
+```bash
+python3 robot/kirra_doctor.py               # human ✔/⚠/?/❌ report + fixes
+python3 robot/kirra_doctor.py --json        # full schema-v1 JSON
+python3 robot/kirra_doctor.py --summary     # the short spoken/logged summary
+python3 robot/kirra_doctor.py --verbose --timings
+python3 robot/kirra_doctor.py --module voice --module devices
+python3 robot/kirra_doctor.py --all         # + opt-in heavy modules
+python3 robot/kirra_doctor.py --list
+python3 robot/kirra_doctor.py --output /var/log/kirra/doctor-last.json
+```
+
+**Exit codes:** `0` healthy · `1` warnings or unverifiable · `2` failures ·
+`3` internal orchestrator error (including an unknown `--module` name).
+
+## JSON schema (v1 — stable; fields are added, never renamed)
+
+```json
+{
+  "schema_version": 1,
+  "status": "PASS|WARN|UNKNOWN|FAIL",
+  "timestamp": "2026-07-20T12:45:07Z",
+  "host": "yahboom",
+  "duration_ms": 69,
+  "summary": {"PASS": 8, "WARN": 1, "UNKNOWN": 0, "FAIL": 0},
+  "modules": [{
+    "name": "devices", "description": "…", "status": "PASS", "elapsed_ms": 19,
+    "details": [{"check": "motor serial", "status": "PASS", "info": "/dev/myserial",
+                 "fix": "…(only on non-PASS)"}],
+    "recommended_action": null,
+    "metadata": {"default": true, "heavy": false, "read_only": true}
+  }]
+}
+```
+
+A future wire format (protobuf) would be generated from this same shape;
+`schema_version` bumps on any breaking change.
+
+## Voice ("Rabbit, run diagnostics")
+
+`rabbit_diag.py` — deterministic regex (no LLM), matched in
+`rabbit_converse.handle_turn` after the OTA matcher and **before** the LLM
+router. Phrases: "run diagnostics", "run a self check/self-test",
+"run self diagnostics", "check yourself", "diagnose yourself", "how healthy
+are you". Reply = `speech_summary`: counts + at most three plain issue
+sentences (module + failing check), never paths/details — voice lines G1–G3
+in `RABBIT_VOICE_LINES.md`.
+
+## Boot
+
+`rabbit_boot._maybe_warn_misconfigured` runs the default set after the
+greeting: the summary is **logged every boot**; Rabbit **speaks only on a
+FAIL** (voice line A6 + the single top issue) — WARNs are routine and must not
+become boot nag. Falls back to the standalone `kirra_voice_doctor.sh` when the
+framework isn't staged; never breaks boot.
+
+## systemd
+
+`kirra-doctor.service` (oneshot; human report → journal, JSON archive →
+`/var/log/kirra/doctor-last.json`; exit 1 = SuccessExitStatus so warnings
+don't mark the unit failed) + `kirra-doctor.timer` (5 min after boot, then
+hourly; interval via drop-in). Staged NOT enabled by
+`install_robot_units.sh`; enable deliberately:
+`sudo systemctl enable --now kirra-doctor.timer`.
+
+## Remote exposure (follow-up, designed)
+
+The verifier already serves the posture-exempt observability GETs
+(`/health` `/ready` `/metrics`). A `/diagnostics` GET serving the timer's
+archived JSON report (path via a registered `KIRRA_*` env key, summary-only by
+default, 404 when no report exists) is the planned follow-up — it touches the
+verifier binary + route matrix, so it ships as its own reviewed PR rather
+than riding this one.
+
+## Adding a module
+
+1. New file `robot/doctor/modules/<name>.py` with the interface above.
+   Read-only; expected failures become details, never exceptions.
+2. Choose `DEFAULT` honestly: anything slow, sudo-prompting, or
+   environment-dependent is opt-in.
+3. Add a host test in `robot/kirra_doctor_test.py` (stub external commands —
+   the `voice` wrapper test is the pattern).
+4. Nothing else: discovery is automatic (`--list` shows it), the installer
+   copies the package tree, CI runs the test file.
+
+## Testing
+
+`robot/kirra_doctor_test.py` — host-only, CI-run (`Test` lane), no hardware /
+sudo / network: fake-module runners prove schema shape + ordering,
+worst-of aggregation, exit-code mapping, isolation (raise + timeout),
+recommended-action derivation, selection (default/`--all`/explicit/unknown),
+speech capping, the voice-wrapper exit mapping against a stub script, and the
+diagnostic-phrase matcher (including OTA/drive non-overlap).

--- a/docs/rabbit/RABBIT_VOICE_LINES.md
+++ b/docs/rabbit/RABBIT_VOICE_LINES.md
@@ -60,7 +60,19 @@ Legend: **LIVE** = wired today (file:seam cited) · **GAP** = to be wired · the
 | A3 | Shutting down | **LIVE** `rabbit_boot.py` `shutdown_line` (systemd `ExecStop`) | "Powering down. I've come to a safe stop — try not to miss me too much." |
 | A4 | Idle / standing by | optional (not wired) | "Standing by{name}." (or silence) |
 | A5 | LLM digest changed since it was vetted (stealth update) | **LIVE** `rabbit_boot.py` `_maybe_warn_model_changed` (only on a CONFIRMED change; unpinned/unavailable stay silent) | "A heads-up{name}: my language model has changed since it was last vetted. I'd re-run the model check before trusting me to drive." |
-| A6 | Voice-config doctor found a ❌ on boot (mic/speaker device drifted, missing engine, …) | **LIVE** `rabbit_boot.py` `_maybe_warn_misconfigured` (runs the read-only `kirra_voice_doctor.sh --quiet`; only on a FAIL, silent when clean or the doctor can't run) | "A heads-up{name}: my self-check found a configuration problem. Run the voice doctor before relying on me — my ears or voice may be off." |
+| A6 | Boot self-check found a FAIL (a drifted device, missing engine, broken prerequisite) | **LIVE** `rabbit_boot.py` `_maybe_warn_misconfigured` (runs the read-only `kirra_doctor` default set — falls back to `kirra_voice_doctor.sh`; SPEAKS only on FAIL + at most ONE issue, WARNs go to the journal — no boot nag) | "A heads-up{name}: my self-check found a configuration problem. The devices module has a problem: motor serial. Run kirra doctor for the full report." |
+
+### G. Diagnostics on demand ("Rabbit, run diagnostics")
+
+Deterministic matcher (`rabbit_diag.py`, the OTA-matcher pattern — NO LLM), handled
+before the LLM/movement path. Read-only `kirra_doctor` run; the summary speaks
+counts + at most three plain issue sentences, never paths or details.
+
+| # | Situation | Wiring | Line |
+|---|---|---|---|
+| G1 | Self-check requested, everything healthy | **LIVE** `rabbit_diag.handle` → `kirra_doctor` → `speech_summary` | "Diagnostics complete. Everything looks healthy across 9 modules." |
+| G2 | Self-check requested, problems found | **LIVE** same path | "Diagnostics complete. 1 problem found and 2 warnings. The devices module has a problem: motor serial. …" |
+| G3 | The diagnostics runner itself errored | **LIVE** `rabbit_diag.run_and_summarize` fallback | "I couldn't complete my self-check — the diagnostics runner hit an internal error. Try kirra doctor from a terminal." |
 
 ### B. Driving (you gave a command)
 

--- a/robot/doctor/__init__.py
+++ b/robot/doctor/__init__.py
@@ -1,0 +1,11 @@
+"""doctor — the R2 diagnostics framework (read-only observability layer).
+
+Composes the existing per-concern checks (kirra_voice_doctor.sh,
+preflight_autostart.sh, lint_robot_env.sh, the verifier's /health//ready//metrics)
+into one deterministic, modular runner. See docs/diagnostics.md.
+
+🔴 SECURITY MODEL: diagnostics are OBSERVABILITY, never a safety authority.
+Every module is read-only (no writes, no GPIO actuation, no firmware, no motion,
+no /intent). A diagnostics verdict never gates the planner, the governor, RSS,
+the checker, or the fence — those fail closed on their own, independently.
+"""

--- a/robot/doctor/core.py
+++ b/robot/doctor/core.py
@@ -1,0 +1,274 @@
+"""doctor.core — schema, module runner, aggregation, and report rendering.
+
+Design (docs/diagnostics.md):
+  * Every module is an independent file in doctor/modules/ exposing
+    NAME / DESCRIPTION / DEFAULT / HEAVY / TIMEOUT_S and run(ctx) -> partial
+    result. A module raising is an UNKNOWN result for that module — it never
+    stops the others (isolation is enforced HERE, not trusted per-module).
+  * Statuses: PASS < WARN < UNKNOWN < FAIL (severity order). UNKNOWN means
+    "could not verify" — not healthy, so it maps to the WARN exit code.
+  * Report schema v1 is STABLE and machine-readable (kirra_doctor --json);
+    fields are only ever added, never renamed (schema_version bumps on breaks).
+  * Deterministic: modules run sorted by name, results are emitted sorted by
+    name; the only environment-independent nondeterminism is the timestamp and
+    elapsed timings.
+  * stdlib only (urllib, subprocess, concurrent.futures) — same dependency
+    discipline as the rabbit_* scripts.
+
+Status policy (matches kirra_voice_doctor.sh): FAIL is reserved for
+"configured-but-broken" (an env var points at a missing file, a pinned device
+absent). "Optional thing not running" (a service that is staged-not-enabled,
+NTP off) is a WARN — diagnostics must not cry wolf.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import importlib
+import json
+import os
+import pkgutil
+import socket
+import subprocess
+import time
+import urllib.request
+
+SCHEMA_VERSION = 1
+STATUSES = ("PASS", "WARN", "UNKNOWN", "FAIL")
+_RANK = {"PASS": 0, "WARN": 1, "UNKNOWN": 2, "FAIL": 3}
+# Exit codes: 0 healthy / 1 warnings-or-unverifiable / 2 failures / 3 internal.
+EXIT_FOR = {"PASS": 0, "WARN": 1, "UNKNOWN": 1, "FAIL": 2}
+EXIT_INTERNAL = 3
+DEFAULT_MODULE_TIMEOUT_S = 20
+
+
+def worst(statuses):
+    """Severity-max of an iterable of statuses ('' -> PASS baseline)."""
+    w = "PASS"
+    for s in statuses:
+        if _RANK.get(s, _RANK["UNKNOWN"]) > _RANK[w]:
+            w = s if s in _RANK else "UNKNOWN"
+    return w
+
+
+def detail(check, status, info="", fix=None):
+    """One check row inside a module result."""
+    d = {"check": check, "status": status, "info": info}
+    if fix:
+        d["fix"] = fix
+    return d
+
+
+# ---- read-only helpers modules share (never raise) --------------------------
+
+def run_cmd(argv, timeout_s=15, env=None):
+    """(rc, stdout, stderr); rc -1 on timeout / not-found. Never raises."""
+    try:
+        p = subprocess.run(argv, capture_output=True, text=True,
+                           timeout=timeout_s, env=env)
+        return p.returncode, p.stdout, p.stderr
+    except subprocess.TimeoutExpired:
+        return -1, "", f"timeout after {timeout_s}s"
+    except Exception as e:  # noqa: BLE001
+        return -1, "", str(e)
+
+
+def http_status(url, timeout_s=2.0):
+    """HTTP status code for a GET, or None (unreachable). Never raises."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout_s) as r:
+            return r.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def port_listening(port, host="127.0.0.1", timeout_s=0.5):
+    try:
+        with socket.create_connection((host, port), timeout=timeout_s):
+            return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def read_env_file(path):
+    """KEY=value pairs from a robot.env-style file ('' on unreadable)."""
+    out = {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                out[k.strip()] = v.strip().strip('"').strip("'")
+    except Exception:  # noqa: BLE001
+        pass
+    return out
+
+
+def make_ctx():
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # robot/
+    repo = os.path.dirname(here)
+    renv_path = os.environ.get("KIRRA_ROBOT_ENV", "/etc/kirra/robot.env")
+    return {
+        "here": here,                       # the staged/repo robot/ dir
+        "repo": repo,                       # repo root when running from a checkout
+        "robot_env_path": renv_path,
+        "robot_env": read_env_file(renv_path),
+        "env": dict(os.environ),
+    }
+
+
+# ---- discovery + execution ---------------------------------------------------
+
+def discover_modules():
+    """Import every doctor.modules.* file exposing NAME + run(). Sorted by NAME.
+    A module that fails to IMPORT is surfaced as an UNKNOWN placeholder rather
+    than silently vanishing (a missing diagnostic must be visible)."""
+    from doctor import modules as pkg
+    found = []
+    for info in pkgutil.iter_modules(pkg.__path__):
+        if info.name.startswith("_"):
+            continue
+        try:
+            m = importlib.import_module(f"doctor.modules.{info.name}")
+            if hasattr(m, "NAME") and callable(getattr(m, "run", None)):
+                found.append(m)
+        except Exception as e:  # noqa: BLE001
+            found.append(_broken_module(info.name, str(e)))
+    return sorted(found, key=lambda m: m.NAME)
+
+
+def _broken_module(name, err):
+    class _B:  # minimal stand-in so the failure is REPORTED, not hidden
+        NAME = name
+        DESCRIPTION = "module failed to import"
+        DEFAULT, HEAVY, TIMEOUT_S = True, False, 5
+        _err = err
+
+        @staticmethod
+        def run(_ctx):
+            return {"details": [detail("import", "UNKNOWN", _B._err)],
+                    "recommended_action": "fix the module import error"}
+    return _B
+
+
+def run_module(mod, ctx, timeout_s=None):
+    """Execute one module with isolation: an exception or timeout is an UNKNOWN
+    result for THIS module only. Expected failures carry no stack traces —
+    the exception message is the operator-facing info."""
+    t0 = time.monotonic()
+    timeout = timeout_s or getattr(mod, "TIMEOUT_S", DEFAULT_MODULE_TIMEOUT_S)
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            partial = ex.submit(mod.run, ctx).result(timeout=timeout)
+    except concurrent.futures.TimeoutError:
+        partial = {"details": [detail("execution", "UNKNOWN",
+                                      f"module timed out after {timeout}s")],
+                   "recommended_action": "investigate why this check hangs"}
+    except Exception as e:  # noqa: BLE001
+        partial = {"details": [detail("execution", "UNKNOWN", f"internal error: {e}")],
+                   "recommended_action": "run this module alone with --verbose"}
+    details = partial.get("details", [])
+    status = partial.get("status") or worst(d["status"] for d in details) if details else "UNKNOWN"
+    rec = partial.get("recommended_action")
+    if rec is None:  # derive from the first non-PASS detail carrying a fix
+        for d in details:
+            if d["status"] != "PASS" and d.get("fix"):
+                rec = d["fix"]
+                break
+    return {
+        "name": mod.NAME,
+        "description": getattr(mod, "DESCRIPTION", ""),
+        "status": status,
+        "elapsed_ms": int((time.monotonic() - t0) * 1000),
+        "details": details,
+        "recommended_action": rec,
+        "metadata": {"heavy": bool(getattr(mod, "HEAVY", False)),
+                     "default": bool(getattr(mod, "DEFAULT", True)),
+                     "read_only": True,
+                     **partial.get("metadata", {})},
+    }
+
+
+def run_all(mods, ctx=None, parallel=True):
+    """Run modules (parallel by default — every module is read-only, so there is
+    no cross-module state to race) and assemble the schema-v1 report."""
+    ctx = ctx or make_ctx()
+    t0 = time.monotonic()
+    if parallel and len(mods) > 1:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(mods))) as ex:
+            results = list(ex.map(lambda m: run_module(m, ctx), mods))
+    else:
+        results = [run_module(m, ctx) for m in mods]
+    results.sort(key=lambda r: r["name"])
+    counts = {s: sum(1 for r in results if r["status"] == s) for s in STATUSES}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": worst(r["status"] for r in results),
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "host": socket.gethostname(),
+        "duration_ms": int((time.monotonic() - t0) * 1000),
+        "modules": results,
+        "summary": counts,
+    }
+
+
+# ---- rendering ---------------------------------------------------------------
+
+_MARK = {"PASS": "✔", "WARN": "⚠", "UNKNOWN": "?", "FAIL": "❌"}
+
+
+def human_report(report, verbose=False, timings=False):
+    lines = [f"== kirra doctor — {report['status']} "
+             f"({report['summary']['PASS']} pass / {report['summary']['WARN']} warn / "
+             f"{report['summary']['UNKNOWN']} unknown / {report['summary']['FAIL']} fail, "
+             f"{report['duration_ms']} ms) =="]
+    for m in report["modules"]:
+        t = f"  [{m['elapsed_ms']} ms]" if timings else ""
+        lines.append(f" {_MARK[m['status']]} {m['name']:<12} {m['status']:<7}{t}  {m['description']}")
+        for d in m["details"]:
+            if verbose or d["status"] != "PASS":
+                lines.append(f"     {_MARK[d['status']]} {d['check']}: {d['info']}")
+                if d.get("fix") and d["status"] != "PASS":
+                    lines.append(f"        ↳ fix: {d['fix']}")
+        if m["recommended_action"] and m["status"] in ("FAIL", "UNKNOWN"):
+            lines.append(f"     ↳ recommended: {m['recommended_action']}")
+    return "\n".join(lines)
+
+
+def issues(report):
+    """(module, first non-PASS detail) pairs, FAILs first — the speech source."""
+    out = []
+    for m in sorted(report["modules"], key=lambda m: -_RANK[m["status"]]):
+        if m["status"] == "PASS":
+            continue
+        first = next((d for d in m["details"] if d["status"] != "PASS"), None)
+        out.append((m, first))
+    return out
+
+
+def speech_summary(report, max_issues=3):
+    """A short spoken summary — counts + at most max_issues plain sentences.
+    Never reads details/paths aloud (the CLI/JSON has those)."""
+    probs = issues(report)
+    if not probs:
+        n = len(report["modules"])
+        return f"Diagnostics complete. Everything looks healthy across {n} modules."
+    fails = report["summary"]["FAIL"]
+    others = len(probs) - fails
+    head = "Diagnostics complete. "
+    if fails:
+        head += f"{fails} problem{'s' if fails != 1 else ''} found"
+        head += f" and {others} warning{'s' if others != 1 else ''}." if others else "."
+    else:
+        head += f"{others} warning{'s' if others != 1 else ''}, nothing broken."
+    parts = [head]
+    for m, d in probs[:max_issues]:
+        what = d["check"] if d else "a check"
+        verb = "has a problem" if m["status"] == "FAIL" else "needs a look"
+        parts.append(f"The {m['name']} module {verb}: {what}.")
+    if len(probs) > max_issues:
+        parts.append(f"And {len(probs) - max_issues} more — see the full report.")
+    return " ".join(parts)

--- a/robot/doctor/modules/__init__.py
+++ b/robot/doctor/modules/__init__.py
@@ -1,0 +1,15 @@
+"""doctor.modules — one file per diagnostic. Each exposes:
+
+  NAME         stable module id (sorted, addressable via --module NAME)
+  DESCRIPTION  one line for reports
+  DEFAULT      True → runs in the default set; False → opt-in via --module/--all
+               (heavy, sudo-prompting, or environment-dependent checks)
+  HEAVY        advisory flag surfaced in metadata
+  TIMEOUT_S    per-module isolation timeout
+  run(ctx)     -> {"details": [core.detail(...)], "recommended_action": str|None,
+                   "metadata": {...}}   (status derived = worst of details)
+
+Modules must be READ-ONLY and must never raise for an *expected* failure —
+report it as a detail. Unexpected exceptions are caught by the runner and
+become an UNKNOWN for this module only.
+"""

--- a/robot/doctor/modules/autostart.py
+++ b/robot/doctor/modules/autostart.py
@@ -1,0 +1,26 @@
+"""autostart — wraps preflight_autostart.sh. OPT-IN (DEFAULT=False): the
+preflight uses plain `sudo cat` reads that can BLOCK on a password prompt when
+run non-interactively, so it must not sit in the default (boot/voice/timer)
+path. Run it deliberately: kirra_doctor --module autostart (from a terminal).
+"""
+import os
+
+from doctor.core import detail, run_cmd
+
+NAME = "autostart"
+DESCRIPTION = "autostart readiness (wraps preflight_autostart.sh; needs sudo)"
+DEFAULT, HEAVY, TIMEOUT_S = False, True, 60
+
+
+def run(ctx):
+    script = os.path.join(ctx["repo"], "robot", "install", "preflight_autostart.sh")
+    if not os.path.isfile(script):
+        return {"details": [detail("preflight_autostart.sh", "UNKNOWN",
+                                   "not found (running outside the repo checkout?)")]}
+    rc, out, err = run_cmd(["bash", script], timeout_s=55)
+    tail = " | ".join((out.strip().splitlines() or [err.strip()])[-3:])
+    if rc == -1:
+        return {"details": [detail("preflight", "UNKNOWN", tail or "timed out (sudo prompt?)",
+                                   fix="run it in a terminal: robot/install/preflight_autostart.sh")]}
+    return {"details": [detail("preflight", "PASS" if rc == 0 else "FAIL", tail[:200],
+                               fix=None if rc == 0 else "run it directly for the per-check fixes")]}

--- a/robot/doctor/modules/cold_boot.py
+++ b/robot/doctor/modules/cold_boot.py
@@ -1,0 +1,26 @@
+"""cold_boot — wraps cold_boot_drill.sh. OPT-IN (DEFAULT=False): it sources ROS
+and inspects live topics, which is slow and environment-dependent — it is the
+POST-boot acceptance drill, not a background health check. Run deliberately:
+kirra_doctor --module cold_boot (with the stack up).
+"""
+import os
+
+from doctor.core import detail, run_cmd
+
+NAME = "cold_boot"
+DESCRIPTION = "post-boot acceptance (wraps cold_boot_drill.sh; slow, needs ROS)"
+DEFAULT, HEAVY, TIMEOUT_S = False, True, 120
+
+
+def run(ctx):
+    script = os.path.join(ctx["repo"], "robot", "cold_boot_drill.sh")
+    if not os.path.isfile(script):
+        return {"details": [detail("cold_boot_drill.sh", "UNKNOWN",
+                                   "not found (running outside the repo checkout?)")]}
+    rc, out, err = run_cmd(["bash", script], timeout_s=115)
+    tail = " | ".join((out.strip().splitlines() or [err.strip()])[-3:])
+    if rc == -1:
+        return {"details": [detail("drill", "UNKNOWN", tail or "timed out",
+                                   fix="run it directly with the stack up")]}
+    return {"details": [detail("drill", "PASS" if rc == 0 else "FAIL", tail[:200],
+                               fix=None if rc == 0 else "run robot/cold_boot_drill.sh for details")]}

--- a/robot/doctor/modules/config.py
+++ b/robot/doctor/modules/config.py
@@ -1,0 +1,49 @@
+"""config — robot.env presence, structure, and lint (composes lint_robot_env.sh).
+
+The verifier's own config self-audit (env_config.rs unknown-var sweep + the
+EffectiveConfig digest in the audit chain) runs verifier-side at ITS boot; this
+module covers the robot-side env file the doer scripts source.
+"""
+import os
+
+from doctor.core import detail, run_cmd
+
+NAME = "config"
+DESCRIPTION = "robot.env present, well-formed, and lint-clean"
+DEFAULT, HEAVY, TIMEOUT_S = True, False, 20
+
+
+def run(ctx):
+    details = []
+    path = ctx["robot_env_path"]
+    if os.path.isfile(path) and os.access(path, os.R_OK):
+        details.append(detail("robot.env readable", "PASS", path))
+    else:
+        details.append(detail("robot.env readable", "FAIL", path,
+                              fix="create it — docs/hardware/R2_VOICE_AUDIO_SETUP.md §4"))
+        return {"details": details}
+
+    env = ctx["robot_env"]
+    for key in ("KIRRA_MOTOR_PORT", "KIRRA_EXPECTED_CAR_TYPE"):
+        if env.get(key):
+            details.append(detail(f"{key} set", "PASS", env[key]))
+        else:
+            details.append(detail(f"{key} set", "WARN", "unset",
+                                  fix="see robot/install/env.template"))
+    placeholders = [k for k, v in env.items() if "__FILLED" in v]
+    if placeholders:
+        details.append(detail("placeholder values", "FAIL", ", ".join(placeholders),
+                              fix="fill the __FILLED_...__ values (installer/enrollment)"))
+    else:
+        details.append(detail("placeholder values", "PASS", "none"))
+
+    lint = os.path.join(ctx["repo"], "robot", "install", "lint_robot_env.sh")
+    if os.path.isfile(lint):
+        rc, out, err = run_cmd(["bash", lint], timeout_s=15)
+        last = (out.strip().splitlines() or [err.strip() or "no output"])[-1]
+        details.append(detail("lint_robot_env.sh", "PASS" if rc == 0 else "FAIL",
+                              last[:160], fix=None if rc == 0 else "run it directly for the full report"))
+    else:
+        details.append(detail("lint_robot_env.sh", "UNKNOWN",
+                              "script not found (running outside the repo checkout?)"))
+    return {"details": details}

--- a/robot/doctor/modules/devices.py
+++ b/robot/doctor/modules/devices.py
@@ -1,0 +1,59 @@
+"""devices — the hardware the doer layer depends on: motor serial, lidar,
+camera, sound, GPIO, and the group memberships that gate access to them.
+Existence + permission checks only — nothing is opened for writing.
+"""
+import glob
+import grp
+import os
+
+from doctor.core import detail
+
+NAME = "devices"
+DESCRIPTION = "motor/lidar serial, camera, sound, GPIO devices + permissions"
+DEFAULT, HEAVY, TIMEOUT_S = True, False, 10
+
+
+def _in_group(name):
+    try:
+        return name in [g.gr_name for g in grp.getgrall() if os.getlogin() in g.gr_mem] \
+            or grp.getgrgid(os.getgid()).gr_name == name
+    except Exception:  # noqa: BLE001 — os.getlogin can fail under systemd
+        try:
+            import pwd
+            user = pwd.getpwuid(os.getuid()).pw_name
+            return any(user in g.gr_mem for g in grp.getgrall() if g.gr_name == name)
+        except Exception:  # noqa: BLE001
+            return False
+
+
+def run(ctx):
+    details = []
+    # Pinned serial devices: configured-but-missing is a FAIL (drive/lidar dead).
+    motor = ctx["robot_env"].get("KIRRA_MOTOR_PORT", "/dev/myserial")
+    for label, path, sev in (("motor serial", motor, "FAIL"),
+                             ("lidar serial", "/dev/ydlidar", "WARN")):
+        if os.path.exists(path):
+            rw = os.access(path, os.R_OK | os.W_OK)
+            details.append(detail(label, "PASS" if rw else "WARN",
+                                  f"{path}{'' if rw else ' (no rw access — dialout group?)'}",
+                                  fix=None if rw else "sudo usermod -aG dialout $USER"))
+        else:
+            details.append(detail(label, sev, f"{path} missing",
+                                  fix="check the USB lead + vendor udev rules (capture_from_robot.sh)"))
+
+    cams = glob.glob("/dev/video*")
+    details.append(detail("camera", "PASS" if cams else "WARN",
+                          ", ".join(cams[:4]) or "no /dev/video*",
+                          fix=None if cams else "check the Astra USB lead"))
+    snd = glob.glob("/dev/snd/pcm*")
+    details.append(detail("sound devices", "PASS" if snd else "WARN",
+                          f"{len(snd)} PCM device(s)" if snd else "no /dev/snd/pcm*",
+                          fix=None if snd else "plug the USB mic/speaker — R2_VOICE_AUDIO_SETUP.md §0"))
+    gpio = glob.glob("/dev/gpiochip*")
+    details.append(detail("GPIO chardev", "PASS" if gpio else "WARN",
+                          ", ".join(gpio) or "none"))
+    for g in ("audio", "gpio", "dialout"):
+        details.append(detail(f"group: {g}", "PASS" if _in_group(g) else "WARN",
+                              "member" if _in_group(g) else "not a member",
+                              fix=None if _in_group(g) else f"sudo usermod -aG {g} $USER (re-login)"))
+    return {"details": details}

--- a/robot/doctor/modules/governor.py
+++ b/robot/doctor/modules/governor.py
@@ -1,0 +1,48 @@
+"""governor — prerequisites for the GOVERNED drive path (observability only).
+
+Verifies the pieces the ADR-0033 chokepoint needs exist: the release-token
+verify key, the consumer FFI cdylib, and the verifier itself. A FAIL here never
+gates anything — the chokepoint fails closed on its own; this just tells the
+operator BEFORE a drive attempt dead-ends.
+"""
+import os
+
+from doctor.core import detail, http_status
+
+NAME = "governor"
+DESCRIPTION = "governed-drive prerequisites (key, FFI, verifier)"
+DEFAULT, HEAVY, TIMEOUT_S = True, False, 10
+
+
+def run(ctx):
+    env, details = ctx["robot_env"], []
+
+    vk = env.get("KIRRA_GOVERNOR_VK_HEX", "")
+    if vk and "__FILLED" not in vk:
+        details.append(detail("governor verify key pinned", "PASS", f"{len(vk)} hex chars"))
+    else:
+        details.append(detail("governor verify key pinned", "FAIL",
+                              "unset or placeholder",
+                              fix="install_kirra.sh --dev-key (bench) or enroll the real key"))
+
+    so = env.get("KIRRA_CONSUMER_LIB", "/opt/kirra/lib/libkirra_consumer_ffi.so")
+    if os.path.isfile(so):
+        details.append(detail("consumer FFI cdylib", "PASS", so))
+    else:
+        details.append(detail("consumer FFI cdylib", "FAIL", f"missing: {so}",
+                              fix="robot/install/install_kirra.sh (builds + stages it)"))
+
+    # KIRRA_VEHICLE_CLASS lives in the VERIFIER env (kirra.env, root 600) — not
+    # readable here without sudo. The verifier itself fail-closes at startup if
+    # it is unset, so "verifier is up" below already implies a class was set.
+    verifier = env.get("KIRRA_VERIFIER_URL", "http://localhost:8090").rstrip("/")
+    code = http_status(f"{verifier}/health")
+    if code == 200:
+        details.append(detail("verifier /health", "PASS",
+                              f"{verifier} (implies KIRRA_VEHICLE_CLASS was set — "
+                              "startup aborts without one)"))
+    else:
+        details.append(detail("verifier /health", "WARN",
+                              f"{verifier} unreachable ({code})",
+                              fix="start the verifier — R2_LIVE_LOOP_BRINGUP.md"))
+    return {"details": details}

--- a/robot/doctor/modules/network.py
+++ b/robot/doctor/modules/network.py
@@ -1,0 +1,52 @@
+"""network — interfaces, DNS, and time sync. Offline-tolerant: this robot may
+legitimately run without internet, so external reachability is a WARN, never a
+FAIL. No pings are sent (read-only + no traffic surprises) — DNS resolution and
+kernel interface state only.
+"""
+import glob
+import os
+import socket
+
+from doctor.core import detail, run_cmd
+
+NAME = "network"
+DESCRIPTION = "interfaces up, DNS, NTP time sync"
+DEFAULT, HEAVY, TIMEOUT_S = True, False, 12
+
+
+def run(_ctx):
+    details = []
+    up = []
+    for p in glob.glob("/sys/class/net/*"):
+        name = os.path.basename(p)
+        if name == "lo":
+            continue
+        try:
+            with open(os.path.join(p, "operstate"), encoding="utf-8") as f:
+                if f.read().strip() == "up":
+                    up.append(name)
+        except OSError:
+            pass
+    details.append(detail("interfaces up", "PASS" if up else "FAIL",
+                          ", ".join(up) or "none (besides lo)",
+                          fix=None if up else "check wifi/ethernet — no link at all"))
+
+    try:
+        socket.setdefaulttimeout(3)
+        socket.getaddrinfo("github.com", 443)
+        details.append(detail("DNS resolution", "PASS", "github.com resolves"))
+    except OSError as e:
+        details.append(detail("DNS resolution", "WARN", f"cannot resolve ({e})",
+                              fix="offline is fine for driving; OTA/model pulls need DNS"))
+    finally:
+        socket.setdefaulttimeout(None)
+
+    rc, out, _ = run_cmd(["timedatectl", "show", "-p", "NTPSynchronized"], timeout_s=5)
+    if rc == 0 and "=yes" in out:
+        details.append(detail("time sync (NTP)", "PASS", "synchronized"))
+    elif rc == 0:
+        details.append(detail("time sync (NTP)", "WARN", "not synchronized",
+                              fix="timedatectl set-ntp true (cert/OTA freshness checks need sane time)"))
+    else:
+        details.append(detail("time sync (NTP)", "UNKNOWN", "timedatectl unavailable"))
+    return {"details": details}

--- a/robot/doctor/modules/services.py
+++ b/robot/doctor/modules/services.py
@@ -1,0 +1,45 @@
+"""services — loop service ports + systemd unit states.
+
+Port listeners are the primary signal (this robot runs the loop by hand today);
+systemd states are secondary because the units are deliberately STAGED, NOT
+ENABLED (R2_AUTOSTART_CHECKLIST.md) — an inactive unit is a WARN, never a FAIL.
+"""
+from doctor.core import detail, port_listening, run_cmd
+
+NAME = "services"
+DESCRIPTION = "loop services (ports) + systemd unit states"
+DEFAULT, HEAVY, TIMEOUT_S = True, False, 15
+
+PORTS = (("verifier", 8090), ("mick", 8102), ("ollama", 11434))
+UNITS = ("kirra-verifier.service", "kirra-mick.service", "kirra-planner.service",
+         "kirra-taj.service", "kirra-consumer.service", "kirra-ros-stack.service",
+         "kirra-rabbit-watch.service")
+
+
+def run(_ctx):
+    details = []
+    for name, port in PORTS:
+        if port_listening(port):
+            details.append(detail(f"{name} port :{port}", "PASS", "listening"))
+        else:
+            details.append(detail(f"{name} port :{port}", "WARN", "not listening",
+                                  fix="bring up the loop — R2_LIVE_LOOP_BRINGUP.md"))
+    for unit in UNITS:
+        rc, out, _ = run_cmd(["systemctl", "show", unit, "--no-pager",
+                              "-p", "ActiveState,SubState,NRestarts,ExecMainPID"], timeout_s=5)
+        if rc != 0:
+            details.append(detail(unit, "UNKNOWN", "systemctl unavailable"))
+            continue
+        props = dict(line.split("=", 1) for line in out.strip().splitlines() if "=" in line)
+        state = props.get("ActiveState", "?")
+        info = (f"{state}/{props.get('SubState', '?')} pid={props.get('ExecMainPID', '?')} "
+                f"restarts={props.get('NRestarts', '?')}")
+        if state == "active":
+            n = int(props.get("NRestarts", "0") or 0)
+            details.append(detail(unit, "WARN" if n > 3 else "PASS",
+                                  info, fix="journalctl -u " + unit if n > 3 else None))
+        elif state == "failed":
+            details.append(detail(unit, "FAIL", info, fix=f"journalctl -u {unit} -e"))
+        else:  # inactive = staged-not-enabled by design
+            details.append(detail(unit, "PASS", f"{info} (staged, not enabled — by design)"))
+    return {"details": details}

--- a/robot/doctor/modules/snapshot.py
+++ b/robot/doctor/modules/snapshot.py
@@ -1,0 +1,34 @@
+"""snapshot — is there a RECENT per-robot config capture (the reflash-recovery
+lifeline)? capture_from_robot.sh WRITES a snapshot, so this module does not run
+it (diagnostics are read-only) — it reports presence + age and tells the
+operator to refresh when stale.
+"""
+import os
+import socket
+import time
+
+from doctor.core import detail
+
+NAME = "snapshot"
+DESCRIPTION = "per-robot config capture present + fresh (read-only status)"
+DEFAULT, HEAVY, TIMEOUT_S = True, False, 5
+
+STALE_DAYS = 90
+
+
+def run(ctx):
+    cap = os.path.join(ctx["repo"], "robot", "install", "captured", socket.gethostname())
+    if not os.path.isdir(cap):
+        return {"details": [detail("capture dir", "WARN", f"none at {cap}",
+                                   fix="robot/install/capture_from_robot.sh (makes REFLASH.md real)")]}
+    try:
+        newest = max(os.path.getmtime(os.path.join(r, f))
+                     for r, _, fs in os.walk(cap) for f in fs)
+        age_d = (time.time() - newest) / 86400
+        status = "WARN" if age_d > STALE_DAYS else "PASS"
+        return {"details": [detail("capture age", status, f"{age_d:.0f} days old",
+                                   fix=None if status == "PASS"
+                                   else "re-run capture_from_robot.sh after config changes")]}
+    except ValueError:
+        return {"details": [detail("capture dir", "WARN", "present but empty",
+                                   fix="robot/install/capture_from_robot.sh")]}

--- a/robot/doctor/modules/storage.py
+++ b/robot/doctor/modules/storage.py
@@ -1,0 +1,49 @@
+"""storage — disk headroom, /etc/kirra presence, mount writability. Full disks
+kill the audit chain, model pulls, and journal — before anything else notices.
+"""
+import os
+import shutil
+
+from doctor.core import detail
+
+NAME = "storage"
+DESCRIPTION = "disk usage, /etc/kirra, mount writability"
+DEFAULT, HEAVY, TIMEOUT_S = True, False, 10
+
+WARN_PCT, FAIL_PCT = 85, 95
+
+
+def run(_ctx):
+    details = []
+    try:
+        du = shutil.disk_usage("/")
+        pct = 100 * du.used / du.total
+        status = "FAIL" if pct >= FAIL_PCT else ("WARN" if pct >= WARN_PCT else "PASS")
+        details.append(detail("root disk usage", status,
+                              f"{pct:.0f} % of {du.total // 2**30} GiB",
+                              fix=None if status == "PASS" else "free space (old models/logs/build artifacts)"))
+    except OSError as e:
+        details.append(detail("root disk usage", "UNKNOWN", str(e)))
+
+    etc = "/etc/kirra"
+    details.append(detail("/etc/kirra", "PASS" if os.path.isdir(etc) else "FAIL",
+                          "present" if os.path.isdir(etc) else "missing",
+                          fix=None if os.path.isdir(etc) else "robot/install/install_kirra.sh"))
+
+    # root remounted read-only (a classic SD/eMMC failure symptom) → FAIL.
+    ro = False
+    try:
+        with open("/proc/mounts", encoding="utf-8") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 4 and parts[1] == "/" and "ro" in parts[3].split(","):
+                    ro = True
+    except OSError:
+        pass
+    details.append(detail("root mount", "FAIL" if ro else "PASS",
+                          "READ-ONLY (fs error? dying storage?)" if ro else "rw",
+                          fix="dmesg | grep -i 'remount.*ro'; back up now" if ro else None))
+
+    home = os.path.expanduser("~")
+    details.append(detail("home writable", "PASS" if os.access(home, os.W_OK) else "WARN", home))
+    return {"details": details}

--- a/robot/doctor/modules/telemetry.py
+++ b/robot/doctor/modules/telemetry.py
@@ -1,0 +1,59 @@
+"""telemetry — the verifier's observability endpoints + host vitals (thermal,
+memory, load). The endpoints are the same posture-exempt GETs an operator uses
+to tell 'LockedOut' from 'service down' (Bug 2); vitals come from /proc + /sys.
+"""
+import os
+
+from doctor.core import detail, http_status
+
+NAME = "telemetry"
+DESCRIPTION = "verifier /health //ready //metrics + host vitals"
+DEFAULT, HEAVY, TIMEOUT_S = True, False, 12
+
+WARN_C, FAIL_C = 85.0, 97.0     # Orin throttles near 90s; sustained ~97 is real trouble
+WARN_MEM_PCT = 92
+
+
+def run(ctx):
+    details = []
+    base = ctx["robot_env"].get("KIRRA_VERIFIER_URL", "http://localhost:8090").rstrip("/")
+    for ep in ("/health", "/ready", "/metrics"):
+        code = http_status(f"{base}{ep}")
+        details.append(detail(f"GET {ep}", "PASS" if code == 200 else "WARN",
+                              f"{code}" if code else "unreachable",
+                              fix=None if code == 200 else "verifier down? R2_LIVE_LOOP_BRINGUP.md"))
+
+    temps = []
+    for zone in sorted(os.listdir("/sys/class/thermal") if os.path.isdir("/sys/class/thermal") else []):
+        p = f"/sys/class/thermal/{zone}/temp"
+        if zone.startswith("thermal_zone") and os.path.isfile(p):
+            try:
+                with open(p, encoding="utf-8") as f:
+                    temps.append(int(f.read().strip()) / 1000.0)
+            except (OSError, ValueError):
+                pass
+    if temps:
+        t = max(temps)
+        status = "FAIL" if t >= FAIL_C else ("WARN" if t >= WARN_C else "PASS")
+        details.append(detail("max thermal zone", status, f"{t:.1f} °C",
+                              fix=None if status == "PASS" else "check airflow/fan; reduce load"))
+    else:
+        details.append(detail("max thermal zone", "UNKNOWN", "no thermal zones readable"))
+
+    try:
+        with open("/proc/meminfo", encoding="utf-8") as f:
+            mem = {l.split(":")[0]: int(l.split()[1]) for l in f if ":" in l}
+        used_pct = 100 * (1 - mem["MemAvailable"] / mem["MemTotal"])
+        details.append(detail("memory used", "WARN" if used_pct > WARN_MEM_PCT else "PASS",
+                              f"{used_pct:.0f} %"))
+    except Exception:  # noqa: BLE001
+        details.append(detail("memory used", "UNKNOWN", "/proc/meminfo unreadable"))
+
+    try:
+        load1 = os.getloadavg()[0]
+        ncpu = os.cpu_count() or 1
+        details.append(detail("load average (1m)", "WARN" if load1 > 2 * ncpu else "PASS",
+                              f"{load1:.2f} on {ncpu} cores"))
+    except OSError:
+        details.append(detail("load average (1m)", "UNKNOWN", "unavailable"))
+    return {"details": details}

--- a/robot/doctor/modules/voice.py
+++ b/robot/doctor/modules/voice.py
@@ -1,0 +1,26 @@
+"""voice — composes the existing kirra_voice_doctor.sh (STT/TTS engines, model
+files, and the ALSA plughw drift check) as one module. The shell doctor stays
+independently runnable; this wrap only maps its exit + --quiet line into the
+framework schema.
+"""
+import os
+
+from doctor.core import detail, run_cmd
+
+NAME = "voice"
+DESCRIPTION = "voice/audio config (wraps kirra_voice_doctor.sh)"
+DEFAULT, HEAVY, TIMEOUT_S = True, False, 25
+
+
+def run(ctx):
+    script = os.path.join(ctx["here"], "kirra_voice_doctor.sh")
+    if not os.path.isfile(script):
+        return {"details": [detail("kirra_voice_doctor.sh", "UNKNOWN",
+                                   f"not found at {script}")]}
+    rc, out, err = run_cmd(["bash", script, "--quiet"], timeout_s=20)
+    line = (out.strip().splitlines() or [err.strip() or "no output"])[-1]
+    if rc == 0:
+        return {"details": [detail("voice doctor", "PASS", line)]}
+    return {"details": [detail("voice doctor", "FAIL", line,
+                               fix="run robot/kirra_voice_doctor.sh for the full ✔/❌ report")],
+            "recommended_action": "run robot/kirra_voice_doctor.sh"}

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -35,16 +35,25 @@ echo "== 1. Rabbit scripts -> ${OPT}/robot =="
 sudo install -d -m 0755 "${OPT}/robot"
 for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabbit_boot.py \
          rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py \
-         ros_env.sh kirra_voice_doctor.sh; do
+         ros_env.sh kirra_voice_doctor.sh kirra_doctor.py rabbit_diag.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"
 done
+# The diagnostics framework package (docs/diagnostics.md) — a directory, so cp -r.
+if [[ -d "${REPO}/robot/doctor" ]]; then
+  sudo rm -rf "${OPT}/robot/doctor"
+  sudo cp -r "${REPO}/robot/doctor" "${OPT}/robot/doctor"
+  sudo find "${OPT}/robot/doctor" -type d -exec chmod 0755 {} +
+  sudo find "${OPT}/robot/doctor" -type f -exec chmod 0644 {} +
+  echo "  installed ${OPT}/robot/doctor/ (diagnostics modules)"
+fi
 
 # ---- 2. render + install the units -----------------------------------------
 echo "== 2. units -> /etc/systemd/system =="
 for u in kirra-ros-stack.service kirra-rabbit-watch.service kirra-rabbit-greet.service \
-         kirra-ota-check.service kirra-ota-check.timer; do
+         kirra-ota-check.service kirra-ota-check.timer \
+         kirra-doctor.service kirra-doctor.timer; do
   [[ -f "${UNITS}/${u}" ]] || { echo "❌ missing ${UNITS}/${u}"; exit 1; }
   sed "s/__KIRRA_ROBOT_USER__/${ROBOT_USER}/g" "${UNITS}/${u}" \
     | sudo tee "/etc/systemd/system/${u}" >/dev/null

--- a/robot/install/systemd/kirra-doctor.service
+++ b/robot/install/systemd/kirra-doctor.service
@@ -1,0 +1,27 @@
+# kirra-doctor.service — one read-only diagnostics pass (docs/diagnostics.md).
+#
+# Runs the DEFAULT module set (opt-in/heavy modules excluded — the autostart
+# module's sudo reads must not block a timer). Human summary → journal; the full
+# schema-v1 JSON report is archived to /var/log/kirra/doctor-last.json (the one
+# artifact this read-only subsystem writes — its own report, never robot state).
+# Driven by kirra-doctor.timer; also runnable on demand:
+#   sudo systemctl start kirra-doctor && journalctl -u kirra-doctor -e
+#
+# STAGED, NOT ENABLED by install_robot_units.sh — enable the timer deliberately
+# (R2_AUTOSTART_CHECKLIST.md discipline):  sudo systemctl enable --now kirra-doctor.timer
+[Unit]
+Description=KIRRA robot diagnostics (read-only, observability only)
+Documentation=file:///opt/kirra/robot/kirra_doctor.py
+
+[Service]
+Type=oneshot
+User=__KIRRA_ROBOT_USER__
+EnvironmentFile=-/etc/kirra/robot.env
+# LogsDirectory creates /var/log/kirra owned by User= (no manual mkdir/chown).
+LogsDirectory=kirra
+ExecStart=/usr/bin/python3 /opt/kirra/robot/kirra_doctor.py --timings --output /var/log/kirra/doctor-last.json
+# Exit 1 (warnings) is a NORMAL outcome for a health probe, not a unit failure;
+# 2 (failures) and 3 (internal) still mark the unit failed → visible in systemctl.
+SuccessExitStatus=1
+TimeoutStartSec=180
+Nice=10

--- a/robot/install/systemd/kirra-doctor.timer
+++ b/robot/install/systemd/kirra-doctor.timer
@@ -1,0 +1,15 @@
+# kirra-doctor.timer — periodic read-only diagnostics (docs/diagnostics.md).
+# Default cadence: 5 min after boot, then hourly. Change the interval with a
+# drop-in (systemctl edit kirra-doctor.timer → [Timer] OnUnitActiveSec=…).
+# STAGED, NOT ENABLED:  sudo systemctl enable --now kirra-doctor.timer
+[Unit]
+Description=Periodic KIRRA robot diagnostics
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=1h
+RandomizedDelaySec=2min
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/robot/kirra_doctor.py
+++ b/robot/kirra_doctor.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""kirra_doctor — the R2 diagnostics orchestrator (read-only observability).
+
+Discovers the independent modules in robot/doctor/modules/, runs them in
+parallel with per-module isolation (one module failing/hanging never stops the
+others), aggregates a schema-v1 report, and renders it human- or
+machine-readable. See docs/diagnostics.md for the architecture and schema.
+
+  kirra_doctor.py                 # default module set, human report
+  kirra_doctor.py --json          # full schema-v1 JSON on stdout
+  kirra_doctor.py --summary       # the short spoken/logged summary line(s)
+  kirra_doctor.py --verbose       # include PASS details
+  kirra_doctor.py --timings       # per-module elapsed ms
+  kirra_doctor.py --module voice --module devices   # just these (incl. opt-in)
+  kirra_doctor.py --all           # default set + the opt-in heavy modules
+  kirra_doctor.py --list          # module inventory
+  kirra_doctor.py --output r.json # also write the JSON report to a file
+  kirra_doctor.py --serial        # disable parallel execution
+
+Exit codes: 0 healthy · 1 warnings/unverifiable · 2 failures · 3 internal error.
+
+🔴 Read-only. Never a safety authority: no writes to robot state, no actuation,
+no /intent — and no verdict here ever gates the planner/governor/checker/fence.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from doctor import core  # noqa: E402
+
+
+def select_modules(mods, names=None, include_all=False):
+    """Explicit --module names win (and may include opt-in modules); otherwise
+    the DEFAULT set, plus the opt-ins under --all. Unknown names are an error
+    (exit 3) — a typo'd module silently skipped would be a lie of omission."""
+    if names:
+        by_name = {m.NAME: m for m in mods}
+        missing = [n for n in names if n not in by_name]
+        if missing:
+            raise KeyError(f"unknown module(s): {', '.join(missing)} "
+                           f"(known: {', '.join(sorted(by_name))})")
+        return [by_name[n] for n in sorted(set(names))]
+    return [m for m in mods if include_all or getattr(m, "DEFAULT", True)]
+
+
+def collect(module_names=None, include_all=False, parallel=True):
+    """Programmatic entry (rabbit_boot / rabbit_diag import this): run and
+    return the schema-v1 report dict."""
+    mods = select_modules(core.discover_modules(), module_names, include_all)
+    return core.run_all(mods, parallel=parallel)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="kirra_doctor", description=__doc__.splitlines()[0])
+    ap.add_argument("--json", action="store_true", help="full JSON report on stdout")
+    ap.add_argument("--summary", action="store_true", help="short summary only")
+    ap.add_argument("--verbose", action="store_true", help="include PASS details")
+    ap.add_argument("--timings", action="store_true", help="per-module elapsed ms")
+    ap.add_argument("--module", action="append", metavar="NAME",
+                    help="run only NAME (repeatable; may name opt-in modules)")
+    ap.add_argument("--all", action="store_true", help="include opt-in heavy modules")
+    ap.add_argument("--list", action="store_true", help="list modules and exit")
+    ap.add_argument("--output", metavar="PATH", help="also write the JSON report to PATH")
+    ap.add_argument("--serial", action="store_true", help="disable parallel execution")
+    args = ap.parse_args(argv)
+
+    try:
+        mods = core.discover_modules()
+        if args.list:
+            for m in mods:
+                tag = "default" if getattr(m, "DEFAULT", True) else "opt-in"
+                tag += ", heavy" if getattr(m, "HEAVY", False) else ""
+                print(f"{m.NAME:<12} [{tag}]  {getattr(m, 'DESCRIPTION', '')}")
+            return 0
+        selected = select_modules(mods, args.module, args.all)
+        report = core.run_all(selected, parallel=not args.serial)
+    except KeyError as e:
+        print(f"kirra_doctor: {e}", file=sys.stderr)
+        return core.EXIT_INTERNAL
+    except Exception as e:  # noqa: BLE001 — orchestrator's own failure = exit 3
+        print(f"kirra_doctor: internal error: {e}", file=sys.stderr)
+        return core.EXIT_INTERNAL
+
+    if args.output:
+        try:
+            with open(args.output, "w", encoding="utf-8") as f:
+                json.dump(report, f, indent=2, sort_keys=True)
+        except OSError as e:
+            print(f"kirra_doctor: could not write {args.output}: {e}", file=sys.stderr)
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif args.summary:
+        print(core.speech_summary(report))
+    else:
+        print(core.human_report(report, verbose=args.verbose, timings=args.timings))
+    return core.EXIT_FOR[report["status"]]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/kirra_doctor_test.py
+++ b/robot/kirra_doctor_test.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""kirra_doctor_test — host tests for the diagnostics framework. CI-safe: no
+hardware, no network beyond localhost-refused connects, no sudo, no LLM. Fake
+modules exercise the runner/schema/isolation; the real voice wrapper runs
+against a stub script; the rabbit_diag matcher is tested pure.
+Runner style matches rabbit_voice_test.py (assert-based, stdlib only).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from doctor import core  # noqa: E402
+import rabbit_diag  # noqa: E402
+
+
+# ---- helpers: fake modules ---------------------------------------------------
+
+def _fake(name, details=None, exc=None, sleep=0.0, default=True):
+    class M:
+        NAME, DESCRIPTION = name, f"fake {name}"
+        DEFAULT, HEAVY, TIMEOUT_S = default, False, 1
+
+        @staticmethod
+        def run(_ctx):
+            if sleep:
+                time.sleep(sleep)
+            if exc:
+                raise exc
+            return {"details": details or [core.detail("ok", "PASS", "fine")]}
+    return M
+
+
+def _report(mods):
+    return core.run_all(mods, ctx={"robot_env": {}, "robot_env_path": "/none",
+                                   "here": "/none", "repo": "/none", "env": {}},
+                        parallel=True)
+
+
+# ---- aggregation + exit codes ------------------------------------------------
+
+def test_worst_severity_order() -> None:
+    assert core.worst([]) == "PASS"
+    assert core.worst(["PASS", "WARN"]) == "WARN"
+    assert core.worst(["WARN", "UNKNOWN"]) == "UNKNOWN"
+    assert core.worst(["UNKNOWN", "FAIL", "PASS"]) == "FAIL"
+    assert core.worst(["garbage"]) == "UNKNOWN"          # unknown token never masks
+
+
+def test_exit_code_mapping() -> None:
+    assert core.EXIT_FOR["PASS"] == 0
+    assert core.EXIT_FOR["WARN"] == 1 and core.EXIT_FOR["UNKNOWN"] == 1
+    assert core.EXIT_FOR["FAIL"] == 2 and core.EXIT_INTERNAL == 3
+
+
+# ---- schema stability --------------------------------------------------------
+
+def test_report_schema_v1_shape_and_ordering() -> None:
+    rep = _report([_fake("zeta"), _fake("alpha")])
+    for key in ("schema_version", "status", "timestamp", "host", "duration_ms",
+                "modules", "summary"):
+        assert key in rep, key
+    assert rep["schema_version"] == 1
+    assert [m["name"] for m in rep["modules"]] == ["alpha", "zeta"]   # deterministic order
+    m = rep["modules"][0]
+    for key in ("name", "description", "status", "elapsed_ms", "details",
+                "recommended_action", "metadata"):
+        assert key in m, key
+    assert m["metadata"]["read_only"] is True
+    json.loads(json.dumps(rep))                                        # JSON-clean
+
+
+# ---- isolation: one bad module never stops the others ------------------------
+
+def test_raising_module_is_unknown_and_isolated() -> None:
+    rep = _report([_fake("boom", exc=RuntimeError("kaput")), _fake("good")])
+    by = {m["name"]: m for m in rep["modules"]}
+    assert by["boom"]["status"] == "UNKNOWN"
+    assert "kaput" in by["boom"]["details"][0]["info"]
+    assert "Traceback" not in json.dumps(rep)             # no stack traces in reports
+    assert by["good"]["status"] == "PASS"
+    assert rep["status"] == "UNKNOWN"                     # worst-of
+
+
+def test_hanging_module_times_out_isolated() -> None:
+    slow = _fake("slow", sleep=5)
+    slow.TIMEOUT_S = 0.2
+    rep = _report([slow, _fake("fast")])
+    by = {m["name"]: m for m in rep["modules"]}
+    assert by["slow"]["status"] == "UNKNOWN" and "timed out" in by["slow"]["details"][0]["info"]
+    assert by["fast"]["status"] == "PASS"
+
+
+# ---- status + recommended action derivation ----------------------------------
+
+def test_status_derived_worst_of_details_and_fix_promoted() -> None:
+    mod = _fake("mix", details=[core.detail("a", "PASS", ""),
+                                core.detail("b", "FAIL", "broken", fix="do X"),
+                                core.detail("c", "WARN", "meh")])
+    rep = _report([mod])
+    m = rep["modules"][0]
+    assert m["status"] == "FAIL"
+    assert m["recommended_action"] == "do X"
+
+
+# ---- selection ---------------------------------------------------------------
+
+def test_selection_default_all_explicit_and_unknown() -> None:
+    from kirra_doctor import select_modules
+    mods = [_fake("a"), _fake("b", default=False)]
+    assert [m.NAME for m in select_modules(mods)] == ["a"]
+    assert [m.NAME for m in select_modules(mods, include_all=True)] == ["a", "b"]
+    assert [m.NAME for m in select_modules(mods, names=["b"])] == ["b"]  # opt-in addressable
+    try:
+        select_modules(mods, names=["nope"])
+        assert False, "unknown module must raise"
+    except KeyError as e:
+        assert "nope" in str(e)
+
+
+# ---- speech summary ----------------------------------------------------------
+
+def test_speech_summary_healthy_and_issue_capped() -> None:
+    healthy = _report([_fake("a"), _fake("b")])
+    s = core.speech_summary(healthy)
+    assert "healthy" in s and "2 modules" in s
+    bad = _report([_fake(n, details=[core.detail("dev", "FAIL", "x")]) for n in "abcde"])
+    s2 = core.speech_summary(bad, max_issues=3)
+    assert "5 problems found" in s2
+    assert "more — see the full report" in s2             # capped, not a monologue
+    assert "/" not in s2.split("report")[0]               # no paths spoken
+
+
+# ---- the real voice wrapper against a stub shell doctor ----------------------
+
+def test_voice_module_maps_stub_exit_codes() -> None:
+    from doctor.modules import voice
+    with tempfile.TemporaryDirectory() as tmp:
+        stub = os.path.join(tmp, "kirra_voice_doctor.sh")
+        ctx = {"here": tmp, "repo": tmp, "robot_env": {}, "robot_env_path": "/none", "env": {}}
+        with open(stub, "w", encoding="utf-8") as f:
+            f.write("#!/bin/sh\necho OK\nexit 0\n")
+        assert core.run_module(voice, ctx)["status"] == "PASS"
+        with open(stub, "w", encoding="utf-8") as f:
+            f.write("#!/bin/sh\necho 'FAIL: mic drifted'\nexit 1\n")
+        r = core.run_module(voice, ctx)
+        assert r["status"] == "FAIL" and "mic drifted" in r["details"][0]["info"]
+
+
+# ---- deterministic voice matcher ---------------------------------------------
+
+def test_diag_matcher_positive() -> None:
+    for u in ("Rabbit, run diagnostics", "run a self check", "run self diagnostics",
+              "check yourself", "please run a self-test", "diagnose yourself",
+              "how healthy are you"):
+        assert rabbit_diag.matches(u), u
+
+
+def test_diag_matcher_negative_no_overlap() -> None:
+    for u in ("creep forward one meter", "take us to the door", "what do you see?",
+              "check for updates", "apply the update", "nice weather today",
+              "check the door", ""):
+        assert not rabbit_diag.matches(u), u
+
+
+# ---- CLI plumbing (list + json against the REAL registry, no env needed) -----
+
+def test_cli_list_and_json_run() -> None:
+    import kirra_doctor
+    assert kirra_doctor.main(["--list"]) == 0
+    # A full real run must complete without raising and exit 0/1/2 (environment-
+    # dependent statuses are fine — the contract is bounded exit + valid schema).
+    code = kirra_doctor.main(["--json", "--module", "storage"])
+    assert code in (0, 1, 2)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    print("kirra_doctor host tests (no hardware):")
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok   {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/rabbit_boot.py
+++ b/robot/rabbit_boot.py
@@ -60,25 +60,44 @@ def shutdown_line():
     return "Powering down. I've come to a safe stop — try not to miss me too much."
 
 
-def misconfig_line():
-    """A6: the voice-config doctor found a ❌ (e.g. a mic/speaker device drifted,
-    a missing engine). Generic advisory — run the doctor for specifics."""
-    return (f"A heads-up{name_slot()}: my self-check found a configuration problem. "
-            "Run the voice doctor before relying on me — my ears or voice may be off.")
+def misconfig_line(top_issue=None):
+    """A6: the boot self-check found a FAIL (a drifted device, a missing engine,
+    a broken prerequisite). Speaks at most ONE issue; the full report is
+    kirra_doctor from a terminal. Back-compatible: no-arg = generic advisory."""
+    base = f"A heads-up{name_slot()}: my self-check found a configuration problem."
+    tail = top_issue if top_issue else \
+        "Run the voice doctor before relying on me — my ears or voice may be off."
+    return f"{base} {tail} Run kirra doctor for the full report." if top_issue else f"{base} {tail}"
 
 
 def _maybe_warn_misconfigured():
-    """Channel-A advisory if the read-only voice-config doctor (kirra_voice_doctor.sh,
-    next to this file) reports a FAIL. Best-effort and lazy; never breaks boot, and
-    stays silent when the doctor passes or can't run (e.g. not staged here)."""
+    """Channel-A advisory from the boot self-check. Prefers the full kirra_doctor
+    framework (default read-only module set): logs the summary to stderr every
+    boot, but SPEAKS only on a FAIL (voice line A6 + the top issue) — WARNs are
+    common (staged-not-enabled services, NTP) and must not become boot nag.
+    Falls back to the standalone kirra_voice_doctor.sh if the framework isn't
+    staged. Best-effort: a self-check advisory must never break boot."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    try:
+        from kirra_doctor import collect  # lazy; same dir (repo or /opt/kirra/robot)
+        from doctor.core import issues, speech_summary
+        report = collect()
+        print(f"rabbit_boot self-check: {speech_summary(report)}", file=sys.stderr)
+        if report["status"] == "FAIL":
+            top = issues(report)[0]
+            speak(misconfig_line(f"The {top[0]['name']} module has a problem"
+                                 + (f": {top[1]['check']}." if top[1] else ".")))
+        return
+    except Exception:  # noqa: BLE001 — fall back to the shell voice doctor
+        pass
     import subprocess
-    doctor = os.path.join(os.path.dirname(os.path.abspath(__file__)), "kirra_voice_doctor.sh")
+    doctor = os.path.join(here, "kirra_voice_doctor.sh")
     if not os.path.exists(doctor):
         return
     try:
         rc = subprocess.run(["bash", doctor, "--quiet"], timeout=15,
                             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode
-    except Exception:  # noqa: BLE001 — a self-check advisory must never break boot
+    except Exception:  # noqa: BLE001
         return
     if rc != 0:
         speak(misconfig_line())

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -47,6 +47,7 @@ from rabbit_ask import (  # noqa: E402
     RABBIT_SYSTEM, MICK, MODEL, OLLAMA, gather_perception, gather_posture,
     gather_stop_reason, speak,
 )
+import rabbit_diag  # noqa: E402 — deterministic self-check voice command (read-only)
 import rabbit_ota  # noqa: E402 — deterministic OTA voice commands (NOT the movement door)
 from rabbit_persona import name_slot, operator_name  # noqa: E402
 
@@ -169,6 +170,17 @@ def handle_turn(history, utterance):
         speak(ota_reply)
         history.append({"role": "user", "content": utterance})
         history.append({"role": "assistant", "content": ota_reply})
+        del history[: max(0, len(history) - 2 * MAX_TURNS)]
+        return
+
+    # "Run diagnostics" / "check yourself" — deterministic like OTA, matched
+    # BEFORE the LLM (a self-check must never depend on model inference), and
+    # read-only (kirra_doctor; no /intent, no motion).
+    diag_reply = rabbit_diag.handle(utterance)
+    if diag_reply is not None:
+        speak(diag_reply)
+        history.append({"role": "user", "content": utterance})
+        history.append({"role": "assistant", "content": diag_reply})
         del history[: max(0, len(history) - 2 * MAX_TURNS)]
         return
 

--- a/robot/rabbit_diag.py
+++ b/robot/rabbit_diag.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""rabbit_diag — DETERMINISTIC voice-triggered diagnostics (Channel A).
+
+"Rabbit, run diagnostics" / "run a self check" / "check yourself" → run the
+read-only kirra_doctor default set → speak the SHORT summary (counts + at most
+three plain issue sentences — never paths/details; the CLI/JSON has those).
+
+Deterministic like rabbit_ota: a regex matcher, NO LLM inference — a diagnostics
+request must never depend on a model's mood, and the LLM must never be able to
+'decide' to run (or fake) a self-check. Matched utterances are handled BEFORE
+the LLM/movement path in rabbit_converse.handle_turn.
+
+🔴 Channel A only: kirra_doctor is read-only observability. No /intent, no
+motion, no writes — and no diagnostic verdict gates the checker/governor/fence
+(they fail closed on their own).
+"""
+import re
+
+# Movement-safe by construction: every alternative requires a self-check noun/
+# reflexive ("check yourself", "self test", "diagnostics") — none of these
+# overlap the OTA matcher ("check for updates") or a drive utterance.
+_DIAG_RE = re.compile(
+    r"\b(run\s+(a\s+)?(self[\s-]*)?(check|test|diagnostics?)"
+    r"|(self[\s-]*)(check|test|diagnostics?)"
+    r"|check\s+yourself"
+    r"|diagnose\s+yourself"
+    r"|how\s+healthy\s+are\s+you)\b",
+    re.IGNORECASE,
+)
+
+
+def matches(utterance):
+    """Pure matcher (unit-tested separately from execution)."""
+    return bool(_DIAG_RE.search(utterance or ""))
+
+
+def run_and_summarize():
+    """Run the default read-only module set; return the spoken summary."""
+    try:
+        from kirra_doctor import collect  # lazy: same dir (repo or /opt/kirra/robot)
+        from doctor.core import speech_summary
+        return speech_summary(collect())
+    except Exception:  # noqa: BLE001 — the internal-error voice line, no traceback
+        return ("I couldn't complete my self-check — the diagnostics runner hit "
+                "an internal error. Try kirra_doctor from a terminal.")
+
+
+def handle(utterance):
+    """rabbit_ota.handle contract: the spoken reply, or None if not a
+    diagnostics request (the turn falls through to the LLM router)."""
+    if not matches(utterance):
+        return None
+    return run_and_summarize()


### PR DESCRIPTION
Evolves #1020's voice doctor into the full diagnostics subsystem: the robot runs deterministic self-diagnostics **from the CLI, by voice, at boot, and on a timer**, with one stable machine-readable schema — while remaining **pure observability**: read-only, never a safety authority, never gating motion. The verifier/checker/fence fail closed on their own, independently; a green doctor is not a permission and a red doctor is not a stop.

## Architecture (and why)
```
robot/kirra_doctor.py        CLI + programmatic collect()
robot/doctor/core.py         schema v1, parallel runner + isolation, rendering
robot/doctor/modules/*.py    one INDEPENDENT file per diagnostic (11 modules)
robot/rabbit_diag.py         deterministic voice trigger → spoken summary
kirra-doctor.service/.timer  periodic run → journal + JSON archive
```
Key decisions, each grounded in an existing repo discipline:
- **Composition, not replacement** — `kirra_voice_doctor.sh`, `lint_robot_env.sh`, `preflight_autostart.sh`, `cold_boot_drill.sh` stay independently runnable and are *wrapped* as modules. `capture_from_robot.sh` **writes** a snapshot, so its module reports presence/age only — a read-only framework must not run it.
- **Isolation enforced by the runner, not trusted per-module** — a raising or hanging module becomes `UNKNOWN` *for that module only* (proven by tests); no stack traces in reports, message-only operator info.
- **Honest status policy** (the voice-doctor precedent): `FAIL` = configured-but-broken; optional-not-running (staged-not-enabled units, NTP, offline DNS) = `WARN` — no crying wolf. `UNKNOWN` = could-not-verify and shares the warning exit code (unverifiable ≠ healthy).
- **Deterministic voice trigger** (the `rabbit_ota` pattern): regex, **no LLM inference** — the model can neither decide to run nor fake a self-check; matcher proven non-overlapping with OTA and drive utterances. Speech = counts + ≤3 plain sentences, never paths.
- **Boot speaks only on FAIL** (A6 + single top issue); WARNs log to the journal — routine warnings must not become boot nag. Never breaks boot; falls back to the shell doctor when the framework isn't staged.
- **Opt-in for anything that can block**: `autostart` (plain-`sudo` reads can prompt) and `cold_boot` (slow, needs ROS) are `DEFAULT=False` — excluded from the boot/voice/timer paths, addressable via `--module`/`--all`.
- **stdlib-only Python** — same dependency discipline as the `rabbit_*` layer; parallel default set completes in ~70 ms.

## Surfaces
- **CLI**: `--json --summary --verbose --timings --module N --all --list --output F --serial`; exits `0/1/2/3` (unknown `--module` = 3, never silently skipped — a typo'd module skipped would be a lie of omission).
- **Voice** (`G1–G3` catalogued): "run diagnostics" / "run a self check" / "check yourself" / "diagnose yourself" → real runner → spoken summary.
- **Boot**: logged every boot; spoken A6 on FAIL.
- **systemd**: `kirra-doctor.timer` (5 min post-boot + hourly, drop-in configurable) → journal + JSON archive at `/var/log/kirra/doctor-last.json` (the *one* artifact this read-only subsystem writes: its own report). `SuccessExitStatus=1` so warnings don't mark the unit failed. Staged, **not** enabled.
- **Remote**: the verifier `/diagnostics` GET (serving the archived report, summary-only, env-key-registered path) is **designed in `docs/diagnostics.md` and deliberately deferred to its own PR** — it touches the verifier binary + route authorization matrix, which deserves separate review rather than riding a robot-layer PR.

## Schema (v1, stable)
Versioned, fields added-never-renamed; `status/timestamp/host/duration_ms/summary/modules[{name,status,elapsed_ms,details[{check,status,info,fix}],recommended_action,metadata}]`. A future protobuf generates from this shape.

## Verification
- **12/12** framework host tests (schema shape+ordering, worst-of aggregation + exit codes, isolation via raise *and* timeout, fix promotion, selection incl. unknown-name→3, speech capping, voice wrapper against a stub script, matcher overlap) + **16/16** existing voice tests — wired into the CI `Test` lane.
- Real end-to-end run in the dev sandbox: correctly reported the sandbox's genuine non-robot state (missing `/etc/kirra`, absent devices) with per-check fixes; `rabbit_diag.handle("Rabbit, run diagnostics")` returned a real spoken summary; `"creep forward one meter"` → `None` (falls through to the LLM/movement path untouched).
- `bash -n` + `py_compile` + ci.yml YAML clean.

## Security
Read-only throughout: no writes to robot state, no GPIO actuation, no firmware, no motion, no `/intent`. No influence on planner/governor/RSS/checker/fence. Reports carry env **key names** and statuses, never secret values.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_