### PR TITLE
WS-3.1 #796: named known-failure manifest (set equality), pre-committed real-detector profile, KPI evidence artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,27 @@ jobs:
         # WP-23: the deterministic sweep PLUS the seeded Monte-Carlo campaign at
         # the per-PR sampled-subset size (95% CI bounds). The full 10⁴–10⁵ corpus
         # runs nightly in kpi-campaign-nightly.yml.
+        # #796 F4/F5: also gates SET EQUALITY against the named known-failure
+        # manifest (ci/scenario_kpi_known_failures.json) — a fix-3-break-3 PR
+        # is no longer invisible, and any FP flip is attributable by name.
+        # #796 F2: the pre-committed real-detector profile
+        # (ci/scenario_kpi_thresholds_real_detector.json) activates by passing
+        # it as the binary's first argument in a `detector: real` lane once a
+        # real detector rides the MockSemanticDetector seam — until then this
+        # mock lane is unchanged.
         env:
           KIRRA_KPI_MC_PROFILE: per_pr
+          # #796 F11 — evidence artifacts (GateReport JSON + per-scenario
+          # verdict CSV + corpus-hash stamp), uploaded below pass or fail.
+          KIRRA_KPI_REPORT_DIR: kpi-evidence
         run: cargo run --locked -p kirra-kpi-gate --bin scenario_kpi_gate
+      - name: Upload KPI evidence artifacts (#796 F11)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scenario-kpi-evidence
+          path: kpi-evidence/
+          if-no-files-found: warn
 
   # WS-5.1 — the QNX governor-judge cross-build: the EPIC-#270 no_std
   # core-only judge staticlib for both QNX 8.0 tuples (x86_64 + the aarch64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,6 +2281,7 @@ dependencies = [
  "kirra-trajectory",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
 ]
 
 [[package]]

--- a/ci/scenario_kpi_known_failures.json
+++ b/ci/scenario_kpi_known_failures.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "#796 F4/F5 — the NAMED known-failure manifest for the WS-3.1 scenario-KPI gate (crates/kirra-kpi-gate::run_manifest_gate). The gate requires SET EQUALITY between these lists and the measured checker-refused scenarios (MRC/Pending) per planner: a measured failure NOT listed here is a REGRESSION (red, unsafe direction — a scenario the checker used to admit is now refused, or a fixed one silently broke back); a listed name that no longer fails is an IMPROVEMENT and is ALSO red until this file is tightened to lock it in (a one-line reviewed change — the mechanized ratchet). Names, not rates: a fix-3-break-3 PR is no longer invisible, and any libm/toolchain FP flip (#777 F7) is attributable to a scenario NAME. Counts reconcile with the rate floors in scenario_kpi_thresholds.json (geometric 8 = 248-240; learned 24 = 248-224; pinned by test). The failing cells are the coherent close-hazard/high-speed corner (x12-x20 at v4-v6), where the checker's RSS refusal is the intended fail-closed outcome pending planner improvements. Regenerate after an intentional change: cargo test -p kirra-kpi-gate dump_failing_scenario_names -- --ignored --nocapture.",
+  "geometric": [
+    "Oncoming_x12_v4_g40",
+    "Oncoming_x12_v4_g60",
+    "Stopped_x12_v6_g40",
+    "Oncoming_x12_v6_g40",
+    "Oncoming_x16_v6_g40",
+    "Stopped_x12_v6_g60",
+    "Oncoming_x12_v6_g60",
+    "Oncoming_x16_v6_g60"
+  ],
+  "learned_safetyaware_seed7": [
+    "Stopped_x12_v4_g40",
+    "LeadMoving_x12_v4_g40",
+    "Oncoming_x12_v4_g40",
+    "Stopped_x12_v4_g60",
+    "LeadMoving_x12_v4_g60",
+    "Oncoming_x12_v4_g60",
+    "Stopped_x12_v6_g40",
+    "Stopped_x16_v6_g40",
+    "Stopped_x20_v6_g40",
+    "LeadMoving_x12_v6_g40",
+    "LeadMoving_x16_v6_g40",
+    "LeadMoving_x20_v6_g40",
+    "Oncoming_x12_v6_g40",
+    "Oncoming_x16_v6_g40",
+    "Oncoming_x20_v6_g40",
+    "Stopped_x12_v6_g60",
+    "Stopped_x16_v6_g60",
+    "Stopped_x20_v6_g60",
+    "LeadMoving_x12_v6_g60",
+    "LeadMoving_x16_v6_g60",
+    "LeadMoving_x20_v6_g60",
+    "Oncoming_x12_v6_g60",
+    "Oncoming_x16_v6_g60",
+    "Oncoming_x20_v6_g60"
+  ]
+}

--- a/ci/scenario_kpi_thresholds_real_detector.json
+++ b/ci/scenario_kpi_thresholds_real_detector.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "#796 F2 — the PRE-COMMITTED real-detector threshold profile, labeled and reviewed BEFORE any real detector exists, so the first loosening of the perception bars is a deliberate profile SWITCH (mock -> real, visible in the CI lane definition) rather than an edit to the mock profile that is indistinguishable from a regression. Activate by passing this file to the gate binary (first argument) in a `detector: real` lane once the RGB->TensorRT detector rides the MockSemanticDetector seam; until then the mock lane keeps running scenario_kpi_thresholds.json unchanged. PROVENANCE: hazard_recall_min 0.9 is the execution plan's AoU target named in #796 F2 — the ONE bound with a plan-sourced number. unsafe_miss_rate_max and the differential rows are DELIBERATELY kept at the mock profile's 0.0: no plan-sourced relaxation exists for the catastrophic direction, and this repo does not invent safety numbers — if the real detector cannot meet 0.0 unsafe-miss on the corpus, the relaxation must arrive as a reviewed change to THIS file citing its derivation (safety-owner sign-off), which is exactly the audit trail F2 exists to force. The doer admissibility rows are detector-independent (same corpus, same planners) and match the mock profile.",
+  "detector": "real",
+  "geometric_admissibility_min": 0.9677,
+  "learned_admissibility_min": 0.9032,
+  "unsafe_miss_rate_max": 0.0,
+  "hazard_recall_min": 0.9,
+  "differential_missed_tighten_max": 0.0,
+  "differential_phantom_tighten_max": 0.0
+}

--- a/crates/kirra-kpi-gate/Cargo.toml
+++ b/crates/kirra-kpi-gate/Cargo.toml
@@ -19,6 +19,7 @@ kirra-doer-eval = { path = "../kirra-doer-eval" }
 kirra-taj = { path = "../kirra-taj" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.11"
 
 [[bin]]
 name = "scenario_kpi_gate"

--- a/crates/kirra-kpi-gate/src/bin/scenario_kpi_gate.rs
+++ b/crates/kirra-kpi-gate/src/bin/scenario_kpi_gate.rs
@@ -20,9 +20,13 @@ use kirra_kpi_gate::sotif_coverage::{
     check_sotif_coverage, live_corpus_scenario_names, parse_aou_ids, parse_trigger_ids,
     SotifCoverageManifest,
 };
-use kirra_kpi_gate::{run_gate, run_montecarlo_gate, KpiThresholds};
+use kirra_kpi_gate::{
+    corpus_fingerprint_sha256, per_scenario_verdicts, run_gate, run_manifest_gate,
+    run_montecarlo_gate, FailureManifest, KpiThresholds,
+};
 
 const MC_POLICY_PATH: &str = "ci/scenario_kpi_montecarlo.json";
+const MANIFEST_PATH: &str = "ci/scenario_kpi_known_failures.json";
 
 fn main() {
     let thresholds_path = std::env::args()
@@ -30,6 +34,9 @@ fn main() {
         .unwrap_or_else(|| "ci/scenario_kpi_thresholds.json".to_string());
 
     let kpi_ok = run_kpi_gate(&thresholds_path);
+    println!();
+    // #796 F4/F5 — the named known-failure manifest, SET EQUALITY per planner.
+    let manifest_ok = run_manifest_gate_cli();
     println!();
     // WP-23: the seeded Monte-Carlo campaign. Opt-in via KIRRA_KPI_MC_PROFILE
     // (per_pr | nightly) so the deterministic gate above stays the default; CI
@@ -39,10 +46,139 @@ fn main() {
     println!();
     let sotif_ok = run_sotif_gate();
 
-    if kpi_ok && mc_ok && sotif_ok {
+    // #796 F11 — the evidence artifact: opt-in via KIRRA_KPI_REPORT_DIR (CI
+    // sets it and uploads). Written on pass AND fail — a red gate's evidence
+    // is the more valuable kind.
+    write_evidence_artifacts(&thresholds_path, kpi_ok && manifest_ok && mc_ok && sotif_ok);
+
+    if kpi_ok && manifest_ok && mc_ok && sotif_ok {
         std::process::exit(0);
     }
     std::process::exit(1);
+}
+
+/// #796 F4/F5 — load the committed known-failure manifest and demand set
+/// equality with the measured failing scenarios, BY NAME, per planner.
+/// Returns `true` on pass. Exits(2) on an unreadable/unparseable manifest.
+fn run_manifest_gate_cli() -> bool {
+    let raw = match std::fs::read_to_string(MANIFEST_PATH) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!(
+                "scenario_kpi_gate: cannot read known-failure manifest at {MANIFEST_PATH}: {e}"
+            );
+            std::process::exit(2);
+        }
+    };
+    let manifest: FailureManifest = match serde_json::from_str(&raw) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("scenario_kpi_gate: manifest at {MANIFEST_PATH} does not parse: {e}");
+            std::process::exit(2);
+        }
+    };
+
+    let diffs = run_manifest_gate(&manifest);
+    println!("=== Known-failure manifest gate (#796 F4/F5, set equality) ===");
+    let mut ok = true;
+    for d in &diffs {
+        println!(
+            "  [{}] {:<28} committed={} new_failures={} fixed={} unknown={}",
+            if d.pass() { "PASS" } else { "FAIL" },
+            d.planner,
+            match d.planner {
+                "geometric" => manifest.geometric.len(),
+                _ => manifest.learned_safetyaware_seed7.len(),
+            },
+            d.new_failures.len(),
+            d.fixed.len(),
+            d.unknown_names.len(),
+        );
+        for n in &d.new_failures {
+            println!("      NEW FAILURE (regression): {n}");
+        }
+        for n in &d.fixed {
+            println!("      FIXED (tighten the manifest to lock it in): {n}");
+        }
+        for n in &d.unknown_names {
+            println!("      UNKNOWN NAME (stale manifest / renamed scenario): {n}");
+        }
+        ok &= d.pass();
+    }
+    if ok {
+        println!("Manifest gate: PASS");
+    } else {
+        eprintln!(
+            "Manifest gate: FAIL — the failing-scenario set drifted from {MANIFEST_PATH}. A NEW \
+             failure is a regression (fix it); a FIXED scenario is an improvement (remove its \
+             line from the manifest, with the PR noting the fix). Never widen silently."
+        );
+    }
+    ok
+}
+
+/// #796 F11 — GateReport JSON + per-scenario verdict CSV + corpus/toolchain
+/// stamp, written under `KIRRA_KPI_REPORT_DIR` when set. Failures to write
+/// are LOUD but non-fatal: the gate verdict is authoritative, the artifact is
+/// evidence packaging.
+fn write_evidence_artifacts(thresholds_path: &str, passed: bool) {
+    let Ok(dir) = std::env::var("KIRRA_KPI_REPORT_DIR") else {
+        return;
+    };
+    if dir.trim().is_empty() {
+        return;
+    }
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("scenario_kpi_gate: cannot create report dir {dir}: {e}");
+        return;
+    }
+
+    // The full report re-runs the deterministic gates (cheap, seconds) so the
+    // artifact is self-contained even though main() already printed them.
+    let thresholds: Option<KpiThresholds> = std::fs::read_to_string(thresholds_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok());
+    let manifest: Option<FailureManifest> = std::fs::read_to_string(MANIFEST_PATH)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok());
+    let report = thresholds.as_ref().map(run_gate);
+    let diffs = manifest.as_ref().map(run_manifest_gate);
+
+    let stamp = serde_json::json!({
+        "gate": "scenario-kpi (WS-3.1)",
+        "passed": passed,
+        "thresholds_path": thresholds_path,
+        "detector_profile": thresholds.as_ref().map(|t| t.detector.clone()),
+        "corpus_sha256": corpus_fingerprint_sha256(),
+        "kpi_gate_crate_version": env!("CARGO_PKG_VERSION"),
+        "report": report,
+        "manifest_diffs": diffs,
+    });
+    let json_path = format!("{dir}/gate_report.json");
+    match serde_json::to_string_pretty(&stamp) {
+        Ok(s) => {
+            if let Err(e) = std::fs::write(&json_path, s) {
+                eprintln!("scenario_kpi_gate: cannot write {json_path}: {e}");
+            } else {
+                println!("evidence artifact: {json_path}");
+            }
+        }
+        Err(e) => eprintln!("scenario_kpi_gate: report serialize failed: {e}"),
+    }
+
+    let csv_path = format!("{dir}/per_scenario_verdicts.csv");
+    let mut csv = String::from("planner,scenario,verdict,admissible\n");
+    for row in per_scenario_verdicts() {
+        csv.push_str(&format!(
+            "{},{},{},{}\n",
+            row.planner, row.scenario, row.verdict, row.admissible
+        ));
+    }
+    if let Err(e) = std::fs::write(&csv_path, csv) {
+        eprintln!("scenario_kpi_gate: cannot write {csv_path}: {e}");
+    } else {
+        println!("evidence artifact: {csv_path}");
+    }
 }
 
 /// The WP-23 Monte-Carlo campaign gate. Returns `true` on pass OR when not

--- a/crates/kirra-kpi-gate/src/lib.rs
+++ b/crates/kirra-kpi-gate/src/lib.rs
@@ -378,6 +378,13 @@ pub struct KpiThresholds {
     /// Free-text rationale — travels with the numbers.
     #[serde(rename = "_comment")]
     pub comment: String,
+    /// #796 F2 — which detector this profile bounds: `"mock"` (the scripted
+    /// seam, perfection-pinned) or `"real"` (the pre-committed AoU-target
+    /// profile in `ci/scenario_kpi_thresholds_real_detector.json`). Defaults
+    /// to `"mock"` so the original profile is unchanged on disk; stamped into
+    /// the F11 evidence artifact so a report names the profile it gated.
+    #[serde(default = "default_detector")]
+    pub detector: String,
     /// Min fraction of GEOMETRIC-planner proposals the checker admits
     /// without an MRC (`Accept | Clamp`) over the doer corpus.
     pub geometric_admissibility_min: f64,
@@ -394,6 +401,10 @@ pub struct KpiThresholds {
     /// EP-20 differential: max fraction of all frames with an UNJUSTIFIED
     /// Phase-B tighten (availability cost, over-conservative direction).
     pub differential_phantom_tighten_max: f64,
+}
+
+fn default_detector() -> String {
+    "mock".to_string()
 }
 
 /// One evaluated KPI row: measured value vs its bound.
@@ -760,12 +771,327 @@ pub fn run_montecarlo_gate(policy: &MonteCarloPolicy, profile: Profile) -> McGat
 }
 
 // ---------------------------------------------------------------------------
+// #796 F4/F5 — the NAMED known-failure manifest (set-equality ratchet)
+//
+// `run_gate`'s rate rows discard the tallies' identities: a PR that fixes 3
+// scenarios and breaks 3 different ones is byte-identical to no-change, and
+// the honor-system float ratchet is exposed to libm/toolchain FP flips (F7).
+// The manifest mechanizes both: the failing-scenario SET is committed BY NAME
+// per planner (`ci/scenario_kpi_known_failures.json`) and the gate demands
+// SET EQUALITY —
+//   * a measured failure NOT in the manifest = a REGRESSION (unsafe
+//     direction, always red);
+//   * a manifest entry that no longer fails = an IMPROVEMENT (also red, until
+//     the manifest is tightened to lock it in — a one-line reviewed change,
+//     never silent).
+// Any FP flip is therefore attributable to a scenario NAME, and the bounds
+// are integer/set-valued, not truncated float rates.
+// ---------------------------------------------------------------------------
+
+/// The committed known-failure manifest: per planner, the exact scenario
+/// names the checker currently refuses (MRC/Pending). Keys are stable planner
+/// labels; scenario names come from `generated_doer_corpus` (deterministic).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailureManifest {
+    /// Free-text rationale — travels with the names.
+    #[serde(rename = "_comment")]
+    pub comment: String,
+    /// Geometric planner (`GeometricPlannerConfig::default()`).
+    pub geometric: Vec<String>,
+    /// Seeded SafetyAware learned planner (`trained(7, Teacher::SafetyAware)`).
+    pub learned_safetyaware_seed7: Vec<String>,
+}
+
+/// One per-scenario, per-planner checker verdict — the F11 CSV artifact row
+/// and the manifest gate's raw material.
+#[derive(Debug, Clone, Serialize)]
+pub struct PlannerVerdictRow {
+    pub planner: &'static str,
+    pub scenario: String,
+    pub verdict: &'static str,
+    /// `Accept | Clamp` (the `admissibility_rate` predicate).
+    pub admissible: bool,
+}
+
+fn verdict_label(v: kirra_core::trajectory::TrajectoryVerdict) -> (&'static str, bool) {
+    use kirra_core::trajectory::TrajectoryVerdict as V;
+    match v {
+        V::Accept => ("Accept", true),
+        V::Clamp => ("Clamp", true),
+        V::MRCFallback => ("MRCFallback", false),
+        V::Pending => ("Pending", false),
+    }
+}
+
+/// Every (planner × scenario) verdict over the deterministic corpus — the
+/// same construction as `run_gate`'s rate rows, with identities kept.
+#[must_use]
+pub fn per_scenario_verdicts() -> Vec<PlannerVerdictRow> {
+    let corpus = generated_doer_corpus();
+    let learned = LearnedPlanner::trained(7, Teacher::SafetyAware);
+    let mut rows = Vec::with_capacity(corpus.len() * 2);
+    for sc in &corpus {
+        let out = GeometricPlanner::new(GeometricPlannerConfig::default()).plan(&sc.plan_input());
+        let (verdict, admissible) = verdict_label(verdict_of(
+            &out,
+            sc.corridor(),
+            sc.objects(),
+            sc.config(),
+            sc.posture(),
+        ));
+        rows.push(PlannerVerdictRow {
+            planner: "geometric",
+            scenario: sc.name.clone(),
+            verdict,
+            admissible,
+        });
+        let out = learned.plan_with_chosen_index(&sc.plan_input()).1;
+        let (verdict, admissible) = verdict_label(verdict_of(
+            &out,
+            sc.corridor(),
+            sc.objects(),
+            sc.config(),
+            sc.posture(),
+        ));
+        rows.push(PlannerVerdictRow {
+            planner: "learned_safetyaware_seed7",
+            scenario: sc.name.clone(),
+            verdict,
+            admissible,
+        });
+    }
+    rows
+}
+
+/// One planner's set-equality outcome against the manifest.
+#[derive(Debug, Clone, Serialize)]
+pub struct ManifestDiff {
+    pub planner: &'static str,
+    /// Failing now, NOT in the manifest — a regression (unsafe direction).
+    pub new_failures: Vec<String>,
+    /// In the manifest, no longer failing — an improvement to lock in.
+    pub fixed: Vec<String>,
+    /// Manifest names that don't exist in the corpus at all (a rename/typo —
+    /// a stale manifest must red, not silently gate nothing).
+    pub unknown_names: Vec<String>,
+}
+
+impl ManifestDiff {
+    #[must_use]
+    pub fn pass(&self) -> bool {
+        self.new_failures.is_empty() && self.fixed.is_empty() && self.unknown_names.is_empty()
+    }
+}
+
+/// The F4/F5 gate: measured failing sets vs the committed manifest, per
+/// planner, SET EQUALITY required.
+#[must_use]
+pub fn run_manifest_gate(manifest: &FailureManifest) -> Vec<ManifestDiff> {
+    use std::collections::BTreeSet;
+    let rows = per_scenario_verdicts();
+    let corpus_names: BTreeSet<&str> = rows.iter().map(|r| r.scenario.as_str()).collect();
+    let diff_for = |planner: &'static str, committed: &[String]| -> ManifestDiff {
+        let measured: BTreeSet<&str> = rows
+            .iter()
+            .filter(|r| r.planner == planner && !r.admissible)
+            .map(|r| r.scenario.as_str())
+            .collect();
+        let committed_set: BTreeSet<&str> = committed.iter().map(String::as_str).collect();
+        ManifestDiff {
+            planner,
+            new_failures: measured
+                .difference(&committed_set)
+                .map(|s| (*s).to_string())
+                .collect(),
+            fixed: committed_set
+                .difference(&measured)
+                .filter(|s| corpus_names.contains(**s))
+                .map(|s| (*s).to_string())
+                .collect(),
+            unknown_names: committed_set
+                .iter()
+                .filter(|s| !corpus_names.contains(**s))
+                .map(|s| (*s).to_string())
+                .collect(),
+        }
+    };
+    vec![
+        diff_for("geometric", &manifest.geometric),
+        diff_for(
+            "learned_safetyaware_seed7",
+            &manifest.learned_safetyaware_seed7,
+        ),
+    ]
+}
+
+/// #796 F11 — the corpus fingerprint stamped into the evidence artifact: a
+/// SHA-256 over every doer scenario name + every perception case name, in
+/// corpus order. Any generator change (added axis, renamed cell, resized
+/// sweep) changes the stamp, so a report is attributable to an exact corpus.
+#[must_use]
+pub fn corpus_fingerprint_sha256() -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    for sc in generated_doer_corpus() {
+        h.update(sc.name.as_bytes());
+        h.update([0u8]);
+    }
+    for case in generated_perception_corpus() {
+        h.update(case.name.as_bytes());
+        h.update([0u8]);
+    }
+    hex_lower(&h.finalize())
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes.iter().fold(String::new(), |mut s, b| {
+        let _ = write!(s, "{b:02x}");
+        s
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The committed manifest path (repo root), used by the equality pin below.
+    const MANIFEST_PATH: &str = "../../ci/scenario_kpi_known_failures.json";
+
+    fn committed_manifest() -> FailureManifest {
+        let raw = std::fs::read_to_string(MANIFEST_PATH).expect("read known-failures manifest");
+        serde_json::from_str(&raw).expect("parse known-failures manifest")
+    }
+
+    /// #796 F4/F5 — the committed manifest matches the measured failing sets
+    /// EXACTLY (set equality). A new failure OR an unrecorded fix reds this.
+    #[test]
+    fn known_failure_manifest_is_set_equal_to_measured() {
+        let diffs = run_manifest_gate(&committed_manifest());
+        for d in &diffs {
+            assert!(
+                d.pass(),
+                "manifest drift for {}: new_failures={:?} fixed={:?} unknown={:?} — a new \
+                 failure is a regression; a fix must be locked in by tightening \
+                 ci/scenario_kpi_known_failures.json (regenerate via the ignored \
+                 dump_failing_scenario_names test)",
+                d.planner,
+                d.new_failures,
+                d.fixed,
+                d.unknown_names
+            );
+        }
+    }
+
+    /// The manifest counts must reconcile with the rate rows (240/248 and
+    /// 224/248 today): the names ARE the integer bounds (#796 F5).
+    #[test]
+    fn manifest_counts_reconcile_with_the_rate_floors() {
+        let m = committed_manifest();
+        assert_eq!(m.geometric.len(), 8, "248 - 240 admitted");
+        assert_eq!(m.learned_safetyaware_seed7.len(), 24, "248 - 224 admitted");
+    }
+
+    /// The gate DISCRIMINATES: perturbing the committed sets in either
+    /// direction (drop a name → "fixed"; add a bogus-but-real name → covered
+    /// by new_failures on the other side; add a nonexistent name → unknown)
+    /// is caught by name.
+    #[test]
+    fn manifest_gate_flags_drift_in_both_directions() {
+        let mut m = committed_manifest();
+        let dropped = m.geometric.pop().expect("manifest has entries");
+        m.learned_safetyaware_seed7
+            .push("no_such_scenario".to_string());
+        let diffs = run_manifest_gate(&m);
+        let geo = &diffs[0];
+        assert_eq!(
+            geo.new_failures,
+            vec![dropped],
+            "a dropped entry surfaces as a NEW failure by name"
+        );
+        let learned = &diffs[1];
+        assert_eq!(
+            learned.unknown_names,
+            vec!["no_such_scenario".to_string()],
+            "a stale/typo name is flagged, never silently ignored"
+        );
+    }
+
+    /// Regeneration utility (documented in the manifest _comment): dumps the
+    /// measured failing names as JSON arrays. `--ignored --nocapture`.
+    #[test]
+    #[ignore = "manifest regeneration utility, not a gate"]
+    fn dump_failing_scenario_names() {
+        for planner in ["geometric", "learned_safetyaware_seed7"] {
+            let names: Vec<String> = per_scenario_verdicts()
+                .into_iter()
+                .filter(|r| r.planner == planner && !r.admissible)
+                .map(|r| r.scenario)
+                .collect();
+            println!(
+                "{planner}: {}",
+                serde_json::to_string_pretty(&names).unwrap()
+            );
+        }
+    }
+
+    /// #796 F2 — the pre-committed real-detector profile parses, is labeled,
+    /// and differs from the mock profile ONLY in `hazard_recall_min` (the one
+    /// bound with a plan-sourced number: the AoU 0.9 target). Every other
+    /// bound — including the catastrophic-direction `unsafe_miss_rate_max` —
+    /// is pinned identical: a relaxation there must arrive as a reviewed
+    /// change to the profile file, never ride in silently.
+    #[test]
+    fn real_detector_profile_relaxes_only_the_plan_sourced_bound() {
+        let mock: KpiThresholds = serde_json::from_str(
+            &std::fs::read_to_string("../../ci/scenario_kpi_thresholds.json").unwrap(),
+        )
+        .unwrap();
+        let real: KpiThresholds = serde_json::from_str(
+            &std::fs::read_to_string("../../ci/scenario_kpi_thresholds_real_detector.json")
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            mock.detector, "mock",
+            "the original profile defaults to mock"
+        );
+        assert_eq!(real.detector, "real", "the new profile is labeled");
+        assert_eq!(real.hazard_recall_min, 0.9, "the plan-sourced AoU target");
+        assert!(real.hazard_recall_min < mock.hazard_recall_min);
+        // Everything else identical — especially the catastrophic direction.
+        assert_eq!(real.unsafe_miss_rate_max, mock.unsafe_miss_rate_max);
+        assert_eq!(
+            real.geometric_admissibility_min,
+            mock.geometric_admissibility_min
+        );
+        assert_eq!(
+            real.learned_admissibility_min,
+            mock.learned_admissibility_min
+        );
+        assert_eq!(
+            real.differential_missed_tighten_max,
+            mock.differential_missed_tighten_max
+        );
+        assert_eq!(
+            real.differential_phantom_tighten_max,
+            mock.differential_phantom_tighten_max
+        );
+    }
+
+    /// #796 F11 — the corpus fingerprint is stable across runs (determinism)
+    /// and 64 hex chars.
+    #[test]
+    fn corpus_fingerprint_is_deterministic() {
+        let a = corpus_fingerprint_sha256();
+        assert_eq!(a, corpus_fingerprint_sha256());
+        assert_eq!(a.len(), 64);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
 
     /// Corpus sizes are pinned: a silent shrink would weaken the gate while
     /// it kept reporting green.


### PR DESCRIPTION
Lands the F4/F5 + F2 + F11 slice of #796 (scenario-KPI gate maturation).

## F4/F5 — named known-failure manifest, SET EQUALITY

`ci/scenario_kpi_known_failures.json` lists the checker-refused scenarios BY NAME per planner (geometric: 8, learned SafetyAware seed7: 24 — the coherent close-hazard/high-speed corner, x12–x20 at v4–v6). `run_manifest_gate` (new in `kirra-kpi-gate`) requires set equality with the measured refusals:

- a measured failure **not listed** → red (regression, unsafe direction);
- a listed name that **no longer fails** → also red until the manifest is tightened — a one-line reviewed change, the mechanized ratchet;
- a manifest name not in the corpus → red (stale entry).

Names, not rates: a fix-3-break-3 PR is no longer invisible behind an unchanged admissibility rate, and any libm/toolchain FP flip (#777 F7) is attributable to a scenario name. A test pins the manifest counts to the existing rate floors (248−240=8, 248−224=24), and a drift test proves the gate flags both directions.

## F2 — pre-committed real-detector threshold profile

`ci/scenario_kpi_thresholds_real_detector.json` (`detector: "real"`) exists BEFORE any real detector does, so the first loosening of the perception bars is a deliberate, visible profile switch in the lane definition — not an edit to the mock profile indistinguishable from a regression. Exactly ONE bound relaxes: `hazard_recall_min` 0.9, the execution plan's AoU target (the one plan-sourced number). `unsafe_miss_rate_max` and the differential rows stay 0.0 — no invented safety numbers; any relaxation must arrive as a reviewed edit to that file citing its derivation. `KpiThresholds` gains a `detector` label (serde default `"mock"`, back-compatible), and `real_detector_profile_relaxes_only_the_plan_sourced_bound` locks the two profiles' relationship in step.

## F11 — evidence artifacts

With `KIRRA_KPI_REPORT_DIR` set (the CI lane sets it; unset = byte-identical no-op) the gate binary writes:
- `gate_report.json` — full `GateReport`, manifest diffs, corpus SHA-256 fingerprint, thresholds path, detector profile, crate version, overall verdict;
- `per_scenario_verdicts.csv` — planner × scenario × verdict × admissible for all 2×248 rows.

The `scenario-kpi-gate` job uploads them `if: always()` via pinned `upload-artifact@043fb46…# v7`, so a red gate still ships its evidence.

## Verification

- `cargo test -p kirra-kpi-gate` — 41 pass (6 new: set-equality against live measurement, count reconciliation, both-direction drift detection, fingerprint determinism, profile lock-step, plus the `#[ignore]`d manifest-regeneration utility).
- Gate binary end-to-end from repo root: KPI PASS + Manifest PASS (0 new / 0 fixed / 0 unknown both planners) + SOTIF PASS, exit 0; both artifacts written and inspected (497 CSV rows). Also green in the no-arg CI shape and with the real-detector profile as first arg.
- fmt / clippy clean; quality guardrails satisfied; ci.yml YAML + both JSONs parse.

## Remainders (stay open on #796)

F3 (corpus axes: curvature/junction/VRU scenarios), F8 (closed-loop subset), F9 (parko KPI row) — larger corpus-engineering tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_