### PR TITLE
feat(robot): World Model read projection (voice-cognition Slice 4, opt-in)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1265,6 +1265,12 @@ jobs:
           # and THE single-door invariant — execute_skill_decisions routes motion
           # ONLY through the injected fence sink. See robot/skill_registry.py.
           python3 robot/skill_registry_test.py
+          # World Model read projection (pure, no HTTP): TTL freshness incl. the
+          # boundary + clock-skew, absent/stale → UNKNOWN (never a stale value),
+          # the situation-report matcher's non-overlap, render SAYING unknown for
+          # a stale field, and assemble leaving an 'unavailable' source UNKNOWN
+          # (fail-closed). The live gather is the seam. See robot/world_model.py.
+          python3 robot/world_model_test.py
           # ADR-0033 Tier-3 sentinel logic (#887, pure, no device): owner/mode
           # violations vs the AOU-ACTUATION-SERIAL-001 contract (the vendor
           # 0777 rule is the canonical hazard case), holder reporting, and the

--- a/docs/hardware/RABBIT_CONVERSATION_DESIGN.md
+++ b/docs/hardware/RABBIT_CONVERSATION_DESIGN.md
@@ -229,6 +229,29 @@ it without a redesign.
 
 ---
 
+## World Model (opt-in) — a read projection, not a shared brain
+
+`KIRRA_WORLD_MODEL_ENABLED=1` adds a deterministic **"situation report" / "sitrep"**
+voice command (`robot/world_model.py`) that renders a single TTL'd view of the
+live grounding — posture, perception, last stop reason, operator.
+
+It is deliberately a **read projection, not an authority** (architecture ruling
+§5.1). Rather than one shared mutable "brain" every subsystem depends on — a
+single point of staleness that turns "is this fresh enough to act on?" into a
+global question — each field carries its own `source` / `stamp_ms` / `ttl_ms`, and
+a field read past its TTL comes back **`UNKNOWN`**. A stale or unavailable value
+is **said to be unknown, never dressed as current**; a source that reports
+"unavailable" leaves its field unset (`UNKNOWN`), never fabricated. The KIRRA
+checker still reads its **own** inputs directly — the projection never gates
+safety; it is Channel-A narration only.
+
+The freshness core (fresh/stale/skew, snapshot, render, assemble) is host-tested;
+the live gather is the thin seam. Fields without a producer yet (battery,
+localization, nav state, known people) are simply absent → `UNKNOWN` — documented
+projection slots, not fabricated readings.
+
+---
+
 ## Honest caveats
 
 - **Latency.** A local LLM on the Orin (gemma3:4b) is a few seconds per turn.

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -36,7 +36,8 @@ sudo install -d -m 0755 "${OPT}/robot"
 for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabbit_boot.py \
          rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py \
          ros_env.sh kirra_voice_doctor.sh kirra_doctor.py rabbit_diag.py \
-         wake_word.py rabbit_wake.py vad_record.py barge_in.py skill_registry.py; do
+         wake_word.py rabbit_wake.py vad_record.py barge_in.py skill_registry.py \
+         world_model.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -32,6 +32,13 @@ KIRRA_TTS_CMD="./speak.sh"
 # Graduating this to default requires extending rabbit_model_smoketest.py to gate
 # the skills contract. See robot/skill_registry.py + RABBIT_CONVERSATION_DESIGN.md.
 #KIRRA_SKILLS_ENABLED=1
+# WORLD MODEL (opt-in): a read-only "situation report" / "sitrep" voice command
+# that renders a TTL'd projection of the live grounding (posture / perception /
+# last stop / operator). Non-authoritative and Channel-A — the checker reads its
+# OWN inputs; this never gates safety. A stale/unavailable field is SAID to be
+# unknown, never a stale value presented as current. Default off → the command is
+# inert. See robot/world_model.py.
+#KIRRA_WORLD_MODEL_ENABLED=1
 # Bounded push-to-talk recorder (the -d bound = no open mic). WAV path appended.
 KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
 # VAD ENDPOINTING (opt-in): stop on trailing silence instead of the fixed -d window

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -52,6 +52,7 @@ import rabbit_ota  # noqa: E402 — deterministic OTA voice commands (NOT the mo
 import rabbit_wake  # noqa: E402 — deterministic wake-listener controls (state file only)
 import barge_in  # noqa: E402 — interruptible reply speech (opt-in; Channel A, cosmetic)
 import skill_registry  # noqa: E402 — opt-in named-skill router (motion → the SAME /intent fence)
+import world_model  # noqa: E402 — opt-in situation report (read-only TTL'd projection)
 from rabbit_persona import name_slot, operator_name  # noqa: E402
 
 MAX_TURNS = 10  # rolling conversation memory (user+assistant pairs kept)
@@ -233,6 +234,18 @@ def handle_turn(history, utterance):
         speak(wake_reply)
         history.append({"role": "user", "content": utterance})
         history.append({"role": "assistant", "content": wake_reply})
+        del history[: max(0, len(history) - 2 * MAX_TURNS)]
+        return
+
+    # "Situation report" / "sitrep" — deterministic, read-only (opt-in,
+    # KIRRA_WORLD_MODEL_ENABLED). Renders the TTL'd World Model projection: a
+    # stale/unavailable field is SAID to be unknown, never a stale value. No LLM,
+    # no /intent, no motion. Off → None → falls through to the LLM.
+    wm_reply = world_model.handle(utterance)
+    if wm_reply is not None:
+        _speak_reply(wm_reply)
+        history.append({"role": "user", "content": utterance})
+        history.append({"role": "assistant", "content": wm_reply})
         del history[: max(0, len(history) - 2 * MAX_TURNS)]
         return
 

--- a/robot/world_model.py
+++ b/robot/world_model.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""world_model.py — the Rabbit World Model READ PROJECTION (voice-cognition
+Slice 4, opt-in). A non-authoritative, TTL'd view the Conversation Manager (and
+later the planner) can READ to answer "what's my situation?" in one place.
+
+🔴 IT IS A READ PROJECTION, NOT AN AUTHORITY (architecture ruling §5.1):
+  * No subsystem depends on it for a safety decision — the KIRRA checker reads
+    its OWN inputs directly. This is operator-facing narration only (Channel A).
+  * Every field carries its own `source`, `stamp_ms`, and `ttl_ms`. On read, a
+    field older than its TTL reads as UNKNOWN — a stale value is NEVER presented
+    as current. Absent field → UNKNOWN. That is the whole point: fail-closed
+    freshness, kept LOCAL and checkable, instead of one shared mutable brain that
+    turns "is this fresh enough?" into a global question.
+
+The pure core (freshness, snapshot, render) is host-tested. The live assembler
+pulls the read-only grounding that already exists (posture / perception / last
+stop reason / operator) and stamps each field; a source that reports
+"unavailable/unreachable" leaves its field UNSET → UNKNOWN (fail-closed), it is
+never fabricated. Fields without a producer yet (battery, localization, nav
+state, known people) are simply absent → UNKNOWN, documented projection slots.
+
+Opt-in: `KIRRA_WORLD_MODEL_ENABLED` (default off). Off → the deterministic
+"situation report" voice command is inert and rabbit_converse is byte-identical.
+"""
+import os
+import re
+import time
+from collections import namedtuple
+
+
+class _Unknown:
+    __slots__ = ()
+
+    def __repr__(self):
+        return "UNKNOWN"
+
+
+UNKNOWN = _Unknown()  # singleton sentinel — a field that is stale/absent/unavailable
+
+
+def is_unknown(v):
+    return isinstance(v, _Unknown)
+
+
+Field = namedtuple("Field", ["value", "source", "stamp_ms", "ttl_ms"])
+
+# Default per-field freshness budgets (ms). Posture mirrors POSTURE_CACHE_TTL_MS.
+DEFAULT_TTLS = {
+    "posture": 5_000,
+    "perception": 3_000,
+    "stop_reason": 15_000,
+    "operator": 3_600_000,
+}
+
+# The spoken order + labels for the situation report.
+_REPORT_ORDER = [
+    ("posture", "Posture"),
+    ("perception", "Ahead"),
+    ("stop_reason", "Last stop"),
+    ("operator", "Operator"),
+]
+
+_REPORT_RE = re.compile(
+    r"\b(situation\s+report|status\s+report|status\s+update|sitrep"
+    r"|give\s+me\s+(a\s+)?status|how\s+are\s+we\s+doing)\b",
+    re.IGNORECASE,
+)
+
+
+# ── pure core (host-tested; no I/O) ──────────────────────────────────────────
+
+def enabled():
+    """Armed only on an explicit affirmative (fail-closed: unset/typo → off)."""
+    return (os.environ.get("KIRRA_WORLD_MODEL_ENABLED") or "").strip().lower() \
+        in ("1", "true", "yes", "on")
+
+
+def is_fresh(stamp_ms, ttl_ms, now_ms):
+    """Fresh iff read within the TTL of the stamp. A future stamp (clock skew)
+    reads fresh, not stale; a non-positive TTL is always stale."""
+    if ttl_ms <= 0:
+        return False
+    return (now_ms - stamp_ms) <= ttl_ms
+
+
+def is_source_failure(text):
+    """A gather that returned an 'unavailable/unreachable' marker is NOT data — the
+    projection must leave that field UNKNOWN rather than present the marker as a
+    fact."""
+    t = (text or "").lower()
+    return any(m in t for m in ("unavailable", "unreachable", "not reachable",
+                                "not available", "cannot reach", "offline"))
+
+
+class WorldModel:
+    """A bag of TTL'd fields. `get`/`snapshot` return UNKNOWN for absent-or-stale;
+    time is injected (now_ms) so reads are deterministic under test."""
+
+    def __init__(self):
+        self._fields = {}
+
+    def set(self, name, value, source, stamp_ms, ttl_ms):
+        self._fields[name] = Field(value, source, stamp_ms, ttl_ms)
+
+    def get(self, name, now_ms):
+        f = self._fields.get(name)
+        if f is None or not is_fresh(f.stamp_ms, f.ttl_ms, now_ms):
+            return UNKNOWN
+        return f.value
+
+    def fresh(self, name, now_ms):
+        f = self._fields.get(name)
+        return f is not None and is_fresh(f.stamp_ms, f.ttl_ms, now_ms)
+
+    def snapshot(self, now_ms):
+        """A read-time view: {name: {value|UNKNOWN, fresh, age_ms, source, ttl_ms}}."""
+        out = {}
+        for name, f in self._fields.items():
+            fresh = is_fresh(f.stamp_ms, f.ttl_ms, now_ms)
+            out[name] = {
+                "value": f.value if fresh else UNKNOWN,
+                "fresh": fresh,
+                "age_ms": now_ms - f.stamp_ms,
+                "source": f.source,
+                "ttl_ms": f.ttl_ms,
+            }
+        return out
+
+
+def render(snapshot):
+    """A spoken situation report. A stale/absent/UNKNOWN field is SAID to be
+    unknown — never a stale value dressed as current."""
+    lines = ["Here's my situation report."]
+    for name, label in _REPORT_ORDER:
+        entry = snapshot.get(name)
+        if entry is None:
+            lines.append(f"{label}: unknown — no reading.")
+        elif entry["fresh"] and not is_unknown(entry["value"]):
+            lines.append(f"{label}: {entry['value']}.")
+        else:
+            lines.append(f"{label}: unknown — stale or unavailable.")
+    return " ".join(lines)
+
+
+def matches(utterance):
+    """Deterministic 'situation report' matcher — no LLM. Does not overlap the
+    diagnostics ('check yourself'), OTA ('check for updates'), or drive matchers."""
+    return bool(_REPORT_RE.search(utterance or ""))
+
+
+def assemble(now_ms, gathers, operator, ttls=None):
+    """Build a WorldModel from injected gather callables (pure: no HTTP here).
+    `gathers` maps field-name → a zero-arg callable returning a string; a string
+    that `is_source_failure` leaves the field UNSET → UNKNOWN (fail-closed). This
+    is the seam the live report drives with rabbit_ask's real gathers."""
+    ttls = ttls or DEFAULT_TTLS
+    wm = WorldModel()
+    for name, gather in gathers.items():
+        try:
+            text = gather()
+        except Exception:  # noqa: BLE001 — a broken source is UNKNOWN, never a crash
+            continue
+        if isinstance(text, str) and text.strip() and not is_source_failure(text):
+            wm.set(name, text.strip(), name, now_ms, ttls.get(name, 5_000))
+    if operator:
+        wm.set("operator", operator, "env", now_ms, ttls.get("operator", 3_600_000))
+    return wm
+
+
+# ── live seam (thin; not unit-tested — drives the pure core with real gathers) ─
+
+def run_report():
+    """Assemble from the live read-only grounding and render the spoken report."""
+    try:
+        import sys
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from rabbit_ask import gather_perception, gather_posture, gather_stop_reason
+        from rabbit_persona import operator_name
+    except Exception:  # noqa: BLE001
+        return "I can't reach my situation sources right now."
+    now_ms = int(time.time() * 1000)
+    wm = assemble(now_ms, {
+        "posture": gather_posture,
+        "perception": gather_perception,
+        "stop_reason": gather_stop_reason,
+    }, operator_name())
+    return render(wm.snapshot(now_ms))
+
+
+def handle(utterance):
+    """rabbit_diag.handle contract: the spoken report, or None if this isn't a
+    situation-report request / the feature is off (→ falls through to the LLM)."""
+    if not enabled() or not matches(utterance):
+        return None
+    return run_report()

--- a/robot/world_model_test.py
+++ b/robot/world_model_test.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Host tests for the pure World Model read-projection core in `world_model.py`.
+
+The freshness / snapshot / render / assemble logic is pure (time injected, gathers
+injected), so the fail-closed staleness semantics run on a plain host. The live
+`run_report` (real HTTP gathers + wall clock) is the thin seam, exercised on the
+robot.
+
+Runs standalone (`python3 robot/world_model_test.py`, exit 1 on failure); also
+importable under pytest.
+
+Covers: the enable gate (fail-closed); TTL freshness incl. the exact boundary and
+clock-skew; absent/stale → UNKNOWN (never a stale value); the snapshot shape; the
+report matcher (and its non-overlap); render SAYS unknown for a stale field; and
+assemble stamping a good source but leaving an 'unavailable' one UNKNOWN.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import world_model as wm  # noqa: E402
+from world_model import (  # noqa: E402
+    UNKNOWN, WorldModel, assemble, is_fresh, is_source_failure, is_unknown,
+    matches, render,
+)
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def test_enable_gate_fail_closed():
+    prev = os.environ.get("KIRRA_WORLD_MODEL_ENABLED")
+    try:
+        for off in (None, "", "0", "false", "no", "off", "enabled"):
+            if off is None:
+                os.environ.pop("KIRRA_WORLD_MODEL_ENABLED", None)
+            else:
+                os.environ["KIRRA_WORLD_MODEL_ENABLED"] = off
+            check(not wm.enabled(), f"{off!r} must NOT arm (fail-closed)")
+        for on in ("1", "true", "yes", "on"):
+            os.environ["KIRRA_WORLD_MODEL_ENABLED"] = on
+            check(wm.enabled(), f"{on!r} should arm")
+    finally:
+        if prev is None:
+            os.environ.pop("KIRRA_WORLD_MODEL_ENABLED", None)
+        else:
+            os.environ["KIRRA_WORLD_MODEL_ENABLED"] = prev
+
+
+def test_is_fresh_boundary_and_skew():
+    check(is_fresh(1000, 500, 1400), "within ttl → fresh")
+    check(is_fresh(1000, 500, 1500), "exactly at ttl → fresh (<=)")
+    check(not is_fresh(1000, 500, 1501), "past ttl → stale")
+    check(is_fresh(1000, 500, 900), "future stamp (skew) → fresh, not stale")
+    check(not is_fresh(1000, 0, 1000), "non-positive ttl → always stale")
+
+
+def test_get_absent_and_stale_are_unknown():
+    m = WorldModel()
+    check(is_unknown(m.get("posture", 0)), "absent field → UNKNOWN")
+    m.set("posture", "nominal", "src", stamp_ms=1000, ttl_ms=500)
+    check(m.get("posture", 1400) == "nominal", "fresh → the value")
+    check(is_unknown(m.get("posture", 2000)), "stale → UNKNOWN, never the stale value")
+
+
+def test_snapshot_shape():
+    m = WorldModel()
+    m.set("posture", "nominal", "verifier", stamp_ms=1000, ttl_ms=500)
+    snap = m.snapshot(1200)
+    e = snap["posture"]
+    check(e["fresh"] and e["value"] == "nominal", "fresh snapshot carries the value")
+    check(e["age_ms"] == 200 and e["source"] == "verifier", f"snapshot meta wrong: {e}")
+    stale = m.snapshot(2000)["posture"]
+    check(not stale["fresh"] and is_unknown(stale["value"]),
+          "stale snapshot value is UNKNOWN")
+
+
+def test_render_says_unknown_for_stale():
+    m = WorldModel()
+    m.set("posture", "nominal", "verifier", stamp_ms=1000, ttl_ms=500)
+    fresh_text = render(m.snapshot(1200))
+    check("Posture: nominal." in fresh_text, f"fresh render missing posture: {fresh_text}")
+    stale_text = render(m.snapshot(9999))
+    check("Posture: unknown" in stale_text and "nominal" not in stale_text,
+          f"stale render must SAY unknown, not the stale value: {stale_text}")
+
+
+def test_matcher_scope():
+    for yes in ("situation report", "give me a status", "SITREP", "status update",
+                "how are we doing"):
+        check(matches(yes), f"should match {yes!r}")
+    for no in ("check yourself", "check for updates", "take us to the door", "hello"):
+        check(not matches(no), f"must NOT match {no!r} (overlap)")
+
+
+def test_source_failure_detection():
+    check(is_source_failure("posture: unavailable (cannot reach the governor)"), "unavailable")
+    check(is_source_failure("perception: unavailable (ROS not reachable)"), "unreachable")
+    check(not is_source_failure("posture: nominal, all trusted"), "real value is not a failure")
+
+
+def test_assemble_stamps_good_leaves_failure_unknown():
+    gathers = {
+        "posture": lambda: "posture: nominal",
+        "perception": lambda: "perception: unavailable (ROS not reachable)",
+        "stop_reason": lambda: "  ",                       # empty → skip
+        "boom": lambda: (_ for _ in ()).throw(RuntimeError()),  # raises → skip
+    }
+    m = assemble(now_ms=1000, gathers=gathers, operator="Justin",
+                 ttls={"posture": 5000, "perception": 5000, "operator": 9999})
+    check(m.get("posture", 1000) == "posture: nominal", "good source stamped")
+    check(is_unknown(m.get("perception", 1000)), "failed source → UNKNOWN, not the marker")
+    check(is_unknown(m.get("stop_reason", 1000)), "empty source → UNKNOWN")
+    check(is_unknown(m.get("boom", 1000)), "raising source → UNKNOWN (no crash)")
+    check(m.get("operator", 1000) == "Justin", "operator set")
+
+
+def test_assemble_no_operator():
+    m = assemble(1000, {"posture": lambda: "posture: nominal"}, operator="")
+    check(is_unknown(m.get("operator", 1000)), "no operator → UNKNOWN, never guessed")
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"world_model_test: all {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Context

Slice 4 of the Rabbit voice-cognition roadmap (Slices 1–3 merged: #1136 VAD, #1137 barge-in, #1138 skill registry). Realizes architecture ruling **§5.1**: a non-authoritative, TTL'd "situation report" the Conversation Manager can read to answer "what's my situation?" in one place — **without a shared mutable brain.**

## Read projection, not an authority

`robot/world_model.py`:
- Every field carries its own **`source` / `stamp_ms` / `ttl_ms`**. On read, a field past its TTL comes back **`UNKNOWN`**; absent → `UNKNOWN`. A stale/unavailable value is **said to be unknown, never presented as current.** This keeps the fail-closed freshness question **local and checkable** instead of a global one — the reason I pushed back on a single centralized world-model.
- The **KIRRA checker still reads its own inputs directly** — the projection never gates safety; it's Channel-A narration only.
- `assemble()` pulls the read-only grounding that already exists (posture / perception / last stop / operator) and stamps each field; a source reporting "unavailable/unreachable" leaves its field **unset → `UNKNOWN`** (fail-closed), never fabricated. Fields without a producer yet (battery, localization, nav state) are absent → `UNKNOWN` — documented projection slots, not fake readings.

## Wiring (opt-in, `KIRRA_WORLD_MODEL_ENABLED`, default off → byte-identical)

A deterministic **"situation report" / "sitrep"** pre-matcher in `rabbit_converse` (alongside OTA/diag/wake) renders the projection — no LLM, no `/intent`, no motion.

## Verification

- `python3 robot/world_model_test.py` → 9/9: fail-closed enable gate, TTL freshness incl. the exact boundary + clock-skew, absent/stale → `UNKNOWN`, snapshot shape, **render SAYING unknown for a stale field** (not the stale value), the report matcher's non-overlap with diag/OTA/drive, and `assemble` stamping a good source while leaving an 'unavailable'/empty/raising one `UNKNOWN`.
- Slices 1–3 tests still pass; `rabbit_converse` compiles; installer `bash -n` clean; CI YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_