### PR TITLE
#1124 SG5 go-live: map-anchored commit-zone producer (spec + pose anchor + per-tick scene fill)

### DIFF
--- a/docs/safety/PARKO_SCENE_VETO_SEMANTICS.md
+++ b/docs/safety/PARKO_SCENE_VETO_SEMANTICS.md
@@ -22,10 +22,11 @@ enabled-but-silent → fail-closed house rule). Not armed → the gate is never 
 
 ## F6 — armed without a producer = permanent immobilization (fail-loud)
 
-This build ships **no producers** for the occlusion / water / commit-zone slots.
-An armed gate with a slot that is never fed fails closed to a STOP **every tick,
-forever** — a permanent immobilization. That behaviour is fail-*safe* (a stop),
-but silently coming up immobilized with no diagnostic is a foot-gun.
+This build ships **no producers** for the occlusion / water slots (commit-zone
+now has one — see the #1124 section below). An armed gate with a slot that is
+never fed fails closed to a STOP **every tick, forever** — a permanent
+immobilization. That behaviour is fail-*safe* (a stop), but silently coming up
+immobilized with no diagnostic is a foot-gun.
 
 `ParkoNodeConfig::scene_gate_startup_check` (pure, unit-tested) makes it loud: if
 any gate that would *actually* immobilize is armed (see
@@ -41,10 +42,47 @@ The veto **configs** (`WaterVetoConfig`, `CommitZoneCfg`) are now carried on
 per-tick hardcoded `Default()`, so their (VALIDATION-PENDING) bounds are a
 deployment knob. Defaults are unchanged → byte-identical.
 
-**Remaining (tracked):** land at least one *real* producer — a sightline-from-lidar
-occlusion source or a map-anchored commit-zone source. That is perception work
-requiring hardware/design validation and is out of scope for the fail-loud guard
-above.
+**Remaining (tracked, #1124):** a producer for the occlusion slot
+(sightline-from-lidar — perception work requiring hardware/design validation)
+and for the water slot. The commit-zone slot's producer landed (#1124, below).
+
+## #1124 — the map-anchored commit-zone producer (shipped)
+
+`parko/crates/parko-ros2/src/commit_zone_producer.rs` — the first real scene
+producer, map-anchored with **no new perception**:
+
+- **Zones** are a site-authored, versioned JSON artifact
+  (`PARKO_COMMIT_ZONE_MAP_PATH`): polygons in the map frame (rail crossings,
+  box junctions, narrow bridges). Loaded **fail-closed at startup** — an
+  unreadable or invalid spec (bad version, empty, duplicate ids, <3 or
+  non-finite vertices, degenerate polygon) ABORTS the node; never a partial
+  zone map. Each zone's traverse length is derived as the polygon **diameter**
+  (conservative: a longer assumed zone → a longer required clearance gap).
+- **Anchor** is the ego pose (`PARKO_POSE_TOPIC`, `nav_msgs/Odometry`,
+  arrival-stamped). A missing, stale, future-skewed, or non-finite pose yields
+  `CommitZoneScene::Unknown` → the gate vetoes ("Reject fires from MAP ALONE" —
+  an unanchored prior is exactly the `Unknown` case). Pose *accuracy* rides
+  AOU-LOCALIZATION-001; a frame-integrity feed composes later via
+  `gate_commit_zone_scene` unchanged.
+- **Distance** is the Euclidean point-to-polygon distance (0 inside). Parko has
+  no route model, so this LOWER-BOUNDS any along-path distance — the veto can
+  only fire *earlier* than a path-aware producer's, never later. A zone near
+  (but not on) the actual path can over-veto; sites author polygons accordingly.
+- **Entry confirmations are DERIVED, never asserted**: `exit_verified` via
+  `exit_clearance_verified`, `clearance_confirmed` via `non_yielding_clearance`.
+  The node currently supplies **no evidence** (`NonYieldingScene::Absent`, no
+  exit measurement), so a zone within the look-ahead **vetoes — the ego stops
+  short of every mapped commit zone**. That is SG5's intended fail-closed
+  behaviour until the #107/#108 evidence *ingestion* lands; the producer's
+  evidence parameters make that a fill-in, not a rework (tests pin that entry
+  becomes earnable the moment evidence arrives).
+
+Arming: `commit_zone_producer_armed()` = spec **and** pose topic configured
+(the same one-predicate discipline as `object_gate_armed`). With the producer
+armed, the commit-zone gate drops out of `producerless_armed_scene_gates` and
+the F6 startup guard passes without the immobilizer acknowledgment; a
+half-configured producer (spec without pose topic, or vice versa) still counts
+as producer-less and refuses startup.
 
 ## F8 — occlusion angular-channel semantics (pending decision)
 

--- a/parko/crates/parko-ros2/Cargo.toml
+++ b/parko/crates/parko-ros2/Cargo.toml
@@ -37,7 +37,7 @@ default = []
 # Everything this lane touches is BASE-jazzy (sensor_msgs / std_msgs /
 # nav_msgs / geometry_msgs, plus untyped subscriptions whose payload is a
 # `serde_json::Value`), so no curated message workspace is needed.
-ros2 = ["dep:r2r", "dep:tracing-subscriber", "dep:futures", "dep:serde_json"]
+ros2 = ["dep:r2r", "dep:tracing-subscriber", "dep:futures"]
 
 # Opt-in: the DEFERRED typed r2r radar adapter (`radar_scan_msg_to_detections`),
 # which references `r2r::radar_msgs::msg::RadarScan`. `radar_msgs` is NOT a
@@ -97,10 +97,12 @@ tracing-subscriber = { version = "0.3", features = ["json", "env-filter"], optio
 # streams in the drain tasks. Same pattern as the adapter.
 futures = { version = "0.3", optional = true }
 
-# r2r's untyped subscriptions/publishers exchange `serde_json::Value`; the node
-# builds the geometry_msgs/Twist envelope with `json!`. ros2-only (the default
-# unit-test lane has no r2r and never touches it), hence optional + the feature.
-serde_json = { version = "1", optional = true }
+# r2r's untyped subscriptions/publishers exchange `serde_json::Value` (the node
+# builds the geometry_msgs/Twist envelope with `json!`), and — since #1124 — the
+# DEFAULT lane parses the fail-closed commit-zone map spec
+# (`commit_zone_producer::parse_commit_zone_spec`), so this is a plain
+# dependency now (it was ros2-optional before the producer landed).
+serde_json = "1"
 
 # Optional ONNX backend. The integrator opts in when ORT is installed.
 parko-onnx = { path = "../parko-onnx", optional = true }

--- a/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
+++ b/parko/crates/parko-ros2/src/bin/parko_ros2_node.rs
@@ -350,6 +350,10 @@ async fn install_shutdown_handler() {
 ///   - `PARKO_IMPACT_SPIKE_THRESHOLD_MPS2` — decel threshold (deployment-tunable,
 ///     VALIDATION-PENDING; parko-core default 30 m/s²). A non-numeric value is
 ///     ignored with a warning (the safe default stands).
+///   - `PARKO_POSE_TOPIC` — `nav_msgs/Odometry` ego-pose topic (map frame), the
+///     commit-zone producer's anchor (#1124).
+///   - `PARKO_COMMIT_ZONE_MAP_PATH` — site-authored commit-zone spec JSON,
+///     loaded FAIL-CLOSED (unreadable/invalid → startup abort) (#1124).
 fn build_config() -> ParkoNodeConfig {
     let imu_topic = std::env::var("PARKO_IMU_TOPIC")
         .ok()
@@ -436,6 +440,47 @@ fn build_config() -> ParkoNodeConfig {
     // producer (a deliberate permanent immobilizer). Unset → the startup guard
     // REFUSES a producer-less armed gate instead of silently immobilizing.
     config.allow_scene_gate_without_producer = env_flag("PARKO_ALLOW_SCENE_GATE_WITHOUT_PRODUCER");
+    // #1124 — the map-anchored commit-zone producer's two inputs:
+    //   - PARKO_POSE_TOPIC: nav_msgs/Odometry ego pose (map frame), the anchor.
+    //   - PARKO_COMMIT_ZONE_MAP_PATH: the site-authored zone-spec JSON, loaded
+    //     FAIL-CLOSED here — an unreadable or invalid spec ABORTS startup (a
+    //     defective zone map must never anchor a safety veto; same fail-closed-
+    //     exit shape as the backend-select and scene-gate guards).
+    // Both set → `commit_zone_producer_armed()` and the commit-zone gate is no
+    // longer producer-less for the #795 F6 startup guard.
+    config.pose_topic = std::env::var("PARKO_POSE_TOPIC")
+        .ok()
+        .filter(|s| !s.is_empty());
+    if let Some(path) = std::env::var("PARKO_COMMIT_ZONE_MAP_PATH")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+            tracing::error!(path = %path, error = %e,
+                "parko-ros2: FATAL — PARKO_COMMIT_ZONE_MAP_PATH is set but unreadable");
+            eprintln!(
+                "parko_ros2_node: commit-zone map {path:?} unreadable ({e}) — refusing to \
+                 start (fail-closed)"
+            );
+            std::process::exit(2);
+        });
+        match parko_ros2::commit_zone_producer::parse_commit_zone_spec(&raw) {
+            Ok(spec) => {
+                tracing::info!(path = %path, zones = spec.zones.len(),
+                    "parko-ros2: commit-zone map loaded and validated (#1124)");
+                config.commit_zone_spec = Some(spec);
+            }
+            Err(e) => {
+                tracing::error!(path = %path, error = %e,
+                    "parko-ros2: FATAL — commit-zone map failed validation");
+                eprintln!(
+                    "parko_ros2_node: commit-zone map {path:?} invalid ({e}) — refusing to \
+                     start (fail-closed, never a partial zone map)"
+                );
+                std::process::exit(2);
+            }
+        }
+    }
     config
 }
 

--- a/parko/crates/parko-ros2/src/commit_zone_producer.rs
+++ b/parko/crates/parko-ros2/src/commit_zone_producer.rs
@@ -1,0 +1,823 @@
+// parko/crates/parko-ros2/src/commit_zone_producer.rs
+//
+// #1124 (SG5 go-live, producer half) — the MAP-ANCHORED COMMIT-ZONE PRODUCER.
+//
+// The SG5 commit-zone gate (`scene_vetoes::apply_commit_zone_gate` over
+// `parko_core::commit_zone`) shipped fully tested but with NO producer for its
+// scene slot: arming it meant a permanent fail-closed immobilization, which the
+// #795 F6 startup guard refuses without an explicit acknowledgment. This module
+// is the first real producer — map-anchored, NO new perception:
+//
+//   * The ZONES are a site-authored, versioned JSON artifact (rail crossings,
+//     box junctions, narrow bridges — polygons in the map frame), loaded and
+//     validated FAIL-CLOSED at startup (`parse_commit_zone_spec`; any defect
+//     aborts the node rather than producing a partial map).
+//   * The ANCHOR is the ego pose (`PARKO_POSE_TOPIC`, `nav_msgs/Odometry`):
+//     the producer computes the ego→zone distance each tick. A missing, stale,
+//     or non-finite pose yields `CommitZoneScene::Unknown` — which the gate
+//     vetoes ("Reject fires from MAP ALONE", the SG5 robustness property; an
+//     unanchored map prior is exactly the `Unknown` case).
+//   * The ENTRY CONFIRMATIONS are DERIVED, never asserted: `exit_verified` via
+//     `exit_clearance_verified` over supplied receiving-space evidence, and
+//     `clearance_confirmed` via `non_yielding_clearance` over the supplied
+//     non-yielding-agent scene. The node currently supplies NO evidence
+//     (`NonYieldingScene::Absent`, no exit measurement) — so a zone within the
+//     look-ahead VETOES (stop short), which is SG5's intended fail-closed
+//     behaviour until the #107/#108 evidence ingestion lands. The evidence
+//     parameters exist so that landing is a producer change, not a rework, and
+//     the tests prove entry becomes earnable the moment evidence arrives.
+//
+// CONSERVATISM OF THE GEOMETRY: the ego→zone distance is the EUCLIDEAN distance
+// to the zone polygon (0 inside). Parko has no route/path model, so this
+// LOWER-BOUNDS any along-path distance — the veto can only fire EARLIER than a
+// path-aware producer would, never later. A zone near (but not on) the ego's
+// actual path can over-veto; that is the accepted conservative direction and a
+// site chooses its zone polygons accordingly.
+//
+// LOCALIZATION COUPLING: pose FRESHNESS is enforced here (stale → `Unknown`).
+// Pose ACCURACY is AOU-LOCALIZATION-001 (the ≤0.10 m 95th-pct lateral AoU that
+// every map-anchored trust in this stack rides on); when a frame-integrity feed
+// lands in this node, `parko_core::localization::gate_commit_zone_scene`
+// composes on top of this producer unchanged (untrusted pose → `Unknown`).
+
+use parko_core::commit_zone::{
+    exit_clearance_verified, non_yielding_clearance, CommitZoneCfg, CommitZoneMap, CommitZoneScene,
+    ExitClearanceEvidence, NonYieldingScene,
+};
+
+use crate::scene_vetoes::StampedScene;
+
+/// The one spec schema version this build understands. A different version is
+/// a REFUSAL, never a best-effort parse (a future schema could carry fields
+/// whose absence changes safety semantics).
+pub const COMMIT_ZONE_SPEC_VERSION: u64 = 1;
+
+/// Confidence carried on the produced `CommitZoneMap` prior. The zone map is a
+/// STATIC, load-time-validated artifact — its "confidence" is not a live
+/// estimate, so a validated spec is fully confident; what actually varies at
+/// runtime is the POSE anchoring, carried in the map's `age_ms` (the pose age)
+/// against `max_age_ms` (the pose staleness budget). The floor is kept at the
+/// containment corridor's conventional 0.5 so the health check stays
+/// two-sided (a future live map source can lower `confidence` meaningfully).
+pub const STATIC_MAP_CONFIDENCE: f32 = 1.0;
+/// See [`STATIC_MAP_CONFIDENCE`].
+pub const STATIC_MAP_MIN_CONFIDENCE: f32 = 0.5;
+
+/// One mapped commit zone: a closed polygon in the map frame.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommitZone {
+    /// Site-unique zone id (nonempty; e.g. `rail-xing-7`).
+    pub id: String,
+    /// Informational kind tag (e.g. `rail_crossing` / `box_junction` /
+    /// `narrow_bridge`). Not interpreted by the producer — the veto semantics
+    /// are identical for every kind (SG5 does not grade commit zones).
+    pub kind: String,
+    /// Closed polygon vertices `(x_m, y_m)`, map frame, ≥3, all finite.
+    /// The closing edge (last → first) is implicit.
+    pub polygon: Vec<(f64, f64)>,
+    /// Along-path traverse length used for clearance timing, DERIVED at load as
+    /// the polygon DIAMETER (max pairwise vertex distance). The diameter upper-
+    /// bounds any straight traverse chord, so the derived clearance time is
+    /// CONSERVATIVE (a longer assumed zone → a longer required gap).
+    pub length_m: f64,
+}
+
+/// The loaded, validated commit-zone map (≥1 zone, unique ids).
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommitZoneSpec {
+    pub zones: Vec<CommitZone>,
+}
+
+/// Why a spec was refused. Every variant is a startup ABORT in the binary —
+/// a defective zone map must never anchor a safety veto.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SpecError {
+    /// Not valid JSON, or the top level is not an object.
+    Malformed(String),
+    /// `version` missing or not the supported [`COMMIT_ZONE_SPEC_VERSION`].
+    UnsupportedVersion(Option<u64>),
+    /// `zones` missing, not an array, or empty. An EMPTY zone map is refused
+    /// deliberately: a site with no commit zones should not configure the
+    /// producer at all (and not arm the gate) — an empty spec is far more
+    /// likely an authoring error than a statement of fact.
+    NoZones,
+    /// A zone entry failed validation; the message names the zone and defect.
+    BadZone(String),
+    /// Two zones share an id.
+    DuplicateId(String),
+}
+
+impl std::fmt::Display for SpecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpecError::Malformed(m) => write!(f, "commit-zone spec is not valid JSON: {m}"),
+            SpecError::UnsupportedVersion(v) => write!(
+                f,
+                "commit-zone spec version {v:?} is not the supported version \
+                 {COMMIT_ZONE_SPEC_VERSION}"
+            ),
+            SpecError::NoZones => write!(
+                f,
+                "commit-zone spec has no zones — a site with no commit zones should not \
+                 configure the producer (an empty spec is refused as a likely authoring error)"
+            ),
+            SpecError::BadZone(m) => write!(f, "commit-zone spec zone invalid: {m}"),
+            SpecError::DuplicateId(id) => {
+                write!(f, "commit-zone spec has duplicate zone id {id:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SpecError {}
+
+/// Parse + validate a commit-zone spec JSON document (fail-closed: any defect
+/// refuses the WHOLE spec — never a partial zone map).
+///
+/// Schema (version 1):
+/// ```json
+/// {
+///   "version": 1,
+///   "zones": [
+///     { "id": "rail-xing-7", "kind": "rail_crossing",
+///       "polygon": [[12.0, 3.0], [18.0, 3.0], [18.0, 9.0], [12.0, 9.0]] }
+///   ]
+/// }
+/// ```
+// SAFETY: SG5 | REQ: commit-zone-spec-fail-closed-load | TEST: spec_happy_path_parses,spec_wrong_version_refused,spec_missing_or_empty_zones_refused,spec_duplicate_id_refused,spec_bad_polygon_refused,spec_nonfinite_vertex_refused,spec_degenerate_polygon_refused,spec_malformed_json_refused
+pub fn parse_commit_zone_spec(json: &str) -> Result<CommitZoneSpec, SpecError> {
+    let root: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| SpecError::Malformed(e.to_string()))?;
+    let obj = root
+        .as_object()
+        .ok_or_else(|| SpecError::Malformed("top level is not an object".to_string()))?;
+
+    let version = obj.get("version").and_then(|v| v.as_u64());
+    if version != Some(COMMIT_ZONE_SPEC_VERSION) {
+        return Err(SpecError::UnsupportedVersion(version));
+    }
+
+    let zones_raw = obj
+        .get("zones")
+        .and_then(|v| v.as_array())
+        .filter(|a| !a.is_empty())
+        .ok_or(SpecError::NoZones)?;
+
+    let mut zones = Vec::with_capacity(zones_raw.len());
+    let mut seen_ids = std::collections::BTreeSet::new();
+    for (i, z) in zones_raw.iter().enumerate() {
+        let zobj = z
+            .as_object()
+            .ok_or_else(|| SpecError::BadZone(format!("zones[{i}] is not an object")))?;
+        let id = zobj
+            .get("id")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| SpecError::BadZone(format!("zones[{i}] has no nonempty string id")))?
+            .to_string();
+        if !seen_ids.insert(id.clone()) {
+            return Err(SpecError::DuplicateId(id));
+        }
+        let kind = zobj
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| SpecError::BadZone(format!("zone {id:?} has no nonempty string kind")))?
+            .to_string();
+        let poly_raw = zobj
+            .get("polygon")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| SpecError::BadZone(format!("zone {id:?} has no polygon array")))?;
+        if poly_raw.len() < 3 {
+            return Err(SpecError::BadZone(format!(
+                "zone {id:?} polygon has {} vertices (need >= 3)",
+                poly_raw.len()
+            )));
+        }
+        let mut polygon = Vec::with_capacity(poly_raw.len());
+        for (j, v) in poly_raw.iter().enumerate() {
+            let pair = v.as_array().filter(|a| a.len() == 2).ok_or_else(|| {
+                SpecError::BadZone(format!("zone {id:?} polygon[{j}] is not an [x, y] pair"))
+            })?;
+            let x = pair[0].as_f64();
+            let y = pair[1].as_f64();
+            match (x, y) {
+                (Some(x), Some(y)) if x.is_finite() && y.is_finite() => polygon.push((x, y)),
+                _ => {
+                    return Err(SpecError::BadZone(format!(
+                        "zone {id:?} polygon[{j}] has a non-finite or non-numeric coordinate"
+                    )))
+                }
+            }
+        }
+        let length_m = polygon_diameter(&polygon);
+        if !(length_m.is_finite() && length_m > 0.0) {
+            return Err(SpecError::BadZone(format!(
+                "zone {id:?} polygon is degenerate (diameter {length_m}) — all vertices coincide"
+            )));
+        }
+        zones.push(CommitZone {
+            id,
+            kind,
+            polygon,
+            length_m,
+        });
+    }
+    Ok(CommitZoneSpec { zones })
+}
+
+/// Max pairwise vertex distance — the conservative traverse-length bound.
+fn polygon_diameter(polygon: &[(f64, f64)]) -> f64 {
+    let mut d: f64 = 0.0;
+    for i in 0..polygon.len() {
+        for j in (i + 1)..polygon.len() {
+            let (ax, ay) = polygon[i];
+            let (bx, by) = polygon[j];
+            d = d.max((ax - bx).hypot(ay - by));
+        }
+    }
+    d
+}
+
+/// The ego pose sample the producer anchors on (map frame, metres). Heading is
+/// deliberately absent: the Euclidean lower-bound distance needs none, and a
+/// heading-dependent "is the zone ahead of me" filter would RELAX the bound
+/// (a zone behind a reversing ego must still bind).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EgoPose {
+    pub x_m: f64,
+    pub y_m: f64,
+}
+
+/// Distance from a point to a closed polygon: 0.0 inside (or on the boundary),
+/// else the minimum distance to any edge. Assumes finite, pre-validated
+/// vertices (the spec loader enforces this); the POINT is the caller's to
+/// validate (the producer refuses a non-finite pose before calling).
+// SAFETY: SG5 | REQ: commit-zone-distance-conservative | TEST: distance_inside_is_zero,distance_to_edge_hand_checked,distance_to_vertex_hand_checked,distance_on_boundary_is_zero
+pub fn distance_to_zone(point: (f64, f64), polygon: &[(f64, f64)]) -> f64 {
+    if point_in_polygon(point, polygon) {
+        return 0.0;
+    }
+    let mut best = f64::INFINITY;
+    for i in 0..polygon.len() {
+        let a = polygon[i];
+        let b = polygon[(i + 1) % polygon.len()];
+        best = best.min(point_segment_distance(point, a, b));
+    }
+    best
+}
+
+fn point_segment_distance(p: (f64, f64), a: (f64, f64), b: (f64, f64)) -> f64 {
+    let (px, py) = p;
+    let (ax, ay) = a;
+    let (bx, by) = b;
+    let (dx, dy) = (bx - ax, by - ay);
+    let len2 = dx * dx + dy * dy;
+    // Degenerate edge (repeated vertex) → distance to the point itself.
+    if len2 <= 0.0 {
+        return (px - ax).hypot(py - ay);
+    }
+    let t = (((px - ax) * dx + (py - ay) * dy) / len2).clamp(0.0, 1.0);
+    let (cx, cy) = (ax + t * dx, ay + t * dy);
+    (px - cx).hypot(py - cy)
+}
+
+/// Even-odd ray cast; boundary points count as INSIDE via a small edge-distance
+/// check (conservative: on-the-line reads distance 0, never a sliver positive).
+fn point_in_polygon(p: (f64, f64), polygon: &[(f64, f64)]) -> bool {
+    let (px, py) = p;
+    let mut inside = false;
+    let n = polygon.len();
+    let mut j = n - 1;
+    for i in 0..n {
+        let (xi, yi) = polygon[i];
+        let (xj, yj) = polygon[j];
+        if ((yi > py) != (yj > py)) && (px < (xj - xi) * (py - yi) / (yj - yi) + xi) {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}
+
+/// The entry-confirmation evidence the node supplies alongside the map prior.
+/// TODAY the node passes the no-evidence values (`NonYieldingScene::Absent`,
+/// `exit: None`) — both derivations then FAIL CLOSED and a zone within the
+/// look-ahead vetoes (stop short). When the #107/#108 evidence ingestion lands,
+/// the node fills these from perception and entry becomes earnable with NO
+/// change to this producer.
+pub struct CommitZoneEvidence<'a> {
+    /// The non-yielding-crosser scene (train / fast agent). `Absent` → the
+    /// clearance derivation fails closed (never "no train").
+    pub non_yielding: &'a NonYieldingScene,
+    /// Measured downstream receiving space beyond the zone's far edge. `None` →
+    /// the exit derivation fails closed (an unmeasured exit is NO exit).
+    pub exit: Option<&'a ExitClearanceEvidence>,
+    /// The ego speed (m/s) used for the traverse-time half of the clearance
+    /// derivation (the tick's proposed |linear| speed).
+    pub ego_speed_mps: f64,
+}
+
+impl CommitZoneEvidence<'_> {
+    /// The node's current no-evidence instance (#107/#108 ingestion deferred).
+    #[must_use]
+    pub fn absent(ego_speed_mps: f64) -> CommitZoneEvidence<'static> {
+        CommitZoneEvidence {
+            non_yielding: &NonYieldingScene::Absent,
+            exit: None,
+            ego_speed_mps,
+        }
+    }
+}
+
+/// Produce this tick's [`CommitZoneScene`] from the static zone spec anchored
+/// on the latest ego pose.
+///
+/// FAIL-CLOSED lattice:
+///   * pose missing / stale / future-skewed (per [`StampedScene::is_fresh`]) /
+///     non-finite → [`CommitZoneScene::Unknown`] (an unanchored map prior; the
+///     gate vetoes — "Reject fires from MAP ALONE").
+///   * otherwise → [`CommitZoneScene::ZoneAhead`] for the NEAREST zone, with
+///     `distance_to_zone_m` the Euclidean lower bound (0 inside),
+///     `zone_length_m` the zone's conservative diameter, and BOTH entry
+///     confirmations DERIVED from `evidence` via the parko-core primitives
+///     (no-evidence → both false → the gate vetoes within the look-ahead; a
+///     zone beyond the look-ahead is not yet actionable and does not veto).
+///
+/// This producer never emits `NoZone`: a validated spec always carries ≥1 zone
+/// and "far away" is expressed as a large `distance_to_zone_m`, which the
+/// gate's look-ahead horizon already treats as not-yet-actionable — identical
+/// routing outcome, without a second horizon constant living here.
+// SAFETY: SG5 | REQ: commit-zone-producer-fail-closed | TEST: producer_no_pose_is_unknown,producer_stale_pose_is_unknown,producer_future_skewed_pose_is_unknown,producer_nonfinite_pose_is_unknown,producer_reports_nearest_zone,producer_no_evidence_vetoes_within_lookahead,producer_far_zone_does_not_veto,producer_entry_earnable_with_evidence,producer_inside_zone_distance_zero,producer_map_health_carries_pose_age
+pub fn produce_commit_zone_scene(
+    spec: &CommitZoneSpec,
+    pose: Option<&StampedScene<EgoPose>>,
+    pose_max_age_ms: u64,
+    now_ms: u64,
+    cfg: &CommitZoneCfg,
+    evidence: &CommitZoneEvidence<'_>,
+) -> CommitZoneScene {
+    let stamped = match pose {
+        Some(s) if s.is_fresh(now_ms, pose_max_age_ms) => s,
+        _ => return CommitZoneScene::Unknown,
+    };
+    let ego = stamped.scene;
+    if !(ego.x_m.is_finite() && ego.y_m.is_finite()) {
+        return CommitZoneScene::Unknown;
+    }
+
+    // Nearest zone by the conservative Euclidean lower bound. The spec loader
+    // guarantees ≥1 zone, so the fold always yields one; the defensive Unknown
+    // arm keeps an impossible empty spec fail-closed rather than panicking.
+    let Some((zone, distance_m)) = spec
+        .zones
+        .iter()
+        .map(|z| (z, distance_to_zone((ego.x_m, ego.y_m), &z.polygon)))
+        .min_by(|a, b| a.1.total_cmp(&b.1))
+    else {
+        return CommitZoneScene::Unknown;
+    };
+
+    let map = CommitZoneMap {
+        zone_ahead: true,
+        distance_to_zone_m: distance_m,
+        confidence: STATIC_MAP_CONFIDENCE,
+        // The static prior's freshness IS the pose anchoring's freshness, so the
+        // gate's own `is_healthy` re-verifies what the producer just checked
+        // (belt-and-braces; the two staleness gates share one budget).
+        age_ms: stamped.age_ms(now_ms),
+        min_confidence: STATIC_MAP_MIN_CONFIDENCE,
+        max_age_ms: pose_max_age_ms,
+    };
+    // DERIVED confirmations — never asserted (the #107/#108 discipline).
+    let exit_verified = evidence
+        .exit
+        .map(|e| exit_clearance_verified(e, cfg))
+        .unwrap_or(false);
+    let clearance_confirmed = non_yielding_clearance(
+        evidence.non_yielding,
+        &map,
+        zone.length_m,
+        evidence.ego_speed_mps,
+        cfg,
+    );
+    CommitZoneScene::ZoneAhead {
+        map,
+        clearance_confirmed,
+        exit_verified,
+        zone_length_m: zone.length_m,
+        proposed_stop_distance_m: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parko_core::commit_zone::commit_zone_blocked;
+
+    /// A valid two-zone spec: a 6×6 square at x∈[12,18], y∈[3,9] and a far
+    /// 4×4 square at x∈[200,204], y∈[0,4].
+    fn spec_json() -> &'static str {
+        r#"{
+            "version": 1,
+            "zones": [
+                { "id": "rail-xing-7", "kind": "rail_crossing",
+                  "polygon": [[12.0, 3.0], [18.0, 3.0], [18.0, 9.0], [12.0, 9.0]] },
+                { "id": "box-junction-2", "kind": "box_junction",
+                  "polygon": [[200.0, 0.0], [204.0, 0.0], [204.0, 4.0], [200.0, 4.0]] }
+            ]
+        }"#
+    }
+
+    fn spec() -> CommitZoneSpec {
+        parse_commit_zone_spec(spec_json()).expect("fixture spec parses")
+    }
+
+    fn fresh_pose(x: f64, y: f64) -> StampedScene<EgoPose> {
+        StampedScene {
+            scene: EgoPose { x_m: x, y_m: y },
+            stamp_ms: 1_000,
+        }
+    }
+
+    fn cfg() -> CommitZoneCfg {
+        CommitZoneCfg::default() // look_ahead 94 m, vehicle 4.5 m, margin 1.0 m
+    }
+
+    // ---- spec load (fail-closed) -------------------------------------------
+
+    #[test]
+    fn spec_happy_path_parses() {
+        let s = spec();
+        assert_eq!(s.zones.len(), 2);
+        assert_eq!(s.zones[0].id, "rail-xing-7");
+        assert_eq!(s.zones[0].kind, "rail_crossing");
+        // Diameter of a 6×6 square = 6·√2.
+        let expect = 6.0 * std::f64::consts::SQRT_2;
+        assert!(
+            (s.zones[0].length_m - expect).abs() < 1e-9,
+            "derived length must be the polygon diameter; got {}",
+            s.zones[0].length_m
+        );
+    }
+
+    #[test]
+    fn spec_wrong_version_refused() {
+        let bad = spec_json().replace("\"version\": 1", "\"version\": 2");
+        assert_eq!(
+            parse_commit_zone_spec(&bad),
+            Err(SpecError::UnsupportedVersion(Some(2)))
+        );
+        let missing = r#"{ "zones": [] }"#;
+        assert_eq!(
+            parse_commit_zone_spec(missing),
+            Err(SpecError::UnsupportedVersion(None))
+        );
+    }
+
+    #[test]
+    fn spec_missing_or_empty_zones_refused() {
+        for bad in [
+            r#"{ "version": 1 }"#,
+            r#"{ "version": 1, "zones": [] }"#,
+            r#"{ "version": 1, "zones": 42 }"#,
+        ] {
+            assert_eq!(
+                parse_commit_zone_spec(bad),
+                Err(SpecError::NoZones),
+                "{bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn spec_duplicate_id_refused() {
+        let bad = spec_json().replace("box-junction-2", "rail-xing-7");
+        assert_eq!(
+            parse_commit_zone_spec(&bad),
+            Err(SpecError::DuplicateId("rail-xing-7".to_string()))
+        );
+    }
+
+    #[test]
+    fn spec_bad_polygon_refused() {
+        // Two vertices only.
+        let two = r#"{ "version": 1, "zones": [
+            { "id": "z", "kind": "k", "polygon": [[0.0, 0.0], [1.0, 1.0]] } ] }"#;
+        assert!(matches!(
+            parse_commit_zone_spec(two),
+            Err(SpecError::BadZone(_))
+        ));
+        // A vertex that is not an [x, y] pair.
+        let pair = r#"{ "version": 1, "zones": [
+            { "id": "z", "kind": "k", "polygon": [[0.0, 0.0], [1.0], [1.0, 1.0]] } ] }"#;
+        assert!(matches!(
+            parse_commit_zone_spec(pair),
+            Err(SpecError::BadZone(_))
+        ));
+        // Missing id / kind.
+        let noid = r#"{ "version": 1, "zones": [
+            { "kind": "k", "polygon": [[0.0,0.0],[1.0,0.0],[1.0,1.0]] } ] }"#;
+        assert!(matches!(
+            parse_commit_zone_spec(noid),
+            Err(SpecError::BadZone(_))
+        ));
+        let nokind = r#"{ "version": 1, "zones": [
+            { "id": "z", "polygon": [[0.0,0.0],[1.0,0.0],[1.0,1.0]] } ] }"#;
+        assert!(matches!(
+            parse_commit_zone_spec(nokind),
+            Err(SpecError::BadZone(_))
+        ));
+    }
+
+    #[test]
+    fn spec_nonfinite_vertex_refused() {
+        // JSON has no NaN/Infinity literal — a string smuggle must also refuse
+        // (as_f64 on a string is None → non-numeric).
+        let bad = r#"{ "version": 1, "zones": [
+            { "id": "z", "kind": "k", "polygon": [[0.0, 0.0], ["NaN", 0.0], [1.0, 1.0]] } ] }"#;
+        assert!(matches!(
+            parse_commit_zone_spec(bad),
+            Err(SpecError::BadZone(_))
+        ));
+    }
+
+    #[test]
+    fn spec_degenerate_polygon_refused() {
+        let bad = r#"{ "version": 1, "zones": [
+            { "id": "z", "kind": "k", "polygon": [[5.0, 5.0], [5.0, 5.0], [5.0, 5.0]] } ] }"#;
+        assert!(matches!(
+            parse_commit_zone_spec(bad),
+            Err(SpecError::BadZone(_))
+        ));
+    }
+
+    #[test]
+    fn spec_malformed_json_refused() {
+        assert!(matches!(
+            parse_commit_zone_spec("not json"),
+            Err(SpecError::Malformed(_))
+        ));
+        assert!(matches!(
+            parse_commit_zone_spec("[1, 2, 3]"),
+            Err(SpecError::Malformed(_))
+        ));
+    }
+
+    // ---- geometry (hand-checked) -------------------------------------------
+
+    const UNIT_SQUARE: [(f64, f64); 4] = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)];
+
+    #[test]
+    fn distance_inside_is_zero() {
+        assert_eq!(distance_to_zone((0.5, 0.5), &UNIT_SQUARE), 0.0);
+    }
+
+    #[test]
+    fn distance_to_edge_hand_checked() {
+        // (2, 0.5) is 1.0 right of the unit square's right edge.
+        let d = distance_to_zone((2.0, 0.5), &UNIT_SQUARE);
+        assert!((d - 1.0).abs() < 1e-12, "got {d}");
+    }
+
+    #[test]
+    fn distance_to_vertex_hand_checked() {
+        // (2, 2) is nearest the (1, 1) corner → √2.
+        let d = distance_to_zone((2.0, 2.0), &UNIT_SQUARE);
+        assert!((d - std::f64::consts::SQRT_2).abs() < 1e-12, "got {d}");
+    }
+
+    #[test]
+    fn distance_on_boundary_is_zero() {
+        // A point ON an edge must read 0 (edge distance is 0 even when the
+        // even-odd inside test is ambiguous on the boundary).
+        let d = distance_to_zone((1.0, 0.5), &UNIT_SQUARE);
+        assert!(d.abs() < 1e-12, "boundary point must read 0, got {d}");
+    }
+
+    // ---- producer (fail-closed lattice) --------------------------------------
+
+    #[test]
+    fn producer_no_pose_is_unknown() {
+        let s = produce_commit_zone_scene(
+            &spec(),
+            None,
+            500,
+            1_000,
+            &cfg(),
+            &CommitZoneEvidence::absent(1.0),
+        );
+        assert!(matches!(s, CommitZoneScene::Unknown));
+        assert!(
+            commit_zone_blocked(&s, &cfg()),
+            "an unanchored map prior must veto (Reject from map alone)"
+        );
+    }
+
+    #[test]
+    fn producer_stale_pose_is_unknown() {
+        let pose = fresh_pose(0.0, 6.0); // stamp 1_000
+        let s = produce_commit_zone_scene(
+            &spec(),
+            Some(&pose),
+            500,
+            10_000, // 9 s later — stale
+            &cfg(),
+            &CommitZoneEvidence::absent(1.0),
+        );
+        assert!(matches!(s, CommitZoneScene::Unknown));
+    }
+
+    #[test]
+    fn producer_future_skewed_pose_is_unknown() {
+        // #770 F4 parity: a pose stamped implausibly in the future is a clock
+        // fault, not an age-0 anchor.
+        let pose = StampedScene {
+            scene: EgoPose { x_m: 0.0, y_m: 6.0 },
+            stamp_ms: 100_000,
+        };
+        let s = produce_commit_zone_scene(
+            &spec(),
+            Some(&pose),
+            500,
+            1_000,
+            &cfg(),
+            &CommitZoneEvidence::absent(1.0),
+        );
+        assert!(matches!(s, CommitZoneScene::Unknown));
+    }
+
+    #[test]
+    fn producer_nonfinite_pose_is_unknown() {
+        for (x, y) in [(f64::NAN, 6.0), (0.0, f64::INFINITY)] {
+            let pose = fresh_pose(x, y);
+            let s = produce_commit_zone_scene(
+                &spec(),
+                Some(&pose),
+                500,
+                1_000,
+                &cfg(),
+                &CommitZoneEvidence::absent(1.0),
+            );
+            assert!(
+                matches!(s, CommitZoneScene::Unknown),
+                "non-finite pose ({x},{y}) must be Unknown"
+            );
+        }
+    }
+
+    #[test]
+    fn producer_reports_nearest_zone() {
+        // Ego at (0, 6): 12 m left of the rail crossing's near edge, ~190 m from
+        // the box junction → the rail crossing is the reported zone.
+        let pose = fresh_pose(0.0, 6.0);
+        let s = produce_commit_zone_scene(
+            &spec(),
+            Some(&pose),
+            500,
+            1_000,
+            &cfg(),
+            &CommitZoneEvidence::absent(1.0),
+        );
+        match s {
+            CommitZoneScene::ZoneAhead {
+                map, zone_length_m, ..
+            } => {
+                assert!(
+                    (map.distance_to_zone_m - 12.0).abs() < 1e-9,
+                    "nearest-zone distance must be the rail crossing's 12 m, got {}",
+                    map.distance_to_zone_m
+                );
+                let expect_len = 6.0 * std::f64::consts::SQRT_2;
+                assert!((zone_length_m - expect_len).abs() < 1e-9);
+            }
+            other => panic!("expected ZoneAhead, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn producer_no_evidence_vetoes_within_lookahead() {
+        // The go-live semantics: a zone within the look-ahead with NO evidence
+        // (Absent non-yielding scene, unmeasured exit) VETOES — stop short.
+        let pose = fresh_pose(0.0, 6.0); // 12 m out, well within 94 m
+        let s = produce_commit_zone_scene(
+            &spec(),
+            Some(&pose),
+            500,
+            1_000,
+            &cfg(),
+            &CommitZoneEvidence::absent(1.0),
+        );
+        match &s {
+            CommitZoneScene::ZoneAhead {
+                clearance_confirmed,
+                exit_verified,
+                ..
+            } => {
+                assert!(!clearance_confirmed, "Absent scene must derive NOT clear");
+                assert!(!exit_verified, "unmeasured exit must derive NOT verified");
+            }
+            other => panic!("expected ZoneAhead, got {other:?}"),
+        }
+        assert!(
+            commit_zone_blocked(&s, &cfg()),
+            "no-evidence zone within look-ahead must veto (stop short)"
+        );
+    }
+
+    #[test]
+    fn producer_far_zone_does_not_veto() {
+        // Ego far from every zone: nearest distance > look-ahead → the gate's
+        // horizon rule leaves the command unbound (no over-veto in open space).
+        let pose = fresh_pose(-500.0, 6.0);
+        let s = produce_commit_zone_scene(
+            &spec(),
+            Some(&pose),
+            500,
+            1_000,
+            &cfg(),
+            &CommitZoneEvidence::absent(1.0),
+        );
+        assert!(
+            !commit_zone_blocked(&s, &cfg()),
+            "a zone beyond the look-ahead must not veto"
+        );
+    }
+
+    #[test]
+    fn producer_entry_earnable_with_evidence() {
+        // The derivation seam is NOT welded shut: positive non-yielding
+        // clearance (KnownNone) + ample measured receiving space earn entry.
+        let pose = fresh_pose(0.0, 6.0);
+        let exit = ExitClearanceEvidence {
+            downstream_clear_m: 20.0, // >> 4.5 + 1.0
+        };
+        let evidence = CommitZoneEvidence {
+            non_yielding: &NonYieldingScene::KnownNone,
+            exit: Some(&exit),
+            ego_speed_mps: 1.0,
+        };
+        let s = produce_commit_zone_scene(&spec(), Some(&pose), 500, 1_000, &cfg(), &evidence);
+        match &s {
+            CommitZoneScene::ZoneAhead {
+                clearance_confirmed,
+                exit_verified,
+                ..
+            } => {
+                assert!(clearance_confirmed);
+                assert!(exit_verified);
+            }
+            other => panic!("expected ZoneAhead, got {other:?}"),
+        }
+        assert!(
+            !commit_zone_blocked(&s, &cfg()),
+            "confirmed + verified entry on a fresh anchor must not veto"
+        );
+    }
+
+    #[test]
+    fn producer_inside_zone_distance_zero() {
+        // Ego INSIDE the rail crossing → distance 0 (within look-ahead, no
+        // evidence → veto: the gate holds the stop while inside an unconfirmed
+        // zone rather than fabricating clearance).
+        let pose = fresh_pose(15.0, 6.0);
+        let s = produce_commit_zone_scene(
+            &spec(),
+            Some(&pose),
+            500,
+            1_000,
+            &cfg(),
+            &CommitZoneEvidence::absent(1.0),
+        );
+        match &s {
+            CommitZoneScene::ZoneAhead { map, .. } => {
+                assert_eq!(map.distance_to_zone_m, 0.0);
+            }
+            other => panic!("expected ZoneAhead, got {other:?}"),
+        }
+        assert!(commit_zone_blocked(&s, &cfg()));
+    }
+
+    #[test]
+    fn producer_map_health_carries_pose_age() {
+        // The produced map prior's age is the POSE age against the pose budget,
+        // so the gate's own is_healthy re-verifies the anchoring freshness.
+        let pose = fresh_pose(0.0, 6.0); // stamp 1_000
+        let s = produce_commit_zone_scene(
+            &spec(),
+            Some(&pose),
+            500,
+            1_300, // age 300 of budget 500 — fresh
+            &cfg(),
+            &CommitZoneEvidence::absent(1.0),
+        );
+        match s {
+            CommitZoneScene::ZoneAhead { map, .. } => {
+                assert_eq!(map.age_ms, 300);
+                assert_eq!(map.max_age_ms, 500);
+                assert!(map.is_healthy());
+            }
+            other => panic!("expected ZoneAhead, got {other:?}"),
+        }
+    }
+}

--- a/parko/crates/parko-ros2/src/config.rs
+++ b/parko/crates/parko-ros2/src/config.rs
@@ -191,6 +191,23 @@ pub struct ParkoNodeConfig {
     /// `CommitZoneCfg::default()` (byte-identical to the prior hardcode).
     pub commit_zone_config: CommitZoneCfg,
 
+    /// #1124 (SG5 go-live) — ego-pose topic (`nav_msgs/Odometry`, map frame)
+    /// anchoring the map-anchored commit-zone producer. When set together with
+    /// `commit_zone_spec`, the producer computes a fresh `CommitZoneScene` each
+    /// tick from the latest pose (missing/stale/non-finite pose → `Unknown` →
+    /// veto), and the commit-zone gate is no longer producer-less. **Default
+    /// `None`.** Env: `PARKO_POSE_TOPIC`.
+    pub pose_topic: Option<String>,
+
+    /// #1124 (SG5 go-live) — the LOADED, VALIDATED commit-zone map spec (site-
+    /// authored zone polygons; see `commit_zone_producer::parse_commit_zone_spec`).
+    /// The binary loads it fail-closed from `PARKO_COMMIT_ZONE_MAP_PATH` (an
+    /// unreadable or invalid spec ABORTS startup — never a partial zone map).
+    /// Together with `pose_topic` this arms the producer
+    /// ([`commit_zone_producer_armed`](Self::commit_zone_producer_armed)).
+    /// **Default `None`.**
+    pub commit_zone_spec: Option<crate::commit_zone_producer::CommitZoneSpec>,
+
     /// #795 F6 — EXPLICIT operator acknowledgment that a scene-veto gate
     /// (occlusion / water / commit-zone) may be ARMED even though this build ships
     /// **no producer** for its slot. An armed gate with no producer fails closed to
@@ -255,6 +272,10 @@ impl Default for ParkoNodeConfig {
             // loop); default to their parko-core Default() → byte-identical.
             water_veto_config: WaterVetoConfig::default(),
             commit_zone_config: CommitZoneCfg::default(),
+            // #1124: no pose channel / zone map by default — the commit-zone
+            // producer arms only when BOTH are configured.
+            pose_topic: None,
+            commit_zone_spec: None,
             // #795 F6: a producer-less armed gate is a permanent immobilizer;
             // arming one requires the operator's explicit acknowledgment.
             allow_scene_gate_without_producer: false,
@@ -338,6 +359,11 @@ impl ParkoNodeConfig {
     ///
     /// Returned by name (fixed order occlusion → water → commit-zone) so the
     /// startup guard can name exactly which gates are producer-less.
+    ///
+    /// #1124: commit-zone now has a REAL producer (the map-anchored
+    /// `commit_zone_producer`), so an armed commit-zone gate counts as
+    /// producer-less only when that producer is NOT configured
+    /// ([`commit_zone_producer_armed`](Self::commit_zone_producer_armed)).
     #[must_use]
     pub fn producerless_armed_scene_gates(&self) -> Vec<&'static str> {
         let mut armed = Vec::new();
@@ -347,10 +373,24 @@ impl ParkoNodeConfig {
         if self.water_gate_enabled {
             armed.push("water");
         }
-        if self.commit_zone_gate_enabled {
+        if self.commit_zone_gate_enabled && !self.commit_zone_producer_armed() {
             armed.push("commit_zone");
         }
         armed
+    }
+
+    /// #1124 — the SINGLE commit-zone-producer arming predicate (the same
+    /// one-predicate discipline as [`object_gate_armed`](Self::object_gate_armed)):
+    /// the map-anchored producer runs only when BOTH its inputs are configured —
+    /// the validated zone spec (`commit_zone_spec`, loaded fail-closed by the
+    /// binary) and the ego-pose channel (`pose_topic`, the anchor). Missing
+    /// either → the producer cannot anchor the map prior, so it stays dark and
+    /// an armed commit-zone gate is still counted producer-less (startup
+    /// refusal, #795 F6). node.rs's per-tick fill and this guard both call this
+    /// one method so the two halves cannot drift.
+    #[must_use]
+    pub fn commit_zone_producer_armed(&self) -> bool {
+        self.commit_zone_spec.is_some() && self.pose_topic.is_some()
     }
 
     /// #795 F6 — fail-closed startup guard against SILENT permanent immobilization.
@@ -569,6 +609,101 @@ mod tests {
         assert!(
             cfg.scene_gate_startup_check().is_ok(),
             "an acknowledged immobilizer may start"
+        );
+    }
+
+    /// #1124 — a minimal valid loaded zone spec for the producer-arming tests.
+    fn loaded_spec() -> crate::commit_zone_producer::CommitZoneSpec {
+        crate::commit_zone_producer::parse_commit_zone_spec(
+            r#"{ "version": 1, "zones": [
+                { "id": "z", "kind": "rail_crossing",
+                  "polygon": [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]] } ] }"#,
+        )
+        .expect("fixture spec parses")
+    }
+
+    /// #1124 — the producer arms only with BOTH inputs (spec AND pose topic);
+    /// either alone stays dark (and an armed gate stays producer-less).
+    #[test]
+    fn commit_zone_producer_arming_truth_table() {
+        for (spec, topic, expect) in [
+            (false, false, false),
+            (true, false, false),
+            (false, true, false),
+            (true, true, true),
+        ] {
+            let cfg = ParkoNodeConfig {
+                commit_zone_spec: spec.then(loaded_spec),
+                pose_topic: topic.then(|| "/odom".to_string()),
+                ..ParkoNodeConfig::default()
+            };
+            assert_eq!(
+                cfg.commit_zone_producer_armed(),
+                expect,
+                "spec={spec} topic={topic}"
+            );
+        }
+    }
+
+    /// #1124 — the go-live: an armed commit-zone gate WITH the producer
+    /// configured is no longer producer-less, so startup passes with NO
+    /// acknowledgment flag. A partially-configured producer (spec without pose
+    /// topic, or vice versa) still refuses.
+    #[test]
+    fn commit_zone_gate_with_producer_passes_startup() {
+        let cfg = ParkoNodeConfig {
+            commit_zone_gate_enabled: true,
+            commit_zone_spec: Some(loaded_spec()),
+            pose_topic: Some("/odom".to_string()),
+            ..ParkoNodeConfig::default()
+        };
+        assert!(cfg.producerless_armed_scene_gates().is_empty());
+        assert!(
+            cfg.scene_gate_startup_check().is_ok(),
+            "an armed gate with a configured producer must start without the \
+             immobilizer acknowledgment"
+        );
+
+        for (spec, topic) in [(true, false), (false, true)] {
+            let partial = ParkoNodeConfig {
+                commit_zone_gate_enabled: true,
+                commit_zone_spec: spec.then(loaded_spec),
+                pose_topic: topic.then(|| "/odom".to_string()),
+                ..ParkoNodeConfig::default()
+            };
+            assert_eq!(
+                partial.producerless_armed_scene_gates(),
+                vec!["commit_zone"],
+                "a half-configured producer (spec={spec} topic={topic}) must still \
+                 count as producer-less"
+            );
+            assert!(partial.scene_gate_startup_check().is_err());
+        }
+    }
+
+    /// #1124 — configuring the producer WITHOUT arming the gate is inert for the
+    /// startup guard (nothing armed → nothing producer-less), and the water gate
+    /// is unaffected by the commit-zone producer.
+    #[test]
+    fn commit_zone_producer_without_gate_is_inert() {
+        let cfg = ParkoNodeConfig {
+            commit_zone_spec: Some(loaded_spec()),
+            pose_topic: Some("/odom".to_string()),
+            ..ParkoNodeConfig::default()
+        };
+        assert!(cfg.producerless_armed_scene_gates().is_empty());
+        assert!(cfg.scene_gate_startup_check().is_ok());
+
+        let water = ParkoNodeConfig {
+            water_gate_enabled: true,
+            commit_zone_spec: Some(loaded_spec()),
+            pose_topic: Some("/odom".to_string()),
+            ..ParkoNodeConfig::default()
+        };
+        assert_eq!(
+            water.producerless_armed_scene_gates(),
+            vec!["water"],
+            "the commit-zone producer must not vouch for the water gate"
         );
     }
 

--- a/parko/crates/parko-ros2/src/lib.rs
+++ b/parko/crates/parko-ros2/src/lib.rs
@@ -27,6 +27,7 @@
 pub mod backend_select;
 pub mod clearance_gate;
 pub mod command_mapping;
+pub mod commit_zone_producer;
 pub mod comparator_adapter;
 pub mod config;
 pub mod containment_gate;
@@ -57,6 +58,10 @@ pub use crate::clearance_gate::{
     run_pipeline_tick_with_clearance, ClearedTickOutcome, NodeClearance,
 };
 pub use crate::command_mapping::{enforce_outgoing_twist, OutgoingTwist};
+pub use crate::commit_zone_producer::{
+    parse_commit_zone_spec, produce_commit_zone_scene, CommitZoneEvidence, CommitZoneSpec, EgoPose,
+    SpecError,
+};
 pub use crate::comparator_adapter::ComparatorAsGovernor;
 pub use crate::config::ParkoNodeConfig;
 pub use crate::containment_gate::{

--- a/parko/crates/parko-ros2/src/node.rs
+++ b/parko/crates/parko-ros2/src/node.rs
@@ -32,6 +32,7 @@ use crate::clearance_gate::{
     run_pipeline_tick_with_clearance, ContactCell, ImpactInputs, NodeClearance,
 };
 use crate::command_mapping::OutgoingTwist;
+use crate::commit_zone_producer::{produce_commit_zone_scene, CommitZoneEvidence, EgoPose};
 use crate::config::ParkoNodeConfig;
 use crate::containment_gate::{apply_containment_gate, CONTAINMENT_HORIZON_S, CONTAINMENT_STEP_S};
 use crate::imu_shim::imu_msg_to_sample;
@@ -293,6 +294,39 @@ where
         Arc::new(StdMutex::new(None));
     let latest_commit_zone: Arc<StdMutex<Option<StampedScene<CommitZoneScene>>>> =
         Arc::new(StdMutex::new(None));
+
+    // #1124 — ego-pose channel (`nav_msgs/Odometry`, map frame) anchoring the
+    // map-anchored commit-zone producer. ARRIVAL-stamped (the same convention
+    // as the IMU arrival watchdog and the Taj track stamp — one clock, no
+    // producer-clock skew on the freshness gate; producer-side latency rides
+    // AOU-LOCALIZATION-001's timing half). Subscribed whenever a pose topic is
+    // configured, so future map-anchored producers share the channel.
+    let latest_pose: Arc<StdMutex<Option<StampedScene<EgoPose>>>> = Arc::new(StdMutex::new(None));
+    if let Some(topic) = &config.pose_topic {
+        let pose_stream =
+            node.subscribe::<r2r::nav_msgs::msg::Odometry>(topic, r2r::QosProfile::default())?;
+        let cell = Arc::clone(&latest_pose);
+        tokio::spawn(async move {
+            use futures::StreamExt;
+            let mut s = pose_stream;
+            while let Some(msg) = s.next().await {
+                let p = &msg.pose.pose.position;
+                let sample = StampedScene {
+                    scene: EgoPose { x_m: p.x, y_m: p.y },
+                    stamp_ms: current_time_ms(),
+                };
+                if let Ok(mut g) = cell.lock() {
+                    *g = Some(sample);
+                }
+            }
+            tracing::warn!(
+                "parko-ros2: pose stream closed — the commit-zone producer's anchor goes stale \
+                 and an armed commit-zone gate fails closed (stop)"
+            );
+        });
+        tracing::info!(topic = %topic,
+            "parko-ros2: ego-pose channel subscribed (map-anchored producer anchor, #1124)");
+    }
     // Occlusion needs the RSS params → armed only with a platform_profile
     // (same precedent as the object gate). Enabled without a profile → warn.
     let drain_occlusion_params = config
@@ -319,10 +353,24 @@ where
         );
     }
     if config.commit_zone_gate_enabled {
-        tracing::warn!(
-            "parko-ros2: WS-0.1 SG5 commit-zone gate ARMED — a missing/stale zone scene fails \
+        if config.commit_zone_producer_armed() {
+            tracing::info!(
+                zones = config
+                    .commit_zone_spec
+                    .as_ref()
+                    .map(|s| s.zones.len())
+                    .unwrap_or(0),
+                "parko-ros2: WS-0.1 SG5 commit-zone gate ARMED with the map-anchored producer \
+                 (#1124) — a missing/stale/non-finite pose anchors the map prior to Unknown → \
+                 fail-closed STOP; entry through a zone stays vetoed until clearance/exit \
+                 evidence ingestion lands (#107/#108)"
+            );
+        } else {
+            tracing::warn!(
+                "parko-ros2: WS-0.1 SG5 commit-zone gate ARMED — a missing/stale zone scene fails \
                  closed to a STOP; ensure a producer feeds the commit-zone slot"
-        );
+            );
+        }
     }
 
     // --- Drain task: consume the sensor stream, tick, publish ---------
@@ -358,6 +406,10 @@ where
     let drain_commit_zone = Arc::clone(&latest_commit_zone);
     let drain_water_armed = config.water_gate_enabled;
     let drain_commit_zone_armed = config.commit_zone_gate_enabled;
+    // #1124: the ONE producer-arming predicate (shared with the startup guard's
+    // producer-less accounting, so the two halves cannot drift).
+    let drain_commit_zone_producer = config.commit_zone_producer_armed();
+    let drain_pose = Arc::clone(&latest_pose);
 
     let drain_task = tokio::spawn(async move {
         use futures::StreamExt;
@@ -505,6 +557,36 @@ where
                 ),
                 None => outcome,
             };
+
+            // #1124 — the map-anchored commit-zone PRODUCER: derive this tick's
+            // zone scene from the static spec anchored on the latest pose, and
+            // write it into the slot the gate below reads (one path through the
+            // chain, same as an external producer would take). A missing/stale/
+            // non-finite pose yields `Unknown` (the gate vetoes — Reject from
+            // MAP ALONE). Evidence is the no-evidence instance until #107/#108
+            // ingestion lands: the derived confirmations stay false and a zone
+            // within the look-ahead vetoes (stop short) — SG5's intended
+            // fail-closed go-live behaviour.
+            if drain_commit_zone_producer {
+                if let Some(spec) = drain_config.commit_zone_spec.as_ref() {
+                    let pose_slot = drain_pose.lock().ok().and_then(|g| g.clone());
+                    let now = current_time_ms();
+                    let scene = produce_commit_zone_scene(
+                        spec,
+                        pose_slot.as_ref(),
+                        drain_config.corridor_max_age_ms,
+                        now,
+                        &drain_config.commit_zone_config,
+                        &CommitZoneEvidence::absent(outcome.twist.linear_x_mps.abs()),
+                    );
+                    if let Ok(mut g) = drain_commit_zone.lock() {
+                        *g = Some(StampedScene {
+                            scene,
+                            stamp_ms: now,
+                        });
+                    }
+                }
+            }
 
             // WS-0.1 scene-veto gates (occlusion / water / commit-zone),
             // composed after the object gate on the same publication seam via


### PR DESCRIPTION
## Summary

The SG5 commit-zone gate (`scene_vetoes::apply_commit_zone_gate` over `parko_core::commit_zone`) shipped fully tested but **producer-less** — arming it meant a permanent fail-closed immobilization, which the #795 F6 startup guard refuses without an explicit acknowledgment. This PR lands the first real producer for its scene slot: **map-anchored, no new perception**.

## What's in it

- **`parko/crates/parko-ros2/src/commit_zone_producer.rs`** (new)
  - Zones are a site-authored, **versioned JSON artifact** (polygons in the map frame — rail crossings, box junctions, narrow bridges), parsed **fail-closed** at startup (`parse_commit_zone_spec`): any defect aborts the node, never a partial zone map. An unrecognized `COMMIT_ZONE_SPEC_VERSION` is a refusal, never a best-effort parse.
  - The anchor is the ego pose: the producer computes the ego→zone distance each tick. A missing, stale, or non-finite pose yields `CommitZoneScene::Unknown` → **veto** ("reject fires from map alone", the SG5 robustness property).
  - **Geometry conservatism:** ego→zone distance is Euclidean (0 inside the polygon), which lower-bounds any along-path distance — the veto can only fire *earlier* than a path-aware producer would, never later.
  - Entry confirmations are **derived, never asserted** (`exit_clearance_verified` / `non_yielding_clearance`). The node currently supplies no evidence, so a zone within look-ahead vetoes (stop short) — SG5's intended fail-closed behaviour until #107/#108 evidence ingestion lands; tests prove entry becomes earnable the moment evidence arrives.

- **`config.rs`** — `pose_topic` (`PARKO_POSE_TOPIC`) + `commit_zone_spec` (`PARKO_COMMIT_ZONE_MAP_PATH`) slots, both default `None`. The single `commit_zone_producer_armed()` predicate (same one-predicate discipline as `object_gate_armed`) feeds both the per-tick fill and the #795 F6 producer-less-gate census, so the two halves cannot drift: an armed commit-zone gate counts as producer-less only when the producer is not configured.

- **`node.rs` / `bin/parko_ros2_node.rs`** — per-tick producer fill of the commit-zone scene slot from the latest pose; fail-closed spec load + `nav_msgs/Odometry` pose subscription wiring.

- **`docs/safety/PARKO_SCENE_VETO_SEMANTICS.md`** — producer semantics, geometry conservatism, and the localization coupling recorded: pose *freshness* is enforced here (stale → `Unknown`); pose *accuracy* rides on AOU-LOCALIZATION-001, and `parko_core::localization::gate_commit_zone_scene` composes on top unchanged when a frame-integrity feed lands.

## Safety posture

Default-off and byte-identical when unconfigured: the producer arms only when **both** the validated zone spec and the pose channel are configured; missing either keeps it dark and the #795 F6 startup refusal for a producer-less armed gate stands. Every failure direction (bad spec, stale pose, no evidence) resolves to veto/abort, never a relaxation.

## Testing

- Full `parko/` workspace test run green, including the new producer unit tests (spec parse refusals, `Unknown`-on-stale-pose, veto-until-evidence, entry-earnable-with-evidence) and the updated #795 F6 census tests.
- The only local failures were `parko-openvino`'s 4 runtime-dependent tests (no OpenVINO/ONNX native runtimes in the sandbox) — CI's runtime-free parko lane excludes those crates by design; they run in the dedicated runtime jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_