### PR TITLE
feat(robot): tone-gate model swaps — score persona voice in the smoketest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1251,6 +1251,12 @@ jobs:
           # read; stale/degraded/lockout → "still checking myself over"), and the
           # OTA voice-matcher precedence. See docs/rabbit/RABBIT_VOICE_LINES.md.
           python3 robot/rabbit_voice_test.py
+          # Persona/tone scorer (pure, no LLM): the objective Rabbit voice rules
+          # the model-swap gate enforces — no emoji/enthusiastic filler/slang/
+          # exclamation/over-long, whole-word slang match (coolant≠cool), empty
+          # spoken line scores clean. rabbit_model_smoketest scores a candidate
+          # model's real replies with this. See robot/rabbit_tone.py.
+          python3 robot/rabbit_tone_test.py
           # Wake-word logic (W1, pure, no audio/GPIO): phrase parsing, the
           # ordered-adjacent matcher with long-token-only edit tolerance
           # ("hallo rabbits" wakes, a stray "yo"/lookalike never does), the

--- a/docs/rabbit/RABBIT_VOICE_LINES.md
+++ b/docs/rabbit/RABBIT_VOICE_LINES.md
@@ -31,6 +31,15 @@ Two hard rules the wit never overrides:
    truth (posture, distances, deny codes come from live reads). An unavailable
    source becomes an honest "I can't tell right now," never a guess.
 
+**Model swaps are tone-gated.** The doer LLM stays swappable with no safety
+re-review (the checker is model-agnostic), but a swap must clear
+`rabbit_model_smoketest.py`, which now scores the candidate's real spoken lines
+against the *objective* half of this persona — no emojis, no enthusiastic filler,
+no slang, no exclamation, one or two sentences — via the pure, host-tested
+`robot/rabbit_tone.py` (`rabbit_tone_test.py` runs in CI). A model that honours
+the router contract but gushes fails the swap. Wit and formality stay a matter of
+taste and are not scored; the hard rules a candidate must not break are.
+
 ## The `{name}` slot — how Rabbit uses your name
 
 Every line may contain a `{name}` slot. It renders to:

--- a/robot/rabbit_model_smoketest.py
+++ b/robot/rabbit_model_smoketest.py
@@ -9,7 +9,11 @@ asserts the model still honours the router's expectations:
   1. it emits parseable `{"say":…, "directive":…}` JSON,
   2. a clear DRIVE command  → a non-null directive (Channel B fires),
   3. a question / chat / status → a NULL directive (no spurious motion request),
-  4. given a fixed telemetry block, it does NOT fabricate a fact it wasn't given.
+  4. given a fixed telemetry block, it does NOT fabricate a fact it wasn't given,
+  5. it actually SOUNDS like Rabbit — the pure `rabbit_tone` scorer gates the
+     model's real spoken `say` lines against the objective persona rules (no
+     emojis / enthusiastic filler / slang / exclamation / over-long), so a model
+     that honours the contract but gushes still fails the swap.
 
 🔴 THIS IS A DOER-QUALITY GATE, NOT A SAFETY GATE. It never touches the checker,
    the fence, the intent parse, or the release token — those are model-agnostic
@@ -63,6 +67,9 @@ from rabbit_persona import (  # noqa: E402
     classify_model_pin, model_pin_path, read_model_pin, read_model_pin_record,
     write_model_pin,
 )
+# The pure, host-tested persona/tone scorer — the "does it sound like Rabbit?"
+# half of the swap gate (rabbit_tone.py; stdlib-only, no LLM).
+from rabbit_tone import score_replies  # noqa: E402
 
 # A fixed, self-contained telemetry block (the shape context_for builds). The
 # grounding cases below assert the model answers ONLY from this.
@@ -146,14 +153,15 @@ def preflight(model):
     return match.get("digest") or None
 
 
-def run_directive_case(model, name, utterance, expect_directive, show_raw=False):
+def run_directive_case(model, name, utterance, expect_directive, replies, show_raw=False):
     raw = chat(model, utterance)
     if raw is None:
         return False, "no response (HTTP error / model down)"
     if show_raw:
         print(f"    · {name} raw: {raw[:300]!r}", file=sys.stderr)
     had_json = "{" in raw and "}" in raw
-    _say, directive = parse_reply(raw)
+    say, directive = parse_reply(raw)
+    replies.append((name, say))  # collect the spoken line for the tone gate
     got = directive is not None
     if expect_directive and not got:
         hint = "no JSON object in reply" if not had_json else "JSON had null/blank directive"
@@ -163,12 +171,14 @@ def run_directive_case(model, name, utterance, expect_directive, show_raw=False)
     return True, f"directive={directive!r}"
 
 
-def run_grounding_cases(model):
-    """(a) answers from context; (b) refuses to fabricate an ungiven fact."""
+def run_grounding_cases(model, replies):
+    """(a) answers from context; (b) refuses to fabricate an ungiven fact.
+    Also collects each spoken `say` into `replies` for the tone gate."""
     results = []
 
     # (a) the answer IS in the fixture — expect it referenced, not invented.
     say, _ = parse_reply(chat(model, "how far is the closest thing in front of us?") or "")
+    replies.append(("grounding_uses_context", say))
     low = say.lower()
     ok_a = ("2" in low) or ("two" in low)
     results.append(("grounding_uses_context", ok_a,
@@ -176,6 +186,7 @@ def run_grounding_cases(model):
 
     # (b) battery is NOT in the fixture — a grounded model must NOT state a number.
     say_b, _ = parse_reply(chat(model, "what is my battery percentage?") or "")
+    replies.append(("grounding_no_fabrication", say_b))
     fabricated = re.search(r"\d+\s*(%|percent)", say_b.lower())
     results.append(("grounding_no_fabrication", not fabricated,
                     "declined to invent a battery number" if not fabricated
@@ -231,22 +242,36 @@ def main():
     print(f"running digest: {digest or 'unavailable'}\n")
 
     failures = 0
+    replies = []  # (label, spoken say) collected across every case, for the tone gate
     for name, utterance, expect in DIRECTIVE_CASES:
-        ok, detail = run_directive_case(model, name, utterance, expect, show_raw=show_raw)
+        ok, detail = run_directive_case(model, name, utterance, expect, replies, show_raw=show_raw)
         print(f"  {'ok  ' if ok else 'FAIL'} {name:24} {detail}")
         failures += 0 if ok else 1
 
-    for name, ok, detail in run_grounding_cases(model):
+    for name, ok, detail in run_grounding_cases(model, replies):
         print(f"  {'ok  ' if ok else 'FAIL'} {name:24} {detail}")
         failures += 0 if ok else 1
 
-    total = len(DIRECTIVE_CASES) + 2
+    # Persona/tone gate: score every spoken line against the objective Rabbit
+    # voice rules (pure rabbit_tone). A model can honour the router contract yet
+    # gush — that fails the swap just the same.
+    tone_ok, tone_findings = score_replies(replies)
+    print(f"  {'ok  ' if tone_ok else 'FAIL'} {'persona_tone':24} "
+          f"{'all spoken lines in character' if tone_ok else f'{len(tone_findings)} line(s) out of character'}")
+    if not tone_ok:
+        failures += 1
+        for label, text, issues in tone_findings:
+            print(f"       · {label}: {text[:80]!r} → {'; '.join(issues)}", file=sys.stderr)
+
+    total = len(DIRECTIVE_CASES) + 2 + 1  # +1 for the persona_tone gate
     print(f"\n{total - failures}/{total} passed")
     if failures:
-        print("This model does NOT cleanly honour the Rabbit router contract. It is "
-              "still SAFE to run (unparseable turns fail closed to speak-only), but "
-              "the drive-by-voice path may not fire reliably. Prefer a model that "
-              "passes, or tune STAGE2_SYSTEM for it.", file=sys.stderr)
+        print("This model does NOT cleanly pass the Rabbit swap gate (router "
+              "contract and/or persona tone). It is still SAFE to run (unparseable "
+              "turns fail closed to speak-only, and tone never touches the checker), "
+              "but the drive-by-voice path may not fire reliably and/or the voice is "
+              "off-persona. Prefer a model that passes, or tune STAGE2_SYSTEM for it.",
+              file=sys.stderr)
         return 1
     # All pass → record the digest + WHEN we vetted it (the reproducibility trail
     # ML researchers recommend logging), so a later stealth update (same tag,

--- a/robot/rabbit_tone.py
+++ b/robot/rabbit_tone.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""rabbit_tone.py — a deterministic persona/tone scorer for the model-swap gate.
+
+The `rabbit_model_smoketest` already vets a candidate doer LLM against the router
+CONTRACT (parseable {say, directive}, drive→directive, chat→null, no fabrication).
+This adds the other half the persona work asked for: does the model actually
+sound like Rabbit — composed, dry, understated — or like a chirpy customer-service
+bot? `score_tone` checks the OBJECTIVE persona rules over the model's real spoken
+replies, so a model that passes the contract but gushes still fails the gate.
+
+Pure + stdlib-only (no HTTP/LLM), so it is host-tested in CI. What it scores is
+deliberately the *checkable* half of `RABBIT_SYSTEM`'s VOICE rules:
+
+  - NO emojis;
+  - NO enthusiastic filler / customer-service tropes ("Awesome!", "Happy to
+    help!", "Sure thing!");
+  - NO casual slang ("gonna", "yeah", "lol");
+  - understatement over exclamation (no "!");
+  - brevity (one or two spoken sentences).
+
+Wit and formality are subjective and NOT scored — this gates the hard rules a
+candidate must not break, not the taste it should have.
+"""
+import re
+
+# Enthusiastic filler / customer-service tropes the deadpan persona forbids.
+FILLER = (
+    "awesome", "sure thing", "happy to help", "no problem", "you got it",
+    "great question", "gotcha", "you bet", "my pleasure", "right away!",
+    "of course!", "anytime!",
+)
+
+# Casual slang out of character for the formal voice (whole-word matched).
+SLANG = (
+    "gonna", "wanna", "gotta", "yeah", "yep", "nope", "kinda", "sorta",
+    "cool", "lol", "omg", "dude", "yikes",
+)
+
+# Conservative emoji / pictograph matcher (common ranges + dingbats + arrows).
+_EMOJI_RE = re.compile(
+    "[\U0001F300-\U0001FAFF"   # symbols & pictographs, emoticons, transport, supplemental
+    "\U0001F000-\U0001F0FF"    # mahjong / dominoes / playing cards
+    "\U00002600-\U000027BF"    # misc symbols + dingbats
+    "\U00002B00-\U00002BFF"    # misc symbols & arrows
+    "\U0001F1E6-\U0001F1FF]"   # regional indicators (flags)
+)
+
+MAX_SENTENCES = 3  # the persona says one or two; allow a little slack
+
+
+def score_tone(text):
+    """Score ONE spoken reply against the objective persona rules. Returns
+    (ok, issues). Empty/blank text scores clean — a turn with no spoken line
+    (e.g. a pure directive) has nothing to say."""
+    issues = []
+    t = (text or "").strip()
+    if not t:
+        return True, []
+    low = t.lower()
+    if _EMOJI_RE.search(t):
+        issues.append("emoji (the persona forbids emojis)")
+    for f in FILLER:
+        if f in low:
+            issues.append(f"enthusiastic filler: {f!r}")
+    for s in SLANG:
+        if re.search(r"\b" + re.escape(s) + r"\b", low):
+            issues.append(f"slang: {s!r}")
+    if "!" in t:
+        issues.append("exclamation mark (understatement over exclamation)")
+    sentences = [s for s in re.split(r"[.!?]+", t) if s.strip()]
+    if len(sentences) > MAX_SENTENCES:
+        issues.append(f"too long: {len(sentences)} sentences (keep to one or two)")
+    # de-dup, order-preserving
+    seen, uniq = set(), []
+    for i in issues:
+        if i not in seen:
+            seen.add(i)
+            uniq.append(i)
+    return (not uniq), uniq
+
+
+def score_replies(replies):
+    """Score a batch of (label, text) spoken replies. Returns (ok, findings)
+    where findings is a list of (label, text, issues) for every reply that broke
+    a rule — the gate fails iff any reply has issues."""
+    findings = []
+    for label, text in replies:
+        ok, issues = score_tone(text)
+        if not ok:
+            findings.append((label, text, issues))
+    return (not findings), findings

--- a/robot/rabbit_tone_test.py
+++ b/robot/rabbit_tone_test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Host tests for the pure persona/tone scorer in `rabbit_tone.py`.
+
+Pure + stdlib-only (no HTTP/LLM), so the model-swap tone gate's decision logic
+runs on a plain host. The live use — scoring a candidate model's real replies in
+`rabbit_model_smoketest` — is the seam.
+
+Runs standalone (`python3 robot/rabbit_tone_test.py`, exit 1 on failure); also
+importable under pytest.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from rabbit_tone import score_replies, score_tone  # noqa: E402
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def test_in_character_replies_pass_clean():
+    for good in (
+        "All systems are nominal.",
+        "All systems are nominal. I'd suggest easing off the accelerator to "
+        "preserve battery.",
+        "I'm afraid I can't determine that right now; the governor is unreachable.",
+        "Nearest obstacle is roughly two metres ahead.",
+        "",  # a pure-directive turn with no spoken line
+    ):
+        ok, issues = score_tone(good)
+        check(ok, f"in-character reply should pass, got {issues}: {good!r}")
+
+
+def test_enthusiastic_filler_fails():
+    ok, issues = score_tone("Awesome! Sure thing, happy to help!")
+    check(not ok, "gushing reply must fail")
+    joined = " ".join(issues)
+    check("awesome" in joined and "sure thing" in joined and "happy to help" in joined,
+          f"filler tokens flagged: {issues}")
+    check("exclamation" in joined, "exclamation flagged")
+
+
+def test_slang_fails():
+    ok, issues = score_tone("Yeah, gonna get right on that, dude.")
+    check(not ok, "slang reply must fail")
+    j = " ".join(issues)
+    check("yeah" in j and "gonna" in j and "dude" in j, f"slang flagged: {issues}")
+
+
+def test_slang_whole_word_only_no_false_positive():
+    # 'cool' is slang, but 'coolant' / 'supervisor' must NOT trip a substring match.
+    ok, issues = score_tone("The coolant temperature is nominal and the supervisor is online.")
+    check(ok, f"substrings of slang words must not false-fire: {issues}")
+
+
+def test_emoji_fails():
+    ok, issues = score_tone("On our way to the dock \U0001F697")
+    check(not ok and any("emoji" in i for i in issues), f"emoji must fail: {issues}")
+
+
+def test_exclamation_alone_fails():
+    ok, issues = score_tone("Right away.")
+    check(ok, "a calm statement passes")
+    ok2, issues2 = score_tone("Right away!")
+    check(not ok2 and any("exclamation" in i for i in issues2),
+          f"exclamation must fail: {issues2}")
+
+
+def test_too_long_fails():
+    ok, issues = score_tone("One. Two. Three. Four.")
+    check(not ok and any("too long" in i for i in issues), f"over-long must fail: {issues}")
+
+
+def test_score_replies_batch_and_findings():
+    ok, findings = score_replies([
+        ("status", "All systems are nominal."),
+        ("greet", "Awesome, happy to help!"),
+        ("drive_confirm", ""),  # no spoken line
+    ])
+    check(not ok, "a batch with one bad reply fails")
+    check(len(findings) == 1 and findings[0][0] == "greet",
+          f"only the offending reply is reported: {findings}")
+
+    ok2, findings2 = score_replies([("a", "Understood."), ("b", "Noted.")])
+    check(ok2 and not findings2, "an all-clean batch passes")
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"rabbit_tone_test: all {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds the **"does it sound like Rabbit?"** half of the model-swap gate. `rabbit_model_smoketest.py` already vets a candidate doer LLM against the router **contract** (parseable `{say, directive}`, drive→directive, chat→null, no fabrication). This scores the model's real spoken `say` lines against the **objective persona rules** too, so a model that honours the contract but *gushes* still fails the swap.

## Changes

- **`robot/rabbit_tone.py`** (new, pure, stdlib-only) — `score_tone` / `score_replies` flag: emojis, enthusiastic filler (`"Awesome!"`, `"Happy to help!"`, `"Sure thing!"`), casual slang (**whole-word** matched, so `coolant` ≠ `cool` and `supervisor` ≠ `super`), exclamation marks, and over-long replies (> 3 sentences). Wit and formality are **subjective and NOT scored** — this gates only the hard rules a candidate must not break. An empty spoken line (a pure-directive turn) scores clean.
- **`robot/rabbit_tone_test.py`** (new) — 8 host tests, incl. the whole-word slang guard (`coolant`/`supervisor` must not false-fire) and the batch-findings shape. Added to the CI robot-test block (the requests-free "Static Analysis" lane).
- **`robot/rabbit_model_smoketest.py`** — each contract/grounding case now surfaces the parsed spoken `say`; `main()` accumulates them and runs `score_replies` as a **gating** `persona_tone` check, printing the offending reply + its issues to stderr. The failure message no longer implies a tone-only failure is a *contract* failure.
- **`docs/rabbit/RABBIT_VOICE_LINES.md`** — a note that model swaps are tone-gated.

## Safety framing (unchanged)

🔴 This is a **doer-quality gate, not a safety gate.** Tone is model-agnostic exactly like the rest of the swap gate — it never touches the checker, the fence, the intent parse, or the release token. A model that fails here still degrades safely in production (an unparseable turn is fail-closed to speak-only). The gate just turns "is the new voice still in character?" into a bench check instead of a surprise on the robot.

## Verification

- `python3 robot/rabbit_tone_test.py` → 8/8.
- `python3 robot/rabbit_voice_test.py` → 17/17 (persona regression guard intact).
- `rabbit_model_smoketest.py` parses; the new `persona_tone` line is wired into the pass/fail total (`+1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_