### PR TITLE
feat(robot): kirra-lidar.service — YDLIDAR driver as a boot service

### DIFF
--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -53,7 +53,8 @@ fi
 
 # ---- 2. render + install the units -----------------------------------------
 echo "== 2. units -> /etc/systemd/system =="
-for u in kirra-ros-stack.service kirra-rabbit-watch.service kirra-rabbit-greet.service \
+for u in kirra-ros-stack.service kirra-lidar.service \
+         kirra-rabbit-watch.service kirra-rabbit-greet.service \
          kirra-rabbit-voice.service \
          kirra-ota-check.service kirra-ota-check.timer \
          kirra-doctor.service kirra-doctor.timer; do

--- a/robot/install/systemd/kirra-lidar.service
+++ b/robot/install/systemd/kirra-lidar.service
@@ -1,0 +1,46 @@
+# kirra-lidar.service — the YDLIDAR TG30 driver as a boot service, so `/scan` is
+# always publishing (real perception for "what do you see" + the governed loop)
+# without keeping a terminal open.
+#
+# Publishes /scan @ ~10 Hz from `ydlidar_ros2_driver` on `/dev/ydlidar`
+# (baud 512000, TG30 — the VALIDATED hardware; the image's `my_lidar=4ROS`
+# marker is WRONG for this unit, see docs/hardware/ROSMASTER_X3_BRINGUP.md §6 +
+# installer/platform_map.toml).
+#
+# 🔴 Perception INPUT only / Channel A. It publishes a sensor topic; it has NO
+#    path to actuation — the checker still bounds every command. Kept separate
+#    from kirra-ros-stack (occy_doer + interceptor) by design.
+#
+# ROS_DOMAIN_ID must match the rest of the ROS graph (the motor consumer + taj +
+# rabbit). It is read from /etc/kirra/robot.env, defaulting to 28 (this unit's
+# domain) — a mismatched domain means /scan is invisible to rabbit.
+#
+# INSTALL (deliberate opt-in — confirm the manual launch works first:
+#   `ros2 launch ydlidar_ros2_driver ydlidar_launch.py` + `ros2 topic hz /scan`):
+#   sudo systemctl enable --now kirra-lidar.service
+#   ros2 topic hz /scan          # verify ~10 Hz
+# Staged to /etc/systemd/system by install_robot_units.sh, which renders User=
+# to the invoking user (same idiom as kirra-ros-stack / kirra-consumer).
+
+[Unit]
+Description=Kirra YDLIDAR driver (publishes /scan for perception)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+After=multi-user.target
+Wants=multi-user.target
+
+[Service]
+Type=simple
+User=__KIRRA_ROBOT_USER__
+EnvironmentFile=-/etc/kirra/robot.env
+# Source ROS 2 (+ the ws overlay so ydlidar_ros2_driver is found wherever it
+# lives — best-effort: if only the base install has it, the ws source is a
+# no-op), force the shared domain, then exec the driver as the main PID so
+# SIGTERM tears the launch down cleanly.
+ExecStart=/bin/bash -c 'source /opt/kirra/robot/ros_env.sh && kirra_source_ros && { source "${KIRRA_ROS_WS_SETUP:-/home/__KIRRA_ROBOT_USER__/kirra-runtime-sdk/ros2_ws/install/setup.bash}" 2>/dev/null || true; }; export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-28}"; exec ros2 launch ydlidar_ros2_driver ydlidar_launch.py'
+# A transient serial hiccup should recover; a persistent one backs off (not a
+# hot loop).
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## What

Perception depended on keeping a terminal running `ros2 launch ydlidar_ros2_driver ydlidar_launch.py` — close it or reboot and `/scan` stops, so "what do you see?" correctly falls to "perception unavailable" (verified live on the `yahboom` unit). Adds an **opt-in** systemd service that runs the YDLIDAR driver on boot so `/scan` is always publishing (~10 Hz).

## How

Modeled on `kirra-ros-stack.service`:
- Sources ROS via `ros_env.sh` + the ws overlay (best-effort — a base-install `ydlidar_ros2_driver` also works).
- Forces `ROS_DOMAIN_ID` from `robot.env`, **default 28** to match the motor consumer + taj + rabbit graph (a mismatched domain makes `/scan` invisible to rabbit).
- `exec`s the driver as the main PID (clean SIGTERM), `Restart=on-failure`.
- Staged by `install_robot_units.sh` with `User=` rendered to the invoking user; **NOT auto-enabled** — deliberate opt-in after confirming the manual launch + `ros2 topic hz /scan`.

🔴 Perception **input only** / Channel A — publishes a sensor topic, has no path to actuation; the checker still bounds every command. Kept separate from `kirra-ros-stack` (occy + interceptor) by design.

## Install (on the robot, after merge + re-stage)

```
sudo systemctl enable --now kirra-lidar.service
ros2 topic hz /scan          # verify ~10 Hz
```

## Verification

`bash -n install_robot_units.sh` OK; the unit is added to the installer's render loop (confirmed the `User=` placeholder path). The validated hardware config (YDLIDAR TG30 / `/dev/ydlidar` / 512000, not the image's `4ROS` marker) matches `installer/platform_map.toml` and `docs/hardware/ROSMASTER_X3_BRINGUP.md §6`, and was just confirmed live (`/scan` steady at 10.18 Hz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_