### PR TITLE
perf(robot): persist Rabbit speed tuning — keep-alive + speed doc (Slice S)

### DIFF
--- a/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
@@ -134,6 +134,39 @@ Rabbit confirms. Approach an obstacle → it warns, unprompted. That's Rabbit.
 
 ---
 
+## Speed — making Rabbit reply fast
+
+If Rabbit feels slow to answer it is almost always one of these; all are
+UX-layer (none touch the checker or the fence), and the env defaults now ship
+tuned. In order of impact:
+
+1. **Keep the model resident.** The biggest per-turn cost is Ollama unloading
+   the model after ~5 min idle and cold-reloading it on the next turn.
+   `KIRRA_RABBIT_KEEP_ALIVE` (default `30m`; use `-1` on a dedicated robot) is
+   sent on every request to pin it. Residency only — it never changes the
+   model's output.
+2. **Max out the Jetson.** Run once at boot (not an env var — put it in a
+   systemd unit or `rc.local`):
+   ```bash
+   sudo nvpmodel -m 0 && sudo jetson_clocks
+   ```
+   Max power mode + locked clocks — the biggest inference speedup after keep-alive.
+3. **tiny.en for the wake listener** (`KIRRA_WAKE_STT_CMD`) so the always-on
+   detector sips CPU; keep `base.en` on `KIRRA_STT_CMD` for turn transcription.
+4. **VAD endpointing** for the turn recorder (`KIRRA_RECORD_CMD=…vad_record.py`)
+   so a terse command returns in ~1 s instead of the fixed `-d 4` window.
+5. **Event-driven re-arm + follow-up mode** (Slices R/F) so back-to-back
+   questions need neither a dead-window wait nor a fresh wake word.
+
+Optionally cap the reply length with `KIRRA_RABBIT_NUM_PREDICT` — but see the
+warning in `rabbit.env.example`: too low TRUNCATES the router's `{say, directive}`
+JSON and fail-closes to a dropped drive command, so re-run
+`rabbit_model_smoketest.py` at your chosen value first. The router/persona system
+prompt is deliberately **not** trimmed for speed: its length is load-bearing
+correctness (the "never null a drive request" guardrail + the routing examples).
+
+---
+
 ## Swapping the LLM (a newer/better model)
 
 The model is behind an HTTP seam, so a swap is **config-only** — no rebuild, and

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -108,6 +108,33 @@ KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
 #   python3 robot/rabbit_model_smoketest.py <candidate-model>
 KIRRA_OLLAMA_URL="http://localhost:11434"
 KIRRA_RABBIT_MODEL="gemma3:4b"
+# Keep the model RESIDENT between turns (Slice S) — the biggest per-turn latency
+# win on the Orin: without it Ollama unloads after ~5 min idle and the next turn
+# eats a multi-second cold reload. "30m" holds it after each request, "-1" pins
+# it indefinitely (best on a dedicated robot), "0" unloads at once. Residency
+# only — never changes the model's output, so it cannot affect the router or the
+# checker. Default "30m".
+#KIRRA_RABBIT_KEEP_ALIVE=-1
+# Reply-length cap (OPT-IN, default unset). The router emits a {say, directive}
+# JSON object; a too-tight cap TRUNCATES it and parse_reply fail-closes to
+# directive=null — a silently DROPPED drive command. Leave unset unless you have
+# re-run rabbit_model_smoketest.py at your chosen value and it still passes the
+# drive→directive cases (it imports the same options, so it catches a bad cap).
+#KIRRA_RABBIT_NUM_PREDICT=200
+
+# ── Speed & responsiveness (Slice S) — the proven levers, in one place ─────────
+# The Rabbit felt slow to reply mostly from LLM cold-reload + long capture. The
+# fixes, all persisted here (none touch the checker / the fence):
+#   1. KIRRA_RABBIT_KEEP_ALIVE (above) — kills the cold-reload stall. Biggest win.
+#   2. tiny.en for the WAKE listener (KIRRA_WAKE_STT_CMD above) — low idle CPU;
+#      keep base.en on KIRRA_STT_CMD for turn transcription quality.
+#   3. VAD endpointing for the turn recorder (KIRRA_RECORD_CMD=vad_record.py
+#      above) — a terse command returns in ~1 s instead of the fixed -d 4 window.
+#   4. Slice R re-arm + Slice F follow-up (above) — no dead window, no re-wake.
+#   5. OS governor (NOT env — run once at boot, e.g. a systemd unit / rc.local):
+#        sudo nvpmodel -m 0 && sudo jetson_clocks
+#      max power mode + locked clocks. The single biggest inference speedup after
+#      keep_alive; see docs/hardware/RABBIT_BRINGUP_RUNBOOK.md ("Speed").
 
 # ── Loop endpoints (localhost defaults; override only if you moved a service) ─
 KIRRA_VERIFIER_URL="http://localhost:8090"   # posture (/metrics), narration source

--- a/robot/rabbit_ask.py
+++ b/robot/rabbit_ask.py
@@ -52,6 +52,13 @@ TAJ = os.environ.get("KIRRA_TAJ_URL", "http://localhost:8101").rstrip("/")
 OLLAMA = os.environ.get("KIRRA_OLLAMA_URL", "http://localhost:11434").rstrip("/")
 MODEL = os.environ.get("KIRRA_RABBIT_MODEL", "gemma3:4b")
 FORWARD_CONE_RAD = math.radians(15.0)
+# Speed (Slice S): keep the model RESIDENT between turns so a follow-up doesn't
+# pay the cold-reload stall (the single biggest per-turn latency on the Orin).
+# Sent as Ollama's top-level `keep_alive`: "30m" holds it ~half an hour after a
+# request, "-1" pins it indefinitely, "0" unloads at once. UX-layer latency only
+# — keep_alive changes residency, never the model's OUTPUT, so it cannot affect
+# the router's directive decision or the checker.
+KEEP_ALIVE = (os.environ.get("KIRRA_RABBIT_KEEP_ALIVE") or "30m").strip()
 
 RABBIT_SYSTEM = (
     "You are Rabbit, the voice of a small self-driving robot. Your manner is "
@@ -227,7 +234,7 @@ def ask_ollama(question, context):
     back to a plain factual read)."""
     try:
         r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0, json={
-            "model": MODEL, "stream": False,
+            "model": MODEL, "stream": False, "keep_alive": KEEP_ALIVE,
             "messages": [
                 {"role": "system", "content": RABBIT_SYSTEM},
                 {"role": "user", "content": f"{context}\n\nOperator asks: {question}"},

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -44,8 +44,8 @@ except ImportError:
 # Reuse Stage 1's read-only grounding + persona + speak (robot/ is on sys.path[0]).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from rabbit_ask import (  # noqa: E402
-    RABBIT_SYSTEM, MICK, MODEL, OLLAMA, gather_perception, gather_posture,
-    gather_stop_reason, speak,
+    KEEP_ALIVE, RABBIT_SYSTEM, MICK, MODEL, OLLAMA, gather_perception,
+    gather_posture, gather_stop_reason, speak,
 )
 import rabbit_diag  # noqa: E402 — deterministic self-check voice command (read-only)
 import rabbit_ota  # noqa: E402 — deterministic OTA voice commands (NOT the movement door)
@@ -68,6 +68,15 @@ PERCEPTION_WORDS = ("see", "around", "ahead", "front", "obstacle", "clear",
 # imports THIS so the gate calls the model exactly as production does; a vetted
 # pass then predicts production behaviour instead of a lucky sample.
 ROUTER_LLM_OPTIONS = {"temperature": 0.1}
+# Speed (Slice S, OPT-IN): cap the reply length. DEFAULT UNSET — the router emits
+# a {say, directive} JSON object and a too-tight cap could TRUNCATE it, which
+# parse_reply fail-closes to directive=None (a silently DROPPED drive command).
+# So this is opt-in and must be generous (>= a full reply's JSON); the model-swap
+# smoketest imports ROUTER_LLM_OPTIONS, so a value that starts truncating the
+# directive is caught by its drive→directive assertions before you ship it.
+_num_predict = (os.environ.get("KIRRA_RABBIT_NUM_PREDICT") or "").strip()
+if _num_predict.lstrip("-").isdigit():
+    ROUTER_LLM_OPTIONS["num_predict"] = int(_num_predict)
 
 STAGE2_SYSTEM = (
     RABBIT_SYSTEM
@@ -123,7 +132,7 @@ def ask_llm(history, context, utterance):
     try:
         r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0,
                           json={"model": MODEL, "stream": False, "messages": messages,
-                                "options": ROUTER_LLM_OPTIONS})
+                                "keep_alive": KEEP_ALIVE, "options": ROUTER_LLM_OPTIONS})
         if r.status_code != 200:
             return None, None
         raw = (r.json().get("message", {}).get("content") or "").strip()
@@ -144,7 +153,7 @@ def ask_llm_skills(history, context, utterance):
     try:
         r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0,
                           json={"model": MODEL, "stream": False, "messages": messages,
-                                "options": ROUTER_LLM_OPTIONS})
+                                "keep_alive": KEEP_ALIVE, "options": ROUTER_LLM_OPTIONS})
         if r.status_code != 200:
             return ""
         return (r.json().get("message", {}).get("content") or "").strip()
@@ -164,7 +173,7 @@ def ask_llm_mission(history, context, utterance):
     try:
         r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0,
                           json={"model": MODEL, "stream": False, "messages": messages,
-                                "options": ROUTER_LLM_OPTIONS})
+                                "keep_alive": KEEP_ALIVE, "options": ROUTER_LLM_OPTIONS})
         if r.status_code != 200:
             return ""
         return (r.json().get("message", {}).get("content") or "").strip()

--- a/robot/rabbit_model_smoketest.py
+++ b/robot/rabbit_model_smoketest.py
@@ -60,7 +60,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # The REAL production contract — same system prompt + lenient fail-closed parser
 # the live router uses. Testing anything else would be testing a fiction.
 from rabbit_converse import (  # noqa: E402
-    OLLAMA, ROUTER_LLM_OPTIONS, STAGE2_SYSTEM, parse_reply,
+    KEEP_ALIVE, OLLAMA, ROUTER_LLM_OPTIONS, STAGE2_SYSTEM, parse_reply,
 )
 from rabbit_ask import MODEL as DEFAULT_MODEL  # noqa: E402
 from rabbit_persona import (  # noqa: E402
@@ -101,6 +101,7 @@ def chat(model, utterance):
     try:
         r = requests.post(f"{OLLAMA}/api/chat", timeout=60.0,
                           json={"model": model, "stream": False, "messages": messages,
+                                "keep_alive": KEEP_ALIVE,       # mirror production residency
                                 "options": ROUTER_LLM_OPTIONS})  # mirror production sampling
         if r.status_code != 200:
             return None


### PR DESCRIPTION
## What

Persists the proven latency fixes from the physical Rabbit bring-up so a fresh deploy is fast by default — none of it touches the checker or the fence.

## Changes

- **`keep_alive` (the biggest per-turn win).** Ollama unloads the model after ~5 min idle and cold-reloads on the next turn. Every `/api/chat` request now sends a top-level `keep_alive` (`KIRRA_RABBIT_KEEP_ALIVE`, default `"30m"`, `"-1"` to pin) so the model stays resident. **Residency only — never changes the model's output**, so it cannot affect the router's directive decision or the checker. Wired into `rabbit_ask`, `rabbit_converse` (all three calls), and mirrored in `rabbit_model_smoketest`.
- **`num_predict` (opt-in reply-length cap).** `KIRRA_RABBIT_NUM_PREDICT`, **default UNSET**. Kept opt-in because a too-tight cap **truncates the router's `{say, directive}` JSON** and `parse_reply` fail-closes to a dropped drive command. It lives in `ROUTER_LLM_OPTIONS`, which the model-swap smoketest imports — so a bad value is caught by the smoketest's drive→directive assertions before you ship it.
- **Docs.** `rabbit.env.example` gains a **"Speed & responsiveness"** section consolidating every lever (keep-alive, tiny.en wake model, VAD endpointing, Slice R/F re-arm, `nvpmodel -m 0` + `jetson_clocks`); `RABBIT_BRINGUP_RUNBOOK.md` gains a **"Speed"** section.

## Deliberately NOT done

The router/persona system prompt is **not** trimmed for speed. Its length is load-bearing correctness — the *"never null a drive request"* guardrail and the routing examples — and there is no CI gate on it, so trading it for a few hundred prompt tokens would risk the drive classifier. Documented as such in the runbook.

## Verification

- `python3 robot/rabbit_voice_test.py` → 18/18, `robot/wake_word_test.py` → ALL OK, `robot/turn_state_test.py` → 12/12 — all unchanged.
- Wiring checked under both default and opt-in: default is `keep_alive="30m"` with **no** `num_predict` cap (output byte-identical); `KIRRA_RABBIT_NUM_PREDICT=200 KIRRA_RABBIT_KEEP_ALIVE=-1` correctly threads through. `rabbit_model_smoketest` imports clean with the `KEEP_ALIVE` mirror.

Defaults change model **residency** only; generated output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_