### PR TITLE
feat(taj): emit coasted objects, marked on the wire and in the digest (C2, part 2)

### DIFF
--- a/crates/kirra-sidecars/src/taj.rs
+++ b/crates/kirra-sidecars/src/taj.rs
@@ -353,6 +353,16 @@ pub struct ObjOut {
     pub y: f64,
     pub vx: f64,
     pub vy: f64,
+    /// True when this object was NOT observed this frame — a coasted track,
+    /// retained through a detection dropout and emitted at an extrapolated
+    /// position.
+    ///
+    /// The checker treats it exactly as an observed object: retaining a hazard
+    /// tightens, and a consumer ignoring this flag gets the conservative
+    /// reading. The flag exists so an AUDIT can tell what the robot actually
+    /// saw from what it inferred — which is why it is also hashed into the
+    /// evidence digest rather than being presentation-only.
+    pub coasted: bool,
 }
 
 /// One tracked pedestrian/VRU emitted by Taj for the planner's pedestrian RSS
@@ -374,6 +384,13 @@ pub struct PedestrianOut {
     pub camera_observation_id: Option<u64>,
     pub camera_confidence: Option<f64>,
     pub association_distance_m: Option<f64>,
+    /// True when the underlying lidar track was NOT observed this frame.
+    ///
+    /// This channel is the reason the marker matters most: a coasted track
+    /// already reaches the checker's omnidirectional pedestrian RSS bound
+    /// (`classify_vrus` walks every retained track), so without this flag a
+    /// pedestrian the sensor did not see is indistinguishable from one it did.
+    pub coasted: bool,
 }
 
 /// Auditable supporting association between camera/depth geometry and an
@@ -591,6 +608,10 @@ fn compute_perception_evidence_digest(response: &PerceptionResponse) -> String {
         hash_f64(&mut hasher, object.y);
         hash_f64(&mut hasher, object.vx);
         hash_f64(&mut hasher, object.vy);
+        // Observed vs coasted changes what the evidence MEANS, so it belongs
+        // in the digest: two frames identical but for which objects were
+        // actually seen must not share an evidence identity.
+        hash_bool(&mut hasher, object.coasted);
     }
 
     hash_usize(&mut hasher, response.camera_associations.len());
@@ -612,6 +633,7 @@ fn compute_perception_evidence_digest(response: &PerceptionResponse) -> String {
         hash_str(&mut hasher, pedestrian.lidar_classification);
         hash_str(&mut hasher, pedestrian.fused_classification);
         hash_str(&mut hasher, pedestrian.fusion_reason);
+        hash_bool(&mut hasher, pedestrian.coasted);
         hash_optional_u64(&mut hasher, pedestrian.camera_observation_id);
         hash_optional_f64(&mut hasher, pedestrian.camera_confidence);
         hash_optional_f64(&mut hasher, pedestrian.association_distance_m);
@@ -1151,6 +1173,14 @@ pub fn handle_perception_tracked(
     let to_poly = |pts: &[kirra_core::corridor::Point]| -> Vec<[f64; 2]> {
         pts.iter().map(|p| [p.x_m, p.y_m]).collect()
     };
+    // Which emitted objects the sensor did not actually see this frame. Set
+    // membership rather than a field on `PerceivedObject`: coasting is a Taj
+    // concept, and that type is the WCET-critical one the checker consumes,
+    // with ~138 construction sites across this workspace and parko that have
+    // no opinion about it. The marker becomes structural HERE, at the wire.
+    let coasted_ids: std::collections::BTreeSet<u64> =
+        perception.coasted_ids.iter().copied().collect();
+
     let left = to_poly(corridor.left_boundary());
     let right = to_poly(corridor.right_boundary());
     let objects = perception
@@ -1162,6 +1192,7 @@ pub fn handle_perception_tracked(
             y: o.pos.y_m,
             vx: o.vel.x_m,
             vy: o.vel.y_m,
+            coasted: coasted_ids.contains(&o.id),
         })
         .collect();
 
@@ -1191,6 +1222,7 @@ pub fn handle_perception_tracked(
             camera_observation_id: result.camera_observation_id,
             camera_confidence: result.camera_confidence,
             association_distance_m: result.association_distance_m,
+            coasted: coasted_ids.contains(&result.pedestrian.id),
         })
         .collect();
 
@@ -1286,6 +1318,92 @@ mod tests {
             camera_stamp_ms: None,
             camera_max_age_ms: DEFAULT_CAMERA_MAX_AGE_MS,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Coasted-object marker
+    //
+    // A coasted track is a hazard the sensor did NOT report this frame. It is
+    // emitted so the hazard survives a dropout, and the checker treats it as
+    // real — the conservative reading. What must never happen is an audit being
+    // unable to tell it apart from an observation, so the marker rides the wire
+    // AND the evidence digest.
+    // -----------------------------------------------------------------------
+
+    /// An obstacle straight ahead at `bx` metres.
+    fn blob_ranges(bx: f32) -> Vec<f32> {
+        (0..300)
+            .map(|i| {
+                let theta = -1.5 + (i as f64) * 0.01;
+                if theta.abs() < 0.15 {
+                    (f64::from(bx) / theta.cos()) as f32
+                } else {
+                    f32::INFINITY
+                }
+            })
+            .collect()
+    }
+
+    fn at(ranges: Vec<f32>, stamp_ms: u64) -> PerceptionRequest {
+        let mut r = req(ranges);
+        r.stamp_ms = stamp_ms;
+        r
+    }
+
+    #[test]
+    fn an_observed_object_is_never_marked_coasted() {
+        let mut state = TrackedPerceptionState::default();
+        let response = handle_perception_tracked(&at(blob_ranges(4.0), 1_000), &mut state);
+        assert!(
+            !response.objects.is_empty(),
+            "fixture must detect something"
+        );
+        assert!(
+            response.objects.iter().all(|o| !o.coasted),
+            "a detected object must never carry the coasted marker"
+        );
+    }
+
+    #[test]
+    fn a_coasted_object_reaches_the_wire_marked() {
+        let mut state = TrackedPerceptionState::default();
+        let seen = handle_perception_tracked(&at(blob_ranges(4.0), 1_000), &mut state);
+        let id = seen.objects[0].id;
+
+        // The detector reports nothing; the hazard is retained.
+        let gap = handle_perception_tracked(&at(vec![f32::INFINITY; 300], 1_100), &mut state);
+        let coasted: Vec<&ObjOut> = gap.objects.iter().filter(|o| o.id == id).collect();
+        assert_eq!(coasted.len(), 1, "the hazard must survive the dropout");
+        assert!(
+            coasted[0].coasted,
+            "an object the sensor did not see must be marked on the wire"
+        );
+    }
+
+    #[test]
+    fn the_marker_changes_the_evidence_digest() {
+        // The load-bearing property: observed and coasted are DIFFERENT
+        // evidence, so two frames identical but for what was actually seen must
+        // not share an evidence identity. If the marker were presentation-only
+        // this assertion fails and the audit trail is forgeable by omission.
+        let mut response = invalid_perception_response(false);
+        response.objects = vec![ObjOut {
+            id: 7,
+            x: 4.0,
+            y: 0.0,
+            vx: 0.0,
+            vy: 0.0,
+            coasted: false,
+        }];
+        let observed = compute_perception_evidence_digest(&response);
+
+        response.objects[0].coasted = true;
+        let coasted = compute_perception_evidence_digest(&response);
+
+        assert_ne!(
+            observed, coasted,
+            "the coasted marker must be part of the evidence identity"
+        );
     }
 
     /// A clear-ahead scan: returns far out on every ray, so Phase A yields a

--- a/crates/kirra-taj/src/lib.rs
+++ b/crates/kirra-taj/src/lib.rs
@@ -175,6 +175,23 @@ pub struct TajPerception {
     pub corridor: TajCorridor,
     pub objects: Vec<PerceivedObject>,
     pub stamp_ms: u64,
+    /// Ids of the objects in `objects` that were NOT observed this frame —
+    /// coasted tracks, retained through a detection dropout and emitted with
+    /// an extrapolated position.
+    ///
+    /// Carried here rather than as a field on `PerceivedObject` deliberately.
+    /// That type has ~138 construction sites across this workspace and parko —
+    /// planner, map, KPI gate, ROS adapter — none of which have any opinion
+    /// about coasting, and it is the WCET-critical type the checker consumes.
+    /// Coasting is a Taj tracker concept, so the id set travels with Taj's own
+    /// output and is applied at the wire boundary, where it becomes a per-object
+    /// `coasted` flag on the response and enters the evidence digest.
+    ///
+    /// A consumer that ignores this list treats coasted objects exactly as
+    /// observed ones — the conservative reading, and what the checker does by
+    /// design. The marker exists so an AUDIT can tell them apart, not to gate
+    /// behaviour.
+    pub coasted_ids: Vec<u64>,
 }
 
 // ===========================================================================
@@ -472,6 +489,7 @@ impl TajPhaseA {
         }
         (
             TajPerception {
+                coasted_ids: Vec::new(),
                 corridor,
                 objects,
                 stamp_ms: scan.stamp_ms,
@@ -1574,6 +1592,27 @@ impl TajTracker {
                 break; // bounded: coasting can never grow the set without limit
             }
             let predicted = predicted_track_position(tr, now_ms);
+            // Emit the retained track as an object so the HAZARD survives the
+            // dropout, not just the track identity. Position is extrapolated
+            // from the last estimated velocity — freezing it at last-seen would
+            // under-protect against an object that was closing.
+            //
+            // The id goes on `coasted_ids`, which becomes a per-object marker
+            // on the wire and enters the evidence digest: a synthetic object in
+            // front of the checker must never be indistinguishable from an
+            // observed one in an audit.
+            perception.objects.push(PerceivedObject {
+                id: tr.id,
+                pos: predicted,
+                velocity_mps: tr.vel.x_m.hypot(tr.vel.y_m),
+                heading_rad: if tr.vel.x_m.hypot(tr.vel.y_m) > 1e-6 {
+                    tr.vel.y_m.atan2(tr.vel.x_m)
+                } else {
+                    0.0
+                },
+                vel: tr.vel,
+            });
+            perception.coasted_ids.push(tr.id);
             next_tracks.push(Track {
                 id: tr.id,
                 pos: predicted,
@@ -2906,11 +2945,14 @@ mod tests {
         let first = taj.track(&blob_scan(10.0, 0), 0);
         let id = first.objects[0].id;
 
-        // Frame 2: the detector reports nothing.
+        // Frame 2: the detector reports nothing — the hazard is coasted.
         let gap = taj.track(&empty_scan(100), 100);
-        assert!(
-            gap.objects.is_empty(),
-            "no detection means no object emitted"
+        assert_eq!(gap.objects.len(), 1, "the hazard must survive the dropout");
+        assert_eq!(gap.objects[0].id, id);
+        assert_eq!(
+            gap.coasted_ids,
+            vec![id],
+            "and must be marked as unobserved"
         );
 
         // Frame 3: the object is seen again, close to where it was.
@@ -2958,19 +3000,48 @@ mod tests {
     }
 
     #[test]
-    fn coasting_emits_no_objects() {
-        // Scope boundary for this change: it keeps the TRACK alive, it does not
-        // put an unobserved object in front of the checker. Retaining the
-        // hazard itself is a separate, wire-visible change.
+    fn a_coasted_object_is_emitted_and_always_marked() {
+        // The point of retention: the HAZARD survives, not just the track id.
+        // Every synthetic object must carry the marker, on every coasted frame
+        // — an unobserved object that an audit cannot distinguish from a real
+        // detection is the failure mode this exists to prevent.
         let mut taj = TajTracker::default();
-        let _ = taj.track(&blob_scan(10.0, 0), 0);
-        for (i, t) in [100_u64, 150, 200].iter().enumerate() {
-            let out = taj.track(&empty_scan(*t), *t);
-            assert!(
-                out.objects.is_empty(),
-                "coasting frame {i} emitted an object the sensor never saw"
+        let first = taj.track(&blob_scan(10.0, 0), 0);
+        let id = first.objects[0].id;
+        assert!(
+            first.coasted_ids.is_empty(),
+            "an observed object must never be marked coasted"
+        );
+
+        for t in [100_u64, 150, 200] {
+            let out = taj.track(&empty_scan(t), t);
+            assert_eq!(out.objects.len(), 1, "hazard dropped at t={t}");
+            assert_eq!(
+                out.coasted_ids,
+                vec![id],
+                "coasted object emitted UNMARKED at t={t}"
             );
         }
+    }
+
+    #[test]
+    fn every_unobserved_object_is_in_the_marker_set() {
+        // The invariant an audit relies on: `coasted_ids` is exactly the set of
+        // emitted objects the sensor did not report this frame — never a
+        // subset, and never containing an id that was not emitted.
+        let mut taj = TajTracker::default();
+        let _ = taj.track(&blob_scan(10.0, 0), 0);
+        let out = taj.track(&empty_scan(100), 100);
+
+        let emitted: Vec<u64> = out.objects.iter().map(|o| o.id).collect();
+        for coasted in &out.coasted_ids {
+            assert!(
+                emitted.contains(coasted),
+                "marker names id {coasted}, which was not emitted"
+            );
+        }
+        // Everything emitted this frame was coasted, since nothing was detected.
+        assert_eq!(out.coasted_ids.len(), emitted.len());
     }
 
     #[test]


### PR DESCRIPTION
## Disclosure first — #1193 was less scoped than its description said

#1193 (part 1) claimed it "does not put an unobserved object in front of the checker," resting on a test named `coasting_emits_no_objects`.

Taj has **two** channels to the checker. That test covered one.

`classify_vrus` iterates `self.tracks`, which since part 1 includes coasted tracks. So a coasted **pedestrian** was already reaching the checker's omnidirectional RSS bound. Probed directly rather than reasoned about:

```
objects_on_dropout = 0    vrus_before = 1    vrus_after_dropout = 1
```

The direction was safe — retaining a pedestrian tightens, never loosens — and it is the behaviour this part wants anyway. But it shipped **unmarked and undisclosed**, which is exactly the property the marker exists to prevent. `PedestrianOut.coasted` closes it, and that makes the pedestrian channel the more urgent half of this change rather than an afterthought.

## Summary

Part 1 retained the **track** through a detection dropout. This retains the **hazard**: a coasted track is emitted as an object at its extrapolated position, so a limiting object surviving one missed scan actually reaches the checker instead of vanishing and re-appearing.

An unobserved object in front of the safety authority must never be indistinguishable from an observed one.

- **`ObjOut.coasted`** and **`PedestrianOut.coasted`** carry the flag on the response.
- **Both are hashed into the perception evidence digest.** Observed and coasted are *different evidence*: two frames identical but for what was actually seen must not share an evidence identity, or the audit trail is forgeable by omission. `the_marker_changes_the_evidence_digest` asserts exactly that.

## Checker treatment is deliberately unchanged

A coasted object is bounded against exactly like an observed one. Retaining a hazard tightens, and a consumer that ignores the flag gets the conservative reading. The marker is for the **audit**, not to gate behaviour — so the failure mode of ignoring it is benign.

## Where the marker lives, and why not on `PerceivedObject`

`PerceivedObject` has **~138 construction sites** across this workspace *and* `parko` — planner, map, KPI gate, ROS adapter — none of which have any opinion about coasting, and it is the WCET-critical type the checker consumes.

Coasting is a Taj tracker concept, so the id set travels on `TajPerception.coasted_ids` (a three-field struct, Taj's own output) and becomes a structural per-object flag at the **wire boundary**, which is where audits read. The marker lands on the wire and in the digest as intended, without forcing 138 unrelated sites to declare a property they don't have.

Trade-off: consumers join by id rather than reading a field off the object. Acceptable, because the checker treats both alike and ignoring the marker is the conservative path.

## Tests (+4), and two deliberate reversals

Two of part 1's scope-boundary assertions are **reversed on purpose** — `coasting_emits_no_objects` becomes `a_coasted_object_is_emitted_and_always_marked`, because emitting is now the point.

New coverage:

- an observed object is **never** marked coasted
- a coasted object reaches the wire **marked**
- `coasted_ids` is **exactly** the emitted-but-unobserved set — never a subset, never naming an id that was not emitted
- the marker **changes the evidence digest**

## Verification

- `kirra-taj` 98 passed, `kirra-sidecars` 81 passed
- Root workspace: **3 239 passed, 0 failed**
- `cargo fmt --check`, `clippy --workspace --all-targets -D warnings`: clean
- `parko` verified unaffected (`PerceivedObject` untouched)

## Reviewer note

Same mutation-gate blind spot as #1192 and #1193: the gate diffs `crates/kirra-trajectory/src`, so changes in `kirra-taj` and `kirra-sidecars` skip it. Worth its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_