### PR TITLE
fix(checker): arm the occlusion / assured-clear-distance bound (S2, #1025)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -611,6 +611,13 @@ feeding the omnidirectional pedestrian bound; the pure `vru_channel::resolve_vru
 the three-way decision DISARMED→checker no-op / armed+fresh→live `PedestrianScene` / armed+silent→
 MRC-floor cap, so an armed-but-silent VRU sensor STOPS the ego rather than driving blind; producer
 must publish at rate per AOU-VRU-RATE-001),
+`KIRRA_OCCLUSION_CHANNEL_ENABLED` (S2 / #1025 — enables the `~/input/visibility` subscription
+(a `std_msgs/Float64` assured-clear distance in metres) that ARMS the checker's RSS Rule 4
+limited-visibility bound, previously fed a hardcoded `None` (dormant every tick); the pure
+`occlusion_channel::resolve_occlusion_channel` makes the same three-way decision DISARMED→checker
+no-op / armed+fresh+valid→live sight distance to the occlusion gate / armed+silent-or-garbage→
+MRC-floor cap, so an armed-but-silent occlusion sensor STOPS the ego rather than driving blind into
+an unobserved junction; producer must publish at rate per AOU-OCCLUSION-RATE-001),
 `KIRRA_SUBSCRIPTION_STALENESS_MS` (subscription/channel freshness budget).
 
 ---

--- a/crates/kirra-ros2-adapter/src/lib.rs
+++ b/crates/kirra-ros2-adapter/src/lib.rs
@@ -42,7 +42,9 @@ pub mod perception_ingest;
 // `crate::{config,validation,prediction,perception_redundancy}::*` imports resolve
 // unchanged. `state` stays local (it owns the ROS runtime `AdaptorState`) but
 // re-exports the relocated `AcceptedTrajectory` / `EgoOdom` contract types.
-pub use kirra_trajectory::{config, perception_redundancy, prediction, validation, vru_channel};
+pub use kirra_trajectory::{
+    config, occlusion_channel, perception_redundancy, prediction, validation, vru_channel,
+};
 
 // `posture_tracker` was relocated to the kernel
 // (`kirra_core::posture_tracker`) by M2b so the parko-ros2 node

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -44,6 +44,7 @@ use crate::contract_producer::{proposal_payload, ProposalSequencer};
 pub use crate::control_ingress::IngressControlCommand;
 use crate::control_ingress::{fail_closed_control_command, parse_control_command_json};
 use crate::corridor::CorridorSource;
+use crate::occlusion_channel::{resolve_occlusion_channel, OCCLUSION_CHANNEL_ENABLED_ENV};
 use crate::perception_redundancy::{
     more_restrictive_cap, perception_redundancy_enabled, resolve_redundancy_cap,
     DivergenceEscalator, RedundancyConfig,
@@ -98,6 +99,20 @@ fn subscription_staleness_timeout_ms() -> u64 {
 /// `perception_redundancy_enabled`.
 fn vru_channel_enabled() -> bool {
     std::env::var(VRU_CHANNEL_ENABLED_ENV)
+        .map(|v| {
+            let t = v.trim();
+            t == "1" || t.eq_ignore_ascii_case("true") || t.eq_ignore_ascii_case("yes")
+        })
+        .unwrap_or(false)
+}
+
+/// Occlusion / assured-clear-distance channel enable gate (S2, #1025) — reads
+/// `KIRRA_OCCLUSION_CHANNEL_ENABLED`. Adapter INTEGRATION glue (env I/O), kept out
+/// of the pure checker crate so its mutation gate covers only the tested
+/// `resolve_occlusion_channel` decision. Same truthy grammar as
+/// `vru_channel_enabled`; unset/anything else = disarmed (byte-identical no-op).
+fn occlusion_channel_enabled() -> bool {
+    std::env::var(OCCLUSION_CHANNEL_ENABLED_ENV)
         .map(|v| {
             let t = v.trim();
             t == "1" || t.eq_ignore_ascii_case("true") || t.eq_ignore_ascii_case("yes")
@@ -364,6 +379,23 @@ pub async fn run_adapter(
     } else {
         None
     };
+    // Occlusion / assured-clear-distance subscription (S2, #1025) — a scalar
+    // sight-distance-ahead topic (metres; a producer such as kirra-taj / kirra-map
+    // `sight_distance`) that ARMS the RSS Rule 4 limited-visibility bound. Same
+    // opt-in discipline as the VRU channel: registered ONLY when the occlusion
+    // gate is enabled, so a deployment without an occlusion source adds no
+    // subscription and the checker's `visibility_range_m: None` no-op path stays
+    // byte-identical. Remap `~/input/visibility` to the producer's topic in the
+    // launch file. When enabled but the channel is silent/stale, the slow loop
+    // FAILS CLOSED (MRC cap), never treats silence as "wide-open visibility".
+    let vis_stream = if occlusion_channel_enabled() {
+        Some(node.subscribe::<r2r::std_msgs::msg::Float64>(
+            "~/input/visibility",
+            ingress_sensor_qos(), // N1
+        )?)
+    } else {
+        None
+    };
     let _map_sub = node.subscribe_untyped(
         "~/input/map",
         "autoware_map_msgs/msg/LaneletMapBin",
@@ -586,6 +618,31 @@ pub async fn run_adapter(
         });
     }
 
+    // Occlusion / visibility drain (S2, #1025) — mirror of the VRU drain. Each
+    // Float64 message REPLACES the assured-clear-distance snapshot and stamps its
+    // freshness (`update_visibility`); the slow loop reads it via
+    // `snapshot_visibility` with fail-closed staleness. Stream close (producer
+    // dies) → the channel goes stale → the slow loop fails closed (MRC).
+    if let Some(vis_stream) = vis_stream {
+        let vis_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            let mut s = vis_stream;
+            while let Some(msg) = s.next().await {
+                let now = now_ms_fresh();
+                tracing::info!(
+                    target: "kirra::ingress",
+                    topic = "visibility",
+                    stamp_ms = now,
+                    "subscription_callback"
+                );
+                vis_state.update_visibility(msg.data, now);
+            }
+            tracing::error!(
+                "visibility subscription stream closed — occlusion channel will fail closed (MRC)"
+            );
+        });
+    }
+
     let odom_state = Arc::clone(&state);
     tokio::spawn(async move {
         let mut s = odom_stream;
@@ -763,6 +820,27 @@ pub async fn run_adapter(
                 barriers: &[],
             });
 
+            // Occlusion / assured-clear-distance channel (S2, #1025) — the sibling
+            // of the VRU resolver, ARMING the RSS Rule 4 limited-visibility bound
+            // that was previously fed a hardcoded `None` (dormant every tick).
+            // DISARMED → the checker's `None` (occlusion gate skipped,
+            // byte-identical); armed + FRESH + valid range → feed the gate the
+            // observed sight distance; armed + SILENT/STALE/garbage → fail closed
+            // to an MRC-floor cap (never drive blind). Same short-circuit as VRU:
+            // only read the snapshot when armed, so a DISARMED default-off
+            // deployment never takes the visibility lock or logs.
+            let occlusion_enabled = occlusion_channel_enabled();
+            let occlusion = resolve_occlusion_channel(
+                occlusion_enabled,
+                if occlusion_enabled {
+                    slow_state.snapshot_visibility(now_mono, subscription_staleness_timeout_ms())
+                } else {
+                    None
+                },
+            );
+            let effective_perception_cap =
+                more_restrictive_cap(effective_perception_cap, occlusion.perception_cap());
+
             // Sustained-divergence → posture escalation (orthogonal to the per-tick MRC cap
             // above): a divergence (or lost redundant channel) that PERSISTS is a
             // perception-integrity fault that escalates the EFFECTIVE fleet posture — Degraded,
@@ -804,10 +882,14 @@ pub async fn run_adapter(
                 odom.as_ref(),
                 posture.clone(),
                 effective_perception_cap,
-                // Occlusion / assured-clear-distance bound (RSS Rule 4): perception
-                // does not yet supply a visibility range → None (no-op), mirroring
-                // the perception-derate cap's pre-wiring state.
-                None,
+                // Occlusion / assured-clear-distance bound (RSS Rule 4): S2 (#1025)
+                // — ARMED from the occlusion channel resolved above. DISARMED →
+                // `None` (gate skipped, byte-identical); armed + fresh → the live
+                // sight distance so the checker refuses a trajectory that outruns
+                // what the ego can see; armed + silent/garbage → `None` here but
+                // the MRC-floor cap already folded into `effective_perception_cap`
+                // stops the ego (never a silent no-op — see `resolve_occlusion_channel`).
+                occlusion.visibility_range(),
                 // Multi-modal predictive RSS (gap #3) — LIVE: the CV (and, when the tracker yaw
                 // feed is fresh, CTRV) modes rolled from the live objects above. The checker
                 // worst-cases over them, refusing a trajectory a predicted cut-in / turn-in

--- a/crates/kirra-ros2-adapter/src/state.rs
+++ b/crates/kirra-ros2-adapter/src/state.rs
@@ -110,6 +110,14 @@ pub struct AdaptorState {
     /// the integrator enables the VRU gate, a silent or stale channel FAILS
     /// CLOSED (see [`snapshot_pedestrians`](AdaptorState::snapshot_pedestrians)).
     pub pedestrians_cache: Arc<RwLock<Vec<PerceivedPedestrian>>>,
+    /// S2 (#1025) — the occlusion / assured-clear-distance channel: the latest
+    /// sight distance ahead (metres) from a producer such as kirra-taj /
+    /// kirra-map `sight_distance`. OPT-IN like the pedestrian channel: never
+    /// written when no source is wired; once the integrator enables the occlusion
+    /// gate, a silent/stale channel FAILS CLOSED (see
+    /// [`snapshot_visibility`](AdaptorState::snapshot_visibility)). `f64::NAN` is
+    /// the never-written sentinel (also treated as fail-closed by the resolver).
+    pub visibility_cache: Arc<RwLock<f64>>,
     /// Per-object **turn-rate** estimates `(object_id, yaw_rate_rad_s)` from the tracker — the
     /// SAME CTRV estimate the planner consumes as `MotionState`, supplied to the checker so the
     /// multi-modal predictive RSS (gap #3) can add the CTRV turn-in hypothesis, not just CV.
@@ -136,6 +144,10 @@ pub struct AdaptorState {
     pub last_objects_b_ms: Arc<AtomicU64>,
     /// Monotonic stamp of the last pedestrian-channel write (0 = never seen).
     pub last_pedestrians_ms: Arc<AtomicU64>,
+    /// S2 (#1025) — monotonic stamp of the last occlusion/visibility write
+    /// (0 = never seen). The slow loop checks it against the staleness budget: an
+    /// enabled-but-silent occlusion channel fails closed (MRC), never drives blind.
+    pub last_visibility_ms: Arc<AtomicU64>,
     /// Wall-clock-ms when the LAST per-object yaw-rate estimate arrived (0 = none yet). A STALE
     /// yaw feed degrades the predictive pass to CV-only (the estimate would keep predicting a
     /// turn-in after the object straightened) — an enhancement dropped, NOT a fault.
@@ -202,6 +214,7 @@ impl AdaptorState {
             objects_cache: Arc::new(RwLock::new(Vec::new())),
             objects_cache_b: Arc::new(RwLock::new(Vec::new())),
             pedestrians_cache: Arc::new(RwLock::new(Vec::new())),
+            visibility_cache: Arc::new(RwLock::new(f64::NAN)),
             object_yaw_rates: Arc::new(RwLock::new(Vec::new())),
             config: Arc::new(config),
             latest_odom: Arc::new(RwLock::new(None)),
@@ -209,6 +222,7 @@ impl AdaptorState {
             last_objects_ms: Arc::new(AtomicU64::new(0)),
             last_objects_b_ms: Arc::new(AtomicU64::new(0)),
             last_pedestrians_ms: Arc::new(AtomicU64::new(0)),
+            last_visibility_ms: Arc::new(AtomicU64::new(0)),
             last_object_yaw_ms: Arc::new(AtomicU64::new(0)),
             last_odom_ms: Arc::new(AtomicU64::new(0)),
             posture_tracker: Arc::new(RwLock::new(PostureTracker::nominal_default_no_source())),
@@ -227,6 +241,7 @@ impl AdaptorState {
             objects_cache: Arc::new(RwLock::new(Vec::new())),
             objects_cache_b: Arc::new(RwLock::new(Vec::new())),
             pedestrians_cache: Arc::new(RwLock::new(Vec::new())),
+            visibility_cache: Arc::new(RwLock::new(f64::NAN)),
             object_yaw_rates: Arc::new(RwLock::new(Vec::new())),
             config: Arc::new(config),
             latest_odom: Arc::new(RwLock::new(None)),
@@ -234,6 +249,7 @@ impl AdaptorState {
             last_objects_ms: Arc::new(AtomicU64::new(0)),
             last_objects_b_ms: Arc::new(AtomicU64::new(0)),
             last_pedestrians_ms: Arc::new(AtomicU64::new(0)),
+            last_visibility_ms: Arc::new(AtomicU64::new(0)),
             last_object_yaw_ms: Arc::new(AtomicU64::new(0)),
             last_odom_ms: Arc::new(AtomicU64::new(0)),
             posture_tracker: Arc::new(RwLock::new(PostureTracker::nominal_default_no_source())),
@@ -255,6 +271,7 @@ impl AdaptorState {
             objects_cache: Arc::new(RwLock::new(Vec::new())),
             objects_cache_b: Arc::new(RwLock::new(Vec::new())),
             pedestrians_cache: Arc::new(RwLock::new(Vec::new())),
+            visibility_cache: Arc::new(RwLock::new(f64::NAN)),
             object_yaw_rates: Arc::new(RwLock::new(Vec::new())),
             config: Arc::new(config),
             latest_odom: Arc::new(RwLock::new(None)),
@@ -262,6 +279,7 @@ impl AdaptorState {
             last_objects_ms: Arc::new(AtomicU64::new(0)),
             last_objects_b_ms: Arc::new(AtomicU64::new(0)),
             last_pedestrians_ms: Arc::new(AtomicU64::new(0)),
+            last_visibility_ms: Arc::new(AtomicU64::new(0)),
             last_object_yaw_ms: Arc::new(AtomicU64::new(0)),
             last_odom_ms: Arc::new(AtomicU64::new(0)),
             posture_tracker: Arc::new(RwLock::new(PostureTracker::with_source())),
@@ -510,6 +528,51 @@ impl AdaptorState {
         }
     }
 
+    /// S2 (#1025) — replace the occlusion/visibility snapshot (assured-clear
+    /// distance ahead, metres) and stamp its arrival at `now_ms`. Mirrors
+    /// [`update_pedestrians`](Self::update_pedestrians), including the fail-closed
+    /// RwLock-poisoning handling.
+    pub fn update_visibility(&self, assured_clear_distance_m: f64, now_ms: u64) {
+        self.last_visibility_ms.store(now_ms, Ordering::Relaxed);
+        if let Ok(mut guard) = self.visibility_cache.write() {
+            *guard = assured_clear_distance_m;
+        } else {
+            tracing::error!("visibility_cache RwLock POISONED — occlusion snapshot dropped");
+        }
+    }
+
+    /// S2 (#1025) — read the occlusion channel with fail-closed freshness semantics
+    /// (for a slow loop running with the occlusion gate ENABLED):
+    ///   - fresh (written within `staleness_budget_ms`) → `Some(range_m)` (the
+    ///     resolver still fault-checks the value's finiteness/sign);
+    ///   - NEVER seen, STALE, or POISONED → `None` — the caller MUST fail closed
+    ///     (MRC via [`resolve_occlusion_channel`](kirra_trajectory::occlusion_channel::resolve_occlusion_channel)),
+    ///     never treat it as "wide-open visibility": an enabled-but-silent
+    ///     occlusion source is a lost perception channel, exactly like the VRU one.
+    /// Integrators with the gate DISABLED never call this (the checker's
+    /// `visibility_range_m: None` no-op path is byte-identical prior behavior).
+    pub fn snapshot_visibility(&self, now_ms: u64, staleness_budget_ms: u64) -> Option<f64> {
+        let stamp = self.last_visibility_ms.load(Ordering::Relaxed);
+        if stamp == 0 || now_ms.saturating_sub(stamp) > staleness_budget_ms {
+            tracing::error!(
+                stamp,
+                now_ms,
+                staleness_budget_ms,
+                "occlusion/visibility channel silent/stale with the gate enabled — failing closed"
+            );
+            return None;
+        }
+        match self.visibility_cache.read() {
+            Ok(guard) => Some(*guard),
+            Err(_) => {
+                tracing::error!(
+                    "visibility_cache RwLock POISONED — failing slow loop closed (MRC)"
+                );
+                None
+            }
+        }
+    }
+
     /// Replace the per-object yaw-rate estimates `(object_id, yaw_rate_rad_s)` and stamp arrival
     /// at `now_ms`. Called by the integrator's tracker feed (the same CTRV estimate the planner
     /// gets as `MotionState`); the slow loop reads it to add CTRV modes to the predictive RSS.
@@ -675,6 +738,39 @@ mod tests {
         );
         assert!(
             st.snapshot_pedestrians(1_500, 500).is_some(),
+            "at the budget is fresh"
+        );
+    }
+
+    // ---- S2 (#1025): the occlusion/visibility channel (fail-closed freshness) ----
+
+    #[test]
+    fn visibility_channel_fresh_snapshot_returns_the_range() {
+        let st = AdaptorState::new();
+        st.update_visibility(18.5, 1_000);
+        assert_eq!(st.snapshot_visibility(1_200, 500), Some(18.5));
+    }
+
+    /// Enabled-but-NEVER-SEEN fails closed — an enabled occlusion gate with no
+    /// producer is a lost perception channel, not "wide-open visibility".
+    #[test]
+    fn visibility_channel_never_seen_fails_closed() {
+        let st = AdaptorState::new();
+        assert!(st.snapshot_visibility(10_000, 500).is_none());
+    }
+
+    /// A stale channel (producer died mid-run) fails closed at 1 ms past budget.
+    #[test]
+    fn visibility_channel_stale_fails_closed() {
+        let st = AdaptorState::new();
+        st.update_visibility(25.0, 1_000);
+        assert!(
+            st.snapshot_visibility(1_501, 500).is_none(),
+            "1 ms past the budget"
+        );
+        assert_eq!(
+            st.snapshot_visibility(1_500, 500),
+            Some(25.0),
             "at the budget is fresh"
         );
     }

--- a/crates/kirra-trajectory/src/lib.rs
+++ b/crates/kirra-trajectory/src/lib.rs
@@ -31,6 +31,12 @@ pub mod perception_redundancy;
 // from a live channel, fail-closed on silence/staleness. Pure, no ROS.
 pub mod vru_channel;
 
+// Occlusion / assured-clear-distance channel resolver (S2, #1025) — arms the
+// RSS Rule 4 limited-visibility bound from a live sight-distance channel,
+// fail-closed on silence/staleness/garbage. Pure, no ROS. Same three-way
+// disarmed/live/fail-closed shape as `vru_channel`.
+pub mod occlusion_channel;
+
 // Phase 2A Adversarial Review Hardening
 pub mod redundancy_hardening;
 pub mod validation_hardening;

--- a/crates/kirra-trajectory/src/occlusion_channel.rs
+++ b/crates/kirra-trajectory/src/occlusion_channel.rs
@@ -1,0 +1,213 @@
+//! **Occlusion / assured-clear-distance channel orchestration (S2, #1025) — pure, no ROS.**
+//!
+//! The RSS Rule 4 limited-visibility bound ([`crate::validation`]'s
+//! `outruns_assured_clear_distance`) is sound and already plumbed into
+//! `validate_trajectory_slow_*` via the `visibility_range_m` parameter — but the
+//! live ROS 2 node fed it a hardcoded `None` ("perception does not yet supply a
+//! visibility range"), so the gate was **dormant every tick**. The only occlusion
+//! protection deployed was the untrusted planner's own `OccludedApproach` cap —
+//! i.e. the DOER guarding a hazard the CHECKER is meant to bound (finding S2).
+//!
+//! This module is the **one safety-critical decision that stands between a
+//! perception-supplied sight distance and the checker** — the exact sibling of
+//! [`crate::vru_channel`].
+//!
+//! ## Why an explicit resolver (the overloaded-`None` hazard)
+//!
+//! The checker's `visibility_range_m` argument is `Option<f64>` where `None` means
+//! "**no occlusion channel → skip the gate (no-op)**" (byte-identical). A
+//! freshness snapshot ALSO returns `None` to mean "**silent / stale → fail
+//! closed**". Those two `None`s mean OPPOSITE things: passing a silent snapshot
+//! straight through would turn a lost sight-distance sensor into a silent no-op —
+//! the ego driving at full ODD speed into unobserved space, the exact failure this
+//! channel exists to prevent.
+//!
+//! So the node makes a THREE-way decision, pure and testable here:
+//!
+//! 1. **DISARMED** (`KIRRA_OCCLUSION_CHANNEL_ENABLED` unset/false) → feed the
+//!    checker `None` (skip the occlusion gate), no cap. Byte-identical to the
+//!    pre-wiring behaviour.
+//! 2. **LIVE** (armed, snapshot fresh AND a finite, non-negative range) → feed the
+//!    checker `Some(range)`. A trajectory that outruns what the ego can see now
+//!    breaches → MRC.
+//! 3. **FAIL-CLOSED** (armed, snapshot `None` = silent/stale, OR a non-finite /
+//!    negative range = garbage) → do NOT feed the occlusion gate an admitting
+//!    `None`; instead compose an MRC-floor cap (`Some(0.0)`) into the SAME Track-C
+//!    derate ([`crate::perception_redundancy::more_restrictive_cap`] →
+//!    `apply_perception_cap`), bringing the ego to a controlled stop.
+//!
+//! **AOU-OCCLUSION-RATE-001 (assumption of use).** An armed channel MUST publish
+//! the assured-clear distance at a bounded rate — including when visibility is
+//! wide open (a large range), not silence. Silence is indistinguishable from a
+//! dead sensor and is treated as a fault (state 3, MRC stop), exactly as the
+//! object / secondary / VRU channels already require.
+//!
+//! The fail-closed enforcement deliberately rides the perception cap (option a,
+//! mirroring `vru_channel`) rather than feeding `visibility_range_m = Some(0.0)`
+//! into the occlusion gate: the cap path is posture-composed and does not depend
+//! on the occlusion gate's `max_decel_mps2` brake parameter (finding S4 / #1038),
+//! so a lost sensor always stops via the Track-C derate.
+
+/// Environment gate for the occlusion / assured-clear-distance channel (mirrors
+/// [`crate::vru_channel::VRU_CHANNEL_ENABLED_ENV`]). Truthy = `1`/`true`/`yes`
+/// (case-insensitive); unset or anything else = disarmed (byte-identical no-op).
+/// The `std::env` READ lives in the adapter node (integration glue), not here —
+/// this pure checker module keeps only the tested [`resolve_occlusion_channel`]
+/// decision, so the mutation gate covers only safety logic, not env I/O.
+pub const OCCLUSION_CHANNEL_ENABLED_ENV: &str = "KIRRA_OCCLUSION_CHANNEL_ENABLED";
+
+/// The per-tick decision for the occlusion channel — the three-way distinction the
+/// checker's `Option<f64>` cannot express on its own.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OcclusionResolution {
+    /// Channel disarmed → feed the checker `None` (skip the gate), no cap.
+    Disarmed,
+    /// Armed + fresh + valid range (metres) → feed this to the occlusion gate.
+    Live(f64),
+    /// Armed + silent/stale/garbage → feed the checker `None` **and** an MRC-floor cap.
+    FailClosedStale,
+}
+
+impl OcclusionResolution {
+    /// The assured-clear distance to hand the checker's `visibility_range_m`:
+    /// `Some` only in [`Live`], so a [`FailClosedStale`] can NEVER reach the
+    /// occlusion gate as an admitting no-op — its enforcement rides the
+    /// [`perception_cap`](Self::perception_cap) instead.
+    ///
+    /// [`Live`]: OcclusionResolution::Live
+    /// [`FailClosedStale`]: OcclusionResolution::FailClosedStale
+    #[must_use]
+    pub fn visibility_range(&self) -> Option<f64> {
+        match self {
+            OcclusionResolution::Live(range) => Some(*range),
+            OcclusionResolution::Disarmed | OcclusionResolution::FailClosedStale => None,
+        }
+    }
+
+    /// The perception cap this resolution contributes, to compose via
+    /// [`crate::perception_redundancy::more_restrictive_cap`] into the Track-C
+    /// derate: an MRC-floor `Some(0.0)` on a silent/stale/garbage channel, else
+    /// `None`.
+    #[must_use]
+    pub fn perception_cap(&self) -> Option<f64> {
+        match self {
+            OcclusionResolution::FailClosedStale => Some(0.0),
+            OcclusionResolution::Disarmed | OcclusionResolution::Live(_) => None,
+        }
+    }
+}
+
+/// Resolve the occlusion channel for one slow-loop tick from the enable gate and
+/// the already-fail-closed `snapshot` the state layer produced.
+///
+/// * `enabled` — the adapter's occlusion enable gate
+///   (`KIRRA_OCCLUSION_CHANNEL_ENABLED`, read in the node). The caller MUST only
+///   evaluate `snapshot` when `enabled` (short-circuit), so a disarmed deployment
+///   never touches the visibility lock or logs — the byte-identical no-op.
+/// * `snapshot` — the assured-clear distance in metres: `Some(range)` when the
+///   channel is fresh, `None` when silent / stale (already failed closed by the
+///   freshness layer).
+///
+/// The rules that make this safe:
+/// * an `enabled` channel whose snapshot is `None` becomes [`FailClosedStale`]
+///   (→ MRC cap), NEVER a bare `None` handed to the checker (a silent no-op);
+/// * an `enabled` channel whose range is non-finite or negative (a garbage
+///   reading) ALSO becomes [`FailClosedStale`] — the occlusion gate must never be
+///   armed with a value that could compute a nonsensical assured-clear speed.
+///   Only a `DISARMED` channel yields the no-op `None`.
+///
+/// [`FailClosedStale`]: OcclusionResolution::FailClosedStale
+#[must_use]
+pub fn resolve_occlusion_channel(enabled: bool, snapshot: Option<f64>) -> OcclusionResolution {
+    if !enabled {
+        return OcclusionResolution::Disarmed; // state 1 — the checker's byte-identical no-op
+    }
+    match snapshot {
+        // state 2 — fresh AND a sane range (finite, non-negative metres)
+        Some(range) if range.is_finite() && range >= 0.0 => OcclusionResolution::Live(range),
+        // state 3 — armed but lost (None) OR garbage (NaN/Inf/negative) → MRC cap
+        _ => OcclusionResolution::FailClosedStale,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// DISARMED (enabled=false) is the checker's no-op regardless of the snapshot
+    /// — `visibility_range() == None`, `perception_cap() == None`. Byte-identical.
+    #[test]
+    fn disarmed_is_the_checker_noop() {
+        let r = resolve_occlusion_channel(false, Some(25.0));
+        assert_eq!(r, OcclusionResolution::Disarmed);
+        assert_eq!(r.visibility_range(), None);
+        assert_eq!(r.perception_cap(), None);
+        // …and with no snapshot.
+        assert_eq!(
+            resolve_occlusion_channel(false, None),
+            OcclusionResolution::Disarmed
+        );
+    }
+
+    /// Armed + fresh + valid range → LIVE: the range reaches the occlusion gate,
+    /// no extra cap.
+    #[test]
+    fn armed_fresh_valid_range_is_live() {
+        let r = resolve_occlusion_channel(true, Some(18.5));
+        assert_eq!(r, OcclusionResolution::Live(18.5));
+        assert_eq!(r.visibility_range(), Some(18.5));
+        assert_eq!(r.perception_cap(), None);
+    }
+
+    /// A fresh range of EXACTLY zero (the ego can see nothing ahead) is a valid,
+    /// legitimate reading — not garbage. It reaches the gate as `Some(0.0)`, which
+    /// refuses any forward speed. This is distinct from a silent channel (which
+    /// also stops, but via the cap), and pins the `>= 0.0` boundary as inclusive.
+    #[test]
+    fn armed_zero_range_is_live_not_garbage() {
+        let r = resolve_occlusion_channel(true, Some(0.0));
+        assert_eq!(r, OcclusionResolution::Live(0.0));
+        assert_eq!(r.visibility_range(), Some(0.0));
+        assert_eq!(r.perception_cap(), None);
+    }
+
+    /// THE safety-critical case: armed + `None` snapshot (silent/stale, already
+    /// failed closed by the freshness layer) → FailClosedStale. The range handed
+    /// to the checker is `None` (NOT an admitting no-op) and the MRC-floor cap
+    /// carries the enforcement — the ego stops rather than driving blind.
+    #[test]
+    fn armed_silent_snapshot_fails_closed_not_noop() {
+        let r = resolve_occlusion_channel(true, None);
+        assert_eq!(r, OcclusionResolution::FailClosedStale);
+        assert_eq!(r.visibility_range(), None); // must NOT reach the gate as a no-op
+        assert_eq!(r.perception_cap(), Some(0.0)); // …enforcement is the MRC-floor cap
+    }
+
+    /// Armed + a GARBAGE range (NaN / +Inf / negative) is a fault, NOT a live
+    /// bound: feeding it to the occlusion gate could compute a nonsensical
+    /// assured-clear speed. Each fails closed to the MRC-floor cap.
+    #[test]
+    fn armed_garbage_range_fails_closed() {
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -1.0, -0.001] {
+            let r = resolve_occlusion_channel(true, Some(bad));
+            assert_eq!(
+                r,
+                OcclusionResolution::FailClosedStale,
+                "range {bad} must fail closed"
+            );
+            assert_eq!(r.visibility_range(), None);
+            assert_eq!(r.perception_cap(), Some(0.0));
+        }
+    }
+
+    /// The disarmed `None` and the fail-closed `None` differ ONLY by the gate, and
+    /// they produce OPPOSITE caps — the whole point of the resolver.
+    #[test]
+    fn the_two_nones_are_disambiguated_by_the_gate() {
+        let disarmed = resolve_occlusion_channel(false, None);
+        let armed_silent = resolve_occlusion_channel(true, None);
+        assert_eq!(disarmed.visibility_range(), armed_silent.visibility_range()); // both None
+        assert_eq!(disarmed.perception_cap(), None); // …but disarmed relaxes
+        assert_eq!(armed_silent.perception_cap(), Some(0.0)); // …and armed-silent stops
+    }
+}

--- a/docs/safety/ASSUMPTIONS_OF_USE.md
+++ b/docs/safety/ASSUMPTIONS_OF_USE.md
@@ -1333,3 +1333,60 @@ deadline's entire purpose at the actuator.
   the deadline watchdog, and the F2 breach→posture escalator.
 - `SAFE_STATE_SPECIFICATION.md` SS-003 (MRC fallback); the SDK `503 → 0.0`
   consumer safe-stop (#405 / ADR-0011).
+
+---
+
+## AOU-OCCLUSION-RATE-001 — Armed occlusion channel publishes assured-clear distance at rate
+
+### Assumption
+
+When the occlusion / limited-visibility channel is ARMED
+(`KIRRA_OCCLUSION_CHANNEL_ENABLED`, S2 / #1025), its producer SHALL publish the
+ego's **assured-clear distance ahead** (metres — how far into its path the ego has
+actually observed) on `~/input/visibility` at a **bounded rate**, including when
+visibility is wide open (a large range), never silence. A "clear" reading is a
+large number, not the absence of a message. The publish period SHALL stay within
+the subscription staleness budget (`KIRRA_SUBSCRIPTION_STALENESS_MS`, default
+`SUBSCRIPTION_STALENESS_TIMEOUT_MS`). The value SHALL be finite and non-negative.
+
+### Why it is load-bearing
+
+The checker's RSS Rule 4 limited-visibility bound (`outruns_assured_clear_distance`)
+refuses a trajectory the ego could not stop within before entering unobserved
+space — treating what it cannot see as a potential stopped hazard. That bound is
+DISARMED by default (`visibility_range_m = None` → byte-identical no-op); when a
+deployment arms it, the safety property is only as good as the freshness of the
+sight-distance feed. A silent producer (dead sensor / stalled transport) is
+indistinguishable from "the road is clear" — exactly the confusion that would let
+the ego enter a blind junction at full ODD speed. So an armed-but-silent/stale/
+garbage channel is treated as a **fault**: `resolve_occlusion_channel` maps it to
+an MRC-floor perception cap (`Some(0.0)`) that composes into the Track-C derate
+(`apply_perception_cap`) and brings the ego to a controlled stop — it NEVER
+reaches the checker as an admitting `None`. Until a producer publishes, occlusion
+remains a **doer-only** hazard (bounded only by the untrusted planner's own
+`OccludedApproach` cap): the checker's bound is present but disarmed.
+
+### Pairs with
+
+- **AOU-VRU-RATE-001** — the pedestrian-channel sibling (an armed VRU producer
+  must likewise publish an empty "clear" message, not silence). `resolve_occlusion_channel`
+  mirrors `resolve_vru_channel`'s three-way disarmed/live/fail-closed decision.
+- **AOU-TIMESYNC-001** — the arrival stamps the freshness gate ages must be in the
+  monotonic boundary clock domain (a future stamp would mask a stale feed).
+
+### Verification status — **AoU-GAP** (integrator obligation)
+
+The checker + adapter side is DISCHARGED: the pure `resolve_occlusion_channel`
+decision (disarmed no-op / live / fail-closed on silence/garbage) and the
+`AdaptorState::snapshot_visibility` fail-closed freshness are unit-tested; the
+occlusion gate itself (`outruns_assured_clear_distance` / `assured_clear_distance_speed_cap`)
+has existing coverage. The producer that publishes `~/input/visibility` at rate —
+e.g. kirra-taj / kirra-map `sight_distance` per approach lane — is the
+integrator's obligation; the channel ships DISARMED so a deployment without such a
+producer is byte-identical to prior behaviour.
+
+### Cited by
+
+- `crates/kirra-trajectory/src/occlusion_channel.rs` (the resolver);
+  `crates/kirra-trajectory/src/validation.rs` §D (the RSS Rule 4 gate).
+- `SAFE_STATE_SPECIFICATION.md` (MRC fallback); the review finding S2 / #1025.


### PR DESCRIPTION
Closes #1025. Part of the engineering-review remediation epic #1023 (HIGH). The sibling of the S1 fix (#1051): the checker's *other* not-on-the-wire promise.

## The finding (S2)
The RSS Rule 4 limited-visibility bound (`outruns_assured_clear_distance` — refuse a trajectory the ego couldn't stop within what it can actually see, treating unobserved space as a potential stopped hazard) is **fully implemented and correct**, but the live node fed `validate_trajectory_slow_with_envelope` a **hardcoded `visibility_range_m = None` every tick** (`node.rs`), so the gate was **dormant**. The only occlusion protection deployed was the untrusted planner's own `OccludedApproach` cap — the DOER guarding a hazard the CHECKER is meant to bound.

## The fix — mirror the VRU channel (#789) exactly
- **New pure resolver** `occlusion_channel::resolve_occlusion_channel` — the three-way decision the checker's `Option<f64>` can't express: `DISARMED → None` (gate skipped, byte-identical) / `armed + fresh + valid → Some(range)` (live sight distance) / `armed + silent-or-garbage → FailClosedStale` (MRC-floor perception cap → controlled stop, never a silent no-op). Includes a finite/non-negative value guard so a garbage reading can't arm a nonsensical bound.
- **`AdaptorState`**: `visibility_cache` + `last_visibility_ms` + `update_visibility` / `snapshot_visibility` with fail-closed freshness (mirrors the pedestrian channel).
- **`node.rs`**: `KIRRA_OCCLUSION_CHANNEL_ENABLED` gate + `~/input/visibility` (`std_msgs/Float64`, metres) subscription + drain task; resolve per-tick; compose `occlusion.perception_cap()` into `effective_perception_cap`; feed `occlusion.visibility_range()` to the slow-loop call **in place of the hardcoded `None`**.
- **Default OFF** — disarmed → byte-identical prior behaviour. A producer that publishes at rate (kirra-taj / kirra-map `sight_distance`) is the integrator obligation, documented as **AOU-OCCLUSION-RATE-001**. Until then occlusion stays a doer-only hazard, now explicitly recorded in the safety case rather than silently assumed covered.

The fail-closed enforcement deliberately rides the Track-C perception cap (posture-composed) rather than feeding `Some(0.0)` into the occlusion gate — so a lost sensor stops without depending on that gate's `max_decel_mps2` brake parameter (the separate finding S4 / #1038).

## Tests
- **6 resolver cases** (`occlusion_channel.rs`): disarmed no-op / live / zero-range-is-live (inclusive boundary) / silent-fails-closed / garbage-fails-closed (NaN/±Inf/negative) / two-`None`s-disambiguated.
- **3 `AdaptorState` freshness tests** (fresh / never-seen-fails-closed / stale-at-budget).
- **Mutation gate: 0 missed** (ran `cargo mutants -p kirra-trajectory --in-diff` locally → 13 caught, 1 unviable). fmt + clippy clean; adapter default suite green (49).

## Scope note
The ros2-gated `node.rs` wiring compiles only under `--features ros2` (needs r2r/ROS), validated by the CI `ros2 adapter build` lane — the pure resolver + state channel + freshness are fully covered by the default-build tests here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_