### PR TITLE
#797 remainder: MSRV workspace inheritance, full-feature deny graph, scheduled advisories, ghcr ordering guard

### DIFF
--- a/.github/workflows/advisories-cron.yml
+++ b/.github/workflows/advisories-cron.yml
@@ -1,0 +1,63 @@
+# #797 F4 (#775) — the SCHEDULED advisory scan. The per-PR supply-chain gate
+# (ci.yml) is event-driven: a RUSTSEC advisory published while no PR is in
+# flight would sit unseen until the next unrelated PR went red on it. This
+# cron closes that window: both workspaces are scanned daily against the SAME
+# policy (/deny.toml, --all-features — the identical resolve the PR gate
+# runs), and a finding FILES/UPDATES a tracking issue so the signal lands on
+# a human without blocking anyone's PR.
+#
+# Kept in its OWN workflow (the kpi-campaign-nightly precedent) so the
+# `schedule` trigger does not fan the whole ci.yml job graph out nightly.
+#
+# Triage path (same as the gating lane): bump the dependency, or add a
+# scoped, dated entry to deny.toml `[advisories].ignore` with a written
+# justification — never continue-on-error.
+name: Advisories (scheduled scan)
+
+on:
+  schedule:
+    # 06:41 UTC daily (off the hour to dodge the top-of-hour scheduler surge).
+    - cron: "41 6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write # files/updates/closes the tracking issue below
+
+concurrency:
+  group: advisories-cron
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: RUSTSEC advisories — both workspaces (issue-filing, non-blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      # continue-on-error here is CORRECT (unlike the PR gate): the scan's
+      # whole job is to observe-and-file; the red signal is the ISSUE, and
+      # the filing step below must run precisely when these steps fail.
+      - name: Advisories — root workspace
+        id: root
+        continue-on-error: true
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
+        with:
+          command: check advisories
+          arguments: --locked
+      - name: Advisories — parko workspace
+        id: parko
+        continue-on-error: true
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
+        with:
+          command: check advisories
+          arguments: --locked
+          manifest-path: ./parko/Cargo.toml
+      - name: File / update / close the tracking issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          OUTCOME_ROOT: ${{ steps.root.outcome }}
+          OUTCOME_PARKO: ${{ steps.parko.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: python3 ci/file_advisory_issue.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,28 +31,43 @@ env:
 
 jobs:
   # WS-0.6 — supply-chain gate. Deterministic checks only (licenses / bans /
-  # sources go red only when the dependency tree or the policy changes);
-  # advisories runs non-gating below because it goes red on events EXTERNAL
-  # to the repo (a freshly published CVE) — that is signal for a human, not
-  # a reason to block an unrelated PR. Policy: /deny.toml (single config,
-  # passed explicitly to BOTH workspaces so they cannot drift).
+  # sources go red only when the dependency tree or the policy changes).
+  # Policy: /deny.toml — one policy file for both workspaces; the pin step
+  # below ASSERTS parko/deny.toml is still a symlink to it (#797 F9 — a
+  # replaced regular file would silently fork the policy).
+  #
+  # #797 F3 (#775): the policy graph resolves the FULL feature set — see
+  # deny.toml [graph] all-features = true (the one policy file; set there,
+  # not per-invocation, so a local `cargo deny check` resolves identically).
+  # That folds the feature-gated production trees into every check below:
+  # root `ros2` (r2r + ROS message chain), `tpm` (tss-esapi + bindgen chain),
+  # `capture`, and parko's backend features. The inventory of what stays
+  # OUTSIDE the policy graph is documented on that [graph] section.
   supply-chain:
     name: supply-chain gate (cargo-deny)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - name: Deny gate — root workspace (licenses / bans / sources)
+      - name: Single-policy pin — parko/deny.toml must BE the root policy (symlink)
+        # #797 F9: the one-policy claim is load-bearing for every parko check
+        # below; assert the mechanism instead of trusting a comment.
+        run: |
+          test -L parko/deny.toml || { echo "parko/deny.toml is not a symlink — policy forked"; exit 1; }
+          test "$(readlink parko/deny.toml)" = "../deny.toml" \
+            || { echo "parko/deny.toml points at $(readlink parko/deny.toml), not ../deny.toml"; exit 1; }
+      - name: Deny gate — root workspace, full feature graph (licenses / bans / sources)
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
         with:
           command: check licenses bans sources
           arguments: --locked
-      - name: Deny gate — parko workspace (licenses / bans / sources)
+      - name: Deny gate — parko workspace, full feature graph (licenses / bans / sources)
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
         with:
           command: check licenses bans sources
           arguments: --locked
-          # parko/deny.toml is a symlink to the root deny.toml — one policy.
+          # One policy: parko/deny.toml -> ../deny.toml, asserted by the pin
+          # step above.
           manifest-path: ./parko/Cargo.toml
       # WP-04 (MGA G-6): advisories are now GATING. A new RUSTSEC advisory on a
       # locked dependency reds the PR until it is either bumped (the normal
@@ -235,6 +250,10 @@ jobs:
           test -n "$pin" && test "$actual" = "$pin" \
             || { echo "talisman blob $actual != pinned $pin"; exit 1; }
 
+  # MSRV floor (policy §3). The number lives in THREE places bumped in
+  # lock-step: the two [workspace.package] rust-version fields (root +
+  # parko/Cargo.toml — every member inherits, #797 F3) and this lane's
+  # toolchain pin.
   msrv:
     name: MSRV check (rustc 1.88)
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      # #797 F6 — the REGISTRY half of the A4 version-ordering guard
+      # (ci/check_version_ordering.py covers the in-repo line): refuse to
+      # publish while any ghcr tag semver-exceeds the version being built, so
+      # a semver image-update policy can never "upgrade" a fleet onto an old
+      # image. The pre-existing Aegis-era 1.5.0/1.5 tags are allowlisted with
+      # justifications in ci/ghcr_legacy_tags.json pending OWNER deletion or
+      # re-tag; any NEW offender reds this job before anything is pushed.
+      - name: ghcr tag-ordering guard (no tag may semver-exceed this build)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 ci/check_ghcr_tag_ordering.py
+
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
@@ -77,6 +89,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      # #797 F6 — same registry-ordering guard over the dashboard package.
+      - name: ghcr tag-ordering guard (no tag may semver-exceed this build)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_PACKAGE: kirra-dashboard
+        run: python3 ci/check_ghcr_tag_ordering.py
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,15 @@
 members = [".", "crates/kirra-core", "crates/kirra-policy-types", "crates/kirra-industrial", "crates/kirra-contract-channel", "crates/kirra-hv-carrier", "crates/kirra-inline-governor", "crates/kirra-l3-e2e", "crates/kirra-release-token", "crates/kirra-timing", "crates/kirra-wcet-bench", "crates/kirra-trajectory", "crates/kirra-fleet-types", "crates/kirra-ros2-adapter", "crates/kirra-capture-schema", "crates/kirra-collector", "crates/kirra-governor-service", "crates/kirra-wire-client", "crates/kirra-proposal-bench", "crates/kirra-planner", "crates/kirra-mick", "crates/kirra-map", "crates/kirra-taj", "crates/kirra-fleet-transport", "crates/kirra-doer-eval", "crates/kirra-kpi-gate", "crates/kirra-ota-installer", "crates/kirra-ota-campaign", "crates/kirra-fabric-types", "crates/kirra-audit-hash", "crates/kirra-persistence", "crates/kirra-safety-authority", "crates/kirra-replay", "crates/kirra-actuation-consumer", "crates/kirra-sidecars", "crates/kirra-consumer-ffi"]
 resolver = "2"
 
+# One MSRV source of truth for this workspace (#797 F3 / VERSIONING_POLICY.md
+# §3): every member (including the root package) inherits via
+# `rust-version.workspace = true`, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front instead of dying
+# mid-compile. Bump in lock-step with parko/Cargo.toml [workspace.package]
+# and the ci.yml `msrv` lane toolchain pin.
+[workspace.package]
+rust-version = "1.88"
+
 [package]
 name = "kirra-verifier"
 version = "1.1.2"
@@ -31,8 +40,9 @@ edition = "2021"
 # libloading 0.9, ort) — not by our own code. ENFORCED on every PR by the `msrv`
 # CI lane (`cargo +1.88.0 check --workspace --locked`), not just asserted here.
 # Raising this is a MINOR bump + CHANGELOG entry, per policy — in lock-step with
-# the CI lane and the parko-core `rust-version`.
-rust-version = "1.88"
+# the CI lane and parko's [workspace.package]. The value lives in THIS
+# manifest's [workspace.package]; every member inherits it (#797 F3).
+rust-version.workspace = true
 description = "Vendor-neutral runtime safety kernel for autonomous vehicles, robots, and drones"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 homepage = "https://kirrasystems.com"

--- a/ci/check_ghcr_tag_ordering.py
+++ b/ci/check_ghcr_tag_ordering.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""ghcr tag-ordering guard (#797 F6 / the #1049 A4 registry half).
+
+The version line went backwards across the rebrand (v1.5.0 "Aegis" →
+v1.1.2 "Kirra"), so the ghcr registry still carries `1.5.0`/`1.5` image tags
+that SEMVER-SORT ABOVE the current code — any semver image-update policy
+(Renovate, Flux/Argo semver ranges, `~1`) would "upgrade" a fleet onto the
+old Aegis image. The in-repo half of A4 is ci/check_version_ordering.py;
+THIS guard covers the registry: no published ghcr tag may semver-exceed the
+version being built, except entries in the reviewed legacy allowlist
+(ci/ghcr_legacy_tags.json) awaiting owner deletion/re-tag.
+
+Runs in .github/workflows/docker.yml BEFORE the image build/push, with the
+job's GITHUB_TOKEN (packages scope). Fail-closed: an unreadable registry is
+a red, not a silent green — publishing next to an unverifiable tag set is
+the exact hazard.
+
+Exit 0 = ordering sane. Exit 1 = an offending tag (delete/re-tag it, or —
+only for pre-existing legacy tags — allowlist it with a justification) or a
+registry/API failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+ALLOWLIST_PATH = REPO_DIR / "ci" / "ghcr_legacy_tags.json"
+
+SEMVER_TAG_RE = re.compile(r"^v?(\d+)\.(\d+)(?:\.(\d+))?$")
+
+
+def current_version() -> tuple[int, int, int]:
+    text = (REPO_DIR / "Cargo.toml").read_text(encoding="utf-8")
+    m = re.search(r'^version\s*=\s*"(\d+)\.(\d+)\.(\d+)"', text, re.M)
+    if not m:
+        sys.exit("FAIL cannot read [package] version from Cargo.toml")
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def tag_version(tag: str) -> tuple[int, int, int] | None:
+    """Parse a semver-ish tag (1.5.0, 1.5, v2.0.0). Partial tags compare by
+    their floor (1.5 == 1.5.0) — that is exactly how a floating-tag consumer
+    resolves them. Non-semver tags (main, latest, sha-*, aegis-*) are not
+    version-ordered and are ignored."""
+    m = SEMVER_TAG_RE.match(tag)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3) or 0))
+
+
+def fetch_all_tags(owner: str, package: str, token: str) -> list[str]:
+    """Every tag on the container package, via the org endpoint with the
+    user endpoint as fallback (the repo may live under either)."""
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    last_err: Exception | None = None
+    for base in (
+        f"https://api.github.com/orgs/{owner}/packages/container/{package}/versions",
+        f"https://api.github.com/users/{owner}/packages/container/{package}/versions",
+    ):
+        tags: list[str] = []
+        page = 1
+        try:
+            while True:
+                req = urllib.request.Request(
+                    f"{base}?per_page=100&page={page}", headers=headers
+                )
+                for attempt in range(3):
+                    try:
+                        with urllib.request.urlopen(req) as resp:
+                            batch = json.load(resp)
+                        break
+                    except urllib.error.URLError as e:
+                        if attempt == 2:
+                            raise
+                        time.sleep(2 * (attempt + 1))
+                        last_err = e
+                if not batch:
+                    return tags
+                for v in batch:
+                    tags.extend(
+                        v.get("metadata", {}).get("container", {}).get("tags", [])
+                    )
+                page += 1
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                last_err = e
+                continue  # wrong owner kind — try the other endpoint
+            raise
+    sys.exit(f"FAIL ghcr package not found under org or user endpoint: {last_err}")
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    if not token or "/" not in repository:
+        sys.exit("FAIL GITHUB_TOKEN / GITHUB_REPOSITORY not set")
+    owner, repo_name = repository.split("/", 1)
+    # The container package name defaults to the repo (the verifier image);
+    # the dashboard job overrides via GHCR_PACKAGE (its image lives under
+    # ghcr.io/<owner>/kirra-dashboard).
+    package = os.environ.get("GHCR_PACKAGE", repo_name)
+
+    allowlist = json.loads(ALLOWLIST_PATH.read_text(encoding="utf-8"))
+    allowed = {entry["tag"]: entry["reason"] for entry in allowlist}
+
+    cur = current_version()
+    tags = fetch_all_tags(owner, package, token)
+    offenders = []
+    for tag in sorted(set(tags)):
+        ver = tag_version(tag)
+        if ver is None or ver <= cur:
+            continue
+        if tag in allowed:
+            print(f"warn {tag} semver-exceeds {'.'.join(map(str, cur))} — "
+                  f"ALLOWLISTED: {allowed[tag]}")
+            continue
+        offenders.append(tag)
+
+    # A stale allowlist entry (tag gone, or no longer exceeding) should be
+    # removed — decreases never need review.
+    for tag in allowed:
+        ver = tag_version(tag)
+        if tag not in tags or (ver is not None and ver <= cur):
+            print(f"warn allowlist entry `{tag}` is stale — remove it from "
+                  f"{ALLOWLIST_PATH.name}")
+
+    if offenders:
+        print(
+            f"\nFAIL these ghcr tags semver-exceed the version being built "
+            f"({'.'.join(map(str, cur))}): {', '.join(offenders)}\n"
+            "A semver image-update policy would 'upgrade' onto them. Delete or "
+            "re-tag them (e.g. aegis-<ver>); only a pre-existing legacy tag may "
+            "be allowlisted in ci/ghcr_legacy_tags.json with a justification."
+        )
+        return 1
+    print(f"ghcr tag ordering ok ({len(tags)} tags, none unexpectedly above "
+          f"{'.'.join(map(str, cur))})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/file_advisory_issue.py
+++ b/ci/file_advisory_issue.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""File/update/close the scheduled-advisory-scan tracking issue (#797 F4).
+
+Runs as the last step of .github/workflows/advisories-cron.yml, after the two
+cargo-deny advisory scans (root + parko, continue-on-error). Behavior:
+
+* any scan FAILED  -> ensure ONE open tracking issue exists: create it if
+  absent, else append a comment (so repeated nightly findings thread into one
+  issue instead of spamming new ones).
+* both scans PASSED -> if an open tracking issue exists, comment and CLOSE it
+  (the advisory was bumped or triaged; the loop self-resolves).
+
+Identity: the issue is found by its exact TITLE marker, not labels — label
+creation needs repo-admin steps this script must not depend on.
+
+Pure stdlib (urllib): no third-party action, nothing new to SHA-pin (M-6).
+Exit is ALWAYS 0 on a completed filing decision — the red signal is the
+ISSUE, not this workflow — but an API failure exits 1 loudly (a scan that
+cannot report is not a scan).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+
+TITLE = "[advisories] scheduled RUSTSEC scan findings"
+
+TRIAGE = (
+    "Triage (same policy as the gating PR lane): bump the affected "
+    "dependency, or add a scoped, dated entry to `deny.toml` "
+    "`[advisories].ignore` with a written justification + expiry. "
+    "This issue is updated by `.github/workflows/advisories-cron.yml` and "
+    "closes itself on the first clean scan."
+)
+
+
+def api(path: str, method: str = "GET", body: dict | None = None):
+    repo = os.environ["GITHUB_REPOSITORY"]
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}{path}",
+        method=method,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers={
+            "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.load(resp)
+
+
+def find_open_tracking_issue() -> int | None:
+    # Newest 100 open issues is ample: there is at most one tracking issue.
+    for issue in api("/issues?state=open&per_page=100"):
+        if issue.get("title") == TITLE and "pull_request" not in issue:
+            return issue["number"]
+    return None
+
+
+def main() -> int:
+    outcomes = {
+        "root workspace": os.environ["OUTCOME_ROOT"],
+        "parko workspace": os.environ["OUTCOME_PARKO"],
+    }
+    run_url = os.environ["RUN_URL"]
+    failed = [ws for ws, oc in outcomes.items() if oc != "success"]
+    existing = find_open_tracking_issue()
+
+    if failed:
+        summary = ", ".join(failed)
+        body = (
+            f"Scheduled RUSTSEC advisory scan found advisories in: **{summary}**.\n\n"
+            f"Full cargo-deny output: {run_url}\n\n{TRIAGE}"
+        )
+        if existing is None:
+            created = api("/issues", "POST", {"title": TITLE, "body": body})
+            print(f"filed tracking issue #{created['number']} ({summary})")
+        else:
+            api(f"/issues/{existing}/comments", "POST", {"body": body})
+            print(f"updated tracking issue #{existing} ({summary})")
+    else:
+        if existing is not None:
+            api(
+                f"/issues/{existing}/comments",
+                "POST",
+                {"body": f"Scheduled scan is clean again ({run_url}) — closing."},
+            )
+            api(f"/issues/{existing}", "PATCH", {"state": "closed"})
+            print(f"closed tracking issue #{existing} (scan clean)")
+        else:
+            print("scan clean; no tracking issue open — nothing to do")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/ghcr_legacy_tags.json
+++ b/ci/ghcr_legacy_tags.json
@@ -1,0 +1,10 @@
+[
+  {
+    "tag": "1.5.0",
+    "reason": "Aegis-era image published before the v1.5.0->v1.1.2 rebrand renumbering (#1049 A4); semver-sorts above current Kirra code. Pending OWNER deletion or re-tag to aegis-1.5.0 (#797 F6) — remove this entry when done."
+  },
+  {
+    "tag": "1.5",
+    "reason": "Floating Aegis-era tag, same hazard as 1.5.0. Pending OWNER deletion or re-tag (#797 F6) — remove this entry when done."
+  }
+]

--- a/crates/kirra-actuation-consumer/Cargo.toml
+++ b/crates/kirra-actuation-consumer/Cargo.toml
@@ -20,6 +20,10 @@ version = "0.1.0"
 publish = false
 edition = "2021"
 
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 [dependencies]
 kirra-release-token = { path = "../kirra-release-token" }
 ed25519-dalek = "2"

--- a/crates/kirra-audit-hash/Cargo.toml
+++ b/crates/kirra-audit-hash/Cargo.toml
@@ -20,6 +20,10 @@
 name = "kirra-audit-hash"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Pure audit/causal hash-chain primitives for Kirra — SHA-256 record hashes, domain-separated canonical signing/anchor-head payloads, content-addressed key ids. No DB, no state."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-capture-schema/Cargo.toml
+++ b/crates/kirra-capture-schema/Cargo.toml
@@ -2,6 +2,10 @@
 name = "kirra-capture-schema"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Wire schema for Kirra's learning-loop capture records — the single authoritative, governor-free type set shared by the SDK emitters and the offline collector."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 authors = ["Kirra Systems, LLC <justin.looney@kirrasystems.com>"]

--- a/crates/kirra-collector/Cargo.toml
+++ b/crates/kirra-collector/Cargo.toml
@@ -2,6 +2,10 @@
 name = "kirra-collector"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Offline learning-loop collector: joins Kirra capture JSONL to a bus recording and writes a training-ready Parquet dataset. Depends on kirra-capture-schema ONLY — never the governor (docs/COLLECTOR_DESIGN.md §0)."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 authors = ["Kirra Systems, LLC <justin.looney@kirrasystems.com>"]

--- a/crates/kirra-consumer-ffi/Cargo.toml
+++ b/crates/kirra-consumer-ffi/Cargo.toml
@@ -15,7 +15,7 @@
 name = "kirra-consumer-ffi"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.88"
+rust-version.workspace = true  # inherited from [workspace.package] (#797 F3)
 description = "C-ABI surface over the ADR-0033 verifying motor consumer (kirra-actuation-consumer) for the Python Rosmaster consumer."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-contract-channel/Cargo.toml
+++ b/crates/kirra-contract-channel/Cargo.toml
@@ -15,6 +15,10 @@
 name = "kirra-contract-channel"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Frozen #[repr(C)] cross-partition governor contract view + odd/even generation seqlock (ADR-0006 Clause 2 / HVCHAN-001)"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"

--- a/crates/kirra-core/Cargo.toml
+++ b/crates/kirra-core/Cargo.toml
@@ -13,6 +13,10 @@
 name = "kirra-core"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Lean safety/contract foundation for the Kirra stack — no service/runtime deps."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-doer-eval/Cargo.toml
+++ b/crates/kirra-doer-eval/Cargo.toml
@@ -17,6 +17,10 @@
 name = "kirra-doer-eval"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Doer performance eval harness — runs planner proposals through the KIRRA checker to produce admissibility + plan-quality metrics (Q-1a)."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-fabric-types/Cargo.toml
+++ b/crates/kirra-fabric-types/Cargo.toml
@@ -25,6 +25,10 @@
 name = "kirra-fabric-types"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Lean fabric-plane domain types for Kirra — FabricAsset (+ asset/kinematic-profile enums) and the CausalLogEntry forensic-ledger record. No service/DB/audit deps."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-fleet-transport/Cargo.toml
+++ b/crates/kirra-fleet-transport/Cargo.toml
@@ -22,6 +22,10 @@
 name = "kirra-fleet-transport"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Fleet-lane (QM) Zenoh transport spike for KIRRA — untrusted carrier; trust is Ed25519 payload signatures; grants terminate at the verifier store (#296). Not a safety artifact."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-fleet-types/Cargo.toml
+++ b/crates/kirra-fleet-types/Cargo.toml
@@ -24,6 +24,10 @@
 name = "kirra-fleet-types"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Lean fleet-lane trust/wire types for Kirra — federated trust reports (v1/v2), Ed25519 verification, freshness, and the FleetTrustStore persistence seam. No service/DB deps."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-governor-service/Cargo.toml
+++ b/crates/kirra-governor-service/Cargo.toml
@@ -14,6 +14,10 @@
 name = "kirra-governor-service"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Minimal UDP KIRRA governor (two-box prototype); wraps the verdict core verbatim. serde + bincode + std only — no ROS/async."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-hv-carrier/Cargo.toml
+++ b/crates/kirra-hv-carrier/Cargo.toml
@@ -14,6 +14,10 @@
 name = "kirra-hv-carrier"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "L3 cross-partition contract carrier — POSIX-SHM (host) binding of the ContractReader/Writer seam (ADR-0030)"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-industrial/Cargo.toml
+++ b/crates/kirra-industrial/Cargo.toml
@@ -22,6 +22,10 @@
 name = "kirra-industrial"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Industrial-protocol adapter layer for Kirra — CANopen / DNP3 / EtherNet-IP fieldbus decoders + bounds and the posture-gated industrial-event evaluation. Depends only on kirra-policy-types + kirra-core; no service/DB deps."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-inline-governor/Cargo.toml
+++ b/crates/kirra-inline-governor/Cargo.toml
@@ -21,6 +21,10 @@
 name = "kirra-inline-governor"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "In-line doer→checker→release governor loop over the frozen SHM contract (EP-01 / G-1 software half)"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-kpi-gate/Cargo.toml
+++ b/crates/kirra-kpi-gate/Cargo.toml
@@ -2,6 +2,10 @@
 name = "kirra-kpi-gate"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "WS-3.1 scenario-KPI CI gate: thresholds unsafe_miss_rate / admissibility / hazard_recall over the generated scenario corpus"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-l3-e2e/Cargo.toml
+++ b/crates/kirra-l3-e2e/Cargo.toml
@@ -14,6 +14,10 @@
 name = "kirra-l3-e2e"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "On-target L3 end-to-end harness — two-process doer→checker→release over POSIX SHM (QNX/host)"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-map/Cargo.toml
+++ b/crates/kirra-map/Cargo.toml
@@ -12,6 +12,10 @@
 name = "kirra-map"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Shared lane-map substrate for the Kirra stack — Lanelet2-lite lane graph, routing, right-of-way, lane-line crossing rules, and a pure-Rust .osm parser. Lean (kirra-core + roxmltree)."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-mick/Cargo.toml
+++ b/crates/kirra-mick/Cargo.toml
@@ -9,6 +9,10 @@
 name = "kirra-mick"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Live LLM transport for Mick — an Ollama-backed ModelClient (local Gemma) behind the kirra-planner MickBrain seam."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-ota-campaign/Cargo.toml
+++ b/crates/kirra-ota-campaign/Cargo.toml
@@ -22,6 +22,10 @@
 name = "kirra-ota-campaign"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Lean OTA governor-artifact campaign engine for Kirra — the pure Campaign/CampaignState state machine, fail-closed halt-on-regression, node-assignment resolution, and rollout metrics. No service/DB deps."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-ota-installer/Cargo.toml
+++ b/crates/kirra-ota-installer/Cargo.toml
@@ -11,7 +11,7 @@
 name = "kirra-ota-installer"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.88"
+rust-version.workspace = true  # inherited from [workspace.package] (#797 F3)
 description = "Node-side dual-slot governor-artifact installer with health-gated rollback (device-agnostic core)."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-persistence/Cargo.toml
+++ b/crates/kirra-persistence/Cargo.toml
@@ -21,6 +21,10 @@
 name = "kirra-persistence"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Kirra persistence layer — VerifierStore (rusqlite WAL SQLite), versioned migrations, the backend-portable storage-trait seams + in-memory backends, and the audit-chain write mechanics. Depends only on the lean domain/audit leaf crates."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-planner/Cargo.toml
+++ b/crates/kirra-planner/Cargo.toml
@@ -19,6 +19,10 @@
 name = "kirra-planner"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Occy autonomy planner — Phase-0 interface lock. Proposes trajectories consumed by the existing #131 validation path; does not itself check."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-policy-types/Cargo.toml
+++ b/crates/kirra-policy-types/Cargo.toml
@@ -27,6 +27,10 @@
 name = "kirra-policy-types"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Command-classification policy types for Kirra — the doer-agnostic OperationalCommand enum, the pure HTTP method+path classifier (SG-006 fail-closed allowlist), the cmd_vel kinematic gate, and posture-aware action-claim evaluation. No service/DB deps."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-proposal-bench/Cargo.toml
+++ b/crates/kirra-proposal-bench/Cargo.toml
@@ -8,6 +8,10 @@
 name = "kirra-proposal-bench"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "DEV/TEST UDP bench for kirra-governor-service — sends a proposal sweep and prints the verdict table. Not a safety artifact."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-release-token/Cargo.toml
+++ b/crates/kirra-release-token/Cargo.toml
@@ -14,6 +14,10 @@
 name = "kirra-release-token"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Governor→actuator release-token bridge — sign/verify the validated contract digest (HVCHAN §3.5-6, ADR-0013)"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-replay/Cargo.toml
+++ b/crates/kirra-replay/Cargo.toml
@@ -8,6 +8,10 @@ version = "0.1.0"
 publish = false
 edition = "2021"
 
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 [dependencies]
 # The REAL checker + the per-class contract profiles (the replayed verdict is
 # computed by the same functions the deployed gateway runs — no reimplementation).

--- a/crates/kirra-ros2-adapter/Cargo.toml
+++ b/crates/kirra-ros2-adapter/Cargo.toml
@@ -31,6 +31,10 @@
 name = "kirra-ros2-adapter"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "ROS 2 adapter for the Kirra Governor (Option-B per-trajectory wiring, S131 Phase 1)"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-safety-authority/Cargo.toml
+++ b/crates/kirra-safety-authority/Cargo.toml
@@ -21,6 +21,10 @@
 name = "kirra-safety-authority"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Kirra safety-authority core (ADR-0035 Stage 3) — the pure, AppState-free posture-decision surface: FleetNodePosture, the fleet-fold, the RSS recovery streak, and the fail-closed LockoutReason codes. No service/DB deps."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-sidecars/Cargo.toml
+++ b/crates/kirra-sidecars/Cargo.toml
@@ -30,6 +30,10 @@
 name = "kirra-sidecars"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Shipped doer-side sidecar services: Occy planner, Taj perception, and the Mick typed-intent endpoint"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-taj/Cargo.toml
+++ b/crates/kirra-taj/Cargo.toml
@@ -17,6 +17,10 @@
 name = "kirra-taj"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Taj — R2 perception layer (ADR-0015) Phase A: raw range data → the Kirra perception input contract (corridor + objects + health). Geometric, model-free."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-timing/Cargo.toml
+++ b/crates/kirra-timing/Cargo.toml
@@ -17,6 +17,10 @@
 name = "kirra-timing"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Certifiable no_std/zero-alloc WCET timing-instrumentation primitives (min/avg/max/jitter + percentiles, env-tagged reports) for the QNX target campaign (#274)"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"

--- a/crates/kirra-trajectory/Cargo.toml
+++ b/crates/kirra-trajectory/Cargo.toml
@@ -22,6 +22,10 @@
 name = "kirra-trajectory"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Lean trajectory checker for the Kirra stack — containment + per-pose kinematics + RSS + predictive RSS, over kirra-core types. ROS-free, async-free."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-wcet-bench/Cargo.toml
+++ b/crates/kirra-wcet-bench/Cargo.toml
@@ -16,6 +16,10 @@
 name = "kirra-wcet-bench"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "DEV host-indicative WCET report generator: measures the governor verdict path via kirra-timing and emits an env-tagged CSV/table. Not a certified-WCET artifact (#274)."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/crates/kirra-wire-client/Cargo.toml
+++ b/crates/kirra-wire-client/Cargo.toml
@@ -11,6 +11,10 @@
 name = "kirra-wire-client"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "DEV/TEST client-side mirror of the kirra-governor-service UDP wire schema (serde + bincode). Not a safety artifact."
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"

--- a/deny.toml
+++ b/deny.toml
@@ -23,10 +23,16 @@
 # advisory pass unseen instead.
 
 [graph]
-# Resolve the graph for the shipped feature set (default features), all
-# targets we release for. --all-features would drag CI/hardware-gated
-# resolution (ros2/r2r, TensorRT) into the policy graph.
-all-features = false
+# Resolve the FULL feature graph (#797 F3 / #775): the `ros2` (r2r + ROS
+# message chain) and `tpm` (tss-esapi + bindgen chain) trees are built and
+# shipped by CI, so they must be license/ban/source/advisory-checked like
+# everything else — feature-gated is not exempt. Resolution is metadata-only
+# (from the committed lockfiles); no ROS/TPM system libraries are needed.
+# What STAYS outside this policy graph: the workspace-DETACHED harness trees
+# (fuzz/, verification/kani, kirra-loom-models, kirra-verifier-pg,
+# tools/iceoryx2-spike) with their own lockfiles, and native SDKs linked on
+# hardware at build time (TensorRT) that are not crates.io dependencies.
+all-features = true
 targets = [
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
@@ -51,6 +57,11 @@ allow = [
     "BSL-1.0",
     "Unicode-3.0",
     "CDLA-Permissive-2.0",
+    # Apache-2.0 with the LLVM binary-embedding exception — strictly MORE
+    # permissive than plain Apache-2.0 (the exception only removes the §4
+    # notice burden when embedding in binaries). Enters the full-feature
+    # graph via target-lexicon (tss-esapi-sys/bindgen build chain, #797 F3).
+    "Apache-2.0 WITH LLVM-exception",
 ]
 confidence-threshold = 0.8
 
@@ -89,4 +100,11 @@ ignore = [
     # only (no known vulnerability). Remove when the dependents migrate to
     # rustls-pki-types PemObject (track reqwest/rustls bumps).
     { id = "RUSTSEC-2025-0134", reason = "unmaintained; no drop-in upgrade; parses operator-supplied PEM only" },
+    # paste is unmaintained (advisory is unmaintained-class only, no known
+    # vulnerability). It is a COMPILE-TIME proc-macro (token pasting) with
+    # zero runtime footprint, pinned by the r2r 0.9.5 ROS bindings chain —
+    # surfaced only now that the policy graph covers the ros2 feature tree
+    # (#797 F3). Not bumpable from this repo. Remove when r2r moves off
+    # paste (track r2r releases > 0.9.5).
+    { id = "RUSTSEC-2024-0436", reason = "unmaintained; compile-time-only proc-macro; pinned by r2r 0.9.5; remove on r2r upgrade" },
 ]

--- a/docs/VERSIONING_POLICY.md
+++ b/docs/VERSIONING_POLICY.md
@@ -69,9 +69,12 @@ it is the natural removal milestone for the §5.1 shims below.
 
 ## 3. MSRV (Minimum Supported Rust Version)
 
-- **Current MSRV: 1.88** — pinned as `rust-version` in the root
-  `Cargo.toml` and in `parko/crates/parko-core/Cargo.toml` (the base crate
-  of the parko workspace), and verified empirically against both committed
+- **Current MSRV: 1.88** — pinned ONCE per workspace as
+  `[workspace.package] rust-version` (root `Cargo.toml` and
+  `parko/Cargo.toml`); **every member inherits it** via
+  `rust-version.workspace = true` (#797 F3), so `cargo <cmd> -p <member>` on
+  an old toolchain fails the rust-version check up front rather than dying
+  mid-compile in a dependency. Verified empirically against both committed
   lockfiles (`cargo +1.88.0 check --workspace --locked`); the floor is set
   by locked dependencies (`time-core 0.1.9` requires 1.88), not by our own
   code (`u64::is_multiple_of` needs 1.87).
@@ -79,7 +82,8 @@ it is the natural removal milestone for the §5.1 shims below.
   `rust-version`), instead of failing cryptically mid-compile.
 - **Raising the MSRV is a deliberate act:** a MINOR version bump, a
   CHANGELOG entry stating the new floor and what forced it, and an update
-  to the two `rust-version` fields plus this document. Routine `cargo
+  to the two `[workspace.package] rust-version` fields (root + parko), the
+  `msrv` CI-lane toolchain pin, plus this document. Routine `cargo
   update` must not silently raise the effective floor past the pinned MSRV
   — if it would, either pin the dependency back or raise the MSRV by this
   process.

--- a/parko/Cargo.toml
+++ b/parko/Cargo.toml
@@ -2,6 +2,12 @@
 members = ["crates/parko-core", "crates/parko-onnx", "crates/parko-kirra", "crates/parko-ros2", "crates/parko-openvino", "crates/parko-tensorrt"]
 resolver = "2"
 
+# One MSRV source of truth for the parko workspace (#797 F3 / policy §3):
+# every member inherits via `rust-version.workspace = true`. Bump in lock-step
+# with the ROOT workspace's [workspace.package] and the ci.yml `msrv` lane.
+[workspace.package]
+rust-version = "1.88"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/parko/crates/parko-core/Cargo.toml
+++ b/parko/crates/parko-core/Cargo.toml
@@ -2,9 +2,10 @@
 name = "parko-core"
 version = "0.1.0"
 edition = "2021"
-# Workspace MSRV floor (WS-0.7, docs/VERSIONING_POLICY.md §3) — parko-core is
-# the base crate every parko member depends on, so this bounds the workspace.
-rust-version = "1.88"
+# Workspace MSRV floor (WS-0.7, docs/VERSIONING_POLICY.md §3) — inherited from
+# parko/Cargo.toml [workspace.package]; every parko member carries the same
+# inheritance, so the floor bounds the workspace at every entry point (#797 F3).
+rust-version.workspace = true
 description = "Core types and traits for vendor-neutral ML inference runtime"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../../COPYRIGHT"

--- a/parko/crates/parko-kirra/Cargo.toml
+++ b/parko/crates/parko-kirra/Cargo.toml
@@ -2,6 +2,10 @@
 name = "parko-kirra"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "Adapter that bridges parko-core's SafetyGovernor trait to the kirra-core kinematics contract"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../../COPYRIGHT"

--- a/parko/crates/parko-onnx/Cargo.toml
+++ b/parko/crates/parko-onnx/Cargo.toml
@@ -2,6 +2,10 @@
 name = "parko-onnx"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "ONNX Runtime backend for parko-core via ort"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../../COPYRIGHT"

--- a/parko/crates/parko-openvino/Cargo.toml
+++ b/parko/crates/parko-openvino/Cargo.toml
@@ -15,6 +15,10 @@
 name = "parko-openvino"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "OpenVINO inference backend for parko-core (CPU device; runtime-linked)"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../../COPYRIGHT"

--- a/parko/crates/parko-ros2/Cargo.toml
+++ b/parko/crates/parko-ros2/Cargo.toml
@@ -17,6 +17,10 @@
 name = "parko-ros2"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "ROS 2 node for Parko's end-to-end ML control path (M2; parallel to kirra-ros2-adapter)"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../../COPYRIGHT"

--- a/parko/crates/parko-tensorrt/Cargo.toml
+++ b/parko/crates/parko-tensorrt/Cargo.toml
@@ -2,6 +2,10 @@
 name = "parko-tensorrt"
 version = "0.1.0"
 edition = "2021"
+# MSRV floor inherited from the workspace root ([workspace.package]) — one
+# source of truth per workspace, so `cargo <cmd> -p <member>` on an old
+# toolchain fails the rust-version check up front, never mid-compile (#797 F3).
+rust-version.workspace = true
 description = "TensorRT (NVIDIA Jetson) backend for parko-core via ort's TensorRT execution provider"
 repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../../COPYRIGHT"


### PR DESCRIPTION
Closes the five items left open on #797 after #821 landed the `msrv` lane. One commit; every change verified locally (all four cargo-deny checks green over both workspaces under the new policy, plus pin-actions / version-ordering / guardrails / orphan-cores / fence / fmt).

## F3 (#776) — MSRV inheritance
`[workspace.package] rust-version = "1.88"` in **both** workspace roots; every member inherits (`rust-version.workspace = true` — 38 inserted, 3 explicit pins converted), so `cargo <cmd> -p <member>` on an old toolchain fails the rust-version check up front instead of dying mid-compile. Verified via `cargo metadata`: every member of both workspaces now reports the floor. Detached harness trees can't inherit and stay lane-pinned. `msrv` lane comment + `VERSIONING_POLICY.md` §3 updated (the number now lives in exactly three lock-step places: two `[workspace.package]` fields + the lane pin).

## F3 (#775) — deny gate over the full feature graph
`deny.toml [graph] all-features = true` — set in the one policy file rather than per-invocation, so local `cargo deny` runs resolve identically to CI. The `ros2` (r2r + ROS message chain) and `tpm` (tss-esapi + bindgen) trees are CI-built and shipped; they are now license/ban/source/advisory-checked like everything else. The `[graph]` comment carries the inventory of what stays outside the policy graph (detached harness trees; on-hardware native SDKs that aren't crates.io deps).

**The wider graph immediately caught two real findings**, both triaged per policy:
- `target-lexicon` — `Apache-2.0 WITH LLVM-exception` → allowlisted (strictly more permissive than plain Apache-2.0; justification inline).
- `paste` — RUSTSEC-2024-0436 (unmaintained-class, compile-time-only proc-macro, pinned by r2r 0.9.5, not bumpable from this repo) → scoped `[advisories].ignore` entry with a removal condition (r2r upgrade).

## F4 remainder (#775) — scheduled advisory scan
`.github/workflows/advisories-cron.yml` (own workflow, the kpi-campaign-nightly precedent): daily scan of both workspaces; on findings, `ci/file_advisory_issue.py` files **one** tracking issue, threads repeat findings into it as comments, and self-closes it on the first clean scan. Pure stdlib over the GitHub API — nothing new to SHA-pin (M-6). Decision logic unit-tested against a mocked API (create / thread / self-close / a PR with the marker title is excluded).

## F6 (#776) — ghcr tag-ordering guard
`ci/check_ghcr_tag_ordering.py`, wired into `docker.yml` before **both** image builds (verifier + dashboard via `GHCR_PACKAGE`): no published ghcr tag may semver-exceed the version being built — the registry half of the A4 (#1049) guard (`check_version_ordering.py` covers the in-repo line). The pre-existing Aegis `1.5.0`/`1.5` tags are allowlisted with justifications in `ci/ghcr_legacy_tags.json` **pending owner deletion or re-tag** (that half remains owner-action; stale allowlist entries are flagged for removal once done). Fail-closed on an unreadable registry. Tag parsing/ordering unit-tested — partial tags (`1.5`) compare by their floor, exactly how a floating-tag consumer resolves them; `latest`/`main`/`sha-*`/`aegis-*` are ignored.

## F9 (#775) — the symlink pin
The supply-chain job now **asserts** `parko/deny.toml` is a symlink to `../deny.toml` before any parko check runs (a replaced regular file would silently fork the policy), and the two comments that previously overstated the one-policy claim now point at the pin step.

## Owner action remaining after merge (tracked on #797)
Delete or re-tag ghcr `1.5.0`/`1.5` (e.g. `aegis-1.5.0`), then remove both entries from `ci/ghcr_legacy_tags.json` — the guard flags them as stale from that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_