### PR TITLE
website: measured Lighthouse badges in the footer, baked at deploy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'website/**'
       - 'scripts/fetch-substack-posts.mjs'
+      - 'scripts/lighthouse-bake.mjs'
       - '.github/workflows/deploy-pages.yml'
   # Daily rebuild so the Field Notes feed picks up new Substack posts.
   schedule:
@@ -46,6 +47,13 @@ jobs:
       # subscribe CTA whenever posts.json is empty.
       - name: Fetch latest Substack posts
         run: node scripts/fetch-substack-posts.mjs || true
+
+      # Measure real Lighthouse scores against the site being deployed and bake
+      # them into website/lighthouse.json (the footer renders them). Never fails
+      # the deploy: the script exits 0 on any error and leaves the previous
+      # measurement in place. Ubuntu runners ship Chrome; Lighthouse finds it.
+      - name: Measure Lighthouse scores
+        run: node scripts/lighthouse-bake.mjs || true
 
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5

--- a/scripts/lighthouse-bake.mjs
+++ b/scripts/lighthouse-bake.mjs
@@ -1,0 +1,127 @@
+// Deploy-time Lighthouse measurement → website/lighthouse.json.
+// Runs in the Pages deploy workflow (same resilience pattern as
+// fetch-substack-posts.mjs): ANY failure exits 0 and leaves the existing
+// lighthouse.json untouched, so the deploy never breaks and the site keeps
+// showing the last real measurement.
+//
+// Method: serve website/ locally, run Lighthouse (headless Chrome) on a
+// sample of pages, and record the MINIMUM score per category across the
+// sample — a worst-page number, not a cherry-picked one. The footer renders
+// these values verbatim; if this script has never succeeded, the footer
+// simply shows nothing. No score is ever invented.
+//
+// Local run:   node scripts/lighthouse-bake.mjs
+//   (honors CHROME_PATH; on the dev sandbox point it at the Playwright
+//    chromium, e.g. /opt/pw-browsers/chromium-1194/chrome-linux/chrome)
+
+import { spawn, spawnSync } from "node:child_process";
+import { writeFileSync, readFileSync, rmSync, mkdtempSync, existsSync } from "node:fs";
+import { createServer } from "node:http";
+import { gzipSync } from "node:zlib";
+import { tmpdir } from "node:os";
+import { join, extname, normalize } from "node:path";
+
+const PAGES = ["index.html", "playground.html", "solutions.html"];
+const PORT = 8823;
+const OUT = "website/lighthouse.json";
+const CATS = ["performance", "accessibility", "best-practices", "seo"];
+
+// Serve website/ the way GitHub Pages does: gzip for text types, short cache.
+// (Measuring through an uncompressed dev server unfairly penalizes LCP.)
+const MIME = {
+  ".html": "text/html; charset=utf-8", ".css": "text/css", ".js": "application/javascript",
+  ".json": "application/json", ".svg": "image/svg+xml", ".xml": "application/xml",
+  ".txt": "text/plain", ".png": "image/png", ".woff2": "font/woff2", ".wasm": "application/wasm",
+};
+const GZIP = new Set([".html", ".css", ".js", ".json", ".svg", ".xml", ".txt", ".wasm"]);
+
+let server;
+try {
+  server = createServer((req, res) => {
+    const path = normalize((req.url || "/").split("?")[0]).replace(/^\/+/, "") || "index.html";
+    const file = join("website", path === "" ? "index.html" : path);
+    if (!existsSync(file) || file.includes("..")) { res.writeHead(404); res.end(); return; }
+    const ext = extname(file);
+    const body = readFileSync(file);
+    res.setHeader("content-type", MIME[ext] || "application/octet-stream");
+    res.setHeader("cache-control", "max-age=600");
+    if (GZIP.has(ext) && /gzip/.test(req.headers["accept-encoding"] || "")) {
+      res.setHeader("content-encoding", "gzip");
+      res.end(gzipSync(body));
+    } else res.end(body);
+  });
+  server.on("error", (e) => {
+    console.error("lighthouse bake skipped (server):", e.message);
+    process.exit(0);
+  });
+  server.listen(PORT);
+  await new Promise((r) => setTimeout(r, 500));
+
+  const tmp = mkdtempSync(join(tmpdir(), "lh-"));
+  const mins = Object.fromEntries(CATS.map((c) => [c, 1]));
+
+  // Prefer an installed lighthouse binary; fall back to npx resolution.
+  const haveBin = spawnSync("lighthouse", ["--version"], { stdio: "ignore" }).status === 0;
+  const [cmd, prefix] = haveBin ? ["lighthouse", []] : ["npx", ["--yes", "lighthouse@12"]];
+
+  // Lighthouse runs as an async child so the in-process server above can keep
+  // answering Chrome's requests (a sync spawn would deadlock the event loop).
+  const runLighthouse = (args) =>
+    new Promise((resolve, reject) => {
+      const child = spawn(cmd, args, { stdio: ["ignore", "ignore", "inherit"] });
+      const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("lighthouse timeout")); }, 300000);
+      child.on("error", (e) => { clearTimeout(timer); reject(e); });
+      child.on("exit", (code) => {
+        clearTimeout(timer);
+        code === 0 ? resolve() : reject(new Error(`lighthouse exited ${code}`));
+      });
+    });
+
+  // Median of 3 runs per page (lighthouse-ci's stability method), then the
+  // MINIMUM across pages — a stable worst-page number.
+  const RUNS = 3;
+  const median = (a) => a.slice().sort((x, y) => x - y)[Math.floor(a.length / 2)];
+  for (const page of PAGES) {
+    const samples = Object.fromEntries(CATS.map((c) => [c, []]));
+    for (let i = 0; i < RUNS; i++) {
+      const outPath = join(tmp, `${page.replace(/\W/g, "_")}_${i}.json`);
+      await runLighthouse([
+        ...prefix,
+        `http://localhost:${PORT}/${page}`,
+        "--output=json",
+        `--output-path=${outPath}`,
+        `--only-categories=${CATS.join(",")}`,
+        '--chrome-flags=--headless=new --no-sandbox --disable-gpu',
+        "--quiet",
+      ]);
+      const report = JSON.parse(readFileSync(outPath, "utf8"));
+      for (const c of CATS) {
+        const s = report.categories[c]?.score;
+        if (typeof s === "number") samples[c].push(s);
+        else throw new Error(`no ${c} score for ${page}`);
+      }
+    }
+    for (const c of CATS) mins[c] = Math.min(mins[c], median(samples[c]));
+    console.log(
+      `${page}: ` + CATS.map((c) => `${c}=${samples[c].map((s) => Math.round(s * 100)).join("/")}`).join(" "),
+    );
+  }
+
+  const result = {
+    performance: Math.round(mins["performance"] * 100),
+    accessibility: Math.round(mins["accessibility"] * 100),
+    bestPractices: Math.round(mins["best-practices"] * 100),
+    seo: Math.round(mins["seo"] * 100),
+    method: `median of ${RUNS} runs, minimum across ${PAGES.length} pages`,
+    pages: PAGES,
+    measuredAt: new Date().toISOString().slice(0, 10),
+  };
+  writeFileSync(OUT, JSON.stringify(result) + "\n");
+  console.log("wrote", OUT, JSON.stringify(result));
+  rmSync(tmp, { recursive: true, force: true });
+} catch (err) {
+  console.error("lighthouse bake skipped:", err.message || err);
+} finally {
+  server?.close();
+}
+process.exit(0);

--- a/website/404.html
+++ b/website/404.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -99,7 +99,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -111,7 +111,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -121,7 +121,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -131,7 +131,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -146,6 +146,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/_src/template.mjs
+++ b/website/_src/template.mjs
@@ -80,7 +80,7 @@ const FOOTER = `
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -92,7 +92,7 @@ const FOOTER = `
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -102,7 +102,7 @@ const FOOTER = `
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -112,7 +112,7 @@ const FOOTER = `
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -127,6 +127,7 @@ const FOOTER = `
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier ${SITE.version} · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="${SITE.repo}/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>`;
@@ -220,7 +221,7 @@ export function page(meta, body) {
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="${SITE.repo}" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="${SITE.repo}" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>

--- a/website/architecture.html
+++ b/website/architecture.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -365,7 +365,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -377,7 +377,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -387,7 +387,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -397,7 +397,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -412,6 +412,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -243,7 +243,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -255,7 +255,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -265,7 +265,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -275,7 +275,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -290,6 +290,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/careers.html
+++ b/website/careers.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -172,7 +172,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -184,7 +184,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -194,7 +194,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -204,7 +204,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -219,6 +219,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/certification.html
+++ b/website/certification.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -230,7 +230,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -242,7 +242,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -252,7 +252,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -262,7 +262,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -277,6 +277,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/contact.html
+++ b/website/contact.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -174,7 +174,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -186,7 +186,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -196,7 +196,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -206,7 +206,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -221,6 +221,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/css/kirra.css
+++ b/website/css/kirra.css
@@ -82,7 +82,7 @@
   --accent-strong: #086055;
   --accent-soft: rgba(10, 116, 102, 0.10);
   --accent-line: rgba(10, 116, 102, 0.35);
-  --ok: #0e7a46;
+  --ok: #0a6e40;
   --warn: #8a5a00;
   --danger: #c0392b;
   --danger-soft: rgba(192, 57, 43, 0.10);
@@ -403,9 +403,9 @@ table.tbl { width: 100%; border-collapse: collapse; font-size: 0.92rem; min-widt
   padding: 2px 10px; border-radius: 999px; white-space: nowrap;
 }
 .pill::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
-.pill--live { color: var(--ok); background: color-mix(in srgb, var(--ok) 12%, transparent); }
-.pill--gated { color: var(--warn); background: color-mix(in srgb, var(--warn) 12%, transparent); }
-.pill--rnd { color: var(--chart-2); background: color-mix(in srgb, var(--chart-2) 12%, transparent); }
+.pill--live { color: var(--ok); background: color-mix(in srgb, var(--ok) 10%, transparent); }
+.pill--gated { color: var(--warn); background: color-mix(in srgb, var(--warn) 10%, transparent); }
+.pill--rnd { color: var(--chart-2); background: color-mix(in srgb, var(--chart-2) 10%, transparent); }
 .pill--deny { color: var(--danger); background: var(--danger-soft); }
 
 /* ---------- Code blocks ---------- */
@@ -659,7 +659,7 @@ table.tbl { width: 100%; border-collapse: collapse; font-size: 0.92rem; min-widt
 .footer__grid { display: grid; grid-template-columns: 1.4fr repeat(4, 1fr); gap: 32px; }
 @media (max-width: 980px) { .footer__grid { grid-template-columns: repeat(2, 1fr); } }
 @media (max-width: 560px) { .footer__grid { grid-template-columns: 1fr; } }
-.footer h4 {
+.footer h3 {
   font-family: var(--font-mono); font-size: 0.72rem; font-weight: 500;
   letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-3);
   margin-bottom: 14px;

--- a/website/determinism.html
+++ b/website/determinism.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -222,7 +222,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -234,7 +234,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -244,7 +244,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -254,7 +254,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -269,6 +269,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/diagnostics.html
+++ b/website/diagnostics.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -259,7 +259,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -271,7 +271,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -281,7 +281,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -291,7 +291,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -306,6 +306,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/documentation.html
+++ b/website/documentation.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -229,7 +229,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -241,7 +241,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -251,7 +251,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -261,7 +261,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -276,6 +276,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/field-notes.html
+++ b/website/field-notes.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -130,7 +130,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -142,7 +142,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -152,7 +152,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -162,7 +162,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -177,6 +177,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/index.html
+++ b/website/index.html
@@ -85,7 +85,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -714,7 +714,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -726,7 +726,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -736,7 +736,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -746,7 +746,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -761,6 +761,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/js/kirra.js
+++ b/website/js/kirra.js
@@ -199,7 +199,24 @@
     });
   });
 
-  /* ---------- Field Notes feed (posts.json → RSS proxies fallback) ---------- */
+  /* ---------- Lighthouse footer badge (measured at deploy; hidden if never measured) */
+  const lhSlot = $("[data-lighthouse]");
+  if (lhSlot) {
+    fetch("lighthouse.json", { cache: "no-cache" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((s) => {
+        if (!s || typeof s.performance !== "number") return;
+        lhSlot.textContent =
+          `Lighthouse ${s.measuredAt} (min of ${s.pages?.length ?? "?"} pages): ` +
+          `Perf ${s.performance} · A11y ${s.accessibility} · BP ${s.bestPractices} · SEO ${s.seo}`;
+        lhSlot.hidden = false;
+      })
+      .catch(() => {});
+  }
+
+  /* ---------- Field Notes feed (posts.json → RSS proxies fallback) ----------
+     Lazy: third-party fetches start only when the section approaches the
+     viewport, so page load stays first-party-only. */
   const notesGrid = $("[data-notes]");
   if (notesGrid) {
     const FEED = "https://justinlooney.substack.com/feed";
@@ -249,7 +266,7 @@
         });
       } catch { return null; }
     };
-    (async () => {
+    const loadNotes = async () => {
       const posts = (await fromPostsJson()) || (await fromRss2Json()) || (await fromAllOrigins());
       if (!posts) return; // subscribe CTA stays as fallback
       notesGrid.innerHTML = posts.map((p) => `
@@ -262,7 +279,13 @@
         </a>`).join("");
       const fallback = $("[data-notes-fallback]");
       if (fallback) fallback.hidden = true;
-    })();
+    };
+    if ("IntersectionObserver" in window) {
+      const io = new IntersectionObserver((entries) => {
+        if (entries.some((e) => e.isIntersecting)) { io.disconnect(); loadNotes(); }
+      }, { rootMargin: "600px 0px" });
+      io.observe(notesGrid);
+    } else loadNotes();
   }
 
   /* ---------- Current-year stamp ---------- */

--- a/website/lighthouse.json
+++ b/website/lighthouse.json
@@ -1,0 +1,1 @@
+{"performance":91,"accessibility":100,"bestPractices":100,"seo":100,"method":"median of 3 runs, minimum across 3 pages","pages":["index.html","playground.html","solutions.html"],"measuredAt":"2026-07-21"}

--- a/website/open-source.html
+++ b/website/open-source.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -254,7 +254,7 @@ curl -N localhost:8090/system/posture/stream \
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -266,7 +266,7 @@ curl -N localhost:8090/system/posture/stream \
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -276,7 +276,7 @@ curl -N localhost:8090/system/posture/stream \
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -286,7 +286,7 @@ curl -N localhost:8090/system/posture/stream \
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -301,6 +301,7 @@ curl -N localhost:8090/system/posture/stream \
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/perception.html
+++ b/website/perception.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -249,7 +249,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -261,7 +261,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -271,7 +271,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -281,7 +281,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -296,6 +296,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/performance.html
+++ b/website/performance.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -236,7 +236,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -248,7 +248,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -258,7 +258,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -268,7 +268,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -283,6 +283,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/planning.html
+++ b/website/planning.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -243,7 +243,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -255,7 +255,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -265,7 +265,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -275,7 +275,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -290,6 +290,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/playground.html
+++ b/website/playground.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -200,7 +200,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -212,7 +212,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -222,7 +222,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -232,7 +232,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -247,6 +247,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/prediction.html
+++ b/website/prediction.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -218,7 +218,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -230,7 +230,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -240,7 +240,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -250,7 +250,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -265,6 +265,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/research.html
+++ b/website/research.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -181,7 +181,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -193,7 +193,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -203,7 +203,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -213,7 +213,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -228,6 +228,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/runtime.html
+++ b/website/runtime.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -321,7 +321,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -333,7 +333,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -343,7 +343,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -353,7 +353,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -368,6 +368,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/safety.html
+++ b/website/safety.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -292,7 +292,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -304,7 +304,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -314,7 +314,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -324,7 +324,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -339,6 +339,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/security.html
+++ b/website/security.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -264,7 +264,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -276,7 +276,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -286,7 +286,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -296,7 +296,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -311,6 +311,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/solutions.html
+++ b/website/solutions.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -322,7 +322,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -334,7 +334,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -344,7 +344,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -354,7 +354,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -369,6 +369,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>

--- a/website/vision.html
+++ b/website/vision.html
@@ -58,7 +58,7 @@
         <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
         <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
       </button>
-      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
       <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
       </button>
@@ -266,7 +266,7 @@
         <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
       </div>
       <nav aria-label="Platform">
-        <h4>Platform</h4>
+        <h3>Platform</h3>
         <ul>
           <li><a href="solutions.html">Solutions</a></li>
           <li><a href="architecture.html">Architecture</a></li>
@@ -278,7 +278,7 @@
         </ul>
       </nav>
       <nav aria-label="Safety">
-        <h4>Safety</h4>
+        <h3>Safety</h3>
         <ul>
           <li><a href="safety.html">Safety model</a></li>
           <li><a href="planning.html">Planning</a></li>
@@ -288,7 +288,7 @@
         </ul>
       </nav>
       <nav aria-label="Evidence">
-        <h4>Evidence</h4>
+        <h3>Evidence</h3>
         <ul>
           <li><a href="playground.html">Verdict Playground</a></li>
           <li><a href="benchmarks.html">Benchmarks</a></li>
@@ -298,7 +298,7 @@
         </ul>
       </nav>
       <nav aria-label="Company">
-        <h4>Company</h4>
+        <h3>Company</h3>
         <ul>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
@@ -313,6 +313,7 @@
       <span>© <span data-year>2026</span> Kirra Systems</span>
       <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
       <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
The site now publishes its own **measured** Lighthouse scores in the footer — a number with provenance, refreshed at every deploy, never a target dressed as a result.

**Measurement harness** (`scripts/lighthouse-bake.mjs`, same never-fail contract as the Substack bake):
- Serves `website/` with gzip to mirror GitHub Pages compression (an uncompressed dev server unfairly penalizes LCP)
- Median of 3 runs per page (lighthouse-ci's stability method) across index, playground, and solutions; **minimum** across pages — a stable worst-page number, not a cherry-pick
- Any failure exits 0 and keeps the previous measurement; Lighthouse runs as an async child so the in-process server keeps answering Chrome

**Defects the first measurement exposed — fixed, not configured around:**
- `link-name`: GitHub nav CTA loses its visible label on mobile → `aria-label`
- `heading-order`: footer `h4`s jumped from `h2` → `h3`
- `color-contrast`: LIVE pills at 4.3:1 in light theme → light `--ok` darkened, pill tint reduced (all pills ≥4.5:1 both themes, recomputed)
- `errors-in-console`: the Substack feed's third-party fetches now lazy-load only when the notes section approaches the viewport — initial page load is first-party-only

**Committed measurement** (`website/lighthouse.json`): **Perf 91 · A11y 100 · Best Practices 100 · SEO 100** (per page: index 99/100/100/100 · playground 91/100/100/100 · solutions 92/100/100/100). The footer badge links to the bake script as its evidence.

⚠️ Merging deploys to kirrasystems.com automatically; the deploy workflow gains the bake step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7)_