### PR TITLE
parko(deadline): occlusion clamp-to-cap + bounded shutdown (#794)

### DIFF
--- a/parko/crates/parko-core/src/scheduler.rs
+++ b/parko/crates/parko-core/src/scheduler.rs
@@ -45,8 +45,37 @@ fn override_reason(action: &EnforcementAction) -> Option<&'static str> {
 /// `cmd_vel` MUST additionally dead-man a silent command stream to STOP within
 /// this budget (else it would hold a pre-hang MOVING twist live across the hang).
 /// See `AOU-ACTUATION-DEADMAN-001` in `docs/safety/ASSUMPTIONS_OF_USE.md`.
-/// Budget-deriving this default from the FTTI decomposition (vs the current
-/// "generous" rationale) is a tracked safety-case item.
+///
+/// # FTTI budget derivation (#794 F1) — DRAFT, pending safety-owner ratify
+///
+/// This deadline is one term in the Fault-Tolerant Time Interval (FTTI) for the
+/// "backend wedge → moving ego" hazard: the total wall-clock from the backend
+/// ceasing to return until the vehicle reaches the MRC (full stop) must not
+/// exceed the hazard's time-to-harm `T_harm`. The chain is
+///
+/// ```text
+///   T_ftti = t_detect + t_propagate + t_actuate + t_decel   ≤   T_harm
+/// ```
+///
+/// where, for the parko path:
+/// - `t_detect` = THIS deadline — the bound on how long `tick` waits for a wedged
+///   backend before it publishes STOP. (≤ 1000 ms today.)
+/// - `t_propagate` = drain-loop + transport latency from the STOP command to the
+///   base controller (bounded by the tick period + DDS/QoS).
+/// - `t_actuate` = base-controller dead-man reaction (AOU-ACTUATION-DEADMAN-001) —
+///   it must STOP on a silent `cmd_vel` within this same budget.
+/// - `t_decel` = kinematic stopping time from the pre-hang speed under the class
+///   MRC decel profile (`contract_for` / `mrc_fallback_for`).
+///
+/// To DERIVE (not merely bound) this default, the safety owner supplies the
+/// per-class empirical inputs — `T_harm` for the design ODD, the measured
+/// `t_propagate`/`t_actuate`, and the MRC decel — and solves for the admissible
+/// `t_detect`; the deadline is then set to `min(that, current generous default)`.
+/// Those inputs are NOT asserted here: this comment records the decomposition
+/// FORM so the number has a home in the safety case, and the empirical values +
+/// the ratified `t_detect` remain a signed-off safety-engineering deliverable.
+/// Until then the value is unchanged — the "generous 20×-tick" bound above
+/// stands as a conservative placeholder, never a validated FTTI allocation.
 pub const DEFAULT_INFERENCE_DEADLINE_MS: u64 = 1_000;
 
 /// WS-0.4 F6 — sanity CEILING on the per-tick inference deadline, ms. The

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -460,8 +460,30 @@ fn env_flag(name: &str) -> bool {
     }
 }
 
-#[tokio::main]
-async fn main() {
+/// #794 F7: bounded post-shutdown grace for lingering `spawn_blocking` workers.
+/// The inference backend runs on a blocking worker; a wedged model call cannot be
+/// aborted, and the default tokio runtime `Drop` blocks FOREVER waiting for such a
+/// thread — hanging SIGTERM until systemd escalates to SIGKILL and the clean-exit
+/// path (tracing flush, task abort acknowledgement) is lost. After `async_main`
+/// returns (the SIGINT/SIGTERM handler has fired and the node task is aborted) we
+/// give any stuck worker this window, then abandon it and exit.
+const SHUTDOWN_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
+fn main() {
+    // Explicit runtime (not `#[tokio::main]`) so we own the shutdown: the macro's
+    // implicit `Drop` would wait unboundedly on a wedged blocking inference thread.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("parko_ros2_node: failed to build the tokio runtime");
+
+    runtime.block_on(async_main());
+
+    // Bounded shutdown — never hang SIGTERM on a stuck inference worker.
+    runtime.shutdown_timeout(SHUTDOWN_GRACE);
+}
+
+async fn async_main() {
     init_tracing();
 
     let config = Arc::new(build_config());

--- a/parko/crates/parko-ros2/src/scene_vetoes.rs
+++ b/parko/crates/parko-ros2/src/scene_vetoes.rs
@@ -102,7 +102,7 @@ fn already_stopped(outcome: &TickOutcome) -> bool {
 /// scene: `Absent` (or missing/stale when armed) caps at 0.0 (any motion
 /// stops), `KnownClear` never binds, `Limited` binds via
 /// `occlusion_limited_speed` (fail-closed to 0.0 on invalid inputs).
-// SAFETY: SG1 | REQ: parko-ros2-occlusion-gate | TEST: occlusion_known_clear_passes,occlusion_limited_caps_overspeed,occlusion_limited_admits_slow_ego,occlusion_missing_scene_fails_closed,occlusion_stale_scene_fails_closed,already_stopped_outcome_passes_all_gates
+// SAFETY: SG1 | REQ: parko-ros2-occlusion-gate | TEST: occlusion_known_clear_passes,occlusion_limited_caps_overspeed,occlusion_limited_clamp_preserves_direction,occlusion_absent_scene_full_stops,occlusion_nonfinite_overspeed_full_stops,occlusion_limited_admits_slow_ego,occlusion_missing_scene_fails_closed,occlusion_stale_scene_fails_closed,already_stopped_outcome_passes_all_gates
 pub fn apply_occlusion_gate(
     outcome: TickOutcome,
     occlusion: Option<&StampedScene<OcclusionScene>>,
@@ -115,10 +115,31 @@ pub fn apply_occlusion_gate(
     }
     let scene = resolve_scene(occlusion, max_age_ms, now_ms, OcclusionScene::Absent);
     let cap = compute_occlusion_cap(&scene, params);
-    // `<=` is NaN-safe: a non-finite speed fails the comparison → stop. (The
-    // twist is already finiteness-enforced upstream; this is defence-in-depth.)
-    if outcome.twist.linear_x_mps.abs() <= cap {
-        outcome
+    let v = outcome.twist.linear_x_mps;
+    // Within the assured-clear-distance cap (`<=` is NaN-safe: a non-finite
+    // speed fails the comparison → the fail-closed branch below).
+    if v.abs() <= cap {
+        return outcome;
+    }
+    // #794 F8/F9: over the cap → CLAMP the ego to the assured-clear-distance
+    // speed (creep at ±cap, preserving direction) instead of a bang-bang full
+    // STOP that a cap-unaware planner fights every tick (park-at-every-blind-
+    // junction / oscillation). The clamped speed IS safe by construction — `cap`
+    // is the RSS-Rule-4 max safe speed for the sightline. Full-stop only when no
+    // motion is admissible: `cap == 0` (Absent / no visibility) or a non-finite
+    // command. The breach tag is preserved either way. (F8: the occlusion gate
+    // binds only the LINEAR channel — the in-place-rotation-while-limited
+    // decision is a separate track — so the clamp leaves `angular_z` untouched;
+    // the full-stop path zeros both via `OutgoingTwist::stopped`.)
+    if cap > 0.0 && v.is_finite() {
+        TickOutcome {
+            twist: OutgoingTwist {
+                linear_x_mps: v.clamp(-cap, cap),
+                ..outcome.twist
+            },
+            error: Some(TickError::OcclusionBreach),
+            degraded: outcome.degraded,
+        }
     } else {
         TickOutcome {
             twist: OutgoingTwist::stopped(outcome.twist.stamp_ms),
@@ -289,18 +310,74 @@ mod tests {
 
     #[test]
     fn occlusion_limited_caps_overspeed() {
-        // A short sightline yields a small cap; a 5 m/s ego must stop.
-        let s = stamped(
-            OcclusionScene::Limited {
-                d_sight_m: 2.0,
-                v_emerge_max_mps: 1.5,
-            },
-            100,
+        // #794 F8/F9: a bounded sightline yields a positive cap; an overspeed ego
+        // is CLAMPED to that cap (creep), not bang-bang stopped. The breach tag is
+        // still raised so provenance/telemetry see the correction.
+        let scene = OcclusionScene::Limited {
+            d_sight_m: 30.0,
+            v_emerge_max_mps: 1.0,
+        };
+        let cap = compute_occlusion_cap(&scene, &params());
+        assert!(
+            cap > 0.0,
+            "this sightline must admit creep for the clamp branch to be exercised; got {cap}"
         );
+        let s = stamped(scene, 100);
+        let out = apply_occlusion_gate(outcome(20.0), Some(&s), &params(), 500, 100);
+        assert_eq!(
+            out.twist.linear_x_mps, cap,
+            "overspeed past a positive occlusion cap clamps to the cap (creep), not to 0"
+        );
+        assert_eq!(out.error, Some(TickError::OcclusionBreach));
+    }
+
+    #[test]
+    fn occlusion_limited_clamp_preserves_direction() {
+        // #794 F8/F9: a reversing ego over the cap clamps to -cap, not +cap — the
+        // clamp bounds MAGNITUDE and keeps sign, it never flips travel direction.
+        let scene = OcclusionScene::Limited {
+            d_sight_m: 30.0,
+            v_emerge_max_mps: 1.0,
+        };
+        let cap = compute_occlusion_cap(&scene, &params());
+        assert!(cap > 0.0, "sightline must admit creep; got {cap}");
+        let s = stamped(scene, 100);
+        let out = apply_occlusion_gate(outcome(-20.0), Some(&s), &params(), 500, 100);
+        assert_eq!(
+            out.twist.linear_x_mps, -cap,
+            "reverse overspeed clamps to -cap (magnitude bound, sign preserved)"
+        );
+        assert_eq!(out.error, Some(TickError::OcclusionBreach));
+    }
+
+    #[test]
+    fn occlusion_absent_scene_full_stops() {
+        // #794 F8/F9: cap == 0 (Absent / no admissible motion) is the only branch
+        // that still bang-bang STOPS — there is no non-zero speed to clamp to.
+        let s = stamped(OcclusionScene::Absent, 100);
         let out = apply_occlusion_gate(outcome(5.0), Some(&s), &params(), 500, 100);
         assert_eq!(
             out.twist.linear_x_mps, 0.0,
-            "overspeed past the occlusion cap must stop"
+            "a zero cap admits no motion → full stop"
+        );
+        assert_eq!(out.error, Some(TickError::OcclusionBreach));
+    }
+
+    #[test]
+    fn occlusion_nonfinite_overspeed_full_stops() {
+        // A non-finite command can never be clamped to a finite cap safely → the
+        // fail-closed full-stop branch, even under a positive cap.
+        let s = stamped(
+            OcclusionScene::Limited {
+                d_sight_m: 30.0,
+                v_emerge_max_mps: 1.0,
+            },
+            100,
+        );
+        let out = apply_occlusion_gate(outcome(f64::INFINITY), Some(&s), &params(), 500, 100);
+        assert_eq!(
+            out.twist.linear_x_mps, 0.0,
+            "a non-finite command fails closed to a full stop, not a clamp"
         );
         assert_eq!(out.error, Some(TickError::OcclusionBreach));
     }


### PR DESCRIPTION
Third and final PR of the #793 → #795 → #794 ascending-risk batch from the deep review. Addresses the three deadline-watchdog residuals in #794.

## F8/F9 — occlusion gate clamps to the RSS-Rule-4 cap (not bang-bang stop)

`apply_occlusion_gate` (`parko/crates/parko-ros2/src/scene_vetoes.rs`) previously full-stopped any tick whose speed exceeded the assured-clear-distance cap. Now:

- **cap > 0 and finite command** → clamp linear speed to `±cap` (creep, **direction preserved**). The clamped speed is safe by construction — `cap` is the RSS-Rule-4 max safe speed for the sightline — so a cap-unaware planner no longer fights the gate every tick (park-at-every-blind-junction / oscillation into a blind approach).
- **cap == 0 (Absent / no visibility) or non-finite command** → the only branch that still full-stops (no admissible motion to clamp to).
- The `OcclusionBreach` tag is preserved on every corrected tick (telemetry/provenance still see the correction), and the clamp binds only the **linear** channel — `angular_z` is left untouched (in-place-rotation-while-limited is a separate track).

New tests: `occlusion_limited_clamp_preserves_direction`, `occlusion_absent_scene_full_stops`, `occlusion_nonfinite_overspeed_full_stops`; `occlusion_limited_caps_overspeed` now asserts the clamp-to-cap value. SAFETY-tag test list updated.

## F7 — bounded runtime shutdown in the node binary

`parko_ros2_node` runs the inference backend on a `spawn_blocking` worker that a wedged model call cannot abort. Under `#[tokio::main]` the implicit runtime `Drop` waits **forever** for that worker, hanging SIGTERM until systemd escalates to SIGKILL (losing the clean-exit path). The binary now owns the runtime explicitly and calls `shutdown_timeout(SHUTDOWN_GRACE)` after `async_main` returns, so a stuck worker is abandoned within a bounded window and the process exits cleanly. (ros2-gated `#[cfg(feature = "ros2")]` file — built only by the ros2 CI lane.)

## F1 — DRAFT FTTI budget derivation (value UNCHANGED)

Documents the `t_detect + t_propagate + t_actuate + t_decel ≤ T_harm` decomposition form for `DEFAULT_INFERENCE_DEADLINE_MS` so the number has a home in the safety case. **The value is unchanged (1000 ms)** and explicitly flagged pending safety-owner ratification — the empirical per-class inputs and the ratified `t_detect` remain a signed-off safety-engineering deliverable; the generous 20×-tick bound stays a conservative placeholder until then. No silent constant change.

## Verification

- `cargo fmt --check` — clean (parko workspace)
- `cargo test -p parko-ros2 --lib scene_vetoes::` — 19 pass
- `cargo test -p parko-core --lib scheduler::` — 17 pass
- `cargo test -p parko-ros2 --lib` — 249 pass
- `cargo clippy -p parko-core -p parko-ros2 --lib --tests` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_