### PR TITLE
robot: Ollama server-tuning drop-in + opt-in num_ctx + lidar orientation bring-up check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1317,6 +1317,13 @@ jobs:
           # routing guardrails, and parse_reply (the fail-closed directive authority)
           # is order-agnostic. See robot/rabbit_converse.py.
           python3 robot/rabbit_stream_integration_test.py
+          # Lidar orientation check (pure geometry, no ROS/hardware): the scan
+          # angle→direction labelling (0°=FRONT, +90°=LEFT), in-band return
+          # filtering, per-direction nearest, and the forward-aligned verdict — the
+          # bring-up tool that confirms 0° points forward and left/right isn't
+          # mirrored (the checker reads /scan raw, so this is safety-relevant). See
+          # robot/lidar_orient_check.py.
+          python3 robot/lidar_orient_check_test.py
           # Mission Executive (pure, no LLM/HTTP): fail-closed plan parsing,
           # validate REFUSING a mission with any unsupported skill before any
           # motion, and THE single-door invariant in run_mission — motion routes

--- a/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
@@ -176,13 +176,34 @@ tuned. In order of impact:
    the directive. Validate on your model with `rabbit_model_smoketest.py` before
    relying on it (a model that ignores the field order simply falls back, losing
    only the speed-up). Off → byte-identical to today.
+7. **Ollama server tuning** (the memory-bandwidth levers). The Orin NX is
+   bandwidth-bound, so the remaining wins come from moving fewer bytes per token —
+   flash attention + an 8-bit KV cache + a single inference slot. These are
+   **ollama-server env flags, not per-request options**, so they ship as a staged
+   systemd drop-in `robot/install/kirra-ollama-tuning.conf` (`OLLAMA_FLASH_ATTENTION=1`,
+   `OLLAMA_KV_CACHE_TYPE=q8_0`, `OLLAMA_NUM_PARALLEL=1`, `OLLAMA_MAX_LOADED_MODELS=1`,
+   `OLLAMA_KEEP_ALIVE`). Install it deliberately:
+   ```bash
+   sudo install -Dm0644 robot/install/kirra-ollama-tuning.conf \
+        /etc/systemd/system/ollama.service.d/kirra-tuning.conf
+   sudo systemctl daemon-reload && sudo systemctl restart ollama
+   ```
+   Gains are real but modest; measure a canned turn before/after. `q8_0` is
+   near-lossless — do not use `q4_*` for the router (a lossy KV cache can flip a
+   routing decision).
 
 Optionally cap the reply length with `KIRRA_RABBIT_NUM_PREDICT` — but see the
 warning in `rabbit.env.example`: too low TRUNCATES the router's `{say, directive}`
 JSON and fail-closes to a dropped drive command, so re-run
-`rabbit_model_smoketest.py` at your chosen value first. The router/persona system
-prompt is deliberately **not** trimmed for speed: its length is load-bearing
-correctness (the "never null a drive request" guardrail + the routing examples).
+`rabbit_model_smoketest.py` at your chosen value first. Likewise
+`KIRRA_RABBIT_NUM_CTX` caps the INPUT context window (smaller KV cache → faster
+prefill), but first check the effective size with `ollama ps` — only cap if it
+defaults large — and mind the same truncation caveat on the input side (it can
+drop the system prompt / history / telemetry). The router/persona system prompt
+is deliberately **not** trimmed for speed: its length is load-bearing correctness
+(the "never null a drive request" guardrail + the routing examples), and because
+it is a stable prefix Ollama already reuses its KV cache across turns, so it is
+not re-paid every turn.
 
 ---
 

--- a/robot/install/README.md
+++ b/robot/install/README.md
@@ -129,6 +129,26 @@ ros2 topic hz /scan            # steady ~10 Hz (TG30)
 ros2 topic echo /scan --once   # finite, room-plausible ranges (not all 0/inf)
 ```
 
+**Lidar orientation — verify 0° points FORWARD and left/right isn't mirrored.**
+This is safety-relevant: the checker + Taj read `/scan` **raw** and treat angle 0
+as the ego +X axis (forward), +90° as left — there is **no tf/offset layer**, so a
+rotated or mirrored sensor corrupts the robot's whole notion of "ahead" and
+"which side." `ros2 topic echo` truncates the array (and prints from −180° =
+behind), so it can't show the front rays — use the bring-up tool instead:
+
+```bash
+# Put a narrow object (box/pole) ~1 m directly in FRONT of the robot's centreline.
+python3 robot/lidar_orient_check.py     # only needs rclpy + sensor_msgs
+#   valid returns=<N>                    (0 → the lidar isn't producing data, not orientation)
+#   NEAREST return overall: ~1 m at ~0°  ->  FRONT   ← 0° faces forward ✅
+```
+
+- Nearest reads **LEFT** (≈+90°) → sensor rotated; rotate the unit 90° **clockwise**
+  (top view). **RIGHT** (≈−90°) → 90° CCW. **BEHIND** (≈180°) → 180°.
+- Then move the object to the robot's **LEFT** and re-run: **LEFT** should go short,
+  **RIGHT** stay long. If **RIGHT** goes short, left/right are mirrored → flip
+  `inverted` in `robot/install/captured/yahboom/ydlidar/ydlidar.yaml` and relaunch.
+
 ```bash
 # (c) First governed motion — 🔴 WHEELS ELEVATED:
 /opt/kirra/robot/first_run_elevated.sh

--- a/robot/install/kirra-ollama-tuning.conf
+++ b/robot/install/kirra-ollama-tuning.conf
@@ -1,0 +1,47 @@
+# kirra-ollama-tuning.conf — Ollama SERVER tuning for fast Rabbit inference on Jetson.
+#
+# These are ollama-SERVER environment flags. They cannot be set from the Rabbit
+# HTTP request (that only carries per-request `options` like temperature /
+# num_predict), which is why they live here as a systemd drop-in and not in
+# rabbit.env. None of this touches the checker, the governor, or the fence — it is
+# the doer-side (Channel A) inference layer only, exactly like the nvpmodel /
+# jetson_clocks perf unit (kirra-jetson-perf.service).
+#
+# INSTALL (STAGED + deliberate — not auto-applied; the same drop-in mechanism as
+# the Ollama keep_alive override you may already have):
+#   sudo install -Dm0644 robot/install/kirra-ollama-tuning.conf \
+#        /etc/systemd/system/ollama.service.d/kirra-tuning.conf
+#   sudo systemctl daemon-reload && sudo systemctl restart ollama
+#
+# VERIFY it took:
+#   systemctl show ollama -p Environment | tr ' ' '\n' | grep OLLAMA_
+#   ollama run "$KIRRA_RABBIT_MODEL" hi >/dev/null   # warm the model
+#   curl -s localhost:11434/api/ps | python3 -m json.tool   # size_vram > 0 == on GPU
+# Then measure a canned turn before/after — the gains are real but MODEST against
+# the Orin NX's memory-bandwidth wall; do not expect miracles.
+#
+# WHY each flag (the Orin NX is memory-BANDWIDTH-bound, so the wins come from
+# moving fewer bytes per token, not more compute):
+#
+#  - OLLAMA_FLASH_ATTENTION=1 — flash attention: less memory traffic for the
+#    attention step → lower TTFT and faster decode. It is also the PREREQUISITE
+#    for KV-cache quantization below.
+#  - OLLAMA_KV_CACHE_TYPE=q8_0 — store the KV cache in 8-bit (requires flash
+#    attention). Halves KV-cache bandwidth/footprint at ~no quality cost (q8_0 is
+#    near-lossless). Do NOT use q4_* here — the router must stay accurate; a
+#    lossy cache can flip a routing decision.
+#  - OLLAMA_NUM_PARALLEL=1 — Rabbit is a SINGLE user. One slot dedicates the whole
+#    KV cache to the one request instead of pre-splitting it across parallel slots
+#    (each slot gets a smaller context) → better single-request latency.
+#  - OLLAMA_MAX_LOADED_MODELS=1 — never evict/reload the resident doer to make room
+#    for a second model; removes surprise reload stalls on a memory-tight box.
+#  - OLLAMA_KEEP_ALIVE=30m — keep the model resident (mirrors the app-level
+#    KIRRA_RABBIT_KEEP_ALIVE default; use -1 to pin it forever on a dedicated
+#    robot). Kills the ~5-min-idle cold-reload stall.
+#
+[Service]
+Environment="OLLAMA_FLASH_ATTENTION=1"
+Environment="OLLAMA_KV_CACHE_TYPE=q8_0"
+Environment="OLLAMA_NUM_PARALLEL=1"
+Environment="OLLAMA_MAX_LOADED_MODELS=1"
+Environment="OLLAMA_KEEP_ALIVE=30m"

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -121,6 +121,13 @@ KIRRA_RABBIT_MODEL="gemma3:4b"
 # re-run rabbit_model_smoketest.py at your chosen value and it still passes the
 # drive→directive cases (it imports the same options, so it catches a bad cap).
 #KIRRA_RABBIT_NUM_PREDICT=200
+# Input context window cap (OPT-IN, default unset → Ollama's default). Smaller
+# num_ctx = smaller KV cache = less memory bandwidth + faster prefill/TTFT on the
+# bandwidth-bound Orin. FIRST check the effective size with `ollama ps`; only cap
+# if it defaults large. Same truncation caveat as num_predict but on the INPUT
+# side — too small drops the system prompt / history / telemetry and can degrade
+# routing, so keep it well above one turn and re-run rabbit_model_smoketest.py.
+#KIRRA_RABBIT_NUM_CTX=4096
 # First-clause streaming to TTS (Slice T, OPT-IN, default off). Rabbit starts
 # SPEAKING the first sentence of a chat reply while the model generates the rest
 # — the biggest drop in PERCEIVED latency per turn. Safe: the router goes
@@ -143,6 +150,11 @@ KIRRA_RABBIT_MODEL="gemma3:4b"
 #        sudo nvpmodel -m 0 && sudo jetson_clocks
 #      max power mode + locked clocks. The single biggest inference speedup after
 #      keep_alive; see docs/hardware/RABBIT_BRINGUP_RUNBOOK.md ("Speed").
+#   6. Ollama SERVER flags (NOT env here — these are ollama.service flags, not
+#      per-request options): flash attention + q8_0 KV cache + single-slot. Stage
+#      the drop-in robot/install/kirra-ollama-tuning.conf. Cuts bytes-per-token on
+#      the bandwidth-bound Orin; see RABBIT_BRINGUP_RUNBOOK.md ("Speed").
+#   7. KIRRA_RABBIT_STREAM_TTS + KIRRA_RABBIT_NUM_CTX (above).
 
 # ── Loop endpoints (localhost defaults; override only if you moved a service) ─
 KIRRA_VERIFIER_URL="http://localhost:8090"   # posture (/metrics), narration source

--- a/robot/lidar_orient_check.py
+++ b/robot/lidar_orient_check.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""lidar_orient_check.py — verify the lidar points FORWARD and left/right isn't
+mirrored, from one live /scan. A bring-up tool: it needs nothing but rclpy +
+sensor_msgs (NOT the kirra_safety workspace, unlike inspect_corridor.py), so it
+runs the moment the ydlidar driver is publishing.
+
+WHY it matters (safety, not cosmetics): the checker + Taj read /scan RAW and
+treat the ray at angle 0 as the ego +X axis (forward), +90° as +Y (left). There
+is no tf/offset layer. So if the sensor's 0° is not physically forward, the
+robot's whole notion of "ahead" is wrong (it brakes for phantom side obstacles,
+misses real front ones); if left/right are mirrored, lateral RSS sees hazards on
+the wrong side. This tool confirms both.
+
+USAGE:
+  1. Put a single narrow object (box/pole) ~1 m directly in FRONT of the robot's
+     centerline, nothing else close. Run it — the nearest return should read
+     FRONT at ~0°.
+  2. Move the object to the robot's LEFT and re-run — LEFT should go short (the
+     object), RIGHT stay long. If RIGHT goes short instead, left/right are
+     mirrored → flip `inverted` in the ydlidar params and relaunch.
+
+  python3 robot/lidar_orient_check.py
+
+Read-only, zero actuation. The pure geometry (angle math, direction labelling)
+is host-tested in robot/lidar_orient_check_test.py; only the /scan grab is live.
+"""
+from __future__ import annotations
+
+import math
+
+# A return within this many degrees of a cardinal target counts toward it.
+DIR_TOLERANCE_DEG = 10.0
+# A nearest return within this many degrees of 0 is "aligned forward".
+FORWARD_ALIGN_DEG = 5.0
+
+
+# ---- pure geometry (host-tested) --------------------------------------------
+
+def wrap180(a_deg: float) -> float:
+    """Normalize an angle to (-180, 180]."""
+    return ((a_deg + 180.0) % 360.0) - 180.0
+
+
+def valid_returns(angle_min_rad, angle_increment_rad, ranges, range_min, range_max):
+    """[(angle_deg, range_m)] for finite in-band returns, in scan order."""
+    out = []
+    for i, r in enumerate(ranges):
+        if math.isfinite(r) and range_min < r < range_max:
+            out.append((math.degrees(angle_min_rad + i * angle_increment_rad), float(r)))
+    return out
+
+
+def direction_label(a_deg: float) -> str:
+    """FRONT / LEFT / RIGHT / BEHIND for an angle, or 'off the main axes'."""
+    a = wrap180(a_deg)
+    if abs(a) <= 20.0:
+        return "FRONT"
+    if abs(a - 90.0) <= 20.0:
+        return "LEFT"
+    if abs(a + 90.0) <= 20.0:
+        return "RIGHT"
+    if abs(abs(a) - 180.0) <= 20.0:
+        return "BEHIND"
+    return "off the main axes"
+
+
+def direction_min(valid, target_deg: float, tol_deg: float = DIR_TOLERANCE_DEG) -> float:
+    """Nearest range within ±tol of target_deg, or +inf if nothing there."""
+    xs = [r for a, r in valid if abs(wrap180(a - target_deg)) <= tol_deg]
+    return min(xs) if xs else float("inf")
+
+
+def summarize(valid):
+    """A report dict from the valid returns (or None if there are none)."""
+    if not valid:
+        return None
+    ang, rng = min(valid, key=lambda ar: ar[1])
+    return {
+        "count": len(valid),
+        "nearest_deg": ang,
+        "nearest_m": rng,
+        "nearest_label": direction_label(ang),
+        "front_m": direction_min(valid, 0.0),
+        "left_m": direction_min(valid, 90.0),
+        "right_m": direction_min(valid, -90.0),
+        "behind_m": direction_min(valid, 180.0),
+        "forward_aligned": abs(wrap180(ang)) <= FORWARD_ALIGN_DEG,
+    }
+
+
+def render(report) -> str:
+    if report is None:
+        return ("valid returns=0 — every range is 0/out-of-band. The lidar is NOT\n"
+                "producing data (motor not spinning / wrong baud / blocked view).\n"
+                "That is a DATA problem, not orientation — fix it first.")
+    lines = [
+        f"valid returns={report['count']}",
+        f"NEAREST return overall: {report['nearest_m']:.2f} m at "
+        f"{report['nearest_deg']:+.1f} deg  ->  {report['nearest_label']}",
+        f"   FRONT  (0): {report['front_m']:.2f} m",
+        f"   LEFT (+90): {report['left_m']:.2f} m",
+        f"   RIGHT(-90): {report['right_m']:.2f} m",
+        f"   BEHIND(180): {report['behind_m']:.2f} m",
+    ]
+    return "\n".join(lines)
+
+
+# ---- live /scan grab --------------------------------------------------------
+
+def _grab_scan(timeout_s: float = 5.0):
+    import rclpy
+    from rclpy.node import Node
+    from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+    from sensor_msgs.msg import LaserScan
+    import time
+
+    class _Grab(Node):
+        def __init__(self):
+            super().__init__("lidar_orient_check")
+            q = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,
+                           history=HistoryPolicy.KEEP_LAST, depth=1)
+            self.scan = None
+            self.create_subscription(LaserScan, "/scan", self._cb, q)
+
+        def _cb(self, m):
+            self.scan = m
+
+    rclpy.init()
+    try:
+        node = _Grab()
+        t0 = time.monotonic()
+        while node.scan is None and time.monotonic() - t0 < timeout_s:
+            rclpy.spin_once(node, timeout_sec=0.2)
+        scan = node.scan
+        node.destroy_node()
+        return scan
+    finally:
+        rclpy.shutdown()
+
+
+def main() -> int:
+    scan = _grab_scan()
+    if scan is None:
+        print("NO /scan received (is the ydlidar driver up and on ROS_DOMAIN_ID 28?)")
+        return 1
+    valid = valid_returns(scan.angle_min, scan.angle_increment,
+                          list(scan.ranges), scan.range_min, scan.range_max)
+    print(f"points={len(scan.ranges)}")
+    print(render(summarize(valid)))
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/robot/lidar_orient_check_test.py
+++ b/robot/lidar_orient_check_test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""lidar_orient_check_test — host tests for the pure lidar-orientation geometry.
+CI-safe: no ROS, no hardware (the /scan grab is the only live part, and it is not
+exercised here). Runner style matches rabbit_voice_test.py (assert-based, stdlib).
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import lidar_orient_check as loc  # noqa: E402
+
+
+def test_wrap180() -> None:
+    assert loc.wrap180(0.0) == 0.0
+    assert loc.wrap180(190.0) == -170.0
+    assert loc.wrap180(-190.0) == 170.0
+    assert loc.wrap180(360.0) == 0.0
+
+
+def test_direction_label_cardinals() -> None:
+    assert loc.direction_label(0.0) == "FRONT"
+    assert loc.direction_label(-0.8) == "FRONT"        # the real front-box reading
+    assert loc.direction_label(91.6) == "LEFT"         # the real left-box reading
+    assert loc.direction_label(-90.0) == "RIGHT"
+    assert loc.direction_label(180.0) == "BEHIND"
+    assert loc.direction_label(-180.0) == "BEHIND"
+    assert loc.direction_label(45.0) == "off the main axes"
+
+
+def test_valid_returns_filters_out_of_band_and_nonfinite() -> None:
+    # 5 rays from -180° stepping +90°: -180, -90, 0, 90, 180.
+    ranges = [0.0, 2.0, 1.0, float("inf"), 60.0]   # 0.0 too small, inf/60 out of band
+    v = loc.valid_returns(math.radians(-180.0), math.radians(90.0), ranges, 0.01, 50.0)
+    # only the -90° (2.0) and 0° (1.0) rays survive
+    angs = sorted(round(a) for a, _ in v)
+    assert angs == [-90, 0], v
+
+
+def test_direction_min_picks_nearest_within_tolerance() -> None:
+    valid = [(-0.8, 1.39), (91.6, 0.97), (-90.0, 2.28), (2.0, 4.22)]
+    assert abs(loc.direction_min(valid, 0.0) - 1.39) < 1e-9   # front box, not the 4.22 ray
+    assert abs(loc.direction_min(valid, 90.0) - 0.97) < 1e-9
+    assert abs(loc.direction_min(valid, -90.0) - 2.28) < 1e-9
+    assert loc.direction_min(valid, 180.0) == float("inf")    # nothing behind
+
+
+def test_summarize_front_box_is_aligned() -> None:
+    # Reproduces the real bring-up reading: nearest 1.39 m at -0.8° → FRONT, aligned.
+    valid = [(-0.8, 1.39), (91.6, 2.12), (-90.0, 2.28)]
+    r = loc.summarize(valid)
+    assert r["nearest_label"] == "FRONT"
+    assert r["forward_aligned"] is True
+    assert abs(r["front_m"] - 1.39) < 1e-9
+
+
+def test_summarize_rotated_lidar_is_not_aligned() -> None:
+    # A front box that shows up at +91.6° means the sensor is rotated (front reads
+    # as left) → nearest labels LEFT and forward_aligned is False.
+    valid = [(91.6, 0.97), (-0.8, 4.22)]
+    r = loc.summarize(valid)
+    assert r["nearest_label"] == "LEFT"
+    assert r["forward_aligned"] is False
+
+
+def test_summarize_none_on_no_returns() -> None:
+    assert loc.summarize([]) is None
+    assert "DATA problem" in loc.render(None)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    print("lidar_orient_check host tests (no hardware):")
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok   {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -78,6 +78,17 @@ ROUTER_LLM_OPTIONS = {"temperature": 0.1}
 _num_predict = (os.environ.get("KIRRA_RABBIT_NUM_PREDICT") or "").strip()
 if _num_predict.lstrip("-").isdigit():
     ROUTER_LLM_OPTIONS["num_predict"] = int(_num_predict)
+# Speed (Slice S, OPT-IN): cap the INPUT context window (num_ctx). Smaller ctx =
+# smaller KV cache = less memory bandwidth and faster prefill/TTFT on the
+# bandwidth-bound Orin. DEFAULT UNSET → Ollama's own default (check the effective
+# size with `ollama ps`; only cap if it is defaulting large). SAME truncation
+# caveat as num_predict but on the INPUT side: too small drops the system prompt /
+# history / telemetry and can silently degrade routing, so keep it comfortably
+# above one turn (system prompt + a few history pairs + the telemetry block) and
+# let the smoketest (which imports these options) catch a bad value.
+_num_ctx = (os.environ.get("KIRRA_RABBIT_NUM_CTX") or "").strip()
+if _num_ctx.isdigit() and int(_num_ctx) > 0:
+    ROUTER_LLM_OPTIONS["num_ctx"] = int(_num_ctx)
 
 STAGE2_SYSTEM = (
     RABBIT_SYSTEM

--- a/robot/rabbit_stream_integration_test.py
+++ b/robot/rabbit_stream_integration_test.py
@@ -57,6 +57,32 @@ def test_stream_gate_defaults_off_and_guardrails_preserved() -> None:
     assert directive == "creep forward" and say == "Creeping forward.", (say, directive)
 
 
+def test_num_ctx_env_wires_into_router_options() -> None:
+    if not _HAVE_REQUESTS:
+        print("  skip (requests unavailable — CI lane)")
+        return
+    import importlib
+    prev = os.environ.get("KIRRA_RABBIT_NUM_CTX")
+    try:
+        os.environ["KIRRA_RABBIT_NUM_CTX"] = "2048"
+        import rabbit_converse
+        importlib.reload(rabbit_converse)
+        assert rabbit_converse.ROUTER_LLM_OPTIONS.get("num_ctx") == 2048, \
+            "KIRRA_RABBIT_NUM_CTX must populate the router's num_ctx option"
+        # A non-positive / garbage value is ignored (falls back to Ollama's default).
+        os.environ["KIRRA_RABBIT_NUM_CTX"] = "0"
+        importlib.reload(rabbit_converse)
+        assert "num_ctx" not in rabbit_converse.ROUTER_LLM_OPTIONS, \
+            "a non-positive num_ctx must be ignored, not sent"
+    finally:
+        if prev is None:
+            os.environ.pop("KIRRA_RABBIT_NUM_CTX", None)
+        else:
+            os.environ["KIRRA_RABBIT_NUM_CTX"] = prev
+        import rabbit_converse
+        importlib.reload(rabbit_converse)
+
+
 def _run_all() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     print("rabbit_stream integration tests:")


### PR DESCRIPTION
Robot bring-up / doer-side tooling from the Gemma-on-Orin + lidar sessions. All Channel-A / ops config or read-only bring-up — **nothing touches the checker, governor, or fence.**

## 1. Ollama server tuning (Jetson bandwidth levers)

A code review of the LLM path established the app-side speed levers are already in place — `keep_alive` on every call, opt-in `num_predict`, `temperature 0.1`, MAXN + `jetson_clocks` (`kirra-jetson-perf.service`), and a stable system-prompt prefix Ollama already KV-caches across turns. The untapped set is the **memory-bandwidth levers**, and those are **ollama-server env flags, not per-request options**, so they can't be set from the Rabbit HTTP request.

- **`robot/install/kirra-ollama-tuning.conf`** — a STAGED `ollama.service` drop-in (same deliberate, not-auto-applied pattern as `kirra-jetson-perf.service`): `OLLAMA_FLASH_ATTENTION=1`, `OLLAMA_KV_CACHE_TYPE=q8_0` (near-lossless — q4 could flip a routing decision), `OLLAMA_NUM_PARALLEL=1` + `OLLAMA_MAX_LOADED_MODELS=1` (single-user: dedicate the whole KV cache, never reload the doer), `OLLAMA_KEEP_ALIVE`. Install command + verification in the file header.
- **`rabbit_converse.py`** — `KIRRA_RABBIT_NUM_CTX` opt-in (default unset → Ollama's default), mirroring the `num_predict` wiring; smaller input context = smaller KV cache = faster prefill/TTFT, same truncation caveat on the input side (the smoketest imports these options and catches a bad value). New integration test.

## 2. Lidar orientation bring-up check

A self-contained tool to confirm the lidar points forward and left/right isn't mirrored, from one live `/scan` — needing only `rclpy` + `sensor_msgs` (NOT the `kirra_safety` workspace, so it runs before the full stack is built; `inspect_corridor.py` needs that workspace).

Safety-relevant: the checker + Taj read `/scan` **raw** and treat angle 0 as the ego +X axis (forward), +90° as +Y (left) — no tf/offset layer — so a rotated sensor corrupts "ahead" and a mirrored scan puts lateral hazards on the wrong side. `ros2 topic echo` truncates the array (and prints from −180° = behind), so it can't show the front rays; this reports the nearest return's angle + per-direction nearest + a forward-aligned verdict.

- **`robot/lidar_orient_check.py`** — pure geometry (`wrap180` / `valid_returns` / `direction_label` / `direction_min` / `summarize` / `render`) + a thin live `/scan` grab.
- **`robot/lidar_orient_check_test.py`** — 7 host tests over the pure core, incl. the real bring-up readings (front box at −0.8° → FRONT aligned; a +91.6° box → LEFT, rotated).
- **`robot/install/README.md`** — a "Lidar orientation" step next to the existing `/scan` liveness check, with the rotate-by-N and flip-`inverted` guidance.

## Docs + verification

- `rabbit.env.example` + `RABBIT_BRINGUP_RUNBOOK.md` "Speed" document both LLM levers (drop-in install command, "check `ollama ps` before capping ctx" guidance, honest "modest gains against the bandwidth wall" framing).
- New host tests: `num_ctx` wiring (skips where `requests` absent) + lidar geometry 7/7. Robot turn-path sweep green; defaults byte-identical (`num_ctx` unset, drop-in staged not applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum