### PR TITLE
Add supporting camera association for lidar VRU tracks

### DIFF
--- a/crates/kirra-sidecars/src/taj.rs
+++ b/crates/kirra-sidecars/src/taj.rs
@@ -11,8 +11,8 @@
 
 use kirra_core::corridor::CorridorSource;
 use kirra_taj::{
-    clip_corridor_to_hazards, hazard_clip_x, LaserScan, SemanticClass, SemanticDetection,
-    TajConfig, TajTracker, VruClassifierConfig,
+    clip_corridor_to_hazards, hazard_clip_x, CameraVruFusionConfig, CameraVruObservation,
+    LaserScan, SemanticClass, SemanticDetection, TajConfig, TajTracker, VruClassifierConfig,
 };
 use serde::{Deserialize, Serialize};
 
@@ -73,6 +73,18 @@ impl CameraDetection {
     }
 }
 
+/// Supporting camera/depth position observation.
+///
+/// This is geometry evidence only. It does not assert pedestrian identity,
+/// create a track, or loosen any lidar-derived bound.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CameraObservationReq {
+    pub observation_id: u64,
+    pub x: f64,
+    pub y: f64,
+    pub confidence: f64,
+}
+
 /// Camera (Phase-B) channel verdict for one request — the same three-way,
 /// fail-closed decision the occlusion / VRU channels make: DISARMED → no-op,
 /// armed+fresh → live fusion, armed+silent-or-garbage → MRC floor.
@@ -121,6 +133,10 @@ pub struct PerceptionRequest {
     /// means "the camera looked and saw no hazard".
     #[serde(default)]
     pub detections: Vec<CameraDetection>,
+    /// Supporting depth-camera geometry for association with existing lidar
+    /// tracks. This channel never creates tracks or pedestrian membership.
+    #[serde(default)]
+    pub camera_observations: Vec<CameraObservationReq>,
     /// Producer stamp of the camera frame the detections came from. `None` while
     /// `camera_armed` is a SILENT channel → fail closed ("the detector did not
     /// look" is never "clear").
@@ -310,6 +326,7 @@ fn invalid_perception_response(camera_armed: bool) -> PerceptionResponse {
         left: Vec::new(),
         right: Vec::new(),
         objects: Vec::new(),
+        camera_associations: Vec::new(),
         pedestrians: Vec::new(),
         camera_healthy: !camera_armed,
         camera_clip_x_m: None,
@@ -337,6 +354,16 @@ pub struct PedestrianOut {
     pub age_s: f64,
 }
 
+/// Auditable supporting association between camera/depth geometry and an
+/// existing lidar track.
+#[derive(Clone, Serialize)]
+pub struct CameraAssociationOut {
+    pub track_id: u64,
+    pub observation_id: u64,
+    pub distance_m: f64,
+    pub confidence: f64,
+}
+
 #[derive(Clone, Serialize)]
 pub struct PerceptionResponse {
     pub healthy: bool,
@@ -355,6 +382,9 @@ pub struct PerceptionResponse {
     pub left: Vec<[f64; 2]>,
     pub right: Vec<[f64; 2]>,
     pub objects: Vec<ObjOut>,
+    /// Supporting-only camera/depth associations. These do not create tracks,
+    /// modify positions, or change pedestrian classification membership.
+    pub camera_associations: Vec<CameraAssociationOut>,
     /// Conservative VRU classifications derived from the persistent tracker.
     ///
     /// First sightings with a pedestrian-sized footprint are included because
@@ -618,6 +648,33 @@ pub fn handle_perception_tracked(
         .expect("tracker initialized above")
         .classify_pedestrians(req.stamp_ms, &VruClassifierConfig::default());
 
+    // Supporting-only camera/depth association. The lidar tracker remains
+    // authoritative: camera observations cannot create tracks, alter track
+    // state, or change pedestrian classifier membership.
+    let camera_observations: Vec<CameraVruObservation> = req
+        .camera_observations
+        .iter()
+        .map(|observation| CameraVruObservation {
+            observation_id: observation.observation_id,
+            pos: kirra_core::corridor::Point {
+                x_m: observation.x,
+                y_m: observation.y,
+            },
+            confidence: observation.confidence,
+            stamp_ms: req.camera_stamp_ms.unwrap_or(req.stamp_ms),
+        })
+        .collect();
+
+    let camera_associations = state
+        .tracker
+        .as_ref()
+        .expect("tracker initialized above")
+        .associate_camera_vrus(
+            &camera_observations,
+            req.stamp_ms,
+            &CameraVruFusionConfig::default(),
+        );
+
     // ---- Phase B: camera fusion (TIGHTEN-ONLY) -----------------------------
     // The camera may only SHORTEN the drivable corridor Phase A produced; it can
     // never extend it (`clip_corridor_to_hazards` truncates the boundaries, and
@@ -711,6 +768,16 @@ pub fn handle_perception_tracked(
         })
         .collect();
 
+    let camera_associations: Vec<CameraAssociationOut> = camera_associations
+        .iter()
+        .map(|association| CameraAssociationOut {
+            track_id: association.track_id,
+            observation_id: association.observation_id,
+            distance_m: association.distance_m,
+            confidence: association.confidence,
+        })
+        .collect();
+
     let pedestrians = classified_pedestrians
         .iter()
         .map(|pedestrian| PedestrianOut {
@@ -736,6 +803,7 @@ pub fn handle_perception_tracked(
         left,
         right,
         objects,
+        camera_associations,
         pedestrians,
         camera_healthy,
         camera_clip_x_m,
@@ -769,6 +837,7 @@ mod tests {
             confidence_floor: default_floor(),
             camera_armed: false,
             detections: Vec::new(),
+            camera_observations: Vec::new(),
             camera_stamp_ms: None,
             camera_max_age_ms: DEFAULT_CAMERA_MAX_AGE_MS,
         }
@@ -1353,6 +1422,7 @@ mod tracked_perception_tests {
             camera_stamp_ms: None,
             camera_max_age_ms: DEFAULT_CAMERA_MAX_AGE_MS,
             detections: Vec::new(),
+            camera_observations: Vec::new(),
         }
     }
 
@@ -1463,6 +1533,7 @@ mod duplicate_frame_tracking_tests {
             camera_stamp_ms: None,
             camera_max_age_ms: DEFAULT_CAMERA_MAX_AGE_MS,
             detections: Vec::new(),
+            camera_observations: Vec::new(),
         }
     }
 

--- a/crates/kirra-taj/src/lib.rs
+++ b/crates/kirra-taj/src/lib.rs
@@ -544,6 +544,49 @@ impl TajPhaseA {
     }
 }
 
+/// One camera-derived VRU observation in the ego frame.
+///
+/// This observation is supporting evidence only. A camera-only observation
+/// never creates a safety-authoritative pedestrian track; it must associate
+/// with an existing lidar track before it may influence classification.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CameraVruObservation {
+    pub observation_id: u64,
+    pub pos: Point,
+    pub confidence: f64,
+    pub stamp_ms: u64,
+}
+
+/// Result of deterministic lidar-camera VRU association.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CameraVruAssociation {
+    pub track_id: u64,
+    pub observation_id: u64,
+    pub distance_m: f64,
+    pub confidence: f64,
+}
+
+/// Configuration for the supporting camera-VRU fusion seam.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CameraVruFusionConfig {
+    /// Maximum ego-frame position error for association.
+    pub association_gate_m: f64,
+    /// Minimum camera confidence admitted as supporting evidence.
+    pub minimum_confidence: f64,
+    /// Maximum age difference between lidar track time and camera observation.
+    pub maximum_age_ms: u64,
+}
+
+impl Default for CameraVruFusionConfig {
+    fn default() -> Self {
+        Self {
+            association_gate_m: 0.75,
+            minimum_confidence: 0.60,
+            maximum_age_ms: 250,
+        }
+    }
+}
+
 /// Auditable result of Taj's geometric VRU classifier.
 ///
 /// `PossiblePedestrian` feeds the stricter pedestrian RSS bound.
@@ -753,6 +796,112 @@ fn associate_tracks_globally(
     matches
 }
 
+#[derive(Debug, Clone, Copy)]
+struct CameraVruEdge {
+    track_index: usize,
+    observation_index: usize,
+    distance_m: f64,
+    track_id: u64,
+    observation_id: u64,
+}
+
+/// Deterministically associate camera VRU observations to existing lidar tracks.
+///
+/// Camera evidence is supporting-only:
+///
+/// - no lidar track means no association;
+/// - one observation can support at most one track;
+/// - one track can consume at most one observation;
+/// - malformed, stale, low-confidence, or out-of-gate observations are ignored;
+/// - association order is independent of input storage order.
+fn associate_camera_vrus_to_tracks(
+    tracks: &[Track],
+    observations: &[CameraVruObservation],
+    now_ms: u64,
+    cfg: &CameraVruFusionConfig,
+) -> Vec<CameraVruAssociation> {
+    let config_valid = cfg.association_gate_m.is_finite()
+        && cfg.association_gate_m > 0.0
+        && cfg.minimum_confidence.is_finite()
+        && (0.0..=1.0).contains(&cfg.minimum_confidence);
+
+    if !config_valid || tracks.is_empty() || observations.is_empty() {
+        return Vec::new();
+    }
+
+    let mut edges = Vec::new();
+
+    for (track_index, track) in tracks.iter().enumerate() {
+        let predicted = predicted_track_position(track, now_ms);
+
+        for (observation_index, observation) in observations.iter().enumerate() {
+            if !observation.pos.x_m.is_finite()
+                || !observation.pos.y_m.is_finite()
+                || !observation.confidence.is_finite()
+                || observation.confidence < cfg.minimum_confidence
+            {
+                continue;
+            }
+
+            let age_ms = now_ms.abs_diff(observation.stamp_ms);
+            if age_ms > cfg.maximum_age_ms {
+                continue;
+            }
+
+            let distance_m =
+                (observation.pos.x_m - predicted.x_m).hypot(observation.pos.y_m - predicted.y_m);
+
+            if distance_m.is_finite() && distance_m <= cfg.association_gate_m {
+                edges.push(CameraVruEdge {
+                    track_index,
+                    observation_index,
+                    distance_m,
+                    track_id: track.id,
+                    observation_id: observation.observation_id,
+                });
+            }
+        }
+    }
+
+    edges.sort_by(|left, right| {
+        left.distance_m
+            .total_cmp(&right.distance_m)
+            .then_with(|| left.track_id.cmp(&right.track_id))
+            .then_with(|| left.observation_id.cmp(&right.observation_id))
+            .then_with(|| left.track_index.cmp(&right.track_index))
+            .then_with(|| left.observation_index.cmp(&right.observation_index))
+    });
+
+    let mut track_used = vec![false; tracks.len()];
+    let mut observation_used = vec![false; observations.len()];
+    let mut associations = Vec::new();
+
+    for edge in edges {
+        if track_used[edge.track_index] || observation_used[edge.observation_index] {
+            continue;
+        }
+
+        track_used[edge.track_index] = true;
+        observation_used[edge.observation_index] = true;
+
+        let observation = observations[edge.observation_index];
+        associations.push(CameraVruAssociation {
+            track_id: edge.track_id,
+            observation_id: edge.observation_id,
+            distance_m: edge.distance_m,
+            confidence: observation.confidence,
+        });
+    }
+
+    associations.sort_by(|left, right| {
+        left.track_id
+            .cmp(&right.track_id)
+            .then_with(|| left.observation_id.cmp(&right.observation_id))
+    });
+
+    associations
+}
+
 /// Taj **temporal tracker** — wraps the Phase-A geometric pipeline and adds
 /// frame-to-frame object association + velocity estimation. Phase-A is
 /// single-frame (every object static); the tracker associates each new detection
@@ -960,6 +1109,21 @@ impl TajTracker {
                 }
             })
             .collect()
+    }
+
+    /// Associate supporting camera VRU evidence with current lidar tracks.
+    ///
+    /// This method never creates tracks and never returns camera-only VRUs.
+    /// The returned associations are diagnostic/supporting evidence for a
+    /// subsequent fusion policy.
+    #[must_use]
+    pub fn associate_camera_vrus(
+        &self,
+        observations: &[CameraVruObservation],
+        now_ms: u64,
+        cfg: &CameraVruFusionConfig,
+    ) -> Vec<CameraVruAssociation> {
+        associate_camera_vrus_to_tracks(&self.tracks, observations, now_ms, cfg)
     }
 
     /// Compatibility view consumed by the pedestrian RSS producer.
@@ -1271,6 +1435,137 @@ mod tests {
 
     /// `age_s` reflects real measurement staleness at classify time (#789 F8:
     /// the reachable disc has already grown for that long).
+    #[test]
+    fn camera_vru_association_requires_an_existing_lidar_track() {
+        let tracker = TajTracker::new(TajConfig::default());
+        let observations = [CameraVruObservation {
+            observation_id: 90,
+            pos: Point { x_m: 3.0, y_m: 0.2 },
+            confidence: 0.95,
+            stamp_ms: 1_000,
+        }];
+
+        let associations =
+            tracker.associate_camera_vrus(&observations, 1_000, &CameraVruFusionConfig::default());
+
+        assert!(
+            associations.is_empty(),
+            "camera-only evidence must never create a safety-authoritative VRU"
+        );
+    }
+
+    #[test]
+    fn camera_vru_association_matches_existing_lidar_track() {
+        let mut tracker = TajTracker::new(TajConfig::default());
+        let scan = scan_from(10.0, 1_000, |theta| {
+            if theta.abs() < 0.035 {
+                Some(3.0)
+            } else {
+                None
+            }
+        });
+        let perception = tracker.track(&scan, 1_000);
+        assert_eq!(perception.objects.len(), 1);
+
+        let observation = CameraVruObservation {
+            observation_id: 91,
+            pos: Point {
+                x_m: perception.objects[0].pos.x_m + 0.05,
+                y_m: perception.objects[0].pos.y_m,
+            },
+            confidence: 0.90,
+            stamp_ms: 1_000,
+        };
+
+        let associations =
+            tracker.associate_camera_vrus(&[observation], 1_000, &CameraVruFusionConfig::default());
+
+        assert_eq!(associations.len(), 1);
+        assert_eq!(associations[0].track_id, perception.objects[0].id);
+        assert_eq!(associations[0].observation_id, 91);
+    }
+
+    #[test]
+    fn camera_vru_association_rejects_stale_low_confidence_and_out_of_gate_rows() {
+        let mut tracker = TajTracker::new(TajConfig::default());
+        let scan = scan_from(10.0, 1_000, |theta| {
+            if theta.abs() < 0.035 {
+                Some(3.0)
+            } else {
+                None
+            }
+        });
+        tracker.track(&scan, 1_000);
+
+        let observations = [
+            CameraVruObservation {
+                observation_id: 1,
+                pos: Point { x_m: 3.0, y_m: 0.0 },
+                confidence: 0.20,
+                stamp_ms: 1_000,
+            },
+            CameraVruObservation {
+                observation_id: 2,
+                pos: Point { x_m: 3.0, y_m: 0.0 },
+                confidence: 0.95,
+                stamp_ms: 100,
+            },
+            CameraVruObservation {
+                observation_id: 3,
+                pos: Point { x_m: 8.0, y_m: 4.0 },
+                confidence: 0.95,
+                stamp_ms: 1_000,
+            },
+        ];
+
+        assert!(tracker
+            .associate_camera_vrus(&observations, 1_000, &CameraVruFusionConfig::default(),)
+            .is_empty());
+    }
+
+    #[test]
+    fn camera_vru_association_is_independent_of_observation_order() {
+        let mut tracker = TajTracker::new(TajConfig::default());
+        let scan = scan_from(10.0, 1_000, |theta| {
+            if theta.abs() < 0.035 {
+                Some(3.0)
+            } else {
+                None
+            }
+        });
+        tracker.track(&scan, 1_000);
+
+        let a = CameraVruObservation {
+            observation_id: 10,
+            pos: Point {
+                x_m: 3.05,
+                y_m: 0.0,
+            },
+            confidence: 0.90,
+            stamp_ms: 1_000,
+        };
+        let b = CameraVruObservation {
+            observation_id: 11,
+            pos: Point {
+                x_m: 3.20,
+                y_m: 0.0,
+            },
+            confidence: 0.99,
+            stamp_ms: 1_000,
+        };
+
+        let cfg = CameraVruFusionConfig::default();
+        let forward = tracker.associate_camera_vrus(&[a, b], 1_000, &cfg);
+        let reversed = tracker.associate_camera_vrus(&[b, a], 1_000, &cfg);
+
+        assert_eq!(forward, reversed);
+        assert_eq!(forward.len(), 1);
+        assert_eq!(
+            forward[0].observation_id, 10,
+            "lowest geometric error wins, not input order or confidence"
+        );
+    }
+
     #[test]
     fn classifier_invalid_configuration_fails_closed_to_possible_pedestrian() {
         let mut tracker = TajTracker::new(TajConfig::default());

--- a/ros2_ws/src/kirra_safety/kirra_safety/camera_detect_core.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/camera_detect_core.py
@@ -254,6 +254,58 @@ def blob_to_target(
     }
 
 
+def blobs_to_camera_vrus(
+    blobs: Iterable[Blob],
+    intr: CameraIntrinsics,
+    extr: CameraExtrinsics,
+    cfg: DetectConfig,
+) -> List[dict]:
+    """Convert usable camera blobs into supporting VRU observations.
+
+    These rows do not assert pedestrian identity and do not create tracks.
+    Taj must associate them with an existing lidar track before they can become
+    fusion evidence. The current classical detector therefore labels them only
+    as ``possible_person``.
+    """
+    rows = []
+    for index, blob in enumerate(blobs):
+        confidence = blob_confidence(blob, cfg)
+        if confidence <= 0.0:
+            continue
+
+        ego = pixel_to_ego(
+            blob.u,
+            blob.v,
+            blob.depth_m,
+            intr,
+            extr,
+            cfg.max_range_m,
+        )
+        if ego is None:
+            continue
+
+        x_m, y_m, _z_m = ego
+        if x_m <= 0.0:
+            continue
+
+        rows.append({
+            "observation_id": int(index),
+            "class": "possible_person",
+            "x": float(x_m),
+            "y": float(y_m),
+            "confidence": float(confidence),
+        })
+
+    rows.sort(
+        key=lambda row: (
+            row["x"],
+            row["y"],
+            row["observation_id"],
+        )
+    )
+    return rows
+
+
 def blobs_to_targets(
     blobs: Iterable[Blob],
     intr: CameraIntrinsics,
@@ -356,6 +408,11 @@ def build_detection_frame(
         ),
         "detections": points_to_obstacle_detections(points, cfg) if usable else [],
         "targets": blobs_to_targets(blobs, intr, extr, cfg) if usable else [],
+        "camera_observations": (
+            blobs_to_camera_vrus(blobs, intr, extr, cfg)
+            if usable
+            else []
+        ),
     }
 
 
@@ -394,7 +451,16 @@ def camera_perception_fields(
         if isinstance(stamp, int) and not isinstance(stamp, bool) and stamp >= 0:
             out["camera_stamp_ms"] = stamp
             out["detections"] = [
-                d for d in (frame.get("detections") or []) if isinstance(d, dict)
+                detection
+                for detection in (frame.get("detections") or [])
+                if isinstance(detection, dict)
+            ]
+            out["camera_observations"] = [
+                observation
+                for observation in (
+                    frame.get("camera_observations") or []
+                )
+                if isinstance(observation, dict)
             ]
     return out
 


### PR DESCRIPTION
## Summary

- adds deterministic camera/depth association with existing lidar tracks
- publishes camera observations using one consistent `camera_observations` wire field
- requires an existing lidar track before camera evidence is accepted
- exposes auditable camera-to-track associations from Taj
- rejects stale, malformed, low-confidence, and out-of-gate observations
- preserves lidar authority over tracking and pedestrian RSS membership

## Safety properties

- camera-only observations cannot create tracks
- camera evidence cannot loosen lidar-derived safety bounds
- camera evidence cannot independently create or remove pedestrian classification
- each camera observation associates with at most one lidar track
- each lidar track consumes at most one camera observation
- association is deterministic and independent of observation order
- absent camera observations preserve existing behavior

## Validation

- `cargo test -p kirra-taj` — 63 passed
- `cargo test -p kirra-sidecars` — 62 passed
- clippy passes with `-D warnings`
- camera detector Python tests — 35 passed
- Python compilation checks pass