### PR TITLE
Rabbit W1: opt-in wake word ("hello rabbit" / "hey rabbit" / "yo rabbit")

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1207,6 +1207,13 @@ jobs:
           # read; stale/degraded/lockout → "still checking myself over"), and the
           # OTA voice-matcher precedence. See docs/rabbit/RABBIT_VOICE_LINES.md.
           python3 robot/rabbit_voice_test.py
+          # Wake-word logic (W1, pure, no audio/GPIO): phrase parsing, the
+          # ordered-adjacent matcher with long-token-only edit tolerance
+          # ("hallo rabbits" wakes, a stray "yo"/lookalike never does), the
+          # RMS gate math, the fail-OPEN nap/mute state gate, and the
+          # rabbit_wake control matcher incl. non-overlap with the OTA/diag/
+          # drive matchers. See docs/hardware/RABBIT_AUDIO_STACK.md §3b.
+          python3 robot/wake_word_test.py
           # Diagnostics framework (pure, no hardware): schema v1 shape/ordering,
           # worst-of aggregation + exit codes, module isolation (raise/timeout →
           # UNKNOWN for that module only), the deterministic "run diagnostics"

--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -128,6 +128,53 @@ Concrete, replayable setup for this R2: `R2_VOICE_AUDIO_SETUP.md`.
 > Losing the button = you can't talk to it; losing the e-stop = you can't stop it.
 > Different circuits, different criticality — never wire one as the other.
 
+## 3b. Wake word (W1, opt-in) — "hello rabbit" as a third trigger source
+
+PTT **stays the recommended default**; the wake word is an opt-in *trigger
+producer* honoring the same one-newline contract, so it drops in with zero
+change to the pipeline:
+
+```bash
+python3 robot/wake_word.py | ./robot/rabbit_voice.sh                              # wake word only
+{ python3 robot/ptt_button.py & python3 robot/wake_word.py; } | ./robot/rabbit_voice.sh   # both
+```
+
+As a service: `kirra-rabbit-voice.service` (staged by `install_robot_units.sh`,
+enable deliberately). Master gate `KIRRA_WAKE_ENABLED` in `robot.env`; the
+listener exits cleanly when unset. Full env set: `robot/install/rabbit.env.example`.
+
+**Detection** (no LLM anywhere): `arecord` raw stream → in-memory ring buffer →
+**RMS energy pre-gate** (a silent room runs zero inference) → whisper.cpp
+**tiny** (`KIRRA_WAKE_STT_CMD` — a second, smaller model than the turn STT) on a
+~2 s tmpfs window → a **pure token matcher** (ordered-adjacent, one-edit
+tolerance on long tokens only: "hallo rabbits" wakes; a stray "yo" or "hey the
+rabbit robot" never does; host-tested in `robot/wake_word_test.py`). On a hit:
+ack cue ("Yes?" through TTS by default — a **false fire is heard, not silent**),
+the mic is **released** for `KIRRA_WAKE_HOLDOFF_S` so the turn recorder can
+claim the device, then a cooldown.
+
+**How this answers §3's three objections** (which still stand for *naive*
+always-listening):
+- *Bounds when the LLM runs* — the LLM still runs at most once per wake, exactly
+  as once per press; detection is energy-gated tiny-whisper + a regex-class
+  matcher, and idle ≈ zero inference.
+- *Mishears* — a false wake is exactly the phantom-PTT-press class (one bounded
+  clip → garbage transcript → no intent → no motion), made audible by the ack
+  cue. The wake word adds **zero actuation authority**.
+- *Hot mic* — transcribe-and-discard: fixed in-memory window, tmpfs wav deleted
+  every cycle, no audio persisted, no transcripts logged (only wake hits).
+  Operator controls: **"rabbit, go to sleep"** (nap, `KIRRA_WAKE_NAP_MIN`) /
+  **"stop listening"** (mute) — deterministic matchers in `rabbit_wake.py`,
+  never LLM-decided; while suspended the capture process is closed entirely.
+  Optional `KIRRA_WAKE_LED_PIN` lights while the mic is open. Note the
+  asymmetry: a muted listener can't hear "start listening" — resume via the
+  button/Enter or the nap timer.
+
+Before enabling on battery, measure the duty-cycled tiny.en cost (§5 pattern,
+`tegrastats` A/B with the listener on/off). If it's too hot, the recorded
+fallback is swapping the producer for a dedicated wake engine (openWakeWord) —
+the trigger contract means that changes one script and nothing else.
+
 ---
 
 ## 4. 🔴 Audio from a systemd service (read this before enabling the units)

--- a/docs/rabbit/RABBIT_VOICE_LINES.md
+++ b/docs/rabbit/RABBIT_VOICE_LINES.md
@@ -74,6 +74,22 @@ counts + at most three plain issue sentences, never paths or details.
 | G2 | Self-check requested, problems found | **LIVE** same path | "Diagnostics complete. 1 problem found and 2 warnings. The devices module has a problem: motor serial. …" |
 | G3 | The diagnostics runner itself errored | **LIVE** `rabbit_diag.run_and_summarize` fallback | "I couldn't complete my self-check — the diagnostics runner hit an internal error. Try kirra doctor from a terminal." |
 
+### W. Wake word (W1 — "hello rabbit" / "hey rabbit" / "yo rabbit")
+
+The wake ack is deliberately SHORT (it gates the turn's 4 s record window —
+a long line would eat the operator's speaking slot), and it fires on EVERY
+wake so a false fire is heard, never silent. The nap/mute confirmations must
+state the resume asymmetry: a muted listener cannot hear "start listening" —
+the button (or the nap timer) is the way back.
+
+| # | Situation | Wiring | Line |
+|---|---|---|---|
+| W1 | Wake phrase heard, turn window opening | **LIVE** `wake_word.py` `_ack` (`KIRRA_WAKE_ACK_CMD`, else TTS) | "Yes?" |
+| W2 | "Rabbit, go to sleep" (nap `KIRRA_WAKE_NAP_MIN` minutes) | **LIVE** `rabbit_wake.handle` | "Going quiet{name} — I'll stop listening for about 30 minutes. The button still works if you need me." |
+| W3 | "Stop listening" (mute until explicitly resumed) | **LIVE** `rabbit_wake.handle` | "Ears off{name}. I won't listen for my name until you press the button and ask me to start listening again." |
+| W4 | "Start listening" (via PTT/Enter — the muted listener can't hear it) | **LIVE** `rabbit_wake.handle` | "I'm listening again{name}." |
+| W5 | Wake control state file unwritable | **LIVE** `rabbit_wake.handle` fallback | "I couldn't reach my wake control — the listening state is unchanged. Check the wake state file from a terminal." |
+
 ### B. Driving (you gave a command)
 
 | # | Trigger | Status | Line |

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -35,7 +35,8 @@ echo "== 1. Rabbit scripts -> ${OPT}/robot =="
 sudo install -d -m 0755 "${OPT}/robot"
 for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabbit_boot.py \
          rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py \
-         ros_env.sh kirra_voice_doctor.sh kirra_doctor.py rabbit_diag.py; do
+         ros_env.sh kirra_voice_doctor.sh kirra_doctor.py rabbit_diag.py \
+         wake_word.py rabbit_wake.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"
@@ -52,6 +53,7 @@ fi
 # ---- 2. render + install the units -----------------------------------------
 echo "== 2. units -> /etc/systemd/system =="
 for u in kirra-ros-stack.service kirra-rabbit-watch.service kirra-rabbit-greet.service \
+         kirra-rabbit-voice.service \
          kirra-ota-check.service kirra-ota-check.timer \
          kirra-doctor.service kirra-doctor.timer; do
   [[ -f "${UNITS}/${u}" ]] || { echo "❌ missing ${UNITS}/${u}"; exit 1; }
@@ -69,3 +71,5 @@ echo
 echo "  validate then enable, one at a time:"
 echo "    sudo systemctl start kirra-ros-stack   && journalctl -u kirra-ros-stack -f"
 echo "    sudo systemctl start kirra-rabbit-watch  && journalctl -u kirra-rabbit-watch -f"
+echo "    sudo systemctl start kirra-rabbit-voice  && journalctl -u kirra-rabbit-voice -f"
+echo "      (wake word is OPT-IN: also set KIRRA_WAKE_ENABLED=1 + KIRRA_WAKE_STT_CMD in robot.env)"

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -18,6 +18,27 @@ KIRRA_TTS_CMD="./speak.sh"
 # Bounded push-to-talk recorder (the -d bound = no open mic). WAV path appended.
 KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
 
+# ── Wake word (W1, OPT-IN — off by default; PTT stays the recommended default) ─
+# "hello rabbit" / "hey rabbit" / "yo rabbit" as a hands-free trigger. It is a
+# MIC TRIGGER with zero actuation authority (a false fire dead-ends at the
+# fenced /intent door, exactly like a phantom PTT press) and is transcribe-and-
+# discard (tmpfs, no audio persisted, no transcripts logged). Voice controls:
+# "rabbit, go to sleep" (nap) / "stop listening" (mute; resume needs the button).
+#KIRRA_WAKE_ENABLED=1
+# REQUIRED when enabled: a SECOND, TINY whisper model for the always-on listener
+# (keep KIRRA_STT_CMD on base.en for turn quality; tiny.en keeps idle CPU low).
+#KIRRA_WAKE_STT_CMD="whisper-cli -m models/ggml-tiny.en.bin -np -nt -f"
+# Comma-separated phrases. Matching is ordered-adjacent tokens with a 1-edit
+# tolerance on long tokens only ("hallo rabbits" wakes; a stray "yo" never does).
+#KIRRA_WAKE_PHRASES="hello rabbit,hey rabbit,yo rabbit"
+#KIRRA_WAKE_RMS_FLOOR=300        # energy pre-gate: a silent room runs ZERO inference
+#KIRRA_WAKE_COOLDOWN_S=2         # refractory period between wakes
+#KIRRA_WAKE_HOLDOFF_S=10         # mic released this long per wake (>= record -d + ~6)
+#KIRRA_WAKE_ACK_CMD=             # cue on wake; default speaks "Yes?" via KIRRA_TTS_CMD
+#KIRRA_WAKE_NAP_MIN=30           # "go to sleep" duration (minutes)
+#KIRRA_WAKE_STATE_FILE=/tmp/kirra_rabbit_wake.state
+#KIRRA_WAKE_LED_PIN=             # optional BOARD pin lit while the wake mic is open
+
 # ── The persona LLM (local, offline) ─────────────────────────────────────────
 # Swapping models is config-only (no rebuild, no safety re-review — the checker
 # is model-agnostic): `ollama pull <model>`, change KIRRA_RABBIT_MODEL, restart the

--- a/robot/install/systemd/kirra-rabbit-voice.service
+++ b/robot/install/systemd/kirra-rabbit-voice.service
@@ -1,0 +1,54 @@
+# kirra-rabbit-voice.service — the Rabbit VOICE LISTENER as a service (W1).
+#
+# Runs the wake-word trigger piped into the conversation front-end:
+#   wake_word.py | rabbit_voice.sh → rabbit_converse.py
+# This is the unit that makes "hello rabbit / hey rabbit / yo rabbit" work
+# hands-free — without it (or a terminal running the same pipeline) NOTHING
+# on the robot listens, button or not.
+#
+# 🔴 SAFETY: the wake word is a MICROPHONE trigger with zero actuation
+# authority — a (false) wake records ONE bounded clip whose transcript enters
+# the loop only through the fenced mick /intent door; a mishear dead-ends in
+# the intent parser (no intent, no motion). It is NOT the e-stop.
+#
+# OPT-IN: wake_word.py exits 0 immediately unless KIRRA_WAKE_ENABLED=1 in
+# /etc/kirra/robot.env (Restart=on-failure means the unit then just goes
+# inactive — enabling the unit without enabling the env flag is a no-op).
+# KIRRA_WAKE_STT_CMD (whisper tiny) is REQUIRED when enabled.
+#
+# PRIVACY: transcribe-and-discard (tmpfs, no audio persisted, no transcripts
+# logged); "rabbit, go to sleep" / "stop listening" suspend it by voice;
+# optional KIRRA_WAKE_LED_PIN lights while the mic is open.
+#
+# ⚠ AUDIO-FROM-A-SYSTEM-SERVICE caveat (same as kirra-rabbit-watch): use
+# ALSA-DIRECT record/STT/TTS commands and put the rendered User in the
+# `audio` group; a Pulse/PipeWire-based command may have no session sink.
+#
+# ⚠ NOT YET HARDWARE-VALIDATED as a service. Enable deliberately:
+# `sudo systemctl enable --now kirra-rabbit-voice`. See R2_AUTOSTART_CHECKLIST.md.
+#
+# User= is rendered by the installer to the invoking user (needs `audio`,
+# and `gpio` if KIRRA_WAKE_LED_PIN is set).
+
+[Unit]
+Description=KIRRA Rabbit voice listener (wake word -> bounded turn -> fenced intent door)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+# Talks to mick/verifier/Ollama but is fail-soft per turn — no hard dependency.
+After=network-online.target kirra.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=__KIRRA_ROBOT_USER__
+EnvironmentFile=/etc/kirra/robot.env
+WorkingDirectory=/opt/kirra/robot
+# pipefail so a dead listener fails the pipeline (and vice versa); exec'd bash
+# stays the main PID and SIGTERM tears both halves down.
+ExecStart=/bin/bash -o pipefail -c 'python3 /opt/kirra/robot/wake_word.py | /opt/kirra/robot/rabbit_voice.sh'
+# on-failure (NOT always): a disabled listener (KIRRA_WAKE_ENABLED unset)
+# exits 0 and the unit rests inactive instead of restart-looping.
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/robot/kirra_voice_doctor.sh
+++ b/robot/kirra_voice_doctor.sh
@@ -103,6 +103,55 @@ else
   warn "Jetson.GPIO not importable (PTT button off; Enter-key still works)"; fix "pip install >=2.1.12 from GitHub on Super boards — §5"
 fi
 
+# 8. wake word (W1, opt-in) — only checked when enabled; off is a clean ok.
+case "$(printf '%s' "${KIRRA_WAKE_ENABLED:-}" | tr '[:upper:]' '[:lower:]')" in
+  1|true|yes|on)
+    ok "wake word ENABLED (KIRRA_WAKE_ENABLED)"
+    # 8a. the wake STT engine (a SECOND, tiny model — not the turn STT).
+    if [ -n "${KIRRA_WAKE_STT_CMD:-}" ]; then
+      wb="$(first_tok "$KIRRA_WAKE_STT_CMD")"
+      command -v "$wb" >/dev/null 2>&1 && ok "wake STT binary: $wb" || { bad "wake STT binary not found: $wb"; fix "build whisper.cpp; use the TINY model for the listener"; }
+      wm="$(opt_val -m "$KIRRA_WAKE_STT_CMD")"
+      [ -z "$wm" ] || { [ -f "$wm" ] && ok "wake STT model: $wm" || { bad "wake STT model missing: $wm"; fix "download-ggml-model.sh tiny.en"; }; }
+    else
+      bad "KIRRA_WAKE_ENABLED is on but KIRRA_WAKE_STT_CMD unset"; fix 'set it, e.g. "whisper-cli -m models/ggml-tiny.en.bin -np -nt -f"'
+    fi
+    # 8b. phrases parse to something.
+    if python3 -c "
+import sys; sys.path.insert(0, '$(dirname "$0")')
+from wake_word import parse_phrases, DEFAULT_PHRASES
+import os
+sys.exit(0 if parse_phrases(os.environ.get('KIRRA_WAKE_PHRASES', DEFAULT_PHRASES)) else 1)" 2>/dev/null; then
+      ok "wake phrases parse (${KIRRA_WAKE_PHRASES:-hello rabbit,hey rabbit,yo rabbit})"
+    else
+      bad "KIRRA_WAKE_PHRASES parses to nothing"; fix "comma-separated phrases, e.g. \"hello rabbit,hey rabbit\""
+    fi
+    # 8c. hold-off must cover the turn recorder's -d bound (mic contention:
+    # the listener releases the device for holdoff; a short holdoff steals it
+    # back mid-turn and the turn recorder fails SILENTLY).
+    rd="$(opt_val -d "${KIRRA_RECORD_CMD:-arecord -d 4}")"
+    ho="${KIRRA_WAKE_HOLDOFF_S:-10}"
+    if [ -n "$rd" ] && awk "BEGIN{exit !($ho >= $rd + 3)}" 2>/dev/null; then
+      ok "wake holdoff ${ho}s covers the ${rd}s turn recording (+STT/TTS)"
+    else
+      warn "KIRRA_WAKE_HOLDOFF_S=${ho} may not cover the ${rd:-?}s turn recording + STT + TTS"; fix "set KIRRA_WAKE_HOLDOFF_S >= record -d + ~6"
+    fi
+    # 8d. ack cue: false fires must be AUDIBLE, not silent.
+    if [ -n "${KIRRA_WAKE_ACK_CMD:-}" ] || [ -n "${KIRRA_TTS_CMD:-}" ]; then
+      ok "wake ack cue available (KIRRA_WAKE_ACK_CMD or TTS \"Yes?\")"
+    else
+      warn "no KIRRA_WAKE_ACK_CMD and no KIRRA_TTS_CMD — wakes (incl. FALSE fires) will be silent"
+    fi
+    # 8e. state-file directory writable (nap/mute controls).
+    wsf="${KIRRA_WAKE_STATE_FILE:-/tmp/kirra_rabbit_wake.state}"
+    wsd="$(dirname "$wsf")"
+    [ -d "$wsd" ] && [ -w "$wsd" ] && ok "wake state dir writable: $wsd" || { warn "wake state dir not writable: $wsd (nap/mute controls will no-op)"; fix "set KIRRA_WAKE_STATE_FILE to a writable path"; }
+    ;;
+  *)
+    ok "wake word off (KIRRA_WAKE_ENABLED unset — PTT/Enter are the triggers)"
+    ;;
+esac
+
 # summary + exit code
 if [ "$QUIET" = 1 ]; then
   [ "$FAIL" -eq 0 ] && echo "OK" || echo "FAIL: $FIRST_FAIL"

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -49,6 +49,7 @@ from rabbit_ask import (  # noqa: E402
 )
 import rabbit_diag  # noqa: E402 — deterministic self-check voice command (read-only)
 import rabbit_ota  # noqa: E402 — deterministic OTA voice commands (NOT the movement door)
+import rabbit_wake  # noqa: E402 — deterministic wake-listener controls (state file only)
 from rabbit_persona import name_slot, operator_name  # noqa: E402
 
 MAX_TURNS = 10  # rolling conversation memory (user+assistant pairs kept)
@@ -181,6 +182,18 @@ def handle_turn(history, utterance):
         speak(diag_reply)
         history.append({"role": "user", "content": utterance})
         history.append({"role": "assistant", "content": diag_reply})
+        del history[: max(0, len(history) - 2 * MAX_TURNS)]
+        return
+
+    # "Go to sleep" / "stop listening" / "start listening" — deterministic
+    # wake-listener controls (W1). Whether the ambient mic is open must never
+    # depend on model inference; rabbit_wake only writes the local state file
+    # wake_word.py polls (no /intent, no motion).
+    wake_reply = rabbit_wake.handle(utterance)
+    if wake_reply is not None:
+        speak(wake_reply)
+        history.append({"role": "user", "content": utterance})
+        history.append({"role": "assistant", "content": wake_reply})
         del history[: max(0, len(history) - 2 * MAX_TURNS)]
         return
 

--- a/robot/rabbit_wake.py
+++ b/robot/rabbit_wake.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""rabbit_wake.py — DETERMINISTIC wake-listener controls (Channel A).
+
+"Rabbit, go to sleep" / "stop listening" / "start listening" → write the wake
+control file `robot/wake_word.py` polls, and speak a confirmation. Deterministic
+like rabbit_ota / rabbit_diag: a regex matcher, NO LLM inference — whether the
+robot's ambient microphone is open must never depend on a model's mood, and the
+LLM must never be able to 'decide' to reopen it. Matched BEFORE the LLM/movement
+path in rabbit_converse.handle_turn.
+
+🔴 Channel A only: this writes ONE local state file. No /intent, no motion, no
+authority — and note the asymmetry: MUTING always works via any trigger (PTT or
+wake), but a muted wake listener cannot hear "start listening" (its mic is
+closed) — resuming needs the PTT button / Enter, or the nap timer expiring.
+The confirmations say so (voice lines W2–W4).
+
+State file (KIRRA_WAKE_STATE_FILE, default /tmp/kirra_rabbit_wake.state):
+  {"mode": "awake" | "nap" | "mute", "until_ms": N, "set_at_ms": N}
+wake_word.py fails OPEN on an absent/corrupt file (listening) — safe because a
+wake trigger carries no actuation authority; it dead-ends at the fence.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from rabbit_persona import name_slot  # noqa: E402 — stdlib-only helper
+
+STATE_FILE = os.environ.get("KIRRA_WAKE_STATE_FILE", "/tmp/kirra_rabbit_wake.state")
+NAP_MIN = float(os.environ.get("KIRRA_WAKE_NAP_MIN", "30"))
+
+# Movement-safe by construction: every alternative requires a listening/sleep
+# noun or an explicit ear reference — none overlaps the OTA matcher ("check for
+# updates"), the diagnostics matcher ("check yourself"), or a drive utterance
+# ("stop" alone is NOT matched; it must be "stop listening").
+_NAP_RE = re.compile(
+    r"\b(go\s+to\s+sleep|take\s+a\s+nap|sleep\s+for\s+a\s+(while|bit))\b",
+    re.IGNORECASE,
+)
+_MUTE_RE = re.compile(
+    r"\b(stop\s+listening|mute\s+(your(self)?\s+)?(ears?|mic(rophone)?)"
+    r"|turn\s+off\s+(the\s+)?(wake\s+word|listening))\b",
+    re.IGNORECASE,
+)
+_RESUME_RE = re.compile(
+    r"\b(start\s+listening|listen\s+again|wake\s+word\s+on"
+    r"|unmute\s+(your(self)?\s+)?(ears?|mic(rophone)?))\b",
+    re.IGNORECASE,
+)
+
+
+def classify(utterance: str | None) -> str | None:
+    """Pure matcher: 'nap' | 'mute' | 'resume' | None. Mute wins over nap when
+    both appear (the more conservative state)."""
+    u = utterance or ""
+    if _MUTE_RE.search(u):
+        return "mute"
+    if _NAP_RE.search(u):
+        return "nap"
+    if _RESUME_RE.search(u):
+        return "resume"
+    return None
+
+
+def state_for(action: str, now_ms: int, nap_min: float = NAP_MIN) -> dict:
+    """Pure state builder for a classified action."""
+    if action == "nap":
+        return {"mode": "nap", "until_ms": now_ms + int(nap_min * 60_000),
+                "set_at_ms": now_ms}
+    if action == "mute":
+        return {"mode": "mute", "until_ms": 0, "set_at_ms": now_ms}
+    return {"mode": "awake", "until_ms": 0, "set_at_ms": now_ms}
+
+
+def reply_for(action: str, nap_min: float = NAP_MIN) -> str:
+    """The spoken confirmation (voice lines W2–W4)."""
+    if action == "nap":
+        mins = int(nap_min)
+        return (f"Going quiet{name_slot()} — I'll stop listening for about "
+                f"{mins} minutes. The button still works if you need me.")
+    if action == "mute":
+        return (f"Ears off{name_slot()}. I won't listen for my name until you "
+                "press the button and ask me to start listening again.")
+    return f"I'm listening again{name_slot()}."
+
+
+def _write_state(state: dict) -> bool:
+    try:
+        tmp = STATE_FILE + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(state, f)
+        os.replace(tmp, STATE_FILE)
+        return True
+    except OSError:
+        return False
+
+
+def handle(utterance: str | None) -> str | None:
+    """rabbit_ota.handle contract: the spoken reply, or None if not a wake
+    control (the turn falls through to the next matcher / the LLM router)."""
+    action = classify(utterance)
+    if action is None:
+        return None
+    if not _write_state(state_for(action, int(time.time() * 1000))):
+        return ("I couldn't reach my wake control — the listening state is "
+                "unchanged. Check the wake state file from a terminal.")
+    return reply_for(action)
+
+
+if __name__ == "__main__":  # manual poke: python3 rabbit_wake.py "go to sleep"
+    print(handle(" ".join(sys.argv[1:])) or "(not a wake control)")

--- a/robot/wake_word.py
+++ b/robot/wake_word.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""wake_word.py — an opt-in wake-word TRIGGER for the Rabbit voice loop (W1).
+
+A third trigger producer honoring the ONE trigger contract (ptt_button.py:
+exactly ONE newline on stdout per trigger), so:
+
+    python3 robot/wake_word.py | ./robot/rabbit_voice.sh
+
+makes "hello rabbit" (or "hey rabbit" / "yo rabbit") = the Enter key. ZERO
+change to rabbit_voice.sh / rabbit_converse.py / mick / Occy / the checker:
+after the trigger fires, everything is the existing pipeline — the bounded
+KIRRA_RECORD_CMD clip, STT, the deterministic matchers, at most the fenced
+text-to-the-door POST.
+
+🔴 SAFETY — WHAT A WAKE WORD IS (and is NOT), same banner as the button:
+  * It is a MICROPHONE trigger. A false fire is exactly the phantom-PTT-press
+    class (already documented for the floating Orin pin): one bounded clip,
+    an empty/garbage transcript, no intent latched, NO motion. It adds no
+    actuation authority and cannot bypass the checker.
+  * It is NOT the e-stop (separate hardware kill — R2_UNTETHERED_BRINGUP.md §3).
+
+DETECTION (no LLM anywhere in this file):
+  arecord raw stream → in-memory ring buffer → RMS energy pre-gate (a silent
+  room runs ZERO inference) → whisper.cpp tiny (KIRRA_WAKE_STT_CMD) on a ~2 s
+  window in tmpfs → a PURE token matcher (ordered-adjacent tokens with a small
+  edit tolerance on long tokens only — "hallo rabbits" wakes, a stray "yo"
+  never does). Matched → newline trigger + ack cue + mic released for the
+  hold-off window (rabbit_voice.sh needs the device) + cooldown.
+
+PRIVACY (the RABBIT_AUDIO_STACK.md §3 objection, answered):
+  transcribe-and-discard — fixed in-memory window, tmpfs wav deleted every
+  cycle, NO audio persisted, NO transcript logged (only wake HITS are logged).
+  Everything stays on the robot (whisper.cpp is local). Operator controls:
+  "rabbit, go to sleep" / "stop listening" (rabbit_wake.py writes the state
+  file this listener polls), and an optional LED lit while the mic is open.
+
+STDOUT DISCIPLINE (ptt_button.py's rule): ONLY trigger newlines touch stdout;
+every log goes to STDERR.
+
+Env (robot/install/rabbit.env.example has the annotated set):
+  KIRRA_WAKE_ENABLED      master gate; not truthy → exit 0 immediately (unit stays off)
+  KIRRA_WAKE_STT_CMD      REQUIRED when enabled — whisper-cli + a TINY model;
+                          wav path appended as the last arg (house convention)
+  KIRRA_WAKE_PHRASES      comma-separated, default "hello rabbit,hey rabbit,yo rabbit"
+  KIRRA_WAKE_RECORD_CMD   raw-stream capture, default "arecord -f S16_LE -r 16000 -c 1 -t raw"
+  KIRRA_WAKE_RMS_FLOOR    energy gate (default 300; 16-bit full scale = 32767)
+  KIRRA_WAKE_COOLDOWN_S   refractory period between wakes (default 2)
+  KIRRA_WAKE_HOLDOFF_S    mic released this long after a trigger (default 10;
+                          must cover KIRRA_RECORD_CMD's -d bound + STT + TTS)
+  KIRRA_WAKE_ACK_CMD      cue command on wake (no stdin). Default: speak "Yes?"
+                          via KIRRA_TTS_CMD if set, else a stderr note.
+  KIRRA_WAKE_STATE_FILE   nap/mute control file (default /tmp/kirra_rabbit_wake.state)
+  KIRRA_WAKE_LED_PIN      optional BOARD output pin lit while the mic is open
+"""
+from __future__ import annotations
+
+import array
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+import wave
+
+# ---------------------------------------------------------------------------
+# Pure logic (host-tested in robot/wake_word_test.py — no audio, no GPIO)
+# ---------------------------------------------------------------------------
+
+DEFAULT_PHRASES = "hello rabbit,hey rabbit,yo rabbit"
+
+# Whisper decorates non-speech as bracketed/parenthesized annotations
+# ("[BLANK_AUDIO]", "(wind blowing)"); they are never wake tokens.
+_ANNOTATION_RE = re.compile(r"\[[^\]]*\]|\([^)]*\)")
+_NON_WORD_RE = re.compile(r"[^a-z']+")
+
+
+def parse_phrases(spec: str | None) -> list[list[str]]:
+    """KIRRA_WAKE_PHRASES → list of token lists. Empty/whitespace entries are
+    dropped; an all-empty spec yields [] (the caller refuses to start on it —
+    an enabled listener with nothing to listen for is a misconfiguration)."""
+    out: list[list[str]] = []
+    for part in (spec or "").split(","):
+        toks = transcript_tokens(part)
+        if toks:
+            out.append(toks)
+    return out
+
+
+def transcript_tokens(text: str | None) -> list[str]:
+    """Normalize an STT transcript to lowercase word tokens. Bracketed
+    annotations are stripped BEFORE tokenizing, apostrophes kept ("what's")."""
+    t = _ANNOTATION_RE.sub(" ", (text or "").lower())
+    return [w for w in _NON_WORD_RE.split(t) if w]
+
+
+def _edit_distance_le(a: str, b: str, bound: int) -> bool:
+    """Levenshtein distance <= bound (bound is 0 or 1 here; small and exact)."""
+    if a == b:
+        return True
+    if bound <= 0:
+        return False
+    la, lb = len(a), len(b)
+    if abs(la - lb) > bound:
+        return False
+    prev = list(range(lb + 1))
+    for i in range(1, la + 1):
+        cur = [i] + [0] * lb
+        for j in range(1, lb + 1):
+            cur[j] = min(prev[j] + 1, cur[j - 1] + 1,
+                         prev[j - 1] + (a[i - 1] != b[j - 1]))
+        prev = cur
+    return prev[lb] <= bound
+
+
+def _token_matches(heard: str, want: str) -> bool:
+    """Per-token tolerance rule: long tokens (>=5 chars: hello, rabbit) absorb
+    ONE edit ("hallo", "rabbits"); short tokens (hey, yo) match EXACTLY —
+    "yo"'s edit-distance-1 neighborhood (to/so/no/go) is all noise words."""
+    return _edit_distance_le(heard, want, 1 if len(want) >= 5 else 0)
+
+
+def wake_hit(tokens: list[str], phrases: list[list[str]]) -> str | None:
+    """Return the matched phrase (joined) or None. A phrase matches when its
+    tokens appear ADJACENT and IN ORDER anywhere in the transcript — "hey the
+    rabbit robot" does NOT wake (intervening token), "well hello rabbit" does."""
+    for phrase in phrases:
+        n = len(phrase)
+        for i in range(len(tokens) - n + 1):
+            if all(_token_matches(tokens[i + k], phrase[k]) for k in range(n)):
+                return " ".join(phrase)
+    return None
+
+
+def rms(pcm: bytes) -> float:
+    """RMS of 16-bit little-endian mono PCM. Stdlib-only (no audioop — it is
+    removed in newer Pythons); an odd trailing byte is dropped."""
+    if len(pcm) < 2:
+        return 0.0
+    samples = array.array("h")
+    samples.frombytes(pcm[: len(pcm) - (len(pcm) % 2)])
+    if sys.byteorder == "big":
+        samples.byteswap()
+    if not samples:
+        return 0.0
+    return (sum(s * s for s in samples) / len(samples)) ** 0.5
+
+
+def wake_allowed(state_text: str | None, now_ms: int) -> bool:
+    """The nap/mute gate over the control file rabbit_wake.py writes.
+    FAIL-OPEN BY DESIGN and safely so: an absent/corrupt state file means
+    LISTENING — the wake word carries no actuation authority (a trigger
+    dead-ends at the fence), so the availability-friendly default is right,
+    unlike anything safety-bearing. mode: awake | nap (until until_ms) | mute."""
+    if not state_text:
+        return True
+    try:
+        j = json.loads(state_text)
+        mode = j.get("mode")
+        if mode == "mute":
+            return False
+        if mode == "nap":
+            return now_ms >= int(j.get("until_ms", 0))
+        return True
+    except Exception:  # noqa: BLE001 — corrupt state file → listening
+        return True
+
+
+# ---------------------------------------------------------------------------
+# The listener (hardware side — not imported by tests)
+# ---------------------------------------------------------------------------
+
+SAMPLE_RATE = 16_000
+BYTES_PER_SAMPLE = 2
+HOP_S = 0.25          # RMS gate granularity
+WINDOW_S = 2.0        # transcription window handed to whisper
+STATE_POLL_S = 1.0    # nap/mute file poll cadence
+
+
+def _log(msg: str) -> None:
+    print(f"wake_word: {msg}", file=sys.stderr, flush=True)
+
+
+def _truthy(v: str | None) -> bool:
+    return (v or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+class _Led:
+    """Optional mic-open indicator. Degrades to a no-op without Jetson.GPIO —
+    the LED is UX, never load-bearing."""
+
+    def __init__(self, pin_env: str | None):
+        self.pin = None
+        self.gpio = None
+        if not pin_env:
+            return
+        try:
+            import Jetson.GPIO as GPIO  # type: ignore
+            pin = int(pin_env)
+            GPIO.setmode(GPIO.BOARD)
+            GPIO.setup(pin, GPIO.OUT, initial=GPIO.LOW)
+            self.pin, self.gpio = pin, GPIO
+        except Exception as e:  # noqa: BLE001
+            _log(f"LED disabled ({type(e).__name__}: {e})")
+
+    def set(self, on: bool) -> None:
+        if self.gpio is not None:
+            try:
+                self.gpio.output(self.pin, self.gpio.HIGH if on else self.gpio.LOW)
+            except Exception:  # noqa: BLE001
+                pass
+
+    def close(self) -> None:
+        if self.gpio is not None:
+            try:
+                self.set(False)
+                self.gpio.cleanup(self.pin)
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def _transcribe(stt_cmd: list[str], window: bytes, tmp_dir: str) -> str:
+    """Window → tmpfs wav → STT → transcript. The wav is deleted before this
+    returns, success or not (transcribe-and-discard: nothing persists)."""
+    fd, path = tempfile.mkstemp(suffix=".wav", dir=tmp_dir)
+    try:
+        with os.fdopen(fd, "wb") as f, wave.open(f, "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(BYTES_PER_SAMPLE)
+            w.setframerate(SAMPLE_RATE)
+            w.writeframes(window)
+        p = subprocess.run(stt_cmd + [path], capture_output=True, text=True,
+                           timeout=10.0)
+        return p.stdout if p.returncode == 0 else ""
+    except Exception:  # noqa: BLE001 — a failed STT cycle is just a missed window
+        return ""
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _ack(ack_cmd: str | None, tts_cmd: str | None) -> None:
+    """The audible wake acknowledgment (voice line W1) — false fires must be
+    HEARD, not silent. Precedence: KIRRA_WAKE_ACK_CMD, else "Yes?" through
+    KIRRA_TTS_CMD, else a stderr note (print-not-speak parity with rabbit_ask)."""
+    try:
+        if ack_cmd:
+            subprocess.run(shlex.split(ack_cmd), timeout=5.0,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        elif tts_cmd:
+            subprocess.run(shlex.split(tts_cmd), input="Yes?", text=True,
+                           timeout=10.0, stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL)
+        else:
+            _log("wake ack (no KIRRA_WAKE_ACK_CMD / KIRRA_TTS_CMD — silent)")
+    except Exception as e:  # noqa: BLE001 — a broken cue never blocks the trigger
+        _log(f"ack failed ({type(e).__name__}: {e})")
+
+
+def _read_state(path: str) -> str | None:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return f.read()
+    except OSError:
+        return None
+
+
+def main() -> int:
+    if not _truthy(os.environ.get("KIRRA_WAKE_ENABLED")):
+        _log("KIRRA_WAKE_ENABLED not set — wake word off (exit 0; PTT/Enter still work)")
+        return 0
+
+    stt_raw = os.environ.get("KIRRA_WAKE_STT_CMD", "")
+    if not stt_raw.strip():
+        _log("FATAL: KIRRA_WAKE_ENABLED is on but KIRRA_WAKE_STT_CMD is unset — "
+             'point it at whisper-cli with a TINY model, e.g. '
+             '"whisper-cli -m models/ggml-tiny.en.bin -np -nt -f"')
+        return 1
+    stt_cmd = shlex.split(stt_raw)
+
+    phrases = parse_phrases(os.environ.get("KIRRA_WAKE_PHRASES", DEFAULT_PHRASES))
+    if not phrases:
+        _log("FATAL: KIRRA_WAKE_PHRASES parsed to nothing — an enabled listener "
+             "with no phrases is a misconfiguration")
+        return 1
+
+    record_cmd = shlex.split(os.environ.get(
+        "KIRRA_WAKE_RECORD_CMD", "arecord -f S16_LE -r 16000 -c 1 -t raw"))
+    rms_floor = float(os.environ.get("KIRRA_WAKE_RMS_FLOOR", "300"))
+    cooldown_s = float(os.environ.get("KIRRA_WAKE_COOLDOWN_S", "2"))
+    holdoff_s = float(os.environ.get("KIRRA_WAKE_HOLDOFF_S", "10"))
+    state_file = os.environ.get("KIRRA_WAKE_STATE_FILE", "/tmp/kirra_rabbit_wake.state")
+    ack_cmd = os.environ.get("KIRRA_WAKE_ACK_CMD")
+    tts_cmd = os.environ.get("KIRRA_TTS_CMD")
+    tmp_dir = "/dev/shm" if os.path.isdir("/dev/shm") else tempfile.gettempdir()
+
+    hop_bytes = int(SAMPLE_RATE * HOP_S) * BYTES_PER_SAMPLE
+    window_bytes = int(SAMPLE_RATE * WINDOW_S) * BYTES_PER_SAMPLE
+    led = _Led(os.environ.get("KIRRA_WAKE_LED_PIN"))
+    _log(f"listening for {[' '.join(p) for p in phrases]} "
+         f"(rms_floor={rms_floor:g}, holdoff={holdoff_s:g}s)")
+
+    try:
+        while True:
+            # Nap/mute gate — while suspended, the mic stays CLOSED (no capture
+            # process at all), polled once a second.
+            if not wake_allowed(_read_state(state_file), int(time.time() * 1000)):
+                led.set(False)
+                time.sleep(STATE_POLL_S)
+                continue
+
+            cap = subprocess.Popen(record_cmd, stdout=subprocess.PIPE,
+                                   stderr=subprocess.DEVNULL)
+            led.set(True)
+            ring = b""
+            last_stt = 0.0
+            last_state_poll = 0.0
+            hit = None
+            try:
+                while True:
+                    chunk = cap.stdout.read(hop_bytes)
+                    if not chunk:
+                        _log("capture stream ended (recorder died?) — retrying in 2 s")
+                        time.sleep(2.0)
+                        break
+                    ring = (ring + chunk)[-window_bytes:]
+
+                    now = time.monotonic()
+                    if now - last_state_poll >= STATE_POLL_S:
+                        last_state_poll = now
+                        if not wake_allowed(_read_state(state_file),
+                                            int(time.time() * 1000)):
+                            _log("nap/mute engaged — releasing the mic")
+                            break
+
+                    # Energy pre-gate: a quiet hop runs no inference at all.
+                    if rms(chunk) < rms_floor:
+                        continue
+                    # Rate-limit STT to at most one run per second of audio-with-
+                    # energy (the window slides; adjacent runs see the phrase).
+                    if now - last_stt < 1.0 or len(ring) < window_bytes:
+                        continue
+                    last_stt = now
+                    text = _transcribe(stt_cmd, ring, tmp_dir)
+                    hit = wake_hit(transcript_tokens(text), phrases)
+                    if hit:
+                        break
+            finally:
+                led.set(False)
+                cap.terminate()
+                try:
+                    cap.wait(timeout=2.0)
+                except subprocess.TimeoutExpired:
+                    cap.kill()
+
+            if hit:
+                # Release-before-trigger: the mic is already closed (above), so
+                # rabbit_voice.sh's bounded recorder can claim the device.
+                _log(f'wake: "{hit}"')
+                sys.stdout.write("\n")   # THE TRIGGER — sole stdout writer
+                sys.stdout.flush()
+                _ack(ack_cmd, tts_cmd)
+                time.sleep(holdoff_s)    # the turn's record+STT+TTS window
+                time.sleep(cooldown_s)   # refractory: no immediate re-wake
+    except KeyboardInterrupt:
+        return 0
+    except BrokenPipeError:
+        _log("stdout consumer gone (rabbit_voice.sh exited) — stopping")
+        return 0
+    finally:
+        led.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/wake_word_test.py
+++ b/robot/wake_word_test.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Host tests for the PURE wake-word logic (`wake_word.py` matcher/gates and
+`rabbit_wake.py` controls). No audio, no GPIO, no subprocesses — the impure
+listener loop is deliberately not imported here (only the pure functions are).
+
+Runs standalone (`python3 robot/wake_word_test.py`, exit 1 on any failure);
+also importable under pytest. Covers: phrase parsing, transcript
+normalization (whisper's bracketed annotations), the ordered-adjacent matcher
+with the long-token-only edit tolerance (hallo/rabbits wake; a stray "yo" or
+"yo… to/go/no" lookalikes never do), hostile near-misses, the RMS gate math,
+the nap/mute fail-OPEN state gate, the rabbit_wake classifier (including
+non-overlap with the OTA / diagnostics / drive matchers), and its state/reply
+builders.
+"""
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import rabbit_diag  # noqa: E402
+import rabbit_wake  # noqa: E402
+from rabbit_ota import match_command  # noqa: E402
+from wake_word import (  # noqa: E402
+    DEFAULT_PHRASES, parse_phrases, rms, transcript_tokens, wake_allowed,
+    wake_hit,
+)
+
+PHRASES = parse_phrases(DEFAULT_PHRASES)
+
+
+def _hit(text):
+    return wake_hit(transcript_tokens(text), PHRASES)
+
+
+# --- phrase parsing ----------------------------------------------------------
+
+def test_default_phrases_parse() -> None:
+    assert PHRASES == [["hello", "rabbit"], ["hey", "rabbit"], ["yo", "rabbit"]]
+
+
+def test_phrase_parsing_drops_empty_entries() -> None:
+    assert parse_phrases(" hello rabbit ,, ,hey rabbit") == [
+        ["hello", "rabbit"], ["hey", "rabbit"]]
+    assert parse_phrases("") == []
+    assert parse_phrases(None) == []
+
+
+# --- transcript normalization ------------------------------------------------
+
+def test_tokens_strip_whisper_annotations_and_punctuation() -> None:
+    assert transcript_tokens(" Hello, Rabbit!  ") == ["hello", "rabbit"]
+    assert transcript_tokens("[BLANK_AUDIO]") == []
+    assert transcript_tokens("(wind blowing) hey rabbit.") == ["hey", "rabbit"]
+    assert transcript_tokens(None) == []
+
+
+# --- the matcher -------------------------------------------------------------
+
+def test_all_three_phrases_wake() -> None:
+    assert _hit("hello rabbit") == "hello rabbit"
+    assert _hit("Hey Rabbit") == "hey rabbit"
+    assert _hit("yo rabbit") == "yo rabbit"
+
+
+def test_wake_phrase_embedded_mid_sentence_wakes() -> None:
+    assert _hit("well hello rabbit how are you") == "hello rabbit"
+
+
+def test_long_token_tolerance_absorbs_whisper_mishears() -> None:
+    # One edit on tokens >= 5 chars: hello->hallo, rabbit->rabbits/rabbi.
+    assert _hit("hallo rabbit") == "hello rabbit"
+    assert _hit("hello rabbits") == "hello rabbit"
+    assert _hit("hey rabbi") == "hey rabbit"
+
+
+def test_short_greetings_match_exactly() -> None:
+    # "yo"/"hey" get NO tolerance: their edit-1 neighborhoods are noise words.
+    for near in ("to rabbit", "go rabbit", "no rabbit", "so rabbit",
+                 "hay rabbit", "they rabbit"):
+        assert _hit(near) is None, f"{near!r} must not wake"
+
+
+def test_adjacency_is_required() -> None:
+    # An intervening token breaks the phrase — conversational mentions of the
+    # robot must not wake it.
+    assert _hit("hey the rabbit robot is over there") is None
+    assert _hit("hello there rabbit") is None
+
+
+def test_order_is_required_and_anchor_alone_is_insufficient() -> None:
+    assert _hit("rabbit hello") is None
+    assert _hit("rabbit") is None
+    assert _hit("yo") is None
+    assert _hit("") is None
+
+
+def test_two_edits_on_the_anchor_do_not_wake() -> None:
+    assert _hit("hello rabbitts") is None  # distance 2 from "rabbit"
+
+
+# --- RMS gate ----------------------------------------------------------------
+
+def test_rms_silence_is_zero_and_signal_scales() -> None:
+    silence = struct.pack("<8h", *([0] * 8))
+    loud = struct.pack("<8h", *([10_000, -10_000] * 4))
+    assert rms(silence) == 0.0
+    assert abs(rms(loud) - 10_000.0) < 1e-6
+    assert rms(b"") == 0.0
+    assert rms(b"\x01") == 0.0  # odd fragment: dropped, not a crash
+
+
+# --- nap/mute gate (fail-OPEN by design: no actuation authority) --------------
+
+def test_wake_allowed_states() -> None:
+    now = 1_000_000
+    assert wake_allowed(None, now), "absent file -> listening"
+    assert wake_allowed("not json {", now), "corrupt file -> listening"
+    assert wake_allowed('{"mode": "awake"}', now)
+    assert not wake_allowed('{"mode": "mute"}', now)
+    nap = '{"mode": "nap", "until_ms": 1000500}'
+    assert not wake_allowed(nap, now), "napping until the deadline"
+    assert wake_allowed(nap, 1_000_500), "nap expires exactly at until_ms"
+
+
+# --- rabbit_wake controls ------------------------------------------------------
+
+def test_wake_control_classifier() -> None:
+    assert rabbit_wake.classify("rabbit, go to sleep") == "nap"
+    assert rabbit_wake.classify("take a nap") == "nap"
+    assert rabbit_wake.classify("stop listening") == "mute"
+    assert rabbit_wake.classify("mute your ears") == "mute"
+    assert rabbit_wake.classify("turn off the wake word") == "mute"
+    assert rabbit_wake.classify("start listening") == "resume"
+    assert rabbit_wake.classify("unmute your microphone") == "resume"
+    assert rabbit_wake.classify(None) is None
+
+
+def test_wake_controls_do_not_swallow_drive_or_status_turns() -> None:
+    # "stop" alone is a DRIVE word — it must fall through to the router.
+    for utter in ("stop", "stop right there", "creep forward one meter",
+                  "what do you see", "how healthy are you",
+                  "check for updates", "check yourself"):
+        assert rabbit_wake.classify(utter) is None, f"{utter!r} must fall through"
+
+
+def test_matcher_precedence_no_cross_matches() -> None:
+    # The three deterministic matchers stay disjoint on each other's canon.
+    wake_canon = ["go to sleep", "stop listening", "start listening"]
+    for utter in wake_canon:
+        assert match_command(utter) is None, f"OTA must not match {utter!r}"
+        assert not rabbit_diag.matches(utter), f"diag must not match {utter!r}"
+    assert rabbit_wake.classify("check for updates") is None
+    assert rabbit_wake.classify("run diagnostics") is None
+
+
+def test_mute_wins_when_both_appear() -> None:
+    assert rabbit_wake.classify("go to sleep and stop listening") == "mute"
+
+
+def test_state_builder_shapes() -> None:
+    now = 42_000
+    nap = rabbit_wake.state_for("nap", now, nap_min=30)
+    assert nap == {"mode": "nap", "until_ms": now + 30 * 60_000, "set_at_ms": now}
+    assert rabbit_wake.state_for("mute", now)["mode"] == "mute"
+    assert rabbit_wake.state_for("resume", now)["mode"] == "awake"
+
+
+def test_replies_state_the_resume_asymmetry() -> None:
+    # A muted wake listener cannot hear "start listening" — the confirmations
+    # must tell the operator the button is the way back (voice lines W2/W3).
+    assert "button" in rabbit_wake.reply_for("nap")
+    assert "button" in rabbit_wake.reply_for("mute")
+    assert rabbit_wake.reply_for("resume")
+
+
+# --- standalone runner (house pattern) ----------------------------------------
+
+def _run_all() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  ok  {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL  {name}: {e}")
+    print("wake_word_test:", "ALL OK" if failures == 0 else f"{failures} FAILURE(S)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
Implements the W1 wake-word design (ratified in-session after the "hello rabbit did nothing" field report — root cause: the stack had no wake word by design, and no listener unit existed at all). Amends `RABBIT_AUDIO_STACK.md` §3 with §3b, answering its three always-listening objections rather than contradicting them. PTT stays the recommended default; everything here is opt-in and off by default.

## What this is

A **third trigger producer** honoring `ptt_button.py`'s exact one-newline-per-trigger contract:

```bash
python3 robot/wake_word.py | ./robot/rabbit_voice.sh
```

**Zero change to the turn pipeline or the fence** — after the trigger, it's the existing bounded record → STT → `rabbit_converse` deterministic matchers → at most the fenced mick `/intent` text door. The wake word adds no actuation authority: a false fire is exactly the documented phantom-PTT-press class (one bounded clip → garbage transcript → no intent → no motion), now made *audible* by the ack cue.

## Pieces

- **`robot/wake_word.py`** — stdlib-only listener: `arecord` raw stream → in-memory ring buffer → **RMS energy pre-gate** (a silent room runs zero inference) → whisper.cpp **tiny** (`KIRRA_WAKE_STT_CMD`, a second small model beside the turn STT) on a ~2 s tmpfs window → a **pure ordered-adjacent token matcher** with 1-edit tolerance on long tokens only ("hallo rabbits" wakes; a stray "yo", "to/go/no rabbit", or "hey the rabbit robot is over there" never does). Hit → newline trigger + ack ("Yes?" via TTS by default) + release-before-trigger mic holdoff (the turn recorder needs the device) + cooldown. **Transcribe-and-discard**: no audio persisted, no transcripts logged (only wake hits). Stdout discipline preserved (trigger newlines only).
- **`robot/rabbit_wake.py`** — deterministic nap/mute/resume voice controls ("rabbit, go to sleep" / "stop listening" / "start listening"), wired into `rabbit_converse.handle_turn` after diag, before the LLM — whether the ambient mic is open is never LLM-decided. Writes the state file the listener polls; the gate **fails OPEN** deliberately (a wake trigger carries no authority, so availability-friendly is correct here, unlike anything safety-bearing). Confirmations state the resume asymmetry: a muted listener can't hear "start listening" — the button is the way back. Bare "stop" deliberately falls through to the drive router.
- **`kirra-rabbit-voice.service`** — the listener as a staged (NOT enabled) unit, doubly opt-in: it exits inactive unless `KIRRA_WAKE_ENABLED=1` is also set in `robot.env`. This also closes the second half of the field report — previously *nothing* on the robot listened unless a terminal was running the pipeline.
- **`kirra_voice_doctor.sh`** wake section (engine/model present, phrases parse, holdoff covers the turn recorder's `-d` bound, ack audible, state dir writable); `rabbit.env.example` wake block; voice lines **W1–W5** catalogued in `RABBIT_VOICE_LINES.md`.

## Evidence

- `robot/wake_word_test.py`: 18 pure host tests (matcher hits/tolerance/hostile near-misses, RMS math, fail-open state gate, control classifier + **non-overlap with the OTA/diag/drive matchers**) — added to the CI robot lane.
- Existing suites unregressed: `rabbit_voice_test.py` 16/16, `kirra_doctor_test.py` 12/12.
- The real listener loop smoke-tested against stub recorder/STT: exactly one trigger newline per wake, **zero leftover wavs in `/dev/shm`**, and a muted state runs zero STT with the capture process closed.
- Doctor smoke-run in both modes (wake off → clean ✔; wake on with gaps → precise ❌/fix hints).

## Before enabling on battery

Measure the duty-cycled tiny.en cost (`tegrastats` A/B, listener on/off — §3b). The recorded fallback if it's too hot is swapping the producer for a dedicated wake engine; the trigger contract means that changes one script and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_