### PR TITLE
console: live SSE posture stream + verified end-to-end against the real verifier

### DIFF
--- a/console/PRODUCTION.md
+++ b/console/PRODUCTION.md
@@ -52,6 +52,17 @@ images, cosign signing — see `.github/workflows/docker.yml` for the pattern).
 - **Failure containment**: route-segment error boundary (`app/error.tsx`) and
   root boundary (`app/global-error.tsx`) — a screen crash never blanks the
   console, and the recovery copy states that the UI is not the fleet
+- **Live event transport (SSE)**: the fleet hook attaches to the verifier's
+  real posture stream (`GET /system/posture/stream`) once a live snapshot
+  succeeds; each pushed event schedules a coalesced snapshot refetch so the
+  table stays authoritative, and polling relaxes to a 30 s heartbeat while the
+  stream is open. Any stream error falls back to full-rate polling and retries
+  with backoff — never worse than the pre-SSE behavior. The proxy streams SSE
+  unbuffered (push-pump + `no-transform`/`x-accel-buffering: no`) so
+  `EventSource` fires `onopen` immediately. The Overview and Live screens show
+  the live transport (`SSE stream` vs `polling`). Verified end-to-end against a
+  running verifier: a node registration pushed an event over the stream and the
+  new node appeared in the table.
 - **Data-layer resilience** (pre-existing, kept): every hook aborts in-flight
   requests on unmount, distinguishes demo/abort/failure, settles to labeled
   demo data, and keeps re-polling — network interruptions self-heal
@@ -91,12 +102,10 @@ quick-nav keyboard flow must navigate. Locally:
    registry (#314); until then, SSO-in-front is the supported model.
 2. **Auditor-role token instead of admin token** — supported by the verifier
    today; a deployment choice, documented above.
-3. **SSE adoption** — the stream is proxied but unconsumed; polling remains
-   the transport (5–30 s). Roadmap item #1 in REVIEW.md.
-4. **Nonce-based CSP**, error-reporter integration (the boundaries and
+3. **Nonce-based CSP**, error-reporter integration (the boundaries and
    structured logs are the hook points), OpenTelemetry spans on the proxy.
-5. **Test depth** — the smoke gate covers rendering and navigation; component
+4. **Test depth** — the smoke gate covers rendering and navigation; component
    and contract tests (wire types vs verifier serde) are the next layer.
-6. **Preview screens in customer deployments** — the 12 simulated screens are
+5. **Preview screens in customer deployments** — the 12 simulated screens are
    labeled at three levels; a build-time flag to hide them entirely is a
    product decision awaiting real customer telemetry to replace them.

--- a/console/REVIEW.md
+++ b/console/REVIEW.md
@@ -76,9 +76,10 @@ Recommended next (no test infrastructure exists yet):
 
 ## 16. Fleet-scale roadmap (ranked)
 
-1. **Consume the real SSE posture stream** (`/system/posture/stream` is already
-   proxy-allow-listed) instead of 5 s polling + client diffing — lower latency,
-   correct event ordering, and the fleet page becomes genuinely live.
+1. ~~Consume the real SSE posture stream~~ **— DONE.** `useLiveFleet` attaches
+   to `/system/posture/stream`; events push a coalesced snapshot refetch, the
+   transport is shown in the UI, and it falls back to polling on any error.
+   Verified end-to-end against a live verifier (see `PRODUCTION.md`).
 2. **Alert center**: persist posture transitions + audit anomalies with
    acknowledge/history (groundwork: `useLiveFleet` already synthesizes
    transition events).

--- a/console/app/api/kirra/[...path]/route.ts
+++ b/console/app/api/kirra/[...path]/route.ts
@@ -122,14 +122,59 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ path
       cache: 'no-store',
       signal,
     })
-    // Pass the body straight through (works for JSON and text/event-stream).
+
+    // SSE: returning the upstream body directly lets the Node runtime buffer
+    // text/event-stream, so the browser's EventSource never fires onopen
+    // (stays CONNECTING). Manually pumping the upstream reader into a fresh
+    // ReadableStream forces the response headers out immediately and streams
+    // each chunk as it arrives. `no-transform` + `x-accel-buffering: no`
+    // stop any compression/buffering intermediary.
+    if (isStream && upstream.body) {
+      const reader = upstream.body.getReader()
+      const enc = new TextEncoder()
+      const passthrough = new ReadableStream<Uint8Array>({
+        start(controller) {
+          // Eagerly emit a comment so the runtime flushes response headers
+          // immediately (EventSource fires onopen), then self-pump the
+          // upstream. Push-driven, not pull-driven — the runtime cannot defer.
+          controller.enqueue(enc.encode(': open\n\n'))
+          ;(async () => {
+            try {
+              for (;;) {
+                const { done, value } = await reader.read()
+                if (done) break
+                controller.enqueue(value)
+              }
+            } catch {
+              /* upstream closed */
+            } finally {
+              controller.close()
+            }
+          })()
+        },
+        cancel() {
+          reader.cancel().catch(() => {})
+        },
+      })
+      const out = new Headers({
+        'content-type': 'text/event-stream; charset=utf-8',
+        'cache-control': 'no-cache, no-transform',
+        'connection': 'keep-alive',
+        'x-accel-buffering': 'no',
+      })
+      return respond(new NextResponse(passthrough, { status: upstream.status, headers: out }), {
+        upstream: upstream.status,
+        stream: true,
+      })
+    }
+
+    // Non-stream reads: pass the body straight through.
     const out = new Headers()
     const ct = upstream.headers.get('content-type')
     if (ct) out.set('content-type', ct)
     out.set('cache-control', 'no-store')
     return respond(new NextResponse(upstream.body, { status: upstream.status, headers: out }), {
       upstream: upstream.status,
-      stream: isStream || undefined,
     })
   } catch (e) {
     const detail = String((e as Error)?.message ?? e)

--- a/console/app/live/page.tsx
+++ b/console/app/live/page.tsx
@@ -8,7 +8,7 @@ import type { Tone } from '@/lib/types'
 import { utcTime } from '@/lib/format'
 
 export default function LivePage() {
-  const { fleet, events, source, error, updatedAt } = useLiveFleet(5000)
+  const { fleet, events, source, error, updatedAt, transport } = useLiveFleet(5000)
   const audit = useAuditChain(15000)
   const counts = fleet.reduce(
     (a, n) => { a[n.propagated_status] = (a[n.propagated_status] ?? 0) + 1; return a },
@@ -21,7 +21,7 @@ export default function LivePage() {
         <div>
           <h1 className="font-display text-xl font-semibold text-ink">Live Fleet</h1>
           <p className="font-mono text-[11px] text-faint">
-            verifier · GET /fleet/posture · {source === 'live' ? `updated ${updatedAt ? utcTime(updatedAt) : '—'}` : 'mock fallback'}
+            verifier · {transport === 'stream' ? 'SSE /system/posture/stream + snapshot' : 'GET /fleet/posture'} · {source === 'live' ? `updated ${updatedAt ? utcTime(updatedAt) : '—'}` : 'mock fallback'}
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/console/components/ui/overview-status.tsx
+++ b/console/components/ui/overview-status.tsx
@@ -10,7 +10,7 @@ import { Pill } from '@/components/ui/primitives'
     otherwise the demo dataset with the badge saying exactly that. Nothing in
     this strip is a hardcoded reassurance. */
 export function OverviewStatus() {
-  const { fleet, source, updatedAt } = useLiveFleet()
+  const { fleet, source, updatedAt, transport } = useLiveFleet()
   const { verify, source: auditSource } = useAuditChain()
 
   const posture = useMemo(() => {
@@ -27,6 +27,11 @@ export function OverviewStatus() {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <DemoBadge live={source === 'live'} />
+      {source === 'live' && (
+        <Pill tone={transport === 'stream' ? 'ice' : 'muted'}>
+          {transport === 'stream' ? 'SSE stream' : 'polling'}
+        </Pill>
+      )}
       <Pill tone={posture.tone}>{posture.label}</Pill>
       <Pill tone="muted">
         {trusted}/{fleet.length} nominal

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { kirra, DemoMode } from './client'
+import { PROXY_BASE } from './config'
 import type { AuditEntry, AuditVerify, AssetPosture, ConsoleAnalytics, ConsoleRuntime, ConsoleSites, ConsoleVersions, FabricTelemetry, FederatedReport, FleetNodePosture, FleetPostureState, NodeHistoryEntry, PostureStreamEvent } from './types'
 import { robots } from '@/lib/mock'
 import { log as demoEvents, sources as demoSources } from '@/lib/events'
@@ -97,20 +98,29 @@ export function useLiveFleet(pollMs = 5000): {
   source: Source
   error: string | null
   updatedAt: number | null
+  transport: 'stream' | 'poll' | 'demo'
 } {
   const [fleet, setFleet] = useState<FleetNodePosture[]>(() => demoFleet())
   const [events, setEvents] = useState<PostureStreamEvent[]>([])
   const [source, setSource] = useState<Source>('demo')
   const [error, setError] = useState<string | null>(null)
   const [updatedAt, setUpdatedAt] = useState<number | null>(null)
+  const [transport, setTransport] = useState<'stream' | 'poll' | 'demo'>('demo')
   const prev = useRef<Map<string, FleetPostureState>>(new Map())
   const demoTimer = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
     const ctrl = new AbortController()
     let timer: ReturnType<typeof setTimeout>
+    let esTimer: ReturnType<typeof setTimeout>
+    let refetchTimer: ReturnType<typeof setTimeout> | null = null
+    let es: EventSource | null = null
+    let esBackoff = 5000
+    let streaming = false
+    let disposed = false
 
     const startDemo = () => {
+      setTransport('demo')
       if (demoTimer.current) return
       const f = demoFleet(); setFleet(f); setSource('demo')
       let k = 0
@@ -120,7 +130,39 @@ export function useLiveFleet(pollMs = 5000): {
       }, 2600)
     }
 
-    const load = async () => {
+    // SSE upgrade: once a live snapshot succeeds, attach to the verifier's
+    // real posture stream (GET /system/posture/stream through the proxy).
+    // Events arrive push-fashion; each one schedules a coalesced snapshot
+    // refetch so the fleet table stays authoritative. While the stream is
+    // open, polling stretches to a 30s safety heartbeat. Any stream error
+    // falls back to full-rate polling and retries the stream with backoff —
+    // the console is never worse off than the pre-SSE behavior.
+    const openStream = () => {
+      if (disposed || es || typeof EventSource === 'undefined') return
+      const sse = new EventSource(`${PROXY_BASE}/system/posture/stream`)
+      es = sse
+      sse.onopen = () => { streaming = true; esBackoff = 5000; setTransport('stream') }
+      sse.onmessage = (m) => {
+        try {
+          const ev = JSON.parse(m.data) as PostureStreamEvent
+          if (typeof ev?.event_type === 'string') {
+            setEvents((cur) => [ev, ...cur].slice(0, 40))
+            if (!refetchTimer) refetchTimer = setTimeout(() => { refetchTimer = null; void load(true) }, 250)
+          }
+        } catch { /* ignore malformed frames — the snapshot loop stays authoritative */ }
+      }
+      sse.onerror = () => {
+        sse.close()
+        es = null
+        if (streaming) { streaming = false; setTransport('poll') }
+        if (!disposed) {
+          esTimer = setTimeout(openStream, esBackoff)
+          esBackoff = Math.min(esBackoff * 2, 60000)
+        }
+      }
+    }
+
+    const load = async (oneShot = false) => {
       try {
         const { fleet: next } = await kirra.fleetPosture(ctrl.signal)
         if (demoTimer.current) { clearInterval(demoTimer.current); demoTimer.current = null }
@@ -132,23 +174,29 @@ export function useLiveFleet(pollMs = 5000): {
           prev.current.set(n.node_id, n.propagated_status)
         }
         setFleet(next); setSource('live'); setError(null); setUpdatedAt(Date.now())
-        if (fresh.length) setEvents((cur) => [...fresh, ...cur].slice(0, 40))
-        timer = setTimeout(load, pollMs)
+        if (!streaming) setTransport('poll')
+        if (fresh.length && !streaming) setEvents((cur) => [...fresh, ...cur].slice(0, 40))
+        openStream()
+        if (!oneShot) timer = setTimeout(() => void load(), streaming ? Math.max(pollMs, 30000) : pollMs)
       } catch (e) {
         if (isAbort(e)) return
         if (isDemo(e)) { startDemo(); return }       // no backend — settle into demo
         setError(String((e as Error)?.message ?? e)) // backend down — show demo, keep retrying
-        startDemo(); timer = setTimeout(load, pollMs)
+        startDemo()
+        if (!oneShot) timer = setTimeout(() => void load(), pollMs)
       }
     }
-    load()
+    void load()
     return () => {
-      ctrl.abort(); clearTimeout(timer)
+      disposed = true
+      ctrl.abort(); clearTimeout(timer); clearTimeout(esTimer)
+      if (refetchTimer) clearTimeout(refetchTimer)
+      es?.close(); es = null
       if (demoTimer.current) { clearInterval(demoTimer.current); demoTimer.current = null }
     }
   }, [pollMs])
 
-  return { fleet, events, source, error, updatedAt }
+  return { fleet, events, source, error, updatedAt, transport }
 }
 
 // Audit-chain integrity + recent entries (verify is admin-gated, entries are


### PR DESCRIPTION
Adopts the verifier's real event stream (the console's #1 roadmap item) and proves the entire console against a running `kirra_verifier_service` — not demo data.

**SSE transport** (`lib/api/hooks.ts` `useLiveFleet`)
- Once a live snapshot succeeds, attaches an `EventSource` to `GET /system/posture/stream` (already proxy-allow-listed). Each pushed event schedules a coalesced 250 ms snapshot refetch so the fleet table stays authoritative; while streaming, polling relaxes to a 30 s heartbeat.
- Fully fail-safe: stream error → full-rate polling + backoff reconnect; demo mode never attaches. Never worse than the prior poll-only path.
- Exposes `transport` (`stream`/`poll`/`demo`); Overview shows an SSE-stream/polling pill and the Live page names the actual transport.

**Proxy SSE fix** (`app/api/kirra/[...path]/route.ts`)
- The Node runtime buffered `text/event-stream`, so the browser's `EventSource` never fired `onopen` (stayed CONNECTING). Fixed with a push-based passthrough stream that emits an initial `: open` comment to force the header flush, plus `no-transform` + `x-accel-buffering: no`. Headers flush immediately; `onopen` fires; events arrive.

**End-to-end verification against the real verifier** (not demo)
- Built and ran `kirra_verifier_service`, seeded and **honestly attested** a 5-node fleet to Nominal via the Ed25519 challenge/response (`robot/attest_bench_node.py`), and bound the console with `KIRRA_API_URL`.
- Confirmed in headless Chromium: `LIVE · CONNECTED`, `FLEET NOMINAL`, real node counts (6/5/1/0), the real attested fleet table, 398 real audit entries, `EventSource` `onopen`, transport pill = `stream`, and a node registration pushed a `SYSTEM_POSTURE_TRANSITION` over SSE that made the new node appear in the table — zero page errors.
- Demo-mode smoke still **PASS 18/18 + quick-nav** (SSE falls back cleanly when there's no backend).

Docs: `PRODUCTION.md` moves SSE from gaps to implemented (with the verification note); `REVIEW.md` roadmap item #1 marked done.

No deploy impact: Pages only publishes `website/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7)_