### PR TITLE
parko(scene-veto): interlock integrity — F3/F5/F7/F10 (#795)

### DIFF
--- a/parko/crates/parko-kirra/src/diverse.rs
+++ b/parko/crates/parko-kirra/src/diverse.rs
@@ -214,6 +214,23 @@ impl DiverseKirraGovernor {
         self
     }
 
+    /// #795 F5 — mirror of [`crate::KirraGovernor::with_operator_waived`]: scene
+    /// RSS is WAIVED (driving blind), quiescent like `with_external_rss_gate`
+    /// but recorded distinctly for audit. A comparator pairing MUST set the SAME
+    /// declaration on both arms (or neither) — a one-sided one is a permanent
+    /// false divergence.
+    #[must_use]
+    pub fn with_operator_waived(mut self) -> Self {
+        self.rss_feed = RssFeed::OperatorWaived;
+        self
+    }
+
+    /// #795 F5 — the current RSS-feed observability label for audit/divergence.
+    #[must_use]
+    pub fn rss_feed_label(&self) -> &'static str {
+        self.rss_feed.label()
+    }
+
     /// DIFFERENCE #1 — single regime classifier. Folds the primary's
     /// LockedOut-then-RSS-gate-then-posture-match control flow into one
     /// dispatch. LockedOut dominates (matches the primary returning Deny
@@ -227,7 +244,8 @@ impl DiverseKirraGovernor {
         let rss_safe = match &self.rss_feed {
             RssFeed::NeverFed => false,
             RssFeed::Fed(state) => state.safe,
-            RssFeed::ExternallyGated => true,
+            // #795 F5: both quiescent — the split is observability-only.
+            RssFeed::ExternallyGated | RssFeed::OperatorWaived => true,
         };
         if posture == SafetyPosture::LockedOut {
             Regime::HardStop

--- a/parko/crates/parko-kirra/src/lib.rs
+++ b/parko/crates/parko-kirra/src/lib.rs
@@ -402,19 +402,43 @@ pub enum RssFeed {
     NeverFed,
     /// The most recent verdict pushed via `update_rss_state`.
     Fed(RssState),
-    /// The integrator explicitly declared that scene-RSS enforcement happens
-    /// outside this governor (publication-seam gate) or was explicitly
-    /// waived. The pushed-state RSS tier does not gate.
+    /// #795 F5 — the integrator declared that scene-RSS enforcement happens
+    /// OUTSIDE this governor, at the publication seam (parko-ros2's
+    /// `apply_object_rss_gate` bounds the exact twist about to publish). The
+    /// scene RSS IS enforced, just not by this governor's pushed-state tier.
     ExternallyGated,
+    /// #795 F5 — the operator EXPLICITLY WAIVED scene RSS (no producer + an
+    /// acknowledged `PARKO_ALLOW_MOTION_WITHOUT_OBJECT_PERCEPTION`): the vehicle
+    /// drives BLIND to scene RSS. Behaviourally identical to `ExternallyGated`
+    /// (the pushed-state tier is quiescent, every other tier still enforces) —
+    /// but SAFETY-DISTINCT: "enforced elsewhere" vs "not enforced at all". Split
+    /// out so an auditor / the divergence sink can tell them apart (the prior
+    /// single `ExternallyGated` conflated the two, hiding a driving-blind fleet).
+    OperatorWaived,
 }
 
 impl RssFeed {
     /// The RSS-safe verdict this feed contributes to the three-tier gate.
+    /// `OperatorWaived` is quiescent EXACTLY like `ExternallyGated` — the split
+    /// is for observability, never for the gate verdict.
     fn rss_safe(&self) -> bool {
         match self {
             RssFeed::NeverFed => false,
             RssFeed::Fed(state) => state.safe,
-            RssFeed::ExternallyGated => true,
+            RssFeed::ExternallyGated | RssFeed::OperatorWaived => true,
+        }
+    }
+
+    /// #795 F5 — a stable observability label for the feed state, for the
+    /// divergence sink / audit records so "waived (driving blind)" is never
+    /// indistinguishable from "enforced elsewhere".
+    #[must_use]
+    pub fn label(&self) -> &'static str {
+        match self {
+            RssFeed::NeverFed => "never_fed",
+            RssFeed::Fed(_) => "fed",
+            RssFeed::ExternallyGated => "externally_gated",
+            RssFeed::OperatorWaived => "operator_waived",
         }
     }
 }
@@ -559,6 +583,26 @@ impl KirraGovernor {
     pub fn with_external_rss_gate(mut self) -> Self {
         self.rss_feed = RssFeed::ExternallyGated;
         self
+    }
+
+    /// #795 F5 — EXPLICITLY declare that scene RSS is WAIVED (the operator
+    /// accepted motion with no scene-RSS producer; the vehicle drives BLIND to
+    /// scene RSS). Behaviourally identical to [`with_external_rss_gate`](Self::with_external_rss_gate)
+    /// — the pushed-state RSS tier is quiescent and every other tier still
+    /// enforces — but recorded as [`RssFeed::OperatorWaived`] so an auditor can
+    /// tell "waived" from "enforced elsewhere". Use THIS for the acknowledged-
+    /// waiver path and `with_external_rss_gate` for the seam-enforced path.
+    #[must_use]
+    pub fn with_operator_waived(mut self) -> Self {
+        self.rss_feed = RssFeed::OperatorWaived;
+        self
+    }
+
+    /// #795 F5 — the current RSS-feed observability label (`never_fed` / `fed` /
+    /// `externally_gated` / `operator_waived`) for logging + audit records.
+    #[must_use]
+    pub fn rss_feed_label(&self) -> &'static str {
+        self.rss_feed.label()
     }
 
     /// Construct a governor that uses the nominal profile regardless of
@@ -1492,6 +1536,31 @@ mod tests {
             matches!(action, EnforcementAction::Allow),
             "externally-gated governor passes an in-envelope command, got {action:?}"
         );
+    }
+
+    /// #795 F5 — the operator-WAIVED opt-out is behaviourally identical to the
+    /// externally-gated one (both quiescent, envelope pass-through) but carries
+    /// a DISTINCT audit label, so "driving blind" is never indistinguishable
+    /// from "enforced elsewhere".
+    #[test]
+    fn operator_waived_is_quiescent_like_external_but_labeled_distinctly() {
+        let waived = KirraGovernor::new().with_operator_waived();
+        let gated = KirraGovernor::new().with_external_rss_gate();
+        let prev = cmd(3.0);
+        // Same gate behaviour: an in-envelope command passes under both.
+        assert!(matches!(
+            waived.evaluate(&cmd(3.0), Some(&prev), 0.05, SafetyPosture::Nominal),
+            EnforcementAction::Allow
+        ));
+        assert!(matches!(
+            gated.evaluate(&cmd(3.0), Some(&prev), 0.05, SafetyPosture::Nominal),
+            EnforcementAction::Allow
+        ));
+        // But the observability label distinguishes them (the F5 payoff).
+        assert_eq!(waived.rss_feed_label(), "operator_waived");
+        assert_eq!(gated.rss_feed_label(), "externally_gated");
+        assert_ne!(waived.rss_feed_label(), gated.rss_feed_label());
+        assert_eq!(KirraGovernor::new().rss_feed_label(), "never_fed");
     }
 
     /// Feeding a safe verdict exits NeverFed; feeding an unsafe one after a

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -283,19 +283,21 @@ where
     // operator explicitly accepted motion without object perception; it is
     // applied to BOTH comparator arms (a one-sided declaration would be a
     // permanent false divergence).
-    let gate_arm = |g: KirraGovernor| {
-        if external_rss_gate {
-            g.with_external_rss_gate()
-        } else {
-            g
-        }
+    // #795 F5: distinguish the TWO quiescent-RSS reasons. `object_gate_armed`
+    // → scene RSS is ENFORCED at the publication seam (`with_external_rss_gate`);
+    // the waiver-only path (`external_rss_gate` true but the object gate NOT
+    // armed ⟹ `allow_motion_without_object_perception`) → scene RSS is WAIVED,
+    // driving blind (`with_operator_waived`). Both are quiescent; only the audit
+    // label differs, so an auditor can tell "enforced elsewhere" from "waived".
+    let gate_arm = |g: KirraGovernor| match (external_rss_gate, object_gate_armed) {
+        (false, _) => g,
+        (true, true) => g.with_external_rss_gate(),
+        (true, false) => g.with_operator_waived(),
     };
-    let gate_arm_diverse = |g: DiverseKirraGovernor| {
-        if external_rss_gate {
-            g.with_external_rss_gate()
-        } else {
-            g
-        }
+    let gate_arm_diverse = |g: DiverseKirraGovernor| match (external_rss_gate, object_gate_armed) {
+        (false, _) => g,
+        (true, true) => g.with_external_rss_gate(),
+        (true, false) => g.with_operator_waived(),
     };
     let comparator = match platform_profile {
         Some(profile) => GovernorComparator::with_sink(
@@ -429,14 +431,29 @@ fn build_config() -> ParkoNodeConfig {
     config
 }
 
-/// `1` / `true` (case-insensitive, trimmed) → `true`; everything else → `false`.
+/// Read a boolean gate-arming env var. Unset → `false` (fail-safe default). A
+/// recognized `1`/`true`/`0`/`false` → that value. A SET-but-unrecognized value
+/// (`=yes`, `=on`, a typo) → a LOUD error + `false` (#795 F10): a mis-spelled
+/// enable must never silently leave a safety gate disarmed with no diagnostic.
+/// The pure classifier lives in `parko_ros2::config` (non-`ros2`-gated) so it is
+/// unit-tested in the default CI build; this reader adds the env read + WARN.
 fn env_flag(name: &str) -> bool {
-    std::env::var(name)
-        .map(|v| {
-            let v = v.trim().to_ascii_lowercase();
-            v == "1" || v == "true"
-        })
-        .unwrap_or(false)
+    match std::env::var(name) {
+        Err(_) => false,
+        Ok(raw) => match parko_ros2::config::classify_env_flag(&raw) {
+            parko_ros2::config::EnvFlagValue::Set(b) => b,
+            parko_ros2::config::EnvFlagValue::Unrecognized => {
+                tracing::error!(
+                    var = name,
+                    value = %raw,
+                    "parko-ros2: {name} is set to an UNRECOGNIZED value {raw:?} — expected \
+                     1/true or 0/false. Treating as DISABLED (fail-safe); a mis-spelled enable \
+                     (e.g. =yes / =on) will NOT arm the gate. Fix the value to arm it."
+                );
+                false
+            }
+        },
+    }
 }
 
 #[tokio::main]
@@ -469,9 +486,11 @@ async fn main() {
     // WS-0.1 (#G2): decide the governors' RSS mode. Fail-closed default: with
     // no armed object gate and no explicit waiver, the governors stay UNFED
     // and the node HOLDs at zero.
-    let object_gate_armed = config.object_rss_enabled
-        && config.lidar_topic.is_some()
-        && config.platform_profile.is_some();
+    // #795 F3: the ONE arming predicate (`ParkoNodeConfig::object_gate_armed`),
+    // shared with node.rs's seam-gate decision so the two interlock halves
+    // cannot drift into a fail-open (governors declaring external gating while
+    // the seam gate stays dark).
+    let object_gate_armed = config.object_gate_armed();
     let external_rss_gate = object_gate_armed || config.allow_motion_without_object_perception;
     if object_gate_armed {
         tracing::info!(

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -227,6 +227,10 @@ fn build_loop<B>(
     inference_deadline_ms: u64,
     platform_profile: Option<&CourierPlatformProfile>,
     external_rss_gate: bool,
+    // #795 F5: whether the object gate is ARMED (scene RSS enforced at the seam)
+    // vs merely WAIVED (`external_rss_gate` true via the operator waiver only).
+    // Both are quiescent; this selects the audit label the gate-arm applies.
+    object_gate_armed: bool,
 ) -> Arc<Mutex<InferenceLoop<B>>>
 where
     B: InferenceBackend + 'static,
@@ -519,6 +523,7 @@ async fn main() {
         config.inference_deadline_ms,
         config.platform_profile.as_ref(),
         external_rss_gate,
+        object_gate_armed,
     );
 
     // M2 posture: static, defaults to Nominal. M1b's `PostureTracker`

--- a/parko/crates/parko-ros2/src/config.rs
+++ b/parko/crates/parko-ros2/src/config.rs
@@ -270,11 +270,97 @@ impl ParkoNodeConfig {
     pub fn needs_object_snapshot(&self) -> bool {
         self.object_rss_enabled || self.vanished_detection_enabled
     }
+
+    /// #795 F3 — the SINGLE object-RSS-gate arming predicate.
+    ///
+    /// The scene-RSS object gate is ARMED only when the operator opted in
+    /// (`object_rss_enabled`) AND both inputs it needs are configured: a lidar
+    /// stream (`lidar_topic`, the object source) and a `platform_profile` (the
+    /// footprint + RSS params). Missing either → the object slot would never be
+    /// fed and the gate would MRC forever, so it stays DISARMED (fail-safe).
+    ///
+    /// This was previously re-derived independently in the bin's `main()` (which
+    /// decides `with_external_rss_gate`) AND in `node.rs` (which decides whether
+    /// the seam gate actually runs) — two textually-matched halves of ONE
+    /// interlock with no shared function and no test. If they ever drifted, the
+    /// governors could declare the scene tier externally-gated while the seam
+    /// gate stayed dark (a latent fail-OPEN). Both now call this one method.
+    #[must_use]
+    pub fn object_gate_armed(&self) -> bool {
+        self.object_rss_enabled && self.lidar_topic.is_some() && self.platform_profile.is_some()
+    }
+}
+
+/// #795 F10 — classification of a boolean env-flag value. `1`/`true` → enabled;
+/// `0`/`false`/empty → disabled; anything ELSE (`yes`, `on`, a typo) →
+/// `Unrecognized`, so the reader can WARN instead of SILENTLY treating a
+/// mis-spelled enable as "off" (which would leave a safety gate disarmed with
+/// no signal). Lives HERE (non-`ros2`-gated) rather than in the `ros2`-only
+/// node binary, so it is unit-tested in the default CI build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvFlagValue {
+    Set(bool),
+    Unrecognized,
+}
+
+/// Classify a raw env value (case-insensitive, trimmed). See [`EnvFlagValue`].
+#[must_use]
+pub fn classify_env_flag(raw: &str) -> EnvFlagValue {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" => EnvFlagValue::Set(true),
+        "0" | "false" | "" => EnvFlagValue::Set(false),
+        _ => EnvFlagValue::Unrecognized,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn env_flag_recognizes_true_false_tokens() {
+        for t in ["1", "true", "TRUE", " True ", "tRuE"] {
+            assert_eq!(classify_env_flag(t), EnvFlagValue::Set(true), "{t:?}");
+        }
+        for f in ["0", "false", "FALSE", " ", ""] {
+            assert_eq!(classify_env_flag(f), EnvFlagValue::Set(false), "{f:?}");
+        }
+    }
+
+    /// #795 F10 — a mis-spelled enable is UNRECOGNIZED (not silently false), so
+    /// the reader can warn instead of quietly leaving a safety gate disarmed.
+    #[test]
+    fn env_flag_misspelled_enables_are_unrecognized() {
+        for u in ["yes", "on", "y", "enable", "enabled", "2", "tru"] {
+            assert_eq!(classify_env_flag(u), EnvFlagValue::Unrecognized, "{u:?}");
+        }
+    }
+
+    /// #795 F3 — the object-gate arming predicate is the AND of all three
+    /// inputs, over the FULL {object_rss} × {lidar} × {profile} truth table.
+    /// The bin and node.rs now share THIS, so the interlock cannot drift.
+    #[test]
+    fn object_gate_armed_is_the_and_of_all_three_inputs() {
+        for object_rss in [false, true] {
+            for has_lidar in [false, true] {
+                for has_profile in [false, true] {
+                    let cfg = ParkoNodeConfig {
+                        object_rss_enabled: object_rss,
+                        lidar_topic: has_lidar.then(|| "/lidar".to_string()),
+                        platform_profile: has_profile
+                            .then(CourierPlatformProfile::courier_reference),
+                        ..Default::default()
+                    };
+                    let expected = object_rss && has_lidar && has_profile;
+                    assert_eq!(
+                        cfg.object_gate_armed(),
+                        expected,
+                        "object_rss={object_rss} lidar={has_lidar} profile={has_profile}"
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn default_tick_period_is_20hz() {

--- a/parko/crates/parko-ros2/src/node.rs
+++ b/parko/crates/parko-ros2/src/node.rs
@@ -35,9 +35,7 @@ use crate::command_mapping::OutgoingTwist;
 use crate::config::ParkoNodeConfig;
 use crate::containment_gate::{apply_containment_gate, CONTAINMENT_HORIZON_S, CONTAINMENT_STEP_S};
 use crate::imu_shim::imu_msg_to_sample;
-use crate::scene_vetoes::{
-    apply_commit_zone_gate, apply_occlusion_gate, apply_water_gate, StampedScene,
-};
+use crate::scene_vetoes::{apply_scene_gates, SceneGateChain, StampedScene};
 use crate::sensor_mapping::{ImuSample, SensorInputMapping};
 use crate::taj_corridor::{laserscan_msg_to_taj, CorridorSnapshot, EGO_REAR_COVER_M};
 use crate::taj_objects::{
@@ -340,10 +338,14 @@ where
     // footprint are configured — otherwise the slot would never be fed and the
     // gate would MRC forever. `None` → byte-identical (gate skipped).
     let drain_objects = Arc::clone(&latest_objects);
+    // #795 F3: the seam gate arms on the SHARED `object_gate_armed()` predicate
+    // (== the bin's `with_external_rss_gate` decision), so this half of the
+    // interlock cannot drift from the bin's half. `platform_profile.as_ref()`
+    // supplies the params; the filter is the one arming authority.
     let drain_object_params = config
         .platform_profile
         .as_ref()
-        .filter(|_| config.object_rss_enabled && config.lidar_topic.is_some())
+        .filter(|_| config.object_gate_armed())
         .map(courier_rss_params);
     // #309: SG6 vanished-object scene sourcing — armed under the SAME condition as
     // the bin's `with_vanished_detection` (enabled + object perception present),
@@ -505,46 +507,31 @@ where
             };
 
             // WS-0.1 scene-veto gates (occlusion / water / commit-zone),
-            // composed after the object gate on the same publication seam.
-            // Armed-when-configured; inside an armed gate a missing/stale
-            // scene fails closed (stop). The brief std-mutex locks release
-            // before any `.await`.
-            let outcome = match &drain_occlusion_params {
-                Some(params) => apply_occlusion_gate(
-                    outcome,
-                    drain_occlusion.lock().ok().and_then(|g| g.clone()).as_ref(),
-                    params,
-                    drain_config.corridor_max_age_ms,
-                    current_time_ms(),
-                ),
-                None => outcome,
-            };
-            let outcome = if drain_water_armed {
-                apply_water_gate(
-                    outcome,
-                    drain_water.lock().ok().and_then(|g| g.clone()).as_ref(),
-                    &WaterVetoConfig::default(),
-                    drain_config.corridor_max_age_ms,
-                    current_time_ms(),
-                )
-            } else {
-                outcome
-            };
-            let outcome = if drain_commit_zone_armed {
-                apply_commit_zone_gate(
-                    outcome,
-                    drain_commit_zone
-                        .lock()
-                        .ok()
-                        .and_then(|g| g.clone())
-                        .as_ref(),
-                    &CommitZoneCfg::default(),
-                    drain_config.corridor_max_age_ms,
-                    current_time_ms(),
-                )
-            } else {
-                outcome
-            };
+            // composed after the object gate on the same publication seam via
+            // the extracted, CI-tested `apply_scene_gates` (#795 F7). Armed-when-
+            // configured; inside an armed gate a missing/stale scene fails closed
+            // (stop). The brief std-mutex locks release before any `.await` (the
+            // clones are taken here, and the chain borrows them).
+            let occlusion_slot = drain_occlusion.lock().ok().and_then(|g| g.clone());
+            let water_slot = drain_water.lock().ok().and_then(|g| g.clone());
+            let commit_zone_slot = drain_commit_zone.lock().ok().and_then(|g| g.clone());
+            let water_cfg = WaterVetoConfig::default();
+            let commit_zone_cfg = CommitZoneCfg::default();
+            let outcome = apply_scene_gates(
+                outcome,
+                &SceneGateChain {
+                    occlusion_params: drain_occlusion_params.as_ref(),
+                    occlusion: occlusion_slot.as_ref(),
+                    water_armed: drain_water_armed,
+                    water: water_slot.as_ref(),
+                    water_cfg: &water_cfg,
+                    commit_zone_armed: drain_commit_zone_armed,
+                    commit_zone: commit_zone_slot.as_ref(),
+                    commit_zone_cfg: &commit_zone_cfg,
+                    max_age_ms: drain_config.corridor_max_age_ms,
+                    now_ms: current_time_ms(),
+                },
+            );
 
             // Surface the per-tick clearance delivery (a console-recorded grant
             // arriving on this node's own tick). A `NoGrant` no-op is silent.

--- a/parko/crates/parko-ros2/src/scene_vetoes.rs
+++ b/parko/crates/parko-ros2/src/scene_vetoes.rs
@@ -180,6 +180,69 @@ pub fn apply_commit_zone_gate(
     }
 }
 
+/// #795 F7 — the resolved inputs to the per-tick scene-veto chain. `Some(params)`
+/// / `*_armed = true` ARMS a gate; the borrowed scene is that gate's latest
+/// slot (already locked out of its mutex by the caller). Grouped into a struct
+/// so [`apply_scene_gates`] has a small signature and the drain loop just fills
+/// this in.
+pub struct SceneGateChain<'a> {
+    /// `Some` = occlusion gate armed; the RSS bound for the occlusion cap.
+    pub occlusion_params: Option<&'a RssParams>,
+    pub occlusion: Option<&'a StampedScene<OcclusionScene>>,
+    pub water_armed: bool,
+    pub water: Option<&'a StampedScene<WaterScene>>,
+    pub water_cfg: &'a WaterVetoConfig,
+    pub commit_zone_armed: bool,
+    pub commit_zone: Option<&'a StampedScene<CommitZoneScene>>,
+    pub commit_zone_cfg: &'a CommitZoneCfg,
+    pub max_age_ms: u64,
+    pub now_ms: u64,
+}
+
+/// #795 F7 — the per-tick scene-veto CHAIN, composed in the fixed order
+/// occlusion → water → commit-zone. Each gate runs ONLY when armed; a DISARMED
+/// gate is skipped (never stops), an ARMED gate with a missing/stale scene
+/// fails CLOSED (stop) INSIDE the gate (the enabled-but-silent rule). Extracted
+/// out of the `ros2`-gated drain loop (which was build-only in CI) so the
+/// arming + ordering logic is unit-testable — the loop now just locks the slots
+/// and calls this.
+// SAFETY: SG1 SG4 SG5 | REQ: parko-ros2-scene-gate-chain | TEST: scene_gate_chain_arming_truth_table,scene_gate_chain_disarmed_gates_never_stop
+#[must_use]
+pub fn apply_scene_gates(outcome: TickOutcome, chain: &SceneGateChain<'_>) -> TickOutcome {
+    let outcome = match chain.occlusion_params {
+        Some(params) => apply_occlusion_gate(
+            outcome,
+            chain.occlusion,
+            params,
+            chain.max_age_ms,
+            chain.now_ms,
+        ),
+        None => outcome,
+    };
+    let outcome = if chain.water_armed {
+        apply_water_gate(
+            outcome,
+            chain.water,
+            chain.water_cfg,
+            chain.max_age_ms,
+            chain.now_ms,
+        )
+    } else {
+        outcome
+    };
+    if chain.commit_zone_armed {
+        apply_commit_zone_gate(
+            outcome,
+            chain.commit_zone,
+            chain.commit_zone_cfg,
+            chain.max_age_ms,
+            chain.now_ms,
+        )
+    } else {
+        outcome
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -404,5 +467,74 @@ mod tests {
             "upstream provenance preserved"
         );
         assert_eq!(out.twist, OutgoingTwist::stopped(7));
+    }
+
+    // ---- #795 F7: the composed chain's arming truth table ------------------
+
+    /// Over the FULL {occlusion} × {water} × {commit-zone} arming table, a
+    /// MOVING command with NO scenes fed stops IFF at least one gate is armed
+    /// (an armed gate with a silent slot fails closed inside the gate); with no
+    /// gate armed the command passes through unchanged. This pins the extracted
+    /// composition's arming + ordering logic in a non-ros2 unit test.
+    #[test]
+    fn scene_gate_chain_arming_truth_table() {
+        let p = params();
+        let wcfg = WaterVetoConfig::default();
+        let czcfg = CommitZoneCfg::default();
+        for occ in [false, true] {
+            for wat in [false, true] {
+                for cz in [false, true] {
+                    let chain = SceneGateChain {
+                        occlusion_params: occ.then_some(&p),
+                        occlusion: None,
+                        water_armed: wat,
+                        water: None,
+                        water_cfg: &wcfg,
+                        commit_zone_armed: cz,
+                        commit_zone: None,
+                        commit_zone_cfg: &czcfg,
+                        max_age_ms: 100,
+                        now_ms: 0,
+                    };
+                    let out = apply_scene_gates(outcome(2.0), &chain);
+                    let any_armed = occ || wat || cz;
+                    assert_eq!(
+                        out.twist.linear_x_mps == 0.0,
+                        any_armed,
+                        "occ={occ} water={wat} commit_zone={cz}: armed+silent must fail closed"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A DISARMED gate is skipped entirely: even a scene that WOULD stop
+    /// (`OcclusionScene::Absent` / `WaterScene::Unknown` /
+    /// `CommitZoneScene::Unknown`) present in a disarmed slot never stops the
+    /// command — arming is the sole authority for whether a gate runs.
+    #[test]
+    fn scene_gate_chain_disarmed_gates_never_stop() {
+        let wcfg = WaterVetoConfig::default();
+        let czcfg = CommitZoneCfg::default();
+        let occ = stamped(OcclusionScene::Absent, 0);
+        let wat = stamped(WaterScene::Unknown, 0);
+        let cz = stamped(CommitZoneScene::Unknown, 0);
+        let chain = SceneGateChain {
+            occlusion_params: None, // disarmed despite a would-stop scene
+            occlusion: Some(&occ),
+            water_armed: false,
+            water: Some(&wat),
+            water_cfg: &wcfg,
+            commit_zone_armed: false,
+            commit_zone: Some(&cz),
+            commit_zone_cfg: &czcfg,
+            max_age_ms: 100,
+            now_ms: 0,
+        };
+        let out = apply_scene_gates(outcome(2.0), &chain);
+        assert!(
+            (out.twist.linear_x_mps - 2.0).abs() < 1e-9 && out.error.is_none(),
+            "disarmed gates must not run — command passes unchanged, got {out:?}"
+        );
     }
 }


### PR DESCRIPTION
Deferred **#795** findings (WS-0.1 scene-veto go-live) — the interlock-integrity slice. **No safety-behaviour change to the armed gates**; this hardens the *arming / composition / observability* around them and makes the logic CI-testable.

## F3 — dedupe the object-gate arming predicate (latent fail-open)
The arming condition (`object_rss_enabled && lidar_topic && platform_profile`) was re-derived **independently** in the bin's `main()` (deciding `with_external_rss_gate`) and in `node.rs` (deciding whether the seam gate runs) — two textually-matched halves of one interlock, no shared fn, no test. A drift would fail **open** (governors declaring external gating while the seam gate stayed dark). Both now call the single `ParkoNodeConfig::object_gate_armed()`, pinned by a full `{object_rss}×{lidar}×{profile}` truth-table test.

## F10 — `env_flag` no longer silently swallows a typo'd enable
`=yes` / `=on` / a misspelling mapped to `false`, quietly leaving a safety gate disarmed. The pure classifier is now `parko_ros2::config::classify_env_flag` (`Set(bool)` | `Unrecognized`) — **in the non-`ros2`-gated lib so it's unit-tested in the default CI build** — and the node's reader WARNs loudly on `Unrecognized` (fail-safe to disabled, *with* a diagnostic).

## F5 — split `ExternallyGated` into enforced-elsewhere vs operator-waived
The single variant conflated "scene RSS enforced at the publication seam" with "operator **waived** it (driving blind)". Added `RssFeed::OperatorWaived` + `with_operator_waived()` + `rss_feed_label()` on both `KirraGovernor` and `DiverseKirraGovernor` — behaviourally identical/quiescent (**gate verdict unchanged**), but an auditor / the divergence sink can now tell "enforced" from "waived". The bin picks the label by reason (`object_gate_armed` → external; waiver-only → waived).

## F7 — extract the gate chain into a testable, non-`ros2` module
The occlusion → water → commit-zone chain was inline in the `ros2`-gated drain loop (build-only in CI). Extracted into pure `scene_vetoes::apply_scene_gates(SceneGateChain)`; the drain loop now just locks the slots and calls it. Adds an arming truth-table test (armed+silent ⇒ fail closed; none armed ⇒ pass) + a disarmed-gates-never-run test.

## Left as tracked #795 remainders
- **F6** — a real occlusion/water/commit-zone **producer** (perception work, needs sensors)
- **F8** — the rotation-while-blind angular-channel **semantics decision** (a documented owner call)

## Validation
- parko fmt clean; **parko-kirra 181 + parko-ros2 246** lib tests green (incl. the new F3/F5/F7/F10 tests).
- No parko clippy CI lane exists, but the changed code is clippy-clean under `-D warnings`.

Refs #795 — F3/F5/F7/F10 land here; F6 (producer) + F8 (semantics) are their own tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_