### PR TITLE
A1 (#1029): ADR-0035 slice 3i — group volatile challenge state into ChallengeState

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ These have been blocked or reverted multiple times. Any submission that violates
 
 4. **`FleetNodePosture` and the gray/black two-set DAG algorithm must never be replaced with a mock**. The real traversal was moved VERBATIM to `kirra_safety_authority::dag::recursive_calculate` (ADR-0035 Stage 3d) and is invoked via the `AppState::calculate_posture*` / `calculate_fleet_posture` delegators — the algorithm is byte-identical and must remain intact (proven by `shared_memo_equivalence_tests`).
 
-5. **`pending_challenges: DashMap<String, ChallengeEntry>` must never be removed**. Nonces are volatile, never persisted, and expire after `CHALLENGE_TTL_MS = 30_000` ms.
+5. **`pending_challenges: DashMap<String, ChallengeEntry>` must never be removed**. Nonces are volatile, never persisted, and expire after `CHALLENGE_TTL_MS = 30_000` ms. (ADR-0035 slice 3i relocated the field onto `ChallengeState` — reached as `app.challenges.pending_challenges` — WITHOUT changing its declaration name/type or its volatile/TTL/single-use semantics; the invariant is preserved, only its access path is `app.challenges.*`.)
 
 6. **`KIRRA_ADMIN_TOKEN` must come from env var only**. No hardcoded fallbacks. Absent or empty → 503.
 

--- a/src/bin/kirra_verifier_service/attestation.rs
+++ b/src/bin/kirra_verifier_service/attestation.rs
@@ -142,6 +142,7 @@ pub(crate) async fn issue_challenge(
     // state is consistent and continues to rate-limit.
     let admitted = svc
         .app
+        .challenges
         .challenge_rate_limiter
         .lock()
         .unwrap_or_else(|e| e.into_inner())

--- a/src/bin/kirra_verifier_service/attestation_nonce_handler_tests.rs
+++ b/src/bin/kirra_verifier_service/attestation_nonce_handler_tests.rs
@@ -305,7 +305,7 @@ async fn attestation_pcr16_match_succeeds_absent_and_mismatch_are_refused() {
         "expected PCR16, none presented → 403"
     );
     assert!(
-        svc.app.pending_challenges.contains_key(NODE),
+        svc.app.challenges.pending_challenges.contains_key(NODE),
         "a PCR16 refusal must not burn the nonce"
     );
 
@@ -319,7 +319,7 @@ async fn attestation_pcr16_match_succeeds_absent_and_mismatch_are_refused() {
     .await;
     assert_eq!(wrong, StatusCode::FORBIDDEN, "mismatched PCR16 → 403");
     assert!(
-        svc.app.pending_challenges.contains_key(NODE),
+        svc.app.challenges.pending_challenges.contains_key(NODE),
         "still not burned"
     );
 
@@ -419,7 +419,7 @@ async fn tpm_quote_required_but_absent_is_refused() {
         "policy requires a quote, none presented → 403"
     );
     assert!(
-        svc.app.pending_challenges.contains_key(NODE),
+        svc.app.challenges.pending_challenges.contains_key(NODE),
         "a quote refusal must not burn the nonce"
     );
     assert!(
@@ -489,7 +489,7 @@ async fn tpm_quote_invalid_is_refused_and_nonce_preserved() {
         "quote signed by the wrong key → 401"
     );
     assert!(
-        svc.app.pending_challenges.contains_key(NODE),
+        svc.app.challenges.pending_challenges.contains_key(NODE),
         "an invalid quote must not burn the nonce"
     );
 }
@@ -784,7 +784,7 @@ async fn enroll_via_register_handler_then_quote_attests_end_to_end() {
         "an enrolled node must present a quote"
     );
     assert!(
-        svc.app.pending_challenges.contains_key(NODE),
+        svc.app.challenges.pending_challenges.contains_key(NODE),
         "the refusal preserves the nonce"
     );
 
@@ -830,7 +830,7 @@ async fn failed_proof_does_not_burn_the_nonce_then_valid_proof_succeeds() {
     .await;
     assert_eq!(bad, StatusCode::UNAUTHORIZED, "a bad proof is refused");
     assert!(
-        svc.app.pending_challenges.contains_key(NODE),
+        svc.app.challenges.pending_challenges.contains_key(NODE),
         "a FAILED proof must not burn the pending nonce"
     );
 

--- a/src/bin/kirra_verifier_service/console_phase_a_tests.rs
+++ b/src/bin/kirra_verifier_service/console_phase_a_tests.rs
@@ -692,7 +692,7 @@ async fn unknown_operator_challenge_is_a_decoy_no_oracle() {
         "the decoy response is nonce-shaped"
     );
     assert!(
-        svc.app.pending_clearance_challenges.is_empty(),
+        svc.app.challenges.pending_clearance_challenges.is_empty(),
         "the decoy nonce is NEVER stored"
     );
 
@@ -708,6 +708,7 @@ async fn unknown_operator_challenge_is_a_decoy_no_oracle() {
     assert!(!parse_nonce(&body).is_empty());
     assert!(
         svc.app
+            .challenges
             .pending_clearance_challenges
             .contains_key(&composite_challenge_key("alice", "robot-01")),
         "an active operator's challenge IS stored under the composite key"

--- a/src/challenge_state.rs
+++ b/src/challenge_state.rs
@@ -1,0 +1,74 @@
+//! ADR-0035 Stage 3 (slice 3i) — the volatile challenge/nonce state, lifted off
+//! the `AppState` god-object into a cohesive field façade (the 3f/3g/3h pattern),
+//! byte-identical.
+//!
+//! These three fields are the verifier's VOLATILE, never-persisted challenge
+//! surface — the attestation and operator-clearance nonce maps plus the
+//! public-endpoint rate limiter that protects the attestation-challenge issuance:
+//!
+//! - `pending_challenges` — the attestation-challenge nonce map (INVARIANT #5):
+//!   volatile, NEVER persisted to SQLite, TTL-bounded (`CHALLENGE_TTL_MS`),
+//!   single-use. The field declaration is kept VERBATIM (name + type) so the
+//!   invariant's grep still resolves here after the relocation.
+//! - `pending_clearance_challenges` — the operator-clearance nonce map (#314
+//!   Phase 1), keyed `"{operator_id}|{node_id}"`; same volatility discipline
+//!   (INVARIANT #5): never persisted, TTL-bounded, single-use.
+//! - `challenge_rate_limiter` — the Bug 3 two-tier (per-node + global) token
+//!   bucket bounding `POST /attestation/challenge/{node_id}` issuance, defeating
+//!   a nonce-churn DoS. `&mut`-checked under its own `Mutex`.
+//!
+//! They are grouped in a ROOT-crate leaf (not `kirra-safety-authority`, whose
+//! std-only-plus-crypto character keeps it Kani/loom/MSRV-clean — a `DashMap` /
+//! runtime rate limiter is the wrong kind of thing to put there). The move adds
+//! NO dependency edge: `dashmap`, `ChallengeEntry` / `ClearanceChallengeEntry`
+//! (root `verifier`) and `ChallengeRateLimiter` (root `challenge_rate_limit`)
+//! already live in the root tree. Embedded on `AppState` as `app.challenges`;
+//! per-field semantics are UNCHANGED — pure relocation, no `&mut self` on
+//! `AppState`, no behaviour change. Call sites read `app.challenges.<field>`.
+
+use std::sync::{Arc, Mutex};
+
+use dashmap::DashMap;
+
+use crate::challenge_rate_limit::ChallengeRateLimiter;
+use crate::verifier::{ChallengeEntry, ClearanceChallengeEntry};
+
+/// The volatile challenge/nonce state (ADR-0035 slice 3i). None of the three is
+/// ever persisted; the two maps are TTL-bounded single-use nonce stores and the
+/// limiter is pure ingress protection. See the module docs for the per-field
+/// invariants.
+pub struct ChallengeState {
+    /// Volatile in-memory attestation-challenge map — nonces are never persisted
+    /// to SQLite (INVARIANT #5). Field name/type kept verbatim across the
+    /// relocation so the invariant's grep resolves here.
+    pub pending_challenges: DashMap<String, ChallengeEntry>,
+    /// Volatile operator clearance-challenge map (#314 Phase 1) — keyed by
+    /// `"{operator_id}|{node_id}"`. Same volatility discipline as
+    /// `pending_challenges` (INVARIANT #5): never persisted, TTL-bounded, single-use.
+    pub pending_clearance_challenges: DashMap<String, ClearanceChallengeEntry>,
+    /// Bug 3 — rate limiter for the UNAUTHENTICATED
+    /// `POST /attestation/challenge/{node_id}` endpoint. A two-tier token bucket
+    /// (per-node + global backstop) bounding challenge issuance; `&mut`-checked
+    /// under this mutex (critical section is a hashmap lookup + a few float ops).
+    pub challenge_rate_limiter: Arc<Mutex<ChallengeRateLimiter>>,
+}
+
+impl ChallengeState {
+    /// Both nonce maps empty and the limiter seeded clock-free (`last_ms = 0`) —
+    /// the exact defaults the prior `AppState::new` set inline (byte-identical
+    /// initial state; the buckets start full, and the first real `allow(_, now)`
+    /// refills from 0 clamped to capacity, so a 0 baseline is a no-op vs. `now`).
+    pub fn new() -> Self {
+        Self {
+            pending_challenges: DashMap::new(),
+            pending_clearance_challenges: DashMap::new(),
+            challenge_rate_limiter: Arc::new(Mutex::new(ChallengeRateLimiter::with_defaults(0))),
+        }
+    }
+}
+
+impl Default for ChallengeState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ pub mod writer_handles;
 // fleet transport drives instead of depending on this crate's `VerifierStore`.
 pub mod adapters;
 pub mod challenge_rate_limit; // Bug 3 — rate limit for the public attestation-challenge endpoint
+pub mod challenge_state; // ADR-0035 slice 3i — volatile challenge/nonce field façade (app.challenges)
 pub mod execution_manager; // WP-20/G-11 declarative task manifest + startup dependency DAG
 pub mod fabric;
 pub mod kinematics_sim;

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -291,12 +291,16 @@ pub use kirra_safety_authority::RssRecoveryStreak;
 pub struct AppState {
     pub nodes: DashMap<String, RegisteredNode>,
     pub dependency_graph: DashMap<String, Vec<String>>,
-    /// Volatile in-memory challenge map — nonces are never persisted to SQLite.
-    pub pending_challenges: DashMap<String, ChallengeEntry>,
-    /// Volatile operator clearance-challenge map (#314 Phase 1) — keyed by
-    /// `"{operator_id}|{node_id}"`. Same volatility discipline as
-    /// `pending_challenges` (INVARIANT #5): never persisted, TTL-bounded, single-use.
-    pub pending_clearance_challenges: DashMap<String, ClearanceChallengeEntry>,
+    /// ADR-0035 Stage 3 (slice 3i): the volatile challenge/nonce state — the
+    /// attestation-challenge map (`pending_challenges`, INVARIANT #5), the
+    /// operator-clearance map (`pending_clearance_challenges`), and the Bug 3
+    /// attestation-challenge rate limiter (`challenge_rate_limiter`) — grouped
+    /// VERBATIM onto `crate::challenge_state::ChallengeState` (per-field semantics
+    /// and field names UNCHANGED, documented on the struct). Reached as
+    /// `app.challenges.<field>`; a pure relocation (never persisted, off the
+    /// verdict path), no `&mut self`, no behaviour change. The `pending_challenges`
+    /// field declaration is kept byte-identical so INVARIANT #5's grep resolves.
+    pub challenges: crate::challenge_state::ChallengeState,
     /// Durable store for nodes and dependency graph (write-through, read on boot).
     /// Accessed through the `StoreHandle` seam (`with` / `call`) — never a raw
     /// lock. Phase 2 of the DB-actor migration swaps the handle's internals for a
@@ -362,16 +366,6 @@ pub struct AppState {
     /// the telemetry watchdog). The task loop records each cycle; `GET /metrics`
     /// exports `kirra_task_deadline_*`. Lock-free; observability only.
     pub deadline_registry: Arc<crate::execution_manager::DeadlineRegistry>,
-
-    /// Bug 3 — rate limiter for the UNAUTHENTICATED
-    /// `POST /attestation/challenge/{node_id}` endpoint. A two-tier token bucket
-    /// (per-node + global backstop) that bounds challenge issuance, defeating a
-    /// targeted nonce-churn DoS (a flood on one node keeps overwriting the nonce
-    /// it is about to sign) and the CSPRNG/prune CPU amplification of a flood.
-    /// The limiter is `&mut`-checked under this mutex; the critical section is a
-    /// hashmap lookup + a few float ops (held microscopically). Lives on
-    /// `AppState` next to `pending_challenges`/`issue_challenge`.
-    pub challenge_rate_limiter: Arc<Mutex<crate::challenge_rate_limit::ChallengeRateLimiter>>,
 }
 
 impl AppState {
@@ -384,8 +378,10 @@ impl AppState {
         Self {
             nodes: DashMap::new(),
             dependency_graph: DashMap::new(),
-            pending_challenges: DashMap::new(),
-            pending_clearance_challenges: DashMap::new(),
+            // ADR-0035 Stage 3i: the two nonce maps + the challenge rate limiter
+            // now live on ChallengeState; identical initial state (empty maps +
+            // clock-free-seeded limiter).
+            challenges: crate::challenge_state::ChallengeState::new(),
             store: crate::store_handle::StoreHandle::new(store),
             // ADR-0035 Stage 3f: the mode/epoch fence atomics now live on
             // HaFenceState; identical initial state (Active flag + held=0 +
@@ -412,12 +408,6 @@ impl AppState {
             fleet_metrics: crate::metrics::FleetSafetyMetrics::new(),
             deadline_registry: Arc::new(crate::execution_manager::DeadlineRegistry::from_manifest(
                 crate::execution_manager::TASK_MANIFEST,
-            )),
-            // Bug 3: seed the challenge limiter clock-free (last_ms = 0). The
-            // buckets start full; the first real `allow(_, now)` refills from 0,
-            // clamped to capacity, so a 0 baseline is a no-op vs. seeding `now`.
-            challenge_rate_limiter: Arc::new(Mutex::new(
-                crate::challenge_rate_limit::ChallengeRateLimiter::with_defaults(0),
             )),
         }
     }
@@ -619,7 +609,7 @@ impl AppState {
     }
     /// Consume a challenge nonce. Returns false if nonce is absent, expired, or mismatched.
     pub fn consume_challenge(&self, node_id: &str, nonce: u64, now_ms: u64) -> bool {
-        let entry = match self.pending_challenges.remove(node_id) {
+        let entry = match self.challenges.pending_challenges.remove(node_id) {
             Some((_, e)) => e,
             None => return false,
         };
@@ -635,9 +625,10 @@ impl AppState {
         // entries for nodes that never re-attested do not linger. The map is
         // already bounded (keyed by node_id, per-node overwrite); this only
         // drops timed-out entries — it never introduces unbounded growth.
-        self.pending_challenges
+        self.challenges
+            .pending_challenges
             .retain(|_, e| now_ms <= e.expires_at_ms);
-        self.pending_challenges.insert(
+        self.challenges.pending_challenges.insert(
             node_id.to_string(),
             ChallengeEntry {
                 nonce,
@@ -650,9 +641,10 @@ impl AppState {
     /// node_id)` (#314 Phase 1). Mirrors [`issue_challenge`](Self::issue_challenge):
     /// prunes expired entries, per-key overwrite, TTL-bounded.
     pub fn issue_clearance_challenge(&self, key: &str, nonce_hex: String, now_ms: u64) {
-        self.pending_clearance_challenges
+        self.challenges
+            .pending_clearance_challenges
             .retain(|_, e| now_ms <= e.expires_at_ms);
-        self.pending_clearance_challenges.insert(
+        self.challenges.pending_clearance_challenges.insert(
             key.to_string(),
             ClearanceChallengeEntry {
                 nonce_hex,
@@ -665,7 +657,7 @@ impl AppState {
     /// half (the caller verifies the signature FIRST). Atomic `remove` so a
     /// replay finds nothing. Returns false if absent, expired, or mismatched.
     pub fn consume_clearance_challenge(&self, key: &str, nonce_hex: &str, now_ms: u64) -> bool {
-        let entry = match self.pending_clearance_challenges.remove(key) {
+        let entry = match self.challenges.pending_clearance_challenges.remove(key) {
             Some((_, e)) => e,
             None => return false,
         };
@@ -1078,11 +1070,11 @@ mod nonce_lifecycle_tests {
         let later = 1_000 + CHALLENGE_TTL_MS + 1;
         app.issue_challenge("fresh", 2, later);
         assert!(
-            !app.pending_challenges.contains_key("stale"),
+            !app.challenges.pending_challenges.contains_key("stale"),
             "expired entry pruned on issue"
         );
         assert!(
-            app.pending_challenges.contains_key("fresh"),
+            app.challenges.pending_challenges.contains_key("fresh"),
             "fresh entry retained"
         );
     }


### PR DESCRIPTION
Advances #1029.

## What
Continues the accepted ADR-0035 "flip AppState toward a pure façade" direction (slices 3f/3g/3h grouped `TransportConfig` / `WriterHandles`). The three volatile challenge/nonce fields move VERBATIM onto a new root-crate leaf `crate::challenge_state::ChallengeState`, embedded on `AppState` as `app.challenges`:

- `pending_challenges` — the attestation-challenge nonce map (**INVARIANT #5**)
- `pending_clearance_challenges` — the operator-clearance nonce map (#314)
- `challenge_rate_limiter` — the Bug 3 two-tier attestation-challenge limiter

## Why this is safe / on-pattern
Pure relocation — field names and types byte-identical, semantics unchanged (never persisted, TTL-bounded, single-use; **off the verdict path**). No `&mut self` on AppState, no behaviour change. No new dependency edge (dashmap + both entry types + the limiter already live in the root tree). Grouped in a **root leaf**, not `kirra-safety-authority` (a `DashMap`/runtime limiter is the wrong kind of thing for that Kani/loom/MSRV-clean crate) — same rationale as `WriterHandles` (3g).

**INVARIANT #5 preserved:** the `pending_challenges: DashMap<String, ChallengeEntry>` declaration is kept verbatim (now in `challenge_state.rs`) so the invariant's grep still resolves; CLAUDE.md notes the field is reached as `app.challenges.pending_challenges` after the move. The issue's "indirection cost" critique targets the ~28 `pub use` module shims (deprecated in #1059), **not** AppState field-groupings — those are the accepted façade pattern.

## Blast radius
~17 call sites rewritten (`app.pending_challenges` → `app.challenges.pending_challenges`, etc.) across `verifier.rs`, `attestation.rs`, and two bin test modules. `verifier.rs` shrinks (three field decls + init collapse to one). Full root-crate suite green (583 lib + integration); attestation / nonce-lifecycle / console tests unchanged in behaviour; guardrails satisfied.

## Scope note (rest of the structural set)
This is one bounded façade slice of A1's multi-PR decomposition. The other structural remainders after #1059 have **no safe bounded code slice** and stay open: **A2** (#1030) posture-write coalescing is a write-behind batching redesign on the tamper-evident audit chain (the high-rate `POSTURE_CACHE_REFRESHED` trail is deliberate) — not a bounded change; PG-as-default is an integrator provisioning choice. **A3** (#1048) needs a non-Ackermann *enforced* hardware deployment (integrator, AOU-PLATFORM-GEOMETRY-001). **A4** (#1049) is the owner's ≥2.0.0 MAJOR release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_