### PR TITLE
Wire Taj VRU classifications into pedestrian RSS

### DIFF
--- a/crates/kirra-sidecars/src/planner.rs
+++ b/crates/kirra-sidecars/src/planner.rs
@@ -35,6 +35,7 @@ use kirra_taj::object_goal::{
 use kirra_trajectory::corridor::{CorridorSource, Point};
 use kirra_trajectory::state::{PerceivedObject, TrajectoryVerdict};
 use kirra_trajectory::validation::validate_trajectory_slow_explained;
+use kirra_trajectory::vru::{PedestrianScene, PerceivedPedestrian, VruRssParams};
 use kirra_trajectory::VehicleConfig;
 use serde::{Deserialize, Serialize};
 
@@ -65,6 +66,20 @@ pub struct ObjReq {
     pub vy: f64,
 }
 
+/// One tracked pedestrian/VRU supplied by Taj.
+///
+/// Coordinates, velocity, and age are already expressed in the ego-frame
+/// perception contract consumed by the checker.
+#[derive(Deserialize)]
+pub struct PedestrianReq {
+    pub id: u64,
+    pub x: f64,
+    pub y: f64,
+    pub vx: f64,
+    pub vy: f64,
+    pub age_s: f64,
+}
+
 #[derive(Deserialize)]
 pub struct PlanRequest {
     pub ego: EgoReq,
@@ -75,6 +90,11 @@ pub struct PlanRequest {
     pub right: Vec<[f64; 2]>,
     #[serde(default)]
     pub objects: Vec<ObjReq>,
+    /// Taj's conservative tracked VRU classifications.
+    ///
+    /// Empty or absent preserves the pre-VRU planner path byte-for-byte.
+    #[serde(default)]
+    pub pedestrians: Vec<PedestrianReq>,
     /// Optional vehicle footprint/kinematics for the CHECKER. Absent → the
     /// urban-car default (4.8 m). A small differential robot MUST pass its own
     /// dimensions, or the car-sized footprint can't fit a robot-scale corridor
@@ -278,6 +298,10 @@ fn validate_finite(req: &PlanRequest) -> Result<(), SeamRejection> {
         .chain(req.right.iter())
         .all(|p| finite(&[p[0], p[1]]));
     let obj_ok = req.objects.iter().all(|o| finite(&[o.x, o.y, o.vx, o.vy]));
+    let pedestrian_ok = req
+        .pedestrians
+        .iter()
+        .all(|p| finite(&[p.x, p.y, p.vx, p.vy, p.age_s]) && p.age_s >= 0.0);
     // The optional vehicle overrides feed the checker's VehicleConfig and the
     // planner preset — a NaN footprint would mask comparisons downstream, so
     // they get the same gate (review: Copilot on #894).
@@ -295,7 +319,7 @@ fn validate_finite(req: &PlanRequest) -> Result<(), SeamRejection> {
         .flatten()
         .all(|x| x.is_finite())
     });
-    if ego_ok && goal_ok && corr_ok && obj_ok && veh_ok {
+    if ego_ok && goal_ok && corr_ok && obj_ok && pedestrian_ok && veh_ok {
         Ok(())
     } else {
         Err(SeamRejection {
@@ -463,6 +487,29 @@ pub fn handle_plan(req: &PlanRequest) -> Result<PlanResponse, SeamRejection> {
         })
         .collect();
 
+    let pedestrians: Vec<PerceivedPedestrian> = req
+        .pedestrians
+        .iter()
+        .map(|pedestrian| PerceivedPedestrian {
+            id: pedestrian.id,
+            pos: Point {
+                x_m: pedestrian.x,
+                y_m: pedestrian.y,
+            },
+            vel: Point {
+                x_m: pedestrian.vx,
+                y_m: pedestrian.vy,
+            },
+            age_s: pedestrian.age_s,
+        })
+        .collect();
+
+    let pedestrian_scene = PedestrianScene {
+        pedestrians: &pedestrians,
+        params: VruRssParams::default(),
+        barriers: &[],
+    };
+
     let world = PlanInput {
         ego: EgoState {
             pose: Pose {
@@ -525,7 +572,7 @@ pub fn handle_plan(req: &PlanRequest) -> Result<PlanResponse, SeamRejection> {
         None,
         None,
         None,
-        None,
+        Some(&pedestrian_scene),
         FrameTrust::Trusted,
     );
 
@@ -594,6 +641,7 @@ mod tests {
             left: vec![[-5.0, 5.0], [100.0, 5.0]],
             right: vec![[-5.0, -5.0], [100.0, -5.0]],
             objects: vec![],
+            pedestrians: vec![],
             vehicle: None,
             intent: None,
             // Object-goal channel off by default, so every pre-existing
@@ -757,6 +805,74 @@ mod tests {
                 "no motion may ride on a rejected intent"
             );
         }
+    }
+
+    #[test]
+    fn pedestrian_channel_binds_the_real_checker() {
+        let mut req = base_request();
+
+        // Keep the proposal short and slow enough that the ordinary vehicle
+        // checks admit it, then place a pedestrian directly in its path.
+        req.goal = Xy { x: 6.0, y: 0.0 };
+        req.cruise = 1.0;
+        req.pedestrians = vec![PedestrianReq {
+            id: 44,
+            x: 3.0,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            age_s: 0.0,
+        }];
+
+        let response = handle_plan(&req).expect("valid VRU request reaches checker");
+
+        assert_eq!(
+            response.verdict, "MRCFallback",
+            "a pedestrian in the proposed path must bind the VRU RSS checker"
+        );
+        assert!(!response.admitted);
+        assert!(response.trajectory.is_empty());
+    }
+
+    #[test]
+    fn absent_pedestrian_channel_preserves_existing_plan_path() {
+        let mut req = base_request();
+        req.pedestrians.clear();
+
+        let response = handle_plan(&req).expect("empty VRU channel is a no-op");
+
+        assert!(
+            matches!(response.verdict.as_str(), "Accept" | "Clamp"),
+            "empty VRU input must preserve the existing clean-plan path, got {}",
+            response.verdict
+        );
+    }
+
+    #[test]
+    fn malformed_pedestrian_input_is_refused_at_the_seam() {
+        let mut req = base_request();
+        req.pedestrians = vec![PedestrianReq {
+            id: 1,
+            x: f64::NAN,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            age_s: 0.0,
+        }];
+
+        assert_eq!(handle_plan(&req).unwrap_err().code, "NONFINITE_INPUT");
+
+        let mut req = base_request();
+        req.pedestrians = vec![PedestrianReq {
+            id: 1,
+            x: 2.0,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            age_s: -0.1,
+        }];
+
+        assert_eq!(handle_plan(&req).unwrap_err().code, "NONFINITE_INPUT");
     }
 
     #[test]

--- a/crates/kirra-sidecars/src/taj.rs
+++ b/crates/kirra-sidecars/src/taj.rs
@@ -12,7 +12,7 @@
 use kirra_core::corridor::CorridorSource;
 use kirra_taj::{
     clip_corridor_to_hazards, hazard_clip_x, LaserScan, SemanticClass, SemanticDetection,
-    TajConfig, TajTracker,
+    TajConfig, TajTracker, VruClassifierConfig,
 };
 use serde::{Deserialize, Serialize};
 
@@ -310,6 +310,7 @@ fn invalid_perception_response(camera_armed: bool) -> PerceptionResponse {
         left: Vec::new(),
         right: Vec::new(),
         objects: Vec::new(),
+        pedestrians: Vec::new(),
         camera_healthy: !camera_armed,
         camera_clip_x_m: None,
     }
@@ -322,6 +323,18 @@ pub struct ObjOut {
     pub y: f64,
     pub vx: f64,
     pub vy: f64,
+}
+
+/// One tracked pedestrian/VRU emitted by Taj for the planner's pedestrian RSS
+/// scene. Coordinates and velocity are in the ego frame used by `objects`.
+#[derive(Clone, Serialize)]
+pub struct PedestrianOut {
+    pub id: u64,
+    pub x: f64,
+    pub y: f64,
+    pub vx: f64,
+    pub vy: f64,
+    pub age_s: f64,
 }
 
 #[derive(Clone, Serialize)]
@@ -342,6 +355,11 @@ pub struct PerceptionResponse {
     pub left: Vec<[f64; 2]>,
     pub right: Vec<[f64; 2]>,
     pub objects: Vec<ObjOut>,
+    /// Conservative VRU classifications derived from the persistent tracker.
+    ///
+    /// First sightings with a pedestrian-sized footprint are included because
+    /// unknown velocity cannot safely disprove the pedestrian envelope.
+    pub pedestrians: Vec<PedestrianOut>,
     /// Phase-B observability: `false` when the camera channel is ARMED but the
     /// frame is missing / stale / undecodable (the request then fails closed to
     /// the MRC floor). `true` when disarmed (nothing to be unhealthy about) or
@@ -590,6 +608,16 @@ pub fn handle_perception_tracked(
         .expect("tracker initialized above")
         .track(&scan, req.stamp_ms);
 
+    // WP-10 production producer: classify the same persistent tracks that
+    // supplied the object IDs and velocities above. Classification uncertainty
+    // tightens toward pedestrian; every classified track also remains in
+    // `objects`, so the VRU bound is additive rather than substitutive.
+    let classified_pedestrians = state
+        .tracker
+        .as_ref()
+        .expect("tracker initialized above")
+        .classify_pedestrians(req.stamp_ms, &VruClassifierConfig::default());
+
     // ---- Phase B: camera fusion (TIGHTEN-ONLY) -----------------------------
     // The camera may only SHORTEN the drivable corridor Phase A produced; it can
     // never extend it (`clip_corridor_to_hazards` truncates the boundaries, and
@@ -683,6 +711,18 @@ pub fn handle_perception_tracked(
         })
         .collect();
 
+    let pedestrians = classified_pedestrians
+        .iter()
+        .map(|pedestrian| PedestrianOut {
+            id: pedestrian.id,
+            x: pedestrian.pos.x_m,
+            y: pedestrian.pos.y_m,
+            vx: pedestrian.vel.x_m,
+            vy: pedestrian.vel.y_m,
+            age_s: pedestrian.age_s,
+        })
+        .collect();
+
     let response = PerceptionResponse {
         healthy,
         confidence,
@@ -696,6 +736,7 @@ pub fn handle_perception_tracked(
         left,
         right,
         objects,
+        pedestrians,
         camera_healthy,
         camera_clip_x_m,
     };
@@ -773,6 +814,35 @@ mod tests {
             lateral_min_m: lat_min,
             lateral_max_m: lat_max,
         }
+    }
+
+    #[test]
+    fn tracked_response_emits_conservative_pedestrian_channel() {
+        let mut state = TrackedPerceptionState::new();
+        let request = req((0..301)
+            .map(|index| {
+                let angle = -1.5 + index as f64 * 0.01;
+                if angle.abs() < 0.035 {
+                    3.0
+                } else {
+                    f32::INFINITY
+                }
+            })
+            .collect());
+
+        let response = handle_perception_tracked(&request, &mut state);
+
+        assert_eq!(response.objects.len(), 1);
+        assert_eq!(
+            response.pedestrians.len(),
+            1,
+            "a first-sighting pedestrian-sized cluster must feed the VRU channel"
+        );
+        assert_eq!(
+            response.pedestrians[0].id, response.objects[0].id,
+            "the additive object and VRU channels must preserve the same track ID"
+        );
+        assert_eq!(response.pedestrians[0].age_s, 0.0);
     }
 
     #[test]

--- a/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
@@ -358,6 +358,7 @@ class OccyDoer(Node):
                 'left': left,
                 'right': right,
                 'objects': taj.get('objects', []),
+                'pedestrians': taj.get('pedestrians', []),
                 'vehicle': self._vehicle,
             }
             if goal_fields:


### PR DESCRIPTION
## Summary
- emits conservative tracked pedestrian classifications from Taj
- preserves each VRU in the ordinary object channel with the same persistent ID
- carries pedestrian position, velocity, and measurement age through the perception API
- forwards Taj pedestrians through OccyDoer into the planner request
- constructs a real PedestrianScene for the slow-loop checker
- keeps the absent pedestrian channel backward compatible
- rejects malformed or non-finite pedestrian inputs at the planner seam

## Safety properties
- VRU RSS is additive to ordinary object RSS
- first-sighting pedestrian-sized tracks are conservatively classified
- malformed pedestrian input fails closed
- empty or absent pedestrian input preserves prior behavior

## Validation
- cargo test -p kirra-taj
- cargo test -p kirra-sidecars
- cargo clippy -p kirra-taj -p kirra-sidecars --all-targets -- -D warnings
- python3 -m py_compile ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
- live Jetson verification:
  - kirra-taj.service active
  - kirra-planner.service active
  - kirra-ros-stack.service active
  - Taj healthy=true
  - 12 tracked objects
  - 9 additive pedestrian classifications
  - pedestrian IDs match corresponding object IDs