### PR TITLE
WCET honesty (evidence): W1/W3/W4 (#1027 #1032 #1043)

### DIFF
--- a/crates/kirra-replay/src/lib.rs
+++ b/crates/kirra-replay/src/lib.rs
@@ -39,8 +39,17 @@ use kirra_core::capture::record_from_verdict;
 use kirra_verifier::gateway::contract_profiles::{contract_for, mrc_fallback_for, VehicleClass};
 use kirra_verifier::gateway::kinematics_contract::{
     enforce_degraded_decel_to_stop, validate_vehicle_command, ProposedVehicleCommand,
+    VehicleKinematicsContract,
 };
 use kirra_verifier::verifier::FleetPosture;
+
+/// W4 (#1043): the cross-platform (x86 replay/CI vs aarch64 Orin/QNX) libm
+/// spread on a `tan`/`atan`-derived P6 steering clamp. A correctly-rounded IEEE
+/// result would be bit-identical; real libm implementations differ by ~1–2 ulps.
+/// 64 ulps is generous headroom for that spread while remaining astronomically
+/// tighter than any physically-meaningful steering tamper (changing a clamp by
+/// even 1e-6° is ~10^10 ulps), so the tamper non-vacuity is preserved.
+const MAX_PLATFORM_APPROX_ULPS: u64 = 64;
 
 /// The bit-comparable projection of a verdict record (the fields the emit
 /// mapping derives from the verdict; timing/join fields excluded by design).
@@ -74,6 +83,21 @@ pub enum ReplayResult {
     Divergent {
         recorded: VerdictImage,
         recomputed: VerdictImage,
+    },
+    /// W4 (#1043): the recomputed verdict matches on every field EXCEPT the exact
+    /// bits of a P6 lateral-accel clamp's steering value, which is `tan`/`atan`-
+    /// derived and therefore NOT bit-portable across x86 (CI/replay) and aarch64
+    /// (Orin/QNX) libm — the two values agree to within `MAX_PLATFORM_APPROX_ULPS`.
+    /// Classified platform-approximate rather than raised as a FALSE incident
+    /// divergence. (The EP-15 Kani proofs honestly EXCLUDE this transcendental
+    /// path for the same non-portability reason.) Everything else — a different
+    /// outcome / deny-code / mrc, a non-P6 clamp value, or a value more than a few
+    /// ulps off — stays [`Divergent`](Self::Divergent), so tamper detection holds.
+    PlatformApproximate {
+        recorded: VerdictImage,
+        recomputed: VerdictImage,
+        /// ulp distance between the recorded and recomputed steering value.
+        ulps: u64,
     },
     /// The record does not carry its complete checker inputs; classified,
     /// never guessed. The reason says exactly what is missing.
@@ -148,13 +172,112 @@ pub fn replay_record(rec: &CaptureRecord, class: VehicleClass) -> ReplayResult {
     let recorded = VerdictImage::of(rec);
     let recomputed = VerdictImage::of(&recomputed_rec);
     if recorded == recomputed {
-        ReplayResult::Identical
-    } else {
-        ReplayResult::Divergent {
+        return ReplayResult::Identical;
+    }
+    // W4 (#1043): before declaring a divergence, check whether the ONLY difference
+    // is the value of a P6 lateral-accel steering clamp — which is `tan`/`atan`-
+    // derived and not bit-portable across libm/arch. If so, and the values agree
+    // within a few ulps, it is a platform-approximate match, not an incident.
+    if let Some(ulps) = p6_clamp_platform_approx(&recorded, &recomputed, &cmd, class, posture) {
+        return ReplayResult::PlatformApproximate {
             recorded,
             recomputed,
-        }
+            ulps,
+        };
     }
+    ReplayResult::Divergent {
+        recorded,
+        recomputed,
+    }
+}
+
+/// W4 (#1043): `Some(ulps)` iff `recorded`/`recomputed` differ ONLY in a P6
+/// lateral-accel steering-clamp value that is within `MAX_PLATFORM_APPROX_ULPS` —
+/// the tan/atan-derived, non-bit-portable case. `None` (→ a real divergence) for
+/// any different outcome/deny-code/mrc, a non-`ClampSteering` verdict (only
+/// `ClampSteering` carries the atan value in `safe_value`; `ClampBoth` records the
+/// deterministic longitudinal clamp), a value more than a few ulps off, or a clamp
+/// P6 was not the binding constraint for.
+fn p6_clamp_platform_approx(
+    recorded: &VerdictImage,
+    recomputed: &VerdictImage,
+    cmd: &ProposedVehicleCommand,
+    class: VehicleClass,
+    posture: FleetPosture,
+) -> Option<u64> {
+    // Only a ClampSteering verdict exposes the atan value in `safe_value`; both
+    // sides must agree it is a steering clamp, and nothing else may differ.
+    if recorded.outcome != CaptureOutcome::ClampSteering
+        || recomputed.outcome != CaptureOutcome::ClampSteering
+        || recorded.deny_code != recomputed.deny_code
+        || recorded.mrc != recomputed.mrc
+    {
+        return None;
+    }
+    let (Some(a_bits), Some(b_bits)) = (recorded.safe_value_bits, recomputed.safe_value_bits)
+    else {
+        return None;
+    };
+    // Was the tan/atan P6 arm the BINDING steering constraint here? (A P5a hard
+    // limit / P5b rate ceiling also yields ClampSteering, but tan/atan-free and
+    // fully deterministic — those stay bit-compared.)
+    if !p6_was_the_binding_steering_constraint(cmd, class, posture) {
+        return None;
+    }
+    let ulps = ulps_apart(f64::from_bits(a_bits), f64::from_bits(b_bits));
+    (ulps <= MAX_PLATFORM_APPROX_ULPS).then_some(ulps)
+}
+
+/// Black-box probe: is the P6 lateral-accel envelope (the `tan`/`atan` arm) the
+/// binding steering constraint for this command? Recompute with the lateral-accel
+/// ceiling raised to `+∞` — so the talisman's P6 `>` can never fire and its `atan`
+/// is never reached — and see if the verdict changes. If it does, P6 was binding
+/// and the produced steering is atan-derived. This never touches the frozen
+/// kinematics talisman; it only feeds it a different contract.
+fn p6_was_the_binding_steering_constraint(
+    cmd: &ProposedVehicleCommand,
+    class: VehicleClass,
+    posture: FleetPosture,
+) -> bool {
+    let (base, mut no_p6) = match posture {
+        FleetPosture::Nominal => (contract_for(class), contract_for(class)),
+        FleetPosture::Degraded => (mrc_fallback_for(class), mrc_fallback_for(class)),
+        FleetPosture::LockedOut => return false,
+    };
+    no_p6.max_lateral_accel_mps2 = f64::INFINITY;
+    recompute_image(cmd, &base, posture) != recompute_image(cmd, &no_p6, posture)
+}
+
+/// The [`VerdictImage`] the checker produces for `cmd` under `posture` against an
+/// explicit `contract` (used by the P6-binding probe to compare with vs without
+/// the lateral-accel envelope). Same functions the deployed arms run.
+fn recompute_image(
+    cmd: &ProposedVehicleCommand,
+    contract: &VehicleKinematicsContract,
+    posture: FleetPosture,
+) -> VerdictImage {
+    let verdict = match posture {
+        FleetPosture::Nominal => validate_vehicle_command(cmd, contract),
+        FleetPosture::Degraded => enforce_degraded_decel_to_stop(cmd, contract),
+        FleetPosture::LockedOut => unreachable!("classified before this point"),
+    };
+    // seq / t_wall / derate do not affect the compared fields.
+    VerdictImage::of(&record_from_verdict(0, 0, &verdict, posture, cmd, false))
+}
+
+/// ulp distance between two SAME-SIGN finite f64s (the recorded and recomputed
+/// steering share the command's `signum`). Returns `u64::MAX` for a sign flip or a
+/// non-finite value — those are never "a few ulps apart" and stay divergent.
+fn ulps_apart(a: f64, b: f64) -> u64 {
+    if a == b {
+        return 0;
+    }
+    if !a.is_finite() || !b.is_finite() || a.is_sign_negative() != b.is_sign_negative() {
+        return u64::MAX;
+    }
+    // For two same-sign finite floats the raw bit patterns are monotonic in
+    // magnitude, so the absolute bit difference IS the ulp distance.
+    (a.to_bits() as i128 - b.to_bits() as i128).unsigned_abs() as u64
 }
 
 /// A whole-session replay summary.
@@ -163,6 +286,9 @@ pub struct ReplaySummary {
     pub total: usize,
     pub identical: usize,
     pub not_replayable: usize,
+    /// W4 (#1043): records that matched on everything but a P6 tan/atan clamp
+    /// value within a few ulps — a cross-platform libm spread, NOT a divergence.
+    pub platform_approximate: usize,
     /// `(decision_seq, detail)` for every divergent record.
     pub divergences: Vec<(u64, String)>,
     /// `(decision_seq, reason)` for every classified-out record.
@@ -172,8 +298,10 @@ pub struct ReplaySummary {
 }
 
 impl ReplaySummary {
-    /// The session replays deterministically: every replayable record is
-    /// bit-identical and every line parsed.
+    /// The session replays deterministically: no true divergence and every line
+    /// parsed. W4 (#1043): platform-approximate matches (a P6 tan/atan clamp
+    /// within a few ulps across x86/aarch64 libm) are NOT divergences and do not
+    /// break determinism — the incident-reconstruction verdict is unchanged.
     #[must_use]
     pub fn is_deterministic(&self) -> bool {
         self.divergences.is_empty() && self.parse_errors.is_empty()
@@ -199,6 +327,7 @@ pub fn replay_session_jsonl(jsonl: &str, class: VehicleClass) -> ReplaySummary {
         summary.total += 1;
         match replay_record(&rec, class) {
             ReplayResult::Identical => summary.identical += 1,
+            ReplayResult::PlatformApproximate { .. } => summary.platform_approximate += 1,
             ReplayResult::Divergent {
                 recorded,
                 recomputed,
@@ -380,6 +509,112 @@ mod tests {
             replay_record(&rec, VehicleClass::Robotaxi),
             ReplayResult::NotReplayable { .. }
         ));
+    }
+
+    /// Re-parse a record through the JSONL round-trip (the tests avoid relying on
+    /// `CaptureRecord: Clone`; production replay reads JSONL lines anyway).
+    fn reparse(rec: &CaptureRecord) -> CaptureRecord {
+        serde_json::from_str(&serde_json::to_string(rec).expect("serialize")).expect("parse")
+    }
+
+    /// W4 (#1043): a P6 lateral-accel steering clamp is `tan`/`atan`-derived, so a
+    /// few-ulp cross-platform (x86/aarch64 libm) perturbation of its recorded value
+    /// is classified `PlatformApproximate` — not a false incident divergence — while
+    /// a LARGE perturbation (a tamper) still diverges.
+    #[test]
+    fn p6_clamp_ulp_perturbation_is_platform_approximate() {
+        let class = VehicleClass::Robotaxi;
+        // A PURE P6 lateral-accel clamp: high speed + in-range steering that breaches
+        // ONLY the lateral-accel envelope (20° < the 35° hard limit; 20°/s < the rate
+        // ceiling), so the clamp value comes from the atan back-solve.
+        let p6_cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 30.0,
+            current_velocity_mps: 30.0,
+            delta_time_s: 1.0,
+            steering_angle_deg: 20.0,
+            current_steering_angle_deg: 0.0,
+        };
+        let verdict = validate_vehicle_command(&p6_cmd, &contract_for(class));
+        let rec = record_from_verdict(0, 0, &verdict, FleetPosture::Nominal, &p6_cmd, false);
+        assert_eq!(
+            rec.outcome,
+            CaptureOutcome::ClampSteering,
+            "fixture must be a P6 steering clamp"
+        );
+        assert!(
+            p6_was_the_binding_steering_constraint(&p6_cmd, class, FleetPosture::Nominal),
+            "fixture sanity: P6 must be the binding constraint"
+        );
+
+        // Same-platform replay is EXACTLY identical (no excusal on a real match).
+        assert!(matches!(
+            replay_record(&rec, class),
+            ReplayResult::Identical
+        ));
+
+        // Perturb the recorded steering by 4 ulps → PlatformApproximate.
+        let mut approx = reparse(&rec);
+        let v = approx
+            .safe_value
+            .expect("P6 clamp carries a steering value");
+        approx.safe_value = Some(f64::from_bits(v.to_bits() + 4));
+        match replay_record(&approx, class) {
+            ReplayResult::PlatformApproximate { ulps, .. } => assert_eq!(ulps, 4),
+            other => panic!("expected PlatformApproximate, got {other:?}"),
+        }
+        // A whole-session summary counts it approximate, NOT a divergence, and stays
+        // deterministic — an ulp-level libm spread is not an incident.
+        let summary = replay_session_jsonl(&serde_json::to_string(&approx).unwrap(), class);
+        assert_eq!(summary.platform_approximate, 1);
+        assert!(summary.divergences.is_empty());
+        assert!(summary.is_deterministic());
+
+        // A LARGE perturbation (≫ any libm spread) is still a real divergence.
+        let mut big = reparse(&rec);
+        big.safe_value = Some(big.safe_value.unwrap() + 1.0); // ~10^15 ulps — a tamper
+        assert!(matches!(
+            replay_record(&big, class),
+            ReplayResult::Divergent { .. }
+        ));
+    }
+
+    /// W4 non-vacuity: a `tan`/`atan`-FREE steering clamp (a P5b rate ceiling) is
+    /// fully deterministic, so even a 4-ulp perturbation must DIVERGE — the
+    /// platform-approximate excusal is scoped to the P6 arm only.
+    #[test]
+    fn p5_rate_clamp_ulp_perturbation_still_diverges() {
+        let class = VehicleClass::Robotaxi;
+        // Low speed (P6 never fires) but a large steering STEP over a short dt → P5b
+        // rate ceiling clamps it, deterministically.
+        let p5_cmd = ProposedVehicleCommand {
+            linear_velocity_mps: 2.0,
+            current_velocity_mps: 2.0,
+            delta_time_s: 0.05,
+            steering_angle_deg: 30.0,
+            current_steering_angle_deg: -30.0,
+        };
+        let verdict = validate_vehicle_command(&p5_cmd, &contract_for(class));
+        let rec = record_from_verdict(0, 0, &verdict, FleetPosture::Nominal, &p5_cmd, false);
+        assert_eq!(
+            rec.outcome,
+            CaptureOutcome::ClampSteering,
+            "fixture must be a P5 rate clamp"
+        );
+        assert!(
+            !p6_was_the_binding_steering_constraint(&p5_cmd, class, FleetPosture::Nominal),
+            "fixture sanity: this clamp is P5, not P6"
+        );
+
+        let mut nudged = reparse(&rec);
+        let v = nudged.safe_value.unwrap();
+        nudged.safe_value = Some(f64::from_bits(v.to_bits() + 4));
+        assert!(
+            matches!(
+                replay_record(&nudged, class),
+                ReplayResult::Divergent { .. }
+            ),
+            "a deterministic P5 clamp must still diverge on ANY bit change"
+        );
     }
 
     /// Fail-closed class parse (a typo must never select another envelope).

--- a/docs/safety/WCET_MEASUREMENT_METHODOLOGY.md
+++ b/docs/safety/WCET_MEASUREMENT_METHODOLOGY.md
@@ -259,12 +259,34 @@ argument is grandfathered (it is environment-independent); the *numbers* are not
 |---|---|---|---|
 | **Kinematic gateway / verdict** | `validate_vehicle_command` / `validate_cmd_vel` — the P0..P6 verdict pipeline (`src/wcet_gate.rs`) | QNX Governor partition, FIFO | #274 (re-measure §5); CI guard `GOVERNOR_VERDICT_WCET_CI_THRESHOLD_MICROS` holds the regression line |
 | **HVCHAN snapshot→validate→digest** | The cross-partition trust chain: seqlock snapshot → bounds → CRC → judge → digest → release token (HVCHAN §3) | QNX Governor partition, FIFO; HVCHAN §5 partition config | #278 (the HVCHAN hardware half) + #274 |
-| **Judge (contract checker)** | `kirra_judge_assess` fixed check order (#271 harness today on host) | QNX Governor partition per #274 (host = indicative only) | #271 harness reports host-indicative now; #274 produces the target-under-FIFO numbers |
+| **Judge (contract checker)** | `kirra_judge_assess` fixed check order (#271 harness today on host) — a **PROXY**: integer-only, `no_std`, crypto-free, FP-free, talisman-free, with a proxy velocity bound | QNX Governor partition per #274 (host = indicative only) | #271 harness reports host-indicative now; #274 produces the target-under-FIFO numbers. **NOTE (W1 #1027): this proxy does NOT represent the assembled release loop below** |
+| **Assembled release loop (EP-01)** | `kirra_inline_governor::govern_and_release` — the DEPLOYED enforced cycle: verdict (P0..P6 + the FP `validate_vehicle_command` talisman) **+ release token** (2× SHA-256 + Ed25519 **sign** + Ed25519 **verify_strict**) | QNX Governor + Actuator partitions, FIFO, pages locked (W2 #1028) | **REMAINDER (W1 #1027): NOT yet target-measured-under-FIFO.** The `kirra_judge_assess` proxy (row above) does NOT stand in for it. Host-indicative today via `wcet_gate::regression_inline_loop_full_step` against the **SEPARATE** `GOVERNOR_RELEASE_TOKEN_WCET_*` budget (W3 #1032); porting the assembled loop to the #271/#274 harness is the open obligation |
 | **FFI / fault-injection timing criteria** | The timing half of the #279 fault-injection catalogue — measured as the SAME campaign as the fault verdicts (§3) | QNX Governor partition, FIFO; HVCHAN §4 barrier attribution | #279 (timing criteria == this methodology, not a second standard) |
 
 Each path's number is only a WCET once it is target-measured-under-FIFO per §1–§4,
 margined per §0 (VALIDATION-PENDING until the FTTI closure), and accepted in
 safety-engineer review.
+
+**W1 (#1027) — the on-target proxy caveat (scoping the FTTI evidence honestly).**
+The only on-QNX-target number today is `kirra_judge_assess` (row "Judge"): a
+crypto-free, FP-free, talisman-free checker with a *proxy* velocity bound (min
+31 ns / p99.9 79 ns, `tools/qnx-rtm-harness/results/`). It establishes the harness
+and the verdict-**correctness** FDIT/RTM matrix on target — but it is structurally
+UNLIKE the **deployed** enforced loop (row "Assembled release loop"), whose dominant
+timing terms — 2× Ed25519, 2× SHA-256, and the floating-point
+`validate_vehicle_command` talisman — have **zero target-under-FIFO timing
+evidence**. Two consequences, stated plainly so the safety case does not over-claim:
+
+- The FTTI **reaction** budget (0.5 s) is **not** at risk: the whole crypto term is
+  ~0.06 % of it (see `GOVERNOR_INTEGRITY_EVIDENCE.md` §3 and the W3 #1032 budget
+  split), so nothing here changes the fail-closed-within-FTTI argument.
+- But **no tighter control-cycle bound is earned** for the assembled loop until it is
+  ported to the #271/#274 harness and measured under FIFO with pages locked. Until
+  then the assembled-loop timing is **HOST-INDICATIVE only** (`wcet_gate::
+  regression_inline_loop_full_step`, gated on the separate `GOVERNOR_RELEASE_TOKEN_WCET_*`
+  budget — W3 #1032), never a WCET, and the certified FTTI budget explicitly **scopes
+  out** the release-token crypto pending that measurement. The proxy-judge number MUST
+  NOT be cited as representative of the enforced path.
 
 ---
 

--- a/src/wcet_gate.rs
+++ b/src/wcet_gate.rs
@@ -75,21 +75,72 @@
 //    bounded (AUDIT_QUEUE_BOUND = 2048) so production cannot grow the
 //    queue beyond a fixed size.
 //
-// CONCLUSION: a finite WCET for the verdict path exists by construction.
-// This module measures it and gates CI against regressions.
+// 7. THE RELEASE-TOKEN CRYPTO IS A SEPARATE, BOUNDED TERM — NOT IN §1–§6.
+//    W3 (#1032): the §1–§6 argument bounds the CRYPTO-FREE verdict path
+//    (`validate_vehicle_command` + the O(1) posture/cap reads). The ASSEMBLED
+//    EP-01 enforced loop (`kirra_inline_governor::govern_and_release`) ALSO
+//    mints/verifies a release token per cycle: 2× SHA-256 (payload digest) +
+//    one Ed25519 SIGN (GovernorStation) + one Ed25519 verify_strict
+//    (ActuatorStation). That crypto term is NOT covered by §1–§6 and must not be
+//    folded into the crypto-free verdict budget. It IS still bounded: each op is
+//    O(1) in the command (fixed-size 32-byte payload, fixed-size keys/signatures),
+//    data-independent in time (no secret-dependent branching in the dalek impls),
+//    and allocation-free on the release path. So a finite WCET for the ASSEMBLED
+//    loop also exists by construction — but as `verdict_WCET + crypto_WCET`, two
+//    SEPARATE budgets (`GOVERNOR_VERDICT_WCET_*` vs `GOVERNOR_RELEASE_TOKEN_WCET_*`
+//    below), each with its own evidence. The crypto-free/verdict separation is a
+//    CI invariant of its own (`ci/check_verdict_core_purity.py`): a signing op must
+//    never slip INTO the verdict path, which is exactly what keeps the two budgets
+//    decomposable.
+//
+// CONCLUSION: a finite WCET for the verdict path exists by construction, and a
+// finite WCET for the assembled release loop exists as verdict + a bounded crypto
+// term. This module measures both and gates CI against regressions.
 
 // ---------------------------------------------------------------------------
 // Budgets
 // ---------------------------------------------------------------------------
 
-/// SG9 fail-closed timeout TARGET (microseconds) for deployment hardware.
+/// SG9 fail-closed timeout TARGET (microseconds) for deployment hardware —
+/// the CRYPTO-FREE verdict path only (W3 #1032).
 ///
 /// This is the verdict-path WCET budget the Governor must stay under on the
 /// target SoC. It must fit inside the control-cycle period minus the
 /// actuation latency (loop closure: WCET + actuation < cycle < 0.5 s
 /// reaction budget per SPEED_ENVELOPE.md). 100 µs is conservative for the
-/// O(1) scalar-math kernel proven above; S8 (#120) re-measures on target.
+/// O(1) scalar-math kernel proven above (§1–§6); S8 (#120) re-measures on target.
+///
+/// SCOPE (W3): this budget covers `validate_vehicle_command` + the O(1)
+/// posture/cap reads — it does NOT include the release-token crypto (2× SHA-256
+/// + Ed25519 sign + verify) the assembled EP-01 loop runs. That term has its own
+/// budget below (`GOVERNOR_RELEASE_TOKEN_WCET_TARGET_MICROS`); the two are
+/// decomposable precisely because the crypto-free/verdict separation is a CI
+/// invariant (`ci/check_verdict_core_purity.py`).
 pub const GOVERNOR_VERDICT_WCET_TARGET_MICROS: u64 = 100;
+
+/// TARGET (microseconds) for the ASSEMBLED release-token path — the crypto term
+/// the verdict budget above deliberately excludes (W3 #1032).
+///
+/// The EP-01 enforced loop (`kirra_inline_governor::govern_and_release`) mints and
+/// verifies a release token every cycle: 2× SHA-256 + one Ed25519 SIGN + one
+/// Ed25519 `verify_strict`. The code's own estimate is ~50–100 µs each for sign
+/// and verify on a release build, so ~200–300 µs for the whole crypto term. 500 µs
+/// is a conservative target with headroom; it is a SEPARATE budget from the
+/// crypto-free verdict path, NOT a revision of it. Both still fit the control cycle
+/// with orders of magnitude of headroom against the 0.5 s reaction FTTI (crypto is
+/// ~0.06% of it). PROVISIONAL / CI-relative — the certified number is the
+/// QNX-target-under-FIFO measurement of the assembled loop (W1 #1027 remainder;
+/// `docs/safety/WCET_MEASUREMENT_METHODOLOGY.md`), which the host proxy judge does
+/// NOT yet represent. S8 (#120) re-measures on target.
+pub const GOVERNOR_RELEASE_TOKEN_WCET_TARGET_MICROS: u64 = 500;
+
+/// CI regression-gate threshold (microseconds) for the assembled release-token
+/// loop. Generous (10× the target) for the same CI-hardware-variance reason as
+/// the verdict threshold, plus the crypto term's own variance (dalek codepath +
+/// the seqlock read/republish). Catches a GROSS regression on the assembled loop
+/// (e.g. an accidental extra sign/verify, or an alloc on the release path) — it is
+/// NOT certified timing. The certified number is the QNX-target measurement.
+pub const GOVERNOR_RELEASE_TOKEN_WCET_CI_THRESHOLD_MICROS: u64 = 5_000;
 
 /// CI regression-gate threshold (microseconds).
 ///
@@ -239,6 +290,30 @@ mod ci_gate_tests {
         );
     }
 
+    /// W3 (#1032): the assembled release-token loop is gated against its OWN,
+    /// larger budget — the crypto term the crypto-free verdict budget excludes —
+    /// NOT the verdict threshold. Same p99.9 / host-indicative framing.
+    fn assert_under_release_token_budget(name: &str, max_ns: u128, p999_ns: u128) {
+        let (max_us, p999_us) = (max_ns / 1000, p999_ns / 1000);
+        println!(
+            "GOVERNOR RELEASE-TOKEN REGRESSION-GATE (host-indicative p99.9, NOT certified WCET) \
+             {name}: max={max_ns}ns ({max_us}us)  p99.9={p999_ns}ns ({p999_us}us)  vs \
+             release-token CI-threshold {}us  (release-token target {}us; the crypto-free verdict \
+             budget is a SEPARATE {}us)",
+            GOVERNOR_RELEASE_TOKEN_WCET_CI_THRESHOLD_MICROS,
+            GOVERNOR_RELEASE_TOKEN_WCET_TARGET_MICROS,
+            GOVERNOR_VERDICT_WCET_TARGET_MICROS,
+        );
+        assert!(
+            p999_us < GOVERNOR_RELEASE_TOKEN_WCET_CI_THRESHOLD_MICROS as u128,
+            "RELEASE-TOKEN LATENCY REGRESSION on {name}: p99.9 {p999_us}us exceeds the \
+             release-token CI threshold {}us — the assembled sign→verify loop regressed \
+             (an extra crypto op, or an alloc on the release path). (Host-indicative, NOT \
+             certified WCET; max={max_us}us reported but not gated.)",
+            GOVERNOR_RELEASE_TOKEN_WCET_CI_THRESHOLD_MICROS,
+        );
+    }
+
     fn nominal_cmd() -> ProposedVehicleCommand {
         // Worst-case Allow path: all P0..P6 guards run to completion
         // without returning early. This is the full pipeline depth.
@@ -269,11 +344,13 @@ mod ci_gate_tests {
     /// validate → decode → kinematic bound → Ed25519 sign → actuator verify →
     /// release decision) over the in-process reference carrier, through the
     /// assembled `kirra-inline-governor` API — the exact composition the SHM
-    /// path runs. The Ed25519 sign+verify dominates (~50-100 µs release-build),
-    /// still well inside the 1 ms CI threshold. The in-loop republish
-    /// (sub-µs CRC + stores) is included and negligible at this scale.
-    /// HOST-INDICATIVE p99.9, NOT certified WCET — the QNX-target measurement
-    /// remains the certified path.
+    /// path runs. The Ed25519 sign+verify dominates (~50-100 µs release-build).
+    /// The in-loop republish (sub-µs CRC + stores) is included and negligible at
+    /// this scale. W3 (#1032): gated against the SEPARATE release-token budget (the
+    /// crypto term the crypto-free verdict budget excludes), NOT the verdict
+    /// threshold. HOST-INDICATIVE p99.9, NOT certified WCET — the QNX-target
+    /// measurement remains the certified path (and the on-target proxy judge does
+    /// NOT yet measure THIS crypto term — W1 #1027 remainder).
     #[test]
     fn regression_inline_loop_full_step() {
         use kirra_contract_channel::reference::InProcessRegion;
@@ -322,7 +399,7 @@ mod ci_gate_tests {
             let _ = std::hint::black_box(released);
         });
         if cfg!(not(debug_assertions)) {
-            assert_under_budget("inline_loop::govern_and_release", max_ns, p999_ns);
+            assert_under_release_token_budget("inline_loop::govern_and_release", max_ns, p999_ns);
         } else {
             println!(
                 "inline_loop::govern_and_release (DEBUG structural pass, not gated): \


### PR DESCRIPTION
Part of #1023 (epic group 4, "WCET honesty"). Three of the four findings — the ones about **evidence telling the truth**. **W2 (#1028, the real RT syscalls) is a separate PR** (platform code deserving its own review). None of this touches the frozen kinematics talisman or the mutation-gated checker crate.

## W3 (#1032) — split the verdict vs release-token WCET budget
`GOVERNOR_VERDICT_WCET_TARGET_MICROS = 100` was derived for the crypto-free O(1) scalar kernel, but the assembled EP-01 loop that actually gates actuation runs an Ed25519 **sign** + **verify** + 2× SHA-256 per cycle (~200–300 µs). That made the budget, the §1–§6 structural argument, and the enforced path mutually inconsistent.
- New `GOVERNOR_RELEASE_TOKEN_WCET_TARGET_MICROS` (500 µs) + CI threshold (5 ms) — a **separate** budget for the crypto term, not a revision of the verdict budget.
- New structural-argument **§7**: the crypto term is bounded and input-independent (fixed-size payload/keys/sigs, data-independent dalek time, alloc-free) but is explicitly **not** part of the crypto-free §1–§6 argument.
- `regression_inline_loop_full_step` now gates against the release-token budget, not the verdict budget.
- The crypto-free/verdict separation is already a CI invariant (`ci/check_verdict_core_purity.py`), which is what keeps the two budgets decomposable.

## W4 (#1043) — replay classifies P6-clamp records as platform-approximate
Replay compared verdicts **bit-identically** (`f64::to_bits`), but the P6 lateral-accel clamp's steering is `tan`/`atan`-derived (libm/HW-dependent, not IEEE correctly-rounded), and production is aarch64 while replay/CI is x86 — so a legitimate replay of a P6-clamp record would falsely "diverge" on a 1-ulp libm spread (or mask a real one). Kani honestly excludes this exact path.
- New `ReplayResult::PlatformApproximate`: when the **only** difference is a P6-clamp steering value within `MAX_PLATFORM_APPROX_ULPS` (64) **and** P6 was the binding constraint → classified platform-approximate (not a divergence; doesn't break determinism).
- Scope is exact: only `ClampSteering` carries the atan value in `safe_value` (`ClampBoth` records the deterministic *longitudinal* clamp).
- P6-binding is detected as a **black box** — recompute with the lateral-accel ceiling raised to `+∞` and see if the verdict changes — so the **frozen talisman is never touched**.
- Tamper non-vacuity preserved: a large perturbation, or the same ulp perturbation on a deterministic **P5** clamp, still `Divergent`.

## W1 (#1027) — scope the on-target WCET evidence honestly
The only on-QNX-target number is the `kirra_judge_assess` **proxy** (crypto-free, FP-free, talisman-free), structurally unlike the deployed loop (2× Ed25519 + 2× SHA-256 + FP talisman have zero target-under-FIFO evidence). No QNX target is available here, so this takes the issue's **documented alternative**: `WCET_MEASUREMENT_METHODOLOGY.md` §6 gains an explicit **"Assembled release loop (EP-01)"** row marked *REMAINDER — not yet target-measured*, a proxy caveat ("the judge number MUST NOT be cited as representative of the enforced path"), and the honest scoping that the FTTI **reaction** budget (0.5 s) is not at risk (crypto ~0.06 %) while **no tighter control-cycle bound is earned** until the assembled loop is ported to the harness and measured under FIFO with pages locked (W2 #1028).

## Tests
- kirra-replay: `p6_clamp_ulp_perturbation_is_platform_approximate` + `p5_rate_clamp_ulp_perturbation_still_diverges` (7 pass) — the P6 ulp-spread is excused, a large tamper and a deterministic P5 clamp still diverge.
- `wcet_gate`: 13 pass, including the **release-mode** release-token assertion (verified locally under `--release`).
- `fmt` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_