### PR TITLE
robot: back up yahboom per-unit config (ydlidar params, udev rules, provenance)

### DIFF
--- a/robot/install/captured/yahboom/devices.txt
+++ b/robot/install/captured/yahboom/devices.txt
@@ -1,0 +1,6 @@
+# captured device state (yahboom)
+/dev/myserial -> /dev/ttyUSB2
+/dev/ydlidar -> /dev/ttyUSB0
+/dev/rplidar -> /dev/ttyUSB0
+crw-rw-rw- 1 root dialout 188, 0 Jul 20 19:07 /dev/ttyUSB0
+crwxrwxrwx 1 root dialout 188, 2 Jul 20 19:07 /dev/ttyUSB2

--- a/robot/install/captured/yahboom/udev/rplidar.rules
+++ b/robot/install/captured/yahboom/udev/rplidar.rules
@@ -1,0 +1,1 @@
+KERNEL=="ttyUSB*", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE:="0666", GROUP:="dialout",  SYMLINK+="rplidar"

--- a/robot/install/captured/yahboom/udev/serial.rules
+++ b/robot/install/captured/yahboom/udev/serial.rules
@@ -1,0 +1,4 @@
+KERNEL=="ttyUSB*",ATTRS{idVendor}=="1a86",ATTRS{idProduct}=="7523",MODE:="0777",SYMLINK+="myserial"
+
+
+

--- a/robot/install/captured/yahboom/udev/ydlidar.rules
+++ b/robot/install/captured/yahboom/udev/ydlidar.rules
@@ -1,0 +1,1 @@
+KERNEL=="ttyUSB*", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE:="0666", GROUP:="dialout",  SYMLINK+="ydlidar"

--- a/robot/install/captured/yahboom/versions.txt
+++ b/robot/install/captured/yahboom/versions.txt
@@ -1,0 +1,8 @@
+# provenance stamps (yahboom)
+Linux yahboom 5.15.148-tegra #1 SMP PREEMPT Tue Jan 7 17:14:38 PST 2025 aarch64 aarch64 aarch64 GNU/Linux
+# R36 (release), REVISION: 4.3, GCID: 38968081, BOARD: generic, EABI: aarch64, DATE: Wed Jan  8 01:49:37 UTC 2025
+# KERNEL_VARIANT: oot
+TARGET_USERSPACE_LIB_DIR=nvidia
+TARGET_USERSPACE_LIB_DIR_PATH=usr/lib/aarch64-linux-gnu/nvidia
+ROS 2 humble present
+Rosmaster_Lib: /usr/local/lib/python3.10/dist-packages/Rosmaster_Lib-3.3.9-py3.10.egg/Rosmaster_Lib

--- a/robot/install/captured/yahboom/ydlidar/G1.yaml
+++ b/robot/install/captured/yahboom/ydlidar/G1.yaml
@@ -1,0 +1,23 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: /dev/ttyUSB0
+    frame_id: laser
+    ignore_array: ""
+    baudrate: 230400
+    lidar_type: 1
+    device_type: 0
+    sample_rate: 9
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: true
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: false
+    intensity: false
+    support_motor_dtr: false
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 16.0
+    range_min: 0.1
+    frequency: 10.0
+    invalid_range_is_inf: false

--- a/robot/install/captured/yahboom/ydlidar/G2.yaml
+++ b/robot/install/captured/yahboom/ydlidar/G2.yaml
@@ -1,0 +1,24 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: /dev/ttyUSB0
+    frame_id: laser
+    ignore_array: ""
+    baudrate: 230400
+    lidar_type: 1
+    device_type: 0
+    sample_rate: 4
+    intensity_bit: 10
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: true
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: false
+    intensity: true
+    support_motor_dtr: false
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 16.0
+    range_min: 0.1
+    frequency: 10.0
+    invalid_range_is_inf: false

--- a/robot/install/captured/yahboom/ydlidar/G6.yaml
+++ b/robot/install/captured/yahboom/ydlidar/G6.yaml
@@ -1,0 +1,23 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: /dev/ttyUSB0
+    frame_id: laser
+    ignore_array: ""
+    baudrate: 512000
+    lidar_type: 1
+    device_type: 0
+    sample_rate: 18
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: true
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: false
+    intensity: false
+    support_motor_dtr: false
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 25.0
+    range_min: 0.1
+    frequency: 10.0
+    invalid_range_is_inf: false

--- a/robot/install/captured/yahboom/ydlidar/GS2.yaml
+++ b/robot/install/captured/yahboom/ydlidar/GS2.yaml
@@ -1,0 +1,24 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: /dev/ttyUSB0
+    frame_id: laser
+    ignore_array: ""
+    baudrate: 921600
+    lidar_type: 3
+    device_type: 0
+    sample_rate: 9
+    intensity_bit: 0
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: true
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: false
+    intensity: false
+    support_motor_dtr: false
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 1.0
+    range_min: 0.025
+    frequency: 10.0
+    invalid_range_is_inf: false

--- a/robot/install/captured/yahboom/ydlidar/TEA.yaml
+++ b/robot/install/captured/yahboom/ydlidar/TEA.yaml
@@ -1,0 +1,23 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: 192.168.0.11
+    frame_id: laser
+    ignore_array: ""
+    baudrate: 8090
+    lidar_type: 0
+    device_type: 1
+    sample_rate: 20
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: true
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: false
+    intensity: true
+    support_motor_dtr: false
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 50.0
+    range_min: 0.01
+    frequency: 20.0
+    invalid_range_is_inf: false

--- a/robot/install/captured/yahboom/ydlidar/TG.yaml
+++ b/robot/install/captured/yahboom/ydlidar/TG.yaml
@@ -1,0 +1,23 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: /dev/ydlidar
+    frame_id: laser
+    ignore_array: ""
+    baudrate: 512000
+    lidar_type: 0
+    device_type: 0
+    sample_rate: 20
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: false
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: false
+    intensity: false
+    support_motor_dtr: false
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 50.0
+    range_min: 0.01
+    frequency: 10.0
+    invalid_range_is_inf: false

--- a/robot/install/captured/yahboom/ydlidar/TminiPro.yaml
+++ b/robot/install/captured/yahboom/ydlidar/TminiPro.yaml
@@ -1,0 +1,24 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: /dev/ttyUSB0
+    frame_id: laser
+    ignore_array: ""
+    baudrate: 230400
+    lidar_type: 1
+    device_type: 0
+    sample_rate: 4
+    intensity_bit: 8
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: true
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: false
+    intensity: true
+    support_motor_dtr: false
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 12.0
+    range_min: 0.03
+    frequency: 10.0
+    invalid_range_is_inf: false

--- a/robot/install/captured/yahboom/ydlidar/X2.yaml
+++ b/robot/install/captured/yahboom/ydlidar/X2.yaml
@@ -1,0 +1,23 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: /dev/ttyUSB0
+    frame_id: laser
+    ignore_array: ""
+    baudrate: 115200
+    lidar_type: 1
+    device_type: 0
+    sample_rate: 3
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: true
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: true
+    intensity: false
+    support_motor_dtr: true
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 12.0
+    range_min: 0.1
+    frequency: 10.0
+    invalid_range_is_inf: false

--- a/robot/install/captured/yahboom/ydlidar/X4-Pro.yaml
+++ b/robot/install/captured/yahboom/ydlidar/X4-Pro.yaml
@@ -1,0 +1,23 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: /dev/ttyUSB0
+    frame_id: laser
+    ignore_array: ""
+    baudrate: 128000
+    lidar_type: 1
+    device_type: 0
+    sample_rate: 5
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: true
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: true
+    intensity: false
+    support_motor_dtr: false
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 12.0
+    range_min: 0.1
+    frequency: 10.0
+    invalid_range_is_inf: false

--- a/robot/install/captured/yahboom/ydlidar/X4.yaml
+++ b/robot/install/captured/yahboom/ydlidar/X4.yaml
@@ -1,0 +1,23 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: /dev/ttyUSB0
+    frame_id: laser
+    ignore_array: ""
+    baudrate: 128000
+    lidar_type: 1
+    device_type: 0
+    sample_rate: 5
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: true
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: false
+    intensity: false
+    support_motor_dtr: true
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 12.0
+    range_min: 0.1
+    frequency: 10.0
+    invalid_range_is_inf: false

--- a/robot/install/captured/yahboom/ydlidar/ydlidar.yaml
+++ b/robot/install/captured/yahboom/ydlidar/ydlidar.yaml
@@ -1,0 +1,23 @@
+ydlidar_ros2_driver_node:
+  ros__parameters:
+    port: /dev/ydlidar
+    frame_id: laser
+    ignore_array: ""
+    baudrate: 512000
+    lidar_type: 0
+    device_type: 0
+    sample_rate: 20
+    abnormal_check_count: 4
+    fixed_resolution: true
+    reversion: true
+    inverted: true
+    auto_reconnect: true
+    isSingleChannel: false
+    intensity: false
+    support_motor_dtr: false
+    angle_max: 180.0
+    angle_min: -180.0
+    range_max: 50.0
+    range_min: 0.01
+    frequency: 10.0
+    invalid_range_is_inf: false


### PR DESCRIPTION
## What

Backs up the per-robot config snapshot from the **yahboom** R2 into the repo, under `robot/install/captured/yahboom/`. Captured on hardware by `robot/install/capture_from_robot.sh` (Orin NX, JetPack 6.2 / L4T R36.4.3, ROS 2 Humble).

16 files, all pure data:
- `ydlidar/*.yaml` — the 11 ydlidar driver param sets (`G1`/`G2`/`G6`/`GS2`/`TEA`/`TG`/`TminiPro`/`X2`/`X4`/`X4-Pro` + the active `ydlidar.yaml` symlink target)
- `udev/*.rules` — the serial/lidar udev `SYMLINK` rules (`/dev/myserial`, `/dev/ydlidar`, `/dev/rplidar`) — the stable device names the stack binds to
- `devices.txt` — captured `/dev` symlink → `ttyUSB` resolution + permissions
- `versions.txt` — kernel / L4T / ROS / `Rosmaster_Lib` provenance stamps

## Why

The diagnostics `snapshot` module (`robot/doctor/modules/snapshot.py`, shipped in #1021) checks for exactly this captured config and WARNed on its first live hardware run because nothing was captured yet. Committing the snapshot:
- makes the config **survive a reflash** (that's the whole point of `capture_from_robot.sh`),
- clears the `snapshot` WARN — the module reports present + fresh,
- gives a replayable per-unit record alongside the `docs/hardware/R2_VOICE_AUDIO_SETUP.md` reconfigure guide.

## Safety

Read-only observability artifact — no code, no CI surface, nothing that participates in safety. Contents are device paths + USB VID/PID + version strings only; **no secrets** (no tokens, keys, or env values). The `snapshot` module never *runs* capture (capture writes); it only reports presence/age.

## Verification

The 16 reconstructed files were checked against the robot's own git blob hashes for the 13 files where those were available — all match byte-for-byte (e.g. `devices.txt` `0f111c23`, `udev/serial.rules` `4182a112`, `ydlidar/G1.yaml` `96a9e3a0`, `ydlidar/X2.yaml` `233abf66`). First live `kirra_doctor` run post-capture: `snapshot` → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_