### PR TITLE
feat(robot): skill registry — named skills through the same fence (Slice 3, opt-in)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1259,6 +1259,12 @@ jobs:
           # and speak_interruptible completing vs being killed mid-playback. See
           # docs/hardware/RABBIT_AUDIO_STACK.md §3c.
           python3 robot/barge_in_test.py
+          # Skill registry (pure, no LLM/HTTP): the fail-closed dispatcher
+          # (motion → a directive for the SAME /intent fence, unimplemented/
+          # unknown → REFUSE, never faked), fail-closed {say,skills[]} parsing,
+          # and THE single-door invariant — execute_skill_decisions routes motion
+          # ONLY through the injected fence sink. See robot/skill_registry.py.
+          python3 robot/skill_registry_test.py
           # ADR-0033 Tier-3 sentinel logic (#887, pure, no device): owner/mode
           # violations vs the AOU-ACTUATION-SERIAL-001 contract (the vendor
           # 0777 rule is the canonical hazard case), holder reporting, and the

--- a/docs/hardware/RABBIT_CONVERSATION_DESIGN.md
+++ b/docs/hardware/RABBIT_CONVERSATION_DESIGN.md
@@ -194,6 +194,41 @@ supplied telemetry; the persona phrases, the numbers are ground truth.
 
 ---
 
+## Skills mode (opt-in) — named skills through the *same* door
+
+`KIRRA_SKILLS_ENABLED=1` swaps the free-form `{say, directive}` router for a
+**named-skill** contract: the LLM emits `{say, skills:[{name, parameters}]}` from
+a REGISTERED vocabulary (`robot/skill_registry.py`). Default off → the free-form
+router is byte-identical.
+
+The registry is a **catalog, not a new door.** Its dispatcher (pure,
+host-tested) turns each skill into exactly one of three decisions:
+
+- **`FENCE`** — a *motion* skill (`navigate` / `cruise` / `turn` / `pull_over` /
+  `stop`) compiles to a plain-words directive that goes through the **same**
+  `offer_to_door` → mick `POST /intent` → `MickIntent` grounding → checker path a
+  free-form directive already takes. Motion reaches the wheels ONLY via this
+  decision, and it is just text handed to the existing door.
+- **`SPEAK`** — a read-only skill (`speak`) narrates; no actuation.
+- **`REFUSE`** — a cataloged-but-unimplemented skill (`dock`, `follow_person`,
+  `search_area`, …) or an unknown name is refused, **never faked**. Fabricating a
+  capability is the failure mode this guards against.
+
+`execute_skill_decisions(decisions, offer_to_door, speak)` routes motion ONLY
+through the injected fence sink — the single-door invariant, asserted directly in
+`skill_registry_test.py`. So `ci/check_mick_actuation_fence.py` and the
+one-door rule are untouched: a skill name buys the LLM a vocabulary, not
+authority.
+
+**Not yet default:** graduating the flag requires extending
+`rabbit_model_smoketest.py` to gate the skills contract (the model-swap
+discipline), and the mission Executive (the multi-step sequencer) is a later
+slice. Metadata each skill advertises (permissions, interruptibility,
+preconditions, failure modes) is carried now so that Executive can reason about
+it without a redesign.
+
+---
+
 ## Honest caveats
 
 - **Latency.** A local LLM on the Orin (gemma3:4b) is a few seconds per turn.

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -36,7 +36,7 @@ sudo install -d -m 0755 "${OPT}/robot"
 for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabbit_boot.py \
          rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py \
          ros_env.sh kirra_voice_doctor.sh kirra_doctor.py rabbit_diag.py \
-         wake_word.py rabbit_wake.py vad_record.py barge_in.py; do
+         wake_word.py rabbit_wake.py vad_record.py barge_in.py skill_registry.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -24,6 +24,14 @@ KIRRA_TTS_CMD="./speak.sh"
 # Any event source can also raise one: `python3 robot/barge_in.py --signal`.
 #KIRRA_BARGE_IN_ENABLED=1
 #KIRRA_BARGE_IN_FILE=/tmp/kirra_rabbit_bargein.epoch
+# SKILLS MODE (opt-in, EXPERIMENTAL): the LLM emits {say, skills[]} from a
+# REGISTERED vocabulary (navigate/cruise/turn/pull_over/stop/speak) instead of a
+# free-form directive. A motion skill still routes through the SAME fenced door
+# (mick /intent → checker); an unimplemented/unknown skill is REFUSED, never
+# faked. Default off → the free-form {say, directive} router (byte-identical).
+# Graduating this to default requires extending rabbit_model_smoketest.py to gate
+# the skills contract. See robot/skill_registry.py + RABBIT_CONVERSATION_DESIGN.md.
+#KIRRA_SKILLS_ENABLED=1
 # Bounded push-to-talk recorder (the -d bound = no open mic). WAV path appended.
 KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
 # VAD ENDPOINTING (opt-in): stop on trailing silence instead of the fixed -d window

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -51,6 +51,7 @@ import rabbit_diag  # noqa: E402 — deterministic self-check voice command (rea
 import rabbit_ota  # noqa: E402 — deterministic OTA voice commands (NOT the movement door)
 import rabbit_wake  # noqa: E402 — deterministic wake-listener controls (state file only)
 import barge_in  # noqa: E402 — interruptible reply speech (opt-in; Channel A, cosmetic)
+import skill_registry  # noqa: E402 — opt-in named-skill router (motion → the SAME /intent fence)
 from rabbit_persona import name_slot, operator_name  # noqa: E402
 
 MAX_TURNS = 10  # rolling conversation memory (user+assistant pairs kept)
@@ -126,6 +127,26 @@ def ask_llm(history, context, utterance):
     except Exception:  # noqa: BLE001
         return None, None
     return parse_reply(raw)
+
+
+def ask_llm_skills(history, context, utterance):
+    """Skills-mode persona call (opt-in, KIRRA_SKILLS_ENABLED). Returns the raw
+    JSON string; `skill_registry.plan_skills` parses it fail-closed. Same model +
+    near-deterministic options as the default router — only the CONTRACT differs
+    (named skills instead of a free-form directive)."""
+    system = RABBIT_SYSTEM + "\n\n" + skill_registry.skills_prompt_fragment()
+    messages = [{"role": "system", "content": system}]
+    messages += history
+    messages.append({"role": "user", "content": f"{context}\n\nOperator says: {utterance}"})
+    try:
+        r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0,
+                          json={"model": MODEL, "stream": False, "messages": messages,
+                                "options": ROUTER_LLM_OPTIONS})
+        if r.status_code != 200:
+            return ""
+        return (r.json().get("message", {}).get("content") or "").strip()
+    except Exception:  # noqa: BLE001
+        return ""
 
 
 def parse_reply(raw):
@@ -216,6 +237,26 @@ def handle_turn(history, utterance):
         return
 
     context = context_for(utterance)
+
+    # SKILLS MODE (opt-in, KIRRA_SKILLS_ENABLED): the LLM emits {say, skills[]}
+    # from the REGISTERED vocabulary instead of a free-form directive. A motion
+    # skill still routes through the SAME fenced door (offer_to_door → /intent →
+    # checker) via execute_skill_decisions — the registry is a catalog, not a new
+    # door — and an unimplemented/unknown skill is REFUSED, never faked. Default
+    # off → the free-form {say, directive} router below is byte-identical.
+    if skill_registry.enabled():
+        say, decisions = skill_registry.plan_skills(
+            ask_llm_skills(history, context, utterance))
+        if say:
+            _speak_reply(say)
+        elif not decisions:
+            _speak_reply(f"I didn't quite catch that{name_slot()}.")
+        skill_registry.execute_skill_decisions(decisions, offer_to_door, _speak_reply)
+        history.append({"role": "user", "content": utterance})
+        history.append({"role": "assistant", "content": say or "(skill request)"})
+        del history[: max(0, len(history) - 2 * MAX_TURNS)]
+        return
+
     say, directive = ask_llm(history, context, utterance)
     if say is None:
         say = "My voice module is offline for a moment."

--- a/robot/skill_registry.py
+++ b/robot/skill_registry.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""skill_registry.py — the Rabbit capability catalog + fail-closed dispatcher
+(voice-cognition Slice 3, opt-in). Realizes the architecture ruling §5.2: the LLM
+invokes NAMED, registered skills instead of free-form commands, and
+
+  🔴 THE SKILL REGISTRY IS A CATALOG, NOT A NEW DOOR TO THE WHEELS.
+
+A *motion* skill NEVER actuates directly — it compiles to a plain-words directive
+that goes through the EXISTING fail-closed door (mick `POST /intent` →
+`MickIntent::from_llm_json` grounding → Occy → the KIRRA checker), exactly the
+path a typed directive already takes. Read-only skills (speak) never touch
+actuation. A skill that is cataloged-but-unimplemented, or unknown, is REFUSED —
+never faked, never a bypass. So the single-door invariant is preserved: the only
+way a skill reaches the wheels is a `FENCE` decision, and that decision is just
+directive text handed to the same door.
+
+This module is PURE (no HTTP, no LLM) so the safety-critical mapping — which
+skills can reach the fence, which are refused — is fully host-tested. The live
+executor injects the real `offer_to_door` / speak sinks; motion flows ONLY
+through the injected fence sink.
+
+Opt-in: `KIRRA_SKILLS_ENABLED` (default off). Off → rabbit_converse keeps the
+existing `{say, directive}` router, byte-identical.
+"""
+import json
+import os
+from collections import namedtuple
+
+# ── skill kinds ──────────────────────────────────────────────────────────────
+MOTION = "motion"            # compiles to a directive → the /intent fence
+READONLY = "readonly"        # Channel-A, no actuation (e.g. speak)
+UNIMPLEMENTED = "unimplemented"  # cataloged for the future → always REFUSED today
+
+Skill = namedtuple("Skill", [
+    "name", "kind", "description", "permission",
+    "interruptible", "est_duration_s", "preconditions", "failure_modes",
+])
+
+# Decision kinds — the ONLY three things a dispatched skill can become.
+FENCE = "fence"      # payload = directive text for offer_to_door (the sole motion path)
+SPEAK = "speak"      # payload = text to speak (Channel A)
+REFUSE = "refuse"    # payload = reason; NO motion, NO speech-of-content
+Decision = namedtuple("Decision", ["kind", "payload"])
+
+
+def _m(name, desc, precond, fail, dur):
+    return Skill(name, MOTION, desc, "actuator", True, dur, precond, fail)
+
+
+REGISTRY = {
+    # ── MOTION — each maps to a directive through the EXISTING /intent fence ──
+    "navigate": _m("navigate", "Drive to a named place the operator gave.",
+                   ["localization", "map", "posture=nominal"],
+                   ["no route", "checker refusal", "occlusion cap"], 60.0),
+    "cruise": _m("cruise", "Drive forward at a requested speed.",
+                 ["posture=nominal"], ["checker speed clamp"], 30.0),
+    "turn": _m("turn", "Turn left / right / straight at the next junction.",
+               ["localization"], ["no junction", "checker refusal"], 10.0),
+    "pull_over": _m("pull_over", "Pull over to the side and stop.",
+                    [], ["checker refusal"], 15.0),
+    "stop": _m("stop", "Come to a controlled stop (MRC).",
+               [], [], 5.0),
+    # ── READONLY — Channel A, cannot actuate ──
+    "speak": Skill("speak", READONLY, "Say something to the operator.",
+                   "none", True, 3.0, [], []),
+    # ── UNIMPLEMENTED — cataloged with metadata, REFUSED until a real, fenced
+    #    backing exists. NEVER faked (that would be a fabricated capability). ──
+    "dock": Skill("dock", UNIMPLEMENTED, "Dock at a charging/parking station.",
+                  "actuator", True, 90.0, ["dock detected"], ["no dock"]),
+    "follow_person": Skill("follow_person", UNIMPLEMENTED, "Follow a tracked person.",
+                           "actuator", True, 120.0, ["person tracked"], ["lost track"]),
+    "search_area": Skill("search_area", UNIMPLEMENTED, "Search an area for an object.",
+                         "actuator", True, 300.0, ["map"], ["not found"]),
+    "capture_image": Skill("capture_image", UNIMPLEMENTED, "Capture a camera image.",
+                           "sensor", True, 2.0, ["camera"], ["camera fault"]),
+    "read_qr": Skill("read_qr", UNIMPLEMENTED, "Read a QR / AprilTag in view.",
+                     "sensor", True, 3.0, ["camera"], ["no code"]),
+    "inspect_object": Skill("inspect_object", UNIMPLEMENTED, "Inspect a detected object.",
+                            "sensor", True, 20.0, ["object detected"], ["not found"]),
+    "flash_lights": Skill("flash_lights", UNIMPLEMENTED, "Flash the indicator lights.",
+                          "actuator", True, 2.0, ["led"], ["no led"]),
+}
+
+
+# ── pure core (host-tested; no I/O) ──────────────────────────────────────────
+
+def enabled():
+    """Armed only on an explicit affirmative (fail-closed: unset/typo → off)."""
+    return (os.environ.get("KIRRA_SKILLS_ENABLED") or "").strip().lower() \
+        in ("1", "true", "yes", "on")
+
+
+def _num(v):
+    """A finite float from a JSON scalar, or None (fail-closed on junk/NaN/Inf)."""
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    return f if f == f and abs(f) != float("inf") else None
+
+
+def to_directive(name, params):
+    """Compile a MOTION skill + params into the plain-words directive that goes to
+    the /intent fence, or None if the skill is not motion / the params are bad
+    (→ the caller REFUSES; nothing reaches the door)."""
+    params = params if isinstance(params, dict) else {}
+    if name == "navigate":
+        target = str(params.get("target", "")).strip()
+        return f"take us to {target}" if target else None
+    if name == "cruise":
+        speed = _num(params.get("speed_mps"))
+        return f"cruise at {speed:g} meters per second" if speed is not None and speed >= 0 else None
+    if name == "turn":
+        d = str(params.get("direction", "")).strip().lower()
+        return f"turn {d}" if d in ("left", "right", "straight") else None
+    if name == "pull_over":
+        return "pull over to the side and stop"
+    if name == "stop":
+        return "come to a controlled stop"
+    return None
+
+
+def dispatch(name, params):
+    """Map ONE skill invocation to a Decision, fail-closed. Only a MOTION skill
+    with valid params yields FENCE (the sole motion path); UNIMPLEMENTED and
+    unknown names REFUSE; readonly `speak` SPEAKs its text."""
+    skill = REGISTRY.get(name)
+    if skill is None:
+        return Decision(REFUSE, f"unknown skill '{name}'")
+    if skill.kind == UNIMPLEMENTED:
+        return Decision(REFUSE, f"'{name}' is not supported yet")
+    if skill.kind == READONLY:
+        text = str((params or {}).get("text", "")).strip() if isinstance(params, dict) else ""
+        return Decision(SPEAK, text) if text else Decision(REFUSE, "nothing to say")
+    # MOTION
+    directive = to_directive(name, params)
+    if directive is None:
+        return Decision(REFUSE, f"bad parameters for '{name}'")
+    return Decision(FENCE, directive)
+
+
+def plan_skills(llm_json):
+    """Parse the LLM's {say, skills:[{name, parameters}]} reply into (say,
+    [Decision]). Fail-closed: bad JSON / wrong shapes → ('', []) or skipped
+    entries, never a raw command."""
+    try:
+        j = json.loads(llm_json) if isinstance(llm_json, str) else llm_json
+    except (ValueError, TypeError):
+        return "", []
+    if not isinstance(j, dict):
+        return "", []
+    say = j.get("say")
+    say = say.strip() if isinstance(say, str) else ""
+    decisions = []
+    skills = j.get("skills")
+    if isinstance(skills, list):
+        for entry in skills:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str):
+                continue
+            decisions.append(dispatch(name, entry.get("parameters")))
+    return say, decisions
+
+
+def execute_skill_decisions(decisions, fence_fn, speak_fn):
+    """Execute planned decisions with INJECTED sinks. Motion flows ONLY through
+    `fence_fn` (the real offer_to_door → /intent → checker); nothing here builds
+    a command. Returns counts. Host-testable: fence_fn is never called for a
+    REFUSE/SPEAK decision (the single-door invariant, as an assertion point)."""
+    counts = {FENCE: 0, SPEAK: 0, REFUSE: 0}
+    for d in decisions:
+        counts[d.kind] = counts.get(d.kind, 0) + 1
+        if d.kind == FENCE:
+            result = fence_fn(d.payload)          # the ONLY actuation-adjacent call
+            if result != "ok":
+                speak_fn("I heard that, but the governor wouldn't clear it, so I'm holding.")
+        elif d.kind == SPEAK:
+            speak_fn(d.payload)
+        else:  # REFUSE
+            speak_fn(f"I can't do that yet — {d.payload}.")
+    return counts
+
+
+def registered_skill_names():
+    """Names the LLM is allowed to invoke (motion + readonly; unimplemented ones
+    are cataloged but the prompt does not offer them)."""
+    return sorted(n for n, s in REGISTRY.items() if s.kind != UNIMPLEMENTED)
+
+
+def skills_prompt_fragment():
+    """The additive system-prompt fragment describing the skill contract. Kept
+    here (not in rabbit_converse) so the offered vocabulary and the dispatcher
+    stay in lock-step."""
+    names = ", ".join(registered_skill_names())
+    return (
+        "Reply with a JSON object and nothing else:\n"
+        '  {"say": "<one or two sentences to speak>",\n'
+        '   "skills": [{"name": "<one of the skills below>", "parameters": {…}}]}\n'
+        f"Allowed skills: {names}.\n"
+        "  navigate{target} · cruise{speed_mps} · turn{direction:left|right|straight} · "
+        "pull_over{} · stop{} · speak{text}.\n"
+        "Use `speak` (or an empty skills list) for chat/questions. Emit a motion "
+        "skill ONLY when the operator clearly asks to move; copy any place/number "
+        "they gave into parameters VERBATIM, and NEVER invent a destination or "
+        "number they did not say. You are NOT the safety authority — the KIRRA "
+        "checker bounds every motion; never drop a movement request to 'protect' "
+        "the robot."
+    )

--- a/robot/skill_registry_test.py
+++ b/robot/skill_registry_test.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Host tests for the pure skill-registry core in `skill_registry.py`.
+
+The catalog, dispatcher, planner, and executor are pure (no HTTP/LLM), so the
+safety-critical mapping — which skills can reach the fence, which are refused —
+runs on a plain host. The single-door invariant is asserted directly:
+`execute_skill_decisions` calls the fence sink ONLY for a valid motion skill,
+never for a refused/unimplemented/unknown one.
+
+Runs standalone (`python3 robot/skill_registry_test.py`, exit 1 on failure);
+also importable under pytest.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import skill_registry as sk  # noqa: E402
+from skill_registry import (  # noqa: E402
+    FENCE, MOTION, READONLY, REFUSE, REGISTRY, SPEAK, UNIMPLEMENTED, Decision,
+    dispatch, execute_skill_decisions, plan_skills, to_directive,
+)
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+# ── catalog integrity ────────────────────────────────────────────────────────
+
+def test_every_skill_has_metadata():
+    for name, s in REGISTRY.items():
+        check(s.name == name, f"{name}: name mismatch")
+        check(s.kind in (MOTION, READONLY, UNIMPLEMENTED), f"{name}: bad kind {s.kind}")
+        check(bool(s.description), f"{name}: missing description")
+        check(isinstance(s.preconditions, list), f"{name}: preconditions not a list")
+        check(isinstance(s.failure_modes, list), f"{name}: failure_modes not a list")
+        check(isinstance(s.interruptible, bool), f"{name}: interruptible not bool")
+
+
+def test_registered_names_exclude_unimplemented():
+    offered = set(sk.registered_skill_names())
+    for name, s in REGISTRY.items():
+        if s.kind == UNIMPLEMENTED:
+            check(name not in offered, f"unimplemented {name} must not be offered to the LLM")
+        else:
+            check(name in offered, f"{name} should be offered")
+
+
+# ── dispatch decision table ──────────────────────────────────────────────────
+
+def test_motion_yields_fence_directive():
+    d = dispatch("navigate", {"target": "the loading dock"})
+    check(d == Decision(FENCE, "take us to the loading dock"), f"navigate → {d}")
+    d = dispatch("cruise", {"speed_mps": 1.5})
+    check(d.kind == FENCE and "1.5" in d.payload, f"cruise → {d}")
+    d = dispatch("turn", {"direction": "LEFT"})
+    check(d == Decision(FENCE, "turn left"), f"turn → {d}")
+    check(dispatch("pull_over", {}).kind == FENCE, "pull_over → fence")
+    check(dispatch("stop", {}).kind == FENCE, "stop → fence")
+
+
+def test_bad_params_refuse_not_fence():
+    check(dispatch("navigate", {}).kind == REFUSE, "navigate w/o target → refuse")
+    check(dispatch("cruise", {"speed_mps": "fast"}).kind == REFUSE, "cruise non-numeric → refuse")
+    check(dispatch("cruise", {"speed_mps": float("inf")}).kind == REFUSE, "cruise inf → refuse")
+    check(dispatch("turn", {"direction": "around"}).kind == REFUSE, "turn bad dir → refuse")
+
+
+def test_unimplemented_and_unknown_refuse():
+    for name in ("dock", "follow_person", "search_area", "capture_image",
+                 "read_qr", "inspect_object", "flash_lights"):
+        check(dispatch(name, {}).kind == REFUSE, f"{name} (unimplemented) → refuse")
+    check(dispatch("hack_the_gibson", {}).kind == REFUSE, "unknown skill → refuse")
+
+
+def test_readonly_speak():
+    check(dispatch("speak", {"text": "hello"}) == Decision(SPEAK, "hello"), "speak text")
+    check(dispatch("speak", {}).kind == REFUSE, "speak w/o text → refuse (nothing to say)")
+
+
+def test_to_directive_motion_only():
+    check(to_directive("speak", {"text": "x"}) is None, "readonly is not a directive")
+    check(to_directive("dock", {}) is None, "unimplemented is not a directive")
+    check(to_directive("unknown", {}) is None, "unknown is not a directive")
+
+
+# ── planner: fail-closed parsing ─────────────────────────────────────────────
+
+def test_plan_skills_fail_closed():
+    check(plan_skills("not json") == ("", []), "bad JSON → empty")
+    check(plan_skills('["a","list"]') == ("", []), "non-object → empty")
+    say, decs = plan_skills('{"say":"ok","skills":"nope"}')
+    check(say == "ok" and decs == [], "non-list skills → no decisions")
+    say, decs = plan_skills('{"say":"hi","skills":[{"name":"navigate","parameters":{"target":"home"}},'
+                            '{"noname":true},{"name":123}]}')
+    check(say == "hi", "say parsed")
+    check(len(decs) == 1 and decs[0].kind == FENCE, "only the well-formed skill dispatched")
+
+
+# ── THE single-door invariant (executor) ─────────────────────────────────────
+
+def test_executor_motion_only_through_fence():
+    fenced, spoke = [], []
+    decisions = [
+        dispatch("navigate", {"target": "home"}),     # FENCE
+        dispatch("dock", {}),                          # REFUSE (unimplemented)
+        dispatch("hack", {}),                          # REFUSE (unknown)
+        dispatch("speak", {"text": "on it"}),          # SPEAK
+        dispatch("cruise", {"speed_mps": 2}),          # FENCE
+    ]
+    counts = execute_skill_decisions(
+        decisions,
+        fence_fn=lambda directive: (fenced.append(directive) or "ok"),
+        speak_fn=lambda text: spoke.append(text),
+    )
+    check(fenced == ["take us to home", "cruise at 2 meters per second"],
+          f"ONLY motion skills reached the fence: {fenced}")
+    check(counts[FENCE] == 2 and counts[REFUSE] == 2 and counts[SPEAK] == 1,
+          f"decision counts wrong: {counts}")
+    # A refused/unknown skill must NEVER have produced a fence call.
+    check("hack" not in " ".join(fenced) and "dock" not in " ".join(fenced),
+          "a refused skill must never reach the fence")
+
+
+def test_executor_rejected_by_checker_speaks_hold():
+    spoke = []
+    execute_skill_decisions([dispatch("navigate", {"target": "the wall"})],
+                            fence_fn=lambda d: "reject",  # checker refuses
+                            speak_fn=lambda t: spoke.append(t))
+    check(any("holding" in s.lower() or "wouldn't clear" in s.lower() for s in spoke),
+          f"a checker rejection should be narrated, got {spoke}")
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"skill_registry_test: all {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Context

Slice 3 of the Rabbit voice-cognition roadmap (Slices 1–2 merged: #1136 VAD, #1137 barge-in). Realizes architecture ruling **§5.2**: the LLM invokes **named, registered skills** instead of a free-form directive — **without creating a new path to the wheels.**

## The one invariant

🔴 **The skill registry is a catalog, not a new door.** `robot/skill_registry.py`'s pure dispatcher turns each skill into exactly one of three decisions:

| Decision | Skills | Behaviour |
|---|---|---|
| **`FENCE`** | motion: `navigate` / `cruise` / `turn` / `pull_over` / `stop` | compiles to a plain-words directive that goes through the **same** `offer_to_door` → mick `POST /intent` → `MickIntent` grounding → **checker** path a free-form directive already takes. Motion reaches the wheels **only** here. |
| **`SPEAK`** | `speak` | Channel-A narration; no actuation |
| **`REFUSE`** | unimplemented (`dock`, `follow_person`, `search_area`, `capture_image`, `read_qr`, `inspect_object`, `flash_lights`) or unknown names | refused, **never faked** — fabricating a capability is the failure mode this guards against |

`execute_skill_decisions(decisions, offer_to_door, speak)` routes motion **only** through the injected fence sink — the single-door invariant, asserted directly in the tests. `ci/check_mick_actuation_fence.py` and the one-door rule are untouched: a skill name buys the LLM a *vocabulary*, not *authority*.

Each skill also advertises metadata (permission scope, interruptibility, estimated duration, preconditions, failure modes) so the future mission Executive can reason about it without a redesign.

## Wiring (opt-in, `KIRRA_SKILLS_ENABLED`, default off → byte-identical)

`rabbit_converse` gains `ask_llm_skills` + a `handle_turn` branch that plans `{say, skills[]}` and executes it via the existing `offer_to_door` fence. Off → the free-form `{say, directive}` router is unchanged.

## Verification

- `python3 robot/skill_registry_test.py` → 10/10: catalog integrity, dispatch decision table, **bad-params / unimplemented / unknown → REFUSE never FENCE**, fail-closed `{say,skills[]}` parsing, and the executor **single-door invariant** (a refused/unknown skill never reaches the fence; a checker `reject` is narrated as a hold).
- Slices 1 & 2 tests still pass; `rabbit_converse` compiles; installer `bash -n` clean; CI YAML parses.

## Not yet default

Graduating the flag requires extending `rabbit_model_smoketest.py` to gate the skills contract (the model-swap discipline), and the multi-step mission Executive is a later slice — both noted in the env example and `RABBIT_CONVERSATION_DESIGN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_