### PR TITLE
feat(robot): R.A.B.I.T. — the name is the architecture, on the nominal boot line

### DIFF
--- a/docs/rabbit/RABBIT_VOICE_LINES.md
+++ b/docs/rabbit/RABBIT_VOICE_LINES.md
@@ -9,6 +9,18 @@
 > line can be witty, wrong, or hallucinated and the KIRRA checker still bounds
 > every motion identically. The words are theatre; the checker is the safety.
 
+## The name
+
+**Rabbit** is an acronym — **R.A.B.I.T. = Robotic Agent, Bounded by Independent
+Trust.** It is not decoration: it *is* the architecture. Rabbit (the robot + its
+LLM) is a doer that only ever **proposes**; every motion is bounded by an
+independent safety checker it cannot bypass or talk its way past. Rabbit
+introduces itself with the expansion on a nominal boot (row A1) — the one moment
+it is genuinely ready — and never states that trust posture on the degraded or
+not-ready lines, where it would not be true. Canonical string
+(`RABIT_EXPANSION`, `robot/rabbit_boot.py`): "Robotic Agent, Bounded by
+Independent Trust".
+
 ## Persona
 
 Rabbit is **composed, impeccably well-spoken, and dryly understated — protective
@@ -69,7 +81,7 @@ Legend: **LIVE** = wired today (file:seam cited) · **GAP** = to be wired · the
 
 | # | Trigger | Status | Line |
 |---|---|---|---|
-| A1 | Powered on, **fresh nominal** posture confirmed | **LIVE** `rabbit_boot.py` `greeting_line` (posture-gated: claims "governor nominal" only on a real fresh code-0 read) | "Good morning{name}. All systems online, governor nominal — I'm at your disposal." |
+| A1 | Powered on, **fresh nominal** posture confirmed | **LIVE** `rabbit_boot.py` `greeting_line` (posture-gated: claims "governor nominal" only on a real fresh code-0 read; the R.A.B.I.T. self-introduction rides ONLY this nominal-ready path — never the degraded/not-ready lines, so Rabbit never states its trust posture unless it's true) | "Good morning{name}. Rabbit here — a Robotic Agent, Bounded by Independent Trust. All systems online, governor nominal; I'm at your disposal." |
 | A1b | Powered on, fresh but **degraded** | **LIVE** `rabbit_boot.py` | "Good morning{name}. I'm online, but starting in a degraded mode — I'll be cautious until it clears." |
 | A2 | Powered on, governor not ready by deadline (LockedOut / no read / stale) | **LIVE** `rabbit_boot.py` | "I'm awake{name}, but still checking myself over. Give me a moment before we go anywhere." |
 | A3 | Shutting down | **LIVE** `rabbit_boot.py` `shutdown_line` (systemd `ExecStop`) | "Powering down. I've come to a safe stop — try not to miss me too much." |

--- a/robot/rabbit_boot.py
+++ b/robot/rabbit_boot.py
@@ -36,6 +36,13 @@ from rabbit_persona import name_slot, speak  # noqa: E402
 VERIFIER = os.environ.get("KIRRA_VERIFIER_URL", "http://localhost:8090").rstrip("/")
 GREET_DEADLINE_S = int(os.environ.get("KIRRA_RABBIT_GREET_DEADLINE_MS", "20000")) / 1000.0
 
+# R.A.B.I.T. — the name is an acronym, and it *means* the architecture: a doer
+# (the robot/LLM) that only ever PROPOSES, bounded by an independent safety
+# checker it cannot bypass. Rabbit introduces itself with the expansion on a
+# nominal boot (the one path where it is genuinely ready). Single source of truth
+# for both the greeting and docs/rabbit/RABBIT_VOICE_LINES.md.
+RABIT_EXPANSION = "Robotic Agent, Bounded by Independent Trust"
+
 _FLEET_RE = re.compile(r"kirra_fleet_posture\{[^}]*\}\s+(\d+)")
 _STALE_RE = re.compile(r"kirra_posture_cache_stale\{[^}]*\}\s+1\b")
 
@@ -46,8 +53,8 @@ def greeting_line(posture_code, fresh):
     fresh: the read is fresh (posture present AND cache not stale)."""
     slot = name_slot()
     if fresh and posture_code == 0:
-        return (f"Good morning{slot}. All systems online, governor nominal — "
-                "I'm at your disposal.")
+        return (f"Good morning{slot}. Rabbit here — a {RABIT_EXPANSION}. "
+                "All systems online, governor nominal; I'm at your disposal.")
     if fresh and posture_code == 1:
         return (f"Good morning{slot}. I'm online, but starting in a degraded mode — "
                 "I'll be cautious until it clears.")

--- a/robot/rabbit_voice_test.py
+++ b/robot/rabbit_voice_test.py
@@ -19,7 +19,9 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from rabbit_boot import greeting_line, misconfig_line, shutdown_line  # noqa: E402
+from rabbit_boot import (  # noqa: E402
+    RABIT_EXPANSION, greeting_line, misconfig_line, shutdown_line,
+)
 from rabbit_ota import match_command  # noqa: E402
 from rabbit_persona import (  # noqa: E402
     classify_model_pin, name_slot, read_model_pin, read_model_pin_record,
@@ -71,6 +73,20 @@ def test_greeting_nominal_fresh_claims_governor_nominal() -> None:
     with _with_operator(None):
         line = greeting_line(0, True)
     assert "governor nominal" in line and "online" in line
+
+
+def test_greeting_nominal_introduces_rabit_acronym() -> None:
+    """On the nominal-ready path Rabbit introduces itself with the R.A.B.I.T.
+    expansion — the name IS the doer/checker architecture. It must NOT leak onto
+    the not-ready / degraded lines (Rabbit never overclaims while not nominal)."""
+    assert RABIT_EXPANSION == "Robotic Agent, Bounded by Independent Trust"
+    with _with_operator(None):
+        nominal = greeting_line(0, True)
+        degraded = greeting_line(1, True)
+        not_ready = greeting_line(2, True)
+    assert RABIT_EXPANSION in nominal and "Rabbit here" in nominal
+    assert RABIT_EXPANSION not in degraded, "no self-introduction while degraded"
+    assert RABIT_EXPANSION not in not_ready, "no self-introduction while not ready"
 
 
 def test_greeting_degraded_fresh_says_degraded_not_nominal() -> None:


### PR DESCRIPTION
## What

Makes the name canon as an acronym: **R.A.B.I.T. = "Robotic Agent, Bounded by Independent Trust."** It isn't decoration — it *states the doer/checker split*: the robot and its LLM only ever **propose**; an independent safety checker bounds every motion and cannot be bypassed or talked past.

Rabbit now **introduces itself** with the expansion on a nominal boot — the one moment it is genuinely ready.

## Changes

- **`robot/rabbit_boot.py`** — new `RABIT_EXPANSION` constant (single source of truth for code + docs). The nominal-fresh `greeting_line` becomes:
  > "Good morning{name}. **Rabbit here — a Robotic Agent, Bounded by Independent Trust.** All systems online, governor nominal; I'm at your disposal."

  The self-introduction rides **only** the nominal-ready path. The degraded and not-ready lines are untouched, so Rabbit never states that trust posture unless it's actually true (same honesty discipline as the rest of the boot greeting). The existing `"online"` / `"governor nominal"` assertions are preserved.
- **`robot/rabbit_voice_test.py`** — a new guard asserts the exact expansion string, that it appears (with "Rabbit here") on the nominal line, and that it does **not** leak onto the degraded / not-ready lines. **18/18** pass.
- **`docs/rabbit/RABBIT_VOICE_LINES.md`** — a new **"The name"** section explaining the acronym-as-architecture, and the updated **A1** row.

## Safety framing

🔴 **Channel A only** — this is speech, with zero actuation authority. The KIRRA checker bounds every motion identically regardless of what Rabbit says; the acronym just names that fact out loud.

## Verification

- `python3 robot/rabbit_voice_test.py` → 18/18 (incl. the new acronym guard + the "must not leak while degraded/not-ready" assertion).
- Dry-run of the three greeting paths confirms the expansion appears only on nominal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_