### PR TITLE
console: production hardening — proxy, headers, error boundaries, CI smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1252,3 +1252,31 @@ jobs:
           source /opt/ros/jazzy/setup.bash
           cargo build -p parko-ros2 --bin parko_ros2_node --features ros2,onnx-backend
           cargo build -p parko-ros2 --bin parko_ros2_node --features ros2,tensorrt-backend
+
+  # ── Kirra Console (Next.js operator console) ─────────────────────────────
+  # Typecheck + production build + headless smoke: every route must render
+  # with zero page errors (this is what catches React hydration regressions —
+  # the class of bug fixed in the design-system port), the shell must compose
+  # (#console-main present), and the quick-nav keyboard flow must navigate.
+  # The smoke script self-manages the production server (scripts/smoke.mjs).
+  console:
+    name: Console typecheck + build + smoke (Next.js)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: console
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Install dependencies (locked)
+        run: npm ci --no-audit --no-fund
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Lint
+        run: npm run lint
+      - name: Production build
+        run: npm run build
+      - name: Install smoke browser
+        run: npx playwright install --with-deps chromium
+      - name: Smoke — all routes render clean, quick-nav navigates
+        run: npm run smoke

--- a/console/PRODUCTION.md
+++ b/console/PRODUCTION.md
@@ -1,0 +1,102 @@
+# Kirra Console — Production Deployment & Operations
+
+The hardening record and runbook for running the console as a customer-facing
+operations surface. Companion to `REVIEW.md` (design/UX pass). Everything here
+is implemented and verified unless explicitly listed under **Known gaps**.
+
+## What this application is — and is not
+
+The console is a **read-only observation surface** over the Kirra verifier.
+By construction it cannot actuate, register, or clear anything: the server-side
+proxy forwards **GET only**, against a regex **allow-list** of verifier read
+paths. Write paths (operator clearance grants, node registration) live in the
+verifier's own operator console (`static/console.html`) and the Vite dashboard,
+deliberately. Keep that split until per-operator sessions exist (see gaps).
+
+## Runtime configuration (all server-side; nothing reaches the bundle)
+
+| Variable | Effect |
+|---|---|
+| `KIRRA_API_URL` | Verifier base URL. **Unset → demo mode** (bundled simulated fleet, clearly labeled at nav, page, and shell level). |
+| `KIRRA_ADMIN_TOKEN` | Bearer for admin-gated reads. Injected by the proxy per-request; never sent to the browser. |
+| `KIRRA_CLIENT_ID` | `x-kirra-client-id` for identity-gated reads. |
+
+Set in `console/.env.local` (dev) or the process environment (prod).
+
+## Serving
+
+```bash
+npm ci && npm run build && npm start        # or:
+node .next/standalone/server.js             # output: 'standalone' bundle
+```
+
+`output: 'standalone'` produces a self-contained server for container images.
+Containerize per the repository's supply-chain policy (digest-pinned base
+images, cosign signing — see `.github/workflows/docker.yml` for the pattern).
+
+## Hardening implemented (verify with `npm run smoke` + `curl -I`)
+
+- **Proxy** (`app/api/kirra/[...path]/route.ts`):
+  - 10 s upstream timeout on every read (504 to the client); the SSE stream
+    path is exempt (long-lived) but aborts on client disconnect
+  - per-IP sliding-window rate limit (240 req/min, bounded memory) → 429
+  - query-string length cap (414); GET-only; path allow-list (403)
+  - structured JSON request logs on stdout (`src: kirra-proxy`, request id,
+    path, status, duration, upstream status/error) — ship with any log agent
+  - `x-request-id` echoed on every response for support correlation;
+    upstream error detail is logged server-side, never returned to clients
+- **Headers** (`next.config.mjs`, applied to every response including the API):
+  `X-Frame-Options: DENY`, `nosniff`, `Referrer-Policy`, `Permissions-Policy`,
+  CSP (`frame-ancestors 'none'; object-src 'none'; base-uri 'self'`),
+  `poweredByHeader: false`
+- **Failure containment**: route-segment error boundary (`app/error.tsx`) and
+  root boundary (`app/global-error.tsx`) — a screen crash never blanks the
+  console, and the recovery copy states that the UI is not the fleet
+- **Data-layer resilience** (pre-existing, kept): every hook aborts in-flight
+  requests on unmount, distinguishes demo/abort/failure, settles to labeled
+  demo data, and keeps re-polling — network interruptions self-heal
+- **Determinism**: demo data uses a seeded PRNG and fixed epoch; all times
+  render in pinned UTC (`lib/format.ts`) — no hydration drift, no ambiguous
+  local timestamps for distributed operators
+- **Supply chain**: `package-lock.json` committed; `npm ci` in CI; fonts
+  self-hosted (no build-time network); CI actions SHA-pinned (repo M-6 gate)
+
+## CI gate (`.github/workflows/ci.yml` → `console` job)
+
+`npm ci` → typecheck → lint → production build → headless smoke
+(`scripts/smoke.mjs`): all 18 routes must return 200 and render with **zero
+page errors** (catches hydration regressions), the shell must compose, and the
+quick-nav keyboard flow must navigate. Locally:
+`npm run smoke` (set `KIRRA_SMOKE_CHROMIUM` to reuse a preinstalled browser).
+
+## Security posture — read before exposing this to a network
+
+1. **The console has no user authentication of its own.** Anyone who can reach
+   it gets read access to whatever the configured token can read. Deploy behind
+   an authenticating reverse proxy / SSO (oauth2-proxy, IAP, mTLS mesh). This
+   is a deliberate scope line, not an oversight: adding a half-measure login to
+   a read-only surface would imply session security that doesn't exist yet.
+2. The rate limiter is per-instance and in-memory. Multi-replica deployments
+   should rate-limit at the edge as well.
+3. The CSP does not lock `script-src` (Next inline bootstrap requires nonce
+   plumbing). All scripts are same-origin and no third-party requests are made
+   at runtime; full nonce-based CSP is a tracked gap.
+4. The token grants **read** scopes only in spirit — but it is the *admin*
+   token today. When the verifier's per-principal tokens (WS-1 `auditor` role)
+   are provisioned, use one: the proxy needs no change.
+
+## Known gaps before enterprise deployment (ranked)
+
+1. **Per-operator sessions + RBAC** — requires the verifier's operator
+   registry (#314); until then, SSO-in-front is the supported model.
+2. **Auditor-role token instead of admin token** — supported by the verifier
+   today; a deployment choice, documented above.
+3. **SSE adoption** — the stream is proxied but unconsumed; polling remains
+   the transport (5–30 s). Roadmap item #1 in REVIEW.md.
+4. **Nonce-based CSP**, error-reporter integration (the boundaries and
+   structured logs are the hook points), OpenTelemetry spans on the proxy.
+5. **Test depth** — the smoke gate covers rendering and navigation; component
+   and contract tests (wire types vs verifier serde) are the next layer.
+6. **Preview screens in customer deployments** — the 12 simulated screens are
+   labeled at three levels; a build-time flag to hide them entirely is a
+   product decision awaiting real customer telemetry to replace them.

--- a/console/app/api/kirra/[...path]/route.ts
+++ b/console/app/api/kirra/[...path]/route.ts
@@ -8,6 +8,17 @@ export const dynamic = 'force-dynamic'
 // lets the console read admin- and identity-gated endpoints. Read-only: only
 // GET, and only an allow-listed set of verifier read paths are forwarded.
 //
+// Production hardening (all server-side, none of it reaches the bundle):
+//   - upstream timeout (UPSTREAM_TIMEOUT_MS); the SSE stream path is exempt
+//     from the read timeout (long-lived by design) but still aborts when the
+//     client disconnects
+//   - per-IP sliding-window rate limit (in-memory; per-instance — front a
+//     multi-replica deployment with an edge limiter, see PRODUCTION.md)
+//   - structured JSON request logs with a request id, echoed to the client
+//     as x-request-id for support correlation
+//   - upstream error details are logged server-side and NEVER returned to the
+//     client (generic 502/504 body only)
+//
 // Server env (NOT NEXT_PUBLIC — stays server-side):
 //   KIRRA_API_URL       base URL of the verifier (unset → demo mode)
 //   KIRRA_ADMIN_TOKEN   Bearer token for admin/identity-gated reads
@@ -26,38 +37,110 @@ const ALLOW: RegExp[] = [
   /^system\/posture\/stream$/,
 ]
 
-function demo() {
-  return NextResponse.json({ status: 'demo' }, { status: 503, headers: { 'x-kirra-mode': 'demo' } })
+const STREAM_PATH = /^system\/posture\/stream$/
+const UPSTREAM_TIMEOUT_MS = 10_000
+const MAX_QUERY_LENGTH = 512
+
+// Per-IP sliding window: RATE_LIMIT requests per RATE_WINDOW_MS, per instance.
+const RATE_LIMIT = 240
+const RATE_WINDOW_MS = 60_000
+const rateBuckets = new Map<string, number[]>()
+function rateLimited(ip: string): boolean {
+  const now = Date.now()
+  const hits = (rateBuckets.get(ip) ?? []).filter((t) => now - t < RATE_WINDOW_MS)
+  if (hits.length >= RATE_LIMIT) {
+    rateBuckets.set(ip, hits)
+    return true
+  }
+  hits.push(now)
+  rateBuckets.set(ip, hits)
+  // Bound the map so an address scan can't grow memory unboundedly.
+  if (rateBuckets.size > 10_000) {
+    for (const key of rateBuckets.keys()) {
+      if ((rateBuckets.get(key) ?? []).every((t) => now - t >= RATE_WINDOW_MS)) rateBuckets.delete(key)
+    }
+  }
+  return false
+}
+
+function log(fields: Record<string, unknown>) {
+  // Single-line structured JSON on stdout — pick up with any log shipper.
+  console.log(JSON.stringify({ ts: new Date().toISOString(), src: 'kirra-proxy', ...fields }))
+}
+
+function demo(reqId: string) {
+  return NextResponse.json(
+    { status: 'demo' },
+    { status: 503, headers: { 'x-kirra-mode': 'demo', 'x-request-id': reqId } },
+  )
 }
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
-  const base = process.env.KIRRA_API_URL?.replace(/\/+$/, '')
-  if (!base) return demo()
-
+  const started = Date.now()
+  const reqId = crypto.randomUUID()
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'local'
   const { path } = await params
   const rel = (path ?? []).join('/')
+
+  const respond = (res: NextResponse, extra?: Record<string, unknown>) => {
+    res.headers.set('x-request-id', reqId)
+    log({ reqId, path: rel, status: res.status, ms: Date.now() - started, ...extra })
+    return res
+  }
+
+  if (rateLimited(ip)) {
+    return respond(
+      NextResponse.json({ error: 'rate limited' }, { status: 429, headers: { 'retry-after': '10' } }),
+      { rateLimited: true },
+    )
+  }
+
+  const base = process.env.KIRRA_API_URL?.replace(/\/+$/, '')
+  if (!base) return respond(demo(reqId), { mode: 'demo' })
+
   if (!ALLOW.some((re) => re.test(rel))) {
-    return NextResponse.json({ error: 'path not allowed' }, { status: 403 })
+    return respond(NextResponse.json({ error: 'path not allowed' }, { status: 403 }))
+  }
+  if (req.nextUrl.search.length > MAX_QUERY_LENGTH) {
+    return respond(NextResponse.json({ error: 'query too long' }, { status: 414 }))
   }
 
   const headers: Record<string, string> = { accept: req.headers.get('accept') ?? 'application/json' }
   if (process.env.KIRRA_ADMIN_TOKEN) headers.authorization = `Bearer ${process.env.KIRRA_ADMIN_TOKEN}`
   if (process.env.KIRRA_CLIENT_ID) headers['x-kirra-client-id'] = process.env.KIRRA_CLIENT_ID
 
+  // The SSE stream is long-lived: only the client's own disconnect aborts it.
+  // Every other read gets a hard upstream timeout so a hung verifier can't
+  // pin console requests open.
+  const isStream = STREAM_PATH.test(rel)
+  const signal = isStream ? req.signal : AbortSignal.any([req.signal, AbortSignal.timeout(UPSTREAM_TIMEOUT_MS)])
+
   try {
     const upstream = await fetch(`${base}/${rel}${req.nextUrl.search}`, {
       method: 'GET',
       headers,
       cache: 'no-store',
-      signal: req.signal,
+      signal,
     })
     // Pass the body straight through (works for JSON and text/event-stream).
     const out = new Headers()
     const ct = upstream.headers.get('content-type')
     if (ct) out.set('content-type', ct)
     out.set('cache-control', 'no-store')
-    return new NextResponse(upstream.body, { status: upstream.status, headers: out })
+    return respond(new NextResponse(upstream.body, { status: upstream.status, headers: out }), {
+      upstream: upstream.status,
+      stream: isStream || undefined,
+    })
   } catch (e) {
-    return NextResponse.json({ error: 'verifier unreachable', detail: String((e as Error)?.message ?? e) }, { status: 502 })
+    const detail = String((e as Error)?.message ?? e)
+    const timedOut = (e as Error)?.name === 'TimeoutError' || detail.includes('timeout')
+    // Detail stays in the server log; the client gets a generic body + reqId.
+    return respond(
+      NextResponse.json(
+        { error: timedOut ? 'verifier timeout' : 'verifier unreachable', reqId },
+        { status: timedOut ? 504 : 502 },
+      ),
+      { error: detail },
+    )
   }
 }

--- a/console/app/error.tsx
+++ b/console/app/error.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useEffect } from 'react'
+
+// Route-segment error boundary: a rendering failure in one screen must never
+// blank the whole console. The operator gets a branded, actionable recovery
+// surface; the error itself goes to the console (and any attached reporter).
+export default function RouteError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error(JSON.stringify({ src: 'kirra-console', kind: 'route-error', digest: error.digest, message: error.message }))
+  }, [error])
+  return (
+    <div className="grid min-h-[60vh] place-items-center p-6">
+      <div className="max-w-md rounded-xl border border-line bg-panel p-6 text-center shadow-panel">
+        <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-crit">screen failed to render</p>
+        <h2 className="mt-2 font-display text-lg font-semibold text-ink">This view hit an error.</h2>
+        <p className="mt-2 text-[13px] text-muted">
+          The rest of the console is unaffected. Retry the view, or navigate elsewhere — nothing about the
+          fleet itself has changed.
+        </p>
+        {error.digest && <p className="mt-2 font-mono text-[10px] text-faint">digest {error.digest}</p>}
+        <button
+          onClick={reset}
+          className="mt-4 rounded-lg border border-line bg-elevated px-4 py-2 text-[13px] text-ink hover:border-line-strong"
+        >
+          Retry this view
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/console/app/global-error.tsx
+++ b/console/app/global-error.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+// Last-resort boundary: catches failures in the root layout itself. Renders a
+// bare-HTML recovery page (no layout, no fonts — those may be what failed).
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <html lang="en">
+      <body style={{ background: '#05070d', color: '#e8eef7', fontFamily: 'monospace', display: 'grid', placeItems: 'center', minHeight: '100vh', margin: 0 }}>
+        <div style={{ textAlign: 'center', maxWidth: 420, padding: 24 }}>
+          <p style={{ color: '#f0655d', letterSpacing: '0.2em', fontSize: 11 }}>CONSOLE FAILED TO RENDER</p>
+          <p style={{ fontSize: 14, color: '#a7b4c6' }}>
+            The console shell hit an unrecoverable error. This affects the UI only — the verifier and fleet
+            are not controlled by this surface.
+          </p>
+          {error.digest && <p style={{ fontSize: 10, color: '#8a97ab' }}>digest {error.digest}</p>}
+          <button
+            onClick={reset}
+            style={{ marginTop: 16, background: 'transparent', color: '#3fd9c9', border: '1px solid #2a3a55', borderRadius: 8, padding: '8px 16px', cursor: 'pointer' }}
+          >
+            Reload console
+          </button>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/console/next.config.mjs
+++ b/console/next.config.mjs
@@ -1,5 +1,28 @@
 /** @type {import('next').NextConfig} */
+
+// Security headers for every response. The CSP is the safe-without-nonces
+// subset (Next's app router injects inline bootstrap scripts, so a full
+// script-src lockdown needs nonce plumbing — tracked in PRODUCTION.md):
+// clickjacking, object embedding, MIME sniffing and base hijacking are all
+// closed here; the console makes no third-party requests at runtime.
+const securityHeaders = [
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+  {
+    key: 'Content-Security-Policy',
+    value: "frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'",
+  },
+]
+
 const nextConfig = {
   reactStrictMode: true,
-};
-export default nextConfig;
+  poweredByHeader: false,
+  // Standalone output → a self-contained server bundle for container deploys.
+  output: 'standalone',
+  async headers() {
+    return [{ source: '/:path*', headers: securityHeaders }]
+  },
+}
+export default nextConfig

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -23,6 +23,7 @@
         "autoprefixer": "^10.4.20",
         "eslint": "^8.57.1",
         "eslint-config-next": "15.5.19",
+        "playwright": "^1.61.1",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3"
@@ -5113,6 +5114,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/console/package.json
+++ b/console/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "smoke": "node scripts/smoke.mjs"
   },
   "dependencies": {
     "clsx": "^2.1.1",
@@ -24,6 +26,7 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
     "eslint-config-next": "15.5.19",
+    "playwright": "^1.61.1",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3"

--- a/console/scripts/smoke.mjs
+++ b/console/scripts/smoke.mjs
@@ -1,0 +1,92 @@
+// Self-managing production smoke test for the Kirra Console.
+//
+//   npm run build && npm run smoke
+//
+// Builds are not touched here: this script starts the production server on a
+// scratch port, drives every route in headless Chromium, and fails on:
+//   - non-200 document responses
+//   - any page error (including React hydration failures)
+//   - any console error other than the expected demo-mode 503s
+//   - a missing <main id="console-main"> (shell failed to compose)
+// It also exercises the quick-nav keyboard flow end-to-end.
+//
+// This is the CI gate distilled from the manual verification runs that caught
+// the hydration regressions — codified so they can't return.
+
+import { spawn } from 'node:child_process'
+import { chromium } from 'playwright'
+
+const PORT = 8899
+const ROUTES = [
+  '', 'live', 'global', 'fleet', 'fleet/r1', 'safety', 'runtime', 'telemetry',
+  'missions', 'oversight', 'doer-bound', 'events', 'incidents', 'compliance',
+  'analytics', 'explorer', 'reports', 'settings',
+]
+
+const server = spawn('npx', ['next', 'start', '-p', String(PORT)], { stdio: 'ignore' })
+const kill = () => { try { server.kill('SIGTERM') } catch {} }
+process.on('exit', kill)
+
+// Wait for the server to accept connections.
+let up = false
+for (let i = 0; i < 60 && !up; i++) {
+  try {
+    const r = await fetch(`http://localhost:${PORT}/`, { redirect: 'manual' })
+    up = r.status < 500
+  } catch {
+    await new Promise((r) => setTimeout(r, 500))
+  }
+}
+if (!up) {
+  console.error('SMOKE FAIL: server did not come up')
+  process.exit(1)
+}
+
+// KIRRA_SMOKE_CHROMIUM overrides the browser binary (for sandboxes with a
+// preinstalled Chromium); CI installs the matching build via
+// `npx playwright install --with-deps chromium` and uses the default.
+const browser = await chromium.launch({ executablePath: process.env.KIRRA_SMOKE_CHROMIUM || undefined })
+const failures = []
+
+for (const route of ROUTES) {
+  const page = await browser.newPage({ viewport: { width: 1600, height: 950 } })
+  const errs = []
+  page.on('pageerror', (e) => errs.push(`pageerror: ${e.message.slice(0, 140)}`))
+  page.on('console', (m) => {
+    const t = m.text()
+    if (m.type() === 'error' && !t.includes('503')) errs.push(`console: ${t.slice(0, 140)}`)
+  })
+  try {
+    const resp = await page.goto(`http://localhost:${PORT}/${route}`, { waitUntil: 'networkidle', timeout: 30000 })
+    if (!resp || resp.status() !== 200) errs.push(`status: ${resp?.status()}`)
+    await page.waitForTimeout(1200)
+    if (!(await page.$('#console-main'))) errs.push('missing #console-main')
+  } catch (e) {
+    errs.push(`nav: ${e.message.slice(0, 140)}`)
+  }
+  if (errs.length) failures.push({ route: route || '/', errs })
+  console.log(`${errs.length ? '✗' : '✓'} /${route}`)
+  await page.close()
+}
+
+// Quick-nav keyboard flow: type, Enter, land on the target route.
+{
+  const page = await browser.newPage({ viewport: { width: 1600, height: 950 } })
+  await page.goto(`http://localhost:${PORT}/`, { waitUntil: 'networkidle', timeout: 30000 })
+  await page.fill('input[role="combobox"]', 'incid')
+  await page.keyboard.press('Enter')
+  await page.waitForURL('**/incidents', { timeout: 10000 }).catch(() => failures.push({ route: 'quicknav', errs: ['did not navigate to /incidents'] }))
+  console.log(`${failures.some((f) => f.route === 'quicknav') ? '✗' : '✓'} quick-nav`)
+  await page.close()
+}
+
+await browser.close()
+kill()
+
+if (failures.length) {
+  console.error('\nSMOKE FAIL:')
+  for (const f of failures) console.error(` /${f.route}\n   ${f.errs.join('\n   ')}`)
+  process.exit(1)
+}
+console.log(`\nSMOKE PASS: ${ROUTES.length} routes + quick-nav clean`)
+process.exit(0)


### PR DESCRIPTION
Production-hardening pass over the operator console (full record + runbook in `console/PRODUCTION.md`; the design/UX pass was #1089). No screen behavior changes.

**Proxy hardening** (`app/api/kirra/[...path]/route.ts`)
- 10 s upstream timeout → 504; the SSE stream path is exempt (long-lived) but still aborts on client disconnect — a hung verifier can no longer pin console requests
- Per-IP sliding-window rate limit (240/min, bounded memory) → 429; query-length cap → 414
- Structured JSON request logging with a request id echoed as `x-request-id`; upstream error detail is logged server-side and **never** returned to clients

**App shell**
- Security headers on every response (X-Frame-Options DENY, nosniff, Referrer-Policy, Permissions-Policy, CSP `frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'`); `poweredByHeader` off; `output: 'standalone'` for container deploys
- Route-segment + global error boundaries — a screen crash never blanks the console, and the recovery copy states the UI is not the fleet

**Verification institutionalized**
- `scripts/smoke.mjs`: self-managing production smoke — builds' server started on a scratch port, all 18 routes driven in headless Chromium, failing on any page error (the exact check that caught the hydration regressions), missing shell, or a broken quick-nav keyboard flow
- New blocking **`console` CI lane**: `npm ci` → typecheck → lint → build → `playwright install chromium` → smoke. Actions SHA-pinned (M-6 gate passes); workflow YAML validated (29 jobs)

**Docs** — `console/PRODUCTION.md`: runbook (env vars, serving, standalone output), the hardening inventory with verify commands, an honest security posture (the console has **no in-console user auth by design** — deploy behind SSO/reverse-proxy auth; per-instance rate limiter; CSP scope), and the ranked remaining gaps before enterprise deployment (per-operator RBAC via #314, auditor-role token, SSE adoption, nonce CSP, contract tests).

**Verified:** `tsc` clean · build green · headers curl-verified on pages and API routes · smoke **18/18 routes + quick-nav PASS** · `scripts/pin-actions.sh --check` OK.

No deploy impact: Pages only publishes `website/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7)_