### PR TITLE
M3 (#1042): closure-inclusive cross-distro wire-compat check + CI self-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,23 @@ jobs:
       - name: Version-ordering gate (A4 — never sort backwards)
         run: python3 ci/check_version_ordering.py
 
+  # M3 (#1042) — cross-distro closure-comparator self-test. The Humble↔Jazzy
+  # wire-safety argument rests on the curated `.msg` closures being byte-identical
+  # across distros. The bench tool (crossdistro_hash_check.sh) needs real dual-distro
+  # msg shares, so it is not itself per-PR gateable — but its NEW closure-inclusive
+  # comparator (closure_diff.py, which walks the full recursive closure incl. base
+  # messages, not just the curated leaf) has its LOGIC gated here: the self-test runs
+  # it over committed fixture trees and proves it detects a nested base-message drift
+  # the old leaf-only step-3 missed. Pure python3, no ROS — never flakes.
+  msgsync-closure-selftest:
+    name: cross-distro closure comparator self-test (M3)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: closure_diff.py catches nested drift the leaf-only check misses
+        run: bash scripts/curated_interface/closure_diff_selftest.sh
+
   # WS-3.1 — the scenario-KPI gate: thresholds unsafe_miss_rate /
   # admissibility / hazard_recall over the generated deterministic corpus
   # (248 doer scenarios + 71 perception frames) against the reviewed policy

--- a/scripts/curated_interface/README.md
+++ b/scripts/curated_interface/README.md
@@ -31,6 +31,23 @@ re-extract + re-verify (below) and a bumped reference in the SRAC
   into the matching curated package and regenerates each `CMakeLists.txt`.
 - `verify_hashes.sh [REF_SHARE]` — the gate: byte-diffs every curated `.msg`
   against the reference; non-zero exit on any mismatch.
+- `crossdistro_hash_check.sh [REF_HUMBLE] [REF_JAZZY]` — the ADR-0036
+  Humble↔Jazzy wire-safety bench check: curated == each reference, then the
+  cross-distro closure diff (step 3). Needs BOTH distros' msg shares.
+- `closure_diff.py --ref-a DIR --ref-b DIR --seed pkg/Msg …` — **M3 (#1042)**:
+  walks the FULL recursive closure of each seed across two reference `share/`
+  trees and byte-compares every message in it, **base packages included**
+  (`builtin_interfaces`, `std_msgs`, `geometry_msgs`, …). This is what step 3 of
+  `crossdistro_hash_check.sh` now runs — a differing *nested* base message
+  (leaf identical, RIHS hash drifted) is no longer invisible. `--leaf-only`
+  reproduces the old leaf-only comparison for contrast.
+- `closure_diff_selftest.sh` — the **CI-gated** proof (pure python3, no ROS):
+  runs `closure_diff.py` over the synthetic `testdata/{humble,jazzy}/` fixtures
+  and asserts the closure check catches a nested drift the leaf-only check
+  misses (and does not false-alarm on an identical tree). Wired into CI as
+  `cross-distro closure comparator self-test (M3)`. The FULL dual-distro
+  comparison against real `/opt/ros/{humble,jazzy}/share` stays a bench tool
+  until pinned dual-distro msg shares are containerized (the #1042 remainder).
 
 ## Build sequence (governor host needs NO apt Autoware packages)
 

--- a/scripts/curated_interface/closure_diff.py
+++ b/scripts/curated_interface/closure_diff.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""closure_diff.py — recursive-closure cross-distro .msg wire-compat comparator.
+
+The leaf-only step-3 of crossdistro_hash_check.sh diffs only the curated
+top-level autoware_*_msgs .msg. A DIFFERING NESTED base message (e.g.
+builtin_interfaces/Time or geometry_msgs/Point) leaves every curated leaf
+byte-identical while the RIHS type hash diverges — undetected. This walks the
+FULL transitive closure from the seeds across BOTH reference share trees and
+byte-compares every message in it, base packages included.
+
+Exit: 0 = whole closure byte-identical across both refs; 1 = drift/missing.
+Pure text over two `share/` dirs — no ROS, no rosidl.
+"""
+import argparse
+import os
+import sys
+
+PRIMITIVES = {
+    "bool", "byte", "char", "float32", "float64", "int8", "int16", "int32",
+    "int64", "uint8", "uint16", "uint32", "uint64", "string", "wstring",
+}
+
+
+def resolve(base, cur_pkg):
+    """(pkg, Msg) for a field base type, or None for a primitive/unresolved."""
+    if base in PRIMITIVES:
+        return None
+    if "/" in base:
+        p, n = base.split("/", 1)
+        return (p, n)
+    if base == "Header":
+        return ("std_msgs", "Header")
+    if base in ("Time", "Duration"):
+        return ("builtin_interfaces", base)
+    if base[:1].isupper():
+        return (cur_pkg, base)  # same-package nested type
+    return None
+
+
+def deps_of(msg_path, cur_pkg):
+    out = []
+    with open(msg_path, "r") as fh:
+        for raw in fh:
+            line = raw.split("#", 1)[0].strip()
+            if not line:
+                continue
+            toks = line.split()
+            type_tok = toks[0]
+            # constant: "Type NAME=value" (second token contains '=')
+            if len(toks) >= 2 and "=" in toks[1]:
+                continue
+            base = type_tok.split("[", 1)[0].split("<", 1)[0]
+            r = resolve(base, cur_pkg)
+            if r:
+                out.append(r)
+    return out
+
+
+def closure(ref_a, seeds):
+    """BFS the closure using ref_a as the structure oracle; returns sorted set."""
+    seen, queue, missing = set(), list(seeds), []
+    while queue:
+        pkg, msg = queue.pop(0)
+        if (pkg, msg) in seen:
+            continue
+        seen.add((pkg, msg))
+        p = os.path.join(ref_a, pkg, "msg", msg + ".msg")
+        if not os.path.isfile(p):
+            missing.append((pkg, msg))
+            continue
+        queue.extend(deps_of(p, pkg))
+    return sorted(seen), missing
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ref-a", required=True)
+    ap.add_argument("--ref-b", required=True)
+    ap.add_argument("--seed", action="append", required=True,
+                    help="pkg/Msg, repeatable")
+    ap.add_argument("--leaf-only", action="store_true",
+                    help="compare only the seed leaves (models the OLD gate)")
+    args = ap.parse_args()
+
+    seeds = []
+    for s in args.seed:
+        pkg, msg = s.split("/", 1)
+        seeds.append((pkg, msg))
+
+    if args.leaf_only:
+        members, missing = list(seeds), []
+    else:
+        members, missing = closure(args.ref_a, seeds)
+
+    drift = 0
+    for pkg, msg in members:
+        rel = os.path.join(pkg, "msg", msg + ".msg")
+        a = os.path.join(args.ref_a, rel)
+        b = os.path.join(args.ref_b, rel)
+        if not os.path.isfile(a) or not os.path.isfile(b):
+            print(f"MISSING {rel} (absent on a reference)")
+            drift = 1
+            continue
+        with open(a, "rb") as fa, open(b, "rb") as fb:
+            if fa.read() == fb.read():
+                print(f"MATCH   {rel}")
+            else:
+                print(f"DRIFT   {rel} (ref-a != ref-b)")
+                drift = 1
+    for pkg, msg in missing:
+        print(f"UNRESOLVED {pkg}/{msg} (not found in ref-a closure walk)")
+        drift = 1
+    print(f"-- {len(members)} messages in "
+          f"{'leaf set' if args.leaf_only else 'closure'} --")
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/curated_interface/closure_diff_selftest.sh
+++ b/scripts/curated_interface/closure_diff_selftest.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# closure_diff_selftest.sh — CI-gated proof that closure_diff.py catches a
+# NESTED base-message drift the leaf-only step-3 misses (M3, #1042). Pure
+# python3 over committed fixture trees — no ROS, so it gates on every PR.
+#
+# The fixtures under testdata/{humble,jazzy}/ have byte-identical curated leaves
+# but a geometry_msgs/Point that differs (jazzy drops `z`). Assertions:
+#   1. leaf-only  humble vs jazzy  -> PASS (models the OLD gate's blind spot)
+#   2. closure    humble vs jazzy  -> FAIL (the fix: nested drift detected)
+#   3. closure    humble vs humble -> PASS (positive control: no false alarm)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TD="$HERE/testdata"
+DIFF="$HERE/closure_diff.py"
+SEED="autoware_demo_msgs/Leaf"
+rc=0
+
+echo "== 1. leaf-only humble vs jazzy (must PASS — the OLD gate is blind here) =="
+if python3 "$DIFF" --ref-a "$TD/humble" --ref-b "$TD/jazzy" --seed "$SEED" --leaf-only; then
+  echo "OK: leaf-only passed (nested drift invisible, as expected)"
+else
+  echo "SELFTEST FAIL: leaf-only should have passed" >&2; rc=1
+fi
+
+echo; echo "== 2. closure humble vs jazzy (must FAIL — the fix detects nested drift) =="
+if python3 "$DIFF" --ref-a "$TD/humble" --ref-b "$TD/jazzy" --seed "$SEED"; then
+  echo "SELFTEST FAIL: closure should have detected the geometry_msgs/Point drift" >&2; rc=1
+else
+  echo "OK: closure correctly flagged the nested drift"
+fi
+
+echo; echo "== 3. closure humble vs humble (must PASS — no false positive) =="
+if python3 "$DIFF" --ref-a "$TD/humble" --ref-b "$TD/humble" --seed "$SEED"; then
+  echo "OK: identical closure passes"
+else
+  echo "SELFTEST FAIL: identical closure should pass" >&2; rc=1
+fi
+
+echo
+if [ "$rc" -eq 0 ]; then
+  echo "SELFTEST PASS — closure_diff.py detects nested drift the leaf check misses."
+else
+  echo "SELFTEST FAILED." >&2
+fi
+exit "$rc"

--- a/scripts/curated_interface/crossdistro_hash_check.sh
+++ b/scripts/curated_interface/crossdistro_hash_check.sh
@@ -12,13 +12,26 @@
 #
 #   1. curated == Humble reference       (reuses verify_hashes.sh)
 #   2. curated == Jazzy  reference       (reuses verify_hashes.sh)
-#   3. Humble reference == Jazzy reference, per curated .msg  (the cross-distro diff)
+#   3. Humble reference == Jazzy reference, over the FULL RECURSIVE CLOSURE of
+#      each curated seed — base packages included (closure_diff.py)
 #
-# A DRIFT in step 3 names the exact interface that must go through
+# M3 (#1042): step 3 previously diffed only the curated top-level autoware_*_msgs
+# `.msg`. A differing NESTED base message (e.g. builtin_interfaces/Time,
+# std_msgs/Header, a geometry_msgs sub-type) leaves every curated leaf
+# byte-identical while the RIHS type hash diverges — undetected. Step 3 now walks
+# the transitive closure from the seeds and byte-compares EVERY message in it
+# across the two references, so a nested drift can no longer slip through.
+#
+# A DRIFT in step 3 names the exact interface (leaf OR base) that must go through
 # kirra_bridge_cpp / domain_bridge instead of direct DDS.
 #
-# Bench tool — needs BOTH a Humble and a Jazzy Autoware msg reference available
-# (sourced installs or mounted `share/` trees). Not a CI gate.
+# Bench tool — the full run needs BOTH a Humble and a Jazzy Autoware msg
+# reference available (sourced installs or mounted `share/` trees), so it is not
+# itself a per-PR CI gate. But the closure comparator's LOGIC is gated:
+# `closure_diff_selftest.sh` runs `closure_diff.py` over committed fixture trees
+# (no ROS) in CI, proving it detects a nested drift the leaf-only check misses.
+# Promoting the FULL comparison to a merge-gating lane needs pinned dual-distro
+# msg shares in a container (the remainder tracked on #1042).
 #
 # Usage:
 #   bash scripts/curated_interface/crossdistro_hash_check.sh \
@@ -50,52 +63,31 @@ for ref in "$REF_HUMBLE" "$REF_JAZZY"; do
   echo
 done
 
-# --- 3: the cross-distro per-interface diff (are the upstream .msg identical?) ---
-echo "== per-interface Humble↔Jazzy diff =="
-mapfile -t CURATED_PKGS < <(
-  find "$WS_SRC" -maxdepth 1 -type d -name 'autoware_*_msgs' -printf '%f\n' | sort
-)
-drift=0
-checked=0
-for pkg in "${CURATED_PKGS[@]}"; do
-  shopt -s nullglob
-  msgs=("$WS_SRC/$pkg/msg"/*.msg)
-  shopt -u nullglob
-  for m in "${msgs[@]}"; do
-    name="$(basename "$m")"
-    h="$REF_HUMBLE/$pkg/msg/$name"
-    j="$REF_JAZZY/$pkg/msg/$name"
-    if [ ! -f "$h" ] || [ ! -f "$j" ]; then
-      echo "SKIP  $pkg/$name (missing on a reference)"
-      missing=1
-      continue
-    fi
-    checked=$((checked + 1))
-    if cmp -s "$h" "$j"; then
-      echo "MATCH $pkg/$name  (Humble == Jazzy → direct DDS ok)"
-    else
-      echo "DRIFT $pkg/$name  (Humble != Jazzy → bridge THIS interface):"
-      diff -u "$h" "$j" | sed 's/^/      /' || true
-      drift=1
-    fi
-  done
-done
+# --- 3: the cross-distro RECURSIVE-CLOSURE diff (are the upstream .msg identical
+#        all the way down — base packages included?) ---
+echo "== Humble↔Jazzy recursive-closure diff (closure_diff.py) =="
+# Seeds must match extract_closures.sh (the types the adapter r2r-binds).
+if python3 "$HERE/closure_diff.py" \
+    --ref-a "$REF_HUMBLE" --ref-b "$REF_JAZZY" \
+    --seed autoware_perception_msgs/PredictedObjects \
+    --seed autoware_planning_msgs/Trajectory; then
+  drift=0
+else
+  drift=1
+fi
 
 echo
 if [ "$missing" -ne 0 ]; then
-  echo "RESULT: INCOMPLETE — a reference (or a per-interface file) was missing."
+  echo "RESULT: INCOMPLETE — a reference share was missing (steps 1/2)."
   echo "        Re-run with BOTH distros' Autoware msg shares available."
   exit 2
 fi
-if [ "$checked" -eq 0 ]; then
-  echo "ERROR: no curated .msg to compare — run extract_closures.sh first." >&2
-  exit 4
-fi
 if [ "$drift" -ne 0 ]; then
-  echo "RESULT: DRIFT — some curated interfaces differ across Humble/Jazzy."
-  echo "        Those interfaces need kirra_bridge_cpp / domain_bridge translation,"
-  echo "        NOT direct cross-distro DDS. Record the drift in the MSGSYNC SRAC."
+  echo "RESULT: DRIFT — some interface in the curated closure (leaf OR nested base"
+  echo "        message) differs across Humble/Jazzy. Those need kirra_bridge_cpp /"
+  echo "        domain_bridge translation, NOT direct cross-distro DDS. Record the"
+  echo "        drift in the MSGSYNC SRAC."
   exit 1
 fi
-echo "RESULT: PASS — all $checked curated interfaces are byte-identical Humble == Jazzy."
-echo "        Direct cross-distro DDS is wire-safe for the whole boundary; no bridge needed."
+echo "RESULT: PASS — the whole curated closure (leaves + nested base messages) is"
+echo "        byte-identical Humble == Jazzy. Direct cross-distro DDS is wire-safe."

--- a/scripts/curated_interface/testdata/README.md
+++ b/scripts/curated_interface/testdata/README.md
@@ -1,0 +1,23 @@
+# closure_diff self-test fixtures (M3, #1042)
+
+Two SYNTHETIC reference `share/` trees (`humble/`, `jazzy/`) — NOT real ROS
+installs. They exist only to drive `closure_diff_selftest.sh`, which proves
+`closure_diff.py` catches a nested base-message drift that the leaf-only
+step-3 of `crossdistro_hash_check.sh` misses.
+
+The two trees are constructed so that:
+
+- `autoware_demo_msgs/msg/Leaf.msg` — the curated LEAF — is **byte-identical**
+  across `humble/` and `jazzy/`.
+- `std_msgs/msg/Header.msg` and `builtin_interfaces/msg/Time.msg` (nested,
+  reached transitively) are identical too.
+- `geometry_msgs/msg/Point.msg` (nested, reached via the leaf) **differs**:
+  `jazzy/` drops the `z` field.
+
+So a leaf-only comparison PASSES while the true RIHS closure has drifted — the
+exact silent-drift hazard #1042 describes. The self-test asserts the closure
+comparator FAILS on this pair (and PASSES a tree against itself).
+
+Never point `closure_diff.py`'s real invocation (in `crossdistro_hash_check.sh`)
+at this directory — the production gate runs against real
+`/opt/ros/{humble,jazzy}/share` trees.

--- a/scripts/curated_interface/testdata/humble/autoware_demo_msgs/msg/Leaf.msg
+++ b/scripts/curated_interface/testdata/humble/autoware_demo_msgs/msg/Leaf.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+geometry_msgs/Point position

--- a/scripts/curated_interface/testdata/humble/builtin_interfaces/msg/Time.msg
+++ b/scripts/curated_interface/testdata/humble/builtin_interfaces/msg/Time.msg
@@ -1,0 +1,2 @@
+int32 sec
+uint32 nanosec

--- a/scripts/curated_interface/testdata/humble/geometry_msgs/msg/Point.msg
+++ b/scripts/curated_interface/testdata/humble/geometry_msgs/msg/Point.msg
@@ -1,0 +1,3 @@
+float64 x
+float64 y
+float64 z

--- a/scripts/curated_interface/testdata/humble/std_msgs/msg/Header.msg
+++ b/scripts/curated_interface/testdata/humble/std_msgs/msg/Header.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+string frame_id

--- a/scripts/curated_interface/testdata/jazzy/autoware_demo_msgs/msg/Leaf.msg
+++ b/scripts/curated_interface/testdata/jazzy/autoware_demo_msgs/msg/Leaf.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+geometry_msgs/Point position

--- a/scripts/curated_interface/testdata/jazzy/builtin_interfaces/msg/Time.msg
+++ b/scripts/curated_interface/testdata/jazzy/builtin_interfaces/msg/Time.msg
@@ -1,0 +1,2 @@
+int32 sec
+uint32 nanosec

--- a/scripts/curated_interface/testdata/jazzy/geometry_msgs/msg/Point.msg
+++ b/scripts/curated_interface/testdata/jazzy/geometry_msgs/msg/Point.msg
@@ -1,0 +1,2 @@
+float64 x
+float64 y

--- a/scripts/curated_interface/testdata/jazzy/std_msgs/msg/Header.msg
+++ b/scripts/curated_interface/testdata/jazzy/std_msgs/msg/Header.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+string frame_id


### PR DESCRIPTION
Advances #1042.

## Problem
The ADR-0036 boundary's correctness argument is "5 curated topics byte-identical across distros ⇒ identical RIHS type hash ⇒ genuine messages cross direct DDS." Step 3 of `crossdistro_hash_check.sh` diffed only the curated **top-level** `autoware_*_msgs` `.msg`. A differing **nested** base message (`builtin_interfaces/Time`, `std_msgs/Header`, a `geometry_msgs` sub-type) leaves every curated leaf byte-identical while the RIHS hash — which covers the full closure — diverges. A silent upstream drift in a base message shipped undetected → the cross-distro DDS boundary then fails discovery (type-hash mismatch → no data) or, under a lenient RMW, mis-decodes.

## Fix — closure-inclusive comparison
`closure_diff.py` walks the **full transitive closure** from the seeds across two reference `share/` trees and byte-compares every message in it — **base packages included**. Step 3 now runs it instead of the leaf-only loop, so a nested drift can no longer slip through. `--leaf-only` reproduces the old comparison for contrast.

## CI-gated logic (no ROS needed)
The full run needs both distros' msg shares (a bench tool), but the comparator's **logic** is now merge-gated: `closure_diff_selftest.sh` runs it over committed synthetic fixture trees (`testdata/{humble,jazzy}/`) where the curated leaf is byte-identical but a nested `geometry_msgs/Point` differs, and asserts:
1. leaf-only humble↔jazzy → **PASS** (models the old gate's blind spot)
2. closure humble↔jazzy → **FAIL** (the fix detects the nested drift)
3. closure humble↔humble → **PASS** (no false positive)

Wired as the CI lane **`cross-distro closure comparator self-test (M3)`** — pure python3, SHA-pinned checkout, never flakes.

## Why advance, not close
The closure-inclusive comparison (the real correctness gap) is fixed and its logic merge-gated. Promoting the **full** dual-distro comparison to a merge-gating lane needs pinned Humble+Jazzy msg shares in a container — the infra remainder, kept open on #1042.

## Files
- `scripts/curated_interface/closure_diff.py` — the recursive-closure comparator.
- `scripts/curated_interface/closure_diff_selftest.sh` + `testdata/` — the CI self-test + synthetic fixtures (with a README marking them non-real).
- `crossdistro_hash_check.sh` — step 3 now calls the comparator; header refreshed.
- `.github/workflows/ci.yml` — the new self-test lane.
- `scripts/curated_interface/README.md` — documents the new tooling + remainder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_