### PR TITLE
ADR-0013: console "Request Emergency Stop" UI action (the deferred step)

### DIFF
--- a/docs/CONSOLE_RUNBOOK.md
+++ b/docs/CONSOLE_RUNBOOK.md
@@ -151,6 +151,33 @@ req = urllib.request.Request(f"{BASE}/console/clearance-grants", method="POST",
 print(urllib.request.urlopen(req).read().decode())
 ```
 
+### 4. Request an emergency stop — operator-signed (ADR-0013)
+
+The console's second authenticated affordance is the **"Request emergency stop"** card
+— the clearance loop **inverted**. It is a signed **REQUEST** to the governor, never a
+console→actuator command: the operator signs, the fail-closed governor judges it and
+commands the MRC (controlled decel-to-stop · HOLD → sticky `LockedOut`) under **its own**
+authority. Recovery is a deliberate supervisor reset, not automatic. It is **supplementary
+to the hardwired physical E-stop, never the primary safety mechanism**.
+
+In the browser: enter node id + operator id, paste the operator PEM (memory only), tick
+the acknowledgement, and submit — the page signs the **STOP-distinct** payload
+(`KIRRA-OPERATOR-ESTOP-v1`) and posts to `/console/estop-requests`. It is **operator-signed
+ONLY — there is no break-glass** (ADR-0013 #2: the stop must be non-repudiable, provably a
+specific operator's; a shared key cannot give that). When WebCrypto Ed25519 is unavailable,
+sign from the CLI — identical to the grant snippet above with two changes: the domain tag
+and the endpoint:
+
+```python
+# ... same challenge fetch + `lp` length-prefix helper as the grant snippet above ...
+payload = b"KIRRA-OPERATOR-ESTOP-v1" + lp(op) + lp(node) + lp(nonce)  # == operator_stop_signing_payload
+sig = base64.b64encode(priv.sign(payload)).decode()
+req = urllib.request.Request(f"{BASE}/console/estop-requests", method="POST",
+    data=json.dumps({"node_id":node,"operator_id":op,"nonce":nonce,"signature_b64":sig}).encode(),
+    headers={"content-type":"application/json"})
+print(urllib.request.urlopen(req).read().decode())   # -> {"status":"stop_commanded","governor_action":"MRC_COMMANDED",...}
+```
+
 ### Break-glass policy (the named, audited supervisor fallback)
 
 The shared supervisor key (`KIRRA_SUPERVISOR_RESET_KEY`, #255) **remains** as an

--- a/docs/adr/0013-governor-routed-authenticated-estop.md
+++ b/docs/adr/0013-governor-routed-authenticated-estop.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | **Accepted** — verifier-side implementation landed (#412); the console action (UI) remains the one deferred step. |
+| Status | **Accepted** — verifier-side implementation (#412) AND the console "Request Emergency Stop" action (UI) landed; end-to-end validation remains hardware-gated. |
 | Date | 2026-06-21 (design); implemented 2026-06-30 |
 | Deciders | Project / safety-case owner |
 | Issues | #412 (this), #314 (operator identity), #410 / #405 (MRC / decel-to-stop), ADR-0006 (the QM↔safety boundary), #411 (console safety-theater fix) |
@@ -84,12 +84,21 @@ This **design note first** (this ADR). Then implementation (laptop; end-to-end
    domain-distinct `OPERATOR_STOP_DOMAIN` so a clearance signature can't be replayed as a stop),
 3. ✅ the chain events (`OperatorStopRequested` → `GovernorMRCCommanded`), with the MRC commanded
    under the governor's own authority (sticky `supervisor_tripped` + `force_lockout`),
-4. ⬜ the console "Request Emergency Stop" action (UI — deferred; the console correctly has no
-   E-stop button today, #411).
+4. ✅ the console "Request Emergency Stop" action (UI). Landed in the embedded operator console
+   (`static/console.html`, served at `GET /console`) as the inverse of the clearance-grant panel:
+   the operator signs the challenge in-browser with WebCrypto Ed25519 under the STOP-distinct
+   payload (`KIRRA-OPERATOR-ESTOP-v1`) and POSTs to `/console/estop-requests`. Framed as a
+   **REQUEST** ("Request emergency stop · routed to governor"), gated behind operator
+   authentication exactly like clearance, with an explicit acknowledgement that acceptance commands
+   a sticky-LockedOut MRC recoverable only by a supervisor reset. Operator-signed ONLY — no
+   break-glass (constraint #2 requires non-repudiation). If WebCrypto Ed25519 is unavailable it
+   surfaces the CLI flow, never a silent fallback. Guarded by
+   `console_serves_the_estop_request_action` (`console_phase_a_tests.rs`).
 
 Items 1–3 (the verifier-side core) are implemented + unit-tested (operator-signed happy path
 commands the MRC + chains both events; domain separation rejects a clearance signature; unknown
-operator / replay / passive-standby all fail closed). End-to-end validation remains
+operator / replay / passive-standby all fail closed). Item 4 (the console UI action) is wired and
+regression-guarded. End-to-end validation (a running governor + actuator path) remains
 hardware-gated.
 
 Cross-ref: #314, the clearance-loop PRs, ADR-0006 (the boundary), #411 (console

--- a/src/bin/kirra_verifier_service/console_phase_a_tests.rs
+++ b/src/bin/kirra_verifier_service/console_phase_a_tests.rs
@@ -101,6 +101,34 @@ async fn console_html_is_served() {
 }
 
 #[tokio::test]
+async fn console_serves_the_estop_request_action() {
+    // ADR-0013 item 4: the console's authenticated "Request Emergency Stop"
+    // action. Guard its wiring — it must POST to the governor-request endpoint,
+    // sign under the STOP-distinct domain (so a clearance signature can't be
+    // replayed as a stop), and be framed as a REQUEST, never a command.
+    let (status, body) = get(build_state(), "/console").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.contains("/console/estop-requests"),
+        "the e-stop action must target the governor-request endpoint"
+    );
+    assert!(
+        body.contains("KIRRA-OPERATOR-ESTOP-v1"),
+        "the in-page signing must use the STOP-distinct domain (not the grant domain)"
+    );
+    assert!(
+        body.contains("REQUEST · routed to governor"),
+        "the UI must frame the stop as a REQUEST, never a direct command"
+    );
+    // ADR-0013 #2: the stop must be non-repudiable — operator-signed ONLY, no
+    // supervisor break-glass (a shared key cannot prove which operator asked).
+    assert!(
+        body.contains("operator-signed only"),
+        "the e-stop panel must state it is operator-signed only (no break-glass)"
+    );
+}
+
+#[tokio::test]
 async fn console_fleet_returns_seeded_node() {
     let svc = build_state();
     seed_node(&svc, "robot-01");

--- a/static/console.html
+++ b/static/console.html
@@ -63,11 +63,19 @@
          font-size:11px; color:var(--dim); white-space:pre-wrap; word-break:break-word; }
   button { margin-top:12px; background:var(--accent); color:#fff; border:0; border-radius:5px;
            padding:8px 14px; font:inherit; cursor:pointer; }
+  button.danger { background:var(--bad); }
   button:disabled { opacity:.5; cursor:default; }
   .result { margin-top:10px; padding:9px; border-radius:5px; font-size:13px; display:none; }
   .result.recorded { display:block; background:rgba(74,134,232,.12); border:1px solid var(--accent); }
+  .result.commanded { display:block; background:rgba(224,83,59,.15); border:1px solid var(--bad); }
+  .result.commanded .pend { color:var(--bad); }
   .result.rejected { display:block; background:rgba(224,83,59,.12); border:1px solid var(--bad); color:var(--bad); }
   .result .pend { color:var(--warn); font-weight:600; }
+  .estop-warn { color:var(--dim); font-size:12px; margin:2px 0 10px; padding:8px;
+                background:rgba(224,83,59,.08); border:1px solid rgba(224,83,59,.4); border-radius:5px; }
+  label.confirm { display:flex; align-items:flex-start; gap:8px; margin-top:10px; color:var(--dim);
+                  font-size:12px; cursor:pointer; }
+  label.confirm input { width:auto; margin-top:2px; }
   .empty { color:var(--dim); font-style:italic; }
   footer { padding:12px 18px; color:var(--dim); font-size:11px; border-top:1px solid var(--line);
            background:var(--panel); line-height:1.6; }
@@ -167,6 +175,51 @@
   </section>
 
   <section>
+    <h2>Request emergency stop <span class="badge">REQUEST · routed to governor</span></h2>
+
+    <!-- ADR-0013: an authenticated REQUEST, never a console->actuator command.
+         The console is QM-domain and holds NO actuator authority (ADR-0006). The
+         operator SIGNS a stop request; the fail-closed governor JUDGES it and
+         commands the MRC under ITS OWN authority. The console asks; the governor
+         acts. This is the clearance loop INVERTED — same signed channel + same
+         verify-then-consume, a domain-distinct payload (KIRRA-OPERATOR-ESTOP-v1)
+         so a clearance signature can never be replayed as a stop. Supplementary
+         to the hardwired PHYSICAL E-stop, never the primary safety mechanism. -->
+    <div id="estopsigned">
+      <p class="estop-warn">Sends a <b>signed request</b> to the governor. On acceptance the governor
+        commands the MRC (controlled decel-to-stop &amp; <b>HOLD</b>) and the fleet goes
+        <b>LockedOut</b> — recovery is a deliberate <b>supervisor reset</b>, not automatic. This does
+        not touch the actuator directly and does <b>not</b> replace the hardwired physical E-stop.</p>
+
+      <!-- Operator-proven identity (#314), signed in-browser with WebCrypto
+           Ed25519. The private key is held in memory ONLY — never localStorage,
+           never sent. -->
+      <form id="estopform" autocomplete="off">
+        <label for="es_node_id">Node id (must be registered)</label>
+        <input id="es_node_id" required>
+        <label for="es_operator_id">Operator id (must be a registered operator)</label>
+        <input id="es_operator_id" required>
+        <label for="es_opkey">Operator private key — PKCS#8 PEM (in memory for this session only — NEVER stored, NEVER sent; the page signs locally)</label>
+        <textarea id="es_opkey" rows="4" placeholder="-----BEGIN PRIVATE KEY-----&#10;...&#10;-----END PRIVATE KEY-----" required></textarea>
+        <label class="confirm"><input type="checkbox" id="es_confirm" required>
+          I understand this REQUESTS a governor-commanded MRC (sticky <b>LockedOut</b>) and recovery requires a supervisor reset.</label>
+        <button type="submit" id="estopbtn" class="danger">Sign &amp; request emergency stop</button>
+      </form>
+      <div class="result" id="estopresult"></div>
+    </div>
+
+    <!-- Operator-signed ONLY. There is NO break-glass for a stop: ADR-0013 #2
+         requires the stop be NON-REPUDIABLE (provably the operator's), which a
+         shared supervisor key cannot give. If WebCrypto Ed25519 is unavailable,
+         point to the CLI flow — never a silent fallback. -->
+    <div id="estopclifallback" style="display:none">
+      <p class="err">This browser cannot sign Ed25519 in-page (WebCrypto Ed25519 unavailable, or not a secure context).</p>
+      <p style="color:var(--dim);font-size:12px">Use the documented <b>CLI signing flow</b> in
+        <code>docs/CONSOLE_RUNBOOK.md</code>. A stop request is <b>operator-signed only</b> — there is no break-glass.</p>
+    </div>
+  </section>
+
+  <section>
     <h2>Audit chain feed</h2>
     <div class="feed" id="audit"><span class="empty">loading…</span></div>
   </section>
@@ -174,14 +227,18 @@
 
 <footer>
   <strong>QM domain.</strong> This console is a <em>read-only view</em> of the
-  verifier's real store, plus <em>one</em> authenticated affordance: recording a
-  supervisor clearance grant. The UI never claims a release the system hasn't made:
-  a grant is recorded and cryptographically signed, then <em>delivered</em> to the
-  node's <code>ClearanceLoop</code> (Phase B) — which re-validates it and is the
-  thing that actually clears. The card shows <code>RECORDED</code> until a real
-  delivery outcome (<code>CLEARED</code> / <code>REJECTED</code>) exists. The
-  governor judges; this UI does not. Posture-exempt so it stays reachable during
-  LockedOut.
+  verifier's real store, plus <em>two</em> authenticated affordances, both routed
+  through the governor: recording a supervisor <em>clearance grant</em> (RELEASE),
+  and requesting an <em>emergency stop</em> (STOP). The UI never claims a release
+  the system hasn't made: a grant is recorded and cryptographically signed, then
+  <em>delivered</em> to the node's <code>ClearanceLoop</code> (Phase B) — which
+  re-validates it and is the thing that actually clears. The card shows
+  <code>RECORDED</code> until a real delivery outcome (<code>CLEARED</code> /
+  <code>REJECTED</code>) exists. A stop is an authenticated <em>request</em>
+  (ADR-0013): the governor judges it and commands the MRC under its own authority —
+  this console never touches the actuator, and this software path never replaces
+  the hardwired physical E-stop. The governor judges; this UI does not.
+  Posture-exempt so it stays reachable during LockedOut.
 </footer>
 
 <script>
@@ -411,11 +468,13 @@ function b64FromBytes(buf){
   for(let i=0;i<u.length;i++) s += String.fromCharCode(u[i]);
   return btoa(s);
 }
-// MUST byte-match Rust attestation::operator_grant_signing_payload:
-//   "KIRRA-OPERATOR-GRANT-v1" || for f in [operator_id,node_id,nonce]: u64_le(len(f)) || f
-function operatorGrantPayload(operatorId, nodeId, nonce){
+// Domain-framed operator payload: DOMAIN || for f in [operator_id,node_id,nonce]:
+//   u64_le(len(f)) || f. The DOMAIN tag makes the two operator verbs
+//   (RELEASE vs STOP) non-interchangeable — a clearance signature can never be
+//   replayed as a stop, nor vice versa.
+function domainFramedPayload(domainStr, operatorId, nodeId, nonce){
   const te = new TextEncoder();
-  const domain = te.encode("KIRRA-OPERATOR-GRANT-v1");
+  const domain = te.encode(domainStr);
   const fields = [operatorId, nodeId, nonce].map(s => te.encode(s));
   let total = domain.length; for(const f of fields) total += 8 + f.length;
   const buf = new Uint8Array(total); let o = 0;
@@ -425,6 +484,15 @@ function operatorGrantPayload(operatorId, nodeId, nonce){
     buf.set(f, o); o += f.length;
   }
   return buf;
+}
+// MUST byte-match Rust attestation::operator_grant_signing_payload.
+function operatorGrantPayload(operatorId, nodeId, nonce){
+  return domainFramedPayload("KIRRA-OPERATOR-GRANT-v1", operatorId, nodeId, nonce);
+}
+// MUST byte-match Rust attestation::operator_stop_signing_payload
+// (OPERATOR_STOP_DOMAIN, ADR-0013) — domain-distinct from the grant above.
+function operatorStopPayload(operatorId, nodeId, nonce){
+  return domainFramedPayload("KIRRA-OPERATOR-ESTOP-v1", operatorId, nodeId, nonce);
 }
 async function ed25519Supported(){
   try {
@@ -446,6 +514,18 @@ function showRecorded(res, body){
 function showRejected(res, status, reason){
   res.className = "result rejected";
   res.innerHTML = 'REJECTED ('+esc(status)+'): '+esc(reason || "request refused");
+}
+// ADR-0013: the governor ACCEPTED the stop request and commanded the MRC under
+// its own authority. The console did not touch the actuator — it renders the
+// governor's action, not a claim of its own.
+function showStopCommanded(res, body){
+  res.className = "result commanded";
+  res.innerHTML = '<span class="pend">STOP REQUESTED — GOVERNOR COMMANDED MRC</span><br>'+
+    'node <b>'+esc(body.node_id)+'</b> · operator <b>'+esc(body.operator_id)+'</b><br>'+
+    'governor action: <b>'+esc(body.governor_action||"MRC_COMMANDED")+'</b> · posture <b>'+esc(body.posture||"LockedOut")+'</b>'+
+    (body.operator_key_fingerprint ? (' · key <span class="fp">'+esc(body.operator_key_fingerprint)+'</span>') : '')+'<br>'+
+    '<span style="color:var(--dim)">'+esc(body.note||"")+'</span>';
+  poll(); // reflect the new LockedOut posture + the chained OperatorStopRequested/GovernorMRCCommanded events
 }
 
 // PRIMARY: operator-signed grant. Fetch challenge → sign locally → submit.
@@ -502,12 +582,51 @@ document.getElementById("bgform").addEventListener("submit", async (ev) => {
   finally { supEl.value = ""; btn.disabled = false; } // never retain the key
 });
 
-// Feature-detect WebCrypto Ed25519. If unavailable, hide the in-page signing form
+// ADR-0013: operator-signed emergency-stop REQUEST. Same signed channel as a
+// clearance grant (reuses /console/clearance-challenge for the nonce), but the
+// STOP payload is domain-distinct (KIRRA-OPERATOR-ESTOP-v1) and it POSTs to
+// /console/estop-requests. Operator-signed ONLY — no break-glass (the stop must
+// be non-repudiable). The console REQUESTS; the governor commands the MRC.
+document.getElementById("estopform").addEventListener("submit", async (ev) => {
+  ev.preventDefault();
+  const btn = document.getElementById("estopbtn");
+  const res = document.getElementById("estopresult");
+  const opkeyEl = document.getElementById("es_opkey");
+  const node_id = document.getElementById("es_node_id").value.trim();
+  const operator_id = document.getElementById("es_operator_id").value.trim();
+  const confirmed = document.getElementById("es_confirm").checked;
+  const pem = opkeyEl.value; // memory only; never stored, never sent
+  btn.disabled = true; res.className = "result"; res.style.display = "none";
+  try {
+    if(!confirmed){ showRejected(res, "confirm", "tick the acknowledgement — a stop request commands the MRC (sticky LockedOut)"); return; }
+    let key;
+    try { key = await crypto.subtle.importKey("pkcs8", pemToDer(pem), {name:"Ed25519"}, false, ["sign"]); }
+    catch(_){ showRejected(res, "key", "private key is not a valid PKCS#8 Ed25519 PEM"); return; }
+    const cr = await fetch("/console/clearance-challenge?operator_id="+encodeURIComponent(operator_id)+
+                           "&node_id="+encodeURIComponent(node_id), { headers:{accept:"application/json"} });
+    const cbody = await cr.json().catch(() => ({}));
+    if(!cr.ok){ showRejected(res, cr.status, cbody.error || "could not get a challenge (is the operator registered?)"); return; }
+    const sigBuf = await crypto.subtle.sign({name:"Ed25519"}, key,
+                       operatorStopPayload(operator_id, node_id, cbody.nonce));
+    const r = await fetch("/console/estop-requests", {
+      method:"POST", headers:{"content-type":"application/json"},
+      body: JSON.stringify({ node_id, operator_id, nonce: cbody.nonce, signature_b64: b64FromBytes(sigBuf) }),
+    });
+    const body = await r.json().catch(() => ({}));
+    if(r.ok && body.status === "stop_commanded") showStopCommanded(res, body);
+    else showRejected(res, r.status, body.reason);
+  } catch(e){ showRejected(res, "err", e.message); }
+  finally { opkeyEl.value = ""; document.getElementById("es_confirm").checked = false; btn.disabled = false; }
+});
+
+// Feature-detect WebCrypto Ed25519. If unavailable, hide the in-page signing forms
 // and surface the documented CLI flow — NEVER a silent break-glass fallback.
 ed25519Supported().then(ok => {
   if(!ok){
     document.getElementById("opsigned").style.display = "none";
     document.getElementById("clifallback").style.display = "block";
+    document.getElementById("estopsigned").style.display = "none";
+    document.getElementById("estopclifallback").style.display = "block";
   }
 });
 


### PR DESCRIPTION
## Summary

Lands **item 4 of ADR-0013** — the operator console's authenticated **"Request Emergency Stop"** action — the last deferred step of the governor-routed software E-stop. The verifier side (`POST /console/estop-requests` → `console_estop_request`, the domain-separated signed path, the `OperatorStopRequested` → `GovernorMRCCommanded` chain events) already landed (#412); only the console UI action remained.

## What it does

In the embedded operator console (`static/console.html`, served at `GET /console`), added as the **inverse** of the existing clearance-grant panel — same signed channel, opposite verb:

- **Operator-signed, in-browser** — the operator pastes their PKCS#8 Ed25519 private key (held in memory only, never `localStorage`, never sent). The page fetches a one-time challenge from the existing `/console/clearance-challenge`, signs the **STOP-distinct** payload (`KIRRA-OPERATOR-ESTOP-v1`, byte-matching Rust `operator_stop_signing_payload`), and POSTs to `/console/estop-requests`.
- **REQUEST, never a command** — the panel is badged "REQUEST · routed to governor" with an explicit acknowledgement checkbox: acceptance drives a sticky `LockedOut` MRC recoverable only by a deliberate supervisor reset, and this software path never replaces the hardwired physical E-stop (ADR-0013 constraints #1 and #4). The console touches no actuator — it *asks*; the governor *acts*.
- **Non-repudiable — operator-signed ONLY** — no supervisor break-glass (constraint #2: a shared key cannot prove *which* operator requested the stop). When WebCrypto Ed25519 is unavailable, it surfaces the documented CLI flow, never a silent fallback.
- **Domain separation reused** — the shared `/console/clearance-challenge` nonce channel is reused; the domain-distinct payload is what keeps release-vs-stop non-interchangeable (a clearance signature can never be replayed as a stop).

## Regression guard + docs

- New test `console_serves_the_estop_request_action` (`console_phase_a_tests.rs`) asserts the served page wires the `/console/estop-requests` endpoint, signs under the stop-distinct domain, frames the action as a REQUEST, and states operator-signed-only (no break-glass).
- ADR-0013 status + item 4 marked landed; `CONSOLE_RUNBOOK.md` gains the operator e-stop flow + a CLI signing snippet.
- The JS payload builder was refactored to a shared `domainFramedPayload` helper so grant and stop differ only by their domain tag — mirroring the Rust side, where the two `operator_*_signing_payload` fns differ only by their domain constant.

## Scope note

This lands in the **embedded operator console** — the surface that already hosts the operator-signing (clearance-grant) flow. The Next.js dashboard keeps its read-only "Emergency Stop Readiness" indicator (#411). End-to-end validation (a running governor + actuator path) remains hardware-gated, as recorded in the ADR.

## Verification

Console tests 34/34 (incl. the new guard); fmt clean; quality guardrails satisfied. Branch is cleanly based on the latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_