### PR TITLE
CHANGELOG: rename [Unreleased] → [v2.0.0] (release prep, no tag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,16 @@ the versioned public surface, the MSRV policy, and the deprecation process).
 
 ## [Unreleased]
 
-Everything since v1.1.2 (May 2026 → present). The highlights, by stream —
-detail lives in `docs/adr/`, `docs/safety/`, and the PR history:
+_Nothing yet — this section accumulates changes until the next release is cut._
+
+## [v2.0.0] — 2026-07-21
+
+The disambiguating **MAJOR**: it moves the version line permanently above the
+retired v1.5.0 "Aegis" high-water — clearing the v1.5.0/v1.1.2 sort inversion for
+good (`docs/VERSIONING_POLICY.md` §2.1) — and completes the ADR-0035 re-export-shim
+removal (#1029). Otherwise it carries everything accumulated since v1.1.2
+(May 2026 → present). The highlights, by stream — detail lives in `docs/adr/`,
+`docs/safety/`, and the PR history:
 
 ### Added
 


### PR DESCRIPTION
## Summary

Release prep for the v2.0.0 cut (already on `main` via #1086) — **not a release itself; no tag is pushed.**

Renames the accumulated `## [Unreleased]` block to `## [v2.0.0] — 2026-07-21` so that when the `v2.0.0` tag is eventually pushed, `release.yml`'s preflight (which *hard-fails* a tag lacking a matching `## [v<version>]` section) passes. Adds a one-line framing of what the MAJOR is (version-line disambiguation + ADR-0035 shim removal), and leaves a fresh empty `## [Unreleased]` on top per the `VERSIONING_POLICY.md` §6 housekeeping flow.

## Verification

Ran the preflight's **exact** prefix-match awk against the file for `VERSION=v2.0.0` — it returns a non-empty section, so a future tag passes:

```
awk -v ver="v2.0.0" '/^## / { want = "## [" ver "]"; flag = (substr($0,1,length(want)) == want); next } flag' CHANGELOG.md
```

Section ordering is correct: `[Unreleased]` → `[v2.0.0] — 2026-07-21` → `[v1.1.2]` → `[v1.5.0]`.

## Not in scope

- **No tag is pushed.** Cutting the release (`git tag v2.0.0`, which triggers `release.yml`) remains a separate, deliberate step.
- The date is the version-cut date on `main`; adjust it if the tag slips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_