### PR TITLE
feat(robot): rabbit_update.sh — one-command "pull latest + bring the voice back up"

### DIFF
--- a/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
@@ -175,6 +175,30 @@ specifically the tool-calling/truncation fixes are *welcome* — they harden the
 `{say, directive}` JSON contract; the smoketest confirms it. The FA4/vision gains
 don't reach the Orin — Ampere, text-only router.)
 
+### Update the Rabbit *code* (scripts) to the latest HEAD
+
+Distinct from a model swap: this pulls the merged repo changes (persona, boot
+line, voice cognition) onto the robot. There is **no remote self-update** — the
+OTA timer updates only the governor *artifact*, never these Python scripts — so
+you pull the checkout and re-stage. One command does it end-to-end:
+
+```bash
+cd ~/kirra-runtime-sdk
+robot/rabbit_update.sh        # ff-pull main → re-stage → restart ACTIVE units → speak a confirmation
+```
+
+It refuses on a dirty tree (never clobbers local edits), restarts **only the
+Rabbit units already running** (it won't newly-enable a disabled one — validate
+wheels-up first per `R2_AUTOSTART_CHECKLIST.md`), and speaks a confirmation so you
+can hear it's talking. Flags: `--ref <branch>`, `--restart-stack` (also bounce
+`kirra-ros-stack`), `--no-restart`, `--no-talk`. If it prints the line but no
+audio comes out, `KIRRA_TTS_CMD` is unset — configure piper per
+`rabbit.env.example` + `RABBIT_AUDIO_STACK.md`, or run `robot/kirra_voice_doctor.sh`.
+
+Equivalent manual steps if you prefer: `git pull --ff-only origin main` →
+`robot/install/install_robot_units.sh` → `sudo systemctl restart
+kirra-rabbit-watch kirra-rabbit-greet kirra-rabbit-voice`.
+
 ### Update commands (copy-paste)
 
 **A — re-pull the same tag** (stealth in-place update, e.g. the Gemma-4 case):

--- a/robot/rabbit_update.sh
+++ b/robot/rabbit_update.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# rabbit_update.sh — pull the latest Rabbit code onto this robot and bring the
+# voice back up, in one command. **Run this ON the robot** (it operates on the
+# repo checkout; there is no remote self-update — the OTA path updates only the
+# governor artifact, never these scripts).
+#
+#   robot/rabbit_update.sh                 # pull main, re-stage, restart, talk-test
+#   robot/rabbit_update.sh --ref <branch>  # pull a branch other than main
+#   robot/rabbit_update.sh --restart-stack # also restart kirra-ros-stack (the doer)
+#   robot/rabbit_update.sh --no-restart    # update + re-stage only (no unit restart)
+#   robot/rabbit_update.sh --no-talk       # skip the spoken confirmation
+#
+# What it does (idempotent, fail-closed on a real error):
+#   1. fast-forwards the repo checkout to origin/<ref> (refuses on a dirty tree
+#      so it never clobbers local edits),
+#   2. re-stages the Rabbit scripts to /opt/kirra/robot via install_robot_units.sh,
+#   3. restarts ONLY the Rabbit units that are already ACTIVE — it never newly
+#      starts a disabled unit (the "validate wheels-up before enabling" rule,
+#      docs/hardware/R2_AUTOSTART_CHECKLIST.md),
+#   4. speaks a confirmation line so you can hear it's talking (and tells you
+#      plainly if KIRRA_TTS_CMD is unset, i.e. print-only, no audio).
+#
+# 🔴 CHANNEL A / operations only. This updates code and restarts services; it has
+#    no path to motion. The KIRRA checker bounds every command regardless.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "${HERE}/.." && pwd)"
+
+REF="main"
+DO_RESTART=1
+RESTART_STACK=0
+DO_TALK=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ref) REF="${2:?--ref needs a branch name}"; shift 2 ;;
+    --no-restart) DO_RESTART=0; shift ;;
+    --restart-stack) RESTART_STACK=1; shift ;;
+    --no-talk) DO_TALK=0; shift ;;
+    -h|--help) sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1 (see --help)" >&2; exit 2 ;;
+  esac
+done
+
+say() { printf '\n== %s ==\n' "$*"; }
+
+# ---- 1. update the checkout -------------------------------------------------
+say "1. update ${REPO} → origin/${REF}"
+if [[ -n "$(git -C "${REPO}" status --porcelain)" ]]; then
+  echo "REFUSING: the checkout has uncommitted changes — commit/stash them first" >&2
+  git -C "${REPO}" status --short >&2
+  exit 1
+fi
+git -C "${REPO}" fetch origin "${REF}"
+git -C "${REPO}" checkout "${REF}"
+# Fast-forward only: a non-ff (someone committed locally) stops here, loudly,
+# rather than creating a surprise merge on the robot.
+if ! git -C "${REPO}" merge --ff-only "origin/${REF}"; then
+  echo "REFUSING: cannot fast-forward — the local branch has diverged from origin/${REF}" >&2
+  exit 1
+fi
+NEW_HEAD="$(git -C "${REPO}" log --oneline -1)"
+echo "now at: ${NEW_HEAD}"
+
+# ---- 2. re-stage the scripts ------------------------------------------------
+say "2. re-stage Rabbit scripts → /opt/kirra/robot"
+"${REPO}/robot/install/install_robot_units.sh"
+
+# ---- 3. restart the ACTIVE Rabbit units -------------------------------------
+if [[ "${DO_RESTART}" -eq 1 ]]; then
+  say "3. restart running Rabbit units (active ones only)"
+  UNITS=(kirra-rabbit-watch kirra-rabbit-voice kirra-rabbit-greet)
+  [[ "${RESTART_STACK}" -eq 1 ]] && UNITS=(kirra-ros-stack "${UNITS[@]}")
+  restarted=0
+  for u in "${UNITS[@]}"; do
+    if systemctl is-active --quiet "${u}"; then
+      sudo systemctl restart "${u}" && echo "  restarted ${u}" && restarted=1
+    else
+      echo "  skipped ${u} (not active — enable it deliberately after validation)"
+    fi
+  done
+  [[ "${restarted}" -eq 0 ]] && echo "  (no active Rabbit units — start them per RABBIT_BRINGUP_RUNBOOK.md)"
+else
+  say "3. restart skipped (--no-restart)"
+fi
+
+# ---- 4. talk-test -----------------------------------------------------------
+if [[ "${DO_TALK}" -eq 1 ]]; then
+  say "4. talk-test"
+  # Load the robot's audio env (KIRRA_TTS_CMD lives here) exactly as the units do.
+  [[ -f /etc/kirra/robot.env ]] && { set -a; . /etc/kirra/robot.env; set +a; }
+  if [[ -z "${KIRRA_TTS_CMD:-}" ]]; then
+    echo "  NOTE: KIRRA_TTS_CMD is unset → Rabbit will PRINT the line but not speak it."
+    echo "        Configure TTS (piper) per robot/install/rabbit.env.example +"
+    echo "        docs/hardware/RABBIT_AUDIO_STACK.md, then re-run to hear it aloud."
+  fi
+  MSG="Rabbit updated to the latest and back online. Robotic Agent, Bounded by Independent Trust — at your disposal."
+  PYTHONPATH="${REPO}/robot" python3 -c 'import sys; from rabbit_persona import speak; speak(sys.argv[1])' "${MSG}" \
+    || echo "  (speak failed — see robot/kirra_voice_doctor.sh for an audio check)"
+fi
+
+say "done — Rabbit is on ${NEW_HEAD}"


### PR DESCRIPTION
## What

Updating the Rabbit code on the robot was a manual multi-step dance (git pull → re-stage → restart the right units → check it talks). This folds it into **one idempotent, fail-closed command run *on* the robot**:

```bash
cd ~/kirra-runtime-sdk
robot/rabbit_update.sh        # ff-pull main → re-stage → restart ACTIVE units → speak a confirmation
```

## Why a script (and not remote)

I can't reach the Orin from CI/cloud, and there's deliberately **no remote self-update** for these scripts — the OTA timer updates only the governor *artifact*, never the Rabbit Python. So the robot pulls its own checkout and re-stages. The script just makes that safe and one-step.

## Safety-minded behaviour

- **Refuses on a dirty tree** — never clobbers local edits.
- **Fast-forward only** — never makes a surprise merge commit on the robot; a diverged branch stops it loudly.
- **Restarts only ACTIVE units** — it will *not* newly-start a disabled unit, honouring the "validate wheels-up before enabling" rule (`R2_AUTOSTART_CHECKLIST.md`). `--restart-stack` opts into bouncing `kirra-ros-stack` too.
- **Talk-test** — loads `/etc/kirra/robot.env` for `KIRRA_TTS_CMD` exactly as the units do, speaks a confirmation so you can *hear* it's up, and says plainly when TTS is unset (print-only) with a pointer to `RABBIT_AUDIO_STACK.md` / `kirra_voice_doctor.sh`.

Flags: `--ref <branch>`, `--restart-stack`, `--no-restart`, `--no-talk`, `--help`.

Deliberately **not** staged to `/opt/kirra/robot` — it operates on the repo checkout (it has to `git pull`), so it's run as `robot/rabbit_update.sh`.

## Docs

`RABBIT_BRINGUP_RUNBOOK.md` gains an **"Update the Rabbit code"** section, distinct from the model-swap flow.

## Verification

- `bash -n` clean; `--help` renders; unknown arg → exit 2; the talk-test speak line prints (and pipes to `KIRRA_TTS_CMD` when set).
- Current `main` robot host-tests still green (tone 13/13, voice 18/18) — the code this pulls is sound.

## Safety framing

🔴 **Channel A / operations only** — updates code and restarts services; no path to motion. The KIRRA checker bounds every command regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_