### PR TITLE
A1 slice 3k (#1029): FleetGraph façade — lift nodes + dependency_graph off AppState

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ These have been blocked or reverted multiple times. Any submission that violates
 
 11. **All handlers use `State<Arc<ServiceState>>`**, not `State<Arc<AppState>>`. `ServiceState` has `app: Arc<AppState>` and `posture_cache: SharedPostureCache`. Accessing app state in handlers: `svc.app.*`.
 
-12. **SQLite writes go to disk before memory** (fail-closed ordering). `persist_and_insert_node` calls `save_node` then `nodes.insert` — never reverse this.
+12. **SQLite writes go to disk before memory** (fail-closed ordering). `persist_and_insert_node` calls `save_node` then `fleet.nodes.insert` — never reverse this. (ADR-0035 slice 3k: the map is `app.fleet.nodes`; the disk-before-memory ordering is unchanged.)
 
 13. **`no std::env::set_var` in multithreaded context**.
 
@@ -59,7 +59,7 @@ These have been blocked or reverted multiple times. Any submission that violates
 
 | Type | File | Notes |
 |------|------|-------|
-| `AppState` | `src/verifier.rs:169` | DashMap nodes/dependency_graph/challenges, Arc<Mutex<VerifierStore>>, mode_active AtomicBool, posture_tx |
+| `AppState` | `src/verifier.rs:169` | `fleet` (FleetGraph: DashMap nodes/dependency_graph — ADR-0035 slice 3k), `challenges` (ChallengeState), Arc<Mutex<VerifierStore>>, mode_active AtomicBool, posture_tx |
 | `RegisteredNode` | `src/verifier.rs:34` | `node_id`, `status: NodeTrustState`, `registered_at_ms`, `last_trust_update_ms`, `ak_public_pem`, `expected_pcr16_digest_hex` |
 | `ServiceState` | `src/posture_cache.rs` | Wraps `Arc<AppState>` + `SharedPostureCache`; is the axum router state |
 | `FleetPosture` | `src/verifier.rs` | `Nominal` / `Degraded` / `LockedOut` |
@@ -746,7 +746,7 @@ HD-maps) — KIRRA is the checker that bounds it. Scaffold: `deploy/autoware-iso
 - Calling `should_route_command` with 2 args — signature is `(cache, now_ms, command)`
 - Importing `FleetPosture` from `crate::gateway::posture_cache` — correct path is `crate::verifier::FleetPosture`
 - Using `node.trust_state` — the field is `node.status` on `RegisteredNode`
-- Using `app.deps` — the field is `app.dependency_graph` on `AppState`
+- Using `app.deps` — the field is `app.fleet.dependency_graph` on `AppState` (ADR-0035 slice 3k grouped `nodes` + `dependency_graph` onto `app.fleet`; likewise `app.fleet.nodes`)
 - Calling `app.store.method()` directly — store is `Arc<Mutex<VerifierStore>>`; use `app.store.lock().unwrap().method()`
 - Calling `cache.read().await` on `SharedPostureCache` in sync code — use `cache.blocking_read()` or restructure as async
 - Replacing `admin_routes` router structure without accounting for all existing protected routes

--- a/crates/kirra-persistence/src/nodes.rs
+++ b/crates/kirra-persistence/src/nodes.rs
@@ -341,7 +341,7 @@ impl VerifierStore {
     /// Cheap `COUNT(*)` (no row materialization, unlike `load_nodes`). Used by
     /// the posture engine's M-9 empty-live-set guard to distinguish a genuinely
     /// empty fleet (`0` here too) from a hydration/consistency gap (the in-memory
-    /// `app.nodes` is empty while the durable registry still holds nodes) — both
+    /// `app.fleet.nodes` is empty while the durable registry still holds nodes) — both
     /// fail closed, but the reason code differs for operators.
     pub fn count_nodes(&self) -> Result<i64> {
         self.conn

--- a/src/bin/kirra_verifier_service.rs
+++ b/src/bin/kirra_verifier_service.rs
@@ -681,10 +681,10 @@ async fn main() {
             }
         };
         for node in nodes {
-            app_state.nodes.insert(node.node_id.clone(), node);
+            app_state.fleet.nodes.insert(node.node_id.clone(), node);
         }
         for (node_id, deps) in dependencies {
-            app_state.dependency_graph.insert(node_id, deps);
+            app_state.fleet.dependency_graph.insert(node_id, deps);
         }
     }
 

--- a/src/bin/kirra_verifier_service/attestation.rs
+++ b/src/bin/kirra_verifier_service/attestation.rs
@@ -109,7 +109,7 @@ pub(crate) async fn issue_challenge(
         )
             .into_response();
     }
-    if !svc.app.nodes.contains_key(&node_id) {
+    if !svc.app.fleet.nodes.contains_key(&node_id) {
         return (
             StatusCode::NOT_FOUND,
             Json(json!({ "error": "node not registered" })),
@@ -198,7 +198,7 @@ pub(crate) async fn verify_attestation(
     // into the AK signature (`verify_attestation_proof_with_pcr16`); a node with no
     // expectation is unaffected. A hardware TPM *quote* (the deeper measured-boot
     // root) is enforced just below for a node whose policy requires it.
-    let (ak_public_pem, expected_pcr16) = match svc.app.nodes.get(&req.node_id) {
+    let (ak_public_pem, expected_pcr16) = match svc.app.fleet.nodes.get(&req.node_id) {
         Some(node) => (
             node.ak_public_pem.clone(),
             node.expected_pcr16_digest_hex.clone(),
@@ -384,7 +384,7 @@ pub(crate) async fn get_node_status(
     State(svc): State<Arc<ServiceState>>,
     Path(node_id): Path<String>,
 ) -> impl IntoResponse {
-    match svc.app.nodes.get(&node_id) {
+    match svc.app.fleet.nodes.get(&node_id) {
         Some(node) => {
             let status = match &node.status {
                 NodeTrustState::Trusted => "Trusted",

--- a/src/bin/kirra_verifier_service/attestation_nonce_handler_tests.rs
+++ b/src/bin/kirra_verifier_service/attestation_nonce_handler_tests.rs
@@ -245,7 +245,7 @@ async fn signed_adoption_report_is_attested_and_forgery_rejected() {
 /// measured-boot PCR16 digest.
 fn svc_with_pcr16_node(ak_pem: String, expected_pcr16: &str) -> Arc<ServiceState> {
     let svc = svc_with_registered_node(ak_pem);
-    let existing = svc.app.nodes.get(NODE).map(|n| n.clone()).unwrap();
+    let existing = svc.app.fleet.nodes.get(NODE).map(|n| n.clone()).unwrap();
     svc.app
         .persist_and_insert_node(RegisteredNode {
             expected_pcr16_digest_hex: Some(expected_pcr16.to_string()),
@@ -334,7 +334,7 @@ async fn attestation_pcr16_match_succeeds_absent_and_mismatch_are_refused() {
     assert_eq!(ok, StatusCode::OK, "matching bound PCR16 attests");
     assert!(
         matches!(
-            svc.app.nodes.get(NODE).unwrap().status,
+            svc.app.fleet.nodes.get(NODE).unwrap().status,
             NodeTrustState::Trusted
         ),
         "node becomes Trusted after a valid PCR16-bound proof"
@@ -424,7 +424,7 @@ async fn tpm_quote_required_but_absent_is_refused() {
     );
     assert!(
         matches!(
-            svc.app.nodes.get(NODE).unwrap().status,
+            svc.app.fleet.nodes.get(NODE).unwrap().status,
             NodeTrustState::Unknown
         ),
         "node is not trusted without the required quote"
@@ -454,7 +454,7 @@ async fn tpm_quote_valid_attests_node_trusted() {
     assert_eq!(status, StatusCode::OK, "valid quote attests");
     assert!(
         matches!(
-            svc.app.nodes.get(NODE).unwrap().status,
+            svc.app.fleet.nodes.get(NODE).unwrap().status,
             NodeTrustState::Trusted
         ),
         "node becomes Trusted after a valid hardware quote"
@@ -522,7 +522,7 @@ async fn tpm_quote_policy_absent_is_back_compat() {
     );
     assert!(
         matches!(
-            svc.app.nodes.get(NODE).unwrap().status,
+            svc.app.fleet.nodes.get(NODE).unwrap().status,
             NodeTrustState::Trusted
         ),
         "node attests via the back-compat self-report path"
@@ -738,7 +738,7 @@ async fn register_quote_required_without_material_is_400() {
     );
 
     // Neither node was minted.
-    assert!(!svc.app.nodes.contains_key("n1") && !svc.app.nodes.contains_key("n2"));
+    assert!(!svc.app.fleet.nodes.contains_key("n1") && !svc.app.fleet.nodes.contains_key("n2"));
 }
 
 /// WP-16 end-to-end: ENROLL a node through the real `register_node` handler with
@@ -804,7 +804,7 @@ async fn enroll_via_register_handler_then_quote_attests_end_to_end() {
     );
     assert!(
         matches!(
-            svc.app.nodes.get(NODE).unwrap().status,
+            svc.app.fleet.nodes.get(NODE).unwrap().status,
             NodeTrustState::Trusted
         ),
         "the enrolled measured-boot node becomes Trusted after a valid quote"
@@ -843,7 +843,7 @@ async fn failed_proof_does_not_burn_the_nonce_then_valid_proof_succeeds() {
     );
     assert!(
         matches!(
-            svc.app.nodes.get(NODE).unwrap().status,
+            svc.app.fleet.nodes.get(NODE).unwrap().status,
             NodeTrustState::Trusted
         ),
         "node becomes Trusted after a valid proof"

--- a/src/bin/kirra_verifier_service/console.rs
+++ b/src/bin/kirra_verifier_service/console.rs
@@ -206,7 +206,7 @@ pub(crate) async fn console_runtime(State(svc): State<Arc<ServiceState>>) -> imp
             .load(std::sync::atomic::Ordering::SeqCst),
         "last_recalc_ms": last_recalc_ms,
         "posture_cache_ttl_ms": POSTURE_CACHE_TTL_MS,
-        "total_nodes": svc.app.nodes.len(),
+        "total_nodes": svc.app.fleet.nodes.len(),
         "fabric_assets": svc.fabric_router.fabric_state().total_assets,
         "fabric_denial_rate": svc.fabric_telemetry.summary().fabric_denial_rate,
         "audit_entries": audit_entries,
@@ -358,7 +358,7 @@ pub(crate) async fn console_sites(State(svc): State<Arc<ServiceState>>) -> impl 
     let mut sites: BTreeMap<String, (u64, u64, u64, u64)> = BTreeMap::new();
     let mut unassigned: u64 = 0;
 
-    for entry in svc.app.nodes.iter() {
+    for entry in svc.app.fleet.nodes.iter() {
         let node = entry.value();
         let bucket = match &node.status {
             NodeTrustState::Trusted => 0,
@@ -404,7 +404,7 @@ pub(crate) async fn console_versions(State(svc): State<Arc<ServiceState>>) -> im
     let mut unknown: u64 = 0;
     let mut total: u64 = 0;
 
-    for entry in svc.app.nodes.iter() {
+    for entry in svc.app.fleet.nodes.iter() {
         total += 1;
         match &entry.value().firmware_version {
             Some(v) => *versions.entry(v.clone()).or_insert(0) += 1,

--- a/src/bin/kirra_verifier_service/fleet.rs
+++ b/src/bin/kirra_verifier_service/fleet.rs
@@ -356,6 +356,7 @@ pub(crate) async fn report_node_artifact(
         }
         let ak = svc
             .app
+            .fleet
             .nodes
             .get(&node_id)
             .and_then(|n| n.ak_public_pem.clone());
@@ -609,7 +610,7 @@ pub(crate) async fn handle_sensor_fault_report(
         )
             .into_response();
     }
-    if !svc.app.nodes.contains_key(&req.source_node_id) {
+    if !svc.app.fleet.nodes.contains_key(&req.source_node_id) {
         return (
             StatusCode::NOT_FOUND,
             Json(json!({ "error": "node not registered" })),
@@ -728,6 +729,7 @@ pub(crate) async fn handle_sensor_fault_report(
 
     let currently_untrusted = svc
         .app
+        .fleet
         .nodes
         .get(&req.source_node_id)
         .map(|n| matches!(n.status, NodeTrustState::Untrusted(_)))
@@ -875,7 +877,7 @@ pub(crate) async fn handle_register_av_asset(
         )
             .into_response();
     }
-    if !svc.app.nodes.contains_key(&req.node_id) {
+    if !svc.app.fleet.nodes.contains_key(&req.node_id) {
         return (
             StatusCode::NOT_FOUND,
             Json(json!({ "error": "node not registered" })),

--- a/src/bin/kirra_verifier_service/industrial.rs
+++ b/src/bin/kirra_verifier_service/industrial.rs
@@ -379,7 +379,7 @@ pub(crate) async fn evaluate_canopen_adapter(
         let resolved = global_resolve(eval.node_id);
         let registered = resolved
             .as_deref()
-            .map(|n| svc.app.nodes.contains_key(n))
+            .map(|n| svc.app.fleet.nodes.contains_key(n))
             .unwrap_or(false);
         Some(classify_nmt_offline(eval.node_id, resolved, registered))
     } else {

--- a/src/fleet_graph.rs
+++ b/src/fleet_graph.rs
@@ -1,0 +1,55 @@
+//! ADR-0035 Stage 3 (slice 3k) — the in-memory fleet trust graph, lifted off the
+//! `AppState` god-object into a cohesive field façade (the 3c/3e/3f/3g/3h/3i/3j
+//! pattern), byte-identical.
+//!
+//! Unlike the peripheral plumbing slices (writer handles, observability counters),
+//! these two DashMaps are the CORE fleet-legitimacy state the gray/black DAG
+//! traversal reads TOGETHER on every posture recalculation, so they earn a named
+//! home rather than hanging loose off the god-object:
+//!
+//! - `nodes` — the registered-node registry (`node_id` → [`RegisteredNode`]:
+//!   trust state, AK PEM, PCR16). The in-memory mirror of the durable `nodes`
+//!   table; hydrated on boot and kept write-through (disk before memory,
+//!   INVARIANT #12).
+//! - `dependency_graph` — the fleet dependency edges (`node_id` →
+//!   `Vec<dependent_node_id>`). The adjacency list the
+//!   `kirra_safety_authority::dag::recursive_calculate` gray/black traversal walks.
+//!
+//! Both are `DashMap`s (lock-free interior mutability, shared via the outer
+//! `Arc<AppState>`), so the move is a pure relocation — no `&mut self`, no ordering
+//! change, no behaviour change. Grouped in a ROOT-crate leaf (not
+//! `kirra-safety-authority`: the traversal ALGORITHM already lives there per ADR-0035
+//! Stage 3d; this is the mutable state it reads, which stays with the control plane).
+//! Embedded on `AppState` as `app.fleet`; reached as `app.fleet.nodes` /
+//! `app.fleet.dependency_graph`. The persist-then-insert ordering (INVARIANT #12) and
+//! the C2 (#1031) shard-locked read-modify-write are unchanged — they operate on
+//! `self.fleet.nodes` exactly as they did on `self.nodes`.
+
+use dashmap::DashMap;
+
+use kirra_core::RegisteredNode;
+
+/// The in-memory fleet trust graph (ADR-0035 slice 3k): the registered-node
+/// registry + the dependency adjacency list the DAG traversal reads together.
+#[derive(Debug, Default)]
+pub struct FleetGraph {
+    /// Registered-node registry: `node_id` → [`RegisteredNode`]. In-memory mirror
+    /// of the durable `nodes` table; write-through (disk before memory,
+    /// INVARIANT #12). Field semantics UNCHANGED from the prior `app.nodes`.
+    pub nodes: DashMap<String, RegisteredNode>,
+    /// Fleet dependency edges: `node_id` → `Vec<dependent_node_id>`. The adjacency
+    /// list the gray/black DAG traversal walks. Field semantics UNCHANGED from the
+    /// prior `app.dependency_graph`.
+    pub dependency_graph: DashMap<String, Vec<String>>,
+}
+
+impl FleetGraph {
+    /// Construct an empty fleet graph — byte-identical to the prior two inline
+    /// `DashMap::new()` field initializers in `AppState::new`.
+    pub fn new() -> Self {
+        Self {
+            nodes: DashMap::new(),
+            dependency_graph: DashMap::new(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ pub mod challenge_rate_limit; // Bug 3 — rate limit for the public attestation
 pub mod challenge_state; // ADR-0035 slice 3i — volatile challenge/nonce field façade (app.challenges)
 pub mod execution_manager; // WP-20/G-11 declarative task manifest + startup dependency DAG
 pub mod fabric;
+pub mod fleet_graph; // ADR-0035 slice 3k — in-memory fleet trust graph façade (app.fleet)
 pub mod kinematics_sim;
 pub mod lease; // WP-19/G-21 lease-based failover timing model (pure)
 pub mod observability_state; // ADR-0035 slice 3j — fleet-observability registries façade (app.observability)

--- a/src/posture_engine.rs
+++ b/src/posture_engine.rs
@@ -108,16 +108,16 @@ pub fn recalculate_and_broadcast(app: &Arc<AppState>, cache: &SharedPostureCache
     // Step 1: Traverse the full DAG for every registered node.
     //
     // B1 (deadlock hazard): snapshot the node ids FIRST, releasing the
-    // `app.nodes` shard guards, THEN traverse. The previous form held a
+    // `app.fleet.nodes` shard guards, THEN traverse. The previous form held a
     // `nodes.iter()` shard read-guard across each `calculate_posture()` call,
-    // which re-locks `app.nodes` / `app.dependency_graph` inside
+    // which re-locks `app.fleet.nodes` / `app.fleet.dependency_graph` inside
     // `recursive_calculate`. A re-entrant `get()` on the SAME shard while a writer
     // is queued on it can self-deadlock (DashMap's per-shard RwLock is
     // writer-preferring) and hang the safety engine. Collecting the keys to an
     // owned Vec drops every iterator guard before any traversal begins.
     // SAFETY: SG-RED-2 — snapshot iteration prevents nested DashMap locks.
     // SAFETY: SG-RED-3 — posture DAG recalculation must be deadlock-free.
-    let node_ids: Vec<String> = app.nodes.iter().map(|e| e.key().clone()).collect();
+    let node_ids: Vec<String> = app.fleet.nodes.iter().map(|e| e.key().clone()).collect();
     // P3: ONE shared `black` memo across the whole-fleet traversal. Each node's
     // fully-evaluated posture is root-independent, so a node depended on by K
     // others is traversed once and black-hit by the rest — O(N·(N+E)) → ~O(N+E).
@@ -747,7 +747,7 @@ mod posture_engine_tests {
             .with(|s| s.save_node(&registered_trusted_node("orphan")))
             .unwrap();
         assert!(
-            app.nodes.is_empty(),
+            app.fleet.nodes.is_empty(),
             "in-memory live set must be empty for this case"
         );
 
@@ -1011,7 +1011,7 @@ mod posture_engine_tests {
 
     fn insert_node(app: &AppState, id: &str, status: NodeTrustState) {
         use crate::verifier::RegisteredNode;
-        app.nodes.insert(
+        app.fleet.nodes.insert(
             id.to_string(),
             RegisteredNode {
                 node_id: id.to_string(),

--- a/src/recovery_hysteresis.rs
+++ b/src/recovery_hysteresis.rs
@@ -290,7 +290,7 @@ pub async fn handle_sensor_fault_report(
     State(svc): State<Arc<ServiceState>>,
     Json(report): Json<SensorFaultReport>,
 ) -> Result<StatusCode, StatusCode> {
-    if !svc.app.nodes.contains_key(&report.source_node_id) {
+    if !svc.app.fleet.nodes.contains_key(&report.source_node_id) {
         return Err(StatusCode::NOT_FOUND);
     }
 
@@ -314,7 +314,7 @@ pub async fn handle_sensor_fault_report(
         let _ = svc.app.store.reset_recovery_streak(&report.source_node_id, ts);
 
         // Memory mutation after disk write.
-        if let Some(mut node) = svc.app.nodes.get_mut(&report.source_node_id) {
+        if let Some(mut node) = svc.app.fleet.nodes.get_mut(&report.source_node_id) {
             node.trust_state = NodeTrustState::Untrusted(reason.to_string());
         }
 
@@ -327,7 +327,7 @@ pub async fn handle_sensor_fault_report(
         ).await;
 
     } else {
-        let currently_untrusted = svc.app.nodes
+        let currently_untrusted = svc.app.fleet.nodes
             .get(&report.source_node_id)
             .map(|n| matches!(n.trust_state, NodeTrustState::Untrusted(_)))
             .unwrap_or(false);
@@ -340,7 +340,7 @@ pub async fn handle_sensor_fault_report(
                         streak   = streak,
                         "Hysteresis satisfied — re-trusting node"
                     );
-                    if let Some(mut node) = svc.app.nodes.get_mut(&report.source_node_id) {
+                    if let Some(mut node) = svc.app.fleet.nodes.get_mut(&report.source_node_id) {
                         node.trust_state = NodeTrustState::Trusted;
                     }
                     let _ = svc.app.store.reset_recovery_streak(&report.source_node_id, ts);

--- a/src/scenario_runner.rs
+++ b/src/scenario_runner.rs
@@ -301,7 +301,7 @@ impl ScenarioRunner {
                                 .store
                                 .with(|store| store.touch_av_telemetry_timestamp(node_id, ts));
 
-                            if let Some(mut node) = self.app.nodes.get_mut(node_id) {
+                            if let Some(mut node) = self.app.fleet.nodes.get_mut(node_id) {
                                 node.status = NodeTrustState::Untrusted(reason.to_string());
                             }
                             needs_recalc = true;
@@ -309,6 +309,7 @@ impl ScenarioRunner {
                             // Health report — check if node is currently untrusted
                             let currently_untrusted = self
                                 .app
+                                .fleet
                                 .nodes
                                 .get(node_id)
                                 .map(|n| matches!(n.status, NodeTrustState::Untrusted(_)))
@@ -329,7 +330,9 @@ impl ScenarioRunner {
                                             virtual_ms = ts,
                                             "Scenario: recovery confirmed"
                                         );
-                                        if let Some(mut node) = self.app.nodes.get_mut(node_id) {
+                                        if let Some(mut node) =
+                                            self.app.fleet.nodes.get_mut(node_id)
+                                        {
                                             node.status = NodeTrustState::Trusted;
                                         }
                                         let _ = self
@@ -382,7 +385,7 @@ impl ScenarioRunner {
                             .app
                             .store
                             .with(|store| store.reset_recovery_streak(node_id, ts));
-                        if let Some(mut node) = self.app.nodes.get_mut(node_id) {
+                        if let Some(mut node) = self.app.fleet.nodes.get_mut(node_id) {
                             node.status = NodeTrustState::Untrusted(reason.clone());
                         }
                         needs_recalc = true;
@@ -477,7 +480,7 @@ async fn evaluate_assertion(
             }
         }
 
-        PostureAssertion::NodeTrustIs(node_id, expected) => match app.nodes.get(node_id) {
+        PostureAssertion::NodeTrustIs(node_id, expected) => match app.fleet.nodes.get(node_id) {
             Some(node) => {
                 let ok = node.status == *expected;
                 let desc = format!(
@@ -492,7 +495,7 @@ async fn evaluate_assertion(
             ),
         },
 
-        PostureAssertion::NodeIsUntrusted(node_id) => match app.nodes.get(node_id) {
+        PostureAssertion::NodeIsUntrusted(node_id) => match app.fleet.nodes.get(node_id) {
             Some(node) => {
                 let ok = matches!(node.status, NodeTrustState::Untrusted(_));
                 let desc = format!("NodeIsUntrusted({node_id}): got {:?}", node.status);
@@ -501,7 +504,7 @@ async fn evaluate_assertion(
             None => (false, format!("NodeIsUntrusted({node_id}): node not found")),
         },
 
-        PostureAssertion::NodeIsTrusted(node_id) => match app.nodes.get(node_id) {
+        PostureAssertion::NodeIsTrusted(node_id) => match app.fleet.nodes.get(node_id) {
             Some(node) => {
                 let ok = matches!(node.status, NodeTrustState::Trusted);
                 let desc = format!("NodeIsTrusted({node_id}): got {:?}", node.status);

--- a/src/telemetry_watchdog.rs
+++ b/src/telemetry_watchdog.rs
@@ -106,7 +106,7 @@ pub(crate) struct WatchdogNodeEntry {
 ///   3. At `AV_TELEMETRY_WARN_MS` silence: logs a structured warning
 ///   4. At `AV_TELEMETRY_TIMEOUT_MS` silence:
 ///      a. Persists node `Untrusted("TELEMETRY_TIMEOUT")` to SQLite
-///      b. Updates AppState.nodes via the same disk-first helper
+///      b. Updates AppState.fleet.nodes via the same disk-first helper
 ///      c. Logs a structured error
 ///      d. Sends `PostureRecalcTrigger::WatchdogTimeout` to the posture engine channel
 ///      (NOT calling recalculate_and_broadcast directly — routes through the
@@ -383,7 +383,8 @@ fn watchdog_sweep_once_inner(
                             .with_read(|store| store.get_last_telemetry_timestamp(node_id))
                             .unwrap_or(0);
                         let monitoring_started_ms = if last_seen == 0 {
-                            app.nodes
+                            app.fleet
+                                .nodes
                                 .get(node_id)
                                 .map(|n| n.registered_at_ms)
                                 .unwrap_or(now)
@@ -469,6 +470,7 @@ fn watchdog_sweep_once_inner(
             // Already-timed-out check avoids repeated triggers for the
             // same ongoing silence.
             let already_timed_out = app
+                .fleet
                 .nodes
                 .get(&entry.node_id)
                 .map(|n| n.status == NodeTrustState::Untrusted("TELEMETRY_TIMEOUT".to_string()))
@@ -513,7 +515,7 @@ fn watchdog_sweep_once_inner(
                     Ok(false) => {
                         tracing::error!(
                             node_id = %entry.node_id,
-                            "Watchdog: timed-out node missing from AppState.nodes — \
+                            "Watchdog: timed-out node missing from AppState.fleet.nodes — \
                              enqueueing graph recalc (fail-closed)"
                         );
                         if let Err(e) =
@@ -816,7 +818,7 @@ mod watchdog_di_tests {
     use tokio::sync::mpsc;
 
     fn insert_trusted_node(app: &Arc<AppState>, node_id: &str, registered_at_ms: u64) {
-        app.nodes.insert(
+        app.fleet.nodes.insert(
             node_id.to_string(),
             RegisteredNode {
                 node_id: node_id.to_string(),
@@ -881,7 +883,7 @@ mod watchdog_di_tests {
         );
 
         // (a) node was mutated to Untrusted("TELEMETRY_TIMEOUT").
-        let status = app.nodes.get("lidar_front").unwrap().status.clone();
+        let status = app.fleet.nodes.get("lidar_front").unwrap().status.clone();
         assert_eq!(
             status,
             NodeTrustState::Untrusted("TELEMETRY_TIMEOUT".to_string()),
@@ -973,7 +975,7 @@ mod watchdog_di_tests {
 
         // And the dead-man's switch must still fire.
         assert_eq!(
-            app.nodes.get("lidar_front").unwrap().status,
+            app.fleet.nodes.get("lidar_front").unwrap().status,
             NodeTrustState::Untrusted("TELEMETRY_TIMEOUT".to_string()),
             "watchdog must still mark a silent node Untrusted despite a poisoned store lock"
         );
@@ -1009,7 +1011,7 @@ mod watchdog_di_tests {
 
         assert!(
             matches!(
-                app.nodes.get("imu_main").map(|n| n.status.clone()),
+                app.fleet.nodes.get("imu_main").map(|n| n.status.clone()),
                 Some(NodeTrustState::Trusted)
             ),
             "node must remain Trusted while in warn band (silence < TIMEOUT)"
@@ -1101,7 +1103,7 @@ mod watchdog_di_tests {
         );
 
         assert_eq!(
-            app.nodes.get("camera_front").unwrap().status,
+            app.fleet.nodes.get("camera_front").unwrap().status,
             NodeTrustState::Untrusted("TELEMETRY_TIMEOUT".to_string()),
             "a registered node that never reports must not be skipped forever"
         );
@@ -1167,7 +1169,7 @@ mod watchdog_di_tests {
         // Node is untrusted, streak is cleared, and the telemetry timestamp is
         // PRESERVED (the timeout did not invent a fresh last-seen).
         assert_eq!(
-            app.nodes.get("lidar_front").unwrap().status,
+            app.fleet.nodes.get("lidar_front").unwrap().status,
             NodeTrustState::Untrusted("TELEMETRY_TIMEOUT".to_string()),
         );
         let (count, start) = app
@@ -1419,7 +1421,7 @@ mod watchdog_di_tests {
             "the offloaded sweep must enqueue a WatchdogTimeout trigger; got {trigger:?}"
         );
         assert_eq!(
-            app.nodes.get("lidar_front").unwrap().status,
+            app.fleet.nodes.get("lidar_front").unwrap().status,
             NodeTrustState::Untrusted("TELEMETRY_TIMEOUT".to_string()),
             "the offloaded sweep must mark the silent node Untrusted"
         );
@@ -1509,7 +1511,7 @@ mod sg_003_cert_tests {
     fn app_with_trusted_node(node_id: &str, last_seen_ms: u64) -> Arc<AppState> {
         let store = VerifierStore::new(":memory:").expect("memory store");
         let app = Arc::new(AppState::new(store, VerifierOperationMode::Active));
-        app.nodes.insert(
+        app.fleet.nodes.insert(
             node_id.to_string(),
             RegisteredNode {
                 node_id: node_id.to_string(),
@@ -1555,7 +1557,7 @@ mod sg_003_cert_tests {
         watchdog_sweep_once(&app, &tx, clock.as_ref(), &mut nh, &mut last_refresh);
 
         assert_eq!(
-            app.nodes.get("lidar_front").unwrap().status.clone(),
+            app.fleet.nodes.get("lidar_front").unwrap().status.clone(),
             NodeTrustState::Untrusted("TELEMETRY_TIMEOUT".to_string()),
             "SG-003: a node silent ≥ AV_TELEMETRY_TIMEOUT_MS must be marked Untrusted(TELEMETRY_TIMEOUT)"
         );
@@ -1579,7 +1581,7 @@ mod sg_003_cert_tests {
         watchdog_sweep_once(&app, &tx, below.as_ref(), &mut nh, &mut last_refresh);
         assert!(
             matches!(
-                app.nodes.get("imu_main").map(|n| n.status.clone()),
+                app.fleet.nodes.get("imu_main").map(|n| n.status.clone()),
                 Some(NodeTrustState::Trusted)
             ),
             "SG-003: must NOT detect a timeout before AV_TELEMETRY_TIMEOUT_MS of silence"
@@ -1600,7 +1602,7 @@ mod sg_003_cert_tests {
             "SG-003: worst-case detection latency must be ≤ TIMEOUT + one SWEEP"
         );
         assert_eq!(
-            app.nodes.get("imu_main").unwrap().status.clone(),
+            app.fleet.nodes.get("imu_main").unwrap().status.clone(),
             NodeTrustState::Untrusted("TELEMETRY_TIMEOUT".to_string()),
             "SG-003: node must be detected within TIMEOUT + one sweep"
         );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -239,7 +239,7 @@ fn test_startup_sentinel_trusted_with_live_swtpm() {
 // --- Verifier engine tests ---------------------------------------------------
 
 fn make_node(state: &AppState, id: &str, status: NodeTrustState) {
-    state.nodes.insert(
+    state.fleet.nodes.insert(
         id.to_string(),
         RegisteredNode {
             node_id: id.to_string(),
@@ -268,12 +268,15 @@ fn test_posture_diamond_dag_not_misidentified_as_cycle() {
         make_node(&state, id, NodeTrustState::Trusted);
     }
     state
+        .fleet
         .dependency_graph
         .insert("A".to_string(), vec!["B".to_string(), "C".to_string()]);
     state
+        .fleet
         .dependency_graph
         .insert("B".to_string(), vec!["D".to_string()]);
     state
+        .fleet
         .dependency_graph
         .insert("C".to_string(), vec!["D".to_string()]);
 
@@ -311,6 +314,7 @@ fn test_posture_deep_acyclic_chain_is_not_depth_locked_out() {
         // Chain edges A_i → A_{i+1}.
         for i in 0..N - 1 {
             state
+                .fleet
                 .dependency_graph
                 .insert(ids[i].clone(), vec![ids[i + 1].clone()]);
         }
@@ -322,7 +326,7 @@ fn test_posture_deep_acyclic_chain_is_not_depth_locked_out() {
         } else {
             vec![ids[1].clone(), ids[N - 1].clone()]
         };
-        state.dependency_graph.insert(ids[0].clone(), a0_deps);
+        state.fleet.dependency_graph.insert(ids[0].clone(), a0_deps);
 
         let posture = state.calculate_posture("A0");
         assert_eq!(posture.propagated_status, FleetPosture::Nominal,
@@ -345,9 +349,11 @@ fn test_posture_cycle_returns_locked_out_with_diagnostic_tag() {
         make_node(&state, id, NodeTrustState::Trusted);
     }
     state
+        .fleet
         .dependency_graph
         .insert("A".to_string(), vec!["B".to_string()]);
     state
+        .fleet
         .dependency_graph
         .insert("B".to_string(), vec!["A".to_string()]);
 
@@ -381,6 +387,7 @@ fn test_posture_locked_out_dep_propagates_locked_out_not_degraded() {
         NodeTrustState::Untrusted("compromised".to_string()),
     );
     state
+        .fleet
         .dependency_graph
         .insert("parent".to_string(), vec!["dep".to_string()]);
 

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -2,7 +2,6 @@
 
 use crate::security::constant_time_compare;
 use crate::verifier_store::VerifierStore;
-use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -289,8 +288,16 @@ impl TransportConfig {
 pub use kirra_safety_authority::RssRecoveryStreak;
 
 pub struct AppState {
-    pub nodes: DashMap<String, RegisteredNode>,
-    pub dependency_graph: DashMap<String, Vec<String>>,
+    /// ADR-0035 Stage 3 (slice 3k): the in-memory fleet trust graph — the
+    /// registered-node registry (`nodes`) and the dependency adjacency list
+    /// (`dependency_graph`) the gray/black DAG traversal reads TOGETHER — grouped
+    /// VERBATIM onto `crate::fleet_graph::FleetGraph` (per-field semantics and field
+    /// names UNCHANGED, documented on the struct). Reached as `app.fleet.nodes` /
+    /// `app.fleet.dependency_graph`; both are `DashMap` (lock-free interior
+    /// mutability), so the move is pure relocation — no `&mut self`, no ordering
+    /// change. The persist-then-insert ordering (INVARIANT #12) and the C2 (#1031)
+    /// shard-locked RMW operate on `self.fleet.nodes` exactly as before.
+    pub fleet: crate::fleet_graph::FleetGraph,
     /// ADR-0035 Stage 3 (slice 3i): the volatile challenge/nonce state — the
     /// attestation-challenge map (`pending_challenges`, INVARIANT #5), the
     /// operator-clearance map (`pending_clearance_challenges`), and the Bug 3
@@ -375,8 +382,9 @@ impl AppState {
         // value before any request lands. Unreadable → 0 (gate falls through).
         let initial_db_epoch = store.current_epoch().unwrap_or(0);
         Self {
-            nodes: DashMap::new(),
-            dependency_graph: DashMap::new(),
+            // ADR-0035 Stage 3k: the node registry + dependency adjacency list now
+            // live on FleetGraph; identical initial state (two empty DashMaps).
+            fleet: crate::fleet_graph::FleetGraph::new(),
             // ADR-0035 Stage 3i: the two nonce maps + the challenge rate limiter
             // now live on ChallengeState; identical initial state (empty maps +
             // clock-free-seeded limiter).
@@ -464,11 +472,11 @@ impl AppState {
     // leave disk=Untrusted / memory=Trusted → a restart hydrating from disk would
     // resurrect revoked trust the running system believed gone. Disk before
     // memory within the lock (invariant #12). No store closure ever touches
-    // `self.nodes`, so holding the shard lock across `store.with` cannot deadlock.
+    // `self.fleet.nodes`, so holding the shard lock across `store.with` cannot deadlock.
     #[allow(clippy::result_unit_err)]
     pub fn persist_and_insert_node(&self, node: RegisteredNode) -> Result<(), ()> {
         use dashmap::mapref::entry::Entry;
-        match self.nodes.entry(node.node_id.clone()) {
+        match self.fleet.nodes.entry(node.node_id.clone()) {
             Entry::Occupied(mut occ) => {
                 self.persist_node_row(&node)?;
                 occ.insert(node);
@@ -532,7 +540,7 @@ impl AppState {
                     .map_err(|_| ())
             }
         };
-        match self.nodes.entry(node.node_id.clone()) {
+        match self.fleet.nodes.entry(node.node_id.clone()) {
             Entry::Occupied(mut occ) => {
                 self.store.with(write)?;
                 occ.insert(node);
@@ -562,7 +570,7 @@ impl AppState {
         F: FnOnce(&RegisteredNode) -> RegisteredNode,
     {
         use dashmap::mapref::entry::Entry;
-        match self.nodes.entry(node_id.to_string()) {
+        match self.fleet.nodes.entry(node_id.to_string()) {
             Entry::Occupied(mut occ) => {
                 let updated = f(occ.get());
                 self.store
@@ -618,7 +626,9 @@ impl AppState {
                     .map_err(|_| ())
             }
         })?;
-        self.dependency_graph.insert(node_id.to_string(), deps);
+        self.fleet
+            .dependency_graph
+            .insert(node_id.to_string(), deps);
         Ok(())
     }
 
@@ -626,7 +636,11 @@ impl AppState {
     /// traversal in `kirra_safety_authority::dag` (ADR-0035 slice 3d) — the
     /// algorithm is byte-identical and never mocked (INVARIANT #4).
     pub fn calculate_posture(&self, node_id: &str) -> FleetNodePosture {
-        kirra_safety_authority::dag::calculate_posture(&self.nodes, &self.dependency_graph, node_id)
+        kirra_safety_authority::dag::calculate_posture(
+            &self.fleet.nodes,
+            &self.fleet.dependency_graph,
+            node_id,
+        )
     }
 
     /// Whole-fleet-shared-memo posture (see `dag::calculate_posture_memoized`).
@@ -636,8 +650,8 @@ impl AppState {
         black: &mut HashMap<Arc<str>, Arc<FleetNodePosture>>,
     ) -> FleetNodePosture {
         kirra_safety_authority::dag::calculate_posture_memoized(
-            &self.nodes,
-            &self.dependency_graph,
+            &self.fleet.nodes,
+            &self.fleet.dependency_graph,
             node_id,
             black,
         )
@@ -646,7 +660,10 @@ impl AppState {
     /// Whole-fleet per-node posture in ONE pass with a shared memo
     /// (see `dag::calculate_fleet_posture`). Snapshot-then-traverse, deadlock-free.
     pub fn calculate_fleet_posture(&self) -> Vec<FleetNodePosture> {
-        kirra_safety_authority::dag::calculate_fleet_posture(&self.nodes, &self.dependency_graph)
+        kirra_safety_authority::dag::calculate_fleet_posture(
+            &self.fleet.nodes,
+            &self.fleet.dependency_graph,
+        )
     }
     /// Consume a challenge nonce. Returns false if nonce is absent, expired, or mismatched.
     pub fn consume_challenge(&self, node_id: &str, nonce: u64, now_ms: u64) -> bool {
@@ -975,7 +992,7 @@ mod mark_node_untrusted_tests {
         assert!(updated, "an existing node is updated");
 
         assert!(matches!(
-            app.nodes.get("robot-01").unwrap().status,
+            app.fleet.nodes.get("robot-01").unwrap().status,
             NodeTrustState::Untrusted(_)
         ));
         assert_eq!(
@@ -1011,7 +1028,7 @@ mod mark_node_untrusted_tests {
         app.ha_fence.held_epoch.store(2, SeqCst);
         app.persist_and_insert_node(trusted_node("holder")).unwrap();
         app.persist_and_insert_deps("holder", vec![]).unwrap();
-        assert!(app.nodes.get("holder").is_some());
+        assert!(app.fleet.nodes.get("holder").is_some());
 
         // Superseded primary (held == 1 < durable == 2) is rejected, fail-closed.
         app.ha_fence.held_epoch.store(1, SeqCst);
@@ -1020,7 +1037,7 @@ mod mark_node_untrusted_tests {
             "a superseded primary's registration must fail closed"
         );
         assert!(
-            app.nodes.get("stale").is_none(),
+            app.fleet.nodes.get("stale").is_none(),
             "the in-memory map must not be mutated when the durable write is fenced (disk before memory)"
         );
         assert!(
@@ -1223,7 +1240,7 @@ mod shared_memo_equivalence_tests {
     /// memo equals resolving the whole fleet through ONE shared memo (in id-sorted
     /// order). This pins the P3/P5 change as result-preserving.
     fn assert_shared_equals_per_call(app: &AppState) {
-        let mut ids: Vec<String> = app.nodes.iter().map(|e| e.key().clone()).collect();
+        let mut ids: Vec<String> = app.fleet.nodes.iter().map(|e| e.key().clone()).collect();
         ids.sort();
         let mut shared: HashMap<Arc<str>, Arc<FleetNodePosture>> = HashMap::new();
         for id in &ids {
@@ -1364,10 +1381,12 @@ mod shared_memo_equivalence_tests {
         // straight into the in-memory graph (the edges intentionally reference
         // unregistered ids, which a persisted FK path would not allow).
         const N: usize = 20;
-        app.dependency_graph
+        app.fleet
+            .dependency_graph
             .insert("a".to_string(), vec!["u1".to_string()]);
         for i in 1..N {
-            app.dependency_graph
+            app.fleet
+                .dependency_graph
                 .insert(format!("u{i}"), vec![format!("u{}", i + 1)]);
         }
 

--- a/tests/generation_persistence.rs
+++ b/tests/generation_persistence.rs
@@ -37,7 +37,7 @@ fn app_on(path: &std::path::Path) -> Arc<AppState> {
         site: None,
         firmware_version: None,
     };
-    app.nodes.insert(node.node_id.clone(), node);
+    app.fleet.nodes.insert(node.node_id.clone(), node);
     app
 }
 

--- a/tests/governor_closes_loop_proof.rs
+++ b/tests/governor_closes_loop_proof.rs
@@ -340,11 +340,11 @@ fn register_av_infra(app: &Arc<AppState>) {
             let _ = store.register_av_subsystem_meta(id, ty, hw, 0.70, 0);
         }
     });
-    app.dependency_graph.insert(
+    app.fleet.dependency_graph.insert(
         "perception_fusion".to_string(),
         vec!["lidar_front".to_string(), "camera_front".to_string()],
     );
-    app.dependency_graph.insert(
+    app.fleet.dependency_graph.insert(
         "trajectory_planner".to_string(),
         vec!["perception_fusion".to_string()],
     );
@@ -354,7 +354,7 @@ fn register_av_infra(app: &Arc<AppState>) {
         "perception_fusion",
         "trajectory_planner",
     ] {
-        app.nodes.insert(
+        app.fleet.nodes.insert(
             id.to_string(),
             RegisteredNode {
                 node_id: id.to_string(),

--- a/tests/node_trust_atomicity.rs
+++ b/tests/node_trust_atomicity.rs
@@ -56,7 +56,10 @@ fn update_node_atomic_is_a_noop_on_an_absent_node() {
     let app = app();
     let r = app.update_node_atomic("ghost", |n| n.clone());
     assert_eq!(r, Ok(false));
-    assert!(app.nodes.get("ghost").is_none(), "no memory row created");
+    assert!(
+        app.fleet.nodes.get("ghost").is_none(),
+        "no memory row created"
+    );
     assert!(disk_status(&app, "ghost").is_none(), "no disk row created");
 }
 
@@ -69,7 +72,13 @@ fn a_downgrade_writes_disk_and_memory_together() {
 
     assert_eq!(app.mark_node_untrusted("n1", "FAULT", 42), Ok(true));
 
-    let mem = app.nodes.get("n1").expect("memory row").status.clone();
+    let mem = app
+        .fleet
+        .nodes
+        .get("n1")
+        .expect("memory row")
+        .status
+        .clone();
     assert!(
         matches!(mem, NodeTrustState::Untrusted(_)),
         "memory reflects the downgrade"
@@ -110,7 +119,13 @@ fn concurrent_downgrade_and_retrust_keep_disk_and_memory_consistent() {
         h.join().expect("thread");
     }
 
-    let mem = app.nodes.get("n1").expect("memory row").status.clone();
+    let mem = app
+        .fleet
+        .nodes
+        .get("n1")
+        .expect("memory row")
+        .status
+        .clone();
     let disk = disk_status(&app, "n1").expect("disk row");
     assert_eq!(
         std::mem::discriminant(&mem),

--- a/tests/postureenginetests.rs
+++ b/tests/postureenginetests.rs
@@ -40,20 +40,22 @@ async fn posture_recalc_remains_bounded_under_dashmap_contention() {
     let app = app();
     let cache: SharedPostureCache = Arc::new(std::sync::RwLock::new(None));
 
-    app.nodes.insert("root".into(), node("root"));
-    app.nodes.insert("dep_a".into(), node("dep_a"));
-    app.dependency_graph
+    app.fleet.nodes.insert("root".into(), node("root"));
+    app.fleet.nodes.insert("dep_a".into(), node("dep_a"));
+    app.fleet
+        .dependency_graph
         .insert("root".into(), vec!["dep_a".into()]);
 
     let writer_app = Arc::clone(&app);
     let writer = tokio::spawn(async move {
         for i in 0..250u32 {
             let temp = format!("temp-{i}");
-            writer_app.nodes.insert(temp.clone(), node(&temp));
+            writer_app.fleet.nodes.insert(temp.clone(), node(&temp));
             writer_app
+                .fleet
                 .dependency_graph
                 .insert("root".into(), vec!["dep_a".into(), temp.clone()]);
-            writer_app.nodes.remove(temp.as_str());
+            writer_app.fleet.nodes.remove(temp.as_str());
             tokio::task::yield_now().await;
         }
     });
@@ -128,7 +130,9 @@ async fn posture_dag_recalc_completes_under_dashmap_contention() {
         let id = format!("n{i}");
         app.persist_and_insert_node(node(&id)).expect("insert node");
         if i > 0 {
-            app.dependency_graph.insert(id, vec![format!("n{}", i - 1)]);
+            app.fleet
+                .dependency_graph
+                .insert(id, vec![format!("n{}", i - 1)]);
         }
     }
 
@@ -137,10 +141,11 @@ async fn posture_dag_recalc_completes_under_dashmap_contention() {
         for i in 0..200usize {
             let id = format!("w{}", i % 24);
             app_w
+                .fleet
                 .dependency_graph
                 .insert(id.clone(), vec![format!("n{}", i % 24)]);
             if i % 3 == 0 {
-                app_w.dependency_graph.remove(&id);
+                app_w.fleet.dependency_graph.remove(&id);
             }
             tokio::task::yield_now().await;
         }

--- a/tests/rss_simulation.rs
+++ b/tests/rss_simulation.rs
@@ -234,7 +234,7 @@ fn test_locked_out_hard_stop_dominates_rss_gate() {
     )));
 
     // Register an untrusted node — DAG drives fleet posture to LockedOut.
-    app.nodes.insert(
+    app.fleet.nodes.insert(
         "adversarial_node".to_string(),
         RegisteredNode {
             node_id: "adversarial_node".to_string(),

--- a/tests/temporal_scenario_tests.rs
+++ b/tests/temporal_scenario_tests.rs
@@ -72,12 +72,12 @@ async fn build_av_test_infrastructure() -> (Arc<AppState>, SharedPostureCache, A
 
     // Set up dependency graph edges (mirrors POST /fleet/dependencies)
     // perception_fusion depends on lidar_front and camera_front
-    app.dependency_graph.insert(
+    app.fleet.dependency_graph.insert(
         "perception_fusion".to_string(),
         vec!["lidar_front".to_string(), "camera_front".to_string()],
     );
     // trajectory_planner depends on perception_fusion
-    app.dependency_graph.insert(
+    app.fleet.dependency_graph.insert(
         "trajectory_planner".to_string(),
         vec!["perception_fusion".to_string()],
     );
@@ -90,7 +90,7 @@ async fn build_av_test_infrastructure() -> (Arc<AppState>, SharedPostureCache, A
         "perception_fusion",
         "trajectory_planner",
     ] {
-        app.nodes.insert(
+        app.fleet.nodes.insert(
             node_id.to_string(),
             kirra_verifier::verifier::RegisteredNode {
                 node_id: node_id.to_string(),


### PR DESCRIPTION
The core cluster of the ADR-0035 AppState de-monolith (#1029, A1). Continues the field-façade pattern (3c/3e/3f/3g/3h/3i/3j).

## What moved
The two in-memory DashMaps the gray/black DAG traversal reads **together** — `nodes` (registered-node registry: trust state, AK PEM, PCR16) and `dependency_graph` (dependency adjacency list) — move off the `AppState` god-object into a cohesive `FleetGraph` façade at `src/fleet_graph.rs`, reached as `app.fleet.nodes` / `app.fleet.dependency_graph`.

Unlike the peripheral plumbing slices (writer handles, observability counters), this is the **central** fleet-legitimacy state — which is exactly why it earns a named home rather than hanging loose off the god-object.

## Why it's a safe, byte-identical relocation
- Both are `DashMap`s (lock-free interior mutability, shared via the outer `Arc<AppState>`) — no `&mut self`, no ordering change.
- The persist-then-insert ordering (**INVARIANT #12**) and the C2 (#1031) shard-locked read-modify-write operate on `self.fleet.nodes` exactly as before.
- The DAG delegators pass `&self.fleet.nodes` / `&self.fleet.dependency_graph` into the already-relocated `kirra_safety_authority::dag` traversal (Stage 3d) — unchanged.
- Grouped in a **root leaf** (not `kirra-safety-authority`: the traversal *algorithm* already lives there; this is the mutable state the control plane owns). No new dependency edge.

## The rename
~80 mechanical `.nodes` / `.dependency_graph` → `.fleet.*` sites across 12 `src/` + 6 `tests/` files. The one collision — `summary.nodes` in `kirra_console_demo_seed.rs` (a `CampaignSummary` count field, not AppState) — was audited as the **only** non-AppState receiver and excluded. No `.nodes()` methods exist. Removed the now-unused `dashmap::DashMap` import from `verifier.rs`.

## Docs
CLAUDE.md updated for honesty: the `AppState` row, **INVARIANT #12** wording (`fleet.nodes.insert`), and the `app.deps` common-mistake line now point at the `app.fleet.*` paths; the `kirra-persistence` `count_nodes` doc-prose reference likewise.

## Verification
- `cargo test --lib`: 583 passed.
- Integration: `node_trust_atomicity`, `temporal_scenario_tests`, `generation_persistence`, `rss_simulation`, `governor_closes_loop_proof`, `postureenginetests`, `posture_gate_integration`, `two_node_rollout` — all green.
- `cargo fmt --check` clean; quality guardrails satisfied (`verifier.rs` + the bin stay under their ceilings — no bump needed).
- No `crates/kirra-trajectory/src` changes → WP-08 mutation gate has no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_