### PR TITLE
A1 shim-deprecation (#1029): re-export shim ratchet + deprecation policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1095,6 +1095,16 @@ jobs:
         # the DD review asked for after finding six unwired "DONE" cores.
         # See ci/check_orphan_cores.py + ci/orphan_cores_baseline.json.
         run: python3 ci/check_orphan_cores.py
+      - name: Re-export shim ratchet (ADR-0035 shim deprecation, #1029)
+        # The de-monolith left thin `pub use <lean-crate>` re-export shims in src/
+        # for path back-compat. #1029 requires treating them as a DEPRECATION with
+        # a removal milestone (v2.0.0), not a permanent layer. This ratchet freezes
+        # the set: a NEW untracked shim fails (no silent indirection accretion), and
+        # the count only moves DOWN. Self-test first (non-vacuity of the detector).
+        # See ci/check_reexport_shims.py + ci/reexport_shims_baseline.json.
+        run: |
+          python3 ci/check_reexport_shims.py --self-test
+          python3 ci/check_reexport_shims.py
       - name: Mick actuation fence (no path from the intent layer to the motors)
         # The doer-checker thesis, structurally: kirra-mick and the sidecar
         # binaries must have NO dependency route to the release-token mint,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,14 @@ These have been blocked or reverted multiple times. Any submission that violates
 
 ### Module Map
 
+**Re-export shims are DEPRECATED, not permanent (#1029).** The `— re-export shim
+→ <crate>` modules below are pure `pub use` back-compat surfaces left by the
+de-monolith; ADR-0035 §"Shim deprecation" schedules them for removal at the next
+MAJOR (v2.0.0). The `ci/check_reexport_shims.py` ratchet (guardrails CI job,
+inventory in `ci/reexport_shims_baseline.json`) FREEZES the set: a NEW `pub use`
+shim fails CI, and the count only moves DOWN. Do not add a new shim without
+recording it in the baseline (or, preferably, wire the canonical path directly).
+
 ```
 src/
 ├── verifier.rs               — AppState, FleetPosture, DAG traversal, TransportIdentityConfig

--- a/ci/check_reexport_shims.py
+++ b/ci/check_reexport_shims.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""ADR-0035 re-export shim ratchet (#1029 A1 — the shim-deprecation front).
+
+The de-monolith relocated cohesive modules into lean leaf crates and left a thin
+`pub use <lean-crate>::*;` re-export shim behind in `src/` so every existing
+`crate::<mod>::*` / `kirra_verifier::<mod>::*` path resolves unchanged. That is a
+DELIBERATE transition aid — but the review (#1029) flagged the shims as "pure
+indirection cost" that must be treated as a DEPRECATION with a removal milestone,
+NOT a permanent layer.
+
+This guard makes that policy enforceable. It:
+
+  1. Discovers every re-export shim in `src/` (a module file whose only code
+     statements are `use` / `pub use` — zero item definitions).
+  2. Compares the discovered set to the tracked inventory
+     (`ci/reexport_shims_baseline.json`).
+  3. FAILS if a NEW, untracked shim appears (so new indirection can't accrete
+     silently — a new shim is a conscious decision that must be recorded here with
+     its canonical target, or, better, avoided) or if the count exceeds the
+     ceiling.
+  4. Notes (does not fail) when a tracked shim is GONE — a removal win; the dev
+     tightens the baseline to lock it (the ratchet only moves down).
+
+Removal milestone: the whole set is scheduled for deletion at the next MAJOR
+(`remove_in` in the baseline), when internal callers repoint to the canonical
+crate path. See docs/adr/0035-verifier-crate-decomposition.md §Shim deprecation.
+
+Usage:
+  python3 ci/check_reexport_shims.py            # gate (CI)
+  python3 ci/check_reexport_shims.py --list     # print the discovered shim set
+  python3 ci/check_reexport_shims.py --self-test # prove the detector is non-vacuous
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = REPO_ROOT / "src"
+BASELINE_PATH = REPO_ROOT / "ci" / "reexport_shims_baseline.json"
+
+# A statement that, if present as a top-level item, means the file carries real
+# code and is therefore NOT a pure re-export shim.
+_DEFINITION_RE = re.compile(
+    r"^(pub(\s*\([^)]*\))?\s+)?"
+    r"(fn|struct|enum|trait|impl|const|static|type|mod|union|macro_rules!)\b"
+)
+
+
+def _strip_inline_comment(line: str) -> str:
+    """Drop a trailing `// ...` comment. Rust `use` paths use `::`, never `//`,
+    and shim files hold no string literals, so a `//` not preceded by `:` starts a
+    comment."""
+    return re.sub(r"(?<!:)//.*$", "", line)
+
+
+def is_reexport_shim(path: Path) -> bool:
+    """True iff `path` is a pure `pub use` re-export shim (>=1 `pub use`, and every
+    code statement is a `use`/`pub use` — no item definitions)."""
+    text = path.read_text(encoding="utf-8")
+    # Remove block comments (shims use line comments, but be robust).
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+
+    code_lines: list[str] = []
+    for raw in text.splitlines():
+        s = _strip_inline_comment(raw).strip()
+        if not s:
+            continue
+        if s.startswith("//"):  # // /// //! doc/line comments
+            continue
+        if s.startswith("#!") or s.startswith("#["):  # attributes (inner/outer)
+            continue
+        code_lines.append(s)
+
+    if not code_lines:
+        return False
+
+    # A definition keyword anywhere disqualifies immediately (cheap + precise).
+    for line in code_lines:
+        if _DEFINITION_RE.match(line):
+            return False
+
+    # Every `;`-terminated statement must be a use / pub use.
+    joined = " ".join(code_lines)
+    stmts = [x.strip() for x in joined.split(";") if x.strip()]
+    if not stmts:
+        return False
+
+    has_pub_use = False
+    for st in stmts:
+        if st.startswith("pub use"):
+            has_pub_use = True
+        elif st.startswith("use "):
+            continue  # a private `use` supporting the re-export
+        else:
+            return False
+    return has_pub_use
+
+
+def discover_shims() -> list[str]:
+    """Repo-relative POSIX paths of every re-export shim under src/, sorted."""
+    shims = []
+    for path in SRC_ROOT.rglob("*.rs"):
+        if is_reexport_shim(path):
+            shims.append(path.relative_to(REPO_ROOT).as_posix())
+    return sorted(shims)
+
+
+def _self_test() -> int:
+    """Prove the detector distinguishes a shim from a real module (non-vacuity)."""
+    import tempfile
+
+    ok = True
+    with tempfile.TemporaryDirectory() as d:
+        shim = Path(d) / "shim.rs"
+        shim.write_text("// doc\npub use other_crate::thing::*;\n")
+        real = Path(d) / "real.rs"
+        real.write_text("// doc\npub use x::Y;\npub fn f() -> u8 { 0 }\n")
+        multiline = Path(d) / "ml.rs"
+        multiline.write_text("pub use a::b::{\n    One,\n    Two,\n};\n")
+        if not is_reexport_shim(shim):
+            print("SELF-TEST FAIL: a pure re-export was not detected as a shim")
+            ok = False
+        if is_reexport_shim(real):
+            print("SELF-TEST FAIL: a module with a `fn` was misdetected as a shim")
+            ok = False
+        if not is_reexport_shim(multiline):
+            print("SELF-TEST FAIL: a multi-line `pub use {..}` was not detected")
+            ok = False
+    if ok:
+        print("self-test OK: shim detector is non-vacuous")
+        return 0
+    return 1
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        rc = _self_test()
+        if rc != 0:
+            return rc
+
+    discovered = discover_shims()
+
+    if "--list" in argv:
+        print(f"{len(discovered)} re-export shims discovered under src/:")
+        for s in discovered:
+            print(f"  {s}")
+        return 0
+
+    if not BASELINE_PATH.exists():
+        print(f"ERROR: baseline missing: {BASELINE_PATH}")
+        print("Run with --list and record the set in the baseline.")
+        return 2
+
+    baseline = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    tracked = set(baseline.get("shims", {}).keys())
+    max_shims = int(baseline.get("max_shims", 0))
+    remove_in = baseline.get("remove_in", "?")
+    discovered_set = set(discovered)
+
+    violations: list[str] = []
+
+    new_shims = sorted(discovered_set - tracked)
+    for s in new_shims:
+        violations.append(
+            f"- NEW untracked re-export shim: {s}\n"
+            f"    A new `pub use` shim is fresh indirection. Prefer NOT adding one;\n"
+            f"    if it is a deliberate transition aid, record it in\n"
+            f"    ci/reexport_shims_baseline.json with its canonical target crate."
+        )
+
+    if len(discovered) > max_shims:
+        violations.append(
+            f"- shim count {len(discovered)} > ceiling {max_shims} "
+            f"(the ratchet only moves DOWN — shims are deprecated, remove_in={remove_in})"
+        )
+
+    # A tracked shim that vanished is a removal WIN — note it and ask to tighten.
+    removed = sorted(tracked - discovered_set)
+    for s in removed:
+        print(
+            f"NOTE: tracked shim no longer present: {s}\n"
+            f"      Removal win — drop it from ci/reexport_shims_baseline.json and "
+            f"lower max_shims to lock the gain."
+        )
+
+    print(
+        f"\nre-export shims: {len(discovered)} present "
+        f"(ceiling {max_shims}, scheduled for removal at v{remove_in})."
+    )
+
+    if violations:
+        print("\n=== Re-export shim ratchet violations ===")
+        for v in violations:
+            print(v)
+        return 1
+
+    print("Re-export shim ratchet satisfied (no new indirection).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/ci/reexport_shims_baseline.json
+++ b/ci/reexport_shims_baseline.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "ADR-0035 re-export shim inventory + deprecation policy (#1029 A1 — the shim-deprecation front). Each entry is a src/ module that is now a PURE `pub use <canonical>` re-export left in place ONLY for path back-compat after the de-monolith relocated its contents into a lean leaf crate (so every existing `crate::<mod>::*` / `kirra_verifier::<mod>::*` path resolves unchanged). Per the #1029 review these are DEPRECATED indirection, NOT a permanent layer: scheduled for removal at the next MAJOR (`remove_in`), when internal callers repoint to the canonical crate path and the shim module is deleted. This ratchet (ci/check_reexport_shims.py) FREEZES the set: a NEW untracked shim fails CI (new indirection must be a conscious, recorded decision — or, better, avoided), and `max_shims` only moves DOWN. Removing a shim = migrate its callers to the canonical path, delete the module + its `pub mod` line, drop the entry here, and lower max_shims to lock the gain. NOTE: src/gateway/interceptor.rs is an INTERNAL import-surface shim (re-exports crate::posture_cache + kirra_core for policy_layer), not a leaf-crate relocation, but is tracked here so the shim set as a whole cannot grow.",
+  "remove_in": "2.0.0",
+  "max_shims": 17,
+  "shims": {
+    "src/adapters.rs": "kirra_industrial::adapters",
+    "src/attestation.rs": "kirra_safety_authority::attestation",
+    "src/capture.rs": "kirra_core::capture",
+    "src/fabric/asset.rs": "kirra_fabric_types::asset",
+    "src/federation.rs": "kirra_fleet_types::federation",
+    "src/federation_reconciliation.rs": "kirra_fleet_types::federation_reconciliation",
+    "src/gateway/cmd_vel.rs": "kirra_policy_types::cmd_vel",
+    "src/gateway/containment.rs": "kirra_core::containment",
+    "src/gateway/interceptor.rs": "crate::posture_cache (internal import surface)",
+    "src/gateway/kinematics_contract.rs": "kirra_core::kinematics_contract",
+    "src/gateway/perception_monitor.rs": "kirra_core::perception_monitor",
+    "src/governor_guard.rs": "kirra_core::governor_guard",
+    "src/kinematics_sim.rs": "kirra_core::kinematics_sim",
+    "src/ota_campaign.rs": "kirra_ota_campaign",
+    "src/posture_tracker.rs": "kirra_core::posture_tracker",
+    "src/protocol_adapter.rs": "kirra_industrial::protocol_adapter",
+    "src/verifier_store.rs": "kirra_persistence"
+  }
+}

--- a/docs/adr/0035-verifier-crate-decomposition.md
+++ b/docs/adr/0035-verifier-crate-decomposition.md
@@ -391,3 +391,29 @@ No behaviour change: byte-identical verdicts, the SAME audit chain bytes, the sa
 fail-closed semantics and one-transaction atomicity. The power-loss, loom, and
 deterministic-replay suites gate this; any tempting semantic change is a separate
 ADR/PR.
+
+## Shim deprecation (#1029 — the shim-deprecation front)
+
+The `pub use` re-export shims (Constraint 2) are a DELIBERATE transition aid, but
+they are **deprecated indirection, not a permanent layer**. The #1029 review
+flagged them as "pure indirection cost" — every relocated type keeps two
+names/paths, which muddies the safety-case boundary. The policy:
+
+- **Freeze the set.** `ci/reexport_shims_baseline.json` is the tracked inventory
+  (each shim → its canonical crate). `ci/check_reexport_shims.py` (guardrails CI
+  job) discovers every pure `pub use` re-export module under `src/` and FAILS if a
+  NEW untracked shim appears or the count exceeds the ceiling. New indirection
+  cannot accrete silently — a new shim is a conscious, recorded decision (or,
+  preferably, avoided). The ceiling only moves DOWN.
+- **Removal milestone: the next MAJOR (v2.0.0).** Deleting a shim is a
+  path-breaking change for `crate::<mod>::*` / `kirra_verifier::<mod>::*`
+  consumers, so it is gated to a MAJOR bump per `docs/VERSIONING_POLICY.md`. Until
+  then the shims stay (back-compat) but cannot grow.
+- **How to remove one** (at the MAJOR, or opportunistically for an internal-only
+  shim): migrate its callers to the canonical crate path, delete the module + its
+  `pub mod` line in `lib.rs`, drop the entry from the baseline, and lower
+  `max_shims` to lock the gain. The ratchet's "removal win" note flags a
+  baseline entry whose file has already vanished.
+
+This converts the shims from an open-ended layer into a tracked, shrinking one —
+the "deprecation with a removal milestone" the review asked for.


### PR DESCRIPTION
Opens the **shim-deprecation front** of #1029 (A1). The de-monolith left 17 thin `pub use <lean-crate>` re-export shims in `src/` for path back-compat. The review flagged these as "pure indirection cost" that should be a **deprecation with a removal milestone, not a permanent layer.** This makes that policy enforceable — without touching back-compat (actual removal is gated to the next MAJOR).

## What this adds
- **`ci/check_reexport_shims.py`** — discovers every pure `pub use` re-export module under `src/` (a file whose only code statements are `use`/`pub use` — zero item definitions) and ratchets it against the inventory:
  - a **NEW untracked shim FAILS CI** → new indirection can't accrete silently;
  - the count (`max_shims`) only moves **DOWN**;
  - a vanished tracked shim is noted as a removal win (tighten the baseline).
  - `--self-test` proves the detector is non-vacuous (distinguishes a shim from a real module, handles multi-line `pub use {..}`).
- **`ci/reexport_shims_baseline.json`** — the tracked inventory (each of the 17 shims → its canonical crate) + `remove_in: 2.0.0` + `max_shims: 17`.
- **CI wiring** — a step in the guardrails job (self-test then gate), beside the orphan-core ratchet.
- **Policy docs** — a new ADR-0035 "Shim deprecation" section (freeze the set; remove at v2.0.0; the exact remove-one procedure) + a CLAUDE.md Module Map note.

## The 17 tracked shims
`verifier_store`, `ota_campaign`, `protocol_adapter`, `adapters`, `attestation`, `capture`, `federation`, `federation_reconciliation`, `governor_guard`, `kinematics_sim`, `posture_tracker`, `fabric/asset`, `gateway/{cmd_vel,containment,interceptor,kinematics_contract,perception_monitor}` — each a `pub use` of its canonical leaf crate.

## Why a ratchet (not `#[deprecated]`)
A `#[deprecated]` on a glob re-export would fire warnings on every internal caller and break the `-D warnings` lanes — it presupposes the caller migration that only the MAJOR bump authorizes. The ratchet instead freezes the set now and gives a tracked, shrinking path to removal, which is exactly the recommended disposition.

## Verification
- Ratchet passes at 17; a probe shim was confirmed to trip it (exit 1) and pass again after removal.
- `--self-test` green; existing quality guardrails still pass; `ci.yml` YAML validates.
- **Pure CI/docs slice — no Rust source changes** (no build / WCET / mutation-gate impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_