### PR TITLE
release: enforce safety-constant sign-off gate at tag time (review F2, Critical)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,19 @@ jobs:
           fi
           echo "OK: CHANGELOG.md has a '## [$VERSION]' section"
 
+      - name: Release safety-constant sign-off gate (EP-09; review F2)
+        # A tagged release must not ship UNAPPROVED safety constants. The EP-09
+        # provenance gate, run here under KIRRA_RELEASE_GATE=1, fails if ANY governed
+        # constant in ci/safety_constants_manifest.json is still `pending` sign-off —
+        # making the stated release policy real at the tag. ci.yml runs this same
+        # check only as a NON-blocking red-path self-test; the enforcement point is
+        # here. Placed in the toolchain-free preflight (no build, no cargo) so a
+        # release blocked on sign-off never reaches the cross-compiles or the cosign
+        # signing identity — same fail-fast rationale as the tag/changelog gates.
+        # Until all constants are `validated`, a tag is intentionally blocked here;
+        # sign one off (with recorded provenance + owner) to release.
+        run: KIRRA_RELEASE_GATE=1 python3 ci/check_safety_constants.py
+
   build-dashboard:
     name: Build dashboard
     needs: preflight


### PR DESCRIPTION
## Summary

Fixes external production-review finding **F2 (Critical)** — verified true on `main`: a tagged release does **not** run the EP-09 release safety-constant gate, and **all 19** governed constants in `ci/safety_constants_manifest.json` are `pending` sign-off. So a signed release could ship unapproved RSS / prediction / VRU / divergence parameters with nothing in the pipeline blocking it.

- `ci.yml` only runs `KIRRA_RELEASE_GATE=1` as a **non-blocking red-path self-test** (`ci.yml:396-413`).
- `release.yml` never ran it at all — the `safety-case` job runs the check *without* the gate by design (`build_safety_case.py:96-99`).

## Fix

One toolchain-free preflight step in `release.yml`:

```yaml
- name: Release safety-constant sign-off gate (EP-09; review F2)
  run: KIRRA_RELEASE_GATE=1 python3 ci/check_safety_constants.py
```

It fails the tag while any constant is still `pending`, placed **before** the cross-compiles + cosign so a blocked release never reaches the signing identity — the same fail-fast rationale as the existing tag↔version and changelog preflight gates. This makes the stated release policy real.

## Behavioral note (intentional)

Until each of the 19 constants is signed off (`status → validated` with recorded provenance + owner), **a release tag is intentionally blocked here.** That is the point of the fix — it converts "the policy exists" into "the policy is enforced." It does not affect normal PR CI or the version bump already on `main`; it only gates the release-tag path.

## Verification

- `KIRRA_RELEASE_GATE=1 python3 ci/check_safety_constants.py` → exit **1** with the current 19 pending (gate blocks, as intended).
- Normal provenance-match (`python3 ci/check_safety_constants.py`, no gate) → exit **0** (unchanged; `ci.yml`'s regular path unaffected).
- `release.yml` parses as valid YAML.

Verified as part of a systematic verification of the external review (F1–F15 + security); F2 confirmed. The companion **F1** blocker (HA promotion uses stale trust state) is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_