### PR TITLE
website: add Vision page — strategic framing, plus grid/overflow fixes

### DIFF
--- a/website/404.html
+++ b/website/404.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -129,6 +130,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/_src/pages/index.mjs
+++ b/website/_src/pages/index.mjs
@@ -552,6 +552,31 @@ export const body = `
 
     <hr class="rule">
 
+    <!-- ═══════════ WHERE THIS FITS ═══════════ -->
+    <section id="vision" aria-labelledby="h-vision">
+      <div class="container">
+        <div class="grid grid--2" style="align-items:center;gap:48px">
+          <div class="section-head" style="margin-bottom:0">
+            <p class="eyebrow" data-reveal>The world of tomorrow</p>
+            <h2 id="h-vision" data-reveal>Every machine gets a model.<br>Every model needs an envelope.</h2>
+            <p class="lede" data-reveal>Capability is outrunning verification, and regulation is converging on
+            runtime assurance. The durable layer in that future isn't any particular AI stack — it's the provable
+            envelope between intent and actuation, engineered as a safety element for integration into certified
+            platforms.</p>
+            <p data-reveal style="margin-top:18px"><a class="card__more" href="vision.html">Where Kirra fits <span aria-hidden="true">→</span></a></p>
+          </div>
+          <div style="display:grid;gap:10px" data-reveal aria-hidden="true">
+            <div class="card" style="padding:16px 22px"><p class="mono dim" style="font-size:0.8rem">AI doer stacks — unverifiable, swappable</p></div>
+            <div class="card" style="padding:16px 22px;border-color:var(--accent-line);background:var(--accent-soft)"><p class="mono" style="font-size:0.8rem;color:var(--accent)">KIRRA — the governed layer (SEooC)</p></div>
+            <div class="card" style="padding:16px 22px"><p class="mono dim" style="font-size:0.8rem">certified OS / hypervisor — QNX 8.0 target</p></div>
+            <div class="card" style="padding:16px 22px"><p class="mono dim" style="font-size:0.8rem">safety-rated silicon — vendor-neutral inference</p></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
     <!-- ═══════════ FIELD NOTES ═══════════ -->
     <section id="notes" aria-labelledby="h-notes">
       <div class="container">

--- a/website/_src/pages/vision.mjs
+++ b/website/_src/pages/vision.mjs
@@ -1,0 +1,164 @@
+import { ev, evRow, pageHero, ctaBand, LIVE, PLANNED } from "../template.mjs";
+
+export const meta = {
+  slug: "vision",
+  title: "Vision",
+  desc: "Why runtime governance is the missing layer of the autonomy stack: the embodied-AI wave, the regulatory shift to runtime assurance, and Kirra's place between certified platforms and unverifiable AI.",
+};
+
+const stackSvg = `
+<svg viewBox="0 0 960 380" role="img" aria-labelledby="stT stD">
+  <title id="stT">The autonomy stack of tomorrow</title>
+  <desc id="stD">Four layers: AI doer stacks at the top; the Kirra governed layer beneath them; certified operating systems and hypervisors below that; and safety-rated silicon at the base. Kirra is the layer that makes the unverifiable top compatible with the certified bottom.</desc>
+  <g>
+    <rect class="dg-box" x="80" y="16" width="800" height="70" rx="12"/>
+    <text class="dg-label" x="104" y="46">AI doer stacks — capable, fast-moving, unverifiable</text>
+    <text class="dg-sub" x="104" y="68">Autoware-class AV stacks · learned planners · LLM agents · whatever comes next</text>
+  </g>
+  <g>
+    <rect class="dg-box dg-box--accent" x="80" y="106" width="800" height="86" rx="12"/>
+    <text class="dg-label" x="104" y="138">KIRRA — the governed layer</text>
+    <text class="dg-mono" x="104" y="160">typed intents · posture · kinematic envelopes · RSS · signed release</text>
+    <text class="dg-sub" x="104" y="180">an SEooC: a safety element designed to be integrated, not a stack that competes</text>
+  </g>
+  <g>
+    <rect class="dg-box" x="80" y="212" width="800" height="70" rx="12"/>
+    <text class="dg-label" x="104" y="242">Certified OS &amp; hypervisors</text>
+    <text class="dg-sub" x="104" y="264">QNX 8.0 for Safety (the recorded deployment target) · safety-certified RTOS class</text>
+  </g>
+  <g>
+    <rect class="dg-box" x="80" y="302" width="800" height="62" rx="12"/>
+    <text class="dg-label" x="104" y="330">Safety-rated silicon</text>
+    <text class="dg-sub" x="104" y="352">DRIVE-class targets · Jetson Orin today · vendor-neutral inference: ONNX / OpenVINO / TensorRT, Qualcomm QNN &amp; TI TIDL on the roadmap</text>
+  </g>
+  <path class="dg-edge dg-edge--deny" d="M480 86 L 480 104"/>
+  <path class="dg-edge dg-edge--flow" d="M480 192 L 480 210"/>
+  <path class="dg-edge dg-edge--flow" d="M480 282 L 480 300"/>
+  <text class="dg-mono" x="500" y="100">bounded, never trusted</text>
+</svg>`;
+
+export const body = `
+${pageHero({
+  eyebrow: "Vision",
+  title: "The missing layer of<br>the autonomy stack.",
+  lede: "Every machine that moves is getting a model. Models are getting more capable and less inspectable at the same time — and no amount of training makes a neural network certifiable. The industry's honest answer is an old one, rebuilt for the AI era: don't verify the driver; verify the envelope. That layer is what Kirra is.",
+})}
+
+    <section aria-labelledby="h-need">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>The need</p>
+          <h2 id="h-need" data-reveal>Three forces, one gap</h2>
+          <p class="lede" data-reveal>The next decade of robotics is already legible: capability is outrunning
+          verification, regulation is converging on runtime assurance, and compute is consolidating onto
+          certified platforms. All three point at the same missing piece.</p>
+        </div>
+        <div class="grid grid--3">
+          <div class="card" data-reveal>
+            <h3>AI is outrunning verification</h3>
+            <p>Foundation models are entering planners, and language is becoming a robot interface. You cannot
+            test a distribution into being safe — but you can bound what any of it is permitted to do. Kirra's
+            safety case is deliberately <em>doer-invariant</em>: it holds whether the doer is geometric code,
+            a learned policy, or an LLM, which means it also holds for the doer nobody has built yet.</p>
+            ${evRow("docs/adr/0020-doer-invariant-safety-case.md", "docs/llm_integration_guide.md")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Regulation is converging on runtime assurance</h3>
+            <p>UL 4600 safety cases, SOTIF, ASTM F3269 run-time assurance, and the emerging AI-safety standards
+            (ISO/IEC TR 5469, ISO/PAS 8800) all circle the same architecture: an untrusted complex function
+            behind a verifiable monitor. Kirra maintains mappings to each of these — drafted in the open,
+            versioned with the code — so the compliance story grows with the product instead of after it.</p>
+            ${evRow("docs/safety/UL4600_SAFETY_CASE.md", "docs/safety/ASTM_F3269_RTA_MAPPING.md", "docs/safety/ISO_IEC_TR_5469_MAPPING.md")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Platforms need a governed layer</h3>
+            <p>Certified hypervisors and safety-rated silicon solve isolation and compute — they don't decide
+            whether a command is safe. Kirra is built to be that decision layer on exactly those platforms:
+            the deployment decision of record is a QNX 8.0 safety partition, and the inference substrate is
+            vendor-neutral by design.</p>
+            ${evRow("docs/adr/0032-governor-deployment-platform.md", "parko/README.md")}
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-stack">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Where it fits</p>
+          <h2 id="h-stack" data-reveal>Between certified platforms<br>and unverifiable AI</h2>
+          <p class="lede" data-reveal>Kirra doesn't compete with the layers above or below it. It's engineered as an
+          <strong>SEooC</strong> — ISO 26262's term for a safety element built out of context, for integration into
+          someone else's product — with its assumptions of use written down and its integration seams frozen.</p>
+        </div>
+        <div class="diagram-frame flow-anim" data-reveal>${stackSvg}</div>
+        <p class="diagram-caption">
+          <span>Vendor-neutral on purpose: today's inference backends are ONNX Runtime, OpenVINO, and TensorRT; Qualcomm QNN and TI TIDL are tracked on the roadmap ${PLANNED}</span>
+        </p>
+        ${evRow("docs/safety/GOVERNOR_SAFETY_MANUAL.md", "docs/safety/ASSUMPTIONS_OF_USE.md", "docs/adr/0003-two-tier-base-and-d1-addon.md")}
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-asset">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Built to be built upon</p>
+          <h2 id="h-asset" data-reveal>Engineered for integration<br>from the first commit</h2>
+          <p class="lede" data-reveal>Whether Kirra ships inside a vehicle program, an industrial platform, or a
+          larger safety portfolio, the properties an integrator has to diligence are already in place — and
+          machine-checked where possible.</p>
+        </div>
+        <div class="grid grid--2">
+          <div class="card" data-reveal>
+            <h3>Clean, permissive IP posture</h3>
+            <p>The dependency license policy is an enforced allowlist — MIT, Apache-2.0, BSD-family and peers only,
+            gated by cargo-deny on every push, with crates.io as the sole permitted source. The robot MCU firmware
+            is a documented clean-room implementation. No copyleft surprises, no vendored mystery code.</p>
+            ${evRow("deny.toml", "firmware/rosmaster-r2/README.md")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>The paper trail ships with every release</h3>
+            <p>Tagged releases build a safety-case evidence bundle in CI — traceability matrix, safety constants
+            provenance, gate results — so an assessment (or a diligence review) starts from artifacts, not
+            interviews. Actions are SHA-pinned; containers are digest-pinned and cosign-signed.</p>
+            ${evRow(".github/workflows/release.yml", "ci/build_safety_case.py")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>One repository, fully auditable</h3>
+            <p>The checker, the runtime, the proofs, the safety case drafts, the hardware runbooks, and this
+            website live in a single versioned tree with 27 blocking CI lanes. What you can diligence in a
+            week here would take a quarter against a stack of private wikis.</p>
+            ${evRow(".github/workflows/ci.yml")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Small, certifiable core</h3>
+            <p>The path to certification runs through a minimal <code>no_std</code> verdict core with a purity gate —
+            no allocation, no clock, no crypto inside the decision — and a Ferrocene-ready toolchain direction.
+            The expensive artifact to certify is deliberately the smallest one.</p>
+            ${evRow("ci/check_verdict_core_purity.py", "docs/adr/0032-governor-deployment-platform.md")}
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-bet">
+      <div class="container container--narrow" style="text-align:center">
+        <p class="eyebrow" data-reveal style="justify-content:center">The bet</p>
+        <h2 id="h-bet" data-reveal>Autonomy will be won by whoever<br>can prove safety at runtime.</h2>
+        <p class="lede" data-reveal style="margin:20px auto 0">Models will keep changing. Sensors will keep changing.
+        The one durable interface in the stack is the envelope between intent and actuation — and whoever owns a
+        proven, portable, certifiable version of that layer owns a seat in every machine that moves. Kirra is
+        that layer, built in the open, with its evidence attached.</p>
+        <div class="hero__ctas" style="justify-content:center" data-reveal>
+          <a class="btn btn--primary" href="solutions.html">See it applied <span class="arrow" aria-hidden="true">→</span></a>
+          <a class="btn btn--ghost" href="architecture.html">See how it's built</a>
+        </div>
+      </div>
+    </section>
+`;

--- a/website/_src/template.mjs
+++ b/website/_src/template.mjs
@@ -42,6 +42,7 @@ export const MARK = `<svg viewBox="0 0 32 32" fill="none" aria-hidden="true">
 
 const NAV_LINKS = [
   ["solutions.html", "Solutions"],
+  ["vision.html", "Vision"],
   ["architecture.html", "Architecture"],
   ["safety.html", "Safety"],
   ["certification.html", "Certification"],
@@ -50,6 +51,7 @@ const NAV_LINKS = [
 
 const SUBNAV = [
   ["solutions.html", "solutions"],
+  ["vision.html", "vision"],
   ["architecture.html", "architecture"],
   ["runtime.html", "runtime"],
   ["safety.html", "safety"],
@@ -107,6 +109,7 @@ const FOOTER = `
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="${SITE.repo}" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/architecture.html
+++ b/website/architecture.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html" aria-current="page">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html" aria-current="page">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -392,6 +394,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -270,6 +272,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/careers.html
+++ b/website/careers.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -199,6 +201,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/certification.html
+++ b/website/certification.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html" aria-current="page">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -257,6 +259,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/css/kirra.css
+++ b/website/css/kirra.css
@@ -179,7 +179,9 @@ section { padding-block: clamp(64px, 10vh, 128px); position: relative; }
 .section-head p { margin-top: 16px; }
 
 .grid { display: grid; gap: 20px; }
-.grid--2 { grid-template-columns: repeat(auto-fit, minmax(min(340px, 100%), 1fr)); }
+.grid > * { min-width: 0; }
+.grid--2 { grid-template-columns: repeat(2, 1fr); }
+@media (max-width: 760px) { .grid--2 { grid-template-columns: 1fr; } }
 .grid--3 { grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr)); }
 .grid--4 { grid-template-columns: repeat(auto-fit, minmax(min(240px, 100%), 1fr)); }
 
@@ -355,6 +357,8 @@ a.card:hover { transform: translateY(-3px); box-shadow: var(--shadow-1); border-
   border-radius: 6px; padding: 3px 9px;
   text-decoration: none;
   max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
   transition: color 0.2s, border-color 0.2s;
 }
 .evidence::before { content: "▸"; color: var(--accent); font-size: 0.7em; }

--- a/website/determinism.html
+++ b/website/determinism.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -249,6 +251,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/documentation.html
+++ b/website/documentation.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -256,6 +258,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/field-notes.html
+++ b/website/field-notes.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -157,6 +159,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/index.html
+++ b/website/index.html
@@ -74,6 +74,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -605,6 +606,31 @@
 
     <hr class="rule">
 
+    <!-- ═══════════ WHERE THIS FITS ═══════════ -->
+    <section id="vision" aria-labelledby="h-vision">
+      <div class="container">
+        <div class="grid grid--2" style="align-items:center;gap:48px">
+          <div class="section-head" style="margin-bottom:0">
+            <p class="eyebrow" data-reveal>The world of tomorrow</p>
+            <h2 id="h-vision" data-reveal>Every machine gets a model.<br>Every model needs an envelope.</h2>
+            <p class="lede" data-reveal>Capability is outrunning verification, and regulation is converging on
+            runtime assurance. The durable layer in that future isn't any particular AI stack — it's the provable
+            envelope between intent and actuation, engineered as a safety element for integration into certified
+            platforms.</p>
+            <p data-reveal style="margin-top:18px"><a class="card__more" href="vision.html">Where Kirra fits <span aria-hidden="true">→</span></a></p>
+          </div>
+          <div style="display:grid;gap:10px" data-reveal aria-hidden="true">
+            <div class="card" style="padding:16px 22px"><p class="mono dim" style="font-size:0.8rem">AI doer stacks — unverifiable, swappable</p></div>
+            <div class="card" style="padding:16px 22px;border-color:var(--accent-line);background:var(--accent-soft)"><p class="mono" style="font-size:0.8rem;color:var(--accent)">KIRRA — the governed layer (SEooC)</p></div>
+            <div class="card" style="padding:16px 22px"><p class="mono dim" style="font-size:0.8rem">certified OS / hypervisor — QNX 8.0 target</p></div>
+            <div class="card" style="padding:16px 22px"><p class="mono dim" style="font-size:0.8rem">safety-rated silicon — vendor-neutral inference</p></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
     <!-- ═══════════ FIELD NOTES ═══════════ -->
     <section id="notes" aria-labelledby="h-notes">
       <div class="container">
@@ -689,6 +715,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/open-source.html
+++ b/website/open-source.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -235,6 +237,7 @@ curl -N localhost:8090/system/posture/stream \
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/perception.html
+++ b/website/perception.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -276,6 +278,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/performance.html
+++ b/website/performance.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -263,6 +265,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/planning.html
+++ b/website/planning.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -270,6 +272,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/prediction.html
+++ b/website/prediction.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -245,6 +247,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/research.html
+++ b/website/research.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -208,6 +210,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/runtime.html
+++ b/website/runtime.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html" aria-current="page">runtime</a>
       <a href="safety.html">safety</a>
@@ -348,6 +350,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/safety.html
+++ b/website/safety.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html" aria-current="page">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html" aria-current="page">safety</a>
@@ -319,6 +321,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/security.html
+++ b/website/security.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -291,6 +293,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -18,4 +18,5 @@
   <url><loc>https://kirrasystems.com/safety.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/security.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/solutions.html</loc><lastmod>2026-07-21</lastmod></url>
+  <url><loc>https://kirrasystems.com/vision.html</loc><lastmod>2026-07-21</lastmod></url>
 </urlset>

--- a/website/solutions.html
+++ b/website/solutions.html
@@ -47,6 +47,7 @@
 </svg><span>KIRRA</span></a>
       <nav class="nav__links" id="navLinks" aria-label="Primary">
         <a href="solutions.html" aria-current="page">Solutions</a>
+        <a href="vision.html">Vision</a>
         <a href="architecture.html">Architecture</a>
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
@@ -65,6 +66,7 @@
   <nav class="subnav" aria-label="Platform sections">
     <div class="subnav__inner">
       <a href="solutions.html" aria-current="page">solutions</a>
+      <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
       <a href="safety.html">safety</a>
@@ -287,6 +289,7 @@
       <nav aria-label="Company">
         <h4>Company</h4>
         <ul>
+          <li><a href="vision.html">Vision</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/vision.html
+++ b/website/vision.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vision — Kirra Systems</title>
+  <meta name="description" content="Why runtime governance is the missing layer of the autonomy stack: the embodied-AI wave, the regulatory shift to runtime assurance, and Kirra's place between certified platforms and unverifiable AI.">
+  <link rel="canonical" href="https://kirrasystems.com/vision.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Kirra Systems">
+  <meta property="og:title" content="Vision — Kirra Systems">
+  <meta property="og:description" content="Why runtime governance is the missing layer of the autonomy stack: the embodied-AI wave, the regulatory shift to runtime assurance, and Kirra's place between certified platforms and unverifiable AI.">
+  <meta property="og:url" content="https://kirrasystems.com/vision.html">
+  <meta property="og:image" content="https://kirrasystems.com/assets/og.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Vision — Kirra Systems">
+  <meta name="twitter:description" content="Why runtime governance is the missing layer of the autonomy stack: the embodied-AI wave, the regulatory shift to runtime assurance, and Kirra's place between certified platforms and unverifiable AI.">
+  <meta name="twitter:image" content="https://kirrasystems.com/assets/og.png">
+  <meta name="theme-color" content="#05070d">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="assets/kirra-logo.png" type="image/png">
+  <link rel="apple-touch-icon" href="assets/kirra-logo.png">
+  <link rel="preload" href="fonts/space-grotesk-var-latin.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="fonts/inter-var-latin.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="stylesheet" href="css/kirra.css">
+  <script>/* theme init before first paint — prevents flash */
+(function(){try{var t=localStorage.getItem("kirra-theme");if(!t)t=matchMedia("(prefers-color-scheme: light)").matches?"light":"dark";document.documentElement.dataset.theme=t;}catch(e){document.documentElement.dataset.theme="dark";}})();</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Vision — Kirra Systems","description":"Why runtime governance is the missing layer of the autonomy stack: the embodied-AI wave, the regulatory shift to runtime assurance, and Kirra's place between certified platforms and unverifiable AI.","url":"https://kirrasystems.com/vision.html","isPartOf":{"@type":"WebSite","name":"Kirra Systems","url":"https://kirrasystems.com"}}</script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="nav" id="nav">
+    <div class="nav__inner">
+      <a href="index.html" class="nav__brand" aria-label="Kirra Systems home"><svg viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <g stroke="currentColor" stroke-width="1.4" opacity="0.85">
+    <path d="M7 4v24M7 17 25 4M11.5 13.7 25 28"/>
+    <path d="M7 4l7 6.5M7 28l4.5-14.3M14 10.5 7 17" opacity="0.35"/>
+  </g>
+  <g fill="var(--accent, #3fd9c9)">
+    <circle cx="7" cy="4" r="2"/><circle cx="7" cy="17" r="2.4"/><circle cx="7" cy="28" r="2"/>
+    <circle cx="25" cy="4" r="2"/><circle cx="25" cy="28" r="2"/>
+    <circle cx="14" cy="10.5" r="1.5"/><circle cx="11.5" cy="13.7" r="1.5"/>
+  </g>
+</svg><span>KIRRA</span></a>
+      <nav class="nav__links" id="navLinks" aria-label="Primary">
+        <a href="solutions.html">Solutions</a>
+        <a href="vision.html" aria-current="page">Vision</a>
+        <a href="architecture.html">Architecture</a>
+        <a href="safety.html">Safety</a>
+        <a href="certification.html">Certification</a>
+        <a href="field-notes.html">Field Notes</a>
+      </nav>
+      <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
+        <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
+        <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+      </button>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+      </button>
+    </div>
+  </header>
+  <nav class="subnav" aria-label="Platform sections">
+    <div class="subnav__inner">
+      <a href="solutions.html">solutions</a>
+      <a href="vision.html" aria-current="page">vision</a>
+      <a href="architecture.html">architecture</a>
+      <a href="runtime.html">runtime</a>
+      <a href="safety.html">safety</a>
+      <a href="planning.html">planning</a>
+      <a href="perception.html">perception</a>
+      <a href="prediction.html">prediction</a>
+      <a href="determinism.html">determinism</a>
+      <a href="performance.html">performance</a>
+      <a href="security.html">security</a>
+      <a href="certification.html">certification</a>
+      <a href="benchmarks.html">benchmarks</a>
+      <a href="open-source.html">open source</a>
+      <a href="documentation.html">docs</a>
+      <a href="research.html">research</a>
+    </div>
+  </nav>
+
+  <main id="main">
+
+
+    <section class="page-hero">
+      <div class="container">
+        <p class="eyebrow" data-reveal>Vision</p>
+        <h1 data-reveal>The missing layer of<br>the autonomy stack.</h1>
+        <p class="lede" data-reveal>Every machine that moves is getting a model. Models are getting more capable and less inspectable at the same time — and no amount of training makes a neural network certifiable. The industry's honest answer is an old one, rebuilt for the AI era: don't verify the driver; verify the envelope. That layer is what Kirra is.</p>
+      </div>
+    </section>
+
+    <section aria-labelledby="h-need">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>The need</p>
+          <h2 id="h-need" data-reveal>Three forces, one gap</h2>
+          <p class="lede" data-reveal>The next decade of robotics is already legible: capability is outrunning
+          verification, regulation is converging on runtime assurance, and compute is consolidating onto
+          certified platforms. All three point at the same missing piece.</p>
+        </div>
+        <div class="grid grid--3">
+          <div class="card" data-reveal>
+            <h3>AI is outrunning verification</h3>
+            <p>Foundation models are entering planners, and language is becoming a robot interface. You cannot
+            test a distribution into being safe — but you can bound what any of it is permitted to do. Kirra's
+            safety case is deliberately <em>doer-invariant</em>: it holds whether the doer is geometric code,
+            a learned policy, or an LLM, which means it also holds for the doer nobody has built yet.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/adr/0020-doer-invariant-safety-case.md" target="_blank" rel="noopener">docs/adr/0020-doer-invariant-safety-case.md</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/llm_integration_guide.md" target="_blank" rel="noopener">docs/llm_integration_guide.md</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Regulation is converging on runtime assurance</h3>
+            <p>UL 4600 safety cases, SOTIF, ASTM F3269 run-time assurance, and the emerging AI-safety standards
+            (ISO/IEC TR 5469, ISO/PAS 8800) all circle the same architecture: an untrusted complex function
+            behind a verifiable monitor. Kirra maintains mappings to each of these — drafted in the open,
+            versioned with the code — so the compliance story grows with the product instead of after it.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/safety/UL4600_SAFETY_CASE.md" target="_blank" rel="noopener">docs/safety/UL4600_SAFETY_CASE.md</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/safety/ASTM_F3269_RTA_MAPPING.md" target="_blank" rel="noopener">docs/safety/ASTM_F3269_RTA_MAPPING.md</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/safety/ISO_IEC_TR_5469_MAPPING.md" target="_blank" rel="noopener">docs/safety/ISO_IEC_TR_5469_MAPPING.md</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Platforms need a governed layer</h3>
+            <p>Certified hypervisors and safety-rated silicon solve isolation and compute — they don't decide
+            whether a command is safe. Kirra is built to be that decision layer on exactly those platforms:
+            the deployment decision of record is a QNX 8.0 safety partition, and the inference substrate is
+            vendor-neutral by design.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/adr/0032-governor-deployment-platform.md" target="_blank" rel="noopener">docs/adr/0032-governor-deployment-platform.md</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/parko/README.md" target="_blank" rel="noopener">parko/README.md</a></p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-stack">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Where it fits</p>
+          <h2 id="h-stack" data-reveal>Between certified platforms<br>and unverifiable AI</h2>
+          <p class="lede" data-reveal>Kirra doesn't compete with the layers above or below it. It's engineered as an
+          <strong>SEooC</strong> — ISO 26262's term for a safety element built out of context, for integration into
+          someone else's product — with its assumptions of use written down and its integration seams frozen.</p>
+        </div>
+        <div class="diagram-frame flow-anim" data-reveal>
+<svg viewBox="0 0 960 380" role="img" aria-labelledby="stT stD">
+  <title id="stT">The autonomy stack of tomorrow</title>
+  <desc id="stD">Four layers: AI doer stacks at the top; the Kirra governed layer beneath them; certified operating systems and hypervisors below that; and safety-rated silicon at the base. Kirra is the layer that makes the unverifiable top compatible with the certified bottom.</desc>
+  <g>
+    <rect class="dg-box" x="80" y="16" width="800" height="70" rx="12"/>
+    <text class="dg-label" x="104" y="46">AI doer stacks — capable, fast-moving, unverifiable</text>
+    <text class="dg-sub" x="104" y="68">Autoware-class AV stacks · learned planners · LLM agents · whatever comes next</text>
+  </g>
+  <g>
+    <rect class="dg-box dg-box--accent" x="80" y="106" width="800" height="86" rx="12"/>
+    <text class="dg-label" x="104" y="138">KIRRA — the governed layer</text>
+    <text class="dg-mono" x="104" y="160">typed intents · posture · kinematic envelopes · RSS · signed release</text>
+    <text class="dg-sub" x="104" y="180">an SEooC: a safety element designed to be integrated, not a stack that competes</text>
+  </g>
+  <g>
+    <rect class="dg-box" x="80" y="212" width="800" height="70" rx="12"/>
+    <text class="dg-label" x="104" y="242">Certified OS &amp; hypervisors</text>
+    <text class="dg-sub" x="104" y="264">QNX 8.0 for Safety (the recorded deployment target) · safety-certified RTOS class</text>
+  </g>
+  <g>
+    <rect class="dg-box" x="80" y="302" width="800" height="62" rx="12"/>
+    <text class="dg-label" x="104" y="330">Safety-rated silicon</text>
+    <text class="dg-sub" x="104" y="352">DRIVE-class targets · Jetson Orin today · vendor-neutral inference: ONNX / OpenVINO / TensorRT, Qualcomm QNN &amp; TI TIDL on the roadmap</text>
+  </g>
+  <path class="dg-edge dg-edge--deny" d="M480 86 L 480 104"/>
+  <path class="dg-edge dg-edge--flow" d="M480 192 L 480 210"/>
+  <path class="dg-edge dg-edge--flow" d="M480 282 L 480 300"/>
+  <text class="dg-mono" x="500" y="100">bounded, never trusted</text>
+</svg></div>
+        <p class="diagram-caption">
+          <span>Vendor-neutral on purpose: today's inference backends are ONNX Runtime, OpenVINO, and TensorRT; Qualcomm QNN and TI TIDL are tracked on the roadmap <span class="pill pill--rnd">PLANNED</span></span>
+        </p>
+        <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/safety/GOVERNOR_SAFETY_MANUAL.md" target="_blank" rel="noopener">docs/safety/GOVERNOR_SAFETY_MANUAL.md</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/safety/ASSUMPTIONS_OF_USE.md" target="_blank" rel="noopener">docs/safety/ASSUMPTIONS_OF_USE.md</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/adr/0003-two-tier-base-and-d1-addon.md" target="_blank" rel="noopener">docs/adr/0003-two-tier-base-and-d1-addon.md</a></p>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-asset">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Built to be built upon</p>
+          <h2 id="h-asset" data-reveal>Engineered for integration<br>from the first commit</h2>
+          <p class="lede" data-reveal>Whether Kirra ships inside a vehicle program, an industrial platform, or a
+          larger safety portfolio, the properties an integrator has to diligence are already in place — and
+          machine-checked where possible.</p>
+        </div>
+        <div class="grid grid--2">
+          <div class="card" data-reveal>
+            <h3>Clean, permissive IP posture</h3>
+            <p>The dependency license policy is an enforced allowlist — MIT, Apache-2.0, BSD-family and peers only,
+            gated by cargo-deny on every push, with crates.io as the sole permitted source. The robot MCU firmware
+            is a documented clean-room implementation. No copyleft surprises, no vendored mystery code.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/deny.toml" target="_blank" rel="noopener">deny.toml</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/firmware/rosmaster-r2/README.md" target="_blank" rel="noopener">firmware/rosmaster-r2/README.md</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>The paper trail ships with every release</h3>
+            <p>Tagged releases build a safety-case evidence bundle in CI — traceability matrix, safety constants
+            provenance, gate results — so an assessment (or a diligence review) starts from artifacts, not
+            interviews. Actions are SHA-pinned; containers are digest-pinned and cosign-signed.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/.github/workflows/release.yml" target="_blank" rel="noopener">.github/workflows/release.yml</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/ci/build_safety_case.py" target="_blank" rel="noopener">ci/build_safety_case.py</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>One repository, fully auditable</h3>
+            <p>The checker, the runtime, the proofs, the safety case drafts, the hardware runbooks, and this
+            website live in a single versioned tree with 27 blocking CI lanes. What you can diligence in a
+            week here would take a quarter against a stack of private wikis.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/.github/workflows/ci.yml" target="_blank" rel="noopener">.github/workflows/ci.yml</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Small, certifiable core</h3>
+            <p>The path to certification runs through a minimal <code>no_std</code> verdict core with a purity gate —
+            no allocation, no clock, no crypto inside the decision — and a Ferrocene-ready toolchain direction.
+            The expensive artifact to certify is deliberately the smallest one.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/ci/check_verdict_core_purity.py" target="_blank" rel="noopener">ci/check_verdict_core_purity.py</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/adr/0032-governor-deployment-platform.md" target="_blank" rel="noopener">docs/adr/0032-governor-deployment-platform.md</a></p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-bet">
+      <div class="container container--narrow" style="text-align:center">
+        <p class="eyebrow" data-reveal style="justify-content:center">The bet</p>
+        <h2 id="h-bet" data-reveal>Autonomy will be won by whoever<br>can prove safety at runtime.</h2>
+        <p class="lede" data-reveal style="margin:20px auto 0">Models will keep changing. Sensors will keep changing.
+        The one durable interface in the stack is the envelope between intent and actuation — and whoever owns a
+        proven, portable, certifiable version of that layer owns a seat in every machine that moves. Kirra is
+        that layer, built in the open, with its evidence attached.</p>
+        <div class="hero__ctas" style="justify-content:center" data-reveal>
+          <a class="btn btn--primary" href="solutions.html">See it applied <span class="arrow" aria-hidden="true">→</span></a>
+          <a class="btn btn--ghost" href="architecture.html">See how it's built</a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+<footer class="footer">
+  <div class="container">
+    <div class="footer__grid">
+      <div class="footer__brand">
+        <a class="nav__brand" href="index.html"><svg viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <g stroke="currentColor" stroke-width="1.4" opacity="0.85">
+    <path d="M7 4v24M7 17 25 4M11.5 13.7 25 28"/>
+    <path d="M7 4l7 6.5M7 28l4.5-14.3M14 10.5 7 17" opacity="0.35"/>
+  </g>
+  <g fill="var(--accent, #3fd9c9)">
+    <circle cx="7" cy="4" r="2"/><circle cx="7" cy="17" r="2.4"/><circle cx="7" cy="28" r="2"/>
+    <circle cx="25" cy="4" r="2"/><circle cx="25" cy="28" r="2"/>
+    <circle cx="14" cy="10.5" r="1.5"/><circle cx="11.5" cy="13.7" r="1.5"/>
+  </g>
+</svg><span>KIRRA</span></a>
+        <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
+      </div>
+      <nav aria-label="Platform">
+        <h4>Platform</h4>
+        <ul>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="architecture.html">Architecture</a></li>
+          <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="determinism.html">Determinism</a></li>
+          <li><a href="performance.html">Performance</a></li>
+          <li><a href="security.html">Security</a></li>
+        </ul>
+      </nav>
+      <nav aria-label="Safety">
+        <h4>Safety</h4>
+        <ul>
+          <li><a href="safety.html">Safety model</a></li>
+          <li><a href="planning.html">Planning</a></li>
+          <li><a href="perception.html">Perception</a></li>
+          <li><a href="prediction.html">Prediction</a></li>
+          <li><a href="certification.html">Certification</a></li>
+        </ul>
+      </nav>
+      <nav aria-label="Evidence">
+        <h4>Evidence</h4>
+        <ul>
+          <li><a href="benchmarks.html">Benchmarks</a></li>
+          <li><a href="open-source.html">Open source</a></li>
+          <li><a href="documentation.html">Documentation</a></li>
+          <li><a href="research.html">Research</a></li>
+        </ul>
+      </nav>
+      <nav aria-label="Company">
+        <h4>Company</h4>
+        <ul>
+          <li><a href="vision.html">Vision</a></li>
+          <li><a href="field-notes.html">Field Notes</a></li>
+          <li><a href="careers.html">Careers</a></li>
+          <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>
+          <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/SECURITY.md" target="_blank" rel="noopener">Security policy ↗</a></li>
+        </ul>
+      </nav>
+    </div>
+    <div class="footer__meta">
+      <span>© <span data-year>2026</span> Kirra Systems</span>
+      <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
+      <span>Every claim on this site links to its source in the repository.</span>
+    </div>
+  </div>
+</footer>
+  <script src="js/kirra.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
Adds the strategic layer: a Vision page framing Kirra for readers evaluating long-term value and fit — the embodied-AI verification gap, regulation converging on runtime assurance (UL 4600 / SOTIF / ASTM F3269 / ISO/IEC TR 5469 / ISO/PAS 8800, all with in-repo mappings cited), the four-layer "stack of tomorrow" diagram placing Kirra as the SEooC governed layer between certified platforms (QNX 8.0 target, vendor-neutral inference incl. Qualcomm QNN / TI TIDL roadmap) and unverifiable AI, and a "built to be built upon" section covering the integration/diligence-ready qualities (CI-enforced permissive-only licensing, clean-room firmware, release-time safety-case evidence bundles, single auditable repo, minimal `no_std` certifiable core). Every claim keeps its evidence chips; roadmap items are labeled PLANNED.

Homepage gains a compact "world of tomorrow" band with the layer stack, linking to the Vision page. Vision joins nav/subnav/footer.

Also fixes two layout defects found during verification: `.grid--2` now renders a true 2×2 (was auto-fit 3+1 at wide widths), and long evidence-chip file paths no longer force min-content overflow on narrow viewports (was 136px of horizontal scroll on solutions mobile). Verified: zero horizontal scroll at 390px across seven pages; 2×2 confirmed at 1440px.

⚠️ Merging deploys to kirrasystems.com automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7)_