### PR TITLE
ci: sweep parko clippy debt + add a parko clippy lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -837,6 +837,39 @@ jobs:
           cargo test -p parko-core --features test-helpers
           cargo test -p parko-kirra --features verifier-sink
 
+  parko-clippy:
+    name: Parko Clippy (lint gate — no ROS, no ORT)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          components: clippy
+      - name: Clippy — parko workspace
+        # `parko/` is a SEPARATE workspace: the root `static-analysis` Clippy lane
+        # runs `cargo clippy --workspace` from the repo root, and `cargo clippy`
+        # NEVER crosses a workspace boundary — so it does not descend into parko.
+        # parko clippy debt was therefore caught by NO lane and silently
+        # accumulated on main (the root lane runs only on PRs, and never over
+        # parko at all). This lane closes that hole with the SAME invocation +
+        # flags the root lane uses, over `--manifest-path parko/Cargo.toml`.
+        #
+        # Runtime-FREE (like `parko-safety`, but MORE so): clippy is a
+        # compile-time check — it never dlopens the ONNX / OpenVINO / TensorRT
+        # native runtimes that the parko-onnx/openvino/tensorrt tests load at
+        # EXECUTION, so it can lint the whole graph (including those crates' test
+        # targets) with no runtime installed, and needs no `--exclude` list.
+        # Pinned toolchain (1.94.1) is inherited from rust-toolchain.toml exactly
+        # as the root lane, so the lint set matches byte-for-byte.
+        run: |
+          cargo clippy --manifest-path parko/Cargo.toml --workspace --all-targets -- \
+            -D warnings \
+            -W clippy::all \
+            -A clippy::module_name_repetitions \
+            -A clippy::must_use_candidate \
+            2>&1 | tee clippy-parko-report.txt
+
   parko-ros2-backends:
     name: Parko ros2 backend-selection lanes (build, no runtime)
     runs-on: ubuntu-latest

--- a/parko/crates/parko-ros2/src/taj_objects.rs
+++ b/parko/crates/parko-ros2/src/taj_objects.rs
@@ -313,10 +313,7 @@ mod tests {
             objects_to_agent_scene(&[], 1.0),
             AgentScene::KnownEmpty
         ));
-        assert!(matches!(
-            parko_kirra::compute_scene_rss(&objects_to_agent_scene(&[], 1.0), &params()).safe,
-            true
-        ));
+        assert!(parko_kirra::compute_scene_rss(&objects_to_agent_scene(&[], 1.0), &params()).safe);
     }
 
     #[test]

--- a/parko/crates/parko-tensorrt/tests/engine_cache_probe.rs
+++ b/parko/crates/parko-tensorrt/tests/engine_cache_probe.rs
@@ -36,8 +36,9 @@ use parko_tensorrt::{TrtBackend, TrtConfig};
 const MODEL: &str = "tests/data/mnist-12.onnx";
 const INPUT_NAME: &str = "Input3";
 const OUTPUT_NAME: &str = "Plus214_Output_0";
-/// MNIST fixture input is [1,1,28,28] (asserted in positive_probe.rs).
-const TOTAL: usize = 1 * 1 * 28 * 28;
+/// MNIST fixture input is [1,1,28,28] (asserted in positive_probe.rs); the
+/// batch and channel dims are 1, so the element count is the spatial 28*28.
+const TOTAL: usize = 28 * 28;
 
 fn require_ep() -> bool {
     std::env::var("PARKO_TRT_REQUIRE_EP")
@@ -95,7 +96,7 @@ fn engine_cache_fingerprint(dir: &Path) -> Option<(String, u64, u64)> {
     let mut best: Option<(std::path::PathBuf, u64)> = None;
     for entry in std::fs::read_dir(dir).ok()?.flatten() {
         if let Ok(md) = entry.metadata() {
-            if md.is_file() && best.as_ref().map_or(true, |(_, b)| md.len() > *b) {
+            if md.is_file() && best.as_ref().is_none_or(|(_, b)| md.len() > *b) {
                 best = Some((entry.path(), md.len()));
             }
         }

--- a/parko/crates/parko-tensorrt/tests/positive_probe.rs
+++ b/parko/crates/parko-tensorrt/tests/positive_probe.rs
@@ -15,6 +15,7 @@
 //! environments the fail-closed test targets:
 //!   * the GPU-less sandbox / default workspace job (no ORT dylib)       → skip
 //!   * the parko-tensorrt CI job's CPU-only ORT (`with_config` Errs)     → skip
+//!
 //! It only ASSERTS where a TensorRT-enabled ORT is present (the Jetson). The
 //! existing CI fail-closed job runs `--test fail_closed` specifically, so adding
 //! this file does not change CI behaviour; run it on hardware with:

--- a/parko/crates/parko-tensorrt/tests/tf32_probe.rs
+++ b/parko/crates/parko-tensorrt/tests/tf32_probe.rs
@@ -16,6 +16,7 @@
 //!   3. compares: reports the measured per-logit drift, and ASSERTS the governed
 //!      DECISION (argmax) is unchanged — a TF32-induced decision flip is a safety
 //!      failure.
+//!
 //! Each process uses its OWN engine-cache dir so a default-TF32 engine is never
 //! reused under the override.
 //!


### PR DESCRIPTION
## Why

The root `static-analysis` (ISO 26262) Clippy lane runs `cargo clippy --workspace` from the repo root — and `cargo clippy` **never crosses a workspace boundary**, so it never descends into the separate `parko/` workspace. parko clippy debt was therefore caught by **no CI lane** and silently accumulated on main. (It surfaced when running the exact CI clippy invocation over parko locally.) The root workspace itself is already clean.

## What

**1. Sweep the outstanding parko debt** — all mechanical, no behaviour change:

| File | Lint | Fix |
|------|------|-----|
| `parko-tensorrt/tests/engine_cache_probe.rs` | `identity_op` | `1 * 1 * 28 * 28` → `28 * 28` (unit batch/channel dims kept in the doc-comment) |
| `parko-tensorrt/tests/engine_cache_probe.rs` | `unnecessary_map_or` | `map_or(true, …)` → `is_none_or(…)` |
| `parko-tensorrt/tests/positive_probe.rs` | `doc_lazy_continuation` | blank `//!` before a prose paragraph following a doc list |
| `parko-tensorrt/tests/tf32_probe.rs` | `doc_lazy_continuation` | same |
| `parko-ros2/src/taj_objects.rs` | `redundant_pattern_matching` | `matches!(expr, true)` → assert the bool directly |

**2. Add a dedicated `parko-clippy` CI job** so the debt can't silently re-accumulate. It closes the coverage hole with the **same invocation + flags** the root lane uses, over `--manifest-path parko/Cargo.toml`. It's runtime-free: clippy is a compile-time check and never dlopens the ONNX/OpenVINO/TensorRT native runtimes, so it lints the whole parko graph (including those crates' test targets) with no runtime installed and needs no `--exclude` list. The pinned toolchain (1.94.1) is inherited from `rust-toolchain.toml`, so the lint set matches the root lane byte-for-byte.

This mirrors the L1 precedent (fmt debt sweep **+** blocking fmt gate).

## Verification

- `cargo clippy --manifest-path parko/Cargo.toml --workspace --all-targets -- -D warnings -W clippy::all -A clippy::module_name_repetitions -A clippy::must_use_candidate` → clean (exit 0).
- Root workspace clippy (same flags) → already clean.
- `cargo fmt --check --all --manifest-path parko/Cargo.toml` → clean.
- CI YAML parses; new job present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_