### PR TITLE
console+site: hosted static console demo at /console + live-demo links

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     paths:
       - 'website/**'
+      - 'console/**'
       - 'scripts/fetch-substack-posts.mjs'
       - 'scripts/lighthouse-bake.mjs'
       - '.github/workflows/deploy-pages.yml'
@@ -54,6 +55,25 @@ jobs:
       # measurement in place. Ubuntu runners ship Chrome; Lighthouse finds it.
       - name: Measure Lighthouse scores
         run: node scripts/lighthouse-bake.mjs || true
+
+      # Build the console's static DEMO export and place it at website/console
+      # so it ships to /console on the same Pages site (pure static, demo data
+      # only, no backend). Never fails the deploy: on any error the site still
+      # publishes and only the /console demo is unavailable.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+      - name: Build console static demo
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+        run: |
+          cd console
+          npm ci --no-audit --no-fund
+          node scripts/build-demo.mjs
+          rm -rf ../website/console
+          cp -r out ../website/console
+        continue-on-error: true
 
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5

--- a/console/.gitignore
+++ b/console/.gitignore
@@ -4,3 +4,4 @@ out
 .env*
 *.tsbuildinfo
 next-env.d.ts
+console/out/

--- a/console/lib/api/client.ts
+++ b/console/lib/api/client.ts
@@ -7,7 +7,15 @@ export class DemoMode extends Error {
   constructor() { super('demo'); this.name = 'DemoMode' }
 }
 
+// Static-demo builds (the hosted GitHub Pages demo, `output: export`) have no
+// server proxy at all, so every read short-circuits straight to the DemoMode
+// sentinel — the hooks then render bundled demo data and label it truthfully.
+// Set at build time only; a normal server build leaves this unset and reads
+// live through the proxy exactly as before.
+const STATIC_DEMO = process.env.NEXT_PUBLIC_KIRRA_STATIC_DEMO === '1'
+
 async function getJSON<T>(path: string, signal?: AbortSignal): Promise<T> {
+  if (STATIC_DEMO) throw new DemoMode()
   const res = await fetch(`${PROXY_BASE}${path}`, {
     method: 'GET',
     headers: { accept: 'application/json' },

--- a/console/lib/api/hooks.ts
+++ b/console/lib/api/hooks.ts
@@ -138,6 +138,8 @@ export function useLiveFleet(pollMs = 5000): {
     // falls back to full-rate polling and retries the stream with backoff —
     // the console is never worse off than the pre-SSE behavior.
     const openStream = () => {
+      // Static-demo builds have no proxy/stream; stay on the demo path.
+      if (process.env.NEXT_PUBLIC_KIRRA_STATIC_DEMO === '1') return
       if (disposed || es || typeof EventSource === 'undefined') return
       const sse = new EventSource(`${PROXY_BASE}/system/posture/stream`)
       es = sse

--- a/console/next.config.mjs
+++ b/console/next.config.mjs
@@ -16,13 +16,34 @@ const securityHeaders = [
   },
 ]
 
-const nextConfig = {
-  reactStrictMode: true,
-  poweredByHeader: false,
-  // Standalone output → a self-contained server bundle for container deploys.
-  output: 'standalone',
-  async headers() {
-    return [{ source: '/:path*', headers: securityHeaders }]
-  },
-}
+// Two build modes:
+//   • default (server)  — the production console: standalone server, live
+//     verifier proxy, security headers. `npm run build` / `npm start`.
+//   • KIRRA_STATIC_DEMO — a pure static export for GitHub Pages hosting: no
+//     server, no proxy, demo data only, served under /console. Built by
+//     scripts/build-demo.mjs (which also removes the proxy route, since route
+//     handlers can't be statically exported). Headers there are set by the
+//     hosting layer, not Next.
+const STATIC_DEMO = process.env.KIRRA_STATIC_DEMO === '1'
+
+const nextConfig = STATIC_DEMO
+  ? {
+      reactStrictMode: true,
+      poweredByHeader: false,
+      output: 'export',
+      basePath: '/console',
+      assetPrefix: '/console',
+      trailingSlash: true,
+      images: { unoptimized: true },
+      env: { NEXT_PUBLIC_KIRRA_STATIC_DEMO: '1' },
+    }
+  : {
+      reactStrictMode: true,
+      poweredByHeader: false,
+      output: 'standalone',
+      async headers() {
+        return [{ source: '/:path*', headers: securityHeaders }]
+      },
+    }
+
 export default nextConfig

--- a/console/scripts/build-demo.mjs
+++ b/console/scripts/build-demo.mjs
@@ -1,0 +1,45 @@
+// Build the static, hostable DEMO of the console for GitHub Pages.
+//
+//   node scripts/build-demo.mjs   →  console/out/  (served at /console/)
+//
+// The console normally runs as a Next server (with the verifier proxy). A
+// static export can't include a route handler, and the public demo has no
+// backend anyway — so this script temporarily removes the proxy route, builds
+// with `output: export` + basePath /console + NEXT_PUBLIC_KIRRA_STATIC_DEMO=1
+// (which makes the client short-circuit straight to demo data), then restores
+// the route. The result is a pure static site: no server, demo data only,
+// labeled as such at every level.
+
+import { execFileSync } from 'node:child_process'
+import { renameSync, existsSync, rmSync } from 'node:fs'
+
+// Routes that can't be statically exported (a dynamic route handler, and the
+// catch-all placeholder which would need on-demand rendering). They're stashed
+// for the demo build and always restored. The proxy has no meaning without a
+// backend; unknown routes fall through to the static 404 page.
+const STASH = [
+  ['app/api', '.stash-api'],
+  ['app/[...slug]', '.stash-slug'],
+]
+
+function restore() {
+  for (const [dir, stash] of STASH) if (existsSync(stash)) renameSync(stash, dir)
+}
+
+// Always restore the proxy route, even on failure — it must never be lost.
+process.on('exit', restore)
+process.on('SIGINT', () => { restore(); process.exit(1) })
+
+try {
+  rmSync('out', { recursive: true, force: true })
+  for (const [dir, stash] of STASH) if (existsSync(dir)) renameSync(dir, stash)
+  execFileSync('npx', ['next', 'build'], {
+    stdio: 'inherit',
+    env: { ...process.env, KIRRA_STATIC_DEMO: '1' },
+  })
+  console.log('\n✓ static demo built → console/out (serve under /console)')
+} catch (e) {
+  console.error('demo build failed:', e.message)
+  restore()
+  process.exit(1)
+}

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,1 @@
+website/console/

--- a/website/_src/pages/contact.mjs
+++ b/website/_src/pages/contact.mjs
@@ -33,6 +33,10 @@ ${pageHero({
               <a class="btn btn--ghost" href="${SITE.repo}" target="_blank" rel="noopener">The repository ↗</a>
               <a class="btn btn--ghost" href="mailto:justin.looney@kirrasystems.com?subject=Technical%20evaluation%20%E2%80%94%20Kirra">Ask us directly</a>
             </div>
+            <p class="evidence-note" style="margin-top:16px">Or touch it now — two live demos, no install:
+            <a class="evidence" href="playground.html">the Verdict Playground</a> runs the real frozen checker in your
+            browser; <a class="evidence" href="/console/">the operator console demo</a> runs the full Next.js console
+            on a simulated fleet.</p>
             ${evRow(".github/workflows/release.yml", "ci/build_safety_case.py")}
           </div>
           <div class="card" data-reveal>

--- a/website/_src/pages/diagnostics.mjs
+++ b/website/_src/pages/diagnostics.mjs
@@ -85,6 +85,11 @@ ${pageHero({
           <p class="lede" data-reveal>Operator UIs never overstate what happened. The air-gapped console renders a
           clearance grant as “GRANT RECORDED — DELIVERY PENDING” rather than implying a vehicle was released —
           the fail-closed philosophy applied to pixels.</p>
+          <p data-reveal style="margin-top:16px">
+            <a class="btn btn--primary" href="/console/" style="text-decoration:none">Open the live console demo <span class="arrow" aria-hidden="true">→</span></a>
+          </p>
+          <p class="evidence-note" data-reveal>Runs entirely in your browser on a simulated fleet — clearly labeled
+          demo data, no backend, nothing to install. The same Next.js console operators run against a live verifier.</p>
         </div>
         <div class="grid grid--3">
           <div class="card" data-reveal>

--- a/website/contact.html
+++ b/website/contact.html
@@ -119,6 +119,10 @@
               <a class="btn btn--ghost" href="https://github.com/kirra-systems/kirra-runtime-sdk" target="_blank" rel="noopener">The repository ↗</a>
               <a class="btn btn--ghost" href="mailto:justin.looney@kirrasystems.com?subject=Technical%20evaluation%20%E2%80%94%20Kirra">Ask us directly</a>
             </div>
+            <p class="evidence-note" style="margin-top:16px">Or touch it now — two live demos, no install:
+            <a class="evidence" href="playground.html">the Verdict Playground</a> runs the real frozen checker in your
+            browser; <a class="evidence" href="/console/">the operator console demo</a> runs the full Next.js console
+            on a simulated fleet.</p>
             <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/.github/workflows/release.yml" target="_blank" rel="noopener">.github/workflows/release.yml</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/ci/build_safety_case.py" target="_blank" rel="noopener">ci/build_safety_case.py</a></p>
           </div>
           <div class="card" data-reveal>

--- a/website/diagnostics.html
+++ b/website/diagnostics.html
@@ -171,6 +171,11 @@
           <p class="lede" data-reveal>Operator UIs never overstate what happened. The air-gapped console renders a
           clearance grant as “GRANT RECORDED — DELIVERY PENDING” rather than implying a vehicle was released —
           the fail-closed philosophy applied to pixels.</p>
+          <p data-reveal style="margin-top:16px">
+            <a class="btn btn--primary" href="/console/" style="text-decoration:none">Open the live console demo <span class="arrow" aria-hidden="true">→</span></a>
+          </p>
+          <p class="evidence-note" data-reveal>Runs entirely in your browser on a simulated fleet — clearly labeled
+          demo data, no backend, nothing to install. The same Next.js console operators run against a live verifier.</p>
         </div>
         <div class="grid grid--3">
           <div class="card" data-reveal>


### PR DESCRIPTION
Ships a touchable, **hosted** operator-console demo alongside the site on GitHub Pages — no backend, no install — so evaluators can drive the real console UI, not just read screenshots. (The other hosted demo, the in-browser Verdict Playground, was already live.)

**Console static-demo export**
- `next.config.mjs` env-branches: the default is the **unchanged** production server build (standalone + security headers); `KIRRA_STATIC_DEMO` produces `output: 'export'` + basePath/assetPrefix `/console` + trailing slashes for GitHub Pages.
- `lib/api/client.ts` + `hooks.ts`: with `NEXT_PUBLIC_KIRRA_STATIC_DEMO` the client short-circuits every read (and the SSE attach) straight to the `DemoMode` sentinel — the static build makes **zero** `/api` calls and renders bundled demo data, labeled "DEMO · simulated fleet" at every level.
- `scripts/build-demo.mjs`: stashes the routes that can't static-export (the proxy route handler + the catch-all placeholder), builds to `console/out`, and **always restores** them. `out/` and `website/console/` are gitignored (built in CI, never committed).

**Deploy** — `deploy-pages.yml` gains a Node setup + console-demo build step (SHA-pinned `setup-node` matching `release.yml`) that copies `console/out` → `website/console`, shipped to `/console` on the same Pages site. `continue-on-error`: a console-build hiccup never blocks the site deploy. Trigger paths add `console/**`.

**Site links** — the Diagnostics page gets an "Open the live console demo" CTA; Contact's technical-evaluation door now points at **both** live demos.

**Verified:** server build green + smoke **18/18** (production path unchanged); static export builds, all routes 200 under `/console` with the shell, demo mode honest, **zero** `/api` calls, zero errors; combined local deploy serves the site at root and the console demo at `/console/` including deep routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTsHnUqrZ1th9Vq3mfUvg7)_