### PR TITLE
website: add Company / About page with founder background

### DIFF
--- a/website/404.html
+++ b/website/404.html
@@ -133,6 +133,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/_src/pages/careers.mjs
+++ b/website/_src/pages/careers.mjs
@@ -63,6 +63,7 @@ ${pageHero({
         <div class="hero__ctas" style="justify-content:center" data-reveal>
           <a class="btn btn--primary" href="${SITE.repo}/issues" target="_blank" rel="noopener">Open issues <span class="arrow" aria-hidden="true">→</span></a>
           <a class="btn btn--ghost" href="open-source.html">How contributions are gated</a>
+          <a class="btn btn--ghost" href="company.html">About the company</a>
         </div>
       </div>
     </section>

--- a/website/_src/pages/company.mjs
+++ b/website/_src/pages/company.mjs
@@ -1,0 +1,148 @@
+import { SITE, ev, evRow, pageHero, ctaBand } from "../template.mjs";
+
+export const meta = {
+  slug: "company",
+  title: "Company",
+  desc: "Kirra Systems is a safety-governance company based in Titusville, Florida, founded by Justin Looney — a career grounded in hardware verification, network security, military communications, and real safety-critical control.",
+  jsonld: {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Kirra Systems",
+    url: "https://kirrasystems.com",
+    logo: "https://kirrasystems.com/assets/kirra-logo.png",
+    sameAs: ["https://github.com/kirra-systems/kirra-runtime-sdk"],
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "Titusville",
+      addressRegion: "FL",
+      addressCountry: "US",
+    },
+    founder: {
+      "@type": "Person",
+      name: "Justin Looney",
+      jobTitle: "Founder",
+    },
+  },
+};
+
+export const body = `
+${pageHero({
+  eyebrow: "Company",
+  title: "Built by people who have<br>been downstream of a bad command.",
+  lede: "Kirra Systems builds the fail-closed layer between AI intent and physical action. It is grounded in a simple conviction, earned across enterprise hardware verification, federal network security, military communications, and the operation of real public-safety infrastructure: complex systems must fail closed, in the real world, with real consequences downstream.",
+})}
+
+    <section aria-labelledby="h-founder">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>The founder</p>
+          <h2 id="h-founder" data-reveal>Justin Looney</h2>
+        </div>
+        <div class="grid grid--2" style="align-items:start;gap:48px">
+          <div data-reveal>
+            <div style="display:flex;align-items:center;gap:18px;margin-bottom:22px">
+              <div aria-hidden="true" style="flex:none;width:72px;height:72px;border-radius:16px;display:grid;place-items:center;background:var(--accent-soft);border:1px solid var(--accent-line);font-family:var(--font-display);font-weight:700;font-size:1.5rem;color:var(--accent);letter-spacing:0.02em">JL</div>
+              <div>
+                <p class="mono" style="font-size:0.8rem;color:var(--ink)">Founder</p>
+                <p class="mono dim" style="font-size:0.78rem">Titusville, Florida</p>
+              </div>
+            </div>
+            <p class="lede" style="font-size:1.08rem">Justin Looney founded Kirra Systems and architected its core —
+            the planner-independent checker, the fail-closed actuation model, and the cryptographic attestation that
+            makes every safety decision auditable. His career has centered on the exact disciplines a safety
+            governor demands: rigorous hardware and systems verification, network security, and safety-critical
+            infrastructure.</p>
+          </div>
+          <div style="display:grid;gap:16px">
+            <div class="card" data-reveal>
+              <h3>Enterprise hardware verification</h3>
+              <p>Hardware and Diagnostics Test Engineer and technical lead on IBM's <strong>xSeries</strong>
+              enterprise server line; test lead at <strong>Emulex</strong> for CNA/FCoE — Converged Network
+              Adapter / Fibre Channel over Ethernet, high-performance data-center networking hardware. This is
+              work defined by one discipline: proving complex systems behave correctly and fail predictably under
+              fault — the discipline at the heart of Kirra.</p>
+            </div>
+            <div class="card" data-reveal>
+              <h3>Federal network &amp; security programs</h3>
+              <p>U.S. EPA Technical Point of Contact (GS-2210-13) on an enterprise network and security task order —
+              technical authority over enterprise wireless design and deployment, a data-center network
+              modernization from Cisco Catalyst to Nexus, and a WAN security upgrade to <strong>MTIPS</strong>, the
+              federal Managed Trusted Internet Protocol Service.</p>
+            </div>
+            <div class="card" data-reveal>
+              <h3>Career military communications</h3>
+              <p>Retired U.S. Army Signal Corps <strong>Master Sergeant (E-8)</strong>, a Telecommunications
+              Operations Chief (25W) — two decades leading mission-critical military communications, where systems
+              fail safely or not at all.</p>
+            </div>
+            <div class="card" data-reveal>
+              <h3>Real safety-critical control</h3>
+              <p>Licensed operation of public water-treatment infrastructure — direct, hands-on responsibility for
+              the automated control systems that govern a real public utility, where a wrong command has physical
+              consequences and auditability is not optional.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-shows">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Experience, in the codebase</p>
+          <h2 id="h-shows" data-reveal>Where that background shows up</h2>
+          <p class="lede" data-reveal>The founder's story isn't a résumé beside the product — it's visible in the
+          engineering choices. Each discipline maps to a mechanism you can read.</p>
+        </div>
+        <div class="grid grid--2">
+          <div class="card" data-reveal>
+            <h3>Verification instinct → proofs, not promises</h3>
+            <p>A career spent proving hardware fails predictably is why the checker core is machine-checked over all
+            inputs, kill-tested for durability, and gated by 27 CI lanes — not asserted in a datasheet.</p>
+            ${evRow("verification/kani/", "tests/audit_chain_prefix_on_kill.rs")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Network security → attestation &amp; audit</h3>
+            <p>Federal network-security program leadership is why trust is proven per node with Ed25519
+            challenge-response, and why every decision lands in a hash-chained ledger — a governor you audit, not
+            one you trust.</p>
+            ${evRow("crates/kirra-safety-authority/src/attestation.rs", "src/audit_chain.rs")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Military comms → fail safe or not at all</h3>
+            <p>Two decades where systems fail safely or not at all is the origin of the fail-closed default:
+            unproven, stale, malformed, or unclassified — the answer is deny.</p>
+            ${evRow("src/posture_cache.rs", "docs/safety/SAFE_STATE_SPECIFICATION.md")}
+          </div>
+          <div class="card" data-reveal>
+            <h3>Water-plant control → deny on physics</h3>
+            <p>Hands-on responsibility for utility control systems is why Kirra's industrial adapters decode the
+            actual setpoint on the wire and deny on magnitude regardless of credentials — the exact class of the
+            2021 Oldsmar water-plant incident.</p>
+            ${evRow("crates/kirra-industrial", "docs/protocol_adapters.md")}
+          </div>
+        </div>
+        <p class="evidence-note" style="margin-top:20px">The founder biography above is provided by Kirra Systems; the
+        repository links show the mechanisms each discipline informed.</p>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-where">
+      <div class="container container--narrow" style="text-align:center">
+        <p class="eyebrow" data-reveal style="justify-content:center">Where we are</p>
+        <h2 id="h-where" data-reveal>Titusville, Florida</h2>
+        <p class="lede" data-reveal style="margin:18px auto 0">On Florida's Space Coast — a region built around systems
+        that cannot be allowed to fail unsafely. Kirra Systems develops entirely in the open; the fastest way to
+        know the company is to read its repository.</p>
+        <div class="hero__ctas" style="justify-content:center" data-reveal>
+          <a class="btn btn--primary" href="contact.html">Get in touch <span class="arrow" aria-hidden="true">→</span></a>
+          <a class="btn btn--ghost" href="careers.html">How we work</a>
+          <a class="btn btn--ghost" href="${SITE.repo}" target="_blank" rel="noopener">The repository ↗</a>
+        </div>
+      </div>
+    </section>
+`;

--- a/website/_src/pages/index.mjs
+++ b/website/_src/pages/index.mjs
@@ -14,6 +14,13 @@ export const meta = {
         url: "https://kirrasystems.com",
         logo: "https://kirrasystems.com/assets/kirra-logo.png",
         sameAs: ["https://github.com/kirra-systems/kirra-runtime-sdk"],
+        address: {
+          "@type": "PostalAddress",
+          addressLocality: "Titusville",
+          addressRegion: "FL",
+          addressCountry: "US",
+        },
+        founder: { "@type": "Person", name: "Justin Looney", jobTitle: "Founder" },
       },
       {
         "@type": "WebSite",

--- a/website/_src/template.mjs
+++ b/website/_src/template.mjs
@@ -114,6 +114,7 @@ const FOOTER = `
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/architecture.html
+++ b/website/architecture.html
@@ -399,6 +399,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -277,6 +277,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/careers.html
+++ b/website/careers.html
@@ -148,6 +148,7 @@
         <div class="hero__ctas" style="justify-content:center" data-reveal>
           <a class="btn btn--primary" href="https://github.com/kirra-systems/kirra-runtime-sdk/issues" target="_blank" rel="noopener">Open issues <span class="arrow" aria-hidden="true">→</span></a>
           <a class="btn btn--ghost" href="open-source.html">How contributions are gated</a>
+          <a class="btn btn--ghost" href="company.html">About the company</a>
         </div>
       </div>
     </section>
@@ -206,6 +207,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/certification.html
+++ b/website/certification.html
@@ -264,6 +264,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/company.html
+++ b/website/company.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Company — Kirra Systems</title>
+  <meta name="description" content="Kirra Systems is a safety-governance company based in Titusville, Florida, founded by Justin Looney — a career grounded in hardware verification, network security, military communications, and real safety-critical control.">
+  <link rel="canonical" href="https://kirrasystems.com/company.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Kirra Systems">
+  <meta property="og:title" content="Company — Kirra Systems">
+  <meta property="og:description" content="Kirra Systems is a safety-governance company based in Titusville, Florida, founded by Justin Looney — a career grounded in hardware verification, network security, military communications, and real safety-critical control.">
+  <meta property="og:url" content="https://kirrasystems.com/company.html">
+  <meta property="og:image" content="https://kirrasystems.com/assets/og.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Company — Kirra Systems">
+  <meta name="twitter:description" content="Kirra Systems is a safety-governance company based in Titusville, Florida, founded by Justin Looney — a career grounded in hardware verification, network security, military communications, and real safety-critical control.">
+  <meta name="twitter:image" content="https://kirrasystems.com/assets/og.png">
+  <meta name="theme-color" content="#05070d">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="assets/kirra-logo.png" type="image/png">
+  <link rel="apple-touch-icon" href="assets/kirra-logo.png">
+  <link rel="preload" href="fonts/space-grotesk-var-latin.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="fonts/inter-var-latin.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="stylesheet" href="css/kirra.css">
+  <script>/* theme init before first paint — prevents flash */
+(function(){try{var t=localStorage.getItem("kirra-theme");if(!t)t=matchMedia("(prefers-color-scheme: light)").matches?"light":"dark";document.documentElement.dataset.theme=t;}catch(e){document.documentElement.dataset.theme="dark";}})();</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"Kirra Systems","url":"https://kirrasystems.com","logo":"https://kirrasystems.com/assets/kirra-logo.png","sameAs":["https://github.com/kirra-systems/kirra-runtime-sdk"],"address":{"@type":"PostalAddress","addressLocality":"Titusville","addressRegion":"FL","addressCountry":"US"},"founder":{"@type":"Person","name":"Justin Looney","jobTitle":"Founder"}}</script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="nav" id="nav">
+    <div class="nav__inner">
+      <a href="index.html" class="nav__brand" aria-label="Kirra Systems home"><svg viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <g stroke="currentColor" stroke-width="1.4" opacity="0.85">
+    <path d="M7 4v24M7 17 25 4M11.5 13.7 25 28"/>
+    <path d="M7 4l7 6.5M7 28l4.5-14.3M14 10.5 7 17" opacity="0.35"/>
+  </g>
+  <g fill="var(--accent, #3fd9c9)">
+    <circle cx="7" cy="4" r="2"/><circle cx="7" cy="17" r="2.4"/><circle cx="7" cy="28" r="2"/>
+    <circle cx="25" cy="4" r="2"/><circle cx="25" cy="28" r="2"/>
+    <circle cx="14" cy="10.5" r="1.5"/><circle cx="11.5" cy="13.7" r="1.5"/>
+  </g>
+</svg><span>KIRRA</span></a>
+      <nav class="nav__links" id="navLinks" aria-label="Primary">
+        <a href="solutions.html">Solutions</a>
+        <a href="vision.html">Vision</a>
+        <a href="architecture.html">Architecture</a>
+        <a href="safety.html">Safety</a>
+        <a href="certification.html">Certification</a>
+        <a href="field-notes.html">Field Notes</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <button class="theme-toggle" id="themeToggle" aria-label="Toggle color theme">
+        <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z"/></svg>
+        <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.9 4.9l1.4 1.4m11.4 11.4 1.4 1.4M2 12h2m16 0h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+      </button>
+      <a href="https://github.com/kirra-systems/kirra-runtime-sdk" class="nav__cta" target="_blank" rel="noopener" aria-label="Kirra on GitHub (opens in new tab)"><span class="label">GitHub</span><span aria-hidden="true">↗</span></a>
+      <button class="nav__burger" id="navBurger" aria-label="Open menu" aria-expanded="false" aria-controls="navLinks">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+      </button>
+    </div>
+  </header>
+  <nav class="subnav" aria-label="Platform sections">
+    <div class="subnav__inner">
+      <a href="solutions.html">solutions</a>
+      <a href="vision.html">vision</a>
+      <a href="architecture.html">architecture</a>
+      <a href="runtime.html">runtime</a>
+      <a href="diagnostics.html">diagnostics</a>
+      <a href="safety.html">safety</a>
+      <a href="planning.html">planning</a>
+      <a href="perception.html">perception</a>
+      <a href="prediction.html">prediction</a>
+      <a href="determinism.html">determinism</a>
+      <a href="performance.html">performance</a>
+      <a href="security.html">security</a>
+      <a href="certification.html">certification</a>
+      <a href="benchmarks.html">benchmarks</a>
+      <a href="playground.html">playground</a>
+      <a href="open-source.html">open source</a>
+      <a href="documentation.html">docs</a>
+      <a href="research.html">research</a>
+    </div>
+  </nav>
+
+  <main id="main">
+
+
+    <section class="page-hero">
+      <div class="container">
+        <p class="eyebrow" data-reveal>Company</p>
+        <h1 data-reveal>Built by people who have<br>been downstream of a bad command.</h1>
+        <p class="lede" data-reveal>Kirra Systems builds the fail-closed layer between AI intent and physical action. It is grounded in a simple conviction, earned across enterprise hardware verification, federal network security, military communications, and the operation of real public-safety infrastructure: complex systems must fail closed, in the real world, with real consequences downstream.</p>
+      </div>
+    </section>
+
+    <section aria-labelledby="h-founder">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>The founder</p>
+          <h2 id="h-founder" data-reveal>Justin Looney</h2>
+        </div>
+        <div class="grid grid--2" style="align-items:start;gap:48px">
+          <div data-reveal>
+            <div style="display:flex;align-items:center;gap:18px;margin-bottom:22px">
+              <div aria-hidden="true" style="flex:none;width:72px;height:72px;border-radius:16px;display:grid;place-items:center;background:var(--accent-soft);border:1px solid var(--accent-line);font-family:var(--font-display);font-weight:700;font-size:1.5rem;color:var(--accent);letter-spacing:0.02em">JL</div>
+              <div>
+                <p class="mono" style="font-size:0.8rem;color:var(--ink)">Founder</p>
+                <p class="mono dim" style="font-size:0.78rem">Titusville, Florida</p>
+              </div>
+            </div>
+            <p class="lede" style="font-size:1.08rem">Justin Looney founded Kirra Systems and architected its core —
+            the planner-independent checker, the fail-closed actuation model, and the cryptographic attestation that
+            makes every safety decision auditable. His career has centered on the exact disciplines a safety
+            governor demands: rigorous hardware and systems verification, network security, and safety-critical
+            infrastructure.</p>
+          </div>
+          <div style="display:grid;gap:16px">
+            <div class="card" data-reveal>
+              <h3>Enterprise hardware verification</h3>
+              <p>Hardware and Diagnostics Test Engineer and technical lead on IBM's <strong>xSeries</strong>
+              enterprise server line; test lead at <strong>Emulex</strong> for CNA/FCoE — Converged Network
+              Adapter / Fibre Channel over Ethernet, high-performance data-center networking hardware. This is
+              work defined by one discipline: proving complex systems behave correctly and fail predictably under
+              fault — the discipline at the heart of Kirra.</p>
+            </div>
+            <div class="card" data-reveal>
+              <h3>Federal network &amp; security programs</h3>
+              <p>U.S. EPA Technical Point of Contact (GS-2210-13) on an enterprise network and security task order —
+              technical authority over enterprise wireless design and deployment, a data-center network
+              modernization from Cisco Catalyst to Nexus, and a WAN security upgrade to <strong>MTIPS</strong>, the
+              federal Managed Trusted Internet Protocol Service.</p>
+            </div>
+            <div class="card" data-reveal>
+              <h3>Career military communications</h3>
+              <p>Retired U.S. Army Signal Corps <strong>Master Sergeant (E-8)</strong>, a Telecommunications
+              Operations Chief (25W) — two decades leading mission-critical military communications, where systems
+              fail safely or not at all.</p>
+            </div>
+            <div class="card" data-reveal>
+              <h3>Real safety-critical control</h3>
+              <p>Licensed operation of public water-treatment infrastructure — direct, hands-on responsibility for
+              the automated control systems that govern a real public utility, where a wrong command has physical
+              consequences and auditability is not optional.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-shows">
+      <div class="container">
+        <div class="section-head">
+          <p class="eyebrow" data-reveal>Experience, in the codebase</p>
+          <h2 id="h-shows" data-reveal>Where that background shows up</h2>
+          <p class="lede" data-reveal>The founder's story isn't a résumé beside the product — it's visible in the
+          engineering choices. Each discipline maps to a mechanism you can read.</p>
+        </div>
+        <div class="grid grid--2">
+          <div class="card" data-reveal>
+            <h3>Verification instinct → proofs, not promises</h3>
+            <p>A career spent proving hardware fails predictably is why the checker core is machine-checked over all
+            inputs, kill-tested for durability, and gated by 27 CI lanes — not asserted in a datasheet.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/verification/kani/" target="_blank" rel="noopener">verification/kani/</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/tests/audit_chain_prefix_on_kill.rs" target="_blank" rel="noopener">tests/audit_chain_prefix_on_kill.rs</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Network security → attestation &amp; audit</h3>
+            <p>Federal network-security program leadership is why trust is proven per node with Ed25519
+            challenge-response, and why every decision lands in a hash-chained ledger — a governor you audit, not
+            one you trust.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/crates/kirra-safety-authority/src/attestation.rs" target="_blank" rel="noopener">crates/kirra-safety-authority/src/attestation.rs</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/audit_chain.rs" target="_blank" rel="noopener">src/audit_chain.rs</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Military comms → fail safe or not at all</h3>
+            <p>Two decades where systems fail safely or not at all is the origin of the fail-closed default:
+            unproven, stale, malformed, or unclassified — the answer is deny.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/src/posture_cache.rs" target="_blank" rel="noopener">src/posture_cache.rs</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/safety/SAFE_STATE_SPECIFICATION.md" target="_blank" rel="noopener">docs/safety/SAFE_STATE_SPECIFICATION.md</a></p>
+          </div>
+          <div class="card" data-reveal>
+            <h3>Water-plant control → deny on physics</h3>
+            <p>Hands-on responsibility for utility control systems is why Kirra's industrial adapters decode the
+            actual setpoint on the wire and deny on magnitude regardless of credentials — the exact class of the
+            2021 Oldsmar water-plant incident.</p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/crates/kirra-industrial" target="_blank" rel="noopener">crates/kirra-industrial</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/protocol_adapters.md" target="_blank" rel="noopener">docs/protocol_adapters.md</a></p>
+          </div>
+        </div>
+        <p class="evidence-note" style="margin-top:20px">The founder biography above is provided by Kirra Systems; the
+        repository links show the mechanisms each discipline informed.</p>
+      </div>
+    </section>
+
+    <hr class="rule">
+
+    <section aria-labelledby="h-where">
+      <div class="container container--narrow" style="text-align:center">
+        <p class="eyebrow" data-reveal style="justify-content:center">Where we are</p>
+        <h2 id="h-where" data-reveal>Titusville, Florida</h2>
+        <p class="lede" data-reveal style="margin:18px auto 0">On Florida's Space Coast — a region built around systems
+        that cannot be allowed to fail unsafely. Kirra Systems develops entirely in the open; the fastest way to
+        know the company is to read its repository.</p>
+        <div class="hero__ctas" style="justify-content:center" data-reveal>
+          <a class="btn btn--primary" href="contact.html">Get in touch <span class="arrow" aria-hidden="true">→</span></a>
+          <a class="btn btn--ghost" href="careers.html">How we work</a>
+          <a class="btn btn--ghost" href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">The repository ↗</a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+<footer class="footer">
+  <div class="container">
+    <div class="footer__grid">
+      <div class="footer__brand">
+        <a class="nav__brand" href="index.html"><svg viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <g stroke="currentColor" stroke-width="1.4" opacity="0.85">
+    <path d="M7 4v24M7 17 25 4M11.5 13.7 25 28"/>
+    <path d="M7 4l7 6.5M7 28l4.5-14.3M14 10.5 7 17" opacity="0.35"/>
+  </g>
+  <g fill="var(--accent, #3fd9c9)">
+    <circle cx="7" cy="4" r="2"/><circle cx="7" cy="17" r="2.4"/><circle cx="7" cy="28" r="2"/>
+    <circle cx="25" cy="4" r="2"/><circle cx="25" cy="28" r="2"/>
+    <circle cx="14" cy="10.5" r="1.5"/><circle cx="11.5" cy="13.7" r="1.5"/>
+  </g>
+</svg><span>KIRRA</span></a>
+        <p>The fail-closed runtime safety governor for AI-driven machines. The doer proposes; the checker bounds it.</p>
+      </div>
+      <nav aria-label="Platform">
+        <h3>Platform</h3>
+        <ul>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="architecture.html">Architecture</a></li>
+          <li><a href="runtime.html">Runtime</a></li>
+          <li><a href="diagnostics.html">Diagnostics</a></li>
+          <li><a href="determinism.html">Determinism</a></li>
+          <li><a href="performance.html">Performance</a></li>
+          <li><a href="security.html">Security</a></li>
+        </ul>
+      </nav>
+      <nav aria-label="Safety">
+        <h3>Safety</h3>
+        <ul>
+          <li><a href="safety.html">Safety model</a></li>
+          <li><a href="planning.html">Planning</a></li>
+          <li><a href="perception.html">Perception</a></li>
+          <li><a href="prediction.html">Prediction</a></li>
+          <li><a href="certification.html">Certification</a></li>
+        </ul>
+      </nav>
+      <nav aria-label="Evidence">
+        <h3>Evidence</h3>
+        <ul>
+          <li><a href="playground.html">Verdict Playground</a></li>
+          <li><a href="benchmarks.html">Benchmarks</a></li>
+          <li><a href="open-source.html">Open source</a></li>
+          <li><a href="documentation.html">Documentation</a></li>
+          <li><a href="research.html">Research</a></li>
+        </ul>
+      </nav>
+      <nav aria-label="Company">
+        <h3>Company</h3>
+        <ul>
+          <li><a href="company.html">About</a></li>
+          <li><a href="vision.html">Vision</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="field-notes.html">Field Notes</a></li>
+          <li><a href="careers.html">Careers</a></li>
+          <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">GitHub ↗</a></li>
+          <li><a href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/SECURITY.md" target="_blank" rel="noopener">Security policy ↗</a></li>
+        </ul>
+      </nav>
+    </div>
+    <div class="footer__meta">
+      <span>© <span data-year>2026</span> Kirra Systems</span>
+      <span class="mono">kirra-verifier v1.1.2 · Rust 2021 · MSRV 1.88</span>
+      <span>Every claim on this site links to its source in the repository.</span>
+      <a class="mono" data-lighthouse hidden href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/scripts/lighthouse-bake.mjs" target="_blank" rel="noopener" style="text-decoration:none"></a>
+    </div>
+  </div>
+</footer>
+  <script src="js/kirra.js" defer></script>
+</body>
+</html>

--- a/website/contact.html
+++ b/website/contact.html
@@ -208,6 +208,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/determinism.html
+++ b/website/determinism.html
@@ -256,6 +256,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/diagnostics.html
+++ b/website/diagnostics.html
@@ -293,6 +293,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/documentation.html
+++ b/website/documentation.html
@@ -263,6 +263,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/field-notes.html
+++ b/website/field-notes.html
@@ -164,6 +164,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/index.html
+++ b/website/index.html
@@ -27,7 +27,7 @@
   <link rel="stylesheet" href="css/kirra.css">
   <script>/* theme init before first paint — prevents flash */
 (function(){try{var t=localStorage.getItem("kirra-theme");if(!t)t=matchMedia("(prefers-color-scheme: light)").matches?"light":"dark";document.documentElement.dataset.theme=t;}catch(e){document.documentElement.dataset.theme="dark";}})();</script>
-  <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"Kirra Systems","url":"https://kirrasystems.com","logo":"https://kirrasystems.com/assets/kirra-logo.png","sameAs":["https://github.com/kirra-systems/kirra-runtime-sdk"]},{"@type":"WebSite","name":"Kirra Systems","url":"https://kirrasystems.com"},{"@type":"SoftwareSourceCode","name":"kirra-runtime-sdk","codeRepository":"https://github.com/kirra-systems/kirra-runtime-sdk","programmingLanguage":"Rust","description":"Distributed runtime legitimacy engine and safety governor for AI-driven robotic and edge systems."}]}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"Kirra Systems","url":"https://kirrasystems.com","logo":"https://kirrasystems.com/assets/kirra-logo.png","sameAs":["https://github.com/kirra-systems/kirra-runtime-sdk"],"address":{"@type":"PostalAddress","addressLocality":"Titusville","addressRegion":"FL","addressCountry":"US"},"founder":{"@type":"Person","name":"Justin Looney","jobTitle":"Founder"}},{"@type":"WebSite","name":"Kirra Systems","url":"https://kirrasystems.com"},{"@type":"SoftwareSourceCode","name":"kirra-runtime-sdk","codeRepository":"https://github.com/kirra-systems/kirra-runtime-sdk","programmingLanguage":"Rust","description":"Distributed runtime legitimacy engine and safety governor for AI-driven robotic and edge systems."}]}</script>
 </head>
 <body>
   <div class="preloader" id="preloader" hidden aria-hidden="true">
@@ -748,6 +748,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/open-source.html
+++ b/website/open-source.html
@@ -288,6 +288,7 @@ curl -N localhost:8090/system/posture/stream \
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/perception.html
+++ b/website/perception.html
@@ -283,6 +283,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/performance.html
+++ b/website/performance.html
@@ -270,6 +270,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/planning.html
+++ b/website/planning.html
@@ -277,6 +277,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/playground.html
+++ b/website/playground.html
@@ -234,6 +234,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/prediction.html
+++ b/website/prediction.html
@@ -252,6 +252,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/research.html
+++ b/website/research.html
@@ -215,6 +215,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/runtime.html
+++ b/website/runtime.html
@@ -355,6 +355,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/safety.html
+++ b/website/safety.html
@@ -326,6 +326,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/security.html
+++ b/website/security.html
@@ -298,6 +298,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -4,6 +4,7 @@
   <url><loc>https://kirrasystems.com/benchmarks.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/careers.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/certification.html</loc><lastmod>2026-07-21</lastmod></url>
+  <url><loc>https://kirrasystems.com/company.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/contact.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/determinism.html</loc><lastmod>2026-07-21</lastmod></url>
   <url><loc>https://kirrasystems.com/diagnostics.html</loc><lastmod>2026-07-21</lastmod></url>

--- a/website/solutions.html
+++ b/website/solutions.html
@@ -356,6 +356,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>

--- a/website/vision.html
+++ b/website/vision.html
@@ -300,6 +300,7 @@
       <nav aria-label="Company">
         <h3>Company</h3>
         <ul>
+          <li><a href="company.html">About</a></li>
           <li><a href="vision.html">Vision</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="field-notes.html">Field Notes</a></li>


### PR DESCRIPTION
Adds the Company/About page — the founder depth that was previously blocked on non-repo content — in the site's evidence-first voice.

- **Founder (Justin Looney)**: the four disciplines a safety governor demands, each as its own card — enterprise hardware verification (IBM xSeries, Emulex CNA/FCoE), federal network & security programs (EPA GS-2210-13, MTIPS), career military communications (Army Signal Corps Master Sergeant / E-8, 25W), and licensed public water-treatment control.
- **"Where that background shows up"**: each discipline mapped to the actual repository mechanism it informed — verification instinct → Kani proofs + kill-tested audit; network security → attestation + hash-chained audit; military comms → fail-closed posture; water-plant control → industrial setpoint adapters (the Oldsmar incident class) — with evidence chips, plus an explicit note that *the biography is company-provided and the links show the mechanisms, not the bio.*
- **Titusville, Florida** location with Get-in-touch / How-we-work / repository CTAs.
- **Structured data**: Organization + Person + PostalAddress JSON-LD on the page, and the homepage Organization schema now carries the founder and Titusville, FL address.
- Wired into the footer Company group (as "About") and cross-linked from Careers.

Verified: generated, full-page rendered, JSON-LD parses, zero broken links, zero page errors.

⚠️ Merging deploys to kirrasystems.com automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7)_