### PR TITLE
docs(hardware): capture 2026-07 R2 bench findings (voice hardening + field diagnostics)

### DIFF
--- a/docs/hardware/R2_FIELD_DIAGNOSTICS.md
+++ b/docs/hardware/R2_FIELD_DIAGNOSTICS.md
@@ -1,0 +1,156 @@
+# R2 field diagnostics — recipes from the bench
+
+Reusable "why isn't it doing the thing" recipes for the R2 (Jetson Orin NX),
+distilled from real bench sessions. Each is copy-pasteable and tells you what a
+PASS vs FAIL looks like. Companion to `R2_VOICE_AUDIO_SETUP.md` (voice) and
+`PLATFORM_R2_PENDING.md` (the r2 class gate).
+
+---
+
+## 1. "It won't creep / it needs too much space" — is the lidar seeing the robot?
+
+**Symptom:** occy accepts a goal (`new goal: (x, y)`) but proposes zero
+(`/cmd_vel_raw` stays `linear.x: 0`), so the wheels never turn — even in an open
+room. Everything else looks healthy (odom, `/scan` at rate, both sidecars up).
+
+**Root cause we hit (2026-07):** the depth **camera / lidar adapter was sitting
+in the lidar's horizontal scan plane**, ~0.35 m in front. The lidar read its own
+mount as a wall, Taj's corridor pinched shut, and the planner correctly
+`safe_stop`-ed. It was never the governor or the vehicle-class envelope.
+
+### 1a. QoS gotcha (read this first)
+`/scan` is published **BEST_EFFORT** (sensor-data QoS). A probe subscriber that
+defaults to RELIABLE receives **nothing** and you'll misread "no data" as "clear
+ahead". Always subscribe with `qos_profile_sensor_data`.
+
+### 1b. Closest-obstacle-ahead probe
+```bash
+source /opt/ros/humble/setup.bash
+source ~/kirra-runtime-sdk/ros2_ws/install/setup.bash
+export ROS_DOMAIN_ID=28
+python3 - <<'EOF'
+import rclpy, math, time
+from sensor_msgs.msg import LaserScan
+from rclpy.qos import qos_profile_sensor_data
+rclpy.init(); n=rclpy.create_node('probe'); got={}
+def cb(m):
+    fwd=[]; a=m.angle_min
+    for r in m.ranges:
+        if abs(math.atan2(math.sin(a),math.cos(a)))<math.radians(15) and m.range_min<r<m.range_max: fwd.append(r)
+        a+=m.angle_increment
+    got['min']=min(fwd) if fwd else None
+n.create_subscription(LaserScan,'/scan',cb,qos_profile_sensor_data)
+t=time.time()
+while 'min' not in got and time.time()-t<5: rclpy.spin_once(n,timeout_sec=0.5)
+print('FORWARD closest (m):', got.get('min'))
+rclpy.shutdown()
+EOF
+```
+
+### 1c. The self-occlusion test (the decisive one)
+**Move the robot.** If the closest-forward range **doesn't change**, the return
+is *on the robot* — a mount, cable, or the camera in the scan plane. Confirm the
+bearing (swap the callback body for this to print the 10 nearest hits):
+```python
+    pts=[]; a=m.angle_min
+    for r in m.ranges:
+        deg=math.degrees(math.atan2(math.sin(a),math.cos(a)))
+        if -40<deg<40 and m.range_min<r<m.range_max: pts.append((deg,r))
+        a+=m.angle_increment
+    pts.sort(key=lambda p:p[1]); got['near']=pts[:10]   # then: print(got['near'])
+```
+A tight cluster at a **fixed bearing and range** (ours: +9°→+12°, 0.347–0.359 m,
+a 12 mm spread) = a rigid on-robot surface. Environmental returns scatter and
+move when the robot does.
+
+### 1d. Fixes (in order of preference)
+1. **Physical (best):** raise the lidar above the camera, or move the
+   camera/adapter out of the horizontal scan plane. Re-run 1b — the number
+   should jump to the real room distance.
+2. **Software stopgap:** mask just the offending angular wedge on `/scan` before
+   perception consumes it. Keep it **narrow** (only the degrees the mount
+   occupies) — that sector is physically blind anyway, so masking loses no real
+   perception, but a *wide* mask blinds the robot. This is a workaround, not a
+   substitute for remounting; treat a masked wedge as "occluded", never "known
+   clear".
+
+> Rule of thumb: the r2 envelope wants ~0.5 m of standoff, so occy needs
+> **≳0.8 m of genuinely clear runway ahead** before it will commit to a creep.
+> A cluttered bench with anything inside ~0.6 m will (correctly) hold.
+
+---
+
+## 2. r2 vehicle-class switch — the as-applied procedure + what "healthy" looks like
+
+The three flip sites (gated — see `PLATFORM_R2_PENDING.md` "THE FLIP"):
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `installer/platform_map.toml` | `[platform.r2] profile_class` `"courier"` → `"r2"` (runtime-inert; installer-verify metadata) |
+| 2 | `ros2_ws/src/kirra_safety/config/kirra_params.yaml` | interceptor `wheelbase_m` → `0.229` (**runtime-critical**) |
+| 3 | `/etc/kirra/kirra.env` | `KIRRA_VEHICLE_CLASS=courier` → `r2` (**runtime-critical**; verifier reads it) |
+
+Apply → restart **verifier first**, confirm, then the ros-stack:
+```bash
+sudo systemctl restart kirra-verifier.service
+sudo journalctl -u kirra-verifier.service -n 40 --no-pager | grep -i 'vehicle_class'
+#   PASS: … vehicle class selected … vehicle_class="r2"
+sudo systemctl restart kirra-ros-stack.service     # reloads the interceptor's 0.229
+```
+
+**Expected, not-a-bug:** in the seconds between the two restarts the *old*
+interceptor (still 0.229 vs a just-restarted verifier, or vice-versa) may log a
+`🔴 WHEELBASE MISMATCH … LATCHED to stop`. That's the fast-loop refusing to
+convert Twist→steering with a wheelbase the verifier didn't sign — it clears the
+instant the fresh interceptor comes up matched. A **persistent** mismatch after
+both are up = sites 2 and 3 disagree; make both `0.229`/`r2`.
+
+**Config-with-symlink-install note:** if `ros2_ws/install/.../kirra_params.yaml`
+is a symlink chain back to `src/` (check with `ls -l`), your edit is already live
+— just restart, no `colcon` rebuild. If it's a real copy, rebuild the one
+package: `colcon build --symlink-install --packages-select kirra_safety`.
+
+> These edits are **uncommitted working-tree changes on the robot** and the r2
+> flip is gated (4 bench measurements + dynamic-limit benching + review still
+> owed). Do **not** `git stash`/`checkout` on the robot — you'll revert to
+> courier. `/etc/kirra/kirra.env` is a system file, unaffected by git.
+
+---
+
+## 3. Networking — reach the robot without the Ethernet cable
+
+> Scope: this is the **connectivity/SSH** recipe (how *you* reach the box).
+> `R2_UNTETHERED_BRINGUP.md` is the complementary **driving-off-network**
+> architecture — and its load-bearing point still holds here: the WiFi/SSH link
+> is *not* in the control loop, so none of this touches how the robot drives.
+
+**The reality on this unit:** the WiFi radio (`wlP1p1s0`) runs in **AP mode** —
+it *hosts* the `ROSMASTER` hotspot (`iw dev wlP1p1s0 info` → `type AP`, ch 1,
+2.4 GHz). A single radio in AP mode **cannot scan for or join another WiFi**, and
+`ROSMASTER` has **no internet uplink**. The robot's internet (and therefore
+Tailscale) rides the **Ethernet** cable.
+
+Confirm the picture:
+```bash
+iw dev wlP1p1s0 info | grep -iE 'type|ssid|channel'   # type AP  ssid ROSMASTER
+ip route | grep default                               # default via …dev eno1 = internet is on Ethernet
+tailscale status                                      # robot 100.x + your phone as a peer
+```
+
+Two ways off the cable:
+
+- **A — LAN-direct over `ROSMASTER` (works immediately, no changes):** join your
+  **phone** to the `ROSMASTER` WiFi (its PSK: `sudo nmcli connection show
+  ROSMASTER | grep -i psk`), then `ssh jetson@192.168.1.11`. No internet, only
+  reachable when you're near the robot. **This is the one that needs a WiFi
+  password (on the phone).**
+- **B — Tailscale from anywhere (needs internet on the robot):** the robot must
+  be a WiFi **client** of a router with internet, which means switching the radio
+  **AP → client mode first** (tear down the `ROSMASTER` AP), then
+  `sudo nmcli device wifi connect "<home-ssid>" password "<psk>"`. Then
+  `ssh` to the robot's Tailscale IP (stable, e.g. `100.x.y.z`) from anywhere —
+  **no WiFi password on the phone side.** Bigger reconfigure; do it wired so a
+  failed join is recoverable.
+
+**SSH never uses the WiFi password** — that authenticates with the `jetson`
+login. The WiFi PSK only gets a *device onto a network*.

--- a/docs/hardware/R2_UNTETHERED_BRINGUP.md
+++ b/docs/hardware/R2_UNTETHERED_BRINGUP.md
@@ -250,6 +250,7 @@ swap them freely without touching the safety loop.
 5. **Fleet (later)** — Zenoh transport when you go multi-robot.
 
 ## References
+- `docs/hardware/R2_FIELD_DIAGNOSTICS.md` — the concrete SSH-connectivity recipe (Tailscale / the `ROSMASTER` AP / reach `jetson@192.168.1.11` off the cable), plus the lidar-self-occlusion and r2-switch bench recipes
 - `docs/hardware/R2_LIVE_LOOP_BRINGUP.md` — the tethered governed loop (Stages 1–2)
 - `docs/testing/SPEECH_RABBIT_DEMO.md` — the voice UX (whisper.cpp / Piper, env, CI)
 - `robot/install/install_kirra.sh` — installer + the staged `kirra-consumer.service`

--- a/docs/hardware/R2_VOICE_AUDIO_SETUP.md
+++ b/docs/hardware/R2_VOICE_AUDIO_SETUP.md
@@ -31,6 +31,18 @@ arecord -D plughw:3,0 -d 3 -f S16_LE -r 16000 -c 1 /tmp/t.wav && aplay -D plughw
 Use `plughw:` (not `hw:`) so ALSA converts the sample rate/format (the speaker
 runs 48 kHz; piper is 22050 Hz).
 
+> **Prefer the device-NAME address, not the number.** ALSA card numbers move
+> across reboots/replugs — on the 2026-07 hardening pass the mic came back as
+> card **1**, not the card **3** in the table above (same physical device). The
+> **names** held. Use the name form everywhere (`speak.sh`, `KIRRA_RECORD_CMD`,
+> `amixer -c`), and you never chase a renumber:
+> ```bash
+> # find the stable NAME token (the [id] in brackets), then use plughw:CARD=<id>:
+> aplay -l   | sed -n 's/^card [0-9]*: \([^ ]*\).*/speaker id: \1/p'
+> arecord -l | sed -n 's/^card [0-9]*: \([^ ]*\).*/mic id:     \1/p'
+> #  → speaker: plughw:CARD=UACDemoV10,DEV=0     mic: plughw:CARD=Device,DEV=0
+> ```
+
 ---
 
 ## 1. STT — whisper.cpp (`whisper-cli`)
@@ -55,23 +67,35 @@ Both the `.onnx` (~60 M) and its `.onnx.json` are required. If piper errors on a
 missing `.so`, run with `LD_LIBRARY_PATH=~/piper` (and bake that into `speak.sh`).
 
 ## 3. `speak.sh` (TTS wrapper — text on stdin → speaker)
-`~/kirra-runtime-sdk/speak.sh` (the `-D plughw:0,0` is the **speaker** device):
+Keep it **OUTSIDE the git checkout** — `/opt/kirra/robot/speak.sh`. Use the
+speaker's **name** (`plughw:CARD=UACDemoV10,DEV=0`), not `plughw:0,0`:
 ```bash
+sudo install -d -m0755 /opt/kirra/robot
+sudo tee /opt/kirra/robot/speak.sh >/dev/null <<'SH'
 #!/usr/bin/env bash
 exec ~/piper/piper --model ~/piper/en_US-lessac-medium.onnx --output-raw \
-  | aplay -D plughw:0,0 -r 22050 -f S16_LE -t raw -
+  | aplay -D plughw:CARD=UACDemoV10,DEV=0 -r 22050 -f S16_LE -t raw -
+SH
+sudo chmod +x /opt/kirra/robot/speak.sh
 ```
-`chmod +x ~/kirra-runtime-sdk/speak.sh`
+> **⚠ Why out of the repo (learned the hard way, 2026-07):** an untracked
+> `speak.sh` *inside* the checkout gets swept by `git stash push -u` /
+> `git clean` during any branch-cleanup — and TTS then dies with a silent
+> `FileNotFoundError` while wake/STT/LLM all still look fine. Living under
+> `/opt/kirra/robot/` makes it immune to every git operation. Point
+> `KIRRA_TTS_CMD` at that path (§4).
 
 ## 4. Env — `/etc/kirra/robot.env` (the single source every Rabbit script sources)
 ```bash
 KIRRA_STT_CMD="whisper-cli -m /home/jetson/whisper.cpp/models/ggml-base.en.bin -np -nt -f"
-KIRRA_TTS_CMD="/home/jetson/kirra-runtime-sdk/speak.sh"
-KIRRA_RECORD_CMD="arecord -D plughw:3,0 -d 4 -f S16_LE -r 16000 -c 1"   # -D = the MIC device
+KIRRA_TTS_CMD="/opt/kirra/robot/speak.sh"                                   # git-safe path (§3)
+KIRRA_RECORD_CMD="arecord -D plughw:CARD=Device,DEV=0 -d 4 -f S16_LE -r 16000 -c 1"  # -D = the MIC (name, not number)
+# (optional) let rabbit_converse ground perception ("what do you see?") — see §7:
+# KIRRA_ROS_SETUP="/opt/ros/humble/setup.bash"
 # (optional) verdict-narration voice — an AUDITOR-role token, never the admin token:
 # KIRRA_MICK_AUDITOR_TOKEN="<auditor principal token>"
 ```
-Only the two `-D plughw:X,0` values and the real paths differ from
+Only the two `-D plughw:CARD=…` values and the real paths differ from
 `robot/install/rabbit.env.example`. `-d 4` is the record window (drop to `-d 3`
 for snappier turns).
 
@@ -105,6 +129,59 @@ The ROS 2 apt repo key expired (`EXPKEYSIG F42ED6FBAB17C654`); refresh it so
 sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
   -o /usr/share/keyrings/ros-archive-keyring.gpg && sudo apt update
 ```
+
+## 7. Field hardening (2026-07 bring-up — the non-obvious stuff)
+
+Three things that made the difference between "silent/quiet/deaf" and "works",
+none of them in the engine setup above:
+
+### 7a. ALSA mixer levels — and PERSIST them (they reset on reboot)
+Fresh boots came up with the mic gain low (barely-heard wake word) and the
+speaker hot. Set the levels, then **store** them — otherwise ALSA resets to
+defaults on the next reboot and you re-debug "it stopped hearing/speaking":
+```bash
+# control names vary by device — list them first, per card (use the NAME, §0):
+amixer -c Device   scontrols          # mic card
+amixer -c UACDemoV10 scontrols        # speaker card
+# this unit — boost mic capture/AGC to full, set speaker to a comfortable 80%:
+amixer -c Device   sset 'Auto Gain Control' 100% 2>/dev/null || true
+amixer -c Device   sset 'Mic'  100% cap  2>/dev/null || true
+amixer -c UACDemoV10 sset 'PCM' 80%
+# PERSIST across reboot (without this, every reboot silently reverts the above):
+sudo alsactl store
+```
+80% on the speaker was the sweet spot on this unit — 100% was uncomfortably loud
+in a room. Re-run + `alsactl store` after any reflash.
+
+### 7b. Let the voice service GROUND perception ("what do you see?")
+`rabbit_converse` can only answer perception questions if it has a **full ROS
+environment** (`ROS_DISTRO`/`AMENT_PREFIX_PATH`), not just `ROS_DOMAIN_ID`. A
+bare systemd `--user` service that only exports the domain id answers "I can't
+see" to everything. Source ROS in the unit via a drop-in (adjust the unit name
+to your voice service):
+```bash
+mkdir -p ~/.config/systemd/user/rabbit-voice.service.d
+cat > ~/.config/systemd/user/rabbit-voice.service.d/10-ros.conf <<'EOF'
+[Service]
+# Source the ROS base (and the ws overlay if the node needs custom msgs) before exec.
+ExecStart=
+ExecStart=/usr/bin/env bash -lc 'source "${KIRRA_ROS_SETUP:-/opt/ros/humble/setup.bash}" && exec /opt/kirra/robot/rabbit_voice.sh'
+EOF
+systemctl --user daemon-reload && systemctl --user restart rabbit-voice.service
+# confirm the running process actually has ROS (not just the domain id):
+tr '\0' '\n' < /proc/$(pgrep -f rabbit_converse | head -1)/environ | grep -E 'ROS_DISTRO|AMENT_PREFIX'
+```
+Set `KIRRA_ROS_SETUP` in `/etc/kirra/robot.env` if your ROS lives elsewhere.
+
+### 7c. Resource contention degrades the local LLM router
+Running the drive stack + Ollama + whisper concurrently on the Orin starves the
+gemma router: it starts returning `directive: null` or mis-classifying (e.g. a
+movement request → `cruise`, which carries no goal and is ignored). Mitigations:
+use the **router's own example phrasing** ("creep forward one meter" parses far
+more reliably than "drive forward"); don't run a big `colcon`/`cargo` build in
+the same window as a voice turn; and for a clean deterministic drive trigger,
+publish a `/goal_pose` directly instead of going through STT→LLM (see
+`ros2_ws/.../occy_doer.py` — it subscribes `/goal_pose`).
 
 ---
 


### PR DESCRIPTION
## Summary

Reconciles the R2 (Jetson Orin NX) hardware docs with what was actually configured and debugged on the bench during the 2026-07 sessions, so the hard-won operational details survive a reflash / a second unit instead of being re-derived from scratch. **Docs only — no code, no behavior change.**

## `R2_VOICE_AUDIO_SETUP.md` — reconciled with reality
- **Prefer stable device NAMES over ALSA card numbers.** The mic re-enumerated card 3 → card 1 across a reflash; the numbers move, the device names hold. The old `plughw:0,0` / `plughw:3,0` examples would have sprung exactly that trap.
- **Relocated `speak.sh` out of the git checkout** to `/opt/kirra/robot/speak.sh`, with the *why*: an untracked `speak.sh` inside the repo gets swept by `git stash -u` / `git clean` during branch cleanup, and TTS then dies with a silent `FileNotFoundError` while wake/STT/LLM all still look healthy. `KIRRA_TTS_CMD` repointed accordingly.
- **New §7 field hardening** — the non-obvious stuff that isn't in the engine setup: ALSA mixer levels + `alsactl store` (they silently reset on reboot otherwise), the ROS-sourcing systemd drop-in that lets `rabbit_converse` ground perception ("what do you see?"), and the resource-contention note (concurrent drive + Ollama + whisper degrades the local gemma router).

## `R2_FIELD_DIAGNOSTICS.md` (new) — reusable bench recipes
- **Lidar self-occlusion** — diagnosing "won't creep / needs too much space" when the depth camera / lidar adapter sits in the horizontal scan plane and reads as a wall. Includes the `/scan` **BEST_EFFORT QoS** gotcha (a RELIABLE subscriber gets zero messages), the move-the-robot invariance test, and the fixed-bearing/range cluster signature.
- **The r2 vehicle-class switch as-applied** — the 3 flip sites, verifier-first restart, the *expected* transient `WHEELBASE MISMATCH … LATCHED` during the restart window, and the symlink-install config note. Points at the gated `PLATFORM_R2_PENDING.md` for the flip authority.
- **Networking reality** — `ROSMASTER` is the robot's own AP (`type AP`, 2.4 GHz, no internet uplink) → Tailscale rides Ethernet → the two untethered-SSH options (LAN-direct over `ROSMASTER`, vs AP→client onto a home WiFi for Tailscale-from-anywhere).

Cross-linked with `R2_UNTETHERED_BRINGUP.md` (architecture) so readers see the distinction between the driving-off-network design and the concrete connectivity recipe.

## Test plan
Documentation only. The SDK-docs CI lane is a `cargo doc` (rustdoc) build, which markdown changes don't affect. No runtime, API, or config surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoequnLBhG4EcNywrMsBmr)_