### PR TITLE
WCET honesty (real-time): W2 (#1028) — RT syscalls on the enforced loop

### DIFF
--- a/crates/kirra-hv-carrier/src/lib.rs
+++ b/crates/kirra-hv-carrier/src/lib.rs
@@ -42,6 +42,12 @@ use kirra_contract_channel::{
     ContractReader, ContractWriter, GovernorContractView, CANONICAL_IMAGE_LEN, MAX_COMMAND_BYTES,
 };
 
+// W2 (#1028) — real-time configuration for the enforced SHM loop (SCHED_FIFO /
+// affinity / mlockall) + the SHM pre-fault. Lives here because this is the one
+// crate on the L3 path that is NOT `#![forbid(unsafe_code)]` (ADR-0006 Clause 3),
+// so the RT syscalls sit beside the mmap they configure.
+pub mod realtime;
+
 /// The mapped region viewed as atomics. `#[repr(C)]`, field order + widths
 /// **identical to [`GovernorContractView`]**, so the mapped bytes are the frozen
 /// contract image and a peer that maps the same region interprets it identically.
@@ -264,6 +270,22 @@ impl PosixShmRegion {
     fn view(&self) -> &AtomicView {
         unsafe { &*self.ptr }
     }
+
+    /// W2 (#1028): pre-fault the mapped region so the enforced loop's first access
+    /// cannot take a major page fault (paired with `mlockall(MCL_FUTURE)` the pages
+    /// stay resident). Call once, after mapping, before entering the hot loop. A
+    /// no-op on non-Linux hosts.
+    pub fn prefault(&self) {
+        #[cfg(target_os = "linux")]
+        // SAFETY: `self.ptr` maps exactly `CANONICAL_IMAGE_LEN` bytes and this handle
+        // (hence the mapping) is live for the call.
+        unsafe {
+            crate::realtime::prefault_region(
+                self.ptr as *mut core::ffi::c_void,
+                CANONICAL_IMAGE_LEN,
+            );
+        }
+    }
 }
 
 impl ContractReader for PosixShmRegion {
@@ -320,6 +342,22 @@ impl PosixShmReader {
     fn view(&self) -> &AtomicView {
         unsafe { &*self.ptr }
     }
+
+    /// W2 (#1028): pre-fault the mapped region (the governor's read-only side) so
+    /// the enforced loop's first read cannot take a major page fault. See
+    /// [`PosixShmRegion::prefault`]. No-op on non-Linux.
+    pub fn prefault(&self) {
+        #[cfg(target_os = "linux")]
+        // SAFETY: `self.ptr` maps exactly `CANONICAL_IMAGE_LEN` bytes and this handle
+        // is live for the call. `MADV_WILLNEED` + a READ touch is valid on a
+        // `PROT_READ` mapping.
+        unsafe {
+            crate::realtime::prefault_region(
+                self.ptr as *mut core::ffi::c_void,
+                CANONICAL_IMAGE_LEN,
+            );
+        }
+    }
 }
 
 impl ContractReader for PosixShmReader {
@@ -363,6 +401,27 @@ mod tests {
             steering_angle_deg: -4.0,
             current_steering_angle_deg: -3.5,
         }
+    }
+
+    /// W2 (#1028): pre-faulting the mapped region (both the guest RW handle and the
+    /// governor read-only handle) touches every page WITHOUT a fault/panic, and the
+    /// region is still fully usable afterwards (a command round-trips) — so
+    /// pre-faulting before the enforced loop is behaviour-preserving.
+    #[test]
+    fn prefault_touches_the_region_and_it_still_round_trips() {
+        let name = unique_name("prefault");
+        let region = PosixShmRegion::create(&name).expect("create");
+        let governor = PosixShmReader::open(&name).expect("ro open");
+        region.prefault();
+        governor.prefault();
+
+        // Still works: publish through the RW handle, read a coherent snapshot RO.
+        let payload = demo(7);
+        let gen = region.load_generation();
+        publish(&region, gen, &payload.to_view(gen, 7, 0, u64::MAX / 2));
+        let snap = read_coherent_snapshot(&governor, MAX_SNAPSHOT_RETRIES)
+            .expect("coherent snapshot after prefault");
+        assert_eq!(snap.sequence, 7);
     }
 
     #[test]

--- a/crates/kirra-hv-carrier/src/realtime.rs
+++ b/crates/kirra-hv-carrier/src/realtime.rs
@@ -1,0 +1,321 @@
+//! W2 (#1028) — real-time configuration for the ENFORCED SHM loop.
+//!
+//! The in-line governor/actuator cycle (`kirra-inline-governor`) is the
+//! hard-real-time path: a planner publishes into the shared region, the governor
+//! bounds in-line, the actuator releases on proof. Off the QNX target, on stock
+//! Linux, that cycle is by default `SCHED_OTHER` — **preemptible, core-migratable,
+//! and subject to a major page fault on the first touch of a demand-paged mapping
+//! inside the loop**. Every host timing number then carries an unbounded
+//! scheduling/paging tail, and there is no real-time-configured path at all.
+//!
+//! This module wires the three primitives that remove that tail, as **opt-in**,
+//! **degrade-with-warning** calls the enforced-loop entry point makes ONCE, before
+//! entering the cycle:
+//!
+//! 1. [`configure_realtime`] — `mlockall(MCL_CURRENT|MCL_FUTURE)` (no future page
+//!    fault), `sched_setscheduler(SCHED_FIFO)` (not preempted by `SCHED_OTHER`),
+//!    and `sched_setaffinity` (no core migration). Each step is attempted
+//!    independently; a step the process is not privileged for (the common CI /
+//!    unprivileged-container case: `EPERM`) is reported [`RtStep::Degraded`] with a
+//!    warning, never a panic and never a hard failure — a governor that cannot get
+//!    RT scheduling must still run (fail-safe), it just runs without the guarantee.
+//! 2. [`PosixShmRegion::prefault`](crate::PosixShmRegion::prefault) /
+//!    [`PosixShmReader::prefault`](crate::PosixShmReader::prefault) — `madvise
+//!    (MADV_WILLNEED)` + a touch of every page, so the FIRST access inside the loop
+//!    cannot take a major fault (paired with `mlockall(MCL_FUTURE)` the pages then
+//!    stay resident).
+//!
+//! Scope: this is the **enforced-loop** real-time path. The verifier's
+//! `execution_manager::TASK_MANIFEST` scheduling intent is a SEPARATE, control-plane
+//! concern (the supervised background monitors are not hard-real-time and must NOT
+//! be `SCHED_FIFO` — that would starve the async runtime); wiring that manifest is
+//! tracked independently. On the QNX target the same three primitives are the
+//! partition's scheduling/locking config (ADR-0006 Clause 3).
+
+/// What one real-time step did. `Applied` = the syscall succeeded; `Skipped` = the
+/// caller did not request it; `Degraded` = it was requested but refused (e.g.
+/// `EPERM` unprivileged) — the loop runs WITHOUT that guarantee, fail-safe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RtStep {
+    /// The syscall succeeded.
+    Applied,
+    /// The caller did not request this step (`RtConfig` had it off).
+    Skipped,
+    /// Requested but refused; the string is the OS reason (never a panic).
+    Degraded(String),
+}
+
+impl RtStep {
+    /// True unless this step was requested-and-refused — i.e. every guarantee the
+    /// caller asked for actually holds.
+    #[must_use]
+    pub fn is_ok(&self) -> bool {
+        !matches!(self, RtStep::Degraded(_))
+    }
+}
+
+/// The outcome of [`configure_realtime`], one [`RtStep`] per primitive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RtStatus {
+    /// `mlockall(MCL_CURRENT | MCL_FUTURE)`.
+    pub memory_lock: RtStep,
+    /// `sched_setscheduler(0, SCHED_FIFO, …)`.
+    pub scheduler: RtStep,
+    /// `sched_setaffinity(0, …)`.
+    pub affinity: RtStep,
+}
+
+impl RtStatus {
+    /// True iff EVERY requested step was applied (no requested step degraded).
+    #[must_use]
+    pub fn fully_applied(&self) -> bool {
+        self.memory_lock.is_ok() && self.scheduler.is_ok() && self.affinity.is_ok()
+    }
+}
+
+/// What real-time configuration to request for the calling thread. Defaults to
+/// all-off (a no-op — byte-identical to not calling this at all), so a caller
+/// opts in field by field.
+#[derive(Debug, Clone, Default)]
+pub struct RtConfig {
+    /// `mlockall(MCL_CURRENT | MCL_FUTURE)` — lock all current + future pages
+    /// resident so the enforced loop never takes a page fault.
+    pub lock_memory: bool,
+    /// `Some(prio)` → `SCHED_FIFO` at that priority (1..=99 on Linux); `None` → skip.
+    pub fifo_priority: Option<i32>,
+    /// `Some(cpu)` → pin the calling thread to that CPU; `None` → skip.
+    pub cpu_affinity: Option<usize>,
+}
+
+impl RtConfig {
+    /// The recommended enforced-loop configuration: lock memory, `SCHED_FIFO` at a
+    /// high (but sub-ceiling, leaving headroom for a watchdog) priority, pinned to
+    /// `cpu`. The exact priority/CPU is a deployment/integration choice; this is a
+    /// sensible default for the governor thread.
+    #[must_use]
+    pub fn enforced_loop(cpu: usize) -> Self {
+        Self {
+            lock_memory: true,
+            fifo_priority: Some(80),
+            cpu_affinity: Some(cpu),
+        }
+    }
+}
+
+/// Apply `cfg` to the CALLING thread, best-effort and fail-safe. Each requested
+/// step is attempted independently; a refused step is reported `Degraded(reason)`
+/// with a `stderr` warning (degrade-with-warning) and the others still apply. This
+/// NEVER panics and NEVER aborts the loop: a governor that cannot obtain RT
+/// scheduling must still bound commands — it just does so without the timing
+/// guarantee, which the returned [`RtStatus`] makes explicit for the caller to log
+/// / gate on.
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn configure_realtime(cfg: &RtConfig) -> RtStatus {
+    RtStatus {
+        memory_lock: if cfg.lock_memory {
+            apply_mlockall()
+        } else {
+            RtStep::Skipped
+        },
+        scheduler: match cfg.fifo_priority {
+            Some(prio) => apply_sched_fifo(prio),
+            None => RtStep::Skipped,
+        },
+        affinity: match cfg.cpu_affinity {
+            Some(cpu) => apply_affinity(cpu),
+            None => RtStep::Skipped,
+        },
+    }
+}
+
+/// Non-Linux hosts (e.g. a macOS dev box building the workspace): the three
+/// primitives are Linux/QNX-specific, so every requested step degrades cleanly
+/// rather than failing to compile. The real target is Linux/QNX.
+#[cfg(not(target_os = "linux"))]
+#[must_use]
+pub fn configure_realtime(cfg: &RtConfig) -> RtStatus {
+    let unsupported = |requested: bool| {
+        if requested {
+            RtStep::Degraded("real-time syscalls are Linux/QNX-only on this host".to_string())
+        } else {
+            RtStep::Skipped
+        }
+    };
+    RtStatus {
+        memory_lock: unsupported(cfg.lock_memory),
+        scheduler: unsupported(cfg.fifo_priority.is_some()),
+        affinity: unsupported(cfg.cpu_affinity.is_some()),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn degrade(step: &str) -> RtStep {
+    let e = std::io::Error::last_os_error();
+    eprintln!(
+        "kirra-hv-carrier: real-time step '{step}' DEGRADED: {e} — the enforced loop \
+         runs WITHOUT this guarantee (fail-safe). Grant CAP_SYS_NICE / CAP_IPC_LOCK \
+         or run on the RT-configured target to enable it."
+    );
+    RtStep::Degraded(e.to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn apply_mlockall() -> RtStep {
+    // SAFETY: FFI with constant flags; no memory is passed in.
+    let rc = unsafe { libc::mlockall(libc::MCL_CURRENT | libc::MCL_FUTURE) };
+    if rc == 0 {
+        RtStep::Applied
+    } else {
+        degrade("mlockall")
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn apply_sched_fifo(priority: i32) -> RtStep {
+    // Clamp to the kernel's valid SCHED_FIFO band [1, 99] so a caller typo can
+    // never pass an out-of-range priority to the syscall.
+    let sched_priority = priority.clamp(1, 99);
+    let param = libc::sched_param { sched_priority };
+    // SAFETY: FFI. `&param` is a valid, initialized `sched_param` for the call;
+    // pid 0 targets the calling thread.
+    let rc = unsafe { libc::sched_setscheduler(0, libc::SCHED_FIFO, &param) };
+    if rc == 0 {
+        RtStep::Applied
+    } else {
+        degrade("sched_setscheduler(SCHED_FIFO)")
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn apply_affinity(cpu: usize) -> RtStep {
+    // SAFETY: `cpu_set_t` is zero-initializable; CPU_ZERO/CPU_SET operate on it in
+    // place; sched_setaffinity reads exactly `size_of::<cpu_set_t>()` bytes.
+    unsafe {
+        let mut set: libc::cpu_set_t = core::mem::zeroed();
+        libc::CPU_ZERO(&mut set);
+        libc::CPU_SET(cpu, &mut set);
+        let rc = libc::sched_setaffinity(0, core::mem::size_of::<libc::cpu_set_t>(), &set);
+        if rc == 0 {
+            RtStep::Applied
+        } else {
+            degrade("sched_setaffinity")
+        }
+    }
+}
+
+/// Pre-fault `len` bytes at `ptr`: advise the kernel the region will be needed
+/// (`MADV_WILLNEED`) and touch one byte of every page so the pages are resident
+/// BEFORE the enforced loop's first access — paired with `mlockall(MCL_FUTURE)`
+/// they then stay resident, so the loop can never take a major page fault.
+///
+/// # Safety
+/// `ptr` must point to a valid mapping of at least `len` bytes that stays mapped
+/// for the duration of the call (the caller — a live `PosixShmRegion` — guarantees
+/// this; the mapping is `CANONICAL_IMAGE_LEN` bytes and outlives the handle).
+#[cfg(target_os = "linux")]
+pub unsafe fn prefault_region(ptr: *mut core::ffi::c_void, len: usize) {
+    if ptr.is_null() || len == 0 {
+        return;
+    }
+    // Best-effort hint; ignore the result (touching below is what actually faults).
+    let _ = libc::madvise(ptr, len, libc::MADV_WILLNEED);
+    // Touch one byte per page. A volatile READ populates the page table entry
+    // (the region is already zeroed by ftruncate, so no write is needed to make it
+    // resident); `read_volatile` prevents the compiler from eliding the touch.
+    let page = page_size();
+    let base = ptr as *const u8;
+    let mut off = 0usize;
+    while off < len {
+        let _ = core::ptr::read_volatile(base.add(off));
+        off += page;
+    }
+    // The final byte, in case `len` is not a page multiple.
+    let _ = core::ptr::read_volatile(base.add(len - 1));
+}
+
+#[cfg(target_os = "linux")]
+fn page_size() -> usize {
+    // SAFETY: FFI with a constant selector.
+    let p = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if p > 0 {
+        p as usize
+    } else {
+        4096
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    /// An all-off config is a pure no-op: every step `Skipped`, `fully_applied`.
+    #[test]
+    fn default_config_is_a_noop() {
+        let status = configure_realtime(&RtConfig::default());
+        assert_eq!(status.memory_lock, RtStep::Skipped);
+        assert_eq!(status.scheduler, RtStep::Skipped);
+        assert_eq!(status.affinity, RtStep::Skipped);
+        assert!(
+            status.fully_applied(),
+            "a no-op config is trivially fully applied"
+        );
+    }
+
+    /// The core fail-safe contract: requesting the full enforced-loop config NEVER
+    /// panics, and each step is either applied or cleanly degraded — even
+    /// unprivileged (CI is typically not `CAP_SYS_NICE`, so `SCHED_FIFO` degrades).
+    /// This is the degrade-with-warning path the enforced-loop entry relies on.
+    #[test]
+    fn enforced_loop_config_is_fail_safe_unprivileged() {
+        let status = configure_realtime(&RtConfig::enforced_loop(0));
+        // Every field is a well-formed RtStep (Applied or Degraded — never a panic,
+        // never Skipped since all three were requested).
+        for step in [&status.memory_lock, &status.scheduler, &status.affinity] {
+            assert!(
+                matches!(step, RtStep::Applied | RtStep::Degraded(_)),
+                "a requested step must be Applied or Degraded, got {step:?}"
+            );
+        }
+        // A degraded SCHED_FIFO (the common unprivileged case) carries a reason.
+        if let RtStep::Degraded(reason) = &status.scheduler {
+            assert!(!reason.is_empty(), "a degrade must carry the OS reason");
+        }
+    }
+
+    /// A refused priority is reported, not applied — but the OTHER steps are
+    /// independent (an affinity/mlock success is not blocked by a FIFO refusal).
+    #[test]
+    fn steps_are_independent() {
+        // Only affinity: FIFO is not requested, so it must be Skipped regardless of
+        // privilege, proving one refusal cannot forge another step's outcome.
+        let status = configure_realtime(&RtConfig {
+            lock_memory: false,
+            fifo_priority: None,
+            cpu_affinity: Some(0),
+        });
+        assert_eq!(status.memory_lock, RtStep::Skipped);
+        assert_eq!(status.scheduler, RtStep::Skipped);
+        assert!(matches!(
+            status.affinity,
+            RtStep::Applied | RtStep::Degraded(_)
+        ));
+    }
+
+    /// `prefault_region` touches every page of a live heap mapping without a fault
+    /// or panic (a stand-in for the SHM region; the SHM path is covered by the
+    /// `PosixShmRegion::prefault` test).
+    #[test]
+    fn prefault_touches_a_region_without_panic() {
+        let mut buf = vec![0u8; 3 * page_size() + 17];
+        // SAFETY: buf is a valid mapping of buf.len() bytes for the call.
+        unsafe {
+            prefault_region(buf.as_mut_ptr() as *mut core::ffi::c_void, buf.len());
+        }
+        // A null / zero-length call is a clean no-op.
+        unsafe {
+            prefault_region(core::ptr::null_mut(), 0);
+            prefault_region(buf.as_mut_ptr() as *mut core::ffi::c_void, 0);
+        }
+    }
+}

--- a/crates/kirra-inline-governor/src/bin/inline_demo.rs
+++ b/crates/kirra-inline-governor/src/bin/inline_demo.rs
@@ -139,6 +139,36 @@ fn governor_main() -> ExitCode {
         }
     }
 
+    // W2 (#1028) — enforced-loop real-time configuration. Pre-fault BOTH mappings
+    // so the timed loop below cannot take a MAJOR PAGE FAULT on first touch of the
+    // demand-paged SHM region (always safe, needs no privilege — this is the
+    // paging-tail half of the honest "host is INDICATIVE only" caveat). SCHED_FIFO /
+    // CPU affinity / mlockall are opt-in via `KIRRA_INLINE_RT=1` because they need
+    // CAP_SYS_NICE / CAP_IPC_LOCK (degrade-with-warning otherwise), so the default
+    // unprivileged run stays quiet; on the RT-configured target they apply cleanly.
+    region.prefault();
+    reader.prefault();
+    if std::env::var("KIRRA_INLINE_RT")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        let cpu: usize = std::env::var("KIRRA_INLINE_RT_CPU")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        let status = kirra_hv_carrier::realtime::configure_realtime(
+            &kirra_hv_carrier::realtime::RtConfig::enforced_loop(cpu),
+        );
+        println!(
+            "enforced-loop RT config: mlockall={:?}  sched_fifo={:?}  affinity={:?}  \
+             (fully_applied={})",
+            status.memory_lock,
+            status.scheduler,
+            status.affinity,
+            status.fully_applied()
+        );
+    }
+
     // INDICATIVE latency of the FULL in-line step (read → validate → bound →
     // sign → verify → release-decision), in the PRODUCTION shape: the same
     // long-lived station pair across every cycle, each iteration a fresh

--- a/src/execution_manager.rs
+++ b/src/execution_manager.rs
@@ -24,6 +24,17 @@
 //! platform permits, degrade-with-warning where not), and FEEDING `DeadlineStats`
 //! into `/metrics` + supervisor escalation are the recorded follow-up — the running
 //! startup sequence is untouched here, so this slice changes no runtime behaviour.
+//!
+//! **W2 (#1028) — note the two distinct paths.** These `SchedulingClass` intents
+//! are for the verifier's CONTROL-PLANE supervised monitors (the async
+//! campaign/cert-expiry/audit-shipper loops) — they run on the tokio runtime and
+//! must NOT be `SCHED_FIFO` (a FIFO async loop starves the executor). The HARD
+//! real-time path is the separate in-line ENFORCED loop (`kirra-inline-governor`
+//! over the SHM carrier), and its real `SCHED_FIFO` + affinity + `mlockall` + SHM
+//! pre-fault primitives now exist in `kirra_hv_carrier::realtime` (opt-in,
+//! degrade-with-warning) and are wired into the `inline_demo` enforced-loop entry.
+//! Wiring THESE control-plane intents to syscalls (only meaningful once those loops
+//! move to dedicated OS threads / an RT partition) stays the recorded follow-up.
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};


### PR DESCRIPTION
Closes #1028 · part of #1023 (epic group 4, "WCET honesty"). The remaining WCET-honesty finding — the real one about the enforced loop having **no real-time-configured path at all**. Companion to #1055 (the evidence-honesty trio W1/W3/W4).

## Problem
The in-line SHM enforced loop (`kirra-inline-governor`) was `SCHED_OTHER` off the QNX target: **preemptible, core-migratable, and subject to a major page fault on first touch of the demand-paged SHM mapping inside the loop** — so every host number carried an unbounded scheduling/paging tail. A grep for `SCHED_FIFO|mlockall|sched_setaffinity` across the hot-path crates returned only doc comments.

## Fix — real primitives, opt-in, fail-safe
New **`crates/kirra-hv-carrier/src/realtime.rs`** (this is the one crate on the L3 path that is *not* `#[forbid(unsafe_code)]` — the ADR-0006 Clause 3 boundary, where the RT syscalls belong, beside the mmap):
- **`configure_realtime(RtConfig) -> RtStatus`** — `mlockall(MCL_CURRENT|MCL_FUTURE)` + `sched_setscheduler(SCHED_FIFO)` + `sched_setaffinity`, each attempted independently and **fail-safe**: a step the process isn't privileged for (`EPERM` in an unprivileged CI container) is `RtStep::Degraded` with a stderr warning (**degrade-with-warning**), never a panic, never a hard failure — a governor that can't get RT scheduling must still bound commands. `RtConfig::default()` is all-off (a pure no-op); `RtConfig::enforced_loop(cpu)` is the recommended governor config. Non-Linux hosts degrade cleanly (macOS dev builds still compile).
- **`PosixShmRegion::prefault()` / `PosixShmReader::prefault()`** — `madvise(MADV_WILLNEED)` + a touch of every page, so the loop's first access can't take a major fault; paired with `mlockall(MCL_FUTURE)` the pages stay resident.

`inline_demo` wires it into the enforced-loop entry: **always** pre-fault both mappings (no privilege needed — the paging-tail half of the honest "host is INDICATIVE only" caveat); SCHED_FIFO/affinity/mlockall are opt-in via `KIRRA_INLINE_RT=1` (`KIRRA_INLINE_RT_CPU`).

## Scope note (the two distinct paths)
The verifier's `execution_manager::TASK_MANIFEST` `SchedulingClass` intents are a **separate, control-plane concern** — those supervised monitors run on the tokio runtime and must **not** be `SCHED_FIFO` (it would starve the executor). The **hard** real-time path is this enforced SHM loop; wiring the control-plane intents to syscalls (only meaningful once those loops move to dedicated OS threads / an RT partition) stays the recorded follow-up. The `execution_manager` doc now states this explicitly. On the QNX target the same three primitives are the partition's scheduling/locking config.

## Tests
- `realtime` unit tests: all-off is a no-op; the **fail-safe unprivileged** path asserts each requested step is Applied-or-Degraded (never a panic, the exact contract CI's non-root runner exercises); step independence; `prefault_region` touches a region without a fault.
- A SHM-path test: pre-faulting **both** handles is behaviour-preserving (a command still round-trips).
- `inline_demo` runs end-to-end with `KIRRA_INLINE_RT=1` (verified locally). `fmt` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_