### PR TITLE
feat(robot): VAD-endpointed recorder (voice-cognition Slice 1, opt-in)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1247,6 +1247,12 @@ jobs:
           # rabbit_wake control matcher incl. non-overlap with the OTA/diag/
           # drive matchers. See docs/hardware/RABBIT_AUDIO_STACK.md §3b.
           python3 robot/wake_word_test.py
+          # VAD endpointing (pure, no audio): the RMS energy math and the
+          # silence-endpoint state machine — endpoint only after enough ACTUAL
+          # speech + trailing silence, a lone click never ends the clip, and the
+          # HARD max-ms ceiling always wins (the bounded-mic guarantee). The
+          # capture loop is the hardware seam. See RABBIT_AUDIO_STACK.md §1.
+          python3 robot/vad_record_test.py
           # ADR-0033 Tier-3 sentinel logic (#887, pure, no device): owner/mode
           # violations vs the AOU-ACTUATION-SERIAL-001 contract (the vendor
           # 0777 rule is the canonical hazard case), holder reporting, and the

--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -65,8 +65,33 @@ the text comes back. Build with CUDA on the Orin if you can — it moves STT fro
 KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"   # 4 s, 16 kHz mono, the whisper-native rate
 ```
 The `-d 4` bound is the single biggest latency lever. To make Rabbit feel snappier,
-either shorten it (`-d 2` for terse commands) or, as a follow-up, put a VAD in
-front so it stops on silence instead of waiting the full window.
+either shorten it (`-d 2` for terse commands) or use **VAD endpointing** (below).
+
+### 1a. VAD endpointing (`vad_record.py`) — opt-in, stop on silence
+
+`robot/vad_record.py` is a **drop-in replacement** for the `arecord` line: it
+records ONE utterance that ends on trailing silence instead of always waiting the
+full window, so a terse "check yourself" returns in ~1 s while a longer sentence
+still gets its time — up to a hard ceiling. It writes the appended WAV path (the
+same `$KIRRA_RECORD_CMD "$wav"` contract), so nothing else in the pipeline
+changes:
+
+```bash
+KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"    # opt in
+#   (left as the arecord line above → byte-identical prior behaviour)
+```
+
+It stays a **bounded** mic, not an open one: `KIRRA_VAD_MAX_MS` (default 8 s) is a
+hard ceiling the endpointer always stops at, exactly like arecord's `-d` bound,
+and a silence-only capture ends at `KIRRA_VAD_START_TIMEOUT_MS` with an empty clip
+→ the fenced parser latches nothing → no motion. It emits only a WAV the existing
+STT transcribes — **no new authority**. The default backend is `energy` (RMS vs
+`KIRRA_VAD_RMS_FLOOR`, zero new deps — the same idea as `wake_word.py`'s pre-gate);
+`KIRRA_VAD_BACKEND` is a fail-closed seam for a future Silero/webrtc detector (an
+unimplemented value is refused, never silently ignored). The endpoint state
+machine (min actual speech + trailing-silence + hard cap) is host-tested in
+`robot/vad_record_test.py`; the capture loop is the hardware seam. Full env set:
+`robot/install/rabbit.env.example`.
 
 ## 2. TTS — piper
 

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -36,7 +36,7 @@ sudo install -d -m 0755 "${OPT}/robot"
 for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabbit_boot.py \
          rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py \
          ros_env.sh kirra_voice_doctor.sh kirra_doctor.py rabbit_diag.py \
-         wake_word.py rabbit_wake.py; do
+         wake_word.py rabbit_wake.py vad_record.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -17,6 +17,18 @@ KIRRA_STT_CMD="whisper-cli -m models/ggml-base.en.bin -np -nt -f"
 KIRRA_TTS_CMD="./speak.sh"
 # Bounded push-to-talk recorder (the -d bound = no open mic). WAV path appended.
 KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
+# VAD ENDPOINTING (opt-in): stop on trailing silence instead of the fixed -d window
+# → a terse command returns in ~1 s, not always 4 s. Drop-in replacement (writes
+# the appended WAV path, same contract). Default = the arecord line above (off).
+# vad_record.py is still a BOUNDED mic (KIRRA_VAD_MAX_MS is a hard ceiling) and
+# only produces a clip the existing pipeline transcribes — no new authority.
+#KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"
+#KIRRA_VAD_BACKEND=energy         # 'energy' (RMS, zero deps); silero/webrtc = later slice
+#KIRRA_VAD_RMS_FLOOR=300          # speech energy threshold (16-bit FS = 32767)
+#KIRRA_VAD_SILENCE_MS=800         # trailing silence that ends the utterance
+#KIRRA_VAD_MIN_SPEECH_MS=300      # min actual speech before an endpoint is honored
+#KIRRA_VAD_MAX_MS=8000            # HARD ceiling (the bounded-mic guarantee)
+#KIRRA_VAD_START_TIMEOUT_MS=3000  # if speech never starts, give up (empty clip → no-op)
 
 # ── Wake word (W1, OPT-IN — off by default; PTT stays the recommended default) ─
 # "hello rabbit" / "hey rabbit" / "yo rabbit" as a hands-free trigger. It is a

--- a/robot/vad_record.py
+++ b/robot/vad_record.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""vad_record.py — VAD-endpointed bounded recorder (Slice 1 of the voice-cognition
+roadmap). A DROP-IN replacement for `arecord -d N …`: it records ONE utterance
+that stops on trailing SILENCE instead of always waiting a fixed window, then
+writes it to the WAV path passed as its last argument (the house convention —
+`rabbit_voice.sh` calls `$KIRRA_RECORD_CMD "$wav"`).
+
+    KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"   # opt in
+    #  (unset / left as `arecord -d 4 …` → byte-identical prior behaviour)
+
+Why: the fixed `-d 4` clip is the single biggest voice-latency lever
+(docs/hardware/RABBIT_AUDIO_STACK.md §1). Endpointing on silence makes a terse
+command ("check yourself") return in ~1 s instead of always 4 s, while a longer
+sentence still gets its time — up to a HARD cap.
+
+🔴 SAFETY / DISCIPLINE — this is a RECORDER, not a new authority:
+  * It is still a BOUNDED mic, never an open one. `KIRRA_VAD_MAX_MS` is a HARD
+    ceiling (the endpointer STOPs at it no matter what), exactly like arecord's
+    `-d` bound — the "no open mic" guarantee is preserved.
+  * It only produces a WAV that the EXISTING pipeline transcribes. It emits no
+    intent, no command, no motion; a silent/garbled clip yields an empty
+    transcript → the fenced parser latches nothing → no motion (fail-closed).
+  * Fail-closed on capture/backend error: no clip (or an empty one) → the turn
+    dead-ends, never a hang (bounded by MAX_MS / START_TIMEOUT_MS) and never a
+    fabricated utterance.
+
+Backends (`KIRRA_VAD_BACKEND`):
+  * `energy` (default) — RMS energy vs a floor. ZERO new deps (same idea as
+    wake_word.py's pre-gate); robust for endpointing in a reasonable environment.
+  * anything else → FATAL exit (fail-closed seam; a Silero/webrtc backend is a
+    later slice — no silent fallback to an unimplemented detector).
+
+Env (all optional):
+  KIRRA_VAD_BACKEND        'energy' (default); other → refuse
+  KIRRA_VAD_CAPTURE_CMD    raw-PCM capture to stdout
+                           (default "arecord -f S16_LE -r 16000 -c 1 -t raw")
+  KIRRA_VAD_RMS_FLOOR      speech energy threshold (default 300; 16-bit FS=32767)
+  KIRRA_VAD_FRAME_MS       analysis frame (default 30 ms)
+  KIRRA_VAD_MIN_SPEECH_MS  min speech before an endpoint is honored (default 300)
+  KIRRA_VAD_SILENCE_MS     trailing silence that ends the utterance (default 800)
+  KIRRA_VAD_MAX_MS         HARD ceiling — always stop by here (default 8000)
+  KIRRA_VAD_START_TIMEOUT_MS  if speech never starts, give up (default 3000)
+  KIRRA_VAD_SAMPLE_RATE    Hz (default 16000, whisper-native)
+
+The pure core (`rms_energy`, `Endpointer`) is host-tested in vad_record_test.py;
+the capture loop is the thin hardware seam.
+"""
+import os
+import subprocess
+import sys
+import wave
+
+SAMPLE_WIDTH_BYTES = 2  # S16_LE
+
+
+def log(msg):
+    """Human-facing output to STDERR only (stdout is left clean, though this tool
+    writes its result to a file, not a pipe)."""
+    print(f"vad_record: {msg}", file=sys.stderr, flush=True)
+
+
+# ── pure core (host-tested; no I/O) ──────────────────────────────────────────
+
+def rms_energy(frame_bytes):
+    """RMS amplitude of a little-endian signed-16 PCM frame (0.0 for an empty
+    frame). Pure integer math — no numpy dep."""
+    n = len(frame_bytes) // SAMPLE_WIDTH_BYTES
+    if n == 0:
+        return 0.0
+    total = 0
+    for i in range(0, n * SAMPLE_WIDTH_BYTES, SAMPLE_WIDTH_BYTES):
+        s = int.from_bytes(frame_bytes[i:i + SAMPLE_WIDTH_BYTES], "little", signed=True)
+        total += s * s
+    return (total / n) ** 0.5
+
+
+# Endpoint decisions.
+CONTINUE = "continue"
+STOP_ENDPOINTED = "endpointed"   # speech, then enough trailing silence
+STOP_MAX = "max"                 # hit the hard ceiling
+STOP_NO_SPEECH = "no_speech"     # speech never started
+
+
+class Endpointer:
+    """Silence-endpoint state machine, fed one (is_speech, t_ms) per frame.
+
+    Guarantees:
+      * never ends before `min_speech_ms` of speech has been seen (a click can't
+        end the clip);
+      * ends after `silence_ms` of trailing silence once speech has started;
+      * ALWAYS ends by `max_ms` (the hard bounded-mic ceiling);
+      * if speech never starts, ends at `start_timeout_ms` (→ empty clip → the
+        turn dead-ends, fail-closed).
+    Time is injected (t_ms) so the logic is deterministic under test."""
+
+    def __init__(self, min_speech_ms=300, silence_ms=800, max_ms=8000,
+                 start_timeout_ms=3000):
+        self.min_speech_ms = min_speech_ms
+        self.silence_ms = silence_ms
+        self.max_ms = max_ms
+        self.start_timeout_ms = start_timeout_ms
+        self.speech_started_at = None
+        self.last_speech_at = None
+        self.prev_t_ms = 0
+        self.speech_ms = 0  # ACCUMULATED speech time, not elapsed-since-start
+
+    def feed(self, is_speech, t_ms):
+        """Return one of CONTINUE / STOP_* for the frame ending at t_ms."""
+        # The hard ceiling wins over everything — the bounded-mic guarantee.
+        if t_ms >= self.max_ms:
+            return STOP_MAX
+        dt = t_ms - self.prev_t_ms
+        self.prev_t_ms = t_ms
+        if self.speech_started_at is None:
+            if is_speech:
+                self.speech_started_at = t_ms
+                self.last_speech_at = t_ms
+                self.speech_ms += dt
+            elif t_ms >= self.start_timeout_ms:
+                return STOP_NO_SPEECH
+            return CONTINUE
+        # In speech.
+        if is_speech:
+            self.last_speech_at = t_ms
+            self.speech_ms += dt
+            return CONTINUE
+        trailing_silence_ms = t_ms - self.last_speech_at
+        # Endpoint only after ENOUGH ACTUAL SPEECH (a lone click never qualifies)
+        # AND enough trailing silence.
+        if self.speech_ms >= self.min_speech_ms and trailing_silence_ms >= self.silence_ms:
+            return STOP_ENDPOINTED
+        return CONTINUE
+
+
+# ── hardware seam (thin; not unit-tested) ────────────────────────────────────
+
+def _env_int(key, default):
+    raw = (os.environ.get(key) or "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw, 0)
+    except ValueError:
+        log(f"{key}={raw!r} not an integer — using default {default}")
+        return default
+
+
+def _write_wav(path, pcm, sample_rate):
+    with wave.open(path, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(SAMPLE_WIDTH_BYTES)
+        w.setframerate(sample_rate)
+        w.writeframes(pcm)
+
+
+def main(argv):
+    if len(argv) < 1:
+        log("FATAL: no output WAV path (it is appended as the last argument, "
+            "like arecord's target).")
+        return 2
+    out_path = argv[-1]
+
+    backend = (os.environ.get("KIRRA_VAD_BACKEND") or "energy").strip().lower()
+    if backend != "energy":
+        log(f"FATAL: KIRRA_VAD_BACKEND={backend!r} not supported (only 'energy' "
+            "is wired; silero/webrtc are a later slice).")
+        return 2
+
+    sample_rate = _env_int("KIRRA_VAD_SAMPLE_RATE", 16000)
+    frame_ms = _env_int("KIRRA_VAD_FRAME_MS", 30)
+    floor = _env_int("KIRRA_VAD_RMS_FLOOR", 300)
+    endpointer = Endpointer(
+        min_speech_ms=_env_int("KIRRA_VAD_MIN_SPEECH_MS", 300),
+        silence_ms=_env_int("KIRRA_VAD_SILENCE_MS", 800),
+        max_ms=_env_int("KIRRA_VAD_MAX_MS", 8000),
+        start_timeout_ms=_env_int("KIRRA_VAD_START_TIMEOUT_MS", 3000),
+    )
+    frame_bytes = max(1, (sample_rate * frame_ms) // 1000) * SAMPLE_WIDTH_BYTES
+
+    import shlex
+    capture_cmd = os.environ.get("KIRRA_VAD_CAPTURE_CMD") \
+        or f"arecord -f S16_LE -r {sample_rate} -c 1 -t raw"
+    capture_argv = shlex.split(capture_cmd)
+
+    log(f"endpointing capture ({backend}, floor={floor}, silence="
+        f"{endpointer.silence_ms}ms, max={endpointer.max_ms}ms) → {out_path}")
+
+    pcm = bytearray()
+    proc = None
+    try:
+        proc = subprocess.Popen(capture_argv, stdout=subprocess.PIPE,
+                                stderr=subprocess.DEVNULL)
+    except Exception as e:  # noqa: BLE001
+        log(f"FATAL: capture command failed to start ({e})")
+        return 2
+
+    reason = STOP_MAX
+    t_ms = 0
+    try:
+        while True:
+            chunk = proc.stdout.read(frame_bytes)
+            if not chunk or len(chunk) < frame_bytes:
+                # Stream ended / underran — stop with whatever we have (fail-soft).
+                break
+            t_ms += frame_ms
+            is_speech = rms_energy(chunk) >= floor
+            decision = endpointer.feed(is_speech, t_ms)
+            if is_speech or endpointer.speech_started_at is not None:
+                pcm += chunk  # keep audio only from first speech onward (+ trailing)
+            if decision != CONTINUE:
+                reason = decision
+                break
+    finally:
+        if proc:
+            proc.terminate()
+            try:
+                proc.wait(timeout=1)
+            except Exception:  # noqa: BLE001
+                proc.kill()
+
+    # Fail-closed: no speech → write an (empty) clip so the turn dead-ends cleanly
+    # in the parser rather than reusing a stale file.
+    try:
+        _write_wav(out_path, bytes(pcm), sample_rate)
+    except Exception as e:  # noqa: BLE001
+        log(f"FATAL: could not write {out_path} ({e})")
+        return 2
+
+    log(f"stopped: {reason} ({t_ms} ms, {len(pcm)} bytes pcm)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/robot/vad_record_test.py
+++ b/robot/vad_record_test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Host tests for the pure VAD-endpointing core in `vad_record.py`.
+
+Pure and dependency-light: `rms_energy` and the `Endpointer` state machine do no
+I/O (no mic, no arecord, no wave file), so they run on a plain host. The capture
+loop is the thin hardware seam, exercised on the robot.
+
+Runs standalone (`python3 robot/vad_record_test.py`, exit 1 on any failure);
+also importable under pytest.
+
+Covers: RMS on silence vs a loud frame; the endpoint honored only after
+min-speech + trailing-silence; a short click NOT ending the clip; continuous
+speech capped by the HARD ceiling (bounded-mic guarantee); no-speech timeout;
+and speech→silence→speech re-arming the trailing-silence window.
+"""
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from vad_record import (  # noqa: E402
+    CONTINUE, STOP_ENDPOINTED, STOP_MAX, STOP_NO_SPEECH, Endpointer, rms_energy,
+)
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def _frame(amplitude, n=480):
+    """A PCM frame of `n` constant-amplitude int16 samples (little-endian)."""
+    return struct.pack("<%dh" % n, *([amplitude] * n))
+
+
+# ── rms_energy ───────────────────────────────────────────────────────────────
+
+def test_rms_silence_vs_loud():
+    check(rms_energy(b"") == 0.0, "empty frame → 0")
+    check(rms_energy(_frame(0)) == 0.0, "silent frame → 0")
+    loud = rms_energy(_frame(5000))
+    check(abs(loud - 5000.0) < 1.0, f"constant 5000 → rms ~5000, got {loud}")
+    check(rms_energy(_frame(100)) < rms_energy(_frame(3000)), "louder → higher rms")
+
+
+# ── endpoint: the normal case ────────────────────────────────────────────────
+
+def _run(endpointer, speech_flags, frame_ms=30):
+    """Feed a list of per-frame is_speech bools; return (stop_reason, t_ms)."""
+    t = 0
+    for is_speech in speech_flags:
+        t += frame_ms
+        d = endpointer.feed(is_speech, t)
+        if d != CONTINUE:
+            return d, t
+    return CONTINUE, t
+
+
+def test_endpoint_after_speech_then_silence():
+    ep = Endpointer(min_speech_ms=300, silence_ms=300, max_ms=8000, start_timeout_ms=3000)
+    # 400 ms speech (14 frames) then silence; endpoint ~300 ms into the silence.
+    flags = [True] * 14 + [False] * 20
+    reason, t = _run(ep, flags)
+    check(reason == STOP_ENDPOINTED, f"expected endpointed, got {reason}")
+    # speech ended at 420 ms; +300 ms silence → ~720 ms.
+    check(680 <= t <= 760, f"endpoint timing off: {t} ms")
+
+
+def test_short_click_does_not_end():
+    # A single 30 ms blip (< min_speech 300) then silence must NOT endpoint;
+    # it should run to the no-speech/other stop, never STOP_ENDPOINTED early.
+    ep = Endpointer(min_speech_ms=300, silence_ms=300, max_ms=8000, start_timeout_ms=3000)
+    flags = [True] + [False] * 40
+    reason, t = _run(ep, flags)
+    check(reason != STOP_ENDPOINTED,
+          f"a sub-min click must not endpoint the clip (got {reason} at {t})")
+
+
+def test_continuous_speech_hits_hard_cap():
+    ep = Endpointer(min_speech_ms=300, silence_ms=800, max_ms=1000, start_timeout_ms=3000)
+    flags = [True] * 200  # never any silence
+    reason, t = _run(ep, flags)
+    check(reason == STOP_MAX, f"continuous speech must hit the hard cap, got {reason}")
+    check(t >= 1000, f"cap should fire at/after max_ms, got {t}")
+
+
+def test_no_speech_times_out():
+    ep = Endpointer(min_speech_ms=300, silence_ms=800, max_ms=8000, start_timeout_ms=1000)
+    flags = [False] * 200
+    reason, t = _run(ep, flags)
+    check(reason == STOP_NO_SPEECH, f"silence-only must time out, got {reason}")
+    check(t >= 1000, f"no-speech timeout at start_timeout_ms, got {t}")
+
+
+def test_pause_within_speech_rearms_silence():
+    # speech, a SHORT pause (< silence_ms), then speech again → must NOT endpoint
+    # at the short pause; only the final trailing silence ends it.
+    ep = Endpointer(min_speech_ms=300, silence_ms=500, max_ms=8000, start_timeout_ms=3000)
+    flags = ([True] * 14) + ([False] * 10) + ([True] * 10) + ([False] * 30)
+    reason, t = _run(ep, flags)
+    check(reason == STOP_ENDPOINTED, f"expected final endpoint, got {reason}")
+    # It must have survived the 300 ms mid-pause (10 frames) and ended in the
+    # final silence run, i.e. well after the second speech burst.
+    check(t > (14 + 10 + 10) * 30, f"ended too early (mid-pause?): {t} ms")
+
+
+def test_hard_cap_wins_even_during_speech():
+    # At exactly max_ms the endpointer stops regardless of speech state.
+    ep = Endpointer(min_speech_ms=0, silence_ms=800, max_ms=300, start_timeout_ms=3000)
+    check(ep.feed(True, 300) == STOP_MAX, "max_ms boundary must stop even mid-speech")
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"vad_record_test: all {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Context

First shippable slice of the Rabbit voice-cognition roadmap (the architecture review flagged VAD endpointing as the highest value-per-effort gap). Cuts the biggest voice-latency lever — the fixed `arecord -d 4` clip — by stopping on trailing silence instead of always waiting the full window. A terse "check yourself" returns in ~1 s; a longer sentence still gets its time, up to a hard ceiling.

## What

`robot/vad_record.py` is a **drop-in replacement** for the `arecord` recorder: it writes the appended WAV path (the same `$KIRRA_RECORD_CMD "$wav"` house contract), so nothing else in the pipeline changes. Opt in by pointing `KIRRA_RECORD_CMD` at it; left unset, behaviour is byte-identical.

## Discipline honoured

| Property | How |
|---|---|
| **Opt-in, default off** | shipped default recorder unchanged |
| **Still a bounded mic** | `KIRRA_VAD_MAX_MS` (8 s) is a hard ceiling the endpointer always stops at — exactly like arecord's `-d`; silence-only → empty clip at `KIRRA_VAD_START_TIMEOUT_MS` → parser latches nothing → no motion |
| **No new authority** | produces only a WAV the existing STT transcribes; no intent/command/motion. Channel-A intact |
| **Zero new deps** | default `energy` backend = RMS vs a floor (same idea as `wake_word.py`'s pre-gate). `KIRRA_VAD_BACKEND` is a **fail-closed seam** for a future Silero/webrtc detector — an unimplemented value is refused, never silently ignored |
| **Pure core host-tested** | `rms_energy` + the `Endpointer` state machine in `vad_record_test.py` (7 tests): endpoint only after enough **actual** speech + trailing silence; a lone click never ends the clip; the hard max-ms ceiling always wins. The capture loop is the thin hardware seam |

## Verification

- `python3 robot/vad_record_test.py` → 7/7 pass.
- End-to-end synthetic-stream smoke test (loud burst → silence) endpoints at ~1 s (not the full stream) and writes a valid 16 kHz mono WAV.
- Fail-closed paths verified: unknown backend → exit 2; missing WAV arg → exit 2.
- Installer `bash -n` clean; CI YAML parses.

## Wiring

Stage `vad_record.py` in `install_robot_units.sh`; document `KIRRA_VAD_*` in `rabbit.env.example`; add the pure test to the robot host-test CI block; update `RABBIT_AUDIO_STACK.md §1a` (the VAD follow-up, now shipped opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_