### PR TITLE
fix(doer): move Taj and planner HTTP off the timer callback

### DIFF
--- a/ros2_ws/src/kirra_safety/config/kirra_params.yaml
+++ b/ros2_ws/src/kirra_safety/config/kirra_params.yaml
@@ -38,6 +38,17 @@ occy_doer:
     # a different lidar rate needs a deployment-review update here.
     scan_stale_s: 0.25
 
+    # Plan-cycle rate. The Taj + planner calls run in a background job, so a
+    # tick publishes the PREVIOUS tick's result: perception is one tick period
+    # plus one round trip old when it is used. At the node default of 5 Hz that
+    # is 200 ms + up to 120 ms of HTTP against a 250 ms budget, so plans would
+    # age out and the doer would hold intermittently on a healthy lidar. 10 Hz
+    # (100 ms) matches the bench-verified TG30 scan rate and leaves the
+    # staleness budget intact. The node WARNs at startup if this no longer
+    # fits. Raising it above the lidar rate costs nothing: a job is issued only
+    # when a new scan has arrived.
+    plan_hz: 10.0
+
     # --- frame-health detectors (OPT-IN; default off) --------------------
     # scan_stale_s above measures ARRIVAL. It cannot distinguish a live lidar
     # from a driver that has wedged and is republishing its last buffer at the

--- a/ros2_ws/src/kirra_safety/kirra_safety/async_plan.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/async_plan.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Pure decision logic for the doer's non-blocking plan cycle.
+
+No ROS / rclpy, no `requests`, no clock reads, no globals, no environment. Every
+function takes explicit values and returns a decision, so the whole issue /
+resolve state machine is unit-testable without a ROS graph or a sidecar.
+
+WHY THIS EXISTS
+---------------
+`occy_doer._tick` used to make two SEQUENTIAL BLOCKING POSTs (Taj, then the
+planner) inside a 5 Hz timer callback — up to 120 ms of a 200 ms period. With
+rclpy's single-threaded executor that stalls every other callback on the node,
+including the scan subscription, so a slow or hung sidecar froze perception
+ingest as well as planning.
+
+The calls now run in one bounded background job. This module owns the two
+decisions that keeps that safe:
+
+  1. ISSUE   — may the tick start a job at all?
+  2. RESOLVE — may the tick USE the result a job left behind?
+
+THREAD DISCIPLINE THIS MODULE ASSUMES
+-------------------------------------
+The worker computes; the TIMER publishes. A worker deposits an immutable
+`JobResult` into a slot and touches nothing else — no publisher, no tracker, no
+goal/pose/scan state. Every actuation-relevant decision is made by the executor
+thread calling into this module. These functions are pure, so they hold no lock
+and can never be the thing that stalls a callback.
+
+SCAN IDENTITY vs EVIDENCE IDENTITY — two different sequences
+------------------------------------------------------------
+ROS 2 removed `header.seq`, so a LaserScan carries no producer sequence number.
+The doer therefore stamps its own monotonic `scan_sequence` on arrival: that is
+WHICH LIDAR SCAN a job was issued for, and it is what supersession and staleness
+are judged against.
+
+Taj's `frame_id.scan_sequence` is a DIFFERENT counter — Taj's own per-request
+counter (`kirra-sidecars/src/taj.rs`, `state.scan_sequence += 1`). Comparing it
+to the node's counter would be meaningless. It is used for the one thing it can
+prove: that the planner planned against the SAME Taj frame this job fetched
+(`taj_scan_sequence == plan_scan_sequence`). A mismatch means the two sidecar
+responses describe different perception, which is a fault, not a stale result.
+
+WHY A RESULT IS USED AT MOST ONCE
+---------------------------------
+`last_used_scan_sequence` is a strictly-advancing watermark, the same discipline
+the V2 release gate applies to command sequences. It stops a result being
+republished after its scan has been superseded, and stops out-of-order delivery
+walking the doer backwards. A tick that finds nothing new to say holds, rather
+than repeating stale intent.
+"""
+
+from collections import namedtuple
+
+# --- issue decision --------------------------------------------------------
+ISSUE = "ISSUE"                    # start a job for the current snapshot
+IN_FLIGHT = "IN_FLIGHT"            # a job is already running — never start a second
+NO_FRESH_INPUT = "NO_FRESH_INPUT"  # nothing new to plan against
+
+# --- result resolution -----------------------------------------------------
+USE = "USE"                # publish a proposal built from this result
+ABSENT = "ABSENT"          # no result yet (first ticks, or job still running)
+SUPERSEDED = "SUPERSEDED"  # the result describes a scan we have moved past
+STALE = "STALE"            # the perception behind it aged out of the budget
+FAULT = "FAULT"            # the job failed, or its two responses disagree
+
+# One completed job. Immutable, and built ONLY from values the worker copied out
+# of the HTTP responses — never a live ROS message.
+JobResult = namedtuple("JobResult", [
+    "requested_scan_sequence",  # node-local id of the scan this job was issued for
+    "scan_received_s",          # monotonic receipt time of that scan
+    "taj_scan_sequence",        # Taj's own frame_id.scan_sequence (or None on fault)
+    "plan_scan_sequence",       # the planner's echoed perception_frame_id (or None)
+    "plan",                     # the planner response dict, or None on fault
+    "camera_healthy",           # Taj's camera_healthy, surfaced for the tick to log
+    "fault",                    # None, or a short stable reason tag
+])
+
+# The immutable snapshot a worker is handed. Contains plain Python values only:
+# the tick copies everything it needs out of the ROS messages first, so the
+# worker can never read a message the executor thread is mutating.
+JobRequest = namedtuple("JobRequest", [
+    "scan_sequence",
+    "scan_received_s",
+    "taj_url",
+    "planner_url",
+    "timeout_s",
+    "perception",   # fully-built Taj request body
+    "plan_fields",  # everything the plan body needs except the Taj-derived parts
+])
+
+Resolution = namedtuple("Resolution", ["state", "reason"])
+
+_ABSENT = Resolution(ABSENT, "no completed job yet")
+
+
+def decide_issue(job_in_flight, has_fresh_input):
+    """May this tick start a plan job?
+
+    `IN_FLIGHT` is the bound on concurrency: exactly one job may run, so a slow
+    sidecar cannot cause unbounded thread creation however fast the timer fires.
+    Requests cannot be cancelled, so the only way to avoid a pile-up is not to
+    start one.
+    """
+    if job_in_flight:
+        return IN_FLIGHT
+    if not has_fresh_input:
+        return NO_FRESH_INPUT
+    return ISSUE
+
+
+def resolve_result(
+    result,
+    newest_scan_sequence,
+    last_used_scan_sequence,
+    now_s,
+    scan_stale_s,
+):
+    """May this tick publish a proposal built from `result`?
+
+    Order is deliberate. Absence and faults are decided before identity, because
+    a failed job carries no evidence to compare. Identity is decided before
+    staleness, because a result about the wrong scan tells us nothing regardless
+    of its age.
+
+    Staleness is measured on the SCAN the result describes, not on when the job
+    finished: the safety question is "how old is the perception behind this
+    proposal", and `scan_stale_s` is the operator-set answer to exactly that.
+    """
+    if result is None:
+        return _ABSENT
+
+    if result.fault:
+        return Resolution(FAULT, result.fault)
+
+    # Evidence consistency: the planner must have planned against the SAME Taj
+    # frame this job fetched. These are Taj's counter, not the lidar's.
+    if (
+        result.taj_scan_sequence is None
+        or result.plan_scan_sequence is None
+        or result.taj_scan_sequence != result.plan_scan_sequence
+    ):
+        return Resolution(
+            FAULT,
+            "evidence mismatch: taj={} plan={}".format(
+                result.taj_scan_sequence, result.plan_scan_sequence
+            ),
+        )
+
+    seq = result.requested_scan_sequence
+
+    # Used at most once, and never backwards. A result for a scan we have
+    # already acted on (or moved past) is refused rather than republished.
+    if seq <= last_used_scan_sequence:
+        return Resolution(
+            SUPERSEDED,
+            "scan {} already used (watermark {})".format(seq, last_used_scan_sequence),
+        )
+
+    # A result claiming a scan the node has never seen means the worker and the
+    # node disagree about identity — refuse rather than guess.
+    if seq > newest_scan_sequence:
+        return Resolution(
+            SUPERSEDED,
+            "scan {} ahead of newest {}".format(seq, newest_scan_sequence),
+        )
+
+    age_s = now_s - result.scan_received_s
+    if age_s > scan_stale_s:
+        return Resolution(
+            STALE, "perception {:.3f}s old (budget {:.3f}s)".format(age_s, scan_stale_s)
+        )
+
+    return Resolution(USE, "")
+
+
+def evidence_sequences(taj_response, plan_response):
+    """Pull the two evidence sequences out of the sidecar responses.
+
+    Returns `(taj_scan_sequence, plan_scan_sequence)`, either of which is None
+    when the response did not carry a usable one. Kept here (not in the worker)
+    so the extraction rule is testable and the worker stays a thin shell.
+    """
+    taj_seq = _frame_scan_sequence(
+        taj_response.get("frame_id") if isinstance(taj_response, dict) else None
+    )
+    plan_seq = _frame_scan_sequence(
+        plan_response.get("perception_frame_id")
+        if isinstance(plan_response, dict)
+        else None
+    )
+    return taj_seq, plan_seq
+
+
+def _frame_scan_sequence(frame):
+    if not isinstance(frame, dict):
+        return None
+    value = frame.get("scan_sequence")
+    # bool is an int subclass; a JSON `true` is not a sequence number.
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value

--- a/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
@@ -13,6 +13,17 @@ KIRRA. Each tick it:
   4. converts that trajectory to velocities (pure pursuit) and publishes them on
      /cmd_vel_raw as an ATOMIC evidence-bound proposal envelope — the PROPOSAL.
 
+Steps 2-3 do NOT run inside the timer callback. rclpy's executor is
+single-threaded, so two sequential blocking POSTs (up to 2x http_timeout_ms of a
+1/plan_hz period) stalled every other callback on this node — including the scan
+subscription, so a slow sidecar froze perception ingest as well as planning. They
+now run in ONE bounded background job: the worker COMPUTES and the timer
+PUBLISHES. A tick therefore publishes the PREVIOUS tick's result — a pipeline,
+one tick of latency — and a result is used at most once, only for a scan the
+doer has not already acted on, and only while the perception behind it is inside
+`scan_stale_s`. Anything else holds. The decision algebra is pure and lives in
+`async_plan.py`; this module is the ROS shim around it.
+
 The envelope is canonical JSON in a std_msgs/String (see bound_proposal.py), not a
 bare Twist: it carries the proposed velocities AND the `release_binding` naming the
 exact Taj evidence frame, platform profile, and Occy proposal digest they were
@@ -46,6 +57,7 @@ unchanged. Mick (the LLM) fits by publishing the goal/intent instead of RViz.
 
 import json
 import math
+import threading
 import time
 
 import rclpy
@@ -65,6 +77,15 @@ from kirra_safety.camera_detect_core import (
     plan_object_goal_fields,
 )
 from kirra_safety.bound_proposal import build_release_binding, encode_bound_proposal
+from kirra_safety.async_plan import (
+    ISSUE,
+    USE,
+    JobRequest,
+    JobResult,
+    decide_issue,
+    evidence_sequences,
+    resolve_result,
+)
 from kirra_safety.sensor_freshness import (
     FAIL_CLOSED,
     FrameHealthConfig,
@@ -205,6 +226,26 @@ class OccyDoer(Node):
         self._timeout_s = self.get_parameter('http_timeout_ms').value / 1000.0
         self._back_m = self.get_parameter('corridor_back_m').value
 
+        # The plan cycle is a PIPELINE: a tick publishes the PREVIOUS tick's
+        # result, so the perception behind a proposal is always at least one
+        # tick period plus one round trip old. If that does not fit inside
+        # `scan_stale_s`, results age out and the doer holds intermittently
+        # even with a perfectly healthy lidar — a liveness fault that looks
+        # like a sensor fault. WARN rather than abort: the real round-trip time
+        # is a measured deployment number and a fast sidecar pair can make a
+        # marginal configuration work; refusing to start would be worse.
+        self._plan_hz = float(self.get_parameter('plan_hz').value)
+        pipeline_s = (1.0 / self._plan_hz) + 2.0 * self._timeout_s
+        if pipeline_s > self._scan_stale_s:
+            self.get_logger().warn(
+                f'plan pipeline budget {pipeline_s * 1000:.0f} ms '
+                f'(1/plan_hz={1000.0 / self._plan_hz:.0f} ms + 2x http_timeout_ms) '
+                f'exceeds scan_stale_s ({self._scan_stale_s * 1000:.0f} ms): '
+                'plans will age out and the doer will hold intermittently. '
+                'Raise plan_hz, lower http_timeout_ms, or review the staleness '
+                'budget against the deployment lidar rate.'
+            )
+
         # Frame-health tracker. Disarmed unless explicitly enabled, in which
         # case every resolution is a no-op DISARMED and the tick path below is
         # byte-identical to its prior behaviour.
@@ -220,6 +261,40 @@ class OccyDoer(Node):
             frame_cfg = FrameHealthConfig.disarmed()
         self._frame_health = FrameHealthTracker(frame_cfg)
         self._frame_health_reason = None  # latched, so a hold logs once per episode
+
+        # --- non-blocking plan cycle -------------------------------------
+        # The Taj + planner POSTs run in ONE bounded background job so the
+        # timer callback never blocks. Thread discipline (see async_plan.py):
+        # the worker COMPUTES, the timer PUBLISHES. The worker touches only
+        # `_pending_result` / `_job_in_flight`, both under `_job_lock`; it never
+        # publishes, never calls _hold, and never reads or mutates goal, pose,
+        # scan or frame-health state.
+        #
+        # The lock is held ONLY for the slot swap — never across network I/O,
+        # so a hung sidecar cannot block the executor thread on acquisition.
+        self._job_lock = threading.Lock()
+        self._job_in_flight = False
+        self._pending_result = None
+        # Node-local monotonic scan id. ROS 2 removed `header.seq`, so this is
+        # the only "which lidar scan" identity available. Written in _on_scan
+        # and read in _tick — both on the executor thread, so it needs no lock.
+        self._scan_seq = 0
+        # Strictly-advancing watermark: a result is consumed at most once and
+        # never goes backwards (the V2 release gate's discipline).
+        self._last_used_scan_sequence = 0
+        # The scan the last job was issued for. Re-issuing against the same
+        # scan would spend a sidecar round-trip on a result the watermark is
+        # guaranteed to discard, so a tick with no new perception simply does
+        # not start a job (NO_FRESH_INPUT). Executor thread only.
+        self._last_issued_scan_sequence = 0
+
+        # The Mick intent fetch gets the same treatment: it is HTTP reachable
+        # from the timer, so it cannot run inline either. Its own slot, because
+        # it is a different endpoint on a different failure budget — a Mick
+        # outage must not stall or fault the plan cycle.
+        self._mick_lock = threading.Lock()
+        self._mick_in_flight = False
+        self._mick_result = None
         self._vehicle = {
             'class': self.get_parameter('vehicle_class').value,
             'wheelbase_m': self.get_parameter('wheelbase_m').value,
@@ -253,7 +328,7 @@ class OccyDoer(Node):
             String, self.get_parameter('camera_detections_topic').value, self._on_camera, 10)
         self.create_subscription(
             String, self.get_parameter('object_goal_topic').value, self._on_object_goal, 10)
-        self.create_timer(1.0 / self.get_parameter('plan_hz').value, self._tick)
+        self.create_timer(1.0 / self._plan_hz, self._tick)
 
         if not REQUESTS_AVAILABLE:
             self.get_logger().error('python3-requests missing — doer holds (publishes zero).')
@@ -275,11 +350,15 @@ class OccyDoer(Node):
         self.get_logger().info(f'new goal: ({self._goal[0]:.2f}, {self._goal[1]:.2f})')
 
     def _on_scan(self, msg: LaserScan):
+        # Node-local scan identity. Incremented BEFORE the slot is replaced so
+        # `_scan_seq` and `_scan` are always consistent when _tick reads them
+        # (same thread, so this is ordering discipline rather than a race fix).
+        self._scan_seq += 1
         self._scan = (msg, time.monotonic())
-        # Fold the arrival into the frame-health tracker. This does NOT change
-        # the request architecture — the callback still only stores and returns;
-        # the HTTP path is untouched (that is PR 3b). The work is skipped
-        # entirely when disarmed, so the nominal path costs nothing.
+        # Fold the arrival into the frame-health tracker. The callback still
+        # only stores and returns — it makes no request and takes no lock. The
+        # work is skipped entirely when disarmed, so the nominal path costs
+        # nothing.
         if not self._frame_health_enabled:
             return
         stamp_ms = int(msg.header.stamp.sec * 1000
@@ -313,7 +392,12 @@ class OccyDoer(Node):
 
     # --- Mick intent consumption (intents, never commands) -------------------
     def _poll_mick(self):
-        """Ground a NEW Mick intent, fail-closed at every step.
+        """Apply a NEW Mick intent, fail-closed at every step.
+
+        The FETCH is a background job (see `_maybe_issue_mick`) so the timer
+        callback never blocks on Mick either; this half runs on the executor
+        thread and is the ONLY place the goal is mutated — the worker deposits
+        the raw wire dict and nothing else.
 
         Any fault — Mick unreachable, malformed JSON, an unknown tag, a
         non-finite coordinate — leaves the current goal untouched (the same
@@ -322,8 +406,13 @@ class OccyDoer(Node):
         """
         if not self._mick or self._pose is None:
             return
+        self._maybe_issue_mick()
+        with self._mick_lock:
+            wire = self._mick_result
+            self._mick_result = None
+        if wire is None:
+            return  # nothing fetched yet, or the fetch faulted
         try:
-            wire = requests.get(f'{self._mick}/intent/last', timeout=self._timeout_s).json()
             intent = wire.get('intent')
             seq = int(wire.get('seq', 0))
             if not isinstance(intent, dict) or seq <= self._mick_seq:
@@ -350,6 +439,31 @@ class OccyDoer(Node):
                     f'mick intent #{seq}: `{tag}` carries no goal for this bridge — ignored')
         except Exception as e:  # noqa: BLE001 — any fault keeps the current goal (fail-soft)
             self.get_logger().debug(f'mick poll: {e}')
+
+    def _maybe_issue_mick(self):
+        """Start one background Mick fetch if none is running. Never publishes,
+        never touches the goal — it deposits the raw wire dict only."""
+        with self._mick_lock:
+            if self._mick_in_flight:
+                return
+            self._mick_in_flight = True
+        threading.Thread(
+            target=self._run_mick_fetch, name='occy-doer-mick', daemon=True,
+        ).start()
+
+    def _run_mick_fetch(self):
+        """WORKER THREAD. One bounded GET; the wire dict or nothing."""
+        wire = None
+        try:
+            payload = requests.get(
+                f'{self._mick}/intent/last', timeout=self._timeout_s).json()
+            if isinstance(payload, dict):
+                wire = payload
+        except Exception:  # noqa: BLE001 — a fault is simply "no new intent"
+            wire = None
+        with self._mick_lock:
+            self._mick_result = wire
+            self._mick_in_flight = False
 
     # --- the doer loop ------------------------------------------------------
     def _publish_envelope(self, data: str):
@@ -434,57 +548,79 @@ class OccyDoer(Node):
             return self._hold(f'object-goal-refused:{refusal}')
         self._object_refusal = None
 
-        try:
-            perception = {
-                'angle_min_rad': float(scan.angle_min),
-                'angle_increment_rad': float(scan.angle_increment),
-                'range_min_m': float(scan.range_min),
-                'range_max_m': float(scan.range_max),
-                'ranges': [float(r) for r in scan.ranges],
-                'stamp_ms': scan_stamp_ms, 'forward_extent_m': self._extent,
-            }
-            # Camera Phase-B (tighten-only). Disarmed → this is {'camera_armed': False}
-            # and the endpoint is byte-identical to the lidar-only path.
-            perception.update(camera_perception_fields(
-                self._camera_armed, self._camera, self._camera_max_age_ms))
-            taj = requests.post(
-                f'{self._taj}/perception', timeout=self._timeout_s, json=perception).json()
-            if self._camera_armed:
-                # Taj already floored the speed cap; say so once per transition so an
-                # operator sees WHY the robot crawled rather than guessing — and once
-                # per transition rather than every tick, so the log stays readable.
-                healthy = taj.get('camera_healthy') is not False
-                if healthy != self._camera_healthy:
-                    self._camera_healthy = healthy
-                    if healthy:
-                        self.get_logger().info('camera channel healthy again')
-                    else:
-                        self.get_logger().warn(
-                            'camera channel unhealthy — Taj floored the speed cap '
-                            '(no usable frame: detector down, stale, or blind)')
+        # Snapshot every input the job needs, as PLAIN PYTHON VALUES. The scan's
+        # ranges are copied here, on the executor thread, so the worker can
+        # never read a ROS message the executor is replacing underneath it.
+        perception = {
+            'angle_min_rad': float(scan.angle_min),
+            'angle_increment_rad': float(scan.angle_increment),
+            'range_min_m': float(scan.range_min),
+            'range_max_m': float(scan.range_max),
+            'ranges': [float(r) for r in scan.ranges],
+            'stamp_ms': scan_stamp_ms, 'forward_extent_m': self._extent,
+        }
+        # Camera Phase-B (tighten-only). Disarmed → this is {'camera_armed': False}
+        # and the endpoint is byte-identical to the lidar-only path.
+        perception.update(camera_perception_fields(
+            self._camera_armed, self._camera, self._camera_max_age_ms))
+        request = JobRequest(
+            scan_sequence=self._scan_seq,
+            scan_received_s=self._scan[1],
+            taj_url=self._taj,
+            planner_url=self._planner,
+            timeout_s=self._timeout_s,
+            perception=perception,
+            plan_fields={
+                'speed': float(speed), 'gx': gx, 'gy': gy,
+                'cruise': self._cruise, 'back_m': self._back_m,
+                'vehicle': self._vehicle, 'goal_fields': goal_fields,
+            },
+        )
 
-            # Extend the Taj corridor behind the robot (footprint containment) and tell the
-            # checker the robot's real size, so KIRRA judges a robot — not a 4.8 m car.
-            left, right = extend_corridor_back(taj.get('left', []), taj.get('right', []), self._back_m)
-            plan_req = {
-                'ego': {'x': 0.0, 'y': 0.0, 'heading': 0.0, 'speed': float(speed)},
-                'goal': {'x': gx, 'y': gy},
-                'cruise': self._cruise,
-                'left': left,
-                'right': right,
-                'objects': taj.get('objects', []),
-                'pedestrians': taj.get('pedestrians', []),
-                'predicted_vrus': taj.get('predicted_vrus', []),
-                'perception_frame_id': taj.get('frame_id'),
-                'vehicle': self._vehicle,
-            }
-            if goal_fields:
-                plan_req.update(goal_fields)
-            plan = requests.post(
-                f'{self._planner}/plan', timeout=self._timeout_s, json=plan_req).json()
-        except Exception as e:  # noqa: BLE001 — any fault holds (fail-soft)
-            return self._hold(f'service-error:{e}')
+        # Exactly one publish per tick — a proposal built from the LAST job's
+        # result, or a hold. Then start the next job. The consume-then-issue
+        # order is what makes this a pipeline: this tick acts on the previous
+        # tick's perception while the next round-trip is already in flight.
+        self._publish_from_pending(gx, gy)
+        self._maybe_issue(request)
 
+    # --- the non-blocking plan cycle ---------------------------------------
+
+    def _publish_from_pending(self, gx: float, gy: float):
+        """Publish a proposal from the last completed job, or hold.
+
+        Runs on the EXECUTOR thread and is the only place a proposal is built.
+        The result is TAKEN from the slot (not peeked), so every result gets
+        exactly one verdict and reuse is structurally impossible.
+        """
+        with self._job_lock:
+            result = self._pending_result
+            self._pending_result = None
+        # Resolution is pure and runs OUTSIDE the lock.
+        resolution = resolve_result(
+            result,
+            newest_scan_sequence=self._scan_seq,
+            last_used_scan_sequence=self._last_used_scan_sequence,
+            now_s=time.monotonic(),
+            scan_stale_s=self._scan_stale_s,
+        )
+        if resolution.state != USE:
+            return self._hold(f'plan-{resolution.state.lower()}:{resolution.reason}')
+
+        # Camera-channel health is NODE state, so the transition log lives here
+        # rather than in the worker. Once per transition, not per tick.
+        if self._camera_armed:
+            healthy = result.camera_healthy is not False
+            if healthy != self._camera_healthy:
+                self._camera_healthy = healthy
+                if healthy:
+                    self.get_logger().info('camera channel healthy again')
+                else:
+                    self.get_logger().warn(
+                        'camera channel unhealthy — Taj floored the speed cap '
+                        '(no usable frame: detector down, stale, or blind)')
+
+        plan = result.plan
         v, w, reason = decide(plan, self._lookahead, self._max_v, self._max_w)
 
         # Bind the velocities to the evidence they were authored against. Both
@@ -505,8 +641,99 @@ class OccyDoer(Node):
         if envelope is None:
             return self._hold('unencodable-proposal')
 
+        # Advance the watermark only once the proposal is actually published.
+        self._last_used_scan_sequence = result.requested_scan_sequence
         self._publish_envelope(envelope)
         self.get_logger().debug(f'{reason}  v={v:.2f} w={w:.2f}  goal_base=({gx:.1f},{gy:.1f})')
+
+    def _maybe_issue(self, request):
+        """Start one plan job if none is running. Never publishes."""
+        fresh = request is not None and (
+            request.scan_sequence > self._last_issued_scan_sequence)
+        with self._job_lock:
+            decision = decide_issue(self._job_in_flight, fresh)
+            if decision != ISSUE:
+                return decision
+            self._job_in_flight = True
+        self._last_issued_scan_sequence = request.scan_sequence
+        # Thread creation happens OUTSIDE the lock. `daemon=True` is the
+        # teardown contract: a worker blocked on a hung sidecar can never keep
+        # the process alive at shutdown, and nothing joins it.
+        threading.Thread(
+            target=self._run_job, args=(request,),
+            name='occy-doer-plan', daemon=True,
+        ).start()
+        return ISSUE
+
+    def _run_job(self, request):
+        """WORKER THREAD. Computes, deposits, and touches nothing else."""
+        result = self._execute_job(request)
+        with self._job_lock:
+            self._pending_result = result
+            self._job_in_flight = False
+
+    def _execute_job(self, request):
+        """WORKER THREAD. The two bounded POSTs, as a pure request→result map.
+
+        No lock is held here: all network I/O happens outside `_job_lock`.
+        Every failure becomes a JobResult carrying a fault tag, so a fault can
+        never be mistaken for "no result yet".
+        """
+        def faulted(reason):
+            return JobResult(
+                requested_scan_sequence=request.scan_sequence,
+                scan_received_s=request.scan_received_s,
+                taj_scan_sequence=None, plan_scan_sequence=None,
+                plan=None, camera_healthy=None, fault=reason,
+            )
+
+        fields = request.plan_fields
+        try:
+            taj = requests.post(
+                f'{request.taj_url}/perception',
+                timeout=request.timeout_s, json=request.perception).json()
+            if not isinstance(taj, dict):
+                # Named explicitly rather than left to blow up on `.get` below,
+                # so the operator sees WHICH sidecar answered wrongly.
+                return faulted('taj-response-not-an-object')
+            # Extend the Taj corridor behind the robot (footprint containment) and
+            # tell the checker the robot's real size, so KIRRA judges a robot — not
+            # a 4.8 m car.
+            left, right = extend_corridor_back(
+                taj.get('left', []), taj.get('right', []), fields['back_m'])
+            plan_req = {
+                'ego': {'x': 0.0, 'y': 0.0, 'heading': 0.0, 'speed': fields['speed']},
+                'goal': {'x': fields['gx'], 'y': fields['gy']},
+                'cruise': fields['cruise'],
+                'left': left,
+                'right': right,
+                'objects': taj.get('objects', []),
+                'pedestrians': taj.get('pedestrians', []),
+                'predicted_vrus': taj.get('predicted_vrus', []),
+                'perception_frame_id': taj.get('frame_id'),
+                'vehicle': fields['vehicle'],
+            }
+            if fields['goal_fields']:
+                plan_req.update(fields['goal_fields'])
+            plan = requests.post(
+                f'{request.planner_url}/plan',
+                timeout=request.timeout_s, json=plan_req).json()
+        except Exception as e:  # noqa: BLE001 — any fault holds (fail-soft)
+            return faulted(f'service-error:{type(e).__name__}')
+
+        if not isinstance(plan, dict):
+            return faulted('planner-response-not-an-object')
+
+        taj_seq, plan_seq = evidence_sequences(taj, plan)
+        return JobResult(
+            requested_scan_sequence=request.scan_sequence,
+            scan_received_s=request.scan_received_s,
+            taj_scan_sequence=taj_seq,
+            plan_scan_sequence=plan_seq,
+            plan=plan,
+            camera_healthy=taj.get('camera_healthy'),
+            fault=None,
+        )
 
 
 def main(args=None):

--- a/ros2_ws/src/kirra_safety/test/test_async_plan.py
+++ b/ros2_ws/src/kirra_safety/test/test_async_plan.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for the doer's non-blocking plan-cycle decisions.
+
+No ROS / rclpy / requests — imports the pure `async_plan` module directly. Every
+issue state and every resolution state is covered, including the two that exist
+purely to stop the async rework introducing a hazard the synchronous loop could
+not have: SUPERSEDED (a reply about a scan we have moved past) and the evidence
+mismatch FAULT (the planner planned against a different Taj frame than the one
+this job fetched).
+
+Run:  pytest ros2_ws/src/kirra_safety/test/test_async_plan.py
+"""
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "kirra_safety")
+)
+from async_plan import (  # noqa: E402
+    ABSENT, FAULT, IN_FLIGHT, ISSUE, NO_FRESH_INPUT, STALE, SUPERSEDED, USE,
+    JobResult, decide_issue, evidence_sequences, resolve_result,
+)
+
+BUDGET_S = 0.25
+
+
+def _result(**over):
+    base = dict(
+        requested_scan_sequence=10,
+        scan_received_s=100.0,
+        taj_scan_sequence=7,
+        plan_scan_sequence=7,
+        plan={"kind": "Motion"},
+        camera_healthy=True,
+        fault=None,
+    )
+    base.update(over)
+    return JobResult(**base)
+
+
+def _resolve(result, newest=10, last_used=9, now_s=100.05, budget_s=BUDGET_S):
+    return resolve_result(result, newest, last_used, now_s, budget_s)
+
+
+# ---------------------------------------------------------------------------
+# decide_issue — every state
+# ---------------------------------------------------------------------------
+
+def test_issue_when_idle_with_fresh_input():
+    assert decide_issue(job_in_flight=False, has_fresh_input=True) == ISSUE
+
+
+def test_in_flight_blocks_a_second_job():
+    # The concurrency bound: requests cannot be cancelled, so the only way to
+    # avoid a pile-up is not to start one.
+    assert decide_issue(job_in_flight=True, has_fresh_input=True) == IN_FLIGHT
+
+
+def test_in_flight_wins_over_missing_input():
+    assert decide_issue(job_in_flight=True, has_fresh_input=False) == IN_FLIGHT
+
+
+def test_no_fresh_input_blocks_issue():
+    assert decide_issue(job_in_flight=False, has_fresh_input=False) == NO_FRESH_INPUT
+
+
+# ---------------------------------------------------------------------------
+# resolve_result — every state
+# ---------------------------------------------------------------------------
+
+def test_use_for_the_newest_scan_within_budget():
+    assert _resolve(_result()).state == USE
+
+
+def test_absent_when_no_job_has_completed():
+    resolution = _resolve(None)
+    assert resolution.state == ABSENT
+    assert "no completed job" in resolution.reason
+
+
+def test_fault_is_reported_with_its_reason():
+    resolution = _resolve(_result(fault="service-error:Timeout"))
+    assert resolution.state == FAULT
+    assert resolution.reason == "service-error:Timeout"
+
+
+def test_fault_outranks_identity_and_staleness():
+    # A failed job carries no evidence to compare, so the fault is the answer
+    # even when the scan is also superseded and ancient.
+    resolution = _resolve(
+        _result(fault="service-error:ConnectionError", requested_scan_sequence=1),
+        newest=99, last_used=98, now_s=1e6,
+    )
+    assert resolution.state == FAULT
+
+
+def test_superseded_when_the_scan_was_already_used():
+    # The strictly-advancing watermark: a result is consumed at most once.
+    resolution = _resolve(_result(requested_scan_sequence=9), newest=10, last_used=9)
+    assert resolution.state == SUPERSEDED
+    assert "already used" in resolution.reason
+
+
+def test_superseded_for_an_older_scan_after_a_newer_one_arrived():
+    resolution = _resolve(_result(requested_scan_sequence=5), newest=12, last_used=8)
+    assert resolution.state == SUPERSEDED
+
+
+def test_superseded_when_the_result_claims_a_scan_the_node_never_saw():
+    # Worker and node disagreeing about identity is refused, not guessed at.
+    resolution = _resolve(_result(requested_scan_sequence=99), newest=10, last_used=9)
+    assert resolution.state == SUPERSEDED
+    assert "ahead of newest" in resolution.reason
+
+
+def test_stale_when_the_perception_aged_out_of_the_budget():
+    # Staleness is measured on the SCAN, not on when the job finished: the
+    # safety question is how old the perception behind the proposal is.
+    resolution = _resolve(_result(scan_received_s=100.0), now_s=100.0 + BUDGET_S + 0.01)
+    assert resolution.state == STALE
+    assert "budget" in resolution.reason
+
+
+def test_exactly_at_the_budget_is_still_usable():
+    assert _resolve(_result(scan_received_s=100.0), now_s=100.0 + BUDGET_S).state == USE
+
+
+def test_evidence_mismatch_is_a_fault_not_a_stale_result():
+    # The planner answered about a DIFFERENT Taj frame than this job fetched.
+    # That is inconsistent evidence, not old evidence.
+    resolution = _resolve(_result(taj_scan_sequence=7, plan_scan_sequence=8))
+    assert resolution.state == FAULT
+    assert "evidence mismatch" in resolution.reason
+
+
+def test_missing_evidence_sequence_is_a_fault():
+    for over in ({"taj_scan_sequence": None}, {"plan_scan_sequence": None}):
+        assert _resolve(_result(**over)).state == FAULT, over
+
+
+def test_resolution_order_identity_before_staleness():
+    # A result about the wrong scan tells us nothing regardless of its age, so
+    # supersession is decided first.
+    resolution = _resolve(
+        _result(requested_scan_sequence=3, scan_received_s=0.0),
+        newest=10, last_used=9, now_s=1e6,
+    )
+    assert resolution.state == SUPERSEDED
+
+
+# ---------------------------------------------------------------------------
+# evidence_sequences
+# ---------------------------------------------------------------------------
+
+def test_evidence_sequences_extracts_both():
+    taj = {"frame_id": {"scan_sequence": 4}}
+    plan = {"perception_frame_id": {"scan_sequence": 4}}
+    assert evidence_sequences(taj, plan) == (4, 4)
+
+
+def test_evidence_sequences_rejects_unusable_values():
+    # Taj's invalid-frame sentinel is scan_sequence 0; a JSON `true` is an int
+    # subclass but not a sequence number.
+    for bad in (0, -1, True, "4", None, 1.5):
+        taj = {"frame_id": {"scan_sequence": bad}}
+        assert evidence_sequences(taj, {})[0] is None, bad
+
+
+def test_evidence_sequences_tolerates_missing_structure():
+    assert evidence_sequences({}, {}) == (None, None)
+    assert evidence_sequences(None, None) == (None, None)
+    assert evidence_sequences({"frame_id": "nope"}, {"perception_frame_id": 3}) == (None, None)

--- a/ros2_ws/src/kirra_safety/test/test_occy_doer_async.py
+++ b/ros2_ws/src/kirra_safety/test/test_occy_doer_async.py
@@ -1,0 +1,919 @@
+"""
+Callback-level tests for the doer's non-blocking plan cycle.
+
+These pin the invariants that only exist where the timer callback meets the
+background worker — that `_tick` returns while HTTP is still blocked, that a
+slow sidecar cannot pile up threads, and that a reply about the wrong scan is
+discarded rather than published. The decision algebra itself is covered purely
+in test_async_plan.py; this file deliberately does not re-test it.
+
+NO ROS GRAPH IS NEEDED. `rclpy` / the message packages are stubbed into
+sys.modules before the node module is imported, and the node instance is built
+without running `Node.__init__` — so callbacks run against ordinary Python
+objects. `requests` is replaced by a recorder whose responses (and blocking) the
+test controls, so "did not wait for HTTP" is an assertion about wall-clock and a
+call count rather than about a network.
+
+Run:  pytest ros2_ws/src/kirra_safety/test/test_occy_doer_async.py
+"""
+
+import ast
+import json
+import os
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# ROS stubs — installed BEFORE importing the node module
+# ---------------------------------------------------------------------------
+
+class _Vec3:
+    def __init__(self):
+        self.x = 0.0
+        self.y = 0.0
+        self.z = 0.0
+
+
+class _Quat:
+    def __init__(self):
+        self.x = 0.0
+        self.y = 0.0
+        self.z = 0.0
+        self.w = 1.0
+
+
+class _Stamp:
+    def __init__(self, sec=0, nanosec=0):
+        self.sec = sec
+        self.nanosec = nanosec
+
+
+class _Header:
+    def __init__(self, sec=0, nanosec=0):
+        self.stamp = _Stamp(sec, nanosec)
+
+
+class String:
+    def __init__(self):
+        self.data = ''
+
+
+class PoseStamped:
+    pass
+
+
+class Odometry:
+    pass
+
+
+class LaserScan:
+    """Only the fields the doer reads."""
+
+    def __init__(self, stamp_ms=1_000, ranges=None):
+        self.header = _Header(stamp_ms // 1000, (stamp_ms % 1000) * 1_000_000)
+        self.angle_min = -1.5
+        self.angle_increment = 0.01
+        self.range_min = 0.1
+        self.range_max = 12.0
+        self.ranges = [1.0] * 8 if ranges is None else list(ranges)
+
+
+def _install_ros_stubs():
+    rclpy = types.ModuleType('rclpy')
+    rclpy.init = lambda *a, **k: None
+    rclpy.spin = lambda *a, **k: None
+    rclpy.try_shutdown = lambda *a, **k: None
+
+    rclpy_node = types.ModuleType('rclpy.node')
+
+    class Node:
+        def __init__(self, *a, **k):
+            pass
+
+    rclpy_node.Node = Node
+    rclpy.node = rclpy_node
+
+    rclpy_qos = types.ModuleType('rclpy.qos')
+    rclpy_qos.QoSProfile = lambda **k: dict(k)
+    rclpy_qos.ReliabilityPolicy = types.SimpleNamespace(RELIABLE=1, BEST_EFFORT=2)
+    rclpy_qos.HistoryPolicy = types.SimpleNamespace(KEEP_LAST=1)
+    rclpy.qos = rclpy_qos
+
+    geometry_msgs = types.ModuleType('geometry_msgs')
+    geometry_msgs_msg = types.ModuleType('geometry_msgs.msg')
+    geometry_msgs_msg.PoseStamped = PoseStamped
+    geometry_msgs.msg = geometry_msgs_msg
+
+    nav_msgs = types.ModuleType('nav_msgs')
+    nav_msgs_msg = types.ModuleType('nav_msgs.msg')
+    nav_msgs_msg.Odometry = Odometry
+    nav_msgs.msg = nav_msgs_msg
+
+    sensor_msgs = types.ModuleType('sensor_msgs')
+    sensor_msgs_msg = types.ModuleType('sensor_msgs.msg')
+    sensor_msgs_msg.LaserScan = LaserScan
+    sensor_msgs.msg = sensor_msgs_msg
+
+    std_msgs = types.ModuleType('std_msgs')
+    std_msgs_msg = types.ModuleType('std_msgs.msg')
+    std_msgs_msg.String = String
+    std_msgs.msg = std_msgs_msg
+
+    sys.modules.update({
+        'rclpy': rclpy,
+        'rclpy.node': rclpy_node,
+        'rclpy.qos': rclpy_qos,
+        'geometry_msgs': geometry_msgs,
+        'geometry_msgs.msg': geometry_msgs_msg,
+        'nav_msgs': nav_msgs,
+        'nav_msgs.msg': nav_msgs_msg,
+        'sensor_msgs': sensor_msgs,
+        'sensor_msgs.msg': sensor_msgs_msg,
+        'std_msgs': std_msgs,
+        'std_msgs.msg': std_msgs_msg,
+    })
+
+
+_install_ros_stubs()
+
+# The node module imports `kirra_safety.*`, so the directory CONTAINING the
+# `kirra_safety` python package goes on the path — that is the ROS package root
+# one level up, not `src/` (which would resolve `kirra_safety` to the ROS
+# package directory and give a namespace package with no modules in it).
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "kirra_safety"))
+sys.path.insert(0, os.path.join(_HERE, ".."))
+
+from kirra_safety import occy_doer as doer  # noqa: E402
+from kirra_safety.async_plan import JobResult  # noqa: E402
+from kirra_safety.bound_proposal import (  # noqa: E402
+    build_release_binding, encode_bound_proposal,
+)
+from kirra_safety.doer_core import decide, extend_corridor_back  # noqa: E402
+from kirra_safety.sensor_freshness import (  # noqa: E402
+    FrameHealthConfig, FrameHealthTracker,
+)
+
+DOER_SOURCE = os.path.join(_HERE, "..", "kirra_safety", "occy_doer.py")
+
+# A worker that never returns must never make a test hang either.
+JOIN_TIMEOUT_S = 5.0
+
+PROFILE = "a" * 64
+EVIDENCE = "b" * 64
+PROPOSAL = "c" * 64
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class _Publisher:
+    def __init__(self):
+        self.published = []
+
+    def publish(self, msg):
+        self.published.append(msg.data)
+
+
+class _Logger:
+    def __init__(self):
+        self.records = []
+
+    def _log(self, level, msg):
+        self.records.append((level, str(msg)))
+
+    info = lambda self, m: self._log('info', m)      # noqa: E731
+    warn = lambda self, m: self._log('warn', m)      # noqa: E731
+    error = lambda self, m: self._log('error', m)    # noqa: E731
+    debug = lambda self, m: self._log('debug', m)    # noqa: E731
+    fatal = lambda self, m: self._log('fatal', m)    # noqa: E731
+
+    def text(self):
+        return " | ".join(m for _, m in self.records)
+
+
+class _Response:
+    def __init__(self, body):
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+class _Requests:
+    """Recorder standing in for the `requests` module.
+
+    `gate` (an Event) lets a test hold a POST open inside the worker for as long
+    as it likes — which is how "the tick did not wait for HTTP" is asserted
+    without a real slow server.
+    """
+
+    def __init__(self, taj=None, plan=None, gate=None, raises=None):
+        self.calls = []
+        self.entered = threading.Event()
+        self._taj = taj if taj is not None else _taj_body()
+        self._plan = plan if plan is not None else _plan_body()
+        self._gate = gate
+        self._raises = raises or {}
+        self._lock = threading.Lock()
+
+    def post(self, url, json=None, timeout=None):
+        with self._lock:
+            self.calls.append({'url': url, 'json': json, 'timeout': timeout})
+        self.entered.set()
+        if self._gate is not None:
+            self._gate.wait(JOIN_TIMEOUT_S)
+        which = 'perception' if url.endswith('/perception') else 'plan'
+        if which in self._raises:
+            raise self._raises[which]
+        return _Response(self._taj if which == 'perception' else self._plan)
+
+    def get(self, url, timeout=None):  # pragma: no cover — Mick is off by default
+        with self._lock:
+            self.calls.append({'url': url, 'json': None, 'timeout': timeout})
+        return _Response({})
+
+    @property
+    def urls(self):
+        with self._lock:
+            return [c['url'] for c in self.calls]
+
+    def count(self, suffix):
+        return sum(1 for u in self.urls if u.endswith(suffix))
+
+
+def _frame_id(scan_sequence=11, **over):
+    frame = {
+        'scan_sequence': scan_sequence,
+        'camera_sequence': 3,
+        'tracker_generation': 2,
+        'profile_digest': PROFILE,
+        'evidence_digest': EVIDENCE,
+    }
+    frame.update(over)
+    return frame
+
+
+def _taj_body(**over):
+    body = {
+        # Taj returns corridor polylines as [x, y] pairs.
+        'left': [[0.0, 0.6], [6.0, 0.6]],
+        'right': [[0.0, -0.6], [6.0, -0.6]],
+        'objects': [],
+        'pedestrians': [],
+        'predicted_vrus': [],
+        'frame_id': _frame_id(),
+        'camera_healthy': True,
+    }
+    body.update(over)
+    return body
+
+
+def _plan_body(**over):
+    body = {
+        'kind': 'Motion',
+        'verdict': 'Accept',
+        'trajectory': [
+            {'x': 0.0, 'y': 0.0, 'speed': 0.8},
+            {'x': 1.0, 'y': 0.0, 'speed': 0.8},
+            {'x': 2.0, 'y': 0.0, 'speed': 0.8},
+        ],
+        'perception_frame_id': _frame_id(),
+        'proposal_digest': PROPOSAL,
+    }
+    body.update(over)
+    return body
+
+
+def _node(requests_stub, **over):
+    """Build an OccyDoer without running Node.__init__ (no ROS graph)."""
+    n = object.__new__(doer.OccyDoer)
+
+    n._taj = 'http://taj.test'
+    n._planner = 'http://planner.test'
+    n._mick = ''
+    n._mick_seq = 0
+    n._mick_ignored = set()
+    n._cruise = 1.2
+    n._max_v = 1.2
+    n._max_w = 1.5
+    n._lookahead = 0.8
+    n._goal_tol = 0.25
+    n._extent = 8.0
+    n._scan_stale_s = 0.25
+    n._timeout_s = 0.05
+    n._back_m = 0.5
+
+    n._frame_health_enabled = False
+    n._frame_health = FrameHealthTracker(FrameHealthConfig.disarmed())
+    n._frame_health_reason = None
+
+    n._job_lock = threading.Lock()
+    n._job_in_flight = False
+    n._pending_result = None
+    n._scan_seq = 0
+    n._last_used_scan_sequence = 0
+    n._last_issued_scan_sequence = 0
+
+    n._mick_lock = threading.Lock()
+    n._mick_in_flight = False
+    n._mick_result = None
+
+    n._vehicle = {
+        'class': 'courier', 'wheelbase_m': 0.2, 'half_length_m': 0.18,
+        'half_width_m': 0.15, 'max_speed_mps': 1.2, 'max_steering_deg': 30.0,
+        'rss_lateral_alignment_tolerance_m': 0.6,
+        'lateral_clearance_target_m': 0.6,
+    }
+    n._camera_armed = False
+    n._camera_max_age_ms = doer.DEFAULT_CAMERA_MAX_AGE_MS
+
+    n._pose = (0.0, 0.0, 0.0, 0.0)
+    n._goal = (5.0, 0.0)
+    n._scan = None
+    n._camera = None
+    n._object_goal = None
+    n._object_refusal = None
+    n._camera_healthy = True
+
+    n._pub = _Publisher()
+    n._logger = _Logger()
+    n.get_logger = lambda: n._logger
+
+    for k, v in over.items():
+        setattr(n, k, v)
+
+    doer.requests = requests_stub
+    doer.REQUESTS_AVAILABLE = True
+    return n
+
+
+def _result_for(node, scan_sequence, **over):
+    """A completed job's result for a given scan, as a worker would build it."""
+    base = dict(
+        requested_scan_sequence=scan_sequence,
+        scan_received_s=node._scan[1],
+        taj_scan_sequence=11,
+        plan_scan_sequence=11,
+        plan=_plan_body(),
+        camera_healthy=True,
+        fault=None,
+    )
+    base.update(over)
+    return JobResult(**base)
+
+
+def _push_scan(node, stamp_ms=1_000):
+    node._on_scan(LaserScan(stamp_ms=stamp_ms))
+
+
+def _await_idle(node, timeout_s=JOIN_TIMEOUT_S):
+    """Wait for the in-flight job to deposit its result."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        with node._job_lock:
+            if not node._job_in_flight:
+                return True
+        time.sleep(0.002)
+    return False
+
+
+def _live_workers():
+    return [t for t in threading.enumerate() if t.name.startswith('occy-doer-')]
+
+
+@pytest.fixture(autouse=True)
+def _no_worker_leaks():
+    """Every test must leave the worker pool empty.
+
+    A leaked worker would make a later test's thread count meaningless, and a
+    leak IS the failure mode this PR is guarding against.
+    """
+    yield
+    for t in _live_workers():
+        t.join(JOIN_TIMEOUT_S)
+    assert not [t for t in _live_workers() if t.is_alive()], 'worker leaked'
+
+
+# ---------------------------------------------------------------------------
+# The tick does not block
+# ---------------------------------------------------------------------------
+
+def test_tick_returns_while_http_is_still_blocked():
+    gate = threading.Event()
+    req = _Requests(gate=gate)
+    n = _node(req)
+    _push_scan(n)
+    try:
+        started = time.monotonic()
+        n._tick()
+        elapsed = time.monotonic() - started
+        # The worker holds a POST open for as long as the gate is shut. If the
+        # tick had done the HTTP inline it could not have returned at all.
+        assert req.entered.wait(JOIN_TIMEOUT_S), 'worker never issued its POST'
+        assert elapsed < 0.5, f'tick blocked for {elapsed:.3f}s'
+        with n._job_lock:
+            assert n._job_in_flight
+    finally:
+        gate.set()
+        _await_idle(n)
+
+
+def test_repeated_ticks_start_exactly_one_job_while_one_is_in_flight():
+    gate = threading.Event()
+    req = _Requests(gate=gate)
+    n = _node(req)
+    _push_scan(n)
+    try:
+        for _ in range(20):
+            _push_scan(n)   # new perception every tick, as on a live robot
+            n._tick()
+        assert req.entered.wait(JOIN_TIMEOUT_S)
+        # One chain: one Taj POST, no planner POST yet (it is gated behind it),
+        # and exactly one worker thread however fast the timer fires.
+        assert req.count('/perception') == 1, req.urls
+        assert req.count('/plan') == 0, req.urls
+        assert len(_live_workers()) == 1
+    finally:
+        gate.set()
+        _await_idle(n)
+    assert req.count('/plan') == 1
+
+
+def test_a_new_job_starts_once_the_previous_one_finished():
+    n = _node(_Requests())
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    assert doer.requests.count('/perception') == 2
+
+
+# ---------------------------------------------------------------------------
+# Faults hold
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('which', ['perception', 'plan'])
+@pytest.mark.parametrize('exc', [TimeoutError('t'), ConnectionError('c')])
+def test_sidecar_timeout_or_failure_eventually_holds(which, exc):
+    n = _node(_Requests(raises={which: exc}))
+    _push_scan(n)
+    n._tick()                     # issues the job; publishes a hold (no result yet)
+    assert _await_idle(n)
+    n._pub.published.clear()
+    _push_scan(n)
+    n._tick()                     # consumes the faulted result
+    assert n._pub.published == [doer.HOLD_ENVELOPE]
+    assert 'plan-fault:service-error' in n._logger.text()
+
+
+@pytest.mark.parametrize('bad, tag', [
+    ({'plan': ['not', 'an', 'object']}, 'planner-response-not-an-object'),
+    ({'taj': ['not', 'an', 'object']}, 'taj-response-not-an-object'),
+])
+def test_a_sidecar_returning_a_non_object_holds(bad, tag):
+    # Named per sidecar, so the operator sees WHICH one answered wrongly rather
+    # than a generic AttributeError from the first `.get`.
+    n = _node(_Requests(**bad))
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    _push_scan(n)
+    n._pub.published.clear()
+    n._tick()
+    assert n._pub.published == [doer.HOLD_ENVELOPE]
+    assert tag in n._logger.text()
+
+
+def test_evidence_mismatch_between_taj_and_plan_holds():
+    # The planner answered about a different Taj frame than this job fetched.
+    n = _node(_Requests(plan=_plan_body(
+        perception_frame_id=_frame_id(scan_sequence=99))))
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    _push_scan(n)
+    n._pub.published.clear()
+    n._tick()
+    assert n._pub.published == [doer.HOLD_ENVELOPE]
+    assert 'evidence mismatch' in n._logger.text()
+
+
+def test_an_unbindable_plan_holds():
+    # Taj's invalid-frame sentinel: no evidence identity to bind to.
+    sentinel = _frame_id(scan_sequence=7, profile_digest='', evidence_digest='')
+    n = _node(_Requests(taj=_taj_body(frame_id=sentinel),
+                        plan=_plan_body(perception_frame_id=sentinel)))
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    _push_scan(n)
+    n._pub.published.clear()
+    n._tick()
+    assert n._pub.published == [doer.HOLD_ENVELOPE]
+    assert 'unbound-plan' in n._logger.text()
+
+
+# ---------------------------------------------------------------------------
+# Which results get used
+# ---------------------------------------------------------------------------
+
+def test_result_for_the_newest_scan_is_published():
+    n = _node(_Requests())
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    n._pub.published.clear()
+    n._tick()
+    assert len(n._pub.published) == 1
+    envelope = json.loads(n._pub.published[0])
+    assert envelope['release_binding']['proposal_digest'] == PROPOSAL
+    assert envelope['linear_x'] > 0.0
+    assert n._last_used_scan_sequence == 1
+
+
+def test_a_superseded_result_is_discarded():
+    n = _node(_Requests())
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    # Rewind the watermark past the pending result: exactly the state a tick is
+    # in when a later scan's result has already been consumed.
+    n._last_used_scan_sequence = 5
+    n._scan_seq = 9
+    n._pub.published.clear()
+    n._tick()
+    assert n._pub.published == [doer.HOLD_ENVELOPE]
+    assert 'plan-superseded' in n._logger.text()
+
+
+def test_an_old_successful_result_is_not_reused_after_a_newer_scan():
+    n = _node(_Requests())
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    n._pub.published.clear()
+    n._tick()                          # consumes result #1 → publishes
+    assert len(n._pub.published) == 1
+    first = n._pub.published[0]
+    assert first != doer.HOLD_ENVELOPE
+    assert n._last_used_scan_sequence == 1
+    assert _await_idle(n)
+
+    # A late reply about scan 1 lands after it has already been acted on — an
+    # out-of-order or duplicate completion. The plan itself is PERFECTLY VALID;
+    # only its identity is spent. It must be discarded, not republished: a robot
+    # must never act twice on one perception frame.
+    with n._job_lock:
+        n._pending_result = _result_for(n, scan_sequence=1)
+    _push_scan(n)
+    n._pub.published.clear()
+    n._tick()
+    assert n._pub.published == [doer.HOLD_ENVELOPE]
+    assert first not in n._pub.published
+    assert 'plan-superseded' in n._logger.text()
+    assert n._last_used_scan_sequence == 1
+    assert _await_idle(n)
+
+
+def test_no_new_scan_means_no_new_job():
+    # Re-issuing against a scan already planned for would spend a sidecar
+    # round-trip on a result the watermark is guaranteed to discard.
+    n = _node(_Requests())
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    assert doer.requests.count('/perception') == 1
+    for _ in range(5):
+        n._tick()                      # same scan, nothing new to plan against
+        assert _await_idle(n)
+    assert doer.requests.count('/perception') == 1
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    assert doer.requests.count('/perception') == 2
+
+
+def test_stale_perception_holds_even_when_the_result_is_valid():
+    n = _node(_Requests())
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    # Age the scan past the budget without changing its identity.
+    scan, _ = n._scan
+    n._scan = (scan, time.monotonic() - (n._scan_stale_s + 1.0))
+    n._pub.published.clear()
+    n._tick()
+    # The tick's own arrival-freshness guard fires first; either way it holds
+    # and no motion is proposed on perception older than the budget.
+    assert n._pub.published == [doer.HOLD_ENVELOPE]
+
+
+def test_exactly_one_publish_per_tick():
+    n = _node(_Requests())
+    _push_scan(n)
+    for _ in range(4):
+        before = len(n._pub.published)
+        n._tick()
+        assert len(n._pub.published) - before == 1
+        assert _await_idle(n)
+        _push_scan(n)
+    assert _await_idle(n)
+
+
+# ---------------------------------------------------------------------------
+# Thread discipline
+# ---------------------------------------------------------------------------
+
+def test_the_worker_never_publishes_and_never_mutates_node_state():
+    n = _node(_Requests())
+    _push_scan(n)
+    before = (n._goal, n._pose, n._scan, n._scan_seq,
+              n._last_used_scan_sequence, n._camera_healthy)
+    n._pub.published.clear()
+    n._maybe_issue(_snapshot(n))
+    assert _await_idle(n)
+    # The job ran to completion and deposited a result...
+    with n._job_lock:
+        assert n._pending_result is not None
+    # ...and published nothing, and left every piece of node state alone.
+    assert n._pub.published == []
+    assert (n._goal, n._pose, n._scan, n._scan_seq,
+            n._last_used_scan_sequence, n._camera_healthy) == before
+
+
+def test_workers_are_daemons_so_shutdown_cannot_hang():
+    gate = threading.Event()
+    n = _node(_Requests(gate=gate))
+    _push_scan(n)
+    try:
+        n._tick()
+        workers = _live_workers()
+        assert workers, 'no worker started'
+        # `daemon=True` IS the teardown contract: the interpreter exits without
+        # joining these, so a worker wedged on a hung sidecar cannot keep the
+        # process alive.
+        assert all(t.daemon for t in workers)
+    finally:
+        gate.set()
+        _await_idle(n)
+
+
+def test_the_node_never_joins_a_worker():
+    # The other half of the teardown contract: a daemon thread still blocks
+    # shutdown if something waits on it. Nothing in this module may.
+    for sub in ast.walk(_module_ast()):
+        if (isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute)
+                and sub.func.attr == 'join'):
+            pytest.fail(f'thread join at line {sub.lineno} could hang teardown')
+
+
+def test_the_job_lock_is_never_held_across_network_io():
+    # If `_execute_job` took `_job_lock`, this deliberately-held lock would
+    # deadlock the worker and the wait would time out.
+    n = _node(_Requests())
+    _push_scan(n)
+    request = _snapshot(n)
+    done = threading.Event()
+    result = {}
+
+    def run():
+        result['value'] = n._execute_job(request)
+        done.set()
+
+    t = threading.Thread(target=run, name='occy-doer-probe', daemon=True)
+    with n._job_lock:
+        t.start()
+        assert done.wait(JOIN_TIMEOUT_S), '_execute_job blocked on _job_lock'
+    t.join(JOIN_TIMEOUT_S)
+    assert result['value'].fault is None
+
+
+def test_a_scan_arriving_mid_job_advances_identity_without_touching_the_slot():
+    gate = threading.Event()
+    n = _node(_Requests(gate=gate))
+    _push_scan(n)
+    try:
+        n._tick()
+        assert doer.requests.entered.wait(JOIN_TIMEOUT_S)
+        _push_scan(n)                 # scan #2 lands while job #1 is in flight
+        assert n._scan_seq == 2
+        with n._job_lock:
+            assert n._pending_result is None
+    finally:
+        gate.set()
+        assert _await_idle(n)
+    # Job #1's result is about scan #1, which is still un-consumed and still
+    # within budget, so it is usable — supersession is by watermark, not by
+    # "a newer scan exists".
+    with n._job_lock:
+        assert n._pending_result.requested_scan_sequence == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression: the emitted envelope is what the synchronous doer emitted
+# ---------------------------------------------------------------------------
+
+def _synchronous_reference(node, taj, plan_response, gx, gy, speed):
+    """The pre-async emit path, frozen.
+
+    Deliberately a literal transcription of the synchronous `_tick` tail rather
+    than a call into the new code, so this test can actually catch the async
+    rework changing what goes on the wire.
+    """
+    left, right = extend_corridor_back(
+        taj.get('left', []), taj.get('right', []), node._back_m)
+    plan_req = {
+        'ego': {'x': 0.0, 'y': 0.0, 'heading': 0.0, 'speed': float(speed)},
+        'goal': {'x': gx, 'y': gy},
+        'cruise': node._cruise,
+        'left': left,
+        'right': right,
+        'objects': taj.get('objects', []),
+        'pedestrians': taj.get('pedestrians', []),
+        'predicted_vrus': taj.get('predicted_vrus', []),
+        'perception_frame_id': taj.get('frame_id'),
+        'vehicle': node._vehicle,
+    }
+    v, w, _reason = decide(
+        plan_response, node._lookahead, node._max_v, node._max_w)
+    binding = build_release_binding(
+        plan_response.get('perception_frame_id'),
+        plan_response.get('proposal_digest'))
+    return plan_req, encode_bound_proposal(v, 0.0, w, binding)
+
+
+@pytest.mark.parametrize('speed', [0.0, 0.7])
+@pytest.mark.parametrize('trajectory', [
+    [{'x': 0.0, 'y': 0.0, 'speed': 0.8}, {'x': 1.0, 'y': 0.0, 'speed': 0.8},
+     {'x': 2.0, 'y': 0.0, 'speed': 0.8}],
+    [{'x': 0.0, 'y': 0.0, 'speed': 0.5}, {'x': 1.0, 'y': 0.4, 'speed': 0.5},
+     {'x': 2.0, 'y': 1.1, 'speed': 0.5}],
+])
+def test_emitted_envelope_matches_the_synchronous_implementation(speed, trajectory):
+    taj = _taj_body()
+    plan_response = _plan_body(trajectory=trajectory)
+    n = _node(_Requests(taj=taj, plan=plan_response), _pose=(0.0, 0.0, 0.0, speed))
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    n._pub.published.clear()
+    n._tick()
+    assert _await_idle(n)
+
+    expected_plan_req, expected_envelope = _synchronous_reference(
+        n, taj, plan_response, gx=5.0, gy=0.0, speed=speed)
+    assert expected_envelope is not None
+    assert n._pub.published[0] == expected_envelope
+    # The request the worker sent must also be the request the synchronous
+    # implementation sent — the envelope can only be right if the plan was
+    # authored from the same inputs.
+    plan_calls = [c['json'] for c in doer.requests.calls if c['url'].endswith('/plan')]
+    assert plan_calls[0] == expected_plan_req
+
+
+def test_the_published_envelope_is_a_valid_bound_proposal():
+    n = _node(_Requests())
+    _push_scan(n)
+    n._tick()
+    assert _await_idle(n)
+    n._pub.published.clear()
+    n._tick()
+    assert _await_idle(n)
+    envelope = json.loads(n._pub.published[0])
+    assert set(envelope) >= {'linear_x', 'linear_y', 'angular_z', 'release_binding'}
+    assert envelope['release_binding'] == {
+        'scan_sequence': 11, 'camera_sequence': 3, 'tracker_generation': 2,
+        'profile_digest': PROFILE, 'evidence_digest': EVIDENCE,
+        'proposal_digest': PROPOSAL,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Structural: no HTTP survives on the callback path
+# ---------------------------------------------------------------------------
+
+CALLBACKS = ('_tick', '_on_scan', '_on_odom', '_on_goal', '_on_camera',
+             '_on_object_goal')
+
+HTTP_ATTRS = ('post', 'get', 'put', 'patch', 'delete', 'request', 'head')
+
+
+def _module_ast():
+    with open(DOER_SOURCE) as fh:
+        return ast.parse(fh.read())
+
+
+def _methods():
+    tree = _module_ast()
+    cls = next(n for n in tree.body
+               if isinstance(n, ast.ClassDef) and n.name == 'OccyDoer')
+    return {m.name: m for m in cls.body if isinstance(m, ast.FunctionDef)}
+
+
+def _http_calls_in(node):
+    """`requests.<verb>(...)` occurrences directly inside one function body."""
+    found = []
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Call):
+            continue
+        func = sub.func
+        if (isinstance(func, ast.Attribute) and func.attr in HTTP_ATTRS
+                and isinstance(func.value, ast.Name) and func.value.id == 'requests'):
+            found.append(f'requests.{func.attr} at line {sub.lineno}')
+    return found
+
+
+def _self_calls_in(node):
+    return {sub.func.attr for sub in ast.walk(node)
+            if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute)
+            and isinstance(sub.func.value, ast.Name) and sub.func.value.id == 'self'}
+
+
+def test_no_http_is_reachable_from_any_callback():
+    """Transitive, not just direct.
+
+    A direct-only check passes the moment the call moves one helper deeper,
+    which is exactly the regression this guards: `_poll_mick`'s blocking GET
+    survived a direct-only scan of `_tick`.
+    """
+    methods = _methods()
+    offenders = {}
+
+    def walk(name, seen):
+        if name in seen or name not in methods:
+            return
+        seen.add(name)
+        for hit in _http_calls_in(methods[name]):
+            offenders.setdefault(name, []).append(hit)
+        for callee in _self_calls_in(methods[name]):
+            walk(callee, seen)
+
+    for entry in CALLBACKS:
+        assert entry in methods, entry
+        walk(entry, set())
+
+    assert offenders == {}, f'blocking HTTP reachable from a callback: {offenders}'
+
+
+def test_the_worker_entry_points_are_the_only_http_holders():
+    # The counterpart assertion: the check above would also pass if the HTTP
+    # had simply been deleted. It must still exist — in the workers.
+    methods = _methods()
+    holders = {name for name, node in methods.items() if _http_calls_in(node)}
+    assert holders == {'_execute_job', '_run_mick_fetch'}, holders
+
+
+def test_every_thread_the_node_starts_is_a_daemon():
+    for sub in ast.walk(_module_ast()):
+        if (isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute)
+                and sub.func.attr == 'Thread'):
+            kwargs = {kw.arg: kw.value for kw in sub.keywords}
+            assert 'daemon' in kwargs, f'Thread at line {sub.lineno} sets no daemon'
+            assert kwargs['daemon'].value is True, f'line {sub.lineno}'
+
+
+# ---------------------------------------------------------------------------
+# Helpers used by the thread-discipline tests
+# ---------------------------------------------------------------------------
+
+def _snapshot(node):
+    """The JobRequest a nominal tick would build, without publishing."""
+    scan = node._scan[0]
+    stamp_ms = int(scan.header.stamp.sec * 1000 + scan.header.stamp.nanosec // 1_000_000)
+    return doer.JobRequest(
+        scan_sequence=node._scan_seq,
+        scan_received_s=node._scan[1],
+        taj_url=node._taj,
+        planner_url=node._planner,
+        timeout_s=node._timeout_s,
+        perception={
+            'angle_min_rad': float(scan.angle_min),
+            'angle_increment_rad': float(scan.angle_increment),
+            'range_min_m': float(scan.range_min),
+            'range_max_m': float(scan.range_max),
+            'ranges': [float(r) for r in scan.ranges],
+            'stamp_ms': stamp_ms, 'forward_extent_m': node._extent,
+        },
+        plan_fields={
+            'speed': 0.0, 'gx': 5.0, 'gy': 0.0,
+            'cruise': node._cruise, 'back_m': node._back_m,
+            'vehicle': node._vehicle, 'goal_fields': None,
+        },
+    )
+
+
+def test_jobresult_is_immutable():
+    # The slot hands a value across a thread boundary; a namedtuple makes
+    # "the timer cannot be handed something the worker still mutates" structural.
+    result = JobResult(1, 0.0, 2, 2, {}, True, None)
+    with pytest.raises(AttributeError):
+        result.fault = 'nope'


### PR DESCRIPTION
## Summary

Moves the Occy doer's Taj and planner HTTP calls out of the ROS timer callback and into one bounded background job.

The worker computes. The ROS executor thread remains the only thread that publishes proposals, mutates goals, evaluates freshness, or makes actuation-relevant decisions.

> ⚠️ **Reviewer note — this PR changes the deployed `plan_hz` from 5 Hz to 10 Hz.** That is a scheduling and command-cadence change, not an implementation detail. See [Scheduling consequence](#scheduling-consequence) below for why it belongs in this PR.

## Problem

`occy_doer._tick` previously performed two sequential synchronous HTTP requests:

- Taj perception request
- Occy planner request

At 5 Hz, with 60 ms timeouts for each call, the timer could spend up to 120 ms blocked during a 200 ms period. A slow or hung sidecar therefore delayed the executor and every callback sharing it.

## Concurrency model

- At most one plan job may be in flight.
- `_tick` copies all required ROS inputs into an immutable plain-Python `JobRequest`.
- The worker performs the existing bounded Taj and planner requests.
- The worker never publishes, holds, mutates ROS state, changes goals, or touches the frame-health tracker.
- It deposits one immutable `JobResult` into a lock-protected slot.
- The executor thread takes and clears that slot, gives it exactly one verdict, and publishes or holds.

Locks are held only for short state transitions and slot swaps, never during network I/O.

Mick intent polling was also moved off the timer path because it was transitively reachable from `_tick`.

## Result acceptance

A result is usable only when:

1. It exists and carries no worker fault.
2. Taj's `frame_id.scan_sequence` matches the planner's echoed `perception_frame_id.scan_sequence`.
3. Its locally requested scan sequence strictly advances the last-used watermark.
4. It does not claim a future local scan.
5. The source scan remains inside the existing `scan_stale_s` budget.

Every result is consumed once. Late, duplicated, inconsistent, or superseded results produce a hold and can never be reused.

ROS 2 LaserScan messages do not contain `header.seq`, so the doer uses a node-local arrival sequence for local issue/use ordering. Taj's sequence is used only to prove consistency between the Taj and planner responses.

## Scheduling consequence

The deployed `plan_hz` changes from 5 Hz to 10 Hz.

With the new pipeline, a result is naturally at least one timer period old when consumed. At 5 Hz, that adds 200 ms before accounting for up to 120 ms of bounded HTTP, which conflicts with the existing 250 ms scan staleness budget and could cause intermittent holds on a healthy 10 Hz lidar.

Running the executor decision loop at 10 Hz reduces the scheduling contribution to 100 ms. Jobs are still issued only when a new scan exists, so this does not double sidecar request volume.

A startup warning reports configurations whose timer period and HTTP budget do not fit within the scan staleness budget.

## Fail-closed behavior

- No new scan: no job is issued.
- Job already running: no second job is created.
- Taj or planner timeout/failure: no proposal is published.
- Late result: discarded.
- Superseded result: discarded.
- Inconsistent Taj/planner evidence: discarded.
- No usable result: the existing empty, deliberately unparseable hold envelope is published.
- Shutdown never waits indefinitely for a worker.

The synchronous `cmd_vel_interceptor` path is intentionally unchanged. Its bounded timeout and immediate stop behavior are part of the fast actuation fail-closed contract.

## Tests

Adds 49 tests:

- 19 pure tests for issue and result-resolution decisions.
- 30 callback-level and structural tests covering:
  - non-blocking `_tick`
  - one job in flight under repeated ticks
  - Taj and planner failures
  - latest-result acceptance
  - superseded-result rejection
  - no successful-result reuse
  - worker publishing prohibition
  - lock-free network execution
  - non-blocking teardown
  - transitive AST proof that callback paths contain no HTTP
  - byte-identical bound-proposal output for fixed fixtures

Full ROS package suite: 262 passed.

## Suggested review focus

Whether a newer scan arriving while a job is in flight causes the old result to be discarded quickly enough without allowing repeated empty holds to mask a permanently slow sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_