### PR TITLE
feat(robot): Rabbit follow-up mode — keep talking without re-waking (Slice F)

### DIFF
--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -193,6 +193,19 @@ five-consecutive-cycle re-arm proof — is host-tested in
 `robot/turn_state_test.py`. `KIRRA_WAKE_REARM=timer` restores the legacy blind
 `KIRRA_WAKE_HOLDOFF_S` hold-off.
 
+**Follow-up mode (Slice F, opt-in).** With `KIRRA_WAKE_FOLLOWUP_ENABLED=1`, for
+`KIRRA_WAKE_FOLLOWUP_S` seconds after each reply the listener holds the mic open
+and treats the operator simply *starting to speak* (sustained energy, no wake
+phrase, no STT) as a follow-up — so a back-and-forth exchange needs the wake word
+only once, exactly like Google's Continued Conversation / Alexa's Follow-Up Mode.
+A silent window (or a nap/mute) closes it and the wake word is required again. The
+"Yes?" ack fires only on the initial wake, not on each follow-up. It carries **no
+new authority**: a follow-up fires the *same* fenced trigger the wake word does,
+so a misheard follow-up still dead-ends at `MickIntent::parse_llm_json`. The pure
+`followup_decision` gate — including a chained-conversation simulation — is
+host-tested in `robot/wake_word_test.py`. Off by default → byte-identical (every
+turn needs a wake word).
+
 **How this answers §3's three objections** (which still stand for *naive*
 always-listening):
 - *Bounds when the LLM runs* — the LLM still runs at most once per wake, exactly

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -87,6 +87,15 @@ KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
 #KIRRA_WAKE_TURN_MAX_S=45        # hard ceiling if a turn signals active but never done (writer crash)
 #KIRRA_WAKE_TURN_STATE_FILE=/dev/shm/kirra_rabbit_turn.state  # shared signal file (rabbit_converse writes, wake_word reads)
 #KIRRA_WAKE_HOLDOFF_S=10         # LEGACY: fixed hold-off used ONLY when KIRRA_WAKE_REARM=timer
+# Follow-up mode (Slice F, OPT-IN — like Google Continued Conversation / Alexa
+# Follow-Up Mode). After a reply, hold a short window where the operator can just
+# TALK — no wake word — before the listener falls back to requiring one. The wake
+# ack ("Yes?") fires only on the wake, not on each follow-up (natural back-and-
+# forth). Zero new authority: a follow-up fires the SAME fenced trigger the wake
+# word does. Off → byte-identical (each turn needs a wake word).
+#KIRRA_WAKE_FOLLOWUP_ENABLED=1
+#KIRRA_WAKE_FOLLOWUP_S=6          # seconds to keep listening after a reply before requiring the wake word again
+#KIRRA_WAKE_FOLLOWUP_ONSET_HOPS=2 # consecutive ~0.25s energy hops that count as "started speaking" (>=2 ignores a lone click)
 #KIRRA_WAKE_ACK_CMD=             # cue on wake; default speaks "Yes?" via KIRRA_TTS_CMD
 #KIRRA_WAKE_NAP_MIN=30           # "go to sleep" duration (minutes)
 #KIRRA_WAKE_STATE_FILE=/tmp/kirra_rabbit_wake.state

--- a/robot/wake_word.py
+++ b/robot/wake_word.py
@@ -171,6 +171,30 @@ def wake_allowed(state_text: str | None, now_ms: int) -> bool:
         return True
 
 
+def followup_decision(elapsed_s: float, onset: bool, window_s: float) -> str:
+    """Follow-up mode (Slice F): after a reply, should the listener fire a
+    follow-up trigger WITHOUT a wake word, keep waiting for the operator to
+    start speaking, or close the window?
+
+    Like Google's Continued Conversation / Alexa Follow-Up Mode: for a short
+    window after each answer the operator can just talk. Pure so the whole
+    follow-up gate is host-testable with no audio.
+
+      onset      — the operator has STARTED speaking (sustained energy above the
+                   floor) → fire a follow-up trigger, treated exactly as a wake
+                   (the same fenced text-to-the-door path; zero new authority).
+      window_s   — how long to hold the window open; a silent window closes and
+                   the listener falls back to requiring the wake word.
+
+    Returns 'trigger' | 'listen' | 'expire'. Onset wins even past the window —
+    speech that just began is honoured, not dropped on a boundary tie."""
+    if onset:
+        return "trigger"
+    if elapsed_s >= window_s:
+        return "expire"
+    return "listen"
+
+
 # ---------------------------------------------------------------------------
 # The listener (hardware side — not imported by tests)
 # ---------------------------------------------------------------------------
@@ -202,6 +226,24 @@ def _wait_for_rearm(state_file, baseline_seq, grace_s, max_s):
 
 def _log(msg: str) -> None:
     print(f"wake_word: {msg}", file=sys.stderr, flush=True)
+
+
+def _fire_trigger_and_wait(turn_state_file, rearm_mode, holdoff_s,
+                           grace_s, max_s, cooldown_s, after_fire=None):
+    """Emit ONE trigger newline (the wake/follow-up signal) and hold the mic
+    closed until the turn it causes settles (Slice R), then a cooldown. Shared by
+    the wake path and the follow-up path so both re-arm identically. The mic is
+    already CLOSED by the caller before this runs (release-before-trigger)."""
+    baseline_seq = turn_state.read_state(turn_state_file)[1]
+    sys.stdout.write("\n")   # THE TRIGGER — sole stdout writer
+    sys.stdout.flush()
+    if after_fire is not None:
+        after_fire()
+    if rearm_mode == "timer":
+        time.sleep(holdoff_s)   # legacy: blind fixed hold-off
+    else:
+        _wait_for_rearm(turn_state_file, baseline_seq, grace_s, max_s)
+    time.sleep(cooldown_s)   # refractory: no immediate re-trigger
 
 
 def _truthy(v: str | None) -> bool:
@@ -290,6 +332,52 @@ def _read_state(path: str) -> str | None:
         return None
 
 
+def _listen_for_speech_onset(record_cmd, rms_floor, window_s, onset_hops,
+                             hop_bytes, led, state_file) -> bool:
+    """Follow-up mode (Slice F): open the mic and wait up to window_s for the
+    operator to START speaking (onset_hops consecutive energy hops above the
+    floor). Returns True on onset — with the mic already CLOSED so the turn
+    recorder can claim the device (release-before-trigger, same as the wake
+    path) — or False on a silent timeout / nap-mute / recorder fault (→ fall
+    back to requiring the wake word). No STT and no phrase match: after Rabbit's
+    OWN answer, the operator simply talking is the trigger, exactly like a
+    Nest/Alexa follow-up. Carries no new authority — it fires the same fenced
+    trigger the wake word does."""
+    try:
+        cap = subprocess.Popen(record_cmd, stdout=subprocess.PIPE,
+                               stderr=subprocess.DEVNULL)
+    except Exception as e:  # noqa: BLE001 — no mic → no follow-up, just fall back
+        _log(f"follow-up: recorder failed to start ({type(e).__name__}) — wake-word only")
+        return False
+    led.set(True)
+    loud = 0
+    onset = False
+    t0 = time.monotonic()
+    try:
+        while True:
+            elapsed = time.monotonic() - t0
+            # A nap/mute engaged during the window closes it immediately.
+            if not wake_allowed(_read_state(state_file), int(time.time() * 1000)):
+                break
+            decision = followup_decision(elapsed, onset, window_s)
+            if decision != "listen":
+                break
+            chunk = cap.stdout.read(hop_bytes)
+            if not chunk:
+                break  # recorder died → treat as no onset
+            loud = loud + 1 if rms(chunk) >= rms_floor else 0
+            if loud >= onset_hops:
+                onset = True   # next iteration's decision → 'trigger' → break
+    finally:
+        led.set(False)
+        cap.terminate()
+        try:
+            cap.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            cap.kill()
+    return onset
+
+
 def main() -> int:
     if not _truthy(os.environ.get("KIRRA_WAKE_ENABLED")):
         _log("KIRRA_WAKE_ENABLED not set — wake word off (exit 0; PTT/Enter still work)")
@@ -323,6 +411,12 @@ def main() -> int:
     turn_state_file = turn_state.state_path()
     rearm_grace_s = float(os.environ.get("KIRRA_WAKE_TURN_GRACE_S", "7"))
     rearm_max_s = float(os.environ.get("KIRRA_WAKE_TURN_MAX_S", "45"))
+    # Slice F: follow-up mode (opt-in, like Nest/Alexa). After a reply, hold a
+    # short window where the operator can just talk — no wake word — before the
+    # listener falls back to requiring one.
+    followup_enabled = _truthy(os.environ.get("KIRRA_WAKE_FOLLOWUP_ENABLED"))
+    followup_window_s = float(os.environ.get("KIRRA_WAKE_FOLLOWUP_S", "6"))
+    followup_onset_hops = max(1, int(os.environ.get("KIRRA_WAKE_FOLLOWUP_ONSET_HOPS", "2")))
     ack_cmd = os.environ.get("KIRRA_WAKE_ACK_CMD")
     tts_cmd = os.environ.get("KIRRA_TTS_CMD")
     tmp_dir = "/dev/shm" if os.path.isdir("/dev/shm") else tempfile.gettempdir()
@@ -388,23 +482,28 @@ def main() -> int:
 
             if hit:
                 # Release-before-trigger: the mic is already closed (above), so
-                # rabbit_voice.sh's bounded recorder can claim the device.
-                # Baseline the turn counter BEFORE firing so the turn this trigger
-                # causes is detected as "advanced past baseline" when it completes.
-                baseline_seq = turn_state.read_state(turn_state_file)[1]
+                # rabbit_voice.sh's bounded recorder can claim the device. The
+                # ack ("Yes?") fires once, on the WAKE — not on each follow-up.
                 _log(f'wake: "{hit}"')
-                sys.stdout.write("\n")   # THE TRIGGER — sole stdout writer
-                sys.stdout.flush()
-                _ack(ack_cmd, tts_cmd)
-                if rearm_mode == "timer":
-                    time.sleep(holdoff_s)   # legacy: blind fixed hold-off
-                else:
-                    # Slice R: keep the mic closed only until the turn actually
-                    # finishes (or a bounded fallback) — no dead window that drops
-                    # a fast turn's immediate follow-up wake.
-                    _wait_for_rearm(turn_state_file, baseline_seq,
-                                    rearm_grace_s, rearm_max_s)
-                time.sleep(cooldown_s)   # refractory: no immediate re-wake
+                _fire_trigger_and_wait(
+                    turn_state_file, rearm_mode, holdoff_s, rearm_grace_s,
+                    rearm_max_s, cooldown_s,
+                    after_fire=lambda: _ack(ack_cmd, tts_cmd))
+
+                # Slice F: follow-up window(s). After the reply, listen briefly
+                # for the operator to just start talking (no wake word). Each
+                # onset fires another turn and reopens the window; a silent
+                # window (or nap/mute) closes it → back to wake-word listening.
+                while followup_enabled and wake_allowed(
+                        _read_state(state_file), int(time.time() * 1000)):
+                    if not _listen_for_speech_onset(
+                            record_cmd, rms_floor, followup_window_s,
+                            followup_onset_hops, hop_bytes, led, state_file):
+                        break
+                    _log("follow-up: speech onset — firing without a wake word")
+                    _fire_trigger_and_wait(
+                        turn_state_file, rearm_mode, holdoff_s, rearm_grace_s,
+                        rearm_max_s, cooldown_s)
     except KeyboardInterrupt:
         return 0
     except BrokenPipeError:

--- a/robot/wake_word_test.py
+++ b/robot/wake_word_test.py
@@ -23,8 +23,8 @@ import rabbit_diag  # noqa: E402
 import rabbit_wake  # noqa: E402
 from rabbit_ota import match_command  # noqa: E402
 from wake_word import (  # noqa: E402
-    DEFAULT_PHRASES, parse_phrases, rms, transcript_tokens, wake_allowed,
-    wake_hit,
+    DEFAULT_PHRASES, followup_decision, parse_phrases, rms, transcript_tokens,
+    wake_allowed, wake_hit,
 )
 
 PHRASES = parse_phrases(DEFAULT_PHRASES)
@@ -122,6 +122,49 @@ def test_wake_allowed_states() -> None:
     nap = '{"mode": "nap", "until_ms": 1000500}'
     assert not wake_allowed(nap, now), "napping until the deadline"
     assert wake_allowed(nap, 1_000_500), "nap expires exactly at until_ms"
+
+
+# --- follow-up mode gate (Slice F) -------------------------------------------
+
+def test_followup_listen_until_onset_or_window() -> None:
+    W = 6.0
+    assert followup_decision(0.0, False, W) == "listen"   # just opened, silent
+    assert followup_decision(3.0, False, W) == "listen"   # mid-window, silent
+    assert followup_decision(2.0, True, W) == "trigger"   # operator started talking
+    assert followup_decision(W, False, W) == "expire"     # window elapsed silent
+    assert followup_decision(99.0, False, W) == "expire"
+
+
+def test_followup_onset_wins_even_past_window() -> None:
+    # Speech that just began at/after the boundary is honoured, not dropped on a
+    # tie — onset is checked before the window expiry.
+    assert followup_decision(6.0, True, 6.0) == "trigger"
+    assert followup_decision(100.0, True, 6.0) == "trigger"
+
+
+def test_followup_chained_conversation_simulation() -> None:
+    """Three back-to-back follow-ups then a silent window closes the loop — the
+    Slice F acceptance shape: 'respond and keep talking' without re-waking."""
+    W = 6.0
+    fired = 0
+    # each cycle: silent hops then an onset; the 4th cycle stays silent to close.
+    cycles = [
+        [(0.0, False), (1.0, False), (1.5, True)],   # follow-up 1
+        [(0.0, False), (2.0, True)],                 # follow-up 2
+        [(0.0, False), (0.5, True)],                 # follow-up 3
+        [(0.0, False), (3.0, False), (W, False)],    # silent → expire
+    ]
+    for samples in cycles:
+        outcome = None
+        for elapsed, onset in samples:
+            outcome = followup_decision(elapsed, onset, W)
+            if outcome != "listen":
+                break
+        if outcome == "trigger":
+            fired += 1
+        else:
+            assert outcome == "expire"
+    assert fired == 3, f"expected 3 chained follow-ups, got {fired}"
 
 
 # --- rabbit_wake controls ------------------------------------------------------


### PR DESCRIPTION
## What

After a reply, for a short **opt-in** window the operator can just talk — no wake word — before the listener falls back to requiring one. This is the *"respond and keep talking"* behaviour asked for, matching Google Nest's **Continued Conversation** and Alexa's **Follow-Up Mode** (both opt-in in the real products). Built directly on Slice R's turn-done re-arm.

## How

- **`wake_word.py`**: after firing the wake and waiting for the turn (Slice R), when `KIRRA_WAKE_FOLLOWUP_ENABLED=1` it opens a `KIRRA_WAKE_FOLLOWUP_S`-second window and listens for speech **onset** — sustained energy above the floor (`KIRRA_WAKE_FOLLOWUP_ONSET_HOPS` consecutive ~0.25 s hops, ≥2 ignores a lone click); **no STT, no phrase match**. An onset fires the **same fenced trigger** the wake word does and reopens the window (chained conversation); a silent window — or a nap/mute — closes it and the wake word is required again. The "Yes?" ack fires only on the initial wake, not each follow-up (natural back-and-forth).
- Refactored the trigger+re-arm into a shared `_fire_trigger_and_wait` so the wake and follow-up paths re-arm identically; added `_listen_for_speech_onset` (the mic seam, release-before-trigger) and the pure `followup_decision` gate.

🔴 **Zero new authority.** A follow-up is text-to-the-door exactly like a wake, so a misheard follow-up still dead-ends at `MickIntent::parse_llm_json` — no motion. **Off by default → byte-identical** (every turn needs a wake word).

## Verification

- `python3 robot/wake_word_test.py` → ALL OK — adds the pure `followup_decision` cases (listen → onset/`trigger` / silent-`expire`, onset-wins-past-window boundary tie) and a **chained-conversation simulation** (three back-to-back follow-ups then a silent window closes the loop).
- `python3 robot/turn_state_test.py` → 12/12 and `python3 robot/rabbit_voice_test.py` → 18/18 unchanged. Compile + wiring checked.

Env documented in `robot/install/rabbit.env.example`; `docs/hardware/RABBIT_AUDIO_STACK.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_