### PR TITLE
federation: validate trusted-controller Ed25519 key at registration (#1105)

### DIFF
--- a/crates/kirra-fleet-types/src/federation.rs
+++ b/crates/kirra-fleet-types/src/federation.rs
@@ -82,6 +82,28 @@ pub fn verify_federated_report_signature(
         .is_ok()
 }
 
+/// True iff `public_key_b64` decodes (Base64 STANDARD) to a valid 32-byte Ed25519
+/// verifying key — the EXACT format `verify_federated_report_signature` expects
+/// (base64 → `[u8; 32]` → `VerifyingKey::from_bytes`).
+///
+/// A trusted-controller registration should FAIL FAST on a malformed key rather
+/// than storing a string that can never verify and only surfacing the error at the
+/// first report (a confusing, deferred failure). This mirrors the parse-at-boundary
+/// discipline the attestation/operator key-registration paths already apply. Pure /
+/// side-effect-free; the caller maps `false` to a 422.
+pub fn federation_public_key_is_valid(public_key_b64: &str) -> bool {
+    use base64::{engine::general_purpose::STANDARD as b64, Engine as _};
+    use ed25519_dalek::VerifyingKey;
+
+    let Ok(pk_bytes) = b64.decode(public_key_b64) else {
+        return false;
+    };
+    let Ok(pk_array) = <[u8; 32]>::try_from(pk_bytes.as_slice()) else {
+        return false;
+    };
+    VerifyingKey::from_bytes(&pk_array).is_ok()
+}
+
 /// Evaluates structural completeness, chronological freshness, and replay window.
 /// Cryptographic signature verification and nonce uniqueness are enforced by the caller.
 pub fn evaluate_federated_report(
@@ -129,5 +151,30 @@ pub fn evaluate_federated_report(
     ReportEvaluation {
         accepted: true,
         reason: "FEDERATED_OBSERVATION_RECORDED".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod key_validation_tests {
+    use super::federation_public_key_is_valid;
+    use base64::{engine::general_purpose::STANDARD as b64, Engine as _};
+
+    #[test]
+    fn accepts_a_real_ed25519_key_and_rejects_malformed() {
+        // A real verifying key: base64 of its 32 raw bytes (the format the verify
+        // path decodes). from_bytes must accept it.
+        let sk = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let good = b64.encode(sk.verifying_key().to_bytes());
+        assert!(
+            federation_public_key_is_valid(&good),
+            "a real key is accepted"
+        );
+
+        // Not base64.
+        assert!(!federation_public_key_is_valid("!!! not base64 !!!"));
+        // Valid base64 but the wrong length (16 bytes, not 32).
+        assert!(!federation_public_key_is_valid(&b64.encode([0u8; 16])));
+        // Empty string.
+        assert!(!federation_public_key_is_valid(""));
     }
 }

--- a/src/bin/kirra_verifier_service/federation.rs
+++ b/src/bin/kirra_verifier_service/federation.rs
@@ -18,6 +18,19 @@ pub(crate) async fn register_federation_controller(
         )
             .into_response();
     }
+    // Fail-fast (#1105): the key must parse as the base64 Ed25519 (32-byte) verifying
+    // key that report verification expects — reject a malformed key here rather than
+    // storing it and only failing at the first signed report. Same parse-at-boundary
+    // discipline as attestation/operator key registration.
+    if !kirra_fleet_types::federation::federation_public_key_is_valid(&req.public_key_b64) {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({
+                "error": "public_key_b64 must be a base64-encoded 32-byte Ed25519 public key"
+            })),
+        )
+            .into_response();
+    }
     // P1: durable write off the worker pool (`call` → spawn_blocking). Own the
     // captured request fields (still needed for the response). `call` wraps the
     // closure's own `Result` in an outer `Result<_, StoreError>`, so a DB error


### PR DESCRIPTION
Closes #1105.

## Summary
Verified review quick-win: `POST /federation/controllers/register` accepted a trusted-peer public key **without validating it parses** — it only checked the field was non-empty and stored the raw base64 string. A malformed key registered "successfully" and only failed much later, at report-verification time (a confusing, deferred failure). The rest of the key-registration surface (attestation / operator) fail-closes on an unparseable key at the boundary; federation did not.

## Fix (fail-fast, parse-at-boundary)
- **New pure `kirra_fleet_types::federation::federation_public_key_is_valid`** — decodes Base64 STANDARD to exactly `[u8; 32]` and parses via `VerifyingKey::from_bytes`, the **exact** format `verify_federated_report_signature` expects. Co-located with verify (single source of truth for the key format). Includes a unit test: a real key is accepted; non-base64 / wrong-length / empty are rejected.
- **`register_federation_controller` returns 422** before the durable write when the key is invalid.

Low security severity (a bad key can't forge reports — `verify_strict` still fails closed); this restores the fail-fast/validate-at-boundary discipline the rest of the key surface follows.

## Verification
- `kirra-fleet-types` validator unit test passes.
- The service bin compiles; `cargo fmt --check` + guardrails green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_