### PR TITLE
Low backlog PR3 (#1050): M6 explicit malformed discriminant + S6/S7/M4/M5 docs

### DIFF
--- a/crates/kirra-fleet-transport/src/transport.rs
+++ b/crates/kirra-fleet-transport/src/transport.rs
@@ -294,6 +294,20 @@ impl FleetSubscriber {
         counter: &RejectionCounter,
         now_ms: u64,
     ) -> Result<FederatedTrustReportV2, RejectReason> {
+        // M4 (#1050) — RESIDUAL, documented: the rate-limit gate runs AFTER
+        // `recv_async`, i.e. once a sample has already been pulled off the zenoh
+        // subscriber's FIFO. That is deliberate — it is where the per-sample
+        // `key_expr` (the bucket source) is available, and it cheaply drops a
+        // flood BEFORE the expensive Ed25519 verify + decode (the real DoS
+        // amplifier this shield targets). What it does NOT do is relieve
+        // raw-PACKET FIFO pressure: a burst still occupies the bounded
+        // `FifoChannelHandler` queue up to its capacity before this loop drains
+        // and drops it. That backpressure is bounded by the FIFO depth (the
+        // carrier is untrusted and lossy by design — an overrun drops samples,
+        // never blocks the safety path), so the residual is a throughput dip
+        // under flood, not a safety or memory-growth hazard. Tightening it would
+        // mean a smaller subscriber FIFO or a pre-recv admission hook — a zenoh
+        // config/API choice, tracked as the remainder of M4.
         let sample = self
             .subscriber
             .recv_async()

--- a/crates/kirra-ros2-adapter/src/contract_producer.rs
+++ b/crates/kirra-ros2-adapter/src/contract_producer.rs
@@ -155,6 +155,7 @@ mod tests {
             linear_velocity_mps,
             steering_angle_rad,
             stamp_ms: 0,
+            malformed: false,
         }
     }
 

--- a/crates/kirra-ros2-adapter/src/control_ingress.rs
+++ b/crates/kirra-ros2-adapter/src/control_ingress.rs
@@ -19,6 +19,15 @@ pub struct IngressControlCommand {
     /// Wall-clock ms from the ROS message stamp, or the receipt timestamp when
     /// the message carries no usable top-level stamp.
     pub stamp_ms: u64,
+    /// M6 (#1050): an EXPLICIT malformed/MRC discriminant. A parse failure sets
+    /// this `true`; the fast-loop consumer treats `malformed == true` as an
+    /// unconditional reject (→ MRC command) INDEPENDENT of the field magnitudes.
+    /// Previously `fail_closed_control_command` carried a `f64::MAX` poison pill
+    /// that merely *passed* `is_finite` and *relied on* the downstream conformance
+    /// check rejecting huge magnitudes — a fragile coupling. The discriminant makes
+    /// the fail-closed intent self-contained; the sentinel magnitudes are kept as
+    /// defense-in-depth (a value the envelope also rejects), not the sole signal.
+    pub malformed: bool,
 }
 
 /// Parse the minimal Autoware Control fields consumed by the fast-loop
@@ -45,18 +54,26 @@ pub fn parse_control_command_json(
         linear_velocity_mps: velocity,
         steering_angle_rad: steering,
         stamp_ms: stamp_ms_from_control(msg).unwrap_or(received_ms),
+        malformed: false,
     })
 }
 
-/// A finite command that the fast-loop conformance check must reject, causing
-/// publication of the configured MRC command. Used for malformed untyped input
-/// so parse failure fails closed instead of producing no gated output.
+/// A command the fast-loop conformance check must reject, causing publication of
+/// the configured MRC command. Used for malformed untyped input so parse failure
+/// fails closed instead of producing no gated output.
+///
+/// M6 (#1050): `malformed: true` is the AUTHORITATIVE reject signal — the
+/// consumer rejects on it regardless of the numeric fields. The `f64::MAX`
+/// magnitudes are retained as belt-and-suspenders (the envelope also rejects
+/// them), NOT as the primary mechanism, so the fail-closed behaviour no longer
+/// depends on a downstream check happening to reject huge-but-finite values.
 pub fn fail_closed_control_command(asset_id: &str, received_ms: u64) -> IngressControlCommand {
     IngressControlCommand {
         asset_id: asset_id.to_string(),
         linear_velocity_mps: f64::MAX,
         steering_angle_rad: f64::MAX,
         stamp_ms: received_ms,
+        malformed: true,
     }
 }
 
@@ -140,5 +157,24 @@ mod tests {
         assert!(cmd.steering_angle_rad.is_finite());
         assert_eq!(cmd.linear_velocity_mps, f64::MAX);
         assert_eq!(cmd.stamp_ms, 42);
+        // M6 (#1050): the AUTHORITATIVE reject signal — the consumer MRCs on this
+        // regardless of the (sentinel) magnitudes.
+        assert!(
+            cmd.malformed,
+            "a fail-closed command must be flagged malformed"
+        );
+    }
+
+    #[test]
+    fn a_successfully_parsed_command_is_not_flagged_malformed() {
+        let msg = serde_json::json!({
+            "longitudinal": { "velocity": 1.0 },
+            "lateral": { "steering_tire_angle": 0.0 },
+        });
+        let parsed = parse_control_command_json("ego", &msg, 7).expect("parse");
+        assert!(
+            !parsed.malformed,
+            "a well-formed command must not be flagged malformed"
+        );
     }
 }

--- a/crates/kirra-ros2-adapter/src/node.rs
+++ b/crates/kirra-ros2-adapter/src/node.rs
@@ -1122,6 +1122,24 @@ pub async fn run_adapter(
             // stamps + `promoted_at_ms` so `any_subscription_stale` / `is_stale`
             // measure a true elapsed age, immune to a wall-clock step.
             let now_ms = now_ms_fresh();
+            // M6 (#1050): an EXPLICITLY-malformed ingress command (a parse failure
+            // flagged the discriminant) is an unconditional MRC, decided here on
+            // the `malformed` flag — NOT on the sentinel magnitudes happening to
+            // trip the envelope in `check_command_conforms` downstream. Checked
+            // before the conformance path so the fail-closed behaviour is
+            // self-contained.
+            if in_cmd.malformed {
+                let out = mrc_command(in_cmd.asset_id.clone(), fast_state.config.max_decel_mps2);
+                if let Err(e) = fast_loop_out_tx.try_send(out) {
+                    tracing::error!(
+                        asset_id = %in_cmd.asset_id,
+                        error = ?e,
+                        "fast-loop output channel send failed (malformed path)",
+                    );
+                }
+                tracing::warn!(asset_id = %in_cmd.asset_id, "malformed_ingress_mrc");
+                continue;
+            }
             let cmd = IncomingControl {
                 velocity_mps: in_cmd.linear_velocity_mps,
                 steering_rad: in_cmd.steering_angle_rad,

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -92,6 +92,16 @@ const OCCLUSION_SPEED_TOL_MPS: f64 = 0.1;
 /// behind) that the reaction-time swerve term in `lateral_safe_distance` otherwise rejected
 /// (`COMPETITIVE_PLANNER_ANALYSIS §4`'s over-rejection) — while any real lateral closing is
 /// still caught. Small, so only genuine lateral stillness is admitted; fail-closed elsewhere.
+///
+/// S6 (#1050) — RESIDUAL: a slow-drift cut-in whose lateral speed is just under
+/// this eps (`|v_lat| < 0.1 m/s`) is NOT treated as a lateral cut-in for the
+/// current tick, so a very-slowly-developing cut-in is admitted momentarily. This
+/// is a bounded, self-correcting residual, not a hole: the check runs EVERY slow
+/// loop tick, so as the cut-in develops (lateral speed rises past the eps, or the
+/// object comes abreast/longitudinally-unsafe) it is caught on a subsequent tick,
+/// well before contact at these sub-0.1 m/s closing rates. Lowering the eff would
+/// re-introduce the over-rejection of genuinely-stationary same-lane objects the
+/// threshold exists to admit; the value is a reviewed safety/availability balance.
 const RSS_LATERAL_MOTION_EPS_MPS: f64 = 0.1;
 
 /// One predicted future position of an object at a time, in the world frame. A
@@ -962,6 +972,14 @@ fn outruns_assured_clear_distance(
         }
         let remaining = visibility_m - traveled;
         let cap = assured_clear_distance_speed_cap(remaining, brake_decel_mps2);
+        // S7 (#1050): the comparison is on the SIGNED speed, deliberately NOT
+        // `abs()`. The assured-clear-distance bound (RSS Rule 4) is a FORWARD
+        // visibility model — it caps how fast the ego may drive INTO the observed
+        // corridor ahead. A reverse command (`velocity_mps < 0`) is never capped
+        // by this bound (it is `< cap`), which is correct: driving backwards does
+        // not outrun forward visibility. The asymmetry is intentional and bounded
+        // to this forward model; reverse motion is governed by the other envelope
+        // checks, not the occlusion cap.
         if p.velocity_mps > cap + OCCLUSION_SPEED_TOL_MPS {
             return true;
         }

--- a/src/ros2_adapter.rs
+++ b/src/ros2_adapter.rs
@@ -35,6 +35,19 @@ impl Ros2Adapter {
         })
     }
 
+    /// Decode a `geometry_msgs/Twist` from a RAW little-endian body — six `f64`s
+    /// at fixed offsets 0/8/…/40, with NO CDR encapsulation.
+    ///
+    /// M5 (#1050) — NON-WIRE FIXTURE, not a DDS decoder. A real DDS-serialized
+    /// sample is CDR: it begins with a 4-byte encapsulation header (2-byte scheme
+    /// + 2-byte options) that selects big/little endianness, so the `f64` payload
+    /// starts at offset 4, not 0 — this reader would be 4 bytes off and mis-decode
+    /// every field. It exists ONLY to exercise the interlock/kinematic-clamp logic
+    /// against a hand-built fixed-layout buffer in tests; the production ingress is
+    /// the r2r-typed `~/input/*` path (`crates/kirra-ros2-adapter`), which lets the
+    /// RMW do CDR (de)serialization. Do NOT feed this a real DDS sample. Making it
+    /// wire-correct means parsing the encapsulation header + dispatching on
+    /// endianness — deferred until/unless a raw-CDR ingress is actually needed.
     pub fn decode_twist_frame(
         &self,
         raw_buffer: &[u8],


### PR DESCRIPTION
Third and final code slice of the #1050 low-severity hardening backlog. One behavioural fix (M6) plus four documentation-of-intent items that record residuals/asymmetries a reviewer flagged as "looks like a bug" but are deliberate.

## M6 — explicit `malformed` discriminant on `IngressControlCommand` (behavioural)
`crates/kirra-ros2-adapter/src/control_ingress.rs` + `node.rs`

Previously `fail_closed_control_command` fabricated an `f64::MAX` poison-pill magnitude and *relied on* the downstream conformance envelope rejecting huge-but-finite values — a fragile coupling (the sentinel merely passed `is_finite`). Added an explicit `pub malformed: bool` discriminant:
- `parse_control_command_json` sets `malformed: false`.
- `fail_closed_control_command` sets `malformed: true`.
- The fast-loop consumer (`node.rs`) treats `malformed == true` as an unconditional reject → MRC command, independent of the numeric fields. The sentinel magnitudes stay as belt-and-suspenders, no longer the sole signal.

Tests: `control_ingress` 5/5 (added `a_successfully_parsed_command_is_not_flagged_malformed`, extended the fail-closed test to assert the flag); `kirra-ros2-adapter` suite 8/8; `contract_producer` test helper updated for the new field.

## Documentation-of-intent (no behaviour change)
- **S7** (`crates/kirra-trajectory/src/validation.rs`) — documents the intentional no-`abs()` asymmetry at the occlusion speed gate (`velocity_mps > cap + OCCLUSION_SPEED_TOL_MPS`): reverse motion is not occlusion-limited, so the one-sided compare is correct, not a missing `abs()`.
- **S6** (`crates/kirra-trajectory/src/validation.rs`) — documents the `RSS_LATERAL_MOTION_EPS_MPS` residual (why the epsilon exists and why it is not a swept-away zero).
- **M5** (`src/ros2_adapter.rs`) — marks `decode_twist_frame` a NON-WIRE test fixture (a real DDS sample is CDR-encapsulated; the `f64` payload starts at offset 4, not 0). Production ingress is the r2r-typed path.
- **M4** (`crates/kirra-fleet-transport/src/transport.rs`) — documents the recv-then-gate FIFO residual in `recv_report`.

## Verification
- `cargo mutants -p kirra-trajectory --in-diff` (WP-08 gate): 2 mutants tested, 2 caught.
- `cargo test` green for kirra-trajectory (5+61), kirra-ros2-adapter (8), fleet-transport + root lib build clean.
- Quality guardrails: all satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_