### PR TITLE
robot(rabbit): GPU/CUDA doctor + first-clause streaming reply-to-TTS (opt-in)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1324,6 +1324,11 @@ jobs:
           # voice matcher (no OTA/drive overlap), speech-summary capping, and
           # the voice-doctor wrapper against a stub. See docs/diagnostics.md.
           python3 robot/kirra_doctor_test.py
+          # GPU/CUDA doctor module (pure, no GPU): Tegra detection, the CUDA/
+          # TensorRT/nvidia-smi classifiers, and the load-bearing Ollama-offload
+          # check (resident-on-CPU → WARN, on-GPU → PASS, idle → UNKNOWN) — plus a
+          # bounded, never-FAIL live run on a GPU-less host. See robot/doctor/modules/gpu.py.
+          python3 robot/gpu_doctor_test.py
           # Detecting-installer contract (R2 golden build): detect/verify/install
           # are fail-closed (wrong car-type mode, unknown platform, missing
           # devices all refuse with remediation) and SELECT-NOT-INFER holds (the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1306,6 +1306,17 @@ jobs:
           # a stale field, and assemble leaving an 'unavailable' source UNKNOWN
           # (fail-closed). The live gather is the seam. See robot/world_model.py.
           python3 robot/world_model_test.py
+          # Streaming reply-to-TTS parser (pure, no HTTP/LLM): a directive-first
+          # CHAT stream voices its say as clean unescaped clauses AS THEY ARRIVE, a
+          # DRIVE stream voices NOTHING before routing, and any non-directive-first
+          # / malformed stream gives up → the caller falls back to today's exact
+          # non-streaming path. See robot/rabbit_stream.py.
+          python3 robot/rabbit_stream_test.py
+          # Streaming integration wiring (skips where requests is absent, e.g. this
+          # lane): the gate defaults OFF, the directive-first prompt PRESERVES the
+          # routing guardrails, and parse_reply (the fail-closed directive authority)
+          # is order-agnostic. See robot/rabbit_converse.py.
+          python3 robot/rabbit_stream_integration_test.py
           # Mission Executive (pure, no LLM/HTTP): fail-closed plan parsing,
           # validate REFUSING a mission with any unsupported skill before any
           # motion, and THE single-door invariant in run_mission — motion routes

--- a/docs/hardware/JETSON_CUDA_SETUP.md
+++ b/docs/hardware/JETSON_CUDA_SETUP.md
@@ -1,0 +1,108 @@
+# Jetson (Orin NX) CUDA setup — getting the DOERS on the GPU
+
+Companion to the `gpu` diagnostics module (`robot/doctor/modules/gpu.py`). This
+is the runbook its WARNs point at. It configures CUDA acceleration for the
+components that actually benefit, and is explicit about the one component that
+must **not** move to the GPU.
+
+Run every step's verification with:
+
+```bash
+robot/kirra_doctor.py --module gpu --verbose
+```
+
+## Who benefits from CUDA (and who doesn't)
+
+| Component | GPU? | Why |
+|---|---|---|
+| **rabbit** | ✅ big win | Its doer LLM is Ollama (`gemma3:4b`). GPU offload is the fix for slow spoken responses. Whisper.cpp STT can use CUDA too. |
+| **mick** | ✅ (same path) | `mick_service` calls the same Ollama; mick itself is Rust/CPU. |
+| **parko inference** | ✅ real code path | `parko-onnx` `cuda` feature (ORT CUDA EP) + `parko-tensorrt`. **Fail-closed**: a missing GPU/driver makes the CUDA EP registration error, never a silent CPU run. |
+| **Taj** | ⚪ little today | Shipped Taj is geometric lidar (CPU). Benefits only with learned perception. |
+| **occy** | ⚪ not yet | Today's doer scorer is a tiny MLP; `DOER_MODEL_SCALEUP.md` measured INT8 *slower* than FP32 (no compute to accelerate). Revisit with the real-sized M-lane doer. |
+| **kirra (checker)** | 🔴 **stays CPU by design** | The checker is deterministic + WCET-bounded — that is the safety invariant. GPU CUDA is not bitwise-reproducible (`parko-onnx` says so in-code). Moving the checker to CUDA would break the safety argument, not help it. **Do not.** |
+
+So the goal is: **doers on the GPU, checker on the CPU.** The highest-leverage,
+lowest-risk first target is Ollama (rabbit + mick).
+
+> ⚠️ These steps run on the Orin, not in CI. Treat any timing as indicative until
+> measured on the target — the same rule as the WCET methodology.
+
+## Step 0 — baseline: what does the box already have?
+
+On a Jetson, "installing CUDA" means **JetPack** (the L4T BSP), not a desktop
+CUDA installer. First see what's present:
+
+```bash
+robot/kirra_doctor.py --module gpu --verbose      # platform + cuda + tensorrt + ollama offload
+cat /etc/nv_tegra_release                          # L4T / JetPack release line
+dpkg -l | grep -i nvidia-jetpack                   # the JetPack meta-package
+```
+
+If `platform` doesn't report a Jetson, you're on the wrong host.
+
+## Step 1 — CUDA + TensorRT runtime (parko inference)
+
+If the `cuda runtime` check WARNs (no `libcudart`), install the JetPack runtime:
+
+```bash
+sudo apt update
+sudo apt install nvidia-jetpack        # pulls CUDA, cuDNN, TensorRT for this L4T
+```
+
+Re-run the doctor: `cuda runtime` and `tensorrt` should go PASS with versions.
+(You do **not** need `nvcc` at runtime — the runtime `.so`s are enough; `nvcc` is
+only for building.)
+
+## Step 2 — Ollama on the GPU (the rabbit + mick win)
+
+The `ollama GPU offload` check is the load-bearing one: Ollama **silently falls
+back to CPU** if it can't find a CUDA runtime, and a model resident on the CPU is
+the usual cause of a sluggish rabbit — the check reports it as `0 B in VRAM`.
+
+1. Use a CUDA-enabled Ollama build for arm64/Jetson (the official install script
+   detects the Tegra GPU; if you containerize, use a `jetson-containers` Ollama
+   image). After install, warm the model and check offload:
+   ```bash
+   ollama run "$KIRRA_RABBIT_MODEL" "hi" >/dev/null      # load it
+   curl -s localhost:11434/api/ps | python3 -m json.tool  # size_vram > 0 == on GPU
+   robot/kirra_doctor.py --module gpu --verbose
+   ```
+   `ollama GPU offload` → **PASS "fully on GPU"** is the target. If it stays on
+   CPU, check `journalctl -u ollama | grep -i gpu` for "no compatible GPUs" (a
+   CUDA-runtime / build problem, back to Step 1).
+
+2. **Keep it resident** (removes the cold-reload stall on the first utterance
+   after idle) — set a long/pinned `keep_alive` on the Ollama service, e.g.
+   `Environment=OLLAMA_KEEP_ALIVE=-1`. This pairs with the rabbit responsiveness
+   work (streaming to TTS + a `num_predict` cap).
+
+3. If offload is only **partial** (some layers on CPU), the model doesn't fully
+   fit VRAM — use a smaller / more-quantized `KIRRA_RABBIT_MODEL` (and re-run the
+   `rabbit_model_smoketest.py` + re-pin the digest before trusting the swap).
+
+## Step 3 — Whisper.cpp STT on the GPU (optional)
+
+If STT latency matters, build whisper.cpp with CUDA (`GGML_CUDA=1`) so the
+transcription step uses the iGPU too. Verify by timing a canned clip through the
+PTT path. Piper TTS stays CPU (fine — it's cheap).
+
+## Step 4 — parko inference backends
+
+Build the parko inference crate with the GPU backend once CUDA is present:
+
+- `parko-onnx` with `--features cuda` → the ORT CUDA EP (`build_cuda_session`,
+  registered `error_on_failure` — **fail-closed**, no silent CPU fallback).
+- `parko-tensorrt` for the TensorRT path (needs the `tensorrt` check PASS).
+
+These are opt-in; the CPU backends remain the default and the checker path is
+unaffected. See `parko/QNX_BACKEND_SELECTION.md` and `parko/crates/parko-tensorrt/Q1B_ORIN.md`.
+
+## Step 5 — confirm, and leave the checker alone
+
+```bash
+robot/kirra_doctor.py --module gpu --verbose      # doers green
+```
+
+Do **not** add a GPU execution path to the KIRRA checker / governor / fence. Its
+determinism and WCET bound are the safety case; keep it on the CPU.

--- a/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
@@ -163,6 +163,19 @@ tuned. In order of impact:
    so a terse command returns in ~1 s instead of the fixed `-d 4` window.
 5. **Event-driven re-arm + follow-up mode** (Slices R/F) so back-to-back
    questions need neither a dead-window wait nor a fresh wake word.
+6. **First-clause streaming to TTS** (Slice T, `KIRRA_RABBIT_STREAM_TTS=1`,
+   default off). Rabbit starts *speaking* the first sentence of a chat reply
+   while the model is still generating the rest, instead of waiting for the whole
+   answer — the largest drop in *perceived* latency for a conversational turn. It
+   is safe by construction: the router emits a DIRECTIVE-FIRST variant of the same
+   contract, so the routing decision is known before any speech — a **drive** turn
+   still voices nothing until the door has decided (its "on our way" vs "couldn't
+   pin down a safe destination" line is never pre-empted), and any non-directive-
+   first or malformed reply falls back to the normal non-streaming path. Barge-in
+   still stops the whole reply. `parse_reply` remains the fail-closed authority on
+   the directive. Validate on your model with `rabbit_model_smoketest.py` before
+   relying on it (a model that ignores the field order simply falls back, losing
+   only the speed-up). Off → byte-identical to today.
 
 Optionally cap the reply length with `KIRRA_RABBIT_NUM_PREDICT` — but see the
 warning in `rabbit.env.example`: too low TRUNCATES the router's `{say, directive}`

--- a/robot/doctor/modules/gpu.py
+++ b/robot/doctor/modules/gpu.py
@@ -1,0 +1,219 @@
+"""gpu — Jetson CUDA/GPU acceleration + Ollama GPU offload (read-only).
+
+Answers the one operational question that actually moves the needle on this
+robot: **are the DOERS on the GPU?** The doer LLM (rabbit + mick, via Ollama)
+and the parko ONNX/TensorRT inference backends are the components CUDA helps;
+the KIRRA checker is deliberately deterministic CPU (WCET-bounded) and is NOT a
+GPU consumer by design — so this module never asks the checker to "use CUDA."
+
+The load-bearing check is `ollama GPU offload`: Ollama silently falls back to
+CPU when its CUDA runtime is missing, and a model resident on the CPU is the #1
+cause of a sluggish rabbit — visible here as "0 B in VRAM," not a crash.
+
+Status policy (doctor.core): FAIL is reserved for "configured-but-broken."
+Missing CUDA on a Jetson that must run parko inference is a WARN (actionable),
+never FAIL — the parko backends fail closed on their own if the GPU is absent
+(`parko-onnx` registers the CUDA EP `error_on_failure`). On a non-Tegra host
+(a laptop / CI runner) the Jetson checks are informational PASS — the doctor
+must not cry wolf where GPU accel was never expected.
+
+Pure classifiers (`detect_tegra`, `classify_*`) take raw command/file output and
+return check rows, so the safety-irrelevant-but-fiddly parsing is host-tested
+(`robot/gpu_doctor_test.py`); `run` does only the read-only IO. stdlib only.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+import urllib.request
+
+from doctor.core import detail, run_cmd
+
+NAME = "gpu"
+DESCRIPTION = "Jetson CUDA/TensorRT + Ollama GPU offload (doers only; checker stays CPU)"
+DEFAULT, HEAVY, TIMEOUT_S = True, False, 15
+
+# Where JetPack / desktop CUDA drop their runtime .so; globbed, never assumed.
+_CUDA_LIB_GLOBS = (
+    "/usr/local/cuda*/lib64/libcudart.so*",
+    "/usr/local/cuda*/targets/*/lib/libcudart.so*",
+    "/usr/lib/aarch64-linux-gnu/libcudart.so*",
+    "/usr/lib/x86_64-linux-gnu/libcudart.so*",
+)
+_TRT_LIB_GLOBS = (
+    "/usr/lib/aarch64-linux-gnu/libnvinfer.so*",
+    "/usr/lib/x86_64-linux-gnu/libnvinfer.so*",
+)
+
+
+# ---- pure parsers ------------------------------------------------------------
+
+def parse_nvcc_version(nvcc_out: str):
+    """CUDA toolkit version from `nvcc --version` output, or None."""
+    m = re.search(r"release (\d+\.\d+)", nvcc_out or "")
+    return m.group(1) if m else None
+
+
+def parse_gpu_names(smi_l_out: str):
+    """GPU names from `nvidia-smi -L` ('GPU 0: NAME (UUID: ...)'). The name may
+    itself contain parens (a Jetson lists 'Orin (nvgpu)'), so split on '(UUID:',
+    not the first '('."""
+    return [m.group(1).strip()
+            for m in re.finditer(r"GPU \d+:\s*(.+?)\s*\(UUID:", smi_l_out or "")]
+
+
+def _mib(n) -> int:
+    try:
+        return int(n) // (1024 * 1024)
+    except (TypeError, ValueError):
+        return 0
+
+
+# ---- pure classifiers (raw signal -> one check row) --------------------------
+
+def detect_tegra(model_text: str, tegra_release_text: str):
+    """(is_tegra, human_name). A Jetson is identified by /proc/device-tree/model
+    naming (Jetson/Orin/Tegra) OR the mere presence of /etc/nv_tegra_release."""
+    name = (model_text or "").strip().strip("\x00") or "unknown host"
+    is_tegra = bool(
+        re.search(r"jetson|orin|tegra|xavier|nano", model_text or "", re.I)
+        or (tegra_release_text or "").strip()
+    )
+    return is_tegra, name
+
+
+def classify_platform(is_tegra: bool, name: str):
+    if is_tegra:
+        return detail("platform", "PASS", f"Jetson/Tegra: {name}")
+    return detail("platform", "PASS",
+                  f"non-Tegra host ({name}) — Jetson GPU checks are informational here")
+
+
+def classify_cuda_runtime(is_tegra: bool, cuda_libs, nvcc_version):
+    if cuda_libs:
+        base = os.path.basename(cuda_libs[0])
+        v = f"nvcc {nvcc_version}" if nvcc_version else "nvcc not installed (runtime-only is fine)"
+        return detail("cuda runtime", "PASS", f"CUDA runtime present: {base} ({v})")
+    if not is_tegra:
+        return detail("cuda runtime", "PASS",
+                      "no system CUDA runtime — not applicable on a non-Tegra host")
+    return detail(
+        "cuda runtime", "WARN",
+        "no system CUDA runtime (libcudart) found — parko ONNX-CUDA / TensorRT "
+        "backends can't initialise (they fail closed). Note: Ollama bundles its "
+        "own CUDA, so rabbit may still offload — see the ollama check",
+        fix="install JetPack CUDA (sudo apt install nvidia-jetpack) — see docs/hardware/JETSON_CUDA_SETUP.md",
+    )
+
+
+def classify_tensorrt(is_tegra: bool, trt_libs):
+    if trt_libs:
+        return detail("tensorrt", "PASS", f"TensorRT present: {os.path.basename(trt_libs[0])}")
+    if not is_tegra:
+        return detail("tensorrt", "PASS", "non-Tegra host — TensorRT check skipped")
+    # Optional per backend → informational, not a WARN (ONNX-CUDA works without it).
+    return detail("tensorrt", "PASS",
+                  "TensorRT (libnvinfer) not found — the parko-tensorrt backend is "
+                  "unavailable; parko ONNX-CUDA still works if CUDA is present")
+
+
+def classify_nvidia_smi(is_tegra: bool, rc: int, smi_l_out: str):
+    names = parse_gpu_names(smi_l_out) if rc == 0 else []
+    if names:
+        return detail("nvidia-smi", "PASS", f"nvidia-smi sees: {names[0]}")
+    if is_tegra:
+        return detail("nvidia-smi", "PASS",
+                      "nvidia-smi absent (normal on Jetson/L4T — use tegrastats); GPU is "
+                      "confirmed via the cuda-runtime + ollama-offload checks")
+    return detail("nvidia-smi", "PASS", "no NVIDIA GPU tooling (nvidia-smi absent)")
+
+
+def classify_ollama_offload(reachable: bool, models, model_hint: str):
+    """The load-bearing check: is the resident doer model on the GPU?
+    `models` = the Ollama /api/ps `models` list (dicts with size / size_vram)."""
+    if not reachable:
+        return detail("ollama GPU offload", "PASS",
+                      "Ollama not reachable at :11434 — offload check skipped (see the services module)")
+    if not models:
+        return detail(
+            "ollama GPU offload", "UNKNOWN",
+            "no model resident (Ollama idle-unloaded it) — can't confirm GPU offload",
+            fix="warm the doer (send rabbit one utterance) then re-run, or pin it with Ollama keep_alive",
+        )
+    m = models[0]
+    name = m.get("name") or m.get("model") or model_hint
+    size, vram = int(m.get("size") or 0), int(m.get("size_vram") or 0)
+    if size <= 0:
+        return detail("ollama GPU offload", "UNKNOWN",
+                      f"{name} is resident but Ollama reported no size — can't classify offload")
+    if vram <= 0:
+        return detail(
+            "ollama GPU offload", "WARN",
+            f"{name} is resident on the CPU (0 B in VRAM) — GPU offload is NOT active; "
+            "this is the usual cause of slow rabbit/mick responses",
+            fix="confirm Ollama has a CUDA runtime + a GPU build; check: journalctl -u ollama | grep -i gpu",
+        )
+    if vram >= size * 0.99:
+        return detail("ollama GPU offload", "PASS", f"{name} fully on GPU ({_mib(vram)} MiB in VRAM)")
+    pct = round(100 * vram / size)
+    return detail(
+        "ollama GPU offload", "WARN",
+        f"{name} only partially offloaded ({pct}% — {_mib(vram)} of {_mib(size)} MiB on GPU); "
+        "the remaining layers run on the CPU",
+        fix="use a smaller / more-quantized model or free VRAM so the whole model fits",
+    )
+
+
+# ---- read-only IO ------------------------------------------------------------
+
+def _read(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _glob_any(patterns) -> list:
+    out = []
+    for p in patterns:
+        out.extend(sorted(glob.glob(p)))
+    return out
+
+
+def _ollama_ps(ctx):
+    """(reachable, models_list) from Ollama's GET /api/ps. Never raises."""
+    env = ctx.get("env", {}) if isinstance(ctx, dict) else {}
+    base = (env.get("KIRRA_OLLAMA_URL") or "http://127.0.0.1:11434").rstrip("/")
+    try:
+        with urllib.request.urlopen(f"{base}/api/ps", timeout=2.0) as r:
+            body = json.loads(r.read().decode("utf-8"))
+        models = body.get("models") if isinstance(body, dict) else None
+        return True, (models if isinstance(models, list) else [])
+    except Exception:  # noqa: BLE001
+        return False, []
+
+
+def run(ctx):
+    env = ctx.get("env", {}) if isinstance(ctx, dict) else {}
+    model_hint = (env.get("KIRRA_RABBIT_MODEL")
+                  or ctx.get("robot_env", {}).get("KIRRA_RABBIT_MODEL")
+                  or "the doer model")
+
+    is_tegra, name = detect_tegra(_read("/proc/device-tree/model"), _read("/etc/nv_tegra_release"))
+    details = [classify_platform(is_tegra, name)]
+
+    _, nvcc_out, _ = run_cmd(["nvcc", "--version"], timeout_s=5)
+    details.append(classify_cuda_runtime(is_tegra, _glob_any(_CUDA_LIB_GLOBS),
+                                         parse_nvcc_version(nvcc_out)))
+    details.append(classify_tensorrt(is_tegra, _glob_any(_TRT_LIB_GLOBS)))
+
+    rc, smi_out, _ = run_cmd(["nvidia-smi", "-L"], timeout_s=5)
+    details.append(classify_nvidia_smi(is_tegra, rc, smi_out))
+
+    reachable, models = _ollama_ps(ctx)
+    details.append(classify_ollama_offload(reachable, models, model_hint))
+
+    return {"details": details}

--- a/robot/gpu_doctor_test.py
+++ b/robot/gpu_doctor_test.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""gpu_doctor_test — host tests for the doctor `gpu` module. CI-safe: no
+hardware, no GPU, no network beyond a localhost-refused connect. The pure
+classifiers are exercised with synthetic command/file output; the live `run`
+is smoke-tested for a bounded, valid, non-raising result on a GPU-less host.
+Runner style matches rabbit_voice_test.py / kirra_doctor_test.py (assert-based,
+stdlib only).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from doctor import core  # noqa: E402
+from doctor.modules import gpu  # noqa: E402
+
+_VALID = set(core.STATUSES)
+
+
+# ---- pure parsers ------------------------------------------------------------
+
+def test_parse_nvcc_version() -> None:
+    out = ("nvcc: NVIDIA (R) Cuda compiler driver\n"
+           "Cuda compilation tools, release 12.2, V12.2.140\n")
+    assert gpu.parse_nvcc_version(out) == "12.2"
+    assert gpu.parse_nvcc_version("") is None
+    assert gpu.parse_nvcc_version("garbage") is None
+
+
+def test_parse_gpu_names() -> None:
+    out = "GPU 0: NVIDIA GeForce RTX 3090 (UUID: GPU-abc)\nGPU 1: Orin (nvgpu) (UUID: GPU-def)\n"
+    assert gpu.parse_gpu_names(out) == ["NVIDIA GeForce RTX 3090", "Orin (nvgpu)"]
+    assert gpu.parse_gpu_names("") == []
+
+
+# ---- tegra detection ---------------------------------------------------------
+
+def test_detect_tegra_from_model() -> None:
+    is_tegra, name = gpu.detect_tegra("NVIDIA Jetson Orin NX Engineering Reference\x00", "")
+    assert is_tegra
+    assert "Orin" in name and "\x00" not in name
+
+
+def test_detect_tegra_from_release_file_alone() -> None:
+    # A generic model string but nv_tegra_release present is still a Jetson.
+    is_tegra, _ = gpu.detect_tegra("", "# R36 (release), REVISION: 3.0\n")
+    assert is_tegra
+
+
+def test_detect_non_tegra() -> None:
+    is_tegra, name = gpu.detect_tegra("Dell Inc. XPS 15", "")
+    assert not is_tegra
+    assert "XPS" in name
+
+
+# ---- cuda runtime ------------------------------------------------------------
+
+def test_cuda_present_passes() -> None:
+    d = gpu.classify_cuda_runtime(True, ["/usr/local/cuda-12.2/lib64/libcudart.so.12"], "12.2")
+    assert d["status"] == "PASS" and "12.2" in d["info"]
+
+
+def test_cuda_absent_on_tegra_warns() -> None:
+    d = gpu.classify_cuda_runtime(True, [], None)
+    assert d["status"] == "WARN" and "fix" in d
+    assert "bundles its own CUDA" in d["info"]  # the Ollama caveat is surfaced
+
+
+def test_cuda_absent_off_tegra_is_not_applicable() -> None:
+    d = gpu.classify_cuda_runtime(False, [], None)
+    assert d["status"] == "PASS"  # never cry wolf on a laptop / CI runner
+
+
+# ---- tensorrt (informational) -----------------------------------------------
+
+def test_tensorrt_present_passes() -> None:
+    d = gpu.classify_tensorrt(True, ["/usr/lib/aarch64-linux-gnu/libnvinfer.so.8"])
+    assert d["status"] == "PASS" and "TensorRT present" in d["info"]
+
+
+def test_tensorrt_absent_is_informational_not_warn() -> None:
+    # Optional per backend — ONNX-CUDA works without it, so absence never WARNs.
+    assert gpu.classify_tensorrt(True, [])["status"] == "PASS"
+    assert gpu.classify_tensorrt(False, [])["status"] == "PASS"
+
+
+# ---- nvidia-smi (never FAIL) -------------------------------------------------
+
+def test_nvidia_smi_names_pass() -> None:
+    d = gpu.classify_nvidia_smi(False, 0, "GPU 0: NVIDIA A100 (UUID: GPU-x)\n")
+    assert d["status"] == "PASS" and "A100" in d["info"]
+
+
+def test_nvidia_smi_absent_on_tegra_is_normal() -> None:
+    d = gpu.classify_nvidia_smi(True, -1, "")
+    assert d["status"] == "PASS" and "tegrastats" in d["info"]
+
+
+# ---- the load-bearing ollama-offload classifier ------------------------------
+
+def test_ollama_unreachable_skips_without_alarm() -> None:
+    d = gpu.classify_ollama_offload(False, [], "gemma3:4b")
+    assert d["status"] == "PASS" and "skipped" in d["info"]
+
+
+def test_ollama_idle_is_unknown() -> None:
+    d = gpu.classify_ollama_offload(True, [], "gemma3:4b")
+    assert d["status"] == "UNKNOWN" and "fix" in d
+
+
+def test_ollama_on_cpu_warns() -> None:
+    # size_vram == 0 → resident on CPU → the slow-rabbit smoking gun.
+    models = [{"name": "gemma3:4b", "size": 3_000_000_000, "size_vram": 0}]
+    d = gpu.classify_ollama_offload(True, models, "gemma3:4b")
+    assert d["status"] == "WARN" and "0 B in VRAM" in d["info"] and "fix" in d
+
+
+def test_ollama_fully_on_gpu_passes() -> None:
+    models = [{"name": "gemma3:4b", "size": 3_000_000_000, "size_vram": 3_000_000_000}]
+    d = gpu.classify_ollama_offload(True, models, "gemma3:4b")
+    assert d["status"] == "PASS" and "fully on GPU" in d["info"]
+
+
+def test_ollama_partial_offload_warns() -> None:
+    models = [{"name": "gemma3:4b", "size": 4_000_000_000, "size_vram": 1_000_000_000}]
+    d = gpu.classify_ollama_offload(True, models, "gemma3:4b")
+    assert d["status"] == "WARN" and "partially offloaded" in d["info"]
+
+
+def test_ollama_resident_but_no_size_is_unknown() -> None:
+    d = gpu.classify_ollama_offload(True, [{"name": "x", "size": 0, "size_vram": 0}], "x")
+    assert d["status"] == "UNKNOWN"
+
+
+# ---- live run smoke (GPU-less host: bounded, valid, never raises) ------------
+
+def test_run_is_bounded_and_valid_on_this_host() -> None:
+    ctx = {"env": dict(os.environ), "robot_env": {}, "robot_env_path": "/none",
+           "here": "/none", "repo": "/none"}
+    out = gpu.run(ctx)
+    details = out["details"]
+    # One row per probe: platform, cuda, tensorrt, nvidia-smi, ollama.
+    assert len(details) == 5
+    for d in details:
+        assert d["status"] in _VALID, d
+    # No probe on a plain host may FAIL (FAIL is 'configured-but-broken').
+    assert all(d["status"] != "FAIL" for d in details)
+
+
+def test_module_integrates_with_the_runner() -> None:
+    # Through the real isolation runner: valid schema-v1 module result, read-only.
+    ctx = {"env": {}, "robot_env": {}, "robot_env_path": "/none", "here": "/none", "repo": "/none"}
+    res = core.run_module(gpu, ctx)
+    assert res["name"] == "gpu"
+    assert res["status"] in _VALID
+    assert res["metadata"]["read_only"] is True
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    print("gpu doctor host tests (no hardware):")
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok   {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -121,6 +121,14 @@ KIRRA_RABBIT_MODEL="gemma3:4b"
 # re-run rabbit_model_smoketest.py at your chosen value and it still passes the
 # drive→directive cases (it imports the same options, so it catches a bad cap).
 #KIRRA_RABBIT_NUM_PREDICT=200
+# First-clause streaming to TTS (Slice T, OPT-IN, default off). Rabbit starts
+# SPEAKING the first sentence of a chat reply while the model generates the rest
+# — the biggest drop in PERCEIVED latency per turn. Safe: the router goes
+# directive-first so a DRIVE turn still voices nothing until the door decides, and
+# any non-directive-first/malformed reply falls back to the normal path. Validate
+# with rabbit_model_smoketest.py first (a model that ignores field order just
+# falls back). Off → byte-identical. See RABBIT_BRINGUP_RUNBOOK.md ("Speed").
+#KIRRA_RABBIT_STREAM_TTS=1
 
 # ── Speed & responsiveness (Slice S) — the proven levers, in one place ─────────
 # The Rabbit felt slow to reply mostly from LLM cold-reload + long capture. The

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -55,6 +55,7 @@ import turn_state  # noqa: E402 — cross-process "turn in progress" signal (Sli
 import skill_registry  # noqa: E402 — opt-in named-skill router (motion → the SAME /intent fence)
 import world_model  # noqa: E402 — opt-in situation report (read-only TTL'd projection)
 import mission  # noqa: E402 — opt-in multi-step Executive (each step → the SAME /intent fence)
+import rabbit_stream  # noqa: E402 — opt-in first-clause streaming of the reply to TTS
 from rabbit_persona import name_slot, operator_name  # noqa: E402
 
 MAX_TURNS = 10  # rolling conversation memory (user+assistant pairs kept)
@@ -102,6 +103,29 @@ STAGE2_SYSTEM = (
     '  creep forward one meter  -> {"say": "Creeping forward a meter; the checker will bound it.", "directive": "creep forward one meter"}\n'
     '  take us to the door      -> {"say": "Heading for the door.", "directive": "take us to the door"}\n'
     '  what do you see?         -> {"say": "Nearest obstacle is about two meters ahead.", "directive": null}'
+)
+
+# Streaming reply-to-TTS (Slice T, OPT-IN via KIRRA_RABBIT_STREAM_TTS). Default
+# OFF → this whole block is inert and the turn path is byte-identical. When ON,
+# the router uses a DIRECTIVE-FIRST variant of the SAME contract so the routing
+# decision is known BEFORE any speech: a CHAT turn streams its `say` aloud clause
+# by clause as the model generates it (the latency win); a DRIVE turn voices
+# nothing until the door has decided, exactly as today. All the routing
+# guardrails above are preserved verbatim — only the field ORDER changes — and
+# any non-directive-first / malformed reply falls back to the normal path, so
+# streaming can only match or beat current behaviour, never alter routing.
+STREAM_TTS = (os.environ.get("KIRRA_RABBIT_STREAM_TTS") or "").strip().lower() in \
+    ("1", "true", "yes", "on")
+
+STAGE2_SYSTEM_STREAM = (
+    STAGE2_SYSTEM
+    + "\n\nOUTPUT ORDER (IMPORTANT): put the `directive` field FIRST and `say` "
+    "SECOND, so the object reads {\"directive\": <null or the request>, \"say\": "
+    "\"...\"}. The routing decision must precede the spoken words. Everything else "
+    "above — when to set `directive`, never nulling a drive request — is unchanged.\n"
+    "Examples:\n"
+    '  creep forward one meter  -> {"directive": "creep forward one meter", "say": "Creeping forward a meter; the checker will bound it."}\n'
+    '  what do you see?         -> {"directive": null, "say": "Nearest obstacle is about two meters ahead."}'
 )
 
 
@@ -233,6 +257,70 @@ def _speak_reply(text):
                                  barge_in.make_file_cancel_check(path, baseline))
 
 
+def _stream_messages(history, context, utterance):
+    """Router messages for the streaming path — identical to ask_llm's, but with
+    the DIRECTIVE-FIRST system prompt so routing resolves before the spoken words."""
+    return ([{"role": "system", "content": STAGE2_SYSTEM_STREAM}] + list(history)
+            + [{"role": "user", "content": f"{context}\n\nOperator says: {utterance}"}])
+
+
+def _make_stream_speaker():
+    """(speak_clause, cancelled): speak streamed clauses sharing ONE barge-in
+    baseline for the whole reply, so a single barge-in stops the REST of it (no
+    regression vs the single-call _speak_reply). Off → plain speak()."""
+    if not barge_in.enabled():
+        return (lambda text: speak(text)), (lambda: False)
+    tts_argv = (os.environ.get("KIRRA_TTS_CMD") or "").split()
+    path = barge_in.signal_path()
+    cancel_check = barge_in.make_file_cancel_check(path, barge_in.read_epoch(path))
+    state = {"cancelled": False}
+
+    def speak_clause(text):
+        if state["cancelled"] or cancel_check():
+            state["cancelled"] = True
+            return
+        barge_in.speak_interruptible(text, tts_argv, cancel_check)
+        if cancel_check():
+            state["cancelled"] = True
+
+    return speak_clause, (lambda: state["cancelled"])
+
+
+def route_stream(messages, on_clause, cancelled):
+    """Stream the router reply, speaking CHAT clauses via on_clause as they arrive.
+    Returns the parser's finish() plan (with `raw` for the caller's fallback
+    parse), or None on any HTTP/stream failure → caller falls back to ask_llm.
+    A DRIVE turn speaks nothing (the parser emits no clauses before routing)."""
+    parser = rabbit_stream.StreamingSayParser()
+    try:
+        with requests.post(f"{OLLAMA}/api/chat", timeout=60.0, stream=True,
+                           json={"model": MODEL, "stream": True, "messages": messages,
+                                 "keep_alive": KEEP_ALIVE, "options": ROUTER_LLM_OPTIONS}) as r:
+            if r.status_code != 200:
+                return None
+            for line in r.iter_lines():
+                if cancelled():
+                    break
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except Exception:  # noqa: BLE001
+                    continue
+                piece = (obj.get("message") or {}).get("content") or ""
+                if piece:
+                    for clause in parser.feed(piece):
+                        on_clause(clause)
+                if obj.get("done"):
+                    break
+    except Exception:  # noqa: BLE001 — any streaming failure → non-streaming fallback
+        return None
+    plan = parser.finish()
+    for clause in plan["trailing"]:
+        on_clause(clause)
+    return plan
+
+
 def handle_turn(history, utterance):
     # System commands (OTA "check/apply update") are matched DETERMINISTICALLY and
     # handled BEFORE the LLM/movement path — they run local kirra-ota-ctl, never
@@ -332,7 +420,24 @@ def handle_turn(history, utterance):
         del history[: max(0, len(history) - 2 * MAX_TURNS)]
         return
 
-    say, directive = ask_llm(history, context, utterance)
+    # Default free-form {say, directive} router. Streaming (opt-in) voices a CHAT
+    # reply clause-by-clause as it generates; a DRIVE turn and every failure mode
+    # fall through to the exact non-streaming path below. `already_spoken` marks a
+    # CHAT reply that streaming has already voiced (so we don't say it twice).
+    say = directive = None
+    already_spoken = False
+    if STREAM_TTS:
+        speak_clause, cancelled = _make_stream_speaker()
+        plan = route_stream(_stream_messages(history, context, utterance),
+                            speak_clause, cancelled)
+        if plan is not None:
+            # parse_reply is ALWAYS the authority on the directive (fail-closed);
+            # streaming only decides whether `say` was voiced early.
+            say, directive = parse_reply(plan["raw"])
+            already_spoken = bool(plan.get("streamed")) and directive is None
+    if say is None and directive is None and not already_spoken:
+        say, directive = ask_llm(history, context, utterance)   # non-streaming / fallback
+
     if say is None:
         say = "My voice module is offline for a moment."
         directive = None
@@ -346,10 +451,13 @@ def handle_turn(history, utterance):
                       "safe destination — could you say it another way?")
         else:  # error
             spoken = "I can't reach my driving control right now, so I'm staying put."
+    elif already_spoken:
+        spoken = say                       # a CHAT reply streaming already voiced
     else:
         spoken = say
 
-    _speak_reply(spoken)
+    if not already_spoken:
+        _speak_reply(spoken)
     # rolling memory (store the spoken reply, not the raw grounding)
     history.append({"role": "user", "content": utterance})
     history.append({"role": "assistant", "content": spoken})

--- a/robot/rabbit_stream.py
+++ b/robot/rabbit_stream.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""rabbit_stream.py — first-clause streaming of the router's spoken reply to TTS.
+
+The single biggest perceived-latency win for a voice loop is to start SPEAKING
+the first clause of the answer while the model is still generating the rest,
+instead of waiting for the whole reply. rabbit_converse's router emits a JSON
+object, though — you cannot naively split a `{"say": "…"}` token stream on
+punctuation and speak it, or you'd read the JSON syntax aloud.
+
+This module makes streaming SAFE for that router by consuming a **directive-first**
+JSON stream — `{"directive": <null|"…">, "say": "…"}` — and:
+
+  * resolving the ROUTING decision (`directive`) FIRST, before any speech. A DRIVE
+    turn (non-null directive) emits NO clauses at all — the caller runs the exact
+    existing door/verdict path so the door-result-dependent line ("On our way" vs
+    "couldn't pin down a safe destination") is never pre-empted. Only a CHAT turn
+    (directive null) streams its `say` aloud.
+  * emitting `say` as complete, JSON-UNESCAPED clauses (split on . ! ?) the instant
+    each is available — never the JSON punctuation, quotes, or the trailing
+    `,"directive":…` structure.
+
+FAIL-SAFE BY CONSTRUCTION: if the stream is not directive-first, is malformed, or
+is ambiguous in any way, the parser "gives up" and emits nothing — the caller then
+falls back to the normal, non-streaming `parse_reply(raw_buffer)` and speaks the
+reply exactly as it does today. Streaming is therefore a best-effort accelerant
+that can only ever match or beat the current behaviour, never change routing.
+
+Pure + stdlib only (no HTTP, no LLM) so the parsing is fully host-tested
+(`robot/rabbit_stream_test.py`). The live streaming HTTP call lives in
+rabbit_converse and feeds chunks in here.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+# A COMPLETE directive field: `"directive": null` or `"directive": "<escaped>"`.
+# Anchored to a complete value (full quoted string or the null literal), so a
+# match means the routing decision is fully known — never a truncated one.
+_DIRECTIVE_RE = re.compile(r'"directive"\s*:\s*(null|"(?:[^"\\]|\\.)*")', re.IGNORECASE)
+_SAY_START_RE = re.compile(r'"say"\s*:\s*"')
+# Sentence boundary: one-or-more terminators followed by whitespace (so "3.5" or
+# "e.g." mid-number/abbrev without a following space is not split prematurely).
+_CLAUSE_RE = re.compile(r"[.!?]+(?=\s)")
+
+
+def split_ready_clauses(text: str):
+    """(complete_clauses, remainder). A clause ends at .!? followed by whitespace;
+    the trailing unfinished fragment is returned separately."""
+    clauses, last = [], 0
+    for m in _CLAUSE_RE.finditer(text):
+        end = m.end()
+        clause = text[last:end].strip()
+        if clause:
+            clauses.append(clause)
+        last = end
+    return clauses, text[last:].strip()
+
+
+def _safe_unescape(escaped: str) -> str:
+    """JSON-unescape a possibly-truncated string body. Trims a dangling backslash
+    or an incomplete \\uXXXX so json.loads never chokes on a mid-escape cut."""
+    # Drop a trailing odd run of backslashes (an incomplete escape).
+    i = len(escaped)
+    while i > 0 and escaped[i - 1] == "\\":
+        i -= 1
+    if (len(escaped) - i) % 2 == 1:
+        escaped = escaped[:-1]
+    escaped = re.sub(r"\\u[0-9a-fA-F]{0,3}$", "", escaped)
+    try:
+        return json.loads('"' + escaped + '"')
+    except Exception:  # noqa: BLE001 — a still-bad fragment just yields nothing yet
+        return ""
+
+
+def _find_string_end(s: str):
+    """Index of the first UNESCAPED closing quote in a JSON string body, or None."""
+    esc = False
+    for i, ch in enumerate(s):
+        if esc:
+            esc = False
+        elif ch == "\\":
+            esc = True
+        elif ch == '"':
+            return i
+    return None
+
+
+class StreamingSayParser:
+    """Feed router-JSON chunks in; get speakable clauses out. See module docstring.
+
+    Lifecycle: `feed(chunk)` per streamed chunk (returns clauses to speak NOW),
+    then `finish()` once the stream ends (returns the final plan + any trailing
+    clause). `raw` is the full accumulated text for the caller's fallback parse.
+    """
+
+    def __init__(self) -> None:
+        self.raw = ""
+        self.phase = "seek"          # seek -> chat | drive ; giveup is terminal
+        self.directive = None
+        self._giveup = False
+        self._say_from = None        # index in `raw` where the say VALUE begins
+        self._say_closed = False
+        self._say_text = ""          # unescaped say-so-far
+        self._clauses_spoken = 0
+
+    # -- resolution ---------------------------------------------------------
+
+    def _resolve_route(self) -> None:
+        """In `seek`: decide chat vs drive from the directive-first field. If a
+        `say` value opens before any directive resolves, the stream is NOT
+        directive-first → give up (fall back to non-streaming)."""
+        m = _DIRECTIVE_RE.search(self.raw)
+        say_m = _SAY_START_RE.search(self.raw)
+        if m and (not say_m or m.start() < say_m.start()):
+            tok = m.group(1)
+            if tok.lower() == "null":
+                self.phase = "chat"
+            else:
+                try:
+                    self.directive = json.loads(tok).strip() or None
+                except Exception:  # noqa: BLE001
+                    self.directive = None
+                self.phase = "chat" if self.directive is None else "drive"
+        elif say_m:
+            # say arrived first (or without a resolvable directive) → not
+            # directive-first; cannot stream safely. Fall back.
+            self._giveup = True
+
+    def _pump_say(self):
+        """In `chat`: emit any newly-complete say clauses."""
+        if self._say_from is None:
+            m = _SAY_START_RE.search(self.raw)
+            if not m:
+                return []
+            self._say_from = m.end()
+        body = self.raw[self._say_from:]
+        end = _find_string_end(body)
+        if end is None:
+            usable = body                      # still open — unescape the safe prefix
+        else:
+            usable, self._say_closed = body[:end], True
+        self._say_text = _safe_unescape(usable)
+        clauses, _ = split_ready_clauses(self._say_text)
+        new = clauses[self._clauses_spoken:]
+        self._clauses_spoken = len(clauses)
+        return new
+
+    # -- public API ---------------------------------------------------------
+
+    def feed(self, chunk: str):
+        self.raw += chunk
+        if self._giveup:
+            return []
+        if self.phase == "seek":
+            self._resolve_route()
+        if self.phase == "chat" and not self._giveup:
+            return self._pump_say()
+        return []
+
+    def finish(self):
+        """End the stream. Returns a plan dict:
+          streamed:  True iff we handled it as a streamed CHAT turn (say voiced)
+          route:     'chat' | 'drive' | 'unknown'
+          directive: the resolved directive (drive turns), else None
+          trailing:  final clause(s) the caller must still speak (chat turns)
+          raw:       full accumulated text (the caller's fallback-parse source)
+        """
+        if self.phase == "seek" and not self._giveup:
+            self._resolve_route()          # a very short reply may only resolve now
+        trailing = []
+        if self.phase == "chat" and not self._giveup:
+            trailing = self._pump_say()
+            if self._say_text:
+                _, remainder = split_ready_clauses(self._say_text)
+                if remainder:
+                    trailing = trailing + [remainder]
+        streamed = self.phase == "chat" and not self._giveup and self._say_from is not None
+        route = self.phase if self.phase in ("chat", "drive") else "unknown"
+        return {"streamed": streamed, "route": route, "directive": self.directive,
+                "trailing": trailing, "raw": self.raw}

--- a/robot/rabbit_stream_integration_test.py
+++ b/robot/rabbit_stream_integration_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""rabbit_stream_integration_test — checks the streaming path's wiring in
+rabbit_converse WITHOUT touching the network or an LLM.
+
+rabbit_converse imports `requests` at module load (it sys.exits without it), and
+the CI robot lane doesn't install requests, so this test SKIPS cleanly there and
+runs fully wherever requests exists (the robot). The pure clause parser is
+covered unconditionally in rabbit_stream_test.py; this locks the three
+integration invariants that keep streaming a no-regression accelerant:
+
+  1. the streaming gate is OFF by default (production is byte-identical);
+  2. the directive-first prompt PRESERVES every routing guardrail (it is the base
+     prompt + an ordering override — the "never null a drive request" contract is
+     intact);
+  3. parse_reply — the fail-closed authority on the directive — is order-agnostic,
+     so a directive-first reply routes exactly like the say-first one.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+try:
+    import requests  # noqa: F401 — rabbit_converse needs it at import
+    _HAVE_REQUESTS = True
+except ImportError:
+    _HAVE_REQUESTS = False
+
+
+def test_stream_gate_defaults_off_and_guardrails_preserved() -> None:
+    if not _HAVE_REQUESTS:
+        print("  skip (requests unavailable — CI lane; parser covered in rabbit_stream_test)")
+        return
+    os.environ.pop("KIRRA_RABBIT_STREAM_TTS", None)
+    import importlib
+    import rabbit_converse
+    importlib.reload(rabbit_converse)
+
+    # 1. Default OFF.
+    assert rabbit_converse.STREAM_TTS is False, "streaming must default off"
+
+    # 2. Guardrails preserved: the streaming prompt is the base prompt + override,
+    #    so the load-bearing "never null a drive request" contract is intact.
+    base, stream = rabbit_converse.STAGE2_SYSTEM, rabbit_converse.STAGE2_SYSTEM_STREAM
+    assert stream.startswith(base), "streaming prompt must extend the base contract, not replace it"
+    assert "NEVER set" in stream and "null" in stream, "the drive-request guardrail must survive"
+    assert "directive` field FIRST" in stream, "streaming prompt must request directive-first order"
+
+    # 3. parse_reply is order-agnostic (the fail-closed directive authority).
+    say, directive = rabbit_converse.parse_reply('{"directive": null, "say": "All nominal."}')
+    assert directive is None and say == "All nominal.", (say, directive)
+    say, directive = rabbit_converse.parse_reply(
+        '{"directive": "creep forward", "say": "Creeping forward."}')
+    assert directive == "creep forward" and say == "Creeping forward.", (say, directive)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    print("rabbit_stream integration tests:")
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok   {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/rabbit_stream_test.py
+++ b/robot/rabbit_stream_test.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""rabbit_stream_test — host tests for the streaming say-parser. CI-safe: pure,
+no hardware/HTTP/LLM. Feeds synthetic router-JSON streams at various chunk
+boundaries and asserts: chat turns voice their say as clean unescaped clauses,
+drive turns voice NOTHING before routing, and any non-directive-first / malformed
+stream gives up so the caller falls back to the current behaviour.
+Runner style matches rabbit_voice_test.py (assert-based, stdlib only).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import rabbit_stream as rs  # noqa: E402
+
+
+def _drive(payload: str, chunk: int):
+    """Feed `payload` through the parser in fixed-size chunks; return
+    (spoken_clauses, finish_plan)."""
+    p = rs.StreamingSayParser()
+    spoken = []
+    for i in range(0, len(payload), chunk):
+        spoken += p.feed(payload[i:i + chunk])
+    plan = p.finish()
+    spoken += plan["trailing"]
+    return spoken, plan
+
+
+# ---- split_ready_clauses -----------------------------------------------------
+
+def test_split_ready_clauses() -> None:
+    clauses, rem = rs.split_ready_clauses("Hello there. How are you? I am fine")
+    assert clauses == ["Hello there.", "How are you?"], clauses
+    assert rem == "I am fine", rem
+
+
+def test_split_does_not_break_on_decimal() -> None:
+    # No whitespace after the '.', so "2.5" is not a boundary.
+    clauses, rem = rs.split_ready_clauses("The gap is 2.5 meters")
+    assert clauses == []
+    assert rem == "The gap is 2.5 meters"
+
+
+def test_safe_unescape_handles_truncated_escape() -> None:
+    assert rs._safe_unescape('hello') == "hello"
+    assert rs._safe_unescape('a\\"b') == 'a"b'
+    assert rs._safe_unescape('trailing\\') == "trailing"          # dangling backslash trimmed
+    assert rs._safe_unescape('half\\u12') == "half"               # incomplete \u trimmed
+
+
+# ---- chat turns stream their say --------------------------------------------
+
+def test_chat_turn_streams_clauses_across_chunks() -> None:
+    payload = '{"directive": null, "say": "We are nominal. Holding position for now."}'
+    for chunk in (1, 3, 7, 200):
+        spoken, plan = _drive(payload, chunk)
+        assert plan["route"] == "chat", (chunk, plan)
+        assert plan["streamed"] is True, (chunk, plan)
+        assert plan["directive"] is None
+        # Every clause is clean prose — no JSON punctuation ever leaks.
+        joined = " ".join(spoken)
+        assert "{" not in joined and '"' not in joined and "directive" not in joined, spoken
+        assert spoken == ["We are nominal.", "Holding position for now."], (chunk, spoken)
+
+
+def test_chat_first_clause_available_before_stream_ends() -> None:
+    # The whole point: the first sentence is emitted mid-stream, not at finish.
+    p = rs.StreamingSayParser()
+    early = []
+    early += p.feed('{"directive": null, "say": "On it. ')   # first sentence + a space
+    assert early == ["On it."], early                          # spoken already, before the rest
+    early += p.feed('Standing by."}')
+    plan = p.finish()
+    assert (early + plan["trailing"]) == ["On it.", "Standing by."]
+
+
+def test_chat_unescapes_quotes_and_newlines() -> None:
+    payload = '{"directive": null, "say": "I heard \\"go\\" clearly. All set.\\n"}'
+    spoken, plan = _drive(payload, 5)
+    assert plan["route"] == "chat"
+    assert spoken[0] == 'I heard "go" clearly.'
+    assert "All set." in spoken[1]
+
+
+def test_short_chat_reply_with_no_terminator_flushes_at_finish() -> None:
+    payload = '{"directive": null, "say": "Understood"}'
+    spoken, plan = _drive(payload, 4)
+    assert spoken == ["Understood"], spoken
+    assert plan["streamed"] is True
+
+
+# ---- drive turns voice NOTHING before routing -------------------------------
+
+def test_drive_turn_emits_no_speech_and_reports_directive() -> None:
+    payload = '{"directive": "take us to the door", "say": "Heading for the door."}'
+    spoken, plan = _drive(payload, 6)
+    assert spoken == [], spoken                     # nothing pre-spoken on a drive turn
+    assert plan["route"] == "drive"
+    assert plan["streamed"] is False
+    assert plan["directive"] == "take us to the door"
+
+
+def test_drive_directive_resolved_before_say_is_seen() -> None:
+    # Directive is complete well before the say value starts → drive locked in early.
+    p = rs.StreamingSayParser()
+    out = p.feed('{"directive": "creep forward", ')
+    assert out == []
+    assert p.phase == "drive" and p.directive == "creep forward"
+
+
+# ---- fail-safe: non-directive-first / malformed → give up (caller falls back)-
+
+def test_say_first_stream_gives_up_and_speaks_nothing() -> None:
+    # Legacy / non-compliant ordering: say before directive → cannot stream safely.
+    payload = '{"say": "Heading out.", "directive": "go forward"}'
+    spoken, plan = _drive(payload, 5)
+    assert spoken == [], spoken
+    assert plan["streamed"] is False
+    # raw is preserved verbatim for the caller's parse_reply fallback.
+    assert plan["raw"] == payload
+
+
+def test_garbage_stream_gives_up() -> None:
+    payload = "sorry I cannot comply as JSON"
+    spoken, plan = _drive(payload, 4)
+    assert spoken == []
+    assert plan["streamed"] is False
+    assert plan["route"] == "unknown"
+    assert plan["raw"] == payload
+
+
+def test_raw_is_always_the_full_payload() -> None:
+    payload = '{"directive": null, "say": "Anything at all here."}'
+    _, plan = _drive(payload, 9)
+    assert plan["raw"] == payload
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    print("rabbit_stream host tests (no hardware):")
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok   {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
Two robot-side, Channel-A/UX improvements for the R2 ("rabbit") voice loop. Neither touches the checker, the fence, or any safety authority — both are read-only or opt-in, and the movement path is unchanged.

## 1. GPU/CUDA doctor (`robot/doctor/modules/gpu.py`)

A read-only diagnostics module answering the one operational question that moves the needle on the Orin: **are the DOERS on the GPU?** The doer LLM (rabbit + mick via Ollama) and the parko ONNX/TensorRT backends are the CUDA consumers; the KIRRA checker is deliberately deterministic CPU and is **not** a GPU consumer by design, so the module never asks the checker to use CUDA.

Checks (pure classifiers + read-only probes): Tegra/Jetson platform, CUDA runtime (`libcudart` + `nvcc`), TensorRT, `nvidia-smi`, and — the load-bearing one — **Ollama GPU offload** (parses `/api/ps` `size_vram`: resident-on-CPU → WARN, fully-on-GPU → PASS, partial → WARN, idle → UNKNOWN). Auto-discovered (`DEFAULT=True`) so it joins the `kirra_doctor` default set and rabbit's spoken diagnostics with no wiring. On a non-Tegra host every check is an informational PASS (never cries wolf in CI). 20 host tests. Companion runbook `docs/hardware/JETSON_CUDA_SETUP.md` documents the per-consumer CUDA setup the WARNs point at.

## 2. First-clause streaming reply-to-TTS (`KIRRA_RABBIT_STREAM_TTS`, default off)

Rabbit's biggest perceived-latency cost on a chat turn is waiting for the whole reply before speaking. This adds opt-in streaming that starts **speaking the first sentence while the model is still generating the rest**.

The router emits JSON (`{say, directive}`), so a naive punctuation-split stream would read the JSON aloud — and voicing `say` eagerly would speak a drive turn's "on our way" before the door has decided. Both are avoided by routing the streaming path through a **directive-first** variant of the *same* router contract (all routing guardrails preserved verbatim; only field order changes):

- **CHAT turn** (directive null) → streams its `say` aloud clause-by-clause — the latency win.
- **DRIVE turn** (non-null directive) → voices **nothing** until `offer_to_door` has decided, exactly as today — its door-result-dependent line is never pre-empted.
- **Any** non-directive-first / malformed / failed stream → falls back to today's exact non-streaming path. Streaming can only match or beat current behaviour, never alter routing.

`parse_reply` stays the fail-closed **authority** on the directive (streaming only decides whether `say` was voiced early); barge-in shares one baseline across the streamed reply so a single interrupt stops the rest. Skills / mission / world-model / memory paths untouched. Default off → byte-identical.

- `robot/rabbit_stream.py` — pure `StreamingSayParser` + `split_ready_clauses` (JSON unescaping, truncated-escape safe). **12 host tests.**
- `robot/rabbit_stream_integration_test.py` — gate-off default + guardrail preservation + `parse_reply` order-agnosticism (skips where `requests` is absent, e.g. the CI lane).
- Runbook "Speed" section (item 6) + `rabbit.env.example` document the lever.

## Verification

- New host tests: gpu doctor 20/20, streaming parser 12/12, integration 1/1.
- Full robot turn-path sweep (voice/skills/mission/world-model/barge-in) still green.
- On-device gate for streaming: `rabbit_model_smoketest.py` — a model that ignores the field order simply falls back, losing only the speed-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_