### PR TITLE
fix(robot): actuator serial udev rule silently defeated by vendor's := lock

### DIFF
--- a/robot/install/99-kirra-serial-exclusivity.rules
+++ b/robot/install/99-kirra-serial-exclusivity.rules
@@ -4,17 +4,31 @@
 # The stock Yahboom rule (captured/yahboom/udev/serial.rules) ships the CH340
 # motor board MODE:=0777 — WORLD-WRITABLE: any process on the host can drive
 # the motors with no ROS at all, bypassing the checker (the #887 gap below the
-# bus). This rule matches the SAME device and, running later in lexical order
-# (99- vs the vendor's), overrides ownership/mode while keeping the
-# /dev/myserial symlink the whole stack expects.
+# bus). This rule matches the SAME device and, running earlier in lexical
+# order (99- vs the vendor's bare "serial.rules" — '9' < 's'), tightens
+# ownership/mode while keeping the /dev/myserial symlink the whole stack
+# expects.
+#
+# 🔴 OWNER/MODE use `:=` (FINAL assignment), NOT `=` — load-bearing. The
+# vendor's own rule uses `MODE:=0777`; udev's `:=` locks a key against ANY
+# later rule's attempt to change it, REGARDLESS of that later rule's own
+# operator. Since our rule runs FIRST (alphabetically before "serial.rules"),
+# a plain `=` here would look like it worked but be silently overwritten +
+# re-locked by the vendor's later `MODE:=0777` — the port stays 0777
+# world-writable with NO error, defeating this entire mitigation. Using `:=`
+# ourselves closes that: we lock the value before the vendor rule ever runs.
+# (Confirm the winning rule any time with the dry-run `udevadm test
+# $(udevadm info -q path -n /dev/myserial)` — it names which rule applied.)
 #
 # __KIRRA_ROBOT_USER__ is rendered by install_kirra.sh to the consumer's user.
 # After install: sudo udevadm control --reload && sudo udevadm trigger
-# (or replug the board). Verify: stat -c '%U %a' /dev/myserial → <user> 600.
+# (or replug the board — a device already open when triggered may need
+# `systemctl stop kirra-consumer` first to release the fd). Verify:
+# stat -c '%U %a' /dev/myserial → <user> 600.
 #
 # NOTE: this matches the CH340 (1a86:7523) like the vendor rule does. If a
 # second CH340 device is ever attached, it inherits the same tightening —
 # prefer that (fail-closed) over a serial-number match that silently misses a
 # replaced expansion board. The consumer's boot sentinel
 # (robot/serial_exclusivity.py) independently verifies the result either way.
-KERNEL=="ttyUSB*", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", OWNER="__KIRRA_ROBOT_USER__", MODE="0600", SYMLINK+="myserial"
+KERNEL=="ttyUSB*", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", OWNER:="__KIRRA_ROBOT_USER__", MODE:="0600", SYMLINK+="myserial"


### PR DESCRIPTION
## What

A silent ADR-0033 mitigation failure, found live on hardware. After installing `99-kirra-serial-exclusivity.rules` exactly as documented — rendered, reloaded, triggered — `/dev/myserial` was **still `root:0777`** (world-writable). No error anywhere; `kirra_doctor`'s devices check is what caught it.

## Root cause

Confirmed with `udevadm test` (a dry-run rule trace) on the R2 bench unit:

```
99-kirra-serial-exclusivity.rules:20  OWNER 1000 / MODE 0600   (runs first)
serial.rules:1                        MODE:="0777"             (runs second, WINS)
```

The vendor's stock rule (captured verbatim in this repo at `captured/yahboom/udev/serial.rules`) uses udev's **`:=` final assignment** for `MODE`. Per `udev(7)`: `:=` "assign[s] a value to a key finally; disallow[s] any later changes" — by **any** later rule, regardless of that rule's own operator. Our rule ran first with a plain `=`, so the vendor's later `:=0777` simply overwrote and **re-locked** it. The mitigation *looked* installed and was not in effect. Every deployment using the vendor's stock CH340 driver has the same gap.

## Fix

`OWNER`/`MODE` now use `:=` themselves. Since our rule runs first (alphabetically, `"99-..."` < `"serial.rules"`), locking here wins outright — the vendor's later `:=0777` attempt on an already-finalized key becomes a no-op. Documented inline (the *why*, not just the *what* — this is exactly the "looks fixed, isn't" class of gap that invites a silent regression if someone "simplifies" it back to `=` later).

## Verification

- `python3 robot/serial_exclusivity_test.py` → **12/12** (nothing parses the rule file's exact operator — only the filename appears in fix-hint strings — so no other code needed to change).
- The `:=` mechanism is exactly what `udevadm test $(udevadm info -q path -n /dev/myserial)` traced as the *cause* on the R2 bench unit for the prior (broken) plain-`=` rule. Re-verifying the corrected rule on hardware (reload → trigger → `stat -c '%U %a' /dev/myserial` → `jetson 600`) is the operator's next step after this lands.

## Safety framing

🔴 This closes a real actuation-security gap named in ADR-0033/#887: an unpinned, world-writable motor serial port lets **any process on the host drive the motors directly, bypassing the checker entirely**. The fix is config-only (a udev rule), touches no Rust/checker code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_