### PR TITLE
ros2: fail-safe Degraded default when no posture source is configured (#1095)

### DIFF
--- a/crates/kirra-core/src/posture_tracker.rs
+++ b/crates/kirra-core/src/posture_tracker.rs
@@ -69,6 +69,13 @@ pub struct PostureTracker {
     /// for the tracker's lifetime — an integrator changes mode by
     /// recreating `AdaptorState`.
     source_configured: bool,
+    /// #1095 (F5): the posture returned when NO source is configured
+    /// (`!source_configured`). The fail-safe default is `Degraded`
+    /// (`degraded_default_no_source`) — a verifier-less deployment runs at the
+    /// MRC envelope, not the full one; the legacy `Nominal`-forever behaviour
+    /// (`nominal_default_no_source`) is now an EXPLICIT dev/demo opt-in. Unused on
+    /// the source-configured path (that path derives posture from observations).
+    no_source_posture: FleetPosture,
     /// Last observation from the source. `None` until the first
     /// `observe` call.
     last_observation: Option<FleetPosture>,
@@ -83,13 +90,36 @@ pub struct PostureTracker {
 }
 
 impl PostureTracker {
-    /// Construct a tracker for the no-source configuration. M1 behaviour
-    /// is preserved: `current_posture` always returns `Nominal`,
-    /// `observe` is a no-op.
+    /// Construct a no-source tracker that returns `Nominal` FOREVER — the legacy
+    /// M1 behaviour. `observe` is a no-op.
+    ///
+    /// #1095 (F5): this is NO LONGER the safe default for a verifier-less
+    /// deployment — it runs UNGOVERNED by fleet posture while appearing governed.
+    /// It is retained ONLY for the explicit dev/demo opt-in (and unit tests that
+    /// want the full envelope); production verifier-less nodes must use
+    /// [`Self::degraded_default_no_source`]. The adapter binary selects between the
+    /// two on an explicit env opt-in.
     #[must_use]
     pub fn nominal_default_no_source() -> Self {
         Self {
             source_configured: false,
+            no_source_posture: FleetPosture::Nominal,
+            last_observation: None,
+            last_event_ms: None,
+            sticky_locked_out: false,
+        }
+    }
+
+    /// #1095 (F5): construct a no-source tracker that returns `Degraded` FOREVER —
+    /// the FAIL-SAFE default when no posture source is configured. A verifier-less
+    /// deployment then runs at the MRC envelope (not the full one) and cannot
+    /// silently appear governed while ignoring fleet `LockedOut`/`Degraded`.
+    /// `observe` is a no-op (no source to observe).
+    #[must_use]
+    pub fn degraded_default_no_source() -> Self {
+        Self {
+            source_configured: false,
+            no_source_posture: FleetPosture::Degraded,
             last_observation: None,
             last_event_ms: None,
             sticky_locked_out: false,
@@ -99,11 +129,12 @@ impl PostureTracker {
     /// Construct a tracker for a source-configured deployment. The
     /// pre-first-event seed is `Degraded` (fail-closed): a new
     /// fleet must not be commandable at full envelope before the
-    /// verifier confirms posture.
+    /// verifier confirms posture. (`no_source_posture` is unused on this path.)
     #[must_use]
     pub fn with_source() -> Self {
         Self {
             source_configured: true,
+            no_source_posture: FleetPosture::Nominal,
             last_observation: None,
             last_event_ms: None,
             sticky_locked_out: false,
@@ -138,7 +169,9 @@ impl PostureTracker {
 
     /// Resolve the effective posture at wall-clock `now_ms`.
     ///
-    /// No-source path: always `Nominal` (preserves M1 behaviour).
+    /// No-source path: returns the fixed `no_source_posture` — `Nominal` for the
+    /// legacy/demo tracker (`nominal_default_no_source`) or `Degraded` for the
+    /// fail-safe tracker (`degraded_default_no_source`, the #1095 default).
     ///
     /// Source-configured path, in priority order:
     ///   1. Sticky-LockedOut → return `LockedOut` (most restrictive
@@ -152,7 +185,9 @@ impl PostureTracker {
     #[must_use]
     pub fn current_posture(&self, now_ms: u64) -> FleetPosture {
         if !self.source_configured {
-            return FleetPosture::Nominal;
+            // #1095 (F5): the configured no-source default — `Nominal` for the
+            // legacy/demo tracker, `Degraded` for the fail-safe tracker.
+            return self.no_source_posture;
         }
         if self.sticky_locked_out {
             return FleetPosture::LockedOut;
@@ -196,6 +231,25 @@ mod tracker_tests {
             t.current_posture(3_000),
             FleetPosture::Nominal,
             "observe must not affect a no-source tracker"
+        );
+    }
+
+    #[test]
+    fn tracker_degraded_default_no_source_stays_degraded_and_ignores_observe() {
+        // #1095 (F5): the FAIL-SAFE no-source default returns Degraded forever —
+        // a verifier-less deployment runs at the MRC envelope, never Nominal, and
+        // (like the legacy no-source tracker) observe is a no-op.
+        let mut t = PostureTracker::degraded_default_no_source();
+        assert!(!t.source_configured());
+        assert_eq!(t.current_posture(0), FleetPosture::Degraded);
+        assert_eq!(t.current_posture(1_000_000), FleetPosture::Degraded);
+        // observe cannot lift it to Nominal (no source to trust).
+        t.observe(1_000, FleetPosture::Nominal);
+        t.observe(2_000, FleetPosture::Nominal);
+        assert_eq!(
+            t.current_posture(3_000),
+            FleetPosture::Degraded,
+            "the fail-safe no-source tracker never leaves Degraded"
         );
     }
 

--- a/crates/kirra-ros2-adapter/src/bin/kirra_ros2_adapter_node.rs
+++ b/crates/kirra-ros2-adapter/src/bin/kirra_ros2_adapter_node.rs
@@ -33,7 +33,7 @@ use kirra_ros2_adapter::{
     corridor::{CorridorSource, MockCorridorSource},
     node::run_adapter,
     posture_source::{spawn_posture_source, PostureSourceConfig},
-    state::AdaptorState,
+    state::{ungoverned_demo_opt_in, AdaptorState},
 };
 
 #[cfg(feature = "lanelet2")]
@@ -244,9 +244,11 @@ async fn main() {
 
     // M1b — three-state posture-source decision:
     //
-    //   NoSource              (URL unset)                    → AdaptorState::new()
+    //   NoSource              (URL unset)                    → AdaptorState::new_no_source()
     //                                                          + no SSE task
-    //                                                          → Nominal (M1 default)
+    //                                                          → Degraded (FAIL-SAFE, #1095);
+    //                                                            Nominal only under the
+    //                                                            KIRRA_ALLOW_UNGOVERNED_DEMO opt-in
     //   ConfiguredNoTransport (URL set, auth missing/unusable)
     //                                                        → with_posture_source()
     //                                                          + no SSE task
@@ -266,11 +268,32 @@ async fn main() {
     let decision = classify_posture_source();
     let state = match &decision {
         PostureSourceDecision::NoSource => {
-            tracing::info!(
-                "M1b: KIRRA_POSTURE_STREAM_URL not set; using M1 default \
-                 (no-source tracker — posture stays Nominal)"
+            // #1095 (F5): no posture source configured. FAIL-SAFE by default —
+            // the no-source tracker holds Degraded (MRC envelope), so a
+            // verifier-less node is NOT ungoverned-at-full-envelope while
+            // appearing governed. The legacy Nominal-forever behaviour is an
+            // EXPLICIT dev/demo opt-in (KIRRA_ALLOW_UNGOVERNED_DEMO).
+            let allow_ungoverned = ungoverned_demo_opt_in(
+                std::env::var("KIRRA_ALLOW_UNGOVERNED_DEMO").ok().as_deref(),
             );
-            AdaptorState::new()
+            if allow_ungoverned {
+                tracing::warn!(
+                    "M1b/#1095: KIRRA_POSTURE_STREAM_URL not set AND \
+                     KIRRA_ALLOW_UNGOVERNED_DEMO opted in — running UNGOVERNED by \
+                     fleet posture (no-source tracker stays Nominal FOREVER). \
+                     DEV/DEMO ONLY: fleet LockedOut/Degraded has NO effect here. \
+                     Do NOT use in production."
+                );
+            } else {
+                tracing::warn!(
+                    "M1b/#1095: KIRRA_POSTURE_STREAM_URL not set — no fleet posture \
+                     source. FAIL-SAFE: the adapter runs at the Degraded (MRC) \
+                     envelope. Set KIRRA_POSTURE_STREAM_URL to govern from the \
+                     verifier, or KIRRA_ALLOW_UNGOVERNED_DEMO=1 for the (unsafe) \
+                     ungoverned demo."
+                );
+            }
+            AdaptorState::new_no_source(allow_ungoverned)
         }
         PostureSourceDecision::ConfiguredNoTransport { reason } => {
             tracing::warn!(reason = %reason,
@@ -338,8 +361,9 @@ async fn main() {
 /// task. See `main` for the dispatch table.
 enum PostureSourceDecision {
     /// `KIRRA_POSTURE_STREAM_URL` is unset or empty. Verifier-less
-    /// deployment / CARLA-only smoke. Use the M1 no-source default —
-    /// `AdaptorState::new()` → tracker returns `Nominal` forever.
+    /// deployment / CARLA-only smoke. Uses `AdaptorState::new_no_source()`
+    /// — FAIL-SAFE `Degraded` forever (#1095), unless the explicit
+    /// `KIRRA_ALLOW_UNGOVERNED_DEMO` opt-in restores the legacy `Nominal`.
     NoSource,
     /// URL is set (operator INTENT to govern is explicit) but the
     /// transport cannot be brought up — typically a missing or empty

--- a/crates/kirra-ros2-adapter/src/state.rs
+++ b/crates/kirra-ros2-adapter/src/state.rs
@@ -205,6 +205,17 @@ pub fn monotonic_now_ms() -> u64 {
     EPOCH.get_or_init(Instant::now).elapsed().as_millis() as u64
 }
 
+/// #1095 (F5): parse the `KIRRA_ALLOW_UNGOVERNED_DEMO` opt-in flag value.
+/// `Some("1" | "true" | "TRUE")` → `true` (admit the legacy `Nominal`-forever
+/// no-source tracker for a dev/demo run); anything else — including unset
+/// (`None`), empty, or an unrecognized value — → `false`, the FAIL-SAFE
+/// `Degraded` default. Pure over the flag value so the binary's env read is
+/// unit-tested here rather than in the ros2-gated bin.
+#[must_use]
+pub fn ungoverned_demo_opt_in(flag: Option<&str>) -> bool {
+    matches!(flag, Some("1") | Some("true") | Some("TRUE"))
+}
+
 impl AdaptorState {
     pub fn new() -> Arc<Self> {
         let config = VehicleConfig::default_urban();
@@ -256,6 +267,25 @@ impl AdaptorState {
             latest_frame_integrity: Arc::new(RwLock::new(None)),
             last_frame_integrity_ms: Arc::new(AtomicU64::new(0)),
         })
+    }
+
+    /// #1095 (F5) — constructs the verifier-less (no posture source)
+    /// `AdaptorState`. FAIL-SAFE by default: the `PostureTracker` returns
+    /// `Degraded` forever, so a node with no posture source runs at the MRC
+    /// envelope rather than silently appearing governed at the full envelope
+    /// while ignoring fleet `LockedOut`/`Degraded`.
+    ///
+    /// `allow_ungoverned` (the explicit dev/demo opt-in, resolved from
+    /// `KIRRA_ALLOW_UNGOVERNED_DEMO` by [`ungoverned_demo_opt_in`]) restores the
+    /// legacy `Nominal`-forever tracker. The adapter binary logs LOUDLY in either
+    /// branch. Built on [`AdaptorState::new`] (Nominal tracker), swapping in the
+    /// fail-safe tracker unless the demo is opted into.
+    pub fn new_no_source(allow_ungoverned: bool) -> Arc<Self> {
+        let state = Self::new();
+        if !allow_ungoverned {
+            *state.posture_tracker.write().unwrap() = PostureTracker::degraded_default_no_source();
+        }
+        state
     }
 
     /// **M1b** — constructs an `AdaptorState` with a live posture source
@@ -1182,15 +1212,50 @@ mod tests {
 
     #[test]
     fn url_unset_no_source_default_is_still_nominal() {
-        // Regression: the M1 no-source default is **untouched** by the
-        // M1b amendment. Verifier-less deployments (URL env var unset)
-        // continue to use `AdaptorState::new()` and see `Nominal`.
+        // `AdaptorState::new()` semantics are UNCHANGED — Nominal forever. Since
+        // #1095 this is the unit-test / explicit dev-demo tracker, NOT the
+        // verifier-less production default (see `new_no_source` + the tests below).
         let state = AdaptorState::new();
         assert_eq!(
             state.current_posture(),
             FleetPosture::Nominal,
-            "URL-unset no-source default must remain Nominal (M1 path unchanged)"
+            "AdaptorState::new() must remain Nominal (test/demo path unchanged)"
         );
+    }
+
+    #[test]
+    fn no_source_default_is_fail_safe_degraded_and_opt_in_restores_nominal() {
+        // #1095 (F5): a verifier-less node (URL unset) must fail SAFE. The
+        // default no-source AdaptorState holds Degraded forever — never the full
+        // Nominal envelope while ungoverned.
+        let fail_safe = AdaptorState::new_no_source(/* allow_ungoverned */ false);
+        assert_eq!(
+            fail_safe.current_posture(),
+            FleetPosture::Degraded,
+            "no-source default must be fail-safe Degraded, never ungoverned-Nominal"
+        );
+
+        // The explicit dev/demo opt-in restores the legacy Nominal-forever tracker.
+        let demo = AdaptorState::new_no_source(/* allow_ungoverned */ true);
+        assert_eq!(
+            demo.current_posture(),
+            FleetPosture::Nominal,
+            "the ungoverned-demo opt-in restores Nominal"
+        );
+    }
+
+    #[test]
+    fn ungoverned_demo_opt_in_only_admits_the_explicit_true_values() {
+        // #1095 (F5): only an explicit affirmative admits the ungoverned demo;
+        // unset / empty / anything-else fails safe to `false` (Degraded default).
+        assert!(ungoverned_demo_opt_in(Some("1")));
+        assert!(ungoverned_demo_opt_in(Some("true")));
+        assert!(ungoverned_demo_opt_in(Some("TRUE")));
+        assert!(!ungoverned_demo_opt_in(None));
+        assert!(!ungoverned_demo_opt_in(Some("")));
+        assert!(!ungoverned_demo_opt_in(Some("0")));
+        assert!(!ungoverned_demo_opt_in(Some("false")));
+        assert!(!ungoverned_demo_opt_in(Some("yes")));
     }
 
     // ----- S-FI1 live frame-integrity source -----


### PR DESCRIPTION
## Summary

An unset `KIRRA_POSTURE_STREAM_URL` selected the no-source posture tracker, which returned **Nominal forever** — so a verifier-less deployment ran **ungoverned** by fleet posture (fleet `LockedOut`/`Degraded` had no effect on ROS enforcement) while *appearing* governed. A high-likelihood misconfiguration, and fail-**open**.

Per your decision (default Degraded + opt-in), this makes the no-source default **fail-safe**:

- **kirra-core**: `PostureTracker::degraded_default_no_source()` — a no-source tracker that returns `Degraded` forever (MRC envelope). `current_posture` now returns the configured `no_source_posture`. The legacy `nominal_default_no_source()` is retained **only** for the explicit dev/demo opt-in and unit tests.
- **kirra-ros2-adapter**: `AdaptorState::new_no_source(allow_ungoverned)` builds the verifier-less state — **fail-safe Degraded by default**, Nominal only under the opt-in. Pure `ungoverned_demo_opt_in()` parses `KIRRA_ALLOW_UNGOVERNED_DEMO` (`1`/`true`/`TRUE` → admit; unset/empty/other → fail-safe). **`AdaptorState::new()` is unchanged** (Nominal) — it's now the test/demo tracker, not the verifier-less production default; its 30 call sites are unaffected.
- **adapter binary** (ros2 lane): the `NoSource` arm reads `KIRRA_ALLOW_UNGOVERNED_DEMO`, picks the tracker, and **logs loudly** in both branches — fail-safe Degraded with remediation, or an explicit `UNGOVERNED / DEV-ONLY` warning.

## New env var
`KIRRA_ALLOW_UNGOVERNED_DEMO` — dev/demo only. Set to `1` to restore the legacy Nominal-forever no-source tracker (runs ungoverned). Absent → fail-safe Degraded.

## Testing
All in the **non-ros2 crates**, so they run on every PR:
- `tracker_degraded_default_no_source_stays_degraded_and_ignores_observe`
- `no_source_default_is_fail_safe_degraded_and_opt_in_restores_nominal` (`new_no_source(false)`=Degraded, `(true)`=Nominal)
- `ungoverned_demo_opt_in_only_admits_the_explicit_true_values`
- The existing `url_unset_..._nominal` test is retargeted to document `new()`'s unchanged test/demo semantics.
- `cargo test -p kirra-core -p kirra-ros2-adapter` (185 + 52) + `cargo fmt` + guardrails clean. The ros2 bin wiring is compile-checked by the `ros2 adapter build` CI lane.

Closes #1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_