### PR TITLE
feat(robot): mission Executive — multi-step, checker-bounded (Slice 5, opt-in)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1282,6 +1282,13 @@ jobs:
           # a stale field, and assemble leaving an 'unavailable' source UNKNOWN
           # (fail-closed). The live gather is the seam. See robot/world_model.py.
           python3 robot/world_model_test.py
+          # Mission Executive (pure, no LLM/HTTP): fail-closed plan parsing,
+          # validate REFUSING a mission with any unsupported skill before any
+          # motion, and THE single-door invariant in run_mission — motion routes
+          # ONLY through the injected fence sink, a checker refusal HALTS (never
+          # skip-and-continue), transient errors retry then halt, and a barge-in
+          # cancels mid-mission. See robot/mission.py.
+          python3 robot/mission_test.py
           # ADR-0033 Tier-3 sentinel logic (#887, pure, no device): owner/mode
           # violations vs the AOU-ACTUATION-SERIAL-001 contract (the vendor
           # 0777 rule is the canonical hazard case), holder reporting, and the

--- a/docs/hardware/RABBIT_CONVERSATION_DESIGN.md
+++ b/docs/hardware/RABBIT_CONVERSATION_DESIGN.md
@@ -252,6 +252,39 @@ projection slots, not fabricated readings.
 
 ---
 
+## Missions (opt-in) — a multi-step Executive that the checker still bounds
+
+`KIRRA_MISSIONS_ENABLED=1` adds a multi-step **Executive** (`robot/mission.py`):
+the LLM emits `{say, mission:[{name, parameters}, …]}` — an ordered plan over the
+**registered** skills — and the Executive runs it with sequencing, retry,
+cancellation, and progress narration. It takes precedence over skills mode;
+default off → the single-turn router is byte-identical.
+
+The Executive is a **doer; the checker still owns every step:**
+
+- **Motion only through the fence.** Each motion step is executed by handing its
+  directive to the *same* `offer_to_door` → `/intent` → checker path a single
+  directive already takes. `run_mission` routes motion *only* through the
+  injected fence sink — asserted in `mission_test.py`.
+- **Refuse before motion.** `validate_mission` dispatches every step up front; a
+  mission with *any* unimplemented/unknown skill (e.g. `inspect`, `dock`) is
+  **refused before a single step runs** — no partial mission with a bad step.
+- **Halt, never skip.** A step the checker **refuses** halts the mission (motion
+  never continues to the next step); a transient door error retries a bounded
+  number of times, then halts. Fail-closed throughout.
+- **Cancellable.** A barge-in (Slice 2 — a PTT press / `barge_in.py --signal`)
+  cancels between or within steps; the ego stops (the checker's own MRC) and the
+  Executive never authors re-acceleration.
+
+So the mission layer buys the operator *sequencing*, not *authority*: the same
+`ci/check_mick_actuation_fence.py` one-door rule holds, one step at a time. The
+Executive core (plan / validate / step transitions / run) is pure and
+host-tested; the LLM planning call is the thin seam. Missions are limited to the
+registered skills — as unimplemented skills (`dock`, `search_area`, …) gain real,
+fenced backings, missions get richer with no change to this safety story.
+
+---
+
 ## Honest caveats
 
 - **Latency.** A local LLM on the Orin (gemma3:4b) is a few seconds per turn.

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -37,7 +37,7 @@ for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabb
          rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py \
          ros_env.sh kirra_voice_doctor.sh kirra_doctor.py rabbit_diag.py \
          wake_word.py rabbit_wake.py vad_record.py barge_in.py skill_registry.py \
-         world_model.py; do
+         world_model.py mission.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -39,6 +39,14 @@ KIRRA_TTS_CMD="./speak.sh"
 # unknown, never a stale value presented as current. Default off → the command is
 # inert. See robot/world_model.py.
 #KIRRA_WORLD_MODEL_ENABLED=1
+# MISSIONS (opt-in, EXPERIMENTAL): a multi-step Executive. The LLM emits
+# {say, mission:[...]} over the REGISTERED skills; the Executive runs them with
+# sequencing / retry / cancel. Each MOTION step still routes through the SAME
+# fenced door (mick /intent → checker); a mission with any unsupported skill is
+# REFUSED before any motion; a checker-refused step HALTS (never skip-and-
+# continue); a barge-in (Slice 2) cancels. Takes precedence over KIRRA_SKILLS_
+# ENABLED. Default off → the single-turn router. See robot/mission.py.
+#KIRRA_MISSIONS_ENABLED=1
 # Bounded push-to-talk recorder (the -d bound = no open mic). WAV path appended.
 KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
 # VAD ENDPOINTING (opt-in): stop on trailing silence instead of the fixed -d window

--- a/robot/mission.py
+++ b/robot/mission.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""mission.py — the Rabbit mission planner + Executive (voice-cognition Slice 5,
+opt-in). Expands a multi-step request ("go to the dock, then pull over") into a
+sequence of REGISTERED skills and runs them with sequencing / retry / cancel /
+progress — WITHOUT ever becoming a new path to the wheels.
+
+🔴 THE EXECUTIVE IS A DOER; THE CHECKER STILL OWNS EACH STEP (ruling §5.2):
+  * A mission is only an ORDERED LIST of the same skills `skill_registry`
+    dispatches. Every MOTION step is executed by handing its directive text to
+    the SAME fenced door (offer_to_door → mick /intent → MickIntent grounding →
+    the KIRRA checker) — the executive never builds a command.
+  * FAIL-CLOSED sequencing: a step the checker REFUSES HALTS the mission (never
+    skip-and-continue into the next step); a transient door error retries a
+    bounded number of times, then halts. Motion never continues past a refusal.
+  * A mission containing ANY unimplemented/unknown skill is REFUSED BEFORE ANY
+    MOTION (validate up front) — a partial mission with a bad step never starts.
+  * CANCELLABLE: a barge-in (PTT / e-stop signal, Slice 2) cancels the mission
+    between/within steps — the ego stops (the checker's own MRC), the executive
+    never authors re-acceleration.
+
+The Executive is PURE (injected fence / speak / cancel sinks, no HTTP/LLM), so
+the safety-critical routing — motion ONLY through the fence sink, halt-on-refuse,
+refuse-unsupported — is fully host-tested.
+
+Opt-in: `KIRRA_MISSIONS_ENABLED` (default off). Off → rabbit_converse keeps its
+existing single-turn router, byte-identical.
+"""
+import json
+import os
+import sys
+from collections import namedtuple
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import skill_registry as sk  # noqa: E402 — the skill catalog + fail-closed dispatcher
+
+# Mission outcome states.
+COMPLETED = "completed"
+HALTED = "halted"          # a checker refusal / unreachable door stopped it
+CANCELLED = "cancelled"    # a barge-in cancelled it
+REFUSED = "refused"        # the plan itself was rejected before any motion
+
+MissionResult = namedtuple("MissionResult", ["status", "steps_done", "total", "reason"])
+
+DEFAULT_MAX_RETRIES = 2
+
+
+# ── pure core (host-tested; no I/O) ──────────────────────────────────────────
+
+def enabled():
+    """Armed only on an explicit affirmative (fail-closed: unset/typo → off)."""
+    return (os.environ.get("KIRRA_MISSIONS_ENABLED") or "").strip().lower() \
+        in ("1", "true", "yes", "on")
+
+
+def plan_mission(llm_json):
+    """Parse the LLM's {say, mission:[{name, parameters}]} into (say, [(name,
+    params)]). Fail-closed: bad JSON / wrong shapes → ('', []) or skipped
+    entries, never a raw command."""
+    try:
+        j = json.loads(llm_json) if isinstance(llm_json, str) else llm_json
+    except (ValueError, TypeError):
+        return "", []
+    if not isinstance(j, dict):
+        return "", []
+    say = j.get("say")
+    say = say.strip() if isinstance(say, str) else ""
+    steps = []
+    seq = j.get("mission")
+    if isinstance(seq, list):
+        for entry in seq:
+            if isinstance(entry, dict) and isinstance(entry.get("name"), str):
+                steps.append((entry["name"], entry.get("parameters")))
+    return say, steps
+
+
+def validate_mission(steps):
+    """Dispatch every step up front. Returns (ok, decisions, reason). The mission
+    is REFUSED (ok=False) if it is empty or ANY step dispatches to REFUSE — a
+    mission with an unsupported/unknown skill never starts a single motion."""
+    if not steps:
+        return False, [], "the mission was empty"
+    decisions = [sk.dispatch(name, params) for name, params in steps]
+    for (name, _), d in zip(steps, decisions):
+        if d.kind == sk.REFUSE:
+            return False, decisions, f"'{name}' — {d.payload}"
+    return True, decisions, None
+
+
+def _decide(outcome, attempts, max_retries):
+    """Pure per-step transition for a MOTION step. outcome ∈ 'ok'|'reject'|
+    'error'. Returns 'advance' | 'retry' | 'halt'. A checker refusal halts
+    immediately (retrying a refused command is pointless and hammers the fence);
+    only a transient door error retries, up to the bound."""
+    if outcome == "ok":
+        return "advance"
+    if outcome == "reject":
+        return "halt"           # the checker refused — fail-closed stop
+    return "retry" if attempts < max_retries else "halt"  # transient 'error'
+
+
+def run_mission(decisions, fence_fn, speak_fn, cancel_check=None,
+                max_retries=DEFAULT_MAX_RETRIES, progress_fn=None):
+    """Execute pre-validated decisions with INJECTED sinks. Motion flows ONLY
+    through `fence_fn` (offer_to_door → /intent → checker), which returns
+    'ok'|'reject'|'error'. SPEAK steps narrate; a REFUSE decision (should have
+    been validated out) fail-closes to REFUSED. Returns a MissionResult.
+
+    Host-testable single-door invariant: `fence_fn` is called ONLY for a FENCE
+    step; a cancel between/within steps stops before the next fence call."""
+    cancel_check = cancel_check or (lambda: False)
+    total = len(decisions)
+    for i, d in enumerate(decisions):
+        if cancel_check():
+            return MissionResult(CANCELLED, i, total, "cancelled by the operator")
+        if progress_fn:
+            progress_fn(i + 1, total, d)
+        if d.kind == sk.SPEAK:
+            speak_fn(d.payload)
+            continue
+        if d.kind == sk.REFUSE:  # defense in depth — validate should have caught it
+            return MissionResult(REFUSED, i, total, d.payload)
+        # FENCE — the sole motion path.
+        attempts = 0
+        while True:
+            if cancel_check():
+                return MissionResult(CANCELLED, i, total, "cancelled by the operator")
+            action = _decide(fence_fn(d.payload), attempts, max_retries)
+            if action == "advance":
+                break
+            if action == "halt":
+                reason = (f"step {i + 1} of {total} was refused by the governor"
+                          if attempts == 0 else
+                          f"step {i + 1} of {total} couldn't reach the driving control")
+                return MissionResult(HALTED, i, total, reason)
+            attempts += 1  # retry a transient error
+    return MissionResult(COMPLETED, total, total, None)
+
+
+def narrate_result(result):
+    """A spoken summary of a finished mission."""
+    if result.status == COMPLETED:
+        return "Mission complete — all steps done."
+    if result.status == CANCELLED:
+        return f"Mission cancelled after {result.steps_done} of {result.total} steps; I'm holding."
+    if result.status == REFUSED:
+        return f"I can't run that mission — {result.reason}."
+    return f"Mission halted — {result.reason}. I've stopped."
+
+
+def narrate_progress(index, total, decision):
+    """A short per-step line (Channel A)."""
+    if decision.kind == sk.FENCE:
+        return f"Step {index} of {total}: {decision.payload}."
+    return None  # SPEAK steps narrate themselves; no meta-line needed
+
+
+# ── live seam (thin; not unit-tested — wires the pure core to real sinks) ─────
+
+def cancel_check_from_barge_in():
+    """A cancel predicate driven by the Slice-2 barge-in signal (a PTT press /
+    `barge_in.py --signal` cancels the running mission). None when barge-in is
+    off → the mission runs to completion/halt uninterrupted."""
+    try:
+        import barge_in
+        if not barge_in.enabled():
+            return None
+        path = barge_in.signal_path()
+        baseline = barge_in.read_epoch(path)
+        return barge_in.make_file_cancel_check(path, baseline)
+    except Exception:  # noqa: BLE001 — a broken cancel source must not run motion unguarded
+        return None
+
+
+def missions_prompt_fragment():
+    """The additive system-prompt fragment for mission planning. Lives here so the
+    offered vocabulary stays in lock-step with skill_registry's dispatcher."""
+    names = ", ".join(sk.registered_skill_names())
+    return (
+        "The operator may ask for a MULTI-STEP mission. Reply with a JSON object "
+        "and nothing else:\n"
+        '  {"say": "<one or two sentences to speak>",\n'
+        '   "mission": [{"name": "<skill>", "parameters": {…}}, …]}\n'
+        f"Allowed skills (each step must be one of these): {names}.\n"
+        "  navigate{target} · cruise{speed_mps} · turn{direction} · pull_over{} · "
+        "stop{} · speak{text}.\n"
+        "List the steps IN ORDER. Copy any place/number the operator gave into "
+        "parameters VERBATIM; NEVER invent a destination or number they did not "
+        "say. For chat/questions with no multi-step motion, use an empty mission "
+        "(and put your reply in `say`). You are NOT the safety authority — the "
+        "KIRRA checker bounds every step and will halt the mission if a step is "
+        "unsafe; never drop a step to 'protect' the robot."
+    )

--- a/robot/mission_test.py
+++ b/robot/mission_test.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Host tests for the pure mission planner + Executive in `mission.py`.
+
+Planning, validation, and the Executive are pure (injected fence / speak / cancel
+sinks — no HTTP/LLM), so the safety-critical routing runs on a plain host. The
+single-door invariant is asserted directly: `run_mission` calls the fence sink
+ONLY for a motion step, halts (never skips) on a checker refusal, and refuses a
+mission with an unsupported step before any motion.
+
+Runs standalone (`python3 robot/mission_test.py`, exit 1 on failure); also
+importable under pytest.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import mission  # noqa: E402
+import skill_registry as sk  # noqa: E402
+from mission import (  # noqa: E402
+    CANCELLED, COMPLETED, HALTED, REFUSED, plan_mission, run_mission,
+    validate_mission,
+)
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+class _Fence:
+    """A fake door: returns a scripted outcome per call, recording every directive
+    it was handed (so we can assert motion routed ONLY here, and in order)."""
+    def __init__(self, script=None):
+        self.script = list(script or [])
+        self.calls = []
+
+    def __call__(self, directive):
+        self.calls.append(directive)
+        return self.script.pop(0) if self.script else "ok"
+
+
+def test_enable_gate_fail_closed():
+    prev = os.environ.get("KIRRA_MISSIONS_ENABLED")
+    try:
+        for off in (None, "", "0", "false", "off", "enabled"):
+            if off is None:
+                os.environ.pop("KIRRA_MISSIONS_ENABLED", None)
+            else:
+                os.environ["KIRRA_MISSIONS_ENABLED"] = off
+            check(not mission.enabled(), f"{off!r} must NOT arm (fail-closed)")
+        os.environ["KIRRA_MISSIONS_ENABLED"] = "1"
+        check(mission.enabled(), "'1' should arm")
+    finally:
+        if prev is None:
+            os.environ.pop("KIRRA_MISSIONS_ENABLED", None)
+        else:
+            os.environ["KIRRA_MISSIONS_ENABLED"] = prev
+
+
+def test_plan_mission_fail_closed():
+    check(plan_mission("not json") == ("", []), "bad JSON → empty")
+    check(plan_mission('{"say":"hi"}') == ("hi", []), "no mission key → no steps")
+    say, steps = plan_mission('{"say":"ok","mission":[{"name":"navigate","parameters":'
+                              '{"target":"dock"}},{"noname":1},{"name":"pull_over"}]}')
+    check(say == "ok" and steps == [("navigate", {"target": "dock"}), ("pull_over", None)],
+          f"well-formed steps only: {steps}")
+
+
+def test_validate_refuses_empty_and_unsupported():
+    ok, _, reason = validate_mission([])
+    check(not ok and "empty" in reason, "empty mission refused")
+    ok, _, reason = validate_mission([("navigate", {"target": "dock"}),
+                                      ("dock", {})])  # dock = unimplemented
+    check(not ok and "dock" in reason, f"unsupported step refuses whole mission: {reason}")
+    ok, decisions, reason = validate_mission([("navigate", {"target": "dock"}),
+                                              ("pull_over", {})])
+    check(ok and reason is None and all(d.kind == sk.FENCE for d in decisions),
+          "all-motion mission validates to FENCE decisions")
+
+
+def test_run_completes_motion_only_through_fence_in_order():
+    _, decisions, _ = validate_mission([("navigate", {"target": "dock"}),
+                                        ("speak", {"text": "arriving"}),
+                                        ("pull_over", {})])
+    fence = _Fence()
+    spoke = []
+    result = run_mission(decisions, fence_fn=fence, speak_fn=spoke.append)
+    check(result.status == COMPLETED and result.steps_done == 3, f"should complete: {result}")
+    check(fence.calls == ["take us to dock", "pull over to the side and stop"],
+          f"ONLY motion steps hit the fence, in order: {fence.calls}")
+    check(spoke == ["arriving"], f"speak step narrated: {spoke}")
+
+
+def test_checker_refusal_halts_no_skip():
+    _, decisions, _ = validate_mission([("navigate", {"target": "dock"}),
+                                        ("cruise", {"speed_mps": 2}),
+                                        ("pull_over", {})])
+    fence = _Fence(script=["ok", "reject"])  # step 2 refused by the checker
+    result = run_mission(decisions, fence_fn=fence, speak_fn=lambda t: None)
+    check(result.status == HALTED and result.steps_done == 1, f"halt at the refusal: {result}")
+    check("refused by the governor" in result.reason, f"reason names the refusal: {result.reason}")
+    # The THIRD step must never have been attempted (no skip-and-continue).
+    check(fence.calls == ["take us to dock", "cruise at 2 meters per second"],
+          f"motion stopped at the refused step, never ran step 3: {fence.calls}")
+
+
+def test_transient_error_retries_then_halts():
+    _, decisions, _ = validate_mission([("navigate", {"target": "dock"})])
+    fence = _Fence(script=["error", "error", "error"])  # never succeeds
+    result = run_mission(decisions, fence_fn=fence, speak_fn=lambda t: None, max_retries=2)
+    check(result.status == HALTED, f"exhausted retries → halt: {result}")
+    check(len(fence.calls) == 3, f"1 try + 2 retries = 3 calls, got {len(fence.calls)}")
+
+    fence2 = _Fence(script=["error", "ok"])  # recovers on the retry
+    r2 = run_mission(decisions, fence_fn=fence2, speak_fn=lambda t: None, max_retries=2)
+    check(r2.status == COMPLETED, f"a recovered retry completes: {r2}")
+
+
+def test_cancel_stops_before_next_fence():
+    _, decisions, _ = validate_mission([("navigate", {"target": "dock"}),
+                                        ("pull_over", {})])
+    fence = _Fence()
+    # Cancel fires after the first step's fence call.
+    state = {"n": 0}
+
+    def cancel():
+        # not cancelled at entry; cancelled once the first step has run
+        return fence.calls and state["n"] >= 1
+
+    def counting_fence(d):
+        state["n"] += 1
+        return fence(d)
+
+    result = run_mission(decisions, fence_fn=counting_fence, speak_fn=lambda t: None,
+                         cancel_check=cancel)
+    check(result.status == CANCELLED, f"should cancel mid-mission: {result}")
+    check(len(fence.calls) == 1, f"the second motion step must NOT have run: {fence.calls}")
+
+
+def test_refuse_decision_defense_in_depth():
+    # Feed a REFUSE decision straight to run_mission (bypassing validate) — it must
+    # fail-closed to REFUSED and never call the fence.
+    refuse = [sk.dispatch("dock", {})]  # unimplemented → REFUSE
+    fence = _Fence()
+    result = run_mission(refuse, fence_fn=fence, speak_fn=lambda t: None)
+    check(result.status == REFUSED and not fence.calls,
+          f"a REFUSE decision never reaches the fence: {result}, calls={fence.calls}")
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"mission_test: all {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -53,6 +53,7 @@ import rabbit_wake  # noqa: E402 — deterministic wake-listener controls (state
 import barge_in  # noqa: E402 — interruptible reply speech (opt-in; Channel A, cosmetic)
 import skill_registry  # noqa: E402 — opt-in named-skill router (motion → the SAME /intent fence)
 import world_model  # noqa: E402 — opt-in situation report (read-only TTL'd projection)
+import mission  # noqa: E402 — opt-in multi-step Executive (each step → the SAME /intent fence)
 from rabbit_persona import name_slot, operator_name  # noqa: E402
 
 MAX_TURNS = 10  # rolling conversation memory (user+assistant pairs kept)
@@ -136,6 +137,26 @@ def ask_llm_skills(history, context, utterance):
     near-deterministic options as the default router — only the CONTRACT differs
     (named skills instead of a free-form directive)."""
     system = RABBIT_SYSTEM + "\n\n" + skill_registry.skills_prompt_fragment()
+    messages = [{"role": "system", "content": system}]
+    messages += history
+    messages.append({"role": "user", "content": f"{context}\n\nOperator says: {utterance}"})
+    try:
+        r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0,
+                          json={"model": MODEL, "stream": False, "messages": messages,
+                                "options": ROUTER_LLM_OPTIONS})
+        if r.status_code != 200:
+            return ""
+        return (r.json().get("message", {}).get("content") or "").strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def ask_llm_mission(history, context, utterance):
+    """Mission-mode persona call (opt-in, KIRRA_MISSIONS_ENABLED). Returns the raw
+    JSON string; `mission.plan_mission` parses it fail-closed. Same model +
+    options as the other routers — only the CONTRACT differs (an ordered
+    multi-step mission over the registered skills)."""
+    system = RABBIT_SYSTEM + "\n\n" + mission.missions_prompt_fragment()
     messages = [{"role": "system", "content": system}]
     messages += history
     messages.append({"role": "user", "content": f"{context}\n\nOperator says: {utterance}"})
@@ -250,6 +271,37 @@ def handle_turn(history, utterance):
         return
 
     context = context_for(utterance)
+
+    # MISSION MODE (opt-in, KIRRA_MISSIONS_ENABLED; takes precedence over skills):
+    # the LLM emits {say, mission:[...]} — a multi-step plan the Executive runs
+    # with sequencing / retry / cancel. Each MOTION step still routes through the
+    # SAME fenced door (offer_to_door → /intent → checker); a mission with any
+    # unsupported skill is REFUSED before any motion; a checker-refused step HALTS
+    # (never skip-and-continue); a barge-in cancels. Default off → byte-identical.
+    if mission.enabled():
+        say, steps = mission.plan_mission(ask_llm_mission(history, context, utterance))
+        if say:
+            _speak_reply(say)
+        ok, decisions, reason = mission.validate_mission(steps)
+        if not ok:
+            if steps:  # a real (but unsupported) mission — say why; empty = just chat
+                _speak_reply(f"I can't run that mission — {reason}.")
+            elif not say:
+                _speak_reply(f"I didn't quite catch that{name_slot()}.")
+        else:
+            def _mission_progress(i, n, d):
+                line = mission.narrate_progress(i, n, d)
+                if line:
+                    _speak_reply(line)
+            result = mission.run_mission(
+                decisions, offer_to_door, _speak_reply,
+                cancel_check=mission.cancel_check_from_barge_in(),
+                progress_fn=_mission_progress)
+            _speak_reply(mission.narrate_result(result))
+        history.append({"role": "user", "content": utterance})
+        history.append({"role": "assistant", "content": say or "(mission)"})
+        del history[: max(0, len(history) - 2 * MAX_TURNS)]
+        return
 
     # SKILLS MODE (opt-in, KIRRA_SKILLS_ENABLED): the LLM emits {say, skills[]}
     # from the REGISTERED vocabulary instead of a free-form directive. A motion


### PR DESCRIPTION
## Context

Slice 5 — the final voice-cognition slice (1–4 merged: #1136 VAD, #1137 barge-in, #1138 skill registry, #1139 World Model). A multi-step **Executive** that expands "go to the dock, then pull over" into a sequence of the **registered** skills and runs it with sequencing / retry / cancel / progress — realizing ruling **§5.2** for missions: *the Executive is a doer; the checker still owns every step.*

## The invariant, one step at a time

`robot/mission.py` (pure planner + Executive):

| Guarantee | How |
|---|---|
| **Motion only through the fence** | each motion step hands its directive to the *same* `offer_to_door` → mick `/intent` → `MickIntent` grounding → **checker** path. `run_mission` routes motion **only** through the injected fence sink |
| **Refuse before motion** | `validate_mission` dispatches every step up front (reusing `skill_registry`); a mission with **any** unimplemented/unknown skill (`inspect`, `dock`, …) is **refused before a single step runs** |
| **Halt, never skip** | a checker-**refused** step **halts** the mission (motion never continues to the next step); a transient door error retries a bounded number of times, then halts |
| **Cancellable** | `cancel_check_from_barge_in` ties Slice-2 barge-in to cancellation — a PTT press / `barge_in.py --signal` stops between or within steps; the ego stops (the checker's MRC), the Executive never re-accelerates |

So missions buy the operator **sequencing, not authority** — `ci/check_mick_actuation_fence.py` and the one-door rule hold, one fenced step at a time.

## Wiring (opt-in, `KIRRA_MISSIONS_ENABLED`, default off → byte-identical; precedence over skills mode)

`rabbit_converse` gains `ask_llm_mission` + a `handle_turn` branch that plans, validates, runs, and narrates progress/outcome via the existing `offer_to_door` fence.

## Verification

- `python3 robot/mission_test.py` → 8/8: fail-closed enable gate + plan parsing, `validate` refusing empty/unsupported missions, **motion-only-through-fence in order**, **checker-refusal HALTS with no skip** (step 3 never runs), transient-error retry-then-halt + recovered-retry, **cancel-stops-before-next-fence**, and a REFUSE decision never reaching the fence.
- Slices 1–4 tests still pass; `rabbit_converse` compiles; installer `bash -n` clean; CI YAML parses.

## Honest scope

Missions are limited to the registered skills — `inspect`/`search_area`/`dock` are unimplemented, so a mission needing them is refused (fail-closed). As those gain real, fenced backings, missions get richer with no change to this safety story. The Executive core is pure/host-tested; the LLM planning call is the thin seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_