### PR TITLE
parko(scene-veto): producer guard + veto-config plumbing + F8/F11 (#795)

### DIFF
--- a/docs/safety/PARKO_SCENE_VETO_SEMANTICS.md
+++ b/docs/safety/PARKO_SCENE_VETO_SEMANTICS.md
@@ -1,0 +1,74 @@
+# Parko scene-veto gate semantics (WS-0.1 / #795)
+
+Status: **living doc.** Records the intended behaviour and the open safety-owner
+decisions for the parko-ros2 publication-seam scene-veto gates (occlusion / water
+/ commit-zone). Cited from `parko/crates/parko-ros2/src/scene_vetoes.rs` and
+`parko/crates/parko-ros2/src/config.rs`.
+
+## The gates
+
+Each gate composes ONTO a `TickOutcome` after the tick, bounding the exact twist
+about to be published (same seam as `taj_objects::apply_object_rss_gate`). A gate
+runs only when **armed** (configured); an armed gate whose scene slot is
+missing/stale fails **closed** to its worst-case scene variant (the
+enabled-but-silent → fail-closed house rule). Not armed → the gate is never called
+→ byte-identical prior behaviour.
+
+| Gate | Armed by | Missing/stale (armed) | Bounds |
+|------|----------|-----------------------|--------|
+| Occlusion (RSS rule iv) | `occlusion_gate_enabled` **and** a `platform_profile` (RSS params) | `OcclusionScene::Absent` → cap 0.0 | **linear only** (see below) |
+| Water (SG4) | `water_gate_enabled` | `WaterScene::Unknown` → veto | zeroes both channels |
+| Commit-zone (SG5) | `commit_zone_gate_enabled` | `CommitZoneScene::Unknown` → veto | zeroes both channels |
+
+## F6 — armed without a producer = permanent immobilization (fail-loud)
+
+This build ships **no producers** for the occlusion / water / commit-zone slots.
+An armed gate with a slot that is never fed fails closed to a STOP **every tick,
+forever** — a permanent immobilization. That behaviour is fail-*safe* (a stop),
+but silently coming up immobilized with no diagnostic is a foot-gun.
+
+`ParkoNodeConfig::scene_gate_startup_check` (pure, unit-tested) makes it loud: if
+any gate that would *actually* immobilize is armed (see
+`producerless_armed_scene_gates`) and the operator has **not** set
+`PARKO_ALLOW_SCENE_GATE_WITHOUT_PRODUCER=1`, the node **refuses to start** and
+names the offending gates. The operator then either configures a producer,
+disarms the gate, or deliberately acknowledges the immobilization (e.g. a
+bring-up / immobilizer test). Occlusion counts only when it truly arms (flag +
+`platform_profile`); a flag with no profile is a dark flag, not an immobilizer.
+
+The veto **configs** (`WaterVetoConfig`, `CommitZoneCfg`) are now carried on
+`ParkoNodeConfig` (`water_veto_config` / `commit_zone_config`) rather than a
+per-tick hardcoded `Default()`, so their (VALIDATION-PENDING) bounds are a
+deployment knob. Defaults are unchanged → byte-identical.
+
+**Remaining (tracked):** land at least one *real* producer — a sightline-from-lidar
+occlusion source or a map-anchored commit-zone source. That is perception work
+requiring hardware/design validation and is out of scope for the fail-loud guard
+above.
+
+## F8 — occlusion angular-channel semantics (pending decision)
+
+The occlusion cap is an assured-clear-**distance** bound, so it binds only the
+LINEAR channel and leaves `angular_z` untouched. This is deliberate:
+
+- A pure in-place rotation (`linear ≈ 0`, `angular ≠ 0`) under an `Absent` /
+  `Limited` scene passes the gate unchanged. Turning in place does not advance the
+  ego into the unobserved region — it is the *creep-and-peek* primitive that lets
+  the ego rotate to improve its own sightline before committing to forward motion.
+  Zeroing it would deadlock that maneuver.
+- Any rotation with a nonzero turn radius carries a nonzero `linear_x` and is
+  therefore still bound by the clamp (its along-track speed is capped).
+
+**Open decision (safety owner):** a *swept* in-place rotation of a long /
+rectangular footprint can sweep the vehicle's extremities into an occluded
+conflict zone even at zero `linear_x`. Whether to additionally bound that
+swept-rotation case here — versus the stricter water / commit-zone gates, which
+zero both channels — is a footprint-geometry decision. Until decided, the
+linear-only binding stands (documented here so the choice is explicit, not
+implicit).
+
+## F9 — occlusion clamp-to-cap (#794, shipped)
+
+Over a positive assured-clear-distance cap the ego is clamped to ±cap (creep,
+direction preserved), not bang-bang stopped; full-stop only when no motion is
+admissible (`cap == 0` / non-finite). See #794.

--- a/parko/crates/parko-kirra/src/comparator.rs
+++ b/parko/crates/parko-kirra/src/comparator.rs
@@ -388,6 +388,34 @@ pub(crate) fn actions_diverge(
     (p_lin - s_lin).abs() > tol || (p_ang - s_ang).abs() > tol
 }
 
+impl GovernorComparator<DiverseKirraGovernor> {
+    /// #795 F11 — declare `ExternallyGated` on **both** arms at once.
+    ///
+    /// The scene-RSS declaration MUST match on the primary and the shadow: a
+    /// one-sided `with_external_rss_gate` is a PERMANENT false divergence (one arm
+    /// quiescent, the other still `NeverFed`). The per-arm builders warn about
+    /// this in prose, but the symmetry was convention-only. This applies the
+    /// declaration to both arms in one call, so it cannot drift. Production
+    /// wiring (primary `KirraGovernor` + shadow `DiverseKirraGovernor`) should use
+    /// this instead of gating each arm by hand.
+    #[must_use]
+    pub fn with_external_rss_gate(mut self) -> Self {
+        self.primary = self.primary.with_external_rss_gate();
+        self.shadow = self.shadow.with_external_rss_gate();
+        self
+    }
+
+    /// #795 F11 — declare `OperatorWaived` on **both** arms at once (the waiver
+    /// twin of [`with_external_rss_gate`](Self::with_external_rss_gate); same
+    /// no-drift guarantee).
+    #[must_use]
+    pub fn with_operator_waived(mut self) -> Self {
+        self.primary = self.primary.with_operator_waived();
+        self.shadow = self.shadow.with_operator_waived();
+        self
+    }
+}
+
 impl<S: SafetyGovernor> GovernorComparator<S> {
     /// Create a comparator with a primary `KirraGovernor` and a shadow
     /// governor `S`, and the default in-memory divergence sink.
@@ -678,6 +706,23 @@ mod tests {
         primary.update_rss_state(safe_rss());
         shadow.update_rss_state(unsafe_rss());
         (primary, shadow)
+    }
+
+    /// #795 F11 — the comparator-level `with_external_rss_gate` declares the SAME
+    /// RSS-feed state on BOTH arms in one call, so the symmetry (which the per-arm
+    /// builders warn MUST hold, or it is a permanent false divergence) cannot
+    /// drift. `with_operator_waived` is the waiver twin.
+    #[test]
+    fn comparator_gate_helpers_declare_both_arms() {
+        let gated = GovernorComparator::new(KirraGovernor::new(), DiverseKirraGovernor::new())
+            .with_external_rss_gate();
+        assert_eq!(gated.primary.rss_feed_label(), "externally_gated");
+        assert_eq!(gated.shadow.rss_feed_label(), "externally_gated");
+
+        let waived = GovernorComparator::new(KirraGovernor::new(), DiverseKirraGovernor::new())
+            .with_operator_waived();
+        assert_eq!(waived.primary.rss_feed_label(), "operator_waived");
+        assert_eq!(waived.shadow.rss_feed_label(), "operator_waived");
     }
 
     // -----------------------------------------------------------------

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -432,6 +432,10 @@ fn build_config() -> ParkoNodeConfig {
     config.occlusion_gate_enabled = env_flag("PARKO_OCCLUSION_GATE_ENABLED");
     config.water_gate_enabled = env_flag("PARKO_WATER_GATE_ENABLED");
     config.commit_zone_gate_enabled = env_flag("PARKO_COMMIT_ZONE_GATE_ENABLED");
+    // #795 F6: explicit acknowledgment that a scene-veto gate may be armed with no
+    // producer (a deliberate permanent immobilizer). Unset → the startup guard
+    // REFUSES a producer-less armed gate instead of silently immobilizing.
+    config.allow_scene_gate_without_producer = env_flag("PARKO_ALLOW_SCENE_GATE_WITHOUT_PRODUCER");
     config
 }
 
@@ -488,6 +492,18 @@ async fn async_main() {
 
     let config = Arc::new(build_config());
     tracing::info!(?config, "parko_ros2_node starting");
+
+    // #795 F6: fail-closed startup guard. A scene-veto gate (occlusion/water/
+    // commit-zone) armed with no producer feeding its slot fails closed to a STOP
+    // every tick — a PERMANENT immobilization. Refuse to start (rather than come
+    // up silently immobilized) unless the operator explicitly acknowledged it via
+    // PARKO_ALLOW_SCENE_GATE_WITHOUT_PRODUCER. Same fail-closed-exit shape as the
+    // backend-select guard below.
+    if let Err(refusal) = config.scene_gate_startup_check() {
+        tracing::error!("parko_ros2_node: {refusal}");
+        eprintln!("parko_ros2_node: {refusal} — refusing to start (fail-closed)");
+        std::process::exit(2);
+    }
 
     // Pick the backend compiled into THIS build (compile-time feature gate, so a
     // misconfigured production build can't fall through to the mock). The mock lane

--- a/parko/crates/parko-ros2/src/config.rs
+++ b/parko/crates/parko-ros2/src/config.rs
@@ -6,6 +6,9 @@
 
 use std::time::Duration;
 
+use parko_core::commit_zone::CommitZoneCfg;
+use parko_core::water::WaterVetoConfig;
+
 use crate::platform_profile::CourierPlatformProfile;
 
 /// Configuration for the Parko ROS 2 node. Constructed by the binary
@@ -172,6 +175,32 @@ pub struct ParkoNodeConfig {
     /// (`CommitZoneScene::Unknown` → veto): arm only
     /// with a map-anchored zone producer. **Default `false`.**
     pub commit_zone_gate_enabled: bool,
+
+    /// #795 F6 — the SG4 water-veto bounds threaded into `apply_water_gate`
+    /// (`max_exit_distance_m` / `max_puddle_extent_m`). Previously the drain loop
+    /// hardcoded `WaterVetoConfig::default()`; carrying it on the config makes the
+    /// (VALIDATION-PENDING) puddle bounds a deployment knob, one source shared by
+    /// the gate and any diagnostics. **Default:** `WaterVetoConfig::default()`
+    /// (byte-identical to the prior hardcode).
+    pub water_veto_config: WaterVetoConfig,
+
+    /// #795 F6 — the SG5 commit-zone geometry threaded into `apply_commit_zone_gate`
+    /// (look-ahead / vehicle length / exit margin / clearance-time margin).
+    /// Previously the drain loop hardcoded `CommitZoneCfg::default()`; carrying it
+    /// here makes the (VALIDATION-PENDING) geometry a deployment knob. **Default:**
+    /// `CommitZoneCfg::default()` (byte-identical to the prior hardcode).
+    pub commit_zone_config: CommitZoneCfg,
+
+    /// #795 F6 — EXPLICIT operator acknowledgment that a scene-veto gate
+    /// (occlusion / water / commit-zone) may be ARMED even though this build ships
+    /// **no producer** for its slot. An armed gate with no producer fails closed to
+    /// a STOP every tick — a *permanent immobilization*. **Default `false` —
+    /// fail-closed:** [`scene_gate_startup_check`](Self::scene_gate_startup_check)
+    /// REFUSES startup (rather than silently immobilizing) when a producer-less gate
+    /// is armed and this is unset. Set `true` only for a deliberate
+    /// bring-up/immobilizer test; the operator — not a silent default — owns that
+    /// choice. (When a real producer lands, that gate drops out of the guard.)
+    pub allow_scene_gate_without_producer: bool,
 }
 
 /// Placeholder for an MRC fallback override. Today's MRC is always
@@ -222,6 +251,13 @@ impl Default for ParkoNodeConfig {
             occlusion_gate_enabled: false,
             water_gate_enabled: false,
             commit_zone_gate_enabled: false,
+            // #795 F6: veto configs plumbed (previously hardcoded in the drain
+            // loop); default to their parko-core Default() → byte-identical.
+            water_veto_config: WaterVetoConfig::default(),
+            commit_zone_config: CommitZoneCfg::default(),
+            // #795 F6: a producer-less armed gate is a permanent immobilizer;
+            // arming one requires the operator's explicit acknowledgment.
+            allow_scene_gate_without_producer: false,
         }
     }
 }
@@ -289,7 +325,91 @@ impl ParkoNodeConfig {
     pub fn object_gate_armed(&self) -> bool {
         self.object_rss_enabled && self.lidar_topic.is_some() && self.platform_profile.is_some()
     }
+
+    /// #795 F6 — the scene-veto gates that are ARMED **and will actually
+    /// immobilize**, in this build that ships no producers for their slots.
+    ///
+    /// Each such gate, with its slot never fed, fails closed to a STOP every tick
+    /// — a permanent immobilization. Occlusion additionally needs a
+    /// `platform_profile` (its RSS params) to arm at all: `occlusion_gate_enabled`
+    /// with no profile is a *dark* flag (the gate is skipped, no immobilization),
+    /// so it is NOT counted here — only a gate that will genuinely hold the ego at
+    /// zero. Water and commit-zone need no profile, so the flag alone arms them.
+    ///
+    /// Returned by name (fixed order occlusion → water → commit-zone) so the
+    /// startup guard can name exactly which gates are producer-less.
+    #[must_use]
+    pub fn producerless_armed_scene_gates(&self) -> Vec<&'static str> {
+        let mut armed = Vec::new();
+        if self.occlusion_gate_enabled && self.platform_profile.is_some() {
+            armed.push("occlusion");
+        }
+        if self.water_gate_enabled {
+            armed.push("water");
+        }
+        if self.commit_zone_gate_enabled {
+            armed.push("commit_zone");
+        }
+        armed
+    }
+
+    /// #795 F6 — fail-closed startup guard against SILENT permanent immobilization.
+    ///
+    /// A scene-veto gate armed with no producer feeding its slot fails closed to a
+    /// STOP forever. Rather than let the node come up and hold the ego at zero with
+    /// no diagnostic, REFUSE startup when any producer-less gate
+    /// ([`producerless_armed_scene_gates`](Self::producerless_armed_scene_gates)) is
+    /// armed — UNLESS the operator has explicitly acknowledged the immobilization
+    /// via `allow_scene_gate_without_producer` (a deliberate bring-up/immobilizer
+    /// test). Default config → no armed gates → `Ok`, so ordinary deployments are
+    /// unaffected. When a real producer for a gate lands, that gate drops out of
+    /// `producerless_armed_scene_gates` and no longer trips this guard.
+    ///
+    /// # Errors
+    /// Returns [`SceneGateStartupRefusal`] naming the armed-without-producer gates
+    /// when the acknowledgment is unset.
+    pub fn scene_gate_startup_check(&self) -> Result<(), SceneGateStartupRefusal> {
+        let armed = self.producerless_armed_scene_gates();
+        if armed.is_empty() || self.allow_scene_gate_without_producer {
+            Ok(())
+        } else {
+            SceneGateStartupRefusal::from_gates(&armed)
+        }
+    }
 }
+
+/// #795 F6 — a fail-closed startup refusal: one or more scene-veto gates are
+/// ARMED but have no producer, so the node would come up permanently immobilized.
+/// Names the offending gates so the operator can either configure a producer,
+/// disarm the gate, or (deliberately) acknowledge the immobilization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SceneGateStartupRefusal {
+    /// The armed-without-producer gate names (occlusion / water / commit_zone).
+    pub armed_gates: Vec<String>,
+}
+
+impl SceneGateStartupRefusal {
+    fn from_gates(gates: &[&str]) -> Result<(), Self> {
+        Err(Self {
+            armed_gates: gates.iter().map(|g| (*g).to_string()).collect(),
+        })
+    }
+}
+
+impl std::fmt::Display for SceneGateStartupRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "scene-veto gate(s) [{}] are ARMED but this build ships no producer for \
+             their slots — the node would come up PERMANENTLY IMMOBILIZED (fail-closed \
+             STOP every tick). Configure a producer, disarm the gate(s), or set \
+             PARKO_ALLOW_SCENE_GATE_WITHOUT_PRODUCER=1 to acknowledge the immobilization.",
+            self.armed_gates.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for SceneGateStartupRefusal {}
 
 /// #795 F10 — classification of a boolean env-flag value. `1`/`true` → enabled;
 /// `0`/`false`/empty → disabled; anything ELSE (`yes`, `on`, a typo) →
@@ -360,6 +480,96 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// #795 F6 — the default (all gates disarmed) has nothing producer-less and
+    /// the startup guard passes: ordinary deployments are unaffected.
+    #[test]
+    fn scene_gate_guard_passes_by_default() {
+        let cfg = ParkoNodeConfig::default();
+        assert!(cfg.producerless_armed_scene_gates().is_empty());
+        assert!(cfg.scene_gate_startup_check().is_ok());
+        // The veto configs default to parko-core Default() (byte-identical to the
+        // prior drain-loop hardcode). WaterVetoConfig/CommitZoneCfg don't derive
+        // PartialEq, so compare their fields.
+        let w = WaterVetoConfig::default();
+        assert!((cfg.water_veto_config.max_exit_distance_m - w.max_exit_distance_m).abs() < 1e-9);
+        assert!((cfg.water_veto_config.max_puddle_extent_m - w.max_puddle_extent_m).abs() < 1e-9);
+        let cz = CommitZoneCfg::default();
+        assert!((cfg.commit_zone_config.look_ahead_m - cz.look_ahead_m).abs() < 1e-9);
+        assert!((cfg.commit_zone_config.vehicle_length_m - cz.vehicle_length_m).abs() < 1e-9);
+        assert!((cfg.commit_zone_config.exit_margin_m - cz.exit_margin_m).abs() < 1e-9);
+        assert!(
+            (cfg.commit_zone_config.clearance_time_margin_s - cz.clearance_time_margin_s).abs()
+                < 1e-9
+        );
+        assert!(!cfg.allow_scene_gate_without_producer);
+    }
+
+    /// #795 F6 — arming water or commit-zone (no profile needed) makes them
+    /// producer-less-armed and REFUSES startup; the refusal names the gate.
+    #[test]
+    fn arming_water_or_commit_zone_refuses_startup() {
+        for (field, name) in [("water", "water"), ("commit_zone", "commit_zone")] {
+            let cfg = ParkoNodeConfig {
+                water_gate_enabled: field == "water",
+                commit_zone_gate_enabled: field == "commit_zone",
+                ..ParkoNodeConfig::default()
+            };
+            assert_eq!(cfg.producerless_armed_scene_gates(), vec![name]);
+            let err = cfg
+                .scene_gate_startup_check()
+                .expect_err("an armed producer-less gate must refuse startup");
+            assert_eq!(err.armed_gates, vec![name.to_string()]);
+            assert!(err.to_string().contains(name));
+        }
+    }
+
+    /// #795 F6 — the occlusion gate only immobilizes when it actually ARMS, which
+    /// needs a platform_profile (its RSS params). The flag WITHOUT a profile is a
+    /// dark flag (gate skipped) → not counted, guard passes; WITH a profile it is
+    /// producer-less-armed → refused.
+    #[test]
+    fn occlusion_counts_only_when_it_actually_arms() {
+        let dark = ParkoNodeConfig {
+            occlusion_gate_enabled: true,
+            platform_profile: None,
+            ..ParkoNodeConfig::default()
+        };
+        assert!(
+            dark.producerless_armed_scene_gates().is_empty(),
+            "occlusion flag with no profile does not arm → not an immobilizer"
+        );
+        assert!(dark.scene_gate_startup_check().is_ok());
+
+        let armed = ParkoNodeConfig {
+            occlusion_gate_enabled: true,
+            platform_profile: Some(CourierPlatformProfile::courier_reference()),
+            ..ParkoNodeConfig::default()
+        };
+        assert_eq!(armed.producerless_armed_scene_gates(), vec!["occlusion"]);
+        assert!(armed.scene_gate_startup_check().is_err());
+    }
+
+    /// #795 F6 — the explicit operator acknowledgment turns the refusal into an
+    /// (allowed, deliberate) immobilizer: the guard passes even with gates armed.
+    #[test]
+    fn acknowledgment_allows_producerless_immobilizer() {
+        let cfg = ParkoNodeConfig {
+            water_gate_enabled: true,
+            commit_zone_gate_enabled: true,
+            allow_scene_gate_without_producer: true,
+            ..ParkoNodeConfig::default()
+        };
+        // Still reported as producer-less (observability), but startup is allowed.
+        assert_eq!(
+            cfg.producerless_armed_scene_gates(),
+            vec!["water", "commit_zone"]
+        );
+        assert!(
+            cfg.scene_gate_startup_check().is_ok(),
+            "an acknowledged immobilizer may start"
+        );
     }
 
     #[test]

--- a/parko/crates/parko-ros2/src/node.rs
+++ b/parko/crates/parko-ros2/src/node.rs
@@ -42,9 +42,9 @@ use crate::taj_objects::{
     apply_object_rss_gate, courier_rss_params, object_snapshot_to_vanished_scene, ObjectSnapshot,
 };
 use crate::tick_pipeline::{current_time_ms, TickError};
-use parko_core::commit_zone::{CommitZoneCfg, CommitZoneScene};
+use parko_core::commit_zone::CommitZoneScene;
 use parko_core::rss::OcclusionScene;
-use parko_core::water::{WaterScene, WaterVetoConfig};
+use parko_core::water::WaterScene;
 use parko_kirra::clearance_delivery::DeliveryOutcome;
 
 /// Run the Parko ROS 2 node. Owns the r2r context for the lifetime of
@@ -515,8 +515,8 @@ where
             let occlusion_slot = drain_occlusion.lock().ok().and_then(|g| g.clone());
             let water_slot = drain_water.lock().ok().and_then(|g| g.clone());
             let commit_zone_slot = drain_commit_zone.lock().ok().and_then(|g| g.clone());
-            let water_cfg = WaterVetoConfig::default();
-            let commit_zone_cfg = CommitZoneCfg::default();
+            // #795 F6: the veto configs come from ParkoNodeConfig (plumbed) rather
+            // than a per-tick hardcoded `Default()`.
             let outcome = apply_scene_gates(
                 outcome,
                 &SceneGateChain {
@@ -524,10 +524,10 @@ where
                     occlusion: occlusion_slot.as_ref(),
                     water_armed: drain_water_armed,
                     water: water_slot.as_ref(),
-                    water_cfg: &water_cfg,
+                    water_cfg: &drain_config.water_veto_config,
                     commit_zone_armed: drain_commit_zone_armed,
                     commit_zone: commit_zone_slot.as_ref(),
-                    commit_zone_cfg: &commit_zone_cfg,
+                    commit_zone_cfg: &drain_config.commit_zone_config,
                     max_age_ms: drain_config.corridor_max_age_ms,
                     now_ms: current_time_ms(),
                 },

--- a/parko/crates/parko-ros2/src/scene_vetoes.rs
+++ b/parko/crates/parko-ros2/src/scene_vetoes.rs
@@ -102,6 +102,29 @@ fn already_stopped(outcome: &TickOutcome) -> bool {
 /// scene: `Absent` (or missing/stale when armed) caps at 0.0 (any motion
 /// stops), `KnownClear` never binds, `Limited` binds via
 /// `occlusion_limited_speed` (fail-closed to 0.0 on invalid inputs).
+///
+/// # Angular channel (#795 F8 — intended semantics)
+///
+/// The occlusion cap is an assured-clear-**distance** bound: it limits FORWARD
+/// PROGRESS, so it binds only the LINEAR channel (`linear_x_mps`) and leaves
+/// `angular_z_rads` untouched. This is DELIBERATE, not an oversight:
+/// - A pure in-place rotation (`linear ≈ 0`, `angular ≠ 0`) under an `Absent` /
+///   `Limited` scene PASSES this gate unchanged. Turning in place does not
+///   advance the ego into the unobserved region — it is the *creep-and-peek*
+///   primitive that lets the ego rotate to improve its own sightline before
+///   committing to forward motion. Zeroing it would deadlock that maneuver.
+/// - Any rotation with a nonzero turn RADIUS carries a nonzero `linear_x` and is
+///   therefore still bound by the clamp above (the arc's along-track speed is
+///   capped to the sightline).
+///
+/// CAVEAT (pending safety-owner decision, NOT silently assumed): a *swept*
+/// in-place rotation of a long/rectangular footprint can sweep the vehicle's
+/// extremities into an occluded conflict zone even at zero `linear_x`. Whether
+/// to additionally BOUND that swept-rotation case here — versus the stricter
+/// water / commit-zone gates, which zero BOTH channels — is a footprint-geometry
+/// safety decision left to the owner. Until decided, the linear-only binding
+/// documented above stands (this note exists so the choice is explicit, not
+/// implicit). See `docs/safety/PARKO_SCENE_VETO_SEMANTICS.md`.
 // SAFETY: SG1 | REQ: parko-ros2-occlusion-gate | TEST: occlusion_known_clear_passes,occlusion_limited_caps_overspeed,occlusion_limited_clamp_preserves_direction,occlusion_absent_scene_full_stops,occlusion_nonfinite_overspeed_full_stops,occlusion_limited_admits_slow_ego,occlusion_missing_scene_fails_closed,occlusion_stale_scene_fails_closed,already_stopped_outcome_passes_all_gates
 pub fn apply_occlusion_gate(
     outcome: TickOutcome,


### PR DESCRIPTION
Closes the remaining **code-only** #795 scene-veto follow-ups. (F3/F5/F7/F10 landed in #1118; F9 under #794.) The one remainder left open is "land a real lidar/map producer," which is genuine perception + hardware validation work.

## F6 (Medium) — armed-without-producer is no longer a *silent* permanent immobilization

This build ships **no producers** for the occlusion/water/commit-zone slots, so an armed gate fails closed to a STOP every tick, forever — fail-safe, but silently coming up immobilized with no diagnostic is a foot-gun.

- New pure, unit-tested `ParkoNodeConfig::scene_gate_startup_check` **refuses startup** (naming the offending gates) when a gate that would *actually* immobilize is armed, **unless** the operator explicitly acknowledges it via `PARKO_ALLOW_SCENE_GATE_WITHOUT_PRODUCER=1` (a deliberate bring-up / immobilizer test). Wired into the node binary's `async_main` with the same fail-closed-exit shape as the backend-select guard.
- Occlusion counts only when it *truly* arms (flag **and** `platform_profile`); a flag with no profile is a dark flag (gate skipped), not an immobilizer — so it does not trip the guard.
- The veto configs (`WaterVetoConfig` / `CommitZoneCfg`) are now carried on `ParkoNodeConfig` (`water_veto_config` / `commit_zone_config`) and threaded into the drain loop, instead of a per-tick hardcoded `Default()`. **Defaults unchanged → byte-identical.**

## F8 (Low-Med) — occlusion angular-channel semantics documented (not implicit)

The assured-clear-**distance** cap binds only the LINEAR channel. Documented as *intended*: a pure in-place rotation is the creep-and-peek primitive and passes; a turning arc carries `linear_x` and is still clamped. The **swept-rotation footprint** case (a long body sweeping into an occluded zone at zero `linear_x`) is flagged as a **pending safety-owner decision** — behavior is not changed. New `docs/safety/PARKO_SCENE_VETO_SEMANTICS.md`.

## F11 (Low) — comparator both-arms symmetry is no longer convention-only

`GovernorComparator::with_external_rss_gate` / `with_operator_waived` apply the RSS-feed declaration to **both** arms in one call, so the symmetry the per-arm builders require (a one-sided declaration is a permanent false divergence) can no longer drift.

## Verification (parko workspace)

- `cargo fmt --check` — clean
- `cargo test -p parko-ros2 --lib` — 253 pass (F6 config guard truth table + scene_vetoes)
- `cargo test -p parko-kirra --lib comparator::` — 28 pass (incl. F11 both-arms symmetry)

Note: the node-binary env read + startup-guard call are in the `#[cfg(feature = "ros2")]` binary (built only by the ros2 CI lane); the guard logic itself lives in the non-gated `config` module and is unit-tested in the default build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_