### PR TITLE
fix(robot): rabbit_voice.sh sources ROS so the service grounds perception

### DIFF
--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -140,6 +140,12 @@ KIRRA_RABBIT_MODEL="gemma3:4b"
 KIRRA_VERIFIER_URL="http://localhost:8090"   # posture (/metrics), narration source
 KIRRA_MICK_URL="http://localhost:8102"        # POST /intent (the door), /narration/last
 KIRRA_TAJ_URL="http://localhost:8101"         # perception snapshot ("what do you see")
+# ROS domain — MUST match the lidar (kirra-lidar.service) so rabbit_converse's
+# rclpy can subscribe to /scan for "what do you see". A systemd service does not
+# inherit your login shell's ROS_DOMAIN_ID, so set it here (rabbit_voice.sh sources
+# ROS + exports this); without it rclpy defaults to domain 0 and perception reads
+# "unavailable" even while the lidar publishes. Match your robot's domain (28 here).
+ROS_DOMAIN_ID=28
 
 # ── "Why did we stop" + proactive deny events need the #893 narration relay ──
 # mick_service must be started with KIRRA_VERIFIER_URL + an AUDITOR-role token so

--- a/robot/rabbit_voice.sh
+++ b/robot/rabbit_voice.sh
@@ -22,6 +22,24 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Optional shared env (STT/TTS/RECORD live here — see robot/install/rabbit.env.example)
 if [ -f /etc/kirra/robot.env ]; then set -a; . /etc/kirra/robot.env; set +a; fi
 
+# Perception grounding ("what do you see") needs ROS in the process env so
+# rabbit_converse's rclpy can subscribe to /scan. A systemd service does NOT
+# inherit a login shell's ROS setup, so under the service that subscribe fails and
+# perception reads "unavailable" even though the lidar is publishing — while it
+# works fine from a sourced terminal. Source ROS best-effort here so the service is
+# self-sufficient; fail-soft (a no-op if ROS isn't installed — the perception grab
+# already degrades gracefully). ROS_DOMAIN_ID must match the lidar's — set it in
+# robot.env (the sourced env above exports it), else rclpy defaults to domain 0 and
+# never sees /scan.
+if [ -f "${HERE}/ros_env.sh" ]; then
+  # shellcheck source=/dev/null
+  . "${HERE}/ros_env.sh"
+  kirra_source_ros || true
+  if [ -n "${KIRRA_ROS_WS_SETUP:-}" ] && [ -f "${KIRRA_ROS_WS_SETUP}" ]; then
+    set +u; . "${KIRRA_ROS_WS_SETUP}" || true; set -u
+  fi
+fi
+
 if [ -z "${KIRRA_STT_CMD:-}" ]; then
   echo "FATAL: KIRRA_STT_CMD required (e.g. \"whisper-cli -m models/ggml-base.en.bin -np -nt -f\")" >&2
   exit 1


### PR DESCRIPTION
## What

"what do you see?" read **"perception unavailable"** under the `rabbit-voice` systemd service even with the lidar publishing `/scan` — while `python3 robot/rabbit_ask.py "what do you see"` from a sourced terminal returned a full real answer. Confirmed live on `yahboom`.

## Root cause

A **systemd service does not inherit a login shell's ROS setup** (no `.bashrc`), so `rabbit_converse`'s `gather_perception` couldn't `import rclpy` / subscribe to `/scan`. It "worked" before only because the pre-reboot service had inherited ROS env from the shell that started it; a clean boot starts the user service with a bare environment.

## Fix

- **`rabbit_voice.sh`** sources ROS best-effort (via `ros_env.sh` + the ws overlay) right after `robot.env`, so the service is self-sufficient. Fail-soft — a no-op if ROS isn't installed (dev machines), and `gather_perception` already degrades gracefully. Since the service runs `rabbit_voice.sh`, its child `rabbit_converse` inherits ROS.
- **`rabbit.env.example`** documents `ROS_DOMAIN_ID` — it MUST match the lidar's domain (`rabbit_voice.sh` exports it from `robot.env`); without it `rclpy` defaults to domain 0 and never sees `/scan`.

🔴 Channel A — sourcing ROS for a read-only `/scan` subscribe; no path to actuation.

## Verification

`bash -n robot/rabbit_voice.sh` OK. The perception chain itself is already proven live (rabbit_ask from a sourced shell returns "one obstacle ~1 m ahead, 5 objects, ~10 m corridor"); this fix just gives the *service* the same ROS env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_