### PR TITLE
feat(robot): barge-in — interruptible replies (voice-cognition Slice 2, opt-in)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1253,6 +1253,12 @@ jobs:
           # HARD max-ms ceiling always wins (the bounded-mic guarantee). The
           # capture loop is the hardware seam. See RABBIT_AUDIO_STACK.md §1.
           python3 robot/vad_record_test.py
+          # Barge-in (pure + subprocess seam, no audio): the priority arbiter
+          # (P1 cuts P3, P3 never cuts P1), the fail-closed enable gate, the
+          # monotonic epoch signal (absent/corrupt → 0, baseline never false-cuts),
+          # and speak_interruptible completing vs being killed mid-playback. See
+          # docs/hardware/RABBIT_AUDIO_STACK.md §3c.
+          python3 robot/barge_in_test.py
           # ADR-0033 Tier-3 sentinel logic (#887, pure, no device): owner/mode
           # violations vs the AOU-ACTUATION-SERIAL-001 contract (the vendor
           # 0777 rule is the canonical hazard case), holder reporting, and the

--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -200,6 +200,34 @@ Before enabling on battery, measure the duty-cycled tiny.en cost (§5 pattern,
 fallback is swapping the producer for a dedicated wake engine (openWakeWord) —
 the trigger contract means that changes one script and nothing else.
 
+### 3c. Barge-in (`barge_in.py`) — opt-in, cut a reply and listen
+
+When Rabbit is mid-reply and you want to talk NOW, barge-in stops the speech
+instead of making you wait for the sentence to finish. Opt in with
+`KIRRA_BARGE_IN_ENABLED=1`; default off → conversational replies use the plain
+blocking `speak()` (byte-identical).
+
+How it works: a **PTT press** (`ptt_button.py`) raises a monotonic **signal
+file** (`KIRRA_BARGE_IN_FILE`), and the in-progress conversational reply — played
+in a killable subprocess by `barge_in.speak_interruptible` — polls that signal
+and terminates playback the moment it advances past the baseline captured when
+the reply started (so a leftover signal never false-cuts the *next* reply). The
+press's own trigger then records your follow-up as usual. Any event source can
+raise one too: `python3 robot/barge_in.py --signal` (wire it to an e-stop / a
+"hush" button / a critical posture transition).
+
+🔴 It is **Channel A / cosmetic**: a barge-in only STOPS speech — it never starts
+motion, emits an intent, or touches the fenced `/intent` door, so cutting a reply
+early is always safe. The priority model is P0 e-stop > P1 {wake, human-interrupt}
+> P2 mission > P3 info-speech; a reply is P3, so any raised barge-in cuts it
+(`should_interrupt`, host-tested).
+
+The **PTT** path works today because the button is independent of the mic. The
+*acoustic* "say the wake word over Rabbit" path does not yet, because the wake
+listener releases the mic for the turn's hold-off while Rabbit speaks — closing
+that needs full-duplex audio (echo cancellation) or a shorter hold-off, a tracked
+follow-up.
+
 ---
 
 ## 4. 🔴 Audio from a systemd service (read this before enabling the units)

--- a/robot/barge_in.py
+++ b/robot/barge_in.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""barge_in.py — interruptible speech + a priority arbiter (voice-cognition
+Slice 2, opt-in). Lets a higher-priority event CUT Rabbit's current spoken reply
+so it stops talking and listens, instead of blocking until the sentence finishes.
+
+The live producer today is the **PTT button**: pressing it raises a barge-in
+signal (a cross-process epoch file), and an in-progress conversational reply
+polls that signal and stops. The button is independent of the mic hold-off, so
+this works even while Rabbit is speaking. (Acoustic "say the wake word over
+Rabbit" needs full-duplex audio / a shorter hold-off — a documented follow-up.)
+
+🔴 SAFETY / DISCIPLINE — Channel A only, zero authority:
+  * A barge-in only STOPS speech (cosmetic) — it never starts motion, emits an
+    intent, or touches the fenced /intent door. Cutting a reply early is always
+    safe.
+  * The signal is a local epoch FILE (like rabbit_wake.py's control file), never
+    stdout — the ptt_button / wake_word stdout trigger contract is preserved.
+  * Fail-soft everywhere: a missing/corrupt signal file reads as "no barge-in"
+    (epoch 0); a TTS/playback error is swallowed (speech is never load-bearing).
+  * OFF by default: unless KIRRA_BARGE_IN_ENABLED=1, replies use the plain
+    blocking speak() and producers never raise a signal — byte-identical.
+
+Priority model (the architecture doc's event priorities):
+  P0 e-stop  >  P1 {human-interrupt, wake, obstacle}  >  P2 mission  >  P3 info-speech
+A conversational reply is P3, so any raised barge-in (P0/P1) cuts it.
+
+Env:
+  KIRRA_BARGE_IN_ENABLED  1/true/yes/on to arm; else off (default)
+  KIRRA_BARGE_IN_FILE     epoch signal file (default /tmp/kirra_rabbit_bargein.epoch)
+
+CLI:  python3 robot/barge_in.py --signal    # raise a barge-in (e-stop / event source)
+"""
+import os
+import subprocess
+import sys
+import time
+
+# Priority levels — LOWER number = MORE urgent (preempts).
+P0_ESTOP = 0
+P1_INTERRUPT = 1   # human interrupt / wake / obstacle
+P2_MISSION = 2
+P3_INFO = 3        # conversational / informational speech
+
+DEFAULT_SIGNAL_FILE = "/tmp/kirra_rabbit_bargein.epoch"
+
+
+def log(msg):
+    print(f"barge_in: {msg}", file=sys.stderr, flush=True)
+
+
+# ── pure core (host-tested; no process I/O) ──────────────────────────────────
+
+def enabled():
+    """Armed only on an explicit affirmative (fail-closed: unset/typo → off)."""
+    return (os.environ.get("KIRRA_BARGE_IN_ENABLED") or "").strip().lower() \
+        in ("1", "true", "yes", "on")
+
+
+def signal_path():
+    return (os.environ.get("KIRRA_BARGE_IN_FILE") or "").strip() or DEFAULT_SIGNAL_FILE
+
+
+def should_interrupt(current_priority, incoming_priority):
+    """A strictly MORE urgent event preempts current speech. Equal or lower does
+    not (info-speech never interrupts info-speech; a P3 event never cuts P1)."""
+    return incoming_priority < current_priority
+
+
+def read_epoch(path):
+    """Current barge-in epoch (monotonic counter). Absent/unreadable/corrupt → 0
+    (fail-safe: 'no barge-in', never a crash)."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return int(f.read().strip() or "0")
+    except (OSError, ValueError):
+        return 0
+
+
+def raise_barge_in(path):
+    """Advance the epoch → any speaker baselined below it will cut. Atomic write
+    (temp + rename) so a reader never sees a torn value. Returns the new epoch."""
+    nxt = read_epoch(path) + 1
+    tmp = f"{path}.tmp.{os.getpid()}"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(str(nxt))
+        os.replace(tmp, path)
+    except OSError as e:
+        log(f"could not raise barge-in ({e})")
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return read_epoch(path)
+    return nxt
+
+
+def make_file_cancel_check(path, baseline):
+    """A predicate that becomes True once the epoch at `path` advances beyond
+    `baseline` — i.e. a barge-in was raised AFTER this speech started (a signal
+    left over from before is captured in the baseline and does NOT false-cut)."""
+    return lambda: read_epoch(path) > baseline
+
+
+# ── interruptible speak (the thin process seam; killable playback) ───────────
+
+def speak_interruptible(text, tts_argv, cancel_check=None, poll_ms=100):
+    """Speak `text` via `tts_argv` (argv list, text on STDIN — never a shell), but
+    poll `cancel_check()` while it plays and KILL playback the moment it returns
+    True. Returns True iff the speech was cut. Fail-soft: any error → returns
+    False (speech is cosmetic). Prints the line first (parity with speak())."""
+    print(text)
+    if not tts_argv:
+        return False
+    if cancel_check is None:
+        cancel_check = lambda: False  # noqa: E731
+    try:
+        proc = subprocess.Popen(tts_argv, stdin=subprocess.PIPE,
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception as e:  # noqa: BLE001
+        log(f"tts failed to start: {e}")
+        return False
+    try:
+        try:
+            if proc.stdin:
+                proc.stdin.write(text.encode())
+                proc.stdin.close()
+        except (BrokenPipeError, OSError):
+            pass  # a TTS that ignores/closes stdin is fine
+        poll_s = max(0.005, poll_ms / 1000.0)
+        while True:
+            if proc.poll() is not None:
+                return False  # finished on its own
+            if cancel_check():
+                proc.terminate()
+                try:
+                    proc.wait(timeout=0.5)
+                except Exception:  # noqa: BLE001
+                    proc.kill()
+                return True    # barged in
+            time.sleep(poll_s)
+    except Exception as e:  # noqa: BLE001
+        log(f"tts playback error: {e}")
+        try:
+            proc.kill()
+        except Exception:  # noqa: BLE001
+            pass
+        return False
+
+
+def main(argv):
+    if "--signal" in argv:
+        epoch = raise_barge_in(signal_path())
+        log(f"barge-in raised (epoch {epoch}) at {signal_path()}")
+        return 0
+    log("usage: barge_in.py --signal   (raise a barge-in for the current speaker)")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/robot/barge_in_test.py
+++ b/robot/barge_in_test.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Host tests for the barge-in core in `barge_in.py`.
+
+The decision + signal logic (`should_interrupt`, `enabled`, `read_epoch`,
+`raise_barge_in`, `make_file_cancel_check`) is pure/filesystem-only and runs on a
+plain host. `speak_interruptible` is exercised with standard unix commands
+(`sleep`) instead of a real TTS engine — a killable subprocess is the point.
+
+Runs standalone (`python3 robot/barge_in_test.py`, exit 1 on failure); also
+importable under pytest.
+
+Covers: the priority arbiter truth table; the fail-closed enable gate;
+epoch round-trip (absent/corrupt → 0, monotonic advance, atomic); the
+baseline cancel-check (a pre-existing signal does NOT false-cut, a later one
+does); and speak_interruptible completing normally vs being cut mid-playback.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import barge_in  # noqa: E402
+from barge_in import (  # noqa: E402
+    P0_ESTOP, P1_INTERRUPT, P2_MISSION, P3_INFO, make_file_cancel_check,
+    raise_barge_in, read_epoch, should_interrupt, speak_interruptible,
+)
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+# ── priority arbiter ─────────────────────────────────────────────────────────
+
+def test_priority_truth_table():
+    check(should_interrupt(P3_INFO, P1_INTERRUPT), "P1 must cut P3 info-speech")
+    check(should_interrupt(P3_INFO, P0_ESTOP), "P0 e-stop must cut P3")
+    check(should_interrupt(P2_MISSION, P1_INTERRUPT), "P1 must cut P2 mission")
+    check(not should_interrupt(P1_INTERRUPT, P3_INFO), "P3 must NOT cut P1")
+    check(not should_interrupt(P3_INFO, P3_INFO), "equal priority must NOT interrupt")
+    check(not should_interrupt(P1_INTERRUPT, P2_MISSION), "P2 must NOT cut P1")
+
+
+# ── enable gate (fail-closed off) ────────────────────────────────────────────
+
+def test_enable_gate_fail_closed():
+    prev = os.environ.get("KIRRA_BARGE_IN_ENABLED")
+    try:
+        for off in (None, "", "0", "false", "no", "off", "enabled", "2"):
+            if off is None:
+                os.environ.pop("KIRRA_BARGE_IN_ENABLED", None)
+            else:
+                os.environ["KIRRA_BARGE_IN_ENABLED"] = off
+            check(not barge_in.enabled(), f"{off!r} must NOT arm (fail-closed)")
+        for on in ("1", "true", "TRUE", "yes", "on"):
+            os.environ["KIRRA_BARGE_IN_ENABLED"] = on
+            check(barge_in.enabled(), f"{on!r} should arm")
+    finally:
+        if prev is None:
+            os.environ.pop("KIRRA_BARGE_IN_ENABLED", None)
+        else:
+            os.environ["KIRRA_BARGE_IN_ENABLED"] = prev
+
+
+# ── epoch signal ─────────────────────────────────────────────────────────────
+
+def test_epoch_absent_and_corrupt_read_zero():
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "sig.epoch")
+        check(read_epoch(p) == 0, "absent file → epoch 0")
+        with open(p, "w") as f:
+            f.write("garbage")
+        check(read_epoch(p) == 0, "corrupt file → epoch 0 (fail-safe)")
+
+
+def test_epoch_monotonic_advance():
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "sig.epoch")
+        check(raise_barge_in(p) == 1, "first raise → 1")
+        check(raise_barge_in(p) == 2, "second raise → 2")
+        check(read_epoch(p) == 2, "reads back the latest epoch")
+
+
+def test_baseline_cancel_check():
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "sig.epoch")
+        raise_barge_in(p)                       # a signal from BEFORE we start
+        baseline = read_epoch(p)                # baseline captures it
+        cancel = make_file_cancel_check(p, baseline)
+        check(not cancel(), "a pre-existing signal must NOT false-cut")
+        raise_barge_in(p)                       # a NEW signal during speech
+        check(cancel(), "a signal raised after baseline must cut")
+
+
+# ── interruptible speak ──────────────────────────────────────────────────────
+
+def test_speak_completes_when_not_cancelled():
+    t0 = time.monotonic()
+    interrupted = speak_interruptible("hi", ["sleep", "0.2"],
+                                      cancel_check=lambda: False, poll_ms=20)
+    check(not interrupted, "uncancelled speech should complete, not interrupt")
+    check(time.monotonic() - t0 >= 0.15, "should have waited for playback to finish")
+
+
+def test_speak_cut_mid_playback():
+    t0 = time.monotonic()
+    interrupted = speak_interruptible("a long droning reply", ["sleep", "5"],
+                                      cancel_check=lambda: True, poll_ms=20)
+    elapsed = time.monotonic() - t0
+    check(interrupted, "a raised cancel must cut playback")
+    check(elapsed < 1.0, f"cut should be prompt, took {elapsed:.2f}s")
+
+
+def test_speak_no_tts_prints_only():
+    check(speak_interruptible("printed", [], cancel_check=lambda: True) is False,
+          "no TTS command → print only, never 'interrupted'")
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"barge_in_test: all {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -36,7 +36,7 @@ sudo install -d -m 0755 "${OPT}/robot"
 for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabbit_boot.py \
          rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py \
          ros_env.sh kirra_voice_doctor.sh kirra_doctor.py rabbit_diag.py \
-         wake_word.py rabbit_wake.py vad_record.py; do
+         wake_word.py rabbit_wake.py vad_record.py barge_in.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -15,6 +15,15 @@ KIRRA_STT_CMD="whisper-cli -m models/ggml-base.en.bin -np -nt -f"
 #   exec piper --model en_US-lessac-medium.onnx --output-raw | aplay -r 22050 -f S16_LE -t raw -
 # Unset → Rabbit PRINTS instead of speaks (still works, just silent).
 KIRRA_TTS_CMD="./speak.sh"
+# BARGE-IN (opt-in): make Rabbit's conversational reply interruptible — a PTT
+# press (ptt_button.py) raises a signal that CUTS the in-progress reply so Rabbit
+# stops and listens, instead of blocking to the end of the sentence. Channel A /
+# cosmetic — cutting speech never affects the fenced /intent door. Default off →
+# replies use the plain blocking speak(). (Acoustic "talk over Rabbit" needs
+# full-duplex audio / a shorter wake hold-off — a follow-up; PTT works today.)
+# Any event source can also raise one: `python3 robot/barge_in.py --signal`.
+#KIRRA_BARGE_IN_ENABLED=1
+#KIRRA_BARGE_IN_FILE=/tmp/kirra_rabbit_bargein.epoch
 # Bounded push-to-talk recorder (the -d bound = no open mic). WAV path appended.
 KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
 # VAD ENDPOINTING (opt-in): stop on trailing silence instead of the fixed -d window

--- a/robot/ptt_button.py
+++ b/robot/ptt_button.py
@@ -78,6 +78,18 @@ def env_int(key, default):
         sys.exit(2)
 
 
+def _maybe_barge_in():
+    """Raise a barge-in signal on press so an in-progress reply is cut (opt-in via
+    KIRRA_BARGE_IN_ENABLED). Best-effort and side-channel: it writes a signal file,
+    never stdout, and never raises — the mic trigger must never depend on it."""
+    try:
+        import barge_in  # same dir; sys.path[0]
+        if barge_in.enabled():
+            barge_in.raise_barge_in(barge_in.signal_path())
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def main():
     try:
         import Jetson.GPIO as GPIO
@@ -138,6 +150,10 @@ def main():
                     # THE TRIGGER — the only thing that ever touches stdout.
                     sys.stdout.write("\n")
                     sys.stdout.flush()
+                    # BARGE-IN (opt-in): a press means "I want to talk" — cut any
+                    # in-progress spoken reply. Writes a signal FILE, never stdout,
+                    # so the trigger contract above is untouched. Best-effort.
+                    _maybe_barge_in()
                     log("press -> record one clip")
             elif not down and is_pressed:
                 is_pressed = False

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -50,6 +50,7 @@ from rabbit_ask import (  # noqa: E402
 import rabbit_diag  # noqa: E402 — deterministic self-check voice command (read-only)
 import rabbit_ota  # noqa: E402 — deterministic OTA voice commands (NOT the movement door)
 import rabbit_wake  # noqa: E402 — deterministic wake-listener controls (state file only)
+import barge_in  # noqa: E402 — interruptible reply speech (opt-in; Channel A, cosmetic)
 from rabbit_persona import name_slot, operator_name  # noqa: E402
 
 MAX_TURNS = 10  # rolling conversation memory (user+assistant pairs kept)
@@ -162,6 +163,23 @@ def offer_to_door(directive_text):
         return "error"
 
 
+def _speak_reply(text):
+    """Speak a CONVERSATIONAL reply (P3 info-speech). Interruptible (barge-in)
+    when KIRRA_BARGE_IN_ENABLED=1 — a PTT press / raised signal cuts it so Rabbit
+    stops and listens; otherwise the plain blocking speak(). Channel A, cosmetic:
+    cutting a reply early never affects the fenced /intent door. Only the long
+    conversational line uses this; the short deterministic lines (OTA/diag/wake)
+    stay on plain speak()."""
+    if not barge_in.enabled():
+        speak(text)
+        return
+    tts_argv = (os.environ.get("KIRRA_TTS_CMD") or "").split()
+    path = barge_in.signal_path()
+    baseline = barge_in.read_epoch(path)
+    barge_in.speak_interruptible(text, tts_argv,
+                                 barge_in.make_file_cancel_check(path, baseline))
+
+
 def handle_turn(history, utterance):
     # System commands (OTA "check/apply update") are matched DETERMINISTICALLY and
     # handled BEFORE the LLM/movement path — they run local kirra-ota-ctl, never
@@ -215,7 +233,7 @@ def handle_turn(history, utterance):
     else:
         spoken = say
 
-    speak(spoken)
+    _speak_reply(spoken)
     # rolling memory (store the spoken reply, not the raw grounding)
     history.append({"role": "user", "content": utterance})
     history.append({"role": "assistant", "content": spoken})


### PR DESCRIPTION
## Context

Slice 2 of the Rabbit voice-cognition roadmap (Slice 1, VAD endpointing, merged in #1136). Lets a higher-priority event **cut Rabbit's current spoken reply** so it stops and listens, instead of blocking to the end of the sentence.

## What

`robot/barge_in.py`:
- **`should_interrupt(current, incoming)`** — the priority arbiter (P0 e-stop > P1 {wake, human-interrupt} > P2 mission > P3 info-speech); a reply is P3, so any raised barge-in cuts it.
- A **monotonic epoch signal file** (`raise_barge_in`/`read_epoch`, atomic write) with a **baseline cancel-check** so a leftover signal never false-cuts the *next* reply.
- **`speak_interruptible(text, tts_argv, cancel_check)`** — plays TTS in a **killable** subprocess (argv + text on stdin, never a shell) and terminates it the moment the cancel check fires.

## Live producer

The **PTT button** — it's independent of the mic hold-off, so a press cuts speech even while Rabbit talks. Any event source can also raise one: `python3 robot/barge_in.py --signal` (e-stop / hush button / posture transition).

## Wiring (all opt-in behind `KIRRA_BARGE_IN_ENABLED`, default off → byte-identical)

| Site | Change |
|---|---|
| `rabbit_converse` | conversational reply (`_speak_reply`) becomes interruptible when armed; short deterministic lines (OTA/diag/wake) stay on plain `speak()` |
| `ptt_button` | a press raises a barge-in signal — side-channel **file**, never stdout (the one-newline trigger contract is untouched); best-effort, never blocks |

## Discipline

**Channel A / cosmetic** — a barge-in only *stops* speech; it never starts motion, emits an intent, or touches the fenced `/intent` door, so cutting a reply early is always safe. Fail-soft throughout (missing/corrupt signal → epoch 0; any TTS error swallowed).

## Verification

- `python3 robot/barge_in_test.py` → 8/8 (arbiter truth table, fail-closed gate, epoch round-trip incl. corrupt→0 + no-false-cut baseline, `speak_interruptible` complete-vs-cut).
- End-to-end: a droning 5 s reply cut in ~0.2 s via the signal file.
- `rabbit_converse`/`ptt_button` compile; installer `bash -n` clean; CI YAML parses.

## Honest scope

PTT barge-in works today. The **acoustic** "talk over Rabbit" path needs full-duplex audio / a shorter wake hold-off (the listener releases the mic during the turn) — a tracked follow-up, documented in `RABBIT_AUDIO_STACK.md §3c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_