### PR TITLE
fix(checker): enforce lateral-accel/rollover envelope on the outgoing command (S1, #1024)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -52,4 +52,13 @@ exclude_re = [
     # behaviourally identical for any real perception input.
     "replace < with <= in validate_trajectory_slow_capped",
     "replace < with <= in predictive_rss_breach",
+    # S1 (#1024) fast-loop lateral-acceleration bound: `lhs <= rhs` vs `lhs < rhs`
+    # differ only when the command's lateral accel EXACTLY equals the envelope
+    # ceiling (v²·|tan δ| == (max+tol)·L to the bit) — a measure-zero boundary,
+    # behaviourally identical for any real command. Same class as the RSS gates
+    # above. The bound was deliberately extracted into its own one-comparison
+    # function so this exclusion is precise (the only `<=` there); the `*`/`+`
+    # arithmetic and both `>` steering limits in `check_command_conforms` ARE
+    # killed by the conformance tests.
+    "replace <= with < in command_within_lateral_envelope",
 ]

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -677,6 +677,9 @@ pub async fn run_adapter(
                         traj.points.clone(),
                         TrajectoryVerdict::MRCFallback,
                         None,
+                        // No lateral envelope on the removal path — the MRC arm
+                        // removes the slot and ignores it (S1, #1024).
+                        None,
                         now_ms_fresh(),
                     );
                     continue;
@@ -833,12 +836,23 @@ pub async fn run_adapter(
             // staleness reads — so a forward wall-clock step can never make a fresh
             // trajectory look stale. (The capture record below keeps a separate
             // wall timestamp for human/audit correlation.)
+            // S1 fix (#1024): derive the posture-composed lateral envelope from
+            // the SAME contract the slow loop enforced (via the shared
+            // `to_posture_kinematics_contract` mapping) and attach it, so the fast
+            // loop can bound the outgoing command's lateral acceleration — not
+            // just its steering against the static rack limit.
+            let lateral_envelope = crate::state::LateralEnvelope::from_contract(
+                &slow_state
+                    .config
+                    .to_posture_kinematics_contract(posture.clone()),
+            );
             slow_state.update_trajectory(
                 traj.asset_id.clone(),
                 traj.trajectory_id,
                 traj.points.clone(),
                 verdict,
                 effective_ceiling,
+                Some(lateral_envelope),
                 now_mono,
             );
             let elapsed_us = start.elapsed().as_micros();

--- a/crates/kirra-ros2-adapter/src/state.rs
+++ b/crates/kirra-ros2-adapter/src/state.rs
@@ -42,7 +42,9 @@ pub use kirra_core::trajectory::{
 // `kirra_ros2_adapter::state::*` resolve unchanged. The ROS RUNTIME store
 // (`AdaptorState`, subscription stamps, `monotonic_now_ms`, `IncomingTrajectory`,
 // `SUBSCRIPTION_STALENESS_TIMEOUT_MS`) stays below — it is adapter-only.
-pub use kirra_trajectory::state::{AcceptedTrajectory, EgoOdom, DEFAULT_MAX_AGE_MS};
+pub use kirra_trajectory::state::{
+    AcceptedTrajectory, EgoOdom, LateralEnvelope, DEFAULT_MAX_AGE_MS,
+};
 
 /// Default subscription-staleness timeout (ms). Phase 4: the adapter's
 /// own SG9 fail-closed path. If any of the REQUIRED upstream
@@ -549,6 +551,14 @@ impl AdaptorState {
     /// verdict, `None` on `Accept`. Attached to the installed record so the
     /// fast loop conforms a `Clamp`-verdict command to the DERATED ceiling, not
     /// the planner's original speed. Ignored on the removal (MRC/Pending) arm.
+    /// `lateral_envelope` (S1 fix, #1024): the checker's posture-composed lateral
+    /// envelope (steering hard-limit + lateral-accel + wheelbase). Attached so
+    /// the fast loop bounds the outgoing command's lateral acceleration, not just
+    /// its steering against the static rack limit. `None` → static-limit fallback.
+    // The promote path carries the full accepted-trajectory record shape (ids +
+    // points + verdict + both derate side-channels + stamp); grouping into a
+    // struct is churn for a single call site, so the arg count is intentional.
+    #[allow(clippy::too_many_arguments)]
     pub fn update_trajectory(
         &self,
         asset_id: impl Into<String>,
@@ -556,6 +566,7 @@ impl AdaptorState {
         points: Vec<TrajectoryPoint>,
         verdict: TrajectoryVerdict,
         effective_ceiling: Option<Vec<f64>>,
+        lateral_envelope: Option<LateralEnvelope>,
         now_ms: u64,
     ) {
         let asset_id = asset_id.into();
@@ -568,7 +579,8 @@ impl AdaptorState {
                     verdict,
                     now_ms,
                 )
-                .with_effective_ceiling(effective_ceiling);
+                .with_effective_ceiling(effective_ceiling)
+                .with_lateral_envelope(lateral_envelope);
                 self.install(record);
             }
             TrajectoryVerdict::MRCFallback | TrajectoryVerdict::Pending => {

--- a/crates/kirra-trajectory/src/config.rs
+++ b/crates/kirra-trajectory/src/config.rs
@@ -10,6 +10,7 @@
 
 use kirra_core::containment::VehicleFootprint;
 use kirra_core::kinematics_contract::{VehicleKinematicsContract, URBAN_ODD_SPEED_CAP_MPS};
+use kirra_core::FleetPosture;
 
 /// Integrator-supplied vehicle profile. Holds the platform geometry +
 /// dynamic limits the validator needs. All units SI.
@@ -382,6 +383,31 @@ impl VehicleConfig {
     /// this directly.
     pub fn to_vehicle_footprint(&self) -> VehicleFootprint {
         VehicleFootprint::from(&self.to_kinematics_contract())
+    }
+
+    /// Select the posture-composed kinematics contract:
+    ///
+    /// - `Nominal` → the integrator's full envelope (`to_kinematics_contract`).
+    /// - `Degraded` → the MRC-derated dynamic limits (`to_mrc_kinematics_contract`).
+    /// - `LockedOut` → the MRC contract (most conservative). A LockedOut posture
+    ///   never promotes a trajectory, so this is a safe default the fast path
+    ///   never actually enforces — fail-closed, not a panic.
+    ///
+    /// Single source of truth for the posture→contract mapping, shared by the
+    /// slow-loop per-pose validation (`validate_trajectory_slow_with_envelope`'s
+    /// `base_kinematics`) and the S1 (#1024) fast-loop lateral envelope
+    /// (`LateralEnvelope::from_contract` at the promote site), so the fast loop
+    /// bounds the outgoing command against EXACTLY the contract the slow loop
+    /// enforced — they cannot drift.
+    #[must_use]
+    pub fn to_posture_kinematics_contract(
+        &self,
+        posture: FleetPosture,
+    ) -> VehicleKinematicsContract {
+        match posture {
+            FleetPosture::Nominal => self.to_kinematics_contract(),
+            FleetPosture::Degraded | FleetPosture::LockedOut => self.to_mrc_kinematics_contract(),
+        }
     }
 }
 

--- a/crates/kirra-trajectory/src/state.rs
+++ b/crates/kirra-trajectory/src/state.rs
@@ -16,6 +16,51 @@
 // TrajectoryPoint, TrajectoryVerdict}` resolves for the checker exactly as before.
 pub use kirra_core::trajectory::{PerceivedObject, Pose, TrajectoryPoint, TrajectoryVerdict};
 
+use kirra_core::kinematics_contract::VehicleKinematicsContract;
+
+/// S1 fix (#1024) — the checker's **posture-composed lateral envelope**, carried
+/// from the slow loop to the fast-loop conformance gate.
+///
+/// Motivation: the fast loop is the actual per-cycle gate on the untrusted
+/// controller's outgoing steering command, but it previously bounded steering
+/// only against the STATIC `config.max_steering_rad` (the Nominal rack limit) and
+/// never bounded the command's LATERAL ACCELERATION at all. So a within-rack
+/// steer at ODD speed (`a_lat = v²·tan(δ)/L`, far above the rollover envelope)
+/// passed conformance and was republished to the actuators verbatim. This
+/// envelope lets `check_command_conforms` re-apply the kernel's own P5a/P6 bound
+/// (posture-composed → tighter under Degraded) to the OUTGOING command.
+///
+/// Like the B1 velocity ceiling, it rides HERE on the heap-backed slow-loop
+/// record, never on `TrajectoryVerdict` (which stays a pinned one byte). It is a
+/// pure function of `(config, posture)` — the perception cap only tightens speed,
+/// not the lateral limit — so the promote site builds it directly from the same
+/// posture-composed `VehicleKinematicsContract` the slow loop enforced.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LateralEnvelope {
+    /// Posture-composed dynamic lateral-acceleration ceiling (bicycle model), m/s².
+    pub max_lateral_accel_mps2: f64,
+    /// Posture-composed hard steering-angle limit, radians. Tighter than the
+    /// static `config.max_steering_rad` under Degraded (the MRC contract).
+    pub max_steering_rad: f64,
+    /// Wheelbase `L`, metres. Physical — posture-independent.
+    pub wheelbase_m: f64,
+}
+
+impl LateralEnvelope {
+    /// Extract the lateral envelope from the posture-composed kinematics
+    /// contract the slow loop enforced (`config.to_posture_kinematics_contract`).
+    /// The kernel stores the steering hard limit in DEGREES; the fast-loop
+    /// conformance gate works in radians, so convert here once.
+    #[must_use]
+    pub fn from_contract(contract: &VehicleKinematicsContract) -> Self {
+        Self {
+            max_lateral_accel_mps2: contract.max_lateral_accel_mps2,
+            max_steering_rad: contract.max_steering_deg.to_radians(),
+            wheelbase_m: contract.wheelbase_m,
+        }
+    }
+}
+
 /// The per-asset accepted-trajectory record held in `AdaptorState`.
 #[derive(Debug, Clone)]
 pub struct AcceptedTrajectory {
@@ -37,6 +82,13 @@ pub struct AcceptedTrajectory {
     /// `TrajectoryVerdict`, which stays a pinned one byte (the #893
     /// side-channel discipline; see `trajectory_verdict_stays_one_byte`).
     pub effective_velocity_ceiling: Option<Vec<f64>>,
+    /// S1 fix (#1024) — the checker's posture-composed lateral envelope. `Some`
+    /// on a freshly-validated Accept/Clamp record (the slow loop attaches it from
+    /// the same contract it enforced); `check_command_conforms` then bounds the
+    /// OUTGOING command's steering hard-limit AND lateral acceleration against it.
+    /// `None` on a legacy record → the fast loop falls back to the static
+    /// `config.max_steering_rad` only (byte-identical to before this field).
+    pub effective_lateral_envelope: Option<LateralEnvelope>,
     /// Wall-clock ms when this trajectory was promoted into the slot. The
     /// fast loop computes age against `now_ms` for staleness.
     pub promoted_at_ms: u64,
@@ -68,6 +120,7 @@ impl AcceptedTrajectory {
             points,
             verdict: TrajectoryVerdict::Accept,
             effective_velocity_ceiling: None,
+            effective_lateral_envelope: None,
             promoted_at_ms,
             max_age_ms: DEFAULT_MAX_AGE_MS,
         }
@@ -90,6 +143,7 @@ impl AcceptedTrajectory {
             points,
             verdict,
             effective_velocity_ceiling: None,
+            effective_lateral_envelope: None,
             promoted_at_ms,
             max_age_ms: DEFAULT_MAX_AGE_MS,
         }
@@ -106,6 +160,19 @@ impl AcceptedTrajectory {
     #[must_use]
     pub fn with_effective_ceiling(mut self, ceiling: Option<Vec<f64>>) -> Self {
         self.effective_velocity_ceiling = ceiling;
+        self
+    }
+
+    /// Attach the checker's posture-composed lateral envelope (S1 fix, #1024).
+    /// The slow loop calls this on every promoted Accept/Clamp record with the
+    /// envelope derived from the same posture contract it enforced; the fast
+    /// loop's `check_command_conforms` then bounds the outgoing command's
+    /// steering hard-limit + lateral acceleration against it. Chainable off
+    /// [`with_verdict`](Self::with_verdict) / [`with_effective_ceiling`]. A
+    /// `None` argument is a no-op (leaves the static-limit fallback path).
+    #[must_use]
+    pub fn with_lateral_envelope(mut self, envelope: Option<LateralEnvelope>) -> Self {
+        self.effective_lateral_envelope = envelope;
         self
     }
 

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -36,7 +36,8 @@ use crate::config::VehicleConfig;
 use crate::corridor::{CorridorSource, Point};
 use crate::frenet::CenterlineFrenet;
 use crate::state::{
-    AcceptedTrajectory, EgoOdom, PerceivedObject, Pose, TrajectoryPoint, TrajectoryVerdict,
+    AcceptedTrajectory, EgoOdom, LateralEnvelope, PerceivedObject, Pose, TrajectoryPoint,
+    TrajectoryVerdict,
 };
 
 /// Minimum corridor confidence the slow loop accepts. Tracks the
@@ -1192,6 +1193,33 @@ pub struct IncomingControl {
     pub stamp_ms: u64,
 }
 
+/// Fast-loop bicycle-model lateral-acceleration bound (P6), S1 fix (#1024).
+///
+/// The command's lateral acceleration `a_lat = v²·|tan δ| / L` must stay within
+/// the posture-composed envelope (`max_lateral_accel_mps2 + tolerance`). The test
+/// is written in the **multiplied-out, division-free** form
+///
+/// ```text
+///   v²·|tan δ|  ≤  (max_lateral_accel + tol) · L
+/// ```
+///
+/// so there is NO division and hence NO near-zero wheelbase / velocity guard: at
+/// `v = 0` the LHS is 0 and never exceeds the (positive) RHS, and a degenerate
+/// `wheelbase ≈ 0` drives the RHS to 0 so any real steer at speed **fails closed**
+/// (the earlier divide-and-guard form fail-*opened* on that degenerate case).
+/// Returns `true` when the command is WITHIN the envelope. `tan` feeds a boolean
+/// bound with tolerance, not a signed value into a signature/replay digest, so the
+/// cross-platform ulp concern (#1043 / W4) does not apply.
+#[inline]
+fn command_within_lateral_envelope(cmd: &IncomingControl, env: &LateralEnvelope) -> bool {
+    let lhs = cmd.velocity_mps * cmd.velocity_mps * cmd.steering_rad.tan().abs();
+    let rhs = (env.max_lateral_accel_mps2 + LATERAL_ACCEL_TOLERANCE_MPS2) * env.wheelbase_m;
+    // Boundary note (mutation gate): `<=` vs `<` differ only at exact float
+    // equality `lhs == rhs` — a measure-zero boundary excluded as an equivalent
+    // mutant in `.cargo/mutants.toml`, matching the RSS-gate policy there.
+    lhs <= rhs
+}
+
 // SAFETY: SG7 SG8 | REQ: fast-loop-trajectory-conformance | TEST: test_conforming_command_passes,test_overspeed_command_mrcs,test_stale_trajectory_mrcs,test_no_trajectory_mrcs
 /// Per-cycle conformance check.
 ///
@@ -1304,23 +1332,10 @@ pub fn check_command_conforms(
             }
             // D2. Dynamic lateral-acceleration envelope (bicycle model; P6),
             // solved for the command's OWN velocity — the same bound
-            // `validate_vehicle_command` enforces on the plan. Guard both the
-            // wheelbase and v² away from zero (division / near-stationary, where
-            // the bicycle model is undefined and a tiny steer is harmless).
-            //
-            // `tan` here feeds a BOOLEAN bound with tolerance, NOT a signed value
-            // into a signature/replay digest, so the cross-platform ulp concern
-            // (#1043 / W4) does not apply — a one-ulp `tan` difference only shifts
-            // the accept/MRC boundary by a negligible fraction of the tolerance.
-            if env.wheelbase_m > 1e-6 {
-                let v2 = cmd.velocity_mps.powi(2);
-                if v2 > 1e-6 {
-                    let implied_lat_accel = (v2 * cmd.steering_rad.tan().abs()) / env.wheelbase_m;
-                    if implied_lat_accel > env.max_lateral_accel_mps2 + LATERAL_ACCEL_TOLERANCE_MPS2
-                    {
-                        return ConformanceVerdict::MRCFallback;
-                    }
-                }
+            // `validate_vehicle_command` enforces on the plan. Division-free +
+            // guard-free (see `command_within_lateral_envelope`).
+            if !command_within_lateral_envelope(cmd, env) {
+                return ConformanceVerdict::MRCFallback;
             }
         }
         // No envelope (legacy record): the static rack limit only — byte-identical

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -421,11 +421,12 @@ pub fn validate_trajectory_slow_with_envelope(
     // LockedOut was short-circuited above; this match is exhaustive on
     // the remaining variants.
     let degraded = posture == FleetPosture::Degraded;
-    let base_kinematics = match posture {
-        FleetPosture::Nominal => config.to_kinematics_contract(),
-        FleetPosture::Degraded => config.to_mrc_kinematics_contract(),
-        FleetPosture::LockedOut => unreachable!("handled by the posture short-circuit above"),
-    };
+    // Posture→contract selection via the shared helper (single source of truth,
+    // #1024): the SAME mapping the S1 fast-loop lateral envelope uses at the
+    // promote site, so the two cannot drift. LockedOut was short-circuited to MRC
+    // above, so it never reaches here; the helper maps it to the MRC contract
+    // (fail-closed, not a panic) as a safe default.
+    let base_kinematics = config.to_posture_kinematics_contract(posture);
     // KIRRA-OCCY-PMON-003: compose the Track-C perception-derate cap (most-
     // conservative-wins `min` into `odd_speed_cap_mps`). Applied uniformly —
     // a no-op when `None` (state 1) or when the cap is above the posture
@@ -1170,6 +1171,14 @@ pub enum ConformanceVerdict {
 /// disagree on the boundary.
 pub const VELOCITY_TOLERANCE_MPS: f64 = 0.5;
 
+/// Fast-loop lateral-acceleration conformance tolerance (m/s²), S1 fix (#1024).
+/// A small slack — the lateral analogue of [`VELOCITY_TOLERANCE_MPS`] — so a
+/// controller tracking legitimately at the lateral envelope does not chatter into
+/// MRC on floating-point boundary noise, while staying far below any rollover
+/// margin. This is the fast-loop *conformance* band; the kernel's own P6 clamp
+/// (`validate_vehicle_command`) uses no tolerance and clamps at exactly the bound.
+pub const LATERAL_ACCEL_TOLERANCE_MPS2: f64 = 0.5;
+
 /// Minimal envelope over the incoming `autoware_control_msgs::Control`
 /// fields. Built at the subscriber boundary (Phase 4 — when the typed
 /// callback lands) so the conformance check stays ROS-free.
@@ -1193,7 +1202,11 @@ pub struct IncomingControl {
 ///      horizon — at least one pose with
 ///      `time_from_start_s >= now_ms - promoted_at_ms` exists.
 ///   C. `cmd.velocity_mps <= nearest.velocity_mps + VELOCITY_TOLERANCE_MPS`.
-///   D. `cmd.steering_rad.abs() <= config.max_steering_rad`.
+///   D. Steering + lateral-acceleration bound (S1 fix, #1024): the command's
+///      hard steering angle AND its bicycle-model lateral acceleration at the
+///      command's OWN speed are within the posture-composed envelope the slow
+///      loop enforced (falls back to the static `config.max_steering_rad` when
+///      no envelope is attached — a legacy record).
 ///
 /// Anything else → `MRCFallback`. The `ego` argument is reserved for
 /// Phase 4 extensions (per-axis lateral conformance + acceleration-
@@ -1206,6 +1219,15 @@ pub fn check_command_conforms(
     config: &VehicleConfig,
     now_ms: u64,
 ) -> ConformanceVerdict {
+    // Fail closed on any non-finite command field (NaN/Inf). A NaN comparison is
+    // always false, so without this a non-finite velocity or steering would slip
+    // EVERY bound below (C, D) and be accepted. Defense in depth — the ROS
+    // ingress also rejects NaN/Inf — but the conformance gate is the last line
+    // before the command is republished, so it must fail closed here too.
+    if !cmd.velocity_mps.is_finite() || !cmd.steering_rad.is_finite() {
+        return ConformanceVerdict::MRCFallback;
+    }
+
     // A. Staleness
     if trajectory.is_stale(now_ms) {
         return ConformanceVerdict::MRCFallback;
@@ -1257,9 +1279,57 @@ pub fn check_command_conforms(
         return ConformanceVerdict::MRCFallback;
     }
 
-    // D. Steering bound
-    if cmd.steering_rad.abs() > config.max_steering_rad {
-        return ConformanceVerdict::MRCFallback;
+    // D. Steering + lateral-acceleration bound (S1 fix, #1024).
+    //
+    // FINDING: the prior gate checked ONLY `cmd.steering_rad.abs() <=
+    // config.max_steering_rad` (the static, posture-independent rack limit) and
+    // NEVER bounded the command's lateral acceleration. So the untrusted
+    // controller could command a within-rack steer at ODD speed —
+    // `a_lat = v²·tan(δ)/L` far above the rollover envelope (e.g. 35° at 22.35 m/s
+    // ≈ 125 m/s², ~36× the 3.5 m/s² limit) — and it passed conformance and was
+    // republished to the actuators verbatim. The checker validated the PLAN
+    // (slow loop) but forwarded the COMMAND bounded only by a rack limit.
+    //
+    // FIX: when the slow loop attached its posture-composed lateral envelope,
+    // re-apply the kernel's own P5a (hard steering) + P6 (lateral-accel) bounds to
+    // the OUTGOING command — independently of what the plan proposed, and against
+    // the SAME posture-composed contract the slow loop enforced (tighter under
+    // Degraded). Absent envelope (a legacy record) → the static rack limit only,
+    // byte-identical to before this field existed.
+    match trajectory.effective_lateral_envelope.as_ref() {
+        Some(env) => {
+            // D1. Hard steering-angle limit (posture-composed; P5a).
+            if cmd.steering_rad.abs() > env.max_steering_rad {
+                return ConformanceVerdict::MRCFallback;
+            }
+            // D2. Dynamic lateral-acceleration envelope (bicycle model; P6),
+            // solved for the command's OWN velocity — the same bound
+            // `validate_vehicle_command` enforces on the plan. Guard both the
+            // wheelbase and v² away from zero (division / near-stationary, where
+            // the bicycle model is undefined and a tiny steer is harmless).
+            //
+            // `tan` here feeds a BOOLEAN bound with tolerance, NOT a signed value
+            // into a signature/replay digest, so the cross-platform ulp concern
+            // (#1043 / W4) does not apply — a one-ulp `tan` difference only shifts
+            // the accept/MRC boundary by a negligible fraction of the tolerance.
+            if env.wheelbase_m > 1e-6 {
+                let v2 = cmd.velocity_mps.powi(2);
+                if v2 > 1e-6 {
+                    let implied_lat_accel = (v2 * cmd.steering_rad.tan().abs()) / env.wheelbase_m;
+                    if implied_lat_accel > env.max_lateral_accel_mps2 + LATERAL_ACCEL_TOLERANCE_MPS2
+                    {
+                        return ConformanceVerdict::MRCFallback;
+                    }
+                }
+            }
+        }
+        // No envelope (legacy record): the static rack limit only — byte-identical
+        // to the pre-#1024 behaviour.
+        None => {
+            if cmd.steering_rad.abs() > config.max_steering_rad {
+                return ConformanceVerdict::MRCFallback;
+            }
+        }
     }
 
     ConformanceVerdict::Accept

--- a/crates/kirra-trajectory/tests/conformance.rs
+++ b/crates/kirra-trajectory/tests/conformance.rs
@@ -416,6 +416,58 @@ fn s1_lateral_accel_within_tolerance_band_accepts() {
     );
 }
 
+#[test]
+fn s1_high_speed_low_steer_within_envelope_accepts() {
+    // Pins the v² term (NOT v+…) in the lateral bound. At 20 m/s with a small
+    // 0.02 rad steer, a_lat = 400·tan(0.02)/2.8 ≈ 2.86 m/s² < 3.5 → admitted.
+    // A mutant that turns `v·v·|tan|` into `v + v·|tan|` (≈ 20.4, over the 11.2
+    // RHS) would wrongly MRC this — so an Accept here kills that mutant, where
+    // the low-speed cases (v small ⇒ v² ≈ v) cannot.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let cfg = VehicleConfig::default_urban();
+    let traj = accepted_with_envelope(
+        promoted,
+        straight_pts(10, 20.0, 0.1),
+        &cfg,
+        FleetPosture::Nominal,
+    );
+    let cmd = IncomingControl {
+        velocity_mps: 20.0,
+        steering_rad: 0.02,
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::Accept,
+    );
+}
+
+#[test]
+fn s1_non_finite_on_legacy_path_fails_closed() {
+    // The non-finite guard is load-bearing ONLY on the None (legacy) path: with an
+    // envelope, D2 also rejects a non-finite (v²·|tan| → NaN → not within). On the
+    // None path there is no D2, so a `||`→`&&` mutation of the guard would let a
+    // single non-finite field slip C and the static steering check → Accept. These
+    // cases pin the `||` (each has exactly ONE non-finite field).
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let cfg = VehicleConfig::default_urban();
+    let traj = fresh_accepted(promoted, straight_pts(10, 5.0, 0.1)); // envelope = None
+    for (v, s) in [(f64::NAN, 0.0), (5.0, f64::NAN), (f64::INFINITY, 0.0)] {
+        let cmd = IncomingControl {
+            velocity_mps: v,
+            steering_rad: s,
+            stamp_ms: now,
+        };
+        assert_eq!(
+            check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+            ConformanceVerdict::MRCFallback,
+            "non-finite ({v}, {s}) on the legacy path must fail closed via the guard",
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // B1 regression — a `Clamp` verdict must derate the forwarded command.
 //

--- a/crates/kirra-trajectory/tests/conformance.rs
+++ b/crates/kirra-trajectory/tests/conformance.rs
@@ -339,6 +339,83 @@ fn s1_non_finite_command_fails_closed() {
     }
 }
 
+#[test]
+fn s1_steering_exactly_at_posture_limit_accepts() {
+    // Boundary pin for D1 (`>` NOT `>=`): |steering| EXACTLY == the posture
+    // envelope's hard steering limit. The kernel P5a clamps only when strictly
+    // greater, so at-exactly-the-limit is admissible. Read the envelope's own f64
+    // so the equality is bit-exact. Low speed keeps the lateral bound (D2) clear.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let cfg = VehicleConfig::default_urban();
+    let env =
+        LateralEnvelope::from_contract(&cfg.to_posture_kinematics_contract(FleetPosture::Nominal));
+    let traj = accepted_with_envelope(
+        promoted,
+        straight_pts(10, 1.0, 0.1),
+        &cfg,
+        FleetPosture::Nominal,
+    );
+    let cmd = IncomingControl {
+        velocity_mps: 1.0,
+        steering_rad: env.max_steering_rad, // exactly at the limit
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::Accept,
+        "at-exactly-the-steering-limit is admissible; a `>=` here would wrongly MRC it",
+    );
+}
+
+#[test]
+fn s1_static_fallback_steering_exactly_at_limit_accepts() {
+    // Boundary pin for the None (legacy) path (`>` NOT `>=`): |steering| EXACTLY
+    // == config.max_steering_rad → admitted. Complements `oversteer_command_mrcs`
+    // (which sits just OVER the limit) so the operator is pinned on both sides.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let cfg = VehicleConfig::default_urban();
+    let traj = fresh_accepted(promoted, straight_pts(10, 1.0, 0.1)); // envelope = None
+    let cmd = IncomingControl {
+        velocity_mps: 1.0,
+        steering_rad: cfg.max_steering_rad, // exactly at the static rack limit
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::Accept,
+    );
+}
+
+#[test]
+fn s1_lateral_accel_within_tolerance_band_accepts() {
+    // Pins the `+` tolerance sign (NOT `-`) and the `*` arithmetic in the lateral
+    // bound. 0.0977 rad at 10 m/s → a_lat ≈ 3.5 m/s²: ABOVE max−tol (3.0) but
+    // BELOW max+tol (4.0), so it is admitted. A `+`→`-` mutant would use a 3.0
+    // ceiling and MRC this command; the arithmetic mutants shift the ceiling
+    // enough to flip the verdict too.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let cfg = VehicleConfig::default_urban();
+    let traj = accepted_with_envelope(
+        promoted,
+        straight_pts(10, 10.0, 0.1),
+        &cfg,
+        FleetPosture::Nominal,
+    );
+    let cmd = IncomingControl {
+        velocity_mps: 10.0,
+        steering_rad: 0.0977, // a_lat = 100·tan(0.0977)/2.8 ≈ 3.50 m/s²
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::Accept,
+        "a command inside the tolerance band (max−tol, max+tol) must be admitted",
+    );
+}
+
 // ---------------------------------------------------------------------------
 // B1 regression — a `Clamp` verdict must derate the forwarded command.
 //

--- a/crates/kirra-trajectory/tests/conformance.rs
+++ b/crates/kirra-trajectory/tests/conformance.rs
@@ -134,6 +134,212 @@ fn oversteer_command_mrcs() {
 }
 
 // ---------------------------------------------------------------------------
+// S1 fix (#1024): the lateral-acceleration / rollover envelope on the OUTGOING
+// command. Arm D previously bounded steering only against the STATIC rack limit
+// and never bounded lateral acceleration, so a within-rack steer at ODD speed
+// (a_lat = v²·tan(δ)/L far above the envelope) passed conformance and was
+// republished verbatim → rollover. These drive the real checker envelope.
+// ---------------------------------------------------------------------------
+
+use kirra_trajectory::state::LateralEnvelope;
+
+/// A fresh Accept record carrying the posture-composed lateral envelope, exactly
+/// as the slow loop attaches it at the promote site.
+fn accepted_with_envelope(
+    promoted_at_ms: u64,
+    pts: Vec<TrajectoryPoint>,
+    cfg: &VehicleConfig,
+    posture: FleetPosture,
+) -> AcceptedTrajectory {
+    AcceptedTrajectory::with_verdict("av_01", 1, pts, TrajectoryVerdict::Accept, promoted_at_ms)
+        .with_lateral_envelope(Some(LateralEnvelope::from_contract(
+            &cfg.to_posture_kinematics_contract(posture),
+        )))
+}
+
+#[test]
+fn s1_within_rack_but_over_lateral_accel_mrcs() {
+    // THE FINDING. 0.3 rad ≈ 17.2° is well within the 35° rack limit, but at
+    // 10 m/s the bicycle-model lateral accel is a_lat = 100·tan(0.3)/2.8
+    // ≈ 11.05 m/s² — ~3× the 3.5 m/s² envelope (+0.5 tol). With the envelope
+    // attached the fast loop now MRCs it.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let cfg = VehicleConfig::default_urban();
+    let traj = accepted_with_envelope(
+        promoted,
+        straight_pts(10, 10.0, 0.1),
+        &cfg,
+        FleetPosture::Nominal,
+    );
+    let cmd = IncomingControl {
+        velocity_mps: 10.0,
+        steering_rad: 0.3,
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::MRCFallback,
+        "a within-rack steer whose lateral accel exceeds the envelope must MRC",
+    );
+}
+
+#[test]
+fn s1_legacy_record_without_envelope_admits_the_rollover_command() {
+    // The SAME command against a record with NO lateral envelope (a legacy /
+    // pre-#1024 record) is admitted — |0.3| ≤ max_steering_rad on the static
+    // fallback path. This pins that the None path is byte-identical to the old
+    // behaviour AND documents precisely the gap the envelope closes.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let cfg = VehicleConfig::default_urban();
+    let traj = fresh_accepted(promoted, straight_pts(10, 10.0, 0.1)); // envelope = None
+    let cmd = IncomingControl {
+        velocity_mps: 10.0,
+        steering_rad: 0.3,
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::Accept,
+        "static-limit fallback (no envelope) stays byte-identical — this is the gap S1 closes",
+    );
+}
+
+#[test]
+fn s1_command_within_lateral_envelope_accepts() {
+    // 0.05 rad at 10 m/s → a_lat = 100·tan(0.05)/2.8 ≈ 1.79 m/s² < 3.5 (+0.5).
+    // "Drive gently, don't stop" — a command inside the envelope still passes.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let cfg = VehicleConfig::default_urban();
+    let traj = accepted_with_envelope(
+        promoted,
+        straight_pts(10, 10.0, 0.1),
+        &cfg,
+        FleetPosture::Nominal,
+    );
+    let cmd = IncomingControl {
+        velocity_mps: 10.0,
+        steering_rad: 0.05,
+        stamp_ms: now,
+    };
+    assert_eq!(
+        check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::Accept,
+    );
+}
+
+#[test]
+fn s1_degraded_tightens_lateral_envelope() {
+    // 0.25 rad at 5 m/s → a_lat = 25·tan(0.25)/2.8 ≈ 2.28 m/s². Under Nominal
+    // (3.5 +0.5) this passes; under Degraded (MRC lateral 1.5 +0.5 = 2.0) it
+    // MRCs. Same command, posture-composed envelope decides — Degraded is
+    // tighter, exactly as the slow loop enforces.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let cfg = VehicleConfig::default_urban();
+    let cmd = IncomingControl {
+        velocity_mps: 5.0,
+        steering_rad: 0.25,
+        stamp_ms: now,
+    };
+
+    let nominal = accepted_with_envelope(
+        promoted,
+        straight_pts(10, 5.0, 0.1),
+        &cfg,
+        FleetPosture::Nominal,
+    );
+    assert_eq!(
+        check_command_conforms(&cmd, &nominal, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::Accept,
+    );
+
+    let degraded = accepted_with_envelope(
+        promoted,
+        straight_pts(10, 5.0, 0.1),
+        &cfg,
+        FleetPosture::Degraded,
+    );
+    assert_eq!(
+        check_command_conforms(&cmd, &degraded, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::MRCFallback,
+        "the MRC contract's tighter lateral limit must reject a steer the Nominal envelope admits",
+    );
+}
+
+#[test]
+fn s1_degraded_tightens_hard_steering_limit() {
+    // 0.4 rad ≈ 22.9° at 2 m/s: lateral accel is tiny (a_lat ≈ 0.60 m/s²), so
+    // only the HARD steering limit differs. Within the 35° Nominal rack (pass)
+    // but beyond the 15° MRC limit (MRC) — the posture-composed D1 bound.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let cfg = VehicleConfig::default_urban();
+    let cmd = IncomingControl {
+        velocity_mps: 2.0,
+        steering_rad: 0.4,
+        stamp_ms: now,
+    };
+
+    let nominal = accepted_with_envelope(
+        promoted,
+        straight_pts(10, 2.0, 0.1),
+        &cfg,
+        FleetPosture::Nominal,
+    );
+    assert_eq!(
+        check_command_conforms(&cmd, &nominal, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::Accept,
+    );
+
+    let degraded = accepted_with_envelope(
+        promoted,
+        straight_pts(10, 2.0, 0.1),
+        &cfg,
+        FleetPosture::Degraded,
+    );
+    assert_eq!(
+        check_command_conforms(&cmd, &degraded, &EgoOdom::default(), &cfg, now),
+        ConformanceVerdict::MRCFallback,
+    );
+}
+
+#[test]
+fn s1_non_finite_command_fails_closed() {
+    // A NaN comparison is always false, so a non-finite steer/velocity would
+    // slip every bound below. The gate must fail closed — with OR without an
+    // envelope.
+    let promoted = 100_000;
+    let now = promoted + 50;
+    let cfg = VehicleConfig::default_urban();
+    let traj = accepted_with_envelope(
+        promoted,
+        straight_pts(10, 5.0, 0.1),
+        &cfg,
+        FleetPosture::Nominal,
+    );
+    for (v, s) in [
+        (f64::NAN, 0.0),
+        (5.0, f64::NAN),
+        (f64::INFINITY, 0.0),
+        (5.0, f64::INFINITY),
+    ] {
+        let cmd = IncomingControl {
+            velocity_mps: v,
+            steering_rad: s,
+            stamp_ms: now,
+        };
+        assert_eq!(
+            check_command_conforms(&cmd, &traj, &EgoOdom::default(), &cfg, now),
+            ConformanceVerdict::MRCFallback,
+            "non-finite command ({v}, {s}) must fail closed",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // B1 regression — a `Clamp` verdict must derate the forwarded command.
 //
 // The finding (verified on 8ea3e90): the checker computed `ClampLinear(v)`,


### PR DESCRIPTION
Closes #1024. Part of the engineering-review remediation epic #1023 (the CRITICAL finding).

## The finding (S1)
The **fast loop** (`check_command_conforms`) is the actual per-cycle gate on the untrusted controller's outgoing steering command, but it bounded steering **only** against the static `config.max_steering_rad` (the Nominal rack limit) and **never bounded lateral acceleration**. So a within-rack steer at ODD speed —

```
a_lat = v²·tan(δ)/L   →  35° at 22.35 m/s ≈ 125 m/s² (~12.7 g), ~36× the 3.5 m/s² envelope
```

— passed conformance and was republished to the actuators **verbatim → rollover/spin**. The checker's own P5a/P6 lateral clamp ran only in the *slow loop* (bounding the plan); its `ClampSteering`/`ClampBoth` result was discarded because `AcceptedTrajectory` carried no steering ceiling. The controller is explicitly untrusted in the doer-checker model, so this is a designed-for fault mode.

## The fix (mirrors the B1 velocity-ceiling side-channel, ADR-0034)
- **Carry** a posture-composed `LateralEnvelope` (`max_lateral_accel_mps2`, hard steering limit, `wheelbase_m`) on `AcceptedTrajectory`, attached at the promote site from the **same** contract the slow loop enforced.
- **Re-apply** the kernel's P5a (hard steering) + P6 (lateral-accel) bounds to the command's **own** speed in `check_command_conforms` when the envelope is present — posture-composed, so it's **tighter under Degraded** (the MRC 15°/1.5 m/s² contract). Absent envelope (a legacy record) → the static rack limit only, **byte-identical** to before.
- **Fail closed on non-finite** command fields: a `NaN` comparison is always false, so a non-finite steer/velocity previously slipped every bound (C and D) and was accepted. Now → MRC.
- **DRY:** add `VehicleConfig::to_posture_kinematics_contract` as the single source of truth for the posture→contract mapping, shared by the slow loop's `base_kinematics` and the fast-loop envelope so they cannot drift.

`tan` on the fast path feeds a **boolean bound with tolerance**, not a signed value into a signature/replay digest, so the cross-platform ulp concern (W4/#1043) does not apply here.

## Tests
6 new conformance cases in `crates/kirra-trajectory/tests/conformance.rs`:
- `s1_within_rack_but_over_lateral_accel_mrcs` — the exact rollover geometry → MRC.
- `s1_legacy_record_without_envelope_admits_the_rollover_command` — pins the None path byte-identical and documents the gap this closes.
- `s1_command_within_lateral_envelope_accepts` — "drive gently, don't stop".
- `s1_degraded_tightens_lateral_envelope` / `s1_degraded_tightens_hard_steering_limit` — same command, posture-composed envelope decides.
- `s1_non_finite_command_fails_closed`.

**Verification:** `cargo test -p kirra-trajectory` (14 conformance + 61 validation) and `-p kirra-ros2-adapter` (46 + suites) all green; `cargo fmt --check` and `cargo clippy` clean on both crates. The static-fallback (no-envelope) path is byte-identical.

## Scope / not in this PR
This closes S1 (the checker-side enforcement). The sibling HIGH finding **S2** (occlusion bound dormant, #1025) is separate. WCET note: the added `tan` + branch is O(1) on the fast path; it does not affect the reaction FTTI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_