### PR TITLE
taj: camera into Phase-B perception (tighten-only) + object-goal resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1357,7 +1357,9 @@ jobs:
           # fail-closed cores are deliberately rclpy-free): enforcement
           # decision, the A3 wheelbase cross-check, the ADR-0033 release-frame
           # carriage (strict 32/96 parse, never slice/pad), perception cap,
-          # and the doer geometry + staleness-budget validation.
+          # the doer geometry + staleness-budget validation, and the classical-CV
+          # camera detector core (pixel->ego projection, colour grounding, and the
+          # fail-closed "a frame I could not see is not `clear`" stamp rule).
           python3 -m pip install --quiet pytest
           python3 -m pytest ros2_ws/src/kirra_safety/test/ -q
       - name: Install cargo-audit

--- a/crates/kirra-sidecars/src/planner.rs
+++ b/crates/kirra-sidecars/src/planner.rs
@@ -28,6 +28,10 @@ use kirra_planner::{
     plan_for_intent, EgoState, FleetPosture, GeometricPlanner, GeometricPlannerConfig, Goal,
     MickIntent, PlanInput, Pose, ProposalKind,
 };
+use kirra_taj::object_goal::{
+    resolve_object_goal, LabeledTarget, DEFAULT_GOAL_MAX_AGE_MS, DEFAULT_MIN_CONFIDENCE,
+    DEFAULT_TIE_EPSILON_M,
+};
 use kirra_trajectory::corridor::{CorridorSource, Point};
 use kirra_trajectory::state::{PerceivedObject, TrajectoryVerdict};
 use kirra_trajectory::validation::validate_trajectory_slow_explained;
@@ -85,6 +89,41 @@ pub struct PlanRequest {
     /// behavior, byte-identical).
     #[serde(default)]
     pub intent: Option<serde_json::Value>,
+    /// **Object goal** (OPT-IN) — the operator's requested thing, e.g. `"red cup"`.
+    /// Resolved against `targets` into a plain `GoTo`, so it is a DESTINATION and
+    /// asserts nothing about drivability (`kirra_taj::object_goal`). Absent →
+    /// byte-identical prior behaviour. Supplying BOTH this and `intent` is a
+    /// rejected ambiguity (two goal sources), never a silent precedence rule.
+    #[serde(default)]
+    pub object_goal: Option<String>,
+    /// Camera-detected LABELLED things, in the **ego frame** (+X forward, +Y left) —
+    /// the goal channel's input. Not a drivability claim; the corridor still comes
+    /// from lidar (see `taj::CameraDetection` for the drivability channel).
+    #[serde(default)]
+    pub targets: Vec<TargetReq>,
+    /// Producer stamp of the camera frame `targets` came from. Absent while
+    /// `object_goal` is set → refused as STALE ("the detector did not look" is
+    /// never "it isn't there").
+    #[serde(default)]
+    pub targets_stamp_ms: Option<u64>,
+    /// Consumer clock for the freshness check. Absent → the frame's own stamp
+    /// (age 0), matching this service's stateless convention where wall-clock
+    /// staleness is the caller's job.
+    #[serde(default)]
+    pub now_ms: Option<u64>,
+}
+
+/// One labelled camera target on the wire — see [`PlanRequest::targets`].
+#[derive(Deserialize)]
+pub struct TargetReq {
+    pub label: String,
+    pub x: f64,
+    pub y: f64,
+    #[serde(default = "default_target_confidence")]
+    pub confidence: f32,
+}
+fn default_target_confidence() -> f32 {
+    1.0
 }
 fn default_cruise() -> f64 {
     10.0
@@ -320,7 +359,62 @@ fn validate_in_map(req: &PlanRequest, target: (f64, f64)) -> Result<(), SeamReje
 /// (the ONE fail-closed parse — a rejected intent is a [`SeamRejection`],
 /// never a fallback to the request goal), else a `GoTo` at the request goal
 /// (the pre-intent behavior).
+/// Resolve an `object_goal` request ("drive to the red cup") into a plain
+/// `MickIntent::GoTo`.
+///
+/// 🔴 The resolved point is a DESTINATION ONLY — it makes no drivability claim.
+/// The corridor still comes from lidar and the checker still bounds the
+/// trajectory, so a target that is visible but unreachable yields a plan that
+/// stops short rather than one that drives at it. Emitting an ordinary `GoTo`
+/// (rather than a new intent variant) is what keeps that true: nothing
+/// downstream can tell this goal came from a camera.
+///
+/// The resolver works in the EGO frame; `GoTo` is world-framed, so the goal is
+/// transformed through the ego pose (`ObjectGoal::to_world`). Every refusal is
+/// fail-closed → `SeamRejection` → NO MOTION, carrying the stable machine code
+/// plus the operator sentence for narration.
+fn object_goal_intent(req: &PlanRequest, label: &str) -> Result<MickIntent, SeamRejection> {
+    if req.intent.is_some() {
+        return Err(SeamRejection {
+            code: "PLAN_AMBIGUOUS_GOAL_SOURCE",
+            detail: "both `intent` and `object_goal` were supplied — refusing rather \
+                     than silently preferring one; NO MOTION"
+                .to_string(),
+        });
+    }
+    let targets: Vec<LabeledTarget> = req
+        .targets
+        .iter()
+        .map(|t| LabeledTarget {
+            label: t.label.clone(),
+            x_m: t.x,
+            y_m: t.y,
+            confidence: t.confidence,
+        })
+        .collect();
+    // Stateless freshness: absent consumer clock → the frame's own stamp (age 0).
+    let now = req.now_ms.or(req.targets_stamp_ms).unwrap_or(0);
+    let goal = resolve_object_goal(
+        label,
+        &targets,
+        req.targets_stamp_ms,
+        now,
+        DEFAULT_GOAL_MAX_AGE_MS,
+        DEFAULT_MIN_CONFIDENCE,
+        DEFAULT_TIE_EPSILON_M,
+    )
+    .map_err(|why| SeamRejection {
+        code: why.code(),
+        detail: kirra_taj::object_goal::refusal_sentence(label, why),
+    })?;
+    let (x_m, y_m) = goal.to_world(req.ego.x, req.ego.y, req.ego.heading);
+    Ok(MickIntent::GoTo { x_m, y_m })
+}
+
 fn effective_intent(req: &PlanRequest) -> Result<MickIntent, SeamRejection> {
+    if let Some(label) = req.object_goal.as_deref() {
+        return object_goal_intent(req, label);
+    }
     match &req.intent {
         None => Ok(MickIntent::GoTo {
             x_m: req.goal.x,
@@ -502,6 +596,12 @@ mod tests {
             objects: vec![],
             vehicle: None,
             intent: None,
+            // Object-goal channel off by default, so every pre-existing
+            // assertion still describes the plain-goal path.
+            object_goal: None,
+            targets: vec![],
+            targets_stamp_ms: None,
+            now_ms: None,
         }
     }
 
@@ -537,6 +637,93 @@ mod tests {
             r#"{"intent":"go_to","x_m":40.0,"y_m":0.0}"#
         ));
         handle_plan(&req).expect("string-embedded intent admits");
+    }
+
+    // ---- object goal: "drive to the red cup" -------------------------------
+
+    fn target(label: &str, x: f64, y: f64) -> TargetReq {
+        TargetReq {
+            label: label.into(),
+            x,
+            y,
+            confidence: 0.9,
+        }
+    }
+
+    /// The end-to-end shape of "drive to the red cup": a named camera target
+    /// becomes an ordinary `GoTo` and is planned + checked like any other goal.
+    #[test]
+    fn object_goal_grounds_a_named_target_as_a_plain_goto() {
+        let mut req = base_request();
+        req.object_goal = Some("red cup".into());
+        req.targets = vec![target("red cup", 30.0, 0.0)];
+        req.targets_stamp_ms = Some(1_000);
+        req.now_ms = Some(1_000);
+        let resp = handle_plan(&req).expect("a seen, reachable cup plans");
+        assert!(
+            !resp.trajectory.is_empty(),
+            "an admitted plan carries its trajectory"
+        );
+    }
+
+    /// Every resolver refusal is fail-closed at the seam: NO MOTION, carrying the
+    /// stable `OBJECT_GOAL_*` code — never a silent fallback to the request goal.
+    #[test]
+    fn object_goal_refusals_fail_closed_to_no_motion() {
+        // Not seen.
+        let mut req = base_request();
+        req.object_goal = Some("red cup".into());
+        req.targets = vec![target("chair", 10.0, 0.0)];
+        req.targets_stamp_ms = Some(1_000);
+        let e = handle_plan(&req).expect_err("an unseen target must refuse");
+        assert_eq!(e.code, "OBJECT_GOAL_NOT_SEEN");
+
+        // Armed but no camera frame → stale, never "it isn't there".
+        let mut req = base_request();
+        req.object_goal = Some("red cup".into());
+        req.targets = vec![target("red cup", 10.0, 0.0)];
+        req.targets_stamp_ms = None;
+        assert_eq!(
+            handle_plan(&req).expect_err("no frame must refuse").code,
+            "OBJECT_GOAL_STALE"
+        );
+
+        // A red request must never drive to a blue cup.
+        let mut req = base_request();
+        req.object_goal = Some("red cup".into());
+        req.targets = vec![target("blue cup", 10.0, 0.0)];
+        req.targets_stamp_ms = Some(1_000);
+        assert_eq!(
+            handle_plan(&req)
+                .expect_err("wrong colour must refuse")
+                .code,
+            "OBJECT_GOAL_NOT_SEEN"
+        );
+    }
+
+    /// Two goal sources is an ambiguity we refuse rather than resolve by a silent
+    /// precedence rule.
+    #[test]
+    fn object_goal_plus_typed_intent_is_a_refused_ambiguity() {
+        let mut req = base_request();
+        req.object_goal = Some("red cup".into());
+        req.targets = vec![target("red cup", 30.0, 0.0)];
+        req.targets_stamp_ms = Some(1_000);
+        req.intent = Some(serde_json::json!({"intent":"go_to","x_m":40.0,"y_m":0.0}));
+        assert_eq!(
+            handle_plan(&req)
+                .expect_err("two goal sources must refuse")
+                .code,
+            "PLAN_AMBIGUOUS_GOAL_SOURCE"
+        );
+    }
+
+    /// Absent `object_goal` leaves the endpoint byte-identical to its prior form.
+    #[test]
+    fn no_object_goal_is_unchanged_behaviour() {
+        let req = base_request();
+        assert!(req.object_goal.is_none() && req.targets.is_empty());
+        handle_plan(&req).expect("the plain-goal path still plans");
     }
 
     #[test]

--- a/crates/kirra-sidecars/src/taj.rs
+++ b/crates/kirra-sidecars/src/taj.rs
@@ -10,8 +10,81 @@
 //! `speed_cap_mps: 0.0` (the MRC floor — the consumer holds).
 
 use kirra_core::corridor::CorridorSource;
-use kirra_taj::{LaserScan, TajConfig, TajPhaseA};
+use kirra_taj::{
+    clip_corridor_to_hazards, hazard_clip_x, LaserScan, SemanticClass, SemanticDetection,
+    TajConfig, TajPhaseA,
+};
 use serde::{Deserialize, Serialize};
+
+/// Default freshness budget for the camera (Phase-B) channel, ms.
+pub const DEFAULT_CAMERA_MAX_AGE_MS: u64 = 500;
+
+/// One camera-derived semantic region, in the ego frame (+X forward, +Y left) —
+/// the wire form of [`SemanticDetection`].
+///
+/// 🔴 **This is a SAFETY classification, not a goal label.** `class` answers only
+/// "may the ego drive here?", and the fusion is **TIGHTEN-ONLY**: a detection can
+/// shorten the drivable corridor, never extend it (the KPI gate's `ForbiddenLoosen`
+/// is a hard zero). Lidar (Phase A) remains the **sole authority on free space** —
+/// the camera cannot make unseen ground drivable. An unrecognized class token
+/// decodes to [`SemanticClass::Unknown`], which is non-drivable (fail-closed:
+/// never assume drivable).
+///
+/// Naming a *destination* ("the red cup") is a different concern entirely — see
+/// `kirra_taj::object_goal`, which produces a GOAL POINT and makes no drivability
+/// claim whatsoever.
+#[derive(Deserialize)]
+pub struct CameraDetection {
+    /// `road` | `water` | `static_obstacle` | anything else → `unknown`.
+    pub class: String,
+    /// Nearest forward distance to the region (m, ego frame).
+    pub near_x_m: f64,
+    /// Lateral extent `[min, max]` (m; +Y left).
+    pub lateral_min_m: f64,
+    pub lateral_max_m: f64,
+}
+
+impl CameraDetection {
+    /// Decode to the safety type. Unknown/garbage tokens fail closed to
+    /// [`SemanticClass::Unknown`] (non-drivable) rather than being dropped — a
+    /// detection we cannot classify is a hazard, never free space.
+    fn to_semantic(&self) -> SemanticDetection {
+        let class = match self.class.trim().to_ascii_lowercase().as_str() {
+            "road" => SemanticClass::Road,
+            "water" => SemanticClass::Water,
+            "static_obstacle" | "obstacle" => SemanticClass::StaticObstacle,
+            _ => SemanticClass::Unknown,
+        };
+        SemanticDetection {
+            class,
+            near_x_m: self.near_x_m,
+            lateral_min_m: self.lateral_min_m,
+            lateral_max_m: self.lateral_max_m,
+        }
+    }
+
+    /// A detection with any non-finite geometry cannot be reasoned about; the
+    /// caller treats its presence as a perception fault (fail-closed), never
+    /// silently ignores it.
+    fn is_finite(&self) -> bool {
+        self.near_x_m.is_finite()
+            && self.lateral_min_m.is_finite()
+            && self.lateral_max_m.is_finite()
+    }
+}
+
+/// Camera (Phase-B) channel verdict for one request — the same three-way,
+/// fail-closed decision the occlusion / VRU channels make: DISARMED → no-op,
+/// armed+fresh → live fusion, armed+silent-or-garbage → MRC floor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CameraChannel {
+    /// Not configured → Phase-B never runs (byte-identical to lidar-only).
+    Disarmed,
+    /// Armed and the frame is fresh → fuse the detections (tighten-only).
+    Fresh,
+    /// Armed but no frame / stale / non-finite geometry → fail closed.
+    Faulted,
+}
 
 #[derive(Deserialize)]
 pub struct PerceptionRequest {
@@ -32,6 +105,57 @@ pub struct PerceptionRequest {
     pub lane_half_m: f64,
     #[serde(default = "default_floor")]
     pub confidence_floor: f32,
+    /// Phase-B camera channel (OPT-IN). `false` (default) → the camera fusion
+    /// never runs and this endpoint is byte-identical to its lidar-only form.
+    #[serde(default)]
+    pub camera_armed: bool,
+    /// Camera-derived semantic regions for THIS frame (tighten-only; see
+    /// [`CameraDetection`]). Empty with a fresh `camera_stamp_ms` legitimately
+    /// means "the camera looked and saw no hazard".
+    #[serde(default)]
+    pub detections: Vec<CameraDetection>,
+    /// Producer stamp of the camera frame the detections came from. `None` while
+    /// `camera_armed` is a SILENT channel → fail closed ("the detector did not
+    /// look" is never "clear").
+    #[serde(default)]
+    pub camera_stamp_ms: Option<u64>,
+    /// Freshness budget for `camera_stamp_ms` against `stamp_ms`.
+    #[serde(default = "default_camera_age")]
+    pub camera_max_age_ms: u64,
+}
+fn default_camera_age() -> u64 {
+    DEFAULT_CAMERA_MAX_AGE_MS
+}
+
+/// Pure three-way camera-channel decision (host-tested). Mirrors
+/// `resolve_occlusion_channel` / `resolve_vru_channel`: an ARMED-but-silent or
+/// stale or geometrically-invalid channel is a perception GAP, never a verdict.
+/// A camera stamp implausibly far in the FUTURE is also stale (the same
+/// non-monotonic-clock hole the scene-veto gates close).
+#[must_use]
+pub fn resolve_camera_channel(
+    armed: bool,
+    camera_stamp_ms: Option<u64>,
+    now_ms: u64,
+    max_age_ms: u64,
+    detections: &[CameraDetection],
+) -> CameraChannel {
+    if !armed {
+        return CameraChannel::Disarmed;
+    }
+    let Some(stamp) = camera_stamp_ms else {
+        return CameraChannel::Faulted; // armed but silent
+    };
+    if stamp > now_ms.saturating_add(max_age_ms) {
+        return CameraChannel::Faulted; // implausible future stamp
+    }
+    if now_ms.saturating_sub(stamp) > max_age_ms {
+        return CameraChannel::Faulted; // stale
+    }
+    if detections.iter().any(|d| !d.is_finite()) {
+        return CameraChannel::Faulted; // undecodable geometry
+    }
+    CameraChannel::Fresh
 }
 fn default_extent() -> f64 {
     20.0
@@ -72,6 +196,15 @@ pub struct PerceptionResponse {
     pub left: Vec<[f64; 2]>,
     pub right: Vec<[f64; 2]>,
     pub objects: Vec<ObjOut>,
+    /// Phase-B observability: `false` when the camera channel is ARMED but the
+    /// frame is missing / stale / undecodable (the request then fails closed to
+    /// the MRC floor). `true` when disarmed (nothing to be unhealthy about) or
+    /// fresh.
+    pub camera_healthy: bool,
+    /// Forward distance at which the camera fusion clipped the corridor, when a
+    /// detection bound it. `None` = no camera hazard bound the corridor. The
+    /// clip can only SHORTEN the drivable space.
+    pub camera_clip_x_m: Option<f64>,
 }
 
 /// The corridor's straight-ahead reach: the smaller of the two boundary
@@ -101,9 +234,41 @@ pub fn handle_perception(req: &PerceptionRequest) -> PerceptionResponse {
     });
     let perception = taj.process(&scan, req.stamp_ms);
 
-    let confidence = perception.corridor.confidence();
-    let age_ms = perception.corridor.age_ms();
-    let healthy = confidence >= req.confidence_floor;
+    // ---- Phase B: camera fusion (TIGHTEN-ONLY) -----------------------------
+    // The camera may only SHORTEN the drivable corridor Phase A produced; it can
+    // never extend it (`clip_corridor_to_hazards` truncates the boundaries, and
+    // the KPI gate's `ForbiddenLoosen` is a hard zero). Lidar stays the sole
+    // authority on free space.
+    let channel = resolve_camera_channel(
+        req.camera_armed,
+        req.camera_stamp_ms,
+        req.stamp_ms,
+        req.camera_max_age_ms,
+        &req.detections,
+    );
+    let camera_healthy = channel != CameraChannel::Faulted;
+    let (corridor, camera_clip_x_m) = match channel {
+        // Disarmed → untouched Phase-A corridor (byte-identical prior behaviour).
+        // Faulted → also untouched, but `camera_healthy=false` forces the MRC
+        // floor below, so a blind armed camera stops the robot rather than
+        // letting it drive on lidar alone as if nothing were wrong.
+        CameraChannel::Disarmed | CameraChannel::Faulted => (perception.corridor.clone(), None),
+        CameraChannel::Fresh => {
+            let dets: Vec<SemanticDetection> = req
+                .detections
+                .iter()
+                .map(CameraDetection::to_semantic)
+                .collect();
+            let clip = hazard_clip_x(&perception.corridor, &dets);
+            (clip_corridor_to_hazards(&perception.corridor, &dets), clip)
+        }
+    };
+
+    let confidence = corridor.confidence();
+    let age_ms = corridor.age_ms();
+    // Fail-closed conjunction: the corridor must clear the confidence floor AND
+    // the camera channel must not be faulted.
+    let healthy = confidence >= req.confidence_floor && camera_healthy;
 
     // The nearest IN-LANE object (|y| within half a lane), as a discrete
     // clear-distance bound that complements the corridor reach.
@@ -117,7 +282,9 @@ pub fn handle_perception(req: &PerceptionRequest) -> PerceptionResponse {
 
     // Clear distance = the tighter of the corridor reach and the nearest
     // in-lane object.
-    let clear = corridor_reach(&perception.corridor)
+    // Reach is measured on the CLIPPED corridor, so a camera hazard tightens the
+    // clear distance and therefore the ACD speed cap.
+    let clear = corridor_reach(&corridor)
         .min(nearest_object_m.unwrap_or(f64::INFINITY))
         .max(0.0);
 
@@ -133,8 +300,8 @@ pub fn handle_perception(req: &PerceptionRequest) -> PerceptionResponse {
     let to_poly = |pts: &[kirra_core::corridor::Point]| -> Vec<[f64; 2]> {
         pts.iter().map(|p| [p.x_m, p.y_m]).collect()
     };
-    let left = to_poly(perception.corridor.left_boundary());
-    let right = to_poly(perception.corridor.right_boundary());
+    let left = to_poly(corridor.left_boundary());
+    let right = to_poly(corridor.right_boundary());
     let objects = perception
         .objects
         .iter()
@@ -158,6 +325,8 @@ pub fn handle_perception(req: &PerceptionRequest) -> PerceptionResponse {
         left,
         right,
         objects,
+        camera_healthy,
+        camera_clip_x_m,
     }
 }
 
@@ -165,25 +334,212 @@ pub fn handle_perception(req: &PerceptionRequest) -> PerceptionResponse {
 mod tests {
     use super::*;
 
-    /// An empty / all-no-return scan reads as an unhealthy corridor → the
-    /// MRC floor cap (fail-closed, unchanged from the example's contract).
-    #[test]
-    fn empty_scan_fails_closed_to_the_mrc_floor() {
-        let resp = handle_perception(&PerceptionRequest {
+    /// A request over `ranges`, with the camera channel DISARMED by default —
+    /// so every pre-existing assertion still describes the lidar-only path.
+    fn req(ranges: Vec<f32>) -> PerceptionRequest {
+        PerceptionRequest {
             angle_min_rad: -1.5,
             angle_increment_rad: 0.01,
             range_min_m: 0.1,
             range_max_m: 12.0,
-            ranges: vec![f32::INFINITY; 300],
-            stamp_ms: 0,
+            ranges,
+            stamp_ms: 1_000,
             forward_extent_m: default_extent(),
             decel_mps2: default_decel(),
             margin_m: default_margin(),
             lane_half_m: default_lane_half(),
             confidence_floor: default_floor(),
-        });
+            camera_armed: false,
+            detections: Vec::new(),
+            camera_stamp_ms: None,
+            camera_max_age_ms: DEFAULT_CAMERA_MAX_AGE_MS,
+        }
+    }
+
+    /// A clear-ahead scan: returns far out on every ray, so Phase A yields a
+    /// healthy corridor with real forward reach for the camera to clip.
+    fn clear_scan() -> Vec<f32> {
+        vec![10.0; 300]
+    }
+
+    fn det(class: &str, near_x: f64, lat_min: f64, lat_max: f64) -> CameraDetection {
+        CameraDetection {
+            class: class.into(),
+            near_x_m: near_x,
+            lateral_min_m: lat_min,
+            lateral_max_m: lat_max,
+        }
+    }
+
+    /// An empty / all-no-return scan reads as an unhealthy corridor → the
+    /// MRC floor cap (fail-closed, unchanged from the example's contract).
+    #[test]
+    fn empty_scan_fails_closed_to_the_mrc_floor() {
+        let resp = handle_perception(&req(vec![f32::INFINITY; 300]));
         if !resp.healthy {
             assert_eq!(resp.speed_cap_mps, 0.0, "unhealthy → MRC floor");
         }
+    }
+
+    // ---- camera channel arming (the three-way, fail-closed decision) --------
+
+    #[test]
+    fn camera_channel_resolution_is_three_way() {
+        let none: Vec<CameraDetection> = vec![];
+        // Disarmed regardless of anything else.
+        assert_eq!(
+            resolve_camera_channel(false, None, 1_000, 500, &none),
+            CameraChannel::Disarmed
+        );
+        // Armed + fresh stamp → live.
+        assert_eq!(
+            resolve_camera_channel(true, Some(900), 1_000, 500, &none),
+            CameraChannel::Fresh
+        );
+        // Armed + SILENT (no frame) → fail closed.
+        assert_eq!(
+            resolve_camera_channel(true, None, 1_000, 500, &none),
+            CameraChannel::Faulted
+        );
+        // Armed + stale.
+        assert_eq!(
+            resolve_camera_channel(true, Some(100), 5_000, 500, &none),
+            CameraChannel::Faulted
+        );
+        // Armed + implausibly FUTURE stamp (non-monotonic clock) → stale.
+        assert_eq!(
+            resolve_camera_channel(true, Some(90_000), 1_000, 500, &none),
+            CameraChannel::Faulted
+        );
+        // Armed + fresh but non-finite geometry → fault, never silently skipped.
+        let bad = vec![det("water", f64::NAN, -1.0, 1.0)];
+        assert_eq!(
+            resolve_camera_channel(true, Some(900), 1_000, 500, &bad),
+            CameraChannel::Faulted
+        );
+    }
+
+    /// DEFAULT (disarmed) is byte-identical to the lidar-only endpoint: no clip,
+    /// camera reported healthy (nothing to be unhealthy about).
+    #[test]
+    fn disarmed_camera_leaves_the_corridor_untouched() {
+        let resp = handle_perception(&req(clear_scan()));
+        assert!(resp.camera_healthy);
+        assert_eq!(resp.camera_clip_x_m, None);
+    }
+
+    /// ARMED but silent → the robot must STOP, not carry on using lidar alone as
+    /// if nothing were wrong ("the detector did not look" is never "clear").
+    #[test]
+    fn armed_but_silent_camera_fails_closed_to_the_mrc_floor() {
+        let mut r = req(clear_scan());
+        r.camera_armed = true;
+        r.camera_stamp_ms = None;
+        let resp = handle_perception(&r);
+        assert!(!resp.camera_healthy);
+        assert!(!resp.healthy, "a blind armed camera must not read healthy");
+        assert_eq!(resp.speed_cap_mps, 0.0, "armed+silent → MRC floor");
+    }
+
+    /// A fresh frame with NO hazards is a legitimate "I looked, it's clear" —
+    /// distinct from silence, so it must NOT fail closed.
+    #[test]
+    fn armed_and_fresh_with_no_hazards_is_clear_not_faulted() {
+        let mut r = req(clear_scan());
+        r.camera_armed = true;
+        r.camera_stamp_ms = Some(1_000);
+        let resp = handle_perception(&r);
+        assert!(resp.camera_healthy);
+        assert_eq!(resp.camera_clip_x_m, None);
+        assert!(
+            resp.speed_cap_mps > 0.0,
+            "a clear look must not stop the robot"
+        );
+    }
+
+    // ---- TIGHTEN-ONLY: the load-bearing safety property --------------------
+
+    /// A water hazard across the lane clips the corridor and therefore the ACD
+    /// cap: the camera SHORTENS the clear distance.
+    #[test]
+    fn camera_hazard_tightens_clear_distance_and_speed_cap() {
+        let baseline = handle_perception(&req(clear_scan()));
+        let mut r = req(clear_scan());
+        r.camera_armed = true;
+        r.camera_stamp_ms = Some(1_000);
+        r.detections = vec![det("water", 2.0, -2.0, 2.0)];
+        let fused = handle_perception(&r);
+        assert_eq!(fused.camera_clip_x_m, Some(2.0));
+        assert!(
+            fused.clear_distance_m < baseline.clear_distance_m,
+            "camera hazard must SHORTEN clear distance ({} !< {})",
+            fused.clear_distance_m,
+            baseline.clear_distance_m
+        );
+        assert!(
+            fused.speed_cap_mps < baseline.speed_cap_mps,
+            "and therefore the cap"
+        );
+    }
+
+    /// 🔴 The property the KPI gate calls `ForbiddenLoosen`: no camera input of any
+    /// class, at any range, may make the corridor reach FARTHER than lidar-only.
+    /// Swept over classes × ranges — the camera can only ever tighten.
+    #[test]
+    fn camera_can_never_extend_the_corridor() {
+        let baseline = handle_perception(&req(clear_scan()));
+        for class in ["road", "water", "static_obstacle", "unknown", "banana"] {
+            for near_x in [0.5_f64, 1.0, 3.0, 7.0, 50.0] {
+                let mut r = req(clear_scan());
+                r.camera_armed = true;
+                r.camera_stamp_ms = Some(1_000);
+                r.detections = vec![det(class, near_x, -3.0, 3.0)];
+                let fused = handle_perception(&r);
+                assert!(
+                    fused.clear_distance_m <= baseline.clear_distance_m + 1e-9,
+                    "ForbiddenLoosen: class={class} near_x={near_x} extended reach \
+                     ({} > {})",
+                    fused.clear_distance_m,
+                    baseline.clear_distance_m
+                );
+                assert!(fused.speed_cap_mps <= baseline.speed_cap_mps + 1e-9);
+            }
+        }
+    }
+
+    /// `road` is the only drivable class, so a road detection never clips — and an
+    /// UNRECOGNIZED token must behave like `unknown` (non-drivable), not like road.
+    #[test]
+    fn unknown_class_tokens_fail_closed_to_non_drivable() {
+        let mut road = req(clear_scan());
+        road.camera_armed = true;
+        road.camera_stamp_ms = Some(1_000);
+        road.detections = vec![det("road", 2.0, -2.0, 2.0)];
+        assert_eq!(
+            handle_perception(&road).camera_clip_x_m,
+            None,
+            "road is drivable"
+        );
+
+        let mut garbage = req(clear_scan());
+        garbage.camera_armed = true;
+        garbage.camera_stamp_ms = Some(1_000);
+        garbage.detections = vec![det("definitely-not-a-class", 2.0, -2.0, 2.0)];
+        assert_eq!(
+            handle_perception(&garbage).camera_clip_x_m,
+            Some(2.0),
+            "an unclassifiable region is a hazard, never free space"
+        );
+    }
+
+    /// A hazard entirely outside the corridor's lateral span leaves it alone (no
+    /// over-tightening on things that aren't in the way).
+    #[test]
+    fn hazard_beside_the_corridor_does_not_clip() {
+        let mut r = req(clear_scan());
+        r.camera_armed = true;
+        r.camera_stamp_ms = Some(1_000);
+        r.detections = vec![det("water", 2.0, 8.0, 9.0)];
+        assert_eq!(handle_perception(&r).camera_clip_x_m, None);
     }
 }

--- a/crates/kirra-taj/src/lib.rs
+++ b/crates/kirra-taj/src/lib.rs
@@ -44,6 +44,10 @@ pub use semantic_eval::{
     DEFAULT_CLIP_TOL_M,
 };
 
+/// Object-goal resolution: a NAMED thing the operator asked for → a goal point.
+/// Deliberately separate from the drivability fusion above — see the module docs.
+pub mod object_goal;
+
 /// Minimal range-scan input — a `sensor_msgs/LaserScan` subset.
 ///
 /// Angles are measured from the ego **+X** axis (forward); **+Y** is left.

--- a/crates/kirra-taj/src/object_goal.rs
+++ b/crates/kirra-taj/src/object_goal.rs
@@ -88,6 +88,43 @@ pub const DEFAULT_GOAL_MAX_AGE_MS: u64 = 750;
 /// Minimum detector confidence for a target to be drivable-to as a GOAL.
 pub const DEFAULT_MIN_CONFIDENCE: f32 = 0.40;
 
+/// Two matches whose ranges differ by less than this are "equally near" → ambiguous.
+pub const DEFAULT_TIE_EPSILON_M: f64 = 0.25;
+
+impl GoalRefusal {
+    /// Stable machine code for a refusal — the narration/telemetry counterpart of
+    /// the checker's `TRAJECTORY_*` reason codes.
+    #[must_use]
+    pub fn code(self) -> &'static str {
+        match self {
+            GoalRefusal::NoRequestedLabel => "OBJECT_GOAL_NO_LABEL",
+            GoalRefusal::NotSeen => "OBJECT_GOAL_NOT_SEEN",
+            GoalRefusal::LowConfidence => "OBJECT_GOAL_LOW_CONFIDENCE",
+            GoalRefusal::Ambiguous => "OBJECT_GOAL_AMBIGUOUS",
+            GoalRefusal::Stale => "OBJECT_GOAL_STALE",
+            GoalRefusal::NonFinite => "OBJECT_GOAL_NON_FINITE",
+            GoalRefusal::BehindEgo => "OBJECT_GOAL_BEHIND_EGO",
+        }
+    }
+}
+
+impl ObjectGoal {
+    /// Ego-frame → world-frame, for callers whose goal type is world-framed (the
+    /// planner's `GoTo`). Standard 2-D rigid transform about the ego pose:
+    /// `world = ego_xy + R(heading) · ego_frame_xy`.
+    ///
+    /// Getting this wrong would aim the robot at the wrong place, so it is a
+    /// named, tested function rather than inline arithmetic at the call site.
+    #[must_use]
+    pub fn to_world(&self, ego_x_m: f64, ego_y_m: f64, ego_heading_rad: f64) -> (f64, f64) {
+        let (s, c) = ego_heading_rad.sin_cos();
+        (
+            ego_x_m + self.x_m * c - self.y_m * s,
+            ego_y_m + self.x_m * s + self.y_m * c,
+        )
+    }
+}
+
 /// Does `label` satisfy the operator's `requested` phrase?
 ///
 /// Deliberately simple + predictable (no fuzzy matching): every whitespace token
@@ -348,6 +385,63 @@ mod tests {
     }
 
     // ---- narration ----------------------------------------------------------
+
+    // ---- ego → world transform ---------------------------------------------
+
+    #[test]
+    fn to_world_at_origin_heading_zero_is_identity() {
+        let g = ObjectGoal {
+            label: "cup".into(),
+            x_m: 2.0,
+            y_m: 0.5,
+            confidence: 0.9,
+        };
+        let (x, y) = g.to_world(0.0, 0.0, 0.0);
+        assert!((x - 2.0).abs() < 1e-9 && (y - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn to_world_rotates_and_translates() {
+        // Ego at (10, 5) facing +90° (north): a target 2 m AHEAD of the ego lands
+        // 2 m north of the ego, i.e. (10, 7).
+        let g = ObjectGoal {
+            label: "cup".into(),
+            x_m: 2.0,
+            y_m: 0.0,
+            confidence: 0.9,
+        };
+        let (x, y) = g.to_world(10.0, 5.0, std::f64::consts::FRAC_PI_2);
+        assert!((x - 10.0).abs() < 1e-9, "x={x}");
+        assert!((y - 7.0).abs() < 1e-9, "y={y}");
+        // A target 1 m to the ego's LEFT while facing north lands 1 m WEST (-x).
+        let l = ObjectGoal {
+            label: "cup".into(),
+            x_m: 0.0,
+            y_m: 1.0,
+            confidence: 0.9,
+        };
+        let (lx, ly) = l.to_world(10.0, 5.0, std::f64::consts::FRAC_PI_2);
+        assert!((lx - 9.0).abs() < 1e-9, "lx={lx}");
+        assert!((ly - 5.0).abs() < 1e-9, "ly={ly}");
+    }
+
+    #[test]
+    fn every_refusal_has_a_stable_code() {
+        let mut seen = std::collections::HashSet::new();
+        for why in [
+            GoalRefusal::NoRequestedLabel,
+            GoalRefusal::NotSeen,
+            GoalRefusal::LowConfidence,
+            GoalRefusal::Ambiguous,
+            GoalRefusal::Stale,
+            GoalRefusal::NonFinite,
+            GoalRefusal::BehindEgo,
+        ] {
+            let c = why.code();
+            assert!(c.starts_with("OBJECT_GOAL_"), "{why:?} -> {c}");
+            assert!(seen.insert(c), "duplicate code {c}");
+        }
+    }
 
     #[test]
     fn every_refusal_has_an_operator_sentence() {

--- a/crates/kirra-taj/src/object_goal.rs
+++ b/crates/kirra-taj/src/object_goal.rs
@@ -1,0 +1,367 @@
+//! Object-goal resolution — "drive to the red cup" → a GOAL POINT.
+//!
+//! # The separation this module exists to enforce
+//!
+//! A camera contributes two things, and conflating them would be a safety bug:
+//!
+//! 1. **Drivability** (`SemanticClass` / [`crate::clip_corridor_to_hazards`]) —
+//!    "may the ego drive here?" That fusion is **TIGHTEN-ONLY**: a detection can
+//!    shorten the drivable corridor, never extend it. Lidar (Phase A) remains the
+//!    sole authority on free space.
+//! 2. **Where a NAMED THING is** (this module) — "the red cup is 2.4 m ahead,
+//!    0.3 m left." That is a **destination**, not a claim about the ground.
+//!
+//! 🔴 **A resolved object goal asserts NOTHING about drivability.** It is only a
+//! point the operator asked for. The path there is adjudicated exactly as any
+//! other goal: Occy plans inside the lidar corridor and the KIRRA checker bounds
+//! the trajectory, so a visible cup behind an obstacle produces a robot that
+//! **drives as far as is safe and stops short** — never one that drives at the cup
+//! because the camera "saw" it. That is why this returns a bare point and the
+//! caller emits an ordinary `MickIntent::GoTo`: no new intent variant, no new
+//! authority, no change to the fail-closed intent parse, and the single-door
+//! invariant (text → `/intent` → checker) is untouched.
+//!
+//! Fail-closed throughout: an unnamed / unmatched / stale / non-finite / ambiguous
+//! target yields **no goal**, and the caller then speaks instead of driving.
+
+/// A camera-detected, LABELLED thing the operator can name — the goal channel's
+/// input. Distinct from [`crate::SemanticDetection`] (the drivability channel) on
+/// purpose: this carries a free-text `label` and makes no drivability claim.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LabeledTarget {
+    /// Detector label, e.g. `"red cup"`, `"cup"`, `"person"`. Matched
+    /// case-insensitively against the operator's requested phrase.
+    pub label: String,
+    /// Centroid in the ego frame: +X forward, +Y left (metres) — the SAME frame
+    /// the lidar scan and corridor use (see the module docs on `crate`).
+    pub x_m: f64,
+    pub y_m: f64,
+    /// Detector confidence in `[0, 1]`.
+    pub confidence: f32,
+}
+
+impl LabeledTarget {
+    fn is_finite(&self) -> bool {
+        self.x_m.is_finite() && self.y_m.is_finite() && self.confidence.is_finite()
+    }
+}
+
+/// Why no goal was produced. Every arm is a REFUSAL to drive — the caller speaks
+/// the reason instead of moving.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GoalRefusal {
+    /// The operator's phrase named nothing we can match.
+    NoRequestedLabel,
+    /// No detection matched the requested label.
+    NotSeen,
+    /// Matches exist but none clears `min_confidence`.
+    LowConfidence,
+    /// Two or more equally-good matches — "which cup?" is ambiguous, so refuse
+    /// rather than silently pick one.
+    Ambiguous,
+    /// The camera frame is older than the freshness budget (or absent): a stale
+    /// sighting is not a present location.
+    Stale,
+    /// A matching target carried non-finite geometry.
+    NonFinite,
+    /// The match is behind the ego (`x <= 0`): this resolver only produces FORWARD
+    /// goals, so a behind-the-robot target refuses rather than commanding a
+    /// reverse manoeuvre nothing here is bounded for.
+    BehindEgo,
+}
+
+/// A resolved goal: a forward ego-frame point the caller turns into
+/// `MickIntent::GoTo { x_m, y_m }`. Carries the matched label + confidence purely
+/// for narration ("heading for the red cup, 2.4 m ahead").
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjectGoal {
+    pub label: String,
+    pub x_m: f64,
+    pub y_m: f64,
+    pub confidence: f32,
+}
+
+/// Freshness budget for the goal channel, ms. A sighting older than this is not a
+/// present location (the robot may have moved, or the object may have).
+pub const DEFAULT_GOAL_MAX_AGE_MS: u64 = 750;
+
+/// Minimum detector confidence for a target to be drivable-to as a GOAL.
+pub const DEFAULT_MIN_CONFIDENCE: f32 = 0.40;
+
+/// Does `label` satisfy the operator's `requested` phrase?
+///
+/// Deliberately simple + predictable (no fuzzy matching): every whitespace token
+/// of the request must appear as a substring of the label. So `"red cup"` matches
+/// `"red cup"` and `"large red cup"`, but not `"blue cup"` (no `red`) and not
+/// `"cup"` alone (no `red`) — asking for a *red* cup must not drive to a blue one.
+/// A bare `"cup"` request matches any cup.
+#[must_use]
+pub fn label_matches(label: &str, requested: &str) -> bool {
+    let hay = label.to_ascii_lowercase();
+    let mut any = false;
+    for tok in requested.to_ascii_lowercase().split_whitespace() {
+        any = true;
+        if !hay.contains(tok) {
+            return false;
+        }
+    }
+    any // an empty request matches nothing
+}
+
+/// Resolve the operator's requested object to a forward goal point, or refuse.
+///
+/// `now_ms` / `frame_stamp_ms` gate freshness; `frame_stamp_ms: None` (no camera
+/// frame) is [`GoalRefusal::Stale`] — "the detector did not look" is never "it
+/// isn't there". Among fresh, confident, forward matches the NEAREST wins; a tie
+/// within `tie_epsilon_m` is [`GoalRefusal::Ambiguous`].
+///
+/// The returned point is a DESTINATION ONLY — see the module docs. It never
+/// implies the path there is clear.
+pub fn resolve_object_goal(
+    requested: &str,
+    targets: &[LabeledTarget],
+    frame_stamp_ms: Option<u64>,
+    now_ms: u64,
+    max_age_ms: u64,
+    min_confidence: f32,
+    tie_epsilon_m: f64,
+) -> Result<ObjectGoal, GoalRefusal> {
+    if requested.trim().is_empty() {
+        return Err(GoalRefusal::NoRequestedLabel);
+    }
+    // Freshness first: a stale/absent frame refuses regardless of contents.
+    let Some(stamp) = frame_stamp_ms else {
+        return Err(GoalRefusal::Stale);
+    };
+    if stamp > now_ms.saturating_add(max_age_ms) || now_ms.saturating_sub(stamp) > max_age_ms {
+        return Err(GoalRefusal::Stale); // stale, or implausibly future-stamped
+    }
+
+    let matched: Vec<&LabeledTarget> = targets
+        .iter()
+        .filter(|t| label_matches(&t.label, requested))
+        .collect();
+    if matched.is_empty() {
+        return Err(GoalRefusal::NotSeen);
+    }
+    // A matching target with garbage geometry is a fault, not something to skip.
+    if matched.iter().any(|t| !t.is_finite()) {
+        return Err(GoalRefusal::NonFinite);
+    }
+    let confident: Vec<&&LabeledTarget> = matched
+        .iter()
+        .filter(|t| t.confidence >= min_confidence)
+        .collect();
+    if confident.is_empty() {
+        return Err(GoalRefusal::LowConfidence);
+    }
+    let forward: Vec<&&&LabeledTarget> = confident.iter().filter(|t| t.x_m > 0.0).collect();
+    if forward.is_empty() {
+        return Err(GoalRefusal::BehindEgo);
+    }
+
+    let range = |t: &LabeledTarget| (t.x_m * t.x_m + t.y_m * t.y_m).sqrt();
+    let best = forward
+        .iter()
+        .copied()
+        .min_by(|a, b| range(a).total_cmp(&range(b)))
+        .expect("non-empty");
+    // Ambiguity: another DISTINCT match essentially as near as the winner.
+    let ties = forward
+        .iter()
+        .filter(|t| (range(t) - range(best)).abs() <= tie_epsilon_m)
+        .count();
+    if ties > 1 {
+        return Err(GoalRefusal::Ambiguous);
+    }
+    Ok(ObjectGoal {
+        label: best.label.clone(),
+        x_m: best.x_m,
+        y_m: best.y_m,
+        confidence: best.confidence,
+    })
+}
+
+/// One operator-facing sentence for a refusal — Channel-A narration, so the robot
+/// SAYS why it isn't driving instead of silently holding.
+#[must_use]
+pub fn refusal_sentence(requested: &str, why: GoalRefusal) -> String {
+    match why {
+        GoalRefusal::NoRequestedLabel => "I didn't catch what I should drive to.".to_string(),
+        GoalRefusal::NotSeen => format!("I can't see {requested} from here, so I'm staying put."),
+        GoalRefusal::LowConfidence => {
+            format!("I might be seeing {requested}, but not clearly enough to drive to it.")
+        }
+        GoalRefusal::Ambiguous => {
+            format!("I can see more than one {requested} — which one did you mean?")
+        }
+        GoalRefusal::Stale => "My camera view is stale, so I won't drive on it.".to_string(),
+        GoalRefusal::NonFinite => {
+            format!("My reading of {requested} doesn't make sense, so I'm not moving.")
+        }
+        GoalRefusal::BehindEgo => {
+            format!("{requested} is behind me, and I only drive forward to a target.")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(label: &str, x: f64, y: f64, c: f32) -> LabeledTarget {
+        LabeledTarget {
+            label: label.into(),
+            x_m: x,
+            y_m: y,
+            confidence: c,
+        }
+    }
+
+    fn resolve(req: &str, targets: &[LabeledTarget]) -> Result<ObjectGoal, GoalRefusal> {
+        resolve_object_goal(
+            req,
+            targets,
+            Some(1_000),
+            1_000,
+            DEFAULT_GOAL_MAX_AGE_MS,
+            DEFAULT_MIN_CONFIDENCE,
+            0.25,
+        )
+    }
+
+    // ---- label matching -----------------------------------------------------
+
+    #[test]
+    fn label_matching_requires_every_requested_token() {
+        assert!(label_matches("red cup", "red cup"));
+        assert!(label_matches("large red cup", "red cup")); // extra words fine
+        assert!(label_matches("Red Cup", "red cup")); // case-insensitive
+        assert!(label_matches("red cup", "cup")); // generic request
+                                                  // The load-bearing negative: asking for a RED cup must not match a blue one.
+        assert!(!label_matches("blue cup", "red cup"));
+        assert!(!label_matches("cup", "red cup"));
+        assert!(!label_matches("red cup", "")); // empty request matches nothing
+    }
+
+    // ---- the happy path ("drive to the red cup") ---------------------------
+
+    #[test]
+    fn resolves_the_named_target_to_a_forward_goal() {
+        let g = resolve("red cup", &[t("red cup", 2.4, 0.3, 0.9)]).expect("goal");
+        assert_eq!(g.label, "red cup");
+        assert!((g.x_m - 2.4).abs() < 1e-9 && (g.y_m - 0.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn nearest_match_wins_when_unambiguous() {
+        // Two cups, clearly different ranges → the near one, no ambiguity.
+        let g = resolve("cup", &[t("cup", 5.0, 0.0, 0.9), t("cup", 1.5, 0.0, 0.9)]).expect("goal");
+        assert!((g.x_m - 1.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ignores_a_different_coloured_cup() {
+        // A blue cup present, a red one requested and present → picks red even
+        // though blue is nearer.
+        let g = resolve(
+            "red cup",
+            &[t("blue cup", 1.0, 0.0, 0.9), t("red cup", 3.0, 0.2, 0.9)],
+        )
+        .expect("goal");
+        assert_eq!(g.label, "red cup");
+    }
+
+    // ---- every refusal is fail-closed --------------------------------------
+
+    #[test]
+    fn refuses_when_not_seen() {
+        assert_eq!(
+            resolve("red cup", &[t("chair", 2.0, 0.0, 0.9)]),
+            Err(GoalRefusal::NotSeen)
+        );
+        assert_eq!(resolve("red cup", &[]), Err(GoalRefusal::NotSeen));
+    }
+
+    #[test]
+    fn refuses_a_low_confidence_sighting() {
+        assert_eq!(
+            resolve("red cup", &[t("red cup", 2.0, 0.0, 0.1)]),
+            Err(GoalRefusal::LowConfidence)
+        );
+    }
+
+    #[test]
+    fn refuses_two_equally_near_matches() {
+        assert_eq!(
+            resolve("cup", &[t("cup", 2.0, 0.0, 0.9), t("cup", 2.05, 0.1, 0.9)]),
+            Err(GoalRefusal::Ambiguous)
+        );
+    }
+
+    #[test]
+    fn refuses_a_target_behind_the_ego() {
+        assert_eq!(
+            resolve("red cup", &[t("red cup", -2.0, 0.0, 0.9)]),
+            Err(GoalRefusal::BehindEgo)
+        );
+    }
+
+    #[test]
+    fn refuses_non_finite_geometry() {
+        assert_eq!(
+            resolve("red cup", &[t("red cup", f64::NAN, 0.0, 0.9)]),
+            Err(GoalRefusal::NonFinite)
+        );
+        assert_eq!(
+            resolve("red cup", &[t("red cup", f64::INFINITY, 0.0, 0.9)]),
+            Err(GoalRefusal::NonFinite)
+        );
+    }
+
+    #[test]
+    fn refuses_an_absent_or_stale_camera_frame() {
+        let good = [t("red cup", 2.0, 0.0, 0.9)];
+        // No frame at all — "the detector did not look" is never "it isn't there".
+        assert_eq!(
+            resolve_object_goal("red cup", &good, None, 1_000, 750, 0.4, 0.25),
+            Err(GoalRefusal::Stale)
+        );
+        // Frame far older than the budget.
+        assert_eq!(
+            resolve_object_goal("red cup", &good, Some(100), 5_000, 750, 0.4, 0.25),
+            Err(GoalRefusal::Stale)
+        );
+        // Implausibly FUTURE-stamped (non-monotonic clock) is stale too.
+        assert_eq!(
+            resolve_object_goal("red cup", &good, Some(90_000), 1_000, 750, 0.4, 0.25),
+            Err(GoalRefusal::Stale)
+        );
+    }
+
+    #[test]
+    fn refuses_an_empty_request() {
+        assert_eq!(
+            resolve("   ", &[t("red cup", 2.0, 0.0, 0.9)]),
+            Err(GoalRefusal::NoRequestedLabel)
+        );
+    }
+
+    // ---- narration ----------------------------------------------------------
+
+    #[test]
+    fn every_refusal_has_an_operator_sentence() {
+        for why in [
+            GoalRefusal::NoRequestedLabel,
+            GoalRefusal::NotSeen,
+            GoalRefusal::LowConfidence,
+            GoalRefusal::Ambiguous,
+            GoalRefusal::Stale,
+            GoalRefusal::NonFinite,
+            GoalRefusal::BehindEgo,
+        ] {
+            let s = refusal_sentence("the red cup", why);
+            assert!(!s.is_empty() && s.ends_with(['.', '?']), "{why:?} -> {s:?}");
+        }
+    }
+}

--- a/docs/hardware/CAMERA_PERCEPTION_INTEGRATION.md
+++ b/docs/hardware/CAMERA_PERCEPTION_INTEGRATION.md
@@ -115,29 +115,94 @@ Response gains `camera_healthy` and `camera_clip_x_m` (where the fusion clipped,
 3. **Arm it** — send `camera_armed: true` with a stamped frame. Start with the
    channel **disarmed** and confirm parity with lidar-only, then arm.
 
-## Detector: what produces the detections
+## The detector (shipped: classical CV)
 
-The `SemanticDetector` seam (`kirra_taj`) is detector-agnostic — anything that
-produces ego-frame regions plugs in. Practical options, in the order they make
-sense on an Orin NX:
+`camera_detect` (`ros2_ws/src/kirra_safety/kirra_safety/camera_detect.py`) is the
+producer. Split the house way: every decision that could affect motion lives in
+the **pure core** `camera_detect_core.py` (stdlib only — no rclpy, cv2, numpy or
+camera, host-tested in `test/test_camera_detect_core.py`), and the node does only
+the pixel work (HSV threshold → morphology → connected components, plus a coarse
+depth grid).
 
-- **Classical CV (recommended first).** Depth + colour/blob segmentation via
-  OpenCV: fast enough for the per-tick loop, deterministic, testable, no model to
-  ship. Sufficient for both the drivability classes and a coloured-object goal
-  ("red cup").
+```
+camera_detect ──/camera_detect/detections (JSON)──▶ occy_doer
+                                                      ├─ POST /perception  detections  (tighten-only)
+                                                      └─ POST /plan        object_goal + targets
+```
+
+Run it:
+
+```bash
+ros2 run kirra_safety camera_detect --ros-args \
+  -p colours:="['red','blue']" \
+  -p mount_x_m:=0.10 -p mount_z_m:=0.20 -p mount_pitch_deg:=15.0
+```
+
+🔴 **HONEST SCOPE — the classical detector grounds colour, not nouns.** It can
+confirm "there is a red thing at 2.4 m"; it cannot confirm the thing is a *cup*.
+So `colour_term("red cup") -> "red"` and the emitted target label is the colour
+term. Labelling a red blob `"red cup"` would be a fabrication, so the code
+refuses to; verifying the noun is what the ML tier is for.
+
+Its own fail-closed rules (each tested):
+
+| Situation | Behaviour |
+|---|---|
+| Blob with no valid depth / non-finite maths | dropped — never a guessed range |
+| Blob that projects behind the ego (`x <= 0`) | dropped — not a destination |
+| Unknown colour token | refused |
+| Depth not registered to colour (different sizes) | frame refused — a wrong depth would put the target metres off |
+| Depth frame mostly INVALID (`frame_valid_fraction` below floor) | **stamp withheld** → the consumer's channel faults → MRC floor |
+| No known colour configured at startup | node refuses to start (an empty `targets` forever would read as "the object is not there") |
+
+Other detector tiers, when the classical one is not enough:
+
 - **ML detector (ADR-0015's plan).** An RGB detector through
-  `parko-onnx --features cuda` / `parko-tensorrt`. General labels; needs the CUDA
-  path (see `docs/hardware/JETSON_CUDA_SETUP.md`) and a model.
+  `parko-onnx --features cuda` / `parko-tensorrt`. General labels — this is the
+  tier that can verify the noun; needs the CUDA path (see
+  `docs/hardware/JETSON_CUDA_SETUP.md`) and a model.
 - **VLM (`gemma3:4b` is multimodal).** Good for *conversation* ("what do you
   see?") — Channel A. **Not** for the control loop: seconds-scale latency, not
   per-tick safe, and never a drivability authority.
 
+## The consumer hop (`occy_doer`)
+
+Both channels are **opt-in**; with the defaults the endpoint is byte-identical to
+the lidar-only path.
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `camera_armed` | `false` | Arms the Taj Phase-B fusion (tighten-only). |
+| `camera_detections_topic` | `/camera_detect/detections` | Where the detector frame arrives. |
+| `camera_max_age_ms` | 500 | Relayed freshness budget. |
+| `object_goal_topic` | `/object_goal` | A `std_msgs/String` phrase; empty clears. |
+
+Relay discipline: the doer is a **faithful relay, not a second opinion.**
+Freshness is Taj's call, so the doer sends the scan's own ROS header stamp as
+`stamp_ms` and the depth frame's as `camera_stamp_ms` — **one clock domain**, per
+`AOU-TIMESYNC-001`. Armed with no usable frame ⇒ armed but *no stamp* ⇒ Taj
+resolves Faulted ⇒ speed cap floored.
+
+Object-goal flow, all fail-closed:
+
+- The phrase is reduced to its colour term; ungroundable (`"cup"`) or ambiguous
+  (`"red blue thing"`) ⇒ **hold**, logged once, never a fall-back to another goal.
+- No usable camera frame ⇒ hold.
+- Otherwise `object_goal` + `targets` + `targets_stamp_ms` + `now_ms` go to
+  `/plan`, which resolves and refuses on its own terms (not seen / low confidence
+  / ambiguous / stale / behind ego).
+- **Arrival** is latched by `object_goal_reached` on the same tolerance the
+  positional goal uses. Without it the loop oscillates at close range: the target
+  leaves the detector's usable band, the planner refuses, the doer holds, the
+  target reappears, the robot nudges. Arrival is a *positive* claim — not-seen
+  falls through to the planner's refusal rather than reporting "we are there".
+
 ## What is NOT wired yet
 
-- The detector itself (above) — the seam is live, the producer is the remaining work.
-- The ROS 2 node hop that fills `detections` on each `/perception` POST.
 - Camera frames into rabbit/mick for conversation (Channel A; `gemma3:4b` accepts
   images via Ollama, so this is a doer-side UX addition with no safety surface).
+- A launch file wiring `camera_detect` into the R2 stack (run it standalone for
+  bring-up; the vendor camera node comes up separately either way).
 
 ## The object-goal call site (`POST /plan`, planner_service)
 

--- a/docs/hardware/CAMERA_PERCEPTION_INTEGRATION.md
+++ b/docs/hardware/CAMERA_PERCEPTION_INTEGRATION.md
@@ -1,0 +1,142 @@
+# Camera integration — lidar + camera into Taj, and "drive to the red cup"
+
+How the Orbbec Astra camera joins the R2 perception stack, what it is allowed to
+decide, and how an object-named drive command ("drive to the red cup") is grounded
+**without giving the camera any safety authority.**
+
+## The one rule everything follows
+
+A camera contributes **two different things**, and conflating them would be a
+safety bug. The code keeps them in separate modules on purpose:
+
+| | Channel | Type | Authority |
+|---|---|---|---|
+| 1 | **Drivability** — "may the ego drive here?" | `SemanticClass` / `SemanticDetection` → `clip_corridor_to_hazards` | **TIGHTEN-ONLY.** May shorten the drivable corridor, never extend it. |
+| 2 | **Where a named thing is** — "the red cup is 2.4 m ahead" | `kirra_taj::object_goal::LabeledTarget` → `ObjectGoal` | **None.** A destination, not a claim about the ground. |
+
+🔴 **Lidar (Phase A) remains the sole authority on free space.** The camera can
+never make unseen ground drivable. This is enforced three ways:
+
+1. `clip_corridor_to_hazards` *truncates* boundaries — structurally incapable of
+   extending them.
+2. `SemanticClass::is_drivable()` is `true` for `Road` only; every unrecognized
+   class token decodes to `Unknown`, which is **non-drivable** (fail-closed —
+   never assume drivable).
+3. The KPI gate classifies a Phase-B corridor reaching past Phase-A's as
+   **`ForbiddenLoosen`**, a hard zero. The property is also swept in
+   `camera_can_never_extend_the_corridor` (classes × ranges).
+
+## Why "drive to the red cup" is safe by construction
+
+The command decomposes across the two channels, and *neither* lets the camera
+authorize motion:
+
+```
+"drive to the red cup"
+        │
+        ├─ camera → object_goal::resolve_object_goal("red cup", targets…)
+        │      → ObjectGoal{ x: 2.4, y: 0.3 }        ← a DESTINATION
+        │      → caller emits MickIntent::GoTo{x,y}  ← an ordinary intent
+        │
+        ├─ lidar  → Taj Phase-A corridor              ← the free space
+        ├─ camera → Phase-B fusion (tighten-only)      ← may only shorten it
+        │
+        └─ Occy plans inside that corridor → KIRRA checker BOUNDS the trajectory
+```
+
+So if the cup is **visible but the path is blocked**, the robot drives as far as
+is safe and **stops short** — it never drives at the cup because the camera "saw"
+it. `MickIntent::GoTo` already documents exactly this ("it never drives *to* the
+point if getting there is unsafe"), which is why the resolver emits a **plain
+`GoTo`**:
+
+- no new `MickIntent` variant,
+- no change to the fail-closed intent parse (`MickIntent::from_llm_json`),
+- no new actuation path — the single-door invariant (text → mick `/intent` →
+  checker) is untouched.
+
+## Channel arming (the house rule)
+
+The camera channel makes the same three-way, fail-closed decision as the
+occlusion / VRU channels (`resolve_camera_channel`):
+
+| State | Condition | Behaviour |
+|---|---|---|
+| **Disarmed** | `camera_armed: false` (default) | Phase-B never runs → byte-identical to the lidar-only endpoint. |
+| **Fresh** | armed + `camera_stamp_ms` within `camera_max_age_ms` | Fuse the detections (tighten-only). |
+| **Faulted** | armed + **no frame**, stale, implausibly future-stamped, or non-finite geometry | `camera_healthy: false` → **MRC floor** (`speed_cap_mps: 0.0`). |
+
+A fresh frame with **zero detections** is a legitimate "I looked, it's clear" and
+does **not** fault — distinct from silence. *"The detector did not look" is never
+"clear."*
+
+## Wire API (`POST /perception`, taj_service)
+
+New optional fields — all default to the disarmed/no-op state:
+
+```jsonc
+{
+  "angle_min_rad": -3.14, "angle_increment_rad": 0.0031,
+  "range_min_m": 0.01, "range_max_m": 50.0, "ranges": [ ... ],
+  "stamp_ms": 1234567,
+
+  "camera_armed": true,              // opt-in; default false
+  "camera_stamp_ms": 1234500,        // the frame the detections came from
+  "camera_max_age_ms": 500,          // freshness budget
+  "detections": [                    // SAFETY classes only (not goal labels)
+    { "class": "water", "near_x_m": 2.0,
+      "lateral_min_m": -0.5, "lateral_max_m": 0.5 }
+  ]
+}
+```
+
+`class` ∈ `road` | `water` | `static_obstacle` | anything-else→`unknown`.
+Response gains `camera_healthy` and `camera_clip_x_m` (where the fusion clipped,
+`null` if nothing bound the corridor).
+
+## Bring-up on the Orin
+
+1. **Driver** — the R2 ships an Orbbec Astra (`my_camera: astraplus`). Bring up the
+   vendor ROS 2 camera node so `/camera/color/image_raw` and
+   `/camera/depth/image_raw` publish. Verify:
+   ```bash
+   ros2 topic hz /camera/color/image_raw   # steady frame rate
+   ros2 topic hz /camera/depth/image_raw
+   robot/kirra_doctor.py --module devices --verbose   # camera device row
+   ```
+   `ros2_ws/src/kirra_safety/kirra_safety/sensor_monitor.py` already subscribes
+   `/camera/depth/image_raw` and scores a `depth_camera` confidence, so the health
+   plumbing exists once the topics are live.
+2. **Extrinsics** — detections must arrive in the **ego frame (+X forward, +Y
+   left)**, the same frame as `/scan` (verify the lidar first with
+   `robot/lidar_orient_check.py`). A camera-vs-lidar frame mismatch would clip the
+   corridor in the wrong place, so validate with a single object at a known offset
+   before arming.
+3. **Arm it** — send `camera_armed: true` with a stamped frame. Start with the
+   channel **disarmed** and confirm parity with lidar-only, then arm.
+
+## Detector: what produces the detections
+
+The `SemanticDetector` seam (`kirra_taj`) is detector-agnostic — anything that
+produces ego-frame regions plugs in. Practical options, in the order they make
+sense on an Orin NX:
+
+- **Classical CV (recommended first).** Depth + colour/blob segmentation via
+  OpenCV: fast enough for the per-tick loop, deterministic, testable, no model to
+  ship. Sufficient for both the drivability classes and a coloured-object goal
+  ("red cup").
+- **ML detector (ADR-0015's plan).** An RGB detector through
+  `parko-onnx --features cuda` / `parko-tensorrt`. General labels; needs the CUDA
+  path (see `docs/hardware/JETSON_CUDA_SETUP.md`) and a model.
+- **VLM (`gemma3:4b` is multimodal).** Good for *conversation* ("what do you
+  see?") — Channel A. **Not** for the control loop: seconds-scale latency, not
+  per-tick safe, and never a drivability authority.
+
+## What is NOT wired yet
+
+- The detector itself (above) — the seam is live, the producer is the remaining work.
+- The ROS 2 node hop that fills `detections` on each `/perception` POST.
+- Camera frames into rabbit/mick for conversation (Channel A; `gemma3:4b` accepts
+  images via Ollama, so this is a doer-side UX addition with no safety surface).
+- The `object_goal` → `GoTo` call site in the mick/planner sidecar (the resolver
+  and its refusal narration are in place and tested).

--- a/docs/hardware/CAMERA_PERCEPTION_INTEGRATION.md
+++ b/docs/hardware/CAMERA_PERCEPTION_INTEGRATION.md
@@ -138,5 +138,31 @@ sense on an Orin NX:
 - The ROS 2 node hop that fills `detections` on each `/perception` POST.
 - Camera frames into rabbit/mick for conversation (Channel A; `gemma3:4b` accepts
   images via Ollama, so this is a doer-side UX addition with no safety surface).
-- The `object_goal` → `GoTo` call site in the mick/planner sidecar (the resolver
-  and its refusal narration are in place and tested).
+
+## The object-goal call site (`POST /plan`, planner_service)
+
+The resolver is **wired live** on the planner sidecar. Send a label plus the
+ego-frame targets the detector produced; the sidecar grounds it to a plain
+`MickIntent::GoTo` in world coordinates and runs the ordinary checker path:
+
+```jsonc
+{
+  "ego": { "x": 0.0, "y": 0.0, "heading": 0.0, "speed": 0.0 },
+  "object_goal": "red cup",
+  "targets": [ { "label": "red cup", "x": 2.4, "y": 0.3, "confidence": 0.9 } ],
+  "targets_stamp_ms": 1234500,
+  "now_ms": 1234600
+}
+```
+
+Fail-closed properties (each has a test):
+
+- `object_goal` **and** a typed `intent` in the same request → refused
+  (`PLAN_AMBIGUOUS_GOAL_SOURCE`); there is exactly one goal source per plan.
+- Every `GoalRefusal` (not seen / low confidence / ambiguous / stale /
+  non-finite / behind ego) → refusal, i.e. **no motion** — never a guessed goal.
+  `GoalRefusal::code()` gives the machine token, `refusal_sentence` the operator
+  sentence Rabbit can speak.
+- Absent `object_goal` → byte-identical prior behaviour.
+- The ego→world hop is `ObjectGoal::to_world(ego_x, ego_y, ego_heading)`; the
+  detector never has to know the world frame.

--- a/ros2_ws/src/kirra_safety/kirra_safety/camera_detect.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/camera_detect.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+camera_detect — the classical-CV camera detector NODE (the thin hop).
+
+Subscribes the colour + depth + camera_info triple, does the pixel work (HSV
+threshold → morphology → connected components, plus a coarse depth grid), and
+publishes ONE JSON frame on `~/detections`:
+
+    {"usable": true, "stamp_ms": 1234, "frame_valid_fraction": 0.87,
+     "detections": [ {"class":"static_obstacle","near_x_m":…,
+                      "lateral_min_m":…,"lateral_max_m":…}, … ],
+     "targets":    [ {"label":"red","x":2.4,"y":0.3,"confidence":0.8}, … ]}
+
+`occy_doer` consumes it and forwards `detections` to Taj `POST /perception`
+(camera_armed) and `targets` to Occy `POST /plan` (object_goal) — see
+`docs/hardware/CAMERA_PERCEPTION_INTEGRATION.md`.
+
+Every decision that could affect motion lives in the PURE core
+(`camera_detect_core.py`, host-tested with no ROS/cv2/camera). This file only
+turns images into the scalars that core consumes. In particular the node never
+invents a stamp: when the depth frame is not actually usable the core withholds
+it, and the consumer's camera channel then faults to the MRC floor.
+
+🔴 The camera is a DOER input. `detections` can only TIGHTEN the lidar corridor
+   and `targets` are destinations — neither can authorize motion. Lidar remains
+   the sole authority on free space.
+"""
+
+import json
+import math
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+from sensor_msgs.msg import CameraInfo, Image
+from std_msgs.msg import String
+
+from kirra_safety.camera_detect_core import (
+    Blob,
+    CameraExtrinsics,
+    CameraIntrinsics,
+    DetectConfig,
+    build_detection_frame,
+    colour_bands,
+    known_colours,
+)
+
+try:
+    import cv2
+    import numpy as np
+    CV_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only on a box without cv2
+    CV_AVAILABLE = False
+
+# Sensor-ingress QoS: freshness over buffering, and BestEffort matches both
+# BestEffort and Reliable publishers (the house discipline — see occy_doer).
+IMAGE_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+)
+
+
+class CameraDetect(Node):
+    def __init__(self):
+        super().__init__('camera_detect')
+        self.declare_parameter('color_topic', '/camera/color/image_raw')
+        self.declare_parameter('depth_topic', '/camera/depth/image_raw')
+        self.declare_parameter('info_topic', '/camera/color/camera_info')
+        self.declare_parameter('detections_topic', '~/detections')
+        self.declare_parameter('detect_hz', 5.0)
+        # Which colour terms to look for. The classical detector grounds COLOUR,
+        # not nouns (see the core's docstring) — "red cup" is reduced to "red".
+        self.declare_parameter('colours', ['red', 'blue', 'green'])
+        # Mounting, in the ego frame (+X fwd, +Y left, +Z up). pitch_deg is the
+        # DOWNWARD tilt. These must match the physical mount or every detection
+        # lands in the wrong place — validate against /scan before arming.
+        self.declare_parameter('mount_x_m', 0.10)
+        self.declare_parameter('mount_y_m', 0.0)
+        self.declare_parameter('mount_z_m', 0.20)
+        self.declare_parameter('mount_pitch_deg', 0.0)
+        # Detector thresholds (the pure core's DetectConfig).
+        self.declare_parameter('min_pixels', 200)
+        self.declare_parameter('max_range_m', 6.0)
+        self.declare_parameter('ground_z_m', 0.03)
+        self.declare_parameter('min_frame_valid_fraction', 0.20)
+        self.declare_parameter('obstacle_bin_m', 0.20)
+        # Depth grid stride in pixels — the drivability channel samples rather
+        # than projecting every pixel, so the per-tick cost stays bounded.
+        self.declare_parameter('depth_stride_px', 8)
+
+        self._colours = [c for c in self.get_parameter('colours').value
+                         if colour_bands(c) is not None]
+        rejected = [c for c in self.get_parameter('colours').value
+                    if colour_bands(c) is None]
+        if rejected:
+            self.get_logger().warn(
+                f'ignoring unknown colour term(s) {rejected} — known: {list(known_colours())}')
+        if not self._colours:
+            # Fail-closed on configuration: a detector asked to find nothing
+            # would publish empty `targets` forever, which reads as "the object
+            # is not there" rather than "I was never told to look".
+            self.get_logger().fatal(
+                'no known colour terms configured — refusing to start. '
+                f'Set the `colours` parameter to a subset of {list(known_colours())}.')
+            raise SystemExit(2)
+
+        self._extr = CameraExtrinsics(
+            x_m=self.get_parameter('mount_x_m').value,
+            y_m=self.get_parameter('mount_y_m').value,
+            z_m=self.get_parameter('mount_z_m').value,
+            pitch_rad=math.radians(self.get_parameter('mount_pitch_deg').value),
+        )
+        self._cfg = DetectConfig(
+            min_pixels=int(self.get_parameter('min_pixels').value),
+            max_range_m=float(self.get_parameter('max_range_m').value),
+            ground_z_m=float(self.get_parameter('ground_z_m').value),
+            min_frame_valid_fraction=float(
+                self.get_parameter('min_frame_valid_fraction').value),
+            obstacle_bin_m=float(self.get_parameter('obstacle_bin_m').value),
+        )
+        self._stride = max(1, int(self.get_parameter('depth_stride_px').value))
+
+        self._intr = None     # from camera_info; no calibration -> no projection
+        self._color = None
+        self._depth = None
+
+        self._pub = self.create_publisher(
+            String, self.get_parameter('detections_topic').value, 10)
+        self.create_subscription(
+            Image, self.get_parameter('color_topic').value, self._on_color, IMAGE_QOS)
+        self.create_subscription(
+            Image, self.get_parameter('depth_topic').value, self._on_depth, IMAGE_QOS)
+        self.create_subscription(
+            CameraInfo, self.get_parameter('info_topic').value, self._on_info, 10)
+        self.create_timer(1.0 / float(self.get_parameter('detect_hz').value), self._tick)
+
+        if not CV_AVAILABLE:
+            self.get_logger().error(
+                'python3-opencv / numpy missing — detector publishes UNUSABLE frames '
+                '(a consumer that armed the camera channel will hold).')
+        self.get_logger().info(
+            f'camera_detect: colours={self._colours} mount={self._extr} -> '
+            f'{self.get_parameter("detections_topic").value}')
+
+    # --- subscriptions ------------------------------------------------------
+    def _on_info(self, msg: CameraInfo):
+        k = list(msg.k)
+        if len(k) >= 6:
+            self._intr = CameraIntrinsics(fx=k[0], fy=k[4], cx=k[2], cy=k[5])
+
+    def _on_color(self, msg: Image):
+        self._color = msg
+
+    def _on_depth(self, msg: Image):
+        self._depth = msg
+
+    # --- image decoding -----------------------------------------------------
+    def _depth_metres(self, msg: Image):
+        """Depth image -> float32 metres, NaN where invalid. `None` if undecodable."""
+        enc = msg.encoding.lower()
+        if enc == '16uc1' or enc == 'mono16':
+            raw = np.frombuffer(msg.data, dtype=np.uint16).reshape(msg.height, msg.width)
+            d = raw.astype(np.float32) / 1000.0          # millimetres -> metres
+            d[raw == 0] = np.nan                          # 0 is the "no return" sentinel
+            return d
+        if enc == '32fc1':
+            d = np.frombuffer(msg.data, dtype=np.float32).reshape(
+                msg.height, msg.width).astype(np.float32).copy()
+            d[~np.isfinite(d)] = np.nan
+            d[d <= 0.0] = np.nan
+            return d
+        return None   # unknown encoding -> refuse, never reinterpret bytes
+
+    def _bgr(self, msg: Image):
+        """Colour image -> BGR uint8, or `None` for an encoding we will not guess at."""
+        enc = msg.encoding.lower()
+        if enc in ('bgr8', 'rgb8'):
+            a = np.frombuffer(msg.data, dtype=np.uint8).reshape(msg.height, msg.width, 3)
+            return a if enc == 'bgr8' else a[:, :, ::-1]
+        return None
+
+    # --- the detector tick --------------------------------------------------
+    def _unusable(self, why: str):
+        """Publish an explicitly-unusable frame — never a silently-empty one."""
+        self.get_logger().debug(f'unusable frame: {why}')
+        self._pub.publish(String(data=json.dumps(build_detection_frame(
+            blobs=[], points=[], frame_valid_fraction=0.0, stamp_ms=0,
+            intr=self._intr or CameraIntrinsics(0, 0, 0, 0), extr=self._extr,
+            cfg=self._cfg))))
+
+    def _tick(self):
+        if not CV_AVAILABLE:
+            return self._unusable('no-opencv')
+        if self._intr is None or not self._intr.valid():
+            return self._unusable('no-camera_info')
+        if self._color is None or self._depth is None:
+            return self._unusable('awaiting-frames')
+
+        color_msg, depth_msg = self._color, self._depth
+        depth = self._depth_metres(depth_msg)
+        bgr = self._bgr(color_msg)
+        if depth is None:
+            return self._unusable(f'depth-encoding:{depth_msg.encoding}')
+        if bgr is None:
+            return self._unusable(f'color-encoding:{color_msg.encoding}')
+        if depth.shape[:2] != bgr.shape[:2]:
+            # An unregistered pair would give every blob the WRONG depth, which
+            # would put a target metres from the real object. Refuse.
+            return self._unusable(
+                f'depth {depth.shape[:2]} not registered to color {bgr.shape[:2]} '
+                '(enable the driver depth_registration option)')
+
+        stamp_ms = int(depth_msg.header.stamp.sec * 1000
+                       + depth_msg.header.stamp.nanosec // 1_000_000)
+
+        # --- drivability channel: a coarse depth grid -> ego points ---------
+        sub = depth[::self._stride, ::self._stride]
+        vs, us = np.nonzero(np.isfinite(sub))
+        total = sub.size
+        in_range = 0
+        points = []
+        if total:
+            for gv, gu in zip(vs.tolist(), us.tolist()):
+                d = float(sub[gv, gu])
+                if d <= 0.0 or d > self._cfg.max_range_m:
+                    continue
+                in_range += 1
+                p = self._project(gu * self._stride, gv * self._stride, d)
+                if p is not None:
+                    points.append(p)
+        frame_valid_fraction = (in_range / float(total)) if total else 0.0
+
+        # --- goal channel: colour blobs -> labelled targets -----------------
+        blobs = self._find_blobs(bgr, depth)
+
+        frame = build_detection_frame(
+            blobs=blobs, points=points, frame_valid_fraction=frame_valid_fraction,
+            stamp_ms=stamp_ms, intr=self._intr, extr=self._extr, cfg=self._cfg)
+        self._pub.publish(String(data=json.dumps(frame)))
+        self.get_logger().debug(
+            f'usable={frame["usable"]} valid={frame_valid_fraction:.2f} '
+            f'obstacles={len(frame["detections"])} targets={len(frame["targets"])}')
+
+    def _project(self, u, v, d):
+        from kirra_safety.camera_detect_core import pixel_to_ego
+        return pixel_to_ego(u, v, d, self._intr, self._extr, self._cfg.max_range_m)
+
+    def _find_blobs(self, bgr, depth):
+        """HSV threshold -> morphology -> components -> one Blob per region."""
+        hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+        kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (5, 5))
+        out = []
+        for colour in self._colours:
+            bands = colour_bands(colour)
+            mask = None
+            for lo, hi in bands:
+                m = cv2.inRange(hsv, np.array(lo, dtype=np.uint8),
+                                np.array(hi, dtype=np.uint8))
+                mask = m if mask is None else cv2.bitwise_or(mask, m)
+            mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
+            mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+            n, labels, stats, centroids = cv2.connectedComponentsWithStats(mask, 8)
+            for i in range(1, n):   # 0 is the background component
+                area = int(stats[i, cv2.CC_STAT_AREA])
+                if area < self._cfg.min_pixels:
+                    continue
+                region = depth[labels == i]
+                finite = region[np.isfinite(region)]
+                in_range = finite[(finite > 0.0) & (finite <= self._cfg.max_range_m)]
+                if in_range.size == 0:
+                    continue        # no usable depth -> the core would drop it anyway
+                out.append(Blob(
+                    colour=colour,
+                    u=float(centroids[i][0]),
+                    v=float(centroids[i][1]),
+                    pixel_count=area,
+                    depth_m=float(np.median(in_range)),   # robust to blob edges
+                    depth_valid_fraction=float(in_range.size) / float(area),
+                ))
+        return out
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = CameraDetect()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2_ws/src/kirra_safety/kirra_safety/camera_detect_core.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/camera_detect_core.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""
+Classical-CV camera detector — the PURE core (no rclpy, no cv2, no numpy).
+
+This is the producer behind the two camera channels documented in
+`docs/hardware/CAMERA_PERCEPTION_INTEGRATION.md`:
+
+  1. **Drivability** (tighten-only)  — depth → `static_obstacle` regions that may
+     only SHORTEN the Taj Phase-A corridor, never extend it.
+  2. **Where a named thing is**      — a colour blob → a `LabeledTarget`, i.e. a
+     DESTINATION for `object_goal`. Carries no authority over the ground.
+
+Everything here is pure arithmetic on scalars so it is host-testable with no ROS,
+no camera and no OpenCV. The node (`camera_detect.py`) owns the pixel work
+(HSV threshold, morphology, connected components) and calls into this module for
+every decision that could affect motion.
+
+🔴 HONEST SCOPE — the classical detector grounds **colour, not nouns.**
+   It can confirm "there is a red thing at 2.4 m"; it cannot confirm the thing is
+   a *cup*. So `colour_term("red cup") -> "red"` and the emitted target label is
+   the colour term. A caller wanting the noun verified needs the ML detector tier
+   (`parko-onnx` / `parko-tensorrt`). Labelling a red blob "red cup" would be a
+   fabrication, so this module refuses to do it.
+
+🔴 FAIL-CLOSED RULES (each has a test):
+   - No valid depth for a blob  → no target (never a guessed range).
+   - Non-finite arithmetic      → dropped, never propagated.
+   - A blob behind the camera   → dropped (`x <= 0` is not a destination ahead).
+   - A depth frame that is mostly INVALID → `depth_frame_usable() is False`, and
+     the node must then withhold `camera_stamp_ms`, so the Taj camera channel
+     resolves Faulted → MRC floor. "The detector could not see" is never "clear."
+"""
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+# ---------------------------------------------------------------------------
+# Geometry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CameraIntrinsics:
+    """Pinhole intrinsics, as published on `camera_info` (`k` = fx,0,cx,0,fy,cy,...)."""
+
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+
+    def valid(self) -> bool:
+        return (
+            all(math.isfinite(v) for v in (self.fx, self.fy, self.cx, self.cy))
+            and self.fx > 0.0
+            and self.fy > 0.0
+        )
+
+
+@dataclass(frozen=True)
+class CameraExtrinsics:
+    """Where the camera sits on the robot, in the EGO frame (+X fwd, +Y left, +Z up).
+
+    `pitch_rad` is the DOWNWARD tilt of the optical axis (0 = level, positive =
+    nose down, which is the usual mounting for a robot that must see the floor
+    just ahead of itself).
+    """
+
+    x_m: float = 0.0
+    y_m: float = 0.0
+    z_m: float = 0.0
+    pitch_rad: float = 0.0
+
+    def valid(self) -> bool:
+        return all(
+            math.isfinite(v) for v in (self.x_m, self.y_m, self.z_m, self.pitch_rad)
+        )
+
+
+def pixel_to_ego(
+    u: float,
+    v: float,
+    depth_m: float,
+    intr: CameraIntrinsics,
+    extr: CameraExtrinsics,
+    max_range_m: float = 10.0,
+) -> Optional[Tuple[float, float, float]]:
+    """Project one pixel + its depth into the ego frame. `None` = unusable.
+
+    The camera's OPTICAL frame is the ROS convention (+X right, +Y down,
+    +Z along the optical axis), which is what a depth image is expressed in.
+    The ego frame is REP-103 (+X forward, +Y left, +Z up).
+
+    Returns `(x_m, y_m, z_m)`; `z_m` lets the caller reject the floor (a return
+    at ground height is not an obstacle).
+    """
+    if not (intr.valid() and extr.valid()):
+        return None
+    if not math.isfinite(u) or not math.isfinite(v):
+        return None
+    if not math.isfinite(depth_m) or depth_m <= 0.0 or depth_m > max_range_m:
+        return None
+
+    # Optical frame.
+    right = (u - intr.cx) / intr.fx * depth_m
+    down = (v - intr.cy) / intr.fy * depth_m
+    along = depth_m
+
+    # Un-pitch into the ego frame. With a downward tilt theta, the optical axis
+    # is (cos t)*F - (sin t)*U and the image-down axis is (sin t)*F - (cos t)*U.
+    s, c = math.sin(extr.pitch_rad), math.cos(extr.pitch_rad)
+    fwd = along * c + down * s
+    up = -along * s - down * c
+    left = -right
+
+    x_m = extr.x_m + fwd
+    y_m = extr.y_m + left
+    z_m = extr.z_m + up
+    if not all(math.isfinite(q) for q in (x_m, y_m, z_m)):
+        return None
+    return (x_m, y_m, z_m)
+
+
+# ---------------------------------------------------------------------------
+# Colour vocabulary
+# ---------------------------------------------------------------------------
+
+# OpenCV HSV: H in [0,179], S/V in [0,255]. Red wraps the hue origin, so it
+# carries TWO bands — a detector that only takes the upper band misses half of
+# every red object. Each entry is a tuple of (lo_hsv, hi_hsv) inclusive bands.
+COLOUR_BANDS = {
+    "red": (((0, 110, 70), (8, 255, 255)), ((172, 110, 70), (179, 255, 255))),
+    "orange": (((9, 130, 90), (21, 255, 255)),),
+    "yellow": (((22, 110, 110), (33, 255, 255)),),
+    "green": (((36, 80, 60), (85, 255, 255)),),
+    "blue": (((90, 90, 60), (128, 255, 255)),),
+    "purple": (((129, 70, 60), (158, 255, 255)),),
+}
+
+# Ordered longest-first so a two-word colour would win over its prefix; also the
+# stable order used when reporting which colours a phrase mentioned.
+_COLOUR_WORDS = tuple(sorted(COLOUR_BANDS, key=lambda w: (-len(w), w)))
+
+_WORD_RE = re.compile(r"[a-z]+")
+
+
+def known_colours() -> Tuple[str, ...]:
+    """The colour terms this detector can ground, alphabetically."""
+    return tuple(sorted(COLOUR_BANDS))
+
+
+def colour_term(phrase: str) -> Optional[str]:
+    """Reduce an object phrase to the ONE colour term this detector can ground.
+
+    ``"red cup"`` / ``"the RED cup"`` / ``"red"`` -> ``"red"``.
+
+    `None` (refuse) when the phrase names no known colour (``"cup"``) or names
+    more than one (``"red blue thing"``) — an ambiguous request must not silently
+    pick a colour. The noun is deliberately discarded: see the module docstring.
+    """
+    if not isinstance(phrase, str):
+        return None
+    words = set(_WORD_RE.findall(phrase.lower()))
+    found = [c for c in _COLOUR_WORDS if c in words]
+    if len(found) != 1:
+        return None
+    return found[0]
+
+
+def colour_bands(colour: str) -> Optional[Tuple[Tuple[Sequence[int], Sequence[int]], ...]]:
+    """The HSV bands for a colour term, or `None` for an unknown one (fail-closed)."""
+    if not isinstance(colour, str):
+        return None
+    return COLOUR_BANDS.get(colour.strip().lower())
+
+
+# ---------------------------------------------------------------------------
+# Blobs -> labelled targets (the goal channel)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Blob:
+    """One connected colour region, already reduced to scalars by the node."""
+
+    colour: str
+    u: float  # centroid pixel, horizontal
+    v: float  # centroid pixel, vertical
+    pixel_count: int
+    depth_m: float  # ROBUST (median) depth over the region, metres
+    depth_valid_fraction: float  # share of region pixels with a usable depth
+
+
+@dataclass(frozen=True)
+class DetectConfig:
+    """Detector thresholds. All safety-relevant knobs live here, not in the node."""
+
+    min_pixels: int = 200
+    min_depth_valid_fraction: float = 0.30
+    max_range_m: float = 6.0
+    # A return at or below this height above the floor is ground, not an object.
+    ground_z_m: float = 0.03
+    # Depth frames below this valid share mean "could not see" -> withhold the
+    # stamp so the Taj camera channel faults to the MRC floor.
+    min_frame_valid_fraction: float = 0.20
+    # Lateral bin width for the drivability channel.
+    obstacle_bin_m: float = 0.20
+
+
+def blob_confidence(blob: Blob, cfg: DetectConfig) -> float:
+    """A calibrated-ish [0,1] score: region size x depth agreement.
+
+    Deliberately conservative — the size term saturates at 4x the minimum area,
+    so a huge blob does not buy unlimited confidence, and a region whose depth is
+    mostly invalid can never score high no matter how many pixels it has.
+    """
+    if blob.pixel_count < cfg.min_pixels or cfg.min_pixels <= 0:
+        return 0.0
+    frac = blob.depth_valid_fraction
+    if not math.isfinite(frac) or frac < cfg.min_depth_valid_fraction:
+        return 0.0
+    size_term = min(1.0, blob.pixel_count / float(4 * cfg.min_pixels))
+    return max(0.0, min(1.0, size_term * min(1.0, frac)))
+
+
+def blob_to_target(
+    blob: Blob,
+    intr: CameraIntrinsics,
+    extr: CameraExtrinsics,
+    cfg: DetectConfig,
+) -> Optional[dict]:
+    """One blob -> the `targets[]` wire row for `POST /plan`, or `None` to drop it.
+
+    The emitted `label` is the COLOUR TERM (see the module docstring) — never a
+    noun the detector did not verify.
+    """
+    conf = blob_confidence(blob, cfg)
+    if conf <= 0.0:
+        return None
+    if colour_bands(blob.colour) is None:
+        return None  # unknown colour token -> refuse, never a target
+    ego = pixel_to_ego(blob.u, blob.v, blob.depth_m, intr, extr, cfg.max_range_m)
+    if ego is None:
+        return None
+    x_m, y_m, _z_m = ego
+    if x_m <= 0.0:
+        return None  # not ahead of the ego -> not a destination
+    return {
+        "label": blob.colour.strip().lower(),
+        "x": x_m,
+        "y": y_m,
+        "confidence": conf,
+    }
+
+
+def blobs_to_targets(
+    blobs: Iterable[Blob],
+    intr: CameraIntrinsics,
+    extr: CameraExtrinsics,
+    cfg: DetectConfig,
+) -> List[dict]:
+    """Every usable blob as a target row, nearest first (stable, deterministic)."""
+    rows = [t for t in (blob_to_target(b, intr, extr, cfg) for b in blobs) if t]
+    rows.sort(key=lambda t: (t["x"], t["y"], t["label"]))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Depth -> drivability detections (the tighten-only channel)
+# ---------------------------------------------------------------------------
+
+
+def depth_frame_usable(valid_fraction: float, cfg: DetectConfig) -> bool:
+    """Did the depth camera actually SEE this frame?
+
+    Load-bearing: a frame that is mostly invalid (dark, saturated, out of the
+    sensor's range, driver hiccup) must NOT be published as "fresh, zero
+    detections" — that reads to Taj as *"I looked, it's clear"*. The node
+    withholds `camera_stamp_ms` when this is `False`, which makes
+    `resolve_camera_channel` return Faulted and floors the speed cap.
+    """
+    if not math.isfinite(valid_fraction):
+        return False
+    return valid_fraction >= cfg.min_frame_valid_fraction
+
+
+def points_to_obstacle_detections(
+    points: Iterable[Tuple[float, float, float]],
+    cfg: DetectConfig,
+) -> List[dict]:
+    """Ego-frame points -> `detections[]` rows for `POST /perception`.
+
+    Points are binned laterally; each occupied bin reports its NEAREST return as
+    a `static_obstacle`. Because the Taj fusion is tighten-only, a spurious bin
+    can only slow the robot down — the failure direction is availability, never
+    safety. Ground returns (`z <= ground_z_m`) and out-of-range points are
+    dropped, and bins are emitted nearest-first.
+    """
+    if cfg.obstacle_bin_m <= 0.0:
+        return []
+    nearest: dict = {}
+    for p in points:
+        try:
+            x, y, z = float(p[0]), float(p[1]), float(p[2])
+        except (TypeError, ValueError, IndexError):
+            continue
+        if not all(math.isfinite(q) for q in (x, y, z)):
+            continue
+        if x <= 0.0 or x > cfg.max_range_m:
+            continue
+        if z <= cfg.ground_z_m:
+            continue  # floor, not an obstacle
+        b = math.floor(y / cfg.obstacle_bin_m)
+        if b not in nearest or x < nearest[b]:
+            nearest[b] = x
+    rows = [
+        {
+            "class": "static_obstacle",
+            "near_x_m": x,
+            "lateral_min_m": b * cfg.obstacle_bin_m,
+            "lateral_max_m": (b + 1) * cfg.obstacle_bin_m,
+        }
+        for b, x in nearest.items()
+    ]
+    rows.sort(key=lambda r: (r["near_x_m"], r["lateral_min_m"]))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# The published frame
+# ---------------------------------------------------------------------------
+
+
+def build_detection_frame(
+    blobs: Iterable[Blob],
+    points: Iterable[Tuple[float, float, float]],
+    frame_valid_fraction: float,
+    stamp_ms: int,
+    intr: CameraIntrinsics,
+    extr: CameraExtrinsics,
+    cfg: DetectConfig,
+) -> dict:
+    """Assemble the JSON the node publishes and `occy_doer` forwards.
+
+    `stamp_ms` is **withheld (`None`)** — and `usable` is `False` — whenever the
+    depth frame was not actually seen, so a consumer that arms the camera channel
+    faults to the MRC floor instead of believing an empty detection list.
+    """
+    usable = depth_frame_usable(frame_valid_fraction, cfg)
+    return {
+        "usable": usable,
+        "stamp_ms": int(stamp_ms) if usable else None,
+        "frame_valid_fraction": (
+            float(frame_valid_fraction) if math.isfinite(frame_valid_fraction) else 0.0
+        ),
+        "detections": points_to_obstacle_detections(points, cfg) if usable else [],
+        "targets": blobs_to_targets(blobs, intr, extr, cfg) if usable else [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Consumer side: relaying a frame into the sidecar requests
+# ---------------------------------------------------------------------------
+
+# Mirrors `kirra_sidecars::taj::DEFAULT_CAMERA_MAX_AGE_MS`.
+DEFAULT_CAMERA_MAX_AGE_MS = 500
+
+
+def camera_perception_fields(
+    armed: bool,
+    frame: Optional[dict],
+    max_age_ms: int = DEFAULT_CAMERA_MAX_AGE_MS,
+) -> dict:
+    """The camera fields to merge into Taj `POST /perception`.
+
+    A FAITHFUL RELAY, not a second opinion: freshness is Taj's call (it compares
+    `camera_stamp_ms` against the request's `stamp_ms`, so both must come from
+    the SAME clock — per AOU-TIMESYNC-001 the caller sends the ROS header stamps
+    of the scan and the depth frame, never a wall clock mixed with a ROS one).
+
+    - Not armed → `{"camera_armed": false}`: Phase-B never runs, byte-identical
+      to the lidar-only endpoint.
+    - Armed with a usable frame → relay its stamp and detections.
+    - Armed with NO usable frame (detector down, unregistered depth, blind
+      frame) → armed but **no stamp**, which resolves Faulted at Taj and floors
+      the speed cap. Silence must never be relayed as an empty detection list.
+    """
+    if not armed:
+        return {"camera_armed": False}
+    out = {"camera_armed": True, "camera_max_age_ms": int(max_age_ms)}
+    if isinstance(frame, dict) and frame.get("usable") is True:
+        stamp = frame.get("stamp_ms")
+        if isinstance(stamp, int) and not isinstance(stamp, bool) and stamp >= 0:
+            out["camera_stamp_ms"] = stamp
+            out["detections"] = [
+                d for d in (frame.get("detections") or []) if isinstance(d, dict)
+            ]
+    return out
+
+
+def plan_object_goal_fields(
+    phrase: Optional[str],
+    frame: Optional[dict],
+    now_ms: int,
+) -> Tuple[Optional[dict], Optional[str]]:
+    """The object-goal fields for Occy `POST /plan`, or a refusal reason.
+
+    Returns `(fields, None)` when the request can be made, else `(None, why)` —
+    and a refusal means the caller HOLDS. It must never fall back to some other
+    goal: the operator asked for a specific thing, and quietly driving somewhere
+    else would be worse than not moving.
+
+    `phrase` is the operator's words ("drive to the red cup"); it is reduced to
+    the one colour term this detector can ground. The planner does the rest
+    (label match, confidence floor, ambiguity, staleness) and fails closed.
+    """
+    if phrase is None or not str(phrase).strip():
+        return (None, None)  # no object goal requested — not a refusal
+    colour = colour_term(phrase)
+    if colour is None:
+        return (None, f'cannot ground "{phrase}" — name one known colour '
+                      f'({", ".join(known_colours())})')
+    if not (isinstance(frame, dict) and frame.get("usable") is True):
+        return (None, "no usable camera frame")
+    stamp = frame.get("stamp_ms")
+    if not (isinstance(stamp, int) and not isinstance(stamp, bool) and stamp >= 0):
+        return (None, "camera frame carries no stamp")
+    return ({
+        "object_goal": colour,
+        "targets": [t for t in (frame.get("targets") or []) if isinstance(t, dict)],
+        "targets_stamp_ms": stamp,
+        "now_ms": int(now_ms),
+    }, None)
+
+
+def object_goal_reached(phrase: Optional[str], frame: Optional[dict], tol_m: float) -> bool:
+    """Has the ego arrived at the requested thing?
+
+    Without this the loop would oscillate at close range: a target inside the
+    goal tolerance keeps being planned toward, then drops out of the detector's
+    usable band (`x <= 0`, or too near for depth), the planner refuses, the doer
+    holds, the target reappears, and the robot nudges forward again. Latching
+    "arrived" on the same range test the positional goal uses makes the stop
+    deliberate instead of emergent.
+
+    `False` whenever the answer is not knowable (no phrase, no frame, no matching
+    target) — arrival is a positive claim, and not-seen must fall through to the
+    planner's own fail-closed refusal, not be reported as "we are there".
+    """
+    colour = colour_term(phrase) if phrase else None
+    if colour is None or not isinstance(frame, dict) or frame.get("usable") is not True:
+        return False
+    if not math.isfinite(tol_m) or tol_m <= 0.0:
+        return False
+    for t in frame.get("targets") or []:
+        if not isinstance(t, dict) or str(t.get("label", "")).strip().lower() != colour:
+            continue
+        try:
+            x, y = float(t["x"]), float(t["y"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if math.isfinite(x) and math.isfinite(y) and math.hypot(x, y) <= tol_m:
+            return True
+    return False

--- a/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
@@ -26,6 +26,7 @@ the same `objects` list (richer than Taj's geometric clusters) — this node's s
 unchanged. Mick (the LLM) fits by publishing the goal/intent instead of RViz.
 """
 
+import json
 import math
 import time
 
@@ -35,10 +36,15 @@ from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
 from geometry_msgs.msg import Twist, PoseStamped
 from nav_msgs.msg import Odometry
 from sensor_msgs.msg import LaserScan
+from std_msgs.msg import String
 
 from kirra_safety.doer_core import (
     yaw_from_quaternion, goal_to_base, goal_reached, decide, extend_corridor_back,
     staleness_budget_valid,
+)
+from kirra_safety.camera_detect_core import (
+    DEFAULT_CAMERA_MAX_AGE_MS, camera_perception_fields, object_goal_reached,
+    plan_object_goal_fields,
 )
 
 try:
@@ -116,6 +122,19 @@ class OccyDoer(Node):
         # Extend the corridor behind the robot so its footprint (which sits behind the lidar
         # at the origin) is contained — Taj only reports forward free space.
         self.declare_parameter('corridor_back_m', 0.5)
+        # --- camera channels (OPT-IN; default off = byte-identical prior behaviour) ---
+        # `camera_armed` arms the Taj Phase-B fusion, which is TIGHTEN-ONLY: camera
+        # detections may only SHORTEN the lidar corridor, never extend it. Armed but
+        # blind (detector down / unregistered depth) relays NO stamp, so Taj faults the
+        # channel and floors the speed cap — "the detector did not look" is never "clear".
+        self.declare_parameter('camera_armed', False)
+        self.declare_parameter('camera_detections_topic', '/camera_detect/detections')
+        self.declare_parameter('camera_max_age_ms', DEFAULT_CAMERA_MAX_AGE_MS)
+        # The object-goal channel ("drive to the red cup"). A phrase published here is
+        # reduced to the one colour term the classical detector can ground and sent as
+        # `object_goal`; the planner resolves it against `targets` and fails closed.
+        # Empty string clears it. This is a DESTINATION, never a drivability claim.
+        self.declare_parameter('object_goal_topic', '/object_goal')
 
         self._taj = self.get_parameter('taj_url').value.rstrip('/')
         self._planner = self.get_parameter('planner_url').value.rstrip('/')
@@ -153,14 +172,25 @@ class OccyDoer(Node):
             'lateral_clearance_target_m': self.get_parameter('lateral_clearance_target_m').value,
         }
 
+        self._camera_armed = bool(self.get_parameter('camera_armed').value)
+        self._camera_max_age_ms = int(self.get_parameter('camera_max_age_ms').value)
+
         self._pose = None         # (x, y, yaw, speed)
         self._goal = None         # (x, y) in the odom/world frame
         self._scan = None         # (LaserScan, monotonic_recv_time)
+        self._camera = None       # the latest detector frame (dict), or None
+        self._object_goal = None  # the operator's requested thing, e.g. "red cup"
+        self._object_refusal = None   # last refusal reason, logged once
+        self._camera_healthy = True   # last reported channel health, logged on change
 
         self._pub = self.create_publisher(Twist, self.get_parameter('cmd_topic').value, 10)
         self.create_subscription(Odometry, self.get_parameter('odom_topic').value, self._on_odom, 20)
         self.create_subscription(PoseStamped, self.get_parameter('goal_topic').value, self._on_goal, 10)
         self.create_subscription(LaserScan, self.get_parameter('scan_topic').value, self._on_scan, SCAN_QOS)
+        self.create_subscription(
+            String, self.get_parameter('camera_detections_topic').value, self._on_camera, 10)
+        self.create_subscription(
+            String, self.get_parameter('object_goal_topic').value, self._on_object_goal, 10)
         self.create_timer(1.0 / self.get_parameter('plan_hz').value, self._tick)
 
         if not REQUESTS_AVAILABLE:
@@ -184,6 +214,22 @@ class OccyDoer(Node):
 
     def _on_scan(self, msg: LaserScan):
         self._scan = (msg, time.monotonic())
+
+    def _on_camera(self, msg: String):
+        """Store the detector frame. Undecodable JSON drops it (armed -> faults)."""
+        try:
+            frame = json.loads(msg.data)
+        except (ValueError, TypeError):
+            self._camera = None
+            return
+        self._camera = frame if isinstance(frame, dict) else None
+
+    def _on_object_goal(self, msg: String):
+        phrase = (msg.data or '').strip()
+        self._object_goal = phrase or None
+        self._object_refusal = None
+        self.get_logger().info(
+            f'object goal: {self._object_goal!r}' if self._object_goal else 'object goal cleared')
 
     # --- Mick intent consumption (intents, never commands) -------------------
     def _poll_mick(self):
@@ -234,31 +280,78 @@ class OccyDoer(Node):
         if not REQUESTS_AVAILABLE:
             return self._hold('no-requests')
         self._poll_mick()
-        if self._pose is None or self._goal is None:
-            return self._hold('awaiting pose/goal')
+        if self._pose is None:
+            return self._hold('awaiting pose')
+        if self._goal is None and self._object_goal is None:
+            return self._hold('awaiting goal')
         if self._scan is None or (time.monotonic() - self._scan[1]) > self._scan_stale_s:
             return self._hold('stale-scan')  # fail-soft: no fresh perception → hold
 
         rx, ry, ryaw, speed = self._pose
-        gx, gy = goal_to_base(rx, ry, ryaw, self._goal[0], self._goal[1])
-        if goal_reached(gx, gy, self._goal_tol):
-            return self._hold('goal-reached')
+        # The positional goal (if any). With an object goal set, the planner ignores
+        # this in favour of the camera-grounded one — but every numeric field must
+        # still be finite, so the ego is the neutral placeholder.
+        if self._goal is not None:
+            gx, gy = goal_to_base(rx, ry, ryaw, self._goal[0], self._goal[1])
+            if self._object_goal is None and goal_reached(gx, gy, self._goal_tol):
+                return self._hold('goal-reached')
+        else:
+            gx, gy = 0.0, 0.0
 
         scan = self._scan[0]
+        # ONE clock domain for every stamp in the request (AOU-TIMESYNC-001): the
+        # scan's own header stamp is `now_ms` for the camera-freshness comparison,
+        # so a camera stamp from the same ROS clock is judged correctly. Phase A is
+        # unaffected (it derives age as now_ms - scan.stamp_ms, i.e. zero either way).
+        scan_stamp_ms = int(scan.header.stamp.sec * 1000
+                            + scan.header.stamp.nanosec // 1_000_000)
+
+        # The object-goal channel decides BEFORE any request goes out: a refusal is
+        # a hold, never a quiet fall-back to some other goal.
+        if object_goal_reached(self._object_goal, self._camera, self._goal_tol):
+            return self._hold('object-goal-reached')
+        goal_fields, refusal = plan_object_goal_fields(
+            self._object_goal, self._camera, scan_stamp_ms)
+        if refusal:
+            if refusal != self._object_refusal:
+                self._object_refusal = refusal
+                self.get_logger().warn(f'object goal {self._object_goal!r}: {refusal}')
+            return self._hold(f'object-goal-refused:{refusal}')
+        self._object_refusal = None
+
         try:
-            taj = requests.post(f'{self._taj}/perception', timeout=self._timeout_s, json={
+            perception = {
                 'angle_min_rad': float(scan.angle_min),
                 'angle_increment_rad': float(scan.angle_increment),
                 'range_min_m': float(scan.range_min),
                 'range_max_m': float(scan.range_max),
                 'ranges': [float(r) for r in scan.ranges],
-                'stamp_ms': 0, 'forward_extent_m': self._extent,
-            }).json()
+                'stamp_ms': scan_stamp_ms, 'forward_extent_m': self._extent,
+            }
+            # Camera Phase-B (tighten-only). Disarmed → this is {'camera_armed': False}
+            # and the endpoint is byte-identical to the lidar-only path.
+            perception.update(camera_perception_fields(
+                self._camera_armed, self._camera, self._camera_max_age_ms))
+            taj = requests.post(
+                f'{self._taj}/perception', timeout=self._timeout_s, json=perception).json()
+            if self._camera_armed:
+                # Taj already floored the speed cap; say so once per transition so an
+                # operator sees WHY the robot crawled rather than guessing — and once
+                # per transition rather than every tick, so the log stays readable.
+                healthy = taj.get('camera_healthy') is not False
+                if healthy != self._camera_healthy:
+                    self._camera_healthy = healthy
+                    if healthy:
+                        self.get_logger().info('camera channel healthy again')
+                    else:
+                        self.get_logger().warn(
+                            'camera channel unhealthy — Taj floored the speed cap '
+                            '(no usable frame: detector down, stale, or blind)')
 
             # Extend the Taj corridor behind the robot (footprint containment) and tell the
             # checker the robot's real size, so KIRRA judges a robot — not a 4.8 m car.
             left, right = extend_corridor_back(taj.get('left', []), taj.get('right', []), self._back_m)
-            plan = requests.post(f'{self._planner}/plan', timeout=self._timeout_s, json={
+            plan_req = {
                 'ego': {'x': 0.0, 'y': 0.0, 'heading': 0.0, 'speed': float(speed)},
                 'goal': {'x': gx, 'y': gy},
                 'cruise': self._cruise,
@@ -266,7 +359,11 @@ class OccyDoer(Node):
                 'right': right,
                 'objects': taj.get('objects', []),
                 'vehicle': self._vehicle,
-            }).json()
+            }
+            if goal_fields:
+                plan_req.update(goal_fields)
+            plan = requests.post(
+                f'{self._planner}/plan', timeout=self._timeout_s, json=plan_req).json()
         except Exception as e:  # noqa: BLE001 — any fault holds (fail-soft)
             return self._hold(f'service-error:{e}')
 

--- a/ros2_ws/src/kirra_safety/setup.py
+++ b/ros2_ws/src/kirra_safety/setup.py
@@ -36,6 +36,7 @@ setup(
             'perception_governor = kirra_safety.perception_governor:main',
             'doer_commander = kirra_safety.doer_commander:main',
             'occy_doer = kirra_safety.occy_doer:main',
+            'camera_detect = kirra_safety.camera_detect:main',
         ],
     },
 )

--- a/ros2_ws/src/kirra_safety/test/test_camera_detect_core.py
+++ b/ros2_ws/src/kirra_safety/test/test_camera_detect_core.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Host tests for the classical-CV camera detector core (no ROS, no cv2, no camera)."""
+
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from kirra_safety.camera_detect_core import (  # noqa: E402
+    Blob,
+    CameraExtrinsics,
+    CameraIntrinsics,
+    DetectConfig,
+    blob_confidence,
+    blob_to_target,
+    blobs_to_targets,
+    build_detection_frame,
+    camera_perception_fields,
+    colour_bands,
+    colour_term,
+    depth_frame_usable,
+    known_colours,
+    object_goal_reached,
+    pixel_to_ego,
+    plan_object_goal_fields,
+    points_to_obstacle_detections,
+)
+
+# A plausible 640x480 depth camera, mounted 0.20 m up, 0.10 m forward of the
+# ego origin, tilted 15 degrees down so it sees the floor just ahead.
+INTR = CameraIntrinsics(fx=520.0, fy=520.0, cx=320.0, cy=240.0)
+LEVEL = CameraExtrinsics(x_m=0.10, y_m=0.0, z_m=0.20, pitch_rad=0.0)
+TILTED = CameraExtrinsics(x_m=0.10, y_m=0.0, z_m=0.20, pitch_rad=math.radians(15.0))
+CFG = DetectConfig()
+
+
+# --- geometry ---------------------------------------------------------------
+
+def test_principal_point_on_a_level_camera_projects_straight_ahead():
+    x, y, z = pixel_to_ego(INTR.cx, INTR.cy, 2.0, INTR, LEVEL)
+    assert x == 2.1              # 0.10 mount offset + 2.0 depth
+    assert y == 0.0              # dead centre -> no lateral offset
+    assert z == 0.2              # stays at mount height
+
+
+def test_right_of_centre_is_negative_y_left_of_centre_is_positive():
+    # Ego frame is REP-103: +Y is LEFT. A pixel to the RIGHT of the principal
+    # point must therefore land at negative y. Getting this backwards would
+    # mirror every detection.
+    _, y_right, _ = pixel_to_ego(INTR.cx + 104.0, INTR.cy, 2.0, INTR, LEVEL)
+    _, y_left, _ = pixel_to_ego(INTR.cx - 104.0, INTR.cy, 2.0, INTR, LEVEL)
+    assert y_right < 0.0
+    assert y_left > 0.0
+    assert math.isclose(y_right, -0.4, abs_tol=1e-9)   # 104/520 * 2.0
+    assert math.isclose(y_left, 0.4, abs_tol=1e-9)
+
+
+def test_a_downward_tilt_shortens_the_forward_reach_and_lowers_the_point():
+    # The same optical-axis return, once the camera is nosed down 15 deg, is
+    # nearer in x and below the mount height.
+    fx, _, fz = pixel_to_ego(INTR.cx, INTR.cy, 2.0, INTR, TILTED)
+    assert math.isclose(fx, 0.10 + 2.0 * math.cos(math.radians(15.0)), abs_tol=1e-9)
+    assert math.isclose(fz, 0.20 - 2.0 * math.sin(math.radians(15.0)), abs_tol=1e-9)
+    assert fz < 0.0  # 2 m along a 15 deg down-axis is below the floor plane
+
+
+def test_a_camera_looking_straight_down_reports_the_floor_beneath_it():
+    down = CameraExtrinsics(x_m=0.0, y_m=0.0, z_m=0.5, pitch_rad=math.radians(90.0))
+    x, y, z = pixel_to_ego(INTR.cx, INTR.cy, 0.5, INTR, down)
+    assert math.isclose(x, 0.0, abs_tol=1e-9)
+    assert math.isclose(y, 0.0, abs_tol=1e-9)
+    assert math.isclose(z, 0.0, abs_tol=1e-9)   # exactly the ground
+
+
+def test_unusable_depth_and_bad_calibration_are_refused_not_guessed():
+    for bad_depth in (0.0, -1.0, float('nan'), float('inf'), 99.0):
+        assert pixel_to_ego(INTR.cx, INTR.cy, bad_depth, INTR, LEVEL) is None
+    assert pixel_to_ego(float('nan'), INTR.cy, 2.0, INTR, LEVEL) is None
+    assert pixel_to_ego(INTR.cx, INTR.cy, 2.0, CameraIntrinsics(0.0, 520.0, 320.0, 240.0), LEVEL) is None
+    bad_extr = CameraExtrinsics(pitch_rad=float('nan'))
+    assert pixel_to_ego(INTR.cx, INTR.cy, 2.0, INTR, bad_extr) is None
+
+
+# --- colour vocabulary ------------------------------------------------------
+
+def test_colour_term_reduces_a_phrase_to_the_one_colour_it_can_ground():
+    assert colour_term('red cup') == 'red'
+    assert colour_term('the RED  cup') == 'red'
+    assert colour_term('red') == 'red'
+    assert colour_term('drive to the blue box') == 'blue'
+
+
+def test_colour_term_refuses_no_colour_and_refuses_ambiguity():
+    # No colour at all: the classical detector cannot ground a bare noun.
+    assert colour_term('cup') is None
+    assert colour_term('') is None
+    assert colour_term(None) is None
+    # Two colours: must NOT silently pick one.
+    assert colour_term('red blue thing') is None
+
+
+def test_colour_term_does_not_match_a_colour_inside_another_word():
+    # "prepared" contains "red"; word-boundary matching must not fire.
+    assert colour_term('prepared meal') is None
+
+
+def test_red_carries_both_hue_bands_because_red_wraps_the_hue_origin():
+    bands = colour_bands('red')
+    assert len(bands) == 2, 'a single-band red misses half of every red object'
+    los = sorted(b[0][0] for b in bands)
+    assert los[0] == 0 and los[1] > 150
+    for other in ('blue', 'green', 'yellow'):
+        assert len(colour_bands(other)) == 1
+
+
+def test_unknown_colour_tokens_are_refused():
+    assert colour_bands('chartreuse') is None
+    assert colour_bands('') is None
+    assert colour_bands(None) is None
+    assert 'red' in known_colours() and 'blue' in known_colours()
+
+
+# --- blobs -> targets -------------------------------------------------------
+
+def _blob(**kw):
+    base = dict(colour='red', u=INTR.cx, v=INTR.cy, pixel_count=1000,
+                depth_m=2.0, depth_valid_fraction=0.9)
+    base.update(kw)
+    return Blob(**base)
+
+
+def test_a_solid_blob_becomes_a_target_labelled_with_the_colour_term_only():
+    t = blob_to_target(_blob(), INTR, LEVEL, CFG)
+    # The label is the COLOUR, never a noun the detector did not verify.
+    assert t['label'] == 'red'
+    assert math.isclose(t['x'], 2.1, abs_tol=1e-9)
+    assert math.isclose(t['y'], 0.0, abs_tol=1e-9)
+    assert 0.0 < t['confidence'] <= 1.0
+
+
+def test_a_blob_with_mostly_invalid_depth_is_dropped_never_range_guessed():
+    b = _blob(depth_valid_fraction=0.05)
+    assert blob_confidence(b, CFG) == 0.0
+    assert blob_to_target(b, INTR, LEVEL, CFG) is None
+
+
+def test_a_speck_is_dropped_and_confidence_rises_with_size_then_saturates():
+    assert blob_to_target(_blob(pixel_count=10), INTR, LEVEL, CFG) is None
+    small = blob_confidence(_blob(pixel_count=CFG.min_pixels), CFG)
+    mid = blob_confidence(_blob(pixel_count=2 * CFG.min_pixels), CFG)
+    huge = blob_confidence(_blob(pixel_count=10_000 * CFG.min_pixels), CFG)
+    assert small < mid < 1.0
+    assert huge <= 1.0
+    # A giant blob cannot buy confidence beyond its depth agreement.
+    assert blob_confidence(_blob(pixel_count=10**6, depth_valid_fraction=0.5), CFG) <= 0.5
+
+
+def test_an_unknown_colour_or_out_of_range_blob_never_becomes_a_target():
+    assert blob_to_target(_blob(colour='chartreuse'), INTR, LEVEL, CFG) is None
+    assert blob_to_target(_blob(depth_m=CFG.max_range_m + 1.0), INTR, LEVEL, CFG) is None
+    assert blob_to_target(_blob(depth_m=float('nan')), INTR, LEVEL, CFG) is None
+
+
+def test_a_blob_that_projects_behind_the_ego_is_not_a_destination():
+    # Camera looking straight backwards-and-down: a near return lands at x <= 0.
+    behind = CameraExtrinsics(x_m=-1.0, y_m=0.0, z_m=0.2, pitch_rad=0.0)
+    assert blob_to_target(_blob(depth_m=0.5), INTR, behind, CFG) is None
+
+
+def test_targets_are_returned_nearest_first_and_deterministically():
+    rows = blobs_to_targets(
+        [_blob(depth_m=3.0), _blob(colour='blue', depth_m=1.0), _blob(depth_m=2.0)],
+        INTR, LEVEL, CFG)
+    xs = [r['x'] for r in rows]
+    assert xs == sorted(xs)
+    assert rows[0]['label'] == 'blue'
+    assert blobs_to_targets([_blob(depth_m=3.0), _blob(colour='blue', depth_m=1.0),
+                             _blob(depth_m=2.0)], INTR, LEVEL, CFG) == rows
+
+
+# --- depth -> drivability detections ---------------------------------------
+
+def test_occupied_bins_become_static_obstacles_at_their_nearest_return():
+    pts = [(2.0, 0.05, 0.4), (1.5, 0.07, 0.4), (3.0, -0.5, 0.4)]
+    rows = points_to_obstacle_detections(pts, CFG)
+    assert [r['class'] for r in rows] == ['static_obstacle', 'static_obstacle']
+    # Nearest first; the 0.05/0.07 pair share a bin and collapse to x=1.5.
+    assert rows[0]['near_x_m'] == 1.5
+    assert rows[0]['lateral_min_m'] <= 0.05 < rows[0]['lateral_max_m']
+    assert rows[1]['near_x_m'] == 3.0
+
+
+def test_ground_returns_and_out_of_range_points_are_not_obstacles():
+    ground = [(2.0, 0.0, 0.0), (2.0, 0.0, CFG.ground_z_m)]
+    assert points_to_obstacle_detections(ground, CFG) == []
+    assert points_to_obstacle_detections([(CFG.max_range_m + 1.0, 0.0, 0.5)], CFG) == []
+    assert points_to_obstacle_detections([(-1.0, 0.0, 0.5)], CFG) == []
+
+
+def test_malformed_and_non_finite_points_are_skipped_not_propagated():
+    pts = [(float('nan'), 0.0, 0.5), (2.0, float('inf'), 0.5), ('x', 'y', 'z'),
+           (1.0,), None, (2.0, 0.0, 0.5)]
+    rows = points_to_obstacle_detections(pts, CFG)
+    assert len(rows) == 1
+    assert rows[0]['near_x_m'] == 2.0
+    assert all(math.isfinite(v) for r in rows for v in
+               (r['near_x_m'], r['lateral_min_m'], r['lateral_max_m']))
+
+
+# --- the fail-closed frame contract ----------------------------------------
+
+def test_a_mostly_invalid_depth_frame_is_not_usable():
+    assert depth_frame_usable(0.9, CFG) is True
+    assert depth_frame_usable(CFG.min_frame_valid_fraction, CFG) is True
+    assert depth_frame_usable(0.01, CFG) is False
+    assert depth_frame_usable(float('nan'), CFG) is False
+
+
+def test_an_unseen_frame_withholds_the_stamp_so_the_consumer_faults_closed():
+    # THE load-bearing rule: a frame the camera could not actually see must not
+    # be published as "fresh, zero detections" (which reads as "I looked, it's
+    # clear"). Withholding the stamp makes resolve_camera_channel go Faulted.
+    frame = build_detection_frame(
+        blobs=[_blob()], points=[(2.0, 0.0, 0.5)],
+        frame_valid_fraction=0.0, stamp_ms=1234, intr=INTR, extr=LEVEL, cfg=CFG)
+    assert frame['usable'] is False
+    assert frame['stamp_ms'] is None
+    assert frame['detections'] == []
+    assert frame['targets'] == []
+
+
+def test_a_seen_frame_publishes_its_stamp_detections_and_targets():
+    frame = build_detection_frame(
+        blobs=[_blob()], points=[(2.0, 0.0, 0.5)],
+        frame_valid_fraction=0.85, stamp_ms=1234, intr=INTR, extr=LEVEL, cfg=CFG)
+    assert frame['usable'] is True
+    assert frame['stamp_ms'] == 1234
+    assert len(frame['detections']) == 1
+    assert frame['targets'][0]['label'] == 'red'
+
+
+def test_a_seen_but_empty_frame_is_clear_not_faulted():
+    # Distinct from silence: the camera looked and found nothing. Legitimate.
+    frame = build_detection_frame(
+        blobs=[], points=[], frame_valid_fraction=0.95, stamp_ms=7,
+        intr=INTR, extr=LEVEL, cfg=CFG)
+    assert frame['usable'] is True and frame['stamp_ms'] == 7
+    assert frame['detections'] == [] and frame['targets'] == []
+
+
+# --- consumer relay: /perception fields ------------------------------------
+
+def _good_frame(**kw):
+    f = build_detection_frame(
+        blobs=[_blob()], points=[(2.0, 0.0, 0.5)], frame_valid_fraction=0.9,
+        stamp_ms=9000, intr=INTR, extr=LEVEL, cfg=CFG)
+    f.update(kw)
+    return f
+
+
+def test_a_disarmed_camera_relays_nothing_so_taj_is_byte_identical():
+    assert camera_perception_fields(False, _good_frame()) == {'camera_armed': False}
+
+
+def test_an_armed_camera_with_a_usable_frame_relays_stamp_and_detections():
+    out = camera_perception_fields(True, _good_frame())
+    assert out['camera_armed'] is True
+    assert out['camera_stamp_ms'] == 9000
+    assert len(out['detections']) == 1
+    assert out['camera_max_age_ms'] > 0
+
+
+def test_an_armed_camera_with_no_usable_frame_withholds_the_stamp():
+    # Armed but blind: relaying `detections: []` with a fresh stamp would read
+    # at Taj as "I looked, it's clear". Withholding the stamp faults the channel
+    # to the MRC floor instead.
+    for frame in (None, {}, _good_frame(usable=False), _good_frame(stamp_ms=None),
+                  _good_frame(stamp_ms='9000'), _good_frame(stamp_ms=True),
+                  'not-a-dict'):
+        out = camera_perception_fields(True, frame)
+        assert out['camera_armed'] is True
+        assert 'camera_stamp_ms' not in out, frame
+        assert 'detections' not in out, frame
+
+
+def test_malformed_detection_rows_are_dropped_from_the_relay():
+    out = camera_perception_fields(True, _good_frame(detections=[{'class': 'water'}, 7, None]))
+    assert out['detections'] == [{'class': 'water'}]
+
+
+# --- consumer relay: /plan object-goal fields -------------------------------
+
+def test_no_object_goal_requested_is_not_a_refusal():
+    for phrase in (None, '', '   '):
+        fields, why = plan_object_goal_fields(phrase, _good_frame(), now_ms=9100)
+        assert fields is None and why is None
+
+
+def test_a_grounded_phrase_becomes_the_colour_term_plus_targets():
+    fields, why = plan_object_goal_fields('drive to the red cup', _good_frame(), now_ms=9100)
+    assert why is None
+    assert fields['object_goal'] == 'red'      # colour only — the noun is unverified
+    assert fields['targets'][0]['label'] == 'red'
+    assert fields['targets_stamp_ms'] == 9000
+    assert fields['now_ms'] == 9100
+
+
+def test_an_ungroundable_phrase_refuses_and_never_falls_back_to_another_goal():
+    fields, why = plan_object_goal_fields('drive to the cup', _good_frame(), now_ms=9100)
+    assert fields is None
+    assert why and 'cannot ground' in why
+    fields, why = plan_object_goal_fields('the red blue thing', _good_frame(), now_ms=1)
+    assert fields is None and why
+
+
+def test_an_object_goal_without_a_usable_frame_refuses_rather_than_planning_blind():
+    for frame in (None, {}, _good_frame(usable=False), _good_frame(stamp_ms=None)):
+        fields, why = plan_object_goal_fields('red cup', frame, now_ms=9100)
+        assert fields is None, frame
+        assert why, frame
+
+
+# --- arrival ----------------------------------------------------------------
+
+def _targets_frame(targets):
+    return _good_frame(targets=targets)
+
+
+def test_arrival_latches_when_the_matching_target_is_inside_the_tolerance():
+    near = _targets_frame([{'label': 'red', 'x': 0.2, 'y': 0.1, 'confidence': 0.9}])
+    assert object_goal_reached('red cup', near, 0.25) is True
+    far = _targets_frame([{'label': 'red', 'x': 2.0, 'y': 0.0, 'confidence': 0.9}])
+    assert object_goal_reached('red cup', far, 0.25) is False
+
+
+def test_arrival_only_counts_the_requested_colour():
+    other = _targets_frame([{'label': 'blue', 'x': 0.1, 'y': 0.0, 'confidence': 0.9}])
+    assert object_goal_reached('red cup', other, 0.25) is False
+
+
+def test_arrival_is_never_claimed_when_it_cannot_be_known():
+    good = _targets_frame([{'label': 'red', 'x': 0.1, 'y': 0.0, 'confidence': 0.9}])
+    # Not-seen / not-knowable must fall through to the planner's refusal, never
+    # be reported as "we are there".
+    assert object_goal_reached(None, good, 0.25) is False
+    assert object_goal_reached('cup', good, 0.25) is False          # ungroundable
+    assert object_goal_reached('red cup', None, 0.25) is False
+    assert object_goal_reached('red cup', _good_frame(usable=False), 0.25) is False
+    assert object_goal_reached('red cup', _targets_frame([]), 0.25) is False
+    assert object_goal_reached('red cup', good, 0.0) is False       # no tolerance
+    assert object_goal_reached('red cup', good, float('nan')) is False
+
+
+def test_arrival_skips_malformed_target_rows():
+    frame = _targets_frame([
+        7, None, {'label': 'red'}, {'label': 'red', 'x': 'near', 'y': 0.0},
+        {'label': 'red', 'x': float('nan'), 'y': 0.0},
+        {'label': 'red', 'x': 0.1, 'y': 0.0},
+    ])
+    assert object_goal_reached('red cup', frame, 0.25) is True
+    without = _targets_frame([7, None, {'label': 'red', 'x': float('inf'), 'y': 0.0}])
+    assert object_goal_reached('red cup', without, 0.25) is False


### PR DESCRIPTION
Foundation for camera+lidar perception in Taj, and for object-named drive commands ("drive to the red cup") — built so the **camera holds no safety authority**.

## The finding: the camera seam existed but was dormant

`SemanticDetector` / `SemanticDetection` and `clip_corridor_to_hazards` already existed in `kirra-taj`, and ADR-0015 specifies "Astra RGB → Phase B detector → semantic objects". But **`handle_perception` was Phase-A only** — it never called the fusion, so Phase B was unreachable from the live service (the same shape as the old hardcoded-`None` occlusion channel). This wires the existing seam rather than inventing one.

## Two channels, deliberately separate

Conflating these would be a safety bug, so they live in different modules:

| | Channel | Authority |
|---|---|---|
| 1 | **Drivability** — `SemanticClass` → `clip_corridor_to_hazards` | **TIGHTEN-ONLY.** May shorten the corridor, never extend it. |
| 2 | **Where a named thing is** — `object_goal::LabeledTarget` → `ObjectGoal` | **None.** A destination, not a claim about the ground. |

🔴 **Lidar (Phase A) remains the sole authority on free space**, enforced three ways: `clip_corridor_to_hazards` structurally truncates; only `Road` is drivable and any unrecognized token decodes to `Unknown` (non-drivable); and the KPI gate's `ForbiddenLoosen` is a hard zero — now also swept in a test.

## 1. Camera → live Phase-B fusion

- `PerceptionRequest` gains `camera_armed` / `detections` / `camera_stamp_ms` / `camera_max_age_ms`, **all defaulting to the disarmed no-op** → byte-identical lidar-only behaviour when unset.
- `resolve_camera_channel` — the same three-way fail-closed decision the occlusion/VRU channels make: **Disarmed** → no-op; **Fresh** → fuse; **Faulted** (armed + no frame / stale / implausibly future-stamped / non-finite geometry) → `camera_healthy:false` → **MRC floor**. A fresh frame with *zero* detections is a legitimate "I looked, it's clear" — distinct from silence (*"the detector did not look" is never "clear"*).
- Clear distance + the ACD speed cap are measured on the **clipped** corridor, so a camera hazard tightens the cap. Response surfaces `camera_healthy` + `camera_clip_x_m`.

## 2. `kirra_taj::object_goal` — "drive to the red cup"

Resolves a named target to a forward ego-frame point, asserting **nothing** about drivability. The caller emits an ordinary `MickIntent::GoTo`, so there's **no new intent variant, no parse change, and no new actuation path** — the single-door invariant (text → `/intent` → checker) is untouched. Occy plans inside the lidar corridor and the checker bounds the trajectory, so a cup that is **visible but unreachable makes the robot stop short** rather than drive at it (`GoTo` already documents exactly this).

Fail-closed refusals — `NotSeen` / `LowConfidence` / `Ambiguous` / `Stale` / `NonFinite` / `BehindEgo` / `NoRequestedLabel` — each carry an operator sentence, so the robot *says* why it isn't driving. Label matching is deliberately non-fuzzy: **"red cup" must not match "blue cup"**.

## Verification

82 tests pass (48 `kirra-taj` incl. 12 object-goal, 34 `kirra-sidecars`); clippy + rustfmt clean. Notable properties pinned: `camera_can_never_extend_the_corridor` (classes × ranges), `armed_but_silent_camera_fails_closed_to_the_mrc_floor`, `unknown_class_tokens_fail_closed_to_non_drivable`, `disarmed_camera_leaves_the_corridor_untouched`.

## Not in this PR (documented as remaining)

The detector itself, the ROS 2 node hop that fills `detections`, camera frames into rabbit for conversation, and the `object_goal` → `GoTo` call site. Design, wire API, Orin bring-up, and detector trade-offs (classical CV vs ML vs VLM) are in `docs/hardware/CAMERA_PERCEPTION_INTEGRATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_