### PR TITLE
website: close review-pass gaps — Contact, Diagnostics, developer orientation

### DIFF
--- a/website/404.html
+++ b/website/404.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -103,6 +104,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -131,6 +133,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/REDESIGN.md
+++ b/website/REDESIGN.md
@@ -291,3 +291,41 @@ HTML (no client-side rendering of content) so every claim is crawlable.
 | Careers page has no job listings | No roles exist in the repository; inventing them would violate the no-fabrication rule. Culture claims cite commit-visible practices instead. |
 | Field Notes keeps the 3-tier feed fallback | Preserved from the prior implementation because its resilience design (Substack 403s from datacenter IPs) is documented in the old `notes.js` and the deploy workflow. |
 | Preloader ported from the old site | The "VERIFYING FLEET POSTURE" boot sequence was the prior site's most on-brand moment. Rebuilt dependency-free: homepage only, once per session, ~1.3 s, skipped under `prefers-reduced-motion`, armed only when JS runs (can never block a no-JS visit), 3 s hard failsafe. |
+
+---
+
+## 14. Review-pass addendum (second full audit, post-launch)
+
+A second audit of the shipped site against the expanded brief (customers, government,
+investors, acquirers) found four genuine gaps, all closed:
+
+| Gap | Why it weakened the company | Fix |
+|---|---|---|
+| No contact/commercial path anywhere | An acquirer, partner, or customer literally could not reach the company — the single largest credibility gap; signals "project," not "company" | `contact.html`: commercial/partnership, technical-evaluation/due-diligence, security-disclosure, and community doors, each with honest expectations (only the documented 48 h security SLA is promised); Contact in nav + footer |
+| No diagnostics/observability page | Operators and evaluators judge maturity by day-2 tooling; the repo has a strong story (posture-exempt metrics, SSE stream, explainable verdicts, three consoles, drift detection) that was invisible | `diagnostics.html` with the lockout-survivable scrape rationale, Prometheus series table, console honesty rule, and drift/lifecycle monitors |
+| Thin developer orientation | Evaluating engineers had quickstart + gates but no map of the tree, demos, or API entry points | Open Source page gains "Find your way around in five minutes": trust-organized repo map, runnable demos (inline loop, CARLA, proposal bench), CI-built examples |
+| CTAs terminated at GitHub | No path from interest to conversation (demos, partnership, commercial) | Contact CTAs added to Vision and nav; evaluation door points at release evidence bundles |
+
+## 15. Remaining opportunities, ranked (engineering value × business impact)
+
+1. **Demo footage of the R2 refusing a bad command** — nothing on the site shows the
+   governor *acting*; 30 seconds of real hardware denying a hallucinated command would
+   outperform every diagram. (High impact; needs camera + a bring-up session.)
+2. **Live/interactive verdict playground** — a WASM build of the pure checker core
+   (`validate_vehicle_command` is `no_std`, zero-dep — it would compile) letting
+   visitors submit a command and watch the deny codes. Uniquely credible: the real code
+   in the page. (High impact; moderate effort; keep clearly labeled as the real core.)
+3. **Per-vertical landing pages** (OT/utilities first — the Oldsmar story carries it),
+   fed by `docs/MARKET_AUTONOMOUS_SERVICES.md`. (Medium-high; low effort with the
+   existing page generator.)
+4. **Published Lighthouse/a11y scores in the footer** — the site targets them; showing
+   measured numbers (like every other claim on the site) closes the loop. Requires
+   running Lighthouse in CI and baking the badge. (Medium; low effort.)
+5. **Case-study page for the July 2026 R2 bring-up** — the runbooks and hardware
+   findings are already public; a narrative page with photos would humanize the
+   engineering. (Medium; needs photos that don't exist in-repo.)
+6. **Team/About depth** — evaluators eventually ask "who builds this." Not fabricatable
+   from the repository; needs founder-supplied bio/photo before it can ship. (Medium
+   impact; blocked on non-repo content.)
+7. **Search across docs** — a static Lunr-style index over `docs/` titles for the
+   Documentation page. (Low-medium; moderate effort.)

--- a/website/_src/pages/contact.mjs
+++ b/website/_src/pages/contact.mjs
@@ -1,0 +1,71 @@
+import { SITE, ev, evRow, pageHero } from "../template.mjs";
+
+export const meta = {
+  slug: "contact",
+  title: "Contact",
+  desc: "Talk to Kirra Systems: commercial and partnership inquiries, technical evaluation and due diligence, coordinated security disclosure, and open-source collaboration.",
+};
+
+export const body = `
+${pageHero({
+  eyebrow: "Contact",
+  title: "Talk to the people<br>who wrote the code.",
+  lede: "Kirra Systems doesn't route you through a sales layer — inquiries go to the engineering that builds the governor. Pick the door that matches your question; each one tells you exactly what to expect.",
+})}
+
+    <section aria-labelledby="h-doors">
+      <div class="container">
+        <h2 id="h-doors" class="visually-hidden">Contact channels</h2>
+        <div class="grid grid--2">
+          <div class="card" data-reveal>
+            <h3>Commercial &amp; partnerships</h3>
+            <p>Deploying Kirra in a vehicle program, robotics fleet, or industrial platform — or exploring a
+            strategic partnership or platform integration. Tell us your machine class and what proposes commands
+            to it; we'll tell you honestly whether the governor fits today or belongs on the roadmap.</p>
+            <a class="btn btn--primary" style="margin-top:18px" href="mailto:justin.looney@kirrasystems.com?subject=Commercial%20inquiry%20%E2%80%94%20Kirra">justin.looney@kirrasystems.com</a>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Technical evaluation &amp; due diligence</h3>
+            <p>Evaluating the platform seriously? Start where a diligence team should: the repository, the 27
+            blocking CI lanes, and the safety-case evidence bundle attached to every tagged release. Then bring
+            us your hardest questions — we prefer evaluators who arrive skeptical.</p>
+            <div class="hero__ctas" style="margin-top:18px">
+              <a class="btn btn--ghost" href="${SITE.repo}" target="_blank" rel="noopener">The repository ↗</a>
+              <a class="btn btn--ghost" href="mailto:justin.looney@kirrasystems.com?subject=Technical%20evaluation%20%E2%80%94%20Kirra">Ask us directly</a>
+            </div>
+            ${evRow(".github/workflows/release.yml", "ci/build_safety_case.py")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Security disclosure</h3>
+            <p>Found a vulnerability — or got an unsafe command past the checker? Coordinated disclosure with a
+            documented 48-hour first response. If you can break the envelope, we want the writeup more than
+            you do.</p>
+            <a class="btn btn--ghost" style="margin-top:18px" href="${SITE.repo}/blob/main/SECURITY.md" target="_blank" rel="noopener">Read the disclosure policy ↗</a>
+            ${evRow("SECURITY.md")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Open source &amp; community</h3>
+            <p>Bug reports, feature discussions, and contributions run through GitHub in the open — the same
+            gates apply to everyone, including us. Long-form engineering notes ship on Field Notes.</p>
+            <div class="hero__ctas" style="margin-top:18px">
+              <a class="btn btn--ghost" href="${SITE.repo}/issues" target="_blank" rel="noopener">Open an issue ↗</a>
+              <a class="btn btn--ghost" href="field-notes.html">Field Notes</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-expect">
+      <div class="container container--narrow" style="text-align:center">
+        <p class="eyebrow" data-reveal style="justify-content:center">What to expect</p>
+        <h2 id="h-expect" data-reveal>The same honesty you see on this site</h2>
+        <p class="lede" data-reveal style="margin:18px auto 0">If a capability is experimental, we'll say so before you
+        commit anything to it — the repository labels its spikes and drafts, and so do we. Security reports get a
+        first response within 48 hours; everything else gets a direct answer from the people building the system,
+        not a qualification funnel.</p>
+      </div>
+    </section>
+`;

--- a/website/_src/pages/diagnostics.mjs
+++ b/website/_src/pages/diagnostics.mjs
@@ -1,0 +1,145 @@
+import { ev, evRow, pageHero, ctaBand, LIVE } from "../template.mjs";
+
+export const meta = {
+  slug: "diagnostics",
+  title: "Diagnostics",
+  desc: "Kirra's observability surface: fleet posture APIs and live event streams, explainable denial verdicts, Prometheus metrics that survive lockout, tamper-evident audit export, and three operator consoles.",
+};
+
+export const body = `
+${pageHero({
+  eyebrow: "Diagnostics &amp; observability",
+  title: "You can't govern<br>what you can't see.",
+  lede: "A safety governor that goes dark under failure is worse than none — operators must be able to tell “locked out” from “down” at 2 AM. Kirra's observability surface is engineered for exactly that moment: reads survive lockout, denials explain themselves, and the audit trail proves its own integrity.",
+})}
+
+    <section aria-labelledby="h-surface">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>The operator surface</p>
+          <h2 id="h-surface" data-reveal>Observability that survives the bad day</h2>
+          <p class="lede" data-reveal>Observability GETs are deliberately posture-exempt: a read cannot actuate,
+          and blocking it would remove fleet visibility exactly when an operator needs it most. Writes on the
+          same prefixes stay fully gated.</p>
+        </div>
+        <div class="grid grid--3">
+          <div class="card" data-reveal>
+            <h3>Fleet posture, live</h3>
+            <p>Point-in-time posture per fleet and per node, time-series history, flap detection, and a
+            server-sent-events stream of every posture transition — each event carrying its generation number,
+            so consumers can detect reordering and staleness.</p>
+            ${evRow("src/posture_engine_v2.rs", "src/verifier.rs")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Denials that explain themselves</h3>
+            <p>Every denied actuator command mints a verdict id and becomes a signed, human-readable artifact:
+            the machine deny-code, an operator-language explanation, the exact recorded inputs, and the audit-chain
+            fields — served to the auditor role at <code>GET /verdicts/{id}</code>.</p>
+            ${evRow("src/verdicts.rs")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>An audit trail that proves itself</h3>
+            <p>Chain verification and export endpoints let an operator — or a regulator — confirm ledger integrity
+            on demand, and the shipped off-box stream re-verifies independently with no access to the source
+            database.</p>
+            ${evRow("src/audit_chain.rs", "src/audit_shipper.rs")}
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-metrics">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Metrics</p>
+          <h2 id="h-metrics" data-reveal>A scrape that survives lockout</h2>
+          <p class="lede" data-reveal>The Prometheus endpoint is posture-exempt so monitoring keeps working while
+          the fleet is locked out — the moment dashboards matter most. Fleet-safety series sit alongside rollout
+          and credential-lifecycle series.</p>
+        </div>
+        <div class="table-wrap" data-reveal>
+          <table class="tbl">
+            <caption class="visually-hidden">Selected Prometheus series</caption>
+            <thead><tr><th scope="col">Series</th><th scope="col">What it tells an operator</th></tr></thead>
+            <tbody>
+              <tr><td class="mono">kirra_ota_campaigns_total{state}</td><td>Rollout campaigns by lifecycle state — a halted campaign is visible fleet-wide</td></tr>
+              <tr><td class="mono">kirra_ota_campaign_rollout_percent</td><td>Staged rollout progress per campaign</td></tr>
+              <tr><td class="mono">kirra_ota_campaign_applied_nodes</td><td>Adoption numerator — which nodes actually run the artifact</td></tr>
+              <tr><td class="mono">kirra_cert_principals{state}</td><td>mTLS credential census: active, revoked, expired, expiring soon</td></tr>
+            </tbody>
+          </table>
+        </div>
+        ${evRow("src/metrics.rs", "src/health.rs")}
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-consoles">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Operator tooling</p>
+          <h2 id="h-consoles" data-reveal>Three consoles, one honesty rule</h2>
+          <p class="lede" data-reveal>Operator UIs never overstate what happened. The air-gapped console renders a
+          clearance grant as “GRANT RECORDED — DELIVERY PENDING” rather than implying a vehicle was released —
+          the fail-closed philosophy applied to pixels.</p>
+        </div>
+        <div class="grid grid--3">
+          <div class="card" data-reveal>
+            <h3>Fleet console</h3>
+            <p>The full operator application: posture trends, envelope plots, fleet topology and position maps,
+            version-adoption views, incident replay maps, and audit evidence browsing.</p>
+            ${evRow("console/", "docs/CONSOLE_RUNBOOK.md")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Air-gapped console</h3>
+            <p>A single self-contained HTML file — inline styles and scripts, no CDN, no build — for secured
+            environments where the recovery surface must work with nothing but a browser.</p>
+            ${evRow("static/console.html")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Ops dashboard</h3>
+            <p>A lightweight dashboard shipped alongside the verifier in Docker Compose, with its own isolated
+            request pool so an API flood can't starve the operator's view — and vice versa.</p>
+            ${evRow("dashboard/", "docker-compose.yml")}
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-drift">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Health &amp; drift</p>
+          <h2 id="h-drift" data-reveal>The quiet failures, made loud</h2>
+        </div>
+        <div class="grid grid--3">
+          <div class="card" data-reveal>
+            <h3>Config drift detection</h3>
+            <p>Every boot commits a SHA-256 digest of the effective configuration to the audit chain, and unknown
+            <code>KIRRA_*</code> variables warn at startup — a typo'd setting that silently isn't taking effect
+            becomes visible instead of latent.</p>
+            ${evRow("src/env_config.rs")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Credential lifecycle</h3>
+            <p>An hourly census warns on expiring and lapsed mTLS principals with hash-chained audit entries —
+            pure observability, because the auth path already fail-closes expiry on its own.</p>
+            ${evRow("src/cert_expiry_monitor.rs")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Liveness watchdogs</h3>
+            <p>Telemetry silence, stale posture caches, and silent redundancy channels all surface as posture
+            changes within their sweep budgets — absence of data is itself a monitored signal.</p>
+            ${evRow("src/telemetry_watchdog.rs")}
+          </div>
+        </div>
+      </div>
+    </section>
+
+${ctaBand("See the whole system's state in one place.", "Bring up the verifier and dashboard with Docker Compose, watch the posture stream, and pull a verdict explanation yourself.")}
+`;

--- a/website/_src/pages/open-source.mjs
+++ b/website/_src/pages/open-source.mjs
@@ -57,6 +57,51 @@ curl -N localhost:8090/system/posture/stream \\
 
     <hr class="rule">
 
+    <section aria-labelledby="h-orient">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Developer orientation</p>
+          <h2 id="h-orient" data-reveal>Find your way around in five minutes</h2>
+          <p class="lede" data-reveal>The tree is organized by trust, not by feature — knowing that makes the whole
+          repository legible.</p>
+        </div>
+        <div class="grid grid--2" style="align-items:start">
+          <div class="table-wrap" data-reveal>
+            <table class="tbl" style="min-width:0">
+              <caption class="visually-hidden">Repository map</caption>
+              <thead><tr><th scope="col">Path</th><th scope="col">What lives there</th></tr></thead>
+              <tbody>
+                <tr><td class="mono">crates/</td><td>The checker &amp; platform — trajectory validation, planner, maps, transports, OTA</td></tr>
+                <tr><td class="mono">src/</td><td>The verifier control plane — posture, attestation, audit, HTTP service</td></tr>
+                <tr><td class="mono">parko/</td><td>Separate ML workspace — inference backends, diverse second governor</td></tr>
+                <tr><td class="mono">verification/ · fuzz/</td><td>Kani proofs over shipped source; standing fuzz targets</td></tr>
+                <tr><td class="mono">tools/</td><td>Isolated spikes — iceoryx2 carrier, QNX shim/judge harness</td></tr>
+                <tr><td class="mono">robot/ · firmware/</td><td>The physical R2 testbed scripts and clean-room MCU firmware</td></tr>
+                <tr><td class="mono">docs/</td><td>36 ADRs, 65 safety artifacts, hardware runbooks, specs</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div style="display:grid;gap:14px">
+            <div class="card" data-reveal>
+              <h3 style="font-size:1.05rem">Runnable demonstrations</h3>
+              <p>The in-line governor demo drives the full read→decide→sign→verify→release loop across a real
+              process boundary; the CARLA client runs the governor against a simulator; the proposal bench sweeps
+              a live governor with hostile proposals and prints its verdicts.</p>
+              ${evRow("crates/kirra-inline-governor", "src/bin/kirra_carla_client.rs", "crates/kirra-proposal-bench")}
+            </div>
+            <div class="card" data-reveal>
+              <h3 style="font-size:1.05rem">APIs &amp; examples</h3>
+              <p><code>cargo doc --open</code> builds the full API reference (deny-warnings enforced). The governor
+              quickstart example and the C SDK example both build and run in CI, so they're never stale.</p>
+              ${evRow("examples/", ".github/workflows/ci.yml:323")}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
     <section aria-labelledby="h-contrib">
       <div class="container">
         <div class="section-head">

--- a/website/_src/pages/vision.mjs
+++ b/website/_src/pages/vision.mjs
@@ -158,6 +158,7 @@ ${pageHero({
         <div class="hero__ctas" style="justify-content:center" data-reveal>
           <a class="btn btn--primary" href="solutions.html">See it applied <span class="arrow" aria-hidden="true">→</span></a>
           <a class="btn btn--ghost" href="architecture.html">See how it's built</a>
+          <a class="btn btn--ghost" href="contact.html">Start a conversation</a>
         </div>
       </div>
     </section>

--- a/website/_src/template.mjs
+++ b/website/_src/template.mjs
@@ -47,6 +47,7 @@ const NAV_LINKS = [
   ["safety.html", "Safety"],
   ["certification.html", "Certification"],
   ["field-notes.html", "Field Notes"],
+  ["contact.html", "Contact"],
 ];
 
 const SUBNAV = [
@@ -54,6 +55,7 @@ const SUBNAV = [
   ["vision.html", "vision"],
   ["architecture.html", "architecture"],
   ["runtime.html", "runtime"],
+  ["diagnostics.html", "diagnostics"],
   ["safety.html", "safety"],
   ["planning.html", "planning"],
   ["perception.html", "perception"],
@@ -82,6 +84,7 @@ const FOOTER = `
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -110,6 +113,7 @@ const FOOTER = `
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="${SITE.repo}" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/architecture.html
+++ b/website/architecture.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html" aria-current="page">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -367,6 +369,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -395,6 +398,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -245,6 +247,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -273,6 +276,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/certification.html
+++ b/website/certification.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html" aria-current="page">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -232,6 +234,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -260,6 +263,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/contact.html
+++ b/website/contact.html
@@ -3,20 +3,20 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Careers — Kirra Systems</title>
-  <meta name="description" content="How engineering works at Kirra Systems: fail-closed by default, evidence over assertion, proofs where they matter — and how to get involved through the open repository.">
-  <link rel="canonical" href="https://kirrasystems.com/careers.html">
+  <title>Contact — Kirra Systems</title>
+  <meta name="description" content="Talk to Kirra Systems: commercial and partnership inquiries, technical evaluation and due diligence, coordinated security disclosure, and open-source collaboration.">
+  <link rel="canonical" href="https://kirrasystems.com/contact.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Kirra Systems">
-  <meta property="og:title" content="Careers — Kirra Systems">
-  <meta property="og:description" content="How engineering works at Kirra Systems: fail-closed by default, evidence over assertion, proofs where they matter — and how to get involved through the open repository.">
-  <meta property="og:url" content="https://kirrasystems.com/careers.html">
+  <meta property="og:title" content="Contact — Kirra Systems">
+  <meta property="og:description" content="Talk to Kirra Systems: commercial and partnership inquiries, technical evaluation and due diligence, coordinated security disclosure, and open-source collaboration.">
+  <meta property="og:url" content="https://kirrasystems.com/contact.html">
   <meta property="og:image" content="https://kirrasystems.com/assets/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Careers — Kirra Systems">
-  <meta name="twitter:description" content="How engineering works at Kirra Systems: fail-closed by default, evidence over assertion, proofs where they matter — and how to get involved through the open repository.">
+  <meta name="twitter:title" content="Contact — Kirra Systems">
+  <meta name="twitter:description" content="Talk to Kirra Systems: commercial and partnership inquiries, technical evaluation and due diligence, coordinated security disclosure, and open-source collaboration.">
   <meta name="twitter:image" content="https://kirrasystems.com/assets/og.png">
   <meta name="theme-color" content="#05070d">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
@@ -27,7 +27,7 @@
   <link rel="stylesheet" href="css/kirra.css">
   <script>/* theme init before first paint — prevents flash */
 (function(){try{var t=localStorage.getItem("kirra-theme");if(!t)t=matchMedia("(prefers-color-scheme: light)").matches?"light":"dark";document.documentElement.dataset.theme=t;}catch(e){document.documentElement.dataset.theme="dark";}})();</script>
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Careers — Kirra Systems","description":"How engineering works at Kirra Systems: fail-closed by default, evidence over assertion, proofs where they matter — and how to get involved through the open repository.","url":"https://kirrasystems.com/careers.html","isPartOf":{"@type":"WebSite","name":"Kirra Systems","url":"https://kirrasystems.com"}}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Contact — Kirra Systems","description":"Talk to Kirra Systems: commercial and partnership inquiries, technical evaluation and due diligence, coordinated security disclosure, and open-source collaboration.","url":"https://kirrasystems.com/contact.html","isPartOf":{"@type":"WebSite","name":"Kirra Systems","url":"https://kirrasystems.com"}}</script>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -52,7 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
-        <a href="contact.html">Contact</a>
+        <a href="contact.html" aria-current="page">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -91,45 +91,50 @@
 
     <section class="page-hero">
       <div class="container">
-        <p class="eyebrow" data-reveal>Careers</p>
-        <h1 data-reveal>Work where “trust me”<br>isn't an argument.</h1>
-        <p class="lede" data-reveal>Kirra doesn't maintain a list of open roles on this site. What we can show you — verifiably — is how the engineering actually works here, because all of it is public. If that culture reads like home, the door is the repository.</p>
+        <p class="eyebrow" data-reveal>Contact</p>
+        <h1 data-reveal>Talk to the people<br>who wrote the code.</h1>
+        <p class="lede" data-reveal>Kirra Systems doesn't route you through a sales layer — inquiries go to the engineering that builds the governor. Pick the door that matches your question; each one tells you exactly what to expect.</p>
       </div>
     </section>
 
-    <section aria-labelledby="h-culture">
+    <section aria-labelledby="h-doors">
       <div class="container">
-        <div class="section-head">
-          <p class="eyebrow" data-reveal>How we work</p>
-          <h2 id="h-culture" data-reveal>The culture is in the commit history</h2>
-        </div>
+        <h2 id="h-doors" class="visually-hidden">Contact channels</h2>
         <div class="grid grid--2">
           <div class="card" data-reveal>
-            <h3>Deny by default — in code review too</h3>
-            <p>The security invariants exist because people tried to violate them and were reverted. A change that
-            weakens attestation, bypasses the admin gate, or removes the Unknown-command denial is rejected outright,
-            no matter how convenient. Guardrails are scripted, not vibes.</p>
-            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/SECURITY.md" target="_blank" rel="noopener">SECURITY.md</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/ci/check_quality_guardrails.py" target="_blank" rel="noopener">ci/check_quality_guardrails.py</a></p>
+            <h3>Commercial &amp; partnerships</h3>
+            <p>Deploying Kirra in a vehicle program, robotics fleet, or industrial platform — or exploring a
+            strategic partnership or platform integration. Tell us your machine class and what proposes commands
+            to it; we'll tell you honestly whether the governor fits today or belongs on the roadmap.</p>
+            <a class="btn btn--primary" style="margin-top:18px" href="mailto:justin.looney@kirrasystems.com?subject=Commercial%20inquiry%20%E2%80%94%20Kirra">justin.looney@kirrasystems.com</a>
           </div>
           <div class="card" data-reveal>
-            <h3>Evidence over assertion</h3>
-            <p>“It works” means a test, a proof, a drill, or a measurement — with its scope stated. Draft artifacts
-            say Draft. Host benchmarks say host. The README's certification claim includes the sentence most
-            companies leave out.</p>
-            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/README.md#L117" target="_blank" rel="noopener">README.md:117</a></p>
+            <h3>Technical evaluation &amp; due diligence</h3>
+            <p>Evaluating the platform seriously? Start where a diligence team should: the repository, the 27
+            blocking CI lanes, and the safety-case evidence bundle attached to every tagged release. Then bring
+            us your hardest questions — we prefer evaluators who arrive skeptical.</p>
+            <div class="hero__ctas" style="margin-top:18px">
+              <a class="btn btn--ghost" href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">The repository ↗</a>
+              <a class="btn btn--ghost" href="mailto:justin.looney@kirrasystems.com?subject=Technical%20evaluation%20%E2%80%94%20Kirra">Ask us directly</a>
+            </div>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/.github/workflows/release.yml" target="_blank" rel="noopener">.github/workflows/release.yml</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/ci/build_safety_case.py" target="_blank" rel="noopener">ci/build_safety_case.py</a></p>
           </div>
           <div class="card" data-reveal>
-            <h3>Proofs where they pay</h3>
-            <p>We reach for Kani, Loom, and Miri when the property deserves it, and say plainly where the proofs end
-            (the trig path is excluded, and documented as such). Formal methods as a tool, not a religion.</p>
-            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/verification/kani/" target="_blank" rel="noopener">verification/kani/</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/crates/kirra-loom-models/src/lib.rs" target="_blank" rel="noopener">crates/kirra-loom-models/src/lib.rs</a></p>
+            <h3>Security disclosure</h3>
+            <p>Found a vulnerability — or got an unsafe command past the checker? Coordinated disclosure with a
+            documented 48-hour first response. If you can break the envelope, we want the writeup more than
+            you do.</p>
+            <a class="btn btn--ghost" style="margin-top:18px" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/SECURITY.md" target="_blank" rel="noopener">Read the disclosure policy ↗</a>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/SECURITY.md" target="_blank" rel="noopener">SECURITY.md</a></p>
           </div>
           <div class="card" data-reveal>
-            <h3>Real hardware, real humility</h3>
-            <p>First governed motion on a physical robot happened in July 2026 — and the hardware findings doc
-            records exactly what doesn't work yet (steering + drive together awaits a vendor image). We write down
-            the failures with the same care as the wins.</p>
-            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/robot/install/README.md" target="_blank" rel="noopener">robot/install/README.md</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/hardware/HARDWARE_FINDINGS_R2X3.md" target="_blank" rel="noopener">docs/hardware/HARDWARE_FINDINGS_R2X3.md</a></p>
+            <h3>Open source &amp; community</h3>
+            <p>Bug reports, feature discussions, and contributions run through GitHub in the open — the same
+            gates apply to everyone, including us. Long-form engineering notes ship on Field Notes.</p>
+            <div class="hero__ctas" style="margin-top:18px">
+              <a class="btn btn--ghost" href="https://github.com/kirra-systems/kirra-runtime-sdk/issues" target="_blank" rel="noopener">Open an issue ↗</a>
+              <a class="btn btn--ghost" href="field-notes.html">Field Notes</a>
+            </div>
           </div>
         </div>
       </div>
@@ -137,17 +142,14 @@
 
     <hr class="rule">
 
-    <section aria-labelledby="h-join">
+    <section aria-labelledby="h-expect">
       <div class="container container--narrow" style="text-align:center">
-        <p class="eyebrow" data-reveal style="justify-content:center">Getting involved</p>
-        <h2 id="h-join" data-reveal>The interview is a pull request</h2>
-        <p class="lede" data-reveal style="margin:18px auto 0">The fastest way to work with us is to work with us: pick an
-        issue, survive the 27 CI lanes, and defend your change against reviewers who will try to break it. Security
-        researchers: the disclosure policy in SECURITY.md is the front door, and we respond within 48 hours.</p>
-        <div class="hero__ctas" style="justify-content:center" data-reveal>
-          <a class="btn btn--primary" href="https://github.com/kirra-systems/kirra-runtime-sdk/issues" target="_blank" rel="noopener">Open issues <span class="arrow" aria-hidden="true">→</span></a>
-          <a class="btn btn--ghost" href="open-source.html">How contributions are gated</a>
-        </div>
+        <p class="eyebrow" data-reveal style="justify-content:center">What to expect</p>
+        <h2 id="h-expect" data-reveal>The same honesty you see on this site</h2>
+        <p class="lede" data-reveal style="margin:18px auto 0">If a capability is experimental, we'll say so before you
+        commit anything to it — the repository labels its spikes and drafts, and so do we. Security reports get a
+        first response within 48 hours; everything else gets a direct answer from the people building the system,
+        not a qualification funnel.</p>
       </div>
     </section>
 

--- a/website/determinism.html
+++ b/website/determinism.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -224,6 +226,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -252,6 +255,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/diagnostics.html
+++ b/website/diagnostics.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diagnostics — Kirra Systems</title>
+  <meta name="description" content="Kirra's observability surface: fleet posture APIs and live event streams, explainable denial verdicts, Prometheus metrics that survive lockout, tamper-evident audit export, and three operator consoles.">
+  <link rel="canonical" href="https://kirrasystems.com/diagnostics.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Kirra Systems">
+  <meta property="og:title" content="Diagnostics — Kirra Systems">
+  <meta property="og:description" content="Kirra's observability surface: fleet posture APIs and live event streams, explainable denial verdicts, Prometheus metrics that survive lockout, tamper-evident audit export, and three operator consoles.">
+  <meta property="og:url" content="https://kirrasystems.com/diagnostics.html">
+  <meta property="og:image" content="https://kirrasystems.com/assets/og.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Diagnostics — Kirra Systems">
+  <meta name="twitter:description" content="Kirra's observability surface: fleet posture APIs and live event streams, explainable denial verdicts, Prometheus metrics that survive lockout, tamper-evident audit export, and three operator consoles.">
+  <meta name="twitter:image" content="https://kirrasystems.com/assets/og.png">
+  <meta name="theme-color" content="#05070d">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="assets/kirra-logo.png" type="image/png">
+  <link rel="apple-touch-icon" href="assets/kirra-logo.png">
+  <link rel="preload" href="fonts/space-grotesk-var-latin.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="fonts/inter-var-latin.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="stylesheet" href="css/kirra.css">
+  <script>/* theme init before first paint — prevents flash */
+(function(){try{var t=localStorage.getItem("kirra-theme");if(!t)t=matchMedia("(prefers-color-scheme: light)").matches?"light":"dark";document.documentElement.dataset.theme=t;}catch(e){document.documentElement.dataset.theme="dark";}})();</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Diagnostics — Kirra Systems","description":"Kirra's observability surface: fleet posture APIs and live event streams, explainable denial verdicts, Prometheus metrics that survive lockout, tamper-evident audit export, and three operator consoles.","url":"https://kirrasystems.com/diagnostics.html","isPartOf":{"@type":"WebSite","name":"Kirra Systems","url":"https://kirrasystems.com"}}</script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="nav" id="nav">
+    <div class="nav__inner">
+      <a href="index.html" class="nav__brand" aria-label="Kirra Systems home"><svg viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <g stroke="currentColor" stroke-width="1.4" opacity="0.85">
+    <path d="M7 4v24M7 17 25 4M11.5 13.7 25 28"/>
+    <path d="M7 4l7 6.5M7 28l4.5-14.3M14 10.5 7 17" opacity="0.35"/>
+  </g>
+  <g fill="var(--accent, #3fd9c9)">
+    <circle cx="7" cy="4" r="2"/><circle cx="7" cy="17" r="2.4"/><circle cx="7" cy="28" r="2"/>
+    <circle cx="25" cy="4" r="2"/><circle cx="25" cy="28" r="2"/>
+    <circle cx="14" cy="10.5" r="1.5"/><circle cx="11.5" cy="13.7" r="1.5"/>
+  </g>
+</svg><span>KIRRA</span></a>
+      <nav class="nav__links" id="navLinks" aria-label="Primary">
+        <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
+        <a href="architecture.html">Architecture</a>
+        <a href="safety.html">Safety</a>
+        <a href="certification.html">Certification</a>
+        <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
+        <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
+        <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+      </button>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+      </button>
+    </div>
+  </header>
+  <nav class="subnav" aria-label="Platform sections">
+    <div class="subnav__inner">
+      <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
+      <a href="architecture.html">architecture</a>
+      <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html" aria-current="page">diagnostics</a>
+      <a href="safety.html">safety</a>
+      <a href="planning.html">planning</a>
+      <a href="perception.html">perception</a>
+      <a href="prediction.html">prediction</a>
+      <a href="determinism.html">determinism</a>
+      <a href="performance.html">performance</a>
+      <a href="security.html">security</a>
+      <a href="certification.html">certification</a>
+      <a href="benchmarks.html">benchmarks</a>
+      <a href="open-source.html">open source</a>
+      <a href="documentation.html">docs</a>
+      <a href="research.html">research</a>
+    </div>
+  </nav>
+
+  <main id="main">
+
+
+    <section class="page-hero">
+      <div class="container">
+        <p class="eyebrow" data-reveal>Diagnostics &amp; observability</p>
+        <h1 data-reveal>You can't govern<br>what you can't see.</h1>
+        <p class="lede" data-reveal>A safety governor that goes dark under failure is worse than none — operators must be able to tell “locked out” from “down” at 2 AM. Kirra's observability surface is engineered for exactly that moment: reads survive lockout, denials explain themselves, and the audit trail proves its own integrity.</p>
+      </div>
+    </section>
+
+    <section aria-labelledby="h-surface">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>The operator surface</p>
+          <h2 id="h-surface" data-reveal>Observability that survives the bad day</h2>
+          <p class="lede" data-reveal>Observability GETs are deliberately posture-exempt: a read cannot actuate,
+          and blocking it would remove fleet visibility exactly when an operator needs it most. Writes on the
+          same prefixes stay fully gated.</p>
+        </div>
+        <div class="grid grid--3">
+          <div class="card" data-reveal>
+            <h3>Fleet posture, live</h3>
+            <p>Point-in-time posture per fleet and per node, time-series history, flap detection, and a
+            server-sent-events stream of every posture transition — each event carrying its generation number,
+            so consumers can detect reordering and staleness.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/posture_engine_v2.rs" target="_blank" rel="noopener">src/posture_engine_v2.rs</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/verifier.rs" target="_blank" rel="noopener">src/verifier.rs</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Denials that explain themselves</h3>
+            <p>Every denied actuator command mints a verdict id and becomes a signed, human-readable artifact:
+            the machine deny-code, an operator-language explanation, the exact recorded inputs, and the audit-chain
+            fields — served to the auditor role at <code>GET /verdicts/{id}</code>.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/verdicts.rs" target="_blank" rel="noopener">src/verdicts.rs</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>An audit trail that proves itself</h3>
+            <p>Chain verification and export endpoints let an operator — or a regulator — confirm ledger integrity
+            on demand, and the shipped off-box stream re-verifies independently with no access to the source
+            database.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/audit_chain.rs" target="_blank" rel="noopener">src/audit_chain.rs</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/audit_shipper.rs" target="_blank" rel="noopener">src/audit_shipper.rs</a></p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-metrics">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Metrics</p>
+          <h2 id="h-metrics" data-reveal>A scrape that survives lockout</h2>
+          <p class="lede" data-reveal>The Prometheus endpoint is posture-exempt so monitoring keeps working while
+          the fleet is locked out — the moment dashboards matter most. Fleet-safety series sit alongside rollout
+          and credential-lifecycle series.</p>
+        </div>
+        <div class="table-wrap" data-reveal>
+          <table class="tbl">
+            <caption class="visually-hidden">Selected Prometheus series</caption>
+            <thead><tr><th scope="col">Series</th><th scope="col">What it tells an operator</th></tr></thead>
+            <tbody>
+              <tr><td class="mono">kirra_ota_campaigns_total{state}</td><td>Rollout campaigns by lifecycle state — a halted campaign is visible fleet-wide</td></tr>
+              <tr><td class="mono">kirra_ota_campaign_rollout_percent</td><td>Staged rollout progress per campaign</td></tr>
+              <tr><td class="mono">kirra_ota_campaign_applied_nodes</td><td>Adoption numerator — which nodes actually run the artifact</td></tr>
+              <tr><td class="mono">kirra_cert_principals{state}</td><td>mTLS credential census: active, revoked, expired, expiring soon</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/metrics.rs" target="_blank" rel="noopener">src/metrics.rs</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/health.rs" target="_blank" rel="noopener">src/health.rs</a></p>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-consoles">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Operator tooling</p>
+          <h2 id="h-consoles" data-reveal>Three consoles, one honesty rule</h2>
+          <p class="lede" data-reveal>Operator UIs never overstate what happened. The air-gapped console renders a
+          clearance grant as “GRANT RECORDED — DELIVERY PENDING” rather than implying a vehicle was released —
+          the fail-closed philosophy applied to pixels.</p>
+        </div>
+        <div class="grid grid--3">
+          <div class="card" data-reveal>
+            <h3>Fleet console</h3>
+            <p>The full operator application: posture trends, envelope plots, fleet topology and position maps,
+            version-adoption views, incident replay maps, and audit evidence browsing.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/console/" target="_blank" rel="noopener">console/</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/CONSOLE_RUNBOOK.md" target="_blank" rel="noopener">docs/CONSOLE_RUNBOOK.md</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Air-gapped console</h3>
+            <p>A single self-contained HTML file — inline styles and scripts, no CDN, no build — for secured
+            environments where the recovery surface must work with nothing but a browser.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/static/console.html" target="_blank" rel="noopener">static/console.html</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Ops dashboard</h3>
+            <p>A lightweight dashboard shipped alongside the verifier in Docker Compose, with its own isolated
+            request pool so an API flood can't starve the operator's view — and vice versa.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/dashboard/" target="_blank" rel="noopener">dashboard/</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docker-compose.yml" target="_blank" rel="noopener">docker-compose.yml</a></p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-drift">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Health &amp; drift</p>
+          <h2 id="h-drift" data-reveal>The quiet failures, made loud</h2>
+        </div>
+        <div class="grid grid--3">
+          <div class="card" data-reveal>
+            <h3>Config drift detection</h3>
+            <p>Every boot commits a SHA-256 digest of the effective configuration to the audit chain, and unknown
+            <code>KIRRA_*</code> variables warn at startup — a typo'd setting that silently isn't taking effect
+            becomes visible instead of latent.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/env_config.rs" target="_blank" rel="noopener">src/env_config.rs</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Credential lifecycle</h3>
+            <p>An hourly census warns on expiring and lapsed mTLS principals with hash-chained audit entries —
+            pure observability, because the auth path already fail-closes expiry on its own.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/cert_expiry_monitor.rs" target="_blank" rel="noopener">src/cert_expiry_monitor.rs</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Liveness watchdogs</h3>
+            <p>Telemetry silence, stale posture caches, and silent redundancy channels all surface as posture
+            changes within their sweep budgets — absence of data is itself a monitored signal.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/telemetry_watchdog.rs" target="_blank" rel="noopener">src/telemetry_watchdog.rs</a></p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+
+    <section class="cta-band">
+      <div class="container">
+        <p class="eyebrow" style="justify-content:center">READ THE SOURCE</p>
+        <h2>See the whole system's state in one place.</h2>
+        <p class="lede">Bring up the verifier and dashboard with Docker Compose, watch the posture stream, and pull a verdict explanation yourself.</p>
+        <div class="hero__ctas">
+          <a class="btn btn--primary" href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">View the repository <span class="arrow" aria-hidden="true">→</span></a>
+          <a class="btn btn--ghost" href="documentation.html">Browse the documentation</a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+<footer class="footer">
+  <div class="container">
+    <div class="footer__grid">
+      <div class="footer__brand">
+        <a class="nav__brand" href="index.html"><svg viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <g stroke="currentColor" stroke-width="1.4" opacity="0.85">
+    <path d="M7 4v24M7 17 25 4M11.5 13.7 25 28"/>
+    <path d="M7 4l7 6.5M7 28l4.5-14.3M14 10.5 7 17" opacity="0.35"/>
+  </g>
+  <g fill="var(--accent, #3fd9c9)">
+    <circle cx="7" cy="4" r="2"/><circle cx="7" cy="17" r="2.4"/><circle cx="7" cy="28" r="2"/>
+    <circle cx="25" cy="4" r="2"/><circle cx="25" cy="28" r="2"/>
+    <circle cx="14" cy="10.5" r="1.5"/><circle cx="11.5" cy="13.7" r="1.5"/>
+  </g>
+</svg><span>KIRRA</span></a>
+        <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
+      </div>
+      <nav aria-label="Platform">
+        <h4>Platform</h4>
+        <ul>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="architecture.html">Architecture</a></li>
+          <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
+          <li><a href="determinism.html">Determinism</a></li>
+          <li><a href="performance.html">Performance</a></li>
+          <li><a href="security.html">Security</a></li>
+        </ul>
+      </nav>
+      <nav aria-label="Safety">
+        <h4>Safety</h4>
+        <ul>
+          <li><a href="safety.html">Safety model</a></li>
+          <li><a href="planning.html">Planning</a></li>
+          <li><a href="perception.html">Perception</a></li>
+          <li><a href="prediction.html">Prediction</a></li>
+          <li><a href="certification.html">Certification</a></li>
+        </ul>
+      </nav>
+      <nav aria-label="Evidence">
+        <h4>Evidence</h4>
+        <ul>
+          <li><a href="benchmarks.html">Benchmarks</a></li>
+          <li><a href="open-source.html">Open source</a></li>
+          <li><a href="documentation.html">Documentation</a></li>
+          <li><a href="research.html">Research</a></li>
+        </ul>
+      </nav>
+      <nav aria-label="Company">
+        <h4>Company</h4>
+        <ul>
+          <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="field-notes.html">Field Notes</a></li>
+          <li><a href="careers.html">Careers</a></li>
+          <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>
+          <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/SECURITY.md" target="_blank" rel="noopener">Security policy ↗</a></li>
+        </ul>
+      </nav>
+    </div>
+    <div class="footer__meta">
+      <span>© <span data-year>2026</span> Kirra Systems</span>
+      <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
+      <span>Every claim on this site links to its source in the repository.</span>
+    </div>
+  </div>
+</footer>
+  <script src="js/kirra.js" defer></script>
+</body>
+</html>

--- a/website/documentation.html
+++ b/website/documentation.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -231,6 +233,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -259,6 +262,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/field-notes.html
+++ b/website/field-notes.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html" aria-current="page">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -132,6 +134,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -160,6 +163,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/index.html
+++ b/website/index.html
@@ -79,6 +79,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -717,6 +718,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -745,6 +747,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/open-source.html
+++ b/website/open-source.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -131,6 +133,51 @@ curl -N localhost:8090/system/posture/stream \
               the on-robot installer that turns a fresh Jetson into a governed vehicle — and a one-line installer
               for x86_64 / aarch64 / armv7.</p>
               <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/helm/kirra" target="_blank" rel="noopener">helm/kirra</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/deploy/systemd" target="_blank" rel="noopener">deploy/systemd</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/robot/install/README.md" target="_blank" rel="noopener">robot/install/README.md</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/install.sh" target="_blank" rel="noopener">install.sh</a></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-orient">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Developer orientation</p>
+          <h2 id="h-orient" data-reveal>Find your way around in five minutes</h2>
+          <p class="lede" data-reveal>The tree is organized by trust, not by feature — knowing that makes the whole
+          repository legible.</p>
+        </div>
+        <div class="grid grid--2" style="align-items:start">
+          <div class="table-wrap" data-reveal>
+            <table class="tbl" style="min-width:0">
+              <caption class="visually-hidden">Repository map</caption>
+              <thead><tr><th scope="col">Path</th><th scope="col">What lives there</th></tr></thead>
+              <tbody>
+                <tr><td class="mono">crates/</td><td>The checker &amp; platform — trajectory validation, planner, maps, transports, OTA</td></tr>
+                <tr><td class="mono">src/</td><td>The verifier control plane — posture, attestation, audit, HTTP service</td></tr>
+                <tr><td class="mono">parko/</td><td>Separate ML workspace — inference backends, diverse second governor</td></tr>
+                <tr><td class="mono">verification/ · fuzz/</td><td>Kani proofs over shipped source; standing fuzz targets</td></tr>
+                <tr><td class="mono">tools/</td><td>Isolated spikes — iceoryx2 carrier, QNX shim/judge harness</td></tr>
+                <tr><td class="mono">robot/ · firmware/</td><td>The physical R2 testbed scripts and clean-room MCU firmware</td></tr>
+                <tr><td class="mono">docs/</td><td>36 ADRs, 65 safety artifacts, hardware runbooks, specs</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div style="display:grid;gap:14px">
+            <div class="card" data-reveal>
+              <h3 style="font-size:1.05rem">Runnable demonstrations</h3>
+              <p>The in-line governor demo drives the full read→decide→sign→verify→release loop across a real
+              process boundary; the CARLA client runs the governor against a simulator; the proposal bench sweeps
+              a live governor with hostile proposals and prints its verdicts.</p>
+              <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/crates/kirra-inline-governor" target="_blank" rel="noopener">crates/kirra-inline-governor</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/bin/kirra_carla_client.rs" target="_blank" rel="noopener">src/bin/kirra_carla_client.rs</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/crates/kirra-proposal-bench" target="_blank" rel="noopener">crates/kirra-proposal-bench</a></p>
+            </div>
+            <div class="card" data-reveal>
+              <h3 style="font-size:1.05rem">APIs &amp; examples</h3>
+              <p><code>cargo doc --open</code> builds the full API reference (deny-warnings enforced). The governor
+              quickstart example and the C SDK example both build and run in CI, so they're never stale.</p>
+              <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/examples/" target="_blank" rel="noopener">examples/</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/.github/workflows/ci.yml#L323" target="_blank" rel="noopener">.github/workflows/ci.yml:323</a></p>
             </div>
           </div>
         </div>
@@ -210,6 +257,7 @@ curl -N localhost:8090/system/posture/stream \
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -238,6 +286,7 @@ curl -N localhost:8090/system/posture/stream \
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/perception.html
+++ b/website/perception.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html" aria-current="page">perception</a>
@@ -251,6 +253,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -279,6 +282,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/performance.html
+++ b/website/performance.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -238,6 +240,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -266,6 +269,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/planning.html
+++ b/website/planning.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html" aria-current="page">planning</a>
       <a href="perception.html">perception</a>
@@ -245,6 +247,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -273,6 +276,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/prediction.html
+++ b/website/prediction.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -220,6 +222,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -248,6 +251,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/research.html
+++ b/website/research.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -183,6 +185,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -211,6 +214,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/runtime.html
+++ b/website/runtime.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html" aria-current="page">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -323,6 +325,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -351,6 +354,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/safety.html
+++ b/website/safety.html
@@ -52,6 +52,7 @@
         <a href="safety.html" aria-current="page">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html" aria-current="page">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -294,6 +296,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -322,6 +325,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/security.html
+++ b/website/security.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -266,6 +268,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -294,6 +297,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -4,7 +4,9 @@
   <url><loc>https://kirrasystems.com/benchmarks.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/careers.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/certification.html</loc><lastmod>2026-07-21</lastmod></url>
+  <url><loc>https://kirrasystems.com/contact.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/determinism.html</loc><lastmod>2026-07-21</lastmod></url>
+  <url><loc>https://kirrasystems.com/diagnostics.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/documentation.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/field-notes.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/</loc><lastmod>2026-07-21</lastmod></url>

--- a/website/solutions.html
+++ b/website/solutions.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -324,6 +326,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -352,6 +355,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>

--- a/website/vision.html
+++ b/website/vision.html
@@ -52,6 +52,7 @@
         <a href="safety.html">Safety</a>
         <a href="certification.html">Certification</a>
         <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
       </nav>
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
@@ -69,6 +70,7 @@
       <a href="vision.html" aria-current="page">vision</a>
       <a href="architecture.html">architecture</a>
       <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
       <a href="safety.html">safety</a>
       <a href="planning.html">planning</a>
       <a href="perception.html">perception</a>
@@ -238,6 +240,7 @@
         <div class="hero__ctas" style="justify-content:center" data-reveal>
           <a class="btn btn--primary" href="solutions.html">See it applied <span class="arrow" aria-hidden="true">→</span></a>
           <a class="btn btn--ghost" href="architecture.html">See how it's built</a>
+          <a class="btn btn--ghost" href="contact.html">Start a conversation</a>
         </div>
       </div>
     </section>
@@ -267,6 +270,7 @@
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
           <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
           <li><a href="determinism.html">Determinism</a></li>
           <li><a href="performance.html">Performance</a></li>
           <li><a href="security.html">Security</a></li>
@@ -295,6 +299,7 @@
         <h4>Company</h4>
         <ul>
           <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>
           <li><a href="careers.html">Careers</a></li>
           <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>


### PR DESCRIPTION
A second full audit of the live site against the expanded brief (customers, government, investors, acquirers performing technical due diligence) found four genuine gaps; this closes all of them:

- **`contact.html`** — the site previously had no commercial, partnership, or inquiry path at all. Four doors: commercial & partnerships, technical evaluation / due diligence (pointing at the release safety-case evidence bundles), security disclosure (48 h documented SLA — the only promise made), and open-source community. Contact joins the primary nav and footer.
- **`diagnostics.html`** — surfaces the repo's observability story that was previously invisible: posture-exempt Prometheus metrics that survive lockout, the SSE posture stream, explainable denial verdicts, the three operator consoles (including the air-gapped console's "GRANT RECORDED — DELIVERY PENDING" honesty rule), and config-drift / credential-lifecycle monitoring.
- **Open Source** gains a developer-orientation section: the trust-organized repository map, runnable demonstrations (in-line governor loop, CARLA client, proposal bench), and CI-built examples.
- **CTAs** — Vision now closes with "Start a conversation"; Diagnostics joins subnav/footer.

`REDESIGN.md` gains the review-pass addendum and a ranked remaining-opportunities list.

Verified headlessly: both new pages render in both themes, zero broken internal links across all 21 pages, zero page errors.

⚠️ Merging deploys to kirrasystems.com automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7)_