### PR TITLE
#798 roadmap: SLSA build-provenance attestation for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,6 +421,7 @@ jobs:
     permissions:
       contents: write  # create the GitHub release
       id-token: write  # keyless cosign signing (GitHub OIDC identity)
+      attestations: write  # #798 roadmap — SLSA build-provenance attestations
     env:
       # #775 F5 — the signing job routes the tag through env (data, not
       # interpolated script), the highest-value place to close the injection
@@ -492,6 +493,24 @@ jobs:
           done
           ls -l ./*.cosign.bundle
 
+      # #798 roadmap — SLSA build-PROVENANCE for the release artifacts.
+      # `cosign sign-blob` above proves WHO signed (identity), not HOW the
+      # artifact was built; this attaches a signed SLSA provenance statement
+      # (workflow, ref, builder, materials) per artifact to the repo's
+      # attestation store, closing the tarball half of the provenance story
+      # (the container images already carry BuildKit `provenance: mode=max`,
+      # merged with #798 F6). Verify per artifact with:
+      #   gh attestation verify <artifact> --repo kirra-systems/kirra-runtime-sdk
+      # L3 (structural isolation of signing via slsa-github-generator) remains
+      # the recorded roadmap step — see SUPPLY_CHAIN_OWNER_ACTIONS.md §4.
+      - name: Attest build provenance (SLSA)
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.cdx.json
+            dist/SHA256SUMS
+
       - name: Extract changelog for this version
         id: changelog
         run: |
@@ -543,6 +562,16 @@ jobs:
               'https://github.com/kirra-systems/kirra-runtime-sdk/.github/workflows/release.yml@refs/tags/@VERSION@' \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             <artifact>
+          ```
+
+          ### Verify build provenance (SLSA attestation)
+
+          Every artifact also carries a signed SLSA build-provenance
+          attestation (which workflow built it, from which commit, on which
+          builder) in this repository's attestation store:
+
+          ```sh
+          gh attestation verify <artifact> --repo kirra-systems/kirra-runtime-sdk
           ```
 
           The `kirra-@VERSION@-<bin>-<target-triple>.cdx.json` files are

--- a/docs/releases/SUPPLY_CHAIN_OWNER_ACTIONS.md
+++ b/docs/releases/SUPPLY_CHAIN_OWNER_ACTIONS.md
@@ -60,14 +60,16 @@ release run; create it manually if it does not exist yet):
   when cosign is installed; `KIRRA_REQUIRE_SIGNED=1` makes it mandatory
   (fail-closed).
 
-## 4. Roadmap remainder (tracked, not yet merged)
+## 4. Roadmap remainder (tracked)
 
-- **SLSA L2→L3 provenance for the tarballs**: adopt
-  `actions/attest-build-provenance` (or `slsa-github-generator`) in the
-  release workflow — L3 additionally isolates signing from `npm install` /
-  `build.rs` structurally. Deferred from the #798 PR only because the repo's
-  SHA-pinning rule (#775 F2) requires pinning the new action by commit SHA,
-  and resolving that SHA needs repo access outside this session's scope —
-  a one-line follow-up with the SHA in hand. (Container images already get
-  SLSA provenance via BuildKit `provenance: mode=max`, merged with #798.)
+- **SLSA build provenance for the tarballs — MERGED.** The `release` job now
+  runs `actions/attest-build-provenance` (SHA-pinned, v4.1.1) over every
+  tarball, SBOM, and `SHA256SUMS`, and the release notes carry the
+  `gh attestation verify <artifact> --repo kirra-systems/kirra-runtime-sdk`
+  instruction. (Container images already get SLSA provenance via BuildKit
+  `provenance: mode=max`, merged with #798 F6.)
+- **SLSA L3 (structural isolation)**: the remaining hardening step is
+  `slsa-github-generator`, which additionally isolates the signing identity
+  from `npm install` / `build.rs` structurally (a separate, reusable signing
+  workflow). Adopt when the release cadence justifies the workflow split.
 - QNX judge tarball SBOM: tracked in #790.


### PR DESCRIPTION
## Summary

Closes the last code-side remainder of #798. The F5/F6/F7 findings merged earlier (`5ed1a3c`): per-target SBOMs with the 7-SBOM completeness assertion, dashboard npm SBOM + BuildKit image SBOM/provenance, exact-identity verification, the `release` Environment, and `install.sh` cosign dogfooding. The one item `docs/releases/SUPPLY_CHAIN_OWNER_ACTIONS.md` §4 recorded as deferred was **SLSA build provenance for the tarballs** — blocked solely on resolving the action's commit SHA to satisfy the M-6 pin rule. This PR lands it with the SHA in hand.

## Changes

- **`.github/workflows/release.yml`**
  - The `release` job now runs `actions/attest-build-provenance@0f67c3f4…` (v4.1.1, SHA-pinned; resolved via `git ls-remote` and cross-checked against the `v4` alias peel) over every tarball, SBOM, and `SHA256SUMS`, after cosign signing. `cosign sign-blob` proves *who* signed; the attestation proves *how* the artifact was built (workflow, ref, builder, materials) — closing the tarball half of the provenance story (images already carry BuildKit `provenance: mode=max`).
  - `attestations: write` added to the release job's least-privilege permission grant (still the only job holding `id-token: write`).
  - Release notes gain a "Verify build provenance" section: `gh attestation verify <artifact> --repo kirra-systems/kirra-runtime-sdk`, alongside the existing exact-identity cosign verify.
- **`docs/releases/SUPPLY_CHAIN_OWNER_ACTIONS.md`** — §4 updated: tarball provenance recorded MERGED; SLSA L3 (`slsa-github-generator` structural signing isolation) stays the one explicit remaining roadmap step; QNX judge SBOM still tracked in #790.

## What remains on #798 (owner actions, not code)

The `v*` tag ruleset and required reviewers on the `release` Environment — GitHub settings, spelled out with exact `gh api` commands in the owner-actions doc. Once configured, #798 can close.

## Testing

- `scripts/pin-actions.sh --check` (the M-6 action-pinning gate) passes.
- Workflow YAML validates.
- No build/test surface touched — CI on this PR is the full regression evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_