### PR TITLE
checker: per-window predictive-RSS coverage + wire spacing precondition (#1094)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -71,4 +71,15 @@ exclude_re = [
     # change swapped the ego accel/brake ARGS (killed by the `posture_brake_symmetry`
     # tests), not this pre-existing selector.
     "replace < with <= in validate_trajectory_slow_with_envelope",
+    # #1094 (F4) `ego_time_span` min/max scan: `if t < lo { lo = t }` vs
+    # `if t <= lo { lo = t }` (and the `>`/`>=` max twin) are TRULY EQUIVALENT — not
+    # just measure-zero. When `t == lo` the strict form skips (lo already == t) and
+    # the non-strict form re-assigns (lo = t = the same value); the resulting min/max
+    # is bit-identical for EVERY input, so no test can distinguish them. cargo-mutants
+    # cannot prove equivalence, so they are excluded here (same accept-with-reason
+    # policy as the boundary gates above). The scan's real behaviour — that it finds
+    # the true min AND max, and that `in_ego_span` uses them — IS killed by the F4
+    # per-window coverage test (a wrong span flips the in-span verdict).
+    "replace < with <= in ego_time_span",
+    "replace > with >= in ego_time_span",
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ lcov.info
 # cargo-mutants output (quality-hardening pass; `.run*` = kept prior runs
 # for scope comparison, e.g. WP-08's own-tests vs +adapter-tests baselines)
 mutants.out/
+mutants.out.old/
 mutants.out.run*/
 mutants.kill-check/
 

--- a/crates/kirra-trajectory/src/validation.rs
+++ b/crates/kirra-trajectory/src/validation.rs
@@ -39,6 +39,9 @@ use crate::state::{
     AcceptedTrajectory, EgoOdom, LateralEnvelope, PerceivedObject, Pose, TrajectoryPoint,
     TrajectoryVerdict,
 };
+use crate::validation_hardening::{
+    validate_trajectory_time_monotonicity, validate_trajectory_time_spacing,
+};
 
 /// Minimum corridor confidence the slow loop accepts. Tracks the
 /// `kirra_core::containment::Corridor::min_confidence`
@@ -825,6 +828,28 @@ pub fn validate_trajectory_slow_with_envelope(
     // longitudinal-overlap gating, so a mode that stays in its own lane is skipped
     // (this generalizes §4, it does not regress it). Absent input → no-op.
     if let Some(modes) = predicted_modes {
+        // #1094 (F4): max-pose-spacing precondition on the LIVE predictive path
+        // (previously an unused helper). The predictive pass time-matches predicted
+        // object samples to ego poses within `PREDICTIVE_TIME_MATCH_TOLERANCE_S`; if
+        // the ego poses are spaced farther apart than the tolerance can bridge, an
+        // in-span window can fall into a temporal GAP and escape evaluation. Reject
+        // a non-monotonic OR too-coarsely-spaced ego trajectory up front so the
+        // per-window coverage in `predictive_rss_breach` is well-defined (no in-span
+        // gap can hide a cut-in). Fail-closed (a nonconforming planner input →
+        // MRCFallback). SCOPED to modes-present, so the no-modes Nominal WCET path
+        // is byte-identical. Mapped to `PredictiveRssBreach` (whose contract already
+        // covers "a mode was unevaluable").
+        if !modes.is_empty()
+            && (validate_trajectory_time_monotonicity(trajectory).is_some()
+                || validate_trajectory_time_spacing(trajectory, MAX_PREDICTIVE_POSE_SPACING_S)
+                    .is_some())
+        {
+            return (
+                TrajectoryVerdict::MRCFallback,
+                Some(TrajectoryRefusalReason::PredictiveRssBreach),
+                None,
+            );
+        }
         // Pass the SAME (posture-/perception-capped) lateral-accel budget the
         // snapshot lateral branch uses, so both passes agree on the side gap.
         if predictive_rss_breach(
@@ -1029,11 +1054,44 @@ fn outruns_assured_clear_distance(
 /// in for a far-future object — a meaningless comparison. One predicted step.
 const PREDICTIVE_TIME_MATCH_TOLERANCE_S: f64 = 0.5;
 
+/// #1094 (F4): the max ego-pose time spacing the predictive pass accepts. The
+/// predictive pass time-matches to within `PREDICTIVE_TIME_MATCH_TOLERANCE_S`, so
+/// poses spaced up to `2×tolerance` apart keep EVERY in-span instant within
+/// tolerance of some pose (the midpoint of a `2×tolerance` gap is exactly
+/// `tolerance` away → matched by `nearest_in_time`'s `<=`). A trajectory coarser
+/// than this (when predicted modes are supplied) is refused up front so no in-span
+/// window can fall into an unmatched temporal gap. Not applied when no modes are
+/// supplied — the no-predictive-RSS path is unchanged.
+const MAX_PREDICTIVE_POSE_SPACING_S: f64 = 2.0 * PREDICTIVE_TIME_MATCH_TOLERANCE_S;
+
 /// The trajectory pose closest in TIME to `t` (the ego's where-am-I-when index),
 /// but ONLY if that pose is within `tolerance_s` of `t`. Returns `None` when the
 /// nearest pose is further away — i.e. the ego trajectory does not span time `t`
 /// — so the caller skips the sample instead of matching a far-future object to a
 /// near ego pose (the snapshot RSS still bounds the real object).
+/// #1094 (F4): the ego trajectory's finite time span as `(min, max)` over all
+/// poses (robust to unordered input; ignores any non-finite stamp). Returns
+/// `(+INF, -INF)` for an all-non-finite trajectory, which makes every window read
+/// as out-of-span (the per-mode / set-level guards then handle it). Used to decide
+/// whether a skipped predicted window falls WITHIN the ego's temporal coverage
+/// (→ fail closed) or beyond it (→ legitimately unevaluable, skip).
+fn ego_time_span(trajectory: &[TrajectoryPoint]) -> (f64, f64) {
+    let mut lo = f64::INFINITY;
+    let mut hi = f64::NEG_INFINITY;
+    for p in trajectory {
+        let t = p.time_from_start_s;
+        if t.is_finite() {
+            if t < lo {
+                lo = t;
+            }
+            if t > hi {
+                hi = t;
+            }
+        }
+    }
+    (lo, hi)
+}
+
 fn nearest_in_time(
     trajectory: &[TrajectoryPoint],
     t: f64,
@@ -1108,6 +1166,20 @@ fn predictive_rss_breach(
     // fall outside the ego trajectory's span, so `nearest_in_time` returns `None`
     // for every window) — a silent per-object fail-open. `any_windows` preserves
     // the original set-level guard for the "no windows anywhere" case.
+    // #1094 (F4): PER-WINDOW coverage. The per-mode `mode_evaluated` latch below
+    // (set on the FIRST evaluable window) let a LATER in-span window be silently
+    // skipped — a cut-in in that window escaped. A window whose start time falls
+    // WITHIN the ego trajectory's temporal span `[min, max]` must be evaluated; if
+    // it is skipped (non-monotonic prediction dt, or no ego pose within tolerance)
+    // it is an in-span window we could not check → fail closed. A window BEYOND the
+    // span is legitimately unevaluable (the object is predicted past the ego's plan;
+    // the snapshot RSS still bounds the real object) → skip. The band is the plain
+    // span with NO tolerance buffer: the caller's max-pose-spacing precondition
+    // keeps every in-span instant within `nearest_in_time`'s tolerance of some pose,
+    // and a window just OUTSIDE the span is already matchable-or-out (so a buffer
+    // would only add arithmetic with no behavioural effect).
+    let (ego_t_min, ego_t_max) = ego_time_span(trajectory);
+    let in_ego_span = |t: f64| t >= ego_t_min && t <= ego_t_max;
     let mut any_windows = false;
     for mode in modes {
         let mut mode_evaluated = false;
@@ -1129,7 +1201,14 @@ fn predictive_rss_breach(
             }
             let dt = b.time_from_start_s - a.time_from_start_s;
             if dt <= 0.0 {
-                continue; // non-monotonic samples — unevaluable (see post-loop guard)
+                // #1094 (F4): a non-monotonic predicted window WITHIN the ego span
+                // is an in-span window we cannot evaluate (no velocity from the
+                // reversed/zero dt) → fail closed; a cut-in could hide here. Beyond
+                // the span it is legitimately unevaluable → skip.
+                if in_ego_span(a.time_from_start_s) {
+                    return true;
+                }
+                continue; // out-of-span non-monotonic samples — legitimately unevaluable
             }
             let ovx = (b.pos.x_m - a.pos.x_m) / dt;
             let ovy = (b.pos.y_m - a.pos.y_m) / dt;
@@ -1139,7 +1218,15 @@ fn predictive_rss_breach(
                 a.time_from_start_s,
                 PREDICTIVE_TIME_MATCH_TOLERANCE_S,
             ) else {
-                continue; // no ego pose within tolerance at this time — unevaluable
+                // #1094 (F4): no ego pose within tolerance. WITHIN the ego span this
+                // is a temporal GAP (poses too sparse) — an in-span window that
+                // escapes evaluation → fail closed. The caller's max-pose-spacing
+                // precondition normally prevents this; defense-in-depth. Beyond the
+                // span the object is predicted past the ego's plan → legit skip.
+                if in_ego_span(a.time_from_start_s) {
+                    return true;
+                }
+                continue; // out-of-span — legitimately unevaluable
             };
             // Past both unevaluable gates: this window WAS evaluated (whatever the
             // geometric verdict below).

--- a/crates/kirra-trajectory/tests/validation_tests.rs
+++ b/crates/kirra-trajectory/tests/validation_tests.rs
@@ -1225,6 +1225,134 @@ fn predictive_rss_does_not_regress_a_lane_keeping_neighbor() {
 }
 
 #[test]
+fn predictive_input_too_coarsely_spaced_fails_closed_f4() {
+    // #1094 (F4): the predictive pass time-matches predicted samples to ego poses
+    // within a tolerance. When modes are supplied, an ego trajectory whose poses are
+    // spaced FARTHER than the tolerance can bridge (> MAX_PREDICTIVE_POSE_SPACING_S)
+    // leaves in-span windows unmatchable — so it is refused UP FRONT (the previously
+    // unused max-pose-spacing precondition, now wired into the live path).
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let benign = linear_mode(1, 6.0, -3.5, 9.0, 0.0, 2.0); // lane-keeping neighbor
+    let modes = [PredictedMode {
+        object_id: 1,
+        samples: &benign,
+    }];
+
+    // Coarse: 3 poses 1.5 s apart (> 1.0 s bound) → refused, purely on spacing.
+    let coarse = straight_trajectory(3, 3.0, 1.5);
+    let v_coarse = validate_trajectory_slow_capped(
+        &coarse,
+        &corridor,
+        &[],
+        &cfg,
+        None,
+        FleetPosture::Nominal,
+        None,
+        None,
+        Some(&modes),
+        None,
+        FrameTrust::Trusted,
+    );
+    assert_eq!(
+        v_coarse,
+        TrajectoryVerdict::MRCFallback,
+        "a too-coarse ego trajectory with predicted modes must fail closed; got {v_coarse:?}"
+    );
+
+    // The SAME benign mode over a fine (0.1 s) trajectory is admitted — proving the
+    // coarse rejection is the spacing precondition, not the lane-keeping neighbor.
+    let fine = straight_trajectory(20, 3.0, 0.1);
+    let v_fine = validate_trajectory_slow_capped(
+        &fine,
+        &corridor,
+        &[],
+        &cfg,
+        None,
+        FleetPosture::Nominal,
+        None,
+        None,
+        Some(&modes),
+        None,
+        FrameTrust::Trusted,
+    );
+    assert!(
+        matches!(v_fine, TrajectoryVerdict::Accept | TrajectoryVerdict::Clamp),
+        "a fine trajectory with a lane-keeping neighbor is admitted; got {v_fine:?}"
+    );
+}
+
+#[test]
+fn predictive_rss_per_window_coverage_closes_an_in_span_nonmonotonic_gap_f4() {
+    // #1094 (F4): the per-mode "evaluated" latch let a LATER in-span window be
+    // silently skipped once an earlier window evaluated. The object sits in the CLEAR
+    // right lane (y=-3.5) in EVERY evaluable window — so the admit/refuse decision
+    // turns ONLY on whether the ONE non-monotonic, in-span window (window 2,
+    // a.t = 1.0 ∈ [0, 1.9]) is fail-closed. The old per-mode latch (set by windows
+    // 0/1) ADMITTED it; per-window coverage refuses it.
+    let trajectory = straight_trajectory(20, 3.0, 0.1); // ego 3 m/s, spans t=0..1.9
+    let corridor = MockCorridorSource::straight_5m_half_width(200.0);
+    let cfg = VehicleConfig::default_urban();
+    let samples = [
+        // window 0 (0.0→0.5): clear lane — evaluated benign, SETS the latch.
+        PredictedSample {
+            pos: Point {
+                x_m: 9.0,
+                y_m: -3.5,
+            },
+            time_from_start_s: 0.0,
+        },
+        PredictedSample {
+            pos: Point {
+                x_m: 9.0,
+                y_m: -3.5,
+            },
+            time_from_start_s: 0.5,
+        },
+        // window 1 (0.5→1.0): clear lane — evaluated benign.
+        PredictedSample {
+            pos: Point {
+                x_m: 9.0,
+                y_m: -3.5,
+            },
+            time_from_start_s: 1.0,
+        },
+        // window 2 (1.0→0.9): NON-MONOTONIC (dt = -0.1), a.t = 1.0 IN-SPAN → the ONLY
+        // reason the trajectory is refused (same clear lane, so nothing else breaches).
+        PredictedSample {
+            pos: Point {
+                x_m: 9.0,
+                y_m: -3.5,
+            },
+            time_from_start_s: 0.9,
+        },
+    ];
+    let modes = [PredictedMode {
+        object_id: 1,
+        samples: &samples,
+    }];
+    let verdict = validate_trajectory_slow_capped(
+        &trajectory,
+        &corridor,
+        &[],
+        &cfg,
+        None,
+        FleetPosture::Nominal,
+        None,
+        None,
+        Some(&modes),
+        None,
+        FrameTrust::Trusted,
+    );
+    assert_eq!(
+        verdict,
+        TrajectoryVerdict::MRCFallback,
+        "an in-span non-monotonic predicted window must fail closed (per-window coverage, \
+         not the per-mode latch); got {verdict:?}"
+    );
+}
+
+#[test]
 fn predictive_rss_catches_a_predicted_cut_in() {
     // The SAME kind of neighbor, but its predicted mode now CUTS IN: it crosses from
     // the right lane (y=-3.5) INTO the ego's lane just ahead of the ego, then sits


### PR DESCRIPTION
## Summary

The multi-modal predictive-RSS pass marked a `PredictedMode` "evaluated" after the **first** matched window; a **later** window within the ego trajectory's time span that was skipped (non-monotonic prediction `dt`, or no ego pose within the match tolerance) did **not** trip the per-mode fail-closed guard, so a predicted cut-in in that window escaped evaluation. And the max-pose-spacing hardening helper that would bound this was **unused** (zero live call sites).

Per your decision (per-window + spacing), this does both:

### Per-window coverage (`predictive_rss_breach`)
Compute the ego trajectory's time span once; a skipped window whose start time falls **within** that span `[min, max]` is now **fail-closed** (an in-span window we could not evaluate → MRC), while a window **beyond** the span stays legitimately unevaluable (the object is predicted past the ego's plan; the snapshot RSS still bounds the real object). This replaces the per-mode latch's fail-open with true per-window coverage; the existing per-mode "no evaluable window" and set-level "no windows at all" guards are kept (defense in depth).

### Spacing precondition (wired live)
When predicted modes are supplied, reject a non-monotonic **or** too-coarsely-spaced ego trajectory up front via the previously-unused `validate_trajectory_time_monotonicity` / `validate_trajectory_time_spacing` (bound `MAX_PREDICTIVE_POSE_SPACING_S = 2×tolerance = 1.0 s`, so no in-span instant is farther than the tolerance from some pose). Mapped to `PredictiveRssBreach` (its contract already covers "a mode was unevaluable"). **Scoped to modes-present**, so the no-modes Nominal WCET path is byte-identical.

## Testing
- `predictive_rss_per_window_coverage_closes_an_in_span_nonmonotonic_gap_f4` — a clear-lane object with one non-monotonic in-span window now fails closed (was admitted); the object is clear in every *evaluable* window, so MRC turns solely on the new in-span guard.
- `predictive_input_too_coarsely_spaced_fails_closed_f4` — a too-coarse ego trajectory with modes fails closed; the same modes over a fine trajectory are admitted.
- Full `kirra-trajectory` suite green (no regression).
- **WP-08 mutation gate** run locally over the checker diff (`cargo mutants --in-diff`): **24 caught, 10 unviable, 0 missed.** Two truly-equivalent min/max-scan mutants (`< → <=` / `> → >=` in `ego_time_span`, which leave the computed min/max bit-identical) are excluded in `.cargo/mutants.toml` with written justification.
- The `in_ego_span` band was simplified to a plain `[min, max]` (no tolerance buffer — the spacing precondition already guarantees dense poses), which also removed the buffer-arithmetic mutants.

Closes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_