### PR TITLE
ci(mutation-gate): extend the checker scope to kirra-core, and stop it passing vacuously

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -141,4 +141,21 @@ exclude_re = [
     # EXACTLY equidistant, and either choice retains the same minimum. Both are
     # measure-zero and behaviourally identical for any real corridor.
     "replace < with <= in chord_clears_corridor",
+    # C1 PNPoly half-open vertex comparison: `(e0.y > a.y) != (e1.y > a.y)` vs
+    # `>=`. The half-open rule only matters for a point whose y coincides with a
+    # boundary VERTEX's y — and on a corridor polygon that means the point lies
+    # exactly ON the boundary. The function returns
+    # `inside && min_dist_sq >= margin_sq`, so at clearance 0 the conjunction is
+    # false whatever `inside` says: the mutant cannot change the OUTPUT for any
+    # positive margin.
+    #
+    # Not asserted — measured. An exhaustive grid search over three corridor
+    # shapes (rectangular, L-bend, slanted parallelogram) found every differing
+    # point at clearance EXACTLY 0.0, and none anywhere else. The same search is
+    # what produced the killing points for the `x_cross` division mutants, which
+    # ARE now killed by
+    # `the_x_cross_interpolation_decides_points_a_wrong_operator_would_admit` —
+    # so the method distinguishes "equivalent" from "not yet killed" rather than
+    # excusing both.
+    "replace > with >= in chord_clears_corridor",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -125,4 +125,20 @@ exclude_re = [
     # that matches every mutant description, silently excluding the entire file
     # and making the gate vacuous for exactly the code it was widened to cover.
     "replace \\|\\| with && in segment_sagitta_m",
+    # C1 PNPoly ray direction in `chord_clears_corridor`: `a.x < x_cross`
+    # (a half-line toward +x) vs `>` (toward -x). Ray casting is
+    # DIRECTION-INDEPENDENT: for any simple polygon a ray from a point crosses
+    # the boundary an odd number of times iff the point is inside, whichever
+    # way it points. Both forms therefore compute the same parity for every
+    # input — truly equivalent, not measure-zero. The ray-cast doing its job at
+    # all is pinned by `the_ray_cast_holds_on_a_slanted_corridor` and
+    # `a_chord_beyond_the_corridor_is_refused_even_though_it_clears_every_edge`.
+    "replace < with > in chord_clears_corridor",
+    # Two exact-tie boundaries in the same function, same class as the
+    # `CenterlineFrenet::project` exclusion above. `a.x < x_cross` vs `<=`
+    # differs only when the test point lies EXACTLY on an edge's interpolated
+    # crossing; `dist_sq < min_dist_sq` vs `<=` differs only when two edges are
+    # EXACTLY equidistant, and either choice retains the same minimum. Both are
+    # measure-zero and behaviourally identical for any real corridor.
+    "replace < with <= in chord_clears_corridor",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -105,4 +105,24 @@ exclude_re = [
     # the_epsilon`, which fails if the epsilon is ever raised into a range where
     # the arc IS representable — at which point this exclusion must be re-earned.
     "replace < with <= in segment_sagitta_m",
+    # C1 front/rear corner selector: `if front > rear { front } else { rear }`
+    # vs `>=`. The two differ ONLY when front == rear to the bit — and there
+    # both arms return the SAME VALUE, so the function's output is identical for
+    # every input. Truly equivalent, not measure-zero. (The selector genuinely
+    # selecting is pinned by `max_corner_radius_is_the_farthest_corner_from_the_
+    # rear_axle` + the rear-dominant twin.)
+    "replace > with >= in max_corner_radius_m",
+    # C1 sagitta input guard: `!chord.is_finite() || !r_max.is_finite()` vs
+    # `&&`. The `&&` form skips the EARLY return when only one input is
+    # non-finite — but a non-finite chord or radius then propagates through
+    # `r_axle`/`sagitta`, and the FINAL `!sagitta.is_finite()` guard returns
+    # None anyway. Same observable result (None) for every input, so no test can
+    # distinguish them; the early guard is defensive clarity, not the mechanism.
+    # `sagitta_refuses_a_non_finite_chord_or_radius` pins the OBSERVABLE
+    # contract, which is what actually matters.
+    # NOTE the escaping: `||` is regex ALTERNATION. Unescaped, this pattern
+    # parses as `(replace )|( with && in segment_sagitta_m)` — an EMPTY branch
+    # that matches every mutant description, silently excluding the entire file
+    # and making the gate vacuous for exactly the code it was widened to cover.
+    "replace \\|\\| with && in segment_sagitta_m",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -94,4 +94,15 @@ exclude_re = [
     # per-window coverage test (a wrong span flips the in-span verdict).
     "replace < with <= in ego_time_span",
     "replace > with >= in ego_time_span",
+    # C1 (#1192) straight-segment short circuit in `segment_sagitta_m`:
+    # `theta < STRAIGHT_SEGMENT_HEADING_EPS_RAD` vs `<=` differ only at theta
+    # EXACTLY 1e-9 — and at that theta both branches return exactly Some(0.0),
+    # because `1 - cos(theta/2)` underflows to 0.0 in f64 well before 1e-9. The
+    # threshold is a singularity guard (the closed form is 0/0 at theta = 0),
+    # not a behavioural boundary, so no test can distinguish the two forms.
+    # TRULY equivalent, like the ego_time_span pair above rather than merely
+    # measure-zero. Pinned by `the_straight_short_circuit_agrees_with_the_arc_at_
+    # the_epsilon`, which fails if the epsilon is ever raised into a range where
+    # the arc IS representable — at which point this exclusion must be re-earned.
+    "replace < with <= in segment_sagitta_m",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,7 +1,11 @@
 # cargo-mutants configuration (WP-08 / MGA G-6 — mutation-testing gate).
 #
-# SCOPE. Mutation runs target the CHECKER crate (`-p kirra-trajectory`,
-# passed on the command line by the CI lane / the baseline scripts). The
+# SCOPE. Mutation runs target the CHECKER crates (`-p kirra-trajectory`
+# `-p kirra-core`, passed on the command line by the CI lane / the baseline
+# scripts). #1196 added kirra-core: the SG2 containment check, the frozen
+# kinematics-contract talisman and the Track-C perception guard live there and
+# were outside the gate entirely. The CI lane enumerates WHICH kirra-core
+# modules count as checker; see the `mutation-gate` job comment. The
 # checker's slow-loop test battery now lives WITH the checker code
 # (`crates/kirra-trajectory/tests/validation_tests.rs`, relocated from the
 # adapter alongside the code it covers); the adapter crate is kept in scope
@@ -17,7 +21,15 @@
 # ...]` — that does NOT change which package's tests cargo-mutants runs, so
 # the adapter suite never executed and adapter-killed mutants showed as
 # survivors. `test_package` is the fix.)
-test_package = ["kirra-trajectory", "kirra-ros2-adapter"]
+#
+# `kirra-core` must appear here as well as on the command line. cargo-mutants
+# defaults to running the MUTATED package's own tests, but an explicit
+# `test_package` REPLACES that default for every mutant — so without this entry
+# a kirra-core mutant would be judged by the trajectory + adapter suites alone,
+# its own containment/talisman tests would never execute, and it would report
+# as a survivor. That is the same trap the `additional_cargo_test_args` note
+# above describes, one crate over.
+test_package = ["kirra-trajectory", "kirra-ros2-adapter", "kirra-core"]
 
 # Generous per-mutant timeout: some mutations turn bounded loops degenerate;
 # the suite itself runs in seconds, so 300 s cleanly separates "hung mutant"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -802,6 +802,24 @@ jobs:
             echo "No checker changes in this PR — mutation gate not applicable."
             exit 0
           fi
+          # CI-HONESTY (#1196, same doctrine as the WCET gate's "running 0
+          # tests" check). A non-empty checker diff that yields ZERO mutants
+          # means the gate asserted nothing while reporting success. That is
+          # not hypothetical: an `exclude_re` entry written as
+          # `replace || with && in ...` parses as regex ALTERNATION with an
+          # EMPTY branch, which matches every mutant description and silently
+          # excluded all 399 containment mutants — a green, vacuous gate on the
+          # exact file the scope was widened to cover. List first, and fail hard
+          # if the diff is non-empty but nothing is mutable.
+          mutants=$(cargo mutants -p kirra-trajectory -p kirra-core \
+            --in-diff checker.diff --list | wc -l)
+          echo "mutants in diff: $mutants"
+          if [ "$mutants" -eq 0 ]; then
+            echo "::error::checker diff is non-empty but produced 0 mutants — \
+          the gate would pass vacuously. Check .cargo/mutants.toml exclude_re \
+          for an over-matching pattern (unescaped regex metacharacters)."
+            exit 1
+          fi
           cargo mutants -p kirra-trajectory -p kirra-core \
             --in-diff checker.diff --timeout 300 -j 1 --no-shuffle
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -803,23 +803,37 @@ jobs:
             exit 0
           fi
           # CI-HONESTY (#1196, same doctrine as the WCET gate's "running 0
-          # tests" check). A non-empty checker diff that yields ZERO mutants
-          # means the gate asserted nothing while reporting success. That is
-          # not hypothetical: an `exclude_re` entry written as
-          # `replace || with && in ...` parses as regex ALTERNATION with an
-          # EMPTY branch, which matches every mutant description and silently
-          # excluded all 399 containment mutants — a green, vacuous gate on the
-          # exact file the scope was widened to cover. List first, and fail hard
-          # if the diff is non-empty but nothing is mutable.
-          mutants=$(cargo mutants -p kirra-trajectory -p kirra-core \
-            --in-diff checker.diff --list | wc -l)
-          echo "mutants in diff: $mutants"
-          if [ "$mutants" -eq 0 ]; then
-            echo "::error::checker diff is non-empty but produced 0 mutants — \
-          the gate would pass vacuously. Check .cargo/mutants.toml exclude_re \
-          for an over-matching pattern (unescaped regex metacharacters)."
+          # tests" check): a gate that can pass while asserting NOTHING is not a
+          # gate. The realised failure was an `exclude_re` entry written as
+          # `replace || with && in ...` — `||` is regex ALTERNATION with an
+          # EMPTY branch, so it matched every mutant description and silently
+          # excluded all 399 containment mutants.
+          #
+          # The check is on the CONFIG, not on this PR's diff. Diff-shape is the
+          # wrong signal: a test-only change to a checker file legitimately
+          # yields zero mutants (cargo-mutants does not mutate `#[cfg(test)]`
+          # code), so failing on "non-empty diff, zero mutants" would red every
+          # test-only PR — including the one that introduced this gate. Asking
+          # instead whether the checker sources are mutable AT ALL catches an
+          # over-matching exclusion regardless of what the PR happens to touch.
+          total=$(cargo mutants -p kirra-trajectory -p kirra-core --list \
+            2>/dev/null | grep -c 'crates/kirra-core/src/containment.rs' || true)
+          echo "mutable containment mutants under the active config: $total"
+          if [ "$total" -eq 0 ]; then
+            echo "::error::.cargo/mutants.toml excludes EVERY containment mutant \
+          — the gate would pass vacuously. Check exclude_re for an over-matching \
+          pattern (unescaped regex metacharacters such as a bare '||')."
             exit 1
           fi
+          # Zero mutants IN THE DIFF is a legitimate skip: comments, tests, or
+          # doc changes to checker files are not mutable code.
+          in_diff=$(cargo mutants -p kirra-trajectory -p kirra-core \
+            --in-diff checker.diff --list 2>/dev/null | wc -l)
+          if [ "$in_diff" -eq 0 ]; then
+            echo "Checker diff touches no mutable code (tests/comments only) — nothing to gate."
+            exit 0
+          fi
+          echo "mutants in diff: $in_diff"
           cargo mutants -p kirra-trajectory -p kirra-core \
             --in-diff checker.diff --timeout 300 -j 1 --no-shuffle
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,7 +736,7 @@ jobs:
           done
 
   # WP-08 (MGA G-6) — mutation gate on the CHECKER. Runs cargo-mutants ONLY
-  # over the mutants lying in this PR's diff of the checker crate
+  # over the mutants lying in this PR's diff of the checker sources
   # (`--in-diff`): new/changed checker code must kill its own mutants, while
   # the pre-existing survivor debt (tracked + triaged in
   # docs/testing/MUTATION_BASELINE.md, ratcheted DOWN by targeted kill tests)
@@ -744,6 +744,29 @@ jobs:
   # seconds. The test scope (checker + the adapter validation suite, where the
   # checker's deepest tests live) comes from .cargo/mutants.toml — measured on
   # the 2026-07-07 baseline, own-tests-only overstates survivors 318 vs 202.
+  #
+  # SCOPE (#1196): the diff covers kirra-trajectory AND the checker modules in
+  # kirra-core. It used to be kirra-trajectory alone, which left the SG2
+  # drivable-space containment check, the frozen kinematics-contract talisman
+  # and the Track-C perception guard — all safety authority — outside the gate
+  # entirely. Four merged changes (#1192, #1193, #1194, #1195) touched
+  # kirra-core / kirra-taj and the gate reported "no checker changes" in ~5
+  # seconds each.
+  #
+  # Widening is safe for existing code precisely BECAUSE of `--in-diff`: the
+  # gate only ever mutates lines a PR changed, so pre-existing survivors in the
+  # newly-covered files are not tested and cannot red anything. The cost lands
+  # only on future PRs that change those files, which is the point.
+  #
+  # kirra-core is enumerated MODULE BY MODULE rather than as a whole crate: it
+  # also holds non-authority code (capture, kinematics_sim, posture_tracker,
+  # corridor/trajectory types) that should not carry a mutation obligation.
+  # Adding a checker module here is a deliberate act, and the list is greppable.
+  #
+  # The talisman is in scope and that is safe: its blob pin is a CI SHELL step
+  # (`git hash-object`, in the rustfmt job), not a Rust test, and cargo-mutants
+  # mutates a scratch copy of the tree. A mutant cannot trip the pin, so it
+  # cannot produce a false "caught".
   mutation-gate:
     name: Mutation gate (checker diff, WP-08)
     if: github.event_name == 'pull_request'
@@ -758,7 +781,15 @@ jobs:
         run: |
           set -euo pipefail
           git diff "origin/${{ github.base_ref }}"...HEAD -- \
-            crates/kirra-trajectory/src > checker.diff
+            crates/kirra-trajectory/src \
+            crates/kirra-core/src/containment.rs \
+            crates/kirra-core/src/kinematics_contract.rs \
+            crates/kirra-core/src/perception_monitor.rs \
+            crates/kirra-core/src/governor_guard.rs \
+            crates/kirra-core/src/frame_integrity.rs \
+            crates/kirra-core/src/platform_kinematics.rs \
+            crates/kirra-core/src/contract_consumer.rs \
+            > checker.diff
           wc -l checker.diff
       - name: Install cargo-mutants
         if: hashFiles('checker.diff') != ''
@@ -771,8 +802,8 @@ jobs:
             echo "No checker changes in this PR — mutation gate not applicable."
             exit 0
           fi
-          cargo mutants -p kirra-trajectory --in-diff checker.diff \
-            --timeout 300 -j 1 --no-shuffle
+          cargo mutants -p kirra-trajectory -p kirra-core \
+            --in-diff checker.diff --timeout 300 -j 1 --no-shuffle
 
   wcet-gate:
     name: WCET Gate (non-instrumented timing)

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ occy_standards.sh
 
 # cargo-cyclonedx trial outputs (release SBOMs are generated in CI)
 *.cdx.json
+
+# cargo-mutants scratch output (local runs only; CI uses --in-diff and keeps
+# nothing). Large, regenerated per run, and never evidence on its own.
+mutants.out/
+mutants.out.old/

--- a/crates/kirra-core/src/containment.rs
+++ b/crates/kirra-core/src/containment.rs
@@ -1794,6 +1794,119 @@ mod tests {
         assert!(chord_clears_corridor(&g, &h, &corridor, margin_sq));
     }
 
+    /// A corridor whose boundaries are SLANTED, not axis-aligned.
+    ///
+    /// Load-bearing for the ray-cast tests. On an axis-aligned rectangle every
+    /// vertical edge has `e1.x - e0.x == 0`, so the `x_cross` formula collapses
+    /// to `e0.x` no matter what its `*` and `/` do — the arithmetic is
+    /// unreachable and its mutants cannot be killed. A slanted edge makes every
+    /// term of `(e1.x - e0.x) * (a.y - e0.y) / dy + e0.x` matter.
+    fn slanted_corridor(half_w: f64, x_max: f64, slope: f64) -> (Vec<Point>, Vec<Point>) {
+        let n = 8;
+        let dx = x_max / (n as f64 - 1.0);
+        let mut left = Vec::with_capacity(n);
+        let mut right = Vec::with_capacity(n);
+        for i in 0..n {
+            let x = i as f64 * dx;
+            left.push(Point {
+                x_m: x,
+                y_m: half_w + slope * x,
+            });
+            right.push(Point {
+                x_m: x,
+                y_m: -half_w + slope * x,
+            });
+        }
+        (left, right)
+    }
+
+    #[test]
+    fn the_ray_cast_holds_on_a_slanted_corridor() {
+        // With slanted boundaries the `x_cross` interpolation is genuinely
+        // exercised, so a wrong product, quotient or difference in it changes
+        // the inside/outside verdict rather than cancelling out.
+        let (left, right) = slanted_corridor(3.0, 100.0, 0.4);
+        let corridor = healthy_corridor(&left, &right);
+        let margin_sq = 0.16;
+
+        // On the slanted centreline: inside.
+        let a = Point {
+            x_m: 40.0,
+            y_m: 0.4 * 40.0,
+        };
+        let b = Point {
+            x_m: 60.0,
+            y_m: 0.4 * 60.0,
+        };
+        assert!(
+            chord_clears_corridor(&a, &b, &corridor, margin_sq),
+            "a chord down the slanted centreline must clear"
+        );
+
+        // Same x-range, but far off the slanted band and far from every edge:
+        // only the ray-cast can refuse this.
+        let c = Point {
+            x_m: 40.0,
+            y_m: 0.4 * 40.0 + 60.0,
+        };
+        let d = Point {
+            x_m: 60.0,
+            y_m: 0.4 * 60.0 + 60.0,
+        };
+        assert!(
+            !chord_clears_corridor(&c, &d, &corridor, margin_sq),
+            "a chord far above the slanted band must be refused"
+        );
+
+        // Below the band, likewise.
+        let e = Point {
+            x_m: 40.0,
+            y_m: 0.4 * 40.0 - 60.0,
+        };
+        let f = Point {
+            x_m: 60.0,
+            y_m: 0.4 * 60.0 - 60.0,
+        };
+        assert!(!chord_clears_corridor(&e, &f, &corridor, margin_sq));
+    }
+
+    #[test]
+    fn the_ray_cast_is_stable_when_a_vertex_sits_exactly_on_the_ray() {
+        // The `>` half-open comparisons in the crossing test exist to stop a
+        // vertex lying exactly at the test point's y from being counted twice.
+        // A point level with a boundary vertex is the case that pins them.
+        let (left, right) = straight_corridor(3.0, 100.0);
+        let corridor = healthy_corridor(&left, &right);
+        let margin_sq = 0.01;
+
+        // Exactly level with the LEFT boundary's vertices (y = +3.0), but far
+        // outside in x — so distance cannot refuse it and the parity must.
+        let a = Point {
+            x_m: 300.0,
+            y_m: 3.0,
+        };
+        let b = Point {
+            x_m: 340.0,
+            y_m: 3.0,
+        };
+        assert!(
+            !chord_clears_corridor(&a, &b, &corridor, margin_sq),
+            "a chord level with the boundary vertices but far beyond the \
+             corridor must be refused"
+        );
+
+        // And level with the RIGHT boundary's vertices (y = -3.0).
+        let c = Point {
+            x_m: 300.0,
+            y_m: -3.0,
+        };
+        let d = Point {
+            x_m: 340.0,
+            y_m: -3.0,
+        };
+        assert!(!chord_clears_corridor(&c, &d, &corridor, margin_sq));
+    }
+
     #[test]
     fn a_corridor_with_a_non_finite_vertex_is_refused() {
         // The `&&` guard over the polygon's own vertices (distinct from the

--- a/crates/kirra-core/src/containment.rs
+++ b/crates/kirra-core/src/containment.rs
@@ -1459,6 +1459,296 @@ mod tests {
         );
     }
 
+    // --- helper arithmetic (mutation-gate kills) ----------------------------
+    //
+    // The C1 tests below exercise COMPOSED behaviour: they drive
+    // `validate_trajectory_containment` and check verdicts. That left the
+    // helpers' arithmetic untested — a mutation run over the #1192 diff found
+    // 32 survivors, including `max_corner_radius_m -> 0.0`, which shrinks the
+    // sagitta and makes the bound LESS conservative without flipping any
+    // composed verdict. These pin the arithmetic directly.
+
+    #[test]
+    fn max_corner_radius_is_the_farthest_corner_from_the_rear_axle() {
+        // Front-dominant: the front corners are farther, so the front diagonal
+        // wins. Exact value, so a wrong operator or a constant cannot pass.
+        let f = VehicleFootprint {
+            width_m: 0.30,
+            length_m: 0.47,
+            overhang_front_m: 0.18,
+            overhang_rear_m: 0.09,
+            wheelbase_m: 0.20,
+        };
+        // front = hypot(0.20 + 0.18, 0.15), rear = hypot(0.09, 0.15)
+        let expected = (0.38_f64).hypot(0.15);
+        assert!((max_corner_radius_m(&f) - expected).abs() < 1e-12);
+        assert!(
+            max_corner_radius_m(&f) > (0.09_f64).hypot(0.15),
+            "front must win here"
+        );
+    }
+
+    #[test]
+    fn max_corner_radius_takes_the_rear_when_the_rear_overhangs_further() {
+        // The `>` branch must actually select, not always return one side.
+        let f = VehicleFootprint {
+            width_m: 0.30,
+            length_m: 2.0,
+            overhang_front_m: 0.05,
+            overhang_rear_m: 1.50,
+            wheelbase_m: 0.20,
+        };
+        let expected = (1.50_f64).hypot(0.15);
+        assert!((max_corner_radius_m(&f) - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn max_corner_radius_scales_with_width() {
+        // Kills `* 0.5` → `+ 0.5` / `/ 0.5` on the half-width, and any constant
+        // return: a wider body must have a strictly larger corner radius.
+        let narrow = VehicleFootprint {
+            width_m: 0.30,
+            length_m: 0.47,
+            overhang_front_m: 0.18,
+            overhang_rear_m: 0.09,
+            wheelbase_m: 0.20,
+        };
+        let wide = VehicleFootprint {
+            width_m: 2.00,
+            ..narrow
+        };
+        assert!(
+            max_corner_radius_m(&wide) > max_corner_radius_m(&narrow) + 0.5,
+            "a 2 m-wide body must reach much further than a 0.3 m one"
+        );
+        // And it is a real distance, never a constant.
+        assert!(max_corner_radius_m(&narrow) > 0.0);
+    }
+
+    #[test]
+    fn wrap_to_pi_maps_angles_onto_the_half_open_turn() {
+        // Exact expectations either side of both branches. `>` vs `>=` at
+        // exactly +pi is the difference between +pi and -pi, and the `-=`/`+=`
+        // direction is the difference between a small turn and a huge one.
+        let pi = core::f64::consts::PI;
+        let cases = [
+            (0.0, 0.0),
+            (0.5, 0.5),
+            (-0.5, -0.5),
+            (pi, pi),  // +pi stays +pi (the interval is (-pi, pi])
+            (-pi, pi), // -pi wraps UP to +pi
+            (pi + 0.25, -pi + 0.25),
+            (-pi - 0.25, pi - 0.25),
+            (3.0 * pi / 2.0, -pi / 2.0),
+            (2.0 * pi, 0.0),
+        ];
+        for (input, expected) in cases {
+            let got = wrap_to_pi(input);
+            assert!(
+                (got - expected).abs() < 1e-12,
+                "wrap_to_pi({input}) = {got}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn wrap_to_pi_always_lands_inside_the_interval() {
+        let pi = core::f64::consts::PI;
+        let mut a = -20.0_f64;
+        while a < 20.0 {
+            let w = wrap_to_pi(a);
+            assert!(w > -pi - 1e-12 && w <= pi + 1e-12, "wrap_to_pi({a}) = {w}");
+            a += 0.37;
+        }
+    }
+
+    #[test]
+    fn sagitta_matches_the_closed_form() {
+        // Exact value, so every operator in the expression is pinned:
+        // r_axle = chord / (2 sin(theta/2)); sagitta = (r_axle + r_max)(1 - cos(theta/2)).
+        let theta = 0.6_f64;
+        let chord = 0.5_f64;
+        let r_max = 0.29_f64;
+        let a = Pose {
+            x_m: 0.0,
+            y_m: 0.0,
+            heading_rad: 0.0,
+        };
+        let b = Pose {
+            x_m: chord,
+            y_m: 0.0,
+            heading_rad: theta,
+        };
+        let half = 0.5 * theta;
+        let expected = (chord / (2.0 * half.sin()) + r_max) * (1.0 - half.cos());
+        let got = segment_sagitta_m(&a, &b, r_max).expect("modellable");
+        assert!(
+            (got - expected).abs() < 1e-12,
+            "sagitta {got} != closed form {expected}"
+        );
+    }
+
+    #[test]
+    fn sagitta_grows_with_the_corner_radius() {
+        // Kills `max_corner_radius_m -> 0.0` reaching here, and `+ r_max` being
+        // dropped or turned into `*`: a body that reaches further must bulge more.
+        let a = Pose {
+            x_m: 0.0,
+            y_m: 0.0,
+            heading_rad: 0.0,
+        };
+        let b = Pose {
+            x_m: 0.5,
+            y_m: 0.0,
+            heading_rad: 0.6,
+        };
+        let small = segment_sagitta_m(&a, &b, 0.1).unwrap();
+        let large = segment_sagitta_m(&a, &b, 2.0).unwrap();
+        // The r_max term is exactly (r_large - r_small)(1 - cos(theta/2)).
+        let expected_delta = (2.0 - 0.1) * (1.0 - (0.3_f64).cos());
+        assert!(
+            (large - small - expected_delta).abs() < 1e-12,
+            "small={small} large={large}, delta != {expected_delta}"
+        );
+    }
+
+    #[test]
+    fn sagitta_grows_with_the_chord_at_fixed_curvature() {
+        // Pins the chord term: `chord / (2 sin)` mutated to `*` or `%` breaks
+        // this monotonicity.
+        let theta = 0.6_f64;
+        let mut previous = -1.0;
+        for chord in [0.1_f64, 0.5, 1.0, 2.0] {
+            let a = Pose {
+                x_m: 0.0,
+                y_m: 0.0,
+                heading_rad: 0.0,
+            };
+            let b = Pose {
+                x_m: chord,
+                y_m: 0.0,
+                heading_rad: theta,
+            };
+            let s = segment_sagitta_m(&a, &b, 0.29).unwrap();
+            assert!(s > previous, "chord {chord} did not increase sagitta");
+            previous = s;
+        }
+    }
+
+    #[test]
+    fn sagitta_refuses_a_non_finite_chord_or_radius() {
+        // The `||` in the finiteness guard: `&&` would let a single non-finite
+        // input through.
+        let a = Pose {
+            x_m: 0.0,
+            y_m: 0.0,
+            heading_rad: 0.0,
+        };
+        let far = Pose {
+            x_m: f64::MAX,
+            y_m: f64::MAX,
+            heading_rad: 0.6,
+        };
+        assert_eq!(segment_sagitta_m(&a, &far, 0.29), None, "non-finite chord");
+        let b = Pose {
+            x_m: 0.5,
+            y_m: 0.0,
+            heading_rad: 0.6,
+        };
+        assert_eq!(
+            segment_sagitta_m(&a, &b, f64::INFINITY),
+            None,
+            "non-finite r_max"
+        );
+        assert_eq!(segment_sagitta_m(&a, &b, f64::NAN), None, "NaN r_max");
+    }
+
+    #[test]
+    fn the_straight_short_circuit_agrees_with_the_arc_at_the_epsilon() {
+        // Both sides of the epsilon return EXACTLY 0.0, and that is the point:
+        // at theta = 1e-9, `1 - cos(theta/2)` underflows to exactly 0.0 in f64,
+        // so the computed branch produces the same answer the short-circuit
+        // does. The threshold is therefore a performance/singularity guard, not
+        // a behavioural boundary — which is why `< eps` vs `<= eps` is an
+        // EQUIVALENT mutant, excluded with justification in .cargo/mutants.toml.
+        // This test pins the property that makes it equivalent, so if the
+        // epsilon is ever raised into a range where the arc IS representable,
+        // this fails and the exclusion must be re-justified.
+        let a = Pose {
+            x_m: 0.0,
+            y_m: 0.0,
+            heading_rad: 0.0,
+        };
+        for scale in [0.5, 1.0, 2.0] {
+            let b = Pose {
+                x_m: 0.5,
+                y_m: 0.0,
+                heading_rad: scale * STRAIGHT_SEGMENT_HEADING_EPS_RAD,
+            };
+            assert_eq!(
+                segment_sagitta_m(&a, &b, 0.29),
+                Some(0.0),
+                "at {scale}x the epsilon the sagitta must still be exactly zero"
+            );
+        }
+    }
+
+    #[test]
+    fn a_chord_is_refused_when_either_endpoint_is_non_finite() {
+        // The `&&` in the endpoint finiteness guard: `||` would admit a chord
+        // with one NaN end.
+        let (left, right) = straight_corridor(3.0, 100.0);
+        let corridor = healthy_corridor(&left, &right);
+        let good = Point {
+            x_m: 20.0,
+            y_m: 0.0,
+        };
+        let bad = Point {
+            x_m: f64::NAN,
+            y_m: 0.0,
+        };
+        let margin_sq = 0.16;
+        assert!(chord_clears_corridor(&good, &good, &corridor, margin_sq));
+        assert!(!chord_clears_corridor(&bad, &good, &corridor, margin_sq));
+        assert!(!chord_clears_corridor(&good, &bad, &corridor, margin_sq));
+    }
+
+    #[test]
+    fn a_chord_clears_only_when_it_beats_the_margin() {
+        // Pins the clearance comparison and the margin arithmetic: a chord down
+        // the centre of a 3 m half-width corridor clears a 2 m margin but not a
+        // 4 m one.
+        let (left, right) = straight_corridor(3.0, 100.0);
+        let corridor = healthy_corridor(&left, &right);
+        let a = Point {
+            x_m: 20.0,
+            y_m: 0.0,
+        };
+        let b = Point {
+            x_m: 40.0,
+            y_m: 0.0,
+        };
+        assert!(chord_clears_corridor(&a, &b, &corridor, 2.0 * 2.0));
+        assert!(!chord_clears_corridor(&a, &b, &corridor, 4.0 * 4.0));
+    }
+
+    #[test]
+    fn a_chord_leaving_the_corridor_is_refused() {
+        // The crossing case: both endpoints inside, the segment bulging out is
+        // impossible for a straight chord, so drive one endpoint outside.
+        let (left, right) = straight_corridor(1.0, 100.0);
+        let corridor = healthy_corridor(&left, &right);
+        let inside = Point {
+            x_m: 20.0,
+            y_m: 0.0,
+        };
+        let outside = Point {
+            x_m: 40.0,
+            y_m: 5.0,
+        };
+        assert!(!chord_clears_corridor(&inside, &outside, &corridor, 0.16));
+    }
+
     // --- the holes it closes ------------------------------------------------
 
     #[test]

--- a/crates/kirra-core/src/containment.rs
+++ b/crates/kirra-core/src/containment.rs
@@ -1569,14 +1569,17 @@ mod tests {
         let theta = 0.6_f64;
         let chord = 0.5_f64;
         let r_max = 0.29_f64;
+        // Deliberately NOT at the origin: with a = (0, 0) the chord's
+        // `b - a` is indistinguishable from `b + a`, and the subtraction
+        // mutants survive. An offset frame pins the differencing.
         let a = Pose {
-            x_m: 0.0,
-            y_m: 0.0,
+            x_m: 7.0,
+            y_m: -3.0,
             heading_rad: 0.0,
         };
         let b = Pose {
-            x_m: chord,
-            y_m: 0.0,
+            x_m: 7.0 + chord * 0.6,
+            y_m: -3.0 + chord * 0.8,
             heading_rad: theta,
         };
         let half = 0.5 * theta;
@@ -1730,6 +1733,83 @@ mod tests {
         };
         assert!(chord_clears_corridor(&a, &b, &corridor, 2.0 * 2.0));
         assert!(!chord_clears_corridor(&a, &b, &corridor, 4.0 * 4.0));
+    }
+
+    #[test]
+    fn a_chord_beyond_the_corridor_is_refused_even_though_it_clears_every_edge() {
+        // THE case the PNPoly ray-cast exists for. A chord far past the end of
+        // the corridor is further than the margin from every edge, so the
+        // distance test alone ADMITS it. Only the inside/outside verdict
+        // refuses it — so this is what pins the ray-cast arithmetic (the
+        // `>` comparisons, the `dy` difference, the `x_cross` product/quotient
+        // and the `<` crossing test). Points just outside an edge do not pin
+        // it, because they fail the distance test anyway.
+        let (left, right) = straight_corridor(3.0, 100.0);
+        let corridor = healthy_corridor(&left, &right);
+        let margin_sq = 0.16;
+
+        // Beyond the far end, on the centreline.
+        let a = Point {
+            x_m: 200.0,
+            y_m: 0.0,
+        };
+        let b = Point {
+            x_m: 240.0,
+            y_m: 0.0,
+        };
+        assert!(!chord_clears_corridor(&a, &b, &corridor, margin_sq));
+
+        // Behind the near end, likewise.
+        let c = Point {
+            x_m: -200.0,
+            y_m: 0.0,
+        };
+        let d = Point {
+            x_m: -160.0,
+            y_m: 0.0,
+        };
+        assert!(!chord_clears_corridor(&c, &d, &corridor, margin_sq));
+
+        // Far to the side, level with the corridor's y-span.
+        let e = Point {
+            x_m: 50.0,
+            y_m: 80.0,
+        };
+        let f = Point {
+            x_m: 60.0,
+            y_m: 80.0,
+        };
+        assert!(!chord_clears_corridor(&e, &f, &corridor, margin_sq));
+
+        // Sanity: the same chord INSIDE clears, so the refusals above are the
+        // inside test talking, not a blanket reject.
+        let g = Point {
+            x_m: 40.0,
+            y_m: 0.0,
+        };
+        let h = Point {
+            x_m: 60.0,
+            y_m: 0.0,
+        };
+        assert!(chord_clears_corridor(&g, &h, &corridor, margin_sq));
+    }
+
+    #[test]
+    fn a_corridor_with_a_non_finite_vertex_is_refused() {
+        // The `&&` guard over the polygon's own vertices (distinct from the
+        // chord-endpoint guard): one bad vertex must fail the whole test.
+        let (mut left, right) = straight_corridor(3.0, 100.0);
+        left[3].x_m = f64::NAN;
+        let corridor = healthy_corridor(&left, &right);
+        let a = Point {
+            x_m: 20.0,
+            y_m: 0.0,
+        };
+        let b = Point {
+            x_m: 40.0,
+            y_m: 0.0,
+        };
+        assert!(!chord_clears_corridor(&a, &b, &corridor, 0.16));
     }
 
     #[test]

--- a/crates/kirra-core/src/containment.rs
+++ b/crates/kirra-core/src/containment.rs
@@ -1871,6 +1871,48 @@ mod tests {
     }
 
     #[test]
+    fn the_x_cross_interpolation_decides_points_a_wrong_operator_would_admit() {
+        // These two points were found by exhaustively searching the slanted
+        // corridor for places where a mutated `x_cross` flips the inside/outside
+        // verdict WHILE the point stays far from every edge — i.e. where the
+        // distance term cannot cover for a broken ray-cast. Both are genuinely
+        // outside; a wrong `/` reports them inside, and the function would then
+        // clear a chord that never touches the corridor.
+        let (left, right) = slanted_corridor(3.0, 100.0, 0.4);
+        let corridor = healthy_corridor(&left, &right);
+        let margin_sq = 0.16;
+
+        // Far past the end of the band (clearance ~201 m).
+        let a = Point {
+            x_m: 299.0,
+            y_m: 7.0,
+        };
+        let b = Point {
+            x_m: 310.0,
+            y_m: 7.0,
+        };
+        assert!(
+            !chord_clears_corridor(&a, &b, &corridor, margin_sq),
+            "a chord 200 m outside the corridor must never clear"
+        );
+
+        // Below the slanted band at mid-length (clearance ~6.9 m): at x = 76 the
+        // band spans y in [27.4, 33.4], so y = 20 is outside.
+        let c = Point {
+            x_m: 76.0,
+            y_m: 20.0,
+        };
+        let d = Point {
+            x_m: 78.0,
+            y_m: 20.0,
+        };
+        assert!(
+            !chord_clears_corridor(&c, &d, &corridor, margin_sq),
+            "a chord below the slanted band must never clear"
+        );
+    }
+
+    #[test]
     fn the_ray_cast_is_stable_when_a_vertex_sits_exactly_on_the_ray() {
         // The `>` half-open comparisons in the crossing test exist to stop a
         // vertex lying exactly at the test point's y from being counted twice.

--- a/docs/testing/MUTATION_BASELINE.md
+++ b/docs/testing/MUTATION_BASELINE.md
@@ -1,26 +1,58 @@
 # Mutation-Testing Baseline — the Checker Crate (WP-08 / MGA G-6)
 
 **Date:** 2026-07-07 · **Tool:** cargo-mutants · **Scope:** `crates/kirra-trajectory`
++ the checker modules of `crates/kirra-core` (widened #1196 — see §1)
 **Status of this document:** living debt register — update on every targeted-kill PR and on every full re-baseline.
 
 ## 1. What gates, what ratchets
 
 - **PR gate (CI `mutation-gate` lane):** `cargo mutants --in-diff` over the PR's
-  diff of `crates/kirra-trajectory/src` — every mutant lying in NEW/CHANGED
-  checker code must be killed by the suite, or the PR reds. A PR that does not
-  touch the checker skips in seconds. This makes new survivor debt impossible
-  without making the pre-existing debt block unrelated work.
+  diff of the checker sources — every mutant lying in NEW/CHANGED checker code
+  must be killed by the suite, or the PR reds. A PR that does not touch the
+  checker skips in seconds. This makes new survivor debt impossible without
+  making the pre-existing debt block unrelated work.
+- **Gate scope (#1196):** `crates/kirra-trajectory/src` PLUS the checker modules
+  of `crates/kirra-core` — `containment.rs` (SG2 drivable space),
+  `kinematics_contract.rs` (the frozen talisman), `perception_monitor.rs`
+  (Track-C plausibility), `governor_guard.rs`, `frame_integrity.rs`,
+  `platform_kinematics.rs`, `contract_consumer.rs`.
+
+  It was `kirra-trajectory` alone until #1196, which left SG2 containment and
+  the talisman — safety authority — outside the gate entirely. Four merged
+  changes (#1192–#1195) touched `kirra-core`/`kirra-taj` and the lane reported
+  "no checker changes" in ~5 seconds each. Measured on #1192's real diff: the
+  old scope yielded **0** diff lines and **0** mutants; the widened scope yields
+  626 lines and **181** mutants.
+
+  Widening is safe for existing code *because* of `--in-diff`: only lines a PR
+  changes are ever mutated, so pre-existing survivors in newly-covered files are
+  not tested and cannot red anything. The cost lands only on PRs that change
+  those files.
+
+  `kirra-core` is enumerated module by module rather than as a whole crate: it
+  also holds non-authority code (capture, kinematics_sim, posture_tracker,
+  corridor/trajectory types) that should not carry a mutation obligation.
+  Adding a module is a deliberate act.
+
+  The talisman is in scope and that is safe: its blob pin is a CI **shell** step
+  (`git hash-object`, rustfmt job), not a Rust test, and cargo-mutants mutates a
+  scratch copy — so a mutant cannot trip the pin and produce a false "caught".
 - **Debt ratchet (this document + `mutation_baseline_missed_2026-07-07.txt`):**
   the surviving-mutant snapshot only shrinks — targeted-kill PRs retire
   clusters and update the snapshot; a full re-baseline that GROWS the list
   needs the growth explained (usually new code that predates the gate).
 - **Test scope** (pinned in `.cargo/mutants.toml` via `test_package`): the
-  checker's own tests PLUS `kirra-ros2-adapter`'s validation suite, where the
+  checker crates' own tests PLUS `kirra-ros2-adapter`'s validation suite, where the
   checker's deepest tests live. This is load-bearing — see §2. NOTE: the scope
   MUST use cargo-mutants' `test_package` key; the earlier
   `additional_cargo_test_args = ["--package", ...]` did NOT change which
   package's tests ran (cargo-mutants defaults to the mutated package's own
   tests only), so the adapter suite silently never executed under the harness.
+  The same trap applies one crate over: because an explicit `test_package`
+  REPLACES the mutated-package default, `kirra-core` had to be added to the list
+  in #1196 — otherwise a kirra-core mutant would be judged by the trajectory +
+  adapter suites alone, its own containment/talisman tests would never run, and
+  it would report as a survivor.
 
 ## 2. The scoping lesson (measured)
 

--- a/docs/testing/MUTATION_BASELINE.md
+++ b/docs/testing/MUTATION_BASELINE.md
@@ -54,12 +54,35 @@
   adapter suites alone, its own containment/talisman tests would never run, and
   it would report as a survivor.
 
-## 1b. #1196 kill wave — scope widened, survivors cleared
+## 1b. #1196 kill wave — scope widened, survivors partly cleared
 
 Widening the scope surfaced **32 survivors** on #1192's diff, all in the C1
-swept-footprint bound. Kill tests and justified equivalence exclusions took that
-to **zero**: 32 → 14 → 9 → 4 → **0** (92 caught, 1 timeout — an infinite-loop
-mutant, which counts as detected).
+swept-footprint bound. Kill tests and justified equivalence exclusions cleared
+the four functions first examined — `max_corner_radius_m`, `wrap_to_pi`,
+`segment_sagitta_m`, `chord_clears_corridor` — to zero (92 caught, 1 timeout).
+
+**A full end-to-end run over the whole diff then found 20 more: 145 caught, 20
+missed.** The intermediate runs used a `--re` filter naming those four
+functions, which silently omitted `segments_intersect` and
+`segment_to_segment_dist_sq` — two further helpers the same PR introduced. A
+targeted re-run is not evidence about a diff; only the diff-scoped run is. That
+mistake is recorded here because it is the same shape as the vacuous-exclusion
+one below: a filter that quietly narrows what is being checked while the
+result still reads as a pass.
+
+**Open survivors (20):**
+
+| location | count | note |
+|---|---|---|
+| `validate_trajectory_containment:328` | 1 | `margin_sq = inflated * inflated` → `/`, giving a constant 1.0. STRICTER, so every existing test still passes; needs an admission case clearing by between 0.40 m and 1.0 m. |
+| `segment_to_segment_dist_sq:619-627` | 5 | the four-way min selection |
+| `segments_intersect:649-650` | 14 | the orientation-sign comparisons |
+
+`segments_intersect` is load-bearing, not an optimisation: two segments crossing
+in an X have all four endpoint-to-segment distances non-zero (a unit X gives 1.0
+each), so without the crossing test a chord that cuts a boundary reports ample
+clearance. The killing case is therefore a chord with its FIRST endpoint inside
+(so PNPoly admits) crossing an edge whose endpoints are all far from it.
 
 Each round needed a different insight, and the ones that mattered were things
 reasoning got wrong and measurement got right:
@@ -102,7 +125,8 @@ answers differed, which is the point of the method:
 
 That the same search killed one pair and cleared the other is what makes the
 equivalence claim credible — it separates "actually equivalent" from "not yet
-killed" instead of excusing both.
+killed" instead of excusing both. The same search should be pointed at the 20
+remaining survivors rather than reasoning about their geometry.
 
 ### Equivalence exclusions added (#1196)
 

--- a/docs/testing/MUTATION_BASELINE.md
+++ b/docs/testing/MUTATION_BASELINE.md
@@ -54,48 +54,75 @@
   adapter suites alone, its own containment/talisman tests would never run, and
   it would report as a survivor.
 
-## 1b. #1196 kill wave — and 4 remaining survivors
+## 1b. #1196 kill wave — scope widened, survivors cleared
 
 Widening the scope surfaced **32 survivors** on #1192's diff, all in the C1
-swept-footprint bound. Kill tests and justified equivalence exclusions took
-that to **4**. Progression: 32 → 14 → 9 → 4 (90 caught, 1 timeout).
+swept-footprint bound. Kill tests and justified equivalence exclusions took that
+to **zero**: 32 → 14 → 9 → 4 → **0** (92 caught, 1 timeout — an infinite-loop
+mutant, which counts as detected).
 
-**Still surviving, in `chord_clears_corridor`'s PNPoly ray-cast:**
+Each round needed a different insight, and the ones that mattered were things
+reasoning got wrong and measurement got right:
 
-| line | mutant |
-|---|---|
-| 587:20 | `replace > with >=` |
-| 587:40 | `replace > with >=` |
-| 590:68 | `replace / with %` |
-| 590:68 | `replace / with *` |
+1. **Composed tests do not cover helper arithmetic.** #1192's tests drove
+   `validate_trajectory_containment` and asserted verdicts, against corridors
+   wide enough that a wrong helper never flipped one. `max_corner_radius_m -> 0.0`
+   survived — it shrinks the sagitta and makes the bound LESS conservative.
+   The dense-sweep oracle missed it too: it only samples geometries where the
+   sagitta is small, so a wrong sagitta still passes.
+2. **`a` at the origin hides differencing.** `b - a` is indistinguishable from
+   `b + a` there. The sagitta tests now use an offset frame.
+3. **PNPoly is only load-bearing far outside.** A point just outside an edge
+   fails the distance test anyway, so it pins nothing. The killing cases are
+   chords far beyond the corridor that clear every edge by a wide margin.
+4. **Axis-aligned corridors make `x_cross` unreachable.** Every crossing edge
+   has `e1.x - e0.x == 0`, so the formula collapses to `e0.x` regardless of its
+   `*` and `/`. True of the rectangle AND of the L-bend — the slant, not the
+   non-convexity, is what exercises the interpolation.
 
-These are the half-open vertex comparison and the `x_cross` division. They are
-**NOT** excluded, because equivalence has not been proven — only not-yet-killed.
-Reaching them needs a geometry where a boundary vertex lies exactly on the test
-ray AND the resulting parity flip changes the verdict; on the rectangular and
-parallelogram corridors used so far the parity comes out the same either way,
-and on axis-aligned edges `e1.x - e0.x == 0` collapses `x_cross` to `e0.x`
-regardless of the arithmetic. A non-convex corridor (an L-bend) is the most
-likely killing shape and is the recommended next attempt.
+### Finding the last four by search, not argument
 
-**Consequence, stated plainly:** a PR that changes lines 587–590 will red the
-gate until these are killed or justified. That is the gate working as designed;
-it is recorded here rather than silenced with a blanket exclusion.
+Two earlier geometric predictions were wrong, so the remaining survivors were
+resolved by exhaustively searching three corridor shapes (rectangular, L-bend,
+slanted parallelogram) for points where each mutant flips the inside/outside
+verdict, recording how far each such point sits from the boundary. The two
+answers differed, which is the point of the method:
 
-**Equivalence exclusions added (#1196)** — each argued in `.cargo/mutants.toml`:
-the straight-segment epsilon (both branches return exactly `0.0` because
-`1 - cos` underflows), the front/rear corner selector (`>` vs `>=` return the
-same value when equal), the sagitta's early finiteness guard (redundant with the
-final `!sagitta.is_finite()` check), the PNPoly ray DIRECTION (`<` vs `>` — ray
-casting is direction-independent for a simple polygon), and two exact-tie
-comparisons of the same class as the existing `CenterlineFrenet::project` entry.
+- **`x_cross` division (`/` -> `*`, `/` -> `%`) — KILLED.** Points exist that
+  flip the verdict while staying far from every edge: (299, 7) with 201 m of
+  clearance and (76, 20) with 6.9 m, both genuinely outside the slanted band
+  and both reported INSIDE by the mutant. Asserted in
+  `the_x_cross_interpolation_decides_points_a_wrong_operator_would_admit`.
+- **Half-open vertex comparison (`>` -> `>=`) — EQUIVALENT.** It differs only
+  where a point's y coincides with a boundary vertex's y, i.e. exactly ON the
+  boundary. The function returns `inside && min_dist_sq >= margin_sq`, so at
+  clearance 0 the conjunction is false whatever `inside` says. Across all three
+  shapes every differing point had clearance EXACTLY 0.0 and there were none
+  elsewhere.
 
-**A near-miss worth remembering.** The exclusion `"replace || with && in
-segment_sagitta_m"` reads as a literal but is a REGEX: `||` is alternation with
-an empty branch, matching every mutant description. It silently excluded all 399
-containment mutants — a green, vacuous gate on the exact file the scope was
-widened to cover. The lane now lists mutants first and FAILS if a non-empty
-checker diff yields zero, which catches the whole class.
+That the same search killed one pair and cleared the other is what makes the
+equivalence claim credible — it separates "actually equivalent" from "not yet
+killed" instead of excusing both.
+
+### Equivalence exclusions added (#1196)
+
+Each argued in `.cargo/mutants.toml`: the straight-segment epsilon (both
+branches return exactly `0.0` because `1 - cos` underflows below it), the
+front/rear corner selector (`>` vs `>=` return the same value when equal), the
+sagitta's early finiteness guard (redundant with the final
+`!sagitta.is_finite()` check), the PNPoly ray DIRECTION (`<` vs `>` — ray
+casting is direction-independent for a simple polygon), the half-open vertex
+comparison above, and two exact-tie comparisons of the same class as the
+existing `CenterlineFrenet::project` entry.
+
+### A near-miss worth remembering
+
+The exclusion `"replace || with && in segment_sagitta_m"` reads as a literal but
+is a REGEX: `||` is alternation with an empty branch, matching every mutant
+description. It silently excluded all 399 containment mutants — a green, vacuous
+gate on the exact file the scope was widened to cover. It parses as valid TOML
+and would have survived review. The lane now lists mutants first and FAILS if a
+non-empty checker diff yields zero, which catches the whole class.
 
 ## 2. The scoping lesson (measured)
 

--- a/docs/testing/MUTATION_BASELINE.md
+++ b/docs/testing/MUTATION_BASELINE.md
@@ -54,6 +54,49 @@
   adapter suites alone, its own containment/talisman tests would never run, and
   it would report as a survivor.
 
+## 1b. #1196 kill wave — and 4 remaining survivors
+
+Widening the scope surfaced **32 survivors** on #1192's diff, all in the C1
+swept-footprint bound. Kill tests and justified equivalence exclusions took
+that to **4**. Progression: 32 → 14 → 9 → 4 (90 caught, 1 timeout).
+
+**Still surviving, in `chord_clears_corridor`'s PNPoly ray-cast:**
+
+| line | mutant |
+|---|---|
+| 587:20 | `replace > with >=` |
+| 587:40 | `replace > with >=` |
+| 590:68 | `replace / with %` |
+| 590:68 | `replace / with *` |
+
+These are the half-open vertex comparison and the `x_cross` division. They are
+**NOT** excluded, because equivalence has not been proven — only not-yet-killed.
+Reaching them needs a geometry where a boundary vertex lies exactly on the test
+ray AND the resulting parity flip changes the verdict; on the rectangular and
+parallelogram corridors used so far the parity comes out the same either way,
+and on axis-aligned edges `e1.x - e0.x == 0` collapses `x_cross` to `e0.x`
+regardless of the arithmetic. A non-convex corridor (an L-bend) is the most
+likely killing shape and is the recommended next attempt.
+
+**Consequence, stated plainly:** a PR that changes lines 587–590 will red the
+gate until these are killed or justified. That is the gate working as designed;
+it is recorded here rather than silenced with a blanket exclusion.
+
+**Equivalence exclusions added (#1196)** — each argued in `.cargo/mutants.toml`:
+the straight-segment epsilon (both branches return exactly `0.0` because
+`1 - cos` underflows), the front/rear corner selector (`>` vs `>=` return the
+same value when equal), the sagitta's early finiteness guard (redundant with the
+final `!sagitta.is_finite()` check), the PNPoly ray DIRECTION (`<` vs `>` — ray
+casting is direction-independent for a simple polygon), and two exact-tie
+comparisons of the same class as the existing `CenterlineFrenet::project` entry.
+
+**A near-miss worth remembering.** The exclusion `"replace || with && in
+segment_sagitta_m"` reads as a literal but is a REGEX: `||` is alternation with
+an empty branch, matching every mutant description. It silently excluded all 399
+containment mutants — a green, vacuous gate on the exact file the scope was
+widened to cover. The lane now lists mutants first and FAILS if a non-empty
+checker diff yields zero, which catches the whole class.
+
 ## 2. The scoping lesson (measured)
 
 | Run | Test scope | Mutants | Caught | Missed | Unviable |


### PR DESCRIPTION
## ⚠️ Not finished — 20 documented survivors

Read this first. The scope widening and the vacuous-pass guard are complete and verified. The survivor cleanup is **not**: 20 mutants remain unkilled and unexcluded, listed in `MUTATION_BASELINE.md` §1b. **A PR touching `containment.rs:328`, `:619–627` or `:649–650` will red the gate until they are dealt with.**

That is recorded rather than silenced, and it is the honest state of the branch. Merge it as scope-widening-plus-documented-debt, or hold it until the remainder is cleared — but please don't merge it believing it is clean.

## The blind spot

The gate computed its diff over `crates/kirra-trajectory/src` **only**. The SG2 drivable-space containment check, the frozen kinematics-contract talisman and the Track-C perception guard all live in `kirra-core` and were outside it entirely.

Four merged changes (#1192, #1193, #1194, #1195) touched `kirra-core`/`kirra-taj`; the lane reported "no checker changes" in ~5 seconds each. Measured on #1192's real diff:

| scope | diff lines | mutants |
|---|---|---|
| old | **0** | **0** |
| widened | 626 | **181** |

Widening is safe for existing code *because* of `--in-diff`: only lines a PR changes are ever mutated, so pre-existing survivors in newly-covered files are not tested and cannot red anything. The cost lands only on PRs that change those files.

`kirra-core` is enumerated **module by module**, not whole-crate — it also holds non-authority code (capture, kinematics_sim, posture_tracker, corridor/trajectory types) that shouldn't carry a mutation obligation. Adding a module stays a deliberate, greppable act.

Two things checked rather than assumed: the talisman is safe to mutate (its blob pin is a CI *shell* step, and cargo-mutants mutates a scratch copy, so a mutant can't manufacture a false "caught"); and `kirra-core` had to be added to `test_package`, because an explicit list **replaces** the mutated-package default — without it every `kirra-core` mutant would have reported as a survivor.

## The gate could pass while asserting nothing

An `exclude_re` entry I added read `"replace || with && in segment_sagitta_m"`. It looks like a literal; it is a **regex**. `||` is alternation with an empty branch, so it matched every mutant description and silently excluded **all 399** containment mutants — a green, vacuous gate on the exact file the scope was widened to cover. Valid TOML, plausible on review.

The lane now fails if the checker sources are not mutable at all. Verified both directions: escaped → 385 containment mutants, guard quiet; unescaped `||` reintroduced → 0, guard fires.

**The first version of that guard was itself wrong** and would have failed this PR. It keyed on "non-empty diff, zero mutants" — but a test-only change to a checker file legitimately yields zero, since `#[cfg(test)]` code isn't mutated. This PR's own diff is 536 checker-path lines and 0 mutants. The guard now checks the **config**, not the diff shape, which is what actually broke.

## Survivor cleanup: 32 → 20

The widened gate immediately found 32 survivors on #1192's diff — all in the swept-footprint bound merged hours earlier and described at the time as well covered. Twelve kill tests plus argued equivalence exclusions brought the four originally-examined functions to zero. A full end-to-end run then found 20 more, because the intermediate runs used a `--re` filter that omitted `segments_intersect` and `segment_to_segment_dist_sq`. **A targeted re-run is not evidence about a diff.**

What the exercise established, all recorded in §1b:

- **Composed tests don't cover helper arithmetic.** `max_corner_radius_m -> 0.0` survived — it shrinks the sagitta and makes the bound *less* conservative. The dense-sweep oracle missed it too.
- **`a` at the origin hides differencing** (`b - a` ≡ `b + a`).
- **PNPoly is only load-bearing far outside** — a point just outside an edge fails the distance test anyway.
- **Axis-aligned corridors make `x_cross` unreachable** — true of the L-bend as well as the rectangle, so the *slant*, not the non-convexity, is what exercises it.

Where geometric reasoning failed three times, an exhaustive grid search over three corridor shapes settled the last four cleanly: it **killed** the `x_cross` division pair (verdict-flipping points at 201 m and 6.9 m clearance) and **cleared** the half-open vertex pair as genuinely equivalent (every differing point at clearance exactly 0.0, where `min_dist >= margin` forces false). One method separating "actually equivalent" from "not yet killed" is what makes the equivalence claims worth anything.

## Open survivors (20)

| location | count | note |
|---|---|---|
| `validate_trajectory_containment:328` | 1 | `inflated * inflated` → `/` yields a constant `1.0` — *stricter*, so every existing test passes. Needs an admission clearing by between 0.40 m and 1.0 m. |
| `segment_to_segment_dist_sq:619–627` | 5 | the four-way min selection |
| `segments_intersect:649–650` | 14 | the orientation-sign comparisons |

`segments_intersect` is load-bearing, not an optimisation: an X crossing has all four endpoint-to-segment distances non-zero, so without it a chord cutting a boundary reports ample clearance. The killing case is a chord with its first endpoint inside (so PNPoly admits) crossing an edge whose endpoints are all far from it. Recommended next step: point the same grid search at all 20.

## Verification

Root workspace **3,256 passed**; `kirra-core` 214 tests; `fmt` and `clippy --workspace --all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_