### PR TITLE
feat(taj): measure clear distance to an object's near edge, not its centroid

### DIFF
--- a/crates/kirra-sidecars/src/taj.rs
+++ b/crates/kirra-sidecars/src/taj.rs
@@ -1143,13 +1143,30 @@ pub fn handle_perception_tracked(
 
     // The nearest IN-LANE object (|y| within half a lane), as a discrete
     // clear-distance bound that complements the corridor reach.
+    // Measured to each object's NEAREST FORWARD EDGE, not its centroid: an
+    // obstacle is not at its middle, and the centroid reading reported it as up
+    // to half its own extent further away than it is. An absent entry (an
+    // object Taj did not cluster this frame) falls back to the centroid —
+    // today's behaviour, never worse. `min` with the centroid means a
+    // pathological edge BEHIND the centroid can only tighten, never relax.
+    //
+    // Eligibility still uses the centroid, so WHICH objects count as forward
+    // and in-lane is unchanged; only the DISTANCE to a counted object tightens.
+    let near_edge_of: std::collections::BTreeMap<u64, f64> =
+        perception.near_edge_x_m.iter().copied().collect();
     let nearest_object_m = perception
         .objects
         .iter()
         .filter(|o| {
             is_forward_object_candidate(o.pos.x_m, o.pos.y_m, req.forward_extent_m, req.lane_half_m)
         })
-        .map(|o| o.pos.x_m)
+        .map(|o| {
+            near_edge_of
+                .get(&o.id)
+                .copied()
+                .filter(|edge: &f64| edge.is_finite())
+                .map_or(o.pos.x_m, |edge: f64| edge.min(o.pos.x_m))
+        })
         .fold(f64::INFINITY, f64::min);
     let nearest_object_m = nearest_object_m.is_finite().then_some(nearest_object_m);
 
@@ -1404,6 +1421,76 @@ mod tests {
             observed, coasted,
             "the coasted marker must be part of the evidence identity"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Nearest-forward-edge clear distance
+    //
+    // Clear distance used to be measured to an object's CENTROID, reporting an
+    // obstacle as up to half its own extent further away than it is. The
+    // clustering already computes each cluster's bounding box and discarded it.
+    // -----------------------------------------------------------------------
+
+    /// A wide obstacle at range `bx`, spanning enough rays to have real
+    /// x-EXTENT — the whole point of the test.
+    ///
+    /// Constant RANGE, deliberately: it traces an arc about the lidar, so
+    /// `x = bx·cos θ` varies across the cluster and its nearest edge sits
+    /// genuinely nearer than its centroid. The `bx / cos θ` form used elsewhere
+    /// in this file describes a flat wall — every point at `x == bx` exactly —
+    /// which has NO near edge and would make these assertions vacuous.
+    fn wide_blob_ranges(bx: f32) -> Vec<f32> {
+        (0..300)
+            .map(|i| {
+                let theta = -1.5 + (i as f64) * 0.01;
+                if theta.abs() < 0.35 {
+                    bx
+                } else {
+                    f32::INFINITY
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn clear_distance_is_measured_to_the_near_edge_not_the_centroid() {
+        let mut state = TrackedPerceptionState::default();
+        let response = handle_perception_tracked(&at(wide_blob_ranges(4.0), 1_000), &mut state);
+
+        let object = response
+            .objects
+            .first()
+            .expect("fixture must produce an obstacle");
+        let clear = response.clear_distance_m;
+
+        // A real gap, not floating-point noise: the arc spans |theta| < 0.35 at
+        // range 4, so the near edge sits ~4(1 - cos 0.35) ~ 0.24 m nearer than
+        // the centroid. Requiring a centimetre-scale gap is what stops a
+        // zero-extent fixture passing this vacuously.
+        assert!(
+            clear < object.x - 0.05,
+            "clear distance {clear} must be materially nearer than the centroid \
+             {} — an obstacle is not at its middle",
+            object.x
+        );
+    }
+
+    #[test]
+    fn the_near_edge_never_reports_an_object_further_than_its_centroid() {
+        // Direction guard. Whatever the geometry, this change may only TIGHTEN:
+        // a bound that could relax would be a safety regression, not a fix.
+        let mut state = TrackedPerceptionState::default();
+        for bx in [2.0_f32, 4.0, 6.0, 8.0] {
+            let response = handle_perception_tracked(&at(wide_blob_ranges(bx), 1_000), &mut state);
+            if let Some(object) = response.objects.first() {
+                let clear = response.clear_distance_m;
+                assert!(
+                    clear <= object.x + 1e-9,
+                    "at bx={bx} clear distance {clear} exceeded the centroid {}",
+                    object.x
+                );
+            }
+        }
     }
 
     /// A clear-ahead scan: returns far out on every ray, so Phase A yields a

--- a/crates/kirra-taj/src/lib.rs
+++ b/crates/kirra-taj/src/lib.rs
@@ -192,6 +192,20 @@ pub struct TajPerception {
     /// design. The marker exists so an AUDIT can tell them apart, not to gate
     /// behaviour.
     pub coasted_ids: Vec<u64>,
+    /// `(object id, nearest forward edge x)` in the ego frame.
+    ///
+    /// An object is NOT at its centroid. The clustering already computes each
+    /// cluster's bounding box and then throws it away, so a clear-distance
+    /// bound taken from `pos.x_m` treats a 0.5 m-wide obstacle as ~0.25 m
+    /// further away than it is — material against a 0.40 m margin at robot
+    /// scale.
+    ///
+    /// Carried by id for the same reason as `coasted_ids`: this is Taj
+    /// geometry, and `PerceivedObject` is the WCET-critical checker type with
+    /// ~138 construction sites that have no opinion about it. An absent entry
+    /// makes the consumer fall back to the centroid — today's behaviour, never
+    /// worse.
+    pub near_edge_x_m: Vec<(u64, f64)>,
 }
 
 // ===========================================================================
@@ -483,13 +497,16 @@ impl TajPhaseA {
         let with_extent = self.cluster_objects_with_extent(&points);
         let mut objects = Vec::with_capacity(with_extent.len());
         let mut extents = Vec::with_capacity(with_extent.len());
-        for (o, e) in with_extent {
+        let mut near_edges = Vec::with_capacity(with_extent.len());
+        for (o, e, near_edge_x_m) in with_extent {
+            near_edges.push((o.id, near_edge_x_m));
             objects.push(o);
             extents.push(e);
         }
         (
             TajPerception {
                 coasted_ids: Vec::new(),
+                near_edge_x_m: near_edges,
                 corridor,
                 objects,
                 stamp_ms: scan.stamp_ms,
@@ -570,7 +587,10 @@ impl TajPhaseA {
     /// lean `PerceivedObject` contract deliberately drops, needed by the
     /// WP-10 VRU classifier ([`TajTracker::classify_pedestrians`]) before it
     /// is lost at the contract boundary.
-    fn cluster_objects_with_extent(&self, points: &[(f64, f64)]) -> Vec<(PerceivedObject, f64)> {
+    fn cluster_objects_with_extent(
+        &self,
+        points: &[(f64, f64)],
+    ) -> Vec<(PerceivedObject, f64, f64)> {
         let mut objects = Vec::new();
         if points.is_empty() {
             return objects;
@@ -601,6 +621,11 @@ impl TajPhaseA {
                         max_y = max_y.max(y);
                     }
                     let extent_m = (max_x - min_x).hypot(max_y - min_y);
+                    // The cluster's NEAREST FORWARD EDGE. The box is computed
+                    // here anyway; collapsing it to a diagonal and keeping only
+                    // the centroid discarded the one number a clear-distance
+                    // bound actually wants — an object is not at its middle.
+                    let near_edge_x_m = min_x;
                     objects.push((
                         PerceivedObject {
                             id: next_id,
@@ -613,6 +638,7 @@ impl TajPhaseA {
                             vel: Point { x_m: 0.0, y_m: 0.0 },
                         },
                         extent_m,
+                        near_edge_x_m,
                     ));
                     next_id += 1;
                 }
@@ -1613,6 +1639,16 @@ impl TajTracker {
                 vel: tr.vel,
             });
             perception.coasted_ids.push(tr.id);
+            // A coasted object has no fresh cluster, so derive its near edge
+            // from the last known extent. Half the bbox DIAGONAL is >= the true
+            // half-extent along x, so this places the edge at least as close as
+            // reality — conservative, the only acceptable direction for a
+            // hazard nobody can currently see.
+            if tr.extent_m.is_finite() && tr.extent_m >= 0.0 {
+                perception
+                    .near_edge_x_m
+                    .push((tr.id, predicted.x_m - 0.5 * tr.extent_m));
+            }
             next_tracks.push(Track {
                 id: tr.id,
                 pos: predicted,


### PR DESCRIPTION
## Summary

Clear distance was measured to each object's **centroid**, so an obstacle was reported as up to half its own extent further away than it is. At robot scale that is material against a 0.40 m margin.

Completes increment **C2** (plan PR 4), after track retention (#1193) and hazard retention with the wire marker (#1194).

## The fix was already sitting in the code

`cluster_objects_with_extent` computes every cluster's bounding box (`min_x`/`max_x`/`min_y`/`max_y`), collapses it to a scalar diagonal for the VRU classifier, and **throws the box away** — while the emitted object keeps only the centroid.

`min_x` *is* the nearest forward edge. It is now carried through and used:

- clustering keeps `near_edge_x_m` alongside the extent it already derives;
- `TajPerception.near_edge_x_m` carries `(id, edge)` to the wire layer — the same by-id pattern as `coasted_ids`, for the same reason: `PerceivedObject` is the WCET-critical checker type with ~138 construction sites across this workspace and `parko` that have no opinion about Taj geometry;
- the sidecar's `nearest_object_m` measures to the edge.

## Tighten-only by construction, three ways

1. **Absent entry → falls back to the centroid.** An object Taj did not cluster this frame behaves exactly as before.
2. **`edge.min(centroid)`.** Even a pathological edge *behind* the centroid can only tighten.
3. **Eligibility still uses the centroid.** *Which* objects count as forward and in-lane is unchanged; only the distance to a counted object moves.

Coasted objects have no fresh cluster, so their edge is derived as `predicted_x − extent/2`. Half the bbox **diagonal** is ≥ the true half-extent along x, so this places the edge at least as close as reality — conservative, the only acceptable direction for a hazard nobody can currently see.

## Tests (+2), and a vacuous one I caught

- the near edge is **materially** nearer than the centroid (≥ 5 cm)
- the bound may only tighten, across a range of distances

**The first test was vacuous when written**, and the fixture is why. Every other obstacle fixture in this file uses `bx / cos θ`, which places every point at `x == bx` *exactly* — a flat wall with **zero x-extent** and therefore no near edge. It passed on 2 × 10⁻⁷ m of floating-point noise:

```
centroid_x = 4.000000007   clear = 3.999999786
```

The fixture now uses a constant **range**, tracing an arc about the lidar so `x = bx·cos θ` genuinely varies. Measured gap: **0.161 m** (centroid 3.919, edge 3.757). The 5 cm threshold exists specifically so a zero-extent fixture cannot pass this again, and the reason is recorded in the fixture's doc comment.

## Verification

- `kirra-sidecars` 83 passed
- Root workspace: **3 241 passed, 0 failed** (rebased onto `61d7151f`)
- `cargo fmt --check`, `clippy --workspace --all-targets -D warnings`: clean

## Reviewer note

Same mutation-gate blind spot as #1192–#1194: the gate diffs `crates/kirra-trajectory/src`, so `kirra-taj` and `kirra-sidecars` changes skip it. Four merged safety-relevant changes have now gone through untested by it; it wants a dedicated pass rather than a rider on a feature PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_