### PR TITLE
fix(voice): require an explicit wake-word microphone

### DIFF
--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -168,6 +168,28 @@ As a service: `kirra-rabbit-voice.service` (staged by `install_robot_units.sh`,
 enable deliberately). Master gate `KIRRA_WAKE_ENABLED` in `robot.env`; the
 listener exits cleanly when unset. Full env set: `robot/install/rabbit.env.example`.
 
+**`KIRRA_WAKE_RECORD_CMD` is mandatory when the gate is on**, and must name an
+ALSA device (`-D` or `--device`). There is no default. A bare `arecord` captures
+from ALSA's default — the first card the kernel enumerated, which on the R2 is
+not the microphone — and the failure is silent: the stream opens, delivers
+near-silence, the unit looks healthy and nobody is ever heard. `wake_word.py`
+validates the command *before* opening anything and exits **non-zero** if it is
+missing, blank, unparseable, or a bare `arecord`.
+
+That non-zero matters: the listener is piped into `rabbit_voice.sh`, so exiting
+0 on a config error would leave the pipeline running with no listener behind it.
+`rabbit-voice.service` restarts visibly instead. A non-`arecord` capture backend
+is exempt from the device rule — it has its own convention.
+
+```bash
+arecord -l    # → card 1: Device [USB Audio Device]  →  CARD=Device
+KIRRA_WAKE_RECORD_CMD="arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw"
+```
+
+`kirra_voice_doctor.sh` FAILs on a missing/bare/malformed wake recorder and, on
+pass, prints the selected device and checks the card is still enumerated (the
+same drift check the turn mic gets).
+
 **Detection** (no LLM anywhere): `arecord` raw stream → in-memory ring buffer →
 **RMS energy pre-gate** (a silent room runs zero inference) → whisper.cpp
 **tiny** (`KIRRA_WAKE_STT_CMD` — a second, smaller model than the turn STT) on a
@@ -285,9 +307,25 @@ So:
    ALSA to convert sample rate/format). `hw:` = no conversion, one process at a
    time — fine here (one speaker, one mic).
    ```bash
-   # speak.sh   → aplay -D plughw:1,0 -r 22050 -f S16_LE -t raw -
-   # KIRRA_RECORD_CMD → arecord -D plughw:1,0 -d 4 -f S16_LE -r 16000 -c 1
+   # speak.sh              → aplay   -D plughw:1,0 -r 22050 -f S16_LE -t raw -
+   # KIRRA_RECORD_CMD      → arecord -D plughw:1,0 -d 4 -f S16_LE -r 16000 -c 1
+   # KIRRA_WAKE_RECORD_CMD → arecord -D plughw:1,0 -f S16_LE -r 16000 -c 1 -t raw
    ```
+   Prefer the by-NAME form (`plughw:CARD=Device,DEV=0`) over the number: card
+   numbers drift across reboots, names do not.
+
+   **`KIRRA_RECORD_CMD` and `KIRRA_WAKE_RECORD_CMD` are different contracts** and
+   must not be copied into one another:
+
+   | | contract | shape |
+   |---|---|---|
+   | `KIRRA_RECORD_CMD` | ONE turn | BOUNDED — `-d N`, writes a wav file (path appended) |
+   | `KIRRA_WAKE_RECORD_CMD` | always-on listener | UNBOUNDED — `-t raw` to stdout, never exits |
+
+   The wake recorder is **mandatory** when `KIRRA_WAKE_ENABLED=1` and has no
+   default: a bare `arecord` would take ALSA's default device, and the listener
+   would run deaf without erroring. `wake_word.py` refuses to start rather than
+   allow that; see §3b.
 2. **Put the service user in `audio`.** `sudo usermod -aG audio <user>` (the
    installer renders `User=` to the invoking user — that user needs `audio`).
 3. **No Pulse in the path.** With `-D hw:/plughw:` there is no dependency on the
@@ -338,6 +376,8 @@ Sum = PTT-release → spoken reply. If it's too slow: shorten `-d`, drop to
 | `aplay: ... No such file or directory` | wrong `hw:` card number | `aplay -l`; the USB codec is often not card 0 |
 | Chipmunk / slow-mo voice | `aplay -r` ≠ voice sample rate | match `-r` to the piper voice (medium = 22050) |
 | Records silence/garbage from a service | wrong `arecord -D` / not in `audio` | name the capture device; `usermod -aG audio` |
+| Wake word never triggers, unit looks healthy | `KIRRA_WAKE_RECORD_CMD` on the wrong mic | `arecord -l` → pin `-D plughw:CARD=<name>,DEV=0`; `kirra_voice_doctor.sh` reports the selected device |
+| `rabbit-voice` restart-loops with a wake FATAL | `KIRRA_WAKE_RECORD_CMD` unset, blank, or bare `arecord` | set it with an explicit `-D`/`--device`; this is deliberate — exiting 0 would leave the pipeline up with no listener |
 | Greeting never speaks on boot | TTS device unreachable in-service | validate with `systemd-run --uid`; it degraded to print |
 
 ## References

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -75,6 +75,23 @@ KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
 # Comma-separated phrases. Matching is ordered-adjacent tokens with a 1-edit
 # tolerance on long tokens only ("hallo rabbits" wakes; a stray "yo" never does).
 #KIRRA_WAKE_PHRASES="hello rabbit,hey rabbit,yo rabbit"
+# REQUIRED when KIRRA_WAKE_ENABLED=1 — the listener REFUSES to start without it.
+#
+# There is deliberately no default. A bare `arecord` uses ALSA's DEFAULT device,
+# which is whichever card the kernel enumerated first; on the R2 that is not the
+# microphone. The failure is SILENT — the stream opens, delivers near-silence,
+# the unit looks healthy and nobody is ever heard — so an explicit device is
+# mandatory rather than recommended.
+#
+# Find YOUR card name (do not assume CARD=Device — it varies by microphone):
+#   arecord -l        → e.g. "card 1: Device [USB Audio Device]" → CARD=Device
+# Prefer the by-NAME form: card NUMBERS drift across reboots, names do not.
+#
+# NOTE this is NOT the same contract as KIRRA_RECORD_CMD above. That one is a
+# BOUNDED recorder (-d N, writes a wav file) for a single turn; this is an
+# UNBOUNDED raw stream the listener reads continuously. Do not copy one into the
+# other.
+#KIRRA_WAKE_RECORD_CMD="arecord -D plughw:CARD=<YOUR_CARD>,DEV=0 -f S16_LE -r 16000 -c 1 -t raw"
 #KIRRA_WAKE_RMS_FLOOR=300        # energy pre-gate: a silent room runs ZERO inference
 #KIRRA_WAKE_COOLDOWN_S=2         # refractory period between wakes
 # Re-arm (Slice R): after a wake, the mic is held closed until the TURN it

--- a/robot/kirra_voice_doctor.sh
+++ b/robot/kirra_voice_doctor.sh
@@ -148,6 +148,44 @@ sys.exit(0 if parse_phrases(os.environ.get('KIRRA_WAKE_PHRASES', DEFAULT_PHRASES
     else
       bad "KIRRA_WAKE_PHRASES parses to nothing"; fix "comma-separated phrases, e.g. \"hello rabbit,hey rabbit\""
     fi
+    # 8b2. the WAKE microphone. Distinct from KIRRA_RECORD_CMD: that one is a
+    # BOUNDED wav recorder (-d N, writes a file), this is an UNBOUNDED raw
+    # stream. A bare `arecord` takes ALSA's DEFAULT device — the first card the
+    # kernel enumerated, which on the R2 is not the mic — and the failure is
+    # SILENT: the stream opens, delivers near-silence, and nobody is heard.
+    # So this is a FAIL, not a warning.
+    if [ -z "${KIRRA_WAKE_RECORD_CMD:-}" ]; then
+      bad "KIRRA_WAKE_ENABLED is on but KIRRA_WAKE_RECORD_CMD unset"; fix 'set it with an EXPLICIT device, e.g. "arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw" (arecord -l for the card name) — §0'
+    else
+      wrb="$(first_tok "$KIRRA_WAKE_RECORD_CMD")"
+      if [ -z "$wrb" ]; then
+        bad "KIRRA_WAKE_RECORD_CMD has no program"; fix 'e.g. "arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw"'
+      else
+        wmic="$(opt_val -D "$KIRRA_WAKE_RECORD_CMD")"
+        [ -n "$wmic" ] || wmic="$(opt_val --device "$KIRRA_WAKE_RECORD_CMD")"
+        case "$(basename "$wrb")" in
+          arecord)
+            if [ -z "$wmic" ]; then
+              bad "KIRRA_WAKE_RECORD_CMD uses arecord with no -D/--device (ALSA DEFAULT device — the listener would run deaf)"; fix 'arecord -l → "arecord -D plughw:CARD=<name>,DEV=0 -f S16_LE -r 16000 -c 1 -t raw" — §0'
+            else
+              # Same drift check the full-turn mic gets: a pinned card that is
+              # no longer enumerated is exactly as deaf as no pin at all.
+              wmc="$(card_ref "$wmic")"
+              if command -v arecord >/dev/null 2>&1 && card_present arecord "$wmc"; then
+                ok "wake mic device present: -D $wmic"
+              else
+                bad "wake mic device NOT in arecord -l (card drifted?): -D $wmic"; fix "arecord -l → update KIRRA_WAKE_RECORD_CMD -D plughw:CARD=<name>,DEV=0 — §0"
+              fi
+            fi
+            ;;
+          *)
+            # A custom capture backend has its own device convention; imposing
+            # ALSA's would refuse a working configuration.
+            ok "wake capture backend: $wrb (custom — no ALSA device rule applied)"
+            ;;
+        esac
+      fi
+    fi
     # 8c. hold-off must cover the turn recorder's -d bound (mic contention:
     # the listener releases the device for holdoff; a short holdoff steals it
     # back mid-turn and the turn recorder fails SILENTLY).

--- a/robot/wake_word.py
+++ b/robot/wake_word.py
@@ -42,7 +42,16 @@ Env (robot/install/rabbit.env.example has the annotated set):
   KIRRA_WAKE_STT_CMD      REQUIRED when enabled — whisper-cli + a TINY model;
                           wav path appended as the last arg (house convention)
   KIRRA_WAKE_PHRASES      comma-separated, default "hello rabbit,hey rabbit,yo rabbit"
-  KIRRA_WAKE_RECORD_CMD   raw-stream capture, default "arecord -f S16_LE -r 16000 -c 1 -t raw"
+  KIRRA_WAKE_RECORD_CMD   REQUIRED when enabled — raw-stream capture, and it must
+                          name an ALSA device explicitly, e.g.
+                          "arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw".
+                          There is deliberately NO default: ALSA's default device
+                          is whichever card the kernel enumerated first, which on
+                          the R2 is not the microphone, and the listener would sit
+                          on the wrong input hearing nothing. NOT derived from
+                          KIRRA_RECORD_CMD — that one is a BOUNDED WAV-file
+                          recorder (-d N, writes a file); this is an UNBOUNDED raw
+                          stream. Different contracts, separate variables.
   KIRRA_WAKE_RMS_FLOOR    energy gate (default 300; 16-bit full scale = 32767)
   KIRRA_WAKE_COOLDOWN_S   refractory period between wakes (default 2)
   KIRRA_WAKE_HOLDOFF_S    mic released this long after a trigger (default 10;
@@ -378,6 +387,56 @@ def _listen_for_speech_onset(record_cmd, rms_floor, window_s, onset_hops,
     return onset
 
 
+def validate_record_cmd(raw: str) -> tuple[list[str] | None, str]:
+    """Parse and check the wake recorder command. Returns `(argv, "")` or `(None, reason)`.
+
+    Pure: no spawning, no device probing. The listener calls this BEFORE opening
+    anything, so a misconfigured wake unit dies at startup instead of running
+    deaf on the wrong microphone.
+
+    Two rules:
+      - the command must be parseable and name a program;
+      - if that program is `arecord`, it must select a device explicitly
+        (`-D DEVICE` or `--device DEVICE`). A bare `arecord` takes ALSA's
+        default, which is the first card the kernel enumerated — on the R2 that
+        is not the mic, and the failure is SILENT: the stream opens, delivers
+        near-silence, and the listener simply never wakes.
+
+    A non-`arecord` program is left alone. A custom capture backend has its own
+    device-selection convention and this module has no business guessing it.
+    """
+    if not raw or not raw.strip():
+        return None, ("KIRRA_WAKE_RECORD_CMD is unset or blank; an explicit ALSA "
+                      'device is required, e.g. "-D plughw:CARD=...,DEV=0"')
+    try:
+        argv = shlex.split(raw)
+    except ValueError as exc:
+        return None, f"KIRRA_WAKE_RECORD_CMD is not parseable as a command: {exc}"
+    if not argv:
+        return None, "KIRRA_WAKE_RECORD_CMD parsed to an empty command"
+    program = os.path.basename(argv[0])
+    if program == "arecord" and not any(a in ("-D", "--device") for a in argv[1:]):
+        return None, ("KIRRA_WAKE_RECORD_CMD uses arecord without -D/--device, so it "
+                      "would capture from ALSA's DEFAULT device — on this platform "
+                      "that is not the microphone, and the listener would run deaf "
+                      'without erroring. Name the device, e.g. '
+                      '"arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw"')
+    return argv, ""
+
+
+def wake_record_device(argv: list[str]) -> str:
+    """The ALSA device `argv` selects, or "" if it names none.
+
+    Used for diagnostics — reporting WHICH microphone the listener opened is the
+    difference between "wake word is on" and "wake word is on, listening to the
+    right thing".
+    """
+    for flag, value in zip(argv, argv[1:]):
+        if flag in ("-D", "--device"):
+            return value
+    return ""
+
+
 def main() -> int:
     if not _truthy(os.environ.get("KIRRA_WAKE_ENABLED")):
         _log("KIRRA_WAKE_ENABLED not set — wake word off (exit 0; PTT/Enter still work)")
@@ -397,8 +456,15 @@ def main() -> int:
              "with no phrases is a misconfiguration")
         return 1
 
-    record_cmd = shlex.split(os.environ.get(
-        "KIRRA_WAKE_RECORD_CMD", "arecord -f S16_LE -r 16000 -c 1 -t raw"))
+    # Fail closed on the microphone BEFORE anything is opened or spawned. An
+    # enabled listener on the wrong input is worse than a disabled one: the unit
+    # looks healthy, the logs look healthy, and nobody is heard.
+    record_cmd, why = validate_record_cmd(os.environ.get("KIRRA_WAKE_RECORD_CMD", ""))
+    if record_cmd is None:
+        _log(f"FATAL: KIRRA_WAKE_ENABLED is on but {why}")
+        return 1
+    device = wake_record_device(record_cmd)
+    _log(f"wake microphone: {device or os.path.basename(record_cmd[0]) + ' (custom backend)'}")
     rms_floor = float(os.environ.get("KIRRA_WAKE_RMS_FLOOR", "300"))
     cooldown_s = float(os.environ.get("KIRRA_WAKE_COOLDOWN_S", "2"))
     holdoff_s = float(os.environ.get("KIRRA_WAKE_HOLDOFF_S", "10"))

--- a/robot/wake_word_test.py
+++ b/robot/wake_word_test.py
@@ -24,7 +24,7 @@ import rabbit_wake  # noqa: E402
 from rabbit_ota import match_command  # noqa: E402
 from wake_word import (  # noqa: E402
     DEFAULT_PHRASES, followup_decision, parse_phrases, rms, transcript_tokens,
-    wake_allowed, wake_hit,
+    validate_record_cmd, wake_allowed, wake_hit, wake_record_device,
 )
 
 PHRASES = parse_phrases(DEFAULT_PHRASES)
@@ -219,6 +219,153 @@ def test_replies_state_the_resume_asymmetry() -> None:
 
 
 # --- standalone runner (house pattern) ----------------------------------------
+
+# --- wake microphone selection (fail closed) ---------------------------------
+#
+# The listener used to default to a bare `arecord`, i.e. ALSA's default device —
+# the first card the kernel enumerated. On the R2 that is not the microphone,
+# and the failure mode is SILENT: the stream opens, delivers near-silence, the
+# unit looks healthy and nobody is ever heard. These pin that an enabled
+# listener refuses to start rather than run deaf.
+
+def test_missing_record_cmd_is_refused() -> None:
+    argv, why = validate_record_cmd("")
+    assert argv is None
+    assert "unset or blank" in why
+    assert "-D plughw:" in why, "the message must show the operator the fix"
+
+
+def test_whitespace_only_record_cmd_is_refused() -> None:
+    for blank in ("   ", "\t", "\n", " \t\n "):
+        argv, why = validate_record_cmd(blank)
+        assert argv is None, repr(blank)
+        assert "unset or blank" in why
+
+
+def test_bare_arecord_is_refused() -> None:
+    # The exact string that used to be the built-in default.
+    argv, why = validate_record_cmd("arecord -f S16_LE -r 16000 -c 1 -t raw")
+    assert argv is None
+    assert "DEFAULT device" in why
+
+
+def test_arecord_with_short_device_flag_is_accepted() -> None:
+    cmd = "arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw"
+    argv, why = validate_record_cmd(cmd)
+    assert why == ""
+    assert argv is not None and argv[0] == "arecord"
+    assert wake_record_device(argv) == "plughw:CARD=Device,DEV=0"
+
+
+def test_arecord_with_long_device_flag_is_accepted() -> None:
+    cmd = "arecord --device plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw"
+    argv, why = validate_record_cmd(cmd)
+    assert why == ""
+    assert wake_record_device(argv) == "plughw:CARD=Device,DEV=0"
+
+
+def test_device_rule_follows_the_program_not_the_path() -> None:
+    # An absolute path to arecord is still arecord.
+    argv, why = validate_record_cmd("/usr/bin/arecord -f S16_LE -t raw")
+    assert argv is None and "DEFAULT device" in why
+    argv, why = validate_record_cmd("/usr/bin/arecord -D hw:1,0 -f S16_LE -t raw")
+    assert why == "" and wake_record_device(argv) == "hw:1,0"
+
+
+def test_custom_capture_backend_is_left_alone() -> None:
+    # A non-arecord backend has its own device convention; imposing ALSA's
+    # would refuse a perfectly good configuration.
+    argv, why = validate_record_cmd("my-capture --rate 16000 --raw")
+    assert why == ""
+    assert argv == ["my-capture", "--rate", "16000", "--raw"]
+    assert wake_record_device(argv) == ""
+
+
+def test_unparseable_command_is_refused() -> None:
+    argv, why = validate_record_cmd('arecord -D "unterminated')
+    assert argv is None
+    assert "not parseable" in why
+
+
+def test_validation_never_spawns_anything() -> None:
+    # The whole point of validating before the loop: no microphone is opened
+    # and no process is started while deciding whether the config is usable.
+    import subprocess
+    calls = []
+    for name in ("Popen", "run", "call", "check_call", "check_output"):
+        original = getattr(subprocess, name)
+        setattr(subprocess, name,
+                lambda *a, _n=name, **k: calls.append(_n) or (_ for _ in ()).throw(
+                    AssertionError(f"validation spawned via subprocess.{_n}")))
+        globals().setdefault("_restore", []).append((name, original))
+    try:
+        for cmd in ("", "   ", "arecord -f S16_LE",
+                    "arecord -D plughw:CARD=Device,DEV=0 -f S16_LE",
+                    "my-capture --raw"):
+            validate_record_cmd(cmd)
+    finally:
+        for name, original in globals().pop("_restore"):
+            setattr(subprocess, name, original)
+    assert calls == []
+
+
+# --- process-level contract (what systemd sees) ------------------------------
+#
+# `rabbit-voice.service` runs the listener alongside `rabbit_voice.sh`. If
+# wake_word.py exited 0 on a config error the unit would look fine while no
+# listener existed — so the exit CODE is part of the contract, not just the log.
+
+def _run_wake(env_extra):
+    import os
+    import subprocess
+    env = {k: v for k, v in os.environ.items() if not k.startswith("KIRRA_")}
+    env["PATH"] = os.environ.get("PATH", "")
+    env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent / "wake_word.py")],
+        env=env, capture_output=True, text=True, timeout=30,
+    )
+
+
+def test_wake_disabled_needs_no_wake_config() -> None:
+    # Off is a clean exit, with no microphone requirement at all.
+    done = _run_wake({})
+    assert done.returncode == 0, done.stderr
+    assert "arecord" not in done.stderr
+
+
+def test_wake_enabled_without_record_cmd_exits_nonzero() -> None:
+    done = _run_wake({
+        "KIRRA_WAKE_ENABLED": "1",
+        "KIRRA_WAKE_STT_CMD": "whisper-cli -m /tmp/none.bin -np -nt -f",
+    })
+    assert done.returncode != 0, "an enabled listener with no mic must NOT exit 0"
+    assert "FATAL" in done.stderr
+    assert "KIRRA_WAKE_RECORD_CMD" in done.stderr
+
+
+def test_wake_enabled_with_bare_arecord_exits_nonzero() -> None:
+    done = _run_wake({
+        "KIRRA_WAKE_ENABLED": "1",
+        "KIRRA_WAKE_STT_CMD": "whisper-cli -m /tmp/none.bin -np -nt -f",
+        "KIRRA_WAKE_RECORD_CMD": "arecord -f S16_LE -r 16000 -c 1 -t raw",
+    })
+    assert done.returncode != 0
+    assert "DEFAULT device" in done.stderr
+
+
+def test_wake_recorder_is_not_inherited_from_the_turn_recorder() -> None:
+    # KIRRA_RECORD_CMD is a BOUNDED wav-file recorder (-d N, writes a file); the
+    # listener needs an UNBOUNDED raw stream. Silently reusing it would produce
+    # a listener that stops after N seconds.
+    done = _run_wake({
+        "KIRRA_WAKE_ENABLED": "1",
+        "KIRRA_WAKE_STT_CMD": "whisper-cli -m /tmp/none.bin -np -nt -f",
+        "KIRRA_RECORD_CMD": "arecord -D plughw:CARD=Device,DEV=0 -d 4 -f S16_LE /tmp/t.wav",
+    })
+    assert done.returncode != 0, "the turn recorder must not satisfy the wake recorder"
+    assert "KIRRA_WAKE_RECORD_CMD" in done.stderr
+
 
 def _run_all() -> int:
     failures = 0


### PR DESCRIPTION
## Summary

`wake_word.py` defaulted `KIRRA_WAKE_RECORD_CMD` to a bare

```
arecord -f S16_LE -r 16000 -c 1 -t raw
```

which captures from ALSA's **default** device — the first card the kernel enumerated. On the R2 that is not the microphone, and the failure mode is **silent**: the stream opens, delivers near-silence, the unit looks healthy, the logs look healthy, and nobody is ever heard. The correct device there is `-D plughw:CARD=Device,DEV=0`.

An enabled listener on the wrong input is worse than a disabled one, so the default is removed and the variable is now mandatory whenever `KIRRA_WAKE_ENABLED` is truthy.

## Validation before anything opens

New pure `validate_record_cmd` (plus `wake_record_device` for diagnostics) parses with the module's existing `shlex` approach and refuses:

- unset, whitespace-only, unparseable, empty program
- `arecord` with no `-D` / `--device`

Both flag spellings are accepted, and the program is matched on its **basename**, so `/usr/bin/arecord` is still arecord. A non-`arecord` backend is exempt — a custom capture tool has its own device convention and this module has no business guessing it.

Nothing is spawned while deciding, which a test pins by trapping every `subprocess` entry point rather than just checking a return value.

## Not derived from `KIRRA_RECORD_CMD`

Different contracts, and conflating them would be a subtle bug rather than an obvious one:

| | contract | shape |
|---|---|---|
| `KIRRA_RECORD_CMD` | one turn | **bounded** — `-d N`, writes a wav file |
| `KIRRA_WAKE_RECORD_CMD` | always-on listener | **unbounded** — `-t raw` to stdout, never exits |

Falling back to the turn recorder would produce a listener that stops after N seconds. A test asserts the turn recorder does **not** satisfy the wake recorder.

## The exit code is part of the contract

The listener is piped into `rabbit_voice.sh`, so exiting 0 on a config error would leave the pipeline up with **no listener behind it**. It exits non-zero, and `kirra-rabbit-voice.service` runs the pipeline under `-o pipefail` with `Restart=on-failure`.

Verified end to end rather than by reading the unit:

```
enabled + no record cmd  → pipeline exit 1   (systemd restarts visibly)
wake disabled            → pipeline exit 0   (no restart loop from opting out)
```

## Diagnostics

`kirra_voice_doctor.sh` now **FAILs** — not warns — on a missing, programless, or bare-`arecord` wake recorder. On pass it prints the selected device and runs the same card-drift check the full-turn mic gets, since a pinned card that is no longer enumerated is exactly as deaf as no pin at all.

Exercised against stubbed environments for every case:

```
missing            → ❌ KIRRA_WAKE_ENABLED is on but KIRRA_WAKE_RECORD_CMD unset
bare arecord       → ❌ uses arecord with no -D/--device (ALSA DEFAULT device …)
-D  + card present → ✔ wake mic device present: -D plughw:CARD=Device,DEV=0
--device + present → ✔ wake mic device present: -D plughw:CARD=Device,DEV=0
custom backend     → ✔ wake capture backend: my-capture (custom — no ALSA rule)
wake off           → ✔ wake word off (PTT/Enter are the triggers)
```

## Template and docs

`rabbit.env.example` gains a required, commented entry using a **`<YOUR_CARD>` placeholder** rather than assuming `CARD=Device`, with how to find the real name (`arecord -l`) and why the by-name form beats the card number (numbers drift across reboots).

`RABBIT_AUDIO_STACK.md`: §0 gains the two-contract table above; §3b explains the mandatory device and why the non-zero exit is deliberate; the troubleshooting table gains rows for the silent-wrong-mic symptom and for the restart loop.

## Tests

**+12** in `wake_word_test.py` (34 there; **64** across the Rabbit/voice suites, all green): wake disabled with no config, enabled without it, whitespace-only, bare `arecord`, both accepted device spellings, absolute-path arecord, custom backend, unparseable, no-spawn-on-refusal, and turn-recorder non-inheritance.

## Safety boundaries

No change to phrase matching, RMS gating, STT, TTS, follow-up, re-arm, PTT, Mick, Occy, or actuation.

## Validation run

`py_compile` on both Python files · `bash -n` on the doctor · all six Rabbit/voice suites · `git diff --check` · clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_