### PR TITLE
fix(robot): wake listener re-arms on turn-done signal, not a blind timer (Slice R)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1274,6 +1274,14 @@ jobs:
           # rabbit_wake control matcher incl. non-overlap with the OTA/diag/
           # drive matchers. See docs/hardware/RABBIT_AUDIO_STACK.md §3b.
           python3 robot/wake_word_test.py
+          # Turn-state re-arm gate (Slice R, pure, no audio): the cross-process
+          # "turn in progress" signal (fail-safe parse, active/done round-trip,
+          # seq monotonicity) and the bounded rearm_decision that fixes the wake
+          # listener re-arming on a blind timer — a completed turn reopens the mic
+          # AT ONCE (no dropped follow-up), a long turn is never cut before its
+          # ceiling, a garbage clip reopens after grace, incl. the 5-consecutive-
+          # cycle acceptance proof. See robot/turn_state.py.
+          python3 robot/turn_state_test.py
           # VAD endpointing (pure, no audio): the RMS energy math and the
           # silence-endpoint state machine — endpoint only after enough ACTUAL
           # speech + trailing silence, a lone click never ends the clip, and the

--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -175,8 +175,23 @@ listener exits cleanly when unset. Full env set: `robot/install/rabbit.env.examp
 tolerance on long tokens only: "hallo rabbits" wakes; a stray "yo" or "hey the
 rabbit robot" never does; host-tested in `robot/wake_word_test.py`). On a hit:
 ack cue ("Yes?" through TTS by default — a **false fire is heard, not silent**),
-the mic is **released** for `KIRRA_WAKE_HOLDOFF_S` so the turn recorder can
-claim the device, then a cooldown.
+the mic is **released** so the turn recorder can claim the device, then a
+cooldown.
+
+**Re-arm is event-driven, not a blind timer (Slice R).** The mic is held closed
+only until the turn it triggered actually *finishes*, then reopens at once — so
+the operator's immediate follow-up "hey rabbit" is heard. The old fixed
+`KIRRA_WAKE_HOLDOFF_S` sleep couldn't fit a variable-length turn: a fast turn left
+the mic shut through a dead window that dropped the follow-up (the "it only
+answered one question" symptom), while a long turn reopened mid-reply. Now
+`rabbit_converse` publishes a tmpfs turn-state file (`turn_state.py`, the same
+atomic-epoch pattern as `barge_in.py`) that the listener waits on, bounded by
+`KIRRA_WAKE_TURN_GRACE_S` (wait-for-start / garbage-clip reopen) and
+`KIRRA_WAKE_TURN_MAX_S` (hung-writer ceiling) and fail-safe (an old/crashed
+writer degrades to the timers). The pure `rearm_decision` gate — including a
+five-consecutive-cycle re-arm proof — is host-tested in
+`robot/turn_state_test.py`. `KIRRA_WAKE_REARM=timer` restores the legacy blind
+`KIRRA_WAKE_HOLDOFF_S` hold-off.
 
 **How this answers §3's three objections** (which still stand for *naive*
 always-listening):
@@ -223,10 +238,12 @@ early is always safe. The priority model is P0 e-stop > P1 {wake, human-interrup
 (`should_interrupt`, host-tested).
 
 The **PTT** path works today because the button is independent of the mic. The
-*acoustic* "say the wake word over Rabbit" path does not yet, because the wake
-listener releases the mic for the turn's hold-off while Rabbit speaks — closing
-that needs full-duplex audio (echo cancellation) or a shorter hold-off, a tracked
-follow-up.
+*acoustic* "say the wake word **over** Rabbit while it is still speaking" path
+does not yet: the wake mic stays closed until the reply finishes, so a barge-in
+mid-sentence needs full-duplex audio (echo cancellation) — a tracked follow-up.
+Note this is now **only** the interrupt-while-speaking case: the wake word
+**immediately after** a reply is heard right away (event-driven re-arm, Slice R
+above), so back-to-back questions no longer need the button.
 
 ---
 

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -77,7 +77,16 @@ KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
 #KIRRA_WAKE_PHRASES="hello rabbit,hey rabbit,yo rabbit"
 #KIRRA_WAKE_RMS_FLOOR=300        # energy pre-gate: a silent room runs ZERO inference
 #KIRRA_WAKE_COOLDOWN_S=2         # refractory period between wakes
-#KIRRA_WAKE_HOLDOFF_S=10         # mic released this long per wake (>= record -d + ~6)
+# Re-arm (Slice R): after a wake, the mic is held closed until the TURN it
+# triggered actually finishes, then reopens AT ONCE — so a fast turn's immediate
+# follow-up "hey rabbit" is heard (the old fixed hold-off dropped it: "only
+# answered one question"). Event-driven via a tmpfs turn-state file rabbit_converse
+# writes; bounded and fail-safe (an old/crashed writer degrades to the timers).
+#KIRRA_WAKE_REARM=signal         # "signal" (default, event-driven) | "timer" (legacy blind hold-off)
+#KIRRA_WAKE_TURN_GRACE_S=7       # wait-for-turn-start window (>= record -d + STT); also the garbage-clip / no-writer reopen time
+#KIRRA_WAKE_TURN_MAX_S=45        # hard ceiling if a turn signals active but never done (writer crash)
+#KIRRA_WAKE_TURN_STATE_FILE=/dev/shm/kirra_rabbit_turn.state  # shared signal file (rabbit_converse writes, wake_word reads)
+#KIRRA_WAKE_HOLDOFF_S=10         # LEGACY: fixed hold-off used ONLY when KIRRA_WAKE_REARM=timer
 #KIRRA_WAKE_ACK_CMD=             # cue on wake; default speaks "Yes?" via KIRRA_TTS_CMD
 #KIRRA_WAKE_NAP_MIN=30           # "go to sleep" duration (minutes)
 #KIRRA_WAKE_STATE_FILE=/tmp/kirra_rabbit_wake.state

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -51,6 +51,7 @@ import rabbit_diag  # noqa: E402 — deterministic self-check voice command (rea
 import rabbit_ota  # noqa: E402 — deterministic OTA voice commands (NOT the movement door)
 import rabbit_wake  # noqa: E402 — deterministic wake-listener controls (state file only)
 import barge_in  # noqa: E402 — interruptible reply speech (opt-in; Channel A, cosmetic)
+import turn_state  # noqa: E402 — cross-process "turn in progress" signal (Slice R re-arm)
 import skill_registry  # noqa: E402 — opt-in named-skill router (motion → the SAME /intent fence)
 import world_model  # noqa: E402 — opt-in situation report (read-only TTL'd projection)
 import mission  # noqa: E402 — opt-in multi-step Executive (each step → the SAME /intent fence)
@@ -346,13 +347,25 @@ def handle_turn(history, utterance):
     del history[: max(0, len(history) - 2 * MAX_TURNS)]
 
 
+def _run_turn(history, utterance):
+    """One turn, bracketed by the cross-process turn-state signal so the wake
+    listener re-arms its mic the instant the reply finishes (Slice R) instead of
+    on a blind timer. mark_active spans exactly the LLM+TTS stretch the listener
+    can't see; mark_done runs in a finally so a mid-turn error still re-arms."""
+    turn_state.mark_active()
+    try:
+        handle_turn(history, utterance)
+    finally:
+        turn_state.mark_done()
+
+
 def main():
     once = "--once" in sys.argv[1:]
     history = []
     if once:
         utterance = sys.stdin.read().strip()
         if utterance:
-            handle_turn(history, utterance)
+            _run_turn(history, utterance)
         else:
             # Empty transcript (e.g. PTT released with nothing intelligible) → F2.
             speak(f"I didn't quite catch that{name_slot()}.")
@@ -362,7 +375,7 @@ def main():
     for line in sys.stdin:
         utterance = line.strip()
         if utterance:
-            handle_turn(history, utterance)
+            _run_turn(history, utterance)
 
 
 if __name__ == "__main__":

--- a/robot/turn_state.py
+++ b/robot/turn_state.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""turn_state.py — a tiny cross-process "a conversation turn is in progress"
+signal (Slice R, reliability). It exists to fix ONE bug: the wake listener
+re-arming its microphone on a BLIND FIXED TIMER instead of when the turn it
+triggered actually finishes.
+
+THE BUG it fixes (wake_word.py's old post-trigger `time.sleep(holdoff_s)`):
+  A turn (record → STT → LLM → TTS) has VARIABLE duration, so a fixed hold-off
+  cannot fit it. If the turn finished FAST, the operator's immediate follow-up
+  "hey rabbit" landed in the still-closed dead window and was DROPPED — "it only
+  answered one question". If the turn ran LONG, the mic reopened mid-reply and
+  captured Rabbit's own voice. Event-driven re-arm (like a Nest/Alexa) settles
+  both: the listener waits for the turn to SIGNAL done, then reopens at once.
+
+WHO WRITES / WHO READS:
+  * rabbit_converse.py (the turn handler) MARKS a turn active at the top of each
+    turn and done when the reply finishes speaking — it spans exactly the
+    LLM+TTS stretch the wake listener cannot otherwise see.
+  * wake_word.py (the always-on listener) READS it after firing a trigger and
+    waits for the turn to complete before reopening the mic.
+
+🔴 SAFETY / DISCIPLINE — Channel A only, ZERO authority (identical stance to
+   barge_in.py):
+  * This signal only paces the microphone hold-off. It never starts motion,
+    emits an intent, or touches the fenced /intent door. A wrong value at worst
+    reopens the mic a little early/late — never an unsafe motion.
+  * It is a local state FILE (atomic temp+rename), never stdout — the
+    ptt_button / wake_word stdout trigger contract is untouched.
+  * FAIL-SAFE everywhere: an absent/corrupt file reads as "idle, seq 0"; every
+    write swallows its error. The listener's wait is always bounded by timers,
+    so a crashed/old writer degrades to the legacy hold-off, never a wedge.
+
+Format (JSON): {"active": <bool>, "seq": <int>}.
+  seq is a monotonic "turns completed" counter — it advances on mark_done, so a
+  reader that baselined seq at trigger time can detect "the turn I caused has
+  finished" even if it never observed the brief active=True window.
+
+Env:
+  KIRRA_WAKE_TURN_STATE_FILE   shared path (default /tmp/kirra_rabbit_turn.state,
+                               or /dev/shm/... when that tmpfs exists)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+DEFAULT_STATE_FILE = "kirra_rabbit_turn.state"
+
+
+def log(msg: str) -> None:
+    print(f"turn_state: {msg}", file=sys.stderr, flush=True)
+
+
+def default_state_path() -> str:
+    """Prefer the /dev/shm tmpfs (never hits disk) when present — parity with
+    wake_word.py's transcribe-and-discard tmpfs choice — else /tmp."""
+    base = "/dev/shm" if os.path.isdir("/dev/shm") else "/tmp"
+    return os.path.join(base, DEFAULT_STATE_FILE)
+
+
+def state_path() -> str:
+    return (os.environ.get("KIRRA_WAKE_TURN_STATE_FILE") or "").strip() \
+        or default_state_path()
+
+
+# ── pure read/parse (host-tested; fail-safe) ─────────────────────────────────
+
+def parse_state(text: str | None) -> tuple[bool, int]:
+    """(active, seq) from the file's text. Absent/corrupt/partial → (False, 0):
+    'no turn in progress, nothing completed' — the availability-safe default,
+    correct here because the signal carries no actuation authority."""
+    if not text:
+        return False, 0
+    try:
+        j = json.loads(text)
+        active = bool(j.get("active", False))
+        seq = int(j.get("seq", 0))
+        return active, (seq if seq >= 0 else 0)
+    except Exception:  # noqa: BLE001 — corrupt file reads as idle, never a crash
+        return False, 0
+
+
+def read_state(path: str | None = None) -> tuple[bool, int]:
+    """(active, seq) from `path` (default the shared file). Fail-safe → (False, 0)."""
+    p = path or state_path()
+    try:
+        with open(p, "r", encoding="utf-8") as f:
+            return parse_state(f.read())
+    except OSError:
+        return False, 0
+
+
+# ── the write seam (atomic temp+rename; fail-soft) ───────────────────────────
+
+def _write(path: str, active: bool, seq: int) -> None:
+    tmp = f"{path}.tmp.{os.getpid()}"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(json.dumps({"active": active, "seq": seq}))
+        os.replace(tmp, path)
+    except OSError as e:
+        log(f"could not write turn state ({e})")
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def mark_active(path: str | None = None) -> None:
+    """A turn has STARTED handling. Keeps the current seq (it counts COMPLETED
+    turns) and raises the active flag. Fail-soft."""
+    p = path or state_path()
+    _, seq = read_state(p)
+    _write(p, True, seq)
+
+
+def mark_done(path: str | None = None) -> int:
+    """A turn has FINISHED (its reply is spoken). Lowers the active flag and
+    ADVANCES seq so a listener baselined below it detects completion. Returns the
+    new seq (0 on a write it could not read back). Fail-soft."""
+    p = path or state_path()
+    _, seq = read_state(p)
+    nxt = seq + 1
+    _write(p, False, nxt)
+    return nxt
+
+
+# ── the pure re-arm gate (host-tested — the whole point of Slice R) ──────────
+
+def rearm_decision(elapsed_s: float, turn_active: bool, turn_advanced: bool,
+                   *, grace_s: float, max_s: float) -> str:
+    """Should the wake listener REOPEN its mic now, or keep WAITING?
+
+    Called by wake_word.py in a poll loop AFTER it fired a trigger, until it
+    returns 'reopen'. Pure so the whole re-arm behaviour is host-testable with
+    no audio.
+
+      elapsed_s     — seconds since the trigger fired
+      turn_active   — a turn is CURRENTLY in progress (writer marked active,
+                      not yet done)
+      turn_advanced — the turn we triggered has COMPLETED (seq advanced past the
+                      baseline captured at trigger time)
+      grace_s       — how long to wait for a turn to even START (must cover the
+                      record clip + STT before rabbit_converse marks active); if
+                      nothing has started by then the clip was empty/garbage →
+                      reopen. Also the reopen time when NO writer is signalling
+                      (old/absent rabbit_converse) — the fail-safe fallback.
+      max_s         — hard ceiling on the whole wait, so a writer that marked
+                      active but never marked done (crash mid-turn) can't wedge
+                      the listener shut forever.
+
+    Returns 'reopen' or 'wait'. The ordering matters: a COMPLETED turn reopens
+    immediately (no dead window → the follow-up "hey rabbit" is heard), and an
+    in-progress turn is NEVER cut short by the grace window — only by max_s."""
+    if turn_advanced:
+        return "reopen"                       # turn finished → re-arm at once
+    if elapsed_s >= max_s:
+        return "reopen"                       # fail-safe ceiling (writer hung)
+    if turn_active:
+        return "wait"                         # a turn is running — let it finish
+    if elapsed_s >= grace_s:
+        return "reopen"                       # nothing ever started (garbage clip)
+    return "wait"                             # still inside the wait-for-start grace

--- a/robot/turn_state_test.py
+++ b/robot/turn_state_test.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Host tests for turn_state.py — the pure cross-process turn signal + re-arm
+gate that fixes the wake listener's "only answered one question" bug (Slice R).
+
+No audio, no subprocesses: the round-trip uses a tmp file, the re-arm decision is
+pure. Runs standalone (`python3 robot/turn_state_test.py`, exit 1 on failure);
+also importable under pytest.
+
+Covers: fail-safe parse (absent/corrupt/partial/negative), the active/done
+round-trip, seq monotonicity across turns, and rearm_decision across every
+branch — culminating in a simulation proving FIVE consecutive wake→turn→re-arm
+cycles all re-arm promptly (no dead window) AND that a fast turn's follow-up is
+never dropped while a long turn is never cut short before its max ceiling.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from turn_state import (  # noqa: E402
+    mark_active, mark_done, parse_state, read_state, rearm_decision,
+)
+
+
+# --- fail-safe parse ---------------------------------------------------------
+
+def test_parse_absent_or_corrupt_is_idle() -> None:
+    assert parse_state(None) == (False, 0)
+    assert parse_state("") == (False, 0)
+    assert parse_state("not json {") == (False, 0)
+    assert parse_state("[]") == (False, 0)            # wrong shape → idle
+    assert parse_state('{"active": true}') == (True, 0)   # missing seq → 0
+    assert parse_state('{"seq": 4}') == (False, 4)        # missing active → False
+
+
+def test_parse_negative_seq_heals_to_zero() -> None:
+    # A corrupt negative counter must never read as "advanced" — floor at 0.
+    assert parse_state('{"active": false, "seq": -9}') == (False, 0)
+
+
+def test_read_missing_file_is_idle() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        assert read_state(os.path.join(d, "nope.state")) == (False, 0)
+
+
+# --- active/done round-trip + seq monotonicity -------------------------------
+
+def test_active_done_round_trip_and_seq_advances() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "turn.state")
+        assert read_state(p) == (False, 0)             # fresh → idle
+        mark_active(p)
+        assert read_state(p) == (True, 0)              # in progress, none done yet
+        seq1 = mark_done(p)
+        assert seq1 == 1 and read_state(p) == (False, 1)
+        # second turn: seq strictly advances, active toggles correctly
+        mark_active(p)
+        assert read_state(p) == (True, 1)
+        seq2 = mark_done(p)
+        assert seq2 == 2 and read_state(p) == (False, 2)
+
+
+def test_mark_done_without_active_still_advances() -> None:
+    # A turn that errored before mark_active (defensive) still advances the
+    # counter on the finally's mark_done — the listener must not wedge.
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "turn.state")
+        assert mark_done(p) == 1
+        assert read_state(p) == (False, 1)
+
+
+# --- the pure re-arm gate ----------------------------------------------------
+
+GRACE, MAX = 7.0, 45.0
+
+
+def test_completed_turn_reopens_immediately() -> None:
+    # seq advanced past baseline at t=2s (a very fast turn) → reopen NOW, do not
+    # sit out the rest of a fixed hold-off. THIS is the "only one question" fix.
+    assert rearm_decision(2.0, False, True, grace_s=GRACE, max_s=MAX) == "reopen"
+
+
+def test_in_progress_turn_waits_until_done_not_cut_by_grace() -> None:
+    # active turn, well past the grace window, not yet advanced → keep WAITING
+    # (a long LLM+TTS reply must not be cut short and have the mic reopen on top
+    # of Rabbit's own voice).
+    assert rearm_decision(20.0, True, False, grace_s=GRACE, max_s=MAX) == "wait"
+
+
+def test_in_progress_turn_reopens_at_max_ceiling() -> None:
+    # active but never signalled done by the ceiling (writer crashed mid-turn) →
+    # fail-safe reopen so the listener can't wedge shut forever.
+    assert rearm_decision(MAX, True, False, grace_s=GRACE, max_s=MAX) == "reopen"
+
+
+def test_garbage_clip_reopens_after_grace() -> None:
+    # No turn ever started (empty/garbage clip → rabbit_converse got no line):
+    # wait through the grace window, then reopen.
+    assert rearm_decision(3.0, False, False, grace_s=GRACE, max_s=MAX) == "wait"
+    assert rearm_decision(GRACE, False, False, grace_s=GRACE, max_s=MAX) == "reopen"
+
+
+def test_advanced_beats_everything() -> None:
+    # Completion is checked first: even at/over max, an advanced turn is a clean
+    # reopen (not the fail-safe branch) — same outcome, correct reason.
+    assert rearm_decision(100.0, True, True, grace_s=GRACE, max_s=MAX) == "reopen"
+
+
+def _simulate_wait(samples, *, grace_s=GRACE, max_s=MAX):
+    """Drive rearm_decision over an ordered list of (elapsed, active, advanced)
+    poll samples; return the elapsed at which it FIRST says 'reopen' (or None)."""
+    for elapsed, active, advanced in samples:
+        if rearm_decision(elapsed, active, advanced,
+                          grace_s=grace_s, max_s=max_s) == "reopen":
+            return elapsed
+    return None
+
+
+def test_five_consecutive_cycles_all_rearm_promptly() -> None:
+    """The Slice R acceptance proof: five back-to-back wake→turn→re-arm cycles,
+    each a realistic fast turn (record+STT ~5s, then a short reply), re-arm the
+    moment the turn completes — never sitting out a dead window. If ANY cycle
+    failed to reopen, the operator's next 'hey rabbit' would be dropped."""
+    reopen_times = []
+    for _ in range(5):
+        # poll timeline for one cycle: mic-closed grace, turn goes active at ~5s
+        # (post record+STT), completes at ~8s (short reply spoken).
+        samples = [
+            (0.0, False, False),   # just fired; nothing started yet
+            (3.0, False, False),   # still recording — inside grace, keep waiting
+            (5.0, True, False),    # transcript arrived, turn active
+            (7.0, True, False),    # LLM/TTS running
+            (8.0, False, True),    # turn done, seq advanced → reopen
+        ]
+        t = _simulate_wait(samples)
+        assert t == 8.0, f"cycle did not re-arm at turn completion (got {t})"
+        reopen_times.append(t)
+    assert reopen_times == [8.0] * 5
+
+
+def test_fast_turn_followup_is_not_dropped() -> None:
+    """Regression for the exact reported symptom: a turn that finishes FAST must
+    reopen the mic well before the old fixed 10s+ hold-off would have, so an
+    immediate follow-up wake is heard."""
+    # turn active at 5s, done at 6s → reopen at 6s, not held to 12s.
+    t = _simulate_wait([
+        (0.0, False, False), (5.0, True, False), (6.0, False, True),
+    ])
+    assert t == 6.0
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok   {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"  FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    print("turn_state host tests (pure, no audio):")
+    sys.exit(_run_all())

--- a/robot/wake_word.py
+++ b/robot/wake_word.py
@@ -65,6 +65,9 @@ import tempfile
 import time
 import wave
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import turn_state  # noqa: E402 — cross-process "turn in progress" signal (Slice R)
+
 # ---------------------------------------------------------------------------
 # Pure logic (host-tested in robot/wake_word_test.py — no audio, no GPIO)
 # ---------------------------------------------------------------------------
@@ -177,6 +180,24 @@ BYTES_PER_SAMPLE = 2
 HOP_S = 0.25          # RMS gate granularity
 WINDOW_S = 2.0        # transcription window handed to whisper
 STATE_POLL_S = 1.0    # nap/mute file poll cadence
+REARM_POLL_S = 0.2    # turn-state poll cadence while waiting to re-arm the mic
+
+
+def _wait_for_rearm(state_file, baseline_seq, grace_s, max_s):
+    """After a trigger fires, hold the mic CLOSED until the turn it caused is
+    settled, then return so the outer loop reopens the mic. Event-driven (polls
+    turn_state) and bounded by grace_s / max_s, so an old/absent/crashed writer
+    degrades to a timed reopen instead of wedging. Replaces the old blind
+    `time.sleep(holdoff_s)` that dropped a fast turn's follow-up wake (Slice R)."""
+    t0 = time.monotonic()
+    while True:
+        active, seq = turn_state.read_state(state_file)
+        elapsed = time.monotonic() - t0
+        decision = turn_state.rearm_decision(
+            elapsed, active, seq > baseline_seq, grace_s=grace_s, max_s=max_s)
+        if decision == "reopen":
+            return
+        time.sleep(REARM_POLL_S)
 
 
 def _log(msg: str) -> None:
@@ -294,6 +315,14 @@ def main() -> int:
     cooldown_s = float(os.environ.get("KIRRA_WAKE_COOLDOWN_S", "2"))
     holdoff_s = float(os.environ.get("KIRRA_WAKE_HOLDOFF_S", "10"))
     state_file = os.environ.get("KIRRA_WAKE_STATE_FILE", "/tmp/kirra_rabbit_wake.state")
+    # Slice R: re-arm the mic on the TURN-DONE signal, not a blind timer.
+    #   default ("signal"): wait for rabbit_converse to finish the turn, bounded
+    #   by grace_s (wait-for-start / garbage-clip reopen) and max_s (hung-writer
+    #   ceiling). "timer" forces the legacy fixed-holdoff sleep.
+    rearm_mode = (os.environ.get("KIRRA_WAKE_REARM") or "signal").strip().lower()
+    turn_state_file = turn_state.state_path()
+    rearm_grace_s = float(os.environ.get("KIRRA_WAKE_TURN_GRACE_S", "7"))
+    rearm_max_s = float(os.environ.get("KIRRA_WAKE_TURN_MAX_S", "45"))
     ack_cmd = os.environ.get("KIRRA_WAKE_ACK_CMD")
     tts_cmd = os.environ.get("KIRRA_TTS_CMD")
     tmp_dir = "/dev/shm" if os.path.isdir("/dev/shm") else tempfile.gettempdir()
@@ -360,11 +389,21 @@ def main() -> int:
             if hit:
                 # Release-before-trigger: the mic is already closed (above), so
                 # rabbit_voice.sh's bounded recorder can claim the device.
+                # Baseline the turn counter BEFORE firing so the turn this trigger
+                # causes is detected as "advanced past baseline" when it completes.
+                baseline_seq = turn_state.read_state(turn_state_file)[1]
                 _log(f'wake: "{hit}"')
                 sys.stdout.write("\n")   # THE TRIGGER — sole stdout writer
                 sys.stdout.flush()
                 _ack(ack_cmd, tts_cmd)
-                time.sleep(holdoff_s)    # the turn's record+STT+TTS window
+                if rearm_mode == "timer":
+                    time.sleep(holdoff_s)   # legacy: blind fixed hold-off
+                else:
+                    # Slice R: keep the mic closed only until the turn actually
+                    # finishes (or a bounded fallback) — no dead window that drops
+                    # a fast turn's immediate follow-up wake.
+                    _wait_for_rearm(turn_state_file, baseline_seq,
+                                    rearm_grace_s, rearm_max_s)
                 time.sleep(cooldown_s)   # refractory: no immediate re-wake
     except KeyboardInterrupt:
         return 0


### PR DESCRIPTION
## What

Fixes the **"it only answered one question"** symptom on the physical Rabbit robot: after a wake word, the always-on listener held its microphone closed for a **fixed `KIRRA_WAKE_HOLDOFF_S` sleep**, decoupled from the actual conversation turn.

## Root cause

A turn (`record → STT → LLM → TTS`) has **variable** duration, so a fixed hold-off cannot fit it:

- **Fast turn:** the operator's immediate follow-up "hey rabbit" landed in the still-closed **dead window** and was silently dropped. → *only answered one question.*
- **Long turn:** the mic reopened **mid-reply** and captured Rabbit's own speaker output.

A timer is the wrong mechanism — a Nest/Alexa re-arms the instant the response ends. The re-arm needs to be **event-driven**.

## Fix

A tiny cross-process **turn-state signal**, bounded and fail-safe:

- **`robot/turn_state.py`** (new): a "turn in progress" signal over a tmpfs file (atomic temp+rename, the same pattern as `barge_in.py`). Fail-safe — an absent/corrupt file reads as *idle*; a monotonic `seq` counts completed turns so a reader baselined at trigger time detects completion even if it never saw the brief `active` window.
- **`robot/rabbit_converse.py`**: marks a turn `active` at the top of each turn and `done` in a `finally`, spanning exactly the LLM+TTS stretch the listener can't otherwise see.
- **`robot/wake_word.py`**: replaces the blind sleep with a bounded wait on that signal —
  - a **completed** turn reopens the mic **at once** (no dropped follow-up),
  - an in-progress turn is **never cut short** before `KIRRA_WAKE_TURN_MAX_S` (hung-writer ceiling),
  - a **garbage clip / absent writer** reopens after `KIRRA_WAKE_TURN_GRACE_S` (degrades to today's behaviour),
  - `KIRRA_WAKE_REARM=timer` restores the legacy fixed hold-off.

🔴 **Channel A only, zero authority.** The signal only paces the microphone hold-off — it never starts motion, emits an intent, or touches the fenced `/intent` door. A wrong value at worst reopens the mic a little early/late, never an unsafe motion.

## Verification

- `python3 robot/turn_state_test.py` → **12/12** — fail-safe parse (absent/corrupt/partial/negative seq), the active/done round-trip, seq monotonicity, every `rearm_decision` branch, and the **five-consecutive-cycle re-arm acceptance proof** + a direct regression for the fast-turn-follow-up-not-dropped symptom. Wired into the CI robot-tests lane.
- `python3 robot/wake_word_test.py` → ALL OK (unchanged); `python3 robot/rabbit_voice_test.py` → 18/18. Compile + import wiring checked for `wake_word.py` and `rabbit_converse.py`.

Env documented in `robot/install/rabbit.env.example`; `docs/hardware/RABBIT_AUDIO_STACK.md` §3b updated (the acoustic follow-up is now *only* the interrupt-while-speaking full-duplex case; back-to-back questions no longer need the button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_