### PR TITLE
fix(taj): bound forward_extent_m so huge finite values cannot crash or hang

### DIFF
--- a/crates/kirra-sidecars/src/taj.rs
+++ b/crates/kirra-sidecars/src/taj.rs
@@ -229,6 +229,10 @@ enum PerceptionRequestError {
     ScanTooLarge,
     NanRangeSample,
     InvalidForwardExtent,
+    /// Finite, but beyond [`MAX_FORWARD_EXTENT_M`]. Distinct from
+    /// `InvalidForwardExtent` so a unit mistake (metres given as millimetres,
+    /// say) is diagnosable as "too far" rather than "malformed".
+    ForwardExtentTooLarge,
     InvalidDeceleration,
     InvalidMargin,
     InvalidLaneHalfWidth,
@@ -275,6 +279,10 @@ fn validate_perception_request(req: &PerceptionRequest) -> Result<(), Perception
 
     if !req.forward_extent_m.is_finite() || req.forward_extent_m <= MIN_FORWARD_OBJECT_X_M {
         return Err(PerceptionRequestError::InvalidForwardExtent);
+    }
+
+    if req.forward_extent_m > MAX_FORWARD_EXTENT_M {
+        return Err(PerceptionRequestError::ForwardExtentTooLarge);
     }
 
     if !req.decel_mps2.is_finite() || req.decel_mps2 <= 0.0 {
@@ -769,6 +777,31 @@ fn minimum_corridor_width_before_reach_m(
 /// Returns closer than this are treated as near-origin/self-geometry candidates.
 /// This does NOT remove them from raw perception or corridor construction.
 const MIN_FORWARD_OBJECT_X_M: f64 = 0.15;
+
+/// Maximum accepted `forward_extent_m` (metres) for a perception request.
+///
+/// PHYSICAL RATIONALE. The forward extent is a perception HORIZON, and no
+/// ground-vehicle horizon usefully exceeds this. The longest-range production
+/// automotive lidars reach roughly 250-300 m; the deployed R2 TG30 maxes at
+/// 12 m, and every extent configured anywhere in this repository is 8-40 m. So
+/// 500 m is ~2x the best sensor in the industry and >12x the largest value we
+/// actually use — generous enough that no legitimate deployment meets it, tight
+/// enough that a unit mistake does not sail through.
+///
+/// COMPUTATIONAL RATIONALE. `TajPhaseA::extract_corridor` is
+/// O(stations x points) with `stations = ceil(extent / station_m)` and
+/// `station_m` floored at 0.1 m, so the extent alone sets the work. Capping at
+/// 500 m bounds stations at 5,000 (== `kirra_taj::MAX_CORRIDOR_STATIONS`),
+/// keeping the corridor pass finite and predictable for any accepted request.
+/// Without a cap the cost is unbounded in a caller-supplied f64: 1e300 m does
+/// not merely run slowly, it saturates the float->usize cast to `usize::MAX`,
+/// which panicked on `nstations + 1` in debug and became a ~1.8e19-iteration
+/// loop in release.
+///
+/// Deliberately paired with that library ceiling: a request accepted here can
+/// never reach the backstop, and the backstop covers callers that bypass this
+/// validation entirely (`TajConfig` is public).
+const MAX_FORWARD_EXTENT_M: f64 = 500.0;
 
 /// Maximum bearing from the vehicle forward axis for an object to participate in
 /// the scalar nearest-object braking bound.
@@ -1480,6 +1513,99 @@ mod tests {
             assert!(response.left.is_empty());
             assert!(response.right.is_empty());
             assert!(response.objects.is_empty());
+        }
+    }
+
+    /// The forward-extent bound, walked across its whole domain.
+    ///
+    /// The load-bearing rows are `1e300` and `just above the maximum`: both are
+    /// FINITE, so the pre-existing `is_finite() || <= MIN` guard admitted them.
+    /// A finite-but-enormous extent is not merely slow — `extract_corridor`
+    /// saturates its float->usize station cast to `usize::MAX`, which panicked
+    /// on `nstations + 1` in debug and became a ~1.8e19-iteration loop in
+    /// release.
+    #[test]
+    fn forward_extent_bound_accepts_the_usable_range_and_refuses_the_rest() {
+        use PerceptionRequestError::{ForwardExtentTooLarge, InvalidForwardExtent};
+
+        let cases: [(f64, Option<PerceptionRequestError>); 11] = [
+            // --- lower bound: unchanged pre-existing behaviour ---
+            (f64::NAN, Some(InvalidForwardExtent)),
+            (f64::INFINITY, Some(InvalidForwardExtent)),
+            (f64::NEG_INFINITY, Some(InvalidForwardExtent)),
+            (-1.0, Some(InvalidForwardExtent)),
+            (0.0, Some(InvalidForwardExtent)),
+            (MIN_FORWARD_OBJECT_X_M, Some(InvalidForwardExtent)), // boundary is exclusive
+            // --- normal configured values (kirra_params.yaml, defaults, tests) ---
+            (8.0, None),
+            (default_extent(), None),
+            // --- the new upper bound ---
+            (MAX_FORWARD_EXTENT_M, None), // exact maximum is ACCEPTED
+            (
+                MAX_FORWARD_EXTENT_M + f64::EPSILON * MAX_FORWARD_EXTENT_M,
+                Some(ForwardExtentTooLarge),
+            ),
+            (1e300, Some(ForwardExtentTooLarge)), // the reported crasher
+        ];
+
+        for (extent, expected) in cases {
+            let mut request = req(clear_scan());
+            request.forward_extent_m = extent;
+            // `margin_m` must stay below the extent or it masks the case under
+            // test with InvalidMargin.
+            request.margin_m = 0.0;
+            assert_eq!(
+                validate_perception_request(&request).err(),
+                expected,
+                "forward_extent_m = {extent:e}"
+            );
+        }
+    }
+
+    /// Regression: a huge FINITE extent is refused at the perimeter, so the
+    /// request never reaches Taj computation — and the endpoint answers with
+    /// the fail-closed response rather than panicking or hanging.
+    ///
+    /// Exercised in both profiles: debug catches the arithmetic overflow that
+    /// used to fire at `kirra_taj::lib.rs:445`, release catches the wrapped
+    /// loop that used to hang instead.
+    #[test]
+    fn huge_finite_forward_extent_is_refused_before_taj_computation() {
+        for extent in [1e300, 1e30, f64::MAX, MAX_FORWARD_EXTENT_M * 2.0] {
+            let mut request = req(clear_scan());
+            request.forward_extent_m = extent;
+            request.margin_m = 0.0;
+
+            assert_eq!(
+                validate_perception_request(&request).err(),
+                Some(PerceptionRequestError::ForwardExtentTooLarge),
+                "forward_extent_m = {extent:e} must be refused"
+            );
+
+            // The full endpoint must return the fail-closed response — reaching
+            // here at all proves no panic and no unbounded loop.
+            let response = handle_perception(&request);
+            assert!(!response.healthy, "{extent:e}");
+            assert_eq!(response.speed_cap_mps, 0.0, "{extent:e}");
+            assert!(response.left.is_empty() && response.right.is_empty());
+            assert!(response.objects.is_empty());
+        }
+    }
+
+    /// Every extent configured anywhere in the repository must remain valid, so
+    /// the new ceiling cannot have broken a live deployment.
+    #[test]
+    fn all_shipped_forward_extents_are_within_the_bound() {
+        // kirra_params.yaml (perception_governor + occy_doer), TajConfig's own
+        // default, the sidecar default, and the largest test-stack value.
+        for extent in [8.0, 8.0, 20.0, default_extent(), 40.0] {
+            assert!(
+                extent > MIN_FORWARD_OBJECT_X_M && extent <= MAX_FORWARD_EXTENT_M,
+                "shipped extent {extent} is outside the accepted band"
+            );
+            let mut request = req(clear_scan());
+            request.forward_extent_m = extent;
+            assert!(validate_perception_request(&request).is_ok(), "{extent}");
         }
     }
 

--- a/crates/kirra-taj/src/lib.rs
+++ b/crates/kirra-taj/src/lib.rs
@@ -366,6 +366,52 @@ const MIN_CORRIDOR_POINT_X_M: f64 = 0.15;
 /// passage boundaries near the vehicle envelope remain eligible.
 const MIN_CORRIDOR_BOUNDARY_ABS_Y_M: f64 = 0.26;
 
+/// Hard ceiling on the number of corridor stations `extract_corridor` will
+/// build, whatever configuration it is handed.
+///
+/// This is a LIBRARY BACKSTOP, not a policy. Callers that validate their input
+/// (the Taj sidecar rejects `forward_extent_m` above its own
+/// `MAX_FORWARD_EXTENT_M`, which is exactly this ceiling × the 0.1 m station
+/// floor) never reach it. It exists because `TajConfig` is public and
+/// unvalidated: a direct caller can set `forward_extent_m` to any finite f64,
+/// and Rust's float→int `as` cast SATURATES, so `(1e300 / 0.1).ceil() as usize`
+/// yields `usize::MAX`. The subsequent `nstations + 1` then panicked with an
+/// integer overflow in debug and wrapped to a ~1.8e19-iteration loop in release.
+///
+/// Clamping is fail-SAFE rather than fail-open: fewer stations produce a
+/// SHORTER corridor, i.e. less claimed free space, so a downstream containment
+/// check becomes more conservative, never less.
+const MAX_CORRIDOR_STATIONS: usize = 5_000;
+
+/// Number of corridor stations for a forward extent and station spacing,
+/// saturating-cast safe and bounded by [`MAX_CORRIDOR_STATIONS`].
+///
+/// Returns 0 for any non-finite or non-positive input rather than propagating a
+/// garbage count into an allocation.
+fn corridor_station_count(forward_extent_m: f64, station_m: f64) -> usize {
+    if !forward_extent_m.is_finite()
+        || forward_extent_m <= 0.0
+        || !station_m.is_finite()
+        || station_m <= 0.0
+    {
+        return 0;
+    }
+    let raw = (forward_extent_m / station_m).ceil();
+    if raw.is_nan() || raw <= 0.0 {
+        return 0;
+    }
+    // The DIVISION itself can overflow f64 (`f64::MAX / 0.1` is +inf). That
+    // means "astronomically many stations", not "none" — clamp it like any
+    // other over-large count rather than collapsing to an empty corridor.
+    //
+    // Compare in f64 BEFORE casting: `as usize` saturates, so testing the cast
+    // result against the ceiling would already have lost the overflow.
+    if !raw.is_finite() || raw >= MAX_CORRIDOR_STATIONS as f64 {
+        return MAX_CORRIDOR_STATIONS;
+    }
+    raw as usize
+}
+
 impl TajPhaseA {
     #[must_use]
     pub fn new(cfg: TajConfig) -> Self {
@@ -441,9 +487,13 @@ impl TajPhaseA {
         let cap = self.cfg.open_half_width_m;
         let step = self.cfg.corridor_station_m.max(0.1);
 
-        let nstations = (ext / step).ceil() as usize;
-        let mut left = Vec::with_capacity(nstations + 1);
-        let mut right = Vec::with_capacity(nstations + 1);
+        // Bounded + saturating-cast safe: `TajConfig` is public and unvalidated,
+        // so a direct caller can hand us any finite extent (see
+        // `corridor_station_count`). `saturating_add` keeps the `+ 1` honest
+        // even at the ceiling.
+        let nstations = corridor_station_count(ext, step);
+        let mut left = Vec::with_capacity(nstations.saturating_add(1));
+        let mut right = Vec::with_capacity(nstations.saturating_add(1));
         for i in 0..=nstations {
             let xs = (i as f64 * step).min(ext);
             let mut left_y = cap; // nearest left obstacle in this station's window
@@ -3704,6 +3754,98 @@ mod tests {
         assert!(
             max_y < 1.0,
             "straight (CV) path stays near y≈0, got {max_y}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Corridor-station bound (library backstop)
+    //
+    // `TajConfig` is public and unvalidated, so these cover the callers that
+    // bypass the sidecar's `MAX_FORWARD_EXTENT_M` check entirely. Before the
+    // bound, `forward_extent_m = 1e300` saturated the float->usize cast to
+    // `usize::MAX` and `nstations + 1` panicked with an integer overflow at
+    // this file's line 445 (debug) / wrapped into a ~1.8e19-iteration loop
+    // (release).
+    // -----------------------------------------------------------------
+
+    fn probe_scan() -> LaserScan {
+        LaserScan {
+            angle_min_rad: -1.0,
+            angle_increment_rad: 0.01,
+            range_min_m: 0.1,
+            range_max_m: 12.0,
+            ranges: vec![1.0; 16],
+            stamp_ms: 1_000,
+        }
+    }
+
+    #[test]
+    fn corridor_station_count_is_bounded_and_saturation_safe() {
+        // Normal configured geometry is untouched by the clamp.
+        assert_eq!(corridor_station_count(8.0, 1.0), 8);
+        assert_eq!(corridor_station_count(20.0, 1.0), 20);
+        assert_eq!(corridor_station_count(40.0, 1.0), 40);
+        // The sidecar's accepted maximum at the 0.1 m station floor lands
+        // EXACTLY on the ceiling — the two constants are deliberately paired,
+        // so a validated request never engages the clamp.
+        assert_eq!(corridor_station_count(500.0, 0.1), MAX_CORRIDOR_STATIONS);
+        // Beyond it, the count is clamped rather than saturating to usize::MAX.
+        assert_eq!(corridor_station_count(1e300, 0.1), MAX_CORRIDOR_STATIONS);
+        assert_eq!(corridor_station_count(f64::MAX, 0.1), MAX_CORRIDOR_STATIONS);
+        // Degenerate inputs yield 0 rather than a garbage allocation size.
+        for (ext, step) in [
+            (f64::NAN, 1.0),
+            (f64::INFINITY, 1.0),
+            (f64::NEG_INFINITY, 1.0),
+            (-1.0, 1.0),
+            (0.0, 1.0),
+            (8.0, f64::NAN),
+            (8.0, 0.0),
+            (8.0, -1.0),
+        ] {
+            assert_eq!(corridor_station_count(ext, step), 0, "{ext:e} / {step:e}");
+        }
+    }
+
+    #[test]
+    fn huge_finite_extent_does_not_panic_or_hang() {
+        // The exact reported crasher, driven straight at the library.
+        for extent in [1e300, 1e30, f64::MAX, 1e6] {
+            let taj = TajPhaseA::new(TajConfig {
+                forward_extent_m: extent,
+                ..Default::default()
+            });
+            let out = taj.process(&probe_scan(), 1_000);
+            // Reaching this line at all is the assertion: no overflow panic in
+            // debug, no unbounded loop in release.
+            assert!(
+                out.corridor.left.len() <= MAX_CORRIDOR_STATIONS + 1,
+                "{extent:e} produced {} boundary vertices",
+                out.corridor.left.len()
+            );
+            assert!(out.corridor.right.len() <= MAX_CORRIDOR_STATIONS + 1);
+        }
+    }
+
+    #[test]
+    fn clamping_shortens_the_corridor_rather_than_extending_it() {
+        // Fail-SAFE, not fail-open: clamping yields FEWER stations, so less
+        // claimed free space. A corridor that grew under clamping would be the
+        // dangerous direction.
+        let taj = TajPhaseA::new(TajConfig {
+            forward_extent_m: 1e300,
+            ..Default::default()
+        });
+        let clamped = taj.process(&probe_scan(), 1_000);
+        let furthest = clamped
+            .corridor
+            .left
+            .iter()
+            .map(|p| p.x_m)
+            .fold(0.0_f64, f64::max);
+        assert!(
+            furthest.is_finite(),
+            "every boundary vertex must be finite, got {furthest}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Bounds `forward_extent_m` at 500 m and hardens Taj corridor station-count arithmetic so huge finite values cannot crash in debug or hang in release.

## Reproduction

Before this fix, `forward_extent_m = 1e300` passed sidecar validation.

- Debug builds panicked at the corridor station-count addition with integer overflow.
- Release builds wrapped the addition and attempted `0..=usize::MAX`, hanging for more than 90 seconds.

The underlying path was:

`ceil(forward_extent_m / station_m) as usize`

Rust saturates the float-to-integer cast at `usize::MAX`, after which `nstations + 1` either panicked or wrapped depending on build profile.

## Fix

- Adds `MAX_FORWARD_EXTENT_M = 500.0` to the sidecar validation contract.
- Rejects non-finite, too-small, and above-maximum extents before Taj computation.
- Adds `MAX_CORRIDOR_STATIONS = 5_000` in the Taj library as a defense for callers that bypass HTTP validation.
- Compares the quotient in floating point before integer conversion.
- Uses saturation-safe capacity arithmetic.
- Treats an overflowed quotient as an oversized request and clamps conservatively.

The two ceilings are paired:

`500 m / 0.1 m minimum station spacing = 5,000 stations`

A validated request therefore never reaches the library clamp.

## Safety rationale

The largest configured extent in this repository is 40 m, the R2 TG30 range is about 12 m, and long-range automotive lidars are generally below 300 m. A 500 m ceiling remains well above any legitimate deployment while rejecting unit mistakes and pathological values.

Clamping in the library produces a shorter corridor, which claims less free space and is therefore conservative.

## Tests

Added coverage for:

- NaN and both infinities
- negative, zero, and lower-bound values
- normal and default extents
- exact 500 m maximum
- one ULP above the maximum
- `1e300` and `f64::MAX`
- refusal before Taj computation
- bounded station count
- no panic or hang for huge finite values
- conservative corridor shortening
- all shipped repository configurations remaining within the bound

Validated in both debug and release profiles.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p kirra-taj -p kirra-sidecars --all-targets -- -D warnings`
- `cargo test -p kirra-taj`
- `cargo test -p kirra-sidecars`
- dependent planner and KPI-gate tests
- 40 m stack test
- `git diff --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_