### PR TITLE
Medium hardening: C3 (#1034) poison-tolerant streak locks + M2 (#1041) ingress LRU eviction

### DIFF
--- a/crates/kirra-fleet-transport/src/ingress_limit.rs
+++ b/crates/kirra-fleet-transport/src/ingress_limit.rs
@@ -9,13 +9,14 @@
 //!
 //! Two tiers, both of which must permit an ingest:
 //! - a **per-source** bucket bounds any single source's rate (the source is the
-//!   Zenoh key-expression's node id — untrusted, but fine for *bucketing*: the
-//!   worst an attacker does by spoofing many ids is fall through to the global
-//!   backstop);
+//!   Zenoh key-expression's node id — untrusted, but fine for *bucketing*). The
+//!   per-source map is memory-bounded by `max_tracked_sources`; at the cap a new
+//!   source EVICTS the longest-idle bucket (LRU-by-idle, M2 · #1041), so an
+//!   id-churn flood cannot strip per-source isolation from genuine active peers —
+//!   its single-use spoofed ids are the eviction victims, not the active sources;
 //! - a **global** bucket bounds the TOTAL ingest rate — the backstop against a
-//!   many-source spoofing flood, and the reason the per-source map is memory-bounded
-//!   (a new source seen while the map is full is limited by the global bucket alone,
-//!   never allocated, so the map cannot grow without bound).
+//!   many-source spoofing flood, checked first and short-circuiting (an
+//!   over-global flood is denied before any per-source alloc/eviction).
 //!
 //! Pure and clock-injected (`now_ms` is always supplied — no wall-clock read), so
 //! the limiter is deterministically testable and reused across the sync/async paths.
@@ -79,16 +80,28 @@ impl TokenBucket {
     fn consume_one(&mut self) {
         self.tokens -= 1.0;
     }
+
+    /// Timestamp of this bucket's last refill/activity (ms). Advances every time
+    /// the bucket is queried via a later `now_ms`; a bucket that is never touched
+    /// again keeps its old value — so the SMALLEST `last_activity_ms` across the
+    /// map is the longest-idle (LRU) entry. Used by the per-source-map eviction
+    /// (M2 · #1041).
+    #[must_use]
+    pub fn last_activity_ms(&self) -> u64 {
+        self.last_ms
+    }
 }
 
 /// Two-tier ingest rate limiter: a global backstop bucket plus a bounded map of
 /// per-source buckets. For a TRACKED source, an ingest is allowed iff BOTH the
 /// global and that source's bucket have a token; only then is one consumed from
 /// each (so a denial charges neither). Once `max_tracked_sources` is reached, a
-/// previously-unseen source is NOT allocated a bucket — it is admitted purely on
-/// the global backstop (the memory bound against a spoofing flood). The global
-/// bucket is checked FIRST and short-circuits: when it is empty nothing can be
-/// admitted, so no per-source bucket is even allocated.
+/// previously-unseen source EVICTS the longest-idle tracked bucket (LRU-by-idle,
+/// M2 · #1041) and takes its slot — so the map stays memory-bounded AND every
+/// genuine source keeps its own bucket, while a churn-flood's single-use spoofed
+/// ids are the eviction victims. The global bucket is checked FIRST and short-
+/// circuits: when it is empty nothing can be admitted, so no per-source bucket is
+/// even allocated (nor evicted).
 #[derive(Debug)]
 pub struct IngressRateLimiter {
     global: TokenBucket,
@@ -101,7 +114,7 @@ pub struct IngressRateLimiter {
 impl IngressRateLimiter {
     /// Build a limiter. `global_*` bound the total ingest rate; `per_source_*` bound
     /// any single source; `max_tracked_sources` caps the per-source map (a new
-    /// source seen while the map is full is limited by the global bucket alone).
+    /// source seen while the map is full evicts the longest-idle bucket, M2 · #1041).
     #[must_use]
     pub fn new(
         global_capacity: u32,
@@ -132,13 +145,35 @@ impl IngressRateLimiter {
             return false;
         }
 
-        // Per-source bucket: reuse an existing one; else allocate ONLY if under the
-        // tracking cap. When the map is full and the source is unknown, fall back to
-        // the global bucket alone (memory-bounded — a spoofing flood cannot grow the
-        // map, and the global backstop still bounds total rate).
+        // Per-source bucket: reuse an existing one; else allocate. When the map is
+        // at its tracking cap and the source is unknown, EVICT the longest-idle
+        // (smallest `last_activity_ms`) bucket and admit this source into a fresh
+        // one, rather than falling through to global-only.
+        //
+        // M2 (#1041): the old "full map → global-only" fallthrough let an id-churn
+        // flood (a fresh spoofed source id per message — the Zenoh key-expr id is
+        // untrusted) SATURATE the map with buckets it never revisits, after which
+        // every genuine new source lost per-source isolation until restart. LRU-by-
+        // idle inverts that: an ACTIVE genuine source (recently touched → large
+        // `last_activity_ms`) is preserved, while the churned-once spoofed ids
+        // (never touched again → smallest `last_activity_ms`) are the eviction
+        // victims. The map stays memory-bounded (evict-one-insert-one holds the cap)
+        // and the global backstop still bounds total rate. Eviction only runs for a
+        // globally-admitted ingest (the global check above short-circuits a flood
+        // first), so the O(n) scan is bounded by the global rate, not the flood.
         let source_ok = if let Some(b) = self.per_source.get_mut(source) {
             b.available_at(now_ms) >= 1.0
-        } else if self.per_source.len() < self.max_tracked_sources {
+        } else {
+            if self.per_source.len() >= self.max_tracked_sources {
+                if let Some(victim) = self
+                    .per_source
+                    .iter()
+                    .min_by_key(|(_, b)| b.last_activity_ms())
+                    .map(|(k, _)| k.clone())
+                {
+                    self.per_source.remove(&victim);
+                }
+            }
             let mut b = TokenBucket::new(
                 self.per_source_capacity,
                 self.per_source_refill_per_sec,
@@ -147,9 +182,6 @@ impl IngressRateLimiter {
             let ok = b.available_at(now_ms) >= 1.0;
             self.per_source.insert(source.to_string(), b);
             ok
-        } else {
-            // Untracked source under a full map → global-only.
-            true
         };
 
         if source_ok {
@@ -167,6 +199,14 @@ impl IngressRateLimiter {
     #[must_use]
     pub fn tracked_sources(&self) -> usize {
         self.per_source.len()
+    }
+
+    /// Whether `source` currently has its own per-source bucket (observability /
+    /// tests — e.g. proving M2 eviction kept an active source and dropped the
+    /// longest-idle one).
+    #[must_use]
+    pub fn is_tracked(&self, source: &str) -> bool {
+        self.per_source.contains_key(source)
     }
 }
 
@@ -315,5 +355,68 @@ mod tests {
         assert!(!lim.allow("s", 0));
         assert!(!lim.allow("s", 500), "half a second → not yet refilled");
         assert!(lim.allow("s", 1_000), "one second → one token back");
+    }
+
+    #[test]
+    fn full_map_evicts_longest_idle_and_keeps_active_sources() {
+        // M2 (#1041): at the tracking cap, a new source must EVICT the longest-idle
+        // bucket (not fall through to global-only), preserving per-source isolation
+        // for genuine active sources against an id-churn flood.
+        //
+        // Generous global rate so the global backstop never masks the per-source
+        // behaviour under test; per-source cap 1; MAP CAP = 2.
+        let mut lim = IngressRateLimiter::new(1_000_000, 1_000_000.0, 1, 1.0, 2, 0);
+
+        // Fill both slots.
+        assert!(lim.allow("a", 0));
+        assert!(lim.allow("b", 0));
+        assert_eq!(lim.tracked_sources(), 2);
+
+        // Touch "a" later so "b" becomes the longest-idle (last_activity: a=100,
+        // b=0). The admit RESULT is irrelevant (a's cap-1 bucket is empty 0.1 s
+        // after its first use) — the point is that querying it REFRESHES a's idle
+        // timestamp, which is what protects it from eviction.
+        lim.allow("a", 100);
+
+        // A NEW source "c" arrives at the cap → evict the longest-idle ("b"),
+        // admit "c" into a fresh per-source bucket. The map stays at the cap.
+        assert!(lim.allow("c", 200));
+        assert_eq!(lim.tracked_sources(), 2, "cap held — eviction, not growth");
+        assert!(lim.is_tracked("a"), "the recently-active source survives");
+        assert!(
+            lim.is_tracked("c"),
+            "the new source got its OWN per-source bucket"
+        );
+        assert!(!lim.is_tracked("b"), "the longest-idle source was evicted");
+
+        // Isolation restored for "c": its own capacity-1 bucket rate-limits it,
+        // rather than it riding global-only (which the old fallthrough allowed).
+        assert!(
+            !lim.allow("c", 200),
+            "c's per-source bucket is now empty → denied"
+        );
+    }
+
+    #[test]
+    fn id_churn_flood_cannot_strip_isolation_from_an_active_source() {
+        // The end-to-end M2 property: a genuine active source keeps its per-source
+        // bucket even while an attacker churns a fresh spoofed id every message.
+        let mut lim = IngressRateLimiter::new(1_000_000, 1_000_000.0, 1, 1.0, 4, 0);
+
+        // Genuine source "good" is active every tick.
+        for t in 0..50u64 {
+            // Keep "good" warm (its bucket refills at 1/s; capacity 1).
+            let _ = lim.allow("good", t * 1_000);
+            // Attacker: a brand-new id each tick.
+            assert!(lim.allow(&format!("spoof-{t}"), t * 1_000 + 1));
+        }
+        assert!(
+            lim.is_tracked("good"),
+            "the continuously-active source retained its per-source bucket through the flood"
+        );
+        assert!(
+            lim.tracked_sources() <= 4,
+            "the map stayed memory-bounded at the cap"
+        );
     }
 }

--- a/src/posture_engine_v2.rs
+++ b/src/posture_engine_v2.rs
@@ -312,6 +312,20 @@ pub fn fail_closed_on_downgrade_send_failure(
     crate::posture_engine::force_lockout(posture_cache, now_ms);
 }
 
+/// Poison-tolerant lock for the escalation STREAK mutexes (C3 · #1034).
+///
+/// Every streak-update site used to be gated `if let Ok(mut s) = ….lock() { … }`,
+/// which is silently skipped FOREVER once the mutex is poisoned (any panic while
+/// a streak lock was held). That is two-directional harm: auto-recovery to
+/// Nominal never advances AND the fault escalation-to-LockedOut streak stops
+/// advancing — a sustained fault would fail to reach the sticky lockout it
+/// should. The streak payload is a plain integer pair (`count` / `start_ms`),
+/// NEVER left torn by a panic, so recovering the guard via `into_inner()` is
+/// always safe — the same policy `StoreHandle` already applies.
+fn streak_lock<T>(m: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// Applies an RSS state report to `AppState` violation/recovery fields.
 ///
 /// Violation (safe==false): sets `rss_active_violation` and resets the streak.
@@ -327,7 +341,8 @@ pub fn apply_rss_state(app: &Arc<AppState>, rss: &RssState, now_ms: u64) {
         app.escalation
             .rss_active_violation
             .store(true, Ordering::SeqCst);
-        if let Ok(mut streak) = app.escalation.rss_recovery_streak.lock() {
+        {
+            let mut streak = streak_lock(&app.escalation.rss_recovery_streak);
             streak.count = 0;
             streak.start_ms = 0;
         }
@@ -337,7 +352,8 @@ pub fn apply_rss_state(app: &Arc<AppState>, rss: &RssState, now_ms: u64) {
             "RSS violation active — fleet posture will be escalated to Degraded"
         );
     } else if app.escalation.rss_active_violation.load(Ordering::SeqCst) {
-        if let Ok(mut streak) = app.escalation.rss_recovery_streak.lock() {
+        {
+            let mut streak = streak_lock(&app.escalation.rss_recovery_streak);
             // Window expiry: discard streak and start fresh from this tick.
             if streak.start_ms > 0
                 && now_ms.saturating_sub(streak.start_ms) >= AV_RECOVERY_WINDOW_MS
@@ -392,7 +408,8 @@ pub fn apply_frame_integrity_state(app: &Arc<AppState>, trust: FrameTrust, now_m
         FrameTrust::Trusted => {
             // Recovery: only meaningful while a frame degradation is active.
             if app.escalation.frame_degraded_active.load(Ordering::SeqCst) {
-                if let Ok(mut streak) = app.escalation.frame_recovery_streak.lock() {
+                {
+                    let mut streak = streak_lock(&app.escalation.frame_recovery_streak);
                     if streak.start_ms > 0
                         && now_ms.saturating_sub(streak.start_ms) >= AV_RECOVERY_WINDOW_MS
                     {
@@ -417,7 +434,8 @@ pub fn apply_frame_integrity_state(app: &Arc<AppState>, trust: FrameTrust, now_m
                 }
             }
             // A trusted tick breaks any sustained-untrusted run.
-            if let Ok(mut s) = app.escalation.frame_untrusted_streak.lock() {
+            {
+                let mut s = streak_lock(&app.escalation.frame_untrusted_streak);
                 s.count = 0;
                 s.start_ms = 0;
             }
@@ -430,11 +448,13 @@ pub fn apply_frame_integrity_state(app: &Arc<AppState>, trust: FrameTrust, now_m
             app.escalation
                 .frame_degraded_active
                 .store(true, Ordering::SeqCst);
-            if let Ok(mut s) = app.escalation.frame_recovery_streak.lock() {
+            {
+                let mut s = streak_lock(&app.escalation.frame_recovery_streak);
                 s.count = 0;
                 s.start_ms = 0;
             }
-            if let Ok(mut s) = app.escalation.frame_untrusted_streak.lock() {
+            {
+                let mut s = streak_lock(&app.escalation.frame_untrusted_streak);
                 s.count = 0;
                 s.start_ms = 0;
             }
@@ -444,12 +464,14 @@ pub fn apply_frame_integrity_state(app: &Arc<AppState>, trust: FrameTrust, now_m
             app.escalation
                 .frame_degraded_active
                 .store(true, Ordering::SeqCst);
-            if let Ok(mut s) = app.escalation.frame_recovery_streak.lock() {
+            {
+                let mut s = streak_lock(&app.escalation.frame_recovery_streak);
                 s.count = 0;
                 s.start_ms = 0;
             }
             // Inverted streak toward the sticky LockedOut escalation.
-            if let Ok(mut streak) = app.escalation.frame_untrusted_streak.lock() {
+            {
+                let mut streak = streak_lock(&app.escalation.frame_untrusted_streak);
                 if streak.start_ms > 0
                     && now_ms.saturating_sub(streak.start_ms) >= AV_RECOVERY_WINDOW_MS
                 {
@@ -511,7 +533,8 @@ pub fn apply_governor_divergence_state(
         app.escalation
             .divergence_degraded_active
             .store(true, Ordering::SeqCst);
-        if let Ok(mut s) = app.escalation.divergence_recovery_streak.lock() {
+        {
+            let mut s = streak_lock(&app.escalation.divergence_recovery_streak);
             s.count = 0;
             s.start_ms = 0;
         }
@@ -532,7 +555,8 @@ pub fn apply_governor_divergence_state(
             .divergence_degraded_active
             .load(Ordering::SeqCst)
         {
-            if let Ok(mut streak) = app.escalation.divergence_recovery_streak.lock() {
+            {
+                let mut streak = streak_lock(&app.escalation.divergence_recovery_streak);
                 if streak.start_ms > 0
                     && now_ms.saturating_sub(streak.start_ms) >= AV_RECOVERY_WINDOW_MS
                 {
@@ -811,6 +835,47 @@ mod posture_engine_v2_tests {
         use crate::verifier_store::VerifierStore;
         let store = VerifierStore::new(":memory:").unwrap();
         Arc::new(AppState::new(store, VerifierOperationMode::Active))
+    }
+
+    /// C3 (#1034): a POISONED streak mutex must not permanently freeze the
+    /// escalation. Before the fix, every streak update was gated `if let Ok(mut
+    /// s) = ….lock()`, so a single prior panic while a streak lock was held would
+    /// skip all subsequent updates forever — a sustained fault would then never
+    /// escalate Degraded → the sticky LockedOut. With the poison-tolerant
+    /// `streak_lock`, the sustained-Untrusted run still reaches the lockout.
+    #[test]
+    fn poisoned_streak_still_escalates_to_lockout() {
+        let app = frame_app();
+
+        // Poison the untrusted-escalation streak mutex: a helper thread panics
+        // while holding it.
+        let app2 = app.clone();
+        let handle = std::thread::spawn(move || {
+            let _g = app2.escalation.frame_untrusted_streak.lock().unwrap();
+            panic!("intentional panic to poison the streak mutex");
+        });
+        assert!(
+            handle.join().is_err(),
+            "the helper thread must have panicked, poisoning the lock"
+        );
+        assert!(
+            app.escalation.frame_untrusted_streak.lock().is_err(),
+            "precondition: the streak mutex is now poisoned"
+        );
+
+        // Drive AV_RECOVERY_STREAK_THRESHOLD sustained-Untrusted ticks within the
+        // window. With the OLD `if let Ok` gate every one of these would be a
+        // silent no-op and the lockout would NEVER be set.
+        let start = 1_000u64;
+        for i in 0..AV_RECOVERY_STREAK_THRESHOLD {
+            apply_frame_integrity_state(&app, FrameTrust::Untrusted, start + i as u64 * 100);
+        }
+
+        assert!(
+            app.escalation.frame_lockout_active.load(Ordering::SeqCst),
+            "a sustained Untrusted run must reach the sticky LockedOut EVEN through a poisoned \
+             streak lock (C3 #1034); it froze before the fix"
+        );
     }
 
     // ---- S-DG1 governor-divergence tests (mirror the S-FI1 frame matrix) ----


### PR DESCRIPTION
First PR of the **remaining-mediums** group (epic #1023) — two independent, self-contained, fully-tested fixes.

## C3 (#1034) — poison-tolerant escalation-streak locks
Every streak update in `posture_engine_v2` was gated `if let Ok(mut s) = ….lock() { … }`. `std::sync::Mutex` poisoning is **sticky** — after any panic while a streak lock was held, all 10 of these blocks are skipped **permanently**. Two-directional harm: auto-recovery to Nominal never advances **and** the fault escalation-to-LockedOut streak stops advancing, so a sustained fault fails to reach the sticky lockout it should.

- New poison-tolerant `streak_lock` helper (`m.lock().unwrap_or_else(|p| p.into_inner())` — the same policy `StoreHandle` already applies); all 10 `.lock()` sites use it. The streak payload is a plain integer pair, never left torn by a panic, so recovering the guard is always safe. **Block scoping preserved** so each streak lock still releases before the next is acquired (no deadlock).
- **Regression test** `poisoned_streak_still_escalates_to_lockout`: poison the untrusted-streak mutex, then a sustained-Untrusted run still reaches the sticky frame LockedOut — it froze permanently before the fix.

## M2 (#1041) — ingress rate-limiter had no eviction (isolation defeatable by id-churn)
At `max_tracked_sources` the old code fell through to **global-only** for any new source. An id-churn flood (a fresh spoofed node-id per message — the Zenoh key-expr id is untrusted) **saturated** the map, after which every genuine new source lost per-source isolation until process restart.

- A full map now **evicts the longest-idle bucket** (smallest `last_activity_ms`, LRU-by-idle) and admits the new source into a fresh one. Active genuine sources (recently touched) are preserved; the churned-once spoofed ids are the eviction victims. Map stays memory-bounded (evict-one-insert-one holds the cap); the global backstop still short-circuits an over-global flood **before** any eviction, so the O(n) scan is bounded by the global rate, not the flood.
- Tests: `full_map_evicts_longest_idle_and_keeps_active_sources` + `id_churn_flood_cannot_strip_isolation_from_an_active_source`.

## Verification
`cargo test -p kirra-fleet-transport ingress_limit` → 12 passed; `cargo test -p kirra-verifier --lib posture_engine_v2` → 28 passed (incl. the new poison test); `cargo fmt --check` clean.

Refs #1034, #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_