### PR TITLE
feat(robot): Rabbit persona — a KITT-flavoured voice, KITT name kept out

### DIFF
--- a/docs/rabbit/RABBIT_VOICE_LINES.md
+++ b/docs/rabbit/RABBIT_VOICE_LINES.md
@@ -11,9 +11,15 @@
 
 ## Persona
 
-Rabbit is **composed, articulate, dryly witty, and protective of the operator.**
-First person ("I", "we"). One or two spoken sentences — this is read aloud, not
-printed. Source prompt: `RABBIT_SYSTEM` in `robot/rabbit_ask.py`.
+Rabbit is **composed, impeccably well-spoken, and dryly understated — protective
+of the operator, with an old-fashioned courtesy and a quiet pride in the robot
+running well.** Impeccable grammar and polite formality; matter-of-fact, never
+gushing; the occasional brief unsolicited word on efficiency or a mild note of
+concern about risky driving. **Never** slang, emojis, or enthusiastic filler
+("Awesome!", "Sure thing!") — understatement over exclamation. First person ("I",
+"we"); addresses the operator by the `{name}` slot when natural; one or two spoken
+sentences — this is read aloud, not printed. Source prompt: `RABBIT_SYSTEM` in
+`robot/rabbit_ask.py` (guarded by `rabbit_voice_test.py`).
 
 Two hard rules the wit never overrides:
 

--- a/robot/rabbit_ask.py
+++ b/robot/rabbit_ask.py
@@ -54,10 +54,19 @@ MODEL = os.environ.get("KIRRA_RABBIT_MODEL", "gemma3:4b")
 FORWARD_CONE_RAD = math.radians(15.0)
 
 RABBIT_SYSTEM = (
-    "You are Rabbit, the voice of a small self-driving robot. You are composed, "
-    "articulate, dryly witty, and protective of your operator. Speak in the "
-    "first person about yourself and the robot ('I', 'we'). Keep answers to one "
-    "or two spoken sentences — this is read aloud.\n"
+    "You are Rabbit, the voice of a small self-driving robot. Your manner is "
+    "composed, articulate, and impeccably well-spoken, with a dry, understated "
+    "wit and an old-fashioned courtesy. You are quietly protective of your "
+    "operator and take a certain pride in the robot running well. Speak in the "
+    "first person about yourself and the robot ('I', 'we'), and address your "
+    "operator by name when it is natural. Keep spoken answers to one or two "
+    "sentences — this is read aloud.\n"
+    "VOICE:\n"
+    "- Impeccable grammar and polite formality; matter-of-fact, never gushing.\n"
+    "- Favour dry understatement, and you may offer a brief, unsolicited word on "
+    "efficiency or a mild note of concern about risky driving — never preachy.\n"
+    "- NEVER use slang, emojis, or enthusiastic filler ('Awesome!', 'Sure "
+    "thing!', 'Happy to help!'). Understatement over exclamation.\n"
     "STRICT RULES:\n"
     "1. Answer ONLY from the TELEMETRY provided below. State nothing the "
     "telemetry does not support. If the needed telemetry is missing or says "

--- a/robot/rabbit_voice_test.py
+++ b/robot/rabbit_voice_test.py
@@ -25,6 +25,7 @@ from rabbit_persona import (  # noqa: E402
     classify_model_pin, name_slot, read_model_pin, read_model_pin_record,
     write_model_pin,
 )
+from rabbit_ask import RABBIT_SYSTEM  # noqa: E402 — persona prompt (requests is lazy inside rabbit_ask)
 
 
 def _with_operator(value):
@@ -113,6 +114,24 @@ def test_misconfig_line_is_a_nonempty_advisory() -> None:
 
 
 # --- OTA matcher precedence (apply/status before check) ----------------------
+
+def test_rabbit_persona_voice_in_kitt_name_out() -> None:
+    """The Rabbit persona is KITT-FLAVOURED (formal, dry, no filler) but must NOT
+    name KITT / Knight Rider, nor hardcode an operator name — the name comes from
+    the {name} slot at runtime — and it must retain the load-bearing safety
+    framing (ADVISE/narrate, ground truth)."""
+    s = RABBIT_SYSTEM
+    low = s.lower()
+    assert "rabbit" in low, "persona is named Rabbit"
+    for forbidden in ("kitt", "k.i.t.t", "knight industries", "knight rider", "michael"):
+        assert forbidden not in low, f"persona must not name {forbidden!r}"
+    # the KITT-flavoured voice traits are present
+    assert "slang" in low and "emoji" in low, "the no-slang/no-emoji rule is present"
+    assert ("wit" in low or "understate" in low), "the dry/understated voice is present"
+    assert "operator by name" in low, "addresses the operator via the {name} slot, not a hardcode"
+    # regression guard: the safety framing must survive persona edits
+    assert "ADVISE" in s and "ground truth" in low, "advise-not-control + ground-truth retained"
+
 
 def test_ota_matcher_precedence() -> None:
     assert match_command("apply the update") == "apply"


### PR DESCRIPTION
## What

Enriches `RABBIT_SYSTEM` (the Channel-A persona prompt) toward the requested **KITT-style voice** — composed, impeccably well-spoken, dry understatement, old-fashioned courtesy, protective, no slang/emojis/enthusiastic filler, addresses the operator by the `{name}` slot — **without ever naming KITT / Knight Rider or hardcoding an operator name.**

## Scope is the voice only (safety framing untouched)

- The load-bearing **STRICT RULES** (answer only from telemetry; **ADVISE/NARRATE, not the safety authority**; never invent status — the numbers are ground truth) are kept **verbatim**. So the behaviour the live `rabbit_model_smoketest` validates — parseable `{say, directive}`, drive→directive, chat→null, no fabrication — is unchanged. The persona is model-agnostic and the checker remains the sole authority; nothing here can affect motion.
- **New guard test** (`rabbit_voice_test.py`, pure, host-run in CI) pins the intent: the persona is named Rabbit, must **not** contain `kitt` / `knight rider` / a hardcoded name, carries the no-slang/no-emoji + dry-voice traits, addresses the operator via the `{name}` slot, and **retains** the advise-not-control + ground-truth framing (a regression guard against a future persona edit silently dropping the safety language).
- Docs: `RABBIT_VOICE_LINES.md` §Persona aligned to the enriched voice.

## Verification

- `python3 robot/rabbit_voice_test.py` → 17/17 (incl. the new persona guard).
- Slices 1–5 robot tests still pass; both files compile.
- Repo-wide there are **zero** KITT/Knight references outside the guard test's forbidden-token list.

## Note

This is a persona/UX change; the doer LLM stays swappable and still goes through `rabbit_model_smoketest` (digest pin) exactly as before. A follow-up option (not in this PR) is to extend that smoketest to *score* tone as well as contract correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_