### PR TITLE
Low backlog PR2 (#1050): Sec9 + C8 + M7 + W10 — robustness batch

### DIFF
--- a/crates/kirra-contract-channel/src/seqlock.rs
+++ b/crates/kirra-contract-channel/src/seqlock.rs
@@ -12,6 +12,15 @@
 //! them to the hypervisor-mapped region (where the mapping `unsafe` lives — the
 //! ADR-0006 Clause 3 integration shim, *outside* this crate), while the protocol
 //! itself stays `#![forbid(unsafe_code)]` and host-testable against atomics.
+//!
+//! **LOCKSTEP-SEQLOCK-HVCHAN-001 (W10 #1050):** `crates/kirra-loom-models`
+//! carries a HAND-COPIED mirror of this protocol (`seqlock_publish` /
+//! `seqlock_read`) to model it under loom. The two must stay in lock-step — any
+//! change to the FOUR ordering edges below (odd marker Release, the Release
+//! fence, the even commit Release, the Acquire fence before the g2 re-read) MUST
+//! be reflected in the mirror. The loom crate's `production_seqlock_edges_are_in_lockstep`
+//! test reads THIS file and reds if a mirrored edge disappears, so the drift is
+//! caught in CI rather than silently diverging the one subtle concurrency primitive.
 
 use core::sync::atomic::{fence, Ordering};
 

--- a/crates/kirra-loom-models/src/lib.rs
+++ b/crates/kirra-loom-models/src/lib.rs
@@ -329,3 +329,35 @@ fn seqlock_accepted_snapshot_is_never_torn() {
         reader.join().unwrap();
     });
 }
+
+// ---------------------------------------------------------------------------
+// W10 (#1050) — LOCKSTEP-SEQLOCK-HVCHAN-001 drift tripwire.
+//
+// `seqlock_publish` / `seqlock_read` above are a HAND-COPIED mirror of the
+// production `kirra_contract_channel::{publish,read_coherent_snapshot}`. The
+// loom model only proves the MIRROR sound — if the production ordering edges
+// drift without the mirror following, loom would be validating a stale protocol.
+// This test reads the production source at compile time and asserts its four
+// load-bearing ordering edges (the ones the mirror replicates) are still present,
+// so a change there reds this test and forces the mirror to be re-checked. It is
+// a drift reminder, not a full-equivalence proof (that is what the loom model is,
+// against the mirror). Pure `include_str!` + substring checks — no loom runtime.
+// ---------------------------------------------------------------------------
+#[test]
+fn production_seqlock_edges_are_in_lockstep() {
+    const PROD: &str = include_str!("../../kirra-contract-channel/src/seqlock.rs");
+    for needle in [
+        "LOCKSTEP-SEQLOCK-HVCHAN-001",   // the reciprocal marker naming this test
+        "committed_gen.wrapping_add(1)", // odd marker: write in progress
+        "committed_gen.wrapping_add(2)", // even commit
+        "fence(Ordering::Release)",      // edge 3: publisher release fence
+        "fence(Ordering::Acquire)",      // edge 4: reader acquire fence before g2 re-read
+    ] {
+        assert!(
+            PROD.contains(needle),
+            "LOCKSTEP DRIFT: production seqlock.rs no longer contains `{needle}` — \
+             the loom mirror (seqlock_publish/seqlock_read) may now model a stale \
+             protocol. Update the mirror in lock-step (W10 #1050) and re-pin this test."
+        );
+    }
+}

--- a/crates/kirra-loom-models/src/lib.rs
+++ b/crates/kirra-loom-models/src/lib.rs
@@ -347,11 +347,11 @@ fn seqlock_accepted_snapshot_is_never_torn() {
 fn production_seqlock_edges_are_in_lockstep() {
     const PROD: &str = include_str!("../../kirra-contract-channel/src/seqlock.rs");
     for needle in [
-        "LOCKSTEP-SEQLOCK-HVCHAN-001",   // the reciprocal marker naming this test
+        "LOCKSTEP-SEQLOCK-HVCHAN-001", // the reciprocal marker naming this test
         "committed_gen.wrapping_add(1)", // odd marker: write in progress
         "committed_gen.wrapping_add(2)", // even commit
-        "fence(Ordering::Release)",      // edge 3: publisher release fence
-        "fence(Ordering::Acquire)",      // edge 4: reader acquire fence before g2 re-read
+        "fence(Ordering::Release)",    // edge 3: publisher release fence
+        "fence(Ordering::Acquire)",    // edge 4: reader acquire fence before g2 re-read
     ] {
         assert!(
             PROD.contains(needle),

--- a/crates/kirra-persistence/src/nodes.rs
+++ b/crates/kirra-persistence/src/nodes.rs
@@ -199,6 +199,83 @@ impl VerifierStore {
         Ok(())
     }
 
+    /// Sec9 (#1050): register a node AND its attestation policy in ONE
+    /// transaction. `register_node` previously wrote the TPM-quote policy and the
+    /// node record as two separate durable writes — a correct fail-closed ORDER
+    /// (policy first, so a quote-required node is never live without its
+    /// requirement) but NOT atomic: a crash between them could leave a policy row
+    /// with no node. Folding both INSERT-OR-REPLACEs into one transaction makes
+    /// registration all-or-nothing. Plain variant (no epoch fence) for a
+    /// never-claimed store (`held == 0`; see `AppState::persist_node_row`).
+    pub fn save_node_with_policy(
+        &self,
+        node: &RegisteredNode,
+        require_tpm_quote: bool,
+    ) -> Result<()> {
+        let status_json =
+            serde_json::to_string(&node.status).map_err(|_| rusqlite::Error::InvalidQuery)?;
+        let tx = self.conn.unchecked_transaction()?;
+        Self::insert_node_and_policy_tx(&tx, node, &status_json, require_tpm_quote)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Sec9 (#1050): the epoch-fenced sibling of [`save_node_with_policy`] — the
+    /// same atomic node+policy write, preceded in the SAME `Immediate` transaction
+    /// by the `held_epoch` fence (C5 #1036 semantics; a superseded primary is
+    /// rejected before it can write either row). Fail-closed like
+    /// [`save_node_epoch_fenced`].
+    pub fn save_node_with_policy_epoch_fenced(
+        &mut self,
+        node: &RegisteredNode,
+        require_tpm_quote: bool,
+        held_epoch: u64,
+    ) -> std::result::Result<(), DurableWriteError> {
+        let status_json =
+            serde_json::to_string(&node.status).map_err(|_| rusqlite::Error::InvalidQuery)?;
+        let tx = self
+            .conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        Self::assert_epoch_held(&tx, held_epoch)?;
+        Self::insert_node_and_policy_tx(&tx, node, &status_json, require_tpm_quote)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Shared body for the Sec9 combined write: the node INSERT-OR-REPLACE + the
+    /// attestation-policy INSERT-OR-REPLACE, both inside the caller's transaction
+    /// (so they commit together). Node first, policy second — but atomicity, not
+    /// order, is the guarantee here (either both land or neither does).
+    fn insert_node_and_policy_tx(
+        tx: &rusqlite::Transaction<'_>,
+        node: &RegisteredNode,
+        status_json: &str,
+        require_tpm_quote: bool,
+    ) -> Result<()> {
+        tx.execute(
+            "INSERT OR REPLACE INTO nodes
+             (node_id, status_json, registered_at_ms, last_trust_update_ms,
+              ak_public_pem, expected_pcr16_digest_hex, site, firmware_version)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                node.node_id,
+                status_json,
+                node.registered_at_ms as i64,
+                node.last_trust_update_ms as i64,
+                node.ak_public_pem,
+                node.expected_pcr16_digest_hex,
+                node.site,
+                node.firmware_version,
+            ],
+        )?;
+        tx.execute(
+            "INSERT OR REPLACE INTO node_attestation_policy (node_id, require_tpm_quote)
+             VALUES (?1, ?2)",
+            params![node.node_id, require_tpm_quote as i64],
+        )?;
+        Ok(())
+    }
+
     /// C5 (#1036): epoch-fenced dependency-set replace. The atomic
     /// DELETE-then-re-INSERT of [`save_dependencies`], preceded in the SAME
     /// `Immediate` transaction by the `held_epoch` fence — a superseded primary can
@@ -561,5 +638,47 @@ mod epoch_fenced_write_tests {
             store.load_dependencies().unwrap().get("c").is_none(),
             "a fenced-out dependency write must leave NO edges (fail-closed)"
         );
+    }
+
+    // Sec9 (#1050): the node record and its attestation policy are written
+    // atomically — both land, or (when fenced out) neither does.
+    #[test]
+    fn node_and_attestation_policy_are_written_and_fenced_together() {
+        let mut store = VerifierStore::new(":memory:").expect("store");
+
+        // Plain path (never-claimed store): both the node row AND the quote policy
+        // land from one call.
+        store
+            .save_node_with_policy(&node("n1"), true)
+            .expect("combined write");
+        assert!(store.node_exists("n1").unwrap());
+        assert!(
+            store.node_requires_tpm_quote("n1").unwrap(),
+            "the attestation policy committed in the same transaction as the node"
+        );
+
+        // Fenced path: advance the durable epoch so a stale held-epoch is
+        // superseded; the combined write must leave NEITHER row.
+        store.try_claim_epoch(0, "A", 1).unwrap();
+        store.try_claim_epoch(1, "B", 2).unwrap();
+        let err = store
+            .save_node_with_policy_epoch_fenced(&node("n2"), true, 1)
+            .expect_err("superseded combined write rejected");
+        assert!(superseded(&err), "expected EpochSuperseded, got {err:?}");
+        assert!(
+            !store.node_exists("n2").unwrap(),
+            "fenced-out registration must leave no node row"
+        );
+        assert!(
+            !store.node_requires_tpm_quote("n2").unwrap(),
+            "fenced-out registration must leave no policy row (defaults false when absent)"
+        );
+
+        // Holder (held == durable == 2) commits both.
+        store
+            .save_node_with_policy_epoch_fenced(&node("n3"), true, 2)
+            .expect("holder combined write admitted");
+        assert!(store.node_exists("n3").unwrap());
+        assert!(store.node_requires_tpm_quote("n3").unwrap());
     }
 }

--- a/src/bin/kirra_verifier_service/attestation.rs
+++ b/src/bin/kirra_verifier_service/attestation.rs
@@ -70,33 +70,23 @@ pub(crate) async fn register_node(
         firmware_version: req.firmware_version,
     };
 
-    // TPM-quote policy (#572 follow-up) is committed BEFORE the node record, so
-    // a node that requires a hardware quote is never live without its policy
-    // (fail-closed: no window where the requirement silently does not apply). A
-    // store error here fails the whole registration — the node is not inserted.
-    {
-        // SAFETY: SG-HA-3 — durable write off the async worker pool.
-        let node_id_p = req.node_id.clone();
-        let policy_err = !matches!(
-            svc.app
-                .store
-                .call(move |store| { store.set_node_attestation_policy(&node_id_p, require) })
-                .await,
-            Ok(Ok(()))
-        );
-        if policy_err {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({ "error": "failed to persist attestation policy" })),
-            )
-                .into_response();
-        }
-    }
-
-    if svc.app.persist_and_insert_node(node).is_err() {
+    // Sec9 (#1050): the node record and its TPM-quote policy (#572 follow-up) are
+    // now written in ONE durable transaction, so registration is atomic — a crash
+    // can no longer leave a policy row without its node (or vice versa). The
+    // fail-closed intent is preserved (a quote-required node is never live without
+    // its requirement) and strengthened to all-or-nothing. Runs off the async
+    // worker (SAFETY: SG-HA-3) via `spawn_blocking` on the combined write.
+    let app = std::sync::Arc::clone(&svc.app);
+    let persisted = tokio::task::spawn_blocking(move || {
+        app.persist_and_insert_node_with_policy(node, require)
+            .is_ok()
+    })
+    .await
+    .unwrap_or(false);
+    if !persisted {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": "failed to persist node" })),
+            Json(json!({ "error": "failed to persist node registration" })),
         )
             .into_response();
     }

--- a/src/standby_monitor/heartbeat.rs
+++ b/src/standby_monitor/heartbeat.rs
@@ -65,6 +65,19 @@ async fn heartbeat_loop(app: Arc<AppState>, id: String, ha: HaTimings) {
     // FAILURES the primary self-demotes (disk-wedge / fence-uncertainty).
     let mut consecutive_failures: u32 = 0;
 
+    // C8 (#1050): a STRICTLY-monotonic per-tick sequence folded into the
+    // freshness token. The token is only a change-detector for the standby
+    // (`HeartbeatFreshness` compares it as an opaque string; it never parses the
+    // value), and any value that changes EVERY tick suffices. `now_ms()` alone
+    // does not: at a sub-millisecond cadence (a misconfigured interval below the
+    // clock resolution) two ticks would stamp the same millisecond → the same
+    // token → the standby would read "unchanged" and could spuriously promote.
+    // Pairing the timestamp with `heartbeat_seq` (which advances every tick
+    // regardless of clock granularity) removes that collision while keeping the
+    // millisecond for human-readable logs. Not reachable at the shipped ≥2 s
+    // interval; this hardens the misconfigured case.
+    let mut heartbeat_seq: u64 = 0;
+
     // The store work runs under one acquisition; the closure returns an
     // OUTCOME the outer loop acts on (the closure cannot `continue`/`break`
     // the outer loop directly — Rule 4).
@@ -111,6 +124,11 @@ async fn heartbeat_loop(app: Arc<AppState>, id: String, ha: HaTimings) {
         // OWN monotonic clock — see `HeartbeatFreshness`. Any value that
         // strictly changes each tick would do; `now_ms()` is convenient.
         let ts = now_ms();
+        // C8 (#1050): strictly-monotonic per-tick sequence — guarantees the
+        // freshness token changes every tick even if `ts` repeats within a
+        // sub-ms interval. Wraps only after 2^64 ticks (unreachable).
+        heartbeat_seq = heartbeat_seq.wrapping_add(1);
+        let heartbeat_token = format!("{ts}.{heartbeat_seq}");
         // P1: run the heartbeat write + epoch read OFF the tokio worker pool
         // (`call` → spawn_blocking) so the ~2 s fsync write can't pin a shared
         // worker and head-of-line-block request handlers / the fast loop. The
@@ -122,7 +140,7 @@ async fn heartbeat_loop(app: Arc<AppState>, id: String, ha: HaTimings) {
         let id_c = id.clone();
         let lease_c = lease;
         let outcome = match app.store.call(move |store| {
-                if let Err(e) = store.save_engine_state(HEARTBEAT_KEY, &ts.to_string()) {
+                if let Err(e) = store.save_engine_state(HEARTBEAT_KEY, &heartbeat_token) {
                     tracing::warn!(
                         error       = %e,
                         instance_id = %id_c,

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -508,7 +508,7 @@ impl AppState {
     /// ONE durable transaction, then insert into the in-memory registry (disk
     /// before memory, invariant #12). Atomic registration — a crash can no longer
     /// leave a policy row without its node. Same held-epoch fence dispatch as
-    /// [`persist_node_row`] (a superseded primary is rejected before either row is
+    /// `persist_node_row` (a superseded primary is rejected before either row is
     /// written). `Ok(())` only after both durable writes commit AND the memory
     /// insert lands.
     #[allow(clippy::result_unit_err)]

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -504,6 +504,48 @@ impl AppState {
         })
     }
 
+    /// Sec9 (#1050): persist a node record AND its TPM-quote attestation policy in
+    /// ONE durable transaction, then insert into the in-memory registry (disk
+    /// before memory, invariant #12). Atomic registration — a crash can no longer
+    /// leave a policy row without its node. Same held-epoch fence dispatch as
+    /// [`persist_node_row`] (a superseded primary is rejected before either row is
+    /// written). `Ok(())` only after both durable writes commit AND the memory
+    /// insert lands.
+    #[allow(clippy::result_unit_err)]
+    pub fn persist_and_insert_node_with_policy(
+        &self,
+        node: RegisteredNode,
+        require_tpm_quote: bool,
+    ) -> Result<(), ()> {
+        use dashmap::mapref::entry::Entry;
+        let held = self
+            .ha_fence
+            .held_epoch
+            .load(std::sync::atomic::Ordering::SeqCst);
+        let write = |store: &mut VerifierStore| {
+            if held == 0 {
+                store
+                    .save_node_with_policy(&node, require_tpm_quote)
+                    .map_err(|_| ())
+            } else {
+                store
+                    .save_node_with_policy_epoch_fenced(&node, require_tpm_quote, held)
+                    .map_err(|_| ())
+            }
+        };
+        match self.nodes.entry(node.node_id.clone()) {
+            Entry::Occupied(mut occ) => {
+                self.store.with(write)?;
+                occ.insert(node);
+            }
+            Entry::Vacant(vac) => {
+                self.store.with(write)?;
+                vac.insert(node);
+            }
+        }
+        Ok(())
+    }
+
     /// Atomically read-modify-write a REGISTERED node's record under the per-key
     /// entry (shard) lock (C2 #1031). `f` receives the current record and returns
     /// its replacement; the read, the disk write and the memory write ALL happen

--- a/tools/iceoryx2-spike/src/frozen.rs
+++ b/tools/iceoryx2-spike/src/frozen.rs
@@ -55,6 +55,33 @@ pub struct WireView(pub GovernorContractView);
 // safe to share across a process/partition boundary by value. `WireView` is
 // `#[repr(transparent)]` over it, so the same holds. This is the single, audited
 // `unsafe` the carrier needs (ADR-0006 Clause 3 integration boundary).
+// M7 (#1050): PROVE the "no padding" claim the `ZeroCopySend` safety argument
+// rests on, rather than only asserting it in prose. If the compiler inserted any
+// implicit padding, `size_of::<GovernorContractView>()` would exceed the SUM of
+// the field sizes, and those uninitialized padding bytes would be shared across
+// the process/partition boundary. The frozen layout is widest-first with the
+// `u32`s paired into 8-byte slots, so Σ(field sizes) == size_of == the canonical
+// image length; this const assertion fails to compile the instant that stops
+// holding (a reordered/added field that introduces a hole).
+const _: () = {
+    let sum_of_fields = core::mem::size_of::<u32>()   // layout_version
+        + core::mem::size_of::<u32>()                 // magic
+        + core::mem::size_of::<u64>()                 // generation
+        + core::mem::size_of::<u64>()                 // sequence
+        + core::mem::size_of::<u64>()                 // publication_nanos
+        + core::mem::size_of::<u64>()                 // deadline_nanos
+        + core::mem::size_of::<u32>()                 // crc32
+        + core::mem::size_of::<u32>()                 // command_len
+        + MAX_COMMAND_BYTES; // command: [u8; MAX_COMMAND_BYTES]
+    assert!(
+        core::mem::size_of::<GovernorContractView>() == sum_of_fields,
+        "GovernorContractView has implicit padding — ZeroCopySend would share \
+         uninitialized bytes across the boundary"
+    );
+    // `WireView` is `#[repr(transparent)]` over it, so the same holds.
+    assert!(core::mem::size_of::<WireView>() == sum_of_fields);
+};
+
 unsafe impl ZeroCopySend for WireView {}
 
 /// The transport-contract fault classes the carrier drives through iceoryx2, each


### PR DESCRIPTION
Part of #1050 (Low hardening backlog). Four low-severity robustness findings across subsystems:

- **Sec9** — node registration wrote the TPM-quote policy and the node record as **two** durable writes (correct fail-closed order, but a crash between them could orphan a policy row). New `save_node_with_policy{,_epoch_fenced}` (kirra-persistence) write both INSERT-OR-REPLACEs in **one transaction** (held-epoch fenced, reusing the C5 #1036 pattern); `AppState::persist_and_insert_node_with_policy` dispatches + inserts into memory disk-before-memory; the register handler calls the single atomic method via `spawn_blocking`. Registration is now all-or-nothing. Test: both rows land together / a superseded epoch leaves neither.
- **C8** — the heartbeat freshness token was `now_ms().to_string()`; at a sub-millisecond (misconfigured) cadence two ticks could share a token and the standby (opaque change-detector) could read "unchanged" → spurious failover. Folded a strictly-monotonic per-tick `heartbeat_seq` into the token so it changes every tick regardless of clock resolution. Not reachable at the shipped ≥2 s interval.
- **M7** — the `unsafe impl ZeroCopySend for WireView` asserted "no padding" only in prose. Added a `const _` static assertion that `size_of::<GovernorContractView>() == Σ(field sizes)` (== the canonical image length), so the no-padding claim the safety argument rests on is compiler-checked and reds the instant a field reorder introduces a hole.
- **W10** — the loom model uses a hand-copied mirror of the production seqlock. Added a reciprocal `LOCKSTEP-SEQLOCK-HVCHAN-001` marker in `seqlock.rs` and a CI-gated (loom lane) `include_str!` tripwire (`production_seqlock_edges_are_in_lockstep`) asserting the production source still carries the four ordering edges the mirror replicates — so drift on the one subtle concurrency primitive reds instead of silently diverging.

## Tests / gates
kirra-persistence + root-crate suites green (33 binaries incl. the register→policy→quote flow); the W10 tripwire passes locally under `--cfg loom`; the iceoryx2-spike compiles with the M7 static assert (arithmetic: 4+4+8+8+8+8+4+4 + `MAX_COMMAND_BYTES` = 48 + 128 = 176 = `size_of`, no padding); guardrails satisfied (no ratchet-tracked file over ceiling).

Remaining #1050 items (Sec5–Sec8, M4–M6, W6, S6/S7) follow / are documented in a final batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_